### PR TITLE
All Instruction's APIs should use Module * for the parent module instead of using a reference

### DIFF
--- a/include/glow/IR/IR.h
+++ b/include/glow/IR/IR.h
@@ -93,12 +93,12 @@ protected:
   void pushOperand(Operand op);
 
 public:
-  Instruction(Module &M, llvm::StringRef name, Kinded::Kind k, TypeRef Ty)
-      : Value(name, Ty, k), M(&M) {}
+  Instruction(Module *M, llvm::StringRef name, Kinded::Kind k, TypeRef Ty)
+      : Value(name, Ty, k), M(M) {}
 
-  Instruction(Module &M, llvm::StringRef name, Kinded::Kind k, TypeRef Ty,
+  Instruction(Module *M, llvm::StringRef name, Kinded::Kind k, TypeRef Ty,
               llvm::ArrayRef<Operand> ops)
-      : Value(name, Ty, k), M(&M) {
+      : Value(name, Ty, k), M(M) {
     for (auto &op : ops) {
       pushOperand(op);
     }
@@ -140,13 +140,12 @@ public:
                           unsigned srcIdx);
 
   /// \returns parent of current instruction.
-  Module &getParent() const {
-    assert(M);
-    return *M;
+  Module *getParent() const {
+    return M;
   }
 
   /// Sets a parent for the current instruction.
-  void setParent(Module &Mod) { M = &Mod; }
+  void setParent(Module *Mod) { M = Mod; }
 
   /// Erases instruction from its parent and destroy it.
   void eraseFromParent();

--- a/src/glow/IR/IR.cpp
+++ b/src/glow/IR/IR.cpp
@@ -51,7 +51,7 @@ Instruction::Operand Instruction::getOperand(unsigned idx) const {
   return ops_[idx];
 }
 
-void Instruction::eraseFromParent() { getParent().eraseInstruction(this); }
+void Instruction::eraseFromParent() { getParent()->eraseInstruction(this); }
 
 void Instruction::verifyUseList() const {
   for (const auto &op : ops_) {
@@ -59,7 +59,7 @@ void Instruction::verifyUseList() const {
     (void)v;
     assert(v && "Instruction operand must be a real value");
     assert(v->hasUser(this) && "Invalid use-list");
-    v->verifyUseList(getParent());
+    v->verifyUseList(*getParent());
   }
 }
 
@@ -124,13 +124,13 @@ void Module::removeInstruction(glow::Instruction *I) {
 
 void Module::insertInstruction(glow::Instruction *I) {
   instrs_.push_back(I);
-  I->setParent(*this);
+  I->setParent(this);
 }
 
 void Module::insertInstruction(InstListTy::iterator where,
                                glow::Instruction *I) {
   instrs_.insert(where, I);
-  I->setParent(*this);
+  I->setParent(this);
 }
 
 Module::~Module() { clear(); }

--- a/src/glow/IR/IRGen.cpp
+++ b/src/glow/IR/IRGen.cpp
@@ -535,17 +535,17 @@ void generateBackwardPass(Module &M) {
     switch (I->getKind()) {
     case Kind::AllocActivationInstKind: {
       auto *AC = cast<AllocActivationInst>(I);
-      auto *N = new AllocActivationInst(M, AC->getName(), AC->getType());
+      auto *N = new AllocActivationInst(&M, AC->getName(), AC->getType());
       allocs.push_back(N);
       weightToGradMap[I] = N;
 
-      auto *D = new DeallocActivationInst(M, AC->getName(), N);
+      auto *D = new DeallocActivationInst(&M, AC->getName(), N);
       deallocs.push_back(D);
       break;
     }
     case Kind::CopyInstKind: {
       auto *CC = cast<CopyInst>(I);
-      auto *N = new CopyInst(M, CC->getName(), weightToGradMap[CC->getSrc()],
+      auto *N = new CopyInst(&M, CC->getName(), weightToGradMap[CC->getSrc()],
                              weightToGradMap[CC->getDest()]);
       toAppend.push_back(N);
       break;
@@ -610,7 +610,7 @@ void generateBackwardPass(Module &M) {
       Value *src = weightToGradMap[RI->getSrc()];
       // Swap the src and dest.
       toAppend.push_back(
-          new ReshapeInst(M, I->getName(), src, dest, src->dims()));
+          new ReshapeInst(&M, I->getName(), src, dest, src->dims()));
       break;
     }
     case Kind::TransposeInstKind: {
@@ -627,12 +627,12 @@ void generateBackwardPass(Module &M) {
 
       // Swap the src and dest.
       toAppend.push_back(
-          new TransposeInst(M, I->getName(), src, dest, reverseShuffle));
+          new TransposeInst(&M, I->getName(), src, dest, reverseShuffle));
       break;
     }
     case Kind::ZeroInstKind: {
       Value *src = weightToGradMap[I->getOperand(0).first];
-      toAppend.push_back(new ZeroInst(M, I->getName(), src));
+      toAppend.push_back(new ZeroInst(&M, I->getName(), src));
       break;
     }
     case Kind::InsertTensorInstKind: {
@@ -641,7 +641,7 @@ void generateBackwardPass(Module &M) {
       Value *src = weightToGradMap[ITI->getSrc()];
       // Swap the src and dest.
       toAppend.push_back(
-          new ExtractTensorInst(M, I->getName(), src, dest, ITI->getOffsets()));
+          new ExtractTensorInst(&M, I->getName(), src, dest, ITI->getOffsets()));
       break;
     }
     case Kind::ExtractTensorInstKind: {
@@ -651,7 +651,7 @@ void generateBackwardPass(Module &M) {
 
       // Swap the src and dest.
       toAppend.push_back(
-          new InsertTensorInst(M, I->getName(), src, dest, ETI->getOffsets()));
+          new InsertTensorInst(&M, I->getName(), src, dest, ETI->getOffsets()));
       break;
     }
     default:

--- a/src/glow/Optimizer/IROptimizer.cpp
+++ b/src/glow/Optimizer/IROptimizer.cpp
@@ -419,12 +419,12 @@ void rematerializeCompute(Module &M) {
       }
 
       // Recompute the relu locally.
-      auto *A = new AllocActivationInst(M, O.first->getName().str() + ".re",
+      auto *A = new AllocActivationInst(&M, O.first->getName().str() + ".re",
                                         O.first->getType());
       M.insertInstruction(it, A);
-      auto *R = new ReluInst(M, "re.Relu", A, prevRelu->getSrc());
+      auto *R = new ReluInst(&M, "re.Relu", A, prevRelu->getSrc());
       M.insertInstruction(it, R);
-      auto *D = new DeallocActivationInst(M, "re", A);
+      auto *D = new DeallocActivationInst(&M, "re", A);
       M.insertInstruction(D);
 
       I->setOperand(op, A);

--- a/tools/ClassGen/InstrBuilder.cpp
+++ b/tools/ClassGen/InstrBuilder.cpp
@@ -14,7 +14,7 @@ unsigned InstrBuilder::getOperandIndexByName(llvm::StringRef name) const {
 }
 
 void InstrBuilder::emitCtor(std::ostream &os) const {
-  os << "\t" << name_ << "Inst(Module &M, llvm::StringRef name";
+  os << "\t" << name_ << "Inst(Module *M, llvm::StringRef name";
 
   // The operands of the instruction class:
   for (const auto &op : operands_) {
@@ -62,7 +62,7 @@ void InstrBuilder::emitIRBuilderMethods(std::ostream &os) const {
 
   // Initialize the base clases:
   os << ") {\n";
-  os << "auto *A = new " << name_ << "Inst(getModule(), name ";
+  os << "auto *A = new " << name_ << "Inst(&getModule(), name ";
 
   // The operands of the instruction class:
   for (const auto &op : operands_) {


### PR DESCRIPTION
This follows the LLVM's approach.