### PR TITLE
[JIT] Fix Quantize Function Call Type in JIT

### DIFF
--- a/lib/Backends/CPU/LLVMIRGen.h
+++ b/lib/Backends/CPU/LLVMIRGen.h
@@ -57,9 +57,11 @@ class LLVMIRGen {
   /// \p builder. The size type is native to the machine (size_t).
   llvm::Value *emitValueSize(llvm::IRBuilder<> &builder, glow::Value *val);
   /// Generates LLVM IR that materializes the constant \p val.
-  llvm::Value *emitConst(llvm::IRBuilder<> &builder, float val);
+  llvm::Value *emitConstF32(llvm::IRBuilder<> &builder, float val);
   /// Generates LLVM IR that materializes the constant \p val.
-  llvm::Value *emitConst(llvm::IRBuilder<> &builder, size_t val);
+  llvm::Value *emitConstI32(llvm::IRBuilder<> &builder, int32_t val);
+  /// Generates LLVM IR that materializes the constant \p val.
+  llvm::Value *emitConstST(llvm::IRBuilder<> &builder, size_t val);
   /// Generates LLVM IR that materializes the string literal \p str.
   llvm::Value *emitStringConst(llvm::IRBuilder<> &builder, llvm::StringRef str);
   /// Generates LLVM IR that materializes the constant array \p vals.

--- a/lib/Backends/CPU/libjit.cpp
+++ b/lib/Backends/CPU/libjit.cpp
@@ -791,8 +791,7 @@ void libjit_pool_avg_grad_f(float *inG, const float *outG,
 }
 
 void libjit_quantize_i8(int8_t *outW, const float *inW, size_t numElem,
-                        float scale, size_t offset_u64) {
-  int32_t offset = (int32_t)offset_u64;
+                        float scale, int32_t offset) {
   for (size_t i = 0; i < numElem; i++) {
     int32_t result = (int32_t)roundf(inW[i] / scale + offset);
     outW[i] = MAX(INT8_MIN, MIN(INT8_MAX, result));
@@ -800,8 +799,7 @@ void libjit_quantize_i8(int8_t *outW, const float *inW, size_t numElem,
 }
 
 void libjit_dequantize_f(float *outW, const int8_t *inW, size_t numElem,
-                         float scale, size_t offset_u64) {
-  int32_t offset = (int32_t)offset_u64;
+                         float scale, int32_t offset) {
   for (size_t i = 0; i < numElem; i++) {
     outW[i] = scale * (inW[i] - offset);
   }


### PR DESCRIPTION
This commit fixes the function signature for both libjit_quantize and libjit_dequantize to use 32-bit integers for offsets, and, in doing so, adds an emitConst() overload for int32_t.