### PR TITLE
Move AutoGenNodes into Base CMakeLists.txt too

### DIFF
--- a/src/glow/Base/CMakeLists.txt
+++ b/src/glow/Base/CMakeLists.txt
@@ -1,30 +1,59 @@
 
-set(HDR ${GLOW_BINARY_DIR}/AutoGenInstr.h)
-set(SRC ${GLOW_BINARY_DIR}/AutoGenInstr.cpp)
-set(DEF ${GLOW_BINARY_DIR}/AutoGenInstr.def)
-set(BLD ${GLOW_BINARY_DIR}/AutoGenIRBuilder.h)
+# AutoGenInstr
+set(INSTR_HDR ${GLOW_BINARY_DIR}/AutoGenInstr.h)
+set(INSTR_SRC ${GLOW_BINARY_DIR}/AutoGenInstr.cpp)
+set(INSTR_DEF ${GLOW_BINARY_DIR}/AutoGenInstr.def)
+set(INSTR_BLD ${GLOW_BINARY_DIR}/AutoGenIRBuilder.h)
 
 add_custom_command(OUTPUT
-                    "${HDR}"
-                    "${SRC}"
-                    "${DEF}"
-                    "${BLD}"
-                   COMMAND InstrGen ${HDR} ${SRC} ${DEF} ${BLD}
-                   DEPENDS InstrGen
-                   COMMENT "InstrGen: Generating instrs." VERBATIM)
+                    "${INSTR_HDR}"
+                    "${INSTR_SRC}"
+                    "${INSTR_DEF}"
+                    "${INSTR_BLD}"
+                    COMMAND InstrGen ${INSTR_HDR} ${INSTR_SRC} ${INSTR_DEF} ${INSTR_BLD}
+                    DEPENDS InstrGen
+                    COMMENT "InstrGen: Generating instructions." VERBATIM)
 
+add_library(AutoGenInstr
+            ${INSTR_HDR}
+            ${INSTR_SRC}
+            ${INSTR_DEF}
+            ${INSTR_BLD})
+
+target_link_libraries(AutoGenInstr PUBLIC Support)
+
+# AutoGenNodes
+set(NODES_HDR ${GLOW_BINARY_DIR}/AutoGenNodes.h)
+set(NODES_SRC ${GLOW_BINARY_DIR}/AutoGenNodes.cpp)
+set(NODES_DEF ${GLOW_BINARY_DIR}/AutoGenNodes.def)
+
+add_custom_command(OUTPUT
+                   "${NODES_HDR}"
+                   "${NODES_SRC}"
+                   "${NODES_DEF}"
+                   COMMAND NodeGen ${NODES_HDR} ${NODES_SRC} ${NODES_DEF}
+                   DEPENDS NodeGen
+                   COMMENT "NodeGen: Generating nodes." VERBATIM)
+
+add_library(AutoGenNodes
+            ${NODES_HDR}
+            ${NODES_SRC}
+            ${NODES_DEF}
+            ${NODES_BLD})
+
+target_link_libraries(AutoGenNodes PUBLIC Support)
+
+# Base
 add_library(Base
               Tensor.cpp
               Type.cpp
-              Image.cpp
-              ${HDR}
-              ${SRC}
-              ${DEF}
-              ${BLD})
+              Image.cpp)
 
 target_link_libraries(Base
                       PUBLIC
-                       Support)
+                        Support
+                        AutoGenInstr
+                        AutoGenNodes)
 if(PNG_FOUND)
   target_compile_definitions(Base
                              PRIVATE

--- a/src/glow/Graph/CMakeLists.txt
+++ b/src/glow/Graph/CMakeLists.txt
@@ -1,24 +1,7 @@
-
-set(HDR ${GLOW_BINARY_DIR}/AutoGenNodes.h)
-set(SRC ${GLOW_BINARY_DIR}/AutoGenNodes.cpp)
-set(DEF ${GLOW_BINARY_DIR}/AutoGenNodes.def)
-
-add_custom_command(OUTPUT
-                    "${HDR}"
-                    "${SRC}"
-                    "${DEF}"
-                   COMMAND NodeGen ${HDR} ${SRC} ${DEF}
-                   DEPENDS NodeGen
-                   COMMENT "NodeGen: Generating nodes." VERBATIM)
-
 add_library(Graph
             Nodes.cpp
             Graph.cpp
-            Grad.cpp
-            ${HDR}
-            ${SRC}
-            ${DEF}
-            )
+            Grad.cpp)
 
 
 target_link_libraries(Graph


### PR DESCRIPTION
Got more errors. `Base/Traits.h` also depends on `AutoGenNodes`, which is generated later by Graph. Didn't get these errors yesterday. Either the order in which targets are built is weird, or I already had these files generated from previous runs and thus they weren't rebuilt by Make (I also switched to Ninja now).

I think this makes most sense now? Let me know.