### PR TITLE
[cpu] Fix CPUMaxSplat transformation

### DIFF
--- a/tests/unittests/BackendCorrectnessTest.cpp
+++ b/tests/unittests/BackendCorrectnessTest.cpp
@@ -770,6 +770,19 @@ TEST_P(BackendCorrectnessTest, tinyResnet) {
   EXPECT_TRUE(out1.isEqual(out2, 0.001));
 }
 
+// Test MaxSplat transformation in CPU backend.
+TEST_P(CPUOnly, maxSplatTest) {
+  PseudoRNG PRNG;
+  Tensor input(ElemKind::Int8QTy, {5, 5}, 0.001, -10);
+  input.getHandle<int8_t>().randomize(-128, 127, PRNG);
+  Tensor out1, out2;
+
+  inferMaxSplat(&input, &out1, backendKind_);
+  inferMaxSplat(&input, &out2, BackendKind::Interpreter);
+
+  EXPECT_TRUE(out1.isEqual(out2));
+}
+
 #ifdef GLOW_WITH_CPU
 INSTANTIATE_TEST_CASE_P(CPU, BackendCorrectnessTest,
                         ::testing::Values(BackendKind::CPU));

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -133,4 +133,6 @@ void inferTinyResnet(Tensor *input, Tensor *out, std::vector<Tensor> &weights,
 
 void inferExtract3D(Tensor *input, Tensor *out, BackendKind kind);
 
+void inferMaxSplat(Tensor *input, Tensor *out, BackendKind kind);
+
 } // namespace glow


### PR DESCRIPTION
Recently sinkRescaleQuantizeNode was extended for Min/Max nodes (https://github.com/pytorch/glow/commit/1e5fdff1c90ea22795641fea52a10c485a09c730). This broke CPUMaxSplat transformation, because now Max nodes can have different quantization scale or offset for input and output, which is not supported by CPUMaxSplat node.
This patch fixes this issue by pulling Rescale node out from Max node, before replacing it with CPUMaxSplat.