### PR TITLE
Forward-declare raw_ostream in Type.h

### DIFF
--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -6,11 +6,14 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/ErrorHandling.h"
-#include "llvm/Support/raw_ostream.h"
 
 #include <cstddef>
 #include <cstdint>
 #include <type_traits>
+
+namespace llvm {
+class raw_ostream;
+}
 
 namespace glow {
 struct Type;


### PR DESCRIPTION
Forward-declares llvm::raw_ostream in Type.h
This reduces compilation time by ~400ms
(It is nontrivial to remove the include in Type.cpp because it uses inline functions defined in the header)