### PR TITLE
[quantization profile] Fix init type of vars to allow them to be mutable.

### DIFF
--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -446,13 +446,15 @@ QuantizationProfileNode *Graph::createQuantizationProfile(llvm::StringRef name,
                                                           NodeValue input) {
   // TODO: this size is going to be refined. Just a placeholder now.
   const size_t numberOfBuckets = 2000U;
-  auto *histogram = createVariable(ElemKind::FloatTy, {numberOfBuckets},
-                                   "histogram", Variable::InitKind::Extern);
+  auto *histogram =
+      createVariable(ElemKind::FloatTy, {numberOfBuckets}, "histogram",
+                     Variable::InitKind::Broadcast, 0);
   // Intermediate data used for histogram calculations.
   // Min tensor value seen so far is kept on the first position.
   // Max tensor value seen so far is kept on the second position.
-  auto *computationInfo = createVariable(
-      ElemKind::FloatTy, {2}, "computationInfo", Variable::InitKind::Extern);
+  auto *computationInfo =
+      createVariable(ElemKind::FloatTy, {2}, "computationInfo",
+                     Variable::InitKind::Broadcast, 0);
 
   return addNode(
       new QuantizationProfileNode(name, input, histogram, computationInfo));

--- a/lib/IR/IRGen.cpp
+++ b/lib/IR/IRGen.cpp
@@ -546,15 +546,12 @@ public:
       break;
     }
     case glow::Kinded::Kind::QuantizationProfileNodeKind: {
-      auto *quantizationProfileNode = cast<QuantizationProfileNode>(N);
-      auto *inputTensor = valueForNode(quantizationProfileNode->getInput());
-      auto *histogram =
-          valueForNode(quantizationProfileNode->getHistogramVar());
-      auto *computationInfo =
-          valueForNode(quantizationProfileNode->getComputationInfoVar());
-      builder_.createQuantizationProfileInst(quantizationProfileNode->getName(),
-                                             inputTensor, histogram,
-                                             computationInfo);
+      auto *QPN = cast<QuantizationProfileNode>(N);
+      auto *inputTensor = valueForNode(QPN->getInput());
+      auto *histogram = valueForNode(QPN->getHistogramVar());
+      auto *computationInfo = valueForNode(QPN->getComputationInfoVar());
+      builder_.createQuantizationProfileInst(QPN->getName(), inputTensor,
+                                             histogram, computationInfo);
       break;
     }
 

--- a/tests/unittests/InterpreterTest.cpp
+++ b/tests/unittests/InterpreterTest.cpp
@@ -56,6 +56,24 @@ TEST(Interpreter, interpret) {
   EE.run({input}, {&inputs});
 }
 
+TEST(Interpreter, profileQuantizationForANetwork) {
+  ExecutionEngine EE;
+  auto &G = EE.getGraph();
+  Tensor inputs(ElemKind::FloatTy, {1, 4});
+
+  auto *A = G.createVariable(ElemKind::FloatTy, {1, 4}, "A");
+  auto *Ex = G.createVariable(ElemKind::FloatTy, {1, 4}, "E");
+  Node *O = G.createFullyConnected("fc", A, 4);
+  O = G.createRELU("relu", O);
+  O = G.createRegression("reg", O, Ex);
+
+  ::glow::profileQuantization(G);
+
+  EE.compile(CompilationMode::Infer);
+
+  EE.run({A}, {&inputs});
+}
+
 TEST(Interpreter, trainASimpleNetwork) {
   ExecutionEngine EE;
   // Learning a single input vector.


### PR DESCRIPTION
* Explicitly initialize vars equal to 0 and make them mutable.
* Cosmetic changes in lib/IR/IRGen.cpp.
* Add a simple test to run interpreter through profileQuantization nodes.