### PR TITLE
OpenCL: fix insert tensor operation for OpenCL backend.

### DIFF
--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -37,6 +37,15 @@ struct ShapeNHWC {
     return ShapeNHWC(shape[0], shape[1], shape[2], 1);
   }
 
+  static ShapeNHWC fromXY(llvm::ArrayRef<size_t> shape) {
+    assert(shape.size() == 2 && "Invalid 2d shape");
+    return ShapeNHWC(shape[0], shape[1], 1, 1);
+  }
+
+  static ShapeNHWC empty() {
+    return ShapeNHWC(0, 0, 0, 0);
+  }
+
   explicit ShapeNHWC(size_t samples, size_t height, size_t width,
                      size_t channels)
       : n(samples), h(height), w(width), c(channels) {}


### PR DESCRIPTION
This is covered by tests while running Execution Engine in the OpenCL mode.

2-dimensional tensors appear if `concat` is used on `fully connected nodes`.