### PR TITLE
[Quantization profile] Quantization profile skeleton

### DIFF
--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -54,7 +54,7 @@ struct ShapeNHWC {
   }
 };
 
-/// Colllapse a tensor shape into two sizes: the first dimension and the size of
+/// Collapse a tensor shape into two sizes: the first dimension and the size of
 /// the rest of the dimensions.
 /// For example, [7, 3, 4, 2] -> [7, 24]
 inline std::pair<size_t, size_t> flattenCdr(llvm::ArrayRef<size_t> dims) {

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -155,6 +155,11 @@ public:
   ArithmeticNode *createArithmetic(llvm::StringRef name, NodeValue LHS,
                                    NodeValue RHS, ArithmeticNode::Mode op);
 
+  /// Create quantization profile node named \p name for the output tensor from
+  /// \p input.
+  QuantizationProfileNode *createQuantizationProfile(llvm::StringRef name,
+                                                     NodeValue input);
+
   SelectNode *createSelect(llvm::StringRef name, NodeValue Cond, NodeValue LHS,
                            NodeValue RHS);
 

--- a/include/glow/Graph/Node.h
+++ b/include/glow/Graph/Node.h
@@ -137,7 +137,9 @@ public:
   unsigned getNumInputs() const;
   llvm::StringRef getInputName(unsigned idx) const;
   NodeValue getInputNode(unsigned idx) const;
-  llvm::StringRef getOutputName(unsigned idx);
+  llvm::StringRef getOutputName(unsigned idx) const;
+  /// \returns whether gradient node needs to be generated for this node.
+  bool shouldGenerateGradNode() const;
 
   /// \returns a textual description of the node.
   std::string getDebugDesc() const;

--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -67,7 +67,7 @@ public:
   llvm::StringRef getInputName(unsigned idx) const;
   NodeValue getInputNode(unsigned idx) const;
   llvm::StringRef getOutputName(unsigned idx) const;
-
+  bool shouldGenerateGradNode() const;
   std::string getDebugDesc() const;
 
   void visit(Node *parent, NodeWalker *visitor);

--- a/include/glow/Importer/Caffe2.h
+++ b/include/glow/Importer/Caffe2.h
@@ -76,7 +76,8 @@ public:
   caffe2ModelLoader(const std::string &netDescFilename,
                     const std::string &netWeightFilename,
                     llvm::ArrayRef<const char *> names,
-                    llvm::ArrayRef<Tensor *> tensors, ExecutionEngine &IP);
+                    llvm::ArrayRef<Tensor *> tensors, ExecutionEngine &IP,
+                    const std::string &quantizationProfileFile);
 
   ~caffe2ModelLoader();
 

--- a/include/glow/Optimizer/Optimizer.h
+++ b/include/glow/Optimizer/Optimizer.h
@@ -7,10 +7,11 @@ class Module;
 class Graph;
 
 enum class CompilationMode {
-  TrainDebug, /// Compiler the graph for training and add extra instrumentation
-              /// that enable unit testing and debugging.
+  TrainDebug, /// Compile the graph for training and add extra instrumentation
+              /// that enable unit testing and debugging, e.g, saving gradient
+              /// results.
   Train,      /// Compile the graph in preperation for training.
-  Infer,      /// Compiler the graph for inference. Notice that this operation
+  Infer,      /// Compile the graph for inference. Notice that this operation
               /// changes the graph in a way that is not reversible.
 };
 
@@ -20,6 +21,10 @@ void optimize(Graph &G, CompilationMode mode);
 /// Lower the high-level neural network operators into low-level lineal algebra
 /// operators.
 void lower(Graph &G, CompilationMode mode);
+
+/// Instrument graph \p G by inserting quantization profile nodes
+/// for capturing stats for quantization.
+void profileQuantization(Graph &G);
 
 } // namespace glow
 

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -1124,3 +1124,8 @@ void Interpreter::fwdDebugPrintInst(bool isTrain, const DebugPrintInst *I) {
   dumpImpl(getTensor(V));
   llvm::outs() << "\n";
 }
