### PR TITLE
[Interpreter,CPU] Quantized BatchedReduceAdd instruction in backends

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -284,6 +284,9 @@ public:
   BatchedReduceAddNode *createBatchedReduceAdd(llvm::StringRef name,
                                                NodeValue batch);
 
+  BatchedReduceAddNode *createBatchedReduceAdd(llvm::StringRef name,
+                                               TypeRef outTy, NodeValue batch);
+
   BatchedAddNode *createBatchedAdd(llvm::StringRef name, NodeValue batch,
                                    NodeValue sample);
 

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -369,6 +369,7 @@ bool CPUBackend::isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const {
     switch (opKind) {
     case Kinded::Kind::AddNodeKind:
     case Kinded::Kind::BatchedAddNodeKind:
+    case Kinded::Kind::BatchedReduceAddNodeKind:
     case Kinded::Kind::CmpLTENodeKind:
     case Kinded::Kind::ConcatNodeKind:
     case Kinded::Kind::ConvolutionNodeKind:

--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -615,6 +615,22 @@ void libjit_batchedreduceadd_f(float *dest, const float *batch, size_t destSize,
   }
 }
 
+void libjit_batchedreduceadd_i8(int8_t *dest, const int8_t *batch,
+                                size_t destSize, size_t numSlice,
+                                size_t sliceSize, int32_t destOffset,
+                                int32_t batchOffset, int32_t batchPre,
+                                int32_t batchPost, int32_t batchScale) {
+  for (size_t i = 0; i < sliceSize; i++) {
+    int32_t sum = 0;
+    for (size_t n = 0; n < numSlice; n++) {
+      sum += batch[n * sliceSize + i] - batchOffset;
+    }
+    int32_t q =
+        libjit_scale_i32i8(sum, batchPre, batchPost, batchScale, destOffset);
+    dest[i] = libjit_clip(q);
+  }
+}
+
 void libjit_gather_f(float *dest, const float *data, const size_t *indices,
                      size_t numIndices, size_t sliceSize) {
   libjit_gather(dest, data, indices, numIndices, sliceSize);

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -95,6 +95,7 @@ bool Interpreter::isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const {
   if (elementTy == ElemKind::Int8QTy) {
     switch (opKind) {
     case Kinded::Kind::AddNodeKind:
+    case Kinded::Kind::BatchedReduceAddNodeKind:
     case Kinded::Kind::ConcatNodeKind:
     case Kinded::Kind::ConvolutionNodeKind:
     case Kinded::Kind::DequantizeNodeKind:

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -798,11 +798,19 @@ MatMulNode *Function::createMatMul(llvm::StringRef name, NodeValue lhs,
 }
 
 BatchedReduceAddNode *Function::createBatchedReduceAdd(llvm::StringRef name,
+                                                       TypeRef outTy,
+                                                       NodeValue batch) {
+  assert(outTy->size() == flattenCdr(batch.dims()).second);
+  auto OT = getParent()->uniqueType(*outTy);
+  return addNode(new BatchedReduceAddNode(name, OT, batch));
+}
+
+BatchedReduceAddNode *Function::createBatchedReduceAdd(llvm::StringRef name,
                                                        NodeValue batch) {
   auto BT = batch.getType();
-  auto RT = Type(BT->getElementType(), BT->dims().drop_front());
-  return addNode(
-      new BatchedReduceAddNode(name, getParent()->uniqueType(RT), batch));
+  auto OT =
+      getParent()->uniqueType(BT->getElementType(), BT->dims().drop_front());
+  return createBatchedReduceAdd(name, OT, batch);
 }
 
 BatchedAddNode *Function::createBatchedAdd(llvm::StringRef name,

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -810,6 +810,8 @@ void BatchedAddNode::verify() const {
 }
 
 void BatchedReduceAddNode::verify() const {
+  assert(getResult().getElementType() == getBatch().getElementType() &&
+         "Mismatched element types");
   assert(getBatch().dims().size() > 1 && "Invalid shape");
 }
 


### PR DESCRIPTION
This commit implements the quantized version of the BatchedReduceAdd instruction in the Interpreter and CPU backends.  It also adds an associated test.