### PR TITLE
 Revert: [Placeholder] Add support for Placeholders in the execution engine.

### DIFF
--- a/include/glow/Backends/CompiledFunction.h
+++ b/include/glow/Backends/CompiledFunction.h
@@ -16,12 +16,7 @@
 #ifndef GLOW_BACKENDS_COMPILEDFUNCTION_H
 #define GLOW_BACKENDS_COMPILEDFUNCTION_H
 
-#include "llvm/ADT/ArrayRef.h"
-
 namespace glow {
-
-class Placeholder;
-class Tensor;
 
 /// Interface for executing a compiled function.
 class CompiledFunction {
@@ -29,10 +24,8 @@ public:
   /// Dtor.
   virtual ~CompiledFunction() = default;
 
-  /// Execute the network. The backing tensors in \p tensors are mapped to the
-  /// placeholders of \p placeholders for the invocation of the program.
-  virtual void execute(llvm::ArrayRef<Placeholder *> placeholders,
-                       llvm::ArrayRef<Tensor *> tensors) = 0;
+  /// Execute the network.
+  virtual void execute() = 0;
 };
 
 } // end namespace glow

--- a/include/glow/ExecutionEngine/ExecutionEngine.h
+++ b/include/glow/ExecutionEngine/ExecutionEngine.h
@@ -80,19 +80,19 @@ public:
 
   /// Runs a single execution of the function. This method updates the variables
   /// in \p nodes with the tensor content values \p inputs.
-  void run(llvm::ArrayRef<Storage *> vars, llvm::ArrayRef<Tensor *> inputs);
+  void run(llvm::ArrayRef<Variable *> vars, llvm::ArrayRef<Tensor *> inputs);
 
   /// Runs \p iterations iterations of the function. The method updates a local
   /// counter and future invocations of this method continue running iterations
   /// of the batch at the next available slice.
   /// The method updates the variables in \p vars with the tensors \p inputs.
