### PR TITLE
[Backend][Interpreter] Implement FP16 ElementMax

### DIFF
--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -117,6 +117,9 @@ private:
   void fwdElementAddInst_I8Impl(const ElementAddInst *I);
   template <typename ElemTy>
   void fwdElementAddInst_FloatImpl(const ElementAddInst *I);
+
+  void fwdElementMaxInst_I8Impl(const ElementMaxInst *I);
+  void fwdElementMaxInst_FloatImpl(const ElementMaxInst *I);
   ///@}
 };
 

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -119,6 +119,7 @@ private:
   void fwdElementAddInst_FloatImpl(const ElementAddInst *I);
 
   void fwdElementMaxInst_I8Impl(const ElementMaxInst *I);
+  template <typename ElemTy>
   void fwdElementMaxInst_FloatImpl(const ElementMaxInst *I);
   ///@}
 };

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -1175,31 +1175,32 @@ void InterpreterFunction::fwdElementDivInst(const ElementDivInst *I) {
   }
 }
 
-void InterpreterFunction::fwdElementMaxInst(const ElementMaxInst *I) {
-  if (getTensor(I->getLHS())->getType().isQuantizedType()) {
-    auto lhsTy = I->getLHS()->getType();
-    auto rhsTy = I->getRHS()->getType();
-    auto destTy = I->getDest()->getType();
+void InterpreterFunction::fwdElementMaxInst_I8Impl(const ElementMaxInst *I) {
+  assert(getTensor(I->getLHS())->getType().isQuantizedType() &&
+         "Wrong function");
+  auto lhsTy = I->getLHS()->getType();
+  auto rhsTy = I->getRHS()->getType();
+  auto destTy = I->getDest()->getType();
 
-    TensorQuantizationParams lhsQ{lhsTy->getScale(), lhsTy->getOffset()};
-    TensorQuantizationParams rhsQ{rhsTy->getScale(), rhsTy->getOffset()};
-    TensorQuantizationParams destQ{destTy->getScale(), destTy->getOffset()};
+  TensorQuantizationParams lhsQ{lhsTy->getScale(), lhsTy->getOffset()};
+  TensorQuantizationParams rhsQ{rhsTy->getScale(), rhsTy->getOffset()};
+  TensorQuantizationParams destQ{destTy->getScale(), destTy->getOffset()};
 
-    auto outW = getWeightHandle<int8_t>(I->getDest());
-    auto lhsW = getWeightHandle<int8_t>(I->getLHS());
-    auto rhsW = getWeightHandle<int8_t>(I->getRHS());
-    for (size_t i = 0, e = outW.size(); i < e; i++) {
-      // Convert both sides to the destination scale and perform a regular
-      // comparison.
-      int8_t L = quantization::quantize(
-          quantization::dequantize(lhsW.raw(i), lhsQ), destQ);
-      int8_t R = quantization::quantize(
-          quantization::dequantize(rhsW.raw(i), rhsQ), destQ);
-      outW.raw(i) = std::max(L, R);
-    }
-    return;
+  auto outW = getWeightHandle<int8_t>(I->getDest());
+  auto lhsW = getWeightHandle<int8_t>(I->getLHS());
+  auto rhsW = getWeightHandle<int8_t>(I->getRHS());
+  for (size_t i = 0, e = outW.size(); i < e; i++) {
+    // Convert both sides to the destination scale and perform a regular
+    // comparison.
+    int8_t L = quantization::quantize(
+        quantization::dequantize(lhsW.raw(i), lhsQ), destQ);
+    int8_t R = quantization::quantize(
+        quantization::dequantize(rhsW.raw(i), rhsQ), destQ);
+    outW.raw(i) = std::max(L, R);
   }
+}
 
+void InterpreterFunction::fwdElementMaxInst_FloatImpl(const ElementMaxInst *I) {
   auto *lhs = getTensor(I->getLHS());
   auto *rhs = getTensor(I->getRHS());
   auto *out = getTensor(I->getDest());
@@ -1208,6 +1209,16 @@ void InterpreterFunction::fwdElementMaxInst(const ElementMaxInst *I) {
   auto rhsW = rhs->getHandle();
   for (size_t i = 0, e = outW.size(); i < e; i++) {
     outW.raw(i) = std::max(lhsW.raw(i), rhsW.raw(i));
+  }
+}
+
+void InterpreterFunction::fwdElementMaxInst(const ElementMaxInst *I) {
+  if (getTensor(I->getLHS())->getType().isQuantizedType()) {
+    fwdElementMaxInst_I8Impl(I);
+  } else if (I->getLHS()->getType()->getElementType() == ElemKind::FloatTy) {
+    fwdElementMaxInst_FloatImpl(I);
+  } else {
+    llvm_unreachable("Type is not supported");
   }
 }
 

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -1643,6 +1643,32 @@ TEST_P(InterpAndCPU, EntropyLossTest) {
   EXPECT_NEAR(R.at({0}), -log(0.5) - log(0.3), 0.1);
 }
 
+/// Check that the max operator works properly.
+TEST_P(Operator, Max) {
+  PseudoRNG PRNG;
+
+  auto *inputA =
+      mod_.createPlaceholder(ElemKind::FloatTy, {1, 3, 3, 1}, "A", false);
+  ctx_.allocate(inputA)->getHandle<float>().randomize(-3.0, 3.0, PRNG);
+  auto *inputB =
+      mod_.createPlaceholder(ElemKind::FloatTy, {1, 3, 3, 1}, "B", false);
+  ctx_.allocate(inputB)->getHandle<float>().randomize(-3.0, 3.0, PRNG);
+  auto *Max = F_->createMax("max", inputA, inputB);
+  auto *S = F_->createSave(ctx_, "save", Max);
+  ctx_.allocate(S->getPlaceholder());
+
+  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.run();
+
+  auto result = ctx_.get(S->getPlaceholder())->getHandle<float>();
+  auto handleA = ctx_.get(inputA)->getHandle<float>();
+  auto handleB = ctx_.get(inputB)->getHandle<float>();
+  ASSERT_EQ(result.size(), handleA.size());
+  for (size_t idx = 0, end = result.size(); idx != end; ++idx) {
+    EXPECT_EQ(result.raw(idx), std::max(handleA.raw(idx), handleB.raw(idx)));
+  }
+}
+
 TEST_P(Operator, RescaleNode) {
   // Check the outputs of the RescaleQuantized operation.
   auto *input = mod_.createPlaceholder(ElemKind::Int8QTy, {4, 10}, 0.4, -3,


### PR DESCRIPTION
*Description*
This commit templatizes the implementation of ElementMax and adds the
dispatch code to execute the single precision or half precision
variant for floating point types.

*Testing*
Added test case

Related to #1329