### PR TITLE
[Caffe2] Add support for Copy, EnsureCPUOutput, EnsureDense operators

### DIFF
--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -453,8 +453,10 @@ void Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     return;
   }
 
-  if (typeName == "CopyCPUToMKL" || typeName == "CopyMKLToCPU") {
-    // Glow does not support MKL now, just pass these two ops.
+  if (typeName == "CopyCPUToMKL" || typeName == "CopyMKLToCPU" ||
+      typeName == "Copy" || typeName == "EnsureCPUOutput" ||
+      typeName == "EnsureDense") {
+    // Glow does not support any of these ops now, so implement them as no-ops.
     auto in = getNodeValueOrCreateVariableByName(op.input(0));
     addNodeAsOutput(op, in);
     return;


### PR DESCRIPTION
**Description**
This commit adds support for the `Copy`, `EnsureCPUOutput`, and `EnsureDense`
Caffe2 operators. These operators do not make much sense in the context
of Glow and have been implemented as no-ops.

**Testing**
All unit tests pass.

**Fixes**
This commit fixes #1700.
