### PR TITLE
Extend MemoryAllocator to handle evictions and to support handles

### DIFF
--- a/include/glow/CodeGen/MemoryAllocator.h
+++ b/include/glow/CodeGen/MemoryAllocator.h
@@ -18,6 +18,9 @@
 #include <cstddef>
 #include <cstdint>
 #include <list>
+#include <set>
+#include <unordered_map>
+#include <vector>
 
 namespace glow {
 
@@ -39,15 +42,17 @@ public:
 };
 
 /// Allocates segments of memory.
+/// Each allocation is associated with a user-defined handle, typically
+/// representing a client-specific object, e.g. a handle can be a `Value *` and
+/// represent a value whose payload is going to be stored in the allocated
+/// memory block. This simplifies the clients of MemoryAllocator and allows them
+/// to use higher-level client-side objects instead of raw allocated addresses
+/// to refer to the allocated memory blocks.
 class MemoryAllocator {
-  /// A list of live buffers.
-  std::list<Segment> allocations_;
-  /// The size of the memory region that we can allocate segments into.
-  uint64_t poolSize_;
-  /// This is the high water mark for the allocated memory.
-  uint64_t maxMemoryAllocated_{0};
-
 public:
+  /// Type that should be used as a handle.
+  using Handle = const void *;
+
   /// A reserved value to mark invalid allocation.
   static const uint64_t npos;
 
@@ -56,6 +61,8 @@ public:
   void reset() {
     maxMemoryAllocated_ = 0;
     allocations_.clear();
+    handleToAddr_.clear();
+    addrToHandle_.clear();
   }
 
   /// \returns True if the value \p idx is within the currently allocated range.
@@ -68,16 +75,65 @@ public:
     return false;
   }
 
-  /// Allocate a region of size \p size.
+  /// Allocate a region of size \p size and associate a \p handle with it.
   /// \returns the allocated pointer, or MemoryAllocator::npos, if the
   /// allocation failed.
-  uint64_t allocate(uint64_t size);
+  uint64_t allocate(uint64_t size, Handle handle);
 
-  /// Frees the allocation at \p ptr.
-  void deallocate(uint64_t ptr);
+  /// Allocate a region of size \p size and associate a handle \p Handle with
+  /// it. If the allocation is not possible, the allocator should try to evict
+  /// some entries that are not needed at the moment, but it is not allowed to
+  /// evict any entries from \p mustNotEvict set. All evicted entries are stored
+  /// in the \p evicted set.
+  ///
+  /// \returns the allocated pointer, or MemoryAllocator::npos, if the
+  /// allocation failed.
+  uint64_t allocate(uint64_t size, Handle handle,
+                    const std::set<Handle> &mustNotEvict,
+                    std::vector<Handle> &evicted);
+
+  /// \returns the handle currently associated with the allocation at \p
+  /// address.
+  Handle getHandle(uint64_t ptr) const;
+
+  /// \returns true if there is a handle currently associated with the
+  /// allocation at \p address.
+  bool hasHandle(uint64_t ptr) const;
+
+  /// \returns the address currently associated with the \p handle.
+  uint64_t getAddress(Handle handle) const;
+
+  /// \returns true if there is an address currently associated with the \p
+  /// handle.
+  bool hasAddress(Handle handle) const;
+
+  /// Frees the allocation associated with \p handle.
+  void deallocate(Handle handle);
 
   /// \returns the high water mark for the allocated memory.
   uint64_t getMaxMemoryUsage() const { return maxMemoryAllocated_; }
+
+private:
+  /// A list of live buffers.
+  std::list<Segment> allocations_;
+  /// The size of the memory region that we can allocate segments into.
+  uint64_t poolSize_;
+  /// This is the high water mark for the allocated memory.
+  uint64_t maxMemoryAllocated_{0};
+  /// Maps allocated addresses to the currently associated handles.
+  std::unordered_map<uint64_t, Handle> addrToHandle_;
+  /// Maps handles to allocated addresses currently associated with them.
+  std::unordered_map<Handle, uint64_t> handleToAddr_;
+
+  /// Tries to evict some entries that are not needed at the moment to free
+  /// enough memory for the allocation of \p size bytes, but it is not allowed
+  /// to evict any entries from \p mustNotEvict set. All evicted entries are
+  /// stored in the \p evicted set. Uses first-fit approach for finding eviction
+  /// candidates.
+  void evictFirstFit(uint64_t size, const std::set<Handle> &mustNotEvict,
+                     std::vector<Handle> &evicted);
+  /// Associates a \p handle with an allocated address \p ptr.
+  void setHandle(uint64_t ptr, Handle handle);
 };
 
 } // namespace glow

