### PR TITLE
[Placeholders] Migrate forgotten createSave in graphGradTest

### DIFF
--- a/tests/unittests/graphGradTest.cpp
+++ b/tests/unittests/graphGradTest.cpp
@@ -168,7 +168,7 @@ TEST(GraphAutoGrad, checkPlaceholderGradTest) {
   Placeholder *A =
       mod.createPlaceholder(ElemKind::FloatTy, {10, 28, 28, 1}, "input", true);
   auto *RL = F->createRELU("relu", A);
-  F->createSave("return", RL);
+  F->createSave(ctx, "return", RL);
 
   // Expect a single user to the trainable input placeholder.
   EXPECT_EQ(A->getNumUsers(), 1);


### PR DESCRIPTION
**Description**
This commit migrates a `createSave` call in `graphGradTest.cpp` to the
version that creates a `Placeholder` instead of a `Variable`. This
should have been included as part of #1679.

**Testing**
All unit tests pass.