### PR TITLE
[InstrBuilder/InstrGen] Generate autoIRGen on destruction; move addGradientInstr back to void

### DIFF
--- a/tools/ClassGen/InstrBuilder.cpp
+++ b/tools/ClassGen/InstrBuilder.cpp
@@ -239,9 +239,9 @@ InstrBuilder::~InstrBuilder() {
   emitAutoIRGen(irGenStream);
 }
 
-InstrBuilder &
-InstrBuilder::addGradientInstr(llvm::ArrayRef<llvm::StringRef> originalFields,
-                               llvm::ArrayRef<llvm::StringRef> gradFields) {
+void InstrBuilder::addGradientInstr(
+    llvm::ArrayRef<llvm::StringRef> originalFields,
+    llvm::ArrayRef<llvm::StringRef> gradFields) {
   InstrBuilder GI(headerStream, cppStream, defStream, builderHeaderStream,
                   builderCppStream, irGenStream, name_ + "Grad",
                   isBackendSpecific_);
@@ -269,7 +269,6 @@ InstrBuilder::addGradientInstr(llvm::ArrayRef<llvm::StringRef> originalFields,
       }
     }
   }
-  return *this;
 }
 
 void InstrBuilder::emitAutoIRGen(std::ostream &os) const {

--- a/tools/ClassGen/InstrBuilder.h
+++ b/tools/ClassGen/InstrBuilder.h
@@ -139,8 +139,8 @@ public:
 
   /// Constructs a new gradient instruction that is based on the current
   /// instruction that we are building.
-  InstrBuilder &addGradientInstr(llvm::ArrayRef<llvm::StringRef> originalFields,
-                                 llvm::ArrayRef<llvm::StringRef> gradFields);
+  void addGradientInstr(llvm::ArrayRef<llvm::StringRef> originalFields,
+                        llvm::ArrayRef<llvm::StringRef> gradFields);
 
   /// Turns on automatic IRGen generation for this instruction given the Node \p
   /// name (if empty, defaults to same name as Instr).

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -69,8 +69,8 @@ int main(int argc, char **argv) {
       .addMember(MemberType::SizeT, "Stride")
       .addMember(MemberType::SizeT, "Pad")
       .addMember(MemberType::SizeT, "Depth")
-      .addGradientInstr({"Src", "Filter"}, {"Dest", "Src", "Filter", "Bias"})
-      .autoIRGen();
+      .autoIRGen()
+      .addGradientInstr({"Src", "Filter"}, {"Dest", "Src", "Filter", "Bias"});
 
   // PoolMax version caching XY coordinates to speedup gradient-based
   // computations.
@@ -96,8 +96,8 @@ int main(int argc, char **argv) {
       .addMember(MemberType::SizeT, "Kernel")
       .addMember(MemberType::SizeT, "Stride")
       .addMember(MemberType::SizeT, "Pad")
-      .addGradientInstr({"Dest"}, {"Dest", "Src"})
-      .autoIRGen();
+      .autoIRGen()
+      .addGradientInstr({"Dest"}, {"Dest", "Src"});
 
   //===--------------------------------------------------------------------===//
   //                     Normalization
@@ -117,9 +117,9 @@ int main(int argc, char **argv) {
           "Dest",
           "Src",
       })
+      .autoIRGen()
       .addGradientInstr({"Src", "Scale", "Mean", "Var"},
-                        {"Dest", "Src", "Scale", "Bias"})
-      .autoIRGen();
+                        {"Dest", "Src", "Scale", "Bias"});
 
   BB.newInstr("LocalResponseNormalization")
       .addOperand("Dest", OperandKind::Out)


### PR DESCRIPTION
Should prevent any bugs due to ordering of InstrGen method calls.