### PR TITLE
[importer] Use Variable through Load node

### DIFF
--- a/include/glow/Importer/ProtobufLoader.h
+++ b/include/glow/Importer/ProtobufLoader.h
@@ -101,9 +101,9 @@ protected:
   /// \returns the tensor that was registered under the name \p name.
   Tensor *getTensorByName(llvm::StringRef name);
 
-  /// Create a new variable \p name initialized with \p tensor.
-  /// The created variable is also registered under \p name.
-  /// \returns the newly created variable.
+  /// Create a new variable \p name initialized with \p tensor and load it.
+  /// The load is also registered under \p name.
+  /// \returns A load to the newly created variable.
   /// \pre !hasNodeByName(name)
   Node *createAndRememberVariable(
       llvm::StringRef name, Tensor &tensor,
@@ -120,8 +120,16 @@ public:
   Node *getNodeByName(llvm::StringRef name) const;
 
   /// \returns the node that was registered with the name \p name or create a
-  /// new Variable node for a tensor with this name.
+  /// new Variable node for a tensor with this name and load it.
+  /// In case a new variable is returned, this method registers
+  /// the returned load node, not the variable itself.
+  /// Only save and load node are allowed to use variable directly.
   Node *getOrCreateVariableByName(llvm::StringRef name);
+
+  /// \returns The variable referenced by the load registered
+  /// under \p name.
+  /// \pre isa<LoadNode>(getNodeByName(name))
+  Variable *getVariableByName(llvm::StringRef name) const;
 
   /// Create a new variable \p name initialized with \p tensor.
   /// \returns the newly created variable.

--- a/tools/loader/ImageClassifier.cpp
+++ b/tools/loader/ImageClassifier.cpp
@@ -140,15 +140,15 @@ int main(int argc, char **argv) {
         {"data", "gpu_0/data", "softmax_expected"},
         {&data, &data, &expectedSoftmax}, *loader.getFunction());
     SM = LD.getRoot();
-    i0 = llvm::cast<Variable>(LD.getOrCreateVariableByName("gpu_0/data"));
-    i1 = llvm::cast<Variable>(LD.getOrCreateVariableByName("data"));
+    i0 = LD.getVariableByName("gpu_0/data");
+    i1 = LD.getVariableByName("data");
   } else {
     ONNXModelLoader LD(loader.getOnnxModelFilename(),
                        {"data_0", "gpu_0/data_0", "softmax_expected"},
                        {&data, &data, &expectedSoftmax}, *loader.getFunction());
     SM = LD.getRoot();
-    i0 = llvm::cast<Variable>(LD.getOrCreateVariableByName("gpu_0/data_0"));
-    i1 = llvm::cast<Variable>(LD.getOrCreateVariableByName("data_0"));
+    i0 = LD.getVariableByName("gpu_0/data_0");
+    i1 = LD.getVariableByName("data_0");
   }
 
   assert(i0->getVisibilityKind() == VisibilityKind::Public);


### PR DESCRIPTION
This patch wires the load node in the importer.
This is one step closer for making the load and save nodes the
only users of Variable.