### PR TITLE
Fix bugs in our Caffe2 importer

### DIFF
--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -700,9 +700,14 @@ void ConcatNode::verify() const {
   auto dimension = getDim();
   (void)inputs;
   (void)dimension;
+  assert(!inputs.empty() && "Empty concat?!");
+  assert(inputs[0].dims().size() > dimension && "concat on invalid dimension");
 
+  size_t nbDims = inputs[0].dims().size();
   for (size_t i = 1; i < inputs.size(); i++) {
-    for (size_t j = 0; j < inputs[0].dims().size(); j++) {
+    assert(nbDims == inputs[i].dims().size() &&
+           "input #dims are incompatible between elements");
+    for (size_t j = 0; j < nbDims; j++) {
       if (j == dimension) {
         continue;
       }

--- a/tests/models/caffe2Models/concat_add_axis_predict_net.pbtxt
+++ b/tests/models/caffe2Models/concat_add_axis_predict_net.pbtxt
@@ -1,0 +1,22 @@
+name: "concatx3add_axis"
+op {
+  input: "inputs_0"
+  input: "inputs_1"
+  input: "inputs_2"
+  output: "concat_result"
+  output: "split_info"
+  name: ""
+  type: "Concat"
+  arg {
+    name: "add_axis"
+    i: 1
+  }
+  arg {
+    name: "axis"
+    i: 1
+  }
+}
+external_input: "inputs_0"
+external_input: "inputs_1"
+external_input: "inputs_2"
+external_output: "concat_result"

--- a/tests/models/caffe2Models/concat_predict_net.pbtxt
+++ b/tests/models/caffe2Models/concat_predict_net.pbtxt
@@ -1,0 +1,22 @@
+name: "concatx3"
+op {
+  input: "inputs_0"
+  input: "inputs_1"
+  input: "inputs_2"
+  output: "concat_result"
+  output: "split_info"
+  name: ""
+  type: "Concat"
+  arg {
+    name: "add_axis"
+    i: 0
+  }
+  arg {
+    name: "axis"
+    i: 1
+  }
+}
+external_input: "inputs_0"
+external_input: "inputs_1"
+external_input: "inputs_2"
+external_output: "concat_result"

--- a/tests/models/caffe2Models/matmul_trans_RHS_predict_net.pbtxt
+++ b/tests/models/caffe2Models/matmul_trans_RHS_predict_net.pbtxt
@@ -1,0 +1,23 @@
+name: "matmul_trans_RHS"
+op {
+  input: "inputs_0"
+  input: "inputs_1"
+  output: "output"
+  name: ""
+  type: "BatchMatMul"
+  arg {
+    name: "broadcast"
+    i: 0
+  }
+  arg {
+    name: "trans_a"
+    i: 0
+  }
+  arg {
+    name: "trans_b"
+    i: 1
+  }
+}
+external_input: "inputs_0"
+external_input: "inputs_1"
+external_output: "output"

--- a/tests/unittests/caffe2ImporterTest.cpp
+++ b/tests/unittests/caffe2ImporterTest.cpp
@@ -53,3 +53,149 @@ TEST(caffe2, importConv) {
   for (size_t i = 0; i < 4 * 4; i++)
     EXPECT_FLOAT_EQ(result.raw(i), expectedValues[i]);
 }
+
+/// Test loading a concat node with add_axis.
+/// Concat nodes with add_axis have a different semantic
+/// than the plain glow concat.
+/// concat A(dim0, dim1), B(dim0, dim1), ... 1, add_axis = 1
+/// res = A, B...
+/// C2 shape: dim0, #input, dim1, i.e., three dimensions.
+/// Glow shape: dim0, #input x dim1, i.e., two dimensions.
+///
+/// To fill the gap between the two, glow issues a reshape
+/// right after its concat.
+TEST(caffe2, concatAddAxis) {
+  ExecutionEngine EE{BackendKind::Interpreter};
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+
+  std::string NetDescFilename(
+      "tests/models/caffe2Models/concat_add_axis_predict_net.pbtxt");
+  std::string NetWeightFilename(
+      "tests/models/caffe2Models/empty_init_net.pbtxt");
+
+  SaveNode *output;
+  Tensor inputs_0(ElemKind::FloatTy, {10, 7});
+  Tensor inputs_1(ElemKind::FloatTy, {10, 7});
+  Tensor inputs_2(ElemKind::FloatTy, {10, 7});
+  inputs_0.getHandle().randomize(-3.0, 3.0, mod.getPRNG());
+  inputs_1.getHandle().randomize(-3.0, 3.0, mod.getPRNG());
+  inputs_2.getHandle().randomize(-3.0, 3.0, mod.getPRNG());
+  // Destroy the loader after the graph is loaded since the following execution
+  // will not depend on anyting from the loader.
+  {
+    caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename,
+                               {"inputs_0", "inputs_1", "inputs_2"},
+                               {&inputs_0, &inputs_1, &inputs_2}, *F);
+    output = caffe2LD.getSingleOutput();
+  }
+
+  auto result = output->getVariable()->getHandle();
+  // Check that the shape of the output matches what Caffe2 expects.
+  std::vector<size_t> expectedDims = {10, 3, 7};
+  EXPECT_TRUE(result.dims().vec() == expectedDims);
+
+  EE.compile(CompilationMode::Infer, F);
+  EE.run({}, {});
+  // High level check on the content of the graph.
+  // We have 1 reshape, 1 concat, and 1 save.
+  EXPECT_EQ(F->getNodes().size(), 3);
+  // With have three inputs and one outputs.
+  EXPECT_EQ(mod.getVars().size(), 4);
+
+  // Check that the graph has the expected shape,
+  // starting from the output.
+  auto *reshape = llvm::dyn_cast<ReshapeNode>(output->getInput().getNode());
+  ASSERT_TRUE(reshape);
+  auto *concat = llvm::dyn_cast<ConcatNode>(reshape->getInput());
+  ASSERT_TRUE(concat);
+  // We will check that the inputs are correct within
+  // the next loop.
+
+  // Check that the output matches the concatenation of
+  // all the inputs.
+  Tensor *inputs[] = {&inputs_0, &inputs_1, &inputs_2};
+  for (size_t i = 0; i < 3; ++i) {
+    const auto inputsHandle = inputs[i]->getHandle();
+    ASSERT_TRUE(llvm::isa<Variable>(concat->getInputs()[i]));
+    EXPECT_TRUE(llvm::cast<Variable>(concat->getInputs()[i])
+                    ->getPayload()
+                    .isEqual(*inputs[i]));
+
+    for (size_t row = 0; row < 10; ++row) {
+      for (size_t column = 0; column < 7; ++column) {
+        EXPECT_FLOAT_EQ(result.at({row, i, column}),
+                        inputsHandle.at({row, column}));
+      }
+    }
+  }
+}
+
+/// Test loading a regular concat node.
+TEST(caffe2, concat) {
+  ExecutionEngine EE{BackendKind::Interpreter};
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+
+  std::string NetDescFilename(
+      "tests/models/caffe2Models/concat_predict_net.pbtxt");
+  std::string NetWeightFilename(
+      "tests/models/caffe2Models/empty_init_net.pbtxt");
+
+  SaveNode *output;
+  Tensor inputs_0(ElemKind::FloatTy, {10, 7});
+  Tensor inputs_1(ElemKind::FloatTy, {10, 12});
+  Tensor inputs_2(ElemKind::FloatTy, {10, 5});
+  inputs_0.getHandle().randomize(-3.0, 3.0, mod.getPRNG());
+  inputs_1.getHandle().randomize(-3.0, 3.0, mod.getPRNG());
+  inputs_2.getHandle().randomize(-3.0, 3.0, mod.getPRNG());
+  // Destroy the loader after the graph is loaded since the following execution
+  // will not depend on anyting from the loader.
+  {
+    caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename,
+                               {"inputs_0", "inputs_1", "inputs_2"},
+                               {&inputs_0, &inputs_1, &inputs_2}, *F);
+    output = caffe2LD.getSingleOutput();
+  }
+
+  auto result = output->getVariable()->getHandle();
+  // Check that the shape of the output matches what Caffe2 expects.
+  std::vector<size_t> expectedDims = {10, 24};
+  EXPECT_TRUE(result.dims().vec() == expectedDims);
+
+  EE.compile(CompilationMode::Infer, F);
+  EE.run({}, {});
+  // High level check on the content of the graph.
+  // We have 1 concat, and 1 save.
+  EXPECT_EQ(F->getNodes().size(), 2);
+  // With have three inputs and one outputs.
+  EXPECT_EQ(mod.getVars().size(), 4);
+
+  // Check that the graph has the expected shape,
+  // starting from the output.
+  auto *concat = llvm::dyn_cast<ConcatNode>(output->getInput());
+  ASSERT_TRUE(concat);
+  // We will check that the inputs are correct within
+  // the next loop.
+
+  // Check that the output matches the concatenation of
+  // all the inputs.
+  Tensor *inputs[] = {&inputs_0, &inputs_1, &inputs_2};
+  size_t columnsChecked = 0;
+  for (size_t i = 0; i < 3; ++i) {
+    const auto inputsHandle = inputs[i]->getHandle();
+    ASSERT_TRUE(llvm::isa<Variable>(concat->getInputs()[i]));
+    EXPECT_TRUE(llvm::cast<Variable>(concat->getInputs()[i])
+                    ->getPayload()
+                    .isEqual(*inputs[i]));
+
+    size_t currentColumnWidth = inputs[i]->dims()[1];
+    for (size_t row = 0; row < 10; ++row) {
+      for (size_t column = 0; column < currentColumnWidth; ++column) {
+        EXPECT_FLOAT_EQ(result.at({row, columnsChecked + column}),
+                        inputsHandle.at({row, column}));
+      }
+    }
+    columnsChecked += currentColumnWidth;
+  }
+}


### PR DESCRIPTION
Each commit fixes a different bug:
- First one has to do with our modeling of concat which has a slightly different resulting shape between glow and caffe2
- Second one has to do with the indices used in the transpose for batched matmul.

Note: I stacked these commits in the same PR, because I use a newly introduced file (empty_init_net.pbtxt) in both of them.