### PR TITLE
Allow for backend to accept a Function instead of IRFunction

### DIFF
--- a/include/glow/Backends/Backend.h
+++ b/include/glow/Backends/Backend.h
@@ -40,12 +40,6 @@ public:
   /// Dtor.
   virtual ~Backend() = default;
 
-  /// Generate code for input IR function \param IR. \p ctx is the context that
-  /// maps the graph to the concrete execution environment for a specific
-  /// function.
-  virtual std::unique_ptr<CompiledFunction>
-  compile(std::unique_ptr<IRFunction> IR, const Context &ctx) const = 0;
-
   /// Generate code for input function \param F. \p ctx is the context that maps
   /// the graph to the concrete execution environment for a specific function.
   virtual std::unique_ptr<CompiledFunction>
@@ -90,6 +84,17 @@ public:
 
 /// Create a backend of kind \p kind.
 Backend *createBackend(BackendKind backendKind);
+
+// Backends that use Glow low-level IR should inherit from this class. It allows
+// for unit tests to create low-level IR to compile and run.
+class BackendUsingGlowIR : public Backend {
+public:
+  /// Generate code for input IR function \param IR. \p ctx is the context that
+  /// maps the graph to the concrete execution environment for a specific
+  /// function. This is used only for unit testing.
+  virtual std::unique_ptr<CompiledFunction>
+  compileIR(std::unique_ptr<IRFunction> IR, const Context &ctx) const = 0;
+};
 
 } // namespace glow
 

--- a/include/glow/Backends/Backend.h
+++ b/include/glow/Backends/Backend.h
@@ -40,17 +40,22 @@ public:
   /// Dtor.
   virtual ~Backend() = default;
 
-  /// Generate code for input function \param IR. \p ctx is the context that
+  /// Generate code for input IR function \param IR. \p ctx is the context that
   /// maps the graph to the concrete execution environment for a specific
   /// function.
   virtual std::unique_ptr<CompiledFunction>
   compile(std::unique_ptr<IRFunction> IR, const Context &ctx) const = 0;
 
-  /// Save the bundle for \p IR for a later standalone execution
+  /// Generate code for input function \param F. \p ctx is the context that maps
+  /// the graph to the concrete execution environment for a specific function.
+  virtual std::unique_ptr<CompiledFunction>
+  compile(Function *F, const Context &ctx) const = 0;
+
+  /// Save the bundle for \p F for a later standalone execution
   /// in \p outputDir. Make \p networkName the function name for
   /// the entry point of the network and prepend all generated
   /// files with this name.
