### PR TITLE
[bundles | fix] Add missing model_input_name for all Makefiles

### DIFF
--- a/examples/bundles/resnet50/Makefile
+++ b/examples/bundles/resnet50/Makefile
@@ -13,6 +13,9 @@ QUANTIZE?=YES
 # Path to the images.
 IMAGES=${GLOW_SRC}/tests/images/imagenet
 
+# Input name of the model.
+MODEL_INPUT_NAME=gpu_0/data
+
 # Compiler.
 CXX=clang++
 
@@ -29,17 +32,17 @@ resnet50: build/main.o build/resnet50.o
 profile.yml: download_weights
 	# Capture quantization profile based on all inputs.
 	# Note, Interpreter backend is used to collect the profile data.
-	${LOADER} ${IMAGES}/*.png -image_mode=0to1 -dump_profile=profile.yml -m resnet50
+	${LOADER} ${IMAGES}/*.png -image_mode=0to1 -dump_profile=profile.yml -m resnet50 -model_input_name=${MODEL_INPUT_NAME}
 
 ifeq ($(QUANTIZE),YES)
 build/resnet50.o: profile.yml
 	mkdir -p build
 	# Create bundle with quantized weights and computation graph.
-	${LOADER} ${IMAGES}/dog_207.png -image_mode=0to1 -load_profile=profile.yml -m resnet50 -cpu -emit-bundle build -g
+	${LOADER} ${IMAGES}/dog_207.png -image_mode=0to1 -load_profile=profile.yml -m resnet50 -model_input_name=${MODEL_INPUT_NAME} -cpu -emit-bundle build -g
 else
 build/resnet50.o: download_weights
 	mkdir -p build
-	${LOADER} ${IMAGES}/dog_207.png -image_mode=0to1 -m resnet50 -cpu -emit-bundle build -g
+	${LOADER} ${IMAGES}/dog_207.png -image_mode=0to1 -m resnet50 -model_input_name=${MODEL_INPUT_NAME} -cpu -emit-bundle build -g
 endif
 
 build/main.o: resnet50.cpp

--- a/examples/bundles/vgg19/Makefile
+++ b/examples/bundles/vgg19/Makefile
@@ -13,6 +13,9 @@ QUANTIZE?=YES
 # Path to the images.
 IMAGES=${GLOW_SRC}/tests/images/imagenet
 
+# Input name of the model.
+MODEL_INPUT_NAME=data
+
 # Compiler.
 CXX=clang++
 
@@ -29,17 +32,17 @@ vgg19: build/main.o build/vgg19.o
 profile.yml: download_weights
 	# Capture quantization profile based on all inputs.
 	# Note, Interpreter backend is used to collect the profile data.
-	${LOADER} ${IMAGES}/*.png -image_mode=128to127 -dump_profile=profile.yml -m vgg19
+	${LOADER} ${IMAGES}/*.png -image_mode=128to127 -dump_profile=profile.yml -m vgg19 -model_input_name=${MODEL_INPUT_NAME}
 
 ifeq ($(QUANTIZE),YES)
 build/vgg19.o: profile.yml
 	mkdir -p build
 	# Create bundle with quantized weights and computation graph.
-	${LOADER} ${IMAGES}/dog_207.png -image_mode=128to127 -load_profile=profile.yml -m vgg19 -cpu -emit-bundle build -g
+	${LOADER} ${IMAGES}/dog_207.png -image_mode=128to127 -load_profile=profile.yml -m vgg19 -model_input_name=${MODEL_INPUT_NAME} -cpu -emit-bundle build -g
 else
 build/vgg19.o: download_weights
 	mkdir -p build
-	${LOADER} ${IMAGES}/dog_207.png -image_mode=128to127 -m vgg19 -cpu -emit-bundle build -g
+	${LOADER} ${IMAGES}/dog_207.png -image_mode=128to127 -m vgg19 -model_input_name=${MODEL_INPUT_NAME} -cpu -emit-bundle build -g
 endif
 
 build/main.o: vgg19.cpp

--- a/examples/bundles/zfnet512/Makefile
+++ b/examples/bundles/zfnet512/Makefile
@@ -13,6 +13,9 @@ QUANTIZE?=YES
 # Path to the images.
 IMAGES=${GLOW_SRC}/tests/images/imagenet
 
+# Input name of the model.
+MODEL_INPUT_NAME=gpu_0/data
+
 # Compiler.
 CXX=clang++
 
@@ -29,17 +32,17 @@ zfnet512: build/main.o build/zfnet512.o
 profile.yml: download_weights
 	# Capture quantization profile based on all inputs.
 	# Note, Interpreter backend is used to collect the profile data.
-	${LOADER} ${IMAGES}/*.png -image_mode=0to256 -dump_profile=profile.yml -m zfnet512
+	${LOADER} ${IMAGES}/*.png -image_mode=0to256 -dump_profile=profile.yml -m zfnet512 -model_input_name=${MODEL_INPUT_NAME}
 
 ifeq ($(QUANTIZE),YES)
 build/zfnet512.o: profile.yml
 	mkdir -p build
 	# Create bundle with quantized weights and computation graph.
-	${LOADER} ${IMAGES}/dog_207.png -image_mode=0to256 -load_profile=profile.yml -m zfnet512 -cpu -emit-bundle build -g
+	${LOADER} ${IMAGES}/dog_207.png -image_mode=0to256 -load_profile=profile.yml -m zfnet512 -model_input_name=${MODEL_INPUT_NAME} -cpu -emit-bundle build -g
 else
 build/zfnet512.o: download_weights
 	mkdir -p build
-	${LOADER} ${IMAGES}/dog_207.png -image_mode=0to256 -m zfnet512 -cpu -emit-bundle build -g
+	${LOADER} ${IMAGES}/dog_207.png -image_mode=0to256 -m zfnet512 -model_input_name=${MODEL_INPUT_NAME} -cpu -emit-bundle build -g
 endif
 
 build/main.o: zfnet512.cpp


### PR DESCRIPTION
Missed adding these in https://github.com/pytorch/glow/pull/1578

I cannot verify things are working as it seems we have a regression here (see https://github.com/pytorch/glow/issues/1604). I verified that https://github.com/pytorch/glow/pull/1578 was not the cause of this regression. So I cannot verify the full bundle creation, however this PR will still be required for the full fix.