### PR TITLE
[quantization] Currently sub is not supported. Support will be added in the next PR.

### DIFF
--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -106,7 +106,6 @@ bool Interpreter::isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const {
     case Kinded::Kind::MaxNodeKind:
     case Kinded::Kind::MinNodeKind:
     case Kinded::Kind::MulNodeKind:
-    case Kinded::Kind::SubNodeKind:
     case Kinded::Kind::QuantizeNodeKind:
     case Kinded::Kind::DequantizeNodeKind:
     case Kinded::Kind::RescaleQuantizedNodeKind:


### PR DESCRIPTION
For the reference: https://github.com/facebookexternal/Glow/blob/master/lib/Backends/Interpreter/InterpreterNodes.cpp#L884

I'm loading profile for fr2en model and apparently quantized `sub` is not yet supported by the interpreter.