### PR TITLE
[OpenCLSpecificNodesVerification] Fix broken pad for conv output dims

### DIFF
--- a/tools/ClassGen/Backends/OpenCL/OpenCLSpecificNodesVerification.h
+++ b/tools/ClassGen/Backends/OpenCL/OpenCLSpecificNodesVerification.h
@@ -19,8 +19,9 @@
 void OCLConvolutionNode::verify() const {
   ShapeNCHW idim(getInput().getType()->dims());
   ShapeNCHW odim(getResult().getType()->dims());
+  auto pad = getPad();
   auto outSz = calculateConvOutputDims(idim.h, idim.w, getKernel(), getStride(),
-                                       getPad());
+                                       {pad, pad, pad, pad});
   ShapeNCHW exp(idim.n, getBias().dims()[0], outSz.first, outSz.second);
   (void)exp;
   assert(exp == odim && "Invalid output dimensions");


### PR DESCRIPTION
Fixes missed change from from https://github.com/pytorch/glow/pull/1154 which has broken the OCL unit tests.