### PR TITLE
[GraphIR] Make the overwrites explicit for SGD through Save

### DIFF
--- a/lib/Graph/Grad.cpp
+++ b/lib/Graph/Grad.cpp
@@ -71,8 +71,6 @@ Function *glow::differentiate(Function *F, const TrainingConfig &conf,
 
   // A list of nodes to add to the Function.
   std::vector<Node *> toAppend;
-  // A list of vars to add to the Function.
-  std::vector<Variable *> newVars;
 
   // Generate the gradient nodes for each one of the nodes in the function.
 
@@ -232,9 +230,6 @@ Function *glow::differentiate(Function *F, const TrainingConfig &conf,
   // Add all of the new variables and instructions.
   for (auto &I : toAppend) {
     G->addNode(I);
-  }
-  for (auto &I : newVars) {
-    G->getParent()->addVar(I);
   }
 
   return G;

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -512,11 +512,6 @@ void SparseLengthsSumNode::verify() const {
 }
 
 void SGDNode::verify() const {
-  if (Momentum_ > 0.0) {
-    assert(getGradient().getType() == getGsum().getType() &&
-           "Invalid gsum type");
-  }
-
   assert(getGradient().getType() == getWeight().getType() &&
          "Invalid weight or gradient type");
 }

--- a/tests/unittests/graphGradTest.cpp
+++ b/tests/unittests/graphGradTest.cpp
@@ -137,5 +137,22 @@ TEST(GraphAutoGrad, cloneAndDiff) {
   diffF->verify();
 
   EXPECT_EQ(M.getFunctions().size(), 3);
-  EXPECT_EQ(M.getVars().size(), 7);
+  EXPECT_EQ(M.getVars().size(), 5);
+  // Check that we have as many SGD node as variables that need to be trained.
+  unsigned nbSGDs = 0;
+  unsigned nbSGDA = 0;
+  unsigned nbSGDB = 0;
+  for (auto &node : diffF->getNodes()) {
+    SGDNode *SGD = llvm::dyn_cast<SGDNode>(&node);
+    if (!SGD)
+      continue;
+    ++nbSGDs;
+    if (A == SGD->getWeight())
+      ++nbSGDA;
+    else if (B == SGD->getWeight())
+      ++nbSGDB;
+  }
+  EXPECT_EQ(nbSGDs, 2);
+  EXPECT_EQ(nbSGDA, 1);
+  EXPECT_EQ(nbSGDB, 1);
 }

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -386,15 +386,16 @@ int main(int argc, char **argv) {
   BB.newNode("SGD")
       .addInput("Gradient")
       .addInput("Weight")
-      .addInput("Gsum")
       .addMember(MemberType::Float, "L1Decay")
       .addMember(MemberType::Float, "L2Decay")
       .addMember(MemberType::Float, "LearningRate")
       .addMember(MemberType::Float, "Momentum")
       .addMember(MemberType::Unsigned, "BatchSize")
-      .addOverwrittenInput("Weight")
+      .addResult("Weight.getType()", "UpdatedWeight")
       .setHasSideEffects(true)
-      .setDocstring("Stochastic Gradient Descent node used during training.");
+      .setDocstring("Stochastic Gradient Descent node used during training. "
+                    "Produces the updated weight that needs to be used "
+                    "instead of Weight for the next iteration.");
 
   //===--------------------------------------------------------------------===//
   //                Nodes used by quantization.


### PR DESCRIPTION
Instead of using overwrites of input arguments for the weight and
gsum arguments of the SGD node, have the node produces two results
and save them at the right places.

This is one more step toward having save and load nodes the only
direct users of variables.

NFC.