### PR TITLE
[quantization] Allow backend to decide whether quantization is needed for a node.

### DIFF
--- a/include/glow/Backends/Backend.h
+++ b/include/glow/Backends/Backend.h
@@ -1,6 +1,8 @@
 #ifndef GLOW_BACKENDS_BACKEND_H
 #define GLOW_BACKENDS_BACKEND_H
 
+#include "glow/Base/Traits.h"
+
 #include <llvm/ADT/StringRef.h>
 
 namespace glow {
@@ -11,7 +13,6 @@ class Value;
 class Tensor;
 class Variable;
 class Function;
-class Node;
 
 enum class BackendKind {
   Interpreter, // Execute the network with the built-in interpreter.
@@ -50,8 +51,9 @@ public:
   virtual bool transformPostLowering(Function *F) { return false; }
   /// @}
 
-  // \returns true if the given node \p node can be quantized by the backend.
-  virtual bool canQuantize(const Node* node) const { return false; };
+  /// \returns true if backend supports given kind of operation with
+  /// the given \p elementTy element type.
+  virtual bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const = 0;
 };
 
 /// Create a backend of kind \p kind, to run the IR function \p M.

--- a/include/glow/ExecutionEngine/ExecutionEngine.h
+++ b/include/glow/ExecutionEngine/ExecutionEngine.h
@@ -3,6 +3,7 @@
 
 #include "glow/Backends/Backend.h"
 #include "glow/Base/Train.h"
+#include "glow/Base/Traits.h"
 #include "glow/Optimizer/Optimizer.h"
 
 #include "llvm/ADT/ArrayRef.h"
@@ -57,8 +58,10 @@ public:
   /// \returns the internal graph.
   Module &getModule() { return *M_; }
 
-  /// \returns the internal backend.
-  const Backend &getBackend() const { return *IP_; }
+  /// \returns whether operation is supported by the underlying backend.
+  bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const {
+    return IP_->isOpSupported(opKind, elementTy);
+  }
 
   /// Optimize the graph, generate IR, optimize IR and compile it for a
   /// specific target. This method should be invoked before the run method.

--- a/include/glow/Quantization/Quantization.h
+++ b/include/glow/Quantization/Quantization.h
@@ -4,13 +4,14 @@
 #define GLOW_QUANTIZATION_QUANTIZATION_H
 
 #include "glow/Graph/Graph.h"
-#include "glow/Backends/Backend.h"
 
 #include <string>
 #include <tuple>
 #include <vector>
 
 namespace glow {
+
+class ExecutionEngine;
 
 /// Main attributes of a quantized tensor.
 /// Scale and Offset allow quantization of a float tensor and dequantization of
@@ -96,9 +97,11 @@ template <class SrcTy, class DestTy> DestTy clip(SrcTy in) {
 }
 
 /// Converts floating point graph to a quantized one.
-/// Note, if not all operators have a conversion support graph ends up being hybrid.
+/// Note, if not all operators have a conversion support graph ends up being
+/// hybrid.
 void generateQuantizedGraph(
-    const Backend& backend, Function *F, llvm::ArrayRef<NodeQuantizationInfo> quantizationInfos);
+    const ExecutionEngine &EE, Function *F,
+    llvm::ArrayRef<NodeQuantizationInfo> quantizationInfos);
 
 } // namespace quantization
 

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -283,3 +283,19 @@ void CPUBackend::save(llvm::StringRef outputDir) {
   // Produce the bundle.
   produceBundle(outputDir);
 }
