### PR TITLE
[Interpreter] Support group argument for Convolution.

### DIFF
--- a/lib/Backends/Interpreter/Interpreter.h
+++ b/lib/Backends/Interpreter/Interpreter.h
@@ -103,7 +103,7 @@ private:
                                  size_t pad);
   void fwdConvolutionInst_FloatImpl(Value *inV, Value *outV, Value *filterV,
                                     Value *biasV, size_t filterSize,
-                                    size_t stride, size_t pad);
+                                    size_t stride, size_t pad, size_t group);
   ///@}
 };
 


### PR DESCRIPTION
It's now clear that GroupConvolution needs support on backend level to allow smaller compiled code size. This is reference implementation for Interpreter in floats.