### PR TITLE
Rename PoolAvg and PoolMax to AvgPool and MaxPool respectively

### DIFF
--- a/docs/ClassGen.md
+++ b/docs/ClassGen.md
@@ -27,7 +27,7 @@ builder (described in the builder Doxygen comments) construct the different
 kinds of fields that the Instruction has.
 
   ```
-  BB.newInstr("PoolAvg")
+  BB.newInstr("AvgPool")
       .addOperand("Dest", OperandKind::Out)
       .addOperand("Src", OperandKind::In)
       .addMember(MemberType::SizeT, "Kernel")

--- a/docs/Example.md
+++ b/docs/Example.md
@@ -28,11 +28,11 @@ Variable *A = mod.createVariable(
 // Construct LeNet.
 auto *CV0 = F->createConv("conv", A, 16, 5, 1, 2, 1);
 auto *RL0 = F->createRELU("relu", CV0);
-auto *MP0 = F->createPoolMax("pool", RL0, 3, 3, 0);
+auto *MP0 = F->createMaxPool("pool", RL0, 3, 3, 0);
 
 auto *CV1 = F->createConv("conv", MP0, 16, 5, 1, 2, 1);
 auto *RL1 = F->createRELU("relu", CV1);
-auto *MP1 = F->createPoolMax("pool", RL1, 3, 3, 0);
+auto *MP1 = F->createMaxPool("pool", RL1, 3, 3, 0);
 
 auto *FCL1 = F->createFullyConnected("fc", MP1, 10);
 
@@ -101,14 +101,14 @@ code {
   0 %conv__4.res = allocactivation  { Ty: float<8 x 28 x 28 x 16>} // size: 401408 // Users: @in 3, @out 4, @out 1
   1 %conv__4 = convolution @out %conv__4.res, @in %input__1, @in %filter__2, @in %bias__3 { Kernel: 5, Stride: 1, Pads: [2, 2, 2, 2], Depth: 16, Group: 1}
   2 %pool.res = allocactivation  { Ty: float<8 x 9 x 9 x 16>} // size: 41472 // Users: @in 7, @out 5, @out 3, @out 8, @in 5
-  3 %pool__149 = poolmax @out %pool.res, @in %conv__4.res { Kernel: 3, Stride: 3, Pads: [0, 0, 0, 0]}
+  3 %pool__149 = maxpool @out %pool.res, @in %conv__4.res { Kernel: 3, Stride: 3, Pads: [0, 0, 0, 0]}
   4 %dealloc = deallocactivation @out %conv__4.res // size: 401408
   5 %relu__160 = cpumaxsplat @out %pool.res, @in %pool.res { SplatValue: 0.000000e+00}
   6 %conv__9.res = allocactivation  { Ty: float<8 x 9 x 9 x 16>} // size: 41472 // Users: @in 10, @out 11, @out 7
   7 %conv__9 = convolution @out %conv__9.res, @in %pool.res, @in %filter__7, @in %bias__8 { Kernel: 5, Stride: 1, Pads: [2, 2, 2, 2], Depth: 16, Group: 1}
   8 %dealloc0 = deallocactivation @out %pool.res // size: 41472
   9 %pool.res0 = allocactivation  { Ty: float<8 x 3 x 3 x 16>} // size: 4608 // Users: @in 13, @out 12, @out 10, @out 16, @in 12
-  10 %pool__151 = poolmax @out %pool.res0, @in %conv__9.res { Kernel: 3, Stride: 3, Pads: [0, 0, 0, 0]}
+  10 %pool__151 = maxpool @out %pool.res0, @in %conv__9.res { Kernel: 3, Stride: 3, Pads: [0, 0, 0, 0]}
   11 %dealloc1 = deallocactivation @out %conv__9.res // size: 41472
   12 %relu__161 = cpumaxsplat @out %pool.res0, @in %pool.res0 { SplatValue: 0.000000e+00}
   13 %tensorview.reshape = tensorview @in %pool.res0 { Ty: float<8 x 144>} // Users: @in 15

--- a/docs/mnist.svg
+++ b/docs/mnist.svg
@@ -173,7 +173,7 @@
 <path fill="#fa8072" stroke="#000000" stroke-width="2" d="M419.5,-497.5C419.5,-497.5 575.8496,-497.5 575.8496,-497.5 581.8496,-497.5 587.8496,-503.5 587.8496,-509.5 587.8496,-509.5 587.8496,-649.5 587.8496,-649.5 587.8496,-655.5 581.8496,-661.5 575.8496,-661.5 575.8496,-661.5 419.5,-661.5 419.5,-661.5 413.5,-661.5 407.5,-655.5 407.5,-649.5 407.5,-649.5 407.5,-509.5 407.5,-509.5 407.5,-503.5 413.5,-497.5 419.5,-497.5"/>
 <text text-anchor="middle" x="497.2759" y="-646.3" font-family="Times,serif" font-size="14.00" fill="#000000">Input</text>
 <polyline fill="none" stroke="#000000" stroke-width="2" points="407.5,-639.5 587.8496,-639.5 "/>
-<text text-anchor="start" x="415.5" y="-624.3" font-family="Times,serif" font-size="14.00" fill="#000000">PoolMax</text>
+<text text-anchor="start" x="415.5" y="-624.3" font-family="Times,serif" font-size="14.00" fill="#000000">MaxPool</text>
 <text text-anchor="start" x="415.5" y="-610.3" font-family="Times,serif" font-size="14.00" fill="#000000">name : pool__11</text>
 <text text-anchor="start" x="415.5" y="-596.3" font-family="Times,serif" font-size="14.00" fill="#000000">Input : float&lt;8 x 9 x 9 x 16&gt;</text>
 <text text-anchor="start" x="415.5" y="-582.3" font-family="Times,serif" font-size="14.00" fill="#000000">Kernel : 3</text>
@@ -314,7 +314,7 @@
 <path fill="#fa8072" stroke="#000000" stroke-width="2" d="M211.6138,-1100.5C211.6138,-1100.5 375.7358,-1100.5 375.7358,-1100.5 381.7358,-1100.5 387.7358,-1106.5 387.7358,-1112.5 387.7358,-1112.5 387.7358,-1252.5 387.7358,-1252.5 387.7358,-1258.5 381.7358,-1264.5 375.7358,-1264.5 375.7358,-1264.5 211.6138,-1264.5 211.6138,-1264.5 205.6138,-1264.5 199.6138,-1258.5 199.6138,-1252.5 199.6138,-1252.5 199.6138,-1112.5 199.6138,-1112.5 199.6138,-1106.5 205.6138,-1100.5 211.6138,-1100.5"/>
 <text text-anchor="middle" x="293.3896" y="-1249.3" font-family="Times,serif" font-size="14.00" fill="#000000">Input</text>
 <polyline fill="none" stroke="#000000" stroke-width="2" points="199.6138,-1242.5 387.7358,-1242.5 "/>
-<text text-anchor="start" x="207.6138" y="-1227.3" font-family="Times,serif" font-size="14.00" fill="#000000">PoolMax</text>
+<text text-anchor="start" x="207.6138" y="-1227.3" font-family="Times,serif" font-size="14.00" fill="#000000">MaxPool</text>
 <text text-anchor="start" x="207.6138" y="-1213.3" font-family="Times,serif" font-size="14.00" fill="#000000">name : pool__6</text>
 <text text-anchor="start" x="207.6138" y="-1199.3" font-family="Times,serif" font-size="14.00" fill="#000000">Input : float&lt;8 x 28 x 28 x 16&gt;</text>
 <text text-anchor="start" x="207.6138" y="-1185.3" font-family="Times,serif" font-size="14.00" fill="#000000">Kernel : 3</text>

--- a/examples/cifar10.cpp
+++ b/examples/cifar10.cpp
@@ -113,15 +113,15 @@ void testCIFAR10() {
   // Create the rest of the network.
   auto *CV0 = F->createConv("conv", A, 16, 5, 1, 2, 1);
   auto *RL0 = F->createRELU("relu", CV0);
-  auto *MP0 = F->createPoolMax("pool", RL0, 2, 2, 0);
+  auto *MP0 = F->createMaxPool("pool", RL0, 2, 2, 0);
 
   auto *CV1 = F->createConv("conv", MP0, 20, 5, 1, 2, 1);
   auto *RL1 = F->createRELU("relu", CV1);
-  auto *MP1 = F->createPoolMax("pool", RL1, 2, 2, 0);
+  auto *MP1 = F->createMaxPool("pool", RL1, 2, 2, 0);
 
   auto *CV2 = F->createConv("conv", MP1, 20, 5, 1, 2, 1);
   auto *RL2 = F->createRELU("relu", CV2);
-  auto *MP2 = F->createPoolMax("pool", RL2, 2, 2, 0);
+  auto *MP2 = F->createMaxPool("pool", RL2, 2, 2, 0);
 
   auto *FCL1 = F->createFullyConnected("fc", MP2, 10);
   auto *SM = F->createSoftMax("softmax", FCL1, E);

--- a/examples/mnist.cpp
+++ b/examples/mnist.cpp
@@ -116,11 +116,11 @@ void testMNIST() {
 
   auto *CV0 = F->createConv("conv", A, 16, 5, 1, 2, 1);
   auto *RL0 = F->createRELU("relu", CV0);
-  auto *MP0 = F->createPoolMax("pool", RL0, 3, 3, 0);
+  auto *MP0 = F->createMaxPool("pool", RL0, 3, 3, 0);
 
   auto *CV1 = F->createConv("conv", MP0, 16, 5, 1, 2, 1);
   auto *RL1 = F->createRELU("relu", CV1);
-  auto *MP1 = F->createPoolMax("pool", RL1, 3, 3, 0);
+  auto *MP1 = F->createMaxPool("pool", RL1, 3, 3, 0);
 
   auto *FCL1 = F->createFullyConnected("fc", MP1, 10);
   Variable *selected =

--- a/include/glow/Backends/LayoutConverter.h
+++ b/include/glow/Backends/LayoutConverter.h
@@ -57,7 +57,7 @@ Node *convertPoolToNCHWPool(PoolNode *PN, Function *F) {
   auto *NPN =
       F->addNode(new NCHWPoolNode(PN->getName(), outTy, NI, PN->getKernel(),
                                   PN->getStride(), PN->getPads()));
-  auto NR = F->createTranspose("poolmax.result", NPN, NCHW2NHWC);
+  auto NR = F->createTranspose("maxpool.result", NPN, NCHW2NHWC);
 
   return NR;
 }

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -211,18 +211,18 @@ public:
                               size_t kernel, size_t stride, size_t pad,
                               size_t group);
 
-  PoolMaxNode *createPoolMax(llvm::StringRef name, NodeValue input,
+  MaxPoolNode *createMaxPool(llvm::StringRef name, NodeValue input,
                              size_t kernel, size_t stride,
                              llvm::ArrayRef<size_t> pads);
 
-  PoolMaxNode *createPoolMax(llvm::StringRef name, NodeValue input,
+  MaxPoolNode *createMaxPool(llvm::StringRef name, NodeValue input,
                              size_t kernel, size_t stride, size_t pad);
 
-  PoolAvgNode *createPoolAvg(llvm::StringRef name, NodeValue input,
+  AvgPoolNode *createAvgPool(llvm::StringRef name, NodeValue input,
                              size_t kernel, size_t stride,
                              llvm::ArrayRef<size_t> pads);
 
-  PoolAvgNode *createPoolAvg(llvm::StringRef name, NodeValue input,
+  AvgPoolNode *createAvgPool(llvm::StringRef name, NodeValue input,
                              size_t kernel, size_t stride, size_t pad);
 
   FullyConnectedNode *createFullyConnected(llvm::StringRef name,

--- a/include/glow/IR/IRBuilder.h
+++ b/include/glow/IR/IRBuilder.h
@@ -52,11 +52,11 @@ public:
   /// @name High-level, operation-level IRBuilder.
   ///@{
 
-  PoolMaxWithXYInst *createPoolMaxWithXYOp(Value *input, size_t kernel,
+  MaxPoolWithXYInst *createMaxPoolWithXYOp(Value *input, size_t kernel,
                                            size_t stride,
                                            llvm::ArrayRef<size_t> pads);
 
-  PoolAvgInst *createPoolAvgOp(Value *input, size_t kernel, size_t stride,
+  AvgPoolInst *createAvgPoolOp(Value *input, size_t kernel, size_t stride,
                                llvm::ArrayRef<size_t> pads);
 
   CrossEntropyLossInst *createCrossEntropyLossOp(Value *P, Value *labels);

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -156,8 +156,8 @@ bool CPUBackend::isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const {
     case Kinded::Kind::MaxNodeKind:
     case Kinded::Kind::MinNodeKind:
     case Kinded::Kind::MulNodeKind:
-    case Kinded::Kind::PoolAvgNodeKind:
-    case Kinded::Kind::PoolMaxNodeKind:
+    case Kinded::Kind::AvgPoolNodeKind:
+    case Kinded::Kind::MaxPoolNodeKind:
     case Kinded::Kind::QuantizeNodeKind:
     case Kinded::Kind::ReluNodeKind:
     case Kinded::Kind::RescaleQuantizedNodeKind:

--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -1606,8 +1606,8 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     break;
   }
 
-  case Kinded::Kind::PoolMaxInstKind: {
-    auto *PM = cast<PoolMaxInst>(I);
+  case Kinded::Kind::MaxPoolInstKind: {
+    auto *PM = cast<MaxPoolInst>(I);
     auto *dest = PM->getDest();
     auto *src = PM->getSrc();
     auto *destPtr = emitValueAddress(builder, dest);
@@ -1626,8 +1626,8 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     break;
   }
 
-  case Kinded::Kind::PoolMaxWithXYInstKind: {
-    auto *PMXY = cast<PoolMaxWithXYInst>(I);
+  case Kinded::Kind::MaxPoolWithXYInstKind: {
+    auto *PMXY = cast<MaxPoolWithXYInst>(I);
     auto *dest = PMXY->getDest();
     auto *src = PMXY->getSrc();
     auto *destPtr = emitValueAddress(builder, dest);
@@ -1648,8 +1648,8 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     break;
   }
 
-  case Kinded::Kind::PoolMaxWithXYGradInstKind: {
-    auto *PMG = cast<PoolMaxWithXYGradInst>(I);
+  case Kinded::Kind::MaxPoolWithXYGradInstKind: {
+    auto *PMG = cast<MaxPoolWithXYGradInst>(I);
     auto *srcGrad = PMG->getSrcGrad();
     auto *srcGradPtr = emitValueAddress(builder, srcGrad);
     auto *destGradPtr = emitValueAddress(builder, PMG->getDestGrad());
@@ -1664,8 +1664,8 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     break;
   }
 
-  case Kinded::Kind::PoolAvgInstKind: {
-    auto *PA = cast<PoolAvgInst>(I);
+  case Kinded::Kind::AvgPoolInstKind: {
+    auto *PA = cast<AvgPoolInst>(I);
     auto *dest = PA->getDest();
     auto *src = PA->getSrc();
     auto *destPtr = emitValueAddress(builder, dest);
@@ -1706,8 +1706,8 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     }
   }
 
-  case Kinded::Kind::PoolAvgGradInstKind: {
-    auto *PAG = cast<PoolAvgGradInst>(I);
+  case Kinded::Kind::AvgPoolGradInstKind: {
+    auto *PAG = cast<AvgPoolGradInst>(I);
     auto *srcGrad = PAG->getSrcGrad();
     auto *srcGradPtr = emitValueAddress(builder, srcGrad);
     auto *destGradPtr = emitValueAddress(builder, PAG->getDestGrad());

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -46,8 +46,8 @@ bool Interpreter::isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const {
     case Kinded::Kind::MaxNodeKind:
     case Kinded::Kind::MinNodeKind:
     case Kinded::Kind::MulNodeKind:
-    case Kinded::Kind::PoolAvgNodeKind:
-    case Kinded::Kind::PoolMaxNodeKind:
+    case Kinded::Kind::AvgPoolNodeKind:
+    case Kinded::Kind::MaxPoolNodeKind:
     case Kinded::Kind::QuantizeNodeKind:
     case Kinded::Kind::ReluNodeKind:
     case Kinded::Kind::RescaleQuantizedNodeKind:

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -285,7 +285,7 @@ void InterpreterFunction::fwdConvolutionGradInst(const ConvolutionGradInst *I) {
 //                       Pooling
 //===----------------------------------------------------------------------===//
 template <class T>
-static void fwdPoolMax(Tensor *inW, Tensor *outW, Handle<size_t> *SXY,
+static void fwdMaxPool(Tensor *inW, Tensor *outW, Handle<size_t> *SXY,
                        size_t filterSize, size_t stride,
                        llvm::ArrayRef<size_t> pads) {
   ShapeNHWC odim(outW->dims());
@@ -343,34 +343,34 @@ static void fwdPoolMax(Tensor *inW, Tensor *outW, Handle<size_t> *SXY,
   }       // N
 }
 
-void InterpreterFunction::fwdPoolMaxInst(const PoolMaxInst *I) {
+void InterpreterFunction::fwdMaxPoolInst(const MaxPoolInst *I) {
   auto inW = getTensor(I->getSrc());
   auto outW = getTensor(I->getDest());
 
   if (inW->getType().isQuantizedType()) {
-    fwdPoolMax<int8_t>(inW, outW, nullptr, I->getKernel(), I->getStride(),
+    fwdMaxPool<int8_t>(inW, outW, nullptr, I->getKernel(), I->getStride(),
                        I->getPads());
   } else {
-    fwdPoolMax<float>(inW, outW, nullptr, I->getKernel(), I->getStride(),
+    fwdMaxPool<float>(inW, outW, nullptr, I->getKernel(), I->getStride(),
                       I->getPads());
   }
 }
 
-void InterpreterFunction::fwdPoolMaxWithXYInst(const PoolMaxWithXYInst *I) {
+void InterpreterFunction::fwdMaxPoolWithXYInst(const MaxPoolWithXYInst *I) {
   auto inW = getTensor(I->getSrc());
   auto outW = getTensor(I->getDest());
   auto SXY = getTensor(I->getSrcXY())->getHandle<size_t>();
 
   if (inW->getType().isQuantizedType()) {
-    fwdPoolMax<int8_t>(inW, outW, &SXY, I->getKernel(), I->getStride(),
+    fwdMaxPool<int8_t>(inW, outW, &SXY, I->getKernel(), I->getStride(),
                        I->getPads());
   } else {
-    fwdPoolMax<float>(inW, outW, &SXY, I->getKernel(), I->getStride(),
+    fwdMaxPool<float>(inW, outW, &SXY, I->getKernel(), I->getStride(),
                       I->getPads());
   }
 }
 
-void InterpreterFunction::fwdPoolAvgInst(const PoolAvgInst *I) {
+void InterpreterFunction::fwdAvgPoolInst(const AvgPoolInst *I) {
   ShapeNHWC odim(I->getDest()->dims());
   ShapeNHWC idim(I->getSrc()->dims());
 
@@ -462,8 +462,8 @@ void InterpreterFunction::fwdPoolAvgInst(const PoolAvgInst *I) {
   }       // N
 }
 
-void InterpreterFunction::fwdPoolMaxWithXYGradInst(
-    const PoolMaxWithXYGradInst *I) {
+void InterpreterFunction::fwdMaxPoolWithXYGradInst(
+    const MaxPoolWithXYGradInst *I) {
   auto inG = getWeightHandle(I->getSrcGrad());
   auto outW = getWeightHandle(I->getDest());
   auto outG = getWeightHandle(I->getDestGrad());
@@ -496,7 +496,7 @@ void InterpreterFunction::fwdPoolMaxWithXYGradInst(
   }       // N
 }
 
-void InterpreterFunction::fwdPoolAvgGradInst(const PoolAvgGradInst *I) {
+void InterpreterFunction::fwdAvgPoolGradInst(const AvgPoolGradInst *I) {
   auto inG = getWeightHandle(I->getSrcGrad());
   auto outW = getWeightHandle(I->getDest());
   auto outG = getWeightHandle(I->getDestGrad());

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -959,7 +959,7 @@ void OpenCLFunction::execute() {
       continue;
     }
 
-    if (auto *PM = dyn_cast<PoolMaxInst>(&I)) {
+    if (auto *PM = dyn_cast<MaxPoolInst>(&I)) {
       // This is a naive implementation that parallelizes using three dims:
       // the X and the Y in the output filter.
       cl_kernel kernel = createKernel(kernelName);
@@ -981,7 +981,7 @@ void OpenCLFunction::execute() {
       continue;
     }
 
-    if (auto *PM = dyn_cast<PoolMaxWithXYInst>(&I)) {
+    if (auto *PM = dyn_cast<MaxPoolWithXYInst>(&I)) {
       // This is a naive implementation that parallelizes using three dims:
       // the X and the Y in the output filter.
       cl_kernel kernel = createKernel(kernelName);
@@ -1003,7 +1003,7 @@ void OpenCLFunction::execute() {
       continue;
     }
 
-    if (auto *PMG = dyn_cast<PoolMaxWithXYGradInst>(&I)) {
+    if (auto *PMG = dyn_cast<MaxPoolWithXYGradInst>(&I)) {
       cl_kernel kernel = createKernel(kernelName);
       setKernelArg(kernel, 0, deviceBuffer_);
       auto numArgs = setKernelArgsForBuffers(kernel, I, 1, tensors_);
@@ -1026,7 +1026,7 @@ void OpenCLFunction::execute() {
       continue;
     }
 
-    if (auto *PA = dyn_cast<PoolAvgInst>(&I)) {
+    if (auto *PA = dyn_cast<AvgPoolInst>(&I)) {
       // This is a naive implementation that parallelizes using three dims:
       // the X and the Y in the output filter.
       cl_kernel kernel = createKernel(kernelName);
@@ -1173,7 +1173,7 @@ void OpenCLFunction::execute() {
       continue;
     }
 
-    if (auto PA = dyn_cast<OCLPoolAvgInst>(&I)) {
+    if (auto PA = dyn_cast<OCLAvgPoolInst>(&I)) {
       cl_kernel kernel = createKernel(kernelName);
       setKernelArg(kernel, 0, deviceBuffer_);
       auto numArgs = setKernelArgsForBuffers(kernel, I, 1, tensors_);
@@ -1193,7 +1193,7 @@ void OpenCLFunction::execute() {
       continue;
     }
 
-    if (auto *PM = dyn_cast<OCLPoolMaxInst>(&I)) {
+    if (auto *PM = dyn_cast<OCLMaxPoolInst>(&I)) {
       cl_kernel kernel = createKernel(kernelName);
       setKernelArg(kernel, 0, deviceBuffer_);
       auto numArgs = setKernelArgsForBuffers(kernel, I, 1, tensors_);

--- a/lib/Backends/OpenCL/Transforms.cpp
+++ b/lib/Backends/OpenCL/Transforms.cpp
@@ -41,14 +41,14 @@ bool OCLBackend::transformPostLowering(Function *F,
       changed = true;
       continue;
     }
-    if (auto *PMN = dyn_cast<PoolMaxNode>(&node)) {
-      auto *NR = convertPoolToNCHWPool<PoolMaxNode, OCLPoolMaxNode>(PMN, F);
+    if (auto *PMN = dyn_cast<MaxPoolNode>(&node)) {
+      auto *NR = convertPoolToNCHWPool<MaxPoolNode, OCLMaxPoolNode>(PMN, F);
       NodeValue(&node, 0).replaceAllUsesOfWith(NR);
       changed = true;
       continue;
     }
-    if (auto *PAN = dyn_cast<PoolAvgNode>(&node)) {
-      auto *NR = convertPoolToNCHWPool<PoolAvgNode, OCLPoolAvgNode>(PAN, F);
+    if (auto *PAN = dyn_cast<AvgPoolNode>(&node)) {
+      auto *NR = convertPoolToNCHWPool<AvgPoolNode, OCLAvgPoolNode>(PAN, F);
       NodeValue(&node, 0).replaceAllUsesOfWith(NR);
       changed = true;
       continue;

--- a/lib/Backends/OpenCL/kernels.cl
+++ b/lib/Backends/OpenCL/kernels.cl
@@ -864,7 +864,7 @@ __kernel void convolutiongradW(__global void *mem,
                     filterSize, stride, pads, srcDim, destGradDim, filterGradDim);
 }
 
-__kernel void poolmaxK(__global float *dest, __global float *src,
+__kernel void maxpoolK(__global float *dest, __global float *src,
                        cl_uint32_t filterSize, cl_uint32_t stride,
                        PaddingTLBR pads, ShapeNHWC odim, ShapeNHWC idim) {
   size_t ax = get_global_id(0);
@@ -905,13 +905,13 @@ __kernel void poolmaxK(__global float *dest, __global float *src,
   } // N
 }
 
-__kernel void poolmaxW(__global void *mem, cl_uint32_t dest, cl_uint32_t src,
+__kernel void maxpoolW(__global void *mem, cl_uint32_t dest, cl_uint32_t src,
                        cl_uint32_t filterSize, cl_uint32_t stride,
                        PaddingTLBR pads, ShapeNHWC odim, ShapeNHWC idim) {
-  poolmaxK(&mem[dest], &mem[src], filterSize, stride, pads, odim, idim);
+  maxpoolK(&mem[dest], &mem[src], filterSize, stride, pads, odim, idim);
 }
 
-__kernel void oclpoolmaxK(__global float *dest, __global float *src,
+__kernel void oclmaxpoolK(__global float *dest, __global float *src,
                        cl_uint32_t filterSize, cl_uint32_t stride,
                        PaddingTLBR pads, ShapeNCHW odim, ShapeNCHW idim) {
   size_t ax = get_global_id(0);
@@ -952,13 +952,13 @@ __kernel void oclpoolmaxK(__global float *dest, __global float *src,
   } // N
 }
 
-__kernel void oclpoolmaxW(__global void *mem, cl_uint32_t dest, cl_uint32_t src,
+__kernel void oclmaxpoolW(__global void *mem, cl_uint32_t dest, cl_uint32_t src,
                        cl_uint32_t filterSize, cl_uint32_t stride,
                        PaddingTLBR pads, ShapeNCHW odim, ShapeNCHW idim) {
-  oclpoolmaxK(&mem[dest], &mem[src], filterSize, stride, pads, odim, idim);
+  oclmaxpoolK(&mem[dest], &mem[src], filterSize, stride, pads, odim, idim);
 }
 
-__kernel void poolmaxwithxyK(__global float *dest, __global float *src,
+__kernel void maxpoolwithxyK(__global float *dest, __global float *src,
                              __global cl_uint64_t *srcXY, cl_uint32_t filterSize,
                              cl_uint32_t stride, PaddingTLBR pads,
                              ShapeNHWC odim, ShapeNHWC idim) {
@@ -1008,16 +1008,16 @@ __kernel void poolmaxwithxyK(__global float *dest, __global float *src,
   } // N
 }
 
-__kernel void poolmaxwithxyW(__global void *mem, cl_uint32_t dest,
+__kernel void maxpoolwithxyW(__global void *mem, cl_uint32_t dest,
                              cl_uint32_t src, cl_uint32_t srcXY,
                              cl_uint32_t filterSize, cl_uint32_t stride,
                              PaddingTLBR pads, ShapeNHWC odim, ShapeNHWC idim) {
-  poolmaxwithxyK(&mem[dest], &mem[src], &mem[srcXY], filterSize, stride, pads,
+  maxpoolwithxyK(&mem[dest], &mem[src], &mem[srcXY], filterSize, stride, pads,
                  odim, idim);
 }
 
 __kernel void
-poolmaxwithxygradK(__global float *dest, __global cl_uint64_t *srcXY,
+maxpoolwithxygradK(__global float *dest, __global cl_uint64_t *srcXY,
                    __global float *destGrad, __global float *srcGrad,
                    cl_uint32_t filterSize, cl_uint32_t stride, PaddingTLBR pads,
                    ShapeNHWC srcGradDim, ShapeNHWC destGradDim) {
@@ -1047,16 +1047,16 @@ poolmaxwithxygradK(__global float *dest, __global cl_uint64_t *srcXY,
   }     // C
 }
 
-__kernel void poolmaxwithxygradW(__global void *mem, cl_uint32_t dest,
+__kernel void maxpoolwithxygradW(__global void *mem, cl_uint32_t dest,
                                  cl_uint32_t srcXY, cl_uint32_t destGrad,
                                  cl_uint32_t srcGrad, cl_uint32_t filterSize,
                                  cl_uint32_t stride, PaddingTLBR pads,
                                  ShapeNHWC srcGradDim, ShapeNHWC destDim) {
-  poolmaxwithxygradK(&mem[dest], &mem[srcXY], &mem[destGrad], &mem[srcGrad],
+  maxpoolwithxygradK(&mem[dest], &mem[srcXY], &mem[destGrad], &mem[srcGrad],
                      filterSize, stride, pads, srcGradDim, destDim);
 }
 
-__kernel void poolavgK(__global float *dest, __global float *src,
+__kernel void avgpoolK(__global float *dest, __global float *src,
                        cl_uint32_t filterSize, cl_uint32_t stride,
                        PaddingTLBR pads, ShapeNHWC odim, ShapeNHWC idim) {
   size_t ax = get_global_id(0);
@@ -1092,13 +1092,13 @@ __kernel void poolavgK(__global float *dest, __global float *src,
   } // N
 }
 
-__kernel void poolavgW(__global void *mem, cl_uint32_t dest, cl_uint32_t src,
+__kernel void avgpoolW(__global void *mem, cl_uint32_t dest, cl_uint32_t src,
                        cl_uint32_t filterSize, cl_uint32_t stride,
                        PaddingTLBR pads, ShapeNHWC odim, ShapeNHWC idim) {
-  poolavgK(&mem[dest], &mem[src], filterSize, stride, pads, odim, idim);
+  avgpoolK(&mem[dest], &mem[src], filterSize, stride, pads, odim, idim);
 }
 
-__kernel void oclpoolavgK(__global float *dest, __global float *src,
+__kernel void oclavgpoolK(__global float *dest, __global float *src,
                        cl_uint32_t filterSize, cl_uint32_t stride,
                        PaddingTLBR pads, ShapeNCHW odim, ShapeNCHW idim) {
   size_t ax = get_global_id(0);
@@ -1134,10 +1134,10 @@ __kernel void oclpoolavgK(__global float *dest, __global float *src,
   } // N
 }
 
-__kernel void oclpoolavgW(__global void *mem, cl_uint32_t dest, cl_uint32_t src,
+__kernel void oclavgpoolW(__global void *mem, cl_uint32_t dest, cl_uint32_t src,
                        cl_uint32_t filterSize, cl_uint32_t stride,
                        PaddingTLBR pads, ShapeNCHW odim, ShapeNCHW idim) {
-  oclpoolavgK(&mem[dest], &mem[src], filterSize, stride, pads, odim, idim);
+  oclavgpoolK(&mem[dest], &mem[src], filterSize, stride, pads, odim, idim);
 }
 
 /// Macro to define a kernel for transpose operations. The body of

--- a/lib/Graph/Grad.cpp
+++ b/lib/Graph/Grad.cpp
@@ -94,8 +94,8 @@ Function *glow::differentiate(Function *F, const TrainingConfig &conf,
   }
 
     CONVERT_TO_GRAD_NODE(ConvolutionNode)
-    CONVERT_TO_GRAD_NODE(PoolMaxNode)
-    CONVERT_TO_GRAD_NODE(PoolAvgNode)
+    CONVERT_TO_GRAD_NODE(MaxPoolNode)
+    CONVERT_TO_GRAD_NODE(AvgPoolNode)
     CONVERT_TO_GRAD_NODE(FullyConnectedNode)
     CONVERT_TO_GRAD_NODE(LocalResponseNormalizationNode)
     CONVERT_TO_GRAD_NODE(SoftMaxNode)

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -462,7 +462,7 @@ ConvolutionNode *Function::createConv(llvm::StringRef name, NodeValue input,
   return createConv(name, input, depth, kernel, stride, pads, group);
 }
 
-PoolMaxNode *Function::createPoolMax(llvm::StringRef name, NodeValue input,
+MaxPoolNode *Function::createMaxPool(llvm::StringRef name, NodeValue input,
                                      size_t kernel, size_t stride,
                                      llvm::ArrayRef<size_t> pads) {
   ShapeNHWC idim = ShapeNHWC(input.dims());
@@ -477,16 +477,16 @@ PoolMaxNode *Function::createPoolMax(llvm::StringRef name, NodeValue input,
   auto OT = getParent()->uniqueTypeWithNewShape(
       input.getType(), {idim.n, outSz.first, outSz.second, idim.c});
 
-  return addNode(new PoolMaxNode(name, OT, input, kernel, stride, pads));
+  return addNode(new MaxPoolNode(name, OT, input, kernel, stride, pads));
 }
 
-PoolMaxNode *Function::createPoolMax(llvm::StringRef name, NodeValue input,
+MaxPoolNode *Function::createMaxPool(llvm::StringRef name, NodeValue input,
                                      size_t kernel, size_t stride, size_t pad) {
   llvm::SmallVector<size_t, 4> pads = {pad, pad, pad, pad};
-  return createPoolMax(name, input, kernel, stride, pads);
+  return createMaxPool(name, input, kernel, stride, pads);
 }
 
-PoolAvgNode *Function::createPoolAvg(llvm::StringRef name, NodeValue input,
+AvgPoolNode *Function::createAvgPool(llvm::StringRef name, NodeValue input,
                                      size_t kernel, size_t stride,
                                      llvm::ArrayRef<size_t> pads) {
   ShapeNHWC idim = ShapeNHWC(input.dims());
@@ -501,13 +501,13 @@ PoolAvgNode *Function::createPoolAvg(llvm::StringRef name, NodeValue input,
   auto OT = getParent()->uniqueTypeWithNewShape(
       input.getType(), {idim.n, outSz.first, outSz.second, idim.c});
 
-  return addNode(new PoolAvgNode(name, OT, input, kernel, stride, pads));
+  return addNode(new AvgPoolNode(name, OT, input, kernel, stride, pads));
 }
 
-PoolAvgNode *Function::createPoolAvg(llvm::StringRef name, NodeValue input,
+AvgPoolNode *Function::createAvgPool(llvm::StringRef name, NodeValue input,
                                      size_t kernel, size_t stride, size_t pad) {
   llvm::SmallVector<size_t, 4> pads = {pad, pad, pad, pad};
-  return createPoolAvg(name, input, kernel, stride, pads);
+  return createAvgPool(name, input, kernel, stride, pads);
 }
 
 FullyConnectedNode *Function::createFullyConnected(llvm::StringRef name,

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -261,15 +261,15 @@ void ConvolutionGradNode::verify() const {
                     Kernel_, Stride_, Pads_, Group_);
 }
 
-void PoolMaxNode::verify() const {
+void MaxPoolNode::verify() const {
   verifyPool(getInput(), getResult(), Kernel_, Stride_, Pads_);
 }
 
-void PoolAvgNode::verify() const {
+void AvgPoolNode::verify() const {
   verifyPool(getInput(), getResult(), Kernel_, Stride_, Pads_);
 }
 
-void PoolMaxGradNode::verify() const {
+void MaxPoolGradNode::verify() const {
   verifyInputAndGradInputTypes(getInput(), getGradOfInputNamedInput());
   verifyOutputAndGradOutputTypes(getOriginalOutputForResult(),
                                  getGradOfOriginalOutputNamedResult());
@@ -277,7 +277,7 @@ void PoolMaxGradNode::verify() const {
              Kernel_, Stride_, Pads_);
 }
 
-void PoolAvgGradNode::verify() const {
+void AvgPoolGradNode::verify() const {
   verifyInputAndGradInputTypes(getInput(), getGradOfInputNamedInput());
   verifyOutputAndGradOutputTypes(getOriginalOutputForResult(),
                                  getGradOfOriginalOutputNamedResult());

--- a/lib/IR/IRBuilder.cpp
+++ b/lib/IR/IRBuilder.cpp
@@ -55,8 +55,8 @@ void IRBuilder::deallocateActiveInstrs() {
 //===----------------------------------------------------------------------===//
 //                        High level operators.
 //===----------------------------------------------------------------------===//
-PoolMaxWithXYInst *
-IRBuilder::createPoolMaxWithXYOp(Value *input, size_t kernel, size_t stride,
+MaxPoolWithXYInst *
+IRBuilder::createMaxPoolWithXYOp(Value *input, size_t kernel, size_t stride,
                                  llvm::ArrayRef<size_t> pads) {
   ShapeNHWC idim = ShapeNHWC(input->dims());
 
@@ -73,10 +73,10 @@ IRBuilder::createPoolMaxWithXYOp(Value *input, size_t kernel, size_t stride,
       input->getType(), {idim.n, outSz.first, outSz.second, idim.c});
   Value *dest = createAllocActivationInst("pool.res", outTy);
 
-  return createPoolMaxWithXYInst("pool", dest, input, srcXY, kernel, stride,
+  return createMaxPoolWithXYInst("pool", dest, input, srcXY, kernel, stride,
                                  pads);
 }
-PoolAvgInst *IRBuilder::createPoolAvgOp(Value *input, size_t kernel,
+AvgPoolInst *IRBuilder::createAvgPoolOp(Value *input, size_t kernel,
                                         size_t stride,
                                         llvm::ArrayRef<size_t> pads) {
   ShapeNHWC idim = ShapeNHWC(input->dims());
@@ -87,7 +87,7 @@ PoolAvgInst *IRBuilder::createPoolAvgOp(Value *input, size_t kernel,
       input->getType(), {idim.n, outSz.first, outSz.second, idim.c});
   Value *dest = createAllocActivationInst("pool.res", outTy);
 
-  return createPoolAvgInst("pool", dest, input, kernel, stride, pads);
+  return createAvgPoolInst("pool", dest, input, kernel, stride, pads);
 }
 
 CrossEntropyLossInst *IRBuilder::createCrossEntropyLossOp(Value *p,

--- a/lib/IR/IRGen.cpp
+++ b/lib/IR/IRGen.cpp
@@ -152,10 +152,10 @@ public:
       registerIR(CG->getGradOfInputNamedBias(), biasG);
       break;
     }
-    case glow::Kinded::Kind::PoolMaxNodeKind: {
-      auto *P = cast<PoolMaxNode>(N);
+    case glow::Kinded::Kind::MaxPoolNodeKind: {
+      auto *P = cast<MaxPoolNode>(N);
       auto *in = valueForNode(P->getInput());
-      auto *V = builder_.createPoolMaxWithXYOp(in, P->getKernel(),
+      auto *V = builder_.createMaxPoolWithXYOp(in, P->getKernel(),
                                                P->getStride(), P->getPads());
       Value *dest = V->getDest();
       nodeToInstr_[N] = V;
@@ -163,8 +163,8 @@ public:
       registerIR(N, dest);
       break;
     }
-    case glow::Kinded::Kind::PoolMaxGradNodeKind: {
-      auto *PG = cast<PoolMaxGradNode>(N);
+    case glow::Kinded::Kind::MaxPoolGradNodeKind: {
+      auto *PG = cast<MaxPoolGradNode>(N);
 
       auto poolOut = PG->getOriginalOutputForResult();
       auto *outW = valueForNode(poolOut);
@@ -176,16 +176,16 @@ public:
       // Find the original pool instruction.
       assert(nodeToInstr_.count(poolOut) &&
              "Pool IRgen did not register itself");
-      auto *PI = cast<PoolMaxWithXYInst>(nodeToInstr_[poolOut.getNode()]);
+      auto *PI = cast<MaxPoolWithXYInst>(nodeToInstr_[poolOut.getNode()]);
 
-      builder_.createPoolMaxWithXYGradInst(N->getName(), outW, PI->getSrcXY(),
+      builder_.createMaxPoolWithXYGradInst(N->getName(), outW, PI->getSrcXY(),
                                            outG, inG, PG->getKernel(),
                                            PG->getStride(), PG->getPads());
       registerIR(PG->getGradOfInputNamedInput(), inG);
       break;
     }
-    case glow::Kinded::Kind::PoolAvgGradNodeKind: {
-      auto *PG = cast<PoolAvgGradNode>(N);
+    case glow::Kinded::Kind::AvgPoolGradNodeKind: {
+      auto *PG = cast<AvgPoolGradNode>(N);
 
       auto poolOut = PG->getOriginalOutputForResult();
       auto *outW = valueForNode(poolOut);
@@ -194,7 +194,7 @@ public:
       auto *inG = builder_.createAllocActivationInst("pool.outG",
                                                      PG->getInput().getType());
 
-      builder_.createPoolAvgGradInst(N->getName(), outW, outG, inG,
+      builder_.createAvgPoolGradInst(N->getName(), outW, outG, inG,
                                      PG->getKernel(), PG->getStride(),
                                      PG->getPads());
       registerIR(PG->getGradOfInputNamedInput(), inG);

--- a/lib/Importer/Caffe2.cpp
+++ b/lib/Importer/Caffe2.cpp
@@ -214,9 +214,9 @@ void caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
 
     Node *node = nullptr;
     if (typeName == "MaxPool") {
-      node = G_.createPoolMax(opName, tr, kernel, stride, pads);
+      node = G_.createMaxPool(opName, tr, kernel, stride, pads);
     } else {
-      node = G_.createPoolAvg(opName, tr, kernel, stride, pads);
+      node = G_.createAvgPool(opName, tr, kernel, stride, pads);
     }
     auto *N = G_.createTranspose(opName, node, NHWC2NCHW);
     addNodeAsOutput(op, N);

--- a/lib/Importer/ONNX.cpp
+++ b/lib/Importer/ONNX.cpp
@@ -306,9 +306,9 @@ bool ONNXModelLoader::loadOperator(const onnx::NodeProto &op) {
 
     Node *node = nullptr;
     if (typeName == "MaxPool") {
-      node = G_.createPoolMax(opName, tr, kernel, stride, pads);
+      node = G_.createMaxPool(opName, tr, kernel, stride, pads);
     } else {
-      node = G_.createPoolAvg(opName, tr, kernel, stride, pads);
+      node = G_.createAvgPool(opName, tr, kernel, stride, pads);
     }
     auto *N = G_.createTranspose(opName, node, NHWC2NCHW);
     addNodeAsOutput(op, N);
@@ -327,7 +327,7 @@ bool ONNXModelLoader::loadOperator(const onnx::NodeProto &op) {
     size_t kernel = in->dims(0)[2];
     std::vector<size_t> pads = getPads(dict);
     auto *tr = G_.createTranspose(opName, in, NCHW2NHWC);
-    Node *node = G_.createPoolAvg(opName, tr, kernel, stride, pads);
+    Node *node = G_.createAvgPool(opName, tr, kernel, stride, pads);
     auto *N = G_.createTranspose(opName, node, NHWC2NCHW);
     addNodeAsOutput(op, N);
     return true;

--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -757,7 +757,7 @@ static void optimizePool(Function *F) {
     // nodes does not give us much. However, reordering the buffers allows us to
     // reuse the memory buffer of the pool operation and potentially save
     // memory.
-    if (auto *PL = dyn_cast<PoolMaxNode>(&node)) {
+    if (auto *PL = dyn_cast<MaxPoolNode>(&node)) {
       auto *RL = dyn_cast<ReluNode>(PL->getInput());
 
       if (!RL) {
@@ -772,7 +772,7 @@ static void optimizePool(Function *F) {
       }
 
       auto *NPL =
-          F->createPoolMax(PL->getName(), RL->getInput(), PL->getKernel(),
+          F->createMaxPool(PL->getName(), RL->getInput(), PL->getKernel(),
                            PL->getStride(), PL->getPads());
       auto *NRL = F->createRELU(RL->getName(), NPL);
       PL->getResult().replaceAllUsesOfWith(NRL);

--- a/lib/Optimizer/IROptimizer.cpp
+++ b/lib/Optimizer/IROptimizer.cpp
@@ -1500,8 +1500,8 @@ void performPeepholeOptimizations(IRFunction &M) {
     auto cur = it;
     auto *I = &*cur;
     it = std::next(it);
-    // PoolMaxWithXYInst -> PoolMaxInst.
-    if (auto *PMI = dyn_cast<PoolMaxWithXYInst>(I)) {
+    // MaxPoolWithXYInst -> MaxPoolInst.
+    if (auto *PMI = dyn_cast<MaxPoolWithXYInst>(I)) {
       auto *SrcXY = PMI->getSrcXY();
       // Optimize only if the cache is an allocation and
       // it has exactly 2 users: the current instruction and
@@ -1509,7 +1509,7 @@ void performPeepholeOptimizations(IRFunction &M) {
       if (!isa<AllocActivationInst>(SrcXY) || SrcXY->getNumUsers() != 2)
         continue;
 
-      auto *newI = B.createPoolMaxInst(PMI->getName(), PMI->getDest(),
+      auto *newI = B.createMaxPoolInst(PMI->getName(), PMI->getDest(),
                                        PMI->getSrc(), PMI->getKernel(),
                                        PMI->getStride(), PMI->getPads());
       it = M.moveInstruction(I, newI);

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -193,23 +193,23 @@ static Node *quantizeNode(Function *F, Node *node,
         F->createReshape(R->getName(), quantizedInputs[0], R->getDims());
     break;
   }
-  case Kinded::Kind::PoolMaxNodeKind: {
-    auto *P = cast<PoolMaxNode>(node);
+  case Kinded::Kind::MaxPoolNodeKind: {
+    auto *P = cast<MaxPoolNode>(node);
     assert(quantizedInputs.size() == 1 && "Invalid number of inputs");
     assert(qParams.size() == 1 && "Invalid number of quantized outputs");
 
     quantizedNode =
-        F->createPoolMax(node->getName(), quantizedInputs[0], P->getKernel(),
+        F->createMaxPool(node->getName(), quantizedInputs[0], P->getKernel(),
                          P->getStride(), P->getPads());
     break;
   }
-  case Kinded::Kind::PoolAvgNodeKind: {
-    auto *P = cast<PoolAvgNode>(node);
+  case Kinded::Kind::AvgPoolNodeKind: {
+    auto *P = cast<AvgPoolNode>(node);
     assert(quantizedInputs.size() == 1 && "Invalid number of inputs");
     assert(qParams.size() == 1 && "Invalid number of quantized outputs");
 
     quantizedNode =
-        F->createPoolAvg(node->getName(), quantizedInputs[0], P->getKernel(),
+        F->createAvgPool(node->getName(), quantizedInputs[0], P->getKernel(),
                          P->getStride(), P->getPads());
     break;
   }
@@ -334,8 +334,8 @@ static Node *
 postProcessQuantizedNode(Function *F, Node *quantizedNode,
                          llvm::ArrayRef<TensorQuantizationParams> qParams) {
   if (quantizedNode->getKind() == Kinded::Kind::ReluNodeKind ||
-      quantizedNode->getKind() == Kinded::Kind::PoolMaxNodeKind ||
-      quantizedNode->getKind() == Kinded::Kind::PoolAvgNodeKind ||
+      quantizedNode->getKind() == Kinded::Kind::MaxPoolNodeKind ||
+      quantizedNode->getKind() == Kinded::Kind::AvgPoolNodeKind ||
       quantizedNode->getKind() == Kinded::Kind::GatherNodeKind) {
     // These nodes do not change {S,O} of the output, they use the same
     // {S,O} as the input. Make sure that rescale is applied to comply with

--- a/tests/unittests/BackendCorrectnessTest.cpp
+++ b/tests/unittests/BackendCorrectnessTest.cpp
@@ -380,20 +380,20 @@ TEST_P(BackendCorrectnessTest, minTest) {
   EXPECT_TRUE(out1.isEqual(out2));
 }
 
-TEST_P(BackendCorrectnessTest, poolAvgTest) {
+TEST_P(BackendCorrectnessTest, AvgPoolTest) {
   PseudoRNG PRNG;
   Tensor inputs(ElemKind::FloatTy, {14, 12, 19, 7});
   inputs.getHandle().initXavier(1, PRNG);
   Tensor out1;
   Tensor out2;
 
-  inferPoolAvgNet(&inputs, &out1, backendKind_);
-  inferPoolAvgNet(&inputs, &out2, BackendKind::Interpreter);
+  inferAvgPoolNet(&inputs, &out1, backendKind_);
+  inferAvgPoolNet(&inputs, &out2, BackendKind::Interpreter);
 
   EXPECT_TRUE(out1.isEqual(out2));
 }
 
-TEST_P(CPUOnly, poolAvgGradTest) {
+TEST_P(CPUOnly, AvgPoolGradTest) {
   PseudoRNG PRNG;
   Tensor inputs(ElemKind::FloatTy, {5, 7, 6, 3});
   Tensor weights(ElemKind::FloatTy, {126, 72});
@@ -413,28 +413,28 @@ TEST_P(CPUOnly, poolAvgGradTest) {
   Tensor out1(ElemKind::FloatTy, shape2);
   Tensor out2(ElemKind::FloatTy, shape2);
 
-  trainPoolAvgNet(&inputs, &weights, &bias, &selected, shape1, shape2, &out1,
+  trainAvgPoolNet(&inputs, &weights, &bias, &selected, shape1, shape2, &out1,
                   backendKind_);
-  trainPoolAvgNet(&inputs, &weights, &bias, &selected, shape1, shape2, &out2,
+  trainAvgPoolNet(&inputs, &weights, &bias, &selected, shape1, shape2, &out2,
                   BackendKind::Interpreter);
 
   EXPECT_TRUE(out1.isEqual(out2));
 }
 
-TEST_P(BackendCorrectnessTest, poolMaxTest) {
+TEST_P(BackendCorrectnessTest, MaxPoolTest) {
   PseudoRNG PRNG;
   Tensor inputs(ElemKind::FloatTy, {5, 53, 71, 14});
   inputs.getHandle().initXavier(1, PRNG);
   Tensor out1;
   Tensor out2;
 
-  inferPoolMaxNet(&inputs, &out1, backendKind_);
-  inferPoolMaxNet(&inputs, &out2, BackendKind::Interpreter);
+  inferMaxPoolNet(&inputs, &out1, backendKind_);
+  inferMaxPoolNet(&inputs, &out2, BackendKind::Interpreter);
 
   EXPECT_TRUE(out1.isEqual(out2));
 }
 
-TEST_P(BackendCorrectnessTest, poolMaxGradTest) {
+TEST_P(BackendCorrectnessTest, MaxPoolGradTest) {
   PseudoRNG PRNG;
   Tensor inputs(ElemKind::FloatTy, {4, 8, 7, 2});
   Tensor weights(ElemKind::FloatTy, {112, 84});
@@ -454,9 +454,9 @@ TEST_P(BackendCorrectnessTest, poolMaxGradTest) {
   Tensor out1(ElemKind::FloatTy, shape2);
   Tensor out2(ElemKind::FloatTy, shape2);
 
-  trainPoolMaxNet(&inputs, &weights, &bias, &selected, shape1, shape2, &out1,
+  trainMaxPoolNet(&inputs, &weights, &bias, &selected, shape1, shape2, &out1,
                   backendKind_);
-  trainPoolMaxNet(&inputs, &weights, &bias, &selected, shape1, shape2, &out2,
+  trainMaxPoolNet(&inputs, &weights, &bias, &selected, shape1, shape2, &out2,
                   BackendKind::Interpreter);
 
   EXPECT_TRUE(out1.isEqual(out2));

--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -110,15 +110,15 @@ TEST_P(BackendTest, simpleInference) {
 
   auto *CV0 = F->createConv("conv1", input, 16, 5, 1, 2, 1);
   auto *RL0 = F->createRELU("relu1", CV0);
-  auto *MP0 = F->createPoolMax("pool1", RL0, 2, 2, 0);
+  auto *MP0 = F->createMaxPool("pool1", RL0, 2, 2, 0);
 
   auto *CV1 = F->createConv("conv2", MP0, 20, 5, 1, 2, 1);
   auto *RL1 = F->createRELU("relu2", CV1);
-  auto *MP1 = F->createPoolMax("pool2", RL1, 2, 2, 0);
+  auto *MP1 = F->createMaxPool("pool2", RL1, 2, 2, 0);
 
   auto *CV2 = F->createConv("conv3", MP1, 20, 5, 1, 2, 1);
   auto *RL2 = F->createRELU("relu3", CV2);
-  auto *MP2 = F->createPoolMax("pool3", RL2, 2, 2, 0);
+  auto *MP2 = F->createMaxPool("pool3", RL2, 2, 2, 0);
 
   auto *FCL1 = F->createFullyConnected("fc", MP2, 10);
   auto *RL3 = F->createRELU("relu4", FCL1);

--- a/tests/unittests/BackendTestUtils.cpp
+++ b/tests/unittests/BackendTestUtils.cpp
@@ -267,19 +267,19 @@ void inferMinNet(Tensor *inputs1, Tensor *inputs2, Tensor *out,
   out->copyFrom(&result->getVariable()->getPayload());
 }
 
-void inferPoolAvgNet(Tensor *inputs, Tensor *out, BackendKind kind) {
+void inferAvgPoolNet(Tensor *inputs, Tensor *out, BackendKind kind) {
   ExecutionEngine EE(kind);
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
   auto *var = VarFrom(inputs);
-  auto *pool = F->createPoolAvg("pool", var, 3, 3, 1);
+  auto *pool = F->createAvgPool("pool", var, 3, 3, 1);
   auto result = F->createSave("ret", pool);
   EE.compile(CompilationMode::Infer, F);
   EE.run({var}, {inputs});
   out->copyFrom(&result->getVariable()->getPayload());
 }
 
-void trainPoolAvgNet(Tensor *inputs, Tensor *weights, Tensor *bias,
+void trainAvgPoolNet(Tensor *inputs, Tensor *weights, Tensor *bias,
                      Tensor *selected, llvm::ArrayRef<size_t> shape1,
                      llvm::ArrayRef<size_t> shape2, Tensor *out,
                      BackendKind kind) {
@@ -297,7 +297,7 @@ void trainPoolAvgNet(Tensor *inputs, Tensor *weights, Tensor *bias,
   cast<Variable>(fc->getWeights())->copyFrom(weights);
   cast<Variable>(fc->getBias())->copyFrom(bias);
   auto *reshape1 = F->createReshape("reshape1", fc, shape1);
-  auto *pool = F->createPoolAvg("pool", reshape1, 2, 2, 0);
+  auto *pool = F->createAvgPool("pool", reshape1, 2, 2, 0);
   auto *reshape2 = F->createReshape("reshape2", pool, shape2);
   auto *softmax = F->createSoftMax("softmax", reshape2, var2);
   auto result = F->createSave("ret", softmax);
@@ -311,19 +311,19 @@ void trainPoolAvgNet(Tensor *inputs, Tensor *weights, Tensor *bias,
   out->copyFrom(&result->getVariable()->getPayload());
 }
 
-void inferPoolMaxNet(Tensor *inputs, Tensor *out, BackendKind kind) {
+void inferMaxPoolNet(Tensor *inputs, Tensor *out, BackendKind kind) {
   ExecutionEngine EE(kind);
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
   auto *var = VarFrom(inputs);
-  auto *pool = F->createPoolMax("pool", var, 4, 2, 3);
+  auto *pool = F->createMaxPool("pool", var, 4, 2, 3);
   auto result = F->createSave("ret", pool);
   EE.compile(CompilationMode::Infer, F);
   EE.run({var}, {inputs});
   out->copyFrom(&result->getVariable()->getPayload());
 }
 
-void trainPoolMaxNet(Tensor *inputs, Tensor *weights, Tensor *bias,
+void trainMaxPoolNet(Tensor *inputs, Tensor *weights, Tensor *bias,
                      Tensor *selected, llvm::ArrayRef<size_t> shape1,
                      llvm::ArrayRef<size_t> shape2, Tensor *out,
                      BackendKind kind) {
@@ -341,7 +341,7 @@ void trainPoolMaxNet(Tensor *inputs, Tensor *weights, Tensor *bias,
   cast<Variable>(fc->getWeights())->copyFrom(weights);
   cast<Variable>(fc->getBias())->copyFrom(bias);
   auto *reshape1 = F->createReshape("reshape1", fc, shape1);
-  auto *pool = F->createPoolMax("pool", reshape1, 5, 3, 4);
+  auto *pool = F->createMaxPool("pool", reshape1, 5, 3, 4);
   auto *reshape2 = F->createReshape("reshape2", pool, shape2);
   auto *softmax = F->createSoftMax("softmax", reshape2, var2);
   auto result = F->createSave("ret", softmax);
@@ -630,7 +630,7 @@ void inferBasicConvNet(Tensor *inputs, Tensor *out, BackendKind kind,
   auto *conv = F->createConv("conv", tr, convDepth, 5, 2, {1, 1, 1, 1}, 1);
   cast<Variable>(conv->getFilter())->getHandle().clear(2);
   cast<Variable>(conv->getBias())->getHandle().clear(2);
-  auto *pool = F->createPoolMax("pool", conv, 2, 2, 0);
+  auto *pool = F->createMaxPool("pool", conv, 2, 2, 0);
   auto result = F->createSave("ret", pool);
   EE.compile(CompilationMode::Infer, F);
   EE.run({var}, {inputs});
@@ -698,7 +698,7 @@ void inferComplexNet1(Tensor *inputs1, Tensor *inputs2, Tensor *inputs3,
   cast<Variable>(fc1->getWeights())->getHandle().clear(0.6);
   auto *reshape1 = F->createReshape("reshape1", fc1, {8, 14, 28, 6});
   auto *relu1 = F->createRELU("relu1", reshape1);
-  auto *pool1 = F->createPoolMax("pool1", relu1, 2, 2, 1);
+  auto *pool1 = F->createMaxPool("pool1", relu1, 2, 2, 1);
   auto *add = F->createAdd("add", sigmoid1, pool1);
   auto *tanh = F->createTanh("tanh", add);
   auto *fc2 = F->createFullyConnected("fc2", var3, 720);
@@ -712,7 +712,7 @@ void inferComplexNet1(Tensor *inputs1, Tensor *inputs2, Tensor *inputs3,
   auto *reshape3 = F->createReshape("reshape3", conv2, {8, 8, 7, 4});
   auto *sub = F->createSub("sub", reshape3, var4);
   auto *relu2 = F->createRELU("relu2", sub);
-  auto *pool2 = F->createPoolAvg("pool2", relu2, 3, 2, 1);
+  auto *pool2 = F->createAvgPool("pool2", relu2, 3, 2, 1);
   auto *sigmoid3 = F->createSigmoid("sigmoid3", pool2);
   auto result = F->createSave("ret", sigmoid3);
   EE.compile(CompilationMode::Infer, F);

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -67,16 +67,16 @@ void inferMaxNet(Tensor *inputs1, Tensor *inputs2, Tensor *out,
 void inferMinNet(Tensor *inputs1, Tensor *inputs2, Tensor *out,
                  BackendKind kind);
 
-void inferPoolAvgNet(Tensor *inputs, Tensor *out, BackendKind kind);
+void inferAvgPoolNet(Tensor *inputs, Tensor *out, BackendKind kind);
 
-void trainPoolAvgNet(Tensor *inputs, Tensor *weights, Tensor *bias,
+void trainAvgPoolNet(Tensor *inputs, Tensor *weights, Tensor *bias,
                      Tensor *selected, llvm::ArrayRef<size_t> shape1,
                      llvm::ArrayRef<size_t> shape2, Tensor *out,
                      BackendKind kind);
 
-void inferPoolMaxNet(Tensor *inputs, Tensor *out, BackendKind kind);
+void inferMaxPoolNet(Tensor *inputs, Tensor *out, BackendKind kind);
 
-void trainPoolMaxNet(Tensor *inputs, Tensor *weights, Tensor *bias,
+void trainMaxPoolNet(Tensor *inputs, Tensor *weights, Tensor *bias,
                      Tensor *selected, llvm::ArrayRef<size_t> shape1,
                      llvm::ArrayRef<size_t> shape2, Tensor *out,
                      BackendKind kind);

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -2309,7 +2309,7 @@ TEST_P(Operator, NonSquarePaddingAveragePool) {
   for (size_t i = 0; i < 4 * 4; i++) {
     IH.raw(i) = i + 1;
   }
-  auto *Pool = F_->createPoolAvg("pool", input, 2, 1, {0, 2, 1, 3});
+  auto *Pool = F_->createAvgPool("pool", input, 2, 1, {0, 2, 1, 3});
   auto *S = F_->createSave("save", Pool);
   EE_.compile(CompilationMode::Infer, F_);
   EE_.run({}, {});
@@ -2324,7 +2324,7 @@ TEST_P(Operator, NonSquarePaddingAveragePool) {
     }
 
   Function *refF = mod_.createFunction("mainRef");
-  Pool = refF->createPoolAvg("pool1", input1, 2, 1, 0);
+  Pool = refF->createAvgPool("pool1", input1, 2, 1, 0);
   S = refF->createSave("save1", Pool);
   EE_.compile(CompilationMode::Infer, refF);
   EE_.run({}, {});
@@ -2343,7 +2343,7 @@ TEST_P(Operator, NonSquarePaddingMaxPool) {
   for (size_t i = 0; i < 4 * 4; i++) {
     IH.raw(i) = i + 1;
   }
-  auto *Pool = F_->createPoolMax("pool", input, 2, 1, {0, 2, 1, 3});
+  auto *Pool = F_->createMaxPool("pool", input, 2, 1, {0, 2, 1, 3});
   auto *S = F_->createSave("save", Pool);
   EE_.compile(CompilationMode::Infer, F_);
   EE_.run({}, {});
@@ -2358,7 +2358,7 @@ TEST_P(Operator, NonSquarePaddingMaxPool) {
     }
 
   Function *refF = mod_.createFunction("mainRef");
-  Pool = refF->createPoolMax("pool1", input1, 2, 1, 0);
+  Pool = refF->createMaxPool("pool1", input1, 2, 1, 0);
   S = refF->createSave("save1", Pool);
   EE_.compile(CompilationMode::Infer, refF);
   EE_.run({}, {});

--- a/tests/unittests/basicIRTest.cpp
+++ b/tests/unittests/basicIRTest.cpp
@@ -131,7 +131,7 @@ TEST(IR, allInstrs) {
 
     builder.createCopyInst("", I1, I0);
     builder.createConvolutionInst("", I3, I1, F0, B0, 7, 2, {3, 3, 3, 3}, 1);
-    builder.createPoolMaxInst("", I4, I0, 7, 2, {3, 3, 3, 3});
+    builder.createMaxPoolInst("", I4, I0, 7, 2, {3, 3, 3, 3});
     builder.createSigmoidInst("", I1, I0);
     builder.createTanhInst("", I1, I0);
     builder.createSoftMaxInst("", I1, I0);
@@ -155,15 +155,15 @@ TEST(IR, casting) {
     auto *input = bb.createWeightVar(ElemKind::FloatTy, {1, 224, 224, 3});
     auto *res = bb.createAllocActivationInst("sigmoid.res", input->getType());
     auto *sig = bb.createSigmoidInst("sigmoid", res, input);
-    auto *pool = bb.createPoolAvgOp(sig->getDest(), 7, 2, {3, 3, 3, 3});
+    auto *pool = bb.createAvgPoolOp(sig->getDest(), 7, 2, {3, 3, 3, 3});
 
-    EXPECT_EQ(isa<PoolAvgInst>(pool), true);
-    EXPECT_EQ(isa<PoolAvgInst>(input), false);
+    EXPECT_EQ(isa<AvgPoolInst>(pool), true);
+    EXPECT_EQ(isa<AvgPoolInst>(input), false);
     EXPECT_EQ(isa<SigmoidInst>(sig), true);
     EXPECT_EQ(isa<SigmoidInst>(pool), false);
 
-    EXPECT_NE(dyn_cast<PoolAvgInst>(pool), nullptr);
-    EXPECT_EQ(dyn_cast<PoolAvgInst>(pool), pool);
+    EXPECT_NE(dyn_cast<AvgPoolInst>(pool), nullptr);
+    EXPECT_EQ(dyn_cast<AvgPoolInst>(pool), pool);
 
     EXPECT_NE(dyn_cast<WeightVar>(input), nullptr);
     EXPECT_EQ(dyn_cast<WeightVar>(input), input);

--- a/tests/unittests/gradCheckTest.cpp
+++ b/tests/unittests/gradCheckTest.cpp
@@ -183,7 +183,7 @@ static void gradientCheckGroupConv(size_t numInputChan, size_t group,
                                 VisibilityKind::Public, false);
 
   Node *O = F->createConv("conv", A, 4, 5, 1, 2, group);
-  O = F->createPoolMax("pool", O, 3, 3, 0);
+  O = F->createMaxPool("pool", O, 3, 3, 0);
   O = F->createFullyConnected("fc", O, numOutputElem);
   O = F->createRELU("relu", O);
   O = F->createRegression("reg", O, Ex);
@@ -220,7 +220,7 @@ TEST_P(InterpreterGrad, gradientCheckAvgPool) {
   auto *Exp = mod.createVariable(ElemKind::FloatTy, {1, numOutputElem}, "Exp",
                                  VisibilityKind::Public, false);
 
-  Node *O = F->createPoolAvg("pool", A, 3, 3, 1);
+  Node *O = F->createAvgPool("pool", A, 3, 3, 1);
   O = F->createTanh("tanh", O);
   O = F->createFullyConnected("fc", O, numOutputElem);
   O = F->createRegression("reg", O, Exp);

--- a/tests/unittests/graphGradTest.cpp
+++ b/tests/unittests/graphGradTest.cpp
@@ -46,11 +46,11 @@ TEST(GraphAutoGrad, autoGrad) {
 
   auto *CV0 = F->createConv("conv1", A, 16, 5, 1, 2, 1);
   auto *RL0 = F->createRELU("relu1", CV0);
-  auto *MP0 = F->createPoolMax("pool1", RL0, 3, 3, 0);
+  auto *MP0 = F->createMaxPool("pool1", RL0, 3, 3, 0);
 
   auto *CV1 = F->createConv("conv2", MP0, 16, 5, 1, 2, 1);
   auto *RL1 = F->createRELU("conv23", CV1);
-  auto *MP1 = F->createPoolMax("pool2", RL1, 3, 3, 0);
+  auto *MP1 = F->createMaxPool("pool2", RL1, 3, 3, 0);
 
   auto *FCL1 = F->createFullyConnected("fc3", MP1, 10);
   auto *RL2 = F->createRELU("relu3", FCL1);

--- a/tests/unittests/graphOptzTest.cpp
+++ b/tests/unittests/graphOptzTest.cpp
@@ -373,7 +373,7 @@ TEST_F(GraphOptz, poolBelowReluSwapped) {
   Node *A = mod_.createVariable(ElemKind::FloatTy, {1, 5, 10, 15}, "input",
                                 VisibilityKind::Public, false);
   Node *R = F_->createRELU("relu", A);
-  Node *PL = F_->createPoolMax("pool", R, 1, 10, 20);
+  Node *PL = F_->createMaxPool("pool", R, 1, 10, 20);
   Node *O = F_->createSave("ret", PL);
 
   EXPECT_EQ(F_->getNodes().size(), 3);
@@ -391,7 +391,7 @@ TEST_F(GraphOptz, poolBelowReluNotSwappedIfModeNotMax) {
   Node *A = mod_.createVariable(ElemKind::FloatTy, {1, 5, 10, 15}, "input",
                                 VisibilityKind::Public, false);
   Node *R = F_->createRELU("relu", A);
-  Node *PL = F_->createPoolAvg("pool", R, 1, 10, 20);
+  Node *PL = F_->createAvgPool("pool", R, 1, 10, 20);
   Node *O = F_->createSave("ret", PL);
 
   EXPECT_EQ(F_->getNodes().size(), 3);
@@ -400,7 +400,7 @@ TEST_F(GraphOptz, poolBelowReluNotSwappedIfModeNotMax) {
 
   // Expecting Pool->Output (no swap).
   EXPECT_TRUE(llvm::isa<SaveNode>(O));
-  EXPECT_TRUE(llvm::isa<PoolAvgNode>(llvm::dyn_cast<SaveNode>(O)->getInput()));
+  EXPECT_TRUE(llvm::isa<AvgPoolNode>(llvm::dyn_cast<SaveNode>(O)->getInput()));
 
   EXPECT_EQ(F_->getNodes().size(), 3);
 }
@@ -409,7 +409,7 @@ TEST_F(GraphOptz, poolBelowReluNotSwappedIfNotSingleUse) {
   Node *A = mod_.createVariable(ElemKind::FloatTy, {1, 5, 10, 15}, "input",
                                 VisibilityKind::Public, false);
   Node *R = F_->createRELU("relu", A);
-  Node *PL = F_->createPoolMax("pool", R, 1, 10, 20);
+  Node *PL = F_->createMaxPool("pool", R, 1, 10, 20);
   Node *O = F_->createSave("ret", PL);
   F_->createSave("ret", R);
 
@@ -419,7 +419,7 @@ TEST_F(GraphOptz, poolBelowReluNotSwappedIfNotSingleUse) {
 
   // Expecting Pool->Output (no swap).
   EXPECT_TRUE(llvm::isa<SaveNode>(O));
-  EXPECT_TRUE(llvm::isa<PoolMaxNode>(llvm::dyn_cast<SaveNode>(O)->getInput()));
+  EXPECT_TRUE(llvm::isa<MaxPoolNode>(llvm::dyn_cast<SaveNode>(O)->getInput()));
 
   EXPECT_EQ(F_->getNodes().size(), 4);
 }

--- a/tests/unittests/graphTest.cpp
+++ b/tests/unittests/graphTest.cpp
@@ -405,7 +405,7 @@ TEST(Graph, nodesWithPredicates) {
 
   auto *CV0 = F->createConv("conv1", input, 16, 5, 1, 2, 1);
   auto *RL0 = F->createRELU("relu1", CV0);
-  auto *MP0 = F->createPoolMax("pool1", RL0, 2, 2, 0);
+  auto *MP0 = F->createMaxPool("pool1", RL0, 2, 2, 0);
 
   CV0->setPredicate(pred);
   RL0->setPredicate(pred);

--- a/tests/unittests/quantizationTest.cpp
+++ b/tests/unittests/quantizationTest.cpp
@@ -158,12 +158,12 @@ static Function *createSimpleGraphForQuantization(Module *M, Variable *A,
   fillStableRandomData(filter->getPayload().getHandle(), 1000, 1);
 
   auto *RL = F->createRELU("relu", CV);
-  auto *MP = F->createPoolMax("maxPool", RL, 2, 2, 1);
+  auto *MP = F->createMaxPool("maxPool", RL, 2, 2, 1);
   // Just add noop transpose.
   auto *T = F->createTranspose("transpose", MP, {0, 1, 2, 3});
   // Noop reshape, make sure conversion quantization procedure works well.
   auto *R = F->createReshape("reshape", T, T->getResult().dims());
-  auto *AP = F->createPoolAvg("avgPool", R, 2, 2, 1);
+  auto *AP = F->createAvgPool("avgPool", R, 2, 2, 1);
 
   FullyConnectedNode *FC = F->createFullyConnected("fc", AP, 10);
 

--- a/tools/ClassGen/Backends/OpenCL/OpenCLSpecificInstrs.h
+++ b/tools/ClassGen/Backends/OpenCL/OpenCLSpecificInstrs.h
@@ -27,7 +27,7 @@ BB.newBackendSpecificInstr("OCLConvolution")
     .autoIRGen()
     .autoVerify(VerifyKind::SameElementType, {"Dest", "Src", "Filter", "Bias"});
 
-BB.newBackendSpecificInstr("OCLPoolAvg")
+BB.newBackendSpecificInstr("OCLAvgPool")
     .addOperand("Dest", OperandKind::Out)
     .addOperand("Src", OperandKind::In)
     .addMember(MemberType::SizeT, "Kernel")
@@ -37,7 +37,7 @@ BB.newBackendSpecificInstr("OCLPoolAvg")
     .autoVerify(VerifyKind::SameElementType, {"Dest", "Src"})
     .addGradientInstr({"Dest"}, {"Dest", "Src"});
 
-BB.newBackendSpecificInstr("OCLPoolMax")
+BB.newBackendSpecificInstr("OCLMaxPool")
     .addOperand("Dest", OperandKind::Out)
     .addOperand("Src", OperandKind::In)
     .addMember(MemberType::SizeT, "Kernel")

--- a/tools/ClassGen/Backends/OpenCL/OpenCLSpecificNodes.h
+++ b/tools/ClassGen/Backends/OpenCL/OpenCLSpecificNodes.h
@@ -28,7 +28,7 @@ BB.newNode("OCLConvolution")
         "This is an OpenCL-specific convolution implementation where the "
         "filter, the bias and the input are in the HCHW format");
 
-BB.newNode("OCLPoolAvg")
+BB.newNode("OCLAvgPool")
     .addInput("Input")
     .addMember(MemberType::SizeT, "Kernel")
     .addMember(MemberType::SizeT, "Stride")
@@ -39,7 +39,7 @@ BB.newNode("OCLPoolAvg")
         "provided Kernel, Stride, and Pads. The input and output are in NCHW "
         "format");
 
-BB.newNode("OCLPoolMax")
+BB.newNode("OCLMaxPool")
     .addInput("Input")
     .addMember(MemberType::SizeT, "Kernel")
     .addMember(MemberType::SizeT, "Stride")

--- a/tools/ClassGen/Backends/OpenCL/OpenCLSpecificNodesVerification.h
+++ b/tools/ClassGen/Backends/OpenCL/OpenCLSpecificNodesVerification.h
@@ -26,7 +26,7 @@ void OCLConvolutionNode::verify() const {
   assert(exp == odim && "Invalid output dimensions");
 }
 
-void OCLPoolAvgNode::verify() const {}
+void OCLAvgPoolNode::verify() const {}
 
-void OCLPoolMaxNode::verify() const {}
+void OCLMaxPoolNode::verify() const {}
 #endif // GLOW_WITH_OPENCL

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -90,9 +90,9 @@ int main(int argc, char **argv) {
                   {"Dest", "Src", "Filter", "Bias"})
       .addGradientInstr({"Src", "Filter"}, {"Dest", "Src", "Filter", "Bias"});
 
-  // PoolMax version caching XY coordinates to speedup gradient-based
+  // MaxPool version caching XY coordinates to speedup gradient-based
   // computations.
-  BB.newInstr("PoolMaxWithXY")
+  BB.newInstr("MaxPoolWithXY")
       .addOperand("Dest", OperandKind::Out)
       .addOperand("Src", OperandKind::In)
       .addOperand("SrcXY", OperandKind::Out)
@@ -102,7 +102,7 @@ int main(int argc, char **argv) {
       .autoVerify(VerifyKind::SameElementType, {"Dest", "Src"})
       .addGradientInstr({"Dest", "SrcXY"}, {"Dest", "Src"});
 
-  BB.newInstr("PoolMax")
+  BB.newInstr("MaxPool")
       .addOperand("Dest", OperandKind::Out)
       .addOperand("Src", OperandKind::In)
       .addMember(MemberType::SizeT, "Kernel")
@@ -110,7 +110,7 @@ int main(int argc, char **argv) {
       .addMember(MemberType::VectorSizeT, "Pads")
       .autoVerify(VerifyKind::SameElementType, {"Dest", "Src"});
 
-  BB.newInstr("PoolAvg")
+  BB.newInstr("AvgPool")
       .addOperand("Dest", OperandKind::Out)
       .addOperand("Src", OperandKind::In)
       .addMember(MemberType::SizeT, "Kernel")

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -70,7 +70,7 @@ int main(int argc, char **argv) {
                     "Bias tensors, as well as provided Kernel, Stride, Pads, "
                     "and Group.");
 
-  BB.newNode("PoolMax")
+  BB.newNode("MaxPool")
       .addInput("Input")
       .addMember(MemberType::SizeT, "Kernel")
       .addMember(MemberType::SizeT, "Stride")
@@ -80,7 +80,7 @@ int main(int argc, char **argv) {
       .setDocstring("Performs a Max Pool operation on the Input given provided "
                     "Kernel, Stride, and Pads.");
 
-  BB.newNode("PoolAvg")
+  BB.newNode("AvgPool")
       .addInput("Input")
       .addMember(MemberType::SizeT, "Kernel")
       .addMember(MemberType::SizeT, "Stride")


### PR DESCRIPTION
This PR addresses issue #1288. Renaming `PoolAvg` to `AvgPool` and `PoolMax` to `MaxPool`. 

Ran `ninja test` and all tests passed.  I also ran the  tests on top of @bertmaher's diffs in `fbcode` and they passed as well. Please let me know if I should run any other tests.


@artemrakhov  @bertmaher please review