### PR TITLE
[JIT] Support the emission of debug information

### DIFF
--- a/examples/compile_lenet_mnist/build_lenet_mnist_standalone.sh
+++ b/examples/compile_lenet_mnist/build_lenet_mnist_standalone.sh
@@ -29,10 +29,10 @@ done
 # lenet_mnist.o is the object file containing the compiled model
 # lenet_mnist.weights is the file with weights
 mkdir -p build
-${LOADER} ${GLOW_ROOT}/tests/images/mnist/5_1087.png -image_mode=0to1 -d lenet_mnist -jit -emit-bundle build
+${LOADER} ${GLOW_ROOT}/tests/images/mnist/5_1087.png -image_mode=0to1 -d lenet_mnist -jit -emit-bundle build -g
 
 # Compile lenet_mnist_standalone.cpp.
-${CXX} -std=c++11 -c ${SCRIPT_DIR}/lenet_mnist_standalone.cpp -o build/lenet_mnist_standalone.o
+${CXX} -std=c++11 -c -g ${SCRIPT_DIR}/lenet_mnist_standalone.cpp -o build/lenet_mnist_standalone.o
 
 # Produce a standalone executable by linking
 # lenet_mnist_standalone.o and lenet_mnist.o

--- a/lib/Backends/CPU/LLVMIRGen.h
+++ b/lib/Backends/CPU/LLVMIRGen.h
@@ -5,6 +5,7 @@
 #include "glow/Base/Tensor.h"
 
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/IR/DIBuilder.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Module.h"
@@ -49,6 +50,15 @@ class LLVMIRGen {
   llvm::DenseMap<llvm::Constant *, llvm::Value *> constArrayPtrs_;
   /// The IRBuilder used for the code generation.
   std::unique_ptr<llvm::IRBuilder<>> builder_;
+  /// Debug info emission support.
+  struct DebugInfo {
+    /// Debug info for the current compilation unit.
+    llvm::DICompileUnit *compilationUnit_;
+    /// Mapping from LLVM types to DebugInfo types.
+    llvm::DenseMap<llvm::Type *, llvm::DIType *> DITypes_;
+  } DbgInfo_;
+  /// Debug info builder.
+  std::unique_ptr<llvm::DIBuilder> DIBuilder_;
 
   /// Generates LLVM IR that computes the address of \p val using \p builder.
   /// The address type is specified by \p ptrTy.
@@ -91,6 +101,10 @@ class LLVMIRGen {
   void generateLLVMIRForDataParallelInstr(
       llvm::IRBuilder<> &builder, glow::Instruction *I, llvm::Function *kernel,
       llvm::DenseMap<Value *, int> &bufferToArgNum, llvm::Value *loopCount);
+  /// Create a debug information for a given LLVM type \p ty.
+  llvm::DIType *getDebugType(llvm::IRBuilder<> &builder, llvm::Type *ty);
+  /// Generate debug information.
+  void generateDebugInfo();
 
 public:
   /// Ctor.


### PR DESCRIPTION
There is a new command-line option `-g`, which can be used to emit debug information.
If this option is used, it is possible to debug the generated AOT bundles using a debugger like LLDB.

When you stop the execution, the debugger would show you the name of the current function and its arguments, e.g. buffer pointers, number of dimensions, etc. At the moment, the names of the arguments are not very user-friendly and do not reflect their semantics. They are called arg1, arg2, etc. I'll try to improve it in the future. But even with this, you can use the usual debugger commands to inspect the values, e.g. `print arg1[10]`, to inspect the 10th element of the buffer.

Stepping does not work properly, because there is no textual representation of a network model at the moment. But I'm thinking about adding an even more advanced debugging support in the future, so that one can execute Glow low-level IR step-by-step using a debugger. To do that, we just need to serialize the Glow low-level IR into a text file and use the line numbers referring to it.