### PR TITLE
Add option to disable Graph optis; Enable travis to run tests without Graph/IR optis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,10 @@ matrix:
         - mkdir build && cd build
         - cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DGLOW_WITH_OPENCL=OFF -DGLOW_USE_COVERAGE=ON ../
       script:
-        - ../.travis/run_coverage.sh 
+        - ../.travis/run_coverage.sh
 
 script:
  - ninja all
  - CTEST_PARALLEL_LEVEL=2 ninja test
  - cat Testing/Temporary/LastTest.log
+ - CTEST_PARALLEL_LEVEL=2 ninja test_unopt

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -128,6 +128,7 @@ target_link_libraries(OCLTest
                         gtest
                         testMain)
 add_test(OCLTest ${GLOW_BINARY_DIR}/tests/OCLTest)
+LIST(APPEND UNOPT_TESTS ./tests/OCLTest -optimize-ir=false &&)
 endif()
 
 if(GLOW_WITH_CPU)
@@ -143,6 +144,7 @@ target_link_libraries(JITTest
                         gtest
                         testMain)
 add_test(JITTest ${GLOW_BINARY_DIR}/tests/JITTest)
+LIST(APPEND UNOPT_TESTS ./tests/JITTest -optimize-ir=false &&)
 endif()
 
 add_executable(memoryAllocatorTest
@@ -153,3 +155,12 @@ target_link_libraries(memoryAllocatorTest
                         gtest
                         testMain)
 add_test(memoryAllocatorTest ${GLOW_BINARY_DIR}/tests/memoryAllocatorTest)
+
+
+LIST(APPEND UNOPT_TESTS
+       ./tests/gradCheckTest -optimize-ir=false &&
+       ./tests/graphTest -optimize-ir=false &&
+       ./tests/graphGradTest -optimize-ir=false)
+
+add_custom_target(test_unopt ${UNOPT_TESTS}
+                  WORKING_DIRECTORY ${CMAKE_BINARY_DIR})


### PR DESCRIPTION
Travis will now run all applicable tests with Graph + IR optimizations, without Graph optimizations, and without IR optimizations. By default these unoptimized tests are not run; you can enable them via CMake with `-DENABLE_TESTING_UNOPT=ON`.

I could also add tests without both Graph and IR optimizations if desired.

For now the following tests fail, so they are disabled in `CTestCustom.cmake`. Will work next to fix them + enable them:

`interpreterTest_NoIROpt`
`operatorTest_NoGraphOpt`
`operatorTest_NoIROpt `
`quantizationTest_NoGraphOpt`
`quantizationTest_NoIROpt`