### PR TITLE
[GraphOptimizer] Add optimization for replacing Concat of a single input with that input

### DIFF
--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -1103,6 +1103,12 @@ static NodeValue simplifyConcatNode(Function *F, ConcatNode *CN) {
   if (auto transformedConcatNode = tryToOptimizeConcatOfRehapes(F, CN)) {
     return transformedConcatNode;
   }
+
+  // If the concat has a single input, replace the concat with that input.
+  if (CN->getNumInputs() == 1) {
+    return CN->getInputs()[0];
+  }
+
   return NodeValue(nullptr);
 }
 


### PR DESCRIPTION
*Description*: Add optimization for replacing Concat of a single input with that input. This is seen in en2gr.

*Testing*: Added unit test. Fixed another unit test this opt breaks.

*Documentation*: N/A