### PR TITLE
Work around OrcJIT API instability

### DIFF
--- a/lib/Backends/CPU/BundleSaver.cpp
+++ b/lib/Backends/CPU/BundleSaver.cpp
@@ -147,7 +147,11 @@ void BundleSaver::produceBundle(llvm::StringRef outputDir) {
               "Could not open the output file for saving the bundle code");
   if (fileName.endswith(".bc")) {
     // Emit the bitcode file.
+#ifdef FACEBOOK
+    llvm::WriteBitcodeToFile(M, outputFile);
+#else
     llvm::WriteBitcodeToFile(&M, outputFile);
+#endif
   } else if (fileName.endswith(".o")) {
     // Emit the object file.
     llvm::legacy::PassManager PM;


### PR DESCRIPTION
I'm not super-happy about this PR, but the API for Orc JIT seems to have churned a lot.  I've tried llvm stable, llvm master, and FB's internal stable branch, and they *all* have little differences from each other, and of course from llvm6.  So... I'm thinking -DFACEBOOK is about the best way to handle this for the present, and at some point we can migrate fully to llvm7 once that's a stable release.