### PR TITLE
[onnxifi] Load output nodes, perform setIO and run the Graph.

### DIFF
--- a/include/glow/Importer/ONNX.h
+++ b/include/glow/Importer/ONNX.h
@@ -43,10 +43,6 @@ class ONNXModelLoader
   /// Set ir verion and op version.
   void setVersion(ONNX_NAMESPACE::ModelProto MP);
 
-  /// Set the output nodes of the network \p net. Initializes the map from the
-  /// names of the outputs to the save nodes that save each output.
-  void setOutputNodes(ONNX_NAMESPACE::GraphProto &net);
-
   /// Load the network initializers from the GraphProto.
   void loadInitializers(ONNX_NAMESPACE::GraphProto &net);
 
@@ -85,6 +81,11 @@ protected:
   /// onnxModel with the model size \p onnxModelSize.
   bool loadProto(ONNX_NAMESPACE::GraphProto &net, const void *onnxModel,
                  size_t onnxModelSize);
+
+  /// Set the output nodes of the network \p net. Initializes the map from the
+  /// names of the outputs to the save nodes that save each output.
+  /// \returns true if output nodes were found.
+  bool setOutputNodes(ONNX_NAMESPACE::GraphProto &net);
 
 public:
   /// Checks that the inputs tensors are compatible with the inputs declared in

--- a/include/glow/Importer/ONNXIFILoader.h
+++ b/include/glow/Importer/ONNXIFILoader.h
@@ -21,6 +21,8 @@
 
 #include "glow/Importer/ONNX.h"
 
+#include "llvm/ADT/StringMap.h"
+
 namespace glow {
 namespace onnxifi {
 
@@ -36,7 +38,20 @@ private:
   bool loadWeights(uint32_t weightsCount,
                    const onnxTensorDescriptorV1 *weightDescriptors);
 
+  /// Mapping between ONNX names for inputs and actual Glow input vars.
+  llvm::StringMap<Variable *> onnxNameToInputVars_;
+
 public:
+  /// \returns mapping between ONNX names and actual Glow input vars.
+  const llvm::StringMap<Variable *> &getInputVarsMapping() const {
+    return onnxNameToInputVars_;
+  }
+
+  /// \returns mapping between ONNX names and actual Glow output nodes.
+  const llvm::StringMap<SaveNode *> &getOutputVarsMapping() const {
+    return outputsByName_;
+  }
+
   /// \returns unique pointer to ModelLoader if \p onnxModel can be parsed
   /// and static weights can be loaded from the \p wightDescriptors.
   /// \returns nullptr otherwise.

--- a/include/glow/Importer/ProtobufLoader.h
+++ b/include/glow/Importer/ProtobufLoader.h
@@ -21,6 +21,7 @@
 #include "glow/Graph/Graph.h"
 
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/StringMap.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -99,7 +100,7 @@ protected:
   /// A list of weight tensors indexed by name.
   std::unordered_map<std::string, Tensor *> tensors_;
   /// A map from names of the external outputs of the network to SaveNodes.
-  std::unordered_map<std::string, SaveNode *> outputsByName_;
+  llvm::StringMap<SaveNode *> outputsByName_;
 
   /// \returns the tensor that was registered under the name \p name.
   Tensor *getTensorByName(llvm::StringRef name);

--- a/lib/Importer/ONNX.cpp
+++ b/lib/Importer/ONNX.cpp
@@ -29,7 +29,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <fstream>
-#include <iostream>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -457,7 +456,7 @@ bool ONNXModelLoader::setOutputNodes(ONNX_NAMESPACE::GraphProto &net) {
   }
 
   for (int i = 0; i < net.output_size(); i++) {
-    auto &outputName = net.output(i).name();
+    const auto &outputName = net.output(i).name();
     auto r = getNodeValueByName(outputName);
     outputsByName_[outputName] = G_.createSave("save_" + outputName, r);
   }

--- a/lib/Importer/ONNXIFILoader.cpp
+++ b/lib/Importer/ONNXIFILoader.cpp
@@ -118,6 +118,10 @@ std::unique_ptr<ModelLoader> ModelLoader::parse(
   if (!loader->loadNetwork(modelDef)) {
     return nullptr;
   }
+  
+  if (!loader->setOutputNodes(modelDef)) {
+    return nullptr;
+  }
 
   return loader;
 }


### PR DESCRIPTION
towards issue: https://github.com/pytorch/glow/issues/1190
* Set output nodes
* Handle set graph IO ONNXIFI method
* Perform inference as part of the Run() method

cc: @yinghai @Maratyszcza 

running ```pytest -s test_onnxifi.py```, it passes e2e for ReLU and Conv nets.