### PR TITLE
[JIT] Introduce a dedicated type AllocationsInfo for handling memory allocation related functionality

### DIFF
--- a/lib/Backends/JIT/AllocationsInfo.cpp
+++ b/lib/Backends/JIT/AllocationsInfo.cpp
@@ -1,0 +1,157 @@
+#define DEBUG_TYPE "jit-allocations"
+
+#include "AllocationsInfo.h"
+#include "glow/CodeGen/MemoryAllocator.h"
+#include "glow/Graph/Graph.h"
+#include "glow/Graph/Nodes.h"
+#include "glow/IR/Instrs.h"
+
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace glow;
+
+using namespace glow;
+using llvm::StringRef;
+using llvm::cast;
+using llvm::dyn_cast;
+using llvm::isa;
+
+void AllocationsInfo::allocateWeightVars(IRFunction *F, bool reuseAddresses) {
+  // Use two different allocators, because constant weights and mutable weights
+  // may use different memory blocks.
+  MemoryAllocator constantWeightVarsAllocator(0);
+  MemoryAllocator mutableWeightVarsAllocator(0);
+
+  // Compute the new offsets for all the weights, do not reuse their current
+  // addresses. Process all constant WeightVars first.
+  for (auto &v : F->getGraph()->getParent()->getVars()) {
+    assert(isa<WeightVar>(F->getWeightForNode(v)));
+    auto *w = cast<WeightVar>(F->getWeightForNode(v));
+    if (v->getVisibilityKind() == Variable::VisibilityKind::Public)
+      continue;
+    auto numBytes = w->getType()->getSizeInBytes();
+    size_t addr = constantWeightVarsAllocator.allocate(numBytes);
+    if (!reuseAddresses) {
+      allocatedAddressed_[w] = addr;
+    } else {
+      // Reuse the address used by the payload.
+      allocatedAddressed_[w] =
+          v->getPayload().getUnsafePtr() - static_cast<char *>(nullptr);
+    }
+  }
+
+  // Process all mutable WeightVars afterwards.
+  for (auto &v : F->getGraph()->getParent()->getVars()) {
+    assert(isa<WeightVar>(F->getWeightForNode(v)));
+    auto *w = cast<WeightVar>(F->getWeightForNode(v));
+    if (v->getVisibilityKind() != Variable::VisibilityKind::Public)
+      continue;
+    auto numBytes = w->getType()->getSizeInBytes();
+    size_t addr = mutableWeightVarsAllocator.allocate(numBytes);
+    if (!reuseAddresses) {
+      allocatedAddressed_[w] = addr;
+    } else {
+      // Reuse the address used by the payload.
+      allocatedAddressed_[w] =
+          v->getPayload().getUnsafePtr() - static_cast<char *>(nullptr);
+    }
+  }
+
+  // Remember that max required memory size for each kind of weights.
+  constantWeightVarsMemSize_ = constantWeightVarsAllocator.getMaxMemoryUsage();
+  mutableWeightVarsMemSize_ = mutableWeightVarsAllocator.getMaxMemoryUsage();
+
+  DEBUG(for (auto &A
+             : allocatedAddressed_) {
+    auto origin = getOrigin(A.first);
+    if (isa<AllocActivationInst>(origin))
+      continue;
+    assert(valueNumbers_.count(origin) && "Unknown weight");
+    llvm::StringRef kind =
+        valueNumbers_[origin].first == ValueKind::ConstantWeight
+            ? "constant weight"
+            : "mutable weight";
+    llvm::errs() << "Allocated " << kind << " " << A.first->getName()
+                 << " size: " << A.first->getType()->getSizeInBytes()
+                 << "  address range:  [" << allocatedAddressed_[origin] << ", "
+                 << allocatedAddressed_[origin] +
+                        A.first->getType()->getSizeInBytes()
+                 << "]\n";
+  });
+}
+
+void AllocationsInfo::allocateActivations(IRFunction *F) {
+  // Use a memory allocator with no upper bound on how much memory we can
+  // allocate.
+  MemoryAllocator activationsAllocator(0);
+
+  // Maps activations and views to some offset within the heap.
+  llvm::DenseMap<Value *, size_t> activationAddr;
+
+  // Assign device-space addresses to the activations.
+  for (auto &I : F->getInstrs()) {
+    if (auto *A = dyn_cast<AllocActivationInst>(I)) {
+      auto numBytes = I->getType()->getSizeInBytes();
+      size_t addr = activationsAllocator.allocate(numBytes);
+      assert(!activationAddr.count(A) && "Allocation already made!");
+      activationAddr[A] = addr;
+      continue;
+    }
+
+    if (auto *D = dyn_cast<DeallocActivationInst>(I)) {
+      auto *A = D->getAlloc();
+      assert(activationAddr.count(A) && "Invalid deallocation!");
+      activationsAllocator.deallocate(activationAddr[A]);
+      continue;
+    }
+  }
+
+  activationsMemSize_ = activationsAllocator.getMaxMemoryUsage();
+
+  // Register specific addresses within the heap to activations.
+  for (auto &A : activationAddr) {
+    allocatedAddressed_[A.first] = A.second;
+  }
+  DEBUG(for (auto &A
+             : allocatedAddressed_) {
+    llvm::errs() << "Allocated activation " << A.first->getName()
+                 << " size: " << A.first->getType()->getSizeInBytes()
+                 << "  address range:  ["
+                 << allocatedAddressed_[getOrigin(A.first)] << ", "
+                 << allocatedAddressed_[A.first] +
+                        A.first->getType()->getSizeInBytes()
+                 << "]\n";
+  });
+}
+
+void AllocationsInfo::numberValues(IRFunction *F) {
+  size_t valueIdx = 0;
+  // Assign numbers to all weights.
+  for (auto &v : F->getGraph()->getParent()->getVars()) {
+    assert(isa<WeightVar>(F->getWeightForNode(v)));
+    auto *w = cast<WeightVar>(F->getWeightForNode(v));
+    auto kind = v->getVisibilityKind() != Variable::VisibilityKind::Public
+                    ? ValueKind::ConstantWeight
+                    : ValueKind::MutableWeight;
+    valueNumbers_[w] = std::make_pair(kind, valueIdx++);
+  }
+  // Assign numbers to all activations.
+  for (auto &I : F->getInstrs()) {
+    if (auto *A = dyn_cast<AllocActivationInst>(I)) {
+      valueNumbers_[A] = std::make_pair(ValueKind::Activation, valueIdx++);
+      continue;
+    }
+  }
+}
+
+void AllocationsInfo::clear() {
+  allocatedAddressed_.clear();
+  valueNumbers_.clear();
+  baseActivationsAddress_ = nullptr;
+  baseConstantWeightVarsAddress_ = nullptr;
+  baseMutableWeightVarsAddress_ = nullptr;
+  activationsMemSize_ = 0;
+  constantWeightVarsMemSize_ = 0;
+  mutableWeightVarsMemSize_ = 0;
+}

