### PR TITLE
[Loader] Add Fp16 conversion

### DIFF
--- a/include/glow/Graph/Utils.h
+++ b/include/glow/Graph/Utils.h
@@ -132,6 +132,21 @@ public:
   }
 };
 
+/// Change the type to \p newTy for all the results of \p node
+/// whose element type is equal to \p origTy.
+/// \note This API does not support converting to a quantized type.
+inline void mutateNodeResTypeThatMatch(Module &mod, Node &node, ElemKind origTy,
+                                       ElemKind newTy) {
+  for (unsigned idx = 0, end = node.getNumResults(); idx != end; ++idx) {
+    NodeValue res = node.getNthResult(idx);
+    if (res.getElementType() != origTy) {
+      continue;
+    }
+    TypeRef newTyRef = mod.uniqueType(newTy, res.dims());
+    res.setType(newTyRef);
+  }
+}
+
 } // namespace glow
 
 #endif // GLOW_GRAPH_UTILS_H

--- a/include/glow/Graph/Utils.h
+++ b/include/glow/Graph/Utils.h
@@ -147,6 +147,15 @@ inline void mutateNodeResTypeThatMatch(Module &mod, Node &node, ElemKind origTy,
   }
 }
 
+/// Replace with \p newTy, the type of all the nodes, placeholders and so on
+/// that use \p origTy.
+/// If a \p context is provided, this method makes sure the tensors
+/// backing the placeholders are properly updated. Otherwise,
+/// this method assumes the placeholders are not bound to anything.
+/// \pre The parent module has only one function, this one.
+void mutateNodesType(Function &F, ElemKind origTy, ElemKind newTy,
+                     Context *context = nullptr);
+
 } // namespace glow
 
 #endif // GLOW_GRAPH_UTILS_H

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -115,6 +115,7 @@ private:
   void fwdMatMulInst_FloatImpl(const glow::MatMulInst *I);
 
   void fwdBatchedAddInst_I8Impl(const BatchedAddInst *I);
+  template <typename ElemTy>
   void fwdBatchedAddInst_FloatImpl(const BatchedAddInst *I);
   ///@}
 };

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -113,6 +113,9 @@ private:
   void fwdMatMulInst_I8Impl(const glow::MatMulInst *I);
   template <typename ElemTy>
   void fwdMatMulInst_FloatImpl(const glow::MatMulInst *I);
+
+  void fwdBatchedAddInst_I8Impl(const BatchedAddInst *I);
+  void fwdBatchedAddInst_FloatImpl(const BatchedAddInst *I);
   ///@}
 };
 

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -119,6 +119,7 @@ private:
   void fwdBatchedAddInst_FloatImpl(const BatchedAddInst *I);
 
   void fwdElementMaxInst_I8Impl(const ElementMaxInst *I);
+  template <typename ElemTy>
   void fwdElementMaxInst_FloatImpl(const ElementMaxInst *I);
   ///@}
 };

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -123,6 +123,7 @@ private:
   void fwdElementMaxInst_FloatImpl(const ElementMaxInst *I);
 
   void fwdElementAddInst_I8Impl(const ElementAddInst *I);
+  template <typename ElemTy>
   void fwdElementAddInst_FloatImpl(const ElementAddInst *I);
   ///@}
 };

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -121,6 +121,9 @@ private:
   void fwdElementMaxInst_I8Impl(const ElementMaxInst *I);
   template <typename ElemTy>
   void fwdElementMaxInst_FloatImpl(const ElementMaxInst *I);
+
+  void fwdElementAddInst_I8Impl(const ElementAddInst *I);
+  void fwdElementAddInst_FloatImpl(const ElementAddInst *I);
   ///@}
 };
 

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -117,6 +117,9 @@ private:
   void fwdBatchedAddInst_I8Impl(const BatchedAddInst *I);
   template <typename ElemTy>
   void fwdBatchedAddInst_FloatImpl(const BatchedAddInst *I);
+
+  void fwdElementMaxInst_I8Impl(const ElementMaxInst *I);
+  void fwdElementMaxInst_FloatImpl(const ElementMaxInst *I);
   ///@}
 };
 

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -1515,11 +1515,17 @@ void InterpreterFunction::fwdBatchedAddInst_I8Impl(
   }
 }
 
