### PR TITLE
Backends: adjust inclusion

### DIFF
--- a/lib/Backends/Backends.cpp
+++ b/lib/Backends/Backends.cpp
@@ -1,8 +1,12 @@
 // Copyright 2017 Facebook Inc.  All Rights Reserved.
 
 #include "Interpreter/Interpreter.h"
+#if defined(GLOW_WITH_JIT)
 #include "JIT/JIT.h"
+#endif
+#if defined(GLOW_WITH_OPENCL)
 #include "OpenCL/OpenCL.h"
+#endif
 
 #include "glow/Backends/Backend.h"
 #include "glow/Graph/Graph.h"


### PR DESCRIPTION
OpenCL and JIT are optional, and the headers may not be available.  Account for that.