### PR TITLE
Use GLOW_UNREACHABLE for invalid backend kind

### DIFF
--- a/lib/Backends/Backends.cpp
+++ b/lib/Backends/Backends.cpp
@@ -32,7 +32,7 @@ Backend *glow::createBackend(BackendKind backendKind, IRFunction *F) {
 #endif
   default:
     // Unknown execution backend.
-    llvm_unreachable("Invalid backend kind.");
+    GLOW_UNREACHABLE("Invalid backend kind.");
     break;
   }
 }


### PR DESCRIPTION
If you forget to build WITH_CPU and try to run `loader -jit`, a release build will just quietly run the interpreter, which is kind of a bummer.  GLOW_UNREACHABLE aborts even in release mode.