### PR TITLE
Fp16 interpreter support: Convolution

### DIFF
--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -345,6 +345,25 @@ public:
     }
   }
 
+  /// Convenience method to copy the content of \p t
+  /// to this while both have different underlying types.
+  /// This copy will read each element of \p t as SrcElemType
+  /// and cast them to DestElemType in this.
+  template <typename DestElemType, typename SrcElemType>
+  void copyWithCast(const Tensor *t) {
+    static_assert(!std::is_same<DestElemType, SrcElemType>::value,
+                  "Use copyRawFrom instead");
+    assert(this != t && "Copying to self");
+    assert(getElementType() != t->getElementType() &&
+           "Use copyRawFrom instead");
+    assert(size() == t->size() && "Different sizes");
+    const auto *src = t->getRawDataPointer<SrcElemType>();
+    auto *dst = getRawDataPointer<DestElemType>();
+    for (size_t idx = 0, end = size(); idx != end; ++idx) {
+      dst[idx] = DestElemType(src[idx]);
+    }
+  }
+
   /// Transpose the tensor \p src into the empty tensor \p dest. Shuffle the
   /// axis based on the list \p shuffle, where each element is the src index.
   void transpose(Tensor *dest, llvm::ArrayRef<unsigned_t> shuffle) {

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -73,6 +73,9 @@ bool Interpreter::isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const {
       return false;
     }
   }
+  if (elementTy == ElemKind::Float16Ty) {
+    return false;
+  }
 
   return true;
 }

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -96,6 +96,8 @@ private:
                                  llvm::ArrayRef<unsigned_t> kernelSizes,
                                  llvm::ArrayRef<unsigned_t> strides,
                                  llvm::ArrayRef<unsigned_t> pads, size_t group);
+
+  template <typename ElemTy = float>
   void fwdConvolutionInst_FloatImpl(Value *inV, Value *outV, Value *filterV,
                                     Value *biasV,
                                     llvm::ArrayRef<unsigned_t> kernelSizes,

--- a/tests/unittests/tensorsTest.cpp
+++ b/tests/unittests/tensorsTest.cpp
@@ -305,6 +305,25 @@ TEST(Tensor, copySlice) {
   }
 }
 
+/// Check that we can copy tensors across different types.
+TEST(Tensor, copyWithCast) {
+  PseudoRNG PRNG;
+  Tensor A(ElemKind::Float16Ty, {10, 5, 3});
+  Tensor B(ElemKind::FloatTy, {10, 5, 3});
+
+  auto AH = A.getHandle<float16_t>();
+  auto BH = B.getHandle<>();
+
+  AH.randomize(-2.0, 2.0, PRNG);
+
+  B.copyWithCast<float, float16_t>(&A);
+
+  EXPECT_EQ(A.size(), B.size());
+  for (size_t idx = 0, end = A.size(); idx != end; ++idx) {
+    EXPECT_NEAR(AH.raw(idx), BH.raw(idx), 0.0001);
+  }
+}
+
 TEST(Tensor, reset) {
   Tensor A(ElemKind::FloatTy, {2, 3});
   Tensor QA(ElemKind::Int8QTy, {3, 4}, 2.2, 7);


### PR DESCRIPTION
*Description*:
This PR adds fp16 support for the convolution node in the interpreter

*Testing*:
Added test cases
*Documentation*: N/A

This depends on #1660 and is related to #1329 