### PR TITLE
[Interpreter,CPU] Quantized Top-K instruction in backends

### DIFF
--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -385,6 +385,7 @@ bool CPUBackend::isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const {
     case Kinded::Kind::RescaleQuantizedNodeKind:
     case Kinded::Kind::ReshapeNodeKind:
     case Kinded::Kind::SubNodeKind:
+    case Kinded::Kind::TopKNodeKind:
     case Kinded::Kind::TransposeNodeKind:
       return true;
     default:

--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -1532,12 +1532,11 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
 
   case Kinded::Kind::TopKInstKind: {
     TopKInst *TI = cast<TopKInst>(I);
-
     auto *input = TI->getInput();
     auto *valuesPtr = emitValueAddress(builder, TI->getValues());
     auto *indicesPtr = emitValueAddress(builder, TI->getIndices());
-    auto *scratchPtr = emitValueAddress(builder, TI->getScratch());
     auto *inputPtr = emitValueAddress(builder, input);
+    auto *scratchPtr = emitValueAddress(builder, TI->getScratch());
 
     auto *k = emitConstSizeT(builder, TI->getK());
     auto *n = emitConstSizeT(builder, input->dims().back());
@@ -1545,7 +1544,7 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
 
     auto *F = getFunction("topk", input->getElementType());
     builder.CreateCall(
-        F, {inputPtr, valuesPtr, indicesPtr, scratchPtr, k, n, size});
+        F, {valuesPtr, indicesPtr, inputPtr, scratchPtr, k, n, size});
     break;
   }
 

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -821,9 +821,9 @@ TopKNode *Function::createTopK(llvm::StringRef name, NodeValue input,
   assert(k <= inDims.back());
   ShapeVector outDims(inDims.begin(), inDims.end());
   outDims.back() = k;
+  auto OT = getParent()->uniqueTypeWithNewShape(input.getType(), outDims);
   return addNode(new TopKNode(
-      name, getParent()->uniqueType(input->getElementType(), outDims),
-      getParent()->uniqueType(ElemKind::IndexTy, outDims), input, k));
+      name, OT, getParent()->uniqueType(ElemKind::IndexTy, outDims), input, k));
 }
 
 GatherNode *Function::createGather(llvm::StringRef name, NodeValue data,

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -851,9 +851,14 @@ void RescaleQuantizedNode::verify() const {
 }
 
 void TopKNode::verify() const {
-  assert(getInput().getElementType() == ElemKind::FloatTy);
-  assert(getValues().getElementType() == ElemKind::FloatTy);
   assert(getValues().dims() == getIndices().dims());
+  if (getInput()->getType()->isQuantizedType()) {
+    // Quantization scales must be identical; no rescaling is allowed.
+    assert(getValues()->getType(0)->getScale() ==
+           getInput()->getType()->getScale());
+    assert(getValues()->getType(0)->getOffset() ==
+           getInput()->getType()->getOffset());
+  }
 }
 
 void GatherNode::verify() const {

--- a/lib/IR/IRBuilder.cpp
+++ b/lib/IR/IRBuilder.cpp
@@ -112,12 +112,13 @@ TopKInst *IRBuilder::createTopKOp(Value *input, size_t k) {
   assert(k <= inDims.back());
   ShapeVector outDims(inDims.begin(), inDims.end());
   outDims.back() = k;
+  auto outTy = F_->getGraph()->getParent()->uniqueTypeWithNewShape(
+      input->getType(), outDims);
   // Allocate enough scratch space to hold N values and N indices.
   auto *scratch = createAllocActivationInst("topk.scratch", ElemKind::IndexTy,
                                             {inDims.back() * 2});
   createSplatInst("topk.zero.scratch", scratch, 0);
-  auto *values = createAllocActivationInst("topk.values",
-                                           input->getElementType(), outDims);
+  auto *values = createAllocActivationInst("topk.values", outTy);
   auto *indices =
       createAllocActivationInst("topk.indices", ElemKind::IndexTy, outDims);
   return createTopKInst("topk", values, indices, input, scratch, k);

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -394,8 +394,7 @@ int main(int argc, char **argv) {
       .addOperand("Input", OperandKind::In)
       .addOperand("Scratch", OperandKind::InOut)
       .addMember(MemberType::SizeT, "K")
-      .autoVerify(VerifyKind::SameElementType,
-                  {"Values", "Input", "ElemKind::FloatTy"})
+      .autoVerify(VerifyKind::SameElementType, {"Values", "Input"})
       .autoVerify(VerifyKind::SameShape, {"Values", "Indices"});
 
   //===--------------------------------------------------------------------===//


### PR DESCRIPTION
This commit enables a quantized Top-K instruction for the Interpreter and also implements quantized Top-K for the CPU backend.  (For the Interpreter, this enablement is accomplished by modifying the verifier logic to allow integer inputs while requiring that the input and output quantization scales match.)