### PR TITLE
[Placeholder] Migrate gradCheckTest to Placeholders

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -497,6 +497,7 @@ public:
                                  NodeValue lengths);
 
   SaveNode *createSave(llvm::StringRef name, NodeValue input);
+  SaveNode *createSavePH(llvm::StringRef name, NodeValue input);
   SaveNode *createSave(llvm::StringRef name, NodeValue input, Storage *output);
 
   /// Create quantization profile node named \p name for the output tensor from

--- a/lib/Graph/Grad.cpp
+++ b/lib/Graph/Grad.cpp
@@ -240,8 +240,8 @@ Function *glow::differentiate(Function *F, const TrainingConfig &conf,
       if (map.hasGradient(V)) {
         std::string nodeName = "_grad_" + V->getName().str();
         // Save the gradient and return the destination variable.
-        auto *saveNode = G->createSave(nodeName, map.getGradient(V));
-        auto *GradV = llvm::dyn_cast<Storage>(saveNode->getOutput().getNode());
+        auto *saveNode = G->createSavePH(nodeName, map.getGradient(V));
+        auto *GradV = llvm::dyn_cast<Storage>(saveNode->getPlaceholder());
         varGrads->push_back({V, GradV});
       }
       continue;

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1327,6 +1327,12 @@ Function::createSparseLengthsWeightedSum(llvm::StringRef name, NodeValue data,
                                                   indices, lengths));
 }
 
