### PR TITLE
[mltest]LearnLog: new ML test case

### DIFF
--- a/tests/unittests/MLTest.cpp
+++ b/tests/unittests/MLTest.cpp
@@ -205,6 +205,81 @@ TEST_P(MLTest, learnXor) {
   }
 }
 
+/// Learn the logarithmic function.
+TEST_P(MLTest, learnLog) {
+  unsigned numInputs = 50;
+  unsigned batchSize = 5;
+  EE_.getConfig().learningRate = 0.07;
+  EE_.getConfig().batchSize = batchSize;
+
+  auto &mod = EE_.getModule();
+  Function *F = mod.createFunction("learnLog");
+
+  auto *A =
+      mod.createVariable(ElemKind::FloatTy, {batchSize, 1}, "A",
+                         VisibilityKind::Public, Variable::TrainKind::None);
+  auto *Ex =
+      mod.createVariable(ElemKind::FloatTy, {batchSize, 1}, "Ex",
+                         VisibilityKind::Public, Variable::TrainKind::None);
+
+  Node *O = F->createFullyConnected("fc1", A, 4);
+  O = F->createTanh("tanh1", O);
+  O = F->createFullyConnected("fc3", O, 1);
+  O = F->createRegression("reg", O, Ex);
+  auto *result = F->createSave("ret", O);
+
+
+  // Set the training data.
+  Tensor trainingSet(ElemKind::FloatTy, {numInputs, 1});
+  Tensor trainingLabels(ElemKind::FloatTy, {numInputs, 1});
+
+  auto TS = trainingSet.getHandle<>();
+  auto TL = trainingLabels.getHandle<>();
+
+  // Set the training date as floating number from range [0.75, 1.5).
+
+  const float LO = 0.75; // Lower bound of training data.
+  const float HI = 1.5;  // Upper bound of training data.
+  for (size_t i = 0; i < numInputs; i++) {
+    // Generate a floating number in the range of [LO,HI).
+    float a = LO + i * (HI-LO) / numInputs;
+    TS.at({i, 0}) = a;
+    TL.at({i, 0}) = std::log(a);
+  }
+
+  Function *TF = glow::differentiate(F, EE_.getConfig());
+  EE_.compile(CompilationMode::Train, TF);
+
+  // Train the network:
+  EE_.runBatch(1000, {A, Ex}, {&trainingSet, &trainingLabels});
+
+  EE_.compile(CompilationMode::Infer, F);
+
+  // Set the testing data.
+  Tensor testSet(ElemKind::FloatTy, {batchSize, 1});
+
+  auto TES = testSet.getHandle<>();
+
+  const float LO_T = 1.1; // Lower bound of testing data.
+  const float HI_T = 1.2; // Upper bound of testing data.
+
+  for (size_t i = 0; i < batchSize; i++) {
+
+    // Generate a floating number in the range of [LO_T,HI_T).
+    float a = LO_T + i * (HI_T-LO_T) / numInputs;
+    TES.at({i, 0}) = a;
+  }
+
+  EE_.run({A}, {&testSet});
+  auto resH = result->getVariable()->getPayload().getHandle<>();
+
+  // Test the output:
+  for (size_t i = 0; i < batchSize; i++) {
+    float a = TES.at({i, 0});
+    EXPECT_NEAR(resH.at({i, 0}), (std::log(a)), 0.02);
+  }
+}
+
 unsigned numSamples = 230;
 
 /// Generate data in two classes. The circle of dots that's close to the axis is
@@ -1100,7 +1175,7 @@ TEST_P(MLTest, matrixRotationRecognition) {
   EE_.compile(CompilationMode::Train, trainingGradientFunction);
   // Training:
   EE_.runBatch(200, {varMatricesA, varMatricesB, varExpected},
-              {&matricesA, &matricesB, &expected});
+               {&matricesA, &matricesB, &expected});
 
   // Switch to inference mode.
   EE_.compile(CompilationMode::Infer, F);

