### PR TITLE
[Backend][Interpreter] Implement FP16 SoftMax

### DIFF
--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -108,6 +108,7 @@ private:
   void fwdAvgPoolInst_I8Impl(const AvgPoolInst *I);
   template <typename ElemTy>
   void fwdAvgPoolInst_FloatImpl(const AvgPoolInst *I);
+  template <typename ElemTy> void fwdSoftMaxInst_Impl(const SoftMaxInst *I);
   ///@}
 };
 


### PR DESCRIPTION
*Description*
This commit templatizes the implementation of SoftMax and adds the
dispatch code to execute the single precision or half precision
variant for floating point types.

*Testing*
Added test case

Related to #1329 