### PR TITLE
[ONNX] ONNX operator version 

### DIFF
--- a/include/glow/Importer/Caffe2.h
+++ b/include/glow/Importer/Caffe2.h
@@ -38,6 +38,9 @@ class Value;
 /// Loads caffe2 models.
 class caffe2ModelLoader
     : public CommonOperatorLoader<caffe2::OperatorDef, caffe2::Argument> {
+  /// Get the broadcast attribute.
+  bool getBroadcast(const ArgumentDictionaryTy &dict) override;
+
   /// Load the weight tensors from the 'init' file and register them in the map
   /// \p tensors.
   void loadWeights(caffe2::NetDef &net);

--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -39,6 +39,8 @@ protected:
   using ArgumentDictionaryTy =
       std::unordered_map<std::string, const AttrType *>;
 
+  virtual bool getBroadcast(const ArgumentDictionaryTy &dict) { return true; }
+
   void addNodeAsOutput(const OpType &op, Node *R) {
     for (int i = 0, e = op.output_size(); i < e; i++) {
       nodeByName_[op.output(i)] = R;
@@ -124,11 +126,11 @@ protected:
     auto *in0 = getOrCreateVariableByName(op.input(0));
     auto *in1 = getOrCreateVariableByName(op.input(1));
 
-    int broadcast = loadInt(dict["broadcast"]);
+    bool broadcast = getBroadcast(dict);
 
     Node *finalIn1 = nullptr;
-    if (broadcast == 1) {
-      int axis = loadInt(dict["axis"]);
+    if (broadcast) {
+      int axis = dict.count("axis") ? loadInt(dict["axis"]) : -1;
       // In ONNX, if axis == -1 then it sets the axis so that the
       // trailing-most dimensions are aligned like this.
       if (axis == -1) {

--- a/include/glow/Importer/ONNX.h
+++ b/include/glow/Importer/ONNX.h
@@ -28,6 +28,7 @@ namespace onnx {
 class AttributeProto;
 class NodeProto;
 class GraphProto;
+class ModelProto;
 } // namespace onnx
 
 namespace glow {
@@ -35,6 +36,12 @@ namespace glow {
 /// Loads ONNX models.
 class ONNXModelLoader
     : public CommonOperatorLoader<onnx::NodeProto, onnx::AttributeProto> {
+  /// Get the broadcast attribute based on different ONNX op versions.
+  bool getBroadcast(const ArgumentDictionaryTy &dict) override;
+
+  /// Set ir verion and op version.
+  void setVersion(onnx::ModelProto MP);
+
   /// Load the network operators from the GraphProto.
   void loadNetwork(onnx::GraphProto &net);
 
@@ -48,6 +55,12 @@ class ONNXModelLoader
   /// Reads a network (weights or structure) from the serialized protocol buffer
   /// file.
   bool loadProtoFile(onnx::GraphProto &net, const std::string &filename);
+
+  /// ONNX model ir_version;
+  size_t irVersion_;
+
+  /// ONNX model op_version;
+  size_t opsetVersion_;
 
 public:
   /// Loads the ONNX model that's represented by a model description file,

--- a/lib/Importer/Caffe2.cpp
+++ b/lib/Importer/Caffe2.cpp
@@ -121,6 +121,10 @@ bool caffe2ModelLoader::loadProtoFile(caffe2::NetDef &net,
   return true;
 }
 
+bool caffe2ModelLoader::getBroadcast(const ArgumentDictionaryTy &dict) {
+  return dict.count("broadcast") && (loadInt(dict.at("broadcast")) == 1);
+}
+
 void caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
   ArgumentDictionaryTy dict = loadArgumentMap(op);
   const std::string &typeName = op.type();


### PR DESCRIPTION
Some ONNX ops have different versions. For example, Gemm-1 and Gemm-6 has "broadcast" attr whose default value is 0, while Gemm-7 and Gemm-8 version have no such attribute and always broadcast Tensor C. So we get op_version for each model to handle different op versions if necessary. This PR is triggered by inception_v2 ONNX model and only handles Gemm op versions. I think we could support different op version by demand in the future. 