### PR TITLE
[onnxifi] Support compatibility function.

### DIFF
--- a/include/glow/Importer/ONNX.h
+++ b/include/glow/Importer/ONNX.h
@@ -40,9 +40,6 @@ class ONNXModelLoader
   /// Get the broadcast attribute based on different ONNX op versions.
   bool getBroadcast(const ArgumentDictionaryTy &dict) override;
 
-  /// Set ir verion and op version.
-  void setVersion(ONNX_NAMESPACE::ModelProto MP);
-
   /// Load the network initializers from the GraphProto.
   void loadInitializers(ONNX_NAMESPACE::GraphProto &net);
 
@@ -50,16 +47,6 @@ class ONNXModelLoader
   /// Load the operator \p op into the network. This creates one or more nodes
   /// in the network.
   bool loadOperator(const ONNX_NAMESPACE::NodeProto &op);
-
-  /// \returns true if \p net can be constructed from the content of the
-  /// file \p filename.
-  /// Loads GraphProto \p net from the file containing serialized protobuf.
-  bool loadProto(ONNX_NAMESPACE::GraphProto &net, const std::string &filename);
-
-  /// \returns true if GraphProto \p net can be loaded from the stream \p
-  /// iStream.
-  bool loadProto(ONNX_NAMESPACE::GraphProto &net,
-                 google::protobuf::io::ZeroCopyInputStream &iStream);
 
   /// ONNX model ir_version;
   size_t irVersion_;
@@ -75,19 +62,33 @@ protected:
   /// \returns true if network can be loaded.
   bool loadNetwork(ONNX_NAMESPACE::GraphProto &net);
 
-  /// \returns true if \p net can be constructed from the in-memory
-  /// serialized protobuf.
-  /// Loads GraphProto \p net from the in-memory serialized protobuf \p
-  /// onnxModel with the model size \p onnxModelSize.
-  bool loadProto(ONNX_NAMESPACE::GraphProto &net, const void *onnxModel,
-                 size_t onnxModelSize);
-
   /// Set the output nodes of the network \p net. Initializes the map from the
   /// names of the outputs to the save nodes that save each output.
   /// \returns true if output nodes were found.
   bool setOutputNodes(ONNX_NAMESPACE::GraphProto &net);
 
+  /// Set ir verion and op version.
+  void setVersion(ONNX_NAMESPACE::ModelProto MP);
+
+  /// \returns true if ModelProto \p net can be loaded from the stream \p
+  /// iStream.
+  static bool loadProto(ONNX_NAMESPACE::ModelProto &net,
+                        google::protobuf::io::ZeroCopyInputStream &iStream);
+
 public:
+  /// \returns true if ModelProto \p net can be constructed from the content
+  /// of the file \p filename.
+  /// Loads ModelProto \p net from the file containing serialized protobuf.
+  static bool loadProto(ONNX_NAMESPACE::ModelProto &net,
+                        const std::string &filename);
+
+  /// \returns true if ModelProto \p net can be constructed from the in-memory
+  /// serialized protobuf.
+  /// Loads ModelProto \p net from the in-memory serialized protobuf \p
+  /// onnxModel with the model size \p onnxModelSize.
+  static bool loadProto(ONNX_NAMESPACE::ModelProto &net, const void *onnxModel,
+                        size_t onnxModelSize);
+
   /// Checks that the inputs tensors are compatible with the inputs declared in
   /// the ONNX model. The input tensors in \p tensors are stored with the names
   /// in the list of names \p tensorNames.

--- a/include/glow/Importer/ONNXIFILoader.h
+++ b/include/glow/Importer/ONNXIFILoader.h
@@ -59,11 +59,13 @@ public:
   parse(const void *onnxModel, uint32_t onnxModelSize, uint32_t weightsCount,
         const onnxTensorDescriptorV1 *weightDescriptors, Function &F);
 
-  /// \returns unique pointer to ModelLoader if \p onnxModel can be parsed,
-  /// e.g., the model is a valid ONNX model and Glow supports all of the
-  /// operators in the network. \returns nullptr otherwise.
-  static std::unique_ptr<ModelLoader> parse(const void *onnxModel,
-                                            size_t onnxModelSize, Function &F);
+  /// \returns nullptr if ONNX operator from the \p onnxModel is not
+  /// supported by the ONNX model parser.
+  /// \returns unique ptr to operation kind and element kind otherwise.
+  ///
+  /// \param onnxModel contains a single ONNX operator.
+  static std::unique_ptr<std::pair<Kinded::Kind, ElemKind>>
+  parseOperator(const void *onnxModel, size_t onnxModelSize);
 };
 
 } // namespace onnxifi

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -22,9 +22,8 @@
 namespace glow {
 namespace onnxifi {
 
-bool BackendId::isOpSupported(const Node &node) {
-  // TODO: add support for node with multiple outputs.
-  return executionEngine_.isOpSupported(node.getKind(), node.getElementType(0));
+bool BackendId::isOpSupported(Kinded::Kind opKind, ElemKind elementTy) {
+  return executionEngine_.isOpSupported(opKind, elementTy);
 }
 
 bool Event::signal() {

--- a/lib/Onnxifi/Base.h
+++ b/lib/Onnxifi/Base.h
@@ -36,8 +36,8 @@ class BackendId {
 public:
   explicit BackendId(int id) : id_(id) {}
 
-  /// Verify that given operation is supported by the backend.
-  bool isOpSupported(const glow::Node &node);
+  /// Verify that given operation kind is supported by the backend.
+  bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy);
 
   /// \returns Execution Engine associated with the Backend.
   glow::ExecutionEngine &getEE() { return executionEngine_; }


### PR DESCRIPTION
Add proper support for onnxGetBackendCompatibility ONNXIFI method.
```
onnxGetBackendCompatibility(onnxBackendID backendID, size_t onnxModelSize,
                            const void *onnxModel) 
```
An important use case for onnxGetBackendCompatibility is when onnxModel contains only a single operation. It does not have weights and it does not have inputs.
This PR allows checking whether specific ONNX operation is supported by the Glow and specific backend.


towards fixing https://github.com/pytorch/glow/issues/1190.