### PR TITLE
[Context] Add a method to allocate a new backing tensor.

### DIFF
--- a/include/glow/ExecutionEngine/ExecutionEngine.h
+++ b/include/glow/ExecutionEngine/ExecutionEngine.h
@@ -18,9 +18,9 @@
 
 #include "glow/Backends/Backend.h"
 #include "glow/Backends/CompiledFunction.h"
-#include "glow/Base/Context.h"
 #include "glow/Base/Train.h"
 #include "glow/Base/Traits.h"
+#include "glow/Graph/Context.h"
 #include "glow/Graph/Graph.h"
 #include "glow/Optimizer/Optimizer.h"
 

--- a/include/glow/Graph/Context.h
+++ b/include/glow/Graph/Context.h
@@ -49,6 +49,10 @@ public:
   /// Inserts the Placeholder-Tensor pair.
   void insert(Placeholder *P, Tensor &&T);
 
+  /// Allocates a tensor to back the placeholder \p P. The new tensor has the
+  /// type of P.
+  Tensor *allocate(Placeholder *P);
+
   /// \returns True if \p P is a registered Placeholder.
   size_t count(Placeholder *P) const;
 

--- a/lib/Backends/CPU/AllocationsInfo.cpp
+++ b/lib/Backends/CPU/AllocationsInfo.cpp
@@ -16,8 +16,8 @@
 #define DEBUG_TYPE "jit-allocations"
 
 #include "AllocationsInfo.h"
-#include "glow/Base/Context.h"
 #include "glow/CodeGen/MemoryAllocator.h"
+#include "glow/Graph/Context.h"
 #include "glow/Graph/Graph.h"
 #include "glow/Graph/Nodes.h"
 #include "glow/IR/IRUtils.h"

--- a/lib/Backends/CPU/BundleSaver.cpp
+++ b/lib/Backends/CPU/BundleSaver.cpp
@@ -19,7 +19,7 @@
 
 #include "CPUBackend.h"
 
-#include "glow/Base/Context.h"
+#include "glow/Graph/Context.h"
 #include "glow/Graph/Graph.h"
 #include "glow/IR/Instrs.h"
 #include "glow/Support/Debug.h"

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -17,8 +17,8 @@
 #define GLOW_BACKENDS_INTERPRETER_INTERPRETERFUNCTION_H
 
 #include "glow/Backends/CompiledFunction.h"
-#include "glow/Base/Context.h"
 #include "glow/Base/Tensor.h"
+#include "glow/Graph/Context.h"
 
 #include "llvm/ADT/ArrayRef.h"
 

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -18,9 +18,9 @@
 
 #include "glow/Backends/Backend.h"
 #include "glow/Backends/CompiledFunction.h"
-#include "glow/Base/Context.h"
 #include "glow/Base/Tensor.h"
 #include "glow/Base/Traits.h"
+#include "glow/Graph/Context.h"
 #include "glow/Graph/Node.h"
 #include "llvm/ADT/ArrayRef.h"
 

--- a/lib/Base/CMakeLists.txt
+++ b/lib/Base/CMakeLists.txt
@@ -1,5 +1,4 @@
 add_library(Base
-              Context.cpp
               Tensor.cpp
               Type.cpp
               Image.cpp)

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -16,7 +16,7 @@
 
 #include "glow/ExecutionEngine/ExecutionEngine.h"
 #include "glow/Backends/Backend.h"
-#include "glow/Base/Context.h"
+#include "glow/Graph/Context.h"
 #include "glow/Graph/Graph.h"
 #include "glow/IR/IR.h"
 #include "glow/IR/IRBuilder.h"

--- a/lib/Graph/CMakeLists.txt
+++ b/lib/Graph/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(Graph
             ${INSTR_DEF}
             ${INSTR_BLD_HDR}
             ${INSTR_BLD_SRC}
+            Context.cpp
             Node.cpp
             Nodes.cpp
             Graph.cpp

--- a/lib/Graph/Context.cpp
+++ b/lib/Graph/Context.cpp
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-#include "glow/Base/Context.h"
+#include "glow/Graph/Context.h"
 #include "glow/Base/Tensor.h"
+#include "glow/Graph/Nodes.h"
 
 using namespace glow;
 
@@ -43,6 +44,13 @@ void Context::clear() {
   }
 
   map_.clear();
+}
+
+Tensor *Context::allocate(Placeholder *P) {
+  assert(!map_.count(P) && "Placeholder already registered");
+  Tensor *T = new Tensor(P->getType());
+  map_[P] = T;
+  return T;
 }
 
 Context::Context(llvm::ArrayRef<Placeholder *> placeholders,

--- a/tests/unittests/BackendCorrectnessTest.cpp
+++ b/tests/unittests/BackendCorrectnessTest.cpp
@@ -16,8 +16,8 @@
 
 #include "BackendTestUtils.h"
 
-#include "glow/Base/Context.h"
 #include "glow/ExecutionEngine/ExecutionEngine.h"
+#include "glow/Graph/Context.h"
 #include "glow/Graph/Graph.h"
 #include "glow/IR/IR.h"
 #include "glow/IR/IRBuilder.h"

--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#include "glow/Base/Context.h"
 #include "glow/ExecutionEngine/ExecutionEngine.h"
+#include "glow/Graph/Context.h"
 #include "glow/Graph/Graph.h"
 #include "glow/IR/IRBuilder.h"
 
@@ -204,7 +204,6 @@ TEST(Context, basicContextTest) {
   TypeRef ty = mod.uniqueType(ElemKind::FloatTy, {1, 32, 32, 3});
 
   Tensor T1(ty);
-  Tensor T2(ty);
 
   // Create a simple graph, just to have a few placeholders.
   Function *F = mod.createFunction("main");
@@ -218,7 +217,7 @@ TEST(Context, basicContextTest) {
   Context C;
 
   C.insert(input1, std::move(T1));
-  C.insert(input2, std::move(T2));
+  Tensor *I2 = C.allocate(input2);
 
   // Check that the right placeholders are found.
   EXPECT_TRUE(C.count(input1));
@@ -232,6 +231,10 @@ TEST(Context, basicContextTest) {
   EXPECT_NE(V1, nullptr);
   EXPECT_NE(V2, nullptr);
   EXPECT_EQ(V3, nullptr);
+
+  // The tensor that we got while allocating T2 is the same one that we got
+  // while searching the context.
+  EXPECT_EQ(I2, V2);
 }
 
 INSTANTIATE_TEST_CASE_P(Interpreter, BackendTest,

--- a/tests/unittests/onnxImporterTest.cpp
+++ b/tests/unittests/onnxImporterTest.cpp
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 #include "ImporterTestUtils.h"
-#include "glow/Base/Context.h"
 #include "glow/ExecutionEngine/ExecutionEngine.h"
+#include "glow/Graph/Context.h"
 #include "glow/Graph/Graph.h"
 #include "glow/Importer/ONNX.h"
 #include "gtest/gtest.h"


### PR DESCRIPTION
*Description*:

While writing a unit test that replaces some Variable with a Placeholder
I realized that in most cases we mainly care about allocating new
tensors, and not moving an existing tensor into the context. To
implement the new 'allocate' method I had to move the Context into the
Graph library, because it depends on the Placeholder class to figure out
the type of the Placeholder for Tensor allocatio method I had to move
the Context into the Graph library, because it depends on the
Placeholder class to figure out the type of the Placeholder for Tensor
allocation.

*Testing*: Updated the unit test.
*Documentation*: None.