+
+bool CPUBackend::isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const {
+  // Check for quantization support.
+  if (elementTy == ElemKind::Int8QTy) {
+    switch (opKind) {
+    case Kinded::Kind::ConvolutionNodeKind:
+    case Kinded::Kind::QuantizeNodeKind:
+    case Kinded::Kind::DequantizeNodeKind:
+      return true;
+    default:
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/lib/Backends/CPU/CPUBackend.h
+++ b/lib/Backends/CPU/CPUBackend.h
@@ -69,6 +69,8 @@ public:
   void doForwardPass(bool isTrain) override;
 
   bool transformPostLowering(Function *F) override;
+
+  bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override;
   /// @}
 };
 

--- a/lib/Backends/CPU/Pipeline.cpp
+++ b/lib/Backends/CPU/Pipeline.cpp
@@ -101,10 +101,11 @@ void LLVMIRGen::optimizeLLVMModule(llvm::Function *F, llvm::TargetMachine &TM) {
       FF.addFnAttr(llvm::Attribute::AttrKind::NoInline);
     }
   }
-  
+
   // The "main" function is parameterized by the base addresses of memory areas
-  // and it is always invoked from either the "jitmain" function or the AOT entry
-  // point. To enable better LLVM optimizations "main" should always be inlined.
+  // and it is always invoked from either the "jitmain" function or the AOT
+  // entry point. To enable better LLVM optimizations "main" should always be
+  // inlined.
   M->getFunction("main")->addFnAttr(llvm::Attribute::AttrKind::AlwaysInline);
 
   llvm::legacy::FunctionPassManager FPM(M);

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -91,12 +91,33 @@ void Interpreter::deleteTensor(const Value *v) {
   tensors_.erase(it);
 }
 
-bool Interpreter::canQuantize(const Node *node) const {
-  return llvm::isa<FullyConnectedNode>(node) ||
-         llvm::isa<ConvolutionNode>(node) || llvm::isa<ReluNode>(node) ||
-         llvm::isa<TransposeNode>(node) || llvm::isa<ReshapeNode>(node) ||
-         node->isArithmetic() || llvm::isa<ConcatNode>(node) ||
-         llvm::isa<PoolMaxNode>(node) || llvm::isa<PoolAvgNode>(node);
+bool Interpreter::isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const {
+  // Check quantization support.
+  if (elementTy == ElemKind::Int8QTy) {
+    switch (opKind) {
+    case Kinded::Kind::FullyConnectedNodeKind:
+    case Kinded::Kind::ConvolutionNodeKind:
+    case Kinded::Kind::ReluNodeKind:
+    case Kinded::Kind::TransposeNodeKind:
+    case Kinded::Kind::ReshapeNodeKind:
+    case Kinded::Kind::ConcatNodeKind:
+    case Kinded::Kind::PoolMaxNodeKind:
+    case Kinded::Kind::PoolAvgNodeKind:
+    case Kinded::Kind::AddNodeKind:
+    case Kinded::Kind::MaxNodeKind:
+    case Kinded::Kind::MinNodeKind:
+    case Kinded::Kind::MulNodeKind:
+    case Kinded::Kind::SubNodeKind:
+    case Kinded::Kind::QuantizeNodeKind:
+    case Kinded::Kind::DequantizeNodeKind:
+    case Kinded::Kind::RescaleQuantizedNodeKind:
+      return true;
+    default:
+      return false;
+    }
+  }
+
+  return true;
 }
 
 void Interpreter::doForwardPass(bool isTrain) {

--- a/lib/Backends/Interpreter/Interpreter.h
+++ b/lib/Backends/Interpreter/Interpreter.h
@@ -48,7 +48,7 @@ public:
 
   void doForwardPass(bool isTrain) override;
 
-  bool canQuantize(const Node *node) const override;
+  bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override;
   /// @}
 
 private:

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -56,6 +56,14 @@ public:
   void init() override;
 
   void doForwardPass(bool isTrain) override;
+
+  bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override {
+    if (elementTy == ElemKind::Int8QTy) {
+      return false;
+    }
+
+    return true;
+  };
   /// @}
 
 private:

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -2,6 +2,8 @@
 
 #include "glow/Quantization/Quantization.h"
 
+#include "glow/ExecutionEngine/ExecutionEngine.h"
+
 #include <cmath>
 #include <unordered_set>
 #include <vector>
@@ -250,7 +252,8 @@ quantizeInputs(Function *F, Node *node,
 }
 
 void generateQuantizedGraph(
-    const Backend &backend, Function *F, llvm::ArrayRef<NodeQuantizationInfo> quantizationInfos) {
+    const ExecutionEngine &EE, Function *F,
+    llvm::ArrayRef<NodeQuantizationInfo> quantizationInfos) {
   // Build a mapping between node name and TensorQuantizatonParams.
   std::unordered_map<std::string, TensorQuantizationParams> nodeToTQP;
   for (const auto &quantizationInfo : quantizationInfos) {
@@ -263,7 +266,7 @@ void generateQuantizedGraph(
   for (auto nodeIt = F->getNodes().rbegin(), e = F->getNodes().rend();
        nodeIt != e; ++nodeIt) {
     Node *node = *nodeIt;
-    if (!backend.canQuantize(node)) {
+    if (!EE.isOpSupported(node->getKind(), ElemKind::Int8QTy)) {
       continue;
     }
 

--- a/tools/loader/loader.cpp
+++ b/tools/loader/loader.cpp
@@ -267,7 +267,7 @@ int main(int argc, char **argv) {
     auto quantizationInfos = deserializeFromYaml(loadProfileFileOpt);
 
     // Quantize the graph based on the captured profile.
-    quantization::generateQuantizedGraph(EE.getBackend(), F, quantizationInfos);
+    quantization::generateQuantizedGraph(EE, F, quantizationInfos);
   }
 
   if (!emitBundle.empty()) {


### PR DESCRIPTION
This helps to test JIT and other backends in isolation from Interpreter in a sense that not all operations need to be implemented right away for a given backend.

For example, we could test Resnet50 on JIT with the only int_conv implemented. Also, this greatly helps with running e2e quantization test for JIT and other backends.