### PR TITLE
[ir] Represent Glow IR instructions lists using LLVM's intrusive lists

### DIFF
--- a/include/glow/IR/IR.h
+++ b/include/glow/IR/IR.h
@@ -151,10 +151,10 @@ public:
   /// Adds a new operand \p op at the end of the operand list.
   void pushOperand(Operand op);
 
-  Instruction(IRFunction *M, llvm::StringRef name, Kinded::Kind k, TypeRef Ty)
+  Instruction(llvm::StringRef name, Kinded::Kind k, TypeRef Ty)
       : Value(name, Ty, k), F_(nullptr) {}
 
-  Instruction(IRFunction *M, llvm::StringRef name, Kinded::Kind k, TypeRef Ty,
+  Instruction(llvm::StringRef name, Kinded::Kind k, TypeRef Ty,
               llvm::ArrayRef<Operand> ops)
       : Value(name, Ty, k), F_(nullptr) {
     for (auto &op : ops) {

--- a/include/glow/IR/IR.h
+++ b/include/glow/IR/IR.h
@@ -23,6 +23,8 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/ilist.h"
+#include "llvm/ADT/ilist_node.h"
 
 #include <list>
 #include <unordered_map>
@@ -101,11 +103,15 @@ public:
 };
 
 /// This represents an instruction in our IR.
-class Instruction : public Value {
+class Instruction : public Value, public llvm::ilist_node<Instruction> {
 public:
   using Operand = InstructionOperand;
 
 private:
+  friend llvm::ilist_traits<Instruction>;
+  friend llvm::ilist_traits<IRFunction>;
+  friend IRFunction;
+
   /// Parent function.
   IRFunction *F_;
   /// If a predicate is set this index points to the non-zero index of the
@@ -120,7 +126,12 @@ private:
   Instruction(const Instruction &I) = delete;
   Instruction &operator=(const Instruction &I) = delete;
 
-protected:
+  /// Destroy an instruction and deallocate its memory. This function is
+  /// automatically invoked when the instruction is being deleted from the list
+  /// of instructions.
+  static void destroyInstruction(Instruction *I);
+
+public:
   /// Prevent the destruction of a derived object via a base-class pointer.
   /// Use IRFunction::destroyInstruction instead.
   ~Instruction() {
@@ -141,11 +152,11 @@ public:
   void pushOperand(Operand op);
 
   Instruction(IRFunction *M, llvm::StringRef name, Kinded::Kind k, TypeRef Ty)
-      : Value(name, Ty, k), F_(M) {}
+      : Value(name, Ty, k), F_(nullptr) {}
 
   Instruction(IRFunction *M, llvm::StringRef name, Kinded::Kind k, TypeRef Ty,
               llvm::ArrayRef<Operand> ops)
-      : Value(name, Ty, k), F_(M) {
+      : Value(name, Ty, k), F_(nullptr) {
     for (auto &op : ops) {
       pushOperand(op);
     }
@@ -201,6 +212,39 @@ protected:
   /// Dump the operands of the instruction into the stream \p os.
   void dumpOperands(llvm::raw_ostream &os) const;
 };
+} // namespace glow
+
+//===----------------------------------------------------------------------===//
+// ilist_traits for glow::Instruction
+//===----------------------------------------------------------------------===//
+
+namespace llvm {
+
+template <>
+struct ilist_traits<glow::Instruction>
+    : public ilist_default_traits<glow::Instruction> {
+  using Instruction = glow::Instruction;
+
+private:
+  glow::IRFunction *getContainingFunction();
+
+  using instr_iterator = simple_ilist<Instruction>::iterator;
+
+public:
+  static void deleteNode(Instruction *V) { Instruction::destroyInstruction(V); }
+
+  void addNodeToList(Instruction *I);
+  void removeNodeFromList(Instruction *I);
+  void transferNodesFromList(ilist_traits<Instruction> &L2,
+                             instr_iterator first, instr_iterator last);
+
+private:
+  void createNode(const Instruction &);
+};
+
+} // namespace llvm
+
+namespace glow {
 
 class WeightVar;
 class Value;
@@ -210,7 +254,7 @@ class Node;
 class IRFunction final {
 public:
   using VariableMap = std::unordered_map<const Node *, Value *>;
-  using InstListTy = std::list<Instruction *>;
+  using InstListTy = llvm::iplist<Instruction>;
   using InstrIterator = InstListTy::iterator;
   using InstrConstIterator = InstListTy::const_iterator;
   using WeightVarListTy = std::list<WeightVar *>;
@@ -285,47 +329,29 @@ public:
   /// \returns the list of instructions.
   const InstListTy &getInstrs() const { return instrs_; }
 
+  /// \returns pointer to the class member for the instruction list.
+  static InstListTy IRFunction::*getInstrsMemberPtr() {
+    return &IRFunction::instrs_;
+  }
+
   /// \returns the list of weights.
   WeightVarListTy &getWeights() { return weights_; }
 
   /// Erase the instruction from the function.
   void eraseInstruction(Instruction *I);
 
-  /// Erase the instruction from the function.
-  InstrIterator eraseInstruction(InstrIterator it);
-
   /// Remove the instruction from the function.
-  void removeInstruction(Instruction *I);
-
-  /// Remove the instruction from the function.
-  InstrIterator removeInstruction(InstrIterator it);
-
-  /// Destroy an instruction.
-  void destroyInstruction(Instruction *I);
+  InstrIterator removeInstruction(Instruction *I);
 
   /// Inserts an instruction at the place described by \where.
-  InstrIterator insertInstruction(InstrIterator where, Instruction *I);
-
-  /// Moves an instruction belonging to a function before the place described by
-  /// \where.
-  InstrIterator moveInstruction(InstrIterator where, Instruction *I);
-
-  /// Moves an instruction belonging to a function before the place described by
-  /// \where.
-  InstrIterator moveInstruction(InstrIterator where, InstrIterator I);
-
-  /// Moves an instruction belonging to a function before the place described by
-  /// \where.
-  InstrIterator moveInstruction(const Instruction *where, Instruction *I);
+  InstrIterator insertInstruction(Instruction *where, Instruction *I);
 
   /// Inserts an instruction at the end of the instructions list.
   void insertInstruction(Instruction *I);
 
-  /// \returns instruction's list iterator corresponding to the instruction.
-  InstrIterator getInstrIterator(const Instruction *I);
-
-  /// \returns instruction's list iterator corresponding to the instruction.
-  InstrConstIterator getInstrIterator(const Instruction *I) const;
+  /// Moves an instruction belonging to a function before the place described by
+  /// \where.
+  InstrIterator moveInstruction(Instruction *where, Instruction *I);
 };
 
 /// Iterator over inteructions.
@@ -334,8 +360,8 @@ using InstrConstIterator = IRFunction::InstrConstIterator;
 
 /// A helper class used for instructions numbering.
 class InstructionNumbering {
-  using NumberedInstructionMap = std::vector<InstrConstIterator>;
-  using InstructionNumbersMap = std::unordered_map<Instruction *, size_t>;
+  using NumberedInstructionMap = std::vector<const Instruction *>;
+  using InstructionNumbersMap = std::unordered_map<const Instruction *, size_t>;
   /// Maps the number to an instruction.
   NumberedInstructionMap numToInstr_;
   /// Maps an instruction to its number.
@@ -346,23 +372,12 @@ public:
 
   /// Return the instruction with a given number or
   /// M.getInstrs().end() if this instruction is not assigned any number.
-  InstrConstIterator getInstr(size_t InstrNumber) const;
+  const Instruction *getInstr(size_t InstrNumber) const;
 
   /// Return the number of an instruction or a negative value if no number
   /// was assigned to this instruction.
-  int64_t getInstrNumber(InstrConstIterator IT) const;
-
-  /// Return the number of an instruction or a negative value if no number
-  /// was assigned to this instruction.
-  int64_t getInstrNumber(Instruction *I) const;
+  int64_t getInstrNumber(const Instruction *I) const;
 };
-
-/// Get the allocation corrsponding to th value \p V. It can look through
-/// tensorview instructions. \returns found allocation or nullptr.
-Value *getAllocationOrigin(Value *V);
-
-/// \returns peels off the layers of tensorviews from a value \p V.
-Value *getOrigin(Value *V);
 
 } // namespace glow
 

--- a/include/glow/IR/IRUtils.h
+++ b/include/glow/IR/IRUtils.h
@@ -130,6 +130,9 @@ Value *getAllocationOrigin(Value *V);
 /// \returns peels off the layers of tensorviews from a value \p V.
 Value *getOrigin(Value *V);
 
+/// \returns peels off the layers of tensorviews from a value \p V.
+const Value *getOrigin(const Value *V);
+
 } // namespace glow
 
 #endif // GLOW_IR_IRUTILS_H

--- a/lib/Backends/CPU/AllocationsInfo.h
+++ b/lib/Backends/CPU/AllocationsInfo.h
@@ -33,12 +33,12 @@ struct AllocationsInfo {
   enum class ValueKind { ConstantWeight, MutableWeight, Activation };
   using KindAndNumber = std::pair<ValueKind, size_t>;
   /// Map Values in the module to their numbers.
-  llvm::DenseMap<Value *, KindAndNumber> valueNumbers_;
+  llvm::DenseMap<const Value *, KindAndNumber> valueNumbers_;
   /// To get the offset of a given value simply use
   /// numberOffsets_[valueNumbers_[v]]
 
   /// Maps Values in the module to their offsets.
-  llvm::DenseMap<Value *, size_t> allocatedAddressed_;
+  llvm::DenseMap<const Value *, size_t> allocatedAddressed_;
   /// Amount of memory to be allocated for constant WeightVars.
   size_t constantWeightVarsMemSize_{0};
   /// Amount of memory to be allocated for mutable WeightVars.

--- a/lib/Backends/CPU/DebugInfo.cpp
+++ b/lib/Backends/CPU/DebugInfo.cpp
@@ -19,6 +19,7 @@
 #include "CommandLine.h"
 
 #include "glow/Graph/Graph.h"
+#include "glow/IR/IRUtils.h"
 #include "glow/IR/Instrs.h"
 
 #include "llvm/IR/Verifier.h"
@@ -271,7 +272,7 @@ void LLVMIRGen::initDebugInfo() {
                          : nullptr;
 }
 
-void LLVMIRGen::emitDebugGlobalVariableForValue(Value *val) {
+void LLVMIRGen::emitDebugGlobalVariableForValue(const Value *val) {
   auto name = val->getName();
   // Create a proper type for the variable.
   // Represent Glow's N-dimensional tensors as N-dimensional C arrays in the
@@ -377,10 +378,10 @@ void LLVMIRGen::generateDebugInfo() {
     emitDebugGlobalVariableForValue(w);
   }
 
-  for (auto I : F_->getInstrs()) {
-    if (!isa<AllocActivationInst>(I) && !isa<TensorViewInst>(I))
+  for (const auto &I : F_->getInstrs()) {
+    if (!isa<AllocActivationInst>(&I) && !isa<TensorViewInst>(&I))
       continue;
-    emitDebugGlobalVariableForValue(I);
+    emitDebugGlobalVariableForValue(&I);
   }
 
   // Finalize the debug info.

--- a/lib/Backends/CPU/LLVMIRGen.h
+++ b/lib/Backends/CPU/LLVMIRGen.h
@@ -144,7 +144,7 @@ class LLVMIRGen {
       llvm::IRBuilder<> &builder, glow::Instruction *I, llvm::Function *kernel,
       llvm::DenseMap<Value *, int> &bufferToArgNum, llvm::Value *loopCount);
   /// \returns the llvm type of the glow vale \p val.
-  llvm::Type *getElementType(llvm::IRBuilder<> &builder, Value *val);
+  llvm::Type *getElementType(llvm::IRBuilder<> &builder, const Value *val);
   /// Create a debug information for a given LLVM type \p ty.
   llvm::DIType *getDebugType(llvm::IRBuilder<> &builder, llvm::Type *ty);
   /// Init the generation of debug information.
@@ -168,7 +168,7 @@ class LLVMIRGen {
   /// AllocationsInfo inside the memory blocks dynamically allocated by clients
   /// for weights and activations, but behave like regular global variables from
   /// the debugger's perspective.
-  void emitDebugGlobalVariableForValue(Value *val);
+  void emitDebugGlobalVariableForValue(const Value *val);
 
 public:
   /// Ctor.

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -18,6 +18,7 @@
 
 #include "glow/Graph/Graph.h"
 #include "glow/Graph/Nodes.h"
+#include "glow/IR/IRUtils.h"
 #include "glow/IR/Instrs.h"
 
 #include "llvm/Support/Casting.h"
@@ -155,13 +156,13 @@ void Interpreter::doForwardPass() {
 #define DEF_VALUE(CLASS, NAME)
 #define DEF_INSTR(CLASS, NAME)                                                 \
   case Kinded::Kind::CLASS##Kind: {                                            \
-    fwd##CLASS(llvm::cast<CLASS>(I));                                          \
+    fwd##CLASS(llvm::cast<CLASS>(&I));                                         \
     break;                                                                     \
   }
 #define DEF_BACKEND_SPECIFIC_INSTR(CLASS, NAME)
   // Dispatch the interpreter on each instruction in the program:
-  for (auto *I : F_->getInstrs()) {
-    switch (I->getKind()) {
+  for (const auto &I : F_->getInstrs()) {
+    switch (I.getKind()) {
 #include "AutoGenInstr.def"
 
     default:

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -142,7 +142,7 @@ private:
                   ElemKind elemKind);
 
   /// Execution a convolution instruction which uses NCHW format.
-  void executeConvolution(OCLConvolutionInst *CC);
+  void executeConvolution(const OCLConvolutionInst *CC);
   /// Allocate a device buffer of required \p size.
   cl_mem allocDeviceBuffer(size_t size);
   /// Frees a device buffer.

--- a/lib/IR/IRBuilder.cpp
+++ b/lib/IR/IRBuilder.cpp
@@ -17,6 +17,7 @@
 #include "glow/Graph/Graph.h"
 
 #include "glow/IR/IRBuilder.h"
+#include "glow/IR/IRUtils.h"
 
 using namespace glow;
 using llvm::dyn_cast;
@@ -37,8 +38,8 @@ void IRBuilder::deallocateActiveInstrs() {
   auto &instrs = F_->getInstrs();
   // Inserts dealloc instructions for all instructions that don't have
   // 'dealloc' as one of their users.
-  for (auto it = instrs.begin(), e = instrs.end(); it != e; ++it) {
-    auto AA = dyn_cast<AllocActivationInst>(*it);
+  for (auto &I : instrs) {
+    auto AA = dyn_cast<AllocActivationInst>(&I);
     if (!AA) {
       continue;
     }

--- a/lib/IR/IRUtils.cpp
+++ b/lib/IR/IRUtils.cpp
@@ -39,6 +39,10 @@ Value *glow::getAllocationOrigin(Value *V) {
 }
 
 Value *glow::getOrigin(Value *V) {
+  return const_cast<Value *>(getOrigin(const_cast<const Value *>(V)));
+}
+
+const Value *glow::getOrigin(const Value *V) {
   while (true) {
     auto *TVI = dyn_cast<TensorViewInst>(V);
     if (!TVI)

--- a/lib/Optimizer/IROptimizer.cpp
+++ b/lib/Optimizer/IROptimizer.cpp
@@ -1385,7 +1385,7 @@ static void performDebugInstrumentation(IRFunction &M) {
         name += instrName;
         name += ".";
         name += I->getKindName();
-        auto *dumpInstr = new DebugPrintInst(&M, name, Op.first);
+        auto *dumpInstr = new DebugPrintInst(name, Op.first);
         M.insertInstruction(I, dumpInstr);
       }
 
@@ -1397,7 +1397,7 @@ static void performDebugInstrumentation(IRFunction &M) {
         name += instrName;
         name += ".";
         name += I->getKindName();
-        auto *dumpInstr = new DebugPrintInst(&M, name, Op.first);
+        auto *dumpInstr = new DebugPrintInst(name, Op.first);
         M.insertInstruction(&*next, dumpInstr);
       }
     }

--- a/tests/unittests/IROptTest.cpp
+++ b/tests/unittests/IROptTest.cpp
@@ -157,8 +157,8 @@ TEST(Optimizer, copyPropagation) {
 
   auto &instrs = M.getInstrs();
   EXPECT_TRUE(std::none_of(
-      instrs.begin(), instrs.end(), [](const Instruction *I) -> bool {
-        return I->getKind() == Instruction::Kind::CopyInstKind;
+      instrs.begin(), instrs.end(), [](const Instruction &I) -> bool {
+        return I.getKind() == Instruction::Kind::CopyInstKind;
       }));
 }
 
@@ -189,9 +189,9 @@ TEST(Optimizer, copyPropagationSimple) {
 
   auto &instrs = M.getInstrs();
   EXPECT_TRUE(std::none_of(
-      instrs.begin(), instrs.end(), [](const Instruction *I) -> bool {
-        return isa<AllocActivationInst>(I) || isa<DeallocActivationInst>(I) ||
-               isa<CopyInst>(I);
+      instrs.begin(), instrs.end(), [](const Instruction &I) -> bool {
+        return isa<AllocActivationInst>(&I) || isa<DeallocActivationInst>(&I) ||
+               isa<CopyInst>(&I);
       }));
 }
 
@@ -225,9 +225,9 @@ TEST(Optimizer, copyPropagationTranspose) {
 
   auto &instrs = M.getInstrs();
   EXPECT_TRUE(std::none_of(
-      instrs.begin(), instrs.end(), [](const Instruction *I) -> bool {
-        return isa<TransposeInst>(I) || isa<AllocActivationInst>(I) ||
-               isa<DeallocActivationInst>(I);
+      instrs.begin(), instrs.end(), [](const Instruction &I) -> bool {
+        return isa<TransposeInst>(&I) || isa<AllocActivationInst>(&I) ||
+               isa<DeallocActivationInst>(&I);
       }));
 }
 
@@ -258,10 +258,10 @@ TEST(Optimizer, insertOptimizer) {
   // insert, alloc, and dealloc should be gone.
   auto &instrs = M.getInstrs();
   EXPECT_EQ(instrs.size(), 3);
-  EXPECT_TRUE(std::all_of(instrs.begin(), instrs.end(),
-                          [](const Instruction *I) -> bool {
-                            return isa<SplatInst>(I) || isa<TensorViewInst>(I);
-                          }));
+  EXPECT_TRUE(std::all_of(
+      instrs.begin(), instrs.end(), [](const Instruction &I) -> bool {
+        return isa<SplatInst>(&I) || isa<TensorViewInst>(&I);
+      }));
 }
 
 /// This is representative of what a ConcatNode is IRGen'd into: src1 and src2
@@ -303,10 +303,10 @@ TEST(Optimizer, twoInsertsWithBuffersOptimizer) {
   // the inserts, allocs, and deallocs should be gone.
   auto &instrs = M.getInstrs();
   EXPECT_EQ(instrs.size(), 5);
-  EXPECT_TRUE(std::all_of(instrs.begin(), instrs.end(),
-                          [](const Instruction *I) -> bool {
-                            return isa<SplatInst>(I) || isa<TensorViewInst>(I);
-                          }));
+  EXPECT_TRUE(std::all_of(
+      instrs.begin(), instrs.end(), [](const Instruction &I) -> bool {
+        return isa<SplatInst>(&I) || isa<TensorViewInst>(&I);
+      }));
 }
 
 /// This is representative of what a SliceNode is IRGen'd into: src is the
@@ -353,5 +353,5 @@ TEST(Optimizer, twoExtractsWithBuffersOptimizer) {
   EXPECT_EQ(instrs.size(), 7);
   EXPECT_TRUE(std::none_of(
       instrs.begin(), instrs.end(),
-      [](const Instruction *I) -> bool { return isa<ExtractTensorInst>(I); }));
+      [](const Instruction &I) -> bool { return isa<ExtractTensorInst>(&I); }));
 }

--- a/tools/ClassGen/InstrBuilder.cpp
+++ b/tools/ClassGen/InstrBuilder.cpp
@@ -28,7 +28,7 @@ unsigned InstrBuilder::getOperandIndexByName(llvm::StringRef name) const {
 }
 
 void InstrBuilder::emitCtor(std::ostream &os) const {
-  os << "  " << name_ << "Inst(IRFunction *M, llvm::StringRef name";
+  os << "  " << name_ << "Inst(llvm::StringRef name";
 
   // The operands of the instruction class:
   for (const auto &op : operands_) {
@@ -41,8 +41,8 @@ void InstrBuilder::emitCtor(std::ostream &os) const {
   }
 
   // Initialize the base clases:
-  os << ")\n      : Instruction(M, name, Kinded::Kind::" << name_
-     << "InstKind, " << ty_ << ", {\n";
+  os << ")\n      : Instruction(name, Kinded::Kind::" << name_ << "InstKind, "
+     << ty_ << ", {\n";
 
   // The operands of the instruction class:
   for (const auto &op : operands_) {
@@ -84,7 +84,7 @@ void InstrBuilder::emitIRBuilderMethods(std::ostream &osH,
 
   // Initialize the base clases:
   osB << ") {\n";
-  osB << "  auto *A = new " << name_ << "Inst(&getIRFunction(), name ";
+  osB << "  auto *A = new " << name_ << "Inst(name ";
 
   // The operands of the instruction class:
   for (const auto &op : operands_) {


### PR DESCRIPTION
This change solves a number of compilation performance issues, because instructions can be found in the list or removed from the list very quickly.

The change touches many of the loops iterating over the instruction lists.

While looking at the loops iterating over the Glow IR instructions, also take the chance to tighten their const correctness. This includes tightening the const correctness of some APIs used by those loops as well.