### PR TITLE
[unittest] Speed up sinus test a bit.

### DIFF
--- a/tests/unittests/InterpreterTest.cpp
+++ b/tests/unittests/InterpreterTest.cpp
@@ -874,7 +874,7 @@ TEST(LinearClassifier, classifyPlayerSport) {
 TEST(Interpreter, learnSinus) {
   // Try to learn the sin(x) function.
   float epsilon = 0.1;
-  unsigned numSamples = 150;
+  unsigned numSamples = 50;
 
   ExecutionEngine EE;
   EE.getConfig().learningRate = 0.2;


### PR DESCRIPTION
We could probably do even better, but 7s looks good for now (vs 23).

I run this test in a loop for 60 times, results look stable.

@opti-mix just to make interpreter test as a whole to run a bit faster.
