### PR TITLE
[support] Introduce DEBUG_GLOW macro

### DIFF
--- a/include/glow/Support/Debug.h
+++ b/include/glow/Support/Debug.h
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_SUPPORT_DEBUG_H
+#define GLOW_SUPPORT_DEBUG_H
+
+namespace glow {
+
+#ifndef NDEBUG
+
+/// \returns true if \p type matches the activated debug type.
+bool isCurrentDebugType(const char *type);
+
+/// Macro to perform debug actions when TYPE is activated.
+#define DEBUG_GLOW_WITH_TYPE(TYPE, X)                                          \
+  do {                                                                         \
+    if (glow::DebugFlag || glow::isCurrentDebugType(TYPE)) {                   \
+      X;                                                                       \
+    }                                                                          \
+  } while (false)
+
+#else
+
+#define DEBUG_GLOW_WITH_TYPE(TYPE, X)                                          \
+  do {                                                                         \
+  } while (false)
+
+#endif
+
+/// Set to true if '-debug-glow' command line option is specified.
+extern bool DebugFlag;
+
+/// DEBUG_GLOW macros.  Used to emit debug information.  Enabled via
+/// '-debug-glow' or '-debug-glow-only'.
+#define DEBUG_GLOW(X) DEBUG_GLOW_WITH_TYPE(DEBUG_TYPE, X)
+
+} // namespace glow
+
+#endif // GLOW_SUPPORT_DEBUG_H

--- a/lib/Backends/CPU/AllocationsInfo.cpp
+++ b/lib/Backends/CPU/AllocationsInfo.cpp
@@ -21,6 +21,7 @@
 #include "glow/Graph/Nodes.h"
 #include "glow/IR/IRUtils.h"
 #include "glow/IR/Instrs.h"
+#include "glow/Support/Debug.h"
 
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
@@ -28,10 +29,10 @@
 using namespace glow;
 
 using namespace glow;
+using llvm::StringRef;
 using llvm::cast;
 using llvm::dyn_cast;
 using llvm::isa;
