### PR TITLE
[ModelRunner] Make leak sanitizer happy

### DIFF
--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -243,6 +243,9 @@ public:
 
     if (size()) {
       size_t count = size() * type_.getElementSize();
+      // We are allocating memory specifically for this tensor,
+      // thus, it owns it.
+      isUnowned_ = false;
       data_ = reinterpret_cast<char *>(alignedAlloc(count, TensorAlignment));
       zero();
     }

--- a/tools/loader/ModelRunner.cpp
+++ b/tools/loader/ModelRunner.cpp
@@ -22,6 +22,8 @@
 
 #include "llvm/Support/raw_ostream.h"
 
+#include <memory>
+
 using namespace glow;
 
 int main(int argc, char **argv) {
@@ -30,14 +32,14 @@ int main(int argc, char **argv) {
   Loader loader(argc, argv);
 
   // Create the model based on the input net, and get SaveNode for the output.
-  ProtobufLoader *LD;
+  std::unique_ptr<ProtobufLoader> LD;
   if (!loader.getCaffe2NetDescFilename().empty()) {
-    LD = new caffe2ModelLoader(loader.getCaffe2NetDescFilename(),
-                               loader.getCaffe2NetWeightFilename(), {}, {},
-                               *loader.getFunction());
+    LD.reset(new caffe2ModelLoader(loader.getCaffe2NetDescFilename(),
+                                   loader.getCaffe2NetWeightFilename(), {}, {},
+                                   *loader.getFunction()));
   } else {
-    LD = new ONNXModelLoader(loader.getOnnxModelFilename(), {}, {},
-                             *loader.getFunction());
+    LD.reset(new ONNXModelLoader(loader.getOnnxModelFilename(), {}, {},
+                                 *loader.getFunction()));
   }
   SaveNode *output = LD->getSingleOutput();
 


### PR DESCRIPTION
When running the model-runner, we don't explicitly delete the loader
that we dynamically allocate. Although the memory will be reclaimed
at the end of the process, this made leak sanitizer to complain.

NFC.