### PR TITLE
[quantization] Remove original function when needed after running quantization.

### DIFF
--- a/examples/fr2en.cpp
+++ b/examples/fr2en.cpp
@@ -164,7 +164,13 @@ struct Model {
       auto quantizationInfos = deserializeFromYaml(loadProfileFileOpt);
 
       // Quantize the graph based on the captured profile.
-      F_ = glow::quantization::quantizeFunction(EE_, quantizationInfos, F_);
+      auto *Q =
+          glow::quantization::quantizeFunction(EE_, quantizationInfos, F_);
+
+      // Erase the original function so that the redundant variables that are
+      // only referenced by the original function will be removed.
+      Q->getParent()->eraseFunction(F_);
+      F_ = Q;
     }
 
     EE_.compile(CompilationMode::Infer, F_);

--- a/include/glow/Quantization/Quantization.h
+++ b/include/glow/Quantization/Quantization.h
@@ -62,6 +62,8 @@ generateNodeQuantizationInfos(const Function *F,
 /// function based on \p quantizationInfos. This method converts to integer as
 /// many nodes as permitted by the backend \p EE. The new quantized function is
 /// called \p newFuncName. If no name is given the method will generate a name.
+/// This method clones original function \p F and caller is responsible
+/// for cleaning up/erasing original function \p F if needed.
 /// \returns a new quantized function.
 Function *
 quantizeFunction(const ExecutionEngine &EE,

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -432,9 +432,6 @@ quantizeFunction(const ExecutionEngine &EE,
     }
   } while (nodeIt != stopIt);
 
-  // Erase the original function so that the redundant variables that are only 
-  // referenced by the original function will be removed.
-  F->getParent()->eraseFunction(F);
   return G;
 }
 

