### PR TITLE
Always align buffers to float size

### DIFF
--- a/lib/CodeGen/MemoryAllocator.cpp
+++ b/lib/CodeGen/MemoryAllocator.cpp
@@ -10,6 +10,8 @@ using namespace glow;
 const size_t MemoryAllocator::npos = -1;
 
 size_t MemoryAllocator::allocate(size_t size) {
+  // Always allocate buffers properly aligned to hold values of any type.
+  size = (size + alignof(float) - 1) & ~(alignof(float) - 1);
   size_t prev = 0;
   for (auto it = allocations_.begin(), e = allocations_.end(); it != e; it++) {
     if (it->begin_ - prev >= size) {

--- a/tests/unittests/memoryAllocatorTest.cpp
+++ b/tests/unittests/memoryAllocatorTest.cpp
@@ -85,9 +85,9 @@ TEST(MemAlloc, dealloc2) {
 }
 
 TEST(MemAlloc, allocateToTheMax) {
-  MemoryAllocator MA(100);
-  auto p0 = MA.allocate(50);
-  auto p1 = MA.allocate(50);
+  MemoryAllocator MA(128);
+  auto p0 = MA.allocate(64);
+  auto p1 = MA.allocate(64);
 
   EXPECT_EQ(p0, 0);
   EXPECT_NE(p1, MemoryAllocator::npos);
@@ -95,5 +95,5 @@ TEST(MemAlloc, allocateToTheMax) {
   MA.deallocate(p0);
   MA.deallocate(p1);
 
-  EXPECT_EQ(MA.getMaxMemoryUsage(), 100);
+  EXPECT_EQ(MA.getMaxMemoryUsage(), 128);
 }


### PR DESCRIPTION
I noticed this from a UBSAN failure on my quantized-concat diff.  I thought about trying to individually-align every allocation, but it doesn't seem worth the extra complexity for the very small memory savings.