### PR TITLE
[cleanup] Fix compilation warning and clag-format code base.

### DIFF
--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -360,11 +360,7 @@ struct Type final {
   /// \return the textual name of the element \p Ty.
   static llvm::StringRef getElementName(ElemKind Ty) {
     static const char *names[] = {
-        "float",
-        "i8",
-        "i16",
-        "i32",
-        "index",
+        "float", "i8", "i16", "i32", "index",
     };
     return names[(int)Ty];
   }

--- a/include/glow/Support/Compiler.h
+++ b/include/glow/Support/Compiler.h
@@ -34,7 +34,7 @@
 #ifdef _WIN32
 #define glow_aligned_malloc(p, a, s)                                           \
   (((*(p)) = _aligned_malloc((s), (a))), *(p) ? 0 : errno)
-#define glow_aligned_free(p)_aligned_free(p)
+#define glow_aligned_free(p) _aligned_free(p)
 #else
 #define glow_aligned_malloc(p, a, s) posix_memalign(p, a, s)
 #define glow_aligned_free(p) free(p)

--- a/lib/CodeGen/MemoryAllocator.cpp
+++ b/lib/CodeGen/MemoryAllocator.cpp
@@ -111,6 +111,7 @@ void MemoryAllocator::evictFirstFit(uint64_t size,
     for (auto &candidate : evictionCandidates) {
       auto &curHandle = candidate.second;
       auto &segment = candidate.first;
+      (void)segment;
       DEBUG_GLOW(llvm::dbgs() << "Evict a buffer from the '" << name_ << "': "
                               << "address: " << segment.begin_
                               << " size: " << segment.size() << "\n");

--- a/lib/Onnxifi/onnxifiGlow.cpp
+++ b/lib/Onnxifi/onnxifiGlow.cpp
@@ -156,7 +156,7 @@ onnxGetBackendCompatibility(onnxBackendID backendID, size_t onnxModelSize,
 
   // Make sure that the backend itself is capable of executing
   // the operation.
-  for(const auto &op : operations) {
+  for (const auto &op : operations) {
     if (!glowBackendId->isOpSupported(op.first, op.second)) {
       return ONNXIFI_STATUS_UNSUPPORTED_OPERATOR;
     }

--- a/tests/unittests/HyphenTest.cpp
+++ b/tests/unittests/HyphenTest.cpp
@@ -31,8 +31,8 @@
 
 #include "gtest/gtest.h"
 
-#include <string>
 #include <cctype>
+#include <string>
 
 using namespace glow;
 using llvm::cast;


### PR DESCRIPTION
*Description*:
* run clang-format on the code base.
* fix unused var warning

*Testing*:
existing unit tests
