### PR TITLE
[Placeholder] Fix a differentiation bug related to Placeholders.

### DIFF
--- a/lib/Graph/Grad.cpp
+++ b/lib/Graph/Grad.cpp
@@ -115,7 +115,7 @@ Function *glow::differentiate(Function *F, const TrainingConfig &conf,
                               cast<SaveNode>(N)->getInput().getType(), 0);
       toAppend.push_back(X);
       map.addGradient(cast<SaveNode>(N)->getInput(), X);
-      map.addGradient(cast<SaveNode>(N)->getVariable(), X);
+      map.addGradient(cast<SaveNode>(N)->getOutput(), X);
       continue;
     }
 


### PR DESCRIPTION
*Description*:

Fix a differentiation bug related to Placeholders. The line assumed that
the destination is a variable. 

*Testing*:

This bug was exposed in PR #1622. I did not add a specific test for this because as soon as we migrate more tests to using Placeholders this code will be tested.

*Documentation*: None
