### PR TITLE
[GraphOptimizer] Remove useless temporaries

### DIFF
--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -851,15 +851,8 @@ static void optimizeBatchNorm(Function *F) {
       // Q = W * A
       // C = b * A + B
 
-      // FIXME: We need to use a temporary node to hold on
-      // the variables, because using the result directly
-      // will create a temporary NodeValue that is going
-      // to be otherwise alive at the call site and that
-      // messes up with the number of users.
-      Node *tmp = CV->getFilter().getNode();
-      Variable *filterV = getUniquelyUsedVariable(*tmp);
-      tmp = CV->getBias().getNode();
-      Variable *cbiasV = getUniquelyUsedVariable(*tmp);
+      Variable *filterV = getUniquelyUsedVariable(*CV->getFilter().getNode());
+      Variable *cbiasV = getUniquelyUsedVariable(*CV->getBias().getNode());
 
       if (!filterV || !cbiasV) {
         continue;


### PR DESCRIPTION
*Description*:
These temporaries were added to work around a bug in how NodeValues
used to affect the uselist. The problem was fixed by #1274.

NFC.

*Testing*: ninja check
*Documentation*: N/A
