### PR TITLE
Move ProtobufLoader output map to Variables instead of SaveNodes

### DIFF
--- a/include/glow/Importer/ONNXIFILoader.h
+++ b/include/glow/Importer/ONNXIFILoader.h
@@ -48,8 +48,8 @@ public:
   }
 
   /// \returns mapping between ONNX names and actual Glow output nodes.
-  const llvm::StringMap<SaveNode *> &getOutputVarsMapping() const {
-    return outputsByName_;
+  const llvm::StringMap<Variable *> &getOutputVarsMapping() const {
+    return outputVarsByName_;
   }
 
   /// \returns unique pointer to ModelLoader if \p onnxModel can be parsed

--- a/include/glow/Importer/ProtobufLoader.h
+++ b/include/glow/Importer/ProtobufLoader.h
@@ -98,8 +98,8 @@ protected:
   llvm::StringMap<NodeValue> nodeValueByName_;
   /// A list of weight tensors indexed by name.
   llvm::StringMap<Tensor *> tensors_;
-  /// A map from names of the external outputs of the network to SaveNodes.
-  llvm::StringMap<SaveNode *> outputsByName_;
+  /// A map from names of the external outputs of the network to Variables.
+  llvm::StringMap<Variable *> outputVarsByName_;
 
   /// \returns the tensor that was registered under the name \p name.
   Tensor *getTensorByName(llvm::StringRef name);
@@ -141,19 +141,19 @@ public:
 
   virtual ~ProtobufLoader();
 
-  /// \returns the single final output of the network. The function assumes
-  /// there is only one output, verified via assertion. For image
+  /// \returns the single final output Variable of the network. The function
+  /// assumes there is only one output, verified via assertion. For image
   /// classification, this single final output is usually the result of the last
   /// softmax or regression layer.
-  /// \pre outputsByName_.size() == 1
-  SaveNode *getSingleOutput() {
-    assert(outputsByName_.size() == 1);
-    return outputsByName_.begin()->second;
+  /// \pre outputVarsByName_.size() == 1
+  Variable *getSingleOutput() {
+    assert(outputVarsByName_.size() == 1);
+    return outputVarsByName_.begin()->second;
   }
 
-  /// \returns the SaveNode for the external output with \p name.
-  /// \pre outputsByName_.find(name) != outputsByName_.end()
-  SaveNode *getOutputByName(llvm::StringRef name) const;
+  /// \returns the Variable for the external output with \p name.
+  /// \pre outputVarsByName_.find(name) != outputVarsByName_.end()
+  Variable *getOutputByName(llvm::StringRef name) const;
 };
 
 } // namespace glow

--- a/lib/Importer/Caffe2.cpp
+++ b/lib/Importer/Caffe2.cpp
@@ -543,7 +543,8 @@ void caffe2ModelLoader::loadNetwork(caffe2::NetDef &net) {
   for (int i = 0; i < net.external_output_size(); i++) {
     auto &outputName = net.external_output(i);
     auto r = getNodeValueByName(outputName);
-    outputsByName_[outputName] = G_.createSave("save_" + outputName, r);
+    auto *SN = G_.createSave("save_" + outputName, r);
+    outputVarsByName_[outputName] = SN->getVariable();
   }
 }
 

