### PR TITLE
Support: use llvm::Timer instead of a local implementation

### DIFF
--- a/examples/cifar10.cpp
+++ b/examples/cifar10.cpp
@@ -4,6 +4,8 @@
 #include "glow/Interpreter/Interpreter.h"
 #include "glow/Support/Support.h"
 
+#include "llvm/Support/Timer.h"
+
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
@@ -109,7 +111,9 @@ void testCIFAR10() {
 
   for (int iter = 0; iter < 100000; iter++) {
     std::cout << "Training - iteration #" << iter << "\n";
-    TimerGuard reportTime(reportRate * minibatchSize);
+
+    llvm::Timer timer("Training", "Training");
+    timer.startTimer();
 
     // Bind the images tensor to the input array A, and the labels tensor
     // to the softmax node SM.
@@ -136,6 +140,8 @@ void testCIFAR10() {
         }
       }
     }
+
+    timer.stopTimer();
 
     std::cout << "Batch #" << iter << " score: " << score << "%\n";
   }

--- a/examples/mnist.cpp
+++ b/examples/mnist.cpp
@@ -4,6 +4,8 @@
 #include "glow/Interpreter/Interpreter.h"
 #include "glow/Support/Support.h"
 
+#include "llvm/Support/Timer.h"
+
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
@@ -102,11 +104,16 @@ void testMNIST() {
 
   for (int iter = 0; iter < 60; iter++) {
     std::cout << "Training - iteration #" << iter << " ";
-    TimerGuard reportTime(reportRate * minibatchSize);
+
+    llvm::Timer timer("Training", "Training");
+    timer.startTimer();
+
     // On each training iteration take an input from imageInputs and update
     // the input variable A, and add take a corresponding label and update the
     // softmax layer.
     IP.train(reportRate, {A, selected}, {&imageInputs, &labelInputs});
+
+    timer.stopTimer();
   }
   std::cout << "Validating.\n";
   IP.optimize(OptimizationMode::Infer);

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -67,6 +67,10 @@ foreach(library tinfo terminfo curses ncurses ncursesw)
   endif()
 endforeach()
 
+target_link_libraries(LLVMSupport
+                      INTERFACE
+                        Threads::Threads)
+
 add_dependencies(LLVMSupport llvm-install)
 
 ExternalProject_Add(googletest

--- a/include/glow/Support/Support.h
+++ b/include/glow/Support/Support.h
@@ -16,25 +16,6 @@ std::string to_string(const llvm::StringRef sr);
 
 namespace glow {
 
-/// A class for measuring the lifetime of some event
-/// and for rate calculation.
-class TimerGuard {
-  int iterations_;
-  std::chrono::time_point<std::chrono::system_clock> start;
-
-public:
-  TimerGuard(int iterations) : iterations_(iterations) {
-    start = std::chrono::system_clock::now();
-  }
-
-  ~TimerGuard() {
-    auto end = std::chrono::system_clock::now();
-    std::chrono::duration<double> elapsed_seconds = end - start;
-    std::cout << "Rate: " << (iterations_ / elapsed_seconds.count())
-              << "/sec\n";
-  }
-};
-
 /// \returns the escaped content of string \p str.
 /// The char '\n' becomes '\'+'n' and quotes are handled correctly.
 std::string escapeDottyString(const std::string &str);


### PR DESCRIPTION
This removes the local TimerGuard in favour of the LLVM Support Timer
class.