### PR TITLE
[ONNXIFI] Use CMakefile in onnx to build onnx library

### DIFF
--- a/include/glow/Importer/ONNX.h
+++ b/include/glow/Importer/ONNX.h
@@ -24,44 +24,44 @@
 
 #include <string>
 
-namespace onnx {
+namespace ONNX_NAMESPACE {
 class AttributeProto;
 class NodeProto;
 class GraphProto;
 class ModelProto;
-} // namespace onnx
+} // namespace ONNX_NAMESPACE
 
 namespace glow {
 
 /// Loads ONNX models.
 class ONNXModelLoader
-    : public CommonOperatorLoader<onnx::NodeProto, onnx::AttributeProto> {
+    : public CommonOperatorLoader<ONNX_NAMESPACE::NodeProto, ONNX_NAMESPACE::AttributeProto> {
   /// Get the broadcast attribute based on different ONNX op versions.
   bool getBroadcast(const ArgumentDictionaryTy &dict) override;
 
   /// Set ir verion and op version.
-  void setVersion(onnx::ModelProto MP);
+  void setVersion(ONNX_NAMESPACE::ModelProto MP);
 
   /// Set the output nodes of the network \p net. Initializes the map from the
   /// names of the outputs to the save nodes that save each output.
-  void setOutputNodes(onnx::GraphProto &net);
+  void setOutputNodes(ONNX_NAMESPACE::GraphProto &net);
 
   /// Load the network initializers from the GraphProto.
-  void loadInitializers(onnx::GraphProto &net);
+  void loadInitializers(ONNX_NAMESPACE::GraphProto &net);
 
   /// \returns true if operator \p op can be loaded.
   /// Load the operator \p op into the network. This creates one or more nodes
   /// in the network.
-  bool loadOperator(const onnx::NodeProto &op);
+  bool loadOperator(const ONNX_NAMESPACE::NodeProto &op);
 
   /// \returns true if \p net can be constructed from the content of the
   /// file \p filename.
   /// Loads GraphProto \p net from the file containing serialized protobuf.
-  bool loadProto(onnx::GraphProto &net, const std::string &filename);
+  bool loadProto(ONNX_NAMESPACE::GraphProto &net, const std::string &filename);
 
   /// \returns true if GraphProto \p net can be loaded from the stream \p
   /// iStream.
-  bool loadProto(onnx::GraphProto &net,
+  bool loadProto(ONNX_NAMESPACE::GraphProto &net,
                  google::protobuf::io::ZeroCopyInputStream &iStream);
 
   /// ONNX model ir_version;
@@ -76,13 +76,13 @@ protected:
 
   /// Load the network operators from the GraphProto.
   /// \returns true if network can be loaded.
-  bool loadNetwork(onnx::GraphProto &net);
+  bool loadNetwork(ONNX_NAMESPACE::GraphProto &net);
 
   /// \returns true if \p net can be constructed from the in-memory
   /// serialized protobuf.
   /// Loads GraphProto \p net from the in-memory serialized protobuf \p
   /// onnxModel with the model size \p onnxModelSize.
-  bool loadProto(onnx::GraphProto &net, const void *onnxModel,
+  bool loadProto(ONNX_NAMESPACE::GraphProto &net, const void *onnxModel,
                  size_t onnxModelSize);
 
 public:

--- a/include/glow/Importer/ONNXIFILoader.h
+++ b/include/glow/Importer/ONNXIFILoader.h
@@ -30,7 +30,7 @@ private:
 
   /// Load the inputs from the GraphProto. This is useful when the
   /// initializers are not available.
-  void loadInputs(onnx::GraphProto &net);
+  void loadInputs(ONNX_NAMESPACE::GraphProto &net);
 
   /// Load pre-trained weights from \p weightDescriptors.
   bool loadWeights(uint32_t weightsCount,

--- a/lib/Importer/CMakeLists.txt
+++ b/lib/Importer/CMakeLists.txt
@@ -1,15 +1,19 @@
-find_package(Protobuf REQUIRED)
-
 include_directories(${PROTOBUF_INCLUDE_DIRS})
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
-include_directories(${GLOW_THIRDPARTY_DIR}/onnx)
 
 add_definitions(-DGOOGLE_PROTOBUF_NO_RTTI)
 
+if(NOT TARGET onnx_proto)
+  # Note: This avoids libprotobuf.so complaining about name collisions at runtime
+  if(NOT ONNX_NAMESPACE)
+    set(ONNX_NAMESPACE "glow_onnx")
+  endif()
+  add_definitions("-DONNX_NAMESPACE=${ONNX_NAMESPACE}")
+  add_subdirectory(${GLOW_THIRDPARTY_DIR}/onnx EXCLUDE_FROM_ALL build)
+endif()
+
+find_package(Protobuf REQUIRED)
 PROTOBUF_GENERATE_CPP(CAFFE_SRCS CAFFE_HDRS caffe.proto)
-PROTOBUF_GENERATE_CPP(ONNX_SRCS
-                      ONNX_HDRS
-                      ${GLOW_THIRDPARTY_DIR}/onnx/onnx/onnx.proto)
 
 # NB: We need to copy the *.pb.h files to appropriately-prefixed paths to
 # placate FB's internal build system.  That is, we need:
@@ -26,20 +30,14 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CAFFE_HDRS} ${GLOW_BINARY_DIR}/glow/caffe.pb.h
   DEPENDS ${CAFFE_HDRS})
 
-add_custom_command(
-  OUTPUT ${GLOW_BINARY_DIR}/onnx/onnx.pb.h
-  COMMAND ${CMAKE_COMMAND} -E copy_if_different ${ONNX_HDRS} ${GLOW_BINARY_DIR}/onnx/onnx.pb.h
-  DEPENDS ${ONNX_HDRS})
-
 add_library(Importer
               ProtobufLoader.cpp
               Caffe2.cpp
               ONNX.cpp
               ONNXIFILoader.cpp 
               ${CAFFE_SRCS}
-              ${GLOW_BINARY_DIR}/glow/caffe.pb.h
-              ${ONNX_SRCS}
-              ${GLOW_BINARY_DIR}/onnx/onnx.pb.h)
+              ${GLOW_BINARY_DIR}/glow/caffe.pb.h)
+target_include_directories(Importer PUBLIC ${ONNX_INCLUDE_DIRS})
 target_compile_definitions(Importer
                            INTERFACE
                              -DGOOGLE_PROTOBUF_NO_RTTI)
@@ -47,5 +45,6 @@ target_link_libraries(Importer
                       PRIVATE
                         Base
                         Graph
-                        Support
-                        ${PROTOBUF_LIBRARY})
+                        Support)
+target_link_libraries(Importer PUBLIC onnx_proto ${PROTOBUF_LIBRARY})
+

--- a/lib/Importer/ONNXIFILoader.cpp
+++ b/lib/Importer/ONNXIFILoader.cpp
@@ -16,7 +16,7 @@
 
 #include "glow/Importer/ONNXIFILoader.h"
 
-#include "onnx.pb.h"
+#include "onnx/onnx.pb.h"
 
 namespace glow {
 namespace onnxifi {
@@ -24,15 +24,15 @@ namespace onnxifi {
 /// Creates tensor \p T from the input \p in. Note, there is no data associated
 /// with the Tensor. This method makes sure that the tensor is created with the
 /// proper shape and element type.
-static void setTensorType(const onnx::TypeProto &in, Tensor *T) {
+static void setTensorType(const ONNX_NAMESPACE::TypeProto &in, Tensor *T) {
   std::vector<size_t> dim;
   for (auto d : in.tensor_type().shape().dim()) {
     dim.push_back(d.dim_value());
   }
 
-  if (in.tensor_type().elem_type() == onnx::TensorProto::FLOAT) {
+  if (in.tensor_type().elem_type() == ONNX_NAMESPACE::TensorProto::FLOAT) {
     T->reset(ElemKind::FloatTy, dim);
-  } else if (in.tensor_type().elem_type() == onnx::TensorProto::INT64) {
+  } else if (in.tensor_type().elem_type() == ONNX_NAMESPACE::TensorProto::INT64) {
     // TODO: either switch IndexTy to be 64 bit, or switch to another type here.
     T->reset(ElemKind::IndexTy, dim);
   } else {
@@ -40,7 +40,7 @@ static void setTensorType(const onnx::TypeProto &in, Tensor *T) {
   }
 }
 
-void ModelLoader::loadInputs(onnx::GraphProto &net) {
+void ModelLoader::loadInputs(ONNX_NAMESPACE::GraphProto &net) {
   for (const auto &in : net.input()) {
     Tensor *T = new Tensor();
     setTensorType(in.type(), T);
@@ -104,7 +104,7 @@ std::unique_ptr<ModelLoader> ModelLoader::parse(
     const onnxTensorDescriptorV1 *weightDescriptors, Function &F) {
   std::unique_ptr<ModelLoader> loader(new ModelLoader(F));
 
-  onnx::GraphProto modelDef;
+  ONNX_NAMESPACE::GraphProto modelDef;
   if (!loader->loadProto(modelDef, onnxModel, onnxModelSize)) {
     return nullptr;
   }
@@ -125,7 +125,7 @@ std::unique_ptr<ModelLoader>
 ModelLoader::parse(const void *onnxModel, size_t onnxModelSize, Function &F) {
   std::unique_ptr<ModelLoader> loader(new ModelLoader(F));
 
-  onnx::GraphProto modelDef;
+  ONNX_NAMESPACE::GraphProto modelDef;
   if (!loader->loadProto(modelDef, onnxModel, onnxModelSize)) {
     return nullptr;
   }

--- a/lib/Onnxifi/CMakeLists.txt
+++ b/lib/Onnxifi/CMakeLists.txt
@@ -1,5 +1,4 @@
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
-include_directories(${GLOW_THIRDPARTY_DIR}/onnx)
 
 add_library(onnxifi-glow
             SHARED


### PR DESCRIPTION
Currently CMakefile to build ONNX has issue that when glow lib is used with onnx lib in the same process, there will be protobuf registration conflicts. This was studied and solved during Pythorch/Onnx integration. We reuse the solution in CMakefile in onnx to build onnx protobuf lib to avoid the issue. 

@rdzhabarov 