### PR TITLE
[travis.yml] Use keep_alive() instead of travis_wait

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,8 +66,11 @@ jobs:
       script:
         - CLANG_COMMAND=/usr/bin/clang-format-6.0 ./utils/format.sh check
 
+# Note: keep_alive() prevents travis from exiting early on tests that take a while.
 script:
+ - function keep_alive() { while true; do echo -en "\a"; sleep 60; done }
+ - keep_alive &
  - ninja all
- - CTEST_PARALLEL_LEVEL=2 travis_wait 20 ninja test
+ - CTEST_PARALLEL_LEVEL=2 ninja test
  - cat Testing/Temporary/LastTest.log
- - CTEST_PARALLEL_LEVEL=2 travis_wait 20 ninja test_unopt
+ - CTEST_PARALLEL_LEVEL=2 ninja test_unopt


### PR DESCRIPTION
We have an issue with a cat failing on travis after `travis_wait` not exiting correctly. I don't know why this has suddenly started occurring. It seems to be a quirk of `travis_wait`. This PR basically duplicates some functionality of `travis_wait` -- it will write to the terminal every minute to make sure travis doesn't fail early, waiting until the tests end. Based on https://github.com/travis-ci/dpl/issues/568#issuecomment-272465349

Here's another potential solution to fix this problem, which would allow us to keep using `travis_wait`: https://github.com/travis-ci/travis-ci/issues/4704#issuecomment-348435959