### PR TITLE
Improve compilation speed by speeding up the removal of instructions

### DIFF
--- a/include/glow/IR/IR.h
+++ b/include/glow/IR/IR.h
@@ -291,11 +291,15 @@ public:
   /// Inserts an instruction at the place described by \where.
   InstrIterator insertInstruction(InstrIterator where, Instruction *I);
 
-  /// Moves an instruction belonging to a function to the place described by
+  /// Moves an instruction belonging to a function before the place described by
   /// \where.
   InstrIterator moveInstruction(InstrIterator where, Instruction *I);
 
-  /// Moves an instruction belonging to a function to the place described by
+  /// Moves an instruction belonging to a function before the place described by
+  /// \where.
+  InstrIterator moveInstruction(InstrIterator where, InstrIterator I);
+
+  /// Moves an instruction belonging to a function before the place described by
   /// \where.
   InstrIterator moveInstruction(const Instruction *where, Instruction *I);
 

--- a/lib/IR/IR.cpp
+++ b/lib/IR/IR.cpp
@@ -216,6 +216,13 @@ InstrIterator IRFunction::moveInstruction(InstrIterator where,
   return insertInstruction(where, I);
 }
 
+InstrIterator IRFunction::moveInstruction(InstrIterator where,
+                                          InstrIterator I) {
+  auto instr = *I;
+  removeInstruction(I);
+  return insertInstruction(where, instr);
+}
+
 InstrIterator IRFunction::moveInstruction(const Instruction *where,
                                           glow::Instruction *I) {
   I->getParent()->removeInstruction(I);


### PR DESCRIPTION
We discovered on our internal tests that some models result in very long IR instructions lists and they took a lot of time to compile. 

Profiling has shown that it is mainly due to a single bottleneck related to a very slow instruction removal. The removal function was performing a linear scan of the instruction list to find the instruction to be removed.

This PR solves the issue by introducing an API for removing an IR instruction from the instructions list by providing a list iterator referring to this instruction. This way there is no need for any list scan during removal.

While fixing it, I also slightly updated `hoistDealloc` to avoid two full scans over the instructions.

With these changes the models that took more than 30 seconds to compile can now be compiled and executed in 3-5 seconds.