### PR TITLE
loader.cpp: improve command line argument parsing

### DIFF
--- a/tests/images/run.sh
+++ b/tests/images/run.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 for png_filename in tests/images/*.png; do
-  ./bin/loader $png_filename 0to1 resnet50/predict_net.pb resnet50/init_net.pb
-  ./bin/loader $png_filename 128to127 vgg19/predict_net.pb vgg19/init_net.pb
-  ./bin/loader $png_filename 128to127 squeezenet/predict_net.pb squeezenet/init_net.pb
-  ./bin/loader $png_filename 0to256 vgg16/predict_net.pb vgg16/init_net.pb
+  ./bin/loader $png_filename -image_mode=0to1 -n=resnet50/predict_net.pb -w=resnet50/init_net.pb
+  ./bin/loader $png_filename -image_mode=128to127 -n=vgg19/predict_net.pb -w=vgg19/init_net.pb
+  ./bin/loader $png_filename -image_mode=128to127 -n=squeezenet/predict_net.pb -w=squeezenet/init_net.pb
+  ./bin/loader $png_filename -image_mode=0to256 -n=vgg16/predict_net.pb -w=vgg16/init_net.pb
 done
 


### PR DESCRIPTION
This change adds the llvm CommandLine library and changes the API for
loader.

The loader program now accepts a list of images to process, as well as
specifying the image_mode and caffe2 model paths with command line
flags.

Here are a few example command line invocations:

./loader -image_mode=0to1 -d=resnet50 tests/images/zebra_340.png
./loader -image_mode=0to1 -n=resnet50/predict_net.pb -w=resnet50/init_net.pb tests/images/zebra_340.png

More information can be found by running
./loader -help