### PR TITLE
[libjit] Faster, more robust gemm

### DIFF
--- a/lib/Backends/CPU/libjit.cpp
+++ b/lib/Backends/CPU/libjit.cpp
@@ -27,6 +27,23 @@ typedef float float8 __attribute__((ext_vector_type(8)));
 #define AT(tensor, dims, numDims, indices, numIndices)                         \
   tensor[get_element_ptr(tensor, dims, numDims, indices, numIndices)]
 
+/// Perform an unaligned load of a float8 from a float pointer.
+float8 LoaduFloat8(const float *p) {
+  float8 res;
+  memcpy(&res, p, sizeof(float8));
+  return res;
+}
+
+/// Perform an unaligned store to a float pointer.
+void StoreuFloat8(float *p, float8 v) {
+  memcpy(p, &v, sizeof(float8));
+}
+
+/// Perform an unaligned addition to a float pointer.
+void AdduFloat8(float *p, float8 v) {
+  StoreuFloat8(p, LoaduFloat8(p) + v);
+}
+
 namespace {
 
 /// \returns the index of the element at x,y,z,w,q.
@@ -452,79 +469,118 @@ void libjit_pool_max_xy_generic(const T *inW, T *outW, size_t *inXY,
   }       // N
 }
 
-/// Innermost helper for matrix multiplication.  When inlined, the y dimension
-/// will be vectorized and flattened.
-/// \p lda is the leading dimension(*) of a (i.e., dim[1]).
-/// \p ldb is the leading dimension(*) of b (i.e., dim[1])
-/// \p mBlock, \p nBlock, and \p kBlock are the dimensions of the submatrix.
-///
-/// * The "leading dimension" for a row-major matrix is equal to the number of
-/// columns in the matrix.  For a, this is k; for b and c, this is n.
-static void libjit_matmul_inner_f8(float *c, const float *a, const float *b,
-                                   size_t lda, size_t ldb, size_t mBlock,
-                                   size_t kBlock, size_t nBlock) {
-  for (size_t x = 0; x < mBlock; x++) {
-    float8 sum[8];
-    for (size_t y = 0; y < nBlock / 8; y++) {
-      sum[y] = LoadFloat8(&c[ldb * x + y * 8]);
-    }
-    for (size_t i = 0; i < kBlock; i++) {
-      auto aElt = BroadcastFloat8(a[lda * x + i]);
-      for (size_t y = 0; y < nBlock / 8; y++) {
-        sum[y] += aElt * LoadFloat8(&b[ldb * i + y * 8]);
-      }
-    }
-    for (size_t y = 0; y < nBlock / 8; y++) {
-      StoreFloat8(&c[ldb * x + y * 8], sum[y]);
-    }
-  }
-}
+/// Macros for accessing submatrices of a matmul using the leading dimension.
+#define A(i, j) a[(i)*lda + (j)]
+#define B(i, j) b[(i)*ldb + (j)]
+#define C(i, j) c[(i)*ldc + (j)]
 
