### PR TITLE
Fix an issue in hoistDealloc

### DIFF
--- a/src/glow/Optimizer/IROptimizer.cpp
+++ b/src/glow/Optimizer/IROptimizer.cpp
@@ -44,6 +44,11 @@ static void hoistDealloc(Module &M) {
     if (isa<DeallocActivationInst>(*it))
       continue;
 
+    if (auto alloc = dyn_cast<AllocActivationInst>(*it)) {
+      lastUser[alloc] = it;
+      continue;
+    }
+
     for (int i = 0, e = (*it)->getNumOperands(); i < e; i++) {
       auto op = (*it)->getOperand(i).first;
       if (auto alloc = dyn_cast<AllocActivationInst>(op)) {


### PR DESCRIPTION
If an allocation was just allocated, but not used at all and then deallocated, then hoistDealloc would crash because it wouldn't know where to insert the hoisted dealloc.