### PR TITLE
[Importer] Report error if model contains non-2D pool

### DIFF
--- a/lib/Importer/ONNX.cpp
+++ b/lib/Importer/ONNX.cpp
@@ -318,6 +318,11 @@ bool ONNXModelLoader::loadOperator(const ONNX_NAMESPACE::NodeProto &op) {
 
     std::vector<unsigned_t> pads = getPads(dict);
 
+    if (in.dims().size() != 4 || kernels.size() != 2) {
+      // Glow only handles 2D pooling currently.
+      return false;
+    }
+
     auto *tr = G_.createTranspose(opName, in, NCHW2NHWC);
 
     // If 'global_pooling' is set then the operation will pool over the size of

--- a/tests/models/onnxModels/averagePool3D.onnxtxt
+++ b/tests/models/onnxModels/averagePool3D.onnxtxt
@@ -1,0 +1,70 @@
+ir_version: 3
+producer_name: "backend-test"
+graph {
+  node {
+    input: "x"
+    output: "y"
+    op_type: "AveragePool"
+    attribute {
+      name: "kernel_shape"
+      ints: 2
+      ints: 2
+      ints: 2
+      type: INTS
+    }
+  }
+  name: "test_averagepool_3d_default"
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: FLOAT
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 32
+          }
+          dim {
+            dim_value: 32
+          }
+          dim {
+            dim_value: 32
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: FLOAT
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 31
+          }
+          dim {
+            dim_value: 31
+          }
+          dim {
+            dim_value: 31
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 9
+}

--- a/tests/unittests/onnxImporterTest.cpp
+++ b/tests/unittests/onnxImporterTest.cpp
@@ -78,3 +78,18 @@ TEST(onnx, importConv) {
   for (size_t i = 0; i < 4 * 4; i++)
     EXPECT_FLOAT_EQ(result.raw(i), expectedValues[i]);
 }
+
+TEST(onnx, importAveragePool3D) {
+  ExecutionEngine EE{BackendKind::Interpreter};
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+
+  std::string NetFilename("tests/models/onnxModels/averagePool3D.onnxtxt");
+
+  // Destroy the loader after the graph is loaded since the following execution
+  // will not depend on anyting from the loader.
+  {
+    Tensor data(ElemKind::FloatTy, {1, 3, 32, 32, 32});
+    EXPECT_DEATH(ONNXModelLoader(NetFilename, {"x"}, {&data}, *F), "");
+  }
+}


### PR DESCRIPTION
*Description*: We were crashing on a 3D average pool, because we expect to do a 4D transpose for NCHW to NHWC (rather than a 5D transpose).  Return false instead.
*Testing*: Death test for onnxModelLoader.  (Note that ONNXIFI will not die; this is the standalone ONNX model loader that dies when a model can't be loaded, which seems proper.)
*Documentation*: N/A
Fixes #1736 
