### PR TITLE
Use llvm::StringRef for dumpDAG methods

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -155,7 +155,7 @@ public:
   void dumpDAG();
 
   /// Dump a dotty graph that depicts the Module.
-  void dumpDAG(const char *dotFilename);
+  void dumpDAG(llvm::StringRef dotFilename);
 };
 
 /// Represents the compute graph.
@@ -526,7 +526,7 @@ public:
   void dumpDAG();
 
   /// Dump a dotty graph that depicts the function.
-  void dumpDAG(const char *dotFilename);
+  void dumpDAG(llvm::StringRef dotFilename);
 
   /// \returns the list of nodes that the Function owns.
   NodesList &getNodes() { return nodes_; }

--- a/include/glow/IR/IR.h
+++ b/include/glow/IR/IR.h
@@ -317,7 +317,7 @@ public:
   void dump(llvm::raw_ostream &OS);
 
   /// Dump a dotty graph that depicts the function.
-  void dumpDAG(const char *dotFilename);
+  void dumpDAG(llvm::StringRef dotFilename);
 
   /// Dump a dotty graph that depicts the function.
   void dumpDAG();

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -249,16 +249,15 @@ void Module::dumpDAG() {
   dumpDAG(stream.str().c_str());
 }
 
-void Module::dumpDAG(const char *dotFilename) {
-  std::string filename = dotFilename;
-  llvm::outs() << "Writing dotty graph for Module to: " << filename << '\n';
+void Module::dumpDAG(llvm::StringRef dotFilename) {
+  llvm::outs() << "Writing dotty graph for Module to: " << dotFilename << '\n';
 
   ModuleDottyPrinter DP;
 
   DP.visitModule(this);
 
   std::ofstream myfile;
-  myfile.open(filename);
+  myfile.open(dotFilename);
   DP.dumpAll(myfile);
   myfile.close();
 }
@@ -1705,16 +1704,15 @@ void Function::dumpDAG() {
   dumpDAG(stream.str().c_str());
 }
 
-void Function::dumpDAG(const char *dotFilename) {
-  std::string filename = dotFilename;
-  llvm::outs() << "Writing dotty graph for Function to: " << filename << '\n';
+void Function::dumpDAG(llvm::StringRef dotFilename) {
+  llvm::outs() << "Writing dotty graph for Function to: " << dotFilename << '\n';
 
   FunctionDottyPrinter DP;
 
   DP.visitGraph(this);
 
   std::ofstream myfile;
-  myfile.open(filename);
+  myfile.open(dotFilename);
   DP.dumpAll(myfile);
   myfile.close();
 }

--- a/lib/IR/IR.cpp
+++ b/lib/IR/IR.cpp
@@ -617,9 +617,8 @@ void IRFunction::dumpDAG() {
 }
 
 /// Dump a dotty graph that depicts the function.
-void IRFunction::dumpDAG(const char *dotFilename) {
-  std::string filename = dotFilename;
-  llvm::outs() << "Writing dotty graph to: " << filename << '\n';
+void IRFunction::dumpDAG(llvm::StringRef dotFilename) {
+  llvm::outs() << "Writing dotty graph to: " << dotFilename << '\n';
 
   std::string buffer;
   llvm::raw_string_ostream stream(buffer);


### PR DESCRIPTION
I keep wanting to build filenames like `std::string(F->getName()) + "_suffix"`, and it's kind of tedious to wrap that in `(...).c_str()`.  I picked `llvm::StringRef` since it's lightweight compared to `std::string`