### PR TITLE
[quantization][opencl]: Support quantization for RescaleQuantizedInst

### DIFF
--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -186,6 +186,7 @@ public:
       case Kinded::Kind::MinNodeKind:
       case Kinded::Kind::MulNodeKind:
       case Kinded::Kind::QuantizeNodeKind:
+      case Kinded::Kind::RescaleQuantizedNodeKind:
       case Kinded::Kind::SplatNodeKind:
       case Kinded::Kind::SubNodeKind:
       case Kinded::Kind::TransposeNodeKind:

--- a/lib/Backends/OpenCL/kernels.cl
+++ b/lib/Backends/OpenCL/kernels.cl
@@ -114,6 +114,26 @@ __kernel void quantize_i8W(__global void *mem, cl_uint32_t dest,
   quantize_i8K(&mem[dest], &mem[src], scale, offset);
 }
 
+__kernel void rescalequantized_i8K(__global cl_int8_t *dest,
+                                   __global cl_int8_t *src, cl_int32_t destOffset,
+                                   cl_int32_t srcOffset, cl_int32_t rescalePre,
+                                   cl_int32_t rescalePost,
+                                   cl_int32_t rescaleScale) {
+  size_t i = get_global_id(0);
+  cl_int32_t s = scale_i32i8(src[i] - srcOffset, rescalePre, rescalePost,
+                             rescaleScale, destOffset);
+  dest[i] = clip(s);
+}
+
+__kernel void rescalequantized_i8W(
+    __global void *mem, cl_uint32_t dest, cl_uint32_t src,
+    cl_int32_t destOffset,
+    cl_int32_t srcOffset, QuantizationTransform32To8 rescaleParams) {
+  rescalequantized_i8K(&mem[dest], &mem[src], destOffset, srcOffset,
+                        rescaleParams.pre_, rescaleParams.post_,
+                        rescaleParams.scale_);
+}
+
 __kernel void dequantizeK(__global float *dest, __global cl_int8_t *src,
                           float scale, cl_int32_t offset) {
   size_t i = get_global_id(0);

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -1203,7 +1203,7 @@ TEST_P(Operator, RescaleNode) {
                                     Variable::TrainKind::Broadcast, 40);
 
   auto *output =
-      mod_.createVariable(ElemKind::Int8QTy, {4, 10}, 0.4, -3, "output",
+      mod_.createVariable(ElemKind::Int8QTy, {4, 10}, 0.4, -4, "output",
                           VisibilityKind::Public, Variable::TrainKind::None);
 
   auto T1 = mod_.uniqueType(ElemKind::Int8QTy, {4, 10}, 0.7, 5);


### PR DESCRIPTION
Support quantization for RescaleQuantizedInst
-- Modified the "RescaleNode" test so that createRescaleQuantized() didn't get optimized out. 
-- RescaleNode test stands as the test for this PR