### PR TITLE
[Cleanup] Move the method sliceSize from Tensor to Type.

### DIFF
--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -435,6 +435,10 @@ public:
     return R % sizes_[dim];
   }
 
+  /// \returns the type of the tensor.
+  const Type &getType() const { return tensor_->getType(); }
+
+  /// \returns the element type of the tensor.
   ElemKind getElementType() const { return tensor_->getElementType(); }
 
   /// Construct a Tensor handle.
@@ -467,16 +471,6 @@ public:
 
   /// \returns the number of elements in the whole tensor.
   size_t size() const { return tensor_->size(); }
-
-  /// \returns the number of elements in a slice for a specific dimension.
-  /// For a tensor of dimensions (w, x,y,z) the result for each value of \p
-  /// dimIdx would be [x * y * z, y * z, z, 1]. This means that each element
-  /// in the n-th dimension is made of tensors with n-1 dimensions, and this
-  /// function returns the size of that tensor.
-  size_t sliceSize(unsigned dimIdx) const {
-    assert(dimIdx < max_tensor_dimensions);
-    return sizeIntegral_[dimIdx];
-  }
 
   bool isInBounds(llvm::ArrayRef<size_t> indices) const {
     return tensor_->isInBounds(indices);

--- a/lib/Base/Tensor.cpp
+++ b/lib/Base/Tensor.cpp
@@ -66,6 +66,7 @@ template <class ElemTy>
 static void dumpGenericImpl(Handle<ElemTy> handle, llvm::raw_ostream &os) {
   auto shape = handle.dims();
   size_t numDims = shape.size();
+  auto &Ty = handle.getType();
 
   // Check for 0-dimensional tensor.
   if (!numDims) {
@@ -112,7 +113,7 @@ static void dumpGenericImpl(Handle<ElemTy> handle, llvm::raw_ostream &os) {
 
     // Print one open brace at the beginning of every row, slice, and tensor.
     for (size_t j = 0, e = numDims - 1; numDims > 1 && j < e; j++) {
-      if (i % handle.sliceSize(j) == 0) {
+      if (i % Ty.getSliceSize(j + 1) == 0) {
         // This iteration of outer loop is a new row, slice or tensor.
         os << "[";
       }
@@ -124,7 +125,7 @@ static void dumpGenericImpl(Handle<ElemTy> handle, llvm::raw_ostream &os) {
     // Print one closed brace at the end of every row, slice, or tensor.
     for (size_t j = 0, e = numDims - 1; numDims > 1 && j < e; j++) {
       size_t next_index = i + 1;
-      if (next_index % handle.sliceSize(j) == 0u) {
+      if (next_index % Ty.getSliceSize(j + 1) == 0u) {
         os << "]";
       }
     }
@@ -134,7 +135,7 @@ static void dumpGenericImpl(Handle<ElemTy> handle, llvm::raw_ostream &os) {
     // Print one newline at the end of every row, slice, or tensor.
     for (size_t j = 0, e = numDims - 1; numDims > 1 && j < e; j++) {
       size_t next_index = i + 1;
-      if (next_index % handle.sliceSize(j) == 0u) {
+      if (next_index % Ty.getSliceSize(j + 1) == 0u) {
         // Next iteration of outer loop will be a new row, slice or tensor.
         os << "\n";
       }


### PR DESCRIPTION
Replace calls to sliceSize with Type::getSliceSize(). Slice information is related to Type and not to the tensor. Graph node operands are not backed by tensors and we still want to figure out information about them without allocating a tensor.