### PR TITLE
[ONNXIFI] Add a getter to silence the unused var warning. NFC.

### DIFF
--- a/lib/Onnxifi/Base.h
+++ b/lib/Onnxifi/Base.h
@@ -45,6 +45,9 @@ public:
   /// \returns Execution Engine associated with the Backend.
   glow::ExecutionEngine &getEE() { return executionEngine_; }
 
+  /// \returns the backend id.
+  int getID() { return id_; }
+
 private:
   int id_;
   glow::ExecutionEngine executionEngine_;


### PR DESCRIPTION
*Description*: [ONNXIFI] Add a getter to silence the unused var warning. NFC.
*Testing*: ninja check
*Documentation*: none