### PR TITLE
A couple of usability improvements to MemoryAllocator API

### DIFF
--- a/include/glow/CodeGen/MemoryAllocator.h
+++ b/include/glow/CodeGen/MemoryAllocator.h
@@ -63,7 +63,7 @@ public:
   void reset() {
     maxMemoryAllocated_ = 0;
     allocations_.clear();
-    handleToAddr_.clear();
+    handleToAllocInfo_.clear();
     addrToHandle_.clear();
   }
 
@@ -105,6 +105,10 @@ public:
   /// \returns the address currently associated with the \p handle.
   uint64_t getAddress(Handle handle) const;
 
+  /// \returns the size of the allocated block currently associated with the \p
+  /// handle.
+  uint64_t getSize(Handle handle) const;
+
   /// \returns true if there is an address currently associated with the \p
   /// handle.
   bool hasAddress(Handle handle) const;
@@ -114,6 +118,10 @@ public:
 
   /// \returns the high water mark for the allocated memory.
   uint64_t getMaxMemoryUsage() const { return maxMemoryAllocated_; }
+
+  /// \returns the size of the whole memory region that we can allocate segments
+  /// into.
+  uint64_t getMemorySize() const { return poolSize_; }
 
   /// \returns the name of the memory region.
   const std::string &getName() const { return name_; }
@@ -129,8 +137,9 @@ private:
   uint64_t maxMemoryAllocated_{0};
   /// Maps allocated addresses to the currently associated handles.
   std::unordered_map<uint64_t, Handle> addrToHandle_;
-  /// Maps handles to allocated addresses currently associated with them.
-  std::unordered_map<Handle, uint64_t> handleToAddr_;
+  /// Maps handles to the allocation information about the memory block
+  /// currently associated with them.
+  std::unordered_map<Handle, Segment> handleToAllocInfo_;
 
   /// Tries to evict some entries that are not needed at the moment to free
   /// enough memory for the allocation of \p size bytes, but it is not allowed
@@ -139,8 +148,8 @@ private:
   /// candidates.
   void evictFirstFit(uint64_t size, const std::set<Handle> &mustNotEvict,
                      std::vector<Handle> &evicted);
-  /// Associates a \p handle with an allocated address \p ptr.
-  void setHandle(uint64_t ptr, Handle handle);
+  /// Associates a \p handle with an allocated address \p ptr and size \p size.
+  void setHandle(uint64_t ptr, uint64_t size, Handle handle);
 };
 
 } // namespace glow

--- a/include/glow/CodeGen/MemoryAllocator.h
+++ b/include/glow/CodeGen/MemoryAllocator.h
@@ -19,6 +19,7 @@
 #include <cstdint>
 #include <list>
 #include <set>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -56,7 +57,8 @@ public:
   /// A reserved value to mark invalid allocation.
   static const uint64_t npos;
 
