### PR TITLE
[cpu] Introduce GLOW_LIBJIT_PATH for non-standard libjit location

### DIFF
--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -137,6 +137,12 @@ loadStandardLibrary(llvm::LLVMContext *ctx, llvm::StringRef filename) {
   using llvm::sys::path::parent_path;
 
   llvm::SMDiagnostic error;
+
+  auto *envPath = getenv("GLOW_LIBJIT_PATH");
+  if (envPath != nullptr) {
+    return llvm::parseIRFile(envPath, error, *ctx);
+  }
+
   // Figure out the location of the current executable.
   auto mainExec =
       llvm::sys::fs::getMainExecutable(nullptr, (void *)&loadStandardLibrary);


### PR DESCRIPTION
While CMake lets us decide where to put libjit.bc, other systems (such as buck) don't have this flexibility.  Using an environment variable lets us override the default search path.