### PR TITLE
Preserve the predicate across the sinkCode optimization

### DIFF
--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -401,9 +401,11 @@ static bool sinkCode(Function *F) {
 #undef BOOLEAN_OP_CASE
 #undef ARITHMETIC_CASE
 
+      newAN->setPredicate(node->getPredicate());
       changed = true;
       auto *newTR =
           F->createTranspose(LTR->getName(), newAN, LTR->getShuffle());
+      newTR->setPredicate(node->getPredicate());
 #define GET_RESULT(NODE_) NODE_->getNthResult(0)
       GET_RESULT(node).replaceAllUsesOfWith(newTR);
 #undef GET_RESULT
@@ -455,7 +457,9 @@ static bool sinkCode(Function *F) {
 
       auto *newCN = F->createConcat(
           CN->getName(), {L->getInput(), R->getInput()}, newChannelIdx);
+      newCN->setPredicate(CN->getPredicate());
       auto *newTR = F->createTranspose(L->getName(), newCN, L->getShuffle());
+      newTR->setPredicate(CN->getPredicate());
       CN->getResult().replaceAllUsesOfWith(newTR);
       changed = true;
     }

--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -236,7 +236,9 @@ static bool sinkCode(Function *F) {
           BN->getName(), TR->getInput(), BN->getBias(), BN->getScale(),
           BN->getMean(), BN->getVar(), newChannelIdx, BN->getEpsilon(),
           BN->getMomentum());
+      NewBN->setPredicate(BN->getPredicate());
       auto *newTR = F->createTranspose(TR->getName(), NewBN, TR->getShuffle());
+      newTR->setPredicate(TR->getPredicate());
 
       BN->getResult().replaceAllUsesOfWith(newTR);
       changed = true;
@@ -256,7 +258,9 @@ static bool sinkCode(Function *F) {
       auto reluOutTy = F->getParent()->uniqueTypeWithNewShape(
           RL->getResult().getType(), TR->getInput().dims());
       auto *NRL = F->createRELU(RL->getName(), TR->getInput(), reluOutTy);
+      NRL->setPredicate(RL->getPredicate());
       auto *newTR = F->createTranspose(TR->getName(), NRL, TR->getShuffle());
+      newTR->setPredicate(TR->getPredicate());
       RL->getResult().replaceAllUsesOfWith(newTR);
       changed = true;
       continue;
@@ -271,7 +275,9 @@ static bool sinkCode(Function *F) {
       }
 
       auto *NSI = F->createSigmoid(SI->getName(), TR->getInput());
+      NSI->setPredicate(SI->getPredicate());
       auto *newTR = F->createTranspose(TR->getName(), NSI, TR->getShuffle());
+      newTR->setPredicate(TR->getPredicate());
       SI->getResult().replaceAllUsesOfWith(newTR);
       changed = true;
       continue;
@@ -286,7 +292,9 @@ static bool sinkCode(Function *F) {
       }
 
       auto *NTN = F->createTanh(TN->getName(), TR->getInput());
+      NTN->setPredicate(TN->getPredicate());
       auto *newTR = F->createTranspose(TR->getName(), NTN, TR->getShuffle());
+      newTR->setPredicate(TR->getPredicate());
       TN->getResult().replaceAllUsesOfWith(newTR);
       changed = true;
       continue;

--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -424,8 +424,10 @@ static bool sinkCode(Function *F) {
       if (L && R) {
         auto *newCN = F->createConcat(
             CN->getName(), {L->getInput(), R->getInput()}, CN->getDim());
+        newCN->setPredicate(node->getPredicate());
         auto *newRL =
             F->createRELU(L->getName(), newCN, CN->getResult().getType());
+        newRL->setPredicate(node->getPredicate());
         CN->getResult().replaceAllUsesOfWith(newRL);
       }
     }

--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -236,9 +236,9 @@ static bool sinkCode(Function *F) {
           BN->getName(), TR->getInput(), BN->getBias(), BN->getScale(),
           BN->getMean(), BN->getVar(), newChannelIdx, BN->getEpsilon(),
           BN->getMomentum());
-      NewBN->setPredicate(BN->getPredicate());
+      NewBN->setPredicate(node->getPredicate());
       auto *newTR = F->createTranspose(TR->getName(), NewBN, TR->getShuffle());
-      newTR->setPredicate(TR->getPredicate());
+      newTR->setPredicate(node->getPredicate());
 
       BN->getResult().replaceAllUsesOfWith(newTR);
       changed = true;
@@ -258,9 +258,9 @@ static bool sinkCode(Function *F) {
       auto reluOutTy = F->getParent()->uniqueTypeWithNewShape(
           RL->getResult().getType(), TR->getInput().dims());
       auto *NRL = F->createRELU(RL->getName(), TR->getInput(), reluOutTy);
-      NRL->setPredicate(RL->getPredicate());
+      NRL->setPredicate(node->getPredicate());
       auto *newTR = F->createTranspose(TR->getName(), NRL, TR->getShuffle());
-      newTR->setPredicate(TR->getPredicate());
+      newTR->setPredicate(node->getPredicate());
       RL->getResult().replaceAllUsesOfWith(newTR);
       changed = true;
       continue;
@@ -275,9 +275,9 @@ static bool sinkCode(Function *F) {
       }
 
       auto *NSI = F->createSigmoid(SI->getName(), TR->getInput());
-      NSI->setPredicate(SI->getPredicate());
+      NSI->setPredicate(node->getPredicate());
       auto *newTR = F->createTranspose(TR->getName(), NSI, TR->getShuffle());
-      newTR->setPredicate(TR->getPredicate());
+      newTR->setPredicate(node->getPredicate());
       SI->getResult().replaceAllUsesOfWith(newTR);
       changed = true;
       continue;
@@ -292,9 +292,9 @@ static bool sinkCode(Function *F) {
       }
 
       auto *NTN = F->createTanh(TN->getName(), TR->getInput());
-      NTN->setPredicate(TN->getPredicate());
+      NTN->setPredicate(node->getPredicate());
       auto *newTR = F->createTranspose(TR->getName(), NTN, TR->getShuffle());
-      newTR->setPredicate(TR->getPredicate());
+      newTR->setPredicate(node->getPredicate());
       TN->getResult().replaceAllUsesOfWith(newTR);
       changed = true;
       continue;
@@ -459,9 +459,9 @@ static bool sinkCode(Function *F) {
 
       auto *newCN = F->createConcat(
           CN->getName(), {L->getInput(), R->getInput()}, newChannelIdx);
-      newCN->setPredicate(CN->getPredicate());
+      newCN->setPredicate(node->getPredicate());
       auto *newTR = F->createTranspose(L->getName(), newCN, L->getShuffle());
-      newTR->setPredicate(CN->getPredicate());
+      newTR->setPredicate(node->getPredicate());
       CN->getResult().replaceAllUsesOfWith(newTR);
       changed = true;
     }
@@ -921,6 +921,8 @@ static void optimizeBatchNorm(Function *F) {
         cbiasH.raw(i) = cbiasH.raw(i) * A + B;
       }
 
+      // Take the predicate of what was expected for the output.
+      CV->setPredicate(BN->getPredicate());
       BN->getResult().replaceAllUsesOfWith(CV);
     }
   } // For all nodes in the graph.

--- a/tests/unittests/graphOptzTest.cpp
+++ b/tests/unittests/graphOptzTest.cpp
@@ -113,6 +113,13 @@ TEST_F(GraphOptz, optimizeBatchNormAfterConv) {
 
   ::glow::optimize(F_, CompilationMode::Infer);
   EXPECT_EQ(F_->getNodes().size(), 2);
+
+  ASSERT_EQ(A->getNumUsers(), 1);
+  Node *newCV = A->getUsers().begin()->getUser();
+  EXPECT_TRUE(llvm::isa<ConvolutionNode>(newCV));
+  ASSERT_EQ(newCV->getNumUsers(), 1);
+  Node *save = newCV->getUsers().begin()->getUser();
+  EXPECT_TRUE(llvm::isa<SaveNode>(save));
 }
 
 /// Check that the batch normalization optimization is

--- a/tests/unittests/graphOptzTest.cpp
+++ b/tests/unittests/graphOptzTest.cpp
@@ -616,7 +616,8 @@ TEST_F(GraphOptz, cancelTwoTransposesWithPredicate) {
 }
 
 TEST_F(GraphOptz, removeIdentityTranspose) {
-  Node *A = mod_.createVariable(ElemKind::FloatTy, {1, 5, 10, 15}, "input",
+  const size_t origDims[] = {1, 5, 10, 15};
+  Node *A = mod_.createVariable(ElemKind::FloatTy, origDims, "input",
                                 VisibilityKind::Public, false);
   Node *T = F_->createTranspose("transpose", A, {0, 1, 2, 3});
   Node *K = F_->createRELU("relu", T);
@@ -629,6 +630,9 @@ TEST_F(GraphOptz, removeIdentityTranspose) {
 
   EXPECT_EQ(F_->getNodes().size(), 2);
   EXPECT_EQ(K->getNthInput(0).getNode(), A);
+  // Make sure we didn't mess up with the dimensions of the
+  // variable while eliminating the transpose.
+  EXPECT_EQ(A->dims(0), llvm::makeArrayRef(origDims));
 }
 
 TEST_F(GraphOptz, dontCancelTwoTransposesIfNotMatching) {


### PR DESCRIPTION
*Description*:
This patch series makes sure the predicates are properly preserved through the sinkCode optimization.
The PR is quite lengthy, but the relevant changes (i.e., not test cases) are pretty small (maybe ~20 lines in GraphOptimizer.cpp).

The bulk of the PR is an hardening of the sinkCode tests + new tests for predication.

*Testing*:
ninja check
At this point, predicates don't change the behavior of the program anyway
*Documentation*: N/A