### PR TITLE
[Graph] Make Module non-copyable

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -182,8 +182,19 @@ public:
   /// Erase all of the functions from the module.
   void eraseFunctions();
 
+  /// Erase all the functions, variables, etc.
+  void clear();
+
   /// Erase a function \p F from the module.
   void eraseFunction(Function *F);
+
+  // Don't copy or move this class around.
+  // The destructor will wipe the functions leaving
+  // the original Module only dangling pointers.
+  Module(const Module &) = delete;
+  Module(Module &&) = delete;
+  Module &operator=(const Context &) = delete;
+  Module &operator=(Context &&) = delete;
 };
 
 /// Represents the compute graph.

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -52,7 +52,7 @@ Function *Module::createFunction(llvm::StringRef name) {
   return F;
 }
 
-Module::~Module() {
+void Module::clear() {
   eraseFunctions();
 
   for (auto it = vars_.begin(), e = vars_.end(); it != e; it++) {
@@ -68,6 +68,7 @@ Module::~Module() {
   placeholders_.clear();
 }
 
+Module::~Module() { clear(); }
 void Module::verify() const {
   for (auto *F : functions_) {
     F->verify();

--- a/tests/unittests/graphTest.cpp
+++ b/tests/unittests/graphTest.cpp
@@ -45,6 +45,32 @@ TEST(Graph, testVariableErasure) {
   EXPECT_EQ(std::distance(vars.begin(), vars.end()), vars.size());
 }
 
+/// Check that the clear method completely reset a module.
+TEST(Graph, clear) {
+  Module M;
+
+  // Check that the module is initially empty.
+  EXPECT_EQ(M.getVars().size(), 0);
+  EXPECT_EQ(M.getPlaceholders().size(), 0);
+  EXPECT_EQ(M.getFunctions().size(), 0);
+
+  // Create a few things.
+  M.createFunction("main");
+  M.createPlaceholder(ElemKind::FloatTy, {1}, "placeholder", true);
+  M.createVariable(ElemKind::FloatTy, {1}, "var");
+
+  EXPECT_EQ(M.getVars().size(), 1);
+  EXPECT_EQ(M.getPlaceholders().size(), 1);
+  EXPECT_EQ(M.getFunctions().size(), 1);
+
+  // Check that clearing the module makes it completely free of any kind of
+  // objects.
+  M.clear();
+  EXPECT_EQ(M.getVars().size(), 0);
+  EXPECT_EQ(M.getPlaceholders().size(), 0);
+  EXPECT_EQ(M.getFunctions().size(), 0);
+}
+
 TEST(Graph, simpleTestConv) {
   Module MD;
   Function *F = MD.createFunction("F");


### PR DESCRIPTION
*Description*
Copying Modules around would make them share the same underlying memory
for all the functions, variables, and placeholders.

Therefore, if we were to copy a module by mistake (e.g., by forgetting
to put & after the typename of a local variable), when this copy
would get deleted, it would leave the original module with dangling
pointers.

This patch also adds a clear method for the one test case where the
copy of a module was made on purpose.

*Testing*
Added test case for the clear mehod and changed the one test case
that was using Module copy.

*Description*:
*Testing*:
*Documentation*:
[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
