### PR TITLE
Certain variables require zero size allocations

### DIFF
--- a/src/glow/Backends/MemoryAllocator.cpp
+++ b/src/glow/Backends/MemoryAllocator.cpp
@@ -10,7 +10,6 @@ using namespace glow;
 const size_t MemoryAllocator::npos = -1;
 
 size_t MemoryAllocator::allocate(size_t size) {
-  assert(size && "Allocating an empty buffer");
   size_t prev = 0;
   for (auto it = allocations_.begin(), e = allocations_.end(); it != e; it++) {
     if (it->begin_ - prev >= size) {


### PR DESCRIPTION
Found the following while running grad check tests for OpenCL backend:

```
******
Variable
name : "gsum__46"
output : <void>
init : broadcast
val : 0
users : 1

******
size - 0

******
Variable
name : "gsum__47"
output : <void>
init : broadcast
val : 0
users : 1

******
size - 0
```

Those variables do not require allocations for tensors. @nadavrot 

