### PR TITLE
Improve download_test_db.py

### DIFF
--- a/utils/download_test_db.py
+++ b/utils/download_test_db.py
@@ -1,64 +1,120 @@
-import pickle
-import gzip
+from __future__ import division
+from __future__ import print_function
+
+import argparse
 import array
-import urllib
-import tarfile
+import collections
+import gzip
 import os.path
+import pickle
+import sys
+import tarfile
+import urllib
 
-# This script downloads and extracts the mnist and cifar-10 databases.
-
-print("""Downloading test files. If the download fails try setting up a proxy:
-    #export http_proxy="http://fwdproxy:8080
-
-""")
-
-mnist_filename = "mnist.pkl.gz"
-cifar10_filename = "cifar-10.binary.tar.gz"
-ptb_filename = "ptb.tgz"
-
-if os.path.exists(mnist_filename):
-    print("MNIST file found. Not downloading.")
-else:
-    print("Downloading MNIST ... ")
-    urllib.urlretrieve ("http://www.iro.umontreal.ca/~lisa/deep/data/mnist/mnist.pkl.gz", mnist_filename)
-
-if os.path.exists(cifar10_filename):
-    print("CIFAR file found. Not downloading.")
-else:
-    print("Downloading CIFAR ... ")
-    urllib.urlretrieve ("http://www.cs.toronto.edu/~kriz/cifar-10-binary.tar.gz", cifar10_filename)
-
-if os.path.exists(ptb_filename):
-    print("PTB file found. Not downloading.")
-else:
-    print("Downloading PTB ... ")
-    urllib.urlretrieve ("http://www.fit.vutbr.cz/~imikolov/rnnlm/simple-examples.tgz", ptb_filename)
-
-def dumpToFile(dataset):
-    data, labels = dataset
-
-    imagesFile = open('mnist_images.bin', 'wb')
-    data.tofile(imagesFile)
-    imagesFile.close()
-
-    labelsFile = open('mnist_labels.bin', 'wb')
-    L = array.array('B', labels)
-    L.tofile(labelsFile)
-    labelsFile.close()
-
-print("Extracting the mnist database.")
-
-with gzip.open(mnist_filename, 'rb') as f:
-    train_set, valid_set, test_set = pickle.load(f)
-    dumpToFile(train_set)
+try:
+    from urllib.error import URLError
+except ImportError:
+    from urllib2 import URLError
 
 
-print("Extracting the CIFAR-10 database.")
-tar = tarfile.open(cifar10_filename, "r:gz")
-tar.extractall()
-tar.close()
+Dataset = collections.namedtuple('Dataset', 'filename, url, handler')
 
-print("Extracting the PTB database.")
-tar = tarfile.open(ptb_filename, "r:gz")
-tar.extractall('ptb')
-tar.close()
+
+def handle_mnist(filename):
+    print('Extracting {} ...'.format(filename))
+    with gzip.open(filename, 'rb') as file:
+        training_set, _, _ = pickle.load(file)
+        data, labels = training_set
+
+        images_file = open('mnist_images.bin', 'wb')
+        data.tofile(images_file)
+        images_file.close()
+
+        labels_file = open('mnist_labels.bin', 'wb')
+        L = array.array('B', labels)
+        L.tofile(labels_file)
+        labels_file.close()
+
+
+def untar(filename):
+    print('Extracting {} ...'.format(filename))
+    tar = tarfile.open(filename, "r:gz")
+    tar.extractall()
+    tar.close()
+
+
+DATASETS = dict(
+    mnist=Dataset(
+        'mnist.pkl.gz',
+        'http://www.iro.umontreal.ca/~lisa/deep/data/mnist/mnist.pkl.gz',
+        handle_mnist,
+    ),
+    cifar10=Dataset(
+        'cifar-10.binary.tar.gz',
+        'http://www.cs.toronto.edu/~kriz/cifar-10-binary.tar.gz',
+        untar,
+    ),
+    ptb=Dataset(
+        'ptb.tgz',
+        'http://www.fit.vutbr.cz/~imikolov/rnnlm/simple-examples.tgz',
+        untar,
+    ),
+)
+DATASET_NAMES = list(DATASETS.keys())
+
+
+def report_download_progress(chunk_number, chunk_size, file_size):
+    if file_size != -1:
+        percent = min(1, (chunk_number * chunk_size) / file_size)
+        bar = '#' * int(64 * percent)
+        sys.stdout.write('\r0% |{:<64}| {}%'.format(bar, int(percent * 100)))
+
+
+def download_dataset(dataset):
+    if os.path.exists(dataset.filename):
+        print('{} already exists, skipping ...'.format(dataset.filename))
+    else:
+        print('Downloading {} from {} ...'.format(dataset.filename,
+                                                  dataset.url))
+        try:
+            urllib.urlretrieve(
+                dataset.url,
+                dataset.filename,
+                reporthook=report_download_progress)
+        except URLError:
+            print('Error downloading {}!'.format(dataset.filename))
+        finally:
+            # Just a newline.
+            print()
+
+
+def parse():
+    parser = argparse.ArgumentParser(description='Download datasets for Glow')
+    parser.add_argument('-d', '--datasets', nargs='+', choices=DATASET_NAMES)
+    parser.add_argument('-a', '--all', action='store_true')
+    options = parser.parse_args()
+
+    if options.all:
+        datasets = DATASET_NAMES
+    elif options.datasets:
+        datasets = options.datasets
+    else:
+        parser.error('Must specify at least one dataset or --all.')
+
+    return datasets
+
+
+def main():
+    datasets = parse()
+    try:
+        for name in datasets:
+            dataset = DATASETS[name]
+            download_dataset(dataset)
+            dataset.handler(dataset.filename)
+        print('Done.')
+    except KeyboardInterrupt:
+        print('Interrupted')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Improves the script to download datasets a bit.

1. Adds an argument parser:

```
 psag@psag-mbp:~/home/Glow python utils/download_test_db.py -h                                                                                                                                                                                                                                                           
usage: download_test_db.py [-h]
                           [-d {ptb,mnist,cifar10} [{ptb,mnist,cifar10} ...]]
                           [-a]

Download datasets for Glow

optional arguments:
  -h, --help            show this help message and exit
  -d {ptb,mnist,cifar10} [{ptb,mnist,cifar10} ...], --datasets {ptb,mnist,cifar10} [{ptb,mnist,cifar10} ...]
  -a, --all
```

This allows downloading individual datasets with `-d <dataset1> [, <dataset2>]` or all of them with `-a/--all`. Closes #211.

Also adds a progress bar and better error handling and descriptive output:

<img width="714" alt="screen shot 2018-01-02 at 22 41 35" src="https://user-images.githubusercontent.com/6429851/34511127-55d13aa2-f00e-11e7-94fe-48199a12420a.png">
