### PR TITLE
[GraphScheduler] Honor memory dependencies implied by the SaveNode

### DIFF
--- a/tests/unittests/graphTest.cpp
+++ b/tests/unittests/graphTest.cpp
@@ -546,8 +546,7 @@ TEST(Graph, schedulingOfSaves) {
     }
   }
   EXPECT_TRUE(A->getPayload().isEqual(zero->getPayload(), 0.0));
-  // FIXME: This should be true, but right now it is not!
-  EXPECT_FALSE /*TRUE*/ (allEqual);
+  EXPECT_TRUE(allEqual);
 }
 
 /// Check that the parent link is properly updated while tweaking


### PR DESCRIPTION
When a variable is used as output in a save node, this is expected
to be its last use. Make sure the GraphSchedule looks at the implicit
dependencies between all the uses of a variable and its save node
when walking the dependencies.

This fixes issue #1283.