### PR TITLE
[GraphOptimizer] Merge Reshape into private Variables with one use

### DIFF
--- a/tests/unittests/graphOptzTest.cpp
+++ b/tests/unittests/graphOptzTest.cpp
@@ -780,8 +780,8 @@ TEST_F(GraphOptz, ReshapeReshapeOpt) {
   const size_t shape[] = {10, 20};
   const size_t reshape1[] = {200, 1};
   const size_t reshape2[] = {200};
-  Node *input =
-      F_->getParent()->createVariable(ElemKind::FloatTy, shape, "input");
+  Node *input = F_->getParent()->createVariable(
+      ElemKind::FloatTy, shape, "input", VisibilityKind::Public);
   auto *R1 = F_->createReshape("reshape1", input, reshape1);
   auto *R2 = F_->createReshape("reshape2", R1, reshape2);
   auto *O = F_->createSave("ret", R2);
@@ -1136,7 +1136,8 @@ TEST_F(GraphOptz, concatReshapes) {
     // original ConcatNode (before opt) is 20, and the size of leading
     // dimensions of original ConcatNode (before opt) is 10.
     Node *var = F_->getParent()->createVariable(ElemKind::FloatTy, shape1,
-                                                "input" + std::to_string(i));
+                                                "input" + std::to_string(i),
+                                                VisibilityKind::Public);
     auto *RN = F_->createReshape("reshape" + std::to_string(i), var, shape2);
     inputs1.push_back(RN);
   }
@@ -1148,7 +1149,8 @@ TEST_F(GraphOptz, concatReshapes) {
     // makes the leading/trailing dims same as in the case of the original
     // concat node.
     Node *var = F_->getParent()->createVariable(ElemKind::FloatTy, shape3,
-                                                "input" + std::to_string(i));
+                                                "input" + std::to_string(i),
+                                                VisibilityKind::Public);
     auto *RN = F_->createReshape("reshape" + std::to_string(i), var, shape2);
     inputs2.push_back(RN);
   }

--- a/tests/unittests/graphOptzTest.cpp
+++ b/tests/unittests/graphOptzTest.cpp
@@ -1337,3 +1337,30 @@ TEST_F(GraphOptz, eliminateSingleConcat) {
   // Save node should just save the input.
   EXPECT_TRUE(SN->getInput().getNode() == input);
 }
+
+/// Test that a reshape of a private variable with one use has the reshape
+/// merged into the variable.
+TEST_F(GraphOptz, ReshapePrivateVarOneUse) {
+  const size_t shape[] = {10, 20};
+  const size_t reshape1[] = {200, 1};
+  const size_t reshape2[] = {200};
+  Node *input = F_->getParent()->createVariable(
+      ElemKind::FloatTy, shape, "input", VisibilityKind::Private);
+  auto *R1 = F_->createReshape("reshape1", input, reshape1);
+  auto *R2 = F_->createReshape("reshape2", R1, reshape2);
+  auto *O = F_->createSave("ret", R2);
+
+  // Before optimization, we have 2 Reshapes and a Save.
+  EXPECT_EQ(F_->getNodes().size(), 3);
+
+  ::glow::optimize(F_, CompilationMode::Infer);
+
+  // After optimization, we expect to see just a Save.
+  EXPECT_EQ(F_->getNodes().size(), 1);
+
+  // Save should have the new Variable as input.
+  auto *V = llvm::dyn_cast<Variable>(O->getInput());
+  ASSERT_TRUE(V);
+  // The new Variable should have the same shape as the original second Reshape.
+  EXPECT_TRUE(V->getType()->dims().equals(reshape2));
+}


### PR DESCRIPTION
*Description*: Merge Reshape nodes into private Variables with a single use. Similar to a Reshape(Splat) optimization with the same purpose.

*Testing*: Added a unit test. This opt also broke other unit tests which reshaped private variables, so I made all those variables public to prevent breaking the tests.

*Documentation*: N/A