### PR TITLE
[LLVMIR] Fix LLVM IR Function Declaration Generation

### DIFF
--- a/lib/Backends/JIT/Pipeline.cpp
+++ b/lib/Backends/JIT/Pipeline.cpp
@@ -68,6 +68,9 @@ void JITBackend::optimizeLLVMModule(llvm::Function *F,
   // the frontend.
   llvm::AttributeList AL;
   for (auto &FF : *M) {
+    if (FF.isDeclaration()) {
+      continue;
+    }
     // Check for no-inline attribute.
     bool dontInline = FF.hasFnAttribute(llvm::Attribute::AttrKind::NoInline);
     // Clear all attributes.


### PR DESCRIPTION
This commit fixes a problem with the LLVM IR generated for function declarations.