### PR TITLE
**WIP**[quantization][opencl]: Support quantization for OCLConvolution

### DIFF
--- a/lib/Backends/OpenCL/Transforms.cpp
+++ b/lib/Backends/OpenCL/Transforms.cpp
@@ -36,9 +36,9 @@ bool OCLBackend::transformPostLowering(Function *F,
   bool changed = false;
   for (auto &node : F->getNodes()) {
     if (auto *CN = dyn_cast<ConvolutionNode>(&node)) {
-      if (CN->getInput()->getType(0)->isQuantizedType()) {
-        continue;
-      }
+      // if (CN->getInput()->getType(0)->isQuantizedType()) {
+      //   continue;
+      // }
       auto *NR = convertConvToNCHWConv<OCLConvolutionNode>(CN, F);
       NodeValue(&node, 0).replaceAllUsesOfWith(NR);
       changed = true;

--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -341,6 +341,10 @@ static bool sinkCode(Function *F) {
         continue;
       }
 
+      if (node->getNthResult(0)->getType(0)->isQuantizedType()) {
+        continue;
+      }
+
       Node *newAN = nullptr;
 
 #define ARITHMETIC_CASE(NODE_NAME_)                                            \


### PR DESCRIPTION
Support quantization for OCLConvolution.
While there are still some things about this PR:
-- All tests passed (including conv tests)
-- However resnet50 cannot produce correct results right now, not sure if it's the precision issues.
-- I have to disable some sinkNode optimization for the arithmetic ops that follows the OCLConvolution node. Due to the type inconsistency caused by the transformation from ConvolutionNode to OCLConvolutionNode (different scale and offset)

Please comment if you have any idea to solve the problems above.