### PR TITLE
[cleanup] Remove double type.

### DIFF
--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -77,7 +77,6 @@ inline bool operator==(const ShapeNHWC &LHS, const ShapeNHWC &RHS) {
 
 enum class ElemKind : unsigned char {
   FloatTy,
-  DoubleTy,
   Int8QTy,
   Int32QTy,
   IndexTy,
@@ -189,8 +188,6 @@ struct Type final {
     switch (Ty) {
     case ElemKind::FloatTy:
       return std::is_same<ElemTy, float>::value;
-    case ElemKind::DoubleTy:
-      return std::is_same<ElemTy, double>::value;
     case ElemKind::Int8QTy:
       return std::is_same<ElemTy, int8_t>::value;
     case ElemKind::Int32QTy:
@@ -217,8 +214,6 @@ struct Type final {
     switch (Ty) {
     case ElemKind::FloatTy:
       return sizeof(float);
-    case ElemKind::DoubleTy:
-      return sizeof(double);
     case ElemKind::Int8QTy:
       return sizeof(int8_t);
     case ElemKind::Int32QTy:
@@ -237,7 +232,10 @@ struct Type final {
   /// \return the textual name of the element \p Ty.
   static llvm::StringRef getElementName(ElemKind Ty) {
     static const char *names[] = {
-        "float", "double", "i8", "i32", "index",
+        "float",
+        "i8",
+        "i32",
+        "index",
     };
     return names[(int)Ty];
   }

--- a/lib/Base/Tensor.cpp
+++ b/lib/Base/Tensor.cpp
@@ -176,8 +176,6 @@ void glow::dumpAsciiImpl(Tensor *T) {
   switch (T->getElementType()) {
   case ElemKind::FloatTy:
     return dumpAsciiGenericImpl(T->getHandle<float>());
-  case ElemKind::DoubleTy:
-    return dumpAsciiGenericImpl(T->getHandle<double>());
   case ElemKind::Int8QTy:
     return dumpAsciiGenericImpl(T->getHandle<int8_t>());
   case ElemKind::Int32QTy:
@@ -191,8 +189,6 @@ void glow::dumpImpl(Tensor *T) {
   switch (T->getElementType()) {
   case ElemKind::FloatTy:
     return dumpGenericImpl(T->getHandle<float>());
-  case ElemKind::DoubleTy:
-    return dumpGenericImpl(T->getHandle<double>());
   case ElemKind::Int8QTy:
     return dumpGenericImpl(T->getHandle<int8_t>());
   case ElemKind::Int32QTy:

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -191,10 +191,6 @@ void Variable::initPayload() {
       payload_.getHandle<float>().clear(val_);
       break;
     }
-    case ElemKind::DoubleTy: {
-      payload_.getHandle<double>().clear(val_);
-      break;
-    }
     case ElemKind::Int8QTy: {
       payload_.getHandle<int8_t>().clear(val_);
       break;
@@ -215,10 +211,6 @@ void Variable::initPayload() {
     switch (payload_.getElementType()) {
     case ElemKind::FloatTy: {
       payload_.getHandle<float>().initXavier(val_);
-      break;
-    }
-    case ElemKind::DoubleTy: {
-      payload_.getHandle<double>().initXavier(val_);
       break;
     }
     case ElemKind::Int8QTy: {
@@ -654,9 +646,8 @@ void SGDNode::verify() const {
 
 void QuantizationProfileNode::verify() const {
   // Make sure that input tensor is a floating point type.
-  assert(getInput().getElementType() == ElemKind::FloatTy ||
-         getInput().getElementType() == ElemKind::DoubleTy &&
-             "Floating point type is expected");
+  assert(getInput().getElementType() == ElemKind::FloatTy &&
+         "Floating point type is expected");
 
   // Check computation info has proper size.
   assert(getComputationInfo().dims().size() == 1 &&

--- a/lib/IR/Instrs.cpp
+++ b/lib/IR/Instrs.cpp
@@ -401,9 +401,8 @@ void DeallocActivationInst::verify() const {
 
 void QuantizationProfileInst::verify() const {
   // Make sure that input tensor is a floating point type.
-  assert(getOperand(0).first->getElementType() == ElemKind::FloatTy ||
-         getOperand(0).first->getElementType() == ElemKind::DoubleTy &&
-             "Floating point type is expected");
+  assert(getOperand(0).first->getElementType() == ElemKind::FloatTy &&
+         "Floating point type is expected");
 
   // Check computation info has proper size.
   assert(getOperand(2).first->dims().size() == 1 &&


### PR DESCRIPTION
We could add it back in the future if needed, but as we go to quantized values, we'd probably not need to.