### PR TITLE
[jit] Add i8 copy kernel

### DIFF
--- a/lib/Backends/CPU/libjit.cpp
+++ b/lib/Backends/CPU/libjit.cpp
@@ -370,6 +370,7 @@ DEFINE_DATA_PARALLEL_KERNEL(libjit_elementmin_kernel_f, float,
                             MIN(LHS[idx], RHS[idx]))
 DEFINE_DATA_PARALLEL_KERNEL(libjit_copy_kernel_f, float, LHS[idx])
 DEFINE_DATA_PARALLEL_KERNEL(libjit_copy_kernel_u, size_t, LHS[idx])
+DEFINE_DATA_PARALLEL_KERNEL(libjit_copy_kernel_i8, int8_t, LHS[idx])
 DEFINE_DATA_PARALLEL_KERNEL(libjit_element_cmp_lte_kernel_f, float,
                             LHS[idx] <= RHS[idx] ? 1.0 : 0.0)
 DEFINE_DATA_PARALLEL_KERNEL(libjit_element_add_kernel_f, float,

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -653,7 +653,6 @@ TEST(Operator, CrossEntropyLossTest) {
 
 TEST_P(Operator, RescaleNode) {
   // Check the outputs of the RescaleQuantized operation.
-  ExecutionEngine EE;
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
 


### PR DESCRIPTION
The shadowing of EE in rescale was causing this test to not actually exercise the jit.  We need one more simple fix here (although, I don't think this test actually does any rescale, because it's all optimized down to a copy).

I've also made this test harder to screw up in #764 .