### PR TITLE
Add quantization schema

### DIFF
--- a/include/glow/Quantization/Base/Base.h
+++ b/include/glow/Quantization/Base/Base.h
@@ -56,6 +56,13 @@ struct QuantizationTransform32To8 {
 
 namespace quantization {
 
+enum Schema {
+  /// Asymmetric quantization produces ranges not necessarily centered on 0.
+  Asymmetric,
+  /// Symmetric quantization produces ranges centered on 0.
+  Symmetric,
+};
+
 /// Converts floating point value to int8 based on the quantization
 /// parameters \p TQP.
 int8_t quantize(float input, const TensorQuantizationParams &TQP);
@@ -82,8 +89,10 @@ QuantizationTransform32To8 quantizeScaleOffset32To8(float scale,
                                                     int32_t offset);
 
 /// Calculate TensorQuantizationParams based on the clipped \p min and \p max
-/// floating point range.
-TensorQuantizationParams chooseQuantizationParams(float min, float max);
+/// floating point range and using the quantization method described
+/// by \p schema.
+TensorQuantizationParams chooseQuantizationParams(float min, float max,
+                                                  Schema schema = Asymmetric);
 
 } // namespace quantization
 } // namespace glow

--- a/include/glow/Quantization/Quantization.h
+++ b/include/glow/Quantization/Quantization.h
@@ -52,9 +52,11 @@ struct NodeQuantizationInfo {
 
 namespace quantization {
 
-/// Generate NodeQuantizationInfo for all required nodes from graph \p G.
+/// Generate NodeQuantizationInfo for all required nodes from graph \p G
+/// using the method specified by \p schema.
 std::vector<NodeQuantizationInfo>
-generateNodeQuantizationInfos(const Function *F);
+generateNodeQuantizationInfos(const Function *F,
+                              Schema schema = Schema::Asymmetric);
 
 /// Quantizes the function \p F into a new unoptimized partially quantized
 /// function based on \p quantizationInfos. This method converts to integer as

--- a/lib/Quantization/Base/Base.cpp
+++ b/lib/Quantization/Base/Base.cpp
@@ -189,7 +189,8 @@ TensorQuantizationParams chooseQuantizationParams(float min, float max,
                                 : zeroPointFromMax;
 
   // For symmetric quantization, if min == -max, force the zero point to be 0.
-  if (min == -max) {
+  float difference = std::abs(max + min);
+  if (difference <= std::numeric_limits<float>::epsilon()) {
     initialZeroPoint = 0;
   }
 

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -28,7 +28,7 @@ namespace glow {
 namespace quantization {
 
 std::vector<NodeQuantizationInfo>
-generateNodeQuantizationInfos(const Function *F) {
+generateNodeQuantizationInfos(const Function *F, Schema schema) {
   std::vector<NodeQuantizationInfo> quantizationInfos;
 
   for (auto &node : F->getNodes()) {
@@ -46,7 +46,7 @@ generateNodeQuantizationInfos(const Function *F) {
       // TODO: Ideally tensor quantization params should be calculated
       // based on the histogram distribution. Use simplistic approach for now.
       (void)histogram;
-      TensorQuantizationParams TQP = chooseQuantizationParams(min, max);
+      TensorQuantizationParams TQP = chooseQuantizationParams(min, max, schema);
 
       quantizationInfos.emplace_back(fullOutputName, TQP);
     }

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -68,6 +68,15 @@ llvm::cl::opt<std::string> dumpProfileFileOpt(
     llvm::cl::value_desc("profile.yaml"), llvm::cl::Optional,
     llvm::cl::cat(loaderCat));
 
+llvm::cl::opt<quantization::Schema> quantizationSchema(
+    "quantization-schema",
+    llvm::cl::desc("Specify which quantization schema to use"),
+    llvm::cl::values(clEnumValN(quantization::Schema::Asymmetric, "asymmetric",
+                                "Use asymmetric ranges"),
+                     clEnumValN(quantization::Schema::Symmetric, "symmetric",
+                                "Use symmetric ranges")),
+    llvm::cl::init(quantization::Schema::Asymmetric), llvm::cl::cat(loaderCat));
+
 llvm::cl::opt<std::string> loadProfileFileOpt(
     "load_profile",
     llvm::cl::desc("Load quantization profile file and quantize the graph"),
@@ -186,7 +195,7 @@ void Loader::runInference(llvm::ArrayRef<Variable *> variables,
 
   if (!dumpProfileFileOpt.empty()) {
     std::vector<NodeQuantizationInfo> QI =
-        quantization::generateNodeQuantizationInfos(F_);
+        quantization::generateNodeQuantizationInfos(F_, quantizationSchema);
     serializeToYaml(dumpProfileFileOpt, QI);
   }
 }


### PR DESCRIPTION
Plumb quantization schema up to the load command line so that we can choose which kind of quantization (symmetric/asymmetric) we want to use.

This is related to #1321.