### PR TITLE
getNthInput should return a reference to NodeValue

### DIFF
--- a/include/glow/Graph/Node.h
+++ b/include/glow/Graph/Node.h
@@ -139,7 +139,8 @@ public:
   /// Getters to access Node's inputs and outputs.
   unsigned getNumInputs() const;
   llvm::StringRef getInputName(unsigned idx) const;
-  NodeValue getNthInput(unsigned idx) const;
+  NodeValue &getNthInput(unsigned idx);
+  const NodeValue &getNthInput(unsigned idx) const;
   llvm::StringRef getOutputName(unsigned idx) const;
   bool hasSideEffects() const;
 

--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -65,7 +65,7 @@ public:
 
   unsigned getNumInputs() const;
   llvm::StringRef getInputName(unsigned idx) const;
-  NodeValue getNthInput(unsigned idx) const;
+  NodeValue &getNthInput(unsigned idx);
   llvm::StringRef getOutputName(unsigned idx) const;
   bool hasSideEffects() const;
   std::string getDebugDesc() const;

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -280,7 +280,7 @@ unsigned Variable::getNumInputs() const { return 0; }
 llvm::StringRef Variable::getInputName(unsigned idx) const {
   llvm_unreachable("Invalid index");
 }
-NodeValue Variable::getNthInput(unsigned idx) const {
+NodeValue &Variable::getNthInput(unsigned idx) {
   llvm_unreachable("Invalid index");
 }
 llvm::StringRef Variable::getOutputName(unsigned idx) const {
@@ -314,11 +314,22 @@ llvm::StringRef Node::getInputName(unsigned idx) const {
     llvm_unreachable("Unhandled node");
   }
 }
-NodeValue Node::getNthInput(unsigned idx) const {
+NodeValue &Node::getNthInput(unsigned idx) {
   switch (getKind()) {
 #define DEF_NODE(CLASS, NAME)                                                  \
   case glow::Kinded::Kind::CLASS##Kind:                                        \
-    return static_cast<const CLASS *>(this)->getNthInput(idx);
+    return static_cast<CLASS *>(this)->getNthInput(idx);
+#include "AutoGenNodes.def"
+  default:
+    llvm_unreachable("Unhandled node");
+  }
+}
+
+const NodeValue &Node::getNthInput(unsigned idx) const {
+  switch (getKind()) {
+#define DEF_NODE(CLASS, NAME)                                                  \
+  case glow::Kinded::Kind::CLASS##Kind:                                        \
+    return static_cast<CLASS *>(const_cast<Node *>(this))->getNthInput(idx);
 #include "AutoGenNodes.def"
   default:
     llvm_unreachable("Unhandled node");

--- a/tools/ClassGen/NodeBuilder.cpp
+++ b/tools/ClassGen/NodeBuilder.cpp
@@ -163,7 +163,7 @@ void NodeBuilder::emitEdges(std::ostream &os) const {
   os << "\t\tllvm_unreachable(\"Invalid index\");\n"
      << "}\n";
 
-  os << "NodeValue " << name_ << "Node::getNthInput(unsigned idx) const {\n";
+  os << "NodeValue &" << name_ << "Node::getNthInput(unsigned idx) {\n";
   for (size_t i = 0; i < nodeInputs_.size(); i++) {
     os << "\t\tif (idx == " << i << ") { return " << nodeInputs_[i] << "_; }\n";
   }
@@ -337,7 +337,7 @@ void NodeBuilder::emitNodeClass(std::ostream &os) const {
 
   os << "\tllvm::StringRef getInputName(unsigned idx) const;\n";
 
-  os << "\tNodeValue getNthInput(unsigned idx) const;\n";
+  os << "\tNodeValue &getNthInput(unsigned idx);\n";
 
   os << "\tllvm::StringRef getOutputName(unsigned idx) const;\n";
 


### PR DESCRIPTION
This avoids registering useless new Node uses for the temporary copies of NodeValues.