### PR TITLE
Unbreak/cleanup fr2en 

### DIFF
--- a/examples/fr2en.cpp
+++ b/examples/fr2en.cpp
@@ -343,9 +343,10 @@ void Model::loadDecoder() {
     hidden = createPyTorchGRUCell(F_, relu, hidden, w_ih, b_ih, w_hh, b_hh);
 
     Node *FC = F_->createFullyConnected("decoder.outFC", hidden, out_w, out_b);
-    Node *topK = F_->createTopK("decoder.topK", FC, 1);
+    auto *topK = F_->createTopK("decoder.topK", FC, 1);
 
-    lastWordIdx = F_->createReshape("decoder.reshape", {topK, 1}, {batchSize_});
+    lastWordIdx =
+        F_->createReshape("decoder.reshape", topK->getIndices(), {batchSize_});
     outputs.push_back(lastWordIdx);
   }
 

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -654,12 +654,12 @@ ConcatNode *Function::createConcat(llvm::StringRef name,
                                    llvm::ArrayRef<NodeValue> inputs,
                                    unsigned dimension) {
   for (int i = 1, e = inputs.size(); i < e; i++) {
-    assert(sameSameShapeExceptDim(inputs[i]->getType(), inputs[0]->getType(),
+    assert(sameSameShapeExceptDim(inputs[i].getType(), inputs[0].getType(),
                                   dimension) &&
            "Invalid type");
     (void)sameSameShapeExceptDim;
   }
-  auto inDim = inputs[0]->dims();
+  auto inDim = inputs[0].dims();
 
   ShapeVector shape(inDim.begin(), inDim.end());
 
@@ -667,10 +667,10 @@ ConcatNode *Function::createConcat(llvm::StringRef name,
   // increase the size of the tensor along this dimension.
   shape[dimension] = 0;
   for (auto I : inputs) {
-    shape[dimension] += I->getType()->dims()[dimension];
+    shape[dimension] += I.getType()->dims()[dimension];
   }
 
-  auto NT = getParent()->uniqueTypeWithNewShape(inputs[0]->getType(), shape);
+  auto NT = getParent()->uniqueTypeWithNewShape(inputs[0].getType(), shape);
   std::vector<NodeValue> ops;
   ops.reserve(inputs.size());
   for (auto I : inputs) {

--- a/tools/ClassGen/NodeBuilder.cpp
+++ b/tools/ClassGen/NodeBuilder.cpp
@@ -233,7 +233,7 @@ void NodeBuilder::emitPrettyPrinter(std::ostream &os) const {
     os << "  unsigned mIndex = 0;\n";
     os << "  for (auto II : get" << mem.second << "()) {\n"
        << "    db.addParam(\"" << mem.second
-       << "\"+std::to_string(mIndex++), *II->getType());\n"
+       << "\"+std::to_string(mIndex++), *II.getType());\n"
        << "  }\n";
   }
 


### PR DESCRIPTION
Some places used the Node instead of NodeValue to get the type and dims. This issue was uncovered due the opti recently landed by @ZchiPitt , as the inputs were previously Reshapes but are now TopKs. Also small cleanup to use `getIndices()` directly instead of the implicit NodeValue via `{topk, 1}`.