### PR TITLE
Add the compilation mode parameter to the backend hooks

### DIFF
--- a/include/glow/Backends/Backend.h
+++ b/include/glow/Backends/Backend.h
@@ -17,6 +17,7 @@
 #define GLOW_BACKENDS_BACKEND_H
 
 #include "glow/Base/Traits.h"
+#include "glow/Optimizer/Optimizer.h"
 
 #include <llvm/ADT/StringRef.h>
 
@@ -62,8 +63,12 @@ public:
   /// cleaning up after itself.
   /// \returns True if the graph was modified.
   ///@{
-  virtual bool transformPreLowering(Function *F) { return false; }
-  virtual bool transformPostLowering(Function *F) { return false; }
+  virtual bool transformPreLowering(Function *F, CompilationMode mode) {
+    return false;
+  }
+  virtual bool transformPostLowering(Function *F, CompilationMode mode) {
+    return false;
+  }
   /// @}
 
   /// \returns true if backend supports given kind of operation with

--- a/lib/Backends/CPU/CPUBackend.h
+++ b/lib/Backends/CPU/CPUBackend.h
@@ -85,7 +85,7 @@ public:
 
   void doForwardPass() override;
 
-  bool transformPostLowering(Function *F) override;
+  bool transformPostLowering(Function *F, CompilationMode mode) override;
 
   bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override;
   /// @}

--- a/lib/Backends/CPU/Transforms.cpp
+++ b/lib/Backends/CPU/Transforms.cpp
@@ -78,7 +78,7 @@ static Node *optimizeCPUConv(ConvolutionNode *CN, Function *F) {
       CN->getKernel(), CN->getStride(), CN->getPad()));
 }
 
-bool CPUBackend::transformPostLowering(Function *F) {
+bool CPUBackend::transformPostLowering(Function *F, CompilationMode mode) {
   bool changed = false;
   for (auto node : F->getNodes()) {
 

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -128,7 +128,7 @@ void ExecutionEngine::generateIR(CompilationMode mode, Function *F) {
   ::glow::optimize(F, mode);
 
   // Allow the backend to transform the graph prior to lowering.
-  if (IP_->transformPreLowering(F)) {
+  if (IP_->transformPreLowering(F, mode)) {
     // Optimize the graph again after the backend transformation.
     // In particular, DCE is very likely to be useful.
     ::glow::optimize(F, mode);
@@ -141,7 +141,7 @@ void ExecutionEngine::generateIR(CompilationMode mode, Function *F) {
   ::glow::optimize(F, mode);
 
   // Allow the backend to transform the graph after lowering.
-  if (IP_->transformPostLowering(F)) {
+  if (IP_->transformPostLowering(F, mode)) {
     // Optimize the graph again after the backend transformation.
     // In particular, DCE is very likely to be useful.
     ::glow::optimize(F, mode);


### PR DESCRIPTION
Some transformations may need to be done only in inference or training mode.