+SaveNode *Function::createSavePH(llvm::StringRef name, NodeValue input) {
+  auto *dest = getParent()->createPlaceholder(input.getType(), name, false);
+
+  return addNode(new SaveNode(name, input, dest));
+}
+
 SaveNode *Function::createSave(llvm::StringRef name, NodeValue input) {
   auto *dest = getParent()->createVariable(input.getType(), name,
                                            VisibilityKind::Public, false);

--- a/tests/unittests/gradCheckTest.cpp
+++ b/tests/unittests/gradCheckTest.cpp
@@ -55,13 +55,20 @@ float gradDiff(float G1, float G2) {
   return std::min(std::abs(G1 - G2), std::abs(G1 - G2) / std::abs(G1 + G2 + 1));
 }
 
-Variable *getGrad(const VariableGradientsList &grads, Variable *V) {
+Placeholder *getGrad(const VariableGradientsList &grads, Placeholder *V) {
   for (auto &p : grads) {
     if (p.first == V) {
-      return cast<Variable>(p.second);
+      return cast<Placeholder>(p.second);
     }
   }
   return nullptr;
+}
+
+void allocateGrads(Context &ctx, const VariableGradientsList &grads) {
+  for (auto &p : grads) {
+    auto grad = cast<Placeholder>(p.second);
+    ctx.allocate(grad);
+  }
 }
 
 /// Performs gradient check by comparing analytical and numerical gradients.
@@ -70,20 +77,25 @@ Variable *getGrad(const VariableGradientsList &grads, Variable *V) {
 /// propagation.
 ///
 /// \param EE Execution engine to compile/run network.
+/// \param ctx Execution context.
 /// \param result Node that contains result of f(x).
-/// \param inputVar Variable which gradient is assessed.
-/// \param expVar Variable with expected value, only used during the training.
-/// \param inputs Tensor for \p inputVar variable.
-/// \param outputs Tensor for \p expVar variable.
-/// \param allowedError allowed delta between analytical and numerical
-///                     gradients.
-void performGradCheck(ExecutionEngine &EE, SaveNode *result, Variable *inputVar,
-                      Variable *expVar, Tensor *inputs, Tensor *outputs,
-                      float delta, float allowedError) {
+/// \param inputVar Placeholder which gradient is assessed.
+/// \param expVar Placeholder with expected value, only used during the
+/// training. \param inputs Tensor for \p inputVar placeholder. \param outputs
+/// Tensor for \p expVar placeholder. \param allowedError allowed delta between
+/// analytical and numerical gradients.
+void performGradCheck(ExecutionEngine &EE, Context &ctx, SaveNode *result,
+                      Placeholder *inputVar, Placeholder *expVar,
+                      Tensor *inputs, Tensor *outputs, float delta,
+                      float allowedError) {
   TrainingConfig TC;
-  Context ctx;
 
   auto &F = *EE.getModule().getFunction("main");
+
+  // Allocate result, inputVar and expVar.
+  auto resultTensor = ctx.allocate(result->getPlaceholder());
+  ctx.allocate(inputVar);
+  ctx.allocate(expVar);
 
   // This variable records the number of the next sample to be used for
   // training.
@@ -95,42 +107,42 @@ void performGradCheck(ExecutionEngine &EE, SaveNode *result, Variable *inputVar,
 
   // The network might have variables, other than inputVar and expVar.
   // Train the network until other variables reach some stable local minimum.
-  runBatch(EE, 300, sampleCounter, {inputVar, expVar}, {inputs, outputs});
+  runBatch(EE, ctx, 300, sampleCounter, {inputVar, expVar}, {inputs, outputs});
 
   // Create a version of the network that records the gradients to some side
   // table instead of updating them.
   VariableGradientsList varGrads;
   Function *recordNet = glow::differentiate(&F, TC, "record", &varGrads);
+  allocateGrads(ctx, varGrads);
   EE.compile(CompilationMode::Train, recordNet, ctx);
 
   // Clear the gradients of the first layer.
   auto gradVar = getGrad(varGrads, inputVar);
-  gradVar->getPayload().zero();
+  auto gradVarTensor = ctx.get(gradVar);
+  gradVarTensor->zero();
 
   // Train the network just once to record the values of gradient for inputVar.
-  runBatch(EE, 1, sampleCounter, {inputVar, expVar}, {inputs, outputs});
+  runBatch(EE, ctx, 1, sampleCounter, {inputVar, expVar}, {inputs, outputs});
 
   // Compile the original network in inference mode.
   EE.compile(CompilationMode::Infer, &F, ctx);
 
-  auto analyticalGradsH = gradVar->getPayload().getHandle();
+  auto analyticalGradsH = gradVarTensor->getHandle();
   auto inputsH = inputs->getHandle<>();
   for (size_t i = 0; i < analyticalGradsH.size(); i++) {
     auto old = inputsH.raw(i);
-    Tensor &res = result->getVariable()->getPayload();
-
     // Calculate f(x+e):
     inputsH.raw(i) = old + delta;
-    updateVariables({inputVar}, {inputs});
+    updateVariables(ctx, {inputVar}, {inputs});
     EE.run();
-    auto plusLoss = computeL2Loss(outputs, &res);
+    auto plusLoss = computeL2Loss(outputs, resultTensor);
 
     // Calculate f(x-e):
     inputsH.raw(i) = old - delta;
-    updateVariables({inputVar}, {inputs});
+    updateVariables(ctx, {inputVar}, {inputs});
     EE.run();
 
-    auto minusLoss = computeL2Loss(outputs, &res);
+    auto minusLoss = computeL2Loss(outputs, resultTensor);
 
     // Restore value back.
     inputsH.raw(i) = old;
@@ -146,26 +158,29 @@ void performGradCheck(ExecutionEngine &EE, SaveNode *result, Variable *inputVar,
 }
 
 TEST_P(InterpreterGrad, gradientCheckFCConcatRELU) {
+  Context ctx;
   size_t numInputElem = 20;
   size_t numOutputElem = 10;
 
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("main");
-  auto *A = mod.createVariable(ElemKind::FloatTy, {1, numInputElem}, "A",
-                               VisibilityKind::Public, false);
-  auto *Exp = mod.createVariable(ElemKind::FloatTy, {1, numOutputElem}, "exp",
-                                 VisibilityKind::Public, false);
+  auto *A =
+      mod.createPlaceholder(ElemKind::FloatTy, {1, numInputElem}, "A", false);
+  auto *Exp = mod.createPlaceholder(ElemKind::FloatTy, {1, numOutputElem},
+                                    "exp", false);
 
   Node *FA = F->createFullyConnected("fc1", A, numOutputElem / 2);
   FA = F->createRELU("relu1", FA);
 
-  auto *B = mod.createVariable(ElemKind::FloatTy, {1, numInputElem}, "B");
+  auto *B =
+      mod.createPlaceholder(ElemKind::FloatTy, {1, numInputElem}, "B", true);
+  ctx.allocate(B);
   Node *FB = F->createFullyConnected("fc2", B, numOutputElem / 2);
   FB = F->createRELU("relu2", FB);
 
   Node *O = F->createConcat("concat", {FA, FB}, 1);
   O = F->createRegression("reg", O, Exp);
-  auto *result = F->createSave("ret", O);
+  auto *result = F->createSave(ctx, "ret", O);
 
   Tensor inputs(ElemKind::FloatTy, {{1, numInputElem}});
   Tensor outputs(ElemKind::FloatTy, {{1, numOutputElem}});
@@ -176,24 +191,24 @@ TEST_P(InterpreterGrad, gradientCheckFCConcatRELU) {
   inputsH.initXavier(1, mod.getPRNG());
   outputsH.initXavier(1, mod.getPRNG());
 
-  performGradCheck(EE_, result, A, Exp, &inputs, &outputs, 0.0001, 0.001);
+  performGradCheck(EE_, ctx, result, A, Exp, &inputs, &outputs, 0.0001, 0.001);
 }
 
 static void gradientCheckGroupConv(size_t depth, size_t group,
                                    ExecutionEngine &EE_) {
+  Context ctx;
   size_t numDim = 10;
 
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("main");
-  auto *A = mod.createVariable(ElemKind::FloatTy, {1, numDim, numDim, depth},
-                               "A", VisibilityKind::Public, false);
-  auto *Ex =
-      mod.createVariable(ElemKind::FloatTy, {1, numDim + 1, numDim + 1, depth},
-                         "exp", VisibilityKind::Public, false);
+  auto *A = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim, numDim, depth},
+                                  "A", false);
+  auto *Ex = mod.createPlaceholder(
+      ElemKind::FloatTy, {1, numDim + 1, numDim + 1, depth}, "exp", false);
 
   Node *O = F->createConv("conv", A, depth, 2, 1, 1, group);
   O = F->createRegression("reg", O, Ex);
-  auto *result = F->createSave("ret", O);
+  auto *result = F->createSave(ctx, "ret", O);
 
   Tensor inputs(ElemKind::FloatTy, {1, numDim, numDim, depth});
   Tensor outputs(ElemKind::FloatTy, {1, numDim + 1, numDim + 1, depth});
@@ -204,7 +219,7 @@ static void gradientCheckGroupConv(size_t depth, size_t group,
   inputsH.randomize(-1, 1, mod.getPRNG());
   outputsH.randomize(-1, 1, mod.getPRNG());
 
-  performGradCheck(EE_, result, A, Ex, &inputs, &outputs, 0.001, 0.04);
+  performGradCheck(EE_, ctx, result, A, Ex, &inputs, &outputs, 0.001, 0.04);
 }
 
 TEST_P(GradCheck, gradientCheckConv) { gradientCheckGroupConv(1, 1, EE_); }
@@ -216,21 +231,22 @@ TEST_P(GradCheck, gradientCheckDepthwiseConv) {
 TEST_P(GradCheck, gradientCheckGroupConv) { gradientCheckGroupConv(4, 2, EE_); }
 
 TEST_P(InterpreterGrad, gradientCheckAvgPool) {
+  Context ctx;
   size_t numDim = 10;
   size_t numOutputElem = 10;
 
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("main");
-  auto *A = mod.createVariable(ElemKind::FloatTy, {1, numDim, numDim, 1}, "A",
-                               VisibilityKind::Public, false);
-  auto *Exp = mod.createVariable(ElemKind::FloatTy, {1, numOutputElem}, "Exp",
-                                 VisibilityKind::Public, false);
+  auto *A = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim, numDim, 1},
+                                  "A", false);
+  auto *Exp = mod.createPlaceholder(ElemKind::FloatTy, {1, numOutputElem},
+                                    "Exp", false);
 
   Node *O = F->createAvgPool("pool", A, 3, 3, 1);
   O = F->createTanh("tanh", O);
   O = F->createFullyConnected("fc", O, numOutputElem);
   O = F->createRegression("reg", O, Exp);
-  auto *result = F->createSave("ret", O);
+  auto *result = F->createSave(ctx, "ret", O);
 
   Tensor inputs(ElemKind::FloatTy, {1, numDim, numDim, 1});
   Tensor outputs(ElemKind::FloatTy, {1, numOutputElem});
@@ -241,24 +257,25 @@ TEST_P(InterpreterGrad, gradientCheckAvgPool) {
   inputsH.initXavier(1, mod.getPRNG());
   outputsH.initXavier(1, mod.getPRNG());
 
-  performGradCheck(EE_, result, A, Exp, &inputs, &outputs, 0.001, 0.004);
+  performGradCheck(EE_, ctx, result, A, Exp, &inputs, &outputs, 0.001, 0.004);
 }
 
 TEST_P(InterpreterGrad, gradientCheckBatchNorm) {
+  Context ctx;
   size_t numDim = 5;
   size_t numOutputElem = numDim * numDim * 3;
 
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("main");
-  auto *A = mod.createVariable(ElemKind::FloatTy, {1, numDim, numDim, 3}, "A",
-                               VisibilityKind::Public, false);
-  auto *Ex = mod.createVariable(ElemKind::FloatTy, {1, numOutputElem}, "exp",
-                                VisibilityKind::Public, false);
+  auto *A = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim, numDim, 3},
+                                  "A", false);
+  auto *Ex = mod.createPlaceholder(ElemKind::FloatTy, {1, numOutputElem}, "exp",
+                                   false);
 
   Node *O = F->createBatchNormalization("batch", A, 3, 0.0001, 0.9);
   O = F->createReshape("reshape", O, {1, numDim * numDim * 3});
   O = F->createRegression("reg", O, Ex);
-  auto result = F->createSave("ret", O);
+  auto result = F->createSave(ctx, "ret", O);
 
   Tensor inputs(ElemKind::FloatTy, {1, numDim, numDim, 3});
   Tensor outputs(ElemKind::FloatTy, {1, numOutputElem});
@@ -274,29 +291,29 @@ TEST_P(InterpreterGrad, gradientCheckBatchNorm) {
     inputsH.raw(i) += 4;
   }
 
-  performGradCheck(EE_, result, A, Ex, &inputs, &outputs, 0.001, 0.004);
+  performGradCheck(EE_, ctx, result, A, Ex, &inputs, &outputs, 0.001, 0.004);
 }
 
 TEST_P(InterpreterGrad, gradientCheckArithmeticDiv) {
   // The test creates a net: A / B = Exp. Where A is trainable weight,
   // B and Exp are external data (initialized randomly once). SGD will find
   // correct value for A, and then gradient check will be performed.
+  Context ctx;
   size_t numDim = 10;
 
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("main");
-  auto *A = mod.createVariable(ElemKind::FloatTy, {1, numDim}, "A",
-                               VisibilityKind::Public, true);
-  auto *B = mod.createVariable(ElemKind::FloatTy, {1, numDim}, "B",
-                               VisibilityKind::Public, false);
-  auto *Exp = mod.createVariable(ElemKind::FloatTy, {1, numDim}, "exp",
-                                 VisibilityKind::Public, false);
+  auto *A = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim}, "A", true);
+  auto *B = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim}, "B", false);
+  auto *Exp =
+      mod.createPlaceholder(ElemKind::FloatTy, {1, numDim}, "exp", false);
 
-  A->getPayload().init(Tensor::InitKind::Xavier, 1.0, mod.getPRNG());
+  auto *ATensor = ctx.allocate(A);
+  ATensor->init(Tensor::InitKind::Xavier, 1.0, mod.getPRNG());
 
   Node *O = F->createDiv("div", A, B);
   O = F->createRegression("reg", O, Exp);
-  auto *result = F->createSave("ret", O);
+  auto *result = F->createSave(ctx, "ret", O);
 
   Tensor BValues(ElemKind::FloatTy, {1, numDim});
   Tensor ExpValues(ElemKind::FloatTy, {1, numDim});
@@ -305,36 +322,38 @@ TEST_P(InterpreterGrad, gradientCheckArithmeticDiv) {
   BValues.getHandle().randomize(0.1, 1, mod.getPRNG());
   ExpValues.getHandle().randomize(0.1, 1, mod.getPRNG());
 
-  performGradCheck(EE_, result, B, Exp, &BValues, &ExpValues, 0.0001, 0.001);
+  performGradCheck(EE_, ctx, result, B, Exp, &BValues, &ExpValues, 0.0001,
+                   0.001);
 }
 
 TEST_P(InterpreterGrad, gradientCheckArithmetic) {
+  Context ctx;
   size_t numDim = 20;
 
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("main");
-  auto *A = mod.createVariable(ElemKind::FloatTy, {1, numDim}, "A",
-                               VisibilityKind::Public, false);
-  auto *B = mod.createVariable(ElemKind::FloatTy, {1, numDim}, "B",
-                               VisibilityKind::Public, false);
-  auto *C = mod.createVariable(ElemKind::FloatTy, {1, numDim}, "C",
-                               VisibilityKind::Public, false);
-  auto *D = mod.createVariable(ElemKind::FloatTy, {1, numDim}, "D",
-                               VisibilityKind::Public, false);
-  auto *E = mod.createVariable(ElemKind::FloatTy, {1, numDim}, "E",
-                               VisibilityKind::Public, false);
-  // Randomize E to avoid div by zero.
-  E->getPayload().getHandle().initXavier(1, mod.getPRNG());
+  auto *A = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim}, "A", false);
+  auto *B = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim}, "B", false);
+  auto *C = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim}, "C", false);
+  auto *D = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim}, "D", false);
+  auto *E = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim}, "E", false);
+  ctx.allocate(B);
+  ctx.allocate(C);
+  ctx.allocate(D);
 
