### PR TITLE
[jit] Implement TopK

### DIFF
--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -783,6 +783,25 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     break;
   }
 
+  case Kinded::Kind::TopKInstKind: {
+    TopKInst *TI = cast<TopKInst>(I);
+
+    auto *input = TI->getInput();
+    auto *valuesPtr = emitValueAddress(builder, TI->getValues());
+    auto *indicesPtr = emitValueAddress(builder, TI->getIndices());
+    auto *scratchPtr = emitValueAddress(builder, TI->getScratch());
+    auto *inputPtr = emitValueAddress(builder, input);
+
+    auto *k = emitConstST(builder, TI->getK());
+    auto *n = emitConstST(builder, input->dims().back());
+    auto *size = emitConstST(builder, input->getType()->size());
+
+    auto *F = getFunction("topk", input->getElementType());
+    builder.CreateCall(
+        F, {inputPtr, valuesPtr, indicesPtr, scratchPtr, k, n, size});
+    break;
+  }
+
   case Kinded::Kind::TransposeInstKind: {
     TransposeInst *TI = cast<TransposeInst>(I);
     auto *dest = TI->getDest();

--- a/lib/IR/IRBuilder.cpp
+++ b/lib/IR/IRBuilder.cpp
@@ -112,11 +112,15 @@ TopKInst *IRBuilder::createTopKOp(Value *input, size_t k) {
   assert(k <= inDims.back());
   llvm::SmallVector<size_t, 6> outDims(inDims.begin(), inDims.end());
   outDims.back() = k;
+  // Allocate enough scratch space to hold N values and N indices.
+  auto *scratch = createAllocActivationInst("topk.scratch", ElemKind::IndexTy,
+                                            {inDims.back() * 2});
+  createSplatInst("topk.zero.scratch", scratch, 0);
   auto *values = createAllocActivationInst("topk.values",
                                            input->getElementType(), outDims);
   auto *indices =
       createAllocActivationInst("topk.indices", ElemKind::IndexTy, outDims);
-  return createTopKInst("topk", values, indices, input, k);
+  return createTopKInst("topk", values, indices, input, scratch, k);
 }
 
 Value *IRBuilder::createReturnOp(Value *input) {

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -355,6 +355,7 @@ int main(int argc, char **argv) {
       .addOperand("Values", OperandKind::Out)
       .addOperand("Indices", OperandKind::Out)
       .addOperand("Input", OperandKind::In)
+      .addOperand("Scratch", OperandKind::InOut)
       .addMember(MemberType::SizeT, "K");
 
   //===--------------------------------------------------------------------===//


### PR DESCRIPTION
Adding TopK to the JIT.  The weird quirk of TopK is that it's annoying to come up with an algorithm for selecting max k elements that uses no additional memory but is faster than O(n*k).  The interpreter uses a std::vector scratch space for sorting, but we (probably?) don't want to malloc() in the jit.

This implementation adds scratch space to the IR, since it seems like it would be a generally useful thing for many backends.  But tbh I don't like it - among other reasons, the scratch buffer is not correctly typed (It's 2n size_t's, but you'll see what I really need is 2n {size_t, float}).

So I'm kind of thinking of biting the bullet and writing my own in-place partial heap sort, but, I dunno.  I'm not sure how critical this feels since I'm just trying to unblock jitting fr2en so I can look at other optimizations :).

Thoughts?