### PR TITLE
Fix Travis CI config to test the CPU JIT again by using -DGLOW_WITH_CPU=ON

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
         - sudo apt-get install -y ninja-build llvm ocl-icd-opencl-dev libprotobuf-dev protobuf-compiler libpng-dev
       install:
         - mkdir build && cd build
-        - cmake -G Ninja -DGLOW_USE_SANITIZER="Address;Undefined" -DCMAKE_BUILD_TYPE=Debug -DGLOW_WITH_OPENCL=OFF -DGLOW_WITH_JIT=ON ../
+        - cmake -G Ninja -DGLOW_USE_SANITIZER="Address;Undefined" -DCMAKE_BUILD_TYPE=Debug -DGLOW_WITH_OPENCL=OFF -DGLOW_WITH_CPU=ON ../
     - os: linux
       before_install:
         - sudo apt-get -qq update


### PR DESCRIPTION
This change was forgotten during the last round of re-namings.