### PR TITLE
[trivial] Add ReLU to the list of supported operations for openCL.

### DIFF
--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -187,6 +187,7 @@ public:
       case Kinded::Kind::MinNodeKind:
       case Kinded::Kind::MulNodeKind:
       case Kinded::Kind::QuantizeNodeKind:
+      case Kinded::Kind::ReluNodeKind:
       case Kinded::Kind::RescaleQuantizedNodeKind:
       case Kinded::Kind::SplatNodeKind:
       case Kinded::Kind::SubNodeKind:


### PR DESCRIPTION
This should help to make element-wise max operation to be quantized in the Resnet50 with openCL backend.
The conversion logic/execution is covered by quantization end2end test. cc: @ZchiPitt 