### PR TITLE
Add support for serializing standalone bundles

### DIFF
--- a/lib/Backends/JIT/AllocationsInfo.cpp
+++ b/lib/Backends/JIT/AllocationsInfo.cpp
@@ -1,0 +1,157 @@
+#define DEBUG_TYPE "jit-allocations"
+
+#include "AllocationsInfo.h"
+#include "glow/CodeGen/MemoryAllocator.h"
+#include "glow/Graph/Graph.h"
+#include "glow/Graph/Nodes.h"
+#include "glow/IR/Instrs.h"
+
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace glow;
+
+using namespace glow;
+using llvm::StringRef;
+using llvm::dyn_cast;
+using llvm::isa;
+
+void AllocationsInfo::allocateWeightVars(IRFunction *F, bool reuseAddresses) {
+  // Use two different allocators, because constant weights and mutable weights
+  // may use different memory blocks.
+  MemoryAllocator constantWeightVarsAllocator(0);
+  MemoryAllocator mutableWeightVarsAllocator(0);
+
+  // Compute the new offsets for all the weights, do not reuse their current
+  // addresses. Process all constant WeightVars first.
+  for (auto &v : F->getGraph()->getParent()->getVars()) {
+    assert(isa<WeightVar>(F->getWeightForNode(v)));
+    auto *w = llvm::cast<WeightVar>(F->getWeightForNode(v));
+    if (v->getVisibilityKind() == Variable::VisibilityKind::Public)
+      continue;
+    auto numBytes = w->getType()->getSizeInBytes();
+    size_t addr = constantWeightVarsAllocator.allocate(numBytes);
+    if (!reuseAddresses) {
+      allocatedAddressed_[w] = addr;
+    } else {
+      // Reuse the address used by the payload.
+      allocatedAddressed_[w] =
+          v->getPayload().getUnsafePtr() - static_cast<char *>(nullptr);
+    }
+  }
+
+  // Process all mutable WeightVars afterwards.
+  for (auto &v : F->getGraph()->getParent()->getVars()) {
+    assert(isa<WeightVar>(F->getWeightForNode(v)));
+    auto *w = llvm::cast<WeightVar>(F->getWeightForNode(v));
+    if (v->getVisibilityKind() != Variable::VisibilityKind::Public)
+      continue;
+    auto numBytes = w->getType()->getSizeInBytes();
+    size_t addr = mutableWeightVarsAllocator.allocate(numBytes);
+    if (!reuseAddresses) {
+      allocatedAddressed_[w] = addr;
+    } else {
+      // Reuse the address used by the payload.
+      allocatedAddressed_[w] =
+          v->getPayload().getUnsafePtr() - static_cast<char *>(nullptr);
+    }
+  }
+
+  // Remember that max required memory size for each kind of weights.
+  constantWeightVarsMemSize_ = constantWeightVarsAllocator.getMaxMemoryUsage();
+  mutableWeightVarsMemSize_ = mutableWeightVarsAllocator.getMaxMemoryUsage();
+
+  DEBUG(for (auto &A
+             : allocatedAddressed_) {
+    auto origin = getOrigin(A.first);
+    if (isa<AllocActivationInst>(origin))
+      continue;
+    assert(valueNumbers_.count(origin) && "Unknown weight");
+    llvm::StringRef kind =
+        valueNumbers_[origin].first == ValueKind::ConstantWeight
+            ? "constant weight"
+            : "mutable weight";
+    llvm::errs() << "Allocated " << kind << " " << A.first->getName()
+                 << " size: " << A.first->getType()->getSizeInBytes()
+                 << "  address range:  [" << allocatedAddressed_[origin] << ", "
+                 << allocatedAddressed_[origin] +
+                        A.first->getType()->getSizeInBytes()
+                 << "]\n";
+  });
+}
+
+void AllocationsInfo::allocateActivations(IRFunction *F) {
+  // Use a memory allocator with no upper bound on how much memory we can
+  // allocate.
+  MemoryAllocator activationsAllocator(0);
+  // allocatedAddressed_.clear();
+
+  // Maps activations and views to some offset within the heap.
+  llvm::DenseMap<Value *, size_t> activationAddr;
+
+  // Assign device-space addresses to the activations.
+  for (auto &I : F->getInstrs()) {
+    if (auto *A = llvm::dyn_cast<AllocActivationInst>(I)) {
+      auto numBytes = I->getType()->getSizeInBytes();
+      size_t addr = activationsAllocator.allocate(numBytes);
+      assert(!activationAddr.count(A) && "Allocation already made!");
+      activationAddr[A] = addr;
+      continue;
+    }
+
+    if (auto *D = llvm::dyn_cast<DeallocActivationInst>(I)) {
+      auto *A = D->getAlloc();
+      assert(activationAddr.count(A) && "Invalid deallocation!");
+      activationsAllocator.deallocate(activationAddr[A]);
+      continue;
+    }
+  }
+
+  activationsMemSize_ = activationsAllocator.getMaxMemoryUsage();
+
+  // Register specific addresses within the heap to activations.
+  for (auto &A : activationAddr) {
+    allocatedAddressed_[A.first] = A.second;
+  }
+  DEBUG(for (auto &A
+             : allocatedAddressed_) {
+    llvm::errs() << "Allocated activation " << A.first->getName()
+                 << " size: " << A.first->getType()->getSizeInBytes()
+                 << "  address range:  ["
+                 << allocatedAddressed_[getOrigin(A.first)] << ", "
+                 << allocatedAddressed_[A.first] +
+                        A.first->getType()->getSizeInBytes()
+                 << "]\n";
+  });
+}
+
+void AllocationsInfo::numberValues(IRFunction *F) {
+  size_t valueIdx = 0;
+  // Assign numbers to all weights.
+  for (auto &v : F->getGraph()->getParent()->getVars()) {
+    assert(isa<WeightVar>(F->getWeightForNode(v)));
+    auto *w = llvm::cast<WeightVar>(F->getWeightForNode(v));
+    auto kind = v->getVisibilityKind() != Variable::VisibilityKind::Public
+                    ? ValueKind::ConstantWeight
+                    : ValueKind::MutableWeight;
+    valueNumbers_[w] = std::make_pair(kind, valueIdx++);
+  }
+  // Assign numbers to all activations.
+  for (auto &I : F->getInstrs()) {
+    if (auto *A = llvm::dyn_cast<AllocActivationInst>(I)) {
+      valueNumbers_[A] = std::make_pair(ValueKind::Activation, valueIdx++);
+      continue;
+    }
+  }
+}
+
+void AllocationsInfo::clear() {
+  allocatedAddressed_.clear();
+  valueNumbers_.clear();
+  baseActivationsAddress_ = nullptr;
+  baseConstantWeightVarsAddress_ = nullptr;
+  baseMutableWeightVarsAddress_ = nullptr;
+  activationsMemSize_ = 0;
+  constantWeightVarsMemSize_ = 0;
+  mutableWeightVarsMemSize_ = 0;
+}

