### PR TITLE
[debug-info] Improvements and bug-fixes related to debug info emission

### DIFF
--- a/include/glow/IR/IR.h
+++ b/include/glow/IR/IR.h
@@ -274,8 +274,12 @@ private:
   /// represent them in the lower IR.
   VariableMap variableMap_{};
 
-  /// Assign the instructions in the function a unique name.
-  void nameInstructions();
+  /// Assign the instruction \p Named in the function a unique legal name.
+  /// Legal names are legal C identifiers in the form: "[a-zA-Z_][a-zA-Z0-9_]*".
+  /// If the instruction does not have any name yet, use the \p suggestion as a
+  /// hint for a name.
+  void nameInstruction(Named *named, llvm::StringRef suggestion,
+                       llvm::StringSet<> &stringTable);
 
   /// Perform scheduling on the graph.
   /// \returns computed schedule in the \p Schedule parameter.
@@ -353,6 +357,10 @@ public:
   /// Moves an instruction belonging to a function before the place described by
   /// \where.
   InstrIterator moveInstruction(Instruction *where, Instruction *I);
+
+  /// Assign the instructions in the function unique legal names.
+  /// Legal names are legal C identifiers in the form: "[a-zA-Z_][a-zA-Z0-9_]*".
+  void nameInstructions();
 };
 
 /// Iterator over inteructions.

