### PR TITLE
[cleanup] Rename output of FC to Result to be consistent

### DIFF
--- a/lib/Optimizer/Lower.cpp
+++ b/lib/Optimizer/Lower.cpp
@@ -121,7 +121,7 @@ void lowerFullyConnectedNode(Graph &graph, FullyConnectedNode &FC) {
   if (W->getType()->isQuantizedType()) {
     // We use the scale and offset from the output of the FC for both the matrix
     // multiplication node and the batched-add node.
-    auto FCT = FC.getOutput()->getType();
+    auto FCT = FC.getResult()->getType();
     outTy = graph.getParent().uniqueType(elemTy, {1, xDim.first, wDim[1]},
                                          FCT->getScale(), FCT->getOffset());
   } else {
@@ -131,15 +131,15 @@ void lowerFullyConnectedNode(Graph &graph, FullyConnectedNode &FC) {
 
   auto *mulFlat = graph.createReshape("fc.cast2", mul, {xDim.first, wDim[1]});
   auto add = graph.createBatchedArithmetic(
-      "fc.add.bias", FC.getOutput()->getType(),
+      "fc.add.bias", FC.getResult()->getType(),
       BatchedArithmeticNode::Mode::Add, mulFlat, FC.getBias());
-  FC.getOutput().replaceAllUsesOfWith(add);
+  FC.getResult().replaceAllUsesOfWith(add);
 }
 
 void lowerFullyConnectedGradNode(Graph &graph, FullyConnectedGradNode &FCG) {
   // Follow the lowering from here:
   // https://github.com/huyouare/CS231n/blob/master/assignment2/cs231n/layers.py#L53
-  auto out = FCG.getGradOfOriginalOutputNamedOutput();
+  auto out = FCG.getGradOfOriginalOutputNamedResult();
   auto xDims = flattenCdr(FCG.getInput().dims());
   auto outDims = out.dims();
   auto fDims = FCG.getWeights().dims();

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -288,7 +288,7 @@ void generateQuantizedGraph(
       auto *FC = cast<FullyConnectedNode>(node);
       assert(quantizedInputs.size() == 3 && "Invalid number of inputs");
       auto QT = G.getParent().uniqueType(
-          ElemKind::Int8QTy, FC->getOutput()->dims(), TQP.scale_, TQP.offset_);
+          ElemKind::Int8QTy, FC->getResult()->dims(), TQP.scale_, TQP.offset_);
       quantizedNode =
           G.createFullyConnected(FC->getName(), quantizedInputs[0],
                                  quantizedInputs[1], quantizedInputs[2], QT);

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -62,7 +62,7 @@ int main(int argc, char **argv) {
       .addInput("Input")
       .addInput("Weights")
       .addInput("Bias")
-      .addResultFromCtorArg("Output")
+      .addResultFromCtorArg()
       .addGradient();
 
   //===--------------------------------------------------------------------===//


### PR DESCRIPTION
To be consistent with the rest of the ops: conv, pool, etc.

@hegemanjwh2 @nadavrot I remember seeing this in some of the comments you had in the past.