### PR TITLE
Fix libjit/LLVMIRGen pool names to be consistent with Node/Instr names

### DIFF
--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -1600,7 +1600,7 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     auto *strides = emitConstArray(builder, PM->getStrides());
     auto *pads = emitConstArray(builder, PM->getPads());
 
-    auto *F = getFunction("pool_max", dest->getElementType());
+    auto *F = getFunction("max_pool", dest->getElementType());
     createCall(builder, F,
                {srcPtr, destPtr, srcDims, destDims, kernels, strides, pads});
     break;
@@ -1621,7 +1621,7 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     auto *strides = emitConstArray(builder, PMXY->getStrides());
     auto *pads = emitConstArray(builder, PMXY->getPads());
 
-    auto *F = getFunction("pool_max_xy", dest->getElementType());
+    auto *F = getFunction("max_pool_xy", dest->getElementType());
     createCall(
         builder, F,
         {srcPtr, destPtr, srcXYPtr, srcDims, destDims, kernels, strides, pads});
@@ -1638,7 +1638,7 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     auto *srcGradDims = emitValueDims(builder, srcGrad);
     auto *destDims = emitValueDims(builder, PMG->getDest());
 
-    auto *F = getFunction("pool_max_xy_grad", srcGrad->getElementType());
+    auto *F = getFunction("max_pool_xy_grad", srcGrad->getElementType());
     createCall(builder, F,
                {srcGradPtr, destGradPtr, srcXYPtr, srcGradDims, destDims});
     break;

--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -1674,13 +1674,13 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
       auto *outPost = emitConstI32(builder, outScaleParam.post);
       auto *outScale = emitConstI32(builder, outScaleParam.scale);
 
