### PR TITLE
IR: make ShapeNWHC constructor explicit (NFC)

### DIFF
--- a/include/glow/IR/Type.h
+++ b/include/glow/IR/Type.h
@@ -20,13 +20,19 @@ struct ShapeNHWC {
   size_t h; // Height
   size_t w; // Width
   size_t c; // # of Channels
-  ShapeNHWC(ArrayRef<size_t> shape) {
+
+  // TODO: deprecate this for std::array<size_t, 4>
+  explicit ShapeNHWC(ArrayRef<size_t> shape) {
     assert(shape.size() == 4 && "Invalid shape");
     n = shape[0];
     h = shape[1];
     w = shape[2];
     c = shape[3];
   }
+
+  explicit ShapeNHWC(size_t samples, size_t height, size_t width,
+                     size_t channels)
+      : n(samples), h(height), w(width), c(channels) {}
 
   bool equals(const ShapeNHWC &other) const {
     return n == other.n && h == other.h && w == other.w && c == other.c;

--- a/src/glow/IR/IRBuilder.cpp
+++ b/src/glow/IR/IRBuilder.cpp
@@ -21,7 +21,7 @@ void IRBuilder::deallocateActiveInstrs() {
 ConvolutionInst *IRBuilder::createConvOp(Value *input, size_t depth,
                                          size_t kernel, size_t stride,
                                          size_t pad) {
-  ShapeNHWC idim = input->dims();
+  ShapeNHWC idim = ShapeNHWC(input->dims());
   assert(idim.w >= kernel && idim.h >= kernel &&
          "buffer too small for selected stride");
 
@@ -47,7 +47,7 @@ ConvolutionInst *IRBuilder::createConvOp(Value *input, size_t depth,
 
 PoolInst *IRBuilder::createPoolOp(Value *input, PoolInst::OpKind kind,
                                   size_t kernel, size_t stride, size_t pad) {
-  ShapeNHWC idim = input->dims();
+  ShapeNHWC idim = ShapeNHWC(input->dims());
   assert(idim.w >= kernel && idim.h >= kernel &&
          "buffer too small for selected stride");
 

--- a/src/glow/IR/Instrs.cpp
+++ b/src/glow/IR/Instrs.cpp
@@ -116,15 +116,15 @@ void ConvolutionInst::verify() const {
   (void)filter;
   (void)bias;
 
-  ShapeNHWC idim = src->getType()->dims();
-  ShapeNHWC odim = dest->getType()->dims();
+  ShapeNHWC idim(src->getType()->dims());
+  ShapeNHWC odim(dest->getType()->dims());
   (void)odim;
   assert(idim.w >= kernel_ && idim.h >= kernel_ &&
          "buffer too small for selected stride");
 
   auto outSz =
       ConvNode::calculateOutputDims(idim.h, idim.w, pad_, kernel_, stride_);
-  ShapeNHWC exp = ArrayRef<size_t>{idim.n, outSz.first, outSz.second, depth_};
+  ShapeNHWC exp(idim.n, outSz.first, outSz.second, depth_);
   (void)exp;
   assert(exp == odim && "Invalid output dimensions");
 
@@ -140,15 +140,15 @@ void PoolInst::verify() const {
   Value *src = getOperand(1).first;
   Value *srcXY = getOperand(2).first;
   (void)srcXY;
-  ShapeNHWC idim = src->getType()->dims();
-  ShapeNHWC odim = dest->getType()->dims();
+  ShapeNHWC idim = ShapeNHWC(src->getType()->dims());
+  ShapeNHWC odim = ShapeNHWC(dest->getType()->dims());
   (void)odim;
   assert(idim.w >= kernel_ && idim.h >= kernel_ &&
          "buffer too small for selected stride");
 
   auto outSz =
       ConvNode::calculateOutputDims(idim.h, idim.w, pad_, kernel_, stride_);
-  ShapeNHWC exp = ArrayRef<size_t>{idim.n, outSz.first, outSz.second, idim.c};
+  ShapeNHWC exp(idim.n, outSz.first, outSz.second, idim.c);
   (void)exp;
   assert(exp == odim && "Invalid output dimensions");
 

--- a/src/glow/Interpreter/InterpreterNodes.cpp
+++ b/src/glow/Interpreter/InterpreterNodes.cpp
@@ -37,8 +37,8 @@ void Interpreter::fwdConvolutionInst(Context *ctx, bool isTrain,
   size_t pad = I->getPad();
   size_t stride = I->getStride();
 
-  ShapeNHWC odim = outW.dims();
-  ShapeNHWC idim = inW.dims();
+  ShapeNHWC odim(outW.dims());
+  ShapeNHWC idim(inW.dims());
 
   // For each input in the batch:
   for (size_t n = 0; n < idim.n; n++) {
@@ -94,8 +94,8 @@ void Interpreter::bwdConvolutionInst(Context *ctx, const ConvolutionInst *I) {
   size_t pad = I->getPad();
   size_t stride = I->getStride();
 
-  ShapeNHWC odim = outW.dims();
-  ShapeNHWC idim = inW.dims();
+  ShapeNHWC odim(outW.dims());
+  ShapeNHWC idim(inW.dims());
 
   // For each input in the batch:
   for (size_t n = 0; n < odim.n; n++) {
@@ -154,8 +154,8 @@ void Interpreter::fwdPoolMax_impl(Context *ctx, const PoolInst *I) {
   auto inW = getWeightHandle(ctx, I->getSrc());
   auto outW = getWeightHandle(ctx, I->getDest());
 
-  ShapeNHWC odim = outW.dims();
-  ShapeNHWC idim = inW.dims();
+  ShapeNHWC odim(outW.dims());
+  ShapeNHWC idim(inW.dims());
 
   auto pad = I->getPad();
   auto filterSize = I->getKernel();
@@ -215,8 +215,8 @@ void Interpreter::fwdPoolAvg_impl(Context *ctx, const PoolInst *I) {
   auto inW = getWeightHandle(ctx, I->getSrc());
   auto outW = getWeightHandle(ctx, I->getDest());
 
-  ShapeNHWC odim = outW.dims();
-  ShapeNHWC idim = inW.dims();
+  ShapeNHWC odim(outW.dims());
+  ShapeNHWC idim(inW.dims());
 
   auto pad = I->getPad();
   auto filterSize = I->getKernel();
@@ -273,7 +273,7 @@ void Interpreter::bwdPoolMax_impl(Context *ctx, const PoolInst *I) {
   auto outW = getWeightHandle(ctx, I->getDest());
   auto outG = getGradHandle(ctx, I->getDest());
 
-  ShapeNHWC odim = outW.dims();
+  ShapeNHWC odim(outW.dims());
 
   auto SXY = getTensorForValue(I->srcXY())->getHandle<size_t>();
 
@@ -305,8 +305,8 @@ void Interpreter::bwdPoolAvg_impl(Context *ctx, const PoolInst *I) {
   auto outW = getWeightHandle(ctx, I->getDest());
   auto outG = getGradHandle(ctx, I->getDest());
 
-  ShapeNHWC odim = outW.dims();
-  ShapeNHWC idim = inW.dims();
+  ShapeNHWC odim(outW.dims());
+  ShapeNHWC idim(inW.dims());
 
   auto pad = I->getPad();
   auto filterSize = I->getKernel();
@@ -852,8 +852,9 @@ void Interpreter::fwdLocalResponseNormalizationInst(
   auto outW = getWeightHandle(ctx, I->getDest());
   auto scaleCache = getWeightHandle(ctx, I->getScale());
 
-  ShapeNHWC odim = outW.dims();
-  ShapeNHWC idim = inW.dims();
+  ShapeNHWC odim(outW.dims());
+  ShapeNHWC idim(inW.dims());
+
   (void)odim;
 
   // LRN node does not change the shape of the input.
@@ -918,7 +919,7 @@ void Interpreter::bwdLocalResponseNormalizationInst(
   auto outG = getGradHandle(ctx, I->getDest());
   auto scaleCache = getWeightHandle(ctx, I->getScale());
 
-  ShapeNHWC odim = outW.dims();
+  ShapeNHWC odim(outW.dims());
 
   auto halfWindowSize = I->gethalfWindowSize();
   auto beta = I->getBeta();

--- a/src/glow/Network/Nodes.cpp
+++ b/src/glow/Network/Nodes.cpp
@@ -12,7 +12,7 @@ ConvNode::ConvNode(Network *N, NodeBase *input, size_t outDepth,
 
 void ConvNode::init(Context *ctx) const {
   assert(input_ && input_->size(ctx) && "Invalid input");
-  ShapeNHWC idim = input_->dims(ctx);
+  ShapeNHWC idim(input_->dims(ctx));
   assert(idim.h >= filterSize_ && idim.w >= filterSize_ &&
          "buffer too small for selected stride");
 
@@ -65,8 +65,8 @@ std::string ConvNode::getDebugRepr(Context *ctx) const {
 }
 
 void ConvNode::forward(Context *ctx, PassKind kind) const {
-  ShapeNHWC odim = dims(ctx);
-  ShapeNHWC idim = input_->dims(ctx);
+  ShapeNHWC odim(dims(ctx));
+  ShapeNHWC idim(input_->dims(ctx));
 
   auto inW = input_->getWeightHandle(ctx);
   auto outW = getWeightHandle(ctx);
@@ -114,8 +114,9 @@ void ConvNode::forward(Context *ctx, PassKind kind) const {
 }
 
 void ConvNode::backward(Context *ctx) const {
-  ShapeNHWC odim = dims(ctx);
-  ShapeNHWC idim = input_->dims(ctx);
+  ShapeNHWC odim(dims(ctx));
+  ShapeNHWC idim(input_->dims(ctx));
+
   auto inW = input_->getWeightHandle(ctx);
   auto inG = input_->getGradHandle(ctx);
   auto outG = getGradHandle(ctx);
@@ -176,7 +177,7 @@ MaxPoolNode::MaxPoolNode(Network *N, NodeBase *input, OpKind kind,
 
 void MaxPoolNode::init(Context *ctx) const {
   assert(input_ && input_->size(ctx) && "Invalid input");
-  ShapeNHWC idim = input_->dims(ctx);
+  ShapeNHWC idim(input_->dims(ctx));
   assert(idim.w >= filterSize_ && idim.h >= filterSize_ &&
          "buffer too small for selected stride");
 
@@ -229,8 +230,9 @@ void MaxPoolNode::backward(Context *ctx) const {
 }
 
 void MaxPoolNode::forwardMax(Context *ctx) const {
-  ShapeNHWC odim = dims(ctx);
-  ShapeNHWC idim = input_->dims(ctx);
+  ShapeNHWC odim(dims(ctx));
+  ShapeNHWC idim(input_->dims(ctx));
+
   auto inW = input_->getWeightHandle(ctx);
   auto outW = getWeightHandle(ctx);
 
@@ -286,7 +288,8 @@ void MaxPoolNode::forwardMax(Context *ctx) const {
 }
 
 void MaxPoolNode::backwardMax(Context *ctx) const {
-  ShapeNHWC odim = dims(ctx);
+  ShapeNHWC odim(dims(ctx));
+
   auto inG = input_->getGradHandle(ctx);
   auto outG = getGradHandle(ctx);
 
@@ -319,8 +322,9 @@ void MaxPoolNode::forwardAvg(Context *ctx) const {
   // Implement the avg pooling operation as defined here:
   // https://arxiv.org/abs/1312.4400
 
-  ShapeNHWC odim = dims(ctx);
-  ShapeNHWC idim = input_->dims(ctx);
+  ShapeNHWC odim(dims(ctx));
+  ShapeNHWC idim(input_->dims(ctx));
+
   auto inW = input_->getWeightHandle(ctx);
   auto outW = getWeightHandle(ctx);
 
@@ -360,8 +364,9 @@ void MaxPoolNode::forwardAvg(Context *ctx) const {
 }
 
 void MaxPoolNode::backwardAvg(Context *ctx) const {
-  ShapeNHWC odim = dims(ctx);
-  ShapeNHWC idim = input_->dims(ctx);
+  ShapeNHWC odim(dims(ctx));
+  ShapeNHWC idim(input_->dims(ctx));
+
   auto inG = input_->getGradHandle(ctx);
   auto outG = getGradHandle(ctx);
   FloatTy filterArea = filterSize_ * filterSize_;
@@ -529,8 +534,9 @@ void LRNNode::forward(Context *ctx, PassKind kind) const {
   auto inW = input_->getWeightHandle(ctx);
   auto scaleCache = ctx->getTensor(&scale_)->getHandle<FloatTy>();
 
-  ShapeNHWC odim = dims(ctx);
-  ShapeNHWC idim = input_->dims(ctx);
+  ShapeNHWC odim(dims(ctx));
+  ShapeNHWC idim(input_->dims(ctx));
+
   (void)odim;
 
   // LRN node does not change the shape of the input.
@@ -591,7 +597,7 @@ void LRNNode::backward(Context *ctx) const {
   auto inW = input_->getWeightHandle(ctx);
   auto scaleCache = ctx->getTensor(&scale_)->getHandle<FloatTy>();
 
-  ShapeNHWC odim = dims(ctx);
+  ShapeNHWC odim(dims(ctx));
 
   auto windowSize = 2 * halfWindowSize_ + 1;
   auto normedAlpha = alpha_ / windowSize;


### PR DESCRIPTION
Summary:

Avoid an implicit conversion of ArrayRef<size_t> to ShapeNWHC.  This is in
preparation to remove our local definition of ArrayRef.  Add a helper
constructor avoid the ArrayRef perfect-forwarding construction to construct the
ShapeNWHC.

Test Plan: ninja

Reviewers: nrotem

Subscribers: #glow

Tasks:

Tags:

Blame Revision: