### PR TITLE
[bundles/resnet50] Read from the right output tensor

### DIFF
--- a/examples/bundles/resnet50/resnet50.cpp
+++ b/examples/bundles/resnet50/resnet50.cpp
@@ -326,7 +326,8 @@ static uint8_t *allocateMutableWeightVars(const BundleConfig &config) {
 /// finding the index of the max element.
 static void dumpInferenceResults(const BundleConfig &config,
                                  uint8_t *mutableWeightVars) {
-  const SymbolTableEntry &outputWeights = getMutableWeightVar(config, "output");
+  const SymbolTableEntry &outputWeights =
+      getMutableWeightVar(config, "save_gpu_0_softmax");
   int maxIdx = 0;
   float maxValue = 0;
   float *results = (float *)(mutableWeightVars + outputWeights.offset);


### PR DESCRIPTION
*Description*:
At some point the output of the network changed from "output" to
"gpu_0/softmax". Reflect that when reading the result from the
bundle.


*Testing*:
Ran the makefile of the bundle of resnet50

*Documentation*: N/A
[Optional Fixes #issue]
This fixes #1604