### PR TITLE
[onnxifi] Adding more functionality to the onnxifi prototype.

### DIFF
--- a/include/glow/Importer/ONNX.h
+++ b/include/glow/Importer/ONNX.h
@@ -42,20 +42,12 @@ class ONNXModelLoader
   /// Set ir verion and op version.
   void setVersion(onnx::ModelProto MP);
 
-  /// Load the network operators from the GraphProto.
-  /// \returns true if network can be loaded.
-  bool loadNetwork(onnx::GraphProto &net);
-
   /// Set the output nodes of the network \p net. Initializes the map from the
   /// names of the outputs to the save nodes that save each output.
   void setOutputNodes(onnx::GraphProto &net);
 
   /// Load the network initializers from the GraphProto.
   void loadInitializers(onnx::GraphProto &net);
-
-  /// Load the inputs from the GraphProto. This is useful when the
-  /// initializers are not available.
-  void loadInputs(onnx::GraphProto &net);
 
   /// \returns true if operator \p op can be loaded.
   /// Load the operator \p op into the network. This creates one or more nodes
@@ -67,26 +59,31 @@ class ONNXModelLoader
   /// Loads GraphProto \p net from the file containing serialized protobuf.
   bool loadProto(onnx::GraphProto &net, const std::string &filename);
 
-  /// \returns true if \p net can be constructed from the in-memory
-  /// serialized protobuf.
-  /// Loads GraphProto \p net from the in-memory serialized protobuf \p
-  /// onnxModel with the model size \p onnxModelSize.
-  bool loadProto(onnx::GraphProto &net, const void *onnxModel,
-                 size_t onnxModelSize);
-
   /// \returns true if GraphProto \p net can be loaded from the stream \p
   /// iStream.
   bool loadProto(onnx::GraphProto &net,
                  google::protobuf::io::ZeroCopyInputStream &iStream);
-
-  /// Creates a ONNX model loader to build \p F.
-  ONNXModelLoader(Function &F);
 
   /// ONNX model ir_version;
   size_t irVersion_;
 
   /// ONNX model op_version;
   size_t opsetVersion_;
+
+protected:
+  /// Creates a ONNX model loader to build \p F.
+  ONNXModelLoader(Function &F);
+
+  /// Load the network operators from the GraphProto.
+  /// \returns true if network can be loaded.
+  bool loadNetwork(onnx::GraphProto &net);
+
+  /// \returns true if \p net can be constructed from the in-memory
+  /// serialized protobuf.
+  /// Loads GraphProto \p net from the in-memory serialized protobuf \p
+  /// onnxModel with the model size \p onnxModelSize.
+  bool loadProto(onnx::GraphProto &net, const void *onnxModel,
+                 size_t onnxModelSize);
 
 public:
   /// Loads the ONNX model that's represented by a model description file,
@@ -96,12 +93,6 @@ public:
   ONNXModelLoader(const std::string &modelDescFilename,
                   llvm::ArrayRef<const char *> tensorNames,
                   llvm::ArrayRef<Tensor *> tensors, Function &F);
-
-  /// \returns unique pointer to ONNXModelLoader if \p onnxModel can be parsed,
-  /// e.g., the model is a valid ONNX model and Glow supports all of the
-  /// operators in the network. \returns nullptr otherwise.
-  static std::unique_ptr<ONNXModelLoader>
-  parse(const void *onnxModel, size_t onnxModelSize, Function &F);
 };
 
 } // namespace glow

--- a/include/glow/Importer/ONNXIFILoader.h
+++ b/include/glow/Importer/ONNXIFILoader.h
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef GLOW_IMPORTER_ONNXIFILOADER_H
+#define GLOW_IMPORTER_ONNXIFILOADER_H
+
+#include "onnx/onnxifi.h"
+
+#include "glow/Importer/ONNX.h"
+
+namespace glow {
+namespace onnxifi {
+
+class ModelLoader : public ONNXModelLoader {
+private:
+  ModelLoader(Function &F) : ONNXModelLoader(F) {}
+
+  /// Load the inputs from the GraphProto. This is useful when the
+  /// initializers are not available.
+  void loadInputs(onnx::GraphProto &net);
+
+  /// Load pre-trained weights from \p weightDescriptors.
+  bool loadWeights(uint32_t weightsCount,
+                   const onnxTensorDescriptorV1 *weightDescriptors);
+
+public:
+  /// \returns unique pointer to ModelLoader if \p onnxModel can be parsed
+  /// and static weights can be loaded from the \p wightDescriptors.
+  /// \returns nullptr otherwise.
+  static std::unique_ptr<ModelLoader>
+  parse(const void *onnxModel, uint32_t onnxModelSize, uint32_t weightsCount,
+        const onnxTensorDescriptorV1 *weightDescriptors, Function &F);
+
+  /// \returns unique pointer to ModelLoader if \p onnxModel can be parsed,
+  /// e.g., the model is a valid ONNX model and Glow supports all of the
+  /// operators in the network. \returns nullptr otherwise.
+  static std::unique_ptr<ModelLoader> parse(const void *onnxModel,
+                                            size_t onnxModelSize, Function &F);
+};
+
+} // namespace onnxifi
+} // namespace glow
+
+#endif // GLOW_IMPORTER_ONNXIFILOADER_H

