### PR TITLE
[GraphOptimizer] Move transpose constant folding optimization before merging BatchNorm into Convolution

### DIFF
--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -2015,11 +2015,13 @@ void glow::optimize(Function *F, CompilationMode mode) {
   DCE(F);
 
   if (mode == CompilationMode::Infer) {
-    // Merge batch normalization operations.
-    optimizeBatchNorm(F);
-
     // Constant-fold transpose operations.
     optimizeTranspose(F);
+
+    // Merge batch normalization operations.
+    // Do after transpose constant folding, as weight transposes can prevent
+    // the optimization from triggering.
+    optimizeBatchNorm(F);
   }
 
   // Perform Common Subexpression Elimination.


### PR DESCRIPTION
*Description*:
An internal net model I'm working on has explicit transpose nodes for convolution weights. This prevents BatchNorm + Conv merge optimization from triggering.
The patch moves transpose constant folding before BatchNorm optimization in order to get rid of these transposes and make BatchNorm + Conv merge happen.

*Testing*:
Added a unit test.

*Documentation*:
N/A