### PR TITLE
[opencl]: Support several nodes for int8 operation

### DIFF
--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -180,9 +180,11 @@ public:
     if (elementTy == ElemKind::Int8QTy) {
       switch (opKind) {
       case Kinded::Kind::AddNodeKind:
+      case Kinded::Kind::ConcatNodeKind:
       case Kinded::Kind::ConvolutionNodeKind:
       case Kinded::Kind::DequantizeNodeKind:
       case Kinded::Kind::DivNodeKind:
+      case Kinded::Kind::FullyConnectedNodeKind:
       case Kinded::Kind::MaxNodeKind:
       case Kinded::Kind::MinNodeKind:
       case Kinded::Kind::MulNodeKind:
@@ -191,6 +193,8 @@ public:
       case Kinded::Kind::QuantizeNodeKind:
       case Kinded::Kind::ReluNodeKind:
       case Kinded::Kind::RescaleQuantizedNodeKind:
+      case Kinded::Kind::ReshapeNodeKind:
+      case Kinded::Kind::SliceNodeKind:
       case Kinded::Kind::SplatNodeKind:
       case Kinded::Kind::SubNodeKind:
       case Kinded::Kind::TransposeNodeKind:


### PR DESCRIPTION
Support several nodes for int8 operation:
-- FullyConnectedNode (lowered to matmul and batchedAdd)
-- ConcatNode (lowered to inserttensor)
-- ReshapeNode (lowered to copyinst)
-- SliceNode (lowered to extracttensor)