### PR TITLE
loader.cpp: now batch process images

### DIFF
--- a/tests/images/run.sh
+++ b/tests/images/run.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 
-for png_filename in tests/images/*.png; do
-  ./bin/loader $png_filename -image_mode=0to1 -d=resnet50
-  ./bin/loader $png_filename -image_mode=128to127 -d=vgg19
-  ./bin/loader $png_filename -image_mode=128to127 -d=squeezenet
-  ./bin/loader $png_filename -image_mode=0to256 -d=vgg16
-done
+./bin/loader tests/images/*.png -image_mode=0to1 -d=resnet50
+./bin/loader tests/images/*.png -image_mode=128to127 -d=vgg19
+./bin/loader tests/images/*.png -image_mode=128to127 -d=squeezenet
+./bin/loader tests/images/*.png -image_mode=0to256 -d=vgg16
 


### PR DESCRIPTION
This change batch classifies multiple images instead of iterating
through all the files passed on the command line.

This code still requires that all the images have the same dimensions.

The dimensions of the Tensor we pass through to the caffe2ModelLoader:

N x C x H x W
Number of images x Color of Pixel (3 floats) x Height of image x Width
of Image