### PR TITLE
[OpenCL] Fix compilation error in a kernel.

### DIFF
--- a/lib/Backends/OpenCL/kernels.cl
+++ b/lib/Backends/OpenCL/kernels.cl
@@ -779,7 +779,7 @@ __kernel void convolution_i8K(__global cl_int8_t *dest, __global cl_int8_t *src,
     }
 
     sum += round((float)(bias[d] - biasOffset) * (biasScale / matMulScale));
-    dest[getNHWC(odim, n, ax, ay, d)] = clip(round(float(sum) * (matMulScale 
+    dest[getNHWC(odim, n, ax, ay, d)] = clip(round((float)(sum) * (matMulScale 
                                         / destScale) + destOffset));
   } 
 }


### PR DESCRIPTION
doing `float(5)` doesn't work in `C99`. We should always use `(float)5`