### PR TITLE
[quantization] Fix graph optimization for rescale/splat case.

### DIFF
--- a/lib/Backends/CPU/Transforms.cpp
+++ b/lib/Backends/CPU/Transforms.cpp
@@ -78,6 +78,11 @@ bool CPUBackend::transformPostLowering(Function *F) {
     }
     if (auto *MN = dyn_cast<MaxNode>(node)) {
       if (auto *splat = dyn_cast<SplatNode>(MN->getLHS())) {
+        // TODO: support efficient max quantized splat.
+        if (splat->getResult().getType()->isQuantizedType()) {
+          continue;
+        }
+
         auto MSN = F->addNode(new CPUMaxSplatNode(MN->getName(), MN->getRHS(),
                                                   splat->getValue()));
         NodeValue(node, 0).replaceAllUsesOfWith(MSN);
@@ -85,6 +90,11 @@ bool CPUBackend::transformPostLowering(Function *F) {
         continue;
       }
       if (auto *splat = dyn_cast<SplatNode>(MN->getRHS())) {
+        // TODO: support efficient max quantized splat.
+        if (splat->getResult().getType()->isQuantizedType()) {
+          continue;
+        }
+
         auto MSN = F->addNode(new CPUMaxSplatNode(MN->getName(), MN->getLHS(),
                                                   splat->getValue()));
         NodeValue(node, 0).replaceAllUsesOfWith(MSN);

--- a/lib/Backends/CPU/libjit.cpp
+++ b/lib/Backends/CPU/libjit.cpp
@@ -788,8 +788,8 @@ void libjit_convDKKC8_f(float *outW, const float *inW, const float *filterW,
                     filterW, biasW, outWdims, inWdims, filterWdims, biasWdims,
                     filterSize, stride, pad);
 
-      } // For each D (the depth, or the output channel).
-  }     // For each N, the sample in the batch.
+    } // For each D (the depth, or the output channel).
+  }   // For each N, the sample in the batch.
 }
 
 void libjit_convolution_f(float *outW, const float *inW, const float *filterW,

--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -738,10 +738,8 @@ static void optimizeQuantization(Function *F) {
       // Merge splat and rescale nodes.
       // Rescale(Splat()) -> Splat()
       if (auto *SP = dyn_cast<SplatNode>(RS->getInput())) {
-        auto destTy = RS->getType();
-        TensorQuantizationParams destQ{destTy->getScale(), destTy->getOffset()};
-        int8_t val = quantization::quantize(SP->getValue(), destQ);
-        auto *newRS = F->createSplat(SP->getName(), RS->getType(), val);
+        auto *newRS =
+            F->createSplat(SP->getName(), RS->getType(), SP->getValue());
 
         worklist.push_back(newRS);
         RS->getResult().replaceAllUsesOfWith(newRS);

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -327,7 +327,9 @@ int main(int argc, char **argv) {
   BB.newNode("Splat")
       .addMember(MemberType::Float, "Value")
       .addResultFromCtorArg()
-      .setDocstring("Generate a tensor of a specific type filled with 'Value'");
+      .setDocstring("Generate a tensor of a specific type filled with 'Value'."
+                    "Splat always keep floating point value internally but can"
+                    "quantize it based on the output type.");
 
   BB.newNode("SGD")
       .addInput("Gradient")


### PR DESCRIPTION
1) Splat semantics such that it holds floating value and output could be of any type (int8, float).
Graph optimizer attempted to store the rescaled value in case of rescales which broke the semantics.
New rescale parameters need only be reflected in the Splat output type.

2) Fix the implementation of splat for the `CPU/JIT`. Fix the discrepancy between CPU and Interpreter.
