### PR TITLE
[utils] Add two script to help generate simple caffe2/onnx models used for importer unittest.

### DIFF
--- a/utils/scripts/gen_caffe2_model.py
+++ b/utils/scripts/gen_caffe2_model.py
@@ -1,0 +1,58 @@
+## This is a helper script that generates Caffe2 models.
+## The generated model will be used for Caffe2 importer unittest:    
+## ./tests/unittests/caffe2ImporterTest.cpp 
+## Run $>python gen_caffe2_model.py to get the model files.
+
+from caffe2.proto import caffe2_pb2
+from caffe2.python import utils
+from google.protobuf import text_format
+# Define a weights network
+weights = caffe2_pb2.NetDef()
+weights.name = "init"
+
+op = caffe2_pb2.OperatorDef()
+op.type = "GivenTensorFill"
+op.output.extend(["conv_w"])
+op.arg.extend([utils.MakeArgument("shape", [1, 1, 2, 2])])
+op.arg.extend([utils.MakeArgument("values", [1.0 for i in range(4)])])
+weights.op.extend([op])
+
+op = caffe2_pb2.OperatorDef()
+op.type = "GivenTensorFill"
+op.output.extend(["conv_b"])
+op.arg.extend([utils.MakeArgument("shape", [1])])
+op.arg.extend([utils.MakeArgument("values", [2.0 for i in range(1)])])
+weights.op.extend([op])
+weights.external_output.extend(op.output)
+
+# Define an inference net
+net = caffe2_pb2.NetDef()
+net.name = "predict"
+
+op = caffe2_pb2.OperatorDef()
+op.type = "Conv"
+op.input.extend(["data"])
+op.input.extend(["conv_w"])
+op.input.extend(["conv_b"])
+op.arg.add().CopyFrom(utils.MakeArgument("kernel", 2));
+op.arg.add().CopyFrom(utils.MakeArgument("stride", 1));
+op.arg.add().CopyFrom(utils.MakeArgument("group", 1));
+op.arg.add().CopyFrom(utils.MakeArgument("pad", 1));
+op.output.extend(["conv_out"])
+net.op.extend([op])
+
+net.external_output.extend(op.output)
+
+# Generate model in text format.
+with open('predict_net.pbtxt', 'w') as f:
+  f.write(text_format.MessageToString(net));
+
+with open('init_net.pbtxt', 'w') as f:
+  f.write(text_format.MessageToString(weights))
+
+# Generate model in binary format.
+with open('predict_net.pb', 'wb') as f:
+  f.write(net.SerializeToString());
+
+with open('init_net.pb', 'wb') as f:
+  f.write(net.SerializeToString())

--- a/utils/scripts/gen_onnx_model.py
+++ b/utils/scripts/gen_onnx_model.py
@@ -1,0 +1,66 @@
+## This is a helper script that generates ONNX models.
+## The generated model will be used for ONNX importer unittest:
+## ./tests/unittests/onnxImporterTest.cpp
+## Run $>python gen_onnx_model.py to get the ONNX model.
+
+import onnx
+from onnx import helper
+from onnx import AttributeProto, TensorProto, GraphProto
+import numpy as np
+
+# The protobuf definition can be found here:
+# https://github.com/onnx/onnx/blob/master/onnx/onnx.proto
+
+W = np.array([[[[1., 1.],  # (1, 1, 2, 2) tensor for convolution weights
+                [1., 1.]]]]).astype(np.float32)
+
+B = np.array([2.]).astype(np.float32)
+
+
+# Convolution with padding. "data" represents the input data,
+# which will be provided by ONNX importer unittests.
+node_def = onnx.helper.make_node(
+    'Conv',
+    inputs=['data', 'W', 'B'],
+    outputs=['y'],
+    kernel_shape=[2, 2],
+    strides=[1, 1],
+    pads=[1, 1, 1, 1],
+    name="conv1"
+)
+
+weight_tensor = helper.make_tensor(
+            name='W',
+            data_type=TensorProto.FLOAT,
+            dims=(1, 1, 2, 2),
+            vals=W.reshape(4).tolist()
+            )
+
+bias_tensor = helper.make_tensor(
+            name='B',
+            data_type=TensorProto.FLOAT,
+            dims=(1,),
+            vals=B.reshape(1).tolist()
+            )
+# Create the graph (GraphProto)
+graph_def = helper.make_graph(
+    [node_def],
+    "test-model",
+    inputs=[helper.make_tensor_value_info("data", TensorProto.FLOAT, [1, 1, 3, 3]),
+            helper.make_tensor_value_info("W", TensorProto.FLOAT, [1, 1, 2, 2]),
+            helper.make_tensor_value_info("B", TensorProto.FLOAT, [1,])],
+    outputs=[helper.make_tensor_value_info("y", TensorProto.FLOAT, [1, 1, 4, 4])]
+)
+
+graph_def.initializer.extend([weight_tensor])
+graph_def.initializer.extend([bias_tensor])
+graph_def.initializer[0].name = 'W'
+graph_def.initializer[1].name = 'B'
+# Create the model (ModelProto)
+model_def = helper.make_model(graph_def, producer_name='onnx-conv')
+
+with open('simpleConv.onnxtxt', 'w') as f:
+  f.write(str(model_def));
+
+onnx.checker.check_model(model_def)
+print('The model is checked!')


### PR DESCRIPTION
The 2 files in this PR is to provide an sample code for generating simple Caffe2/ONNX models used for our Caffe2/ONNX importer unit testing. The generated model is in text format.  Currently, the files generate a simple CNN with a convolution layer only. Users should customize the code to generate their only models.