### PR TITLE
[InstrGen] Teach inplaceOperand how to deal with several results

### DIFF
--- a/tools/ClassGen/InstrBuilder.cpp
+++ b/tools/ClassGen/InstrBuilder.cpp
@@ -101,13 +101,15 @@ void InstrBuilder::emitIRBuilderMethods(std::ostream &osH,
 void InstrBuilder::emitInplaceMethod(std::ostream &os) const {
   os << "\n  bool isInplaceOp(unsigned dstIdx, unsigned srcIdx) const {\n";
   if (!inplaceOperands_.empty()) {
-    assert(inplaceOperands_.size() > 1 &&
-           "We don't have a pair of inplace args");
-    for (int i = 1, e = inplaceOperands_.size(); i < e; i++) {
-      auto F0 = getOperandIndexByName(inplaceOperands_[0]);
-      auto F1 = getOperandIndexByName(inplaceOperands_[i]);
-      os << "  if (" << F0 << " == dstIdx && " << F1
-         << " == srcIdx) { return true; }\n";
+    for (const std::vector<std::string> curInplaceOperands : inplaceOperands_) {
+      assert(curInplaceOperands.size() > 1 &&
+             "We don't have a pair of inplace args");
+      for (int i = 1, e = curInplaceOperands.size(); i < e; i++) {
+        auto F0 = getOperandIndexByName(curInplaceOperands[0]);
+        auto F1 = getOperandIndexByName(curInplaceOperands[i]);
+        os << "  if (" << F0 << " == dstIdx && " << F1
+           << " == srcIdx) { return true; }\n";
+      }
     }
   }
   os << "    return false;\n  }\n";


### PR DESCRIPTION
Prior to this commit, it was impossible to describe more than one
inplace property. This would limit our ability to set the inplace
property on instruction with more than one result.

With this patch, it is now possible to define one inplace property
list for each output of an instruction. To use this feature
simply invoke inplaceOperand method for each output on the
declaration of the instruction.