-  void runBatch(size_t iterations, llvm::ArrayRef<Storage *> vars,
+  void runBatch(size_t iterations, llvm::ArrayRef<Variable *> vars,
                 llvm::ArrayRef<Tensor *> inputs);
 
 private:
   /// Update the inputs for all variables \p vars with data from the inputs \p
   /// inputs at offset \p sampleIdx. Then perform a run of the network.
-  void updateInputsAndRunNetwork(llvm::ArrayRef<Storage *> vars,
+  void updateInputsAndRunNetwork(llvm::ArrayRef<Variable *> vars,
                                  llvm::ArrayRef<Tensor *> inputs,
                                  size_t sampleIdx);
 

--- a/lib/Backends/CPU/CPUFunction.cpp
+++ b/lib/Backends/CPU/CPUFunction.cpp
@@ -26,8 +26,7 @@ CPUFunction::CPUFunction(std::unique_ptr<llvm::orc::GlowJIT> JIT, void *heap)
 
 CPUFunction::~CPUFunction() { alignedFree(heap_); }
 
-void CPUFunction::execute(llvm::ArrayRef<Placeholder *> placeholders,
-                          llvm::ArrayRef<Tensor *> tensors) {
+void CPUFunction::execute() {
   auto sym = JIT_->findSymbol("jitmain");
   assert(sym && "Unable to JIT the code!");
   using JitFuncType = void (*)(void);

--- a/lib/Backends/CPU/CPUFunction.h
+++ b/lib/Backends/CPU/CPUFunction.h
@@ -38,8 +38,7 @@ public:
   ///@{
   ~CPUFunction() override;
 
-  void execute(llvm::ArrayRef<Placeholder *> placeholders,
-               llvm::ArrayRef<Tensor *> tensors) override;
+  void execute() override;
   ///@}
 };
 

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -54,8 +54,7 @@ public:
   ///@{
   ~InterpreterFunction() override;
 
-  void execute(llvm::ArrayRef<Placeholder *> placeholders,
-               llvm::ArrayRef<Tensor *> tensors) override;
+  void execute() override;
   ///@}
 
 private:

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -587,8 +587,7 @@ static void topK(Tensor &outW, Tensor &indW, Tensor &inW, size_t k) {
   }
 }
 
-void OpenCLFunction::execute(llvm::ArrayRef<Placeholder *> placeholders,
-                             llvm::ArrayRef<Tensor *> tensors) {
+void OpenCLFunction::execute() {
   auto copiedToDeviceBytes = copyMutableWeightsToDevice();
   (void)copiedToDeviceBytes;
   DEBUG_GLOW(llvm::dbgs() << "Copied " << copiedToDeviceBytes

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -98,8 +98,7 @@ public:
   ///@{
   ~OpenCLFunction() override;
 
-  void execute(llvm::ArrayRef<Placeholder *> placeholders,
-               llvm::ArrayRef<Tensor *> tensors) override;
+  void execute() override;
   ///@}
 
 private:

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -2155,6 +2155,9 @@ void Function::verify() const {
     llvm_unreachable("Multiple nodes with the same name");
   }
 
+  const auto &vars = getParent()->getVars();
+  (void)vars;
+
   // Any node referenced by one of the graph nodes should be part of the Graph.
   for (const auto &N : nodes_) {
     for (size_t idx = 0, e = N.getNumInputs(); idx < e; ++idx) {

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -68,7 +68,7 @@ onnxStatus Graph::initGraph(const void *onnxModel, size_t onnxModelSize,
 onnxStatus Graph::run() {
   // Copy tensors from the input addresses to the Glow tensors.
   llvm::SmallVector<Tensor *, 4> tensors;
-  llvm::SmallVector<Storage *, 4> vars;
+  llvm::SmallVector<Variable *, 4> vars;
   for (auto inputVar : inputVarToBuffer_) {
     auto *var = inputVar.first;
     auto *type = var->getType();

--- a/tests/unittests/BackendCorrectnessTest.cpp
+++ b/tests/unittests/BackendCorrectnessTest.cpp
@@ -304,7 +304,7 @@ TEST_P(CPUOnly, dataParallelStackingTest) {
   }
 
   MockCPUBackend backend;
-  backend.compile(std::move(M))->execute({}, {});
+  backend.compile(std::move(M))->execute();
   auto H = var->getHandle();
   EXPECT_EQ(H.at(0), 3);
   EXPECT_EQ(H.at(1), 4);

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -23,8 +23,7 @@ namespace glow {
 /// MockBackend used only for unit testing.
 class MockBackend : public Backend {
   class MockFunction : public CompiledFunction {
-    void execute(llvm::ArrayRef<Placeholder *> placeholders,
-                 llvm::ArrayRef<Tensor *> tensors) override {}
+    void execute() override {}
   };
   std::unique_ptr<CompiledFunction>
   compile(std::unique_ptr<IRFunction> IR) const override {

--- a/tests/unittests/partitionTest.cpp
+++ b/tests/unittests/partitionTest.cpp
@@ -35,7 +35,7 @@ protected:
 };
 
 /// Execute a graph of functions serially, which is the simplest approach.
-static void executeSerial(const FunctionDAG &G, llvm::ArrayRef<Storage *> vars,
+static void executeSerial(const FunctionDAG &G, llvm::ArrayRef<Variable *> vars,
                           llvm::ArrayRef<Tensor *> inputs) {
   for (auto *F : G.getFunctions()) {
     ExecutionEngine EE;

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -267,7 +267,7 @@ void Loader::compile() {
   }
 }
 
-void Loader::runInference(llvm::ArrayRef<Storage *> variables,
+void Loader::runInference(llvm::ArrayRef<Variable *> variables,
                           llvm::ArrayRef<Tensor *> tensors) {
   assert(!emittingBundle() &&
          "No inference is performed in the bundle generation mode.");

--- a/tools/loader/Loader.h
+++ b/tools/loader/Loader.h
@@ -60,7 +60,7 @@ public:
 
   /// Runs inference, unless emit bundle mode is enabled. If inference is run
   /// then it will \return true, else false.
-  void runInference(llvm::ArrayRef<Storage *> variables,
+  void runInference(llvm::ArrayRef<Variable *> variables,
                     llvm::ArrayRef<Tensor *> tensors);
 
   /// Create the Loader driver object, and parse/verify the command line


### PR DESCRIPTION
*Description*:

This commit reverts the parts of the PR #1586 that pass the placeholder
variables in the run command of the execution engine. At first I thought
that this would allow to eliminate the variables from the high-level
parts of the compilation, but I realized that we need to start with
fixing all of the backends and add support to the compiled function.

#1586

*Testing*: Ran the local test. Removed the two placeholder tests.
*Documentation*: None.