### PR TITLE
[WIP][GraphOptimizer] Sink Transpose below Slice

### DIFF
--- a/tests/unittests/graphOptzTest.cpp
+++ b/tests/unittests/graphOptzTest.cpp
@@ -194,6 +194,47 @@ TEST_F(GraphOptz, batchNormAfterConvNotOptimizeWhenMoreThanOneUseOfConv) {
   EXPECT_EQ(F_->getNodes().size(), 4);
 }
 
+TEST_F(GraphOptz, sinkTransposeBelowSlice) {
+  Node *A = mod_.createVariable(ElemKind::FloatTy, {1, 10, 15, 5}, "input",
+                                VisibilityKind::Public, false);
+  Node *T = F_->createTranspose("transpose", A, NHWC2NCHW);
+  Node *SA = F_->createSlice("sliceInput", A, {0, 0, 0, 0}, {1, 10, 15, 5});
+  Node *ST = F_->createSlice("sliceTranspose", T, {0, 4, 0, 0}, {1, 5, 10, 15});
+  F_->createSave("saveSliceInput", SA);
+  Node *OT = F_->createSave("saveSliceTranspose", ST);
+
+  // The graph created above looks like this:
+  //                        input
+  //                    {1, 10, 15, 5}
+  //                   /              \
+  //                  v               v
+  //  sliceInput {0, 0, 0, 0}         transpose {NHWC2NCHW}
+  //      {1, 10, 15, 5}                  {1, 5, 10, 15}
+  //           |                                |
+  //           v                                v
+  //     saveSliceInput               sliceTranspose {0, 4, 0, 0}
+  //                                      {1, 1, 10, 15}
+  //                                            |
+  //                                            v
+  //                                    saveSliceTranspose
+  //
+  // The expected output is the same, but with the 'transpose' and
+  // 'sliceTranspose' nodes interchanged. Note that without the path from
+  // input -> saveSliceInput, the input will be statically transposed and the
+  // code path that sinks Tranpose below Slice will not be triggered.
+
+  EXPECT_EQ(F_->getNodes().size(), 5);
+
+  ::glow::optimize(F_, CompilationMode::Infer);
+
+  // Expecting Transpose->Output rather than Slice->Output.
+  EXPECT_TRUE(llvm::isa<SaveNode>(OT));
+  EXPECT_TRUE(
+      llvm::isa<TransposeNode>(llvm::dyn_cast<SaveNode>(OT)->getInput()));
+
+  EXPECT_EQ(F_->getNodes().size(), 5);
+}
+
 TEST_F(GraphOptz, sinkTransposeBelowOptimizeBatchNorm) {
   Node *A = mod_.createVariable(ElemKind::FloatTy, {1, 5, 10, 15}, "input",
                                 VisibilityKind::Public, false);


### PR DESCRIPTION
**Description**
This commit modifies the `sinkCode` function in `GraphOptimizer.cpp`
to sink `TransposeNodes` below `SliceNodes`. In the best case, when
all of the children of a particular `TransposeNode` are `SliceNodes`,
this optimisation will help reduce the memory footprint by taking
slices directly out of the input to the original `TransposeNode`
and then transposing those slices (presumably) in-place. In the
worst case, when only one of the children of a `TransposeNode` is
a `SliceNode` and the rest are nodes that the optimizer does not
sink `TransposeNodes` into, this optimisation will keep the memory
footprint the same because the `TransposeNode` that it inserts
can presumably still be executed in-place.

**Testing**
This commit includes a unit test (`sinkTransposeBelowSlice`)
in `graphOptzTest.cpp` that tests this optimisation. All other unit
tests still pass.

**Example**
Below is an example of a graph that motivated this optimisation. It's hard to see, but the blue node is a `TransposeNode` whose children are all `SliceNodes` that feed into `ReshapeNodes` that in turn feed into `MatMulNodes`.

![before](https://user-images.githubusercontent.com/4392003/45454630-72f96a80-b699-11e8-9b5e-49fb8f5810bf.jpeg)

The memory footprint of this example can be reduced by sinking that `TransposeNode` into the `SliceNodes` and rewiring the `SliceNodes` to take slices out of the input to the TransposeNode, which is exactly what this optimisation does:

![after](https://user-images.githubusercontent.com/4392003/45454669-8d334880-b699-11e8-83f8-a4cc6c0858f3.jpeg)


