### PR TITLE
Disable unrolling grouped convolution opt (lowerGroupConvolutionNode) lowerGroupConvolutionNode

### DIFF
--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -417,6 +417,12 @@ bool CPUBackend::isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const {
   return true;
 }
 
+bool CPUBackend::shouldLower(Node *N) const {
+  if (N->getKind() == Kinded::Kind::ConvolutionNodeKind)
+    return false;
+  return true;
+}
+
 llvm::CallInst *glow::createCall(llvm::IRBuilder<> &builder,
                                  llvm::Function *callee,
                                  llvm::ArrayRef<llvm::Value *> args) {

--- a/lib/Backends/CPU/CPUBackend.h
+++ b/lib/Backends/CPU/CPUBackend.h
@@ -94,6 +94,8 @@ public:
   bool transformPostLowering(Function *F, CompilationMode mode) override;
 
   bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override;
+
+  bool shouldLower(Node *N) const override;
   /// @}
 };
 

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -145,6 +145,12 @@ bool Interpreter::isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const {
   return true;
 }
 
+bool Interpreter::shouldLower(Node *N) const {
+  if (N->getKind() == Kinded::Kind::ConvolutionNodeKind)
+    return false;
+  return true;
+}
+
 void Interpreter::doForwardPass() {
 // Do the forward pass.
 #define DEF_VALUE(CLASS, NAME)

--- a/lib/Backends/Interpreter/Interpreter.h
+++ b/lib/Backends/Interpreter/Interpreter.h
@@ -64,6 +64,8 @@ public:
   void doForwardPass() override;
 
   bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override;
+
+  bool shouldLower(Node *N) const override;
   /// @}
 
 private:


### PR DESCRIPTION
Group convolution is supported in CPU and Interpreter Backends.