### PR TITLE
[Quantization] Support for Slice, Gather, Tile

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -328,12 +328,12 @@ public:
                            llvm::ArrayRef<NodeValue> inputs,
                            unsigned_t dimension, TypeRef outTy);
 
-  /// Create a TileNode with \p name, \p input, \p tiles, and \p axis. For
-  /// example, an input tensor {{1,2,3,4}} of dimension 1x4 with tiles = 2 and
-  /// axis = 0 would result in an output tensor {{1,2,3,4}, {1,2,3,4}} of
+  /// Create a quantized TileNode with \p name, \p input, \p tiles, and \p axis.
+  /// For example, an input tensor {{1,2,3,4}} of dimension 1x4 with tiles = 2
+  /// and axis = 0 would result in an output tensor {{1,2,3,4}, {1,2,3,4}} of
   /// dimension 2x4.
   TileNode *createTile(llvm::StringRef name, NodeValue input, unsigned_t tiles,
-                       unsigned_t axis);
+                       unsigned_t axis, TypeRef outTy = nullptr);
 
   /// Create an insert tensor node \p name, which inserts \p small into \p big
   /// at offset into big \p start \p count times along \p axis.

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -169,6 +169,7 @@ bool CPUBackend::isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const {
     case Kinded::Kind::DequantizeNodeKind:
     case Kinded::Kind::DivNodeKind:
     case Kinded::Kind::FullyConnectedNodeKind:
+    case Kinded::Kind::GatherNodeKind:
     case Kinded::Kind::MatMulNodeKind:
     case Kinded::Kind::MaxNodeKind:
     case Kinded::Kind::MinNodeKind:
@@ -180,6 +181,7 @@ bool CPUBackend::isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const {
     case Kinded::Kind::RescaleQuantizedNodeKind:
     case Kinded::Kind::ReshapeNodeKind:
     case Kinded::Kind::SelectNodeKind:
+    case Kinded::Kind::SliceNodeKind:
     case Kinded::Kind::SigmoidNodeKind:
     case Kinded::Kind::SubNodeKind:
     case Kinded::Kind::TanhNodeKind:

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -183,6 +183,7 @@ bool CPUBackend::isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const {
     case Kinded::Kind::SigmoidNodeKind:
     case Kinded::Kind::SubNodeKind:
     case Kinded::Kind::TanhNodeKind:
+    case Kinded::Kind::TileNodeKind:
     case Kinded::Kind::TopKNodeKind:
     case Kinded::Kind::TransposeNodeKind:
       return true;

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -64,6 +64,7 @@ bool Interpreter::isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const {
     case Kinded::Kind::SliceNodeKind:
     case Kinded::Kind::SubNodeKind:
     case Kinded::Kind::TanhNodeKind:
+    case Kinded::Kind::TileNodeKind:
     case Kinded::Kind::TopKNodeKind:
     case Kinded::Kind::TransposeNodeKind:
       return true;

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -828,15 +828,19 @@ ConcatNode *Function::createConcat(llvm::StringRef name,
 }
 
 TileNode *Function::createTile(llvm::StringRef name, NodeValue input,
-                               unsigned_t tiles, unsigned_t axis) {
+                               unsigned_t tiles, unsigned_t axis,
+                               TypeRef outTy) {
   assert(tiles > 0 && "Tiles must be non-zero.");
   assert(axis >= 0 && axis < input.dims().size() &&
          "Axis must fall in range of source dims.");
 
-  ShapeVector outShape(input.dims().begin(), input.dims().end());
-  outShape[axis] *= tiles;
-  auto OT = getParent()->uniqueTypeWithNewShape(input.getType(), outShape);
-  return addNode(new TileNode(name, OT, input, tiles, axis));
+  if (outTy == nullptr) {
+    ShapeVector outShape(input.dims().begin(), input.dims().end());
+    outShape[axis] *= tiles;
+    outTy = getParent()->uniqueTypeWithNewShape(input.getType(), outShape);
+  }
+
+  return addNode(new TileNode(name, outTy, input, tiles, axis));
 }
 
 InsertTensorNode *Function::createInsertTensor(llvm::StringRef name,

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -360,6 +360,19 @@ static Node *quantizeNode(Function *F, Node *node,
                                     quantizedInputs[1]);
     break;
   }
+  case Kinded::Kind::TileNodeKind: {
+    auto *TN = cast<TileNode>(node);
+    assert(quantizedInputs.size() == 1 && "Invalid number of inputs");
+    assert(qParams.size() == 1 && "Invalid number of quantized outputs");
+
+    auto QT =
+        F->getParent()->uniqueType(ElemKind::Int8QTy, TN->getResult().dims(),
+                                   qParams[0].scale, qParams[0].offset);
+
+    quantizedNode = F->createTile(TN->getName(), quantizedInputs[0],
+                                  TN->getCount(), TN->getAxis(), QT);
+    break;
+  }
   default:
     GLOW_UNREACHABLE("The node type is not supported for quantization");
   }

--- a/tests/unittests/quantizationTest.cpp
+++ b/tests/unittests/quantizationTest.cpp
@@ -225,7 +225,8 @@ static Function *createSimpleGraphForQuantization(Module *M, Variable *A,
   auto *TN = F->createTranspose("transpose", O, {1, 0});
   auto *MMN = F->createMatMul("batchedreduceadd", O, TN);
   auto *BRAN = F->createBatchedReduceAdd("batchedreduceadd", MMN, 0);
-  F->createSave("save", BRAN);
+  auto *TLN = F->createTile("tile", BRAN, 2, 0);
+  F->createSave("save", TLN);
   return F;
 }
 


### PR DESCRIPTION
Allow for a Tile to be quantized based on the profile that was gathered for it. I added Tile to the end2end quantization test.

Slice and Gather were already supported, but not yet added to the CPU Backend.