--- a/lib/Importer/CMakeLists.txt
+++ b/lib/Importer/CMakeLists.txt
@@ -2,6 +2,7 @@ find_package(Protobuf REQUIRED)
 
 include_directories(${PROTOBUF_INCLUDE_DIRS})
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
+include_directories(${GLOW_THIRDPARTY_DIR}/onnx)
 
 add_definitions(-DGOOGLE_PROTOBUF_NO_RTTI)
 
@@ -34,6 +35,7 @@ add_library(Importer
               ProtobufLoader.cpp
               Caffe2.cpp
               ONNX.cpp
+              ONNXIFILoader.cpp 
               ${CAFFE_SRCS}
               ${GLOW_BINARY_DIR}/glow/caffe.pb.h
               ${ONNX_SRCS}

--- a/lib/Importer/ONNXIFILoader.cpp
+++ b/lib/Importer/ONNXIFILoader.cpp
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/Importer/ONNXIFILoader.h"
+
+#include "onnx.pb.h"
+
+namespace glow {
+namespace onnxifi {
+
+/// Creates tensor \p T from the input \p in. Note, there is no data associated
+/// with the Tensor. This method makes sure that the tensor is created with the
+/// proper shape and element type.
+static void setTensorType(const onnx::TypeProto &in, Tensor *T) {
+  std::vector<size_t> dim;
+  for (auto d : in.tensor_type().shape().dim()) {
+    dim.push_back(d.dim_value());
+  }
+
+  if (in.tensor_type().elem_type() == onnx::TensorProto::FLOAT) {
+    T->reset(ElemKind::FloatTy, dim);
+  } else if (in.tensor_type().elem_type() == onnx::TensorProto::INT64) {
+    // TODO: either switch IndexTy to be 64 bit, or switch to another type here.
+    T->reset(ElemKind::IndexTy, dim);
+  } else {
+    assert(false && "Only float and index tensors are supported");
+  }
+}
+
+void ModelLoader::loadInputs(onnx::GraphProto &net) {
+  for (const auto &in : net.input()) {
+    Tensor *T = new Tensor();
+    setTensorType(in.type(), T);
+    tensors_[in.name()] = T;
+  }
+}
+
+/// Loads tensor \p T from the input \p in.
+static bool loadWeight(const onnxTensorDescriptorV1 &in, Tensor *T) {
+  // Only support CPU memory tensors.
+  if (in.memoryType != ONNXIFI_MEMORY_TYPE_CPU) {
+    return false;
+  }
+
+  std::vector<size_t> dims;
+  for (unsigned i = 0; i < in.dimensions; ++i) {
+    dims.push_back(in.shape[i]);
+  }
+
+  if (in.dataType == ONNXIFI_DATATYPE_FLOAT32) {
+    T->reset(ElemKind::FloatTy, dims);
+
+    auto TH = T->getHandle<>();
+    float *data = (float *)in.buffer;
+    for (size_t i = 0; i < TH.size(); ++i) {
+      TH.raw(i) = data[i];
+    }
+  } else if (in.dataType == ONNXIFI_DATATYPE_UINT64) {
+    // TODO: either switch IndexTy to be 64 bit, or switch to another type here.
+    T->reset(ElemKind::IndexTy, dims);
+
+    auto TH = T->getHandle<size_t>();
+    int64_t *data = (int64_t *)in.buffer;
+    for (size_t i = 0; i < TH.size(); ++i) {
+      TH.raw(i) = data[i];
+    }
+  } else {
+    llvm_unreachable("Only float and index tensors are supported");
+  }
+
+  return false;
+}
+
+bool ModelLoader::loadWeights(uint32_t weightsCount,
+                              const onnxTensorDescriptorV1 *weightDescriptors) {
+  for (uint32_t i = 0; i < weightsCount; ++i) {
+    Tensor *T = new Tensor();
+
+    if (!loadWeight(weightDescriptors[i], T)) {
+      return false;
+    }
+
+    tensors_[weightDescriptors[i].name] = T;
+  }
+
+  return true;
+}
+
+std::unique_ptr<ModelLoader> ModelLoader::parse(
+    const void *onnxModel, uint32_t onnxModelSize, uint32_t weightsCount,
+    const onnxTensorDescriptorV1 *weightDescriptors, Function &F) {
+  std::unique_ptr<ModelLoader> loader(new ModelLoader(F));
+
+  onnx::GraphProto modelDef;
+  if (!loader->loadProto(modelDef, onnxModel, onnxModelSize)) {
+    return nullptr;
+  }
+
+  if (!loader->loadWeights(weightsCount, weightDescriptors)) {
+    return nullptr;
+  }
+  loader->loadInputs(modelDef);
+
+  if (!loader->loadNetwork(modelDef)) {
+    return nullptr;
+  }
+
+  return loader;
+}
+
+std::unique_ptr<ModelLoader>
+ModelLoader::parse(const void *onnxModel, size_t onnxModelSize, Function &F) {
+  std::unique_ptr<ModelLoader> loader(new ModelLoader(F));
+
+  onnx::GraphProto modelDef;
+  if (!loader->loadProto(modelDef, onnxModel, onnxModelSize)) {
+    return nullptr;
+  }
+
+  loader->loadInputs(modelDef);
+  if (!loader->loadNetwork(modelDef)) {
+    return nullptr;
+  }
+
+  return loader;
+}
+
+} // namespace onnxifi
+} // namespace glow

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -15,8 +15,15 @@
  */
 #include "Base.h"
 
+#include "glow/Importer/ONNXIFILoader.h"
+
 namespace glow {
 namespace onnxifi {
+
+bool BackendId::isOpSupported(const Node &node) {
+  // TODO: add support for node with multiple outputs.
+  return executionEngine_.isOpSupported(node.getKind(), node.getElementType(0));
+}
 
 bool Event::signal() {
   {
@@ -38,6 +45,16 @@ void Event::wait() {
 onnxStatus Graph::initGraph(const void *onnxModel, size_t onnxModelSize,
                             uint32_t weightCount,
                             const onnxTensorDescriptorV1 *weightDescriptors) {
+  // TODO: support multiple functions here.
+  function_ = backendPtr_->getEE().getModule().createFunction("inference");
+
+  std::unique_ptr<ModelLoader> loader = ModelLoader::parse(
+      onnxModel, onnxModelSize, weightCount, weightDescriptors, *function_);
+  // TODO: make better error reporting.
+  if (!loader) {
+    return ONNXIFI_STATUS_INTERNAL_ERROR;
+  }
+
   return ONNXIFI_STATUS_SUCCESS;
 }
 

--- a/lib/Onnxifi/Base.h
+++ b/lib/Onnxifi/Base.h
@@ -31,8 +31,16 @@ class BackendId {
 public:
   explicit BackendId(int id) : id_(id) {}
 
+  /// Verify that given operation is supported by the backend.
+  bool isOpSupported(const glow::Node &node);
+
+  /// \returns Execution Engine associated with the Backend.
+  glow::ExecutionEngine &getEE() { return executionEngine_; }
+
 private:
   int id_;
+  // By default use the Interpreter backend.
+  glow::ExecutionEngine executionEngine_{glow::BackendKind::Interpreter};
 };
 
 typedef BackendId *BackendIdPtr;
@@ -40,6 +48,9 @@ typedef BackendId *BackendIdPtr;
 class Backend {
 public:
   explicit Backend(BackendIdPtr backendId) : backendIdPtr_(backendId) {}
+
+  /// \returns Execution Engine associated with the Backend.
+  glow::ExecutionEngine &getEE() { return backendIdPtr_->getEE(); }
 
 private:
   BackendIdPtr backendIdPtr_;
@@ -67,6 +78,8 @@ class Graph {
 public:
   explicit Graph(BackendPtr backendPtr) : backendPtr_(backendPtr) {}
 
+  BackendPtr backend() { return backendPtr_; }
+
   /// InitGraph.
   onnxStatus initGraph(const void *onnxModel, size_t onnxModelSize,
                        uint32_t weightCount,
@@ -81,6 +94,7 @@ public:
 
 private:
   BackendPtr backendPtr_;
+  Function *function_;
 };
 
 typedef Graph *GraphPtr;


### PR DESCRIPTION
* Support init Graph and add more mock functions to support end2end onnxifi run;
* Move onnxifi model loading logic to a separate class.

Note, I was running through the toy example which does processing of conv node (has a dependency on C2). Integration test for this code (C2 independent) is being worked on onnx side (once it's done, I'll integrate it here).

cc: @Maratyszcza @yinghai 