### PR TITLE
[opencl] Add convolutiongrad support

### DIFF
--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -193,6 +193,15 @@ void setKernelArg(cl_kernel kernel, unsigned argIdx, T value) {
   GLOW_ASSERT(err == CL_SUCCESS && "Unable to set parameter");
 }
 
+void OCLBackend::fillBuffer(cl_mem buffer, size_t start, size_t len,
+                            float value, ElemKind elemKind) {
+  auto kernel = createKernel(getKernelName("splat", elemKind));
+  setKernelArg(kernel, 0, buffer);
+  setKernelArg<cl_uint>(kernel, 1, start);
+  setKernelArg(kernel, 2, value);
+  enqueueKernel(commands_, kernel, deviceId_, {len}, kernelLaunches_);
+}
+
 /// \returns the max local workgroup size for each dimension, under the
 /// opencl constraints, with the global workgroup sizes of \p global;
 void getMaxLocalWorkgroupSize(cl_kernel kernel, cl_device_id device,

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -132,6 +132,12 @@ private:
   /// \returns number of copied bytes.
   size_t copyMutableWeightsFromDevice();
 
+  /// Fill the device \p buffer with a given \p value.
+  /// \param len number of buffer elements to be filled by the \p value.
+  /// Elements are considered to be of the type described by \p elemKind.
+  void fillBuffer(cl_mem buffer, size_t start, size_t len, float value,
+                  ElemKind elemKind);
+
   /// Allocate a device buffer of required \p size.
   cl_mem allocDeviceBuffer(size_t size);
   /// Frees a device buffer.


### PR DESCRIPTION
This operation is necessary for the training mode. It is not optimized for speed yet.

The implementation is making use of atomics to ensure the correctness of the results when this kernel is executed by multiple threads on GPUs.