### PR TITLE
[CI] osx travis build could block other jobs and takes way too long to be scheduled.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,20 +7,6 @@ compiler: clang
 matrix:
   fast_finish: true
   include:
-    - os: osx
-      before_install:
-        - brew update
-        - brew install ninja llvm protobuf libpng
-      install:
-        - mkdir build && cd build
-        - cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DGLOW_WITH_OPENCL=OFF -DCMAKE_PREFIX_PATH=/usr/local/Cellar/llvm/5.0.1/lib/cmake/llvm/ ../
-    - os: osx
-      before_install:
-        - brew update
-        - brew install ninja llvm protobuf libpng
-      install:
-        - mkdir build && cd build
-        - cmake -G Ninja -DGLOW_USE_SANITIZER="Address;Undefined" -DCMAKE_BUILD_TYPE=Debug -DGLOW_WITH_OPENCL=OFF -DCMAKE_PREFIX_PATH=/usr/local/Cellar/llvm/5.0.1/lib/cmake/llvm/ ../
     - os: linux
       before_install:
         - sudo apt-get -qq update
@@ -28,7 +14,13 @@ matrix:
       install:
         - mkdir build && cd build
         - cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DGLOW_WITH_OPENCL=OFF ../
-      dist: trusty
+    - os: linux
+      before_install:
+        - sudo apt-get -qq update
+        - sudo apt-get install -y ninja-build llvm ocl-icd-opencl-dev libprotobuf-dev protobuf-compiler libpng-dev
+      install:
+        - mkdir build && cd build
+        - cmake -G Ninja -DGLOW_USE_SANITIZER="Address;Undefined" -DCMAKE_BUILD_TYPE=Debug -DGLOW_WITH_OPENCL=OFF ../
 
 script:
  - ninja all


### PR DESCRIPTION
Appears that it takes quite some time to schedule osx travis build.
Currently, it takes more than an hour to dequeue Travis job from the queue.

This PR allows to run just linux builds.