### PR TITLE
[Caffe2 loader] Speed up the caffe2 model loading.

### DIFF
--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -69,7 +69,8 @@ TypeRef Graph::getVoidTy() { return uniqueType(Type()); }
 Variable *Graph::createVariable(TypeRef T, llvm::StringRef name,
                                 Variable::VisibilityKind visibility,
                                 Variable::TrainKind train, float val) {
-  return addVar(new Variable(name, T, visibility, train, val));
+  auto FT = uniqueType(*T);
+  return addVar(new Variable(name, FT, visibility, train, val));
 }
 
 Variable *Graph::createVariable(ElemKind T, llvm::ArrayRef<size_t> dims,
@@ -167,6 +168,7 @@ ConvolutionNode *Graph::createConv(llvm::StringRef name, NodeValue input,
   ShapeNHWC idim = ShapeNHWC(input.dims());
   assert(idim.w >= kernel && idim.h >= kernel &&
          "buffer too small for selected stride");
+  (void)idim;
 
   auto filterDims = filter->dims();
   assert(filterDims[0] == depth && filterDims[1] == kernel &&

--- a/tests/unittests/graphTest.cpp
+++ b/tests/unittests/graphTest.cpp
@@ -1,7 +1,7 @@
 // Copyright 2017 Facebook Inc.  All Rights Reserved.
 
-#include "glow/ExecutionEngine/ExecutionEngine.h"
 #include "glow/Graph/Graph.h"
+#include "glow/ExecutionEngine/ExecutionEngine.h"
 #include "glow/Graph/Node.h"
 #include "glow/Graph/Nodes.h"
 #include "glow/IR/IR.h"
@@ -143,4 +143,3 @@ TEST(Graph, simpleQuant) {
   G.createSave("ret", O);
   EE.compile(CompilationMode::Infer);
 }
-


### PR DESCRIPTION
[Caffe2 loader] Speed up the caffe2 model loading.

Before this change we were creating convolutions and initialized the conv values to random values before loading the weights from the file. This change removes the random initialization and speeds the loading process significantly (~13%).