--- a/tests/unittests/MLTest.cpp
+++ b/tests/unittests/MLTest.cpp
@@ -41,8 +41,7 @@ TEST_P(MLTest, trainASimpleNetwork) {
   EE_.getConfig().learningRate = 0.05;
 
   auto &mod = EE_.getModule();
-  Function *F = mod.createFunction("main");
-  F->setName("trainASimpleNetwork");
+  Function *F = mod.createFunction("trainASimpleNetwork");
 
   // Create a variable with 1 input, which is a vector of 4 elements.
   auto *A =
@@ -55,7 +54,6 @@ TEST_P(MLTest, trainASimpleNetwork) {
   Node *O = F->createFullyConnected("fc1", A, 10);
   O = F->createSigmoid("sig1", O);
   O = F->createFullyConnected("fc2", O, 4);
-  O = F->createSigmoid("sig2", O);
   O = F->createRegression("reg", O, E);
   auto *result = F->createSave("return", O);
 
@@ -95,8 +93,7 @@ TEST_P(MLTest, simpleRegression) {
   Tensor expected(ElemKind::FloatTy, {1, numInputs});
 
   auto &mod = EE_.getModule();
-  Function *F = mod.createFunction("main");
-  F->setName("simpleRegression");
+  Function *F = mod.createFunction("simpleRegression");
   auto *A =
       mod.createVariable(ElemKind::FloatTy, {1, numInputs}, "A",
                          VisibilityKind::Public, Variable::TrainKind::None);
@@ -145,8 +142,7 @@ TEST_P(MLTest, learnXor) {
   EE_.getConfig().learningRate = 0.05;
 
   auto &mod = EE_.getModule();
-  Function *F = mod.createFunction("main");
-  F->setName("learnXor");
+  Function *F = mod.createFunction("learnXor");
 
   auto *A =
       mod.createVariable(ElemKind::FloatTy, {numInputs, 2}, "A",
@@ -158,7 +154,6 @@ TEST_P(MLTest, learnXor) {
   Node *O = F->createFullyConnected("fc1", A, 6);
   O = F->createTanh("tanh1", O);
   O = F->createFullyConnected("fc2", O, 1);
-  O = F->createTanh("tanh2", O);
   O = F->createRegression("reg", O, Ex);
   auto *result = F->createSave("ret", O);
 
@@ -224,7 +219,7 @@ TEST_P(MLTest, learnLog) {
 
   Node *O = F->createFullyConnected("fc1", A, 4);
   O = F->createTanh("tanh1", O);
-  O = F->createFullyConnected("fc3", O, 1);
+  O = F->createFullyConnected("fc2", O, 1);
   O = F->createRegression("reg", O, Ex);
   auto *result = F->createSave("ret", O);
 
@@ -321,8 +316,7 @@ TEST_P(MLTest, circle) {
   unsigned minibatchSize = 11;
 
   auto &mod = EE_.getModule();
-  Function *F = mod.createFunction("main");
-  F->setName("circle");
+  Function *F = mod.createFunction("circle");
   auto *A =
       mod.createVariable(ElemKind::FloatTy, {minibatchSize, 2}, "A",
                          VisibilityKind::Public, Variable::TrainKind::None);
@@ -333,8 +327,7 @@ TEST_P(MLTest, circle) {
   auto *FCL0 = F->createFullyConnected("fc1", A, 8);
   auto *T0 = F->createTanh("tanh1", FCL0);
   auto *FCL1 = F->createFullyConnected("fc2", T0, 2);
-  auto *T1 = F->createTanh("tanh2", FCL1);
-  auto *SM = F->createSoftMax("soft", T1, S);
+  auto *SM = F->createSoftMax("soft", FCL1, S);
   auto *result = F->createSave("ret", SM);
 
   Function *TF = glow::differentiate(F, EE_.getConfig());
@@ -408,8 +401,7 @@ TEST_P(MLTest, learnSingleValueConcat) {
   EE_.getConfig().learningRate = 0.01;
 
   auto &mod = EE_.getModule();
-  Function *F = mod.createFunction("main");
-  F->setName("learnSingleValueConcat");
+  Function *F = mod.createFunction("learnSingleValueConcat");
 
   auto *Ex =
       mod.createVariable(ElemKind::FloatTy, {1, width * 2}, "Ex",
@@ -484,8 +476,7 @@ void testRNNCell(TCellGenerator cell) {
   EE.getConfig().learningRate = 0.05;
 
   auto &mod = EE.getModule();
-  Function *F = mod.createFunction("main");
-  F->setName("testRNNCell");
+  Function *F = mod.createFunction("testRNNCell");
 
   const unsigned NumVectors = 3;
   const unsigned NumElements = 4;
@@ -571,8 +562,7 @@ TEST_P(MLTest, learnSqrt2) {
   EE_.getConfig().learningRate = 0.03;
 
   auto &mod = EE_.getModule();
-  Function *F = mod.createFunction("main");
-  F->setName("Square root of 2");
+  Function *F = mod.createFunction("Square root of 2");
 
   auto *A =
       mod.createVariable(ElemKind::FloatTy, {1}, "A", VisibilityKind::Public,
@@ -607,8 +597,7 @@ TEST_P(MLTest, trainSimpleLinearRegression) {
   EE_.getConfig().batchSize = numSamples;
 
   auto &mod = EE_.getModule();
-  Function *F = mod.createFunction("main");
-  F->setName("Gradient descent solution for simple linear regression");
+  Function *F = mod.createFunction("Gradient descent solution for simple linear regression");
 
   // These m and b are only used to generate training data.
   float referenceM = 3.0;
@@ -683,8 +672,7 @@ TEST_P(MLTest, classifyPlayerSport) {
   EE_.getConfig().learningRate = 0.05;
 
   auto &mod = EE_.getModule();
-  Function *F = mod.createFunction("main");
-  F->setName("classifyPlayers");
+  Function *F = mod.createFunction("classifyPlayers");
 
   const unsigned numTrainPlayers = 200;
   const size_t numFeatures = 2;
@@ -745,8 +733,7 @@ TEST_P(MLTest, learnSinus) {
   EE_.getConfig().batchSize = numSamples;
 
   auto &mod = EE_.getModule();
-  Function *F = mod.createFunction("main");
-  F->setName("Gradient descent solution for sin(x)");
+  Function *F = mod.createFunction("Gradient descent solution for sin(x)");
 
   // Function that should be learned by the NN
   auto FF = [](float x) -> float {
@@ -817,8 +804,7 @@ TEST_P(MLTest, nonLinearClassifier) {
   EE_.getConfig().batchSize = batchSize;
 
   auto &mod = EE_.getModule();
-  Function *F = mod.createFunction("main");
-  F->setName("nonLinearClassifier");
+  Function *F = mod.createFunction("nonLinearClassifier");
 
   auto *A =
       mod.createVariable(ElemKind::FloatTy, {batchSize, 2}, "A",


### PR DESCRIPTION
hi. a few changes i made since my last try:
1). Systematically generated training/testing data, instead of randomly. (Trains faster with simpler network)
2). Use 2 fc only. One with 4 output depth, one with 1 output depth. Used an tanh activation function in between. (I have tried with sigmoid, but worse than tanh)
3). Training data is still sampled from [0.75,1.5], with testing data sampled from [1.1, 1.2]. 
4). The execution time of this MLTest is much shorter than last try. 
- Interpreter/MLTest (86 ms total)
- JIT/MLTest (386 ms total)
- OpenCL/MLTest (948 ms total)
Short than existing test like "learnXor"
