### PR TITLE
[quantization]: Support div node for quantization

### DIFF
--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -226,10 +226,11 @@ static Node *quantizeNode(Function *F, Node *node,
     break;                                                                     \
   }
     CASE_QUANTIZE_NODE(Add);
-    CASE_QUANTIZE_NODE(Mul);
-    CASE_QUANTIZE_NODE(Sub);
+    CASE_QUANTIZE_NODE(Div);
     CASE_QUANTIZE_NODE(Max);
     CASE_QUANTIZE_NODE(Min);
+    CASE_QUANTIZE_NODE(Mul);
+    CASE_QUANTIZE_NODE(Sub);
 #undef CASE_QUANTIZE_NODE
 
   case Kinded::Kind::ConcatNodeKind: {


### PR DESCRIPTION
Don't know why Div node was not supported for quantization when given the profiling scale and offset.  But some network do need support for div node.