### PR TITLE
Remove VisibilityKind from WeightVar.

### DIFF
--- a/include/glow/Base/Traits.h
+++ b/include/glow/Base/Traits.h
@@ -100,15 +100,6 @@ public:
   const char *getKindName() const { return getKindName(kind_); }
 };
 
-/// Specifies the visibility of a WeightVar. Public nodes can't be
-/// optimized because they are visible to external users that may hold a
-/// reference or handles. Their equivalent WeightVar must be left Mutable at the
-/// Instr level.
-enum class VisibilityKind {
-  Public,  // The weight is visible from outside the graph.
-  Private, // The weight isn't visible from outside the graph.
-};
-
 using KindSet = llvm::SmallSet<Kinded::Kind, 4>;
 
 } // namespace glow

--- a/include/glow/IR/IRBuilder.h
+++ b/include/glow/IR/IRBuilder.h
@@ -83,13 +83,11 @@ public:
   ///@{
 
   WeightVar *createWeightVar(TypeRef T, llvm::StringRef name = "",
-                             MutabilityKind m = MutabilityKind::Mutable,
-                             VisibilityKind v = VisibilityKind::Private);
+                             MutabilityKind m = MutabilityKind::Mutable);
 
   WeightVar *createWeightVar(ElemKind elemTy, llvm::ArrayRef<size_t> dims,
                              llvm::StringRef name = "",
-                             MutabilityKind m = MutabilityKind::Mutable,
-                             VisibilityKind v = VisibilityKind::Private);
+                             MutabilityKind m = MutabilityKind::Mutable);
 
   AllocActivationInst *createAllocActivationInst(llvm::StringRef name,
                                                  ElemKind elemTy,

--- a/include/glow/IR/Instrs.h
+++ b/include/glow/IR/Instrs.h
@@ -37,13 +37,9 @@ private:
   /// The mutability mode.
   MutabilityKind mut_;
 
-  /// The visibility of the WeightVar.
-  VisibilityKind vis_;
-
 public:
-  WeightVar(llvm::StringRef name, TypeRef Ty, MutabilityKind mut,
-            VisibilityKind vis)
-      : Value(name, Ty, Kinded::Kind::WeightVarKind), mut_(mut), vis_(vis) {}
+  WeightVar(llvm::StringRef name, TypeRef Ty, MutabilityKind mut)
+      : Value(name, Ty, Kinded::Kind::WeightVarKind), mut_(mut) {}
 
   static bool classof(const Kinded *k) {
     return k->getKind() == Kinded::Kind::WeightVarKind;
@@ -53,13 +49,16 @@ public:
 
   const char *getMutabilityStr() const;
 
+  /// \returns true if the mutability kind of the weight is constant.
+  bool isConstant() const {
+    return getMutability() == MutabilityKind::Constant;
+  }
+
+  /// \returns the mutability kind of the weight.
   MutabilityKind getMutability() const { return mut_; }
 
+  /// Updates the mutability kind of the weight to \p mut.
   void setMutability(MutabilityKind mut) { mut_ = mut; }
-
-  VisibilityKind getVisibility() const { return vis_; }
-
-  void setVisibility(VisibilityKind vis) { vis_ = vis; }
 
   void dump(llvm::raw_ostream &os) const;
   void verify() const {}

--- a/lib/Backends/CPU/AllocationsInfo.cpp
+++ b/lib/Backends/CPU/AllocationsInfo.cpp
@@ -209,9 +209,8 @@ void AllocationsInfo::numberValues(const IRFunction *F) {
       auto *viewOrigin = getOrigin(A);
       auto kind = ValueKind::Activation;
       if (auto *w = dyn_cast<WeightVar>(viewOrigin)) {
-        kind = w->getVisibility() != VisibilityKind::Public
-                   ? ValueKind::ConstantWeight
-                   : ValueKind::MutableWeight;
+        kind = w->isConstant() ? ValueKind::ConstantWeight
+                               : ValueKind::MutableWeight;
       }
       valueNumbers_[A] = std::make_pair(kind, valueIdx++);
       continue;

--- a/lib/IR/IRBuilder.cpp
+++ b/lib/IR/IRBuilder.cpp
@@ -149,8 +149,7 @@ TopKInst *IRBuilder::createTopKOp(Value *input, size_t k) {
 
 Value *IRBuilder::createReturnOp(Value *input) {
   auto *W = createWeightVar(input->getType(), "result",
-                            WeightVar::MutabilityKind::Mutable,
-                            VisibilityKind::Public);
+                            WeightVar::MutabilityKind::Mutable);
   createCopyInst("return", W, input);
   return W;
 }
@@ -162,19 +161,14 @@ Value *IRBuilder::createReturnOp(Value *input) {
 WeightVar *IRBuilder::createWeightVar(ElemKind elemTy,
                                       llvm::ArrayRef<size_t> dims,
                                       llvm::StringRef name,
-                                      WeightVar::MutabilityKind m,
-                                      VisibilityKind v) {
+                                      WeightVar::MutabilityKind m) {
   auto T = F_->getGraph()->getParent()->uniqueType(elemTy, dims);
-  return createWeightVar(T, name, m, v);
+  return createWeightVar(T, name, m);
 }
 
 WeightVar *IRBuilder::createWeightVar(TypeRef T, llvm::StringRef name,
-                                      WeightVar::MutabilityKind m,
-                                      VisibilityKind v) {
-  assert(!(m == WeightVar::MutabilityKind::Constant &&
-           v == VisibilityKind::Public) &&
-         "Cannot have a Constant Public Variable.");
-  auto *A = new WeightVar(uniqueName(name), T, m, v);
+                                      WeightVar::MutabilityKind m) {
+  auto *A = new WeightVar(uniqueName(name), T, m);
   F_->getWeights().push_back(A);
   A->setName(name);
   return A;

--- a/lib/IR/IRGen.cpp
+++ b/lib/IR/IRGen.cpp
@@ -368,8 +368,7 @@ public:
     case glow::Kinded::Kind::ConstantKind: {
       auto *V = cast<Constant>(N);
       auto *W = builder_.createWeightVar(V->getType(), V->getName(),
-                                         WeightVar::MutabilityKind::Mutable,
-                                         VisibilityKind::Private);
+                                         WeightVar::MutabilityKind::Constant);
       W->setName(N->getName());
       registerIR(N, W);
       break;
@@ -377,8 +376,7 @@ public:
     case glow::Kinded::Kind::PlaceholderKind: {
       auto *P = cast<Placeholder>(N);
       auto *W = builder_.createWeightVar(P->getType(), P->getName(),
-                                         WeightVar::MutabilityKind::Mutable,
-                                         VisibilityKind::Public);
+                                         WeightVar::MutabilityKind::Mutable);
       W->setName(N->getName());
       registerIR(N, W);
       break;

--- a/lib/Optimizer/IROptimizer.cpp
+++ b/lib/Optimizer/IROptimizer.cpp
@@ -467,9 +467,7 @@ static Instruction *getSingleWriter(const Value *V) {
 void makeWeightsConst(IRFunction &M) {
   // For each weight:
   for (auto *W : M.getWeights()) {
-    if (W->getVisibility() == VisibilityKind::Public) {
-      assert(W->getMutability() != WeightVar::MutabilityKind::Constant &&
-             "Public vars can not be Constant.");
+    if (!W->isConstant()) {
       continue;
     }
     bool readOnly = true;


### PR DESCRIPTION
*Description*: This PR removes the VisibilityKind from WeightVar. It is not needed anymore now that we have Placeholder and Constants. We can rely on the mutability of the variable for everything. Thanks @jfix71 for identifying this. 

*Testing*: Ninja check. 

*Documentation*: None.