### PR TITLE
[IROptimizer] Add command line option -dump-opt-mod to dump the optimized Module.

### DIFF
--- a/lib/Optimizer/IROptimizer.cpp
+++ b/lib/Optimizer/IROptimizer.cpp
@@ -36,6 +36,11 @@ static llvm::cl::opt<bool>
     instrumentDebug("instrument-debug",
                     llvm::cl::desc("Instrument the IR for debugging"),
                     llvm::cl::init(false), llvm::cl::Hidden);
+static llvm::cl::opt<bool> dumpOptMod(
+    "dump-opt-mod",
+    llvm::cl::desc(
+        "Print the module to stdout after all optimizations are applied."),
+    llvm::cl::init(false), llvm::cl::Hidden);
 static llvm::cl::opt<bool> optimizeIR("optimize-ir",
                                       llvm::cl::desc("Enable IR optimizations"),
                                       llvm::cl::init(true), llvm::cl::Hidden);
@@ -1543,6 +1548,10 @@ void glow::optimize(IRFunction &M, CompilationMode mode, const Backend &B) {
 
   // Perform a debug instrumentation if required.
   performDebugInstrumentation(M);
+
+  // Print the module to stdout if requested.
+  if (dumpOptMod)
+    M.dump();
 
   M.verify();
 }


### PR DESCRIPTION
I've found this to be useful when debugging. 