### PR TITLE
[GraphIR] Verify that all nodes belongs to the function that holds them

### DIFF
--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1912,6 +1912,8 @@ void Function::verify() const {
   }
 
   for (const auto &N : nodes_) {
+    assert(N.getParent() == this &&
+           "Node is not linked to the function it belongs");
     N.verify();
   }
 }


### PR DESCRIPTION
We already check that when a node has a parent link its parent holds a
reference to the node, but we were missing the check in the other direction.

The patch adds this check.

NFC.