### PR TITLE
Made {kernel, stride, pad} usage consistent across codebase

### DIFF
--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -102,9 +102,9 @@ using VariableNode = Variable;
 /// Calculate the size of the output tensor based on the convolution
 /// parameters.
 inline std::pair<size_t, size_t> calculateConvOutputDims(size_t sx, size_t sy,
-                                                         size_t pad,
                                                          size_t filterSize,
-                                                         size_t stride) {
+                                                         size_t stride,
+                                                         size_t pad) {
   size_t outsx = ((sx + pad * 2 - filterSize) / stride + 1);
   size_t outsy = ((sy + pad * 2 - filterSize) / stride + 1);
   return {outsx, outsy};

--- a/lib/Backends/JIT/LLVMIRGen.cpp
+++ b/lib/Backends/JIT/LLVMIRGen.cpp
@@ -230,7 +230,7 @@ void JITBackend::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     assert(F && "Unable to load the function");
     builder.CreateCall(F,
                        {srcPtr, destPtr, filterPtr, biasPtr, srcDims, destDims,
-                        filterDims, biasDims, kernel, pad, stride});
+                        filterDims, biasDims, kernel, stride, pad});
     break;
   }
 
@@ -248,7 +248,7 @@ void JITBackend::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     auto *F = getFunction("pool_max_f");
     assert(F && "Unable to load the function");
     builder.CreateCall(
-        F, {srcPtr, destPtr, srcDims, destDims, pad, kernel, stride});
+        F, {srcPtr, destPtr, srcDims, destDims, kernel, stride, pad});
     break;
   }
 
@@ -266,7 +266,7 @@ void JITBackend::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     auto *F = getFunction("pool_avg_f");
     assert(F && "Unable to load the function");
     builder.CreateCall(
-        F, {srcPtr, destPtr, srcDims, destDims, pad, kernel, stride});
+        F, {srcPtr, destPtr, srcDims, destDims, kernel, stride, pad});
     break;
   }
 

