### PR TITLE
Revert "[build fix] Make dtor for Instruction virtual."

### DIFF
--- a/include/glow/IR/IR.h
+++ b/include/glow/IR/IR.h
@@ -117,7 +117,7 @@ public:
     }
   }
 
-  virtual ~Instruction() {
+  ~Instruction() {
     for (unsigned idx = 0, e = ops_.size(); idx < e; ++idx) {
       setOperand(idx, nullptr);
     }


### PR DESCRIPTION
Reverts facebookexternal/Glow#330
We try to avoid using virtual functions. This issue will be fixed in a different way.