### PR TITLE
Add MeanVarNormalization for use by BatchNormalization for training

### DIFF
--- a/include/glow/Optimizer/Optimizer.h
+++ b/include/glow/Optimizer/Optimizer.h
@@ -37,7 +37,7 @@ void optimize(Function *F, CompilationMode mode);
 
 /// Lower the high-level neural network operators into low-level linear algebra
 /// operators.
-void lower(Function *F, CompilationMode mode, const Backend &B);
+void lower(Function *F, const Backend &B);
 
 /// Instrument function \p F by inserting quantization profile nodes
 /// for capturing stats for quantization. The new quantized function is called

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -136,7 +136,7 @@ std::unique_ptr<IRFunction> ExecutionEngine::generateIR(CompilationMode mode,
   }
 
   // Lower the graph into a sequence of low-level linear algebra operations.
-  ::glow::lower(F, mode, *backend_);
+  ::glow::lower(F, *backend_);
 
   // Optimize the graph again.
   ::glow::optimize(F, mode);

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -485,6 +485,11 @@ void BatchNormalizationGradNode::verify() const {
       getGradOfInputNamedMean(), getGradOfInputNamedVar(), ChannelIdx_);
 }
 
+void MeanVarNormalizationNode::verify() const {
+  checkType(getMean(), ElemKind::FloatTy);
+  checkSameType(getMean(), getVar());
+}
+
 void LocalResponseNormalizationNode::verify() const {
   verifyLocalResponseNormalization(getInput(), getResult());
 }

--- a/lib/Optimizer/Lower.cpp
+++ b/lib/Optimizer/Lower.cpp
@@ -579,7 +579,7 @@ void lowerGroupConvolutionNode(Function *F, ConvolutionNode &BNG) {
   BNG.getResult().replaceAllUsesOfWith(result);
 }
 
-void glow::lower(Function *F, CompilationMode mode, const Backend &B) {
+void glow::lower(Function *F, const Backend &B) {
   auto &nodes = F->getNodes();
 
   for (auto &N : nodes) {

--- a/tests/unittests/graphTest.cpp
+++ b/tests/unittests/graphTest.cpp
@@ -54,7 +54,7 @@ TEST(Graph, simpleTestConv) {
   F->createSave("Save", K);
   F->dump();
   F->dumpDAG();
-  lower(F, CompilationMode::Train, MockBackend());
+  lower(F, MockBackend());
   ::optimize(F, CompilationMode::Train);
   M.generateIR();
   M.dump();
@@ -179,7 +179,7 @@ TEST(Graph, simpleTestFC) {
   F->createSave("Save", O);
   F->dump();
   F->dumpDAG();
-  lower(F, CompilationMode::Train, MockBackend());
+  lower(F, MockBackend());
   ::optimize(F, CompilationMode::Train);
   M.generateIR();
   M.dump();
@@ -213,7 +213,7 @@ TEST(Graph, QuantizationProfileNodes) {
   // Simulate actual usage.
   ::optimize(F, CompilationMode::Infer);
   F = ::glow::profileQuantization(F);
-  lower(F, CompilationMode::Infer, MockBackend());
+  lower(F, MockBackend());
   ::optimize(F, CompilationMode::Infer);
 
   size_t numberOfProfileNodes =
@@ -430,7 +430,7 @@ unsigned getConvNodeSize(BackendKind kind) {
   F->createSave("save", CN);
 
   std::unique_ptr<Backend> backend(createBackend(kind));
-  lower(F, CompilationMode::Infer, *backend);
+  lower(F, *backend);
 
   unsigned count = 0;
   for (auto &n : F->getNodes()) {

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -120,6 +120,17 @@ int main(int argc, char **argv) {
                     "Momentum. Similar to Caffe2 SpatialBN, and ONNX "
                     "BatchNormalization operator.");
 
+  BB.newNode("MeanVarNormalization")
+      .addInput("Input")
+      .addInput("Mean")
+      .addInput("Var")
+      .addMember(MemberType::SizeT, "ChannelIdx")
+      .addMember(MemberType::Float, "Momentum")
+      .addResult("Mean.getType()", "NewMean")
+      .addResult("Var.getType()", "NewVar")
+      .setDocstring("Calculates new normalized mean and variance based on the "
+                    "input mean, variance, and input.");
+
   BB.newNode("LocalResponseNormalization")
       .addInput("Input")
       .addMember(MemberType::SizeT, "HalfWindowSize")


### PR DESCRIPTION
I removed the CompilationMode from `lower()` in a separate commit here as well. This resolves https://github.com/pytorch/glow/issues/1309.