### PR TITLE
[Caffe2] Implement ReplaceNaN operator

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -413,6 +413,18 @@ public:
   ARITHMETIC_FUN_DECL(Pow);
 #undef ARITHMETIC_FUN_DECL
 
+  /// Create a node that produces an boolean output of the same shape as
+  /// \p input in which each element indicates whether or not the corresponding
+  /// element in \p input is NaN or not.
+  IsNaNNode *createIsNaN(llvm::StringRef name, NodeValue input);
+
+  /// Implements an operation that replaces all instances of NaN in \p input
+  /// with \p value. This operation is lowered to a Select node with \p input
+  /// as one of the inputs, a Splat node created using \p value as the other
+  /// input, and an IsNaN node as the comparator input.
+  /// \returns the Select node.
+  Node *createReplaceNaN(llvm::StringRef name, NodeValue input, float value);
+
   PowNode *createPow(llvm::StringRef name, NodeValue base, float exp);
 
   SelectNode *createSelect(llvm::StringRef name, NodeValue Cond, NodeValue LHS,

--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -909,6 +909,7 @@ void LLVMIRGen::generateLLVMIRForDataParallelInstr(
     ARITHMETIC_UNARY_OP_CASE(Sigmoid, "sigmoid");
     ARITHMETIC_UNARY_OP_CASE(Tanh, "tanh");
     ARITHMETIC_UNARY_OP_CASE(ElementLog, "element_log");
+    ARITHMETIC_UNARY_OP_CASE(ElementIsNaN, "element_is_nan");
 #undef ARITHMETIC_UNARY_OP_CASE
 
   case Kinded::Kind::CopyInstKind: {

--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -675,6 +675,8 @@ DEFINE_DATA_PARALLEL_KERNEL(libjit_element_mul_kernel_f, float,
 DEFINE_DATA_PARALLEL_KERNEL(libjit_element_pow_kernel_f, float,
                             pow(LHS[idx], RHS[idx]))
 DEFINE_DATA_PARALLEL_KERNEL(libjit_element_log_kernel_f, float, log(LHS[idx]))
+DEFINE_DATA_PARALLEL_KERNEL(libjit_element_is_nan_kernel_f, float,
+                            isnan(LHS[idx]))
 DEFINE_DATA_PARALLEL_KERNEL_QUANTIZED(libjit_element_add_kernel_i8, int8_t,
                                       lhs + rhs)
 DEFINE_DATA_PARALLEL_KERNEL_QUANTIZED(libjit_element_sub_kernel_i8, int8_t,

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -1219,6 +1219,15 @@ void InterpreterFunction::fwdElementPowInst(const glow::ElementPowInst *I) {
   }
 }
 
+void InterpreterFunction::fwdElementIsNaNInst(const glow::ElementIsNaNInst *I) {
+  auto inW = getWeightHandle(I->getSrc());
+  auto outW = getWeightHandle(I->getDest());
+  for (size_t i = 0, e = inW.size(); i < e; i++) {
+    float val = inW.raw(i);
+    outW.raw(i) = std::isnan(val);
+  }
+}
+
 void InterpreterFunction::fwdElementLogInst(const ElementLogInst *I) {
   auto inW = getWeightHandle(I->getSrc());
   auto outW = getWeightHandle(I->getDest());

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1075,6 +1075,25 @@ CmpEQNode *Function::createCmpEQ(llvm::StringRef name, NodeValue LHS,
   return addNode(new CmpEQNode(name, OT, LHS, RHS));
 }
 
+IsNaNNode *Function::createIsNaN(llvm::StringRef name, NodeValue input) {
+  TypeRef OT = getResultTypeOfBooleanOp(*getParent(), input.getType());
+  return addNode(new IsNaNNode(name, OT, input));
+}
+
+Node *Function::createReplaceNaN(llvm::StringRef name, NodeValue input,
+                                 float value) {
+  // Create IsNaN node.
+  auto *INN = createIsNaN(name.str() + ".isNaN", input);
+
+  // Create Splat node.
+  auto *S = createSplat(name.str() + ".splat", input.getType(), value);
+
+  // Create Select node to pick between original and replacement values.
+  auto *SN = createSelect(name.str() + ".select", INN, S, input);
+
+  return SN;
+}
+
 PowNode *Function::createPow(llvm::StringRef name, NodeValue base, float exp) {
   auto *SP = createSplat(name, base.getType(), exp);
   return createPow(name, base, SP);

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -728,6 +728,8 @@ void LogNode::verify() const {
   }
 }
 
+void IsNaNNode::verify() const { checkSameShape(getInput(), getResult()); }
+
 void SelectNode::verify() const {
   assert(getResult().getElementType() == getCond().getElementType());
   assert(getResult().getElementType() == getLHS().getElementType());

--- a/lib/Importer/Caffe2.cpp
+++ b/lib/Importer/Caffe2.cpp
@@ -328,6 +328,19 @@ void caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     return;
   }
 
+  if (typeName == "ReplaceNaN") {
+    // Load the input and NaN replacement value:
+    auto input = getNodeValueOrCreateVariableByName(op.input(0));
+    auto valueIt = dict.find("value");
+    auto value = valueIt != dict.end() ? loadFloat(valueIt->second) : 0.0f;
+
+    auto *node = G_.createReplaceNaN(opName, input, value);
+
+    // Save the outputs:
+    addNodeAsOutput(op, node);
+    return;
+  }
+
   if (typeName == "ChannelShuffle") {
     auto in = getNodeValueOrCreateVariableByName(op.input(0));
 

--- a/tests/models/caffe2Models/replace_nan_predict_net.pbtxt
+++ b/tests/models/caffe2Models/replace_nan_predict_net.pbtxt
@@ -1,0 +1,13 @@
+name: "replaceNaN"
+op {
+  input: "input"
+  output: "replace_nan_result"
+  name: ""
+  type: "ReplaceNaN"
+  arg {
+    name: "value"
+    f: 1
+  }
+}
+external_input: "input"
+external_output: "replace_nan_result"

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -300,6 +300,17 @@ int main(int argc, char **argv) {
       .autoVerify(VerifyKind::SameShape, {"Dest", "LHS", "RHS"})
       .autoIRGen("CmpEQ");
 
+  BB.newInstr("ElementIsNaN")
+      .addOperand("Dest", OperandKind::Out)
+      .addOperand("Src", OperandKind::In)
+      .inplaceOperand({
+          "Dest",
+          "Src",
+      })
+      .dataParallel()
+      .autoVerify(VerifyKind::SameShape, {"Dest", "Src"})
+      .autoIRGen("IsNaN");
+
   BB.newInstr("ElementPow")
       .addOperand("Dest", OperandKind::Out)
       .addOperand("LHS", OperandKind::In)

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -315,6 +315,14 @@ int main(int argc, char **argv) {
                     "Weights[0] * Slice(0) + Weights[1] * Slice(1) + ... "
                     "It implies that len(Weights) == len(Indices).");
 
+  // clang-format off
+  BB.newNode("IsNaN")
+    .addInput("Input")
+    .addResultFromCtorArg()
+    .setDocstring("Determines whether each element of the Input is NaN and "
+                  "generates a mask that can be consumed by a Select node.");
+  // clang-format on
+
   //===--------------------------------------------------------------------===//
   //                Non-linearities
   //===--------------------------------------------------------------------===//


### PR DESCRIPTION
**Description**
This commit fixes #1704 and adds support for the `ReplaceNaN` Caffe2 operator to the
Caffe2 model importer. This operator accepts one tensor as an input and
a value as an argument, and replaces all elements of the input that are
`NaN` with the given value. To implement this operator, this commit adds a new
Glow node, `IsNaN`, which accepts an input tensor and outputs a tensor in
which each element is a boolean indicating whether or not the
corresponding element in the input is `NaN`. With this new node in
hand, a `ReplaceNaN` operator is implemented as a `Select` node with the
`ReplaceNaN` input as one of the inputs, a `Splat` node created using the replacement value
as the other input, and the output of an `IsNaN` node as the comparator
input. This `IsNaN` node becomes a new instruction called `elementisnan`,
which is implemented using `std::isnan` from the `cmath` header and `isnan`
from the `math.h` header in the interpreter and CPU backends,
respectively.

**Testing**
This commit adds a new test case to `caffe2ImporterTest.cpp` which imports
and runs a Caffe2 model consisting of only the `ReplaceNaN` operator. This
test performs high level checks on the Glow node graph produced by the
importer, and checks that all instances of `NaN` in a test input tensor
are replaced with the replacement value provided in the model protobuf
and non-`NaN` elements have been left unchanged.

This commit also adds a new test case to `OperatorTest.cpp` for `createReplaceNaN` to test that
`NaN` values are replaced correctly by the interpreter and CPU backends.

All other unit tests still pass.
