### PR TITLE
[Converter] Introduce a FunctionConverter helper class

### DIFF
--- a/include/glow/Converter/FunctionConverter.h
+++ b/include/glow/Converter/FunctionConverter.h
@@ -1,0 +1,166 @@
+/**
+ * Copyright (c) 2018-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/// \file This file describes the high-level API for converting a function
+/// from one type to another.
+#ifndef GLOW_CONVERTER_FUNCTIONCONVERTER_H
+#define GLOW_CONVERTER_FUNCTIONCONVERTER_H
+
+#include "glow/Base/Type.h"
+
+#include "llvm/ADT/SmallVector.h"
+
+#include <utility> // For std::pair.
+
+namespace glow {
+class Context;
+class Function;
+class Node;
+struct NodeValue;
+
+/// Pair representing the destination and source type of a conversion.
+/// dstTy = cast(srcTy).
+using DstTySrcTy = std::pair<TypeRef, TypeRef>;
+
+/// This class implements the high-level APIs used to convert a function
+/// to one type to another. The actual conversions must be implemented
+/// by derived classes.
+class FunctionConverter {
+protected:
+  /// The function to be converted.
+  Function &function_;
+  /// The list of all the conversions inserted during ::convert.
+  llvm::SmallVector<Node *, 16> conversions_;
+
+  /// \return the type that \p out needs to have at the end of the conversion
+  /// procedure. In other words, this is the type this value will have at the
+  /// end of ::convert.
+  /// E.g., let say we want to convert:
+  /// \verbatim
+  /// res = matmul float
+  /// \endverbatim
+  /// into
+  /// \verbatim
+  /// res = matmul fp16
+  /// \endverbatim
+  /// The target type for res is fp16.
+  ///
+  /// Using this information, the conversion procedure will insert a conversion
+  /// of \p out from this type to the current type of \p out.
+  /// \verbatim
+  /// res = matmul fp16
+  /// ... = convert fp16 res to res's current type
+  /// \endverbatim
+  ///
+  /// If nullptr is returned or the returned type is identical to the current
+  /// type of the related value, no conversion will be inserted by the
+  /// conversion procedure.
+  virtual TypeRef getTargetTypeForOutput(const NodeValue &out) const;
+
+  /// \return the type that the input operand described by \p idx-th input of
+  /// \p use needs to have at the end of the conversion procedure. In other
+  /// words, this is the type this value will have at the end of ::convert.
+  /// E.g., let say we want to convert:
+  /// \verbatim
+  /// res = matmul float A, B
+  /// \endverbatim
+  /// into
+  /// \verbatim
+  /// res = matmul fp16 A, B
+  /// \endverbatim
+  /// The target type for A (i.e., (matmul, 0)) is fp16.
+  ///
+  /// Using this information, the conversion procedure will insert a conversion
+  /// of (\p node, \p idx) from its current type to the returned type.
+  /// \verbatim
+  /// convertedA = convert A's current type A to returned type
+  /// res = matmul fp16 convertedA, B
+  /// \endverbatim
+  ///
+  /// If nullptr is returned or the returned type is identical to the current
+  /// type of the related value, no conversion will be inserted by the
+  /// conversion procedure.
+  virtual TypeRef getTargetTypeForInput(const Node &use, unsigned idx) const;
+
+  /// \returns the source and destination type of a \p conversion.
+  /// E.g., dstTy = cast(srcTy) should return (dstTy, srcTy).
+  /// The default implementation returns the zero-th result as destination type
+  /// and the zero-th input as source type.
+  virtual DstTySrcTy getConversionType(const Node &conversion) const;
+
+  /// Check if \p node can be converted.
+  /// \return false if \p node shouldn't be considered for conversion.
+  virtual bool canConvert(const Node &node) const;
+
+  /// Create a conversion with \p val as input and \p destTy as the destination
+  /// type. In other words, creates something like cast val to destTy.
+  virtual Node *createConversion(NodeValue &val, TypeRef destTy) = 0;
+
+  /// Given a \p conversion, get its output value.
+  /// The default implementation returns the zero-th result.
+  /// If a conversion node defined more than one value, this
+  /// method must be overloaded.
+  virtual NodeValue getConversionOutput(Node &conversion) const;
+
+  /// Morph \p node into its final form. For the most part
+  /// this method should be a noop and just return \p node.
+  /// However, this hook provides a way to perform changes
+  /// on more than just the type of the inputs and outputs,
+  /// like changing the opcode of an operation.
+  ///
+  /// \warning \p node must not be deleted.
+  ///
+  /// \pre All the inputs of \p node have been converted to
+  ///      their target type using ::getTargetTypeForInput.
+  /// \pre All the results of \p node have been converted to
+  ///      their target type using ::getTargetTypeForOutput.
+  ///
+  /// \return the final morphed node.
+  virtual Node &morphNode(Node &node);
+
+  /// Hook to perform some post processing on the final morphed node.
+  virtual void postProcessing(Node &node);
+
+  /// Hook to do a final clean-up after all operations have been converted.
+  virtual void cleanUp() {}
+
+public:
+  /// Create a function converter for \p F.
+  ///
+  /// \note This method will modify \p F when calling ::convert.
+  ///       If one wants to keep the original function around,
+  ///       they need to clone it before creating this converter.
+  FunctionConverter(Function &F) : function_(F) {}
+
+  virtual ~FunctionConverter() {}
+
+  /// Convert \p F according to ::getTargetTypeForOutput and
+  /// ::getTargetTypeForInput.
+  ///
+  /// The high level algorithm looks like:
+  /// \code
+  /// for each node in function:
+  ///   insert conversions for the inputs of node
+  ///   update the inputs of node to use the results of the conversions
+  ///   mutate the type of the outputs of node
+  ///   insert conversions for the outputs of node
+  ///   morph node
+  ///   postProcessing node
+  /// cleanUp
+  /// \endcode
+  void convert();
+};
+} // namespace glow
+#endif

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_subdirectory(Backends)
 add_subdirectory(Base)
 add_subdirectory(CodeGen)
+add_subdirectory(Converter)
 add_subdirectory(ExecutionEngine)
 add_subdirectory(Graph)
 add_subdirectory(IR)

--- a/lib/Converter/CMakeLists.txt
+++ b/lib/Converter/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_library(Converter
+            FunctionConverter.cpp)
+
+target_link_libraries(Converter
+                      PRIVATE
+                        Base
+                        Graph)

--- a/lib/Converter/FunctionConverter.cpp
+++ b/lib/Converter/FunctionConverter.cpp
@@ -1,0 +1,169 @@
+/**
+ * Copyright (c) 2018-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "glow/Converter/FunctionConverter.h"
+
+#include "glow/Graph/Graph.h" // For Function.
+#include "glow/Graph/Node.h"  // For Node.
+#include "glow/Graph/Nodes.h" // For Placeholder and Variable.
+
+using namespace glow;
+
+TypeRef
+FunctionConverter::getTargetTypeForOutput(const NodeValue &nodeVal) const {
+  // Default implementation says there is nothing to do.
+  return nullptr;
+}
+
+TypeRef FunctionConverter::getTargetTypeForInput(const Node &use,
+                                                 unsigned idx) const {
+  // Default implementation says there is nothing to do.
+  return nullptr;
+}
+
+DstTySrcTy FunctionConverter::getConversionType(const Node &conversion) const {
+  // Although that function would work on something not added by
+  // the conversion process, we assert on that to make sure this
+  // method is called like expected.
+  assert(std::find(conversions_.begin(), conversions_.end(), &conversion) !=
+             conversions_.end() &&
+         "This conversion wasn't added by this converter");
+  assert(conversion.getNumResults() == 1 &&
+         "This needs target specific overloading");
+  assert(conversion.getNumInputs() == 1 &&
+         "This needs target specific overloading");
+  return DstTySrcTy(conversion.getType(0), conversion.getNthInput(0).getType());
+}
+
+bool FunctionConverter::canConvert(const Node &node) const {
+  // By default, we assume everything is convertible.
+  switch (node.getKind()) {
+  default:
+    return true;
+  case Kinded::Kind::PlaceholderKind:
+  case Kinded::Kind::SaveNodeKind:
+    // Save node or placeholder special because
+    // they are or their effects are visible from
+    // the outside of the function being converted.
+    // Thus, we cannot convert them, unless we change
+    // the semantic of this function and the related
+    // placeholder.
+    return false;
+  }
+}
+
+NodeValue FunctionConverter::getConversionOutput(Node &conversion) const {
+  assert(conversion.getNumResults() == 1 && "This method should be overloaded");
+  return NodeValue(&conversion, 0);
+}
+
+Node &FunctionConverter::morphNode(Node &node) { return node; }
+
+void FunctionConverter::postProcessing(Node &node) {}
+
+void FunctionConverter::convert() {
+  // Traverse all nodes.
+  // Check what the conversion should look like, if any.
+  // Convert the node appropriately.
+
+  // For every unprocessed node in the graph we keep the invariant of having
+  // all inputs to be of the uncovered type.
+  // I.e., if we have:
+  // res(outTy) = node arg1(in2Ty), arg2(in2Ty)
+  //
+  // after converting "node", we will have something that looks like:
+  // newArg1(convertedIn1Ty) = conversion arg1
+  // newArg2(convertedIn2Ty) = conversion arg2
+  // newRes(convertedOutTy) = node newArg1, newArg2
+  // res(outTy) = conversion newRes
+  //
+  // In other words, the boundaries (in and out) are unchanged.
+
+  // The iterator looks weird because we only want to iterate through
+  // the original nodes.
+  auto nodeIt = function_.getNodes().end();
+  auto stopIt = function_.getNodes().begin();
+  do {
+    --nodeIt;
+    Node &node = *nodeIt;
+    if (!canConvert(node)) {
+      continue;
+    }
+    // Mutate the output types and insert the conversion to keep our
+    // invariant.
+    for (unsigned idx = 0, end = node.getNumResults(); idx != end; ++idx) {
+      NodeValue val = node.getNthResult(idx);
+      TypeRef targetTy = getTargetTypeForOutput(val);
+      if (!targetTy || targetTy == val.getType()) {
+        continue;
+      }
+      // convert the node and create a conversion to keep the users happy.
+      assert(targetTy->dims() == val.getType()->dims() &&
+             "Conversion does not preserve shape");
+      TypeRef origTy = val.getType();
+      // Fake the morphing of the node so that the creation
+      // of the conversion works properly.
+      val.setType(targetTy);
+      // Create the conversion.
+      Node *conversion = createConversion(val, origTy);
+      conversions_.push_back(conversion);
+      // "conversion" uses val so after this call,
+      // we will get a use of conversion inside conversion.
+      NodeValue conversionVal = getConversionOutput(*conversion);
+      // Store the users in a temporary object because setOperand
+      // will invalidate the iterator.
+      llvm::SmallVector<NodeUse, 4> users(val.getUsers().begin(),
+                                          val.getUsers().end());
+      // We cannot use replaceAllUsesWith here because:
+      // 1. At this point, val and conversion don't have the same type
+      //    (one is converted the other is the original type), and that
+      //    would trigger an assertion.
+      // 2. We would end up replacing the use of val in "conversion" by
+      //   "conversion".
+      for (auto use : users) {
+        if (use.getUser() == conversion) {
+          continue;
+        }
+        use.get()->setOperand(conversionVal.getNode(),
+                              conversionVal.getResNo());
+      }
+    }
+    // Convert the inputs of the node.
+    for (unsigned idx = 0, end = node.getNumInputs(); idx != end; ++idx) {
+      NodeValue val = node.getNthInput(idx);
+      TypeRef targetTy = getTargetTypeForInput(node, idx);
+      if (!targetTy || targetTy == val.getType()) {
+        continue;
+      }
+      // convert the node and create a conversion to keep the users happy.
+      assert(targetTy->dims() == val.getType()->dims() &&
+             "Conversion does not preserve shape");
+      // Create the conversion.
+      Node *conversion = createConversion(val, targetTy);
+      conversions_.push_back(conversion);
+      node.setNthInput(idx, getConversionOutput(*conversion));
+    }
+    // All the surrounding code is properly typed, finally the morph node.
+    Node &morphedNode = morphNode(node);
+    // Do some post processing if need be.
+    postProcessing(morphedNode);
+  } while (nodeIt != stopIt);
+
+  // Allow a late clean-up before verifying the conversation produced a valid
+  // function.
+  cleanUp();
+
+  function_.verify();
+}


### PR DESCRIPTION
*Description*
Converting some operators of a function from one type to another,
for instance single precision floating point to half precision
floating point, single precision floating point to quantized type,
and son on, does not depend on the source and destination types.
Therefore, it is possible to share the same core framework for all
such conversion.

This patch introduces a new helper class FunctionConverter that
realizes this concept. In particular, it features the main conversion
procedure (FunctionConverter::convert) and relies on the specialization
of the class to implement the type specific bit like how to materialize
the conversion from the source type to the destination type, what type
should be used for a specific value and so on.

The main conversion procedure works like this:
for each node in function:
  check if the node need to be converted
  insert conversions for the inputs of node
  update the inputs of node to use the results of the conversions
  mutate the type of the outputs of the node
  insert conversions for the outputs of the node
  morph node
  postProcessing node
cleanUp

After each conversion step, we preserve the invariant that the input
and output types of "node" are untouched.
E.g.,
Before converting node:
res(outTy) = node arg1(in2Ty), arg2(in2Ty)

After converting "node", we will have something that looks like:
newArg1(convertedIn1Ty) = conversion arg1
newArg2(convertedIn2Ty) = conversion arg2
newRes(convertedOutTy) = node newArg1, newArg2
res(outTy) = conversion newRes

We will eventually optimize the useless intermediate conversions but
this is outside of the scope of this change.

*Testing*
N/A, this is an abstract class and this patch does not include any
user.