### PR TITLE
[fix] Fix double registration when loaded by onnxifi_load

### DIFF
--- a/lib/Importer/CMakeLists.txt
+++ b/lib/Importer/CMakeLists.txt
@@ -5,10 +5,7 @@ add_definitions(-DGOOGLE_PROTOBUF_NO_RTTI)
 
 if(NOT TARGET onnx_proto)
   # Note: This avoids libprotobuf.so complaining about name collisions at runtime
-  if(NOT ONNX_NAMESPACE)
-    set(ONNX_NAMESPACE "glow_onnx")
-  endif()
-  add_definitions("-DONNX_NAMESPACE=${ONNX_NAMESPACE}")
+  add_definitions("-DONNX_NAMESPACE=glow_onnx")
   add_subdirectory(${GLOW_THIRDPARTY_DIR}/onnx EXCLUDE_FROM_ALL build)
 endif()
 


### PR DESCRIPTION
*Description*:
Fix libprotobuf.so issue when loading libonnxifi-glow through onnxifi_load.

*Testing*:
Running ./run_sh (in progress) and onnxifi_load by zrphercule (for now manually)
*Documentation*:
N/A

cc: @zrphercule @yinghai @bddppq
