### PR TITLE
[cpu] Remove AllocationsInfo::clear. NFC

### DIFF
--- a/lib/Backends/CPU/AllocationsInfo.cpp
+++ b/lib/Backends/CPU/AllocationsInfo.cpp
@@ -196,14 +196,3 @@ void AllocationsInfo::numberValues(const IRFunction *F) {
     }
   }
 }
-
-void AllocationsInfo::clear() {
-  allocatedAddressed_.clear();
-  valueNumbers_.clear();
-  baseActivationsAddress_ = nullptr;
-  baseConstantWeightVarsAddress_ = nullptr;
-  baseMutableWeightVarsAddress_ = nullptr;
-  activationsMemSize_ = 0;
-  constantWeightVarsMemSize_ = 0;
-  mutableWeightVarsMemSize_ = 0;
-}

--- a/lib/Backends/CPU/AllocationsInfo.h
+++ b/lib/Backends/CPU/AllocationsInfo.h
@@ -71,8 +71,6 @@ struct AllocationsInfo {
   /// Number all allocations and weight variables by assigning them unique
   /// numbers.
   void numberValues(const IRFunction *F);
-  /// Reset the state of the allocation info.
-  void clear();
 };
 
 } // namespace glow

--- a/lib/Backends/CPU/BundleSaver.cpp
+++ b/lib/Backends/CPU/BundleSaver.cpp
@@ -242,7 +242,6 @@ void BundleSaver::emitBundleConfig() {
 }
 
 void BundleSaver::performBundleMemoryAllocation() {
-  allocationsInfo_.clear();
   allocationsInfo_.numberValues(F_);
   allocationsInfo_.allocateActivations(F_);
   // Tell the allocateWeightVars to not reuse any existing addresses for weights

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -96,7 +96,6 @@ static void emitJitMain(AllocationsInfo &allocationsInfo, LLVMIRGen &irgen) {
 /// Perform memory allocation for a JIT execution.
 static void *allocateJITMemory(const IRFunction *F,
                                AllocationsInfo &allocationsInfo) {
-  allocationsInfo.clear();
   allocationsInfo.numberValues(F);
   allocationsInfo.allocateActivations(F);
   // Tell the allocateWeightVars to reuse existing addresses for weights.


### PR DESCRIPTION
We don't currently reuse the AllocationsInfo object anywhere, and it seems better to discourage that anyways.