### PR TITLE
[ExecutionEngine] Verify the function before lowering

### DIFF
--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -111,6 +111,9 @@ void ExecutionEngine::compile(CompilationMode mode, Function *F) {
     generateGradientNodes(*F, getConfig(), mode);
   }
 
+  // Verify the function pre-optimization/lowering.
+  F->verify();
+
   // Optimized the graph.
   ::glow::optimize(*F, mode);
 


### PR DESCRIPTION
Verify the Function before any optimization or lowering, to ensure all input nodes are verified. It's also still verified during `generateIR`. I thought this made the most sense, but we could also/instead verify at other points in the compilation pipeline. Thoughts?