### PR TITLE
Fix the other bundles

### DIFF
--- a/examples/bundles/vgg19/Makefile
+++ b/examples/bundles/vgg19/Makefile
@@ -19,6 +19,9 @@ MODEL_INPUT_NAME=data
 # Compiler.
 CXX=clang++
 
+# Option passed to image_mode.
+IMAGE_MODE=neg128to127
+
 run: vgg19
 	cd build; \
 	for file in ${IMAGES}/*; do \
@@ -32,17 +35,17 @@ vgg19: build/main.o build/vgg19.o
 profile.yml: download_weights
 	# Capture quantization profile based on all inputs.
 	# Note, Interpreter backend is used to collect the profile data.
-	${LOADER} ${IMAGES}/*.png -image_mode=128to127 -dump_profile=profile.yml -m vgg19 -model_input_name=${MODEL_INPUT_NAME}
+	${LOADER} ${IMAGES}/*.png -image_mode=${IMAGE_MODE} -dump_profile=profile.yml -m vgg19 -model_input_name=${MODEL_INPUT_NAME}
 
 ifeq ($(QUANTIZE),YES)
 build/vgg19.o: profile.yml
 	mkdir -p build
 	# Create bundle with quantized weights and computation graph.
-	${LOADER} ${IMAGES}/dog_207.png -image_mode=128to127 -load_profile=profile.yml -m vgg19 -model_input_name=${MODEL_INPUT_NAME} -cpu -emit-bundle build -g
+	${LOADER} ${IMAGES}/dog_207.png -image_mode=${IMAGE_MODE} -load_profile=profile.yml -m vgg19 -model_input_name=${MODEL_INPUT_NAME} -cpu -emit-bundle build -g
 else
 build/vgg19.o: download_weights
 	mkdir -p build
-	${LOADER} ${IMAGES}/dog_207.png -image_mode=128to127 -m vgg19 -model_input_name=${MODEL_INPUT_NAME} -cpu -emit-bundle build -g
+	${LOADER} ${IMAGES}/dog_207.png -image_mode=${IMAGE_MODE} -m vgg19 -model_input_name=${MODEL_INPUT_NAME} -cpu -emit-bundle build -g
 endif
 
 build/main.o: vgg19.cpp

--- a/examples/bundles/vgg19/vgg19.cpp
+++ b/examples/bundles/vgg19/vgg19.cpp
@@ -326,7 +326,8 @@ static uint8_t *allocateMutableWeightVars(const BundleConfig &config) {
 /// finding the index of the max element.
 static void dumpInferenceResults(const BundleConfig &config,
                                  uint8_t *mutableWeightVars) {
-  const SymbolTableEntry &outputWeights = getMutableWeightVar(config, "output");
+  const SymbolTableEntry &outputWeights =
+      getMutableWeightVar(config, "save_prob");
   int maxIdx = 0;
   float maxValue = 0;
   float *results = (float *)(mutableWeightVars + outputWeights.offset);

--- a/examples/bundles/zfnet512/zfnet512.cpp
+++ b/examples/bundles/zfnet512/zfnet512.cpp
@@ -326,7 +326,8 @@ static uint8_t *allocateMutableWeightVars(const BundleConfig &config) {
 /// finding the index of the max element.
 static void dumpInferenceResults(const BundleConfig &config,
                                  uint8_t *mutableWeightVars) {
-  const SymbolTableEntry &outputWeights = getMutableWeightVar(config, "output");
+  const SymbolTableEntry &outputWeights =
+      getMutableWeightVar(config, "save_gpu_0_softmax");
   int maxIdx = 0;
   float maxValue = 0;
   float *results = (float *)(mutableWeightVars + outputWeights.offset);


### PR DESCRIPTION
*Description*:
Fix vgg19 and vfnet512 bundles.
They were both reading from the wrong tensor.
Also vgg19 needed to be updated to use the new name for 128to127 image_mode.

*Testing*:
Ran the respective makefile

*Documentation*: N/A