### PR TITLE
[Tensor/Type] Fix asserts for allowed size of tensors

### DIFF
--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -452,7 +452,7 @@ public:
       pi *= sizes_[i];
     }
 
-    assert(numDims_ < max_tensor_dimensions);
+    assert(numDims_ <= max_tensor_dimensions && "Too many dimensions.");
   }
 
   llvm::ArrayRef<size_t> dims() const {

--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -313,7 +313,7 @@ private:
   /// Setup the internals of type that store the dimensions. This method is used
   /// by the constructor.
   void initDims(llvm::ArrayRef<size_t> dims) {
-    assert(dims.size() < max_tensor_dimensions && "Too many indices");
+    assert(dims.size() <= max_tensor_dimensions && "Too many dimensions.");
     // Update the tensor sizes.
     for (size_t i = 0, e = dims.size(); i < e; i++) {
       sizes_[i] = dims[i];


### PR DESCRIPTION
It looks like assert conditions were set incorrectly for max_tensor_dimensions -- we are allocating arrays of size `max_tensor_dimensions` to hold the shape of Tensors, but then disallowing Tensors of size exactly `max_tensor_dimensions`, which doesn't make any sense (e.g. we allocated the shape array to allow for up to 6 dimensions, but only allowed for up to 5 dimensional tensors).