### PR TITLE
[fix] Fix variable erasure.

### DIFF
--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1724,7 +1724,7 @@ Variable *Module::getVariableByName(llvm::StringRef name) {
 }
 
 void Module::eraseVariable(Variable *N) {
-  auto vars = getVars();
+  auto &vars = getVars();
   auto I = std::find(vars.begin(), vars.end(), N);
   eraseVariable(I);
 }
@@ -1817,7 +1817,7 @@ void Function::verify() const {
     llvm_unreachable("Multiple nodes with the same name");
   }
 
-  auto vars = getParent()->getVars();
+  const auto &vars = getParent()->getVars();
 
   // Any node referenced by one of the graph nodes should be part of the Graph.
   for (const auto &N : nodes_) {

--- a/tests/unittests/graphTest.cpp
+++ b/tests/unittests/graphTest.cpp
@@ -25,6 +25,22 @@
 
 using namespace glow;
 
+TEST(Graph, testVariableErasure) {
+  Module MD;
+  auto &vars = MD.getVars();
+  EXPECT_EQ(vars.size(), 0);
+  EXPECT_EQ(std::distance(vars.begin(), vars.end()), vars.size());
+
+  Variable *V = MD.createVariable(ElemKind::FloatTy, {1, 1}, "dummy",
+                                  VisibilityKind::Public);
+  EXPECT_EQ(vars.size(), 1);
+  EXPECT_EQ(std::distance(vars.begin(), vars.end()), vars.size());
+
+  MD.eraseVariable(V);
+  EXPECT_EQ(vars.size(), 0);
+  EXPECT_EQ(std::distance(vars.begin(), vars.end()), vars.size());
+}
+
 TEST(Graph, simpleTestConv) {
   Module MD;
   Function *F = MD.createFunction("F");


### PR DESCRIPTION
`Module::vars_` calls `erase` using the iterator taken from a copied variable list. This causes iterators of `vars_` to iterate more than its size and access invalid memory.