### PR TITLE
[Tensor] Disallow GetHandle() when Tensor is an rvalue object

### DIFF
--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -381,7 +381,10 @@ public:
   char *getUnsafePtr() const { return getData(); }
 
   /// \return a new handle that points and manages this tensor.
-  template <class ElemTy = float> Handle<ElemTy> getHandle();
+  template <class ElemTy = float> Handle<ElemTy> getHandle() &;
+
+  /// If Tensor is rvalue, it is an error to get its Handle.
+  template <class ElemTy = float> Handle<ElemTy> getHandle() && = delete;
 
 private:
   /// \returns a pointer to the raw data, of type \p ElemTy.
@@ -779,7 +782,7 @@ private:
   }
 };
 
-template <class ElemTy> Handle<ElemTy> Tensor::getHandle() {
+template <class ElemTy> Handle<ElemTy> Tensor::getHandle() & {
   assert(type_.isType<ElemTy>() && "Getting a handle to the wrong type.");
   return Handle<ElemTy>(this);
 }


### PR DESCRIPTION
*Description*:
Recently @beicy debugged an issue where doing `auto H = T.extractSlice(i).getHandle();` resulted in corrupted Handle. This happened because `T.extractSlice(i)` was creating a temporary Tensor object, which was destroyed on the same line. So Handle outlived Tensor it was pointing at. Such errors could be caught at compilation stage.

*Testing*:
Make sure that `auto TT = Tensor(424.).getHandle();` does not compile.

Let me know what you think. I don't see `&&` specifier used in this way in our codebase. But maybe we should add it everywhere else, e.g. `getUnsafePtr()`, `getUnowned()`.
