### PR TITLE
[GraphOptimizer] Add identities for div/mul by one

### DIFF
--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -184,11 +184,19 @@ static Node *simplifyNode(Node *node, Function *F) {
     if (isSplatOfVal(MN->getRHS(), 0)) {
       return MN->getRHS();
     }
+    // X * 1 => X
+    if (isSplatOfVal(MN->getRHS(), 1)) {
+      return MN->getLHS();
+    }
   }
 
-  // 0 / X => 0
   if (auto *DN = dyn_cast<DivNode>(node)) {
+    // 0 / X => 0
     if (isSplatOfVal(DN->getLHS(), 0)) {
+      return DN->getLHS();
+    }
+    // X / 1 => X
+    if (isSplatOfVal(DN->getRHS(), 1)) {
       return DN->getLHS();
     }
   }

--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -142,13 +142,13 @@ static bool isIdentityShuffle(llvm::ArrayRef<unsigned_t> shuffle1,
   return true;
 }
 
-/// \returns True if the node \p N always evaluates to zero.
-bool isZero(Node *N) {
+/// \returns True if the node \p N always evaluates to \p val.
+bool isSplatOfVal(Node *N, float val) {
   SplatNode *Z = dyn_cast<SplatNode>(N);
   if (!Z)
     return false;
 
-  return (Z->getValue() == 0);
+  return (Z->getValue() == val);
 }
 
 /// \returns True if the node returns a constant value.
@@ -174,28 +174,28 @@ static Node *simplifyNode(Node *node, Function *F) {
 
   if (auto *AN = dyn_cast<AddNode>(node)) {
     // X + 0 => X
-    if (isZero(AN->getRHS())) {
+    if (isSplatOfVal(AN->getRHS(), 0)) {
       return AN->getLHS();
     }
   }
 
   if (auto *MN = dyn_cast<MulNode>(node)) {
     // X * 0 => 0
-    if (isZero(MN->getRHS())) {
+    if (isSplatOfVal(MN->getRHS(), 0)) {
       return MN->getRHS();
     }
   }
 
   // 0 / X => 0
   if (auto *DN = dyn_cast<DivNode>(node)) {
-    if (isZero(DN->getLHS())) {
+    if (isSplatOfVal(DN->getLHS(), 0)) {
       return DN->getLHS();
     }
   }
 
   // X - 0 => X
   if (auto *SN = dyn_cast<SubNode>(node)) {
-    if (isZero(SN->getRHS())) {
+    if (isSplatOfVal(SN->getRHS(), 0)) {
       return SN->getLHS();
     }
   }

--- a/tests/unittests/graphOptzTest.cpp
+++ b/tests/unittests/graphOptzTest.cpp
@@ -630,6 +630,31 @@ TEST_F(GraphOptz, ZeroArithmeticParentsMustBeSimplifiedFirst) {
   EXPECT_EQ(O->getInput().getNode(), zero);
 }
 
+/// Tests opts for the identities: [1 * X = X] [X / 1 = X]
+TEST_F(GraphOptz, ArithmeticIdentitiesOne) {
+  Variable *input = mod_.createVariable(ElemKind::FloatTy, {4, 10}, "input",
+                                        VisibilityKind::Public);
+
+  // This builds the expression: (I / 1) * 1:
+  SplatNode *one = F_->createSplat("one", input->getType(), 1.);
+  DivNode *div = F_->createDiv("div", input, one);
+  MulNode *mul = F_->createMul("mul", div, one);
+  SaveNode *SN = F_->createSave("ret", mul);
+
+  // Splat, Div, Mul, Save.
+  EXPECT_EQ(F_->getNodes().size(), 4);
+
+  ::glow::optimize(F_, CompilationMode::Infer);
+
+  // The expression evaluates to "I", so Save is only node left.
+  EXPECT_EQ(F_->getNodes().size(), 1);
+  ASSERT_TRUE(std::find_if(F_->getNodes().begin(), F_->getNodes().end(),
+                           IsSameNodeAddress(SN)) != F_->getNodes().end());
+
+  // Save node should just save the input.
+  EXPECT_TRUE(SN->getInput().getNode() == input);
+}
+
 /// Reverse the intrusive list of nodes. This custom implementation is required,
 /// because std::reverse cannot be used with LLVM's intrusive lists.
 static void reverse(NodesList &L) {


### PR DESCRIPTION
*Description*: We were missing optimizations for identities for dividing/multiplying by 1. These are seen in en2gr.

*Testing*: Added a unit test.

*Documentation*: N/A
