### PR TITLE
Use llvm::raw_ostream instead of std::ostream everywhere

### DIFF
--- a/include/glow/IR/IR.h
+++ b/include/glow/IR/IR.h
@@ -133,7 +133,7 @@ public:
   void verify() const;
 
   /// Print instruction.
-  void dump(std::ostream &out);
+  void dump(llvm::raw_ostream &out);
 
   /// The static dispatch version of isInplaceOp.
   static bool isInplaceOp(const Instruction *I, unsigned dstIdx,
@@ -154,7 +154,7 @@ public:
 
 protected:
   /// Dump the operands of the instruction into the stream \p os.
-  void dumpOperands(std::ostream &os) const;
+  void dumpOperands(llvm::raw_ostream &os) const;
 };
 
 class WeightVar;

--- a/include/glow/IR/Instrs.h
+++ b/include/glow/IR/Instrs.h
@@ -37,7 +37,7 @@ public:
 
   void setMutability(MutabilityKind mut) { mut_ = mut; }
 
-  void dump(std::ostream &os) const;
+  void dump(llvm::raw_ostream &os) const;
   void verify() const {}
 };
 

--- a/src/glow/IR/IR.cpp
+++ b/src/glow/IR/IR.cpp
@@ -224,7 +224,7 @@ InstrIterator InstructionNumbering::getInstr(size_t InstrNumber) {
 //                    IR printing and visualizing
 //===----------------------------------------------------------------------===//
 
-static void dumpIR(Value *V, std::ostream &out) {
+static void dumpIR(Value *V, llvm::raw_ostream &out) {
 #define DEF_INSTR(CLASS, NAME)                                                 \
   if (const auto *X = dyn_cast<const CLASS>(V))                                \
     return X->dump(out);
@@ -235,7 +235,8 @@ static void dumpIR(Value *V, std::ostream &out) {
   glow_unreachable();
 }
 
-static void dumpUsers(Value *V, std::ostream &out, InstructionNumbering &IN) {
+static void dumpUsers(Value *V, llvm::raw_ostream &out,
+                      InstructionNumbering &IN) {
   if (V->getNumUsers() == 0)
     return;
   out << " // Users: ";
@@ -252,7 +253,7 @@ static void dumpUsers(Value *V, std::ostream &out, InstructionNumbering &IN) {
   }
 }
 
-void Instruction::dump(std::ostream &out) { dumpIR(this, out); }
+void Instruction::dump(llvm::raw_ostream &out) { dumpIR(this, out); }
 
 bool Instruction::isInplaceOp(const Instruction *I, unsigned dstIdx,
                               unsigned srcIdx) {
@@ -265,7 +266,7 @@ bool Instruction::isInplaceOp(const Instruction *I, unsigned dstIdx,
   glow_unreachable();
 }
 
-void Instruction::dumpOperands(std::ostream &os) const {
+void Instruction::dumpOperands(llvm::raw_ostream &os) const {
   for (size_t i = 0, e = getNumOperands(); i < e; i++) {
     auto op = getOperand(i);
     auto CC = getOperandKindStr(op.second);
@@ -314,7 +315,8 @@ void Module::dump() {
   nameInstructions();
   InstructionNumbering InstrNumbering(*this);
   // Print all of the variables:
-  std::stringstream sb;
+  std::string s;
+  llvm::raw_string_ostream sb{s};
   sb << "module " << G_->getName().str() << "\n";
 
   size_t sizeInBytes = 0;

--- a/src/glow/IR/Instrs.cpp
+++ b/src/glow/IR/Instrs.cpp
@@ -25,8 +25,8 @@ const char *WeightVar::getMutabilityStr() const {
   return getMutabilityStr(mut_);
 }
 
-void WeightVar::dump(std::ostream &os) const {
-  os << '%' << (std::string)getName() << " = WeightVar ";
+void WeightVar::dump(llvm::raw_ostream &os) const {
+  os << "%" << (std::string)getName() << " = WeightVar ";
   os << std::to_string(*getType()) << " " << getMutabilityStr();
 }
 

--- a/src/glow/Optimizer/IROptimizer.cpp
+++ b/src/glow/Optimizer/IROptimizer.cpp
@@ -647,9 +647,9 @@ void copyPropagation(Module &M) {
     auto *Dest = ci->getDest();
     assert(Src->getType() == Dest->getType() &&
            "Both src and dest of copy should have the same type");
-    DEBUG(llvm::outs() << "Instruction " << instIdx << ": Found a copy from "
+    DEBUG(llvm::dbgs() << "Instruction " << instIdx << ": Found a copy from "
                        << Src->getName() << " to " << Dest->getName() << ":\n";
-          ci->dump(std::cout); std::cout << "\n");
+          ci->dump(llvm::dbgs()); llvm::dbgs() << "\n");
 
     // We plan to replace the assignments to Src by assignments
     // to Dest and replace all uses of Src to use Dest to get rid of the copy.
@@ -776,8 +776,8 @@ void copyPropagation(Module &M) {
     /// live intervals map?
     assert(!ChangedInstrs.empty() &&
            "Some instructions should have been changed");
-    DEBUG(llvm::outs() << "Can replace this copy by producing instruction:\n";
-          ChangedInstrs[0]->dump(std::cout); std::cout << "\n");
+    DEBUG(llvm::dbgs() << "Can replace this copy by producing instruction:\n";
+          ChangedInstrs[0]->dump(llvm::dbgs()); llvm::dbgs() << "\n");
     assert(ci->getSrc() == ci->getDest() && "Src and Dest of a copy "
                                             "instruction should be the same "
                                             "after copy propagation");
@@ -844,14 +844,14 @@ static void eliminateDeadStores(Module &M) {
         // to remove it.
         continue;
       }
-      DEBUG(std::cout << "Found a dead store into " << ML->getName().str()
-                      << ": ";
-            (*I)->dump(std::cout); std::cout << "\n";
-            std::cout << "Operand being updated is: "
-                      << Operands[0].first->getName().str() << "\n";
-            std::cout << "Interval is: "
-                      << "(" << IntervalBegin << ", " << IntervalEnd << ")"
-                      << "\n");
+      DEBUG(llvm::dbgs() << "Found a dead store into " << ML->getName().str()
+                         << ": ";
+            (*I)->dump(llvm::dbgs()); llvm::dbgs() << "\n";
+            llvm::dbgs() << "Operand being updated is: "
+                         << Operands[0].first->getName().str() << "\n";
+            llvm::dbgs() << "Interval is: "
+                         << "(" << IntervalBegin << ", " << IntervalEnd << ")"
+                         << "\n");
       assert(Operands[0].first == ML);
       // Only the current memory location is being updated by this instruction.
       ErasedInstructions.insert(IntervalBegin);

--- a/tests/unittests/InterpreterTest.cpp
+++ b/tests/unittests/InterpreterTest.cpp
@@ -8,6 +8,8 @@
 
 #include "gtest/gtest.h"
 
+#include "llvm/Support/raw_ostream.h"
+
 #include <cassert>
 #include <string>
 
@@ -201,8 +203,8 @@ TEST(Interpreter, learnXor) {
   for (size_t i = 0; i < numTests; i++) {
     int a = TS.at({i, 0});
     int b = TS.at({i, 1});
-    std::cout << "a = " << a << " b = " << b << " => " << resH.at({i, 0})
-              << "\n";
+    llvm::outs() << "a = " << a << " b = " << b << " => " << resH.at({i, 0})
+                 << "\n";
     EXPECT_NEAR(resH.at({i, 0}), (a ^ b), 0.1);
   }
 }
@@ -292,11 +294,11 @@ TEST(Network, circle) {
         ch = '-';
       }
 
-      std::cout << ch;
+      llvm::outs() << ch;
     }
-    std::cout << "\n";
+    llvm::outs() << "\n";
   }
-  std::cout << "\n";
+  llvm::outs() << "\n";
 
   {
     // The dot in the middle must be zero.

--- a/tools/ClassGen/InstrBuilder.cpp
+++ b/tools/ClassGen/InstrBuilder.cpp
@@ -133,8 +133,9 @@ void InstrBuilder::emitSettersGetters(std::ostream &os) const {
 }
 
 void InstrBuilder::emitPrettyPrinter(std::ostream &os) const {
-  os << "void " << name_ << "Inst::dump(std::ostream &os) const {\n";
-  os << "\tos << '%' << (std::string) getName() << \" = \" << getKindName() << "
+  os << "void " << name_ << "Inst::dump(llvm::raw_ostream &os) const {\n";
+  os << "\tos << \"%\" << (std::string) getName() "
+        "<< \" = \" << getKindName() << "
         "\" \";\n";
   os << "\tdumpOperands(os);\n";
 
@@ -147,7 +148,7 @@ void InstrBuilder::emitPrettyPrinter(std::ostream &os) const {
          << "get" << mem.second << "());\n";
       first = false;
     }
-    os << "\tos << '}';\n";
+    os << "\tos << \"}\";\n";
   }
   os << "\n}\n";
 }
@@ -170,7 +171,7 @@ void InstrBuilder::emitClass(std::ostream &os) const {
     os << "\t" << m << "\n";
   }
 
-  os << "\t void dump(std::ostream &os) const;\n";
+  os << "\t void dump(llvm::raw_ostream &os) const;\n";
   os << "\t void verify() const;\n";
   os << "};\n\n} // namespace glow\n";
 }


### PR DESCRIPTION
This introduces consistency when it comes to the output of a program and follows the LLVM approach.
It will also make it easier in the future to control program output by means of the command-line options.