### PR TITLE
[AOT] Add an example that creates a standalone AOT bundle for resnet50

### DIFF
--- a/docs/AOT.md
+++ b/docs/AOT.md
@@ -146,3 +146,34 @@ The script performs the following steps:
 * Finally, it runs this standalone executable with mnist images as inputs and outputs the
 results of the network model execution.
 
+## A step-by-step example for the resnet50 network model
+
+There is a concrete example of integrating a network model with a project.  You
+can find it in the `examples/compile_resnet50` directory in the Glow
+repository.
+
+To build and run this example, you just need to run the
+`build_standalone.sh` script in the `examples/compile_resnet50`
+directory. You may need to adjust the environment variables at the top to match
+your setup.
+
+The script performs the following steps:
+* It downloads the resnet50 network model in the Caffe2 format.
+* It generates the bundle files using the Glow loader as described above.
+  The concrete command line looks like this:
+  `loader tests/images/imagenet/cat_285.png -image_mode=0to1 -d resnet50 -jit -emit-bundle build`
+  It reads the network model from `resnet50` and generates the `resnet50.o`
+  and `resnet50.weights` files into the `build` directory.
+* Then it compiles the `resnet50_standalone.cpp` file, which is the main file of the project.
+  This source file gives a good idea about how to interface with an auto-generated bundle.
+  It contains the code for interfacing with with the auto-generated bundle.
+  *  It allocated the memory areas based on their memory sizes provided in `resnet50_config`.
+  *  Then it loads the weights from the auto-generated `resnet50.weights` file.
+  *  It loads the input image, pre-processes it and puts it into the mutable weight variables
+     memory area.
+  *  Once evertything is setup, it invokes the compiled network model by calling the
+     `resnet50` function from the `resnet50.o` object file.
+* Then it links the user-defined `resnet50_standalone.o` and auto-generated `resnet50.o`
+  into a standalone executable file called `resnet50_standalone`
+* Finally, it runs this standalone executable with imagenet images as inputs and outputs the
+results of the network model execution.

