### PR TITLE
[Caffe2] Implement DotProduct operator

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -280,6 +280,12 @@ public:
                                        NodeValue input, Variable *W, Node *B,
                                        TypeRef outTy);
 
+  /// Implement an operation that computes the row-wise dot product of its
+  /// inputs. Consequently, \p X and \p Y must be either 1D or 2D tensors. This
+  /// lowered to a Mul node, and is followed by a BatchedReduceAdd if \p X and
+  /// \p Y are 2D. \returns either the Mul or BatchedReduceAdd node.
+  Node *createDotProduct(llvm::StringRef name, NodeValue X, NodeValue Y);
+
   /// Create a ReLU node with the given \p name and \p input.
   /// Result type will be implicitly set based on the \p input type.
   ReluNode *createRELU(llvm::StringRef name, NodeValue input);

--- a/lib/Importer/Caffe2.cpp
+++ b/lib/Importer/Caffe2.cpp
@@ -329,6 +329,19 @@ void caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     return;
   }
 
+  if (typeName == "DotProduct") {
+    // Load the inputs.
+    auto X = getNodeValueOrCreateVariableByName(op.input(0));
+    auto Y = getNodeValueOrCreateVariableByName(op.input(1));
+
+    // Create dot product node.
+    auto *node = G_.createDotProduct(opName, X, Y);
+
+    // Save the output.
+    addNodeAsOutput(op, node);
+    return;
+  }
+
   if (typeName == "ReplaceNaN") {
     // Load the input and NaN replacement value:
     auto input = getNodeValueOrCreateVariableByName(op.input(0));

--- a/tests/models/caffe2Models/dot_product_predict_net.pbtxt
+++ b/tests/models/caffe2Models/dot_product_predict_net.pbtxt
@@ -1,0 +1,11 @@
+name: "dot_product"
+op {
+  input: "X"
+  input: "Y"
+  output: "dot_product"
+  name: ""
+  type: "DotProduct"
+}
+external_input: "X"
+external_input: "Y"
+external_output: "dot_product"


### PR DESCRIPTION
**Description**
This commit fixes #1701 and adds support for the `DotProduct` Caffe2
operator to the Caffe2 model importer. This operator accepts two tensors
of the same shape and with at most 2 dimensions, and computes their
row-wise dot product. This dot product operator is immediately lowered
to a `Mul` node if the inputs are 1D, and to a `Mul` node followed by a
`BatchedReduceAdd` on `axis=1` if the inputs are 2D.

**Testing**
This commit adds two test cases to `caffe2ImporterTest.cpp`, one for 1D
inputs and the other for 2D inputs.

All other unit tests pass.
