### PR TITLE
[profile quantization] Add storage for min/max.

### DIFF
--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -445,9 +445,16 @@ QuantizationProfileNode *Graph::createQuantizationProfile(llvm::StringRef name,
                                                           NodeValue input) {
   // TODO: this size is going to be refined. Just a placeholder now.
   const size_t numberOfBuckets = 2000U;
-  auto *statVar = createVariable(ElemKind::FloatTy, {numberOfBuckets}, name,
-                                 Variable::InitKind::Extern);
-  return addNode(new QuantizationProfileNode(name, input, statVar));
+  auto *histogram = createVariable(ElemKind::FloatTy, {numberOfBuckets},
+                                   "histogram", Variable::InitKind::Extern);
+  // Intermediate data used for histogram calculations.
+  // Min tensor value seen so far is kept on the first position.
+  // Max tensor value seen so far is kept on the second position.
+  auto *computationInfo = createVariable(
+      ElemKind::FloatTy, {2}, "computationInfo", Variable::InitKind::Extern);
+
+  return addNode(
+      new QuantizationProfileNode(name, input, histogram, computationInfo));
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/IR/IRGen.cpp
+++ b/lib/IR/IRGen.cpp
@@ -516,9 +516,13 @@ public:
     case glow::Kinded::Kind::QuantizationProfileNodeKind: {
       auto *quantizationProfileNode = cast<QuantizationProfileNode>(N);
       auto *inputTensor = valueForNode(quantizationProfileNode->getInput());
-      auto *histogram = valueForNode(quantizationProfileNode->getVariable());
+      auto *histogram =
+          valueForNode(quantizationProfileNode->getHistogramVar());
+      auto *computationInfo =
+          valueForNode(quantizationProfileNode->getComputationInfoVar());
       builder_.createQuantizationProfileInst(quantizationProfileNode->getName(),
-                                             inputTensor, histogram);
+                                             inputTensor, histogram,
+                                             computationInfo);
       break;
     }
 

--- a/lib/IR/Instrs.cpp
+++ b/lib/IR/Instrs.cpp
@@ -364,9 +364,16 @@ void DeallocActivationInst::verify() const {
 }
 
 void QuantizationProfileInst::verify() const {
+  // Make sure that input tensor is a floating point type.
   assert(getOperand(0).first->getElementType() == ElemKind::FloatTy ||
          getOperand(0).first->getElementType() == ElemKind::DoubleTy &&
              "Floating point type is expected");
+
+  // Check computation info has proper size.
+  assert(getOperand(2).first->dims().size() == 1 &&
+         "Computation info should be 1 dimensional");
+  assert(getOperand(2).first->dims()[0] == 2 &&
+         "Computation info should contain Min and Max value only");
 }
 
 // TODO: verify the gradient instructions.

--- a/tests/unittests/basicIRTest.cpp
+++ b/tests/unittests/basicIRTest.cpp
@@ -88,6 +88,8 @@ TEST(IR, allInstrs) {
     auto *I6 = builder.createWeightVar(ElemKind::FloatTy, {2, 12, 12, 64});
     auto *I7 = builder.createWeightVar(T1, "I7");
     auto *I8 = builder.createWeightVar(ElemKind::FloatTy, {1, 24, 3, 24}, "I8");
+    auto *ComputationInfo =
+        builder.createWeightVar(ElemKind::FloatTy, {2}, "ComputationInfo");
 
     auto *XY = builder.createWeightVar(ElemKind::IndexTy, {1, 12, 12, 3, 2});
     auto *B0 = builder.createWeightVar(T2, "B0");
@@ -118,7 +120,7 @@ TEST(IR, allInstrs) {
                                          0.9);
     builder.createElementMulInst("", I1, I0, I0);
     builder.createDebugPrintInst("", I0);
-    builder.createQuantizationProfileInst("", I0, B0);
+    builder.createQuantizationProfileInst("", I0, B0, ComputationInfo);
   }
   M.verify();
 }

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -288,7 +288,8 @@ int main(int argc, char **argv) {
 
   BB.newInstr("QuantizationProfile")
       .addOperand("InputTensor", OperandKind::In)
-      .addOperand("Histogram", OperandKind::InOut);
+      .addOperand("Histogram", OperandKind::InOut)
+      .addOperand("ComputationInfo", OperandKind::InOut);
 
   return 0;
 }

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -251,8 +251,11 @@ int main(int argc, char **argv) {
   BB.newNode("QuantizationProfile")
       .addInput("Input")
       .addInput("Histogram")
-      .addExtraMethod("Variable *getVariable() const { return "
+      .addInput("ComputationInfo")
+      .addExtraMethod("Variable *getHistogramVar() const { return "
                       "llvm::cast<Variable>(Histogram_.getNode()); };")
+      .addExtraMethod("Variable *getComputationInfoVar() const { return "
+                      "llvm::cast<Variable>(ComputationInfo_.getNode()); };")
       .setDocstring(
           "Generate profile (distribution of values) of the Input tensor. "
           "This data is used for quantization of the tensor later on.")


### PR DESCRIPTION
For profiling we need
1) Tensor we'd like to profile;
2) Histogram of values we captured so far;
3) Min/Max value to recalculate histogram buckets as we do not know min/max value in advance.

This PR adds 3.