### PR TITLE
[quantization] Make quantization procedure more generic. Add TopK node.

### DIFF
--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -118,6 +118,7 @@ bool Interpreter::isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const {
     case Kinded::Kind::SelectNodeKind:
     case Kinded::Kind::SliceNodeKind:
     case Kinded::Kind::SubNodeKind:
+    case Kinded::Kind::TopKNodeKind:
     case Kinded::Kind::TransposeNodeKind:
       return true;
     default:

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -847,8 +847,9 @@ Function::createQuantizationProfile(llvm::StringRef name, NodeValue input) {
       ElemKind::FloatTy, {2}, "computationInfo",
       Variable::VisibilityKind::Private, Variable::TrainKind::None);
 
-  return addNode(new QuantizationProfileNode(
-      name, input, histogram, computationInfo, input->getName().str()));
+  return addNode(
+      new QuantizationProfileNode(name, input, histogram, computationInfo,
+                                  input->getName().str(), input.getResNo()));
 }
 
 TopKNode *Function::createTopK(llvm::StringRef name, NodeValue input,

--- a/lib/Optimizer/Quantization.cpp
+++ b/lib/Optimizer/Quantization.cpp
@@ -16,15 +16,23 @@ void glow::profileQuantization(Function *F) {
   // to observe tensor values from every node's output.
   std::unordered_set<NodeValue> nodesToInstrument;
 
+  // Add Quantization Profile node to all of the floating point outputs.
   for (const auto &node : F->getNodes()) {
-    // Add Quantization Profile node to parent's output linked to the
-    // i-th input of the current node.
-    for (unsigned i = 0, e = node->getNumInputs(); i < e; ++i) {
-      if (node->getNthInput(i).getElementType() != ElemKind::FloatTy) {
+    for (unsigned i = 0, e = node->getNumResults(); i < e; ++i) {
+      if (node->getNthResult(i).getElementType() != ElemKind::FloatTy) {
         continue;
       }
-      nodesToInstrument.insert(node->getNthInput(i));
+      nodesToInstrument.insert(node->getNthResult(i));
     }
+  }
+
+  // Add Quantization Profile node to all floating point vars.
+  for (const auto &var : F->getParent()->getVars()) {
+    if (var->getNthResult(0).getElementType() != ElemKind::FloatTy) {
+      continue;
+    }
+    // Assuming varable has only a single output.
+    nodesToInstrument.insert(var->getNthResult(0));
   }
 
   for (const auto &node : nodesToInstrument) {

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -353,6 +353,7 @@ int main(int argc, char **argv) {
       .addInput("Histogram")
       .addInput("ComputationInfo")
       .addMember(MemberType::String, "ProfiledNodeName")
+      .addMember(MemberType::Unsigned, "ProfiledOutputNumber")
       .addExtraMethod("Variable *getHistogramVar() const ;",
                       "Variable *QuantizationProfileNode::getHistogramVar() "
                       "const { return "
@@ -364,9 +365,15 @@ int main(int argc, char **argv) {
       .addOverwrittenInput("ComputationInfo")
       .addOverwrittenInput("Histogram")
       .setHasSideEffects(true)
-      .setDocstring("Generate profile (distribution of values) of the Input "
-                    "tensor. This data is used for quantization of the tensor "
-                    "later on.");
+      .setDocstring(
+          "Generate profile (distribution of values) of the Input "
+          "tensor. This data is used for quantization of the tensor "
+          "later on. ProfiledNodeName contains the name of the node "
+          "which is profiled by the QuantizationProfile node. "
+          "ProfiledNodeName is helpful as lowering might transform the "
+          "original graph. "
+          "ProfiledOutputNumber contains the position of the node's output "
+          "which gets profiled.");
 
   BB.newNode("Quantize")
       .addInput("Input")


### PR DESCRIPTION
This PR makes the quantization procedure more robust to handle nodes with multiple outputs.

There are several things that have to be changed in order to support more generic procedure:
* Keep the profiled node output number as part of the QuantizationProfile node similar to the original node name (change in the profiling).
* Profile outputs such that there is a profile data for all outputs, this facilitates cleaner implementation of the quantization procedure (change in the profiling).

Existing tests: e2e quantization and profile quantization nodes.
Note, I'll add small LSTM quantization e2e test in the next PR.

Running fr2en quantized:
```
./bin/fr2en < input -load_profile=profile.yml -dumpGraphDAG=dag.g
Writing dotty graph for Function to: dag.g
Here are some examples:
	nous sommes desormais en securite .
	vous etes puissantes .
	il etudie l histoire a l universite .
	je ne suis pas timide .
	j y songe encore .
	je suis maintenant a l aeroport .

we re safe now .

you re powerful .

he is studying history at the university .

i m not shy .

i m still thinking about it .

i m at the airport now .
```
