### PR TITLE
[Node] Add a setType method

### DIFF
--- a/include/glow/Graph/Node.h
+++ b/include/glow/Graph/Node.h
@@ -88,6 +88,8 @@ public:
 
   /// Return the TypeRef of the referenced return value.
   TypeRef getType() const;
+  /// Set the type of the referenced value.
+  void setType(TypeRef ty);
 
   /// Methods that forward to the result type (that must be valid):
   /// @{
@@ -333,6 +335,12 @@ public:
 
   /// \returns the n'th result type of the node.
   TypeRef getType(unsigned idx) const;
+  /// Set the \p idx'th result type of the node.
+  /// \note This setter only changes the type of this one
+  ///       result. If that type is incompatible with
+  ///       the inputs of the node, the caller is
+  ///       responsible to update these if need be.
+  void setType(unsigned idx, TypeRef ty);
 
   /// Methods that forward to the result type (that must be valid):
   /// @{

--- a/lib/Graph/Node.cpp
+++ b/lib/Graph/Node.cpp
@@ -90,6 +90,13 @@ TypeRef Node::getType(unsigned idx) const {
   return types_[idx];
 }
 
+void Node::setType(unsigned idx, TypeRef ty) {
+  assert(idx < numRes_ && "Result number does not exist.");
+  assert(types_[idx]->dims() == ty->dims() &&
+         "Better create a new node at this point");
+  types_[idx] = ty;
+}
+
 ElemKind Node::getElementType(unsigned resNo) const {
   TypeRef TR = getType(resNo);
   return TR->getElementType();
@@ -195,6 +202,7 @@ void Node::visit(Node *parent, NodeWalker *visitor) {
 }
 
 TypeRef NodeValue::getType() const { return node_->getType(resNo_); }
+void NodeValue::setType(TypeRef ty) { node_->setType(resNo_, ty); }
 
 ElemKind NodeValue::getElementType() const {
   return getType()->getElementType();

--- a/tests/unittests/graphTest.cpp
+++ b/tests/unittests/graphTest.cpp
@@ -968,3 +968,49 @@ TEST(Graph, placeholder) {
   K = F->createSoftMax("SoftMax", K, S);
   F->createSave(ctx, "Save", K);
 }
+
+/// Check that the setType API allows to change the type of the
+/// related result and only the related result.
+TEST(Graph, setType) {
+  Module M;
+  auto *F = M.createFunction("main");
+
+  const size_t inputDims[] = {4, 10};
+  const size_t top5Dims[] = {4, 5};
+  auto *input =
+      M.createPlaceholder(ElemKind::FloatTy, inputDims, "input", true);
+  TopKNode *topK = F->createTopK("add", input, 5);
+  TypeRef origTopKRes0 = M.uniqueType(ElemKind::FloatTy, top5Dims);
+  TypeRef origTopKRes1 = M.uniqueType(ElemKind::Int64ITy, top5Dims);
+
+  EXPECT_EQ(topK->getType(0), origTopKRes0);
+  EXPECT_EQ(topK->getType(1), origTopKRes1);
+
+  // Modify the type of result 0 and make sure type 1 is not
+  // affected. Similarly the input shouldn't be affected.
+  TypeRef inputTy = M.uniqueType(ElemKind::FloatTy, inputDims);
+  TypeRef topKRes0 = M.uniqueType(ElemKind::Float16Ty, top5Dims);
+  topK->setType(0, topKRes0);
+  EXPECT_EQ(input->getType(), inputTy);
+  EXPECT_EQ(topK->getType(0), topKRes0);
+  EXPECT_EQ(topK->getType(1), origTopKRes1);
+
+  // Make sure the NodeValue API works the same way
+  // as the Node::setType API.
+  NodeValue valRes1 = topK->getNthResult(1);
+  valRes1.setType(topKRes0);
+  EXPECT_EQ(input->getType(), inputTy);
+  EXPECT_EQ(topK->getType(0), topKRes0);
+  EXPECT_EQ(topK->getType(1), topKRes0);
+  EXPECT_EQ(valRes1.getType(), topKRes0);
+
+  // Now restore sane types.
+  NodeValue valRes0 = topK->getNthResult(0);
+  valRes0.setType(origTopKRes0);
+  topK->setType(1, origTopKRes1);
+  EXPECT_EQ(input->getType(), inputTy);
+  EXPECT_EQ(topK->getType(0), origTopKRes0);
+  EXPECT_EQ(valRes0.getType(), origTopKRes0);
+  EXPECT_EQ(topK->getType(1), origTopKRes1);
+  EXPECT_EQ(valRes1.getType(), origTopKRes1);
+}


### PR DESCRIPTION
* Description *
Prior to this patch the only way to change the type of a Node was
to create a new one with a different type and manually set the
arguments to match the node you want to replace.

This patch introduces a setType method that allows to change the
type of a specific result.

This method only changes the type of the specified result, in other
words if this type is only valid if the type of the inputs are changed
as well, these inputs have to be updated independently.

E.g.,
tensor<float> A
tensor<float> B
tensor<float> = batchAdd A, B

Changing the type of the result of batchAdd won't change the type
of A and B. Thus if those are not updated the verifier will complain
that the type for the sources and the result are incompatible.

* Testing *
Added test case.

* Documentation *
N/A

Related to #1329, we want an easy way to convert graphs to different
types for testing purposes.

*Description*:
*Testing*:
*Documentation*:
[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
