### PR TITLE
[quantization] Add a symmetric with uint8 mode

### DIFF
--- a/docs/Quantization.md
+++ b/docs/Quantization.md
@@ -74,16 +74,22 @@ For example, you can run the following command to capture profile for Resnet50.
 ./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to1 -m=resnet50 -dump_profile="profile.yaml"
 ```
 By default, the loader will produce quantized results using asymmetric ranges.
-That is ranges not necessarily centered on 0. The loader supports two modes
-or schemas of quantization: asymmetric and symmetric. The symmetric schema
+That is ranges not necessarily centered on 0. The loader supports three modes
+or schemas of quantization: asymmetric, symmetric, and symmetric with uint8. The symmetric schema
 will always map the data on ranges centered on 0. In practice, this means
 the symmetric schema may extend the range it needs to capture to make
 sure 0.0 is at the center of that range. Therefore, this schema potentially
 waste some encoding space to enforce the symmetric property, but it comes
 with the property that the offset is always equal to zero.
+The symmetric with uint8 schema conceptually produces ranges where the offset
+is always equal to zero but allows the quantized ranges to be either
+int8 [-128; 127] or uint8 [0; 255]. In practice, this schema represents
+uint8 ranges using int8 ranges with an offset of -128. Therefore, when
+using this schema, the produced profile will have two kinds of ranges:
+one with an offset of 0 and the other with an offset of -128.
 Use ```quantization-schema=<schema>``` to specify the schema for
-the quantization process, where schema is either ```asymmetric``` or
-```symmetric```.
+the quantization process, where schema is ```asymmetric```,
+```symmetric```, or ```symmetric_with_uint8```.
 
 
 ```load_profile=profile.yaml``` option is used to quantize graph based on the

--- a/include/glow/Quantization/Base/Base.h
+++ b/include/glow/Quantization/Base/Base.h
@@ -61,6 +61,11 @@ enum Schema {
   Asymmetric,
   /// Symmetric quantization produces ranges centered on 0.
   Symmetric,
+  /// Symmetric quantization produces ranges centered on 0 or 128
+  /// (i.e., offset == -128).
+  /// An offset of -128 represents an unsigned int8 with an offset of zero:
+  /// int8 is [-128; 127] - (-128) == uint8 [0; 255] - 0
+  SymmetricWithUInt8,
 };
 
 /// Converts floating point value to int8 based on the quantization

--- a/tests/unittests/quantizationTest.cpp
+++ b/tests/unittests/quantizationTest.cpp
@@ -507,7 +507,8 @@ TEST(Quantization, chooseQuantizationSymmetric) {
   EXPECT_NEAR(symmetricParams.scale, 10.0 / 255, 0.001);
 
   // Map float [2.0; 5.0] to int [-128; 127].
-  // => [-5.0; 5.0] range for symmetric mode.
+  // Ranges are extended to include 0.
+  // => [0.0; 5.0] range for symmetric mode.
   symmetricParams =
       chooseQuantizationParams(2.0, 5.0, quantization::Schema::Symmetric);
   // Scale: (5.0 - (0.0)) / (127 - (-128)) == 5.0 / 255.0

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -71,10 +71,14 @@ llvm::cl::opt<std::string> dumpProfileFileOpt(
 llvm::cl::opt<quantization::Schema> quantizationSchema(
     "quantization-schema",
     llvm::cl::desc("Specify which quantization schema to use"),
-    llvm::cl::values(clEnumValN(quantization::Schema::Asymmetric, "asymmetric",
-                                "Use asymmetric ranges"),
-                     clEnumValN(quantization::Schema::Symmetric, "symmetric",
-                                "Use symmetric ranges")),
+    llvm::cl::values(
+        clEnumValN(quantization::Schema::Asymmetric, "asymmetric",
+                   "Use asymmetric ranges"),
+        clEnumValN(quantization::Schema::Symmetric, "symmetric",
+                   "Use symmetric ranges"),
+        clEnumValN(quantization::Schema::SymmetricWithUInt8,
+                   "symmetric_with_uint8",
+                   "Use symmetric ranges with potentially uint8 ranges")),
     llvm::cl::init(quantization::Schema::Asymmetric), llvm::cl::cat(loaderCat));
 
 llvm::cl::opt<std::string> loadProfileFileOpt(


### PR DESCRIPTION
This PR adds a new schema symmetric with uint8 that basically feature symmetric range for both int8 and uint8.
Uint8 are represented as int8 with an offset -128.