### PR TITLE
[Caffe2] Implement BatchBoxCox Caffe2 operator

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -582,6 +582,22 @@ public:
   Node *createWeightedSum(llvm::StringRef name, llvm::ArrayRef<NodeValue> data,
                           llvm::ArrayRef<NodeValue> weights);
 
+  /// Create a series of nodes that implements a two-parameter
+  /// rowwise Box-Cox transform. For each element of the \p input x, this is
+  /// defined as:
+  ///
+  /// y = ln(max(x + lambda2, 1e-6)), if lambda1 == 0
+  ///     (max(x + lambda2, 1e-6)^lambda1 - 1)/lambda1, if lambda1 != 0
+  ///
+  /// The transform parameters \p lambda1 and \p lambda2 are vectors of size D
+  /// that are broadcasted to match the size of \p input (NxD). The transform
+  /// itself is implemented using elementwise Max, Add, Log (if lambda1 == 0),
+  /// Pow, Splat, Sub, and Div (if lambda1 != 0) nodes with a Splat and Select
+  /// node to select between the two cases listed above. \returns the final
+  /// Select node.
+  Node *createBatchBoxCox(llvm::StringRef name, NodeValue input,
+                          NodeValue lambda1, NodeValue lambda2);
+
   /// Create a series of nodes for the Clip operator. It limits the given input
   /// within an interval specified by the `min` and `max` arguments.
   Node *createClip(llvm::StringRef name, NodeValue input, float min, float max);

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -125,6 +125,9 @@ private:
   void fwdBatchedAddInst_I8Impl(const BatchedAddInst *I);
   template <typename ElemTy>
   void fwdBatchedAddInst_FloatImpl(const BatchedAddInst *I);
+
+  template <typename ElemTy>
+  void fwdElementCmpEQInstImpl(const glow::ElementCmpEQInst *I);
   ///@}
 };
 

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -605,6 +605,16 @@ void Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     return;
   }
 
+  if (typeName == "BatchBoxCox") {
+    auto data = getNodeValueOrCreateVariableByName(op.input(0));
+    auto lambda1 = getNodeValueOrCreateVariableByName(op.input(1));
+    auto lambda2 = getNodeValueOrCreateVariableByName(op.input(2));
+
+    auto *node = G_.createBatchBoxCox(opName, data, lambda1, lambda2);
+    addNodeAsOutput(op, node);
+    return;
+  }
+
   unexpectedNodeError(op, "Unsupported operator.");
 }
 

--- a/tests/models/caffe2Models/batch_box_cox_predict_net.pbtxt
+++ b/tests/models/caffe2Models/batch_box_cox_predict_net.pbtxt
@@ -1,0 +1,13 @@
+name: "batch_box_cox"
+op {
+  input: "data"
+  input: "lambda1"
+  input: "lambda2"
+  output: "batch_box_cox"
+  name: ""
+  type: "BatchBoxCox"
+}
+external_input: "data"
+external_input: "lambda1"
+external_input: "lambda2"
+external_output: "batch_box_cox"


### PR DESCRIPTION
**Description**
This commit adds support for the `BatchBoxCox` Caffe2 operator. This
operator accepts a matrix `data` and two vectors `lambda1` and `lambda2`
as input and computes the two-parameter Box-Cox transform of each column
`c` of `data` with parameters `lambda1` and `lambda2`. The transform
`y_i` for each element `c_i` of the input column is given by

<a href="https://www.codecogs.com/eqnedit.php?latex=y&space;\left&space;(&space;x,&space;\lambda_{1},&space;\lambda_{2}&space;\right&space;)=&space;\begin{cases}&space;\ln&space;\left&space;(&space;\max(x&space;&plus;&space;\lambda_{2},&space;1&space;\times&space;10^{-6})\right&space;)&space;&&space;,\lambda_{1}&space;=&space;0&space;\\&space;\frac{(\max(x&space;&plus;&space;\lambda_{2},&space;1&space;\times&space;10^{-6}))^{\lambda_{1}}&space;-&space;1}{\lambda_{1}}&space;&&space;,\lambda_{1}&space;\neq&space;0&space;\\&space;\end{cases}" target="_blank"><img src="https://latex.codecogs.com/gif.latex?y&space;\left&space;(&space;x,&space;\lambda_{1},&space;\lambda_{2}&space;\right&space;)=&space;\begin{cases}&space;\ln&space;\left&space;(&space;\max(x&space;&plus;&space;\lambda_{2},&space;1&space;\times&space;10^{-6})\right&space;)&space;&&space;,\lambda_{1}&space;=&space;0&space;\\&space;\frac{(\max(x&space;&plus;&space;\lambda_{2},&space;1&space;\times&space;10^{-6}))^{\lambda_{1}}&space;-&space;1}{\lambda_{1}}&space;&&space;,\lambda_{1}&space;\neq&space;0&space;\\&space;\end{cases}" title="y \left ( x, \lambda_{1}, \lambda_{2} \right )= \begin{cases} \ln \left ( \max(x + \lambda_{2}, 1 \times 10^{-6})\right ) & ,\lambda_{1} = 0 \\ \frac{(\max(x + \lambda_{2}, 1 \times 10^{-6}))^{\lambda_{1}} - 1}{\lambda_{1}} & ,\lambda_{1} \neq 0 \\ \end{cases}" /></a>

The `BatchBoxCox` operator is immediately lowered to a combination of
`Broadcast`, `Splat`, `Add`, `Pow`, `Max`, `Sub`, `Log`, `Div`, `Select`
and `CmpEq` nodes. After broadcasting `lambda1` and `lambda2` so that
they have the same shape as `data`, both cases shown above are computed
using basic elementwise arithmetic nodes, and a `Select` node is used at
the end to chose between them.

**Testing**
This commit adds a test case for this operator to `caffe2ImporterTest.cpp`.

**Fixes**
This commit fixes #1705.
