### PR TITLE
[NodeGen] Describe how the new scale and offset are chosen for the rescale node

### DIFF
--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -459,8 +459,9 @@ int main(int argc, char **argv) {
   BB.newNode("RescaleQuantized")
       .addInput("Input")
       .addResultFromCtorArg()
-      .setDocstring("Rescale input quantized tensor to a new Scale and "
-                    "Offset.");
+      .setDocstring("Rescale the input quantized tensor to a new Scale and "
+                    "Offset. The new Scale and Offset are specified by the "
+                    "output type passed to the constructor");
 
   //===--------------------------------------------------------------------===//
   //                Nodes used by RNN


### PR DESCRIPTION
NFC.

Was not obvious from the definition of the node and in particular, I missed it was fixed at construction time and thought it was re-profiled while running the profile... Which doesn't make much sense but that would imply that someone thinks while reading the description :P.