### PR TITLE
[Placeholder/Quantization] Fix the profile-guided quantization of PH.

### DIFF
--- a/lib/Optimizer/Quantization.cpp
+++ b/lib/Optimizer/Quantization.cpp
@@ -56,6 +56,14 @@ Function *glow::profileQuantization(Function *F, llvm::StringRef newFuncName) {
     nodesToInstrument.insert(var->getOutput());
   }
 
+  // Add Quantization Profile node to all floating point placeholders.
+  for (const auto &PH : G->getParent()->getPlaceholders()) {
+    if (PH->getOutput().getElementType() != ElemKind::FloatTy) {
+      continue;
+    }
+    nodesToInstrument.insert(PH->getOutput());
+  }
+
   for (const auto &node : nodesToInstrument) {
     G->createQuantizationProfile("QuantizationProfile", node);
   }


### PR DESCRIPTION
*Description*:

Fix the profile-guided quantization of placeholders. The problem was
that we were not profiling placeholder nodes. This commit also ports the
tests from Variables to Placeholders.

*Testing*: Ported the test to use PH.
*Documentation*: None.