### PR TITLE
GraphOptimizer.cpp: add sink optimizations for sigmoid and tanh

### DIFF
--- a/src/glow/Optimizer/GraphOptimizer.cpp
+++ b/src/glow/Optimizer/GraphOptimizer.cpp
@@ -134,7 +134,6 @@ static void sinkCode(Graph &G) {
     }
 
     // Sink Transpose below batch RELU nodes.
-    // TODO: support other similar activation functions, such as sigmoid, etc.
     if (auto *RL = dyn_cast<ReluNode>(node)) {
       auto *TR = dyn_cast<TransposeNode>(RL->getInput());
 
@@ -145,6 +144,34 @@ static void sinkCode(Graph &G) {
       auto *NRL = G.createRELU(RL->getName(), TR->getInput());
       auto *newTR = G.createTranspose(TR->getName(), NRL, TR->getShuffle());
       RL->getResult().replaceAllUsesOfWith(newTR);
+      continue;
+    }
+
+    // Sink Transpose below Sigmoid nodes.
+    if (auto *SI = dyn_cast<SigmoidNode>(node)) {
+      auto *TR = dyn_cast<TransposeNode>(SI->getInput());
+
+      if (!TR) {
+        continue;
+      }
+
+      auto *NSI = G.createSigmoid(SI->getName(), TR->getInput());
+      auto *newTR = G.createTranspose(TR->getName(), NSI, TR->getShuffle());
+      SI->getResult().replaceAllUsesOfWith(newTR);
+      continue;
+    }
+
+    // Sink Transpose below Tanh nodes.
+    if (auto *TN = dyn_cast<TanhNode>(node)) {
+      auto *TR = dyn_cast<TransposeNode>(TN->getInput());
+
+      if (!TR) {
+        continue;
+      }
+
+      auto *NTN = G.createTanh(TN->getName(), TR->getInput());
+      auto *newTR = G.createTranspose(TR->getName(), NTN, TR->getShuffle());
+      TN->getResult().replaceAllUsesOfWith(newTR);
       continue;
     }
 


### PR DESCRIPTION
Sigmoid and Tanh are types of activation functions commonly used in
Machine Learning.  In this commit, we want to to optimize our graph that
we generate to sink the Sigmoid and Tanh nodes below the Transpose nodes.

This is similar to an already existing sink optimization that we have with
Transpose and RELU nodes.

Also included are some tests for these two optimizations.

Ori Shalev originally wrote many of the tests for our optimizations and
I want to point out a very useful debugging technique he mentioned
for debugging our optimizations is to add G.dumpDAG("before.dot") and
G.dumpDAG("after.dot") around the call to ::glow:optimize(...)

You can then convert these .dot files to png's and see the optimization.