### PR TITLE
[NodeValue] Add assignment operator.

### DIFF
--- a/include/glow/Graph/Node.h
+++ b/include/glow/Graph/Node.h
@@ -38,6 +38,13 @@ public:
 
   /// Create a new operand and register it as a new user to the node.
   NodeValue(const NodeValue &that) { setOperand(that.getNode(), that.resNo_); }
+
+  /// Unregister old value, assign new NodeValue and register it.
+  NodeValue &operator=(const NodeValue &that) {
+    setOperand(that.getNode(), that.resNo_);
+    return *this;
+  }
+
   /// When deleting an operand we need to unregister the operand from the
   /// use-list of the node it used to reference.
   ~NodeValue() { setOperand(nullptr, 0); }


### PR DESCRIPTION
When constructing Graph, it is convenient to use something like:
```
Node *X = G->createFullyConnected(...)
X = G->createArithmetic(... X ...)
X = G->create..(X)
```

We have this in a lot of places. But actually, using `Node*` is not always OK: some nodes have more then one result.
It's more correct to use `NodeValue`: a pair of `Node*` and `resNo`.
But what happens if we switch from `Node*` to `NodeValue`?
The code will fail at runtime, because apparently it's incorrect to reassign `NodeValue` variable, because of all complicated logic we have for `NodeValue`.
Here's minimal example:
https://gist.github.com/artemrakhov/6d9fc529fbbf90999001cab3661e55a9
Weirdly, but it fails on line 12, while actual reassignment is done on line 13. If I remove 13, the code passes OK, obviously.

Turns out all what we are missing is assignment operator. C++ generates one automatically for us, which was incorrect.
