### PR TITLE
[Placeholder] Remove the ability to save into variables.

### DIFF
--- a/include/glow/ExecutionEngine/ExecutionEngine.h
+++ b/include/glow/ExecutionEngine/ExecutionEngine.h
@@ -70,7 +70,7 @@ public:
   /// target. This method should be invoked before the run method. The context
   /// \p ctx contains the mapping between symbolic values to concrete backing
   /// tensors.
-  void compile(CompilationMode mode, Function *F, const Context &ctx);
+  void compile(CompilationMode mode, Function *F, Context &ctx);
 
   /// Save a bundle for a standalone execution. This method takes care of
   /// everything when preparing the bundle for saving. There is no need to

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -513,8 +513,8 @@ public:
                                  NodeValue lengths);
 
   SaveNode *createSave(llvm::StringRef name, NodeValue input);
-  SaveNode *createSavePH(llvm::StringRef name, NodeValue input);
-  SaveNode *createSave(llvm::StringRef name, NodeValue input, Storage *output);
+  SaveNode *createSave(llvm::StringRef name, NodeValue input,
+                       Placeholder *output);
 
   /// Create quantization profile node named \p name for the output tensor from
   /// \p input in context \p ctx. Capture observed node name in quantization

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -203,9 +203,10 @@ void ExecutionEngine::optimizeFunction(CompilationMode mode, Function *F) {
   }
 }
 
-void ExecutionEngine::compile(CompilationMode mode, Function *F,
-                              const Context &ctx) {
+void ExecutionEngine::compile(CompilationMode mode, Function *F, Context &ctx) {
   optimizeFunction(mode, F);
+  // Make sure that the context has backing tensors for all placeholders.
+  ctx.allocate(M_.getPlaceholders());
   function_ = backend_->compile(F, ctx);
 }
 

--- a/lib/Graph/Grad.cpp
+++ b/lib/Graph/Grad.cpp
@@ -240,7 +240,7 @@ Function *glow::differentiate(Function *F, const TrainingConfig &conf,
       if (map.hasGradient(PH)) {
         std::string nodeName = "_grad_" + PH->getName().str();
         // Save the gradient and return the destination variable.
-        auto *saveNode = G->createSavePH(nodeName, map.getGradient(PH));
+        auto *saveNode = G->createSave(nodeName, map.getGradient(PH));
         Placeholder *GradV = saveNode->getPlaceholder();
         varGrads->push_back({PH, GradV});
       }

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1270,21 +1270,14 @@ Function::createSparseLengthsWeightedSum(llvm::StringRef name, NodeValue data,
                                                   indices, lengths));
 }
 
-SaveNode *Function::createSavePH(llvm::StringRef name, NodeValue input) {
+SaveNode *Function::createSave(llvm::StringRef name, NodeValue input) {
   auto *dest = getParent()->createPlaceholder(input.getType(), name, false);
 
   return addNode(new SaveNode(name, input, dest));
 }
 
-SaveNode *Function::createSave(llvm::StringRef name, NodeValue input) {
-  auto *dest = getParent()->createVariable(input.getType(), name,
-                                           VisibilityKind::Public, false);
-
-  return addNode(new SaveNode(name, input, dest));
-}
-
 SaveNode *Function::createSave(llvm::StringRef name, NodeValue input,
-                               Storage *output) {
+                               Placeholder *output) {
   return addNode(new SaveNode(name, input, output));
 }
 

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -621,7 +621,7 @@ void Caffe2ModelLoader::loadNetwork(caffe2::NetDef &net) {
   for (int i = 0; i < net.external_output_size(); i++) {
     auto &outputName = net.external_output(i);
     auto r = getNodeValueByName(outputName);
-    auto *SN = G_.createSavePH("save_" + outputName, r);
+    auto *SN = G_.createSave("save_" + outputName, r);
     outputVarsByName_[outputName] = SN->getPlaceholder();
   }
 }

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -503,7 +503,7 @@ bool ONNXModelLoader::setOutputNodes(ONNX_NAMESPACE::GraphProto &net) {
   for (int i = 0; i < net.output_size(); i++) {
     const auto &outputName = net.output(i).name();
     auto r = getNodeValueByName(outputName);
-    SaveNode *SN = G_.createSavePH("save_" + outputName, r);
+    SaveNode *SN = G_.createSave("save_" + outputName, r);
     outputVarsByName_[outputName] = SN->getPlaceholder();
   }
 

--- a/lib/Optimizer/Lower.cpp
+++ b/lib/Optimizer/Lower.cpp
@@ -336,9 +336,8 @@ static void lowerSGDNode(Function *F, const SGDNode &SGD) {
   // http://ufldl.stanford.edu/tutorial/supervised/
   // OptimizationStochasticGradientDescent/
   if (momentum > 0.0) {
-    Variable *Gsum = F->getParent()->createVariable(
-        W.getType(), "gsum", VisibilityKind::Private, true);
-    Gsum->getPayload().zero();
+    Placeholder *Gsum =
+        F->getParent()->createPlaceholder(W.getType(), "gsum", false);
 
     auto *momentumSplat = F->createSplat("learningRateSplat", type, momentum);
     auto *GsumMult = F->createMul("GsumMult", momentumSplat, Gsum);

--- a/lib/Optimizer/Partition.cpp
+++ b/lib/Optimizer/Partition.cpp
@@ -151,7 +151,7 @@ FunctionDAG doPartitioning(Function *F, NodeFunctionMap &mapping) {
         }
 
         // Create a new variable to represent this dependence.
-        auto *save = inputF->createSavePH("tmp", input);
+        auto *save = inputF->createSave("tmp", input);
         auto *tmp = save->getPlaceholder();
         variables[input.getNode()] = tmp;
         N.setNthInput(inp, tmp);

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -41,14 +41,9 @@ int main(int argc, char **argv) {
   BB.declareNode("Variable");
   BB.declareNode("Placeholder");
 
-  // Notice: As soon as we finish the migration from bound-variables to unbound
-  // placeholders we'll need to remove the getVariable() API. See issue #1334.
   BB.newNode("Save")
       .addInput("Input")
       .addInput("Output")
-      .addExtraMethod("Variable *getVariable() const;",
-                      "Variable *SaveNode::getVariable() const { return "
-                      "llvm::cast<Variable>(Output_.getNode()); };")
       .addExtraMethod("Placeholder *getPlaceholder() const;",
                       "Placeholder *SaveNode::getPlaceholder() const { return "
                       "llvm::cast<Placeholder>(Output_.getNode()); };")


### PR DESCRIPTION
*Description*:

1.    [Placeholder] Remove the support for variables from SaveNode.

 2. [Placeholder] Remove the ability to create SaveNode that saves into a variable.
    
    This commit removes the SaveNode constructor that saves into a variable.
    It also fixes the lowering method and makes it create a placeholder for
    the GSUM storage.  It also renames createSaveNodePH into createSaveNode.
    
    At the moment we need to initialize the context after lowering because
    lowering creates new placeholders. When we migrate the context into the
    execution method we'll be able to move the initialization outside of the
    compilation code.

*Testing*: Ran ninja check and run.sh
*Documentation*: None.

#1334 