--- a/examples/compile_resnet50/build_standalone.sh
+++ b/examples/compile_resnet50/build_standalone.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# Bash strict mode
+set -euo pipefail
+
+# Configure the following environment variables based on your setup.
+
+# Path to the Glow loader executable.
+LOADER="${LOADER:-~/src/build/Glow/bin/loader}"
+# The command to invoke a c++ compiler.
+CXX="${CXX:-clang++}"
+
+# Get path to this script.
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# The root directory of the Glow source code.
+GLOW_ROOT="$( cd "${SCRIPT_DIR}/../.." && pwd )"
+
+# The name of the neural network model.
+NETWORK_MODEL=resnet50
+
+# This file downloads the ${NETWORK_MODEL} model, uses the loader to create a
+# bundle from it and then links it with the client-code from
+# ${NETWORK_MODEL}_standalone.cpp to create a small standalone executable.
+
+# Download the Caffe2 model.
+for file in predict_net.pbtxt predict_net.pb init_net.pb; do
+  wget http://fb-glow-assets.s3.amazonaws.com/models/$NETWORK_MODEL/$file -P $NETWORK_MODEL -nc 
+done
+
+# Use loader to create a bundle.
+# This command will produce two files:
+# ${NETWORK_MODEL}.o is the object file containing the compiled model
+# ${NETWORK_MODEL}.weights is the file with weights
+mkdir -p build
+${LOADER} ${GLOW_ROOT}/tests/images/imagenet/cat_285.png -image_mode=0to1 -d ${NETWORK_MODEL} -cpu -emit-bundle build -g
+
+# Compile lenet_mnist_standalone.cpp.
+${CXX} -std=c++11 -c -g ${SCRIPT_DIR}/${NETWORK_MODEL}_standalone.cpp -o build/${NETWORK_MODEL}_standalone.o
+
+# Produce a standalone executable by linking
+# ${NETWORK_MODEL}_standalone.o and ${NETWORK_MODEL}.o
+${CXX} -o build/${NETWORK_MODEL}_standalone build/${NETWORK_MODEL}_standalone.o build/${NETWORK_MODEL}.o -lpng
+
+pushd build
+
+# Test the compiled model using the imagenet images.
+for image in ${GLOW_ROOT}/tests/images/imagenet/*; do
+  ./${NETWORK_MODEL}_standalone ${image}
+done
+
+popd

--- a/examples/compile_resnet50/resnet50_standalone.cpp
+++ b/examples/compile_resnet50/resnet50_standalone.cpp
@@ -1,0 +1,370 @@
+#include <assert.h>
+#include <png.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <string>
+#include <vector>
+
+/// This is an example demonstrating how to use auto-generated bundles and
+/// create standalone executables that can perform neural network computations.
+/// This example loads and runs the compiled resnet50 network model.
+
+#define DEFAULT_HEIGHT 224
+#define DEFAULT_WIDTH 224
+
+//===----------------------------------------------------------------------===//
+//                   Image processing helpers
+//===----------------------------------------------------------------------===//
+std::vector<std::string> inputImageFilenames;
+
+/// \returns the index of the element at x,y,z,w.
+size_t getXYZW(const size_t *dims, size_t x, size_t y, size_t z, size_t w) {
+  return (x * dims[1] * dims[2] * dims[3]) + (y * dims[2] * dims[3]) +
+         (z * dims[3]) + w;
+}
+
+/// \returns the index of the element at x,y,z.
+size_t getXYZ(const size_t *dims, size_t x, size_t y, size_t z) {
+  return (x * dims[1] * dims[2]) + (y * dims[2]) + z;
+}
+
+/// Reads a PNG image from a file into a newly allocated memory block \p imageT
+/// representing a WxHxNxC tensor and returns it. The client is responsible for
+/// freeing the memory block.
+bool readPngImage(const char *filename, std::pair<float, float> range,
+                  float *&imageT, size_t *imageDims) {
+  unsigned char header[8];
+  // open file and test for it being a png.
+  FILE *fp = fopen(filename, "rb");
+  // Can't open the file.
+  if (!fp) {
+    return true;
+  }
+
+  // Validate signature.
+  size_t fread_ret = fread(header, 1, 8, fp);
+  if (fread_ret != 8) {
+    return true;
+  }
+  if (png_sig_cmp(header, 0, 8)) {
+    return true;
+  }
+
+  // Initialize stuff.
+  png_structp png_ptr =
+      png_create_read_struct(PNG_LIBPNG_VER_STRING, nullptr, nullptr, nullptr);
+  if (!png_ptr) {
+    return true;
+  }
+
+  png_infop info_ptr = png_create_info_struct(png_ptr);
+  if (!info_ptr) {
+    return true;
+  }
+
+  if (setjmp(png_jmpbuf(png_ptr))) {
+    return true;
+  }
+
+  png_init_io(png_ptr, fp);
+  png_set_sig_bytes(png_ptr, 8);
+  png_read_info(png_ptr, info_ptr);
+
+  size_t width = png_get_image_width(png_ptr, info_ptr);
+  size_t height = png_get_image_height(png_ptr, info_ptr);
+  int color_type = png_get_color_type(png_ptr, info_ptr);
+  int bit_depth = png_get_bit_depth(png_ptr, info_ptr);
+
+  const bool isGray = color_type == PNG_COLOR_TYPE_GRAY;
+  const size_t numChannels = isGray ? 1 : 3;
+
+  (void)bit_depth;
+  assert(bit_depth == 8 && "Invalid image");
+  assert((color_type == PNG_COLOR_TYPE_RGB_ALPHA ||
+          color_type == PNG_COLOR_TYPE_RGB || isGray) &&
+         "Invalid image");
+  bool hasAlpha = (color_type == PNG_COLOR_TYPE_RGB_ALPHA);
+
+  int number_of_passes = png_set_interlace_handling(png_ptr);
+  (void)number_of_passes;
+  assert(number_of_passes == 1 && "Invalid image");
+
+  png_read_update_info(png_ptr, info_ptr);
+
+  // Error during image read.
+  if (setjmp(png_jmpbuf(png_ptr))) {
+    return true;
+  }
+
+  auto *row_pointers = (png_bytep *)malloc(sizeof(png_bytep) * height);
+  for (size_t y = 0; y < height; y++) {
+    row_pointers[y] = (png_byte *)malloc(png_get_rowbytes(png_ptr, info_ptr));
+  }
+
+  png_read_image(png_ptr, row_pointers);
+  png_read_end(png_ptr, info_ptr);
+
+  imageDims[0] = width;
+  imageDims[1] = height;
+  imageDims[2] = numChannels;
+  imageT = static_cast<float *>(
+      calloc(1, width * height * numChannels * sizeof(float)));
+
+  float scale = ((range.second - range.first) / 255.0);
+  float bias = range.first;
+
+  for (size_t row_n = 0; row_n < height; row_n++) {
+    png_byte *row = row_pointers[row_n];
+    for (size_t col_n = 0; col_n < width; col_n++) {
+      png_byte *ptr =
+          &(row[col_n * (hasAlpha ? (numChannels + 1) : numChannels)]);
+      if (isGray) {
+        imageT[getXYZ(imageDims, row_n, col_n, 0)] =
+            float(ptr[0]) * scale + bias;
+      } else {
+        imageT[getXYZ(imageDims, row_n, col_n, 0)] =
+            float(ptr[0]) * scale + bias;
+        imageT[getXYZ(imageDims, row_n, col_n, 1)] =
+            float(ptr[1]) * scale + bias;
+        imageT[getXYZ(imageDims, row_n, col_n, 2)] =
+            float(ptr[2]) * scale + bias;
+      }
+    }
+  }
+
+  for (size_t y = 0; y < height; y++) {
+    free(row_pointers[y]);
+  }
+  free(row_pointers);
+  png_destroy_read_struct(&png_ptr, &info_ptr, (png_infopp)NULL);
+  fclose(fp);
+  printf("Loaded image: %s\n", filename);
+
+  return false;
+}
+
+/// Loads and normalizes all PNGs into a tensor memory block \p resultT in the
+/// NCHW 3x224x224 format.
+static void loadImagesAndPreprocess(const std::vector<std::string> &filenames,
+                                    float *&resultT, size_t *resultDims) {
+  assert(filenames.size() > 0 &&
+         "There must be at least one filename in filenames");
+  std::pair<float, float> range = std::make_pair(0., 1.0);
+  unsigned numImages = filenames.size();
+  // N x C x H x W
+  resultDims[0] = numImages;
+  resultDims[1] = 3;
+  resultDims[2] = DEFAULT_HEIGHT;
+  resultDims[3] = DEFAULT_WIDTH;
+  size_t resultSizeInBytes =
+      numImages * 3 * DEFAULT_HEIGHT * DEFAULT_WIDTH * sizeof(float);
+  resultT = static_cast<float *>(malloc(resultSizeInBytes));
+  // We iterate over all the png files, reading them all into our result tensor
+  // for processing
+  for (unsigned n = 0; n < numImages; n++) {
+    float *imageT{nullptr};
+    size_t dims[3];
+    bool loadSuccess = !readPngImage(filenames[n].c_str(), range, imageT, dims);
+    assert(loadSuccess && "Error reading input image.");
+
+    assert((dims[0] == DEFAULT_HEIGHT && dims[1] == DEFAULT_WIDTH) &&
+           "All images must have the same Height and Width");
+
+    // Convert to BGR, as this is what NN is expecting.
+    for (unsigned z = 0; z < 3; z++) {
+      for (unsigned y = 0; y < dims[1]; y++) {
+        for (unsigned x = 0; x < dims[0]; x++) {
+          resultT[getXYZW(resultDims, n, 2 - z, x, y)] =
+              imageT[getXYZ(dims, x, y, z)];
+        }
+      }
+    }
+  }
+  printf("Loaded images size in bytes is: %lu\n", resultSizeInBytes);
+}
+
+/// Parse images file names into a vector.
+void parseCommandLineOptions(int argc, char **argv) {
+  int arg = 1;
+  while (arg < argc) {
+    inputImageFilenames.push_back(argv[arg++]);
+  }
+}
+
+//===----------------------------------------------------------------------===//
+//                 Wrapper code for executing a bundle
+//===----------------------------------------------------------------------===//
+
+/// Type describing a symbol table entry of a generated bundle.
+struct SymbolTableEntry {
+  // Name of a variable.
+  const char *name;
+  // Offset of the variable inside the memory area.
+  size_t offset;
+  // The number of elements inside this variable.
+  size_t size;
+  // The kind of the variable. 1 if it is a mutable variable, 0 otherwise.
+  char kind;
+};
+
+/// Type describing the config of a generated bundle.
+struct BundleConfig {
+  // Size of the constant weight variables memory area.
+  size_t constantWeightVarsMemSize;
+  // Size of the mutable weight variables memory area.
+  size_t mutableWeightVarsMemSize;
+  // Size of the activations memory area.
+  size_t activationsMemSize;
+  // Alignment to be used for weights and activations.
+  size_t alignment;
+  // Number of symbols in the symbol table.
+  size_t numSymbols;
+  // Symbol table.
+  const SymbolTableEntry *symbolTable;
+};
+
+// These two external symbols are auto-generated by means of the -bundle option.
+extern "C" void resnet50(uint8_t *constantWeightVars,
+                         uint8_t *mutableWeightVars, uint8_t *activations);
+extern "C" BundleConfig resnet50_config;
+
+/// Find in the bundle's symbol table a weight variable whose name starts with
+/// \p name.
+const SymbolTableEntry *getWeightVar(const BundleConfig &config,
+                                     const char *name) {
+  for (unsigned i = 0, e = config.numSymbols; i < e; ++i) {
+    if (!strncmp(config.symbolTable[i].name, name, strlen(name))) {
+      return &config.symbolTable[i];
+    }
+  }
+  return nullptr;
+}
+
+/// Find in the bundle's symbol table a mutable weight variable whose name
+/// starts with \p name.
+const SymbolTableEntry &getMutableWeightVar(const BundleConfig &config,
+                                            const char *name) {
+  const SymbolTableEntry *mutableWeightVar = getWeightVar(config, name);
+  if (!mutableWeightVar) {
+    printf("Expected to find variable '%s'\n", name);
+  }
+  assert(mutableWeightVar && "Expected to find a mutable weight variable");
+  assert(mutableWeightVar->kind != 0 &&
+         "Weight variable is expected to be mutable");
+  return *mutableWeightVar;
+}
+
+/// Allocate an aligned block of memory.
+void *alignedAlloc(const BundleConfig &config, size_t size) {
+  const size_t alignment = 64;
+  void *ptr;
+  // Properly align the memory region.
+  int res = posix_memalign(&ptr, config.alignment, size);
+  assert(res == 0 && "posix_memalign failed");
+  assert((size_t)ptr % alignment == 0 && "Wrong alignment");
+  memset(ptr, 0, size);
+  return ptr;
+}
+
+/// Initialize the constant weights memory block by loading the weights from the
+/// weights file.
+static uint8_t *initConstantWeights(const char *weightsFileName,
+                                    const BundleConfig &config) {
+  // Load weights.
+  FILE *weightsFile = fopen(weightsFileName, "rb");
+  if (!weightsFile) {
+    fprintf(stderr, "Could not open the weights file: %s\n", weightsFileName);
+    exit(1);
+  }
+  fseek(weightsFile, 0, SEEK_END);
+  size_t fileSize = ftell(weightsFile);
+  fseek(weightsFile, 0, SEEK_SET);
+  uint8_t *baseConstantWeightVarsAddr =
+      static_cast<uint8_t *>(alignedAlloc(config, fileSize));
+  printf("Allocated weights of size: %lu\n", fileSize);
+  printf("Expected weights of size: %lu\n", config.constantWeightVarsMemSize);
+  assert(fileSize == config.constantWeightVarsMemSize &&
+         "Wrong weights file size");
+  int result = fread(baseConstantWeightVarsAddr, fileSize, 1, weightsFile);
+  if (result != 1) {
+    perror("Could not read the weights file");
+  } else {
+    printf("Loaded weights of size: %lu from the file %s\n", fileSize,
+           weightsFileName);
+  }
+  fclose(weightsFile);
+  return baseConstantWeightVarsAddr;
+}
+
+/// The assumed layout of the area for mutable WeightVars is:
+/// data | gpu_0/data | results
+static uint8_t *allocateMutableWeightVars(const BundleConfig &config) {
+  auto *weights = static_cast<uint8_t *>(
+      alignedAlloc(config, config.mutableWeightVarsMemSize));
+  printf("Allocated mutable weight variables of size: %lu\n",
+         config.mutableWeightVarsMemSize);
+  return weights;
+}
+
+/// Dump the result of the inference by looking at the results vector and
+/// finding the index of the max element.
+static void dumpInferenceResults(const BundleConfig &config,
+                                 uint8_t *mutableWeightVars) {
+  const SymbolTableEntry &outputWeights = getMutableWeightVar(config, "output");
+  int maxIdx = 0;
+  float maxValue = 0;
+  float *results = (float *)(mutableWeightVars + outputWeights.offset);
+  for (int i = 0; i < outputWeights.size; ++i) {
+    if (results[i] > maxValue) {
+      maxValue = results[i];
+      maxIdx = i;
+    }
+  }
+  printf("Result: %u\n", maxIdx);
+}
+
+/// The assumed layout of the area for mutable WeightVars is:
+/// data | gpu_0/data | results
+static uint8_t *initMutableWeightVars(const BundleConfig &config) {
+  uint8_t *mutableWeightVarsAddr = allocateMutableWeightVars(config);
+  size_t inputDims[4];
+  float *inputT{nullptr};
+  loadImagesAndPreprocess(inputImageFilenames, inputT, inputDims);
+  // Copy image data into the gpu_0/data input variable in the
+  // mutableWeightVars area.
+  size_t imageDataSizeInBytes =
+      inputDims[0] * inputDims[1] * inputDims[2] * inputDims[3] * sizeof(float);
+  printf("Copying image data into mutable weight vars: %lu bytes\n",
+         imageDataSizeInBytes);
+  const SymbolTableEntry &inputGPUDataVar =
+      getMutableWeightVar(config, "gpu_0/data");
+  memcpy(mutableWeightVarsAddr + inputGPUDataVar.offset, inputT,
+         imageDataSizeInBytes);
+  return mutableWeightVarsAddr;
+}
+
+static uint8_t *initActivations(const BundleConfig &config) {
+  return static_cast<uint8_t *>(
+      alignedAlloc(config, config.activationsMemSize));
+}
+
+int main(int argc, char **argv) {
+  parseCommandLineOptions(argc, argv);
+  // Allocate and initialize constant and mutable weights.
+  uint8_t *constantWeightVarsAddr =
+      initConstantWeights("resnet50.weights", resnet50_config);
+  uint8_t *mutableWeightVarsAddr = initMutableWeightVars(resnet50_config);
+  uint8_t *activationsAddr = initActivations(resnet50_config);
+
+  // Perform the computation.
+  resnet50(constantWeightVarsAddr, mutableWeightVarsAddr, activationsAddr);
+
+  // Report the results.
+  dumpInferenceResults(resnet50_config, mutableWeightVarsAddr);
+
+  // Free all resources.
+  free(activationsAddr);
+  free(constantWeightVarsAddr);
+  free(mutableWeightVarsAddr);
+}


### PR DESCRIPTION
resnet50_standalone.cpp is a small wrapper that links with and invokes the bundle auto-generated by means of the loader with the -emit-bundle parameter. All of the logic for images loading is essentially taken from the loader. The bungle itself is serialized into files resnet50.o and resnet50.weights

The standalone bundle can be invoked by using the following command-line:
resnet50_standalone image_file

The commit also provides a step-by-step explanation of the resnet50 example.