--- a/tests/unittests/MLTest.cpp
+++ b/tests/unittests/MLTest.cpp
@@ -908,8 +908,7 @@ TEST_P(InterpreterAndCPU, convNetForImageRecognition) {
   auto *TANH = F->createTanh("tanh", CV);
   auto *FCL = F->createFullyConnected("fc", TANH, 2);
   auto *SM = F->createSoftMax("sm", FCL, ex);
-  auto *SN = F->createSave("ret", SM);
-  auto *resultVar = SN->getVariable();
+  auto *result = F->createSave("ret", SM);
   Function *TF = glow::differentiate(F, TC);
   EE.compile(CompilationMode::Train, TF);
 
@@ -939,7 +938,7 @@ TEST_P(InterpreterAndCPU, convNetForImageRecognition) {
   Tensor testLabels(ElemKind::IndexTy, {batchSize, 1});
   generateImageData(testImages, testLabels, mod.getPRNG());
   EE.run({input}, {&testImages});
-  auto SMH = resultVar->getHandle<>();
+  auto SMH = result->getVariable()->getHandle<>();
   for (size_t i = 0; i < batchSize; i++) {
     bool isLine = testLabels.getHandle<size_t>().at({i, 0}) == 0;
     auto lineWeight = SMH.at({i, 0});
@@ -996,8 +995,7 @@ TEST_P(InterpreterAndCPU, testFindPixelRegression) {
   auto *RL0 = F->createRELU("relu0", FC0);
   auto *FC1 = F->createFullyConnected("fc1", RL0, 2);
   auto *R = F->createRegression("regression", FC1, ex);
-  auto *SN = F->createSave("ret", R);
-  auto *resultVar = SN->getVariable();
+  auto *result = F->createSave("ret", R);
   Function *TF = glow::differentiate(F, TC);
   EE.compile(CompilationMode::Train, TF);
 
@@ -1040,7 +1038,7 @@ TEST_P(InterpreterAndCPU, testFindPixelRegression) {
   EE.run({input}, {&testImages});
 
   // A handle to the projected result.
-  auto RH = resultVar->getHandle<>();
+  auto RH = result->getVariable()->getHandle<>();
   // A handle to the true label.
   auto LH = testLabels.getHandle<>();
 

--- a/tests/unittests/quantizationTest.cpp
+++ b/tests/unittests/quantizationTest.cpp
@@ -201,9 +201,7 @@ TEST_P(Operator, end2end) {
   // STEP1 - Generate the first network to record the quantization parameters.
   Function *F1 = createSimpleGraphForQuantization(mod, A, B, "main");
   Function *F2 = F1->clone("main2");
-  SaveNode *SN1 =
-      cast<SaveNode>(F1->getNodeByName("save"));
-  Variable *result1Var = SN1->getVariable();  
+  SaveNode *result1 = cast<SaveNode>(F1->getNodeByName("save"));
 
   F1 = glow::profileQuantization(F1);
   interpreterEE.compile(CompilationMode::Infer, F1);
@@ -216,17 +214,15 @@ TEST_P(Operator, end2end) {
       quantization::generateNodeQuantizationInfos(F1);
 
   // STEP2 - Use the profile to quantize a network.
-  SaveNode *SN2 =
-      cast<SaveNode>(F2->getNodeByName("save"));
-  Variable *result2Var = SN2->getVariable();
+  SaveNode *result2 = cast<SaveNode>(F2->getNodeByName("save"));
 
   F2 = quantization::quantizeFunction(backendSpecificEE, QI, F2);
   backendSpecificEE.compile(CompilationMode::Infer, F2);
   backendSpecificEE.run({}, {});
 
   // STEP3 - Compare the results of the original and quantized functions.
-  auto result1Handle = result1Var->getHandle();
-  auto result2Handle = result2Var->getHandle();
+  auto result1Handle = result1->getVariable()->getHandle();
+  auto result2Handle = result2->getVariable()->getHandle();
 
   EXPECT_EQ(result1Handle.size(), result2Handle.size());
 
@@ -340,9 +336,7 @@ TEST_P(Quantization, end2endGRU) {
   auto *mod = &interpreterEE.getModule();
   Function *F1 = createGRUForQuantization(mod, "main");
   Function *F2 = F1->clone("main2");
-  SaveNode *SN1 =
-      cast<SaveNode>(F1->getNodeByName("save"));
-  Variable *result1Var = SN1->getVariable();
+  SaveNode *result1 = cast<SaveNode>(F1->getNodeByName("save"));
 
   F1 = glow::profileQuantization(F1);
   interpreterEE.compile(CompilationMode::Infer, F1);
@@ -355,17 +349,15 @@ TEST_P(Quantization, end2endGRU) {
       quantization::generateNodeQuantizationInfos(F1);
 
   // STEP2 - Use the profile to quantize a network.
-  SaveNode *SN2 =
-      cast<SaveNode>(F2->getNodeByName("save"));
-  Variable *result2Var = SN2->getVariable();
+  SaveNode *result2 = cast<SaveNode>(F2->getNodeByName("save"));
 
   F2 = quantization::quantizeFunction(backendSpecificEE, QI, F2);
   backendSpecificEE.compile(CompilationMode::Infer, F2);
   backendSpecificEE.run({}, {});
 
   // STEP3 - Compare the results of the original and quantized functions.
-  auto result1Handle = result1Var->getHandle();
-  auto result2Handle = result2Var->getHandle();
+  auto result1Handle = result1->getVariable()->getHandle();
+  auto result2Handle = result2->getVariable()->getHandle();
 
   EXPECT_EQ(result1Handle.size(), result2Handle.size());
 

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -159,7 +159,13 @@ void Loader::compile() {
     F_->setName("old");
 
     // Quantize the graph based on the captured profile.
-    F_ = quantization::quantizeFunction(EE_, quantizationInfos, F_, oldName);
+    auto *Q =
+        quantization::quantizeFunction(EE_, quantizationInfos, F_, oldName);
+
+    // Erase the original function so that the redundant variables that are only
+    // referenced by the original function will be removed.
+    Q->getParent()->eraseFunction(F_);
+    F_ = Q;
   }
 
   if (emittingBundle()) {


### PR DESCRIPTION
closes https://github.com/pytorch/glow/issues/1482

image-classifier run looks good with dump/load profile.