### PR TITLE
Add ScatterAssign node and instruction

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -408,6 +408,13 @@ public:
   GatherNode *createGather(llvm::StringRef name, NodeValue data,
                            NodeValue indices);
 
+  /// Copies each slice from \p slices into \p data at the corresponding index
+  /// in \p indices, and \returns this new version of data. For example, given
+  /// input data {{1,2},{3,4},{5,6}}, slices {{-3,-4}}, and indices {1}, the
+  /// result is {{1,2},{-3,-4},{5,6}}.
+  ScatterAssignNode *createScatterAssign(llvm::StringRef name, NodeValue data,
+                                         NodeValue indices, NodeValue slices);
+
   /// Create quantization node which transforms floating point tensor to a
   /// quantized one with given Scale and Offset. Scale and Offset params are
   /// part of the \p outTy.

--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -1929,6 +1929,28 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     break;
   }
 
+  case Kinded::Kind::ScatterAssignInstKind: {
+    ScatterAssignInst *SAI = llvm::cast<ScatterAssignInst>(I);
+    auto *data = SAI->getData();
+    auto *indices = SAI->getIndices();
+    auto *slices = SAI->getSlices();
+
+    auto *dataPtr = emitValueAddress(builder, data);
+    auto *indicesPtr = emitValueAddress(builder, indices);
+    auto *slicesPtr = emitValueAddress(builder, slices);
+
+    auto *indicesSize = emitConstSizeT(builder, indices->size());
+
+    auto *dataType = data->getType();
+    auto *sliceSize =
+        emitConstSizeT(builder, dataType->size() / dataType->dims()[0]);
+
+    auto *F = getFunction("scatterassign", data->getElementType());
+    createCall(builder, F,
+               {dataPtr, indicesPtr, slicesPtr, indicesSize, sliceSize});
+    break;
+  }
+
   case Kinded::Kind::DebugPrintInstKind: {
     DebugPrintInst *DPI = llvm::cast<DebugPrintInst>(I);
     auto *src = DPI->getSrc();

--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -352,6 +352,16 @@ void libjit_gather(T *dest, const T *data, const size_t *indices,
 }
 
 template <typename T>
+void libjit_scatterassign(T *data, const size_t *indices, const T *slices,
+                          size_t numIndices, size_t sliceSize) {
+  for (size_t i = 0; i < numIndices; i++) {
+    size_t destDataIdx = indices[i];
+    memcpy(data + destDataIdx * sliceSize, slices + i * sliceSize,
+           sliceSize * sizeof(T));
+  }
+}
+
+template <typename T>
 void libjit_transpose_generic(const T *inW, T *outW, const size_t *idim,
                               const size_t *odim, const size_t *shuffle,
                               size_t numDims) {
@@ -778,6 +788,17 @@ void libjit_gather_f(float *dest, const float *data, const size_t *indices,
 void libjit_gather_i8(int8_t *dest, const int8_t *data, const size_t *indices,
                       size_t numIndices, size_t sliceSize) {
   libjit_gather(dest, data, indices, numIndices, sliceSize);
+}
+
+void libjit_scatterassign_f(float *data, const size_t *indices,
+                            const float *slices, size_t numIndices,
+                            size_t sliceSize) {
+  libjit_scatterassign(data, indices, slices, numIndices, sliceSize);
+}
+void libjit_scatterassign_i8(int8_t *data, const size_t *indices,
+                             const int8_t *slices, size_t numIndices,
+                             size_t sliceSize) {
+  libjit_scatterassign(data, indices, slices, numIndices, sliceSize);
 }
 
 void libjit_local_response_normalization_f(float *outW, const float *inW,

--- a/lib/Backends/OpenCL/kernels.cl
+++ b/lib/Backends/OpenCL/kernels.cl
@@ -1056,4 +1056,21 @@ __kernel void gatherW(__global void *mem,
    gatherK(&mem[dest], &mem[src], &mem[indices], numIndices, sliceSize);
 }
 
+__kernel void scatterassignK(__global float *data,
+                      __global cl_uint64_t *indices,
+                      __global const float *slices,
+                      cl_uint32_t sliceSize) {
+  int idx = get_global_id(0);
+  cl_uint64_t destDataIdx = indices[idx];
+  memcpy_float(data + destDataIdx * sliceSize, slices + idx * sliceSize, sliceSize);
+}
+
+__kernel void scatterassignW(__global void *mem,
+                      cl_uint32_t data,
+                      cl_uint32_t indices,
+                      cl_uint32_t slices,
+                      cl_uint32_t sliceSize) {
+   scatterassignK(&mem[data], &mem[indices], &mem[slices], sliceSize);
+}
+
 )";

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1175,6 +1175,13 @@ GatherNode *Function::createGather(llvm::StringRef name, NodeValue data,
       indices));
 }
 
+ScatterAssignNode *Function::createScatterAssign(llvm::StringRef name,
+                                                 NodeValue data,
+                                                 NodeValue indices,
+                                                 NodeValue slices) {
+  return addNode(new ScatterAssignNode(name, data, indices, slices));
+}
+
 QuantizeNode *Function::createQuantize(llvm::StringRef name, NodeValue input,
                                        TypeRef outTy) {
   assert(input.getElementType() == ElemKind::FloatTy &&

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -912,6 +912,29 @@ void GatherNode::verify() const {
   }
 }
 
+void ScatterAssignNode::verify() const {
+  const auto &slicesDims = getSlices().dims();
+  const auto &dataDims = getData().dims();
+  const auto &indicesDims = getIndices().dims();
+  (void)slicesDims;
+  (void)dataDims;
+  (void)indicesDims;
+
+  assert(indicesDims.size() == 1 &&
+         "Indices should be a single dimensional vector.");
+  assert(indicesDims[0] == slicesDims[0] &&
+         "There should be an index for each slice.");
+  assert(slicesDims.size() == dataDims.size() &&
+         "Slices and data should have same number of dimensions.");
+
+  if (dataDims.size() > 1) {
+    for (size_t i = 1; i < dataDims.size(); i++) {
+      assert(dataDims[i] == slicesDims[i] &&
+             "Slice shape should equal data shape without first dimension.");
+    }
+  }
+}
+
 void SaveNode::verify() const { checkSameType(getInput(), getOutput()); }
 
 void PowNode::verify() const { checkSameType(getResult(), getBase()); }

--- a/lib/IR/IRGen.cpp
+++ b/lib/IR/IRGen.cpp
@@ -307,6 +307,19 @@ public:
       registerIR(N, dest);
       break;
     }
+    case glow::Kinded::Kind::ScatterAssignNodeKind: {
+      auto *SAI = cast<ScatterAssignNode>(N);
+      auto *dataTensor = valueForNode(SAI->getData());
+      auto *indicesTensor = valueForNode(SAI->getIndices());
+      auto *slicesTensor = valueForNode(SAI->getSlices());
+      auto *dest =
+          builder_.createAllocActivationInst(SAI->getName(), SAI->getType());
+      builder_.createCopyInst("copy.scatterassign", dest, dataTensor);
+      builder_.createScatterAssignInst("scatterassign", dest, indicesTensor,
+                                       slicesTensor);
+      registerIR(N, dest);
+      break;
+    }
     case glow::Kinded::Kind::LocalResponseNormalizationNodeKind: {
       auto *LR = cast<LocalResponseNormalizationNode>(N);
       auto *in = valueForNode(LR->getInput());

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -371,6 +371,13 @@ int main(int argc, char **argv) {
       .autoVerify(VerifyKind::SameElementType,
                   {"Indices", "ElemKind::IndexTy"});
 
+  BB.newInstr("ScatterAssign")
+      .addOperand("Data", OperandKind::InOut)
+      .addOperand("Indices", OperandKind::In)
+      .addOperand("Slices", OperandKind::In)
+      .autoVerify(VerifyKind::SameElementType,
+                  {"Indices", "ElemKind::IndexTy"});
+
   //===--------------------------------------------------------------------===//
   //             Instructions used for debugging/profiling/printing
   //===--------------------------------------------------------------------===//

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -339,6 +339,16 @@ int main(int argc, char **argv) {
                     "{I_0, I_1, ... I_n, D_1, D_2, ... D_m}, where D_i and I_j "
                     "denote Data and Indices dimensions respectively.");
 
+  BB.newNode("ScatterAssign")
+      .addInput("Data")
+      .addInput("Indices")
+      .addInput("Slices")
+      .addResult("Data.getType()")
+      .setDocstring("Copies each slice from Slices into Data at the "
+                    "corresponding index in Indices. For example, given input "
+                    "Data {{1,2},{3,4},{5,6}}, Slices {{-3,-4}}, and Indices "
+                    "{1}, the result is {{1,2},{-3,-4},{5,6}}.");
+
   //===--------------------------------------------------------------------===//
   //                Nodes used for network training
   //===--------------------------------------------------------------------===//


### PR DESCRIPTION
More seq2seq support. Unfortunately don't think there's a good way to create this one out of other nodes. Added support for quantization, and the Interp, CPU, and OpenCL backends.