### PR TITLE
[nfc] Add size, getSizeInBytes to Typed API

### DIFF
--- a/include/glow/Base/Traits.h
+++ b/include/glow/Base/Traits.h
@@ -37,6 +37,10 @@ public:
 
   llvm::ArrayRef<size_t> dims() const { return Ty_->dims(); }
 
+  size_t size() const { return Ty_->size(); }
+
+  size_t getSizeInBytes() const { return Ty_->getSizeInBytes(); }
+
   ElemKind getElementType() const { return Ty_->getElementType(); }
 
   bool isType(TypeRef T) { return Ty_ == T; }

--- a/lib/Backends/CPU/AllocationsInfo.cpp
+++ b/lib/Backends/CPU/AllocationsInfo.cpp
@@ -30,7 +30,7 @@ void AllocationsInfo::allocateWeightVars(IRFunction *F, bool reuseAddresses) {
     auto *w = cast<WeightVar>(F->getWeightForNode(v));
     if (v->getVisibilityKind() == Variable::VisibilityKind::Public)
       continue;
-    auto numBytes = w->getType()->getSizeInBytes();
+    auto numBytes = w->getSizeInBytes();
     size_t addr = constantWeightVarsAllocator.allocate(numBytes);
     if (!reuseAddresses) {
       allocatedAddressed_[w] = addr;
@@ -47,7 +47,7 @@ void AllocationsInfo::allocateWeightVars(IRFunction *F, bool reuseAddresses) {
     auto *w = cast<WeightVar>(F->getWeightForNode(v));
     if (v->getVisibilityKind() != Variable::VisibilityKind::Public)
       continue;
-    auto numBytes = w->getType()->getSizeInBytes();
+    auto numBytes = w->getSizeInBytes();
     size_t addr = mutableWeightVarsAllocator.allocate(numBytes);
     if (!reuseAddresses) {
       allocatedAddressed_[w] = addr;
@@ -73,10 +73,9 @@ void AllocationsInfo::allocateWeightVars(IRFunction *F, bool reuseAddresses) {
             ? "constant weight"
             : "mutable weight";
     llvm::errs() << "Allocated " << kind << " " << A.first->getName()
-                 << " size: " << A.first->getType()->getSizeInBytes()
+                 << " size: " << A.first->getSizeInBytes()
                  << "  address range:  [" << allocatedAddressed_[origin] << ", "
-                 << allocatedAddressed_[origin] +
-                        A.first->getType()->getSizeInBytes()
+                 << allocatedAddressed_[origin] + A.first->getSizeInBytes()
                  << "]\n";
   });
 }
@@ -92,7 +91,7 @@ void AllocationsInfo::allocateActivations(IRFunction *F) {
   // Assign device-space addresses to the activations.
   for (auto &I : F->getInstrs()) {
     if (auto *A = dyn_cast<AllocActivationInst>(I)) {
-      auto numBytes = I->getType()->getSizeInBytes();
+      auto numBytes = I->getSizeInBytes();
       size_t addr = activationsAllocator.allocate(numBytes);
       assert(!activationAddr.count(A) && "Allocation already made!");
       activationAddr[A] = addr;
@@ -116,11 +115,10 @@ void AllocationsInfo::allocateActivations(IRFunction *F) {
   DEBUG(for (auto &A
              : allocatedAddressed_) {
     llvm::errs() << "Allocated activation " << A.first->getName()
-                 << " size: " << A.first->getType()->getSizeInBytes()
+                 << " size: " << A.first->getSizeInBytes()
                  << "  address range:  ["
                  << allocatedAddressed_[getOrigin(A.first)] << ", "
-                 << allocatedAddressed_[A.first] +
-                        A.first->getType()->getSizeInBytes()
+                 << allocatedAddressed_[A.first] + A.first->getSizeInBytes()
                  << "]\n";
   });
 }

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -150,7 +150,7 @@ void CPUBackend::saveWeights(llvm::StringRef weightsFileName) {
     auto *w = cast<WeightVar>(F_->getWeightForNode(v));
     if (v->getVisibilityKind() == Variable::VisibilityKind::Public)
       continue;
-    auto numBytes = w->getType()->getSizeInBytes();
+    auto numBytes = w->getSizeInBytes();
     auto payload = v->getPayload().getUnsafePtr();
     auto addr = allocationsInfo_.allocatedAddressed_[getOrigin(w)];
     if (addr < pos) {

--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -347,7 +347,7 @@ llvm::Value *LLVMIRGen::emitValueDims(llvm::IRBuilder<> &builder,
 
 llvm::Value *LLVMIRGen::emitValueSize(llvm::IRBuilder<> &builder,
                                       glow::Value *val) {
-  return builder.getIntN(sizeof(size_t) * 8, val->getType()->size());
+  return builder.getIntN(sizeof(size_t) * 8, val->size());
 }
 
 llvm::Value *LLVMIRGen::emitConstF32(llvm::IRBuilder<> &builder, float val) {
@@ -611,8 +611,7 @@ void LLVMIRGen::generateLLVMIRForModule(llvm::IRBuilder<> &builder) {
       auto val = I->getOperand(0).first;
       auto bundleVal = bundle.back()->getOperand(0).first;
       // Check if shapes have the same amount of elements.
-      isShapeCompatible =
-          val->getType()->size() == bundleVal->getType()->size();
+      isShapeCompatible = val->size() == bundleVal->size();
     }
 
     // If the instruction is not shape-compatible, emit the kernel for the
@@ -1153,7 +1152,7 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     auto *destPtr = emitValueAddress(builder, dest);
     auto *batchPtr = emitValueAddress(builder, batch);
 
-    auto *destSize = emitConstSizeT(builder, dest->getType()->size());
+    auto *destSize = emitConstSizeT(builder, dest->size());
     auto bdim = flattenCdr(batch->dims());
     auto *numSlice = emitConstSizeT(builder, bdim.first);
     auto *sliceSize = emitConstSizeT(builder, bdim.second);
@@ -1575,7 +1574,7 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     auto *srcPtr = emitValueAddress(builder, src);
 
     auto *srcType = src->getType();
-    auto *numElem = emitConstSizeT(builder, dest->getType()->size());
+    auto *numElem = emitConstSizeT(builder, dest->size());
     auto *scale = emitConstF32(builder, srcType->getScale());
     auto *offset = emitConstI32(builder, srcType->getOffset());
 
@@ -1652,7 +1651,7 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
 
     auto *k = emitConstSizeT(builder, TI->getK());
     auto *n = emitConstSizeT(builder, input->dims().back());
-    auto *size = emitConstSizeT(builder, input->getType()->size());
+    auto *size = emitConstSizeT(builder, input->size());
 
     auto *F = getFunction("topk", input->getElementType());
     builder.CreateCall(
@@ -1746,7 +1745,7 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     auto *dataPtr = emitValueAddress(builder, data);
     auto *indicesPtr = emitValueAddress(builder, indices);
 
-    auto *indicesSize = emitConstSizeT(builder, indices->getType()->size());
+    auto *indicesSize = emitConstSizeT(builder, indices->size());
 
     auto *dataType = data->getType();
     auto *sliceSize =

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -572,7 +572,7 @@ void OCLBackend::doForwardPass() {
       }
       size_t destOff = tensors_[dest];
       size_t srcOff = tensors_[src];
-      size_t sizeInBytes = dest->getType()->getSizeInBytes();
+      size_t sizeInBytes = dest->getSizeInBytes();
 
       cl_int err =
           clEnqueueCopyBuffer(commands_, deviceBuffer_, deviceBuffer_, srcOff,
@@ -655,7 +655,7 @@ void OCLBackend::init() {
   // Assign device-space addresses to the activations.
   for (auto &I : F_->getInstrs()) {
     if (auto *A = llvm::dyn_cast<AllocActivationInst>(I)) {
-      auto numBytes = I->getType()->getSizeInBytes();
+      auto numBytes = I->getSizeInBytes();
       size_t addr = allocator_.allocate(numBytes);
       assert(!tensors_.count(A) && "Allocation already made!");
       tensors_[A] = addr;

--- a/lib/IR/IR.cpp
+++ b/lib/IR/IR.cpp
@@ -576,7 +576,7 @@ void IRFunction::dump(llvm::raw_ostream &OS) {
     Value *V = it;
     sb << "  ";
     dumpIR(V, sb);
-    sb << " // size: " << V->getType()->getSizeInBytes();
+    sb << " // size: " << V->getSizeInBytes();
     dumpUsers(V, sb, InstrNumbering);
     sb << "\n";
 
@@ -598,7 +598,7 @@ void IRFunction::dump(llvm::raw_ostream &OS) {
     sb << InstrNum << " ";
     dumpIR(II, sb);
     if (isa<AllocActivationInst>(II))
-      sb << " // size: " << II->getType()->getSizeInBytes();
+      sb << " // size: " << II->getSizeInBytes();
     if (isa<DeallocActivationInst>(II)) {
       sb << " // size: "
          << cast<DeallocActivationInst>(II)


### PR DESCRIPTION
It's pretty common for a backend to need the size of a value, so it's nice to just do `size()` instead of `getType()->size()`.