+template <typename ElemTy>
 void InterpreterFunction::fwdBatchedAddInst_FloatImpl(
     const glow::BatchedAddInst *I) {
-  auto batch = getWeightHandle(I->getBatch());
-  auto slice = getWeightHandle(I->getSlice());
-  auto dest = getWeightHandle(I->getDest());
+  static_assert(
+      std::is_floating_point<ElemTy>::value ||
+          std::is_same<float16_t, typename std::remove_cv<ElemTy>::type>::value,
+      "This implementation is for floating-point values only");
+
+  auto batch = getWeightHandle<ElemTy>(I->getBatch());
+  auto slice = getWeightHandle<ElemTy>(I->getSlice());
+  auto dest = getWeightHandle<ElemTy>(I->getDest());
 
   auto bdim = flattenCdr(batch.dims());
   assert(slice.size() == bdim.second && "Invalid slice size");
@@ -1540,7 +1546,10 @@ void InterpreterFunction::fwdBatchedAddInst(const glow::BatchedAddInst *I) {
   if (getTensor(I->getBatch())->getType().isQuantizedType()) {
     fwdBatchedAddInst_I8Impl(I);
   } else if (I->getBatch()->getType()->getElementType() == ElemKind::FloatTy) {
-    fwdBatchedAddInst_FloatImpl(I);
+    fwdBatchedAddInst_FloatImpl<float>(I);
+  } else if (I->getBatch()->getType()->getElementType() ==
+             ElemKind::Float16Ty) {
+    fwdBatchedAddInst_FloatImpl<float16_t>(I);
   } else {
     llvm_unreachable("Type is not supported");
   }

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -1182,13 +1182,16 @@ void InterpreterFunction::fwdElementMaxInst_I8Impl(const ElementMaxInst *I) {
   }
 }
 
+template <typename ElemTy>
 void InterpreterFunction::fwdElementMaxInst_FloatImpl(const ElementMaxInst *I) {
-  auto *lhs = getTensor(I->getLHS());
-  auto *rhs = getTensor(I->getRHS());
-  auto *out = getTensor(I->getDest());
-  auto outW = out->getHandle();
-  auto lhsW = lhs->getHandle();
-  auto rhsW = rhs->getHandle();
+  static_assert(
+      std::is_floating_point<ElemTy>::value ||
+          std::is_same<float16_t, typename std::remove_cv<ElemTy>::type>::value,
+      "This implementation is for floating-point values only");
+
+  auto outW = getWeightHandle<ElemTy>(I->getDest());
+  auto lhsW = getWeightHandle<ElemTy>(I->getLHS());
+  auto rhsW = getWeightHandle<ElemTy>(I->getRHS());
   for (size_t i = 0, e = outW.size(); i < e; i++) {
     outW.raw(i) = std::max(lhsW.raw(i), rhsW.raw(i));
   }
@@ -1198,7 +1201,9 @@ void InterpreterFunction::fwdElementMaxInst(const ElementMaxInst *I) {
   if (getTensor(I->getLHS())->getType().isQuantizedType()) {
     fwdElementMaxInst_I8Impl(I);
   } else if (I->getLHS()->getType()->getElementType() == ElemKind::FloatTy) {
-    fwdElementMaxInst_FloatImpl(I);
+    fwdElementMaxInst_FloatImpl<float>(I);
+  } else if (I->getLHS()->getType()->getElementType() == ElemKind::Float16Ty) {
+    fwdElementMaxInst_FloatImpl<float16_t>(I);
   } else {
     llvm_unreachable("Type is not supported");
   }

--- a/lib/Graph/CMakeLists.txt
+++ b/lib/Graph/CMakeLists.txt
@@ -46,7 +46,8 @@ add_library(Graph
             Node.cpp
             Nodes.cpp
             Graph.cpp
-            Grad.cpp)
+            Grad.cpp
+            Utils.cpp)
 
 target_link_libraries(Graph
                       PUBLIC

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -16,6 +16,7 @@
 #include "glow/Graph/Graph.h"
 #include "glow/Graph/Context.h"
 #include "glow/Graph/Nodes.h"
+#include "glow/Graph/Utils.h"
 #include "glow/Quantization/Base/Base.h"
 #include "glow/Support/Support.h"
 

--- a/lib/Graph/Utils.cpp
+++ b/lib/Graph/Utils.cpp
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2018-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/Base/Tensor.h"
+#include "glow/Base/Type.h"
+#include "glow/Graph/Context.h"
+#include "glow/Graph/Utils.h"
+#include "glow/Graph/Graph.h"
+#include "glow/Graph/Nodes.h"
+
+using namespace glow;
+
+void glow::mutateNodesType(Function &F, ElemKind origTy, ElemKind newTy,
+                           Context *context) {
+  Module &M = *F.getParent();
+  // Check that the module only has one function. If it has more than one, we
+  // would have to duplicate the placeholders and other module scoped objects
+  // to make sure we are not modifying other functions.
+  GLOW_ASSERT(M.getFunctions().size() == 1 && "No yet implemented");
+  for (Node &node : F.getNodes()) {
+    mutateNodeResTypeThatMatch(M, node, origTy, newTy);
+  }
+  for (Variable *var : M.getVars()) {
+    if (var->getElementType() != origTy) {
+      continue;
+    }
+    mutateNodeResTypeThatMatch(M, *var, origTy, newTy);
+    // Update the values in the tensor.
+    var->getPayload().convertToType(newTy);
+  }
+  for (Placeholder *placeholder : M.getPlaceholders()) {
+    if (placeholder->getElementType() != origTy) {
+      continue;
+    }
+    mutateNodeResTypeThatMatch(M, *placeholder, origTy, newTy);
+    if (context && context->get(placeholder)) {
+      context->get(placeholder)->convertToType(newTy);
+    }
+  }
+}

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -161,6 +161,32 @@ TEST_P(InterpAndCPU, CmpEQ) {
   }
 }
 
+/// Check that the add operator works properly.
+TEST_P(Operator, add) {
+  PseudoRNG PRNG;
+
+  auto *inputA =
+      mod_.createPlaceholder(ElemKind::FloatTy, {1, 3, 3, 1}, "A", false);
+  ctx_.allocate(inputA)->getHandle<float>().randomize(-3.0, 3.0, PRNG);
+  auto *inputB =
+      mod_.createPlaceholder(ElemKind::FloatTy, {1, 3, 3, 1}, "B", false);
+  ctx_.allocate(inputB)->getHandle<float>().randomize(-3.0, 3.0, PRNG);
+  auto *Pool = F_->createAdd("pool", inputA, inputB);
+  auto *S = F_->createSave(ctx_, "save", Pool);
+  ctx_.allocate(S->getPlaceholder());
+
+  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.run();
+
+  auto result = ctx_.get(S->getPlaceholder())->getHandle();
+  auto handleA = ctx_.get(inputA)->getHandle();
+  auto handleB = ctx_.get(inputB)->getHandle();
+  ASSERT_EQ(result.size(), handleA.size());
+  for (size_t idx = 0, end = result.size(); idx != end; ++idx) {
+    EXPECT_EQ(result.raw(idx), handleA.raw(idx) + handleB.raw(idx));
+  }
+}
+
 TEST_P(Operator, matmul) {
   auto *lhs = mod_.createPlaceholder(ElemKind::FloatTy, {3, 2}, "lhs", false);
   auto *rhs = mod_.createPlaceholder(ElemKind::FloatTy, {2, 1}, "rhs", false);

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -1648,6 +1648,32 @@ TEST_P(InterpAndCPU, EntropyLossTest) {
   EXPECT_NEAR(R.at({0}), -log(0.5) - log(0.3), 0.1);
 }
 
+/// Check that the max operator works properly.
+TEST_P(Operator, Max) {
+  PseudoRNG PRNG;
+
+  auto *inputA =
+      mod_.createPlaceholder(ElemKind::FloatTy, {1, 3, 3, 1}, "A", false);
+  ctx_.allocate(inputA)->getHandle<float>().randomize(-3.0, 3.0, PRNG);
+  auto *inputB =
+      mod_.createPlaceholder(ElemKind::FloatTy, {1, 3, 3, 1}, "B", false);
+  ctx_.allocate(inputB)->getHandle<float>().randomize(-3.0, 3.0, PRNG);
+  auto *Max = F_->createMax("max", inputA, inputB);
+  auto *S = F_->createSave(ctx_, "save", Max);
+  ctx_.allocate(S->getPlaceholder());
+
+  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.run();
+
+  auto result = ctx_.get(S->getPlaceholder())->getHandle<float>();
+  auto handleA = ctx_.get(inputA)->getHandle<float>();
+  auto handleB = ctx_.get(inputB)->getHandle<float>();
+  ASSERT_EQ(result.size(), handleA.size());
+  for (size_t idx = 0, end = result.size(); idx != end; ++idx) {
+    EXPECT_EQ(result.raw(idx), std::max(handleA.raw(idx), handleB.raw(idx)));
+  }
+}
+
 TEST_P(Operator, RescaleNode) {
   // Check the outputs of the RescaleQuantized operation.
   auto *input = mod_.createPlaceholder(ElemKind::Int8QTy, {4, 10}, 0.4, -3,

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -3178,6 +3178,33 @@ TEST_P(InterpAndCPU, Int8Sigmoid) {
   }
 }
 
+/// Check that the batch add operator works properly.
+TEST_P(Operator, BatchAdd) {
+  PseudoRNG PRNG;
+
+  auto *input =
+      mod_.createPlaceholder(ElemKind::FloatTy, {13, 3, 3}, "A", false);
+  ctx_.allocate(input)->getHandle<float>().randomize(-3.0, 3.0, PRNG);
+  auto *slice =
+      mod_.createPlaceholder(ElemKind::FloatTy, {3, 3}, "slice", false);
+  ctx_.allocate(slice)->getHandle<float>().randomize(-3.0, 3.0, PRNG);
+  auto *batchAdd = F_->createBatchedAdd("batchAdd", input, slice);
+  auto *S = F_->createSave(ctx_, "save", batchAdd);
+  ctx_.allocate(S->getPlaceholder());
+
+  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.run();
+
+  auto result = ctx_.get(S->getPlaceholder())->getHandle<float>();
+  auto handleInput = ctx_.get(input)->getHandle<float>();
+  auto handleSlice = ctx_.get(slice)->getHandle<float>();
+  ASSERT_EQ(result.size(), handleInput.size());
+  for (size_t idx = 0, end = result.size(); idx != end; ++idx) {
+    EXPECT_EQ(result.raw(idx),
+              handleInput.raw(idx) + handleSlice.raw(idx % handleSlice.size()));
+  }
+}
+
 TEST_P(InterpAndCPU, IntLookupTable) {
   constexpr size_t size = 6;
   auto *input =

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -1674,6 +1674,32 @@ TEST_P(Operator, Max) {
   }
 }
 
+/// Check that the max operator works properly with FP16.
+TEST_P(InterpOnly, FP16Max) {
+  PseudoRNG PRNG;
+
+  auto *inputA =
+      mod_.createPlaceholder(ElemKind::Float16Ty, {1, 3, 3, 1}, "A", false);
+  ctx_.allocate(inputA)->getHandle<float16_t>().randomize(-3.0, 3.0, PRNG);
+  auto *inputB =
+      mod_.createPlaceholder(ElemKind::Float16Ty, {1, 3, 3, 1}, "B", false);
+  ctx_.allocate(inputB)->getHandle<float16_t>().randomize(-3.0, 3.0, PRNG);
+  auto *Max = F_->createMax("max", inputA, inputB);
+  auto *S = F_->createSave(ctx_, "save", Max);
+  ctx_.allocate(S->getPlaceholder());
+
+  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.run();
+
+  auto result = ctx_.get(S->getPlaceholder())->getHandle<float16_t>();
+  auto handleA = ctx_.get(inputA)->getHandle<float16_t>();
+  auto handleB = ctx_.get(inputB)->getHandle<float16_t>();
+  ASSERT_EQ(result.size(), handleA.size());
+  for (size_t idx = 0, end = result.size(); idx != end; ++idx) {
+    EXPECT_EQ(result.raw(idx), std::max(handleA.raw(idx), handleB.raw(idx)));
+  }
+}
+
 TEST_P(Operator, RescaleNode) {
   // Check the outputs of the RescaleQuantized operation.
   auto *input = mod_.createPlaceholder(ElemKind::Int8QTy, {4, 10}, 0.4, -3,

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -187,6 +187,32 @@ TEST_P(Operator, add) {
   }
 }
 
+/// Check that the add operator works properly with FP16.
+TEST_P(InterpOnly, FP16Add) {
+  PseudoRNG PRNG;
+
+  auto *inputA =
+      mod_.createPlaceholder(ElemKind::Float16Ty, {1, 3, 3, 1}, "A", false);
+  ctx_.allocate(inputA)->getHandle<float16_t>().randomize(-3.0, 3.0, PRNG);
+  auto *inputB =
+      mod_.createPlaceholder(ElemKind::Float16Ty, {1, 3, 3, 1}, "B", false);
+  ctx_.allocate(inputB)->getHandle<float16_t>().randomize(-3.0, 3.0, PRNG);
+  auto *Pool = F_->createAdd("pool", inputA, inputB);
+  auto *S = F_->createSave(ctx_, "save", Pool);
+  ctx_.allocate(S->getPlaceholder());
+
+  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.run();
+
+  auto result = ctx_.get(S->getPlaceholder())->getHandle<float16_t>();
+  auto handleA = ctx_.get(inputA)->getHandle<float16_t>();
+  auto handleB = ctx_.get(inputB)->getHandle<float16_t>();
+  ASSERT_EQ(result.size(), handleA.size());
+  for (size_t idx = 0, end = result.size(); idx != end; ++idx) {
+    EXPECT_EQ(result.raw(idx), handleA.raw(idx) + handleB.raw(idx));
+  }
+}
+
 TEST_P(Operator, matmul) {
   auto *lhs = mod_.createPlaceholder(ElemKind::FloatTy, {3, 2}, "lhs", false);
   auto *rhs = mod_.createPlaceholder(ElemKind::FloatTy, {2, 1}, "rhs", false);

--- a/tests/unittests/graphTest.cpp
+++ b/tests/unittests/graphTest.cpp
@@ -1070,3 +1070,45 @@ TEST(Graph, setType) {
   EXPECT_EQ(topK->getType(1), origTopKRes1);
   EXPECT_EQ(valRes1.getType(), origTopKRes1);
 }
+
+TEST(Graph, mutateNodeTypeThatMatch) {
+  Module M;
+  auto *F = M.createFunction("main");
+
+  const size_t inputDims[] = {4, 10};
+  const size_t top5Dims[] = {4, 5};
+  auto *input =
+      M.createPlaceholder(ElemKind::FloatTy, inputDims, "input", true);
+  TopKNode *topK = F->createTopK("add", input, 5);
+  TypeRef origTopKRes0 = M.uniqueType(ElemKind::FloatTy, top5Dims);
+  TypeRef origTopKRes1 = M.uniqueType(ElemKind::Int64ITy, top5Dims);
+
+  EXPECT_EQ(topK->getType(0), origTopKRes0);
+  EXPECT_EQ(topK->getType(1), origTopKRes1);
+
+  // Modify the type of all the results that match FloatTy.
+  // Just the first one should be modified.
+  TypeRef inputTy = M.uniqueType(ElemKind::FloatTy, inputDims);
+  TypeRef topKRes0 = M.uniqueType(ElemKind::Float16Ty, top5Dims);
+  mutateNodeResTypeThatMatch(M, *topK, /*origTy*/ ElemKind::FloatTy,
+                             /*newTy*/ ElemKind::Float16Ty);
+  EXPECT_EQ(input->getType(), inputTy);
+  EXPECT_EQ(topK->getType(0), topKRes0);
+  EXPECT_EQ(topK->getType(1), origTopKRes1);
+
+  // Modify the type of all the results that match Int64ITy.
+  // Now the second result will be modified.
+  mutateNodeResTypeThatMatch(M, *topK, /*origTy*/ ElemKind::Int64ITy,
+                             /*newTy*/ ElemKind::Float16Ty);
+  EXPECT_EQ(input->getType(), inputTy);
+  EXPECT_EQ(topK->getType(0), topKRes0);
+  EXPECT_EQ(topK->getType(1), topKRes0);
+
+  // Modify the type of all the results that match Float16Ty.
+  // Both results should be modified.
+  mutateNodeResTypeThatMatch(M, *topK, /*origTy*/ ElemKind::Float16Ty,
+                             /*newTy*/ ElemKind::FloatTy);
+  EXPECT_EQ(input->getType(), inputTy);
+  EXPECT_EQ(topK->getType(0), origTopKRes0);
+  EXPECT_EQ(topK->getType(1), origTopKRes0);
+}

--- a/tools/loader/ImageClassifier.cpp
+++ b/tools/loader/ImageClassifier.cpp
@@ -173,6 +173,11 @@ void loadImagesAndPreprocess(const llvm::cl::list<std::string> &filenames,
   }
 }
 
+llvm::cl::opt<bool>
+    useFp16("run-fp16",
+            llvm::cl::desc("Run in fp16 for all floating-point computation."),
+            llvm::cl::init(false));
+
 int main(int argc, char **argv) {
   Context ctx;
   // The loader verifies/initializes command line parameters, and initializes
@@ -225,6 +230,11 @@ int main(int argc, char **argv) {
 
   // If in bundle mode, do not run inference.
   if (!emittingBundle()) {
+
+    if (useFp16) {
+      // Force cast the tensors into fp16.
+      data.convertToType(ElemKind::Float16Ty);
+    }
 
     // Update the inputs.
     updateVariables({inputImage}, {&data});


### PR DESCRIPTION
*Description*:
This lengthy PR (I would recommend to review the patch individually) adds the ability to convert an fp32 model into an fp16 model. This can be done by using `-use-fp16`.

The meat of the patch is actually not the change to the loader, but all the ground work to have type conversion being a thing at the node level, tensor level, function level.

*Testing*:
Added test cases.

*Documentation*:
N/A

Related to #1329.