### PR TITLE
[unittest] Since we copy all files to the BUILD dir already, set working dir there as well.

### DIFF
--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -228,7 +228,7 @@ target_link_libraries(caffe2ImporterTest
                         testMain)
 add_glow_test(NAME caffe2ImporterTest 
               COMMAND ${GLOW_BINARY_DIR}/tests/caffe2ImporterTest
-              WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+              WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
 add_executable(onnxImporterTest
                onnxImporterTest.cpp)
@@ -241,7 +241,7 @@ target_link_libraries(onnxImporterTest
                         testMain)
 add_glow_test(NAME onnxImporterTest
               COMMAND ${GLOW_BINARY_DIR}/tests/onnxImporterTest
-              WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+              WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
 LIST(APPEND UNOPT_TESTS
        ./tests/backendTest -optimize-ir=false &&


### PR DESCRIPTION
*Description*:
We copy all required files to binary directory, would be logical to point to the binary dir as working dir.

*Testing*:
ctest + individual runs of onnx/caffe2 importer tests.
