### PR TITLE
[quantization] Properly quantize ReLU.

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -255,7 +255,13 @@ public:
   FullyConnectedNode *createFullyConnected(llvm::StringRef name,
                                            NodeValue input, size_t outDepth);
 
+  /// Create a ReLU node with the given \p name and \p input.
+  /// Result type will be implicitly set based on the \p input type.
   ReluNode *createRELU(llvm::StringRef name, NodeValue input);
+
+  /// Create a ReLU node with the given \p name, \p input and
+  /// output type \p outTy.
+  ReluNode *createRELU(llvm::StringRef name, NodeValue input, TypeRef outTy);
 
   SigmoidNode *createSigmoid(llvm::StringRef name, NodeValue input);
 

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -597,8 +597,13 @@ FullyConnectedNode *Function::createFullyConnected(llvm::StringRef name,
   return addNode(new FullyConnectedNode(name, OT, input, W, B));
 }
 
+ReluNode *Function::createRELU(llvm::StringRef name, NodeValue input,
+                               TypeRef outTy) {
+  return addNode(new ReluNode(name, outTy, input));
+}
+
 ReluNode *Function::createRELU(llvm::StringRef name, NodeValue input) {
-  return addNode(new ReluNode(name, input));
+  return addNode(new ReluNode(name, input.getType(), input));
 }
 
 SigmoidNode *Function::createSigmoid(llvm::StringRef name, NodeValue input) {

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -247,8 +247,15 @@ static void verifyArithmetic(NodeValue LHS, NodeValue RHS, NodeValue res) {
   checkSameShape(LHS, RHS);
 }
 
-static void verifyRelu(NodeValue src, NodeValue dest) {
-  checkSameType(src, dest);
+static void verifyRelu(NodeValue result, NodeValue input) {
+  if (input.getType()->isQuantizedType()) {
+    assert(result.getType()->isQuantizedType());
+    checkSameShape(result, input);
+    assert(result.getType()->getOffset() == -128 &&
+           "Min fp32 value should be 0");
+  } else {
+    checkSameType(result, input);
+  }
 }
 
 static void verifyRegression(NodeValue src, NodeValue dest,

--- a/lib/Optimizer/Lower.cpp
+++ b/lib/Optimizer/Lower.cpp
@@ -182,7 +182,8 @@ void lowerSigmoidGradNode(Function *F, SigmoidGradNode &THG) {
 void lowerReluNode(Function *F, ReluNode &R) {
   // Relu is a max between zero and the input value.
   SplatNode *zero = F->createSplat("zero", R.getResult().getType(), 0.0);
-  auto *relu = F->createMax("relu", zero, R.getInput());
+  auto *relu =
+      F->createMax("relu", R.getResult().getType(), zero, R.getInput());
   R.getResult().replaceAllUsesOfWith(relu);
 }
 

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -2298,6 +2298,7 @@ TEST_P(Operator, IntRelu) {
   const float splatValue = 10;
   const float scale = 1.0;
   const float rescaleScale = 2.0;
+  const int32_t reluOffset = -128;
   const int32_t offset = 5;
   const size_t size = 5;
 
@@ -2307,7 +2308,9 @@ TEST_P(Operator, IntRelu) {
 
   auto *splat = F_->createSplat("splat", splatTy, splatValue);
   auto *rescale = F_->createRescaleQuantized("rescale", splat, rescaleTy);
-  auto *relu = F_->createRELU("relu", rescale);
+  auto *reluOutTy =
+      mod_.uniqueType(ElemKind::Int8QTy, {size}, rescaleScale, reluOffset);
+  auto *relu = F_->createRELU("relu", rescale, reluOutTy);
   auto *dequantize = F_->createDequantize("dequantize", relu);
 
   auto *save = F_->createSave("save", dequantize);

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -300,7 +300,7 @@ int main(int argc, char **argv) {
 
   BB.newNode("Relu")
       .addInput("Input")
-      .addResult("Input.getType()")
+      .addResultFromCtorArg()
       .addGradient()
       .setDocstring(
           "Applies ReLU, max(0, x), to each element in the Input tensor.");


### PR DESCRIPTION
This is not yet ready for review.
Will clean this up a bit later. @jfix71 see if this patch helps with the problem you were seeing.

Essentially it was a bit misleading to have ReLU lowered to Max node with the negative floating point range. Now we create ReLU with the output type according to quantization parameters after profiling (Before that was a sequence of Max->Rescale and Rescale can go away etc).