### PR TITLE
Make Network.gradientCheckFCConcatRELU work consistently

### DIFF
--- a/tests/unittests/gradCheckTest.cpp
+++ b/tests/unittests/gradCheckTest.cpp
@@ -144,8 +144,8 @@ TEST(Network, gradientCheckFCConcatRELU) {
   auto inputsH = inputs.getHandle<>();
   auto outputsH = outputs.getHandle<>();
 
-  inputsH.initXavier(100);
-  outputsH.initXavier(100);
+  inputsH.initXavier(1);
+  outputsH.initXavier(1);
 
   performGradCheck(IP, result, A, Exp, &inputs, &outputs, 0.001, 0.001);
 }


### PR DESCRIPTION
This fails sporadically if I fiddle with the random seed.  Idk why this change would make it more robust but it seems to.  Maybe someone here knows why it would work (or if it somehow defeats the point of the test :) ).