### PR TITLE
Final push to clean our overwritten arguments

### DIFF
--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1127,9 +1127,14 @@ Function::createQuantizationProfile(llvm::StringRef name, NodeValue input) {
       ElemKind::FloatTy, {2}, "computationInfo", VisibilityKind::Private,
       Variable::TrainKind::None);
 
-  return addNode(
+  QuantizationProfileNode *quantNode = addNode(
       new QuantizationProfileNode(name, input, histogram, computationInfo,
                                   input->getName().str(), input.getResNo()));
+  createSave(name.str() + ".updated.histogram",
+             quantNode->getUpdatedHistogram(), histogram);
+  createSave(name.str() + ".updated.computation.info",
+             quantNode->getUpdatedComputationInfo(), computationInfo);
+  return quantNode;
 }
 
 IntLookupTableNode *

--- a/lib/IR/IRGen.cpp
+++ b/lib/IR/IRGen.cpp
@@ -379,8 +379,17 @@ public:
       auto *inputTensor = valueForNode(QPN->getInput());
       auto *histogram = valueForNode(QPN->getHistogramVar());
       auto *computationInfo = valueForNode(QPN->getComputationInfoVar());
-      builder_.createQuantizationProfileInst(QPN->getName(), inputTensor,
-                                             histogram, computationInfo);
+      auto *updatedHistogram = builder_.createAllocActivationInst(
+          QPN->getName().str() + ".upd.histo",
+          QPN->getUpdatedHistogram().getType());
+      auto *updatedComputationInfo = builder_.createAllocActivationInst(
+          QPN->getName().str() + ".opd.compinfo",
+          QPN->getUpdatedComputationInfo().getType());
+      builder_.createQuantizationProfileInst(
+          QPN->getName(), updatedHistogram, updatedComputationInfo, inputTensor,
+          histogram, computationInfo);
+      registerIR(QPN->getUpdatedComputationInfo(), updatedComputationInfo);
+      registerIR(QPN->getUpdatedHistogram(), updatedHistogram);
       break;
     }
     case glow::Kinded::Kind::TopKNodeKind: {

--- a/tests/unittests/basicIRTest.cpp
+++ b/tests/unittests/basicIRTest.cpp
@@ -140,7 +140,15 @@ TEST(IR, allInstrs) {
     builder.createInsertTensorInst("", I6, I3, {0, 0, 0, 0}, 1, 0);
     builder.createElementMulInst("", I1, I0, I0);
     builder.createDebugPrintInst("", I0);
-    builder.createQuantizationProfileInst("", I0, B0, ComputationInfo);
+    auto *updatedHistogram =
+        builder.createAllocActivationInst("upd.histo", B0->getType());
+    auto *updatedComputationInfo = builder.createAllocActivationInst(
+        "upd.compinfo", ComputationInfo->getType());
+    builder.createQuantizationProfileInst(
+        "", updatedHistogram, updatedComputationInfo, I0, B0, ComputationInfo);
+    builder.createCopyInst("to.histogram", B0, updatedHistogram);
+    builder.createCopyInst("to.compinfo", ComputationInfo,
+                           updatedComputationInfo);
   }
   M.verify();
 }

--- a/tools/ClassGen/InstrBuilder.cpp
+++ b/tools/ClassGen/InstrBuilder.cpp
@@ -101,13 +101,15 @@ void InstrBuilder::emitIRBuilderMethods(std::ostream &osH,
 void InstrBuilder::emitInplaceMethod(std::ostream &os) const {
   os << "\n  bool isInplaceOp(unsigned dstIdx, unsigned srcIdx) const {\n";
   if (!inplaceOperands_.empty()) {
-    assert(inplaceOperands_.size() > 1 &&
-           "We don't have a pair of inplace args");
-    for (int i = 1, e = inplaceOperands_.size(); i < e; i++) {
-      auto F0 = getOperandIndexByName(inplaceOperands_[0]);
-      auto F1 = getOperandIndexByName(inplaceOperands_[i]);
-      os << "  if (" << F0 << " == dstIdx && " << F1
-         << " == srcIdx) { return true; }\n";
+    for (const std::vector<std::string> curInplaceOperands : inplaceOperands_) {
+      assert(curInplaceOperands.size() > 1 &&
+             "We don't have a pair of inplace args");
+      for (int i = 1, e = curInplaceOperands.size(); i < e; i++) {
+        auto F0 = getOperandIndexByName(curInplaceOperands[0]);
+        auto F1 = getOperandIndexByName(curInplaceOperands[i]);
+        os << "  if (" << F0 << " == dstIdx && " << F1
+           << " == srcIdx) { return true; }\n";
+      }
     }
   }
   os << "    return false;\n  }\n";

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -403,11 +403,21 @@ int main(int argc, char **argv) {
   //===--------------------------------------------------------------------===//
 
   BB.newInstr("QuantizationProfile")
+      .addOperand("UpdatedHistogram", OperandKind::Out)
+      .addOperand("UpdatedComputationInfo", OperandKind::Out)
       .addOperand("InputTensor", OperandKind::In)
-      .addOperand("Histogram", OperandKind::InOut)
-      .addOperand("ComputationInfo", OperandKind::InOut)
+      .addOperand("Histogram", OperandKind::In)
+      .addOperand("ComputationInfo", OperandKind::In)
       .autoVerify(VerifyKind::SameElementType,
-                  {"InputTensor", "ElemKind::FloatTy"});
+                  {"InputTensor", "ElemKind::FloatTy"})
+      .autoVerify(VerifyKind::SameElementType,
+                  {"UpdatedHistogram", "Histogram"})
+      .autoVerify(VerifyKind::SameElementType,
+                  {"UpdatedComputationInfo", "ComputationInfo"})
+      .inplaceOperand(
+          {"UpdatedHistogram", "InputTensor", "Histogram", "ComputationInfo"})
+      .inplaceOperand({"UpdatedComputationInfo", "InputTensor", "Histogram",
+                       "ComputationInfo"});
 
   BB.newInstr("IntLookupTable")
       .addOperand("Dest", OperandKind::Out)

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -421,8 +421,8 @@ int main(int argc, char **argv) {
           "Variable *getComputationInfoVar() const;",
           "Variable *QuantizationProfileNode::getComputationInfoVar() const { "
           "return llvm::cast<Variable>(ComputationInfo_.getNode()); };")
-      .addOverwrittenInput("ComputationInfo")
-      .addOverwrittenInput("Histogram")
+      .addResult("ComputationInfo.getType()", "UpdatedComputationInfo")
+      .addResult("Histogram.getType()", "UpdatedHistogram")
       .setHasSideEffects(true)
       .setDocstring(
           "Generate profile (distribution of values) of the Input "


### PR DESCRIPTION
The quantization profile node was the last use (aside from save nodes) of the overwritten attribute and thus, was also sensible to the same kind of scheduling bugs that was exposed in #1283.

There are several ways we could have fixed/worked around that:
1. Teach the scheduler how to handle the implicit memory dependencies for that node too
2. Check in the verifier that the overwritten inputs of the quantization profile nodes are not used anywhere else
3. Model quantization profile with producing two outputs

I don't like #1 because it pushes more hacks in the scheduler (eventually I'd like we model the memory dependencies period.). #2 is really just a check that the situation does not happen, but if it does, we're back to square 1.
Therefore, I gave a quick stab at #3 with this PR.

The nice thing I was pursuing and that PR achieves is that we would have the invariant that only save nodes write to variable.