### PR TITLE
[quantization] Remove non supported operators. Fix recently appeared bug.

### DIFF
--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -489,7 +489,8 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     // Pad src dims with 1s to match axis and dest dims.
     ShapeVector newDims(src->dims().begin(), src->dims().end());
     newDims.insert(newDims.begin(), BI->getAxis(), 1);
-    newDims.insert(newDims.end(), dest->dims().size() - src->dims().size() - BI->getAxis(), 1);
+    newDims.insert(newDims.end(),
+                   dest->dims().size() - src->dims().size() - BI->getAxis(), 1);
     auto *srcDims = emitConstArray(builder, newDims);
 
     auto *F = getFunction("broadcast", dest->getElementType());

--- a/lib/Optimizer/Lower.cpp
+++ b/lib/Optimizer/Lower.cpp
@@ -439,9 +439,9 @@ void lowerBatchNormalizationGradNode(Function *F,
       F->createBroadcast("sumDy_broadcasted", sumDy, inW.dims(), channelIdx);
   auto NSplat = F->createSplat("oneSplat", inW.getType(), samplesPerChannel);
   Node *inBrackets = F->createMul("NSplat_outG", NSplat, outG);
-  inBrackets = F->createSub(
-      "inBrackets", F->createSub("inBrackets_2ops", inBrackets, sumDyB),
-      F->createMul("hmu_coef2", hmu, coef2));
+  inBrackets = F->createSub("inBrackets",
+                            F->createSub("inBrackets_2ops", inBrackets, sumDyB),
+                            F->createMul("hmu_coef2", hmu, coef2));
 
   auto inG = F->createMul("inG", coef1, inBrackets);
   BNG.getGradOfInputNamedInput().replaceAllUsesOfWith(inG);


### PR DESCRIPTION
Make sure nodes are not processed multiple times.

* Loop re-structure is pretty much the only change, other things are format related.
* Remove CASE_QUANTIZE_NODE(CmpLTE); and DIV.

Runs fine now.
```
rdzhabarov-mbp:release_build rdzhabarov$ ./bin/loader tests/images/imagenet/*.png -image_mode=0to1 -d=resnet50 -load_profile=profile
Model: resnet50/predict_net.pb
 File: tests/images/imagenet/cat_285.png Result:285
 File: tests/images/imagenet/dog_207.png Result:207
 File: tests/images/imagenet/zebra_340.png Result:340
```

Some background:
When iterating from rbegin() -> rend() and push_back (as this happens during the addNode call) last element is processed twice. It did not manifest before because we did not allow Quantization, Rescale, Dequantize to be processed by the procedure.