### PR TITLE
[docs] Update instructions for llvm installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Install the required dependencies using [Homebrew](https://brew.sh/):
 
   ```bash
   brew install cmake graphviz libpng ninja protobuf wget
-  brew install --with-toolchain llvm
+  brew install --with-toolchain llvm@6
   ```
 
 Note that LLVM is installed to a non-default location (`/usr/local/opt/llvm`) to


### PR DESCRIPTION
*Description*:
Currently, Glow does not work with LLVM7.0 and ```brew install llvm``` attempts to install llvm7.

*Testing*:
Run the command.

*Documentation*:
README.md update