### PR TITLE
[run.sh] Add inception_v1 and bvlc_alexnet models.

### DIFF
--- a/tests/images/run.sh
+++ b/tests/images/run.sh
@@ -6,6 +6,9 @@
 ./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to256 -m=zfnet512 $@
 ./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to1 -m=densenet121 $@
 ./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to1 -m=shufflenet $@
+./bin/image-classifier tests/images/mnist/*.png -image_mode=0to1 -m=lenet_mnist $@
+./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to256 -m=inception_v1 $@
+./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to256 -m=bvlc_alexnet $@
 for png_filename in tests/images/imagenet/*.png; do
   ./bin/image-classifier $png_filename -image_mode=0to1 -m=resnet50/model.onnx $@
 done
@@ -22,9 +25,12 @@ for png_filename in tests/images/imagenet/*.png; do
   ./bin/image-classifier $png_filename -image_mode=0to1 -m=densenet121/model.onnx $@
 done
 ./bin/image-classifier tests/images/imagenet/zebra_340.png -image_mode=0to1 -m=shufflenet/model.onnx $@
-
-./bin/image-classifier tests/images/mnist/*.png -image_mode=0to1 -m=lenet_mnist $@
-
 for png_filename in tests/images/mnist/*.png; do
   ./bin/image-classifier $png_filename -image_mode=0to1 -m=mnist.onnx $@
+done
+for png_filename in tests/images/imagenet/*.png; do
+  ./bin/image-classifier $png_filename -image_mode=0to256 -m=inception_v1/model.onnx $@
+done
+for png_filename in tests/images/imagenet/*.png; do
+  ./bin/image-classifier $png_filename -image_mode=0to256 -m=bvlc_alexnet/model.onnx $@
 done

--- a/utils/download_caffe2_models.sh
+++ b/utils/download_caffe2_models.sh
@@ -10,6 +10,7 @@ shufflenet
 squeezenet
 vgg19
 zfnet512
+bvlc_alexnet
 EOF
 )
 

--- a/utils/download_onnx_models.sh
+++ b/utils/download_onnx_models.sh
@@ -5,6 +5,11 @@ for modelname in resnet50 vgg19 squeezenet zfnet512 densenet121 shufflenet; do
   tar -xzvf $modelname.tar.gz
 done
 
+for modelname in inception_v1 inception_v2 bvlc_alexnet; do
+  wget -nc https://s3.amazonaws.com/download.onnx/models/opset_8/$modelname.tar.gz
+  tar -xzvf $modelname.tar.gz
+done
+
 for modelname in lenet_mnist; do
   wget -nc http://fb-glow-assets.s3.amazonaws.com/models/$modelname.tar.gz
   tar -xzvf $modelname.tar.gz


### PR DESCRIPTION
The following result is for both Caffe2 and ONNX models:
Model: inception_v1
 File: tests/images/imagenet/cat_285.png Result:281
 File: tests/images/imagenet/dog_207.png Result:207
 File: tests/images/imagenet/zebra_340.png Result:340
Model: inception_v2
 File: tests/images/imagenet/cat_285.png Result:173
 File: tests/images/imagenet/dog_207.png Result:124
 File: tests/images/imagenet/zebra_340.png Result:79
Model: bvlc_alexnet
 File: tests/images/imagenet/cat_285.png Result:281
 File: tests/images/imagenet/dog_207.png Result:207
 File: tests/images/imagenet/zebra_340.png Result:340

For inception_v2, I run caffe2_pb_runner.py and got the same result. But it is not added into run.sh due to the incorrect results.