### PR TITLE
[jit] Fail hard if instruction cannot be executed.

### DIFF
--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -986,6 +986,6 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     I->dump(llvm::errs());
     llvm::errs() << "\n";
 #endif
-    llvm_unreachable("ERROR: Cannot select the instruction.");
+    GLOW_UNREACHABLE("ERROR: Cannot select the instruction.");
   }
 }


### PR DESCRIPTION
It's very misleading when there is a node which is not supported but there are no signals about this at all.