### PR TITLE
Add cmake options to disable examples and/or tests build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ enable_testing()
 
 option(GLOW_WITH_CPU "Build the LLVM-based JIT CPU backend" ON)
 option(GLOW_WITH_OPENCL "Build the OpenCL backend" ON)
+option(GLOW_BUILD_EXAMPLES "Build the examples" ON)
+option(GLOW_BUILD_TESTS "Build the tests" ON)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CXX_STANDARD_REQUIRED ON)
@@ -77,19 +79,24 @@ if(NOT EXISTS "${GLOW_THIRDPARTY_DIR}/onnx")
   message(FATAL_ERROR "No onnx git submodule. Run: git submodule update --init --recursive")
 endif()
 
-add_subdirectory(tests/googletest/)
-
 add_subdirectory(lib)
-add_subdirectory(examples)
 add_subdirectory(tools)
-add_subdirectory(tests)
+
+if (GLOW_BUILD_EXAMPLES)
+  add_subdirectory(examples)
+endif()
+
+if (GLOW_BUILD_TESTS)
+  add_subdirectory(tests/googletest)
+  add_subdirectory(tests)
+
+  # Fetch the dependencies for all the tests.
+  get_property(GLOW_TEST_DEPENDS GLOBAL PROPERTY GLOW_TEST_DEPENDS)
+
+  add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND}
+                      DEPENDS ${GLOW_TEST_DEPENDS} USES_TERMINAL)
+endif()
 
 add_custom_target(dependency_graph
                   "${CMAKE_COMMAND}" "--graphviz=dependency_graph" .
                   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}")
-
-# Fetch the dependencies for all the tests.
-get_property(GLOW_TEST_DEPENDS GLOBAL PROPERTY GLOW_TEST_DEPENDS)
-
-add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND}
-                    DEPENDS ${GLOW_TEST_DEPENDS} USES_TERMINAL)


### PR DESCRIPTION
The link with LLVM consumes a substantial amount of resources (cpu time, memory), and I find very convenient to have an option to disable the build of tests and examples when developing.