### PR TITLE
[format.sh] Allow format.sh to check whether the code base does not comply with the clang-format.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,13 @@ jobs:
       script:
         - ../.travis/run_coverage.sh
 
+    - env:
+        - TEST_NAME=CHECK_CLANG_FORMAT
+      before_install:
+        - sudo apt-get install -y clang-format-6.0
+      script:
+        - CLANG_COMMAND=/usr/bin/clang-format-6.0 ./utils/format.sh check
+
 script:
  - ninja all
  - CTEST_PARALLEL_LEVEL=2 travis_wait 20 ninja test

--- a/tests/unittests/MLTest.cpp
+++ b/tests/unittests/MLTest.cpp
@@ -556,18 +556,20 @@ void buildGRU(Context &ctx, Function *F, const std::vector<Node *> &slicesX,
 void buildRNN(Context &ctx, Function *F, const std::vector<Node *> &slicesX,
               unsigned hiddenSize, unsigned outputSize,
               std::vector<NodeValue> &outputs) {
-  return F->createSimpleRNN(ctx, "SimpleRNN", slicesX, 1, hiddenSize, outputSize,
-                            outputs);
+  return F->createSimpleRNN(ctx, "SimpleRNN", slicesX, 1, hiddenSize,
+                            outputSize, outputs);
 };
 
 void buildLSTM(Context &ctx, Function *F, const std::vector<Node *> &slicesX,
                unsigned hiddenSize, unsigned outputSize,
                std::vector<NodeValue> &outputs) {
-  return F->createLSTM(ctx, "LSTM", slicesX, 1, hiddenSize, outputSize, outputs);
+  return F->createLSTM(ctx, "LSTM", slicesX, 1, hiddenSize, outputSize,
+                       outputs);
 };
 
-using TCellGenerator = void (*)(Context &, Function *, const std::vector<Node *> &,
-                                unsigned, unsigned, std::vector<NodeValue> &);
+using TCellGenerator = void (*)(Context &, Function *,
+                                const std::vector<Node *> &, unsigned, unsigned,
+                                std::vector<NodeValue> &);
 
 void testRNNCell(TCellGenerator cell) {
   TrainingConfig TC;
@@ -588,10 +590,10 @@ void testRNNCell(TCellGenerator cell) {
   const unsigned NumElements = 4;
   // Create a variable with 1 input, which is 3 consecutive vectors
   // of 4 elements each.
-  Placeholder *X = mod.createPlaceholder(ElemKind::FloatTy, {1, NumVectors, NumElements},
-                               "X",  false);
-  Placeholder *Y = mod.createPlaceholder(ElemKind::FloatTy, {1, NumVectors}, "Y",
-                               false);
+  Placeholder *X = mod.createPlaceholder(
+      ElemKind::FloatTy, {1, NumVectors, NumElements}, "X", false);
+  Placeholder *Y =
+      mod.createPlaceholder(ElemKind::FloatTy, {1, NumVectors}, "Y", false);
   ctx.allocate(X);
   ctx.allocate(Y);
 

--- a/utils/format.sh
+++ b/utils/format.sh
@@ -5,12 +5,60 @@ set -euo pipefail
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$SCRIPT_DIR/.."
 
-if ! command -v clang-format; then
-    echo "ERROR: can't find clang-format in your path."
+CLANG_COMMAND=${CLANG_COMMAND:-clang-format}
+
+print_usage() {
+  echo "Missing format option:"
+  echo "  Run: './format.sh fix' if you want to fix format."
+  echo "  Run: './format.sh check' if you want to check format."
+}
+
+fix_format() {
+  find lib tests/unittests/ tools/ include examples \
+    -name \*.h -print0 \
+    -o -name \*.cpp -print0 \
+  | xargs -0 -P8 -n1 $CLANG_COMMAND -i;
+}
+
+check_format() {
+  touch pre.status
+  touch post.status
+
+  git status > pre.status
+  fix_format
+  git status > post.status
+
+  if ! diff pre.status post.status; then
+    echo "ERROR: files need to be formatted"
+    echo "***pre.status***"
+    cat pre.status
+    echo "***post.status***"
+    cat post.status
+    echo "***git diff***"
+    git diff master
+
     exit 1
+  fi
+}
+
+if [[ -n ${1:0} ]]; then
+  if ! command -v $CLANG_COMMAND; then
+    echo "ERROR: can't find clang-format in your path. Tried: $CLANG_COMMAND"
+    exit 1
+  fi
+
+  if [ "$1" = "fix" ]; then
+    echo "Running fix format."
+    fix_format
+  elif [ "$1" = "check" ]; then
+    echo "Running check format."
+    check_format
+  else
+    print_usage
+    exit 1
+  fi
+else
+  print_usage
+  exit 1
 fi
 
-find lib tests/unittests/ tools/ include examples \
-     -name \*.h -print0 \
-     -o -name \*.cpp -print0 \
-    | xargs -0 -P8 -n1 clang-format -i


### PR DESCRIPTION
*Description*:
Allow format.sh to process `fix` and `check` args.
When in `check` mode format.sh exits with the error exit code if code base requires formatting.

* `check` is intended to be used as part of the CI.
* `fix` is intended to be used when running format.sh locally.

*Testing*:
Local run with `check` and `fix` params.
Running on Travis with `check` param.

*Documentation*:
format.sh outputs required args if it's invoked with incorrect args.