-  auto *Exp = mod.createVariable(ElemKind::FloatTy, {1, numDim}, "exp",
-                                 VisibilityKind::Public, false);
+  // Randomize E to avoid div by zero.
+  auto *ETensor = ctx.allocate(E);
+  ETensor->getHandle().initXavier(1, mod.getPRNG());
+
+  auto *Exp =
+      mod.createPlaceholder(ElemKind::FloatTy, {1, numDim}, "exp", false);
 
   Node *O = F->createMul("mul", A, B);
   O = F->createAdd("add", O, C);
   O = F->createSub("sub", D, O);
   O = F->createDiv("div", O, E);
   O = F->createRegression("reg", O, Exp);
-  auto *result = F->createSave("ret", O);
+  auto *result = F->createSave(ctx, "ret", O);
 
   Tensor inputs(ElemKind::FloatTy, {1, numDim});
   Tensor outputs(ElemKind::FloatTy, {1, numDim});
@@ -345,25 +364,26 @@ TEST_P(InterpreterGrad, gradientCheckArithmetic) {
   inputsH.initXavier(1, mod.getPRNG());
   outputsH.initXavier(1, mod.getPRNG());
 
-  performGradCheck(EE_, result, A, Exp, &inputs, &outputs, 0.01, 0.004);
+  performGradCheck(EE_, ctx, result, A, Exp, &inputs, &outputs, 0.01, 0.004);
 }
 
 TEST_P(InterpreterGrad, gradientCheckFCConcatTanh) {
   // Using the same gradient check test setup as gradientCheck_FC_Concat_RELU
+  Context ctx;
   size_t numInputElem = 20;
   size_t numOutputElem = 10;
 
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("main");
-  auto *A = mod.createVariable(ElemKind::FloatTy, {1, numInputElem}, "A",
-                               VisibilityKind::Public, false);
-  auto *Exp = mod.createVariable(ElemKind::FloatTy, {1, numOutputElem}, "Exp",
-                                 VisibilityKind::Public, false);
+  auto *A =
+      mod.createPlaceholder(ElemKind::FloatTy, {1, numInputElem}, "A", false);
+  auto *Exp = mod.createPlaceholder(ElemKind::FloatTy, {1, numOutputElem},
+                                    "Exp", false);
 
   Node *FA = F->createFullyConnected("fc", A, numOutputElem);
   FA = F->createTanh("tanh", FA);
   FA = F->createRegression("reg", FA, Exp);
-  auto *result = F->createSave("ret", FA);
+  auto *result = F->createSave(ctx, "ret", FA);
 
   Tensor inputs(ElemKind::FloatTy, {{1, numInputElem}});
   Tensor outputs(ElemKind::FloatTy, {{1, numOutputElem}});
@@ -374,23 +394,24 @@ TEST_P(InterpreterGrad, gradientCheckFCConcatTanh) {
   inputsH.initXavier(1, mod.getPRNG());
   outputsH.initXavier(1, mod.getPRNG());
 
-  performGradCheck(EE_, result, A, Exp, &inputs, &outputs, 0.0001, 0.001);
+  performGradCheck(EE_, ctx, result, A, Exp, &inputs, &outputs, 0.0001, 0.001);
 }
 
 TEST_P(InterpreterGrad, gradientCheckFC) {
+  Context ctx;
   size_t numInputElem = 20;
   size_t numOutputElem = 10;
 
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("main");
-  auto *A = mod.createVariable(ElemKind::FloatTy, {1, numInputElem}, "A",
-                               VisibilityKind::Public, false);
-  auto *Exp = mod.createVariable(ElemKind::FloatTy, {1, numOutputElem}, "Exp",
-                                 VisibilityKind::Public, false);
+  auto *A =
+      mod.createPlaceholder(ElemKind::FloatTy, {1, numInputElem}, "A", false);
+  auto *Exp = mod.createPlaceholder(ElemKind::FloatTy, {1, numOutputElem},
+                                    "Exp", false);
 
   Node *FA = F->createFullyConnected("fc", A, numOutputElem);
   FA = F->createRegression("reg", FA, Exp);
-  auto *result = F->createSave("ret", FA);
+  auto *result = F->createSave(ctx, "ret", FA);
 
   Tensor inputs(ElemKind::FloatTy, {{1, numInputElem}});
   Tensor outputs(ElemKind::FloatTy, {{1, numOutputElem}});
@@ -401,24 +422,26 @@ TEST_P(InterpreterGrad, gradientCheckFC) {
   inputsH.initXavier(1, mod.getPRNG());
   outputsH.initXavier(1, mod.getPRNG());
 
-  performGradCheck(EE_, result, A, Exp, &inputs, &outputs, 0.0001, 0.0001);
+  performGradCheck(EE_, ctx, result, A, Exp, &inputs, &outputs, 0.0001, 0.0001);
 }
 
 TEST_P(InterpreterGrad, gradientCheckSigmoid) {
+  Context ctx;
   size_t numInputElem = 20;
   size_t numOutputElem = 10;
 
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("main");
-  auto *A = mod.createVariable(ElemKind::FloatTy, {1, numInputElem}, "A",
-                               VisibilityKind::Public, false);
-  auto *Exp = mod.createVariable(ElemKind::FloatTy, {1, numOutputElem}, "Exp",
-                                 VisibilityKind::Public, false);
-  F->createSave("ret", A);
+  auto *A =
+      mod.createPlaceholder(ElemKind::FloatTy, {1, numInputElem}, "A", false);
+  auto *Exp = mod.createPlaceholder(ElemKind::FloatTy, {1, numOutputElem},
+                                    "Exp", false);
+  auto *result = F->createSave(ctx, "ret", A);
+  ctx.allocate(result->getPlaceholder());
 
   Node *FA = F->createSigmoid("sig", Exp);
   FA = F->createRegression("reg", FA, Exp);
-  auto *result = F->createSave("ret", FA);
+  result = F->createSave(ctx, "ret", FA);
 
   Tensor inputs(ElemKind::FloatTy, {{1, numInputElem}});
   Tensor outputs(ElemKind::FloatTy, {{1, numOutputElem}});
@@ -429,24 +452,26 @@ TEST_P(InterpreterGrad, gradientCheckSigmoid) {
   inputsH.initXavier(1, mod.getPRNG());
   outputsH.initXavier(1, mod.getPRNG());
 
-  performGradCheck(EE_, result, A, Exp, &inputs, &outputs, 0.0001, 0.001);
+  performGradCheck(EE_, ctx, result, A, Exp, &inputs, &outputs, 0.0001, 0.001);
 }
 
 TEST_P(InterpreterGrad, gradientCheckRelu) {
+  Context ctx;
   size_t numInputElem = 20;
   size_t numOutputElem = 10;
 
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("main");
-  auto *A = mod.createVariable(ElemKind::FloatTy, {1, numInputElem}, "A",
-                               VisibilityKind::Public, false);
-  auto *Exp = mod.createVariable(ElemKind::FloatTy, {1, numOutputElem}, "Exp",
-                                 VisibilityKind::Public, false);
-  F->createSave("ret", A);
+  auto *A =
+      mod.createPlaceholder(ElemKind::FloatTy, {1, numInputElem}, "A", false);
+  auto *Exp = mod.createPlaceholder(ElemKind::FloatTy, {1, numOutputElem},
+                                    "Exp", false);
+  auto *result = F->createSave(ctx, "ret", A);
+  ctx.allocate(result->getPlaceholder());
 
   Node *FA = F->createRELU("relu", Exp);
   FA = F->createRegression("reg", FA, Exp);
-  auto *result = F->createSave("ret", FA);
+  result = F->createSave(ctx, "ret", FA);
 
   Tensor inputs(ElemKind::FloatTy, {{1, numInputElem}});
   Tensor outputs(ElemKind::FloatTy, {{1, numOutputElem}});
@@ -457,23 +482,24 @@ TEST_P(InterpreterGrad, gradientCheckRelu) {
   inputsH.initXavier(1, mod.getPRNG());
   outputsH.initXavier(1, mod.getPRNG());
 
-  performGradCheck(EE_, result, A, Exp, &inputs, &outputs, 0.0001, 0.001);
+  performGradCheck(EE_, ctx, result, A, Exp, &inputs, &outputs, 0.0001, 0.001);
 }
 
 TEST_P(InterpreterGrad, gradientCheckTranspose) {
   // Using the same gradient check test setup as gradientCheck_FC_Concat_RELU
+  Context ctx;
   size_t numOutputElem = 10;
 
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("main");
-  auto *A = mod.createVariable(ElemKind::FloatTy, {1, 5, 10, 5}, "input",
-                               VisibilityKind::Public, false);
-  auto *Exp = mod.createVariable(ElemKind::FloatTy, {1, numOutputElem}, "exp",
-                                 VisibilityKind::Public, false);
+  auto *A =
+      mod.createPlaceholder(ElemKind::FloatTy, {1, 5, 10, 5}, "input", false);
+  auto *Exp = mod.createPlaceholder(ElemKind::FloatTy, {1, numOutputElem},
+                                    "exp", false);
   Node *TA = F->createTranspose("transpose", A, NHWC2NCHW);
   TA = F->createFullyConnected("fc", TA, numOutputElem);
   TA = F->createRegression("regress", TA, Exp);
-  auto *result = F->createSave("ret", TA);
+  auto *result = F->createSave(ctx, "ret", TA);
 
   Tensor inputs(ElemKind::FloatTy, {1, 5, 10, 5});
   Tensor outputs(ElemKind::FloatTy, {1, numOutputElem});
@@ -484,7 +510,7 @@ TEST_P(InterpreterGrad, gradientCheckTranspose) {
   inputsH.randomize(-1, 1, mod.getPRNG());
   outputsH.randomize(-1, 1, mod.getPRNG());
 
-  performGradCheck(EE_, result, A, Exp, &inputs, &outputs, 0.0001, 0.001);
+  performGradCheck(EE_, ctx, result, A, Exp, &inputs, &outputs, 0.0001, 0.001);
 }
 
 TEST_P(InterpreterGrad, gradientCheckCrossEntropyLoss) {
@@ -497,14 +523,15 @@ TEST_P(InterpreterGrad, gradientCheckCrossEntropyLoss) {
 
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("main");
-  auto *P = mod.createVariable(ElemKind::FloatTy, {batchSize, 4}, "P",
-                               VisibilityKind::Public, false);
-  auto *Y = mod.createVariable(ElemKind::Int64ITy, {batchSize}, "Labels",
-                               VisibilityKind::Public, false);
-  auto *L = mod.createVariable(ElemKind::FloatTy, {1}, "L",
-                               VisibilityKind::Public, false);
+  auto *P =
+      mod.createPlaceholder(ElemKind::FloatTy, {batchSize, 4}, "P", false);
+  ctx.allocate(P);
+  auto *Y =
+      mod.createPlaceholder(ElemKind::Int64ITy, {batchSize}, "Labels", false);
+  ctx.allocate(Y);
   Node *CE = F->createCrossEntropyLoss("celoss", P, Y);
-  F->createSave("ret", CE, L);
+  auto *result = F->createSave(ctx, "ret", CE);
+  auto *LTensor = ctx.allocate(result->getPlaceholder());
 
   Tensor inputs(ElemKind::FloatTy, {batchSize, 4});
   Tensor outputs(ElemKind::Int64ITy, {batchSize});
@@ -519,30 +546,32 @@ TEST_P(InterpreterGrad, gradientCheckCrossEntropyLoss) {
 
   VariableGradientsList varGrads;
   Function *TF = glow::differentiate(F, TC, "record", &varGrads);
+  allocateGrads(ctx, varGrads);
   EE_.compile(CompilationMode::Train, TF, ctx);
 
-  auto gradP = getGrad(varGrads, P)->getHandle();
+  auto *gradPlaceholder = getGrad(varGrads, P);
+  auto gradTensorHandle = ctx.get(gradPlaceholder)->getHandle();
 
   for (int i = 0; i < testSamples; ++i) {
     inputsH.randomize(0.0, 1.0, mod.getPRNG());
     for (size_t j = 0; j < inputsH.size(); ++j) {
-      updateVariables({P, Y}, {&inputs, &outputs});
+      updateVariables(ctx, {P, Y}, {&inputs, &outputs});
       EE_.run();
-      L->getPayload().zero();
+      LTensor->zero();
       auto x = inputsH.raw(j);
-      auto g = gradP.raw(j);
+      auto g = gradTensorHandle.raw(j);
       inputsH.raw(j) = x + stepSize;
-      updateVariables({P, Y}, {&inputs, &outputs});
+      updateVariables(ctx, {P, Y}, {&inputs, &outputs});
       EE_.run();
-      auto lp = L->getHandle().raw(0);
+      auto lp = LTensor->getHandle().raw(0);
       inputsH.raw(j) = x - stepSize;
-      L->getPayload().zero();
-      updateVariables({P, Y}, {&inputs, &outputs});
+      LTensor->zero();
+      updateVariables(ctx, {P, Y}, {&inputs, &outputs});
       EE_.run();
-      auto lm = L->getHandle().raw(0);
+      auto lm = LTensor->getHandle().raw(0);
       auto diff = (lp - lm) / (2 * stepSize);
       inputsH.raw(j) = x;
-      updateVariables({P, Y}, {&inputs, &outputs});
+      updateVariables(ctx, {P, Y}, {&inputs, &outputs});
       EE_.run();
       EXPECT_NEAR(diff, g, delta);
     }


### PR DESCRIPTION
**Description**
This commit replaces `Variables` in `gradCheckTest` with `Placeholders`
as part of the larger migration to `Placeholders`.

**Testing**
All unit tests pass.
```
[0/1] Running tests...
Test project /Users/meghanl/fbsource/glow/build_DEBUG
      Start  1: partitionTest
 1/21 Test  #1: partitionTest ....................   Passed    0.04 sec
      Start  2: tensorsTest
 2/21 Test  #2: tensorsTest ......................   Passed    0.33 sec
      Start  3: gradCheckTest
 3/21 Test  #3: gradCheckTest ....................   Passed    4.09 sec
      Start  4: IROptTest
 4/21 Test  #4: IROptTest ........................   Passed    0.01 sec
      Start  5: basicIRTest
 5/21 Test  #5: basicIRTest ......................   Passed    0.01 sec
      Start  6: backendTest
 6/21 Test  #6: backendTest ......................   Passed    1.19 sec
      Start  7: MLTest
 7/21 Test  #7: MLTest ...........................   Passed   42.85 sec
      Start  8: operatorTest
 8/21 Test  #8: operatorTest .....................   Passed    6.82 sec
      Start  9: graphTest
 9/21 Test  #9: graphTest ........................   Passed    0.51 sec
      Start 10: graphGradTest
10/21 Test #10: graphGradTest ....................   Passed    0.04 sec
      Start 11: graphOptzTest
11/21 Test #11: graphOptzTest ....................   Passed    0.02 sec
      Start 12: graphSchedulerTest
12/21 Test #12: graphSchedulerTest ...............   Passed    0.00 sec
      Start 13: quantizationTest
13/21 Test #13: quantizationTest .................   Passed    1.06 sec
      Start 14: UtilsTest
14/21 Test #14: UtilsTest ........................   Passed    0.00 sec
      Start 15: OCLTest
15/21 Test #15: OCLTest ..........................   Passed    0.23 sec
      Start 16: BackendCorrectnessTest
16/21 Test #16: BackendCorrectnessTest ...........   Passed   15.11 sec
      Start 17: GemmTest
17/21 Test #17: GemmTest .........................   Passed    0.04 sec
      Start 18: LLVMIRGenTest
18/21 Test #18: LLVMIRGenTest ....................   Passed    0.01 sec
      Start 19: memoryAllocatorTest
19/21 Test #19: memoryAllocatorTest ..............   Passed    0.01 sec
      Start 20: caffe2ImporterTest
20/21 Test #20: caffe2ImporterTest ...............   Passed    0.03 sec
      Start 21: onnxImporterTest
21/21 Test #21: onnxImporterTest .................   Passed    0.03 sec

100% tests passed, 0 tests failed out of 21

Total Test time (real) =  72.47 sec
```