### PR TITLE
[LLVMIRGen] Make sure path delimiters don't result in empty entry names

### DIFF
--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -103,10 +103,33 @@ void LLVMIRGen::initTargetMachine(llvm::StringRef T,
 std::string LLVMIRGen::getMainEntryName() const {
   llvm::StringRef name =
       mainEntryName_.empty() ? "main" : F_->getGraph()->getName();
-  auto delimPos = name.rfind('/');
-  if (delimPos != llvm::StringRef::npos)
-    name = name.substr(delimPos + 1);
-  return name;
+
+  // The name may finish with '/' and taking the last token
+  // after '/' will produce an empty name.
+  // If that's the case, move to the next '/' to
+  // try to find a non-empty token.
+  size_t delimPos = name.size();
+  llvm::StringRef entryName;
+  do {
+    auto slashPos = name.rfind('/', delimPos);
+    if (slashPos != llvm::StringRef::npos) {
+      entryName = name.substr(slashPos + 1,
+                              /*length = end - start*/ delimPos - slashPos - 1);
+      delimPos = slashPos;
+    } else {
+      // There is no more slashes, the resulting name
+      // is from the beginning of the string to the last
+      // slash we found.
+      entryName = name.substr(0, delimPos);
+      break;
+    }
+  } while (entryName.empty() && delimPos != 0);
+
+  // The name looks like "////" just come up with a default name.
+  if (entryName.empty()) {
+    entryName = "main";
+  }
+  return entryName;
 }
 
 void LLVMIRGen::setMainEntryName(std::string name) { mainEntryName_ = name; }

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -192,6 +192,19 @@ target_link_libraries(GemmTest
                         testMain)
 add_glow_test(GemmTest ${GLOW_BINARY_DIR}/tests/GemmTest)
 LIST(APPEND UNOPT_TESTS ./tests/GemmTest -optimize-ir=false &&)
+
+add_executable(LLVMIRGenTest
+               LLVMIRGenTest.cpp)
+target_link_libraries(LLVMIRGenTest
+                      PRIVATE
+                        CPUBackend
+                        IR
+                        Support
+                        gtest
+                        testMain)
+target_include_directories(LLVMIRGenTest PUBLIC ${CMAKE_SOURCE_DIR}/lib/Backends/CPU)
+add_glow_test(LLVMIRGenTest ${GLOW_BINARY_DIR}/tests/LLVMIRGenTest)
+
 endif()
 
 add_executable(memoryAllocatorTest

--- a/tests/unittests/LLVMIRGenTest.cpp
+++ b/tests/unittests/LLVMIRGenTest.cpp
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "LLVMIRGen.h"
+#include "AllocationsInfo.h"
+
+#include "glow/Graph/Graph.h"
+#include "glow/IR/IR.h"
+
+#include "gtest/gtest.h"
+
+using namespace glow;
+
+#ifndef GLOW_WITH_CPU
+#error "This shouldn't be compiled without the CPU backend"
+#endif
+
+/// Check that we get a non-empty entry name for various
+/// situation.
+TEST(LLVMIRGen, getEntryName) {
+  Module mod;
+  Function *func = mod.createFunction("funcname");
+  IRFunction irfunc(func);
+  AllocationsInfo allocInfo;
+  LLVMIRGen llvmIRGen(&irfunc, allocInfo, "name");
+  // FIXME: We actually use the name of the high level function
+  // as soon as the name we set for LLVMIRGen is not empty.
+  EXPECT_EQ(llvmIRGen.getMainEntryName(), "funcname");
+
+  // FIXME: Disturbing enough the setter doesn't help with the situation.
+  llvmIRGen.setMainEntryName("customName");
+  EXPECT_EQ(llvmIRGen.getMainEntryName(), "funcname");
+
+  // If we set an empty name we get "main".
+  llvmIRGen.setMainEntryName("");
+  EXPECT_EQ(llvmIRGen.getMainEntryName(), "main");
+
+  // Now check that we get a reasonable naming when we are given paths
+  // for the function names. This happens when using the BundleSaver.
+  // In that context, the entry name is used to create files.
+  // Therefore it should not include path delimiters.
+
+  // FIXME: Given the behavior of setMainEntryName, the only way to
+  // change the name is to change the name of the function.
+  func = mod.createFunction("path/to/model_dir");
+  IRFunction irfuncTmp(func);
+  LLVMIRGen llvmIRGenTmp(&irfuncTmp, allocInfo, "name");
+
+  // Check that we only get the last part of the path.
+  EXPECT_EQ(llvmIRGenTmp.getMainEntryName(), "model_dir");
+
+  // Now end the name with a delimiter.
+  func = mod.createFunction("path/to/model_dir/");
+  IRFunction irfuncTmp1(func);
+  LLVMIRGen llvmIRGenTmp1(&irfuncTmp1, allocInfo, "name");
+
+  // Check that we only get the last part of the path.
+  EXPECT_EQ(llvmIRGenTmp1.getMainEntryName(), "model_dir");
+
+  // Now end the name with several delimiters.
+  func = mod.createFunction("path/to/model_dir////");
+  IRFunction irfuncTmp2(func);
+  LLVMIRGen llvmIRGenTmp2(&irfuncTmp2, allocInfo, "name");
+
+  // Check that we only get the last part of the path.
+  EXPECT_EQ(llvmIRGenTmp2.getMainEntryName(), "model_dir");
+
+  // Now with several delimiters sparkled around.
+  func = mod.createFunction("//path/to///model_dir////");
+  IRFunction irfuncTmp3(func);
+  LLVMIRGen llvmIRGenTmp3(&irfuncTmp3, allocInfo, "name");
+
+  // Check that we only get the last part of the path.
+  EXPECT_EQ(llvmIRGenTmp3.getMainEntryName(), "model_dir");
+
+  // Empty name should return a non-null name.
+  func = mod.createFunction("");
+  IRFunction irfuncTmp4(func);
+  LLVMIRGen llvmIRGenTmp4(&irfuncTmp4, allocInfo, "name");
+
+  // Check that we only get the last part of the path.
+  EXPECT_EQ(llvmIRGenTmp4.getMainEntryName(), "main");
+
+  // Finally, only delimiters should return a non-null name.
+  func = mod.createFunction("////");
+  IRFunction irfuncTmp5(func);
+  LLVMIRGen llvmIRGenTmp5(&irfuncTmp5, allocInfo, "name");
+
+  // Check that we only get the last part of the path.
+  EXPECT_EQ(llvmIRGenTmp5.getMainEntryName(), "main");
+}


### PR DESCRIPTION
Prior to this patch setting a name ending with '/' would produce an
empty entry name. Combined with the bundle saver, it was possible to
end up with an empty name being appended to the files saved.

E.g.,
$ model-runner -model model -emit-bundle output
Would produce in output:
model.o
model.weights

But
$ model-runner -model model/ -emit-bundle output
Would produce in output:
.o
.weights

Thus, under unix those are hidden files and one could think the bundler
did not work.

This patch makes sure the entry name is never empty by walking back the '/'
until it finds a non-empty name or the beginning of the string.