### PR TITLE
IR: modernise string conversion

### DIFF
--- a/include/glow/IR/Type.h
+++ b/include/glow/IR/Type.h
@@ -89,9 +89,6 @@ struct Type final {
     numSizes_ = dims.size();
   }
 
-  /// Print the textual representation of the type.
-  std::string asString() const;
-
   /// An empty type.
   Type() : elementType_(ElemKind::IndexTy) { numSizes_ = 0; }
 
@@ -194,5 +191,9 @@ inline bool operator==(const Type &LHS, const Type &RHS) {
 }
 
 } // namespace glow
+
+namespace std {
+std::string to_string(const glow::Type &);
+}
 
 #endif // GLOW_IR_TYPE_H

--- a/src/glow/IR/Instrs.cpp
+++ b/src/glow/IR/Instrs.cpp
@@ -90,7 +90,7 @@ const char *WeightVar::getInitKindStr() const {
 
 std::string WeightVar::getExtraDesc() const {
   auto sp = ", ";
-  auto r = getType()->asString();
+  auto r = std::to_string(*getType());
   if (getInitKind() != InitKind::kExtern) {
     r += std::string(sp) + getInitKindStr() + sp + std::to_string(val_);
   }
@@ -98,7 +98,7 @@ std::string WeightVar::getExtraDesc() const {
 }
 
 std::string AllocActivationInst::getExtraDesc() const {
-  return getType()->asString();
+  return std::to_string(*getType());
 }
 
 /// Check that the type of the first operand matches the type of the second

--- a/src/glow/IR/Type.cpp
+++ b/src/glow/IR/Type.cpp
@@ -4,21 +4,23 @@
 
 using namespace glow;
 
-std::string Type::asString() const {
-  if (!numSizes_) {
+namespace std {
+std::string to_string(const glow::Type &type) {
+  if (type.numSizes_ == 0) {
     return "<void>";
   }
 
-  std::stringstream sb;
-  sb << getElementName().str() << "<";
-
-  for (unsigned i = 0; i < numSizes_; i++) {
+  std::stringstream os;
+  os << type.getElementName().str() << '<';
+  for (unsigned i = 0; i < type.numSizes_; ++i) {
     if (i) {
-      sb << " x ";
+      os << " x ";
     }
-    sb << sizes_[i];
+    os << type.sizes_[i];
   }
+  os << '>';
 
-  sb << ">";
-  return sb.str();
+  return os.str();
 }
+}
+


### PR DESCRIPTION
C++ has a new `std::to_string` idiom to convert values to strings.  Provide a
proper overload for the function and use that instead of a custom `asString`
method.