### PR TITLE
Fix the CollectHeaders custom target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ include_directories(BEFORE
 include_directories(${GLOW_BINARY_DIR})
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
-file(GLOB_RECURSE header_files include/*.h tools/*.h src/*.h)
+file(GLOB_RECURSE header_files include/*.h tools/*.h lib/*.h)
 add_custom_target(CollectHeaders SOURCES ${header_files})
 
 find_package(PNG)


### PR DESCRIPTION
Fix the `CollectHeaders` rule by replacing `src` (that doesn't exists) by `lib`.