### PR TITLE
build: remove link against removed library

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -4,7 +4,6 @@ add_executable(cifar10
 target_link_libraries(cifar10
                       PRIVATE
                         Interpreter
-                        Network
                         ExecutionEngine
                         Graph
                         IR
@@ -15,7 +14,6 @@ add_executable(mnist
 target_link_libraries(mnist
                       PRIVATE
                         Interpreter
-                        Network
                         ExecutionEngine
                         Graph
                         IR

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -13,7 +13,6 @@ add_executable(IRgradCheckTest
                  IRGradCheck.cpp)
 target_link_libraries(IRgradCheckTest
                       PRIVATE
-                        Network
                         Interpreter
                         ExecutionEngine
                         IR
@@ -25,7 +24,6 @@ add_executable(IRTest
                  IRTest.cpp)
 target_link_libraries(IRTest
                       PRIVATE
-                        Network
                         Interpreter
                         IR
                         gtest
@@ -37,7 +35,6 @@ add_executable(InterpreterTest
 target_link_libraries(InterpreterTest
                       PRIVATE
                         Interpreter
-                        Network
                         IR
                         ExecutionEngine
                         gtest
@@ -51,7 +48,6 @@ target_link_libraries(GraphTest
                         Graph
                         IR
                         Interpreter
-                        Network
                         gtest
                         gtest_main)
 add_test(GraphTest ${GLOW_BINARY_DIR}/tests/GraphTest)
@@ -64,7 +60,6 @@ target_link_libraries(GraphOptz
                         Graph
                         IR
                         Interpreter
-                        Network
                         gtest
                         gtest_main)
 add_test(GraphOptz ${GLOW_BINARY_DIR}/tests/GraphOptz)

--- a/tools/loader/CMakeLists.txt
+++ b/tools/loader/CMakeLists.txt
@@ -6,7 +6,6 @@ target_link_libraries(loader
                         Interpreter
                         Importer
                         ExecutionEngine
-                        Network
                         IR
                         Support)
 


### PR DESCRIPTION
There is no Network library, remove the link.  Fixes the build.