### PR TITLE
[quantization] Convert concat to run on quantized tensors

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -216,8 +216,13 @@ public:
                                      llvm::ArrayRef<Node *> inputs,
                                      llvm::ArrayRef<TypeRef> outputs);
 
+  /// Create concat node which concatenates input tensors along \p dimension.
   ConcatNode *createConcat(llvm::StringRef name, llvm::ArrayRef<Node *> inputs,
                            unsigned dimension);
+
+  /// Create concat node with the given return type \p outTy.
+  ConcatNode *createConcat(llvm::StringRef name, llvm::ArrayRef<Node *> inputs,
+                           unsigned dimension, TypeRef outTy);
 
   SliceNode *createSlice(llvm::StringRef name, NodeValue input,
                          UnsignedArrayRef begin, UnsignedArrayRef end);

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -633,6 +633,7 @@ void Interpreter::fwdInsertTensorInst(bool isTrain,
 
   TYPED_INSERT(size_t, ElemKind::IndexTy);
   TYPED_INSERT(float, ElemKind::FloatTy);
+  TYPED_INSERT(int8_t, ElemKind::Int8QTy);
 #undef TYPED_INSERT
 }
 

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -577,13 +577,25 @@ ConcatNode *Function::createConcat(llvm::StringRef name,
     shape[dimension] += I->getType()->dims()[dimension];
   }
 
-  auto NT = getParent()->uniqueType(inputs[0]->getElementType(), shape);
+  auto NT = getParent()->uniqueTypeWithNewShape(inputs[0]->getType(), shape);
   std::vector<NodeValue> ops;
   ops.reserve(inputs.size());
-  for (auto &I : inputs) {
+  for (auto I : inputs) {
     ops.emplace_back(I);
   }
   return addNode(new ConcatNode(name, NT, ops, dimension));
+}
+
+ConcatNode *Function::createConcat(llvm::StringRef name,
+                                   llvm::ArrayRef<Node *> inputs,
+                                   unsigned dimension, TypeRef outTy) {
+  std::vector<NodeValue> ops;
+  ops.reserve(inputs.size());
+  for (auto I : inputs) {
+    ops.emplace_back(I);
+  }
+
+  return addNode(new ConcatNode(name, outTy, ops, dimension));
 }
 
 SliceNode *Function::createSlice(llvm::StringRef name, NodeValue input,

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -856,12 +856,22 @@ void ConcatNode::verify() const {
   (void)inputs;
   (void)dimension;
 
-  for (int i = 1; i < inputs.size(); i++) {
-    for (int j = 0; j < inputs[0].dims().size(); j++) {
+  for (size_t i = 1; i < inputs.size(); i++) {
+    for (size_t j = 0; j < inputs[0].dims().size(); j++) {
       if (j == dimension) {
         continue;
       }
       assert(inputs[0].dims()[j] == inputs[i].dims()[j]);
+    }
+  }
+
+  for (size_t i = 0; i < inputs.size(); i++) {
+    checkType(inputs[i], getResult()->getElementType());
+    if (getResult()->getType()->isQuantizedType()) {
+      assert(inputs[i]->getType()->getScale() ==
+             getResult()->getType()->getScale());
+      assert(inputs[i]->getType()->getOffset() ==
+             getResult()->getType()->getOffset());
     }
   }
 }

--- a/lib/IR/IRGen.cpp
+++ b/lib/IR/IRGen.cpp
@@ -347,8 +347,8 @@ public:
     case glow::Kinded::Kind::ConcatNodeKind: {
       auto *CC = cast<ConcatNode>(N);
 
-      auto *dest = builder_.createAllocActivationInst(
-          CC->getName(), CC->getElementType(), CC->dims());
+      auto *dest =
+          builder_.createAllocActivationInst(CC->getName(), CC->getType());
       builder_.createSplatInst(CC->getName(), dest, 0);
       auto inputs = CC->getInputs();
 


### PR DESCRIPTION
This one is used by SqueezeNet in our example test suite.

Note, Concat does not use any additional IR instructions and just generate the right sequence of insert tensor instructions.

Same output as master.

```
./bin/loader tests/images/imagenet/*.png -image_mode=128to127 -d=squeezenet -load_profile=profile.yaml
Model: squeezenet/predict_net.pb
 File: tests/images/imagenet/cat_285.png Result:281
 File: tests/images/imagenet/dog_207.png Result:207
 File: tests/images/imagenet/zebra_340.png Result:340
```

* Adding test to this PR