### PR TITLE
[examples] Convert PH->constants in mnist

### DIFF
--- a/examples/mnist.cpp
+++ b/examples/mnist.cpp
@@ -158,6 +158,8 @@ void testMNIST() {
     timer.stopTimer();
   }
   llvm::outs() << "Validating.\n";
+
+  ::glow::convertPlaceholdersToConstants(F, ctx, {A, result->getPlaceholder()});
   EE.compile(CompilationMode::Infer, F, ctx);
 
   auto LIH = labelInputs.getHandle<int64_t>();


### PR DESCRIPTION
*Description*: After our recent placeholder conversions, our examples no longer use constant weights during inference.  Let's try out the new constant-conversion opt, starting with mnist.
*Testing*: `./bin/mnist`
