### PR TITLE
[opencl] Implement fast convolution kernels

### DIFF
--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -78,6 +78,41 @@ struct ShapeNHWC {
   }
 };
 
+struct ShapeNCHW {
+  size_t n; // Number of samples
+  size_t c; // Number of Channels
+  size_t h; // Height
+  size_t w; // Width
+
+  explicit ShapeNCHW(llvm::ArrayRef<size_t> shape) {
+    assert(shape.size() == 4 && "Invalid shape");
+    n = shape[0];
+    c = shape[1];
+    h = shape[2];
+    w = shape[3];
+  }
+
+  static ShapeNCHW fromXYZ(llvm::ArrayRef<size_t> shape) {
+    assert(shape.size() == 3 && "Invalid 3d shape");
+    return ShapeNCHW(shape[0], 1, shape[1], shape[2]);
+  }
+
+  static ShapeNCHW fromXY(llvm::ArrayRef<size_t> shape) {
+    assert(shape.size() == 2 && "Invalid 2d shape");
+    return ShapeNCHW(shape[0], 1, shape[1], 1);
+  }
+
+  static ShapeNCHW empty() { return ShapeNCHW(0, 0, 0, 0); }
+
+  explicit ShapeNCHW(size_t samples, size_t channels, size_t height,
+                     size_t width)
+      : n(samples), c(channels), h(height), w(width) {}
+
+  bool equals(const ShapeNCHW &other) const {
+    return n == other.n && h == other.h && w == other.w && c == other.c;
+  }
+};
+
 /// Collapse a tensor shape into two sizes: the first dimension and the size of
 /// the rest of the dimensions.
 /// For example, [7, 3, 4, 2] -> [7, 24]
@@ -93,6 +128,10 @@ inline std::pair<size_t, size_t> flattenCdr(llvm::ArrayRef<size_t> dims) {
 }
 
 inline bool operator==(const ShapeNHWC &LHS, const ShapeNHWC &RHS) {
+  return LHS.equals(RHS);
+}
+
+inline bool operator==(const ShapeNCHW &LHS, const ShapeNCHW &RHS) {
   return LHS.equals(RHS);
 }
 

