### PR TITLE
[nfc] Move implementation of IRUtils.h from IR.cpp to IRUtils.cpp

### DIFF
--- a/lib/IR/CMakeLists.txt
+++ b/lib/IR/CMakeLists.txt
@@ -2,6 +2,7 @@
 add_library(IR
               IR.cpp
               IRGen.cpp
+              IRUtils.cpp
               IRBuilder.cpp
               Instrs.cpp
               GraphScheduler.cpp)

--- a/lib/IR/IR.cpp
+++ b/lib/IR/IR.cpp
@@ -23,31 +23,6 @@ using llvm::isa;
 //                       General IR operations
 //===----------------------------------------------------------------------===//
 
-Value *glow::getAllocationOrigin(Value *V) {
-  while (true) {
-    if (auto *AI = dyn_cast<AllocActivationInst>(V))
-      return AI;
-    if (auto *TVI = dyn_cast<TensorViewInst>(V)) {
-      V = TVI->getSrc();
-      continue;
-    }
-    return nullptr;
-  }
-  return nullptr;
-}
-
-Value *glow::getOrigin(Value *V) {
-  while (true) {
-    auto *TVI = dyn_cast<TensorViewInst>(V);
-    if (!TVI)
-      return V;
-    V = TVI->getSrc();
-  }
-  return V;
-}
-
-bool glow::isTensorView(glow::Value *v) { return isa<TensorViewInst>(v); }
-
 bool Instruction::classof(const Value *V) {
 #define DEF_VALUE(CLASS, NAME)
 #define DEF_INSTR(CLASS, NAME)

--- a/lib/IR/IRUtils.cpp
+++ b/lib/IR/IRUtils.cpp
@@ -1,0 +1,35 @@
+// Copyright 2017 Facebook Inc.  All Rights Reserved.
+
+#include "glow/IR/IRUtils.h"
+#include "glow/IR/Instrs.h"
+
+#include "llvm/Support/Casting.h"
+
+using namespace glow;
+using llvm::dyn_cast;
+using llvm::isa;
+
+bool glow::isTensorView(glow::Value *v) { return isa<TensorViewInst>(v); }
+
+Value *glow::getAllocationOrigin(Value *V) {
+  while (true) {
+    if (auto *AI = dyn_cast<AllocActivationInst>(V))
+      return AI;
+    if (auto *TVI = dyn_cast<TensorViewInst>(V)) {
+      V = TVI->getSrc();
+      continue;
+    }
+    return nullptr;
+  }
+  return nullptr;
+}
+
+Value *glow::getOrigin(Value *V) {
+  while (true) {
+    auto *TVI = dyn_cast<TensorViewInst>(V);
+    if (!TVI)
+      return V;
+    V = TVI->getSrc();
+  }
+  return V;
+}


### PR DESCRIPTION
Do we have a general rule that implementation for stuff in Foo.h should be in Foo.cpp?  I feel like it's a good practice in general (and yeah, I probably wouldn't even notice this if I were using a modern IDE... but still :-p ).