### PR TITLE
Fix .clang-tidy and add rule to ignore pointer->boolean cast

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,8 +1,33 @@
 ---
-Checks:          '*,clang-diagnostic-*, moderinize-*, clang-analyzer-*,-clang-analyzer-alpha*,-readability-named-parameter,-misc-unused-parameters,-google-runtime-references,-google-build-using-namespace,-cppcoreguidelines-pro-type-union-access,-google-readability-casting,-readability-implicit-bool-cast,-google-readability-todo,-readability-braces-around-statements,-google-readability-braces-around-statements,-performance-unnecessary-value-param,-misc-unused-using-decls,-modernize-pass-by-value,-modernize-raw-string-literal,-readability-else-after-return,-readability-implicit-bool-conversion,-cppcoreguidelines-pro-type-member-init,-hicpp-member-init'
+# NOTE: there must be no spaces before the '-', so put the comma first.
+Checks: '
+  *
+  ,clang-diagnostic-*
+  ,modernize-*
+  ,clang-analyzer-*
+  ,-clang-analyzer-alpha*
+  ,-readability-named-parameter
+  ,-misc-unused-parameters
+  ,-google-runtime-references
+  ,-google-build-using-namespace
+  ,-cppcoreguidelines-pro-type-union-access
+  ,-google-readability-casting
+  ,-readability-implicit-bool-cast
+  ,-google-readability-todo
+  ,-readability-braces-around-statements
+  ,-google-readability-braces-around-statements
+  ,-performance-unnecessary-value-param
+  ,-misc-unused-using-decls
+  ,-modernize-pass-by-value
+  ,-modernize-raw-string-literal
+  ,-readability-else-after-return
+  ,-readability-implicit-bool-conversion
+  ,-cppcoreguidelines-pro-type-member-init
+  ,-hicpp-member-init
+  ,-cppcoreguidelines-pro-bounds-array-to-pointer-decay
+  '
 WarningsAsErrors: ''
 HeaderFilterRegex: 'include/glow'
 AnalyzeTemporaryDtors: false
 CheckOptions:
 ...
-


### PR DESCRIPTION
Fixes and tidies up the `.clang-tidy` file. Also adds a rule to ignore the warning about casting pointers to booleans, which we get whenever we use `assert(... && "message");` which is LLVM style. Compiling with clang-tidy otherwise spews hundreds of low-signal warnings about these.

Also `modernize-*` had a type (`moderinize-*`) so we were missing out on all those checks.