### PR TITLE
Fast pass for onnxGetBackendCompatibility

### DIFF
--- a/include/glow/Importer/ONNXIFILoader.h
+++ b/include/glow/Importer/ONNXIFILoader.h
@@ -59,13 +59,12 @@ public:
   parse(const void *onnxModel, uint32_t onnxModelSize, uint32_t weightsCount,
         const onnxTensorDescriptorV1 *weightDescriptors, Function &F);
 
-  /// \returns nullptr if ONNX operator from the \p onnxModel is not
-  /// supported by the ONNX model parser.
-  /// \returns unique ptr to operation kind and element kind otherwise.
+  /// \returns true if ONNX operators from the \p onnxModel is not
+  /// supported by the ONNX model parser. Otherwise, returns false
   ///
   /// \param onnxModel contains a single ONNX operator.
-  static std::unique_ptr<std::pair<Kinded::Kind, ElemKind>>
-  parseOperator(const void *onnxModel, size_t onnxModelSize);
+  //  \param onnxModelSize size of the serialized model string
+  static bool supportModel(const void *onnxModel, size_t onnxModelSize);
 };
 
 } // namespace onnxifi

--- a/lib/Onnxifi/onnxifiGlow.cpp
+++ b/lib/Onnxifi/onnxifiGlow.cpp
@@ -146,18 +146,9 @@ onnxGetBackendCompatibility(onnxBackendID backendID, size_t onnxModelSize,
     return ONNXIFI_STATUS_INVALID_POINTER;
   }
 
-  std::unique_ptr<std::pair<glow::Kinded::Kind, glow::ElemKind>> operation =
-      glow::onnxifi::ModelLoader::parseOperator(onnxModel, onnxModelSize);
-
   // TODO: Make better error reporting.
-  if (!operation) {
+  if(!glow::onnxifi::ModelLoader::supportModel(onnxModel, onnxModelSize)) {
     return ONNXIFI_STATUS_UNSUPPORTED_OPERATOR;
-  }
-
-  // Make sure that the backend itself is capable of executing
-  // the operation.
-  if (!glowBackendId->isOpSupported(operation->first, operation->second)) {
-    return ONNXIFI_STATUS_UNSUPPORTED_OPERATOR; 
   }
 
   return ONNXIFI_STATUS_SUCCESS;


### PR DESCRIPTION
https://github.com/pytorch/glow/pull/1503 had some progress in creating the fast path for `onnxGetBackendCompatibility`, but it's not complete. This PR makes the pass faster and more complete. The reasoning is that preview one won't cover all the case aayway, why don't we just make a quick fact check as what type of ops we support. @rdzhabarov 

Test Plan
With this PR, C2-Glow integration can run through resnet50 correctly. 

$ pytest -s caffe2/python/onnx/test_onnxifi.py