### PR TITLE
[GraphOptimizer] Remove useless assignment from DCE

### DIFF
--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -70,9 +70,8 @@ static void DCE(Function *F) {
 
   // Remove unused nodes. Do not remove unused vars because they are the
   // interface to the user program.
-  bool changedLocally = true;
-  do {
-    changedLocally = false;
+  while (true) {
+    bool changedLocally = false;
     for (auto it = nodes.begin(), e = nodes.end(); it != e;) {
       if (!shouldDeleteNode(&*it)) {
         ++it;
@@ -90,7 +89,10 @@ static void DCE(Function *F) {
       erasedNodes.pop_back();
     }
 
-  } while (changedLocally);
+    if (!changedLocally) {
+      break;
+    }
+  }
 
   // Delete unused variables.
   for (auto it = vars.begin(), e = vars.end(); it != e;) {


### PR DESCRIPTION
*Description*:
Another assignment of this boolean is done first thing at the beginning
of the next do;while loop.
This useless assignment triggers annoying warnings in our internal flow.

NFC.

*Testing*:
ninja check
