### PR TITLE
Implement a new tensorview instruction

### DIFF
--- a/include/glow/IR/IRBuilder.h
+++ b/include/glow/IR/IRBuilder.h
@@ -59,6 +59,10 @@ public:
 
   ReshapeInst *createReshapeOp(Value *input, llvm::ArrayRef<size_t> shape);
 
+  TensorViewInst *createTensorView(ElemKind elemKind,
+                                   llvm::ArrayRef<size_t> dims, Value *src,
+                                   llvm::StringRef name);
+
   TransposeInst *createTransposeOp(Value *input,
                                    llvm::ArrayRef<unsigned> shuffle);
 

--- a/src/glow/Backends/Interpreter/Interpreter.h
+++ b/src/glow/Backends/Interpreter/Interpreter.h
@@ -61,6 +61,11 @@ private:
   /// \returns a tensor for \p v.
   Tensor *getOrCreateTensor(const Value *v);
 
+  /// Allocate an unowned tensor to back the value \p v. The source tensor of
+  /// the unowned tensor is provided by \p src.
+  /// \returns a tensor for \p v.
+  Tensor *getOrCreateUnownedTensor(const Value *v, const Value *src);
+
   /// If a tensor is allocated for \p v then delete it.
   void deleteTensor(const Value *v);
 

--- a/src/glow/IR/IR.cpp
+++ b/src/glow/IR/IR.cpp
@@ -394,7 +394,8 @@ static void nameInstr(std::unordered_set<std::string> &usedNames, Named *named,
 Module::Module(Graph *G) : G_(G), name_(G->getName()) {}
 
 static bool hasResultValue(Instruction *I) {
-  return I->getKind() == Instruction::Kind::AllocActivationInstKind;
+  return I->getKind() == Instruction::Kind::AllocActivationInstKind ||
+         I->getKind() == Instruction::Kind::TensorViewInstKind;
 }
 
 void Module::nameInstructions() {

--- a/src/glow/IR/Instrs.cpp
+++ b/src/glow/IR/Instrs.cpp
@@ -134,6 +134,11 @@ void FullyConnectedInst::verify() const {
   llvm::ArrayRef<size_t> expB = {Depth_};
   assert(B->dims() == expB && "Invalid output shape");
   (void)expB;
+
+  assert(src->dims().size() == 2 &&
+         "Src of a FullyConnectedInst should be 2-dimensional");
+  assert(dest->dims().size() == 2 &&
+         "Dest of a FullyConnectedInst should be 2-dimensional");
 }
 
 void BatchedMatMulInst::verify() const {
@@ -176,6 +181,13 @@ void ReshapeInst::verify() const {
   assert(getOperand(0).first->getType()->size() ==
              getOperand(1).first->getType()->size() &&
          "Reshape into a different size");
+}
+
+void TensorViewInst::verify() const {
+  assert(getOperand(0).first->getType()->size() == getType()->size() &&
+         "TensorView view size should be the same as Src size");
+  assert(getOperand(0).first->getElementType() == getType()->getElementType() &&
+         "TensorView view element type should be the same as Src size");
 }
 
 void TransposeInst::verify() const {

--- a/tests/unittests/basicIRTest.cpp
+++ b/tests/unittests/basicIRTest.cpp
@@ -85,7 +85,6 @@ TEST(IR, allInstrs) {
 
     auto *I3 = builder.createWeightVar(ElemKind::FloatTy, {1, 12, 12, 64});
     auto *I4 = builder.createWeightVar(ElemKind::FloatTy, {1, 12, 12, 3});
-    auto *I5 = builder.createWeightVar(ElemKind::FloatTy, {1, 32});
     auto *I6 = builder.createWeightVar(ElemKind::FloatTy, {2, 12, 12, 64});
     auto *I7 = builder.createWeightVar(T1, "I7");
     auto *I8 = builder.createWeightVar(ElemKind::FloatTy, {1, 24, 3, 24}, "I8");
@@ -109,12 +108,13 @@ TEST(IR, allInstrs) {
     builder.createCopyInst("", I1, I0);
     builder.createConvolutionInst("", I3, I1, F0, B0, 7, 2, 3, 64);
     builder.createPoolMaxInst("", I4, I0, XY, 7, 2, 3);
-    builder.createFullyConnectedInst("", I5, I0, F1, B1, 32);
+    builder.createFullyConnectedOp(I0, F1, B1, 32);
     builder.createReluInst("", I1, I0);
     builder.createSigmoidInst("", I1, I0);
     builder.createTanhInst("", I1, I0);
     builder.createSoftMaxInst("", I1, I0, I7, E0);
     builder.createTransposeInst("", I8, I2, {0, 3, 1, 2});
+    builder.createTensorView(ElemKind::FloatTy, {1, 24, 3, 24}, I2, "I2_view");
     builder.createInsertTensorInst("", I6, I3, {0, 0, 0, 0});
     builder.createBatchNormalizationInst("", I1, I0, S0, S0, S0, S0, 3, 0.01,
                                          0.9);

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -31,6 +31,11 @@ int main(int argc, char **argv) {
       .addMember(MemberType::TypeRef, "Ty")
       .setType("Ty");
 
+  BB.newInstr("TensorView")
+      .addOperand("Src", OperandKind::In)
+      .addMember(MemberType::TypeRef, "Ty")
+      .setType("Ty");
+
   BB.newInstr("DeallocActivation")
       .addOperand("Src", OperandKind::Out)
       .addExtraMethod("AllocActivationInst *getAlloc() const { return "


### PR DESCRIPTION
This instruction is used to create an unowned tensor with a required dimensionality from an existing tensor. The result is just a view of an existing tensor and does not allocate any new memory. Tensorview is essentially a typecast applied to a tensor.