### PR TITLE
Add TileNode, lowered to InsertTensorNode

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -320,12 +320,20 @@ public:
                            llvm::ArrayRef<NodeValue> inputs,
                            unsigned_t dimension, TypeRef outTy);
 
-  /// Create an insert tensor node that implements a tile with provided \p name,
-  /// \p input, \p tiles, and \p axis. For example, an input tensor {{1,2,3,4}}
-  /// of dimension 1x4 with tiles = 2 and axis = 0 would result in an output
-  /// tensor {{1,2,3,4}, {1,2,3,4}} of dimension 2x4.
-  InsertTensorNode *createTile(llvm::StringRef name, NodeValue input,
-                               unsigned_t tiles, unsigned_t axis);
+  /// Create a TileNode with \p name, \p input, \p tiles, and \p axis. For
+  /// example, an input tensor {{1,2,3,4}} of dimension 1x4 with tiles = 2 and
+  /// axis = 0 would result in an output tensor {{1,2,3,4}, {1,2,3,4}} of
+  /// dimension 2x4.
+  TileNode *createTile(llvm::StringRef name, NodeValue input, unsigned_t tiles,
+                       unsigned_t axis);
+
+  /// Create an insert tensor node \p name, which inserts \p small into \p big
+  /// at offset into big \p start \p count times along \p axis.
+  InsertTensorNode *createInsertTensor(llvm::StringRef name, NodeValue big,
+                                       NodeValue small,
+                                       llvm::ArrayRef<size_t> start,
+                                       unsigned_t count = 1,
+                                       unsigned_t axis = 0);
 
   SliceNode *createSlice(llvm::StringRef name, NodeValue input,
                          UnsignedArrayRef begin, UnsignedArrayRef end);

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -820,8 +820,8 @@ ConcatNode *Function::createConcat(llvm::StringRef name,
   return addNode(new ConcatNode(name, OT, ops, dimension));
 }
 
-InsertTensorNode *Function::createTile(llvm::StringRef name, NodeValue input,
-                                       unsigned_t tiles, unsigned_t axis) {
+TileNode *Function::createTile(llvm::StringRef name, NodeValue input,
+                               unsigned_t tiles, unsigned_t axis) {
   assert(tiles > 0 && "Tiles must be non-zero.");
   assert(axis >= 0 && axis < input.dims().size() &&
          "Axis must fall in range of source dims.");
@@ -829,11 +829,15 @@ InsertTensorNode *Function::createTile(llvm::StringRef name, NodeValue input,
   ShapeVector outShape(input.dims().begin(), input.dims().end());
   outShape[axis] *= tiles;
   auto OT = getParent()->uniqueTypeWithNewShape(input.getType(), outShape);
+  return addNode(new TileNode(name, OT, input, tiles, axis));
+}
 
-  // Use a zero splat as the Big node input for InsertTensor.
-  auto *zero = createSplat(name, OT, 0);
-  auto start = std::vector<size_t>(input.dims().size(), 0);
-  return addNode(new InsertTensorNode(name, zero, input, start, tiles, axis));
+InsertTensorNode *Function::createInsertTensor(llvm::StringRef name,
+                                               NodeValue big, NodeValue small,
+                                               llvm::ArrayRef<size_t> start,
+                                               unsigned_t count,
+                                               unsigned_t axis) {
+  return addNode(new InsertTensorNode(name, big, small, start, count, axis));
 }
 
 SliceNode *Function::createSlice(llvm::StringRef name, NodeValue input,

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -423,6 +423,8 @@ void InsertTensorNode::verify() const {
   auto src = getSmall();
   auto offsets = getStart();
   unsigned numDims = dest.dims().size();
+  unsigned axis = getAxis();
+  unsigned count = getCount();
   (void)numDims;
   (void)dest;
   (void)src;
@@ -432,6 +434,14 @@ void InsertTensorNode::verify() const {
 
   for (unsigned i = 0; i < numDims; i++) {
     assert(src.dims()[i] + offsets[i] <= dest.dims()[i] && "out of bounds");
+  }
+
+  assert(axis <= src.dims().size() && "Invalid axis.");
+  for (size_t i = 0; i < src.dims().size(); i++) {
+    size_t mul = (i == axis) ? count : 1;
+    (void)mul;
+    assert(src.dims()[i] * mul <= dest.dims()[i] &&
+           "Small does not fit inside Big.");
   }
 }
 
@@ -449,6 +459,20 @@ void SliceNode::verify() const {
 
   for (unsigned i = 0; i < numDims; i++) {
     assert(dest.dims()[i] + offsets[i] <= src.dims()[i] && "out of bounds");
+  }
+}
+
+void TileNode::verify() const {
+  auto dest = getResult();
+  auto src = getInput();
+  unsigned axis = getAxis();
+  unsigned count = getCount();
+  (void)dest;
+  assert(axis <= src.dims().size() && "Invalid axis.");
+  for (size_t i = 0; i < src.dims().size(); i++) {
+    size_t mul = (i == axis) ? count : 1;
+    (void)mul;
+    assert(src.dims()[i] * mul == dest.dims()[i] && "Incorrect output shape.");
   }
 }
 

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -395,6 +395,13 @@ int main(int argc, char **argv) {
                     "Data {{1,2},{3,4},{5,6}}, Slices {{-3,-4}}, and Indices "
                     "{1}, the result is {{1,2},{-3,-4},{5,6}}.");
 
+  BB.newNode("Tile")
+      .addInput("Input")
+      .addMember(MemberType::Unsigned, "Count")
+      .addMember(MemberType::Unsigned, "Axis")
+      .addResultFromCtorArg()
+      .setDocstring("Tile an Input tensor Count times along Axis.");
+
   //===--------------------------------------------------------------------===//
   //                Nodes used for network training
   //===--------------------------------------------------------------------===//


### PR DESCRIPTION
*Description*: Backends may prefer to be passed a TileNode instead of implementing it as an InsertTensorNode/Instruction. Add the TileNode explicitly so that the backend can prevent lowering. I also added the creator for InsertTensorNode since it did not already exist.

*Testing*: Current tests for Tile should cover this already. I also added a test for InsertTensorNode which was not previously explicitly tested.

*Documentation*: N/A
