### PR TITLE
[bug fix] When schema is symmetric with unit8 we need to allow 0 check in the assert.

### DIFF
--- a/lib/Quantization/Base/Base.cpp
+++ b/lib/Quantization/Base/Base.cpp
@@ -230,9 +230,7 @@ TensorQuantizationParams chooseQuantizationParams(float min, float max,
          "Symmetric quantization should be centered on 0");
   // The only valid offsets for symmetric quantization with uint8 support are 0
   // and -128.
-  // When we use the symmetric property we actually go update the schema in use,
-  // thus 0 is already covered by the previous assert.
-  assert((result.offset == -128 ||
+  assert((result.offset == -128 || result.offset == 0 ||
           schema != quantization::Schema::SymmetricWithUInt8) &&
          "Symmetric quantization should be centered on 0");
   return result;

--- a/lib/Quantization/Base/Base.cpp
+++ b/lib/Quantization/Base/Base.cpp
@@ -228,6 +228,7 @@ TensorQuantizationParams chooseQuantizationParams(float min, float max,
   // The only valid offset for symmetric quantization is 0.
   assert((result.offset == 0 || schema != quantization::Schema::Symmetric) &&
          "Symmetric quantization should be centered on 0");
+
   // The only valid offsets for symmetric quantization with uint8 support are 0
   // and -128.
   assert((result.offset == -128 || result.offset == 0 ||

--- a/tests/unittests/quantizationTest.cpp
+++ b/tests/unittests/quantizationTest.cpp
@@ -640,6 +640,12 @@ TEST(Quantization, chooseQuantizationSymmetricWithUInt8) {
   EXPECT_EQ(symmetricParams.offset, 0);
   EXPECT_NEAR(symmetricParams.scale, 10.0 / 255, 0.001);
 
+  // Map float [0; 0] to int [-128; 127].
+  symmetricParams = chooseQuantizationParams(
+      0.0, 0.0, quantization::Schema::SymmetricWithUInt8);
+  EXPECT_EQ(symmetricParams.offset, 0);
+  EXPECT_NEAR(symmetricParams.scale, 0.1, 0.001);
+
   // Map float [2.0; 5.0] to int [-128; 127].
   // All positive, using uint8.
   // However, our quantization schemas always include zero.


### PR DESCRIPTION
*Description*:
schema == SymmetricWithUInt8 and offset == 0 makes the

```
assert(result.offset == -128 || schema != quantization::Schema::SymmetricWithUInt8)
```
fail

*Testing*:
./tests/quantizationTest

*Documentation*:
N/A

cc: @opti-mix who discovered assert failure on dumping profile for some models.