### PR TITLE
[ee] Remove getIR from API

### DIFF
--- a/examples/ptb.cpp
+++ b/examples/ptb.cpp
@@ -55,8 +55,6 @@ llvm::cl::opt<std::string> dumpTrainingGraphDAGFileOpt(
         "Specify the file to export the training Graph in DOT format"),
     llvm::cl::value_desc("file.dot"), llvm::cl::cat(ptbCat));
 
-llvm::cl::opt<bool> dumpIROpt("dumpIR", llvm::cl::desc("Prints IR to stdout"),
-                              llvm::cl::cat(ptbCat));
 } // namespace
 
 unsigned loadPTB(Tensor &inputWords, Tensor &targetWords, size_t numSteps,
@@ -241,9 +239,6 @@ void testPTB() {
   if (!dumpTrainingGraphDAGFileOpt.empty()) {
     llvm::outs() << "Dumping training graph\n";
     TF->dumpDAG(dumpTrainingGraphDAGFileOpt.c_str());
-  }
-  if (dumpIROpt) {
-    EE.getIR().dump();
   }
 
   size_t numBatches = (numWords / minibatchSize - 1) / numSteps;

--- a/include/glow/ExecutionEngine/ExecutionEngine.h
+++ b/include/glow/ExecutionEngine/ExecutionEngine.h
@@ -67,9 +67,6 @@ public:
   /// Reset the execution engine.
   void reset();
 
-  /// \returns the internal IR function.
-  IRFunction &getIR() { return *IR_; }
-
   /// \returns the internal graph.
   Module &getModule() { return *M_; }
 

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -23,7 +23,19 @@
 #include "glow/IR/Instrs.h"
 #include "glow/Optimizer/Optimizer.h"
 
+#include "llvm/Support/CommandLine.h"
+
 using namespace glow;
+
+namespace {
+static llvm::cl::opt<std::string>
+    dumpIRDAG("dump-ir-dag",
+              llvm::cl::desc("Specify the file to export the IR in DOT format"),
+              llvm::cl::value_desc("file.dot"));
+
+static llvm::cl::opt<bool> dumpIR("dump-ir",
+                                  llvm::cl::desc("Prints IR to stdout"));
+} // namespace
 
 ExecutionEngine::ExecutionEngine(BackendKind backendKind) {
   backendKind_ = backendKind;
@@ -157,6 +169,14 @@ void ExecutionEngine::generateIR(CompilationMode mode, Function *F) {
 
   // Optimize the generated IR.
   ::glow::optimize(*IR_, mode, *backend_);
+
+  // If requested, dump IR to stdout and/or dot file for debugging.
+  if (dumpIR) {
+    IR_->dump();
+  }
+  if (!dumpIRDAG.empty()) {
+    IR_->dumpDAG(dumpIRDAG.getValue());
+  }
 }
 
 void ExecutionEngine::compile(CompilationMode mode, Function *F) {

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -98,14 +98,6 @@ llvm::cl::opt<bool> dumpGraphOpt("dumpGraph",
                                  llvm::cl::desc("Prints Graph to stdout"),
                                  llvm::cl::cat(modelExportCat));
 
-llvm::cl::opt<std::string> dumpIRDAGFileOpt(
-    "dumpIRDAG",
-    llvm::cl::desc("Specify the file to export the IR in DOT format"),
-    llvm::cl::value_desc("file.dot"), llvm::cl::cat(modelExportCat));
-
-llvm::cl::opt<bool> dumpIROpt("dumpIR", llvm::cl::desc("Prints IR to stdout"),
-                              llvm::cl::cat(modelExportCat));
-
 /// Emit a bundle into the specified output directory.
 llvm::cl::opt<std::string>
     emitBundle("emit-bundle",
@@ -170,12 +162,6 @@ void Loader::compile() {
   }
   if (!dumpGraphDAGFileOpt.empty()) {
     F_->dumpDAG(dumpGraphDAGFileOpt.c_str());
-  }
-  if (dumpIROpt) {
-    EE_.getIR().dump();
-  }
-  if (!dumpIRDAGFileOpt.empty()) {
-    EE_.getIR().dumpDAG(dumpIRDAGFileOpt.c_str());
   }
 }
 


### PR DESCRIPTION
To preserve debuggability, I added -dump-ir and -dump-ir-dag to ExecutionEngine, which also saves us re-implementing it in every example program :-).

I did have to work around the lack of getIR in one unit test, which is the most substantial code change in this diff.