### PR TITLE
Use tmp directory for unnamed dumpDAG

### DIFF
--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -22,6 +22,7 @@
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include <fstream>
@@ -243,10 +244,9 @@ public:
 
 // TODO: consider refactoring boilerplate code to new trait: DottyPrintable<ADP>
 void Module::dumpDAG() {
-  std::string buffer;
-  llvm::raw_string_ostream stream(buffer);
-  stream << "dotty_graph_dump_" << this << ".dot";
-  dumpDAG(stream.str().c_str());
+  llvm::SmallString<64> dotPath;
+  llvm::sys::fs::createTemporaryFile("dotty_graph_dump", "dot", dotPath);
+  dumpDAG(dotPath);
 }
 
 void Module::dumpDAG(llvm::StringRef dotFilename) {
@@ -1834,10 +1834,9 @@ public:
 };
 
 void Function::dumpDAG() {
-  std::string buffer;
-  llvm::raw_string_ostream stream(buffer);
-  stream << "dotty_graph_dump_" << this << ".dot";
-  dumpDAG(stream.str().c_str());
+  llvm::SmallString<64> dotPath;
+  llvm::sys::fs::createTemporaryFile("dotty_graph_dump", "dot", dotPath);
+  dumpDAG(dotPath);
 }
 
 void Function::dumpDAG(llvm::StringRef dotFilename) {

--- a/lib/IR/IR.cpp
+++ b/lib/IR/IR.cpp
@@ -21,6 +21,7 @@
 #include "glow/Support/Support.h"
 
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/raw_ostream.h"
 
 #include <fstream>
@@ -586,10 +587,9 @@ static const char *getDottyArrowForCC(OperandKind k) {
 }
 
 void IRFunction::dumpDAG() const {
-  std::string buffer;
-  llvm::raw_string_ostream stream(buffer);
-  stream << "dotty_ir_dump_" << this << ".dot";
-  dumpDAG(stream.str().c_str());
+  llvm::SmallString<64> dotPath;
+  llvm::sys::fs::createTemporaryFile("dotty_ir_dump", "dot", dotPath);
+  dumpDAG(dotPath);
 }
 
 /// Dump a dotty graph that depicts the function.


### PR DESCRIPTION
When running unit tests in-tree, these methods leave these temp files scattered about.  Might as well put them in /tmp by default.