### PR TITLE
[jit/quantization] Add quantized transpose support.

### DIFF
--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -291,6 +291,7 @@ bool CPUBackend::isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const {
     case Kinded::Kind::ConvolutionNodeKind:
     case Kinded::Kind::QuantizeNodeKind:
     case Kinded::Kind::DequantizeNodeKind:
+    case Kinded::Kind::TransposeNodeKind:
       return true;
     default:
       return false;

--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -357,7 +357,7 @@ llvm::Value *LLVMIRGen::emitStringConst(llvm::IRBuilder<> &builder,
 
 llvm::Function *LLVMIRGen::getFunction(const std::string &name) {
   auto *F = llmodule_->getFunction("libjit_" + name);
-  assert(F && "Unable to load the function");
+  GLOW_ASSERT(F && "Unable to load the function");
   return F;
 }
 
@@ -365,7 +365,7 @@ llvm::Function *LLVMIRGen::getFunction(const std::string &name,
                                        ElemKind elemTy) {
   auto get = [this](llvm::StringRef funcName) {
     auto *F = llmodule_->getFunction(funcName);
-    assert(F && "Unable to load the function");
+    GLOW_ASSERT(F && "Unable to load the function");
     return F;
   };
   switch (elemTy) {

--- a/lib/IR/Instrs.cpp
+++ b/lib/IR/Instrs.cpp
@@ -37,8 +37,8 @@ void WeightVar::dump(llvm::raw_ostream &os) const {
 void CopyInst::verify() const {
   auto *dest = getDest();
   auto *src = getSrc();
-  (void) dest;
-  (void) src;
+  (void)dest;
+  (void)src;
   assert(dest->getType() == src->getType() && "Invalid type.");
   // The operands of the copy instruction must be variables.
   assert(isa<AllocActivationInst>(dest) || isa<WeightVar>(dest) ||

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -547,13 +547,9 @@ void checkIntConvolution(ExecutionEngine &EE, unsigned convDepth) {
   }
 }
 
-TEST_P(Operator, IntConvolutionDepth10) {
-  checkIntConvolution(EE, 10);
-}
+TEST_P(Operator, IntConvolutionDepth10) { checkIntConvolution(EE, 10); }
 
-TEST_P(Operator, IntConvolutionDepth8) {
-  checkIntConvolution(EE, 8);
-}
+TEST_P(Operator, IntConvolutionDepth8) { checkIntConvolution(EE, 8); }
 
 TEST(OperatorInterpOnly, IntConcat) {
   ExecutionEngine EE;


### PR DESCRIPTION
NOTE, there is a test covering transpose: e2e quantization test.

Resnet50 looks good.
```
rdzhabarov-mbp:release_build rdzhabarov$ ./bin/loader tests/images/imagenet/*.png -image_mode=0to1 -d=resnet50 -jit -load_profile=profile
Model: resnet50/predict_net.pb
 File: tests/images/imagenet/cat_285.png Result:285
 File: tests/images/imagenet/dog_207.png Result:207
 File: tests/images/imagenet/zebra_340.png Result:340
```

* clang format fixes
* fail hard when a function cannot be found