### PR TITLE
Remove Base as a dependency of generated files

### DIFF
--- a/src/glow/Base/CMakeLists.txt
+++ b/src/glow/Base/CMakeLists.txt
@@ -1,8 +1,27 @@
 
+set(HDR ${GLOW_BINARY_DIR}/AutoGenInstr.h)
+set(SRC ${GLOW_BINARY_DIR}/AutoGenInstr.cpp)
+set(DEF ${GLOW_BINARY_DIR}/AutoGenInstr.def)
+set(BLD ${GLOW_BINARY_DIR}/AutoGenIRBuilder.h)
+
+add_custom_command(OUTPUT
+                    "${HDR}"
+                    "${SRC}"
+                    "${DEF}"
+                    "${BLD}"
+                   COMMAND InstrGen ${HDR} ${SRC} ${DEF} ${BLD}
+                   DEPENDS InstrGen
+                   COMMENT "InstrGen: Generating instrs." VERBATIM)
+
 add_library(Base
               Tensor.cpp
               Type.cpp
-              Image.cpp)
+              Image.cpp
+              ${HDR}
+              ${SRC}
+              ${DEF}
+              ${BLD})
+
 target_link_libraries(Base
                       PUBLIC
                        Support)
@@ -17,4 +36,3 @@ if(PNG_FOUND)
                         PRIVATE
                           ${PNG_LIBRARY})
 endif()
-

--- a/src/glow/IR/CMakeLists.txt
+++ b/src/glow/IR/CMakeLists.txt
@@ -1,29 +1,4 @@
 
-set(HDR ${GLOW_BINARY_DIR}/AutoGenInstr.h)
-set(SRC ${GLOW_BINARY_DIR}/AutoGenInstr.cpp)
-set(DEF ${GLOW_BINARY_DIR}/AutoGenInstr.def)
-set(BLD ${GLOW_BINARY_DIR}/AutoGenIRBuilder.h)
-
-add_custom_command(OUTPUT
-                    "${HDR}"
-                    "${SRC}"
-                    "${DEF}"
-                    "${BLD}"
-                   COMMAND InstrGen ${HDR} ${SRC} ${DEF} ${BLD}
-                   DEPENDS InstrGen
-                   COMMENT "InstrGen: Generating instrs." VERBATIM)
-
-# Add a library that's dedicated to the auto-generated IR to break the circular
-# dependency on the Graph library that uses the generated def file.
-add_library(AutoGenIR
-              ${HDR}
-              ${SRC}
-              ${DEF}
-              ${BLD})
-target_link_libraries(AutoGenIR
-                      PUBLIC
-                        Support)
-
 add_library(IR
               IR.cpp
               IRGen.cpp
@@ -32,8 +7,6 @@ add_library(IR
 
 target_link_libraries(IR
                       PUBLIC
-                        AutoGenIR
                         Graph
                         Base
                         Support)
-

--- a/tools/ClassGen/CMakeLists.txt
+++ b/tools/ClassGen/CMakeLists.txt
@@ -9,10 +9,8 @@ add_executable(InstrGen
 
 target_link_libraries(NodeGen
                       PUBLIC
-                        Base
                         Support)
 
 target_link_libraries(InstrGen
                       PUBLIC
-                        Base
                         Support)


### PR DESCRIPTION
Was getting this error when compiling Glow for the first time:

```
In file included from /Users/psag/home/Glow/src/glow/Graph/Nodes.cpp:3:
In file included from /Users/psag/home/Glow/include/glow/Graph/Nodes.h:5:
In file included from /Users/psag/home/Glow/include/glow/Graph/Grad.h:4:
In file included from /Users/psag/home/Glow/include/glow/Graph/Node.h:6:
/Users/psag/home/Glow/include/glow/Base/Traits.h:51:10: fatal error: 'AutoGenInstr.def' file not found
#include "AutoGenInstr.def"
         ^~~~~~~~~~~~~~~~~~
1 error generated.
```

I looked around and it seems `Base/Traits.h` includes `AutoGenInstr.def`, while that file would only be generated by `IR`, which depends on `Base` and is thus compiled *after* `Base`. As such `AutoGenInstr.def` is not yet available when `Base` gets compiled. I fixed this by moving the generation of `AutoGenInstr.*` into `Base/CMakeLists.txt`. I then discovered a cyclic dependency between `AutoGenInstr` and `Base`. Looking at `InstrBuilder.h`, it seems it does not require `Base` at all, but only `Support`. So I got rid of `Base` as a dependency for `AutoGenInstr` which also resolves the dependency cycle. The same is true for `AutoGenNodes`.

Wondering why this only occurred for me? It seems like this should always fail.