### PR TITLE
Re-factoring: Move all math computations from InterpreterNodes.cpp into to NNMath.cpp

### DIFF
--- a/include/glow/Graph/Node.h
+++ b/include/glow/Graph/Node.h
@@ -133,6 +133,9 @@ public:
   /// \returns the number of results that the node has.
   unsigned getNumRes() const { return numRes_; }
 
+  /// \returns the \p idx result of the node.
+  NodeValue getResult(unsigned idx);
+
   /// Getters to access Node's inputs and outputs.
   unsigned getNumInputs() const;
   llvm::StringRef getInputName(unsigned idx) const;

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -325,6 +325,11 @@ NodeValue Node::getInputNode(unsigned idx) const {
   }
 }
 
+NodeValue Node::getResult(unsigned idx) {
+  assert(idx < getNumRes());
+  return NodeValue(this, idx);
+}
+
 llvm::StringRef Node::getOutputName(unsigned idx) const {
   switch (getKind()) {
 #define DEF_NODE(CLASS, NAME)                                                  \


### PR DESCRIPTION
This re-factoring makes it easier to test the correctness of the math functions without any need for creating NN models.
The tests can operate directly on tensors.

This PR does not introduce any functionality changes.