### PR TITLE
[msvc] Fixes CMakeLists.txt and FindOpenCL.cmake under Win32.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,14 @@ if (GLOW_WITH_OPENCL)
   find_package(OpenCL REQUIRED)
 endif ()
 
+if(MSVC)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4710 /wd4711 /wd4514 /wd4571 /wd4820 /wd4774 /wd4625")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4526 /wd4061 /wd4365 /wd4242 /wd4996 /wd5026 /wd4626")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd5027 /wd4668 /wd4305 /wd4826 /wd4574 /wd4946 /wd4125")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd5027 /wd4668 /wd4305 /wd4826 /wd4574 /wd4946 /wd4125")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4647 /wd5045")
+endif()
+
 # Prefer LLVM 6.
 find_package(LLVM 6 CONFIG)
 # If LLVM 6 not found, try build with whatever is available.
@@ -92,9 +100,15 @@ if (GLOW_BUILD_TESTS)
 
   # Fetch the dependencies for all the tests.
   get_property(GLOW_TEST_DEPENDS GLOBAL PROPERTY GLOW_TEST_DEPENDS)
+  get_property(GLOW_TEST_NAME_DEPENDS GLOBAL PROPERTY GLOW_TEST_NAME_DEPENDS)
 
-  add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND}
-                      DEPENDS ${GLOW_TEST_DEPENDS} USES_TERMINAL)
+  add_custom_target(
+    check
+    COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -C $<CONFIG>
+    DEPENDS ${GLOW_TEST_DEPENDS}
+    USES_TERMINAL
+  )
+  add_dependencies(check ${GLOW_TEST_NAME_DEPENDS})
 endif()
 
 add_custom_target(dependency_graph

--- a/cmake/modules/FindOpenCL.cmake
+++ b/cmake/modules/FindOpenCL.cmake
@@ -1,0 +1,184 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#.rst:
+# FindOpenCL
+# ----------
+#
+# Try to find OpenCL
+#
+# IMPORTED Targets
+# ^^^^^^^^^^^^^^^^
+#
+# This module defines :prop_tgt:`IMPORTED` target ``OpenCL::OpenCL``, if
+# OpenCL has been found.
+#
+# Result Variables
+# ^^^^^^^^^^^^^^^^
+#
+# This module defines the following variables::
+#
+#   OpenCL_FOUND          - True if OpenCL was found
+#   OpenCL_INCLUDE_DIRS   - include directories for OpenCL
+#   OpenCL_LIBRARIES      - link against this library to use OpenCL
+#   OpenCL_VERSION_STRING - Highest supported OpenCL version (eg. 1.2)
+#   OpenCL_VERSION_MAJOR  - The major version of the OpenCL implementation
+#   OpenCL_VERSION_MINOR  - The minor version of the OpenCL implementation
+#
+# The module will also define two cache variables::
+#
+#   OpenCL_INCLUDE_DIR    - the OpenCL include directory
+#   OpenCL_LIBRARY        - the path to the OpenCL library
+#
+
+function(_FIND_OPENCL_VERSION)
+  include(CheckSymbolExists)
+  include(CMakePushCheckState)
+  set(CMAKE_REQUIRED_QUIET ${OpenCL_FIND_QUIETLY})
+
+  CMAKE_PUSH_CHECK_STATE()
+  foreach(VERSION "2_2" "2_1" "2_0" "1_2" "1_1" "1_0")
+    set(CMAKE_REQUIRED_INCLUDES "${OpenCL_INCLUDE_DIR}")
+
+    if(APPLE)
+      CHECK_SYMBOL_EXISTS(
+        CL_VERSION_${VERSION}
+        "${OpenCL_INCLUDE_DIR}/Headers/cl.h"
+        OPENCL_VERSION_${VERSION})
+    else()
+      CHECK_SYMBOL_EXISTS(
+        CL_VERSION_${VERSION}
+        "${OpenCL_INCLUDE_DIR}/CL/cl.h"
+        OPENCL_VERSION_${VERSION})
+    endif()
+
+    if(OPENCL_VERSION_${VERSION})
+      string(REPLACE "_" "." VERSION "${VERSION}")
+      set(OpenCL_VERSION_STRING ${VERSION} PARENT_SCOPE)
+      string(REGEX MATCHALL "[0-9]+" version_components "${VERSION}")
+      list(GET version_components 0 major_version)
+      list(GET version_components 1 minor_version)
+      set(OpenCL_VERSION_MAJOR ${major_version} PARENT_SCOPE)
+      set(OpenCL_VERSION_MINOR ${minor_version} PARENT_SCOPE)
+      break()
+    endif()
+  endforeach()
+  CMAKE_POP_CHECK_STATE()
+endfunction()
+
+find_path(OpenCL_INCLUDE_DIR
+  NAMES
+    CL/cl.h OpenCL/cl.h
+  HINTS
+    ENV "PROGRAMFILES(X86)"
+    ENV AMDAPPSDKROOT
+    ENV INTELOCLSDKROOT
+    ENV NVSDKCOMPUTE_ROOT
+    ENV CUDA_PATH
+    ENV ATISTREAMSDKROOT
+    ENV OCL_ROOT
+  PATHS
+    ENV "PROGRAMFILES(X86)"
+    ENV AMDAPPSDKROOT
+    ENV INTELOCLSDKROOT
+    ENV NVSDKCOMPUTE_ROOT
+    ENV CUDA_PATH
+    ENV ATISTREAMSDKROOT
+    ENV OCL_ROOT
+  PATH_SUFFIXES
+    include
+    OpenCL/common/inc
+    "AMD APP/include")
+
+_FIND_OPENCL_VERSION()
+
+if(WIN32)
+  if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+    find_library(OpenCL_LIBRARY
+      NAMES OpenCL
+    HINTS
+        ENV "PROGRAMFILES(X86)"
+        ENV AMDAPPSDKROOT
+        ENV INTELOCLSDKROOT
+        ENV CUDA_PATH
+        ENV NVSDKCOMPUTE_ROOT
+        ENV ATISTREAMSDKROOT
+        ENV OCL_ROOT
+    PATHS
+        ENV "PROGRAMFILES(X86)"
+        ENV AMDAPPSDKROOT
+        ENV INTELOCLSDKROOT
+        ENV CUDA_PATH
+        ENV NVSDKCOMPUTE_ROOT
+        ENV ATISTREAMSDKROOT
+        ENV OCL_ROOT
+      PATH_SUFFIXES
+        "AMD APP/lib/x86"
+        lib/x86
+        lib/Win32
+        OpenCL/common/lib/Win32)
+  elseif(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    find_library(OpenCL_LIBRARY
+      NAMES OpenCL
+      HINTS
+        ENV "PROGRAMFILES(X86)"
+        ENV AMDAPPSDKROOT
+        ENV INTELOCLSDKROOT
+        ENV CUDA_PATH
+        ENV NVSDKCOMPUTE_ROOT
+        ENV ATISTREAMSDKROOT
+        ENV OCL_ROOT
+      PATHS
+        ENV "PROGRAMFILES(X86)"
+        ENV AMDAPPSDKROOT
+        ENV INTELOCLSDKROOT
+        ENV CUDA_PATH
+        ENV NVSDKCOMPUTE_ROOT
+        ENV ATISTREAMSDKROOT
+        ENV OCL_ROOT
+      PATH_SUFFIXES
+        "AMD APP/lib/x86_64"
+        lib/x86_64
+        lib/x64
+        OpenCL/common/lib/x64)
+  endif()
+else()
+  find_library(OpenCL_LIBRARY
+    NAMES OpenCL
+    PATHS
+      ENV AMDAPPSDKROOT
+      ENV CUDA_PATH
+    PATH_SUFFIXES
+      lib/x86_64
+      lib/x64
+      lib
+      lib64)
+endif()
+
+set(OpenCL_LIBRARIES ${OpenCL_LIBRARY})
+set(OpenCL_INCLUDE_DIRS ${OpenCL_INCLUDE_DIR})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  OpenCL
+  FOUND_VAR OpenCL_FOUND
+  REQUIRED_VARS OpenCL_LIBRARY OpenCL_INCLUDE_DIR
+  VERSION_VAR OpenCL_VERSION_STRING)
+
+mark_as_advanced(
+  OpenCL_INCLUDE_DIR
+  OpenCL_LIBRARY)
+
+if(OpenCL_FOUND AND NOT TARGET OpenCL::OpenCL)
+  if(OpenCL_LIBRARY MATCHES "/([^/]+)\\.framework$")
+    add_library(OpenCL::OpenCL INTERFACE IMPORTED)
+    set_target_properties(OpenCL::OpenCL PROPERTIES
+      INTERFACE_LINK_LIBRARIES "${OpenCL_LIBRARY}")
+  else()
+    add_library(OpenCL::OpenCL UNKNOWN IMPORTED)
+    set_target_properties(OpenCL::OpenCL PROPERTIES
+      IMPORTED_LOCATION "${OpenCL_LIBRARY}")
+  endif()
+  set_target_properties(OpenCL::OpenCL PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${OpenCL_INCLUDE_DIRS}")
+endif()

--- a/cmake/modules/GlowTestSupport.cmake
+++ b/cmake/modules/GlowTestSupport.cmake
@@ -26,8 +26,10 @@ function(add_glow_test)
 
   list(GET ARG_COMMAND 0 TEST_EXEC)
   list(APPEND ARG_DEPENDS ${TEST_EXEC})
-  
+
   set_property(GLOBAL APPEND PROPERTY GLOW_TEST_DEPENDS ${ARG_DEPENDS})
+
+  set_property(GLOBAL APPEND PROPERTY GLOW_TEST_NAME_DEPENDS ${ARG_NAME})
 
   # Produce the specific test rule using the default built-in.
   add_test(NAME ${ARG_NAME} COMMAND ${ARG_COMMAND})

--- a/lib/Backends/CPU/CMakeLists.txt
+++ b/lib/Backends/CPU/CMakeLists.txt
@@ -9,34 +9,30 @@ find_program(LLVM_LINK_BIN
                llvm-link-6.0
                llvm-link)
 
-add_library(CPURuntime
-            SHARED
-              libjit/libjit.cpp
-              libjit/libjit_conv.cpp
-              libjit/libjit_matmul.cpp)
-set_target_properties(CPURuntime
-                      PROPERTIES
-                        CXX_STANDARD 11)
-target_compile_options(CPURuntime
-                       PRIVATE
-                         -ffast-math
-                         -g0
-                         -emit-llvm
-                         -O0)
+set(CPURunttimeCompileOptions -ffast-math -g0 -emit-llvm -O0)
+set (CPURuntime_OBJS
+  ${CMAKE_CURRENT_BINARY_DIR}/CPURuntime/libjit.bc.o
+  ${CMAKE_CURRENT_BINARY_DIR}/CPURuntime/libjit_conv.bc.o
+  ${CMAKE_CURRENT_BINARY_DIR}/CPURuntime/libjit_matmul.bc.o
+)
+
 # NOTE(abdulras) explicitly override the compiler and linker invocations with
-# custom rules.  The trailing `#` is the comment leader intended to nullify the
-# compile and link commands.  Doing this allows us to override the compiler
-# (driver) and the linker used for building the runtime which requires clang (to
-# emit LLVM IR for the LTO'ed AOT JIT runtime) and uses the `llvm-link` as the
-# linker to merge the object files.
-set_target_properties(CPURuntime
-                      PROPERTIES
-                        RULE_LAUNCH_COMPILE
-                          "${CLANG_BIN} <DEFINES> <INCLUDES> <FLAGS> -o <OBJECT> -c <SOURCE> # "
-                        RULE_LAUNCH_LINK
-                          "${LLVM_LINK_BIN} -o ${CMAKE_BINARY_DIR}/libjit.bc <OBJECTS> # "
-                        OUTPUT_NAME
-                          libjit.bc)
+# custom rules.
+add_custom_command(
+  OUTPUT ${CPURuntime_OBJS}
+  COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}/CPURuntime
+  COMMAND ${CLANG_BIN} -c libjit/libjit.cpp ${CPURunttimeCompileOptions} -o ${CMAKE_CURRENT_BINARY_DIR}/CPURuntime/libjit.bc.o
+  COMMAND ${CLANG_BIN} -c libjit/libjit_conv.cpp ${CPURunttimeCompileOptions} -o ${CMAKE_CURRENT_BINARY_DIR}/CPURuntime/libjit_conv.bc.o
+  COMMAND ${CLANG_BIN} -c libjit/libjit_matmul.cpp ${CPURunttimeCompileOptions} -o ${CMAKE_CURRENT_BINARY_DIR}/CPURuntime/libjit_matmul.bc.o
+  DEPENDS libjit/libjit.cpp libjit/libjit_conv.cpp libjit/libjit_matmul.cpp
+  WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}"
+)
+
+add_custom_target(CPURuntime
+  COMMAND ${LLVM_LINK_BIN} -o ${GLOW_BINARY_DIR}/libjit.bc ${CPURuntime_OBJS}
+  DEPENDS ${CPURuntime_OBJS}
+  WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}"
+)
 
 add_library(CPURuntimeNative
               libjit/libjit.cpp
@@ -78,6 +74,7 @@ target_link_libraries(CPUBackend
                         ${LLVM_TARGET_LIBRARIES}
                         LLVMCore
                         LLVMExecutionEngine
+                        LLVMOrcJIT
                         LLVMInterpreter
                         LLVMSupport
                         LLVMPasses)

--- a/lib/Onnxifi/CMakeLists.txt
+++ b/lib/Onnxifi/CMakeLists.txt
@@ -9,3 +9,8 @@ target_link_libraries(onnxifi-glow
                       PUBLIC
                         ExecutionEngine
                         Importer)
+
+target_compile_definitions(onnxifi-glow
+  PRIVATE
+  ONNXIFI_BUILD_LIBRARY
+)

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -215,7 +215,7 @@ target_link_libraries(caffe2ImporterTest
                         testMain)
 add_glow_test(NAME caffe2ImporterTest 
               COMMAND ${GLOW_BINARY_DIR}/tests/caffe2ImporterTest
-              WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+              WORKING_DIRECTORY ${GLOW_BINARY_DIR})
 
 add_executable(onnxImporterTest
                onnxImporterTest.cpp)
@@ -228,7 +228,7 @@ target_link_libraries(onnxImporterTest
 			testMain)
 add_glow_test(NAME onnxImporterTest
               COMMAND ${GLOW_BINARY_DIR}/tests/onnxImporterTest
-              WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+              WORKING_DIRECTORY ${GLOW_BINARY_DIR})
 
 LIST(APPEND UNOPT_TESTS
        ./tests/backendTest -optimize-ir=false &&
@@ -240,5 +240,5 @@ LIST(APPEND UNOPT_TESTS
        ./tests/graphGradTest -optimize-ir=false)
 
 add_custom_target(test_unopt ${UNOPT_TESTS}
-                  WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+                  WORKING_DIRECTORY ${GLOW_BINARY_DIR})
 


### PR DESCRIPTION
Compiling bit code on Win32 properly.

ONNXIFI_BUILD_LIBRARY are exported for Win32.