### PR TITLE
[caffe2] Fix out_of_range exception in Caffe2 importer while loading a ConstantFill tensor

### DIFF
--- a/lib/Importer/Caffe2.cpp
+++ b/lib/Importer/Caffe2.cpp
@@ -620,7 +620,9 @@ void caffe2ModelLoader::loadWeight(const caffe2::OperatorDef &op) {
     case caffe2::TensorProto_DataType_FLOAT: {
       T->reset(ElemKind::FloatTy, dims);
       auto TH = T->getHandle<float>();
-      auto f = dict.at("value")->has_f() ? loadFloat(dict.at("value")) : 0.0f;
+      auto f = (dict.count("value") && dict["value"]->has_f())
+                   ? loadFloat(dict["value"])
+                   : 0.0f;
       TH.clear(f);
       break;
     }
@@ -628,7 +630,9 @@ void caffe2ModelLoader::loadWeight(const caffe2::OperatorDef &op) {
     case caffe2::TensorProto_DataType_INT64: {
       T->reset(ElemKind::IndexTy, dims);
       auto TH = T->getHandle<size_t>();
-      auto i = dict.at("value")->has_i() ? loadInt(dict.at("value")) : 0;
+      auto i = (dict.count("value") && dict["value"]->has_i())
+                   ? loadInt(dict["value"])
+                   : 0;
       TH.clear(i);
       break;
     }


### PR DESCRIPTION
Some Caffe2 models we use seem to have ConstantFill tensors, which don't have "value" attribute specified, so GLOW crashes with out_or_range exception in caffe2ModelLoader::loadWeight.
The fix addresses this.