### PR TITLE
[Graph&IR] Add a ConvertTo node

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -235,6 +235,9 @@ public:
                               unsigned_t kernel, unsigned_t stride,
                               unsigned_t pad, unsigned_t group);
 
+  ConvertToNode *createConvertTo(llvm::StringRef name, NodeValue input,
+                                 TypeRef outTy);
+
   MaxPoolNode *createMaxPool(llvm::StringRef name, NodeValue input,
                              llvm::ArrayRef<unsigned_t> kernels,
                              llvm::ArrayRef<unsigned_t> strides,

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -1902,3 +1902,22 @@ void InterpreterFunction::fwdIntLookupTableInst(const IntLookupTableInst *I) {
     destH.raw(i) = mappingH.raw((int)srcH.raw(i) + 128);
   }
 }
+
+void InterpreterFunction::fwdConvertToInst(const glow::ConvertToInst *I) {
+  Tensor *source = getTensor(I->getInput());
+  Tensor *dest = getTensor(I->getResult());
+  switch (source->getElementType()) {
+  case ElemKind::FloatTy:
+    assert(dest->getElementType() == ElemKind::Float16Ty &&
+           "Conversion not supported");
+    dest->copyWithCast<float16_t, float>(source);
+    break;
+  case ElemKind::Float16Ty:
+    assert(dest->getElementType() == ElemKind::FloatTy &&
+           "Conversion not supported");
+    dest->copyWithCast<float, float16_t>(source);
+    break;
+  default:
+    llvm_unreachable("Type not supported");
+  }
+}

--- a/lib/Graph/Grad.cpp
+++ b/lib/Graph/Grad.cpp
@@ -132,6 +132,18 @@ Function *glow::differentiate(Function *F, const TrainingConfig &conf,
       continue;
     }
 
+    if (N->getKind() == Kind::ConvertToNodeKind) {
+      auto *RN = cast<ConvertToNode>(N);
+      NodeValue outputG = map.getGradient(RN->getResult());
+      NodeValue inputW = RN->getInput();
+
+      // Swap the src and dest.
+      auto *X = new ConvertToNode(N->getName(), inputW.getType(), outputG);
+      toAppend.push_back(X);
+      map.addGradient(RN->getInput(), X);
+      continue;
+    }
+
     if (N->getKind() == Kind::TransposeNodeKind) {
       TransposeNode *TN = cast<TransposeNode>(N);
       NodeValue outputG = map.getGradient(TN->getResult());

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1623,6 +1623,11 @@ ConvolutionNode *Function::createConv(Context &ctx, llvm::StringRef name,
   return createConv(ctx, name, input, depth, kernels, strides, pads, group);
 }
 
+ConvertToNode *Function::createConvertTo(llvm::StringRef name, NodeValue input,
+                                         TypeRef outTy) {
+  return addNode(new ConvertToNode(name, outTy, input));
+}
+
 FullyConnectedNode *Function::createFullyConnected(Context &ctx,
                                                    llvm::StringRef name,
                                                    NodeValue input,

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -299,6 +299,17 @@ void ConvolutionGradNode::verify() const {
                     Kernels_, Strides_, Pads_, Group_);
 }
 
+void ConvertToNode::verify() const {
+  assert(getInput().dims() == getResult().dims() && "Shape must be the same");
+  TypeRef srcTy = getInput().getType();
+  (void)srcTy;
+  TypeRef dstTy = getResult().getType();
+  (void)dstTy;
+  assert(srcTy != dstTy && "Nothing to convert");
+  assert(!srcTy->isQuantizedType() && !dstTy->isQuantizedType() &&
+         "Quantized conversion should use Dequantize, Quantize and Rescale");
+}
+
 void MaxPoolNode::verify() const {
   verifyPool(getInput(), getResult(), Kernels_, Strides_, Pads_);
 }

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -481,6 +481,16 @@ int main(int argc, char **argv) {
       .autoVerify(VerifyKind::SameShape, {"Values", "Indices"});
 
   //===--------------------------------------------------------------------===//
+  //                   Conversions
+  //===--------------------------------------------------------------------===//
+
+  BB.newInstr("ConvertTo")
+      .addOperand("Result", OperandKind::Out)
+      .addOperand("Input", OperandKind::In)
+      .autoVerify(VerifyKind::SameShape, {"Result", "Input"})
+      .autoIRGen();
+
+  //===--------------------------------------------------------------------===//
   //                Backend-Specific Instructions
   //===--------------------------------------------------------------------===//
 

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -521,6 +521,16 @@ int main(int argc, char **argv) {
                     "tensor. The input shape {D_0, D_1, ... D_n} results in "
                     "the outputs {D_0, D_1, ... D_n-1, K}, sorted in "
                     "non-decreasing order.");
+  //===--------------------------------------------------------------------===//
+  //                Conversions
+  //===--------------------------------------------------------------------===//
+
+  BB.newNode("ConvertTo")
+      .addInput("Input")
+      .addResultFromCtorArg()
+      .setDocstring(
+          "Convert the input from its current type to the destination "
+          "type. The input and output types must have the same shapes");
 
   //===--------------------------------------------------------------------===//
   //                Backend-Specific Nodes


### PR DESCRIPTION
*Description*
This node/instruction represents a type conversion (a.k.a. a cast)
from the input type to the output type.
The shape of the input and output type must be identical, only the
element type is allowed to change.

This node will allow us to represent type conversions when converting
a graph from one type to another.

This patch adds the support for this node in the interpreter and
teaches the differentiation mechanism how to deal with ConvertTo
node.

Note: We could technically introduce different nodes for the different
conversion (e.g., fpext, fptrunc, inttofp, and so on) since this
node would have different interpretation based on the input and output
types. Right now, we decided not to do that because we expect this
node to not hit any backends. In particular, this node is only
accessible through the C++ API.

*Testing*
Added tests.

Related to #1312.