### PR TITLE
[fix] Fix the problem ReLU node does not work with OpenCL quantization

### DIFF
--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -593,7 +593,7 @@ void OpenCLFunction::execute() {
                                          destTy->getOffset()};
           float val = SI->getValue();
           int8_t int8Val = quantization::quantize(val, destQ);
-          setKernelArg<int8_t>(kernel, ++numArgs, int8Val);
+          setKernelArg<float>(kernel, ++numArgs, static_cast<float>(int8Val));
         }
       } else if (auto *EPI = dyn_cast<ElementPowInst>(&I)) {
         // Pass the exp as a parameter.

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -187,6 +187,7 @@ public:
       case Kinded::Kind::MinNodeKind:
       case Kinded::Kind::MulNodeKind:
       case Kinded::Kind::QuantizeNodeKind:
+      case Kinded::Kind::ReluNodeKind:
       case Kinded::Kind::RescaleQuantizedNodeKind:
       case Kinded::Kind::SplatNodeKind:
       case Kinded::Kind::SubNodeKind:

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -2157,7 +2157,7 @@ TEST_P(InterpAndCPU, Split) {
   EXPECT_FLOAT_EQ(result.at({0, 1, 3}), 12);
 }
 
-TEST_P(InterpAndCPU, IntRelu) {
+TEST_P(Operator, IntRelu) {
   const float splatValue = 10;
   const float scale = 1.0;
   const float rescaleScale = 2.0;
@@ -2184,7 +2184,7 @@ TEST_P(InterpAndCPU, IntRelu) {
   }
 }
 
-TEST_P(InterpAndCPU, IntSplat) {
+TEST_P(Operator, IntSplat) {
   const float splatValue = 10;
   const float scale = 1.0;
   const int32_t offset = 5;


### PR DESCRIPTION
Found the bug that splat int8 kernel always receives 0 as the input value. Fixed it and ReLU works with the opencl quantization now.