### PR TITLE
[quantization]: Quantize splat node

### DIFF
--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -255,6 +255,16 @@ static Node *quantizeNode(Function *F, Node *node,
         F->createConcat(node->getName(), quantizedInputs, C->getDim(), outTy);
     break;
   }
+  case Kinded::Kind::SplatNodeKind: {
+    auto *SPN = cast<SplatNode>(node);
+    assert(quantizedInputs.size() == 0 && "Invalid number of inputs");
+    assert(qParams.size() == 1 && "Invalid number of quantized outputs");
+    auto outTy =
+        F->getParent()->uniqueType(ElemKind::Int8QTy, SPN->getResult().dims(),
+                                   qParams[0].scale, qParams[0].offset);
+    quantizedNode = F->createSplat(node->getName(), outTy, SPN->getValue());
+    break;
+  }
   case Kinded::Kind::GatherNodeKind: {
     auto *gather = cast<GatherNode>(node);
     // Gather node has 2 inputs, but only one should be quantized.

--- a/tests/unittests/quantizationTest.cpp
+++ b/tests/unittests/quantizationTest.cpp
@@ -183,7 +183,9 @@ static Function *createSimpleGraphForQuantization(Module *M, Variable *A,
   fillStableRandomData(bias2->getPayload().getHandle(), 3001, 1);
   fillStableRandomData(filter2->getPayload().getHandle(), 4000, 1);
 
-  auto *O = F->createConcat("concat", {S, B}, 0);
+  auto *CN = F->createConcat("concat", {S, B}, 0);
+  auto *SP = F->createSplat("splat", B->getType(), 10.0);
+  auto *O = F->createConcat("concat", {CN, SP}, 0);
   F->createSave("save", O);
   return F;
 }


### PR DESCRIPTION
Quantize splat node in Quantization.cpp:quantizeNode()
As i talked with @rdzhabarov, this support is anyhow needed if the original graph has splat node, and we have to quantize it based on profiling information