### PR TITLE
build: improve library linkage

### DIFF
--- a/src/glow/IR/CMakeLists.txt
+++ b/src/glow/IR/CMakeLists.txt
@@ -4,4 +4,7 @@ add_library(IR
               Type.cpp
               IRBuilder.cpp
               Instrs.cpp)
+target_link_libraries(IR
+                      PUBLIC
+                        Support)
 

--- a/src/glow/Importer/CMakeLists.txt
+++ b/src/glow/Importer/CMakeLists.txt
@@ -11,5 +11,6 @@ add_library(Importer
                ${PROTO_HDRS})
 target_link_libraries(Importer
                       PRIVATE
+                        IR
                         ${PROTOBUF_LIBRARY})
 

--- a/src/glow/Models/CMakeLists.txt
+++ b/src/glow/Models/CMakeLists.txt
@@ -1,4 +1,7 @@
 
 add_library(Models
               Builders.cpp)
+target_link_libraries(Models
+                      PRIVATE
+                        Network)
 

--- a/src/glow/Network/CMakeLists.txt
+++ b/src/glow/Network/CMakeLists.txt
@@ -6,8 +6,8 @@ add_library(Network
               Node.cpp
               Nodes.cpp)
 target_link_libraries(Network
-                      PRIVATE
-                        Support)
+                      PUBLIC
+                        IR)
 if(PNG_FOUND)
   target_compile_definitions(Network
                              PRIVATE

--- a/src/glow/Support/CMakeLists.txt
+++ b/src/glow/Support/CMakeLists.txt
@@ -5,4 +5,7 @@ add_library(Support
 target_link_libraries(Support
                       INTERFACE
                         LLVMSupport)
+target_include_directories(Support
+                           PUBLIC
+                             $<TARGET_PROPERTY:LLVMSupport,INTERFACE_INCLUDE_DIRECTORIES>)
 


### PR DESCRIPTION
Summary:

Make the libraries represent their dependencies better.  This is for ensuring
that implicit header dependencies are wired up properly.  This is needed for an
upcoming change to remove our local implementation of ArrayRef.

Test Plan: ninja

Reviewers: nrotem

Subscribers: #glow

Tasks:

Tags:

Blame Revision: