### PR TITLE
[ir-optimizer] Remove unused IRBuilder object

### DIFF
--- a/lib/Optimizer/IROptimizer.cpp
+++ b/lib/Optimizer/IROptimizer.cpp
@@ -399,8 +399,6 @@ static void replaceAllNonDeallocUsersWith(Value *val, Value *with) {
       continue;
     }
 
-    auto &M = *I->getParent();
-    IRBuilder B(&M);
     // Ignore dealloc instrs.
     if (isa<DeallocActivationInst>(I)) {
       continue;


### PR DESCRIPTION
Not only this IRBuilder object was created, but never used, but it resulted in a rather significant compilation slow-down, because it is was created inside an often called hot function and apparently the destructor of IRBuilder is calling IRBuilder::deallocateActiveInstrs, which iterates over all IR instructions each time it is called.