### PR TITLE
[Operators] Support CopyCPUToMKL and CopyMKLToCPU

### DIFF
--- a/lib/Importer/Caffe2.cpp
+++ b/lib/Importer/Caffe2.cpp
@@ -387,6 +387,13 @@ void caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     return;
   }
 
+  if (typeName == "CopyCPUToMKL" || typeName == "CopyMKLToCPU") {
+    // Glow does not support MKL now, just pass these two ops.
+    auto *in = getOrCreateVariableByName(op.input(0));
+    addNodeAsOutput(op, in);
+    return;
+  }
+
   unexpectedNodeError(op, "Unsupported operator.");
 }
 


### PR DESCRIPTION
A Caffe2 model has those 2 operators. Glow doesn't support MKL ops now, so we just pass the value in the network to make sure the model can be supported.