### PR TITLE
[CPU] Update the convolution parameter based on some perf measurments.

### DIFF
--- a/lib/Backends/CPU/Transforms.cpp
+++ b/lib/Backends/CPU/Transforms.cpp
@@ -20,12 +20,11 @@ using llvm::isa;
 static Node *optimizeCPUConv(ConvolutionNode *CN, Function *F) {
   auto depth = CN->getDepth();
   auto *M = F->getParent();
-  auto inChannels = CN->getInput()->dims()[3];
 
   // The depth dimension must be a multiple of 64 to perform the
   // transformation. This transformation is currently only profitable on
   // low-channel convolutions.
-  if (depth < 64 || (depth % 64) != 0 || inChannels > 256) {
+  if (depth < 64 || (depth % 64) != 0) {
     return nullptr;
   }
 

--- a/lib/Backends/CPU/libjit.cpp
+++ b/lib/Backends/CPU/libjit.cpp
@@ -647,7 +647,7 @@ void libjit_convDKKC8_f(float *outW, const float *inW, const float *filterW,
   // The number of times to unroll the SIMD vector output-depth.
   constexpr unsigned depthUnroll = 8;
   // The size of the input-channel tile.
-  constexpr unsigned cbSize = 64;
+  constexpr unsigned cbSize = 128;
 
   size_t inChannels = inWdims[3];
   // For each input in the batch:


### PR DESCRIPTION
I've enumerated different parameters in search for the optimal convolution parameters. It looks like channel window size of 128 outperforms 64, and that the DKKN convolution is always better. 

I tested both Haswell and Skylake. 

![screen shot 2018-03-27 at 11 17 13 pm](https://user-images.githubusercontent.com/8635342/38012615-fb97ee6e-3216-11e8-8b71-3178ecea5e72.png)

 