### PR TITLE
[Tensor] Add a convertToType method

### DIFF
--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -364,6 +364,9 @@ public:
     }
   }
 
+  /// Convert each element of this tensor to \p newTy.
+  void convertToType(ElemKind newTy);
+
   /// Transpose the tensor \p src into the empty tensor \p dest. Shuffle the
   /// axis based on the list \p shuffle, where each element is the src index.
   void transpose(Tensor *dest, llvm::ArrayRef<unsigned_t> shuffle) {

--- a/lib/Base/Tensor.cpp
+++ b/lib/Base/Tensor.cpp
@@ -435,3 +435,20 @@ void Tensor::init(InitKind init, float val, PseudoRNG &PRNG) {
   }
   }
 }
+
+void Tensor::convertToType(ElemKind newTy) {
+  Tensor tmp(newTy, dims());
+  switch (newTy) {
+  case ElemKind::Float16Ty:
+    assert(getElementType() == ElemKind::FloatTy && "Cast not implemented");
+    tmp.copyWithCast<float16_t, float>(this);
+    break;
+  case ElemKind::FloatTy:
+    assert(getElementType() == ElemKind::Float16Ty && "Cast not implemented");
+    tmp.copyWithCast<float, float16_t>(this);
+    break;
+  default:
+    llvm_unreachable("Type not supported");
+  }
+  *this = std::move(tmp);
+}


### PR DESCRIPTION
*Description*
This patch adds a convertToType method that allows to convert the content
of a tensor from its current type to a new type.

The shape of the tensor remains unchanged, but the element type
gets updated to the new type.

For now, this method only supports conversion between float and
float16_t.

*Testing*
Added test case.

Related to #1329, this patch adds the functionality required to
change the content of a network while doing conversion from one
type to another.

*Description*:
*Testing*:
*Documentation*:
[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
