### PR TITLE
[JIT] Ignore memory allocation instructions when building bundles of data parallel instructions

### DIFF
--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -532,6 +532,11 @@ void LLVMIRGen::generateLLVMIRForModule(llvm::IRBuilder<> &builder) {
   llvm::SmallVector<Instruction *, 32> bundle;
   for (auto I : instrs) {
     if (!I->isDataParallel()) {
+      // Ignore memory management instructions as they are handled by the
+      // MemoryManager and are NOPs for a JIT.
+      if (isa<AllocActivationInst>(I) || isa<DeallocActivationInst>(I) ||
+          isa<TensorViewInst>(I))
+        continue;
       emitDataParallelKernel(builder, bundle);
       bundle.clear();
       generateLLVMIRForInstr(builder, I);


### PR DESCRIPTION
Ignore memory management instructions as they are handled by the MemoryManager and are NOPs for a JIT. I forgot to copy this code into the final version when I got rid of the InstructionBundler.

Ignoring these instructions allows us to find longer sequences of data parallel instructions.