### PR TITLE
[cleanup] Remove depth parameter from ConvolutionNode.

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -164,8 +164,8 @@ public:
 
   ConvolutionNode *createConv(llvm::StringRef name, NodeValue input,
                               NodeValue filter, NodeValue bias, TypeRef outTy,
-                              size_t depth, size_t kernel, size_t stride,
-                              size_t pad, size_t group);
+                              size_t kernel, size_t stride, size_t pad,
+                              size_t group);
 
   PoolMaxNode *createPoolMax(llvm::StringRef name, NodeValue input,
                              size_t kernel, size_t stride, size_t pad);

--- a/lib/Backends/CPU/Transforms.cpp
+++ b/lib/Backends/CPU/Transforms.cpp
@@ -18,7 +18,7 @@ using llvm::isa;
 /// pre-swizzle the data in the weights to make the access pattern more
 /// efficient.
 static Node *optimizeCPUConv(ConvolutionNode *CN, Function *F) {
-  auto depth = CN->getDepth();
+  auto depth = CN->getFilter().dims()[0];
   auto *M = F->getParent();
 
   // The depth dimension must be a multiple of 64 to perform the
@@ -62,7 +62,7 @@ static Node *optimizeCPUConv(ConvolutionNode *CN, Function *F) {
 
   return F->addNode(new CPUConvDKKC8Node(
       CN->getName(), CN->getType(), CN->getInput(), filter8, CN->getBias(),
-      CN->getKernel(), CN->getStride(), CN->getPad(), CN->getDepth()));
+      CN->getKernel(), CN->getStride(), CN->getPad()));
 }
 
 bool CPUBackend::transformPostLowering(Function *F) {

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -431,11 +431,9 @@ void OCLBackend::doForwardPass() {
       setKernelArg(kernel, 9, idim);
       setKernelArg(kernel, 10, ShapeNHWC(CC->getFilter()->getType()->dims()));
 
-      auto depth = CC->getDepth();
-
       // Use a 3D grid where the first dimension is the depth and the second
       // dimension is the slice index in the batch.
-      enqueueKernel(commands_, kernel, deviceId_, {odim.h, odim.w, depth},
+      enqueueKernel(commands_, kernel, deviceId_, {odim.h, odim.w, odim.c},
                     kernelLaunches);
       continue;
     }

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -488,7 +488,7 @@ static void checkType(NodeValue A, ElemKind expectedType) {
 
 static void verifyConvolution(NodeValue src, NodeValue dest, NodeValue filter,
                               NodeValue bias, size_t kernel, size_t stride,
-                              size_t pad, size_t depth, size_t group) {
+                              size_t pad, size_t group) {
   assert(src.getElementType() == dest.getElementType() && "Invalid Type");
   assert(src.getElementType() == filter.getElementType() && "Invalid Type");
   assert(src.getElementType() == bias.getElementType() && "Invalid Type");
@@ -501,15 +501,14 @@ static void verifyConvolution(NodeValue src, NodeValue dest, NodeValue filter,
   assert(idim.c % group == 0 && "channels number must be divisible by groups");
 
   auto outSz = calculateConvOutputDims(idim.h, idim.w, kernel, stride, pad);
-  ShapeNHWC exp(idim.n, outSz.first, outSz.second, depth * group);
-  (void)exp;
-  assert(exp == odim && "Invalid output dimensions");
+  assert(odim.n == idim.n && odim.h == outSz.first && odim.w == outSz.second &&
+         odim.c % group == 0 && "Invalid output dimensions");
 
-  auto filterDims = {depth * group, kernel, kernel, idim.c / group};
+  auto filterDims = {odim.c, kernel, kernel, idim.c / group};
   assert(filter.getType()->dims().equals(filterDims) && "Invalid filter dims");
   (void)filterDims;
 
-  auto biasDims = {depth * group};
+  auto biasDims = {odim.c};
   assert(bias.getType()->dims().equals(biasDims) && "Invalid bias dims");
   (void)biasDims;
 }
@@ -596,14 +595,14 @@ static void verifyRegression(NodeValue src, NodeValue dest,
 
 void ConvolutionNode::verify() const {
   verifyConvolution(getInput(), getResult(), getFilter(), getBias(), Kernel_,
-                    Stride_, Pad_, Depth_, Group_);
+                    Stride_, Pad_, Group_);
 }
 
 void ConvolutionGradNode::verify() const {
   verifyConvolution(getGradOfInputNamedInput(),
                     getGradOfOriginalOutputNamedResult(),
                     getGradOfInputNamedFilter(), getGradOfInputNamedBias(),
-                    Kernel_, Stride_, Pad_, Depth_, Group_);
+                    Kernel_, Stride_, Pad_, Group_);
 }
 
 void PoolMaxNode::verify() const {

--- a/lib/IR/IRGen.cpp
+++ b/lib/IR/IRGen.cpp
@@ -115,10 +115,9 @@ public:
       auto *filterG = builder_.createAllocActivationInst("conv.filter.G",
                                                          filter->getType());
 
-      builder_.createConvolutionGradInst(N->getName(), input, filter, outGrad,
-                                         inG, filterG, biasG, CG->getKernel(),
-                                         CG->getStride(), CG->getPad(),
-                                         CG->getDepth(), CG->getGroup());
+      builder_.createConvolutionGradInst(
+          N->getName(), input, filter, outGrad, inG, filterG, biasG,
+          CG->getKernel(), CG->getStride(), CG->getPad(), CG->getGroup());
 
       registerIR(CG->getGradOfInputNamedInput(), inG);
       registerIR(CG->getGradOfInputNamedFilter(), filterG);

--- a/lib/Importer/Caffe2.cpp
+++ b/lib/Importer/Caffe2.cpp
@@ -218,8 +218,8 @@ void caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
         {idim.n, outSz.first, outSz.second, depth}};
     auto outTy = G_.getParent()->uniqueType(ElemKind::FloatTy, outDims);
 
-    auto *node = G_.createConv(opName, tr, filter, bias, outTy, depth / group,
-                               kernel, stride, pad, group);
+    auto *node = G_.createConv(opName, tr, filter, bias, outTy, kernel, stride,
+                               pad, group);
 
     // Transpose the output back.
     auto *N = G_.createTranspose(opName, node, NHWC2NCHW);

--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -762,10 +762,10 @@ static void optimizeQuantization(Function *F) {
       if (auto *CN = dyn_cast<ConvolutionNode>(RS->getInput())) {
         // Create the exact same convolution but with a different scaling
         // return type.
-        auto *newCN = F->createConv(
-            CN->getName(), CN->getInput(), CN->getFilter(), CN->getBias(),
-            RS->getType(), CN->getDepth(), CN->getKernel(), CN->getStride(),
-            CN->getPad(), CN->getGroup());
+        auto *newCN =
+            F->createConv(CN->getName(), CN->getInput(), CN->getFilter(),
+                          CN->getBias(), RS->getType(), CN->getKernel(),
+                          CN->getStride(), CN->getPad(), CN->getGroup());
         RS->getResult().replaceAllUsesOfWith(newCN);
         continue;
       }

--- a/lib/Optimizer/Lower.cpp
+++ b/lib/Optimizer/Lower.cpp
@@ -504,9 +504,8 @@ void lowerGroupConvolutionNode(Function *F, ConvolutionNode &BNG) {
                        {(groupId + 1) * outCperG, kernel, kernel, inCperG});
     auto *bias_slice = F->createSlice(BNG.getName(), bias, {groupId * outCperG},
                                       {(groupId + 1) * outCperG});
-    convs[groupId] =
-        F->createConv(BNG.getName(), in_slice, filter_slice, bias_slice, outTy,
-                      outCperG, kernel, stride, pad, 1);
+    convs[groupId] = F->createConv(BNG.getName(), in_slice, filter_slice,
+                                   bias_slice, outTy, kernel, stride, pad, 1);
   }
   auto result = F->createConcat(BNG.getName(), convs, 3);
   BNG.getResult().replaceAllUsesOfWith(result);

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -322,10 +322,10 @@ void generateQuantizedGraph(
         auto QT = F->getParent()->uniqueType(ElemKind::Int8QTy,
                                              CV->getResult()->dims(),
                                              TQP.scale_, TQP.offset_);
-        quantizedNode = F->createConv(
-            CV->getName(), quantizedInputs[0], quantizedInputs[1],
-            quantizedInputs[2], QT, CV->getDepth(), CV->getKernel(),
-            CV->getStride(), CV->getPad(), CV->getGroup());
+        quantizedNode =
+            F->createConv(CV->getName(), quantizedInputs[0], quantizedInputs[1],
+                          quantizedInputs[2], QT, CV->getKernel(),
+                          CV->getStride(), CV->getPad(), CV->getGroup());
         break;
       }
       case Kinded::Kind::SliceNodeKind: {

--- a/tests/unittests/BackendTestUtils.cpp
+++ b/tests/unittests/BackendTestUtils.cpp
@@ -104,7 +104,7 @@ void inferConvNet(Tensor *inputs, Tensor *filter, Tensor *bias, Tensor *out,
     OT = F->getParent()->uniqueType(out->getElementType(), out->dims());
   }
   auto *conv =
-      F->createConv("conv", inputVar, filterVar, biasVar, OT, 10, 5, 3, 4, 1);
+      F->createConv("conv", inputVar, filterVar, biasVar, OT, 5, 3, 4, 1);
   auto result = F->createSave("ret", conv, outVar);
   EE.compile(CompilationMode::Infer, F);
   EE.run({inputVar, filterVar, biasVar}, {inputs, filter, bias});

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -502,8 +502,8 @@ void checkIntConvolution(ExecutionEngine &EE, unsigned convDepth) {
   auto *biasq = F->createQuantize("bias.q", bias, biasTy);
 
   auto *convq =
-      F->createConv("convq", inputq, filterq, biasq, resTy, conv->getDepth(),
-                    conv->getKernel(), conv->getStride(), conv->getPad(), 1);
+      F->createConv("convq", inputq, filterq, biasq, resTy, conv->getKernel(),
+                    conv->getStride(), conv->getPad(), 1);
   auto *dequantRes = F->createDequantize("dequant", convq);
 
   // Subtract the results of the convolution from the quantized convolution.

--- a/tests/unittests/basicIRTest.cpp
+++ b/tests/unittests/basicIRTest.cpp
@@ -115,7 +115,7 @@ TEST(IR, allInstrs) {
     XY->setName("srcXY");
 
     builder.createCopyInst("", I1, I0);
-    builder.createConvolutionInst("", I3, I1, F0, B0, 7, 2, 3, 64, 1);
+    builder.createConvolutionInst("", I3, I1, F0, B0, 7, 2, 3, 1);
     builder.createPoolMaxInst("", I4, I0, 7, 2, 3);
     builder.createSigmoidInst("", I1, I0);
     builder.createTanhInst("", I1, I0);

--- a/tests/unittests/graphTest.cpp
+++ b/tests/unittests/graphTest.cpp
@@ -123,8 +123,8 @@ TEST(Graph, simpleQuant) {
   std::array<size_t, 4> outDims = {{1, outSz.first, outSz.second, 16}};
   auto t = F->getParent()->uniqueType(glow::ElemKind::Int8QTy, outDims, 1.5, 6);
 
-  auto *conv = F->createConv("conv", input, filter, bias, t, depth, kernel,
-                             step, pad, 1);
+  auto *conv =
+      F->createConv("conv", input, filter, bias, t, kernel, step, pad, 1);
 
   auto s = conv->getType()->size();
   auto *fcFilter = MD.createVariable(ElemKind::Int8QTy, {s, 6}, 0.4, 2, "F");

--- a/tools/ClassGen/Backends/CPU/CPUSpecificInstrs.h
+++ b/tools/ClassGen/Backends/CPU/CPUSpecificInstrs.h
@@ -16,7 +16,6 @@ BB.newBackendSpecificInstr("CPUConvDKKC8")
     .addMember(MemberType::SizeT, "Kernel")
     .addMember(MemberType::SizeT, "Stride")
     .addMember(MemberType::SizeT, "Pad")
-    .addMember(MemberType::SizeT, "Depth")
     .autoIRGen()
     .autoVerify(VerifyKind::SameElementType, {"Dest", "Src", "Filter", "Bias"});
 

--- a/tools/ClassGen/Backends/CPU/CPUSpecificNodes.h
+++ b/tools/ClassGen/Backends/CPU/CPUSpecificNodes.h
@@ -13,7 +13,6 @@ BB.newNode("CPUConvDKKC8")
     .addMember(MemberType::SizeT, "Kernel")
     .addMember(MemberType::SizeT, "Stride")
     .addMember(MemberType::SizeT, "Pad")
-    .addMember(MemberType::SizeT, "Depth")
     .addResultFromCtorArg()
     .setDocstring("This is a cpu-specific convolution implementation where the "
                   "filter is transposed to the shape [D/8, K, K, C, 8]");

--- a/tools/ClassGen/Backends/CPU/CPUSpecificNodesVerification.h
+++ b/tools/ClassGen/Backends/CPU/CPUSpecificNodesVerification.h
@@ -10,7 +10,7 @@ void CPUConvDKKC8Node::verify() const {
   ShapeNHWC odim(getResult().getType()->dims());
   auto outSz = calculateConvOutputDims(idim.h, idim.w, getKernel(), getStride(),
                                        getPad());
-  ShapeNHWC exp(idim.n, outSz.first, outSz.second, getDepth());
+  ShapeNHWC exp(idim.n, outSz.first, outSz.second, getBias().dims()[0]);
   (void)exp;
   assert(exp == odim && "Invalid output dimensions");
 }

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -69,7 +69,6 @@ int main(int argc, char **argv) {
       .addMember(MemberType::SizeT, "Kernel")
       .addMember(MemberType::SizeT, "Stride")
       .addMember(MemberType::SizeT, "Pad")
-      .addMember(MemberType::SizeT, "Depth")
       .addMember(MemberType::SizeT, "Group")
       .autoIRGen()
       .autoVerify(VerifyKind::SameElementType,

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -49,13 +49,12 @@ int main(int argc, char **argv) {
       .addMember(MemberType::SizeT, "Kernel")
       .addMember(MemberType::SizeT, "Stride")
       .addMember(MemberType::SizeT, "Pad")
-      .addMember(MemberType::SizeT, "Depth")
       .addMember(MemberType::SizeT, "Group")
       .addResultFromCtorArg()
       .addGradient()
       .setDocstring("Performs Convolution using a given Input, Filter, and "
                     "Bias tensors, as well as provided Kernel, Stride, Pad, "
-                    "Depth and Group.");
+                    "and Group.");
 
   BB.newNode("PoolMax")
       .addInput("Input")


### PR DESCRIPTION
NFC.
Depth parameter is not coming from ONNX or Caffe2 proto. We set it ourselves, then assert it, verify it, then don't use it in backends. It's essentially odim.c (or filterDims[0] or biasDims[0])