### PR TITLE
Move ElemKind::IndexTy to ElemKind::Int64ITy, and handles from size_t to int64_t

### DIFF
--- a/docs/Example.md
+++ b/docs/Example.md
@@ -38,7 +38,7 @@ auto *FCL1 = F->createFullyConnected("fc", MP1, 10);
 
 // Declare output: an index (0-9) indicating which digit is seen.
 Variable *selected = mod.createVariable(
-    ElemKind::IndexTy, {minibatchSize, 1}, "selected",
+    ElemKind::Int64ITy, {minibatchSize, 1}, "selected",
     VisibilityKind::Public, Variable::TrainKind::None);
 auto *SM = F->createSoftMax("sm", FCL1, selected);
 

--- a/examples/char-rnn.cpp
+++ b/examples/char-rnn.cpp
@@ -88,7 +88,7 @@ static void loadText(Tensor &inputText, Tensor &nextChar, llvm::StringRef text,
   auto S = idim[1];
 
   auto IH = inputText.getHandle();
-  auto NH = nextChar.getHandle<size_t>();
+  auto NH = nextChar.getHandle<int64_t>();
 
   // Fill the tensor with slices from the sentence with an offset of 1.
   // Example:
@@ -161,8 +161,9 @@ static Function *createNetwork(Module &mod, size_t minibatchSize,
   Variable *X =
       mod.createVariable(ElemKind::FloatTy, {minibatchSize, numSteps, 128},
                          "input", VisibilityKind::Public, false);
-  Variable *Y = mod.createVariable(ElemKind::IndexTy, {minibatchSize, numSteps},
-                                   "expected", VisibilityKind::Public, false);
+  Variable *Y =
+      mod.createVariable(ElemKind::Int64ITy, {minibatchSize, numSteps},
+                         "expected", VisibilityKind::Public, false);
   std::vector<Node *> slicesX;
   std::vector<Node *> expectedX;
 
@@ -223,7 +224,7 @@ int main(int argc, char **argv) {
   auto *Y = mod.getVariableByName("expected");
 
   Tensor thisCharTrain(ElemKind::FloatTy, {batchSize, numSteps, 128});
-  Tensor nextCharTrain(ElemKind::IndexTy, {batchSize, numSteps});
+  Tensor nextCharTrain(ElemKind::Int64ITy, {batchSize, numSteps});
   loadText(thisCharTrain, nextCharTrain, text, true);
 
   // Run this number of iterations over the input. On each iteration: train the
@@ -242,7 +243,7 @@ int main(int argc, char **argv) {
 
     // Load a few characters to start the text that we generate.
     Tensor currCharInfer(ElemKind::FloatTy, {minibatchSize, numSteps, 128});
-    Tensor nextCharInfer(ElemKind::IndexTy, {minibatchSize, numSteps});
+    Tensor nextCharInfer(ElemKind::Int64ITy, {minibatchSize, numSteps});
     loadText(currCharInfer, nextCharInfer, text.slice(0, 128), false);
 
     auto *res = llvm::cast<SaveNode>(F->getNodeByName("result"));

--- a/examples/cifar10.cpp
+++ b/examples/cifar10.cpp
@@ -69,10 +69,10 @@ void testCIFAR10() {
 
   /// Load the CIFAR database into a 4d tensor.
   Tensor images(ElemKind::FloatTy, {cifarNumImages, 32, 32, 3});
-  Tensor labels(ElemKind::IndexTy, {cifarNumImages, 1});
+  Tensor labels(ElemKind::Int64ITy, {cifarNumImages, 1});
   size_t idx = 0;
 
-  auto labelsH = labels.getHandle<size_t>();
+  auto labelsH = labels.getHandle<int64_t>();
   auto imagesH = images.getHandle<>();
   for (unsigned w = 0; w < cifarNumImages; w++) {
     labelsH.at({w, 0}) = static_cast<uint8_t>(dbInput.get());
@@ -107,7 +107,7 @@ void testCIFAR10() {
   // Create the input layer:
   auto *A = mod.createVariable(ElemKind::FloatTy, {minibatchSize, 32, 32, 3},
                                "input", VisibilityKind::Public, false);
-  auto *E = mod.createVariable(ElemKind::IndexTy, {minibatchSize, 1},
+  auto *E = mod.createVariable(ElemKind::Int64ITy, {minibatchSize, 1},
                                "expected", VisibilityKind::Public, false);
 
   // Create the rest of the network.

--- a/examples/mnist.cpp
+++ b/examples/mnist.cpp
@@ -42,7 +42,7 @@ llvm::cl::opt<BackendKind> executionBackend(
 unsigned loadMNIST(Tensor &imageInputs, Tensor &labelInputs) {
   /// Load the MNIST database into 4D tensor of images and 2D tensor of labels.
   imageInputs.reset(ElemKind::FloatTy, {50000u, 28, 28, 1});
-  labelInputs.reset(ElemKind::IndexTy, {50000u, 1});
+  labelInputs.reset(ElemKind::Int64ITy, {50000u, 1});
 
   std::ifstream imgInput("mnist_images.bin", std::ios::binary);
   std::ifstream labInput("mnist_labels.bin", std::ios::binary);
@@ -67,7 +67,7 @@ unsigned loadMNIST(Tensor &imageInputs, Tensor &labelInputs) {
 
   size_t idx = 0;
 
-  auto LIH = labelInputs.getHandle<size_t>();
+  auto LIH = labelInputs.getHandle<int64_t>();
   auto IIH = imageInputs.getHandle<>();
 
   for (unsigned w = 0; w < mnistNumImages; w++) {
@@ -124,7 +124,7 @@ void testMNIST() {
 
   auto *FCL1 = F->createFullyConnected("fc", MP1, 10);
   Variable *selected =
-      mod.createVariable(ElemKind::IndexTy, {minibatchSize, 1}, "selected",
+      mod.createVariable(ElemKind::Int64ITy, {minibatchSize, 1}, "selected",
                          VisibilityKind::Public, false);
   auto *SM = F->createSoftMax("sm", FCL1, selected);
 
@@ -153,7 +153,7 @@ void testMNIST() {
   llvm::outs() << "Validating.\n";
   EE.compile(CompilationMode::Infer, F);
 
-  auto LIH = labelInputs.getHandle<size_t>();
+  auto LIH = labelInputs.getHandle<int64_t>();
 
   // Check how many examples out of eighty previously unseen digits we can
   // classify correctly.
@@ -171,7 +171,7 @@ void testMNIST() {
       auto T = res.getHandle<>().extractSlice(i);
       size_t guess = T.getHandle<>().minMaxArg().second;
 
-      size_t correct = LIH.at({minibatchSize * iter + i, 0});
+      int64_t correct = LIH.at({minibatchSize * iter + i, 0});
       rightAnswer += (guess == correct);
 
       if (iter == numIterations) {

--- a/examples/ptb.cpp
+++ b/examples/ptb.cpp
@@ -125,9 +125,9 @@ unsigned loadPTB(Tensor &inputWords, Tensor &targetWords, size_t numSteps,
   // input words. To limit the size of the data we use an upper bound on the
   // vocabulary size.
   inputWords.reset(ElemKind::FloatTy, {numSequences, vocabSize * numSteps});
-  targetWords.reset(ElemKind::IndexTy, {numSequences, numSteps});
+  targetWords.reset(ElemKind::Int64ITy, {numSequences, numSteps});
   auto IIH = inputWords.getHandle<>();
-  auto TIH = targetWords.getHandle<size_t>();
+  auto TIH = targetWords.getHandle<int64_t>();
   for (unsigned batch = 0; batch < minibatchSize; batch++) {
     for (unsigned iter = 0; iter < numBatches; iter++) {
       size_t sequence = batch + iter * minibatchSize;
@@ -202,8 +202,9 @@ void testPTB() {
   Variable *X = mod.createVariable(ElemKind::FloatTy,
                                    {minibatchSize, vocabSize * numSteps},
                                    "input", VisibilityKind::Public, false);
-  Variable *Y = mod.createVariable(ElemKind::IndexTy, {minibatchSize, numSteps},
-                                   "selected", VisibilityKind::Public, false);
+  Variable *Y =
+      mod.createVariable(ElemKind::Int64ITy, {minibatchSize, numSteps},
+                         "selected", VisibilityKind::Public, false);
 
   std::vector<Node *> slicesX;
 
@@ -262,7 +263,7 @@ void testPTB() {
                              {minibatchSize, vocabSize * numSteps});
       inputWordsBatch.copyConsecutiveSlices(&inputWords, minibatchSize * batch);
 
-      Tensor targetWordsBatch(ElemKind::IndexTy, {minibatchSize, numSteps});
+      Tensor targetWordsBatch(ElemKind::Int64ITy, {minibatchSize, numSteps});
       targetWordsBatch.copyConsecutiveSlices(&targetWords,
                                              minibatchSize * batch);
 
@@ -272,7 +273,7 @@ void testPTB() {
         for (unsigned int i = 0; i < minibatchSize; i++) {
           auto T =
               res.getHandle<float>().extractSlice(step * minibatchSize + i);
-          size_t correct = targetWords.getHandle<std::size_t>().at(
+          size_t correct = targetWords.getHandle<int64_t>().at(
               {minibatchSize * batch + i, step});
           float soft_guess = -std::log(T.getHandle<float>().at({correct}));
           perplexity += soft_guess;

--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -278,8 +278,8 @@ public:
       return isEqualImpl<int8_t>(other, allowedError);
     case ElemKind::Int32QTy:
       return isEqualImpl<int32_t>(other, allowedError);
-    case ElemKind::IndexTy:
-      return isEqualImpl<size_t>(other, allowedError);
+    case ElemKind::Int64ITy:
+      return isEqualImpl<int64_t>(other, allowedError);
     }
 
     // This is to make compiler happy. It can never reach this point as switch

--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -180,7 +180,7 @@ enum class ElemKind : unsigned char {
   FloatTy,
   Int8QTy,
   Int32QTy,
-  IndexTy,
+  Int64ITy,
 };
 
 /// A class that represents a type of a tensor.
@@ -199,7 +199,7 @@ struct Type final {
   int32_t offset_{0};
 
   /// Specifies the element type of the tensor.
-  ElemKind elementType_{ElemKind::IndexTy};
+  ElemKind elementType_{ElemKind::Int64ITy};
 
   /// Initialize a new integer type with \p scale and \p offset.
   Type(ElemKind elemTy, llvm::ArrayRef<size_t> dims, float scale,
@@ -311,14 +311,14 @@ struct Type final {
       return std::is_same<ElemTy, int8_t>::value;
     case ElemKind::Int32QTy:
       return std::is_same<ElemTy, int32_t>::value;
-    case ElemKind::IndexTy:
-      return std::is_same<ElemTy, size_t>::value;
+    case ElemKind::Int64ITy:
+      return std::is_same<ElemTy, int64_t>::value;
     }
     GLOW_UNREACHABLE("Invalid type.");
   }
 
   /// \returns true if the type of this Tensor is one of the integer types.
-  /// Notice that we don't consider IndexTy as an integer because we are not
+  /// Notice that we don't consider Int64ITy as an integer because we are not
   /// performing calculations on this type.
   bool isQuantizedType() const { return isType<int8_t>() || isType<int32_t>(); }
 
@@ -337,8 +337,8 @@ struct Type final {
       return sizeof(int8_t);
     case ElemKind::Int32QTy:
       return sizeof(int32_t);
-    case ElemKind::IndexTy:
-      return sizeof(size_t);
+    case ElemKind::Int64ITy:
+      return sizeof(int64_t);
     }
     GLOW_UNREACHABLE("Invalid type.");
   }

--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -75,9 +75,10 @@ protected:
 
     // This is statically known data, and so we create a Tensor for it and
     // register it in tensors_.
-    auto *T = new Tensor(ElemKind::IndexTy, {in.dims().size()});
+    auto *T = new Tensor(ElemKind::Int64ITy, {in.dims().size()});
     tensors_[opName] = T;
-    T->template getHandle<size_t>() = in.dims();
+    T->template getHandle<int64_t>() =
+        std::vector<int64_t>(in.dims().begin(), in.dims().end());
 
     createAndRememberVariable(opName, *T);
   }
@@ -118,7 +119,7 @@ protected:
     // have an option for a selected input anyway. So I am creating this as a
     // placeholder which goes unused during inference.
     auto selected = G_.getParent()->createVariable(
-        ElemKind::IndexTy, {in.dims()[0], 1}, "selected",
+        ElemKind::Int64ITy, {in.dims()[0], 1}, "selected",
         VisibilityKind::Private, false);
 
     // ONNX allows shapes like <N x 10 x 1 x 1 >. Flatten the inputs to the
@@ -237,7 +238,7 @@ protected:
     std::vector<int64_t> requestedDims;
     if (op.input_size() > 1) {
       Tensor *constShapeTensor = getTensorByName(op.input(1));
-      auto TH = constShapeTensor->getHandle<size_t>();
+      auto TH = constShapeTensor->getHandle<int64_t>();
       for (size_t i = 0, e = constShapeTensor->size(); i != e; i++) {
         requestedDims.push_back(TH.at({i}));
       }

--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -241,8 +241,8 @@ void LLVMIRGen::initCodeGen() {
 llvm::Type *LLVMIRGen::getElementType(llvm::IRBuilder<> &builder,
                                       const Value *val) {
   switch (val->getElementType()) {
-  case ElemKind::IndexTy:
-    return builder.getIntNTy(sizeof(size_t) * 8);
+  case ElemKind::Int64ITy:
+    return builder.getInt64Ty();
   case ElemKind::FloatTy:
     return builder.getFloatTy();
   case ElemKind::Int8QTy:
@@ -317,8 +317,8 @@ llvm::Value *LLVMIRGen::emitValueAddress(llvm::IRBuilder<> &builder,
   case ElemKind::Int8QTy:
     T = llvm::Type::getInt8PtrTy(ctx_);
     break;
-  case ElemKind::IndexTy:
-    T = sizeTTy->getPointerTo();
+  case ElemKind::Int64ITy:
+    T = llvm::Type::getInt64PtrTy(ctx_);
     break;
   default:
     llvm_unreachable("Unimplemented");
@@ -453,8 +453,8 @@ llvm::Value *LLVMIRGen::emitConst(llvm::IRBuilder<> &builder, float val,
   switch (kind) {
   case ElemKind::FloatTy:
     return llvm::ConstantFP::get(llvm::Type::getFloatTy(ctx_), val);
-  case ElemKind::IndexTy:
-    return builder.getIntN(sizeof(size_t) * 8, static_cast<size_t>(val));
+  case ElemKind::Int64ITy:
+    return builder.getInt64(static_cast<int64_t>(val));
   case ElemKind::Int8QTy:
     return builder.getInt8(static_cast<int8_t>(val));
   case ElemKind::Int32QTy:
@@ -508,7 +508,7 @@ llvm::Function *LLVMIRGen::getFunction(const std::string &name,
     return get("libjit_" + name + "_i8");
   case ElemKind::Int32QTy:
     return get("libjit_" + name + "_i32");
-  case ElemKind::IndexTy:
+  case ElemKind::Int64ITy:
     return get("libjit_" + name + "_u");
   default:
     GLOW_UNREACHABLE("Unsupported element type");

--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -1280,14 +1280,14 @@ libjit_dump_tensor(uint8_t *tensor, size_t *tensorDim, size_t numDimsTensor,
     FloatTy,
     Int8QTy,
     Int32QTy,
-    IndexTy,
+    Int64ITy,
   };
   // Dump the content of a tensor.
   switch (elemKind) {
   case FloatTy:
     libjit_dump_tensor_impl((float *)tensor, tensorDim, numDimsTensor);
     break;
-  case IndexTy:
+  case Int64ITy:
     libjit_dump_tensor_impl((size_t *)tensor, tensorDim, numDimsTensor);
     break;
   default:

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -128,7 +128,7 @@ static std::string getKernelName(const char *baseName, ElemKind elemTy) {
     return name + "_i8W";
   case ElemKind::Int32QTy:
     return name + "_i32W";
-  case ElemKind::IndexTy:
+  case ElemKind::Int64ITy:
     return name + "_uW";
   default:
     GLOW_ASSERT("Unsupported element type");
@@ -538,7 +538,7 @@ void OpenCLFunction::executeConvolution(const OCLConvolutionInst *CC) {
 template <typename T>
 static void topK(Tensor &outW, Tensor &indW, Tensor &inW, size_t k) {
   auto values = outW.getHandle<T>();
-  auto indices = indW.getHandle<size_t>();
+  auto indices = indW.getHandle<int64_t>();
   auto in = inW.getHandle<T>();
   size_t n = in.dims().back();
 

--- a/lib/Base/Tensor.cpp
+++ b/lib/Base/Tensor.cpp
@@ -273,8 +273,8 @@ void glow::dumpAsciiImpl(Tensor *T, llvm::raw_ostream &os) {
     return dumpAsciiGenericImpl(T->getHandle<int8_t>(), os);
   case ElemKind::Int32QTy:
     return dumpAsciiGenericImpl(T->getHandle<int32_t>(), os);
-  case ElemKind::IndexTy:
-    return dumpAsciiGenericImpl(T->getHandle<size_t>(), os);
+  case ElemKind::Int64ITy:
+    return dumpAsciiGenericImpl(T->getHandle<int64_t>(), os);
   }
 }
 
@@ -288,8 +288,8 @@ void glow::dumpImpl(Tensor *T, llvm::raw_ostream &os) {
     return dumpGenericImpl(T->getHandle<int8_t>(), os);
   case ElemKind::Int32QTy:
     return dumpGenericImpl(T->getHandle<int32_t>(), os);
-  case ElemKind::IndexTy:
-    return dumpGenericImpl(T->getHandle<size_t>(), os);
+  case ElemKind::Int64ITy:
+    return dumpGenericImpl(T->getHandle<int64_t>(), os);
   }
 }
 
@@ -330,9 +330,9 @@ void glow::genericTranspose(Tensor *src, Tensor *dest,
     transposeSelectImpl(srcH, destH, shuffle);
     return;
   }
-  case ElemKind::IndexTy: {
-    auto srcH = src->getHandle<size_t>();
-    auto destH = dest->getHandle<size_t>();
+  case ElemKind::Int64ITy: {
+    auto srcH = src->getHandle<int64_t>();
+    auto destH = dest->getHandle<int64_t>();
     transposeSelectImpl(srcH, destH, shuffle);
     return;
   }
@@ -367,8 +367,8 @@ void Tensor::init(InitKind init, float val, PseudoRNG &PRNG) {
       getHandle<int32_t>().clear(val);
       break;
     }
-    case ElemKind::IndexTy: {
-      getHandle<size_t>().clear(val);
+    case ElemKind::Int64ITy: {
+      getHandle<int64_t>().clear(val);
       break;
     }
     }
@@ -389,8 +389,8 @@ void Tensor::init(InitKind init, float val, PseudoRNG &PRNG) {
       getHandle<int32_t>().initXavier(val, PRNG);
       break;
     }
-    case ElemKind::IndexTy: {
-      getHandle<size_t>().initXavier(val, PRNG);
+    case ElemKind::Int64ITy: {
+      getHandle<int64_t>().initXavier(val, PRNG);
       break;
     }
     }

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1345,7 +1345,8 @@ TopKNode *Function::createTopK(llvm::StringRef name, NodeValue input,
   outDims.back() = k;
   auto OT = getParent()->uniqueTypeWithNewShape(input.getType(), outDims);
   return addNode(new TopKNode(
-      name, OT, getParent()->uniqueType(ElemKind::IndexTy, outDims), input, k));
+      name, OT, getParent()->uniqueType(ElemKind::Int64ITy, outDims), input,
+      k));
 }
 
 GatherNode *Function::createGather(llvm::StringRef name, NodeValue data,

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -535,9 +535,9 @@ void SparseLengthsWeightedSumNode::verify() const {
          "Mismatched element types");
   assert(getWeights().getElementType() == getData().getElementType() &&
          "Mismatched element types");
-  assert(getIndices().getElementType() == ElemKind::IndexTy &&
+  assert(getIndices().getElementType() == ElemKind::Int64ITy &&
          "Indices must have index type");
-  assert(getLengths().getElementType() == ElemKind::IndexTy &&
+  assert(getLengths().getElementType() == ElemKind::Int64ITy &&
          "Lengths must have index type");
   assert(getIndices().dims().size() == 1 && "Indices must be 1D vector");
   assert(getLengths().dims().size() == 1 && "Lengths must be 1D vector");
@@ -611,7 +611,7 @@ void TopKNode::verify() const {
 
 void GatherNode::verify() const {
   assert(getResult().getElementType() == getData().getElementType());
-  assert(getIndices().getElementType() == ElemKind::IndexTy);
+  assert(getIndices().getElementType() == ElemKind::Int64ITy);
   assert(getResult().dims().size() ==
          getData().dims().size() + getIndices().dims().size() - 1);
   if (getResult().getType()->isQuantizedType()) {

--- a/lib/IR/IRBuilder.cpp
+++ b/lib/IR/IRBuilder.cpp
@@ -66,7 +66,7 @@ MaxPoolWithXYInst *IRBuilder::createMaxPoolWithXYOp(
   // Allocate cache arrays that store the x and y coordinates of the incoming
   // gradient for each max element.
   Value *srcXY =
-      createAllocActivationInst("srcXY", ElemKind::IndexTy,
+      createAllocActivationInst("srcXY", ElemKind::Int64ITy,
                                 {idim.n, outSz.first, outSz.second, idim.c, 2});
 
   auto outTy = F_->getGraph()->getParent()->uniqueTypeWithNewShape(
@@ -138,12 +138,12 @@ TopKInst *IRBuilder::createTopKOp(Value *input, size_t k) {
   auto outTy = F_->getGraph()->getParent()->uniqueTypeWithNewShape(
       input->getType(), outDims);
   // Allocate enough scratch space to hold N values and N indices.
-  auto *scratch = createAllocActivationInst("topk.scratch", ElemKind::IndexTy,
+  auto *scratch = createAllocActivationInst("topk.scratch", ElemKind::Int64ITy,
                                             {inDims.back() * 2});
   createSplatInst("topk.zero.scratch", scratch, 0);
   auto *values = createAllocActivationInst("topk.values", outTy);
   auto *indices =
-      createAllocActivationInst("topk.indices", ElemKind::IndexTy, outDims);
+      createAllocActivationInst("topk.indices", ElemKind::Int64ITy, outDims);
   return createTopKInst("topk", values, indices, input, scratch, k);
 }
 

--- a/lib/Importer/Caffe2.cpp
+++ b/lib/Importer/Caffe2.cpp
@@ -508,7 +508,7 @@ void caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     }
     case caffe2::TensorProto_DataType_INT32:
     case caffe2::TensorProto_DataType_INT64: {
-      assert(in.getElementType() == ElemKind::IndexTy &&
+      assert(in.getElementType() == ElemKind::Int64ITy &&
              "Can only cast int to int.");
       break;
     }
@@ -613,11 +613,9 @@ void caffe2ModelLoader::loadWeight(const caffe2::OperatorDef &op) {
         TH.raw(i++) = num;
       }
     } else if (dict["values"]->ints_size()) {
-      T->reset(ElemKind::IndexTy, dim);
-      auto TH = T->getHandle<size_t>();
+      T->reset(ElemKind::Int64ITy, dim);
+      auto TH = T->getHandle<int64_t>();
       for (auto num : dict["values"]->ints()) {
-        assert(0 <= num && num < (1LL << 32) &&
-               "Only uint32 integers are supported");
         TH.raw(i++) = num;
       }
     } else {
@@ -681,8 +679,8 @@ void caffe2ModelLoader::loadWeight(const caffe2::OperatorDef &op) {
     case caffe2::TensorProto_DataType_INT32:
     case caffe2::TensorProto_DataType_INT64:
     case caffe2::TensorProto_DataType_BOOL: {
-      T->reset(ElemKind::IndexTy, dims);
-      auto TH = T->getHandle<size_t>();
+      T->reset(ElemKind::Int64ITy, dims);
+      auto TH = T->getHandle<int64_t>();
       auto i = (dict.count("value") && dict["value"]->has_i())
                    ? loadInt(dict["value"])
                    : 0;

--- a/lib/Importer/ONNX.cpp
+++ b/lib/Importer/ONNX.cpp
@@ -154,8 +154,7 @@ static void loadTensor(const ONNX_NAMESPACE::TensorProto &in, Tensor *T) {
       llvm_unreachable("Unsupported Tensor format.");
     }
   } else if (in.data_type() == ONNX_NAMESPACE::TensorProto::INT64) {
-    // TODO: either switch IndexTy to be 64 bit, or switch to another type here
-    T->reset(ElemKind::IndexTy, dim);
+    T->reset(ElemKind::Int64ITy, dim);
 
     if (in.int64_data_size() > 0) {
       auto TH = T->getHandle<>();

--- a/tests/unittests/BackendCorrectnessTest.cpp
+++ b/tests/unittests/BackendCorrectnessTest.cpp
@@ -140,13 +140,13 @@ TEST_P(BackendCorrectnessTest, convGradTest) {
   Tensor bias1(ElemKind::FloatTy, {3});
   Tensor kernel2(ElemKind::FloatTy, {2, 2, 2, 1});
   Tensor bias2(ElemKind::FloatTy, {2});
-  Tensor selected(ElemKind::IndexTy, {9, 1});
+  Tensor selected(ElemKind::Int64ITy, {9, 1});
   inputs.getHandle().initXavier(1, PRNG);
   kernel1.getHandle().randomize(-1.0, 1.4, PRNG);
   bias1.getHandle().randomize(-0.2, 0.5, PRNG);
   kernel2.getHandle().randomize(-1.8, 2.3, PRNG);
   bias2.getHandle().randomize(-0.5, 1.0, PRNG);
-  auto selectedH = selected.getHandle<size_t>();
+  auto selectedH = selected.getHandle<int64_t>();
   for (size_t i = 0; i < 9; i++) {
     selectedH.raw(i) = PRNG.nextRandInt(0, 29);
   }
@@ -173,8 +173,8 @@ TEST_P(BackendCorrectnessTest, gatherTest) {
   Tensor data(ElemKind::FloatTy, {nSlices, 16, 3, 2});
   data.getHandle().initXavier(1, PRNG);
 
-  Tensor indices(ElemKind::IndexTy, {nGathered});
-  auto indicesH = indices.getHandle<size_t>();
+  Tensor indices(ElemKind::Int64ITy, {nGathered});
+  auto indicesH = indices.getHandle<int64_t>();
   for (size_t i = 0; i < nGathered; i++) {
     indicesH.raw(i) = PRNG.nextRandInt(0, nSlices - 1);
   }
@@ -206,11 +206,11 @@ TEST_P(CPUOnly, localResponseNormalizationGradTest) {
   Tensor inputs(ElemKind::FloatTy, {5, 4, 7, 3});
   Tensor weights(ElemKind::FloatTy, {84, 180});
   Tensor bias(ElemKind::FloatTy, {180});
-  Tensor selected(ElemKind::IndexTy, {5, 1});
+  Tensor selected(ElemKind::Int64ITy, {5, 1});
   inputs.getHandle().initXavier(1, PRNG);
   weights.getHandle().randomize(-2.0, 3.0, PRNG);
   bias.getHandle().randomize(-1.0, 1.3, PRNG);
-  auto selectedH = selected.getHandle<size_t>();
+  auto selectedH = selected.getHandle<int64_t>();
   for (size_t i = 0; i < 5; i++) {
     selectedH.raw(i) = PRNG.nextRandInt(0, 179);
   }
@@ -396,11 +396,11 @@ TEST_P(CPUOnly, AvgPoolGradTest) {
   Tensor inputs(ElemKind::FloatTy, {5, 7, 6, 3});
   Tensor weights(ElemKind::FloatTy, {126, 72});
   Tensor bias(ElemKind::FloatTy, {72});
-  Tensor selected(ElemKind::IndexTy, {5, 1});
+  Tensor selected(ElemKind::Int64ITy, {5, 1});
   inputs.getHandle().initXavier(1, PRNG);
   weights.getHandle().randomize(-0.3, 0.6, PRNG);
   bias.getHandle().randomize(-0.2, 0.1, PRNG);
-  auto selectedH = selected.getHandle<size_t>();
+  auto selectedH = selected.getHandle<int64_t>();
   for (size_t i = 0; i < 5; i++) {
     selectedH.raw(i) = PRNG.nextRandInt(0, 17);
   }
@@ -437,11 +437,11 @@ TEST_P(BackendCorrectnessTest, MaxPoolGradTest) {
   Tensor inputs(ElemKind::FloatTy, {4, 8, 7, 2});
   Tensor weights(ElemKind::FloatTy, {112, 84});
   Tensor bias(ElemKind::FloatTy, {84});
-  Tensor selected(ElemKind::IndexTy, {4, 1});
+  Tensor selected(ElemKind::Int64ITy, {4, 1});
   inputs.getHandle().initXavier(1, PRNG);
   weights.getHandle().randomize(-0.1, 0.7, PRNG);
   bias.getHandle().randomize(-0.3, 0.1, PRNG);
-  auto selectedH = selected.getHandle<size_t>();
+  auto selectedH = selected.getHandle<int64_t>();
   for (size_t i = 0; i < 4; i++) {
     selectedH.raw(i) = PRNG.nextRandInt(0, 31);
   }
@@ -525,8 +525,8 @@ TEST_P(BackendCorrectnessTest, reshapeTest) {
 }
 
 TEST_P(BackendCorrectnessTest, reshapeIndexTest) {
-  Tensor inputs(ElemKind::IndexTy, {12, 6, 8, 12});
-  auto H = inputs.getHandle<size_t>();
+  Tensor inputs(ElemKind::Int64ITy, {12, 6, 8, 12});
+  auto H = inputs.getHandle<int64_t>();
   for (size_t i = 0; i < H.size(); i++) {
     H.raw(i) = i;
   }
@@ -642,9 +642,9 @@ TEST_P(CPUOnly, convDKKC8Test) {
 TEST_P(BackendCorrectnessTest, softmaxTest) {
   PseudoRNG PRNG;
   Tensor inputs(ElemKind::FloatTy, {14, 19});
-  Tensor selected(ElemKind::IndexTy, {14, 1});
+  Tensor selected(ElemKind::Int64ITy, {14, 1});
   inputs.getHandle().initXavier(1, PRNG);
-  auto selectedH = selected.getHandle<size_t>();
+  auto selectedH = selected.getHandle<int64_t>();
   for (size_t i = 0; i < 14; i++) {
     selectedH.raw(i) = PRNG.nextRandInt(0, 18);
   }
@@ -664,11 +664,11 @@ TEST_P(BackendCorrectnessTest, softmaxGradTest) {
   Tensor inputs(ElemKind::FloatTy, shape);
   Tensor weights(ElemKind::FloatTy, {23, 23});
   Tensor bias(ElemKind::FloatTy, {23});
-  Tensor selected(ElemKind::IndexTy, {8, 1});
+  Tensor selected(ElemKind::Int64ITy, {8, 1});
   inputs.getHandle().initXavier(1, PRNG);
   weights.getHandle().randomize(0.0, 0.5, PRNG);
   bias.getHandle().randomize(-0.2, 0.0, PRNG);
-  auto selectedH = selected.getHandle<size_t>();
+  auto selectedH = selected.getHandle<int64_t>();
   for (size_t i = 0; i < 8; i++) {
     selectedH.raw(i) = PRNG.nextRandInt(0, 22);
   }

--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -106,7 +106,7 @@ TEST_P(BackendTest, simpleInference) {
   auto *input = mod.createVariable(ElemKind::FloatTy, {1, 32, 32, 3}, "input",
                                    VisibilityKind::Public);
 
-  auto *ex = mod.createVariable(ElemKind::IndexTy, {1, 1}, "exp");
+  auto *ex = mod.createVariable(ElemKind::Int64ITy, {1, 1}, "exp");
 
   auto *CV0 = F->createConv("conv1", input, 16, 5, 1, 2, 1);
   auto *RL0 = F->createRELU("relu1", CV0);

--- a/tests/unittests/BackendTestUtils.cpp
+++ b/tests/unittests/BackendTestUtils.cpp
@@ -726,7 +726,7 @@ void inferMixedNet(Tensor *inputs, Tensor *out, BackendKind kind) {
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
   auto *var = VarFrom(inputs);
-  auto *selected = mod.createVariable(ElemKind::IndexTy, {2, 1}, "selected");
+  auto *selected = mod.createVariable(ElemKind::Int64ITy, {2, 1}, "selected");
 
   auto *tr = F->createTranspose("tr", var, NCHW2NHWC);
   auto *fc = F->createFullyConnected("fc", tr, 16);

--- a/tests/unittests/HyphenTest.cpp
+++ b/tests/unittests/HyphenTest.cpp
@@ -261,7 +261,7 @@ struct HyphenNetwork {
   HyphenNetwork(Module &mod, TrainingConfig &conf)
       : input_(mod.createVariable(ElemKind::FloatTy, {conf.batchSize, 6, 27},
                                   "input", VisibilityKind::Public, false)),
-        expected_(mod.createVariable(ElemKind::IndexTy, {conf.batchSize, 1},
+        expected_(mod.createVariable(ElemKind::Int64ITy, {conf.batchSize, 1},
                                      "expected", VisibilityKind::Public,
                                      false)),
         infer_(mod.createFunction("infer")), result_(nullptr), train_(nullptr) {
@@ -341,9 +341,9 @@ TEST(HyphenTest, network) {
 
   // Convert words and hyphens to a tensor representation.
   Tensor inputs(ElemKind::FloatTy, {numSamples, 6, 27});
-  Tensor expected(ElemKind::IndexTy, {numSamples, 1});
+  Tensor expected(ElemKind::Int64ITy, {numSamples, 1});
   auto inputHandle = inputs.getHandle<float>();
-  auto expectedHandle = expected.getHandle<size_t>();
+  auto expectedHandle = expected.getHandle<int64_t>();
   for (size_t i = 0; i != numSamples; i++) {
     mapLetterWindow(words[i], i, inputHandle);
     expectedHandle.at({i, 0}) = hyphens[i];

--- a/tests/unittests/MLTest.cpp
+++ b/tests/unittests/MLTest.cpp
@@ -279,7 +279,7 @@ unsigned numSamples = 230;
 /// L0, and the rest of the dots, away from the axis are L1.
 void generateCircleData(Tensor &coordinates, Tensor &labels, PseudoRNG &PRNG) {
   auto C = coordinates.getHandle<>();
-  auto L = labels.getHandle<size_t>();
+  auto L = labels.getHandle<int64_t>();
 
   for (size_t i = 0; i < numSamples / 2; i++) {
     float r = PRNG.nextRand() * 0.4;
@@ -320,7 +320,7 @@ TEST_P(MLTest, circle) {
   Function *F = mod.createFunction("circle");
   auto *A = mod.createVariable(ElemKind::FloatTy, {minibatchSize, 2}, "A",
                                VisibilityKind::Public, false);
-  auto *S = mod.createVariable(ElemKind::IndexTy, {minibatchSize, 1}, "S",
+  auto *S = mod.createVariable(ElemKind::Int64ITy, {minibatchSize, 1}, "S",
                                VisibilityKind::Public, false);
 
   auto *FCL0 = F->createFullyConnected("fc1", A, 8);
@@ -333,7 +333,7 @@ TEST_P(MLTest, circle) {
   EE_.compile(CompilationMode::Train, TF);
 
   Tensor coordinates(ElemKind::FloatTy, {numSamples, 2});
-  Tensor labels(ElemKind::IndexTy, {numSamples, 1});
+  Tensor labels(ElemKind::Int64ITy, {numSamples, 1});
   generateCircleData(coordinates, labels, mod.getPRNG());
 
   // Training:
@@ -644,7 +644,7 @@ enum class Sport : size_t { BASKETBALL = 0, SOCCER = 1 };
 void generatePlayerData(Tensor &players, Tensor &labels,
                         unsigned numTrainPlayers, PseudoRNG &PRNG) {
   auto P = players.getHandle<>();
-  auto L = labels.getHandle<size_t>();
+  auto L = labels.getHandle<int64_t>();
 
   // Auto generate height/weights for basketball players.
   for (size_t i = 0; i < numTrainPlayers / 2; i++) {
@@ -685,7 +685,7 @@ TEST_P(MLTest, classifyPlayerSport) {
   auto *A =
       mod.createVariable(ElemKind::FloatTy, {numTrainPlayers, numFeatures}, "A",
                          VisibilityKind::Public, false);
-  auto *S = mod.createVariable(ElemKind::IndexTy, {numTrainPlayers, 1}, "S",
+  auto *S = mod.createVariable(ElemKind::Int64ITy, {numTrainPlayers, 1}, "S",
                                VisibilityKind::Public, false);
 
   auto *FC = F->createFullyConnected("fc", A, numClasses);
@@ -696,7 +696,7 @@ TEST_P(MLTest, classifyPlayerSport) {
   EE_.compile(CompilationMode::Train, TF);
 
   Tensor players(ElemKind::FloatTy, {numTrainPlayers, numFeatures});
-  Tensor labels(ElemKind::IndexTy, {numTrainPlayers, 1});
+  Tensor labels(ElemKind::Int64ITy, {numTrainPlayers, 1});
   generatePlayerData(players, labels, numTrainPlayers, mod.getPRNG());
 
   // Training:
@@ -813,7 +813,7 @@ TEST_P(MLTest, nonLinearClassifier) {
 
   auto *A = mod.createVariable(ElemKind::FloatTy, {batchSize, 2}, "A",
                                VisibilityKind::Public, false);
-  auto *S = mod.createVariable(ElemKind::IndexTy, {batchSize, 1}, "S",
+  auto *S = mod.createVariable(ElemKind::Int64ITy, {batchSize, 1}, "S",
                                VisibilityKind::Public, false);
 
   auto *FCL0 = F->createFullyConnected("fc1", A, 8);
@@ -828,7 +828,7 @@ TEST_P(MLTest, nonLinearClassifier) {
   EE_.compile(CompilationMode::Train, TF);
 
   Tensor samples(ElemKind::FloatTy, {numSamples, 2});
-  Tensor labels(ElemKind::IndexTy, {numSamples, 1});
+  Tensor labels(ElemKind::Int64ITy, {numSamples, 1});
 
   for (size_t i = 0; i < numSamples; i++) {
     float x = mod.getPRNG().nextRand();
@@ -836,7 +836,7 @@ TEST_P(MLTest, nonLinearClassifier) {
     size_t label = (x < 0.0) ^ (y < 0.0);
     samples.getHandle<>().at({i, 0}) = x;
     samples.getHandle<>().at({i, 1}) = y;
-    labels.getHandle<size_t>().at({i, 0}) = label;
+    labels.getHandle<int64_t>().at({i, 0}) = label;
   }
 
   EE_.runBatch(500, {A, S}, {&samples, &labels});
@@ -861,7 +861,7 @@ TEST_P(MLTest, nonLinearClassifier) {
 /// Generate images in two classes.
 /// A "line" is labeled as 0 and a "cross" is labeled as 1.
 static void generateImageData(Tensor &images, Tensor &labels, PseudoRNG &PRNG) {
-  auto L = labels.getHandle<size_t>();
+  auto L = labels.getHandle<int64_t>();
   auto image = images.getHandle<>();
   unsigned numSamples = images.dims()[0];
   images.zero();
@@ -901,7 +901,7 @@ TEST_P(InterpreterAndCPU, convNetForImageRecognition) {
   auto *input = mod.createVariable(ElemKind::FloatTy, {batchSize, 8, 8, 1},
                                    "input", VisibilityKind::Public, false);
 
-  auto *ex = mod.createVariable(ElemKind::IndexTy, {batchSize, 1}, "exp",
+  auto *ex = mod.createVariable(ElemKind::Int64ITy, {batchSize, 1}, "exp",
                                 VisibilityKind::Public, false);
 
   auto *CV = F->createConv("conv", input, 1, 3, 1, 0, 1);
@@ -913,7 +913,7 @@ TEST_P(InterpreterAndCPU, convNetForImageRecognition) {
   EE.compile(CompilationMode::Train, TF);
 
   Tensor images(ElemKind::FloatTy, {numSamples, 8, 8, 1});
-  Tensor labels(ElemKind::IndexTy, {numSamples, 1});
+  Tensor labels(ElemKind::Int64ITy, {numSamples, 1});
   generateImageData(images, labels, mod.getPRNG());
 
   // Training:
@@ -935,12 +935,12 @@ TEST_P(InterpreterAndCPU, convNetForImageRecognition) {
   EE.compile(CompilationMode::Infer, QP);
   // Generate the images used for testing.
   Tensor testImages(ElemKind::FloatTy, {batchSize, 8, 8, 1});
-  Tensor testLabels(ElemKind::IndexTy, {batchSize, 1});
+  Tensor testLabels(ElemKind::Int64ITy, {batchSize, 1});
   generateImageData(testImages, testLabels, mod.getPRNG());
   EE.run({input}, {&testImages});
   auto SMH = result->getVariable()->getHandle<>();
   for (size_t i = 0; i < batchSize; i++) {
-    bool isLine = testLabels.getHandle<size_t>().at({i, 0}) == 0;
+    bool isLine = testLabels.getHandle<int64_t>().at({i, 0}) == 0;
     auto lineWeight = SMH.at({i, 0});
     auto crossWeight = SMH.at({i, 1});
     EXPECT_TRUE((isLine && lineWeight > crossWeight) ||
@@ -1097,7 +1097,7 @@ static void generateMatrixRotationRecognitionData(Tensor &matricesA,
          "Size of the tensors is incompatible");
   auto handleMatricesA = matricesA.getHandle<float>();
   auto handleMatricesB = matricesB.getHandle<float>();
-  auto handleExpected = expected.getHandle<size_t>();
+  auto handleExpected = expected.getHandle<int64_t>();
 
   handleMatricesA.randomize<int>(0, 1, PRNG);
   handleMatricesB.randomize<int>(0, 1, PRNG);
@@ -1149,7 +1149,7 @@ TEST_P(MLTest, matrixRotationRecognition) {
       mod.createVariable(ElemKind::FloatTy, {TC.batchSize, 3, 3}, "matrixB",
                          VisibilityKind::Public, false);
   Variable *varExpected =
-      mod.createVariable(ElemKind::IndexTy, {TC.batchSize, 1}, "expected",
+      mod.createVariable(ElemKind::Int64ITy, {TC.batchSize, 1}, "expected",
                          VisibilityKind::Public, false);
 
   // Simply concatenating the matrices first would probability be as effective
@@ -1171,7 +1171,7 @@ TEST_P(MLTest, matrixRotationRecognition) {
   const unsigned numSamples = 50;
   Tensor matricesA(ElemKind::FloatTy, {numSamples, 3, 3});
   Tensor matricesB(ElemKind::FloatTy, {numSamples, 3, 3});
-  Tensor expected(ElemKind::IndexTy, {numSamples, 1});
+  Tensor expected(ElemKind::Int64ITy, {numSamples, 1});
   generateMatrixRotationRecognitionData(matricesA, matricesB, expected, PRNG);
 
   EE_.compile(CompilationMode::Train, trainingGradientFunction);
@@ -1201,7 +1201,7 @@ TEST_P(MLTest, matrixRotationRecognition) {
     // Note that the two softmax outputs always sum to 1, so we only look at
     // one. Index one is true if there is a rotation.
     float value = RHtrain.at({i, 1});
-    bool hasRotation = expected.getHandle<size_t>().at({batchStartIdx + i, 0});
+    bool hasRotation = expected.getHandle<int64_t>().at({batchStartIdx + i, 0});
     if ((value > 0.5) != hasRotation) {
       ++errors;
     }

--- a/tests/unittests/OCLTest.cpp
+++ b/tests/unittests/OCLTest.cpp
@@ -86,11 +86,11 @@ TEST(OpenCLCorrectnessTest, softmaxGradTest) {
   Tensor inputs(ElemKind::FloatTy, shape);
   Tensor weights(ElemKind::FloatTy, {23, 23});
   Tensor bias(ElemKind::FloatTy, {23});
-  Tensor selected(ElemKind::IndexTy, {8, 1});
+  Tensor selected(ElemKind::Int64ITy, {8, 1});
   inputs.getHandle().initXavier(1, PRNG);
   weights.getHandle().randomize(0.0, 0.5, PRNG);
   bias.getHandle().randomize(-0.2, 0.0, PRNG);
-  auto selectedH = selected.getHandle<size_t>();
+  auto selectedH = selected.getHandle<int64_t>();
   for (size_t i = 0; i < 8; i++) {
     selectedH.raw(i) = PRNG.nextRandInt(0, 22);
   }
@@ -113,8 +113,8 @@ TEST(OpenCLCorrectnessTest, gatherTest) {
   Tensor data(ElemKind::FloatTy, {nSlices, 16, 3, 2});
   data.getHandle().initXavier(1, PRNG);
 
-  Tensor indices(ElemKind::IndexTy, {nGathered});
-  auto indicesH = indices.getHandle<size_t>();
+  Tensor indices(ElemKind::Int64ITy, {nGathered});
+  auto indicesH = indices.getHandle<int64_t>();
   for (size_t i = 0; i < nGathered; i++) {
     indicesH.raw(i) = PRNG.nextRandInt(0, nSlices - 1);
   }

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -99,12 +99,12 @@ TEST_P(InterpAndCPU, log) {
 }
 
 TEST_P(InterpAndCPU, CmpEQ) {
-  auto *X = mod_.createVariable(ElemKind::IndexTy, {2, 7}, "X");
-  X->getPayload().getHandle<size_t>() = {0, 1, 17, 876, 1000, 44444, 9999999,
-                                         0, 1, 17, 876, 1000, 44444, 9999999};
-  auto *Y = mod_.createVariable(ElemKind::IndexTy, {2, 7}, "Y");
-  Y->getPayload().getHandle<size_t>() = {1, 2, 16, 900, 1111, 44544, 1999999,
-                                         0, 1, 17, 876, 1000, 44444, 9999999};
+  auto *X = mod_.createVariable(ElemKind::Int64ITy, {2, 7}, "X");
+  X->getPayload().getHandle<int64_t>() = {0, 1, 17, 876, 1000, 44444, 9999999,
+                                          0, 1, 17, 876, 1000, 44444, 9999999};
+  auto *Y = mod_.createVariable(ElemKind::Int64ITy, {2, 7}, "Y");
+  Y->getPayload().getHandle<int64_t>() = {1, 2, 16, 900, 1111, 44544, 1999999,
+                                          0, 1, 17, 876, 1000, 44444, 9999999};
 
   auto *cmpEQ = F_->createCmpEQ("cmpEQ", X, Y);
   auto *save = F_->createSave("save", cmpEQ);
@@ -113,7 +113,7 @@ TEST_P(InterpAndCPU, CmpEQ) {
 
   EE_.run({}, {});
 
-  auto saveH = save->getVariable()->getHandle<size_t>();
+  auto saveH = save->getVariable()->getHandle<int64_t>();
   for (size_t i = 0; i < 7; ++i) {
     EXPECT_FALSE(saveH.at({0, i}));
   }
@@ -587,7 +587,7 @@ TEST_P(Operator, minElem) {
 TEST_P(Operator, TopK) {
   auto *inp = mod_.createVariable(ElemKind::FloatTy, {3, 1, 5}, "input");
   auto *values = mod_.createVariable(ElemKind::FloatTy, {3, 1, 3}, "values");
-  auto *indices = mod_.createVariable(ElemKind::IndexTy, {3, 1, 3}, "indices");
+  auto *indices = mod_.createVariable(ElemKind::Int64ITy, {3, 1, 3}, "indices");
 
   inp->getPayload().getHandle() = {
       28, 4, 411, 19, 42, 0.4f, 0.4f, 0.4f, -0.4f, 0.45f, 7, 5, 9, 8, 100,
@@ -603,7 +603,7 @@ TEST_P(Operator, TopK) {
   EE_.run({}, {});
 
   auto V = values->getPayload().getHandle();
-  auto I = indices->getPayload().getHandle<size_t>();
+  auto I = indices->getPayload().getHandle<int64_t>();
 
   EXPECT_FLOAT_EQ(V.at({0, 0, 0}), 411);
   EXPECT_EQ(I.at({0, 0, 0}), 2);
@@ -632,7 +632,7 @@ TEST_P(InterpAndCPU, ConcatTopK) {
   auto *inp1 = mod_.createVariable(ElemKind::FloatTy, {2, 1, 3}, "input");
   auto *inp2 = mod_.createVariable(ElemKind::FloatTy, {2, 1, 3}, "input");
   auto *values = mod_.createVariable(ElemKind::FloatTy, {4, 1, 2}, "values");
-  auto *indices = mod_.createVariable(ElemKind::IndexTy, {4, 1, 2}, "indices");
+  auto *indices = mod_.createVariable(ElemKind::Int64ITy, {4, 1, 2}, "indices");
 
   inp1->getPayload().getHandle() = {1, 2, 3, 17.4f, -0.1f, -10.1f};
   inp2->getPayload().getHandle() = {1, 2, -3, -17.4f, -0.1f, -10.1f};
@@ -655,7 +655,7 @@ TEST_P(InterpAndCPU, ConcatTopK) {
   EE_.run({}, {});
 
   auto V = values->getPayload().getHandle();
-  auto I = indices->getPayload().getHandle<size_t>();
+  auto I = indices->getPayload().getHandle<int64_t>();
 
   EXPECT_FLOAT_EQ(V.at({0, 0, 0}), 3);
   EXPECT_FLOAT_EQ(I.at({0, 0, 0}), 2);
@@ -731,7 +731,7 @@ TEST_P(Operator, matMul) {
 TEST_P(InterpAndCPU, TopK1) {
   auto *inp = mod_.createVariable(ElemKind::FloatTy, {3, 1, 5}, "input");
   auto *values = mod_.createVariable(ElemKind::FloatTy, {3, 1, 1}, "values");
-  auto *indices = mod_.createVariable(ElemKind::IndexTy, {3, 1, 1}, "indices");
+  auto *indices = mod_.createVariable(ElemKind::Int64ITy, {3, 1, 1}, "indices");
 
   inp->getPayload().getHandle() = {
       0, 18, 7, 16, 5, 14, 33, 2, 41, 0, 1, -23, 34, 4, -5,
@@ -747,7 +747,7 @@ TEST_P(InterpAndCPU, TopK1) {
   EE_.run({}, {});
 
   auto V = values->getPayload().getHandle();
-  auto I = indices->getPayload().getHandle<size_t>();
+  auto I = indices->getPayload().getHandle<int64_t>();
 
   EXPECT_FLOAT_EQ(V.at({0, 0, 0}), 18);
   EXPECT_EQ(I.at({0, 0, 0}), 1);
@@ -762,7 +762,7 @@ TEST_P(InterpAndCPU, QuantizedTopK) {
       mod_.createVariable(ElemKind::Int8QTy, {3, 1, 5}, 1.2, 5, "input");
   auto *OV =
       mod_.createVariable(ElemKind::Int8QTy, {3, 1, 3}, 1.2, 5, "values");
-  auto *IV = mod_.createVariable(ElemKind::IndexTy, {3, 1, 3}, "indices");
+  auto *IV = mod_.createVariable(ElemKind::Int64ITy, {3, 1, 3}, "indices");
 
   INV->getPayload().getHandle<int8_t>() = {
       -12, -28, -7, 8, -93, 0, 10, 3, -1, 10, -2, 3, -2, 3, 3,
@@ -778,7 +778,7 @@ TEST_P(InterpAndCPU, QuantizedTopK) {
   EE_.run({}, {});
 
   auto VH = OV->getPayload().getHandle<int8_t>();
-  auto IH = IV->getPayload().getHandle<size_t>();
+  auto IH = IV->getPayload().getHandle<int64_t>();
 
   EXPECT_EQ(VH.at({0, 0, 0}), 8);
   EXPECT_EQ(IH.at({0, 0, 0}), 3);
@@ -829,13 +829,13 @@ TEST_P(Operator, Gather) {
     ]
   */
   auto *data = mod_.createVariable(ElemKind::FloatTy, {3, 2}, "data");
-  auto *indices = mod_.createVariable(ElemKind::IndexTy, {2, 4}, "indices");
+  auto *indices = mod_.createVariable(ElemKind::Int64ITy, {2, 4}, "indices");
   auto *result = mod_.createVariable(ElemKind::FloatTy, {2, 4, 2}, "result");
 
   data->getPayload().getHandle() = {
       1.0f, 1.2f, 2.3f, 3.4f, 4.5f, 5.7f,
   };
-  indices->getPayload().getHandle<size_t>() = {
+  indices->getPayload().getHandle<int64_t>() = {
       0, 1, 0, 1, 1, 2, 2, 0,
   };
 
@@ -930,7 +930,7 @@ TEST_P(Operator, Transpose3Dims) {
   }
 }
 
-/// Check that gather on IndexTy/size_t works.
+/// Check that gather on Int64ITy/size_t works.
 TEST_P(InterpAndCPU, GatherSizeT) {
   /*
     DATA  = [
@@ -957,14 +957,14 @@ TEST_P(InterpAndCPU, GatherSizeT) {
         ],
     ]
   */
-  auto *data = mod_.createVariable(ElemKind::IndexTy, {3, 2}, "data");
-  auto *indices = mod_.createVariable(ElemKind::IndexTy, {2, 4}, "indices");
-  auto *result = mod_.createVariable(ElemKind::IndexTy, {2, 4, 2}, "result");
+  auto *data = mod_.createVariable(ElemKind::Int64ITy, {3, 2}, "data");
+  auto *indices = mod_.createVariable(ElemKind::Int64ITy, {2, 4}, "indices");
+  auto *result = mod_.createVariable(ElemKind::Int64ITy, {2, 4, 2}, "result");
 
-  data->getPayload().getHandle<size_t>() = {
+  data->getPayload().getHandle<int64_t>() = {
       1, 2, 3, 4, 5, 6,
   };
-  indices->getPayload().getHandle<size_t>() = {
+  indices->getPayload().getHandle<int64_t>() = {
       0, 1, 0, 1, 1, 2, 2, 0,
   };
 
@@ -975,7 +975,7 @@ TEST_P(InterpAndCPU, GatherSizeT) {
   EE_.compile(CompilationMode::Infer, F_);
   EE_.run({}, {});
 
-  auto H = result->getPayload().getHandle<size_t>();
+  auto H = result->getPayload().getHandle<int64_t>();
 
   EXPECT_EQ(H.at({0, 0, 0}), 1);
   EXPECT_EQ(H.at({0, 0, 1}), 2);
@@ -1013,13 +1013,13 @@ TEST_P(Operator, BatchedGather) {
    ]
    */
   auto *data = mod_.createVariable(ElemKind::FloatTy, {3, 4}, "data");
-  auto *indices = mod_.createVariable(ElemKind::IndexTy, {2}, "indices");
+  auto *indices = mod_.createVariable(ElemKind::Int64ITy, {2}, "indices");
   auto *result = mod_.createVariable(ElemKind::FloatTy, {3, 2}, "result");
 
   data->getPayload().getHandle() = {
       1.0f, 1.2f, 2.4f, 4.5f, 2.3f, 3.4f, 3.6f, 2.3f, 4.5f, 5.7f, 1.2f, 4.5f,
   };
-  indices->getPayload().getHandle<size_t>() = {
+  indices->getPayload().getHandle<int64_t>() = {
       0,
       2,
   };
@@ -1043,12 +1043,12 @@ TEST_P(Operator, BatchedGather) {
 
 TEST_P(Operator, ScatterAssign) {
   auto *data = mod_.createVariable(ElemKind::FloatTy, {5, 2}, "data");
-  auto *indices = mod_.createVariable(ElemKind::IndexTy, {2}, "indices");
+  auto *indices = mod_.createVariable(ElemKind::Int64ITy, {2}, "indices");
   auto *slices = mod_.createVariable(ElemKind::FloatTy, {2, 2}, "slices");
   auto *result = mod_.createVariable(ElemKind::FloatTy, {5, 2}, "result");
 
   data->getPayload().getHandle() = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-  indices->getPayload().getHandle<size_t>() = {1, 3};
+  indices->getPayload().getHandle<int64_t>() = {1, 3};
   slices->getPayload().getHandle() = {-3, -4, -7, -8};
 
   auto R = F_->createScatterAssign("scatterassign", data, indices, slices);
@@ -1074,12 +1074,12 @@ TEST_P(Operator, ScatterAssign) {
 
 TEST_P(InterpAndCPU, ScatterAssignQuantized) {
   auto *data = mod_.createVariable(ElemKind::FloatTy, {5, 2}, "data");
-  auto *indices = mod_.createVariable(ElemKind::IndexTy, {2}, "indices");
+  auto *indices = mod_.createVariable(ElemKind::Int64ITy, {2}, "indices");
   auto *slices = mod_.createVariable(ElemKind::FloatTy, {2, 2}, "slices");
   auto *result = mod_.createVariable(ElemKind::FloatTy, {5, 2}, "result");
 
   data->getPayload().getHandle() = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
-  indices->getPayload().getHandle<size_t>() = {1, 3};
+  indices->getPayload().getHandle<int64_t>() = {1, 3};
   slices->getPayload().getHandle() = {-3, -4, -7, -8};
 
   auto qParams = glow::quantization::chooseQuantizationParams(-11, 11);
@@ -1368,11 +1368,11 @@ TEST_P(InterpAndCPU, IntFC) {
 
 TEST_P(InterpAndCPU, EntropyLossTest) {
   auto *P = mod_.createVariable(ElemKind::FloatTy, {2, 3}, "P");
-  auto *Y = mod_.createVariable(ElemKind::IndexTy, {2}, "Y");
+  auto *Y = mod_.createVariable(ElemKind::Int64ITy, {2}, "Y");
   auto *L = mod_.createVariable(ElemKind::FloatTy, {1}, "L");
 
   P->getPayload().getHandle() = {0.2f, 0.5f, 0.3f, 0.4f, 0.3f, 0.3f};
-  Y->getPayload().getHandle<size_t>() = {1, 2};
+  Y->getPayload().getHandle<int64_t>() = {1, 2};
   auto *ceLoss = F_->createCrossEntropyLoss("CELoss", P, Y);
   F_->createSave("save", ceLoss, L);
   EE_.compile(CompilationMode::Infer, F_);
@@ -1793,35 +1793,35 @@ TEST_P(Operator, FCGradientCheck) {
 TEST_P(InterpAndCPU, concatVectors) {
   F_->setName("concatVectors");
 
-  auto *V1 = mod_.createVariable(ElemKind::IndexTy, {10}, "V1",
+  auto *V1 = mod_.createVariable(ElemKind::Int64ITy, {10}, "V1",
                                  VisibilityKind::Public);
-  auto *V2 = mod_.createVariable(ElemKind::IndexTy, {20}, "V2",
+  auto *V2 = mod_.createVariable(ElemKind::Int64ITy, {20}, "V2",
                                  VisibilityKind::Public);
-  auto *V3 = mod_.createVariable(ElemKind::IndexTy, {30}, "V3",
+  auto *V3 = mod_.createVariable(ElemKind::Int64ITy, {30}, "V3",
                                  VisibilityKind::Public);
 
   Node *L = F_->createConcat("concat", {V1, V2, V3}, 0);
   auto *result = F_->createSave("ret", L);
 
-  Tensor I1(ElemKind::IndexTy, {10});
-  Tensor I2(ElemKind::IndexTy, {20});
-  Tensor I3(ElemKind::IndexTy, {30});
+  Tensor I1(ElemKind::Int64ITy, {10});
+  Tensor I2(ElemKind::Int64ITy, {20});
+  Tensor I3(ElemKind::Int64ITy, {30});
 
   for (size_t i = 0; i < 10; i++) {
-    I1.getHandle<size_t>().at({i}) = i;
+    I1.getHandle<int64_t>().at({i}) = i;
 
-    I2.getHandle<size_t>().at({i}) = i + 10;
-    I2.getHandle<size_t>().at({i + 10}) = i + 20;
-    I3.getHandle<size_t>().at({i}) = i + 30;
-    I3.getHandle<size_t>().at({i + 10}) = i + 40;
-    I3.getHandle<size_t>().at({i + 20}) = i + 50;
+    I2.getHandle<int64_t>().at({i}) = i + 10;
+    I2.getHandle<int64_t>().at({i + 10}) = i + 20;
+    I3.getHandle<int64_t>().at({i}) = i + 30;
+    I3.getHandle<int64_t>().at({i + 10}) = i + 40;
+    I3.getHandle<int64_t>().at({i + 20}) = i + 50;
   }
 
   EE_.compile(CompilationMode::Infer, F_);
 
   // Testing the output vector.
   EE_.run({V1, V2, V3}, {&I1, &I2, &I3});
-  auto RNWH = result->getVariable()->getPayload().getHandle<size_t>();
+  auto RNWH = result->getVariable()->getPayload().getHandle<int64_t>();
   (void)RNWH;
 
   for (size_t i = 0; i < 60; i++) {
@@ -1835,9 +1835,9 @@ TEST_P(InterpAndCPU, concatVectors) {
 TEST_P(InterpAndCPU, concatVectorsRepeated) {
   F_->setName("concatVectors");
 
-  auto *V1 = mod_.createVariable(ElemKind::IndexTy, {10}, "V1",
+  auto *V1 = mod_.createVariable(ElemKind::Int64ITy, {10}, "V1",
                                  VisibilityKind::Public);
-  auto *V2 = mod_.createVariable(ElemKind::IndexTy, {20}, "V2",
+  auto *V2 = mod_.createVariable(ElemKind::Int64ITy, {20}, "V2",
                                  VisibilityKind::Public);
 
   // Alternate adding sequences of V1 and V2, so that the IRGen'd InsertTensors
@@ -1845,21 +1845,21 @@ TEST_P(InterpAndCPU, concatVectorsRepeated) {
   Node *L = F_->createConcat("concat", {V2, V1, V1, V1, V2, V2, V1, V1, V2}, 0);
   auto *result = F_->createSave("ret", L);
 
-  Tensor I1(ElemKind::IndexTy, {10});
-  Tensor I2(ElemKind::IndexTy, {20});
+  Tensor I1(ElemKind::Int64ITy, {10});
+  Tensor I2(ElemKind::Int64ITy, {20});
 
   for (size_t i = 0; i < 10; i++) {
-    I1.getHandle<size_t>().at({i}) = 1;
+    I1.getHandle<int64_t>().at({i}) = 1;
 
-    I2.getHandle<size_t>().at({i}) = 2;
-    I2.getHandle<size_t>().at({i + 10}) = 2;
+    I2.getHandle<int64_t>().at({i}) = 2;
+    I2.getHandle<int64_t>().at({i + 10}) = 2;
   }
 
   EE_.compile(CompilationMode::Infer, F_);
 
   // Testing the output vector.
   EE_.run({V1, V2}, {&I1, &I2});
-  auto outH = result->getVariable()->getPayload().getHandle<size_t>();
+  auto outH = result->getVariable()->getPayload().getHandle<int64_t>();
   (void)outH;
 
   // Simply verify here that the values are in their correct places, based on
@@ -1876,7 +1876,7 @@ TEST_P(InterpAndCPU, concatVectorsRepeated) {
 TEST_P(InterpAndCPU, sliceVectors) {
   F_->setName("sliceVectors");
 
-  auto *V = mod_.createVariable(ElemKind::IndexTy, {3, 30}, "V",
+  auto *V = mod_.createVariable(ElemKind::Int64ITy, {3, 30}, "V",
                                 VisibilityKind::Public);
 
   Node *S1 = F_->createSlice("slice1", V, {0, 10}, {3, 13});
@@ -1887,23 +1887,23 @@ TEST_P(InterpAndCPU, sliceVectors) {
   auto *result2 = F_->createSave("ret2", S2);
   auto *result3 = F_->createSave("ret3", S3);
 
-  Tensor I(ElemKind::IndexTy, {3, 30});
+  Tensor I(ElemKind::Int64ITy, {3, 30});
 
   for (size_t j = 0; j < 30; j++) {
-    I.getHandle<size_t>().at({0, j}) = j;
-    I.getHandle<size_t>().at({1, j}) = j + 30;
-    I.getHandle<size_t>().at({2, j}) = j + 60;
+    I.getHandle<int64_t>().at({0, j}) = j;
+    I.getHandle<int64_t>().at({1, j}) = j + 30;
+    I.getHandle<int64_t>().at({2, j}) = j + 60;
   }
 
   EE_.compile(CompilationMode::Infer, F_);
 
   // Testing the output slices.
   EE_.run({V}, {&I});
-  auto RNWH1 = result1->getVariable()->getPayload().getHandle<size_t>();
+  auto RNWH1 = result1->getVariable()->getPayload().getHandle<int64_t>();
   (void)RNWH1;
-  auto RNWH2 = result2->getVariable()->getPayload().getHandle<size_t>();
+  auto RNWH2 = result2->getVariable()->getPayload().getHandle<int64_t>();
   (void)RNWH2;
-  auto RNWH3 = result3->getVariable()->getPayload().getHandle<size_t>();
+  auto RNWH3 = result3->getVariable()->getPayload().getHandle<int64_t>();
   (void)RNWH3;
 
   EXPECT_EQ(3, RNWH1.dims()[0]);
@@ -1928,13 +1928,13 @@ TEST_P(InterpAndCPU, sliceVectors) {
 TEST_P(InterpAndCPU, sliceConcatVectors) {
   F_->setName("sliceConcatVectors");
 
-  auto *V = mod_.createVariable(ElemKind::IndexTy, {5, 4}, "V",
+  auto *V = mod_.createVariable(ElemKind::Int64ITy, {5, 4}, "V",
                                 VisibilityKind::Public);
 
-  Tensor I(ElemKind::IndexTy, {5, 4});
+  Tensor I(ElemKind::Int64ITy, {5, 4});
   for (size_t i = 0; i < 5; i++) {
     for (size_t j = 0; j < 4; j++) {
-      I.getHandle<size_t>().at({i, j}) = i * 100 + j;
+      I.getHandle<int64_t>().at({i, j}) = i * 100 + j;
     }
   }
 
@@ -1960,7 +1960,7 @@ TEST_P(InterpAndCPU, sliceConcatVectors) {
                                  {0, 1, 2, 3},         {100, 101, 102, 103},
                                  {200, 201, 202, 203}};
 
-  auto resultH = result->getVariable()->getPayload().getHandle<size_t>();
+  auto resultH = result->getVariable()->getPayload().getHandle<int64_t>();
   EXPECT_EQ(7, resultH.dims()[0]);
   EXPECT_EQ(4, resultH.dims()[1]);
   for (size_t i = 0; i < 7; i++) {
@@ -2884,16 +2884,16 @@ TEST_P(InterpOnly, SparseLengthsSum) {
     ]
   */
   auto *data = mod_.createVariable(ElemKind::FloatTy, {3, 2}, "data");
-  auto *indices = mod_.createVariable(ElemKind::IndexTy, {8}, "indices");
-  auto *lengths = mod_.createVariable(ElemKind::IndexTy, {5}, "lengths");
+  auto *indices = mod_.createVariable(ElemKind::Int64ITy, {8}, "indices");
+  auto *lengths = mod_.createVariable(ElemKind::Int64ITy, {5}, "lengths");
 
   data->getPayload().getHandle() = {
       1.0f, 1.2f, 2.3f, 3.4f, 4.5f, 5.7f,
   };
-  indices->getPayload().getHandle<size_t>() = {
+  indices->getPayload().getHandle<int64_t>() = {
       2, 0, 1, 2, 0, 0, 0, 0,
   };
-  lengths->getPayload().getHandle<size_t>() = {
+  lengths->getPayload().getHandle<int64_t>() = {
       2, 0, 2, 1, 3,
   };
 
@@ -2922,8 +2922,8 @@ TEST_P(InterpOnly, SparseLengthsWeightedSum) {
   */
   auto *data = mod_.createVariable(ElemKind::FloatTy, {3}, "data");
   auto *weights = mod_.createVariable(ElemKind::FloatTy, {8}, "weights");
-  auto *indices = mod_.createVariable(ElemKind::IndexTy, {8}, "indices");
-  auto *lengths = mod_.createVariable(ElemKind::IndexTy, {4}, "lengths");
+  auto *indices = mod_.createVariable(ElemKind::Int64ITy, {8}, "indices");
+  auto *lengths = mod_.createVariable(ElemKind::Int64ITy, {4}, "lengths");
 
   data->getPayload().getHandle() = {
       2.0,
@@ -2933,10 +2933,10 @@ TEST_P(InterpOnly, SparseLengthsWeightedSum) {
   weights->getPayload().getHandle() = {
       3, 1, 0, 0, 0, 0, 2, -0.5,
   };
-  indices->getPayload().getHandle<size_t>() = {
+  indices->getPayload().getHandle<int64_t>() = {
       1, 0, 2, 0, 1, 2, 2, 0,
   };
-  lengths->getPayload().getHandle<size_t>() = {
+  lengths->getPayload().getHandle<int64_t>() = {
       3,
       0,
       3,
@@ -3112,13 +3112,13 @@ TEST_P(Operator, Flatten) {
   }
 }
 
-/// Check that div on IndexTy/size_t works.
+/// Check that div on Int64ITy/size_t works.
 TEST_P(InterpAndCPU, DivSizeT) {
-  auto *LHS = mod_.createVariable(ElemKind::IndexTy, {3, 2}, "LHS");
-  auto *RHS = mod_.createVariable(ElemKind::IndexTy, {3, 2}, "RHS");
-  auto *result = mod_.createVariable(ElemKind::IndexTy, {3, 2}, "result");
-  auto LHSH = LHS->getPayload().getHandle<size_t>();
-  auto RHSH = RHS->getPayload().getHandle<size_t>();
+  auto *LHS = mod_.createVariable(ElemKind::Int64ITy, {3, 2}, "LHS");
+  auto *RHS = mod_.createVariable(ElemKind::Int64ITy, {3, 2}, "RHS");
+  auto *result = mod_.createVariable(ElemKind::Int64ITy, {3, 2}, "result");
+  auto LHSH = LHS->getPayload().getHandle<int64_t>();
+  auto RHSH = RHS->getPayload().getHandle<int64_t>();
 
   LHSH = {10, 20, 30, 40, 50, 60};
   RHSH = {2, 20, 100, 41, 3, 59};
@@ -3130,7 +3130,7 @@ TEST_P(InterpAndCPU, DivSizeT) {
   EE_.compile(CompilationMode::Infer, F_);
   EE_.run({}, {});
 
-  auto H = result->getPayload().getHandle<size_t>();
+  auto H = result->getPayload().getHandle<int64_t>();
 
   for (size_t i = 0; i < 3; i++) {
     for (size_t j = 0; j < 2; j++) {

--- a/tests/unittests/basicIRTest.cpp
+++ b/tests/unittests/basicIRTest.cpp
@@ -97,7 +97,7 @@ TEST(IR, allInstrs) {
   IRFunction M(F);
   auto T1 = mod.uniqueType(ElemKind::FloatTy, {1, 24, 24, 3});
   auto T2 = mod.uniqueType(ElemKind::FloatTy, {64});
-  auto T4 = mod.uniqueType(ElemKind::IndexTy, {1, 1});
+  auto T4 = mod.uniqueType(ElemKind::Int64ITy, {1, 1});
 
   {
     IRBuilder builder(&M);
@@ -114,7 +114,7 @@ TEST(IR, allInstrs) {
     auto *ComputationInfo =
         builder.createWeightVar(ElemKind::FloatTy, {2}, "ComputationInfo");
 
-    auto *XY = builder.createWeightVar(ElemKind::IndexTy, {1, 12, 12, 3, 2});
+    auto *XY = builder.createWeightVar(ElemKind::Int64ITy, {1, 12, 12, 3, 2});
     auto *B0 = builder.createWeightVar(T2, "B0");
     auto *B1 =
         builder.createWeightVar(ElemKind::FloatTy, {32}, "B1", MK::Mutable);
@@ -180,7 +180,7 @@ TEST(IR, predicateIR) {
     IRBuilder builder(&M);
     auto *V1 = builder.createWeightVar(ElemKind::FloatTy, {320, 200});
     auto *V2 = builder.createWeightVar(ElemKind::FloatTy, {320, 200});
-    auto *P = builder.createWeightVar(ElemKind::IndexTy, {320}, "p1");
+    auto *P = builder.createWeightVar(ElemKind::Int64ITy, {320}, "p1");
 
     // Check that we can construct a new instruction.
     auto *CC = builder.createCopyInst("C", V1, V2);

--- a/tests/unittests/gradCheckTest.cpp
+++ b/tests/unittests/gradCheckTest.cpp
@@ -488,7 +488,7 @@ TEST_P(InterpreterGrad, gradientCheckCrossEntropyLoss) {
   Function *F = mod.createFunction("main");
   auto *P = mod.createVariable(ElemKind::FloatTy, {batchSize, 4}, "P",
                                VisibilityKind::Public, false);
-  auto *Y = mod.createVariable(ElemKind::IndexTy, {batchSize}, "Labels",
+  auto *Y = mod.createVariable(ElemKind::Int64ITy, {batchSize}, "Labels",
                                VisibilityKind::Public, false);
   auto *L = mod.createVariable(ElemKind::FloatTy, {1}, "L",
                                VisibilityKind::Public, false);
@@ -496,10 +496,10 @@ TEST_P(InterpreterGrad, gradientCheckCrossEntropyLoss) {
   F->createSave("ret", CE, L);
 
   Tensor inputs(ElemKind::FloatTy, {batchSize, 4});
-  Tensor outputs(ElemKind::IndexTy, {batchSize});
+  Tensor outputs(ElemKind::Int64ITy, {batchSize});
 
   auto inputsH = inputs.getHandle();
-  auto outputsH = outputs.getHandle<size_t>();
+  auto outputsH = outputs.getHandle<int64_t>();
 
   inputsH.randomize(0.0, 1.0, mod.getPRNG());
   outputsH.at({0}) = 2;

--- a/tests/unittests/graphGradTest.cpp
+++ b/tests/unittests/graphGradTest.cpp
@@ -55,7 +55,7 @@ TEST(GraphAutoGrad, autoGrad) {
   auto *FCL1 = F->createFullyConnected("fc3", MP1, 10);
   auto *RL2 = F->createRELU("relu3", FCL1);
   Variable *selected = mod.createVariable(
-      ElemKind::IndexTy, {10, 1}, "selected", VisibilityKind::Public, false);
+      ElemKind::Int64ITy, {10, 1}, "selected", VisibilityKind::Public, false);
 
   auto *SM = F->createSoftMax("sm", RL2, selected);
 
@@ -85,7 +85,7 @@ TEST(GraphAutoGrad, checkLRNGen) {
   auto *FCL1 = F->createFullyConnected("fc3", CV0, 10);
   auto *RL2 = F->createRELU("relu3", FCL1);
   Variable *selected = mod.createVariable(
-      ElemKind::IndexTy, {10, 1}, "selected", VisibilityKind::Public, false);
+      ElemKind::Int64ITy, {10, 1}, "selected", VisibilityKind::Public, false);
 
   auto *SM = F->createSoftMax("sm", RL2, selected);
 

--- a/tests/unittests/graphOptzTest.cpp
+++ b/tests/unittests/graphOptzTest.cpp
@@ -56,7 +56,7 @@ TEST_F(GraphOptz, DCE) {
 
 TEST_F(GraphOptz, liveCodeNotEliminated) {
   Node *K = mod_.createVariable(ElemKind::FloatTy, {4, 320, 200, 3}, "input");
-  auto *Ex = mod_.createVariable(ElemKind::IndexTy, {4, 1}, "Ex");
+  auto *Ex = mod_.createVariable(ElemKind::Int64ITy, {4, 1}, "Ex");
 
   for (int i = 0; i < 40; i++) {
     K = F_->createRELU("relu", K);

--- a/tests/unittests/graphTest.cpp
+++ b/tests/unittests/graphTest.cpp
@@ -49,7 +49,7 @@ TEST(Graph, simpleTestConv) {
   Function *F = MD.createFunction("F");
   IRFunction M(F);
   Node *K = MD.createVariable(ElemKind::FloatTy, {4, 320, 200, 3}, "input");
-  Node *S = MD.createVariable(ElemKind::IndexTy, {4, 1}, "select");
+  Node *S = MD.createVariable(ElemKind::Int64ITy, {4, 1}, "select");
 
   K = F->createConv("Conv1", K, 16, 3, 2, 3, 1);
   K = F->createRELU("Relu", K);
@@ -289,7 +289,7 @@ TEST(Graph, quantizeGather) {
   auto *F = mod.createFunction("main");
   auto *input = mod.createVariable(ElemKind::Int8QTy, {2, 2}, 0.4, 2, "input",
                                    VisibilityKind::Public);
-  auto *indices = mod.createVariable(ElemKind::IndexTy, {1}, "index",
+  auto *indices = mod.createVariable(ElemKind::Int64ITy, {1}, "index",
                                      VisibilityKind::Public);
   auto *gather = F->createGather("gather", input, indices);
   F->createSave("ret", gather);
@@ -301,7 +301,7 @@ TEST(Graph, cloneTest) {
 
   Function *F = M.createFunction("main");
   Node *K = M.createVariable(ElemKind::FloatTy, {4, 320, 200, 3}, "input");
-  Node *S = M.createVariable(ElemKind::IndexTy, {4, 1}, "select");
+  Node *S = M.createVariable(ElemKind::Int64ITy, {4, 1}, "select");
   Node *conv = F->createConv("Conv1", K, 16, 3, 2, 3, 1);
   Node *relu = F->createRELU("Relu", conv);
   Node *SM = F->createSoftMax("SoftMax", relu, S);
@@ -352,7 +352,7 @@ TEST(Graph, cloneTest2) {
 
   auto *F = M.createFunction("main");
   Node *K = M.createVariable(ElemKind::FloatTy, {4, 320, 200, 3}, "input");
-  Node *S = M.createVariable(ElemKind::IndexTy, {4, 1}, "select");
+  Node *S = M.createVariable(ElemKind::Int64ITy, {4, 1}, "select");
   Node *conv = F->createConv("Conv1", K, 16, 3, 2, 3, 1);
   Node *relu = F->createRELU("Relu", conv);
   Node *concat = F->createConcat("concat", {relu, relu, relu}, 0);
@@ -421,9 +421,9 @@ TEST(Graph, nodesWithPredicates) {
   auto *input = mod.createVariable(ElemKind::FloatTy, {1, 32, 32, 3}, "input",
                                    VisibilityKind::Public);
 
-  auto *ex = mod.createVariable(ElemKind::IndexTy, {1, 1}, "exp");
+  auto *ex = mod.createVariable(ElemKind::Int64ITy, {1, 1}, "exp");
 
-  Variable *pred = mod.createVariable(ElemKind::IndexTy, {1}, "predicate",
+  Variable *pred = mod.createVariable(ElemKind::Int64ITy, {1}, "predicate",
                                       VisibilityKind::Private, false);
 
   auto *CV0 = F->createConv("conv1", input, 16, 5, 1, 2, 1);

--- a/tests/unittests/quantizationTest.cpp
+++ b/tests/unittests/quantizationTest.cpp
@@ -270,7 +270,7 @@ TEST_P(Operator, end2end) {
 
 /// Fills the tensor \p H with some stable random integers with the seed \p seed
 /// and the range [0, scale).
-static void fillStableRandomIndex(Handle<size_t> H, size_t seed,
+static void fillStableRandomIndex(Handle<int64_t> H, size_t seed,
                                   size_t scale = 10) {
   for (size_t i = 0, e = H.size(); i < e; i++) {
     H.raw(i) = int(i * 1921 + seed) % scale;
@@ -294,9 +294,9 @@ static Function *createGRUForQuantization(Module *M, llvm::StringRef funcName) {
   fillStableRandomData(emb->getHandle(), 4565, 1);
 
   auto *input = F->getParent()->createVariable(
-      ElemKind::IndexTy, {batchSize, sequenceSize}, "input",
+      ElemKind::Int64ITy, {batchSize, sequenceSize}, "input",
       VisibilityKind::Public, false);
-  fillStableRandomIndex(input->getHandle<size_t>(), 7227, 10);
+  fillStableRandomIndex(input->getHandle<int64_t>(), 7227, 10);
 
   auto *hiddenInit = F->getParent()->createVariable(
       ElemKind::FloatTy, {batchSize, embeddingSize}, "hiddenInit",
@@ -633,7 +633,7 @@ TEST(Quantization, quantizeSoftmaxAndLRN) {
   Function *F = mod.createFunction("main");
 
   auto *input = mod.createVariable(ElemKind::FloatTy, {1, 10}, "input");
-  auto *selected = mod.createVariable(ElemKind::IndexTy, {1, 10}, "selected");
+  auto *selected = mod.createVariable(ElemKind::Int64ITy, {1, 10}, "selected");
   auto *LRN =
       F->createLocalResponseNormalization("LRN", input, 2, 1.0, 0.0001, 0.75);
   auto *SM = F->createSoftMax("softmax", LRN, selected);

--- a/tests/unittests/tensorsTest.cpp
+++ b/tests/unittests/tensorsTest.cpp
@@ -178,7 +178,7 @@ TEST(Tensor, assignment) {
   testAssignment<float>(Type{ElemKind::FloatTy, dim});
   testAssignment<int8_t>(Type{ElemKind::Int8QTy, dim, 1., 0});
   testAssignment<int32_t>(Type{ElemKind::Int32QTy, dim, 1., 0});
-  testAssignment<size_t>(Type{ElemKind::IndexTy, dim});
+  testAssignment<int64_t>(Type{ElemKind::Int64ITy, dim});
 }
 
 TEST(Tensor, concatTensors1D) {
@@ -630,8 +630,8 @@ TEST(ZeroDimensionalTensor, compareToNonZeroDimensional) {
 }
 
 TEST(ZeroDimensionalTensor, transpose) {
-  Tensor T(ElemKind::IndexTy, {});
-  T.getHandle<size_t>() = {15};
+  Tensor T(ElemKind::Int64ITy, {});
+  T.getHandle<int64_t>() = {15};
 
   Tensor TT;
   T.transpose(&TT, {});
@@ -643,7 +643,7 @@ TEST(Type, compare) {
   Type T1(ElemKind::FloatTy, {});
   Type T2(ElemKind::FloatTy, {});
   Type T3(ElemKind::FloatTy, {1});
-  Type T4(ElemKind::IndexTy, {});
+  Type T4(ElemKind::Int64ITy, {});
 
   EXPECT_TRUE(T1.isEqual(T2));
   EXPECT_FALSE(T1.isEqual(T3));

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -203,8 +203,10 @@ int main(int argc, char **argv) {
       .addOperand("Lengths", OperandKind::In)
       .autoIRGen()
       .autoVerify(VerifyKind::SameElementType, {"Dest", "Data", "Weights"})
-      .autoVerify(VerifyKind::SameElementType, {"Indices", "ElemKind::IndexTy"})
-      .autoVerify(VerifyKind::SameElementType, {"Lengths", "ElemKind::IndexTy"})
+      .autoVerify(VerifyKind::SameElementType,
+                  {"Indices", "ElemKind::Int64ITy"})
+      .autoVerify(VerifyKind::SameElementType,
+                  {"Lengths", "ElemKind::Int64ITy"})
       .autoVerify(VerifyKind::SameShape, {"Weights", "Indices"});
 
   /// Adds the 'Slice' operand to each one of the slices in the batch.
@@ -381,7 +383,8 @@ int main(int argc, char **argv) {
       .addOperand("Indices", OperandKind::In)
       .addMember(MemberType::Unsigned, "BatchDims")
       .autoVerify(VerifyKind::SameElementType, {"Dest", "Data"})
-      .autoVerify(VerifyKind::SameElementType, {"Indices", "ElemKind::IndexTy"})
+      .autoVerify(VerifyKind::SameElementType,
+                  {"Indices", "ElemKind::Int64ITy"})
       .autoIRGen();
 
   BB.newInstr("ScatterAssign")
@@ -389,7 +392,7 @@ int main(int argc, char **argv) {
       .addOperand("Indices", OperandKind::In)
       .addOperand("Slices", OperandKind::In)
       .autoVerify(VerifyKind::SameElementType,
-                  {"Indices", "ElemKind::IndexTy"});
+                  {"Indices", "ElemKind::Int64ITy"});
 
   //===--------------------------------------------------------------------===//
   //             Instructions used for debugging/profiling/printing


### PR DESCRIPTION
We often need to load weights from ONNX/Caffe2 that are typed explicitly as unsigned/signed and with a bitwidth. For example, ONNX has `ONNX_NAMESPACE::TensorProto::INT64`, and Caffe2 has `GivenTensorInt64Fill`.

This allows us to load such protos, instead of failing when seeing them. From here we could add new ElemKinds as well, e.g. `ElemKind::Int32ITy`, and then shrink the size of `ElemKind::Int64ITy` tensors to `ElemKind::Int32ITy` if we know they could fit in 32 bits instead.