### PR TITLE
[Quantization] Specialize the FunctionConverter to quantize a function

### DIFF
--- a/lib/Quantization/CMakeLists.txt
+++ b/lib/Quantization/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(Quantization
 
 target_link_libraries(Quantization
                       PRIVATE
+                        Converter
                         Graph
                         ExecutionEngine
                         QuantizationBase)

--- a/tests/unittests/quantizationTest.cpp
+++ b/tests/unittests/quantizationTest.cpp
@@ -714,12 +714,18 @@ TEST(Quantization, quantizeSoftmaxAndLRN) {
 
   F = quantization::quantizeFunction(EE, QI, F);
 
-  auto *qLRN = cast<LocalResponseNormalizationNode>(F->getNodeByName("LRN1"));
-  auto *qSM = cast<SoftMaxNode>(F->getNodeByName("softmax1"));
-  ASSERT_NE(qLRN, nullptr);
-  ASSERT_NE(qSM, nullptr);
-  EXPECT_TRUE(qLRN->getInput().getType()->isQuantizedType());
-  EXPECT_TRUE(qSM->getInput().getType()->isQuantizedType());
+  auto qLRNIt = std::find_if(
+      F->getNodes().begin(), F->getNodes().end(), [](const Node &node) -> bool {
+        return llvm::isa<LocalResponseNormalizationNode>(&node) &&
+               node.getNthResult(0).getType()->isQuantizedType();
+      });
+  ASSERT_NE(qLRNIt, F->getNodes().end());
+  auto qSMIt = std::find_if(
+      F->getNodes().begin(), F->getNodes().end(), [](const Node &node) -> bool {
+        return llvm::isa<SoftMaxNode>(&node) &&
+               node.getNthResult(0).getType()->isQuantizedType();
+      });
+  ASSERT_NE(qSMIt, F->getNodes().end());
 }
 
 /// Test option to disable quantization of specific node kinds in the graph.


### PR DESCRIPTION
Note: The diff will be much more approachable when #1821 lands, since this PR includes both #1821 and the change for this refactoring. Reviewing just the last commit of this PR would have the same effect as waiting for #1821 to be merged.

*Description*
This patch refactors the code of the function that quantizes a function
to reuse the framework set by the FunctionConverter.

This patch is not strictly speaking NFC because unlike the original
implementation the conversion process does not leave the original,
not use after conversion, node around. Other than that, it should
be NFC.

*Testing*
Ran the quantizationTest
Ran different quantized profiles (asymmetric, symmetric, symmetric
with uint8) with and without the patch for resnet50 and checked
that the output IR were identical (modulo some variable names).

Related to #1329, we provide a unified way for converting function
that fp16 is going to use as discussed in #1747.