### PR TITLE
[backend] Factor out CompiledFunction from Interpreter

### DIFF
--- a/include/glow/Backends/Backend.h
+++ b/include/glow/Backends/Backend.h
@@ -16,6 +16,7 @@
 #ifndef GLOW_BACKENDS_BACKEND_H
 #define GLOW_BACKENDS_BACKEND_H
 
+#include "glow/Backends/CompiledFunction.h"
 #include "glow/Base/Traits.h"
 #include "glow/Optimizer/Optimizer.h"
 

--- a/include/glow/Backends/CompiledFunction.h
+++ b/include/glow/Backends/CompiledFunction.h
@@ -18,7 +18,7 @@
 
 namespace glow {
 
-/// Interface containing state necessary to execute a compiled network.
+/// Interface for executing a compiled function.
 class CompiledFunction {
 public:
   /// Dtor.

--- a/include/glow/Backends/CompiledFunction.h
+++ b/include/glow/Backends/CompiledFunction.h
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_BACKENDS_COMPILEDFUNCTION_H
+#define GLOW_BACKENDS_COMPILEDFUNCTION_H
+
+namespace glow {
+
+/// Interface containing state necessary to execute a compiled network.
+class CompiledFunction {
+public:
+  /// Dtor.
+  virtual ~CompiledFunction() = default;
+
+  /// Execute the network.
+  virtual void doForwardPass() = 0;
+};
+
+} // end namespace glow
+
+#endif // GLOW_BACKENDS_COMPILEDFUNCTION_H

--- a/lib/Backends/CPU/CMakeLists.txt
+++ b/lib/Backends/CPU/CMakeLists.txt
@@ -47,6 +47,7 @@ add_library(CPURuntimeNative
 add_library(CPUBackend
             AllocationsInfo.cpp
             BundleSaver.cpp
+            CPUFunction.cpp
             DebugInfo.cpp
             FunctionSpecializer.cpp
             GlowJIT.cpp

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -14,33 +14,20 @@
  * limitations under the License.
  */
 
-#define DEBUG_TYPE "jit"
-
-#include "CPUBackend.h"
-
 #include "BundleSaver.h"
+#include "CPUBackend.h"
 #include "CPUFunction.h"
 
 #include "glow/Graph/Graph.h"
 #include "glow/IR/Instrs.h"
 #include "glow/Support/Debug.h"
 
-#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
-#include "llvm/Bitcode/BitcodeWriter.h"
-#include "llvm/IR/Constants.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/LLVMContext.h"
-#include "llvm/IR/Module.h"
-#include "llvm/Support/Casting.h"
-#include "llvm/Support/Debug.h"
-#include "llvm/Support/raw_ostream.h"
 
 using namespace glow;
-using llvm::cast;
-using llvm::dyn_cast;
-using llvm::isa;
 
 static llvm::cl::opt<std::string> target("target", llvm::cl::desc("target"));
 

--- a/lib/Backends/CPU/CPUBackend.h
+++ b/lib/Backends/CPU/CPUBackend.h
@@ -16,27 +16,13 @@
 #ifndef GLOW_BACKENDS_CPU_CPUBACKEND_H
 #define GLOW_BACKENDS_CPU_CPUBACKEND_H
 
-#include "AllocationsInfo.h"
-#include "GlowJIT.h"
-#include "LLVMIRGen.h"
 #include "glow/Backends/Backend.h"
 #include "glow/Base/Tensor.h"
 
 #include "llvm/ADT/ArrayRef.h"
-#include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/IRBuilder.h"
-#include "llvm/IR/Module.h"
 
 namespace glow {
-
-class Context;
-class IRFunction;
-class Value;
-class Tensor;
-class Variable;
-class Instruction;
-class WeightVar;
-struct AllocationsInfo;
 
 /// Helper function to create a new CallInst, with the specified \p builder, \p
 /// callee, and \p args. Verifies that the function signature is correct,

--- a/lib/Backends/CPU/CPUBackend.h
+++ b/lib/Backends/CPU/CPUBackend.h
@@ -45,20 +45,17 @@ llvm::CallInst *createCall(llvm::IRBuilder<> &builder, llvm::Function *callee,
                            llvm::ArrayRef<llvm::Value *> args);
 
 class CPUBackend final : public Backend {
-  /// The LLVM JIT engine. The jit must be initialized after the ctor
-  /// initializes the LLVM backends.
-  std::unique_ptr<llvm::orc::GlowJIT> JIT_{nullptr};
-  /// This represents the heap, that stores the activations at runtime.
-  void *heap_{nullptr};
+  /// The function compiled for the CPU.
+  std::unique_ptr<CompiledFunction> function_;
 
 public:
   /// Ctor.
-  explicit CPUBackend();
+  CPUBackend() = default;
 
   /// @name Backend methods.
   /// This is the implementation of the Backend interface.
   ///@{
-  ~CPUBackend() override;
+  ~CPUBackend() override = default;
 
   void init(std::unique_ptr<IRFunction> IR) override;
 

--- a/lib/Backends/CPU/CPUFunction.cpp
+++ b/lib/Backends/CPU/CPUFunction.cpp
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CPUFunction.h"
+
+#include "glow/Support/Compiler.h"
+#include "glow/Support/Memory.h"
+
+using namespace glow;
+
+CPUFunction::CPUFunction(std::unique_ptr<llvm::orc::GlowJIT> JIT, void *heap) 
+  : JIT_(std::move(JIT)), heap_(heap) {}
+
+CPUFunction::~CPUFunction() { alignedFree(heap_); }
+
+void CPUFunction::doForwardPass() {
+  auto sym = JIT_->findSymbol("jitmain");
+  assert(sym && "Unable to JIT the code!");
+  using JitFuncType = void (*)(void);
+  auto address = sym.getAddress();
+  if (address) {
+    JitFuncType funcPtr = reinterpret_cast<JitFuncType>(address.get());
+    funcPtr();
+  } else {
+    GLOW_ASSERT(false && "Error getting address.");
+  }
+}

--- a/lib/Backends/CPU/CPUFunction.h
+++ b/lib/Backends/CPU/CPUFunction.h
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_BACKENDS_CPU_CPUFUNCTION_H
+#define GLOW_BACKENDS_CPU_CPUFUNCTION_H
+
+#include "GlowJIT.h"
+
+#include "glow/Backends/CompiledFunction.h"
+
+namespace glow {
+
+/// A function compiled for the CPU using LLVM.
+class CPUFunction final : public CompiledFunction {
+  /// The LLVM JIT engine. The jit must be initialized after the ctor
+  /// initializes the LLVM backends.
+  std::unique_ptr<llvm::orc::GlowJIT> JIT_;
+  /// This represents the heap, that stores the activations at runtime.
+  void *heap_;
+
+ public:
+  /// Ctor.
+  CPUFunction(std::unique_ptr<llvm::orc::GlowJIT> JIT, void *heap);
+
+  /// \name CompiledFunction interface
+  ///@{
+  ~CPUFunction() override;
+
+  void doForwardPass() override;
+  ///@}
+};
+
+} // end namespace glow
+
+#endif // GLOW_BACKENDS_CPU_CPUFUNCTION_H

--- a/lib/Backends/CPU/CPUFunction.h
+++ b/lib/Backends/CPU/CPUFunction.h
@@ -22,7 +22,7 @@
 
 namespace glow {
 
-/// A function compiled for the CPU using LLVM.
+/// A Glow IR function compiled for the CPU using LLVM.
 class CPUFunction final : public CompiledFunction {
   /// The LLVM JIT engine. The jit must be initialized after the ctor
   /// initializes the LLVM backends.

--- a/lib/Backends/CPU/FunctionSpecializer.cpp
+++ b/lib/Backends/CPU/FunctionSpecializer.cpp
@@ -17,6 +17,7 @@
 
 #include "CPUBackend.h"
 #include "CommandLine.h"
+#include "LLVMIRGen.h"
 
 #include "glow/IR/Instrs.h"
 #include "glow/Support/Debug.h"

--- a/lib/Backends/CPU/Pipeline.cpp
+++ b/lib/Backends/CPU/Pipeline.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "CPUBackend.h"
+#include "LLVMIRGen.h"
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallVector.h"

--- a/lib/Backends/Interpreter/CMakeLists.txt
+++ b/lib/Backends/Interpreter/CMakeLists.txt
@@ -1,6 +1,7 @@
 
 add_library(Interpreter
               Interpreter.cpp
+              InterpreterFunction.cpp
               InterpreterNodes.cpp)
 target_link_libraries(Interpreter
                       PRIVATE

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -19,13 +19,9 @@
 
 #include "glow/Graph/Graph.h"
 #include "glow/Graph/Nodes.h"
-#include "glow/IR/IRUtils.h"
-#include "glow/IR/Instrs.h"
-
-#include "llvm/Support/Casting.h"
+#include "glow/IR/IR.h"
 
 using namespace glow;
-using llvm::isa;
 
 void Interpreter::init(std::unique_ptr<IRFunction> IR) {
   function_ = llvm::make_unique<InterpreterFunction>(std::move(IR));

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "Interpreter.h"
+#include "InterpreterFunction.h"
 
 #include "glow/Graph/Graph.h"
 #include "glow/Graph/Nodes.h"
@@ -26,81 +27,12 @@
 using namespace glow;
 using llvm::isa;
 
-Interpreter::~Interpreter() {
-  // Delete the tensors that are owned by this backend.
-  for (auto p : tensors_) {
-    delete p.second;
-  }
-  tensors_.clear();
-  externalTensors_.clear();
-}
-
 void Interpreter::init(std::unique_ptr<IRFunction> IR) {
-  F_ = std::move(IR);
-  for (auto &v : F_->getGraph()->getParent()->getVars()) {
-    auto *w = F_->getWeightForNode(v);
-    assert(!externalTensors_.count(w) && "The tensor is already registered");
-    externalTensors_[w] = &v->getPayload();
-  }
-
-  for (auto *W : F_->getWeights()) {
-    getOrCreateTensor(W);
-  }
+  function_ = llvm::make_unique<InterpreterFunction>(std::move(IR));
 }
 
-Tensor *Interpreter::getTensor(const Value *v) const {
-  auto it = tensors_.find(v);
-  if (it != tensors_.end()) {
-    return it->second;
-  }
-
-  auto ie = externalTensors_.find(v);
-  assert(ie != externalTensors_.end() && "Unknown key Value.");
-  return ie->second;
-}
-
-Tensor *Interpreter::getOrCreateTensor(const Value *v) {
-  auto ie = externalTensors_.find(v);
-  if (ie != externalTensors_.end()) {
-    return ie->second;
-  }
-
-  // Pick the tensor.
-  auto it = tensors_.find(v);
-  if (it == tensors_.end()) {
-    auto *T = new Tensor(v->getType());
-    tensors_[v] = T;
-    return T;
-  }
-  return it->second;
-}
-
-Tensor *Interpreter::getOrCreateUnownedTensor(const Value *v, const Value *src,
-                                              llvm::ArrayRef<size_t> offsets) {
-  assert(isa<TensorViewInst>(v) && "Expected a tensor view");
-
-  // Pick the tensor.
-  auto it = tensors_.find(v);
-
-  // Release unowned tensors before re-creating them.
-  if (it != tensors_.end()) {
-    deleteTensor(v);
-  }
-
-  auto *T = new Tensor();
-  *T = getTensor(src)->getUnowned(v->dims(), offsets);
-  tensors_[v] = T;
-  return T;
-}
-
-void Interpreter::deleteTensor(const Value *v) {
-  auto it = tensors_.find(v);
-  if (it == tensors_.end()) {
-    return;
-  }
-
-  delete it->second;
-  tensors_.erase(it);
+void Interpreter::doForwardPass() {
+  function_->doForwardPass();
 }
 
 bool Interpreter::isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const {
@@ -147,26 +79,6 @@ bool Interpreter::shouldLower(const Node *N) const {
   if (N->getKind() == Kinded::Kind::ConvolutionNodeKind)
     return false;
   return true;
-}
-
-void Interpreter::doForwardPass() {
-// Do the forward pass.
-#define DEF_VALUE(CLASS, NAME)
-#define DEF_INSTR(CLASS, NAME)                                                 \
-  case Kinded::Kind::CLASS##Kind: {                                            \
-    fwd##CLASS(llvm::cast<CLASS>(&I));                                         \
-    break;                                                                     \
-  }
-#define DEF_BACKEND_SPECIFIC_INSTR(CLASS, NAME)
-  // Dispatch the interpreter on each instruction in the program:
-  for (const auto &I : F_->getInstrs()) {
-    switch (I.getKind()) {
-#include "AutoGenInstr.def"
-
-    default:
-      llvm_unreachable("Invalid instruction.");
-    }
-  }
 }
 
 namespace glow {

--- a/lib/Backends/Interpreter/Interpreter.h
+++ b/lib/Backends/Interpreter/Interpreter.h
@@ -19,11 +19,6 @@
 #include "InterpreterFunction.h"
 
 #include "glow/Backends/Backend.h"
-#include "glow/Base/Tensor.h"
-
-#include "llvm/ADT/ArrayRef.h"
-
-#include <unordered_map>
 
 namespace glow {
 

--- a/lib/Backends/Interpreter/Interpreter.h
+++ b/lib/Backends/Interpreter/Interpreter.h
@@ -16,6 +16,8 @@
 #ifndef GLOW_BACKENDS_INTERPRETER_INTERPRETER_H
 #define GLOW_BACKENDS_INTERPRETER_INTERPRETER_H
 
+#include "InterpreterFunction.h"
+
 #include "glow/Backends/Backend.h"
 #include "glow/Base/Tensor.h"
 
@@ -25,37 +27,20 @@
 
 namespace glow {
 
-class Context;
-class IRFunction;
-class Value;
-class Tensor;
-class Variable;
-
-// Forward declare all of the classes.
-#define DEF_VALUE(CLASS, NAME) class CLASS;
-#define DEF_INSTR(CLASS, NAME) class CLASS;
-#define DEF_BACKEND_SPECIFIC_INSTR(CLASS, NAME)
-#include "AutoGenInstr.def"
-
 /// This is the IR-interpreter. It owns the IR, and the heap, and is able to
 /// execute the instructions one at a time.
 class Interpreter final : public Backend {
-  /// The IR to be executed.
-  std::unique_ptr<IRFunction> F_;
-  /// Maps values to Tensors, that are owned by this class.
-  std::unordered_map<const Value *, Tensor *> tensors_;
-
-  /// Maps values to Tensors, that are *not* owned by this class.
-  std::unordered_map<const Value *, Tensor *> externalTensors_;
+  /// State necessary to execute a function using the interpreter.
+  std::unique_ptr<CompiledFunction> function_;
 
 public:
   /// Ctor.
-  explicit Interpreter() {}
+  Interpreter() = default;
 
   /// @name Backend methods.
   /// This is the implementation of the Backend interface.
   ///@{
-  ~Interpreter() override;
+  ~Interpreter() override = default;
 
   void init(std::unique_ptr<IRFunction> IR) override;
 
@@ -65,48 +50,6 @@ public:
 
   bool shouldLower(const Node *N) const override;
   /// @}
-
-private:
-  /// \returns a pointer to the tensor that is saved under \p v.
-  Tensor *getTensor(const Value *v) const;
-
-  /// Allocate a tensor to back the value \p v. Do not allocate anything if a
-  /// tensor is already allocated for \p v.
-  /// \returns a tensor for \p v.
-  Tensor *getOrCreateTensor(const Value *v);
-
-  /// Allocate an unowned tensor to back the value \p v. The source tensor of
-  /// the unowned tensor is provided by \p src.
-  /// \returns a tensor for \p v.
-  Tensor *getOrCreateUnownedTensor(const Value *v, const Value *src,
-                                   llvm::ArrayRef<size_t> offsets);
-
-  /// If a tensor is allocated for \p v then delete it.
-  void deleteTensor(const Value *v);
-
-  /// \returns a typed handle to the tensor that is stored at \p v.
-  template <class ElemTy = float>
-  Handle<ElemTy> getWeightHandle(Value *v) const {
-    return getTensor(v)->getHandle<ElemTy>();
-  }
-
-  /// @name Interpreter methods. This is a list of method declerations that are
-  /// used by the interpreter to dispatch different instructions.
-  ///@{
-
-#define DEF_VALUE(CLASS, NAME)
-#define DEF_INSTR(CLASS, NAME) void fwd##CLASS(const CLASS *I);
-#define DEF_BACKEND_SPECIFIC_INSTR(CLASS, NAME)
-#include "AutoGenInstr.def"
-
-  void fwdConvolutionInst_I8Impl(Value *inV, Value *outV, Value *filterV,
-                                 Value *biasV, size_t filterSize, size_t stride,
-                                 llvm::ArrayRef<size_t> pads, size_t group);
-  void fwdConvolutionInst_FloatImpl(Value *inV, Value *outV, Value *filterV,
-                                    Value *biasV, size_t filterSize,
-                                    size_t stride, llvm::ArrayRef<size_t> pads,
-                                    size_t group);
-  ///@}
 };
 
 } // namespace glow

--- a/lib/Backends/Interpreter/InterpreterFunction.cpp
+++ b/lib/Backends/Interpreter/InterpreterFunction.cpp
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "InterpreterFunction.h"
+
+#include "glow/IR/IR.h"
+#include "glow/IR/IRUtils.h"
+#include "glow/IR/Instrs.h"
+
+#include "llvm/Support/Casting.h"
+
+using namespace glow;
+
+InterpreterFunction::InterpreterFunction(std::unique_ptr<IRFunction> F)
+    : F_(std::move(F)) {
+  for (auto &v : F_->getGraph()->getParent()->getVars()) {
+    auto *w = F_->getWeightForNode(v);
+    assert(!externalTensors_.count(w) && "The tensor is already registered");
+    externalTensors_[w] = &v->getPayload();
+  }
+
+  for (auto *W : F_->getWeights()) {
+    getOrCreateTensor(W);
+  }
+}
+
+InterpreterFunction::~InterpreterFunction() {
+  // Delete the tensors that are owned by this backend.
+  for (auto p : tensors_) {
+    delete p.second;
+  }
+  tensors_.clear();
+  externalTensors_.clear();
+}
+
+Tensor *InterpreterFunction::getTensor(const Value *v) const {
+  auto it = tensors_.find(v);
+  if (it != tensors_.end()) {
+    return it->second;
+  }
+
+  auto ie = externalTensors_.find(v);
+  assert(ie != externalTensors_.end() && "Unknown key Value.");
+  return ie->second;
+}
+
+Tensor *InterpreterFunction::getOrCreateTensor(const Value *v) {
+  auto ie = externalTensors_.find(v);
+  if (ie != externalTensors_.end()) {
+    return ie->second;
+  }
+
+  // Pick the tensor.
+  auto it = tensors_.find(v);
+  if (it == tensors_.end()) {
+    auto *T = new Tensor(v->getType());
+    tensors_[v] = T;
+    return T;
+  }
+  return it->second;
+}
+
+Tensor *
+InterpreterFunction::getOrCreateUnownedTensor(const Value *v, const Value *src,
+                                              llvm::ArrayRef<size_t> offsets) {
+  assert(llvm::isa<TensorViewInst>(v) && "Expected a tensor view");
+
+  // Pick the tensor.
+  auto it = tensors_.find(v);
+
+  // Release unowned tensors before re-creating them.
+  if (it != tensors_.end()) {
+    deleteTensor(v);
+  }
+
+  auto *T = new Tensor();
+  *T = getTensor(src)->getUnowned(v->dims(), offsets);
+  tensors_[v] = T;
+  return T;
+}
+
+void InterpreterFunction::deleteTensor(const Value *v) {
+  auto it = tensors_.find(v);
+  if (it == tensors_.end()) {
+    return;
+  }
+
+  delete it->second;
+  tensors_.erase(it);
+}
+
+void InterpreterFunction::doForwardPass() {
+// Do the forward pass.
+#define DEF_VALUE(CLASS, NAME)
+#define DEF_INSTR(CLASS, NAME)                                                 \
+  case Kinded::Kind::CLASS##Kind: {                                            \
+    fwd##CLASS(llvm::cast<CLASS>(&I));                                         \
+    break;                                                                     \
+  }
+#define DEF_BACKEND_SPECIFIC_INSTR(CLASS, NAME)
+  // Dispatch the interpreter on each instruction in the program:
+  for (const auto &I : F_->getInstrs()) {
+    switch (I.getKind()) {
+#include "AutoGenInstr.def"
+
+    default:
+      llvm_unreachable("Invalid instruction.");
+    }
+  }
+}

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_BACKENDS_INTERPRETER_INTERPRETERFUNCTION_H
+#define GLOW_BACKENDS_INTERPRETER_INTERPRETERFUNCTION_H
+
+#include "glow/Backends/CompiledFunction.h"
+#include "glow/Base/Tensor.h"
+
+#include "llvm/ADT/ArrayRef.h"
+
+#include <memory>
+#include <unordered_map>
+
+namespace glow {
+
+class Context;
+class IRFunction;
+class Value;
+class Tensor;
+class Variable;
+
+// Forward declare all of the classes.
+#define DEF_VALUE(CLASS, NAME) class CLASS;
+#define DEF_INSTR(CLASS, NAME) class CLASS;
+#define DEF_BACKEND_SPECIFIC_INSTR(CLASS, NAME)
+#include "AutoGenInstr.def"
+
+/// Function "compiled" for execution by the interpreter.
+class InterpreterFunction final : public CompiledFunction {
+  /// The IR to be executed.
+  std::unique_ptr<IRFunction> F_;
+  /// Maps values to Tensors, that are owned by this class.
+  std::unordered_map<const Value *, Tensor *> tensors_;
+  /// Maps values to Tensors, that are *not* owned by this class.
+  std::unordered_map<const Value *, Tensor *> externalTensors_;
+
+public:
+  InterpreterFunction(std::unique_ptr<IRFunction> F);
+
+  /// \name CompiledFunction interface
+  ///@{
+  ~InterpreterFunction() override;
+
+  void doForwardPass() override;
+  ///@}
+
+private:
+  /// \returns a pointer to the tensor that is saved under \p v.
+  Tensor *getTensor(const Value *v) const;
+
+  /// Allocate a tensor to back the value \p v. Do not allocate anything if a
+  /// tensor is already allocated for \p v.
+  /// \returns a tensor for \p v.
+  Tensor *getOrCreateTensor(const Value *v);
+
+  /// Allocate an unowned tensor to back the value \p v. The source tensor of
+  /// the unowned tensor is provided by \p src.
+  /// \returns a tensor for \p v.
+  Tensor *getOrCreateUnownedTensor(const Value *v, const Value *src,
+                                   llvm::ArrayRef<size_t> offsets);
+
+  /// If a tensor is allocated for \p v then delete it.
+  void deleteTensor(const Value *v);
+
+  /// \returns a typed handle to the tensor that is stored at \p v.
+  template <class ElemTy = float>
+  Handle<ElemTy> getWeightHandle(Value *v) const {
+    return getTensor(v)->getHandle<ElemTy>();
+  }
+
+  /// @name Interpreter methods. This is a list of method declerations that are
+  /// used by the interpreter to dispatch different instructions.
+  ///@{
+
+#define DEF_VALUE(CLASS, NAME)
+#define DEF_INSTR(CLASS, NAME) void fwd##CLASS(const CLASS *I);
+#define DEF_BACKEND_SPECIFIC_INSTR(CLASS, NAME)
+#include "AutoGenInstr.def"
+
+  void fwdConvolutionInst_I8Impl(Value *inV, Value *outV, Value *filterV,
+                                 Value *biasV, size_t filterSize, size_t stride,
+                                 llvm::ArrayRef<size_t> pads, size_t group);
+  void fwdConvolutionInst_FloatImpl(Value *inV, Value *outV, Value *filterV,
+                                    Value *biasV, size_t filterSize,
+                                    size_t stride, llvm::ArrayRef<size_t> pads,
+                                    size_t group);
+  ///@}
+};
+
+} // end namespace glow
+
+#endif // GLOW_BACKENDS_INTERPRETER_INTERPRETERFUNCTION_H

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -30,18 +30,16 @@ using namespace glow;
 //                       Convolution
 //===----------------------------------------------------------------------===//
 
-void Interpreter::fwdCopyInst(const CopyInst *I) {
+void InterpreterFunction::fwdCopyInst(const CopyInst *I) {
   auto inT = getTensor(I->getSrc());
   auto outT = getTensor(I->getDest());
   outT->copyRawFrom(inT);
 }
 
 // This is the floating point implementation of Convolution.
-void Interpreter::fwdConvolutionInst_FloatImpl(Value *inV, Value *outV,
-                                               Value *filterV, Value *biasV,
-                                               size_t filterSize, size_t stride,
-                                               llvm::ArrayRef<size_t> pads,
-                                               size_t group) {
+void InterpreterFunction::fwdConvolutionInst_FloatImpl(
+    Value *inV, Value *outV, Value *filterV, Value *biasV, size_t filterSize,
+    size_t stride, llvm::ArrayRef<size_t> pads, size_t group) {
 
   auto inW = getWeightHandle(inV);
   auto outW = getWeightHandle(outV);
@@ -102,11 +100,9 @@ void Interpreter::fwdConvolutionInst_FloatImpl(Value *inV, Value *outV,
 }
 
 // This is the quantized i8 implementation of Convolution.
-void Interpreter::fwdConvolutionInst_I8Impl(Value *inV, Value *outV,
-                                            Value *filterV, Value *biasV,
-                                            size_t filterSize, size_t stride,
-                                            llvm::ArrayRef<size_t> pads,
-                                            size_t group) {
+void InterpreterFunction::fwdConvolutionInst_I8Impl(
+    Value *inV, Value *outV, Value *filterV, Value *biasV, size_t filterSize,
+    size_t stride, llvm::ArrayRef<size_t> pads, size_t group) {
   auto inW = getWeightHandle<int8_t>(inV);
   auto outW = getWeightHandle<int8_t>(outV);
   auto filterW = getWeightHandle<int8_t>(filterV);
@@ -195,7 +191,7 @@ void Interpreter::fwdConvolutionInst_I8Impl(Value *inV, Value *outV,
   }         // N
 }
 
-void Interpreter::fwdConvolutionInst(const ConvolutionInst *I) {
+void InterpreterFunction::fwdConvolutionInst(const ConvolutionInst *I) {
   size_t filterSize = I->getKernel();
   llvm::ArrayRef<size_t> pads = I->getPads();
   size_t stride = I->getStride();
@@ -211,7 +207,7 @@ void Interpreter::fwdConvolutionInst(const ConvolutionInst *I) {
                                I->getBias(), filterSize, stride, pads, group);
 }
 
-void Interpreter::fwdConvolutionGradInst(const ConvolutionGradInst *I) {
+void InterpreterFunction::fwdConvolutionGradInst(const ConvolutionGradInst *I) {
   auto inW = getWeightHandle(I->getSrc());
   auto inG = getWeightHandle(I->getSrcGrad());
   auto outG = getWeightHandle(I->getDestGrad());
@@ -346,7 +342,7 @@ static void fwdPoolMax(Tensor *inW, Tensor *outW, Handle<size_t> *SXY,
   }       // N
 }
 
-void Interpreter::fwdPoolMaxInst(const PoolMaxInst *I) {
+void InterpreterFunction::fwdPoolMaxInst(const PoolMaxInst *I) {
   auto inW = getTensor(I->getSrc());
   auto outW = getTensor(I->getDest());
 
@@ -359,7 +355,7 @@ void Interpreter::fwdPoolMaxInst(const PoolMaxInst *I) {
   }
 }
 
-void Interpreter::fwdPoolMaxWithXYInst(const PoolMaxWithXYInst *I) {
+void InterpreterFunction::fwdPoolMaxWithXYInst(const PoolMaxWithXYInst *I) {
   auto inW = getTensor(I->getSrc());
   auto outW = getTensor(I->getDest());
   auto SXY = getTensor(I->getSrcXY())->getHandle<size_t>();
@@ -373,7 +369,7 @@ void Interpreter::fwdPoolMaxWithXYInst(const PoolMaxWithXYInst *I) {
   }
 }
 
-void Interpreter::fwdPoolAvgInst(const PoolAvgInst *I) {
+void InterpreterFunction::fwdPoolAvgInst(const PoolAvgInst *I) {
   ShapeNHWC odim(I->getDest()->dims());
   ShapeNHWC idim(I->getSrc()->dims());
 
@@ -465,7 +461,8 @@ void Interpreter::fwdPoolAvgInst(const PoolAvgInst *I) {
   }       // N
 }
 
-void Interpreter::fwdPoolMaxWithXYGradInst(const PoolMaxWithXYGradInst *I) {
+void InterpreterFunction::fwdPoolMaxWithXYGradInst(
+    const PoolMaxWithXYGradInst *I) {
   auto inG = getWeightHandle(I->getSrcGrad());
   auto outW = getWeightHandle(I->getDest());
   auto outG = getWeightHandle(I->getDestGrad());
@@ -498,7 +495,7 @@ void Interpreter::fwdPoolMaxWithXYGradInst(const PoolMaxWithXYGradInst *I) {
   }       // N
 }
 
-void Interpreter::fwdPoolAvgGradInst(const PoolAvgGradInst *I) {
+void InterpreterFunction::fwdPoolAvgGradInst(const PoolAvgGradInst *I) {
   auto inG = getWeightHandle(I->getSrcGrad());
   auto outW = getWeightHandle(I->getDest());
   auto outG = getWeightHandle(I->getDestGrad());
@@ -550,7 +547,7 @@ void Interpreter::fwdPoolAvgGradInst(const PoolAvgGradInst *I) {
 //                       Activation functions
 //===----------------------------------------------------------------------===//
 
-void Interpreter::fwdSigmoidInst(const SigmoidInst *I) {
+void InterpreterFunction::fwdSigmoidInst(const SigmoidInst *I) {
   auto inW = getWeightHandle(I->getSrc());
   auto outW = getWeightHandle(I->getDest());
 
@@ -560,7 +557,7 @@ void Interpreter::fwdSigmoidInst(const SigmoidInst *I) {
   }
 }
 
-void Interpreter::fwdTanhInst(const TanhInst *I) {
+void InterpreterFunction::fwdTanhInst(const TanhInst *I) {
   auto inW = getWeightHandle(I->getSrc());
   auto outW = getWeightHandle(I->getDest());
 
@@ -574,7 +571,7 @@ void Interpreter::fwdTanhInst(const TanhInst *I) {
 //                        Loss Functions (Softmax/regression/...)
 //===----------------------------------------------------------------------===//
 
-void Interpreter::fwdSoftMaxInst(const SoftMaxInst *I) {
+void InterpreterFunction::fwdSoftMaxInst(const SoftMaxInst *I) {
   auto inW = getWeightHandle(I->getSrc());
   auto outW = getWeightHandle(I->getDest());
   auto idim = inW.dims();
@@ -601,7 +598,7 @@ void Interpreter::fwdSoftMaxInst(const SoftMaxInst *I) {
   } // N
 }
 
-void Interpreter::fwdSoftMaxGradInst(const SoftMaxGradInst *I) {
+void InterpreterFunction::fwdSoftMaxGradInst(const SoftMaxGradInst *I) {
   auto inG = getWeightHandle(I->getSrcGrad());
   auto idim = inG.dims();
   auto outW = getWeightHandle(I->getOrigDest());
@@ -619,7 +616,8 @@ void Interpreter::fwdSoftMaxGradInst(const SoftMaxGradInst *I) {
   }
 }
 
-void Interpreter::fwdCrossEntropyLossInst(const CrossEntropyLossInst *I) {
+void InterpreterFunction::fwdCrossEntropyLossInst(
+    const CrossEntropyLossInst *I) {
   auto P = getWeightHandle(I->getP());
   auto labels = getTensor(I->getLabels())->getHandle<size_t>();
   auto CE = getWeightHandle(I->getCE());
@@ -631,7 +629,7 @@ void Interpreter::fwdCrossEntropyLossInst(const CrossEntropyLossInst *I) {
   }
 }
 
-void Interpreter::fwdCrossEntropyLossGradInst(
+void InterpreterFunction::fwdCrossEntropyLossGradInst(
     const CrossEntropyLossGradInst *I) {
   auto P = getWeightHandle(I->getP());
   auto Labels = getTensor(I->getLabels())->getHandle<size_t>();
@@ -647,7 +645,7 @@ void Interpreter::fwdCrossEntropyLossGradInst(
 //===----------------------------------------------------------------------===//
 //                       Tensor shape (transpose/concat/...)
 //===----------------------------------------------------------------------===//
-void Interpreter::fwdTransposeInst(const TransposeInst *I) {
+void InterpreterFunction::fwdTransposeInst(const TransposeInst *I) {
   auto inT = getTensor(I->getSrc());
   (void)inT;
   auto outT = getTensor(I->getDest());
@@ -661,11 +659,11 @@ void Interpreter::fwdTransposeInst(const TransposeInst *I) {
   }
 }
 
-void Interpreter::fwdTensorViewInst(const TensorViewInst *I) {
+void InterpreterFunction::fwdTensorViewInst(const TensorViewInst *I) {
   getOrCreateUnownedTensor(I, I->getSrc(), I->getOffsets());
 }
 
-void Interpreter::fwdSplatInst(const glow::SplatInst *I) {
+void InterpreterFunction::fwdSplatInst(const glow::SplatInst *I) {
   auto *T = getTensor(I->getDest());
   ElemKind k = T->getElementType();
 
@@ -689,7 +687,7 @@ void Interpreter::fwdSplatInst(const glow::SplatInst *I) {
   llvm_unreachable("Unsupported tensor type");
 }
 
-void Interpreter::fwdInsertTensorInst(const glow::InsertTensorInst *I) {
+void InterpreterFunction::fwdInsertTensorInst(const glow::InsertTensorInst *I) {
   Tensor *outT = getTensor(I->getDest());
   Tensor *inT = getTensor(I->getSrc());
   ElemKind k = outT->getElementType();
@@ -708,7 +706,8 @@ void Interpreter::fwdInsertTensorInst(const glow::InsertTensorInst *I) {
   llvm_unreachable("Unsupported tensor type");
 }
 
-void Interpreter::fwdExtractTensorInst(const glow::ExtractTensorInst *I) {
+void InterpreterFunction::fwdExtractTensorInst(
+    const glow::ExtractTensorInst *I) {
   Tensor *outT = getTensor(I->getDest());
   Tensor *inT = getTensor(I->getSrc());
   ElemKind k = outT->getElementType();
@@ -727,7 +726,7 @@ void Interpreter::fwdExtractTensorInst(const glow::ExtractTensorInst *I) {
   llvm_unreachable("Unsupported tensor type");
 }
 
-void Interpreter::fwdGatherInst(const glow::GatherInst *I) {
+void InterpreterFunction::fwdGatherInst(const glow::GatherInst *I) {
   Tensor *dataT = getTensor(I->getData());
   Tensor *indicesT = getTensor(I->getIndices());
   Tensor *outT = getTensor(I->getDest());
@@ -744,7 +743,8 @@ void Interpreter::fwdGatherInst(const glow::GatherInst *I) {
   }
 }
 
-void Interpreter::fwdScatterAssignInst(const glow::ScatterAssignInst *I) {
+void InterpreterFunction::fwdScatterAssignInst(
+    const glow::ScatterAssignInst *I) {
   Tensor *dataT = getTensor(I->getData());
   Tensor *indicesT = getTensor(I->getIndices());
   Tensor *slicesT = getTensor(I->getSlices());
@@ -766,7 +766,7 @@ void Interpreter::fwdScatterAssignInst(const glow::ScatterAssignInst *I) {
 //                      Local Response Normalization
 //===----------------------------------------------------------------------===//
 
-void Interpreter::fwdLocalResponseNormalizationInst(
+void InterpreterFunction::fwdLocalResponseNormalizationInst(
     const glow::LocalResponseNormalizationInst *I) {
   auto inW = getWeightHandle(I->getSrc());
   auto outW = getWeightHandle(I->getDest());
@@ -821,7 +821,7 @@ void Interpreter::fwdLocalResponseNormalizationInst(
   }
 }
 
-void Interpreter::fwdLocalResponseNormalizationGradInst(
+void InterpreterFunction::fwdLocalResponseNormalizationGradInst(
     const glow::LocalResponseNormalizationGradInst *I) {
   auto inW = getWeightHandle(I->getSrc());
   auto inG = getWeightHandle(I->getSrcGrad());
@@ -895,7 +895,7 @@ void Interpreter::fwdLocalResponseNormalizationGradInst(
 //                       Arithmetic operations
 //===----------------------------------------------------------------------===//
 
-void Interpreter::fwdElementAddInst(const ElementAddInst *I) {
+void InterpreterFunction::fwdElementAddInst(const ElementAddInst *I) {
   if (getTensor(I->getLHS())->getType().isQuantizedType()) {
     auto lhsTy = I->getLHS()->getType();
     auto rhsTy = I->getRHS()->getType();
@@ -936,7 +936,7 @@ void Interpreter::fwdElementAddInst(const ElementAddInst *I) {
   }
 }
 
-void Interpreter::fwdElementSubInst(const ElementSubInst *I) {
+void InterpreterFunction::fwdElementSubInst(const ElementSubInst *I) {
   if (getTensor(I->getLHS())->getType().isQuantizedType()) {
     auto destTy = I->getDest()->getType();
     auto lhsTy = I->getLHS()->getType();
@@ -972,7 +972,7 @@ void Interpreter::fwdElementSubInst(const ElementSubInst *I) {
   }
 }
 
-void Interpreter::fwdElementMulInst(const ElementMulInst *I) {
+void InterpreterFunction::fwdElementMulInst(const ElementMulInst *I) {
   if (getTensor(I->getLHS())->getType().isQuantizedType()) {
     auto lhsTy = I->getLHS()->getType();
     auto rhsTy = I->getRHS()->getType();
@@ -1002,7 +1002,7 @@ void Interpreter::fwdElementMulInst(const ElementMulInst *I) {
   }
 }
 
-void Interpreter::fwdElementDivInst(const ElementDivInst *I) {
+void InterpreterFunction::fwdElementDivInst(const ElementDivInst *I) {
   if (getTensor(I->getLHS())->getType().isQuantizedType()) {
     auto destTy = I->getDest()->getType();
     auto lhsTy = I->getLHS()->getType();
@@ -1038,7 +1038,7 @@ void Interpreter::fwdElementDivInst(const ElementDivInst *I) {
   }
 }
 
-void Interpreter::fwdElementMaxInst(const ElementMaxInst *I) {
+void InterpreterFunction::fwdElementMaxInst(const ElementMaxInst *I) {
   if (getTensor(I->getLHS())->getType().isQuantizedType()) {
     auto lhsTy = I->getLHS()->getType();
     auto rhsTy = I->getRHS()->getType();
@@ -1074,7 +1074,7 @@ void Interpreter::fwdElementMaxInst(const ElementMaxInst *I) {
   }
 }
 
-void Interpreter::fwdElementMinInst(const ElementMinInst *I) {
+void InterpreterFunction::fwdElementMinInst(const ElementMinInst *I) {
   if (getTensor(I->getLHS())->getType().isQuantizedType()) {
     auto lhsTy = I->getLHS()->getType();
     auto rhsTy = I->getRHS()->getType();
@@ -1109,7 +1109,7 @@ void Interpreter::fwdElementMinInst(const ElementMinInst *I) {
 
 // For both quantized and non-quantized CmpLTE, we set the result to 1.0/0.0.
 // In the quantized case, we assume that the scale params are (1.0, 0).
-void Interpreter::fwdElementCmpLTEInst(const ElementCmpLTEInst *I) {
+void InterpreterFunction::fwdElementCmpLTEInst(const ElementCmpLTEInst *I) {
   if (getTensor(I->getLHS())->getType().isQuantizedType()) {
     auto lhsTy = I->getLHS()->getType();
     auto rhsTy = I->getRHS()->getType();
@@ -1140,7 +1140,7 @@ void Interpreter::fwdElementCmpLTEInst(const ElementCmpLTEInst *I) {
   }
 }
 
-void Interpreter::fwdElementCmpEQInst(const ElementCmpEQInst *I) {
+void InterpreterFunction::fwdElementCmpEQInst(const ElementCmpEQInst *I) {
   auto outW = getWeightHandle<size_t>(I->getDest());
   auto lhsW = getWeightHandle<size_t>(I->getLHS());
   auto rhsW = getWeightHandle<size_t>(I->getRHS());
@@ -1149,7 +1149,7 @@ void Interpreter::fwdElementCmpEQInst(const ElementCmpEQInst *I) {
   }
 }
 
-void Interpreter::fwdElementPowInst(const glow::ElementPowInst *I) {
+void InterpreterFunction::fwdElementPowInst(const glow::ElementPowInst *I) {
   auto baseW = getWeightHandle(I->getBase());
   float exp = I->getExp();
   auto outW = getWeightHandle(I->getDest());
@@ -1158,7 +1158,7 @@ void Interpreter::fwdElementPowInst(const glow::ElementPowInst *I) {
   }
 }
 
-void Interpreter::fwdElementLogInst(const ElementLogInst *I) {
+void InterpreterFunction::fwdElementLogInst(const ElementLogInst *I) {
   auto inW = getWeightHandle(I->getSrc());
   auto outW = getWeightHandle(I->getDest());
   for (size_t i = 0, e = inW.size(); i < e; i++) {
@@ -1167,7 +1167,8 @@ void Interpreter::fwdElementLogInst(const ElementLogInst *I) {
   }
 }
 
-void Interpreter::fwdElementSelectInst(const glow::ElementSelectInst *I) {
+void InterpreterFunction::fwdElementSelectInst(
+    const glow::ElementSelectInst *I) {
   if (getTensor(I->getLHS())->getType().isQuantizedType()) {
     auto destTy = I->getDest()->getType();
     auto lhsTy = I->getLHS()->getType();
@@ -1203,7 +1204,7 @@ void Interpreter::fwdElementSelectInst(const glow::ElementSelectInst *I) {
   }
 }
 
-void Interpreter::fwdMatMulInst(const glow::MatMulInst *I) {
+void InterpreterFunction::fwdMatMulInst(const glow::MatMulInst *I) {
   if (getTensor(I->getLHS())->getType().isQuantizedType()) {
     auto lhs = getTensor(I->getLHS())->getHandle<int8_t>();
     auto rhs = getTensor(I->getRHS())->getHandle<int8_t>();
@@ -1271,7 +1272,7 @@ void Interpreter::fwdMatMulInst(const glow::MatMulInst *I) {
   }
 }
 
-void Interpreter::fwdBatchedAddInst(const glow::BatchedAddInst *I) {
+void InterpreterFunction::fwdBatchedAddInst(const glow::BatchedAddInst *I) {
   if (getTensor(I->getBatch())->getType().isQuantizedType()) {
     auto batch = getTensor(I->getBatch())->getHandle<int8_t>();
     auto slice = getTensor(I->getSlice())->getHandle<int8_t>();
@@ -1336,7 +1337,8 @@ void Interpreter::fwdBatchedAddInst(const glow::BatchedAddInst *I) {
   }
 }
 
-void Interpreter::fwdBatchedReduceAddInst(const glow::BatchedReduceAddInst *I) {
+void InterpreterFunction::fwdBatchedReduceAddInst(
+    const glow::BatchedReduceAddInst *I) {
   static_assert(max_tensor_dimensions == 6,
                 "Loops below assume max_tensor_dimensions = 6.");
 
@@ -1434,7 +1436,8 @@ void Interpreter::fwdBatchedReduceAddInst(const glow::BatchedReduceAddInst *I) {
   }
 }
 
-void Interpreter::fwdSparseLengthsSumInst(const SparseLengthsSumInst *I) {
+void InterpreterFunction::fwdSparseLengthsSumInst(
+    const SparseLengthsSumInst *I) {
   auto out = getTensor(I->getDest());
   auto data = getTensor(I->getData());
   auto indices = getTensor(I->getIndices());
@@ -1506,7 +1509,7 @@ static void fwdTopK(Tensor *outW, Tensor *indW, Tensor *inW, size_t k) {
   }
 }
 
-void Interpreter::fwdTopKInst(const TopKInst *I) {
+void InterpreterFunction::fwdTopKInst(const TopKInst *I) {
   auto outW = getTensor(I->getValues());
   auto indW = getTensor(I->getIndices());
   auto inW = getTensor(I->getInput());
@@ -1523,18 +1526,19 @@ void Interpreter::fwdTopKInst(const TopKInst *I) {
 //                  Tensor allocation operations
 //===----------------------------------------------------------------------===//
 
-void Interpreter::fwdAllocActivationInst(const AllocActivationInst *I) {
+void InterpreterFunction::fwdAllocActivationInst(const AllocActivationInst *I) {
   getOrCreateTensor(I);
 }
 
-void Interpreter::fwdDeallocActivationInst(const DeallocActivationInst *I) {
+void InterpreterFunction::fwdDeallocActivationInst(
+    const DeallocActivationInst *I) {
   deleteTensor(I->getSrc());
 }
 
 /// Prints a value of the instruction's operand.
 /// In most cases it will be the name of the variable and the value of the
 /// tensor.
-void Interpreter::fwdDebugPrintInst(const DebugPrintInst *I) {
+void InterpreterFunction::fwdDebugPrintInst(const DebugPrintInst *I) {
   auto *V = I->getSrc();
   llvm::outs() << I->getName() << ": ";
   // Dump the content of a value.
@@ -1548,7 +1552,7 @@ void Interpreter::fwdDebugPrintInst(const DebugPrintInst *I) {
 //                Instructions used by Quantization
 //===----------------------------------------------------------------------===//
 
-void Interpreter::fwdQuantizationProfileInst(
+void InterpreterFunction::fwdQuantizationProfileInst(
     const glow::QuantizationProfileInst *I) {
   auto inputTensor = getWeightHandle(I->getInputTensor());
   auto currentHistogram = getWeightHandle(I->getHistogram());
@@ -1563,7 +1567,7 @@ void Interpreter::fwdQuantizationProfileInst(
 }
 /// Quantize floating point tensor. Scale and Offset are based on return type
 /// of the instruction \p I.
-void Interpreter::fwdQuantizeInst(const glow::QuantizeInst *I) {
+void InterpreterFunction::fwdQuantizeInst(const glow::QuantizeInst *I) {
   auto srcHandle = getWeightHandle(I->getSrc());
   auto *destTensor = getTensor(I->getDest());
 
@@ -1577,7 +1581,7 @@ void Interpreter::fwdQuantizeInst(const glow::QuantizeInst *I) {
 }
 /// Dequantize integer tensor. Scale and Offset are based
 /// on the source tensor type.
-void Interpreter::fwdDequantizeInst(const glow::DequantizeInst *I) {
+void InterpreterFunction::fwdDequantizeInst(const glow::DequantizeInst *I) {
   auto *srcTensor = getTensor(I->getSrc());
   auto destHandle = getWeightHandle(I->getDest());
 
@@ -1590,7 +1594,8 @@ void Interpreter::fwdDequantizeInst(const glow::DequantizeInst *I) {
   }
 }
 
-void Interpreter::fwdRescaleQuantizedInst(const glow::RescaleQuantizedInst *I) {
+void InterpreterFunction::fwdRescaleQuantizedInst(
+    const glow::RescaleQuantizedInst *I) {
   auto src = I->getSrc();
   auto dest = I->getDest();
   auto srcTy = src->getType();
@@ -1608,7 +1613,7 @@ void Interpreter::fwdRescaleQuantizedInst(const glow::RescaleQuantizedInst *I) {
   }
 }
 
-void Interpreter::fwdIntLookupTableInst(const IntLookupTableInst *I) {
+void InterpreterFunction::fwdIntLookupTableInst(const IntLookupTableInst *I) {
   auto srcH = getWeightHandle<int8_t>(I->getSrc());
   auto destH = getWeightHandle<int8_t>(I->getDest());
   auto mappingH = getWeightHandle<int8_t>(I->getMapping());


### PR DESCRIPTION
Finally I think things are in shape to bite off #1234.  This PR creates the CompiledFunction interface, and modifies Backend::init (now known as `compile`) to produce it, and implements that interface in the Interpreter.  (All other tests and backends are not ported yet).

What do you all think?  (In retrospect maybe the interpreter was a weird place to start, because its "forward pass" is very heavyweight.  But hopefully that doesn't cloud things too much.)