### PR TITLE
[CPU] Make LLVMIRGen::generateLLVMIRForModule virtual

### DIFF
--- a/lib/Backends/CPU/LLVMIRGen.h
+++ b/lib/Backends/CPU/LLVMIRGen.h
@@ -213,7 +213,7 @@ public:
   virtual void generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
                                       const glow::Instruction *I);
   /// Emit LLVM-IR for the whole IRFunction.
-  void generateLLVMIRForModule(llvm::IRBuilder<> &builder);
+  virtual void generateLLVMIRForModule(llvm::IRBuilder<> &builder);
   /// \returns a libjit API function by name.
   llvm::Function *getFunction(const std::string &name);
   /// \returns a libjit API function by name and tensor element type.


### PR DESCRIPTION
*Description*:
Small change to make CPU backend inheritable (continues https://github.com/pytorch/glow/pull/1562).
*Testing*:
NFC, so no testing.
*Documentation*:
NFC, so no documentation updates.