### PR TITLE
Let the constructor of the unowned tensor take TypeRef for describing the type

### DIFF
--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -99,8 +99,7 @@ public:
   /// Construct an unowned tensor provided an existing payload buffer.
   /// This constructor can be used when there is a need to work with
   /// "externally" managed payload buffers using Tensor APIs.
-  Tensor(void *data, ElemKind elemTy, llvm::ArrayRef<size_t> dims)
-      : data_(data), type_(elemTy, dims) {
+  Tensor(void *data, TypeRef ty) : data_(data), type_(*ty) {
     // Mark as unowned.
     data_.setInt(1);
   }

--- a/tests/unittests/tensorsTest.cpp
+++ b/tests/unittests/tensorsTest.cpp
@@ -307,7 +307,8 @@ TEST(Tensor, externallyManagedPayload) {
 
   {
     // Work with an existing payload buffer by means of the Tensor APIs.
-    Tensor T1(payload.data(), ElemKind::FloatTy, {2, 2});
+    Type ty(ElemKind::FloatTy, {2, 2});
+    Tensor T1(payload.data(), &ty);
 
     auto H1 = T1.getHandle<>();
     H1.dump();


### PR DESCRIPTION
This allows using this constructor even for quantized tensors.

Addresses @nadavrot comments in #632 