### PR TITLE
Introduce a NodeHandle type to make sure that use-lists of Nodes only contain uses by other Nodes

### DIFF
--- a/include/glow/Graph/Grad.h
+++ b/include/glow/Graph/Grad.h
@@ -30,7 +30,7 @@ class GraphGradMapper {
   /// The graph that we mutate.
   Function *F_;
   /// Maps activation values to their gradient values.
-  UnownedNodeValueMap map_;
+  std::unordered_map<NodeValue, NodeValue> map_;
 
 public:
   GraphGradMapper(Function *F) : F_(F) {}

--- a/include/glow/Graph/Node.h
+++ b/include/glow/Graph/Node.h
@@ -49,6 +49,8 @@ protected:
 
 public:
   /// Create a new value.
+  NodeValue() = default;
+  /// Create a new value.
   /*implicit*/ NodeValue(Node *N);
 
   /// Create a new value for result \p resNo.
@@ -177,28 +179,6 @@ public:
   const_iterator begin() { return ref_.begin(); }
   const_iterator end() { return ref_.end(); }
   NodeValue front() { return *begin(); }
-};
-
-/// A simple linear map that stores NodeValue without maintaining the reverse
-/// reference that allows the RAUW operation.
-class UnownedNodeValueMap {
-public:
-  /// A reference to some Node's result.
-  using ValRef = NodeValue;
-  using Entry = std::pair<ValRef, ValRef>;
-
-private:
-  std::list<Entry> entries_;
-
-public:
-  /// \register the node \p from as mapping to \p to.
-  void insert(NodeValue from, NodeValue to);
-
-  /// \returns True if N is in the map.
-  bool count(NodeValue from);
-
-  /// \returns the node that \p from is mapped to.
-  NodeValue get(NodeValue from);
 };
 
 /// A 'Use' is a use-list representation of a Node operand.

