### PR TITLE
Add support for more operators to the model loader

### DIFF
--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -79,6 +79,23 @@ protected:
     addNodeAsOutput(op, shape);
   }
 
+  /// Loads Sqrt operator, given its protobuf representation and parsed args.
+  void loadSqrt(const OpType &op, ArgumentDictionaryTy &dict) {
+    const std::string &opName = loadOperatorName(op);
+    auto in = getNodeValueOrCreateVariableByName(op.input(0));
+    auto *R = G_.createPow(opName, in, 0.5f);
+    addNodeAsOutput(op, R);
+  }
+
+  /// Loads Reciprocal operator, given its protobuf representation and parsed
+  /// args.
+  void loadReciprocal(const OpType &op, ArgumentDictionaryTy &dict) {
+    const std::string &opName = loadOperatorName(op);
+    auto in = getNodeValueOrCreateVariableByName(op.input(0));
+    auto *R = G_.createPow(opName, in, -1.0f);
+    addNodeAsOutput(op, R);
+  }
+
   void loadSum(const OpType &op, ArgumentDictionaryTy &dict) {
     // TODO: support variadic arguments
     assert(op.input_size() == 2 && "Only Sum of 2 inputs is supported.");
@@ -352,6 +369,14 @@ protected:
     }
     if (typeName == "Shape") {
       loadShape(op, dict);
+      return true;
+    }
+    if (typeName == "Sqrt") {
+      loadSqrt(op, dict);
+      return true;
+    }
+    if (typeName == "Reciprocal") {
+      loadReciprocal(op, dict);
       return true;
     }
     if (typeName == "Sum") {

--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -152,6 +152,24 @@ protected:
     nodeValueByName_[op.output(0)] = NodeValue(N, 0);
   }
 
+  void loadMinMax(llvm::StringRef typeName, const OpType &op,
+                  ArgumentDictionaryTy &dict) {
+    const std::string &opName = loadOperatorName(op);
+    auto in0 = getNodeValueOrCreateVariableByName(op.input(0));
+    auto in1 = getNodeValueOrCreateVariableByName(op.input(1));
+
+    Node *node = nullptr;
+    if (typeName == "Min") {
+      node = G_.createMin(opName, in0, in1);
+    } else if (typeName == "Max") {
+      node = G_.createMax(opName, in0, in1);
+    } else {
+      llvm_unreachable("Invalid min or max operator");
+    }
+
+    addNodeAsOutput(op, node);
+  }
+
   void loadArithmetic(llvm::StringRef typeName, const OpType &op,
                       ArgumentDictionaryTy &dict) {
     const std::string &opName = loadOperatorName(op);
@@ -389,6 +407,10 @@ protected:
     }
     if (typeName == "LRN") {
       loadLRN(op, dict);
+      return true;
+    }
+    if (typeName == "Min" || typeName == "Max") {
+      loadMinMax(typeName, op, dict);
       return true;
     }
     if (typeName == "Mul" || typeName == "Add" || typeName == "Sub" ||


### PR DESCRIPTION
Using some ONNX models, we figured out that support for some operators were missing in the loader:
- sqrt
- reciprocal
- min
- max

The IR nodes already existed so only the loader has been extended.