### PR TITLE
[GraphScheduler] Fix underflow bug

### DIFF
--- a/include/glow/IR/GraphScheduler.h
+++ b/include/glow/IR/GraphScheduler.h
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_IR_GRAPH_SCHEDULER_H
+#define GLOW_IR_GRAPH_SCHEDULER_H
+
+#include "glow/Graph/Graph.h"
+#include "glow/Graph/Nodes.h"
+#include "glow/Graph/Utils.h"
+#include "glow/IR/IR.h"
+#include "glow/Support/Debug.h"
+
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/ADT/StringSet.h"
+#include "llvm/ADT/ilist.h"
+#include "llvm/ADT/ilist_node.h"
+
+#include <unordered_map>
+#include <unordered_set>
+
+namespace glow {
+class Scheduler {
+protected:
+  /// Graph being processed.
+  Function &G_;
+  /// Scheduled nodes.
+  NodesPtrList &scheduled_;
+
+public:
+  Scheduler(Function &G, NodesPtrList &scheduled)
+      : G_(G), scheduled_(scheduled) {}
+
+  virtual ~Scheduler() = default;
+
+  // Create a linear execution schedule for a graph.
+  virtual void schedule() = 0;
+
+  NodesPtrList &getSchedule() { return scheduled_; }
+};
+
+/// This is a scheduler based on the generalized the paper "Generalizations of
+/// the Sethi-Ullman algorithm for register allocation" by Andrew W. Appel and
+/// Kenneth J. Supowit.
+/// http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.54.319&rep=rep1&type=pdf
+///
+/// The idea is to give more priority and schedule earlier those child nodes
+/// that free more memory after their computation.
+class ChildMemSizeBasedScheduler : public Scheduler {
+  /// Required number of bytes to hold the results of a given node.
+  std::unordered_map<const Node *, size_t> resultMemSize_;
+  /// Max number of bytes required during the computation of a given node.
+  std::unordered_map<const Node *, size_t> maxMemSize_;
+
+  /// \returns true if a node \p N is scheduled already.
+  bool isScheduled(const Node *N) const;
+
+  /// Computes the amount of memory required to keep the result
+  /// of each node.
+  void computeNodeResultsMemorySize();
+
+  /// Computes the max amount of memory required during the computation
+  /// of children for each node.
+  void computeNodeComputationMaxMemorySize();
+
+  /// Order children by (maxSize - resultSize). It gives more
+  /// priority to the nodes that free more memory after
+  /// their computation.
+  void orderChildNodesAndSchedule(Node *N);
+
+  void scheduleNodes();
+
+public:
+  ChildMemSizeBasedScheduler(Function &G, NodesPtrList &Schedule)
+      : Scheduler(G, Schedule) {}
+
+  ~ChildMemSizeBasedScheduler() override = default;
+
+  void schedule() override;
+};
+
+} // namespace glow
+
+#endif // GLOW_IR_GRAPH_SCHEDULER_H

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -124,6 +124,16 @@ target_link_libraries(graphOptzTest
                         testMain)
 add_glow_test(graphOptzTest ${GLOW_BINARY_DIR}/tests/graphOptzTest)
 
