### PR TITLE
[GraphIR] Remove the Load node

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -508,8 +508,6 @@ public:
                   unsigned hiddenSize, unsigned outputSize,
                   std::vector<NodeValue> &outputs);
 
-  LoadNode *createLoad(llvm::StringRef name, NodeValue Variable);
-
   /// @}
 
   /// Erase the node \p N from the Function.

--- a/include/glow/Importer/ProtobufLoader.h
+++ b/include/glow/Importer/ProtobufLoader.h
@@ -101,9 +101,8 @@ protected:
   /// \returns the tensor that was registered under the name \p name.
   Tensor *getTensorByName(llvm::StringRef name);
 
-  /// Create a new variable \p name initialized with \p tensor and load it.
-  /// The load is also registered under \p name.
-  /// \returns A load to the newly created variable.
+  /// Create a new variable \p name initialized with \p tensor.
+  /// \returns The newly created variable.
   /// \pre !hasNodeByName(name)
   Node *createAndRememberVariable(
       llvm::StringRef name, const Tensor &tensor,
@@ -127,15 +126,13 @@ public:
   Node *getNodeByName(llvm::StringRef name) const;
 
   /// \returns the node that was registered with the name \p name or create a
-  /// new Variable node for a tensor with this name and load it.
-  /// In case a new variable is returned, this method registers
-  /// the returned load node, not the variable itself.
-  /// Only save and load node are allowed to use variable directly.
+  /// new Variable node for a tensor with this name.
+  /// In case a new variable is created, this method registers
+  /// it under \p name.
   Node *getOrCreateVariableByName(llvm::StringRef name);
 
-  /// \returns The variable referenced by the load registered
-  /// under \p name.
-  /// \pre isa<LoadNode>(getNodeByName(name))
+  /// \returns The variable registered under \p name.
+  /// \pre isa<Variable>(getNodeByName(name))
   Variable *getVariableByName(llvm::StringRef name) const;
 
   /// \returns True if the node that's registered using \p name exists.

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1657,10 +1657,6 @@ void Function::createLSTM(llvm::StringRef namePrefix,
   }
 };
 
-LoadNode *Function::createLoad(llvm::StringRef name, NodeValue variable) {
-  return addNode(new LoadNode(name, variable.getType(), variable));
-}
-
 //===----------------------------------------------------------------------===//
 //                   Graph dumping and printing
 //===----------------------------------------------------------------------===//

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -678,11 +678,6 @@ void ConcatNode::verify() const {
   }
 }
 
-void LoadNode::verify() const {
-  // Loads are restricted to Variables.
-  assert(llvm::isa<Variable>(getAddress().getNode()));
-}
-
 //===----------------------------------------------------------------------===//
 //                     Node hashing support
 //===----------------------------------------------------------------------===//

--- a/lib/IR/IRGen.cpp
+++ b/lib/IR/IRGen.cpp
@@ -363,16 +363,6 @@ public:
       V->setName(N->getName());
       break;
     }
-    case glow::Kinded::Kind::LoadNodeKind: {
-      auto *load = cast<LoadNode>(N);
-      auto *src = valueForNode(load->getVariable());
-      auto *dest = builder_.createAllocActivationInst(
-          load->getName(), load->getResult().getType());
-      auto *copy = builder_.createCopyInst("load", dest, src);
-      copy->setName(N->getName());
-      registerIR(N, dest);
-      break;
-    }
     case glow::Kinded::Kind::VariableNodeKind: {
       auto *V = cast<Variable>(N);
       auto *W = builder_.createWeightVar(V->getType(), V->getName(),

--- a/lib/Importer/ProtobufLoader.cpp
+++ b/lib/Importer/ProtobufLoader.cpp
@@ -65,7 +65,6 @@ Node *ProtobufLoader::createAndRememberVariable(llvm::StringRef name,
                                                 Variable::TrainKind trainKind) {
   assert(!hasNodeByName(name) && "Creating an already existing node?!");
   Node *node = createVariable(name, tensor, visibilityKind, trainKind);
-  node = G_.createLoad(name.str() + ".loaded", node);
   nodeByName_[name] = node;
   return node;
 }
@@ -84,9 +83,9 @@ Variable *ProtobufLoader::getVariableByName(llvm::StringRef name) const {
   assert(hasNodeByName(name) && "Variable was not created");
   auto *node = getNodeByName(name);
 
-  assert(llvm::isa<LoadNode>(node) && "Not a load of a variable");
+  assert(llvm::isa<Variable>(node) && "Node is not a variable");
 
-  return llvm::cast<LoadNode>(node)->getVariable();
+  return llvm::cast<Variable>(node);
 }
 
 bool ProtobufLoader::hasNodeByName(llvm::StringRef name) const {

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -134,27 +134,6 @@ TEST_P(Operator, matmul) {
   EXPECT_NEAR(H.at({2, 0}), 95, 0.001);
 }
 
-TEST_P(Operator, Load) {
-  auto *var = mod_.createVariable(ElemKind::FloatTy, {3, 3}, "var",
-                                  VisibilityKind::Private,
-                                  Variable::TrainKind::Xavier, 1);
-  auto *R = F_->createLoad("load", var);
-
-  auto *result = mod_.createVariable(ElemKind::FloatTy, {3, 3}, "result");
-  F_->createSave("save", R, result);
-
-  EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
-
-  auto resultHandler = result->getPayload().getHandle();
-  auto varHandler = var->getPayload().getHandle();
-  for (size_t i = 0; i < 3; ++i) {
-    for (size_t j = 0; j < 3; ++j) {
-      EXPECT_EQ(resultHandler.at({i, j}), varHandler.at({i, j}));
-    }
-  }
-}
-
 TEST_P(Operator, batchedReduceAdd) {
   auto *batch = mod_.createVariable(ElemKind::FloatTy, {2, 4}, "batch");
   auto *result = mod_.createVariable(ElemKind::FloatTy, {4}, "result");

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -52,17 +52,6 @@ int main(int argc, char **argv) {
                     "this node and all of its ancestor nodes. Generally "
                     "intended to save the final result of a network.");
 
-  BB.newNode("Load")
-      .addInput("Address")
-      .addExtraMethod("Variable *getVariable() const;",
-                      "Variable *LoadNode::getVariable() const { return "
-                      "llvm::cast<Variable>(Address_.getNode()); };")
-      .addResultFromCtorArg()
-      .setDocstring("Load/Copy a variable into local memory. "
-                    "If the memory space of the variable is the same as the "
-                    "local memory space and the memory dependencies allow it, "
-                    "the backend may choose to reuse this buffer directly.");
-
   //===--------------------------------------------------------------------===//
   //                   Convolution / Pool / FC
   //===--------------------------------------------------------------------===//


### PR DESCRIPTION
We decide not to use the load node, at least for now.
Instead, we'll stick to the following constraints:
- Save nodes are the last use of a Variable
- There is at most one save node per variable

This commit mainly reverts 67ec1cb4c030c145c9b40d5094fedc6aa5c419a2.

NFC.