### PR TITLE
[CPU] Change the order of loops in the DKKC8 convolution.

### DIFF
--- a/lib/Backends/CPU/Transforms.cpp
+++ b/lib/Backends/CPU/Transforms.cpp
@@ -22,10 +22,10 @@ static Node *optimizeCPUConv(ConvolutionNode *CN, Function *F) {
   auto *M = F->getParent();
   auto inChannels = CN->getInput()->dims()[3];
 
-  // The depth dimension must of a multiple of 64 to perform the
+  // The depth dimension must be a multiple of 64 to perform the
   // transformation. This transformation is currently only profitable on
   // low-channel convolutions.
-  if (depth < 64 || depth % 64 || inChannels > 256) {
+  if (depth < 64 || (depth % 64) != 0 || inChannels > 256) {
     return nullptr;
   }
 


### PR DESCRIPTION
Iterating over the filter dims (fx, fy) outside of the image x,y improves the filter memory locality.
 Tile the access to the filter and weight along the channel axis.

0.19 -> 0.17 -> 0.163.