### PR TITLE
[GraphIR] Add a Load node

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -479,6 +479,8 @@ public:
                   unsigned hiddenSize, unsigned outputSize,
                   std::vector<NodeValue> &outputs);
 
+  LoadNode *createLoad(llvm::StringRef name, NodeValue Variable);
+
   /// @}
 
   /// Erase the node \p N from the Function.

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1602,6 +1602,10 @@ void Function::createLSTM(llvm::StringRef namePrefix,
   }
 };
 
+LoadNode *Function::createLoad(llvm::StringRef name, NodeValue variable) {
+  return addNode(new LoadNode(name, variable.getType(), variable));
+}
+
 //===----------------------------------------------------------------------===//
 //                   Graph dumping and printing
 //===----------------------------------------------------------------------===//

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -1002,6 +1002,11 @@ void ConcatNode::verify() const {
   }
 }
 
+void LoadNode::verify() const {
+  // Loads are restricted to Variables.
+  assert(llvm::isa<Variable>(getVariable().getNode()));
+}
+
 //===----------------------------------------------------------------------===//
 //                     Node hashing support
 //===----------------------------------------------------------------------===//

--- a/lib/IR/IRGen.cpp
+++ b/lib/IR/IRGen.cpp
@@ -363,6 +363,16 @@ public:
       V->setName(N->getName());
       break;
     }
+    case glow::Kinded::Kind::LoadNodeKind: {
+      auto *load = cast<LoadNode>(N);
+      auto *src = valueForNode(load->getVariable());
+      auto *dest =
+          builder_.createAllocActivationInst(load->getName(), load->getType());
+      auto *copy = builder_.createCopyInst("load", dest, src);
+      copy->setName(N->getName());
+      registerIR(N, dest);
+      break;
+    }
     case glow::Kinded::Kind::VariableNodeKind: {
       auto *V = cast<Variable>(N);
       auto *W = builder_.createWeightVar(V->getType(), V->getName(),

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -134,6 +134,27 @@ TEST_P(Operator, matmul) {
   EXPECT_NEAR(H.at({2, 0}), 95, 0.001);
 }
 
+TEST_P(Operator, Load) {
+  auto *var = mod_.createVariable(ElemKind::FloatTy, {3, 3}, "var",
+                                  VisibilityKind::Private,
+                                  Variable::TrainKind::Xavier, 1);
+  auto *R = F_->createLoad("load", var);
+
+  auto *result = mod_.createVariable(ElemKind::FloatTy, {3, 3}, "result");
+  F_->createSave("save", R, result);
+
+  EE_.compile(CompilationMode::Infer, F_);
+  EE_.run({}, {});
+
+  auto resultHandler = result->getPayload().getHandle();
+  auto varHandler = var->getPayload().getHandle();
+  for (size_t i = 0; i < 3; ++i) {
+    for (size_t j = 0; j < 3; ++j) {
+      EXPECT_EQ(resultHandler.at({i, j}), varHandler.at({i, j}));
+    }
+  }
+}
+
 TEST_P(Operator, batchedReduceAdd) {
   auto *batch = mod_.createVariable(ElemKind::FloatTy, {2, 4}, "batch");
   auto *result = mod_.createVariable(ElemKind::FloatTy, {4}, "result");

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -52,6 +52,14 @@ int main(int argc, char **argv) {
                     "this node and all of its ancestor nodes. Generally "
                     "intended to save the final result of a network.");
 
+  BB.newNode("Load")
+      .addInput("Variable")
+      .addResultFromCtorArg()
+      .setDocstring("Load/Copy a variable into local memory. "
+                    "If the memory space of the variable is the same as the "
+                    "local memory space and the memory dependencies allow it, "
+                    "the backend may choose to reuse this buffer directly.");
+
   //===--------------------------------------------------------------------===//
   //                   Convolution / Pool / FC
   //===--------------------------------------------------------------------===//


### PR DESCRIPTION
The load node represents the action of loading a variable to the
local memory of the device.

This is the first step to handle the flow of data across different
devices. The rough plan is:
- Model memory transfer explicitly with Save and Load nodes
- Extend Variables with some information about their location (e.g., addrspace x on GPU)
- Teach codegen how to materialize those synchronization point (right now we lower Loads into copys)
- Extend the runtime to issue the right DMA (more generally) transactions