### PR TITLE
build: repair build without gtest installed

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,8 @@
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${GLOW_BINARY_DIR}/tests/)
+
+include_directories(SYSTEM ${LLVM_SRC_ROOT}/utils/unittest/googletest/include)
+
 add_subdirectory(unittests)
 add_subdirectory(images)
 


### PR DESCRIPTION
Add the include path for the gtest when expecting to use gtest from LLVM.