### PR TITLE
[Optimizer] Optimize concat that comes from a sequence of slices. 

### DIFF
--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -1670,6 +1670,9 @@ TEST_P(Operator, testBatchAdd) {
 
   auto *cc = F_->createConcat("concat", adds, 0);
 
+  // Remove the reference to the graph nodes to allow DCE to remove them.
+  adds.clear();
+
   F_->createSave("save", cc, result);
 
   EE_.compile(CompilationMode::Infer, F_);
@@ -1721,6 +1724,9 @@ TEST_P(InterpAndCPU, testQuantizedBatchAdd) {
   Node *cc = F_->createConcat("concat", adds, 0, qInType);
   cc = F_->createDequantize("dq", cc);
   F_->createSave("save", cc, result);
+
+  // Remove the reference to the graph nodes to allow DCE to remove them.
+  adds.clear();
 
   EE_.compile(CompilationMode::Infer, F_);
   EE_.run({}, {});


### PR DESCRIPTION
Optimize concat that comes from a sequence of slices. If all of the inputs 
to the concat are extracted from the same input in the right order then we
can just use the extract-input instead of the concat.

Concat(Slice(X, 0..10), Slice(X, 10..20)) -> X.