### PR TITLE
Make IRFunction const in backends

### DIFF
--- a/include/glow/IR/IR.h
+++ b/include/glow/IR/IR.h
@@ -352,6 +352,9 @@ public:
   /// \returns the list of weights.
   WeightVarListTy &getWeights() { return weights_; }
 
+  /// \returns the list of weights.
+  const WeightVarListTy &getWeights() const { return weights_; }
+
   /// Erase the instruction from the function.
   void eraseInstruction(Instruction *I);
 

--- a/include/glow/IR/IR.h
+++ b/include/glow/IR/IR.h
@@ -302,6 +302,9 @@ public:
   Function *getGraph() { return G_; }
 
   /// \returns a reference to the high-level graph.
+  const Function *getGraph() const { return G_; }
+
+  /// Sets the high-level graph corresponding to this function.
   void setGraph(Function *F) { G_ = F; }
 
   /// \returns a unique legal name that's based on the string \p name.  Legal
@@ -314,19 +317,19 @@ public:
   void verify() const;
 
   /// Dump a textual representation of the function.
-  void dump();
+  void dump() const;
 
   /// Dump a textual representation of the function into provided output stream.
-  void dump(llvm::raw_ostream &OS);
+  void dump(llvm::raw_ostream &OS) const;
 
   /// Dump a dotty graph that depicts the function.
-  void dumpDAG(llvm::StringRef dotFilename);
+  void dumpDAG(llvm::StringRef dotFilename) const;
 
   /// Dump a dotty graph that depicts the function.
-  void dumpDAG(const char *dotFilename);
+  void dumpDAG(const char *dotFilename) const;
 
   /// Dump a dotty graph that depicts the function.
-  void dumpDAG();
+  void dumpDAG() const;
 
   /// \returns the variable map.
   VariableMap &getVariableMap() { return variableMap_; }

--- a/lib/Backends/CPU/AllocationsInfo.cpp
+++ b/lib/Backends/CPU/AllocationsInfo.cpp
@@ -34,7 +34,7 @@ using llvm::dyn_cast;
 using llvm::isa;
 using llvm::StringRef;
 
-void AllocationsInfo::allocateWeightVars(IRFunction *F, bool reuseAddresses) {
+void AllocationsInfo::allocateWeightVars(const IRFunction *F, bool reuseAddresses) {
   // Use two different allocators, because constant weights and mutable weights
   // may use different memory blocks.
   MemoryAllocator constantWeightVarsAllocator(0);
@@ -97,7 +97,7 @@ void AllocationsInfo::allocateWeightVars(IRFunction *F, bool reuseAddresses) {
   });
 }
 
-void AllocationsInfo::allocateActivations(IRFunction *F) {
+void AllocationsInfo::allocateActivations(const IRFunction *F) {
   // Use a memory allocator with no upper bound on how much memory we can
   // allocate.
   MemoryAllocator activationsAllocator(0);
@@ -140,7 +140,7 @@ void AllocationsInfo::allocateActivations(IRFunction *F) {
   });
 }
 
