### PR TITLE
[Variable] Remove the tensor initialization from Variable. NFC.

### DIFF
--- a/examples/char-rnn.cpp
+++ b/examples/char-rnn.cpp
@@ -158,12 +158,11 @@ static Function *createNetwork(Module &mod, size_t minibatchSize,
                                size_t numSteps, size_t hiddenSize) {
   Function *F = mod.createFunction("main");
 
-  Variable *X = mod.createVariable(
-      ElemKind::FloatTy, {minibatchSize, numSteps, 128}, "input",
-      VisibilityKind::Public, Variable::TrainKind::None);
+  Variable *X =
+      mod.createVariable(ElemKind::FloatTy, {minibatchSize, numSteps, 128},
+                         "input", VisibilityKind::Public, false);
   Variable *Y = mod.createVariable(ElemKind::IndexTy, {minibatchSize, numSteps},
-                                   "expected", VisibilityKind::Public,
-                                   Variable::TrainKind::None);
+                                   "expected", VisibilityKind::Public, false);
   std::vector<Node *> slicesX;
   std::vector<Node *> expectedX;
 

--- a/examples/cifar10.cpp
+++ b/examples/cifar10.cpp
@@ -105,12 +105,10 @@ void testCIFAR10() {
   Function *F = mod.createFunction("main");
 
   // Create the input layer:
-  auto *A =
-      mod.createVariable(ElemKind::FloatTy, {minibatchSize, 32, 32, 3}, "input",
-                         VisibilityKind::Public, Variable::TrainKind::None);
-  auto *E =
-      mod.createVariable(ElemKind::IndexTy, {minibatchSize, 1}, "expected",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+  auto *A = mod.createVariable(ElemKind::FloatTy, {minibatchSize, 32, 32, 3},
+                               "input", VisibilityKind::Public, false);
+  auto *E = mod.createVariable(ElemKind::IndexTy, {minibatchSize, 1},
+                               "expected", VisibilityKind::Public, false);
 
   // Create the rest of the network.
   auto *CV0 = F->createConv("conv", A, 16, 5, 1, 2, 1);

--- a/examples/fr2en.cpp
+++ b/examples/fr2en.cpp
@@ -176,10 +176,9 @@ private:
 
   Variable *loadEmbedding(llvm::StringRef langPrefix, size_t langSize) {
     auto &mod = EE_.getModule();
-    Variable *result =
-        mod.createVariable(ElemKind::FloatTy, {langSize, EMBEDDING_SIZE},
-                           "embedding." + langPrefix.str(),
-                           VisibilityKind::Private, Variable::TrainKind::None);
+    Variable *result = mod.createVariable(
+        ElemKind::FloatTy, {langSize, EMBEDDING_SIZE},
+        "embedding." + langPrefix.str(), VisibilityKind::Private, false);
     loadMatrixFromFile("fr2en/" + langPrefix.str() + "_embedding.bin",
                        result->getPayload());
     return result;
@@ -237,30 +236,30 @@ void Model::loadEncoder() {
   auto &mod = EE_.getModule();
   input_ = mod.createVariable(ElemKind::IndexTy, {batchSize_, MAX_LENGTH},
                               "encoder.inputsentence", VisibilityKind::Public,
-                              Variable::TrainKind::None);
+                              false);
   seqLength_ =
       mod.createVariable(ElemKind::IndexTy, {batchSize_}, "encoder.seqLength",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+                         VisibilityKind::Public, false);
 
-  Variable *hiddenInit = mod.createVariable(
-      ElemKind::FloatTy, {batchSize_, EMBEDDING_SIZE}, "encoder.hiddenInit",
-      VisibilityKind::Private, Variable::TrainKind::None);
+  Variable *hiddenInit =
+      mod.createVariable(ElemKind::FloatTy, {batchSize_, EMBEDDING_SIZE},
+                         "encoder.hiddenInit", VisibilityKind::Private, false);
   hiddenInit->getPayload().zero();
 
   Node *hidden = hiddenInit;
 
-  Variable *w_ih = mod.createVariable(
-      ElemKind::FloatTy, {EMBEDDING_SIZE, HIDDEN_SIZE}, "encoder.w_ih",
-      VisibilityKind::Private, Variable::TrainKind::None);
+  Variable *w_ih =
+      mod.createVariable(ElemKind::FloatTy, {EMBEDDING_SIZE, HIDDEN_SIZE},
+                         "encoder.w_ih", VisibilityKind::Private, false);
   Variable *b_ih =
       mod.createVariable(ElemKind::FloatTy, {HIDDEN_SIZE}, "encoder.b_ih",
-                         VisibilityKind::Private, Variable::TrainKind::None);
-  Variable *w_hh = mod.createVariable(
-      ElemKind::FloatTy, {EMBEDDING_SIZE, HIDDEN_SIZE}, "encoder.w_hh",
-      VisibilityKind::Private, Variable::TrainKind::None);
+                         VisibilityKind::Private, false);
+  Variable *w_hh =
+      mod.createVariable(ElemKind::FloatTy, {EMBEDDING_SIZE, HIDDEN_SIZE},
+                         "encoder.w_hh", VisibilityKind::Private, false);
   Variable *b_hh =
       mod.createVariable(ElemKind::FloatTy, {HIDDEN_SIZE}, "encoder.b_hh",
-                         VisibilityKind::Private, Variable::TrainKind::None);
+                         VisibilityKind::Private, false);
   loadMatrixFromFile("fr2en/encoder_w_ih.bin", w_ih->getPayload());
   loadMatrixFromFile("fr2en/encoder_b_ih.bin", b_ih->getPayload());
   loadMatrixFromFile("fr2en/encoder_w_hh.bin", w_hh->getPayload());
@@ -297,29 +296,29 @@ void Model::loadDecoder() {
   auto &mod = EE_.getModule();
   Variable *input =
       mod.createVariable(ElemKind::IndexTy, {batchSize_}, "decoder.input",
-                         VisibilityKind::Private, Variable::TrainKind::None);
+                         VisibilityKind::Private, false);
   for (size_t i = 0; i < batchSize_; i++) {
     input->getPayload().getHandle<size_t>().at({i}) = en_.word2index_["SOS"];
   }
 
-  Variable *w_ih = mod.createVariable(
-      ElemKind::FloatTy, {EMBEDDING_SIZE, HIDDEN_SIZE}, "decoder.w_ih",
-      VisibilityKind::Private, Variable::TrainKind::None);
+  Variable *w_ih =
+      mod.createVariable(ElemKind::FloatTy, {EMBEDDING_SIZE, HIDDEN_SIZE},
+                         "decoder.w_ih", VisibilityKind::Private, false);
   Variable *b_ih =
       mod.createVariable(ElemKind::FloatTy, {HIDDEN_SIZE}, "decoder.b_ih",
-                         VisibilityKind::Private, Variable::TrainKind::None);
-  Variable *w_hh = mod.createVariable(
-      ElemKind::FloatTy, {EMBEDDING_SIZE, HIDDEN_SIZE}, "decoder.w_hh",
-      VisibilityKind::Private, Variable::TrainKind::None);
+                         VisibilityKind::Private, false);
+  Variable *w_hh =
+      mod.createVariable(ElemKind::FloatTy, {EMBEDDING_SIZE, HIDDEN_SIZE},
+                         "decoder.w_hh", VisibilityKind::Private, false);
   Variable *b_hh =
       mod.createVariable(ElemKind::FloatTy, {HIDDEN_SIZE}, "decoder.b_hh",
-                         VisibilityKind::Private, Variable::TrainKind::None);
+                         VisibilityKind::Private, false);
   Variable *out_w = mod.createVariable(
       ElemKind::FloatTy, {EMBEDDING_SIZE, en_.index2word_.size()},
-      "decoder.out_w", VisibilityKind::Private, Variable::TrainKind::None);
-  Variable *out_b = mod.createVariable(
-      ElemKind::FloatTy, {en_.index2word_.size()}, "decoder.out_b",
-      VisibilityKind::Private, Variable::TrainKind::None);
+      "decoder.out_w", VisibilityKind::Private, false);
+  Variable *out_b =
+      mod.createVariable(ElemKind::FloatTy, {en_.index2word_.size()},
+                         "decoder.out_b", VisibilityKind::Private, false);
   loadMatrixFromFile("fr2en/decoder_w_ih.bin", w_ih->getPayload());
   loadMatrixFromFile("fr2en/decoder_b_ih.bin", b_ih->getPayload());
   loadMatrixFromFile("fr2en/decoder_w_hh.bin", w_hh->getPayload());
