### PR TITLE
[JIT] Add support for the debug_print instruction

### DIFF
--- a/lib/Backends/CPU/LLVMIRGen.h
+++ b/lib/Backends/CPU/LLVMIRGen.h
@@ -60,6 +60,8 @@ class LLVMIRGen {
   llvm::Value *emitConst(llvm::IRBuilder<> &builder, float val);
   /// Generates LLVM IR that materializes the constant \p val.
   llvm::Value *emitConst(llvm::IRBuilder<> &builder, size_t val);
+  /// Generates LLVM IR that materializes the string literal \p str.
+  llvm::Value *emitStringConst(llvm::IRBuilder<> &builder, llvm::StringRef str);
   /// Generates LLVM IR that materializes the constant array \p vals.
   llvm::Value *emitConstArray(llvm::IRBuilder<> &builder,
                               llvm::ArrayRef<size_t> vals);


### PR DESCRIPTION
This feature is supposed to be used only for debugging. It is very useful when you need to find differences between the execution of the network model by the interpreter and by the JIT, as you can compare two execution longs step-by-step.  I used it to debug JIT compilation problems with PTB.