--- a/lib/Backends/JIT/libjit.c
+++ b/lib/Backends/JIT/libjit.c
@@ -152,7 +152,7 @@ void convolution_f_unroll_k4(const float *inW, float *outW,
                              const float *filterW, const float *biasW,
                              const size_t *inWdims, const size_t *outWdims,
                              const size_t *filterWdims, const size_t *biasWdims,
-                             size_t filterSize, size_t pad, size_t stride) {
+                             size_t filterSize, size_t stride, size_t pad) {
   size_t inChannels = inWdims[3];
 
   // For each input in the batch:
@@ -218,8 +218,8 @@ void convolution_f_unroll_k4(const float *inW, float *outW,
 void convolution_f(const float *inW, float *outW, const float *filterW,
                    const float *biasW, const size_t *inWdims,
                    const size_t *outWdims, const size_t *filterWdims,
-                   const size_t *biasWdims, size_t filterSize, size_t pad,
-                   size_t stride) {
+                   const size_t *biasWdims, size_t filterSize, size_t stride,
+                   size_t pad) {
 
   size_t inChannels = inWdims[3];
 
@@ -263,8 +263,8 @@ void convolution_f(const float *inW, float *outW, const float *filterW,
 }
 
 void pool_max_f(const float *inW, float *outW, const size_t *inWdims,
-                const size_t *outWdims, size_t pad, size_t filterSize,
-                size_t stride) {
+                const size_t *outWdims, size_t filterSize, size_t stride,
+                size_t pad) {
   // For each input in the batch:
   for (size_t n = 0; n < outWdims[0]; n++) {
 
@@ -306,8 +306,8 @@ void pool_max_f(const float *inW, float *outW, const size_t *inWdims,
 }
 
 void pool_avg_f(const float *inW, float *outW, const size_t *inWdims,
-                const size_t *outWdims, size_t pad, size_t filterSize,
-                size_t stride) {
+                const size_t *outWdims, size_t filterSize, size_t stride,
+                size_t pad) {
   float filterArea = filterSize * filterSize;
   // For each input in the batch:
   for (size_t n = 0; n < outWdims[0]; n++) {

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -341,8 +341,8 @@ void OCLBackend::doForwardPass(bool isTrain) {
       auto idim = ShapeNHWC(CC->getSrc()->getType()->dims());
 
       setKernelArg<size_t>(kernel, 5, CC->getKernel());
-      setKernelArg(kernel, 6, CC->getPad());
-      setKernelArg(kernel, 7, CC->getStride());
+      setKernelArg(kernel, 6, CC->getStride());
+      setKernelArg(kernel, 7, CC->getPad());
       setKernelArg(kernel, 8, odim);
       setKernelArg(kernel, 9, idim);
       setKernelArg(kernel, 10, ShapeNHWC(CC->getFilter()->getType()->dims()));
@@ -371,8 +371,8 @@ void OCLBackend::doForwardPass(bool isTrain) {
       auto idim = ShapeNHWC(PM->getSrc()->getType()->dims());
 
       setKernelArg<size_t>(kernel, numArgs + 1, PM->getKernel());
-      setKernelArg(kernel, numArgs + 2, PM->getPad());
-      setKernelArg(kernel, numArgs + 3, PM->getStride());
+      setKernelArg(kernel, numArgs + 2, PM->getStride());
+      setKernelArg(kernel, numArgs + 3, PM->getPad());
       setKernelArg(kernel, numArgs + 4, odim);
       setKernelArg(kernel, numArgs + 5, idim);
 
@@ -396,8 +396,8 @@ void OCLBackend::doForwardPass(bool isTrain) {
       auto idim = ShapeNHWC(PM->getSrc()->getType()->dims());
 
       setKernelArg<size_t>(kernel, numArgs + 1, PM->getKernel());
-      setKernelArg(kernel, numArgs + 2, PM->getPad());
-      setKernelArg(kernel, numArgs + 3, PM->getStride());
+      setKernelArg(kernel, numArgs + 2, PM->getStride());
+      setKernelArg(kernel, numArgs + 3, PM->getPad());
       setKernelArg(kernel, numArgs + 4, odim);
       setKernelArg(kernel, numArgs + 5, idim);
 
@@ -421,8 +421,8 @@ void OCLBackend::doForwardPass(bool isTrain) {
       auto idim = ShapeNHWC(PA->getSrc()->getType()->dims());
 
       setKernelArg<size_t>(kernel, 3, PA->getKernel());
-      setKernelArg(kernel, 4, PA->getPad());
-      setKernelArg(kernel, 5, PA->getStride());
+      setKernelArg(kernel, 4, PA->getStride());
+      setKernelArg(kernel, 5, PA->getPad());
       setKernelArg(kernel, 6, odim);
       setKernelArg(kernel, 7, idim);
 

--- a/lib/Backends/OpenCL/kernels.cl
+++ b/lib/Backends/OpenCL/kernels.cl
@@ -204,7 +204,7 @@ __kernel void softmaxW(__global void *mem, size_t dest, size_t src,
 
 __kernel void convolutionK(__global float *dest, __global float *src,
                            __global float *filter, __global float *bias,
-                           size_t filterSize, size_t pad, size_t stride,
+                           size_t filterSize, size_t stride, size_t pad,
                            ShapeNHWC odim, ShapeNHWC idim,
                            ShapeNHWC filterDim) {
   size_t ax = get_global_id(0);
@@ -246,15 +246,15 @@ __kernel void convolutionK(__global float *dest, __global float *src,
 
 __kernel void convolutionW(__global void *mem, size_t dest, size_t src,
                            size_t filter, size_t bias, size_t filterSize,
-                           size_t pad, size_t stride, ShapeNHWC odim,
+                           size_t stride, size_t pad, ShapeNHWC odim,
                            ShapeNHWC idim, ShapeNHWC filterDim) {
-  convolutionK(&mem[dest], &mem[src], &mem[filter], &mem[bias], filterSize, pad,
-               stride, odim, idim, filterDim);
+  convolutionK(&mem[dest], &mem[src], &mem[filter], &mem[bias], filterSize,
+               stride, pad, odim, idim, filterDim);
 }
 
 __kernel void poolmaxK(__global float *dest, __global float *src,
-                       size_t filterSize, size_t pad,
-                       size_t stride, ShapeNHWC odim, ShapeNHWC idim) {
+                       size_t filterSize, size_t stride, size_t pad,
+                       ShapeNHWC odim, ShapeNHWC idim) {
   size_t ax = get_global_id(0);
   size_t ay = get_global_id(1);
   size_t d = get_global_id(2);
@@ -294,15 +294,14 @@ __kernel void poolmaxK(__global float *dest, __global float *src,
 }
 
 __kernel void poolmaxW(__global void *mem, size_t dest, size_t src,
-                       size_t filterSize, size_t pad,
-                       size_t stride, ShapeNHWC odim, ShapeNHWC idim) {
-  poolmaxK(&mem[dest], &mem[src], filterSize, pad, stride, odim,
-           idim);
+                       size_t filterSize, size_t stride, size_t pad,
+                       ShapeNHWC odim, ShapeNHWC idim) {
+  poolmaxK(&mem[dest], &mem[src], filterSize, stride, pad, odim, idim);
 }
 
 __kernel void poolmaxwithxyK(__global float *dest, __global float *src,
                              __global float *srcXY, size_t filterSize,
-                             size_t pad, size_t stride, ShapeNHWC odim,
+                             size_t stride, size_t pad, ShapeNHWC odim,
                              ShapeNHWC idim) {
   size_t ax = get_global_id(0);
   size_t ay = get_global_id(1);
@@ -343,14 +342,14 @@ __kernel void poolmaxwithxyK(__global float *dest, __global float *src,
 }
 
 __kernel void poolmaxwithxyW(__global void *mem, size_t dest, size_t src,
-                             size_t srcXY, size_t filterSize, size_t pad,
-                             size_t stride, ShapeNHWC odim, ShapeNHWC idim) {
-  poolmaxwithxyK(&mem[dest], &mem[src], &mem[srcXY], filterSize, pad, stride,
+                             size_t srcXY, size_t filterSize, size_t stride,
+                             size_t pad, ShapeNHWC odim, ShapeNHWC idim) {
+  poolmaxwithxyK(&mem[dest], &mem[src], &mem[srcXY], filterSize, stride, pad,
                  odim, idim);
 }
 
 __kernel void poolavgK(__global float *dest, __global float *src,
-                       size_t filterSize, size_t pad, size_t stride,
+                       size_t filterSize, size_t stride, size_t pad,
                        ShapeNHWC odim, ShapeNHWC idim) {
   size_t ax = get_global_id(0);
   size_t ay = get_global_id(1);
@@ -386,9 +385,9 @@ __kernel void poolavgK(__global float *dest, __global float *src,
 }
 
 __kernel void poolavgW(__global void *mem, size_t dest, size_t src,
-                       size_t filterSize, size_t pad, size_t stride,
+                       size_t filterSize, size_t stride, size_t pad,
                        ShapeNHWC odim, ShapeNHWC idim) {
-  poolavgK(&mem[dest], &mem[src], filterSize, pad, stride, odim, idim);
+  poolavgK(&mem[dest], &mem[src], filterSize, stride, pad, odim, idim);
 }
 
 __kernel void transposeK(__global float *dest, __global float *src,

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -140,7 +140,7 @@ ConvolutionNode *Graph::createConv(llvm::StringRef name, NodeValue input,
          "buffer too small for selected stride");
 
   // Calculate the size and allocate the output buffer.
-  auto outSz = calculateConvOutputDims(idim.h, idim.w, pad, kernel, stride);
+  auto outSz = calculateConvOutputDims(idim.h, idim.w, kernel, stride, pad);
 
   std::array<size_t, 4> outDims = {{idim.n, outSz.first, outSz.second, depth}};
 
@@ -196,7 +196,7 @@ PoolNode *Graph::createPool(llvm::StringRef name, NodeValue input,
   assert(idim.w >= kernel && idim.h >= kernel &&
          "buffer too small for selected stride");
 
-  auto outSz = calculateConvOutputDims(idim.h, idim.w, pad, kernel, stride);
+  auto outSz = calculateConvOutputDims(idim.h, idim.w, kernel, stride, pad);
 
   auto OT = uniqueType(ElemKind::FloatTy,
                        {idim.n, outSz.first, outSz.second, idim.c});

--- a/lib/IR/IRBuilder.cpp
+++ b/lib/IR/IRBuilder.cpp
@@ -47,7 +47,7 @@ PoolMaxInst *IRBuilder::createPoolMaxOp(Value *input, size_t kernel,
   assert(idim.w >= kernel && idim.h >= kernel &&
          "buffer too small for selected stride");
 
-  auto outSz = calculateConvOutputDims(idim.h, idim.w, pad, kernel, stride);
+  auto outSz = calculateConvOutputDims(idim.h, idim.w, kernel, stride, pad);
 
   Value *dest =
       createAllocActivationInst("pool.res", ElemKind::FloatTy,
@@ -62,7 +62,7 @@ PoolMaxWithXYInst *IRBuilder::createPoolMaxWithXYOp(Value *input, size_t kernel,
   assert(idim.w >= kernel && idim.h >= kernel &&
          "buffer too small for selected stride");
 
-  auto outSz = calculateConvOutputDims(idim.h, idim.w, pad, kernel, stride);
+  auto outSz = calculateConvOutputDims(idim.h, idim.w, kernel, stride, pad);
 
   // Allocate cache arrays that store the x and y coordinates of the incoming
   // gradient for each max element.
@@ -82,7 +82,7 @@ PoolAvgInst *IRBuilder::createPoolAvgOp(Value *input, size_t kernel,
   assert(idim.w >= kernel && idim.h >= kernel &&
          "buffer too small for selected stride");
 
-  auto outSz = calculateConvOutputDims(idim.h, idim.w, pad, kernel, stride);
+  auto outSz = calculateConvOutputDims(idim.h, idim.w, kernel, stride, pad);
 
   Value *dest =
       createAllocActivationInst("pool.res", ElemKind::FloatTy,

--- a/lib/IR/Instrs.cpp
+++ b/lib/IR/Instrs.cpp
@@ -67,7 +67,7 @@ static void verifyConvDims(ShapeNHWC idim, ShapeNHWC odim, size_t kernel,
   assert(idim.w >= kernel && idim.h >= kernel &&
          "buffer too small for selected stride");
 
-  auto outSz = calculateConvOutputDims(idim.h, idim.w, pad, kernel, stride);
+  auto outSz = calculateConvOutputDims(idim.h, idim.w, kernel, stride, pad);
   ShapeNHWC exp(idim.n, outSz.first, outSz.second, depth);
   (void)exp;
   assert(exp == odim && "Invalid output dimensions");
@@ -105,7 +105,7 @@ void PoolMaxInst::verify() const {
   assert(idim.w >= Kernel_ && idim.h >= Kernel_ &&
          "buffer too small for selected stride");
 
-  auto outSz = calculateConvOutputDims(idim.h, idim.w, Pad_, Kernel_, Stride_);
+  auto outSz = calculateConvOutputDims(idim.h, idim.w, Kernel_, Stride_, Pad_);
   ShapeNHWC exp(idim.n, outSz.first, outSz.second, idim.c);
   (void)exp;
   assert(exp == odim && "Unexpected output dimensions");
@@ -122,7 +122,7 @@ void PoolMaxWithXYInst::verify() const {
   assert(idim.w >= Kernel_ && idim.h >= Kernel_ &&
          "buffer too small for selected stride");
 
-  auto outSz = calculateConvOutputDims(idim.h, idim.w, Pad_, Kernel_, Stride_);
+  auto outSz = calculateConvOutputDims(idim.h, idim.w, Kernel_, Stride_, Pad_);
   ShapeNHWC exp(idim.n, outSz.first, outSz.second, idim.c);
   (void)exp;
   assert(exp == odim && "Unexpected output dimensions");
@@ -143,7 +143,7 @@ void PoolAvgInst::verify() const {
   assert(idim.w >= Kernel_ && idim.h >= Kernel_ &&
          "buffer too small for selected stride");
 
-  auto outSz = calculateConvOutputDims(idim.h, idim.w, Pad_, Kernel_, Stride_);
+  auto outSz = calculateConvOutputDims(idim.h, idim.w, Kernel_, Stride_, Pad_);
   ShapeNHWC exp(idim.n, outSz.first, outSz.second, idim.c);
   (void)exp;
   assert(exp == odim && "Unexpected output dimensions");

--- a/lib/Importer/Caffe2.cpp
+++ b/lib/Importer/Caffe2.cpp
@@ -229,7 +229,7 @@ void caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
 
     // Calculate the size and allocate the output buffer.
     ShapeNHWC idim = ShapeNHWC(tr->dims());
-    auto outSz = calculateConvOutputDims(idim.h, idim.w, pad, kernel, stride);
+    auto outSz = calculateConvOutputDims(idim.h, idim.w, kernel, stride, pad);
     std::array<size_t, 4> outDims = {
         {idim.n, outSz.first, outSz.second, depth}};
     auto outTy = G_.uniqueType(ElemKind::FloatTy, outDims);

--- a/tests/unittests/graphTest.cpp
+++ b/tests/unittests/graphTest.cpp
@@ -129,7 +129,7 @@ TEST(Graph, simpleQuant) {
                                 Variable::VisibilityKind::Private);
 
   // Calculate the size and allocate the output buffer.
-  auto outSz = calculateConvOutputDims(width, width, pad, kernel, step);
+  auto outSz = calculateConvOutputDims(width, width, kernel, step, pad);
   std::array<size_t, 4> outDims = {{1, outSz.first, outSz.second, 16}};
   auto t = G.uniqueType(glow::ElemKind::Int8QTy, outDims, 1.5, 6.7);
 


### PR DESCRIPTION
{[kernel/filterSize], stride, pad} ordering was inconsistent; now always used in this order.