+
+void Interpreter::fwdQuantizationProfileInst(
+    bool isTrain, const glow::QuantizationProfileInst *I) {
+  // TODO: implement actual calculations of statistics.
+}

--- a/lib/Graph/Grad.cpp
+++ b/lib/Graph/Grad.cpp
@@ -65,7 +65,7 @@ void glow::generateGradientNodes(Graph &G, TrainingConfig &conf,
 
   for (auto it = nodes.rbegin(), e = nodes.rend(); it != e; it++) {
     Node *N = *it;
-    if (isa<Variable>(N)) {
+    if (!N->shouldGenerateGradNode()) {
       continue;
     }
 
@@ -160,11 +160,6 @@ void glow::generateGradientNodes(Graph &G, TrainingConfig &conf,
       }
       continue;
     }
-
-    if (N->getKind() == Kind::SplatNodeKind)
-      // Constant nodes don't have inputs therefore don't need grad
-      // calculations.
-      continue;
 
     llvm_unreachable("Invalid instruction type.");
   } // End of the for-each instr loop.

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -363,6 +363,16 @@ SplatNode *Graph::createSplat(llvm::StringRef name, TypeRef ty, float value) {
   return addNode(new SplatNode(name, ty, value));
 }
 
+QuantizationProfileNode *Graph::createQuantizationProfile(llvm::StringRef name,
+                                                          NodeValue input) {
+  // TODO: this size is going to be refined. Just a placeholder now.
+  const size_t bucketNumber = 2000U;
+
+  auto *statVar = createVariable(ElemKind::FloatTy, {bucketNumber},
+                                 "statistics", Variable::InitKind::Extern);
+  return addNode(new QuantizationProfileNode(name, input, statVar));
+}
+
 BatchedMatMulNode *Graph::createBatchedMatMul(llvm::StringRef name,
                                               NodeValue LHS, NodeValue RHS) {
   auto LT = LHS.getType();

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -287,6 +287,8 @@ llvm::StringRef Variable::getOutputName(unsigned idx) const {
   llvm_unreachable("Invalid index");
 }
 
+bool Variable::shouldGenerateGradNode() const { return false; }
+
 //===----------------------------------------------------------------------===//
 //                     Debug description methods
 //===----------------------------------------------------------------------===//
@@ -322,11 +324,22 @@ NodeValue Node::getInputNode(unsigned idx) const {
   }
 }
 
-llvm::StringRef Node::getOutputName(unsigned idx) {
+llvm::StringRef Node::getOutputName(unsigned idx) const {
   switch (getKind()) {
 #define DEF_NODE(CLASS, NAME)                                                  \
   case glow::Kinded::Kind::CLASS##Kind:                                        \
     return static_cast<const CLASS *>(this)->getOutputName(idx);
+#include "AutoGenNodes.def"
+  default:
+    llvm_unreachable("Unhandled node");
+  }
+}
+
+bool Node::shouldGenerateGradNode() const {
+  switch (getKind()) {
+#define DEF_NODE(CLASS, NAME)                                                  \
+  case glow::Kinded::Kind::CLASS##Kind:                                        \
+    return static_cast<const CLASS *>(this)->shouldGenerateGradNode();
 #include "AutoGenNodes.def"
   default:
     llvm_unreachable("Unhandled node");

--- a/lib/IR/IRGen.cpp
+++ b/lib/IR/IRGen.cpp
@@ -211,6 +211,15 @@ public:
       registerIR(N, dest);
       break;
     }
+    case glow::Kinded::Kind::QuantizationProfileNodeKind: {
+      auto *quantizationProfileNode = cast<QuantizationProfileNode>(N);
+      auto *inputTensor = valueForNode(quantizationProfileNode->getInput());
+      auto *stats = valueForNode(quantizationProfileNode->getVariable());
+      builder_.createQuantizationProfileInst(quantizationProfileNode->getName(),
+                                             inputTensor, stats);
+
+      break;
+    }
     case glow::Kinded::Kind::SigmoidNodeKind: {
       auto *S = cast<SigmoidNode>(N);
       auto *V = builder_.createSigmoidOp(valueForNode(S->getInput()));

--- a/lib/IR/Instrs.cpp
+++ b/lib/IR/Instrs.cpp
@@ -210,7 +210,7 @@ void TensorViewInst::verify() const {
   assert(getOperand(0).first->getType()->size() == getType()->size() &&
          "TensorView view size should be the same as Src size");
   assert(getOperand(0).first->getElementType() == getType()->getElementType() &&
-         "TensorView view element type should be the same as Src size");
+         "TensorView view element type should be the same as Src type");
 }
 
 void TransposeInst::verify() const {
@@ -375,4 +375,5 @@ NOVERIFY(BatchNormalizationGradInst)
 NOVERIFY(LocalResponseNormalizationGradInst)
 NOVERIFY(SoftMaxWithEGradInst)
 NOVERIFY(DebugPrintInst)
+NOVERIFY(QuantizationProfileInst)
 #undef NOVERIFY

--- a/lib/Importer/Caffe2.cpp
+++ b/lib/Importer/Caffe2.cpp
@@ -471,7 +471,8 @@ caffe2ModelLoader::caffe2ModelLoader(const std::string &netDescFilename,
                                      const std::string &netWeightFilename,
                                      llvm::ArrayRef<const char *> names,
                                      llvm::ArrayRef<Tensor *> tensors,
-                                     ExecutionEngine &EE)
+                                     ExecutionEngine &EE,
+                                     const std::string &quantizationProfileFile)
     : EE_(EE) {
   // Verify that the version of the library that we linked against is
   // compatible with the version of the headers we compiled against.
@@ -502,6 +503,9 @@ caffe2ModelLoader::caffe2ModelLoader(const std::string &netDescFilename,
   loadWeights(weightsDef);
   loadNetwork(networkDef);
 
+  if (!quantizationProfileFile.empty()) {
+    ::glow::profileQuantization(G);
+  }
   // Emit IR for the graph.
   EE.compile(CompilationMode::Infer);
 }

--- a/lib/Optimizer/CMakeLists.txt
+++ b/lib/Optimizer/CMakeLists.txt
@@ -2,7 +2,8 @@
 add_library(Optimizer
             IROptimizer.cpp
             GraphOptimizer.cpp
-            Lower.cpp)
+            Lower.cpp
+            Quantization.cpp)
 
 target_link_libraries(Optimizer
                       PRIVATE

--- a/lib/Optimizer/IROptimizer.cpp
+++ b/lib/Optimizer/IROptimizer.cpp
@@ -21,10 +21,9 @@ static llvm::cl::opt<bool>
     instrumentDebug("instrument-debug",
                     llvm::cl::desc("Instrument the IR for debugging"),
                     llvm::cl::init(false), llvm::cl::Hidden);
-static llvm::cl::opt<bool>
-    optimizeIR("optimize-ir",
-                    llvm::cl::desc("Enable IR optimizations"),
-                    llvm::cl::init(true), llvm::cl::Hidden);
+static llvm::cl::opt<bool> optimizeIR("optimize-ir",
+                                      llvm::cl::desc("Enable IR optimizations"),
+                                      llvm::cl::init(true), llvm::cl::Hidden);
 
 using namespace glow;
 

--- a/lib/Optimizer/Quantization.cpp
+++ b/lib/Optimizer/Quantization.cpp
@@ -1,0 +1,27 @@
+// Copyright 2017 Facebook Inc.  All Rights Reserved.
+
+#include "glow/Graph/Graph.h"
+#include "glow/Graph/Node.h"
+#include "glow/Graph/Nodes.h"
+
+using namespace glow;
+using llvm::dyn_cast;
+
+/// Profile quantization node should only be added when Graph is compiled in
+/// Inference mode.
+void glow::profileQuantization(Graph &G) {
+  // Iterate over all nodes in the graph and insert QuantizationProfile nodes
+  // to observe tensor values from every node's output.
+  // Note, new nodes are inserted into the same list which is iterated.
+  for (const auto &node : G.getNodes()) {
+    // Skip QuantizationProfileNode nodes.
+    if (auto *quantizationNode = dyn_cast<QuantizationProfileNode>(node)) {
+      continue;
+    }
+
+    // Link quantization profile node to each output of the current node.
+    for (unsigned i = 0; i < node->getNumRes(); ++i) {
+      G.createQuantizationProfile("QuantizationProfile", NodeValue(node, i));
+    }
+  }
+}

--- a/tests/unittests/basicIRTest.cpp
+++ b/tests/unittests/basicIRTest.cpp
@@ -118,6 +118,7 @@ TEST(IR, allInstrs) {
                                          0.9);
     builder.createElementMulInst("", I1, I0, I0);
     builder.createDebugPrintInst("", I0);
+    builder.createQuantizationProfileInst("", I0, B0);
   }
   M.verify();
 }

--- a/tests/unittests/testMain.cpp
+++ b/tests/unittests/testMain.cpp
@@ -1,7 +1,7 @@
 // Copyright 2018 Facebook Inc.  All Rights Reserved.
 
-#include "gtest/gtest.h"
 #include "llvm/Support/CommandLine.h"
+#include "gtest/gtest.h"
 
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -284,6 +284,10 @@ int main(int argc, char **argv) {
   //             Instructions used for debugging/profiling/printing
   //===--------------------------------------------------------------------===//
 
+  BB.newInstr("QuantizationProfile")
+      .addOperand("InputTensor", OperandKind::In)
+      .addOperand("Statistics", OperandKind::InOut);
+
   BB.newInstr("DebugPrint").addOperand("Src", OperandKind::In);
 
   return 0;

--- a/tools/ClassGen/NodeBuilder.cpp
+++ b/tools/ClassGen/NodeBuilder.cpp
@@ -54,6 +54,8 @@ void NodeBuilder::emitCtor(std::ostream &os) const {
     os << ", " << op.second << "_(" << op.second << ") ";
   }
 
+  os << ", shouldGenerateGradNode_(" << shouldGenerateGradNode_ << ")";
+
   // The constructor body:
   os << " {";
   for (auto &RT : nodeOutputs_) {
@@ -84,6 +86,8 @@ void NodeBuilder::emitClassMembers(std::ostream &os) const {
   for (const auto &op : members_) {
     os << "\t" << getStorageTypename(op.first) << " " << op.second << "_;\n";
   }
+
+  os << "bool shouldGenerateGradNode_;\n";
   os << "\n";
 }
 
@@ -320,13 +324,24 @@ void NodeBuilder::emitNodeClass(std::ostream &os) const {
   emitSettersGetters(os);
 
   os << "\tunsigned getNumInputs() const;\n";
+
   os << "\tllvm::StringRef getInputName(unsigned idx) const;\n";
+
   os << "\tNodeValue getInputNode(unsigned idx) const;\n";
+
   os << "\tllvm::StringRef getOutputName(unsigned idx) const;\n";
+
+  os << "\tbool shouldGenerateGradNode() const { return "
+        "shouldGenerateGradNode_; }\n";
+
   os << "\tstd::string getDebugDesc() const;\n";
+
   os << "\tbool isEqual(const " << name_ << "Node &other) const;\n";
+
   os << "\tllvm::hash_code getHash() const;\n";
+
   os << "\tvoid visit(Node *parent, NodeWalker *visitor);\n";
+
   if (!enum_.empty()) {
     os << "\tconst char *getModeStr() const { return getModeStr(mode_); "
           "}\n\tstatic const char *getModeStr(Mode m);\n";

--- a/tools/ClassGen/NodeBuilder.h
+++ b/tools/ClassGen/NodeBuilder.h
@@ -31,6 +31,9 @@ class NodeBuilder {
   std::vector<std::pair<std::string, std::string>> extraParams_;
   /// Stores the body of a new public method that will be added to the class.
   std::vector<std::string> extraMethods_;
+  /// Whether gradient node needs to be generated for this node.
+  /// By default it's generated.
+  bool shouldGenerateGradNode_{true};
   /// Header file stream.
   std::ofstream &hStream;
   /// CPP file stream.
@@ -89,6 +92,12 @@ public:
   /// Set the documentation string. Each line will be prepended with "/// ".
   NodeBuilder &setDocstring(const std::string &docstring) {
     docstring_ = docstring;
+    return *this;
+  }
+
+  /// Set whether gradient node needs to be generated.
+  NodeBuilder &setGenerateGradNode(bool shouldGenerateGradNode) {
+    shouldGenerateGradNode_ = shouldGenerateGradNode;
     return *this;
   }
 

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -228,6 +228,7 @@ int main(int argc, char **argv) {
       .addMember(MemberType::Float, "Value")
       .addExtraParam("TypeRef", "outTy")
       .addResult("outTy")
+      .setGenerateGradNode(false)
       .setDocstring("Generate a tensor of a specific type filled with 'Value'");
 
   BB.newNode("SGD")
@@ -239,6 +240,20 @@ int main(int argc, char **argv) {
       .addMember(MemberType::Float, "LearningRate")
       .addMember(MemberType::Float, "Momentum")
       .addMember(MemberType::Unsigned, "BatchSize");
+
+  //===--------------------------------------------------------------------===//
+  //                Nodes used by quantization.
+  //===--------------------------------------------------------------------===//
+
+  BB.newNode("QuantizationProfile")
+      .addInput("Input")
+      .addInput("Statistics")
+      .addExtraMethod("Variable *getVariable() const { return "
+                      "llvm::cast<Variable>(Statistics_.getNode()); };")
+      .setGenerateGradNode(false)
+      .setDocstring(
+          "Generate profile (distribution of values) of an Input tensor. "
+          "This data is used for quantization of the tensor later on.");
 
   //===--------------------------------------------------------------------===//
   //                Nodes used by unit tests.

--- a/tools/loader/loader.cpp
+++ b/tools/loader/loader.cpp
@@ -161,6 +161,11 @@ llvm::cl::opt<bool>
                          "takes for the program to execute"),
           llvm::cl::Optional);
 
+llvm::cl::opt<std::string> QuantizationProfileFile(
+    "profile",
+    llvm::cl::desc("Perform quantization profiling for a given graph "
+                   "and save result to the file."),
+    llvm::cl::value_desc("file.json"), llvm::cl::Optional);
 } // namespace
 
 int main(int argc, char **argv) {
@@ -186,7 +191,8 @@ int main(int argc, char **argv) {
   {
     caffe2ModelLoader LD(NetDescFilename, NetWeightFilename,
                          {"data", "gpu_0/data", "softmax_expected"},
-                         {&data, &data, &expected_softmax}, EE);
+                         {&data, &data, &expected_softmax}, EE,
+                         QuantizationProfileFile);
     SM = LD.getRoot();
     i0 = llvm::cast<Variable>(LD.getOrCreateNodeByName("gpu_0/data"));
     i1 = llvm::cast<Variable>(LD.getOrCreateNodeByName("data"));


### PR DESCRIPTION
This PR creates a skeleton for further implementation of profiling for quantization.
This covers:
* Inserting proper quantization profile nodes with stats tensors.
* Genereting IR.
* Stubs for IR implementation.
* Misc clang-format fixes.

To test insertion mechanism of QuantizationProfile nodes we could use pretty much any test involving ExecutionEngine and supplying "profile" llvm cli parameter.