@@ -354,8 +353,7 @@ void Model::loadDecoder() {
   Node *reshape = F_->createReshape("decoder.output.reshape", concat,
                                     {MAX_LENGTH, batchSize_});
   output_ = mod.createVariable(ElemKind::IndexTy, {MAX_LENGTH, batchSize_},
-                               "decoder.output", VisibilityKind::Public,
-                               Variable::TrainKind::None);
+                               "decoder.output", VisibilityKind::Public, false);
   F_->createSave("decoder.output", reshape, output_);
 }
 

--- a/examples/mnist.cpp
+++ b/examples/mnist.cpp
@@ -112,7 +112,7 @@ void testMNIST() {
 
   Variable *A =
       mod.createVariable(ElemKind::FloatTy, {minibatchSize, 28, 28, 1}, "input",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+                         VisibilityKind::Public, false);
 
   auto *CV0 = F->createConv("conv", A, 16, 5, 1, 2, 1);
   auto *RL0 = F->createRELU("relu", CV0);
@@ -125,7 +125,7 @@ void testMNIST() {
   auto *FCL1 = F->createFullyConnected("fc", MP1, 10);
   Variable *selected =
       mod.createVariable(ElemKind::IndexTy, {minibatchSize, 1}, "selected",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+                         VisibilityKind::Public, false);
   auto *SM = F->createSoftMax("sm", FCL1, selected);
 
   auto *result = F->createSave("return", SM);

--- a/examples/ptb.cpp
+++ b/examples/ptb.cpp
@@ -199,12 +199,11 @@ void testPTB() {
   Function *F = mod.createFunction("main");
   llvm::outs() << "Building\n";
 
-  Variable *X = mod.createVariable(
-      ElemKind::FloatTy, {minibatchSize, vocabSize * numSteps}, "input",
-      VisibilityKind::Public, Variable::TrainKind::None);
+  Variable *X = mod.createVariable(ElemKind::FloatTy,
+                                   {minibatchSize, vocabSize * numSteps},
+                                   "input", VisibilityKind::Public, false);
   Variable *Y = mod.createVariable(ElemKind::IndexTy, {minibatchSize, numSteps},
-                                   "selected", VisibilityKind::Public,
-                                   Variable::TrainKind::None);
+                                   "selected", VisibilityKind::Public, false);
 
   std::vector<Node *> slicesX;
 

--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -167,7 +167,7 @@ public:
   /// Initialize the content of the tensor using the \p init method. The value
   /// \p val is the initialization parameter. \p PRNG is used to generate
   /// random numbers.
-  void initPayload(InitKind init, float val, PseudoRNG &PRNG);
+  void init(InitKind init, float val, PseudoRNG &PRNG);
 
   /// \returns unowned tensor using the same data buffer as the current tensor
   /// but having different dimensions \p dims. \p offsets represents an optional

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -120,29 +120,23 @@ public:
   /// @name High-level Variable builders.
   ///@{
 
-  Variable *
-  createVariable(TypeRef T, llvm::StringRef name,
-                 VisibilityKind visibility = VisibilityKind::Private,
-                 Variable::TrainKind train = Variable::TrainKind::Broadcast,
-                 float val = 0.0);
+  Variable *createVariable(TypeRef T, llvm::StringRef name,
+                           VisibilityKind visibility = VisibilityKind::Private,
+                           bool isTrainable = true);
 
-  Variable *
-  createVariable(ElemKind T, llvm::ArrayRef<size_t> dims, llvm::StringRef name,
-                 VisibilityKind visibility = VisibilityKind::Private,
-                 Variable::TrainKind train = Variable::TrainKind::Broadcast,
-                 float val = 0.0);
+  Variable *createVariable(ElemKind T, llvm::ArrayRef<size_t> dims,
+                           llvm::StringRef name,
+                           VisibilityKind visibility = VisibilityKind::Private,
+                           bool isTrainable = true);
 
-  Variable *
-  createVariable(ElemKind T, llvm::ArrayRef<size_t> dims, float scale,
-                 int32_t offset, llvm::StringRef name,
-                 VisibilityKind visibility = VisibilityKind::Private,
-                 Variable::TrainKind train = Variable::TrainKind::Broadcast,
-                 float val = 0.0);
+  Variable *createVariable(ElemKind T, llvm::ArrayRef<size_t> dims, float scale,
+                           int32_t offset, llvm::StringRef name,
+                           VisibilityKind visibility = VisibilityKind::Private,
+                           bool isTrainable = true);
 
-  Variable *
-  createVariable(llvm::StringRef name, const Tensor &tensor,
-                 VisibilityKind visibility = VisibilityKind::Private,
-                 Variable::TrainKind train = Variable::TrainKind::Broadcast);
+  Variable *createVariable(llvm::StringRef name, const Tensor &tensor,
+                           VisibilityKind visibility = VisibilityKind::Private,
+                           bool isTrainable = true);
 
   ///@}
 
@@ -192,6 +186,9 @@ public:
     nodes_.push_back(N);
     return N;
   }
+
+  /// Get the pseudo-random number generator used by this module.
+  PseudoRNG &getPRNG() { return getParent()->getPRNG(); }
 
   /// @name High-level, operation-level IRBuilder.
   ///@{

--- a/include/glow/Importer/ProtobufLoader.h
+++ b/include/glow/Importer/ProtobufLoader.h
@@ -110,7 +110,7 @@ protected:
   Variable *createAndRememberVariable(
       llvm::StringRef name, const Tensor &tensor,
       VisibilityKind visibilityKind = VisibilityKind::Private,
-      Variable::TrainKind trainKind = Variable::TrainKind::Broadcast);
+      bool trainable = true);
 
   /// \returns the NodeValue that was registered with the name \p name or
   /// a nullptr wrapped in a NodeValue if no node has been registered with this

--- a/lib/Backends/CPU/Transforms.cpp
+++ b/lib/Backends/CPU/Transforms.cpp
@@ -60,7 +60,7 @@ static Node *optimizeCPUConv(ConvolutionNode *CN, Function *F) {
   assert(dims.size() == 4 && "Invalid filter size");
   auto *filter8 = M->createVariable(
       filterTy->getElementType(), {dims[0] / 8, dims[1], dims[2], dims[3], 8},
-      filter->getName(), VisibilityKind::Private, Variable::TrainKind::None);
+      filter->getName(), VisibilityKind::Private, false);
 
   auto F8H = filter8->getHandle();
   auto FH = filter->getHandle();

--- a/lib/Base/Tensor.cpp
+++ b/lib/Base/Tensor.cpp
@@ -347,7 +347,7 @@ ShapeVector glow::expandDimsToMax(llvm::ArrayRef<size_t> currDims) {
   return newDims;
 }
 
