### PR TITLE
[trivial] Use GLOW_UNREACHABLE where appropriate

### DIFF
--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -485,7 +485,7 @@ llvm::Function *LLVMIRGen::getFunction(const std::string &name,
   case ElemKind::IndexTy:
     return get("libjit_" + name + "_u");
   default:
-    GLOW_ASSERT("Unsupported element type");
+    GLOW_UNREACHABLE("Unsupported element type");
   }
 }
 


### PR DESCRIPTION
I saw a "control reaches end of non-void function" error here when compiling with `-Wreturn-type`.  We could also use `GLOW_ASSERT(false && ...)`, but either way we need to do something that actually terminates the function here.