### PR TITLE
[Placeholder] Remove the ability to differentiate variables.

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -674,7 +674,8 @@ public:
 
 struct TrainingConfig;
 
-using VariableGradientsList = std::list<std::pair<Storage *, Storage *>>;
+using VariableGradientsList =
+    std::list<std::pair<Placeholder *, Placeholder *>>;
 
 /// Create a new Function that 'trains' the input Function. We differentiate the
 /// nodes and insert code to update the weights based on the \p config

--- a/tests/unittests/gradCheckTest.cpp
+++ b/tests/unittests/gradCheckTest.cpp
@@ -58,7 +58,7 @@ float gradDiff(float G1, float G2) {
 Placeholder *getGrad(const VariableGradientsList &grads, Placeholder *V) {
   for (auto &p : grads) {
     if (p.first == V) {
-      return cast<Placeholder>(p.second);
+      return p.second;
     }
   }
   return nullptr;
@@ -66,7 +66,7 @@ Placeholder *getGrad(const VariableGradientsList &grads, Placeholder *V) {
 
 void allocateGrads(Context &ctx, const VariableGradientsList &grads) {
   for (auto &p : grads) {
-    auto grad = cast<Placeholder>(p.second);
+    auto grad = p.second;
     ctx.allocate(grad);
   }
 }


### PR DESCRIPTION
*Description*:

[Placeholder] Remove the ability to differentiate variables.
This commit removes the ability to differentiate variables. From this
point we can only differentiate placeholders. It looks like we've
reached this point because all of the tests are passing. 
@bertmaher 's recent change removed all of the trainable variables.

*Testing*: ninja check

*Documentation*: None

#1334 