### PR TITLE
[NFC][unittests][GraphScheduler] Avoid the use of a temporary std::vector

### DIFF
--- a/tests/unittests/graphSchedulerTest.cpp
+++ b/tests/unittests/graphSchedulerTest.cpp
@@ -79,13 +79,11 @@ TEST(GraphScheduler, testMaxSizeLessThanResultSize) {
 
   // Find the positions of sliceBig and concatSmall in
   // the schedule.
-  std::vector<glow::Node *> vectorSchedule(schedule.begin(), schedule.end());
-  auto concatSmallIt =
-      std::find(vectorSchedule.begin(), vectorSchedule.end(), concatSmall);
-  auto sliceBigIt =
-      std::find(vectorSchedule.begin(), vectorSchedule.end(), sliceBig);
+  auto concatSmallIt = std::find(schedule.begin(), schedule.end(), concatSmall);
+  auto sliceBigIt = std::find(schedule.begin(), schedule.end(), sliceBig);
 
   // For the reason given above, sliceBig should be scheduled
   // before concatSmall.
-  EXPECT_LT(sliceBigIt, concatSmallIt);
+  EXPECT_LT(std::distance(schedule.begin(), sliceBigIt),
+            std::distance(schedule.begin(), concatSmallIt));
 }


### PR DESCRIPTION
*Description*
We use a temporary std::vector because we compare directly two iterator
to check which instruction comes first in the final schedule.
Instead if we compare the distance from the beginning for each
iterator, we don't need our iterator to support random accesses and
we can avoid the temporary object.

This is what this patch does.

NFC
