### PR TITLE
[onnxifi] Prefer to rely on the CPU backend, but if it's not available fallback to the Interpreter.

### DIFF
--- a/lib/Onnxifi/Base.h
+++ b/lib/Onnxifi/Base.h
@@ -34,7 +34,10 @@ namespace onnxifi {
 /// BackendId associated with the Glow backend.
 class BackendId {
 public:
-  explicit BackendId(int id) : id_(id) {}
+  /// Create Glow ONNXIFI backend identifier with the
+  /// given Glow backend \p kind and \p id.
+  explicit BackendId(glow::BackendKind kind, int id)
+      : id_(id), executionEngine_(kind) {}
 
   /// Verify that given operation kind is supported by the backend.
   bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy);
@@ -44,8 +47,7 @@ public:
 
 private:
   int id_;
-  // By default use the Interpreter backend.
-  glow::ExecutionEngine executionEngine_{glow::BackendKind::Interpreter};
+  glow::ExecutionEngine executionEngine_;
 };
 
 typedef BackendId *BackendIdPtr;

--- a/lib/Onnxifi/onnxifiGlow.cpp
+++ b/lib/Onnxifi/onnxifiGlow.cpp
@@ -50,7 +50,12 @@ onnxGetBackendIDs(onnxBackendID *backendIDs, size_t *numBackends) {
 
   // Glow represents a single backend.
   *numBackends = 1;
-  backendIDs[0] = new glow::onnxifi::BackendId(1);
+#ifdef GLOW_WITH_CPU
+  backendIDs[0] = new glow::onnxifi::BackendId(glow::BackendKind::CPU, 1);
+#else
+  backendIDs[0] =
+      new glow::onnxifi::BackendId(glow::BackendKind::Interpreter, 1);
+#endif
 
   return ONNXIFI_STATUS_SUCCESS;
 }


### PR DESCRIPTION
*Description*:
Previously ONNXIFI was running on Interpreter backend only. The execution time is pretty slow and especially for the debug builds it's painful.
This PR allows running ONNXIFI on CPU backend if Glow is compiled with CPU support.
Note, make sure that env var GLOW_LIBJIT_PATH is set correctly to point to the libjit.bc when running integration test, e.g., export GLOW_LIBJIT_PATH=/Users/rdzhabarov/src/release_build/libjit.bc.

*Testing*:
Manual integration test for C2->Glow with Resnet-50.
```
rdzhabarov-mbp:onnx rdzhabarov$ pytest -s test_onnxifi.py 
======================================================================================== test session starts =========================================================================================
platform darwin -- Python 2.7.14, pytest-3.7.1, py-1.5.4, pluggy-0.7.1
rootdir: /Users/rdzhabarov/src/pytorch, inifile:
plugins: hypothesis-3.66.23
collecting 0 items                                                                                                                                                                                   WARNING:root:This caffe2 python run does not have GPU support. Will run in CPU only mode.
collected 3 items                                                                                                                                                                                    

test_onnxifi.py ssBatch size: 1, repeat inference 1 times
WARNING: Logging before InitGoogleLogging() is written to STDERR
W0829 11:22:36.140358 2420155264 init.h:99] Caffe2 GlobalInit should be run before any other API calls.
W0829 11:22:36.140715 2420155264 init.h:99] Caffe2 GlobalInit should be run before any other API calls.
I0829 11:22:38.347115 2420155264 onnxifi_transformer.cc:300] Adding input hint: real_data_0
I0829 11:22:38.352813 2420155264 onnxifi_transformer.cc:335] Cannot export c2 op Copy to onnx as there is no corresponding ONNX schema.
I0829 11:22:38.356204 2420155264 onnxifi_transformer.cc:335] Cannot export c2 op Copy to onnx as there is no corresponding ONNX schema.
I0829 11:22:38.356222 2420155264 onnxifi_transformer.cc:335] Cannot export c2 op Copy to onnx as there is no corresponding ONNX schema.
C2 runtime: 0.395581007004s
Conversion time: 8.11s
Onnxifi runtime: 0.15428185463s, improvement: 60.9986698305%
```

cc: @yinghai @Maratyszcza 