### PR TITLE
build: only build the loader if we have libpng

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,4 +1,6 @@
 add_subdirectory(ClassGen)
 add_subdirectory(emulator)
-add_subdirectory(loader)
+if(PNG_FOUND)
+  add_subdirectory(loader)
+endif()
 


### PR DESCRIPTION
The loader uses libpng to load images.  If libpng is not found, don't bother
building the loader.