### PR TITLE
[ImageClassifier] Add command line option for the model's expected input image name

### DIFF
--- a/docs/AOT.md
+++ b/docs/AOT.md
@@ -38,7 +38,7 @@ This document demonstrates how to produce a bundle for the host CPU using the
 directory.
 
 ```
-$image-classifier image.png -image_mode=0to1 -m resnet50 -cpu -emit-bundle build/
+$image-classifier image.png -image_mode=0to1 -m=resnet50 -model_input_name=gpu_0/data -cpu -emit-bundle build/
 ```
 
 The command above would compile the neural network model described by the files
@@ -163,7 +163,7 @@ The makefile provides the following targets:
 * `download_weights`: it downloads the Resnet50 network model in the Caffe2 format.
 * `build/resnet50.o`: it generates the bundle files using the Glow image-classifier as described above.
   The concrete command line looks like this:
-  `image-classifier tests/images/imagenet/cat_285.png -image_mode=0to1 -m resnet50 -cpu -emit-bundle build`
+  `image-classifier tests/images/imagenet/cat_285.png -image_mode=0to1 -m=resnet50 -model_input_name=gpu_0/data -cpu -emit-bundle build`
   It reads the network model from `resnet50` and generates the `resnet50.o`
   and `resnet50.weights` files into the `build` directory.
 * `build/main.o`:  it compiles the `resnet50_standalone.cpp` file, which is the main file of the project.
@@ -186,9 +186,8 @@ To build and run the example, you just need to execute:
 
 This run performs almost the same steps as non-quantized Resnet50 version
 except it emits bundle based on the quantization profile:
-`image-classifier tests/images/imagenet/cat_285.png -image_mode=0to1 -m resnet50
--load_profile=profile.yml -cpu -emit-bundle build`
+`image-classifier tests/images/imagenet/cat_285.png -image_mode=0to1 -m=resnet50 -model_input_name=gpu_0/data -load_profile=profile.yml -cpu -emit-bundle build`
 
 The `profile.yml` itself is captured at a prior step by executing image-classifier with the `dump_profile` option:
-`image-classifier tests/images/imagenet/*.png -image_mode=0to1 -m resnet50 -dump_profile=profile.yml`.
+`image-classifier tests/images/imagenet/*.png -image_mode=0to1 -m=resnet50 -model_input_name=gpu_0/data -dump_profile=profile.yml`.
 See the makefile for details.

--- a/docs/Quantization.md
+++ b/docs/Quantization.md
@@ -71,7 +71,7 @@ into the ```profile.yaml``` file.
 This information can be used in the process of quantized conversion.
 For example, you can run the following command to capture profile for Resnet50.
 ```
-./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to1 -m=resnet50 -dump_profile="profile.yaml"
+./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to1 -m=resnet50 -model_input_name=gpu_0/data -dump_profile="profile.yaml"
 ```
 By default, the loader will produce quantized results using asymmetric ranges.
 That is ranges not necessarily centered on 0. The loader supports three modes
@@ -99,7 +99,7 @@ the graph.
 For example, you can run the following command to load the profile and quantize
 the graph.
 ```
-./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to1 -m=resnet50 -load_profile="profile.yaml"
+./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to1 -m=resnet50 -model_input_name=gpu_0/data -load_profile="profile.yaml"
 ```
 
 ## Compiler Optimizations

--- a/tests/images/run.sh
+++ b/tests/images/run.sh
@@ -1,36 +1,36 @@
 #!/usr/bin/env bash
 
