### PR TITLE
[cpu] Compile libjit into CPU backend using include-bin

### DIFF
--- a/lib/Backends/CPU/CMakeLists.txt
+++ b/lib/Backends/CPU/CMakeLists.txt
@@ -38,12 +38,18 @@ set_target_properties(CPURuntime
                         OUTPUT_NAME
                           libjit.bc)
 
+add_custom_command(
+  OUTPUT "${CMAKE_BINARY_DIR}/glow/libjit_bc.inc"
+  COMMAND include-bin "${CMAKE_BINARY_DIR}/libjit.bc" "${CMAKE_BINARY_DIR}/glow/libjit_bc.inc"
+  DEPENDS include-bin CPURuntime)
+
 add_library(CPURuntimeNative
               libjit/libjit.cpp
               libjit/libjit_conv.cpp
               libjit/libjit_matmul.cpp)
 
 add_library(CPUBackend
+            "${CMAKE_BINARY_DIR}/glow/libjit_bc.inc"
             AllocationsInfo.cpp
             BundleSaver.cpp
             CommandLine.cpp

--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -136,6 +136,15 @@ void LLVMIRGen::loadBaseAddresses(llvm::IRBuilder<> &builder) {
   offsetsArray_ = F->args().begin() + 3;
 }
 
+/// We compile the standard library (libjit) to LLVM bitcode, and then convert
+/// that binary data to an include file using an external utility (include-bin).
+/// The resulting file is included here to compile the bitcode image into our
+/// library.
+static const unsigned char libjit_bc[] = {
+#include "glow/libjit_bc.inc"
+};
+static const size_t libjit_bc_size = sizeof(libjit_bc);
+
 // Search for the standard library bitcode file on disk and load it into an
 // LLVM module. We search for the standard library around the current executable
 // and also in the current directory.
@@ -146,36 +155,13 @@ loadStandardLibrary(llvm::LLVMContext *ctx, llvm::StringRef filename) {
 
   llvm::SMDiagnostic error;
 
-  auto *envPath = getenv("GLOW_LIBJIT_PATH");
-  if (envPath != nullptr) {
-    return llvm::parseIRFile(envPath, error, *ctx);
-  }
-
-  // Figure out the location of the current executable.
-  auto mainExec =
-      llvm::sys::fs::getMainExecutable(nullptr, (void *)&loadStandardLibrary);
-  llvm::StringRef basePath = parent_path(mainExec);
-
-  // Search for the standard library starting at the location of the executable.
-  // Go up the tree up to three levels (by removing the last directory name).
-  for (int i = 0; i < 3; i++) {
-    llvm::SmallString<256> libPath(basePath);
-    append(libPath, filename);
-    if (llvm::sys::fs::exists(libPath)) {
-      auto res = llvm::parseIRFile(libPath, error, *ctx);
-
-      // If we could not parse the bitcode file then print an error.
-      if (!res.get()) {
-        error.print(mainExec.c_str(), llvm::errs());
-      }
-      return res;
-    }
-
-    // Go up the filesystem tree.
-    basePath = parent_path(basePath);
-  }
-
-  return llvm::parseIRFile(filename, error, *ctx);
+  // Parse the compiled-in image of libjit and return the resulting Module.
+  return llvm::parseIR(
+      llvm::MemoryBufferRef(
+          llvm::StringRef(reinterpret_cast<const char *>(&libjit_bc[0]),
+                          libjit_bc_size),
+          "libjit.bc"),
+      error, *ctx);
 }
 
 /// Register a diagnostics handler that prevents the compiler from printing to

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(ClassGen)
+add_subdirectory(IncludeBin)
 if(PNG_FOUND)
   add_subdirectory(loader)
 endif()

--- a/tools/IncludeBin/CMakeLists.txt
+++ b/tools/IncludeBin/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_executable(include-bin
+               IncludeBin.cpp)

--- a/tools/IncludeBin/IncludeBin.cpp
+++ b/tools/IncludeBin/IncludeBin.cpp
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstdio>
+#include <cstdlib>
+
+/// A simple reimplementation of `xxd -i`.
+///
+/// Usage: include-bin input_file output_file.
+///
+/// Given a binary input file, write an array of hex characters suitable for
+/// inclusion as a C unsigned-char array.  The output looks like:
+///
+/// 0x2f, 0xc5, 0x35, 0x0c, 0xef, 0x7d, 0xea, 0x20, 0x9a, 0x80, 0x31, 0xfa,
+/// 0xdd, 0x98, 0x5e, 0x95, 0xcc, 0xa3, 0xfe, 0x5a, 0xa2, 0x8f, 0xcb, 0x16,
+/// 0x55, 0x14, 0x25, 0xaa, 0xfe, 0x61, 0x0e, 0xb7,
+int main(int argc, char **argv) {
+  if (argc != 3) {
+    fprintf(stderr, "Usage: include-bin input_file output_file\n");
+    exit(1);
+  }
+  FILE *in = fopen(argv[1], "rb");
+  if (!in) {
+    perror("Could not open input file");
+    exit(1);
+  }
+  FILE *out = fopen(argv[2], "w");
+  if (!out) {
+    perror("Could not open output file");
+    exit(1);
+  }
+  for (int i = 0;; i++) {
+    int ch = fgetc(in);
+    if (ch == EOF) {
+      break;
+    }
+    fprintf(out, " 0x%02x,", ch);
+    if (i % 12 == 11) {
+      fprintf(out, "\n");
+    }
+  }
+  fprintf(out, "\n");
+  fclose(out);
+  fclose(in);
+  return 0;
+}


### PR DESCRIPTION
Description: Glow will be easier to distribute if we can package libjit into the library, rather than keeping it as an external file dependency. This PR uses `include-bin` to compile libjit.bc into LLVMIRGen.
Testing: ninja check
Documentation: N/A
