### PR TITLE
Provide helper functions to return output streams for stdout, stderr and debug output

### DIFF
--- a/include/glow/Support/Support.h
+++ b/include/glow/Support/Support.h
@@ -28,6 +28,15 @@ namespace glow {
 /// Convert the ptr \p ptr into an ascii representation in the format "0xFFF..."
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os, void *ptr);
 
+/// \returns output stream for stdout.
+llvm::raw_ostream &outs();
+
+/// \returns output stream for stderr.
+llvm::raw_ostream &errs();
+
+/// \returns output stream for debug messages.
+llvm::raw_ostream &dbgs();
+
 /// Stream LLVM's ArrayRef into the given output stream.
 template <typename E>
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os,

--- a/lib/Support/Support.cpp
+++ b/lib/Support/Support.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "glow/Support/Support.h"
+#include "llvm/Support/Debug.h"
 
 #include <cctype>
 #include <sstream>
@@ -25,6 +26,18 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os, void *ptr) {
   std::ostringstream stringstream;
   stringstream << ptr;
   return os << stringstream.str();
+}
+
+llvm::raw_ostream &outs() {
+  return llvm::outs();
+}
+
+llvm::raw_ostream &errs() {
+  return llvm::errs();
+}
+
+llvm::raw_ostream &dbgs() {
+  return llvm::dbgs();
 }
 
 std::string escapeDottyString(const std::string &str) {


### PR DESCRIPTION
This PR provides glow::outs(), glow::errs() and glow::dbgs() which are similar to llvm::outs(), llvm::errs() and llvm::dbgs(). For now their just wrap the corresponding LLVM functions.

The main difference is that these functions can always be used, even under debugger, which is different from their LLVM counterparts which can be used under debugger only when debug builds of LLVM are used.

For example, you can use these streams in LLDB to dump LLVM module or types like:
`print llmod->print(glow::outs(), 0, 0, 0)`