### PR TITLE
fixed the Release build warning issue

### DIFF
--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -820,6 +820,7 @@ void OCLBackend::doForwardPass() {
       fillBuffer(deviceBuffer_, tensors_[biasGrad], biasGrad->size(), 0,
                  biasGrad->getElementType());
 
+      (void)filter; 
       assert(filter->dims() == filterGrad->dims() && "Dims should be the same");
       assert(src->dims() == srcGrad->dims() && "Dims should be the same");
 

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -684,8 +684,7 @@ Node *Function::createChannelShuffle(llvm::StringRef name, NodeValue input,
 
 Node *Function::createSqueeze(llvm::StringRef name, NodeValue input,
                               llvm::ArrayRef<size_t> axes) {
-  auto originalSize = axes.size();
-  assert(originalSize > 0 && "Parameter `axes` must be provided.");
+  assert(!axes.empty() && "Parameter `axes` must be provided.");
 
   ShapeVector shapeAxes(axes.begin(), axes.end());
 


### PR DESCRIPTION
A var used only in assert() is viewed as "unused var" in release-mode. Fixed the code the avoid this warning reporting in Release build.