### PR TITLE
[opencl] Define a type cl_host_size_t exactly matching the type size_t used on the host side

### DIFF
--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -82,6 +82,19 @@ static void dumpCompileLog(cl_device_id dev, cl_program prog) {
 #endif
 }
 
+/// Add an macro definition with an integer value to the set of options.
+template <typename T>
+static void addIntOption(std::vector<std::string> &options,
+                         const std::string &name, const T value) {
+  options.push_back("-D" + name + "=" + std::to_string(value));
+}
+
+/// Add an macro definition with a string value to the set of options.
+static void addStringOption(std::vector<std::string> &options,
+                            const std::string &name, const std::string &value) {
+  options.push_back("-D" + name + "=" + value);
+}
+
 OpenCLFunction::OpenCLFunction(std::unique_ptr<IRFunction> F)
     : F_(std::move(F)) {
   cl_uint num{0};
@@ -100,8 +113,15 @@ OpenCLFunction::OpenCLFunction(std::unique_ptr<IRFunction> F)
   GLOW_ASSERT(commands_ && "clCreateCommandQueue Failed.");
 
   err = CL_SUCCESS;
-  /// Create the program from the source.
-  createProgram(SHADER_CODE, {}, commands_);
+  std::vector<std::string> options;
+  // Configure the kernels by providing the size of size_t on the host size.
+  // This is required to e.g. properly pass struct parameters of types like
+  // ShapeNHWC, ShapeNCHW, etc. The definitions of these types on the host side
+  // use size_t for their members and they should be defined on the OpenCL's
+  // side using integer types of the same width.
+  addIntOption(options, "SIZEOF_HOST_SIZE_T", sizeof(size_t));
+  // Create the program from the source.
+  createProgram(SHADER_CODE, options, commands_);
   allocateMemory();
 }
 
@@ -372,19 +392,6 @@ static void dumpProfileInfo(const std::vector<KernelLaunch> &kernelLaunches) {
                            k.first / 1000000.0,
                            (unsigned long)(k.first * 100 / total));
   }
-}
-
-/// Add an macro definition with an integer value to the set of options.
-template <typename T>
-static void addIntOption(std::vector<std::string> &options,
-                         const std::string &name, const T value) {
-  options.push_back("-D" + name + "=" + std::to_string(value));
-}
-
-/// Add an macro definition with a string value to the set of options.
-static void addStringOption(std::vector<std::string> &options,
-                            const std::string &name, const std::string &value) {
-  options.push_back("-D" + name + "=" + value);
 }
 
 void OpenCLFunction::executeConvolution(const OCLConvolutionInst *CC) {

--- a/lib/Backends/OpenCL/kernels.cl
+++ b/lib/Backends/OpenCL/kernels.cl
@@ -10,25 +10,38 @@ typedef int cl_int32_t;
 typedef char cl_int8_t;
 typedef unsigned char cl_uint8_t;
 
+/// Define a type cl_host_size_t exactly matching the type size_t used on the
+/// host size. This is required to e.g. properly pass struct parameters of
+/// types like ShapeNHWC, ShapeNCHW, etc. The definitions of these types on the
+/// host side use size_t for their members and they should be defined on the
+/// OpenCL's side using integer types of the same width.
+#if SIZEOF_HOST_SIZE_T == 8
+typedef cl_uint64_t cl_host_size_t;
+#elif SIZEOF_HOST_SIZE_T == 4
+typedef cl_uint32_t cl_host_size_t;
+#else
+#error "Unsupported size of size_t on the host side"
+#endif 
+
 // The types of elements should be always matching the definitions of
 // ShapeNHWC in Type.h
 typedef struct {
-  cl_uint64_t n; // Number of samples
-  cl_uint64_t h; // Height
-  cl_uint64_t w; // Width
-  cl_uint64_t c; // Number of channels
+  cl_host_size_t n; // Number of samples
+  cl_host_size_t h; // Height
+  cl_host_size_t w; // Width
+  cl_host_size_t c; // Number of channels
 } ShapeNHWC;
 
 typedef struct {
-  cl_uint64_t n; // Number of samples
-  cl_uint64_t c; // Number of channels
-  cl_uint64_t h; // Height
-  cl_uint64_t w; // Width
+  cl_host_size_t n; // Number of samples
+  cl_host_size_t c; // Number of channels
+  cl_host_size_t h; // Height
+  cl_host_size_t w; // Width
 } ShapeNCHW;
 
 typedef struct {
-  cl_uint64_t height;
-  cl_uint64_t width;
+  cl_host_size_t height;
+  cl_host_size_t width;
 } ShapeHW;
 
 // Helper struct that contains the information for quantization.
@@ -42,10 +55,10 @@ typedef struct {
 // The types of elements should be always matching the definitions of
 // PaddingTLBR in Type.h
 typedef struct {
-  cl_uint64_t top;
-  cl_uint64_t left;
-  cl_uint64_t bottom;
-  cl_uint64_t right;
+  cl_host_size_t top;
+  cl_host_size_t left;
+  cl_host_size_t bottom;
+  cl_host_size_t right;
 } PaddingTLBR;
 
 #if defined(cl_khr_int32_base_atomics)


### PR DESCRIPTION
This is required to e.g. properly pass struct parameters of types like ShapeNHWC, ShapeNCHW, etc. The definitions of these types on the host side use size_t for their members and they should be defined on the OpenCL's side using integer types of the same width.

Since the size of size_t on the host side is not guaranteed to be of a fixed-width known to OpenCL, it has to be provided to OpenCL dynamically. Thus, the size is passed down to the OpenCL code as a macro definition. This macro definition is then used to define in OpenCL the type cl_host_size_t matching the size_t on the host side.