### PR TITLE
Fix a bug related to the visibility of Variables

### DIFF
--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -57,9 +57,10 @@ public:
     initPayload();
   }
 
-  Variable(llvm::StringRef name, Tensor &&payload)
+  Variable(llvm::StringRef name, VisibilityKind visibility, Tensor &&payload)
       : Node(Kinded::Kind::VariableNodeKind, name), val_(0.0),
-        train_(TrainKind::None), payload_(std::move(payload)) {
+        train_(TrainKind::None), visibility_(visibility),
+        payload_(std::move(payload)) {
     addResult(&payload_.getType());
   }
 

--- a/lib/Importer/Caffe2.cpp
+++ b/lib/Importer/Caffe2.cpp
@@ -367,8 +367,10 @@ void caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     Tensor wtag;
     w->getHandle<>().transpose(&wtag, {1, 0});
 
-    auto W = G_.getParent()->addVar(new Variable("weights", std::move(wtag)));
-    auto B = G_.getParent()->addVar(new Variable("biases", std::move(*b)));
+    auto W = G_.getParent()->addVar(new Variable(
+        "weights", Variable::VisibilityKind::Private, std::move(wtag)));
+    auto B = G_.getParent()->addVar(new Variable(
+        "biases", Variable::VisibilityKind::Private, std::move(*b)));
     auto *FC = G_.createFullyConnected(op.name(), in, W, B);
 
     // Save the outputs:


### PR DESCRIPTION
One of the constructors forgot to take the visibility argument and created "public" variables by default, even though they should be private.