### PR TITLE
[NodeBuilder] Change the naming of the alloc-activation instr.

### DIFF
--- a/tools/ClassGen/InstrBuilder.cpp
+++ b/tools/ClassGen/InstrBuilder.cpp
@@ -299,10 +299,9 @@ void InstrBuilder::emitAutoIRGen(std::ostream &os) const {
 
   assert(!resNodeName.empty() && !destOpName.empty() &&
          "Didn't find a result; Maybe using InOut which isn't yet supported");
-
-  os << "  auto *dest__ = builder_.createAllocActivationInst(\""
-     << autoIRGenNodeName << ".res\", CN__->get" << resNodeName
-     << "()->getType());\n";
+  os << "  std::string allocName = std::string(N->getName()) + \".res\";\n";
+  os << "  auto *dest__ = builder_.createAllocActivationInst(allocName,"
+     << "CN__->get" << resNodeName << "()->getType());\n";
   os << "  auto *V = builder_.create" << name_ << "Inst(\"" << autoIRGenNodeName
      << "\", dest__";
   for (const auto &opPair : operands_) {


### PR DESCRIPTION
[NodeBuilder] Change the naming of the alloc-activation instruction to depend on the input instruction.

I verified manually that the name of the high-level node propagates.

@jfix71 