### PR TITLE
[Placeholder] Add support for Placeholders in the execution engine

### DIFF
--- a/include/glow/Backends/CompiledFunction.h
+++ b/include/glow/Backends/CompiledFunction.h
@@ -16,7 +16,12 @@
 #ifndef GLOW_BACKENDS_COMPILEDFUNCTION_H
 #define GLOW_BACKENDS_COMPILEDFUNCTION_H
 
+#include "llvm/ADT/ArrayRef.h"
+
 namespace glow {
+
+class Placeholder;
+class Tensor;
 
 /// Interface for executing a compiled function.
 class CompiledFunction {
@@ -24,8 +29,10 @@ public:
   /// Dtor.
   virtual ~CompiledFunction() = default;
 
-  /// Execute the network.
-  virtual void execute() = 0;
+  /// Execute the network. The backing tensors in \p tensors are mapped to the
+  /// placeholders of \p placeholders for the invocation of the program.
+  virtual void execute(llvm::ArrayRef<Placeholder *> placeholders,
+                       llvm::ArrayRef<Tensor *> tensors) = 0;
 };
 
 } // end namespace glow

--- a/include/glow/ExecutionEngine/ExecutionEngine.h
+++ b/include/glow/ExecutionEngine/ExecutionEngine.h
@@ -80,19 +80,19 @@ public:
 
   /// Runs a single execution of the function. This method updates the variables
   /// in \p nodes with the tensor content values \p inputs.
-  void run(llvm::ArrayRef<Variable *> vars, llvm::ArrayRef<Tensor *> inputs);
+  void run(llvm::ArrayRef<Storage *> vars, llvm::ArrayRef<Tensor *> inputs);
 
   /// Runs \p iterations iterations of the function. The method updates a local
   /// counter and future invocations of this method continue running iterations
   /// of the batch at the next available slice.
   /// The method updates the variables in \p vars with the tensors \p inputs.
