### PR TITLE
Add support for serializing bundles

### DIFF
--- a/include/glow/Backends/Backend.h
+++ b/include/glow/Backends/Backend.h
@@ -1,6 +1,8 @@
 #ifndef GLOW_BACKENDS_BACKEND_H
 #define GLOW_BACKENDS_BACKEND_H
 
+#include <llvm/ADT/StringRef.h>
+
 namespace glow {
 
 class Context;
@@ -28,6 +30,9 @@ public:
 
   /// Prepare the interpreter for execution of new code.
   virtual void init() = 0;
+
+  /// Save the bundle for a later standalone execution.
+  virtual void save(llvm::StringRef outputDir);
 
   /// Perform a single forward scan of the network, interpreting all of the
   /// instructions.

--- a/include/glow/ExecutionEngine/ExecutionEngine.h
+++ b/include/glow/ExecutionEngine/ExecutionEngine.h
@@ -36,6 +36,9 @@ class ExecutionEngine final {
   /// The kind of the backend being currently used.
   BackendKind backendKind_;
 
+  /// Optimize the graph, generate IR, and optimize the IR.
+  void generateIR(CompilationMode mode, Function *F);
+
 public:
   ExecutionEngine(BackendKind backendKind = BackendKind::Interpreter);
 
@@ -54,8 +57,14 @@ public:
   /// \returns the internal graph.
   Module &getModule() { return *M_; }
 
-  /// Optimize the graph, generate IR, and optimize the IR.
+  /// Optimize the graph, generate IR, optimize IR and compile it for a
+  /// specific target. This method should be invoked before the run method.
   void compile(CompilationMode mode, Function *F);
+
+  /// Save a bundle for a standalone execution. This method takes care of
+  /// everything when preparing the bundle for saving. There is no need to
+  /// invoke the compile method before it.
+  void save(CompilationMode mode, Function *F, llvm::StringRef outputDir);
 
   /// Provides access to the training configuration.
   TrainingConfig &getConfig() { return config_; }

--- a/lib/Backends/Backends.cpp
+++ b/lib/Backends/Backends.cpp
@@ -36,3 +36,7 @@ Backend *glow::createBackend(BackendKind backendKind, IRFunction *F) {
     break;
   }
 }
+
+void Backend::save(llvm::StringRef outputDir) {
+  llvm_unreachable("Saving a bundle is not supported by the backend");
+}

--- a/lib/Backends/JIT/JIT.h
+++ b/lib/Backends/JIT/JIT.h
@@ -40,6 +40,16 @@ class JITBackend final : public Backend {
   void emitJitMain();
   /// Perform memory allocation for a JIT execution.
   void performJITMemoryAllocation();
+  /// Perform memory allocation for a bundle.
+  void performBundleMemoryAllocation();
+  /// Save weights for the bundle.
+  void saveWeights(llvm::StringRef weightsFileName);
+  /// Produce a bundle.
+  void produceBundle(llvm::StringRef outputDir);
+  /// Emit config for a bundle.
+  void emitBundleConfig();
+  /// Emit the entry function for the bundle.
+  void emitBundleEntryFunction();
 
 public:
   /// Ctor.
@@ -53,6 +63,8 @@ public:
   void clear() override;
 
   void init() override;
+
+  void save(llvm::StringRef outputDir) override;
 
   void doForwardPass(bool isTrain) override;
 

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -103,7 +103,7 @@ void ExecutionEngine::loadValueFromTensor(Variable *v, Tensor *input) {
   t.copyFrom(input);
 }
 
-void ExecutionEngine::compile(CompilationMode mode, Function *F) {
+void ExecutionEngine::generateIR(CompilationMode mode, Function *F) {
   // Reset the engine and start a new compilation process.
   reset();
 
@@ -134,5 +134,15 @@ void ExecutionEngine::compile(CompilationMode mode, Function *F) {
 
   // Optimize the generated IR.
   ::glow::optimize(*IR_, mode);
+}
+
+void ExecutionEngine::compile(CompilationMode mode, Function *F) {
+  generateIR(mode, F);
   IP_->init();
+}
+
+void ExecutionEngine::save(CompilationMode mode, Function *F,
+                           llvm::StringRef outputDir) {
+  generateIR(mode, F);
+  IP_->save(outputDir);
 }


### PR DESCRIPTION
Each backend can now implement a `save` method to generate a bundle. As of now, only the JIT backend supports it.

To generate a bundle, use e.g. the following command-line:
loader tests/images/cat_285.png -image_mode=0to1 -d=resnet50 -jit -emit-bundle directory_path

This command would generate two artifacts: the code is serialized into the resnet50.o file and the weights are serialized into resnet50.weights file in the directory specified by the `-bundle-output-dir` parameter.

The generated code is a usual object file which you can link with any client code.

The code exposes an entry point, which has the same name as the bundle, i.e. resnet50 (the name is taken from the model being processes). This entry point has the following function signature and takes the pointers to the initialized memory allocated for constant and mutable weight variables:
`extern "C" void resnet50(uint8_t *constantWeightVarsBaseAddr, uint8_t *mutableWeightVarsBaseAddr, uint8_t *activationsBaseAddr);`

Another exposed symbol has a name which looks like the name of the bundle, but with a suffix `_config` at the end. In the example above, it would have a name `resnet50_config`. This is a structure of the following form, which contains the information about the sizes of the memory blocks for activations, constant weights variables and mutable weights variables:
```c++
struct BundleConfig {
size_t constantWeightVarsMemSize;
size_t mutableWeightVarsMemSize;
size_t activationsMemSize;
};
```

It is a responsibility of the client to properly prepare and initialize the memory blocks for the activations, constant weights variables and mutable weights variable before calling the exposed entry point.