### PR TITLE
[Node] Allow axes equal to the rank of the tensor for Flatten

### DIFF
--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -155,14 +155,13 @@ struct ShapeHW {
 /// of the rest of the dimensions. For example, ([7, 3, 4, 2], 1) -> [7, 24]
 inline std::pair<size_t, size_t> flattenCdr(llvm::ArrayRef<size_t> dims,
                                             unsigned_t n = 1) {
-  assert(1 <= n && n < dims.size());
+  assert(1 <= n && n <= dims.size());
   size_t first = dims[0];
   for (unsigned_t i = 1; i < n; i++) {
     first *= dims[i];
   }
-
-  size_t rest = dims[n];
-  for (unsigned_t i = n + 1; i < dims.size(); i++) {
+  size_t rest = 1;
+  for (unsigned_t i = n; i < dims.size(); i++) {
     rest *= dims[i];
   }
 


### PR DESCRIPTION
Flatten takes a tensor of dimensions [d0, d1, ... dN] and an axis and
produces a 2D tensor of dimensions:
[d0 x d1 x ... x d_axis-1, d_axis x d_axis+1 x ... x dN]

Prior to this patch we would allow axes between [1; rank), where rank
is N + 1.
However, the caffe2 flatten operator allow to use axes up to rank.
In that case, the flattening consists in squashing all the dimensions
together and only have one row:
[d0 x d1 x ... x dN, 1]

This patch thus now allows axes between [1; rank] for the flatten operator.