### PR TITLE
*CPU backend WIP* [Quantization] Row-wise FC

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -267,6 +267,17 @@ public:
   FullyConnectedNode *createFullyConnected(llvm::StringRef name,
                                            NodeValue input, size_t outDepth);
 
+  /// Create a row-wise fully connected node. This node is only used in
+  /// quantization. Parm \p input and \B are quantized in regular way, and \p W
+  /// is row-wise quantized with each row's quantized paramters(i.e. scale and
+  /// offset) stored in W in the follow format: | ... quantized int8 data...|
+  /// 32bit-float scale | 32bit-float offset| | number_of_columns         | 4B
+  /// |       4B          |
+  RowWiseFullyConnectedNode *createRowWiseFullyConnected(llvm::StringRef name,
+                                                         NodeValue input,
+                                                         Node *W, Node *B,
+                                                         TypeRef outTy);
+
   /// Create a ReLU node with the given \p name and \p input.
   /// Result type will be implicitly set based on the \p input type.
   ReluNode *createRELU(llvm::StringRef name, NodeValue input);
@@ -534,6 +545,14 @@ public:
   /// Scale and Offset.
   RescaleQuantizedNode *createRescaleQuantized(llvm::StringRef name,
                                                NodeValue input, TypeRef outTy);
+
+  FloatToFused8BitRowwiseQuantizeNode *
+  createFloatToFused8BitRowwiseQuantize(llvm::StringRef name, NodeValue input,
+                                        TypeRef outTy);
+
+  Fused8BitRowwiseQuantizedToFloatNode *
+  createFused8BitRowwiseQuantizedToFloat(llvm::StringRef name, NodeValue input,
+                                         TypeRef outTy);
 
   /// Create a series of nodes that implement a weighted sum. \p data and \p
   /// weights should have the same number of elements. The nodes in \p weights

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -185,6 +185,7 @@ bool CPUBackend::isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const {
     case Kinded::Kind::TanhNodeKind:
     case Kinded::Kind::TopKNodeKind:
     case Kinded::Kind::TransposeNodeKind:
+      // case Kinded::Kind::RowWiseFullyConnectedNodeKind:
       return true;
     default:
       return false;

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -66,6 +66,7 @@ bool Interpreter::isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const {
     case Kinded::Kind::TanhNodeKind:
     case Kinded::Kind::TopKNodeKind:
     case Kinded::Kind::TransposeNodeKind:
+    case Kinded::Kind::RowWiseFullyConnectedNodeKind:
       return true;
     default:
       return false;

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -628,6 +628,12 @@ FullyConnectedNode *Function::createFullyConnected(llvm::StringRef name,
   return addNode(new FullyConnectedNode(name, OT, input, W, B));
 }
 
+RowWiseFullyConnectedNode *
+Function::createRowWiseFullyConnected(llvm::StringRef name, NodeValue input,
+                                      Node *W, Node *B, TypeRef outTy) {
+  return addNode(new RowWiseFullyConnectedNode(name, outTy, input, W, B));
+}
+
 ReluNode *Function::createRELU(llvm::StringRef name, NodeValue input,
                                TypeRef outTy) {
   return addNode(new ReluNode(name, outTy, input));
@@ -1477,6 +1483,34 @@ RescaleQuantizedNode *Function::createRescaleQuantized(llvm::StringRef name,
 
   return addNode(
       new RescaleQuantizedNode(name, getParent()->uniqueType(*outTy), input));
+}
+
+FloatToFused8BitRowwiseQuantizeNode *
+Function::createFloatToFused8BitRowwiseQuantize(llvm::StringRef name,
+                                                NodeValue input,
+                                                TypeRef outTy) {
+  assert(input.getElementType() == ElemKind::FloatTy &&
+         "Input must be a floating type");
+  assert(outTy->getElementType() == ElemKind::Int8QTy &&
+         "Output must be a quantized type");
+  assert(input.dims().size() == outTy->dims().size() &&
+         "Different dimensions for input and output");
+
+  return addNode(new FloatToFused8BitRowwiseQuantizeNode(
+      name, getParent()->uniqueType(*outTy), input));
+}
+
+Fused8BitRowwiseQuantizedToFloatNode *
+Function::createFused8BitRowwiseQuantizedToFloat(llvm::StringRef name,
+                                                 NodeValue input,
+                                                 TypeRef outTy) {
+  assert(input.getElementType() == ElemKind::Int8QTy &&
+         "Input must be a quantized type");
+  assert(outTy->getElementType() == ElemKind::FloatTy &&
+         "Output must be a float type");
+
+  return addNode(new Fused8BitRowwiseQuantizedToFloatNode(
+      name, getParent()->uniqueType(*outTy), input));
 }
 
 Node *Function::createWeightedSum(llvm::StringRef name,

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -88,6 +88,56 @@ quantizeInputs(Function *F, Node *node,
   return quantizedInputs;
 }
 
+/// Quantize all inputs for \p node and return back pointers to the newly
+/// created qunatization nodes.
+static llvm::SmallVector<NodeValue, 3> quantizeRowWiseFCInputs(
+    Function *F, Node *node,
+    const std::unordered_map<std::string, TensorQuantizationParams>
+        &nodeToTQP) {
+  llvm::SmallVector<NodeValue, 3> quantizedInputs;
+  assert(node->getNumInputs() == 3 && "Invalid num of inputs");
+  for (unsigned i = 0; i < 3; ++i) {
+    auto NV = node->getNthInput(i);
+
+    // Do not quantize non floating point type, e.g., Index type.
+    if (NV.getElementType() != ElemKind::FloatTy) {
+      continue;
+    }
+
+    std::string nodeOutputName = NodeQuantizationInfo::generateNodeOutputName(
+        NV.getNode()->getName(), NV.getResNo());
+    if (i == 1) {
+      // Wights need row-wise quantization.
+      // In FC, the weights is stored in tranposed format already, need to
+      // transpose it back to get row-wise quantization.
+      Node *transNode = F->createTranspose("w.trans", NV, {1, 0});
+      auto QT = F->getParent()->uniqueType(
+          ElemKind::Int8QTy, {NV.dims()[1], NV.dims()[0] + 8}, 0.0, 0);
+      Node *quantizeNode = F->createFloatToFused8BitRowwiseQuantize(
+          "rowwisequantize", transNode, QT);
+      quantizedInputs.push_back(quantizeNode);
+    } else {
+      // Input and Biase -- regular quantization based on given scale and
+      // offset.
+      assert(nodeToTQP.find(nodeOutputName) != nodeToTQP.end() &&
+             "Missing quantization params for a node");
+
+      if (i == 0) {
+        // Input. Should be flatten first.
+        NV = F->createFlatten("fc.1X", NV, 1);
+      }
+      const TensorQuantizationParams &TQP =
+          nodeToTQP.find(nodeOutputName)->second;
+      auto QT = F->getParent()->uniqueType(ElemKind::Int8QTy, NV.dims(),
+                                           TQP.scale, TQP.offset);
+      Node *quantizeNode = F->createQuantize("quantize", NV, QT);
+      quantizedInputs.push_back(quantizeNode);
+    }
+  }
+
+  return quantizedInputs;
+}
+
 /// \returns true when given \p node can be quantized.
 /// Normally node's inputs must have floating point
 /// type, but there are some special cases, e.g., Gather node.
@@ -451,16 +501,36 @@ quantizeFunction(const ExecutionEngine &EE,
     // also we should not quantize Index type inputs.
     if (canBeQuantized(node) &&
         EE.isOpSupported(node->getKind(), ElemKind::Int8QTy)) {
-      // 1) Quantize all of the inputs based on the profiles.
-      //    Quantize only floating point inputs.
-      auto quantizedInputs = quantizeInputs(G, node, nodeToTQP);
-
+      Node *quantizedNode = nullptr;
       auto qParams = getQuantizationParameters(node, nodeToTQP);
+      if (EE.isOpSupported(Kinded::Kind::RowWiseFullyConnectedNodeKind,
+                           ElemKind::Int8QTy) &&
+          node->getKind() == Kinded::Kind::FullyConnectedNodeKind) {
+        // Row-wise quantization for FC node.
+        // 1) Quantize input and bias based on the profiles.
+        //    Row-wise quantize weights. Quantize only floating points inputs.
+        // 2) Quantize the FC node.
+        auto quantizedInputs = quantizeRowWiseFCInputs(G, node, nodeToTQP);
+        auto *FC = cast<FullyConnectedNode>(node);
+        assert(quantizedInputs.size() == 3 && "Invalid number of inputs");
+        assert(qParams.size() == 1 && "Invalid number of quantized outputs");
+        auto QT = G->getParent()->uniqueType(
+            ElemKind::Int8QTy, FC->getResult().dims(), qParams[0].scale,
+            qParams[0].offset);
+        quantizedNode = G->createRowWiseFullyConnected(
+            FC->getName(), quantizedInputs[0], quantizedInputs[1],
+            quantizedInputs[2], QT);
+        assert(quantizedNode != nullptr && "Node must be quantized");
+      } else {
+        // 1) Quantize all of the inputs based on the profiles.
+        //    Quantize only floating point inputs.
+        auto quantizedInputs = quantizeInputs(G, node, nodeToTQP);
 
-      // 2) Quantize the node.
-      Node *quantizedNode = quantizeNode(G, node, quantizedInputs, qParams);
-      quantizedNode = postProcessQuantizedNode(G, quantizedNode, qParams);
-      assert(quantizedNode != nullptr && "Node must be quantized");
+        // 2) Quantize the node.
+        quantizedNode = quantizeNode(G, node, quantizedInputs, qParams);
+        quantizedNode = postProcessQuantizedNode(G, quantizedNode, qParams);
+        assert(quantizedNode != nullptr && "Node must be quantized");
+      }
 
       // 3) Dequantize all outputs of the node so that invariant is kept.
       unsigned qParamIndex = 0;

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -1191,6 +1191,31 @@ TEST_P(Operator, QuantizeAndDequantize) {
       fpResult->getVariable()->getPayload()));
 }
 
+TEST_P(InterpAndCPU, RowWiseQuantizeAndDequantize) {
+  auto *A = mod_.createVariable(ElemKind::FloatTy, {1, 4}, "A",
+                                VisibilityKind::Public);
+  A->getPayload().getHandle() = {1.0f, 1.2f, 0.5f, 1.3f};
+
+  auto qType = mod_.uniqueType(ElemKind::Int8QTy, {1, 12}, 0.0, 0.0);
+  auto *qNode =
+      F_->createFloatToFused8BitRowwiseQuantize("rowwisequantize", A, qType);
+  auto dType = mod_.uniqueType(ElemKind::FloatTy, {1, 4});
+  auto *dequantize = F_->createFused8BitRowwiseQuantizedToFloat(
+      "rowwisedequantize", qNode, dType);
+  auto *S = F_->createSave("save", dequantize);
+
+  Context ctx;
+  EE_.compile(CompilationMode::Infer, F_, ctx);
+  EE_.run();
+
+  auto results = llvm::cast<Variable>(S->getOutput())->getPayload().getHandle();
+
+  EXPECT_EQ(results.size(), 4);
+  std::vector<float> expected = {1.0f, 1.2f, 0.5f, 1.3f};
+  for (size_t i = 0; i < 4; i++)
+    EXPECT_NEAR(results.raw(i), expected[i], 0.01);
+}
+
 TEST_P(Operator, IntMatMul) {
   // The scaling factor 1.4x was carefully selected to make sure we don't
   // overflow or underflow the calculation.

--- a/tests/unittests/quantizationTest.cpp
+++ b/tests/unittests/quantizationTest.cpp
@@ -270,7 +270,7 @@ TEST_P(Operator, end2end) {
     double diff = std::fabs(result2Handle.raw(i) - result1Handle.raw(i)) / mx;
 
     // Allow 3% difference.
-    EXPECT_NEAR(diff, 0, 0.03);
+    EXPECT_NEAR(diff, 0, 0.02);
   }
 }
 
@@ -406,7 +406,7 @@ TEST_P(Operator, end2endGRU) {
     double diff = std::fabs(result2Handle.raw(i) - result1Handle.raw(i)) / mx;
 
     // Allow 3% difference.
-    EXPECT_NEAR(diff, 0, 0.03);
+    EXPECT_NEAR(diff, 0, 0.02);
   }
 }
 

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -120,6 +120,15 @@ int main(int argc, char **argv) {
       .autoVerify(VerifyKind::SameElementType, {"Dest", "Src"})
       .addGradientInstr({"Dest"}, {"Dest", "Src"});
 
+  BB.newInstr("RowWiseFullyConnected")
+      .addOperand("Dest", OperandKind::Out)
+      .addOperand("Src", OperandKind::In)
+      .addOperand("Weights", OperandKind::In)
+      .addOperand("Bias", OperandKind::In)
+      .autoIRGen()
+      .autoVerify(VerifyKind::SameElementType,
+                  {"Dest", "Src", "Weights", "Bias"});
+
   //===--------------------------------------------------------------------===//
   //                     Normalization
   //===--------------------------------------------------------------------===//
@@ -445,6 +454,19 @@ int main(int argc, char **argv) {
       .autoVerify(VerifyKind::SameShape, {"Dest", "Src"})
       .autoIRGen();
 
+  BB.newInstr("FloatToFused8BitRowwiseQuantize")
+      .addOperand("Dest", OperandKind::Out)
+      .addOperand("Src", OperandKind::In)
+      .autoVerify(VerifyKind::SameElementType, {"Src", "ElemKind::FloatTy"})
+      .autoVerify(VerifyKind::SameElementType, {"Dest", "ElemKind::Int8QTy"})
+      .autoIRGen();
+
+  BB.newInstr("Fused8BitRowwiseQuantizedToFloat")
+      .addOperand("Dest", OperandKind::Out)
+      .addOperand("Src", OperandKind::In)
+      .autoVerify(VerifyKind::SameElementType, {"Src", "ElemKind::Int8QTy"})
+      .autoVerify(VerifyKind::SameElementType, {"Dest", "ElemKind::FloatTy"})
+      .autoIRGen();
   //===--------------------------------------------------------------------===//
   //                Instructions used by RNN
   //===--------------------------------------------------------------------===//

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -102,6 +102,17 @@ int main(int argc, char **argv) {
                     "Weights tensor are multiplied, and then the Bias tensor "
                     "is added to it, producing the Output.");
 
+  BB.newNode("RowWiseFullyConnected")
+      .addInput("Input")
+      .addInput("Weights")
+      .addInput("Bias")
+      .addResultFromCtorArg()
+      .setDocstring(
+          "Creates a RowWiseFullyConnected node where the Input tensor and "
+          "Weights tensor are multiplied, and then the Bias tensor is added "
+          "to it, producing the Output. This node is regular quantized, but"
+          " the FC weights use channel-wise quantization.");
+
   //===--------------------------------------------------------------------===//
   //                     Normalization
   //===--------------------------------------------------------------------===//
@@ -474,6 +485,27 @@ int main(int argc, char **argv) {
       .setDocstring("Rescale the input quantized tensor to a new Scale and "
                     "Offset. The new Scale and Offset are specified by the "
                     "output type passed to the constructor");
+
+  BB.newNode("FloatToFused8BitRowwiseQuantize")
+      .addInput("Input")
+      .addResultFromCtorArg()
+      .setDocstring(
+          "Row-wise quantize floating point tensor. This operation "
+          "applies 8-bit row-wise quantization by determining the range "
+          "(maximum - minimum) and offset (minimum value) of each row in "
+          "the input matrix, and then scaling each element to an 8-bit "
+          "number.");
+
+  BB.newNode("Fused8BitRowwiseQuantizedToFloat")
+      .addInput("Input")
+      .addResultFromCtorArg()
+      .setDocstring(
+          "De-quantizes the result of the FloatToFused8BitRowwiseQuantized "
+          "opertor. The input is expected to encode the scale as a 32-bit "
+          "float in the second to the last 4 bytes of each row, followed by "
+          "the offset as a 32-bit int in the next 4 bytes, and the quantized "
+          "values in the preceding bytes of the row. The output is a matrix "
+          "containing only the values, but de-quantized.");
 
   //===--------------------------------------------------------------------===//
   //                Nodes used by RNN


### PR DESCRIPTION
*Description*:
This PR is working on Row-wise FC (or channel-wise FC). It's designed for better quantization. 
1) Two new nodes are introduced for row-wise quantization: 
     1.1 FloatToFused8BitRowwiseQuantize
          The input of this op is a 2-D tensor (i.e. N * M) with float type for each element.  The output is a
          2-D tensor with int8_t type. The shape of the output is (N * (M + 8)). For each row of the output, the 
         stored data is : 
         | ... quantized int8 data...|   scale (float)       |     offset (int32_t)        | 
         |             M   bytes             |      4B                    |            4B                      |
         The scale and offset are chosen based on the min and max of each row of the input tensor. After the  
         scale and the offset of each row is generated, the input data of this row are quantized and stored in 
         the first M bytes of the row of the output.
     1.2 Fused8BitRowwiseQuantizedToFloat
          This is to de-quantize the 1.1 op. The input is a 2-D tensor (N * (M+8)) with int8_t type and the 
          output is a 2-D tensor (N * M) with float type.
    **Notes**:  I was thinking about using 3 separate tensors to represent quantized data, offsets, and 
                        scales. But if later we would like to row-wise quantize more inputs, the number of the 
                        params would be increased. Therefore, I used the similar way as Caffe2 op: 
                        https://caffe2.ai/docs/operators-catalogue.html#floattofused8bitrowwisequantized
2) RowWiseFullyConnected Node.
     Previously, for a FC node, if it is quantized-able, the whole node is quantized and then lowered into 
     matmul + add. In this PR, if a FC node is quantize-able (for Interpreter and CPU backends), we 
    generate the following graph and no more lowering optimization:
 ***********
   Reshape  **(flatten the input of FC)**
   name : fc_1X
   Input : float<10 x 6>
   Dims : [10, 6]
   users : 1

    Quantize **(input of FC)**
    name : quantize
    Input : float<10 x 6>
    users : 1
    Result : i8[S:0.0081 O:-128][0.000,2.073]<10 x 6>

    Transpose **(since the weights of FC is stored in transposed shape, transpose it back )**
    name : w_trans
    Input : float<6 x 2>
    Shuffle : [1, 0]
    users : 1
    Result : float<2 x 6>

    FloatToFused8BitRowwiseQuantize **(row-wise quantization of weights of FC)**
    name : rowwisequantize
    Input : float<2 x 6>
    users : 1
    Result : i8[S:0.0000 O:0][-0.000,0.000]<2 x 14>

   Quantize **(bias of FC)**
   name : quantize1
   Input : float<2>
   users : 1
   Result : i8[S:0.0060 O:-92][-0.215,1.310]<2>

   RowWiseFullyConnected **(row-wise FC)**
   name : fc11
   Input : i8[S:0.0081 O:-128][0.000,2.073]<10 x 6>
   Weights : i8[S:0.0000 O:0][-0.000,0.000]<2 x 14>
   Bias : i8[S:0.0060 O:-92][-0.215,1.310]<2>
   users : 1
   Result : i8[S:0.0355 O:-127][-0.035,9.009]<10 x 2>

   Dequantize 
   name : dequantize
   Input : i8[S:0.0355 O:-127][-0.035,9.009]<10 x 2>
   users : 1
  Result : float<10 x 2> 
  *****************   
3) Interpreter Backend
4) CPU Backend *WIP*
    So far, we use the trivial way to do the row-wise FC. Need to improve it by using the way 
   "QuantizationTransform32To8 quantizeScaleOffset32To8()" does.
 5) Add unittest for   FloatToFused8BitRowwiseQuantize and Fused8BitRowwiseQuantizedToFloat. 
 6) So far, the Row-wise FC is enabled by default. Adding flag to control it will be in later PR.

*Testing*: ninja check, ./tests/images/run.sh
 
*Documentation*:
Need to implement channel-wise quantized fullyconnected node. #1402
[Optional Fixes #1402 ]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
