### PR TITLE
[Dotty] Assign a unique color to each node based on the node kind.

### DIFF
--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -124,16 +124,29 @@ protected:
     os << "\tshape = \"record\"\n";
     os << "\tstyle=\"filled,rounded\"\n";
 
+    // Pick a color based on the node kind.
+    unsigned colorIdx = llvm::hash_value(llvm::StringRef(N->getKindName()));
+
+    static const char *colorNames[] = {
+        "AliceBlue",      "CadetBlue1",   "Coral",      "DarkOliveGreen1",
+        "DarkSeaGreen1",  "GhostWhite",   "Khaki1",     "LavenderBlush1",
+        "LemonChiffon1",  "LightSkyBlue", "MistyRose1", "MistyRose2",
+        "PaleTurquoise2", "PeachPuff1",   "PowderBlue", "Salmon",
+        "Thistle1",       "Thistle3",     "Wheat1",     "Yellow2",
+    };
+    unsigned arrayLen = sizeof(colorNames) / sizeof(colorNames[0]);
+    auto nodeColor = colorNames[colorIdx % arrayLen];
+
     if (auto V = llvm::dyn_cast<Variable>(N)) {
       if (V->getVisibilityKind() == Variable::VisibilityKind::Public) {
-        os << "\tfillcolor=thistle1\n";
+        os << "\tfillcolor=Snow2; color=DarkOliveGreen4\n";
       } else {
-        os << "\tfillcolor=thistle3\n";
+        os << "\tfillcolor=Snow3; color=DeepSkyBlue4\n";
       }
     } else {
-      os << "\tfillcolor=seashell1\n";
+      os << "\tfillcolor=" << nodeColor << "\n";
     }
-    os << "];\n";
+    os << "penwidth = 2];\n";
 
     vertices_.push_back(os.str());
   }
@@ -141,13 +154,6 @@ protected:
   void dumpEdgeStyle(Node *N, size_t i, Node *to, std::ostream &os) {
     if (N->isOverwrittenNthInput(i)) {
       os << " [dir=\"both\"]";
-    }
-    if (isa<Variable>(to)) {
-      if (!N->isOverwrittenNthInput(i)) {
-        os << "[color=SlateBlue4]";
-      } else {
-        os << "[color=RoyalBlue4]";
-      }
     }
   }
 


### PR DESCRIPTION
Assign a unique color to each node based on the node kind. For example,  all Conv nodes are pink, arithmetic nodes are blue, etc.
Change the variable border color and remove the edge color.

Examples:

<img width="601" alt="screen shot 2018-02-21 at 12 31 09 pm" src="https://user-images.githubusercontent.com/8635342/36504116-45990b66-1704-11e8-9db6-0219348c5a76.png">

<img width="327" alt="screen shot 2018-02-21 at 11 21 24 am" src="https://user-images.githubusercontent.com/8635342/36504130-4e8fad7e-1704-11e8-8c38-7710ae4c24d4.png">
