### PR TITLE
[msvc] define ssize_t for MSVC.

### DIFF
--- a/lib/Backends/CPU/libjit/libjit_defs.h
+++ b/lib/Backends/CPU/libjit/libjit_defs.h
@@ -19,6 +19,11 @@
 #include <stdint.h>
 #include <string.h>
 
+#if defined(_MSC_VER)
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
 typedef float float4 __attribute__((ext_vector_type(4)));
 typedef float float8 __attribute__((ext_vector_type(8)));
 


### PR DESCRIPTION
Refer to https://stackoverflow.com/questions/22265610/why-ssize-t-in-visual-studio-2010-is-defined-as-unsigned