### PR TITLE
[Caffe2 Importer] Make more operators to be available from importer

### DIFF
--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -55,6 +55,13 @@ protected:
     addNodeAsOutput(op, R);
   }
 
+  void loadSigmoid(const OpType &op, ArgumentDictionaryTy &dict) {
+    const std::string &opName = loadOperatorName(op);
+    auto in = getNodeValueOrCreateVariableByName(op.input(0));
+    auto *S = G_.createSigmoid(opName, in);
+    addNodeAsOutput(op, S);
+  }
+  
   void loadSum(const OpType &op, ArgumentDictionaryTy &dict) {
     // TODO: support variadic arguments
     assert(op.input_size() == 2 && "Only Sum of 2 inputs is supported.");
@@ -242,6 +249,10 @@ protected:
                              ArgumentDictionaryTy &dict) {
     if (typeName == "Relu") {
       loadRelu(op, dict);
+      return true;
+    }
+    if (typeName == "Sigmoid") {
+      loadSigmoid(op, dict);
       return true;
     }
     if (typeName == "Sum") {

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -606,10 +606,10 @@ TransposeNode *Function::createTranspose(llvm::StringRef name, NodeValue input,
 Node *Function::createBroadcast(llvm::StringRef name, NodeValue input,
                                 llvm::ArrayRef<size_t> newShape,
                                 unsigned axis) {
-  assert(axis >= 0 && axis < newShape.size() &&
-         "Axis must fit inside the newShape.");
-
   const auto &origDims = input.dims();
+
+  assert(axis + origDims.size() <= newShape.size() &&
+         "Axis must fit inside the newShape.");
 
   // Iterate over the new shape; if the original shape had a dimension here
   // (when considering the axis) then verify the dimension either matches the


### PR DESCRIPTION
1. Support Sigmoid.
2. Support BatchGather.
3. Support broadcasting of 0-dimensional tensors.
4. Support transposed RHS for MatMul.
