### PR TITLE
[Graph] change the Concat API to accept NodeValue instead of Node*

### DIFF
--- a/examples/fr2en.cpp
+++ b/examples/fr2en.cpp
@@ -250,7 +250,7 @@ void Model::loadEncoder() {
 
   // TODO: encoder does exactly MAX_LENGTH steps, while input size is smaller.
   // We could use control flow here.
-  std::vector<Node *> outputs;
+  std::vector<NodeValue> outputs;
   for (unsigned step = 0; step < MAX_LENGTH; step++) {
     Node *inputSlice = F->createSlice(
         "encoder." + std::to_string(step) + ".inputSlice", inputEmbedded,
@@ -310,7 +310,7 @@ void Model::loadDecoder() {
   Node *hidden = encoderHiddenOutput_;
   Node *lastWordIdx = input;
 
-  std::vector<Node *> outputs;
+  std::vector<NodeValue> outputs;
   // TODO: decoder does exactly MAX_LENGTH steps, while translation could be
   // smaller. We could use control flow here.
   for (unsigned step = 0; step < MAX_LENGTH; step++) {

--- a/examples/ptb.cpp
+++ b/examples/ptb.cpp
@@ -216,7 +216,7 @@ void testPTB() {
     slicesX.push_back(Xt);
   }
 
-  std::vector<Node *> outputNodes;
+  std::vector<NodeValue> outputNodes;
   F->createSimpleRNN("rnn", slicesX, minibatchSize, hiddenSize, vocabSize,
                      outputNodes);
 

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -229,12 +229,14 @@ public:
                                  UnsignedArrayRef shape, unsigned axis);
 
   /// Create concat node which concatenates input tensors along \p dimension.
-  ConcatNode *createConcat(llvm::StringRef name, llvm::ArrayRef<Node *> inputs,
+  ConcatNode *createConcat(llvm::StringRef name,
+                           llvm::ArrayRef<NodeValue> inputs,
                            unsigned dimension);
 
   /// Create concat node with the given return type \p outTy.
-  ConcatNode *createConcat(llvm::StringRef name, llvm::ArrayRef<Node *> inputs,
-                           unsigned dimension, TypeRef outTy);
+  ConcatNode *createConcat(llvm::StringRef name,
+                           llvm::ArrayRef<NodeValue> inputs, unsigned dimension,
+                           TypeRef outTy);
 
   SliceNode *createSlice(llvm::StringRef name, NodeValue input,
                          UnsignedArrayRef begin, UnsignedArrayRef end);
@@ -348,7 +350,7 @@ public:
   void createSimpleRNN(llvm::StringRef namePrefix,
                        const llvm::ArrayRef<Node *> inputs, unsigned batchSize,
                        unsigned hiddenSize, unsigned outputSize,
-                       std::vector<Node *> &outputs);
+                       std::vector<NodeValue> &outputs);
 
   /// Create an unrolled single-layer GRU cell with \p hiddenSize
   /// dimensionality of the hidden state and \p outputSize dimensionality of the
@@ -361,7 +363,7 @@ public:
   void createGRU(llvm::StringRef namePrefix,
                  const llvm::ArrayRef<Node *> inputs, unsigned batchSize,
                  unsigned hiddenSize, unsigned outputSize,
-                 std::vector<Node *> &outputs);
+                 std::vector<NodeValue> &outputs);
 
   /// Create an unrolled single-layer LSTM cell with \p hiddenSize
   /// dimensionality of the hidden state and \p outputSize dimensionality of the
@@ -374,7 +376,7 @@ public:
   void createLSTM(llvm::StringRef namePrefix,
                   const llvm::ArrayRef<Node *> inputs, unsigned batchSize,
                   unsigned hiddenSize, unsigned outputSize,
-                  std::vector<Node *> &outputs);
+                  std::vector<NodeValue> &outputs);
 
   /// @}
 

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -574,7 +574,7 @@ static bool sameSameShapeExceptDim(TypeRef T1, TypeRef T2, unsigned dim) {
 }
 
 ConcatNode *Function::createConcat(llvm::StringRef name,
-                                   llvm::ArrayRef<Node *> inputs,
+                                   llvm::ArrayRef<NodeValue> inputs,
                                    unsigned dimension) {
   for (int i = 1, e = inputs.size(); i < e; i++) {
     assert(sameSameShapeExceptDim(inputs[i]->getType(), inputs[0]->getType(),
@@ -603,7 +603,7 @@ ConcatNode *Function::createConcat(llvm::StringRef name,
 }
 
 ConcatNode *Function::createConcat(llvm::StringRef name,
-                                   llvm::ArrayRef<Node *> inputs,
+                                   llvm::ArrayRef<NodeValue> inputs,
                                    unsigned dimension, TypeRef outTy) {
   std::vector<NodeValue> ops;
   ops.reserve(inputs.size());
@@ -931,7 +931,7 @@ void Function::createSimpleRNN(llvm::StringRef namePrefix,
                                llvm::ArrayRef<Node *> inputs,
                                unsigned batchSize, unsigned hiddenSize,
                                unsigned outputSize,
-                               std::vector<Node *> &outputs) {
+                               std::vector<NodeValue> &outputs) {
   std::string nameBase = namePrefix;
   const unsigned timeSteps = inputs.size();
   assert(timeSteps > 0 && "empty input");
@@ -986,7 +986,7 @@ void Function::createSimpleRNN(llvm::StringRef namePrefix,
 void Function::createGRU(llvm::StringRef namePrefix,
                          llvm::ArrayRef<Node *> inputs, unsigned batchSize,
                          unsigned hiddenSize, unsigned outputSize,
-                         std::vector<Node *> &outputs) {
+                         std::vector<NodeValue> &outputs) {
   std::string nameBase = namePrefix;
   const unsigned timeSteps = inputs.size();
   assert(timeSteps > 0 && "empty input");
@@ -1122,7 +1122,7 @@ void Function::createGRU(llvm::StringRef namePrefix,
 void Function::createLSTM(llvm::StringRef namePrefix,
                           llvm::ArrayRef<Node *> inputs, unsigned batchSize,
                           unsigned hiddenSize, unsigned outputSize,
-                          std::vector<Node *> &outputs) {
+                          std::vector<NodeValue> &outputs) {
   std::string nameBase = namePrefix;
   const unsigned timeSteps = inputs.size();
   assert(timeSteps > 0 && "empty input");

--- a/lib/Importer/Caffe2.cpp
+++ b/lib/Importer/Caffe2.cpp
@@ -323,7 +323,7 @@ void caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
 
   if (typeName == "Concat") {
     const unsigned numInputs = op.input_size();
-    llvm::SmallVector<Node *, 4> inputs;
+    llvm::SmallVector<NodeValue, 4> inputs;
     inputs.reserve(numInputs);
     for (unsigned i = 0; i < numInputs; i++) {
       inputs.push_back(getOrCreateNodeByName(op.input(i)));

--- a/lib/Importer/ONNX.cpp
+++ b/lib/Importer/ONNX.cpp
@@ -437,7 +437,7 @@ void ONNXModelLoader::loadOperator(const onnx::NodeProto &op) {
 
   if (typeName == "Concat") {
     const unsigned numInputs = op.input_size();
-    llvm::SmallVector<Node *, 4> inputs;
+    llvm::SmallVector<NodeValue, 4> inputs;
     inputs.reserve(numInputs);
     for (unsigned i = 0; i < numInputs; i++) {
       inputs.push_back(getOrCreateNodeByName(op.input(i)));

--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -561,7 +561,7 @@ static void optimizeConcatNodes(Function *F) {
     if (auto *CN = dyn_cast<ConcatNode>(node)) {
       auto inputs = CN->getInputs();
       // Check if any of the inputs is a ConcatNode.
-      llvm::SmallVector<Node *, 16> newInputs;
+      llvm::SmallVector<NodeValue, 16> newInputs;
       bool changed = false;
       for (auto input : inputs) {
         newInputs.push_back(input);

--- a/lib/Optimizer/Lower.cpp
+++ b/lib/Optimizer/Lower.cpp
@@ -508,7 +508,7 @@ void lowerGroupConvolutionNode(Function *F, ConvolutionNode &BNG) {
   auto outTy = F->getParent()->uniqueTypeWithNewShape(
       BNG.getResult()->getType(), outDims);
 
-  std::vector<Node *> convs(group);
+  std::vector<NodeValue> convs;
   for (unsigned groupId = 0; groupId < group; groupId++) {
     auto *in_slice =
         F->createSlice(BNG.getName(), in, {0, 0, 0, groupId * inCperG},
@@ -518,8 +518,8 @@ void lowerGroupConvolutionNode(Function *F, ConvolutionNode &BNG) {
                        {(groupId + 1) * outCperG, kernel, kernel, inCperG});
     auto *bias_slice = F->createSlice(BNG.getName(), bias, {groupId * outCperG},
                                       {(groupId + 1) * outCperG});
-    convs[groupId] = F->createConv(BNG.getName(), in_slice, filter_slice,
-                                   bias_slice, outTy, kernel, stride, pad, 1);
+    convs.push_back(F->createConv(BNG.getName(), in_slice, filter_slice,
+                                  bias_slice, outTy, kernel, stride, pad, 1));
   }
   auto result = F->createConcat(BNG.getName(), convs, 3);
   BNG.getResult().replaceAllUsesOfWith(result);

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -236,11 +236,11 @@ float dequantize(int8_t input, const TensorQuantizationParams &TQP) {
 
 /// Quantize all inputs for \p node and return back pointers to the newly
 /// created qunatization nodes.
-static llvm::SmallVector<Node *, 6>
+static llvm::SmallVector<NodeValue, 6>
 quantizeInputs(Function *F, Node *node,
                const std::unordered_map<std::string, TensorQuantizationParams>
                    &nodeToTQP) {
-  llvm::SmallVector<Node *, 6> quantizedInputs;
+  llvm::SmallVector<NodeValue, 6> quantizedInputs;
 
   for (unsigned i = 0, e = node->getNumInputs(); i < e; ++i) {
     NodeValue &NV = node->getNthInput(i);
@@ -303,7 +303,7 @@ static bool canBeQuantized(const Node *node) {
 /// \param qParams Tensor quantization parameters for all outputs of the
 ///        \p node.
 static Node *quantizeNode(Function *F, Node *node,
-                          llvm::MutableArrayRef<Node *> quantizedInputs,
+                          llvm::MutableArrayRef<NodeValue> quantizedInputs,
                           llvm::ArrayRef<TensorQuantizationParams> qParams) {
   Node *quantizedNode{};
 

--- a/tests/unittests/InterpreterTest.cpp
+++ b/tests/unittests/InterpreterTest.cpp
@@ -475,25 +475,25 @@ TEST_P(MLTest, learnSingleValueConcat) {
 
 void buildGRU(Function *F, const std::vector<Node *> &slicesX,
               unsigned hiddenSize, unsigned outputSize,
-              std::vector<Node *> &outputs) {
+              std::vector<NodeValue> &outputs) {
   return F->createGRU("GRU", slicesX, 1, hiddenSize, outputSize, outputs);
 };
 
 void buildRNN(Function *F, const std::vector<Node *> &slicesX,
               unsigned hiddenSize, unsigned outputSize,
-              std::vector<Node *> &outputs) {
+              std::vector<NodeValue> &outputs) {
   return F->createSimpleRNN("SimpleRNN", slicesX, 1, hiddenSize, outputSize,
                             outputs);
 };
 
 void buildLSTM(Function *F, const std::vector<Node *> &slicesX,
                unsigned hiddenSize, unsigned outputSize,
-               std::vector<Node *> &outputs) {
+               std::vector<NodeValue> &outputs) {
   return F->createLSTM("LSTM", slicesX, 1, hiddenSize, outputSize, outputs);
 };
 
 using TCellGenerator = void (*)(Function *, const std::vector<Node *> &,
-                                unsigned, unsigned, std::vector<Node *> &);
+                                unsigned, unsigned, std::vector<NodeValue> &);
 
 void testRNNCell(TCellGenerator cell) {
   ExecutionEngine EE;
@@ -536,10 +536,10 @@ void testRNNCell(TCellGenerator cell) {
   const unsigned hiddenSize = 5;
   const unsigned outputSize = 1;
 
-  std::vector<Node *> outputNodes;
+  std::vector<NodeValue> outputNodes;
   cell(F, XSliced, hiddenSize, outputSize, outputNodes);
 
-  std::vector<Node *> regressionNodes;
+  std::vector<NodeValue> regressionNodes;
   for (unsigned t = 0; t < NumVectors; t++) {
     regressionNodes.push_back(
         F->createRegression("", outputNodes[t], YSliced[t]));


### PR DESCRIPTION
Change the Concat API to accept NodeValue instead of Node*. We may want
to concat nodes with multiple results and the Node* API does not allow
this.