--- a/lib/Backends/JIT/AllocationsInfo.h
+++ b/lib/Backends/JIT/AllocationsInfo.h
@@ -1,0 +1,59 @@
+#ifndef GLOW_BACKENDS_JIT_ALLOCATIONSINFO_H
+#define GLOW_BACKENDS_JIT_ALLOCATIONSINFO_H
+
+#include "llvm/IR/Module.h"
+
+#include <functional>
+
+namespace glow {
+class Value;
+class IRFunction;
+class WeightVar;
+class Variable;
+
+/// Information about allocations for activations, constant weight variables
+/// and mutable weight variables.
+struct AllocationsInfo {
+  /// Different kinds of values that need to be allocated.
+  enum class ValueKind { ConstantWeight, MutableWeight, Activation };
+  using KindAndNumber = std::pair<ValueKind, size_t>;
+  /// Map Values in the module to their numbers.
+  llvm::DenseMap<Value *, KindAndNumber> valueNumbers_;
+  /// To get the offset of a given value simply use
+  /// numberOffsets_[valueNumbers_[v]]
+
+  /// Maps Values in the module to their offsets.
+  llvm::DenseMap<Value *, size_t> allocatedAddressed_;
+  /// Amount of memory to be allocated for constant WeightVars.
+  size_t constantWeightVarsMemSize_{0};
+  /// Amount of memory to be allocated for mutable WeightVars.
+  size_t mutableWeightVarsMemSize_{0};
+  /// Amount of memory to be allocated for activations.
+  size_t activationsMemSize_{0};
+  /// Base address of constant weights.
+  uint8_t *baseConstantWeightVarsAddress_{nullptr};
+  /// Base address of mutable WeightVars.
+  uint8_t *baseMutableWeightVarsAddress_{nullptr};
+  /// Base address of activations.
+  uint8_t *baseActivationsAddress_{nullptr};
+
+  /// Assign offsets to all WeightVars of \p M.
+  /// If the \p reuseAddresses is true, simply reuse the addresses already used
+  /// by the payloads of tensors corresponding to those WeightVars as offsets.
+  /// This is useful in a JIT setup. If \p reuseAddresses is false, then all the
+  /// WeightVars will get new offsets assigned.
+  void allocateWeightVars(IRFunction *F, bool reuseAddresses);
+  /// Assign offsets to all activations.
+  /// No actual memory allocation is performed. All the allocations should be
+  /// performed by the client based on the information provided by the
+  /// AllocationsInfo.
+  void allocateActivations(IRFunction *F);
+  /// Number all allocations and weight variables by assigning them unique
+  /// numbers.
+  void numberValues(IRFunction *F);
+  /// Reset the state of the allocation info.
+  void clear();
+};
+
+} // namespace glow
+#endif // GLOW_BACKENDS_JIT_ALLOCATIONSINFO_H

