### PR TITLE
Use ilist_node_traits instead of default

### DIFF
--- a/include/glow/Graph/Node.h
+++ b/include/glow/Graph/Node.h
@@ -391,7 +391,7 @@ template <> struct simplify_type<const glow::NodeHandle> {
 //===----------------------------------------------------------------------===//
 
 template <>
-struct ilist_traits<glow::Node> : public ilist_default_traits<glow::Node> {
+struct ilist_traits<glow::Node> : public ilist_node_traits<glow::Node> {
   using Node = glow::Node;
 
   glow::Function *getContainingFunction();

--- a/include/glow/IR/IR.h
+++ b/include/glow/IR/IR.h
@@ -225,7 +225,7 @@ namespace llvm {
 
 template <>
 struct ilist_traits<glow::Instruction>
-    : public ilist_default_traits<glow::Instruction> {
+    : public ilist_node_traits<glow::Instruction> {
   using Instruction = glow::Instruction;
 
 private:


### PR DESCRIPTION
`default` is removed in stable llvm anyways, and it looks like it doesn't add anything here.