### PR TITLE
[Refactor | NFC] Move Broadcast and Transpose from Handle to Tensor

### DIFF
--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -602,26 +602,26 @@ void Interpreter::fwdCrossEntropyLossGradInst(
 //                       Tensor shape (transpose/reshape/concat/...)
 //===----------------------------------------------------------------------===//
 void Interpreter::fwdTransposeInst(const TransposeInst *I) {
-  auto inTensor = getTensor(I->getSrc());
-  (void)inTensor;
-  auto outW = getTensor(I->getDest());
+  auto inT = getTensor(I->getSrc());
+  (void)inT;
+  auto outT = getTensor(I->getDest());
 
-  assert(outW->size() == inTensor->size() && "Invalid tensor dimensions");
+  assert(outT->size() == inT->size() && "Invalid tensor dimensions");
 
   if (I->getSrc()->getType()->isQuantizedType()) {
-    getWeightHandle<int8_t>(I->getSrc()).transpose(outW, I->getShuffle());
+    inT->transpose(outT, I->getShuffle());
   } else {
-    getWeightHandle<float>(I->getSrc()).transpose(outW, I->getShuffle());
+    inT->transpose(outT, I->getShuffle());
   }
 }
 
 void Interpreter::fwdBroadcastInst(const BroadcastInst *I) {
-  auto inW = getWeightHandle(I->getSrc());
-  auto outW = getTensor(I->getDest());
+  auto inT = getTensor(I->getSrc());
+  auto outT = getTensor(I->getDest());
   auto shape = I->getShape();
   auto axis = I->getAxis();
 
-  inW.broadcastToNewShape(outW, shape, axis);
+  inT->broadcastToNewShape(outT, shape, axis);
 }
 
 void Interpreter::fwdReshapeInst(const ReshapeInst *I) {

--- a/lib/Importer/Caffe2.cpp
+++ b/lib/Importer/Caffe2.cpp
@@ -179,7 +179,7 @@ void caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     // weights in the format CRSK. Caffe2 stores the operators as KCRS.
     // C - output_depth, R - filter_height, S - filter_width, K - input_depth.
     Tensor wtag;
-    w->getHandle<>().transpose(&wtag, {0, 2, 3, 1});
+    w->transpose(&wtag, {0, 2, 3, 1});
 
     // The structure of the conv weigts is: NHWC. We take the C, which is the
     // number of filters. We use this value to calculate the size of the bias
@@ -359,7 +359,7 @@ void caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
 
     // Caffe2 stores the transposed W matrix. In here we transpose W back.
     Tensor wtag;
-    w->getHandle<>().transpose(&wtag, {1, 0});
+    w->transpose(&wtag, {1, 0});
 
     auto W = G_.getParent()->addVar(new Variable(
         "weights", Variable::VisibilityKind::Private, std::move(wtag)));

--- a/tests/unittests/tensorsTest.cpp
+++ b/tests/unittests/tensorsTest.cpp
@@ -262,7 +262,7 @@ TEST(Tensor, transpose) {
   };
 
   Tensor Xhat;
-  X.getHandle<>().transpose(&Xhat, {1, 0});
+  X.transpose(&Xhat, {1, 0});
 
   auto XhatH = Xhat.getHandle<>();
 
@@ -278,7 +278,7 @@ TEST(Tensor, transpose2) {
   H.randomize(-2.0, 2.0);
 
   Tensor Xhat;
-  X.getHandle<>().transpose(&Xhat, {1, 2, 0});
+  X.transpose(&Xhat, {1, 2, 0});
 
   auto XhatH = Xhat.getHandle<>();
 
@@ -375,7 +375,7 @@ TEST(Tensor, broadcastNewShape) {
 
   Tensor broadcastedB;
   const unsigned axis = 1;
-  X_B.getHandle<>().broadcastToNewShape(&broadcastedB, dims_A, axis);
+  X_B.broadcastToNewShape(&broadcastedB, dims_A, axis);
 
   auto broadcastedBHandle = broadcastedB.getHandle<>();
 


### PR DESCRIPTION
I don't think there's any good reason to require transpose/broadcast to go through the Handle. All uses were just getting the handle to use one of these ops and then throwing it away.