### PR TITLE
[fix][quantization]Erase the old function after we create the new quantized function

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -160,6 +160,9 @@ public:
 
   /// Erase all of the functions from the module.
   void eraseFunctions();
+
+  /// Erase a function \p F from the module.
+  void eraseFunction(Function *F);
 };
 
 /// Represents the compute graph.

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -265,11 +265,16 @@ void Module::dumpDAG(const char *dotFilename) {
 }
 
 void Module::eraseFunctions() {
-  for (auto *F : functions_) {
-    delete F;
+  while (!functions_.empty()) {
+    eraseFunction(*functions_.begin());
   }
+}
 
-  functions_.clear();
+void Module::eraseFunction(Function *F) {
+  auto it = std::find(functions_.begin(), functions_.end(), F);
+  assert(it != functions_.end() && "Function is not part of a module");
+  functions_.erase(it);
+  delete F;
 }
 
 Function::~Function() {

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -432,6 +432,9 @@ quantizeFunction(const ExecutionEngine &EE,
     }
   } while (nodeIt != stopIt);
 
+  // Erase the original function so that the redundant variables that are only 
+  // referenced by the original function will be removed.
+  F->getParent()->eraseFunction(F);
   return G;
 }
 

--- a/tests/unittests/MLTest.cpp
+++ b/tests/unittests/MLTest.cpp
@@ -908,7 +908,8 @@ TEST_P(InterpreterAndCPU, convNetForImageRecognition) {
   auto *TANH = F->createTanh("tanh", CV);
   auto *FCL = F->createFullyConnected("fc", TANH, 2);
   auto *SM = F->createSoftMax("sm", FCL, ex);
-  auto *result = F->createSave("ret", SM);
+  auto *SN = F->createSave("ret", SM);
+  auto *resultVar = SN->getVariable();
   Function *TF = glow::differentiate(F, TC);
   EE.compile(CompilationMode::Train, TF);
 
@@ -938,7 +939,7 @@ TEST_P(InterpreterAndCPU, convNetForImageRecognition) {
   Tensor testLabels(ElemKind::IndexTy, {batchSize, 1});
   generateImageData(testImages, testLabels, mod.getPRNG());
   EE.run({input}, {&testImages});
-  auto SMH = result->getVariable()->getHandle<>();
+  auto SMH = resultVar->getHandle<>();
   for (size_t i = 0; i < batchSize; i++) {
     bool isLine = testLabels.getHandle<size_t>().at({i, 0}) == 0;
     auto lineWeight = SMH.at({i, 0});
@@ -995,7 +996,8 @@ TEST_P(InterpreterAndCPU, testFindPixelRegression) {
   auto *RL0 = F->createRELU("relu0", FC0);
   auto *FC1 = F->createFullyConnected("fc1", RL0, 2);
   auto *R = F->createRegression("regression", FC1, ex);
-  auto *result = F->createSave("ret", R);
+  auto *SN = F->createSave("ret", R);
+  auto *resultVar = SN->getVariable();
   Function *TF = glow::differentiate(F, TC);
   EE.compile(CompilationMode::Train, TF);
 
@@ -1038,7 +1040,7 @@ TEST_P(InterpreterAndCPU, testFindPixelRegression) {
   EE.run({input}, {&testImages});
 
   // A handle to the projected result.
-  auto RH = result->getVariable()->getHandle<>();
+  auto RH = resultVar->getHandle<>();
   // A handle to the true label.
   auto LH = testLabels.getHandle<>();
 

--- a/tests/unittests/graphTest.cpp
+++ b/tests/unittests/graphTest.cpp
@@ -387,6 +387,26 @@ TEST(Graph, NodeValue) {
       24);
 }
 
+/// Check that by deleting one function, the variables that refernced
+/// by this function, will reduce its number of uses by one.
+TEST(Graph, deleteFunction) {
+  ExecutionEngine EE;
+  auto &mod = EE.getModule();
+  Function *F1 = mod.createFunction("f1");
+  auto *inputX = mod.createVariable(ElemKind::FloatTy, {1}, "input",
+                                    VisibilityKind::Public, true);
+  F1->createLog("log1", inputX);
+  Function *F2 = mod.createFunction("f2");
+  F2->createLog("log2", inputX);
+  // We check the number of user of inputX to be 2 as only F1 and F2 are 
+  // using it.
+  EXPECT_EQ(inputX->getNumUsers(), 2);
+  // Erase this function here to see if we can see the number of user of inputX
+  // reduce to 1.
+  mod.eraseFunction(F1);
+  EXPECT_EQ(inputX->getNumUsers(), 1);
+}
+
 TEST(Graph, nodesWithPredicates) {
   ExecutionEngine EE;
 

--- a/tests/unittests/quantizationTest.cpp
+++ b/tests/unittests/quantizationTest.cpp
@@ -201,7 +201,9 @@ TEST_P(Operator, end2end) {
   // STEP1 - Generate the first network to record the quantization parameters.
   Function *F1 = createSimpleGraphForQuantization(mod, A, B, "main");
   Function *F2 = F1->clone("main2");
-  SaveNode *result1 = cast<SaveNode>(F1->getNodeByName("save"));
+  SaveNode *SN1 =
+      cast<SaveNode>(F1->getNodeByName("save"));
+  Variable *result1Var = SN1->getVariable();  
 
   F1 = glow::profileQuantization(F1);
   interpreterEE.compile(CompilationMode::Infer, F1);
@@ -214,15 +216,17 @@ TEST_P(Operator, end2end) {
       quantization::generateNodeQuantizationInfos(F1);
 
   // STEP2 - Use the profile to quantize a network.
-  SaveNode *result2 = cast<SaveNode>(F2->getNodeByName("save"));
+  SaveNode *SN2 =
+      cast<SaveNode>(F2->getNodeByName("save"));
+  Variable *result2Var = SN2->getVariable();
 
   F2 = quantization::quantizeFunction(backendSpecificEE, QI, F2);
   backendSpecificEE.compile(CompilationMode::Infer, F2);
   backendSpecificEE.run({}, {});
 
   // STEP3 - Compare the results of the original and quantized functions.
-  auto result1Handle = result1->getVariable()->getHandle();
-  auto result2Handle = result2->getVariable()->getHandle();
+  auto result1Handle = result1Var->getHandle();
+  auto result2Handle = result2Var->getHandle();
 
   EXPECT_EQ(result1Handle.size(), result2Handle.size());
 
@@ -336,7 +340,9 @@ TEST_P(Quantization, end2endGRU) {
   auto *mod = &interpreterEE.getModule();
   Function *F1 = createGRUForQuantization(mod, "main");
   Function *F2 = F1->clone("main2");
-  SaveNode *result1 = cast<SaveNode>(F1->getNodeByName("save"));
+  SaveNode *SN1 =
+      cast<SaveNode>(F1->getNodeByName("save"));
+  Variable *result1Var = SN1->getVariable();
 
   F1 = glow::profileQuantization(F1);
   interpreterEE.compile(CompilationMode::Infer, F1);
@@ -349,15 +355,17 @@ TEST_P(Quantization, end2endGRU) {
       quantization::generateNodeQuantizationInfos(F1);
 
   // STEP2 - Use the profile to quantize a network.
-  SaveNode *result2 = cast<SaveNode>(F2->getNodeByName("save"));
+  SaveNode *SN2 =
+      cast<SaveNode>(F2->getNodeByName("save"));
+  Variable *result2Var = SN2->getVariable();
 
   F2 = quantization::quantizeFunction(backendSpecificEE, QI, F2);
   backendSpecificEE.compile(CompilationMode::Infer, F2);
   backendSpecificEE.run({}, {});
 
   // STEP3 - Compare the results of the original and quantized functions.
-  auto result1Handle = result1->getVariable()->getHandle();
-  auto result2Handle = result2->getVariable()->getHandle();
+  auto result1Handle = result1Var->getHandle();
+  auto result2Handle = result2Var->getHandle();
 
   EXPECT_EQ(result1Handle.size(), result2Handle.size());
 

--- a/tools/loader/ImageClassifier.cpp
+++ b/tools/loader/ImageClassifier.cpp
@@ -156,6 +156,10 @@ int main(int argc, char **argv) {
     i1 = LD.getVariableByName("data_0");
   }
 
+  // We want to have a way to reference the variable of SM node later, after 
+  // it is removed when we finish the quantization.
+  auto *SMVar = SM->getVariable();
+
   assert(i0->getVisibilityKind() == VisibilityKind::Public);
   assert(i1->getVisibilityKind() == VisibilityKind::Public);
 
@@ -168,7 +172,7 @@ int main(int argc, char **argv) {
     loader.runInference({i0, i1}, {&data, &data});
 
     // Print out the inferred image classification.
-    Tensor &res = SM->getVariable()->getPayload();
+    Tensor &res = SMVar->getPayload();
     auto H = res.getHandle<>();
     llvm::outs() << "Model: " << loader.getFunction()->getName() << "\n";
     for (unsigned i = 0; i < inputImageFilenames.size(); i++) {


### PR DESCRIPTION
This pr is due to the [issue](https://github.com/pytorch/glow/issues/1441) that we found some FP weights are not used after quantization anymore but they are not removed. 
The reason behind this bug, is that when we perform quantization on an existing function, we create a new quantized function, but we didn't remove the old, which still uses some non-quantized useless variables.
We propose the fix here to remove the old function after quantizing it, and it successfully helped the DCE remove those unused variables. 