--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -28,7 +28,7 @@
 
 namespace glow {
 
-class Variable final : public Node {
+class Variable: public Node {
 public:
   /// Specifies the kind of training and initialization for the variable.
   /// Nodes that are marked as 'none' are not modified during the training
@@ -115,7 +115,7 @@ public:
 
   unsigned getNumInputs() const;
   llvm::StringRef getInputName(unsigned idx) const;
-  NodeValue &getNthInput(unsigned idx);
+  NodeValue getNthInput(unsigned idx);
   llvm::StringRef getOutputName(unsigned idx) const;
   bool hasSideEffects() const;
   std::string getDebugDesc() const;
@@ -129,7 +129,8 @@ public:
   llvm::hash_code getHash() const;
 };
 
-using VariableNode = Variable;
+class VariableNode: public Variable {
+};
 
 /// Calculate the size of the output tensor based on the convolution/pooling
 /// parameters.
@@ -160,6 +161,7 @@ llvm::hash_code hash_value(const glow::Type *T);
 llvm::hash_code hash_value(glow::Node *T);
 
 llvm::hash_code hash_value(const glow::NodeValue &T);
+llvm::hash_code hash_value(const glow::NodeHandle &T);
 
 } // namespace glow
 

--- a/lib/Graph/Grad.cpp
+++ b/lib/Graph/Grad.cpp
@@ -32,13 +32,13 @@ using llvm::isa;
 
 void GraphGradMapper::addGradient(NodeValue activation, NodeValue grad) {
   if (map_.count(activation)) {
-    auto curr = map_.get(activation);
+    auto curr = map_[activation];
     auto *sum = F_->createAdd("updateGrad", curr, grad);
-    map_.insert(activation, sum);
+    map_[activation] = sum;
     return;
   }
 
-  map_.insert(activation, grad);
+  map_[activation] = grad;
 }
 
 bool GraphGradMapper::hasGradient(NodeValue activation) {
@@ -46,7 +46,7 @@ bool GraphGradMapper::hasGradient(NodeValue activation) {
 }
 
 NodeValue GraphGradMapper::getGradient(NodeValue activation) {
-  return map_.get(activation);
+  return map_[activation];
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1812,7 +1812,7 @@ Function *Function::clone(llvm::StringRef newName,
   for (auto &N : newF->getNodes()) {
     // Fix each one of the inputs of this node.
     for (unsigned inp = 0, e = N.getNumInputs(); inp < e; inp++) {
-      NodeValue &input = N.getNthInput(inp);
+      auto input = N.getNthInput(inp);
 
       auto it = currToNew.find(input.getNode());
       if (it == currToNew.end()) {
@@ -1822,7 +1822,7 @@ Function *Function::clone(llvm::StringRef newName,
       }
 
       // Update the node with the edge to the current graph.
-      input.setOperand(it->second, input.getResNo());
+      N.setNthInput(inp, NodeValue(it->second, input.getResNo()));
     }
   }
 

--- a/lib/Graph/Node.cpp
+++ b/lib/Graph/Node.cpp
@@ -21,7 +21,7 @@
 
 using namespace glow;
 
-void NodeUse::setOperand(NodeValue &other) {
+void NodeUse::setOperand(NodeHandle &other) {
   if (other && site_->getNode()) {
     assert(site_->getType() == other.getType() &&
            "Setting operand to a node with a different type");
@@ -32,30 +32,14 @@ void NodeUse::setOperand(NodeValue &other) {
 NodeValue::NodeValue(Node *N) {
   assert((!N || (N->getNumResults() == 1)) &&
          "Constructing a value for a multi-res node");
-  setOperand(N, 0);
+  node_ = N;
+  resNo_ = 0;
 }
 
 NodeValue::NodeValue(Node *N, unsigned resNo) {
   assert(resNo < N->getNumResults() && "Invalid result number");
-  setOperand(N, resNo);
-}
-
-void NodeValue::setOperand(Node *v, unsigned resNo) {
-  if (node_ == v && resNo == resNo_) {
-    return;
-  }
-
-  if (node_) {
-    node_->removeUse(NodeUse(this));
-    node_ = nullptr;
-    resNo_ = 0;
-  }
-
-  if (v) {
-    node_ = v;
-    resNo_ = resNo;
-    v->addUse(NodeUse(this));
-  }
+  node_ = N;
+  resNo_ = resNo;
 }
 
 void NodeValue::replaceAllUsesOfWith(NodeValue v) {
@@ -65,15 +49,13 @@ void NodeValue::replaceAllUsesOfWith(NodeValue v) {
   auto &users = node_->getUsers();
   llvm::SmallVector<NodeUse, 4> usersVec(users.begin(), users.end());
   for (auto &U : usersVec) {
-    NodeValue *site = U.get();
+    NodeHandle *site = U.get();
     assert(site->getNode() == node_ && "Invalid user");
     if (site->getResNo() == getResNo()) {
       site->setOperand(v.getNode(), v.getResNo());
     }
   }
 }
-
-const NodeValue &Node::getPredicate() const { return predicate_; }
 
 void Node::setPredicate(const NodeValue &P) { predicate_ = P; }
 
@@ -124,6 +106,32 @@ bool Node::isEqual(const Node &other) const {
   return false;
 }
 
+NodeHandle::NodeHandle(Node *N) : NodeValue(N) { setOperand(N, 0); }
+
+NodeHandle::NodeHandle(Node *N, unsigned resNo) : NodeValue(N, resNo) {
+  setOperand(N, resNo);
+}
+
+void NodeHandle::setOperand(Node *v, unsigned resNo) {
+  if (node_ == v && resNo == resNo_) {
+    return;
+  }
+
+  if (node_) {
+    node_->removeUse(NodeUse(this));
+    node_ = nullptr;
+    resNo_ = 0;
+  }
+
+  if (v) {
+    node_ = v;
+    resNo_ = resNo;
+    v->addUse(NodeUse(this));
+  }
+}
+
+const NodeValue Node::getPredicate() const { return predicate_; }
+
 namespace {
 class HashNodeVisitor : public NodeVisitor<HashNodeVisitor, llvm::hash_code> {
   using hash_code = llvm::hash_code;
@@ -166,8 +174,7 @@ ElemKind NodeValue::getElementType() const {
 }
 
 void UnownedNodeValueMap::insert(NodeValue from, NodeValue to) {
-  entries_.push_front(
-      {{from.getNode(), from.getResNo()}, {to.getNode(), to.getResNo()}});
+  entries_.push_front({from, to});
 }
 
 NodeValue UnownedNodeValueMap::get(NodeValue from) {
@@ -175,8 +182,8 @@ NodeValue UnownedNodeValueMap::get(NodeValue from) {
     auto &F = E.first;
     auto &T = E.second;
 
-    if (F.first == from.getNode() && F.second == from.getResNo()) {
-      return NodeValue(T.first, T.second);
+    if (F == from) {
+      return T;
     }
   }
 
@@ -187,7 +194,7 @@ NodeValue UnownedNodeValueMap::get(NodeValue from) {
 bool UnownedNodeValueMap::count(NodeValue from) {
   for (auto &E : entries_) {
     auto &F = E.first;
-    if (F.first == from.getNode() && F.second == from.getResNo()) {
+    if (F == from) {
       return true;
     }
   }
@@ -221,7 +228,7 @@ llvm::StringRef Node::getInputName(unsigned idx) const {
     llvm_unreachable("Unhandled node");
   }
 }
-NodeValue &Node::getNthInput(unsigned idx) {
+NodeValue Node::getNthInput(unsigned idx) {
   switch (getKind()) {
 #define DEF_NODE(CLASS, NAME)                                                  \
   case glow::Kinded::Kind::CLASS##Kind:                                        \
@@ -232,11 +239,22 @@ NodeValue &Node::getNthInput(unsigned idx) {
   }
 }
 
-const NodeValue &Node::getNthInput(unsigned idx) const {
+const NodeValue Node::getNthInput(unsigned idx) const {
   switch (getKind()) {
 #define DEF_NODE(CLASS, NAME)                                                  \
   case glow::Kinded::Kind::CLASS##Kind:                                        \
     return static_cast<CLASS *>(const_cast<Node *>(this))->getNthInput(idx);
+#include "AutoGenNodes.def"
+  default:
+    llvm_unreachable("Unhandled node");
+  }
+}
+
+void Node::setNthInput(unsigned idx, NodeValue val) {
+  switch (getKind()) {
+#define DEF_NODE(CLASS, NAME)                                                  \
+  case glow::Kinded::Kind::CLASS##Kind:                                        \
+    return static_cast<CLASS *>(this)->setNthInput(idx, val);
 #include "AutoGenNodes.def"
   default:
     llvm_unreachable("Unhandled node");

--- a/lib/Graph/Node.cpp
+++ b/lib/Graph/Node.cpp
@@ -173,35 +173,6 @@ ElemKind NodeValue::getElementType() const {
   return getType()->getElementType();
 }
 
-void UnownedNodeValueMap::insert(NodeValue from, NodeValue to) {
-  entries_.push_front({from, to});
-}
-
-NodeValue UnownedNodeValueMap::get(NodeValue from) {
-  for (auto &E : entries_) {
-    auto &F = E.first;
-    auto &T = E.second;
-
-    if (F == from) {
-      return T;
-    }
-  }
-
-  llvm_unreachable("Invalid node");
-  return NodeValue(nullptr, 0);
-}
-
-bool UnownedNodeValueMap::count(NodeValue from) {
-  for (auto &E : entries_) {
-    auto &F = E.first;
-    if (F == from) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
 llvm::ArrayRef<size_t> NodeValue::dims() const { return getType()->dims(); }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -113,7 +113,7 @@ llvm::StringRef Variable::getInputName(unsigned idx) const {
   llvm_unreachable("Invalid index");
 }
 
-NodeValue &Variable::getNthInput(unsigned idx) {
+NodeValue Variable::getNthInput(unsigned idx) {
   llvm_unreachable("Invalid index");
 }
 
@@ -717,6 +717,10 @@ llvm::hash_code hash_value(const glow::Type *T) {
 llvm::hash_code hash_value(glow::Node *N) { return N->getHash(); }
 
 llvm::hash_code hash_value(const glow::NodeValue &NV) {
+  return llvm::hash_combine(NV.getNode(), NV.getResNo());
+}
+
+llvm::hash_code hash_value(const glow::NodeHandle &NV) {
   return llvm::hash_combine(NV.getNode(), NV.getResNo());
 }
 } // namespace glow

--- a/lib/IR/IRGen.cpp
+++ b/lib/IR/IRGen.cpp
@@ -38,7 +38,7 @@ using llvm::isa;
 
 /// Helper function that \returns the number of times the same consecutive
 /// NodeValue in \p inputs is found, starting from index \p i.
-static size_t getConsecutiveSameNodeCount(llvm::ArrayRef<NodeValue> inputs,
+static size_t getConsecutiveSameNodeCount(NodeValueArrayRef inputs,
                                           const size_t i) {
   assert(i < inputs.size() && "Index must fit inside the size of the inputs.");
   for (size_t j = i, e = inputs.size(); j < e; j++) {

--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -968,7 +968,7 @@ static int tryToConcatAlongSameSizeSubTensor(llvm::ArrayRef<NodeValue> inputs,
 // ReshapeNode, and the input tensors of these input nodes have same number of
 // dimensions, otherwise returns false.
 static bool
-tryToGetNewConcatInputs(llvm::ArrayRef<NodeValue> originalConcatInputs,
+tryToGetNewConcatInputs(NodeValueArrayRef originalConcatInputs,
                         llvm::SmallVectorImpl<NodeValue> &newConcatInputs) {
   // Go through the input nodes of CN, check if they are all ReshapeNode,
   // and if the input tensors of these input nodes have same number of
@@ -1017,7 +1017,7 @@ static NodeValue simplifyConcatNode(Function *F, ConcatNode *CN) {
     // Check if any of the inputs are ConcatNode.
     llvm::SmallVector<NodeValue, 16> newInputs;
     bool merged = false;
-    for (auto input : inputs) {
+    for (auto &input : inputs) {
       newInputs.push_back(input);
       auto *CNI = dyn_cast<ConcatNode>(input);
       // Bail if it is not a ConcatNode or it is a concat node with a diffrent
@@ -1237,7 +1237,7 @@ static void optimizeReshape(Function *F) {
     auto *reshapeNode = dyn_cast<ReshapeNode>(&node);
     if (!reshapeNode)
       continue;
-    auto &inputNode = reshapeNode->getNthInput(0);
+    auto inputNode = reshapeNode->getNthInput(0);
     // Eliminate ReshapeNode when the input is already the correct shape.
     if (inputNode.dims() == reshapeNode->getResult().dims()) {
       reshapeNode->getResult().replaceAllUsesOfWith(inputNode);

--- a/lib/Optimizer/Lower.cpp
+++ b/lib/Optimizer/Lower.cpp
@@ -445,10 +445,10 @@ void computeBatchNormalizationWeights(Function *F, BatchNormalizationNode &BN) {
         llvm::isa<BatchNormalizationGradNode>(N))
       for (size_t i = 0; i < N.getNumInputs(); i++) {
         if (N.getNthInput(i) == mean) {
-          N.getNthInput(i) = newMean;
+          N.setNthInput(i, NodeValue(newMean));
         }
         if (N.getNthInput(i) == var) {
-          N.getNthInput(i) = newVar;
+          N.setNthInput(i, NodeValue(newVar));
         }
       }
 

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -64,7 +64,7 @@ quantizeInputs(Function *F, Node *node,
   llvm::SmallVector<NodeValue, 6> quantizedInputs;
 
   for (unsigned i = 0, e = node->getNumInputs(); i < e; ++i) {
-    NodeValue &NV = node->getNthInput(i);
+    auto NV = node->getNthInput(i);
 
     // Do not quantize non floating point type, e.g., Index type.
     if (NV.getElementType() != ElemKind::FloatTy) {

--- a/tests/unittests/graphTest.cpp
+++ b/tests/unittests/graphTest.cpp
@@ -83,19 +83,19 @@ TEST(Graph, useList) {
   // Therefore those checks are currently inverted but should be
   // fixed eventually.
   // Test with implicit temporary NodeValue.
-  EXPECT_FALSE /*TRUE*/ (conv->getFilter()->hasOneUse());
-  EXPECT_EQ(conv->getFilter()->getNumUsers(), 2 /*should be one, really*/);
+  EXPECT_TRUE(conv->getFilter()->hasOneUse());
+  EXPECT_EQ(conv->getFilter()->getNumUsers(), 1);
 
   // Test with explicit temporary NodeValue.
   Node *nodeFilter;
   {
     NodeValue tmp = conv->getFilter();
-    EXPECT_FALSE /*TRUE*/ (tmp->hasOneUse());
-    EXPECT_EQ(tmp->getNumUsers(), 2 /*should be one, really*/);
+    EXPECT_TRUE(tmp->hasOneUse());
+    EXPECT_EQ(tmp->getNumUsers(), 1);
     nodeFilter = tmp.getNode();
     // Test with NodeValue still around.
-    EXPECT_FALSE /*TRUE*/ (nodeFilter->hasOneUse());
-    EXPECT_EQ(nodeFilter->getNumUsers(), 2 /*should be one, really*/);
+    EXPECT_TRUE(nodeFilter->hasOneUse());
+    EXPECT_EQ(nodeFilter->getNumUsers(), 1);
   }
 
   // Test with NodeValue took out.
@@ -105,8 +105,8 @@ TEST(Graph, useList) {
   // Same kind of test but with the convolution node itself.
   {
     NodeValue tmpConvRes(conv, 0);
-    EXPECT_EQ(conv->getNumUsers(), 1 /*should be zero*/);
-    EXPECT_EQ(tmpConvRes->getNumUsers(), 1 /*should be zero*/);
+    EXPECT_EQ(conv->getNumUsers(), 0);
+    EXPECT_EQ(tmpConvRes->getNumUsers(), 0);
   }
 
   // Add a couple of uses to conv and make sure it reflects on its use list.
@@ -119,10 +119,10 @@ TEST(Graph, useList) {
 
   {
     NodeValue tmpConvRes(conv, 0);
-    EXPECT_FALSE /*TRUE*/ (tmpConvRes->hasOneUse());
-    EXPECT_FALSE /*TRUE*/ (conv->hasOneUse());
-    EXPECT_EQ(conv->getNumUsers(), 2 /*should be one*/);
-    EXPECT_EQ(tmpConvRes->getNumUsers(), 2 /*should be one*/);
+    EXPECT_TRUE(tmpConvRes->hasOneUse());
+    EXPECT_TRUE(conv->hasOneUse());
+    EXPECT_EQ(conv->getNumUsers(), 1);
+    EXPECT_EQ(tmpConvRes->getNumUsers(), 1);
   }
 
   F->createSave("Save", conv, K);
@@ -136,8 +136,8 @@ TEST(Graph, useList) {
     NodeValue tmpConvRes(conv, 0);
     EXPECT_FALSE(tmpConvRes->hasOneUse());
     EXPECT_FALSE(conv->hasOneUse());
-    EXPECT_EQ(conv->getNumUsers(), 3 /*should be two*/);
-    EXPECT_EQ(tmpConvRes->getNumUsers(), 3 /*should be two*/);
+    EXPECT_EQ(conv->getNumUsers(), 2);
+    EXPECT_EQ(tmpConvRes->getNumUsers(), 2);
   }
 }
 

--- a/tools/ClassGen/MemberType.h
+++ b/tools/ClassGen/MemberType.h
@@ -41,7 +41,7 @@ inline const char *getReturnTypename(MemberType type) {
                                "llvm::ArrayRef<float>",
                                "llvm::ArrayRef<unsigned>",
                                "llvm::ArrayRef<size_t>",
-                               "llvm::ArrayRef<NodeValue>",
+                               "NodeValueArrayRef",
                                nullptr};
   return returnTypes[(int)type];
 }
@@ -55,9 +55,23 @@ inline const char *getStorageTypename(MemberType type) {
                                 "std::vector<float>",
                                 "std::vector<unsigned>",
                                 "std::vector<size_t>",
-                                "std::vector<NodeValue>",
+                                "std::vector<NodeHandle>",
                                 nullptr};
   return storageTypes[(int)type];
+}
+
+inline const char *getCtorArgTypename(MemberType type) {
+  const char *ctorArgTypes[] = {"TypeRef",
+                                "float",
+                                "unsigned",
+                                "size_t",
+                                "std::string",
+                                "std::vector<float>",
+                                "std::vector<unsigned>",
+                                "std::vector<size_t>",
+                                "std::vector<NodeValue>",
+                                nullptr};
+  return ctorArgTypes[(int)type];
 }
 
 #endif // GLOW_TOOLS_CLASSGEN_MEMBERTYPE_H


### PR DESCRIPTION
This PR consists of three major changes:
- It introduces a new type NodeHandle that is used instead of NodeValue inside Nodes to reference the results of other Nodes. NodeHandles register themselves as users in the use-lists. NodeValue becomes a simple POD which does not register itself in the use-lists.
- The affected APIs are updated to use NodeHandle instead of NodeValue where appropriate
- The UnownedNodeValueMap type is removed as it is not needed anymore