### PR TITLE
[Interpreter,CPU] Implement quantized CmpLTE operator in Interpreter and CPU backends

### DIFF
--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -369,6 +369,7 @@ bool CPUBackend::isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const {
     switch (opKind) {
     case Kinded::Kind::AddNodeKind:
     case Kinded::Kind::BatchedAddNodeKind:
+    case Kinded::Kind::CmpLTENodeKind:
     case Kinded::Kind::ConcatNodeKind:
     case Kinded::Kind::ConvolutionNodeKind:
     case Kinded::Kind::DequantizeNodeKind:

--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -505,6 +505,16 @@ DEFINE_DATA_PARALLEL_KERNEL_QUANTIZED(libjit_elementmin_kernel_i8, int8_t,
                                       MIN(lhs, rhs))
 DEFINE_DATA_PARALLEL_KERNEL_QUANTIZED_M(libjit_element_mul_kernel_i8, lhs *rhs)
 DEFINE_DATA_PARALLEL_KERNEL_QUANTIZED_M(libjit_element_div_kernel_i8, lhs / rhs)
+
+int8_t libjit_element_cmp_lte_kernel_i8(size_t idx, const int8_t *LHS,
+                                        const int8_t *RHS, int32_t lhsOffset,
+                                        int32_t rhsOffset, int32_t pre,
+                                        int32_t post, int32_t scale) {
+  int32_t lhs = LHS[idx] - lhsOffset;
+  int32_t rhs = RHS[idx] - rhsOffset;
+  return libjit_scale_i32i8(lhs, pre, post, scale, 0) <= rhs ? 1 : 0;
+}
+
 // tanh cannot be vectorized by LLVM yet. Therefore we use the following
 // formula instead: 1 - 2 / (exp(x * 2) + 1), which is also used by Caffe2 and
 // provides a good accuracy.

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -775,8 +775,16 @@ VERIFY_ARITHMETIC(Sub);
 VERIFY_ARITHMETIC(Div);
 VERIFY_ARITHMETIC(Max);
 VERIFY_ARITHMETIC(Min);
-VERIFY_ARITHMETIC(CmpLTE);
 #undef VERIFY_ARITHMETIC
+
+void CmpLTENode::verify() const {
+  verifyArithmetic(getLHS(), getRHS(), getResult());
+  if (getResult()->getType()->isQuantizedType()) {
+    // Quantization scale params for result must be (1.0, 0).
+    assert(getResult()->getType()->getScale() == 1.0);
+    assert(getResult()->getType()->getOffset() == 0);
+  }
+}
 
 #define VERIFY_ARITHMETIC(NODE_NAME_)                                          \
   void NODE_NAME_##Node::verify() const {                                      \


### PR DESCRIPTION
This commit implements quantized less-than-or-equal-to comparison in both the Interpreter and CPU backends.  It also adds an associated operator test.