### PR TITLE
[IR] Add a test that we can compile code without graph deps.

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -157,6 +157,9 @@ public:
 
   /// Dump a dotty graph that depicts the Module.
   void dumpDAG(const char *dotFilename);
+
+  /// Erase all of the functions from the module.
+  void eraseFunctions();
 };
 
 /// Represents the compute graph.

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -51,9 +51,7 @@ Function *Module::createFunction(llvm::StringRef name) {
 }
 
 Module::~Module() {
-  for (auto *F : functions_) {
-    delete F;
-  }
+  eraseFunctions();
 
   for (auto it = vars_.begin(), e = vars_.end(); it != e;) {
     auto cur = it++;
@@ -264,6 +262,14 @@ void Module::dumpDAG(llvm::StringRef dotFilename) {
 
 void Module::dumpDAG(const char *dotFilename) {
   dumpDAG(llvm::StringRef(dotFilename));
+}
+
+void Module::eraseFunctions() {
+  for (auto *F : functions_) {
+    delete F;
+  }
+
+  functions_.clear();
 }
 
 Function::~Function() {


### PR DESCRIPTION
This commit adds a unit test that checks that we can compile functions
without depending on the IR.  We compile some function and then delete
the function. Later we execute the code and check that things work.