--- a/lib/Backends/CPU/AllocationsInfo.cpp
+++ b/lib/Backends/CPU/AllocationsInfo.cpp
@@ -46,7 +46,7 @@ void AllocationsInfo::allocateWeightVars(const IRFunction *F,
     if (v->getVisibilityKind() == VisibilityKind::Public)
       continue;
     auto numBytes = w->getSizeInBytes();
-    size_t addr = constantWeightVarsAllocator.allocate(numBytes);
+    size_t addr = constantWeightVarsAllocator.allocate(numBytes, w);
     if (!reuseAddresses) {
       allocatedAddressed_[w] = addr;
     } else {
@@ -63,7 +63,7 @@ void AllocationsInfo::allocateWeightVars(const IRFunction *F,
     if (v->getVisibilityKind() != VisibilityKind::Public)
       continue;
     auto numBytes = w->getSizeInBytes();
-    size_t addr = mutableWeightVarsAllocator.allocate(numBytes);
+    size_t addr = mutableWeightVarsAllocator.allocate(numBytes, w);
     if (!reuseAddresses) {
       allocatedAddressed_[w] = addr;
     } else {
@@ -107,7 +107,7 @@ void AllocationsInfo::allocateActivations(const IRFunction *F) {
   for (const auto &I : F->getInstrs()) {
     if (auto *A = dyn_cast<AllocActivationInst>(&I)) {
       auto numBytes = I.getSizeInBytes();
-      size_t addr = activationsAllocator.allocate(numBytes);
+      size_t addr = activationsAllocator.allocate(numBytes, A);
       assert(!activationAddr.count(A) && "Allocation already made!");
       activationAddr[A] = addr;
       continue;
@@ -116,7 +116,7 @@ void AllocationsInfo::allocateActivations(const IRFunction *F) {
     if (auto *D = dyn_cast<DeallocActivationInst>(&I)) {
       auto *A = D->getAlloc();
       assert(activationAddr.count(A) && "Invalid deallocation!");
-      activationsAllocator.deallocate(activationAddr[A]);
+      activationsAllocator.deallocate(A);
       continue;
     }
   }

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -1409,7 +1409,7 @@ void OpenCLFunction::allocateMemory() {
   for (auto it : externalTensors_) {
     Tensor *T = it.second;
     size_t sizeInBytes = T->getType().getSizeInBytes();
-    size_t addr = allocator.allocate(sizeInBytes);
+    size_t addr = allocator.allocate(sizeInBytes, it.first);
     // Associate the new buffer with the weight value.
     tensors_[it.first] = addr;
   }
@@ -1418,7 +1418,7 @@ void OpenCLFunction::allocateMemory() {
   for (const auto &I : F_->getInstrs()) {
     if (auto *A = llvm::dyn_cast<AllocActivationInst>(&I)) {
       auto numBytes = I.getSizeInBytes();
-      size_t addr = allocator.allocate(numBytes);
+      size_t addr = allocator.allocate(numBytes, A);
       assert(!tensors_.count(A) && "Allocation already made!");
       tensors_[A] = addr;
       continue;
@@ -1444,7 +1444,7 @@ void OpenCLFunction::allocateMemory() {
     if (auto *D = llvm::dyn_cast<DeallocActivationInst>(&I)) {
       auto *A = D->getAlloc();
       assert(tensors_.count(A) && "Invalid deallocation!");
-      allocator.deallocate(tensors_[A]);
+      allocator.deallocate(A);
       continue;
     }
   }

--- a/lib/CodeGen/MemoryAllocator.cpp
+++ b/lib/CodeGen/MemoryAllocator.cpp
@@ -17,10 +17,15 @@
 #include "glow/CodeGen/MemoryAllocator.h"
 #include "glow/Support/Memory.h"
 
+#include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/ErrorHandling.h"
 
 using namespace glow;
+
+namespace glow {
+class Value;
+}
 
 /// The type of the address returned by MemoryAllocator::allocate should be at
 /// least 64-bit wide.
@@ -34,7 +39,7 @@ static_assert(std::is_unsigned<decltype(MemoryAllocator::npos)>{},
 
 const uint64_t MemoryAllocator::npos = -1;
 
-uint64_t MemoryAllocator::allocate(uint64_t size) {
+uint64_t MemoryAllocator::allocate(uint64_t size, Handle handle) {
   // Always allocate buffers properly aligned to hold values of any type.
   size = alignedSize(size, TensorAlignment);
   uint64_t prev = 0;
@@ -42,6 +47,7 @@ uint64_t MemoryAllocator::allocate(uint64_t size) {
     if (it->begin_ - prev >= size) {
       allocations_.emplace(it, prev, prev + size);
       maxMemoryAllocated_ = std::max(maxMemoryAllocated_, prev + size);
+      setHandle(prev, handle);
       return prev;
     }
     prev = it->end_;
@@ -56,15 +62,108 @@ uint64_t MemoryAllocator::allocate(uint64_t size) {
 
   allocations_.emplace_back(prev, prev + size);
   maxMemoryAllocated_ = std::max(maxMemoryAllocated_, prev + size);
+  setHandle(prev, handle);
   return prev;
 }
 
-void MemoryAllocator::deallocate(uint64_t ptr) {
+void MemoryAllocator::evictFirstFit(uint64_t size,
+                                    const std::set<Handle> &mustNotEvict,
+                                    std::vector<Handle> &evicted) {
+  // Use the first fit strategy to evict allocated blocks.
+  size = alignedSize(size, TensorAlignment);
+  bool hasSeenNonEvicted{false};
+  uint64_t startAddress = 0;
+  uint64_t begin = 0;
+  llvm::SmallVector<std::pair<Segment, Handle>, 16> evictionCandidates;
+  for (auto it = allocations_.begin(), e = allocations_.end(); it != e; it++) {
+    // Skip any allocations below the start address.
+    if (it->begin_ < startAddress) {
+      continue;
+    }
+    auto curHandle = getHandle(it->begin_);
+    if (mustNotEvict.count(curHandle)) {
+      // The block cannot be evicted. Start looking after it.
+      begin = it->end_;
+      evictionCandidates.clear();
+      hasSeenNonEvicted = true;
+      continue;
+    }
+    // Remember current block as a candidate.
+    evictionCandidates.emplace_back(std::make_pair(*it, curHandle));
+    // If the total to be evicted size is enough, no need to look any further.
+    if (it->end_ - begin >= size) {
+      break;
+    }
+  }
+
+  if ((!evictionCandidates.empty() &&
+       evictionCandidates.back().first.end_ - begin >= size) ||
+      (!hasSeenNonEvicted && poolSize_ >= size)) {
+    // Now evict all eviction candidates.
+    for (auto &candidate : evictionCandidates) {
+      auto &curHandle = candidate.second;
+      deallocate(curHandle);
+      evicted.emplace_back(curHandle);
+    }
+  }
+}
+
+uint64_t MemoryAllocator::allocate(uint64_t size, Handle handle,
+                                   const std::set<Handle> &mustNotEvict,
+                                   std::vector<Handle> &evicted) {
+  // Try the usual allocation first.
+  auto ptr = allocate(size, handle);
+  // If it was possible to allocate the requested block, just return it.
+  if (ptr != npos) {
+    return ptr;
+  }
+  // Allocation was not possible, try to evict something.
+  // Use the first fit strategy to evict allocated blocks.
+  evictFirstFit(size, mustNotEvict, evicted);
+  // Try again to allocate the space. This time it should succeed.
+  ptr = allocate(size, handle);
+  return ptr;
+}
+
+void MemoryAllocator::deallocate(Handle handle) {
+  auto ptr = getAddress(handle);
   for (auto it = allocations_.begin(), e = allocations_.end(); it != e; it++) {
     if (it->begin_ == ptr) {
       allocations_.erase(it);
+      addrToHandle_.erase(ptr);
+      handleToAddr_.erase(handle);
       return;
     }
   }
-  llvm_unreachable("Unknown buffer to allocate");
+  llvm_unreachable("Unknown buffer to deallocate");
+}
+
+bool MemoryAllocator::hasHandle(uint64_t address) const {
+  auto it = addrToHandle_.find(address);
+  return it != addrToHandle_.end();
+}
+
+MemoryAllocator::Handle MemoryAllocator::getHandle(uint64_t address) const {
+  auto it = addrToHandle_.find(address);
+  assert(it != addrToHandle_.end() && "Unknown address");
+  return it->second;
+}
+
+bool MemoryAllocator::hasAddress(Handle handle) const {
+  auto it = handleToAddr_.find(handle);
+  return it != handleToAddr_.end();
+}
+
+uint64_t MemoryAllocator::getAddress(Handle handle) const {
+  auto it = handleToAddr_.find(handle);
+  assert(it != handleToAddr_.end() && "Unknown handle");
+  return it->second;
+}
+
+void MemoryAllocator::setHandle(uint64_t ptr, Handle handle) {
+  // TODO: Check that ptr is an allocated address.
+  assert(contains(ptr) && "The address is not allocated");
+  assert(!hasHandle(ptr) && "The address has an associated handle already");
+  addrToHandle_[ptr] = handle;
+  handleToAddr_[handle] = ptr;
 }

--- a/tests/unittests/memoryAllocatorTest.cpp
+++ b/tests/unittests/memoryAllocatorTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "glow/CodeGen/MemoryAllocator.h"
+#include "glow/IR/IR.h"
 
 #include "gtest/gtest.h"
 
@@ -22,92 +23,283 @@ using namespace glow;
 
 TEST(MemAlloc, simple) {
   MemoryAllocator MA(1000);
+  void *handle = reinterpret_cast<void *>(1);
 
   // Can't allocate huge chunks.
-  EXPECT_EQ(MA.allocate(100000), MemoryAllocator::npos);
+  EXPECT_EQ(MA.allocate(100000, handle), MemoryAllocator::npos);
 
   // First chunk needs to start at zero.
-  EXPECT_EQ(MA.allocate(500), 0);
+  EXPECT_EQ(MA.allocate(500, handle), 0);
 
   // Second chunk must not be zero.
-  EXPECT_NE(MA.allocate(500), 0);
+  EXPECT_NE(MA.allocate(500, handle), 0);
 }
 
 TEST(MemAlloc, holes) {
   MemoryAllocator MA(1000);
+  void *handle0 = reinterpret_cast<void *>(0);
+  void *handle1 = reinterpret_cast<void *>(1);
+  void *handle2 = reinterpret_cast<void *>(2);
+  void *handle4 = reinterpret_cast<void *>(4);
 
-  auto p0 = MA.allocate(10);
-  auto p1 = MA.allocate(10);
-  auto p2 = MA.allocate(10);
+  MA.allocate(10, handle0);
+  auto p1 = MA.allocate(10, handle1);
+  MA.allocate(10, handle2);
 
-  MA.deallocate(p1);
-  auto p4 = MA.allocate(10);
+  MA.deallocate(handle1);
+  auto maxMemoryUsageBefore = MA.getMaxMemoryUsage();
+  auto p4 = MA.allocate(10, handle4);
+  auto maxMemoryUsageAfter = MA.getMaxMemoryUsage();
 
   // Check that p4 was allocated on top of the freed p1.
   EXPECT_EQ(p4, p1);
+  // Max memory usage should not be affected, as a hole was found and used.
+  EXPECT_EQ(maxMemoryUsageBefore, maxMemoryUsageAfter);
 
-  MA.deallocate(p0);
-  MA.deallocate(p2);
+  MA.deallocate(handle0);
+  MA.deallocate(handle2);
+}
+
+/// Check some properties of the first-fit allocation strategy.
+TEST(MemAlloc, firstFitAllocation) {
+  MemoryAllocator MA(1000);
+  void *handle = reinterpret_cast<void *>(10000);
+  void *handle0 = reinterpret_cast<void *>(0);
+  void *handle1 = reinterpret_cast<void *>(1);
+  void *handle2 = reinterpret_cast<void *>(2);
+  void *handle3 = reinterpret_cast<void *>(3);
+  void *handle4 = reinterpret_cast<void *>(4);
+
+  // Allocate three blocks of sizes 30, 20 and 10 and allocate blocks of size 5
+  // between them.
+  auto p0 = MA.allocate(30, handle0);
+  MA.allocate(5, handle);
+  MA.allocate(20, handle1);
+  MA.allocate(5, handle);
+  auto p2 = MA.allocate(10, handle2);
+  MA.allocate(5, handle);
+
+  // Free blocks p0, p1 and p2.
+  MA.deallocate(handle0);
+  MA.deallocate(handle1);
+  MA.deallocate(handle2);
+
+  // Try to allocate a block of size 10.
+  auto maxMemoryUsageBefore = MA.getMaxMemoryUsage();
+  auto p3 = MA.allocate(10, handle3);
+  auto maxMemoryUsageAfter = MA.getMaxMemoryUsage();
+
+  // Check that p4 was allocated on top of the freed p0, because the allocator
+  // uses the first-fit algorithm. Best-fit would have taken the block of p2.
+  EXPECT_EQ(p3, p0);
+  // Max memory usage should not be affected, as a hole was found and used.
+  EXPECT_EQ(maxMemoryUsageBefore, maxMemoryUsageAfter);
+
+  // Allocate 100 bytes. Since the first-fit cannot find any big enough hole
+  // between allocations, the allocator would allocate this block in the free
+  // space after all existing allocations.
+  maxMemoryUsageBefore = MA.getMaxMemoryUsage();
+  auto p4 = MA.allocate(100, handle4);
+  maxMemoryUsageAfter = MA.getMaxMemoryUsage();
+  EXPECT_GT(p4, p2);
+  // Max memory usage should be increased.
+  EXPECT_LT(maxMemoryUsageBefore, maxMemoryUsageAfter);
 }
 
 TEST(MemAlloc, dealloc) {
   MemoryAllocator MA(1000);
-  auto p0 = MA.allocate(10);
-  auto p1 = MA.allocate(10);
-  auto p2 = MA.allocate(10);
-  auto p3 = MA.allocate(10);
+  void *handle0 = reinterpret_cast<void *>(0);
+  void *handle1 = reinterpret_cast<void *>(1);
+  void *handle2 = reinterpret_cast<void *>(2);
+  void *handle3 = reinterpret_cast<void *>(3);
+  void *handle4 = reinterpret_cast<void *>(4);
+
+  auto p0 = MA.allocate(10, handle0);
+  auto p1 = MA.allocate(10, handle1);
+  auto p2 = MA.allocate(10, handle2);
+  auto p3 = MA.allocate(10, handle3);
+
+  auto p4 = MA.allocate(10, handle4);
 
   EXPECT_EQ(p0, 0);
   EXPECT_NE(p1, MemoryAllocator::npos);
   EXPECT_NE(p2, MemoryAllocator::npos);
   EXPECT_NE(p3, MemoryAllocator::npos);
+  EXPECT_NE(p4, MemoryAllocator::npos);
 
   // Deallocate in some arbitrary order.
-  MA.deallocate(p0);
-  MA.deallocate(p2);
-  MA.deallocate(p1);
-  MA.deallocate(p3);
-
+  MA.deallocate(handle0);
+  MA.deallocate(handle2);
+  MA.deallocate(handle1);
+  MA.deallocate(handle3);
+  // Check that it is possible to deallocate using the associated handle.
+  MA.deallocate(handle4);
+#ifndef NDEBUG
+  // Check that deallocating a non-allocated or already deallocated buffer
+  // should result in an assertion failure.
+  ASSERT_DEATH_IF_SUPPORTED(MA.deallocate(handle3),
+                            "Unknown handle");
+#endif
   // Check that after deallocating everything we start allocating from zero.
-  EXPECT_EQ(MA.allocate(10), 0);
+  EXPECT_EQ(MA.allocate(10, handle0), 0);
 }
 
 TEST(MemAlloc, dealloc2) {
   MemoryAllocator MA(10000);
-
-  std::vector<size_t> allocations;
+  std::vector<uint64_t> allocations;
 
   for (int i = 0; i < 100; i++) {
     // Create odd-sized allocations.
-    auto p0 = MA.allocate(10 + i % 4);
+    const void *handle = reinterpret_cast<void *>(i);
+    auto p0 = MA.allocate(10 + i % 4, handle);
+    EXPECT_TRUE(MA.hasAddress(handle));
+    EXPECT_TRUE(MA.hasHandle(p0));
+
     EXPECT_NE(p0, MemoryAllocator::npos);
     allocations.push_back(p0);
 
     if (allocations.size() > 20) {
-      MA.deallocate(allocations[0]);
+      MA.deallocate(MA.getHandle(allocations[0]));
       allocations.erase(allocations.begin());
     }
   }
   // Drain the allocator.
   while (!allocations.empty()) {
-    MA.deallocate(allocations[0]);
+    MA.deallocate(MA.getHandle(allocations[0]));
     allocations.erase(allocations.begin());
   }
 
   // Check that after deallocating everything we start allocating from zero.
-  EXPECT_EQ(MA.allocate(10), 0);
+  const void *handle = reinterpret_cast<void *>(0);
+  EXPECT_EQ(MA.allocate(10, handle), 0);
 }
 
 TEST(MemAlloc, allocateToTheMax) {
   MemoryAllocator MA(128);
-  auto p0 = MA.allocate(64);
-  auto p1 = MA.allocate(64);
+  void *handle0 = reinterpret_cast<void *>(0);
+  void *handle1 = reinterpret_cast<void *>(1);
+  auto p0 = MA.allocate(64, handle0);
+  auto p1 = MA.allocate(64, handle1);
 
   EXPECT_EQ(p0, 0);
   EXPECT_NE(p1, MemoryAllocator::npos);
 
-  MA.deallocate(p0);
-  MA.deallocate(p1);
+  MA.deallocate(handle0);
+  MA.deallocate(handle1);
 
   EXPECT_EQ(MA.getMaxMemoryUsage(), 128);
+}
+
+TEST(MemAlloc, testContains) {
+  MemoryAllocator MA(1000);
+  void *handle = reinterpret_cast<void *>(0);
+
+  EXPECT_EQ(MA.allocate(200, handle), 0);
+
+  // Offset 100 should be inside an allocated block.
+  EXPECT_TRUE(MA.contains(100));
+  // Offset 300 should not be inside an allocated block.
+  EXPECT_FALSE(MA.contains(300));
+}
+
+TEST(MemAlloc, testHandles) {
+  MemoryAllocator MA(1000);
+  // Define a set of handles to be used.
+  void *handle1 = reinterpret_cast<void *>(1);
+  void *handle2 = reinterpret_cast<void *>(2);
+  void *handle3 = reinterpret_cast<void *>(3);
+  // Allocate a block of memory p1, but do not associate any handle with it.
+  auto p1 = MA.allocate(10, handle1);
+  // Check that handle1 is associated with the allocated address p1.
+  EXPECT_EQ(MA.getHandle(p1), handle1);
+  // Check that the address p1 is associated with the handle handle1.
+  EXPECT_EQ(MA.getAddress(handle1), p1);
+
+  // Allocate a block of memory p3 and associate a handle handle3 with it.
+  auto p3 = MA.allocate(10, handle3);
+  // The associated handle of p3 should be handle3.
+  EXPECT_EQ(MA.getHandle(p3), handle3);
+  // The address associated with handle3 should be p3.
+  EXPECT_EQ(MA.getAddress(handle3), p3);
+  // Deallocate the memory.
+  MA.deallocate(handle3);
+  // Check that after deallocation there is no handle is associated with the
+  // allocated address.
+  EXPECT_FALSE(MA.hasHandle(p3));
+  // Check that after deallocation there is no address is associated with
+  // handle3.
+  EXPECT_FALSE(MA.hasAddress(handle3));
+
+  MA.reset();
+  p1 = MA.allocate(10, handle1);
+#ifndef NDEBUG
+  // Deallocating handle2 should result in an assertion failure.
+  ASSERT_DEATH_IF_SUPPORTED(MA.deallocate(handle2),
+                            "Unknown handle");
+#endif
+}
+
+TEST(MemAlloc, testEviction) {
+  MemoryAllocator MA(1024);
+  // Define a set of handles to be used.
+  void *handle1 = reinterpret_cast<void *>(1);
+  void *handle2 = reinterpret_cast<void *>(2);
+  void *handle3 = reinterpret_cast<void *>(3);
+  void *handle4 = reinterpret_cast<void *>(4);
+  void *handle5 = reinterpret_cast<void *>(5);
+  std::vector<const void *> evicted;
+
+  // Allocation of 500 from 1000 bytes should not trigger any eviction.
+  auto p1 = MA.allocate(500, handle1, {}, evicted);
+  EXPECT_NE(p1, MA.npos);
+  EXPECT_TRUE(evicted.empty());
+
+  // Allocation of 400 from remaining 500 bytes should not trigger any eviction.
+  auto p2 = MA.allocate(400, handle2, {}, evicted);
+  EXPECT_NE(p2, MA.npos);
+  EXPECT_TRUE(evicted.empty());
+
+  // Allocation of 400 from remaining 100 bytes should trigger the eviction.
+  auto p3 = MA.allocate(400, handle3, {}, evicted);
+  // The allocation should be successful.
+  EXPECT_NE(p3, MA.npos);
+  EXPECT_EQ(evicted.size(), 1);
+
+  // Allocation of 2000 bytes is impossible. It should not should trigger any
+  // eviction.
+  evicted.clear();
+  auto p4 = MA.allocate(2000, handle4, {}, evicted);
+  EXPECT_EQ(p4, MA.npos);
+  EXPECT_EQ(evicted.size(), 0);
+
+  // Allocation of 1024 bytes only possible if all other allocated blocks are
+  // evicted.
+  evicted.clear();
+  auto p5 = MA.allocate(1024, handle5, {}, evicted);
+  EXPECT_NE(p5, MA.npos);
+  EXPECT_EQ(evicted.size(), 2);
+
+  // Check how eviction works with a non-empty doNotEvict set.
+  MA.reset();
+  evicted.clear();
+  // Allocate 3 blocks, 256 bytes each.
+  p1 = MA.allocate(256, handle1, {}, evicted);
+  EXPECT_EQ(p1, 0);
+  p2 = MA.allocate(256, handle2, {}, evicted);
+  EXPECT_EQ(p2, 256);
+  p3 = MA.allocate(256, handle3, {}, evicted);
+  EXPECT_EQ(p3, 512);
+  // No blocks should be evicted until now.
+  EXPECT_EQ(evicted.size(), 0);
+  // Try to allocate a block of size 512. Without a doNotEvict set and using a
+  // first-fit eviction strategy, the allocator would have to evict blocks p1
+  // and p2 to satisfy this request. But due to providing a doNotEvict set which
+  // forbids the eviction of p1, the allocator should evict p2 and p3 and
+  // allocate the 512 bytes at the same address as p2.
+  std::set<const void *> doNotEvict{handle1};
+  p4 = MA.allocate(512, handle4, doNotEvict, evicted);
+  EXPECT_EQ(p4, p2);
+  EXPECT_EQ(evicted.size(), 2);
+  EXPECT_EQ(evicted[0], handle2);
+  EXPECT_EQ(evicted[1], handle3);
 }


### PR DESCRIPTION
- There is a new version of the `allocate` API that supports eviction.

  If the allocator cannot find enough free space to satisfy the allocation request, it tries to find a set of allocated blocks whose eviction would result in freeing enough space to allocate the memory block of requested size. The client may specify which allocated blocks cannot be evicted.

  The current version of the allocator uses a first-fit approach when it looks for the buffers to be evicted.

- Also, each allocation now takes a `handle` parameter and associates this handle with the allocation. A handle is typically a client-specific object, representing what is being allocated, e.g. a `Value *` whose payload is being allocated by means of a MemoryAllocator. Clients can use handles to deallocate buffers, to describe buffers that should not be evicted, etc.