### PR TITLE
[graphOptimizer]: SinkCode again before the end of optimization

### DIFF
--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -1794,6 +1794,11 @@ void glow::optimize(Function *F, CompilationMode mode) {
     optimizeQuantization(F);
   }
 
+  while (sinkCode(F)) {
+    // Perform Dead Code Elimination between rounds of code sinking.
+    DCE(F);
+  }
+
   // Perform Dead Code Elimination.
   DCE(F);
 }


### PR DESCRIPTION
By profiling the squeezenet and vgg, i found that we get the pattern that"one transpose right after another transpose" during the optimizations, after sinkNode has finished. Which means some other optimization (after sinkNode) rewrites the graph or removes something so that suddenly we have transpose(transpose). 

I propose to sink code again before the end of optimization, and it did remove the extra transpose.