### PR TITLE
[format] Speed up clang-format with xargs -P

### DIFF
--- a/utils/format.sh
+++ b/utils/format.sh
@@ -9,11 +9,7 @@ if [ $(which clang-format) ]; then
   FARRAY=( $FILES ) # count the number of files to process
   echo  Formatting ${#FARRAY[@]} files
 
-  for F in $FILES; do
-    clang-format -i $F
-    echo -n .
-  done
-  echo
+  echo "$FILES" | xargs -P8 -n1 clang-format -i
   echo "Done"
   exit
 fi


### PR DESCRIPTION
Maybe if I can format my PRs faster I'll forget to do it less often :-p.  The magic of parallelism takes format.sh from 9 to 2 seconds on my Macbook.