### PR TITLE
Implement RNN example / Add slice op support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@
 build/
 external/googletest/
 external/llvm/
-

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ C++ compiler that supports C++11, on CMake, protocol buffer, and libpng.
 Before building the compiler you will need to update the git submodules with the
 command:
 
+  ```
   git submodule update
+  ```
 
 Next, create a build directory and run cmake on the source directory:
 
@@ -72,11 +74,14 @@ auto-fix and to enable/disable specific checks:
 
 ## Testing and Running
 
+To compile the project run 'ninja all' from the build/ directory.
+
 The project has a few unittests in the tests/ directory. To run all of the unit
-tests simply run the command 'ninja test' (or gmake test).  After compiling the
-project, a few test programs will be built under the /examples/ directory. The
-'mnist' and 'cifar10' programs train and run the digit recognition and image
-classification benchmarks.
+tests simply run the command 'ninja test' (or gmake test).
+
+After compiling the project, a few test programs will be built under
+the /examples/ directory. The 'mnist' and 'cifar10' programs train and run the
+digit recognition and imageOD classification benchmarks.
 
 
 The default compilation mode is 'Debug'. This means that the compiler itself is
@@ -84,14 +89,17 @@ easy to debug because the binary contains debug info, lots of assertions, and
 the optimizations are disabled. It also means that the compiler and runtime are
 very slow, and the execution time can be hundreds of times slower than that of
 release builds. If you wish to benchmark the compiler, run long benchmarks, or
-release the product then you should compile the compiler in Release mode. Check
+release the product then you should compile the compiler in 'Release' mode. Check
 the main CMake file for more details.
 
-After building Glow in Release-mode run the following command to download the
+After building Glow in 'Release' mode run the following command to download the
 cifar10 and mnist database:
 
 ```
-python ../glow/utils/download_test_db.py
+cd build/
+cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTING=YES ..
+ninja all
+python ../utils/download_test_db.py
 ```
 
 Next, after downloading and extracting the mnist and cifar10 database
@@ -100,6 +108,7 @@ Next, after downloading and extracting the mnist and cifar10 database
 ```
 ./bin/mnist
 ./bin/cifar10
+./bin/ptb
 ```
 
 Note: The databases should be (for now) in the same directory from where the

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -19,3 +19,12 @@ target_link_libraries(mnist
                         IR
                         Support)
 
+add_executable(ptb
+                 ptb.cpp)
+target_link_libraries(ptb
+                      PRIVATE
+                        Interpreter
+                        ExecutionEngine
+                        Graph
+                        IR
+                        Support)

