### PR TITLE
[GraphScheduler] Fix underflow bug

### DIFF
--- a/lib/IR/GraphScheduler.cpp
+++ b/lib/IR/GraphScheduler.cpp
@@ -42,7 +42,7 @@ bool ChildMemSizeBasedScheduler::isScheduled(const Node *N) const {
 /// of each node.
 void ChildMemSizeBasedScheduler::computeNodeResultsMemorySize() {
   for (auto &N : G_.getNodes()) {
-    size_t resultSize = 0;
+    int64_t resultSize = 0;
     for (size_t idx = 0, e = N.getNumResults(); idx < e; ++idx) {
       resultSize += N.getType(idx)->getSizeInBytes();
     }
@@ -59,10 +59,10 @@ void ChildMemSizeBasedScheduler::computeNodeComputationMaxMemorySize() {
   // before the node using them.
   GraphPostOrderVisitor visitor(G_);
   for (auto *N : visitor.getPostOrder()) {
-    size_t maxSize = (N->getNumInputs() > 0)
-                         ? std::max(resultMemSize_[N->getNthInput(0)],
-                                    maxMemSize_[N->getNthInput(0)])
-                         : 0;
+    int64_t maxSize = (N->getNumInputs() > 0)
+                          ? std::max(resultMemSize_[N->getNthInput(0)],
+                                     maxMemSize_[N->getNthInput(0)])
+                          : 0;
     for (size_t idx = 1, e = N->getNumInputs(); idx < e; ++idx) {
       const auto &input = N->getNthInput(idx);
       // Skip operands that do not require memory allocations for storing

--- a/lib/IR/GraphScheduler.h
+++ b/lib/IR/GraphScheduler.h
@@ -49,9 +49,9 @@ public:
 /// that free more memory after their computation.
 class ChildMemSizeBasedScheduler : public Scheduler {
   /// Required number of bytes to hold the results of a given node.
-  std::unordered_map<const Node *, size_t> resultMemSize_;
+  std::unordered_map<const Node *, int64_t> resultMemSize_;
   /// Max number of bytes required during the computation of a given node.
-  std::unordered_map<const Node *, size_t> maxMemSize_;
+  std::unordered_map<const Node *, int64_t> maxMemSize_;
 
   /// \returns true if a node \p N is scheduled already.
   bool isScheduled(const Node *N) const;

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -124,6 +124,18 @@ target_link_libraries(graphOptzTest
                         testMain)
 add_glow_test(graphOptzTest ${GLOW_BINARY_DIR}/tests/graphOptzTest)
 
+add_executable(graphSchedulerTest
+	       graphSchedulerTest.cpp)
+target_link_libraries(graphSchedulerTest
+                      PRIVATE
+                        Graph
+                        IR
+                        gtest
+                        testMain)
+target_include_directories(graphSchedulerTest PRIVATE ${CMAKE_SOURCE_DIR}/lib/IR)
+
+add_glow_test(graphSchedulerTest ${GLOW_BINARY_DIR}/tests/graphSchedulerTest)
+
 add_executable(quantizationTest
                quantizationTest.cpp)
 target_link_libraries(quantizationTest

--- a/tests/unittests/graphSchedulerTest.cpp
+++ b/tests/unittests/graphSchedulerTest.cpp
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "GraphScheduler.h"
+
+#include "glow/Graph/Graph.h"
+#include "glow/Graph/Node.h"
+#include "glow/Graph/Nodes.h"
+
+#include "gtest/gtest.h"
+
+using namespace glow;
+
+/// Tests a case in which the memory required to store a node's
+/// output is greater than the memory required to store its input.
+/// This node uses more memory after it executes, and should be
+/// scheduled after its siblings that free up memory after
+/// they execute.
+TEST(GraphScheduler, testMaxSizeLessThanResultSize) {
+  Module MD;
+  Variable *smallTensorA = MD.createVariable(ElemKind::FloatTy, {1, 4, 4},
+                                             "small_1", VisibilityKind::Public);
+  Variable *smallTensorB = MD.createVariable(ElemKind::FloatTy, {1, 4, 4},
+                                             "small_2", VisibilityKind::Public);
+  Variable *bigTensor = MD.createVariable(ElemKind::FloatTy, {100, 4, 4}, "big",
+                                          VisibilityKind::Public);
+
+  Function *F = MD.createFunction("F");
+  Node *transposeBig = F->createTranspose("transposeBig", bigTensor, {0, 2, 1});
+  Node *sliceBig =
+      F->createSlice("sliceBig", transposeBig, {0, 0, 0}, {1, 4, 4});
+  Node *concatSmall =
+      F->createConcat("concatSmall", {smallTensorA, smallTensorB}, 0);
+  F->createConcat("concat", {concatSmall, sliceBig}, 0);
+
+  // The graph created above looks like this:
+  //
+  //  bigTensor       smallTensorA       smallTensorB
+  // {100, 4, 4}        {1, 4, 4}         {1, 4, 4}
+  //     |                     \         /
+  //     v                      v       v
+  // transposeBig {0, 2, 1}    concatSmall {0}
+  //    {100, 4, 4}              {2, 4, 4}
+  //     |                           |
+  //     v                           |
+  //  sliceBig {0, 0, 0}, {1, 4, 4}  |
+  //    {1, 4, 4}                    |
+  //     |                           |
+  //     |                           |
+  //     |                           |
+  //     --------> concat {0} <-------
+  //               {3, 4, 4}
+  //
+  // Since all of the tensors are Variables, they don't need
+  // memory for storing their outputs. Consequently, sliceBig
+  // should be scheduled before concatSmall in this example
+  // because the former frees up some memory while the latter
+  // uses up more memory after execution.
+  NodesPtrList schedule;
+  ChildMemSizeBasedScheduler scheduler(*F, schedule);
+  scheduler.schedule();
+
+  // Find the positions of sliceBig and concatSmall in
+  // the schedule.
+  std::vector<glow::Node *> vectorSchedule(schedule.begin(), schedule.end());
+  auto concatSmallIt =
+      std::find(vectorSchedule.begin(), vectorSchedule.end(), concatSmall);
+  auto sliceBigIt =
+      std::find(vectorSchedule.begin(), vectorSchedule.end(), sliceBig);
+
+  // For the reason given above, sliceBig should be scheduled
+  // before concatSmall.
+  EXPECT_LT(sliceBigIt, concatSmallIt);
+}


### PR DESCRIPTION
**Description**
This commit fixes an underflow bug in
`ChildMemSizeBasedScheduler::orderChildNodesAndSchedule` that can
cause incorrect scheduling. There is code in this function that
orders the children of a node by the amount of memory they free up
by executing. For each node, this is computed as `maxSize - resultSize`,
where `maxSize` is the total memory needed to compute and store the node's
`inputs`, and `resultSize` is the total memory needed to store the node's
outputs. For some nodes, such as a `Concat` that takes `Variables` as input,
`resultSize > maxSize`, so this subtraction underflows, and the scheduler
thinks that the node frees up a lot of memory and schedules it before
some or all of its siblings that actually free up more memory.

This commit fixes this bug by modifying the scheduler to use `int64_t`
instead of `size_t` to store `resultSize` and `maxSize` for all nodes.

**Testing**
This commit includes a unit test that exposes this bug. This unit
test constructs a graph in which a dummy node has two inputs:
a `Concat` node connected to `Variables`, and a `Slice` node connected to
a `Transpose` node. The `Slice` node should be scheduled before the
`Concat` node since it frees up memory, but without this patch, it is
scheduled after.

The remaining unit tests all pass.