### PR TITLE
[JIT] LocalResponseNormalizationGrad instruction for JIT

### DIFF
--- a/lib/Backends/CPUBackend/LLVMIRGen.cpp
+++ b/lib/Backends/CPUBackend/LLVMIRGen.cpp
@@ -524,6 +524,31 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     break;
   }
 
+  case Kinded::Kind::LocalResponseNormalizationGradInstKind: {
+    LocalResponseNormalizationGradInst *LRNG =
+        llvm::cast<LocalResponseNormalizationGradInst>(I);
+    auto *srcGradPtr =
+        emitValueAddress(builder, LRNG->getSrcGrad(), ElemKind::FloatTy);
+    auto *destGradPtr =
+        emitValueAddress(builder, LRNG->getDestGrad(), ElemKind::FloatTy);
+    auto *srcPtr = emitValueAddress(builder, LRNG->getSrc(), ElemKind::FloatTy);
+    auto *destPtr =
+        emitValueAddress(builder, LRNG->getDest(), ElemKind::FloatTy);
+    auto *scalePtr =
+        emitValueAddress(builder, LRNG->getScale(), ElemKind::FloatTy);
+    auto *destDims = emitValueDims(builder, LRNG->getDest());
+
+    auto *halfWindow = emitConst(builder, LRNG->getHalfWindowSize());
+    auto *alpha = emitConst(builder, LRNG->getAlpha());
+    auto *beta = emitConst(builder, LRNG->getBeta());
+
+    auto *F = getFunction("libjit_local_response_normalization_grad_f");
+    assert(F && "Unable to load the function");
+    builder.CreateCall(F, {srcGradPtr, destGradPtr, srcPtr, destPtr, scalePtr,
+                           destDims, halfWindow, alpha, beta});
+    break;
+  }
+
   case Kinded::Kind::PoolMaxInstKind: {
     PoolMaxInst *PM = cast<PoolMaxInst>(I);
     auto *destPtr = emitValueAddress(builder, PM->getDest(), ElemKind::FloatTy);

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -23,6 +23,11 @@ void trainConvNet(glow::Tensor *inputs, glow::Tensor *kernel1,
 void inferLocalResponseNormalizationNet(glow::Tensor *inputs, glow::Tensor *out,
                                         glow::BackendKind kind);
 
+void trainLocalResponseNormalizationNet(
+    glow::Tensor *inputs, glow::Tensor *weights, glow::Tensor *bias,
+    glow::Tensor *selected, llvm::ArrayRef<size_t> shape1,
+    llvm::ArrayRef<size_t> shape2, glow::Tensor *out, glow::BackendKind kind);
+
 void inferMaxNet(glow::Tensor *inputs1, glow::Tensor *inputs2,
                  glow::Tensor *out, glow::BackendKind kind);
 


### PR DESCRIPTION
This commit adds support for the LocalResponseNormalization gradient operator to the JIT, as well as an associated unit test.