### PR TITLE
[JIT] LocalResponseNormalization instruction for JIT

### DIFF
--- a/lib/Backends/JIT/LLVMIRGen.cpp
+++ b/lib/Backends/JIT/LLVMIRGen.cpp
@@ -482,6 +482,29 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     break;
   }
 
+  case Kinded::Kind::LocalResponseNormalizationInstKind: {
+    LocalResponseNormalizationInst *LRN =
+        llvm::cast<LocalResponseNormalizationInst>(I);
+    auto *destPtr =
+        emitValueAddress(builder, LRN->getDest(), ElemKind::FloatTy);
+    auto *srcPtr = emitValueAddress(builder, LRN->getSrc(), ElemKind::FloatTy);
+    auto *scalePtr =
+        emitValueAddress(builder, LRN->getScale(), ElemKind::FloatTy);
+    auto *destDims = emitValueDims(builder, LRN->getDest());
+    auto *srcDims = emitValueDims(builder, LRN->getSrc());
+
+    auto *halfWindow = emitConst(builder, LRN->getHalfWindowSize());
+    auto *alpha = emitConst(builder, LRN->getAlpha());
+    auto *beta = emitConst(builder, LRN->getBeta());
+    auto *k = emitConst(builder, LRN->getK());
+
+    auto *F = getFunction("libjit_local_response_normalization_f");
+    assert(F && "Unable to load the function");
+    builder.CreateCall(F, {destPtr, srcPtr, scalePtr, destDims, srcDims,
+                           halfWindow, alpha, beta, k});
+    break;
+  }
+
   case Kinded::Kind::PoolMaxInstKind: {
     PoolMaxInst *PM = llvm::cast<PoolMaxInst>(I);
     auto *destPtr = emitValueAddress(builder, PM->getDest(), ElemKind::FloatTy);

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -20,6 +20,9 @@ void trainConvNet(glow::Tensor *inputs, glow::Tensor *kernel1,
                   llvm::ArrayRef<size_t> shape1, llvm::ArrayRef<size_t> shape2,
                   glow::Tensor *out, glow::BackendKind kind);
 
+void inferLocalResponseNormalizationNet(glow::Tensor *inputs, glow::Tensor *out,
+                                        glow::BackendKind kind);
+
 void inferMaxNet(glow::Tensor *inputs1, glow::Tensor *inputs2,
                  glow::Tensor *out, glow::BackendKind kind);
 

--- a/tests/unittests/JITTest.cpp
+++ b/tests/unittests/JITTest.cpp
@@ -98,6 +98,20 @@ TEST(JITCorrectnessTest, convGradTest) {
   EXPECT_TRUE(H1.isEqual(H2));
 }
 
+TEST(JITCorrectnessTest, localResponseNormalizationTest) {
+  Tensor inputs(ElemKind::FloatTy, {8, 15, 13, 30});
+  inputs.getHandle().initXavier(1);
+  Tensor out1;
+  Tensor out2;
+
+  inferLocalResponseNormalizationNet(&inputs, &out1, BackendKind::JIT);
+  inferLocalResponseNormalizationNet(&inputs, &out2, BackendKind::Interpreter);
+  auto H1 = out1.getHandle();
+  auto H2 = out2.getHandle();
+
+  EXPECT_TRUE(H1.isEqual(H2));
+}
+
 TEST(JITCorrectnessTest, maxTest) {
   std::array<size_t, 3> S{{3, 8, 2}};
   llvm::ArrayRef<size_t> shape(S);


### PR DESCRIPTION
This commit adds support for the LocalResponseNormalization instruction to the JIT.  It does so with a slightly-better algorithm than the naive implementation, removing the dependency of the complexity on the window size.  This commit also adds an associated unit test.

Reference Implementation (tested in JIT):
```
for (size_t c = 0; c < inWdims[3]; c++) {
  float m2 = 0.0;
  for (size_t i = (c >= halfWindow ? c - halfWindow : 0);
       i <= MIN(c + halfWindow, inWdims[3] - 1); i++) {
    float val = inW[libjit_getXYZW(inWdims, n, h, w, i)];
    m2 += val * val;
  }
  float scale = k + normedAlpha * m2;
  scaleCache[libjit_getXYZW(inWdims, n, h, w, c)] = scale;
  float normFactor = pow(scale, -beta);
  outW[libjit_getXYZW(outWdims, n, h, w, c)] =
      inW[libjit_getXYZW(inWdims, n, h, w, c)] * normFactor;
}
```
