### PR TITLE
Make sure that use-lists of Nodes only contain uses by other Nodes

### DIFF
--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -28,7 +28,7 @@
 
 namespace glow {
 
-class Variable final : public Node {
+class Variable: public Node {
 public:
   /// Specifies the kind of training and initialization for the variable.
   /// Nodes that are marked as 'none' are not modified during the training
@@ -102,7 +102,7 @@ public:
 
   unsigned getNumInputs() const;
   llvm::StringRef getInputName(unsigned idx) const;
-  NodeValue &getNthInput(unsigned idx);
+  NodeValue getNthInput(unsigned idx);
   llvm::StringRef getOutputName(unsigned idx) const;
   bool hasSideEffects() const;
   std::string getDebugDesc() const;
@@ -116,7 +116,8 @@ public:
   llvm::hash_code getHash() const;
 };
 
-using VariableNode = Variable;
+class VariableNode: public Variable {
+};
 
 /// Calculate the size of the output tensor based on the convolution parameters.
 inline std::pair<size_t, size_t>
@@ -156,6 +157,7 @@ llvm::hash_code hash_value(const glow::Type *T);
 llvm::hash_code hash_value(glow::Node *T);
 
 llvm::hash_code hash_value(const glow::NodeValue &T);
+llvm::hash_code hash_value(const glow::PrivateNodeTypes::NodeValueHandle &T);
 
 } // namespace glow
 

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1788,7 +1788,7 @@ Function *Function::clone(llvm::StringRef newName,
   for (auto &N : newF->getNodes()) {
     // Fix each one of the inputs of this node.
     for (unsigned inp = 0, e = N.getNumInputs(); inp < e; inp++) {
-      NodeValue &input = N.getNthInput(inp);
+      auto input = N.getNthInput(inp);
 
       auto it = currToNew.find(input.getNode());
       if (it == currToNew.end()) {
@@ -1798,7 +1798,7 @@ Function *Function::clone(llvm::StringRef newName,
       }
 
       // Update the node with the edge to the current graph.
-      input.setOperand(it->second, input.getResNo());
+      N.setNthInput(inp, NodeValue(it->second, input.getResNo()));
     }
   }
 

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -113,7 +113,7 @@ llvm::StringRef Variable::getInputName(unsigned idx) const {
   llvm_unreachable("Invalid index");
 }
 
-NodeValue &Variable::getNthInput(unsigned idx) {
+NodeValue Variable::getNthInput(unsigned idx) {
   llvm_unreachable("Invalid index");
 }
 
@@ -709,6 +709,10 @@ llvm::hash_code hash_value(const glow::Type *T) {
 llvm::hash_code hash_value(glow::Node *N) { return N->getHash(); }
 
 llvm::hash_code hash_value(const glow::NodeValue &NV) {
+  return llvm::hash_combine(NV.getNode(), NV.getResNo());
+}
+
+llvm::hash_code hash_value(const glow::PrivateNodeTypes::NodeValueHandle &NV) {
   return llvm::hash_combine(NV.getNode(), NV.getResNo());
 }
 } // namespace glow

--- a/lib/IR/IRGen.cpp
+++ b/lib/IR/IRGen.cpp
@@ -38,7 +38,7 @@ using llvm::isa;
 
 /// Helper function that \returns the number of times the same consecutive
 /// NodeValue in \p inputs is found, starting from index \p i.
-static size_t getConsecutiveSameNodeCount(llvm::ArrayRef<NodeValue> inputs,
+static size_t getConsecutiveSameNodeCount(NodeValueArrayRef inputs,
                                           const size_t i) {
   assert(i < inputs.size() && "Index must fit inside the size of the inputs.");
   for (size_t j = i, e = inputs.size(); j < e; j++) {

--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -865,7 +865,7 @@ static NodeValue simplifyConcatNode(Function *F, ConcatNode *CN) {
     // Check if any of the inputs are ConcatNode.
     llvm::SmallVector<NodeValue, 16> newInputs;
     bool merged = false;
-    for (auto input : inputs) {
+    for (auto &input : inputs) {
       newInputs.push_back(input);
       auto *CNI = dyn_cast<ConcatNode>(input);
       // Bail if it is not a ConcatNode or it is a concat node with a diffrent
@@ -1081,7 +1081,7 @@ static void optimizeReshape(Function *F) {
     auto *reshapeNode = dyn_cast<ReshapeNode>(&node);
     if (!reshapeNode)
       continue;
-    auto &inputNode = reshapeNode->getNthInput(0);
+    auto inputNode = reshapeNode->getNthInput(0);
     // Eliminate ReshapeNode when the input is already the correct shape.
     if (inputNode.dims() == reshapeNode->dims()) {
       reshapeNode->getResult().replaceAllUsesOfWith(inputNode);

--- a/lib/Optimizer/Lower.cpp
+++ b/lib/Optimizer/Lower.cpp
@@ -377,10 +377,10 @@ void computeBatchNormalizationWeights(Function *F, BatchNormalizationNode &BN) {
         llvm::isa<BatchNormalizationGradNode>(N))
       for (size_t i = 0; i < N.getNumInputs(); i++) {
         if (N.getNthInput(i) == mean) {
-          N.getNthInput(i) = newMean;
+          N.setNthInput(i, NodeValue(newMean));
         }
         if (N.getNthInput(i) == var) {
-          N.getNthInput(i) = newVar;
+          N.setNthInput(i, NodeValue(newVar));
         }
       }
 

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -240,7 +240,7 @@ quantizeInputs(Function *F, Node *node,
   llvm::SmallVector<NodeValue, 6> quantizedInputs;
 
   for (unsigned i = 0, e = node->getNumInputs(); i < e; ++i) {
-    NodeValue &NV = node->getNthInput(i);
+    auto NV = node->getNthInput(i);
 
     // Do not quantize non floating point type, e.g., Index type.
     if (NV.getElementType() != ElemKind::FloatTy) {

--- a/tests/unittests/graphTest.cpp
+++ b/tests/unittests/graphTest.cpp
@@ -61,6 +61,23 @@ TEST(Graph, simpleTestConv) {
   EXPECT_GT(M.getInstrs().size(), 0);
 }
 
+TEST(Graph, useList) {
+  Module MD;
+  Function *F = MD.createFunction("F");
+  IRFunction M(F);
+  Node *K = MD.createVariable(ElemKind::FloatTy, {4, 320, 200, 3}, "input");
+
+  EXPECT_EQ(K->getNumUsers(), 0);
+
+  ConvolutionNode *conv = F->createConv("Conv1", K, 16, 3, 2, 3, 1);
+
+  EXPECT_TRUE(K->hasOneUse());
+  EXPECT_EQ(K->getNumUsers(), 1);
+  EXPECT_EQ(conv->getNumUsers(), 0);
+  EXPECT_TRUE(conv->getFilter()->hasOneUse());
+  EXPECT_EQ(conv->getFilter()->getNumUsers(), 1);
+}
+
 TEST(Graph, simpleTestFC) {
   unsigned numInputs = 10;
   Module MD;

--- a/tools/ClassGen/MemberType.h
+++ b/tools/ClassGen/MemberType.h
@@ -41,13 +41,28 @@ inline const char *getReturnTypename(MemberType type) {
                                "llvm::ArrayRef<float>",
                                "llvm::ArrayRef<unsigned>",
                                "llvm::ArrayRef<size_t>",
-                               "llvm::ArrayRef<NodeValue>",
+                               "NodeValueArrayRef",
                                nullptr};
   return returnTypes[(int)type];
 }
 
 inline const char *getStorageTypename(MemberType type) {
-  const char *storageTypes[] = {"TypeRef",
+  const char *storageTypes[] = {
+      "TypeRef",
+      "float",
+      "unsigned",
+      "size_t",
+      "std::string",
+      "std::vector<float>",
+      "std::vector<unsigned>",
+      "std::vector<size_t>",
+      "std::vector<PrivateNodeTypes::NodeValueHandle>",
+      nullptr};
+  return storageTypes[(int)type];
+}
+
+inline const char *getCtorArgTypename(MemberType type) {
+  const char *ctorArgTypes[] = {"TypeRef",
                                 "float",
                                 "unsigned",
                                 "size_t",
@@ -57,7 +72,7 @@ inline const char *getStorageTypename(MemberType type) {
                                 "std::vector<size_t>",
                                 "std::vector<NodeValue>",
                                 nullptr};
-  return storageTypes[(int)type];
+  return ctorArgTypes[(int)type];
 }
 
 #endif // GLOW_TOOLS_CLASSGEN_MEMBERTYPE_H

--- a/tools/ClassGen/NodeBuilder.cpp
+++ b/tools/ClassGen/NodeBuilder.cpp
@@ -48,7 +48,7 @@ void NodeBuilder::emitCtor(std::ostream &os) const {
 
   // Extra class members:
   for (const auto &op : members_) {
-    os << ", " << getStorageTypename(op.first) << " " << op.second;
+    os << ", " << getCtorArgTypename(op.first) << " " << op.second;
   }
 
   // Initialize the base clases:
@@ -66,7 +66,13 @@ void NodeBuilder::emitCtor(std::ostream &os) const {
 
   // Initialize the members:
   for (const auto &op : members_) {
-    os << ", " << op.second << "_(" << op.second << ")";
+    if (op.first != MemberType::VectorNodeValue) {
+      os << ", " << op.second << "_(" << op.second << ")";
+      continue;
+    }
+    os << ", " << op.second << "_(" << op.second << ".begin(), " << op.second
+       << ".end()"
+       << ")";
   }
 
   // The constructor body:
@@ -93,7 +99,7 @@ void NodeBuilder::emitClassMembers(std::ostream &os) const {
     os << "  Mode mode_;\n";
   }
   for (const auto &op : nodeInputs_) {
-    os << "  NodeValue " << op << "_;\n";
+    os << "  PrivateNodeTypes::NodeValueHandle " << op << "_;\n";
   }
   for (const auto &op : members_) {
     os << "  " << getStorageTypename(op.first) << " " << op.second << "_;\n";
@@ -111,8 +117,8 @@ void NodeBuilder::emitMemberGetter(std::ostream &os, MemberType type,
 void NodeBuilder::emitSettersGetters(std::ostream &os) const {
   // Print the getters/setters.
   for (const auto &inName : nodeInputs_) {
-    os << "  NodeValue get" << inName << "() const { return " << inName
-       << "_; }\n";
+    os << "  const NodeValue get" << inName << "() const { return "
+       << inName << "_; }\n";
   }
 
   unsigned idx = 0;
@@ -173,7 +179,7 @@ void NodeBuilder::emitEdges(std::ostream &os) const {
   }
   os << "  llvm_unreachable(\"Invalid index\");\n}\n";
 
-  os << "\nNodeValue &" << name_ << "Node::getNthInput(unsigned idx) {\n";
+  os << "\nNodeValue " << name_ << "Node::getNthInput(unsigned idx) {\n";
   for (size_t i = 0; i < nodeInputs_.size(); i++) {
     os << "  if (idx == " << i << ") { return " << nodeInputs_[i] << "_; }\n";
   }
@@ -184,6 +190,22 @@ void NodeBuilder::emitEdges(std::ostream &os) const {
     }
     os << "  if (idx < " << op.second << "_.size()) { return " << op.second
        << "_[idx]; }\n  idx -= " << op.second << "_.size();\n";
+  }
+  os << "  llvm_unreachable(\"Invalid index\");\n}\n";
+
+  os << "\nvoid " << name_
+     << "Node::setNthInput(unsigned idx, NodeValue val) {\n";
+  for (size_t i = 0; i < nodeInputs_.size(); i++) {
+    os << "  if (idx == " << i << ") { " << nodeInputs_[i]
+       << "_ = val; return; }\n";
+  }
+  os << "  idx -= " << nodeInputs_.size() << ";\n";
+  for (const auto &op : members_) {
+    if (op.first != MemberType::VectorNodeValue) {
+      continue;
+    }
+    os << "  if (idx < " << op.second << "_.size()) { " << op.second
+       << "_[idx] = val; return; }\n  idx -= " << op.second << "_.size();\n";
   }
   os << "  llvm_unreachable(\"Invalid index\");\n}\n";
 
@@ -381,7 +403,8 @@ void NodeBuilder::emitNodeClass(std::ostream &os) const {
 
   os << "  unsigned getNumInputs() const;\n"
      << "  llvm::StringRef getInputName(unsigned idx) const;\n"
-     << "  NodeValue &getNthInput(unsigned idx);\n"
+     << "  NodeValue getNthInput(unsigned idx);\n"
+     << "  void setNthInput(unsigned idx, NodeValue val);\n"
      << "  llvm::StringRef getOutputName(unsigned idx) const;\n"
      << "  bool hasSideEffects() const { return " << hasSideEffects_ << "; }\n"
      << "  std::string getDebugDesc() const;\n"


### PR DESCRIPTION
Until now, NodeValue was used to refer to the results of Nodes. But unfortunately, every NodeValue would add itself to the use-list of a Node it references, which is rather expensive. In many cases, NodeValue objects are created as temporary objects and it makes no sense to consider them to be uses. Moreover, having these extra uses in the use-list prevents some optimizations, etc.

We want to count only references from Nodes to the results of other Nodes as uses. To achieve that this commit introduces a new type NodeValueHandle. It is used instead of NodeValue inside Nodes to refer to the results of other nodes. All NodeValueHandles add themselves as uses to the use lists. And the former NodeValue is changed in such a way that it does not register itself in the use-lists anymore.

To ensure that NodeValueHandle cannot be used in the code outside of Node and its derived classes some kind of a type system  based access control is introduced by means of introducing a "namespace" PrivateNodeTypes, whose members can be accessed only by Node and its derived classes.