### PR TITLE
[ir-optimizer] Clean-ups to improve the compilation speed

### DIFF
--- a/lib/Optimizer/IROptimizer.cpp
+++ b/lib/Optimizer/IROptimizer.cpp
@@ -414,8 +414,6 @@ static void replaceAllNonDeallocUsersWith(Value *val, Value *with) {
       continue;
     }
 
-    auto &M = *I->getParent();
-    IRBuilder B(&M);
     // Ignore dealloc instrs.
     if (isa<DeallocActivationInst>(I)) {
       continue;


### PR DESCRIPTION
Recent testing with big NN models has uncovered some compilation speed issues at the Glow IR level. 

Profiling has shown that most of them are due to the same reasons:
- The versions of moveInstruction and eraseInstruction functions that take a glow::Instruction pointer as a parameter were called. These versions are very inefficient as they need to first find the instruction in the linked list representing the instructions list.

   This commit switches to using instruction iterators instead of instruction pointers. This solves all the issues with moveInstruction and eraseInstruction.

- A glow::IRBuilder object was created in a hot function that was called very often. It resulted in a rather significant compilation slow-down, because it is was created inside an often called hot function and apparently the destructor of IRBuilder is calling IRBuilder::deallocateActiveInstrs, which iterates over all IR instructions each time it is called. 

   Interestingly enough, this IRBuilder object was created, but never used ;-) It was probably forgotten after a re-factoring.  This PR simply removes this object and problems caused by it.

Combined, these simple changes result in very significant (up to 10x) compilation speed-ups on some of the NN models used for testing.