### PR TITLE
Fix the CMAKE variables that control the OCL and JIT backends.

### DIFF
--- a/lib/Backends/CMakeLists.txt
+++ b/lib/Backends/CMakeLists.txt
@@ -3,14 +3,14 @@ add_library(Backends Backends.cpp)
 add_subdirectory(Interpreter)
 
 if(GLOW_WITH_OPENCL)
-  target_compile_definitions(Backends PRIVATE WITH_OPENCL=1)
+  target_compile_definitions(Backends PRIVATE GLOW_WITH_OPENCL=1)
   add_subdirectory(OpenCL)
   LIST(APPEND linked_backends OpenCL)
 endif()
 
 
 if(GLOW_WITH_JIT)
-  target_compile_definitions(Backends PRIVATE WITH_JIT=1)
+  target_compile_definitions(Backends PRIVATE GLOW_WITH_JIT=1)
   add_subdirectory(JIT)
   LIST(APPEND linked_backends JIT)
 endif()

--- a/lib/Backends/OpenCL/CMakeLists.txt
+++ b/lib/Backends/OpenCL/CMakeLists.txt
@@ -7,13 +7,7 @@ target_link_libraries(OpenCL
                       Graph
                       CodeGen)
 
-if(OpenCL_FOUND)
-  target_compile_definitions(OpenCL
-                             PRIVATE
-                             WITH_OPENCL=1)
-
-  target_link_libraries(OpenCL
-                        PRIVATE
-                        OpenCL::OpenCL)
-endif()
+target_link_libraries(OpenCL
+                      PRIVATE
+                      OpenCL::OpenCL)
 


### PR DESCRIPTION
We mixed the cmake variable with the c++ definition. This PR fixes the build.