### PR TITLE
[GraphIR] Have LoadNode::getVariable return Variable

### DIFF
--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -677,7 +677,7 @@ void ConcatNode::verify() const {
 
 void LoadNode::verify() const {
   // Loads are restricted to Variables.
-  assert(llvm::isa<Variable>(getVariable().getNode()));
+  assert(llvm::isa<Variable>(getAddress().getNode()));
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Importer/ProtobufLoader.cpp
+++ b/lib/Importer/ProtobufLoader.cpp
@@ -86,8 +86,7 @@ Variable *ProtobufLoader::getVariableByName(llvm::StringRef name) const {
 
   assert(llvm::isa<LoadNode>(node) && "Not a load of a variable");
 
-  return llvm::cast<Variable>(
-      llvm::cast<LoadNode>(node)->getVariable().getNode());
+  return llvm::cast<LoadNode>(node)->getVariable();
 }
 
 bool ProtobufLoader::hasNodeByName(llvm::StringRef name) const {

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -53,7 +53,10 @@ int main(int argc, char **argv) {
                     "intended to save the final result of a network.");
 
   BB.newNode("Load")
-      .addInput("Variable")
+      .addInput("Address")
+      .addExtraMethod("Variable *getVariable() const;",
+                      "Variable *LoadNode::getVariable() const { return "
+                      "llvm::cast<Variable>(Address_.getNode()); };")
       .addResultFromCtorArg()
       .setDocstring("Load/Copy a variable into local memory. "
                     "If the memory space of the variable is the same as the "


### PR DESCRIPTION
Change the name of the input to Address so that we can use getVariable
to return the properly typed variable.

NFC.