### PR TITLE
Option category for CPU Backend

### DIFF
--- a/lib/Backends/CPUBackend/CommandLine.h
+++ b/lib/Backends/CPUBackend/CommandLine.h
@@ -1,0 +1,10 @@
+// Copyright 2017 Facebook Inc.  All Rights Reserved.
+
+#ifndef GLOW_BACKENDS_CPUBACKEND_COMMANDLINE_H
+#define GLOW_BACKENDS_CPUBACKEND_COMMANDLINE_H
+
+#include "llvm/Support/CommandLine.h"
+
+extern llvm::cl::OptionCategory CPUBackendCat;
+
+#endif // GLOW_BACKENDS_CPUBACKEND_COMMANDLINE_H

--- a/lib/Backends/CPUBackend/FunctionSpecializer.cpp
+++ b/lib/Backends/CPUBackend/FunctionSpecializer.cpp
@@ -2,10 +2,11 @@
 #define DEBUG_TYPE "ir-function-specializer"
 
 #include "CPUBackend.h"
+#include "CommandLine.h"
+
 #include "glow/IR/Instrs.h"
 
 #include "llvm/ADT/Statistic.h"
-#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 
 using namespace glow;
@@ -23,7 +24,8 @@ static llvm::cl::opt<bool>
     jitSpecializeDims("jit-specialize",
                       llvm::cl::desc("Create specialized functions for "
                                      "operations with constant dimensions"),
-                      llvm::cl::init(true));
+                      llvm::cl::init(true),
+                      llvm::cl::cat(CPUBackendCat));
 
 STATISTIC(NumSpecializations, "Number of created specializations");
 STATISTIC(NumSharedSpecializations, "Number of shared specializations");

--- a/lib/Backends/CPUBackend/LLVMIRGen.cpp
+++ b/lib/Backends/CPUBackend/LLVMIRGen.cpp
@@ -2,6 +2,8 @@
 
 #include "LLVMIRGen.h"
 
+#include "CommandLine.h"
+
 #include "glow/Graph/Graph.h"
 #include "glow/IR/Instrs.h"
 
@@ -21,15 +23,19 @@ using llvm::cast;
 using llvm::dyn_cast;
 using llvm::isa;
 
+llvm::cl::OptionCategory CPUBackendCat("Glow CPU Backend Options");
+
 static llvm::cl::opt<bool>
     dumpIR("dump-llvm-ir",
            llvm::cl::desc("Dump the LLVM-IR of the jitted code"),
-           llvm::cl::init(false));
+           llvm::cl::init(false),
+           llvm::cl::cat(CPUBackendCat));
 
 static llvm::cl::opt<bool>
     dumpJitAsm("dump-llvm-asm",
                llvm::cl::desc("Dump the textual assembly of the jitted code"),
-               llvm::cl::init(false));
+               llvm::cl::init(false),
+               llvm::cl::cat(CPUBackendCat));
 
 /// Generate the LLVM MAttr list of attributes.
 static llvm::SmallVector<std::string, 0> getMachineAttributes() {


### PR DESCRIPTION
Dunno how you all feel about having lots of option categories, but this diff makes it easier to find these options amidst all the LLVM options.