### PR TITLE
[GraphIR] Add a proper copy constructor for NodeHandle

### DIFF
--- a/include/glow/Graph/Node.h
+++ b/include/glow/Graph/Node.h
@@ -143,6 +143,8 @@ public:
     setOperand(that.getNode(), that.getResNo());
   }
 
+  NodeHandle(const NodeHandle &that) : NodeHandle(that.parent_, that) {}
+
   /// Create an empty handle.
   NodeHandle() : NodeValue(nullptr), parent_(nullptr) {}
 

--- a/tests/unittests/graphTest.cpp
+++ b/tests/unittests/graphTest.cpp
@@ -359,6 +359,9 @@ TEST(Graph, cloneTest2) {
 
   auto *newF = F->clone("new_main");
   newF->verify();
+  F->dump();
+  newF->dump();
+
   EXPECT_EQ(newF->getNodes().size(), F->getNodes().size());
   EXPECT_EQ(newF->getParent(), F->getParent());
 }

--- a/tools/ClassGen/NodeBuilder.cpp
+++ b/tools/ClassGen/NodeBuilder.cpp
@@ -267,7 +267,7 @@ void NodeBuilder::emitPrettyPrinter(std::ostream &os) const {
 
     // Make sure that inputs are properly indexed.
     os << "  unsigned mIndex = 0;\n";
-    os << "  for (auto II : get" << mem.second << "()) {\n"
+    os << "  for (const auto &II : get" << mem.second << "()) {\n"
        << "    db.addParam(\"" << mem.second
        << "\"+std::to_string(mIndex++), *II.getType());\n"
        << "  }\n";


### PR DESCRIPTION
Prior to this patch, copying a NodeHandle around (like with a vector::resize)
would not properly set the tracking of the value.

For instance, this was impossible to pretty print nodes with vector of inputs
like concat, because our pretty printer was doing creating a local NodeHandle.

This patch features a proper copy constructor for NodeHandle and at the same
time, make sure pretty printing vectors of NodeHandle doesn't create temporary
objects.

NFC.