### PR TITLE
[Placeholder] Refactor the loader APIs to remove some use of Variable (NFC)

### DIFF
--- a/include/glow/Importer/ProtobufLoader.h
+++ b/include/glow/Importer/ProtobufLoader.h
@@ -126,10 +126,6 @@ public:
   /// created, this method registers it under \p name.
   NodeValue getNodeValueOrCreateVariableByName(llvm::StringRef name);
 
-  /// \returns The variable registered under \p name.
-  /// \pre isa<Variable>(getNodeValueByName(name).getNode())
-  Variable *getVariableByName(llvm::StringRef name) const;
-
   /// \returns True if the node that's registered using \p name exists.
   bool hasNodeByName(llvm::StringRef name) const;
 

--- a/lib/Importer/ProtobufLoader.cpp
+++ b/lib/Importer/ProtobufLoader.cpp
@@ -83,15 +83,6 @@ ProtobufLoader::getNodeValueOrCreateVariableByName(llvm::StringRef name) {
   return NodeValue(createAndRememberVariable(name, *T), 0);
 }
 
-Variable *ProtobufLoader::getVariableByName(llvm::StringRef name) const {
-  assert(hasNodeByName(name) && "Variable was not created");
-  auto *node = getNodeValueByName(name).getNode();
-
-  assert(llvm::isa<Variable>(node) && "Node is not a variable");
-
-  return llvm::cast<Variable>(node);
-}
-
 bool ProtobufLoader::hasNodeByName(llvm::StringRef name) const {
   return getNodeValueByNameOrNullNodeValue(name).getNode() != nullptr;
 }

--- a/tools/loader/ImageClassifier.cpp
+++ b/tools/loader/ImageClassifier.cpp
@@ -215,7 +215,8 @@ int main(int argc, char **argv) {
   // Create Variables for both possible input names for flexibility for the
   // input model. The input data is mapped to both names. Whichever Variable is
   // unused will be removed in compile().
-  Variable *inputImage = LD->getVariableByName(inputName);
+  Node *inputImageNode = LD->getNodeValueByName(inputName);
+  Variable *inputImage = llvm::cast<Variable>(inputImageNode);
   assert(inputImage->getVisibilityKind() == VisibilityKind::Public);
 
   // Compile the model, and perform quantization/emit a bundle/dump debug info

--- a/tools/loader/ImageClassifier.cpp
+++ b/tools/loader/ImageClassifier.cpp
@@ -224,7 +224,12 @@ int main(int argc, char **argv) {
 
   // If in bundle mode, do not run inference.
   if (!emittingBundle()) {
-    loader.runInference(ctx, {inputImage}, {&data});
+
+    // Update the inputs.
+    updateVariables({inputImage}, {&data});
+
+    // Perform the inference execution.
+    loader.runInference(ctx);
 
     // Print out the inferred image classification.
     Tensor &res = SMVar->getPayload();

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -268,8 +268,7 @@ void Loader::compile(Context &ctx) {
   }
 }
 
-void Loader::runInference(Context &ctx, llvm::ArrayRef<Variable *> variables,
-                          llvm::ArrayRef<Tensor *> tensors) {
+void Loader::runInference(Context &ctx) {
   assert(!emittingBundle() &&
          "No inference is performed in the bundle generation mode.");
 
@@ -278,7 +277,6 @@ void Loader::runInference(Context &ctx, llvm::ArrayRef<Variable *> variables,
     timer.startTimer();
   }
   for (unsigned i = 0; i < iterationsOpt; i++) {
-    updateVariables(variables, tensors);
     EE_.run();
   }
   if (timeOpt) {

--- a/tools/loader/Loader.h
+++ b/tools/loader/Loader.h
@@ -60,12 +60,10 @@ public:
   /// quantization profile guided information.
   void compile(Context &ctx);
 
-  /// Runs inference, unless emit bundle mode is enabled. If inference is run
-  /// then it will \return true, else false. \p ctx is the context that binds
-  /// specific placeholders to concrete tensors. The concrete tensors include
-  /// quantization profile guided information.
-  void runInference(Context &ctx, llvm::ArrayRef<Variable *> variables,
-                    llvm::ArrayRef<Tensor *> tensors);
+  /// Runs inference, unless emit bundle mode is enabled. \p ctx is the context
+  /// that binds specific placeholders to concrete tensors. The concrete
+  /// tensors include quantization profile guided information.
+  void runInference(Context &ctx);
 
   /// Create the Loader driver object, and parse/verify the command line
   /// parameters.

--- a/tools/loader/ModelRunner.cpp
+++ b/tools/loader/ModelRunner.cpp
@@ -50,7 +50,7 @@ int main(int argc, char **argv) {
 
   // If in bundle mode, do not run inference.
   if (!emittingBundle()) {
-    loader.runInference(ctx, {}, {});
+    loader.runInference(ctx);
 
     llvm::outs() << "Model: " << loader.getFunction()->getName() << "\n";
 

--- a/tools/loader/TextTranslator.cpp
+++ b/tools/loader/TextTranslator.cpp
@@ -320,7 +320,8 @@ int main(int argc, char **argv) {
                               loader.getCaffe2NetWeightFilename(), inputNames,
                               inputTensors, *loader.getFunction());
 
-  Variable *encoderInputsVar = LD.getVariableByName("encoder_inputs");
+  Variable *encoderInputsVar =
+      llvm::cast<Variable>(LD.getNodeValueByName("encoder_inputs"));
 
   // Compile the model, and perform quantization/emit a bundle/dump debug info
   // if requested from command line.

--- a/tools/loader/TextTranslator.cpp
+++ b/tools/loader/TextTranslator.cpp
@@ -337,8 +337,11 @@ int main(int argc, char **argv) {
     // Load the next string into encoderInputs.
     loadNextInputTranslationText(&encoderInputs);
 
+    // update the inputs.
+    updateVariables({encoderInputsVar}, {&encoderInputs});
+
     // Run actual translation.
-    loader.runInference(ctx, {encoderInputsVar}, {&encoderInputs});
+    loader.runInference(ctx);
 
     // Process the outputs to determine the highest likelihood sentence, and
     // print out the decoded translation using the dest dictionary.


### PR DESCRIPTION
*Description*:

Refactor the load APIs to remove the use of Variable:
 
    [PH] remove getVariableByName from the loader. NFC.

    [PH] Remove the variables from the run() interface.

*Testing*: Ran ninja check and run.sh.   I did not test the textual model runner. 

*Documentation*: none. 
