### PR TITLE
[cmake] Remove external libs and tests from dependency graph

### DIFF
--- a/CMakeGraphVizOptions.cmake
+++ b/CMakeGraphVizOptions.cmake
@@ -1,0 +1,2 @@
+set(GRAPHVIZ_EXTERNAL_LIBS FALSE)
+set(GRAPHVIZ_IGNORE_TARGETS "gtest;testMain;gmock;gmock_main;")


### PR DESCRIPTION
Makes the dependency graph way more readable.

<img width="842" src="https://user-images.githubusercontent.com/1198212/37628444-b79f15e2-2b96-11e8-972b-acb14ad77d51.png">