### PR TITLE
[cleanup] Replace scale with S and offset with O in type description.

### DIFF
--- a/lib/Base/Type.cpp
+++ b/lib/Base/Type.cpp
@@ -13,9 +13,9 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Type &type) {
   os << type.getElementName();
 
   if (type.isQuantizedType()) {
-    os << "[scale:";
+    os << "[S:";
     llvm::write_double(os, type.getScale(), llvm::FloatStyle::Fixed, 4);
-    os << " offset:";
+    os << " O:";
     os << type.getOffset();
     os << ']';
     float low = (-128 - type.getOffset()) * type.getScale();


### PR DESCRIPTION
This makes graph nodes look slimmer and probably arguably does not lose readability.