### PR TITLE
[Importer] Support "axis" and "axis_w" params of  "FC" op in Caffe2.

### DIFF
--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -132,14 +132,18 @@ struct PaddingTLBR {
   }
 };
 
-/// Collapse a tensor shape into two sizes: the first dimension and the size of
-/// the rest of the dimensions.
-/// For example, [7, 3, 4, 2] -> [7, 24]
-inline std::pair<size_t, size_t> flattenCdr(llvm::ArrayRef<size_t> dims) {
-  assert(dims.size() > 1);
+/// Collapse a tensor shape into two sizes: the first n dimensions and the size
+/// of the rest of the dimensions. For example, ([7, 3, 4, 2], 1) -> [7, 24]
+inline std::pair<size_t, size_t> flattenCdr(llvm::ArrayRef<size_t> dims,
+                                            size_t n = 1) {
+  assert(1 <= n && n < dims.size());
   size_t first = dims[0];
-  size_t rest = dims[1];
-  for (size_t i = 2; i < dims.size(); i++) {
+  for (size_t i = 1; i < n; i++) {
+    first *= dims[i];
+  }
+
+  size_t rest = dims[n];
+  for (size_t i = n + 1; i < dims.size(); i++) {
     rest *= dims[i];
   }
 

--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -79,26 +79,6 @@ protected:
     addNodeAsOutput(op, node);
   }
 
-  void loadFC(const OpType &op, ArgumentDictionaryTy &dict) {
-    const std::string &opName = loadOperatorName(op);
-    auto *in = getOrCreateVariableByName(op.input(0));
-    // Load weights.
-    Tensor *w = getTensorByName(op.input(1));
-    Tensor *b = getTensorByName(op.input(2));
-
-    // ONNX stores the transposed W matrix. In here we transpose W back.
-    Tensor wtag;
-    w->transpose(&wtag, {1, 0});
-
-    auto W = G_.getParent()->addVar(
-        new Variable("weights", VisibilityKind::Private, std::move(wtag)));
-    auto B = G_.getParent()->addVar(
-        new Variable("biases", VisibilityKind::Private, std::move(*b)));
-    auto *FC = G_.createFullyConnected(opName, in, W, B);
-
-    addNodeAsOutput(op, FC);
-  }
-
   void loadLRN(const OpType &op, ArgumentDictionaryTy &dict) {
     const std::string &opName = loadOperatorName(op);
     auto *in = getOrCreateVariableByName(op.input(0));
@@ -246,10 +226,6 @@ protected:
     }
     if (typeName == "Softmax") {
       loadSoftmax(op, dict);
-      return true;
-    }
-    if (typeName == "FC") {
-      loadFC(op, dict);
       return true;
     }
     if (typeName == "LRN") {


### PR DESCRIPTION
Since only Caffe2 support FC op, we move it to Caffe2.cpp. In ONNX, if the input is 2-dims, Gemm op can be used to represent FC. If the input has > 2dims, we can use Reshape+Gemm for FC layer.
According to Caffe2 FC defs, the input and weight don't have to be 2-dims, and they will be coerced into 2D dims for calculation. In Glow's FC node, the input will be flatten to 2-dims, but the weight needs to be 2D. Therefore, the weight loaded from Caffe2 model should be coerced into 2-dims before the FC node is created.
The "axis" and "axis_w" params of FC operators in Caffe2 are supported. https://caffe2.ai/docs/operators-catalogue.html#fc . The params are used in inception_v1 models. 