### PR TITLE
Support IndexTy for Div and Gather

### DIFF
--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -1170,10 +1170,11 @@ void LLVMIRGen::generateLLVMIRForDataParallelInstr(
                                          loopCount, "buffer.element.addr");
       builder.CreateStore(stackedOpCall, destAddr);
     } else {
+      auto *elementTy = getElementType(builder, dest);
       auto *stackedOpCall =
           createCall(builder, F, {loopCount, lhsPtr, rhsPtr, pointerNull});
-      auto *destAddr = builder.CreateGEP(builder.getFloatTy(), destPtr,
-                                         loopCount, "buffer.element.addr");
+      auto *destAddr = builder.CreateGEP(elementTy, destPtr, loopCount,
+                                         "buffer.element.addr");
       builder.CreateStore(stackedOpCall, destAddr);
     }
     break;

--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -646,6 +646,8 @@ DEFINE_DATA_PARALLEL_KERNEL(libjit_element_sub_kernel_f, float,
                             LHS[idx] - RHS[idx])
 DEFINE_DATA_PARALLEL_KERNEL(libjit_element_div_kernel_f, float,
                             LHS[idx] / RHS[idx])
+DEFINE_DATA_PARALLEL_KERNEL(libjit_element_div_kernel_u, size_t,
+                            LHS[idx] / RHS[idx])
 DEFINE_DATA_PARALLEL_KERNEL(libjit_element_mul_kernel_f, float,
                             LHS[idx] * RHS[idx])
 DEFINE_DATA_PARALLEL_KERNEL(libjit_element_log_kernel_f, float, log(LHS[idx]))

--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -841,6 +841,13 @@ void libjit_gather_i8(int8_t *dest, const int8_t *data, const size_t *indices,
                 sampleSize);
 }
 
+void libjit_gather_u(size_t *dest, const size_t *data, const size_t *indices,
+                     size_t numIndices, size_t sliceSize, size_t numSamples,
+                     size_t sampleSize) {
+  libjit_gather(dest, data, indices, numIndices, sliceSize, numSamples,
+                sampleSize);
+}
+
 void libjit_scatterassign_f(float *data, const size_t *indices,
                             const float *slices, size_t numIndices,
                             size_t sliceSize) {


### PR DESCRIPTION
More seq2seq support, to get running on the Interpreter and CPU backends. Note that gather for the interpreter was already supported, as its implementation works for any type.