### PR TITLE
[libjit] Make vector types compatible with GCC

### DIFF
--- a/lib/Backends/CPU/libjit/libjit_conv.cpp
+++ b/lib/Backends/CPU/libjit/libjit_conv.cpp
@@ -63,7 +63,7 @@ void libjit_convDKKC8_convolve_channel(
   float8 sum[numDepthRegs][ywidth];
   for (unsigned wu = 0; wu < ywidth; wu++) {
     for (unsigned du = 0; du < numDepthRegs; du++) {
-      sum[du][wu] = 0;
+      sum[du][wu] = BroadcastFloat8(0.0);
     }
   }
 
@@ -77,7 +77,7 @@ void libjit_convDKKC8_convolve_channel(
       // Load a single pixel from the input image and broadcast it.
       auto inIdx = libjit_getXYZW(inWdims, sampleN, inX, inY + wu * stride,
                                   fd + group * numChannels);
-      in8[wu] = inW[inIdx];
+      in8[wu] = BroadcastFloat8(inW[inIdx]);
     }
 
     // For each y pixel:

--- a/lib/Backends/CPU/libjit/libjit_defs.h
+++ b/lib/Backends/CPU/libjit/libjit_defs.h
@@ -24,8 +24,13 @@
 typedef SSIZE_T ssize_t;
 #endif
 
-typedef float float4 __attribute__((ext_vector_type(4)));
-typedef float float8 __attribute__((ext_vector_type(8)));
+#if defined(__clang__)
+using float4 = float __attribute__((ext_vector_type(4)));
+using float8 = float __attribute__((ext_vector_type(8)));
+#elif defined(__GNUC__) || defined(__GNUG__)
+using float4 = float __attribute__((vector_size(16)));
+using float8 = float __attribute__((vector_size(32)));
+#endif
 
 /// Loads a simd float8 value from \p ptr.
 #define LoadFloat8(PTR) *((const float8 *)(PTR))
@@ -37,7 +42,11 @@ typedef float float8 __attribute__((ext_vector_type(8)));
 #define AddFloat8(PTR, VAL) *((float8 *)(PTR)) += (VAL);
 
 /// Broadcast the input value to a float8.
+#if defined(__clang__)
 #define BroadcastFloat8(VAL) ((float8)(VAL))
+#elif defined(__GNUC__) || defined(__GNUG__)
+#define BroadcastFloat8(VAL) ((VAL) - (float8){})
+#endif
 
 #define MIN(a, b) (((a) < (b)) ? (a) : (b))
 #define MAX(a, b) (((a) > (b)) ? (a) : (b))


### PR DESCRIPTION
*Description*: GCC doesn't support OpenCL vectors (`ext_vector_type`), which causes libjit to be miscompiled under GCC.  Clang supports GCC vectors (`vector_size`) but has different syntax for casting/broadcasting.  Platform-specific #ifdefs seem like the best way forward
*Testing*: GemmTest
*Documentation*: N/A
Fixes #1661
