### PR TITLE
Provide the functionality to iterate over all nodes referencing a given node

### DIFF
--- a/lib/Graph/Node.cpp
+++ b/lib/Graph/Node.cpp
@@ -106,9 +106,12 @@ bool Node::isEqual(const Node &other) const {
   return false;
 }
 
-NodeHandle::NodeHandle(Node *N) : NodeValue(N) { setOperand(N, 0); }
+NodeHandle::NodeHandle(Node *parent, Node *N) : NodeValue(N), parent_(parent) {
+  setOperand(N, 0);
+}
 
-NodeHandle::NodeHandle(Node *N, unsigned resNo) : NodeValue(N, resNo) {
+NodeHandle::NodeHandle(Node *parent, Node *N, unsigned resNo)
+    : NodeValue(N, resNo), parent_(parent) {
   setOperand(N, resNo);
 }
 

--- a/tests/unittests/graphTest.cpp
+++ b/tests/unittests/graphTest.cpp
@@ -141,6 +141,27 @@ TEST(Graph, useList) {
   }
 }
 
+TEST(Graph, useListIteration) {
+  Module MD;
+  Function *F = MD.createFunction("F");
+  IRFunction M(F);
+  Node *K = MD.createVariable(ElemKind::FloatTy, {4, 320, 200, 3}, "input");
+
+  EXPECT_EQ(K->getNumUsers(), 0);
+
+  ConvolutionNode *conv1 = F->createConv("Conv1", K, 16, 3, 2, 3, 1);
+  ConvolutionNode *conv2 = F->createConv("Conv2", K, 16, 3, 2, 3, 1);
+  // Check the number of users for different nodes.
+  EXPECT_EQ(K->getNumUsers(), 2);
+  EXPECT_EQ(conv1->getNumUsers(), 0);
+  EXPECT_TRUE(conv2->getFilter()->hasOneUse());
+  EXPECT_EQ(conv1->getFilter()->getNumUsers(), 1);
+  // Check that the first user of K is conv1.
+  EXPECT_EQ(K->getUsers().begin()->getUser(), conv1);
+  // Check that the second user of K is conv2.
+  EXPECT_EQ((++K->getUsers().begin())->getUser(), conv2);
+}
+
 TEST(Graph, simpleTestFC) {
   unsigned numInputs = 10;
   Module MD;

--- a/tools/ClassGen/NodeBuilder.cpp
+++ b/tools/ClassGen/NodeBuilder.cpp
@@ -61,7 +61,8 @@ void NodeBuilder::emitCtor(std::ostream &os) const {
 
   // Initialize the operands:
   for (const auto &op : nodeInputs_) {
-    os << ", " << op << "_(" << op << ")";
+    os << ", " << op << "_("
+       << "this, " << op << ")";
   }
 
   // Initialize the members:
@@ -70,6 +71,7 @@ void NodeBuilder::emitCtor(std::ostream &os) const {
       os << ", " << op.second << "_(" << op.second << ")";
       continue;
     }
+    continue;
     os << ", " << op.second << "_(" << op.second << ".begin(), " << op.second
        << ".end()"
        << ")";
@@ -79,6 +81,18 @@ void NodeBuilder::emitCtor(std::ostream &os) const {
   os << " {\n";
   for (auto &RT : nodeOutputs_) {
     os << "    addResult(" << RT.first << ");\n";
+  }
+
+  for (const auto &op : members_) {
+    if (op.first != MemberType::VectorNodeValue) {
+      continue;
+    }
+    os << "    " << op.second << "_.resize(" << op.second << ".size());\n";
+    os << "    for (size_t idx = 0, e = " << op.second
+       << ".size(); idx < e; ++idx) {\n"
+       << "        " << op.second << "_[idx] = " << op.second << "[idx];\n"
+       << "        " << op.second << "_[idx].setParent(this);\n"
+       << "    }\n";
   }
 
   os << "  }\n";


### PR DESCRIPTION
It is now possible to iterate over a use-list of a Node and see which nodes refer to it. NodeUse has now a getUser() method to get this information.

To provide this functionality, we store in each NodeHandle a pointer to the parent node that contains it.

One possible concern regarding this PR is that we add a pointer per NodeHandle, which increases the amount of memory used by Nodes. I was playing with the idea of using (small) offsets from the beginning of the object instead of pointers. But this does not work with nodes like Concat, which contain `std::vector<NodeHandle>`. Such handles inside vectors are allocated on heap and can be very far away from the beginning of the parent object. Therefore, their offsets may require as much memory as a pointer. Hopefully, this possible memory increase is not a big concern, because we don't have that many nodes even for big NN models.