### PR TITLE
Introduce caching and non-caching versions of PoolMax and SoftMax

### DIFF
--- a/include/glow/IR/IRBuilder.h
+++ b/include/glow/IR/IRBuilder.h
@@ -41,6 +41,9 @@ public:
   PoolMaxInst *createPoolMaxOp(Value *input, size_t kernel, size_t stride,
                                size_t pad);
 
+  PoolMaxWithXYInst *createPoolMaxWithXYOp(Value *input, size_t kernel,
+                                           size_t stride, size_t pad);
+
   PoolAvgInst *createPoolAvgOp(Value *input, size_t kernel, size_t stride,
                                size_t pad);
 
@@ -49,6 +52,8 @@ public:
   TanhInst *createTanhOp(Value *input);
 
   SoftMaxInst *createSoftMaxOp(Value *input, Value *selected);
+
+  SoftMaxWithEInst *createSoftMaxWithEOp(Value *input, Value *selected);
 
   ReshapeInst *createReshapeOp(Value *input, llvm::ArrayRef<size_t> shape);
 

--- a/tests/unittests/basicIRTest.cpp
+++ b/tests/unittests/basicIRTest.cpp
@@ -107,10 +107,10 @@ TEST(IR, allInstrs) {
 
     builder.createCopyInst("", I1, I0);
     builder.createConvolutionInst("", I3, I1, F0, B0, 7, 2, 3, 64);
-    builder.createPoolMaxInst("", I4, I0, XY, 7, 2, 3);
+    builder.createPoolMaxInst("", I4, I0, 7, 2, 3);
     builder.createSigmoidInst("", I1, I0);
     builder.createTanhInst("", I1, I0);
-    builder.createSoftMaxInst("", I1, I0, I7, E0);
+    builder.createSoftMaxInst("", I1, I0, I7);
     builder.createTransposeInst("", I8, I2, {0, 3, 1, 2});
     builder.createTensorView(ElemKind::FloatTy, {1, 24, 3, 24}, I2, "I2_view");
     builder.createInsertTensorInst("", I6, I3, {0, 0, 0, 0});

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -63,14 +63,23 @@ int main(int argc, char **argv) {
       .addMember(MemberType::SizeT, "Depth")
       .addGradientInstr({"Src", "Filter"}, {"Dest", "Src", "Filter", "Bias"});
 
-  BB.newInstr("PoolMax")
+  // PoolMax version caching XY coordinates to speedup gradient-based
+  // computations.
+  BB.newInstr("PoolMaxWithXY")
       .addOperand("Dest", OperandKind::Out)
       .addOperand("Src", OperandKind::In)
-      .addOperand("SrcXY", OperandKind::InOut)
+      .addOperand("SrcXY", OperandKind::Out)
       .addMember(MemberType::SizeT, "Kernel")
       .addMember(MemberType::SizeT, "Stride")
       .addMember(MemberType::SizeT, "Pad")
       .addGradientInstr({"Dest", "SrcXY"}, {"Dest", "Src"});
+
+  BB.newInstr("PoolMax")
+      .addOperand("Dest", OperandKind::Out)
+      .addOperand("Src", OperandKind::In)
+      .addMember(MemberType::SizeT, "Kernel")
+      .addMember(MemberType::SizeT, "Stride")
+      .addMember(MemberType::SizeT, "Pad");
 
   BB.newInstr("PoolAvg")
       .addOperand("Dest", OperandKind::Out)
@@ -120,13 +129,20 @@ int main(int argc, char **argv) {
   //                      Loss operations
   //===--------------------------------------------------------------------===//
 
-  BB.newInstr("SoftMax")
+  // SoftMax version caching Expected to speedup gradient-based computations.
+  BB.newInstr("SoftMaxWithE")
       .addOperand("Dest", OperandKind::Out)
       .addOperand("Src", OperandKind::In)
       .addOperand("E", OperandKind::InOut)
       .addOperand("Selected", OperandKind::In)
       .inplaceOperand({"Dest", "Src"})
       .addGradientInstr({"Src", "E", "Selected"}, {"Src"});
+
+  BB.newInstr("SoftMax")
+      .addOperand("Dest", OperandKind::Out)
+      .addOperand("Src", OperandKind::In)
+      .addOperand("Selected", OperandKind::In)
+      .inplaceOperand({"Dest", "Src"});
 
   //===--------------------------------------------------------------------===//
   //                      Arithmetic


### PR DESCRIPTION
Until now, the compiler had only caching versions of PoolMax and SoftMax. In case of inference, these caches were not used at all and just increased memory consumption and execution time.

With this change, the compiler replaces caching instructions by their non-caching versions if it can prove that their caches are not used.