--- a/examples/ptb.cpp
+++ b/examples/ptb.cpp
@@ -1,0 +1,255 @@
+#include "glow/ExecutionEngine/ExecutionEngine.h"
+#include "glow/Graph/Graph.h"
+#include "glow/Support/Support.h"
+
+#include "llvm/Support/Timer.h"
+
+#include <cassert>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <algorithm>
+
+using namespace glow;
+
+unsigned loadPTB(Tensor &inputWords,
+		 Tensor &targetWords,
+		 size_t numSteps,
+		 size_t vocabSize,
+		 size_t minibatchSize,
+		 size_t maxNumWords) {
+
+  std::ifstream ptbInput("ptb/simple-examples/data/ptb.train.txt");
+
+  std::vector<std::string> words;
+  std::string line;
+
+  if (ptbInput.is_open()) {
+    while (getline(ptbInput, line)) {
+      std::istringstream ss(line);
+      std::string token;
+      while (getline(ss, token, ' ')){
+	if (!token.empty()) {
+	  words.push_back(token);
+	}
+      }
+      words.push_back("<eos>");
+    }
+    ptbInput.close();
+  }
+
+  // We limit the number of words to 50,000 otherwise things will be slower.
+  words = std::vector<std::string>(words.begin(), words.begin() + maxNumWords);
+  size_t numWords = words.size();
+  std::cout << "working on it" << std::endl;
+
+  GLOW_ASSERT(numWords && "No words were found.");
+
+  std::map<std::string, int> counter;
+  // Counter of words occurences in the input text
+  for (auto word: words) {
+    if (counter.find(word) == counter.end()) {
+      counter[word] = 0;
+    }
+    counter[word] += 1;
+  }
+
+  // Sort the counter
+  std::vector<std::pair<std::string, int> > counter_v;
+  copy(counter.begin(),
+       counter.end(),
+       std::back_inserter<std::vector<std::pair<std::string, int> > >(counter_v));
+
+  sort(counter_v.begin(), counter_v.end(), [](const std::pair<std::string, int>& lhs,
+					      const std::pair<std::string, int>& rhs) {
+	 if (lhs.second == rhs.second) {
+	   return rhs.first > lhs.first;
+	 }
+	 return lhs.second > rhs.second;
+       });
+
+  // Build the word to id map
+  std::map<std::string, int> word_to_id;
+  for (unsigned i = 0; i < counter_v.size(); i++) {
+    auto const &word = counter_v[i].first;
+    word_to_id[word] = std::min<size_t>(i, vocabSize - 1);
+  }
+
+  // Load the PTB database into two 3d tensors for word inputs and targets.
+	size_t batchLength = numWords / minibatchSize;
+  size_t numBatches = (batchLength - 1) / numSteps;
+  size_t numSequences = minibatchSize * numBatches;
+
+  // While we dont have embedding, we are using one-hot encoding to represent
+  // input words. To limit the size of the data we use an upper bound on the
+  // vocabulary size.
+  inputWords.reset(ElemKind::FloatTy, {numSequences, vocabSize * numSteps});
+  targetWords.reset(ElemKind::IndexTy, {numSequences, numSteps});
+  auto IIH = inputWords.getHandle<>();
+  auto TIH = targetWords.getHandle<size_t>();
+  for (unsigned batch = 0; batch < minibatchSize; batch++) {
+    for (unsigned iter = 0; iter < numBatches; iter++) {
+      size_t sequence = batch + iter * minibatchSize;
+      for (unsigned step = 0; step < numSteps; step++) {
+	int word_counter_id = step + iter * numSteps + batch * batchLength;
+	const std::string word1 = words[word_counter_id];
+	const std::string word2 = words[word_counter_id + 1];
+	IIH.at({sequence, step * vocabSize + word_to_id[word1]}) = 1;
+	TIH.at({sequence, step}) = word_to_id[word2];
+      }
+    }
+  }
+  return numWords;
+}
+
+void debug(Node* node) {
+  std::cout << (std::string)node->getName();
+  for (int i = 0; i < node->dims().size(); i++) {
+    std::cout << " " << node->dims()[i];
+  }
+  std::cout << std::endl;
+}
+
+/// This test builds a RNN language model on the Penn TreeBank dataset.
+/// Results for RNN word-level perplexity are reported in https://arxiv.org/pdf/1409.2329.pdf
+/// Here we simplify the problem ti be able to run it on a single CPU.
+/// The expected results for the following settings is a perplexity of 42
+/// after the 10th iteration.
+/// The current code achieves a perplexity of 98.
+void testPTB() {
+  std::cout << "Loading the ptb database.\n";
+
+  Tensor inputWords;
+  Tensor targetWords;
+
+  size_t numSteps = 5;
+  size_t hiddenSize = 200;
+  size_t vocabSize = 700;
+  size_t minibatchSize = 20;
+  float learningRate = 0.001;
+  size_t maxNumWords = 50000;
+  size_t numEpochs = 10;
+
+  unsigned numWords = loadPTB(inputWords,
+			      targetWords,
+			      numSteps,
+			      vocabSize,
+			      minibatchSize,
+			      maxNumWords);
+  std::cout << "Loaded " << numWords << " words.\n";
+  ExecutionEngine EE;
+
+  // Construct the network:
+  EE.getConfig().learningRate = learningRate;
+  EE.getConfig().momentum = 0;
+
+  auto &G = EE.getGraph();
+
+  Variable *X = G.createVariable(ElemKind::FloatTy, {minibatchSize, vocabSize * numSteps},
+				 "input", Variable::InitKind::Extern);
+  Variable *Y = G.createVariable(ElemKind::IndexTy, {minibatchSize, numSteps},
+				 "selected", Variable::InitKind::Extern);
+
+  auto *HtInit = G.createVariable(ElemKind::FloatTy, {minibatchSize, numSteps},
+				  "initial_state",
+				  Variable::InitKind::Broadcast, 0);
+
+  std::vector<Node *> outputNodes;
+  TanhNode *HtLast;
+
+  for (unsigned t = 0; t < numSteps; t++) {
+    const std::string XtName = std::to_string("x") + std::to_string(t);
+    const std::string FC1tName = std::to_string("fc1") + std::to_string(t);
+    const std::string FC2tName = std::to_string("fc2") + std::to_string(t);
+    const std::string FCtName = std::to_string("fc") + std::to_string(t);
+    const std::string TanhtName = std::to_string("tanh") + std::to_string(t);
+    const std::string OtName = std::to_string("o") + std::to_string(t);
+
+    auto *Xt = G.createSlice(XtName, X, {0, t * vocabSize}, {minibatchSize, vocabSize});
+    FullyConnectedNode *FC1t;
+    if (t == 0) {
+      FC1t = G.createFullyConnected(FC1tName, HtInit, hiddenSize);
+    } else {
+      FC1t = G.createFullyConnected(FC1tName, HtLast, hiddenSize);
+    }
+    auto *FC2t = G.createFullyConnected(FC2tName, Xt, hiddenSize);
+    auto *At = G.createArithmetic(FCtName, FC1t, FC2t, ArithmeticNode::Mode::Add);
+    auto *Ht = G.createTanh(TanhtName, At);
+    HtLast = Ht;
+    auto *Ot = G.createFullyConnected(OtName, Ht, vocabSize);
+    // Ot has shape {minibatchSize, vocabSize}
+    outputNodes.push_back(Ot);
+  }
+  Node *O = outputNodes[0];
+  for (unsigned t = 1; t < numSteps; t++) {
+    const std::string ConcatName = std::to_string("concat") + std::to_string(t);
+    O = G.createConcat(ConcatName, O, outputNodes[t], 0);
+  }
+  // O has final shape of {minibatchSize * numSteps, vocabSize}
+  // Y has shape of {minibatchSize, numSteps}
+  auto *Yr = G.createReshape("yreshape", Y, {minibatchSize * numSteps});
+  auto *SM = G.createSoftMax("softmax", O, Yr);
+  auto *result = G.createSave("result", SM);
+
+  std::cout << "Dumping graph" << std::endl;
+  G.dumpDAG();
+
+  EE.compile(CompilationMode::Train);
+
+  // Run for those many iterations inside an epoch. Note that this is poorly named
+  // as it stands since there is no reporting that happens inside the EE.train(..) call
+  // Also note that this value will affect the range of inputs which is actually covered
+  // by the algorithm unless it is selected in such a way that it will wrap around. Here
+  // we carefully select it in such a way that it will do a single pass on the entire
+  // dataset.
+  size_t numBatches = (numWords / minibatchSize - 1) / numSteps;
+
+  std::cout << "Training for " << numBatches << " rounds" << std::endl;
+
+  for (int iter = 0; iter < numEpochs; iter++) {
+    std::cout << "Training - iteration #" << (iter + 1) << std::endl;
+
+    llvm::Timer timer("Training", "Training");
+    timer.startTimer();
+
+    // On each training iteration take an input from imageInputs and update
+    // the input variable A, and add take a corresponding label and update the
+    // softmax layer.
+    EE.train(numBatches, {X, Y}, {&inputWords, &targetWords});
+
+    // Compute the perplexity over a few minibatches
+    float perplexity = 0;
+    size_t perplexityWordsCount = 0;
+
+    std::cout << "Computing training perplexity" << std::endl;
+    // We should not run infer on training data, these values should be obtained from
+    // the training step itself.
+    for (unsigned batch = 0; batch < numBatches; batch++) {
+      Tensor sample(ElemKind::FloatTy, {minibatchSize, vocabSize * numSteps});
+      sample.copyConsecutiveSlices(&inputWords, minibatchSize * batch);
+      EE.infer({X}, {&sample});
+      Tensor &res = result->getOutput()->getPayload();
+      for (unsigned int i = 0; i < minibatchSize; i++) {
+	for (size_t step = 0; step < numSteps; step++) {
+	  auto T = res.getHandle<>().extractSlice(i * numSteps + step);
+	  size_t correct = targetWords.getHandle<std::size_t>().at({
+	      minibatchSize * batch + i, step});
+	  double soft_guess = - std::log(T.getHandle<>().at({correct}));
+	  unsigned guess = T.getHandle<>().maxArg();
+	  perplexity += soft_guess;
+	  perplexityWordsCount += 1;
+	}
+      }
+    }
+    perplexity /= perplexityWordsCount;
+    perplexity = std::exp(perplexity);
+    std::cout << perplexity << std::endl;
+    timer.stopTimer();
+  }
+}
+
+int main() {
+  testPTB();
+
+  return 0;
+}

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -88,6 +88,10 @@ public:
   TransposeNode *createTranspose(llvm::StringRef name, Node *input,
                                  llvm::ArrayRef<unsigned> shuffle);
 