-/// Matrix multiply for arbitrary shapes.  Used for skinny matrices (and edges
-/// that don't fit the tiling scheme) that are memory-bound anyways.
-static void libjit_matmul_inner(float *c, const float *a, const float *b,
-                                size_t lda, size_t ldb, size_t mBlock,
-                                size_t kBlock, size_t nBlock) {
-  for (size_t i = 0; i < kBlock; i++) {
-    for (size_t x = 0; x < mBlock; x++) {
-      for (size_t y = 0; y < nBlock; y++) {
-        c[ldb * x + y] += a[lda * x + i] * b[ldb * i + y];
+/// Naive gemm helper to handle oddly-sized matrices.
+void libjit_matmul_odd(int m, int n, int k, const float *a, int lda,
+                       const float *b, int ldb, float *c, int ldc) {
+  for (int p = 0; p < k; p++) {
+    for (int i = 0; i < m; i++) {
+      for (int j = 0; j < n; j++) {
+        C(i, j) += A(i, p) * B(p, j);
       }
     }
   }
 }
 
-/// Tiling helper for matrix multiplication.  Processes multiplications in
-/// blocks, with customizable offset and block size to handle the "ragged
-/// edges".
-static void libjit_matmul_tiled(float *c, const float *a, const float *b,
-                                const size_t *cDims, const size_t *aDims,
-                                const size_t *bDims, size_t mBlock,
-                                size_t kBlock, size_t nBlock) {
-  for (size_t x = 0; x < cDims[0] - mBlock + 1; x += mBlock) {
-    for (size_t y = 0; y < cDims[1] - nBlock + 1; y += nBlock) {
-      for (size_t i = 0; i < aDims[1] - kBlock + 1; i += kBlock) {
-        libjit_matmul_inner_f8(&c[libjit_getXY(cDims, x, y)],
-                               &a[libjit_getXY(aDims, x, i)],
-                               &b[libjit_getXY(bDims, i, y)], aDims[1],
-                               bDims[1], mBlock, kBlock, nBlock);
-      }
+/// Compute a 4x16 block of C using a vectorized dot product.
+void libjit_matmul_dot4x16(int k, const float *a, int lda, const float *b,
+                           int ldb, float *c, int ldc) {
+  float8 ctmp07[4] = {0.0};
+  float8 ctmp815[4] = {0.0};
+  for (int p = 0; p < k; p++) {
+    float8 a0p = BroadcastFloat8(A(0, p));
+    float8 a1p = BroadcastFloat8(A(1, p));
+    float8 a2p = BroadcastFloat8(A(2, p));
+    float8 a3p = BroadcastFloat8(A(3, p));
+    float8 bp0p7 = LoaduFloat8(&B(p, 0));
+    float8 bp8p15 = LoaduFloat8(&B(p, 8));
+    ctmp07[0] += a0p * bp0p7;
+    ctmp07[1] += a1p * bp0p7;
+    ctmp07[2] += a2p * bp0p7;
+    ctmp07[3] += a3p * bp0p7;
+    ctmp815[0] += a0p * bp8p15;
+    ctmp815[1] += a1p * bp8p15;
+    ctmp815[2] += a2p * bp8p15;
+    ctmp815[3] += a3p * bp8p15;
+  }
+  AdduFloat8(&C(0, 0), ctmp07[0]);
+  AdduFloat8(&C(1, 0), ctmp07[1]);
+  AdduFloat8(&C(2, 0), ctmp07[2]);
+  AdduFloat8(&C(3, 0), ctmp07[3]);
+  AdduFloat8(&C(0, 8), ctmp815[0]);
+  AdduFloat8(&C(1, 8), ctmp815[1]);
+  AdduFloat8(&C(2, 8), ctmp815[2]);
+  AdduFloat8(&C(3, 8), ctmp815[3]);
+}
+
+/// Compute a portion of C one 4*16 block at a time.  Handle ragged edges with
+/// calls to a slow but general helper.
+void libjit_matmul_inner(int m, int n, int k, const float *a, int lda,
+                         const float *b, int ldb, float *c, int ldc) { 
+  constexpr int mc = 4;
+  constexpr int nr = 16;
+  // The tiling scheme naturally divides the input matrices into 2 parts each;
+  // one tiled section, and three "ragged" edges.
+  //
+  // --------------------    -------
+  // | A00*B00 | A00*B01|    | A00 |   -------------
+  // -------------------- += ------- * | B00 | B01 |
+  // | A10*B00 | A10*B01|    | A10 |   -------------
+  // --------------------    -------
+  //
+  // We can process this as 4 separate matrix multiplications.  A00*B00 is the
+  // perfectly-tiled portion, which we handly with a 4x16 dot-product kernel.
+  // The ragged edges are (ideally) less critical, so we handle them with a call
+  // to a general matrix-multiplication for odd sizes.
+  for (int j = 0; j < n - nr + 1; j += nr) {
+    for (int i = 0; i < m - mc + 1; i += mc) {
+      libjit_matmul_dot4x16(k, &A(i, 0), lda, &B(0, j), ldb, &C(i, j), ldc);
+    }
+  }
+  int i = (m / mc) * mc;
+  int j = (n / nr) * nr;
+  if (i < m) {
+    libjit_matmul_odd(m - i, j, k, &A(i, 0), lda, &B(0, 0), ldb, &C(i, 0), ldc);
+  }
+  if (j < n) {
+    libjit_matmul_odd(i, n - j, k, &A(0, 0), lda, &B(0, j), ldb, &C(0, j), ldc);
+  }
+  if (i < m && j < n) {
+    libjit_matmul_odd(m - i, n - j, k, &A(i, 0), lda, &B(0, j), ldb, &C(i, j),
+                      ldc);
+  }
+}
+
+/// Tile A into mc * kc blocks, where mc and kc are chosen to approximately fit
+/// the L2 cache on recent Intel processors (e.g., 256 KB for Skylake).  Stream
+/// kc * n panels of B through memory to compute each mc * n block of C.
+/// \p a is an \p m x \p k row-major matrix;
+/// \p b is a \p k x \p n row-major matrix;
+/// \p c is a \p m x \p n row-major matrix.
+/// \p lda, \p ldb, and \p ldc are the leading dimensions of A, B, and C,
+/// respectively.
+void libjit_matmul_outer(int m, int n, int k, const float *a, int lda,
+                         const float *b, int ldb, float *c, int ldc) {
+  // TODO: Generalize these parameters for other cache sizes.
+  constexpr int mc = 256;
+  constexpr int kc = 128;
+  for (int p = 0; p < k; p += kc) {
+    int pb = MIN(k - p, kc);
+    for (int i = 0; i < m; i += mc) {
+      int ib = MIN(m - i, mc);
+      libjit_matmul_inner(ib, n, pb, &A(i, p), lda, &B(p, 0), ldb, &C(i, 0),
+                          ldc);
     }
   }
 }
 
-/// Helper struct for matrix partitioning.
-/// \p tile is the part of the matrix that is evenly divisible by the tiling
-/// scheme.
-/// \p edge is simply the input matrix dimension.
-struct part {
-  size_t tile;
-  size_t edge;
-};
-
-/// Helper for matrix partitioning: partition a matrix dimension of size \p p
-/// into blocks of size \p q.
-part partition(size_t p, size_t q) { return {p / q * q, p}; }
+#undef C
+#undef B
+#undef A
 
 } // namespace
 
@@ -649,59 +705,16 @@ void libjit_broadcast_f(float *dest, const float *src, const size_t *dest_dims,
 void libjit_matmul_f(float *c, const float *a, const float *b,
                      const size_t *cDims, const size_t *aDims,
                      const size_t *bDims) {
-  // Blocks are chosen to vectorize well on Intel Skylake CPUs.
-  // TODO: Generalize this.
-  static constexpr size_t mBlock = 32;
-  static constexpr size_t kBlock = 32;
-  static constexpr size_t nBlock = 64;
-  memset(c, 0, sizeof(float) * cDims[0] * cDims[1]);
-
-  // Parition each dimension into a tile that is a multiple of the block size,
-  // and an "edge" that consists of the remaining un-tiled part.
-  auto m = partition(cDims[0], mBlock);
-  auto n = partition(cDims[1], nBlock);
-  auto k = partition(aDims[1], kBlock);
-
-  // The tiling scheme naturally divides the input matrices into 4 parts each;
-  // one tiled section, and three "ragged" edges:
+  memset(c, 0, cDims[0] * cDims[1] * sizeof(float));
+  // Call the matrix multiplication routine with appropriate dimensions and
+  // leading dimensions. The "leading dimension" for a row-major matrix is equal
+  // to the number of columns in the matrix.  For a, this is k; for b and c,
+  // this is n.
   //
-  // -------------   -------------
-  // | A00 | A01 |   | B00 | B01 |
-  // ------------- * -------------
-  // | A10 | A11 |   | B10 | B11 |
-  // -------------   -------------
-  //
-  // We can process this as 8 separate matrix multiplications.  A00 is the tiled
-  // portion that is compute-bound.  The remaining multiplies are more like gemv
-  // operations that we handle with a straightforward implementation.
-
-  // This helper lambda determines if a ragged edge exists, and processes it.
-  // *Off parameters are offsets into the input matrices, and *Upper is the
-  // matrix size in that dimension.
-  auto mul = [=](size_t mOff, size_t mUpper, size_t kOff, size_t kUpper,
-                 size_t nOff, size_t nUpper) {
-    if (mOff == mUpper || kOff == kUpper || nOff == nUpper) {
-      return;
-    }
-    libjit_matmul_inner(&c[libjit_getXY(cDims, mOff, nOff)],
-                        &a[libjit_getXY(aDims, mOff, kOff)],
-                        &b[libjit_getXY(bDims, kOff, nOff)], aDims[1], bDims[1],
-                        mUpper - mOff, kUpper - kOff, nUpper - nOff);
-  };
-
-  if (m.tile && n.tile && k.tile) {
-    libjit_matmul_tiled(c, a, b, cDims, aDims, bDims, mBlock, kBlock, nBlock);
-  }
-
-  // Process the ragged edges.
-  mul(0, m.tile, 0, k.tile, n.tile, n.edge);
-  mul(0, m.tile, k.tile, k.edge, 0, n.tile);
-  mul(0, m.tile, k.tile, k.edge, n.tile, n.edge);
-
-  mul(m.tile, m.edge, 0, k.tile, 0, n.tile);
-  mul(m.tile, m.edge, 0, k.tile, n.tile, n.edge);
-  mul(m.tile, m.edge, k.tile, k.edge, 0, n.tile);
-  mul(m.tile, m.edge, k.tile, k.edge, n.tile, n.edge);
+  // The matrix multiplication routine is heavily inspired by:
+  // https://github.com/flame/how-to-optimize-gemm
+  libjit_matmul_outer(cDims[0], cDims[1], aDims[1], a, aDims[1], b, bDims[1], c,
+                      cDims[1]);
 }
 
 void libjit_matmul_i8(int8_t *outW, const int8_t *lhsW, const int8_t *rhsW,


### PR DESCRIPTION
I've learned a lot about gemm over the past week, particularly from https://github.com/flame/how-to-optimize-gemm.  I've redesigned my approach from last week to use a different approach for register blocking (computing a 4x16 block of C using a 4xk * kx16 dot product), and introduced a layer of L2 cache blocking.  I've also cleaned up the interfaces a bit by using the ld{a,b,c} notation consistently and using macros (as in the FLAME wiki), which makes the code more intelligible.

This approach gets much more consistently high performance on a range of matrix sizes (the previous approach was very rigid about needing multiples of 32x64 blocks).  As an example, the big vector-matrix multiply in resnet50 is about 3x faster.  (That doesn't make any overall difference in resnet since that gemm isn't significant - but it does show where this approach is stronger).