--- a/lib/Backends/JIT/AllocationsInfo.h
+++ b/lib/Backends/JIT/AllocationsInfo.h
@@ -1,0 +1,58 @@
+#ifndef GLOW_BACKENDS_JIT_ALLOCATIONSINFO_H
+#define GLOW_BACKENDS_JIT_ALLOCATIONSINFO_H
+
+#include "llvm/IR/Module.h"
+
+#include <functional>
+
+namespace glow {
+class Value;
+class IRFunction;
+class WeightVar;
+class Variable;
+
+/// Information about allocations for activations, constant weight variables
+/// and mutable weight variables.
+struct AllocationsInfo {
+  /// Different kinds of values that need to be allocated.
+  enum class ValueKind { ConstantWeight, MutableWeight, Activation };
+  using KindAndNumber = std::pair<ValueKind, size_t>;
+  /// Map Values in the module to their numbers.
+  llvm::DenseMap<Value *, KindAndNumber> valueNumbers_;
+  /// To get the offset of a given value simply use
+  /// numberOffsets_[valueNumbers_[v]]
+
+  /// Maps Values in the module to their offsets.
+  llvm::DenseMap<Value *, size_t> allocatedAddressed_;
+  /// Amount of memory to be allocated for constant WeightVars.
+  size_t constantWeightVarsMemSize_{0};
+  /// Amount of memory to be allocated for mutable WeightVars.
+  size_t mutableWeightVarsMemSize_{0};
+  /// Amount of memory to be allocated for activations.
+  size_t activationsMemSize_{0};
+  /// Base address of constant weights.
+  uint8_t *baseConstantWeightVarsAddress_{nullptr};
+  /// Base address of mutable WeightVars.
+  uint8_t *baseMutableWeightVarsAddress_{nullptr};
+  /// Base address of activations.
+  uint8_t *baseActivationsAddress_{nullptr};
+  /// Assign offsets to all WeightVars of \p M.
+  /// If the \p reuseAddresses is true, simply reuse the addresses already used
+  /// by those WeightVars. This is useful in a JIT setup.
+  /// If \p reuseAddresses is false, then all the WeightVars will get new
+  /// offsets assigned.
+  void allocateWeightVars(IRFunction *F, bool reuseAddresses);
+  /// Assign offsets to all activations.
+  /// No actual memory allocation is performed. All the allocations should be
+  /// performed by the client based on the information provided by the
+  /// AllocationsInfo.
+  void allocateActivations(IRFunction *F);
+  /// Number all allocations and weight variables by assigning them unique
+  /// numbers.
+  void numberValues(IRFunction *F);
+  /// Reset the state of the allocation info.
+  void clear();
+};
+
+} // namespace glow
+#endif // GLOW_BACKENDS_JIT_ALLOCATIONSINFO_H

