### PR TITLE
[JIT] Remove SoftMaxWithE instruction everywhere

### DIFF
--- a/include/glow/IR/IRBuilder.h
+++ b/include/glow/IR/IRBuilder.h
@@ -53,8 +53,6 @@ public:
 
   SoftMaxInst *createSoftMaxOp(Value *input, Value *selected);
 
-  SoftMaxWithEInst *createSoftMaxWithEOp(Value *input, Value *selected);
-
   ReshapeInst *createReshapeOp(Value *input, llvm::ArrayRef<size_t> shape);
 
   TensorViewInst *createTensorView(ElemKind elemKind,

--- a/lib/IR/IRBuilder.cpp
+++ b/lib/IR/IRBuilder.cpp
@@ -126,15 +126,6 @@ SoftMaxInst *IRBuilder::createSoftMaxOp(Value *input, Value *selected) {
   return createSoftMaxInst("softmax", res, input, selected);
 }
 
-SoftMaxWithEInst *IRBuilder::createSoftMaxWithEOp(Value *input,
-                                                  Value *selected) {
-  auto *res = createAllocActivationInst("softmax.res", input->getType());
-  auto *E = createAllocActivationInst("e_cache", input->getType());
-  // Initialize E, because it is an inout parameter.
-  createSplatInst("zero", E, 0.0);
-  return createSoftMaxWithEInst("softmax", res, input, E, selected);
-}
-
 ReshapeInst *IRBuilder::createReshapeOp(Value *input,
                                         llvm::ArrayRef<size_t> shape) {
   auto *res =

--- a/lib/IR/IRGen.cpp
+++ b/lib/IR/IRGen.cpp
@@ -261,7 +261,7 @@ public:
       auto *SM = cast<SoftMaxNode>(N);
       auto *in = valueForNode(SM->getInput());
       auto *select = valueForNode(SM->getSelected());
-      auto *V = builder_.createSoftMaxWithEOp(in, select);
+      auto *V = builder_.createSoftMaxOp(in, select);
       V->setName(N->getName());
       registerIR(N, V->getDest());
       nodeToInstr_[N] = V;
@@ -277,12 +277,11 @@ public:
       auto originalNodeResult = SMG->getOriginalOutputForResult();
       assert(nodeToInstr_.count(originalNodeResult.getNode()) &&
              "Unknown original node");
-      auto *SM = cast<SoftMaxWithEInst>(nodeToInstr_[originalNodeResult]);
+      auto *origOut = valueForNode(originalNodeResult);
       auto *srcGrad = builder_.createAllocActivationInst("softmax.res.grad",
                                                          outGrad->getType());
-
-      auto *SMGI = builder_.createSoftMaxWithEGradInst(
-          N->getName(), origIn, SM->getE(), origSelect, srcGrad);
+      auto *SMGI = builder_.createSoftMaxGradInst(N->getName(), origOut, origIn,
+                                                  origSelect, srcGrad);
 
       registerIR(SMG->getGradOfInputNamedInput(), SMGI->getSrcGrad());
       break;

--- a/lib/IR/Instrs.cpp
+++ b/lib/IR/Instrs.cpp
@@ -189,13 +189,21 @@ void BatchedMatMulInst::verify() const {
 void SigmoidInst::verify() const {
   checkSameType(getOperand(0), getOperand(1));
 }
+
 void TanhInst::verify() const { checkSameType(getOperand(0), getOperand(1)); }
+
 void SoftMaxInst::verify() const {
   checkSameType(getOperand(0), getOperand(1));
+  assert(getDest()->dims() == getSrc()->dims() && "Invalid shape");
 }
 
-void SoftMaxWithEInst::verify() const {
+void SoftMaxGradInst::verify() const {
   checkSameType(getOperand(0), getOperand(1));
+  checkSameType(getOperand(0), getOperand(3));
+  auto destShape = getDest()->dims();
+  assert(destShape == getSrc()->dims() && "Invalid shape");
+  assert(destShape == getSrcGrad()->dims() && "Invalid shape");
+  (void)destShape;
 }
 
 void ReshapeInst::verify() const {
@@ -388,6 +396,5 @@ NOVERIFY(PoolMaxWithXYGradInst)
 NOVERIFY(PoolAvgGradInst)
 NOVERIFY(BatchNormalizationGradInst)
 NOVERIFY(LocalResponseNormalizationGradInst)
-NOVERIFY(SoftMaxWithEGradInst)
 NOVERIFY(DebugPrintInst)
 #undef NOVERIFY

--- a/lib/Optimizer/IROptimizer.cpp
+++ b/lib/Optimizer/IROptimizer.cpp
@@ -949,28 +949,6 @@ void performPeepholeOptimizations(Module &M) {
       continue;
     }
 
-    // SoftMaxWithXYInst -> SoftMaxInst.
-    if (auto *SMI = dyn_cast<SoftMaxWithEInst>(I)) {
-      auto *E = SMI->getE();
-      // Optimize only if the cache is read exactly once,
-      // namely by this instruction.
-      bool isUsedE = false;
-      for (auto &U : ValueUses(getOrigin(E))) {
-        if (U.getOperand().second != OperandKind::Out && U.get() != SMI) {
-          isUsedE = true;
-          break;
-        }
-      }
-      if (isUsedE)
-        continue;
-
-      auto *NewSMI = B.createSoftMaxInst(SMI->getName(), SMI->getDest(),
-                                         SMI->getSrc(), SMI->getSelected());
-      it = M.moveInstruction(cur, NewSMI);
-      M.eraseInstruction(cur);
-      continue;
-    }
-
     // reshape -> tensorview, copy
     if (auto *RI = dyn_cast<ReshapeInst>(I)) {
       auto *TVI = B.createTensorViewInst(RI->getName(), RI->getSrc(),

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -1,4 +1,5 @@
-// Copyright 2017 Facebook Inc.  All Rights Reserved.
+// Copyright 2017 Facebook Inc. All Rights Reserved.
+
 #include "InstrBuilder.h"
 
 #include <fstream>
@@ -130,20 +131,12 @@ int main(int argc, char **argv) {
   //                      Loss operations
   //===--------------------------------------------------------------------===//
 
-  // SoftMax version caching Expected to speedup gradient-based computations.
-  BB.newInstr("SoftMaxWithE")
-      .addOperand("Dest", OperandKind::Out)
-      .addOperand("Src", OperandKind::In)
-      .addOperand("E", OperandKind::InOut)
-      .addOperand("Selected", OperandKind::In)
-      .inplaceOperand({"Dest", "Src"})
-      .addGradientInstr({"Src", "E", "Selected"}, {"Src"});
-
   BB.newInstr("SoftMax")
       .addOperand("Dest", OperandKind::Out)
       .addOperand("Src", OperandKind::In)
       .addOperand("Selected", OperandKind::In)
-      .inplaceOperand({"Dest", "Src"});
+      .inplaceOperand({"Dest", "Src"})
+      .addGradientInstr({"Dest", "Src", "Selected"}, {"Src"});
 
   //===--------------------------------------------------------------------===//
   //                      Arithmetic


### PR DESCRIPTION
This commit removes the seemingly-redundant E tensor from the SoftMax instruction and replaces instances of SoftMaxWithE with SoftMax (as well as for the Grad).