### PR TITLE
[Quantization] Support quantizing BatchedReduceAdd and MatMul from profile

### DIFF
--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -336,6 +336,30 @@ static Node *quantizeNode(Function *F, Node *node,
                                      SMN->getSelected(), outTy);
     break;
   }
+  case Kinded::Kind::BatchedReduceAddNodeKind: {
+    auto *BRAN = cast<BatchedReduceAddNode>(node);
+    assert(quantizedInputs.size() == 1 && "Invalid number of inputs");
+    assert(qParams.size() == 1 && "Invalid number of quantized outputs");
+
+    auto outTy =
+        F->getParent()->uniqueType(ElemKind::Int8QTy, BRAN->getResult().dims(),
+                                   qParams[0].scale, qParams[0].offset);
+    quantizedNode = F->createBatchedReduceAdd(
+        BRAN->getName(), outTy, quantizedInputs[0], BRAN->getAxis());
+    break;
+  }
+  case Kinded::Kind::MatMulNodeKind: {
+    auto *MMN = cast<MatMulNode>(node);
+    assert(quantizedInputs.size() == 2 && "Invalid number of inputs");
+    assert(qParams.size() == 1 && "Invalid number of quantized outputs");
+
+    auto outTy =
+        F->getParent()->uniqueType(ElemKind::Int8QTy, MMN->getResult().dims(),
+                                   qParams[0].scale, qParams[0].offset);
+    quantizedNode = F->createMatMul(MMN->getName(), outTy, quantizedInputs[0],
+                                    quantizedInputs[1]);
+    break;
+  }
   default:
     GLOW_UNREACHABLE("The node type is not supported for quantization");
   }

--- a/tests/unittests/quantizationTest.cpp
+++ b/tests/unittests/quantizationTest.cpp
@@ -219,7 +219,10 @@ static Function *createSimpleGraphForQuantization(Module *M, Variable *A,
   auto *CN = F->createConcat("concat", {S, B}, 0);
   auto *SP = F->createSplat("splat", B->getType(), 10.0);
   auto *O = F->createConcat("concat", {CN, SP}, 0);
-  F->createSave("save", O);
+  auto *TN = F->createTranspose("transpose", O, {1, 0});
+  auto *MMN = F->createMatMul("batchedreduceadd", O, TN);
+  auto *BRAN = F->createBatchedReduceAdd("batchedreduceadd", MMN, 0);
+  F->createSave("save", BRAN);
   return F;
 }
 


### PR DESCRIPTION
*Description*: Add missing quantization support from a profile for BatchedReduceAdd and MatMul

*Testing*: Added nodes to quantizationTest's end2end test

*Documentation*: N/A

