### PR TITLE
[Optimizer] Optimization to convert Placeholders to Variables (Constants)

### DIFF
--- a/include/glow/Graph/Node.h
+++ b/include/glow/Graph/Node.h
@@ -83,8 +83,8 @@ public:
   /// \returns the underlying pointer when casting.
   operator Node *() const { return node_; }
 
-  /// Replace all of the uses of this value with \p v.
-  void replaceAllUsesOfWith(NodeValue v);
+  /// Replace all of the uses in \p F of this value with \p v.
+  void replaceAllUsesOfWith(NodeValue v, const Function *F = nullptr);
 
   /// Return the TypeRef of the referenced return value.
   TypeRef getType() const;

--- a/include/glow/Optimizer/Optimizer.h
+++ b/include/glow/Optimizer/Optimizer.h
@@ -16,6 +16,7 @@
 #ifndef GLOW_OPTIMIZER_OPTIMIZER_H
 #define GLOW_OPTIMIZER_OPTIMIZER_H
 
+#include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 
 namespace glow {
@@ -23,6 +24,9 @@ namespace glow {
 class IRFunction;
 class Function;
 class Backend;
+class Module;
+class Context;
+class Placeholder;
 
 enum class CompilationMode {
   Train, /// Compile the graph in preperation for training.
@@ -38,6 +42,11 @@ void optimize(Function *F, CompilationMode mode);
 /// Lower the high-level neural network operators into low-level linear algebra
 /// operators.
 void lower(Function *F, const Backend &B);
+
+/// Convert placeholders in Module \p M to constants based on the values in \p
+/// ctx.  Do not convert any placeholders explicitly listed in \p vars.
+void convertPlaceholdersToConstants(Function *F, const Context &ctx,
+                                    llvm::ArrayRef<Placeholder *> vars);
 
 /// Instrument function \p F by inserting quantization profile nodes
 /// for capturing stats for quantization. The new quantized function is called

--- a/lib/Graph/Node.cpp
+++ b/lib/Graph/Node.cpp
@@ -42,7 +42,7 @@ NodeValue::NodeValue(Node *N, unsigned resNo) {
   resNo_ = resNo;
 }
 
-void NodeValue::replaceAllUsesOfWith(NodeValue v) {
+void NodeValue::replaceAllUsesOfWith(NodeValue v, const Function *F) {
   if (v.getNode()) {
     assert(getType() == v.getType() && "Replacing value with the wrong type");
   }
@@ -53,6 +53,10 @@ void NodeValue::replaceAllUsesOfWith(NodeValue v) {
                                          nodeValueUsers.end());
   for (auto &U : usersVec) {
     NodeHandle *site = U.get();
+    auto *userF = U.getUser()->getParent();
+    // If the user is not in function F, don't touch it.
+    if (F && userF != F)
+      continue;
     assert(site->getNode() == node_ && "Invalid user");
     assert(site->getResNo() == getResNo() && "Invalid list of uses");
     site->setOperand(v.getNode(), v.getResNo());


### PR DESCRIPTION
*Description*: Add an optimization pass that replaces Placeholders with constants, so that the values can be used in optimization.  Placeholders are bound to values passed in via a Context, minus a blacklist (to avoid binding, e.g., function inputs).  I haven't yet wired the new conversion pass into the ExecutionEngine optimization pipeline, because I think we'll want to experiment with where it's called with respect to training and inference passes before baking it in.
*Testing*: A new test in graphOptz, plus a second commit that converts many of the tests that require constants to use the new pass.
*Documentation*: None, yet.
Fixes #1623
