### PR TITLE
Added the minimum needed to make the CPU backend inheritable

### DIFF
--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -47,7 +47,8 @@ namespace {
 /// propagate them into relative addressing computations and the like and
 /// produce a very efficient code that uses absolute addressing whenever
 /// possible.
-static void emitJitMain(AllocationsInfo &allocationsInfo, LLVMIRGen &irgen) {
+static void emitJitMain(LLVMIRGen &irgen) {
+  AllocationsInfo &allocationsInfo = irgen.getAllocationsInfo();
   llvm::Type *voidTy = llvm::Type::getVoidTy(irgen.getLLVMContext());
   llvm::FunctionType *jitFuncTy = llvm::FunctionType::get(voidTy, {}, false);
   auto *func =
@@ -114,22 +115,29 @@ static void *allocateJITMemory(const IRFunction *F,
 
 } // end namespace
 
+std::unique_ptr<LLVMIRGen>
+CPUBackend::createIRGen(IRFunction *IR,
+                        AllocationsInfo &allocationsInfo) const {
+  LLVMIRGen *irgen = new LLVMIRGen(IR, allocationsInfo, "");
+  return std::unique_ptr<LLVMIRGen>(irgen);
+}
+
 std::unique_ptr<CompiledFunction>
 CPUBackend::compile(std::unique_ptr<IRFunction> IR) const {
   AllocationsInfo allocationsInfo;
-  LLVMIRGen irgen(IR.get(), allocationsInfo, "");
-  irgen.initTargetMachine(target.empty() ? "" : target.getValue(),
-                          llvm::CodeModel::Model::Large);
-  irgen.initCodeGen();
+  std::unique_ptr<LLVMIRGen> irgen = createIRGen(IR.get(), allocationsInfo);
+  irgen->initTargetMachine(target.empty() ? "" : target.getValue(),
+                           llvm::CodeModel::Model::Large);
+  irgen->initCodeGen();
   // Perform the address assignment for activations and WeightVars.
-  auto heap = allocateJITMemory(IR.get(), allocationsInfo);
+  auto heap = allocateJITMemory(IR.get(), irgen->getAllocationsInfo());
   // Create the jitmain function to be invoked by JIT.
-  emitJitMain(allocationsInfo, irgen);
+  emitJitMain(*irgen);
   // Emit the code for the body of the entry function.
-  irgen.performCodeGen();
+  irgen->performCodeGen();
   // Hand over the module to JIT for the machine code generation.
-  auto JIT = llvm::make_unique<llvm::orc::GlowJIT>(irgen.getTargetMachine());
-  JIT->addModule(irgen.borrowModule());
+  auto JIT = llvm::make_unique<llvm::orc::GlowJIT>(irgen->getTargetMachine());
+  JIT->addModule(irgen->borrowModule());
   return llvm::make_unique<CPUFunction>(std::move(JIT), heap);
 }
 

--- a/lib/Backends/CPU/CPUBackend.h
+++ b/lib/Backends/CPU/CPUBackend.h
@@ -16,6 +16,8 @@
 #ifndef GLOW_BACKENDS_CPU_CPUBACKEND_H
 #define GLOW_BACKENDS_CPU_CPUBACKEND_H
 
+#include "AllocationsInfo.h"
+#include "LLVMIRGen.h"
 #include "glow/Backends/Backend.h"
 #include "glow/Base/Tensor.h"
 
@@ -30,7 +32,7 @@ namespace glow {
 llvm::CallInst *createCall(llvm::IRBuilder<> &builder, llvm::Function *callee,
                            llvm::ArrayRef<llvm::Value *> args);
 
-class CPUBackend final : public Backend {
+class CPUBackend : public Backend {
 public:
   /// Ctor.
   CPUBackend() = default;
@@ -52,6 +54,13 @@ public:
 
   bool shouldLower(const Node *N) const override;
   /// @}
+
+protected:
+  /// Method that creates the LLVM IR generator. This gives the possibility to
+  /// create a backend that inherits from the CPU backend, while providing
+  /// a specific version of the LLVM IR generator derived from LLVMIRGen.
+  virtual std::unique_ptr<LLVMIRGen>
+  createIRGen(IRFunction *IR, AllocationsInfo &allocationsInfo) const;
 };
 
 } // namespace glow

--- a/lib/Backends/CPU/LLVMIRGen.h
+++ b/lib/Backends/CPU/LLVMIRGen.h
@@ -80,6 +80,7 @@ struct DebugInfo {
 /// This is a class containing a common logic for the generation of the LLVM IR
 /// from an IRFunction. The primary clients of this class are JITs and bundlers.
 class LLVMIRGen {
+protected:
   /// The IR to generate code for.
   const IRFunction *F_;
   /// The LLVM context.
@@ -199,6 +200,8 @@ class LLVMIRGen {
   void emitDebugGlobalVariableForValue(const Value *val);
 
 public:
+  /// Destructor
+  virtual ~LLVMIRGen() {}
   /// Ctor.
   explicit LLVMIRGen(const IRFunction *M, AllocationsInfo &allocationsInfo,
                      std::string mainEntryName);
@@ -207,8 +210,8 @@ public:
   void initTargetMachine(llvm::StringRef T, llvm::CodeModel::Model CM);
 
   /// Emit LLVM-IR for the instruction \p I, using the builder \p builder.
-  void generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
-                              const glow::Instruction *I);
+  virtual void generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
+                                      const glow::Instruction *I);
   /// Emit LLVM-IR for the whole IRFunction.
   void generateLLVMIRForModule(llvm::IRBuilder<> &builder);
   /// \returns a libjit API function by name.


### PR DESCRIPTION
The CPU backend contains all the LLVM IR generation logic and we found very useful to have the possibility to create a backend derived from the CPU backend by simply enabling these 3 possibilities:
- add the possibility to inherit from `CPUBackend`
- add the possibility to call `CPUBackend::compile()` with an object derived from `LLVMIRGen`
- make `LLVMIRGen::generateLLVMIRForInstr` virtual
