### PR TITLE
Remove all mutable bound variables from the first test

### DIFF
--- a/include/glow/ExecutionEngine/ExecutionEngine.h
+++ b/include/glow/ExecutionEngine/ExecutionEngine.h
@@ -94,6 +94,9 @@ public:
 void updateVariables(llvm::ArrayRef<Variable *> vars,
                      llvm::ArrayRef<Tensor *> inputs);
 
+void updateVariables(Context &ctx, llvm::ArrayRef<Placeholder *> ph,
+                     llvm::ArrayRef<Tensor *> inputs);
+
 /// Update the content of the tensors \p vars with some slices that from \p
 /// inputs. The data starts at slice \p sampleIdx and wraps around until the
 /// data in \p v is filled. All dimensions, except for the first (batch)
@@ -116,6 +119,10 @@ void updateVariablesFromBatch(llvm::ArrayRef<Variable *> vars,
 /// (sampleCounter % batchsize).
 void runBatch(ExecutionEngine &EE, size_t iterations, size_t &sampleCounter,
               llvm::ArrayRef<Variable *> vars, llvm::ArrayRef<Tensor *> inputs);
+
+void runBatch(ExecutionEngine &EE, Context &ctx, size_t iterations,
+              size_t &sampleCounter, llvm::ArrayRef<Placeholder *> ph,
+              llvm::ArrayRef<Tensor *> inputs);
 
 } // namespace glow
 

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -29,6 +29,7 @@
 #include <vector>
 
 namespace glow {
+class Context;
 
 /// List of Types.
 using TypesList = std::list<Type>;
@@ -582,6 +583,33 @@ public:
                   const llvm::ArrayRef<Node *> inputs, unsigned batchSize,
                   unsigned hiddenSize, unsigned outputSize,
                   std::vector<NodeValue> &outputs);
+
+  /// @}
+
+  /// @name The builder functions below are identical to the builder functions
+  /// above except that they create nodes that use Placeholder instead of
+  /// Variables. The methods create and initialize the tensors in the context.
+  /// As soon as we finish the Placeholder migration we'll delete these methods
+  /// and merge them with the builder methods above.
+  /// See issue #1334.
+  ///@{
+
+  ConvolutionNode *createConv(Context &ctx, llvm::StringRef name,
+                              NodeValue input, size_t depth,
+                              llvm::ArrayRef<unsigned_t> kernels,
+                              llvm::ArrayRef<unsigned_t> strides,
+                              llvm::ArrayRef<unsigned_t> pads,
+                              unsigned_t group);
+
+  ConvolutionNode *createConv(Context &ctx, llvm::StringRef name,
+                              NodeValue input, size_t depth, unsigned_t kernel,
+                              unsigned_t stride, unsigned_t pad,
+                              unsigned_t group);
+
+  FullyConnectedNode *createFullyConnected(Context &ctx, llvm::StringRef name,
+                                           NodeValue input, size_t outDepth);
+
+  SaveNode *createSave(Context &ctx, llvm::StringRef name, NodeValue input);
 
   /// @}
 

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "glow/Graph/Graph.h"
+#include "glow/Graph/Context.h"
 #include "glow/Graph/Nodes.h"
 #include "glow/Support/Support.h"
 
@@ -1913,6 +1914,89 @@ void Function::createLSTM(llvm::StringRef namePrefix,
     outputs.push_back(O);
   }
 };