-void Tensor::initPayload(InitKind init, float val, PseudoRNG &PRNG) {
+void Tensor::init(InitKind init, float val, PseudoRNG &PRNG) {
   switch (init) {
   case InitKind::Zero:
     zero();

--- a/lib/Importer/ProtobufLoader.cpp
+++ b/lib/Importer/ProtobufLoader.cpp
@@ -62,11 +62,12 @@ NodeValue ProtobufLoader::getNodeValueByName(llvm::StringRef name) const {
 
 Variable *ProtobufLoader::createAndRememberVariable(
     llvm::StringRef name, const Tensor &tensor, VisibilityKind visibilityKind,
-    Variable::TrainKind trainKind) {
+    bool trainable) {
   assert(!hasNodeByName(name) && "Creating an already existing node?!");
   Variable *node =
-      G_.getParent()->createVariable(name, tensor, visibilityKind, trainKind);
+      G_.getParent()->createVariable(name, tensor, visibilityKind, trainable);
   nodeValueByName_[name] = NodeValue(node, 0);
+
   return node;
 }
 
@@ -105,8 +106,7 @@ ProtobufLoader::ProtobufLoader(llvm::ArrayRef<const char *> tensorNames,
   for (unsigned i = 0; i < tensorNames.size(); i++) {
     assert(!hasNodeByName(tensorNames[i]) && "Input names have duplicate");
     createAndRememberVariable(tensorNames[i], *tensors[i],
-                              VisibilityKind::Public,
-                              Variable::TrainKind::None);
+                              VisibilityKind::Public, false);
   }
 }
 

--- a/lib/Optimizer/Lower.cpp
+++ b/lib/Optimizer/Lower.cpp
@@ -305,8 +305,8 @@ void lowerSGDNode(Function *F, SGDNode &SGD) {
   // OptimizationStochasticGradientDescent/
   if (momentum > 0.0) {
     Variable *Gsum = F->getParent()->createVariable(
-        W->getType(0), "gsum", VisibilityKind::Private,
-        Variable::TrainKind::Broadcast, 0);
+        W->getType(0), "gsum", VisibilityKind::Private, true);
+    Gsum->getPayload().zero();
 
     auto *momentumSplat = F->createSplat("learningRateSplat", type, momentum);
     auto *GsumMult = F->createMul("GsumMult", momentumSplat, Gsum);

--- a/lib/Optimizer/Partition.cpp
+++ b/lib/Optimizer/Partition.cpp
@@ -151,9 +151,9 @@ FunctionDAG doPartitioning(Function *F, NodeFunctionMap &mapping) {
         }
 
         // Create a new variable to represent this dependence.
-        auto *tmp = mod->createVariable(
-            input.getType(), std::string(input->getName()) + "_tmp",
-            VisibilityKind::Private, Variable::TrainKind::None);
+        auto *tmp = mod->createVariable(input.getType(),
+                                        std::string(input->getName()) + "_tmp",
+                                        VisibilityKind::Private, false);
         inputF->createSave("tmp", input, tmp);
         variables[input.getNode()] = tmp;
         N.setNthInput(inp, tmp);

--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -39,8 +39,7 @@ TEST(Interpreter, NotImplementedSave) {
   // Create a few nodes to make sure IR can be normally generated.
   Function *F = mod.createFunction("main");
   F->createSave("save", mod.createVariable(ElemKind::FloatTy, {2}, "A",
-                                           VisibilityKind::Public,
-                                           Variable::TrainKind::None));
+                                           VisibilityKind::Public, false));
 
   EXPECT_DEATH(EE.save(CompilationMode::Infer, F, "output"), "");
 }
@@ -135,8 +134,7 @@ TEST_P(BackendTest, debugPrint) {
   Tensor input{0.0, 1.0, 2.0, 3.0};
   Module mod;
   Function *F = mod.createFunction("main");
-  auto *IV = mod.createVariable("input", input, VisibilityKind::Public,
-                                Variable::TrainKind::None);
+  auto *IV = mod.createVariable("input", input, VisibilityKind::Public, false);
   (void)IV;
 
   auto IR = llvm::make_unique<IRFunction>(F);

--- a/tests/unittests/BackendTestUtils.cpp
+++ b/tests/unittests/BackendTestUtils.cpp
@@ -25,8 +25,7 @@ namespace glow {
 using llvm::cast;
 
 #define VarFrom(T)                                                             \
-  mod.createVariable(&T->getType(), #T, VisibilityKind::Public,                \
-                     Variable::TrainKind::None)
+  mod.createVariable(&T->getType(), #T, VisibilityKind::Public, false)
 
 void inferBatchedAddNet(Tensor *batch, Tensor *slice, Tensor *out,
                         BackendKind kind) {

--- a/tests/unittests/HyphenTest.cpp
+++ b/tests/unittests/HyphenTest.cpp
@@ -260,11 +260,10 @@ struct HyphenNetwork {
 
   HyphenNetwork(Module &mod, TrainingConfig &conf)
       : input_(mod.createVariable(ElemKind::FloatTy, {conf.batchSize, 6, 27},
-                                  "input", VisibilityKind::Public,
-                                  Variable::TrainKind::None)),
+                                  "input", VisibilityKind::Public, false)),
         expected_(mod.createVariable(ElemKind::IndexTy, {conf.batchSize, 1},
                                      "expected", VisibilityKind::Public,
-                                     Variable::TrainKind::None)),
+                                     false)),
         infer_(mod.createFunction("infer")), result_(nullptr), train_(nullptr) {
     Node *n;
 

--- a/tests/unittests/MLTest.cpp
+++ b/tests/unittests/MLTest.cpp
@@ -46,12 +46,10 @@ TEST_P(MLTest, trainASimpleNetwork) {
   Function *F = mod.createFunction("trainASimpleNetwork");
 
   // Create a variable with 1 input, which is a vector of 4 elements.
-  auto *A =
-      mod.createVariable(ElemKind::FloatTy, {1, 4}, "A", VisibilityKind::Public,
-                         Variable::TrainKind::None);
-  auto *E =
-      mod.createVariable(ElemKind::FloatTy, {1, 4}, "E", VisibilityKind::Public,
-                         Variable::TrainKind::None);
+  auto *A = mod.createVariable(ElemKind::FloatTy, {1, 4}, "A",
+                               VisibilityKind::Public, false);
+  auto *E = mod.createVariable(ElemKind::FloatTy, {1, 4}, "E",
+                               VisibilityKind::Public, false);
 
   Node *O = F->createFullyConnected("fc1", A, 10);
   O = F->createSigmoid("sig1", O);
@@ -98,12 +96,10 @@ TEST_P(MLTest, simpleRegression) {
 
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("simpleRegression");
-  auto *A =
-      mod.createVariable(ElemKind::FloatTy, {1, numInputs}, "A",
-                         VisibilityKind::Public, Variable::TrainKind::None);
-  auto *Ex =
-      mod.createVariable(ElemKind::FloatTy, {1, numInputs}, "E",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+  auto *A = mod.createVariable(ElemKind::FloatTy, {1, numInputs}, "A",
+                               VisibilityKind::Public, false);
+  auto *Ex = mod.createVariable(ElemKind::FloatTy, {1, numInputs}, "E",
+                                VisibilityKind::Public, false);
   Node *O = F->createFullyConnected("fc", A, 4);
   O = F->createRELU("relu", O);
   O = F->createRegression("reg", O, Ex);
@@ -151,12 +147,10 @@ TEST_P(MLTest, learnXor) {
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("learnXor");
 
-  auto *A =
-      mod.createVariable(ElemKind::FloatTy, {numInputs, 2}, "A",
-                         VisibilityKind::Public, Variable::TrainKind::None);
-  auto *Ex =
-      mod.createVariable(ElemKind::FloatTy, {numInputs, 1}, "Ex",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+  auto *A = mod.createVariable(ElemKind::FloatTy, {numInputs, 2}, "A",
+                               VisibilityKind::Public, false);
+  auto *Ex = mod.createVariable(ElemKind::FloatTy, {numInputs, 1}, "Ex",
+                                VisibilityKind::Public, false);
 
   Node *O = F->createFullyConnected("fc1", A, 6);
   O = F->createTanh("tanh1", O);
@@ -219,12 +213,10 @@ TEST_P(MLTest, learnLog) {
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("learnLog");
 
-  auto *A =
-      mod.createVariable(ElemKind::FloatTy, {batchSize, 1}, "A",
-                         VisibilityKind::Public, Variable::TrainKind::None);
-  auto *Ex =
-      mod.createVariable(ElemKind::FloatTy, {batchSize, 1}, "Ex",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+  auto *A = mod.createVariable(ElemKind::FloatTy, {batchSize, 1}, "A",
+                               VisibilityKind::Public, false);
+  auto *Ex = mod.createVariable(ElemKind::FloatTy, {batchSize, 1}, "Ex",
+                                VisibilityKind::Public, false);
 
   Node *O = F->createFullyConnected("fc1", A, 4);
   O = F->createTanh("tanh1", O);
@@ -326,12 +318,10 @@ TEST_P(MLTest, circle) {
 
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("circle");
-  auto *A =
-      mod.createVariable(ElemKind::FloatTy, {minibatchSize, 2}, "A",
-                         VisibilityKind::Public, Variable::TrainKind::None);
-  auto *S =
-      mod.createVariable(ElemKind::IndexTy, {minibatchSize, 1}, "S",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+  auto *A = mod.createVariable(ElemKind::FloatTy, {minibatchSize, 2}, "A",
+                               VisibilityKind::Public, false);
+  auto *S = mod.createVariable(ElemKind::IndexTy, {minibatchSize, 1}, "S",
+                               VisibilityKind::Public, false);
 
   auto *FCL0 = F->createFullyConnected("fc1", A, 8);
   auto *T0 = F->createTanh("tanh1", FCL0);
@@ -413,21 +403,18 @@ TEST_P(MLTest, learnSingleValueConcat) {
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("learnSingleValueConcat");
 
-  auto *Ex =
-      mod.createVariable(ElemKind::FloatTy, {1, width * 2}, "Ex",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+  auto *Ex = mod.createVariable(ElemKind::FloatTy, {1, width * 2}, "Ex",
+                                VisibilityKind::Public, false);
 
   // Left side of the network:
-  auto *A =
-      mod.createVariable(ElemKind::FloatTy, {1, width}, "A",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+  auto *A = mod.createVariable(ElemKind::FloatTy, {1, width}, "A",
+                               VisibilityKind::Public, false);
   Node *L = F->createFullyConnected("fc1", A, width);
   L = F->createSigmoid("", L);
 
   // Right side of the network:
-  auto *B =
-      mod.createVariable(ElemKind::FloatTy, {1, width}, "B",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+  auto *B = mod.createVariable(ElemKind::FloatTy, {1, width}, "B",
+                               VisibilityKind::Public, false);
   Node *R = F->createFullyConnected("fc2", B, width);
   R = F->createSigmoid("sig", R);
 
@@ -494,12 +481,10 @@ void testRNNCell(TCellGenerator cell) {
   const unsigned NumElements = 4;
   // Create a variable with 1 input, which is 3 consecutive vectors
   // of 4 elements each.
-  auto *X =
-      mod.createVariable(ElemKind::FloatTy, {1, NumVectors, NumElements}, "X",
-                         VisibilityKind::Public, Variable::TrainKind::None);
-  auto *Y =
-      mod.createVariable(ElemKind::FloatTy, {1, NumVectors}, "Y",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+  auto *X = mod.createVariable(ElemKind::FloatTy, {1, NumVectors, NumElements},
+                               "X", VisibilityKind::Public, false);
+  auto *Y = mod.createVariable(ElemKind::FloatTy, {1, NumVectors}, "Y",
+                               VisibilityKind::Public, false);
 
   // Extract a slice for each input.
   std::vector<Node *> XSliced;
@@ -578,12 +563,12 @@ TEST_P(MLTest, learnSqrt2) {
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("Square root of 2");
 
-  auto *A =
-      mod.createVariable(ElemKind::FloatTy, {1}, "A", VisibilityKind::Public,
-                         Variable::TrainKind::Broadcast, 1);
-  auto *Ex =
-      mod.createVariable(ElemKind::FloatTy, {1}, "Ex", VisibilityKind::Public,
-                         Variable::TrainKind::None);
+  auto *A = mod.createVariable(ElemKind::FloatTy, {1}, "A",
+                               VisibilityKind::Public, true);
+  A->getPayload().init(Tensor::InitKind::Broadcast, 1, mod.getPRNG());
+
+  auto *Ex = mod.createVariable(ElemKind::FloatTy, {1}, "Ex",
+                                VisibilityKind::Public, false);
   Ex->getPayload().getHandle() = {2};
 
   Node *O = F->createMul("Mult", A, A);
@@ -630,12 +615,11 @@ TEST_P(MLTest, trainSimpleLinearRegression) {
   }
 
   // Create a variable with 1 input, which is a real number.
-  auto *inputX =
-      mod.createVariable(ElemKind::FloatTy, {numSamples, 1}, "input",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+  auto *inputX = mod.createVariable(ElemKind::FloatTy, {numSamples, 1}, "input",
+                                    VisibilityKind::Public, false);
   auto *expectedY =
       mod.createVariable(ElemKind::FloatTy, {numSamples, 1}, "expected",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+                         VisibilityKind::Public, false);
 
   FullyConnectedNode *FC = F->createFullyConnected("fc", inputX, 1);
   Node *R = F->createRegression("reg", FC, expectedY);
@@ -700,10 +684,9 @@ TEST_P(MLTest, classifyPlayerSport) {
 
   auto *A =
       mod.createVariable(ElemKind::FloatTy, {numTrainPlayers, numFeatures}, "A",
-                         VisibilityKind::Public, Variable::TrainKind::None);
-  auto *S =
-      mod.createVariable(ElemKind::IndexTy, {numTrainPlayers, 1}, "S",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+                         VisibilityKind::Public, false);
+  auto *S = mod.createVariable(ElemKind::IndexTy, {numTrainPlayers, 1}, "S",
+                               VisibilityKind::Public, false);
 
   auto *FC = F->createFullyConnected("fc", A, numClasses);
   auto *SM = F->createSoftMax("softmax", FC, S);
@@ -775,13 +758,12 @@ TEST_P(MLTest, learnSinus) {
     tensorY.getHandle<>().at({i, 0}) = y;
   }
 
-  auto *inputX =
-      mod.createVariable(ElemKind::FloatTy, {numSamples, 1}, "input",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+  auto *inputX = mod.createVariable(ElemKind::FloatTy, {numSamples, 1}, "input",
+                                    VisibilityKind::Public, false);
 
   auto *expectedY =
       mod.createVariable(ElemKind::FloatTy, {numSamples, 1}, "expected",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+                         VisibilityKind::Public, false);
 
   FullyConnectedNode *FC1 = F->createFullyConnected("fc1", inputX, 10);
   Node *O = F->createSigmoid("sigmoid1", FC1);
@@ -829,12 +811,10 @@ TEST_P(MLTest, nonLinearClassifier) {
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("nonLinearClassifier");
 
-  auto *A =
-      mod.createVariable(ElemKind::FloatTy, {batchSize, 2}, "A",
-                         VisibilityKind::Public, Variable::TrainKind::None);
-  auto *S =
-      mod.createVariable(ElemKind::IndexTy, {batchSize, 1}, "S",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+  auto *A = mod.createVariable(ElemKind::FloatTy, {batchSize, 2}, "A",
+                               VisibilityKind::Public, false);
+  auto *S = mod.createVariable(ElemKind::IndexTy, {batchSize, 1}, "S",
+                               VisibilityKind::Public, false);
 
   auto *FCL0 = F->createFullyConnected("fc1", A, 8);
   auto *T0 = F->createTanh("tanh1", FCL0);
@@ -918,13 +898,11 @@ TEST_P(InterpreterAndCPU, convNetForImageRecognition) {
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("convNetForImageRecognition");
 
-  auto *input =
-      mod.createVariable(ElemKind::FloatTy, {batchSize, 8, 8, 1}, "input",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+  auto *input = mod.createVariable(ElemKind::FloatTy, {batchSize, 8, 8, 1},
+                                   "input", VisibilityKind::Public, false);
 
-  auto *ex =
-      mod.createVariable(ElemKind::IndexTy, {batchSize, 1}, "exp",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+  auto *ex = mod.createVariable(ElemKind::IndexTy, {batchSize, 1}, "exp",
+                                VisibilityKind::Public, false);
 
   auto *CV = F->createConv("conv", input, 1, 3, 1, 0, 1);
   auto *TANH = F->createTanh("tanh", CV);
@@ -1005,12 +983,10 @@ TEST_P(InterpreterAndCPU, testFindPixelRegression) {
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
 
-  auto *input =
-      mod.createVariable(ElemKind::FloatTy, {batchSize, 10, 10, 1}, "input",
-                         VisibilityKind::Public, Variable::TrainKind::None);
-  auto *ex =
-      mod.createVariable(ElemKind::FloatTy, {batchSize, 2}, "coordinates",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+  auto *input = mod.createVariable(ElemKind::FloatTy, {batchSize, 10, 10, 1},
+                                   "input", VisibilityKind::Public, false);
+  auto *ex = mod.createVariable(ElemKind::FloatTy, {batchSize, 2},
+                                "coordinates", VisibilityKind::Public, false);
 
   // A simple single-layer FC network could solve this program but we use a two
   // layer FC network to give the compiler something slightly more complex to
@@ -1168,13 +1144,13 @@ TEST_P(MLTest, matrixRotationRecognition) {
   Function *F = mod.createFunction("MatrixRotationRecognition");
   Variable *varMatricesA =
       mod.createVariable(ElemKind::FloatTy, {TC.batchSize, 3, 3}, "matrixA",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+                         VisibilityKind::Public, false);
   Variable *varMatricesB =
       mod.createVariable(ElemKind::FloatTy, {TC.batchSize, 3, 3}, "matrixB",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+                         VisibilityKind::Public, false);
   Variable *varExpected =
       mod.createVariable(ElemKind::IndexTy, {TC.batchSize, 1}, "expected",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+                         VisibilityKind::Public, false);
 
   // Simply concatenating the matrices first would probability be as effective
   // but we want to build something more complex than a straight chain of

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -1223,12 +1223,11 @@ TEST_P(InterpAndCPU, EntropyLossTest) {
 TEST_P(Operator, RescaleNode) {
   // Check the outputs of the RescaleQuantized operation.
   auto *input = mod_.createVariable(ElemKind::Int8QTy, {4, 10}, 0.4, -3,
-                                    "input", VisibilityKind::Public,
-                                    Variable::TrainKind::Broadcast, 40);
+                                    "input", VisibilityKind::Public, true);
+  auto *output = mod_.createVariable(ElemKind::Int8QTy, {4, 10}, 0.4, -4,
+                                     "output", VisibilityKind::Public, false);
 
-  auto *output =
-      mod_.createVariable(ElemKind::Int8QTy, {4, 10}, 0.4, -4, "output",
-                          VisibilityKind::Public, Variable::TrainKind::None);
+  input->getPayload().init(Tensor::InitKind::Broadcast, 40, mod_.getPRNG());
 
   auto T1 = mod_.uniqueType(ElemKind::Int8QTy, {4, 10}, 0.7, 5);
   auto T2 = mod_.uniqueType(ElemKind::Int8QTy, {4, 10}, 0.3, -4);
@@ -1261,24 +1260,18 @@ TEST_P(InterpAndCPU, QuantizedArithmeticRescaled) {
                                 VisibilityKind::Public);
   auto *C = mod_.createVariable(ElemKind::FloatTy, {len}, "C",
                                 VisibilityKind::Public);
-  auto *O1 =
-      mod_.createVariable(ElemKind::FloatTy, {len}, "Max",
-                          VisibilityKind::Public, Variable::TrainKind::None);
-  auto *O2 =
-      mod_.createVariable(ElemKind::FloatTy, {len}, "Min",
-                          VisibilityKind::Public, Variable::TrainKind::None);
-  auto *O3 =
-      mod_.createVariable(ElemKind::FloatTy, {len}, "Add",
-                          VisibilityKind::Public, Variable::TrainKind::None);
-  auto *O4 =
-      mod_.createVariable(ElemKind::FloatTy, {len}, "Sub",
-                          VisibilityKind::Public, Variable::TrainKind::None);
-  auto *O5 =
-      mod_.createVariable(ElemKind::FloatTy, {len}, "Mul",
-                          VisibilityKind::Public, Variable::TrainKind::None);
-  auto *O6 =
-      mod_.createVariable(ElemKind::FloatTy, {len}, "Div",
-                          VisibilityKind::Public, Variable::TrainKind::None);
+  auto *O1 = mod_.createVariable(ElemKind::FloatTy, {len}, "Max",
+                                 VisibilityKind::Public, false);
+  auto *O2 = mod_.createVariable(ElemKind::FloatTy, {len}, "Min",
+                                 VisibilityKind::Public, false);
+  auto *O3 = mod_.createVariable(ElemKind::FloatTy, {len}, "Add",
+                                 VisibilityKind::Public, false);
+  auto *O4 = mod_.createVariable(ElemKind::FloatTy, {len}, "Sub",
+                                 VisibilityKind::Public, false);
+  auto *O5 = mod_.createVariable(ElemKind::FloatTy, {len}, "Mul",
+                                 VisibilityKind::Public, false);
+  auto *O6 = mod_.createVariable(ElemKind::FloatTy, {len}, "Div",
+                                 VisibilityKind::Public, false);
 
   auto AH = A->getHandle();
   auto BH = B->getHandle();
@@ -1415,24 +1408,24 @@ TEST_P(Operator, QuantizedArithmeticUnrescaled) {
   auto *QC =
       mod_.createVariable(ElemKind::Int8QTy, {len}, TQC->getScale(),
                           TQC->getOffset(), "QC", VisibilityKind::Public);
-  auto *O1 = mod_.createVariable(
-      ElemKind::Int8QTy, {len}, TO1->getScale(), TO1->getOffset(), "Max",
-      VisibilityKind::Public, Variable::TrainKind::None);
-  auto *O2 = mod_.createVariable(
-      ElemKind::Int8QTy, {len}, TO2->getScale(), TO2->getOffset(), "Min",
-      VisibilityKind::Public, Variable::TrainKind::None);
-  auto *O3 = mod_.createVariable(
-      ElemKind::Int8QTy, {len}, TO3->getScale(), TO3->getOffset(), "Add",
-      VisibilityKind::Public, Variable::TrainKind::None);
-  auto *O4 = mod_.createVariable(
-      ElemKind::Int8QTy, {len}, TO4->getScale(), TO4->getOffset(), "Sub",
-      VisibilityKind::Public, Variable::TrainKind::None);
-  auto *O5 = mod_.createVariable(
-      ElemKind::Int8QTy, {len}, TO5->getScale(), TO5->getOffset(), "Mul",
-      VisibilityKind::Public, Variable::TrainKind::None);
-  auto *O6 = mod_.createVariable(
-      ElemKind::Int8QTy, {len}, TO6->getScale(), TO6->getOffset(), "Div",
-      VisibilityKind::Public, Variable::TrainKind::None);
+  auto *O1 = mod_.createVariable(ElemKind::Int8QTy, {len}, TO1->getScale(),
+                                 TO1->getOffset(), "Max",
+                                 VisibilityKind::Public, false);
+  auto *O2 = mod_.createVariable(ElemKind::Int8QTy, {len}, TO2->getScale(),
+                                 TO2->getOffset(), "Min",
+                                 VisibilityKind::Public, false);
+  auto *O3 = mod_.createVariable(ElemKind::Int8QTy, {len}, TO3->getScale(),
+                                 TO3->getOffset(), "Add",
+                                 VisibilityKind::Public, false);
+  auto *O4 = mod_.createVariable(ElemKind::Int8QTy, {len}, TO4->getScale(),
+                                 TO4->getOffset(), "Sub",
+                                 VisibilityKind::Public, false);
+  auto *O5 = mod_.createVariable(ElemKind::Int8QTy, {len}, TO5->getScale(),
+                                 TO5->getOffset(), "Mul",
+                                 VisibilityKind::Public, false);
+  auto *O6 = mod_.createVariable(ElemKind::Int8QTy, {len}, TO6->getScale(),
+                                 TO6->getOffset(), "Div",
+                                 VisibilityKind::Public, false);
 
   auto QAH = QA->getHandle<int8_t>();
   auto QBH = QB->getHandle<int8_t>();
@@ -1509,9 +1502,8 @@ TEST_P(InterpAndCPU, QuantizedCmpLTEAndSelect) {
   auto *QD =
       mod_.createVariable(ElemKind::Int8QTy, {len}, TQD->getScale(),
                           TQD->getOffset(), "QD", VisibilityKind::Public);
-  auto *Out =
-      mod_.createVariable(ElemKind::Int8QTy, {len}, 1.5, -2, "out",
-                          VisibilityKind::Public, Variable::TrainKind::None);
+  auto *Out = mod_.createVariable(ElemKind::Int8QTy, {len}, 1.5, -2, "out",
+                                  VisibilityKind::Public, false);
 
   auto QAH = QA->getHandle<int8_t>();
   auto QBH = QB->getHandle<int8_t>();
@@ -1562,9 +1554,8 @@ TEST_P(Operator, TestQuantizedRescaleSequence) {
 
   auto *A = mod_.createVariable(ElemKind::FloatTy, {len}, "A",
                                 VisibilityKind::Public);
-  auto *O =
-      mod_.createVariable(ElemKind::FloatTy, {len}, "Out",
-                          VisibilityKind::Public, Variable::TrainKind::None);
+  auto *O = mod_.createVariable(ElemKind::FloatTy, {len}, "Out",
+                                VisibilityKind::Public, false);
 
   auto AH = A->getPayload().getHandle();
   auto OH = O->getPayload().getHandle();
@@ -1609,18 +1600,18 @@ TEST_P(Operator, FCGradientCheck) {
   // with reference values.
   TrainingConfig TC;
 
-  auto *A =
-      mod_.createVariable(ElemKind::FloatTy, {2, 1}, "A",
-                          VisibilityKind::Public, Variable::TrainKind::None);
-  auto *B =
-      mod_.createVariable(ElemKind::FloatTy, {2, 1}, "B",
-                          VisibilityKind::Public, Variable::TrainKind::None);
+  auto *A = mod_.createVariable(ElemKind::FloatTy, {2, 1}, "A",
+                                VisibilityKind::Public, false);
+  auto *B = mod_.createVariable(ElemKind::FloatTy, {2, 1}, "B",
+                                VisibilityKind::Public, false);
   auto *X = mod_.createVariable(ElemKind::FloatTy, {1, 1}, "X",
-                                VisibilityKind::Public,
-                                Variable::TrainKind::Broadcast, -1.26274);
-  auto *Y =
-      mod_.createVariable(ElemKind::FloatTy, {1}, "Y", VisibilityKind::Public,
-                          Variable::TrainKind::Broadcast, 0.10000);
+                                VisibilityKind::Public, true);
+  auto *Y = mod_.createVariable(ElemKind::FloatTy, {1}, "Y",
+                                VisibilityKind::Public, true);
+
+  X->getPayload().init(Tensor::InitKind::Broadcast, -1.26274, mod_.getPRNG());
+  Y->getPayload().init(Tensor::InitKind::Broadcast, 0.1, mod_.getPRNG());
+
   auto *FC = F_->createFullyConnected("fc", A, X, Y);
   auto *S = F_->createRegression("reg", FC, B);
   F_->createSave("ret", S);
@@ -2244,16 +2235,14 @@ TEST_P(Operator, NonSquarePaddingConvolution) {
     IH.raw(i) = i + 1;
   }
 
-  auto filter =
-      mod_.createVariable(ElemKind::FloatTy, {2, 2, 2, 1}, "filter",
-                          VisibilityKind::Public, Variable::TrainKind::None);
+  auto filter = mod_.createVariable(ElemKind::FloatTy, {2, 2, 2, 1}, "filter",
+                                    VisibilityKind::Public, false);
   auto FH = filter->getHandle();
   for (size_t i = 0; i < 2 * 2 * 2; i++) {
     FH.raw(i) = pow(2.0, i);
   }
-  auto *zeroBias =
-      mod_.createVariable(ElemKind::FloatTy, {2}, "bias",
-                          VisibilityKind::Public, Variable::TrainKind::None);
+  auto *zeroBias = mod_.createVariable(ElemKind::FloatTy, {2}, "bias",
+                                       VisibilityKind::Public, false);
   zeroBias->getPayload().zero();
 
   auto outTy = mod_.uniqueType(ElemKind::FloatTy, {1, 4, 8, 2});

--- a/tests/unittests/gradCheckTest.cpp
+++ b/tests/unittests/gradCheckTest.cpp
@@ -141,12 +141,10 @@ TEST_P(InterpreterGrad, gradientCheckFCConcatRELU) {
 
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("main");
-  auto *A =
-      mod.createVariable(ElemKind::FloatTy, {1, numInputElem}, "A",
-                         VisibilityKind::Public, Variable::TrainKind::None);
-  auto *Exp =
-      mod.createVariable(ElemKind::FloatTy, {1, numOutputElem}, "exp",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+  auto *A = mod.createVariable(ElemKind::FloatTy, {1, numInputElem}, "A",
+                               VisibilityKind::Public, false);
+  auto *Exp = mod.createVariable(ElemKind::FloatTy, {1, numOutputElem}, "exp",
+                                 VisibilityKind::Public, false);
 
   Node *FA = F->createFullyConnected("fc1", A, numOutputElem / 2);
   FA = F->createRELU("relu1", FA);
@@ -178,12 +176,11 @@ static void gradientCheckGroupConv(size_t numInputChan, size_t group,
 
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("main");
-  auto *A = mod.createVariable(
-      ElemKind::FloatTy, {1, numDim, numDim, numInputChan}, "A",
-      VisibilityKind::Public, Variable::TrainKind::None);
-  auto *Ex =
-      mod.createVariable(ElemKind::FloatTy, {1, numOutputElem}, "exp",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+  auto *A =
+      mod.createVariable(ElemKind::FloatTy, {1, numDim, numDim, numInputChan},
+                         "A", VisibilityKind::Public, false);
+  auto *Ex = mod.createVariable(ElemKind::FloatTy, {1, numOutputElem}, "exp",
+                                VisibilityKind::Public, false);
 
   Node *O = F->createConv("conv", A, 4, 5, 1, 2, group);
   O = F->createPoolMax("pool", O, 3, 3, 0);
@@ -218,12 +215,10 @@ TEST_P(InterpreterGrad, gradientCheckAvgPool) {
 
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("main");
-  auto *A =
-      mod.createVariable(ElemKind::FloatTy, {1, numDim, numDim, 1}, "A",
-                         VisibilityKind::Public, Variable::TrainKind::None);
-  auto *Exp =
-      mod.createVariable(ElemKind::FloatTy, {1, numOutputElem}, "Exp",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+  auto *A = mod.createVariable(ElemKind::FloatTy, {1, numDim, numDim, 1}, "A",
+                               VisibilityKind::Public, false);
+  auto *Exp = mod.createVariable(ElemKind::FloatTy, {1, numOutputElem}, "Exp",
+                                 VisibilityKind::Public, false);
 
   Node *O = F->createPoolAvg("pool", A, 3, 3, 1);
   O = F->createTanh("tanh", O);
@@ -249,12 +244,10 @@ TEST_P(InterpreterGrad, gradientCheckBatchNorm) {
 
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("main");
-  auto *A =
-      mod.createVariable(ElemKind::FloatTy, {1, numDim, numDim, 3}, "A",
-                         VisibilityKind::Public, Variable::TrainKind::None);
-  auto *Ex =
-      mod.createVariable(ElemKind::FloatTy, {1, numOutputElem}, "exp",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+  auto *A = mod.createVariable(ElemKind::FloatTy, {1, numDim, numDim, 3}, "A",
+                               VisibilityKind::Public, false);
+  auto *Ex = mod.createVariable(ElemKind::FloatTy, {1, numOutputElem}, "exp",
+                                VisibilityKind::Public, false);
 
   Node *O = F->createBatchNormalization("batch", A, 3, 0.0001, 0.9);
   O = F->createReshape("reshape", O, {1, numDim * numDim * 3});
@@ -287,14 +280,14 @@ TEST_P(InterpreterGrad, gradientCheckArithmeticDiv) {
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("main");
   auto *A = mod.createVariable(ElemKind::FloatTy, {1, numDim}, "A",
-                               VisibilityKind::Public,
-                               Variable::TrainKind::Xavier, 1);
-  auto *B =
-      mod.createVariable(ElemKind::FloatTy, {1, numDim}, "B",
-                         VisibilityKind::Public, Variable::TrainKind::None);
-  auto *Exp =
-      mod.createVariable(ElemKind::FloatTy, {1, numDim}, "exp",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+                               VisibilityKind::Public, true);
+  auto *B = mod.createVariable(ElemKind::FloatTy, {1, numDim}, "B",
+                               VisibilityKind::Public, false);
+  auto *Exp = mod.createVariable(ElemKind::FloatTy, {1, numDim}, "exp",
+                                 VisibilityKind::Public, false);
+
+  A->getPayload().init(Tensor::InitKind::Xavier, 1.0, mod.getPRNG());
+
   Node *O = F->createDiv("div", A, B);
   O = F->createRegression("reg", O, Exp);
   auto *result = F->createSave("ret", O);
@@ -314,27 +307,21 @@ TEST_P(InterpreterGrad, gradientCheckArithmetic) {
 
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("main");
-  auto *A =
-      mod.createVariable(ElemKind::FloatTy, {1, numDim}, "A",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+  auto *A = mod.createVariable(ElemKind::FloatTy, {1, numDim}, "A",
+                               VisibilityKind::Public, false);
   auto *B = mod.createVariable(ElemKind::FloatTy, {1, numDim}, "B",
-                               VisibilityKind::Public,
-                               Variable::TrainKind::None, 0.1);
+                               VisibilityKind::Public, false);
   auto *C = mod.createVariable(ElemKind::FloatTy, {1, numDim}, "C",
-                               VisibilityKind::Public,
-                               Variable::TrainKind::None, 0.1);
+                               VisibilityKind::Public, false);
   auto *D = mod.createVariable(ElemKind::FloatTy, {1, numDim}, "D",
-                               VisibilityKind::Public,
-                               Variable::TrainKind::None, 0.1);
-  auto *E =
-      mod.createVariable(ElemKind::FloatTy, {1, numDim}, "E",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+                               VisibilityKind::Public, false);
+  auto *E = mod.createVariable(ElemKind::FloatTy, {1, numDim}, "E",
+                               VisibilityKind::Public, false);
   // Randomize E to avoid div by zero.
   E->getPayload().getHandle().initXavier(1, mod.getPRNG());
 
-  auto *Exp =
-      mod.createVariable(ElemKind::FloatTy, {1, numDim}, "exp",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+  auto *Exp = mod.createVariable(ElemKind::FloatTy, {1, numDim}, "exp",
+                                 VisibilityKind::Public, false);
 
   Node *O = F->createMul("mul", A, B);
   O = F->createAdd("add", O, C);
@@ -362,12 +349,10 @@ TEST_P(InterpreterGrad, gradientCheckFCConcatTanh) {
 
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("main");
-  auto *A =
-      mod.createVariable(ElemKind::FloatTy, {1, numInputElem}, "A",
-                         VisibilityKind::Public, Variable::TrainKind::None);
-  auto *Exp =
-      mod.createVariable(ElemKind::FloatTy, {1, numOutputElem}, "Exp",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+  auto *A = mod.createVariable(ElemKind::FloatTy, {1, numInputElem}, "A",
+                               VisibilityKind::Public, false);
+  auto *Exp = mod.createVariable(ElemKind::FloatTy, {1, numOutputElem}, "Exp",
+                                 VisibilityKind::Public, false);
 
   Node *FA = F->createFullyConnected("fc", A, numOutputElem);
   FA = F->createTanh("tanh", FA);
@@ -392,12 +377,10 @@ TEST_P(InterpreterGrad, gradientCheckFC) {
 
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("main");
-  auto *A =
-      mod.createVariable(ElemKind::FloatTy, {1, numInputElem}, "A",
-                         VisibilityKind::Public, Variable::TrainKind::None);
-  auto *Exp =
-      mod.createVariable(ElemKind::FloatTy, {1, numOutputElem}, "Exp",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+  auto *A = mod.createVariable(ElemKind::FloatTy, {1, numInputElem}, "A",
+                               VisibilityKind::Public, false);
+  auto *Exp = mod.createVariable(ElemKind::FloatTy, {1, numOutputElem}, "Exp",
+                                 VisibilityKind::Public, false);
 
   Node *FA = F->createFullyConnected("fc", A, numOutputElem);
   FA = F->createRegression("reg", FA, Exp);
@@ -421,12 +404,10 @@ TEST_P(InterpreterGrad, gradientCheckSigmoid) {
 
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("main");
-  auto *A =
-      mod.createVariable(ElemKind::FloatTy, {1, numInputElem}, "A",
-                         VisibilityKind::Public, Variable::TrainKind::None);
-  auto *Exp =
-      mod.createVariable(ElemKind::FloatTy, {1, numOutputElem}, "Exp",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+  auto *A = mod.createVariable(ElemKind::FloatTy, {1, numInputElem}, "A",
+                               VisibilityKind::Public, false);
+  auto *Exp = mod.createVariable(ElemKind::FloatTy, {1, numOutputElem}, "Exp",
+                                 VisibilityKind::Public, false);
   F->createSave("ret", A);
 
   Node *FA = F->createSigmoid("sig", Exp);
@@ -451,12 +432,10 @@ TEST_P(InterpreterGrad, gradientCheckRelu) {
 
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("main");
-  auto *A =
-      mod.createVariable(ElemKind::FloatTy, {1, numInputElem}, "A",
-                         VisibilityKind::Public, Variable::TrainKind::None);
-  auto *Exp =
-      mod.createVariable(ElemKind::FloatTy, {1, numOutputElem}, "Exp",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+  auto *A = mod.createVariable(ElemKind::FloatTy, {1, numInputElem}, "A",
+                               VisibilityKind::Public, false);
+  auto *Exp = mod.createVariable(ElemKind::FloatTy, {1, numOutputElem}, "Exp",
+                                 VisibilityKind::Public, false);
   F->createSave("ret", A);
 
   Node *FA = F->createRELU("relu", Exp);
@@ -481,12 +460,10 @@ TEST_P(InterpreterGrad, gradientCheckTranspose) {
 
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("main");
-  auto *A =
-      mod.createVariable(ElemKind::FloatTy, {1, 5, 10, 5}, "input",
-                         VisibilityKind::Public, Variable::TrainKind::None);
-  auto *Exp =
-      mod.createVariable(ElemKind::FloatTy, {1, numOutputElem}, "exp",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+  auto *A = mod.createVariable(ElemKind::FloatTy, {1, 5, 10, 5}, "input",
+                               VisibilityKind::Public, false);
+  auto *Exp = mod.createVariable(ElemKind::FloatTy, {1, numOutputElem}, "exp",
+                                 VisibilityKind::Public, false);
   Node *TA = F->createTranspose("transpose", A, NHWC2NCHW);
   TA = F->createFullyConnected("fc", TA, numOutputElem);
   TA = F->createRegression("regress", TA, Exp);
@@ -513,15 +490,12 @@ TEST_P(InterpreterGrad, gradientCheckCrossEntropyLoss) {
 
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("main");
-  auto *P =
-      mod.createVariable(ElemKind::FloatTy, {batchSize, 4}, "P",
-                         VisibilityKind::Public, Variable::TrainKind::None);
-  auto *Y =
-      mod.createVariable(ElemKind::IndexTy, {batchSize}, "Labels",
-                         VisibilityKind::Public, Variable::TrainKind::None);
-  auto *L =
-      mod.createVariable(ElemKind::FloatTy, {1}, "L", VisibilityKind::Public,
-                         Variable::TrainKind::None);
+  auto *P = mod.createVariable(ElemKind::FloatTy, {batchSize, 4}, "P",
+                               VisibilityKind::Public, false);
+  auto *Y = mod.createVariable(ElemKind::IndexTy, {batchSize}, "Labels",
+                               VisibilityKind::Public, false);
+  auto *L = mod.createVariable(ElemKind::FloatTy, {1}, "L",
+                               VisibilityKind::Public, false);
   Node *CE = F->createCrossEntropyLoss("celoss", P, Y);
   F->createSave("ret", CE, L);
 

--- a/tests/unittests/graphGradTest.cpp
+++ b/tests/unittests/graphGradTest.cpp
@@ -41,9 +41,8 @@ TEST(GraphAutoGrad, autoGrad) {
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
 
-  Variable *A =
-      mod.createVariable(ElemKind::FloatTy, {10, 28, 28, 1}, "input",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+  Variable *A = mod.createVariable(ElemKind::FloatTy, {10, 28, 28, 1}, "input",
+                                   VisibilityKind::Public, false);
 
   auto *CV0 = F->createConv("conv1", A, 16, 5, 1, 2, 1);
   auto *RL0 = F->createRELU("relu1", CV0);
@@ -55,9 +54,8 @@ TEST(GraphAutoGrad, autoGrad) {
 
   auto *FCL1 = F->createFullyConnected("fc3", MP1, 10);
   auto *RL2 = F->createRELU("relu3", FCL1);
-  Variable *selected =
-      mod.createVariable(ElemKind::IndexTy, {10, 1}, "selected",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+  Variable *selected = mod.createVariable(
+      ElemKind::IndexTy, {10, 1}, "selected", VisibilityKind::Public, false);
 
   auto *SM = F->createSoftMax("sm", RL2, selected);
 
@@ -81,15 +79,13 @@ TEST(GraphAutoGrad, checkLRNGen) {
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
 
-  Variable *A =
-      mod.createVariable(ElemKind::FloatTy, {10, 28, 28, 1}, "input",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+  Variable *A = mod.createVariable(ElemKind::FloatTy, {10, 28, 28, 1}, "input",
+                                   VisibilityKind::Public, false);
   auto *CV0 = F->createLocalResponseNormalization("LRN", A);
   auto *FCL1 = F->createFullyConnected("fc3", CV0, 10);
   auto *RL2 = F->createRELU("relu3", FCL1);
-  Variable *selected =
-      mod.createVariable(ElemKind::IndexTy, {10, 1}, "selected",
-                         VisibilityKind::Public, Variable::TrainKind::None);
+  Variable *selected = mod.createVariable(
+      ElemKind::IndexTy, {10, 1}, "selected", VisibilityKind::Public, false);
 
   auto *SM = F->createSoftMax("sm", RL2, selected);
 
@@ -128,9 +124,8 @@ TEST(GraphAutoGrad, cloneAndDiff) {
 
   EXPECT_EQ(M.getVars().size(), 3);
 
-  Node *label =
-      M.createVariable(ElemKind::FloatTy, {1}, "label", VisibilityKind::Public,
-                       Variable::TrainKind::None);
+  Node *label = M.createVariable(ElemKind::FloatTy, {1}, "label",
+                                 VisibilityKind::Public, false);
   Node *reg = F->createRegression("reg", AplusB_F, label);
   F->createSave("return", reg);
 

--- a/tests/unittests/partitionTest.cpp
+++ b/tests/unittests/partitionTest.cpp
@@ -46,9 +46,8 @@ static void executeSerial(const FunctionDAG &G,
 }
 
 TEST_F(PartitionTest, SerialExecution) {
-  auto *input =
-      mod_.createVariable(ElemKind::FloatTy, {1, 32}, "input",
-                          VisibilityKind::Public, Variable::TrainKind::None);
+  auto *input = mod_.createVariable(ElemKind::FloatTy, {1, 32}, "input",
+                                    VisibilityKind::Public, false);
 
   // Initial FC.
   Node *I = F_->createFullyConnected("initial_fc", input, 16);
@@ -110,9 +109,8 @@ TEST_F(PartitionTest, SerialExecution) {
 }
 
 TEST_F(PartitionTest, Branchover) {
-  auto *input =
-      mod_.createVariable(ElemKind::FloatTy, {1, 8}, "input",
-                          VisibilityKind::Public, Variable::TrainKind::None);
+  auto *input = mod_.createVariable(ElemKind::FloatTy, {1, 8}, "input",
+                                    VisibilityKind::Public, false);
   auto *FC1 = F_->createFullyConnected("fc1", input, 8);
   auto *FC2 = F_->createFullyConnected("fc2", FC1, 8);
   auto *add = F_->createAdd("add", FC1, FC2);
@@ -153,9 +151,8 @@ TEST_F(PartitionTest, Branchover) {
 }
 
 TEST_F(PartitionTest, Train) {
-  auto *input =
-      mod_.createVariable(ElemKind::FloatTy, {1, 8}, "input",
-                          VisibilityKind::Public, Variable::TrainKind::None);
+  auto *input = mod_.createVariable(ElemKind::FloatTy, {1, 8}, "input",
+                                    VisibilityKind::Public, false);
   auto *FC = F_->createFullyConnected("fc", input, 8);
   F_->createSave("save", FC);
   auto *TF = glow::differentiate(F_, TrainingConfig());


### PR DESCRIPTION
This commit removes the initialization code from Variable and moves it to the code that creates the variable. After this change Tensors needs to be initialized externally and not by the Variable constructor like they are today. This is a pretty big patch that touches many many files, but most of the changes are mechanical. 

I tried to make this patch as simple as possible and there are still a few things that we need to clean up. For example, the default values for arguments don't make sense in a few places. We should change the boolean training flag to an enum, etc.  