### PR TITLE
Remove unused CompilationMode from optimize() for IRFunction

### DIFF
--- a/include/glow/Optimizer/Optimizer.h
+++ b/include/glow/Optimizer/Optimizer.h
@@ -31,7 +31,7 @@ enum class CompilationMode {
 };
 
 /// Perform optimizations on the IR representation.
-void optimize(IRFunction &M, CompilationMode mode, const Backend &B);
+void optimize(IRFunction &M, const Backend &B);
 /// Perform optimizations on the graph representation.
 void optimize(Function *F, CompilationMode mode);
 

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -156,7 +156,7 @@ std::unique_ptr<IRFunction> ExecutionEngine::generateIR(CompilationMode mode,
   IR->generateIR();
 
   // Optimize the generated IR.
-  ::glow::optimize(*IR, mode, *backend_);
+  ::glow::optimize(*IR, *backend_);
 
   // If requested, dump IR to stdout and/or dot file for debugging.
   if (dumpIR) {

--- a/lib/Optimizer/IROptimizer.cpp
+++ b/lib/Optimizer/IROptimizer.cpp
@@ -1593,7 +1593,7 @@ void performPeepholeOptimizations(IRFunction &M) {
 }
 
 /// Perform optimizations on the IR representation.
-void glow::optimize(IRFunction &M, CompilationMode mode, const Backend &B) {
+void glow::optimize(IRFunction &M, const Backend &B) {
   M.verify();
   if (!optimizeIR)
     return;

--- a/tests/unittests/IROptTest.cpp
+++ b/tests/unittests/IROptTest.cpp
@@ -56,7 +56,7 @@ TEST(Optimizer, dseBasic) {
   bb.createElementSelectInst("select", output, input1, output, input2);
   bb.createElementAddInst("elem_add2", output, input2, input2);
 
-  optimize(M, CompilationMode::Infer, MockBackend());
+  optimize(M, MockBackend());
 
   // Check that the first relu instruction  and select are eliminated, because
   // their outputs are never read.
@@ -84,7 +84,7 @@ TEST(Optimizer, dseDoNotRemloveLastWriteIntoWeightVar) {
       "cast", output, mod.uniqueType(Type(glow::ElemKind::FloatTy, {1, 1, 1})),
       {0, 0, 0});
 
-  optimize(M, CompilationMode::Infer, MockBackend());
+  optimize(M, MockBackend());
 
   // Check that the first relu instruction  and select are eliminated, because
   // their outputs are never read.
@@ -119,7 +119,7 @@ TEST(Optimizer, shareBuffers) {
   bb.createDeallocActivationInst("dealloc2", alloc2);
   bb.createDeallocActivationInst("dealloc1", alloc1);
 
-  optimize(M, CompilationMode::Infer, MockBackend());
+  optimize(M, MockBackend());
 
   // Check that the first relu instruction  and select are eliminated, because
   // their outputs are never read.
@@ -146,7 +146,7 @@ TEST(Optimizer, deleteDeadViews) {
                           {0});
   bb.createCopyInst("copy", output, input);
 
-  optimize(M, CompilationMode::Infer, MockBackend());
+  optimize(M, MockBackend());
 
   // Check that all tensor_view instructions are eliminated, because they are
   // never used.
@@ -179,7 +179,7 @@ TEST(Optimizer, copyPropagation) {
   bb.createDeallocActivationInst("dealloc2", alloc2);
   bb.createDeallocActivationInst("dealloc1", alloc1);
 
-  optimize(M, CompilationMode::Infer, MockBackend());
+  optimize(M, MockBackend());
 
   EXPECT_EQ(M.getInstrs().size(), 5);
 
@@ -211,7 +211,7 @@ TEST(Optimizer, copyPropagationSimple) {
   bb.createDeallocActivationInst("dealloc2", alloc2);
   bb.createDeallocActivationInst("dealloc1", alloc1);
 
-  optimize(M, CompilationMode::Infer, MockBackend());
+  optimize(M, MockBackend());
 
   EXPECT_EQ(M.getInstrs().size(), 2);
 
@@ -247,7 +247,7 @@ TEST(Optimizer, copyPropagationTranspose) {
   bb.createDeallocActivationInst("dealloc2", alloc2);
   bb.createDeallocActivationInst("dealloc1", alloc1);
 
-  optimize(M, CompilationMode::Infer, MockBackend());
+  optimize(M, MockBackend());
 
   EXPECT_EQ(M.getInstrs().size(), 5);
 
@@ -280,7 +280,7 @@ TEST(Optimizer, insertOptimizer) {
 
   bb.createDeallocActivationInst("deallocSrc", allocSrc);
 
-  optimize(M, CompilationMode::Infer, MockBackend());
+  optimize(M, MockBackend());
 
   // After optimization, should be left with two splats and a tensorview; the
   // insert, alloc, and dealloc should be gone.
@@ -325,7 +325,7 @@ TEST(Optimizer, twoInsertsWithBuffersOptimizer) {
   bb.createDeallocActivationInst("deallocSrc2", allocSrc2);
   bb.createDeallocActivationInst("deallocSrc1", allocSrc1);
 
-  optimize(M, CompilationMode::Infer, MockBackend());
+  optimize(M, MockBackend());
 
   // After optimization, should be left with three splats and two tensorviews;
   // the inserts, allocs, and deallocs should be gone.
@@ -372,7 +372,7 @@ TEST(Optimizer, twoExtractsWithBuffersOptimizer) {
   bb.createDeallocActivationInst("deallocDest2", allocDest2);
   bb.createDeallocActivationInst("deallocDest1", allocDest1);
 
-  optimize(M, CompilationMode::Infer, MockBackend());
+  optimize(M, MockBackend());
 
   // After optimization, the extracts should be gone, as well as both allocDests
   // and their deallocs. Should be left with splatSrc, allocSrc, deallocSrc, two
@@ -415,7 +415,7 @@ TEST(Optimizer, forwardCopy) {
 
   auto &instrs = M.getInstrs();
   auto nbInstrsBeforeOpt = instrs.size();
-  optimize(M, CompilationMode::Infer, MockBackend());
+  optimize(M, MockBackend());
 
   // After optimization, the copy should have been coalesced with input.
   // nbIntrsBeforeOpt - 1 copy - 1 dealloc - 1 alloc
@@ -461,7 +461,7 @@ TEST(Optimizer, chainOfTwoForwardCopies) {
 
   auto &instrs = M.getInstrs();
   auto nbInstrsBeforeOpt = instrs.size();
-  optimize(M, CompilationMode::Infer, MockBackend());
+  optimize(M, MockBackend());
 
   // After optimization, the copies should have been coalesced with
   // input.
@@ -519,7 +519,7 @@ TEST(Optimizer, inoutCopy) {
   bb.createDeallocActivationInst("dealloc1", tmp1);
   bb.createDeallocActivationInst("dealloc2", tmp2);
 
-  optimize(M, CompilationMode::Infer, MockBackend());
+  optimize(M, MockBackend());
 
   // After optimization, the copies shouldn't have been touched.
   // tmp1 = copy input cannot be coalesced because tmp1 is inout.
@@ -611,7 +611,7 @@ TEST(Optimizer, bufferReuseWithoutDefs) {
   bb.createDeallocActivationInst("dealloc2", tmp2);
   bb.createDeallocActivationInst("dealloc2", tmp3);
 
-  optimize(M, CompilationMode::Infer, MockBackend());
+  optimize(M, MockBackend());
 
   // Check that we manage to expose the problematic case we wanted:
   // tmp1 is extended upward and replace the use of input.
@@ -687,7 +687,7 @@ TEST(Optimizer, bufferReuseWithoutDefsPlusCasts) {
   bb.createDeallocActivationInst("dealloc2", tmp2);
   bb.createDeallocActivationInst("dealloc2", tmp3);
 
-  optimize(M, CompilationMode::Infer, MockBackend());
+  optimize(M, MockBackend());
 
   // Check that we manage to expose the problematic case we wanted:
   // tmp1 is extended upward and replace the use of input.


### PR DESCRIPTION
*Description*: CompilationMode is unused during optimize() for IRFunction. Remove it.

*Testing*: ninja test

*Documentation*: None