+
+//===----------------------------------------------------------------------===//
+//                   Placeholder-builder methods.
+//===----------------------------------------------------------------------===//
+
+ConvolutionNode *Function::createConv(Context &ctx, llvm::StringRef name,
+                                      NodeValue input, size_t depth,
+                                      llvm::ArrayRef<unsigned_t> kernels,
+                                      llvm::ArrayRef<unsigned_t> strides,
+                                      llvm::ArrayRef<unsigned_t> pads,
+                                      unsigned_t group) {
+  ShapeNHWC idim = ShapeNHWC(input.dims());
+  ShapeHW kdim(kernels);
+  PaddingTLBR pdim(pads);
+  (void)pdim;
+  assert((idim.w + pdim.left + pdim.right) >= kdim.width &&
+         (idim.h + pdim.top + pdim.bottom) >= kdim.height &&
+         "buffer too small for selected stride");
+
+  assert(group > 0 && "group should be larger than 0");
+  assert(idim.c % group == 0 && "channels number must be divisible by groups");
+  assert(depth % group == 0 && "depth must be divisible by groups");
+
+  // Calculate the size and allocate the output buffer.
+  auto outSz =
+      calculateConvPoolOutputDims(idim.h, idim.w, kernels, strides, pads);
+
+  std::array<size_t, 4> outDims = {{idim.n, outSz.first, outSz.second, depth}};
+
+  // Allocate the Filter and Bias tensors.
+  std::array<size_t, 4> filterDim = {
+      {depth, kdim.height, kdim.width, idim.c / group}};
+  size_t fanIn = kdim.height * kdim.width * idim.c;
+  auto *filter = getParent()->createPlaceholder(ElemKind::FloatTy, filterDim,
+                                                "filter", true);
+  ctx.allocate(filter)->init(glow::Tensor::InitKind::Xavier, fanIn, getPRNG());
+
+  auto *bias =
+      getParent()->createPlaceholder(ElemKind::FloatTy, {depth}, "bias", true);
+  ctx.allocate(bias)->init(glow::Tensor::InitKind::Broadcast, 0.1, getPRNG());
+
+  auto OT = getParent()->uniqueType(ElemKind::FloatTy, outDims);
+
+  return addNode(new ConvolutionNode(name, OT, input, filter, bias, kernels,
+                                     strides, pads, group));
+}
+
+ConvolutionNode *Function::createConv(Context &ctx, llvm::StringRef name,
+                                      NodeValue input, size_t depth,
+                                      unsigned_t kernel, unsigned_t stride,
+                                      unsigned_t pad, unsigned_t group) {
+  llvm::SmallVector<unsigned_t, 4> pads = {pad, pad, pad, pad};
+  llvm::SmallVector<unsigned_t, 2> strides = {stride, stride};
+  llvm::SmallVector<unsigned_t, 2> kernels = {kernel, kernel};
+  return createConv(ctx, name, input, depth, kernels, strides, pads, group);
+}
+
+FullyConnectedNode *Function::createFullyConnected(Context &ctx,
+                                                   llvm::StringRef name,
+                                                   NodeValue input,
+                                                   size_t outDepth) {
+  TypeRef T = input.getType();
+  auto idim = flattenCdr(input.dims());
+  size_t fanIn = idim.second;
+
+  auto *W = getParent()->createPlaceholder(
+      T->getElementType(), {idim.second, outDepth}, "weights", true);
+  auto *B = getParent()->createPlaceholder(T->getElementType(), {outDepth},
+                                           "bias", true);
+
+  ctx.allocate(W)->init(Tensor::InitKind::Xavier, fanIn, getPRNG());
+  ctx.allocate(B)->init(Tensor::InitKind::Broadcast, .1, getPRNG());
+
+  auto OT =
+      getParent()->uniqueType(T->getElementType(), {idim.first, outDepth});
+  return addNode(new FullyConnectedNode(name, OT, input, W, B));
+}
+
+SaveNode *Function::createSave(Context &ctx, llvm::StringRef name,
+                               NodeValue input) {
+  auto *dest = getParent()->createPlaceholder(input.getType(), name, false);
+  return addNode(new SaveNode(name, input, dest));
+}
 
 //===----------------------------------------------------------------------===//
 //                   Graph dumping and printing

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -41,12 +41,17 @@ int main(int argc, char **argv) {
   BB.declareNode("Variable");
   BB.declareNode("Placeholder");
 
+  // Notice: As soon as we finish the migration from bound-variables to unbound
+  // placeholders we'll need to remove the getVariable() API. See issue #1334.
   BB.newNode("Save")
       .addInput("Input")
       .addInput("Output")
       .addExtraMethod("Variable *getVariable() const;",
                       "Variable *SaveNode::getVariable() const { return "
                       "llvm::cast<Variable>(Output_.getNode()); };")
+      .addExtraMethod("Placeholder *getPlaceholder() const;",
+                      "Placeholder *SaveNode::getPlaceholder() const { return "
+                      "llvm::cast<Placeholder>(Output_.getNode()); };")
       .addOverwrittenInput("Output")
       .setHasSideEffects(true)
       .setDocstring("Specifies a node whose Input will be copied to Output."


### PR DESCRIPTION
*Description*:

  * Migrate the MNIST test from using Variables to using Placeholders.
 
  * Add two convenient methods to allow the easy migration
    between Variables to Placeholders. The new methods updateVariable and
    runBatch will be merged with the existing runBatch and updateVariable
    methods as soon as we delete the last use.

 *  Add new node builders that generate Placeholders and not variables. The
    new APIs will allow us to migrate our unit tests from using mutable
    bound variables to unbounded placeholders. As soon as we finish the
    migration we'll merge the new APIs with the regular builder methods
    above. The methods are not annotated with oxygen comments because it's
    only a copy that needs to go away as soon as the migration is complete.
    
  * Add the unsafe method: getPlaceholder() to SaveNode. This will ease the
    migration to Placeholder. We'll need to remove the getVariable method
    when we finish the migration. This is documented in a comment above.

*Testing*: Ran MNIST manually and ran ninja check.

*Documentation*: I updated the region of the new methods with start/end doxygen markers. I did not update all of the methods because the change is mechanical and I hope to delete the new methods very quickly and merge them with the already doxygen-ed methods. 