--- a/lib/Backends/JIT/CMakeLists.txt
+++ b/lib/Backends/JIT/CMakeLists.txt
@@ -13,6 +13,7 @@ add_custom_command(OUTPUT
                    DEPENDS ${LIBJITSRC}
                    COMMENT "Clang: Generating runtime bytecode library." VERBATIM)
 add_library(JIT
+            AllocationsInfo.cpp
             FunctionSpecializer.cpp
             GlowJIT.cpp
             Pipeline.cpp

--- a/lib/Backends/JIT/LLVMIRGen.cpp
+++ b/lib/Backends/JIT/LLVMIRGen.cpp
@@ -12,9 +12,14 @@ using llvm::isa;
 
 llvm::Value *JITBackend::emitValueAddress(llvm::IRBuilder<> &builder,
                                           glow::Value *val, ElemKind ptrTy) {
-  assert(allocatedAddressed_.count(val) && "Value address was not allocated");
-  void *ptr = allocatedAddressed_[val];
-  auto *offset = emitConst(builder, (size_t)ptr);
+  val = getOrigin(val);
+  assert(allocationsInfo_.allocatedAddressed_.count(val) &&
+         "Value address was not allocated");
+  size_t addr = allocationsInfo_.allocatedAddressed_[val];
+  if (isa<AllocActivationInst>(val)) {
+    addr += reinterpret_cast<size_t>(&heap_[0]);
+  }
+  auto *offset = emitConst(builder, addr);
 
   llvm::Type *T = nullptr;
 


### PR DESCRIPTION
To generate a bundle, use e.g. the following command-line:
loader tests/images/cat_285.png -image_mode=0to1 -d=resnet50 -bundler -bundle-output directory_path

This command would generate two artifacts: the code is serialized into resnet50.o and the weights are serialized into resnet50.weights.

The code is a usual object file which you can link with any client code.

The code exposes an entry point, which has the same name as the bundle, i.e. resnet50 (the name is taken from the model being processes). This entry point has the following function signature and takes the pointers to the initialized memory allocated for constant and mutable weight variables:
`extern "C" void resnet50(uint8_t *constantWeightVarsBaseAddr, uint8_t *mutableWeightVarsBaseAddr, uint8_t *activationsBaseAddr);`

Another exposed symbol has a name which looks like the name of the bundle, but with a suffix `_config` at the end. In the example above, it would have a name `resnet50_config`. This is a structure of the following form, which contains the information about the sizes of the memory blocks for activations, constant weights variables and mutable weights variables:
```c++
struct BundleConfig {
size_t constantWeightVarsMemSize;
size_t mutableWeightVarsMemSize;
size_t activationsMemSize;
};
```

It is a responsibility of the client to properly prepare and initialize the memory blocks for the activations, constant weights variables and mutable weights variable before calling the exposed entry point.

You can find an example of a client for the resnet50 network model in the samples/resnet50_standalone.cpp