### PR TITLE
[backends] Break cyclic dependence between Backends and Interpreter

### DIFF
--- a/include/glow/Backends/Backend.h
+++ b/include/glow/Backends/Backend.h
@@ -50,7 +50,9 @@ public:
   virtual void init() = 0;
 
   /// Save the bundle for a later standalone execution.
-  virtual void save(llvm::StringRef outputDir);
+  virtual void save(llvm::StringRef outputDir) {
+    GLOW_UNREACHABLE("Saving a bundle is not supported by the backend");
+  }
 
   /// Perform a single forward scan of the network, interpreting all of the
   /// instructions.

--- a/lib/Backends/Backends.cpp
+++ b/lib/Backends/Backends.cpp
@@ -63,7 +63,3 @@ Backend *glow::createBackend(BackendKind backendKind, IRFunction *F) {
   // always covers all possible values.
   llvm_unreachable("unreachable");
 }
-
-void Backend::save(llvm::StringRef outputDir) {
-  GLOW_UNREACHABLE("Saving a bundle is not supported by the backend");
-}


### PR DESCRIPTION
libBackends depends on the specific backends for the `create*()` functions, so we should make the backend implementations independent of libBackends.  Before this change, libInterpreter needed the implementation of `save()` from Backends.cpp to compile; now it doesn't.

The current setup happens to work because (a) there's a dependency cycle that forces libBackends to build anyways, and (b) a dependency cycle is OK because we build static libs by default.