### PR TITLE
[llvm] More robust and flexible function specialization implementation

### DIFF
--- a/lib/Backends/CPU/LLVMIRGen.h
+++ b/lib/Backends/CPU/LLVMIRGen.h
@@ -196,6 +196,11 @@ public:
   void optimizeLLVMModule(llvm::Function *F, llvm::TargetMachine &TM);
   /// Performs specialization of operations based on constant parameters.
   void performSpecialization();
+  /// Performs specialization of a call based on constant parameters.
+  /// In case of a successful specialization, the old call instruction is
+  /// replaced by the new one and the old one is erases. \returns the new
+  /// specialized call or nullptr if no specialization was possible.
+  llvm::CallInst *specializeCallWithConstantArguments(llvm::CallInst *call);
   /// \returns allocations info.
   AllocationsInfo &getAllocationsInfo() { return allocationsInfo_; }
   /// \returns the name of the main entry point.


### PR DESCRIPTION
- The function specializer should use function cloning instead of relying on the inliner to perform specialization

  The function specializer was relying on the inliner to kick in and produce a specialized body of a function by substituting constant arguments. This works for simple cases, but does not allow for performing any specialization before inlining, which is required in some cases.

  This PR uses LLVM's cloning utilities to create the specialized body and makes the function specializer self-contained and not dependent on the LLVM's optimizer passes.

- Add a utility function for specializing specific calls for constant arguments