### PR TITLE
Convert textual types to enums in InstrGen and NodeGen

### DIFF
--- a/tools/ClassGen/InstrBuilder.h
+++ b/tools/ClassGen/InstrBuilder.h
@@ -2,6 +2,7 @@
 #define GLOW_TOOLS_NODEGEN_INSTRBUILDER_H
 
 #include "glow/Support/Support.h"
+#include "MemberType.h"
 
 #include <cassert>
 #include <fstream>
@@ -42,7 +43,7 @@ class InstrBuilder {
   /// The instruction operands.
   std::vector<std::pair<std::string, OperandKind>> operands_;
   /// A list of instruction members. Format: (type, name).
-  std::vector<std::pair<std::string, std::string>> members_;
+  std::vector<std::pair<MemberType, std::string>> members_;
   /// A list of extra parameters that are passed to the constructor.
   std::vector<std::pair<std::string, std::string>> extraParams_;
   /// A list of getters to override. Format (variable name, alternative getter).
@@ -89,10 +90,11 @@ public:
     addOperand(op + "Grad", OperandKind::InOut);
     return *this;
   }
+
   /// Add a member to the instruction. Format: type, name.
   /// The name should start with a capital letter.
   /// For example: "Filter".
-  InstrBuilder &addMember(const std::string &type, const std::string &name) {
+  InstrBuilder &addMember(const MemberType type, const std::string &name) {
     members_.push_back({type, name});
     return *this;
   }
@@ -146,7 +148,17 @@ public:
   /// Emits the method that calculates the inplace property.
   void emitInplaceMethod(std::ostream &os) const;
 
-  /// Emit stters/getters for each accessible class member.
+  /// Emit the getter for an operand.
+  void emitOperandGetter(std::ostream &os,
+                         const std::string &name,
+                         int index) const;
+
+  /// Emit the getter for a accessible class member.
+  void emitMemberGetter(std::ostream &os,
+                        MemberType type,
+                        const std::string &name) const;
+
+  /// Emit setters/getters for each accessible class member.
   void emitSettersGetters(std::ostream &os) const;
 
   /// Emit the methods that print a textual summary.

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -27,7 +27,9 @@ int main(int argc, char **argv) {
 
   BB.declareValue("WeightVar");
 
-  BB.newInstr("AllocActivation").addMember("TypeRef", "Ty").setType("Ty");
+  BB.newInstr("AllocActivation")
+      .addMember(MemberType::TypeRef, "Ty")
+      .setType("Ty");
 
   BB.newInstr("DeallocActivation")
       .addOperand("Src", OperandKind::Out)
@@ -50,27 +52,27 @@ int main(int argc, char **argv) {
       .addOperand("Src", OperandKind::In)
       .addOperand("Filter", OperandKind::In)
       .addOperand("Bias", OperandKind::In)
-      .addMember("size_t", "Kernel")
-      .addMember("size_t", "Stride")
-      .addMember("size_t", "Pad")
-      .addMember("size_t", "Depth")
+      .addMember(MemberType::SizeT, "Kernel")
+      .addMember(MemberType::SizeT, "Stride")
+      .addMember(MemberType::SizeT, "Pad")
+      .addMember(MemberType::SizeT, "Depth")
       .addGradientInstr({"Src", "Filter"}, {"Dest", "Src", "Filter", "Bias"});
 
   BB.newInstr("PoolMax")
       .addOperand("Dest", OperandKind::Out)
       .addOperand("Src", OperandKind::In)
       .addOperand("SrcXY", OperandKind::InOut)
-      .addMember("size_t", "Kernel")
-      .addMember("size_t", "Stride")
-      .addMember("size_t", "Pad")
+      .addMember(MemberType::SizeT, "Kernel")
+      .addMember(MemberType::SizeT, "Stride")
+      .addMember(MemberType::SizeT, "Pad")
       .addGradientInstr({"Dest", "SrcXY"}, {"Dest", "Src"});
 
   BB.newInstr("PoolAvg")
       .addOperand("Dest", OperandKind::Out)
       .addOperand("Src", OperandKind::In)
-      .addMember("size_t", "Kernel")
-      .addMember("size_t", "Stride")
-      .addMember("size_t", "Pad")
+      .addMember(MemberType::SizeT, "Kernel")
+      .addMember(MemberType::SizeT, "Stride")
+      .addMember(MemberType::SizeT, "Pad")
       .addGradientInstr({"Dest"}, {"Dest", "Src"});
 
   BB.newInstr("FullyConnected")
@@ -78,7 +80,7 @@ int main(int argc, char **argv) {
       .addOperand("Src", OperandKind::In)
       .addOperand("Filter", OperandKind::In)
       .addOperand("Bias", OperandKind::In)
-      .addMember("size_t", "Depth")
+      .addMember(MemberType::SizeT, "Depth")
       .addGradientInstr({"Src", "Filter"}, {"Dest", "Src", "Filter", "Bias"});
 
   //===--------------------------------------------------------------------===//
@@ -92,9 +94,9 @@ int main(int argc, char **argv) {
       .addOperand("Bias", OperandKind::In)
       .addOperand("Mean", OperandKind::In)
       .addOperand("Var", OperandKind::In)
-      .addMember("size_t", "ChannelIdx")
-      .addMember("float", "Epsilon")
-      .addMember("float", "Momentum")
+      .addMember(MemberType::SizeT, "ChannelIdx")
+      .addMember(MemberType::Float, "Epsilon")
+      .addMember(MemberType::Float, "Momentum")
       .inplaceOperand({
           "Dest", "Src",
       })
@@ -105,10 +107,10 @@ int main(int argc, char **argv) {
       .addOperand("Dest", OperandKind::Out)
       .addOperand("Src", OperandKind::In)
       .addOperand("Scale", OperandKind::In)
-      .addMember("size_t", "HalfWindowSize")
-      .addMember("float", "Alpha")
-      .addMember("float", "Beta")
-      .addMember("float", "K")
+      .addMember(MemberType::SizeT, "HalfWindowSize")
+      .addMember(MemberType::Float, "Alpha")
+      .addMember(MemberType::Float, "Beta")
+      .addMember(MemberType::Float, "K")
       .setType("Src->getType()")
       .inplaceOperand({
           "Dest", "Src",
@@ -187,25 +189,20 @@ int main(int argc, char **argv) {
   BB.newInstr("Reshape")
       .addOperand("Dest", OperandKind::Out)
       .addOperand("Src", OperandKind::In)
-      .addMember("std::vector<size_t>", "Dims")
-      .overrideGetter(
-          "Dims", "llvm::ArrayRef<size_t> getDims() const { return Dims_; }")
+      .addMember(MemberType::VectorSizeT, "Dims")
       .addGradientInstr({}, {"Dest", "Src"});
 
   BB.newInstr("Transpose")
       .addOperand("Dest", OperandKind::Out)
       .addOperand("Src", OperandKind::In)
-      .addMember("std::vector<unsigned>", "Shuffle")
-      .overrideGetter(
-          "Shuffle",
-          "llvm::ArrayRef<unsigned> getShuffle() const { return Shuffle_; }")
+      .addMember(MemberType::VectorUnsigned, "Shuffle")
       .addGradientInstr({}, {"Dest", "Src"});
 
   BB.newInstr("Concat")
       .addOperand("Dest", OperandKind::Out)
       .addOperand("LHS", OperandKind::In)
       .addOperand("RHS", OperandKind::In)
-      .addMember("size_t", "Dim")
+      .addMember(MemberType::SizeT, "Dim")
       .addGradientInstr({}, {"Dest", "LHS", "RHS"});
 
   return 0;

--- a/tools/ClassGen/MemberType.h
+++ b/tools/ClassGen/MemberType.h
@@ -1,0 +1,44 @@
+#ifndef GLOW_TOOLS_CLASSGEN_MEMBERTYPE_H
+#define GLOW_TOOLS_CLASSGEN_MEMBERTYPE_H
+
+#include <cassert>
+#include <string>
+#include <unordered_map>
+
+enum MemberType {
+  TypeRef,
+  Float,
+  Unsigned,
+  SizeT,
+  VectorFloat,
+  VectorUnsigned,
+  VectorSizeT,
+};
+
+struct TypeStr {
+  std::string storageType;
+  std::string returnType;
+};
+
+static const std::unordered_map<MemberType, TypeStr> kMemberTypeStrMap = {
+  { MemberType::TypeRef, {"TypeRef", "TypeRef"} },
+  { MemberType::Float, {"float", "float"} },
+  { MemberType::Unsigned, {"unsigned", "unsigned"} },
+  { MemberType::SizeT, {"size_t", "size_t"} },
+  { MemberType::VectorFloat, {"std::vector<float>",
+                              "llvm::ArrayRef<float>"} },
+  { MemberType::VectorUnsigned, {"std::vector<unsigned>",
+                                 "llvm::ArrayRef<unsigned>"} },
+  { MemberType::VectorSizeT, {"std::vector<size_t>",
+                              "llvm::ArrayRef<size_t>"} },
+};
+
+inline std::string getStorageTypename(MemberType type) {
+  return kMemberTypeStrMap.at(type).storageType;
+}
+
+inline std::string getReturnTypename(MemberType type) {
+  return kMemberTypeStrMap.at(type).returnType;
+}
+
+#endif // GLOW_TOOLS_CLASSGEN_MEMBERTYPE_H

--- a/tools/ClassGen/NodeBuilder.h
+++ b/tools/ClassGen/NodeBuilder.h
@@ -1,6 +1,8 @@
 #ifndef GLOW_TOOLS_NODEGEN_NODEBUILDER_H
 #define GLOW_TOOLS_NODEGEN_NODEBUILDER_H
 
+#include "MemberType.h"
+
 #include <cassert>
 #include <fstream>
 #include <iostream>
@@ -19,7 +21,7 @@ class NodeBuilder {
   /// The node operands.
   std::vector<std::string> operands_;
   /// A list of node members. Format: (type, name).
-  std::vector<std::pair<std::string, std::string>> members_;
+  std::vector<std::pair<MemberType, std::string>> members_;
   /// The node enum cases.
   std::vector<std::string> enum_;
   /// A list of extra parameters that are passed to the constructor.
@@ -49,7 +51,7 @@ public:
   /// Add a member to the node. Format: type, name.
   /// The name should start with a capital letter.
   /// For example: "Filter".
-  NodeBuilder &addMember(const std::string &type, const std::string &name) {
+  NodeBuilder &addMember(MemberType type, const std::string &name) {
     members_.push_back({type, name});
     return *this;
   }
@@ -94,7 +96,16 @@ public:
   /// Emits the class members (the fields of the class).
   void emitClassMembers(std::ostream &os) const;
 
-  /// Emit stters/getters for each accessible class member.
+  /// Emit the getter for an operand.
+  void emitOperandGetter(std::ostream &os,
+                         const std::string &name) const;
+
+  /// Emit the getter for a accessible class member.
+  void emitMemberGetter(std::ostream &os,
+                        MemberType type,
+                        const std::string &name) const;
+
+  /// Emit setters/getters for each accessible class member.
   void emitSettersGetters(std::ostream &os) const;
 
   /// Emit the methods that print a textual summary of the node.

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -40,10 +40,10 @@ int main(int argc, char **argv) {
       .addOperand("Input")
       .addOperand("Filter")
       .addOperand("Bias")
-      .addMember("size_t", "Kernel")
-      .addMember("size_t", "Stride")
-      .addMember("size_t", "Pad")
-      .addMember("size_t", "Depth")
+      .addMember(MemberType::SizeT, "Kernel")
+      .addMember(MemberType::SizeT, "Stride")
+      .addMember(MemberType::SizeT, "Pad")
+      .addMember(MemberType::SizeT, "Depth")
       .addExtraParam("TypeRef", "outTy")
       .setType("outTy");
 
@@ -51,9 +51,9 @@ int main(int argc, char **argv) {
       .addEnumCase("Max")
       .addEnumCase("Avg")
       .addOperand("Input")
-      .addMember("size_t", "Kernel")
-      .addMember("size_t", "Stride")
-      .addMember("size_t", "Pad")
+      .addMember(MemberType::SizeT, "Kernel")
+      .addMember(MemberType::SizeT, "Stride")
+      .addMember(MemberType::SizeT, "Pad")
       .addExtraParam("TypeRef", "outTy")
       .setType("outTy");
 
@@ -61,7 +61,7 @@ int main(int argc, char **argv) {
       .addOperand("Input")
       .addOperand("Filter")
       .addOperand("Bias")
-      .addMember("size_t", "Depth")
+      .addMember(MemberType::SizeT, "Depth")
       .addExtraParam("TypeRef", "outTy")
       .setType("outTy");
 
@@ -75,18 +75,18 @@ int main(int argc, char **argv) {
       .addOperand("Bias")
       .addOperand("Mean")
       .addOperand("Var")
-      .addMember("size_t", "ChannelIdx")
-      .addMember("float", "Epsilon")
-      .addMember("float", "Momentum")
+      .addMember(MemberType::SizeT, "ChannelIdx")
+      .addMember(MemberType::Float, "Epsilon")
+      .addMember(MemberType::Float, "Momentum")
       .setType("Input->getType()");
 
   BB.newNode("LocalResponseNormalization")
       .addOperand("Input")
       .addOperand("Scale")
-      .addMember("size_t", "HalfWindowSize")
-      .addMember("float", "Alpha")
-      .addMember("float", "Beta")
-      .addMember("float", "K")
+      .addMember(MemberType::SizeT, "HalfWindowSize")
+      .addMember(MemberType::Float, "Alpha")
+      .addMember(MemberType::Float, "Beta")
+      .addMember(MemberType::Float, "K")
       .setType("Input->getType()");
 
   //===--------------------------------------------------------------------===//
@@ -128,25 +128,20 @@ int main(int argc, char **argv) {
 
   BB.newNode("Reshape")
       .addOperand("Input")
-      .addMember("std::vector<size_t>", "Dims")
+      .addMember(MemberType::VectorSizeT, "Dims")
       .addExtraParam("TypeRef", "outTy")
-      .setType("outTy")
-      .overrideGetter(
-          "Dims", "llvm::ArrayRef<size_t> getDims() const { return Dims_; }");
+      .setType("outTy");
 
   BB.newNode("Transpose")
       .addOperand("Input")
-      .addMember("std::vector<unsigned>", "Shuffle")
+      .addMember(MemberType::VectorUnsigned, "Shuffle")
       .addExtraParam("TypeRef", "outTy")
-      .setType("outTy")
-      .overrideGetter(
-          "Shuffle",
-          "llvm::ArrayRef<unsigned> getShuffle() const { return Shuffle_; }");
+      .setType("outTy");
 
   BB.newNode("Concat")
       .addOperand("LHS")
       .addOperand("RHS")
-      .addMember("size_t", "Dim")
+      .addMember(MemberType::SizeT, "Dim")
       .addExtraParam("TypeRef", "outTy")
       .setType("outTy");
 


### PR DESCRIPTION
We used to have to override getter for vector class members.

```
  BB.newInstr("Reshape")
      .addOperand("Dest", OperandKind::Out)
      .addOperand("Src", OperandKind::In)
      .addMember("std::vector<size_t>", "Dims")
      .overrideGetter(
          "Dims", "llvm::ArrayRef<size_t> getDims() const { return Dims_;
      }")
      .addGradientInstr({}, {"Dest", "Src"});
```

With this, we can avoid the hassle and just do

```
  BB.newInstr("Reshape")
      .addOperand("Dest", OperandKind::Out)
      .addOperand("Src", OperandKind::In)
      .addMember(MemberType::VectorSizeT, "Dims")
      .addGradientInstr({}, {"Dest", "Src"});
```

Task: T23223681

Test Plan: diff the auto generated files with those ones that are
generated from master