### PR TITLE
[NFC] Fix warning introduced by #1671

### DIFF
--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -227,7 +227,7 @@ TEST(Context, basicContextTest) {
   auto *add = F->createAdd("add", input1, input2);
   auto *save = F->createSave(C, "ret", add);
   auto *savePlaceholder = save->getPlaceholder();
-  auto *saveTensor = C.allocate(savePlaceholder);
+  C.allocate(savePlaceholder);
 
   C.insert(input1, std::move(T1));
   Tensor *I2 = C.allocate(input2);


### PR DESCRIPTION
**Description**
This commit fixes a compiler warning for `BackendTest.cpp` introduced by #1671.

**Testing**
Without this patch, the warning appears when compiling:
```
meghanl-mbp:build_DEBUG meghanl$ ninja all
[2/3] Building CXX object tests/unittests/CMakeFiles/backendTest.dir/BackendTest.cpp.o
/Users/meghanl/fbsource/glow/glow/tests/unittests/BackendTest.cpp:230:9: warning: unused variable 'saveTensor' [-Wunused-variable]
  auto *saveTensor = C.allocate(savePlaceholder);
        ^
1 warning generated.
[3/3] Linking CXX executable tests/backendTest
```

With this patch, it does not:
```
meghanl-mbp:build_DEBUG meghanl$ ninja all
[3/3] Linking CXX executable tests/backendTest
meghanl-mbp:build_DEBUG meghanl$ 
```

All unit tests still pass.