### PR TITLE
Format sources with clang-format 6.0.0

### DIFF
--- a/lib/Backends/CPU/AllocationsInfo.cpp
+++ b/lib/Backends/CPU/AllocationsInfo.cpp
@@ -27,10 +27,10 @@
 using namespace glow;
 
 using namespace glow;
-using llvm::StringRef;
 using llvm::cast;
 using llvm::dyn_cast;
 using llvm::isa;
+using llvm::StringRef;
 
 void AllocationsInfo::allocateWeightVars(IRFunction *F, bool reuseAddresses) {
   // Use two different allocators, because constant weights and mutable weights

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -32,10 +32,10 @@
 #include "llvm/Support/raw_ostream.h"
 
 using namespace glow;
-using llvm::StringRef;
 using llvm::cast;
 using llvm::dyn_cast;
 using llvm::isa;
+using llvm::StringRef;
 
 static llvm::cl::opt<std::string> target("target", llvm::cl::desc("target"));
 

--- a/lib/Backends/CPU/DebugInfo.cpp
+++ b/lib/Backends/CPU/DebugInfo.cpp
@@ -27,10 +27,10 @@
 #include <sstream>
 
 using namespace glow;
-using llvm::StringRef;
 using llvm::cast;
 using llvm::dyn_cast;
 using llvm::isa;
+using llvm::StringRef;
 
 extern llvm::cl::OptionCategory CPUBackendCat;
 

--- a/lib/Backends/CPU/FunctionSpecializer.cpp
+++ b/lib/Backends/CPU/FunctionSpecializer.cpp
@@ -25,10 +25,10 @@
 
 using namespace glow;
 
-using llvm::StringRef;
 using llvm::cast;
 using llvm::dyn_cast;
 using llvm::isa;
+using llvm::StringRef;
 
 namespace {
 /// Perform function specialization with constant arguments taking into account

--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -33,10 +33,10 @@
 #include "llvm/Target/TargetMachine.h"
 
 using namespace glow;
-using llvm::StringRef;
 using llvm::cast;
 using llvm::dyn_cast;
 using llvm::isa;
+using llvm::StringRef;
 
 llvm::cl::OptionCategory CPUBackendCat("Glow CPU Backend Options");
 

--- a/lib/Backends/CPU/Pipeline.cpp
+++ b/lib/Backends/CPU/Pipeline.cpp
@@ -50,9 +50,9 @@
 #include "llvm/Transforms/Vectorize.h"
 
 using namespace glow;
-using llvm::StringRef;
 using llvm::dyn_cast;
 using llvm::isa;
+using llvm::StringRef;
 
 void LLVMIRGen::optimizeLLVMModule(llvm::Function *F, llvm::TargetMachine &TM) {
   auto *M = F->getParent();

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -300,7 +300,8 @@ static bool canBeQuantized(const Node *node) {
 /// \param F Function which holds the non quantized \p node.
 /// \param node Node to be quantized.
 /// \param quantizedInputs Array of already quantized inputs to the result node.
-/// \param qParams Tensor quantization parameters for all outputs of the \p node.
+/// \param qParams Tensor quantization parameters for all outputs of the
+///        \p node.
 static Node *quantizeNode(Function *F, Node *node,
                           llvm::MutableArrayRef<Node *> quantizedInputs,
                           llvm::ArrayRef<TensorQuantizationParams> qParams) {
@@ -536,7 +537,7 @@ void generateQuantizedGraph(
       // 1) Quantize all of the inputs based on the profiles.
       //    Quantize only floating point inputs.
       auto quantizedInputs = quantizeInputs(F, node, nodeToTQP);
-      
+
       auto qParams = getQuantizationParameters(node, nodeToTQP);
 
       // 2) Quantize the node.


### PR DESCRIPTION
It looks like clang-format is using a case insensitive sort for the using
statements now. This changes their order.