### PR TITLE
[examples] convertPlaceholdersToConstants in other examples

### DIFF
--- a/examples/fr2en.cpp
+++ b/examples/fr2en.cpp
@@ -173,6 +173,8 @@ struct Model {
       F_ = Q;
     }
 
+    ::glow::convertPlaceholdersToConstants(F_, ctx,
+                                           {input_, seqLength_, output_});
     EE_.compile(CompilationMode::Infer, F_, ctx);
   }
 


### PR DESCRIPTION
*Description*: Convert char-rnn and fr2en, which are the only other examples that compile for inference.  char-rnn is an interesting one.  Since we run multiple rounds of inference, we need to clone the function before each round, or else we'll keep stale variable values around in future inference runs.
*Testing*:  Manually validate that char-rnn and fr2en produce the same results as they used to.