--- a/lib/Backends/OpenCL/CMakeLists.txt
+++ b/lib/Backends/OpenCL/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(OpenCL
-            OpenCL.cpp)
+            OpenCL.cpp
+            Transforms.cpp)
 
 target_link_libraries(OpenCL
                       PRIVATE

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -104,6 +104,8 @@ public:
 
   void doForwardPass() override;
 
+  bool transformPostLowering(Function *F, CompilationMode mode) override;
+
   bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override {
     if (elementTy == ElemKind::Int8QTy) {
       return false;

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -156,6 +156,12 @@ private:
   void enqueueKernel(cl_command_queue commands, cl_kernel kernel,
                      cl_device_id device, llvm::ArrayRef<size_t> global,
                      std::vector<KernelLaunch> &kernelLaunches);
+  /// Enqueue a \p kernel on a provided \p commands queue using specified \p
+  /// global and \p local work sizes.
+  void enqueueKernel(cl_command_queue commands, cl_kernel kernel,
+                     cl_device_id device, llvm::ArrayRef<size_t> global,
+                     llvm::ArrayRef<size_t> local,
+                     std::vector<KernelLaunch> &kernelLaunches);
 
   /// \returns a pointer to the tensor that is saved under \p v.
   Tensor *getTensor(const Value *v) const;

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -34,6 +34,7 @@
 namespace glow {
 class IRFunction;
 class Backend;
+class OCLConvolutionInst;
 /// A helper struct with information about kernels launches.
 struct KernelLaunch {
   /// Kernel that was launched.
@@ -140,6 +141,8 @@ private:
   void fillBuffer(cl_mem buffer, size_t start, size_t len, float value,
                   ElemKind elemKind);
 
+  /// Execution a convolution instruction which uses NCHW format.
+  void executeConvolution(OCLConvolutionInst *CC);
   /// Allocate a device buffer of required \p size.
   cl_mem allocDeviceBuffer(size_t size);
   /// Frees a device buffer.

--- a/lib/Backends/OpenCL/Transforms.cpp
+++ b/lib/Backends/OpenCL/Transforms.cpp
@@ -1,0 +1,119 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "OpenCL.h"
+
+#include "glow/Graph/Graph.h"
+#include "glow/Graph/Nodes.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace glow;
+using llvm::dyn_cast;
+using llvm::isa;
+
+static auto NCHW2NHWC = {0u, 2u, 3u, 1u};
+static auto NHWC2NCHW = {0u, 3u, 1u, 2u};
+
+/// Optimize the regular Convolution into a target-specific convolution
+/// with a different memory layout. Many GPU kernels prefer the NCHW memory
+/// layout.
+static Node *optimizeOCLConv(ConvolutionNode *CN, Function *F) {
+  // Convert filter and input from NHWC (Glow's default) into NCHW.
+  auto *NI = F->createTranspose("conv.input", CN->getInput(), NHWC2NCHW);
+  auto *NF = F->createTranspose("conv.filter", CN->getFilter(), NHWC2NCHW);
+
+  auto originalDims = CN->getType()->dims();
+  size_t outDims[] = {originalDims[0], originalDims[3], originalDims[1],
+                      originalDims[2]};
+  auto outTy = F->getParent()->uniqueType(ElemKind::FloatTy, outDims);
+
+  auto *NC = F->addNode(new OCLConvolutionNode(CN->getName(), outTy, NI, NF,
+                                               CN->getBias(), CN->getKernel(),
+                                               CN->getStride(), CN->getPad()));
+  auto NR = F->createTranspose("conv.result", NC, NCHW2NHWC);
+  return NR;
+}
+
+/// Optimize the regular pool average node into a target-specific node using the
+/// NCHW memory layout.
+static Node *optimizeOCLPoolAvg(PoolAvgNode *PAN, Function *F) {
+  // Convert input from NHWC (Glow's default) into NCHW.
+  auto *NI = F->createTranspose("conv.input", PAN->getInput(), NHWC2NCHW);
+
+  auto originalDims = PAN->getType()->dims();
+  size_t outDims[] = {originalDims[0], originalDims[3], originalDims[1],
+                      originalDims[2]};
+  auto outTy = F->getParent()->uniqueType(ElemKind::FloatTy, outDims);
+
+  auto *NPAN =
+      F->addNode(new OCLPoolAvgNode(PAN->getName(), outTy, NI, PAN->getKernel(),
+                                    PAN->getStride(), PAN->getPad()));
+  auto NR = F->createTranspose("poolavg.result", NPAN, NCHW2NHWC);
+  return NR;
+}
+
+/// Optimize the regular pool max node into a target-specific node using the
+/// NCHW memory layout.
+static Node *optimizeOCLPoolMax(PoolMaxNode *PMN, Function *F) {
+  // Convert input from NHWC (Glow's default) into NCHW.
+  auto *NI = F->createTranspose("conv.input", PMN->getInput(), NHWC2NCHW);
+
+  auto originalDims = PMN->getType()->dims();
+  size_t outDims[] = {originalDims[0], originalDims[3], originalDims[1],
+                      originalDims[2]};
+  auto outTy = F->getParent()->uniqueType(ElemKind::FloatTy, outDims);
+
+  auto *NPAN =
+      F->addNode(new OCLPoolMaxNode(PMN->getName(), outTy, NI, PMN->getKernel(),
+                                    PMN->getStride(), PMN->getPad()));
+  auto NR = F->createTranspose("poolmax.result", NPAN, NCHW2NHWC);
+  return NR;
+}
+
+/// Perform OpenCL specific post-lowering graph transformation.
+bool OCLBackend::transformPostLowering(Function *F, CompilationMode mode) {
+  bool changed = false;
+  // Transformation is not supported in training mode yet, because of some
+  // issues with gradient nodes.
+  if (mode == CompilationMode::Train)
+    return false;
+  // Convert convolutions and pooling nodes into nodes using the NCHW format.
+  for (auto node : F->getNodes()) {
+    if (auto *CN = dyn_cast<ConvolutionNode>(node)) {
+      if (Node *NCN = optimizeOCLConv(CN, F)) {
+        NodeValue(node, 0).replaceAllUsesOfWith(NCN);
+        changed = true;
+        continue;
+      }
+    }
+    if (auto *PAN = dyn_cast<PoolAvgNode>(node)) {
+      if (Node *NPAN = optimizeOCLPoolAvg(PAN, F)) {
+        NodeValue(node, 0).replaceAllUsesOfWith(NPAN);
+        changed = true;
+        continue;
+      }
+    }
+    if (auto *PMN = dyn_cast<PoolMaxNode>(node)) {
+      if (Node *NPMN = optimizeOCLPoolMax(PMN, F)) {
+        NodeValue(node, 0).replaceAllUsesOfWith(NPMN);
+        changed = true;
+        continue;
+      }
+    }
+  }
+  return changed;
+}

--- a/lib/Backends/OpenCL/kernels.cl
+++ b/lib/Backends/OpenCL/kernels.cl
@@ -15,6 +15,13 @@ typedef struct {
   cl_uint64_t c; // Number of channels
 } ShapeNHWC;
 
+typedef struct {
+  cl_uint64_t n; // Number of samples
+  cl_uint64_t c; // Number of channels
+  cl_uint64_t h; // Height
+  cl_uint64_t w; // Width
+} ShapeNCHW;
+
 #if defined(cl_khr_int32_base_atomics)
 #pragma OPENCL EXTENSION cl_khr_int32_base_atomics : enable
 #define ATOMICS_32_AVAILABLE
@@ -45,6 +52,12 @@ inline void atomicAdd(volatile __global float *source, const float operand) {
 size_t getNHWC(ShapeNHWC s, cl_uint32_t n, cl_uint32_t h, cl_uint32_t w,
                cl_uint32_t c) {
   return (n * s.c * s.w * s.h) + (h * s.c * s.w) + (w * s.c) + c;
+}
+
+/// \returns the index of the element at n, c, h, w.
+size_t getNCHW(ShapeNCHW s, cl_uint32_t n, cl_uint32_t c, cl_uint32_t h,
+               cl_uint32_t w) {
+  return (n * s.c * s.w * s.h) + (c * s.h * s.w) + (h * s.w) + w;
 }
 
 /// Macro to define a kernel for data-parallel ternay operations. The body of

--- a/lib/Backends/OpenCL/kernels_fwd_conv.cl
+++ b/lib/Backends/OpenCL/kernels_fwd_conv.cl
@@ -1,0 +1,322 @@
+/// Kernels for the forward convolution.
+
+// This is a parameterized convolution kernel heavily based on the kernels
+// produced by libDNN (https://github.com/naibaf7/libdnn). The libDNN library
+// in turn is inspired by ideas and approaches presented
+// in https://cnugteren.github.io/tutorial/pages/page1.html.
+//
+// The kernel is parameterized by means of macro-definitions, which
+// define such propeties like size of the filter, padding, stride,
+// sizes of workgroups, etc.
+//
+// The parameters of the kernel are:
+// 
+// v_nax - Number of spacial axes.
+// v_g - Number of groups.
+// v_k_0, v_k_1 - dimensions of the kernel
+// v_p_0, v_p_1 - padding
+// v_s_0, v_s_1 - stride
+// v_d_0, v_d_1 - dilation
+// v_fin - Number of kernel input channels.
+// v_fout - Number of kernel output channels.
+// v_bmul - Bias multiplier.
+// v_imsi_0, v_imsi_1 - Spacial dimensions of input.
+// v_imso_0, v_imso_1 - Spacial dimensions of output.
+// v_pad_A - Padding required for tiles of A.
+// v_pad_B - Padding required for tiles of A.
+// workgroup_size_0, workgroup_size_1 - workgroup sizes along each dimension.
+// VWN - vector width in dimension N.
+// VWM - vector width in dimension M.
+
+static const char* FWD_CONV_CODE = R"(
+#define Dtype float
+#define Dtype1 float
+#define Dtype2 float2
+#define Dtype4 float4
+#define Dtype8 float8
+#define Dtype16 float16
+
+#define VEC_1_0(X) X
+#define VEC_2_0(X) X.x
+#define VEC_2_1(X) X.y
+#define VEC_4_0(X) X.x
+#define VEC_4_1(X) X.y
+#define VEC_4_2(X) X.z
+#define VEC_4_3(X) X.w
+#define VEC_8_0(X) X.s0
+#define VEC_8_1(X) X.s1
+#define VEC_8_2(X) X.s2
+#define VEC_8_3(X) X.s3
+#define VEC_8_4(X) X.s4
+#define VEC_8_5(X) X.s5
+#define VEC_8_6(X) X.s6
+#define VEC_8_7(X) X.s7
+#define VEC_16_0(X) X.s0
+#define VEC_16_1(X) X.s1
+#define VEC_16_2(X) X.s2
+#define VEC_16_3(X) X.s3
+#define VEC_16_4(X) X.s4
+#define VEC_16_5(X) X.s5
+#define VEC_16_6(X) X.s6
+#define VEC_16_7(X) X.s7
+#define VEC_16_8(X) X.s8
+#define VEC_16_9(X) X.s9
+#define VEC_16_10(X) X.sA
+#define VEC_16_11(X) X.sB
+#define VEC_16_12(X) X.sC
+#define VEC_16_13(X) X.sD
+#define VEC_16_14(X) X.sE
+#define VEC_16_15(X) X.sF
+
+#define int_tp int
+#define uint_tp unsigned int
+#define int_tpc int
+#define uint_tpc unsigned int
+
+// Input image size in pixels.
+#define v_imsi (v_imsi_0*v_imsi_1)
+// Output image size in pixels.
+#define v_imso (v_imso_0*v_imso_1)
+// Input image batch offset.
+#define v_B_off  (v_fin*v_imsi)
+// Output image batch offset.
+#define v_C_off (v_fout*v_imso)
+// Definitions used by the GEMM kernel.
+#define MG v_fout
+#define MM (v_fout/v_g)
+#define NN v_imso
+#define KG (v_fin*v_k_0*v_k_1)
+#define KK ((v_fin/v_g)*v_k_0*v_k_1)
+// The tile-size in dimension M.
+#define TSM (WPTM*workgroup_size_1)
+// The tile-size in dimension N.
+#define TSN (WPTN*workgroup_size_0)
+// The reduced tile-size in dimension M.
+#define RTSM workgroup_size_1
+// The reduced tile-size in dimension N.
+#define RTSN workgroup_size_0
+// Loads per thread for A.
+#ifdef LPTA
+#undef LPTA
+#endif
+#define LPTA ((TSK*TSM)/(RTSM*RTSN))
+// Loads per thread for B.
+#ifdef LPTB
+#undef LPTB
+#endif
+#define LPTB ((TSK*TSN)/(RTSM*RTSN))
+#ifdef v_num_tiles
+#undef v_num_tiles
+#endif
+#define v_num_tiles (((KK - 1)/(TSK*2) + 1)*2)
+
+__kernel
+__attribute__((reqd_work_group_size(workgroup_size_0, workgroup_size_1, 1)))
+__attribute__((vec_type_hint(Dtype4)))
+void
+conv_forward_mem(__global void *mem, unsigned im_in_offset, unsigned wg_offset,
+                 unsigned bias_offset, unsigned im_out_offset) {
+  __global const Dtype *im_in = &mem[im_in_offset];
+  __global const Dtype *wg = &mem[wg_offset];
+  __global const Dtype *bias = &mem[bias_offset];
+  __global Dtype *im_out = &mem[im_out_offset];
+  // Thread identifiers.
+  // Local row ID (max: RTSM=TSM/WPTM).
+  const int_tp tidn = get_local_id(0);
+  // Local col ID (max: RTSN=TSN/WPTN).
+  const int_tp tidm = get_local_id(1);
+  // Work-group offset.
+  const int_tp offN = TSN * get_group_id(0);
+  // Work-group offset.
+  const int_tp offM = TSM * get_group_id(1);
+  // Local tile memory.
+  // Asub for loading weights & shuffling the output.
+  volatile __local Dtype Asub[TSM][TSK + v_pad_A];
+  // Bsub for loading the input image and shuffling the output image.
+  volatile __local Dtype Bsub[TSK][TSN + v_pad_B];
+  int_tp batch = get_global_id(2);
+  __global const Dtype *Aptr = wg;
+  __global const Dtype *Bptr = im_in + v_B_off * batch;
+  __global Dtype *Cptr = im_out + v_C_off * batch;
+  __global const Dtype *Dptr = bias;
+  // Initialize the accumulation registers.
+  {
+    Dtype4 Creg[WPTM][WPTN / VWN];
+// Initialize the accumulation registers.
+#pragma unroll
+    for (int_tp wm = 0; wm < WPTM; ++wm) {
+#pragma unroll
+      for (int_tp wn = 0; wn < WPTN / VWN; ++wn) {
+        VEC_4_0(Creg[wm][wn]) = 0.0;
+        VEC_4_1(Creg[wm][wn]) = 0.0;
+        VEC_4_2(Creg[wm][wn]) = 0.0;
+        VEC_4_3(Creg[wm][wn]) = 0.0;
+      }
+    }
+    {
+// Loop over all tiles.
+#pragma unroll 1
+      for (int_tp t = 0; t < v_num_tiles; ++t) {
+        // Load one tile of A into local memory.
+        {
+#pragma unroll 4
+          for (int_tp la = 0; la < LPTA; ++la) {
+            int_tp tid = tidm * RTSN + tidn;
+            int_tp id = la * RTSN * RTSM + tid;
+            int_tp row = id / TSK;
+            int_tp col = id % TSK;
+            int_tp tiledIndex = TSK * t + col;
+            if ((offM + row) < MM && tiledIndex < KK) {
+              Asub[row][col] = Aptr[(offM + row) * KK + tiledIndex];
+            } else {
+              Asub[row][col] = 0.0;
+            }
+          }
+        }
+        // Load one tile of B into local memory.
+        {
+#pragma unroll 4
+          for (int_tp lb = 0; lb < LPTB; ++lb) {
+            int_tp tid = tidm * RTSN + tidn;
+            int_tp id = lb * RTSN * RTSM + tid;
+            int_tp col = id % TSN;
+            int_tp row = id / TSN;
+            int_tp tiledIndex = TSK * t + row;
+            if ((offN + col) < NN && tiledIndex < KK) {
+              int_tp d_iter_0;
+              int_tp d_temp_0;
+              int_tp d_iter_1;
+              int_tp d_temp_1;
+              int_tp imageIndex = offN + col;
+              // Compute d_iter, final tiledIndex becomes input feature map ID.
+              // Scale d_iter by the dilation factor.
+              d_iter_1 = (tiledIndex % v_k_1) * v_d_1;
+              tiledIndex = tiledIndex / v_k_1;
+              // Compute d_temp.
+              // Scale d_temp by the stride and subtract the padding.
+              d_temp_1 = (imageIndex % v_imso_1) * v_s_1 - v_p_1;
+              imageIndex = imageIndex / v_imso_1;
+              // Compute d_iter, final tiledIndex becomes input feature map ID.
+              // Scale d_iter by the dilation factor.
+              d_iter_0 = (tiledIndex % v_k_0) * v_d_0;
+              tiledIndex = tiledIndex / v_k_0;
+              // Compute d_temp.
+              // Scale d_temp by the stride and subtract the padding.
+              d_temp_0 = (imageIndex % v_imso_0) * v_s_0 - v_p_0;
+              imageIndex = imageIndex / v_imso_0;
+              // Recombine final index, compute in-range.
+              bool skip_range_check = false;
+              // Used only if padding is not 0.
+              bool in_range = !skip_range_check;
+              int_tp d_iter_im;
+              // Here, d_temp_ represents the column shift,
+              // while d_iter_ is the kernel shift.
+              d_iter_im = d_temp_0 + d_iter_0;
+              tiledIndex = tiledIndex * v_imsi_0 + d_iter_im;
+              if (!skip_range_check) {
+                in_range &= d_iter_im >= 0 && d_iter_im < v_imsi_0;
+              }
+              // Here, d_temp_ represents the column shift,
+              // while d_iter_ is the kernel shift.
+              d_iter_im = d_temp_1 + d_iter_1;
+              tiledIndex = tiledIndex * v_imsi_1 + d_iter_im;
+              if (!skip_range_check) {
+                in_range &= d_iter_im >= 0 && d_iter_im < v_imsi_1;
+              }
+              if (skip_range_check || in_range) {
+                // tiledIndex now holds the memory offset for the input image.
+                Bsub[row][col] = Bptr[tiledIndex];
+              } else {
+                Bsub[row][col] = 0.0;
+              }
+            }
+          }
+        }
+        // Synchronize to make sure the tile is loaded.
+        barrier(CLK_LOCAL_MEM_FENCE);
+        // Temporary registers for A and B.
+        Dtype4 Areg;
+        Dtype4 Breg[WPTN / VWN];
+// Loop over the values of a single tile.
+#pragma unroll 1
+        for (int_tp kt = 0; kt < TSK; kt += TSK_UNROLL) {
+#pragma unroll 1
+          for (int_tp ku = 0; ku < TSK_UNROLL; ++ku) {
+            int_tp k = kt + ku;
+// Cache the values of Bsub in registers.
+#pragma unroll
+            for (int_tp wn = 0; wn < WPTN / VWN; ++wn) {
+              int_tp col = tidn + wn * VWN * RTSN;
+              VEC_4_0(Breg[wn]) = Bsub[k][col + 0 * RTSN];
+              VEC_4_1(Breg[wn]) = Bsub[k][col + 1 * RTSN];
+              VEC_4_2(Breg[wn]) = Bsub[k][col + 2 * RTSN];
+              VEC_4_3(Breg[wn]) = Bsub[k][col + 3 * RTSN];
+            }
+// Perform the computation.
+#pragma unroll
+            for (int_tp wm = 0; wm < WPTM / VWM; ++wm) {
+              int_tp row = tidm + wm * VWM * RTSM;
+              VEC_4_0(Areg) = Asub[row + 0 * RTSM][k];
+              VEC_4_1(Areg) = Asub[row + 1 * RTSM][k];
+              VEC_4_2(Areg) = Asub[row + 2 * RTSM][k];
+              VEC_4_3(Areg) = Asub[row + 3 * RTSM][k];
+#pragma unroll
+              for (int_tp wn = 0; wn < WPTN / VWN; ++wn) {
+                VEC_4_0(Creg[wm * VWM + 0][wn]) +=
+                    VEC_4_0(Areg) * VEC_4_0(Breg[wn]);
+                VEC_4_0(Creg[wm * VWM + 1][wn]) +=
+                    VEC_4_1(Areg) * VEC_4_0(Breg[wn]);
+                VEC_4_0(Creg[wm * VWM + 2][wn]) +=
+                    VEC_4_2(Areg) * VEC_4_0(Breg[wn]);
+                VEC_4_0(Creg[wm * VWM + 3][wn]) +=
+                    VEC_4_3(Areg) * VEC_4_0(Breg[wn]);
+                VEC_4_1(Creg[wm * VWM + 0][wn]) +=
+                    VEC_4_0(Areg) * VEC_4_1(Breg[wn]);
+                VEC_4_1(Creg[wm * VWM + 1][wn]) +=
+                    VEC_4_1(Areg) * VEC_4_1(Breg[wn]);
+                VEC_4_1(Creg[wm * VWM + 2][wn]) +=
+                    VEC_4_2(Areg) * VEC_4_1(Breg[wn]);
+                VEC_4_1(Creg[wm * VWM + 3][wn]) +=
+                    VEC_4_3(Areg) * VEC_4_1(Breg[wn]);
+                VEC_4_2(Creg[wm * VWM + 0][wn]) +=
+                    VEC_4_0(Areg) * VEC_4_2(Breg[wn]);
+                VEC_4_2(Creg[wm * VWM + 1][wn]) +=
+                    VEC_4_1(Areg) * VEC_4_2(Breg[wn]);
+                VEC_4_2(Creg[wm * VWM + 2][wn]) +=
+                    VEC_4_2(Areg) * VEC_4_2(Breg[wn]);
+                VEC_4_2(Creg[wm * VWM + 3][wn]) +=
+                    VEC_4_3(Areg) * VEC_4_2(Breg[wn]);
+                VEC_4_3(Creg[wm * VWM + 0][wn]) +=
+                    VEC_4_0(Areg) * VEC_4_3(Breg[wn]);
+                VEC_4_3(Creg[wm * VWM + 1][wn]) +=
+                    VEC_4_1(Areg) * VEC_4_3(Breg[wn]);
+                VEC_4_3(Creg[wm * VWM + 2][wn]) +=
+                    VEC_4_2(Areg) * VEC_4_3(Breg[wn]);
+                VEC_4_3(Creg[wm * VWM + 3][wn]) +=
+                    VEC_4_3(Areg) * VEC_4_3(Breg[wn]);
+              }
+            }
+          }
+        }
+
+        // Synchronize before loading the next tile.
+        barrier(CLK_LOCAL_MEM_FENCE);
+      }
+    }
+// Store the final results in C.
+#pragma unroll
+    for (int_tp wm = 0; wm < WPTM; ++wm) {
+      int_tp globalRow = offM + tidm + wm * RTSM;
+      Dtype biasval = Dptr[globalRow];
+#pragma unroll
+      for (int_tp wn = 0; wn < WPTN; ++wn) {
+        int_tp globalCol = offN + tidn + wn * RTSN;
+        if (globalRow < MM && globalCol < NN) {
+          Cptr[globalRow * NN + globalCol] =
+              ((Dtype *)(&(Creg[wm][wn / VWN])))[wn % VWN] + v_bmul * biasval;
+        }
+      }
+    }
+  }
+}
+)";

--- a/tools/ClassGen/Backends/OpenCL/CMakeLists.txt
+++ b/tools/ClassGen/Backends/OpenCL/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(VERIF_FILENAME OpenCLSpecificNodesVerification.h)
+configure_file(${VERIF_FILENAME} ${GLOW_BINARY_DIR}/${VERIF_FILENAME} COPYONLY)
+
+set(VERIF_FILENAME OpenCLSpecificInstrsVerification.h)
+configure_file(${VERIF_FILENAME} ${GLOW_BINARY_DIR}/${VERIF_FILENAME} COPYONLY)

--- a/tools/ClassGen/Backends/OpenCL/OpenCLSpecificInstrs.h
+++ b/tools/ClassGen/Backends/OpenCL/OpenCLSpecificInstrs.h
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+#ifdef GLOW_WITH_OPENCL
+
+BB.newBackendSpecificInstr("OCLConvolution")
+    .addOperand("Dest", OperandKind::Out)
+    .addOperand("Src", OperandKind::In)
+    .addOperand("Filter", OperandKind::In)
+    .addOperand("Bias", OperandKind::In)
+    .addMember(MemberType::SizeT, "Kernel")
+    .addMember(MemberType::SizeT, "Stride")
+    .addMember(MemberType::SizeT, "Pad")
+    .autoIRGen()
+    .autoVerify(VerifyKind::SameElementType, {"Dest", "Src", "Filter", "Bias"});
+
+BB.newBackendSpecificInstr("OCLPoolAvg")
+    .addOperand("Dest", OperandKind::Out)
+    .addOperand("Src", OperandKind::In)
+    .addMember(MemberType::SizeT, "Kernel")
+    .addMember(MemberType::SizeT, "Stride")
+    .addMember(MemberType::SizeT, "Pad")
+    .autoIRGen()
+    .autoVerify(VerifyKind::SameElementType, {"Dest", "Src"})
+    .addGradientInstr({"Dest"}, {"Dest", "Src"});
+
+BB.newBackendSpecificInstr("OCLPoolMax")
+    .addOperand("Dest", OperandKind::Out)
+    .addOperand("Src", OperandKind::In)
+    .addMember(MemberType::SizeT, "Kernel")
+    .addMember(MemberType::SizeT, "Stride")
+    .addMember(MemberType::SizeT, "Pad")
+    .autoIRGen()
+    .autoVerify(VerifyKind::SameElementType, {"Dest", "Src"});
+
+BB.includeBackendSpecificVerification("OpenCLSpecificInstrsVerification.h");
+
+#endif // GLOW_WITH_CPU

--- a/tools/ClassGen/Backends/OpenCL/OpenCLSpecificInstrsVerification.h
+++ b/tools/ClassGen/Backends/OpenCL/OpenCLSpecificInstrsVerification.h
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef GLOW_WITH_OPENCL
+
+#endif // GLOW_WITH_OPENCL

--- a/tools/ClassGen/Backends/OpenCL/OpenCLSpecificNodes.h
+++ b/tools/ClassGen/Backends/OpenCL/OpenCLSpecificNodes.h
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef GLOW_WITH_OPENCL
+
+BB.newNode("OCLConvolution")
+    .addInput("Input")
+    .addInput("Filter")
+    .addInput("Bias")
+    .addMember(MemberType::SizeT, "Kernel")
+    .addMember(MemberType::SizeT, "Stride")
+    .addMember(MemberType::SizeT, "Pad")
+    .addResultFromCtorArg()
+    .setDocstring(
+        "This is an OpenCL-specific convolution implementation where the "
+        "filter, the bias and the input are in the HCHW format");
+
+BB.newNode("OCLPoolAvg")
+    .addInput("Input")
+    .addMember(MemberType::SizeT, "Kernel")
+    .addMember(MemberType::SizeT, "Stride")
+    .addMember(MemberType::SizeT, "Pad")
+    .addResultFromCtorArg()
+    .setDocstring(
+        "This is an OpenCL-specific Average Pool operation on the Input given "
+        "provided Kernel, Stride, and Pad. The input and output are in NCHW "
+        "format");
+
+BB.newNode("OCLPoolMax")
+    .addInput("Input")
+    .addMember(MemberType::SizeT, "Kernel")
+    .addMember(MemberType::SizeT, "Stride")
+    .addMember(MemberType::SizeT, "Pad")
+    .addResultFromCtorArg()
+    .setDocstring(
+        "This is an OpenCL-specific Max Pool operation on the Input given "
+        "provided "
+        "Kernel, Stride, and Pad. The input and output are in NCHW format");
+
+BB.includeBackendSpecificVerification("OpenCLSpecificNodesVerification.h");
+
+#endif // GLOW_WITH_CPU

--- a/tools/ClassGen/Backends/OpenCL/OpenCLSpecificNodesVerification.h
+++ b/tools/ClassGen/Backends/OpenCL/OpenCLSpecificNodesVerification.h
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef GLOW_WITH_OPENCL
+
+void OCLConvolutionNode::verify() const {
+  ShapeNCHW idim(getInput().getType()->dims());
+  ShapeNCHW odim(getResult().getType()->dims());
+  auto outSz = calculateConvOutputDims(idim.h, idim.w, getKernel(), getStride(),
+                                       getPad());
+  ShapeNCHW exp(idim.n, getBias().dims()[0], outSz.first, outSz.second);
+  (void)exp;
+  assert(exp == odim && "Invalid output dimensions");
+}
+
+void OCLPoolAvgNode::verify() const {}
+
+void OCLPoolMaxNode::verify() const {}
+#endif // GLOW_WITH_OPENCL

--- a/tools/ClassGen/CMakeLists.txt
+++ b/tools/ClassGen/CMakeLists.txt
@@ -17,3 +17,7 @@ target_link_libraries(InstrGen
 if(GLOW_WITH_CPU)
   add_subdirectory(Backends/CPU)
 endif()
+
+if(GLOW_WITH_OPENCL)
+  add_subdirectory(Backends/OpenCL)
+endif()

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -416,6 +416,7 @@ int main(int argc, char **argv) {
   //===--------------------------------------------------------------------===//
 
 #include "Backends/CPU/CPUSpecificInstrs.h"
+#include "Backends/OpenCL/OpenCLSpecificInstrs.h"
 
   return 0;
 }

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -431,6 +431,7 @@ int main(int argc, char **argv) {
   //===--------------------------------------------------------------------===//
 
 #include "Backends/CPU/CPUSpecificNodes.h"
+#include "Backends/OpenCL/OpenCLSpecificNodes.h"
 
   return 0;
 }


### PR DESCRIPTION
This implementation uses standalone parameterized convolution kernels heavily based on the kernels produced by libDNN. 

The kernel is parameterized by means of macro-definitions, which define such properties like size of the filter, padding, stride, sizes of workgroups, etc.  The OpenCL backend produces specialized convolution kernels by providing these parameters based on the parameters of the current convolution instruction and its operands. 

To achieve their efficiency, the kernels work with inputs and weights in the NCHW format, which is often used for GPUs kernels due to more optimal memory access behavior. Since Glow by default uses the NHWC format, I introduced new OpenCL-backend nodes and instructions for convolutions and pooling. NHWC versions of these nodes are converted into their NCHW counterparts by a custom post-lowering pass. This transformation introduces a number of transposes for the inputs and outputs as the rest of the graph is still expecting the NHWC format. But thanks to the recently improved transpose sinking optimization, (almost) all of these transposes are eliminated and do not introduce any significant performance overhead.

The OpenCL kernels use some typical GPU tricks to improve performance, e.g.:
- Using __local memory to load input and kernel tiles and share them between all threads in a work group to reduce the amount of accesses to the global memory (tiling from off-chip to local memory).
- Increasing the work per thread by means of register blocking (blocking from local memory to registers). 
- Using  local variables of wider vector types to speed up computation in each thread and to accumulate results.
- Explicit loop unrolling and pragmas controlling the loop unrolling.

These generated kernels are much faster than the default OpenCL NHWC convolution kernels that were used so far. On resnet50, the performance with a batch size of 1 approaches the performance of the CPU convolutions. And with batches of size bigger than 2 it surpasses the the performance of the CPU backend.

NOTE: The PR is rather big as besides the fast parameterized kernels (see kernels_fwd_conv.cl and  OCLBackend::executeConvolution) it also provides the required pre-requisites like new nodes and instructions for convolutions and pooling in the NCHW format and post-lowering graph transformations for converting the required nodes into this format. This is done to show how the new kernels and new nodes/instructions play together. Once we agree on the overall approach, the PR can be split into smaller parts if necessary. For example, all the per-requisites can be submitted in a separate PR.