### PR TITLE
[Unit tests] Add optimize-ir flag. Allow using LLVM flags in tests.

### DIFF
--- a/lib/Optimizer/IROptimizer.cpp
+++ b/lib/Optimizer/IROptimizer.cpp
@@ -20,6 +20,10 @@ static llvm::cl::opt<bool>
     instrumentDebug("instrument-debug",
                     llvm::cl::desc("Instrument the IR for debugging"),
                     llvm::cl::init(false), llvm::cl::Hidden);
+static llvm::cl::opt<bool>
+    optimizeIR("optimize-ir",
+                    llvm::cl::desc("Enable IR optimizations"),
+                    llvm::cl::init(true), llvm::cl::Hidden);
 
 using namespace glow;
 
@@ -874,6 +878,8 @@ void performPeepholeOptimizations(Module &M) {
 
 void glow::optimize(Module &M, CompilationMode mode) {
   M.verify();
+  if (!optimizeIR)
+    return;
 
   performPeepholeOptimizations(M);
 

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -1,4 +1,8 @@
-
+add_library(testMain
+            testMain.cpp)
+target_link_libraries(testMain
+                      PRIVATE
+                        gtest)
 
 add_executable(tensorsTest
                tensorsTest.cpp)
@@ -7,7 +11,7 @@ target_link_libraries(tensorsTest
                         Base
                         Support
                         gtest
-                        gtest_main)
+                        testMain)
 add_test(tensorsTest ${GLOW_BINARY_DIR}/tests/tensorsTest)
 
 add_executable(gradCheckTest
@@ -18,7 +22,7 @@ target_link_libraries(gradCheckTest
                         ExecutionEngine
                         IR
                         gtest
-                        gtest_main)
+                        testMain)
 add_test(gradCheckTest ${GLOW_BINARY_DIR}/tests/gradCheckTest)
 
 add_executable(IROptTest
@@ -28,7 +32,7 @@ target_link_libraries(IROptTest
                         Backends
                         IR
                         gtest
-                        gtest_main)
+                        testMain)
 add_test(IROptTest ${GLOW_BINARY_DIR}/tests/IROptTest)
 
 add_executable(basicIRTest
@@ -38,7 +42,7 @@ target_link_libraries(basicIRTest
                         Backends
                         IR
                         gtest
-                        gtest_main)
+                        testMain)
 add_test(basicIRTest ${GLOW_BINARY_DIR}/tests/basicIRTest)
 
 add_executable(interpreterTest
@@ -49,7 +53,7 @@ target_link_libraries(interpreterTest
                         IR
                         ExecutionEngine
                         gtest
-                        gtest_main)
+                        testMain)
 add_test(interpreterTest ${GLOW_BINARY_DIR}/tests/interpreterTest)
 
 add_executable(operatorTest
@@ -60,7 +64,7 @@ target_link_libraries(operatorTest
                         IR
                         ExecutionEngine
                         gtest
-                        gtest_main)
+                        testMain)
 add_test(operatorTest ${GLOW_BINARY_DIR}/tests/operatorTest)
 
 
@@ -72,7 +76,7 @@ target_link_libraries(graphTest
                         IR
                         Backends
                         gtest
-                        gtest_main)
+                        testMain)
 add_test(graphTest ${GLOW_BINARY_DIR}/tests/graphTest)
 
 add_executable(graphGradTest
@@ -84,7 +88,7 @@ target_link_libraries(graphGradTest
                         Backends
                         ExecutionEngine
                         gtest
-                        gtest_main)
+                        testMain)
 add_test(graphGradTest ${GLOW_BINARY_DIR}/tests/graphGradTest)
 
 
@@ -96,7 +100,7 @@ target_link_libraries(graphOptzTest
                         IR
                         Backends
                         gtest
-                        gtest_main)
+                        testMain)
 add_test(graphOptzTest ${GLOW_BINARY_DIR}/tests/graphOptzTest)
 
 if(OpenCL_FOUND)
@@ -108,7 +112,7 @@ target_link_libraries(OCLTest
                         IR
                         ExecutionEngine
                         gtest
-                        gtest_main)
+                        testMain)
 add_test(OCLTest ${GLOW_BINARY_DIR}/tests/OCLTest)
 endif()
 
@@ -119,6 +123,6 @@ target_link_libraries(memoryAllocatorTest
                         Backends
                         IR
                         gtest
-                        gtest_main)
+                        testMain)
 add_test(memoryAllocatorTest ${GLOW_BINARY_DIR}/tests/memoryAllocatorTest)
 

--- a/tests/unittests/testMain.cpp
+++ b/tests/unittests/testMain.cpp
@@ -1,0 +1,10 @@
+// Copyright 2018 Facebook Inc.  All Rights Reserved.
+
+#include "gtest/gtest.h"
+#include "llvm/Support/CommandLine.h"
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  llvm::cl::ParseCommandLineOptions(argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Turns out that our tests don't have own `int main()` function because they use standard one, provided by google test. There is gtest_main build dependency, which adds this function to each test. Also, if you look carefully, you can see very first line in the output of each test:

    Running main() from gtest_main.cc

It doesn't know about LLVM flags, so we need to have our own `int main()`

This is how LLVM solves this: they have `int main()` in a separate [file](https://github.com/llvm-mirror/llvm/blob/master/utils/unittest/UnitTestMain/TestMain.cpp), which they [add](https://github.com/llvm-mirror/llvm/blob/master/utils/unittest/UnitTestMain/CMakeLists.txt) to gtest_main, apparently overwriting standard `int main()`. This overwrite seems to happen only in "build" tree, not in "install" tree, which probably means that we can't use it. So I thought it's better to have our own (also, gtest instead of gmock).

As for running everything with and without: now it's very easy to enable. But I hesitated to do this, because it increases test time, and also normally gives you 2x failures. Perhaps its better to enable it somewhere in continuous integration. What do you think?
