### PR TITLE
Add option to disable quantizing specified node kinds

### DIFF
--- a/docs/Quantization.md
+++ b/docs/Quantization.md
@@ -102,6 +102,19 @@ the graph.
 ./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to1 -m=resnet50 -load_profile="profile.yaml"
 ```
 
+By default, all nodes that can be quantized will be quantized. However, we may
+only want to quantize some parts of a model, e.g. if accuracy loss is too high
+when all node kinds are quantized. The Glow loader currently allows for
+disabling quantization of all nodes of a specific kind which are found in the
+graph. For example, if the loaded model sees high accuracy loss when
+element-wise Add is quantized, it can be left in floating point. This can be
+done by passing on the command line the node name via the option
+`-do_not_quantize_nodes`. Multiple node kinds can be specified to not be
+quantized. For example, to not quantize any Add or Div nodes when running the
+quantized text translator:
+
+```./bin/text-translator -m en2gr -load_profile=en2gr.yaml -do_not_quantize_nodes=Add,Div```
+
 ## Compiler Optimizations
 
 Glow features a number of compiler optimizations that transform the compute

--- a/include/glow/Base/Traits.h
+++ b/include/glow/Base/Traits.h
@@ -19,6 +19,7 @@
 #include "glow/Base/Type.h"
 
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/StringRef.h"
 
 namespace glow {
@@ -107,6 +108,8 @@ enum class VisibilityKind {
   Public,  // The variable is visible from outside the graph.
   Private, // The variable isn't visible from outside the graph.
 };
+
+using KindSet = llvm::SmallSet<Kinded::Kind, 4>;
 
 } // namespace glow
 

--- a/include/glow/Quantization/Quantization.h
+++ b/include/glow/Quantization/Quantization.h
@@ -62,13 +62,16 @@ generateNodeQuantizationInfos(const Function *F,
 /// function based on \p quantizationInfos. This method converts to integer as
 /// many nodes as permitted by the backend \p EE. The new quantized function is
 /// called \p newFuncName. If no name is given the method will generate a name.
-/// This method clones original function \p F and caller is responsible
-/// for cleaning up/erasing original function \p F if needed.
+/// This method clones original function \p F and caller is responsible for
+/// cleaning up/erasing original function \p F if needed. Any nodes of kinds
+/// contained in \p doNotQuantizeKinds will not be quantized, even if a profile
+/// was gathered for them and the backend supports the quantized operation.
 /// \returns a new quantized function.
 Function *
 quantizeFunction(const ExecutionEngine &EE,
                  llvm::ArrayRef<NodeQuantizationInfo> quantizationInfos,
-                 Function *F, llvm::StringRef newFuncName = "");
+                 Function *F, llvm::StringRef newFuncName = "",
+                 const KindSet &doNotQuantizeKinds = {});
 
 } // namespace quantization
 } // namespace glow

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -416,7 +416,8 @@ postProcessQuantizedNode(Function *F, Node *quantizedNode,
 Function *
 quantizeFunction(const ExecutionEngine &EE,
                  llvm::ArrayRef<NodeQuantizationInfo> quantizationInfos,
-                 Function *F, llvm::StringRef newFuncName) {
+                 Function *F, llvm::StringRef newFuncName,
+                 const KindSet &doNotQuantizeKinds) {
   std::string tmpName;
   if (newFuncName.empty()) {
     tmpName = std::string(F->getName()) + "_quantized";
@@ -439,6 +440,11 @@ quantizeFunction(const ExecutionEngine &EE,
   do {
     --nodeIt;
     Node *node = &*nodeIt;
+
+    // The caller may request some node kinds to not be quantized.
+    if (doNotQuantizeKinds.count(node->getKind())) {
+      continue;
+    }
 
     // Make sure that all inputs are floats and int8 operation is supported by
     // the backend. Not all backends support particular quantized operation and


### PR DESCRIPTION
*Description*: We may prefer to not quantize every node kind in a model if it causes unacceptable accuracy loss. This commit adds the ability to disable quantization for node kinds that would otherwise be quantized, preventing accuracy loss.

*Testing*: Added a unit test.

*Documentation*: Added.