-  void runBatch(size_t iterations, llvm::ArrayRef<Variable *> vars,
+  void runBatch(size_t iterations, llvm::ArrayRef<Storage *> vars,
                 llvm::ArrayRef<Tensor *> inputs);
 
 private:
   /// Update the inputs for all variables \p vars with data from the inputs \p
   /// inputs at offset \p sampleIdx. Then perform a run of the network.
-  void updateInputsAndRunNetwork(llvm::ArrayRef<Variable *> vars,
+  void updateInputsAndRunNetwork(llvm::ArrayRef<Storage *> vars,
                                  llvm::ArrayRef<Tensor *> inputs,
                                  size_t sampleIdx);
 

--- a/lib/Backends/CPU/CPUFunction.cpp
+++ b/lib/Backends/CPU/CPUFunction.cpp
@@ -26,7 +26,8 @@ CPUFunction::CPUFunction(std::unique_ptr<llvm::orc::GlowJIT> JIT, void *heap)
 
 CPUFunction::~CPUFunction() { alignedFree(heap_); }
 
-void CPUFunction::execute() {
+void CPUFunction::execute(llvm::ArrayRef<Placeholder *> placeholders,
+                          llvm::ArrayRef<Tensor *> tensors) {
   auto sym = JIT_->findSymbol("jitmain");
   assert(sym && "Unable to JIT the code!");
   using JitFuncType = void (*)(void);

--- a/lib/Backends/CPU/CPUFunction.h
+++ b/lib/Backends/CPU/CPUFunction.h
@@ -38,7 +38,8 @@ public:
   ///@{
   ~CPUFunction() override;
 
-  void execute() override;
+  void execute(llvm::ArrayRef<Placeholder *> placeholders,
+               llvm::ArrayRef<Tensor *> tensors) override;
   ///@}
 };
 

--- a/lib/Backends/Interpreter/InterpreterFunction.cpp
+++ b/lib/Backends/Interpreter/InterpreterFunction.cpp
@@ -31,10 +31,6 @@ InterpreterFunction::InterpreterFunction(std::unique_ptr<IRFunction> F)
     assert(!externalTensors_.count(w) && "The tensor is already registered");
     externalTensors_[w] = &v->getPayload();
   }
-
-  for (auto *W : F_->getWeights()) {
-    getOrCreateTensor(W);
-  }
 }
 
 InterpreterFunction::~InterpreterFunction() {
@@ -102,7 +98,15 @@ void InterpreterFunction::deleteTensor(const Value *v) {
   tensors_.erase(it);
 }
 
-void InterpreterFunction::execute() {
+void InterpreterFunction::execute(llvm::ArrayRef<Placeholder *> placeholders,
+                                  llvm::ArrayRef<Tensor *> tensors) {
+  // Register the placeholder values with the corresponding backing tensor.
+  // Note: the current implementation is not thread safe. See issue #1334.
+  for (int i = 0, e = placeholders.size(); i < e; i++) {
+    auto *w = F_->getWeightForNode(placeholders[i]);
+    externalTensors_[w] = tensors[i];
+  }
+
 // Do the forward pass.
 #define DEF_VALUE(CLASS, NAME)
 #define DEF_INSTR(CLASS, NAME)                                                 \

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -54,7 +54,8 @@ public:
   ///@{
   ~InterpreterFunction() override;
 
-  void execute() override;
+  void execute(llvm::ArrayRef<Placeholder *> placeholders,
+               llvm::ArrayRef<Tensor *> tensors) override;
   ///@}
 
 private:

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -587,7 +587,8 @@ static void topK(Tensor &outW, Tensor &indW, Tensor &inW, size_t k) {
   }
 }
 
-void OpenCLFunction::execute() {
+void OpenCLFunction::execute(llvm::ArrayRef<Placeholder *> placeholders,
+                             llvm::ArrayRef<Tensor *> tensors) {
   auto copiedToDeviceBytes = copyMutableWeightsToDevice();
   (void)copiedToDeviceBytes;
   DEBUG_GLOW(llvm::dbgs() << "Copied " << copiedToDeviceBytes

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -98,7 +98,8 @@ public:
   ///@{
   ~OpenCLFunction() override;
 
-  void execute() override;
+  void execute(llvm::ArrayRef<Placeholder *> placeholders,
+               llvm::ArrayRef<Tensor *> tensors) override;
   ///@}
 
 private:

--- a/lib/IR/GraphScheduler.cpp
+++ b/lib/IR/GraphScheduler.cpp
@@ -222,8 +222,11 @@ void IRFunction::scheduleGraph(NodesPtrList &Schedule) {
   }
   ChildMemSizeBasedScheduler CMSBScheduler(*G_, Schedule);
   CMSBScheduler.schedule();
+  auto numVars = G_->getParent()->getVars().size();
+  auto numPlaceholders = G_->getParent()->getPlaceholders().size();
+
   assert(CMSBScheduler.getSchedule().size() ==
-             G_->getNodes().size() + G_->getParent()->getVars().size() &&
+             G_->getNodes().size() + numPlaceholders + numVars &&
          "All graph nodes have to be scheduled");
 }
 

--- a/lib/IR/IRGen.cpp
+++ b/lib/IR/IRGen.cpp
@@ -79,7 +79,7 @@ public:
 
   /// \returns the generated instruction for the node \p N.
   Value *valueForNode(NodeValue N) {
-    if (auto *V = dyn_cast<Variable>(N)) {
+    if (auto *V = dyn_cast<Storage>(N)) {
       auto &map = F_->getVariableMap();
       return map[V];
     }
@@ -90,7 +90,7 @@ public:
   }
   /// Saves the generated IR in \p v for the node \p N.
   void registerIR(NodeValue N, Value *v) {
-    if (auto *V = dyn_cast<Variable>(N)) {
+    if (auto *V = dyn_cast<Storage>(N)) {
       auto &map = F_->getVariableMap();
       map[V] = v;
       return;
@@ -370,6 +370,15 @@ public:
       auto *W = builder_.createWeightVar(V->getType(), V->getName(),
                                          WeightVar::MutabilityKind::Mutable,
                                          V->getVisibilityKind());
+      W->setName(N->getName());
+      registerIR(N, W);
+      break;
+    }
+    case glow::Kinded::Kind::PlaceholderKind: {
+      auto *P = cast<Placeholder>(N);
+      auto *W = builder_.createWeightVar(P->getType(), P->getName(),
+                                         WeightVar::MutabilityKind::Mutable,
+                                         VisibilityKind::Public);
       W->setName(N->getName());
       registerIR(N, W);
       break;

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -68,7 +68,7 @@ onnxStatus Graph::initGraph(const void *onnxModel, size_t onnxModelSize,
 onnxStatus Graph::run() {
   // Copy tensors from the input addresses to the Glow tensors.
   llvm::SmallVector<Tensor *, 4> tensors;
-  llvm::SmallVector<Variable *, 4> vars;
+  llvm::SmallVector<Storage *, 4> vars;
   for (auto inputVar : inputVarToBuffer_) {
     auto *var = inputVar.first;
     auto *type = var->getType();

--- a/tests/unittests/BackendCorrectnessTest.cpp
+++ b/tests/unittests/BackendCorrectnessTest.cpp
@@ -304,7 +304,7 @@ TEST_P(CPUOnly, dataParallelStackingTest) {
   }
 
   MockCPUBackend backend;
-  backend.compile(std::move(M))->execute();
+  backend.compile(std::move(M))->execute({}, {});
   auto H = var->getHandle();
   EXPECT_EQ(H.at(0), 3);
   EXPECT_EQ(H.at(1), 4);

--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -173,6 +173,8 @@ TEST_P(BackendTest, decoupleCodegenFromGraph) {
   EXPECT_NEAR(HX.at({2}), 9, 1E-5);
 }
 
+/// Check that we can pass information to the execution engine using Placeholder
+/// variables and read it back using Save nodes (in variables).
 TEST(Placeholder, simplePlaceholderValue) {
   Tensor data{99.0, 35.0, 2.0, 3.0};
 
@@ -188,9 +190,40 @@ TEST(Placeholder, simplePlaceholderValue) {
   EE.run({input}, {&data});
 
   auto &res = S->getVariable()->getPayload();
-
-  res.getHandle().dump();
   EXPECT_TRUE(res.isEqual(data));
+}
+
+/// Check that we can pass information to the execution engine using Placeholder
+/// variables and the runBatch API.
+TEST(Placeholder, runBatchTest) {
+  // The input contains two slices of 4 floats each.
+  Tensor data(ElemKind::FloatTy, {4, 4});
+  // Fill the array with the pattern: [0 1 2 3; 10, 11, 12, 13; 20 21 22 23 ...]
+  for (size_t i = 0; i < 4; i++) {
+    for (size_t j = 0; j < 4; j++) {
+      data.getHandle().at({i, j}) = i * 10 + j;
+    }
+  }
+
+  ExecutionEngine EE{BackendKind::Interpreter};
+  auto &mod = EE.getModule();
+
+  Function *F = mod.createFunction("main");
+  auto *input = mod.createPlaceholder(ElemKind::FloatTy, {1, 4}, "input");
+  SaveNode *S = F->createSave("ret", input);
+
+  EE.compile(CompilationMode::Infer, F);
+
+  // Run the batch for 2 iterations:
+  EE.runBatch(2, {input}, {&data});
+
+  Tensor expected{10, 11, 12, 13};
+  auto EH = expected.getHandle();
+  auto RH = S->getVariable()->getPayload().getHandle();
+
+  for (size_t i = 0; i < 4; i++) {
+    EXPECT_EQ(RH.raw(i), EH.raw(i));
+  }
 }
 
 INSTANTIATE_TEST_CASE_P(Interpreter, BackendTest,

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -23,7 +23,8 @@ namespace glow {
 /// MockBackend used only for unit testing.
 class MockBackend : public Backend {
   class MockFunction : public CompiledFunction {
-    void execute() override {}
+    void execute(llvm::ArrayRef<Placeholder *> placeholders,
+                 llvm::ArrayRef<Tensor *> tensors) override {}
   };
   std::unique_ptr<CompiledFunction>
   compile(std::unique_ptr<IRFunction> IR) const override {

--- a/tests/unittests/partitionTest.cpp
+++ b/tests/unittests/partitionTest.cpp
@@ -35,7 +35,7 @@ protected:
 };
 
 /// Execute a graph of functions serially, which is the simplest approach.
-static void executeSerial(const FunctionDAG &G, llvm::ArrayRef<Variable *> vars,
+static void executeSerial(const FunctionDAG &G, llvm::ArrayRef<Storage *> vars,
                           llvm::ArrayRef<Tensor *> inputs) {
   for (auto *F : G.getFunctions()) {
     ExecutionEngine EE;

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -267,7 +267,7 @@ void Loader::compile() {
   }
 }
 
-void Loader::runInference(llvm::ArrayRef<Variable *> variables,
+void Loader::runInference(llvm::ArrayRef<Storage *> variables,
                           llvm::ArrayRef<Tensor *> tensors) {
   assert(!emittingBundle() &&
          "No inference is performed in the bundle generation mode.");

--- a/tools/loader/Loader.h
+++ b/tools/loader/Loader.h
@@ -60,7 +60,7 @@ public:
 
   /// Runs inference, unless emit bundle mode is enabled. If inference is run
   /// then it will \return true, else false.
-  void runInference(llvm::ArrayRef<Variable *> variables,
+  void runInference(llvm::ArrayRef<Storage *> variables,
                     llvm::ArrayRef<Tensor *> tensors);
 
   /// Create the Loader driver object, and parse/verify the command line


### PR DESCRIPTION
*Description*:

Implement the logic for executing Placeholders in the execution engine. This commit changes the backend interface and adds the ability to pass Placeholder variables in addition to Variables. 

This change breaks the out-of-tree backends.
    
This is the first step in adding support for placeholder variables in the execution engine. The commit adds support to the interpreter but not to the OpenCL and CPU backends. The support in the interpreter is single threaded at the moment.

In the next few PRs I'll complete the execution engine support in different backends for across all node kinds (SaveNode, for example).

*Testing*: Ran tests locally and added a new test.

*Documentation*: No functional changes to document. 

issue #1334
