### PR TITLE
[Cleanup] Refactor the argument specializer a bit. NFC.

### DIFF
--- a/lib/Backends/CPU/FunctionSpecializer.cpp
+++ b/lib/Backends/CPU/FunctionSpecializer.cpp
@@ -372,15 +372,3 @@ void LLVMIRGen::performSpecialization() {
     generateFunctionDebugInfo(&FF);
   }
 }
-
-llvm::CallInst *
-LLVMIRGen::specializeCallWithConstantArguments(llvm::CallInst *call) {
-  FunctionSpecializer FuncSpecializer({});
-  auto specializedCall = FuncSpecializer.specializeCall(call);
-  // Remove the original call instruction, if a new call instruction was
-  // created.
-  if (specializedCall) {
-    call->eraseFromParent();
-  }
-  return specializedCall;
-}

--- a/lib/Backends/CPU/LLVMIRGen.h
+++ b/lib/Backends/CPU/LLVMIRGen.h
@@ -38,6 +38,31 @@ class Instruction;
 class WeightVar;
 struct AllocationsInfo;
 
+/// A POD struct that stores information related to debug info.
+struct DebugInfo {
+  /// Source file for the main function.
+  llvm::DIFile *mainFile_{nullptr};
+  /// Debug info for the main function.
+  llvm::DISubprogram *mainF_{nullptr};
+  /// Line number for the first instruction in the textual representation of
+  /// the Glow IR.
+  size_t mainFileFirstInstrLineNo_{0};
+  /// Debug info for the current compilation unit.
+  llvm::DICompileUnit *compilationUnit_{nullptr};
+  /// Mapping from LLVM types to DebugInfo types.
+  llvm::DenseMap<llvm::Type *, llvm::DIType *> DITypes_;
+  /// Global variable holding the base address of the constant WeightVars
+  /// memory
+  /// area. Used only when producing a debug information.
+  llvm::GlobalVariable *constWeightsBaseAddressGV_{nullptr};
+  /// Global variable holding the base address of mutable WeightVars memory
+  /// area. Used only when producing a debug information.
+  llvm::GlobalVariable *mutableWeightsBaseAddressGV_{nullptr};
+  /// Global variable holding the base address of the activations memory area.
+  /// Used only when producing a debug information.
+  llvm::GlobalVariable *activationsBaseAddressGV_{nullptr};
+};
+
 /// This is a class containing a common logic for the generation of the LLVM IR
 /// from an IRFunction. The primary clients of this class are JITs and bundlers.
 class LLVMIRGen {
@@ -72,29 +97,7 @@ class LLVMIRGen {
   /// Output directory for bundles, debug info files, etc.
   llvm::StringRef outputDir_;
   /// Debug info emission support.
-  struct DebugInfo {
-    /// Source file for the main function.
-    llvm::DIFile *mainFile_{nullptr};
-    /// Debug info for the main function.
-    llvm::DISubprogram *mainF_{nullptr};
-    /// Line number for the first instruction in the textual representation of
-    /// the Glow IR.
-    size_t mainFileFirstInstrLineNo_{0};
-    /// Debug info for the current compilation unit.
-    llvm::DICompileUnit *compilationUnit_{nullptr};
-    /// Mapping from LLVM types to DebugInfo types.
-    llvm::DenseMap<llvm::Type *, llvm::DIType *> DITypes_;
-    /// Global variable holding the base address of the constant WeightVars
-    /// memory
-    /// area. Used only when producing a debug information.
-    llvm::GlobalVariable *constWeightsBaseAddressGV_{nullptr};
-    /// Global variable holding the base address of mutable WeightVars memory
-    /// area. Used only when producing a debug information.
-    llvm::GlobalVariable *mutableWeightsBaseAddressGV_{nullptr};
-    /// Global variable holding the base address of the activations memory area.
-    /// Used only when producing a debug information.
-    llvm::GlobalVariable *activationsBaseAddressGV_{nullptr};
-  } dbgInfo_;
+  DebugInfo dbgInfo_;
   /// Debug info builder.
   std::unique_ptr<llvm::DIBuilder> DIBuilder_;
 

--- a/lib/Backends/CPU/LLVMIRGen.h
+++ b/lib/Backends/CPU/LLVMIRGen.h
@@ -199,11 +199,6 @@ public:
   void optimizeLLVMModule(llvm::Function *F, llvm::TargetMachine &TM);
   /// Performs specialization of operations based on constant parameters.
   void performSpecialization();
-  /// Performs specialization of a call based on constant parameters.
-  /// In case of a successful specialization, the old call instruction is
-  /// replaced by the new one and the old one is erases. \returns the new
-  /// specialized call or nullptr if no specialization was possible.
-  llvm::CallInst *specializeCallWithConstantArguments(llvm::CallInst *call);
   /// \returns allocations info.
   AllocationsInfo &getAllocationsInfo() { return allocationsInfo_; }
   /// \returns the name of the main entry point.


### PR DESCRIPTION
The code is still broken/buggy because we only avoid specialization when
the input array is float-ptr, and not when it's say, i8-ptr.