### PR TITLE
Compatibility with FB-internal LLVM

### DIFF
--- a/lib/Backends/CPU/BundleSaver.cpp
+++ b/lib/Backends/CPU/BundleSaver.cpp
@@ -158,7 +158,10 @@ void BundleSaver::produceBundle(llvm::StringRef outputDir) {
     llvm::legacy::PassManager PM;
     auto &TM = irgen_.getTargetMachine();
 
-#if LLVM_VERSION_MAJOR > 6
+#if FACEBOOK_INTERNAL
+    TM.addPassesToEmitFile(
+        PM, outputFile, llvm::TargetMachine::CodeGenFileType::CGFT_ObjectFile);
+#elif LLVM_VERSION_MAJOR > 6
     TM.addPassesToEmitFile(
         PM, outputFile, nullptr,
         llvm::TargetMachine::CodeGenFileType::CGFT_ObjectFile);

--- a/lib/Backends/CPU/GlowJIT.h
+++ b/lib/Backends/CPU/GlowJIT.h
@@ -45,7 +45,11 @@ class GlowJIT {
 private:
   TargetMachine &TM_;
   const DataLayout DL_;
-#if LLVM_VERSION_MAJOR > 6
+#if FACEBOOK_INTERNAL
+  SymbolStringPool SSP_;
+  ExecutionSession ES_;
+  std::shared_ptr<SymbolResolver> resolver_;
+#elif LLVM_VERSION_MAJOR > 6
   std::shared_ptr<SymbolStringPool> SSP_;
   ExecutionSession ES_;
   std::shared_ptr<SymbolResolver> resolver_;

--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -295,7 +295,10 @@ void LLVMIRGen::performCodeGen() {
     llvm::SmallVector<char, 0> asmBuffer;
     llvm::raw_svector_ostream asmStream(asmBuffer);
     llvm::legacy::PassManager PM;
-#if LLVM_VERSION_MAJOR > 6
+#if FACEBOOK_INTERNAL
+    getTargetMachine().addPassesToEmitFile(
+        PM, asmStream, llvm::TargetMachine::CodeGenFileType::CGFT_AssemblyFile);
+#elif LLVM_VERSION_MAJOR > 6
     getTargetMachine().addPassesToEmitFile(
         PM, asmStream, nullptr,
         llvm::TargetMachine::CodeGenFileType::CGFT_AssemblyFile);


### PR DESCRIPTION
*Description*: Sigh.  Facebook's internal LLVM is lagging the stable release, so this is reintroducing a stopgap to get glow to build.
*Testing*: `ninja all` works in OSS repo, internal build also works
*Documentation*: N/A
