### PR TITLE
[Type.h] Add type Int16QTy

### DIFF
--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -276,6 +276,8 @@ public:
       assert(getType().getOffset() == other.getType().getOffset() &&
              "Offsets must match.");
       return isEqualImpl<int8_t>(other, allowedError);
+    case ElemKind::Int16QTy:
+      return isEqualImpl<int16_t>(other, allowedError);
     case ElemKind::Int32QTy:
       return isEqualImpl<int32_t>(other, allowedError);
     case ElemKind::Int64ITy:

--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -181,6 +181,7 @@ inline bool operator==(const ShapeNCHW &LHS, const ShapeNCHW &RHS) {
 enum class ElemKind : unsigned char {
   FloatTy,  // 32-bit float type (float)
   Int8QTy,  // 8-bit quantized type (int8_t)
+  Int16QTy, // 16-bit quantized type (int16_t)
   Int32QTy, // 32-bit quantized type (int32_t)
   Int64ITy, // 64-bit index type (int64_t)
 };
@@ -311,6 +312,8 @@ struct Type final {
       return std::is_same<ElemTy, float>::value;
     case ElemKind::Int8QTy:
       return std::is_same<ElemTy, int8_t>::value;
+    case ElemKind::Int16QTy:
+      return std::is_same<ElemTy, int16_t>::value;
     case ElemKind::Int32QTy:
       return std::is_same<ElemTy, int32_t>::value;
     case ElemKind::Int64ITy:
@@ -322,7 +325,9 @@ struct Type final {
   /// \returns true if the type of this Tensor is one of the integer types.
   /// Notice that we don't consider Int64ITy as an integer because we are not
   /// performing calculations on this type.
-  bool isQuantizedType() const { return isType<int8_t>() || isType<int32_t>(); }
+  bool isQuantizedType() const {
+    return isType<int8_t>() || isType<int16_t>() || isType<int32_t>();
+  }
 
   /// \return the size of the type element.
   unsigned getElementSize() const { return getElementSize(elementType_); }
@@ -337,6 +342,8 @@ struct Type final {
       return sizeof(float);
     case ElemKind::Int8QTy:
       return sizeof(int8_t);
+    case ElemKind::Int16QTy:
+      return sizeof(int16_t);
     case ElemKind::Int32QTy:
       return sizeof(int32_t);
     case ElemKind::Int64ITy:
@@ -355,6 +362,7 @@ struct Type final {
     static const char *names[] = {
         "float",
         "i8",
+        "i16",
         "i32",
         "index",
     };

--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -247,6 +247,8 @@ llvm::Type *LLVMIRGen::getElementType(llvm::IRBuilder<> &builder,
     return builder.getFloatTy();
   case ElemKind::Int8QTy:
     return builder.getInt8Ty();
+  case ElemKind::Int16QTy:
+    return builder.getInt16Ty();
   case ElemKind::Int32QTy:
     return builder.getInt32Ty();
   }
@@ -457,6 +459,8 @@ llvm::Value *LLVMIRGen::emitConst(llvm::IRBuilder<> &builder, float val,
     return builder.getInt64(static_cast<int64_t>(val));
   case ElemKind::Int8QTy:
     return builder.getInt8(static_cast<int8_t>(val));
+  case ElemKind::Int16QTy:
+    return builder.getInt16(static_cast<int16_t>(val));
   case ElemKind::Int32QTy:
     return builder.getInt32(static_cast<int32_t>(val));
   }

--- a/lib/Base/Tensor.cpp
+++ b/lib/Base/Tensor.cpp
@@ -271,6 +271,8 @@ void glow::dumpAsciiImpl(Tensor *T, llvm::raw_ostream &os) {
     return dumpAsciiGenericImpl(T->getHandle<float>(), os);
   case ElemKind::Int8QTy:
     return dumpAsciiGenericImpl(T->getHandle<int8_t>(), os);
+  case ElemKind::Int16QTy:
+    return dumpAsciiGenericImpl(T->getHandle<int16_t>(), os);
   case ElemKind::Int32QTy:
     return dumpAsciiGenericImpl(T->getHandle<int32_t>(), os);
   case ElemKind::Int64ITy:
@@ -286,6 +288,8 @@ void glow::dumpImpl(Tensor *T, llvm::raw_ostream &os) {
     return dumpGenericImpl(T->getHandle<float>(), os);
   case ElemKind::Int8QTy:
     return dumpGenericImpl(T->getHandle<int8_t>(), os);
+  case ElemKind::Int16QTy:
+    return dumpGenericImpl(T->getHandle<int16_t>(), os);
   case ElemKind::Int32QTy:
     return dumpGenericImpl(T->getHandle<int32_t>(), os);
   case ElemKind::Int64ITy:
@@ -321,6 +325,12 @@ void glow::genericTranspose(Tensor *src, Tensor *dest,
   case ElemKind::Int8QTy: {
     auto srcH = src->getHandle<int8_t>();
     auto destH = dest->getHandle<int8_t>();
+    transposeSelectImpl(srcH, destH, shuffle);
+    return;
+  }
+  case ElemKind::Int16QTy: {
+    auto srcH = src->getHandle<int16_t>();
+    auto destH = dest->getHandle<int16_t>();
     transposeSelectImpl(srcH, destH, shuffle);
     return;
   }
@@ -362,7 +372,11 @@ void Tensor::init(InitKind init, float val, PseudoRNG &PRNG) {
     case ElemKind::Int8QTy: {
       getHandle<int8_t>().clear(val);
       break;
-    };
+    }
+    case ElemKind::Int16QTy: {
+      getHandle<int16_t>().clear(val);
+      break;
+    }
     case ElemKind::Int32QTy: {
       getHandle<int32_t>().clear(val);
       break;
@@ -384,7 +398,11 @@ void Tensor::init(InitKind init, float val, PseudoRNG &PRNG) {
     case ElemKind::Int8QTy: {
       getHandle<int8_t>().initXavier(val, PRNG);
       break;
-    };
+    }
+    case ElemKind::Int16QTy: {
+      getHandle<int16_t>().initXavier(val, PRNG);
+      break;
+    }
     case ElemKind::Int32QTy: {
       getHandle<int32_t>().initXavier(val, PRNG);
       break;

--- a/tests/unittests/tensorsTest.cpp
+++ b/tests/unittests/tensorsTest.cpp
@@ -177,6 +177,7 @@ TEST(Tensor, assignment) {
   size_t dim[] = {320, 200, 64};
   testAssignment<float>(Type{ElemKind::FloatTy, dim});
   testAssignment<int8_t>(Type{ElemKind::Int8QTy, dim, 1., 0});
+  testAssignment<int16_t>(Type{ElemKind::Int16QTy, dim, 1., 0});
   testAssignment<int32_t>(Type{ElemKind::Int32QTy, dim, 1., 0});
   testAssignment<int64_t>(Type{ElemKind::Int64ITy, dim});
 }


### PR DESCRIPTION
Add int16 type to be able to use int16 tensors in back-end. Not used in the middle-end at the moment.