### PR TITLE
[JIT] Add target-specific flags to the code generator

### DIFF
--- a/lib/Backends/JIT/CMakeLists.txt
+++ b/lib/Backends/JIT/CMakeLists.txt
@@ -13,6 +13,7 @@ add_custom_command(OUTPUT
                    DEPENDS ${LIBJITSRC}
                    COMMENT "Clang: Generating runtime bytecode library." VERBATIM)
 add_library(JIT
+            GlowJIT.cpp
             JIT.cpp)
 
 target_link_libraries(JIT

--- a/lib/Backends/JIT/GlowJIT.cpp
+++ b/lib/Backends/JIT/GlowJIT.cpp
@@ -1,0 +1,74 @@
+// Copyright 2017 Facebook Inc.  All Rights Reserved.
+
+#include "GlowJIT.h"
+
+using GlowJIT = llvm::orc::GlowJIT;
+
+/// Generate the LLVM MAttr list of attributes.
+static llvm::SmallVector<std::string, 0> getMachineAttributes() {
+  llvm::SmallVector<std::string, 0> result;
+  llvm::StringMap<bool> hostFeatures;
+  if (llvm::sys::getHostCPUFeatures(hostFeatures)) {
+    for (auto &feature : hostFeatures) {
+      if (feature.second) {
+        llvm::StringRef fn = feature.first();
+        // Skip avx512 because LLVM does not support it well.
+        if (fn.startswith("avx512")) {
+          continue;
+        }
+        result.push_back(fn);
+      }
+    }
+  }
+  return result;
+}
+
+/// Returns the CPU hostname.
+static llvm::StringRef getHostCpuName() {
+  auto cpu_name = llvm::sys::getHostCPUName();
+  // Skip avx512 because LLVM does not support it well.
+  cpu_name.consume_back("-avx512");
+  return cpu_name;
+}
+
+GlowJIT::GlowJIT()
+    : TM(EngineBuilder().selectTarget(llvm::Triple(), "", getHostCpuName(),
+                                      getMachineAttributes())),
+      DL(TM->createDataLayout()),
+      ObjectLayer([]() { return std::make_shared<SectionMemoryManager>(); }),
+      CompileLayer(ObjectLayer, SimpleCompiler(*TM)) {
+  llvm::sys::DynamicLibrary::LoadLibraryPermanently(nullptr);
+}
+
+GlowJIT::ModuleHandle GlowJIT::addModule(std::unique_ptr<Module> M) {
+  // Build our symbol resolver:
+  // Lambda 1: Look back into the JIT itself to find symbols that are part of
+  //           the same "logical dylib".
+  // Lambda 2: Search for external symbols in the host process.
+  auto Resolver = createLambdaResolver(
+      [&](const std::string &Name) {
+        if (auto Sym = CompileLayer.findSymbol(Name, false))
+          return Sym;
+        return JITSymbol(nullptr);
+      },
+      [](const std::string &Name) {
+        if (auto SymAddr = RTDyldMemoryManager::getSymbolAddressInProcess(Name))
+          return JITSymbol(SymAddr, JITSymbolFlags::Exported);
+        return JITSymbol(nullptr);
+      });
+
+  // Add the set to the JIT with the resolver we created above and a newly
+  // created SectionMemoryManager.
+  return cantFail(CompileLayer.addModule(std::move(M), std::move(Resolver)));
+}
+
+llvm::JITSymbol GlowJIT::findSymbol(const std::string Name) {
+  std::string MangledName;
+  raw_string_ostream MangledNameStream(MangledName);
+  Mangler::getNameWithPrefix(MangledNameStream, Name, DL);
+  return CompileLayer.findSymbol(MangledNameStream.str(), true);
+}
+
+void GlowJIT::removeModule(GlowJIT::ModuleHandle H) {
+  cantFail(CompileLayer.removeModule(H));
+}

--- a/lib/Backends/JIT/JIT.cpp
+++ b/lib/Backends/JIT/JIT.cpp
@@ -32,9 +32,10 @@ using namespace glow;
 using llvm::StringRef;
 using llvm::isa;
 
-static llvm::cl::opt<bool> optimizeIR("dump-llvm-ir",
-                                      llvm::cl::desc("Dump the LLVM-IR during the JIT compilation phase"),
-                                      llvm::cl::init(false), llvm::cl::Hidden);
+static llvm::cl::opt<bool>
+    dumpIR("dump-llvm-ir",
+           llvm::cl::desc("Dump the LLVM-IR during the JIT compilation phase"),
+           llvm::cl::init(false), llvm::cl::Hidden);
 
 /// Optimize the module that contain the function \p F.
 static void optimizeLLVMModule(llvm::Function *F, llvm::TargetMachine &TM) {
@@ -80,7 +81,7 @@ static void optimizeLLVMModule(llvm::Function *F, llvm::TargetMachine &TM) {
   FPM.doFinalization();
   PM.run(*F->getParent());
 
-  if (optimizeIR) {
+  if (dumpIR) {
     M->print(llvm::errs(), nullptr);
   }
 }


### PR DESCRIPTION
This allows the code generator to use the latest cpu instructions. These CPU features are detected at runtime. In theory the code should run on ARM now without any modifications. 