### PR TITLE
Change FACEBOOK_INTERNAL to generic LLVM_VERSION_MAJOR and reduce som…

### DIFF
--- a/lib/Backends/CPU/BundleSaver.cpp
+++ b/lib/Backends/CPU/BundleSaver.cpp
@@ -147,7 +147,7 @@ void BundleSaver::produceBundle(llvm::StringRef outputDir) {
               "Could not open the output file for saving the bundle code");
   if (fileName.endswith(".bc")) {
     // Emit the bitcode file.
-#ifdef FACEBOOK_INTERNAL
+#if LLVM_VERSION_MAJOR > 6
     llvm::WriteBitcodeToFile(M, outputFile);
 #else
     llvm::WriteBitcodeToFile(&M, outputFile);

--- a/lib/Backends/CPU/GlowJIT.h
+++ b/lib/Backends/CPU/GlowJIT.h
@@ -43,13 +43,13 @@ namespace orc {
 // KaleidoscopeJIT example in the LLVM tree.
 class GlowJIT {
 private:
-#ifdef FACEBOOK_INTERNAL
+  TargetMachine &TM_;
+  const DataLayout DL_;
+#if LLVM_VERSION_MAJOR > 6
   SymbolStringPool SSP_;
   ExecutionSession ES_;
   std::shared_ptr<SymbolResolver> resolver_;
 #endif
-  TargetMachine &TM_;
-  const DataLayout DL_;
   RTDyldObjectLinkingLayer objectLayer_;
   IRCompileLayer<decltype(objectLayer_), SimpleCompiler> compileLayer_;
 
@@ -60,17 +60,15 @@ public:
 
   JITSymbol findSymbol(const std::string name);
 
-#ifdef FACEBOOK_INTERNAL
-  VModuleKey addModule(std::unique_ptr<Module> M);
-
-  void removeModule(VModuleKey K);
+#if LLVM_VERSION_MAJOR > 6
+  using ModuleHandle = orc::VModuleKey;
 #else
   using ModuleHandle = decltype(compileLayer_)::ModuleHandleT;
+#endif
 
   ModuleHandle addModule(std::unique_ptr<Module> M);
 
   void removeModule(ModuleHandle H);
-#endif
 };
 
 } // end namespace orc


### PR DESCRIPTION
This PR starts to reduce some of the `ifdefs` as requested in issue #1359. 

This is the first version to clean up some of the ifdefs and make it as generic as possible. I have switched from `FACEBOOK_INTERNAL` to `LLVM_VERSION_MAJOR` to make it a bit more generic. Please let me know if that is ok or I should keep the `FACEBOOK_INTERNAL` check as it is.

I am not sure how to test this properly with Facebook's version of llvm. Some guidance how to do it will be really helpful.

I am not entirely sure how to use the `OrcBindings.h` api. If I can get some pointers here it will be really helpful. I tried to check if there is anything for `NotifyLoadedFunctor ` in LLVM 7.0 but couldn't find anything yet. I will keep looking if I can find something. 

cc @bertmaher @nadavrot @rdzhabarov please review this version