### PR TITLE
Add axis to the batched add reduce

### DIFF
--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -39,6 +39,12 @@ class Tensor;
 void genericTranspose(Tensor *src, Tensor *dest,
                       llvm::ArrayRef<unsigned> shuffle);
 
+/// Helper function that \returns a ShapeVector of those dimensions in \p
+/// currDims expanded with dimension = 1 until the maximum tensor dimension is
+/// reached. The number of elements in the input dims is the same as in the
+/// returned dims. For example, input {2,1,4} would result in {2,1,4,1,1,1}.
+ShapeVector expandDimsToMax(llvm::ArrayRef<size_t> currDims);
+
 /// A class that represents a contiguous n-dimensional array (a tensor).
 class Tensor final {
   /// A pointer to the tensor data.

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -350,10 +350,11 @@ public:
                            NodeValue rhs);
 
   BatchedReduceAddNode *createBatchedReduceAdd(llvm::StringRef name,
-                                               NodeValue batch);
+                                               NodeValue batch, size_t axis);
 
   BatchedReduceAddNode *createBatchedReduceAdd(llvm::StringRef name,
-                                               TypeRef outTy, NodeValue batch);
+                                               TypeRef outTy, NodeValue batch,
+                                               size_t axis);
 
   BatchedAddNode *createBatchedAdd(llvm::StringRef name, NodeValue batch,
                                    NodeValue sample);

--- a/lib/Backends/CPU/libjit/libjit_defs.h
+++ b/lib/Backends/CPU/libjit/libjit_defs.h
@@ -54,6 +54,15 @@ inline void AdduFloat8(float *p, float8 v) {
   StoreuFloat8(p, LoaduFloat8(p) + v);
 }
 
+/// \returns the index of the element at x,y,z,w,q,r.
+inline size_t libjit_getXYZWQR(const size_t *dims, size_t x, size_t y, size_t z,
+                               size_t w, size_t q, size_t r) {
+  return (x * dims[1] * dims[2] * dims[3] * dims[4] * dims[5]) +
+         (y * dims[2] * dims[3] * dims[4] * dims[5]) +
+         (z * dims[3] * dims[4] * dims[5]) + (w * dims[4] * dims[5]) +
+         (q * dims[5]) + r;
+}
+
 /// \returns the index of the element at x,y,z,w,q.
 inline size_t libjit_getXYZWQ(const size_t *dims, size_t x, size_t y, size_t z,
                               size_t w, size_t q) {

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -739,6 +739,8 @@ void OCLBackend::doForwardPass() {
     }
 
     if (auto *BRA = dyn_cast<BatchedReduceAddInst>(&I)) {
+      assert(BRA->getAxis() == 0 && "No current support for non-zero axis.");
+
       cl_kernel kernel = createKernel(kernelName);
       setKernelArg(kernel, 0, deviceBuffer_);
 

--- a/lib/Base/Tensor.cpp
+++ b/lib/Base/Tensor.cpp
@@ -335,3 +335,11 @@ void glow::genericTranspose(Tensor *src, Tensor *dest,
   }
   }
 }
+
+ShapeVector glow::expandDimsToMax(llvm::ArrayRef<size_t> currDims) {
+  ShapeVector newDims(currDims.begin(), currDims.end());
+  for (size_t i = newDims.size(); i < max_tensor_dimensions; i++) {
+    newDims.push_back(1);
+  }
+  return newDims;
+}

--- a/tests/unittests/BackendTestUtils.cpp
+++ b/tests/unittests/BackendTestUtils.cpp
@@ -62,7 +62,8 @@ void inferBatchedReduceAddNet(Tensor *inputs, Tensor *out, BackendKind kind) {
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
   auto *var = VarFrom(inputs);
-  auto *batchedreduce = F->createBatchedReduceAdd("batchedreduce", var);
+  auto *batchedreduce =
+      F->createBatchedReduceAdd("batchedreduce", var, /* axis */ 0);
   auto result = F->createSave("ret", batchedreduce);
   EE.compile(CompilationMode::Infer, F);
   EE.run({var}, {inputs});

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -185,11 +185,13 @@ int main(int argc, char **argv) {
       .autoIRGen()
       .autoVerify(VerifyKind::SameElementType, {"Dest", "LHS", "RHS"});
 
-  /// Accumulates all of the layers in the batch and produce a tensor that has
-  /// the same dimensions as the input tensor without the first dimension.
+  /// Accumulates all of the layers in the batch along the Axis dimension and
+  /// produce a tensor that has the same dimensions as the input tensor without
+  /// the Axis dimension.
   BB.newInstr("BatchedReduceAdd")
       .addOperand("Dest", OperandKind::Out)
       .addOperand("Batch", OperandKind::In)
+      .addMember(MemberType::SizeT, "Axis")
       .autoVerify(VerifyKind::SameElementType, {"Dest", "Batch"})
       .autoIRGen();
 

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -255,6 +255,7 @@ int main(int argc, char **argv) {
 
   BB.newNode("BatchedReduceAdd")
       .addInput("Batch")
+      .addMember(MemberType::SizeT, "Axis")
       .addResultFromCtorArg()
       .setDocstring("Accumulates all of the layers in the batch and produce a "
                     "tensor that has the same dimensions as the input tensor "


### PR DESCRIPTION
For seq2seq, we need to add in an axis for batched reduce add. This means the current simple implementation is no longer sufficient, since we need to reduce in dimensions other than the first one. I am wondering if the implementation I have here in InterpreterNodes for `fwdBatchedReduceAddInst()` is a preferable direction compared to the other options.

The problem is that we don't know the number of dimensions of the tensor that we want to iterate over ahead of time. To handle this in other cases, we generally do one of two things. One, write multiple cases for each different number of dimensions of different loop nest depths (e.g. in `tryTransposeFastImpl()`, `libjit_transpose_generic()`, `libjit_insert_tensor()`). Or two, have a generic recursive version (e.g. in `transposeGenericImpl()`, `insertTensorsImpl()`), which might not get great performance and is much less readable/understandable. (I had implemented a third option for broadcast that iterated over generic shapes but I removed it once we removed the `BroadcastInst`, and I don't think it had great perf anyway.)

Instead, the approach I took here was to get an unowned view of both the source batch Tensor and the dest Tensor with expanded dimensions up to `max_tensor_dimensions`, with the newly added dimensions = 1. This allows us to have a single loop nest of depth `max_tensor_dimensions`. This should enable good perf since it consists of relatively affine accesses/loops, doesn't require `n` different cases for each of the different number of dimensions, and is still pretty readable IMO. I was thinking we could possibly move toward this sort of implementation in libjit too -- I think it's more readable/maintainable, and post specialization I would imagine would have the same performance (?).

What do you all think?