### PR TITLE
[Loader] Changes to support ONNX graphs generated from tensorflow in NHWC format

### DIFF
--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -319,11 +319,8 @@ protected:
     addNodeAsOutput(op, node);
   }
 
-  void loadDropout(const OpType &op, ArgumentDictionaryTy &dict) {
+  void loadIdentity(const OpType &op, ArgumentDictionaryTy &dict) {
     auto in = getNodeValueOrCreateVariableByName(op.input(0));
-    // Save the identity operation. Note the second output (mask) for Dropout in
-    // Caffe2 and ONNX is unused during inference, and our Dropout does not
-    // currently implement it, thus we do not call addNodeAsOutput() here.
     nodeValueByName_[op.output(0)] = NodeValue(in, 0);
   }
 
@@ -437,7 +434,14 @@ protected:
       return true;
     }
     if (typeName == "Dropout") {
-      loadDropout(op, dict);
+      // Save the identity operation. Note the second output (mask) for Dropout
+      // in Caffe2 and ONNX is unused during inference, and our Dropout does not
+      // currently implement it, thus we do not call addNodeAsOutput() here.
+      loadIdentity(op, dict);
+      return true;
+    }
+    if (typeName == "Identity") {
+      loadIdentity(op, dict);
       return true;
     }
     if (typeName == "TopK") {

--- a/lib/Importer/ONNX.cpp
+++ b/lib/Importer/ONNX.cpp
@@ -443,6 +443,15 @@ bool ONNXModelLoader::loadOperator(const ONNX_NAMESPACE::NodeProto &op) {
     return true;
   }
 
+  if (typeName == "MatMul") {
+    auto LHS = getNodeValueOrCreateVariableByName(op.input(0));
+    auto RHS = getNodeValueOrCreateVariableByName(op.input(1));
+
+    Node *node = G_.createMatMul(opName, LHS, RHS);
+    addNodeAsOutput(op, node);
+    return true;
+  }
+
   return false;
 }
 


### PR DESCRIPTION
*Description*:
GLOW compiler supports caffe2 and ONNX models in NCHW format. Using tf2onnx, ONNX graphs can be generated from tensorflow checkpoints. The input to the graph in this case is in the NHWC format.  The ONNX graphs generated from tensorflow models also have some operators like tf.Identity and tf.MatMul that is not currently supported by the GLOW compiler ONNX code. The pull request is for the changes to support this additional feature for googlenet_v1_slim.onnx and google_v4_slim.onnx generated from tensorflow pretrained models. 

*Testing*: Ran tests/images/run.sh, ran ninja test, all tests passed with "-DGLOW_WITH_OPENCL=OFF -DGLOW_WITH_CPU=OFF

*Documentation*: tf2onnx tool - https://github.com/onnx/tensorflow-onnx/tree/master/tf2onnx
Pretrained googlenet models - https://github.com/tensorflow/models/tree/master/research/slim#pre-trained-models
