### PR TITLE
Fix release build compiler warnings

### DIFF
--- a/include/glow/Support/Compiler.h
+++ b/include/glow/Support/Compiler.h
@@ -18,6 +18,4 @@
 #define GLOW_ASSERT_IMPL(e, file, line)                                        \
   ((void)printf("%s:%u: failed assertion `%s'\n", file, line, e), abort())
 
-#define UNREFERENCED_VAR(X) ((void)(X))
-
 #endif // GLOW_SUPPORT_COMPILER_H

--- a/src/glow/Base/Image.cpp
+++ b/src/glow/Base/Image.cpp
@@ -49,7 +49,7 @@ bool glow::readPngImage(Tensor *T, const char *filename,
   size_t height = png_get_image_height(png_ptr, info_ptr);
   int color_type = png_get_color_type(png_ptr, info_ptr);
   int bit_depth = png_get_bit_depth(png_ptr, info_ptr);
-  UNREFERENCED_VAR(bit_depth);
+  (void)bit_depth;
   assert(bit_depth == 8 && "Invalid image");
   assert((color_type == PNG_COLOR_TYPE_RGB_ALPHA ||
           color_type == PNG_COLOR_TYPE_RGB) &&
@@ -57,7 +57,7 @@ bool glow::readPngImage(Tensor *T, const char *filename,
   bool hasAlpha = (color_type == PNG_COLOR_TYPE_RGB_ALPHA);
 
   int number_of_passes = png_set_interlace_handling(png_ptr);
-  UNREFERENCED_VAR(number_of_passes);
+  (void)number_of_passes;
   assert(number_of_passes == 1 && "Invalid image");
 
   png_read_update_info(png_ptr, info_ptr);


### PR DESCRIPTION
Was running release build, there are some compiler warnings, which should be fixed by this PR.

```
/Users/rdzhabarov/src/glow/src/glow/Base/Image.cpp:194:1: warning: control reaches end of non-void function [-Wreturn-type]
}
^
/Users/rdzhabarov/src/glow/src/glow/Base/Image.cpp:199:1: warning: control reaches end of non-void function [-Wreturn-type]
}
```