### PR TITLE
[unittest] Fix memoryAllocatorTest

### DIFF
--- a/tests/unittests/memoryAllocatorTest.cpp
+++ b/tests/unittests/memoryAllocatorTest.cpp
@@ -15,7 +15,6 @@
  */
 
 #include "glow/CodeGen/MemoryAllocator.h"
-#include "glow/IR/IR.h"
 
 #include "gtest/gtest.h"
 


### PR DESCRIPTION
memoryAllocatorTest was recently extended by 63cbea89. Including IR.h caused a build failure (due to  cmake missing dependency for the test):

In file included from include/glow/IR/IR.h:19:0,
                 from tests/unittests/memoryAllocatorTest.cpp:18:
include/glow/Base/Traits.h:71:33: fatal error: glow/AutoGenInstr.def: No such file or directory

But it looks like IR.h is not needed in the test and can be removed, preventing the issue.