### PR TITLE
Randomize Functions for Int8QTy Tensors

### DIFF
--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -486,6 +486,13 @@ public:
     }
   }
 
+  /// Fill the tensor with uniformly distributed values in the range -128..127.
+  void randomizeInt8() {
+    for (size_t i = 0, e = size(); i < e; i++) {
+      raw(i) = nextRandInt8();
+    }
+  }
+
   /// \returns the mean and variance of the tensor.
   std::pair<ElemTy, ElemTy> calculateMeanVariance() const {
     size_t n = size();

--- a/include/glow/Support/Random.h
+++ b/include/glow/Support/Random.h
@@ -9,6 +9,9 @@ double nextRand();
 /// \returns the next uniform random integer that is either 0 or 1.
 int nextRandInt01();
 
+/// \returns the next uniform random integer in the range -128..127.
+int nextRandInt8();
+
 /// \returns the next uniform random integer that is between 0 and n - 1.
 int nextRandInt(int n);
 

--- a/lib/Support/Random.cpp
+++ b/lib/Support/Random.cpp
@@ -18,6 +18,12 @@ int nextRandInt01() {
   return distribution(generator);
 }
 
+int nextRandInt8() {
+  static std::mt19937 generator;
+  static std::uniform_int_distribution<> distribution(-128, 127);
+  return distribution(generator);
+}
+
 int nextRandInt(int n) {
   static std::mt19937 generator;
   static std::uniform_int_distribution<> distribution(0);


### PR DESCRIPTION
This commit adds a nextRandInt8() function to conveniently produce uniformly-distributed random integers in the int8_t range, as well as a randomizeInt8() function for filling quantized tensors with random elements.