### PR TITLE
[Tensor] Remane the method "copyFrom" in Tensor class to "assign".

### DIFF
--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -299,8 +299,8 @@ public:
     llvm_unreachable("unreachable");
   }
 
-  /// Update the content of the tensor from the tensor \p t.
-  void copyFrom(const Tensor *t) {
+  /// Update the content and type of the tensor from the tensor \p t.
+  void assign(const Tensor *t) {
     assert(this != t && "Copying to self");
     reset(t);
     size_t bufferSize = size() * type_.getElementSize();
@@ -362,7 +362,7 @@ public:
   /// Create a new copy of the current tensor.
   Tensor clone() const {
     Tensor slice;
-    slice.copyFrom(this);
+    slice.assign(this);
     return slice;
   }
 

--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -82,7 +82,7 @@ public:
     return getPayload().getHandle<ElemTy>();
   }
 
-  void copyFrom(const Tensor *t) { payload_.copyFrom(t); }
+  void assign(const Tensor *t) { payload_.assign(t); }
 
   /// \returns the output NodeValue from the Variable. Variables only have a
   /// single output.

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -123,7 +123,7 @@ void ExecutionEngine::loadValueFromTensor(Variable *v, Tensor *input) {
   auto dim = input->dims();
   (void)dim;
   assert(t.dims() == dim && "Invalid slice size");
-  t.copyFrom(input);
+  t.assign(input);
 }
 
 std::unique_ptr<IRFunction> ExecutionEngine::generateIR(CompilationMode mode,

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -350,7 +350,7 @@ Variable *Module::createVariable(llvm::StringRef name, const Tensor &tensor,
                                  VisibilityKind visibility, bool trainable) {
   auto *V = createVariable(tensor.getElementType(), tensor.dims(), name,
                            visibility, trainable);
-  V->copyFrom(&tensor);
+  V->assign(&tensor);
   return V;
 }
 

--- a/lib/Importer/Caffe2.cpp
+++ b/lib/Importer/Caffe2.cpp
@@ -178,7 +178,7 @@ void caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
       if (tensors_.count(biasTensorName)) {
         // Load the serialized bias vector.
         Tensor *b = getTensorByName(biasTensorName);
-        biasTensor.copyFrom(b);
+        biasTensor.assign(b);
       }
     }
     auto *bias = G_.getParent()->createVariable("conv.bias", biasTensor);
@@ -247,10 +247,10 @@ void caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     auto *node = G_.createBatchNormalization(opName, in, channel, epsilon);
 
     // Load the weights.
-    cast<Variable>(node->getScale())->copyFrom(scale);
-    cast<Variable>(node->getBias())->copyFrom(bias);
-    cast<Variable>(node->getMean())->copyFrom(mean);
-    cast<Variable>(node->getVar())->copyFrom(var);
+    cast<Variable>(node->getScale())->assign(scale);
+    cast<Variable>(node->getBias())->assign(bias);
+    cast<Variable>(node->getMean())->assign(mean);
+    cast<Variable>(node->getVar())->assign(var);
 
     addNodeAsOutput(op, node);
     return;

--- a/lib/Importer/ONNX.cpp
+++ b/lib/Importer/ONNX.cpp
@@ -285,7 +285,7 @@ bool ONNXModelLoader::loadOperator(const ONNX_NAMESPACE::NodeProto &op) {
       if (tensors_.count(biasTensorName)) {
         // Load the serialized bias vector.
         Tensor *b = getTensorByName(biasTensorName);
-        biasTensor.copyFrom(b);
+        biasTensor.assign(b);
       }
     }
     auto *bias = G_.getParent()->createVariable("conv.bias", biasTensor);
@@ -394,10 +394,10 @@ bool ONNXModelLoader::loadOperator(const ONNX_NAMESPACE::NodeProto &op) {
     auto *node = G_.createBatchNormalization(opName, in, 1, epsilon);
 
     // Load the weights.
-    cast<Variable>(node->getScale())->copyFrom(scale);
-    cast<Variable>(node->getBias())->copyFrom(bias);
-    cast<Variable>(node->getMean())->copyFrom(mean);
-    cast<Variable>(node->getVar())->copyFrom(var);
+    cast<Variable>(node->getScale())->assign(scale);
+    cast<Variable>(node->getBias())->assign(bias);
+    cast<Variable>(node->getMean())->assign(mean);
+    cast<Variable>(node->getVar())->assign(var);
     addNodeAsOutput(op, node);
     return true;
   }

--- a/tests/unittests/BackendTestUtils.cpp
+++ b/tests/unittests/BackendTestUtils.cpp
@@ -53,7 +53,7 @@ void inferBatchedAddNet(Tensor *batch, Tensor *slice, Tensor *out,
   auto result = F->createSave("ret", batchedadd, outVar);
   EE.compile(CompilationMode::Infer, F);
   EE.run({batchVar, sliceVar}, {batch, slice});
-  out->copyFrom(&result->getVariable()->getPayload());
+  out->assign(&result->getVariable()->getPayload());
 }
 
 void inferBatchedReduceAddNet(Tensor *inputs, Tensor *out, BackendKind kind) {
@@ -66,7 +66,7 @@ void inferBatchedReduceAddNet(Tensor *inputs, Tensor *out, BackendKind kind) {
   auto result = F->createSave("ret", batchedreduce);
   EE.compile(CompilationMode::Infer, F);
   EE.run({var}, {inputs});
-  out->copyFrom(&result->getVariable()->getPayload());
+  out->assign(&result->getVariable()->getPayload());
 }
 
 void inferIntLookupTableNet(Tensor *input, Tensor *out,
@@ -80,7 +80,7 @@ void inferIntLookupTableNet(Tensor *input, Tensor *out,
   auto result = F->createSave("ret", lookupTable);
   EE.compile(CompilationMode::Infer, F);
   EE.run({var}, {input});
-  out->copyFrom(&result->getVariable()->getPayload());
+  out->assign(&result->getVariable()->getPayload());
 }
 
 void inferConvNet(Tensor *inputs, Tensor *filter, Tensor *bias, Tensor *out,
@@ -113,7 +113,7 @@ void inferConvNet(Tensor *inputs, Tensor *filter, Tensor *bias, Tensor *out,
   auto result = F->createSave("ret", conv, outVar);
   EE.compile(CompilationMode::Infer, F);
   EE.run({inputVar, filterVar, biasVar}, {inputs, filter, bias});
-  out->copyFrom(&result->getVariable()->getPayload());
+  out->assign(&result->getVariable()->getPayload());
 }
 
 void trainConvNet(Tensor *inputs, Tensor *kernel1, Tensor *bias1,
@@ -132,12 +132,12 @@ void trainConvNet(Tensor *inputs, Tensor *kernel1, Tensor *bias1,
   auto *var2 = VarFrom(selected);
   auto *conv1 =
       F->createConv("conv1", var1, 3, {5, 3}, {2, 1}, {2, 1, 2, 1}, 1);
-  cast<Variable>(conv1->getFilter())->copyFrom(kernel1);
-  cast<Variable>(conv1->getBias())->copyFrom(bias1);
+  cast<Variable>(conv1->getFilter())->assign(kernel1);
+  cast<Variable>(conv1->getBias())->assign(bias1);
   auto *reshape1 = F->createReshape("reshape1", conv1, shape1);
   auto *conv2 = F->createConv("conv2", reshape1, 2, 2, 2, 0, 1);
-  cast<Variable>(conv2->getFilter())->copyFrom(kernel2);
-  cast<Variable>(conv2->getBias())->copyFrom(bias2);
+  cast<Variable>(conv2->getFilter())->assign(kernel2);
+  cast<Variable>(conv2->getBias())->assign(bias2);
   auto *reshape2 = F->createReshape("reshape2", conv2, shape2);
   auto *softmax = F->createSoftMax("softmax", reshape2, var2);
   auto result = F->createSave("ret", softmax);
@@ -148,7 +148,7 @@ void trainConvNet(Tensor *inputs, Tensor *kernel1, Tensor *bias1,
   EE.runBatch(8, {var1, var2}, {inputs, selected});
   EE.compile(CompilationMode::Infer, F);
   EE.run({var1, var2}, {inputs, selected});
-  out->copyFrom(&result->getVariable()->getPayload());
+  out->assign(&result->getVariable()->getPayload());
 }
 
 void inferGatherNet(Tensor *data, Tensor *indices, Tensor *dest,
@@ -162,7 +162,7 @@ void inferGatherNet(Tensor *data, Tensor *indices, Tensor *dest,
   auto *result = F->createSave("ret", gather);
   EE.compile(CompilationMode::Infer, F);
   EE.run({dataV, indicesV}, {data, indices});
-  dest->copyFrom(&result->getVariable()->getPayload());
+  dest->assign(&result->getVariable()->getPayload());
 }
 
 void inferLocalResponseNormalizationNet(Tensor *inputs, Tensor *out,
@@ -175,7 +175,7 @@ void inferLocalResponseNormalizationNet(Tensor *inputs, Tensor *out,
   auto result = F->createSave("ret", lrn);
   EE.compile(CompilationMode::Infer, F);
   EE.run({var}, {inputs});
-  out->copyFrom(&result->getVariable()->getPayload());
+  out->assign(&result->getVariable()->getPayload());
 }
 
 void trainLocalResponseNormalizationNet(Tensor *inputs, Tensor *weights,
@@ -194,8 +194,8 @@ void trainLocalResponseNormalizationNet(Tensor *inputs, Tensor *weights,
   auto *var1 = VarFrom(inputs);
   auto *var2 = VarFrom(selected);
   auto *fc = F->createFullyConnected("fc", var1, bias->dims()[0]);
-  cast<Variable>(fc->getWeights())->copyFrom(weights);
-  cast<Variable>(fc->getBias())->copyFrom(bias);
+  cast<Variable>(fc->getWeights())->assign(weights);
+  cast<Variable>(fc->getBias())->assign(bias);
   auto *reshape1 = F->createReshape("reshape1", fc, shape1);
   auto *lrn =
       F->createLocalResponseNormalization("lrn", reshape1, 2, 2.0, 0.5, 1.0);
@@ -209,7 +209,7 @@ void trainLocalResponseNormalizationNet(Tensor *inputs, Tensor *weights,
 
   EE.compile(CompilationMode::Infer, F);
   EE.runBatch(1, {var1, var2}, {inputs, selected});
-  out->copyFrom(&result->getVariable()->getPayload());
+  out->assign(&result->getVariable()->getPayload());
 }
 
 void inferMatMulNet(Tensor *lhs, Tensor *rhs, Tensor *out, BackendKind kind) {
@@ -237,7 +237,7 @@ void inferMatMulNet(Tensor *lhs, Tensor *rhs, Tensor *out, BackendKind kind) {
   auto result = F->createSave("ret", matmul, outVar);
   EE.compile(CompilationMode::Infer, F);
   EE.run({lhsVar, rhsVar}, {lhs, rhs});
-  out->copyFrom(&result->getVariable()->getPayload());
+  out->assign(&result->getVariable()->getPayload());
 }
 
 void inferMaxNet(Tensor *inputs1, Tensor *inputs2, Tensor *out,
@@ -251,7 +251,7 @@ void inferMaxNet(Tensor *inputs1, Tensor *inputs2, Tensor *out,
   auto result = F->createSave("ret", max);
   EE.compile(CompilationMode::Infer, F);
   EE.run({var1, var2}, {inputs1, inputs2});
-  out->copyFrom(&result->getVariable()->getPayload());
+  out->assign(&result->getVariable()->getPayload());
 }
 
 void inferMinNet(Tensor *inputs1, Tensor *inputs2, Tensor *out,
@@ -265,7 +265,7 @@ void inferMinNet(Tensor *inputs1, Tensor *inputs2, Tensor *out,
   auto result = F->createSave("ret", min);
   EE.compile(CompilationMode::Infer, F);
   EE.run({var1, var2}, {inputs1, inputs2});
-  out->copyFrom(&result->getVariable()->getPayload());
+  out->assign(&result->getVariable()->getPayload());
 }
 
 void inferAvgPoolNet(Tensor *inputs, Tensor *out, BackendKind kind) {
@@ -277,7 +277,7 @@ void inferAvgPoolNet(Tensor *inputs, Tensor *out, BackendKind kind) {
   auto result = F->createSave("ret", pool);
   EE.compile(CompilationMode::Infer, F);
   EE.run({var}, {inputs});
-  out->copyFrom(&result->getVariable()->getPayload());
+  out->assign(&result->getVariable()->getPayload());
 }
 
 void trainAvgPoolNet(Tensor *inputs, Tensor *weights, Tensor *bias,
@@ -295,8 +295,8 @@ void trainAvgPoolNet(Tensor *inputs, Tensor *weights, Tensor *bias,
   auto *var1 = VarFrom(inputs);
   auto *var2 = VarFrom(selected);
   auto *fc = F->createFullyConnected("fc", var1, bias->dims()[0]);
-  cast<Variable>(fc->getWeights())->copyFrom(weights);
-  cast<Variable>(fc->getBias())->copyFrom(bias);
+  cast<Variable>(fc->getWeights())->assign(weights);
+  cast<Variable>(fc->getBias())->assign(bias);
   auto *reshape1 = F->createReshape("reshape1", fc, shape1);
   auto *pool = F->createAvgPool("pool", reshape1, 2, 2, 0);
   auto *reshape2 = F->createReshape("reshape2", pool, shape2);
@@ -309,7 +309,7 @@ void trainAvgPoolNet(Tensor *inputs, Tensor *weights, Tensor *bias,
   EE.runBatch(10, {var1, var2}, {inputs, selected});
   EE.compile(CompilationMode::Infer, F);
   EE.run({var1, var2}, {inputs, selected});
-  out->copyFrom(&result->getVariable()->getPayload());
+  out->assign(&result->getVariable()->getPayload());
 }
 
 void inferMaxPoolNet(Tensor *inputs, Tensor *out, BackendKind kind) {
@@ -321,7 +321,7 @@ void inferMaxPoolNet(Tensor *inputs, Tensor *out, BackendKind kind) {
   auto result = F->createSave("ret", pool);
   EE.compile(CompilationMode::Infer, F);
   EE.run({var}, {inputs});
-  out->copyFrom(&result->getVariable()->getPayload());
+  out->assign(&result->getVariable()->getPayload());
 }
 
 void trainMaxPoolNet(Tensor *inputs, Tensor *weights, Tensor *bias,
@@ -339,8 +339,8 @@ void trainMaxPoolNet(Tensor *inputs, Tensor *weights, Tensor *bias,
   auto *var1 = VarFrom(inputs);
   auto *var2 = VarFrom(selected);
   auto *fc = F->createFullyConnected("fc", var1, bias->dims()[0]);
-  cast<Variable>(fc->getWeights())->copyFrom(weights);
-  cast<Variable>(fc->getBias())->copyFrom(bias);
+  cast<Variable>(fc->getWeights())->assign(weights);
+  cast<Variable>(fc->getBias())->assign(bias);
   auto *reshape1 = F->createReshape("reshape1", fc, shape1);
   auto *pool = F->createMaxPool("pool", reshape1, 5, 3, 4);
   auto *reshape2 = F->createReshape("reshape2", pool, shape2);
@@ -353,7 +353,7 @@ void trainMaxPoolNet(Tensor *inputs, Tensor *weights, Tensor *bias,
   EE.runBatch(7, {var1, var2}, {inputs, selected});
   EE.compile(CompilationMode::Infer, F);
   EE.runBatch(1, {var1, var2}, {inputs, selected});
-  out->copyFrom(&result->getVariable()->getPayload());
+  out->assign(&result->getVariable()->getPayload());
 }
 
 void inferQuantizeNet(Tensor *inputs, float scale, int32_t offset, Tensor *out,
@@ -372,7 +372,7 @@ void inferQuantizeNet(Tensor *inputs, float scale, int32_t offset, Tensor *out,
   auto result = F->createSave("ret", dequantize);
   EE.compile(CompilationMode::Infer, F);
   EE.run({var}, {inputs});
-  out->copyFrom(&result->getVariable()->getPayload());
+  out->assign(&result->getVariable()->getPayload());
 }
 
 void inferReluNet(Tensor *inputs, Tensor *out, BackendKind kind) {
@@ -384,7 +384,7 @@ void inferReluNet(Tensor *inputs, Tensor *out, BackendKind kind) {
   auto result = F->createSave("ret", relu);
   EE.compile(CompilationMode::Infer, F);
   EE.run({var}, {inputs});
-  out->copyFrom(&result->getVariable()->getPayload());
+  out->assign(&result->getVariable()->getPayload());
 }
 
 void inferReshapeNet(Tensor *inputs, llvm::ArrayRef<size_t> shape, Tensor *out,
@@ -397,7 +397,7 @@ void inferReshapeNet(Tensor *inputs, llvm::ArrayRef<size_t> shape, Tensor *out,
   auto result = F->createSave("ret", reshape);
   EE.compile(CompilationMode::Infer, F);
   EE.run({var}, {inputs});
-  out->copyFrom(&result->getVariable()->getPayload());
+  out->assign(&result->getVariable()->getPayload());
 }
 
 void inferSelectNet(Tensor *cond, Tensor *inputs1, Tensor *inputs2, Tensor *out,
@@ -412,7 +412,7 @@ void inferSelectNet(Tensor *cond, Tensor *inputs1, Tensor *inputs2, Tensor *out,
   auto result = F->createSave("ret", select);
   EE.compile(CompilationMode::Infer, F);
   EE.run({var1, var2, var3}, {cond, inputs1, inputs2});
-  out->copyFrom(&result->getVariable()->getPayload());
+  out->assign(&result->getVariable()->getPayload());
 }
 
 void inferSigmoidNet(Tensor *inputs, Tensor *out, BackendKind kind) {
@@ -424,7 +424,7 @@ void inferSigmoidNet(Tensor *inputs, Tensor *out, BackendKind kind) {
   auto result = F->createSave("ret", sigmoid);
   EE.compile(CompilationMode::Infer, F);
   EE.run({var}, {inputs});
-  out->copyFrom(&result->getVariable()->getPayload());
+  out->assign(&result->getVariable()->getPayload());
 }
 
 void inferSmallConv(Tensor *inputs, Tensor *out, BackendKind kind) {
@@ -438,7 +438,7 @@ void inferSmallConv(Tensor *inputs, Tensor *out, BackendKind kind) {
   auto *result = F->createSave("ret", C);
   EE.compile(CompilationMode::Infer, F);
   EE.run({in}, {inputs});
-  out->copyFrom(&result->getVariable()->getPayload());
+  out->assign(&result->getVariable()->getPayload());
 }
 
 void inferGroupConv(Tensor *out, BackendKind kind) {
@@ -470,7 +470,7 @@ void inferGroupConv(Tensor *out, BackendKind kind) {
 
   EE.compile(CompilationMode::Infer, F);
   EE.run({}, {});
-  out->copyFrom(&result->getVariable()->getPayload());
+  out->assign(&result->getVariable()->getPayload());
 }
 
 void inferNonSquarePaddingConv(Tensor *out, BackendKind kind) {
@@ -501,7 +501,7 @@ void inferNonSquarePaddingConv(Tensor *out, BackendKind kind) {
 
   EE.compile(CompilationMode::Infer, F);
   EE.run({}, {});
-  out->copyFrom(&result->getVariable()->getPayload());
+  out->assign(&result->getVariable()->getPayload());
 }
 
 void inferNonSquareKernelConv(Tensor *out, BackendKind kind) {
@@ -533,7 +533,7 @@ void inferNonSquareKernelConv(Tensor *out, BackendKind kind) {
 
   EE.compile(CompilationMode::Infer, F);
   EE.run({}, {});
-  out->copyFrom(&result->getVariable()->getPayload());
+  out->assign(&result->getVariable()->getPayload());
 }
 
 void inferNonSquareStrideConv(Tensor *out, BackendKind kind) {
@@ -565,7 +565,7 @@ void inferNonSquareStrideConv(Tensor *out, BackendKind kind) {
 
   EE.compile(CompilationMode::Infer, F);
   EE.run({}, {});
-  out->copyFrom(&result->getVariable()->getPayload());
+  out->assign(&result->getVariable()->getPayload());
 }
 
 void inferConvDKKC8(Tensor *out, BackendKind kind) {
@@ -598,7 +598,7 @@ void inferConvDKKC8(Tensor *out, BackendKind kind) {
 
   EE.compile(CompilationMode::Infer, F);
   EE.run({}, {});
-  out->copyFrom(&result->getVariable()->getPayload());
+  out->assign(&result->getVariable()->getPayload());
 }
 
 void inferSoftMaxNet(Tensor *inputs, Tensor *selected, Tensor *out,
@@ -612,7 +612,7 @@ void inferSoftMaxNet(Tensor *inputs, Tensor *selected, Tensor *out,
   auto result = F->createSave("ret", softmax);
   EE.compile(CompilationMode::Infer, F);
   EE.run({var1, var2}, {inputs, selected});
-  out->copyFrom(&result->getVariable()->getPayload());
+  out->assign(&result->getVariable()->getPayload());
 }
 
 void trainSoftMaxNet(Tensor *inputs, Tensor *weights, Tensor *bias,
@@ -628,8 +628,8 @@ void trainSoftMaxNet(Tensor *inputs, Tensor *weights, Tensor *bias,
   auto *var1 = VarFrom(inputs);
   auto *var2 = VarFrom(selected);
   auto *fc = F->createFullyConnected("fc", var1, bias->dims()[0]);
-  cast<Variable>(fc->getWeights())->copyFrom(weights);
-  cast<Variable>(fc->getBias())->copyFrom(bias);
+  cast<Variable>(fc->getWeights())->assign(weights);
+  cast<Variable>(fc->getBias())->assign(bias);
   auto *softmax = F->createSoftMax("softmax", fc, var2);
   auto result = F->createSave("ret", softmax);
 
@@ -639,7 +639,7 @@ void trainSoftMaxNet(Tensor *inputs, Tensor *weights, Tensor *bias,
   EE.runBatch(30, {var1, var2}, {inputs, selected});
   EE.compile(CompilationMode::Infer, F);
   EE.run({var1, var2}, {inputs, selected});
-  out->copyFrom(&result->getVariable()->getPayload());
+  out->assign(&result->getVariable()->getPayload());
 }
 
 void inferTanhNet(Tensor *inputs, Tensor *out, BackendKind kind) {
@@ -651,7 +651,7 @@ void inferTanhNet(Tensor *inputs, Tensor *out, BackendKind kind) {
   auto result = F->createSave("ret", tanh);
   EE.compile(CompilationMode::Infer, F);
   EE.run({var}, {inputs});
-  out->copyFrom(&result->getVariable()->getPayload());
+  out->assign(&result->getVariable()->getPayload());
 }
 
 void inferTransposeNet(Tensor *inputs, Tensor *out, BackendKind kind) {
@@ -663,7 +663,7 @@ void inferTransposeNet(Tensor *inputs, Tensor *out, BackendKind kind) {
   auto result = F->createSave("ret", tr);
   EE.compile(CompilationMode::Infer, F);
   EE.run({var}, {inputs});
-  out->copyFrom(&result->getVariable()->getPayload());
+  out->assign(&result->getVariable()->getPayload());
 }
 
 void inferTanhConcatNet(Tensor *input1, Tensor *input2, Tensor *input3,
@@ -682,7 +682,7 @@ void inferTanhConcatNet(Tensor *input1, Tensor *input2, Tensor *input3,
   auto *result = F->createSave("ret", C2);
   EE.compile(CompilationMode::Infer, F);
   EE.run({var1, var2, var3}, {input1, input2, input3});
-  out->copyFrom(&result->getVariable()->getPayload());
+  out->assign(&result->getVariable()->getPayload());
 }
 
 void inferBasicConvNet(Tensor *inputs, Tensor *out, BackendKind kind,
@@ -700,7 +700,7 @@ void inferBasicConvNet(Tensor *inputs, Tensor *out, BackendKind kind,
   auto result = F->createSave("ret", pool);
   EE.compile(CompilationMode::Infer, F);
   EE.run({var}, {inputs});
-  out->copyFrom(&result->getVariable()->getPayload());
+  out->assign(&result->getVariable()->getPayload());
 }
 
 void inferBasicFCNet(Tensor *inputs, Tensor *out, BackendKind kind) {
@@ -718,7 +718,7 @@ void inferBasicFCNet(Tensor *inputs, Tensor *out, BackendKind kind) {
   auto result = F->createSave("ret", rl1);
   EE.compile(CompilationMode::Infer, F);
   EE.run({var}, {inputs});
-  out->copyFrom(&result->getVariable()->getPayload());
+  out->assign(&result->getVariable()->getPayload());
 }
 
 void inferMixedNet(Tensor *inputs, Tensor *out, BackendKind kind) {
@@ -744,7 +744,7 @@ void inferMixedNet(Tensor *inputs, Tensor *out, BackendKind kind) {
 
   EE.compile(CompilationMode::Infer, F);
   EE.run({var}, {inputs});
-  out->copyFrom(&result->getVariable()->getPayload());
+  out->assign(&result->getVariable()->getPayload());
 }
 
 void inferComplexNet1(Tensor *inputs1, Tensor *inputs2, Tensor *inputs3,
@@ -783,14 +783,14 @@ void inferComplexNet1(Tensor *inputs1, Tensor *inputs2, Tensor *inputs3,
   auto result = F->createSave("ret", sigmoid3);
   EE.compile(CompilationMode::Infer, F);
   EE.run({var1, var2, var3, var4}, {inputs1, inputs2, inputs3, inputs4});
-  out->copyFrom(&result->getVariable()->getPayload());
+  out->assign(&result->getVariable()->getPayload());
 }
 
 namespace {
 // Helper for initializing conv node filter/bias from input tensors.
 static void initConv(ConvolutionNode *C, Tensor &filter, Tensor &bias) {
-  cast<Variable>(C->getFilter())->getPayload().copyFrom(&filter);
-  cast<Variable>(C->getBias())->getPayload().copyFrom(&bias);
+  cast<Variable>(C->getFilter())->getPayload().assign(&filter);
+  cast<Variable>(C->getBias())->getPayload().assign(&bias);
 }
 } // namespace
 
@@ -819,7 +819,7 @@ void inferTinyResnet(Tensor *input, Tensor *out, std::vector<Tensor> &weights,
   EE.compile(CompilationMode::Infer, F);
 
   EE.run({in}, {input});
-  out->copyFrom(&result->getVariable()->getPayload());
+  out->assign(&result->getVariable()->getPayload());
 }
 
 void inferExtract3D(Tensor *input, Tensor *out, BackendKind kind) {
@@ -849,7 +849,7 @@ void inferExtract3D(Tensor *input, Tensor *out, BackendKind kind) {
   EE.compile(CompilationMode::Infer, F);
 
   EE.run({inputs}, {input});
-  out->copyFrom(&result->getVariable()->getPayload());
+  out->assign(&result->getVariable()->getPayload());
 }
 
 void inferMaxSplat(Tensor *input, Tensor *out, BackendKind kind) {
@@ -873,7 +873,7 @@ void inferMaxSplat(Tensor *input, Tensor *out, BackendKind kind) {
   auto result = F->createSave("ret", max2);
   EE.compile(CompilationMode::Infer, F);
   EE.run({var}, {input});
-  out->copyFrom(&result->getVariable()->getPayload());
+  out->assign(&result->getVariable()->getPayload());
 }
 
 } // namespace glow

--- a/tests/unittests/GemmTest.cpp
+++ b/tests/unittests/GemmTest.cpp
@@ -53,7 +53,7 @@ void infer(Tensor *out, Tensor *lhs, Tensor *rhs) {
   auto result = F->createSave("ret", matmul, outVar);
   EE.compile(CompilationMode::Infer, F);
   EE.run({lhsVar, rhsVar}, {lhs, rhs});
-  out->copyFrom(&result->getVariable()->getPayload());
+  out->assign(&result->getVariable()->getPayload());
 }
 
 TEST(Gemm, jitTest) {

--- a/tests/unittests/tensorsTest.cpp
+++ b/tests/unittests/tensorsTest.cpp
@@ -67,7 +67,7 @@ TEST(Tensor, clone) {
   auto H = T.getHandle<>();
 
   Tensor v;
-  v.copyFrom(&T);
+  v.assign(&T);
   auto vH = v.getHandle<>();
 
   EXPECT_EQ(int(vH.at({0})), 1);


### PR DESCRIPTION
This function does not only copy the content of a tensor, but also changes the type. Therefore, it is better to rename it as "assign".