### PR TITLE
[JIT] Make specializer more conservative

### DIFF
--- a/lib/Backends/CPU/FunctionSpecializer.cpp
+++ b/lib/Backends/CPU/FunctionSpecializer.cpp
@@ -47,9 +47,9 @@ llvm::Value *getConstantValue(llvm::Value *v) {
   }
   if (isa<llvm::Constant>(v))
     return v;
-  if (isa<llvm::IntToPtrInst>(v))
-    return nullptr;
-  return v;
+  // This is an unknown pattern. Be conservative and assume it is not a
+  // constant.
+  return nullptr;
 }
 
 /// Specialize functions for constant arguments. Such specialized functions are


### PR DESCRIPTION
Fixes a bug uncovered by recent libjit_copy related commits. The new pattern used a bitcast instruction, which was not caught as a non-constant. As a result, a non-constant argument was used to produce a specialization. This in turn resulted in creating specialized functions referring to non-constant llvm::Values defined in a different function.