### PR TITLE
[Nodes/Instrs] Outline shared verification

### DIFF
--- a/include/glow/Verification/Verification.h
+++ b/include/glow/Verification/Verification.h
@@ -1,0 +1,353 @@
+#ifndef GLOW_VERIFICATION_VERIFICATION_H
+#define GLOW_VERIFICATION_VERIFICATION_H
+
+namespace glow {
+
+/// Check that the type of the first operand matches the type of the second
+/// operand.
+template <class T> void checkSameType(T A, T B) {
+  assert(A.getType() == B.getType() && "Invalid type");
+}
+
+/// Check that the shape of the first operand matches the shape of the second
+/// operand.
+template <class T> void checkSameShape(T A, T B) {
+  assert(A.dims() == B.dims() && "Invalid shape");
+}
+
+template <class T> void checkType(T A, ElemKind expectedType) {
+  assert(A.getElementType() == expectedType && "Invalid type");
+}
+
+template <class T>
+void verifyConvolution(T src, T dest, T filter, T bias, size_t kernel,
+                       size_t stride, size_t pad, size_t depth) {
+  assert(src.getElementType() == dest.getElementType() && "Invalid Type");
+  assert(src.getElementType() == filter.getElementType() && "Invalid Type");
+  assert(src.getElementType() == bias.getElementType() && "Invalid Type");
+
+  ShapeNHWC idim(src.getType()->dims());
+  ShapeNHWC odim(dest.getType()->dims());
+  (void)odim;
+
+  assert(idim.w >= kernel && idim.h >= kernel &&
+         "buffer too small for selected stride");
+
+  auto outSz = calculateConvOutputDims(idim.h, idim.w, kernel, stride, pad);
+  ShapeNHWC exp(idim.n, outSz.first, outSz.second, depth);
+  (void)exp;
+  assert(exp == odim && "Invalid output dimensions");
+
+  auto filterDims = {depth, kernel, kernel, idim.c};
+  assert(filter.getType()->dims().equals(filterDims) && "Invalid filter dims");
+  (void)filterDims;
+
+  auto biasDims = {depth};
+  assert(bias.getType()->dims().equals(biasDims) && "Invalid bias dims");
+  (void)biasDims;
+}
+
+template <class T>
+void verifyPool(T src, T dest, size_t kernel, size_t stride, size_t pad) {
+  ShapeNHWC idim = ShapeNHWC(src.getType()->dims());
+  ShapeNHWC odim = ShapeNHWC(dest.getType()->dims());
+  (void)odim;
+  assert(idim.w >= kernel && idim.h >= kernel &&
+         "buffer too small for selected stride");
+
+  auto outSz = calculateConvOutputDims(idim.h, idim.w, kernel, stride, pad);
+  ShapeNHWC exp(idim.n, outSz.first, outSz.second, idim.c);
+  (void)exp;
+  assert(exp == odim && "Unexpected output dimensions");
+}
+
+template <class T>
+void verifyPoolMaxWithXY(T src, T dest, T srcXY, size_t kernel, size_t stride,
+                         size_t pad) {
+  ShapeNHWC idim = ShapeNHWC(src.getType()->dims());
+  ShapeNHWC odim = ShapeNHWC(dest.getType()->dims());
+  (void)odim;
+  assert(idim.w >= kernel && idim.h >= kernel &&
+         "buffer too small for selected stride");
+
+  auto outSz = calculateConvOutputDims(idim.h, idim.w, kernel, stride, pad);
+  ShapeNHWC exp(idim.n, outSz.first, outSz.second, idim.c);
+  (void)exp;
+  assert(exp == odim && "Unexpected output dimensions");
+
+  // Allocate cache arrays that store the x and y coordinates of the incoming
+  // gradient for each max element.
+  auto E = {idim.n, outSz.first, outSz.second, idim.c, 2UL};
+  assert(srcXY.getType()->dims().equals(E) && "Invalid srcXY dims");
+  (void)E;
+}
+
+template <class T>
+void verifyBatchNormalization(T src, T dest, T bias, T scale, T mean, T var,
+                              size_t channel) {
+  checkSameType(dest, src);
+
+  // Figure out how many channels are in the tensor.
+  size_t channels = src.dims()[channel];
+
+  auto exp = {channels};
+  (void)exp;
+  assert(bias.getType()->dims().equals(exp) && "Invalid bias dim");
+  assert(scale.getType()->dims().equals(exp) && "Invalid scale dim");
+  assert(mean.getType()->dims().equals(exp) && "Invalid mean dim");
+  assert(var.getType()->dims().equals(exp) && "Invalid var dim");
+}
+
+template <class T> void verifySigmoid(T src, T dest) {
+  checkSameType(src, dest);
+}
+
+template <class T> void verifyTanh(T src, T dest) { checkSameType(src, dest); }
+
+template <class T> void verifyArithmetic(T LHS, T RHS, T res) {
+  checkSameShape(res, LHS);
+  checkSameShape(LHS, RHS);
+}
+
+template <class T> void verifySoftMax(T src, T dest) {
+  checkSameType(src, dest);
+  assert(src.dims() == dest.dims() && "Invalid shape");
+}
+
+template <class T> void verifySoftMaxGrad(T src, T dest, T srcGrad) {
+  checkSameType(dest, src);
+  checkSameType(dest, srcGrad);
+  auto destShape = dest.dims();
+  assert(destShape == src.dims() && "Invalid shape");
+  assert(destShape == srcGrad.dims() && "Invalid shape");
+  (void)destShape;
+}
+
+template <class T> void verifyCrossEntropyLoss(T P, T CE, T labels) {
+  assert(P.getElementType() == CE.getElementType());
+  assert(P.dims()[0] == labels.dims()[0] && "Invalid shape");
+}
+
+template <class T> void verifyReshape(T src, T dest) {
+  assert(dest.getType()->size() == src.getType()->size() &&
+         "Reshape into a different size");
+}
+
+template <class T>
+void verifyTranspose(T src, T dest, llvm::ArrayRef<unsigned> shuffle) {
+  llvm::SmallVector<size_t, 6> shape;
+
+  auto dims = src.dims();
+  for (size_t i = 0; i < dims.size(); i++) {
+    shape.push_back(dims[shuffle[i]]);
+  }
+
+  assert(dest.dims().equals(shape) && "Invalid transpose dims");
+}
+
+template <class T>
+void verifyBroadcast(T src, T dest, llvm::ArrayRef<size_t> shape) {
+  assert(src.dims().size() <= dest.dims().size() &&
+         "Source being broadcasted must have <= number dims of result shape.");
+  assert(dest.dims().equals(shape) &&
+         "New broadcasted shape does not match shape to broadcast to.");
+}
+
+template <class T>
+void verifyInsertTensor(T src, T dest, llvm::ArrayRef<size_t> offsets) {
+  unsigned numDims = dest.dims().size();
+  (void)numDims;
+  assert(numDims == src.dims().size() && numDims == offsets.size() &&
+         "Invalid number of dimensions");
+
+  for (unsigned i = 0; i < numDims; i++) {
+    assert(src.dims()[i] + offsets[i] <= dest.dims()[i] && "out of bounds");
+  }
+}
+
+template <class T> void verifyBatchedAdd(T dest, T batch, T slice) {
+  assert(batch.dims().drop_front() == slice.dims() && "Invalid shape");
+  assert(batch.dims() == dest.dims() && "Invalid dest type");
+  assert(batch.getType()->getElementType() ==
+             slice.getType()->getElementType() &&
+         "Mismatched element types");
+}
+
+template <class T> void verifyBatchedReduceAdd(T batch) {
+  assert(batch.dims().size() > 1 && "Invalid shape");
+}
+
+template <class T> void verifyQuantizationProfile(T src, T compInfo) {
+  // Make sure that input tensor is a floating point type.
+  assert(src.getElementType() == ElemKind::FloatTy &&
+         "Floating point type is expected");
+
+  // Check computation info has proper size.
+  assert(compInfo.dims().size() == 1 &&
+         "Computation info should be 1 dimensional");
+  assert(compInfo.dims()[0] == 2 &&
+         "Computation info should contain Min and Max value only");
+}
+
+template <class T> void verifyQuantize(T src, T dest) {
+  // Dest must be quantized.
+  checkType(dest, ElemKind::Int8QTy);
+  // Src must be float.
+  checkType(src, ElemKind::FloatTy);
+  checkSameShape(dest, src);
+}
+
+template <class T> void verifyDequantize(T src, T dest) {
+  // Dest must be float.
+  checkType(dest, ElemKind::FloatTy);
+  // Src must be quantized.
+  checkType(src, ElemKind::Int8QTy);
+  checkSameShape(dest, src);
+}
+
+template <class T> void verifyRescaleQuantized(T src, T dest) {
+  // Dest must be quantized.
+  checkType(dest, ElemKind::Int8QTy);
+  // Src must be quantized.
+  checkType(src, ElemKind::Int8QTy);
+  checkSameShape(dest, src);
+}
+
+template <class T> void verifyTopK(T src, T values, T indices) {
+  assert(src.getElementType() == ElemKind::FloatTy);
+  assert(values.getElementType() == ElemKind::FloatTy);
+  assert(values.dims() == indices.dims());
+}
+
+template <class T> void verifyGather(T dest, T data, T indices) {
+  assert(dest.getElementType() == data.getElementType());
+  assert(indices.getElementType() == ElemKind::IndexTy);
+  assert(dest.dims().size() == data.dims().size() + indices.dims().size() - 1);
+}
+
+template <class T> void verifyIntrinsic(T name) {
+  assert(name.size() && "Name must not be empty");
+}
+
+template <class T> void verifySelect(T dest, T cond, T lhs, T rhs) {
+  checkSameType(dest, cond);
+  checkSameType(dest, lhs);
+  checkSameType(dest, rhs);
+}
+
+template <class T> void verifySave(T src, T dest) { checkSameType(src, dest); }
+
+template <class T>
+void verifyConcat(llvm::ArrayRef<T> inputs, T dest, unsigned dimension) {
+  for (size_t i = 1; i < inputs.size(); i++) {
+    for (size_t j = 0; j < inputs[0].dims().size(); j++) {
+      if (j == dimension) {
+        continue;
+      }
+      assert(inputs[0].dims()[j] == inputs[i].dims()[j]);
+    }
+  }
+
+  for (size_t i = 0; i < inputs.size(); i++) {
+    checkType<NodeValue>(inputs[i], dest->getElementType());
+    if (dest->getType()->isQuantizedType()) {
+      assert(inputs[i]->getType()->getScale() == dest->getType()->getScale());
+      assert(inputs[i]->getType()->getOffset() == dest->getType()->getOffset());
+    }
+  }
+}
+
+template <class T> void verifyFullyConnected(T src, T weights, T bias, T dest) {
+  assert(src.dims()[0] == dest.dims()[0] &&
+         flattenCdr(src.dims()).second == weights.dims()[0] &&
+         "Mismatch on expected source dimensions");
+
+  assert(bias.dims()[0] == weights.dims()[1] &&
+         weights.dims()[1] == dest.dims()[1] &&
+         "Inconsistent bias/weights/dest sizes.");
+}
+
+template <class T> void verifyLocalResponseNormalization(T src, T dest) {
+  checkSameType(src, dest);
+}
+
+template <class T>
+void verifyLocalResponseNormalization(T src, T dest, T scale) {
+  checkSameType(dest, src);
+  checkSameType(dest, scale);
+}
+
+template <class T> void verifyBatchedMatMul(T dest, T lhs, T rhs) {
+  auto LDims = lhs.dims();
+  auto RDims = rhs.dims();
+  auto DDims = dest.dims();
+  (void)DDims;
+  assert(DDims.size() == 3);
+  auto elem = dest.getType()->getElementType();
+  (void)elem;
+  assert(lhs.getType()->getElementType() == elem);
+  assert(rhs.getType()->getElementType() == elem);
+
+  size_t N, X, Y;
+  std::tie(N, X, Y) = calculateMatMulOutputDims(LDims, RDims);
+
+  assert(N == DDims[0] && "Invalid matrix dims");
+  assert(X == DDims[1] && "Invalid matrix dims");
+  assert(Y == DDims[2] && "Invalid matrix dims");
+
+  (void)N;
+  (void)X;
+  (void)Y;
+}
+
+template <class T>
+void verifySlice(T src, T dest, llvm::ArrayRef<size_t> offsets) {
+  unsigned numDims = dest.dims().size();
+  (void)numDims;
+  assert(numDims == src.dims().size() && numDims == offsets.size() &&
+         "Invalid number of dimensions");
+
+  for (unsigned i = 0; i < numDims; i++) {
+    assert(dest.dims()[i] + offsets[i] <= src.dims()[i] && "out of bounds");
+  }
+}
+
+template <class T>
+void verifyExtractTensor(T src, T dest, llvm::ArrayRef<size_t> offsets) {
+  unsigned numDims = dest.dims().size();
+  (void)numDims;
+  assert(numDims == src.dims().size() && numDims == offsets.size() &&
+         "Invalid number of dimensions");
+
+  for (unsigned i = 0; i < numDims; i++) {
+    assert(dest.dims()[i] + offsets[i] <= src.dims()[i] && "out of bounds");
+  }
+}
+
+template <class T>
+void verifySGD(T gradient, T gSum, T weight, float momentum) {
+  if (momentum > 0.0) {
+    assert(gradient.getType() == gSum.getType() && "Invalid gsum type");
+  }
+
+  assert(gradient.getType() == weight.getType() &&
+         "Invalid weight or gradient type");
+}
+
+template <class T> void verifyRegression(T src, T dest, T expected) {
+  checkSameType(src, dest);
+  checkSameType(dest, expected);
+}
+
+template <class T> void verifyRelu(T src, T dest) { checkSameType(src, dest); }
+
+template <class T> void verifyTensorView(T src, TypeRef type) {
+  assert(src.getType()->size() == type->size() &&
+         "TensorView view size should be the same as Src size");
+  assert(src.getElementType() == type->getElementType() &&
+         "TensorView view element type should be the same as Src type");
+}
+
+} // namespace glow
+
+#endif // GLOW_VERIFICATION_VERIFICATION_H

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -4,6 +4,7 @@
 #include "glow/Base/Type.h"
 #include "glow/Graph/Graph.h"
 #include "glow/Support/Support.h"
