### PR TITLE
[test] Verify that nextRandInt actually gets a closed interval

### DIFF
--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -114,7 +114,14 @@ target_link_libraries(quantizationTest
                         testMain)
 add_test(quantizationTest ${GLOW_BINARY_DIR}/tests/quantizationTest)
 
-
+add_executable(UtilsTest
+               UtilsTest.cpp)
+target_link_libraries(UtilsTest
+                      PRIVATE
+                        Support
+                        gtest
+                        testMain)
+add_test(UtilsTest ${GLOW_BINARY_DIR}/tests/UtilsTest)
 
 if(GLOW_WITH_OPENCL)
 add_executable(OCLTest

--- a/tests/unittests/UtilsTest.cpp
+++ b/tests/unittests/UtilsTest.cpp
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/Support/Random.h"
+
+#include "gtest/gtest.h"
+
+using namespace glow;
+
+// Test that nextRandInt generates every number in the closed interval [lb, ub].
+// Use enough trials that the probability of random failure is < 1.0e-9.
+TEST(Utils, randomClosedInterval) {
+  constexpr int lb = -3;
+  constexpr int ub = 3;
+  constexpr int trials = 200;
+
+  for (int i = lb; i <= ub; i++) {
+    int j = 0;
+    for (; j < trials; j++) {
+      if (nextRandInt(lb, ub) == i) {
+        break;
+      }
+    }
+    EXPECT_LT(j, trials);
+  }
+}


### PR DESCRIPTION
I was pretty sure this was the case from looking at code/comments, but, "trust but verify".  This test takes 1 ms in the common case so it's not like it adds any real overhead.