### PR TITLE
Make sure that MemoryAllocator uses wide-enough unsigned types for reresenting the address space being allocated

### DIFF
--- a/include/glow/CodeGen/MemoryAllocator.h
+++ b/include/glow/CodeGen/MemoryAllocator.h
@@ -25,17 +25,17 @@ namespace glow {
 class Segment {
 public:
   /// The allocation starts at this address.
-  size_t begin_;
+  uint64_t begin_;
   /// The allocation ends before this address (half-open interval).
-  size_t end_;
+  uint64_t end_;
 
-  Segment(size_t begin, size_t end) : begin_(begin), end_(end) {}
+  Segment(uint64_t begin, uint64_t end) : begin_(begin), end_(end) {}
 
   /// \returns the size of the interval.
-  size_t size() const { return end_ - begin_; }
+  uint64_t size() const { return end_ - begin_; }
 
   /// \returns True if the value \p idx falls within this segment.
-  bool contains(size_t idx) const { return idx >= begin_ && idx < end_; }
+  bool contains(uint64_t idx) const { return idx >= begin_ && idx < end_; }
 };
 
 /// Allocates segments of memory.
@@ -43,15 +43,15 @@ class MemoryAllocator {
   /// A list of live buffers.
   std::list<Segment> allocations_;
   /// The size of the memory region that we can allocate segments into.
-  size_t poolSize_;
+  uint64_t poolSize_;
   /// This is the high water mark for the allocated memory.
-  size_t maxMemoryAllocated_{0};
+  uint64_t maxMemoryAllocated_{0};
 
 public:
   /// A reserved value to mark invalid allocation.
-  static const size_t npos;
+  static const uint64_t npos;
 
-  explicit MemoryAllocator(size_t poolSize) : poolSize_(poolSize) {}
+  explicit MemoryAllocator(uint64_t poolSize) : poolSize_(poolSize) {}
 
   void reset() {
     maxMemoryAllocated_ = 0;
@@ -59,7 +59,7 @@ public:
   }
 
   /// \returns True if the value \p idx is within the currently allocated range.
-  bool contains(size_t idx) const {
+  bool contains(uint64_t idx) const {
     for (auto &s : allocations_) {
       if (s.contains(idx)) {
         return true;
@@ -71,13 +71,13 @@ public:
   /// Allocate a region of size \p size.
   /// \returns the allocated pointer, or MemoryAllocator::npos, if the
   /// allocation failed.
-  size_t allocate(size_t size);
+  uint64_t allocate(uint64_t size);
 
   /// Frees the allocation at \p ptr.
-  void deallocate(size_t ptr);
+  void deallocate(uint64_t ptr);
 
   /// \returns the high water mark for the allocated memory.
-  size_t getMaxMemoryUsage() const { return maxMemoryAllocated_; }
+  uint64_t getMaxMemoryUsage() const { return maxMemoryAllocated_; }
 };
 
 } // namespace glow

--- a/lib/Backends/CPU/AllocationsInfo.cpp
+++ b/lib/Backends/CPU/AllocationsInfo.cpp
@@ -101,7 +101,7 @@ void AllocationsInfo::allocateActivations(const IRFunction *F) {
   MemoryAllocator activationsAllocator(0);
 
   // Maps activations and views to some offset within the heap.
-  llvm::DenseMap<const Value *, size_t> activationAddr;
+  llvm::DenseMap<const Value *, uint64_t> activationAddr;
 
   // Assign device-space addresses to the activations.
   for (const auto &I : F->getInstrs()) {

--- a/lib/Backends/CPU/AllocationsInfo.h
+++ b/lib/Backends/CPU/AllocationsInfo.h
@@ -38,7 +38,7 @@ struct AllocationsInfo {
   /// numberOffsets_[valueNumbers_[v]]
 
   /// Maps Values in the module to their offsets.
-  llvm::DenseMap<const Value *, size_t> allocatedAddressed_;
+  llvm::DenseMap<const Value *, uint64_t> allocatedAddressed_;
   /// Amount of memory to be allocated for constant WeightVars.
   size_t constantWeightVarsMemSize_{0};
   /// Amount of memory to be allocated for mutable WeightVars.

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -211,7 +211,7 @@ void setKernelArg(cl_kernel kernel, unsigned argIdx, T value) {
 static size_t
 setKernelArgsForBuffers(cl_kernel kernel, const Instruction &I,
                         size_t nextKernelArgIdx,
-                        std::unordered_map<const Value *, size_t> &tensors) {
+                        std::unordered_map<const Value *, uint64_t> &tensors) {
   // Number of instruction operands.
   auto numArgs = I.getNumOperands();
   // The predicate of the instruction if available.
@@ -232,7 +232,7 @@ setKernelArgsForBuffers(cl_kernel kernel, const Instruction &I,
   return kernelArgIdx - 1;
 }
 
-void OpenCLFunction::fillBuffer(cl_mem buffer, size_t start, size_t len,
+void OpenCLFunction::fillBuffer(cl_mem buffer, uint64_t start, uint64_t len,
                                 float value, ElemKind elemKind) {
   auto kernel = createKernel(getKernelName("splat", elemKind));
   setKernelArg(kernel, 0, buffer);
@@ -1293,8 +1293,8 @@ void OpenCLFunction::execute() {
                           << " bytes from OpenCL device\n");
 }
 
-size_t OpenCLFunction::copyValueToDevice(const Value *v, void *buf) {
-  size_t copiedBytes = 0;
+uint64_t OpenCLFunction::copyValueToDevice(const Value *v, void *buf) {
+  uint64_t copiedBytes = 0;
   auto it = tensors_.find(v);
   assert(it != tensors_.end() && "Unknown value");
   size_t sizeInBytes = v->getType()->getSizeInBytes();
@@ -1320,8 +1320,8 @@ size_t OpenCLFunction::copyValueToDevice(const Value *v, void *buf) {
   return copiedBytes;
 }
 
-size_t OpenCLFunction::copyValueFromDevice(const Value *v, void *buf) {
-  size_t copiedBytes = 0;
+uint64_t OpenCLFunction::copyValueFromDevice(const Value *v, void *buf) {
+  uint64_t copiedBytes = 0;
   auto it = tensors_.find(v);
   assert(it != tensors_.end() && "Unknown value");
   size_t sizeInBytes = v->getType()->getSizeInBytes();
@@ -1349,8 +1349,8 @@ size_t OpenCLFunction::copyValueFromDevice(const Value *v, void *buf) {
   return copiedBytes;
 }
 
-size_t OpenCLFunction::copyMutableWeightsToDevice() {
-  size_t copiedBytes = 0;
+uint64_t OpenCLFunction::copyMutableWeightsToDevice() {
+  uint64_t copiedBytes = 0;
   for (auto it : tensors_) {
     if (!externalTensors_.count(it.first)) {
       continue;
@@ -1366,8 +1366,8 @@ size_t OpenCLFunction::copyMutableWeightsToDevice() {
   return copiedBytes;
 }
 
-size_t OpenCLFunction::copyConstantWeightsToDevice() {
-  size_t copiedBytes = 0;
+uint64_t OpenCLFunction::copyConstantWeightsToDevice() {
+  uint64_t copiedBytes = 0;
   for (auto it : tensors_) {
     if (!externalTensors_.count(it.first)) {
       continue;
@@ -1383,7 +1383,7 @@ size_t OpenCLFunction::copyConstantWeightsToDevice() {
   return copiedBytes;
 }
 
-size_t OpenCLFunction::copyMutableWeightsFromDevice() {
+uint64_t OpenCLFunction::copyMutableWeightsFromDevice() {
   size_t copiedBytes = 0;
   clFinish(commands_);
 
@@ -1456,7 +1456,7 @@ void OpenCLFunction::allocateMemory() {
 
   // Ask the memory allocator how much memory is required. What was the high
   // watermark for this program.
-  size_t requiredSpace = allocator.getMaxMemoryUsage();
+  uint64_t requiredSpace = allocator.getMaxMemoryUsage();
   DEBUG_GLOW(llvm::dbgs() << "Allocated GPU memory block of size: "
                           << requiredSpace << "\n");
 
@@ -1477,8 +1477,8 @@ Tensor *OpenCLFunction::getTensor(const Value *v) const {
   return ie->second;
 }
 
-cl_mem OpenCLFunction::allocDeviceBuffer(size_t size) {
-  const size_t alignment = 128;
+cl_mem OpenCLFunction::allocDeviceBuffer(uint64_t size) {
+  const uint64_t alignment = 128;
   // Always allocate buffers properly aligned to hold values of any type.
   size = alignedSize(size, alignment);
   auto buf =

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -71,7 +71,7 @@ class OpenCLFunction final : public CompiledFunction {
   std::unique_ptr<IRFunction> F_;
   /// Maps values to on-device buffers. This list includes both weights and
   /// activations.
-  std::unordered_map<const Value *, size_t> tensors_;
+  std::unordered_map<const Value *, uint64_t> tensors_;
   /// Maps values to Tensors, that are *not* owned by this class.
   std::unordered_map<const Value *, Tensor *> externalTensors_;
   /// CL compute device id.
@@ -107,31 +107,31 @@ private:
   /// Copy the value from a device to a provided buffer.
   /// If \p buf is nullptr, the payload of the underlying tensor is used.
   /// \returns number of copied bytes.
-  size_t copyValueFromDevice(const Value *v, void *buf = nullptr);
+  uint64_t copyValueFromDevice(const Value *v, void *buf = nullptr);
   /// Copy value from the provided buffer to the device.
   /// If \p buf is nullptr, the payload of the underlying tensor is used.
   /// \returns number of copied bytes.
-  size_t copyValueToDevice(const Value *v, void *buf = nullptr);
+  uint64_t copyValueToDevice(const Value *v, void *buf = nullptr);
   /// Copy mutable weights to the device.
   /// \returns number of copied bytes.
-  size_t copyMutableWeightsToDevice();
+  uint64_t copyMutableWeightsToDevice();
   /// Copy constant weights to the device.
   /// \returns number of copied bytes.
-  size_t copyConstantWeightsToDevice();
+  uint64_t copyConstantWeightsToDevice();
   /// Copy mutable weights from the device.
   /// \returns number of copied bytes.
-  size_t copyMutableWeightsFromDevice();
+  uint64_t copyMutableWeightsFromDevice();
 
   /// Fill the device \p buffer with a given \p value.
   /// \param len number of buffer elements to be filled by the \p value.
   /// Elements are considered to be of the type described by \p elemKind.
-  void fillBuffer(cl_mem buffer, size_t start, size_t len, float value,
+  void fillBuffer(cl_mem buffer, uint64_t start, uint64_t len, float value,
                   ElemKind elemKind);
 
   /// Execution a convolution instruction which uses NCHW format.
   void executeConvolution(const OCLConvolutionInst *CC);
   /// Allocate a device buffer of required \p size.
-  cl_mem allocDeviceBuffer(size_t size);
+  cl_mem allocDeviceBuffer(uint64_t size);
   /// Frees a device buffer.
   void freeDeviceBuffer(cl_mem buf);
 


### PR DESCRIPTION
The types should be able to represent any address in the address space of the device, whose memory is being allocated by means of the MemoryAllocator. This device may be different from the host running Glow. E.g. Glow may run on a host with a 32-bit address space, but use a  MemoryAllocator for a GPU or an accelerator with a 64-bit address space.

Therefore, to be on the safe side use `uint64_t` instead of `size_t` in MemoryAllocator APIs.

Update the user's of the API to use `uint64_t` instead of `size_t`.