-      auto *F = getFunction("pool_avg", dest->getElementType());
+      auto *F = getFunction("avg_pool", dest->getElementType());
       createCall(builder, F,
                  {srcPtr, destPtr, srcDims, destDims, kernels, strides, pads,
                   destOffset, srcOffset, outPre, outPost, outScale});
       break;
     } else {
-      auto *F = getFunction("pool_avg", dest->getElementType());
+      auto *F = getFunction("avg_pool", dest->getElementType());
       createCall(builder, F,
                  {srcPtr, destPtr, srcDims, destDims, kernels, strides, pads});
       break;
@@ -1700,7 +1700,7 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     auto *strides = emitConstArray(builder, PAG->getStrides());
     auto *pads = emitConstArray(builder, PAG->getPads());
 
-    auto *F = getFunction("pool_avg_grad", srcGrad->getElementType());
+    auto *F = getFunction("avg_pool_grad", srcGrad->getElementType());
     createCall(builder, F,
                {srcGradPtr, destGradPtr, srcGradDims, destDims, kernels,
                 strides, pads});

--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -454,7 +454,7 @@ void libjit_transpose_generic(const T *inW, T *outW, const size_t *idim,
 }
 
 template <typename T>
-void libjit_pool_max_generic(const T *inW, T *outW, const size_t *inWdims,
+void libjit_max_pool_generic(const T *inW, T *outW, const size_t *inWdims,
                              const size_t *outWdims, size_t *filterSizes,
                              size_t *strides, size_t *pads) {
   size_t pad_t = pads[0];
@@ -506,7 +506,7 @@ void libjit_pool_max_generic(const T *inW, T *outW, const size_t *inWdims,
 }
 
 template <typename T>
-void libjit_pool_max_xy_generic(const T *inW, T *outW, size_t *inXY,
+void libjit_max_pool_xy_generic(const T *inW, T *outW, size_t *inXY,
                                 const size_t *inWdims, const size_t *outWdims,
                                 size_t *kernels, size_t *strides,
                                 size_t *pads) {
@@ -938,34 +938,34 @@ void libjit_local_response_normalization_grad_f(
   }     // N
 }
 
-void libjit_pool_max_i8(const int8_t *inW, int8_t *outW, const size_t *inWdims,
+void libjit_max_pool_i8(const int8_t *inW, int8_t *outW, const size_t *inWdims,
                         const size_t *outWdims, size_t *filterSizes,
                         size_t *strides, size_t *pads) {
-  libjit_pool_max_generic(inW, outW, inWdims, outWdims, filterSizes, strides,
+  libjit_max_pool_generic(inW, outW, inWdims, outWdims, filterSizes, strides,
                           pads);
 }
-void libjit_pool_max_f(const float *inW, float *outW, const size_t *inWdims,
+void libjit_max_pool_f(const float *inW, float *outW, const size_t *inWdims,
                        const size_t *outWdims, size_t *filterSizes,
                        size_t *strides, size_t *pads) {
-  libjit_pool_max_generic(inW, outW, inWdims, outWdims, filterSizes, strides,
+  libjit_max_pool_generic(inW, outW, inWdims, outWdims, filterSizes, strides,
                           pads);
 }
 
-void libjit_pool_max_xy_i8(const int8_t *inW, int8_t *outW, size_t *inXY,
+void libjit_max_pool_xy_i8(const int8_t *inW, int8_t *outW, size_t *inXY,
                            const size_t *inWdims, const size_t *outWdims,
                            size_t *kernels, size_t *strides, size_t *pads) {
-  libjit_pool_max_xy_generic(inW, outW, inXY, inWdims, outWdims, kernels,
+  libjit_max_pool_xy_generic(inW, outW, inXY, inWdims, outWdims, kernels,
                              strides, pads);
 }
 
-void libjit_pool_max_xy_f(const float *inW, float *outW, size_t *inXY,
+void libjit_max_pool_xy_f(const float *inW, float *outW, size_t *inXY,
                           const size_t *inWdims, const size_t *outWdims,
                           size_t *kernels, size_t *strides, size_t *pads) {
-  libjit_pool_max_xy_generic(inW, outW, inXY, inWdims, outWdims, kernels,
+  libjit_max_pool_xy_generic(inW, outW, inXY, inWdims, outWdims, kernels,
                              strides, pads);
 }
 
-void libjit_pool_max_xy_grad_f(float *inG, const float *outG,
+void libjit_max_pool_xy_grad_f(float *inG, const float *outG,
                                const size_t *inXY, const size_t *inGdims,
                                const size_t *outWdims) {
   // NHWC format is assumed

--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -994,7 +994,7 @@ void libjit_pool_max_xy_grad_f(float *inG, const float *outG,
   }       // N
 }
 
-void libjit_pool_avg_i8(const int8_t *inW, int8_t *outW, const size_t *inWdims,
+void libjit_avg_pool_i8(const int8_t *inW, int8_t *outW, const size_t *inWdims,
                         const size_t *outWdims, size_t *filterSizes,
                         size_t *strides, size_t *pads, int32_t outOffset,
                         int32_t inOffset, int32_t outPre, int32_t outPost,
@@ -1040,7 +1040,7 @@ void libjit_pool_avg_i8(const int8_t *inW, int8_t *outW, const size_t *inWdims,
   }       // N
 }
 
-void libjit_pool_avg_f(const float *inW, float *outW, const size_t *inWdims,
+void libjit_avg_pool_f(const float *inW, float *outW, const size_t *inWdims,
                        const size_t *outWdims, size_t *filterSizes,
                        size_t *strides, size_t *pads) {
   size_t pad_t = pads[0];
@@ -1084,7 +1084,7 @@ void libjit_pool_avg_f(const float *inW, float *outW, const size_t *inWdims,
   }       // N
 }
 
-void libjit_pool_avg_grad_f(float *inG, const float *outG,
+void libjit_avg_pool_grad_f(float *inG, const float *outG,
                             const size_t *inGdims, const size_t *outWdims,
                             size_t *kernels, size_t *strides, size_t *pads) {
   size_t pad_t = pads[0];


### PR DESCRIPTION
https://github.com/pytorch/glow/pull/1385 didn't change the names in libjit and LLVMIRGen -- this just makes it more consistent across the code base. Related to https://github.com/pytorch/glow/issues/1288