--- a/lib/Importer/ONNX.cpp
+++ b/lib/Importer/ONNX.cpp
@@ -466,7 +466,8 @@ bool ONNXModelLoader::setOutputNodes(ONNX_NAMESPACE::GraphProto &net) {
   for (int i = 0; i < net.output_size(); i++) {
     const auto &outputName = net.output(i).name();
     auto r = getNodeValueByName(outputName);
-    outputsByName_[outputName] = G_.createSave("save_" + outputName, r);
+    SaveNode *SN = G_.createSave("save_" + outputName, r);
+    outputVarsByName_[outputName] = SN->getVariable();
   }
 
   return true;

--- a/lib/Importer/ProtobufLoader.cpp
+++ b/lib/Importer/ProtobufLoader.cpp
@@ -34,12 +34,12 @@ Tensor *ProtobufLoader::getTensorByName(llvm::StringRef name) {
   return tensors_[name];
 }
 
-SaveNode *ProtobufLoader::getOutputByName(llvm::StringRef name) const {
-  assert(outputsByName_.count(name) &&
-         "There is no tensor registered with this name.");
-  auto it = outputsByName_.find(name);
-  assert(it != outputsByName_.end() &&
-         "No external output was registered with this name.");
+Variable *ProtobufLoader::getOutputByName(llvm::StringRef name) const {
+  assert(outputVarsByName_.count(name) &&
+         "There is no Variable registered with this name.");
+  auto it = outputVarsByName_.find(name);
+  assert(it != outputVarsByName_.end() &&
+         "No external output Variable was registered with this name.");
   return it->second;
 }
 

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -83,7 +83,7 @@ onnxStatus Graph::run() {
   // Copy outputs to the addresses specified in the outputNodeToBuffer_.
   for (auto outputVar : outputNodeToBuffer_) {
     void *outputAddress = reinterpret_cast<void *>(outputVar.second);
-    const Tensor &res = outputVar.first->getVariable()->getPayload();
+    const Tensor &res = outputVar.first->getPayload();
 
     memcpy(outputAddress, res.getUnsafePtr(),
            res.size() * res.getType().getElementSize());

--- a/lib/Onnxifi/Base.h
+++ b/lib/Onnxifi/Base.h
@@ -116,7 +116,7 @@ private:
 
   /// Mapping between ONNX name for the output variable and Glow output
   /// node.
-  llvm::StringMap<SaveNode *> onnxNameToOutputNode_;
+  llvm::StringMap<Variable *> onnxNameToOutputNode_;
 
   /// Mapping between input var and the actual memory address.
   /// Inputs will be read from these addresses.
@@ -124,7 +124,7 @@ private:
 
   /// Mapping between output var and the actual memory address.
   /// Results must be written to these addresses.
-  llvm::DenseMap<SaveNode *, onnxPointer> outputNodeToBuffer_;
+  llvm::DenseMap<Variable *, onnxPointer> outputNodeToBuffer_;
 };
 
 typedef Graph *GraphPtr;

--- a/tests/unittests/caffe2ImporterTest.cpp
+++ b/tests/unittests/caffe2ImporterTest.cpp
@@ -32,7 +32,7 @@ TEST(caffe2, importConv) {
   std::string NetDescFilename("tests/models/caffe2Models/predict_net.pbtxt");
   std::string NetWeightFilename("tests/models/caffe2Models/init_net.pbtxt");
 
-  SaveNode *output;
+  Variable *output;
   // Destroy the loader after the graph is loaded since the following execution
   // will not depend on anyting from the loader.
   {
@@ -45,7 +45,7 @@ TEST(caffe2, importConv) {
 
   EE.compile(CompilationMode::Infer, F);
   EE.run({}, {});
-  auto result = output->getVariable()->getHandle();
+  auto result = output->getHandle();
   std::vector<size_t> expectedDims = {1, 1, 4, 4};
   std::vector<float> expectedValues = {2,  3,  5,  4,  5, 10, 14, 9,
                                        11, 22, 26, 15, 8, 15, 17, 10};

--- a/tools/loader/ImageClassifier.cpp
+++ b/tools/loader/ImageClassifier.cpp
@@ -152,18 +152,15 @@ int main(int argc, char **argv) {
     LD.reset(new ONNXModelLoader(loader.getOnnxModelFilename(), onnxInputs,
                                  {&data, &data}, *loader.getFunction()));
   }
-  // Set the Softmax save node expected to come at the end of image inference.
-  SaveNode *SM = LD->getSingleOutput();
+  // Get the Variable that the final expected Softmax writes into at the end of
+  // image inference.
+  Variable *SMVar = LD->getSingleOutput();
 
   // Create Variables for both possible input names for flexibility for the
   // input model. The input data is mapped to both names. Whichever Variable is
   // unused will be removed in compile().
   Variable *i0 = LD->getVariableByName(c2Model ? c2Inputs[0] : onnxInputs[0]);
   Variable *i1 = LD->getVariableByName(c2Model ? c2Inputs[1] : onnxInputs[1]);
-
-  // We want to have a way to reference the variable of SM node later, after
-  // it is removed when we finish the quantization.
-  auto *SMVar = SM->getVariable();
 
   assert(i0->getVisibilityKind() == VisibilityKind::Public);
   assert(i1->getVisibilityKind() == VisibilityKind::Public);

--- a/tools/loader/ModelRunner.cpp
+++ b/tools/loader/ModelRunner.cpp
@@ -41,7 +41,7 @@ int main(int argc, char **argv) {
     LD.reset(new ONNXModelLoader(loader.getOnnxModelFilename(), {}, {},
                                  *loader.getFunction()));
   }
-  SaveNode *output = LD->getSingleOutput();
+  Variable *output = LD->getSingleOutput();
 
   // Compile the model, and perform quantization/emit a bundle/dump debug info
   // if requested from command line.
@@ -54,7 +54,7 @@ int main(int argc, char **argv) {
     llvm::outs() << "Model: " << loader.getFunction()->getName() << "\n";
 
     // Print out the result of output operator.
-    output->getVariable()->getPayload().getHandle().dump();
+    output->getPayload().getHandle().dump();
   }
 
   return 0;


### PR DESCRIPTION
There's no reason to save outputs by SaveNodes instead of Variables. It is potentially dangerous because non-quantized graphs are often erased after they are quantized, and so any references to the SaveNodes from the non-quantized graph are no longer valid.

This is the case since https://github.com/pytorch/glow/pull/1458