### PR TITLE
Allow the differentiation of Placeholder nodes.

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -127,9 +127,10 @@ public:
   ///@{
 
   Placeholder *createPlaceholder(ElemKind T, llvm::ArrayRef<size_t> dims,
-                                 llvm::StringRef name);
+                                 llvm::StringRef name, bool isTrainable);
 
-  Placeholder *createPlaceholder(TypeRef T, llvm::StringRef name);
+  Placeholder *createPlaceholder(TypeRef T, llvm::StringRef name,
+                                 bool isTrainable);
 
   Variable *createVariable(TypeRef T, llvm::StringRef name,
                            VisibilityKind visibility = VisibilityKind::Private,

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -627,7 +627,7 @@ public:
 
 struct TrainingConfig;
 
-using VariableGradientsList = std::list<std::pair<Variable *, Variable *>>;
+using VariableGradientsList = std::list<std::pair<Storage *, Storage *>>;
 
 /// Create a new Function that 'trains' the input Function. We differentiate the
 /// nodes and insert code to update the weights based on the \p config

--- a/lib/Graph/Grad.cpp
+++ b/lib/Graph/Grad.cpp
@@ -83,7 +83,7 @@ Function *glow::differentiate(Function *F, const TrainingConfig &conf,
 
   for (auto it = nodes.rbegin(), e = nodes.rend(); it != e; it++) {
     Node *N = *it;
-    if (isa<Variable>(N)) {
+    if (isa<Storage>(N)) {
       continue;
     }
 
@@ -228,9 +228,9 @@ Function *glow::differentiate(Function *F, const TrainingConfig &conf,
   } // End of the for-each instr loop.
 
   for (auto N : nodes) {
-    // Iterate only through Variables used by the Function.
+    // Iterate only through Variables/Placeholders used by the Function.
     // These are inserted during the post-order walk.
-    Variable *V = llvm::dyn_cast<Variable>(N);
+    Storage *V = llvm::dyn_cast<Storage>(N);
     if (!V)
       continue;
 
@@ -241,7 +241,7 @@ Function *glow::differentiate(Function *F, const TrainingConfig &conf,
         std::string nodeName = "_grad_" + V->getName().str();
         // Save the gradient and return the destination variable.
         auto *saveNode = G->createSave(nodeName, map.getGradient(V));
-        auto *GradV = llvm::dyn_cast<Variable>(saveNode->getOutput().getNode());
+        auto *GradV = llvm::dyn_cast<Storage>(saveNode->getOutput().getNode());
         varGrads->push_back({V, GradV});
       }
       continue;

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -332,15 +332,16 @@ static ShapeVector getNewShapeWithoutAxis(llvm::ArrayRef<size_t> dims,
 //                       Node builders
 //===----------------------------------------------------------------------===//
 
-Placeholder *Module::createPlaceholder(TypeRef T, llvm::StringRef name) {
+Placeholder *Module::createPlaceholder(TypeRef T, llvm::StringRef name,
+                                       bool isTrainable) {
   auto FT = uniqueType(*T);
-  return addPlaceholder(new Placeholder(name, FT));
+  return addPlaceholder(new Placeholder(name, FT, isTrainable));
 }
 
 Placeholder *Module::createPlaceholder(ElemKind T, llvm::ArrayRef<size_t> dims,
-                                       llvm::StringRef name) {
+                                       llvm::StringRef name, bool isTrainable) {
   auto FT = uniqueType(T, dims);
-  return createPlaceholder(FT, name);
+  return createPlaceholder(FT, name, isTrainable);
 }
 
 Variable *Module::createVariable(TypeRef T, llvm::StringRef name,

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -2069,7 +2069,7 @@ Function *Function::clone(llvm::StringRef newName,
 
       auto it = currToNew.find(input.getNode());
       if (it == currToNew.end()) {
-        assert(isa<Variable>(input.getNode()) &&
+        assert(isa<Storage>(input.getNode()) &&
                "Could not find a mapping for some node!");
         continue;
       }

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -100,7 +100,8 @@ std::string Placeholder::getDebugDesc() const {
   DescriptionBuilder db(getKindName());
   db.addParam("name", quote(getName()))
       .addParam("output", *getType())
-      .addParam("users", getNumUsers());
+      .addParam("users", getNumUsers())
+      .addParam("trainable", isTraining());
   return db;
 }
 

--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -188,7 +188,7 @@ TEST_P(BackendTest, simplePlaceholderValue) {
   Tensor data{99.0, 35.0, 2.0, 3.0};
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("main");
-  auto *input = mod.createPlaceholder(ElemKind::FloatTy, {4}, "input");
+  auto *input = mod.createPlaceholder(ElemKind::FloatTy, {4}, "input", false);
   SaveNode *S = F->createSave("ret", input);
   Context ctx({input}, {&data});
 
@@ -207,9 +207,9 @@ TEST(Context, basicContextTest) {
 
   // Create a simple graph, just to have a few placeholders.
   Function *F = mod.createFunction("main");
-  auto *input1 = mod.createPlaceholder(ty, "input1");
-  auto *input2 = mod.createPlaceholder(ty, "input2");
-  auto *input3 = mod.createPlaceholder(ty, "input3");
+  auto *input1 = mod.createPlaceholder(ty, "input1", false);
+  auto *input2 = mod.createPlaceholder(ty, "input2", false);
+  auto *input3 = mod.createPlaceholder(ty, "input3", false);
   auto *add = F->createAdd("add", input1, input2);
   F->createSave("ret", add);
 

--- a/tests/unittests/gradCheckTest.cpp
+++ b/tests/unittests/gradCheckTest.cpp
@@ -25,6 +25,7 @@
 #include "gtest/gtest.h"
 
 using namespace glow;
+using llvm::cast;
 
 class GradCheckBase : public ::testing::TestWithParam<BackendKind> {
 public:
@@ -57,7 +58,7 @@ float gradDiff(float G1, float G2) {
 Variable *getGrad(const VariableGradientsList &grads, Variable *V) {
   for (auto &p : grads) {
     if (p.first == V) {
-      return p.second;
+      return cast<Variable>(p.second);
     }
   }
   return nullptr;

--- a/tests/unittests/graphTest.cpp
+++ b/tests/unittests/graphTest.cpp
@@ -903,8 +903,9 @@ TEST(Graph, placeholder) {
   Module MD;
   Function *F = MD.createFunction("F");
   IRFunction M(F);
-  Node *K = MD.createPlaceholder(ElemKind::FloatTy, {4, 320, 200, 3}, "input");
-  Node *S = MD.createPlaceholder(ElemKind::Int64ITy, {4, 1}, "select");
+  Node *K =
+      MD.createPlaceholder(ElemKind::FloatTy, {4, 320, 200, 3}, "input", false);
+  Node *S = MD.createPlaceholder(ElemKind::Int64ITy, {4, 1}, "select", false);
 
   K = F->createFullyConnected("FC", K, 10);
   K = F->createRELU("Relu", K);


### PR DESCRIPTION
*Description*: Allow the differentiation of Placeholder nodes. This PR includes two main parts. First, we add a flag to Placeholder to match the Variable node and allow the differentiation of the selected nodes. The second part fixes a few places (scheduler, cloner, etc) that assume that all storage nodes are Variable. 
 
*Testing*: Added unit tests and ran ninja check.
*Documentation*: None.

This is related to #1334. This PR is a step in the direction of eliminating the Variables, and is required for porting our unit tests to Placeholders instead of training mutable variables.  