### PR TITLE
[CPU] Tune the matmul implementation for better FMA utilization

### DIFF
--- a/lib/Backends/CPU/libjit/libjit_matmul.cpp
+++ b/lib/Backends/CPU/libjit/libjit_matmul.cpp
@@ -65,8 +65,8 @@ void libjit_matmul_dot(int k, const float *a, int lda, const float *b, int ldb,
 /// to a slow but general helper.
 void libjit_matmul_inner(int m, int n, int k, const float *a, int lda,
                          const float *b, int ldb, float *c, int ldc) {
-  constexpr int regsA = 4;
-  constexpr int regsB = 2;
+  constexpr int regsA = 3;
+  constexpr int regsB = 4;
 
   constexpr int mc = regsA;
   constexpr int nr = regsB * 8;

--- a/tests/benchmark/GemmBench.cpp
+++ b/tests/benchmark/GemmBench.cpp
@@ -76,7 +76,7 @@ private:
 };
 
 int main() {
-  constexpr int reps = 12;
+  constexpr int reps = 100;
   printf("outX, outY, lhsX, lhsY, rhsX, rhsY, gflops/s, \n");
 
   for (int i = 0; i < 2; i++) {


### PR DESCRIPTION
Our matmul implementation is pretty good. In this PR I changed the implementation of the register-blocked multiplication. Before we were multiplying 2 * 4 registers. This is 8 FMAs for 6 loads. I changed this to 3 * 4. This resulted in 12 FMAs for 7 loads, which gives a better compute ratio. 

Additionally, with the 8-FMA implementation we did not have enough operations to fill the two ports of FMA that had a latency of 5 each. This resulted in 80% utilization. 

By providing 12 FMAs we saturate the FMA ports and jump to 100% utilization. 

On the benchmark that checks [768 x 768] * [768 x 768], we jump from 80 Gflops/sec to 100Gflops/sec. 