### PR TITLE
[Graph] Fix verify one writer

### DIFF
--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -2328,11 +2328,10 @@ void Function::verify() const {
       if (!N.isOverwrittenNthInput(idx)) {
         continue;
       }
-      auto &input = N.getNthInput(idx);
-      if (!isa<Constant>(input)) {
+      const auto *ph = dyn_cast<Placeholder>(N.getNthInput(idx));
+      if (!ph) {
         continue;
       }
-      const auto *ph = cast<Placeholder>(input);
       auto varToFirstDef = placeholderWrittenTo.find(ph);
       if (varToFirstDef != placeholderWrittenTo.end()) {
         llvm::errs() << "Constant " << ph->getDebugDesc() << '\n';

--- a/tests/unittests/graphTest.cpp
+++ b/tests/unittests/graphTest.cpp
@@ -1068,3 +1068,25 @@ TEST(Graph, setType) {
   EXPECT_EQ(topK->getType(1), origTopKRes1);
   EXPECT_EQ(valRes1.getType(), origTopKRes1);
 }
+
+/// Tests that expect death from the verifier cannot currently run in Release
+/// mode as they would not die, since the verifier uses assertions for
+/// verification. Once the verifier moves to returning false instead of aborting
+/// (GH issue #1517), this can be removed and EXPECT_DEATH can be replaced by
+/// EXPECT_FALSE.
+#ifndef NDEBUG
+
+/// Check that verify doesn't allow for multiple writers to the same node.
+TEST(Graph, verifyOneWriter) {
+  Module M;
+  auto *F = M.createFunction("main");
+
+  auto *input = M.createPlaceholder(ElemKind::FloatTy, {5}, "input", false);
+  auto *output = M.createPlaceholder(ElemKind::FloatTy, {5}, "output", false);
+  F->createSave("Save1", input, output);
+  F->createSave("Save2", input, output);
+
+  EXPECT_DEATH(M.verify(), "");
+}
+
+#endif /* NDEBUG */


### PR DESCRIPTION
*Description*: This verify pass was broken during the Placeholder migration. I moved to a `dyn_cast` instead of `isa` followed by `cast` to make it less error prone.
*Testing*: Added a unit test so that it won't be accidentally broken again in the future.
*Documentation*: N/A
