### PR TITLE
IR: appease -Wreturn-type warning (NFC)

### DIFF
--- a/src/glow/IR/IR.cpp
+++ b/src/glow/IR/IR.cpp
@@ -239,6 +239,8 @@ static const char *getDottyArrowForCC(OperandKind k) {
     return "both";
     break;
   }
+
+  glow_unreachable();
 }
 
 /// Dump a dotty graph that depicts the module.


### PR DESCRIPTION
gcc does not like the fact that the switch does not always return a value. Add
a glow_unreachable() to mark the path dead and silence the -Wreturn-type
warning.