### PR TITLE
[Quantization] Add row-wise quantized FC for CPU backend

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -274,11 +274,11 @@ public:
   /// Create a row-wise quantized fully connected node. This node is only used
   /// in quantization. Args \p input and \p B are quantized in regular way, \p W
   /// is the constant weights and will be row-wise quantized during node
-  /// creation time.
+  /// creation time. The output is quantized in the regular way, and its type
+  /// \p outTy is a quantized type.
   RowwiseQuantizedFullyConnectedNode *
-  createRowwiseQuantizedFullyConnected(Context &ctx, llvm::StringRef name,
-                                       NodeValue input, Variable *W, Node *B,
-                                       TypeRef outTy);
+  createRowwiseQuantizedFullyConnected(llvm::StringRef name, NodeValue input,
+                                       Variable *W, Node *B, TypeRef outTy);
 
   /// Implement an operation that computes the row-wise dot product of its
   /// inputs. Consequently, \p X and \p Y must be either 1D or 2D tensors. This

--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -324,6 +324,9 @@ llvm::Value *LLVMIRGen::emitValueAddress(llvm::IRBuilder<> &builder,
   case ElemKind::Int8QTy:
     T = llvm::Type::getInt8PtrTy(ctx_);
     break;
+  case ElemKind::Int32QTy:
+    T = llvm::Type::getInt32PtrTy(ctx_);
+    break;
   case ElemKind::Int64ITy:
     T = llvm::Type::getInt64PtrTy(ctx_);
     break;
@@ -1267,6 +1270,110 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
       createCall(builder, F,
                  {destPtr, lhsPtr, rhsPtr, destDims, lhsDims, rhsDims});
     }
