### PR TITLE
Support batch matmul as a normal matmul plus a couple reshapes

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -376,6 +376,12 @@ public:
   MatMulNode *createMatMul(llvm::StringRef name, TypeRef outTy, NodeValue lhs,
                            NodeValue rhs);
 
+  /// \p lhs is a 3d matrix, where the leading dimension is the batch size. \p
+  /// rhs is a 2d matrix, which every batch from \p lhs (a 2d matrix) is
+  /// multiplied by. This is implemented via reshaping \p lhs to be a 2d matrix,
+  /// multiplying by \p rhs, and then reshaping the result back to 3d.
+  Node *createBatchMatMul(llvm::StringRef name, NodeValue lhs, NodeValue rhs);
+
   BatchedReduceAddNode *createBatchedReduceAdd(llvm::StringRef name,
                                                NodeValue batch, size_t axis);
 

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -134,6 +134,30 @@ TEST_P(Operator, matmul) {
   EXPECT_NEAR(H.at({2, 0}), 95, 0.001);
 }
 
+/// Test that the batch mat mul operator works as expected.
+TEST_P(Operator, batchmatmul) {
+  auto *lhs = mod_.createVariable(ElemKind::FloatTy, {2, 3, 2}, "lhs");
+  auto *rhs = mod_.createVariable(ElemKind::FloatTy, {2, 1}, "rhs");
+  auto *result = mod_.createVariable(ElemKind::FloatTy, {2, 3, 1}, "result");
+  lhs->getPayload().getHandle() = {1, 2, 3, 4, 5, 6, -1, -2, -3, -4, -5, -6};
+  rhs->getPayload().getHandle() = {7, 10};
+
+  auto *R = F_->createBatchMatMul("BMM", lhs, rhs);
+
+  F_->createSave("save", R, result);
+
+  EE_.compile(CompilationMode::Infer, F_);
+  EE_.run({}, {});
+
+  auto H = result->getPayload().getHandle();
+  EXPECT_NEAR(H.at({0, 0, 0}), 27, 0.001);
+  EXPECT_NEAR(H.at({0, 1, 0}), 61, 0.001);
+  EXPECT_NEAR(H.at({0, 2, 0}), 95, 0.001);
+  EXPECT_NEAR(H.at({1, 0, 0}), -27, 0.001);
+  EXPECT_NEAR(H.at({1, 1, 0}), -61, 0.001);
+  EXPECT_NEAR(H.at({1, 2, 0}), -95, 0.001);
+}
+
 TEST_P(Operator, batchedReduceAdd) {
   auto *batch = mod_.createVariable(ElemKind::FloatTy, {2, 4}, "batch");
   auto *result = mod_.createVariable(ElemKind::FloatTy, {4}, "result");


### PR DESCRIPTION
This is very similar to our merging matmuls optimization. Instead of the merged LHS matrices each being individual matrices that we concat together, they're already essentially concatenated together as  each batch of the LHS tensor we already have. This means they're already logically arranged correctly in memory and instead of inserting/slicing them like we do for merged matmuls optimization we just reshape before and after.

Also, it means our optimizations for merging matmuls should work nicely with this. That is, other matmuls/batch matmuls can be merged into this one using the same merge matmuls optimization we already have.