### PR TITLE
[ExecutionEngine] Remove the logic that updates variables from the EE.

### DIFF
--- a/examples/char-rnn.cpp
+++ b/examples/char-rnn.cpp
@@ -257,7 +257,9 @@ int main(int argc, char **argv) {
     // Generate a sentence by running inference over and over again.
     for (unsigned i = 0; i < generateChars; i++) {
       // Generate a char:
-      EE.run({X}, {&currCharInfer});
+      EE.updateVariables({X}, {&currCharInfer});
+      EE.run();
+
       // Pick a char at random from the softmax distribution.
       char c = getPredictedChar(T, 0, numSteps - 1);
 

--- a/examples/char-rnn.cpp
+++ b/examples/char-rnn.cpp
@@ -227,6 +227,10 @@ int main(int argc, char **argv) {
   Tensor nextCharTrain(ElemKind::Int64ITy, {batchSize, numSteps});
   loadText(thisCharTrain, nextCharTrain, text, true);
 
+  // This variable records the number of the next sample to be used for
+  // training.
+  size_t sampleCounter = 0;
+
   // Run this number of iterations over the input. On each iteration: train the
   // network on the whole input and then generate some sample text.
   for (unsigned i = 0; i < numEpochs; i++) {
@@ -234,7 +238,7 @@ int main(int argc, char **argv) {
 
     // Train the network on the whole input.
     llvm::outs() << "Iteration " << i + 1 << "/" << numEpochs;
-    runBatch(EE, batchSize / minibatchSize, {X, Y},
+    runBatch(EE, batchSize / minibatchSize, sampleCounter, {X, Y},
              {&thisCharTrain, &nextCharTrain});
     llvm::outs() << ".\n";
 

--- a/examples/char-rnn.cpp
+++ b/examples/char-rnn.cpp
@@ -234,8 +234,8 @@ int main(int argc, char **argv) {
 
     // Train the network on the whole input.
     llvm::outs() << "Iteration " << i + 1 << "/" << numEpochs;
-    EE.runBatch(batchSize / minibatchSize, {X, Y},
-                {&thisCharTrain, &nextCharTrain});
+    runBatch(EE, batchSize / minibatchSize, {X, Y},
+             {&thisCharTrain, &nextCharTrain});
     llvm::outs() << ".\n";
 
     //// Use the trained network to generate some text ////
@@ -257,7 +257,7 @@ int main(int argc, char **argv) {
     // Generate a sentence by running inference over and over again.
     for (unsigned i = 0; i < generateChars; i++) {
       // Generate a char:
-      EE.updateVariables({X}, {&currCharInfer});
+      updateVariables({X}, {&currCharInfer});
       EE.run();
 
       // Pick a char at random from the softmax distribution.

--- a/examples/cifar10.cpp
+++ b/examples/cifar10.cpp
@@ -150,7 +150,8 @@ void testCIFAR10() {
     for (unsigned int i = 0; i < 100 / minibatchSize; i++) {
       Tensor sample(ElemKind::FloatTy, {minibatchSize, 32, 32, 3});
       sample.copyConsecutiveSlices(&images, minibatchSize * i);
-      EE.run({A}, {&sample});
+      EE.updateVariables({A}, {&sample});
+      EE.run();
       result->getOutput();
       Tensor &res = result->getVariable()->getPayload();
 

--- a/examples/cifar10.cpp
+++ b/examples/cifar10.cpp
@@ -135,6 +135,10 @@ void testCIFAR10() {
 
   llvm::outs() << "Training.\n";
 
+  // This variable records the number of the next sample to be used for
+  // training.
+  size_t sampleCounter = 0;
+
   for (int iter = 0; iter < 100000; iter++) {
     llvm::outs() << "Training - iteration #" << iter << "\n";
 
@@ -143,7 +147,7 @@ void testCIFAR10() {
 
     // Bind the images tensor to the input array A, and the labels tensor
     // to the softmax node SM.
-    runBatch(EE, reportRate, {A, E}, {&images, &labels});
+    runBatch(EE, reportRate, sampleCounter, {A, E}, {&images, &labels});
 
     unsigned score = 0;
 

--- a/examples/cifar10.cpp
+++ b/examples/cifar10.cpp
@@ -143,14 +143,14 @@ void testCIFAR10() {
 
     // Bind the images tensor to the input array A, and the labels tensor
     // to the softmax node SM.
-    EE.runBatch(reportRate, {A, E}, {&images, &labels});
+    runBatch(EE, reportRate, {A, E}, {&images, &labels});
 
     unsigned score = 0;
 
     for (unsigned int i = 0; i < 100 / minibatchSize; i++) {
       Tensor sample(ElemKind::FloatTy, {minibatchSize, 32, 32, 3});
       sample.copyConsecutiveSlices(&images, minibatchSize * i);
-      EE.updateVariables({A}, {&sample});
+      updateVariables({A}, {&sample});
       EE.run();
       result->getOutput();
       Tensor &res = result->getVariable()->getPayload();

--- a/examples/fr2en.cpp
+++ b/examples/fr2en.cpp
@@ -390,7 +390,7 @@ void Model::translate(const std::vector<std::string> &batch) {
         (words.size() - 1) + j * MAX_LENGTH;
   }
 
-  EE_.updateVariables({input_, seqLength_}, {&input, &seqLength});
+  updateVariables({input_, seqLength_}, {&input, &seqLength});
   EE_.run();
 
   auto OH = output_->getPayload().getHandle<int64_t>();

--- a/examples/fr2en.cpp
+++ b/examples/fr2en.cpp
@@ -390,7 +390,8 @@ void Model::translate(const std::vector<std::string> &batch) {
         (words.size() - 1) + j * MAX_LENGTH;
   }
 
-  EE_.run({input_, seqLength_}, {&input, &seqLength});
+  EE_.updateVariables({input_, seqLength_}, {&input, &seqLength});
+  EE_.run();
 
   auto OH = output_->getPayload().getHandle<int64_t>();
   for (unsigned j = 0; j < batch.size(); j++) {

--- a/examples/mnist.cpp
+++ b/examples/mnist.cpp
@@ -138,6 +138,10 @@ void testMNIST() {
 
   llvm::outs() << "Training.\n";
 
+  // This variable records the number of the next sample to be used for
+  // training.
+  size_t sampleCounter = 0;
+
   for (int epoch = 0; epoch < 60; epoch++) {
     llvm::outs() << "Training - epoch #" << epoch << "\n";
 
@@ -146,7 +150,8 @@ void testMNIST() {
     // On each training iteration take a slice of imageInputs and labelInputs
     // and put them into variables A and B, then run forward and backward passes
     // and update weights.
-    runBatch(EE, numIterations, {A, selected}, {&imageInputs, &labelInputs});
+    runBatch(EE, numIterations, sampleCounter, {A, selected},
+             {&imageInputs, &labelInputs});
 
     timer.stopTimer();
   }

--- a/examples/mnist.cpp
+++ b/examples/mnist.cpp
@@ -163,7 +163,8 @@ void testMNIST() {
 
   for (int iter = numIterations; iter < numIterations + 10; iter++) {
     sample.copyConsecutiveSlices(&imageInputs, minibatchSize * iter);
-    EE.run({A}, {&sample});
+    EE.updateVariables({A}, {&sample});
+    EE.run();
 
     Tensor &res = result->getVariable()->getPayload();
 

--- a/examples/mnist.cpp
+++ b/examples/mnist.cpp
@@ -146,7 +146,7 @@ void testMNIST() {
     // On each training iteration take a slice of imageInputs and labelInputs
     // and put them into variables A and B, then run forward and backward passes
     // and update weights.
-    EE.runBatch(numIterations, {A, selected}, {&imageInputs, &labelInputs});
+    runBatch(EE, numIterations, {A, selected}, {&imageInputs, &labelInputs});
 
     timer.stopTimer();
   }
@@ -163,7 +163,7 @@ void testMNIST() {
 
   for (int iter = numIterations; iter < numIterations + 10; iter++) {
     sample.copyConsecutiveSlices(&imageInputs, minibatchSize * iter);
-    EE.updateVariables({A}, {&sample});
+    updateVariables({A}, {&sample});
     EE.run();
 
     Tensor &res = result->getVariable()->getPayload();

--- a/examples/ptb.cpp
+++ b/examples/ptb.cpp
@@ -267,7 +267,7 @@ void testPTB() {
       targetWordsBatch.copyConsecutiveSlices(&targetWords,
                                              minibatchSize * batch);
 
-      EE.runBatch(1, {X, Y}, {&inputWordsBatch, &targetWordsBatch});
+      runBatch(EE, 1, {X, Y}, {&inputWordsBatch, &targetWordsBatch});
       Tensor &res = result->getVariable()->getPayload();
       for (size_t step = 0; step < numSteps; step++) {
         for (unsigned int i = 0; i < minibatchSize; i++) {

--- a/examples/ptb.cpp
+++ b/examples/ptb.cpp
@@ -258,6 +258,10 @@ void testPTB() {
     float perplexity = 0;
     size_t perplexityWordsCount = 0;
 
+    // This variable records the number of the next sample to be used for
+    // training.
+    size_t sampleCounter = 0;
+
     for (unsigned batch = 0; batch < numBatches; batch++) {
       Tensor inputWordsBatch(ElemKind::FloatTy,
                              {minibatchSize, vocabSize * numSteps});
@@ -267,7 +271,8 @@ void testPTB() {
       targetWordsBatch.copyConsecutiveSlices(&targetWords,
                                              minibatchSize * batch);
 
-      runBatch(EE, 1, {X, Y}, {&inputWordsBatch, &targetWordsBatch});
+      runBatch(EE, 1, sampleCounter, {X, Y},
+               {&inputWordsBatch, &targetWordsBatch});
       Tensor &res = result->getVariable()->getPayload();
       for (size_t step = 0; step < numSteps; step++) {
         for (unsigned int i = 0; i < minibatchSize; i++) {

--- a/include/glow/ExecutionEngine/ExecutionEngine.h
+++ b/include/glow/ExecutionEngine/ExecutionEngine.h
@@ -89,19 +89,6 @@ public:
   void runBatch(size_t iterations, llvm::ArrayRef<Variable *> vars,
                 llvm::ArrayRef<Tensor *> inputs);
 
-private:
-  /// Update the inputs for all variables \p vars with data from the inputs \p
-  /// inputs at offset \p sampleIdx. Then perform a run of the network.
-  void updateInputsAndRunNetwork(llvm::ArrayRef<Variable *> vars,
-                                 llvm::ArrayRef<Tensor *> inputs,
-                                 size_t sampleIdx);
-
-  /// Update the content of the tensor \p v with some slices that from \p input.
-  /// The data starts at slice \p sampleIdx and wraps around until the
-  /// data in \p v is filled. All dimensions, except for the first (batch)
-  /// dimension must be identical.
-  void loadValueFromTensorSlice(Variable *v, Tensor *input, size_t sampleIdx);
-
   // Update the content of the tensor \p v with \p input.
   void loadValueFromTensor(Variable *v, Tensor *input);
 };

--- a/include/glow/ExecutionEngine/ExecutionEngine.h
+++ b/include/glow/ExecutionEngine/ExecutionEngine.h
@@ -83,6 +83,14 @@ public:
   void updateVariables(llvm::ArrayRef<Variable *> vars,
                        llvm::ArrayRef<Tensor *> inputs);
 
+  /// Update the content of the tensors \p vars with some slices that from \p
+  /// inputs. The data starts at slice \p sampleIdx and wraps around until the
+  /// data in \p v is filled. All dimensions, except for the first (batch)
+  /// dimension must be identical.
+  void updateVariablesFromBatch(llvm::ArrayRef<Variable *> vars,
+                                llvm::ArrayRef<Tensor *> inputs,
+                                size_t sampleIdx);
+
   /// Runs a single execution of the function.
   void run();
 

--- a/include/glow/ExecutionEngine/ExecutionEngine.h
+++ b/include/glow/ExecutionEngine/ExecutionEngine.h
@@ -78,32 +78,35 @@ public:
   void save(CompilationMode mode, Function *F, llvm::StringRef outputDir,
             llvm::StringRef networkName);
 
-  /// This method updates the variables in \p nodes with the tensor content
-  /// values \p inputs.
-  void updateVariables(llvm::ArrayRef<Variable *> vars,
-                       llvm::ArrayRef<Tensor *> inputs);
-
-  /// Update the content of the tensors \p vars with some slices that from \p
-  /// inputs. The data starts at slice \p sampleIdx and wraps around until the
-  /// data in \p v is filled. All dimensions, except for the first (batch)
-  /// dimension must be identical.
-  void updateVariablesFromBatch(llvm::ArrayRef<Variable *> vars,
-                                llvm::ArrayRef<Tensor *> inputs,
-                                size_t sampleIdx);
-
   /// Runs a single execution of the function.
   void run();
-
-  /// Runs \p iterations iterations of the function. The method updates a local
-  /// counter and future invocations of this method continue running iterations
-  /// of the batch at the next available slice.
-  /// The method updates the variables in \p vars with the tensors \p inputs.
-  void runBatch(size_t iterations, llvm::ArrayRef<Variable *> vars,
-                llvm::ArrayRef<Tensor *> inputs);
-
-  // Update the content of the tensor \p v with \p input.
-  void loadValueFromTensor(Variable *v, Tensor *input);
 };
+
+//===----------------------------------------------------------------------===//
+//         Helper methods for running the execution engine.
+//===----------------------------------------------------------------------===//
+
+/// This method updates the variables in \p vars with the tensor content
+/// values \p inputs.
+void updateVariables(llvm::ArrayRef<Variable *> vars,
+                     llvm::ArrayRef<Tensor *> inputs);
+
+/// Update the content of the tensors \p vars with some slices that from \p
+/// inputs. The data starts at slice \p sampleIdx and wraps around until the
+/// data in \p v is filled. All dimensions, except for the first (batch)
+/// dimension must be identical.
+void updateVariablesFromBatch(llvm::ArrayRef<Variable *> vars,
+                              llvm::ArrayRef<Tensor *> inputs,
+                              size_t sampleIdx);
+
+/// Runs \p iterations iterations of the compiled function. The method updates a
+/// global counter and future invocations of this method continue running
+/// iterations of the batch at the next available slice.
+/// The method updates the variables in \p vars with the tensors \p inputs. The
+/// shape of the slice has to be identical to the shape of slices in the batch.
+/// All dimensions, except for the first (batch) dimension must be identical.
+void runBatch(ExecutionEngine &EE, size_t iterations,
+              llvm::ArrayRef<Variable *> vars, llvm::ArrayRef<Tensor *> inputs);
 
 } // namespace glow
 

--- a/include/glow/ExecutionEngine/ExecutionEngine.h
+++ b/include/glow/ExecutionEngine/ExecutionEngine.h
@@ -78,9 +78,13 @@ public:
   void save(CompilationMode mode, Function *F, llvm::StringRef outputDir,
             llvm::StringRef networkName);
 
-  /// Runs a single execution of the function. This method updates the variables
-  /// in \p nodes with the tensor content values \p inputs.
-  void run(llvm::ArrayRef<Variable *> vars, llvm::ArrayRef<Tensor *> inputs);
+  /// This method updates the variables in \p nodes with the tensor content
+  /// values \p inputs.
+  void updateVariables(llvm::ArrayRef<Variable *> vars,
+                       llvm::ArrayRef<Tensor *> inputs);
+
+  /// Runs a single execution of the function.
+  void run();
 
   /// Runs \p iterations iterations of the function. The method updates a local
   /// counter and future invocations of this method continue running iterations

--- a/include/glow/ExecutionEngine/ExecutionEngine.h
+++ b/include/glow/ExecutionEngine/ExecutionEngine.h
@@ -102,10 +102,16 @@ void updateVariablesFromBatch(llvm::ArrayRef<Variable *> vars,
 /// Runs \p iterations iterations of the compiled function. The method updates a
 /// global counter and future invocations of this method continue running
 /// iterations of the batch at the next available slice.
+///
 /// The method updates the variables in \p vars with the tensors \p inputs. The
 /// shape of the slice has to be identical to the shape of slices in the batch.
 /// All dimensions, except for the first (batch) dimension must be identical.
-void runBatch(ExecutionEngine &EE, size_t iterations,
+///
+/// The variable \p sampleCounter is consumed and updated by the function. This
+/// variable records the number of samples that were consumed by the network in
+/// previous iterations. The next input to be loaded is
+/// (sampleCounter % batchsize).
+void runBatch(ExecutionEngine &EE, size_t iterations, size_t &sampleCounter,
               llvm::ArrayRef<Variable *> vars, llvm::ArrayRef<Tensor *> inputs);
 
 } // namespace glow

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -55,16 +55,23 @@ void ExecutionEngine::setBackend(Backend *backend) {
 
 ExecutionEngine::~ExecutionEngine() = default;
 
-void ExecutionEngine::updateVariables(llvm::ArrayRef<Variable *> vars,
-                                      llvm::ArrayRef<Tensor *> inputs) {
+void glow::updateVariables(llvm::ArrayRef<Variable *> vars,
+                           llvm::ArrayRef<Tensor *> inputs) {
   assert(inputs.size() == vars.size() &&
          "The number of inputs does not match the number of variables");
 
   // Update the input variables.
   for (int i = 0, e = vars.size(); i < e; i++) {
+    assert(vars[i] && "Invalid value");
     assert(vars[i]->getVisibilityKind() == VisibilityKind::Public &&
            "Trying to update a private variable");
-    loadValueFromTensor(vars[i], inputs[i]);
+    auto &t = vars[i]->getPayload();
+    auto dim = inputs[i]->dims();
+    (void)dim;
+    assert(t.dims() == dim &&
+           t.getElementType() == inputs[i]->getElementType() &&
+           "Mismatch on Variable and Tensor types.");
+    t.assign(inputs[i]);
   }
 }
 
@@ -73,13 +80,13 @@ void ExecutionEngine::run() {
   function_->execute();
 }
 
-/// Update the content of the tensors \p vars with some slices that from \p
+/// Update the content of the tensors \p vars with some slices that are from \p
 /// inputs. The data starts at slice \p sampleIdx and wraps around until the
 /// data in \p v is filled. All dimensions, except for the first (batch)
 /// dimension must be identical.
-void ExecutionEngine::updateVariablesFromBatch(llvm::ArrayRef<Variable *> vars,
-                                               llvm::ArrayRef<Tensor *> inputs,
-                                               size_t sampleIdx) {
+void glow::updateVariablesFromBatch(llvm::ArrayRef<Variable *> vars,
+                                    llvm::ArrayRef<Tensor *> inputs,
+                                    size_t sampleIdx) {
   assert(!inputs.empty() && "No inputs");
   assert(inputs.size() == vars.size() &&
          "The number of inputs does not match the number of variables");
@@ -97,9 +104,15 @@ void ExecutionEngine::updateVariablesFromBatch(llvm::ArrayRef<Variable *> vars,
   }
 }
 
-void ExecutionEngine::runBatch(size_t iterations,
-                               llvm::ArrayRef<Variable *> vars,
-                               llvm::ArrayRef<Tensor *> inputs) {
+void glow::runBatch(ExecutionEngine &EE, size_t iterations,
+                    llvm::ArrayRef<Variable *> vars,
+                    llvm::ArrayRef<Tensor *> inputs) {
+  // This is a legacy helper function that helps to train batches of images.
+  // This variable is really a global variable that keeps track of the last
+  // sample in the batch, as we call the runBatch API several times. This is not
+  // a great solution because invocation of different unit tests rely on the
+  // same counter. We should get rid of this variable in favor of a different
+  // method to keep track of the training counter.
   static size_t trainCounter = 0;
 
   // This is the size of one batch (the number of samples in the batch).
@@ -108,21 +121,12 @@ void ExecutionEngine::runBatch(size_t iterations,
   for (size_t i = 0; i < iterations; i++) {
     // Pick up one slice from the input tensors, and load it into corresponding
     // network Variables. Then, run a single pass over the network.
-    updateVariablesFromBatch(vars, inputs, trainCounter);
+    glow::updateVariablesFromBatch(vars, inputs, trainCounter);
 
     // Run the network.
-    run();
+    EE.run();
     trainCounter += batchSize;
   }
-}
-
-void ExecutionEngine::loadValueFromTensor(Variable *v, Tensor *input) {
-  assert(v && "Invalid value");
-  auto &t = v->getPayload();
-  auto dim = input->dims();
-  (void)dim;
-  assert(t.dims() == dim && "Invalid slice size");
-  t.assign(input);
 }
 
 std::unique_ptr<IRFunction> ExecutionEngine::generateIR(CompilationMode mode,

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -105,27 +105,19 @@ void glow::updateVariablesFromBatch(llvm::ArrayRef<Variable *> vars,
 }
 
 void glow::runBatch(ExecutionEngine &EE, size_t iterations,
-                    llvm::ArrayRef<Variable *> vars,
+                    size_t &sampleCounter, llvm::ArrayRef<Variable *> vars,
                     llvm::ArrayRef<Tensor *> inputs) {
-  // This is a legacy helper function that helps to train batches of images.
-  // This variable is really a global variable that keeps track of the last
-  // sample in the batch, as we call the runBatch API several times. This is not
-  // a great solution because invocation of different unit tests rely on the
-  // same counter. We should get rid of this variable in favor of a different
-  // method to keep track of the training counter.
-  static size_t trainCounter = 0;
-
   // This is the size of one batch (the number of samples in the batch).
   size_t batchSize = vars[0]->getType()->dims()[0];
 
   for (size_t i = 0; i < iterations; i++) {
     // Pick up one slice from the input tensors, and load it into corresponding
     // network Variables. Then, run a single pass over the network.
-    glow::updateVariablesFromBatch(vars, inputs, trainCounter);
+    glow::updateVariablesFromBatch(vars, inputs, sampleCounter);
 
     // Run the network.
     EE.run();
-    trainCounter += batchSize;
+    sampleCounter += batchSize;
   }
 }
 

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -55,9 +55,8 @@ void ExecutionEngine::setBackend(Backend *backend) {
 
 ExecutionEngine::~ExecutionEngine() = default;
 
-void ExecutionEngine::run(llvm::ArrayRef<Variable *> vars,
-                          llvm::ArrayRef<Tensor *> inputs) {
-  assert(function_ && "No function has been compiled");
+void ExecutionEngine::updateVariables(llvm::ArrayRef<Variable *> vars,
+                                      llvm::ArrayRef<Tensor *> inputs) {
   assert(inputs.size() == vars.size() &&
          "The number of inputs does not match the number of variables");
 
@@ -67,7 +66,10 @@ void ExecutionEngine::run(llvm::ArrayRef<Variable *> vars,
            "Trying to update a private variable");
     loadValueFromTensor(vars[i], inputs[i]);
   }
+}
 
+void ExecutionEngine::run() {
+  assert(function_ && "No function has been compiled");
   function_->execute();
 }
 

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -79,7 +79,7 @@ onnxStatus Graph::run() {
 
   // Run inference.
   auto &EE = backendPtr_->getEE();
-  EE.updateVariables(vars, tensors);
+  updateVariables(vars, tensors);
   EE.run();
 
   // Copy outputs to the addresses specified in the outputNodeToBuffer_.

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -78,7 +78,9 @@ onnxStatus Graph::run() {
   }
 
   // Run inference.
-  backendPtr_->getEE().run(vars, tensors);
+  auto &EE = backendPtr_->getEE();
+  EE.updateVariables(vars, tensors);
+  EE.run();
 
   // Copy outputs to the addresses specified in the outputNodeToBuffer_.
   for (auto outputVar : outputNodeToBuffer_) {

--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -65,7 +65,7 @@ TEST(Interpreter, profileQuantizationForANetwork) {
 
   // TODO: Verify histogram itself, for now just verify min and max.
   // Run inference first time and capture tensor stats.
-  EE.updateVariables({A}, {&inputs});
+  updateVariables({A}, {&inputs});
   EE.run();
 
   QuantizationProfileNode *profile{nullptr};
@@ -91,7 +91,7 @@ TEST(Interpreter, profileQuantizationForANetwork) {
 
   // Run inference for the second time with new min and max.
   inputs.getHandle() = {0.2f, 1.6f, 0.5f, 1.3f};
-  EE.updateVariables({A}, {&inputs});
+  updateVariables({A}, {&inputs});
   EE.run();
   min = CI.raw(0);
   max = CI.raw(1);
@@ -129,7 +129,7 @@ TEST_P(BackendTest, simpleInference) {
 
   EE_.compile(CompilationMode::Infer, F);
 
-  EE_.updateVariables({input}, {&inputs});
+  updateVariables({input}, {&inputs});
   EE_.run();
 }
 

--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -65,7 +65,8 @@ TEST(Interpreter, profileQuantizationForANetwork) {
 
   // TODO: Verify histogram itself, for now just verify min and max.
   // Run inference first time and capture tensor stats.
-  EE.run({A}, {&inputs});
+  EE.updateVariables({A}, {&inputs});
+  EE.run();
 
   QuantizationProfileNode *profile{nullptr};
   // Find QPN for node A.
@@ -90,7 +91,8 @@ TEST(Interpreter, profileQuantizationForANetwork) {
 
   // Run inference for the second time with new min and max.
   inputs.getHandle() = {0.2f, 1.6f, 0.5f, 1.3f};
-  EE.run({A}, {&inputs});
+  EE.updateVariables({A}, {&inputs});
+  EE.run();
   min = CI.raw(0);
   max = CI.raw(1);
   EXPECT_NEAR(0.2, min, 0.00001);
@@ -127,7 +129,8 @@ TEST_P(BackendTest, simpleInference) {
 
   EE_.compile(CompilationMode::Infer, F);
 
-  EE_.run({input}, {&inputs});
+  EE_.updateVariables({input}, {&inputs});
+  EE_.run();
 }
 
 TEST_P(BackendTest, debugPrint) {
@@ -165,7 +168,7 @@ TEST_P(BackendTest, decoupleCodegenFromGraph) {
 
   // We can run the compiled code without having the graph representation
   // around.
-  EE_.run({}, {});
+  EE_.run();
 
   auto HX = res->getPayload().getHandle();
   EXPECT_NEAR(HX.at({0}), 1, 1E-5);

--- a/tests/unittests/BackendTestUtils.cpp
+++ b/tests/unittests/BackendTestUtils.cpp
@@ -52,7 +52,7 @@ void inferBatchedAddNet(Tensor *batch, Tensor *slice, Tensor *out,
   auto *batchedadd = F->createBatchedAdd("batchedadd", OT, batchVar, sliceVar);
   auto result = F->createSave("ret", batchedadd, outVar);
   EE.compile(CompilationMode::Infer, F);
-  EE.updateVariables({batchVar, sliceVar}, {batch, slice});
+  updateVariables({batchVar, sliceVar}, {batch, slice});
   EE.run();
 
   out->assign(&result->getVariable()->getPayload());
@@ -67,7 +67,7 @@ void inferBatchedReduceAddNet(Tensor *inputs, Tensor *out, BackendKind kind) {
       F->createBatchedReduceAdd("batchedreduce", var, /* axis */ 0);
   auto result = F->createSave("ret", batchedreduce);
   EE.compile(CompilationMode::Infer, F);
-  EE.updateVariables({var}, {inputs});
+  updateVariables({var}, {inputs});
   EE.run();
 
   out->assign(&result->getVariable()->getPayload());
@@ -83,7 +83,7 @@ void inferIntLookupTableNet(Tensor *input, Tensor *out,
   auto *lookupTable = F->createIntLookupTable("lookuptable", var, table, outTy);
   auto result = F->createSave("ret", lookupTable);
   EE.compile(CompilationMode::Infer, F);
-  EE.updateVariables({var}, {input});
+  updateVariables({var}, {input});
   EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
@@ -117,7 +117,7 @@ void inferConvNet(Tensor *inputs, Tensor *filter, Tensor *bias, Tensor *out,
       F->createConv("conv", inputVar, filterVar, biasVar, OT, 5, 3, 4, 1);
   auto result = F->createSave("ret", conv, outVar);
   EE.compile(CompilationMode::Infer, F);
-  EE.updateVariables({inputVar, filterVar, biasVar}, {inputs, filter, bias});
+  updateVariables({inputVar, filterVar, biasVar}, {inputs, filter, bias});
   EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
@@ -151,9 +151,9 @@ void trainConvNet(Tensor *inputs, Tensor *kernel1, Tensor *bias1,
   Function *TF = glow::differentiate(F, TC);
   EE.compile(CompilationMode::Train, TF);
 
-  EE.runBatch(8, {var1, var2}, {inputs, selected});
+  runBatch(EE, 8, {var1, var2}, {inputs, selected});
   EE.compile(CompilationMode::Infer, F);
-  EE.updateVariables({var1, var2}, {inputs, selected});
+  updateVariables({var1, var2}, {inputs, selected});
   EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
@@ -168,7 +168,7 @@ void inferGatherNet(Tensor *data, Tensor *indices, Tensor *dest,
   auto *gather = F->createGather("gather", dataV, indicesV);
   auto *result = F->createSave("ret", gather);
   EE.compile(CompilationMode::Infer, F);
-  EE.updateVariables({dataV, indicesV}, {data, indices});
+  updateVariables({dataV, indicesV}, {data, indices});
   EE.run();
   dest->assign(&result->getVariable()->getPayload());
 }
@@ -182,7 +182,7 @@ void inferLocalResponseNormalizationNet(Tensor *inputs, Tensor *out,
   auto *lrn = F->createLocalResponseNormalization("lrn", var, 5, 3.0, 0.5, 1.5);
   auto result = F->createSave("ret", lrn);
   EE.compile(CompilationMode::Infer, F);
-  EE.updateVariables({var}, {inputs});
+  updateVariables({var}, {inputs});
   EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
@@ -214,10 +214,10 @@ void trainLocalResponseNormalizationNet(Tensor *inputs, Tensor *weights,
 
   Function *TF = glow::differentiate(F, TC);
   EE.compile(CompilationMode::Train, TF);
-  EE.runBatch(8, {var1, var2}, {inputs, selected});
+  runBatch(EE, 8, {var1, var2}, {inputs, selected});
 
   EE.compile(CompilationMode::Infer, F);
-  EE.runBatch(1, {var1, var2}, {inputs, selected});
+  runBatch(EE, 1, {var1, var2}, {inputs, selected});
   out->assign(&result->getVariable()->getPayload());
 }
 
@@ -245,7 +245,7 @@ void inferMatMulNet(Tensor *lhs, Tensor *rhs, Tensor *out, BackendKind kind) {
   auto *matmul = F->createMatMul("matmul", OT, lhsVar, rhsVar);
   auto result = F->createSave("ret", matmul, outVar);
   EE.compile(CompilationMode::Infer, F);
-  EE.updateVariables({lhsVar, rhsVar}, {lhs, rhs});
+  updateVariables({lhsVar, rhsVar}, {lhs, rhs});
   EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
@@ -260,7 +260,7 @@ void inferMaxNet(Tensor *inputs1, Tensor *inputs2, Tensor *out,
   auto *max = F->createMax("max", var1, var2);
   auto result = F->createSave("ret", max);
   EE.compile(CompilationMode::Infer, F);
-  EE.updateVariables({var1, var2}, {inputs1, inputs2});
+  updateVariables({var1, var2}, {inputs1, inputs2});
   EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
@@ -275,7 +275,7 @@ void inferMinNet(Tensor *inputs1, Tensor *inputs2, Tensor *out,
   auto *min = F->createMin("min", var1, var2);
   auto result = F->createSave("ret", min);
   EE.compile(CompilationMode::Infer, F);
-  EE.updateVariables({var1, var2}, {inputs1, inputs2});
+  updateVariables({var1, var2}, {inputs1, inputs2});
   EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
@@ -288,7 +288,7 @@ void inferAvgPoolNet(Tensor *inputs, Tensor *out, BackendKind kind) {
   auto *pool = F->createAvgPool("pool", var, 3, 3, 1);
   auto result = F->createSave("ret", pool);
   EE.compile(CompilationMode::Infer, F);
-  EE.updateVariables({var}, {inputs});
+  updateVariables({var}, {inputs});
   EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
@@ -319,9 +319,9 @@ void trainAvgPoolNet(Tensor *inputs, Tensor *weights, Tensor *bias,
   Function *TF = glow::differentiate(F, TC);
   EE.compile(CompilationMode::Train, TF);
 
-  EE.runBatch(10, {var1, var2}, {inputs, selected});
+  runBatch(EE, 10, {var1, var2}, {inputs, selected});
   EE.compile(CompilationMode::Infer, F);
-  EE.updateVariables({var1, var2}, {inputs, selected});
+  updateVariables({var1, var2}, {inputs, selected});
   EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
@@ -334,7 +334,7 @@ void inferMaxPoolNet(Tensor *inputs, Tensor *out, BackendKind kind) {
   auto *pool = F->createMaxPool("pool", var, 4, 2, 3);
   auto result = F->createSave("ret", pool);
   EE.compile(CompilationMode::Infer, F);
-  EE.updateVariables({var}, {inputs});
+  updateVariables({var}, {inputs});
   EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
@@ -365,9 +365,9 @@ void trainMaxPoolNet(Tensor *inputs, Tensor *weights, Tensor *bias,
   Function *TF = glow::differentiate(F, TC);
   EE.compile(CompilationMode::Train, TF);
 
-  EE.runBatch(7, {var1, var2}, {inputs, selected});
+  runBatch(EE, 7, {var1, var2}, {inputs, selected});
   EE.compile(CompilationMode::Infer, F);
-  EE.runBatch(1, {var1, var2}, {inputs, selected});
+  runBatch(EE, 1, {var1, var2}, {inputs, selected});
   out->assign(&result->getVariable()->getPayload());
 }
 
@@ -386,7 +386,7 @@ void inferQuantizeNet(Tensor *inputs, float scale, int32_t offset, Tensor *out,
   auto *dequantize = F->createDequantize("dequantize", rescale);
   auto result = F->createSave("ret", dequantize);
   EE.compile(CompilationMode::Infer, F);
-  EE.updateVariables({var}, {inputs});
+  updateVariables({var}, {inputs});
   EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
@@ -399,7 +399,7 @@ void inferReluNet(Tensor *inputs, Tensor *out, BackendKind kind) {
   auto *relu = F->createRELU("relu", var);
   auto result = F->createSave("ret", relu);
   EE.compile(CompilationMode::Infer, F);
-  EE.updateVariables({var}, {inputs});
+  updateVariables({var}, {inputs});
   EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
@@ -413,7 +413,7 @@ void inferReshapeNet(Tensor *inputs, llvm::ArrayRef<size_t> shape, Tensor *out,
   auto *reshape = F->createReshape("reshape", var, shape);
   auto result = F->createSave("ret", reshape);
   EE.compile(CompilationMode::Infer, F);
-  EE.updateVariables({var}, {inputs});
+  updateVariables({var}, {inputs});
   EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
@@ -429,7 +429,7 @@ void inferSelectNet(Tensor *cond, Tensor *inputs1, Tensor *inputs2, Tensor *out,
   auto *select = F->createSelect("cond", var1, var2, var3);
   auto result = F->createSave("ret", select);
   EE.compile(CompilationMode::Infer, F);
-  EE.updateVariables({var1, var2, var3}, {cond, inputs1, inputs2});
+  updateVariables({var1, var2, var3}, {cond, inputs1, inputs2});
   EE.run();
 
   out->assign(&result->getVariable()->getPayload());
@@ -443,7 +443,7 @@ void inferSigmoidNet(Tensor *inputs, Tensor *out, BackendKind kind) {
   auto *sigmoid = F->createSigmoid("sigmoid", var);
   auto result = F->createSave("ret", sigmoid);
   EE.compile(CompilationMode::Infer, F);
-  EE.updateVariables({var}, {inputs});
+  updateVariables({var}, {inputs});
   EE.run();
 
   EE.run();
@@ -460,7 +460,7 @@ void inferSmallConv(Tensor *inputs, Tensor *out, BackendKind kind) {
   cast<Variable>(C->getBias())->getHandle().clear(0.4);
   auto *result = F->createSave("ret", C);
   EE.compile(CompilationMode::Infer, F);
-  EE.updateVariables({in}, {inputs});
+  updateVariables({in}, {inputs});
   EE.run();
 
   out->assign(&result->getVariable()->getPayload());
@@ -636,7 +636,7 @@ void inferSoftMaxNet(Tensor *inputs, Tensor *selected, Tensor *out,
   auto *softmax = F->createSoftMax("softmax", var1, var2);
   auto result = F->createSave("ret", softmax);
   EE.compile(CompilationMode::Infer, F);
-  EE.updateVariables({var1, var2}, {inputs, selected});
+  updateVariables({var1, var2}, {inputs, selected});
   EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
@@ -662,9 +662,9 @@ void trainSoftMaxNet(Tensor *inputs, Tensor *weights, Tensor *bias,
   Function *TF = glow::differentiate(F, TC);
   EE.compile(CompilationMode::Train, TF);
 
-  EE.runBatch(30, {var1, var2}, {inputs, selected});
+  runBatch(EE, 30, {var1, var2}, {inputs, selected});
   EE.compile(CompilationMode::Infer, F);
-  EE.updateVariables({var1, var2}, {inputs, selected});
+  updateVariables({var1, var2}, {inputs, selected});
   EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
@@ -677,7 +677,7 @@ void inferTanhNet(Tensor *inputs, Tensor *out, BackendKind kind) {
   auto *tanh = F->createTanh("tanh", var);
   auto result = F->createSave("ret", tanh);
   EE.compile(CompilationMode::Infer, F);
-  EE.updateVariables({var}, {inputs});
+  updateVariables({var}, {inputs});
   EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
@@ -690,7 +690,7 @@ void inferTransposeNet(Tensor *inputs, Tensor *out, BackendKind kind) {
   auto *tr = F->createTranspose("tr", var, {1, 0});
   auto result = F->createSave("ret", tr);
   EE.compile(CompilationMode::Infer, F);
-  EE.updateVariables({var}, {inputs});
+  updateVariables({var}, {inputs});
   EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
@@ -710,7 +710,7 @@ void inferTanhConcatNet(Tensor *input1, Tensor *input2, Tensor *input3,
   Node *C2 = F->createConcat("concat", {T2, T3, C1, T2}, 0);
   auto *result = F->createSave("ret", C2);
   EE.compile(CompilationMode::Infer, F);
-  EE.updateVariables({var1, var2, var3}, {input1, input2, input3});
+  updateVariables({var1, var2, var3}, {input1, input2, input3});
   EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
@@ -729,7 +729,7 @@ void inferBasicConvNet(Tensor *inputs, Tensor *out, BackendKind kind,
   auto *pool = F->createMaxPool("pool", conv, 2, 2, 0);
   auto result = F->createSave("ret", pool);
   EE.compile(CompilationMode::Infer, F);
-  EE.updateVariables({var}, {inputs});
+  updateVariables({var}, {inputs});
   EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
@@ -748,7 +748,7 @@ void inferBasicFCNet(Tensor *inputs, Tensor *out, BackendKind kind) {
   cast<Variable>(fc2->getWeights())->getHandle().clear(1.5);
   auto result = F->createSave("ret", rl1);
   EE.compile(CompilationMode::Infer, F);
-  EE.updateVariables({var}, {inputs});
+  updateVariables({var}, {inputs});
   EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
@@ -775,7 +775,7 @@ void inferMixedNet(Tensor *inputs, Tensor *out, BackendKind kind) {
   cast<Variable>(fc2->getWeights())->getHandle().clear(3.5);
 
   EE.compile(CompilationMode::Infer, F);
-  EE.updateVariables({var}, {inputs});
+  updateVariables({var}, {inputs});
   EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
@@ -815,8 +815,8 @@ void inferComplexNet1(Tensor *inputs1, Tensor *inputs2, Tensor *inputs3,
   auto *sigmoid3 = F->createSigmoid("sigmoid3", pool2);
   auto result = F->createSave("ret", sigmoid3);
   EE.compile(CompilationMode::Infer, F);
-  EE.updateVariables({var1, var2, var3, var4},
-                     {inputs1, inputs2, inputs3, inputs4});
+  updateVariables({var1, var2, var3, var4},
+                  {inputs1, inputs2, inputs3, inputs4});
   EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
@@ -853,7 +853,7 @@ void inferTinyResnet(Tensor *input, Tensor *out, std::vector<Tensor> &weights,
 
   EE.compile(CompilationMode::Infer, F);
 
-  EE.updateVariables({in}, {input});
+  updateVariables({in}, {input});
   EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
@@ -884,7 +884,7 @@ void inferExtract3D(Tensor *input, Tensor *out, BackendKind kind) {
 
   EE.compile(CompilationMode::Infer, F);
 
-  EE.updateVariables({inputs}, {input});
+  updateVariables({inputs}, {input});
   EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
@@ -909,7 +909,7 @@ void inferMaxSplat(Tensor *input, Tensor *out, BackendKind kind) {
 
   auto result = F->createSave("ret", max2);
   EE.compile(CompilationMode::Infer, F);
-  EE.updateVariables({var}, {input});
+  updateVariables({var}, {input});
   EE.run();
   out->assign(&result->getVariable()->getPayload());
 }

--- a/tests/unittests/BackendTestUtils.cpp
+++ b/tests/unittests/BackendTestUtils.cpp
@@ -129,6 +129,10 @@ void trainConvNet(Tensor *inputs, Tensor *kernel1, Tensor *bias1,
   ExecutionEngine EE(kind);
   TrainingConfig TC;
 
+  // This variable records the number of the next sample to be used for
+  // training.
+  size_t sampleCounter = 0;
+
   TC.learningRate = 0.03;
   TC.momentum = 0.3;
   TC.L2Decay = 0.01;
@@ -151,7 +155,7 @@ void trainConvNet(Tensor *inputs, Tensor *kernel1, Tensor *bias1,
   Function *TF = glow::differentiate(F, TC);
   EE.compile(CompilationMode::Train, TF);
 
-  runBatch(EE, 8, {var1, var2}, {inputs, selected});
+  runBatch(EE, 8, sampleCounter, {var1, var2}, {inputs, selected});
   EE.compile(CompilationMode::Infer, F);
   updateVariables({var1, var2}, {inputs, selected});
   EE.run();
@@ -195,6 +199,10 @@ void trainLocalResponseNormalizationNet(Tensor *inputs, Tensor *weights,
   ExecutionEngine EE(kind);
   TrainingConfig TC;
 
+  // This variable records the number of the next sample to be used for
+  // training.
+  size_t sampleCounter = 0;
+
   TC.learningRate = 0.06;
   TC.momentum = 0.1;
   TC.L2Decay = 0.01;
@@ -214,10 +222,10 @@ void trainLocalResponseNormalizationNet(Tensor *inputs, Tensor *weights,
 
   Function *TF = glow::differentiate(F, TC);
   EE.compile(CompilationMode::Train, TF);
-  runBatch(EE, 8, {var1, var2}, {inputs, selected});
+  runBatch(EE, 8, sampleCounter, {var1, var2}, {inputs, selected});
 
   EE.compile(CompilationMode::Infer, F);
-  runBatch(EE, 1, {var1, var2}, {inputs, selected});
+  runBatch(EE, 1, sampleCounter, {var1, var2}, {inputs, selected});
   out->assign(&result->getVariable()->getPayload());
 }
 
@@ -300,6 +308,10 @@ void trainAvgPoolNet(Tensor *inputs, Tensor *weights, Tensor *bias,
   ExecutionEngine EE(kind);
   TrainingConfig TC;
 
+  // This variable records the number of the next sample to be used for
+  // training.
+  size_t sampleCounter = 0;
+
   TC.learningRate = 0.01;
   TC.momentum = 0.4;
   TC.L2Decay = 0.01;
@@ -319,7 +331,7 @@ void trainAvgPoolNet(Tensor *inputs, Tensor *weights, Tensor *bias,
   Function *TF = glow::differentiate(F, TC);
   EE.compile(CompilationMode::Train, TF);
 
-  runBatch(EE, 10, {var1, var2}, {inputs, selected});
+  runBatch(EE, 10, sampleCounter, {var1, var2}, {inputs, selected});
   EE.compile(CompilationMode::Infer, F);
   updateVariables({var1, var2}, {inputs, selected});
   EE.run();
@@ -346,6 +358,10 @@ void trainMaxPoolNet(Tensor *inputs, Tensor *weights, Tensor *bias,
   ExecutionEngine EE(kind);
   TrainingConfig TC;
 
+  // This variable records the number of the next sample to be used for
+  // training.
+  size_t sampleCounter = 0;
+
   TC.learningRate = 0.03;
   TC.momentum = 0.3;
   TC.L2Decay = 0.003;
@@ -365,9 +381,9 @@ void trainMaxPoolNet(Tensor *inputs, Tensor *weights, Tensor *bias,
   Function *TF = glow::differentiate(F, TC);
   EE.compile(CompilationMode::Train, TF);
 
-  runBatch(EE, 7, {var1, var2}, {inputs, selected});
+  runBatch(EE, 7, sampleCounter, {var1, var2}, {inputs, selected});
   EE.compile(CompilationMode::Infer, F);
-  runBatch(EE, 1, {var1, var2}, {inputs, selected});
+  runBatch(EE, 1, sampleCounter, {var1, var2}, {inputs, selected});
   out->assign(&result->getVariable()->getPayload());
 }
 
@@ -646,6 +662,10 @@ void trainSoftMaxNet(Tensor *inputs, Tensor *weights, Tensor *bias,
   ExecutionEngine EE(kind);
   TrainingConfig TC;
 
+  // This variable records the number of the next sample to be used for
+  // training.
+  size_t sampleCounter = 0;
+
   TC.learningRate = 0.003;
   TC.momentum = 0.7;
   TC.L2Decay = 0.001;
@@ -662,7 +682,7 @@ void trainSoftMaxNet(Tensor *inputs, Tensor *weights, Tensor *bias,
   Function *TF = glow::differentiate(F, TC);
   EE.compile(CompilationMode::Train, TF);
 
-  runBatch(EE, 30, {var1, var2}, {inputs, selected});
+  runBatch(EE, 30, sampleCounter, {var1, var2}, {inputs, selected});
   EE.compile(CompilationMode::Infer, F);
   updateVariables({var1, var2}, {inputs, selected});
   EE.run();

--- a/tests/unittests/BackendTestUtils.cpp
+++ b/tests/unittests/BackendTestUtils.cpp
@@ -52,7 +52,9 @@ void inferBatchedAddNet(Tensor *batch, Tensor *slice, Tensor *out,
   auto *batchedadd = F->createBatchedAdd("batchedadd", OT, batchVar, sliceVar);
   auto result = F->createSave("ret", batchedadd, outVar);
   EE.compile(CompilationMode::Infer, F);
-  EE.run({batchVar, sliceVar}, {batch, slice});
+  EE.updateVariables({batchVar, sliceVar}, {batch, slice});
+  EE.run();
+
   out->assign(&result->getVariable()->getPayload());
 }
 
@@ -65,7 +67,9 @@ void inferBatchedReduceAddNet(Tensor *inputs, Tensor *out, BackendKind kind) {
       F->createBatchedReduceAdd("batchedreduce", var, /* axis */ 0);
   auto result = F->createSave("ret", batchedreduce);
   EE.compile(CompilationMode::Infer, F);
-  EE.run({var}, {inputs});
+  EE.updateVariables({var}, {inputs});
+  EE.run();
+
   out->assign(&result->getVariable()->getPayload());
 }
 
@@ -79,7 +83,8 @@ void inferIntLookupTableNet(Tensor *input, Tensor *out,
   auto *lookupTable = F->createIntLookupTable("lookuptable", var, table, outTy);
   auto result = F->createSave("ret", lookupTable);
   EE.compile(CompilationMode::Infer, F);
-  EE.run({var}, {input});
+  EE.updateVariables({var}, {input});
+  EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
 
@@ -112,7 +117,8 @@ void inferConvNet(Tensor *inputs, Tensor *filter, Tensor *bias, Tensor *out,
       F->createConv("conv", inputVar, filterVar, biasVar, OT, 5, 3, 4, 1);
   auto result = F->createSave("ret", conv, outVar);
   EE.compile(CompilationMode::Infer, F);
-  EE.run({inputVar, filterVar, biasVar}, {inputs, filter, bias});
+  EE.updateVariables({inputVar, filterVar, biasVar}, {inputs, filter, bias});
+  EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
 
@@ -147,7 +153,8 @@ void trainConvNet(Tensor *inputs, Tensor *kernel1, Tensor *bias1,
 
   EE.runBatch(8, {var1, var2}, {inputs, selected});
   EE.compile(CompilationMode::Infer, F);
-  EE.run({var1, var2}, {inputs, selected});
+  EE.updateVariables({var1, var2}, {inputs, selected});
+  EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
 
@@ -161,7 +168,8 @@ void inferGatherNet(Tensor *data, Tensor *indices, Tensor *dest,
   auto *gather = F->createGather("gather", dataV, indicesV);
   auto *result = F->createSave("ret", gather);
   EE.compile(CompilationMode::Infer, F);
-  EE.run({dataV, indicesV}, {data, indices});
+  EE.updateVariables({dataV, indicesV}, {data, indices});
+  EE.run();
   dest->assign(&result->getVariable()->getPayload());
 }
 
@@ -174,7 +182,8 @@ void inferLocalResponseNormalizationNet(Tensor *inputs, Tensor *out,
   auto *lrn = F->createLocalResponseNormalization("lrn", var, 5, 3.0, 0.5, 1.5);
   auto result = F->createSave("ret", lrn);
   EE.compile(CompilationMode::Infer, F);
-  EE.run({var}, {inputs});
+  EE.updateVariables({var}, {inputs});
+  EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
 
@@ -236,7 +245,8 @@ void inferMatMulNet(Tensor *lhs, Tensor *rhs, Tensor *out, BackendKind kind) {
   auto *matmul = F->createMatMul("matmul", OT, lhsVar, rhsVar);
   auto result = F->createSave("ret", matmul, outVar);
   EE.compile(CompilationMode::Infer, F);
-  EE.run({lhsVar, rhsVar}, {lhs, rhs});
+  EE.updateVariables({lhsVar, rhsVar}, {lhs, rhs});
+  EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
 
@@ -250,7 +260,8 @@ void inferMaxNet(Tensor *inputs1, Tensor *inputs2, Tensor *out,
   auto *max = F->createMax("max", var1, var2);
   auto result = F->createSave("ret", max);
   EE.compile(CompilationMode::Infer, F);
-  EE.run({var1, var2}, {inputs1, inputs2});
+  EE.updateVariables({var1, var2}, {inputs1, inputs2});
+  EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
 
@@ -264,7 +275,8 @@ void inferMinNet(Tensor *inputs1, Tensor *inputs2, Tensor *out,
   auto *min = F->createMin("min", var1, var2);
   auto result = F->createSave("ret", min);
   EE.compile(CompilationMode::Infer, F);
-  EE.run({var1, var2}, {inputs1, inputs2});
+  EE.updateVariables({var1, var2}, {inputs1, inputs2});
+  EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
 
@@ -276,7 +288,8 @@ void inferAvgPoolNet(Tensor *inputs, Tensor *out, BackendKind kind) {
   auto *pool = F->createAvgPool("pool", var, 3, 3, 1);
   auto result = F->createSave("ret", pool);
   EE.compile(CompilationMode::Infer, F);
-  EE.run({var}, {inputs});
+  EE.updateVariables({var}, {inputs});
+  EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
 
@@ -308,7 +321,8 @@ void trainAvgPoolNet(Tensor *inputs, Tensor *weights, Tensor *bias,
 
   EE.runBatch(10, {var1, var2}, {inputs, selected});
   EE.compile(CompilationMode::Infer, F);
-  EE.run({var1, var2}, {inputs, selected});
+  EE.updateVariables({var1, var2}, {inputs, selected});
+  EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
 
@@ -320,7 +334,8 @@ void inferMaxPoolNet(Tensor *inputs, Tensor *out, BackendKind kind) {
   auto *pool = F->createMaxPool("pool", var, 4, 2, 3);
   auto result = F->createSave("ret", pool);
   EE.compile(CompilationMode::Infer, F);
-  EE.run({var}, {inputs});
+  EE.updateVariables({var}, {inputs});
+  EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
 
@@ -371,7 +386,8 @@ void inferQuantizeNet(Tensor *inputs, float scale, int32_t offset, Tensor *out,
   auto *dequantize = F->createDequantize("dequantize", rescale);
   auto result = F->createSave("ret", dequantize);
   EE.compile(CompilationMode::Infer, F);
-  EE.run({var}, {inputs});
+  EE.updateVariables({var}, {inputs});
+  EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
 
@@ -383,7 +399,8 @@ void inferReluNet(Tensor *inputs, Tensor *out, BackendKind kind) {
   auto *relu = F->createRELU("relu", var);
   auto result = F->createSave("ret", relu);
   EE.compile(CompilationMode::Infer, F);
-  EE.run({var}, {inputs});
+  EE.updateVariables({var}, {inputs});
+  EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
 
@@ -396,7 +413,8 @@ void inferReshapeNet(Tensor *inputs, llvm::ArrayRef<size_t> shape, Tensor *out,
   auto *reshape = F->createReshape("reshape", var, shape);
   auto result = F->createSave("ret", reshape);
   EE.compile(CompilationMode::Infer, F);
-  EE.run({var}, {inputs});
+  EE.updateVariables({var}, {inputs});
+  EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
 
@@ -411,7 +429,9 @@ void inferSelectNet(Tensor *cond, Tensor *inputs1, Tensor *inputs2, Tensor *out,
   auto *select = F->createSelect("cond", var1, var2, var3);
   auto result = F->createSave("ret", select);
   EE.compile(CompilationMode::Infer, F);
-  EE.run({var1, var2, var3}, {cond, inputs1, inputs2});
+  EE.updateVariables({var1, var2, var3}, {cond, inputs1, inputs2});
+  EE.run();
+
   out->assign(&result->getVariable()->getPayload());
 }
 
@@ -423,7 +443,10 @@ void inferSigmoidNet(Tensor *inputs, Tensor *out, BackendKind kind) {
   auto *sigmoid = F->createSigmoid("sigmoid", var);
   auto result = F->createSave("ret", sigmoid);
   EE.compile(CompilationMode::Infer, F);
-  EE.run({var}, {inputs});
+  EE.updateVariables({var}, {inputs});
+  EE.run();
+
+  EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
 
@@ -437,7 +460,9 @@ void inferSmallConv(Tensor *inputs, Tensor *out, BackendKind kind) {
   cast<Variable>(C->getBias())->getHandle().clear(0.4);
   auto *result = F->createSave("ret", C);
   EE.compile(CompilationMode::Infer, F);
-  EE.run({in}, {inputs});
+  EE.updateVariables({in}, {inputs});
+  EE.run();
+
   out->assign(&result->getVariable()->getPayload());
 }
 
@@ -469,7 +494,7 @@ void inferGroupConv(Tensor *out, BackendKind kind) {
   SaveNode *result = F->createSave("save", CN);
 
   EE.compile(CompilationMode::Infer, F);
-  EE.run({}, {});
+  EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
 
@@ -500,7 +525,7 @@ void inferNonSquarePaddingConv(Tensor *out, BackendKind kind) {
   SaveNode *result = F->createSave("save", CN);
 
   EE.compile(CompilationMode::Infer, F);
-  EE.run({}, {});
+  EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
 
@@ -532,7 +557,7 @@ void inferNonSquareKernelConv(Tensor *out, BackendKind kind) {
   SaveNode *result = F->createSave("save", CN);
 
   EE.compile(CompilationMode::Infer, F);
-  EE.run({}, {});
+  EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
 
@@ -564,7 +589,7 @@ void inferNonSquareStrideConv(Tensor *out, BackendKind kind) {
   SaveNode *result = F->createSave("save", CN);
 
   EE.compile(CompilationMode::Infer, F);
-  EE.run({}, {});
+  EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
 
@@ -597,7 +622,7 @@ void inferConvDKKC8(Tensor *out, BackendKind kind) {
   SaveNode *result = F->createSave("save", CN);
 
   EE.compile(CompilationMode::Infer, F);
-  EE.run({}, {});
+  EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
 
@@ -611,7 +636,8 @@ void inferSoftMaxNet(Tensor *inputs, Tensor *selected, Tensor *out,
   auto *softmax = F->createSoftMax("softmax", var1, var2);
   auto result = F->createSave("ret", softmax);
   EE.compile(CompilationMode::Infer, F);
-  EE.run({var1, var2}, {inputs, selected});
+  EE.updateVariables({var1, var2}, {inputs, selected});
+  EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
 
@@ -638,7 +664,8 @@ void trainSoftMaxNet(Tensor *inputs, Tensor *weights, Tensor *bias,
 
   EE.runBatch(30, {var1, var2}, {inputs, selected});
   EE.compile(CompilationMode::Infer, F);
-  EE.run({var1, var2}, {inputs, selected});
+  EE.updateVariables({var1, var2}, {inputs, selected});
+  EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
 
@@ -650,7 +677,8 @@ void inferTanhNet(Tensor *inputs, Tensor *out, BackendKind kind) {
   auto *tanh = F->createTanh("tanh", var);
   auto result = F->createSave("ret", tanh);
   EE.compile(CompilationMode::Infer, F);
-  EE.run({var}, {inputs});
+  EE.updateVariables({var}, {inputs});
+  EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
 
@@ -662,7 +690,8 @@ void inferTransposeNet(Tensor *inputs, Tensor *out, BackendKind kind) {
   auto *tr = F->createTranspose("tr", var, {1, 0});
   auto result = F->createSave("ret", tr);
   EE.compile(CompilationMode::Infer, F);
-  EE.run({var}, {inputs});
+  EE.updateVariables({var}, {inputs});
+  EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
 
@@ -681,7 +710,8 @@ void inferTanhConcatNet(Tensor *input1, Tensor *input2, Tensor *input3,
   Node *C2 = F->createConcat("concat", {T2, T3, C1, T2}, 0);
   auto *result = F->createSave("ret", C2);
   EE.compile(CompilationMode::Infer, F);
-  EE.run({var1, var2, var3}, {input1, input2, input3});
+  EE.updateVariables({var1, var2, var3}, {input1, input2, input3});
+  EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
 
@@ -699,7 +729,8 @@ void inferBasicConvNet(Tensor *inputs, Tensor *out, BackendKind kind,
   auto *pool = F->createMaxPool("pool", conv, 2, 2, 0);
   auto result = F->createSave("ret", pool);
   EE.compile(CompilationMode::Infer, F);
-  EE.run({var}, {inputs});
+  EE.updateVariables({var}, {inputs});
+  EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
 
@@ -717,7 +748,8 @@ void inferBasicFCNet(Tensor *inputs, Tensor *out, BackendKind kind) {
   cast<Variable>(fc2->getWeights())->getHandle().clear(1.5);
   auto result = F->createSave("ret", rl1);
   EE.compile(CompilationMode::Infer, F);
-  EE.run({var}, {inputs});
+  EE.updateVariables({var}, {inputs});
+  EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
 
@@ -743,7 +775,8 @@ void inferMixedNet(Tensor *inputs, Tensor *out, BackendKind kind) {
   cast<Variable>(fc2->getWeights())->getHandle().clear(3.5);
 
   EE.compile(CompilationMode::Infer, F);
-  EE.run({var}, {inputs});
+  EE.updateVariables({var}, {inputs});
+  EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
 
@@ -782,7 +815,9 @@ void inferComplexNet1(Tensor *inputs1, Tensor *inputs2, Tensor *inputs3,
   auto *sigmoid3 = F->createSigmoid("sigmoid3", pool2);
   auto result = F->createSave("ret", sigmoid3);
   EE.compile(CompilationMode::Infer, F);
-  EE.run({var1, var2, var3, var4}, {inputs1, inputs2, inputs3, inputs4});
+  EE.updateVariables({var1, var2, var3, var4},
+                     {inputs1, inputs2, inputs3, inputs4});
+  EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
 
@@ -818,7 +853,8 @@ void inferTinyResnet(Tensor *input, Tensor *out, std::vector<Tensor> &weights,
 
   EE.compile(CompilationMode::Infer, F);
 
-  EE.run({in}, {input});
+  EE.updateVariables({in}, {input});
+  EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
 
@@ -848,7 +884,8 @@ void inferExtract3D(Tensor *input, Tensor *out, BackendKind kind) {
 
   EE.compile(CompilationMode::Infer, F);
 
-  EE.run({inputs}, {input});
+  EE.updateVariables({inputs}, {input});
+  EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
 
@@ -872,7 +909,8 @@ void inferMaxSplat(Tensor *input, Tensor *out, BackendKind kind) {
 
   auto result = F->createSave("ret", max2);
   EE.compile(CompilationMode::Infer, F);
-  EE.run({var}, {input});
+  EE.updateVariables({var}, {input});
+  EE.run();
   out->assign(&result->getVariable()->getPayload());
 }
 

--- a/tests/unittests/GemmTest.cpp
+++ b/tests/unittests/GemmTest.cpp
@@ -52,7 +52,7 @@ void infer(Tensor *out, Tensor *lhs, Tensor *rhs) {
   auto *matmul = F->createMatMul("matmul", OT, lhsVar, rhsVar);
   auto result = F->createSave("ret", matmul, outVar);
   EE.compile(CompilationMode::Infer, F);
-  EE.updateVariables({lhsVar, rhsVar}, {lhs, rhs});
+  updateVariables({lhsVar, rhsVar}, {lhs, rhs});
   EE.run();
 
   out->assign(&result->getVariable()->getPayload());

--- a/tests/unittests/GemmTest.cpp
+++ b/tests/unittests/GemmTest.cpp
@@ -52,7 +52,9 @@ void infer(Tensor *out, Tensor *lhs, Tensor *rhs) {
   auto *matmul = F->createMatMul("matmul", OT, lhsVar, rhsVar);
   auto result = F->createSave("ret", matmul, outVar);
   EE.compile(CompilationMode::Infer, F);
-  EE.run({lhsVar, rhsVar}, {lhs, rhs});
+  EE.updateVariables({lhsVar, rhsVar}, {lhs, rhs});
+  EE.run();
+
   out->assign(&result->getVariable()->getPayload());
 }
 

--- a/tests/unittests/HyphenTest.cpp
+++ b/tests/unittests/HyphenTest.cpp
@@ -357,9 +357,14 @@ TEST(HyphenTest, network) {
   TC.batchSize = 50;
   HyphenNetwork net(EE.getModule(), TC);
 
+  // This variable records the number of the next sample to be used for
+  // training.
+  size_t sampleCounter = 0;
+
   // Train using mini-batch SGD.
   EE.compile(CompilationMode::Train, net.train_);
-  runBatch(EE, 1000, {net.input_, net.expected_}, {&inputs, &expected});
+  runBatch(EE, 1000, sampleCounter, {net.input_, net.expected_},
+           {&inputs, &expected});
 
   // Now test inference on the trained network.
   // Note that we have probably overfitted the data, so we expect 100% accuracy.

--- a/tests/unittests/HyphenTest.cpp
+++ b/tests/unittests/HyphenTest.cpp
@@ -299,7 +299,8 @@ struct HyphenNetwork {
         bi = numSamples - batchSize;
       }
       auto batchInputs = inputs.getUnowned({batchSize, 6, 27}, {bi, 0, 0});
-      EE.run({input_}, {&batchInputs});
+      EE.updateVariables({input_}, {&batchInputs});
+      EE.run();
 
       // Check each output in the batch.
       for (size_t i = 0; i != batchSize; i++) {

--- a/tests/unittests/HyphenTest.cpp
+++ b/tests/unittests/HyphenTest.cpp
@@ -299,7 +299,7 @@ struct HyphenNetwork {
         bi = numSamples - batchSize;
       }
       auto batchInputs = inputs.getUnowned({batchSize, 6, 27}, {bi, 0, 0});
-      EE.updateVariables({input_}, {&batchInputs});
+      updateVariables({input_}, {&batchInputs});
       EE.run();
 
       // Check each output in the batch.
@@ -359,7 +359,7 @@ TEST(HyphenTest, network) {
 
   // Train using mini-batch SGD.
   EE.compile(CompilationMode::Train, net.train_);
-  EE.runBatch(1000, {net.input_, net.expected_}, {&inputs, &expected});
+  runBatch(EE, 1000, {net.input_, net.expected_}, {&inputs, &expected});
 
   // Now test inference on the trained network.
   // Note that we have probably overfitted the data, so we expect 100% accuracy.

--- a/tests/unittests/MLTest.cpp
+++ b/tests/unittests/MLTest.cpp
@@ -67,12 +67,12 @@ TEST_P(MLTest, trainASimpleNetwork) {
   EE_.compile(CompilationMode::Train, TF);
 
   // Train the network. Learn 1000 batches.
-  EE_.runBatch(1000, {A, E}, {&inputs, &expected});
+  runBatch(EE_, 1000, {A, E}, {&inputs, &expected});
 
   // Testing the output vector.
 
   EE_.compile(CompilationMode::Infer, F);
-  EE_.updateVariables({A}, {&inputs});
+  updateVariables({A}, {&inputs});
   EE_.run();
 
   auto RNWH = result->getVariable()->getPayload().getHandle<>();
@@ -118,7 +118,7 @@ TEST_P(MLTest, simpleRegression) {
     float target = float(iter % 9);
     I = {target, 0., 0., 0.};
     E = {0., target + 1, 0., 0.};
-    EE_.runBatch(1, {A, Ex}, {&inputs, &expected});
+    runBatch(EE_, 1, {A, Ex}, {&inputs, &expected});
   }
 
   // Verify the result of the regression layer.
@@ -128,7 +128,7 @@ TEST_P(MLTest, simpleRegression) {
   for (int iter = 0; iter < 5; iter++) {
     float target = iter % 9 + 1;
     I = {target, 0., 0., 0.};
-    EE_.updateVariables({A}, {&inputs});
+    updateVariables({A}, {&inputs});
     EE_.run();
 
     auto resH = result->getVariable()->getPayload().getHandle<>();
@@ -181,7 +181,7 @@ TEST_P(MLTest, learnXor) {
   EE_.compile(CompilationMode::Train, TF);
 
   // Train the network:
-  EE_.runBatch(2500, {A, Ex}, {&trainingSet, &trainingLabels});
+  runBatch(EE_, 2500, {A, Ex}, {&trainingSet, &trainingLabels});
 
   EE_.compile(CompilationMode::Infer, F);
 
@@ -193,7 +193,7 @@ TEST_P(MLTest, learnXor) {
     TS.at({i, 1}) = b;
   }
 
-  EE_.updateVariables({A}, {&trainingSet});
+  updateVariables({A}, {&trainingSet});
   EE_.run();
 
   auto resH = result->getVariable()->getPayload().getHandle<>();
@@ -250,7 +250,7 @@ TEST_P(MLTest, learnLog) {
   EE_.compile(CompilationMode::Train, TF);
 
   // Train the network:
-  EE_.runBatch(1000, {A, Ex}, {&trainingSet, &trainingLabels});
+  runBatch(EE_, 1000, {A, Ex}, {&trainingSet, &trainingLabels});
 
   EE_.compile(CompilationMode::Infer, F);
 
@@ -268,7 +268,7 @@ TEST_P(MLTest, learnLog) {
     TES.at({i, 0}) = a;
   }
 
-  EE_.updateVariables({A}, {&testSet});
+  updateVariables({A}, {&testSet});
   EE_.run();
 
   auto resH = result->getVariable()->getPayload().getHandle<>();
@@ -344,7 +344,7 @@ TEST_P(MLTest, circle) {
   generateCircleData(coordinates, labels, mod.getPRNG());
 
   // Training:
-  EE_.runBatch(4000, {A, S}, {&coordinates, &labels});
+  runBatch(EE_, 4000, {A, S}, {&coordinates, &labels});
 
   EE_.compile(CompilationMode::Infer, F);
 
@@ -357,7 +357,7 @@ TEST_P(MLTest, circle) {
       sample.getHandle<>().at({0, 0}) = float(x) / 10;
       sample.getHandle<>().at({0, 1}) = float(y) / 10;
 
-      EE_.updateVariables({A}, {&sample});
+      updateVariables({A}, {&sample});
       EE_.run();
 
       auto SMH = result->getVariable()->getPayload().getHandle<>();
@@ -381,7 +381,7 @@ TEST_P(MLTest, circle) {
     // The dot in the middle must be one.
     sample.getHandle<>().at({0, 0}) = 0;
     sample.getHandle<>().at({0, 1}) = 0;
-    EE_.updateVariables({A}, {&sample});
+    updateVariables({A}, {&sample});
     EE_.run();
 
     auto SMH = result->getVariable()->getPayload().getHandle<>();
@@ -394,7 +394,7 @@ TEST_P(MLTest, circle) {
     // Far away dot must be zero.
     sample.getHandle<>().at({0, 0}) = 1;
     sample.getHandle<>().at({0, 1}) = 1;
-    EE_.updateVariables({A}, {&sample});
+    updateVariables({A}, {&sample});
     EE_.run();
     auto SMH = result->getVariable()->getPayload().getHandle<>();
     auto A = SMH.at({0, 0});
@@ -443,12 +443,12 @@ TEST_P(MLTest, learnSingleValueConcat) {
   EE_.compile(CompilationMode::Train, TF);
 
   // Train the network:
-  EE_.runBatch(1000, {A, B, Ex}, {&inputs, &inputs, &expected});
+  runBatch(EE_, 1000, {A, B, Ex}, {&inputs, &inputs, &expected});
 
   EE_.compile(CompilationMode::Infer, F);
 
   // Testing the output vector.
-  EE_.updateVariables({A}, {&inputs});
+  updateVariables({A}, {&inputs});
   EE_.run();
   auto RNWH = result->getVariable()->getPayload().getHandle<>();
   (void)RNWH;
@@ -545,12 +545,12 @@ void testRNNCell(TCellGenerator cell) {
   }
 
   // Train the network. Learn 1000 batches.
-  EE.runBatch(1000, {X, Y}, {&inputs, &expected});
+  runBatch(EE, 1000, {X, Y}, {&inputs, &expected});
 
   // Testing the output vector.
   EE.compile(CompilationMode::Infer, F);
 
-  EE.updateVariables({X}, {&inputs});
+  updateVariables({X}, {&inputs});
   EE.run();
 
   auto RNWH = result->getVariable()->getPayload().getHandle<>();
@@ -647,7 +647,7 @@ TEST_P(MLTest, trainSimpleLinearRegression) {
   EE_.compile(CompilationMode::Train, TF);
 
   // Train the network doing 100 steps. Learn on 500 samples.
-  EE_.runBatch(100, {inputX, expectedY}, {&tensorX, &tensorY});
+  runBatch(EE_, 100, {inputX, expectedY}, {&tensorX, &tensorY});
 
   // Testing trained m and b:
   EXPECT_NEAR(M->getPayload().getHandle<>().at({0, 0}), referenceM, 0.01);
@@ -715,7 +715,7 @@ TEST_P(MLTest, classifyPlayerSport) {
   generatePlayerData(players, labels, numTrainPlayers, mod.getPRNG());
 
   // Training:
-  EE_.runBatch(2000, {A, S}, {&players, &labels});
+  runBatch(EE_, 2000, {A, S}, {&players, &labels});
 
   EE_.compile(CompilationMode::Infer, F);
 
@@ -733,7 +733,7 @@ TEST_P(MLTest, classifyPlayerSport) {
     testPlayersTensor.getHandle<>().at({i, 1}) = std::get<1>(testPlayers[i]);
   }
 
-  EE_.updateVariables({A}, {&testPlayersTensor});
+  updateVariables({A}, {&testPlayersTensor});
   EE_.run();
 
   for (size_t i = 0; i < testPlayers.size(); i++) {
@@ -791,7 +791,7 @@ TEST_P(MLTest, learnSinus) {
   EE_.compile(CompilationMode::Train, TF);
 
   // Learn on numSamples samples.
-  EE_.runBatch(2700, {inputX, expectedY}, {&tensorX, &tensorY});
+  runBatch(EE_, 2700, {inputX, expectedY}, {&tensorX, &tensorY});
 
   // Create a test set, which is similar, but different from the training set.
   for (unsigned i = 0; i < numSamples; i++) {
@@ -804,7 +804,7 @@ TEST_P(MLTest, learnSinus) {
   }
 
   EE_.compile(CompilationMode::Infer, F);
-  EE_.updateVariables({inputX}, {&tensorX});
+  updateVariables({inputX}, {&tensorX});
   EE_.run();
   auto resH = result->getVariable()->getPayload().getHandle<>();
 
@@ -856,7 +856,7 @@ TEST_P(MLTest, nonLinearClassifier) {
     labels.getHandle<int64_t>().at({i, 0}) = label;
   }
 
-  EE_.runBatch(500, {A, S}, {&samples, &labels});
+  runBatch(EE_, 500, {A, S}, {&samples, &labels});
 
   EE_.compile(CompilationMode::Infer, F);
 
@@ -869,7 +869,7 @@ TEST_P(MLTest, nonLinearClassifier) {
     Tensor T(ElemKind::FloatTy, {batchSize, 2});
     T.getHandle<>().at({0, 0}) = std::get<0>(tests[i]);
     T.getHandle<>().at({0, 1}) = std::get<1>(tests[i]);
-    EE_.updateVariables({A}, {&T});
+    updateVariables({A}, {&T});
     EE_.run();
     auto RH = result->getVariable()->getPayload().getHandle<>();
     EXPECT_NEAR(RH.at({0, std::get<2>(tests[i])}), 1.0, 0.2);
@@ -935,12 +935,12 @@ TEST_P(InterpreterAndCPU, convNetForImageRecognition) {
   generateImageData(images, labels, mod.getPRNG());
 
   // Training:
-  EE.runBatch(500, {input, ex}, {&images, &labels});
+  runBatch(EE, 500, {input, ex}, {&images, &labels});
 
   // Profiling:
   Function *PF = glow::profileQuantization(F);
   EE.compile(CompilationMode::Infer, PF);
-  EE.runBatch(100, {input}, {&images});
+  runBatch(EE, 100, {input}, {&images});
 
   // Get the quantization info and build the new quantized graph.
   std::vector<NodeQuantizationInfo> QI =
@@ -955,7 +955,7 @@ TEST_P(InterpreterAndCPU, convNetForImageRecognition) {
   Tensor testImages(ElemKind::FloatTy, {batchSize, 8, 8, 1});
   Tensor testLabels(ElemKind::Int64ITy, {batchSize, 1});
   generateImageData(testImages, testLabels, mod.getPRNG());
-  EE.updateVariables({input}, {&testImages});
+  updateVariables({input}, {&testImages});
   EE.run();
   auto SMH = result->getVariable()->getHandle<>();
   for (size_t i = 0; i < batchSize; i++) {
@@ -1024,7 +1024,7 @@ TEST_P(InterpreterAndCPU, testFindPixelRegression) {
   generateRegressionTestData(images, labels, mod.getPRNG());
 
   // Training:
-  EE.runBatch(400, {input, ex}, {&images, &labels});
+  runBatch(EE, 400, {input, ex}, {&images, &labels});
 
   // -- STEP2 - Profile and quantize the network. --
 
@@ -1033,7 +1033,7 @@ TEST_P(InterpreterAndCPU, testFindPixelRegression) {
   EE.compile(CompilationMode::Infer, PF);
 
   // Run the graph to capture the profile.
-  EE.runBatch(100, {input}, {&images});
+  runBatch(EE, 100, {input}, {&images});
 
   // Get quantization infos and build new quantized graph.
   std::vector<NodeQuantizationInfo> QI =
@@ -1054,7 +1054,7 @@ TEST_P(InterpreterAndCPU, testFindPixelRegression) {
   generateRegressionTestData(testImages, testLabels, mod.getPRNG());
 
   // Run the inference:
-  EE.updateVariables({input}, {&testImages});
+  updateVariables({input}, {&testImages});
   EE.run();
 
   // A handle to the projected result.
@@ -1196,8 +1196,8 @@ TEST_P(MLTest, matrixRotationRecognition) {
 
   EE_.compile(CompilationMode::Train, trainingGradientFunction);
   // Training:
-  EE_.runBatch(200, {varMatricesA, varMatricesB, varExpected},
-               {&matricesA, &matricesB, &expected});
+  runBatch(EE_, 200, {varMatricesA, varMatricesB, varExpected},
+           {&matricesA, &matricesB, &expected});
 
   // Switch to inference mode.
   EE_.compile(CompilationMode::Infer, F);
@@ -1213,8 +1213,8 @@ TEST_P(MLTest, matrixRotationRecognition) {
       matricesA.getUnowned({batchSize, 3, 3}, {batchStartIdx, 0, 0});
   auto batchMatricesB =
       matricesB.getUnowned({batchSize, 3, 3}, {batchStartIdx, 0, 0});
-  EE_.updateVariables({varMatricesA, varMatricesB},
-                      {&batchMatricesA, &batchMatricesB});
+  updateVariables({varMatricesA, varMatricesB},
+                  {&batchMatricesA, &batchMatricesB});
   EE_.run();
 
   unsigned errors = 0;

--- a/tests/unittests/MLTest.cpp
+++ b/tests/unittests/MLTest.cpp
@@ -72,7 +72,9 @@ TEST_P(MLTest, trainASimpleNetwork) {
   // Testing the output vector.
 
   EE_.compile(CompilationMode::Infer, F);
-  EE_.run({A}, {&inputs});
+  EE_.updateVariables({A}, {&inputs});
+  EE_.run();
+
   auto RNWH = result->getVariable()->getPayload().getHandle<>();
   (void)RNWH;
 
@@ -126,7 +128,8 @@ TEST_P(MLTest, simpleRegression) {
   for (int iter = 0; iter < 5; iter++) {
     float target = iter % 9 + 1;
     I = {target, 0., 0., 0.};
-    EE_.run({A}, {&inputs});
+    EE_.updateVariables({A}, {&inputs});
+    EE_.run();
 
     auto resH = result->getVariable()->getPayload().getHandle<>();
     (void)resH;
@@ -190,7 +193,9 @@ TEST_P(MLTest, learnXor) {
     TS.at({i, 1}) = b;
   }
 
-  EE_.run({A}, {&trainingSet});
+  EE_.updateVariables({A}, {&trainingSet});
+  EE_.run();
+
   auto resH = result->getVariable()->getPayload().getHandle<>();
 
   // Test the output:
@@ -263,7 +268,9 @@ TEST_P(MLTest, learnLog) {
     TES.at({i, 0}) = a;
   }
 
-  EE_.run({A}, {&testSet});
+  EE_.updateVariables({A}, {&testSet});
+  EE_.run();
+
   auto resH = result->getVariable()->getPayload().getHandle<>();
 
   // Test the output:
@@ -350,7 +357,8 @@ TEST_P(MLTest, circle) {
       sample.getHandle<>().at({0, 0}) = float(x) / 10;
       sample.getHandle<>().at({0, 1}) = float(y) / 10;
 
-      EE_.run({A}, {&sample});
+      EE_.updateVariables({A}, {&sample});
+      EE_.run();
 
       auto SMH = result->getVariable()->getPayload().getHandle<>();
       auto A = SMH.at({0, 0});
@@ -373,7 +381,9 @@ TEST_P(MLTest, circle) {
     // The dot in the middle must be one.
     sample.getHandle<>().at({0, 0}) = 0;
     sample.getHandle<>().at({0, 1}) = 0;
-    EE_.run({A}, {&sample});
+    EE_.updateVariables({A}, {&sample});
+    EE_.run();
+
     auto SMH = result->getVariable()->getPayload().getHandle<>();
     auto A = SMH.at({0, 0});
     auto B = SMH.at({0, 1});
@@ -384,7 +394,8 @@ TEST_P(MLTest, circle) {
     // Far away dot must be zero.
     sample.getHandle<>().at({0, 0}) = 1;
     sample.getHandle<>().at({0, 1}) = 1;
-    EE_.run({A}, {&sample});
+    EE_.updateVariables({A}, {&sample});
+    EE_.run();
     auto SMH = result->getVariable()->getPayload().getHandle<>();
     auto A = SMH.at({0, 0});
     auto B = SMH.at({0, 1});
@@ -437,7 +448,8 @@ TEST_P(MLTest, learnSingleValueConcat) {
   EE_.compile(CompilationMode::Infer, F);
 
   // Testing the output vector.
-  EE_.run({A}, {&inputs});
+  EE_.updateVariables({A}, {&inputs});
+  EE_.run();
   auto RNWH = result->getVariable()->getPayload().getHandle<>();
   (void)RNWH;
 
@@ -538,7 +550,9 @@ void testRNNCell(TCellGenerator cell) {
   // Testing the output vector.
   EE.compile(CompilationMode::Infer, F);
 
-  EE.run({X}, {&inputs});
+  EE.updateVariables({X}, {&inputs});
+  EE.run();
+
   auto RNWH = result->getVariable()->getPayload().getHandle<>();
   (void)RNWH;
 
@@ -580,7 +594,8 @@ TEST_P(MLTest, learnSqrt2) {
 
   // Train the network:
   for (int i = 0; i < 50; i++) {
-    EE_.run({}, {});
+    EE_.run();
+    EE_.run();
   }
 
   float res = A->getPayload().getHandle().at({0});
@@ -718,7 +733,8 @@ TEST_P(MLTest, classifyPlayerSport) {
     testPlayersTensor.getHandle<>().at({i, 1}) = std::get<1>(testPlayers[i]);
   }
 
-  EE_.run({A}, {&testPlayersTensor});
+  EE_.updateVariables({A}, {&testPlayersTensor});
+  EE_.run();
 
   for (size_t i = 0; i < testPlayers.size(); i++) {
     auto SMH = result->getVariable()->getPayload().getHandle<>();
@@ -788,7 +804,8 @@ TEST_P(MLTest, learnSinus) {
   }
 
   EE_.compile(CompilationMode::Infer, F);
-  EE_.run({inputX}, {&tensorX});
+  EE_.updateVariables({inputX}, {&tensorX});
+  EE_.run();
   auto resH = result->getVariable()->getPayload().getHandle<>();
 
   for (size_t i = 0; i < numSamples; i++) {
@@ -852,7 +869,8 @@ TEST_P(MLTest, nonLinearClassifier) {
     Tensor T(ElemKind::FloatTy, {batchSize, 2});
     T.getHandle<>().at({0, 0}) = std::get<0>(tests[i]);
     T.getHandle<>().at({0, 1}) = std::get<1>(tests[i]);
-    EE_.run({A}, {&T});
+    EE_.updateVariables({A}, {&T});
+    EE_.run();
     auto RH = result->getVariable()->getPayload().getHandle<>();
     EXPECT_NEAR(RH.at({0, std::get<2>(tests[i])}), 1.0, 0.2);
   }
@@ -937,7 +955,8 @@ TEST_P(InterpreterAndCPU, convNetForImageRecognition) {
   Tensor testImages(ElemKind::FloatTy, {batchSize, 8, 8, 1});
   Tensor testLabels(ElemKind::Int64ITy, {batchSize, 1});
   generateImageData(testImages, testLabels, mod.getPRNG());
-  EE.run({input}, {&testImages});
+  EE.updateVariables({input}, {&testImages});
+  EE.run();
   auto SMH = result->getVariable()->getHandle<>();
   for (size_t i = 0; i < batchSize; i++) {
     bool isLine = testLabels.getHandle<int64_t>().at({i, 0}) == 0;
@@ -1035,7 +1054,8 @@ TEST_P(InterpreterAndCPU, testFindPixelRegression) {
   generateRegressionTestData(testImages, testLabels, mod.getPRNG());
 
   // Run the inference:
-  EE.run({input}, {&testImages});
+  EE.updateVariables({input}, {&testImages});
+  EE.run();
 
   // A handle to the projected result.
   auto RH = result->getVariable()->getHandle<>();
@@ -1193,7 +1213,9 @@ TEST_P(MLTest, matrixRotationRecognition) {
       matricesA.getUnowned({batchSize, 3, 3}, {batchStartIdx, 0, 0});
   auto batchMatricesB =
       matricesB.getUnowned({batchSize, 3, 3}, {batchStartIdx, 0, 0});
-  EE_.run({varMatricesA, varMatricesB}, {&batchMatricesA, &batchMatricesB});
+  EE_.updateVariables({varMatricesA, varMatricesB},
+                      {&batchMatricesA, &batchMatricesB});
+  EE_.run();
 
   unsigned errors = 0;
   // Check each output in the batch.

--- a/tests/unittests/MLTest.cpp
+++ b/tests/unittests/MLTest.cpp
@@ -39,6 +39,10 @@ class MLTest : public TestRunnerBase {};
 TEST_P(MLTest, trainASimpleNetwork) {
   TrainingConfig TC;
 
+  // This variable records the number of the next sample to be used for
+  // training.
+  size_t sampleCounter = 0;
+
   // Learning a single input vector.
   TC.learningRate = 0.05;
 
@@ -67,7 +71,7 @@ TEST_P(MLTest, trainASimpleNetwork) {
   EE_.compile(CompilationMode::Train, TF);
 
   // Train the network. Learn 1000 batches.
-  runBatch(EE_, 1000, {A, E}, {&inputs, &expected});
+  runBatch(EE_, 1000, sampleCounter, {A, E}, {&inputs, &expected});
 
   // Testing the output vector.
 
@@ -84,6 +88,10 @@ TEST_P(MLTest, trainASimpleNetwork) {
 
 TEST_P(MLTest, simpleRegression) {
   TrainingConfig TC;
+
+  // This variable records the number of the next sample to be used for
+  // training.
+  size_t sampleCounter = 0;
 
   // Testing the regression layer. This test takes the first element from the
   // input vector, adds one to it and places the result in the second element of
@@ -118,7 +126,7 @@ TEST_P(MLTest, simpleRegression) {
     float target = float(iter % 9);
     I = {target, 0., 0., 0.};
     E = {0., target + 1, 0., 0.};
-    runBatch(EE_, 1, {A, Ex}, {&inputs, &expected});
+    runBatch(EE_, 1, sampleCounter, {A, Ex}, {&inputs, &expected});
   }
 
   // Verify the result of the regression layer.
@@ -142,6 +150,10 @@ TEST_P(MLTest, learnXor) {
   TrainingConfig TC;
 
   unsigned numInputs = 10;
+
+  // This variable records the number of the next sample to be used for
+  // training.
+  size_t sampleCounter = 0;
 
   // Learning a single input vector.
   TC.learningRate = 0.05;
@@ -181,7 +193,7 @@ TEST_P(MLTest, learnXor) {
   EE_.compile(CompilationMode::Train, TF);
 
   // Train the network:
-  runBatch(EE_, 2500, {A, Ex}, {&trainingSet, &trainingLabels});
+  runBatch(EE_, 2500, sampleCounter, {A, Ex}, {&trainingSet, &trainingLabels});
 
   EE_.compile(CompilationMode::Infer, F);
 
@@ -209,6 +221,10 @@ TEST_P(MLTest, learnXor) {
 /// Learn the logarithmic function.
 TEST_P(MLTest, learnLog) {
   TrainingConfig TC;
+
+  // This variable records the number of the next sample to be used for
+  // training.
+  size_t sampleCounter = 0;
 
   unsigned numInputs = 50;
   unsigned batchSize = 5;
@@ -250,7 +266,7 @@ TEST_P(MLTest, learnLog) {
   EE_.compile(CompilationMode::Train, TF);
 
   // Train the network:
-  runBatch(EE_, 1000, {A, Ex}, {&trainingSet, &trainingLabels});
+  runBatch(EE_, 1000, sampleCounter, {A, Ex}, {&trainingSet, &trainingLabels});
 
   EE_.compile(CompilationMode::Infer, F);
 
@@ -315,6 +331,10 @@ void generateCircleData(Tensor &coordinates, Tensor &labels, PseudoRNG &PRNG) {
 TEST_P(MLTest, circle) {
   TrainingConfig TC;
 
+  // This variable records the number of the next sample to be used for
+  // training.
+  size_t sampleCounter = 0;
+
   unsigned minibatchSize = 11;
 
   // Testing the softmax layer.
@@ -344,7 +364,7 @@ TEST_P(MLTest, circle) {
   generateCircleData(coordinates, labels, mod.getPRNG());
 
   // Training:
-  runBatch(EE_, 4000, {A, S}, {&coordinates, &labels});
+  runBatch(EE_, 4000, sampleCounter, {A, S}, {&coordinates, &labels});
 
   EE_.compile(CompilationMode::Infer, F);
 
@@ -406,6 +426,10 @@ TEST_P(MLTest, circle) {
 TEST_P(MLTest, learnSingleValueConcat) {
   unsigned width = 6;
 
+  // This variable records the number of the next sample to be used for
+  // training.
+  size_t sampleCounter = 0;
+
   // Learning a single input vector.
   TrainingConfig TC;
   TC.momentum = 0.9;
@@ -443,7 +467,7 @@ TEST_P(MLTest, learnSingleValueConcat) {
   EE_.compile(CompilationMode::Train, TF);
 
   // Train the network:
-  runBatch(EE_, 1000, {A, B, Ex}, {&inputs, &inputs, &expected});
+  runBatch(EE_, 1000, sampleCounter, {A, B, Ex}, {&inputs, &inputs, &expected});
 
   EE_.compile(CompilationMode::Infer, F);
 
@@ -481,6 +505,10 @@ using TCellGenerator = void (*)(Function *, const std::vector<Node *> &,
 
 void testRNNCell(TCellGenerator cell) {
   TrainingConfig TC;
+
+  // This variable records the number of the next sample to be used for
+  // training.
+  size_t sampleCounter = 0;
 
   ExecutionEngine EE;
   // Learning a single input vector.
@@ -545,7 +573,7 @@ void testRNNCell(TCellGenerator cell) {
   }
 
   // Train the network. Learn 1000 batches.
-  runBatch(EE, 1000, {X, Y}, {&inputs, &expected});
+  runBatch(EE, 1000, sampleCounter, {X, Y}, {&inputs, &expected});
 
   // Testing the output vector.
   EE.compile(CompilationMode::Infer, F);
@@ -609,6 +637,10 @@ TEST_P(MLTest, trainSimpleLinearRegression) {
   // m * x + b is approximately equal to y.
   unsigned numSamples = 500;
 
+  // This variable records the number of the next sample to be used for
+  // training.
+  size_t sampleCounter = 0;
+
   TC.learningRate = 0.1;
   TC.batchSize = numSamples;
 
@@ -647,7 +679,7 @@ TEST_P(MLTest, trainSimpleLinearRegression) {
   EE_.compile(CompilationMode::Train, TF);
 
   // Train the network doing 100 steps. Learn on 500 samples.
-  runBatch(EE_, 100, {inputX, expectedY}, {&tensorX, &tensorY});
+  runBatch(EE_, 100, sampleCounter, {inputX, expectedY}, {&tensorX, &tensorY});
 
   // Testing trained m and b:
   EXPECT_NEAR(M->getPayload().getHandle<>().at({0, 0}), referenceM, 0.01);
@@ -691,6 +723,10 @@ TEST_P(MLTest, classifyPlayerSport) {
 
   TrainingConfig TC;
 
+  // This variable records the number of the next sample to be used for
+  // training.
+  size_t sampleCounter = 0;
+
   TC.learningRate = 0.05;
   TC.batchSize = numTrainPlayers;
 
@@ -715,7 +751,7 @@ TEST_P(MLTest, classifyPlayerSport) {
   generatePlayerData(players, labels, numTrainPlayers, mod.getPRNG());
 
   // Training:
-  runBatch(EE_, 2000, {A, S}, {&players, &labels});
+  runBatch(EE_, 2000, sampleCounter, {A, S}, {&players, &labels});
 
   EE_.compile(CompilationMode::Infer, F);
 
@@ -745,6 +781,10 @@ TEST_P(MLTest, classifyPlayerSport) {
 
 TEST_P(MLTest, learnSinus) {
   TrainingConfig TC;
+
+  // This variable records the number of the next sample to be used for
+  // training.
+  size_t sampleCounter = 0;
 
   // Try to learn the sin(x) function.
   float epsilon = 0.1;
@@ -791,7 +831,7 @@ TEST_P(MLTest, learnSinus) {
   EE_.compile(CompilationMode::Train, TF);
 
   // Learn on numSamples samples.
-  runBatch(EE_, 2700, {inputX, expectedY}, {&tensorX, &tensorY});
+  runBatch(EE_, 2700, sampleCounter, {inputX, expectedY}, {&tensorX, &tensorY});
 
   // Create a test set, which is similar, but different from the training set.
   for (unsigned i = 0; i < numSamples; i++) {
@@ -819,6 +859,10 @@ TEST_P(MLTest, nonLinearClassifier) {
   // (-1, 1) and classify according to XOR of the sign bit.
   unsigned batchSize = 46;
   unsigned numSamples = 230;
+
+  // This variable records the number of the next sample to be used for
+  // training.
+  size_t sampleCounter = 0;
 
   TrainingConfig TC;
   TC.learningRate = 0.01;
@@ -856,7 +900,7 @@ TEST_P(MLTest, nonLinearClassifier) {
     labels.getHandle<int64_t>().at({i, 0}) = label;
   }
 
-  runBatch(EE_, 500, {A, S}, {&samples, &labels});
+  runBatch(EE_, 500, sampleCounter, {A, S}, {&samples, &labels});
 
   EE_.compile(CompilationMode::Infer, F);
 
@@ -908,6 +952,10 @@ TEST_P(InterpreterAndCPU, convNetForImageRecognition) {
   const unsigned numSamples = 500;
   const unsigned batchSize = 7;
 
+  // This variable records the number of the next sample to be used for
+  // training.
+  size_t sampleCounter = 0;
+
   TrainingConfig TC;
   TC.learningRate = 0.01;
   TC.batchSize = batchSize;
@@ -935,12 +983,12 @@ TEST_P(InterpreterAndCPU, convNetForImageRecognition) {
   generateImageData(images, labels, mod.getPRNG());
 
   // Training:
-  runBatch(EE, 500, {input, ex}, {&images, &labels});
+  runBatch(EE, 500, sampleCounter, {input, ex}, {&images, &labels});
 
   // Profiling:
   Function *PF = glow::profileQuantization(F);
   EE.compile(CompilationMode::Infer, PF);
-  runBatch(EE, 100, {input}, {&images});
+  runBatch(EE, 100, sampleCounter, {input}, {&images});
 
   // Get the quantization info and build the new quantized graph.
   std::vector<NodeQuantizationInfo> QI =
@@ -994,6 +1042,10 @@ TEST_P(InterpreterAndCPU, testFindPixelRegression) {
   const unsigned numSamples = 1000;
   const unsigned batchSize = 10;
 
+  // This variable records the number of the next sample to be used for
+  // training.
+  size_t sampleCounter = 0;
+
   TrainingConfig TC;
   TC.learningRate = 0.01;
   TC.batchSize = batchSize;
@@ -1024,7 +1076,7 @@ TEST_P(InterpreterAndCPU, testFindPixelRegression) {
   generateRegressionTestData(images, labels, mod.getPRNG());
 
   // Training:
-  runBatch(EE, 400, {input, ex}, {&images, &labels});
+  runBatch(EE, 400, sampleCounter, {input, ex}, {&images, &labels});
 
   // -- STEP2 - Profile and quantize the network. --
 
@@ -1033,7 +1085,7 @@ TEST_P(InterpreterAndCPU, testFindPixelRegression) {
   EE.compile(CompilationMode::Infer, PF);
 
   // Run the graph to capture the profile.
-  runBatch(EE, 100, {input}, {&images});
+  runBatch(EE, 100, sampleCounter, {input}, {&images});
 
   // Get quantization infos and build new quantized graph.
   std::vector<NodeQuantizationInfo> QI =
@@ -1159,6 +1211,10 @@ TEST_P(MLTest, matrixRotationRecognition) {
   TC.learningRate = 0.15;
   TC.batchSize = 17;
 
+  // This variable records the number of the next sample to be used for
+  // training.
+  size_t sampleCounter = 0;
+
   Module &mod = EE_.getModule();
   PseudoRNG &PRNG = mod.getPRNG();
   Function *F = mod.createFunction("MatrixRotationRecognition");
@@ -1196,7 +1252,7 @@ TEST_P(MLTest, matrixRotationRecognition) {
 
   EE_.compile(CompilationMode::Train, trainingGradientFunction);
   // Training:
-  runBatch(EE_, 200, {varMatricesA, varMatricesB, varExpected},
+  runBatch(EE_, 200, sampleCounter, {varMatricesA, varMatricesB, varExpected},
            {&matricesA, &matricesB, &expected});
 
   // Switch to inference mode.

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -1784,6 +1784,10 @@ TEST_P(Operator, FCGradientCheck) {
   // with reference values.
   TrainingConfig TC;
 
+  // This variable records the number of the next sample to be used for
+  // training.
+  size_t sampleCounter = 0;
+
   auto *A = mod_.createVariable(ElemKind::FloatTy, {2, 1}, "A",
                                 VisibilityKind::Public, false);
   auto *B = mod_.createVariable(ElemKind::FloatTy, {2, 1}, "B",
@@ -1807,7 +1811,7 @@ TEST_P(Operator, FCGradientCheck) {
 
   Function *DF = glow::differentiate(F_, TC, "d_main");
   EE_.compile(CompilationMode::Train, DF);
-  runBatch(EE_, 3, {A, B}, {&initA, &initB});
+  runBatch(EE_, 3, sampleCounter, {A, B}, {&initA, &initB});
 
   EXPECT_NEAR(X->getPayload().getHandle().raw(0), -0.21294, 1E-5);
   EXPECT_NEAR(Y->getPayload().getHandle().raw(0), 0.01656, 1E-5);

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -62,7 +62,7 @@ TEST_P(Operator, pow) {
 
   EE_.compile(CompilationMode::Infer, F_);
 
-  EE_.run({}, {});
+  EE_.run();
 
   auto HX = llvm::cast<Variable>(Save1->getOutput())->getPayload().getHandle();
   EXPECT_NEAR(HX.at({0, 0, 0}), 25, 1E-5);
@@ -89,7 +89,7 @@ TEST_P(InterpAndCPU, log) {
 
   EE_.compile(CompilationMode::Infer, F_);
 
-  EE_.run({}, {});
+  EE_.run();
 
   auto saveH = save->getVariable()->getHandle();
 
@@ -111,7 +111,7 @@ TEST_P(InterpAndCPU, CmpEQ) {
 
   EE_.compile(CompilationMode::Infer, F_);
 
-  EE_.run({}, {});
+  EE_.run();
 
   auto saveH = save->getVariable()->getHandle<int64_t>();
   for (size_t i = 0; i < 7; ++i) {
@@ -134,7 +134,7 @@ TEST_P(Operator, matmul) {
   F_->createSave("save", R, result);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   auto H = result->getPayload().getHandle();
   EXPECT_NEAR(H.at({0, 0}), 27, 0.001);
@@ -155,7 +155,7 @@ TEST_P(Operator, BroadcastedBatchMatMul) {
   F_->createSave("save", R, result);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   auto H = result->getPayload().getHandle();
   EXPECT_NEAR(H.at({0, 0, 0}), 27, 0.001);
@@ -178,7 +178,7 @@ TEST_P(Operator, ParallelBatchMatMul) {
   F_->createSave("save", R, result);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   auto H = result->getPayload().getHandle();
   EXPECT_NEAR(H.at({0, 0, 0}), 27, 0.001);
@@ -199,7 +199,7 @@ TEST_P(Operator, batchedReduceAdd) {
   F_->createSave("save", R, result);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   auto H = result->getPayload().getHandle();
   EXPECT_NEAR(H.at({0}), 11, 0.001);
@@ -218,7 +218,7 @@ TEST_P(InterpAndCPU, batchedReduceAddWithAxis) {
   F_->createSave("save", R, result);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   auto H = result->getPayload().getHandle();
   EXPECT_NEAR(H.at({0, 0}), 6, 0.001);
@@ -249,7 +249,7 @@ TEST_P(InterpAndCPU, batchedReduceAddQuantized) {
   F_->createSave("save", R, result);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   for (size_t i = 0; i < 8; i++) {
     std::array<int32_t, 3> b{{BH.at({0, i}), BH.at({1, i}), BH.at({2, i})}};
@@ -283,7 +283,7 @@ TEST_P(InterpAndCPU, batchedReduceAddQuantizedWithAxis) {
   F_->createSave("save", R, result);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   for (size_t i = 0; i < 2; i++) {
     for (size_t j = 0; j < 4; j++) {
@@ -309,7 +309,7 @@ TEST_P(Operator, batchedReduceMean) {
   F_->createSave("save", R, result);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   auto H = result->getPayload().getHandle();
   EXPECT_NEAR(H.at({0}), 5.5, 0.001);
@@ -328,7 +328,7 @@ TEST_P(InterpAndCPU, batchedReduceMeanWithAxis) {
   F_->createSave("save", R, result);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   auto H = result->getPayload().getHandle();
   EXPECT_NEAR(H.at({0, 0}), 2.0, 0.001);
@@ -359,7 +359,7 @@ TEST_P(InterpAndCPU, batchedReduceMeanQuantized) {
   F_->createSave("save", R, result);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   for (size_t i = 0; i < 8; i++) {
     std::array<int32_t, 3> b{{BH.at({0, i}), BH.at({1, i}), BH.at({2, i})}};
@@ -393,7 +393,7 @@ TEST_P(InterpAndCPU, batchedReduceMeanQuantizedWithAxis) {
   F_->createSave("save", R, result);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   for (size_t i = 0; i < 2; i++) {
     for (size_t j = 0; j < 4; j++) {
@@ -422,7 +422,7 @@ TEST_P(Operator, batchedBatchedAdd) {
   F_->createSave("save", R, result);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   auto H = result->getPayload().getHandle();
   EXPECT_NEAR(H.at({0, 0, 0}), 10, 0.001);
@@ -463,7 +463,7 @@ TEST_P(InterpAndCPU, broadcastSimple) {
   F_->createSave("saveQ", QR, broadcastedQ);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   auto broadcastedBHandle = broadcasted->getPayload().getHandle();
   auto broadcastedQBHandle = broadcastedQ->getPayload().getHandle<int8_t>();
@@ -524,7 +524,7 @@ TEST_P(InterpAndCPU, broadcast) {
   F_->createSave("saveQ", QR, broadcastedQ);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   auto broadcastedBHandle = broadcasted->getPayload().getHandle();
   auto broadcastedQBHandle = broadcastedQ->getPayload().getHandle<int8_t>();
@@ -573,7 +573,7 @@ TEST_P(Operator, weightedSum) {
   auto *save = F_->createSave("save", WS);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   // Verify the weighted sum was correctly calculated.
   auto resultH = save->getVariable()->getHandle();
@@ -596,7 +596,7 @@ TEST_P(Operator, minElem) {
   RHS->getHandle().randomize(-10, 10, PRNG);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   auto resultH = save->getVariable()->getHandle();
   auto LHSH = LHS->getHandle();
@@ -623,7 +623,7 @@ TEST_P(Operator, TopK) {
 
   EE_.compile(CompilationMode::Infer, F_);
 
-  EE_.run({}, {});
+  EE_.run();
 
   auto V = values->getPayload().getHandle();
   auto I = indices->getPayload().getHandle<int64_t>();
@@ -675,7 +675,7 @@ TEST_P(InterpAndCPU, ConcatTopK) {
 
   EE_.compile(CompilationMode::Infer, F_);
 
-  EE_.run({}, {});
+  EE_.run();
 
   auto V = values->getPayload().getHandle();
   auto I = indices->getPayload().getHandle<int64_t>();
@@ -736,7 +736,7 @@ TEST_P(Operator, matMul) {
 
   EE_.compile(CompilationMode::Infer, F_);
 
-  EE_.run({}, {});
+  EE_.run();
 
   auto R0 = res0->getPayload().getHandle();
   auto R1 = res1->getPayload().getHandle();
@@ -767,7 +767,7 @@ TEST_P(InterpAndCPU, TopK1) {
 
   EE_.compile(CompilationMode::Infer, F_);
 
-  EE_.run({}, {});
+  EE_.run();
 
   auto V = values->getPayload().getHandle();
   auto I = indices->getPayload().getHandle<int64_t>();
@@ -798,7 +798,7 @@ TEST_P(InterpAndCPU, QuantizedTopK) {
 
   EE_.compile(CompilationMode::Infer, F_);
 
-  EE_.run({}, {});
+  EE_.run();
 
   auto VH = OV->getPayload().getHandle<int8_t>();
   auto IH = IV->getPayload().getHandle<int64_t>();
@@ -867,7 +867,7 @@ TEST_P(Operator, Gather) {
   F_->createSave("save", R, result);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   auto H = result->getPayload().getHandle();
 
@@ -901,7 +901,7 @@ TEST_P(Operator, Transpose2Dims) {
   auto *tr = F_->createTranspose("tr", A, {1, 0});
   auto *result = F_->createSave("saveTranspose", tr);
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
   Tensor dest(ElemKind::FloatTy, {13, 20});
   A->getPayload().transpose(&dest, {1, 0});
   EXPECT_TRUE(result->getVariable()->getPayload().isEqual(dest));
@@ -943,7 +943,7 @@ TEST_P(Operator, Transpose3Dims) {
   EXPECT_EQ(6, nbOfShuffle);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   for (int i = 0; i < 6; ++i) {
     Tensor dest(ElemKind::FloatTy, {dims[shuffles[i][0]], dims[shuffles[i][1]],
@@ -996,7 +996,7 @@ TEST_P(InterpAndCPU, GatherSizeT) {
   F_->createSave("save", R, result);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   auto H = result->getPayload().getHandle<int64_t>();
 
@@ -1053,7 +1053,7 @@ TEST_P(Operator, BatchedGather) {
   F_->createSave("save", R, result);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   auto H = result->getPayload().getHandle();
   EXPECT_FLOAT_EQ(H.at({0, 0}), 1.0);
@@ -1079,7 +1079,7 @@ TEST_P(Operator, ScatterAssign) {
   F_->createSave("save", R, result);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   auto H = result->getPayload().getHandle();
 
@@ -1119,7 +1119,7 @@ TEST_P(InterpAndCPU, ScatterAssignQuantized) {
   F_->createSave("save", DQ, result);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   auto H = result->getPayload().getHandle();
 
@@ -1153,7 +1153,7 @@ TEST_P(Operator, QuantizeAndDequantize) {
   auto *fpResult = F_->createSave("fpSave", fpAdd);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   EXPECT_TRUE(result->getVariable()->getPayload().isEqual(
       fpResult->getVariable()->getPayload()));
@@ -1188,7 +1188,7 @@ TEST_P(Operator, IntMatMul) {
   F_->createSave("save", rq, res);
   EE_.compile(CompilationMode::Infer, F_);
 
-  EE_.run({}, {});
+  EE_.run();
 
   /*
    Test the following matrix multiplication:
@@ -1236,7 +1236,7 @@ TEST_P(InterpAndCPU, IntBatchedArith) {
   F_->createSave("save", rq, res);
   EE_.compile(CompilationMode::Infer, F_);
 
-  EE_.run({}, {});
+  EE_.run();
 
   // A = [8.7, 6.5, 4.3, 2.1, 1.0, -5.1, -4.0, -12.0, 0.2]
   // B = [-9.1, -0.4, 1.3, 2.2, -8.1, 7.6, -6.4, 10.0, 9.1]
@@ -1296,7 +1296,7 @@ void checkIntConvolution(ExecutionEngine &EE, unsigned convDepth) {
 
   F->createSave("save", sub, res);
   EE.compile(CompilationMode::Infer, F);
-  EE.run({}, {});
+  EE.run();
   auto H = res->getPayload().getHandle();
 
   // Check that the difference in the results is less than 0.1.
@@ -1331,7 +1331,7 @@ TEST_P(InterpAndCPU, IntConcat) {
 
   auto res = F_->createSave("save", sub);
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   auto R = res->getVariable()->getHandle();
   // Check that the difference in the results is less than 0.2.
@@ -1375,7 +1375,7 @@ TEST_P(InterpAndCPU, IntFC) {
 
   F_->createSave("save", sub, res);
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   auto H = res->getPayload().getHandle();
   // Check that there aren't too many elements with a difference in the results
@@ -1399,7 +1399,7 @@ TEST_P(InterpAndCPU, EntropyLossTest) {
   auto *ceLoss = F_->createCrossEntropyLoss("CELoss", P, Y);
   F_->createSave("save", ceLoss, L);
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
   auto R = L->getPayload().getHandle();
   EXPECT_NEAR(R.at({0}), -log(0.5) - log(0.3), 0.1);
 }
@@ -1424,7 +1424,7 @@ TEST_P(Operator, RescaleNode) {
 
   F_->createSave("save", Z, output);
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   auto RI = input->getPayload().getHandle<int8_t>();
   auto RO = output->getPayload().getHandle<int8_t>();
@@ -1527,7 +1527,7 @@ TEST_P(InterpAndCPU, QuantizedArithmeticRescaled) {
   F_->createSave("saveDiv", div, O6);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   for (size_t i = 0; i < len; i++) {
     auto max = std::max(AH.at({i}), BH.at({i}));
@@ -1562,7 +1562,7 @@ TEST_P(Operator, QuantizedTranspose) {
   auto *fpTr = F_->createTranspose("fpTr", A, {1, 0});
   auto *fpResult = F_->createSave("fpRet", fpTr);
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
   EXPECT_TRUE(result->getVariable()->getPayload().isEqual(B->getPayload()));
   EXPECT_TRUE(fpResult->getVariable()->getPayload().isEqual(B->getPayload()));
 }
@@ -1642,7 +1642,7 @@ TEST_P(Operator, QuantizedArithmeticUnrescaled) {
   F_->createSave("saveDiv", div, O6);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   for (size_t i = 0; i < len; i++) {
     float a = TQA->getScale() * (QAH.at({i}) - TQA->getOffset());
@@ -1708,7 +1708,7 @@ TEST_P(InterpAndCPU, QuantizedCmpLTEAndSelect) {
   F_->createSave("save", select, Out);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   int count_strict = 0;
   int count = 0;
@@ -1771,7 +1771,7 @@ TEST_P(Operator, TestQuantizedRescaleSequence) {
   // Test a sequence of rescale operations t
   F_->createSave("save", DQ, O);
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   for (size_t i = 0; i < len; i++) {
     EXPECT_NEAR(AH.at({i}), OH.at({i}), 1.0);
@@ -1843,7 +1843,9 @@ TEST_P(InterpAndCPU, concatVectors) {
   EE_.compile(CompilationMode::Infer, F_);
 
   // Testing the output vector.
-  EE_.run({V1, V2, V3}, {&I1, &I2, &I3});
+  EE_.updateVariables({V1, V2, V3}, {&I1, &I2, &I3});
+  EE_.run();
+
   auto RNWH = result->getVariable()->getPayload().getHandle<int64_t>();
   (void)RNWH;
 
@@ -1881,7 +1883,9 @@ TEST_P(InterpAndCPU, concatVectorsRepeated) {
   EE_.compile(CompilationMode::Infer, F_);
 
   // Testing the output vector.
-  EE_.run({V1, V2}, {&I1, &I2});
+  EE_.updateVariables({V1, V2}, {&I1, &I2});
+  EE_.run();
+
   auto outH = result->getVariable()->getPayload().getHandle<int64_t>();
   (void)outH;
 
@@ -1921,7 +1925,9 @@ TEST_P(InterpAndCPU, sliceVectors) {
   EE_.compile(CompilationMode::Infer, F_);
 
   // Testing the output slices.
-  EE_.run({V}, {&I});
+  EE_.updateVariables({V}, {&I});
+  EE_.run();
+
   auto RNWH1 = result1->getVariable()->getPayload().getHandle<int64_t>();
   (void)RNWH1;
   auto RNWH2 = result2->getVariable()->getPayload().getHandle<int64_t>();
@@ -1976,7 +1982,8 @@ TEST_P(InterpAndCPU, sliceConcatVectors) {
 
   EE_.compile(CompilationMode::Infer, F_);
 
-  EE_.run({V}, {&I});
+  EE_.updateVariables({V}, {&I});
+  EE_.run();
 
   const size_t expected[7][4] = {{300, 301, 302, 303}, {400, 401, 402, 403},
                                  {100, 101, 302, 303}, {200, 201, 402, 403},
@@ -2015,7 +2022,8 @@ TEST_P(InterpAndCPU, Tile) {
 
   EE_.compile(CompilationMode::Infer, F_);
 
-  EE_.run({V}, {&VT});
+  EE_.updateVariables({V}, {&VT});
+  EE_.run();
 
   // Testing the output vector with axis 0.
   auto res0 = result0->getVariable()->getHandle<float>();
@@ -2063,7 +2071,8 @@ TEST_P(InterpAndCPU, QuantizedTile) {
 
   EE_.compile(CompilationMode::Infer, F_);
 
-  EE_.run({V}, {&VT});
+  EE_.updateVariables({V}, {&VT});
+  EE_.run();
 
   // Testing the output vector with axis 0.
   auto res0 = result0->getVariable()->getHandle<float>();
@@ -2112,7 +2121,7 @@ TEST_P(Operator, simpleCmpSelectPredication) {
   auto *SN = F_->createSave("ret", data);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   auto H = SN->getVariable()->getHandle();
   ASSERT_NEAR(H.at(0), 1, 0.001);
@@ -2151,7 +2160,7 @@ TEST_P(Operator, simplePredication) {
   FC2->setPredicate(pred);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 }
 
 TEST_P(InterpAndCPU, ChannelShuffle) {
@@ -2164,7 +2173,7 @@ TEST_P(InterpAndCPU, ChannelShuffle) {
   SaveNode *S = F_->createSave("save", CS);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   auto results = llvm::cast<Variable>(S->getOutput())->getPayload().getHandle();
 
@@ -2186,7 +2195,7 @@ TEST_P(Operator, Squeeze) {
     SaveNode *S = F_->createSave("save", SQZ);
 
     EE_.compile(CompilationMode::Infer, F_);
-    EE_.run({}, {});
+    EE_.run();
 
     auto results = S->getVariable()->getHandle();
     std::vector<size_t> expectedDims = {2, 1, 5};
@@ -2202,7 +2211,7 @@ TEST_P(Operator, Squeeze) {
     SaveNode *S = F_->createSave("save", SQZ);
 
     EE_.compile(CompilationMode::Infer, F_);
-    EE_.run({}, {});
+    EE_.run();
 
     auto results = S->getVariable()->getHandle();
     std::vector<size_t> expectedDims = {2, 5};
@@ -2224,7 +2233,7 @@ TEST_P(Operator, Squeeze) {
     SaveNode *S2 = F_->createSave("save", UnSQZ);
 
     EE_.compile(CompilationMode::Infer, F_);
-    EE_.run({}, {});
+    EE_.run();
 
     auto res1 = S1->getVariable()->getHandle();
     EXPECT_TRUE(res1.dims().vec() == std::vector<size_t>());
@@ -2248,7 +2257,7 @@ TEST_P(Operator, ExpandDims) {
   SaveNode *S = F_->createSave("save", EDN);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   // Expected dims based on the axes above; inserted new dimensions of 1 in
   // every unique axes location, based on the output tensor shape.
@@ -2278,7 +2287,7 @@ TEST_P(InterpAndCPU, Split) {
   auto S4 = F_->createSave("save4", outputs2[1]);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   auto result = S1->getVariable()->getHandle();
   EXPECT_EQ(result.dims().vec(), std::vector<size_t>({1, 2, 3}));
@@ -2338,7 +2347,7 @@ TEST_P(Operator, IntRelu) {
 
   auto *save = F_->createSave("save", dequantize);
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   auto result = save->getVariable()->getHandle();
   float expectedValue = std::max(0.0f, splatValue);
@@ -2359,7 +2368,7 @@ TEST_P(Operator, IntSplat) {
 
   auto *save = F_->createSave("save", dequantize);
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   auto result = save->getVariable()->getHandle();
   for (size_t i = 0; i < result.size(); i++) {
@@ -2391,7 +2400,7 @@ TEST_P(Operator, GroupConvolution) {
   SaveNode *S = F_->createSave("save", CN);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   auto result = llvm::cast<Variable>(S->getOutput())->getPayload().getHandle();
 
@@ -2438,7 +2447,7 @@ TEST_P(Operator, NonSquarePaddingConvolution) {
                                        {2, 2}, {1, 1}, {0, 2, 1, 3}, 1);
   SaveNode *S = F_->createSave("save", CN);
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
   Tensor &result = S->getVariable()->getPayload();
 
   // Create the reference conv operator whose input is the same as the
@@ -2456,7 +2465,7 @@ TEST_P(Operator, NonSquarePaddingConvolution) {
                         {1, 1}, {0, 0, 0, 0}, 1);
   S = refF->createSave("save1", CN);
   EE_.compile(CompilationMode::Infer, refF);
-  EE_.run({}, {});
+  EE_.run();
   Tensor &result1 = S->getVariable()->getPayload();
 
   EXPECT_TRUE(result.isEqual(result1));
@@ -2475,7 +2484,7 @@ TEST_P(Operator, NonSquarePaddingAveragePool) {
   auto *Pool = F_->createAvgPool("pool", input, {2, 2}, {1, 1}, {0, 2, 1, 3});
   auto *S = F_->createSave("save", Pool);
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
   Tensor &result = S->getVariable()->getPayload();
 
   auto *input1 = mod_.createVariable(ElemKind::FloatTy, {1, 5, 9, 1}, "input1");
@@ -2490,7 +2499,7 @@ TEST_P(Operator, NonSquarePaddingAveragePool) {
   Pool = refF->createAvgPool("pool1", input1, 2, 1, 0);
   S = refF->createSave("save1", Pool);
   EE_.compile(CompilationMode::Infer, refF);
-  EE_.run({}, {});
+  EE_.run();
   Tensor &result1 = S->getVariable()->getPayload();
 
   EXPECT_TRUE(result.isEqual(result1));
@@ -2509,7 +2518,7 @@ TEST_P(Operator, NonSquarePaddingMaxPool) {
   auto *Pool = F_->createMaxPool("pool", input, {2, 2}, {1, 1}, {0, 2, 1, 3});
   auto *S = F_->createSave("save", Pool);
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
   Tensor &result = S->getVariable()->getPayload();
 
   auto *input1 = mod_.createVariable(ElemKind::FloatTy, {1, 5, 9, 1}, "input1");
@@ -2524,7 +2533,7 @@ TEST_P(Operator, NonSquarePaddingMaxPool) {
   Pool = refF->createMaxPool("pool1", input1, 2, 1, 0);
   S = refF->createSave("save1", Pool);
   EE_.compile(CompilationMode::Infer, refF);
-  EE_.run({}, {});
+  EE_.run();
   Tensor &result1 = S->getVariable()->getPayload();
 
   EXPECT_TRUE(result.isEqual(result1));
@@ -2537,7 +2546,7 @@ TEST_P(Operator, Int8AvgPool) {
   auto *Pool = F_->createAvgPool("pool", input, {2, 2}, {1, 1}, {0, 0, 0, 0});
   auto *S = F_->createSave("save", Pool);
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
   auto result = S->getVariable()->getHandle<int8_t>();
   Tensor out(ElemKind::Int8QTy, {2, 2}, 1, 0);
   out.getHandle<int8_t>() = {2, 3, 5, 6};
@@ -2553,7 +2562,7 @@ TEST_P(Operator, Int8MaxPool) {
   auto *Pool = F_->createMaxPool("pool", input, {2, 2}, {1, 1}, {0, 0, 0, 0});
   auto *S = F_->createSave("save", Pool);
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
   auto result = S->getVariable()->getHandle<int8_t>();
   Tensor out(ElemKind::Int8QTy, {2, 2}, 1, 0);
   out.getHandle<int8_t>() = {4, 5, 7, 8};
@@ -2587,7 +2596,7 @@ TEST_P(InterpAndCPU, Int8Tanh) {
   auto *saveInt = F_->createSave("int8Save", dequantize);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   auto fpResult = saveFp->getVariable()->getHandle();
   auto intResult = saveInt->getVariable()->getHandle();
@@ -2621,7 +2630,7 @@ TEST_P(Operator, NonSquareKernelConvolution) {
                                        {2, 3}, {1, 1}, {0, 0, 0, 0}, 1);
   SaveNode *S = F_->createSave("save", CN);
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
   Tensor &result = S->getVariable()->getPayload();
 
   static const float ref[] = {106, 127, 190, 211, 274, 295};
@@ -2639,7 +2648,7 @@ TEST_P(InterpAndCPU, NonSquareKernelAveragePool) {
   auto *Pool = F_->createAvgPool("pool", input, {2, 3}, {1, 1}, {0, 0, 0, 0});
   auto *S = F_->createSave("save", Pool);
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
   Tensor &result = S->getVariable()->getPayload();
 
   static const float ref[] = {4, 5, 8, 9, 12, 13};
@@ -2657,7 +2666,7 @@ TEST_P(InterpAndCPU, NonSquareKernelMaxPool) {
   auto *Pool = F_->createMaxPool("pool", input, {2, 3}, {1, 1}, {0, 0, 0, 0});
   auto *S = F_->createSave("save", Pool);
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
   Tensor &result = S->getVariable()->getPayload();
 
   static const float ref[] = {7, 8, 11, 12, 15, 16};
@@ -2689,7 +2698,7 @@ TEST_P(Operator, NonSquareStrideConvolution) {
                                        {2, 2}, {3, 2}, {0, 0, 1, 1}, 1);
   SaveNode *S = F_->createSave("save", CN);
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
   Tensor &result = S->getVariable()->getPayload();
 
   static const float ref[] = {44, 64, 41, 47};
@@ -2707,7 +2716,7 @@ TEST_P(InterpAndCPU, NonSquareStrideAveragePool) {
   auto *Pool = F_->createAvgPool("pool", input, {2, 2}, {3, 2}, {0, 0, 1, 1});
   auto *S = F_->createSave("save", Pool);
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
   Tensor &result = S->getVariable()->getPayload();
 
   static const float ref[] = {3.5, 5.5, 6.75, 7.75};
@@ -2725,7 +2734,7 @@ TEST_P(InterpAndCPU, NonSquareStrideMaxPool) {
   auto *Pool = F_->createMaxPool("pool", input, {2, 2}, {3, 2}, {0, 0, 1, 1});
   auto *S = F_->createSave("save", Pool);
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
   Tensor &result = S->getVariable()->getPayload();
 
   static const float ref[] = {6, 8, 14, 16};
@@ -2757,7 +2766,7 @@ TEST_P(InterpAndCPU, Int8Sigmoid) {
   auto *saveInt = F_->createSave("int8Save", dequantize);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   auto fpResult = saveFp->getVariable()->getHandle();
   auto intResult = saveInt->getVariable()->getHandle();
@@ -2785,7 +2794,7 @@ TEST_P(InterpAndCPU, IntLookupTable) {
   auto save = F_->createSave("save", lookupTable);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   auto result = save->getVariable()->getHandle<int8_t>();
   for (size_t i = 0; i < size; ++i) {
@@ -2820,7 +2829,7 @@ TEST_P(Operator, testBatchAdd) {
   F_->createSave("save", cc, result);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   auto RH = result->getPayload().getHandle();
   auto IH = input->getPayload().getHandle();
@@ -2873,7 +2882,7 @@ TEST_P(Operator, testQuantizedBatchAdd) {
   adds.clear();
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   auto RH = result->getPayload().getHandle();
   auto IH = input->getPayload().getHandle();
@@ -2924,7 +2933,7 @@ TEST_P(InterpOnly, SparseLengthsSum) {
   auto S = F_->createSave("save", R);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   Tensor &result = llvm::cast<Variable>(S->getOutput())->getPayload();
   Tensor expected(ElemKind::FloatTy, {5, 2});
@@ -2971,7 +2980,7 @@ TEST_P(InterpOnly, SparseLengthsWeightedSum) {
   auto S = F_->createSave("save", R);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   Tensor &result = llvm::cast<Variable>(S->getOutput())->getPayload();
   Tensor expected(ElemKind::FloatTy, {4});
@@ -3018,7 +3027,7 @@ TEST_P(Operator, sliceReshape) {
 
   EE_.compile(CompilationMode::Infer, F_);
 
-  EE_.run({}, {});
+  EE_.run();
 
   // Verify the slice has the same data as the original X.
   auto SXH = resultSX->getPayload().getHandle();
@@ -3104,7 +3113,7 @@ TEST_P(Operator, Flatten) {
 
   EE_.compile(CompilationMode::Infer, F_);
 
-  EE_.run({}, {});
+  EE_.run();
 
   // Verify the reshapes have the same data as the original value.
   auto tensor4DH = tensor4D->getPayload().getHandle();
@@ -3151,7 +3160,7 @@ TEST_P(InterpAndCPU, DivSizeT) {
   F_->createSave("save", R, result);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   auto H = result->getPayload().getHandle<int64_t>();
 
@@ -3203,7 +3212,7 @@ TEST_P(InterpAndCPU, SigmoidCrossEntropyWithLogits) {
   F_->createSave("save", R, result);
 
   EE_.compile(CompilationMode::Infer, F_);
-  EE_.run({}, {});
+  EE_.run();
 
   Tensor expected(ElemKind::FloatTy, {2, 2});
   expected.getHandle() = {

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -1807,7 +1807,7 @@ TEST_P(Operator, FCGradientCheck) {
 
   Function *DF = glow::differentiate(F_, TC, "d_main");
   EE_.compile(CompilationMode::Train, DF);
-  EE_.runBatch(3, {A, B}, {&initA, &initB});
+  runBatch(EE_, 3, {A, B}, {&initA, &initB});
 
   EXPECT_NEAR(X->getPayload().getHandle().raw(0), -0.21294, 1E-5);
   EXPECT_NEAR(Y->getPayload().getHandle().raw(0), 0.01656, 1E-5);
@@ -1843,7 +1843,7 @@ TEST_P(InterpAndCPU, concatVectors) {
   EE_.compile(CompilationMode::Infer, F_);
 
   // Testing the output vector.
-  EE_.updateVariables({V1, V2, V3}, {&I1, &I2, &I3});
+  updateVariables({V1, V2, V3}, {&I1, &I2, &I3});
   EE_.run();
 
   auto RNWH = result->getVariable()->getPayload().getHandle<int64_t>();
@@ -1883,7 +1883,7 @@ TEST_P(InterpAndCPU, concatVectorsRepeated) {
   EE_.compile(CompilationMode::Infer, F_);
 
   // Testing the output vector.
-  EE_.updateVariables({V1, V2}, {&I1, &I2});
+  updateVariables({V1, V2}, {&I1, &I2});
   EE_.run();
 
   auto outH = result->getVariable()->getPayload().getHandle<int64_t>();
@@ -1925,7 +1925,7 @@ TEST_P(InterpAndCPU, sliceVectors) {
   EE_.compile(CompilationMode::Infer, F_);
 
   // Testing the output slices.
-  EE_.updateVariables({V}, {&I});
+  updateVariables({V}, {&I});
   EE_.run();
 
   auto RNWH1 = result1->getVariable()->getPayload().getHandle<int64_t>();
@@ -1982,7 +1982,7 @@ TEST_P(InterpAndCPU, sliceConcatVectors) {
 
   EE_.compile(CompilationMode::Infer, F_);
 
-  EE_.updateVariables({V}, {&I});
+  updateVariables({V}, {&I});
   EE_.run();
 
   const size_t expected[7][4] = {{300, 301, 302, 303}, {400, 401, 402, 403},
@@ -2022,7 +2022,7 @@ TEST_P(InterpAndCPU, Tile) {
 
   EE_.compile(CompilationMode::Infer, F_);
 
-  EE_.updateVariables({V}, {&VT});
+  updateVariables({V}, {&VT});
   EE_.run();
 
   // Testing the output vector with axis 0.
@@ -2071,7 +2071,7 @@ TEST_P(InterpAndCPU, QuantizedTile) {
 
   EE_.compile(CompilationMode::Infer, F_);
 
-  EE_.updateVariables({V}, {&VT});
+  updateVariables({V}, {&VT});
   EE_.run();
 
   // Testing the output vector with axis 0.

--- a/tests/unittests/caffe2ImporterTest.cpp
+++ b/tests/unittests/caffe2ImporterTest.cpp
@@ -44,7 +44,7 @@ TEST(caffe2, importConv) {
   }
 
   EE.compile(CompilationMode::Infer, F);
-  EE.run({}, {});
+  EE.run();
   auto result = output->getHandle();
   std::vector<size_t> expectedDims = {1, 1, 4, 4};
   std::vector<float> expectedValues = {2,  3,  5,  4,  5, 10, 14, 9,
@@ -96,7 +96,7 @@ TEST(caffe2, concatAddAxis) {
   EXPECT_TRUE(result.dims().vec() == expectedDims);
 
   EE.compile(CompilationMode::Infer, F);
-  EE.run({}, {});
+  EE.run();
   // High level check on the content of the graph.
   // We have 1 reshape, 1 concat, and 1 save.
   EXPECT_EQ(F->getNodes().size(), 3);
@@ -165,7 +165,7 @@ TEST(caffe2, concat) {
   EXPECT_TRUE(result.dims().vec() == expectedDims);
 
   EE.compile(CompilationMode::Infer, F);
-  EE.run({}, {});
+  EE.run();
   // High level check on the content of the graph.
   // We have 1 concat, and 1 save.
   EXPECT_EQ(F->getNodes().size(), 2);

--- a/tests/unittests/graphTest.cpp
+++ b/tests/unittests/graphTest.cpp
@@ -440,7 +440,7 @@ TEST(Graph, nodesWithPredicates) {
   F->createSave("ret", SM);
 
   EE.compile(CompilationMode::Infer, F);
-  EE.updateVariables({input}, {&inputs});
+  updateVariables({input}, {&inputs});
   EE.run();
 }
 

--- a/tests/unittests/graphTest.cpp
+++ b/tests/unittests/graphTest.cpp
@@ -383,7 +383,7 @@ TEST(Graph, NodeValue) {
   auto S = F->createSave("Save", a);
 
   EE.compile(CompilationMode::Infer, F);
-  EE.run({}, {});
+  EE.run();
 
   EXPECT_EQ(
       llvm::cast<Variable>(S->getOutput())->getPayload().getHandle().raw(0),
@@ -440,7 +440,8 @@ TEST(Graph, nodesWithPredicates) {
   F->createSave("ret", SM);
 
   EE.compile(CompilationMode::Infer, F);
-  EE.run({input}, {&inputs});
+  EE.updateVariables({input}, {&inputs});
+  EE.run();
 }
 
 // Return the number of ConvolutionNode after lower.
@@ -513,7 +514,7 @@ TEST(Graph, schedulingOfSavesOrderProvided) {
   Tensor AOrig = A->getPayload().clone();
 
   EE.compile(CompilationMode::Infer, F);
-  EE.run({}, {});
+  EE.run();
   auto *ret = saveNode->getVariable();
   auto handleAOrig = AOrig.getHandle<>();
   auto handleB = B->getPayload().getHandle<>();
@@ -557,7 +558,7 @@ TEST(Graph, schedulingOfSaves) {
   Tensor AOrig = A->getPayload().clone();
 
   EE.compile(CompilationMode::Infer, F);
-  EE.run({}, {});
+  EE.run();
   auto *ret = saveNode->getVariable();
   auto handleAOrig = AOrig.getHandle<>();
   auto handleB = B->getHandle<>();

--- a/tests/unittests/onnxImporterTest.cpp
+++ b/tests/unittests/onnxImporterTest.cpp
@@ -67,7 +67,7 @@ TEST(onnx, importConv) {
   EXPECT_TRUE(tFilterNode->getKind() == Kinded::Kind::TransposeNodeKind);
 
   EE.compile(CompilationMode::Infer, F);
-  EE.run({}, {});
+  EE.run();
   auto result = graphOutputVar->getHandle();
   std::vector<size_t> expectedDims = {1, 1, 4, 4};
   std::vector<float> expectedValues = {2,  3,  5,  4,  5, 10, 14, 9,

--- a/tests/unittests/partitionTest.cpp
+++ b/tests/unittests/partitionTest.cpp
@@ -40,7 +40,8 @@ static void executeSerial(const FunctionDAG &G, llvm::ArrayRef<Variable *> vars,
   for (auto *F : G.getFunctions()) {
     ExecutionEngine EE;
     EE.compile(CompilationMode::Infer, F);
-    EE.run(vars, inputs);
+    EE.updateVariables(vars, inputs);
+    EE.run();
   }
 }
 
@@ -98,7 +99,8 @@ TEST_F(PartitionTest, SerialExecution) {
   Tensor in(ElemKind::FloatTy, {1, 32});
   ExecutionEngine EE;
   EE.compile(CompilationMode::Infer, F_);
-  EE.run({input}, {&in});
+  EE.updateVariables({input}, {&in});
+  EE.run();
   Tensor ref = res.clone();
 
   // Infer using the partitioned graph.
@@ -140,7 +142,8 @@ TEST_F(PartitionTest, Branchover) {
   Tensor in(ElemKind::FloatTy, {1, 8});
   ExecutionEngine EE;
   EE.compile(CompilationMode::Infer, F_);
-  EE.run({input}, {&in});
+  EE.updateVariables({input}, {&in});
+  EE.run();
   Tensor ref = res.clone();
 
   // Infer using the partitioned graph.

--- a/tests/unittests/partitionTest.cpp
+++ b/tests/unittests/partitionTest.cpp
@@ -40,7 +40,7 @@ static void executeSerial(const FunctionDAG &G, llvm::ArrayRef<Variable *> vars,
   for (auto *F : G.getFunctions()) {
     ExecutionEngine EE;
     EE.compile(CompilationMode::Infer, F);
-    EE.updateVariables(vars, inputs);
+    updateVariables(vars, inputs);
     EE.run();
   }
 }
@@ -99,7 +99,7 @@ TEST_F(PartitionTest, SerialExecution) {
   Tensor in(ElemKind::FloatTy, {1, 32});
   ExecutionEngine EE;
   EE.compile(CompilationMode::Infer, F_);
-  EE.updateVariables({input}, {&in});
+  updateVariables({input}, {&in});
   EE.run();
   Tensor ref = res.clone();
 
@@ -142,7 +142,7 @@ TEST_F(PartitionTest, Branchover) {
   Tensor in(ElemKind::FloatTy, {1, 8});
   ExecutionEngine EE;
   EE.compile(CompilationMode::Infer, F_);
-  EE.updateVariables({input}, {&in});
+  updateVariables({input}, {&in});
   EE.run();
   Tensor ref = res.clone();
 

--- a/tests/unittests/quantizationTest.cpp
+++ b/tests/unittests/quantizationTest.cpp
@@ -135,7 +135,7 @@ TEST(Quantization, quantizeGraph) {
 
   // Make sure that graph can be compiled and run.
   EE.compile(CompilationMode::Infer, F);
-  EE.run({}, {});
+  EE.run();
 }
 
 /// Quantize ReLU node and make sure that quantized version
@@ -243,7 +243,7 @@ TEST_P(Operator, end2end) {
   interpreterEE.compile(CompilationMode::Infer, F1);
 
   // Run graph to capture profile.
-  interpreterEE.run({}, {});
+  interpreterEE.run();
 
   // Get quantization infos and build new quantized graph.
   std::vector<NodeQuantizationInfo> QI =
@@ -254,7 +254,7 @@ TEST_P(Operator, end2end) {
 
   F2 = quantization::quantizeFunction(backendSpecificEE, QI, F2);
   backendSpecificEE.compile(CompilationMode::Infer, F2);
-  backendSpecificEE.run({}, {});
+  backendSpecificEE.run();
 
   // STEP3 - Compare the results of the original and quantized functions.
   auto result1Handle = result1->getVariable()->getHandle();
@@ -378,7 +378,7 @@ TEST_P(Operator, end2endGRU) {
   interpreterEE.compile(CompilationMode::Infer, F1);
 
   // Run graph to capture profile.
-  interpreterEE.run({}, {});
+  interpreterEE.run();
 
   // Get quantization infos and build new quantized graph.
   std::vector<NodeQuantizationInfo> QI =
@@ -389,7 +389,7 @@ TEST_P(Operator, end2endGRU) {
 
   F2 = quantization::quantizeFunction(backendSpecificEE, QI, F2);
   backendSpecificEE.compile(CompilationMode::Infer, F2);
-  backendSpecificEE.run({}, {});
+  backendSpecificEE.run();
 
   // STEP3 - Compare the results of the original and quantized functions.
   auto result1Handle = result1->getVariable()->getHandle();
@@ -421,7 +421,7 @@ TEST(Quantization, rescaleSameType) {
 
   EXPECT_EQ(F->getNodes().size(), 3);
   EE.compile(CompilationMode::Infer, F);
-  EE.run({}, {});
+  EE.run();
   EXPECT_EQ(F->getNodes().size(), 2);
 
   auto RH = result->getVariable()->getHandle();
@@ -445,7 +445,7 @@ TEST(Quantization, optimizeRescaleQuantize) {
 
   EXPECT_EQ(F->getNodes().size(), 4);
   EE.compile(CompilationMode::Infer, F);
-  EE.run({}, {});
+  EE.run();
   EXPECT_EQ(F->getNodes().size(), 1);
 
   auto RH = result->getVariable()->getHandle();
@@ -698,7 +698,7 @@ TEST(Quantization, quantizeGraphPartially) {
 
   // Make sure that graph can be compiled and run.
   EE.compile(CompilationMode::Infer, F);
-  EE.run({}, {});
+  EE.run();
 
   {
     // Verify that the output variable is not quantized, and that it has a
@@ -777,7 +777,7 @@ TEST(Quantization, quantizeGraphPartiallyMultipleNodes) {
 
   // Make sure that graph can be compiled and run.
   EE.compile(CompilationMode::Infer, F);
-  EE.run({}, {});
+  EE.run();
 
   {
     // Verify that the output variable is not quantized, and that it has a
@@ -866,7 +866,7 @@ TEST(Quantization, quantizeGraphPartiallyMultipleKinds) {
 
   // Make sure that graph can be compiled and run.
   EE.compile(CompilationMode::Infer, F);
-  EE.run({}, {});
+  EE.run();
 
   {
     // Verify that the output variable is not quantized, and that it has a

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -277,7 +277,7 @@ void Loader::runInference(llvm::ArrayRef<Variable *> variables,
     timer.startTimer();
   }
   for (unsigned i = 0; i < iterationsOpt; i++) {
-    EE_.updateVariables(variables, tensors);
+    updateVariables(variables, tensors);
     EE_.run();
   }
   if (timeOpt) {

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -277,7 +277,8 @@ void Loader::runInference(llvm::ArrayRef<Variable *> variables,
     timer.startTimer();
   }
   for (unsigned i = 0; i < iterationsOpt; i++) {
-    EE_.run(variables, tensors);
+    EE_.updateVariables(variables, tensors);
+    EE_.run();
   }
   if (timeOpt) {
     timer.stopTimer();


### PR DESCRIPTION
*Description*:

This PR refactors the execution engine and removes all of the logic that is responsible for updating variables into external helper functions. It does not make sense for the execution engine, that managed the lifetime of the compiled function to also update variables, and once we migrate to placeholders we won't be able to rely on the execution engine to update the variables/placeholders for us, because they won't be tied to the run() method. 

This change removes the runBatch() method and keeps a simple run() method. All of the variable changes happen before the execution happens. This is the API change for the unit tests:

Before:

    EE.run({var1, var2}, {inputs1, inputs2});	 

After:

    updateVariables({var1, var2}, {inputs1, inputs2});
    EE.run();

*Testing*: I ran "ninja check", the mnist training test and the run.sh inference test.
*Documentation*: Updated doxygen. 
