### PR TITLE
[WIP] Precision Multiplication of float and int

### DIFF
--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -81,110 +81,62 @@ static TensorQuantizationParams chooseQuantizationParams(float min, float max) {
 
 namespace quantization {
 
-QuantizationTransform32To8 quantizeScaleOffset32To8(float scale,
-                                                    int32_t offset) {
-  // In this function we compute an efficient way to convert signed 32-bit
-  // integers into signed 8-bit integers without the use of floating-point
-  // multiplication. Instead, we represent the original calculation:
-  //
-  //    result = (x * scale + offset)
-  //
-  // as the following sequence of integer calculations:
-  //
-  //    ((x >> pre_scale  * integer_scale) >> post_scale) + offset
-  //
-  // This function converts the floating-point scale and offset values to the
-  // constants in the integer formula.
-  //
-  // In this method we assume that any signed 32-bit integer in the input word
-  // must be mapped into an 8-bit integer. If the scale factor is 2X, then the
-  // number 1000 won't be a legal input because after scaling the result would
-  // fall outside of the signed 8-bit range. Any 32-bit number that falls
-  // outside of signed the 8-bit output integer will be clipped. This gives us
-  // the ability to perform 32-bit arithmetic, as explained below.
-  //
-  // We can't accurately represent fraction scales (in the range zero to one),
-  // because the lowest integer multiplication value is one. For example, the
-  // scaling factor 0.25 must be represented as integer multiplication of either
-  // zero or one, which would result in an highly inaccurate output.
-  // Similarly, rounding the scaling factor of 1.6 to 2.0 would produce
-  // inaccurate results because drop a significant part of the number.
-  //
-  // The solution here is to scale (increase in size) the signed integer scalar,
-  // and divide the result by shifting it to the right hand side. For example,
-  // the floating-point scalar 0.41 is multiplied by 32x (to 13.12, rounded to
-  // 13). Then the signed 32-bit integer input is multiplied by 13, and then
-  // shifted 5 times to the right (to shrink the result back). The output of
-  // this calculation is (13.0 / 32), which is about ~0.4.
-  //
-  // This approach works well for some scale values. Notice that the modified
-  // integer multiplication requires more bits because the intermediate result
-  // is larger. Notice that it's always safe to promote the scalar value from a
-  // fraction up to one. When you multiply by the integer value one, the
-  // intermediate result does not overflow (does not require more bits).
-  //
-  // It is actually always safe to perform 16-bit post-multiplication
-  // right-shifts. Let's consider two cases. If the value of the floating-point
-  // scale is greater than 1.0 then we know that at most 8 of the 32-bits in the
-  // input register are used, because the result must fit in 8-bits. The result
-  // of 8-bit times 8-bit multiplication is 16-bits, which leaves another 16
-  // bits that are unused. We can use these 16-bits to increase the size of the
-  // integer scale, and shift the result, as described above, without
-  // overflowing the register.
-  // The second case is where the scalar value is smaller than 1.0.
-  // Multiplication of any number by zero or one does not increase the number of
-  // bits which are used by the number.
-  //
-  // Now, we need to consider another problem. In the previous section we
-  // described how we scaled small fractions into a number that's close to one.
-  // But scaling to around 1.0 is not accurate enough. Rounding a scale factor
-  // like 0.6 to integer would give a very high error rate. Generally, we can't
-  // increase the size of the integer multiplier without a limit because this
-  // would overflow large values that are close to the upper signed 32-bit
-  // limit.
-  //
-  // To solve the accuracy problem we need to continue to increase the size of
-  // the integer scalar without overflowing the signed 32-bit register.
-  // The solution here is to perform right-shift on the input, in addition to
-  // the output. The idea here is that by performing the post-multiplication
-  // right-shift we pick the high bits from the result of the multiplication,
-  // and the low bits are ignored. This means that we can continue to increase
-  // the size of the integer multiplier and continue to increase the accuracy of
-  // the calculation by pre-shifting the 32-bit input. Shifting the input to the
-  // right would flip some input bits to zero, but the accuracy loss would be
-  // minimal.
-  //
-  // If the floating point scale factor small then it spans a small part of the
-  // 32-bit word. For example, a scale factor of 0.125 (1/8) scales some range
-  // into the signed 8-bit result. This range is 8 + 3 bits. This means that we
-  // can shift as much as 32-11 bits without overflowing the register. This is
-  // a net win because we get to increase the accuracy of the floating point
-  // scale factor. For very small scale factors, the used range is very large
-  // and can take up the whole 32-bit register, so overflow is a real problem.
-  // Here we can use the post-shift value to estimate how many bits will be
-  // discarded from the after the multiplication operation and figure out how
-  // many bits we can take from the bottom of the input word by shifting it to
-  // the right and add more precision to the integer scale multiplier.
+MultTransformF32ToI32 computeMultTransformParams(float scale, int bits) {
   int preShift = 0;
   int postShift = 0;
+  int32_t m = 0;
 
-  // Calculate the post-shift value. It's always safe to increase scale as long
-  // as it's below one, and it's always legal to shift at least 15 bits for
-  // small scale values.
-  while (scale < 0.5 || (scale < 256 && postShift < 15)) {
-    scale *= 2;
+  assert(scale > 0.0f && "scale is nonpositive");
+
+  // We need to determine the mantissa in a floating-point-format-independent
+  // way. To do this, upshift or downshift the scale as necessary until it is
+  // equal to its mantissa -- i.e., until it is in [1.0, 2.0).
+  while (scale >= 2.0f) {
+    scale /= 2.0f;
+    postShift--;
+  }
+
+  while (scale < 1.0f) {
+    scale *= 2.0f;
     postShift++;
   }
 
-  // Calculate the pre-multiplication shift. Estimate how many bits we can take
-  // from the input number and pass to the integer scale.
-  while (scale < 255 && preShift < (postShift / 2)) {
-    scale *= 2;
-    preShift++;
+  // Now scale is equal to its mantissa, and postShift is equal to the opposite
+  // of the actual exponent of the original value of scale.
+
+  int mBits = 1;
+
+  // We want to ensure that mBits + bits == 31, as this helps to avoid the
+  // problem of postShift being negative or zero.
+  while (mBits + bits < 31) {
+    scale *= 2.0f;
+    mBits++;
+    postShift++;
   }
 
-  return QuantizationTransform32To8(preShift, postShift, std::round(scale),
-                                    offset);
+  // At this point we have as much precision as possible, but it might not be
+  // evenly balanced. The input variable bits is still equal to its original
+  // value, and if that is greater than 16, then we may want to trade off some
+  // input bits in favor of more precision in the mantissa -- if there is such
+  // precision still to be acquired.
+  float intPart;
+  std::modf(scale, &intPart);
+  while (bits > 16 && scale != intPart) {
+    scale *= 2.0f;
+    bits--;
+    preShift++;
+    std::modf(scale, &intPart);
+  }
+
+  m = (int32_t)intPart;
+
+  if (postShift > 30) {
+    preShift = 0;
+    postShift = 1;
+    m = 0;
+  }
+
+  return MultTransformF32ToI32(preShift, postShift, m);
 }
 
 std::vector<NodeQuantizationInfo>

--- a/tests/unittests/quantizationTest.cpp
+++ b/tests/unittests/quantizationTest.cpp
@@ -75,11 +75,19 @@ TEST(Quantization, quantScaleOffset) {
     // Try all legal integers within the range:
     for (int8_t input = -128; input < 127; input++) {
       int32_t sum32num = round(input / scale);
+      int bits = 0;
+      int32_t test = (sum32num >= 0 ? sum32num : -sum32num);
+      while (test > 0) {
+        test >>= 1;
+        bits++;
+      }
+      if (bits < 8) {
+        bits = 8;
+      }
+      auto MT = quantization::computeMultTransformParams(scale, bits);
+      int32_t result = MT.transform(sum32num);
 
-      auto TR = quantization::quantizeScaleOffset32To8(scale, 0);
-      int32_t computed = TR.transform(sum32num);
-
-      EXPECT_NEAR(input, computed, 1);
+      EXPECT_NEAR(input, result, 1);
     }
   }
 }


### PR DESCRIPTION
This commit adds a new implementation of the parameter selection for performing float * integer multiplication using integer arithmetic only.  In particular, it adds a new struct MultTransformF32ToI32 and implements a new function computeMultTransformParams() which returns an instance of this struct.

The new parameter-selection algorithm is a combination of the IEEE-754 binary32 bit manipulation algorithm of PR#741 with the original 32To8 approach to scaling of the scale (via multiplication and division instead of bit shifting, and which was independent of the particular floating-point binary format).