+  SliceNode *createSlice(llvm::StringRef name, Node *input,
+			 llvm::ArrayRef<size_t> begin,
+			 llvm::ArrayRef<size_t> size);
+
   ConcatNode *createConcat(llvm::StringRef name, Node *LHS, Node *RHS,
                            unsigned dimension);
 

--- a/include/glow/IR/IRBuilder.h
+++ b/include/glow/IR/IRBuilder.h
@@ -58,6 +58,10 @@ public:
   TransposeInst *createTransposeOp(Value *input,
                                    llvm::ArrayRef<unsigned> shuffle);
 
+  SliceInst *createSliceOp(Value *input,
+			   llvm::ArrayRef<size_t> begin,
+			   llvm::ArrayRef<size_t> size);
+
   ConcatInst *createConcatOp(Value *LHS, Value *RHS, unsigned dimension);
 
   BatchNormalizationInst *createBatchNormalizationOp(Value *input,

--- a/src/glow/Backends/Interpreter/InterpreterNodes.cpp
+++ b/src/glow/Backends/Interpreter/InterpreterNodes.cpp
@@ -618,17 +618,126 @@ void Interpreter::fwdTransposeGradInst(bool isTrain,
 }
 
 void Interpreter::fwdReshapeInst(bool isTrain, const ReshapeInst *I) {
-  auto inW = getWeightHandle(I->getSrc());
-  auto outW = getWeightHandle(I->getDest());
-  for (size_t i = 0, e = inW.size(); i < e; i++) {
-    outW.raw(i) = inW.raw(i);
+  auto inT = getTensor(I->getSrc());
+  auto outT = getTensor(I->getDest());
+  switch(inT->getElementType()) {
+  case ElemKind::FloatTy: {
+    auto outW = outT->getHandle<>();
+    auto inW = inT->getHandle<>();
+    for (size_t i = 0, e = inW.size(); i < e; i++) {
+      outW.raw(i) = inW.raw(i);
+    }
+    break;
+  }
+  case ElemKind::IndexTy: {
+    auto outW = outT->getHandle<size_t>();
+    auto inW = inT->getHandle<size_t>();
+    for (size_t i = 0, e = inW.size(); i < e; i++) {
+      outW.raw(i) = inW.raw(i);
+    }
+    break;
+  }
+  case ElemKind::DoubleTy: {
+    break;
+  }
+  case ElemKind::Int8Ty: {
+    break;
+  }
+  case ElemKind::Int32Ty: {
+    break;
+  }
   }
 }
 void Interpreter::fwdReshapeGradInst(bool isTrain, const ReshapeGradInst *I) {
-  auto inG = getWeightHandle(I->getSrcGrad());
-  auto outG = getWeightHandle(I->getDestGrad());
-  for (size_t i = 0, e = outG.size(); i < e; i++) {
-    inG.raw(i) += outG.raw(i);
+  auto inT = getTensor(I->getSrcGrad());
+  auto outT = getTensor(I->getDestGrad());
+  switch(inT->getElementType()) {
+  case ElemKind::FloatTy: {
+    auto outG = outT->getHandle<>();
+    auto inG = inT->getHandle<>();
+    for (size_t i = 0, e = outG.size(); i < e; i++) {
+      inG.raw(i) += outG.raw(i);
+    }
+    break;
+  }
+  case ElemKind::IndexTy: {
+    auto outG = outT->getHandle<size_t>();
+    auto inG = inT->getHandle<size_t>();
+    for (size_t i = 0, e = outG.size(); i < e; i++) {
+      inG.raw(i) += outG.raw(i);
+    }
+    break;
+  }
+  case ElemKind::DoubleTy: {
+    break;
+  }
+  case ElemKind::Int8Ty: {
+    break;
+  }
+  case ElemKind::Int32Ty: {
+    break;
+  }
+  }
+}
+
+void Interpreter::fwdSliceInst(bool isTrain, const SliceInst *I) {
+  auto inW = getTensor(I->getSrc());
+  auto outW = getTensor(I->getDest());
+  auto begin = I->getBegin();
+  // Instead of switching with each tensor element type, we could be using
+  // directly tensor operations similar to copySlice and copyConsecutiveSlices.
+  switch(inW->getElementType()) {
+  case ElemKind::FloatTy: {
+    auto outWH = outW->getHandle<>();
+    auto inWH = inW->getHandle<>();
+    inWH.extractTensors(outWH, begin);
+    break;
+  }
+  case ElemKind::IndexTy: {
+    auto outWH = outW->getHandle<size_t>();
+    auto inWH = inW->getHandle<size_t>();
+    inWH.extractTensors(outWH, begin);
+    break;
+  }
+  case ElemKind::DoubleTy: {
+    break;
+  }
+  case ElemKind::Int8Ty: {
+    break;
+  }
+  case ElemKind::Int32Ty: {
+    break;
+  }
+  }
+}
+void Interpreter::fwdSliceGradInst(bool isTrain, const SliceGradInst *I) {
+  auto inG = getTensor(I->getSrcGrad());
+  auto outG = getTensor(I->getDestGrad());
+  auto begin = I->getBegin();
+  // Instead of switching with each tensor element type, we could be using
+  // directly tensor operations similar to copySlice and copyConsecutiveSlices.
+  switch(inG->getElementType()) {
+  case ElemKind::FloatTy: {
+    auto outGH = outG->getHandle<>();
+    auto inGH = inG->getHandle<>();
+    inGH.insertTensors(outGH, begin);
+    break;
+  }
+  case ElemKind::IndexTy: {
+    auto outGH = outG->getHandle<size_t>();
+    auto inGH = inG->getHandle<size_t>();
+    inGH.extractTensors(outGH, begin);
+    break;
+  }
+  case ElemKind::DoubleTy: {
+    break;
+  }
+  case ElemKind::Int8Ty: {
+    break;
+  }
+  case ElemKind::Int32Ty: {
+    break;
+  }
   }
 }
 

--- a/src/glow/ExecutionEngine/ExecutionEngine.cpp
+++ b/src/glow/ExecutionEngine/ExecutionEngine.cpp
@@ -56,7 +56,7 @@ void ExecutionEngine::train(size_t iterations, llvm::ArrayRef<Variable *> vars,
 
   for (size_t i = 0; i < iterations; i++) {
     // Launch threads that update the different chunks in the batch:
-    updateForwardBackward(vars, inputs, trainCounter + batchSize);
+    updateForwardBackward(vars, inputs, trainCounter);
 
     trainCounter += batchSize;
 

--- a/src/glow/Graph/Graph.cpp
+++ b/src/glow/Graph/Graph.cpp
@@ -154,16 +154,25 @@ TransposeNode *Graph::createTranspose(llvm::StringRef name, Node *input,
   return addNode(new TransposeNode(name, NT, input, shuffle.vec()));
 }
 
+SliceNode *Graph::createSlice(llvm::StringRef name, Node *input,
+			      llvm::ArrayRef<size_t> begin,
+			      llvm::ArrayRef<size_t> size) {
+  auto TS = uniqueType(input->getType()->getElementType(), size);
+
+  return addNode(new SliceNode(name, TS, input, begin.vec(), size.vec()));
+}
+
 ConcatNode *Graph::createConcat(llvm::StringRef name, Node *LHS, Node *RHS,
                                 unsigned dimension) {
   assert(LHS->getType() == RHS->getType() && "Invalid types");
   auto inDim = LHS->dims();
+  auto inDim2 = RHS->dims();
 
   std::vector<size_t> shape(inDim.begin(), inDim.end());
+  std::vector<size_t> shape2(inDim2.begin(), inDim2.end());
   // We are stacking the tensors along a specific dimension. This means that we
   // increase the size of the tensor along this dimension.
-  shape[dimension] *= 2;
-
+  shape[dimension] += shape2[dimension];
   auto NT = uniqueType(LHS->getElementType(), shape);
   return addNode(new ConcatNode(name, NT, LHS, RHS, dimension));
 }

--- a/src/glow/IR/IRBuilder.cpp
+++ b/src/glow/IR/IRBuilder.cpp
@@ -154,15 +154,25 @@ TransposeInst *IRBuilder::createTransposeOp(Value *input,
   return createTransposeInst("transp", res, input, shuffle);
 }
 
+SliceInst *IRBuilder::createSliceOp(Value *input,
+				     llvm::ArrayRef<size_t> begin,
+				     llvm::ArrayRef<size_t> size) {
+  auto *res =
+      createAllocActivationInst("slice.res", input->getElementType(), size);
+  return createSliceInst("slice", res, input, begin, size);
+}
+
 ConcatInst *IRBuilder::createConcatOp(Value *LHS, Value *RHS,
                                       unsigned dimension) {
   assert(LHS->getType() == RHS->getType() && "Invalid dims");
   auto inDim = LHS->dims();
+  auto inDim2 = RHS->dims();
 
   std::vector<size_t> shape(inDim.begin(), inDim.end());
+  std::vector<size_t> shape2(inDim2.begin(), inDim2.end());
   // We are stacking the tensors along a specific dimension. This means that we
   // increase the size of the tensor along this dimension.
-  shape[dimension] *= 2;
+  shape[dimension] += shape2[dimension];
 
   auto *res =
       createAllocActivationInst("concat.res", LHS->getElementType(), shape);

--- a/src/glow/IR/IRGen.cpp
+++ b/src/glow/IR/IRGen.cpp
@@ -150,6 +150,14 @@ public:
       registerIR(N, V->getDest());
       break;
     }
+    case glow::Kinded::Kind::SliceNodeKind: {
+      auto *SS = cast<SliceNode>(N);
+      auto *in = valueForNode(SS->getInput());
+      auto *V = builder_.createSliceOp(in, SS->getBegin(), SS->getSize());
+      V->setName(N->getName());
+      registerIR(N, V->getDest());
+      break;
+    }
     case glow::Kinded::Kind::ReshapeNodeKind: {
       auto *RS = cast<ReshapeNode>(N);
       auto *in = valueForNode(RS->getInput());
@@ -339,6 +347,10 @@ void generateBackwardPass(Module &M) {
     }
     case Kind::TransposeInstKind: {
       toAppend.push_back(cast<TransposeInst>(I)->getGrad(weightToGradMap));
+      break;
+    }
+    case Kind::SliceInstKind: {
+      toAppend.push_back(cast<SliceInst>(I)->getGrad(weightToGradMap));
       break;
     }
     case Kind::ConcatInstKind: {

--- a/src/glow/IR/Instrs.cpp
+++ b/src/glow/IR/Instrs.cpp
@@ -168,6 +168,22 @@ void TransposeInst::verify() const {
          "Invalid transpose dims");
 }
 
+void SliceInst::verify() const {
+  auto *dest = getOperand(0).first;
+  auto *src = getOperand(1).first;
+  auto dims = src->dims();
+  assert(dims.size() == 2 && "Only 2-dimensional slices supported");
+  for (size_t i = 0; i < dims.size(); i++) {
+    auto i_size = Size_[i];
+    auto i_begin = Begin_[i];
+    auto i_end = i_begin + i_size - 1;
+    assert(i_begin >= 0 && "Invalid slice indices");
+    assert(i_size > 0 && "Invalid slice size");
+    assert(i_end < dims[i] && "Invalid slice indices");
+  }
+  assert(dest->dims() == llvm::ArrayRef<size_t>(Size_) && "Invalid slice dims");
+}
+
 void ConcatInst::verify() const {
   assert(getNumOperands() > 1 && "Invalid number of operands");
   // The dimension of the first input.
@@ -238,6 +254,7 @@ NOVERIFY(ReluGradInst)
 NOVERIFY(TanhGradInst)
 NOVERIFY(SigmoidGradInst)
 NOVERIFY(TransposeGradInst)
+NOVERIFY(SliceGradInst)
 NOVERIFY(ReshapeGradInst)
 NOVERIFY(ElementAddGradInst)
 NOVERIFY(ElementMulGradInst)

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -206,6 +206,19 @@ int main(int argc, char **argv) {
           "llvm::ArrayRef<unsigned> getShuffle() const { return Shuffle_; }")
       .addGradientInstr({}, {"Dest", "Src"});
 
+  BB.newInstr("Slice")
+      .addOperand("Dest", OperandKind::Out)
+      .addOperand("Src", OperandKind::In)
+      .addMember("std::vector<size_t>", "Begin")
+      .overrideGetter(
+          "Begin",
+          "llvm::ArrayRef<size_t> getBegin() const { return Begin_; }")
+      .addMember("std::vector<size_t>", "Size")
+      .overrideGetter(
+          "Size",
+          "llvm::ArrayRef<size_t> getSize() const { return Size_; }")
+      .addGradientInstr({}, {"Dest", "Src"});
+
   BB.newInstr("Concat")
       .addOperand("Dest", OperandKind::Out)
       .addOperand("LHS", OperandKind::In)

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -143,6 +143,19 @@ int main(int argc, char **argv) {
           "Shuffle",
           "llvm::ArrayRef<unsigned> getShuffle() const { return Shuffle_; }");
 
+  BB.newNode("Slice")
+      .addOperand("Input")
+      .addMember("std::vector<size_t>", "Begin")
+      .addMember("std::vector<size_t>", "Size")
+      .addExtraParam("TypeRef", "outTy")
+      .setType("outTy")
+      .overrideGetter(
+          "Begin",
+          "llvm::ArrayRef<size_t> getBegin() const { return Begin_; }")
+      .overrideGetter(
+          "Size",
+          "llvm::ArrayRef<size_t> getSize() const { return Size_; }");
+
   BB.newNode("Concat")
       .addOperand("LHS")
       .addOperand("RHS")

--- a/utils/download_test_db.py
+++ b/utils/download_test_db.py
@@ -5,7 +5,7 @@ import urllib
 import tarfile
 import os.path
 
-# This script downloads and extracts the mnist and cifar-10 databases.
+# This script downloads and extracts the mnist, ptb and cifar-10 databases.
 
 print("""Downloading test files. If the download fails try setting up a proxy:
     #export http_proxy="http://fwdproxy:8080
@@ -14,6 +14,7 @@ print("""Downloading test files. If the download fails try setting up a proxy:
 
 mnist_filename = "mnist.pkl.gz"
 cifar10_filename = "cifar-10.binary.tar.gz"
+ptb_filename = "ptb.tgz"
 
 if os.path.exists(mnist_filename):
     print("MNIST file found. Not downloading.")
@@ -26,6 +27,12 @@ if os.path.exists(cifar10_filename):
 else:
     print("Downloading CIFAR ... ")
     urllib.urlretrieve ("http://www.cs.toronto.edu/~kriz/cifar-10-binary.tar.gz", cifar10_filename)
+
+if os.path.exists(ptb_filename):
+    print("PTB file found. Not downloading.")
+else:
+    print("Downloading PTB ... ")
+    urllib.urlretrieve ("http://www.fit.vutbr.cz/~imikolov/rnnlm/simple-examples.tgz", ptb_filename)
 
 def dumpToFile(dataset):
     data, labels = dataset
@@ -51,3 +58,8 @@ tar = tarfile.open(cifar10_filename, "r:gz")
 tar.extractall()
 tar.close()
 
+
+print("Extracting the PTB database.")
+tar = tarfile.open(ptb_filename, "r:gz")
+tar.extractall('ptb')
+tar.close()


### PR DESCRIPTION
In this change I have tried to implement an RNN inspired from the tensorflow tutorial's RNN which can be found here https://www.tensorflow.org/tutorials/recurrent and the corresponding paper https://arxiv.org/pdf/1409.2329.pdf

The RNN we built has several limitations:
 - No use of dropout
 - No use of embedding
 - No use of LSTM
 - No gradient clipping
 - No multi-layer RNNs
 - No learning rate decay

These limitations  can be addressed in future changes

NB: I am still figuring out why my perplixity numbers are showing lower values than the ones reported in the paper and the tutorial. So this change is not yet complete.