### PR TITLE
Silence a warning about unused variable `name`. NFC.

### DIFF
--- a/lib/Backends/CPU/DebugInfo.cpp
+++ b/lib/Backends/CPU/DebugInfo.cpp
@@ -385,6 +385,7 @@ void LLVMIRGen::generateDebugInfo() {
   // debug info for weights and activations, because it uses relative addressing
   // based on these variables.
   for (auto name : dbgInfo_.baseAddressesVariablesNames_) {
+    (void)name;
     assert(getModule().getGlobalVariable(name,
                                          /* allowInternal */ true) &&
            "Base address variable should be present in the LLVM module");


### PR DESCRIPTION
This variable is used only in an assert, when DEBUG mode is used. In release mode, a warning was produced.

Thanks @beicy for noticing it!