### PR TITLE
[jit/quantization] Add reshape as a supported quantized node.

### DIFF
--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -292,6 +292,7 @@ bool CPUBackend::isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const {
     case Kinded::Kind::QuantizeNodeKind:
     case Kinded::Kind::DequantizeNodeKind:
     case Kinded::Kind::TransposeNodeKind:
+    case Kinded::Kind::ReshapeNodeKind:
       return true;
     default:
       return false;


### PR DESCRIPTION
thanks to IR optimizer this inst gets away and converted to seq of already supported JIT operations.

NOTE, this op is covered by quantization e2e test.
```
rdzhabarov-mbp:release_build rdzhabarov$ ./bin/loader tests/images/imagenet/*.png -image_mode=0to1 -d=resnet50 -jit -load_profile=profile
Model: resnet50/predict_net.pb
 File: tests/images/imagenet/cat_285.png Result:285
 File: tests/images/imagenet/dog_207.png Result:207
 File: tests/images/imagenet/zebra_340.png Result:340
```
