### PR TITLE
[Backend][Interpreter] Implement fp16 max pooling

### DIFF
--- a/include/glow/Support/Float16.h
+++ b/include/glow/Support/Float16.h
@@ -50,6 +50,7 @@ public:
   bool operator==(const float16 &b) const {
     return operator float() == float(b);
   }
+  bool operator>=(const float16 &b) const { return !(operator<(b)); }
 
   /// Cast operators.
   operator double() const { return double(operator float()); }

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -365,9 +365,14 @@ void InterpreterFunction::fwdMaxPoolInst(const MaxPoolInst *I) {
   if (inW->getType().isQuantizedType()) {
     fwdMaxPool<int8_t>(inW, outW, nullptr, I->getKernels(), I->getStrides(),
                        I->getPads());
-  } else {
+  } else if (inW->getType().getElementType() == ElemKind::FloatTy) {
     fwdMaxPool<float>(inW, outW, nullptr, I->getKernels(), I->getStrides(),
                       I->getPads());
+  } else if (inW->getType().getElementType() == ElemKind::Float16Ty) {
+    fwdMaxPool<float16_t>(inW, outW, nullptr, I->getKernels(), I->getStrides(),
+                          I->getPads());
+  } else {
+    llvm_unreachable("Type not supported");
   }
 }
 
@@ -379,9 +384,14 @@ void InterpreterFunction::fwdMaxPoolWithXYInst(const MaxPoolWithXYInst *I) {
   if (inW->getType().isQuantizedType()) {
     fwdMaxPool<int8_t>(inW, outW, &SXY, I->getKernels(), I->getStrides(),
                        I->getPads());
-  } else {
+  } else if (inW->getType().getElementType() == ElemKind::FloatTy) {
     fwdMaxPool<float>(inW, outW, &SXY, I->getKernels(), I->getStrides(),
                       I->getPads());
+  } else if (inW->getType().getElementType() == ElemKind::Float16Ty) {
+    fwdMaxPool<float16_t>(inW, outW, &SXY, I->getKernels(), I->getStrides(),
+                          I->getPads());
+  } else {
+    llvm_unreachable("Type not supported");
   }
 }
 

--- a/tests/unittests/float16Test.cpp
+++ b/tests/unittests/float16Test.cpp
@@ -68,3 +68,10 @@ TEST(Float16, eq) {
   EXPECT_FALSE(a == b);
   EXPECT_TRUE(a == a);
 }
+
+TEST(Float16, ge) {
+  float16 a = -31.455;
+  float16 b = 4543.4;
+  EXPECT_EQ(a >= b, float(a) >= float(b));
+  EXPECT_FALSE(a >= b);
+}


### PR DESCRIPTION
    [Backend][Interpreter] Implement fp16 max pooling
    
    *Description*
    This commit adds the right dispatch code to run the MaxPool node
    in half precision.
    
    *Testing*
    Added test case.
    
    Related to #1329.