### PR TITLE
Support multiple outputs in proto loaders and runners

### DIFF
--- a/include/glow/Importer/ONNX.h
+++ b/include/glow/Importer/ONNX.h
@@ -46,8 +46,9 @@ class ONNXModelLoader
   /// \returns true if network can be loaded.
   bool loadNetwork(onnx::GraphProto &net);
 
-  /// Set the root_ as an output node.
-  void setOutputNode(onnx::GraphProto &net);
+  /// Set the output nodes of the network \p net. Initializes the map from the
+  /// names of the outputs to the save nodes that save each output.
+  void setOutputNodes(onnx::GraphProto &net);
 
   /// Load the network initializers from the GraphProto.
   void loadInitializers(onnx::GraphProto &net);

--- a/include/glow/Importer/ProtobufLoader.h
+++ b/include/glow/Importer/ProtobufLoader.h
@@ -98,8 +98,8 @@ protected:
   std::unordered_map<std::string, Node *> nodeByName_;
   /// A list of weight tensors indexed by name.
   std::unordered_map<std::string, Tensor *> tensors_;
-  /// The external output of the network.
-  SaveNode *root_{nullptr};
+  /// A map from names of the external outputs of the network to SaveNodes.
+  std::unordered_map<std::string, SaveNode *> outputsByName_;
 
   /// \returns the tensor that was registered under the name \p name.
   Tensor *getTensorByName(llvm::StringRef name);
@@ -149,9 +149,19 @@ public:
 
   virtual ~ProtobufLoader();
 
-  /// \returns the output of the network. This is usually the result of the last
+  /// \returns the single final output of the network. The function assumes
+  /// there is only one output, verified via assertion. For image
+  /// classification, this single final output is usually the result of the last
   /// softmax or regression layer.
-  SaveNode *getRoot() { return root_; }
+  /// \pre outputsByName_.size() == 1
+  SaveNode *getSingleOutput() {
+    assert(outputsByName_.size() == 1);
+    return outputsByName_.begin()->second;
+  }
+
+  /// \returns the SaveNode for the external output with \p name.
+  /// \pre outputsByName_.find(name) != outputsByName_.end()
+  SaveNode *getOutputByName(llvm::StringRef name) const;
 };
 
 } // namespace glow

--- a/lib/Importer/Caffe2.cpp
+++ b/lib/Importer/Caffe2.cpp
@@ -405,8 +405,12 @@ void caffe2ModelLoader::loadNetwork(caffe2::NetDef &net) {
 
   assert(net.external_output_size() &&
          "Network needs external outputs defined.");
-  auto *r = getNodeByName(net.external_output(0));
-  root_ = G_.createSave("output", r);
+
+  for (int i = 0; i < net.external_output_size(); i++) {
+    auto &outputName = net.external_output(i);
+    auto *r = getNodeByName(outputName);
+    outputsByName_[outputName] = G_.createSave("save_" + outputName, r);
+  }
 }
 
 void caffe2ModelLoader::loadWeights(caffe2::NetDef &net) {

--- a/lib/Importer/ONNX.cpp
+++ b/lib/Importer/ONNX.cpp
@@ -465,10 +465,14 @@ void ONNXModelLoader::loadInitializers(onnx::GraphProto &net) {
   }
 }
 
-void ONNXModelLoader::setOutputNode(onnx::GraphProto &net) {
+void ONNXModelLoader::setOutputNodes(onnx::GraphProto &net) {
   assert(net.output_size() && "Network needs external outputs defined.");
-  auto *r = getNodeByName(net.output(0).name());
-  root_ = G_.createSave("output", r);
+
+  for (int i = 0; i < net.output_size(); i++) {
+    auto &outputName = net.output(i).name();
+    auto *r = getNodeByName(outputName);
+    outputsByName_[outputName] = G_.createSave("save_" + outputName, r);
+  }
 }
 
 bool ONNXModelLoader::loadNetwork(onnx::GraphProto &net) {
@@ -517,6 +521,6 @@ ONNXModelLoader::ONNXModelLoader(const std::string &modelDescFilename,
 
   loadInitializers(modelDef);
   if (loadNetwork(modelDef)) {
-    setOutputNode(modelDef);
+    setOutputNodes(modelDef);
   }
 }

--- a/lib/Importer/ProtobufLoader.cpp
+++ b/lib/Importer/ProtobufLoader.cpp
@@ -34,6 +34,15 @@ Tensor *ProtobufLoader::getTensorByName(llvm::StringRef name) {
   return tensors_[name];
 }
 
+SaveNode *ProtobufLoader::getOutputByName(llvm::StringRef name) const {
+  assert(outputsByName_.count(name) &&
+         "There is no tensor registered with this name.");
+  auto it = outputsByName_.find(name);
+  assert(it != outputsByName_.end() &&
+         "No external output was registered with this name.");
+  return it->second;
+}
+
 Node *ProtobufLoader::getNodeByNameOrNull(llvm::StringRef name) const {
   auto it = nodeByName_.find(name);
   if (it != nodeByName_.end()) {

--- a/tools/loader/ImageClassifier.cpp
+++ b/tools/loader/ImageClassifier.cpp
@@ -146,14 +146,14 @@ int main(int argc, char **argv) {
         loader.getCaffe2NetDescFilename(), loader.getCaffe2NetWeightFilename(),
         {"data", "gpu_0/data", "softmax_expected"},
         {&data, &data, &expectedSoftmax}, *loader.getFunction());
-    SM = LD.getRoot();
+    SM = LD.getSingleOutput();
     i0 = LD.getVariableByName("gpu_0/data");
     i1 = LD.getVariableByName("data");
   } else {
     ONNXModelLoader LD(loader.getOnnxModelFilename(),
                        {"data_0", "gpu_0/data_0", "softmax_expected"},
                        {&data, &data, &expectedSoftmax}, *loader.getFunction());
-    SM = LD.getRoot();
+    SM = LD.getSingleOutput();
     i0 = LD.getVariableByName("gpu_0/data_0");
     i1 = LD.getVariableByName("data_0");
   }

--- a/tools/loader/ModelRunner.cpp
+++ b/tools/loader/ModelRunner.cpp
@@ -39,7 +39,7 @@ int main(int argc, char **argv) {
     LD = new ONNXModelLoader(loader.getOnnxModelFilename(), {}, {},
                              *loader.getFunction());
   }
-  SaveNode *output = LD->getRoot();
+  SaveNode *output = LD->getSingleOutput();
 
   // Compile the model, and perform quantization/emit a bundle/dump debug info
   // if requested from command line.


### PR DESCRIPTION
The loaders were pretty specific to image classification before this, and so assumed/only supported loading networks with a single output.