### PR TITLE
[travis] Run unopt only for debug build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,4 +72,4 @@ script:
  - keep_alive &
  - ninja all
  - CTEST_PARALLEL_LEVEL=2 ninja test || ( cat Testing/Temporary/LastTest.log && exit 1 )
- - CTEST_PARALLEL_LEVEL=2 ninja test_unopt
+ - if [ "$TEST_NAME" = "DEBUG" ]; then CTEST_PARALLEL_LEVEL=2 ninja test_unopt; fi


### PR DESCRIPTION
*Description*:
As part of the CI we run tests with Glow compiler optimizations turned off.
This PR enables such tests only for DEBUG builds but not for ASAN.

This speeds up ASAN run from 40+ to 23 mins.

*Testing*:
CI

*Documentation*:
N/A