### PR TITLE
[Specializer] Allow codegen to disable selected argument specialization

### DIFF
--- a/lib/Backends/CPU/LLVMIRGen.h
+++ b/lib/Backends/CPU/LLVMIRGen.h
@@ -240,6 +240,8 @@ public:
   void generateFunctionDebugInfo(llvm::Function *F);
   /// Generates LLVM IR that materializes the string literal \p str.
   llvm::Value *emitStringConst(llvm::IRBuilder<> &builder, llvm::StringRef str);
+  /// Register \p val as an argument that should not be specialized.
+  void markArgAsUnspecialized(llvm::Value *val);
 };
 
 } // namespace glow

--- a/lib/Backends/CPU/LLVMIRGen.h
+++ b/lib/Backends/CPU/LLVMIRGen.h
@@ -21,6 +21,7 @@
 #include "glow/IR/IR.h"
 
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/DenseSet.h"
 #include "llvm/IR/DIBuilder.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/IRBuilder.h"
@@ -100,6 +101,10 @@ class LLVMIRGen {
   DebugInfo dbgInfo_;
   /// Debug info builder.
   std::unique_ptr<llvm::DIBuilder> DIBuilder_;
+
+  /// A set that contains all of the argument that we request from the
+  /// specializer not to specialize.
+  llvm::DenseSet<llvm::Value *> dontSpecializeArgsSet_;
 
   /// Generates LLVM IR that computes the address of \p val using \p builder.
   /// The address type is specified by \p ptrTy.


### PR DESCRIPTION
This patch disables the specialization of the 'offset' parameter in the insert/extract tensor instruction. It does so by asking the specializer not to specialize certain arguments that are passed in a set of LLVM values. It's important to disable the specialization of the insert/extract instructions because the code is instantiated multiple times with slightly different offsets, and this causes code bloat.

After disabling the specialization of the offset I had to fix the implementation in that could not figure out that the offsets don't alias with anything in the loop. 