### PR TITLE
ExecutionEngine: use `unique_ptr` to manage the lifetime

### DIFF
--- a/include/glow/ExecutionEngine/ExecutionEngine.h
+++ b/include/glow/ExecutionEngine/ExecutionEngine.h
@@ -24,11 +24,11 @@ class Value;
 /// users of this class.
 class ExecutionEngine final {
   /// The Graph that represents the high-level program.
-  Graph *G_;
+  std::unique_ptr<Graph> G_;
   /// The Module that holds the IR.
-  Module *M_;
+  std::unique_ptr<Module> M_;
   /// The network interpreter
-  Interpreter *IP_;
+  std::unique_ptr<Interpreter> IP_;
   /// The network trainer.
   Trainer trainer_{};
 

--- a/src/glow/ExecutionEngine/ExecutionEngine.cpp
+++ b/src/glow/ExecutionEngine/ExecutionEngine.cpp
@@ -12,13 +12,10 @@
 using namespace glow;
 
 ExecutionEngine::ExecutionEngine()
-    : G_(new Graph()), M_(new Module(G_)), IP_(new Interpreter(M_)) {}
+    : G_(std::make_unique<Graph>()), M_(std::make_unique<Module>(&*G_)),
+      IP_(std::make_unique<Interpreter>(&*M_)) {}
 
-ExecutionEngine::~ExecutionEngine() {
-  delete IP_;
-  delete M_;
-  delete G_;
-}
+ExecutionEngine::~ExecutionEngine() = default;
 
 void ExecutionEngine::infer(llvm::ArrayRef<Variable *> vars,
                             llvm::ArrayRef<Tensor *> inputs) {


### PR DESCRIPTION
This makes the lifetime ownership model clearer and simplifies the
management of the allocation.  NFC