### PR TITLE
 Generate OpenCL kernel inc header files from original OpenCL kernel sources directly using the new include-bin utility

### DIFF
--- a/lib/Backends/OpenCL/CMakeLists.txt
+++ b/lib/Backends/OpenCL/CMakeLists.txt
@@ -1,4 +1,30 @@
+add_custom_command(
+  OUTPUT "${CMAKE_BINARY_DIR}/glow/kernels.inc"
+  COMMAND include-bin 
+          "${CMAKE_CURRENT_SOURCE_DIR}/kernels.cl"
+          "${CMAKE_BINARY_DIR}/glow/kernels.inc"
+  DEPENDS include-bin CPURuntime "${CMAKE_CURRENT_SOURCE_DIR}/kernels.cl")
+
+add_custom_command(
+  OUTPUT "${CMAKE_BINARY_DIR}/glow/kernels_fwd_conv.inc"
+  COMMAND include-bin
+          "${CMAKE_CURRENT_SOURCE_DIR}/kernels_fwd_conv.cl"
+          "${CMAKE_BINARY_DIR}/glow/kernels_fwd_conv.inc"
+  DEPENDS include-bin CPURuntime
+          "${CMAKE_CURRENT_SOURCE_DIR}/kernels_fwd_conv.cl")
+
+add_custom_command(
+  OUTPUT "${CMAKE_BINARY_DIR}/glow/kernels_fwd_quantized_conv.inc"
+  COMMAND include-bin
+          "${CMAKE_CURRENT_SOURCE_DIR}/kernels_fwd_quantized_conv.cl"
+          "${CMAKE_BINARY_DIR}/glow/kernels_fwd_quantized_conv.inc"
+  DEPENDS include-bin CPURuntime
+          "${CMAKE_CURRENT_SOURCE_DIR}/kernels_fwd_quantized_conv.cl")
+
 add_library(OpenCL
+            "${CMAKE_BINARY_DIR}/glow/kernels.inc"
+            "${CMAKE_BINARY_DIR}/glow/kernels_fwd_conv.inc"
+            "${CMAKE_BINARY_DIR}/glow/kernels_fwd_quantized_conv.inc" 
             OpenCL.cpp
             Transforms.cpp)
 

--- a/lib/Backends/OpenCL/kernels.cl
+++ b/lib/Backends/OpenCL/kernels.cl
@@ -1,6 +1,3 @@
-
-static const char *SHADER_CODE = R"(
-
 /// This type is always 32 bits.
 typedef unsigned cl_uint32_t;
 /// This type is always 64 bits.
@@ -21,10 +18,10 @@ typedef cl_uint64_t cl_host_size_t;
 typedef cl_uint32_t cl_host_size_t;
 #else
 #error "Unsupported size of size_t on the host side"
-#endif 
+#endif
 
-// The types of elements should be always matching the definitions of
-// ShapeNHWC in Type.h
+/// The types of elements should be always matching the definitions of
+/// ShapeNHWC in Type.h
 typedef struct {
   cl_host_size_t n; // Number of samples
   cl_host_size_t h; // Height
@@ -44,7 +41,7 @@ typedef struct {
   cl_host_size_t width;
 } ShapeHW;
 
-// Helper struct that contains the information for quantization.
+/// Helper struct that contains the information for quantization.
 typedef struct {
   cl_int32_t pre;
   cl_int32_t post;
@@ -52,8 +49,8 @@ typedef struct {
   cl_int32_t offset;
 } QuantizationTransform32To8;
 
-// The types of elements should be always matching the definitions of
-// PaddingTLBR in Type.h
+/// The types of elements should be always matching the definitions of
+/// PaddingTLBR in Type.h
 typedef struct {
   cl_host_size_t top;
   cl_host_size_t left;
@@ -318,12 +315,12 @@ __kernel void dequantizeW(__global void *mem, cl_uint32_t dest, cl_uint32_t src,
   __kernel void name##_i8K(__global cl_int8_t *dest, __global cl_int8_t *lhs,  \
                            __global cl_int8_t *rhs, cl_int32_t destOffset,     \
                            cl_int32_t lhsOffset, cl_int32_t rhsOffset,         \
-                           cl_int32_t pre, cl_int32_t post, cl_int32_t scale) {\
+                           cl_int32_t pre, cl_int32_t post,                    \
+                           cl_int32_t scale) {                                 \
     size_t i = get_global_id(0);                                               \
     cl_int32_t LHS = lhs[i] - lhsOffset;                                       \
     cl_int32_t RHS = rhs[i] - rhsOffset;                                       \
-    dest[i] =                                                                  \
-        clip(scale_i32i8((body), pre, post, scale, destOffset));               \
+    dest[i] = clip(scale_i32i8((body), pre, post, scale, destOffset));         \
   }                                                                            \
   __kernel void name##_i8W(                                                    \
       __global void *mem, cl_uint32_t dest, cl_uint32_t lhs, cl_uint32_t rhs,  \
@@ -1425,5 +1422,3 @@ __kernel void scatterassignW(__global void *mem, cl_uint32_t data,
                              cl_uint32_t sliceSize) {
   scatterassignK(&mem[data], &mem[indices], &mem[slices], sliceSize);
 }
-
-)";

--- a/lib/Backends/OpenCL/kernels_fwd_conv.cl
+++ b/lib/Backends/OpenCL/kernels_fwd_conv.cl
@@ -1,4 +1,4 @@
-/// Kernels for the forward convolution.
+// Kernels for the forward convolution.
 
 // This is a parameterized convolution kernel heavily based on the kernels
 // produced by libDNN (https://github.com/naibaf7/libdnn). The libDNN library
@@ -28,7 +28,6 @@
 // VWN - vector width in dimension N.
 // VWM - vector width in dimension M.
 
-static const char *FWD_CONV_CODE = R"(
 #define Dtype float
 #define Dtype1 float
 #define Dtype2 float2
@@ -319,4 +318,3 @@ __kernel
     }
   }
 }
-)";

--- a/lib/Backends/OpenCL/kernels_fwd_quantized_conv.cl
+++ b/lib/Backends/OpenCL/kernels_fwd_quantized_conv.cl
@@ -1,4 +1,4 @@
-/// Kernels for the quantized forward convolution.
+// Kernels for the quantized forward convolution.
 // Quantized version of kernels_fwd_conv.cl
 // The kernel is parameterized by means of macro-definitions, which
 // define such propeties like size of the filter, padding, stride,
@@ -23,7 +23,6 @@
 // VWN - vector width in dimension N.
 // VWM - vector width in dimension M.
 
-static const char *FWD_CONV_QUANTIZED_CODE = R"(
 #define Dtype char
 #define Dtype1 char
 #define Dtype2 char2
@@ -328,4 +327,3 @@ __kernel
     }
   }
 }
-)";

--- a/utils/format.sh
+++ b/utils/format.sh
@@ -17,6 +17,7 @@ fix_format() {
   find lib tests/unittests/ tools/ include examples \
     -name \*.h -print0 \
     -o -name \*.cpp -print0 \
+    -o -name \*.cl -print0 \
   | xargs -0 -P8 -n1 $CLANG_COMMAND -i;
 }
 


### PR DESCRIPTION
*Description*:
It is now possible to treat the OpenCL sources as real C source files in the editors, formatting tools, etc.

It should also solve issues with compilers which could not handle raw string literals that are too long.

Also take the opportunity to make format.sh run on the OpenCL sources we have.

*Testing*:
ninja test
