### PR TITLE
[Caffe2] Support FCTransposed op.

### DIFF
--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -294,7 +294,7 @@ void Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     return;
   }
 
-  if (typeName == "FC") {
+  if (typeName == "FC" || typeName == "FCTransposed") {
     // Load the inputs:
     auto in = getNodeValueOrCreateVariableByName(op.input(0));
     if (in.getType()->dims().size() > 2) {
@@ -309,14 +309,19 @@ void Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
 
     // Caffe2 stores the transposed W matrix. In here we first coerce W to a 2D
     // matrix size if necessay and then transpose it back.
-    Tensor wtag;
+    Tensor tmp;
     if (w->dims().size() > 2) {
       auto wDims = flattenCdr(w->dims(), axis_w);
-      Tensor tmp(ElemKind::FloatTy, {wDims.first, wDims.second});
+      tmp.reset(ElemKind::FloatTy, {wDims.first, wDims.second});
       tmp.copyRawFrom(w);
-      tmp.transpose(&wtag, {1, 0});
-    } else
+      w = &tmp;
+    }
+    Tensor wtag;
+    if (typeName == "FC") {
       w->transpose(&wtag, {1, 0});
+    } else {
+      wtag.assign(w);
+    }
 
     auto W = G_.getParent()->addVar(
         new Variable("weights", VisibilityKind::Private, std::move(wtag)));

--- a/tests/models/caffe2Models/fcTransposed_init_net.pbtxt
+++ b/tests/models/caffe2Models/fcTransposed_init_net.pbtxt
@@ -1,0 +1,41 @@
+name: "init"
+op {
+  output: "weights"
+  type: "GivenTensorFill"
+  arg {
+    name: "shape"
+    ints: 3
+    ints: 4
+  }
+  arg {
+    name: "values"
+    floats: 1.0
+    floats: 4.0
+    floats: 7.0
+    floats: 10.0
+    floats: 2.0 
+    floats: 5.0
+    floats: 8.0
+    floats: 11.0
+    floats: 3.0
+    floats: 6.0
+    floats: 9.0
+    floats: 12.0
+  }
+}
+op {
+  output: "bias"
+  type: "GivenTensorFill"
+  arg {
+    name: "shape"
+    ints: 4
+  }
+  arg {
+    name: "values"
+    floats: 0.1
+    floats: 0.2
+    floats: 0.3
+    floats: 0.4
+  }
+}
+

--- a/tests/models/caffe2Models/fcTransposed_predict_net.pbtxt
+++ b/tests/models/caffe2Models/fcTransposed_predict_net.pbtxt
@@ -1,0 +1,13 @@
+name: "fc"
+op {
+  input: "inputs"
+  input: "weights"
+  input: "bias"
+  output: "fc_result"
+  name: ""
+  type: "FCTransposed"
+}
+external_input: "inputs"
+external_input: "weights"
+external_input: "bias"
+external_output: "fc_result"

--- a/tests/models/caffe2Models/fc_init_net.pbtxt
+++ b/tests/models/caffe2Models/fc_init_net.pbtxt
@@ -1,0 +1,41 @@
+name: "init"
+op {
+  output: "weights"
+  type: "GivenTensorFill"
+  arg {
+    name: "shape"
+    ints: 4
+    ints: 3
+  }
+  arg {
+    name: "values"
+    floats: 1.0
+    floats: 2.0
+    floats: 3.0
+    floats: 4.0
+    floats: 5.0 
+    floats: 6.0
+    floats: 7.0
+    floats: 8.0
+    floats: 9.0
+    floats: 10.0
+    floats: 11.0
+    floats: 12.0
+  }
+}
+op {
+  output: "bias"
+  type: "GivenTensorFill"
+  arg {
+    name: "shape"
+    ints: 4
+  }
+  arg {
+    name: "values"
+    floats: 0.1
+    floats: 0.2
+    floats: 0.3
+    floats: 0.4
+  }
+}
+

--- a/tests/models/caffe2Models/fc_predict_net.pbtxt
+++ b/tests/models/caffe2Models/fc_predict_net.pbtxt
@@ -1,0 +1,13 @@
+name: "fc"
+op {
+  input: "inputs"
+  input: "weights"
+  input: "bias"
+  output: "fc_result"
+  name: ""
+  type: "FC"
+}
+external_input: "inputs"
+external_input: "weights"
+external_input: "bias"
+external_output: "fc_result"


### PR DESCRIPTION
*Description*:
Support caffe2 FCTransposed op.
https://caffe2.ai/docs/operators-catalogue.html#fctransposed

*Testing*: 
Added unittest in caffe2ImporterTest.cpp
*Documentation*:
[Optional Fixes #1697 ]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
