### PR TITLE
[cpu] Compile libjit into CPUBackend

### DIFF
--- a/lib/Backends/CPU/CMakeLists.txt
+++ b/lib/Backends/CPU/CMakeLists.txt
@@ -38,12 +38,18 @@ set_target_properties(CPURuntime
                         OUTPUT_NAME
                           libjit.bc)
 
+add_custom_command(
+  OUTPUT "${CMAKE_BINARY_DIR}/glow/libjit_bc.inc"
+  COMMAND include-bin "${CMAKE_BINARY_DIR}/libjit.bc" "${CMAKE_BINARY_DIR}/glow/libjit_bc.inc"
+  DEPENDS include-bin CPURuntime)
+
 add_library(CPURuntimeNative
               libjit/libjit.cpp
               libjit/libjit_conv.cpp
               libjit/libjit_matmul.cpp)
 
 add_library(CPUBackend
+            "${CMAKE_BINARY_DIR}/glow/libjit_bc.inc"
             AllocationsInfo.cpp
             BundleSaver.cpp
             CommandLine.cpp

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(ClassGen)
+add_subdirectory(IncludeBin)
 if(PNG_FOUND)
   add_subdirectory(loader)
 endif()

--- a/tools/IncludeBin/CMakeLists.txt
+++ b/tools/IncludeBin/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_executable(include-bin
+               IncludeBin.cpp)

--- a/tools/IncludeBin/IncludeBin.cpp
+++ b/tools/IncludeBin/IncludeBin.cpp
@@ -1,0 +1,33 @@
+#include <cstdio>
+#include <cstdlib>
+
+int main(int argc, char **argv) {
+  if (argc != 3) {
+    fprintf(stderr, "Usage: bin-include input_file output_file\n");
+    exit(1);
+  }
+  FILE *in = fopen(argv[1], "rb");
+  if (!in) {
+    perror("Could not open input file");
+    exit(1);
+  }
+  FILE *out = fopen(argv[2], "wb");
+  if (!out) {
+    perror("Could not open output file");
+    exit(1);
+  }
+  for (int i = 0;; i++) {
+    int ch = fgetc(in);
+    if (ch == EOF) {
+      break;
+    }
+    fprintf(out, " 0x%02x,", ch);
+    if (i % 12 == 11) {
+      fprintf(out, "\n");
+    }
+  }
+  fprintf(out, "\n");
+  fclose(out);
+  fclose(in);
+  return 0;
+}


### PR DESCRIPTION
*Description*: Glow will be easier to distribute if we can package libjit into the library, rather than keeping it as an external file dependency.  This PR implements a simple clone of `xxd -i`, which dumps a binary file as an unsigned char array, and uses it to compile libjit.bc into LLVMIRGen.
*Testing*:  `ninja check`
*Documentation*: N/A

