### PR TITLE
Autogen Grad Instrs IRGen cases

### DIFF
--- a/tools/ClassGen/InstrBuilder.cpp
+++ b/tools/ClassGen/InstrBuilder.cpp
@@ -186,9 +186,9 @@ InstrBuilder::~InstrBuilder() {
   emitIRGenCase();
 }
 
-InstrBuilder &
-InstrBuilder::addGradientInstr(llvm::ArrayRef<llvm::StringRef> originalFields,
-                               llvm::ArrayRef<llvm::StringRef> gradFields) {
+void InstrBuilder::addGradientInstr(
+    llvm::ArrayRef<llvm::StringRef> originalFields,
+    llvm::ArrayRef<llvm::StringRef> gradFields) {
   const bool isGradInst = true;
   InstrBuilder GI(headerStream, cppStream, defStream, builderStream,
                   irGenStream, name_ + "Grad", isGradInst);

--- a/tools/ClassGen/InstrBuilder.h
+++ b/tools/ClassGen/InstrBuilder.h
@@ -124,8 +124,8 @@ public:
 
   /// Constructs a new gradient instruction that is based on the current
   /// instruction that we are building.
-  InstrBuilder &addGradientInstr(llvm::ArrayRef<llvm::StringRef> originalFields,
-                                 llvm::ArrayRef<llvm::StringRef> gradFields);
+  void addGradientInstr(llvm::ArrayRef<llvm::StringRef> originalFields,
+                        llvm::ArrayRef<llvm::StringRef> gradFields);
 
   // Set the autoIRGenNodeName; default is the name of the Instr. If not empty,
   // it means that autoIRGen should proceed.

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -66,8 +66,8 @@ int main(int argc, char **argv) {
       .addMember(MemberType::SizeT, "Stride")
       .addMember(MemberType::SizeT, "Pad")
       .addMember(MemberType::SizeT, "Depth")
-      .addGradientInstr({"Src", "Filter"}, {"Dest", "Src", "Filter", "Bias"})
-      .autoIRGen();
+      .autoIRGen()
+      .addGradientInstr({"Src", "Filter"}, {"Dest", "Src", "Filter", "Bias"});
 
   // PoolMax version caching XY coordinates to speedup gradient-based
   // computations.
@@ -93,8 +93,8 @@ int main(int argc, char **argv) {
       .addMember(MemberType::SizeT, "Kernel")
       .addMember(MemberType::SizeT, "Stride")
       .addMember(MemberType::SizeT, "Pad")
-      .addGradientInstr({"Dest"}, {"Dest", "Src"})
-      .autoIRGen();
+      .autoIRGen()
+      .addGradientInstr({"Dest"}, {"Dest", "Src"});
 
   //===--------------------------------------------------------------------===//
   //                     Normalization
@@ -114,9 +114,9 @@ int main(int argc, char **argv) {
           "Dest",
           "Src",
       })
+      .autoIRGen()
       .addGradientInstr({"Src", "Scale", "Mean", "Var"},
-                        {"Dest", "Src", "Scale", "Bias"})
-      .autoIRGen();
+                        {"Dest", "Src", "Scale", "Bias"});
 
   BB.newInstr("LocalResponseNormalization")
       .addOperand("Dest", OperandKind::Out)


### PR DESCRIPTION
This ended up being a bit complicated. I'm not sure it is worth the added complexity.

For now it only covers the 3 Instrs which are created via `addGradientInstr` and already had `autoIRGen` support for the non-gradient Instr. There are only 7 gradient instructions in total though, so the ceiling isn't very high here.