### PR TITLE
[Caffe2 loader] Allow for larger concats

### DIFF
--- a/lib/Importer/Caffe2.cpp
+++ b/lib/Importer/Caffe2.cpp
@@ -327,7 +327,8 @@ void caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
   if (typeName == "Concat") {
     const unsigned numInputs = op.input_size();
     llvm::SmallVector<Node *, 4> inputs;
-    for (int i = 0; i < numInputs; i++) {
+    inputs.reserve(numInputs);
+    for (unsigned i = 0; i < numInputs; i++) {
       inputs.push_back(getOrCreateNodeByName(op.input(i)));
     }
 


### PR DESCRIPTION
Caffe2 allows for concatenating an arbitrary number of tensors, so this allows for that. Before the code was concatenating the first two and ignoring the rest.