### PR TITLE
[CPU] Fix DKKC8 filter out-of-bounds issue.

### DIFF
--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -1458,7 +1458,7 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     auto *group = emitConstSizeT(builder, CI->getGroup());
 
     size_t inChannels = src->dims()[3];
-    size_t outChannels = src->dims()[3];
+    size_t outChannels = dest->dims()[3];
 
     // Select a method for iterating on the image in the pixel (filter-first, or
     // input-first). Perform convolutions with a high channel count by scanning
@@ -1486,7 +1486,7 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     // Increase the number of strips until we reach the output-tensor depth size
     // or until we exceed some threashold.
     while (2 * depthStrips * stripSize <= tileSize &&
-           2 * depthStrips * numDepthRegs * 8 <= outChannels &&
+           2 * depthStrips * numDepthRegs * 8 <= outChannels / CI->getGroup() &&
            depthStrips < 8) {
       depthStrips *= 2;
     }

--- a/tests/unittests/BackendCorrectnessTest.cpp
+++ b/tests/unittests/BackendCorrectnessTest.cpp
@@ -613,6 +613,16 @@ TEST_P(CPUOnly, nonSquarePaddingConvTest) {
   EXPECT_TRUE(out1.isEqual(out2));
 }
 
+/// This test targets the DKKC8 opt correctionimization.
+TEST_P(CPUOnly, convDKKC8Test) {
+  std::array<size_t, 4> S{{3, 3, 3, 192}};
+  Tensor out1(ElemKind::FloatTy, S);
+  Tensor out2(ElemKind::FloatTy, S);
+  inferConvDKKC8(&out1, BackendKind::CPU);
+  inferConvDKKC8(&out2, BackendKind::Interpreter);
+  EXPECT_TRUE(out1.isEqual(out2));
+}
+
 TEST_P(BackendCorrectnessTest, softmaxTest) {
   PseudoRNG PRNG;
   Tensor inputs(ElemKind::FloatTy, {14, 19});

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -101,6 +101,8 @@ void inferGroupConv(Tensor *out, BackendKind kind);
 
 void inferNonSquarePaddingConv(Tensor *out, BackendKind kind);
 
+void inferConvDKKC8(Tensor *out, BackendKind kind);
+
 void inferSmallConv(Tensor *inputs, Tensor *out, BackendKind kind);
 
 void inferSoftMaxNet(Tensor *inputs, Tensor *selected, Tensor *out,


### PR DESCRIPTION
Before generating libjit_convDKKC8_f function, we can guarantee that (output_channel / group) is divisible by 64. However, in libjit_convDKKC8_f function, we handle "8 * numDepthRegs * depthStrips" channels per time (i.e. d += 8 * numDepthRegs * depthStrips). The  (output_channel / group) may not be divisible by 8 * numDepthRegs * depthStrips. Under such circumstance, the calculated filter index may be out-of-bounds. (An example is in Inception_v1 Caffe2 model, the outChannel is 192, numDepthRegs is 8 and depthStrips is 2.)
One solution is in node level, we apply DKKC8 only if output_channel / group is divisible by 512, since numDepthRegs could be only 2 or 8 and depthStrips could be only 1, 2, 4, 8. But I think this would affect the performance. 
The second way is add boundary check in libjit, which is applied in this PR.