### PR TITLE
Remove the select input from the forward SoftMax instruction.

### DIFF
--- a/include/glow/IR/IRBuilder.h
+++ b/include/glow/IR/IRBuilder.h
@@ -51,7 +51,7 @@ public:
 
   TanhInst *createTanhOp(Value *input);
 
-  SoftMaxInst *createSoftMaxOp(Value *input, Value *selected);
+  SoftMaxInst *createSoftMaxOp(Value *input);
 
   ReshapeInst *createReshapeOp(Value *input, llvm::ArrayRef<size_t> shape);
 

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -444,7 +444,7 @@ void Interpreter::fwdSoftMaxInst(bool isTrain, const SoftMaxInst *I) {
 void Interpreter::fwdSoftMaxGradInst(bool isTrain, const SoftMaxGradInst *I) {
   auto inG = getWeightHandle(I->getSrcGrad());
   auto idim = inG.dims();
-  auto outW = getWeightHandle(I->getDest());
+  auto outW = getWeightHandle(I->getOrigDest());
   auto selectedH = getTensor(I->getSelected())->getHandle<size_t>();
 
   inG.clear();

--- a/lib/Backends/OpenCL/kernels.cl
+++ b/lib/Backends/OpenCL/kernels.cl
@@ -178,8 +178,7 @@ __kernel void elementdivW(__global void *mem, size_t dest, size_t LHS,
 }
 
 __kernel void softmaxK(__global float *dest, __global float *src,
-                       __global float *e_cache, __global unsigned *selected,
-                       size_t sliceSize) {
+                       __global float *e_cache, size_t sliceSize) {
   size_t i = get_global_id(0);
   float max_ = src[i * sliceSize];
   for (size_t j = 0; j < sliceSize; j++) {
@@ -199,15 +198,8 @@ __kernel void softmaxK(__global float *dest, __global float *src,
 }
 
 __kernel void softmaxW(__global void *mem, size_t dest, size_t src,
-                       size_t selected, size_t sliceSize) {
-  softmaxK(&mem[dest], &mem[src], (__global float *)0,
-           (__global unsigned *)&mem[selected], sliceSize);
-}
-
-__kernel void softmaxwitheW(__global void *mem, size_t dest, size_t src,
-                            size_t e_cache, size_t selected, size_t sliceSize) {
-  softmaxK(&mem[dest], &mem[src], &mem[e_cache],
-          (__global unsigned *)&mem[selected], sliceSize);
+                       size_t sliceSize) {
+  softmaxK(&mem[dest], &mem[src], (__global float *)0, sliceSize);
 }
 
 __kernel void convolutionK(__global float *dest, __global float *src,

--- a/lib/IR/IRBuilder.cpp
+++ b/lib/IR/IRBuilder.cpp
@@ -121,9 +121,9 @@ TanhInst *IRBuilder::createTanhOp(Value *input) {
   return createTanhInst("tanh", res, input);
 }
 
-SoftMaxInst *IRBuilder::createSoftMaxOp(Value *input, Value *selected) {
+SoftMaxInst *IRBuilder::createSoftMaxOp(Value *input) {
   auto *res = createAllocActivationInst("softmax.res", input->getType());
-  return createSoftMaxInst("softmax", res, input, selected);
+  return createSoftMaxInst("softmax", res, input);
 }
 
 ReshapeInst *IRBuilder::createReshapeOp(Value *input,

--- a/lib/IR/IRGen.cpp
+++ b/lib/IR/IRGen.cpp
@@ -260,8 +260,7 @@ public:
     case glow::Kinded::Kind::SoftMaxNodeKind: {
       auto *SM = cast<SoftMaxNode>(N);
       auto *in = valueForNode(SM->getInput());
-      auto *select = valueForNode(SM->getSelected());
-      auto *V = builder_.createSoftMaxOp(in, select);
+      auto *V = builder_.createSoftMaxOp(in);
       V->setName(N->getName());
       registerIR(N, V->getDest());
       nodeToInstr_[N] = V;

--- a/lib/IR/Instrs.cpp
+++ b/lib/IR/Instrs.cpp
@@ -200,8 +200,8 @@ void SoftMaxInst::verify() const {
 void SoftMaxGradInst::verify() const {
   checkSameType(getOperand(0), getOperand(1));
   checkSameType(getOperand(0), getOperand(3));
-  auto destShape = getDest()->dims();
-  assert(destShape == getSrc()->dims() && "Invalid shape");
+  auto destShape = getOrigDest()->dims();
+  assert(destShape == getOrigSrc()->dims() && "Invalid shape");
   assert(destShape == getSrcGrad()->dims() && "Invalid shape");
   (void)destShape;
 }

--- a/tests/unittests/basicIRTest.cpp
+++ b/tests/unittests/basicIRTest.cpp
@@ -95,7 +95,6 @@ TEST(IR, allInstrs) {
     auto *I3 = builder.createWeightVar(ElemKind::FloatTy, {1, 12, 12, 64});
     auto *I4 = builder.createWeightVar(ElemKind::FloatTy, {1, 12, 12, 3});
     auto *I6 = builder.createWeightVar(ElemKind::FloatTy, {2, 12, 12, 64});
-    auto *I7 = builder.createWeightVar(T1, "I7");
     auto *I8 = builder.createWeightVar(ElemKind::FloatTy, {1, 24, 3, 24}, "I8");
     auto *ComputationInfo =
         builder.createWeightVar(ElemKind::FloatTy, {2}, "ComputationInfo");
@@ -121,7 +120,7 @@ TEST(IR, allInstrs) {
     builder.createPoolMaxInst("", I4, I0, 7, 2, 3);
     builder.createSigmoidInst("", I1, I0);
     builder.createTanhInst("", I1, I0);
-    builder.createSoftMaxInst("", I1, I0, I7);
+    builder.createSoftMaxInst("", I1, I0);
     builder.createTransposeInst("", I8, I2, {0, 3, 1, 2});
     builder.createTensorView(ElemKind::FloatTy, {1, 24, 3, 24}, I2, "I2_view");
     builder.createInsertTensorInst("", I6, I3, {0, 0, 0, 0});

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -128,15 +128,19 @@ int main(int argc, char **argv) {
       .addGradientInstr({"Dest", "Src", "Scale"}, {"Dest", "Src"});
 
   //===--------------------------------------------------------------------===//
-  //                      Loss operations
+  //                      Loss functions
   //===--------------------------------------------------------------------===//
 
   BB.newInstr("SoftMax")
       .addOperand("Dest", OperandKind::Out)
       .addOperand("Src", OperandKind::In)
+      .inplaceOperand({"Dest", "Src"});
+
+  BB.newInstr("SoftMaxGrad")
+      .addOperand("OrigDest", OperandKind::In)
+      .addOperand("OrigSrc", OperandKind::In)
       .addOperand("Selected", OperandKind::In)
-      .inplaceOperand({"Dest", "Src"})
-      .addGradientInstr({"Dest", "Src", "Selected"}, {"Src"});
+      .addOperand("SrcGrad", OperandKind::Out);
 
   //===--------------------------------------------------------------------===//
   //                      Arithmetic


### PR DESCRIPTION
SoftMax does not use 'select' as part of the forward pass. 