### PR TITLE
Stop exposing details of the backends implementations

### DIFF
--- a/lib/Backends/Backends.cpp
+++ b/lib/Backends/Backends.cpp
@@ -14,14 +14,6 @@
  * limitations under the License.
  */
 
-#include "Interpreter/Interpreter.h"
-#if defined(GLOW_WITH_CPU)
-#include "CPU/CPUBackend.h"
-#endif
-#if defined(GLOW_WITH_OPENCL)
-#include "OpenCL/OpenCL.h"
-#endif
-
 #include "glow/Backends/Backend.h"
 #include "glow/Graph/Graph.h"
 #include "glow/Graph/Nodes.h"
@@ -30,6 +22,24 @@
 #include "llvm/Support/Casting.h"
 
 using namespace glow;
+
+namespace glow {
+/// NOTE: Please add a declaration of a backend-specific `create` method here
+/// when you define a new backend.
+
+/// Create a new instance of the interpreter backend.
+Backend *createInterpreter(IRFunction *F);
+
+#if defined(GLOW_WITH_CPU)
+/// Create a new instance of the CPUBackend backend.
+Backend *createCPUBackend(IRFunction *F);
+#endif
+
+#if defined(GLOW_WITH_OPENCL)
+/// Create a new instance of the OpenCL backend.
+Backend *createOCLBackend(IRFunction *F);
+#endif
+} // namespace glow
 
 Backend *glow::createBackend(BackendKind backendKind, IRFunction *F) {
   switch (backendKind) {

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -40,6 +40,10 @@ using llvm::isa;
 
 static llvm::cl::opt<std::string> target("target", llvm::cl::desc("target"));
 
+namespace glow {
+Backend *createCPUBackend(IRFunction *F) { return new CPUBackend(F); }
+} // namespace glow
+
 CPUBackend::CPUBackend(IRFunction *F)
     : F_(F), irgen_(F_, allocationsInfo_, "") {}
 

--- a/lib/Backends/CPU/CPUBackend.h
+++ b/lib/Backends/CPU/CPUBackend.h
@@ -99,9 +99,6 @@ public:
   /// @}
 };
 
-/// Create a new instance of the JITBackend backend.
-inline Backend *createCPUBackend(IRFunction *M) { return new CPUBackend(M); }
-
 } // namespace glow
 
 #endif // GLOW_BACKENDS_JIT_JIT_H

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -170,3 +170,7 @@ void Interpreter::doForwardPass() {
     }
   }
 }
+
+namespace glow {
+Backend *createInterpreter(IRFunction *F) { return new Interpreter(F); }
+} // namespace glow

--- a/lib/Backends/Interpreter/Interpreter.h
+++ b/lib/Backends/Interpreter/Interpreter.h
@@ -110,9 +110,6 @@ private:
   ///@}
 };
 
-/// Create a new instance of the Interpreter backend.
-inline Backend *createInterpreter(IRFunction *M) { return new Interpreter(M); }
-
 } // namespace glow
 
 #endif // GLOW_INTERPRETER_INTERPRETER_H

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -56,7 +56,9 @@ static llvm::cl::opt<bool> doProfile("opencl-profile",
                                      llvm::cl::cat(OpenCLBackendCat));
 } // namespace
 
-Backend *glow::createOCLBackend(IRFunction *F) { return new OCLBackend(F); }
+namespace glow {
+Backend *createOCLBackend(IRFunction *F) { return new OCLBackend(F); }
+} // namespace glow
 
 using Kind = Kinded::Kind;
 using kernelSrcEnum = struct {

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -174,10 +174,4 @@ private:
 
 } // namespace glow
 
-namespace glow {
-
-Backend *createOCLBackend(IRFunction *M);
-
-} // namespace glow
-
 #endif // GLOW_OPENCL_BACKEND_H


### PR DESCRIPTION
Until now, Backends.cpp included backends-specific header files defining backend classes with all the internal details. This exposed way too much information about the backends implementations. But it was not really necessary. Backends.cpp just needs to know how to create new instances of backends, i.e. it just needs declarations of createXYZBackend methods.

Let's move all such declarations into a dedicated central header file Backend.h and stop including the backend-specific header files into Backend.cpp.

Each new backend needs to add its create method to Backend.h