### PR TITLE
[partition] Introduce FunctionGraph and produce it via partition()

### DIFF
--- a/include/glow/Optimizer/Partition.h
+++ b/include/glow/Optimizer/Partition.h
@@ -25,7 +25,7 @@ namespace glow {
 /// Maps a set of functions to the set of functions it depends on.  The
 /// execution of a function cannot begin until all its dependencies have
 /// executed.
-class FunctionGraph {
+class FunctionDAG {
   /// Dependency map type.
   using Map = llvm::DenseMap<Function *, FunctionList>;
 
@@ -40,18 +40,18 @@ class FunctionGraph {
 
 public:
   /// Ctor.
-  FunctionGraph(const FunctionList &functions);
+  FunctionDAG(const FunctionList &functions);
 
   /// Dtor.
-  ~FunctionGraph() = default;
+  ~FunctionDAG() = default;
 
   /// Move ctor.
-  FunctionGraph(FunctionGraph &&G) = default;
-  FunctionGraph &operator=(FunctionGraph &&G) = default;
+  FunctionDAG(FunctionDAG &&G) = default;
+  FunctionDAG &operator=(FunctionDAG &&G) = default;
 
-  /// FunctionGraph is non-copyable to ensure efficiency.
-  FunctionGraph(const FunctionGraph &G) = delete;
-  FunctionGraph &operator=(const FunctionGraph &G) = delete;
+  /// FunctionDAG is non-copyable to ensure efficiency.
+  FunctionDAG(const FunctionDAG &G) = delete;
+  FunctionDAG &operator=(const FunctionDAG &G) = delete;
 
   /// Get list of functions in this graph.
   const FunctionList &getFunctions() const { return functions_; }
@@ -70,8 +70,8 @@ public:
   bool verify() const;
 };
 
-/// Split an input Function into a FunctionGraph.
-FunctionGraph partition(Function *F);
+/// Split an input Function into a FunctionDAG.
+FunctionDAG partition(Function *F);
 
 } // namespace glow
 

--- a/include/glow/Optimizer/Partition.h
+++ b/include/glow/Optimizer/Partition.h
@@ -36,7 +36,7 @@ class FunctionGraph {
   FunctionList functions_;
 
   /// Input dependencies of each function.
-  Map inputs_;
+  Map dependencies_;
 
 public:
   /// Ctor.
@@ -56,15 +56,18 @@ public:
   /// Get list of functions in this graph.
   const FunctionList &getFunctions() const { return functions_; }
 
-  /// Get input dependences for a function.
-  const MappedType &getInputs(Function *F) const {
-    auto it = inputs_.find(F);
-    assert(it != inputs_.end() && "No inputs found for function in graph");
+  /// Get dependencies for a function.
+  const MappedType &getDependencies(Function *F) const {
+    auto it = dependencies_.find(F);
+    assert(it != dependencies_.end() && "No dependencies found for function in graph");
     return it->second;
   }
 
   /// Record that \p F depends on \p inputF.
-  void add(Function *F, Function *inputF) { inputs_[F].push_back(inputF); }
+  void add(Function *F, Function *inputF) { dependencies_[F].push_back(inputF); }
+
+  /// Verify that function graph is well-formed (acyclic, topologically sorted).
+  bool verify() const;
 };
 
 /// Split an input Function into a FunctionGraph.

--- a/include/glow/Optimizer/Partition.h
+++ b/include/glow/Optimizer/Partition.h
@@ -53,7 +53,7 @@ public:
   FunctionGraph &operator=(const FunctionGraph &G) = delete;
 
   /// Get list of functions in this graph.
-  FunctionList &getFunctions() { return functions_; }
+  const FunctionList &getFunctions() const { return functions_; }
 
   /// Get input dependences for a function.
   const MappedType &getInputs(Function *F) const {

--- a/include/glow/Optimizer/Partition.h
+++ b/include/glow/Optimizer/Partition.h
@@ -22,8 +22,9 @@
 
 namespace glow {
 
-/// Data structure representing a set of interdependent Functions and the
-/// dependences between them.
+/// Maps a set of functions to the set of functions it depends on.  The
+/// execution of a function cannot begin until all its dependencies have
+/// executed.
 class FunctionGraph {
   /// Dependency map type.
   using Map = llvm::DenseMap<Function *, FunctionList>;

--- a/include/glow/Optimizer/Partition.h
+++ b/include/glow/Optimizer/Partition.h
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_OPTIMIZER_PARTITION_H
+#define GLOW_OPTIMIZER_PARTITION_H
+
+#include "glow/Graph/Graph.h"
+
+#include <llvm/ADT/DenseMap.h>
+
+namespace glow {
+
+/// Data structure representing a set of interdependent Functions and the
+/// dependences between them.
+class FunctionGraph {
+  /// Dependency map type.
+  using Map = llvm::DenseMap<Function *, FunctionList>;
+
+  /// Type of dependency list.
+  using MappedType = Map::mapped_type;
+
+  /// List of functions in this graph.
+  FunctionList functions_;
+
+  /// Input dependencies of each function.
+  Map inputs_;
+
+public:
+  /// Ctor.
+  FunctionGraph(const FunctionList &functions);
+
+  /// Dtor.
+  ~FunctionGraph() = default;
+
+  /// Move ctor.
+  FunctionGraph(FunctionGraph &&G) = default;
+  FunctionGraph &operator=(FunctionGraph &&G) = default;
+
+  /// FunctionGraph is non-copyable to ensure efficiency.
+  FunctionGraph(const FunctionGraph &G) = delete;
+  FunctionGraph &operator=(const FunctionGraph &G) = delete;
+
+  /// Get list of functions in this graph.
+  FunctionList &getFunctions() { return functions_; }
+
+  /// Get input dependences for a function.
+  const MappedType &getInputs(Function *F) const {
+    auto it = inputs_.find(F);
+    assert(it != inputs_.end() && "No inputs found for function in graph");
+    return it->second;
+  }
+
+  /// Record that \p F depends on \p inputF.
+  void add(Function *F, Function *inputF) { inputs_[F].push_back(inputF); }
+};
+
+/// Split an input Function into a FunctionGraph.
+FunctionGraph partition(Function *F);
+
+} // namespace glow
+
+#endif // GLOW_OPTIMIZER_PARTITION_H

--- a/lib/Optimizer/CMakeLists.txt
+++ b/lib/Optimizer/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(Optimizer
               IROptimizer.cpp
               GraphOptimizer.cpp
               Lower.cpp
+              Partition.cpp
               Quantization.cpp)
 
 target_link_libraries(Optimizer

--- a/lib/Optimizer/Partition.cpp
+++ b/lib/Optimizer/Partition.cpp
@@ -23,6 +23,7 @@
 #include "llvm/Support/Casting.h"
 
 using namespace glow;
+using llvm::isa;
 
 namespace {
 
@@ -68,7 +69,7 @@ Node *singleNonVariableInput(Node *node) {
 
   for (unsigned i = 0, e = node->getNumInputs(); i < e; i++) {
     Node *in = node->getNthInput(i).getNode();
-    if (llvm::isa<Variable>(in))
+    if (isa<Variable>(in))
       continue;
     if (nonVarInput)
       return nullptr;
@@ -88,7 +89,7 @@ NodeFunctionMap selectPartitions(Function *F) {
   // assigned to a partition before it is assigned.
   GraphPostOrderVisitor visitor(*F);
   for (auto *node : visitor.getPostOrder()) {
-    if (llvm::isa<Variable>(node))
+    if (isa<Variable>(node))
       continue;
 
     // If node has only one input, and that input has only one output, place it
@@ -131,7 +132,7 @@ FunctionGraph doPartitioning(Function *F, NodeFunctionMap &mapping) {
     for (auto &N : F->getNodes()) {
       for (unsigned inp = 0, e = N.getNumInputs(); inp < e; inp++) {
         auto input = N.getNthInput(inp);
-        if (llvm::isa<Variable>(input.getNode()))
+        if (isa<Variable>(input.getNode()))
           continue;
 
         auto *inputF = mapping[input.getNode()];
@@ -166,7 +167,7 @@ FunctionGraph doPartitioning(Function *F, NodeFunctionMap &mapping) {
       for (unsigned inp = 0, e = N.getNumInputs(); inp < e; inp++) {
         auto input = N.getNthInput(inp);
 
-        if (llvm::isa<Variable>(input.getNode()))
+        if (isa<Variable>(input.getNode()))
           continue;
 
         // Link this node to the clone of its input.

--- a/lib/Optimizer/Partition.cpp
+++ b/lib/Optimizer/Partition.cpp
@@ -1,0 +1,194 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/Optimizer/Partition.h"
+
+#include "glow/Graph/Graph.h"
+#include "glow/Graph/Utils.h"
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/Support/Casting.h"
+
+using namespace glow;
+
+namespace {
+
+/// Helper structure for building a partition. Records a mapping of nodes in the
+/// original function to destination partitions, along with a list of the
+/// newly-created functions.
+class NodeFunctionMap {
+  using Map = llvm::DenseMap<Node *, Function *>;
+
+  /// Newly-created partitions.
+  FunctionList functions_;
+
+  /// Map of nodes in the original function to their target partition.
+  Map nodeToFunction_;
+
+public:
+  /// Create a new partition \p F. Add it to the map with initial node \p N.
+  void create(Node *N, Function *F) {
+    functions_.emplace_back(F);
+    nodeToFunction_[N] = F;
+  }
+
+  /// Add a new Node->Function mapping.
+  void add(Node *N, Function *F) { nodeToFunction_[N] = F; }
+
+  /// Get list of functions contained in this map.
+  FunctionList &getFunctions() { return functions_; }
+
+  /// \returns the number of partitions.
+  Map::size_type size() const { return functions_.size(); }
+
+  /// Map API.
+  Map::iterator find(Node *N) { return nodeToFunction_.find(N); }
+  Map::iterator begin() { return nodeToFunction_.begin(); }
+  Map::iterator end() { return nodeToFunction_.end(); }
+  Function *operator[](Node *n) { return nodeToFunction_[n]; }
+};
+
+/// If \p node has a single input that is not a variable, return it.  Otherwise
+/// return nullptr.
+Node *singleNonVariableInput(Node *node) {
+  Node *nonVarInput = nullptr;
+
+  for (unsigned i = 0, e = node->getNumInputs(); i < e; i++) {
+    Node *in = node->getNthInput(i).getNode();
+    if (llvm::isa<Variable>(in))
+      continue;
+    if (nonVarInput)
+      return nullptr;
+    nonVarInput = in;
+  }
+  return nonVarInput;
+}
+
+/// Assign nodes to partitions and return the mapping.  This algorithm
+/// partitions the graph in a manner that looks like basic blocks in a control
+/// flow graphs: regions end after a node with multiple outputs or before a node
+/// with multiple inputs.
+NodeFunctionMap selectPartitions(Function *F) {
+  NodeFunctionMap mapping;
+
+  // Visit graph nodes in reverse post order so that a node's inputs are already
+  // assigned to a partition before it is assigned.
+  GraphPostOrderVisitor visitor(*F);
+  for (auto *node : visitor.getPostOrder()) {
+    if (llvm::isa<Variable>(node))
+      continue;
+
+    // If node has only one input, and that input has only one output, place it
+    // in the same partition.
+    auto *in = singleNonVariableInput(node);
+    if (in && in->getNumUsers() == 1) {
+      auto it = mapping.find(in);
+      assert(it != mapping.end());
+      mapping.add(node, it->second);
+      continue;
+    }
+
+    // Start a new partition with this node.
+    auto *newF = F->getParent()->createFunction(
+        std::string(F->getName()) + "_part" + std::to_string(mapping.size()));
+    mapping.create(node, newF);
+  }
+
+  return mapping;
+}
+
+/// Given a function \p F and partitioning \p mapping, \return a FunctionGraph
+/// that contains appropriately-partitioned functions and their dependences.
+FunctionGraph doPartitioning(Function *F, NodeFunctionMap &mapping) {
+  FunctionGraph G(mapping.getFunctions());
+  llvm::DenseMap<Node *, Node *> currToNew;
+  auto *mod = F->getParent();
+
+  // Clone nodes into target partition.
+  for (auto &N : F->getNodes()) {
+    auto *clone = N.clone();
+    currToNew[&N] = clone;
+    mapping[&N]->addNode(clone);
+  }
+
+  // For any dependency that crosses a partition, add a variable and save
+  // node. Record the dependence in the function graph.
+  llvm::DenseMap<Node *, Variable *> variables;
+  for (auto *F : mapping.getFunctions()) {
+    for (auto &N : F->getNodes()) {
+      for (unsigned inp = 0, e = N.getNumInputs(); inp < e; inp++) {
+        auto input = N.getNthInput(inp);
+        if (llvm::isa<Variable>(input.getNode()))
+          continue;
+
+        auto *inputF = mapping[input.getNode()];
+        if (F == inputF)
+          continue;
+
+        // Add this dependence to the FunctionGraph.
+        G.add(F, inputF);
+
+        // If we've already created a variable for this dependence, use it.
+        auto it = variables.find(input.getNode());
+        if (it != variables.end()) {
+          N.setNthInput(inp, it->second);
+          continue;
+        }
+
+        // Create a new variable to represent this dependence.
+        auto *tmp = mod->createVariable(
+            input.getType(), std::string(input->getName()) + "_tmp",
+            VisibilityKind::Private, Variable::TrainKind::None);
+        inputF->createSave("tmp", input, tmp);
+        variables[input.getNode()] = tmp;
+        N.setNthInput(inp, tmp);
+      }
+    }
+  }
+
+  // Update links between nodes in the cloned functions.  Add variables (and
+  // save nodes) where a link crosses a partition boundary.
+  for (auto *F : mapping.getFunctions()) {
+    for (auto &N : F->getNodes()) {
+      for (unsigned inp = 0, e = N.getNumInputs(); inp < e; inp++) {
+        auto input = N.getNthInput(inp);
+
+        if (llvm::isa<Variable>(input.getNode()))
+          continue;
+
+        // Link this node to the clone of its input.
+        auto *clone = currToNew[input.getNode()];
+        N.setNthInput(inp, NodeValue(clone, input.getResNo()));
+      }
+    }
+  }
+
+  return G;
+}
+
+} // end namespace
+
+FunctionGraph::FunctionGraph(const FunctionList &functions)
+    : functions_(functions) {
+  for (auto *F : functions_) {
+    inputs_[F] = FunctionList();
+  }
+}
+
+FunctionGraph glow::partition(Function *F) {
+  NodeFunctionMap partitionMap = selectPartitions(F);
+  return doPartitioning(F, partitionMap);
+}

--- a/lib/Optimizer/Partition.cpp
+++ b/lib/Optimizer/Partition.cpp
@@ -112,10 +112,10 @@ NodeFunctionMap selectBasicBlockPartitions(Function *F) {
   return mapping;
 }
 
-/// Given a function \p F and partitioning \p mapping, \return a FunctionGraph
+/// Given a function \p F and partitioning \p mapping, \return a FunctionDAG
 /// that contains appropriately-partitioned functions and their dependences.
-FunctionGraph doPartitioning(Function *F, NodeFunctionMap &mapping) {
-  FunctionGraph G(mapping.getFunctions());
+FunctionDAG doPartitioning(Function *F, NodeFunctionMap &mapping) {
+  FunctionDAG G(mapping.getFunctions());
   llvm::DenseMap<Node *, Node *> currToNew;
   auto *mod = F->getParent();
 
@@ -140,7 +140,7 @@ FunctionGraph doPartitioning(Function *F, NodeFunctionMap &mapping) {
         if (F == inputF)
           continue;
 
-        // Add this dependence to the FunctionGraph.
+        // Add this dependence to the FunctionDAG.
         G.add(F, inputF);
 
         // If we've already created a variable for this dependence, use it.
@@ -183,14 +183,14 @@ FunctionGraph doPartitioning(Function *F, NodeFunctionMap &mapping) {
 
 } // end namespace
 
-FunctionGraph::FunctionGraph(const FunctionList &functions)
+FunctionDAG::FunctionDAG(const FunctionList &functions)
     : functions_(functions) {
   for (auto *F : functions_) {
     dependencies_[F] = FunctionList();
   }
 }
 
-bool FunctionGraph::verify() const {
+bool FunctionDAG::verify() const {
   llvm::DenseSet<Function *> seen;
   for (auto *F : functions_) {
     for (auto *dep : dependencies_.lookup(F)) {
@@ -202,7 +202,7 @@ bool FunctionGraph::verify() const {
   return true;
 }
 
-FunctionGraph glow::partition(Function *F) {
+FunctionDAG glow::partition(Function *F) {
   NodeFunctionMap partitionMap = selectBasicBlockPartitions(F);
   auto G = doPartitioning(F, partitionMap);
   assert(G.verify());

--- a/lib/Optimizer/Partition.cpp
+++ b/lib/Optimizer/Partition.cpp
@@ -49,7 +49,7 @@ public:
   void add(Node *N, Function *F) { nodeToFunction_[N] = F; }
 
   /// Get list of functions contained in this map.
-  FunctionList &getFunctions() { return functions_; }
+  const FunctionList &getFunctions() const { return functions_; }
 
   /// \returns the number of partitions.
   Map::size_type size() const { return functions_.size(); }

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -5,6 +5,15 @@ target_link_libraries(testMain
                         LLVMSupport
                         gtest)
 
+add_executable(partitionTest
+               partitionTest.cpp)
+target_link_libraries(partitionTest
+                      PRIVATE
+                        ExecutionEngine
+                        gtest
+                        testMain)
+add_glow_test(partitionTest ${GLOW_BINARY_DIR}/tests/partitionTest)
+
 add_executable(tensorsTest
                tensorsTest.cpp)
 target_link_libraries(tensorsTest
@@ -81,7 +90,6 @@ target_link_libraries(operatorTest
                         gtest
                         testMain)
 add_glow_test(operatorTest ${GLOW_BINARY_DIR}/tests/operatorTest)
-
 
 add_executable(graphTest
                graphTest.cpp)

--- a/tests/unittests/partitionTest.cpp
+++ b/tests/unittests/partitionTest.cpp
@@ -1,0 +1,143 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "BackendTestUtils.h"
+
+#include "glow/Graph/Graph.h"
+#include "glow/Optimizer/Partition.h"
+
+#include "gtest/gtest.h"
+
+using namespace glow;
+
+class PartitionTest : public ::testing::Test {
+public:
+  PartitionTest() : F_(mod_.createFunction("main")) {}
+
+protected:
+  Module mod_;
+  Function *F_;
+};
+
+TEST_F(PartitionTest, SerialExecution) {
+  auto *input =
+      mod_.createVariable(ElemKind::FloatTy, {1, 32}, "input",
+                          VisibilityKind::Public, Variable::TrainKind::None);
+
+  // Initial FC.
+  Node *I = F_->createFullyConnected("initial_fc", input, 16);
+  I = F_->createSigmoid("initial_sigmoid", I);
+
+  // Left branch.
+  Node *L = F_->createFullyConnected("left_fc1", I, 16);
+  L = F_->createSigmoid("left_sigmoid1", L);
+  L = F_->createFullyConnected("left_fc2", L, 8);
+  L = F_->createSigmoid("left_sigmoid2", L);
+
+  // Right branch.
+  Node *R = F_->createFullyConnected("right_fc1", I, 16);
+  R = F_->createSigmoid("right_sigmoid1", R);
+  R = F_->createFullyConnected("right_fc2", R, 8);
+  R = F_->createSigmoid("right_sigmoid2", R);
+
+  // Join branches.
+  auto *mul = F_->createMul("mul", L, R);
+  auto *save = F_->createSave("ret", mul);
+  auto &res = save->getVariable()->getPayload();
+
+  auto G = glow::partition(F_);
+  ASSERT_EQ(G.getFunctions().size(), 4);
+
+  auto it = G.getFunctions().begin();
+  {
+    auto *F = *it++;
+    EXPECT_EQ(F->getNodes().size(), 3);
+    EXPECT_EQ(G.getInputs(F).size(), 0);
+  }
+  {
+    auto *F = *it++;
+    EXPECT_EQ(F->getNodes().size(), 5);
+    EXPECT_EQ(G.getInputs(F).size(), 1);
+  }
+  {
+    auto *F = *it++;
+    EXPECT_EQ(F->getNodes().size(), 5);
+    EXPECT_EQ(G.getInputs(F).size(), 1);
+  }
+  {
+    auto *F = *it++;
+    EXPECT_EQ(F->getNodes().size(), 2);
+    EXPECT_EQ(G.getInputs(F).size(), 2);
+  }
+
+  // Infer using the un-partitioned graph.
+  Tensor in(ElemKind::FloatTy, {1, 32});
+  ExecutionEngine EE;
+  EE.compile(CompilationMode::Infer, F_->clone("clone"));
+  EE.run({input}, {&in});
+  Tensor ref = res.clone();
+
+  // Infer using the partitioned graph.
+  res.zero();
+  for (auto *F : G.getFunctions()) {
+    ExecutionEngine EE;
+    EE.compile(CompilationMode::Infer, F);
+    EE.run({input}, {&in});
+  }
+  Tensor test = res.clone();
+  EXPECT_TRUE(ref.isEqual(test));
+}
+
+TEST_F(PartitionTest, Branchover) {
+  auto *input =
+      mod_.createVariable(ElemKind::FloatTy, {1, 8}, "input",
+                          VisibilityKind::Public, Variable::TrainKind::None);
+  auto *FC1 = F_->createFullyConnected("fc1", input, 8);
+  auto *FC2 = F_->createFullyConnected("fc2", FC1, 8);
+  auto *add = F_->createAdd("add", FC1, FC2);
+  F_->createSave("save", add);
+
+  auto G = glow::partition(F_);
+  ASSERT_EQ(G.getFunctions().size(), 3);
+
+  auto it = G.getFunctions().begin();
+  {
+    auto *F = *it++;
+    EXPECT_EQ(F->getNodes().size(), 2);
+    EXPECT_EQ(G.getInputs(F).size(), 0);
+  }
+  {
+    auto *F = *it++;
+    EXPECT_EQ(F->getNodes().size(), 2);
+    EXPECT_EQ(G.getInputs(F).size(), 1);
+  }
+  {
+    auto *F = *it++;
+    EXPECT_EQ(F->getNodes().size(), 2);
+    EXPECT_EQ(G.getInputs(F).size(), 2);
+  }
+}
+
+TEST_F(PartitionTest, Train) {
+  auto *input =
+      mod_.createVariable(ElemKind::FloatTy, {1, 8}, "input",
+                          VisibilityKind::Public, Variable::TrainKind::None);
+  auto *FC = F_->createFullyConnected("fc", input, 8);
+  F_->createSave("save", FC);
+  auto *TF = glow::differentiate(F_, TrainingConfig());
+  auto G = glow::partition(TF);
+  ASSERT_EQ(G.getFunctions().size(), 6);
+}

--- a/tests/unittests/partitionTest.cpp
+++ b/tests/unittests/partitionTest.cpp
@@ -35,7 +35,7 @@ protected:
 };
 
 /// Execute a graph of functions serially, which is the simplest approach.
-static void executeSerial(const FunctionGraph &G,
+static void executeSerial(const FunctionDAG &G,
                           llvm::ArrayRef<Variable *> vars,
                           llvm::ArrayRef<Tensor *> inputs) {
   for (auto *F : G.getFunctions()) {
@@ -167,7 +167,7 @@ TEST_F(PartitionTest, VerifyTopo) {
   auto *F1 = mod_.createFunction("F1");
   auto *F2 = mod_.createFunction("F2");
   FunctionList functions{F1, F2};
-  FunctionGraph G(functions);
+  FunctionDAG G(functions);
   G.add(F2, F1);
   EXPECT_TRUE(G.verify());
 }
@@ -176,7 +176,7 @@ TEST_F(PartitionTest, VerifyTopoFails) {
   auto *F1 = mod_.createFunction("F1");
   auto *F2 = mod_.createFunction("F2");
   FunctionList functions{F1, F2};
-  FunctionGraph G(functions);
+  FunctionDAG G(functions);
   G.add(F1, F2);
   EXPECT_FALSE(G.verify());
 }
@@ -184,7 +184,7 @@ TEST_F(PartitionTest, VerifyTopoFails) {
 TEST_F(PartitionTest, VerifyCyclicFails) {
   auto *F1 = mod_.createFunction("F1");
   FunctionList functions{F1};
-  FunctionGraph G(functions);
+  FunctionDAG G(functions);
   G.add(F1, F1);
   EXPECT_FALSE(G.verify());
 }


### PR DESCRIPTION
The FunctionGraph representation and the partitioning process seemed like the least controversial parts of the partitioning PR, so I've extracted them, cleaned up and simplified the logic, and put them up for review.

`glow::partition()` is now a standalone function that produces a `FunctionGraph`.  How this graph is executed is an orthogonal question; currently the test simply uses serial execution of the subgraphs, which is the simplest approach.