### PR TITLE
[openCL] add group param to conv for OpenCL backend

### DIFF
--- a/include/glow/Backends/LayoutConverter.h
+++ b/include/glow/Backends/LayoutConverter.h
@@ -25,9 +25,6 @@ namespace glow {
 /// convolution nodes using NCHW.
 template <class NCHWConvNode>
 Node *convertConvToNCHWConv(ConvolutionNode *CN, Function *F) {
-  assert(CN->getGroup() == 1 &&
-         "Group Convolution is not supported for NCHW layout.");
-
   // Convert filter and input from NHWC (Glow's default) into NCHW.
   auto *NI = F->createTranspose("conv.input", CN->getInput(), NHWC2NCHW);
   auto *NF = F->createTranspose("conv.filter", CN->getFilter(), NHWC2NCHW);
@@ -37,9 +34,9 @@ Node *convertConvToNCHWConv(ConvolutionNode *CN, Function *F) {
   auto outTy = F->getParent()->uniqueTypeWithNewShape(CN->getResult().getType(),
                                                       dimsNCHW);
 
-  auto *NC = F->addNode(new NCHWConvNode(CN->getName(), outTy, NI, NF,
-                                         CN->getBias(), CN->getKernels(),
-                                         CN->getStrides(), CN->getPads()));
+  auto *NC = F->addNode(new NCHWConvNode(
+      CN->getName(), outTy, NI, NF, CN->getBias(), CN->getKernels(),
+      CN->getStrides(), CN->getPads(), CN->getGroup()));
   auto NR = F->createTranspose("conv.result", NC, NCHW2NHWC);
 
   return NR;

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -399,6 +399,14 @@ void OpenCLFunction::executeConvolution(const OCLConvolutionInst *CC) {
   PaddingTLBR pads(CC->getPads());
   ShapeHW kdim(CC->getKernels());
   ShapeHW sdim(CC->getStrides());
+  unsigned group = CC->getGroup();
+  // So far, we don't support fast convolution kernel if group > 1.
+  // For group convolution, the slow convolution kernel should be invoked.
+  // The following assertion should be removed once the group > 1 is supported
+  // in fast convolution kernel.
+  assert(group == 1 && "Group Convolution is not supported by OpenCL backend's "
+                       "fast convolution kernel.");
+
   // Create options for compiling the program.
   // Don't use names M, N, K as they are defined in precompiled headers.
 
@@ -406,7 +414,7 @@ void OpenCLFunction::executeConvolution(const OCLConvolutionInst *CC) {
   // Number of spacial axes.
   addIntOption(options, "v_nax", 2);
   // Number of groups.
-  addIntOption(options, "v_g", 1);
+  addIntOption(options, "v_g", group);
   // Parameters for kernel size, padding and stride
   addIntOption(options, "v_k_0", kdim.height);
   addIntOption(options, "v_k_1", kdim.width);
@@ -501,7 +509,6 @@ void OpenCLFunction::executeConvolution(const OCLConvolutionInst *CC) {
   }
 
   // Compute proper parameters for global work and workgroups.
-  int group = 1;
   auto fw_wgs0 = wg_size[0];
   auto fw_wgs1 = wg_size[1];
   int fw_wptn = WPTN;
@@ -914,10 +921,6 @@ void OpenCLFunction::execute() {
       cl_kernel kernel = createKernel(kernelName);
       setKernelArg(kernel, 0, deviceBuffer_);
       auto numArgs = setKernelArgsForBuffers(kernel, I, 1, tensors_);
-
-      assert(CC->getGroup() == 1 &&
-             "Group Convolution is not supported by OpenCL backend.");
-
       auto odim = ShapeNHWC(CC->getDest()->getType()->dims());
       auto idim = ShapeNHWC(CC->getSrc()->getType()->dims());
       auto pads = PaddingTLBR(CC->getPads());
@@ -926,23 +929,24 @@ void OpenCLFunction::execute() {
       setKernelArg(kernel, numArgs + 1, kdim);
       setKernelArg(kernel, numArgs + 2, sdim);
       setKernelArg(kernel, numArgs + 3, pads);
-      setKernelArg(kernel, numArgs + 4, odim);
-      setKernelArg(kernel, numArgs + 5, idim);
-      setKernelArg(kernel, numArgs + 6,
+      setKernelArg(kernel, numArgs + 4, CC->getGroup());
+      setKernelArg(kernel, numArgs + 5, odim);
+      setKernelArg(kernel, numArgs + 6, idim);
+      setKernelArg(kernel, numArgs + 7,
                    ShapeNHWC(CC->getFilter()->getType()->dims()));
       if (isQuantized) {
         auto srcTy = CC->getSrc()->getType();
         auto destTy = CC->getDest()->getType();
         auto filterTy = CC->getFilter()->getType();
         auto biasTy = CC->getBias()->getType();
-        setKernelArg(kernel, numArgs + 7, destTy->getOffset());
-        setKernelArg(kernel, numArgs + 8, destTy->getScale());
-        setKernelArg(kernel, numArgs + 9, srcTy->getOffset());
-        setKernelArg(kernel, numArgs + 10, srcTy->getScale());
-        setKernelArg(kernel, numArgs + 11, filterTy->getOffset());
-        setKernelArg(kernel, numArgs + 12, filterTy->getScale());
-        setKernelArg(kernel, numArgs + 13, biasTy->getOffset());
-        setKernelArg(kernel, numArgs + 14, biasTy->getScale());
+        setKernelArg(kernel, numArgs + 8, destTy->getOffset());
+        setKernelArg(kernel, numArgs + 9, destTy->getScale());
+        setKernelArg(kernel, numArgs + 10, srcTy->getOffset());
+        setKernelArg(kernel, numArgs + 11, srcTy->getScale());
+        setKernelArg(kernel, numArgs + 12, filterTy->getOffset());
+        setKernelArg(kernel, numArgs + 13, filterTy->getScale());
+        setKernelArg(kernel, numArgs + 14, biasTy->getOffset());
+        setKernelArg(kernel, numArgs + 15, biasTy->getScale());
       }
 
       // Use a 3D grid where the first dimension is the depth and the second
@@ -953,9 +957,6 @@ void OpenCLFunction::execute() {
     }
 
     if (auto *CG = dyn_cast<ConvolutionGradInst>(&I)) {
-      assert(CG->getGroup() == 1 &&
-             "Group Convolution is not supported by OpenCL backend.");
-
       auto *src = CG->getSrc();
       auto *filter = CG->getFilter();
       auto *destGrad = CG->getDestGrad();
@@ -975,10 +976,10 @@ void OpenCLFunction::execute() {
       setKernelArg(kernel, numArgs + 1, kdim);
       setKernelArg(kernel, numArgs + 2, sdim);
       setKernelArg(kernel, numArgs + 3, pads);
-      setKernelArg(kernel, numArgs + 4, srcDim);
-      setKernelArg(kernel, numArgs + 5, destGradDim);
-      setKernelArg(kernel, numArgs + 6, filterGradDim);
-
+      setKernelArg(kernel, numArgs + 4, CG->getGroup());
+      setKernelArg(kernel, numArgs + 5, srcDim);
+      setKernelArg(kernel, numArgs + 6, destGradDim);
+      setKernelArg(kernel, numArgs + 7, filterGradDim);
       // Zero memory for the output buffers.
       fillBuffer(deviceBuffer_, tensors_[srcGrad], srcGrad->size(), 0,
                  srcGrad->getElementType());

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -20,7 +20,7 @@
 #include "glow/Backends/CompiledFunction.h"
 #include "glow/Base/Tensor.h"
 #include "glow/Base/Traits.h"
-
+#include "glow/Graph/Node.h"
 #include "llvm/ADT/ArrayRef.h"
 
 #include <unordered_map>
@@ -205,6 +205,14 @@ public:
     }
     return true;
   };
+
+  bool shouldLower(const Node *N) const override {
+    // The group convolution is supported in OpenCL slow convolution kernel.
+    if (N->getKind() == Kinded::Kind::ConvolutionNodeKind)
+      return false;
+    return true;
+  }
+
   /// @}
 };
 

--- a/lib/Backends/OpenCL/Transforms.cpp
+++ b/lib/Backends/OpenCL/Transforms.cpp
@@ -36,6 +36,11 @@ bool OCLBackend::transformPostLowering(Function *F,
   bool changed = false;
   for (auto &node : F->getNodes()) {
     if (auto *CN = dyn_cast<ConvolutionNode>(&node)) {
+      // TODO: OpenCL fast convolution kernel itself has some issue with group >
+      // 1, which will be investigated later. So far, if the group > 1, we just
+      // call the slow convolution kernel.
+      if (CN->getGroup() > 1)
+        continue;
       auto *NR = convertConvToNCHWConv<OCLConvolutionNode>(CN, F);
       NodeValue(&node, 0).replaceAllUsesOfWith(NR);
       changed = true;

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -2278,7 +2278,7 @@ TEST_P(Operator, IntSplat) {
   }
 }
 
-TEST_P(InterpAndCPU, GroupConvolution) {
+TEST_P(Operator, GroupConvolution) {
   auto *input = mod_.createVariable(ElemKind::FloatTy, {1, 2, 1, 8}, "input");
   auto IH = input->getHandle();
   for (size_t i = 0; i < 2 * 8; i++) {

--- a/tests/unittests/graphTest.cpp
+++ b/tests/unittests/graphTest.cpp
@@ -469,8 +469,7 @@ unsigned getConvNodeSize(BackendKind kind) {
 }
 
 // Check the unrolling grouped convolution opt status:
-// -- disabled for Interpreter and CPU backend,
-// -- enabled for openCL backend.
+// -- disabled for Interpreter, CPU and OpenCL backend,
 TEST(Graph, disableUnrollingGroupConv) {
   unsigned numberOfNodesInterpreter = getConvNodeSize(BackendKind::Interpreter);
   (void)numberOfNodesInterpreter;
@@ -482,7 +481,7 @@ TEST(Graph, disableUnrollingGroupConv) {
 
 #ifdef GLOW_WITH_OPENCL
   unsigned numberOfNodesOpenCL = getConvNodeSize(BackendKind::OpenCL);
-  EXPECT_GT(numberOfNodesOpenCL, numberOfNodesInterpreter);
+  EXPECT_EQ(numberOfNodesOpenCL, numberOfNodesInterpreter);
 #endif // GLOW_WITH_OPENCL
 }
 

--- a/tools/ClassGen/Backends/OpenCL/OpenCLSpecificInstrs.h
+++ b/tools/ClassGen/Backends/OpenCL/OpenCLSpecificInstrs.h
@@ -24,6 +24,7 @@ BB.newBackendSpecificInstr("OCLConvolution")
     .addMember(MemberType::VectorUnsigned, "Kernels")
     .addMember(MemberType::VectorUnsigned, "Strides")
     .addMember(MemberType::VectorUnsigned, "Pads")
+    .addMember(MemberType::Unsigned, "Group")
     .autoIRGen()
     .autoVerify(VerifyKind::SameElementType, {"Dest", "Src", "Filter", "Bias"});
 

--- a/tools/ClassGen/Backends/OpenCL/OpenCLSpecificNodes.h
+++ b/tools/ClassGen/Backends/OpenCL/OpenCLSpecificNodes.h
@@ -23,6 +23,7 @@ BB.newNode("OCLConvolution")
     .addMember(MemberType::VectorUnsigned, "Kernels")
     .addMember(MemberType::VectorUnsigned, "Strides")
     .addMember(MemberType::VectorUnsigned, "Pads")
+    .addMember(MemberType::Unsigned, "Group")
     .addResultFromCtorArg()
     .setDocstring(
         "This is an OpenCL-specific convolution implementation where the "


### PR DESCRIPTION
OpenCL fast kernel for group (group > 1) convolution has some issues which are need to be investigated further. Now for group conv, we only call the slow kernel. 