### PR TITLE
[NodeValue] Get rid of the implicit conversion when using the operator->

### DIFF
--- a/include/glow/Graph/Node.h
+++ b/include/glow/Graph/Node.h
@@ -82,8 +82,6 @@ public:
   /// Replace all of the uses of this value with \p v.
   void replaceAllUsesOfWith(NodeValue v);
 
-  /// Provide a smart-pointer interface.
-  Node *operator->() const { return node_; }
   /// Return the TypeRef of the referenced return value.
   TypeRef getType() const;
 

--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -118,7 +118,7 @@ protected:
     // have an option for a selected input anyway. So I am creating this as a
     // placeholder which goes unused during inference.
     auto selected = G_.getParent()->createVariable(
-        ElemKind::IndexTy, {in->dims(0)[0], 1}, "selected",
+        ElemKind::IndexTy, {in.dims()[0], 1}, "selected",
         VisibilityKind::Private, false);
 
     // ONNX allows shapes like <N x 10 x 1 x 1 >. Flatten the inputs to the
@@ -187,9 +187,9 @@ protected:
       // In ONNX, if axis == -1 then it sets the axis so that the
       // trailing-most dimensions are aligned like this.
       if (axis == -1) {
-        axis = in0->dims(0).size() - in1->dims(0).size();
+        axis = in0.dims().size() - in1.dims().size();
       }
-      finalIn1 = G_.createBroadcast(opName, in1, in0->dims(0), axis);
+      finalIn1 = G_.createBroadcast(opName, in1, in0.dims(), axis);
     } else {
       finalIn1 = in1;
     }
@@ -300,7 +300,7 @@ protected:
     std::vector<unsigned> perm = getShape<unsigned>(dict[permArgName]);
     if (perm.empty()) {
       // Empty permutation argument means reversing axes order.
-      size_t N = in->dims(0).size();
+      size_t N = in.dims().size();
       for (int64_t i = N - 1; i >= 0; i--)
         perm.push_back(i);
     }
@@ -332,7 +332,7 @@ protected:
     auto k = loadInt(dict["k"]);
 
     int axis = dict.count("axis") ? loadInt(dict["axis"]) : -1;
-    unsigned lastDim = in->dims(0).size() - 1;
+    unsigned lastDim = in.dims().size() - 1;
     if (axis == -1) {
       axis = lastDim;
     }

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1224,9 +1224,9 @@ Function::createQuantizationProfile(llvm::StringRef name, NodeValue input) {
       getParent()->createVariable(ElemKind::FloatTy, {2}, "computationInfo",
                                   VisibilityKind::Private, false);
 
-  return addNode(
-      new QuantizationProfileNode(name, input, histogram, computationInfo,
-                                  input->getName().str(), input.getResNo()));
+  return addNode(new QuantizationProfileNode(
+      name, input, histogram, computationInfo, input.getNode()->getName().str(),
+      input.getResNo()));
 }
 
 IntLookupTableNode *