-  virtual void save(std::unique_ptr<IRFunction> IR, llvm::StringRef outputDir,
+  virtual void save(Function *F, llvm::StringRef outputDir,
                     llvm::StringRef networkName) const {
     GLOW_UNREACHABLE("Saving a bundle is not supported by the backend");
   }

--- a/include/glow/ExecutionEngine/ExecutionEngine.h
+++ b/include/glow/ExecutionEngine/ExecutionEngine.h
@@ -31,10 +31,10 @@
 
 namespace glow {
 
-/// This is the ExecutionEngine. It owns the Graph, the IR, and the backends.
-/// The Graph, IR, etc in this class are defined as pointers, in order to
-/// erase the type and prevent the internal types from leaking out to the
-/// users of this class.
+/// This is the ExecutionEngine. It owns the Graph, the backend, and the
+/// compiled function.  The Graph, etc in this class are defined as pointers, in
+/// order to erase the type and prevent the internal types from leaking out to
+/// the users of this class.
 class ExecutionEngine final {
   /// The Module that represents the high-level program.
   Module M_;
@@ -43,8 +43,8 @@ class ExecutionEngine final {
   /// A glow function compiled for this ExecutionEngine's backend.
   std::unique_ptr<CompiledFunction> function_;
 
-  /// Optimize the graph, generate IR, and optimize the IR.
-  std::unique_ptr<IRFunction> generateIR(CompilationMode mode, Function *F);
+  /// Optimize the Function \p F given compilation mode \p mode.
+  void optimizeFunction(CompilationMode mode, Function *F);
 
 public:
   ExecutionEngine(BackendKind backendKind = BackendKind::Interpreter);
@@ -66,10 +66,10 @@ public:
     return backend_->isOpSupported(opKind, elementTy);
   }
 
-  /// Optimize the graph, generate IR, optimize IR and compile it for a
-  /// specific target. This method should be invoked before the run method.
-  /// The context \p ctx contains the mapping between symbolic values to
-  /// concrete backing tensors.
+  /// Optimize the graph and pass it to the backend to compile it for a specific
+  /// target. This method should be invoked before the run method. The context
+  /// \p ctx contains the mapping between symbolic values to concrete backing
+  /// tensors.
   void compile(CompilationMode mode, Function *F, const Context &ctx);
 
   /// Save a bundle for a standalone execution. This method takes care of

--- a/include/glow/Optimizer/Optimizer.h
+++ b/include/glow/Optimizer/Optimizer.h
@@ -45,6 +45,11 @@ void lower(Function *F, const Backend &B);
 /// \returns a new function with the added quantization nodes.
 Function *profileQuantization(Function *F, llvm::StringRef newFuncName = "");
 
+/// Helper to generate and optimize IR from given Function \p F. \p
+/// shouldShareBuffers signifies whether to use the share buffers optimization.
+std::unique_ptr<IRFunction> generateAndOptimizeIR(Function *F,
+                                                  bool shouldShareBuffers);
+
 } // namespace glow
 
 #endif // GLOW_OPTIMIZER_OPTIMIZER_H

--- a/include/glow/Optimizer/Optimizer.h
+++ b/include/glow/Optimizer/Optimizer.h
@@ -31,7 +31,7 @@ enum class CompilationMode {
 };
 
 /// Perform optimizations on the IR representation.
-void optimize(IRFunction &M, const Backend &B);
+void optimize(IRFunction &M, bool shouldShareBuffers);
 /// Perform optimizations on the graph representation.
 void optimize(Function *F, CompilationMode mode);
 

--- a/lib/Backends/Backends.cpp
+++ b/lib/Backends/Backends.cpp
@@ -17,7 +17,6 @@
 #include "glow/Backends/Backend.h"
 #include "glow/Graph/Graph.h"
 #include "glow/Graph/Nodes.h"
-#include "glow/IR/Instrs.h"
 
 #include "llvm/Support/Casting.h"
 

--- a/lib/Backends/CPU/CMakeLists.txt
+++ b/lib/Backends/CPU/CMakeLists.txt
@@ -62,6 +62,7 @@ target_link_libraries(CPUBackend
                         CodeGen
                         Graph
                         IR
+                        Optimizer
                         QuantizationBase
                         LLVMAnalysis
                         LLVMCodeGen

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -142,9 +142,16 @@ CPUBackend::compile(std::unique_ptr<IRFunction> IR, const Context &ctx) const {
   return llvm::make_unique<CPUFunction>(std::move(JIT), heap);
 }
 
-void CPUBackend::save(std::unique_ptr<IRFunction> IR, llvm::StringRef outputDir,
+std::unique_ptr<CompiledFunction>
+CPUBackend::compile(Function *F, const Context &ctx) const {
+  auto IR = generateAndOptimizeIR(F, shouldShareBuffers());
+  return compile(std::move(IR), ctx);
+}
+
+void CPUBackend::save(Function *F, llvm::StringRef outputDir,
                       llvm::StringRef networkName) const {
   std::string tgt = target.empty() ? "" : target.getValue();
+  auto IR = generateAndOptimizeIR(F, shouldShareBuffers());
   BundleSaver(IR.get()).save(tgt, outputDir, networkName);
 }
 

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -124,7 +124,8 @@ CPUBackend::createIRGen(IRFunction *IR,
 }
 
 std::unique_ptr<CompiledFunction>
-CPUBackend::compile(std::unique_ptr<IRFunction> IR, const Context &ctx) const {
+CPUBackend::compileIR(std::unique_ptr<IRFunction> IR,
+                      const Context &ctx) const {
   AllocationsInfo allocationsInfo;
   std::unique_ptr<LLVMIRGen> irgen = createIRGen(IR.get(), allocationsInfo);
   irgen->initTargetMachine(target.empty() ? "" : target.getValue(),
@@ -145,7 +146,7 @@ CPUBackend::compile(std::unique_ptr<IRFunction> IR, const Context &ctx) const {
 std::unique_ptr<CompiledFunction>
 CPUBackend::compile(Function *F, const Context &ctx) const {
   auto IR = generateAndOptimizeIR(F, shouldShareBuffers());
-  return compile(std::move(IR), ctx);
+  return compileIR(std::move(IR), ctx);
 }
 
 void CPUBackend::save(Function *F, llvm::StringRef outputDir,

--- a/lib/Backends/CPU/CPUBackend.h
+++ b/lib/Backends/CPU/CPUBackend.h
@@ -45,7 +45,10 @@ public:
   std::unique_ptr<CompiledFunction> compile(std::unique_ptr<IRFunction> IR,
                                             const Context &ctx) const override;
 
-  void save(std::unique_ptr<IRFunction> IR, llvm::StringRef outputDir,
+  std::unique_ptr<CompiledFunction> compile(Function *F,
+                                            const Context &ctx) const override;
+
+  void save(Function *F, llvm::StringRef outputDir,
             llvm::StringRef networkName) const override;
 
   bool transformPostLowering(Function *F, CompilationMode mode) const override;

--- a/lib/Backends/CPU/CPUBackend.h
+++ b/lib/Backends/CPU/CPUBackend.h
@@ -32,7 +32,7 @@ namespace glow {
 llvm::CallInst *createCall(llvm::IRBuilder<> &builder, llvm::Function *callee,
                            llvm::ArrayRef<llvm::Value *> args);
 
-class CPUBackend : public Backend {
+class CPUBackend : public BackendUsingGlowIR {
 public:
   /// Ctor.
   CPUBackend() = default;
@@ -42,8 +42,8 @@ public:
   ///@{
   ~CPUBackend() override = default;
 
-  std::unique_ptr<CompiledFunction> compile(std::unique_ptr<IRFunction> IR,
-                                            const Context &ctx) const override;
+  std::unique_ptr<CompiledFunction>
+  compileIR(std::unique_ptr<IRFunction> IR, const Context &ctx) const override;
 
   std::unique_ptr<CompiledFunction> compile(Function *F,
                                             const Context &ctx) const override;

--- a/lib/Backends/Interpreter/CMakeLists.txt
+++ b/lib/Backends/Interpreter/CMakeLists.txt
@@ -7,4 +7,5 @@ target_link_libraries(Interpreter
                         Base
                         Graph
                         IR
+                        Optimizer
                         QuantizationBase)

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -24,6 +24,12 @@
 using namespace glow;
 
 std::unique_ptr<CompiledFunction>
+Interpreter::compile(Function *F, const Context &ctx) const {
+  auto IR = generateAndOptimizeIR(F, shouldShareBuffers());
+  return compile(std::move(IR), ctx);
+}
+
+std::unique_ptr<CompiledFunction>
 Interpreter::compile(std::unique_ptr<IRFunction> IR, const Context &ctx) const {
   return llvm::make_unique<InterpreterFunction>(std::move(IR), ctx);
 }

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -26,11 +26,12 @@ using namespace glow;
 std::unique_ptr<CompiledFunction>
 Interpreter::compile(Function *F, const Context &ctx) const {
   auto IR = generateAndOptimizeIR(F, shouldShareBuffers());
-  return compile(std::move(IR), ctx);
+  return compileIR(std::move(IR), ctx);
 }
 
 std::unique_ptr<CompiledFunction>
-Interpreter::compile(std::unique_ptr<IRFunction> IR, const Context &ctx) const {
+Interpreter::compileIR(std::unique_ptr<IRFunction> IR,
+                       const Context &ctx) const {
   return llvm::make_unique<InterpreterFunction>(std::move(IR), ctx);
 }
 

--- a/lib/Backends/Interpreter/Interpreter.h
+++ b/lib/Backends/Interpreter/Interpreter.h
@@ -24,7 +24,7 @@ namespace glow {
 
 /// This is the IR-interpreter. It owns the IR, and the heap, and is able to
 /// execute the instructions one at a time.
-class Interpreter final : public Backend {
+class Interpreter final : public BackendUsingGlowIR {
 public:
   /// Ctor.
   Interpreter() = default;
@@ -34,8 +34,8 @@ public:
   ///@{
   ~Interpreter() override = default;
 
-  std::unique_ptr<CompiledFunction> compile(std::unique_ptr<IRFunction> IR,
-                                            const Context &ctx) const override;
+  std::unique_ptr<CompiledFunction>
+  compileIR(std::unique_ptr<IRFunction> IR, const Context &ctx) const override;
 
   std::unique_ptr<CompiledFunction> compile(Function *F,
                                             const Context &ctx) const override;

--- a/lib/Backends/Interpreter/Interpreter.h
+++ b/lib/Backends/Interpreter/Interpreter.h
@@ -37,6 +37,9 @@ public:
   std::unique_ptr<CompiledFunction> compile(std::unique_ptr<IRFunction> IR,
                                             const Context &ctx) const override;
 
+  std::unique_ptr<CompiledFunction> compile(Function *F,
+                                            const Context &ctx) const override;
+
   bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override;
 
   bool shouldLower(const Node *N) const override;

--- a/lib/Backends/OpenCL/CMakeLists.txt
+++ b/lib/Backends/OpenCL/CMakeLists.txt
@@ -8,6 +8,7 @@ target_link_libraries(OpenCL
                       Graph
                       CodeGen
                       IR
+                      Optimizer
                       QuantizationBase)
 
 target_link_libraries(OpenCL

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -1581,12 +1581,13 @@ cl_mem OpenCLFunction::allocDeviceBuffer(uint64_t size) {
 void OpenCLFunction::freeDeviceBuffer(cl_mem buf) { clReleaseMemObject(buf); }
 
 std::unique_ptr<CompiledFunction>
-OCLBackend::compile(std::unique_ptr<IRFunction> IR, const Context &ctx) const {
+OCLBackend::compileIR(std::unique_ptr<IRFunction> IR,
+                      const Context &ctx) const {
   return llvm::make_unique<OpenCLFunction>(std::move(IR), ctx);
 }
 
 std::unique_ptr<CompiledFunction>
 OCLBackend::compile(Function *F, const Context &ctx) const {
   auto IR = generateAndOptimizeIR(F, shouldShareBuffers());
-  return compile(std::move(IR), ctx);
+  return compileIR(std::move(IR), ctx);
 }

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -1584,3 +1584,9 @@ std::unique_ptr<CompiledFunction>
 OCLBackend::compile(std::unique_ptr<IRFunction> IR, const Context &ctx) const {
   return llvm::make_unique<OpenCLFunction>(std::move(IR), ctx);
 }
+
+std::unique_ptr<CompiledFunction>
+OCLBackend::compile(Function *F, const Context &ctx) const {
+  auto IR = generateAndOptimizeIR(F, shouldShareBuffers());
+  return compile(std::move(IR), ctx);
+}

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -161,7 +161,7 @@ private:
 };
 
 /// This is the OpenCL backend.
-class OCLBackend final : public Backend {
+class OCLBackend final : public BackendUsingGlowIR {
 public:
   /// Ctor.
   OCLBackend() = default;
@@ -171,8 +171,8 @@ public:
   ///@{
   ~OCLBackend() override = default;
 
-  std::unique_ptr<CompiledFunction> compile(std::unique_ptr<IRFunction> IR,
-                                            const Context &ctx) const override;
+  std::unique_ptr<CompiledFunction>
+  compileIR(std::unique_ptr<IRFunction> IR, const Context &ctx) const override;
 
   std::unique_ptr<CompiledFunction> compile(Function *F,
                                             const Context &ctx) const override;

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -174,6 +174,9 @@ public:
   std::unique_ptr<CompiledFunction> compile(std::unique_ptr<IRFunction> IR,
                                             const Context &ctx) const override;
 
+  std::unique_ptr<CompiledFunction> compile(Function *F,
+                                            const Context &ctx) const override;
+
   bool transformPostLowering(Function *F, CompilationMode mode) const override;
 
   bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override {

--- a/lib/ExecutionEngine/CMakeLists.txt
+++ b/lib/ExecutionEngine/CMakeLists.txt
@@ -6,5 +6,4 @@ target_link_libraries(ExecutionEngine
                         Backends
                         Optimizer
                         Base
-                        Graph
-                        IR)
+                        Graph)

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -156,7 +156,7 @@ std::unique_ptr<IRFunction> ExecutionEngine::generateIR(CompilationMode mode,
   IR->generateIR();
 
   // Optimize the generated IR.
-  ::glow::optimize(*IR, *backend_);
+  ::glow::optimize(*IR, backend_->shouldShareBuffers());
 
   // If requested, dump IR to stdout and/or dot file for debugging.
   if (dumpIR) {

--- a/lib/Optimizer/CMakeLists.txt
+++ b/lib/Optimizer/CMakeLists.txt
@@ -9,5 +9,4 @@ target_link_libraries(Optimizer
                       PRIVATE
                         Graph
                         IR
-                        Backends
                         QuantizationBase)

--- a/lib/Optimizer/IROptimizer.cpp
+++ b/lib/Optimizer/IROptimizer.cpp
@@ -1593,7 +1593,7 @@ void performPeepholeOptimizations(IRFunction &M) {
 }
 
 /// Perform optimizations on the IR representation.
-void glow::optimize(IRFunction &M, const Backend &B) {
+void glow::optimize(IRFunction &M, bool shouldShareBuffers) {
   M.verify();
   if (!optimizeIR)
     return;
@@ -1607,7 +1607,7 @@ void glow::optimize(IRFunction &M, const Backend &B) {
   optimizeExtracts(M);
 
   // Reuse buffers from previous operations.
-  if (B.shouldShareBuffers())
+  if (shouldShareBuffers)
     shareBuffers(M);
 
   performPeepholeOptimizations(M);

--- a/tests/unittests/BackendCorrectnessTest.cpp
+++ b/tests/unittests/BackendCorrectnessTest.cpp
@@ -239,6 +239,10 @@ class MockCPUBackend : public Backend {
 
 public:
   MockCPUBackend() { backend_.reset(createBackend(BackendKind::CPU)); }
+  std::unique_ptr<CompiledFunction> compile(Function *F,
+                                            const Context &ctx) const override {
+    return backend_->compile(F, ctx);
+  }
   std::unique_ptr<CompiledFunction> compile(std::unique_ptr<IRFunction> IR,
                                             const Context &ctx) const override {
     return backend_->compile(std::move(IR), ctx);

--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -136,6 +136,9 @@ TEST_P(BackendTest, simpleInference) {
   EE_.run();
 }
 
+/// Test that the DebugPrint instruction works correctly for the backend. Note
+/// that the backend being tested must inherit from BackendUsingGlowIR and
+/// implement the compileIR() function for this test to work.
 TEST_P(BackendTest, debugPrint) {
   Tensor input{0.0, 1.0, 2.0, 3.0};
   Module mod;
@@ -147,9 +150,10 @@ TEST_P(BackendTest, debugPrint) {
   IR->generateIR();
   IRBuilder(IR.get()).createDebugPrintInst("print", *IR->getWeights().begin());
 
-  std::unique_ptr<Backend> backend(createBackend(GetParam()));
+  std::unique_ptr<BackendUsingGlowIR> backend(
+      static_cast<BackendUsingGlowIR *>(createBackend(GetParam())));
   Context empty;
-  auto function = backend->compile(std::move(IR), empty);
+  auto function = backend->compileIR(std::move(IR), empty);
   function->execute();
 }
 

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -29,10 +29,6 @@ class MockBackend : public Backend {
                                             const Context &ctx) const override {
     return llvm::make_unique<MockFunction>();
   }
-  std::unique_ptr<CompiledFunction> compile(std::unique_ptr<IRFunction> IR,
-                                            const Context &ctx) const override {
-    return llvm::make_unique<MockFunction>();
-  }
   bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override {
     return false;
   }

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -25,6 +25,10 @@ class MockBackend : public Backend {
   class MockFunction : public CompiledFunction {
     void execute() override {}
   };
+  std::unique_ptr<CompiledFunction> compile(Function *F,
+                                            const Context &ctx) const override {
+    return llvm::make_unique<MockFunction>();
+  }
   std::unique_ptr<CompiledFunction> compile(std::unique_ptr<IRFunction> IR,
                                             const Context &ctx) const override {
     return llvm::make_unique<MockFunction>();

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -226,7 +226,7 @@ target_link_libraries(caffe2ImporterTest
                         ExecutionEngine
                         gtest
                         testMain)
-add_glow_test(NAME caffe2ImporterTest 
+add_glow_test(NAME caffe2ImporterTest
               COMMAND ${GLOW_BINARY_DIR}/tests/caffe2ImporterTest
               WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
@@ -254,4 +254,3 @@ LIST(APPEND UNOPT_TESTS
 
 add_custom_target(test_unopt ${UNOPT_TESTS}
                   WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-

--- a/tests/unittests/IROptTest.cpp
+++ b/tests/unittests/IROptTest.cpp
@@ -56,7 +56,7 @@ TEST(Optimizer, dseBasic) {
   bb.createElementSelectInst("select", output, input1, output, input2);
   bb.createElementAddInst("elem_add2", output, input2, input2);
 
-  optimize(M, MockBackend());
+  optimize(M, MockBackend().shouldShareBuffers());
 
   // Check that the first relu instruction  and select are eliminated, because
   // their outputs are never read.
@@ -84,7 +84,7 @@ TEST(Optimizer, dseDoNotRemloveLastWriteIntoWeightVar) {
       "cast", output, mod.uniqueType(Type(glow::ElemKind::FloatTy, {1, 1, 1})),
       {0, 0, 0});
 
-  optimize(M, MockBackend());
+  optimize(M, MockBackend().shouldShareBuffers());
 
   // Check that the first relu instruction  and select are eliminated, because
   // their outputs are never read.
@@ -119,7 +119,7 @@ TEST(Optimizer, shareBuffers) {
   bb.createDeallocActivationInst("dealloc2", alloc2);
   bb.createDeallocActivationInst("dealloc1", alloc1);
 
-  optimize(M, MockBackend());
+  optimize(M, MockBackend().shouldShareBuffers());
 
   // Check that the first relu instruction  and select are eliminated, because
   // their outputs are never read.
@@ -146,7 +146,7 @@ TEST(Optimizer, deleteDeadViews) {
                           {0});
   bb.createCopyInst("copy", output, input);
 
-  optimize(M, MockBackend());
+  optimize(M, MockBackend().shouldShareBuffers());
 
   // Check that all tensor_view instructions are eliminated, because they are
   // never used.
@@ -179,7 +179,7 @@ TEST(Optimizer, copyPropagation) {
   bb.createDeallocActivationInst("dealloc2", alloc2);
   bb.createDeallocActivationInst("dealloc1", alloc1);
 
-  optimize(M, MockBackend());
+  optimize(M, MockBackend().shouldShareBuffers());
 
   EXPECT_EQ(M.getInstrs().size(), 5);
 
@@ -211,7 +211,7 @@ TEST(Optimizer, copyPropagationSimple) {
   bb.createDeallocActivationInst("dealloc2", alloc2);
   bb.createDeallocActivationInst("dealloc1", alloc1);
 
-  optimize(M, MockBackend());
+  optimize(M, MockBackend().shouldShareBuffers());
 
   EXPECT_EQ(M.getInstrs().size(), 2);
 
@@ -247,7 +247,7 @@ TEST(Optimizer, copyPropagationTranspose) {
   bb.createDeallocActivationInst("dealloc2", alloc2);
   bb.createDeallocActivationInst("dealloc1", alloc1);
 
-  optimize(M, MockBackend());
+  optimize(M, MockBackend().shouldShareBuffers());
 
   EXPECT_EQ(M.getInstrs().size(), 5);
 
@@ -280,7 +280,7 @@ TEST(Optimizer, insertOptimizer) {
 
   bb.createDeallocActivationInst("deallocSrc", allocSrc);
 
-  optimize(M, MockBackend());
+  optimize(M, MockBackend().shouldShareBuffers());
 
   // After optimization, should be left with two splats and a tensorview; the
   // insert, alloc, and dealloc should be gone.
@@ -325,7 +325,7 @@ TEST(Optimizer, twoInsertsWithBuffersOptimizer) {
   bb.createDeallocActivationInst("deallocSrc2", allocSrc2);
   bb.createDeallocActivationInst("deallocSrc1", allocSrc1);
 
-  optimize(M, MockBackend());
+  optimize(M, MockBackend().shouldShareBuffers());
 
   // After optimization, should be left with three splats and two tensorviews;
   // the inserts, allocs, and deallocs should be gone.
@@ -372,7 +372,7 @@ TEST(Optimizer, twoExtractsWithBuffersOptimizer) {
   bb.createDeallocActivationInst("deallocDest2", allocDest2);
   bb.createDeallocActivationInst("deallocDest1", allocDest1);
 
-  optimize(M, MockBackend());
+  optimize(M, MockBackend().shouldShareBuffers());
 
   // After optimization, the extracts should be gone, as well as both allocDests
   // and their deallocs. Should be left with splatSrc, allocSrc, deallocSrc, two
@@ -415,7 +415,7 @@ TEST(Optimizer, forwardCopy) {
 
   auto &instrs = M.getInstrs();
   auto nbInstrsBeforeOpt = instrs.size();
-  optimize(M, MockBackend());
+  optimize(M, MockBackend().shouldShareBuffers());
 
   // After optimization, the copy should have been coalesced with input.
   // nbIntrsBeforeOpt - 1 copy - 1 dealloc - 1 alloc
@@ -461,7 +461,7 @@ TEST(Optimizer, chainOfTwoForwardCopies) {
 
   auto &instrs = M.getInstrs();
   auto nbInstrsBeforeOpt = instrs.size();
-  optimize(M, MockBackend());
+  optimize(M, MockBackend().shouldShareBuffers());
 
   // After optimization, the copies should have been coalesced with
   // input.
@@ -519,7 +519,7 @@ TEST(Optimizer, inoutCopy) {
   bb.createDeallocActivationInst("dealloc1", tmp1);
   bb.createDeallocActivationInst("dealloc2", tmp2);
 
-  optimize(M, MockBackend());
+  optimize(M, MockBackend().shouldShareBuffers());
 
   // After optimization, the copies shouldn't have been touched.
   // tmp1 = copy input cannot be coalesced because tmp1 is inout.
@@ -611,7 +611,7 @@ TEST(Optimizer, bufferReuseWithoutDefs) {
   bb.createDeallocActivationInst("dealloc2", tmp2);
   bb.createDeallocActivationInst("dealloc2", tmp3);
 
-  optimize(M, MockBackend());
+  optimize(M, MockBackend().shouldShareBuffers());
 
   // Check that we manage to expose the problematic case we wanted:
   // tmp1 is extended upward and replace the use of input.
@@ -687,7 +687,7 @@ TEST(Optimizer, bufferReuseWithoutDefsPlusCasts) {
   bb.createDeallocActivationInst("dealloc2", tmp2);
   bb.createDeallocActivationInst("dealloc2", tmp3);
 
-  optimize(M, MockBackend());
+  optimize(M, MockBackend().shouldShareBuffers());
 
   // Check that we manage to expose the problematic case we wanted:
   // tmp1 is extended upward and replace the use of input.

--- a/tests/unittests/quantizationTest.cpp
+++ b/tests/unittests/quantizationTest.cpp
@@ -626,10 +626,6 @@ public:
                                             const Context &ctx) const override {
     return backend_->compile(F, ctx);
   }
-  std::unique_ptr<CompiledFunction> compile(std::unique_ptr<IRFunction> IR,
-                                            const Context &ctx) const override {
-    return backend_->compile(std::move(IR), ctx);
-  }
   bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override {
     if (opKind == Kinded::Kind::SoftMaxNodeKind ||
         opKind == Kinded::Kind::LocalResponseNormalizationNodeKind) {

--- a/tests/unittests/quantizationTest.cpp
+++ b/tests/unittests/quantizationTest.cpp
@@ -622,6 +622,10 @@ public:
   MockQuantBackend() {
     backend_.reset(createBackend(BackendKind::Interpreter));
   }
+  std::unique_ptr<CompiledFunction> compile(Function *F,
+                                            const Context &ctx) const override {
+    return backend_->compile(F, ctx);
+  }
   std::unique_ptr<CompiledFunction> compile(std::unique_ptr<IRFunction> IR,
                                             const Context &ctx) const override {
     return backend_->compile(std::move(IR), ctx);

--- a/tools/loader/CMakeLists.txt
+++ b/tools/loader/CMakeLists.txt
@@ -7,7 +7,6 @@ target_link_libraries(image-classifier
                         Base
                         Importer
                         ExecutionEngine
-                        IR
                         Quantization)
 
 add_executable(text-translator
@@ -19,7 +18,6 @@ target_link_libraries(text-translator
                         Base
                         Importer
                         ExecutionEngine
-                        IR
                         Quantization)
 
 add_executable(model-runner
@@ -31,5 +29,4 @@ target_link_libraries(model-runner
                         Base
                         Importer
                         ExecutionEngine
-                        IR
                         Quantization)


### PR DESCRIPTION
This PR allows for Backends to take a Function pointer for `compile()` and `save()`, instead of a IRFunction. The EE now does this. This allows for example for a backend to decide whether it wants to use our Instruction level IR or implement its own. The Interpreter, CPUBackend, and OpenCL backend all still use our Instruction level IR.

Note that I needed to keep the `compile()` that takes the IRFunction around, as it is used during unit tests. I couldn't think of good ways to change the unit tests to be able to remove it. Open to suggestions.

Also, the first commit here moves the IROptimizer's `optimize()` to take a bool for `shouldShareBuffers` so that Optimizer no longer depends on Backends. This prevents a cyclic dependence from the second commit.

(I also verified that bundling still works 😃)