### PR TITLE
[tests] Disable OpenCL GroupConvolution (ASAN violation)

### DIFF
--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -1510,7 +1510,7 @@ TEST_P(InterpAndCPU, IntSplat) {
   }
 }
 
-TEST_P(Operator, GroupConvolution) {
+TEST_P(InterpAndCPU, GroupConvolution) {
   auto *input = mod_.createVariable(ElemKind::FloatTy, {1, 2, 1, 8}, "input");
   auto IH = input->getHandle();
   for (size_t i = 0; i < 2 * 8; i++) {


### PR DESCRIPTION
Didn't see this last night since I wasn't running with ASAN locally (and Travis doesn't run with OpenCL)