### PR TITLE
Fix the semantics of the BatchedMatMul

### DIFF
--- a/src/glow/Backends/Interpreter/InterpreterNodes.cpp
+++ b/src/glow/Backends/Interpreter/InterpreterNodes.cpp
@@ -1104,8 +1104,8 @@ void Interpreter::fwdBatchedMatMulInst(bool isTrain,
 
         // Perform DOT on the row an column.
         float sum = 0;
-        for (size_t i = 0; i < filterDim[0]; i++) {
-          sum += batch.at({n, x, i}) * filter.at({i, y});
+        for (size_t i = 0; i < filterDim[1]; i++) {
+          sum += batch.at({n, i, x}) * filter.at({y, i});
         }
         dest.at({n, x, y}) = sum;
       }

--- a/src/glow/Graph/Graph.cpp
+++ b/src/glow/Graph/Graph.cpp
@@ -361,12 +361,12 @@ BatchedMatMulNode *Graph::createBatchedMatMul(llvm::StringRef name,
   size_t a2 = BT->dims()[2];
   size_t b1 = FT->dims()[0];
   size_t b2 = FT->dims()[1];
-  assert(a2 == b1 && "Column of A is not equal to the row of A.");
+  assert(a1 == b2 && "Column of A is not equal to the row of B.");
   (void)a1;
   (void)a2;
   (void)b1;
   (void)b2;
-  auto RT = Type(BT->getElementType(), {BT->dims()[0], a1, b2});
+  auto RT = Type(BT->getElementType(), {BT->dims()[0], a2, b1});
   return addNode(new BatchedMatMulNode(name, uniqueType(RT), batch, filter));
 }
 

--- a/src/glow/IR/Instrs.cpp
+++ b/src/glow/IR/Instrs.cpp
@@ -158,8 +158,8 @@ void BatchedMatMulInst::verify() const {
   size_t b2 = filter->dims()[1];
   size_t c1 = dest->dims()[1];
   size_t c2 = dest->dims()[2];
-  assert(a2 == b1 && "Column of A is not equal to the row of A.");
-  assert(c1 == a1 && c2 == b2 && "Invalid size of output matrix");
+  assert(a1 == b2 && "Column of A is not equal to the row of A.");
+  assert(c1 == a2 && c2 == b1 && "Invalid size of output matrix");
   (void)a1;
   (void)a2;
   (void)b1;

--- a/tests/unittests/InterpreterTest.cpp
+++ b/tests/unittests/InterpreterTest.cpp
@@ -580,3 +580,4 @@ TEST(Optimizer, copyPropagation) {
         return I->getKind() == Instruction::Kind::CopyInstKind;
       }));
 }
+

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -22,7 +22,7 @@ TEST(Operator, matmul) {
 
   auto *batch = G.createVariable(ElemKind::FloatTy, {1, 2, 3}, "batch");
   auto *filter = G.createVariable(ElemKind::FloatTy, {3, 2}, "filter");
-  auto *result = G.createVariable(ElemKind::FloatTy, {1, 2, 2}, "result");
+  auto *result = G.createVariable(ElemKind::FloatTy, {1, 3, 3}, "result");
   batch->getPayload().getHandle() = {1, 2, 3, 4, 5, 6};
   filter->getPayload().getHandle() = {7, 8, 9, 10, 11, 12};
 
@@ -35,10 +35,10 @@ TEST(Operator, matmul) {
   EE.run({}, {});
 
   auto H = result->getPayload().getHandle();
-  EXPECT_NEAR(H.at({0, 0, 0}), 58, 0.001);
-  EXPECT_NEAR(H.at({0, 0, 1}), 64, 0.001);
-  EXPECT_NEAR(H.at({0, 1, 0}), 139, 0.001);
-  EXPECT_NEAR(H.at({0, 1, 1}), 154, 0.001);
+  EXPECT_NEAR(H.at({0, 0, 0}), 39, 0.001);
+  EXPECT_NEAR(H.at({0, 0, 1}), 49, 0.001);
+  EXPECT_NEAR(H.at({0, 1, 0}), 54, 0.001);
+  EXPECT_NEAR(H.at({0, 1, 1}), 68, 0.001);
 }
 
 TEST(Operator, batchedReduceAdd) {


### PR DESCRIPTION
This commit fixes the semantics of the batched mat mul arithmetic. The semantics now matches Python, and Caffe2, and the rest of Glow. 

(A, B) = (B, C) x (D, E)  where A = C, B = E, and C == D.