### PR TITLE
Check the consistency between  image and declared ONNX input

### DIFF
--- a/include/glow/Importer/ONNX.h
+++ b/include/glow/Importer/ONNX.h
@@ -89,6 +89,13 @@ class ONNXModelLoader
   size_t opsetVersion_;
 
 public:
+  /// Checks that the inputs tensors are compatible with the inputs declared in
+  /// the ONNX model. The input tensors in \p tensors are stored with the names
+  /// in the list of names \p tensorNames.
+  void checkInputs(onnx::GraphProto &net,
+                   llvm::ArrayRef<const char *> tensorNames,
+                   llvm::ArrayRef<Tensor *> tensors);
+
   /// Loads the ONNX model that's represented by a model description file,
   /// serialized in \p modelDescFilename and populates the network into \p F.
   /// The tensors in \p tensors are stored with the names in the list of names


### PR DESCRIPTION
In the image classifier the input image shape is not checked with regard to the ONNX input declaration.

In case of input image shape mistake, the wrong image shape is propagated accross the model and some indirect errors are usually generated (for instance for a convolution operator inside the model). 

Since the ONNX model declares inputs, it is possible to check the input image shape before any shape propagation and generate an accurate error message. This is what does this PR.