### PR TITLE
Optimize InsertTensors into TensorViews with Offsets.

### DIFF
--- a/examples/ptb.cpp
+++ b/examples/ptb.cpp
@@ -15,6 +15,7 @@
  */
 #include "glow/ExecutionEngine/ExecutionEngine.h"
 #include "glow/Graph/Graph.h"
+#include "glow/IR/IR.h"
 #include "glow/Support/Support.h"
 
 #include "llvm/Support/CommandLine.h"
@@ -53,6 +54,9 @@ llvm::cl::opt<std::string> dumpTrainingGraphDAGFileOpt(
     llvm::cl::desc(
         "Specify the file to export the training Graph in DOT format"),
     llvm::cl::value_desc("file.dot"), llvm::cl::cat(ptbCat));
+
+llvm::cl::opt<bool> dumpIROpt("dumpIR", llvm::cl::desc("Prints IR to stdout"),
+                              llvm::cl::cat(ptbCat));
 } // namespace
 
 unsigned loadPTB(Tensor &inputWords, Tensor &targetWords, size_t numSteps,
@@ -237,6 +241,9 @@ void testPTB() {
   if (!dumpTrainingGraphDAGFileOpt.empty()) {
     llvm::outs() << "Dumping training graph\n";
     TF->dumpDAG(dumpTrainingGraphDAGFileOpt.c_str());
+  }
+  if (dumpIROpt) {
+    EE.getIR().dump();
   }
 
   size_t numBatches = (numWords / minibatchSize - 1) / numSteps;

--- a/include/glow/IR/IRBuilder.h
+++ b/include/glow/IR/IRBuilder.h
@@ -56,7 +56,8 @@ public:
 
   TensorViewInst *createTensorView(ElemKind elemKind,
                                    llvm::ArrayRef<size_t> dims, Value *src,
-                                   llvm::StringRef name);
+                                   llvm::StringRef name,
+                                   llvm::ArrayRef<size_t> offsets = {});
 
   LocalResponseNormalizationInst *
   createLocalResponseNormalizationOp(Value *input, size_t halfWindowSize = 2,

--- a/lib/Backends/CPU/AllocationsInfo.h
+++ b/lib/Backends/CPU/AllocationsInfo.h
@@ -63,6 +63,11 @@ struct AllocationsInfo {
   /// performed by the client based on the information provided by the
   /// AllocationsInfo.
   void allocateActivations(IRFunction *F);
+  /// Assign offsets to all tensorviews.
+  /// No memory allocation is performed. Sets up all offsets into already
+  /// defined offsets for WeightVars and AllocActivations. Assumes the weight
+  /// vars and alloc activations have already been added to allocatedAddressed_.
+  void allocateTensorViews(IRFunction *F);
   /// Number all allocations and weight variables by assigning them unique
   /// numbers.
   void numberValues(IRFunction *F);

--- a/lib/Backends/CPU/DebugInfo.cpp
+++ b/lib/Backends/CPU/DebugInfo.cpp
@@ -273,7 +273,6 @@ void LLVMIRGen::initDebugInfo() {
 
 void LLVMIRGen::emitDebugGlobalVariableForValue(Value *val) {
   auto name = val->getName();
-  val = getOrigin(val);
   // Create a proper type for the variable.
   // Represent Glow's N-dimensional tensors as N-dimensional C arrays in the
   // debug information. This allows for inspecting them in the debugger using a

--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -249,7 +249,6 @@ void LLVMIRGen::performCodeGen() {
 
 llvm::Value *LLVMIRGen::emitValueAddress(llvm::IRBuilder<> &builder,
                                          glow::Value *val) {
-  val = getOrigin(val);
   assert(allocationsInfo_.allocatedAddressed_.count(val) &&
          "Value address was not allocated");
   auto sizeTTy = builder.getIntNTy(sizeof(size_t) * 8);
@@ -300,7 +299,6 @@ llvm::Value *LLVMIRGen::emitValueAddress(llvm::IRBuilder<> &builder,
 llvm::Value *
 LLVMIRGen::emitConstOffsetsArray(llvm::IRBuilder<> &builder,
                                  const AllocationsInfo &allocationsInfo) {
-
   auto sizeTType = builder.getIntNTy(sizeof(size_t) * 8);
   std::vector<llvm::Constant *> elems(allocationsInfo.valueNumbers_.size());
   for (auto &I : allocationsInfo.valueNumbers_) {
@@ -524,7 +522,6 @@ static llvm::Value *
 emitBufferAddress(llvm::IRBuilder<> &builder, Value *val,
                   llvm::Function *kernel,
                   llvm::DenseMap<Value *, int> &bufferToArgNum) {
-  val = getOrigin(val);
   assert(bufferToArgNum.count(val) && "Buffer should be in the map");
   return kernel->args().begin() + bufferToArgNum[val];
 }
@@ -552,7 +549,7 @@ void LLVMIRGen::emitDataParallelKernel(llvm::IRBuilder<> &builder,
   // Collect unique buffers used by the instructions of the kernel.
   for (const auto I : bundle) {
     for (const auto &Op : I->getOperands()) {
-      auto *buf = getOrigin(Op.first);
+      auto *buf = Op.first;
       if (!bufferToArgNum.count(buf)) {
         bufferToArgNum[buf] = argTypes.size();
         buffers.push_back(emitValueAddress(builder, buf));

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -76,8 +76,8 @@ Tensor *Interpreter::getOrCreateTensor(const Value *v) {
   return it->second;
 }
 
-Tensor *Interpreter::getOrCreateUnownedTensor(const Value *v,
-                                              const Value *src) {
+Tensor *Interpreter::getOrCreateUnownedTensor(const Value *v, const Value *src,
+                                              llvm::ArrayRef<size_t> offsets) {
   assert(isa<TensorViewInst>(v) && "Expected a tensor view");
 
   // Pick the tensor.
@@ -89,7 +89,7 @@ Tensor *Interpreter::getOrCreateUnownedTensor(const Value *v,
   }
 
   auto *T = new Tensor();
-  *T = getTensor(src)->getUnowned(v->dims());
+  *T = getTensor(src)->getUnowned(v->dims(), offsets);
   tensors_[v] = T;
   return T;
 }

--- a/lib/Backends/Interpreter/Interpreter.h
+++ b/lib/Backends/Interpreter/Interpreter.h
@@ -78,7 +78,8 @@ private:
   /// Allocate an unowned tensor to back the value \p v. The source tensor of
   /// the unowned tensor is provided by \p src.
   /// \returns a tensor for \p v.
-  Tensor *getOrCreateUnownedTensor(const Value *v, const Value *src);
+  Tensor *getOrCreateUnownedTensor(const Value *v, const Value *src,
+                                   llvm::ArrayRef<size_t> offsets);
 
   /// If a tensor is allocated for \p v then delete it.
   void deleteTensor(const Value *v);

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -647,7 +647,7 @@ void Interpreter::fwdBroadcastInst(const BroadcastInst *I) {
 }
 
 void Interpreter::fwdTensorViewInst(const TensorViewInst *I) {
-  getOrCreateUnownedTensor(I, I->getSrc());
+  getOrCreateUnownedTensor(I, I->getSrc(), I->getOffsets());
 }
 
 void Interpreter::fwdSplatInst(const glow::SplatInst *I) {

--- a/lib/IR/IRBuilder.cpp
+++ b/lib/IR/IRBuilder.cpp
@@ -101,12 +101,19 @@ CrossEntropyLossInst *IRBuilder::createCrossEntropyLossOp(Value *p,
 /// in the view is the same as the number of elements in the source tensor
 /// \p src
 /// \param src the source tensor used to create the unowned tensor.
+/// \param offsets is a vector of offsets into the Tensor for this view of the
+/// Tensor.
 TensorViewInst *IRBuilder::createTensorView(ElemKind elemKind,
                                             llvm::ArrayRef<size_t> dims,
-                                            Value *src, llvm::StringRef name) {
+                                            Value *src, llvm::StringRef name,
+                                            llvm::ArrayRef<size_t> offsets) {
   auto ty =
       getIRFunction().getGraph()->getParent()->uniqueType(Type(elemKind, dims));
-  return createTensorViewInst(name, src, ty);
+  return createTensorViewInst(
+      name, src, ty,
+      (offsets.size()
+           ? offsets
+           : llvm::ArrayRef<size_t>(std::vector<size_t>(dims.size(), 0))));
 }
 
 LocalResponseNormalizationInst *IRBuilder::createLocalResponseNormalizationOp(

--- a/lib/IR/IRGen.cpp
+++ b/lib/IR/IRGen.cpp
@@ -104,10 +104,10 @@ public:
     case glow::Kinded::Kind::ReshapeNodeKind: {
       auto *RN = cast<ReshapeNode>(N);
 
-      std::vector<size_t> offsets(RN->getResult()->getType()->dims().size(), 0);
+      auto *inVal = valueForNode(RN->getInput());
+      std::vector<size_t> offsets(inVal->getType()->dims().size(), 0);
       auto *TVI = builder_.createTensorViewInst(
-          "tensorview.reshape", valueForNode(RN->getInput()),
-          RN->getResult()->getType(), offsets);
+          "tensorview.reshape", inVal, RN->getResult()->getType(), offsets);
       auto *dest = builder_.createAllocActivationInst(
           "copy.reshape.res", RN->getResult()->getType());
       builder_.createCopyInst("copy.reshape", dest, TVI);

--- a/lib/IR/IRGen.cpp
+++ b/lib/IR/IRGen.cpp
@@ -104,9 +104,10 @@ public:
     case glow::Kinded::Kind::ReshapeNodeKind: {
       auto *RN = cast<ReshapeNode>(N);
 
-      auto *TVI = builder_.createTensorViewInst("tensorview.reshape",
-                                                valueForNode(RN->getInput()),
-                                                RN->getResult()->getType());
+      std::vector<size_t> offsets(RN->getResult()->getType()->dims().size(), 0);
+      auto *TVI = builder_.createTensorViewInst(
+          "tensorview.reshape", valueForNode(RN->getInput()),
+          RN->getResult()->getType(), offsets);
       auto *dest = builder_.createAllocActivationInst(
           "copy.reshape.res", RN->getResult()->getType());
       builder_.createCopyInst("copy.reshape", dest, TVI);

--- a/lib/IR/Instrs.cpp
+++ b/lib/IR/Instrs.cpp
@@ -62,8 +62,8 @@ void CopyInst::verify() const {
 }
 
 void TensorViewInst::verify() const {
-  assert(getSrc()->getType()->size() == getType()->size() &&
-         "TensorView view size should be the same as Src size");
+  assert(getSrc()->getType()->size() >= getType()->size() &&
+         "TensorView view size should be no larger than Src size");
   assert(getSrc()->getElementType() == getType()->getElementType() &&
          "TensorView view element type should be the same as Src type");
 }

--- a/lib/Optimizer/IROptimizer.cpp
+++ b/lib/Optimizer/IROptimizer.cpp
@@ -406,8 +406,9 @@ static void replaceAllNonDeallocUsersWith(Value *val, Value *with) {
       replacement = withOrigin;
     if (Op.first->getType() != replacement->getType()) {
       // Perform a cast if required.
+      std::vector<size_t> offsets(Op.first->getType()->dims().size(), 0);
       auto *tv = B.createTensorViewInst(I->getName(), replacement,
-                                        Op.first->getType());
+                                        Op.first->getType(), offsets);
       M.moveInstruction(I, tv);
       replacement = tv;
     }
@@ -706,8 +707,9 @@ static void replaceAllUsesInsideIntervalWith(
         replacement = withOrigin;
       if (op->getType() != replacement->getType()) {
         // Perform a cast if required.
+        std::vector<size_t> offsets(op->getType()->dims().size(), 0);
         auto *tv = B.createTensorViewInst((*it)->getName(), replacement,
-                                          op->getType());
+                                          op->getType(), offsets);
         M.moveInstruction(it, tv);
         replacement = tv;
       }
@@ -1202,8 +1204,9 @@ void performPeepholeOptimizations(IRFunction &M) {
       if (auto W = getSingleWriter(src)) {
         if (isa<SplatInst>(W)) {
           if (src->getType() != dest->getType()) {
-            auto *TVI =
-                B.createTensorViewInst(TI->getName(), src, dest->getType());
+            std::vector<size_t> offsets(dest->getType()->dims().size(), 0);
+            auto *TVI = B.createTensorViewInst(TI->getName(), src,
+                                               dest->getType(), offsets);
             M.moveInstruction(cur, instrs.back());
             src = TVI;
           }

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -93,6 +93,9 @@ void inferTransposeNet(Tensor *inputs, Tensor *out, BackendKind kind);
 void inferBasicConvNet(Tensor *inputs, Tensor *out, BackendKind kind,
                        size_t convDepth);
 
+void inferTanhConcatNet(Tensor *input1, Tensor *input2, Tensor *input3,
+                        Tensor *out, BackendKind kind);
+
 void inferBasicFCNet(Tensor *inputs, Tensor *out, BackendKind kind);
 
 void inferMixedNet(Tensor *inputs, Tensor *out, BackendKind kind);

--- a/tests/unittests/IROptTest.cpp
+++ b/tests/unittests/IROptTest.cpp
@@ -79,7 +79,8 @@ TEST(Optimizer, dseDoNotRemloveLastWriteIntoWeightVar) {
   // no instruction that reads it, because it is an observable side-effect.
   bb.createElementAddInst("elem_add", output, input1, input2);
   bb.createTensorViewInst(
-      "cast", output, mod.uniqueType(Type(glow::ElemKind::FloatTy, {1, 1, 1})));
+      "cast", output, mod.uniqueType(Type(glow::ElemKind::FloatTy, {1, 1, 1})),
+      {0, 0, 0});
 
   optimize(M, CompilationMode::Infer);
 

--- a/tests/unittests/OCLTest.cpp
+++ b/tests/unittests/OCLTest.cpp
@@ -124,3 +124,30 @@ TEST(OpenCLCorrectnessTest, gatherTest) {
 
   EXPECT_TRUE(out1.isEqual(out2));
 }
+
+TEST(OpenCLCorrectnessTest, tanhConcatTest) {
+  Tensor I1(ElemKind::FloatTy, {10, 5});
+  Tensor I2(ElemKind::FloatTy, {20, 5});
+  Tensor I3(ElemKind::FloatTy, {30, 5});
+
+  for (size_t i = 0; i < 10; i++) {
+    for (size_t j = 0; j < 5; j++) {
+      I1.getHandle<float>().at({i, j}) = 0.05 * (i + j * 10 + 1);
+
+      I2.getHandle<float>().at({i, j}) = 0.10 * (i + j * 10 + 1);
+      I2.getHandle<float>().at({i + 10, j}) = 0.15 * (i + j * 10 + 1);
+
+      I3.getHandle<float>().at({i, j}) = 0.20 * (i + j * 10 + 1);
+      I3.getHandle<float>().at({i + 10, j}) = 0.25 * (i + j * 10 + 1);
+      I3.getHandle<float>().at({i + 20, j}) = 0.30 * (i + j * 10 + 1);
+    }
+  }
+
+  Tensor out1(ElemKind::FloatTy, {100, 5});
+  Tensor out2(ElemKind::FloatTy, {100, 5});
+
+  inferTanhConcatNet(&I1, &I2, &I3, &out1, BackendKind::OpenCL);
+  inferTanhConcatNet(&I1, &I2, &I3, &out2, BackendKind::Interpreter);
+
+  EXPECT_TRUE(out1.isEqual(out2));
+}

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -54,6 +54,7 @@ int main(int argc, char **argv) {
   BB.newInstr("TensorView")
       .addOperand("Src", OperandKind::In)
       .addMember(MemberType::TypeRef, "Ty")
+      .addMember(MemberType::VectorSizeT, "Offsets")
       .setType("Ty");
 
   BB.newInstr("DeallocActivation")


### PR DESCRIPTION
The main aim here is optimizing the pattern seen by Concats IRGen'd into InsertTensor. If all inserts are into the first dimension, then we can replace the InsertTensor with a TensorView with the same offset as the InsertTensor. This is because the underlying memory is contiguous for the InsertTensor/TensorView.

This improves ptb execution time on the CPU backend from 7.1 -> 6.2 seconds, which has a big ConcatNode.

For now it only applies to insert tensors with an alloc as the input; I believe this is most common/important.