### PR TITLE
[libjit] Implement copy_u

### DIFF
--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -445,10 +445,12 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     CopyInst *CI = cast<CopyInst>(I);
     auto *dest = CI->getDest();
     auto *destPtr = emitValueAddress(builder, dest);
+    destPtr = builder.CreateBitCast(destPtr, builder.getInt8PtrTy());
     auto *srcPtr = emitValueAddress(builder, CI->getSrc());
+    srcPtr = builder.CreateBitCast(srcPtr, builder.getInt8PtrTy());
     auto *bytes = emitConstST(builder, dest->getType()->getSizeInBytes());
 
-    auto *F = getFunction("copy", dest->getElementType());
+    auto *F = getFunction("copy");
     builder.CreateCall(F, {destPtr, srcPtr, bytes});
     break;
   }

--- a/lib/Backends/CPU/libjit.cpp
+++ b/lib/Backends/CPU/libjit.cpp
@@ -292,12 +292,8 @@ void libjit_batchedreduceadd_f(float *dest, const float *batch, size_t destSize,
   }
 }
 
-void libjit_copy_f(float *dest, const float *src, size_t bytes) {
-  uint8_t *buf_d = (uint8_t *)dest;
-  const uint8_t *buf_s = (const uint8_t *)src;
-  for (int i = 0; i < bytes; i++) {
-    buf_d[i] = buf_s[i];
-  }
+void libjit_copy(void *dest, const void *src, size_t bytes) {
+  memcpy(dest, src, bytes);
 }
 
 void libjit_element_cmp_lte_f(float *dest, const float *LHS, const float *RHS,

--- a/tests/unittests/JITTest.cpp
+++ b/tests/unittests/JITTest.cpp
@@ -336,6 +336,25 @@ TEST(JITCorrectnessTest, reshapeTest) {
   EXPECT_TRUE(H1.isEqual(H2));
 }
 
+TEST(JITCorrectnessTest, reshapeIndexTest) {
+  Tensor inputs(ElemKind::IndexTy, {12, 6, 8, 12});
+  auto H = inputs.getHandle<size_t>();
+  for (size_t i = 0; i < H.size(); i++) {
+    H.raw(i) = i;
+  }
+  std::array<size_t, 4> S{{18, 4, 24, 4}};
+  llvm::ArrayRef<size_t> shape(S);
+  Tensor out1;
+  Tensor out2;
+
+  inferReshapeNet(&inputs, shape, &out1, BackendKind::JIT);
+  inferReshapeNet(&inputs, shape, &out2, BackendKind::Interpreter);
+  auto H1 = out1.getHandle<size_t>();
+  auto H2 = out2.getHandle<size_t>();
+
+  EXPECT_TRUE(H1.isEqual(H2));
+}
+
 TEST(JITCorrectnessTest, selectTest) {
   std::array<size_t, 4> S{{5, 3, 9, 2}};
   llvm::ArrayRef<size_t> shape(S);


### PR DESCRIPTION
fr2en does topk.indices -> reshape, which requires copy_u.  