### PR TITLE
[coverage] Upload coverage report for master travis runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ matrix:
   fast_finish: true
   include:
     - os: linux
+      env:
+        - TEST_NAME=ASAN
       addons:
         apt:
           sources:
@@ -16,17 +18,32 @@ matrix:
             - g++-6
       before_install:
         - sudo apt-get -qq update
-        - sudo apt-get install -y ninja-build llvm ocl-icd-opencl-dev libprotobuf-dev protobuf-compiler libpng-dev
+        - sudo apt-get install -y ninja-build llvm libprotobuf-dev protobuf-compiler libpng-dev
       install:
         - mkdir build && cd build
         - cmake -G Ninja -DGLOW_USE_SANITIZER="Address;Undefined" -DCMAKE_BUILD_TYPE=Debug -DGLOW_WITH_OPENCL=OFF -DGLOW_WITH_CPU=ON ../
     - os: linux
+      env:
+        - TEST_NAME=RELEASE
       before_install:
         - sudo apt-get -qq update
-        - sudo apt-get install -y ninja-build llvm ocl-icd-opencl-dev libprotobuf-dev protobuf-compiler libpng-dev
+        - sudo apt-get install -y ninja-build llvm libprotobuf-dev protobuf-compiler libpng-dev
       install:
         - mkdir build && cd build
         - cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DGLOW_WITH_OPENCL=OFF -DGLOW_WITH_CPU=ON ../
+    - os: linux
+      compiler: g++
+      env:
+        - TEST_NAME=COVERAGE
+      before_install:
+        - sudo apt-get -qq update
+        - sudo apt-get install -y ninja-build llvm lcov libprotobuf-dev protobuf-compiler libpng-dev
+        - sudo pip install awscli --upgrade
+      install:
+        - mkdir build && cd build
+        - cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DGLOW_WITH_OPENCL=OFF -DGLOW_USE_COVERAGE=ON ../
+      script:
+        - ../.travis/run_coverage.sh 
 
 script:
  - ninja all

--- a/.travis/run_coverage.sh
+++ b/.travis/run_coverage.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+ninja all
+ninja glow_coverage
+
+COVERAGE_FILE="./glow_coverage/index.html"
+if [ ! -f "${COVERAGE_FILE}" ]; then
+  echo "ERROR: ${COVERAGE_FILE} not found."
+  exit 1
+fi
+
+# Travis does not allow using secrets (e.g., AWS credentials) on pull requests
+# from a fork. Upload coverage only if secure vars are set.
+if [ "${TRAVIS_SECURE_ENV_VARS}" != "false" ]; then
+  echo "INFO: Uploading coverage to S3."
+  
+  BRANCH_NAME="${TRAVIS_BRANCH}"
+  COVERAGE_DIR="$(dirname "${COVERAGE_FILE}")"
+  UPLOAD_LOCATION="fb-glow-assets/coverage/coverage-${BRANCH_NAME}"
+
+  aws s3 cp "${COVERAGE_DIR}" "s3://${UPLOAD_LOCATION}" --recursive --acl public-read --sse
+  echo "INFO: Coverage report for branch '${BRANCH_NAME}': https://fb-glow-assets.s3.amazonaws.com/coverage/coverage-${BRANCH_NAME}/index.html"
+else
+  echo "WARNING: Coverage cannot be uploaded to s3 for PR from a fork." 
+fi

--- a/cmake/modules/CoverageSupport.cmake
+++ b/cmake/modules/CoverageSupport.cmake
@@ -34,7 +34,7 @@ if(GLOW_USE_COVERAGE)
     COMMAND ctest -j 4
 
     # Capture lcov counters based on the test run.
-    COMMAND ${LCOV_PATH} --directory . --capture --output-file glow_coverage.info
+    COMMAND ${LCOV_PATH} --no-checksum --directory . --capture --output-file glow_coverage.info
     
     # Ignore not related files.
     COMMAND ${LCOV_PATH} --remove glow_coverage.info '*v1*' '/usr/*' '*tests/*' '*llvm_install*' --output-file ${PROJECT_BINARY_DIR}/glow_coverage_result.info


### PR DESCRIPTION
Travis secure vars only work on master repo, not when PR is sent from a fork. Let coverage run only for master builds.

> Also, will look into cleanup policy etc for the coverage/ S3 folder.

No need to clean up now, as it's only for `master` runs.