@@ -1834,8 +1834,9 @@ class FunctionDottyPrinter : public AbstractDottyPrinter {
       auto pred = N->getPredicate();
       size_t resNo = pred.getResNo();
       std::ostringstream edge;
-      edge << uniqueVertexName(pred) << ":" << pred->getOutputName(resNo).str()
-           << " -> " << uniqueVertexName(N) << ":w";
+      edge << uniqueVertexName(pred) << ":"
+           << pred.getNode()->getOutputName(resNo).str() << " -> "
+           << uniqueVertexName(N) << ":w";
       dumpEdgeStyle(N, 0, pred, edge);
       edges_.insert(edge.str());
       visitNode(pred);

--- a/lib/Graph/Node.cpp
+++ b/lib/Graph/Node.cpp
@@ -157,7 +157,7 @@ llvm::hash_code Node::getHash() const { return HashNodeVisitor().visit(this); }
 
 void Node::visit(Node *parent, NodeWalker *visitor) {
   if (hasPredicate()) {
-    getPredicate()->visit(this, visitor);
+    getPredicate().getNode()->visit(this, visitor);
   }
 
   switch (getKind()) {

--- a/lib/Importer/Caffe2.cpp
+++ b/lib/Importer/Caffe2.cpp
@@ -215,7 +215,7 @@ void caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     // If 'global_pooling' is set then the operation will pool over the size of
     // the input by doing: kernels = {height, width}.
     if (dict.count("global_pooling")) {
-      auto Ty = in->getType(0);
+      auto Ty = in.getType();
       kernels[0] = Ty->dims()[2];
       kernels[1] = Ty->dims()[3];
     }
@@ -417,14 +417,14 @@ void caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     for (size_t i = 0; i < starts.size(); i++) {
       ssize_t newStart = starts[i];
       if (newStart == -1) {
-        newStart = data->dims(0)[i];
+        newStart = data.dims()[i];
       }
       assert(newStart >= 0 && "Indices should never be negative.");
       newStarts.push_back(newStart);
 
       ssize_t newEnd = ends[i];
       if (newEnd == -1) {
-        newEnd = data->dims(0)[i];
+        newEnd = data.dims()[i];
       }
       assert(newEnd >= 0 && "Indices should never be negative.");
       newEnds.push_back(newEnd);
@@ -451,7 +451,7 @@ void caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
 
     // BatchMatMul sometimes is actually just a matmul, depending on dimensions
     // of inputs. Thus, only do batch matmul if LHS is 3-dimensional.
-    if (typeName == "BatchMatMul" && LHS->dims(0).size() == 3) {
+    if (typeName == "BatchMatMul" && LHS.dims().size() == 3) {
       node = G_.createBatchMatMul(opName, LHS, RHS);
     } else {
       node = G_.createMatMul(opName, LHS, RHS);

--- a/lib/Importer/ONNX.cpp
+++ b/lib/Importer/ONNX.cpp
@@ -303,7 +303,7 @@ bool ONNXModelLoader::loadOperator(const onnx::NodeProto &op) {
     // If 'global_pooling' is set then the operation will pool over the size of
     // the input by doing: kernel = height/width.
     if (dict.count("global_pooling")) {
-      auto Ty = in->getType(0);
+      auto Ty = in.getType();
       kernels[0] = Ty->dims()[2];
       kernels[1] = Ty->dims()[3];
     }
@@ -328,8 +328,8 @@ bool ONNXModelLoader::loadOperator(const onnx::NodeProto &op) {
     }
 
     std::vector<size_t> kernels(2);
-    kernels[0] = in->dims(0)[2];
-    kernels[1] = in->dims(0)[3];
+    kernels[0] = in.dims()[2];
+    kernels[1] = in.dims()[3];
     std::vector<size_t> pads = getPads(dict);
     auto *tr = G_.createTranspose(opName, in, NCHW2NHWC);
     Node *node = G_.createAvgPool(opName, tr, kernels, strides, pads);
@@ -409,7 +409,7 @@ bool ONNXModelLoader::loadOperator(const onnx::NodeProto &op) {
 
     MatMulNode *mul = G_.createMatMul(opName, A, B);
     if (broadcastC) {
-      int axis = mul->getResult().dims().size() - C->dims(0).size();
+      int axis = mul->getResult().dims().size() - C.dims().size();
       C = G_.createBroadcast(opName, C, mul->getResult().dims(), axis);
     }
 

--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -1041,7 +1041,7 @@ static NodeValue tryToOptimizeConcatOfRehapes(Function *F, ConcatNode *CN) {
     return NodeValue(nullptr);
   }
   auto *newCN = F->createConcat(CN->getName(), newConcatInputs, dim);
-  return F->createReshape(CN->getInputs().front()->getName(), newCN,
+  return F->createReshape(CN->getInputs().front().getNode()->getName(), newCN,
                           CN->getResult().dims());
 }
 

--- a/lib/Optimizer/Lower.cpp
+++ b/lib/Optimizer/Lower.cpp
@@ -305,7 +305,7 @@ void lowerSGDNode(Function *F, SGDNode &SGD) {
   // OptimizationStochasticGradientDescent/
   if (momentum > 0.0) {
     Variable *Gsum = F->getParent()->createVariable(
-        W->getType(0), "gsum", VisibilityKind::Private, true);
+        W.getType(), "gsum", VisibilityKind::Private, true);
     Gsum->getPayload().zero();
 
     auto *momentumSplat = F->createSplat("learningRateSplat", type, momentum);

--- a/lib/Optimizer/Partition.cpp
+++ b/lib/Optimizer/Partition.cpp
@@ -151,9 +151,9 @@ FunctionDAG doPartitioning(Function *F, NodeFunctionMap &mapping) {
         }
 
         // Create a new variable to represent this dependence.
-        auto *tmp = mod->createVariable(input.getType(),
-                                        std::string(input->getName()) + "_tmp",
-                                        VisibilityKind::Private, false);
+        auto *tmp = mod->createVariable(
+            input.getType(), std::string(input.getNode()->getName()) + "_tmp",
+            VisibilityKind::Private, false);
         inputF->createSave("tmp", input, tmp);
         variables[input.getNode()] = tmp;
         N.setNthInput(inp, tmp);

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -72,7 +72,7 @@ quantizeInputs(Function *F, Node *node,
     }
 
     std::string nodeOutputName = NodeQuantizationInfo::generateNodeOutputName(
-        NV->getName(), NV.getResNo());
+        NV.getNode()->getName(), NV.getResNo());
     assert(nodeToTQP.find(nodeOutputName) != nodeToTQP.end() &&
            "Missing quantization params for a node");
 
@@ -244,8 +244,9 @@ static Node *quantizeNode(Function *F, Node *node,
           ElemKind::Int8QTy, quantizedInputs[qi].dims(), qParams[0].scale,
           qParams[0].offset);
 
-      quantizedInputs[qi] = F->createRescaleQuantized(
-          quantizedInputs[qi]->getName(), quantizedInputs[qi], argOutTy);
+      quantizedInputs[qi] =
+          F->createRescaleQuantized(quantizedInputs[qi].getNode()->getName(),
+                                    quantizedInputs[qi], argOutTy);
     }
 
     auto outTy =

--- a/tests/unittests/graphOptzTest.cpp
+++ b/tests/unittests/graphOptzTest.cpp
@@ -687,7 +687,7 @@ TEST_F(GraphOptz, ReshapeAfterSplat) {
 
   // The second input of A3 shoule be a splat node with a shape of R3.
   auto *SN = llvm::dyn_cast<SplatNode>(
-      llvm::dyn_cast<SaveNode>(O)->getInput()->getNthInput(1));
+      llvm::dyn_cast<SaveNode>(O)->getInput().getNode()->getNthInput(1));
   EXPECT_TRUE(SN);
   EXPECT_TRUE(SN->getResult().getType()->dims().equals(reshape));
 
@@ -1077,13 +1077,14 @@ TEST_F(GraphOptz, concatReshapes) {
 
   // The first input of addNode should be a Reshape node now, with the same
   // result shape of concatNode1.
-  auto *newRN = llvm::dyn_cast<ReshapeNode>(O->getInput()->getNthInput(0));
+  auto *newRN =
+      llvm::dyn_cast<ReshapeNode>(O->getInput().getNode()->getNthInput(0));
   ASSERT_TRUE(newRN);
   EXPECT_TRUE(newRN->getResult().getType()->dims().equals(outputShape));
 
   // The input of newRN should be a ConcatNode now.
-  auto *newCN =
-      llvm::dyn_cast<ConcatNode>(O->getInput()->getNthInput(0)->getNthInput(0));
+  auto *newCN = llvm::dyn_cast<ConcatNode>(
+      O->getInput().getNode()->getNthInput(0).getNode()->getNthInput(0));
   ASSERT_TRUE(newCN);
 }
 

--- a/tests/unittests/graphTest.cpp
+++ b/tests/unittests/graphTest.cpp
@@ -83,15 +83,15 @@ TEST(Graph, useList) {
   // Therefore those checks are currently inverted but should be
   // fixed eventually.
   // Test with implicit temporary NodeValue.
-  EXPECT_TRUE(conv->getFilter()->hasOneUse());
-  EXPECT_EQ(conv->getFilter()->getNumUsers(), 1);
+  EXPECT_TRUE(conv->getFilter().getNode()->hasOneUse());
+  EXPECT_EQ(conv->getFilter().getNode()->getNumUsers(), 1);
 
   // Test with explicit temporary NodeValue.
   Node *nodeFilter;
   {
     NodeValue tmp = conv->getFilter();
-    EXPECT_TRUE(tmp->hasOneUse());
-    EXPECT_EQ(tmp->getNumUsers(), 1);
+    EXPECT_TRUE(tmp.getNode()->hasOneUse());
+    EXPECT_EQ(tmp.getNode()->getNumUsers(), 1);
     nodeFilter = tmp.getNode();
     // Test with NodeValue still around.
     EXPECT_TRUE(nodeFilter->hasOneUse());
@@ -106,7 +106,7 @@ TEST(Graph, useList) {
   {
     NodeValue tmpConvRes(conv, 0);
     EXPECT_EQ(conv->getNumUsers(), 0);
-    EXPECT_EQ(tmpConvRes->getNumUsers(), 0);
+    EXPECT_EQ(tmpConvRes.getNode()->getNumUsers(), 0);
   }
 
   // Add a couple of uses to conv and make sure it reflects on its use list.
@@ -119,10 +119,10 @@ TEST(Graph, useList) {
 
   {
     NodeValue tmpConvRes(conv, 0);
-    EXPECT_TRUE(tmpConvRes->hasOneUse());
+    EXPECT_TRUE(tmpConvRes.getNode()->hasOneUse());
     EXPECT_TRUE(conv->hasOneUse());
     EXPECT_EQ(conv->getNumUsers(), 1);
-    EXPECT_EQ(tmpConvRes->getNumUsers(), 1);
+    EXPECT_EQ(tmpConvRes.getNode()->getNumUsers(), 1);
   }
 
   F->createSave("Save", conv, K);
@@ -134,10 +134,10 @@ TEST(Graph, useList) {
 
   {
     NodeValue tmpConvRes(conv, 0);
-    EXPECT_FALSE(tmpConvRes->hasOneUse());
+    EXPECT_FALSE(tmpConvRes.getNode()->hasOneUse());
     EXPECT_FALSE(conv->hasOneUse());
     EXPECT_EQ(conv->getNumUsers(), 2);
-    EXPECT_EQ(tmpConvRes->getNumUsers(), 2);
+    EXPECT_EQ(tmpConvRes.getNode()->getNumUsers(), 2);
   }
 }
 
@@ -154,8 +154,8 @@ TEST(Graph, useListIteration) {
   // Check the number of users for different nodes.
   EXPECT_EQ(K->getNumUsers(), 2);
   EXPECT_EQ(conv1->getNumUsers(), 0);
-  EXPECT_TRUE(conv2->getFilter()->hasOneUse());
-  EXPECT_EQ(conv1->getFilter()->getNumUsers(), 1);
+  EXPECT_TRUE(conv2->getFilter().getNode()->hasOneUse());
+  EXPECT_EQ(conv1->getFilter().getNode()->getNumUsers(), 1);
   // Check that the first user of K is conv1.
   EXPECT_EQ(K->getUsers().begin()->getUser(), conv1);
   // Check that the second user of K is conv2.
@@ -663,8 +663,8 @@ TEST(Graph, usesLists) {
   // To add to the confusion, it is possible to use
   // replaceAllUsesOfWith directly with an instance NodeValue and
   // this would walk only the right uses.
-  EXPECT_EQ(indices->getNumUsers(), 0);
-  EXPECT_EQ(values->getNumUsers(), 0);
+  EXPECT_EQ(indices.getNode()->getNumUsers(), 0);
+  EXPECT_EQ(values.getNode()->getNumUsers(), 0);
 
   // Now add a user to only one result of the topK node.
   F->createSave("saveValues", values);
@@ -673,9 +673,10 @@ TEST(Graph, usesLists) {
   EXPECT_EQ(topK->getNumUsers(), 1);
 
   // Each result should have its own use list.
-  // FIXME: but right now they don't.
-  EXPECT_EQ(indices->getNumUsers(), 1 /*should be 0*/);
-  EXPECT_EQ(values->getNumUsers(), 1);
+  // FIXME: but right now they don't, we have to go through the node.
+  EXPECT_EQ(indices.getNode()->getNumUsers(),
+            1 /*we want a way to get 0 here*/);
+  EXPECT_EQ(values.getNode()->getNumUsers(), 1);
 
   // Add a user to the other result of the topK node.
   F->createSave("saveIndices", indices);
@@ -685,6 +686,6 @@ TEST(Graph, usesLists) {
 
   // Each result should have its own use list.
   // FIXME: but right now they don't.
-  EXPECT_EQ(indices->getNumUsers(), 2 /*should be 1*/);
-  EXPECT_EQ(values->getNumUsers(), 2 /*should be 1*/);
+  EXPECT_EQ(indices.getNode()->getNumUsers(), 2 /*should be 1*/);
+  EXPECT_EQ(values.getNode()->getNumUsers(), 2 /*should be 1*/);
 }

--- a/tools/ClassGen/InstrBuilder.cpp
+++ b/tools/ClassGen/InstrBuilder.cpp
@@ -349,7 +349,7 @@ void InstrBuilder::emitAutoIRGen(std::ostream &os) const {
          "Didn't find a result; Maybe using InOut which isn't yet supported");
   os << "  std::string allocName = std::string(N->getName()) + \".res\";\n";
   os << "  auto *dest__ = builder_.createAllocActivationInst(allocName,"
-     << "CN__->get" << resNodeName << "()->getType(0));\n";
+     << "CN__->get" << resNodeName << "().getType());\n";
   os << "  auto *V = builder_.create" << name_ << "Inst(\"" << autoIRGenNodeName
      << "\", dest__";
   for (const auto &opPair : operands_) {

--- a/tools/ClassGen/NodeBuilder.cpp
+++ b/tools/ClassGen/NodeBuilder.cpp
@@ -377,16 +377,17 @@ void NodeBuilder::emitVisitor(std::ostream &os) const {
      << "Node::visit(Node *parent, NodeWalker *visitor) {\n"
      << "  if (!visitor->shouldVisit(parent, this)) { return; }\n"
      << "  visitor->pre(parent, this);\n"
-     << "  if (hasPredicate()) getPredicate()->visit(this, visitor);\n";
+     << "if (hasPredicate())\n"
+     << " getPredicate().getNode()->visit(this, visitor);\n";
 
   for (const auto &op : nodeInputs_) {
-    os << "  get" << op << "()->visit(this, visitor);\n";
+    os << "  get" << op << "().getNode()->visit(this, visitor);\n";
   }
 
   for (const auto &op : members_) {
     if (op.first == MemberType::VectorNodeValue) {
       os << "  for (auto &I : " << op.second
-         << "_) { I->visit(this, visitor); }\n";
+         << "_) { I.getNode()->visit(this, visitor); }\n";
     }
   }
 


### PR DESCRIPTION
The change is pretty mechanical. Namely, this changes the pattern
NodeValue-><Node_method>
Into
NodeValue.getNode()-><Node_method>

Also, as part of this change, we actually get cleaner accesses to
dimensions, types, etc. Indeed, instead of hardcoding the index of
the result, the NodeValue directly gets us the right value.

Related to #1346.

NFC.