### PR TITLE
Add the 1to1 mode (-1:1 range) to the image classifier application

### DIFF
--- a/tests/images/run.sh
+++ b/tests/images/run.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 ./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to1 -m=resnet50 $@
-./bin/image-classifier tests/images/imagenet/*.png -image_mode=128to127 -m=vgg19 $@
-./bin/image-classifier tests/images/imagenet/*.png -image_mode=128to127 -m=squeezenet $@
+./bin/image-classifier tests/images/imagenet/*.png -image_mode=neg128to127 -m=vgg19 $@
+./bin/image-classifier tests/images/imagenet/*.png -image_mode=neg128to127 -m=squeezenet $@
 ./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to256 -m=zfnet512 $@
 ./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to1 -m=densenet121 $@
 ./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to1 -m=shufflenet $@
@@ -10,10 +10,10 @@ for png_filename in tests/images/imagenet/*.png; do
   ./bin/image-classifier $png_filename -image_mode=0to1 -m=resnet50/model.onnx $@
 done
 for png_filename in tests/images/imagenet/*.png; do
-  ./bin/image-classifier $png_filename -image_mode=128to127 -m=vgg19/model.onnx $@
+  ./bin/image-classifier $png_filename -image_mode=neg128to127 -m=vgg19/model.onnx $@
 done
 for png_filename in tests/images/imagenet/*.png; do
-  ./bin/image-classifier $png_filename -image_mode=128to127 -m=squeezenet/model.onnx $@
+  ./bin/image-classifier $png_filename -image_mode=neg128to127 -m=squeezenet/model.onnx $@
 done
 for png_filename in tests/images/imagenet/*.png; do
   ./bin/image-classifier $png_filename -image_mode=0to256 -m=zfnet512/model.onnx $@

--- a/tools/loader/ImageClassifier.cpp
+++ b/tools/loader/ImageClassifier.cpp
@@ -28,31 +28,31 @@
 using namespace glow;
 
 enum class ImageNormalizationMode {
-  k1to1,    // Values are in the range: -1 and 1.
+  kneg1to1,  // Values are in the range: -1 and 1.
   k0to1,     // Values are in the range: 0 and 1.
   k0to256,   // Values are in the range: 0 and 256.
-  k128to127, // Values are in the range: -128 .. 127
+  kneg128to127, // Values are in the range: -128 .. 127
 };
 
 ImageNormalizationMode strToImageNormalizationMode(const std::string &str) {
   return llvm::StringSwitch<ImageNormalizationMode>(str)
-      .Case("1to1", ImageNormalizationMode::k1to1)
+      .Case("neg1to1", ImageNormalizationMode::kneg1to1)
       .Case("0to1", ImageNormalizationMode::k0to1)
       .Case("0to256", ImageNormalizationMode::k0to256)
-      .Case("128to127", ImageNormalizationMode::k128to127);
+      .Case("neg128to127", ImageNormalizationMode::kneg128to127);
   GLOW_ASSERT(false && "Unknown image format");
 }
 
 /// Convert the normalization to numeric floating poing ranges.
 std::pair<float, float> normModeToRange(ImageNormalizationMode mode) {
   switch (mode) {
-  case ImageNormalizationMode::k1to1:
+  case ImageNormalizationMode::kneg1to1:
     return {-1., 1.};
   case ImageNormalizationMode::k0to1:
     return {0., 1.0};
   case ImageNormalizationMode::k0to256:
     return {0., 256.0};
-  case ImageNormalizationMode::k128to127:
+  case ImageNormalizationMode::kneg128to127:
     return {-128., 127.};
   default:
     GLOW_ASSERT(false && "Image format not defined.");
@@ -69,13 +69,13 @@ llvm::cl::list<std::string> inputImageFilenames(llvm::cl::Positional,
 llvm::cl::opt<ImageNormalizationMode> imageMode(
     "image_mode", llvm::cl::desc("Specify the image mode:"), llvm::cl::Required,
     llvm::cl::cat(imageLoaderCat),
-    llvm::cl::values(clEnumValN(ImageNormalizationMode::k1to1, "1to1",
+    llvm::cl::values(clEnumValN(ImageNormalizationMode::kneg1to1, "neg1to1",
                                 "Values are in the range: -1 and 1"),
                      clEnumValN(ImageNormalizationMode::k0to1, "0to1",
                                 "Values are in the range: 0 and 1"),
                      clEnumValN(ImageNormalizationMode::k0to256, "0to256",
                                 "Values are in the range: 0 and 256"),
-                     clEnumValN(ImageNormalizationMode::k128to127, "128to127",
+                     clEnumValN(ImageNormalizationMode::kneg128to127, "neg128to127",
                                 "Values are in the range: -128 .. 127")));
 llvm::cl::alias imageModeA("i", llvm::cl::desc("Alias for -image_mode"),
                            llvm::cl::aliasopt(imageMode),

--- a/tools/loader/ImageClassifier.cpp
+++ b/tools/loader/ImageClassifier.cpp
@@ -28,6 +28,7 @@
 using namespace glow;
 
 enum class ImageNormalizationMode {
+  k1to1,    // Values are in the range: -1 and 1.
   k0to1,     // Values are in the range: 0 and 1.
   k0to256,   // Values are in the range: 0 and 256.
   k128to127, // Values are in the range: -128 .. 127
@@ -35,6 +36,7 @@ enum class ImageNormalizationMode {
 
 ImageNormalizationMode strToImageNormalizationMode(const std::string &str) {
   return llvm::StringSwitch<ImageNormalizationMode>(str)
+      .Case("1to1", ImageNormalizationMode::k1to1)
       .Case("0to1", ImageNormalizationMode::k0to1)
       .Case("0to256", ImageNormalizationMode::k0to256)
       .Case("128to127", ImageNormalizationMode::k128to127);
@@ -44,6 +46,8 @@ ImageNormalizationMode strToImageNormalizationMode(const std::string &str) {
 /// Convert the normalization to numeric floating poing ranges.
 std::pair<float, float> normModeToRange(ImageNormalizationMode mode) {
   switch (mode) {
+  case ImageNormalizationMode::k1to1:
+    return {-1., 1.};
   case ImageNormalizationMode::k0to1:
     return {0., 1.0};
   case ImageNormalizationMode::k0to256:
@@ -65,7 +69,9 @@ llvm::cl::list<std::string> inputImageFilenames(llvm::cl::Positional,
 llvm::cl::opt<ImageNormalizationMode> imageMode(
     "image_mode", llvm::cl::desc("Specify the image mode:"), llvm::cl::Required,
     llvm::cl::cat(imageLoaderCat),
-    llvm::cl::values(clEnumValN(ImageNormalizationMode::k0to1, "0to1",
+    llvm::cl::values(clEnumValN(ImageNormalizationMode::k1to1, "1to1",
+                                "Values are in the range: -1 and 1"),
+                     clEnumValN(ImageNormalizationMode::k0to1, "0to1",
                                 "Values are in the range: 0 and 1"),
                      clEnumValN(ImageNormalizationMode::k0to256, "0to256",
                                 "Values are in the range: 0 and 256"),


### PR DESCRIPTION
We are working with models trained for inputs in the -1:1 range.
This small PR then proposes to add the "1to1" mode to the image classifier application.