### PR TITLE
Fix a Variable creation bug in optimizeTranspose

### DIFF
--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -85,6 +85,9 @@ public:
   /// \returns the original training mode of the variable.
   TrainKind getTrainKind() const { return train_; }
 
+  /// \returns the value used during initialization.
+  float getValue() const { return val_; }
+
   /// \returns the visibility of the variable.
   VisibilityKind getVisibilityKind() const { return visibility_; }
 

--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -628,8 +628,9 @@ static void optimizeTranspose(Function *F) {
       continue;
     }
     // Create a new variable NV to hold the transposed result.
-    auto *NV = F->getParent()->createVariable(
-        TN->getType(), V->getName(), V->getVisibilityKind(), V->getTrainKind());
+    auto *NV = F->getParent()->createVariable(TN->getType(), V->getName(),
+                                              V->getVisibilityKind(),
+                                              V->getTrainKind(), V->getValue());
     // Transpose the value of V into NV.
     genericTranspose(&V->getPayload(), &NV->getPayload(), TN->getShuffle());
     // Rewrite uses of TN to reference NV.


### PR DESCRIPTION
Provide a proper initialization value to createVariable. The default value of 0 asserts when the training kind is Xavier.