### PR TITLE
[Placeholder] Allow executing Placeholders in the execution engine.

### DIFF
--- a/include/glow/Backends/Backend.h
+++ b/include/glow/Backends/Backend.h
@@ -39,9 +39,12 @@ public:
   /// Dtor.
   virtual ~Backend() = default;
 
-  /// Generate code for input function \param IR.
+  /// Generate code for input function \param IR. \p placeholders is a list of
+  /// Placeholders that are mapped to the concrete input tensor for the
+  /// specific function.
   virtual std::unique_ptr<CompiledFunction>
-  compile(std::unique_ptr<IRFunction> IR) const = 0;
+  compile(std::unique_ptr<IRFunction> IR,
+          const PlaceholderMap &placeholders) const = 0;
 
   /// Save the bundle for \p IR for a later standalone execution
   /// in \p outputDir. Make \p networkName the function name for

--- a/include/glow/Backends/CompiledFunction.h
+++ b/include/glow/Backends/CompiledFunction.h
@@ -16,7 +16,15 @@
 #ifndef GLOW_BACKENDS_COMPILEDFUNCTION_H
 #define GLOW_BACKENDS_COMPILEDFUNCTION_H
 
+#include <unordered_map>
+
 namespace glow {
+
+class Placeholder;
+class Tensor;
+
+/// Maps placeholders to the tensors that back them.
+using PlaceholderMap = std::unordered_map<Placeholder *, Tensor *>;
 
 /// Interface for executing a compiled function.
 class CompiledFunction {

--- a/include/glow/ExecutionEngine/ExecutionEngine.h
+++ b/include/glow/ExecutionEngine/ExecutionEngine.h
@@ -67,7 +67,11 @@ public:
 
   /// Optimize the graph, generate IR, optimize IR and compile it for a
   /// specific target. This method should be invoked before the run method.
-  void compile(CompilationMode mode, Function *F);
+  /// The placeholder variables in \p placeholders are mapped to the concrete
+  /// tensor values in the compiled instance of the function.
+  void compile(CompilationMode mode, Function *F,
+               llvm::ArrayRef<Placeholder *> placeholders = {},
+               llvm::ArrayRef<Tensor *> inputs = {});
 
   /// Save a bundle for a standalone execution. This method takes care of
   /// everything when preparing the bundle for saving. There is no need to

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -123,7 +123,8 @@ CPUBackend::createIRGen(IRFunction *IR,
 }
 
 std::unique_ptr<CompiledFunction>
-CPUBackend::compile(std::unique_ptr<IRFunction> IR) const {
+CPUBackend::compile(std::unique_ptr<IRFunction> IR,
+                    const PlaceholderMap &placeholders) const {
   AllocationsInfo allocationsInfo;
   std::unique_ptr<LLVMIRGen> irgen = createIRGen(IR.get(), allocationsInfo);
   irgen->initTargetMachine(target.empty() ? "" : target.getValue(),

--- a/lib/Backends/CPU/CPUBackend.h
+++ b/lib/Backends/CPU/CPUBackend.h
@@ -43,7 +43,8 @@ public:
   ~CPUBackend() override = default;
 
   std::unique_ptr<CompiledFunction>
-  compile(std::unique_ptr<IRFunction> IR) const override;
+  compile(std::unique_ptr<IRFunction> IR,
+          const PlaceholderMap &placeholders) const override;
 
   void save(std::unique_ptr<IRFunction> IR, llvm::StringRef outputDir,
             llvm::StringRef networkName) const override;

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -24,8 +24,9 @@
 using namespace glow;
 
 std::unique_ptr<CompiledFunction>
-Interpreter::compile(std::unique_ptr<IRFunction> IR) const {
-  return llvm::make_unique<InterpreterFunction>(std::move(IR));
+Interpreter::compile(std::unique_ptr<IRFunction> IR,
+                     const PlaceholderMap &placeholders) const {
+  return llvm::make_unique<InterpreterFunction>(std::move(IR), placeholders);
 }
 
 bool Interpreter::isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const {

--- a/lib/Backends/Interpreter/Interpreter.h
+++ b/lib/Backends/Interpreter/Interpreter.h
@@ -35,7 +35,8 @@ public:
   ~Interpreter() override = default;
 
   std::unique_ptr<CompiledFunction>
-  compile(std::unique_ptr<IRFunction> IR) const override;
+  compile(std::unique_ptr<IRFunction> IR,
+          const PlaceholderMap &placeholders) const override;
 
   bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override;
 

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -48,7 +48,8 @@ class InterpreterFunction final : public CompiledFunction {
   std::unordered_map<const Value *, Tensor *> externalTensors_;
 
 public:
-  InterpreterFunction(std::unique_ptr<IRFunction> F);
+  InterpreterFunction(std::unique_ptr<IRFunction> F,
+                      const PlaceholderMap &placeholders);
 
   /// \name CompiledFunction interface
   ///@{

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -1571,6 +1571,7 @@ cl_mem OpenCLFunction::allocDeviceBuffer(uint64_t size) {
 void OpenCLFunction::freeDeviceBuffer(cl_mem buf) { clReleaseMemObject(buf); }
 
 std::unique_ptr<CompiledFunction>
-OCLBackend::compile(std::unique_ptr<IRFunction> IR) const {
+OCLBackend::compile(std::unique_ptr<IRFunction> IR,
+                    const PlaceholderMap &placeholders) const {
   return llvm::make_unique<OpenCLFunction>(std::move(IR));
 }

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -171,7 +171,8 @@ public:
   ~OCLBackend() override = default;
 
   std::unique_ptr<CompiledFunction>
-  compile(std::unique_ptr<IRFunction> IR) const override;
+  compile(std::unique_ptr<IRFunction> IR,
+          const PlaceholderMap &placeholders) const override;
 
   bool transformPostLowering(Function *F, CompilationMode mode) const override;
 

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -169,8 +169,19 @@ std::unique_ptr<IRFunction> ExecutionEngine::generateIR(CompilationMode mode,
   return IR;
 }
 
-void ExecutionEngine::compile(CompilationMode mode, Function *F) {
-  function_ = backend_->compile(generateIR(mode, F));
+void ExecutionEngine::compile(CompilationMode mode, Function *F,
+                              llvm::ArrayRef<Placeholder *> placeholders,
+                              llvm::ArrayRef<Tensor *> inputs) {
+  PlaceholderMap pmap;
+  assert(placeholders.size() == inputs.size() &&
+         "Invalid number of placeholders");
+
+  for (size_t i = 0, e = placeholders.size(); i < e; i++) {
+    pmap[placeholders[i]] = inputs[i];
+  }
+
+  auto IR = generateIR(mode, F);
+  function_ = backend_->compile(std::move(IR), pmap);
 }
 
 void ExecutionEngine::save(CompilationMode mode, Function *F,

--- a/tests/unittests/BackendCorrectnessTest.cpp
+++ b/tests/unittests/BackendCorrectnessTest.cpp
@@ -239,8 +239,9 @@ class MockCPUBackend : public Backend {
 public:
   MockCPUBackend() { backend_.reset(createBackend(BackendKind::CPU)); }
   std::unique_ptr<CompiledFunction>
-  compile(std::unique_ptr<IRFunction> IR) const override {
-    return backend_->compile(std::move(IR));
+  compile(std::unique_ptr<IRFunction> IR,
+          const PlaceholderMap &placeholders) const override {
+    return backend_->compile(std::move(IR), placeholders);
   }
   bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override {
     return true;
@@ -304,7 +305,8 @@ TEST_P(CPUOnly, dataParallelStackingTest) {
   }
 
   MockCPUBackend backend;
-  backend.compile(std::move(M))->execute();
+  PlaceholderMap empty;
+  backend.compile(std::move(M), empty)->execute();
   auto H = var->getHandle();
   EXPECT_EQ(H.at(0), 3);
   EXPECT_EQ(H.at(1), 4);

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -26,7 +26,8 @@ class MockBackend : public Backend {
     void execute() override {}
   };
   std::unique_ptr<CompiledFunction>
-  compile(std::unique_ptr<IRFunction> IR) const override {
+  compile(std::unique_ptr<IRFunction> IR,
+          const PlaceholderMap &placeholders) const override {
     return llvm::make_unique<MockFunction>();
   }
   bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override {

--- a/tests/unittests/quantizationTest.cpp
+++ b/tests/unittests/quantizationTest.cpp
@@ -615,8 +615,9 @@ public:
     backend_.reset(createBackend(BackendKind::Interpreter));
   }
   std::unique_ptr<CompiledFunction>
-  compile(std::unique_ptr<IRFunction> IR) const override {
-    return backend_->compile(std::move(IR));
+  compile(std::unique_ptr<IRFunction> IR,
+          const PlaceholderMap &placeholders) const override {
+    return backend_->compile(std::move(IR), placeholders);
   }
   bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override {
     if (opKind == Kinded::Kind::SoftMaxNodeKind ||


### PR DESCRIPTION
*Description*:
Implement the logic for executing Placeholders in the execution engine.
This commit changes the backend interface and adds the ability to pass
Placeholder variables in addition to Variables. This change breaks the
out-of-tree backends.

This is the first step in adding support for placeholder variables in
the execution engine. The commit adds support to the interpreter but not
to the OpenCL and CPU backends.

*Testing*: Ran the local tests (ninja check)
*Documentation*: updated doxygen comments.

Related to #1586 and #1334.

