### PR TITLE
[cmake] Add dependency graph generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,3 +73,7 @@ add_subdirectory(lib)
 add_subdirectory(examples)
 add_subdirectory(tools)
 add_subdirectory(tests)
+
+add_custom_target(dependency_graph ALL
+                  "${CMAKE_COMMAND}" "--graphviz=dependency_graph" .
+                  WORKING_DIRECTORY "${CMAKE_BINARY_DIR}")

--- a/docs/Building.md
+++ b/docs/Building.md
@@ -101,3 +101,8 @@ Building documentation can be enabled by passing an additional cmake parameter:
 
 Output will be placed in the `docs/html` subdirectory of the build output
 directory.
+
+## Generate dependency graph for cmake targets
+
+Run cmake normally and then execute `dependency_graph` target. The `dependency_graph`
+file contains dependencies for all project targets.


### PR DESCRIPTION
Generate dependency graph in graphviz compatible format (this is based on actual cmake files and defs from them)

Subgraph for quantizationTest:

![screen shot 2018-03-19 at 1 17 09 pm](https://user-images.githubusercontent.com/34466929/37619864-e80e3cea-2b77-11e8-82b5-3a3bb56889a4.png)
