### PR TITLE
[quantization] Add quantization support for LRN and SoftMax in middle-end

### DIFF
--- a/include/glow/ExecutionEngine/ExecutionEngine.h
+++ b/include/glow/ExecutionEngine/ExecutionEngine.h
@@ -50,9 +50,12 @@ public:
 
   ~ExecutionEngine();
 
-  // Set the code generator kind to \p backendKind. New code will be generated
-  // using this backend.
+  /// Set the code generator kind to \p backendKind. New code will be generated
+  /// using this backend.
   void setBackend(BackendKind backendKind);
+
+  /// Set the code generator to a custom \p backend.
+  void setBackend(Backend *backend);
 
   /// \returns the internal graph.
   Module &getModule() { return M_; }

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -41,9 +41,15 @@ static llvm::cl::opt<bool> dumpIR("dump-ir",
 ExecutionEngine::ExecutionEngine(BackendKind backendKind)
     : backend_(createBackend(backendKind)) {}
 
-// Set the code generator kind to \p backendKind.
+/// Set the code generator kind to \p backendKind.
 void ExecutionEngine::setBackend(BackendKind backendKind) {
   backend_.reset(createBackend(backendKind));
+  function_.reset();
+}
+
+/// Set the code generator kind to \p backend.
+void ExecutionEngine::setBackend(Backend *backend) {
+  backend_.reset(backend);
   function_.reset();
 }
 


### PR DESCRIPTION
Add quantization support for LRN and SoftMax in GLOW middle-end, making possible for any back-and to implement them, if needed.