### PR TITLE
[quantization] Keep profiled node name as part of the QPN node.

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -223,7 +223,8 @@ public:
   SaveNode *createSave(llvm::StringRef name, NodeValue input);
   SaveNode *createSave(llvm::StringRef name, NodeValue input, Variable *output);
   /// Create quantization profile node named \p name for the output tensor from
-  /// \p input.
+  /// \p input. Capture observed node name in quantization profile node as
+  /// original node can be replaced during lowering phase.
   QuantizationProfileNode *createQuantizationProfile(llvm::StringRef name,
                                                      NodeValue input);
 

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -536,8 +536,8 @@ QuantizationProfileNode *Graph::createQuantizationProfile(llvm::StringRef name,
       ElemKind::FloatTy, {2}, "computationInfo",
       Variable::VisibilityKind::Private, Variable::TrainKind::None);
 
-  return addNode(
-      new QuantizationProfileNode(name, input, histogram, computationInfo));
+  return addNode(new QuantizationProfileNode(
+      name, input, histogram, computationInfo, input->getName().str()));
 }
 
 TopKNode *Graph::createTopK(llvm::StringRef name, NodeValue input, size_t k) {

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -204,12 +204,8 @@ generateNodeQuantizationInfos(const Graph &G) {
       float min = CI.raw(0);
       float max = CI.raw(1);
 
-      NodeValue &observedNodeValue = node->getNthInput(0);
-      unsigned resNum = observedNodeValue.getResNo();
-      Node *observedNode = observedNodeValue.getNode();
-
       std::string fullOutputName = NodeQuantizationInfo::generateNodeOutputName(
-          observedNode->getName().str(), resNum);
+          QPN->getProfiledNodeName());
       TensorQuantizationParams TQP =
           calculateTensorQuantizationParams(histogram, min, max);
       quantizationInfos.emplace_back(fullOutputName, TQP);

--- a/tools/ClassGen/MemberType.h
+++ b/tools/ClassGen/MemberType.h
@@ -38,7 +38,7 @@ inline const char *getStorageTypename(MemberType type) {
                                 "float",
                                 "unsigned",
                                 "size_t",
-                                "llvm::StringRef",
+                                "std::string",
                                 "std::vector<float>",
                                 "std::vector<unsigned>",
                                 "std::vector<size_t>",

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -279,6 +279,7 @@ int main(int argc, char **argv) {
       .addInput("Input")
       .addInput("Histogram")
       .addInput("ComputationInfo")
+      .addMember(MemberType::String, "ProfiledNodeName")
       .addExtraMethod("Variable *getHistogramVar() const ;",
                       "Variable *QuantizationProfileNode::getHistogramVar() "
                       "const { return "


### PR DESCRIPTION
With the lowering in place, we cannot get original node name at a later stage without having meta info on QPN node.