### PR TITLE
[quantization] Load profile and quantize the graph.

### DIFF
--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -120,7 +120,11 @@ public:
     Tensor unownedTensor;
     unownedTensor.data_.setPointer(getData());
     unownedTensor.data_.setInt(1);
-    unownedTensor.type_ = Type(getElementType(), dims);
+    unownedTensor.type_ =
+        getType().isQuantizedType()
+            ? Type(getElementType(), dims, getType().getScale(),
+                   getType().getOffset())
+            : Type(getElementType(), dims);
     assert(size() == unownedTensor.size() &&
            "The size of the non-owned tensor should be "
            "the same as the size of the original "

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -132,10 +132,14 @@ public:
                                            NodeValue input, Variable *W,
                                            Variable *B, size_t outDepth);
 
+  /// Create a fully connected node with the specified output type.
+  /// Note, outputDepth is infered based on the output type.
   FullyConnectedNode *createFullyConnected(llvm::StringRef name,
-                                           NodeValue input, Variable *W,
-                                           Variable *B, TypeRef outTy);
+                                           NodeValue input, Node *W, Node *B,
+                                           TypeRef outTy);
 
+  /// Create a fully connected node with the given \p name, \p input and \p
+  /// output depth. Trainable weight and bias variables are created implicitly.
   FullyConnectedNode *createFullyConnected(llvm::StringRef name,
                                            NodeValue input, size_t outDepth);
 

--- a/include/glow/Quantization/Quantization.h
+++ b/include/glow/Quantization/Quantization.h
@@ -21,17 +21,24 @@ struct TensorQuantizationParams {
 
 /// Tensor quantization parameters for a given node.
 struct NodeQuantizationInfo {
-  std::string nodeName_;
+  std::string nodeOutputName_;
   TensorQuantizationParams tensorQuantizationParams_;
 
   NodeQuantizationInfo() = default;
-  NodeQuantizationInfo(const std::string &nodeName,
+  NodeQuantizationInfo(const std::string &nodeOutputName,
                        const TensorQuantizationParams &tensorQuantizationParams)
-      : nodeName_(nodeName),
+      : nodeOutputName_(nodeOutputName),
         tensorQuantizationParams_(tensorQuantizationParams) {}
 
   float Scale() const { return tensorQuantizationParams_.scale_; }
   int32_t Offset() const { return tensorQuantizationParams_.offset_; }
+
+  /// Get the full node output name based on the node name and output number.
+  /// The following format is used: nodename:outputNumber
+  static std::string generateNodeOutputName(const std::string &nodeName,
+                                            unsigned outputNumber = 0) {
+    return nodeName + ":" + std::to_string(outputNumber);
+  }
 };
 
 /// Generate NodeQuantizationInfo for all required nodes from graph \p G.
@@ -82,6 +89,12 @@ int8_t quantize(float input, const TensorQuantizationParams &TQP);
 /// Converts int8 quantized value back to floating point number based on
 /// the quantization parameters \p TQP.
 float dequantize(int8_t input, const TensorQuantizationParams &TQP);
+
+/// Converts floating point graph to a quantized one.
+/// Note, if not all operators have a conversion support,
+/// graph ends up being hybrid.
+void generateQuantizedGraph(
+    Graph &G, llvm::ArrayRef<NodeQuantizationInfo> quantizationInfos);
 
 } // namespace glow
 

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -221,8 +221,8 @@ FullyConnectedNode *Graph::createFullyConnected(llvm::StringRef name,
 }
 
 FullyConnectedNode *Graph::createFullyConnected(llvm::StringRef name,
-                                                NodeValue input, Variable *W,
-                                                Variable *B, TypeRef outTy) {
+                                                NodeValue input, Node *W,
+                                                Node *B, TypeRef outTy) {
   assert(outTy->dims().size() == 2 && "Invalid number of dimensions");
   assert(outTy->dims()[0] == input.dims()[0] && "Invalid dimensions");
 

--- a/lib/Quantization/Serialization.cpp
+++ b/lib/Quantization/Serialization.cpp
@@ -14,7 +14,7 @@ namespace yaml {
 /// Mapping for NodeQuantizationInfo yaml serializer.
 template <> struct MappingTraits<glow::NodeQuantizationInfo> {
   static void mapping(IO &io, glow::NodeQuantizationInfo &info) {
-    io.mapRequired("nodeOutputName", info.nodeName_);
+    io.mapRequired("nodeOutputName", info.nodeOutputName_);
     io.mapRequired("scale", info.tensorQuantizationParams_.scale_);
     io.mapRequired("offset", info.tensorQuantizationParams_.offset_);
   }

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -107,6 +107,7 @@ add_executable(quantizationTest
                quantizationTest.cpp)
 target_link_libraries(quantizationTest
                       PRIVATE
+                        ExecutionEngine
                         Graph
                         Quantization
                         gtest


### PR DESCRIPTION
Transform floating point graph to a quantized representation based on the node's quantization eligibility.
Currently support quantization of a FullyConnected node, which gets lowered later into BatchedMatMul + BatchedAdd.

![screen shot 2018-02-09 at 12 13 59 pm](https://user-images.githubusercontent.com/34466929/36048177-2e3c2b30-0d93-11e8-85f8-1776618dd440.png)



