### PR TITLE
[quantization] Fold quantize node into variable with multiple usages.

### DIFF
--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -1186,8 +1186,11 @@ static void optimizeQuantization(Function *F) {
 
       if (auto *V = dyn_cast<Variable>(Q->getInput())) {
         // Quantize(Variable) -> Variable
-        // V must have a single use and be private.
-        if (!V || !V->hasOneUse() || !V->isPrivate()) {
+        // V must be a private variable.
+        // Note, it does not really matter how many usages this var has.
+        // Quantized graph will use optimized var and other functions will
+        // refer to the floating point original var.
+        if (!V || !V->isPrivate()) {
           continue;
         }
         // Create a new variable NV to hold the quantized result.

--- a/tests/unittests/graphOptzTest.cpp
+++ b/tests/unittests/graphOptzTest.cpp
@@ -670,6 +670,56 @@ TEST_F(GraphOptz, DCEPublicVars) {
   EXPECT_EQ(mod_.getVars().size(), 1);
 }
 
+TEST_F(GraphOptz, foldQuantizeIntoVar) {
+  auto input = mod_.createVariable(ElemKind::FloatTy, {4}, "input",
+                      VisibilityKind::Private);
+  input->getPayload() = {10, 10 , 10, 10};
+  auto qType = mod_.uniqueType(ElemKind::Int8QTy, {4}, 2, 0);
+
+  auto Q = F_->createQuantize("quantize", input, qType);
+  auto S = F_->createSave("save", Q);
+
+  EXPECT_EQ(2, F_->getNodes().size());
+  ::glow::optimize(F_, CompilationMode::Infer);
+  // Quantization node was merged into input var.
+  EXPECT_EQ(1, F_->getNodes().size());
+
+  auto quantizedInput = llvm::cast<Variable>(S->getInput());
+  auto quantizedValues = quantizedInput->getHandle<int8_t>();
+  for(unsigned i = 0; i < 4; ++i) {
+    EXPECT_EQ(5, quantizedValues.raw(i));
+  }
+}
+
+TEST_F(GraphOptz, foldQuantizeIntoVarMultipleUsages) {
+  auto input = mod_.createVariable(ElemKind::FloatTy, {4}, "input",
+                      VisibilityKind::Private);
+  input->getPayload() = {10, 10 , 10, 10};
+  auto qType = mod_.uniqueType(ElemKind::Int8QTy, {4}, 2, 0);
+
+  auto Q = F_->createQuantize("quantize", input, qType);
+  F_->createSave("save", Q);
+  auto clonedF = F_->clone("cloned");
+
+  EXPECT_EQ(2, clonedF->getNodes().size());
+  ::glow::optimize(clonedF, CompilationMode::Infer);
+  // F_ function should not be affected.
+  EXPECT_EQ(2, F_->getNodes().size());
+
+  // Check original var.
+  for(unsigned i = 0; i < 4; ++i) {
+    EXPECT_EQ(10, input->getHandle().raw(i));
+  }
+ 
+  // Quantization node was merged into input var.
+  EXPECT_EQ(1, clonedF->getNodes().size());
+  auto quantizedInput = llvm::cast<Variable>(clonedF->getNodes().front().getNthInput(0));
+  auto quantizedValues = quantizedInput->getHandle<int8_t>();
+  for(unsigned i = 0; i < 4; ++i) {
+    EXPECT_EQ(5, quantizedValues.raw(i));
+  }
+}
+
 TEST_F(GraphOptz, quantizeToRescale) {
   // Check that we are combining quantization-dequantization pairs.
   Node *input = mod_.createVariable(ElemKind::Int8QTy, {4, 10}, 0.5, 11,


### PR DESCRIPTION
It appears that tests for the folding were missing :).
Added the base one + multiple usages.