### PR TITLE
[graph-optimizer] Avoid useless calls of the simplifyNode transformation

### DIFF
--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -139,11 +139,11 @@ static Node *simplifyNode(Node *node, Function *F) {
 #define SIMPLIFY_OPERANDS(NodeKind)                                            \
   if (auto *NN = dyn_cast<NodeKind##Node>(node)) {                             \
     Node *LHS = simplifyNode(NN->getLHS(), F);                                 \
-    Node *RHS = simplifyNode(NN->getRHS(), F);                                 \
     if (LHS != NN->getLHS()) {                                                 \
       return simplifyNode(                                                     \
           F->create##NodeKind(NN->getName(), LHS, NN->getRHS()), F);           \
     }                                                                          \
+    Node *RHS = simplifyNode(NN->getRHS(), F);                                 \
     if (RHS != NN->getRHS()) {                                                 \
       return simplifyNode(                                                     \
           F->create##NodeKind(NN->getName(), NN->getLHS(), RHS), F);           \


### PR DESCRIPTION
The call of simplifyNode for the RHS was ignored when the call of simplifyNode for the LHS was successful. It was ignored even if RHS was actually simplified and thus any nodes created by this simplification were produced, but never used and later removed by the dead code elimination pass.