### PR TITLE
[Backend][Interpreter] Implement fp16 splat

### DIFF
--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -700,6 +700,10 @@ void InterpreterFunction::fwdSplatInst(const glow::SplatInst *I) {
     return T->getHandle<float>().clear(I->getValue());
   }
 
+  if (k == ElemKind::Float16Ty) {
+    return T->getHandle<float16_t>().clear(I->getValue());
+  }
+
   if (k == ElemKind::Int8QTy) {
     // Quantize the requested floating point splat value into the correct
     // integer representation.

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -2530,6 +2530,24 @@ TEST_P(Operator, IntSplat) {
   }
 }
 
+TEST_P(InterpOnly, Fp16Splat) {
+  const float splatValue = 10;
+  const size_t size = 3;
+
+  auto splatTy = mod_.uniqueType(ElemKind::Float16Ty, {size});
+  auto *splat = F_->createSplat("splat", splatTy, splatValue);
+
+  auto *save = F_->createSave(ctx_, "save", splat);
+  ctx_.allocate(mod_.getPlaceholders());
+  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.run();
+
+  auto result = ctx_.get(save->getPlaceholder())->getHandle<float16_t>();
+  for (size_t i = 0; i < result.size(); i++) {
+    EXPECT_EQ(float16_t(splatValue), result.raw(i));
+  }
+}
+
 TEST_P(Operator, GroupConvolution) {
   auto *input =
       mod_.createPlaceholder(ElemKind::FloatTy, {1, 2, 1, 8}, "input", false);


### PR DESCRIPTION
*Description*
This commit adds the right dispatch code to run the Splat node
in half precision.

*Testing*
Added test case.

Related to #1329.