### PR TITLE
Fix ASAN errors

### DIFF
--- a/lib/IR/Instrs.cpp
+++ b/lib/IR/Instrs.cpp
@@ -70,11 +70,13 @@ void ConvolutionInst::verify() const {
   (void)exp;
   assert(exp == odim && "Invalid output dimensions");
 
-  llvm::ArrayRef<size_t> filterDims = {Depth_, Kernel_, Kernel_, idim.c};
-  assert(filter->getType()->dims() == filterDims && "Invalid filter dims");
+  auto filterDims = {Depth_, Kernel_, Kernel_, idim.c};
+  assert(filter->getType()->dims().equals(filterDims) &&
+         "Invalid filter dims");
 
-  llvm::ArrayRef<size_t> biasDims = {Depth_};
-  assert(bias->getType()->dims() == biasDims && "Invalid bias dims");
+  auto biasDims = {Depth_};
+  assert(bias->getType()->dims().equals(biasDims) &&
+         "Invalid bias dims");
 }
 
 void PoolMaxInst::verify() const {
@@ -110,8 +112,9 @@ void PoolMaxWithXYInst::verify() const {
 
   // Allocate cache arrays that store the x and y coordinates of the incoming
   // gradient for each max element.
-  llvm::ArrayRef<size_t> E = {idim.n, outSz.first, outSz.second, idim.c, 2};
-  assert(srcXY->getType()->dims() == E && "Invalid srcXY dims");
+  auto E = {idim.n, outSz.first, outSz.second, idim.c, 2UL};
+  assert(srcXY->getType()->dims().equals(E) &&
+         "Invalid srcXY dims");
 }
 
 void PoolAvgInst::verify() const {
@@ -220,7 +223,7 @@ void TransposeInst::verify() const {
     shape.push_back(dims[Shuffle_[i]]);
   }
 
-  assert(dest->dims() == llvm::ArrayRef<size_t>(shape) &&
+  assert(dest->dims().equals(shape) &&
          "Invalid transpose dims");
 }
 
@@ -266,11 +269,15 @@ void BatchNormalizationInst::verify() const {
   // Figure out how many channels are in the tensor.
   size_t channels = getOperand(0).first->dims()[ChannelIdx_];
 
-  llvm::ArrayRef<size_t> exp = {channels};
-  assert(getOperand(2).first->getType()->dims() == exp && "Invalid bias dim");
-  assert(getOperand(3).first->getType()->dims() == exp && "Invalid scale dim");
-  assert(getOperand(4).first->getType()->dims() == exp && "Invalid mean dim");
-  assert(getOperand(5).first->getType()->dims() == exp && "Invalid var dim");
+  auto exp = {channels};
+  assert(getOperand(2).first->getType()->dims().equals(exp) &&
+         "Invalid bias dim");
+  assert(getOperand(3).first->getType()->dims().equals(exp) &&
+         "Invalid scale dim");
+  assert(getOperand(4).first->getType()->dims().equals(exp) &&
+         "Invalid mean dim");
+  assert(getOperand(5).first->getType()->dims().equals(exp) &&
+         "Invalid var dim");
 }
 
 void LocalResponseNormalizationInst::verify() const {


### PR DESCRIPTION
After the change, ASAN runs cleanly for all tests.

Currently, there are following errors while running tests under ASAN:
```
[ RUN      ] Network.gradientCheckConv
=================================================================
==38744==ERROR: AddressSanitizer: stack-use-after-scope on address 0x7fff4fd485e0 at pc 0x00010fed14f0 bp 0x7fff4fd48090 sp 0x7fff4fd48088
READ of size 8 at 0x7fff4fd485e0 thread T0
    #0 0x10fed14ef in llvm::ArrayRef<unsigned long>::equals(llvm::ArrayRef<unsigned long>) const algorithm:677
    #1 0x10feb7c9e in bool llvm::operator==<unsigned long>(llvm::ArrayRef<unsigned long>, llvm::ArrayRef<unsigned long>) ArrayRef.h:519
    #2 0x10ffc3148 in glow::ConvolutionInst::verify() const Instrs.cpp:75
    #3 0x10feee6f6 in glow::Instruction::verify() const .AutoGenInstr.def:15
    #4 0x10fefc578 in glow::Module::verify() const IR.cpp:249
    #5 0x1100c4f07 in glow::optimize(glow::Module&, glow::CompilationMode) IROptimizer.cpp:876
    #6 0x10fee651f in glow::ExecutionEngine::compile(glow::CompilationMode) ExecutionEngine.cpp:100
    #7 0x10febea8b in Network_gradientCheckConv_Test::TestBody() gradCheckTest.cpp:146
    #8 0x10ffe9874 in testing::Test::Run() gtest.cc:2471
    #9 0x10ffeac50 in testing::TestInfo::Run() gtest.cc:2653
    #10 0x10ffebb01 in testing::TestCase::Run() gtest.cc:2771
    #11 0x10fff7b01 in testing::internal::UnitTestImpl::RunAllTests() gtest.cc:4648
    #12 0x10fff75c4 in testing::UnitTest::Run() gtest.cc:4256
    #13 0x110023547 in main gtest_main.cc:37
    #14 0x7fffe9d66234 in start (libdyld.dylib:x86_64+0x5234)

Address 0x7fff4fd485e0 is located in stack of thread T0 at offset 512 in frame
    #0 0x10ffc1c2f in glow::ConvolutionInst::verify() const Instrs.cpp:55

  This frame has 19 object(s):
    [32, 48) 'ref.tmp' (line 56)
    [64, 80) 'ref.tmp2' (line 57)
    [96, 112) 'ref.tmp5' (line 58)
    [128, 144) 'ref.tmp8' (line 59)
    [160, 192) 'idim' (line 63)
    [224, 240) 'agg.tmp'
    [256, 288) 'odim' (line 64)
    [320, 336) 'agg.tmp13'
    [352, 368) 'outSz' (line 69)
    [384, 416) 'exp' (line 70)
    [448, 464) 'filterDims' (line 74)
    [480, 496) 'ref.tmp26' (line 74)
    [512, 544) 'ref.tmp27' (line 74) <== Memory access at offset 512 is inside this variable
    [576, 592) 'agg.tmp33'
    [608, 624) 'agg.tmp37'
    [640, 656) 'biasDims' (line 77)
    [672, 680) 'ref.tmp40' (line 77)
    [704, 720) 'agg.tmp46'
    [736, 752) 'agg.tmp50'
```