### PR TITLE
[JIT] LRN instruction implementation options for the JIT

### DIFF
--- a/lib/Backends/JIT/libjit.c
+++ b/lib/Backends/JIT/libjit.c
@@ -339,58 +339,23 @@ void libjit_local_response_normalization_f(float *outW, const float *inW,
   for (size_t n = 0; n < inWdims[0]; n++) {
     for (size_t h = 0; h < inWdims[1]; h++) {
       for (size_t w = 0; w < inWdims[2]; w++) {
-        // Prepare right half of sliding window based at c = 0
-        float m2 = 0.0;
-        for (size_t i = 0; i < MIN(halfWindow, inWdims[3]); i++) {
-          float val = inW[libjit_getXYZW(inWdims, n, h, w, i)];
-          m2 += val * val;
-        }
-
-        // Beginning section: Process c = 0 to c = halfWindow
-        for (size_t c = 0; c < MIN(halfWindow + 1, inWdims[3]); c++) {
-          size_t r = c + halfWindow;
-          if (r < inWdims[3]) {
-            float val = inW[libjit_getXYZW(inWdims, n, h, w, r)];
+        for (size_t c = 0; c < inWdims[3]; c++) {
+          float m2 = 0.0;
+          for (size_t i = (c >= halfWindow ? c - halfWindow : 0);
+               i <= MIN(c + halfWindow, inWdims[3] - 1); i++) {
+            float val = inW[libjit_getXYZW(inWdims, n, h, w, i)];
             m2 += val * val;
           }
-          float scale = k + normedAlpha * m2;
-          scaleCache[libjit_getXYZW(inWdims, n, h, w, c)] = scale;
-          float normFactor = pow(scale, -beta);
-          outW[libjit_getXYZW(outWdims, n, h, w, c)] =
-              inW[libjit_getXYZW(inWdims, n, h, w, c)] * normFactor;
-        }
 
-        // Main section: Process c = halfWindow + 1 to
-        // c = inWdims[3] - halfWindow - 1
-        for (size_t c = halfWindow + 1; c < inWdims[3] - halfWindow; c++) {
-          float l = inW[libjit_getXYZW(inWdims, n, h, w, c - halfWindow - 1)];
-          m2 -= l * l;
-          float r = inW[libjit_getXYZW(inWdims, n, h, w, c + halfWindow)];
-          m2 += r * r;
           float scale = k + normedAlpha * m2;
           scaleCache[libjit_getXYZW(inWdims, n, h, w, c)] = scale;
           float normFactor = pow(scale, -beta);
           outW[libjit_getXYZW(outWdims, n, h, w, c)] =
               inW[libjit_getXYZW(inWdims, n, h, w, c)] * normFactor;
-        }
-
-        // Final section: Process
-        // c = MAX(halfWindow + 1, inWdims[3] - halfWindow) to
-        // c = inWdims[3] - 1
-        for (size_t c = (inWdims[3] > 2 * halfWindow ? inWdims[3] - halfWindow
-                                                     : halfWindow + 1);
-             c < inWdims[3]; c++) {
-          float val = inW[libjit_getXYZW(inWdims, n, h, w, c - halfWindow - 1)];
-          m2 -= val * val;
-          float scale = k + normedAlpha * m2;
-          scaleCache[libjit_getXYZW(inWdims, n, h, w, c)] = scale;
-          float normFactor = pow(scale, -beta);
-          outW[libjit_getXYZW(outWdims, n, h, w, c)] =
-              inW[libjit_getXYZW(inWdims, n, h, w, c)] * normFactor;
-        }
-      } // W
-    }   // H
-  }     // N
+        } // C
+      }   // W
+    }     // H
+  }       // N
 }
 
 void libjit_pool_max_f(const float *inW, float *outW, const size_t *inWdims,


### PR DESCRIPTION
This commit is not necessarily to be landed, but contains two different implementations options for the LocalResponseNormalization instruction in the JIT.

After PR #517 , the current implementation for LRN in the JIT is the somewhat-optimized one (having a depth of 4 for-loops).  The present commit, if landed, would revert to the "naive" implementation (5 loops deep).

(I created this PR so that we can continue the discussion from PR 517 while simultaneously allowing me to work on the gradient version.)

Artem had some concerns about the "optimized" implementation regarding precision, and these concerns could manifest in the event that there are large swings in the magnitude of particular values within a row (or whatever you call it when n, h, and w are fixed).

Here are the results from vgg16 and vgg19 tests: (from PR 517)

I ran the following two tests:
```
./bin/loader tests/images/imagenet/.png -image_mode=128to127 -d=vgg19
./bin/loader tests/images/imagenet/.png -image_mode=0to256 -d=vgg16
```

With the Interpreter, I got:
```
jwhegeman-mbp:build_Release jwhegeman$ ./bin/loader tests/images/imagenet/*.png -image_mode=128to127 -d=vgg19
Model: vgg19/predict_net.pb
 File: tests/images/imagenet/cat_285.png Result:281
 File: tests/images/imagenet/dog_207.png Result:207
 File: tests/images/imagenet/zebra_340.png Result:340
jwhegeman-mbp:build_Release jwhegeman$ ./bin/loader tests/images/imagenet/*.png -image_mode=0to256 -d=vgg16
Model: vgg16/predict_net.pb
 File: tests/images/imagenet/cat_285.png Result:281
 File: tests/images/imagenet/dog_207.png Result:207
 File: tests/images/imagenet/zebra_340.png Result:340
jwhegeman-mbp:build_Release jwhegeman$
```

With the JIT hard-coded as the backend, I got:
```
jwhegeman-mbp:build_Release jwhegeman$ ./bin/loader tests/images/imagenet/*.png -image_mode=128to127 -d=vgg19
Model: vgg19/predict_net.pb
 File: tests/images/imagenet/cat_285.png Result:281
 File: tests/images/imagenet/dog_207.png Result:207
 File: tests/images/imagenet/zebra_340.png Result:340
jwhegeman-mbp:build_Release jwhegeman$ ./bin/loader tests/images/imagenet/*.png -image_mode=0to256 -d=vgg16
Model: vgg16/predict_net.pb
 File: tests/images/imagenet/cat_285.png Result:282
 File: tests/images/imagenet/dog_207.png Result:207
 File: tests/images/imagenet/zebra_340.png Result:340
jwhegeman-mbp:build_Release jwhegeman$
```

So the only difference in these tests is the result for cat_285.png with vgg16 -- the Interpreter is giving 281, and the JIT is giving 282. I am unsure what to make of this.
