### PR TITLE
[quantization][opencl]: Support quantization for the slow ConvolutionInst

### DIFF
--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -878,6 +878,16 @@ void OpenCLFunction::execute() {
       setKernelArg(kernel, numArgs + 5, idim);
       setKernelArg(kernel, numArgs + 6,
                    ShapeNHWC(CC->getFilter()->getType()->dims()));
+      if (isQuantized) {
+        setKernelArg(kernel, numArgs + 7, CC->getDest()->getType()->getOffset());
+        setKernelArg(kernel, numArgs + 8, CC->getDest()->getType()->getScale());
+        setKernelArg(kernel, numArgs + 9, CC->getSrc()->getType()->getOffset());
+        setKernelArg(kernel, numArgs + 10, CC->getSrc()->getType()->getScale());
+        setKernelArg(kernel, numArgs + 11, CC->getFilter()->getType()->getOffset());
+        setKernelArg(kernel, numArgs + 12, CC->getFilter()->getType()->getScale());
+        setKernelArg(kernel, numArgs + 13, CC->getBias()->getType()->getOffset());
+        setKernelArg(kernel, numArgs + 14, CC->getBias()->getType()->getScale());
+      }
 
       // Use a 3D grid where the first dimension is the depth and the second
       // dimension is the slice index in the batch.

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -180,6 +180,7 @@ public:
     if (elementTy == ElemKind::Int8QTy) {
       switch (opKind) {
       case Kinded::Kind::AddNodeKind:
+      case Kinded::Kind::ConvolutionNodeKind:
       case Kinded::Kind::DequantizeNodeKind:
       case Kinded::Kind::DivNodeKind:
       case Kinded::Kind::MaxNodeKind:

--- a/lib/Backends/OpenCL/Transforms.cpp
+++ b/lib/Backends/OpenCL/Transforms.cpp
@@ -36,6 +36,9 @@ bool OCLBackend::transformPostLowering(Function *F,
   bool changed = false;
   for (auto &node : F->getNodes()) {
     if (auto *CN = dyn_cast<ConvolutionNode>(&node)) {
+      if (CN->getInput()->getType(0)->isQuantizedType()) {
+        continue;
+      }
       auto *NR = convertConvToNCHWConv<OCLConvolutionNode>(CN, F);
       NodeValue(&node, 0).replaceAllUsesOfWith(NR);
       changed = true;

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -1076,9 +1076,9 @@ void checkIntConvolution(ExecutionEngine &EE, unsigned convDepth) {
   }
 }
 
-TEST_P(InterpAndCPU, IntConvolutionDepth10) { checkIntConvolution(EE_, 10); }
+TEST_P(Operator, IntConvolutionDepth10) { checkIntConvolution(EE_, 10); }
 
-TEST_P(InterpAndCPU, IntConvolutionDepth8) { checkIntConvolution(EE_, 8); }
+TEST_P(Operator, IntConvolutionDepth8) { checkIntConvolution(EE_, 8); }
 
 TEST_P(InterpAndCPU, IntConcat) {
   auto A = mod_.createVariable(ElemKind::FloatTy, {3, 3}, "A");


### PR DESCRIPTION
Support quantization for the slow implementation of ConvolutionInst.
-- Changed the Transform.cpp so that we execute the slow convolution inst when input type is quantized.