### PR TITLE
Fix a warning and rename a variable.

### DIFF
--- a/lib/Backends/CPU/AllocationsInfo.cpp
+++ b/lib/Backends/CPU/AllocationsInfo.cpp
@@ -32,7 +32,7 @@ using llvm::dyn_cast;
 using llvm::isa;
 
 void AllocationsInfo::allocateWeightVars(const IRFunction *F,
-                                         bool reuseAddresses) {
+                                         bool absoluteAddr) {
   // Use two different allocators, because constant weights and mutable weights
   // may use different memory blocks.
   MemoryAllocator constantWeightVarsAllocator("ConstantWeights", 0);
@@ -47,7 +47,7 @@ void AllocationsInfo::allocateWeightVars(const IRFunction *F,
       continue;
     auto numBytes = w->getSizeInBytes();
     size_t addr = constantWeightVarsAllocator.allocate(numBytes, w);
-    if (!reuseAddresses) {
+    if (!absoluteAddr) {
       allocatedAddressed_[w] = addr;
     } else {
       // Reuse the address used by the payload.
@@ -64,7 +64,7 @@ void AllocationsInfo::allocateWeightVars(const IRFunction *F,
       continue;
     auto numBytes = w->getSizeInBytes();
     size_t addr = mutableWeightVarsAllocator.allocate(numBytes, w);
-    if (!reuseAddresses) {
+    if (!absoluteAddr) {
       allocatedAddressed_[w] = addr;
     } else {
       // Reuse the address used by the payload.

--- a/lib/Backends/CPU/AllocationsInfo.h
+++ b/lib/Backends/CPU/AllocationsInfo.h
@@ -53,11 +53,11 @@ struct AllocationsInfo {
   uint8_t *baseActivationsAddress_{nullptr};
 
   /// Assign offsets to all WeightVars of \p M.
-  /// If the \p reuseAddresses is true, simply reuse the addresses already used
+  /// If the \p absoluteAddr is true, simply reuse the addresses already used
   /// by the payloads of tensors corresponding to those WeightVars as offsets.
-  /// This is useful in a JIT setup. If \p reuseAddresses is false, then all the
+  /// This is useful in a JIT setup. If \p absoluteAddr is false, then all the
   /// WeightVars will get new offsets assigned.
-  void allocateWeightVars(const IRFunction *F, bool reuseAddresses);
+  void allocateWeightVars(const IRFunction *F, bool absoluteAddr);
   /// Assign offsets to all activations.
   /// No actual memory allocation is performed. All the allocations should be
   /// performed by the client based on the information provided by the

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -2165,6 +2165,7 @@ void Function::verify() const {
       bool foundNode =
           std::find(nodes_.begin(), nodes_.end(), *input) != nodes_.end();
       (void)foundNode;
+      (void)isGraphStorageNode;
       assert((foundNode || isGraphStorageNode(input, this)) &&
              "Every node referenced by one of the graph nodes should be part of"
              "the graph");

--- a/lib/IR/GraphScheduler.cpp
+++ b/lib/IR/GraphScheduler.cpp
@@ -224,7 +224,8 @@ void IRFunction::scheduleGraph(NodesPtrList &Schedule) {
   CMSBScheduler.schedule();
   auto numVars = G_->getParent()->getVars().size();
   auto numPlaceholders = G_->getParent()->getPlaceholders().size();
-
+  (void)numVars;
+  (void)numPlaceholders;
   assert(CMSBScheduler.getSchedule().size() ==
              G_->getNodes().size() + numPlaceholders + numVars &&
          "All graph nodes have to be scheduled");


### PR DESCRIPTION
*Description*: Two small cleanups. The first is renaming a parameter name in the CPU memory allocator. The second commit fixes a warning in release builds. 
*Testing*: Ran tests locally.
*Documentation*: None.
