### PR TITLE
Cleanup the Insert/Extract implementation and add a unit test. 

### DIFF
--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -108,4 +108,6 @@ void inferComplexNet1(Tensor *inputs1, Tensor *inputs2, Tensor *inputs3,
 void inferTinyResnet(Tensor *input, Tensor *out, std::vector<Tensor> &weights,
                      BackendKind kind);
 
+void inferExtract3D(Tensor *input, Tensor *out, BackendKind kind);
+
 } // namespace glow

--- a/tests/unittests/JITTest.cpp
+++ b/tests/unittests/JITTest.cpp
@@ -89,7 +89,7 @@ TEST(JITCorrectnessTest, convTest) {
 }
 
 TEST(JITCorrectnessTest, extract3Dtest) {
-  Tensor inputs(ElemKind::FloatTy, {10, 100, 100});
+  Tensor inputs(ElemKind::FloatTy, {5, 100, 100});
   inputs.getHandle().initXavier(1);
   std::array<size_t, 4> S{{1, 95, 100}};
   llvm::ArrayRef<size_t> shape(S);

--- a/tests/unittests/JITTest.cpp
+++ b/tests/unittests/JITTest.cpp
@@ -88,6 +88,20 @@ TEST(JITCorrectnessTest, convTest) {
   EXPECT_TRUE(out1.isEqual(out2));
 }
 
+TEST(JITCorrectnessTest, extract3Dtest) {
+  Tensor inputs(ElemKind::FloatTy, {10, 100, 100});
+  inputs.getHandle().initXavier(1);
+  std::array<size_t, 4> S{{1, 95, 100}};
+  llvm::ArrayRef<size_t> shape(S);
+  Tensor out1(ElemKind::FloatTy, shape);
+  Tensor out2(ElemKind::FloatTy, shape);
+
+  inferExtract3D(&inputs, &out1, BackendKind::CPU);
+  inferExtract3D(&inputs, &out2, BackendKind::Interpreter);
+
+  EXPECT_TRUE(out1.isEqual(out2));
+}
+
 TEST(JITCorrectnessTest, quantizedConvTest) {
   Tensor inputs(ElemKind::Int8QTy, {20, 41, 32, 6}, 0.025, -7);
   Tensor kernel(ElemKind::Int8QTy, {10, 5, 5, 6}, 0.003, 3);


### PR DESCRIPTION
The first commit adds a new unit test that stresses the insert/extract tensor instructions. The second commit simplifies the implementation of insert/extract. The recursive implementation was not optimizable and resulted in a sequence of recursive calls for each pixel for each dimension. The new version (which is a sequence of loops) optimizes pretty well.