### PR TITLE
[Backend][Interpreter] Implement FP16 BatchedAdd

### DIFF
--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -123,6 +123,7 @@ private:
   void fwdElementMaxInst_FloatImpl(const ElementMaxInst *I);
 
   void fwdBatchedAddInst_I8Impl(const BatchedAddInst *I);
+  template <typename ElemTy>
   void fwdBatchedAddInst_FloatImpl(const BatchedAddInst *I);
   ///@}
 };

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -121,6 +121,9 @@ private:
   void fwdElementMaxInst_I8Impl(const ElementMaxInst *I);
   template <typename ElemTy>
   void fwdElementMaxInst_FloatImpl(const ElementMaxInst *I);
+
+  void fwdBatchedAddInst_I8Impl(const BatchedAddInst *I);
+  void fwdBatchedAddInst_FloatImpl(const BatchedAddInst *I);
   ///@}
 };
 

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -1502,52 +1502,55 @@ void InterpreterFunction::fwdRowwiseQuantizedFullyConnectedInst(
 //                       Batched operations
 //===----------------------------------------------------------------------===//
 
-void InterpreterFunction::fwdBatchedAddInst(const glow::BatchedAddInst *I) {
-  if (getTensor(I->getBatch())->getType().isQuantizedType()) {
-    auto batch = getWeightHandle<int8_t>(I->getBatch());
-    auto slice = getWeightHandle<int8_t>(I->getSlice());
-    auto dest = getWeightHandle<int8_t>(I->getDest());
+void InterpreterFunction::fwdBatchedAddInst_I8Impl(
+    const glow::BatchedAddInst *I) {
+  assert(getTensor(I->getBatch())->getType().isQuantizedType() &&
+         "Wrong function");
+  auto batch = getWeightHandle<int8_t>(I->getBatch());
+  auto slice = getWeightHandle<int8_t>(I->getSlice());
+  auto dest = getWeightHandle<int8_t>(I->getDest());
 
-    auto batchTy = I->getBatch()->getType();
-    auto sliceTy = I->getSlice()->getType();
-    auto destTy = I->getDest()->getType();
+  auto batchTy = I->getBatch()->getType();
+  auto sliceTy = I->getSlice()->getType();
+  auto destTy = I->getDest()->getType();
 
-    float sliceScale = sliceTy->getScale();
-    float batchScale = batchTy->getScale();
-    float destScale = destTy->getScale();
+  float sliceScale = sliceTy->getScale();
+  float batchScale = batchTy->getScale();
+  float destScale = destTy->getScale();
 
-    int32_t sliceOffset = sliceTy->getOffset();
-    int32_t batchOffset = batchTy->getOffset();
-    int32_t destOffset = destTy->getOffset();
+  int32_t sliceOffset = sliceTy->getOffset();
+  int32_t batchOffset = batchTy->getOffset();
+  int32_t destOffset = destTy->getOffset();
 
-    auto bdim = flattenCdr(batch.dims());
-    assert(slice.size() == bdim.second && "Invalid slice size");
-    assert(batch.dims().drop_front() == slice.dims() && "Invalid batch size");
+  auto bdim = flattenCdr(batch.dims());
+  assert(slice.size() == bdim.second && "Invalid slice size");
+  assert(batch.dims().drop_front() == slice.dims() && "Invalid batch size");
 
-    // For each layer in the batch:
-    for (size_t n = 0; n < bdim.first; n++) {
-      size_t base = batch.getElementPtr({n});
+  // For each layer in the batch:
+  for (size_t n = 0; n < bdim.first; n++) {
+    size_t base = batch.getElementPtr({n});
 
-      // For each element in the slice.
-      for (size_t i = 0; i < bdim.second; i++) {
-        int32_t batchVal = batch.raw(base + i);
-        int32_t sliceVal = slice.raw(i);
-        // We increase the size of the integer up to 16 bits for more accurate
-        // arithmetic.
-        const float largeScale = float(1) / (1 << 15);
-        // Scale both sides from 8-bit to 16-bits.
-        int32_t B = std::round(float(batchVal - batchOffset) *
-                               (batchScale / largeScale));
-        int32_t S = std::round(float(sliceVal - sliceOffset) *
-                               (sliceScale / largeScale));
-        int32_t R = B + S;
-        dest.raw(base + i) = quantization::clip<int32_t, int8_t>(
-            std::round(float(R) * (largeScale / destScale) + destOffset));
-      }
+    // For each element in the slice.
+    for (size_t i = 0; i < bdim.second; i++) {
+      int32_t batchVal = batch.raw(base + i);
+      int32_t sliceVal = slice.raw(i);
+      // We increase the size of the integer up to 16 bits for more accurate
+      // arithmetic.
+      const float largeScale = float(1) / (1 << 15);
+      // Scale both sides from 8-bit to 16-bits.
+      int32_t B =
+          std::round(float(batchVal - batchOffset) * (batchScale / largeScale));
+      int32_t S =
+          std::round(float(sliceVal - sliceOffset) * (sliceScale / largeScale));
+      int32_t R = B + S;
+      dest.raw(base + i) = quantization::clip<int32_t, int8_t>(
+          std::round(float(R) * (largeScale / destScale) + destOffset));
     }
-    return;
   }
+}
 
+void InterpreterFunction::fwdBatchedAddInst_FloatImpl(
+    const glow::BatchedAddInst *I) {
   auto batch = getWeightHandle(I->getBatch());
   auto slice = getWeightHandle(I->getSlice());
   auto dest = getWeightHandle(I->getDest());
@@ -1567,6 +1570,15 @@ void InterpreterFunction::fwdBatchedAddInst(const glow::BatchedAddInst *I) {
   }
 }
 
+void InterpreterFunction::fwdBatchedAddInst(const glow::BatchedAddInst *I) {
+  if (getTensor(I->getBatch())->getType().isQuantizedType()) {
+    fwdBatchedAddInst_I8Impl(I);
+  } else if (I->getBatch()->getType()->getElementType() == ElemKind::FloatTy) {
+    fwdBatchedAddInst_FloatImpl(I);
+  } else {
+    llvm_unreachable("Type is not supported");
+  }
+}
 void InterpreterFunction::fwdBatchedReduceAddInst(
     const glow::BatchedReduceAddInst *I) {
   static_assert(max_tensor_dimensions == 6,

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -3225,6 +3225,33 @@ TEST_P(InterpAndCPU, Int8Sigmoid) {
   }
 }
 
+/// Check that the batch add operator works properly.
+TEST_P(Operator, BatchAdd) {
+  PseudoRNG PRNG;
+
+  auto *input =
+      mod_.createPlaceholder(ElemKind::FloatTy, {13, 3, 3}, "A", false);
+  ctx_.allocate(input)->getHandle<float>().randomize(-3.0, 3.0, PRNG);
+  auto *slice =
+      mod_.createPlaceholder(ElemKind::FloatTy, {3, 3}, "slice", false);
+  ctx_.allocate(slice)->getHandle<float>().randomize(-3.0, 3.0, PRNG);
+  auto *batchAdd = F_->createBatchedAdd("batchAdd", input, slice);
+  auto *S = F_->createSave(ctx_, "save", batchAdd);
+  ctx_.allocate(S->getPlaceholder());
+
+  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.run();
+
+  auto result = ctx_.get(S->getPlaceholder())->getHandle<float>();
+  auto handleInput = ctx_.get(input)->getHandle<float>();
+  auto handleSlice = ctx_.get(slice)->getHandle<float>();
+  ASSERT_EQ(result.size(), handleInput.size());
+  for (size_t idx = 0, end = result.size(); idx != end; ++idx) {
+    EXPECT_EQ(result.raw(idx),
+              handleInput.raw(idx) + handleSlice.raw(idx % handleSlice.size()));
+  }
+}
+
 TEST_P(InterpAndCPU, IntLookupTable) {
   constexpr size_t size = 6;
   auto *input =

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -3252,6 +3252,33 @@ TEST_P(Operator, BatchAdd) {
   }
 }
 
+/// Check that the batch add operator works properly for FP16.
+TEST_P(InterpOnly, FP16BatchAdd) {
+  PseudoRNG PRNG;
+
+  auto *input =
+      mod_.createPlaceholder(ElemKind::Float16Ty, {13, 3, 3}, "A", false);
+  ctx_.allocate(input)->getHandle<float16_t>().randomize(-3.0, 3.0, PRNG);
+  auto *slice =
+      mod_.createPlaceholder(ElemKind::Float16Ty, {3, 3}, "slice", false);
+  ctx_.allocate(slice)->getHandle<float16_t>().randomize(-3.0, 3.0, PRNG);
+  auto *batchAdd = F_->createBatchedAdd("batchAdd", input, slice);
+  auto *S = F_->createSave(ctx_, "save", batchAdd);
+  ctx_.allocate(S->getPlaceholder());
+
+  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.run();
+
+  auto result = ctx_.get(S->getPlaceholder())->getHandle<float16_t>();
+  auto handleInput = ctx_.get(input)->getHandle<float16_t>();
+  auto handleSlice = ctx_.get(slice)->getHandle<float16_t>();
+  ASSERT_EQ(result.size(), handleInput.size());
+  for (size_t idx = 0, end = result.size(); idx != end; ++idx) {
+    EXPECT_EQ(result.raw(idx),
+              handleInput.raw(idx) + handleSlice.raw(idx % handleSlice.size()));
+  }
+}
+
 TEST_P(InterpAndCPU, IntLookupTable) {
   constexpr size_t size = 6;
   auto *input =


### PR DESCRIPTION
*Description*
This commit templatizes the implementation of BatchedAdd and adds the
dispatch code to execute the single precision or half precision
variant for floating point types.

*Testing*
Added test case

Related to #1329