### PR TITLE
[opencl][quantization]: Support TopK for OpenCL backend, with also quantization support

### DIFF
--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -197,6 +197,7 @@ public:
       case Kinded::Kind::SliceNodeKind:
       case Kinded::Kind::SplatNodeKind:
       case Kinded::Kind::SubNodeKind:
+      case Kinded::Kind::TopKInstKind:
       case Kinded::Kind::TransposeNodeKind:
         return true;
       default:

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -584,7 +584,7 @@ TEST_P(Operator, minElem) {
   }
 }
 
-TEST_P(InterpAndCPU, TopK) {
+TEST_P(Operator, TopK) {
   auto *inp = mod_.createVariable(ElemKind::FloatTy, {3, 1, 5}, "input");
   auto *values = mod_.createVariable(ElemKind::FloatTy, {3, 1, 3}, "values");
   auto *indices = mod_.createVariable(ElemKind::IndexTy, {3, 1, 3}, "indices");

--- a/tests/unittests/quantizationTest.cpp
+++ b/tests/unittests/quantizationTest.cpp
@@ -332,7 +332,7 @@ static Function *createGRUForQuantization(Module *M, llvm::StringRef funcName) {
   return F;
 }
 
-TEST_P(Quantization, end2endGRU) {
+TEST_P(Operator, end2endGRU) {
   // STEP1 - Generate the first network to record the quantization parameters.
   auto *mod = &interpreterEE.getModule();
   Function *F1 = createGRUForQuantization(mod, "main");


### PR DESCRIPTION
Support TopK for OpenCL backend, with also quantization support.
Also enabled end2endGRU test for OpenCL now.

For the time being the actual computation of TopK is performed on the host side and not by means of an OpenCL kernel. We may add an optimized kernel in the future.