### PR TITLE
[ProtobufLoader] Set vars created from protos to default untrainable

### DIFF
--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -79,7 +79,7 @@ protected:
     tensors_[opName] = T;
     T->template getHandle<size_t>() = in.dims();
 
-    createAndRememberVariable(opName, *T, VisibilityKind::Private, false);
+    createAndRememberVariable(opName, *T);
   }
 
   /// Loads Sqrt operator, given its protobuf representation and parsed args.

--- a/include/glow/Importer/ProtobufLoader.h
+++ b/include/glow/Importer/ProtobufLoader.h
@@ -109,8 +109,7 @@ protected:
   /// \pre !hasNodeByName(name)
   Variable *createAndRememberVariable(
       llvm::StringRef name, const Tensor &tensor,
-      VisibilityKind visibilityKind = VisibilityKind::Private,
-      bool trainable = true);
+      VisibilityKind visibilityKind = VisibilityKind::Private);
 
   /// \returns the NodeValue that was registered with the name \p name or
   /// a nullptr wrapped in a NodeValue if no node has been registered with this

--- a/lib/Importer/ProtobufLoader.cpp
+++ b/lib/Importer/ProtobufLoader.cpp
@@ -61,11 +61,12 @@ NodeValue ProtobufLoader::getNodeValueByName(llvm::StringRef name) const {
 }
 
 Variable *ProtobufLoader::createAndRememberVariable(
-    llvm::StringRef name, const Tensor &tensor, VisibilityKind visibilityKind,
-    bool trainable) {
+    llvm::StringRef name, const Tensor &tensor, VisibilityKind visibilityKind) {
   assert(!hasNodeByName(name) && "Creating an already existing node?!");
-  Variable *node =
-      G_.getParent()->createVariable(name, tensor, visibilityKind, trainable);
+  // Note: We do not support training from models loaded from protos, so
+  // trainable is always set to false here.
+  Variable *node = G_.getParent()->createVariable(name, tensor, visibilityKind,
+                                                  /* trainable */ false);
   nodeValueByName_[name] = NodeValue(node, 0);
 
   return node;
@@ -106,7 +107,7 @@ ProtobufLoader::ProtobufLoader(llvm::ArrayRef<const char *> tensorNames,
   for (unsigned i = 0; i < tensorNames.size(); i++) {
     assert(!hasNodeByName(tensorNames[i]) && "Input names have duplicate");
     createAndRememberVariable(tensorNames[i], *tensors[i],
-                              VisibilityKind::Public, false);
+                              VisibilityKind::Public);
   }
 }
 


### PR DESCRIPTION
Variables loaded from protos should not be trainable by default. This improves constant deduplication.