### PR TITLE
Fix printing of instruction numbers

### DIFF
--- a/include/glow/IR/IR.h
+++ b/include/glow/IR/IR.h
@@ -307,22 +307,11 @@ class InstructionNumbering {
   /// Maps an instruction to its number.
   InstructionNumbersMap InstrToNum_;
   Module &M_;
+  /// Step to be used for instruction numbering.
+  size_t step_;
 
 public:
-  /// Virtual slot number to be used for instructions numbering. It helps to
-  /// distinguish reads from writes and makes comparision of live intervals
-  /// easier. LLVM used a similar approach for the linear scan register
-  /// allocator.
-  ///
-  /// For an instruction with number N, its @in operands would be considered
-  /// to be at (N+READ_SLOT), its @out operands would be at (N+WRITE_SLOT).
-  enum SLOTS {
-    READ_SLOT = 0,
-    WRITE_SLOT = 2,
-    MAX_SLOT = 4,
-  };
-
-  InstructionNumbering(Module &M);
+  InstructionNumbering(Module &M, size_t step = 1);
 
   /// Return the instruction with a given number or
   /// M.getInstrs().end() if this instruction is not assigned any number.
@@ -335,36 +324,6 @@ public:
   /// Return the number of an instruction or a negative value if no number
   /// was assigned to this instruction.
   int64_t getInstrNumber(Instruction *I) const;
-
-  /// \returns the base number of the instruction.
-  /// It is the same for all slots of a given instruction.
-  static int64_t getInstrBaseNumber(int64_t idx) {
-    return idx / MAX_SLOT * MAX_SLOT;
-  }
-
-  /// \returns true if \p idx is the instruction number of the read slot of the
-  /// instruction.
-  static bool isReadSlotNumber(int64_t idx) {
-    return idx % MAX_SLOT == READ_SLOT;
-  }
-
-  /// \returns true if \p idx is the instruction number of a write slot of the
-  /// instruction.
-  static bool isWriteSlotNumber(int64_t idx) {
-    return idx % MAX_SLOT == WRITE_SLOT;
-  }
-
-  /// \returns the instruction number of a read slot of instruction with number
-  /// \p idx.
-  static int64_t getInstrReadSlotNumber(int64_t idx) {
-    return getInstrBaseNumber(idx) + READ_SLOT;
-  }
-
-  /// \returns the instruction number of a write slot of instruction with number
-  /// \p idx.
-  static int64_t getInstrWriteSlotNumber(int64_t idx) {
-    return getInstrBaseNumber(idx) + WRITE_SLOT;
-  }
 
   /// Return the module
   Module &getModule() { return M_; }

--- a/lib/IR/IR.cpp
+++ b/lib/IR/IR.cpp
@@ -349,11 +349,12 @@ Value *Module::getWeightForNode(const Node *V) const {
 //                    Instruction numbering
 //===----------------------------------------------------------------------===//
 
-InstructionNumbering::InstructionNumbering(Module &M) : M_(M) {
+InstructionNumbering::InstructionNumbering(Module &M, size_t step)
+    : M_(M), step_(step) {
   auto &instrs = M.getInstrs();
   size_t instIdx = 0;
   for (auto it = instrs.begin(), e = instrs.end(); it != e;
-       instIdx += MAX_SLOT, ++it) {
+       instIdx += step_, ++it) {
     NumToInstr_.push_back(it);
     InstrToNum_[*it] = instIdx;
   }
@@ -371,8 +372,8 @@ int64_t InstructionNumbering::getInstrNumber(InstrIterator IT) const {
 }
 
 InstrIterator InstructionNumbering::getInstr(size_t InstrNumber) const {
-  assert(InstrNumber / MAX_SLOT < NumToInstr_.size());
-  return NumToInstr_[InstrNumber / MAX_SLOT];
+  assert(InstrNumber / step_ < NumToInstr_.size());
+  return NumToInstr_[InstrNumber / step_];
 }
 
 //===----------------------------------------------------------------------===//
@@ -517,7 +518,7 @@ void Module::nameInstructions() {
 
 void Module::dump() {
   nameInstructions();
-  InstructionNumbering InstrNumbering(*this);
+  InstructionNumbering InstrNumbering(*this, 1);
   // Print all of the variables:
   std::string s;
   llvm::raw_string_ostream sb{s};


### PR DESCRIPTION
Use consecutive instruction numbers when dumping the module.
Move the logic that is used for the instruction numbering during live intervals computations from InstructionNumbering into a dedicated class LiveIntervalsInstructionNumbering.