### PR TITLE
[backends][nfc] Remove Backend::clear()

### DIFF
--- a/include/glow/Backends/Backend.h
+++ b/include/glow/Backends/Backend.h
@@ -43,9 +43,6 @@ public:
   /// Dtor.
   virtual ~Backend() = default;
 
-  /// Wipe out the state of the backend.
-  virtual void clear() = 0;
-
   /// Prepare the interpreter for execution of new code.
   virtual void init() = 0;
 

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -48,11 +48,9 @@ CPUBackend::CPUBackend(IRFunction *F)
     : F_(F), irgen_(F_, allocationsInfo_, "") {}
 
 CPUBackend::~CPUBackend() {
-  clear();
+  F_->clear();
   alignedFree(heap_);
 }
-
-void CPUBackend::clear() { F_->clear(); }
 
 //===----------------------------------------------------------------------===//
 //                   Functions for executing code using JIT

--- a/lib/Backends/CPU/CPUBackend.h
+++ b/lib/Backends/CPU/CPUBackend.h
@@ -83,8 +83,6 @@ public:
   ///@{
   ~CPUBackend() override;
 
-  void clear() override;
-
   void init() override;
 
   void save(llvm::StringRef outputDir) override;

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -26,14 +26,11 @@
 using namespace glow;
 using llvm::isa;
 
-Interpreter::~Interpreter() { clear(); }
-
-void Interpreter::clear() {
+Interpreter::~Interpreter() {
   // Delete the tensors that are owned by this backend.
   for (auto p : tensors_) {
     delete p.second;
   }
-
   tensors_.clear();
   externalTensors_.clear();
 }

--- a/lib/Backends/Interpreter/Interpreter.h
+++ b/lib/Backends/Interpreter/Interpreter.h
@@ -57,8 +57,6 @@ public:
   ///@{
   ~Interpreter() override;
 
-  void clear() override;
-
   void init() override;
 
   void doForwardPass() override;

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -116,7 +116,7 @@ OCLBackend::~OCLBackend() {
     freeDeviceBuffer(deviceBuffer_);
     deviceBuffer_ = nullptr;
   }
-  clear();
+  externalTensors_.clear();
 }
 
 static std::string getKernelName(const char *baseName, ElemKind elemTy) {
@@ -1233,8 +1233,6 @@ void OCLBackend::init() {
   // Copy constant weights just once.
   copyConstantWeightsToDevice();
 }
-
-void OCLBackend::clear() { externalTensors_.clear(); }
 
 Tensor *OCLBackend::getTensor(const Value *v) const {
   assert(externalTensors_.count(v) && "Unknown value");

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -99,8 +99,6 @@ public:
   ///@{
   ~OCLBackend() override;
 
-  void clear() override;
-
   void init() override;
 
   void doForwardPass() override;

--- a/tests/unittests/BackendCorrectnessTest.cpp
+++ b/tests/unittests/BackendCorrectnessTest.cpp
@@ -240,7 +240,6 @@ public:
   MockCPUBackend(IRFunction *M) {
     backend_.reset(createBackend(BackendKind::CPU, M));
   }
-  void clear() override { backend_->clear(); }
   void init() override { backend_->init(); }
   void doForwardPass() override { backend_->doForwardPass(); }
   bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override {

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -22,7 +22,6 @@ namespace glow {
 
 /// MockBackend used only for unit testing.
 class MockBackend : public Backend {
-  void clear() override {}
   void init() override {}
   void doForwardPass() override {}
   bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override {


### PR DESCRIPTION
`Backend::clear` isn't called anywhere except the various destructors, so I think we should just fold it in to those.  It's existence makes me a bit uncomfortable anyways, since it seems like an invitation to leave unexpected state lingering around