### PR TITLE
[JIT] Introduce the LLVMIRGen class and move a lot of common functionality from JITBackend into it

### DIFF
--- a/lib/Backends/JIT/FunctionSpecializer.cpp
+++ b/lib/Backends/JIT/FunctionSpecializer.cpp
@@ -310,7 +310,7 @@ private:
 
 } // namespace
 
-void JITBackend::performSpecialization() {
+void LLVMIRGen::performSpecialization() {
   FunctionSpecializer FuncSpecializer;
   FuncSpecializer.run(llmodule_.get());
 }

--- a/lib/Backends/JIT/GlowJIT.h
+++ b/lib/Backends/JIT/GlowJIT.h
@@ -27,7 +27,7 @@ namespace orc {
 // KaleidoscopeJIT example in the LLVM tree.
 class GlowJIT {
 private:
-  std::unique_ptr<TargetMachine> TM_;
+  TargetMachine &TM_;
   const DataLayout DL_;
   RTDyldObjectLinkingLayer objectLayer_;
   IRCompileLayer<decltype(objectLayer_), SimpleCompiler> compileLayer_;
@@ -35,9 +35,9 @@ private:
 public:
   using ModuleHandle = decltype(compileLayer_)::ModuleHandleT;
 
-  GlowJIT();
+  GlowJIT(llvm::TargetMachine &TM);
 
-  TargetMachine &getTargetMachine() { return *TM_; }
+  TargetMachine &getTargetMachine() { return TM_; }
 
   ModuleHandle addModule(std::unique_ptr<Module> M);
 

--- a/lib/Backends/JIT/JIT.h
+++ b/lib/Backends/JIT/JIT.h
@@ -3,7 +3,7 @@
 
 #include "AllocationsInfo.h"
 #include "GlowJIT.h"
-
+#include "LLVMIRGen.h"
 #include "glow/Backends/Backend.h"
 #include "glow/Base/Tensor.h"
 
@@ -20,60 +20,24 @@ class Value;
 class Tensor;
 class Variable;
 class Instruction;
+class WeightVar;
+struct AllocationsInfo;
 
 class JITBackend final : public Backend {
   /// The Module that holds the glow IR. This does not own the module.
-  IRFunction *M_;
-  /// The LLVM context.
-  llvm::LLVMContext ctx_;
-  /// The LLVM IR module.
-  std::unique_ptr<llvm::Module> llmodule_{nullptr};
-  /// Points to the main function in the jitted code. The function is owned by
-  /// the LLVM module.
-  llvm::Function *func_{nullptr};
-  /// Maps constant arrays to the constant expressions representing size_t
-  /// pointers to these arrays. This is done to ensure the proper uniqueness
-  /// semantics of such pointers just like it is done for llvm::Constants.
-  llvm::DenseMap<llvm::Constant *, llvm::Value *> constArrayPtrs_;
-  /// This represents the heap, that stores the activations at runtime.
-  std::vector<uint8_t> heap_{};
+  IRFunction *F_;
   /// Information about allocations.
   AllocationsInfo allocationsInfo_;
   /// The LLVM JIT engine. The jit must be initialized after the ctor
   /// initializes the LLVM backends.
   std::unique_ptr<llvm::orc::GlowJIT> JIT_{nullptr};
-  /// Generates LLVM IR that computes the address of \p val using \p builder.
-  /// The address type is specified by \p ptrTy.
-  llvm::Value *emitValueAddress(llvm::IRBuilder<> &builder, glow::Value *val,
-                                ElemKind ptrTy);
-  /// Generates LLVM IR that computes the size of the tensor of \p val using
-  /// \p builder. The size type is native to the machine (size_t).
-  llvm::Value *emitValueSize(llvm::IRBuilder<> &builder, glow::Value *val);
-  /// Generates LLVM IR that materializes the constant \p val.
-  llvm::Value *emitConst(llvm::IRBuilder<> &builder, float val);
-  /// Generates LLVM IR that materializes the constant \p val.
-  llvm::Value *emitConst(llvm::IRBuilder<> &builder, size_t val);
-  /// Generates LLVM IR that materializes the constant array \p vals.
-  llvm::Value *emitConstArray(llvm::IRBuilder<> &builder,
-                              llvm::ArrayRef<size_t> vals);
-  /// Generates LLVM IR that computes the dimensions of \p val using \p builder.
-  /// The result type is "size_t*".
-  llvm::Value *emitValueDims(llvm::IRBuilder<> &builder, glow::Value *val);
 
-  /// \returns a function from the module that we are building on nullptr if
-  /// none was found.
-  llvm::Function *getFunction(const std::string &name);
-
-  /// Emit LLVM-IR for the instruction \p I, using the builder \p builder.
-  void generateLLVMIRForInstr(llvm::IRBuilder<> &builder, glow::Instruction *I);
-
-  /// Optimize the function \p F and the module that owns it. Use the target
-  /// information from the \p TM target machine.
-  void optimizeLLVMModule(llvm::Function *F, llvm::TargetMachine &TM);
-
-  /// Performs specialization of operations based on constant parameters.
-  void performSpecialization();
-  
+  /// The LLVM IR code generator.
+  LLVMIRGen irgen_;
+  /// This represents the heap, that stores the activations at runtime.
+  std::vector<uint8_t> heap_{};
+  /// Produce the main entry point for JIT execution.
+  void emitJitMain();
   /// Perform memory allocation for a JIT execution.
   void performJITMemoryAllocation();
   

--- a/lib/Backends/JIT/LLVMIRGen.cpp
+++ b/lib/Backends/JIT/LLVMIRGen.cpp
@@ -1,8 +1,19 @@
 // Copyright 2017 Facebook Inc.  All Rights Reserved.
 
-#include "JIT.h"
+#include "LLVMIRGen.h"
 
+#include "glow/Graph/Graph.h"
 #include "glow/IR/Instrs.h"
+
+#include "llvm/ExecutionEngine/ExecutionEngine.h"
+#include "llvm/IR/LegacyPassManager.h"
+#include "llvm/IR/Verifier.h"
+#include "llvm/IRReader/IRReader.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/TargetSelect.h"
+#include "llvm/Target/TargetMachine.h"
 
 using namespace glow;
 using llvm::StringRef;
@@ -10,8 +21,181 @@ using llvm::cast;
 using llvm::dyn_cast;
 using llvm::isa;
 
-llvm::Value *JITBackend::emitValueAddress(llvm::IRBuilder<> &builder,
-                                          glow::Value *val, ElemKind ptrTy) {
+static llvm::cl::opt<bool>
+    dumpIR("dump-llvm-ir",
+           llvm::cl::desc("Dump the LLVM-IR of the jitted code"),
+           llvm::cl::init(false));
+
+static llvm::cl::opt<bool>
+    dumpJitAsm("dump-llvm-asm",
+               llvm::cl::desc("Dump the textual assembly of the jitted code"),
+               llvm::cl::init(false));
+
+/// Generate the LLVM MAttr list of attributes.
+static llvm::SmallVector<std::string, 0> getMachineAttributes() {
+  llvm::SmallVector<std::string, 0> result;
+  llvm::StringMap<bool> hostFeatures;
+  if (llvm::sys::getHostCPUFeatures(hostFeatures)) {
+    for (auto &feature : hostFeatures) {
+      if (feature.second) {
+        llvm::StringRef fn = feature.first();
+        // Skip avx512 because LLVM does not support it well.
+        if (fn.startswith("avx512")) {
+          continue;
+        }
+        result.push_back(fn);
+      }
+    }
+  }
+  return result;
+}
+
+/// Returns the CPU hostname.
+static llvm::StringRef getHostCpuName() {
+  auto cpu_name = llvm::sys::getHostCPUName();
+  // Skip avx512 because LLVM does not support it well.
+  cpu_name.consume_back("-avx512");
+  return cpu_name;
+}
+
+/// Initialize LLVM native target related data structures.
+static void LLVMInitializeNative() {
+  llvm::InitializeNativeTarget();
+  llvm::InitializeNativeTargetAsmPrinter();
+}
+
+LLVMIRGen::LLVMIRGen(IRFunction *F, AllocationsInfo &allocationsInfo,
+                     std::string mainEntryName)
+    : F_(F), allocationsInfo_(allocationsInfo), mainEntryName_(mainEntryName) {}
+
+void LLVMIRGen::initTargetMachine(llvm::CodeModel::Model codeModel) {
+  TM_.reset(
+      (LLVMInitializeNative(),
+       llvm::EngineBuilder().setCodeModel(codeModel).selectTarget(
+           llvm::Triple(), "", getHostCpuName(), getMachineAttributes())));
+}
+
+std::string LLVMIRGen::getMainEntryName() const {
+  StringRef name = mainEntryName_.empty() ? "main" : F_->getGraph()->getName();
+  auto delimPos = name.rfind('/');
+  if (delimPos != StringRef::npos)
+    name = name.substr(delimPos + 1);
+  return name;
+}
+
+void LLVMIRGen::setMainEntryName(std::string name) { mainEntryName_ = name; }
+
+/// Load base addresses of different memory areas so that they can be easily
+/// reused during codegen.
+void LLVMIRGen::loadBaseAddresses(llvm::IRBuilder<> &builder) {
+  auto *F = builder.GetInsertBlock()->getParent();
+
+  // Load the base addresses at the beginning of the entry function once they
+  // are set. They won't change after this point and all relative addressing
+  // computations will simply use them.
+  baseActivationsAddr_ = builder.CreatePtrToInt(F->args().begin() + 2,
+                                                llvm::Type::getInt64Ty(ctx_));
+  baseConstantWeightVarsAddr_ =
+      builder.CreatePtrToInt(F->args().begin(), llvm::Type::getInt64Ty(ctx_));
+  baseMutableWeightVarsAddr_ = builder.CreatePtrToInt(
+      F->args().begin() + 1, llvm::Type::getInt64Ty(ctx_));
+  offsetsArray_ = F->args().begin() + 3;
+}
+
+// Search for the standard library bitcode file on disk and load it into an
+// LLVM module. We search for the standard library around the current executable
+// and also in the current directory.
+static std::unique_ptr<llvm::Module> loadStandardLibrary(llvm::LLVMContext *ctx,
+                                                         StringRef filename) {
+  using llvm::sys::path::append;
+  using llvm::sys::path::parent_path;
+
+  llvm::SMDiagnostic Err;
+  auto mainExec =
+      llvm::sys::fs::getMainExecutable(nullptr, (void *)&loadStandardLibrary);
+  StringRef basePath = parent_path(mainExec);
+
+  for (int i = 0; i < 3; i++) {
+    llvm::SmallString<256> libPath(basePath);
+    append(libPath, filename);
+    if (llvm::sys::fs::exists(libPath)) {
+      return llvm::parseIRFile(libPath, Err, *ctx);
+    }
+
+    basePath = parent_path(basePath);
+  }
+
+  return llvm::parseIRFile(filename, Err, *ctx);
+}
+
+void LLVMIRGen::initCodeGen() {
+  // Load the jit library as a new module.
+  llmodule_ = loadStandardLibrary(&ctx_, "libjit.bc");
+  GLOW_ASSERT(llmodule_.get() && "Unable to load the JIT library.");
+
+  // Assign the target information to the module.
+  llmodule_->setDataLayout(getTargetMachine().createDataLayout());
+
+  // Create the entry function into the LLVM module.
+  auto int8PtrTy = llvm::Type::getInt8PtrTy(ctx_);
+  auto sizeTPtrTy = llvm::Type::getIntNPtrTy(ctx_, sizeof(size_t) * 8);
+  // The entry point has the following API:
+  // void entry(uint8_t *baseConstantWeightVars, uint8_t
+  // *baseInoutWeightVars, uint8_t *baseActivations, size_t *offsets);
+  llvm::Type *voidTy = llvm::Type::getVoidTy(ctx_);
+  llvm::FunctionType *jitFuncTy = llvm::FunctionType::get(
+      voidTy, {int8PtrTy, int8PtrTy, int8PtrTy, sizeTPtrTy}, false);
+  auto *func = llvm::Function::Create(
+      jitFuncTy, llvm::Function::ExternalLinkage, "main", llmodule_.get());
+
+  // Setup the entry basic block and initialize the IR builder.
+  llvm::BasicBlock *entry_bb = llvm::BasicBlock::Create(ctx_, "entry", func);
+  builder_ = llvm::make_unique<llvm::IRBuilder<>>(entry_bb);
+}
+
+void LLVMIRGen::performCodeGen() {
+  auto *func = builder_->GetInsertBlock()->getParent();
+  loadBaseAddresses(*builder_);
+
+  // For each instruction in the module:
+  for (auto &I : F_->getInstrs()) {
+    generateLLVMIRForInstr(*builder_, I);
+  }
+
+  // Terminate the function.
+  builder_->CreateRetVoid();
+
+  assert(!llvm::verifyFunction(*func, &llvm::errs()) &&
+         "Function verification failed");
+
+  if (dumpIR) {
+    llvm::outs() << "LLVM module before optimizations:\n";
+    llmodule_->print(llvm::outs(), nullptr);
+  }
+
+  // Optimize the module.
+  optimizeLLVMModule(func, getTargetMachine());
+
+  // And pass the ownership to the JIT.
+
+  if (dumpIR) {
+    llvm::outs() << "LLVM module after optimizations:\n";
+    llmodule_->print(llvm::outs(), nullptr);
+  }
+
+  if (dumpJitAsm) {
+    llvm::SmallVector<char, 0> asmBuffer;
+    llvm::raw_svector_ostream asmStream(asmBuffer);
+    llvm::legacy::PassManager PM;
+    getTargetMachine().addPassesToEmitFile(
+        PM, asmStream, llvm::TargetMachine::CodeGenFileType::CGFT_AssemblyFile);
+    PM.run(*llmodule_);
+    llvm::outs() << asmStream.str();
+  }
+}
+
+llvm::Value *LLVMIRGen::emitValueAddress(llvm::IRBuilder<> &builder,
+                                         glow::Value *val, ElemKind ptrTy) {
   val = getOrigin(val);
   assert(allocationsInfo_.allocatedAddressed_.count(val) &&
          "Value address was not allocated");
@@ -41,8 +225,38 @@ llvm::Value *JITBackend::emitValueAddress(llvm::IRBuilder<> &builder,
   return builder.CreateIntToPtr(offset, T);
 }
 
-llvm::Value *JITBackend::emitConstArray(llvm::IRBuilder<> &builder,
-                                        llvm::ArrayRef<size_t> vals) {
+llvm::Value *
+LLVMIRGen::emitConstOffsetsArray(llvm::IRBuilder<> &builder,
+                                 const AllocationsInfo &allocationsInfo) {
+
+  auto sizeTType = builder.getIntNTy(sizeof(size_t) * 8);
+  std::vector<llvm::Constant *> elems(allocationsInfo.valueNumbers_.size());
+  for (auto &I : allocationsInfo.valueNumbers_) {
+    auto *V = I.first;
+    auto offset = I.second.second;
+    elems[offset] = llvm::ConstantInt::get(
+        sizeTType, allocationsInfo.allocatedAddressed_.lookup(V));
+  }
+  auto *arr = llvm::ConstantArray::get(
+      llvm::ArrayType::get(sizeTType, elems.size()), elems);
+  // Ensure that the same casted global variable is used for the equivalent
+  // const arrays. This is important for the later function specialization pass.
+  // LLVM does not do it automatically for this code pattern involving global
+  // variables. It also reduces the number of variables.
+  auto &constArrayVar = constArrayPtrs_[arr];
+  if (constArrayVar)
+    return constArrayVar;
+
+  auto *M = builder.GetInsertBlock()->getModule();
+
+  auto *G = new llvm::GlobalVariable(*M, arr->getType(), true,
+                                     llvm::GlobalValue::InternalLinkage, arr);
+  constArrayVar = builder.CreateBitCast(G, sizeTType->getPointerTo());
+  return constArrayVar;
+}
+
+llvm::Value *LLVMIRGen::emitConstArray(llvm::IRBuilder<> &builder,
+                                       llvm::ArrayRef<size_t> vals) {
   auto SizeTType = builder.getIntNTy(sizeof(size_t) * 8);
   std::vector<llvm::Constant *> elems;
   for (auto I : vals) {
@@ -61,36 +275,36 @@ llvm::Value *JITBackend::emitConstArray(llvm::IRBuilder<> &builder,
   auto *M = builder.GetInsertBlock()->getModule();
 
   auto *G = new llvm::GlobalVariable(*M, arr->getType(), true,
-                                     llvm::GlobalValue::CommonLinkage, arr);
+                                     llvm::GlobalValue::InternalLinkage, arr);
   constArrayVar = builder.CreateBitCast(G, SizeTType->getPointerTo());
   return constArrayVar;
 }
 
-llvm::Value *JITBackend::emitValueDims(llvm::IRBuilder<> &builder,
-                                       glow::Value *val) {
+llvm::Value *LLVMIRGen::emitValueDims(llvm::IRBuilder<> &builder,
+                                      glow::Value *val) {
   auto dims = val->dims();
   return emitConstArray(builder, dims);
 }
 
-llvm::Value *JITBackend::emitValueSize(llvm::IRBuilder<> &builder,
-                                       glow::Value *val) {
+llvm::Value *LLVMIRGen::emitValueSize(llvm::IRBuilder<> &builder,
+                                      glow::Value *val) {
   return builder.getIntN(sizeof(size_t) * 8, val->getType()->size());
 }
 
-llvm::Value *JITBackend::emitConst(llvm::IRBuilder<> &builder, float val) {
+llvm::Value *LLVMIRGen::emitConst(llvm::IRBuilder<> &builder, float val) {
   return llvm::ConstantFP::get(llvm::Type::getFloatTy(ctx_), val);
 }
 
-llvm::Value *JITBackend::emitConst(llvm::IRBuilder<> &builder, size_t val) {
+llvm::Value *LLVMIRGen::emitConst(llvm::IRBuilder<> &builder, size_t val) {
   return builder.getIntN(sizeof(size_t) * 8, val);
 }
 
-llvm::Function *JITBackend::getFunction(const std::string &name) {
+llvm::Function *LLVMIRGen::getFunction(const std::string &name) {
   return llmodule_->getFunction(name);
 }
 
-void JITBackend::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
-                                        glow::Instruction *I) {
+void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
+                                       glow::Instruction *I) {
   switch (I->getKind()) {
   case Kinded::Kind::SplatInstKind: {
     SplatInst *SI = llvm::cast<SplatInst>(I);

--- a/lib/Backends/JIT/LLVMIRGen.h
+++ b/lib/Backends/JIT/LLVMIRGen.h
@@ -1,0 +1,131 @@
+#ifndef GLOW_BACKENDS_JIT_LLVMIRGEN_H
+#define GLOW_BACKENDS_JIT_LLVMIRGEN_H
+
+#include "AllocationsInfo.h"
+#include "glow/Base/Tensor.h"
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/Module.h"
+
+namespace glow {
+
+class Context;
+class IRFunction;
+class Value;
+class Tensor;
+class Variable;
+class Instruction;
+class WeightVar;
+struct AllocationsInfo;
+
+/// This is a class containing a common logic for the generation of the LLVM IR
+/// from an IRFunction. The primary clients of this class are JITs and bundlers.
+class LLVMIRGen {
+  /// The Module that holds the glow IR. This does not own the module.
+  IRFunction *F_;
+  /// The LLVM context.
+  llvm::LLVMContext ctx_;
+  /// The LLVM IR module.
+  std::unique_ptr<llvm::Module> llmodule_{nullptr};
+  /// The target machine.
+  std::unique_ptr<llvm::TargetMachine> TM_;
+  /// Information about allocations.
+  AllocationsInfo &allocationsInfo_;
+  /// Name of the main entry.
+  std::string mainEntryName_;
+  /// Value holding the base address of the activations memory area.
+  llvm::Value *baseActivationsAddr_{nullptr};
+  /// Value holding the base address of the constant WeightVars memory area.
+  llvm::Value *baseConstantWeightVarsAddr_{nullptr};
+  /// Value holding the base address of mutable WeightVars memory area.
+  llvm::Value *baseMutableWeightVarsAddr_{nullptr};
+  /// Value holding the address of the offsets array.
+  llvm::Value *offsetsArray_{nullptr};
+  /// Maps constant arrays to the constant expressions representing size_t
+  /// pointers to these arrays. This is done to ensure the proper uniqueness
+  /// semantics of such pointers just like it is done for llvm::Constants.
+  llvm::DenseMap<llvm::Constant *, llvm::Value *> constArrayPtrs_;
+  /// The IRBuilder used for the code generation.
+  std::unique_ptr<llvm::IRBuilder<>> builder_;
+
+  /// Generates LLVM IR that computes the address of \p val using \p builder.
+  /// The address type is specified by \p ptrTy.
+  llvm::Value *emitValueAddress(llvm::IRBuilder<> &builder, glow::Value *val,
+                                ElemKind ptrTy);
+  /// Generates LLVM IR that computes the size of the tensor of \p val using
+  /// \p builder. The size type is native to the machine (size_t).
+  llvm::Value *emitValueSize(llvm::IRBuilder<> &builder, glow::Value *val);
+  /// Generates LLVM IR that materializes the constant \p val.
+  llvm::Value *emitConst(llvm::IRBuilder<> &builder, float val);
+  /// Generates LLVM IR that materializes the constant \p val.
+  llvm::Value *emitConst(llvm::IRBuilder<> &builder, size_t val);
+  /// Generates LLVM IR that materializes the constant array \p vals.
+  llvm::Value *emitConstArray(llvm::IRBuilder<> &builder,
+                              llvm::ArrayRef<size_t> vals);
+  /// Generates LLVM IR that computes the dimensions of \p val using \p builder.
+  /// The result type is "size_t*".
+  llvm::Value *emitValueDims(llvm::IRBuilder<> &builder, glow::Value *val);
+
+  /// Load base addresses of different memory areas (activations, const
+  /// weightvars, mutable weight vars) so that they can be reused inside the
+  /// body of the function.
+  void loadBaseAddresses(llvm::IRBuilder<> &builder);
+
+public:
+  /// Ctor.
+  explicit LLVMIRGen(IRFunction *M, AllocationsInfo &allocationsInfo,
+                     std::string mainEntryName);
+
+  /// Init the TargetMachine using a given code model.
+  void initTargetMachine(llvm::CodeModel::Model codeModel);
+
+  /// Emit LLVM-IR for the instruction \p I, using the builder \p builder.
+  void generateLLVMIRForInstr(llvm::IRBuilder<> &builder, glow::Instruction *I);
+  /// \returns a function from the module that we are building on nullptr if
+  /// none was found.
+  llvm::Function *getFunction(const std::string &name);
+  /// Creates global variables for the base addresses of different memory areas
+  /// and invokes a library function to set their values.
+  void
+  createGlobalVariables(llvm::IRBuilder<> &builder,
+                        llvm::ArrayRef<llvm::Value *> initFunctionCallArgs);
+  /// Optimize the function \p F and the module that owns it. Use the target
+  /// information from the \p TM target machine.
+  void optimizeLLVMModule(llvm::Function *F, llvm::TargetMachine &TM);
+  /// Performs specialization of operations based on constant parameters.
+  void performSpecialization();
+  /// \returns allocations info.
+  AllocationsInfo &getAllocationsInfo() { return allocationsInfo_; }
+  /// \returns the name of the main entry point.
+  /// When JITting, it will be "main". In case of bundling it will be the name
+  /// of the bundle.
+  std::string getMainEntryName() const;
+  /// Set the name of the main entry point.
+  void setMainEntryName(std::string name);
+  /// Creates an LLVM module, the entry function, etc.
+  void initCodeGen();
+  /// Emits the code of the entry function, performs optimizations, etc.
+  void performCodeGen();
+  /// \returns the current builder.
+  llvm::IRBuilder<> &getBuilder() { return *builder_; }
+  /// \returns the target machine description.
+  llvm::TargetMachine &getTargetMachine() { return *TM_; }
+  /// \returns the LLVMContext being used.
+  llvm::LLVMContext &getLLVMContext() { return ctx_; }
+  /// Borrows the LLVM module for further processing, e.g. by a JIT.
+  /// The module cannot be used by the LLVMIRGen afterwards.
+  std::unique_ptr<llvm::Module> borrowModule() { return std::move(llmodule_); }
+  /// \returns current LLVM module.
+  llvm::Module &getModule() { return *llmodule_; }
+  /// \returns the IR function.
+  IRFunction *getIRFunction() { return F_; }
+  /// Emit the array of constant offsets as provided by the \p allocationsInfo.
+  llvm::Value *emitConstOffsetsArray(llvm::IRBuilder<> &builder,
+                                     const AllocationsInfo &allocationsInfo);
+};
+
+} // namespace glow
+
+#endif // GLOW_BACKENDS_JIT_LLVMIRGEN_H

--- a/lib/Backends/JIT/Pipeline.cpp
+++ b/lib/Backends/JIT/Pipeline.cpp
@@ -40,8 +40,7 @@ using llvm::StringRef;
 using llvm::dyn_cast;
 using llvm::isa;
 
-void JITBackend::optimizeLLVMModule(llvm::Function *F,
-                                    llvm::TargetMachine &TM) {
+void LLVMIRGen::optimizeLLVMModule(llvm::Function *F, llvm::TargetMachine &TM) {
   auto *M = F->getParent();
 
   // Make all of the definitions from libjit and unnamed symbols internal and
@@ -94,7 +93,7 @@ void JITBackend::optimizeLLVMModule(llvm::Function *F,
     }
   }
 
-  llvm::legacy::FunctionPassManager FPM(F->getParent());
+  llvm::legacy::FunctionPassManager FPM(M);
   llvm::legacy::PassManager PM;
 
   // Add internal analysis passes from the target machine.
@@ -104,10 +103,10 @@ void JITBackend::optimizeLLVMModule(llvm::Function *F,
   PMB.populateFunctionPassManager(FPM);
   PMB.populateModulePassManager(PM);
   FPM.doInitialization();
-  PM.run(*F->getParent());
+  PM.run(*M);
   for (auto &FF : *M) {
     FPM.run(FF);
   }
   FPM.doFinalization();
-  PM.run(*F->getParent());
+  PM.run(*M);
 }


### PR DESCRIPTION
This re-factoring makes a lot of common code generation related functionality re-usable by different JITs and bundlers.