### PR TITLE
Represent lists of graph nodes using LLVM's intrusive lists

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -23,6 +23,8 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/StringSet.h"
+#include "llvm/ADT/ilist.h"
+#include "llvm/ADT/ilist_node.h"
 
 #include <list>
 #include <unordered_map>
@@ -30,9 +32,15 @@
 
 namespace glow {
 
+/// List of Types.
 using TypesList = std::list<Type>;
-using NodesList = std::list<Node *>;
+/// Intrusive list of Nodes.
+using NodesList = llvm::iplist<glow::Node>;
+/// List of pointers to Nodes. The nodes are not owned by the list.
+using NodesPtrList = std::list<glow::Node *>;
+/// List of Functions.
 using FunctionList = std::list<Function *>;
+/// List of Variables.
 using VariablesList = std::list<Variable *>;
 using UnsignedArrayRef = llvm::ArrayRef<size_t>;
 

--- a/include/glow/Graph/Utils.h
+++ b/include/glow/Graph/Utils.h
@@ -57,20 +57,20 @@ public:
 
 /// A helper class for ordering Graph nodes in a post-order order.
 class GraphPostOrderVisitor : public PostOrderVisitor {
-  const Function &G;
+  Function &G;
   void visit() {
     for (const auto *V : G.getParent()->getVars()) {
       V->visit(nullptr, this);
     }
     // Start visiting all root nodes, i.e. nodes that do not have any users.
-    for (auto *N : G.getNodes()) {
-      if (N->getNumUsers() == 0)
-        N->visit(nullptr, this);
+    for (auto &N : G.getNodes()) {
+      if (N.getNumUsers() == 0)
+        N.visit(nullptr, this);
     }
   }
 
 public:
-  explicit GraphPostOrderVisitor(const Function &G) : G(G) {}
+  explicit GraphPostOrderVisitor(Function &G) : G(G) {}
   /// \returns the order.
   llvm::ArrayRef<Node *> getPostOrder() {
     if (postOrder_.empty())

--- a/include/glow/IR/IR.h
+++ b/include/glow/IR/IR.h
@@ -18,6 +18,7 @@
 
 #include "glow/Base/Traits.h"
 #include "glow/Base/Type.h"
+#include "glow/Graph/Graph.h"
 #include "glow/IR/UseDef.h"
 
 #include "llvm/ADT/ArrayRef.h"
@@ -278,7 +279,7 @@ private:
 
   /// Perform scheduling on the graph.
   /// \returns computed schedule in the \p Schedule parameter.
-  void scheduleGraph(std::list<Node *> &Schedule);
+  void scheduleGraph(NodesPtrList &Schedule);
 
 public:
   /// Add an instruction to the instr stream.

--- a/lib/Backends/CPU/Transforms.cpp
+++ b/lib/Backends/CPU/Transforms.cpp
@@ -81,27 +81,27 @@ static Node *optimizeCPUConv(ConvolutionNode *CN, Function *F) {
 
 bool CPUBackend::transformPostLowering(Function *F, CompilationMode mode) {
   bool changed = false;
-  for (auto node : F->getNodes()) {
+  for (auto &node : F->getNodes()) {
 
-    if (auto *CN = dyn_cast<ConvolutionNode>(node)) {
+    if (auto *CN = dyn_cast<ConvolutionNode>(&node)) {
       if (Node *NCN = optimizeCPUConv(CN, F)) {
-        NodeValue(node, 0).replaceAllUsesOfWith(NCN);
+        NodeValue(&node, 0).replaceAllUsesOfWith(NCN);
         changed = true;
         continue;
       }
     }
-    if (auto *MN = dyn_cast<MaxNode>(node)) {
+    if (auto *MN = dyn_cast<MaxNode>(&node)) {
       if (auto *splat = dyn_cast<SplatNode>(MN->getLHS())) {
         auto MSN = F->addNode(new CPUMaxSplatNode(MN->getName(), MN->getRHS(),
                                                   splat->getValue()));
-        NodeValue(node, 0).replaceAllUsesOfWith(MSN);
+        NodeValue(&node, 0).replaceAllUsesOfWith(MSN);
         changed = true;
         continue;
       }
       if (auto *splat = dyn_cast<SplatNode>(MN->getRHS())) {
         auto MSN = F->addNode(new CPUMaxSplatNode(MN->getName(), MN->getLHS(),
                                                   splat->getValue()));
-        NodeValue(node, 0).replaceAllUsesOfWith(MSN);
+        NodeValue(&node, 0).replaceAllUsesOfWith(MSN);
         changed = true;
         continue;
       }

--- a/lib/Backends/OpenCL/Transforms.cpp
+++ b/lib/Backends/OpenCL/Transforms.cpp
@@ -92,24 +92,24 @@ bool OCLBackend::transformPostLowering(Function *F, CompilationMode mode) {
   if (mode == CompilationMode::Train)
     return false;
   // Convert convolutions and pooling nodes into nodes using the NCHW format.
-  for (auto node : F->getNodes()) {
-    if (auto *CN = dyn_cast<ConvolutionNode>(node)) {
+  for (auto &node : F->getNodes()) {
+    if (auto *CN = dyn_cast<ConvolutionNode>(&node)) {
       if (Node *NCN = optimizeOCLConv(CN, F)) {
-        NodeValue(node, 0).replaceAllUsesOfWith(NCN);
+        NodeValue(&node, 0).replaceAllUsesOfWith(NCN);
         changed = true;
         continue;
       }
     }
-    if (auto *PAN = dyn_cast<PoolAvgNode>(node)) {
+    if (auto *PAN = dyn_cast<PoolAvgNode>(&node)) {
       if (Node *NPAN = optimizeOCLPoolAvg(PAN, F)) {
-        NodeValue(node, 0).replaceAllUsesOfWith(NPAN);
+        NodeValue(&node, 0).replaceAllUsesOfWith(NPAN);
         changed = true;
         continue;
       }
     }
-    if (auto *PMN = dyn_cast<PoolMaxNode>(node)) {
+    if (auto *PMN = dyn_cast<PoolMaxNode>(&node)) {
       if (Node *NPMN = optimizeOCLPoolMax(PMN, F)) {
-        NodeValue(node, 0).replaceAllUsesOfWith(NPMN);
+        NodeValue(&node, 0).replaceAllUsesOfWith(NPMN);
         changed = true;
         continue;
       }

--- a/lib/Graph/Grad.cpp
+++ b/lib/Graph/Grad.cpp
@@ -78,7 +78,7 @@ Function *glow::differentiate(Function *F, const TrainingConfig &conf,
 
   PostOrderVisitor pov;
   for (auto &N : G->getNodes()) {
-    N->visit(nullptr, &pov);
+    N.visit(nullptr, &pov);
   }
 
   auto nodes = pov.getPostOrder();

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -436,6 +436,19 @@ Node *Node::clone() const {
   }
 }
 
+void Node::destroyNode(Node *N) {
+  switch (N->getKind()) {
+#define DEF_NODE(CLASS, NAME)                                                  \
+  case glow::Kinded::Kind::CLASS##Kind: {                                      \
+    delete static_cast<CLASS *>(N);                                            \
+    break;                                                                     \
+  }
+#include "AutoGenNodes.def"
+  default:
+    llvm_unreachable("Unhandled node");
+  }
+}
+
 static const char *getVariableTrainKindStr(Variable::TrainKind kind) {
   const char *names[] = {"none", "broadcast", "xavier", nullptr};
   return names[static_cast<int>(kind)];

--- a/lib/IR/IRGen.cpp
+++ b/lib/IR/IRGen.cpp
@@ -399,7 +399,7 @@ public:
 void IRFunction::generateIR() {
   G_->verify();
   // Schedule the nodes.
-  NodesList ScheduledNodes;
+  NodesPtrList ScheduledNodes;
   scheduleGraph(ScheduledNodes);
   IRGenVisitor irgen(this);
 

--- a/lib/Optimizer/Lower.cpp
+++ b/lib/Optimizer/Lower.cpp
@@ -372,15 +372,15 @@ void computeBatchNormalizationWeights(Function *F, BatchNormalizationNode &BN) {
   // Cannot use mean.replaceAllUsesOfWith(newMean) here, because newMean depends
   // on mean. Essentially, we need to replace x with f(x). It means that such
   // replacement would also find `f(x)` itself in the graph, and create a cycle.
-  for (auto N : F->getNodes())
+  for (auto &N : F->getNodes())
     if (llvm::isa<BatchNormalizationNode>(N) ||
         llvm::isa<BatchNormalizationGradNode>(N))
-      for (size_t i = 0; i < N->getNumInputs(); i++) {
-        if (N->getNthInput(i) == mean) {
-          N->getNthInput(i) = newMean;
+      for (size_t i = 0; i < N.getNumInputs(); i++) {
+        if (N.getNthInput(i) == mean) {
+          N.getNthInput(i) = newMean;
         }
-        if (N->getNthInput(i) == var) {
-          N->getNthInput(i) = newVar;
+        if (N.getNthInput(i) == var) {
+          N.getNthInput(i) = newVar;
         }
       }
 
@@ -528,7 +528,8 @@ void lowerGroupConvolutionNode(Function *F, ConvolutionNode &BNG) {
 void glow::lower(Function *F, CompilationMode mode, const Backend &B) {
   auto &nodes = F->getNodes();
 
-  for (auto const &node : nodes) {
+  for (auto &N : nodes) {
+    auto *node = &N;
     if (!B.shouldLower(node)) {
       continue;
     }
@@ -571,7 +572,7 @@ void glow::lower(Function *F, CompilationMode mode, const Backend &B) {
   }
 
   for (auto it = F->getNodes().begin(), e = F->getNodes().end(); it != e;) {
-    auto cur = *(it++);
+    auto cur = &*(it++);
     if (dyn_cast<SGDNode>(cur))
       F->eraseNode(cur);
   }

--- a/lib/Optimizer/Quantization.cpp
+++ b/lib/Optimizer/Quantization.cpp
@@ -38,12 +38,12 @@ Function *glow::profileQuantization(Function *F, llvm::StringRef newFuncName) {
   std::unordered_set<NodeValue> nodesToInstrument;
 
   // Add Quantization Profile node to all of the floating point outputs.
-  for (const auto &node : G->getNodes()) {
-    for (unsigned i = 0, e = node->getNumResults(); i < e; ++i) {
-      if (node->getNthResult(i).getElementType() != ElemKind::FloatTy) {
+  for (auto &node : G->getNodes()) {
+    for (unsigned i = 0, e = node.getNumResults(); i < e; ++i) {
+      if (node.getNthResult(i).getElementType() != ElemKind::FloatTy) {
         continue;
       }
-      nodesToInstrument.insert(node->getNthResult(i));
+      nodesToInstrument.insert(node.getNthResult(i));
     }
   }
 

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -198,8 +198,8 @@ std::vector<NodeQuantizationInfo>
 generateNodeQuantizationInfos(const Function *F) {
   std::vector<NodeQuantizationInfo> quantizationInfos;
 
-  for (auto *node : F->getNodes()) {
-    auto *QPN = llvm::dyn_cast<QuantizationProfileNode>(node);
+  for (auto &node : F->getNodes()) {
+    auto *QPN = llvm::dyn_cast<QuantizationProfileNode>(&node);
 
     if (QPN) {
       auto CI = QPN->getComputationInfoVar()->getHandle<float>();
@@ -585,7 +585,7 @@ quantizeFunction(const ExecutionEngine &EE,
   auto stopIt = G->getNodes().begin();
   do {
     --nodeIt;
-    Node *node = *nodeIt;
+    Node *node = &*nodeIt;
 
     // Make sure that all inputs are floats and int8 operation is suppored by
     // the backend. Not all backends support particular quantized operation and

--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -70,10 +70,10 @@ TEST(Interpreter, profileQuantizationForANetwork) {
 
   QuantizationProfileNode *profile{nullptr};
   // Find QPN for node A.
-  for (auto node : F->getNodes()) {
+  for (auto &node : F->getNodes()) {
     if (QuantizationProfileNode *QPN =
-            llvm::dyn_cast<QuantizationProfileNode>(node)) {
-      Node *observedNode = node->getNthInput(0).getNode();
+            llvm::dyn_cast<QuantizationProfileNode>(&node)) {
+      Node *observedNode = node.getNthInput(0).getNode();
       if (observedNode == A) {
         profile = QPN;
         break;

--- a/tests/unittests/graphGradTest.cpp
+++ b/tests/unittests/graphGradTest.cpp
@@ -119,7 +119,7 @@ TEST(GraphAutoGrad, cloneAndDiff) {
 
   Node *C =
       M.createVariable(ElemKind::FloatTy, {1}, "C", VisibilityKind::Private);
-  Node *AplusB_G = G->getNodes().back();
+  Node *AplusB_G = &G->getNodes().back();
   G->createAdd("totalSum", AplusB_G, C);
 
   EXPECT_EQ(M.getVars().size(), 3);

--- a/tests/unittests/graphTest.cpp
+++ b/tests/unittests/graphTest.cpp
@@ -100,8 +100,8 @@ TEST(Graph, QuantizationProfileNodes) {
   ::optimize(F, CompilationMode::Infer);
 
   size_t numberOfProfileNodes =
-      std::count_if(F->getNodes().begin(), F->getNodes().end(), [](Node *node) {
-        return llvm::isa<QuantizationProfileNode>(node);
+      std::count_if(F->getNodes().begin(), F->getNodes().end(), [](Node &node) {
+        return llvm::isa<QuantizationProfileNode>(&node);
       });
 
   EXPECT_EQ(10, numberOfProfileNodes);
@@ -313,8 +313,8 @@ unsigned getConvNodeSize(BackendKind kind) {
   lower(F, CompilationMode::Infer, *backend);
 
   unsigned count = 0;
-  for (auto *n : F->getNodes()) {
-    if (n->getKind() == Kinded::Kind::ConvolutionNodeKind) {
+  for (auto &n : F->getNodes()) {
+    if (n.getKind() == Kinded::Kind::ConvolutionNodeKind) {
       count++;
     }
   }


### PR DESCRIPTION
Nodes are often moved around or removed from the nodes lists by different optimization passes and thus it makes sense to use LLVM's intrusive lists to make such operations fast.