-using llvm::StringRef;
 
 void AllocationsInfo::allocateWeightVars(IRFunction *F, bool reuseAddresses) {
   // Use two different allocators, because constant weights and mutable weights
@@ -78,8 +79,8 @@ void AllocationsInfo::allocateWeightVars(IRFunction *F, bool reuseAddresses) {
   constantWeightVarsMemSize_ = constantWeightVarsAllocator.getMaxMemoryUsage();
   mutableWeightVarsMemSize_ = mutableWeightVarsAllocator.getMaxMemoryUsage();
 
-  DEBUG(for (auto &A
-             : allocatedAddressed_) {
+  DEBUG_GLOW(for (auto &A
+                  : allocatedAddressed_) {
     if (isa<AllocActivationInst>(A.first) || isa<TensorViewInst>(A.first))
       continue;
     assert(valueNumbers_.count(A.first) && "Unknown weight");
@@ -128,8 +129,8 @@ void AllocationsInfo::allocateActivations(IRFunction *F) {
   for (auto &A : activationAddr) {
     allocatedAddressed_[A.first] = A.second;
   }
-  DEBUG(for (auto &A
-             : allocatedAddressed_) {
+  DEBUG_GLOW(for (auto &A
+                  : allocatedAddressed_) {
     llvm::errs() << "Allocated activation " << A.first->getName()
                  << " size: " << A.first->getSizeInBytes()
                  << "  address range:  [" << allocatedAddressed_[A.first]

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -18,6 +18,7 @@
 #include "CPUBackend.h"
 #include "glow/Graph/Graph.h"
 #include "glow/IR/Instrs.h"
+#include "glow/Support/Debug.h"
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
@@ -32,10 +33,10 @@
 #include "llvm/Support/raw_ostream.h"
 
 using namespace glow;
+using llvm::StringRef;
 using llvm::cast;
 using llvm::dyn_cast;
 using llvm::isa;
-using llvm::StringRef;
 
 static llvm::cl::opt<std::string> target("target", llvm::cl::desc("target"));
 
@@ -248,10 +249,10 @@ void CPUBackend::produceBundle(llvm::StringRef outputDir) {
   auto bundleName = irgen_.getMainEntryName();
   auto bundleCodeOutput = (outputDir + "/" + bundleName + ".o").str();
   auto bundleWeightsOutput = (outputDir + "/" + bundleName + ".weights").str();
-  DEBUG(llvm::outs() << "Producing a bundle:\n"
-                     << "bundle name: " << bundleName << "\n"
-                     << "bundle code: " << bundleCodeOutput << "\n"
-                     << "bundle weights:" << bundleWeightsOutput << "\n");
+  DEBUG_GLOW(llvm::outs() << "Producing a bundle:\n"
+                          << "bundle name: " << bundleName << "\n"
+                          << "bundle code: " << bundleCodeOutput << "\n"
+                          << "bundle weights:" << bundleWeightsOutput << "\n");
   llvm::StringRef fileName = bundleCodeOutput;
   std::error_code EC;
   llvm::raw_fd_ostream outputFile(fileName, EC, llvm::sys::fs::F_None);

--- a/lib/Backends/CPU/FunctionSpecializer.cpp
+++ b/lib/Backends/CPU/FunctionSpecializer.cpp
@@ -19,6 +19,7 @@
 #include "CommandLine.h"
 
 #include "glow/IR/Instrs.h"
+#include "glow/Support/Debug.h"
 
 #include "llvm/ADT/Statistic.h"
 #include "llvm/Support/Debug.h"
@@ -27,10 +28,10 @@
 
 using namespace glow;
 
+using llvm::StringRef;
 using llvm::cast;
 using llvm::dyn_cast;
 using llvm::isa;
-using llvm::StringRef;
 
 namespace {
 /// Perform function specialization with constant arguments taking into account
@@ -115,7 +116,7 @@ class FunctionSpecializer {
     // We don't specialize arguments which are pointers to floating point and
     // quantized buffers, because this is likely to significantly increase the
     // code size without any big performance benefits.
-      if (arg->getType()->isPointerTy()) {
+    if (arg->getType()->isPointerTy()) {
       auto elemTy = cast<llvm::PointerType>(arg->getType())->getElementType();
       // Bail if it is an FP buffer.
       if (elemTy->isFloatTy()) {
@@ -214,9 +215,9 @@ class FunctionSpecializer {
     // it into the specialized function. And if the original fuction did not
     // have any debug info, then its specialization should not have any debug
     // info either.
-    DEBUG(llvm::dbgs() << "\n\nCreated specialized function " << specializedName
-                       << "\n";
-          specializedF->print(llvm::errs(), nullptr));
+    DEBUG_GLOW(llvm::dbgs() << "\n\nCreated specialized function "
+                            << specializedName << "\n";
+               specializedF->print(llvm::errs(), nullptr));
     NumSpecializations++;
     return specializedF;
   }
@@ -275,8 +276,8 @@ public:
 
       // Bail if the values of arguments are not constants.
       if (!getConstantValue(arg)) {
-        DEBUG(llvm::dbgs() << "Could not specialize call:\n";
-              call->print(llvm::dbgs()));
+        DEBUG_GLOW(llvm::dbgs() << "Could not specialize call:\n";
+                   call->print(llvm::dbgs()));
         return nullptr;
       }
     }
@@ -323,10 +324,10 @@ public:
     for (auto *I : erasedInstructions) {
       I->eraseFromParent();
     }
-    DEBUG(llvm::dbgs() << "Number of specializations: " << NumSpecializations
-                       << "\n";
-          llvm::dbgs() << "Number of shared specializations: "
-                       << NumSharedSpecializations << "\n");
+    DEBUG_GLOW(llvm::dbgs() << "Number of specializations: "
+                            << NumSpecializations << "\n";
+               llvm::dbgs() << "Number of shared specializations: "
+                            << NumSharedSpecializations << "\n");
   }
 
 private:

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -21,6 +21,7 @@
 #include "glow/Graph/Nodes.h"
 #include "glow/IR/IRUtils.h"
 #include "glow/IR/Instrs.h"
+#include "glow/Support/Debug.h"
 
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Casting.h"
@@ -473,8 +474,8 @@ void OCLBackend::executeConvolution(const OCLConvolutionInst *CC) {
 void OCLBackend::doForwardPass() {
   auto copiedToDeviceBytes = copyMutableWeightsToDevice();
   (void)copiedToDeviceBytes;
-  DEBUG(llvm::dbgs() << "Copied " << copiedToDeviceBytes
-                     << " bytes to OpenCL device\n");
+  DEBUG_GLOW(llvm::dbgs() << "Copied " << copiedToDeviceBytes
+                          << " bytes to OpenCL device\n");
 
   for (const auto &I : F_->getInstrs()) {
     // The kernels are named after the name of the instruction, plus the "W"
@@ -1125,8 +1126,8 @@ void OCLBackend::doForwardPass() {
 
   auto copiedFromDeviceBytes = copyMutableWeightsFromDevice();
   (void)copiedFromDeviceBytes;
-  DEBUG(llvm::dbgs() << "Copied " << copiedFromDeviceBytes
-                     << " bytes from OpenCL device\n");
+  DEBUG_GLOW(llvm::dbgs() << "Copied " << copiedFromDeviceBytes
+                          << " bytes from OpenCL device\n");
 }
 
 size_t OCLBackend::copyValueToDevice(const Value *v, void *buf) {
@@ -1170,8 +1171,8 @@ size_t OCLBackend::copyValueFromDevice(const Value *v, void *buf) {
         sizeInBytes, buf, /* num_events_in_wait_list */ 0,
         /* event_list */ nullptr, /* event */ nullptr);
     GLOW_ASSERT(err == CL_SUCCESS && "Unable to copy from the device");
-    DEBUG(llvm::dbgs() << "Copied the value from device: "
-                       << it->first->getName() << "\n");
+    DEBUG_GLOW(llvm::dbgs() << "Copied the value from device: "
+                            << it->first->getName() << "\n");
     copiedBytes += sizeInBytes;
   }
   return copiedBytes;
@@ -1283,8 +1284,8 @@ void OCLBackend::init() {
   // Ask the memory allocator how much memory is required. What was the high
   // watermark for this program.
   size_t requiredSpace = allocator_.getMaxMemoryUsage();
-  DEBUG(llvm::dbgs() << "Allocated GPU memory block of size: " << requiredSpace
-                     << "\n");
+  DEBUG_GLOW(llvm::dbgs() << "Allocated GPU memory block of size: "
+                          << requiredSpace << "\n");
 
   // Release the memory from the previous run.
   if (deviceBuffer_) {

--- a/lib/IR/GraphScheduler.cpp
+++ b/lib/IR/GraphScheduler.cpp
@@ -18,6 +18,7 @@
 #include "glow/Graph/Nodes.h"
 #include "glow/Graph/Utils.h"
 #include "glow/IR/IR.h"
+#include "glow/Support/Debug.h"
 
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
@@ -82,8 +83,8 @@ class ChildMemSizeBasedScheduler : public Scheduler {
         resultSize += N.getType(idx)->getSizeInBytes();
       }
       resultMemSize_[&N] = resultSize;
-      DEBUG(llvm::outs() << "ResultSize of " << N.getName() << ":" << resultSize
-                         << "\n");
+      DEBUG_GLOW(llvm::outs() << "ResultSize of " << N.getName() << ":"
+                              << resultSize << "\n");
     }
   }
 
@@ -111,8 +112,8 @@ class ChildMemSizeBasedScheduler : public Scheduler {
           maxSize = maxMemSize_[input];
       }
       maxMemSize_[N] = maxSize;
-      DEBUG(llvm::outs() << "MaxSize of " << N->getName() << ":" << maxSize
-                         << "\n");
+      DEBUG_GLOW(llvm::outs()
+                 << "MaxSize of " << N->getName() << ":" << maxSize << "\n");
     }
   }
 
@@ -150,11 +151,11 @@ class ChildMemSizeBasedScheduler : public Scheduler {
       }
     }
 
-    DEBUG(llvm::outs() << "\nAbout to schedule children of " << N->getName()
-                       << "\n";
-          llvm::outs() << "Children are:\n");
-    DEBUG(for (auto child
-               : orderedChildren) {
+    DEBUG_GLOW(llvm::outs() << "\nAbout to schedule children of "
+                            << N->getName() << "\n";
+               llvm::outs() << "Children are:\n");
+    DEBUG_GLOW(for (auto child
+                    : orderedChildren) {
       llvm::outs() << "Child " << child->getName() << ": "
                    << maxMemSize_[child] - resultMemSize_[child] << "\n";
     });
@@ -165,7 +166,7 @@ class ChildMemSizeBasedScheduler : public Scheduler {
     }
 
     // Schedule the node after all its children are scheduled.
-    DEBUG(llvm::outs() << "Scheduled node: " << N->getName() << "\n");
+    DEBUG_GLOW(llvm::outs() << "Scheduled node: " << N->getName() << "\n");
     scheduled_.push_back(N);
   }
 

--- a/lib/Optimizer/IROptimizer.cpp
+++ b/lib/Optimizer/IROptimizer.cpp
@@ -22,6 +22,7 @@
 #include "glow/IR/IRUtils.h"
 #include "glow/IR/Instrs.h"
 #include "glow/Optimizer/Optimizer.h"
+#include "glow/Support/Debug.h"
 
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/CommandLine.h"
@@ -752,13 +753,14 @@ static void replaceAllUsesInsideIntervalWith(
         replacement = tv;
       }
 
-      DEBUG(llvm::dbgs() << "Replacing inside instruction " << opIdx << "\n";
-            llvm::dbgs() << "before: "; I->dump(llvm::dbgs());
-            llvm::dbgs() << "\n");
+      DEBUG_GLOW(llvm::dbgs()
+                     << "Replacing inside instruction " << opIdx << "\n";
+                 llvm::dbgs() << "before: "; I->dump(llvm::dbgs());
+                 llvm::dbgs() << "\n");
       // Replace the old value by the new value.
       I->setOperand(i, replacement);
-      DEBUG(llvm::dbgs() << "after: "; I->dump(llvm::dbgs());
-            llvm::dbgs() << "\n");
+      DEBUG_GLOW(llvm::dbgs() << "after: "; I->dump(llvm::dbgs());
+                 llvm::dbgs() << "\n");
     }
   }
 }
@@ -769,8 +771,8 @@ static void replaceAllUsesInsideIntervalWith(
 static void eraseInstructions(IRFunction &M,
                               InstructionPtrSet &erasedInstructions) {
   for (auto it : erasedInstructions) {
-    DEBUG(llvm::dbgs() << "Deleting instruction :"; it->dump(llvm::dbgs());
-          llvm::dbgs() << "\n");
+    DEBUG_GLOW(llvm::dbgs() << "Deleting instruction :"; it->dump(llvm::dbgs());
+               llvm::dbgs() << "\n");
     M.eraseInstruction(it);
   }
 }
@@ -785,10 +787,10 @@ static void reuseBufferInsideInterval(
     Value *oldBuffer, Value *newBuffer, Interval oldInterval, IRFunction &M,
     const LiveIntervalsInstructionNumbering &instrNumbering,
     Intervals &oldIntervals, Intervals &newIntervals) {
-  DEBUG(llvm::dbgs() << "\n\nReuse buffers: use buffer of "
-                     << newBuffer->getName() << " as a buffer for "
-                     << oldBuffer->getName() << "\n"
-                     << "in live interval " << oldInterval << "\n");
+  DEBUG_GLOW(llvm::dbgs() << "\n\nReuse buffers: use buffer of "
+                          << newBuffer->getName() << " as a buffer for "
+                          << oldBuffer->getName() << "\n"
+                          << "in live interval " << oldInterval << "\n");
   // Replace oldBuffer with newBuffer.
   replaceAllUsesInsideIntervalWith(oldBuffer, newBuffer, oldInterval, M,
                                    instrNumbering);

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 add_library(Support
+              Debug.cpp
               Random.cpp
               Support.cpp)
 target_link_libraries(Support

--- a/lib/Support/Debug.cpp
+++ b/lib/Support/Debug.cpp
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/Support/Debug.h"
+
+#include "llvm/Support/CommandLine.h"
+
+#include <string>
+
+using namespace glow;
+
+static std::string DebugOnlyType;
+
+/// -debug-glow - Command line option to enable DEBUG_GLOW statements.
+static llvm::cl::opt<bool, true>
+    DebugGlow("debug-glow", llvm::cl::desc("Enable debug output"),
+              llvm::cl::Hidden, llvm::cl::location(DebugFlag));
+
+/// -debug-glow-only - Command line option to enable debug output for specific
+/// passes.
+static llvm::cl::opt<std::string, true>
+    DebugGlowOnly("debug-glow-only",
+                  llvm::cl::desc("Enable a specific type of debug output"),
+                  llvm::cl::Hidden, llvm::cl::location(DebugOnlyType));
+
+namespace glow {
+
+/// Exported boolean set by -debug-glow option.
+bool DebugFlag = false;
+
+bool isCurrentDebugType(const char *type) { return DebugOnlyType == type; }
+
+} // namespace glow


### PR DESCRIPTION
I wanted to use this debugging functionality but realized I needed a Debug build of llvm to get access to -debug and -debug-only.  Feels like we should have our own flavor, so I've added -debug-glow and -debug-glow-only.