### PR TITLE
Create `Dims` typedef for llvm::SmallVector

### DIFF
--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -21,6 +21,8 @@ using TypeRef = const Type *;
 
 constexpr unsigned max_tensor_dimensions = 6;
 
+using ShapeVector = llvm::SmallVector<size_t, max_tensor_dimensions>;
+
 struct ShapeNHWC {
   size_t n; // Number of samples
   size_t h; // Height

--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -487,7 +487,7 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     auto *nDims = emitConstSizeT(builder, dest->dims().size());
 
     // Pad src dims with 1s to match axis and dest dims.
-    llvm::SmallVector<size_t, 6> newDims(src->dims().begin(), src->dims().end());
+    ShapeVector newDims(src->dims().begin(), src->dims().end());
     newDims.insert(newDims.begin(), BI->getAxis(), 1);
     newDims.insert(newDims.end(), dest->dims().size() - src->dims().size() - BI->getAxis(), 1);
     auto *srcDims = emitConstArray(builder, newDims);
@@ -862,7 +862,7 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     auto *srcDims = emitValueDims(builder, src);
 
     // Convert the mask to size_t type.
-    llvm::SmallVector<size_t, 6> shuffSizeT;
+    ShapeVector shuffSizeT;
     for (auto D : TI->getShuffle()) {
       shuffSizeT.push_back((size_t)D);
     }

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -512,7 +512,7 @@ ReshapeNode *Function::createReshape(llvm::StringRef name, NodeValue input,
 
 TransposeNode *Function::createTranspose(llvm::StringRef name, NodeValue input,
                                          llvm::ArrayRef<unsigned> shuffle) {
-  llvm::SmallVector<size_t, 6> shape;
+  ShapeVector shape;
   auto dims = input.dims();
   for (size_t i = 0; i < dims.size(); i++) {
     shape.push_back(dims[shuffle[i]]);
@@ -568,7 +568,7 @@ ConcatNode *Function::createConcat(llvm::StringRef name,
   }
   auto inDim = inputs[0]->dims();
 
-  llvm::SmallVector<size_t, 6> shape(inDim.begin(), inDim.end());
+  ShapeVector shape(inDim.begin(), inDim.end());
 
   // We are stacking the tensors along a specific dimension. This means that we
   // increase the size of the tensor along this dimension.
@@ -779,7 +779,7 @@ TopKNode *Function::createTopK(llvm::StringRef name, NodeValue input,
   auto inDims = input.dims();
   assert(inDims.size() > 0);
   assert(k <= inDims.back());
-  llvm::SmallVector<size_t, 6> outDims(inDims.begin(), inDims.end());
+  ShapeVector outDims(inDims.begin(), inDims.end());
   outDims.back() = k;
   return addNode(new TopKNode(
       name, getParent()->uniqueType(input->getElementType(), outDims),
@@ -791,7 +791,7 @@ GatherNode *Function::createGather(llvm::StringRef name, NodeValue data,
   auto dDims = data.dims();
   auto iDims = indices.dims();
   assert(dDims.size() > 0);
-  llvm::SmallVector<size_t, 6> outDims(iDims.begin(), iDims.end());
+  ShapeVector outDims(iDims.begin(), iDims.end());
   outDims.insert(outDims.end(), dDims.begin() + 1, dDims.end());
   return addNode(new GatherNode(
       name, getParent()->uniqueTypeWithNewShape(data->getType(), outDims), data,

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -682,7 +682,7 @@ void TransposeNode::verify() const {
   auto dest = getResult();
   auto src = getInput();
   (void)dest;
-  llvm::SmallVector<size_t, 6> shape;
+  ShapeVector shape;
 
   auto dims = src.dims();
   for (size_t i = 0; i < dims.size(); i++) {

--- a/lib/IR/IRBuilder.cpp
+++ b/lib/IR/IRBuilder.cpp
@@ -110,7 +110,7 @@ TopKInst *IRBuilder::createTopKOp(Value *input, size_t k) {
   auto inDims = input->dims();
   assert(inDims.size() > 0);
   assert(k <= inDims.back());
-  llvm::SmallVector<size_t, 6> outDims(inDims.begin(), inDims.end());
+  ShapeVector outDims(inDims.begin(), inDims.end());
   outDims.back() = k;
   // Allocate enough scratch space to hold N values and N indices.
   auto *scratch = createAllocActivationInst("topk.scratch", ElemKind::IndexTy,

--- a/lib/IR/Instrs.cpp
+++ b/lib/IR/Instrs.cpp
@@ -246,7 +246,7 @@ void TransposeInst::verify() const {
   auto *dest = getDest();
   auto *src = getSrc();
   (void)dest;
-  llvm::SmallVector<size_t, 6> shape;
+  ShapeVector shape;
 
   auto dims = src->dims();
   for (size_t i = 0; i < dims.size(); i++) {


### PR DESCRIPTION
Seems nicer than using `llvm::SmallVector<size_t, 6>` wherever we want to build new dims.  One hesitation is that I still want these to be passed around as `llvm::ArrayRef` and maybe it's confusing to have the short descriptive typedef be the right thing to use in one place but not the other?  Ideas welcome.