--- a/lib/Backends/CPU/CMakeLists.txt
+++ b/lib/Backends/CPU/CMakeLists.txt
@@ -21,7 +21,7 @@ set_target_properties(CPURuntime
 target_compile_options(CPURuntime
                        PRIVATE
                          -ffast-math
-                         -g
+                         -g0
                          -emit-llvm
                          -O0)
 # NOTE(abdulras) explicitly override the compiler and linker invocations with

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -101,6 +101,8 @@ void CPUBackend::emitJitMain() {
   createCall(builder, entryF, initFunctionCallArgs);
   // Terminate the function.
   builder.CreateRetVoid();
+  // Create the debug info for the entry point function.
+  irgen_.generateFunctionDebugInfo(func);
 }
 
 void CPUBackend::performJITMemoryAllocation() {

--- a/lib/Backends/CPU/DebugInfo.cpp
+++ b/lib/Backends/CPU/DebugInfo.cpp
@@ -357,6 +357,10 @@ void LLVMIRGen::generateDebugInfo() {
     // If a function has a debug information already, no need to re-emit it.
     if (F.getSubprogram())
       continue;
+    // Specializations are not forced to have any debug info. They will have it,
+    // if the original function has it.
+    if (F.getName().endswith("_specialized"))
+      continue;
     llvm_unreachable(
         "Expected all functions to have debug information at this point");
   }

--- a/lib/Backends/CPU/DebugInfo.cpp
+++ b/lib/Backends/CPU/DebugInfo.cpp
@@ -390,22 +390,6 @@ void LLVMIRGen::generateDebugInfo() {
            "Base address variable should be present in the LLVM module");
   }
 
-  // Iterate over all functions in the module and generate a debug information
-  // for them.
-  for (auto &F : getModule()) {
-    if (F.isDeclaration())
-      continue;
-    // If a function has a debug information already, no need to re-emit it.
-    if (F.getSubprogram())
-      continue;
-    // Specializations are not forced to have any debug info. They will have it,
-    // if the original function has it.
-    if (F.getName().endswith("_specialized"))
-      continue;
-    llvm_unreachable(
-        "Expected all functions to have debug information at this point");
-  }
-
   // Now iterate over the module and add debug locations to all instructions
   // inside the functions which have debug information. This is required for the
   // proper emission of the debug information into object files. If debug

--- a/lib/Backends/CPU/DebugInfo.cpp
+++ b/lib/Backends/CPU/DebugInfo.cpp
@@ -187,6 +187,7 @@ void LLVMIRGen::initDebugInfo() {
 #endif
     return;
   }
+  F_->nameInstructions();
   // Remove any existing debug info version flags from the module to
   // avoid possible conflicts, which may happen if libjit was compiled
   // using an older version of Clang which uses the old debug info format.

--- a/lib/Backends/CPU/FunctionSpecializer.cpp
+++ b/lib/Backends/CPU/FunctionSpecializer.cpp
@@ -209,6 +209,11 @@ class FunctionSpecializer {
     // Specializations should not be inlined.
     specializedF->addFnAttr(llvm::Attribute::AttrKind::NoInline);
     specializedF->setName(specializedName);
+    // No need to explicitly emit a debug info for the specialized function. If
+    // the original function had it, the cloner would have automatically copied
+    // it into the specialized function. And if the original fuction did not
+    // have any debug info, then its specialization should not have any debug
+    // info either.
     DEBUG(llvm::dbgs() << "\n\nCreated specialized function " << specializedName
                        << "\n";
           specializedF->print(llvm::errs(), nullptr));
@@ -409,13 +414,4 @@ void LLVMIRGen::performSpecialization() {
   FunctionSpecializer FuncSpecializer(llmodule_->getFunction("main"),
                                       dontSpecializeArgsSet_);
   FuncSpecializer.run();
-  // Add debug info to all the newly created functions, i.e. to the created
-  // specialized functions.
-  for (auto &FF : getModule()) {
-    if (FF.isDeclaration())
-      continue;
-    if (FF.getName().find("_specialized", 0) == llvm::StringRef::npos)
-      continue;
-    generateFunctionDebugInfo(&FF);
-  }
 }

--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -639,7 +639,6 @@ void LLVMIRGen::emitDataParallelKernel(llvm::IRBuilder<> &builder,
 
   // Emit a call of the kernel.
   createCall(builder, kernelFunc, buffers);
-  generateFunctionDebugInfo(kernelFunc);
 }
 
 /// Check if the provided operand overlaps with an operand of an instruction

--- a/lib/Backends/CPU/LLVMIRGen.h
+++ b/lib/Backends/CPU/LLVMIRGen.h
@@ -39,6 +39,16 @@ class Instruction;
 class WeightVar;
 struct AllocationsInfo;
 
+/// Different kinds of memory areas used by the emitted LLVM function.
+/// The order is important. It should match the order of base addresses
+/// arguments passed to "main".
+enum MemoryAreaKind {
+  ConstWeightsMemoryArea,
+  MutableWeightsMemoryArea,
+  ActivationsMemoryArea,
+  LastMemoryArea
+};
+
 /// A POD struct that stores information related to debug info.
 struct DebugInfo {
   /// Source file for the main function.
@@ -52,16 +62,19 @@ struct DebugInfo {
   llvm::DICompileUnit *compilationUnit_{nullptr};
   /// Mapping from LLVM types to DebugInfo types.
   llvm::DenseMap<llvm::Type *, llvm::DIType *> DITypes_;
-  /// Global variable holding the base address of the constant WeightVars
-  /// memory
-  /// area. Used only when producing a debug information.
-  llvm::GlobalVariable *constWeightsBaseAddressGV_{nullptr};
-  /// Global variable holding the base address of mutable WeightVars memory
-  /// area. Used only when producing a debug information.
-  llvm::GlobalVariable *mutableWeightsBaseAddressGV_{nullptr};
-  /// Global variable holding the base address of the activations memory area.
-  /// Used only when producing a debug information.
-  llvm::GlobalVariable *activationsBaseAddressGV_{nullptr};
+  /// Names of global variables to hold the bases address of different memory
+  /// areas, e.g. activations, constant or mutable weights.
+  llvm::SmallVector<llvm::StringRef, LastMemoryArea - 1>
+      baseAddressesVariablesNames_;
+  /// Maps memory area kinds to the global variables holding the base address of
+  /// the corresponding memory area, e.g. activations, constant or mutable
+  /// weights area. Used only when producing a debug information. These
+  /// variables are required to properly show in the debugger weights and
+  /// activations variables, which are expressed in DWARF using a relative
+  /// addressing mode with the base addresses stored in these base addresses
+  /// variables.
+  llvm::SmallVector<llvm::GlobalVariable *, LastMemoryArea - 1>
+      baseAddressesVariables_;
 };
 
 /// This is a class containing a common logic for the generation of the LLVM IR

--- a/lib/IR/IR.cpp
+++ b/lib/IR/IR.cpp
@@ -470,21 +470,14 @@ void Instruction::dumpOperands(llvm::raw_ostream &os) const {
   }
 }
 
-static void nameInstr(std::unordered_set<std::string> &usedNames, Named *named,
-                      llvm::StringRef suggestion) {
-  unsigned idx = 0;
-
+void IRFunction::nameInstruction(Named *named, llvm::StringRef suggestion,
+                                 llvm::StringSet<> &stringTable) {
   // Use the first few letters of the value as the initial name.
   if (!named->hasName()) {
     named->setName(suggestion.slice(0, 4));
   }
 
-  std::string tempName = named->getName();
-
-  while (!usedNames.insert(tempName).second) {
-    tempName = named->getName().str() + std::to_string(idx++);
-  }
-
+  std::string tempName = Module::uniqueName(named->getName(), stringTable);
   named->setName(tempName);
 }
 
@@ -496,12 +489,14 @@ static bool hasResultValue(const Instruction *I) {
 }
 
 void IRFunction::nameInstructions() {
-  std::unordered_set<std::string> usedNames;
+  /// Stores a list of unique instruction names that were used by the IRFunction
+  /// at some point.
+  llvm::StringSet<> uniqueNames;
   for (auto &v : weights_) {
-    nameInstr(usedNames, v, v->getKindName());
+    nameInstruction(v, v->getKindName(), uniqueNames);
   }
   for (auto &I : instrs_) {
-    nameInstr(usedNames, &I, I.getKindName());
+    nameInstruction(&I, I.getKindName(), uniqueNames);
   }
 }
 


### PR DESCRIPTION
This is supposed to be a fix for #1157 

While debugging the issue, I also changed a couple of things to make the debug info emission more robust and to make the debugging of Glow networks in terms of Glow IR more convenient.

Here is a list of changes:
 
- Legalize names of all instructions

  Names of instructions inside IRFunctions are always uniqued. But they were not legalized and thus they could not be used in the debugger, when debugging Glow networks, because debuggers expect legal C identifiers as variable names.

- Do not explicitly emit debug info for specialized functions

  There is no need to explicitly emit a debug info for the specialized function. If the original function had it, the cloner would have automatically copied it into the specialized function. And if the original function did not have any debug info, then its specialization should not have any debug info either.

- Make sure that global variables for based addresses of activations and weights memory areas are not eliminated by optimizations

  These variables are needed for emitting the debug info for weights and activations, because it uses relative addressing based on these variables.

-  Do not emit debug info for stacked kernels
   
   Even if the debug info is emitted, it does not properly reflect what happens inside the optimized stacked kernel. Therefore avoid emitting it, to avoid any confusion.

- Emit the debug info for the entry point function when JITting

   With this change, -g does not crash anymore in JIT mode (i.e. with -cpu) and the debug info is properly emitted. But it is not possible to use a debugger directly on the JITed code code yet. You still need to use the AOT mode for it.

- Do not emit any debug info for libjit

   The debugging of Glow networks should happen at the Glow IR level. Being able to step into heavily optimized libjit kernels is not very helpful, because debuggers usually have a rather weird behavior inside optimized functions. Moreover, the source code of libjit is likely to be unavailable in production use and thus the debugging would not be possible anyways for libjit's functions.