### PR TITLE
[quantization] Add conversion to the max pool node.

### DIFF
--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -414,9 +414,8 @@ PoolNode *Function::createPool(llvm::StringRef name, NodeValue input,
          "buffer too small for selected stride");
 
   auto outSz = calculateConvOutputDims(idim.h, idim.w, kernel, stride, pad);
-
-  auto OT = getParent()->uniqueType(
-      ElemKind::FloatTy, {idim.n, outSz.first, outSz.second, idim.c});
+  auto OT = getParent()->uniqueTypeWithNewShape(
+      input->getType(), {idim.n, outSz.first, outSz.second, idim.c});
 
   return addNode(new PoolNode(name, OT, mode, input, kernel, stride, pad));
 }

--- a/lib/IR/IRBuilder.cpp
+++ b/lib/IR/IRBuilder.cpp
@@ -53,9 +53,10 @@ PoolMaxWithXYInst *IRBuilder::createPoolMaxWithXYOp(Value *input, size_t kernel,
   Value *srcXY =
       createAllocActivationInst("srcXY", ElemKind::IndexTy,
                                 {idim.n, outSz.first, outSz.second, idim.c, 2});
-  Value *dest =
-      createAllocActivationInst("pool.res", ElemKind::FloatTy,
-                                {idim.n, outSz.first, outSz.second, idim.c});
+
+  auto outTy = F_->getGraph()->getParent()->uniqueTypeWithNewShape(
+      input->getType(), {idim.n, outSz.first, outSz.second, idim.c});
+  Value *dest = createAllocActivationInst("pool.res", outTy);
 
   return createPoolMaxWithXYInst("pool", dest, input, srcXY, kernel, stride,
                                  pad);


### PR DESCRIPTION
The good news is that:
```
rdzhabarov-mbp:release_build rdzhabarov$ ./bin/loader tests/images/*.png -image_mode=0to1 -d=resnet50 -dump_profile="profile"
Model: resnet50/predict_net.pb
 File: tests/images/cat_285.png Result:285
 File: tests/images/dog_207.png Result:207
 File: tests/images/zebra_340.png Result:340
rdzhabarov-mbp:release_build rdzhabarov$ ./bin/loader tests/images/*.png -image_mode=0to1 -d=resnet50 -load_profile="profile"
Model: resnet50/predict_net.pb
 File: tests/images/cat_285.png Result:285
 File: tests/images/dog_207.png Result:207
 File: tests/images/zebra_340.png Result:340
```

But there are some issues with the e2e test for quantization. I even narrow that down to simpler version with fewer nodes, so that should be easier to investigate.
Going to do that after this PR is merged.