### PR TITLE
[profile quantization] Do not profile index nodes.

### DIFF
--- a/lib/Optimizer/Quantization.cpp
+++ b/lib/Optimizer/Quantization.cpp
@@ -20,6 +20,9 @@ void glow::profileQuantization(Graph &G) {
     // Add Quantization Profile node to parent's output linked to the
     // i-th input of the current node.
     for (unsigned i = 0; i < node->getNumInputs(); ++i) {
+      if (node->getNthInput(i).getElementType() != ElemKind::FloatTy) {
+        continue;
+      }
       nodesToInstrument.insert(node->getNthInput(i));
     }
   }


### PR DESCRIPTION
Was loading and profiling resnet with the loader and there is a single node (softmax_expected_3) which had IndexTy type of output.

Allow only float outputs.