### PR TITLE
GLOW_ASSERT and GLOW_UNREACHABLE should write messages to stderr

### DIFF
--- a/include/glow/Support/Compiler.h
+++ b/include/glow/Support/Compiler.h
@@ -25,9 +25,10 @@
 #define GLOW_ASSERT(e)                                                         \
   ((void)((e) ? ((void)0) : GLOW_ASSERT_IMPL(#e, __FILE__, __LINE__)))
 #define GLOW_ASSERT_IMPL(e, file, line)                                        \
-  ((void)printf("%s:%u: failed assertion `%s'\n", file, line, e), abort())
+  ((void)fprintf(stderr, "%s:%u: failed assertion `%s'\n", file, line, e),     \
+   abort())
 
 #define GLOW_UNREACHABLE(msg)                                                  \
-  ((void)printf("%s:%u: %s\n", __FILE__, __LINE__, msg), abort())
+  ((void)fprintf(stderr, "%s:%u: %s\n", __FILE__, __LINE__, msg), abort())
 
 #endif // GLOW_SUPPORT_COMPILER_H


### PR DESCRIPTION
As `GLOW_ASSERT` and `GLOW_UNREACHABLE` are supposed to be the drop-in replacements for `assert` and `llvm_unreachable` in terms of APIs, they should use the same output stream, which is stderr. It also helps with testing, as some testing frameworks like `gtest` allow for testing the assertions and expect the messages to be written to stderr.