### PR TITLE
[llvm] Limit the size of the emitted LLVM IR in the "main" function. Split it into multiple functions if required.

### DIFF
--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -200,9 +200,13 @@ void LLVMIRGen::initCodeGen() {
   // The entry point has the following API:
   // void entry(uint8_t *baseConstantWeightVars, uint8_t
   // *baseInoutWeightVars, uint8_t *baseActivations, size_t *offsets);
-  llvm::Type *voidTy = llvm::Type::getVoidTy(ctx_);
-  llvm::FunctionType *jitFuncTy = llvm::FunctionType::get(
-      voidTy, {int8PtrTy, int8PtrTy, int8PtrTy, sizeTPtrTy}, false);
+
+  // Type of the return value.
+  llvm::Type *returnTy = llvm::Type::getVoidTy(ctx_);
+  // Types of parameters.
+  llvm::Type *paramTys[] = {int8PtrTy, int8PtrTy, int8PtrTy, sizeTPtrTy};
+  llvm::FunctionType *jitFuncTy =
+      llvm::FunctionType::get(returnTy, paramTys, /* isVarArg */ false);
   auto *func = llvm::Function::Create(
       jitFuncTy, llvm::Function::ExternalLinkage, "main", llmodule_.get());
 
@@ -672,6 +676,52 @@ static bool isOverlappingWithAnyBundleBufferOperands(
 void LLVMIRGen::generateLLVMIRForModule(llvm::IRBuilder<> &builder) {
   // Go over the instructions and try to group them into bundles.
   auto &instrs = F_->getInstrs();
+  // Number of IR instructions emitted into the current LLVM function.
+  size_t numInstrsInCurrentFn = 0;
+  // Max number of IR instructions to be emitted into a single LLVM function.
+  constexpr size_t maxNumInstrsPerFn = 500;
+  // Current LLVM function that should be used for emitting LLVM instructions.
+  llvm::Function *curFn = builder.GetInsertBlock()->getParent();
+
+  // Create a new LLVM function with the same signature as the current one.
+  // Call this function and pass the arguments of the current function down to
+  // the new one.
+  // This is done to keep all generated LLVM functions rather small
+  // to speed up the JIT compilation.
+  auto createNewFnIfNecessary = [&]() {
+    // Check if the current function is getting too big and a new function needs
+    // to be created.
+    if (numInstrsInCurrentFn > maxNumInstrsPerFn) {
+      auto int8PtrTy = llvm::Type::getInt8PtrTy(ctx_);
+      auto sizeTPtrTy = llvm::Type::getIntNPtrTy(ctx_, sizeof(size_t) * 8);
+      // Type of the return value.
+      llvm::Type *returnTy = llvm::Type::getVoidTy(ctx_);
+      // Types of parameters.
+      llvm::Type *paramTys[] = {int8PtrTy, int8PtrTy, int8PtrTy, sizeTPtrTy};
+      llvm::FunctionType *jitFuncTy =
+          llvm::FunctionType::get(returnTy, paramTys, /* isVarArg */ false);
+      auto *func = llvm::Function::Create(
+          jitFuncTy, llvm::Function::ExternalLinkage, "main", llmodule_.get());
+      // This function should not be inlined as it would lead to huge functions.
+      func->addFnAttr(llvm::Attribute::NoInline);
+      std::vector<llvm::Value *> args;
+      for (auto &arg : curFn->args()) {
+        args.emplace_back(&arg);
+      }
+      // Insert the call of the new function right before the return.
+      createCall(builder, func, args);
+      builder.CreateRetVoid();
+      // The new function becomes a current LLVM function.
+      curFn = func;
+      llvm::BasicBlock *entryBB =
+          llvm::BasicBlock::Create(ctx_, "entry", curFn);
+      // LLVM code for the subsequent IR instructions should be emitted into the
+      // new function.
+      builder.SetInsertPoint(entryBB);
+      loadBaseAddresses(builder);
+      numInstrsInCurrentFn = 0;
+    }
+  };
 
   // Group instructions into bundles of shape compatible data parallel
   // instructions and emit them.
@@ -685,7 +735,9 @@ void LLVMIRGen::generateLLVMIRForModule(llvm::IRBuilder<> &builder) {
         continue;
       emitDataParallelKernel(builder, bundle);
       bundle.clear();
+      createNewFnIfNecessary();
       generateLLVMIRForInstr(builder, I);
+      numInstrsInCurrentFn++;
       continue;
     }
 
@@ -723,9 +775,11 @@ void LLVMIRGen::generateLLVMIRForModule(llvm::IRBuilder<> &builder) {
     if (!isBundleCompatible) {
       emitDataParallelKernel(builder, bundle);
       bundle.clear();
+      createNewFnIfNecessary();
     }
     // Add a data parallel instruction to the bundle.
     bundle.push_back(I);
+    numInstrsInCurrentFn++;
   }
 
   emitDataParallelKernel(builder, bundle);

--- a/lib/Backends/CPU/Pipeline.cpp
+++ b/lib/Backends/CPU/Pipeline.cpp
@@ -68,6 +68,10 @@ void LLVMIRGen::optimizeLLVMModule(llvm::Function *F, llvm::TargetMachine &TM) {
     // start with jit_
     if (name.empty() || name.startswith("libjit_"))
       return false;
+    // Do not preserve main functions that are called internally by the
+    // top-level main.
+    if (name.startswith("main."))
+      return false;
     return true;
   };
 


### PR DESCRIPTION
Some NN models result in really huge number of Glow IR instructions. When they are emitted as LLVM IR it in turn results in very, very big "main" functions. And this is really bad for JIT performance, because it significantly increases the compilation times as many LLVM optimization passes have to iterate over very long instruction lists.

This commit introduces the logic to split big "main" function in LLVM IR into smaller ones. This is done during the LLVMIRGen phase. The algorithm basically allows to irgen at most N Glow IR instructions into a single LLVM function. If there are more Glow IR instructions to be lowered into LLVM IR, then a new LLVM function is created and called at the very end of the current LLVM function currently generated by LLVMIRGen. From this moment, LLVMIRGen emits all subsequent LLVM instructions into this new function. If it becomes too big as well, the process repeats. As a result, it may produce a bunch of "main" functions forming a chain of invocations.

In case of using the CPU backend as a JIT, i.e. when "main" is being called from "jitmain", all invocations of these "main" functions are specialized for the constant parameters used for the base addresses of the activations memory region, weights memory region, etc. This guarantees that the produced optimized code is as efficient as it was when there was only a single, huge main function.