### PR TITLE
[Graph] Change some of the APIs from reference to pointer to make the APIs consistent.

### DIFF
--- a/include/glow/Backends/Backend.h
+++ b/include/glow/Backends/Backend.h
@@ -38,7 +38,7 @@ public:
   /// backend may insert target specific nodes. The backend is responsible for
   /// cleaning up after itself.
   /// \returns True if the graph was modified.
-  virtual bool transform(Function &G) { return false; }
+  virtual bool transform(Function *F) { return false; }
 };
 
 /// Create a backend of kind \p kind, to run the IR function \p M.

--- a/include/glow/Graph/Grad.h
+++ b/include/glow/Graph/Grad.h
@@ -13,12 +13,12 @@ class Function;
 /// and helps to accumulate gradients into variables.
 class GraphGradMapper {
   /// The graph that we mutate.
-  Function &G_;
+  Function *F_;
   /// Maps activation values to their gradient values.
   UnownedNodeValueMap map_;
 
 public:
-  GraphGradMapper(Function &G) : G_(G) {}
+  GraphGradMapper(Function *F) : F_(F) {}
 
   /// \register the node \p grad as the grad of \p activation. If the node is
   /// already registered then create an 'add' node that accumulates the gradient

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -150,20 +150,20 @@ class Function final : public Named {
   NodesList nodes_;
 
   /// A reference to the owner of the function.
-  Module &parent_;
+  Module *parent_;
 
 public:
-  Function(Module &parent, llvm::StringRef Name = {})
+  Function(Module *parent, llvm::StringRef Name = {})
       : Named(Name), parent_(parent) {}
 
   ~Function();
 
-  Module &getParent() { return parent_; }
-  const Module &getParent() const { return parent_; }
+  Module *getParent() { return parent_; }
+  const Module *getParent() const { return parent_; }
 
   /// Inserts the node \p N to the list of nodes, and returns the inserted node.
   template <class NodeTy> NodeTy *addNode(NodeTy *N) {
-    getParent().assignUniqueName(N);
+    getParent()->assignUniqueName(N);
     nodes_.push_back(N);
     return N;
   }

--- a/include/glow/Graph/Utils.h
+++ b/include/glow/Graph/Utils.h
@@ -44,7 +44,7 @@ public:
 class GraphPostOrderVisitor : public PostOrderVisitor {
   const Function &G;
   void visit() {
-    for (const auto *V : G.getParent().getVars()) {
+    for (const auto *V : G.getParent()->getVars()) {
       V->visit(nullptr, this);
     }
     // Start visiting all root nodes, i.e. nodes that do not have any users.

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -25,7 +25,7 @@ void Interpreter::clear() {
 }
 
 void Interpreter::init() {
-  for (auto &v : F_->getGraph()->getParent().getVars()) {
+  for (auto &v : F_->getGraph()->getParent()->getVars()) {
     auto *w = F_->getWeightForNode(v);
     assert(!externalTensors_.count(w) && "The tensor is already registered");
     externalTensors_[w] = &v->getPayload();

--- a/lib/Backends/JIT/JIT.cpp
+++ b/lib/Backends/JIT/JIT.cpp
@@ -155,7 +155,7 @@ void JITBackend::allocateActivationsAndWeights() {
   llvm::DenseMap<Value *, size_t> activationAddr;
 
   // Register the addresses of the tensor payload.
-  for (auto &v : M_->getGraph()->getParent().getVars()) {
+  for (auto &v : M_->getGraph()->getParent()->getVars()) {
     auto *w = M_->getWeightForNode(v);
     allocatedAddressed_[w] = v->getPayload().getUnsafePtr();
   }

--- a/lib/Backends/JIT/JIT.h
+++ b/lib/Backends/JIT/JIT.h
@@ -93,7 +93,7 @@ public:
 
   void doForwardPass(bool isTrain) override;
 
-  bool transform(Function &G) override;
+  bool transform(Function *F) override;
   /// @}
 };
 

--- a/lib/Backends/JIT/Transforms.cpp
+++ b/lib/Backends/JIT/Transforms.cpp
@@ -21,20 +21,20 @@ static bool isZeroNode(NodeValue N) {
   return splat->getValue() == 0;
 }
 
-bool JITBackend::transform(Function &G) {
+bool JITBackend::transform(Function *F) {
   bool changed = false;
-  for (auto node : G.getNodes()) {
+  for (auto node : F->getNodes()) {
     if (auto *AN = dyn_cast<ArithmeticNode>(node)) {
       if (AN->getMode() == ArithmeticNode::Mode::Max) {
         if (isZeroNode(AN->getLHS())) {
-          auto I = G.createIntrinsicNode(AN->getName(), "jit.max0",
+          auto I = F->createIntrinsicNode(AN->getName(), "jit.max0",
                                          {AN->getRHS()}, {AN->getType()});
           NodeValue(node, 0).replaceAllUsesOfWith(I);
           changed = true;
           continue;
         }
         if (isZeroNode(AN->getRHS())) {
-          auto I = G.createIntrinsicNode(AN->getName(), "jit.max0",
+          auto I = F->createIntrinsicNode(AN->getName(), "jit.max0",
                                          {AN->getLHS()}, {AN->getType()});
           NodeValue(node, 0).replaceAllUsesOfWith(I);
           changed = true;

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -548,7 +548,7 @@ void OCLBackend::copyWeightsFromDevice() {
 }
 
 void OCLBackend::init() {
-  for (auto &v : F_->getGraph()->getParent().getVars()) {
+  for (auto &v : F_->getGraph()->getParent()->getVars()) {
     auto *w = F_->getWeightForNode(v);
     assert(!externalTensors_.count(w) && "The tensor is already registered");
     externalTensors_[w] = &v->getPayload();

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -120,7 +120,7 @@ void ExecutionEngine::compile(CompilationMode mode, Function *F) {
   ::glow::optimize(*F, mode);
 
   // Allow the backend to transform the graph.
-  if (IP_->transform(*F)) {
+  if (IP_->transform(F)) {
     // Optimize the graph again after the backend transformation.
     // In particular, DCE is very likely to be useful.
     ::glow::optimize(*F, mode);

--- a/lib/IR/GraphScheduler.cpp
+++ b/lib/IR/GraphScheduler.cpp
@@ -174,13 +174,13 @@ public:
 
 void IRFunction::scheduleGraph(NodesList &Schedule) {
   Schedule.clear();
-  for (auto &N : G_->getParent().getVars()) {
+  for (auto &N : G_->getParent()->getVars()) {
     Schedule.push_back(N);
   }
   ChildMemSizeBasedScheduler CMSBScheduler(*G_, Schedule);
   CMSBScheduler.schedule();
   assert(CMSBScheduler.getSchedule().size() ==
-             G_->getNodes().size() + G_->getParent().getVars().size() &&
+             G_->getNodes().size() + G_->getParent()->getVars().size() &&
          "All graph nodes have to be scheduled");
 }
 

--- a/lib/IR/IRBuilder.cpp
+++ b/lib/IR/IRBuilder.cpp
@@ -114,7 +114,7 @@ CrossEntropyLossInst *IRBuilder::createCrossEntropyLossOp(Value *p,
 
 ReshapeInst *IRBuilder::createReshapeOp(Value *input,
                                         llvm::ArrayRef<size_t> shape) {
-  auto ty = F_->getGraph()->getParent().uniqueTypeWithNewShape(input->getType(),
+  auto ty = F_->getGraph()->getParent()->uniqueTypeWithNewShape(input->getType(),
                                                                shape);
   auto *res = createAllocActivationInst("reshape.res", ty);
   return createReshapeInst("reshape", res, input, shape);
@@ -130,7 +130,7 @@ TensorViewInst *IRBuilder::createTensorView(ElemKind elemKind,
                                             llvm::ArrayRef<size_t> dims,
                                             Value *src, llvm::StringRef name) {
   auto ty =
-      getIRFunction().getGraph()->getParent().uniqueType(Type(elemKind, dims));
+      getIRFunction().getGraph()->getParent()->uniqueType(Type(elemKind, dims));
   return createTensorViewInst(name, src, ty);
 }
 
@@ -277,7 +277,7 @@ WeightVar *IRBuilder::createWeightVar(ElemKind elemTy,
                                       llvm::ArrayRef<size_t> dims,
                                       llvm::StringRef name,
                                       WeightVar::MutabilityKind k) {
-  auto T = F_->getGraph()->getParent().uniqueType(elemTy, dims);
+  auto T = F_->getGraph()->getParent()->uniqueType(elemTy, dims);
   return createWeightVar(T, name, k);
 }
 
@@ -292,6 +292,6 @@ WeightVar *IRBuilder::createWeightVar(TypeRef T, llvm::StringRef name,
 AllocActivationInst *
 IRBuilder::createAllocActivationInst(llvm::StringRef name, ElemKind elemTy,
                                      llvm::ArrayRef<size_t> dims) {
-  auto T = F_->getGraph()->getParent().uniqueType(elemTy, dims);
+  auto T = F_->getGraph()->getParent()->uniqueType(elemTy, dims);
   return createAllocActivationInst(name, T);
 }

--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -38,7 +38,7 @@ static bool shouldDeleteNode(Node *N) {
 /// Dead code elimination.
 static void DCE(Function &G) {
   auto &nodes = G.getNodes();
-  auto &vars = G.getParent().getVars();
+  auto &vars = G.getParent()->getVars();
 
   std::vector<VariablesList::iterator> erasedVars{};
   std::vector<NodesList::iterator> erasedNodes{};
@@ -79,7 +79,7 @@ static void DCE(Function &G) {
 
   while (!erasedVars.empty()) {
     auto it = erasedVars.back();
-    G.getParent().eraseVariable(it);
+    G.getParent()->eraseVariable(it);
     erasedVars.pop_back();
   }
 }

--- a/lib/Optimizer/Lower.cpp
+++ b/lib/Optimizer/Lower.cpp
@@ -122,10 +122,10 @@ void lowerFullyConnectedNode(Function &graph, FullyConnectedNode &FC) {
     // We use the scale and offset from the output of the FC for both the matrix
     // multiplication node and the batched-add node.
     auto FCT = FC.getResult()->getType();
-    outTy = graph.getParent().uniqueType(elemTy, {1, xDim.first, wDim[1]},
+    outTy = graph.getParent()->uniqueType(elemTy, {1, xDim.first, wDim[1]},
                                          FCT->getScale(), FCT->getOffset());
   } else {
-    outTy = graph.getParent().uniqueType(elemTy, {1, xDim.first, wDim[1]});
+    outTy = graph.getParent()->uniqueType(elemTy, {1, xDim.first, wDim[1]});
   }
   auto *mul = graph.createBatchedMatMul("fc.dot", outTy, X, W);
 

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -243,7 +243,7 @@ quantizeInputs(Function &G, Node *node,
 
     const TensorQuantizationParams &TQP =
         nodeToTQP.find(nodeOutputName)->second;
-    auto QT = G.getParent().uniqueType(ElemKind::Int8QTy, NV->dims(),
+    auto QT = G.getParent()->uniqueType(ElemKind::Int8QTy, NV->dims(),
                                        TQP.scale_, TQP.offset_);
 
     Node *quantizeNode = G.createQuantize("quantize", NV, QT);
@@ -287,7 +287,7 @@ void generateQuantizedGraph(
     case Kinded::Kind::FullyConnectedNodeKind: {
       auto *FC = cast<FullyConnectedNode>(node);
       assert(quantizedInputs.size() == 3 && "Invalid number of inputs");
-      auto QT = G.getParent().uniqueType(
+      auto QT = G.getParent()->uniqueType(
           ElemKind::Int8QTy, FC->getResult()->dims(), TQP.scale_, TQP.offset_);
       quantizedNode =
           G.createFullyConnected(FC->getName(), quantizedInputs[0],
@@ -298,7 +298,7 @@ void generateQuantizedGraph(
     case Kinded::Kind::ConvolutionNodeKind: {
       auto *CV = cast<ConvolutionNode>(node);
       assert(quantizedInputs.size() == 3 && "Invalid number of inputs");
-      auto QT = G.getParent().uniqueType(
+      auto QT = G.getParent()->uniqueType(
           ElemKind::Int8QTy, CV->getResult()->dims(), TQP.scale_, TQP.offset_);
       quantizedNode =
           G.createConv(CV->getName(), quantizedInputs[0], quantizedInputs[1],

--- a/tests/unittests/gradCheckTest.cpp
+++ b/tests/unittests/gradCheckTest.cpp
@@ -32,8 +32,8 @@ float gradDiff(float G1, float G2) {
   return std::abs(G1 - G2) / std::abs(G1 + G2 + 1);
 }
 
-Variable *getGrad(Function &G, Variable *V) {
-  return G.getParent().getGradientVariable(V);
+Variable *getGrad(Function *F, Variable *V) {
+  return F->getParent()->getGradientVariable(V);
 }
 
 /// Performs gradient check by comparing analytical and numerical gradients.
@@ -67,7 +67,7 @@ void performGradCheck(ExecutionEngine &IP, SaveNode *result, Variable *inputVar,
   IP.compile(CompilationMode::Train, recordNet);
 
   // Clear the gradients of the first layer.
-  auto gradVar = getGrad(G, inputVar);
+  auto gradVar = getGrad(&G, inputVar);
   gradVar->getPayload().zero();
 
   // Train the network just once to calculate the grads.
@@ -518,7 +518,7 @@ TEST(Network, gradientcheckCrossEntropyLoss) {
   Function *TF = glow::differentiate(&G, IP.getConfig(), "record", true);
   IP.compile(CompilationMode::Train, TF);
 
-  auto gradP = getGrad(G, P)->getHandle();
+  auto gradP = getGrad(&G, P)->getHandle();
 
   for (int i = 0; i < testSamples; ++i) {
     inputsH.randomize(0.0, 1.0);

--- a/tests/unittests/graphTest.cpp
+++ b/tests/unittests/graphTest.cpp
@@ -118,7 +118,7 @@ TEST(Graph, simpleQuant) {
   // Calculate the size and allocate the output buffer.
   auto outSz = calculateConvOutputDims(width, width, kernel, step, pad);
   std::array<size_t, 4> outDims = {{1, outSz.first, outSz.second, 16}};
-  auto t = G.getParent().uniqueType(glow::ElemKind::Int8QTy, outDims, 1.5, 6);
+  auto t = G.getParent()->uniqueType(glow::ElemKind::Int8QTy, outDims, 1.5, 6);
 
   auto *conv =
       G.createConv("conv", input, filter, bias, t, depth, kernel, step, pad);
@@ -137,11 +137,11 @@ TEST(Graph, quantizeDequantizeNodes) {
   auto &G = *MD.createFunction("main");
 
   auto *input = MD.createVariable(ElemKind::FloatTy, {1, 3}, "Input");
-  auto qType = G.getParent().uniqueType(ElemKind::Int8QTy, {1, 3}, 0.3, 5);
+  auto qType = G.getParent()->uniqueType(ElemKind::Int8QTy, {1, 3}, 0.3, 5);
 
   auto *Q = G.createQuantize("quantize", input, qType);
 
-  auto transform = G.getParent().uniqueType(ElemKind::Int8QTy, {1, 3}, 1.4, 3);
+  auto transform = G.getParent()->uniqueType(ElemKind::Int8QTy, {1, 3}, 1.4, 3);
   auto *A = G.createRescaleQuantized("rescale", Q, transform);
 
   auto *D = G.createDequantize("dequantize", A);
@@ -216,5 +216,5 @@ TEST(Graph, cloneTest2) {
   auto *newF = F->clone("new_main");
   newF->verify();
   EXPECT_EQ(newF->getNodes().size(), F->getNodes().size());
-  EXPECT_EQ(&newF->getParent(), &F->getParent());
+  EXPECT_EQ(newF->getParent(), F->getParent());
 }

--- a/tests/unittests/quantizationTest.cpp
+++ b/tests/unittests/quantizationTest.cpp
@@ -111,7 +111,7 @@ TEST(Quantization, quantizeGraph) {
 void createSimpleGraphForQuantization(Function &G, Variable *&input,
                                       SaveNode *&saveNode, Variable *W,
                                       Variable *B) {
-  auto *A = G.getParent().createVariable(ElemKind::FloatTy, {1, 32, 32, 3}, "A",
+  auto *A = G.getParent()->createVariable(ElemKind::FloatTy, {1, 32, 32, 3}, "A",
                                          Variable::VisibilityKind::Public,
                                          Variable::TrainKind::None);
   input = A;


### PR DESCRIPTION
Some of our APIs need to be pointers (for nullability, compatibility with C wrappers, convenience, etc.) and we were using references and pointers randomly in different places. This commit goes in the direction of adopting the LLVM rule of using pointers for referring to functions and let the Module manage their lifetime. This is also consistent with the way we use Nodes in the graph. 

Also, add a map to clone() to report the mapping. This will be used in an upcoming change. 
