### PR TITLE
[random] Add command-line option to use HW random number seed

### DIFF
--- a/lib/Support/Random.cpp
+++ b/lib/Support/Random.cpp
@@ -24,9 +24,22 @@ static llvm::cl::opt<glow::PseudoRNG::result_type>
                      llvm::cl::desc("Seed for pseudo-random numbers"),
                      llvm::cl::init(glow::PseudoRNG::Engine::default_seed));
 
+static llvm::cl::opt<bool> useRandomDevice(
+    "use-random-device",
+    llvm::cl::desc(
+        "Use a non-deterministic random number generator to seed the PRNG"),
+    llvm::cl::Optional, llvm::cl::init(false));
+
+static glow::PseudoRNG::result_type getRandomSeed() {
+  if (useRandomDevice) {
+    return std::random_device()();
+  }
+  return pseudoRandomSeed.getValue();
+}
+
 namespace glow {
 
-PseudoRNG::PseudoRNG() : engine_(pseudoRandomSeed.getValue()) {}
+PseudoRNG::PseudoRNG() : engine_(getRandomSeed()) {}
 
 // Constant uniform distribution used as a template in nextRand.
 // This computes the parameters once instead of on each call.


### PR DESCRIPTION
I think it could be useful for testing to be able to hammer our unit tests with true-random numbers.  E.g.,
```
./tests/MLTest -use-random-device --gtest_repeat=10 --gtest_filter='*MLTest.matrixRotationRecognition*'
```
This tends to expose at least one failure.

I guess we could also use -pseudo-random-seed=$RANDOM and loop the gtest command in a shell script... I dunno.  What do you all think?