+#include "glow/Verification/Verification.h"
 
 using namespace glow;
 
@@ -468,133 +469,6 @@ void Node::verify() const {
   }
 }
 
-/// Check that the type of the first operand matches the type of the second
-/// operand.
-static void checkSameType(NodeValue A, NodeValue B) {
-  assert(A.getType() == B.getType() && "Invalid type");
-}
-
-/// Check that the shape of the first operand matches the shape of the second
-/// operand.
-static void checkSameShape(NodeValue A, NodeValue B) {
-  assert(A.dims() == B.dims() && "Invalid shape");
-}
-
-static void checkType(NodeValue A, ElemKind expectedType) {
-  assert(A.getElementType() == expectedType && "Invalid type");
-}
-
-static void checkSameDims(NodeValue A, NodeValue B) {
-  assert(A.dims().equals(B.dims()) && "Dimensions mismatch");
-}
-
-static void verifyConvolution(NodeValue src, NodeValue dest, NodeValue filter,
-                              NodeValue bias, size_t kernel, size_t stride,
-                              size_t pad, size_t depth) {
-  assert(src.getElementType() == dest.getElementType() && "Invalid Type");
-  assert(src.getElementType() == filter.getElementType() && "Invalid Type");
-  assert(src.getElementType() == bias.getElementType() && "Invalid Type");
-
-  ShapeNHWC idim(src.getType()->dims());
-  ShapeNHWC odim(dest.getType()->dims());
-
-  assert(idim.w >= kernel && idim.h >= kernel &&
-         "buffer too small for selected stride");
-
-  auto outSz = calculateConvOutputDims(idim.h, idim.w, kernel, stride, pad);
-  ShapeNHWC exp(idim.n, outSz.first, outSz.second, depth);
-  (void)exp;
-  assert(exp == odim && "Invalid output dimensions");
-
-  auto filterDims = {depth, kernel, kernel, idim.c};
-  assert(filter.getType()->dims().equals(filterDims) && "Invalid filter dims");
-  (void)filterDims;
-
-  auto biasDims = {depth};
-  assert(bias.getType()->dims().equals(biasDims) && "Invalid bias dims");
-  (void)biasDims;
-}
-
-static void verifyFullyConnected(NodeValue src, NodeValue weights,
-                                 NodeValue bias, NodeValue dest) {
-  assert(src.dims()[0] == dest.dims()[0] &&
-         flattenCdr(src.dims()).second == weights.dims()[0] &&
-         "Mismatch on expected source dimensions");
-
-  assert(bias.dims()[0] == weights.dims()[1] &&
-         weights.dims()[1] == dest.dims()[1] &&
-         "Inconsistent bias/weights/dest sizes.");
-}
-
-static void verifyPool(NodeValue src, NodeValue dest, size_t kernel,
-                       size_t stride, size_t pad) {
-  ShapeNHWC idim = ShapeNHWC(src.getType()->dims());
-  ShapeNHWC odim = ShapeNHWC(dest.getType()->dims());
-  (void)odim;
-  assert(idim.w >= kernel && idim.h >= kernel &&
-         "buffer too small for selected stride");
-
-  auto outSz = calculateConvOutputDims(idim.h, idim.w, kernel, stride, pad);
-  ShapeNHWC exp(idim.n, outSz.first, outSz.second, idim.c);
-  (void)exp;
-  assert(exp == odim && "Unexpected output dimensions");
-}
-
-static void verifyBatchNormalization(NodeValue src, NodeValue dest,
-                                     NodeValue bias, NodeValue scale,
-                                     NodeValue mean, NodeValue var,
-                                     size_t channel) {
-  checkSameType(dest, src);
-
-  // Figure out how many channels are in the tensor.
-  size_t channels = src.dims()[channel];
-
-  auto exp = {channels};
-  (void)exp;
-  assert(bias.getType()->dims().equals(exp) && "Invalid bias dim");
-  assert(scale.getType()->dims().equals(exp) && "Invalid scale dim");
-  assert(mean.getType()->dims().equals(exp) && "Invalid mean dim");
-  assert(var.getType()->dims().equals(exp) && "Invalid var dim");
-}
-
-static void verifySigmoid(NodeValue src, NodeValue dest) {
-  checkSameType(src, dest);
-}
-
-static void verifyTanh(NodeValue src, NodeValue dest) {
-  checkSameType(src, dest);
-}
-
-static void verifySoftMax(NodeValue src, NodeValue dest) {
-  checkSameType(src, dest);
-  assert(src.dims() == dest.dims() && "Invalid shape");
-}
-
-static void verifyCrossEntropyLoss(NodeValue P, NodeValue CE,
-                                   NodeValue labels) {
-  assert(P.getElementType() == CE->getElementType());
-  assert(P.dims()[0] == labels.dims()[0] && "Invalid shape");
-}
-
-static void verifyLocalResponseNormalization(NodeValue src, NodeValue dest) {
-  checkSameType(src, dest);
-}
-
-static void verifyArithmetic(NodeValue LHS, NodeValue RHS, NodeValue res) {
-  checkSameShape(res, LHS);
-  checkSameShape(LHS, RHS);
-}
-
-static void verifyRelu(NodeValue src, NodeValue dest) {
-  checkSameType(src, dest);
-}
-
-static void verifyRegression(NodeValue src, NodeValue dest,
-                             NodeValue expected) {
-  checkSameType(src, dest);
-  checkSameType(dest, expected);
-}
-
 void ConvolutionNode::verify() const {
   verifyConvolution(getInput(), getResult(), getFilter(), getBias(), Kernel_,
                     Stride_, Pad_, Depth_);
@@ -626,32 +500,7 @@ void PoolAvgGradNode::verify() const {
 }
 
 void BatchedMatMulNode::verify() const {
-  auto dest = getResult();
-  auto lhs = getLHS();
-  auto rhs = getRHS();
-  (void)dest;
-  (void)lhs;
-  (void)rhs;
-
-  auto LDims = lhs.dims();
-  auto RDims = rhs.dims();
-  auto DDims = dest.dims();
-  (void)DDims;
-  assert(DDims.size() == 3);
-  auto elem = dest.getType()->getElementType();
-  (void)elem;
-  assert(lhs.getType()->getElementType() == elem);
-  assert(rhs.getType()->getElementType() == elem);
-
-  size_t N, X, Y;
-  std::tie(N, X, Y) = calculateMatMulOutputDims(LDims, RDims);
-
-  assert(N == DDims[0] && "Invalid matrix dims");
-  assert(X == DDims[1] && "Invalid matrix dims");
-  assert(Y == DDims[2] && "Invalid matrix dims");
-  (void)N;
-  (void)X;
-  (void)Y;
+  verifyBatchedMatMul(getResult(), getLHS(), getRHS());
 }
 
 void SigmoidNode::verify() const { verifySigmoid(getInput(), getResult()); }
@@ -670,8 +519,8 @@ void TanhGradNode::verify() const {
 void SoftMaxNode::verify() const { verifySoftMax(getInput(), getResult()); }
 
 void SoftMaxGradNode::verify() const {
-  verifySoftMax(getGradOfInputNamedInput(),
-                getGradOfOriginalOutputNamedResult());
+  verifySoftMaxGrad(getInput(), getOriginalOutputForResult(),
+                    getGradOfInputNamedInput());
 }
 
 void CrossEntropyLossNode::verify() const {
@@ -684,73 +533,24 @@ void CrossEntropyLossGradNode::verify() const {
                          getGradOfInputNamedLabels());
 }
 
-void ReshapeNode::verify() const {
-  assert(getResult().getType()->size() == getInput().getType()->size() &&
-         "Reshape into a different size");
-}
+void ReshapeNode::verify() const { verifyReshape(getInput(), getResult()); }
 
 void TransposeNode::verify() const {
-  auto dest = getResult();
-  auto src = getInput();
-  (void)dest;
-  llvm::SmallVector<size_t, 6> shape;
-
-  auto dims = src.dims();
-  for (size_t i = 0; i < dims.size(); i++) {
-    shape.push_back(dims[Shuffle_[i]]);
-  }
-
-  assert(dest.dims().equals(shape) && "Invalid transpose dims");
+  verifyTranspose(getInput(), getResult(), getShuffle());
 }
 
 void BroadcastNode::verify() const {
-  auto src = getInput();
-  auto dest = getResult();
-  auto shape = getShape();
-  (void)src;
-  (void)dest;
-  (void)shape;
-
-  assert(src.dims().size() <= dest.dims().size() &&
-         "Source being broadcasted must have <= number dims of result shape.");
-  assert(dest.dims().equals(shape) &&
-         "New broadcasted shape does not match shape to broadcast to.");
+  verifyBroadcast(getInput(), getResult(), getShape());
 }
 
 void SplatNode::verify() const {}
 
 void InsertTensorNode::verify() const {
-  auto dest = getBig();
-  auto src = getSmall();
-  auto offsets = getStart();
-  unsigned numDims = dest.dims().size();
-  (void)numDims;
-  (void)dest;
-  (void)src;
-  (void)offsets;
-  assert(numDims == src.dims().size() && numDims == offsets.size() &&
-         "Invalid number of dimensions");
-
-  for (unsigned i = 0; i < numDims; i++) {
-    assert(src.dims()[i] + offsets[i] <= dest.dims()[i] && "out of bounds");
-  }
+  verifyInsertTensor(getSmall(), getBig(), getStart());
 }
 
 void SliceNode::verify() const {
-  auto dest = getResult();
-  auto src = getInput();
-  auto offsets = getStart();
-  unsigned numDims = dest.dims().size();
-  (void)numDims;
-  (void)dest;
-  (void)src;
-  (void)offsets;
-  assert(numDims == src.dims().size() && numDims == offsets.size() &&
-         "Invalid number of dimensions");
-
-  for (unsigned i = 0; i < numDims; i++) {
-    assert(dest.dims()[i] + offsets[i] <= src.dims()[i] && "out of bounds");
-  }
+  verifySlice(getInput(), getResult(), getStart());
 }
 
 void BatchNormalizationNode::verify() const {
@@ -802,90 +602,45 @@ VERIFY_ARITHMETIC(CmpLTEGrad);
 #undef VERIFY_ARITHMETIC
 
 void BatchedAddNode::verify() const {
-  auto batchShape = getBatch().dims();
-  auto rhsShape = getSlice().dims();
-  assert(batchShape.drop_front() == rhsShape && "Invalid shape");
-  assert(getBatch().dims() == getResult().dims() && "Invalid dest type");
-  (void)batchShape;
-  (void)rhsShape;
-  assert(getBatch().getType()->getElementType() ==
-             getSlice().getType()->getElementType() &&
-         "Mismatched element types");
+  verifyBatchedAdd(getResult(), getBatch(), getSlice());
 }
 
 void BatchedReduceAddNode::verify() const {
-  assert(getBatch().dims().size() > 1 && "Invalid shape");
+  verifyBatchedReduceAdd(getBatch());
 }
 
 void SGDNode::verify() const {
-  if (Momentum_ > 0.0) {
-    assert(getGradient().getType() == getGsum().getType() &&
-           "Invalid gsum type");
-  }
-
-  assert(getGradient().getType() == getWeight().getType() &&
-         "Invalid weight or gradient type");
+  verifySGD(getGradient(), getGsum(), getWeight(), Momentum_);
 }
 
 void QuantizationProfileNode::verify() const {
-  // Make sure that input tensor is a floating point type.
-  assert(getInput().getElementType() == ElemKind::FloatTy &&
-         "Floating point type is expected");
-
-  // Check computation info has proper size.
-  assert(getComputationInfo().dims().size() == 1 &&
-         "Computation info should be 1 dimensional");
-  assert(getComputationInfo().dims()[0] == 2 &&
-         "Computation info should contain Min and Max value only");
+  verifyQuantizationProfile(getInput(), getComputationInfo());
 }
 
-void QuantizeNode::verify() const {
-  // Dest must be quantized.
-  checkType(getResult(), ElemKind::Int8QTy);
-  // Src must be float.
-  checkType(getInput(), ElemKind::FloatTy);
-  checkSameDims(getResult(), getInput());
-}
+void QuantizeNode::verify() const { verifyQuantize(getInput(), getResult()); }
 
 void DequantizeNode::verify() const {
-  // Dest must be float.
-  checkType(getResult(), ElemKind::FloatTy);
-  // Src must be quantized.
-  checkType(getInput(), ElemKind::Int8QTy);
-  checkSameDims(getResult(), getInput());
+  verifyDequantize(getInput(), getResult());
 }
 
 void RescaleQuantizedNode::verify() const {
-  // Dest must be quantized.
-  checkType(getResult(), ElemKind::Int8QTy);
-  // Src must be quantized.
-  checkType(getInput(), ElemKind::Int8QTy);
-  checkSameDims(getResult(), getInput());
+  verifyRescaleQuantized(getInput(), getResult());
 }
 
 void TopKNode::verify() const {
-  assert(getInput().getElementType() == ElemKind::FloatTy);
-  assert(getValues().getElementType() == ElemKind::FloatTy);
-  assert(getValues().dims() == getIndices().dims());
+  verifyTopK(getInput(), getValues(), getIndices());
 }
 
 void GatherNode::verify() const {
-  assert(getResult().getElementType() == getData().getElementType());
-  assert(getIndices().getElementType() == ElemKind::IndexTy);
-  assert(getResult().dims().size() ==
-         getData().dims().size() + getIndices().dims().size() - 1);
+  verifyGather(getResult(), getData(), getIndices());
 }
 
-void IntrinsicNode::verify() const {
-  assert(getName().size() && "Name must not be empty");
-}
+void IntrinsicNode::verify() const { verifyIntrinsic(getName()); }
 
-void SaveNode::verify() const { checkSameType(getInput(), getOutput()); }
+void SaveNode::verify() const { verifySave(getInput(), getOutput()); }
 
 void SelectNode::verify() const {
-  checkSameType(getResult(), getCond());
-  checkSameType(getResult(), getLHS());
-  checkSameType(getResult(), getRHS());
+  verifySelect(getResult(), getCond(), getLHS(), getRHS());
 }
 
 void ReluNode::verify() const { verifyRelu(getResult(), getInput()); }
@@ -915,29 +670,7 @@ void FullyConnectedGradNode::verify() const {
 }
 
 void ConcatNode::verify() const {
-  auto inputs = getInputs();
-  auto dimension = getDim();
-  (void)inputs;
-  (void)dimension;
-
-  for (size_t i = 1; i < inputs.size(); i++) {
-    for (size_t j = 0; j < inputs[0].dims().size(); j++) {
-      if (j == dimension) {
-        continue;
-      }
-      assert(inputs[0].dims()[j] == inputs[i].dims()[j]);
-    }
-  }
-
-  for (size_t i = 0; i < inputs.size(); i++) {
-    checkType(inputs[i], getResult()->getElementType());
-    if (getResult()->getType()->isQuantizedType()) {
-      assert(inputs[i]->getType()->getScale() ==
-             getResult()->getType()->getScale());
-      assert(inputs[i]->getType()->getOffset() ==
-             getResult()->getType()->getOffset());
-    }
-  }
+  verifyConcat(getInputs(), getResult(), getDim());
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/IR/Instrs.cpp
+++ b/lib/IR/Instrs.cpp
@@ -3,6 +3,7 @@
 #include "glow/IR/Instrs.h"
 #include "glow/IR/IR.h"
 #include "glow/Support/Support.h"
+#include "glow/Verification/Verification.h"
 
 #include "llvm/Support/Casting.h"
 
@@ -34,24 +35,10 @@ void WeightVar::dump(llvm::raw_ostream &os) const {
 //                       Instruction verification
 //===----------------------------------------------------------------------===//
 
-/// Check that the type of the first operand matches the type of the second
-/// operand.
-static void checkSameType(Value *A, Value *B) {
-  assert(A->getType() == B->getType() && "Invalid type");
-}
-
-static void checkType(Value *A, ElemKind expectedType) {
-  assert(A->getElementType() == expectedType && "Invalid type");
-}
-
-static void checkSameShape(Value *A, Value *B) {
-  assert(A->dims().equals(B->dims()) && "Dimensions mismatch");
-}
-
 void CopyInst::verify() const {
   auto *dest = getDest();
   auto *src = getSrc();
-  checkSameType(dest, src);
+  checkSameType(*dest, *src);
   // The operands of the copy instruction must be variables.
   assert(isa<AllocActivationInst>(dest) || isa<WeightVar>(dest) ||
          isa<TensorViewInst>(dest));
@@ -59,363 +46,123 @@ void CopyInst::verify() const {
          isa<TensorViewInst>(src));
 }
 
-static void verifyConvolution(Value *src, Value *dest, Value *filter,
-                              Value *bias, size_t kernel, size_t stride,
-                              size_t pad, size_t depth) {
-  assert(src->getElementType() == dest->getElementType() && "Invalid Type");
-  assert(src->getElementType() == filter->getElementType() && "Invalid Type");
-  assert(src->getElementType() == bias->getElementType() && "Invalid Type");
-
-  ShapeNHWC idim(src->getType()->dims());
-  ShapeNHWC odim(dest->getType()->dims());
-
-  assert(idim.w >= kernel && idim.h >= kernel &&
-         "buffer too small for selected stride");
-
-  auto outSz = calculateConvOutputDims(idim.h, idim.w, kernel, stride, pad);
-  ShapeNHWC exp(idim.n, outSz.first, outSz.second, depth);
-  (void)exp;
-  assert(exp == odim && "Invalid output dimensions");
-
-  auto filterDims = {depth, kernel, kernel, idim.c};
-  assert(filter->getType()->dims().equals(filterDims) && "Invalid filter dims");
-  (void)filterDims;
-
-  auto biasDims = {depth};
-  assert(bias->getType()->dims().equals(biasDims) && "Invalid bias dims");
-  (void)biasDims;
-}
-
-static void verifyPoolMaxWithXY(Value *src, Value *dest, Value *srcXY,
-                                size_t kernel, size_t stride, size_t pad) {
-  (void)srcXY;
-  ShapeNHWC idim = ShapeNHWC(src->getType()->dims());
-  ShapeNHWC odim = ShapeNHWC(dest->getType()->dims());
-  (void)odim;
-  assert(idim.w >= kernel && idim.h >= kernel &&
-         "buffer too small for selected stride");
-
-  auto outSz = calculateConvOutputDims(idim.h, idim.w, kernel, stride, pad);
-  ShapeNHWC exp(idim.n, outSz.first, outSz.second, idim.c);
-  (void)exp;
-  assert(exp == odim && "Unexpected output dimensions");
-
-  // Allocate cache arrays that store the x and y coordinates of the incoming
-  // gradient for each max element.
-  auto E = {idim.n, outSz.first, outSz.second, idim.c, 2UL};
-  assert(srcXY->getType()->dims().equals(E) && "Invalid srcXY dims");
-  (void)E;
-}
-
-static void verifyPoolAvg(Value *src, Value *dest, size_t kernel, size_t stride,
-                          size_t pad) {
-  ShapeNHWC idim = ShapeNHWC(src->getType()->dims());
-  ShapeNHWC odim = ShapeNHWC(dest->getType()->dims());
-  (void)odim;
-  assert(idim.w >= kernel && idim.h >= kernel &&
-         "buffer too small for selected stride");
-
-  auto outSz = calculateConvOutputDims(idim.h, idim.w, kernel, stride, pad);
-  ShapeNHWC exp(idim.n, outSz.first, outSz.second, idim.c);
-  (void)exp;
-  assert(exp == odim && "Unexpected output dimensions");
-}
-
-static void verifyBatchNormalization(Value *src, Value *dest, Value *scale,
-                                     Value *bias, Value *mean, Value *var,
-                                     size_t channel) {
-  checkSameType(dest, src);
-
-  // Figure out how many channels are in the tensor.
-  size_t channels = dest->dims()[channel];
-
-  auto exp = {channels};
-  (void)exp;
-  assert(scale->getType()->dims().equals(exp) && "Invalid bias dim");
-  assert(bias->getType()->dims().equals(exp) && "Invalid scale dim");
-  assert(mean->getType()->dims().equals(exp) && "Invalid mean dim");
-  assert(var->getType()->dims().equals(exp) && "Invalid var dim");
-}
-
 void ConvolutionInst::verify() const {
-  Value *dest = getDest();
-  Value *src = getSrc();
-  Value *filter = getFilter();
-  Value *bias = getBias();
-
-  verifyConvolution(src, dest, filter, bias, Kernel_, Stride_, Pad_, Depth_);
+  verifyConvolution(*getSrc(), *getDest(), *getFilter(), *getBias(), Kernel_,
+                    Stride_, Pad_, Depth_);
 }
 
 void ConvolutionGradInst::verify() const {
-  Value *dest = getDestGrad();
-  Value *src = getSrcGrad();
-  Value *filter = getFilterGrad();
-  Value *bias = getBiasGrad();
-
-  verifyConvolution(src, dest, filter, bias, Kernel_, Stride_, Pad_, Depth_);
+  verifyConvolution(*getSrcGrad(), *getDestGrad(), *getFilterGrad(),
+                    *getBiasGrad(), Kernel_, Stride_, Pad_, Depth_);
 }
 
 void PoolMaxInst::verify() const {
-  Value *dest = getDest();
-  Value *src = getSrc();
-  ShapeNHWC idim = ShapeNHWC(src->getType()->dims());
-  ShapeNHWC odim = ShapeNHWC(dest->getType()->dims());
-  (void)odim;
-  assert(idim.w >= Kernel_ && idim.h >= Kernel_ &&
-         "buffer too small for selected stride");
-
-  auto outSz = calculateConvOutputDims(idim.h, idim.w, Kernel_, Stride_, Pad_);
-  ShapeNHWC exp(idim.n, outSz.first, outSz.second, idim.c);
-  (void)exp;
-  assert(exp == odim && "Unexpected output dimensions");
+  verifyPool(*getSrc(), *getDest(), Kernel_, Stride_, Pad_);
 }
 
 void PoolMaxWithXYInst::verify() const {
-  Value *dest = getDest();
-  Value *src = getSrc();
-  Value *srcXY = getSrcXY();
-
-  verifyPoolMaxWithXY(src, dest, srcXY, Kernel_, Stride_, Pad_);
+  verifyPoolMaxWithXY(*getSrc(), *getDest(), *getSrcXY(), Kernel_, Stride_,
+                      Pad_);
 }
 
 void PoolMaxWithXYGradInst::verify() const {
-  Value *dest = getDestGrad();
-  Value *src = getSrcGrad();
-  Value *srcXY = getSrcXY();
-
-  verifyPoolMaxWithXY(src, dest, srcXY, Kernel_, Stride_, Pad_);
+  verifyPoolMaxWithXY(*getSrcGrad(), *getDestGrad(), *getSrcXY(), Kernel_,
+                      Stride_, Pad_);
 }
 
 void PoolAvgInst::verify() const {
-  Value *dest = getDest();
-  Value *src = getSrc();
-
-  verifyPoolAvg(src, dest, Kernel_, Stride_, Pad_);
+  verifyPool(*getSrc(), *getDest(), Kernel_, Stride_, Pad_);
 }
 
 void PoolAvgGradInst::verify() const {
-  Value *dest = getDestGrad();
-  Value *src = getSrcGrad();
-
-  verifyPoolAvg(src, dest, Kernel_, Stride_, Pad_);
+  verifyPool(*getSrcGrad(), *getDestGrad(), Kernel_, Stride_, Pad_);
 }
 
 void BatchedMatMulInst::verify() const {
-  Value *dest = getDest();
-  Value *lhs = getLHS();
-  Value *rhs = getRHS();
-
-  auto LDims = lhs->dims();
-  auto RDims = rhs->dims();
-  auto DDims = dest->dims();
-  (void)DDims;
-  assert(DDims.size() == 3);
-  auto elem = dest->getType()->getElementType();
-  (void)elem;
-  assert(lhs->getType()->getElementType() == elem);
-  assert(rhs->getType()->getElementType() == elem);
-
-  size_t N, X, Y;
-  std::tie(N, X, Y) = calculateMatMulOutputDims(LDims, RDims);
-
-  assert(N == DDims[0] && "Invalid matrix dims");
-  assert(X == DDims[1] && "Invalid matrix dims");
-  assert(Y == DDims[2] && "Invalid matrix dims");
-
-  (void)N;
-  (void)X;
-  (void)Y;
+  verifyBatchedMatMul(*getDest(), *getLHS(), *getRHS());
 }
 
-void SigmoidInst::verify() const { checkSameType(getDest(), getSrc()); }
+void SigmoidInst::verify() const { verifySigmoid(*getSrc(), *getDest()); }
 
-void TanhInst::verify() const { checkSameType(getDest(), getSrc()); }
+void TanhInst::verify() const { verifyTanh(*getSrc(), *getDest()); }
 
-void SoftMaxInst::verify() const {
-  checkSameType(getDest(), getSrc());
-  assert(getDest()->dims() == getSrc()->dims() && "Invalid shape");
-}
+void SoftMaxInst::verify() const { verifySoftMax(*getSrc(), *getDest()); }
 
 void SoftMaxGradInst::verify() const {
-  checkSameType(getOrigDest(), getOrigSrc());
-  checkSameType(getOrigDest(), getSrcGrad());
-  auto destShape = getOrigDest()->dims();
-  assert(destShape == getOrigSrc()->dims() && "Invalid shape");
-  assert(destShape == getSrcGrad()->dims() && "Invalid shape");
-  (void)destShape;
+  verifySoftMaxGrad(*getOrigSrc(), *getOrigDest(), *getSrcGrad());
 }
 
 void CrossEntropyLossInst::verify() const {
-  assert(getP()->dims()[0] == getLabels()->dims()[0] && "Invalid shape");
+  verifyCrossEntropyLoss(*getP(), *getCE(), *getLabels());
 }
 
 void CrossEntropyLossGradInst::verify() const {
-  assert(getPgrad()->dims()[0] == getLabels()->dims()[0] && "Invaild shape");
+  verifyCrossEntropyLoss(*getPgrad(), *getCEGrad(), *getLabelsgrad());
 }
 
-void ReshapeInst::verify() const {
-  assert(getDest()->getType()->size() == getSrc()->getType()->size() &&
-         "Reshape into a different size");
-}
+void ReshapeInst::verify() const { verifyReshape(*getSrc(), *getDest()); }
 
-void TensorViewInst::verify() const {
-  assert(getSrc()->getType()->size() == getType()->size() &&
-         "TensorView view size should be the same as Src size");
-  assert(getSrc()->getElementType() == getType()->getElementType() &&
-         "TensorView view element type should be the same as Src type");
-}
+void TensorViewInst::verify() const { verifyTensorView(*getSrc(), getType()); }
 
 void TransposeInst::verify() const {
-  auto *dest = getDest();
-  auto *src = getSrc();
-  (void)dest;
-  llvm::SmallVector<size_t, 6> shape;
-
-  auto dims = src->dims();
-  for (size_t i = 0; i < dims.size(); i++) {
-    shape.push_back(dims[Shuffle_[i]]);
-  }
-
-  assert(dest->dims().equals(shape) && "Invalid transpose dims");
+  verifyTranspose(*getSrc(), *getDest(), getShuffle());
 }
 
 void BroadcastInst::verify() const {
-  auto *src = getSrc();
-  auto *dest = getDest();
-  auto shape = getShape();
-  (void)src;
-  (void)dest;
-  (void)shape;
-
-  assert(src->dims().size() <= dest->dims().size() &&
-         "Source being broadcasted must have <= number dims of result shape.");
-  assert(dest->dims().equals(shape) &&
-         "New broadcasted shape does not match shape to broadcast to.");
+  verifyBroadcast(*getSrc(), *getDest(), getShape());
 }
 
 void SplatInst::verify() const {}
 
 void InsertTensorInst::verify() const {
-  auto *dest = getDest();
-  auto *src = getSrc();
-  auto offsets = getOffsets();
-  unsigned numDims = dest->dims().size();
-  (void)numDims;
-  (void)dest;
-  (void)src;
-  (void)offsets;
-  assert(numDims == src->dims().size() && numDims == offsets.size() &&
-         "Invalid number of dimensions");
-
-  for (unsigned i = 0; i < numDims; i++) {
-    assert(src->dims()[i] + offsets[i] <= dest->dims()[i] && "out of bounds");
-  }
+  verifyInsertTensor(*getSrc(), *getDest(), getOffsets());
 }
 
 void ExtractTensorInst::verify() const {
-  auto *dest = getDest();
-  auto *src = getSrc();
-  auto offsets = getOffsets();
-  unsigned numDims = dest->dims().size();
-  (void)numDims;
-  (void)dest;
-  (void)src;
-  (void)offsets;
-  assert(numDims == src->dims().size() && numDims == offsets.size() &&
-         "Invalid number of dimensions");
-
-  for (unsigned i = 0; i < numDims; i++) {
-    assert(dest->dims()[i] + offsets[i] <= src->dims()[i] && "out of bounds");
-  }
+  verifyExtractTensor(*getSrc(), *getDest(), getOffsets());
 }
 
 void BatchNormalizationInst::verify() const {
-  Value *src = getSrc();
-  Value *dest = getDest();
-  Value *scale = getScale();
-  Value *bias = getBias();
-  Value *mean = getMean();
-  Value *var = getVar();
-
-  verifyBatchNormalization(src, dest, scale, bias, mean, var, ChannelIdx_);
+  verifyBatchNormalization(*getSrc(), *getDest(), *getScale(), *getBias(),
+                           *getMean(), *getVar(), ChannelIdx_);
 }
 
 void BatchNormalizationGradInst::verify() const {
-  Value *src = getSrcGrad();
-  Value *dest = getDestGrad();
-  Value *scale = getScaleGrad();
-  Value *bias = getBiasGrad();
-  Value *mean = getMean();
-  Value *var = getVar();
-
-  verifyBatchNormalization(src, dest, scale, bias, mean, var, ChannelIdx_);
+  verifyBatchNormalization(*getSrcGrad(), *getDestGrad(), *getScaleGrad(),
+                           *getBiasGrad(), *getMean(), *getVar(), ChannelIdx_);
 }
 
 void LocalResponseNormalizationInst::verify() const {
-  checkSameType(getDest(), getSrc());
-  checkSameType(getDest(), getScale());
+  verifyLocalResponseNormalization(*getSrc(), *getDest(), *getScale());
 }
 
 void LocalResponseNormalizationGradInst::verify() const {
-  checkSameType(getDestGrad(), getSrcGrad());
-  checkSameType(getDestGrad(), getScale());
-}
-
-void ElementAddInst::verify() const {
-  checkSameShape(getDest(), getLHS());
-  checkSameShape(getDest(), getRHS());
-}
-
-void ElementMulInst::verify() const {
-  checkSameShape(getDest(), getLHS());
-  checkSameShape(getDest(), getRHS());
-}
-
-void ElementSubInst::verify() const {
-  checkSameType(getDest(), getLHS());
-  checkSameType(getDest(), getRHS());
+  verifyLocalResponseNormalization(*getSrcGrad(), *getDestGrad(), *getScale());
 }
 
 void BatchedAddInst::verify() const {
-  auto batchShape = getBatch()->dims();
-  auto rhsShape = getSlice()->dims();
-  assert(batchShape.drop_front() == rhsShape && "Invalid shape");
-  assert(getBatch()->dims() == getDest()->dims() && "Invalid dest type");
-  (void)batchShape;
-  (void)rhsShape;
-  assert(getBatch()->getType()->getElementType() ==
-             getSlice()->getType()->getElementType() &&
-         "Mismatched element types");
+  verifyBatchedAdd(*getDest(), *getBatch(), *getSlice());
 }
 
 void BatchedReduceAddInst::verify() const {
-  assert(getBatch()->dims().size() > 1 && "Invalid shape");
+  verifyBatchedReduceAdd(*getBatch());
 }
 
-void ElementDivInst::verify() const {
-  checkSameShape(getDest(), getLHS());
-  checkSameShape(getDest(), getRHS());
-}
-
-void ElementMaxInst::verify() const {
-  checkSameShape(getDest(), getLHS());
-  checkSameShape(getDest(), getRHS());
-}
-
-void ElementMinInst::verify() const {
-  checkSameShape(getDest(), getLHS());
-  checkSameShape(getDest(), getRHS());
-}
-
-void ElementCmpLTEInst::verify() const {
-  checkSameShape(getDest(), getLHS());
-  checkSameShape(getDest(), getRHS());
-}
+#define VERIFY_ARITHMETIC(INST_NAME_)                                          \
+  void INST_NAME_##Inst::verify() const {                                      \
+    verifyArithmetic(*getLHS(), *getRHS(), *getDest());                        \
+  }
+VERIFY_ARITHMETIC(ElementAdd);
+VERIFY_ARITHMETIC(ElementMul);
+VERIFY_ARITHMETIC(ElementSub);
+VERIFY_ARITHMETIC(ElementDiv);
+VERIFY_ARITHMETIC(ElementMax);
+VERIFY_ARITHMETIC(ElementMin);
+VERIFY_ARITHMETIC(ElementCmpLTE);
+#undef VERIFY_ARITHMETIC
 
 void ElementSelectInst::verify() const {
-  checkSameShape(getDest(), getCond());
-  checkSameShape(getDest(), getLHS());
-  checkSameShape(getDest(), getRHS());
+  verifySelect(*getDest(), *getCond(), *getLHS(), *getRHS());
 }
 
 void AllocActivationInst::verify() const {
@@ -434,49 +181,26 @@ void DeallocActivationInst::verify() const {
 }
 
 void QuantizationProfileInst::verify() const {
-  assert(getInputTensor()->getElementType() == ElemKind::FloatTy &&
-         "Floating point type is expected");
-
-  assert(getComputationInfo()->dims().size() == 1 &&
-         "Computation info should be 1 dimensional");
-  assert(getComputationInfo()->dims()[0] == 2 &&
-         "Computation info should contain Min and Max value only");
+  verifyQuantizationProfile(*getInputTensor(), *getComputationInfo());
 }
 
-void QuantizeInst::verify() const {
-  checkType(getDest(), ElemKind::Int8QTy);
-  checkType(getSrc(), ElemKind::FloatTy);
-  checkSameShape(getDest(), getSrc());
-}
+void QuantizeInst::verify() const { verifyQuantize(*getSrc(), *getDest()); }
 
-void DequantizeInst::verify() const {
-  checkType(getDest(), ElemKind::FloatTy);
-  checkType(getSrc(), ElemKind::Int8QTy);
-  checkSameShape(getDest(), getSrc());
-}
+void DequantizeInst::verify() const { verifyDequantize(*getSrc(), *getDest()); }
 
 void RescaleQuantizedInst::verify() const {
-  checkType(getDest(), ElemKind::Int8QTy);
-  checkType(getSrc(), ElemKind::Int8QTy);
-  checkSameShape(getDest(), getSrc());
+  verifyRescaleQuantized(*getSrc(), *getDest());
 }
 
 void TopKInst::verify() const {
-  assert(getValues()->getElementType() == ElemKind::FloatTy);
-  assert(getInput()->getElementType() == ElemKind::FloatTy);
-  assert(getValues()->dims() == getIndices()->dims());
+  verifyTopK(*getInput(), *getValues(), *getIndices());
 }
 
 void GatherInst::verify() const {
-  assert(getDest()->getElementType() == getData()->getElementType());
-  assert(getIndices()->getElementType() == ElemKind::IndexTy);
-  assert(getDest()->dims().size() ==
-         getData()->dims().size() + getIndices()->dims().size() - 1);
+  verifyGather(*getDest(), *getData(), *getIndices());
 }
 
-void IntrinsicInst::verify() const {
-  assert(getName().size() && "Name must not be empty");
-}
+void IntrinsicInst::verify() const { verifyIntrinsic(getName()); }
 
 void DebugPrintInst::verify() const {
   // Nothing to verify.


### PR DESCRIPTION
Moved essentially all verification to `Verification.h`, outlining shared verification logic between Nodes and Instrs.

This has left a lot of boilerplate `verify()`s in `Nodes.cpp`/`Instrs.cpp` which call into `Verification.h`, so the next step is to autogenerate as much of that as possible.