### PR TITLE
[JIT] Make Libjit C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.7)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 
-project(Glow)
+project(Glow C CXX)
 enable_testing()
 
 option(GLOW_WITH_JIT "Build the LLVM-based JIT backend" OFF)

--- a/lib/Backends/CPU/CMakeLists.txt
+++ b/lib/Backends/CPU/CMakeLists.txt
@@ -5,9 +5,10 @@ endif()
 
 add_library(CPURuntime
             OBJECT
-              libjit.c)
+              libjit.cpp)
 target_compile_options(CPURuntime
                        PRIVATE
+                         -std=c++11
                          -ffast-math
                          -emit-llvm
                          -Os)

--- a/lib/Backends/CPU/libjit.cpp
+++ b/lib/Backends/CPU/libjit.cpp
@@ -7,6 +7,8 @@
 #define MIN(a, b) (((a) < (b)) ? (a) : (b))
 #define MAX(a, b) (((a) > (b)) ? (a) : (b))
 
+extern "C" {
+
 /// \returns the index of the element at x,y,z,w.
 size_t libjit_getXYZW(const size_t *dims, size_t x, size_t y, size_t z,
                       size_t w) {
@@ -806,3 +808,5 @@ void libjit_extract_tensor_f(float *tensor, float *slice, size_t *offset,
                             tensorDim, sliceDim, numDimsTensor, numDimsSlice,
                             offsetDim, 0, 0);
 }
+
+} // extern "C"


### PR DESCRIPTION
This commit converts libjit.c into a C++ library with C linkage for functions, so that we may [next] take advantage of C++ templates for implementing float/int8_t-quantized instruction kernels.

This is one possible approach (which seemed like the fastest and easiest way to help implement quantized instructions in the JIT, with minimal code duplication).  Let me know what you guys thinks...