### PR TITLE
[cpu-backend] Minor fix for the debug info related errors

### DIFF
--- a/lib/Backends/CPU/DebugInfo.cpp
+++ b/lib/Backends/CPU/DebugInfo.cpp
@@ -32,11 +32,7 @@ using llvm::dyn_cast;
 using llvm::isa;
 using llvm::StringRef;
 
-extern llvm::cl::OptionCategory CPUBackendCat;
-
-static llvm::cl::opt<bool>
-    emitDebugInfo("g", llvm::cl::desc("Emit debug information for debuggers"),
-                  llvm::cl::init(false), llvm::cl::cat(CPUBackendCat));
+extern llvm::cl::opt<bool> emitDebugInfo;
 
 void LLVMIRGen::setCurrentDebugLocation(llvm::IRBuilder<> &builder,
                                         glow::Instruction *I) {


### PR DESCRIPTION
LLVM module verification should not be run until the emission of debug information is finished, because otherwise LLVM verifier produces a lot of errors about the incomplete debug information.