### PR TITLE
[Placeholder ] Add two allocation methods to the context and update SaveNode.

### DIFF
--- a/include/glow/Graph/Context.h
+++ b/include/glow/Graph/Context.h
@@ -18,6 +18,7 @@
 
 #include "llvm/ADT/ArrayRef.h"
 
+#include <list>
 #include <unordered_map>
 
 namespace glow {
@@ -52,6 +53,16 @@ public:
   /// Allocates a tensor to back the placeholder \p P. The new tensor has the
   /// type of P.
   Tensor *allocate(Placeholder *P);
+
+  /// Allocates zero-initialized backing tensors to all placeholders in \p lst
+  /// that are not currently allocated in the context.
+  /// \returns the number of tensors that were allocated.
+  unsigned allocate(std::list<Placeholder *> &lst);
+
+  /// \returns the first placeholder in \p list that is not allocated by this
+  /// context. This method returns null if all placeholders in the list are
+  /// allocated.
+  Placeholder *getFirstUnallocated(std::list<Placeholder *> &lst) const;
 
   /// \returns True if \p P is a registered Placeholder.
   size_t count(Placeholder *P) const;

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -486,7 +486,7 @@ public:
                                  NodeValue lengths);
 
   SaveNode *createSave(llvm::StringRef name, NodeValue input);
-  SaveNode *createSave(llvm::StringRef name, NodeValue input, Variable *output);
+  SaveNode *createSave(llvm::StringRef name, NodeValue input, Storage *output);
 
   /// Create quantization profile node named \p name for the output tensor from
   /// \p input. Capture observed node name in quantization profile node as

--- a/lib/Graph/Context.cpp
+++ b/lib/Graph/Context.cpp
@@ -53,6 +53,33 @@ Tensor *Context::allocate(Placeholder *P) {
   return T;
 }
 
+unsigned Context::allocate(std::list<Placeholder *> &lst) {
+  unsigned allocated = 0;
+  // For each placeholder in the list:
+  for (Placeholder *P : lst) {
+    // Don't allocate tensors for placeholders that are already allocated.
+    if (this->count(P)) {
+      continue;
+    }
+
+    // Allocate a tensor to back P.
+    allocate(P);
+    allocated++;
+  }
+  return allocated;
+}
+
+Placeholder *Context::getFirstUnallocated(std::list<Placeholder *> &lst) const {
+  // For each placeholder in the list:
+  for (Placeholder *P : lst) {
+    // If we found an unallocated placeholder then return it.
+    if (!count(P))
+      return P;
+  }
+
+  return nullptr;
+}
+
 Context::Context(llvm::ArrayRef<Placeholder *> placeholders,
                  llvm::ArrayRef<Tensor *> inputs) {
   assert(placeholders.size() == inputs.size() &&

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1320,7 +1320,7 @@ SaveNode *Function::createSave(llvm::StringRef name, NodeValue input) {
 }
 
 SaveNode *Function::createSave(llvm::StringRef name, NodeValue input,
-                               Variable *output) {
+                               Storage *output) {
   return addNode(new SaveNode(name, input, output));
 }
 

--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -239,6 +239,18 @@ TEST(Context, basicContextTest) {
   // The tensor that we got while allocating T2 is the same one that we got
   // while searching the context.
   EXPECT_EQ(I2, V2);
+
+  // Check that all of the placeholders are allocated.
+  C.allocate(input3);
+  EXPECT_EQ(nullptr, C.getFirstUnallocated(mod.getPlaceholders()));
+
+  // Check that some placeholders are unallocated.
+  C.clear();
+  EXPECT_NE(nullptr, C.getFirstUnallocated(mod.getPlaceholders()));
+
+  // Check that all of the placeholders are allocated.
+  C.allocate(mod.getPlaceholders());
+  EXPECT_EQ(nullptr, C.getFirstUnallocated(mod.getPlaceholders()));
 }
 
 INSTANTIATE_TEST_CASE_P(Interpreter, BackendTest,


### PR DESCRIPTION
*Description*:

    [Placeholder] Allow the SaveNode builder to accept Placeholders.
    
    Allow the SaveNode builder to accept Placeholders. This API is used in some of the upcoming unit test changes.

    [Context] Add two allocation methods to the context.
    
    Add two allocation methods to the context. These methods can be used to
    verify that all placeholders are allocated. I'll include the actual
    check in the next PR, that requires some restructuring of compile() and
    some tests.
    
    Example:
    
    ```
      #ifndef NDEBUG
        auto *P = ctx.getFirstUnallocated(F->getParent()->getPlaceholders());
        (void) P;
        assert(nullptr == P && "Found an unallocated placeholder");
      #endif
    ```

*Testing*: Added a unit test.
*Documentation*: None.
