### PR TITLE
[Placeholder] Implement the execution context.

### DIFF
--- a/examples/char-rnn.cpp
+++ b/examples/char-rnn.cpp
@@ -200,6 +200,7 @@ int main(int argc, char **argv) {
   auto mb = loadFile(inputFilename);
   auto text = mb.get()->getBuffer();
   llvm::outs() << "Loaded " << text.size() << " chars.\n";
+  Context ctx;
 
   const size_t numSteps = 50;
   const size_t minibatchSize = 32;
@@ -234,7 +235,7 @@ int main(int argc, char **argv) {
   // Run this number of iterations over the input. On each iteration: train the
   // network on the whole input and then generate some sample text.
   for (unsigned i = 0; i < numEpochs; i++) {
-    EE.compile(CompilationMode::Train, TF);
+    EE.compile(CompilationMode::Train, TF, ctx);
 
     // Train the network on the whole input.
     llvm::outs() << "Iteration " << i + 1 << "/" << numEpochs;
@@ -243,7 +244,8 @@ int main(int argc, char **argv) {
     llvm::outs() << ".\n";
 
     //// Use the trained network to generate some text ////
-    EE.compile(CompilationMode::Infer, F);
+    Context ctx;
+    EE.compile(CompilationMode::Infer, F, ctx);
 
     // Load a few characters to start the text that we generate.
     Tensor currCharInfer(ElemKind::FloatTy, {minibatchSize, numSteps, 128});

--- a/examples/cifar10.cpp
+++ b/examples/cifar10.cpp
@@ -96,6 +96,8 @@ void testCIFAR10() {
   TrainingConfig TC;
 
   ExecutionEngine EE(executionBackend);
+  Context ctx;
+
   TC.learningRate = 0.001;
   TC.momentum = 0.9;
   TC.L2Decay = 0.0001;
@@ -128,7 +130,7 @@ void testCIFAR10() {
   auto *result = F->createSave("ret", SM);
 
   Function *TF = glow::differentiate(F, TC);
-  EE.compile(CompilationMode::Train, TF);
+  EE.compile(CompilationMode::Train, TF, ctx);
 
   // Report progress every this number of training iterations.
   int reportRate = 256;

--- a/examples/fr2en.cpp
+++ b/examples/fr2en.cpp
@@ -130,6 +130,7 @@ struct Model {
   Variable *input_;
   Variable *seqLength_;
   Variable *output_;
+  Context ctx;
 
   void loadLanguages();
   void loadEncoder();
@@ -172,7 +173,7 @@ struct Model {
       F_ = Q;
     }
 
-    EE_.compile(CompilationMode::Infer, F_);
+    EE_.compile(CompilationMode::Infer, F_, ctx);
   }
 
 private:

--- a/examples/mnist.cpp
+++ b/examples/mnist.cpp
@@ -132,7 +132,8 @@ void testMNIST() {
 
   Function *T = glow::differentiate(F, TC);
 
-  EE.compile(CompilationMode::Train, T);
+  Context ctx;
+  EE.compile(CompilationMode::Train, T, ctx);
 
   const int numIterations = 30;
 
@@ -156,7 +157,7 @@ void testMNIST() {
     timer.stopTimer();
   }
   llvm::outs() << "Validating.\n";
-  EE.compile(CompilationMode::Infer, F);
+  EE.compile(CompilationMode::Infer, F, ctx);
 
   auto LIH = labelInputs.getHandle<int64_t>();
 

--- a/examples/ptb.cpp
+++ b/examples/ptb.cpp
@@ -188,6 +188,7 @@ void testPTB() {
                               minibatchSize, maxNumWords);
   llvm::outs() << "Loaded " << numWords << " words.\n";
   ExecutionEngine EE(executionBackend);
+  Context ctx;
 
   // Construct the network:
   TrainingConfig TC;
@@ -235,7 +236,7 @@ void testPTB() {
 
   Function *TF = glow::differentiate(F, TC);
 
-  EE.compile(CompilationMode::Train, TF);
+  EE.compile(CompilationMode::Train, TF, ctx);
 
   if (!dumpTrainingGraphDAGFileOpt.empty()) {
     llvm::outs() << "Dumping training graph\n";

--- a/include/glow/Backends/Backend.h
+++ b/include/glow/Backends/Backend.h
@@ -26,6 +26,7 @@ namespace glow {
 
 class IRFunction;
 class Node;
+class Context;
 
 enum class BackendKind {
   Interpreter, // Execute the network with the built-in interpreter.
@@ -43,8 +44,7 @@ public:
   /// Placeholders that are mapped to the concrete input tensor for the
   /// specific function.
   virtual std::unique_ptr<CompiledFunction>
-  compile(std::unique_ptr<IRFunction> IR,
-          const PlaceholderMap &placeholders) const = 0;
+  compile(std::unique_ptr<IRFunction> IR, const Context &ctx) const = 0;
 
   /// Save the bundle for \p IR for a later standalone execution
   /// in \p outputDir. Make \p networkName the function name for

--- a/include/glow/Backends/CompiledFunction.h
+++ b/include/glow/Backends/CompiledFunction.h
@@ -20,12 +20,6 @@
 
 namespace glow {
 
-class Placeholder;
-class Tensor;
-
-/// Maps placeholders to the tensors that back them.
-using PlaceholderMap = std::unordered_map<Placeholder *, Tensor *>;
-
 /// Interface for executing a compiled function.
 class CompiledFunction {
 public:

--- a/include/glow/Base/Context.h
+++ b/include/glow/Base/Context.h
@@ -13,8 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef GLOW_EXECUTIONENGINE_CONTEXT_H
-#define GLOW_EXECUTIONENGINE_CONTEXT_H
+#ifndef GLOW_BASE_CONTEXT_H
+#define GLOW_BASE_CONTEXT_H
+
+#include "llvm/ADT/ArrayRef.h"
 
 #include <unordered_map>
 
@@ -42,22 +44,27 @@ private:
 public:
   /// \returns the tensor that corresponds to Placeholder \p P or Null if the
   /// tensor is not found.
-  Tensor *get(Placeholder *P);
+  Tensor *get(Placeholder *P) const;
 
   /// Inserts the Placeholder-Tensor pair.
   void insert(Placeholder *P, Tensor &&T);
 
   /// \returns True if \p P is a registered Placeholder.
-  size_t count(Placeholder *P);
+  size_t count(Placeholder *P) const;
 
   /// Deletes all tensors and clears the mapping between Placeholders and
   /// tensors.
   void clear();
 
   /// \returns the mapping between placeholder to tensors.
-  PlaceholderMap &pairs() { return map_; }
+  const PlaceholderMap &pairs() const { return map_; }
 
   Context() = default;
+
+  /// Construct the Context with an initial mapping between \p placeholders
+  /// and \p inputs;
+  Context(llvm::ArrayRef<Placeholder *> placeholders,
+          llvm::ArrayRef<Tensor *> inputs);
 
   ~Context() { clear(); };
 
@@ -70,4 +77,4 @@ public:
 
 } // namespace glow
 
-#endif // GLOW_EXECUTIONENGINE_CONTEXT_H
+#endif // GLOW_BASE_CONTEXT_H

--- a/include/glow/ExecutionEngine/Context.h
+++ b/include/glow/ExecutionEngine/Context.h
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_EXECUTIONENGINE_CONTEXT_H
+#define GLOW_EXECUTIONENGINE_CONTEXT_H
+
+#include <unordered_map>
+
+namespace glow {
+
+class Tensor;
+class Placeholder;
+
+/// This class provides a mapping between some graph nodes, which are a symbolic
+/// representation of some computation, and concrete tensors that represent the
+/// inputs and outputs to the graph. The context owns the tensors and the graph
+/// uses these values as runtime. This is useful for the multi-threaded
+/// execution of code, where each thread has a different execution context. The
+/// difference between this class and a regular map is that the Context owns the
+/// Tensors (not only the pointers) and manages their lifetime.
+class Context final {
+public:
+  /// Maps placeholders to the tensors that back them.
+  using PlaceholderMap = std::unordered_map<Placeholder *, Tensor *>;
+
+private:
+  /// Maps Placeholders to Tensors.
+  PlaceholderMap map_;
+
+public:
+  /// \returns the tensor that corresponds to Placeholder \p P or Null if the
+  /// tensor is not found.
+  Tensor *get(Placeholder *P);
+
+  /// Inserts the Placeholder-Tensor pair.
+  void insert(Placeholder *P, Tensor &&T);
+
+  /// \returns True if \p P is a registered Placeholder.
+  size_t count(Placeholder *P);
+
+  /// Deletes all tensors and clears the mapping between Placeholders and
+  /// tensors.
+  void clear();
+
+  /// \returns the mapping between placeholder to tensors.
+  PlaceholderMap &pairs() { return map_; }
+
+  Context() = default;
+
+  ~Context() { clear(); };
+
+  // Don't copy or move this class around.
+  Context(const Context &other) = delete;
+  Context(Context &&other) = delete;
+  Context &operator=(const Context &other) = delete;
+  Context &operator=(Context &&other) = delete;
+};
+
+} // namespace glow
+
+#endif // GLOW_EXECUTIONENGINE_CONTEXT_H

--- a/include/glow/ExecutionEngine/ExecutionEngine.h
+++ b/include/glow/ExecutionEngine/ExecutionEngine.h
@@ -18,6 +18,7 @@
 
 #include "glow/Backends/Backend.h"
 #include "glow/Backends/CompiledFunction.h"
+#include "glow/Base/Context.h"
 #include "glow/Base/Train.h"
 #include "glow/Base/Traits.h"
 #include "glow/Graph/Graph.h"
@@ -67,11 +68,9 @@ public:
 
   /// Optimize the graph, generate IR, optimize IR and compile it for a
   /// specific target. This method should be invoked before the run method.
-  /// The placeholder variables in \p placeholders are mapped to the concrete
-  /// tensor values in the compiled instance of the function.
-  void compile(CompilationMode mode, Function *F,
-               llvm::ArrayRef<Placeholder *> placeholders = {},
-               llvm::ArrayRef<Tensor *> inputs = {});
+  /// The context \p ctx contains the mapping between symbolic values to
+  /// concrete backing tensors.
+  void compile(CompilationMode mode, Function *F, const Context &ctx);
 
   /// Save a bundle for a standalone execution. This method takes care of
   /// everything when preparing the bundle for saving. There is no need to

--- a/lib/Backends/CPU/AllocationsInfo.cpp
+++ b/lib/Backends/CPU/AllocationsInfo.cpp
@@ -16,6 +16,7 @@
 #define DEBUG_TYPE "jit-allocations"
 
 #include "AllocationsInfo.h"
+#include "glow/Base/Context.h"
 #include "glow/CodeGen/MemoryAllocator.h"
 #include "glow/Graph/Graph.h"
 #include "glow/Graph/Nodes.h"
@@ -32,7 +33,7 @@ using llvm::dyn_cast;
 using llvm::isa;
 
 void AllocationsInfo::allocateWeightVars(const IRFunction *F,
-                                         const PlaceholderMap &placeholders,
+                                         const Context &ctx,
                                          bool absoluteAddr) {
   // Use two different allocators, because constant weights and mutable weights
   // may use different memory blocks.
@@ -75,7 +76,7 @@ void AllocationsInfo::allocateWeightVars(const IRFunction *F,
   }
 
   // Allocate addresses for the Placeholders.
-  for (auto PH : placeholders) {
+  for (auto PH : ctx.pairs()) {
     assert(isa<WeightVar>(F->getWeightForNode(PH.first)));
     auto *w = cast<WeightVar>(F->getWeightForNode(PH.first));
     auto numBytes = w->getSizeInBytes();

--- a/lib/Backends/CPU/AllocationsInfo.h
+++ b/lib/Backends/CPU/AllocationsInfo.h
@@ -16,8 +16,6 @@
 #ifndef GLOW_BACKENDS_CPU_ALLOCATIONSINFO_H
 #define GLOW_BACKENDS_CPU_ALLOCATIONSINFO_H
 
-#include "glow/Backends/CompiledFunction.h"
-
 #include "llvm/IR/Module.h"
 
 #include <functional>
@@ -27,6 +25,7 @@ class Value;
 class IRFunction;
 class WeightVar;
 class Variable;
+class Context;
 
 /// Information about allocations for activations, constant weight variables
 /// and mutable weight variables.
@@ -60,8 +59,7 @@ struct AllocationsInfo {
   /// by the payloads of tensors corresponding to those WeightVars as offsets.
   /// This is useful in a JIT setup. If \p absoluteAddr is false, then all the
   /// WeightVars will get new offsets assigned.
-  void allocateWeightVars(const IRFunction *F,
-                          const PlaceholderMap &placeholders,
+  void allocateWeightVars(const IRFunction *F, const Context &ctx,
                           bool absoluteAddr);
   /// Assign offsets to all activations.
   /// No actual memory allocation is performed. All the allocations should be

--- a/lib/Backends/CPU/BundleSaver.cpp
+++ b/lib/Backends/CPU/BundleSaver.cpp
@@ -19,6 +19,7 @@
 
 #include "CPUBackend.h"
 
+#include "glow/Base/Context.h"
 #include "glow/Graph/Graph.h"
 #include "glow/IR/Instrs.h"
 #include "glow/Support/Debug.h"
@@ -250,7 +251,7 @@ void BundleSaver::performBundleMemoryAllocation() {
   allocationsInfo_.allocateActivations(F_);
   // Tell the allocateWeightVars to not reuse any existing addresses for weights
   // and to assign new ones.
-  PlaceholderMap empty;
+  Context empty;
   allocationsInfo_.allocateWeightVars(F_, empty, false);
   allocationsInfo_.allocateTensorViews(F_);
 }

--- a/lib/Backends/CPU/CPUBackend.h
+++ b/lib/Backends/CPU/CPUBackend.h
@@ -42,9 +42,8 @@ public:
   ///@{
   ~CPUBackend() override = default;
 
-  std::unique_ptr<CompiledFunction>
-  compile(std::unique_ptr<IRFunction> IR,
-          const PlaceholderMap &placeholders) const override;
+  std::unique_ptr<CompiledFunction> compile(std::unique_ptr<IRFunction> IR,
+                                            const Context &ctx) const override;
 
   void save(std::unique_ptr<IRFunction> IR, llvm::StringRef outputDir,
             llvm::StringRef networkName) const override;

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -24,9 +24,8 @@
 using namespace glow;
 
 std::unique_ptr<CompiledFunction>
-Interpreter::compile(std::unique_ptr<IRFunction> IR,
-                     const PlaceholderMap &placeholders) const {
-  return llvm::make_unique<InterpreterFunction>(std::move(IR), placeholders);
+Interpreter::compile(std::unique_ptr<IRFunction> IR, const Context &ctx) const {
+  return llvm::make_unique<InterpreterFunction>(std::move(IR), ctx);
 }
 
 bool Interpreter::isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const {

--- a/lib/Backends/Interpreter/Interpreter.h
+++ b/lib/Backends/Interpreter/Interpreter.h
@@ -34,9 +34,8 @@ public:
   ///@{
   ~Interpreter() override = default;
 
-  std::unique_ptr<CompiledFunction>
-  compile(std::unique_ptr<IRFunction> IR,
-          const PlaceholderMap &placeholders) const override;
+  std::unique_ptr<CompiledFunction> compile(std::unique_ptr<IRFunction> IR,
+                                            const Context &ctx) const override;
 
   bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override;
 

--- a/lib/Backends/Interpreter/InterpreterFunction.cpp
+++ b/lib/Backends/Interpreter/InterpreterFunction.cpp
@@ -25,11 +25,11 @@
 using namespace glow;
 
 InterpreterFunction::InterpreterFunction(std::unique_ptr<IRFunction> F,
-                                         const PlaceholderMap &placeholders)
+                                         const Context &ctx)
     : F_(std::move(F)) {
 
   // Register the concrete tensors that back the placeholder tensors.
-  for (auto &ph : placeholders) {
+  for (auto &ph : ctx.pairs()) {
     auto *w = F_->getWeightForNode(ph.first);
     assert(!externalTensors_.count(w) && "The tensor is already registered");
     externalTensors_[w] = ph.second;

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -17,6 +17,7 @@
 #define GLOW_BACKENDS_INTERPRETER_INTERPRETERFUNCTION_H
 
 #include "glow/Backends/CompiledFunction.h"
+#include "glow/Base/Context.h"
 #include "glow/Base/Tensor.h"
 
 #include "llvm/ADT/ArrayRef.h"
@@ -48,8 +49,7 @@ class InterpreterFunction final : public CompiledFunction {
   std::unordered_map<const Value *, Tensor *> externalTensors_;
 
 public:
-  InterpreterFunction(std::unique_ptr<IRFunction> F,
-                      const PlaceholderMap &placeholders);
+  InterpreterFunction(std::unique_ptr<IRFunction> F, const Context &ctx);
 
   /// \name CompiledFunction interface
   ///@{

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -18,6 +18,7 @@
 
 #include "glow/Backends/Backend.h"
 #include "glow/Backends/CompiledFunction.h"
+#include "glow/Base/Context.h"
 #include "glow/Base/Tensor.h"
 #include "glow/Base/Traits.h"
 #include "glow/Graph/Node.h"
@@ -92,8 +93,7 @@ class OpenCLFunction final : public CompiledFunction {
 
 public:
   /// Ctor.
-  explicit OpenCLFunction(std::unique_ptr<IRFunction> F,
-                          const PlaceholderMap &placeholders);
+  explicit OpenCLFunction(std::unique_ptr<IRFunction> F, const Context &ctx);
 
   /// @name CompiledFunction interface
   ///@{
@@ -104,7 +104,7 @@ public:
 
 private:
   /// Allocate memory for the tensors.
-  void allocateMemory(const PlaceholderMap &placeholders);
+  void allocateMemory(const Context &ctx);
   /// Copy the value from a device to a provided buffer.
   /// If \p buf is nullptr, the payload of the underlying tensor is used.
   /// \returns number of copied bytes.
@@ -171,9 +171,8 @@ public:
   ///@{
   ~OCLBackend() override = default;
 
-  std::unique_ptr<CompiledFunction>
-  compile(std::unique_ptr<IRFunction> IR,
-          const PlaceholderMap &placeholders) const override;
+  std::unique_ptr<CompiledFunction> compile(std::unique_ptr<IRFunction> IR,
+                                            const Context &ctx) const override;
 
   bool transformPostLowering(Function *F, CompilationMode mode) const override;
 

--- a/lib/Base/CMakeLists.txt
+++ b/lib/Base/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(Base
+              Context.cpp
               Tensor.cpp
               Type.cpp
               Image.cpp)

--- a/lib/ExecutionEngine/CMakeLists.txt
+++ b/lib/ExecutionEngine/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(ExecutionEngine
+              Context.cpp
               ExecutionEngine.cpp)
 
 target_link_libraries(ExecutionEngine

--- a/lib/ExecutionEngine/CMakeLists.txt
+++ b/lib/ExecutionEngine/CMakeLists.txt
@@ -1,5 +1,4 @@
 add_library(ExecutionEngine
-              Context.cpp
               ExecutionEngine.cpp)
 
 target_link_libraries(ExecutionEngine

--- a/lib/ExecutionEngine/Context.cpp
+++ b/lib/ExecutionEngine/Context.cpp
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/ExecutionEngine/Context.h"
+#include "glow/Base/Tensor.h"
+
+using namespace glow;
+
+Tensor *Context::get(Placeholder *P) {
+  auto it = map_.find(P);
+  if (it == map_.end()) {
+    return nullptr;
+  }
+
+  return it->second;
+}
+
+void Context::insert(Placeholder *P, Tensor &&T) {
+  assert(!map_.count(P) && "Placeholder already registered");
+  // Take ownership over the tensor.
+  map_[P] = new Tensor(std::move(T));
+}
+
+size_t Context::count(Placeholder *P) { return map_.count(P); }
+
+void Context::clear() {
+  // Delete all of the tensors that are owned by the context.
+  for (auto PH : map_) {
+    delete PH.second;
+  }
+
+  map_.clear();
+}

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -15,8 +15,8 @@
  */
 
 #include "glow/ExecutionEngine/ExecutionEngine.h"
-
 #include "glow/Backends/Backend.h"
+#include "glow/Base/Context.h"
 #include "glow/Graph/Graph.h"
 #include "glow/IR/IR.h"
 #include "glow/IR/IRBuilder.h"
@@ -170,18 +170,9 @@ std::unique_ptr<IRFunction> ExecutionEngine::generateIR(CompilationMode mode,
 }
 
 void ExecutionEngine::compile(CompilationMode mode, Function *F,
-                              llvm::ArrayRef<Placeholder *> placeholders,
-                              llvm::ArrayRef<Tensor *> inputs) {
-  PlaceholderMap pmap;
-  assert(placeholders.size() == inputs.size() &&
-         "Invalid number of placeholders");
-
-  for (size_t i = 0, e = placeholders.size(); i < e; i++) {
-    pmap[placeholders[i]] = inputs[i];
-  }
-
+                              const Context &ctx) {
   auto IR = generateIR(mode, F);
-  function_ = backend_->compile(std::move(IR), pmap);
+  function_ = backend_->compile(std::move(IR), ctx);
 }
 
 void ExecutionEngine::save(CompilationMode mode, Function *F,

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -60,7 +60,7 @@ onnxStatus Graph::initGraph(const void *onnxModel, size_t onnxModelSize,
   onnxNameToOutputNode_ = loader->getOutputVarsMapping();
 
   // Emit IR for the graph and compile it.
-  backendPtr_->getEE().compile(CompilationMode::Infer, function_);
+  backendPtr_->getEE().compile(CompilationMode::Infer, function_, ctx_);
 
   return ONNXIFI_STATUS_SUCCESS;
 }

--- a/lib/Onnxifi/Base.h
+++ b/lib/Onnxifi/Base.h
@@ -113,6 +113,11 @@ private:
   BackendPtr backendPtr_;
   Function *function_;
 
+  /// This is the compilation context that represents a single thread.
+  /// TODO: Once we finish the migration to placeholders we'll need to manage
+  /// the state properly.
+  Context ctx_;
+
   /// Mapping between ONNX name for the input variable and Glow variable.
   llvm::StringMap<Variable *> onnxNameToInputVar_;
 

--- a/tests/unittests/BackendCorrectnessTest.cpp
+++ b/tests/unittests/BackendCorrectnessTest.cpp
@@ -16,6 +16,7 @@
 
 #include "BackendTestUtils.h"
 
+#include "glow/Base/Context.h"
 #include "glow/ExecutionEngine/ExecutionEngine.h"
 #include "glow/Graph/Graph.h"
 #include "glow/IR/IR.h"
@@ -238,10 +239,9 @@ class MockCPUBackend : public Backend {
 
 public:
   MockCPUBackend() { backend_.reset(createBackend(BackendKind::CPU)); }
-  std::unique_ptr<CompiledFunction>
-  compile(std::unique_ptr<IRFunction> IR,
-          const PlaceholderMap &placeholders) const override {
-    return backend_->compile(std::move(IR), placeholders);
+  std::unique_ptr<CompiledFunction> compile(std::unique_ptr<IRFunction> IR,
+                                            const Context &ctx) const override {
+    return backend_->compile(std::move(IR), ctx);
   }
   bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override {
     return true;
@@ -305,7 +305,7 @@ TEST_P(CPUOnly, dataParallelStackingTest) {
   }
 
   MockCPUBackend backend;
-  PlaceholderMap empty;
+  Context empty;
   backend.compile(std::move(M), empty)->execute();
   auto H = var->getHandle();
   EXPECT_EQ(H.at(0), 3);

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -25,9 +25,8 @@ class MockBackend : public Backend {
   class MockFunction : public CompiledFunction {
     void execute() override {}
   };
-  std::unique_ptr<CompiledFunction>
-  compile(std::unique_ptr<IRFunction> IR,
-          const PlaceholderMap &placeholders) const override {
+  std::unique_ptr<CompiledFunction> compile(std::unique_ptr<IRFunction> IR,
+                                            const Context &ctx) const override {
     return llvm::make_unique<MockFunction>();
   }
   bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override {

--- a/tests/unittests/GemmTest.cpp
+++ b/tests/unittests/GemmTest.cpp
@@ -51,7 +51,9 @@ void infer(Tensor *out, Tensor *lhs, Tensor *rhs) {
   auto OT = F->getParent()->uniqueType(out->getElementType(), out->dims());
   auto *matmul = F->createMatMul("matmul", OT, lhsVar, rhsVar);
   auto result = F->createSave("ret", matmul, outVar);
-  EE.compile(CompilationMode::Infer, F);
+  Context ctx;
+  EE.compile(CompilationMode::Infer, F, ctx);
+
   updateVariables({lhsVar, rhsVar}, {lhs, rhs});
   EE.run();
 

--- a/tests/unittests/HyphenTest.cpp
+++ b/tests/unittests/HyphenTest.cpp
@@ -244,6 +244,9 @@ const vector<const char *> TrainingData{
 
 namespace {
 struct HyphenNetwork {
+  /// The execution context.
+  Context ctx_;
+
   /// The input variable is N x 6 x 27 as encoded by mapLetterWindow().
   Variable *input_;
 
@@ -283,7 +286,7 @@ struct HyphenNetwork {
                            TrainingConfig &TC) {
     // Compilation is destructive because of target-specific lowering.
     // Compile a clone of the inference function.
-    EE.compile(CompilationMode::Infer, infer_->clone(name));
+    EE.compile(CompilationMode::Infer, infer_->clone(name), ctx_);
 
     auto batchSize = TC.batchSize;
     auto numSamples = inputs.dims()[0];
@@ -362,7 +365,7 @@ TEST(HyphenTest, network) {
   size_t sampleCounter = 0;
 
   // Train using mini-batch SGD.
-  EE.compile(CompilationMode::Train, net.train_);
+  EE.compile(CompilationMode::Train, net.train_, net.ctx_);
   runBatch(EE, 1000, sampleCounter, {net.input_, net.expected_},
            {&inputs, &expected});
 

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -60,7 +60,8 @@ TEST_P(Operator, pow) {
   auto *Save2 = F_->createSave("save", Pow2);
   auto *Save3 = F_->createSave("save", Pow3);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
 
   EE_.run();
 
@@ -87,7 +88,8 @@ TEST_P(InterpAndCPU, log) {
 
   auto *save = F_->createSave("save", LN);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
 
   EE_.run();
 
@@ -109,7 +111,8 @@ TEST_P(InterpAndCPU, CmpEQ) {
   auto *cmpEQ = F_->createCmpEQ("cmpEQ", X, Y);
   auto *save = F_->createSave("save", cmpEQ);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
 
   EE_.run();
 
@@ -133,7 +136,8 @@ TEST_P(Operator, matmul) {
 
   F_->createSave("save", R, result);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   auto H = result->getPayload().getHandle();
@@ -154,7 +158,8 @@ TEST_P(Operator, BroadcastedBatchMatMul) {
 
   F_->createSave("save", R, result);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   auto H = result->getPayload().getHandle();
@@ -177,7 +182,8 @@ TEST_P(Operator, ParallelBatchMatMul) {
 
   F_->createSave("save", R, result);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   auto H = result->getPayload().getHandle();
@@ -198,7 +204,8 @@ TEST_P(Operator, batchedReduceAdd) {
 
   F_->createSave("save", R, result);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   auto H = result->getPayload().getHandle();
@@ -217,7 +224,8 @@ TEST_P(InterpAndCPU, batchedReduceAddWithAxis) {
 
   F_->createSave("save", R, result);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   auto H = result->getPayload().getHandle();
@@ -248,7 +256,8 @@ TEST_P(InterpAndCPU, batchedReduceAddQuantized) {
 
   F_->createSave("save", R, result);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   for (size_t i = 0; i < 8; i++) {
@@ -282,7 +291,8 @@ TEST_P(InterpAndCPU, batchedReduceAddQuantizedWithAxis) {
       F_->createBatchedReduceAdd("batched.reduce.add", OT, batch, /* axis */ 1);
   F_->createSave("save", R, result);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   for (size_t i = 0; i < 2; i++) {
@@ -308,7 +318,8 @@ TEST_P(Operator, batchedReduceMean) {
 
   F_->createSave("save", R, result);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   auto H = result->getPayload().getHandle();
@@ -327,7 +338,8 @@ TEST_P(InterpAndCPU, batchedReduceMeanWithAxis) {
 
   F_->createSave("save", R, result);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   auto H = result->getPayload().getHandle();
@@ -358,7 +370,8 @@ TEST_P(InterpAndCPU, batchedReduceMeanQuantized) {
 
   F_->createSave("save", R, result);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   for (size_t i = 0; i < 8; i++) {
@@ -392,7 +405,8 @@ TEST_P(InterpAndCPU, batchedReduceMeanQuantizedWithAxis) {
                                         /* axis */ 1);
   F_->createSave("save", R, result);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   for (size_t i = 0; i < 2; i++) {
@@ -421,7 +435,8 @@ TEST_P(Operator, batchedBatchedAdd) {
   auto R = F_->createBatchedAdd("batch.add", batch, added);
   F_->createSave("save", R, result);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   auto H = result->getPayload().getHandle();
@@ -462,7 +477,8 @@ TEST_P(InterpAndCPU, broadcastSimple) {
   F_->createSave("save", R, broadcasted);
   F_->createSave("saveQ", QR, broadcastedQ);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   auto broadcastedBHandle = broadcasted->getPayload().getHandle();
@@ -523,7 +539,8 @@ TEST_P(InterpAndCPU, broadcast) {
   F_->createSave("save", R, broadcasted);
   F_->createSave("saveQ", QR, broadcastedQ);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   auto broadcastedBHandle = broadcasted->getPayload().getHandle();
@@ -572,7 +589,8 @@ TEST_P(Operator, weightedSum) {
   auto *WS = F_->createWeightedSum("ws", {A, B}, {AW, BW});
   auto *save = F_->createSave("save", WS);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   // Verify the weighted sum was correctly calculated.
@@ -595,7 +613,8 @@ TEST_P(Operator, minElem) {
   LHS->getHandle().randomize(-10, 10, PRNG);
   RHS->getHandle().randomize(-10, 10, PRNG);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   auto resultH = save->getVariable()->getHandle();
@@ -621,7 +640,8 @@ TEST_P(Operator, TopK) {
   F_->createSave("save.values", {R, 0}, values);
   F_->createSave("save.indices", {R, 1}, indices);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
 
   EE_.run();
 
@@ -673,7 +693,8 @@ TEST_P(InterpAndCPU, ConcatTopK) {
   F_->createSave("Save.Values", CV, values);
   F_->createSave("Save.Indices", CI, indices);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
 
   EE_.run();
 
@@ -734,7 +755,8 @@ TEST_P(Operator, matMul) {
   F_->createSave("save.values", A1, res1);
   F_->createSave("save.values", A2, res2);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
 
   EE_.run();
 
@@ -765,7 +787,8 @@ TEST_P(InterpAndCPU, TopK1) {
   F_->createSave("save.values", {R, 0}, values);
   F_->createSave("save.indices", {R, 1}, indices);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
 
   EE_.run();
 
@@ -796,7 +819,8 @@ TEST_P(InterpAndCPU, QuantizedTopK) {
   F_->createSave("save.values", TK->getValues(), OV);
   F_->createSave("save.indices", TK->getIndices(), IV);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
 
   EE_.run();
 
@@ -866,7 +890,8 @@ TEST_P(Operator, Gather) {
 
   F_->createSave("save", R, result);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   auto H = result->getPayload().getHandle();
@@ -900,7 +925,8 @@ TEST_P(Operator, Transpose2Dims) {
 
   auto *tr = F_->createTranspose("tr", A, {1, 0});
   auto *result = F_->createSave("saveTranspose", tr);
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
   Tensor dest(ElemKind::FloatTy, {13, 20});
   A->getPayload().transpose(&dest, {1, 0});
@@ -942,7 +968,8 @@ TEST_P(Operator, Transpose3Dims) {
   // We should have exactly 6 possible permutations for 3 dimensions.
   EXPECT_EQ(6, nbOfShuffle);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   for (int i = 0; i < 6; ++i) {
@@ -995,7 +1022,8 @@ TEST_P(InterpAndCPU, GatherSizeT) {
 
   F_->createSave("save", R, result);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   auto H = result->getPayload().getHandle<int64_t>();
@@ -1052,7 +1080,8 @@ TEST_P(Operator, BatchedGather) {
 
   F_->createSave("save", R, result);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   auto H = result->getPayload().getHandle();
@@ -1078,7 +1107,8 @@ TEST_P(Operator, ScatterAssign) {
 
   F_->createSave("save", R, result);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   auto H = result->getPayload().getHandle();
@@ -1118,7 +1148,8 @@ TEST_P(InterpAndCPU, ScatterAssignQuantized) {
 
   F_->createSave("save", DQ, result);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   auto H = result->getPayload().getHandle();
@@ -1152,7 +1183,8 @@ TEST_P(Operator, QuantizeAndDequantize) {
   auto *fpAdd = F_->createAdd("fpAdd", A, B);
   auto *fpResult = F_->createSave("fpSave", fpAdd);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   EXPECT_TRUE(result->getVariable()->getPayload().isEqual(
@@ -1186,7 +1218,8 @@ TEST_P(Operator, IntMatMul) {
   auto *rq = F_->createDequantize("dequant", matmulq);
 
   F_->createSave("save", rq, res);
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
 
   EE_.run();
 
@@ -1234,7 +1267,8 @@ TEST_P(InterpAndCPU, IntBatchedArith) {
   auto *rq = F_->createDequantize("dequant", matmulq);
 
   F_->createSave("save", rq, res);
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
 
   EE_.run();
 
@@ -1295,7 +1329,9 @@ void checkIntConvolution(ExecutionEngine &EE, unsigned convDepth) {
   auto *sub = F->createSub("compare", dequantRes, conv);
 
   F->createSave("save", sub, res);
-  EE.compile(CompilationMode::Infer, F);
+  Context ctx;
+  EE.compile(CompilationMode::Infer, F, ctx);
+
   EE.run();
   auto H = res->getPayload().getHandle();
 
@@ -1330,7 +1366,8 @@ TEST_P(InterpAndCPU, IntConcat) {
   auto sub = F_->createSub("compare", C, DCQ);
 
   auto res = F_->createSave("save", sub);
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   auto R = res->getVariable()->getHandle();
@@ -1374,7 +1411,8 @@ TEST_P(InterpAndCPU, IntFC) {
   auto *sub = F_->createSub("compare", dequantRes, fc);
 
   F_->createSave("save", sub, res);
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   auto H = res->getPayload().getHandle();
@@ -1398,7 +1436,8 @@ TEST_P(InterpAndCPU, EntropyLossTest) {
   Y->getPayload().getHandle<int64_t>() = {1, 2};
   auto *ceLoss = F_->createCrossEntropyLoss("CELoss", P, Y);
   F_->createSave("save", ceLoss, L);
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
   auto R = L->getPayload().getHandle();
   EXPECT_NEAR(R.at({0}), -log(0.5) - log(0.3), 0.1);
@@ -1423,7 +1462,8 @@ TEST_P(Operator, RescaleNode) {
   auto *Z = F_->createRescaleQuantized("R3", Y, output->getType());
 
   F_->createSave("save", Z, output);
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   auto RI = input->getPayload().getHandle<int8_t>();
@@ -1526,7 +1566,8 @@ TEST_P(InterpAndCPU, QuantizedArithmeticRescaled) {
   F_->createSave("saveMul", mul, O5);
   F_->createSave("saveDiv", div, O6);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   for (size_t i = 0; i < len; i++) {
@@ -1561,7 +1602,8 @@ TEST_P(Operator, QuantizedTranspose) {
   auto *result = F_->createSave("ret", dequantize);
   auto *fpTr = F_->createTranspose("fpTr", A, {1, 0});
   auto *fpResult = F_->createSave("fpRet", fpTr);
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
   EXPECT_TRUE(result->getVariable()->getPayload().isEqual(B->getPayload()));
   EXPECT_TRUE(fpResult->getVariable()->getPayload().isEqual(B->getPayload()));
@@ -1641,7 +1683,8 @@ TEST_P(Operator, QuantizedArithmeticUnrescaled) {
   F_->createSave("saveMul", mul, O5);
   F_->createSave("saveDiv", div, O6);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   for (size_t i = 0; i < len; i++) {
@@ -1707,7 +1750,8 @@ TEST_P(InterpAndCPU, QuantizedCmpLTEAndSelect) {
   // Save result of the operation.
   F_->createSave("save", select, Out);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   int count_strict = 0;
@@ -1770,7 +1814,8 @@ TEST_P(Operator, TestQuantizedRescaleSequence) {
 
   // Test a sequence of rescale operations t
   F_->createSave("save", DQ, O);
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   for (size_t i = 0; i < len; i++) {
@@ -1783,6 +1828,7 @@ TEST_P(Operator, FCGradientCheck) {
   // A and B are fixed. Record gradients for X and Y after 3 steps and compare
   // with reference values.
   TrainingConfig TC;
+  Context ctx;
 
   // This variable records the number of the next sample to be used for
   // training.
@@ -1810,7 +1856,7 @@ TEST_P(Operator, FCGradientCheck) {
   initB.getHandle() = {-13.1f, 3.14f};
 
   Function *DF = glow::differentiate(F_, TC, "d_main");
-  EE_.compile(CompilationMode::Train, DF);
+  EE_.compile(CompilationMode::Train, DF, ctx);
   runBatch(EE_, 3, sampleCounter, {A, B}, {&initA, &initB});
 
   EXPECT_NEAR(X->getPayload().getHandle().raw(0), -0.21294, 1E-5);
@@ -1844,7 +1890,8 @@ TEST_P(InterpAndCPU, concatVectors) {
     I3.getHandle<int64_t>().at({i + 20}) = i + 50;
   }
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
 
   // Testing the output vector.
   updateVariables({V1, V2, V3}, {&I1, &I2, &I3});
@@ -1884,7 +1931,8 @@ TEST_P(InterpAndCPU, concatVectorsRepeated) {
     I2.getHandle<int64_t>().at({i + 10}) = 2;
   }
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
 
   // Testing the output vector.
   updateVariables({V1, V2}, {&I1, &I2});
@@ -1926,7 +1974,8 @@ TEST_P(InterpAndCPU, sliceVectors) {
     I.getHandle<int64_t>().at({2, j}) = j + 60;
   }
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
 
   // Testing the output slices.
   updateVariables({V}, {&I});
@@ -1984,7 +2033,8 @@ TEST_P(InterpAndCPU, sliceConcatVectors) {
 
   auto *result = F_->createSave("ret", C2);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
 
   updateVariables({V}, {&I});
   EE_.run();
@@ -2024,7 +2074,8 @@ TEST_P(InterpAndCPU, Tile) {
     }
   }
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
 
   updateVariables({V}, {&VT});
   EE_.run();
@@ -2073,7 +2124,8 @@ TEST_P(InterpAndCPU, QuantizedTile) {
     }
   }
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
 
   updateVariables({V}, {&VT});
   EE_.run();
@@ -2124,7 +2176,8 @@ TEST_P(Operator, simpleCmpSelectPredication) {
 
   auto *SN = F_->createSave("ret", data);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   auto H = SN->getVariable()->getHandle();
@@ -2163,7 +2216,8 @@ TEST_P(Operator, simplePredication) {
   FC1->setPredicate(pred);
   FC2->setPredicate(pred);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 }
 
@@ -2176,7 +2230,8 @@ TEST_P(InterpAndCPU, ChannelShuffle) {
   Node *CS = F_->createChannelShuffle("CS", inputs, 3, 1);
   SaveNode *S = F_->createSave("save", CS);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   auto results = llvm::cast<Variable>(S->getOutput())->getPayload().getHandle();
@@ -2198,7 +2253,8 @@ TEST_P(Operator, Squeeze) {
     Node *SQZ = F_->createSqueeze("SQZ", inputs, axes);
     SaveNode *S = F_->createSave("save", SQZ);
 
-    EE_.compile(CompilationMode::Infer, F_);
+    Context ctx;
+    EE_.compile(CompilationMode::Infer, F_, ctx);
     EE_.run();
 
     auto results = S->getVariable()->getHandle();
@@ -2214,7 +2270,8 @@ TEST_P(Operator, Squeeze) {
     Node *SQZ = F_->createSqueeze("SQZ", inputs, axes);
     SaveNode *S = F_->createSave("save", SQZ);
 
-    EE_.compile(CompilationMode::Infer, F_);
+    Context ctx;
+    EE_.compile(CompilationMode::Infer, F_, ctx);
     EE_.run();
 
     auto results = S->getVariable()->getHandle();
@@ -2236,7 +2293,8 @@ TEST_P(Operator, Squeeze) {
     Node *UnSQZ = F_->createExpandDims("UnSQZ", SQZ, axes);
     SaveNode *S2 = F_->createSave("save", UnSQZ);
 
-    EE_.compile(CompilationMode::Infer, F_);
+    Context ctx;
+    EE_.compile(CompilationMode::Infer, F_, ctx);
     EE_.run();
 
     auto res1 = S1->getVariable()->getHandle();
@@ -2260,7 +2318,8 @@ TEST_P(Operator, ExpandDims) {
   Node *EDN = F_->createExpandDims("expand", inputs, axes);
   SaveNode *S = F_->createSave("save", EDN);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   // Expected dims based on the axes above; inserted new dimensions of 1 in
@@ -2290,7 +2349,8 @@ TEST_P(InterpAndCPU, Split) {
   auto S3 = F_->createSave("save3", outputs2[0]);
   auto S4 = F_->createSave("save4", outputs2[1]);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   auto result = S1->getVariable()->getHandle();
@@ -2350,7 +2410,8 @@ TEST_P(Operator, IntRelu) {
   auto *dequantize = F_->createDequantize("dequantize", relu);
 
   auto *save = F_->createSave("save", dequantize);
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   auto result = save->getVariable()->getHandle();
@@ -2371,7 +2432,8 @@ TEST_P(Operator, IntSplat) {
   auto *dequantize = F_->createDequantize("dequantize", splat);
 
   auto *save = F_->createSave("save", dequantize);
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   auto result = save->getVariable()->getHandle();
@@ -2403,7 +2465,8 @@ TEST_P(Operator, GroupConvolution) {
       F_->createConv("Conv", input, filter, zeroBias, outTy, 1, 1, 0, 2);
   SaveNode *S = F_->createSave("save", CN);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   auto result = llvm::cast<Variable>(S->getOutput())->getPayload().getHandle();
@@ -2450,7 +2513,8 @@ TEST_P(Operator, NonSquarePaddingConvolution) {
   ConvolutionNode *CN = F_->createConv("Conv", input, filter, zeroBias, outTy,
                                        {2, 2}, {1, 1}, {0, 2, 1, 3}, 1);
   SaveNode *S = F_->createSave("save", CN);
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
   Tensor &result = S->getVariable()->getPayload();
 
@@ -2468,7 +2532,7 @@ TEST_P(Operator, NonSquarePaddingConvolution) {
   CN = refF->createConv("Conv1", input1, filter, zeroBias, outTy, {2, 2},
                         {1, 1}, {0, 0, 0, 0}, 1);
   S = refF->createSave("save1", CN);
-  EE_.compile(CompilationMode::Infer, refF);
+  EE_.compile(CompilationMode::Infer, refF, ctx);
   EE_.run();
   Tensor &result1 = S->getVariable()->getPayload();
 
@@ -2487,7 +2551,8 @@ TEST_P(Operator, NonSquarePaddingAveragePool) {
   }
   auto *Pool = F_->createAvgPool("pool", input, {2, 2}, {1, 1}, {0, 2, 1, 3});
   auto *S = F_->createSave("save", Pool);
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
   Tensor &result = S->getVariable()->getPayload();
 
@@ -2502,7 +2567,7 @@ TEST_P(Operator, NonSquarePaddingAveragePool) {
   Function *refF = mod_.createFunction("mainRef");
   Pool = refF->createAvgPool("pool1", input1, 2, 1, 0);
   S = refF->createSave("save1", Pool);
-  EE_.compile(CompilationMode::Infer, refF);
+  EE_.compile(CompilationMode::Infer, refF, ctx);
   EE_.run();
   Tensor &result1 = S->getVariable()->getPayload();
 
@@ -2521,7 +2586,8 @@ TEST_P(Operator, NonSquarePaddingMaxPool) {
   }
   auto *Pool = F_->createMaxPool("pool", input, {2, 2}, {1, 1}, {0, 2, 1, 3});
   auto *S = F_->createSave("save", Pool);
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
   Tensor &result = S->getVariable()->getPayload();
 
@@ -2536,7 +2602,7 @@ TEST_P(Operator, NonSquarePaddingMaxPool) {
   Function *refF = mod_.createFunction("mainRef");
   Pool = refF->createMaxPool("pool1", input1, 2, 1, 0);
   S = refF->createSave("save1", Pool);
-  EE_.compile(CompilationMode::Infer, refF);
+  EE_.compile(CompilationMode::Infer, refF, ctx);
   EE_.run();
   Tensor &result1 = S->getVariable()->getPayload();
 
@@ -2549,7 +2615,8 @@ TEST_P(Operator, Int8AvgPool) {
   input->getHandle<int8_t>() = {0, 1, 2, 3, 4, 5, 6, 7, 8};
   auto *Pool = F_->createAvgPool("pool", input, {2, 2}, {1, 1}, {0, 0, 0, 0});
   auto *S = F_->createSave("save", Pool);
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
   auto result = S->getVariable()->getHandle<int8_t>();
   Tensor out(ElemKind::Int8QTy, {2, 2}, 1, 0);
@@ -2565,7 +2632,8 @@ TEST_P(Operator, Int8MaxPool) {
   input->getHandle<int8_t>() = {0, 1, 2, 3, 4, 5, 6, 7, 8};
   auto *Pool = F_->createMaxPool("pool", input, {2, 2}, {1, 1}, {0, 0, 0, 0});
   auto *S = F_->createSave("save", Pool);
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
   auto result = S->getVariable()->getHandle<int8_t>();
   Tensor out(ElemKind::Int8QTy, {2, 2}, 1, 0);
@@ -2599,7 +2667,8 @@ TEST_P(InterpAndCPU, Int8Tanh) {
   auto *dequantize = F_->createDequantize("dequantize", intTanh);
   auto *saveInt = F_->createSave("int8Save", dequantize);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   auto fpResult = saveFp->getVariable()->getHandle();
@@ -2633,7 +2702,8 @@ TEST_P(Operator, NonSquareKernelConvolution) {
   ConvolutionNode *CN = F_->createConv("Conv", input, filter, zeroBias, outTy,
                                        {2, 3}, {1, 1}, {0, 0, 0, 0}, 1);
   SaveNode *S = F_->createSave("save", CN);
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
   Tensor &result = S->getVariable()->getPayload();
 
@@ -2651,7 +2721,8 @@ TEST_P(InterpAndCPU, NonSquareKernelAveragePool) {
   }
   auto *Pool = F_->createAvgPool("pool", input, {2, 3}, {1, 1}, {0, 0, 0, 0});
   auto *S = F_->createSave("save", Pool);
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
   Tensor &result = S->getVariable()->getPayload();
 
@@ -2669,7 +2740,8 @@ TEST_P(InterpAndCPU, NonSquareKernelMaxPool) {
   }
   auto *Pool = F_->createMaxPool("pool", input, {2, 3}, {1, 1}, {0, 0, 0, 0});
   auto *S = F_->createSave("save", Pool);
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
   Tensor &result = S->getVariable()->getPayload();
 
@@ -2701,7 +2773,8 @@ TEST_P(Operator, NonSquareStrideConvolution) {
   ConvolutionNode *CN = F_->createConv("Conv", input, filter, zeroBias, outTy,
                                        {2, 2}, {3, 2}, {0, 0, 1, 1}, 1);
   SaveNode *S = F_->createSave("save", CN);
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
   Tensor &result = S->getVariable()->getPayload();
 
@@ -2719,7 +2792,8 @@ TEST_P(InterpAndCPU, NonSquareStrideAveragePool) {
   }
   auto *Pool = F_->createAvgPool("pool", input, {2, 2}, {3, 2}, {0, 0, 1, 1});
   auto *S = F_->createSave("save", Pool);
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
   Tensor &result = S->getVariable()->getPayload();
 
@@ -2737,7 +2811,8 @@ TEST_P(InterpAndCPU, NonSquareStrideMaxPool) {
   }
   auto *Pool = F_->createMaxPool("pool", input, {2, 2}, {3, 2}, {0, 0, 1, 1});
   auto *S = F_->createSave("save", Pool);
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
   Tensor &result = S->getVariable()->getPayload();
 
@@ -2769,7 +2844,8 @@ TEST_P(InterpAndCPU, Int8Sigmoid) {
   auto *dequantize = F_->createDequantize("dequantize", intSigmoid);
   auto *saveInt = F_->createSave("int8Save", dequantize);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   auto fpResult = saveFp->getVariable()->getHandle();
@@ -2797,7 +2873,8 @@ TEST_P(InterpAndCPU, IntLookupTable) {
       F_->createIntLookupTable("lookupTable", input, initValues, outTy);
   auto save = F_->createSave("save", lookupTable);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   auto result = save->getVariable()->getHandle<int8_t>();
@@ -2832,7 +2909,8 @@ TEST_P(Operator, testBatchAdd) {
 
   F_->createSave("save", cc, result);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   auto RH = result->getPayload().getHandle();
@@ -2885,7 +2963,8 @@ TEST_P(Operator, testQuantizedBatchAdd) {
   // Remove the reference to the graph nodes to allow DCE to remove them.
   adds.clear();
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   auto RH = result->getPayload().getHandle();
@@ -2936,7 +3015,8 @@ TEST_P(InterpOnly, SparseLengthsSum) {
   auto R = F_->createSparseLengthsSum("SLS", data, indices, lengths);
   auto S = F_->createSave("save", R);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   Tensor &result = llvm::cast<Variable>(S->getOutput())->getPayload();
@@ -2983,7 +3063,8 @@ TEST_P(InterpOnly, SparseLengthsWeightedSum) {
                                               lengths);
   auto S = F_->createSave("save", R);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   Tensor &result = llvm::cast<Variable>(S->getOutput())->getPayload();
@@ -3029,7 +3110,8 @@ TEST_P(Operator, sliceReshape) {
   F_->createSave("saveSSX", SSX, resultSSX);
   F_->createSave("saveRSSX", RSSX, resultRSSX);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
 
   EE_.run();
 
@@ -3115,7 +3197,8 @@ TEST_P(Operator, Flatten) {
       mod_.createVariable(ElemKind::FloatTy, {72, 1}, "4Dto2Da4");
   F_->createSave("save4Dto2Da4", reshape4Dto2DAxis4, save4Dto2Da4);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
 
   EE_.run();
 
@@ -3163,7 +3246,8 @@ TEST_P(InterpAndCPU, DivSizeT) {
 
   F_->createSave("save", R, result);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   auto H = result->getPayload().getHandle<int64_t>();
@@ -3215,7 +3299,8 @@ TEST_P(InterpAndCPU, SigmoidCrossEntropyWithLogits) {
 
   F_->createSave("save", R, result);
 
-  EE_.compile(CompilationMode::Infer, F_);
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
   EE_.run();
 
   Tensor expected(ElemKind::FloatTy, {2, 2});

--- a/tests/unittests/caffe2ImporterTest.cpp
+++ b/tests/unittests/caffe2ImporterTest.cpp
@@ -43,7 +43,9 @@ TEST(caffe2, importConv) {
     output = caffe2LD.getSingleOutput();
   }
 
-  EE.compile(CompilationMode::Infer, F);
+  Context ctx;
+  EE.compile(CompilationMode::Infer, F, ctx);
+
   EE.run();
   auto result = output->getHandle();
   std::vector<size_t> expectedDims = {1, 1, 4, 4};
@@ -95,7 +97,9 @@ TEST(caffe2, concatAddAxis) {
   std::vector<size_t> expectedDims = {10, 3, 7};
   EXPECT_TRUE(result.dims().vec() == expectedDims);
 
-  EE.compile(CompilationMode::Infer, F);
+  Context ctx;
+  EE.compile(CompilationMode::Infer, F, ctx);
+
   EE.run();
   // High level check on the content of the graph.
   // We have 1 reshape, 1 concat, and 1 save.
@@ -164,7 +168,9 @@ TEST(caffe2, concat) {
   std::vector<size_t> expectedDims = {10, 24};
   EXPECT_TRUE(result.dims().vec() == expectedDims);
 
-  EE.compile(CompilationMode::Infer, F);
+  Context ctx;
+  EE.compile(CompilationMode::Infer, F, ctx);
+
   EE.run();
   // High level check on the content of the graph.
   // We have 1 concat, and 1 save.

--- a/tests/unittests/graphGradTest.cpp
+++ b/tests/unittests/graphGradTest.cpp
@@ -29,6 +29,7 @@ using namespace glow;
 
 TEST(GraphAutoGrad, autoGrad) {
   ExecutionEngine EE;
+  Context ctx;
 
   TrainingConfig TC;
 
@@ -63,13 +64,14 @@ TEST(GraphAutoGrad, autoGrad) {
   (void)result;
 
   Function *TF = glow::differentiate(F, TC);
-  EE.compile(CompilationMode::Train, TF);
-  EE.compile(CompilationMode::Infer, F);
+  EE.compile(CompilationMode::Train, TF, ctx);
+  EE.compile(CompilationMode::Infer, F, ctx);
 }
 
 TEST(GraphAutoGrad, checkLRNGen) {
   ExecutionEngine EE;
   TrainingConfig TC;
+  Context ctx;
 
   // Construct the network:
   TC.learningRate = 0.001;
@@ -92,8 +94,8 @@ TEST(GraphAutoGrad, checkLRNGen) {
   auto *result = F->createSave("return", SM);
   (void)result;
   Function *TF = glow::differentiate(F, TC);
-  EE.compile(CompilationMode::Train, TF);
-  EE.compile(CompilationMode::Infer, F);
+  EE.compile(CompilationMode::Train, TF, ctx);
+  EE.compile(CompilationMode::Infer, F, ctx);
 }
 
 TEST(GraphAutoGrad, cloneAndDiff) {

--- a/tests/unittests/graphTest.cpp
+++ b/tests/unittests/graphTest.cpp
@@ -261,7 +261,8 @@ TEST(Graph, simpleQuant) {
   auto *fcBias = MD.createVariable(ElemKind::Int8QTy, {6}, 0.4, 2, "B");
   Node *O = F->createFullyConnected("fc1", conv, fcFilter, fcBias);
   F->createSave("ret", O);
-  EE.compile(CompilationMode::Infer, F);
+  Context ctx;
+  EE.compile(CompilationMode::Infer, F, ctx);
 }
 
 TEST(Graph, quantizeDequantizeNodes) {
@@ -280,7 +281,8 @@ TEST(Graph, quantizeDequantizeNodes) {
 
   auto *D = F->createDequantize("dequantize", A);
   F->createSave("ret", D);
-  EE.compile(CompilationMode::Infer, F);
+  Context ctx;
+  EE.compile(CompilationMode::Infer, F, ctx);
 }
 
 TEST(Graph, quantizeGather) {
@@ -293,7 +295,8 @@ TEST(Graph, quantizeGather) {
                                      VisibilityKind::Public);
   auto *gather = F->createGather("gather", input, indices);
   F->createSave("ret", gather);
-  EE.compile(CompilationMode::Infer, F);
+  Context ctx;
+  EE.compile(CompilationMode::Infer, F, ctx);
 }
 
 TEST(Graph, cloneTest) {
@@ -382,7 +385,9 @@ TEST(Graph, NodeValue) {
   a = F->createAdd("x8", a, a);
   auto S = F->createSave("Save", a);
 
-  EE.compile(CompilationMode::Infer, F);
+  Context ctx;
+  EE.compile(CompilationMode::Infer, F, ctx);
+
   EE.run();
 
   EXPECT_EQ(
@@ -439,7 +444,9 @@ TEST(Graph, nodesWithPredicates) {
   auto *SM = F->createSoftMax("sm", RL3, ex);
   F->createSave("ret", SM);
 
-  EE.compile(CompilationMode::Infer, F);
+  Context ctx;
+  EE.compile(CompilationMode::Infer, F, ctx);
+
   updateVariables({input}, {&inputs});
   EE.run();
 }
@@ -513,7 +520,9 @@ TEST(Graph, schedulingOfSavesOrderProvided) {
   // Copy the value of A.
   Tensor AOrig = A->getPayload().clone();
 
-  EE.compile(CompilationMode::Infer, F);
+  Context ctx;
+  EE.compile(CompilationMode::Infer, F, ctx);
+
   EE.run();
   auto *ret = saveNode->getVariable();
   auto handleAOrig = AOrig.getHandle<>();
@@ -557,7 +566,9 @@ TEST(Graph, schedulingOfSaves) {
   // Copy the value of A.
   Tensor AOrig = A->getPayload().clone();
 
-  EE.compile(CompilationMode::Infer, F);
+  Context ctx;
+  EE.compile(CompilationMode::Infer, F, ctx);
+
   EE.run();
   auto *ret = saveNode->getVariable();
   auto handleAOrig = AOrig.getHandle<>();

--- a/tests/unittests/onnxImporterTest.cpp
+++ b/tests/unittests/onnxImporterTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "ImporterTestUtils.h"
+#include "glow/Base/Context.h"
 #include "glow/ExecutionEngine/ExecutionEngine.h"
 #include "glow/Graph/Graph.h"
 #include "glow/Importer/ONNX.h"
@@ -66,7 +67,8 @@ TEST(onnx, importConv) {
   EXPECT_TRUE(tInNode->getKind() == Kinded::Kind::TransposeNodeKind);
   EXPECT_TRUE(tFilterNode->getKind() == Kinded::Kind::TransposeNodeKind);
 
-  EE.compile(CompilationMode::Infer, F);
+  Context ctx;
+  EE.compile(CompilationMode::Infer, F, ctx);
   EE.run();
   auto result = graphOutputVar->getHandle();
   std::vector<size_t> expectedDims = {1, 1, 4, 4};

--- a/tests/unittests/partitionTest.cpp
+++ b/tests/unittests/partitionTest.cpp
@@ -39,7 +39,9 @@ static void executeSerial(const FunctionDAG &G, llvm::ArrayRef<Variable *> vars,
                           llvm::ArrayRef<Tensor *> inputs) {
   for (auto *F : G.getFunctions()) {
     ExecutionEngine EE;
-    EE.compile(CompilationMode::Infer, F);
+    Context ctx;
+    EE.compile(CompilationMode::Infer, F, ctx);
+
     updateVariables(vars, inputs);
     EE.run();
   }
@@ -98,7 +100,9 @@ TEST_F(PartitionTest, SerialExecution) {
   // Infer using the un-partitioned graph.
   Tensor in(ElemKind::FloatTy, {1, 32});
   ExecutionEngine EE;
-  EE.compile(CompilationMode::Infer, F_);
+  Context ctx;
+
+  EE.compile(CompilationMode::Infer, F_, ctx);
   updateVariables({input}, {&in});
   EE.run();
   Tensor ref = res.clone();
@@ -141,7 +145,9 @@ TEST_F(PartitionTest, Branchover) {
   // Infer using the un-partitioned graph.
   Tensor in(ElemKind::FloatTy, {1, 8});
   ExecutionEngine EE;
-  EE.compile(CompilationMode::Infer, F_);
+  Context ctx;
+
+  EE.compile(CompilationMode::Infer, F_, ctx);
   updateVariables({input}, {&in});
   EE.run();
   Tensor ref = res.clone();

--- a/tests/unittests/quantizationTest.cpp
+++ b/tests/unittests/quantizationTest.cpp
@@ -134,7 +134,9 @@ TEST(Quantization, quantizeGraph) {
   F = quantization::quantizeFunction(EE, QI, F);
 
   // Make sure that graph can be compiled and run.
-  EE.compile(CompilationMode::Infer, F);
+  Context ctx;
+  EE.compile(CompilationMode::Infer, F, ctx);
+
   EE.run();
 }
 
@@ -157,7 +159,8 @@ TEST(Quantization, quantizeReLU) {
       {NodeQuantizationInfo::generateNodeOutputName(relu->getName()),
        {0.2f, -128}}};
   F = quantization::quantizeFunction(EE, QI, F);
-  EE.compile(CompilationMode::Infer, F);
+  Context ctx;
+  EE.compile(CompilationMode::Infer, F, ctx);
 
   auto *save = llvm::cast<SaveNode>(F->getNodeByName("ret"));
   ASSERT_TRUE(llvm::isa<DequantizeNode>(save->getInput().getNode()));
@@ -238,9 +241,9 @@ TEST_P(Operator, end2end) {
   Function *F1 = createSimpleGraphForQuantization(mod, A, B, "main");
   Function *F2 = F1->clone("main2");
   SaveNode *result1 = cast<SaveNode>(F1->getNodeByName("save"));
-
+  Context ctx;
   F1 = glow::profileQuantization(F1);
-  interpreterEE.compile(CompilationMode::Infer, F1);
+  interpreterEE.compile(CompilationMode::Infer, F1, ctx);
 
   // Run graph to capture profile.
   interpreterEE.run();
@@ -253,7 +256,7 @@ TEST_P(Operator, end2end) {
   SaveNode *result2 = cast<SaveNode>(F2->getNodeByName("save"));
 
   F2 = quantization::quantizeFunction(backendSpecificEE, QI, F2);
-  backendSpecificEE.compile(CompilationMode::Infer, F2);
+  backendSpecificEE.compile(CompilationMode::Infer, F2, ctx);
   backendSpecificEE.run();
 
   // STEP3 - Compare the results of the original and quantized functions.
@@ -374,8 +377,9 @@ TEST_P(Operator, end2endGRU) {
   Function *F2 = F1->clone("main2");
   SaveNode *result1 = cast<SaveNode>(F1->getNodeByName("save"));
 
+  Context ctx;
   F1 = glow::profileQuantization(F1);
-  interpreterEE.compile(CompilationMode::Infer, F1);
+  interpreterEE.compile(CompilationMode::Infer, F1, ctx);
 
   // Run graph to capture profile.
   interpreterEE.run();
@@ -388,7 +392,7 @@ TEST_P(Operator, end2endGRU) {
   SaveNode *result2 = cast<SaveNode>(F2->getNodeByName("save"));
 
   F2 = quantization::quantizeFunction(backendSpecificEE, QI, F2);
-  backendSpecificEE.compile(CompilationMode::Infer, F2);
+  backendSpecificEE.compile(CompilationMode::Infer, F2, ctx);
   backendSpecificEE.run();
 
   // STEP3 - Compare the results of the original and quantized functions.
@@ -420,7 +424,9 @@ TEST(Quantization, rescaleSameType) {
   auto *result = F->createSave("ret", D);
 
   EXPECT_EQ(F->getNodes().size(), 3);
-  EE.compile(CompilationMode::Infer, F);
+  Context ctx;
+  EE.compile(CompilationMode::Infer, F, ctx);
+
   EE.run();
   EXPECT_EQ(F->getNodes().size(), 2);
 
@@ -444,7 +450,9 @@ TEST(Quantization, optimizeRescaleQuantize) {
   auto *result = F->createSave("ret", D);
 
   EXPECT_EQ(F->getNodes().size(), 4);
-  EE.compile(CompilationMode::Infer, F);
+  Context ctx;
+  EE.compile(CompilationMode::Infer, F, ctx);
+
   EE.run();
   EXPECT_EQ(F->getNodes().size(), 1);
 
@@ -614,10 +622,9 @@ public:
   MockQuantBackend() {
     backend_.reset(createBackend(BackendKind::Interpreter));
   }
-  std::unique_ptr<CompiledFunction>
-  compile(std::unique_ptr<IRFunction> IR,
-          const PlaceholderMap &placeholders) const override {
-    return backend_->compile(std::move(IR), placeholders);
+  std::unique_ptr<CompiledFunction> compile(std::unique_ptr<IRFunction> IR,
+                                            const Context &ctx) const override {
+    return backend_->compile(std::move(IR), ctx);
   }
   bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override {
     if (opKind == Kinded::Kind::SoftMaxNodeKind ||
@@ -698,7 +705,9 @@ TEST(Quantization, quantizeGraphPartially) {
   F = QF;
 
   // Make sure that graph can be compiled and run.
-  EE.compile(CompilationMode::Infer, F);
+  Context ctx;
+  EE.compile(CompilationMode::Infer, F, ctx);
+
   EE.run();
 
   {
@@ -777,7 +786,9 @@ TEST(Quantization, quantizeGraphPartiallyMultipleNodes) {
   F = QF;
 
   // Make sure that graph can be compiled and run.
-  EE.compile(CompilationMode::Infer, F);
+  Context ctx;
+  EE.compile(CompilationMode::Infer, F, ctx);
+
   EE.run();
 
   {
@@ -866,7 +877,9 @@ TEST(Quantization, quantizeGraphPartiallyMultipleKinds) {
   F = QF;
 
   // Make sure that graph can be compiled and run.
-  EE.compile(CompilationMode::Infer, F);
+  Context ctx;
+  EE.compile(CompilationMode::Infer, F, ctx);
+
   EE.run();
 
   {

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -145,6 +145,9 @@ llvm::StringRef Loader::getModelOptPath() {
   return modelPathOpt[0];
 }
 
+// This is the execution context of the program.
+Context ctx;
+
 bool glow::emittingBundle() { return !emitBundle.empty(); }
 
 static bool commandLineIsInvalid() {
@@ -256,7 +259,7 @@ void Loader::compile() {
     EE_.save(CompilationMode::Infer, F_, emitBundle, networkName);
   } else {
     // Emit IR for the graph and compile it.
-    EE_.compile(CompilationMode::Infer, F_);
+    EE_.compile(CompilationMode::Infer, F_, ctx);
   }
 
   if (dumpGraphOpt) {


### PR DESCRIPTION
*Description*:

The Context provides a mapping between some graph nodes, which are a
symbolic representation of some computation, and concrete tensors that
represent the inputs and outputs to the graph. The context owns the
tensors and the graph uses these values as runtime. This is useful for
the multi-threaded execution of code, where each thread has a different
execution context. The difference between this class and a regular map
is that the Context owns the Tensors (not only the pointers) and manages
their lifetime.

The plan is to pass the context to the different graph builders (for
example, the LSTM builder) and have the builder initialize the weights
inside the context. Later, the context can be used for execution by the
unit tests. We would need to split the graph builders to APIs that
require context (for example, helper builders that create new variables)
and to low-level builders that don't. It should be easy to do.

Once the Context is in place we'll be able to get rid of the last
mutable variables.

*Testing*: Added a unit test.
*Documentation*: Added documentation. 

Related to #1334 and #1597.

