### PR TITLE
Reduce the number of random integer generation functions

### DIFF
--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -487,13 +487,6 @@ public:
     }
   }
 
-  /// Fill the tensor with uniformly distributed values in the range -128..127.
-  void randomizeInt8() {
-    for (size_t i = 0, e = size(); i < e; i++) {
-      raw(i) = nextRandInt8();
-    }
-  }
-
   /// \returns the mean and variance of the tensor.
   std::pair<ElemTy, ElemTy> calculateMeanVariance() const {
     size_t n = size();

--- a/include/glow/Support/Random.h
+++ b/include/glow/Support/Random.h
@@ -6,14 +6,8 @@ namespace glow {
 /// \returns the next uniform random number in the range -1..1.
 double nextRand();
 
-/// \returns the next uniform random integer that is either 0 or 1.
-int nextRandInt01();
-
-/// \returns the next uniform random integer in the range -128..127.
-int nextRandInt8();
-
-/// \returns the next uniform random integer that is between 0 and n - 1.
-int nextRandInt(int n);
+/// \returns the next uniform random integer in the closed interval [a, b].
+int nextRandInt(int a, int b);
 
 } // namespace glow
 

--- a/lib/Support/Random.cpp
+++ b/lib/Support/Random.cpp
@@ -2,6 +2,7 @@
 
 #include "glow/Support/Random.h"
 
+#include <cassert>
 #include <random>
 
 namespace glow {
@@ -12,28 +13,11 @@ double nextRand() {
   return distribution(generator);
 }
 
-int nextRandInt01() {
-  static std::mt19937 generator;
-  static std::uniform_int_distribution<> distribution(0, 1);
-  return distribution(generator);
-}
-
-int nextRandInt8() {
-  static std::mt19937 generator;
-  static std::uniform_int_distribution<> distribution(-128, 127);
-  return distribution(generator);
-}
-
-int nextRandInt(int n) {
-  static std::mt19937 generator;
-  static std::uniform_int_distribution<> distribution(0);
-  int max = distribution.max() / n;
-  max *= n;
-  int m = distribution(generator);
-  while (m >= max) {
-    m = distribution(generator);
-  }
-  return m % n;
+int nextRandInt(int a, int b) {
+  assert(a <= b && "Invalid bounds");
+  double x = nextRand() + 1.0;
+  int r = (b - a + 1) * x;
+  return r / 2 + a;
 }
 
 } // namespace glow

--- a/tests/unittests/InterpreterTest.cpp
+++ b/tests/unittests/InterpreterTest.cpp
@@ -804,8 +804,8 @@ void generatePlayerData(Tensor &players, Tensor &labels,
 
   // Auto generate height/weights for basketball players.
   for (size_t i = 0; i < numTrainPlayers / 2; i++) {
-    auto heightInches = nextRandInt(19) + 70;                 // [70, 88]
-    auto weightLbs = 4 * heightInches - 85 + nextRandInt(31); // [195, 297]
+    auto heightInches = nextRandInt(70, 88);
+    auto weightLbs = 4 * heightInches + nextRandInt(-85, -55); // [195, 297]
     P.at({i, 0}) = heightInches;
     P.at({i, 1}) = weightLbs;
     L.at({i, 0}) = static_cast<size_t>(Sport::BASKETBALL);
@@ -813,9 +813,9 @@ void generatePlayerData(Tensor &players, Tensor &labels,
 
   // Auto generate height/weights for soccer players.
   for (size_t i = numTrainPlayers / 2; i < numTrainPlayers; i++) {
-    auto heightInches = nextRandInt(17) + 60; // [60, 76]
-    auto weightLbs = static_cast<unsigned>(2 * heightInches) + 20 +
-                     nextRandInt(31); // [140, 202]
+    auto heightInches = nextRandInt(60, 76);
+    auto weightLbs = static_cast<unsigned>(2 * heightInches) +
+                     nextRandInt(20, 50); // [140, 202]
     P.at({i, 0}) = heightInches;
     P.at({i, 1}) = weightLbs;
     L.at({i, 0}) = static_cast<size_t>(Sport::SOCCER);

--- a/tests/unittests/JITTest.cpp
+++ b/tests/unittests/JITTest.cpp
@@ -79,7 +79,7 @@ TEST(JITCorrectnessTest, convGradTest) {
   bias2.getHandle().randomize(-0.5, 1.0);
   auto selectedH = selected.getHandle<size_t>();
   for (size_t i = 0; i < 9; i++) {
-    selectedH.raw(i) = nextRandInt(30);
+    selectedH.raw(i) = nextRandInt(0, 29);
   }
   std::array<size_t, 4> S1{{9, 6, 10, 1}};
   llvm::ArrayRef<size_t> shape1(S1);
@@ -122,7 +122,7 @@ TEST(JITCorrectnessTest, localResponseNormalizationGradTest) {
   bias.getHandle().randomize(-1.0, 1.3);
   auto selectedH = selected.getHandle<size_t>();
   for (size_t i = 0; i < 5; i++) {
-    selectedH.raw(i) = nextRandInt(180);
+    selectedH.raw(i) = nextRandInt(0, 179);
   }
   std::array<size_t, 4> S1{{5, 2, 2, 45}};
   llvm::ArrayRef<size_t> shape1(S1);
@@ -202,7 +202,7 @@ TEST(JITCorrectnessTest, poolAvgGradTest) {
   bias.getHandle().randomize(-0.2, 0.1);
   auto selectedH = selected.getHandle<size_t>();
   for (size_t i = 0; i < 5; i++) {
-    selectedH.raw(i) = nextRandInt(18);
+    selectedH.raw(i) = nextRandInt(0, 17);
   }
   std::array<size_t, 4> S1{{5, 6, 4, 3}};
   llvm::ArrayRef<size_t> shape1(S1);
@@ -245,7 +245,7 @@ TEST(JITCorrectnessTest, poolMaxGradTest) {
   bias.getHandle().randomize(-0.3, 0.1);
   auto selectedH = selected.getHandle<size_t>();
   for (size_t i = 0; i < 4; i++) {
-    selectedH.raw(i) = nextRandInt(32);
+    selectedH.raw(i) = nextRandInt(0, 31);
   }
   std::array<size_t, 4> S1{{4, 6, 7, 2}};
   llvm::ArrayRef<size_t> shape1(S1);
@@ -320,7 +320,7 @@ TEST(JITCorrectnessTest, selectTest) {
   Tensor inputs2(ElemKind::FloatTy, shape);
   auto condH = cond.getHandle();
   for (size_t i = 0; i < 270; i++) {
-    condH.raw(i) = nextRandInt01();
+    condH.raw(i) = nextRandInt(0, 1);
   }
   inputs1.getHandle().initXavier(1);
   inputs2.getHandle().initXavier(1);
@@ -355,7 +355,7 @@ TEST(JITCorrectnessTest, softmaxTest) {
   inputs.getHandle().initXavier(1);
   auto selectedH = selected.getHandle<size_t>();
   for (size_t i = 0; i < 14; i++) {
-    selectedH.raw(i) = nextRandInt(19);
+    selectedH.raw(i) = nextRandInt(0, 18);
   }
   Tensor out1;
   Tensor out2;
@@ -380,7 +380,7 @@ TEST(JITCorrectnessTest, softmaxGradTest) {
   bias.getHandle().randomize(-0.2, 0.0);
   auto selectedH = selected.getHandle<size_t>();
   for (size_t i = 0; i < 8; i++) {
-    selectedH.raw(i) = nextRandInt(23);
+    selectedH.raw(i) = nextRandInt(0, 22);
   }
   Tensor out1(ElemKind::FloatTy, shape);
   Tensor out2(ElemKind::FloatTy, shape);


### PR DESCRIPTION
This commit reduces the number of random integer generation functions (using uniform_int_distribution) to just one -- nextRandInt(int a, int b).  It also makes a single static global mt19937 generator for use in the [now only] two random-number functions.