### PR TITLE
*WIP*[Quantization] Enable rowwise quantized FC.

### DIFF
--- a/examples/fr2en.cpp
+++ b/examples/fr2en.cpp
@@ -165,7 +165,7 @@ struct Model {
 
       // Quantize the graph based on the captured profile.
       auto *Q =
-          glow::quantization::quantizeFunction(EE_, quantizationInfos, F_);
+          glow::quantization::quantizeFunction(EE_, quantizationInfos, F_, ctx);
 
       // Erase the original function so that the redundant variables that are
       // only referenced by the original function will be removed.

--- a/include/glow/Quantization/Quantization.h
+++ b/include/glow/Quantization/Quantization.h
@@ -71,7 +71,7 @@ generateNodeQuantizationInfos(Context &ctx, const Function *F,
 Function *
 quantizeFunction(const ExecutionEngine &EE,
                  llvm::ArrayRef<NodeQuantizationInfo> quantizationInfos,
-                 Function *F, llvm::StringRef newFuncName = "",
+                 Function *F, Context &ctx, llvm::StringRef newFuncName = "",
                  const KindSet &doNotQuantizeKinds = {});
 
 } // namespace quantization

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -189,6 +189,7 @@ bool CPUBackend::isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const {
     case Kinded::Kind::TileNodeKind:
     case Kinded::Kind::TopKNodeKind:
     case Kinded::Kind::TransposeNodeKind:
+    case Kinded::Kind::RowwiseQuantizedFullyConnectedNodeKind:
       return true;
     default:
       return false;

--- a/tests/unittests/MLTest.cpp
+++ b/tests/unittests/MLTest.cpp
@@ -1059,7 +1059,7 @@ TEST_P(InterpreterAndCPU, convNetForImageRecognition) {
   // Get the quantization info and build the new quantized graph.
   std::vector<NodeQuantizationInfo> QI =
       quantization::generateNodeQuantizationInfos(ctx, PF);
-  Function *QP = quantization::quantizeFunction(EE, QI, F);
+  Function *QP = quantization::quantizeFunction(EE, QI, F, ctx);
 
   // Evaluate on the quantized function:
   // Set the execution backend to the backend that we test.
@@ -1164,7 +1164,7 @@ TEST_P(InterpreterAndCPU, testFindPixelRegression) {
   std::vector<NodeQuantizationInfo> QI =
       quantization::generateNodeQuantizationInfos(ctx, PF);
 
-  Function *QP = quantization::quantizeFunction(EE, QI, F);
+  Function *QP = quantization::quantizeFunction(EE, QI, F, ctx);
 
   // -- STEP3 - evaluate the quantized function. --
 

--- a/tests/unittests/quantizationTest.cpp
+++ b/tests/unittests/quantizationTest.cpp
@@ -132,7 +132,7 @@ TEST(Quantization, quantizeGraph) {
       {NodeQuantizationInfo::generateNodeOutputName(FC->getName()), {0.6f, 0}},
   };
 
-  F = quantization::quantizeFunction(EE, QI, F);
+  F = quantization::quantizeFunction(EE, QI, F, ctx);
 
   // Make sure that graph can be compiled and run.
   EE.compile(CompilationMode::Infer, F, ctx);
@@ -158,7 +158,7 @@ TEST(Quantization, quantizeReLU) {
        {0.2f, 0}},
       {NodeQuantizationInfo::generateNodeOutputName(relu->getName()),
        {0.2f, -128}}};
-  F = quantization::quantizeFunction(EE, QI, F);
+  F = quantization::quantizeFunction(EE, QI, F, ctx);
   EE.compile(CompilationMode::Infer, F, ctx);
 
   auto *save = llvm::cast<SaveNode>(F->getNodeByName("ret"));
@@ -255,7 +255,7 @@ TEST_P(Operator, end2end) {
   // STEP2 - Use the profile to quantize a network.
   SaveNode *result2 = cast<SaveNode>(F2->getNodeByName("save"));
 
-  F2 = quantization::quantizeFunction(backendSpecificEE, QI, F2);
+  F2 = quantization::quantizeFunction(backendSpecificEE, QI, F2, ctx);
   backendSpecificEE.compile(CompilationMode::Infer, F2, ctx);
   backendSpecificEE.run();
 
@@ -390,7 +390,7 @@ TEST_P(Operator, end2endGRU) {
   // STEP2 - Use the profile to quantize a network.
   SaveNode *result2 = cast<SaveNode>(F2->getNodeByName("save"));
 
-  F2 = quantization::quantizeFunction(backendSpecificEE, QI, F2);
+  F2 = quantization::quantizeFunction(backendSpecificEE, QI, F2, ctx);
   backendSpecificEE.compile(CompilationMode::Infer, F2, ctx);
   backendSpecificEE.run();
 
@@ -712,7 +712,7 @@ TEST(Quantization, quantizeSoftmaxAndLRN) {
       {NodeQuantizationInfo::generateNodeOutputName(SM->getName()), {0.4f, 0}},
   };
 
-  F = quantization::quantizeFunction(EE, QI, F);
+  F = quantization::quantizeFunction(EE, QI, F, ctx);
 
   auto *qLRN = cast<LocalResponseNormalizationNode>(F->getNodeByName("LRN1"));
   auto *qSM = cast<SoftMaxNode>(F->getNodeByName("softmax1"));
@@ -754,8 +754,8 @@ TEST(Quantization, quantizeGraphPartially) {
   KindSet doNotQuantize;
   doNotQuantize.insert(Kinded::Kind::TanhNodeKind);
 
-  auto *QF =
-      quantization::quantizeFunction(EE, QI, F, "_quantized", doNotQuantize);
+  auto *QF = quantization::quantizeFunction(EE, QI, F, ctx, "_quantized",
+                                            doNotQuantize);
   QF->getParent()->eraseFunction(F);
   F = QF;
 
@@ -835,8 +835,8 @@ TEST(Quantization, quantizeGraphPartiallyMultipleNodes) {
   KindSet doNotQuantize;
   doNotQuantize.insert(Kinded::Kind::TanhNodeKind);
 
-  auto *QF =
-      quantization::quantizeFunction(EE, QI, F, "_quantized", doNotQuantize);
+  auto *QF = quantization::quantizeFunction(EE, QI, F, ctx, "_quantized",
+                                            doNotQuantize);
   QF->getParent()->eraseFunction(F);
   F = QF;
 
@@ -926,8 +926,8 @@ TEST(Quantization, quantizeGraphPartiallyMultipleKinds) {
   doNotQuantize.insert(Kinded::Kind::TanhNodeKind);
   doNotQuantize.insert(Kinded::Kind::AddNodeKind);
 
-  auto *QF =
-      quantization::quantizeFunction(EE, QI, F, "_quantized", doNotQuantize);
+  auto *QF = quantization::quantizeFunction(EE, QI, F, ctx, "_quantized",
+                                            doNotQuantize);
   QF->getParent()->eraseFunction(F);
   F = QF;
 

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -243,7 +243,7 @@ void Loader::compile(Context &ctx) {
     }
 
     // Quantize the graph based on the captured profile.
-    auto *Q = quantization::quantizeFunction(EE_, quantizationInfos, F_,
+    auto *Q = quantization::quantizeFunction(EE_, quantizationInfos, F_, ctx,
                                              oldName, doNotQuantizeKinds);
 
     // Erase the original function so that the redundant variables that are only


### PR DESCRIPTION
*Description*:

Now if a FC is need to be quantized, we create a RowwiseQuantizedFullyConnected node instead based on the control flag.

*Testing*: 
ninja test. Also instrumented code to make sure that rowwise quantization is executed.

*Documentation*:
https://github.com/pytorch/glow/issues/1402
[Optional Fixes #1402]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
