### PR TITLE
[ir] Give instruction unique names eagerly

### DIFF
--- a/include/glow/IR/IRBuilder.h
+++ b/include/glow/IR/IRBuilder.h
@@ -32,6 +32,12 @@ class IRBuilder {
   /// The function that we are building.
   IRFunction *F_;
 
+  /// \returns a unique legal name that's based on the string \p name.  Legal
+  /// names are legal C identifiers in the form: "[a-zA-Z_][a-zA-Z0-9_]*".
+  llvm::StringRef uniqueName(llvm::StringRef name) {
+    return F_->uniqueName(name);
+  }
+
 public:
   explicit IRBuilder(IRFunction *F) : F_(F) {}
 

--- a/lib/Backends/CPU/DebugInfo.cpp
+++ b/lib/Backends/CPU/DebugInfo.cpp
@@ -229,7 +229,6 @@ void LLVMIRGen::initDebugInfo() {
 #endif
     return;
   }
-  F_->nameInstructions();
   // Remove any existing debug info version flags from the module to
   // avoid possible conflicts, which may happen if libjit was compiled
   // using an older version of Clang which uses the old debug info format.

--- a/lib/IR/IR.cpp
+++ b/lib/IR/IR.cpp
@@ -470,17 +470,6 @@ void Instruction::dumpOperands(llvm::raw_ostream &os) const {
   }
 }
 
-void IRFunction::nameInstruction(Named *named, llvm::StringRef suggestion,
-                                 llvm::StringSet<> &stringTable) {
-  // Use the first few letters of the value as the initial name.
-  if (!named->hasName()) {
-    named->setName(suggestion.slice(0, 4));
-  }
-
-  std::string tempName = Module::uniqueName(named->getName(), stringTable);
-  named->setName(tempName);
-}
-
 IRFunction::IRFunction(Function *G) : G_(G) {}
 
 static bool hasResultValue(const Instruction *I) {
@@ -488,22 +477,9 @@ static bool hasResultValue(const Instruction *I) {
          I->getKind() == Instruction::Kind::TensorViewInstKind;
 }
 
-void IRFunction::nameInstructions() {
-  /// Stores a list of unique instruction names that were used by the IRFunction
-  /// at some point.
-  llvm::StringSet<> uniqueNames;
-  for (auto &v : weights_) {
-    nameInstruction(v, v->getKindName(), uniqueNames);
-  }
-  for (auto &I : instrs_) {
-    nameInstruction(&I, I.getKindName(), uniqueNames);
-  }
-}
-
 void IRFunction::dump() { dump(llvm::outs()); }
 
 void IRFunction::dump(llvm::raw_ostream &OS) {
-  nameInstructions();
   InstructionNumbering InstrNumbering(*this);
   // Print all of the variables:
   std::string s;

--- a/lib/IR/IRBuilder.cpp
+++ b/lib/IR/IRBuilder.cpp
@@ -173,7 +173,7 @@ WeightVar *IRBuilder::createWeightVar(TypeRef T, llvm::StringRef name,
   assert(!(m == WeightVar::MutabilityKind::Constant &&
            v == VisibilityKind::Public) &&
          "Cannot have a Constant Public Variable.");
-  auto *A = new WeightVar(name, T, m, v);
+  auto *A = new WeightVar(uniqueName(name), T, m, v);
   F_->getWeights().push_back(A);
   A->setName(name);
   return A;

--- a/tools/ClassGen/InstrBuilder.cpp
+++ b/tools/ClassGen/InstrBuilder.cpp
@@ -84,7 +84,7 @@ void InstrBuilder::emitIRBuilderMethods(std::ostream &osH,
 
   // Initialize the base clases:
   osB << ") {\n";
-  osB << "  auto *A = new " << name_ << "Inst(name ";
+  osB << "  auto *A = new " << name_ << "Inst(uniqueName(name)";
 
   // The operands of the instruction class:
   for (const auto &op : operands_) {


### PR DESCRIPTION
Currently we do this only when outputting the IR for human consumption (dump ir, emit debug info).  But this means we're mutating the state of the world before outputting it, which can be weird for debugging; and it prevents us from using `const IRFunction *` in surprising places.
