### PR TITLE
[travis] Make jobs instead of matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,7 @@ addons:
 before_install:
   - utils/install_protobuf.sh
 
-matrix:
-  fast_finish: true
+jobs:
   include:
     - env:
         - TEST_NAME=ASAN


### PR DESCRIPTION
Matrix does not support conditional switch off for subjobs, which would be needed if we want to run cron jobs (for time consuming runs of run.sh etc).
Currently, matrix capabilities are not used anyways.