### PR TITLE
Implement The  DKKC8 cpu convolution.

### DIFF
--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -1067,6 +1067,34 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     break;
   }
 
+  case Kinded::Kind::CPUConvDKKC8InstKind: {
+    CPUConvDKKC8Inst *CI = cast<CPUConvDKKC8Inst>(I);
+    auto *dest = CI->getDest();
+    auto *src = CI->getSrc();
+    auto *filter = CI->getFilter();
+    auto *bias = CI->getBias();
+    auto *destPtr = emitValueAddress(builder, dest);
+    auto *srcPtr = emitValueAddress(builder, src);
+    auto *filterPtr = emitValueAddress(builder, filter);
+    auto *biasPtr = emitValueAddress(builder, bias);
+
+    auto *destDims = emitValueDims(builder, dest);
+    auto *srcDims = emitValueDims(builder, src);
+    auto *filterDims = emitValueDims(builder, filter);
+    auto *biasDims = emitValueDims(builder, bias);
+
+    auto *kernel = emitConstSizeT(builder, CI->getKernel());
+    auto *stride = emitConstSizeT(builder, CI->getStride());
+    auto *pad = emitConstSizeT(builder, CI->getPad());
+
+    const char *kernelName = "convDKKC8";
+    auto *F = getFunction(kernelName, dest->getElementType());
+
+    builder.CreateCall(F, {destPtr, srcPtr, filterPtr, biasPtr, destDims,
+                           srcDims, filterDims, biasDims, kernel, stride, pad});
+    break;
+  }
+
   case Kinded::Kind::ConvolutionGradInstKind: {
     ConvolutionGradInst *CG = cast<ConvolutionGradInst>(I);
     auto *srcGrad = CG->getSrcGrad();

--- a/lib/Backends/CPU/Transforms.cpp
+++ b/lib/Backends/CPU/Transforms.cpp
@@ -9,9 +9,74 @@ using namespace glow;
 using llvm::dyn_cast;
 using llvm::isa;
 
+/// Try to optimize the regular Convolution into a target-specific convolution
+/// with a different filter memory layout. This optimization adds a new kind of
+/// cpu-specific convolution that operates on filter weight data in a
+/// non-standard format. The default format is DKKC, where D is the output
+/// depth of the filter and C is the input channel, and K is the kernel size.
+/// This optimization changes the data layout to [D/8, K, K, C, 8].  We
+/// pre-swizzle the data in the weights to make the access pattern more
+/// efficient.
+static Node *optimizeCPUConv(ConvolutionNode *CN, Function *F) {
+  auto depth = CN->getDepth();
+  auto *M = F->getParent();
+  auto inChannels = CN->getInput()->dims()[3];
+
+  // The depth dimension must of a multiple of 64 to perform the
+  // transformation. This transformation is currently only profitable on
+  // low-channel convolutions.
+  if (depth < 64 || depth % 64 || inChannels > 128) {
+    return nullptr;
+  }
+
+  Variable *filter = dyn_cast<Variable>(CN->getFilter());
+  if (!filter || filter->getNumUsers() != 1 || !filter->isPrivate()) {
+    // Can't mutate the filter.
+    return nullptr;
+  }
+
+  // We only support Floats for now.
+  if (filter->getElementType() != ElemKind::FloatTy) {
+    return nullptr;
+  }
+
+  // Create a new variable filter with the layout [D/8, K, K, C, 8];
+  TypeRef filterTy = filter->getType();
+  auto dims = filterTy->dims();
+  assert(dims.size() == 4 && "Invalid filter size");
+  auto *filter8 = M->createVariable(
+      filterTy->getElementType(), {dims[0] / 8, dims[1], dims[2], dims[3], 8},
+      filter->getName(), Variable::VisibilityKind::Private,
+      Variable::TrainKind::None);
+
+  auto F8H = filter8->getHandle();
+  auto FH = filter->getHandle();
+
+  // Transpose the weights into the format [D/8, K, K, C, 8], where the depth
+  // dimension is consecutive in memory.
+  for (size_t c0 = 0; c0 < dims[0]; c0++)
+    for (size_t c1 = 0; c1 < dims[1]; c1++)
+      for (size_t c2 = 0; c2 < dims[2]; c2++)
+        for (size_t c3 = 0; c3 < dims[3]; c3++) {
+          F8H.at({c0 / 8, c1, c2, c3, c0 % 8}) = FH.at({c0, c1, c2, c3});
+        }
+
+  return F->addNode(new CPUConvDKKC8Node(
+      CN->getName(), CN->getType(), CN->getInput(), filter8, CN->getBias(),
+      CN->getKernel(), CN->getStride(), CN->getPad(), CN->getDepth()));
+}
+
 bool CPUBackend::transformPostLowering(Function *F) {
   bool changed = false;
   for (auto node : F->getNodes()) {
+
+    if (auto *CN = dyn_cast<ConvolutionNode>(node)) {
+      if (Node *NCN = optimizeCPUConv(CN, F)) {
+        NodeValue(node, 0).replaceAllUsesOfWith(NCN);
+        changed = true;
+        continue;
+      }
+    }
     if (auto *MN = dyn_cast<MaxNode>(node)) {
       if (auto *splat = dyn_cast<SplatNode>(MN->getLHS())) {
         auto MSN = F->addNode(new CPUMaxSplatNode(MN->getName(), MN->getRHS(),

--- a/lib/Backends/CPU/libjit.cpp
+++ b/lib/Backends/CPU/libjit.cpp
@@ -7,12 +7,31 @@
 #include <cstring>
 #include <sys/types.h>
 
+typedef float float4 __attribute__((ext_vector_type(4)));
+typedef float float8 __attribute__((ext_vector_type(8)));
+
+/// Loads a simd float8 value from \p ptr.
+#define LoadFloat8(PTR) *((const float8 *)(PTR))
+
+/// Stores the simd float8 value to \p ptr.
+#define StoreFloat8(PTR, VAL) *((float8 *)(PTR)) = VAL;
+
+/// Accumulate (+=) the simd float8 value to \p ptr.
+#define AddFloat8(PTR, VAL) *((float8 *)(PTR)) += VAL;
+
 #define MIN(a, b) (((a) < (b)) ? (a) : (b))
 #define MAX(a, b) (((a) > (b)) ? (a) : (b))
 #define AT(tensor, dims, numDims, indices, numIndices)                         \
   tensor[get_element_ptr(tensor, dims, numDims, indices, numIndices)]
 
 namespace {
+
+size_t libjit_getXYZWQ(const size_t *dims, size_t x, size_t y, size_t z,
+                       size_t w, size_t q) {
+  return (x * dims[1] * dims[2] * dims[3] * dims[4]) +
+         (y * dims[2] * dims[3] * dims[4]) + (z * dims[3] * dims[4]) +
+         (w * dims[4]) + q;
+}
 
 /// \returns the index of the element at x,y,z,w.
 size_t libjit_getXYZW(const size_t *dims, size_t x, size_t y, size_t z,
@@ -597,6 +616,73 @@ void libjit_batchedreduceadd_f(float *dest, const float *batch, size_t destSize,
       dest[i] += batch[base + i];
     }
   }
+}
+
+void libjit_convDKKC8_f(float *outW, const float *inW, const float *filterW,
+                        const float *biasW, const size_t *outWdims,
+                        const size_t *inWdims, const size_t *filterWdims,
+                        const size_t *biasWdims, size_t filterSize,
+                        size_t stride, size_t pad) {
+  unsigned depthUnroll = 8;
+
+  size_t inChannels = inWdims[3];
+  // For each input in the batch:
+  for (size_t n = 0; n < inWdims[0]; n++) {
+    // For each layer in the output tensor. Process 4 x float8 elements at once.
+    for (size_t d = 0; d < outWdims[3]; d += 8 * depthUnroll) {
+
+      // For each convolution 'jump' in the input tensor:
+      ssize_t x = -(ssize_t)pad;
+      for (size_t ax = 0; ax < outWdims[1]; x += stride, ax++) {
+        ssize_t y = -(ssize_t)pad;
+        for (size_t ay = 0; ay < outWdims[2]; y += stride, ay++) {
+
+          // Process 4 * 8 output pixels at once. Each value here is a scalar in
+          // the depth dimension.
+          float8 sum[depthUnroll];
+          for (int du = 0; du < depthUnroll; du++) {
+            sum[du] = LoadFloat8(&biasW[d + du * 8]);
+          }
+
+          // For each element in the convolution-filter:
+          for (size_t fx = 0; fx < filterSize; fx++) {
+            for (size_t fy = 0; fy < filterSize; fy++) {
+              ssize_t ox = x + fx;
+              ssize_t oy = y + fy;
+
+              // Ignore index access below zero (this is due to padding).
+              if (ox < 0 || oy < 0 || ox >= (ssize_t)inWdims[1] ||
+                  oy >= (ssize_t)inWdims[2]) {
+                continue;
+              }
+
+              // Perform the heart of the convolution.
+              for (size_t fd = 0; fd < inChannels; fd++) {
+                // Load a single pixel from the input image and broadcast it.
+                float8 in =
+                    inW[libjit_getXYZW(inWdims, n, (size_t)ox, (size_t)oy, fd)];
+                // Load 8 x 4 elements from the filter layer. The filter is
+                // pre-swizzled to ensure efficient access.
+
+                for (int du = 0; du < depthUnroll; du++) {
+                  float8 ff0 = LoadFloat8(&filterW[libjit_getXYZWQ(
+                      filterWdims, d / 8 + du, fx, fy, fd, 0)]);
+                  sum[du] += ff0 * in;
+                }
+              }
+            }
+          }
+
+          // Store the results to the output buffer.
+          for (int du = 0; du < depthUnroll; du++) {
+            StoreFloat8(&outW[libjit_getXYZW(outWdims, n, ax, ay, d + du * 8)],
+                        sum[du]);
+          }
+
+        } // W
+      }   // H
+    }     // C
+  }       // N
 }
 
 void libjit_convolution_f(float *outW, const float *inW, const float *filterW,

--- a/tests/unittests/BackendTestUtils.cpp
+++ b/tests/unittests/BackendTestUtils.cpp
@@ -511,14 +511,15 @@ void inferTanhNet(Tensor *inputs, Tensor *out, BackendKind kind) {
   out->copyFrom(&result->getVariable()->getPayload());
 }
 
-void inferBasicConvNet(Tensor *inputs, Tensor *out, BackendKind kind) {
+void inferBasicConvNet(Tensor *inputs, Tensor *out, BackendKind kind,
+                       size_t convDepth) {
   ExecutionEngine EE(kind);
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
   auto *var = mod.createVariable(inputs->getElementType(), inputs->dims(),
                                  "input", Variable::VisibilityKind::Public);
   auto *tr = F->createTranspose("tr", var, {0, 2, 3, 1});
-  auto *conv = F->createConv("conv", tr, 4, 5, 2, 1);
+  auto *conv = F->createConv("conv", tr, convDepth, 5, 2, 1);
   cast<Variable>(conv->getFilter())->getHandle().clear(2);
   cast<Variable>(conv->getBias())->getHandle().clear(2);
   auto *pool = F->createPoolMax("pool", conv, 2, 2, 0);

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -74,7 +74,8 @@ void trainSoftMaxNet(Tensor *inputs, Tensor *weights, Tensor *bias,
 
 void inferTanhNet(Tensor *inputs, Tensor *out, BackendKind kind);
 
-void inferBasicConvNet(Tensor *inputs, Tensor *out, BackendKind kind);
+void inferBasicConvNet(Tensor *inputs, Tensor *out, BackendKind kind,
+                       size_t convDepth);
 
 void inferBasicFCNet(Tensor *inputs, Tensor *out, BackendKind kind);
 

--- a/tests/unittests/JITTest.cpp
+++ b/tests/unittests/JITTest.cpp
@@ -528,17 +528,20 @@ TEST(JITCorrectnessTest, tanhTest) {
 }
 
 TEST(JITCorrectnessTest, convOps) {
-  Tensor inputs(ElemKind::FloatTy, {2, 3, 16, 16});
-  inputs.getHandle().initXavier(1);
-  Tensor out1;
-  Tensor out2;
+  // Construct networks with a different convolution depth.
+  for (auto depth : {4, 12, 128}) {
+    Tensor inputs(ElemKind::FloatTy, {2, 3, 16, 16});
+    inputs.getHandle().initXavier(1);
+    Tensor out1;
+    Tensor out2;
 
-  inferBasicConvNet(&inputs, &out1, BackendKind::JIT);
-  inferBasicConvNet(&inputs, &out2, BackendKind::Interpreter);
-  auto H1 = out1.getHandle();
-  auto H2 = out2.getHandle();
+    inferBasicConvNet(&inputs, &out1, BackendKind::JIT, depth);
+    inferBasicConvNet(&inputs, &out2, BackendKind::Interpreter, depth);
+    auto H1 = out1.getHandle();
+    auto H2 = out2.getHandle();
 
-  EXPECT_TRUE(H1.isEqual(H2));
+    EXPECT_TRUE(H1.isEqual(H2));
+  }
 }
 
 TEST(JITCorrectnessTest, basicFCNet) {

--- a/tests/unittests/OCLTest.cpp
+++ b/tests/unittests/OCLTest.cpp
@@ -36,8 +36,8 @@ TEST(OpenCLCorrectnessTest, convOps) {
   Tensor out1;
   Tensor out2;
 
-  inferBasicConvNet(&inputs, &out1, BackendKind::OpenCL);
-  inferBasicConvNet(&inputs, &out2, BackendKind::Interpreter);
+  inferBasicConvNet(&inputs, &out1, BackendKind::OpenCL, 4);
+  inferBasicConvNet(&inputs, &out2, BackendKind::Interpreter, 4);
   auto H1 = out1.getHandle();
   auto H2 = out2.getHandle();
 

--- a/tools/ClassGen/Backends/CPU/CPUSpecificInstrs.h
+++ b/tools/ClassGen/Backends/CPU/CPUSpecificInstrs.h
@@ -8,6 +8,18 @@ BB.newBackendSpecificInstr("CPUMaxSplat")
     .dataParallel()
     .autoIRGen();
 
+BB.newBackendSpecificInstr("CPUConvDKKC8")
+    .addOperand("Dest", OperandKind::Out)
+    .addOperand("Src", OperandKind::In)
+    .addOperand("Filter", OperandKind::In)
+    .addOperand("Bias", OperandKind::In)
+    .addMember(MemberType::SizeT, "Kernel")
+    .addMember(MemberType::SizeT, "Stride")
+    .addMember(MemberType::SizeT, "Pad")
+    .addMember(MemberType::SizeT, "Depth")
+    .autoIRGen()
+    .autoVerify(VerifyKind::SameElementType, {"Dest", "Src", "Filter", "Bias"});
+
 BB.includeBackendSpecificVerification("CPUSpecificInstrsVerification.h");
 
 #endif // GLOW_WITH_CPU

--- a/tools/ClassGen/Backends/CPU/CPUSpecificNodes.h
+++ b/tools/ClassGen/Backends/CPU/CPUSpecificNodes.h
@@ -6,6 +6,18 @@ BB.newBackendSpecificNode("CPUMaxSplat")
     .addMember(MemberType::Float, "SplatValue")
     .setDocstring("A Max node with one splat input; CPU specific.");
 
+BB.newNode("CPUConvDKKC8")
+    .addInput("Input")
+    .addInput("Filter")
+    .addInput("Bias")
+    .addMember(MemberType::SizeT, "Kernel")
+    .addMember(MemberType::SizeT, "Stride")
+    .addMember(MemberType::SizeT, "Pad")
+    .addMember(MemberType::SizeT, "Depth")
+    .addResultFromCtorArg()
+    .setDocstring("This is a cpu-specific convolution implementation where the "
+                  "filter is transposed to the shape [D/8, K, K, C, 8]");
+
 BB.includeBackendSpecificVerification("CPUSpecificNodesVerification.h");
 
 #endif // GLOW_WITH_CPU

--- a/tools/ClassGen/Backends/CPU/CPUSpecificNodesVerification.h
+++ b/tools/ClassGen/Backends/CPU/CPUSpecificNodesVerification.h
@@ -5,4 +5,14 @@ void CPUMaxSplatNode::verify() const {
   assert(getInput().dims() == getResult().dims() && "Invalid shape");
 }
 
+void CPUConvDKKC8Node::verify() const {
+  ShapeNHWC idim(getInput().getType()->dims());
+  ShapeNHWC odim(getResult().getType()->dims());
+  auto outSz = calculateConvOutputDims(idim.h, idim.w, getKernel(), getStride(),
+                                       getPad());
+  ShapeNHWC exp(idim.n, outSz.first, outSz.second, getDepth());
+  (void)exp;
+  assert(exp == odim && "Invalid output dimensions");
+}
+
 #endif // GLOW_WITH_CPU


### PR DESCRIPTION
This commit adds a new kind of cpu-specific convolution that operates on
filter weight data in a non-standard format. The default format is
DKKC, where D is the output depth of the filter and C is the input
channel, and K is the kernel size. This commit changes the data layout
to [D/8, K, K, C, 8]. We pre-swizzle the data in the weights to make
the access pattern more efficient.

This commit creates a new target-specific node and instruction and
detects profitable patterns. This provides a performance
boost on Resnet50. (0.22sec -> 0.19sec)