### PR TITLE
[JIT] Accelerate conv by unrolling the K loop 4 times. This reduces t…

### DIFF
--- a/lib/Backends/JIT/LLVMIRGen.cpp
+++ b/lib/Backends/JIT/LLVMIRGen.cpp
@@ -188,7 +188,15 @@ void JITBackend::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     auto *stride = emitConst(builder, CI->getStride());
     auto *pad = emitConst(builder, CI->getPad());
 
-    auto *F = llmodule_->getFunction("convolution_f");
+    const char *kernelName = "convolution_f";
+
+    // Use a special version of the kernel for the case where K (the depth of
+    // the convolution) is a multiple of 4.
+    if ((CI->getDest()->dims()[3] % 4) == 0) {
+      kernelName = "convolution_f_unroll_k4";
+    }
+
+    auto *F = llmodule_->getFunction(kernelName);
     assert(F && "Unable to load the function");
     builder.CreateCall(F,
                        {srcPtr, destPtr, filterPtr, biasPtr, srcDims, destDims,


### PR DESCRIPTION
…he memory bandwidth because we iterate on the image K/4 times. This is a form of tiling. The speedup is about 15%.