### PR TITLE
Variable: Remove the VariableNode hack. NFC.

### DIFF
--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -60,14 +60,14 @@ public:
   /// Create a new variable and initialize its payload.
   Variable(llvm::StringRef name, TypeRef Ty, VisibilityKind visibility,
            TrainKind train, float val, PseudoRNG &PRNG)
-      : Node(Kinded::Kind::VariableNodeKind, name), val_(val), train_(train),
+      : Node(Kinded::Kind::VariableKind, name), val_(val), train_(train),
         visibility_(visibility) {
     addResult(Ty);
     initPayload(PRNG);
   }
 
   Variable(llvm::StringRef name, VisibilityKind visibility, Tensor &&payload)
-      : Node(Kinded::Kind::VariableNodeKind, name), val_(0.0),
+      : Node(Kinded::Kind::VariableKind, name), val_(0.0),
         train_(TrainKind::None), visibility_(visibility),
         payload_(std::move(payload)) {
     addResult(&payload_.getType());
@@ -80,7 +80,7 @@ public:
   bool isPrivate() const { return visibility_ == VisibilityKind::Private; }
 
   static bool classof(const Kinded *k) {
-    return k->getKind() == Kinded::Kind::VariableNodeKind;
+    return k->getKind() == Kinded::Kind::VariableKind;
   }
 
   /// \returns the original training mode of the variable.
@@ -128,8 +128,6 @@ public:
 
   llvm::hash_code getHash() const;
 };
-
-class VariableNode : public Variable {};
 
 /// Calculate the size of the output tensor based on the convolution/pooling
 /// parameters.

--- a/lib/IR/IRGen.cpp
+++ b/lib/IR/IRGen.cpp
@@ -365,7 +365,7 @@ public:
       V->setName(N->getName());
       break;
     }
-    case glow::Kinded::Kind::VariableNodeKind: {
+    case glow::Kinded::Kind::VariableKind: {
       auto *V = cast<Variable>(N);
       auto *W = builder_.createWeightVar(V->getType(), V->getName(),
                                          WeightVar::MutabilityKind::Mutable,

--- a/tests/unittests/graphOptzTest.cpp
+++ b/tests/unittests/graphOptzTest.cpp
@@ -149,9 +149,8 @@ TEST_F(GraphOptz, optimizeBatchNormAfterConvButVarReused) {
   ::glow::optimize(F_, CompilationMode::Infer);
   // Make sure the structure of the graph did not change.
   EXPECT_EQ(F_->getNodes().size(), 4);
-  EXPECT_TRUE(llvm::isa<VariableNode>(filterSave->getInput()));
-  VariableNode *varFilter =
-      llvm::dyn_cast<VariableNode>(filterSave->getInput());
+  EXPECT_TRUE(llvm::isa<Variable>(filterSave->getInput()));
+  Variable *varFilter = llvm::dyn_cast<Variable>(filterSave->getInput());
   EXPECT_EQ(varFilter, CV->getFilter());
   EXPECT_TRUE(llvm::isa<BatchNormalizationNode>(ret->getInput()));
   BatchNormalizationNode *batchNorm =

--- a/tools/ClassGen/NodeBuilder.h
+++ b/tools/ClassGen/NodeBuilder.h
@@ -231,7 +231,7 @@ public:
 
   /// Declare the node in the def file but don't generate code for it.
   void declareNode(const std::string &name) {
-    dStream << "DEF_NODE(" << name << "Node, " << name << ")\n";
+    dStream << "DEF_NODE(" << name << ", " << name << ")\n";
   }
 
   /// Include backend-specific verification at the end of the auto-generated


### PR DESCRIPTION
Our node generator added the Node suffix to all nodes, but our variables
don't have the 'Node' suffix. To get things to work someone added the
line:

class VariableNode : public Variable{};

This commit removes all references to VariableNode and teaches NodeGen 
not to emit the Node suffix.