### PR TITLE
Placeholder: add Placeholder as a new kind of input/output to the graph.

### DIFF
--- a/docs/IR.md
+++ b/docs/IR.md
@@ -263,3 +263,24 @@ usage.
 8. Low-level IR optimizations are performed.
 
 9. Backend-specific optimizations and code generation are performed.
+
+### Placeholders
+
+We are in the process of adding a new kind of variable: Placeholder. The
+motivation and plan for Placeholder variables are described in the issue #1334.
+
+The work on Placeholder variables is ongoing and the following tasks are still
+open:
+
+1. Teach the execution engine to bind tensors to the Placeholder nodes.
+
+2. Verify that dotty printing, dump() and debugging work well.
+
+3. Cleanup the APIs that are related to Variable and Placeholder and make them
+consistent.
+
+4. Change (some of) the unit tests to use the new Placeholder API.
+
+5. Make sure that our optimizations are correct when placeholder are used.
+
+

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -38,8 +38,8 @@ using NodesList = llvm::iplist<glow::Node>;
 using NodesPtrList = std::list<glow::Node *>;
 /// List of Functions.
 using FunctionList = std::list<Function *>;
-/// List of Variables.
 using VariablesList = std::list<Variable *>;
+using PlaceholderList = std::list<Placeholder *>;
 using UnsignedArrayRef = llvm::ArrayRef<size_t>;
 
 class Module final {
@@ -53,6 +53,8 @@ class Module final {
   llvm::StringSet<> uniqueVariableNames_{};
   /// A list of variables that the Module owns.
   VariablesList vars_;
+  /// A list of placeholder nodes that the Module owns.
+  PlaceholderList placeholders_;
   /// Deterministic PRNG used to initialize weights in this module.
   PseudoRNG PRNG_;
 
@@ -67,11 +69,10 @@ public:
                                     llvm::StringSet<> &stringTable);
 
   /// Inserts the variable \p V to the list of variables.
-  Variable *addVar(Variable *V) {
-    V->setName(uniqueName(V->getName(), uniqueVariableNames_));
-    vars_.push_back(V);
-    return V;
-  }
+  Variable *addVar(Variable *V);
+
+  /// Inserts the placeholder node \p ph to the list of variables.
+  Placeholder *addPlaceholder(Placeholder *ph);
 
   /// Return a pointer to a uniqued type \p T.
   TypeRef uniqueType(const Type &T);
@@ -117,8 +118,18 @@ public:
 
   const VariablesList &getVars() const { return vars_; }
 
+  /// \returns the list of placeholders that the Module owns.
+  PlaceholderList &getPlaceholders() { return placeholders_; }
+
+  const PlaceholderList &getPlaceholders() const { return placeholders_; }
+
   /// @name High-level Variable builders.
   ///@{
+
+  Placeholder *createPlaceholder(ElemKind T, llvm::ArrayRef<size_t> dims,
+                                 llvm::StringRef name);
+
+  Placeholder *createPlaceholder(TypeRef T, llvm::StringRef name);
 
   Variable *createVariable(TypeRef T, llvm::StringRef name,
                            VisibilityKind visibility = VisibilityKind::Private,

--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -34,6 +34,7 @@ class Storage : public Node {
 public:
   Storage(Kinded::Kind k, llvm::StringRef name) : Node(k, name) {}
 
+  /// \return the single output value of the node.
   NodeValue getOutput() { return getNthResult(0); }
 
   /// Declare the standard Node methods.

--- a/tests/unittests/graphTest.cpp
+++ b/tests/unittests/graphTest.cpp
@@ -886,3 +886,16 @@ TEST(Graph, PostOrderTest) {
   EXPECT_EQ(order[12], ret2->getOutput());
   EXPECT_EQ(order[13], ret2);
 }
+
+TEST(Graph, placeholder) {
+  Module MD;
+  Function *F = MD.createFunction("F");
+  IRFunction M(F);
+  Node *K = MD.createPlaceholder(ElemKind::FloatTy, {4, 320, 200, 3}, "input");
+  Node *S = MD.createPlaceholder(ElemKind::Int64ITy, {4, 1}, "select");
+
+  K = F->createFullyConnected("FC", K, 10); 
+  K = F->createRELU("Relu", K);
+  K = F->createSoftMax("SoftMax", K, S);
+  F->createSave("Save", K);
+}

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -37,7 +37,9 @@ int main(int argc, char **argv) {
   //                    Input/Output nodes
   //===--------------------------------------------------------------------===//
 
+  BB.declareNode("Storage");
   BB.declareNode("Variable");
+  BB.declareNode("Placeholder");
 
   BB.newNode("Save")
       .addInput("Input")


### PR DESCRIPTION
This PR is the first few steps in the implementation of the Placeholder node. The plan is discussed in #1334. Placeholder are unbound variables where the content of the tensor is provided by the execution engine or the AOT compiler at runtime. 

This PR introduces Storage as a superclass for Variable (bound) and Placeholder (unbound). This PR also adds a simple unit test that checks that we can create new Placeholder nodes. This PR does not implement any of the infrastructure that's required to do anything useful with Placeholder variables, such as loading content into them, deleting them, pretty dotty-printer, etc. 

Potentially controversial decisions:
1. Placeholder and Variable inherit from Storage.
2. The name Placeholder.
3. The API for getVar and getPlaceholder instead of getStorage. 

Next steps (not necessarily in any specific order):
1. Teach the execution engine to bind tensors to the Placeholder nodes.
2. Verify that dotty printing, dump() and debugging work well.
3. Cleanup the APIs that are related to Variable and Placeholder and make them consistent. 
4. Change (some of) the unit tests to use the new Placeholder API. 
5. Make sure that our optimizations are correct when placeholder are used.