### PR TITLE
[Placeholder] Migrate the last use of variables in one test.

### DIFF
--- a/tests/unittests/graphTest.cpp
+++ b/tests/unittests/graphTest.cpp
@@ -956,6 +956,7 @@ TEST(Graph, PostOrderTest) {
 
 TEST(Graph, placeholder) {
   Module MD;
+  Context ctx;
   Function *F = MD.createFunction("F");
   IRFunction M(F);
   Node *K =
@@ -965,5 +966,5 @@ TEST(Graph, placeholder) {
   K = F->createFullyConnected("FC", K, 10);
   K = F->createRELU("Relu", K);
   K = F->createSoftMax("SoftMax", K, S);
-  F->createSave("Save", K);
+  F->createSave(ctx, "Save", K);
 }


### PR DESCRIPTION
*Description*:

I found this case by adding an assertion in the SaveNode that saves into variables.

*Testing*: This is a test.

*Documentation*: none. 

#1334