-./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to1 -m=resnet50 "$@"
-./bin/image-classifier tests/images/imagenet/*.png -image_mode=neg128to127 -m=vgg19 "$@"
-./bin/image-classifier tests/images/imagenet/*.png -image_mode=neg128to127 -m=squeezenet "$@"
-./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to256 -m=zfnet512 "$@"
-./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to1 -m=densenet121 "$@"
-./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to1 -m=shufflenet "$@"
-./bin/image-classifier tests/images/mnist/*.png -image_mode=0to1 -m=lenet_mnist "$@"
-./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to256 -m=inception_v1 "$@"
-./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to256 -m=bvlc_alexnet "$@"
+./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to1 -m=resnet50 -model_input_name=gpu_0/data "$@"
+./bin/image-classifier tests/images/imagenet/*.png -image_mode=neg128to127 -m=vgg19 -model_input_name=data "$@"
+./bin/image-classifier tests/images/imagenet/*.png -image_mode=neg128to127 -m=squeezenet -model_input_name=data "$@"
+./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to256 -m=zfnet512 -model_input_name=gpu_0/data "$@"
+./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to1 -m=densenet121 -model_input_name=data "$@"
+./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to1 -m=shufflenet -model_input_name=gpu_0/data "$@"
+./bin/image-classifier tests/images/mnist/*.png -image_mode=0to1 -m=lenet_mnist -model_input_name=data "$@"
+./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to256 -m=inception_v1 -model_input_name=data "$@"
+./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to256 -m=bvlc_alexnet -model_input_name=data "$@"
 for png_filename in tests/images/imagenet/*.png; do
-  ./bin/image-classifier "$png_filename" -image_mode=0to1 -m=resnet50/model.onnx "$@"
+  ./bin/image-classifier "$png_filename" -image_mode=0to1 -m=resnet50/model.onnx -model_input_name=gpu_0/data_0 "$@"
 done
 for png_filename in tests/images/imagenet/*.png; do
-  ./bin/image-classifier "$png_filename" -image_mode=neg128to127 -m=vgg19/model.onnx "$@"
+  ./bin/image-classifier "$png_filename" -image_mode=neg128to127 -m=vgg19/model.onnx -model_input_name=data_0 "$@"
 done
 for png_filename in tests/images/imagenet/*.png; do
-  ./bin/image-classifier "$png_filename" -image_mode=neg128to127 -m=squeezenet/model.onnx "$@"
+  ./bin/image-classifier "$png_filename" -image_mode=neg128to127 -m=squeezenet/model.onnx -model_input_name=data_0 "$@"
 done
 for png_filename in tests/images/imagenet/*.png; do
-  ./bin/image-classifier "$png_filename" -image_mode=0to256 -m=zfnet512/model.onnx "$@"
+  ./bin/image-classifier "$png_filename" -image_mode=0to256 -m=zfnet512/model.onnx -model_input_name=gpu_0/data_0 "$@"
 done
 for png_filename in tests/images/imagenet/*.png; do
-  ./bin/image-classifier "$png_filename" -image_mode=0to1 -m=densenet121/model.onnx "$@"
+  ./bin/image-classifier "$png_filename" -image_mode=0to1 -m=densenet121/model.onnx -model_input_name=data_0 "$@"
 done
-./bin/image-classifier tests/images/imagenet/zebra_340.png -image_mode=0to1 -m=shufflenet/model.onnx "$@"
+./bin/image-classifier tests/images/imagenet/zebra_340.png -image_mode=0to1 -m=shufflenet/model.onnx -model_input_name=gpu_0/data_0 "$@"
 for png_filename in tests/images/mnist/*.png; do
-  ./bin/image-classifier "$png_filename" -image_mode=0to1 -m=mnist.onnx "$@"
+  ./bin/image-classifier "$png_filename" -image_mode=0to1 -m=mnist.onnx -model_input_name=data_0 "$@"
 done
 for png_filename in tests/images/imagenet/*.png; do
-  ./bin/image-classifier "$png_filename" -image_mode=0to256 -m=inception_v1/model.onnx "$@"
+  ./bin/image-classifier "$png_filename" -image_mode=0to256 -m=inception_v1/model.onnx -model_input_name=data_0 "$@"
 done
 for png_filename in tests/images/imagenet/*.png; do
-  ./bin/image-classifier "$png_filename" -image_mode=0to256 -m=bvlc_alexnet/model.onnx "$@"
+  ./bin/image-classifier "$png_filename" -image_mode=0to256 -m=bvlc_alexnet/model.onnx -model_input_name=data_0 "$@"
 done


### PR DESCRIPTION
*Description*: Models may expect different names for the input image in ImageClassifier. We previously had a hack that allowed for two different names. This properly allows the model to have its image name specified.

*Testing*: updated and verified `run.sh` works

*Documentation*: Added.