### PR TITLE
[WIP] Implement the Caffe2 batched operator.

### DIFF
--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -269,6 +269,19 @@ struct Type final {
     return s;
   }
 
+  /// \returns the number of elements in a slice in the tensor. Calculate the
+  /// size of the slice starting at \p startDim. For example, the tensor with
+  /// the shape [10, 10, 3] and startDim 1 would have the size 30, because this
+  /// is the size of the slice [10, 3] that starts at index 1.
+  size_t getSlicesize(unsigned startDim) const {
+    assert(startDim <= numSizes_ && "Invalid start dim");
+    size_t s = 1;
+    for (unsigned i = startDim; i < numSizes_; i++) {
+      s *= size_t(sizes_[i]);
+    }
+    return s;
+  }
+
   /// \returns true if the templated parameter \p ElemTy matches this type.
   template <class ElemTy> bool isType() const {
     return isType<ElemTy>(elementType_);

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -434,8 +434,12 @@ public:
 
   TopKNode *createTopK(llvm::StringRef name, NodeValue input, size_t k);
 
+  /// Gathers entries of the outer-most dimension of \p data indexed by
+  /// \p indices, and concatenates them. A non-zero \p batchDims specifies the
+  /// batch, and the result is the concatenation of the operation on each sample
+  /// in the batch.
   GatherNode *createGather(llvm::StringRef name, NodeValue data,
-                           NodeValue indices);
+                           NodeValue indices, unsigned batchDims = 0);
 
   /// Copies each slice from \p slices into \p data at the corresponding index
   /// in \p indices, and \returns this new version of data. For example, given

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1219,15 +1219,17 @@ TopKNode *Function::createTopK(llvm::StringRef name, NodeValue input,
 }
 
 GatherNode *Function::createGather(llvm::StringRef name, NodeValue data,
-                                   NodeValue indices) {
+                                   NodeValue indices, unsigned batchDims) {
   auto dDims = data.dims();
   auto iDims = indices.dims();
   assert(dDims.size() > 0);
-  ShapeVector outDims(iDims.begin(), iDims.end());
-  outDims.insert(outDims.end(), dDims.begin() + 1, dDims.end());
+  ShapeVector outDims;
+  outDims.insert(outDims.end(), dDims.begin(), dDims.begin() + batchDims);
+  outDims.insert(outDims.end(), iDims.begin(), iDims.end());
+  outDims.insert(outDims.end(), dDims.begin() + batchDims + 1, dDims.end());
   return addNode(new GatherNode(
       name, getParent()->uniqueTypeWithNewShape(data.getType(), outDims), data,
-      indices));
+      indices, batchDims));
 }
 
 ScatterAssignNode *Function::createScatterAssign(llvm::StringRef name,

--- a/tests/unittests/tensorsTest.cpp
+++ b/tests/unittests/tensorsTest.cpp
@@ -36,6 +36,20 @@ TEST(Tensor, init) {
   H.dump();
 }
 
+TEST(Tensor, getSlicesize) {
+  // Test the Type::getSlicesize() function.
+  
+  Tensor X(ElemKind::FloatTy, {3, 2, 10, 4});
+  Tensor Y(ElemKind::FloatTy, {1, 2, 3, 4});
+
+  EXPECT_EQ(X.getType().getSlicesize(0), 3 * 2 * 10 * 4);
+  EXPECT_EQ(X.getType().getSlicesize(1), 2 * 10 * 4);
+  EXPECT_EQ(X.getType().getSlicesize(2), 10 * 4);
+  EXPECT_EQ(X.getType().getSlicesize(3), 4);
+  EXPECT_EQ(Y.getType().getSlicesize(0), 1 * 2 * 3 * 4);
+  EXPECT_EQ(Y.getType().getSlicesize(3), 4);
+}
+
 TEST(Tensor, randomizeInt) {
   PseudoRNG PRNG;
   Tensor T(ElemKind::Int8QTy, {10, 10}, 1.0, 0);

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -378,6 +378,7 @@ int main(int argc, char **argv) {
       .addOperand("Dest", OperandKind::Out)
       .addOperand("Data", OperandKind::In)
       .addOperand("Indices", OperandKind::In)
+      .addMember(MemberType::Unsigned, "BatchDims")
       .autoVerify(VerifyKind::SameElementType, {"Dest", "Data"})
       .autoVerify(VerifyKind::SameElementType, {"Indices", "ElemKind::IndexTy"})
       .autoIRGen();

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -344,12 +344,16 @@ int main(int argc, char **argv) {
   BB.newNode("Gather")
       .addInput("Data")
       .addInput("Indices")
+      .addMember(MemberType::Unsigned, "BatchDims")
       .addResultFromCtorArg()
-      .setDocstring("Gathers entries of the outer-most dimension of Data  "
-                    "indexed by Indices, and concatenates them. Output tensor  "
-                    "will have dimensions: "
-                    "{I_0, I_1, ... I_n, D_1, D_2, ... D_m}, where D_i and I_j "
-                    "denote Data and Indices dimensions respectively.");
+      .setDocstring("Gathers entries of the outer-most dimension of Data "
+                    "indexed by Indices, and concatenates them. Output tensor "
+                    "will have dimensions: {I_0, I_1, ... I_n, D_1, D_2, ... "
+                    "D_m}, where D_i and I_j denote Data and Indices "
+                    "dimensions respectively. If batchDims is not zero, the "
+                    "gather operator will treat the first batchDims as the "
+                    "batch and will concat the result of the gather operation "
+                    "on each sample in the batch.");
 
   BB.newNode("ScatterAssign")
       .addInput("Data")


### PR DESCRIPTION
In this PR we update the gather node to support Batches. We add the
'batches' operand that marks some indices in the beginning of the tensor
as 'batch' indices. The gather operation is executed on each sample in
the batch independently. The batches are later concatenated. This allows
us to implement the Gather and BatchedGather operation in a single node.