### PR TITLE
Cleanup a couple uses of getNthResult(0)

### DIFF
--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -109,6 +109,10 @@ public:
 
   void copyFrom(const Tensor *t) { payload_.copyFrom(t); }
 
+  /// \returns the output NodeValue from the Variable. Variables only have a
+  /// single output.
+  NodeValue getOutput() { return getNthResult(0); }
+
   unsigned getNumInputs() const;
   llvm::StringRef getInputName(unsigned idx) const;
   NodeValue &getNthInput(unsigned idx);

--- a/lib/Optimizer/Quantization.cpp
+++ b/lib/Optimizer/Quantization.cpp
@@ -50,11 +50,10 @@ Function *glow::profileQuantization(Function *F, llvm::StringRef newFuncName) {
 
   // Add Quantization Profile node to all floating point vars.
   for (const auto &var : G->getParent()->getVars()) {
-    if (var->getNthResult(0).getElementType() != ElemKind::FloatTy) {
+    if (var->getOutput().getElementType() != ElemKind::FloatTy) {
       continue;
     }
-    // Assuming varable has only a single output.
-    nodesToInstrument.insert(var->getNthResult(0));
+    nodesToInstrument.insert(var->getOutput());
   }
 
   for (const auto &node : nodesToInstrument) {

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -160,10 +160,10 @@ static Node *quantizeNode(Function *F, Node *node,
     assert(quantizedInputs.size() == 1 && "Invalid number of inputs");
     assert(qParams.size() == 1 && "Invalid number of quantized outputs");
 
-    auto QT = F->getParent()->uniqueType(
-        ElemKind::Int8QTy, S->getResult().dims(),
-        quantizedInputs[0]->getNthResult(0).getType()->getScale(),
-        quantizedInputs[0]->getNthResult(0).getType()->getOffset());
+    auto QT =
+        F->getParent()->uniqueType(ElemKind::Int8QTy, S->getResult().dims(),
+                                   quantizedInputs[0].getType()->getScale(),
+                                   quantizedInputs[0].getType()->getOffset());
 
     quantizedNode =
         F->createSlice(S->getName(), quantizedInputs[0], S->getStart(), QT);


### PR DESCRIPTION
- Variables always have a single output, so I added a getter for its NodeValue instead of `getNthResult(0)`
- Cleanup Quantization of SliceNode, where `getNthResult(0)` was incorrectly used instead of the NodeValue.