+add_executable(graphSchedulerTest
+	       graphSchedulerTest.cpp)
+target_link_libraries(graphSchedulerTest
+                      PRIVATE
+                        Graph
+                        IR
+                        gtest
+                        testMain)
+add_glow_test(graphSchedulerTest ${GLOW_BINARY_DIR}/tests/graphSchedulerTest)
+
 add_executable(quantizationTest
                quantizationTest.cpp)
 target_link_libraries(quantizationTest

--- a/tests/unittests/graphSchedulerTest.cpp
+++ b/tests/unittests/graphSchedulerTest.cpp
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/IR/GraphScheduler.h"
+#include "glow/Graph/Graph.h"
+#include "glow/Graph/Node.h"
+#include "glow/Graph/Nodes.h"
+
+#include "gtest/gtest.h"
+
+using namespace glow;
+
+/// Tests a case in which the memory required to store a node's
+/// output is greater than the memory required to store its input.
+/// This node uses more memory after it executes, and should be
+/// scheduled after its siblings that free up memory after
+/// they execute.
+TEST(GraphScheduler, testMaxSizeLessThanResultSize) {
+  Module MD;
+  Variable *smallTensorA = MD.createVariable(ElemKind::FloatTy, {1, 4, 4},
+                                             "small_1", VisibilityKind::Public);
+  Variable *smallTensorB = MD.createVariable(ElemKind::FloatTy, {1, 4, 4},
+                                             "small_2", VisibilityKind::Public);
+  Variable *bigTensor = MD.createVariable(ElemKind::FloatTy, {100, 4, 4}, "big",
+                                          VisibilityKind::Public);
+
+  Function *F = MD.createFunction("F");
+  Node *transposeBig = F->createTranspose("transposeBig", bigTensor, {0, 2, 1});
+  Node *sliceBig =
+      F->createSlice("sliceBig", transposeBig, {0, 0, 0}, {1, 4, 4});
+  Node *concatSmall =
+      F->createConcat("concatSmall", {smallTensorA, smallTensorB}, 0);
+  F->createConcat("concat", {concatSmall, sliceBig}, 0);
+
+  /// The graph created above looks like this:
+  ///
+  ///  bigTensor       smallTensorA       smallTensorB
+  /// {100, 4, 4}        {1, 4, 4}         {1, 4, 4}
+  ///     |                     \         /
+  ///     v                      v       v
+  /// transposeBig                 concatSmall
+  ///  {0, 2, 1}                     {0}
+  ///     |                           |
+  ///     v                           |
+  ///  sliceBig                       |
+  ///  {0, 0, 0}                      |
+  ///  {1, 4, 4}                      |
+  ///     |                           |
+  ///     ---------> concat <----------
+  ///                 {0}
+  ///
+  /// Since all of the tensors are Variables, they don't need
+  /// memory for storing their outputs. Consequently, sliceBig
+  /// should be scheduled before concatSmall in this example
+  /// because the former frees up some memory while the latter
+  /// uses up more memory after execution.
+  NodesPtrList schedule;
+  ChildMemSizeBasedScheduler scheduler(*F, schedule);
+  scheduler.schedule();
+
+  /// Find the positions of sliceBig and concatSmall in
+  /// the schedule.
+  int i = 0, concatSmallIdx = -1, sliceBigIdx = -1;
+  for (auto *N : schedule) {
+    if (N == concatSmall) {
+      concatSmallIdx = i;
+    }
+
+    if (N == sliceBig) {
+      sliceBigIdx = i;
+    }
+
+    ++i;
+  }
+
+  /// For the reason given above, sliceBig should be scheduled
+  /// before concatSmallIdx.
+  ASSERT_LT(sliceBigIdx, concatSmallIdx);
+}


### PR DESCRIPTION
**Description**
This commit fixes an underflow bug in
`ChildMemSizeBasedScheduler::orderChildNodesAndSchedule` that can
cause incorrect scheduling. There is code in this function that
orders the children of a node by the amount of memory they free up
by executing. For each node, this is computed as `maxSize - resultSize`,
where maxSize is the total memory needed to compute and store the node's
inputs, and resultSize is the total memory needed to store the node's
outputs. For some nodes, such as a `Concat` that takes `Variables` as input,
`resultSize > maxSize`, so this subtraction underflows, and the scheduler
thinks that the node frees up a lot of memory and schedules it before
some or all of its siblings that actually free up more memory.

This commit fixes this bug by setting the amount of memory freed by
the execution of a node to 0 if `maxSize < resultSize` for that node.

**Testing**
This commit includes a unit test that exposes this bug. This unit
tests constructs a graph in which a dummy node has two inputs:
a `Concat` node connected to `Variables`, and a `Slice` node connected to
a `Transpose` node. The Slice node should be scheduled before the
`Concat` node since it frees up memory, but without this patch, it is
scheduled after.

The remaining unit tests all pass.