### PR TITLE
[IROptimizer] Enclosing intervals don't need to be strict

### DIFF
--- a/lib/Optimizer/IROptimizer.cpp
+++ b/lib/Optimizer/IROptimizer.cpp
@@ -664,7 +664,7 @@ static Intervals::iterator getEnclosingInterval(Intervals &liveIntervals,
 
 /// Returns true if RHS is enclosed inside LHS.
 static bool isEnclosedInside(Interval &lhs, Interval &rhs) {
-  return lhs.begin_ < rhs.begin_ && rhs.end_ <= lhs.end_;
+  return lhs.begin_ <= rhs.begin_ && rhs.end_ <= lhs.end_;
 }
 
 /// \returns true of any intervals from \p Ints overlap with interval \p I.


### PR DESCRIPTION
Prior to this patch, we were considering that an interval A is
enclosed inside B iff B strictly started before A and ended after
A, including A's end point.

This patch removes the *strictly* part of the condition. Now, A is
enclosed inside B iff B starts before A and ends after A.

Drive by review.