### PR TITLE
[OpenCL] Fix bug in dispatching Div kernel.

### DIFF
--- a/lib/Backends/OpenCL/kernels.cl
+++ b/lib/Backends/OpenCL/kernels.cl
@@ -318,13 +318,12 @@ __kernel void dequantizeW(__global void *mem, cl_uint32_t dest, cl_uint32_t src,
   __kernel void name##_i8K(__global cl_int8_t *dest, __global cl_int8_t *lhs,  \
                            __global cl_int8_t *rhs, cl_int32_t destOffset,     \
                            cl_int32_t lhsOffset, cl_int32_t rhsOffset,         \
-                           cl_int32_t mulPre, cl_int32_t mulPost,              \
-                           cl_int32_t mulScale) {                              \
+                           cl_int32_t pre, cl_int32_t post, cl_int32_t scale) {\
     size_t i = get_global_id(0);                                               \
     cl_int32_t LHS = lhs[i] - lhsOffset;                                       \
     cl_int32_t RHS = rhs[i] - rhsOffset;                                       \
     dest[i] =                                                                  \
-        clip(scale_i32i8((body), mulPre, mulPost, mulScale, destOffset));      \
+        clip(scale_i32i8((body), pre, post, scale, destOffset));               \
   }                                                                            \
   __kernel void name##_i8W(                                                    \
       __global void *mem, cl_uint32_t dest, cl_uint32_t lhs, cl_uint32_t rhs,  \

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -1568,7 +1568,7 @@ TEST_P(Operator, QuantizedTranspose) {
 }
 
 TEST_P(Operator, QuantizedArithmeticUnrescaled) {
-  const size_t len = 100;
+  const size_t len = 1000;
 
   // In this test we check the correctness of the quantized Max, Min, Add, Sub,
   // Mul, and Div operations.
@@ -3194,9 +3194,9 @@ TEST_P(InterpAndCPU, SigmoidCrossEntropyWithLogits) {
   auto *result = mod_.createVariable(ElemKind::FloatTy, {2, 2}, "result");
 
   logits->getPayload().getHandle() = {1.0f,  1.2f, -0.5f, 0.1f, 0.6f, 0.5f,
-                                      -0.1f, -2.f, 0.3f,  1.f,   2.f,   3.f};
+                                      -0.1f, -2.f, 0.3f,  1.f,  2.f,  3.f};
   targets->getPayload().getHandle() = {0.7f, 0.7f, 0.7f, -0.7f, -0.99f, 1.0f,
-                                       0.f,   0.f,   0.f,   1.f,    2.f,     3.f};
+                                       0.f,  0.f,  0.f,  1.f,   2.f,    3.f};
 
   auto *R = F_->createSigmoidCrossEntropyWithLogits("SCEL", logits, targets);
 


### PR DESCRIPTION
Mul and Div ops have different formulas for computing resulting scale. So dispatching code must have some branching, like LLVMIRGen has.

Now I'm wondering why you didn't see discrepancy on Mac, given that it was a bug in `OpenCL.cpp`, happening before any OpenCL dispatching. Is it possible that random init in unit test is platform dependent?

Also increasing number of test runs in the test.

Fixes #1548 
