### PR TITLE
[trivial] clang-format all the things

### DIFF
--- a/include/glow/Quantization/Base/Base.h
+++ b/include/glow/Quantization/Base/Base.h
@@ -17,10 +17,10 @@
 #ifndef GLOW_QUANTIZATION_BASE_BASE_H
 #define GLOW_QUANTIZATION_BASE_BASE_H
 
-#include <cstdlib>
-#include <cassert>
-#include <limits>
 #include <algorithm>
+#include <cassert>
+#include <cstdlib>
+#include <limits>
 
 namespace glow {
 

--- a/lib/Backends/CPU/AllocationsInfo.cpp
+++ b/lib/Backends/CPU/AllocationsInfo.cpp
@@ -32,9 +32,9 @@ using namespace glow;
 using llvm::cast;
 using llvm::dyn_cast;
 using llvm::isa;
-using llvm::StringRef;
 
-void AllocationsInfo::allocateWeightVars(const IRFunction *F, bool reuseAddresses) {
+void AllocationsInfo::allocateWeightVars(const IRFunction *F,
+                                         bool reuseAddresses) {
   // Use two different allocators, because constant weights and mutable weights
   // may use different memory blocks.
   MemoryAllocator constantWeightVarsAllocator(0);

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -36,7 +36,6 @@ using namespace glow;
 using llvm::cast;
 using llvm::dyn_cast;
 using llvm::isa;
-using llvm::StringRef;
 
 static llvm::cl::opt<std::string> target("target", llvm::cl::desc("target"));
 
@@ -47,9 +46,7 @@ Backend *createCPUBackend(IRFunction *F) { return new CPUBackend(F); }
 CPUBackend::CPUBackend(const IRFunction *F)
     : F_(F), irgen_(F_, allocationsInfo_, "") {}
 
-CPUBackend::~CPUBackend() {
-  alignedFree(heap_);
-}
+CPUBackend::~CPUBackend() { alignedFree(heap_); }
 
 //===----------------------------------------------------------------------===//
 //                   Functions for executing code using JIT

--- a/lib/Backends/CPU/DebugInfo.cpp
+++ b/lib/Backends/CPU/DebugInfo.cpp
@@ -32,7 +32,6 @@ using namespace glow;
 using llvm::cast;
 using llvm::dyn_cast;
 using llvm::isa;
-using llvm::StringRef;
 
 extern llvm::cl::opt<bool> emitDebugInfo;
 

--- a/lib/Backends/CPU/FunctionSpecializer.cpp
+++ b/lib/Backends/CPU/FunctionSpecializer.cpp
@@ -31,7 +31,6 @@ using namespace glow;
 using llvm::cast;
 using llvm::dyn_cast;
 using llvm::isa;
-using llvm::StringRef;
 
 namespace {
 /// Perform function specialization with constant arguments taking into account

--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -38,7 +38,6 @@ using namespace glow;
 using llvm::cast;
 using llvm::dyn_cast;
 using llvm::isa;
-using llvm::StringRef;
 
 llvm::cl::OptionCategory CPUBackendCat("Glow CPU Backend Options");
 
@@ -87,7 +86,7 @@ LLVMIRGen::LLVMIRGen(const IRFunction *F, AllocationsInfo &allocationsInfo,
                      std::string mainEntryName)
     : F_(F), allocationsInfo_(allocationsInfo), mainEntryName_(mainEntryName) {}
 
-void LLVMIRGen::initTargetMachine(StringRef T,
+void LLVMIRGen::initTargetMachine(llvm::StringRef T,
                                   llvm::CodeModel::Model codeModel) {
   llvm::InitializeAllTargets();
   llvm::InitializeAllTargetMCs();
@@ -102,9 +101,10 @@ void LLVMIRGen::initTargetMachine(StringRef T,
 }
 
 std::string LLVMIRGen::getMainEntryName() const {
-  StringRef name = mainEntryName_.empty() ? "main" : F_->getGraph()->getName();
+  llvm::StringRef name =
+      mainEntryName_.empty() ? "main" : F_->getGraph()->getName();
   auto delimPos = name.rfind('/');
-  if (delimPos != StringRef::npos)
+  if (delimPos != llvm::StringRef::npos)
     name = name.substr(delimPos + 1);
   return name;
 }
@@ -131,8 +131,8 @@ void LLVMIRGen::loadBaseAddresses(llvm::IRBuilder<> &builder) {
 // Search for the standard library bitcode file on disk and load it into an
 // LLVM module. We search for the standard library around the current executable
 // and also in the current directory.
-static std::unique_ptr<llvm::Module> loadStandardLibrary(llvm::LLVMContext *ctx,
-                                                         StringRef filename) {
+static std::unique_ptr<llvm::Module>
+loadStandardLibrary(llvm::LLVMContext *ctx, llvm::StringRef filename) {
   using llvm::sys::path::append;
   using llvm::sys::path::parent_path;
 
@@ -140,7 +140,7 @@ static std::unique_ptr<llvm::Module> loadStandardLibrary(llvm::LLVMContext *ctx,
   // Figure out the location of the current executable.
   auto mainExec =
       llvm::sys::fs::getMainExecutable(nullptr, (void *)&loadStandardLibrary);
-  StringRef basePath = parent_path(mainExec);
+  llvm::StringRef basePath = parent_path(mainExec);
 
   // Search for the standard library starting at the location of the executable.
   // Go up the tree up to three levels (by removing the last directory name).
@@ -572,8 +572,8 @@ emitBufferAddress(llvm::IRBuilder<> &builder, Value *val,
 /// only once. This allows us to mark all parameters of the generated kernel as
 /// noalias. As a result, the LLVM optimizer makes use of the noalias attributes
 /// and produces nicely vectorized code for the generated data-parallel kernels.
-void LLVMIRGen::emitDataParallelKernel(llvm::IRBuilder<> &builder,
-                                       llvm::ArrayRef<const Instruction *> bundle) {
+void LLVMIRGen::emitDataParallelKernel(
+    llvm::IRBuilder<> &builder, llvm::ArrayRef<const Instruction *> bundle) {
   if (bundle.empty())
     return;
   llvm::Type *voidTy = llvm::Type::getVoidTy(ctx_);
@@ -737,8 +737,9 @@ void LLVMIRGen::generateLLVMIRForModule(llvm::IRBuilder<> &builder) {
 }
 
 void LLVMIRGen::generateLLVMIRForDataParallelInstr(
-    llvm::IRBuilder<> &builder, const glow::Instruction *I, llvm::Function *kernel,
-    llvm::DenseMap<Value *, int> &bufferToArgNum, llvm::Value *loopCount) {
+    llvm::IRBuilder<> &builder, const glow::Instruction *I,
+    llvm::Function *kernel, llvm::DenseMap<Value *, int> &bufferToArgNum,
+    llvm::Value *loopCount) {
   setCurrentDebugLocation(builder, I);
   assert(I->isDataParallel() && "Expected a data parallel instruction");
   switch (I->getKind()) {
@@ -1553,8 +1554,7 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
   }
 
   case Kinded::Kind::LocalResponseNormalizationInstKind: {
-    auto *LRN =
-        cast<LocalResponseNormalizationInst>(I);
+    auto *LRN = cast<LocalResponseNormalizationInst>(I);
     auto *dest = LRN->getDest();
     auto *src = LRN->getSrc();
     auto *destPtr = emitValueAddress(builder, dest);
@@ -1577,8 +1577,7 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
   }
 
   case Kinded::Kind::LocalResponseNormalizationGradInstKind: {
-    auto *LRNG =
-        llvm::cast<LocalResponseNormalizationGradInst>(I);
+    auto *LRNG = llvm::cast<LocalResponseNormalizationGradInst>(I);
     auto *srcGrad = LRNG->getSrcGrad();
     auto *dest = LRNG->getDest();
     auto *srcGradPtr = emitValueAddress(builder, srcGrad);

--- a/lib/Backends/CPU/LLVMIRGen.h
+++ b/lib/Backends/CPU/LLVMIRGen.h
@@ -155,15 +155,17 @@ class LLVMIRGen {
   void loadBaseAddresses(llvm::IRBuilder<> &builder);
   /// Create a function representing a stacked kernel for instructions provided
   /// in \p stackedInstrs.
-  void emitDataParallelKernel(llvm::IRBuilder<> &builder,
-                              llvm::ArrayRef<const Instruction *> stackedInstrs);
+  void
+  emitDataParallelKernel(llvm::IRBuilder<> &builder,
+                         llvm::ArrayRef<const Instruction *> stackedInstrs);
   /// Emit IR for the data parallel instruction \p I which is invoked inside the
   /// stacked \p kernel. The current loop count is described by \p loopCount.
   /// The \p bufferToArgNum map can be used to find the required buffers, which
   /// are provided as arguments to the stacked \p kernel.
   void generateLLVMIRForDataParallelInstr(
-      llvm::IRBuilder<> &builder, const glow::Instruction *I, llvm::Function *kernel,
-      llvm::DenseMap<Value *, int> &bufferToArgNum, llvm::Value *loopCount);
+      llvm::IRBuilder<> &builder, const glow::Instruction *I,
+      llvm::Function *kernel, llvm::DenseMap<Value *, int> &bufferToArgNum,
+      llvm::Value *loopCount);
   /// \returns the llvm type of the glow vale \p val.
   llvm::Type *getElementType(llvm::IRBuilder<> &builder, const Value *val);
   /// Create a debug information for a given LLVM type \p ty.
@@ -200,7 +202,8 @@ public:
   void initTargetMachine(llvm::StringRef T, llvm::CodeModel::Model CM);
 
   /// Emit LLVM-IR for the instruction \p I, using the builder \p builder.
-  void generateLLVMIRForInstr(llvm::IRBuilder<> &builder, const glow::Instruction *I);
+  void generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
+                              const glow::Instruction *I);
   /// Emit LLVM-IR for the whole IRFunction.
   void generateLLVMIRForModule(llvm::IRBuilder<> &builder);
   /// \returns a libjit API function by name.

--- a/lib/Backends/CPU/Pipeline.cpp
+++ b/lib/Backends/CPU/Pipeline.cpp
@@ -52,7 +52,6 @@
 using namespace glow;
 using llvm::dyn_cast;
 using llvm::isa;
-using llvm::StringRef;
 
 void LLVMIRGen::optimizeLLVMModule(llvm::Function *F, llvm::TargetMachine &TM) {
   auto *M = F->getParent();

--- a/lib/Backends/CPU/Transforms.cpp
+++ b/lib/Backends/CPU/Transforms.cpp
@@ -75,8 +75,8 @@ static Node *optimizeCPUConv(ConvolutionNode *CN, Function *F) {
         }
 
   return F->addNode(new CPUConvDKKC8Node(
-      CN->getName(), CN->getResult().getType(), CN->getInput(), filter8, CN->getBias(),
-      CN->getKernel(), CN->getStride(), CN->getPads(), group));
+      CN->getName(), CN->getResult().getType(), CN->getInput(), filter8,
+      CN->getBias(), CN->getKernel(), CN->getStride(), CN->getPads(), group));
 }
 
 bool CPUBackend::transformPostLowering(Function *F, CompilationMode mode) {

--- a/lib/IR/IRGen.cpp
+++ b/lib/IR/IRGen.cpp
@@ -249,8 +249,8 @@ public:
     case glow::Kinded::Kind::ConcatNodeKind: {
       auto *CC = cast<ConcatNode>(N);
 
-      auto *dest =
-          builder_.createAllocActivationInst(CC->getName(), CC->getResult().getType());
+      auto *dest = builder_.createAllocActivationInst(
+          CC->getName(), CC->getResult().getType());
       builder_.createSplatInst(CC->getName(), dest, 0);
       auto inputs = CC->getInputs();
 
@@ -287,8 +287,8 @@ public:
       auto *SL = cast<SliceNode>(N);
       auto start = SL->getStart();
       auto *in = valueForNode(SL->getInput());
-      auto *dest =
-          builder_.createAllocActivationInst(SL->getName(), SL->getResult().getType());
+      auto *dest = builder_.createAllocActivationInst(
+          SL->getName(), SL->getResult().getType());
       builder_.createExtractTensorInst(SL->getName(), dest, in, start);
       registerIR(N, dest);
       break;
@@ -298,8 +298,8 @@ public:
       auto start = IT->getStart();
       auto *big = valueForNode(IT->getBig());
       auto *small = valueForNode(IT->getSmall());
-      auto *dest =
-          builder_.createAllocActivationInst(IT->getName(), IT->getResult().getType());
+      auto *dest = builder_.createAllocActivationInst(
+          IT->getName(), IT->getResult().getType());
       builder_.createCopyInst("copy.insert", dest, big);
       builder_.createInsertTensorInst("insert", dest, small, start,
                                       /* count */ 1, /* axis */ 0);
@@ -312,8 +312,8 @@ public:
       auto *dataTensor = valueForNode(SAI->getData());
       auto *indicesTensor = valueForNode(SAI->getIndices());
       auto *slicesTensor = valueForNode(SAI->getSlices());
-      auto *dest =
-          builder_.createAllocActivationInst(SAI->getName(), SAI->getResult().getType());
+      auto *dest = builder_.createAllocActivationInst(
+          SAI->getName(), SAI->getResult().getType());
       builder_.createCopyInst("copy.scatterassign", dest, dataTensor);
       builder_.createScatterAssignInst("scatterassign", dest, indicesTensor,
                                        slicesTensor);
@@ -366,8 +366,8 @@ public:
     case glow::Kinded::Kind::LoadNodeKind: {
       auto *load = cast<LoadNode>(N);
       auto *src = valueForNode(load->getVariable());
-      auto *dest =
-          builder_.createAllocActivationInst(load->getName(), load->getResult().getType());
+      auto *dest = builder_.createAllocActivationInst(
+          load->getName(), load->getResult().getType());
       auto *copy = builder_.createCopyInst("load", dest, src);
       copy->setName(N->getName());
       registerIR(N, dest);

--- a/lib/Optimizer/Lower.cpp
+++ b/lib/Optimizer/Lower.cpp
@@ -337,9 +337,11 @@ void computeBatchNormalizationWeights(Function *F, BatchNormalizationNode &BN) {
   // reduce the tensor by the first dimension, to get {numChannels}
   auto *batchedAdd = F->createBatchedReduceAdd("in.sum", inFlat, /* axis */ 0);
   // Mean = sum(in[i]) / N
-  auto samplesPerChannelSplat = F->createSplat(
-      "samplesPerChannelSplat", batchedAdd->getResult().getType(), samplesPerChannel);
-  DivNode *localMean = F->createDiv("localMean", batchedAdd, samplesPerChannelSplat);
+  auto samplesPerChannelSplat =
+      F->createSplat("samplesPerChannelSplat",
+                     batchedAdd->getResult().getType(), samplesPerChannel);
+  DivNode *localMean =
+      F->createDiv("localMean", batchedAdd, samplesPerChannelSplat);
 
   // Calculate Variance:
   // sum((x - mu) ^ 2)
@@ -353,8 +355,8 @@ void computeBatchNormalizationWeights(Function *F, BatchNormalizationNode &BN) {
   localVar = F->createDiv("localVar", localVar, samplesPerChannelSplat);
 
   // Update the global variance and mean:
-  auto momentumSplat =
-      F->createSplat("momentumSplat", localMean->getResult().getType(), momentum);
+  auto momentumSplat = F->createSplat(
+      "momentumSplat", localMean->getResult().getType(), momentum);
   auto oneMinusMomentumSplat = F->createSplat(
       "oneMinusMomentumSplat", localMean->getResult().getType(), 1 - momentum);
 
@@ -505,8 +507,8 @@ void lowerGroupConvolutionNode(Function *F, ConvolutionNode &BNG) {
 
   auto outDims = BNG.getResult().dims().vec();
   outDims[3] = outCperG;
-  auto outTy = F->getParent()->uniqueTypeWithNewShape(
-      BNG.getResult().getType(), outDims);
+  auto outTy = F->getParent()->uniqueTypeWithNewShape(BNG.getResult().getType(),
+                                                      outDims);
 
   std::vector<NodeValue> convs;
   for (unsigned groupId = 0; groupId < group; groupId++) {

--- a/tests/unittests/graphOptzTest.cpp
+++ b/tests/unittests/graphOptzTest.cpp
@@ -586,7 +586,7 @@ TEST_F(GraphOptz, ZeroArithmetic) {
   // Tests the identities: [0 + X = X] [0 * X = 0] [0 / X = 0] [ X - 0 = X]
 
   Variable *input = mod_.createVariable(ElemKind::FloatTy, {4, 10}, "input",
-                                    VisibilityKind::Public);
+                                        VisibilityKind::Public);
 
   // This builds the expression: ((0 / I) + (0 + I) + (0 * I)) - 0
 


### PR DESCRIPTION
I removed all instances of `using llvm::StringRef;` because clang-format can't decide how to sort it, and we only use it unqualified in a handful of places anyways.  This will make it a lot less annoying to use `utils/format.sh` before creating a PR.