### PR TITLE
[tests] Use libjit directly in GemmTest

### DIFF
--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -170,6 +170,7 @@ add_executable(GemmTest
                GemmTest.cpp)
 target_link_libraries(GemmTest
                       PRIVATE
+                        CPURuntimeNative
                         Graph
                         IR
                         ExecutionEngine


### PR DESCRIPTION
This runs much faster, and the point of this test is the correctness of libjit_matmul, not the JIT infra itself.