### PR TITLE
[opencl] Create shader program text with xxd

### DIFF
--- a/lib/Backends/OpenCL/CMakeLists.txt
+++ b/lib/Backends/OpenCL/CMakeLists.txt
@@ -1,4 +1,17 @@
+set(KERNELS_HDR ${GLOW_BINARY_DIR}/kernels_cl.h)
+set(KERNELS_FWD_CONV_HDR ${GLOW_BINARY_DIR}/kernels_fwd_conv_cl.h)
+
+add_custom_command(
+        OUTPUT "${KERNELS_HDR}"
+        COMMAND xxd -i < ${CMAKE_CURRENT_SOURCE_DIR}/kernels.cl > ${KERNELS_HDR})
+
+add_custom_command(
+        OUTPUT "${KERNELS_FWD_CONV_HDR}"
+        COMMAND xxd -i < ${CMAKE_CURRENT_SOURCE_DIR}/kernels_fwd_conv.cl > ${KERNELS_FWD_CONV_HDR})
+
 add_library(OpenCL
+            ${KERNELS_HDR}
+            ${KERNELS_FWD_CONV_HDR}
             OpenCL.cpp
             Transforms.cpp)
 

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -39,10 +39,17 @@ using llvm::isa;
 
 typedef uint32_t cl_size_t;
 
-// This defines the string "SHADER_CODE".
-#include "kernels.cl"
+// This defines the OpenCL kernels.
+const char kernels_cl[] = {
+#include "kernels_cl.h"
+  , 0x00
+};
+
 // This defines kernels for optimized convolutions.
-#include "kernels_fwd_conv.cl"
+const char kernels_fwd_conv_cl[] = {
+#include "kernels_fwd_conv_cl.h"
+  , 0x00
+};
 
 namespace {
 llvm::cl::OptionCategory OpenCLBackendCat("Glow OpenCL Backend Options");
@@ -102,7 +109,7 @@ OCLBackend::OCLBackend(IRFunction *F) : F_(F), allocator_(0xFFFFFFFF) {
 
   err = CL_SUCCESS;
   /// Create the program from the source.
-  createProgram(SHADER_CODE, {}, commands_);
+  createProgram(&kernels_cl[0], {}, commands_);
 }
 
 OCLBackend::~OCLBackend() {
@@ -439,7 +446,7 @@ void OCLBackend::executeConvolution(const OCLConvolutionInst *CC) {
 
   // Generate a tailor-made convolution kernel using the provided options based
   // on the parameters of the current convolution.
-  auto prog = createProgram(FWD_CONV_CODE, options, commands_);
+  auto prog = createProgram(&kernels_fwd_conv_cl[0], options, commands_);
   auto kernel = createKernel("conv_forward_mem", prog);
   setKernelArg(kernel, 0, deviceBuffer_);
   setKernelArg<cl_uint>(kernel, 1, tensors_[input]);

--- a/lib/Backends/OpenCL/kernels.cl
+++ b/lib/Backends/OpenCL/kernels.cl
@@ -1,6 +1,3 @@
-
-static const char* SHADER_CODE = R"(
-
 /// This type is always 32 bits.
 typedef unsigned cl_uint32_t;
 /// This type is always 64 bits.
@@ -1072,5 +1069,3 @@ __kernel void scatterassignW(__global void *mem,
                       cl_uint32_t sliceSize) {
    scatterassignK(&mem[data], &mem[indices], &mem[slices], sliceSize);
 }
-
-)";

--- a/lib/Backends/OpenCL/kernels_fwd_conv.cl
+++ b/lib/Backends/OpenCL/kernels_fwd_conv.cl
@@ -28,7 +28,6 @@
 // VWN - vector width in dimension N.
 // VWM - vector width in dimension M.
 
-static const char* FWD_CONV_CODE = R"(
 #define Dtype float
 #define Dtype1 float
 #define Dtype2 float2
@@ -319,4 +318,3 @@ conv_forward_mem(__global void *mem, unsigned im_in_offset, unsigned wg_offset,
     }
   }
 }
-)";


### PR DESCRIPTION
While I like the R("...") string trick, it's often bugged me that I don't get syntax highlighting in these .cl files since it's just one big string.  Importing the string using `xxd -i` solves that issue, albeit at the cost of a very slightly weirder implementation.  WDYT?