-  explicit MemoryAllocator(uint64_t poolSize) : poolSize_(poolSize) {}
+  explicit MemoryAllocator(const std::string &name, uint64_t poolSize)
+      : name_(name), poolSize_(poolSize) {}
 
   void reset() {
     maxMemoryAllocated_ = 0;
@@ -113,7 +115,12 @@ public:
   /// \returns the high water mark for the allocated memory.
   uint64_t getMaxMemoryUsage() const { return maxMemoryAllocated_; }
 
+  /// \returns the name of the memory region.
+  const std::string &getName() const { return name_; }
+
 private:
+  /// The name of the memory region.
+  std::string name_;
   /// A list of live buffers.
   std::list<Segment> allocations_;
   /// The size of the memory region that we can allocate segments into.

--- a/lib/Backends/CPU/AllocationsInfo.cpp
+++ b/lib/Backends/CPU/AllocationsInfo.cpp
@@ -35,8 +35,8 @@ void AllocationsInfo::allocateWeightVars(const IRFunction *F,
                                          bool reuseAddresses) {
   // Use two different allocators, because constant weights and mutable weights
   // may use different memory blocks.
-  MemoryAllocator constantWeightVarsAllocator(0);
-  MemoryAllocator mutableWeightVarsAllocator(0);
+  MemoryAllocator constantWeightVarsAllocator("ConstantWeights", 0);
+  MemoryAllocator mutableWeightVarsAllocator("MutableWeights", 0);
 
   // Compute the new offsets for all the weights, do not reuse their current
   // addresses. Process all constant WeightVars first.
@@ -98,7 +98,7 @@ void AllocationsInfo::allocateWeightVars(const IRFunction *F,
 void AllocationsInfo::allocateActivations(const IRFunction *F) {
   // Use a memory allocator with no upper bound on how much memory we can
   // allocate.
-  MemoryAllocator activationsAllocator(0);
+  MemoryAllocator activationsAllocator("Activations", 0);
 
   // Maps activations and views to some offset within the heap.
   llvm::DenseMap<const Value *, uint64_t> activationAddr;

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -1398,7 +1398,7 @@ uint64_t OpenCLFunction::copyMutableWeightsFromDevice() {
 
 void OpenCLFunction::allocateMemory() {
   /// The allocator assigns device memory addresses to the buffers.
-  MemoryAllocator allocator(0xFFFFFFFF);
+  MemoryAllocator allocator("GPU", 0xFFFFFFFF);
   for (auto &v : F_->getGraph()->getParent()->getVars()) {
     auto *w = F_->getWeightForNode(v);
     assert(!externalTensors_.count(w) && "The tensor is already registered");

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -200,6 +200,7 @@ target_link_libraries(memoryAllocatorTest
                       PRIVATE
                         CodeGen
                         gtest
+                        Support
                         testMain)
 add_glow_test(memoryAllocatorTest ${GLOW_BINARY_DIR}/tests/memoryAllocatorTest)
 

--- a/tests/unittests/memoryAllocatorTest.cpp
+++ b/tests/unittests/memoryAllocatorTest.cpp
@@ -302,3 +302,22 @@ TEST(MemAlloc, testEviction) {
   EXPECT_EQ(evicted[0], handle2);
   EXPECT_EQ(evicted[1], handle3);
 }
+
+TEST(MemAlloc, testGetSize) {
+  MemoryAllocator MA("test", 1024);
+  void *handle0 = reinterpret_cast<void *>(0);
+  void *handle1 = reinterpret_cast<void *>(1);
+  // Allocate two memory blocks and checks that the size of the allocated blocks
+  // is reported correctly.
+  MA.allocate(10, handle0);
+  EXPECT_EQ(MA.getSize(handle0), 10);
+  MA.allocate(200, handle1);
+  EXPECT_EQ(MA.getSize(handle1), 200);
+}
+
+TEST(MemAlloc, testGetMemorySize) {
+  MemoryAllocator MA1("test1", 1024);
+  EXPECT_EQ(MA1.getMemorySize(), 1024);
+  MemoryAllocator MA2("test1", 102);
+  EXPECT_EQ(MA2.getMemorySize(), 102);
+}

--- a/tests/unittests/memoryAllocatorTest.cpp
+++ b/tests/unittests/memoryAllocatorTest.cpp
@@ -22,7 +22,7 @@
 using namespace glow;
 
 TEST(MemAlloc, simple) {
-  MemoryAllocator MA(1000);
+  MemoryAllocator MA("test", 1000);
   void *handle = reinterpret_cast<void *>(1);
 
   // Can't allocate huge chunks.
@@ -36,7 +36,7 @@ TEST(MemAlloc, simple) {
 }
 
 TEST(MemAlloc, holes) {
-  MemoryAllocator MA(1000);
+  MemoryAllocator MA("test", 1000);
   void *handle0 = reinterpret_cast<void *>(0);
   void *handle1 = reinterpret_cast<void *>(1);
   void *handle2 = reinterpret_cast<void *>(2);
@@ -62,7 +62,7 @@ TEST(MemAlloc, holes) {
 
 /// Check some properties of the first-fit allocation strategy.
 TEST(MemAlloc, firstFitAllocation) {
-  MemoryAllocator MA(1000);
+  MemoryAllocator MA("test", 1000);
   void *handle = reinterpret_cast<void *>(10000);
   void *handle0 = reinterpret_cast<void *>(0);
   void *handle1 = reinterpret_cast<void *>(1);
@@ -107,7 +107,7 @@ TEST(MemAlloc, firstFitAllocation) {
 }
 
 TEST(MemAlloc, dealloc) {
-  MemoryAllocator MA(1000);
+  MemoryAllocator MA("test", 1000);
   void *handle0 = reinterpret_cast<void *>(0);
   void *handle1 = reinterpret_cast<void *>(1);
   void *handle2 = reinterpret_cast<void *>(2);
@@ -144,7 +144,7 @@ TEST(MemAlloc, dealloc) {
 }
 
 TEST(MemAlloc, dealloc2) {
-  MemoryAllocator MA(10000);
+  MemoryAllocator MA("test", 10000);
   std::vector<uint64_t> allocations;
 
   for (int i = 0; i < 100; i++) {
@@ -174,7 +174,7 @@ TEST(MemAlloc, dealloc2) {
 }
 
 TEST(MemAlloc, allocateToTheMax) {
-  MemoryAllocator MA(128);
+  MemoryAllocator MA("test", 128);
   void *handle0 = reinterpret_cast<void *>(0);
   void *handle1 = reinterpret_cast<void *>(1);
   auto p0 = MA.allocate(64, handle0);
@@ -190,7 +190,7 @@ TEST(MemAlloc, allocateToTheMax) {
 }
 
 TEST(MemAlloc, testContains) {
-  MemoryAllocator MA(1000);
+  MemoryAllocator MA("test", 1000);
   void *handle = reinterpret_cast<void *>(0);
 
   EXPECT_EQ(MA.allocate(200, handle), 0);
@@ -202,7 +202,7 @@ TEST(MemAlloc, testContains) {
 }
 
 TEST(MemAlloc, testHandles) {
-  MemoryAllocator MA(1000);
+  MemoryAllocator MA("test", 1000);
   // Define a set of handles to be used.
   void *handle1 = reinterpret_cast<void *>(1);
   void *handle2 = reinterpret_cast<void *>(2);
@@ -239,7 +239,7 @@ TEST(MemAlloc, testHandles) {
 }
 
 TEST(MemAlloc, testEviction) {
-  MemoryAllocator MA(1024);
+  MemoryAllocator MA("test", 1024);
   // Define a set of handles to be used.
   void *handle1 = reinterpret_cast<void *>(1);
   void *handle2 = reinterpret_cast<void *>(2);


### PR DESCRIPTION
- MemoryAllocators should have names

   It makes it easier to debug  memory allocation related issues and to produce more detailed debug output.

- Add to MemoryAllocator the API to get sizes of allocated memory blocks

   This API is useful for some backends. It is also fast as it does not require traversing all allocations.