### PR TITLE
Do not use llvm_unreachable in Type.h

### DIFF
--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -5,7 +5,6 @@
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
-#include "llvm/Support/ErrorHandling.h"
 
 #include <cstddef>
 #include <cstdint>
@@ -195,7 +194,7 @@ struct Type final {
     case ElemKind::IndexTy:
       return std::is_same<ElemTy, size_t>::value;
     }
-    llvm_unreachable("Invalid type.");
+    GLOW_UNREACHABLE("Invalid type.");
   }
 
   /// \returns true if the type of this Tensor is one of the integer types.
@@ -221,7 +220,7 @@ struct Type final {
     case ElemKind::IndexTy:
       return sizeof(size_t);
     }
-    llvm_unreachable("Invalid type.");
+    GLOW_UNREACHABLE("Invalid type.");
   }
 
   /// \return the textual name of the element.

--- a/include/glow/Support/Compiler.h
+++ b/include/glow/Support/Compiler.h
@@ -18,4 +18,7 @@
 #define GLOW_ASSERT_IMPL(e, file, line)                                        \
   ((void)printf("%s:%u: failed assertion `%s'\n", file, line, e), abort())
 
+#define GLOW_UNREACHABLE(msg)                                                  \
+  ((void)printf("%s:%u: %s\n", __FILE__, __LINE__, msg), abort())
+
 #endif // GLOW_SUPPORT_COMPILER_H


### PR DESCRIPTION
Removing this dependency on LLVM dramatically decreases the size of the binaries using only Glow's Tensors, but none of the graph or IR functionality.