### PR TITLE
[cleanup] Add constness to the param in differentiate function.

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -449,7 +449,7 @@ using VariableGradientsList = std::list<std::pair<Variable *, Variable *>>;
 /// (var, grad_var) pairs associating variables with their gradient variables.
 /// This feature is used by the gradient-check unit tests.
 /// \returns a new function with the name \p newFuncName.
-Function *differentiate(Function *F, TrainingConfig &config,
+Function *differentiate(Function *F, const TrainingConfig &config,
                         llvm::StringRef newFuncName = "",
                         VariableGradientsList *varGrads = nullptr);
 

--- a/lib/Graph/Grad.cpp
+++ b/lib/Graph/Grad.cpp
@@ -53,7 +53,7 @@ NodeValue GraphGradMapper::getGradient(NodeValue activation) {
 //        Code for automatically generating the back propagation code.
 //===----------------------------------------------------------------------===//
 
-Function *glow::differentiate(Function *F, TrainingConfig &conf,
+Function *glow::differentiate(Function *F, const TrainingConfig &conf,
                               llvm::StringRef newFuncName,
                               VariableGradientsList *varGrads) {
   // Create a new name for the differentiated function, if none is given.


### PR DESCRIPTION
to address the issue: https://github.com/pytorch/glow/issues/1050