--- a/lib/Backends/JIT/CMakeLists.txt
+++ b/lib/Backends/JIT/CMakeLists.txt
@@ -13,6 +13,7 @@ add_custom_command(OUTPUT
                    DEPENDS ${LIBJITSRC}
                    COMMENT "Clang: Generating runtime bytecode library." VERBATIM)
 add_library(JIT
+            AllocationsInfo.cpp
             FunctionSpecializer.cpp
             GlowJIT.cpp
             Pipeline.cpp

--- a/lib/Backends/JIT/JIT.cpp
+++ b/lib/Backends/JIT/JIT.cpp
@@ -81,6 +81,19 @@ static std::unique_ptr<llvm::Module> loadStandardLibrary(llvm::LLVMContext *ctx,
   return llvm::parseIRFile(filename, Err, *ctx);
 }
 
+void JITBackend::performJITMemoryAllocation() {
+  allocationsInfo_.clear();
+  allocationsInfo_.numberValues(M_);
+  allocationsInfo_.allocateActivations(M_);
+  // Tell the allocateWeightVars to reuse existing addresses for weights.
+  allocationsInfo_.allocateWeightVars(M_, true);
+  // Allocate the heap to match the max memory usage for activations.
+  if (allocationsInfo_.activationsMemSize_ > 0) {
+    heap_.resize(allocationsInfo_.activationsMemSize_);
+    allocationsInfo_.baseActivationsAddress_ = &heap_[0];
+  }
+}
+
 void JITBackend::init() {
   // Load the jit library as a new module.
   llmodule_ = loadStandardLibrary(&ctx_, "libjit.bc");
@@ -100,7 +113,7 @@ void JITBackend::init() {
   llvm::BasicBlock *entry_bb = llvm::BasicBlock::Create(ctx_, "entry", func_);
   llvm::IRBuilder<> builder(entry_bb);
 
-  allocateActivationsAndWeights();
+  performJITMemoryAllocation();
 
   // For each instruction in the module:
   for (auto &I : M_->getInstrs()) {
@@ -145,70 +158,3 @@ void JITBackend::doForwardPass(bool isTrain) {
   }
 }
 
-void JITBackend::allocateActivationsAndWeights() {
-  // Use a memory allocator with no upper bound on how much memory we can
-  // allocate.
-  MemoryAllocator allocator(0);
-  allocatedAddressed_.clear();
-
-  // Maps activations and views to some offset within the heap.
-  llvm::DenseMap<Value *, size_t> activationAddr;
-
-  // Register the addresses of the tensor payload.
-  for (auto &v : M_->getGraph()->getParent()->getVars()) {
-    auto *w = M_->getWeightForNode(v);
-    allocatedAddressed_[w] = v->getPayload().getUnsafePtr();
-  }
-
-  // Assign device-space addresses to the activations.
-  for (auto &I : M_->getInstrs()) {
-    if (auto *A = llvm::dyn_cast<AllocActivationInst>(I)) {
-      auto numBytes = I->getType()->getSizeInBytes();
-      size_t addr = allocator.allocate(numBytes);
-      assert(!activationAddr.count(A) && "Allocation already made!");
-      activationAddr[A] = addr;
-      continue;
-    }
-
-    if (auto *TV = llvm::dyn_cast<TensorViewInst>(I)) {
-      // If the source is heap allocated then add it to the 'heap' map.
-      if (activationAddr.count(TV->getSrc())) {
-        assert(!activationAddr.count(TV) && "Allocation already made!");
-        assert(activationAddr.count(TV->getSrc()) && "Can't find TV source");
-        activationAddr[TV] = activationAddr[TV->getSrc()];
-      } else {
-        assert(allocatedAddressed_.count(TV->getSrc()) &&
-               "Can't find the Weight address");
-        allocatedAddressed_[TV] = allocatedAddressed_[TV->getSrc()];
-      }
-      continue;
-    }
-
-    if (auto *D = llvm::dyn_cast<DeallocActivationInst>(I)) {
-      auto *A = D->getAlloc();
-      assert(activationAddr.count(A) && "Invalid deallocation!");
-      allocator.deallocate(activationAddr[A]);
-      continue;
-    }
-  }
-
-  // Allocate the heap to match the max memory usage.
-  heap_.resize(allocator.getMaxMemoryUsage());
-
-  // Register specific addresses within the heap to activations.
-  for (auto &A : activationAddr) {
-    allocatedAddressed_[A.first] = &heap_[0] + A.second;
-  }
-
-  DEBUG(for (auto &A
-             : allocatedAddressed_) {
-    llvm::errs() << "Allocated " << A.first->getName()
-                 << " size: " << A.first->getType()->getSizeInBytes()
-                 << "  address range:  [" << allocatedAddressed_[A.first]
-                 << ", "
-                 << static_cast<void *>(
-                        (static_cast<char *>(allocatedAddressed_[A.first]) +
-                         A.first->getType()->getSizeInBytes()))
-                 << "]\n";
-  });
-}

--- a/lib/Backends/JIT/LLVMIRGen.cpp
+++ b/lib/Backends/JIT/LLVMIRGen.cpp
@@ -12,9 +12,14 @@ using llvm::isa;
 
 llvm::Value *JITBackend::emitValueAddress(llvm::IRBuilder<> &builder,
                                           glow::Value *val, ElemKind ptrTy) {
-  assert(allocatedAddressed_.count(val) && "Value address was not allocated");
-  void *ptr = allocatedAddressed_[val];
-  auto *offset = emitConst(builder, (size_t)ptr);
+  val = getOrigin(val);
+  assert(allocationsInfo_.allocatedAddressed_.count(val) &&
+         "Value address was not allocated");
+  size_t addr = allocationsInfo_.allocatedAddressed_[val];
+  if (isa<AllocActivationInst>(val)) {
+    addr += reinterpret_cast<size_t>(allocationsInfo_.baseActivationsAddress_);
+  }
+  auto *offset = emitConst(builder, addr);
 
   llvm::Type *T = nullptr;
 


### PR DESCRIPTION
It centralizes the logic for assigning addresses/offsets to activations and WeightVars.
The type itself does not perform any actual memory allocation, it only computes the offsets and sizes of different memory areas. The clients of AllocationsInfo are responsible for the actual memory allocation.