### PR TITLE
[Quantization] Fix the shift scale calculation in quantize32To8

### DIFF
--- a/lib/Backends/CPU/libjit.cpp
+++ b/lib/Backends/CPU/libjit.cpp
@@ -490,7 +490,7 @@ static int32_t libjit_scale_i32i8(int32_t input, int32_t pre, int32_t post,
                                   int32_t scale, int32_t offset) {
   // The operation x >> y is rounded down to negative infinity. To get to
   // round-nearest we add (1 << (shift - 1)) to the value prior to shifting.
-  int rtn = (1 << (post - 1));
+  int rtn = (post > 0) ? (1 << (post - 1)) : 0;
 
   // NOTICE: If your tests are failing because of signed integer overflow then
   // this is a bug in the test and not in the program. You should make sure that

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -169,9 +169,9 @@ QuantizationTransform32To8 quantizeScaleOffset32To8(float scale,
   int postShift = 0;
 
   // Calculate the post-shift value. It's always safe to increase scale as long
-  // as it's below one, and it's always legal to shift at least 16 bits,
-  // because this won't overflow the calculation.
-  while (scale < 0.5 || postShift < 15) {
+  // as it's below one, and it's always legal to shift at least 15 bits for
+  // small scale values.
+  while (scale < 0.5 || (scale < 256 && postShift < 15)) {
     scale *= 2;
     postShift++;
   }


### PR DESCRIPTION
[Quantization] Fix the shift scale calculation in
quantizeScaleOffset32To8. This addresses a problem that James found
where we were not taking into account the number offset.

With this change the quantized Resnet50 works in the CPU backend
(without floating point ops inside the convolution.)