### PR TITLE
[JIT] Quantized MatMul instruction for JIT

### DIFF
--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -289,6 +289,7 @@ bool CPUBackend::isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const {
   if (elementTy == ElemKind::Int8QTy) {
     switch (opKind) {
     case Kinded::Kind::ConvolutionNodeKind:
+    case Kinded::Kind::MatMulNodeKind:
     case Kinded::Kind::QuantizeNodeKind:
     case Kinded::Kind::DequantizeNodeKind:
     case Kinded::Kind::RescaleQuantizedNodeKind:

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -31,6 +31,8 @@ void trainLocalResponseNormalizationNet(Tensor *inputs, Tensor *weights,
                                         llvm::ArrayRef<size_t> shape2,
                                         Tensor *out, BackendKind kind);
 
+void inferMatMulNet(Tensor *lhs, Tensor *rhs, Tensor *out, BackendKind kind);
+
 void inferMaxNet(Tensor *inputs1, Tensor *inputs2, Tensor *out,
                  BackendKind kind);
 

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -396,7 +396,7 @@ TEST_P(Operator, QuantizeAndDequantize) {
   EXPECT_TRUE(expectedHandle.isEqual(resultHandle));
 }
 
-TEST_P(InterpOnly, IntMatMul) {
+TEST_P(Operator, IntMatMul) {
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
 


### PR DESCRIPTION
This commit implements matrix multiplication of quantized tensors in the CPU JIT backend.