### PR TITLE
[IROptimizer] Teach the shareBuffers opt how to extend a dest buffer …

### DIFF
--- a/lib/Optimizer/IROptimizer.cpp
+++ b/lib/Optimizer/IROptimizer.cpp
@@ -676,6 +676,37 @@ static bool hasOverlappingIntervals(Intervals &intervals, Interval I) {
   return false;
 }
 
+/// Helper function to get a compatible value to replace \p val with \p with.
+/// This function casts \p with if necessary. When a cast needs to be created
+/// it will be inserted before \p Before. Moreover, when that happens, the
+/// second element of the returned pair is true, false otherwise.
+///
+/// \returns A pair with the first element being the Value matching val's type,
+/// using \p with's content and the second element being the status of
+/// whether a cast was inserted or not.
+static std::pair<Value *, bool>
+getCompatibleValueForReplacement(IRBuilder &B, Instruction *Before,
+                                 const Value &val, Value &with) {
+  if (val.getType() == with.getType()) {
+    return std::make_pair(&with, false);
+  }
+
+  Value *replacement = getOrigin(&with);
+  if (val.getType() == replacement->getType()) {
+    return std::make_pair(replacement, false);
+  }
+
+  // Perform a cast to make the types match.
+  std::vector<size_t> offsets(replacement->dims().size(), 0);
+  auto *tv = B.createTensorViewInst(with.getName(), replacement, val.getType(),
+                                    offsets);
+  assert(tv->getType()->size() == with.getType()->size() &&
+         "Replacement must have same number of elements as original.");
+  B.getIRFunction().moveInstruction(Before, tv);
+  replacement = tv;
+  return std::make_pair(replacement, true);
+}
+
 /// Moves an interval from one interval list to another.
 static void moveInterval(Intervals &from, Intervals &to, Interval &interval) {
   auto fromIt = std::find(from.begin(), from.end(), interval);
@@ -699,14 +730,25 @@ static void moveInterval(Intervals &from, Intervals &to, Interval &interval) {
 }
 
 /// Replace all uses of \p val by \p with inside interval \p liveInterval.
+/// While replacing the uses if we don't find a definition before
+/// the first use and \p fixUpFirstUseIfNoDef is true, this method will
+/// create a proper definition for \p with.
+///
+/// \p fixUpFirstUseIfNoDef must only be used when we are extending destination
+/// live-ranges upward. Also, \p fixUpFirstUseIfNoDef must only be used if
+/// we extend the live-range of \p with toward the live-range of a WeightVar.
+/// If fixUpFirstUseIfNoDef is required in other situations, that means the
+/// input IR is wrong and that we have a bug somewhere else.
 static void replaceAllUsesInsideIntervalWith(
     Value *val, Value *with, const Interval &liveInterval, IRFunction &M,
-    const LiveIntervalsInstructionNumbering &instrNumbering) {
+    const LiveIntervalsInstructionNumbering &instrNumbering,
+    bool fixUpFirstUseIfNoDef) {
   auto &instrs = M.getInstrs();
   auto valOrigin = getOrigin(val);
-  auto withOrigin = getOrigin(with);
   unsigned instIdx = 0;
   IRBuilder B(&M);
+  bool sawDefinitionBeforeFirstUse = false;
+  Instruction *firstUse = nullptr;
   for (auto it = instrNumbering.getInstr(liveInterval.begin_)->getIterator(),
             e = instrs.end();
        it != e && instIdx <= liveInterval.end_; ++it) {
@@ -721,6 +763,7 @@ static void replaceAllUsesInsideIntervalWith(
     if (instNum < 0)
       continue;
 
+    bool sawDefinition = false;
     // This is an instruction inside the interval.
     // Iterate over all operands and perform replacements.
     for (int i = 0, e = I->getNumOperands(); i < e; i++) {
@@ -739,29 +782,48 @@ static void replaceAllUsesInsideIntervalWith(
       // Skip operands outside of the interval.
       if (opIdx < liveInterval.begin_ || opIdx >= liveInterval.end_)
         continue;
-      auto replacement = with;
-      if (op->getType() != replacement->getType())
-        replacement = withOrigin;
-      if (op->getType() != replacement->getType()) {
-        // Perform a cast if required.
-        std::vector<size_t> offsets(replacement->dims().size(), 0);
-        auto *tv = B.createTensorViewInst(I->getName(), replacement,
-                                          op->getType(), offsets);
-        assert(tv->getType()->size() == with->getType()->size() &&
-               "Replacement must have same number of elements as original.");
-        M.moveInstruction(I, tv);
-        replacement = tv;
+
+      std::pair<Value *, bool> replacementAndHasCreated =
+          getCompatibleValueForReplacement(B, I, *op, *with);
+      auto *replacement = replacementAndHasCreated.first;
+      // If we inserted a cast of with and didn't see any use
+      // of with yet, this is our first use.
+      if (replacementAndHasCreated.second && !firstUse) {
+        assert(llvm::isa<Instruction>(replacement) &&
+               "Replacement status should not be \"hasCreated\"");
+        firstUse = llvm::cast<Instruction>(replacement);
       }
 
       DEBUG_GLOW(llvm::dbgs()
                      << "Replacing inside instruction " << opIdx << "\n";
                  llvm::dbgs() << "before: "; I->dump(llvm::dbgs());
                  llvm::dbgs() << "\n");
+
+      // Don't account for InOut definitions, because the In part of that
+      // definition is going to be undefined if we didn't see any
+      // definition yet.
+      sawDefinition |= opKind == OperandKind::Out;
+      if (!firstUse &&
+          (opKind == OperandKind::In || opKind == OperandKind::InOut)) {
+        firstUse = I;
+      }
+
       // Replace the old value by the new value.
       I->setOperand(i, replacement);
       DEBUG_GLOW(llvm::dbgs() << "after: "; I->dump(llvm::dbgs());
                  llvm::dbgs() << "\n");
     }
+    sawDefinitionBeforeFirstUse |= (sawDefinition && !firstUse);
+  }
+  // We found a use without a definition first and have been asked to
+  // fix those situations.
+  // Insert a copy to initialize "with" with val.
+  if (firstUse && !sawDefinitionBeforeFirstUse && fixUpFirstUseIfNoDef) {
+    std::pair<Value *, bool> replacementAndHasCreated =
+        getCompatibleValueForReplacement(B, firstUse, *with, *val);
+    auto *fixupInit = B.createCopyInst(firstUse->getName().str() + ".fixup",
+                                       with, replacementAndHasCreated.first);
+    M.moveInstruction(firstUse, fixupInit);
   }
 }
 
@@ -973,15 +1035,22 @@ public:
     if (bufferToReuse == destOrigin_) {
       // This operation may extend the lifetime of dest's buffer.
       // shareBuffers will fix it once it's done.
-      reuseBufferInsideInterval(srcOrigin_, dest_, *srcInterval_,
-                                *destInterval_, M_, srcIntervals_,
-                                destIntervals_);
+      // However, if the source interval is a WeightVar, it may
+      // not have a definition on the interval we are replacing.
+      // If that's the case, we need to add one, otherwise
+      // dest will not be defined and shareBuffers won't have enough
+      // information to be able to fix that.
+      reuseBufferInsideInterval(
+          srcOrigin_, dest_, *srcInterval_, *destInterval_, M_, srcIntervals_,
+          destIntervals_,
+          /*fixUpFirstUseIfNoDef*/ llvm::isa<WeightVar>(srcOrigin_));
       return true;
     }
 
     // Source buffer can be reused.
     reuseBufferInsideInterval(destOrigin_, src_, *destInterval_, *srcInterval_,
-                              M_, destIntervals_, srcIntervals_);
+                              M_, destIntervals_, srcIntervals_,
+                              /*fixUpFirstUseIfNoDef*/ false);
     return true;
   }
 
@@ -990,14 +1059,15 @@ public:
   void reuseBufferInsideInterval(Value *oldBuffer, Value *newBuffer,
                                  Interval oldInterval, Interval &newInterval,
                                  IRFunction &M, Intervals &oldIntervals,
-                                 Intervals &newIntervals) {
+                                 Intervals &newIntervals,
+                                 bool fixUpFirstUseIfNoDef) {
     DEBUG_GLOW(llvm::dbgs()
                << "\n\nReuse buffers: use buffer of " << newBuffer->getName()
                << " as a buffer for " << oldBuffer->getName() << "\n"
                << "in live interval " << oldInterval << "\n");
     // Replace oldBuffer with newBuffer.
     replaceAllUsesInsideIntervalWith(oldBuffer, newBuffer, oldInterval, M,
-                                     instrNumbering_);
+                                     instrNumbering_, fixUpFirstUseIfNoDef);
     if (isCopyPropagation()) {
       // This is a copy propagation.
       // Merge the old interval with the new one.

--- a/tests/unittests/IROptTest.cpp
+++ b/tests/unittests/IROptTest.cpp
@@ -18,6 +18,7 @@
 #include "glow/Graph/Graph.h"
 #include "glow/IR/IR.h"
 #include "glow/IR/IRBuilder.h"
+#include "glow/IR/IRUtils.h"
 #include "glow/IR/Instrs.h"
 #include "glow/Optimizer/Optimizer.h"
 
@@ -511,4 +512,177 @@ TEST(Optimizer, inoutCopy) {
     }
     EXPECT_EQ(use.get()->getOperand(0).first, expectedDest[idx++]);
   }
+}
+
+/// Check that we properly define a buffer when we extend its live-range
+/// on a segment of the source that does not have any definition.
+/// A source live-range without any definition can happen when this
+/// is the first use of a WeightVar.
+/// At the high level, this test looks like this:
+/// WeightVar    Buffer
+///    | useA
+///    | useB      | def
+///    | redef     | save to output
+/// - UseA is the first use of WeightVar and we want it to be replaced by
+///   a use of Buffer. I.e., Buffer live-range is extended toward the top.
+/// - UseB involves both WeightVar and Buffer. It exposes the buffer sharing
+///   opportunity between these two variables. It must happen after useA
+///   to expose the case of extending the live-range of a buffer toward
+///   the top where no definition exists.
+/// - redef redefines WeightVar. It is necessary otherwise both useA and useB
+///   could all share the same buffer and thus, we would extend the live-range
+///   of the buffer in useA downward (or the use of Buffer up to the
+///   definition of the buffer in useA), which is not what we want to test.
+/// - save to output is required to keep the def of Buffer alive. Moreover,
+///   the save must be done in such a way that the output buffer and Buffer
+///   must not be able to share the same buffer. Otherwise, the live-range
+///   of output buffer will be extended upward to useB and given output and
+///   WeightVar are both externally observable, the output buffer cannot be
+///   merged with WeightVar.
+///   Therefore, we won't expose an extension of output up to useA
+///   and won't test the case where the replaced buffer doesn't have any
+///   definition.
+///
+/// The expected result at a high level looks like this:
+/// WeightVar    Buffer
+///    |   copy    | <- Buffer gets WeightVar
+///      useA      | <- Buffer is used instead of WeightVar
+///      useB      | def <- ditto
+///    | redef     | save to output
+TEST(Optimizer, bufferReuseWithoutDefs) {
+  Module mod;
+  Function *F = mod.createFunction("bufferReuseWithoutDefs");
+  IRFunction M(F);
+  IRBuilder bb(&M);
+
+  auto *input = bb.createWeightVar(glow::ElemKind::FloatTy, {64}, "input",
+                                   WeightVar::MutabilityKind::Mutable);
+  auto *output = bb.createWeightVar(glow::ElemKind::FloatTy, {2, 64}, "output",
+                                    WeightVar::MutabilityKind::Mutable);
+  auto *tmp1 =
+      bb.createAllocActivationInst("tmp1", glow::ElemKind::FloatTy, {64});
+
+  auto *tmp2 =
+      bb.createAllocActivationInst("tmp2", glow::ElemKind::FloatTy, {64});
+  auto *tmp3 =
+      bb.createAllocActivationInst("tmp3", glow::ElemKind::FloatTy, {64});
+
+  bb.createSplatInst("tmp2init", tmp2, 1.0);
+  // use input for some stuff.
+  auto *useA = bb.createElementAddInst("useA", tmp3, tmp2, input);
+  // Make the first user of input a dependency of the definition
+  // of tmp1 that way the scheduler cannot mess with the layout
+  // we want for the instructions ordering.
+  bb.createElementAddInst("useB", tmp1, input, tmp3);
+  bb.createCopyInst("redef", input, tmp3);
+  auto *view = bb.createTensorViewInst(
+      "view", tmp1, mod.uniqueType(Type(glow::ElemKind::FloatTy, {1, 64})),
+      {0});
+  bb.createInsertTensorInst("save", output, view, {0, 0}, 1, 0);
+
+  bb.createDeallocActivationInst("dealloc1", tmp1);
+  bb.createDeallocActivationInst("dealloc2", tmp2);
+  bb.createDeallocActivationInst("dealloc2", tmp3);
+
+  optimize(M, CompilationMode::Infer, MockBackend());
+
+  // Check that we manage to expose the problematic case we wanted:
+  // tmp1 is extended upward and replace the use of input.
+  EXPECT_EQ(useA->getRHS(), tmp1);
+  // Check that tmp1 is properly defined before useA.
+  Instruction *instBeforeUseA = &*std::prev(useA->getIterator());
+
+  EXPECT_TRUE(isa<CopyInst>(instBeforeUseA));
+  // The somewhat complicated check is to make sure we don't crash the test
+  // when instBeforeUseA is not a copy.
+  // I.e., this test was failing (instead of crashing) when the
+  // bug was present.
+  EXPECT_EQ(instBeforeUseA->getNumOperands() > 0
+                ? instBeforeUseA->getOperand(0).first
+                : nullptr,
+            tmp1);
+  EXPECT_EQ(instBeforeUseA->getNumOperands() > 1
+                ? instBeforeUseA->getOperand(1).first
+                : nullptr,
+            input);
+}
+
+/// Same as bufferReuseWithoutDefs but with casts in the middle.
+/// This makes sure that we properly set the types for whatever fixup
+/// code we will insert.
+/// The high level view of the test is:
+/// WeightVar    Buffer
+///    | useA
+///    | useB(cast)| def
+///    | redef     | save to output
+///
+/// The expected result at a high level looks like this:
+/// WeightVar    Buffer
+///    | copy(cast)| <- Buffer gets WeightVar
+///      useA(cast)| <- Buffer is used instead of WeightVar
+///      useB      | def <- ditto
+///    | redef     | save to output
+TEST(Optimizer, bufferReuseWithoutDefsPlusCasts) {
+  Module mod;
+  Function *F = mod.createFunction("bufferReuseWithoutDefsPlusCasts");
+  IRFunction M(F);
+  IRBuilder bb(&M);
+
+  auto *input = bb.createWeightVar(glow::ElemKind::FloatTy, {1, 64}, "input",
+                                   WeightVar::MutabilityKind::Mutable);
+  auto *output = bb.createWeightVar(glow::ElemKind::FloatTy, {2, 64}, "output",
+                                    WeightVar::MutabilityKind::Mutable);
+  auto *tmp1 =
+      bb.createAllocActivationInst("tmp1", glow::ElemKind::FloatTy, {64});
+
+  auto *tmp2 =
+      bb.createAllocActivationInst("tmp2", glow::ElemKind::FloatTy, {1, 64});
+  auto *tmp3 =
+      bb.createAllocActivationInst("tmp3", glow::ElemKind::FloatTy, {1, 64});
+
+  bb.createSplatInst("tmp2init", tmp2, 1.0);
+  auto *useA = bb.createElementAddInst("useA", tmp3, tmp2, input);
+  auto *inputView = bb.createTensorViewInst(
+      "inputView", input, mod.uniqueType(Type(glow::ElemKind::FloatTy, {64})),
+      {0});
+  auto *tmp3View = bb.createTensorViewInst(
+      "tmp3View", tmp3, mod.uniqueType(Type(glow::ElemKind::FloatTy, {64})),
+      {0});
+
+  bb.createElementAddInst("useB", tmp1, inputView, tmp3View);
+  bb.createCopyInst("redef", input, tmp3);
+  auto *view = bb.createTensorViewInst(
+      "view", tmp1, mod.uniqueType(Type(glow::ElemKind::FloatTy, {1, 64})),
+      {0});
+  bb.createInsertTensorInst("save", output, view, {0, 0}, 1, 0);
+
+  bb.createDeallocActivationInst("dealloc1", tmp1);
+  bb.createDeallocActivationInst("dealloc2", tmp2);
+  bb.createDeallocActivationInst("dealloc2", tmp3);
+
+  optimize(M, CompilationMode::Infer, MockBackend());
+
+  // Check that we manage to expose the problematic case we wanted:
+  // tmp1 is extended upward and replace the use of input.
+  Value *useARHS = useA->getRHS();
+  EXPECT_EQ(getOrigin(useARHS), tmp1);
+  Instruction *tmp1TensorView = dyn_cast<TensorViewInst>(useARHS);
+  EXPECT_TRUE(tmp1TensorView && tmp1TensorView->getOperand(0).first == tmp1);
+  // Check that tmp1 is properly defined before useA.
+  Instruction *tmp1Fixup =
+      tmp1TensorView ? &*std::prev(tmp1TensorView->getIterator()) : nullptr;
+  EXPECT_TRUE(tmp1Fixup && isa<CopyInst>(tmp1Fixup));
+  // The somewhat complicated check is to make sure we don't crash the test
+  // when instBeforeUseA is not a copy.
+  EXPECT_EQ((tmp1Fixup && tmp1Fixup->getNumOperands() > 0)
+                ? getOrigin(tmp1Fixup->getOperand(0).first)
+                : nullptr,
+            tmp1);
+  // Now check that input feeds tmp1Fixup and was properly casted.
+  Instruction *inputCast =
+      (tmp1Fixup && tmp1Fixup->getNumOperands() > 1)
+          ? dyn_cast<TensorViewInst>(tmp1Fixup->getOperand(1).first)
+          : nullptr;
+  EXPECT_EQ(inputCast ? getOrigin(inputCast) : nullptr, input);
+  EXPECT_EQ(inputCast ? inputCast->getOperand(0).first : nullptr, input);
 }


### PR DESCRIPTION
…when the source doesn't have a definition

Let us consider the following pattern:
= useA var
tmp = allocactivation
tmp = useB var

Prior to this patch, if we merge tmp into var while using tmp buffer
the first use of tmp will be undefined because var didn't have any
definition to be replace by tmp:

tmp = allocactivation
= useA tmp    <--- this use of tmp is undefined
tmp = useB tmp

This patch teachs the shareBuffers optimization how to recognize this situation
and insert the proper definition for the buffer:

tmp = allocactivation
tmp = copy var <-- tmp has now var's value
= useA tmp    <--- this use is now fine
tmp = useB tmp