### PR TITLE
[NFC] Lower-case the default source directory name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Glow
 
-* [![Build Status](https://travis-ci.com/pytorch/Glow.svg?token=UwQBGB2pxogBqjigi7Nh&branch=master)](https://travis-ci.com/pytorch/Glow)
+* [![Build Status](https://travis-ci.com/pytorch/glow.svg?token=UwQBGB2pxogBqjigi7Nh&branch=master)](https://travis-ci.com/pytorch/glow)
 * [Code Coverage](https://fb-glow-assets.s3.amazonaws.com/coverage/coverage-master/index.html)
 
 Glow is a machine learning compiler and execution engine for hardware
@@ -78,7 +78,7 @@ good idea to build the project outside of the source directory.
   ```
   mkdir build_Debug
   cd build_Debug
-  cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug ../Glow
+  cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug ../glow
   ninja all
   ```
 
@@ -93,7 +93,7 @@ example, if you installed it using Homebrew on macOS), you need to tell CMake
 where to find llvm using `-DCMAKE_PREFIX_PATH`.  For example:
 
   ```
-  cmake -G Ninja ../Glow \
+  cmake -G Ninja ../glow \
       -DCMAKE_BUILD_TYPE=Debug \
       -DCMAKE_PREFIX_PATH=/usr/local/opt/llvm
   ```
@@ -126,7 +126,7 @@ To run these programs, build Glow in Release mode, then run the following comman
 to download the cifar10, mnist and ptb databases.
 
   ```
-  python ../Glow/utils/download_test_db.py --all
+  python ../glow/utils/download_test_db.py --all
   ```
 
 Now run the examples. Note that the databases should be in the current working

--- a/examples/bundles/resnet50/Makefile
+++ b/examples/bundles/resnet50/Makefile
@@ -2,10 +2,10 @@
 $(VERBOSE).SILENT:
 
 # The path to the loader executable.
-LOADER?=~/src/build/Glow/bin/loader
+LOADER?=~/src/build/glow/bin/loader
 
 # The root directory of the Glow repo.
-GLOW_SRC?=~/src/Glow
+GLOW_SRC?=~/src/glow
 
 # Should quantize the network (YES/NO)?
 QUANTIZE?=YES

--- a/examples/bundles/vgg16/Makefile
+++ b/examples/bundles/vgg16/Makefile
@@ -2,10 +2,10 @@
 $(VERBOSE).SILENT:
 
 # The path to the loader executable.
-LOADER?=~/src/build/Glow/bin/loader
+LOADER?=~/src/build/glow/bin/loader
 
 # The root directory of the Glow repo.
-GLOW_SRC?=~/src/Glow
+GLOW_SRC?=~/src/glow
 
 # Should quantize the network (YES/NO)?
 QUANTIZE?=YES

--- a/examples/fr2en.cpp
+++ b/examples/fr2en.cpp
@@ -115,7 +115,7 @@ void loadMatrixFromFile(llvm::StringRef filename, Tensor &result) {
                  result.size() * sizeof(float))) {
     std::cout << "Error reading file: " << filename.str() << '\n'
               << "Need to be downloaded by calling:\n"
-              << "python ../Glow/utils/download_test_db.py -d fr2en\n";
+              << "python ../glow/utils/download_test_db.py -d fr2en\n";
     exit(1);
   }
 }


### PR DESCRIPTION
Since the project is now known as 'pytorch/glow', rather than 'Glow', the default capitalization of cloned source directories is now lower-case.  This commit updates a few locations to reflect this.

NFC.