### PR TITLE
[bundles] Don't silence Makefiles by default

### DIFF
--- a/examples/bundles/resnet50/Makefile
+++ b/examples/bundles/resnet50/Makefile
@@ -1,6 +1,3 @@
-# Suppress display of executed commands.
-$(VERBOSE).SILENT:
-
 # The path to the image-classifier executable.
 LOADER?=~/src/build/glow/bin/image-classifier
 

--- a/examples/bundles/vgg19/Makefile
+++ b/examples/bundles/vgg19/Makefile
@@ -1,6 +1,3 @@
-# Suppress display of executed commands.
-$(VERBOSE).SILENT:
-
 # The path to the image-classifier executable.
 LOADER?=~/src/build/glow/bin/image-classifier
 

--- a/examples/bundles/zfnet512/Makefile
+++ b/examples/bundles/zfnet512/Makefile
@@ -1,6 +1,3 @@
-# Suppress display of executed commands.
-$(VERBOSE).SILENT:
-
 # The path to the image-classifier executable.
 LOADER?=~/src/build/glow/bin/image-classifier
 


### PR DESCRIPTION
*Description*: Does anyone mind if we make the bundle makefiles echo commands by default?  I started to look at #1726 and it'd be a lot easier to tell what's happening if the commands were echoed.  People can always run `make -s` if the console spam is annoying.
*Testing*:  `make`
*Documentation*:  N/A