+    break;
+  }
+
+  case Kinded::Kind::RowwiseQuantizedFullyConnectedInstKind: {
+    auto *RWQFC = cast<RowwiseQuantizedFullyConnectedInst>(I);
+    // Since we can't get the variable from a glow::Value directly,
+    // we need to traverse the var list and find the one matching the given
+    // Value.
+    Tensor scalesT;
+    auto *F_ = getIRFunction();
+    for (auto &v : F_->getGraph()->getParent()->getVars()) {
+      assert(isa<WeightVar>(F_->getWeightForNode(v)));
+      auto *w = cast<glow::Value>(F_->getWeightForNode(v));
+      if (w == RWQFC->getScales()) {
+        scalesT.assign(&v->getPayload());
+        break;
+      }
+    }
+    GLOW_ASSERT(scalesT.getUnsafePtr() != nullptr &&
+                "Can't find the variable.");
+
+    auto scalesH = scalesT.getHandle();
+    size_t rowNum = scalesH.dims()[0];
+    float inputScale = RWQFC->getSrc()->getType()->getScale();
+
+    float bScale = RWQFC->getBias()->getType()->getScale();
+    int32_t bOffset = RWQFC->getBias()->getType()->getOffset();
+
+    float outputScale = RWQFC->getDest()->getType()->getScale();
+
+    std::vector<llvm::Constant *> biasPreV(rowNum);
+    std::vector<llvm::Constant *> biasPostV(rowNum);
+    std::vector<llvm::Constant *> biasScaleV(rowNum);
+    std::vector<llvm::Constant *> outputPreV(rowNum);
+    std::vector<llvm::Constant *> outputPostV(rowNum);
+    std::vector<llvm::Constant *> outputScaleV(rowNum);
+
+    for (size_t i = 0; i < rowNum; i++) {
+      // Calculate the scale of the values that come out of the matrix
+      // multiplication part of the calculation.
+      float matMulScale = inputScale * scalesH.raw(i);
+
+      // Calculate the scaling parameters for the bias and output.
+      auto biasScaleParam =
+          quantization::quantizeScaleOffset32To8(bScale / matMulScale, bOffset);
+      auto outScaleParam =
+          quantization::quantizeScaleOffset32To8(matMulScale / outputScale, 0);
+
+      // Pass the pre-shift, post-shift and integer scale parameters for the
+      // bias and output calculation.
+      biasPreV[i] = llvm::ConstantInt::get(builder.getInt32Ty(),
+                                           biasScaleParam.pre, true);
+      biasPostV[i] = llvm::ConstantInt::get(builder.getInt32Ty(),
+                                            biasScaleParam.post, true);
+      biasScaleV[i] = llvm::ConstantInt::get(builder.getInt32Ty(),
+                                             biasScaleParam.scale, true);
+      outputPreV[i] =
+          llvm::ConstantInt::get(builder.getInt32Ty(), outScaleParam.pre, true);
+      outputPostV[i] = llvm::ConstantInt::get(builder.getInt32Ty(),
+                                              outScaleParam.post, true);
+      outputScaleV[i] = llvm::ConstantInt::get(builder.getInt32Ty(),
+                                               outScaleParam.scale, true);
+    }
+
+    auto *dest = RWQFC->getDest();
+    auto *src = RWQFC->getSrc();
+    auto *weights = RWQFC->getWeights();
+    auto *bias = RWQFC->getBias();
+    auto *weightsOffsets = RWQFC->getOffsets();
+
+    auto *destPtr = emitValueAddress(builder, dest);
+    auto *srcPtr = emitValueAddress(builder, src);
+    auto *weightsPtr = emitValueAddress(builder, weights);
+    auto *biasPtr = emitValueAddress(builder, bias);
+    auto *weightsOffsetsPtr = emitValueAddress(builder, weightsOffsets);
+    auto *biasPrePtr = emitConstArray(builder, biasPreV, builder.getInt32Ty());
+    auto *biasPostPtr =
+        emitConstArray(builder, biasPostV, builder.getInt32Ty());
+    auto *biasScalePtr =
+        emitConstArray(builder, biasScaleV, builder.getInt32Ty());
+    auto *outputPrePtr =
+        emitConstArray(builder, outputPreV, builder.getInt32Ty());
+    auto *outputPostPtr =
+        emitConstArray(builder, outputPostV, builder.getInt32Ty());
+    auto *outputScalePtr =
+        emitConstArray(builder, outputScaleV, builder.getInt32Ty());
+
+    auto *srcDims = emitValueDims(builder, src);
+    auto *weightsDims = emitValueDims(builder, weights);
+    auto *destDims = emitValueDims(builder, dest);
+    auto *biasDims = emitValueDims(builder, bias);
+    auto *row = emitConstSizeT(builder, weightsOffsets->dims()[0]);
+
+    auto *destOffset = emitConstI32(builder, dest->getType()->getOffset());
+    auto *srcOffset = emitConstI32(builder, src->getType()->getOffset());
+    auto *biasOffset = emitConstI32(builder, bOffset);
+
+    auto *F = getFunction("rowwise_quantized_fc", dest->getElementType());
+
+    createCall(builder, F,
+               {destPtr, srcPtr, weightsPtr, biasPtr, weightsOffsetsPtr,
+                biasPrePtr, biasPostPtr, biasScalePtr, outputPrePtr,
+                outputPostPtr, outputScalePtr, destDims, srcDims, weightsDims,
+                biasDims, row, destOffset, srcOffset, biasOffset});
     break;
   }
 

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -3538,7 +3538,7 @@ TEST_P(InterpAndCPU, insertTensorTest) {
 }
 
 /// Test RowwiseQuantizedFullyConnected Node.
-TEST_P(InterpOnly, rowwiseQuantizedFCTest) {
+TEST_P(InterpAndCPU, rowwiseQuantizedFCTest) {
   // In this test we subtract the outputs of a row-wise quantized FC and a
   // floating-point FC and ensure that the error is below some low value.
   auto *input =
@@ -3571,7 +3571,7 @@ TEST_P(InterpOnly, rowwiseQuantizedFCTest) {
   auto *biasq = F_->createQuantize("bias.q", bias, biasTy);
 
   auto *fcq = F_->createRowwiseQuantizedFullyConnected(
-      ctx_, "fcq", inputq, newWeights, biasq, resTy);
+      "fcq", inputq, newWeights, biasq, resTy);
   auto *dequantRes = F_->createDequantize("dequant", fcq);
 
   // Subtract the results of the convolution from the rowwise quantized fc.


### PR DESCRIPTION
*Description*:
Add row-wise quantized FC for CPU backend.  

*Testing*:
 Enable the unittest `rowwiseQuantizedFCTest` with CPU backend.
*Documentation*:
[Optional Fixes #1402 ]


