### PR TITLE
Allow for conditional lowering of Nodes v2

### DIFF
--- a/include/glow/Backends/Backend.h
+++ b/include/glow/Backends/Backend.h
@@ -13,6 +13,7 @@ class Value;
 class Tensor;
 class Variable;
 class Function;
+class Node;
 
 enum class BackendKind {
   Interpreter, // Execute the network with the built-in interpreter.
@@ -54,6 +55,10 @@ public:
   /// \returns true if backend supports given kind of operation with
   /// the given \p elementTy element type.
   virtual bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const = 0;
+
+  /// \returns true if the supplied Node \N should be lowered. By default, all
+  /// Nodes are candidates for lowering.
+  virtual bool shouldLower(Node *N) { return true; }
 };
 
 /// Create a backend of kind \p kind, to run the IR function \p M.

--- a/include/glow/Optimizer/Optimizer.h
+++ b/include/glow/Optimizer/Optimizer.h
@@ -5,6 +5,7 @@ namespace glow {
 
 class IRFunction;
 class Function;
+class Backend;
 
 enum class CompilationMode {
   Train, /// Compile the graph in preperation for training.
@@ -19,7 +20,7 @@ void optimize(Function *F, CompilationMode mode);
 
 /// Lower the high-level neural network operators into low-level lineal algebra
 /// operators.
-void lower(Function *F, CompilationMode mode);
+void lower(Function *F, CompilationMode mode, Backend *B = nullptr);
 
 /// Instrument function \p F by inserting quantization profile nodes
 /// for capturing stats for quantization.

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -121,7 +121,7 @@ void ExecutionEngine::generateIR(CompilationMode mode, Function *F) {
   }
 
   // Lower the graph into a sequence of low-level linear algebra operations.
-  ::glow::lower(F, mode);
+  ::glow::lower(F, mode, IP_.get());
 
   // Optimized the graph again.
   ::glow::optimize(F, mode);

--- a/lib/IR/IRGen.cpp
+++ b/lib/IR/IRGen.cpp
@@ -79,8 +79,9 @@ public:
 
     switch (N->getKind()) {
     default:
-      // Unknown node kind.
-      llvm_unreachable("Unhandled node kind");
+      llvm_unreachable("Unhandled node; perhaps the node should have been "
+                       "lowered, or the backend should have specified an IRGen "
+                       "case for this node to a backend-specific Instr.");
       break;
 
       // Include all automatically generated cases:
@@ -330,21 +331,6 @@ public:
       registerIR(GN->getResult(), V->getDest());
       V->setName(N->getName());
       break;
-    }
-    case glow::Kinded::Kind::SGDNodeKind:
-    case glow::Kinded::Kind::TanhGradNodeKind:
-    case glow::Kinded::Kind::SigmoidGradNodeKind:
-    case glow::Kinded::Kind::AddGradNodeKind:
-    case glow::Kinded::Kind::MulGradNodeKind:
-    case glow::Kinded::Kind::SubGradNodeKind:
-    case glow::Kinded::Kind::DivGradNodeKind:
-    case glow::Kinded::Kind::ReluNodeKind:
-    case glow::Kinded::Kind::ReluGradNodeKind:
-    case glow::Kinded::Kind::FullyConnectedNodeKind:
-    case glow::Kinded::Kind::FullyConnectedGradNodeKind:
-    case glow::Kinded::Kind::RegressionNodeKind:
-    case glow::Kinded::Kind::RegressionGradNodeKind: {
-      llvm_unreachable("Node should have been lowered to low-level nodes");
     }
     }
   }

--- a/lib/Optimizer/CMakeLists.txt
+++ b/lib/Optimizer/CMakeLists.txt
@@ -9,4 +9,5 @@ target_link_libraries(Optimizer
                       PRIVATE
                         Quantization
                         Graph
-                        IR)
+                        IR
+                        Backends)

--- a/lib/Optimizer/Lower.cpp
+++ b/lib/Optimizer/Lower.cpp
@@ -1,5 +1,6 @@
 // Copyright 2017 Facebook Inc.  All Rights Reserved.
 
+#include "glow/Backends/Backend.h"
 #include "glow/Graph/Graph.h"
 #include "glow/Graph/Node.h"
 #include "glow/Graph/Nodes.h"
@@ -469,10 +470,13 @@ void lowerBatchNormalizationGradNode(Function *F,
   BNG.getGradOfInputNamedVar().replaceAllUsesOfWith(zeroSplat);
 }
 
-void glow::lower(Function *F, CompilationMode mode) {
+void glow::lower(Function *F, CompilationMode mode, Backend *B) {
   auto &nodes = F->getNodes();
 
   for (auto const &node : nodes) {
+    if (B && !B->shouldLower(node)) {
+      continue;
+    }
     if (auto *RN = dyn_cast<RegressionNode>(node)) {
       lowerRegressionNode(*RN);
     } else if (auto *RGN = dyn_cast<RegressionGradNode>(node)) {


### PR DESCRIPTION
I've updated this so that `lower` queries the backend via `isNodeSupported` to see if a node is supported by the backend; if not (the default) it will be lowered as usual.

Again, the second commit `TEMPORARY EXAMPLE` is just that, and will be removed from the PR before merging.

(I accidentally recreated the previous version of this PR which closed it, https://github.com/facebookexternal/Glow/pull/752)