### PR TITLE
Add Slice Node

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -91,6 +91,10 @@ public:
   ConcatNode *createConcat(llvm::StringRef name, llvm::ArrayRef<Node *> inputs,
                            unsigned dimension);
 
+  SliceNode *createSlice(llvm::StringRef name, Node *input,
+                         llvm::ArrayRef<size_t> begin,
+                         llvm::ArrayRef<size_t> end);
+
   BatchNormalizationNode *createBatchNormalization(llvm::StringRef name,
                                                    Node *input,
                                                    size_t channelIdx = 0,

--- a/src/glow/Graph/Graph.cpp
+++ b/src/glow/Graph/Graph.cpp
@@ -211,6 +211,33 @@ ConcatNode *Graph::createConcat(llvm::StringRef name,
   return addNode(new ConcatNode(name, NT, ops, dimension));
 }
 
+SliceNode *Graph::createSlice(llvm::StringRef name, Node *input,
+                              llvm::ArrayRef<size_t> begin,
+                              llvm::ArrayRef<size_t> end) {
+
+  std::vector<size_t> begin_v, shape;
+  auto dims = input->dims();
+  assert(begin.size() == end.size() &&
+         "Begin and End dimensions should match");
+  assert(begin.size() == dims.size() &&
+         "Begin and Input dimensions should match");
+  for (int i = 0; i < dims.size(); i++) {
+    size_t begin_i = begin[i];
+    size_t end_i = end[i];
+    size_t dim_i = dims[i];
+    assert(begin_i >= 0 && "Illegal Begin  indices");
+    assert(end_i > 0 && "Illegal End indices");
+    assert(begin_i < dim_i && "Illegal Begin  indices");
+    assert(end_i <= dim_i && "Illegal End indices");
+    assert(end_i > begin_i && "Illegal Begin and End indices");
+    begin_v.push_back(begin_i);
+    shape.push_back(end_i - begin_i);
+  }
+  auto NT = uniqueType(input->getType()->getElementType(), shape);
+
+  return addNode(new SliceNode(name, NT, input, begin_v));
+}
+
 BatchNormalizationNode *Graph::createBatchNormalization(llvm::StringRef name,
                                                         Node *input,
                                                         size_t channelIdx,

--- a/src/glow/IR/IRGen.cpp
+++ b/src/glow/IR/IRGen.cpp
@@ -180,6 +180,16 @@ public:
       registerIR(N, dest);
       break;
     }
+    case glow::Kinded::Kind::SliceNodeKind: {
+      auto *SL = cast<SliceNode>(N);
+      auto start = SL->getStart();
+      auto *in = valueForNode(SL->getInput());
+      auto *dest = builder_.createAllocActivationInst(
+          SL->getName(), SL->getElementType(), SL->dims());
+      builder_.createExtractTensorInst(SL->getName(), dest, in, start);
+      registerIR(N, dest);
+      break;
+    }
     case glow::Kinded::Kind::BatchNormalizationNodeKind: {
       auto *BN = cast<BatchNormalizationNode>(N);
       auto *in = valueForNode(BN->getInput());

--- a/tests/unittests/InterpreterTest.cpp
+++ b/tests/unittests/InterpreterTest.cpp
@@ -402,3 +402,56 @@ TEST(Network, concatVectors) {
     EXPECT_NEAR(RNWH.at({0, i}), i, 0.001);
   }
 }
+
+TEST(Network, sliceVectors) {
+  ExecutionEngine EE;
+
+  auto &G = EE.getGraph();
+
+  auto *V = G.createVariable(ElemKind::IndexTy, {3, 30}, "V");
+
+  Node *S1 = G.createSlice("slice1", V, {0, 10}, {3, 13});
+  Node *S2 = G.createSlice("slice2", V, {1, 10}, {2, 30});
+  Node *S3 = G.createSlice("slice3", V, {2, 10}, {3, 12});
+
+  auto *result1 = G.createSave("ret1", S1);
+  auto *result2 = G.createSave("ret2", S2);
+  auto *result3 = G.createSave("ret3", S3);
+
+  Tensor I(ElemKind::IndexTy, {3, 30});
+
+  for (size_t j = 0; j < 30; j++) {
+    I.getHandle<size_t>().at({0, j}) = j;
+    I.getHandle<size_t>().at({1, j}) = j + 30;
+    I.getHandle<size_t>().at({2, j}) = j + 60;
+  }
+
+  EE.compile(CompilationMode::Infer);
+
+  // Testing the output slices.
+  EE.infer({V}, {&I});
+  auto RNWH1 = result1->getOutput()->getPayload().getHandle<size_t>();
+  (void)RNWH1;
+  auto RNWH2 = result2->getOutput()->getPayload().getHandle<size_t>();
+  (void)RNWH2;
+  auto RNWH3 = result3->getOutput()->getPayload().getHandle<size_t>();
+  (void)RNWH3;
+
+  EXPECT_EQ(3, RNWH1.dims()[0]);
+  EXPECT_EQ(3, RNWH1.dims()[1]);
+  for (size_t i = 0; i < 3; i++) {
+    for (size_t j = 10; j < 13; j++) {
+      EXPECT_NEAR(RNWH1.at({i, j - 10}), j + i * 30, 0.001);
+    }
+  }
+  EXPECT_EQ(1, RNWH2.dims()[0]);
+  EXPECT_EQ(20, RNWH2.dims()[1]);
+  for (size_t j = 10; j < 30; j++) {
+    EXPECT_NEAR(RNWH2.at({0, j - 10}), j + 30, 0.001);
+  }
+  EXPECT_EQ(1, RNWH3.dims()[0]);
+  EXPECT_EQ(2, RNWH3.dims()[1]);
+  for (size_t j = 10; j < 12; j++) {
+    EXPECT_NEAR(RNWH3.at({0, j - 10}), j + 60, 0.001);
+  }
+}

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -147,5 +147,11 @@ int main(int argc, char **argv) {
                     "parameter 'dim' specifies the dimension to use when "
                     "joining the tensors.");
 
+  BB.newNode("Slice")
+      .addOperand("Input")
+      .addMember(MemberType::VectorSizeT, "Start")
+      .addExtraParam("TypeRef", "outTy")
+      .setType("outTy");
+
   return 0;
 }


### PR DESCRIPTION
I have followed the same semantics used on Caffe as far as I can tell https://caffe2.ai/docs/operators-catalogue#slice

In particular:

```
Slices are passed as 2 1D vectors with starting and end indices for
each dimension of the input data tensor. End indices are non-inclusive.
If a negative value is passed for any of the start or end indices, it
represent number of elements before the end of that dimension.
```