-void AllocationsInfo::allocateTensorViews(IRFunction *F) {
+void AllocationsInfo::allocateTensorViews(const IRFunction *F) {
   for (const auto &I : F->getInstrs()) {
     if (const auto *A = dyn_cast<TensorViewInst>(&I)) {
       auto *viewOrigin = getOrigin(A);
@@ -166,7 +166,7 @@ void AllocationsInfo::allocateTensorViews(IRFunction *F) {
   }
 }
 
-void AllocationsInfo::numberValues(IRFunction *F) {
+void AllocationsInfo::numberValues(const IRFunction *F) {
   size_t valueIdx = 0;
   // Assign numbers to all weights.
   for (auto &v : F->getGraph()->getParent()->getVars()) {

--- a/lib/Backends/CPU/AllocationsInfo.h
+++ b/lib/Backends/CPU/AllocationsInfo.h
@@ -57,20 +57,20 @@ struct AllocationsInfo {
   /// by the payloads of tensors corresponding to those WeightVars as offsets.
   /// This is useful in a JIT setup. If \p reuseAddresses is false, then all the
   /// WeightVars will get new offsets assigned.
-  void allocateWeightVars(IRFunction *F, bool reuseAddresses);
+  void allocateWeightVars(const IRFunction *F, bool reuseAddresses);
   /// Assign offsets to all activations.
   /// No actual memory allocation is performed. All the allocations should be
   /// performed by the client based on the information provided by the
   /// AllocationsInfo.
-  void allocateActivations(IRFunction *F);
+  void allocateActivations(const IRFunction *F);
   /// Assign offsets to all tensorviews.
   /// No memory allocation is performed. Sets up all offsets into already
   /// defined offsets for WeightVars and AllocActivations. Assumes the weight
   /// vars and alloc activations have already been added to allocatedAddressed_.
-  void allocateTensorViews(IRFunction *F);
+  void allocateTensorViews(const IRFunction *F);
   /// Number all allocations and weight variables by assigning them unique
   /// numbers.
-  void numberValues(IRFunction *F);
+  void numberValues(const IRFunction *F);
   /// Reset the state of the allocation info.
   void clear();
 };

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -48,7 +48,6 @@ CPUBackend::CPUBackend(IRFunction *F)
     : F_(F), irgen_(F_, allocationsInfo_, "") {}
 
 CPUBackend::~CPUBackend() {
-  F_->clear();
   alignedFree(heap_);
 }
 

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -44,7 +44,7 @@ namespace glow {
 Backend *createCPUBackend(IRFunction *F) { return new CPUBackend(F); }
 } // namespace glow
 
-CPUBackend::CPUBackend(IRFunction *F)
+CPUBackend::CPUBackend(const IRFunction *F)
     : F_(F), irgen_(F_, allocationsInfo_, "") {}
 
 CPUBackend::~CPUBackend() {

--- a/lib/Backends/CPU/CPUBackend.h
+++ b/lib/Backends/CPU/CPUBackend.h
@@ -46,7 +46,7 @@ llvm::CallInst *createCall(llvm::IRBuilder<> &builder, llvm::Function *callee,
 
 class CPUBackend final : public Backend {
   /// The Module that holds the glow IR. This does not own the module.
-  IRFunction *F_;
+  const IRFunction *F_;
   /// Information about allocations.
   AllocationsInfo allocationsInfo_;
   /// The LLVM JIT engine. The jit must be initialized after the ctor
@@ -76,7 +76,7 @@ class CPUBackend final : public Backend {
 
 public:
   /// Ctor.
-  explicit CPUBackend(IRFunction *M);
+  explicit CPUBackend(const IRFunction *M);
 
   /// @name Backend methods.
   /// This is the implementation of the Backend interface.

--- a/lib/Backends/CPU/DebugInfo.cpp
+++ b/lib/Backends/CPU/DebugInfo.cpp
@@ -37,7 +37,7 @@ using llvm::StringRef;
 extern llvm::cl::opt<bool> emitDebugInfo;
 
 void LLVMIRGen::setCurrentDebugLocation(llvm::IRBuilder<> &builder,
-                                        glow::Instruction *I) {
+                                        const glow::Instruction *I) {
   if (!emitDebugInfo)
     return;
   auto instrNum = instrNumbering_->getInstrNumber(I);

--- a/lib/Backends/CPU/LLVMIRGen.h
+++ b/lib/Backends/CPU/LLVMIRGen.h
@@ -81,7 +81,7 @@ struct DebugInfo {
 /// from an IRFunction. The primary clients of this class are JITs and bundlers.
 class LLVMIRGen {
   /// The Module that holds the glow IR. This does not own the module.
-  IRFunction *F_;
+  const IRFunction *F_;
   /// The LLVM context.
   llvm::LLVMContext ctx_;
   /// The LLVM IR module.
@@ -156,13 +156,13 @@ class LLVMIRGen {
   /// Create a function representing a stacked kernel for instructions provided
   /// in \p stackedInstrs.
   void emitDataParallelKernel(llvm::IRBuilder<> &builder,
-                              llvm::ArrayRef<Instruction *> stackedInstrs);
+                              llvm::ArrayRef<const Instruction *> stackedInstrs);
   /// Emit IR for the data parallel instruction \p I which is invoked inside the
   /// stacked \p kernel. The current loop count is described by \p loopCount.
   /// The \p bufferToArgNum map can be used to find the required buffers, which
   /// are provided as arguments to the stacked \p kernel.
   void generateLLVMIRForDataParallelInstr(
-      llvm::IRBuilder<> &builder, glow::Instruction *I, llvm::Function *kernel,
+      llvm::IRBuilder<> &builder, const glow::Instruction *I, llvm::Function *kernel,
       llvm::DenseMap<Value *, int> &bufferToArgNum, llvm::Value *loopCount);
   /// \returns the llvm type of the glow vale \p val.
   llvm::Type *getElementType(llvm::IRBuilder<> &builder, const Value *val);
@@ -175,7 +175,7 @@ class LLVMIRGen {
   /// Set the debug location for the \p builder, so that it corresponds to the
   /// instruction \p I in the textual representation of the Glow IR.
   void setCurrentDebugLocation(llvm::IRBuilder<> &builder,
-                               glow::Instruction *I);
+                               const glow::Instruction *I);
   /// Get or create a debug information for a given LLVM function.
   llvm::DISubprogram *getOrCreateFunctionDebugInfo(llvm::Function *F,
                                                    llvm::DIScope *scope,
@@ -193,14 +193,14 @@ class LLVMIRGen {
 
 public:
   /// Ctor.
-  explicit LLVMIRGen(IRFunction *M, AllocationsInfo &allocationsInfo,
+  explicit LLVMIRGen(const IRFunction *M, AllocationsInfo &allocationsInfo,
                      std::string mainEntryName);
 
   /// Init the TargetMachine using a given target and code model.
   void initTargetMachine(llvm::StringRef T, llvm::CodeModel::Model CM);
 
   /// Emit LLVM-IR for the instruction \p I, using the builder \p builder.
-  void generateLLVMIRForInstr(llvm::IRBuilder<> &builder, glow::Instruction *I);
+  void generateLLVMIRForInstr(llvm::IRBuilder<> &builder, const glow::Instruction *I);
   /// Emit LLVM-IR for the whole IRFunction.
   void generateLLVMIRForModule(llvm::IRBuilder<> &builder);
   /// \returns a libjit API function by name.
@@ -241,7 +241,7 @@ public:
   /// \returns current LLVM module.
   llvm::Module &getModule() { return *llmodule_; }
   /// \returns the IR function.
-  IRFunction *getIRFunction() { return F_; }
+  const IRFunction *getIRFunction() { return F_; }
   /// Set output directory for bundles, debug info files, etc.
   void setOutputDir(llvm::StringRef outputDir) { outputDir_ = outputDir; }
   /// Get output directory for bundles, debug info files, etc.

--- a/lib/Backends/Interpreter/Interpreter.h
+++ b/lib/Backends/Interpreter/Interpreter.h
@@ -41,7 +41,7 @@ class Variable;
 /// execute the instructions one at a time.
 class Interpreter final : public Backend {
   /// The Module that holds the IR. This does not own the module.
-  IRFunction *F_;
+  const IRFunction *F_;
   /// Maps values to Tensors, that are owned by this class.
   std::unordered_map<const Value *, Tensor *> tensors_;
 
@@ -50,7 +50,7 @@ class Interpreter final : public Backend {
 
 public:
   /// Ctor.
-  explicit Interpreter(IRFunction *F) : F_(F) {}
+  explicit Interpreter(const IRFunction *F) : F_(F) {}
 
   /// @name Backend methods.
   /// This is the implementation of the Backend interface.

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -84,7 +84,7 @@ static void dumpCompileLog(cl_device_id dev, cl_program prog) {
 #endif
 }
 
-OCLBackend::OCLBackend(IRFunction *F) : F_(F), allocator_(0xFFFFFFFF) {
+OCLBackend::OCLBackend(const IRFunction *F) : F_(F), allocator_(0xFFFFFFFF) {
   cl_uint num{0};
   cl_int err = clGetDeviceIDs(nullptr, CL_DEVICE_TYPE_ALL, 0, nullptr, &num);
   GLOW_ASSERT(err == CL_SUCCESS && "clGetDeviceIDs Failed.");

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -66,7 +66,7 @@ class OCLBackend final : public Backend {
     }
   };
   /// The Module that holds the IR. This does not own the module.
-  IRFunction *F_;
+  const IRFunction *F_;
   /// The allocator assigns device memory addresses to the buffers.
   MemoryAllocator allocator_;
   /// Maps values to on-device buffers. This list includes both weights and
@@ -92,7 +92,7 @@ class OCLBackend final : public Backend {
 
 public:
   /// Ctor.
-  explicit OCLBackend(IRFunction *M);
+  explicit OCLBackend(const IRFunction *M);
 
   /// @name Backend methods.
   /// This is the implementation of the Backend interface.

--- a/lib/IR/IR.cpp
+++ b/lib/IR/IR.cpp
@@ -477,9 +477,9 @@ static bool hasResultValue(const Instruction *I) {
          I->getKind() == Instruction::Kind::TensorViewInstKind;
 }
 
-void IRFunction::dump() { dump(llvm::outs()); }
+void IRFunction::dump() const { dump(llvm::outs()); }
 
-void IRFunction::dump(llvm::raw_ostream &OS) {
+void IRFunction::dump(llvm::raw_ostream &OS) const {
   InstructionNumbering InstrNumbering(*this);
   // Print all of the variables:
   std::string s;
@@ -585,7 +585,7 @@ static const char *getDottyArrowForCC(OperandKind k) {
   llvm_unreachable("Invalid operand kind.");
 }
 
-void IRFunction::dumpDAG() {
+void IRFunction::dumpDAG() const {
   std::string buffer;
   llvm::raw_string_ostream stream(buffer);
   stream << "dotty_ir_dump_" << this << ".dot";
@@ -593,7 +593,7 @@ void IRFunction::dumpDAG() {
 }
 
 /// Dump a dotty graph that depicts the function.
-void IRFunction::dumpDAG(llvm::StringRef dotFilename) {
+void IRFunction::dumpDAG(llvm::StringRef dotFilename) const {
   llvm::outs() << "Writing dotty graph to: " << dotFilename << '\n';
 
   std::string buffer;
@@ -658,7 +658,7 @@ void IRFunction::dumpDAG(llvm::StringRef dotFilename) {
   filestream << stream.str();
 }
 
-void IRFunction::dumpDAG(const char *dotFilename) {
+void IRFunction::dumpDAG(const char *dotFilename) const {
   dumpDAG(llvm::StringRef(dotFilename));
 }
 


### PR DESCRIPTION
Backends should just look at the IR function, not mutate it.  Hopefully this will make future refactoring easier, too.

The only functionality change is that the CPU backend was `clear`ing the IR in its destructor.  That feels like a no-no since the IR is really owned by the EE.