### PR TITLE
[quantization] A couple of bug fixes to support quantization

### DIFF
--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -959,31 +959,30 @@ ARITHMETIC_FUN_DEF(Max);
 ARITHMETIC_FUN_DEF(Min);
 #undef ARITHMETIC_FUN_DEF
 
+/// \returns the result type for a logical operation.
+static TypeRef getResultTypeOfLogicalOp(Module &M, TypeRef T) {
+  TypeRef OT;
+  if (T->isQuantizedType()) {
+    OT = M.uniqueType(T->getElementType(), T->dims(), 1.0, 0);
+  } else {
+    OT = M.uniqueType(*T);
+  }
+  return OT;
+}
+
 // For the quantized CmpLTE instruction, we require that the scale params be
 // (1.0, 0), so that the actual value and comparison value match.
 CmpLTENode *Function::createCmpLTE(llvm::StringRef name, NodeValue LHS,
                                    NodeValue RHS) {
   assert(LHS.dims() == RHS.dims() && "Invalid operand shapes");
-  TypeRef OT;
-  if (LHS.getType()->isQuantizedType()) {
-    OT = getParent()->uniqueType(LHS.getType()->getElementType(), LHS.dims(),
-                                 1.0, 0);
-  } else {
-    OT = getParent()->uniqueType(*LHS.getType());
-  }
+  TypeRef OT = getResultTypeOfLogicalOp(*getParent(), LHS.getType());
   return addNode(new CmpLTENode(name, OT, LHS, RHS));
 }
 
 CmpEQNode *Function::createCmpEQ(llvm::StringRef name, NodeValue LHS,
                                  NodeValue RHS) {
   assert(LHS.dims() == RHS.dims() && "Invalid operand shapes");
-  TypeRef OT;
-  if (LHS.getType()->isQuantizedType()) {
-    OT = getParent()->uniqueType(LHS.getType()->getElementType(), LHS.dims(),
-                                 1.0, 0);
-  } else {
-    OT = getParent()->uniqueType(*LHS.getType());
-  }
+  TypeRef OT = getResultTypeOfLogicalOp(*getParent(), LHS.getType());
   return addNode(new CmpEQNode(name, OT, LHS, RHS));
 }
 

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -977,7 +977,13 @@ CmpLTENode *Function::createCmpLTE(llvm::StringRef name, NodeValue LHS,
 CmpEQNode *Function::createCmpEQ(llvm::StringRef name, NodeValue LHS,
                                  NodeValue RHS) {
   assert(LHS.dims() == RHS.dims() && "Invalid operand shapes");
-  auto OT = getParent()->uniqueType(*LHS.getType());
+  TypeRef OT;
+  if (LHS.getType()->isQuantizedType()) {
+    OT = getParent()->uniqueType(LHS.getType()->getElementType(), LHS.dims(),
+                                 1.0, 0);
+  } else {
+    OT = getParent()->uniqueType(*LHS.getType());
+  }
   return addNode(new CmpEQNode(name, OT, LHS, RHS));
 }
 

--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -353,6 +353,15 @@ static bool sinkCode(Function *F) {
 
 #define ARITHMETIC_CASE(NODE_NAME_)                                            \
   case glow::Kinded::Kind::NODE_NAME_##NodeKind:                               \
+    newAN = F->create##NODE_NAME_(                                             \
+        node->getName(),                                                       \
+        F->getParent()->uniqueTypeWithNewShape(                                \
+            node->getType(0), LTR->getInput().getType()->dims()),              \
+        LTR->getInput(), RTR->getInput());                                     \
+    break;
+
+#define LOGICAL_OP_CASE(NODE_NAME_)                                            \
+  case glow::Kinded::Kind::NODE_NAME_##NodeKind:                               \
     newAN = F->create##NODE_NAME_(node->getName(), LTR->getInput(),            \
                                   RTR->getInput());                            \
     break;
@@ -364,11 +373,12 @@ static bool sinkCode(Function *F) {
         ARITHMETIC_CASE(Div);
         ARITHMETIC_CASE(Max);
         ARITHMETIC_CASE(Min);
-        ARITHMETIC_CASE(CmpLTE);
-        ARITHMETIC_CASE(CmpEQ);
+        LOGICAL_OP_CASE(CmpLTE);
+        LOGICAL_OP_CASE(CmpEQ);
       default:
         llvm_unreachable("Unhandled node");
       }
+#undef LOGICAL_OP_CASE
 #undef ARITHMETIC_CASE
 
       changed = true;


### PR DESCRIPTION
- Fix the implementation of createCmpEQ
  The implementation should be aware of the quantization. Use the same approach that we use for createCmpLTE.

- Fix a quantization related bug in sinkCode
  When sinkCode performs the arith(transpose(x), transpose(y)) -> transpose(arith(x, y)) transform, it should take the quantization into account. Specifically, it should create correct types for the transformed arith operation.