### PR TITLE
[libjit] Make BroadcastFloat8 compatible with gcc 4.8.5

### DIFF
--- a/lib/Backends/CPU/libjit/libjit_defs.h
+++ b/lib/Backends/CPU/libjit/libjit_defs.h
@@ -45,7 +45,7 @@ using float8 = float __attribute__((vector_size(32)));
 #if defined(__clang__)
 #define BroadcastFloat8(VAL) ((float8)(VAL))
 #elif defined(__GNUC__) || defined(__GNUG__)
-#define BroadcastFloat8(VAL) ((VAL) - (float8){})
+#define BroadcastFloat8(VAL) ((VAL) - (float8){0})
 #endif
 
 #define MIN(a, b) (((a) < (b)) ? (a) : (b))


### PR DESCRIPTION
*Description*: Surprisingly, this was the only blocking issue I hit when trying to compile with gcc 4.8.5, which is the CentOS 7 default.
*Testing*: ninja check
