### PR TITLE
[Nodes] Do not verify offset of quantized ReluNode

### DIFF
--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -265,8 +265,6 @@ static void verifyRelu(NodeValue result, NodeValue input) {
   if (input.getType()->isQuantizedType()) {
     assert(result.getType()->isQuantizedType());
     checkSameShape(result, input);
-    assert(result.getType()->getOffset() == -128 &&
-           "Min fp32 value should be 0");
   } else {
     checkSameType(result, input);
   }


### PR DESCRIPTION
This check only makes sense if we are using `quantization::Schema::Asymmetric`. Currently the schema is only used when dumping the profile, so it's not possible to know what schema is used when loading the profile/quantizing. Hence I am removing this verify.

This unbreaks models with relus when loading a profile that was dumped with `-quantization-schema=symmetric`. I verified this with Resnet50. I also added a unit test for Relu with symmetric parameters.