### PR TITLE
[Converter] Add a helper class to converter a function from type A to type B

### DIFF
--- a/include/glow/Converter/TypeAToTypeBFunctionConverter.h
+++ b/include/glow/Converter/TypeAToTypeBFunctionConverter.h
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2018-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_CONVERTER_TYPEATOTYPEBFUNCTIONCONVERTER_H
+#define GLOW_CONVERTER_TYPEATOTYPEBFUNCTIONCONVERTER_H
+
+#include "FunctionConverter.h"
+
+#include "glow/Base/Traits.h" // For KindSet.
+#include "glow/Base/Type.h"
+
+namespace glow {
+
+class Function;
+class Module;
+
+/// This helper class converts values of typeA into values of typeB.
+/// The nodes producing these values are morphed into the new type
+/// and proper conversions from/to typeA and typeB are inserted.
+class TypeAToTypeBFunctionConverter : public FunctionConverter {
+protected:
+  /// Module of the function to be converted.
+  Module &mod_;
+  /// Destination type of the conversions.
+  ElemKind dstKind_;
+  /// Source type of the conversions. I.e., the values of this
+  /// element type are going to be converted.
+  ElemKind srcKind_;
+  /// Set of node kinds that should not be converted.
+  KindSet doNotConvertKinds_;
+
+  /// If the element type of \p out is srcKind_ returns a similarly shaped type
+  /// using dstKind_. Otherwise returns nullptr.
+  /// \see FunctionConverter::getTargetTypeForOutput to know how this
+  /// is used.
+  TypeRef getTargetTypeForOutput(const NodeValue &out) const override;
+
+  /// If the element type of the \p idx-th input of \p use is srcKind_
+  /// returns a similarly shaped type using dstKind_. Otherwise returns nullptr.
+  /// \see FunctionConverter::getTargetTypeForInput to know how this
+  /// is used.
+  TypeRef getTargetTypeForInput(const Node &use, unsigned idx) const override;
+
+  /// Create a node that converts \p val to \p destTy.
+  /// \p val and \p destTy must have the same shape.
+  Node *createConversion(NodeValue &val, TypeRef destTy) override;
+
+  /// Check if \p node can be converted.
+  bool canConvert(const Node &node) const override;
+
+public:
+  /// Create a type converter from \p fromKind to \p toKind for \p F.
+  /// If \p doNotConvertKinds is not nullptr, the nodes which kind
+  /// is in this set won't be converted.
+  TypeAToTypeBFunctionConverter(Function &F, ElemKind fromKind, ElemKind toKind,
+                                const KindSet *doNotConvertKinds = nullptr);
+};
+} // namespace glow
+#endif

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -235,6 +235,9 @@ public:
                               unsigned_t kernel, unsigned_t stride,
                               unsigned_t pad, unsigned_t group);
 
+  ConvertToNode *createConvertTo(llvm::StringRef name, NodeValue input,
+                                 TypeRef outTy);
+
   MaxPoolNode *createMaxPool(llvm::StringRef name, NodeValue input,
                              llvm::ArrayRef<unsigned_t> kernels,
                              llvm::ArrayRef<unsigned_t> strides,

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -1902,3 +1902,22 @@ void InterpreterFunction::fwdIntLookupTableInst(const IntLookupTableInst *I) {
     destH.raw(i) = mappingH.raw((int)srcH.raw(i) + 128);
   }
 }
+
+void InterpreterFunction::fwdConvertToInst(const glow::ConvertToInst *I) {
+  Tensor *source = getTensor(I->getInput());
+  Tensor *dest = getTensor(I->getResult());
+  switch (source->getElementType()) {
+  case ElemKind::FloatTy:
+    assert(dest->getElementType() == ElemKind::Float16Ty &&
+           "Conversion not supported");
+    dest->copyWithCast<float16_t, float>(source);
+    break;
+  case ElemKind::Float16Ty:
+    assert(dest->getElementType() == ElemKind::FloatTy &&
+           "Conversion not supported");
+    dest->copyWithCast<float, float16_t>(source);
+    break;
+  default:
+    llvm_unreachable("Type not supported");
+  }
+}

--- a/lib/Converter/CMakeLists.txt
+++ b/lib/Converter/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(Converter
-            FunctionConverter.cpp)
+            FunctionConverter.cpp
+            TypeAToTypeBFunctionConverter.cpp)
 
 target_link_libraries(Converter
                       PRIVATE

--- a/lib/Converter/TypeAToTypeBFunctionConverter.cpp
+++ b/lib/Converter/TypeAToTypeBFunctionConverter.cpp
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2018-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/Converter/TypeAToTypeBFunctionConverter.h"
+
+#include "glow/Graph/Graph.h"
+
+using namespace glow;
+
+TypeAToTypeBFunctionConverter::TypeAToTypeBFunctionConverter(
+    Function &F, ElemKind fromKind, ElemKind toKind,
+    const KindSet *doNotConvertKinds)
+    : FunctionConverter(F), mod_(*F.getParent()), dstKind_(toKind),
+      srcKind_(fromKind) {
+  if (doNotConvertKinds) {
+    doNotConvertKinds_ = *doNotConvertKinds;
+  }
+}
+
+bool TypeAToTypeBFunctionConverter::canConvert(const Node &node) const {
+  if (doNotConvertKinds_.count(node.getKind())) {
+    return false;
+  }
+  return FunctionConverter::canConvert(node);
+}
+
+TypeRef TypeAToTypeBFunctionConverter::getTargetTypeForOutput(
+    const NodeValue &out) const {
+  if (out.getType()->getElementType() != srcKind_) {
+    return nullptr;
+  }
+  return mod_.uniqueType(dstKind_, out.dims());
+}
+
+TypeRef
+TypeAToTypeBFunctionConverter::getTargetTypeForInput(const Node &use,
+                                                     unsigned idx) const {
+  return getTargetTypeForOutput(use.getNthInput(idx));
+}
+
+Node *TypeAToTypeBFunctionConverter::createConversion(NodeValue &val,
+                                                      TypeRef destTy) {
+  assert(((destTy->getElementType() == dstKind_ &&
+           val.getType()->getElementType() == srcKind_) ||
+          (destTy->getElementType() == srcKind_ &&
+           val.getType()->getElementType() == dstKind_)) &&
+         "Unexpected conversion type");
+  return function_.createConvertTo(val.getNode()->getName(), val, destTy);
+}

--- a/lib/Graph/Grad.cpp
+++ b/lib/Graph/Grad.cpp
@@ -132,6 +132,18 @@ Function *glow::differentiate(Function *F, const TrainingConfig &conf,
       continue;
     }
 
+    if (N->getKind() == Kind::ConvertToNodeKind) {
+      auto *RN = cast<ConvertToNode>(N);
+      NodeValue outputG = map.getGradient(RN->getResult());
+      NodeValue inputW = RN->getInput();
+
+      // Swap the src and dest.
+      auto *X = new ConvertToNode(N->getName(), inputW.getType(), outputG);
+      toAppend.push_back(X);
+      map.addGradient(RN->getInput(), X);
+      continue;
+    }
+
     if (N->getKind() == Kind::TransposeNodeKind) {
       TransposeNode *TN = cast<TransposeNode>(N);
       NodeValue outputG = map.getGradient(TN->getResult());

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1623,6 +1623,11 @@ ConvolutionNode *Function::createConv(Context &ctx, llvm::StringRef name,
   return createConv(ctx, name, input, depth, kernels, strides, pads, group);
 }
 
+ConvertToNode *Function::createConvertTo(llvm::StringRef name, NodeValue input,
+                                         TypeRef outTy) {
+  return addNode(new ConvertToNode(name, outTy, input));
+}
+
 FullyConnectedNode *Function::createFullyConnected(Context &ctx,
                                                    llvm::StringRef name,
                                                    NodeValue input,

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -299,6 +299,17 @@ void ConvolutionGradNode::verify() const {
                     Kernels_, Strides_, Pads_, Group_);
 }
 
+void ConvertToNode::verify() const {
+  assert(getInput().dims() == getResult().dims() && "Shape must be the same");
+  TypeRef srcTy = getInput().getType();
+  (void)srcTy;
+  TypeRef dstTy = getResult().getType();
+  (void)dstTy;
+  assert(srcTy != dstTy && "Nothing to convert");
+  assert(!srcTy->isQuantizedType() && !dstTy->isQuantizedType() &&
+         "Quantized conversion should use Dequantize, Quantize and Rescale");
+}
+
 void MaxPoolNode::verify() const {
   verifyPool(getInput(), getResult(), Kernels_, Strides_, Pads_);
 }

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -155,6 +155,18 @@ target_link_libraries(float16Test
                         testMain)
 add_glow_test(float16Test ${GLOW_BINARY_DIR}/tests/float16Test)
 
+add_executable(typeAToTypeBFunctionConverterTest
+               typeAToTypeBFunctionConverterTest.cpp)
+target_link_libraries(typeAToTypeBFunctionConverterTest
+                      PRIVATE
+                        Converter
+                        ExecutionEngine
+                        Graph
+                        gtest
+                        testMain)
+add_glow_test(typeAToTypeBFunctionConverterTest
+              ${GLOW_BINARY_DIR}/tests/typeAToTypeBFunctionConverterTest)
+
 add_executable(UtilsTest
                UtilsTest.cpp)
 target_link_libraries(UtilsTest

--- a/tests/unittests/typeAToTypeBFunctionConverterTest.cpp
+++ b/tests/unittests/typeAToTypeBFunctionConverterTest.cpp
@@ -1,0 +1,452 @@
+/**
+ * Copyright (c) 2018-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/Converter/TypeAToTypeBFunctionConverter.h"
+
+#include "glow/Backends/Backend.h"
+#include "glow/ExecutionEngine/ExecutionEngine.h"
+
+#include "llvm/Support/Casting.h"
+
+#include "gtest/gtest.h"
+
+using namespace glow;
+
+struct AllBackends : public ::testing::TestWithParam<BackendKind> {
+protected:
+  ExecutionEngine EE_{GetParam()};
+};
+
+/// Check that a simple graph is converted properly.
+/// Namely, check that:
+/// \verbatim
+/// Input: Placeholder(float)
+///    |
+///    V
+///   FC(float)  Output: Placeholder(float)
+///    |            |
+///    |    +-------+
+///    |   /
+///    V  V
+///   Save
+/// \endverbatim
+///
+/// Gets converted into:
+/// \verbatim
+/// Input: Placeholder(float)
+///    |
+///    V
+/// ConvertTo(float16)
+///    |
+///    V
+///   FC(float16)  Output: Placeholder(float)
+///    |              |
+///    V              |
+/// ConvertTo(float)  |
+///    |    +---------+
+///    |   /
+///    V  V
+///   Save
+/// \endverbatim
+///
+/// In particular, the input and output of the network shouldn't be modified.
+TEST_P(AllBackends, SimpleOneUseConversionFloatToFloat16) {
+  Module mod;
+  Function *F = mod.createFunction("test");
+  Context ctx;
+
+  auto *input =
+      mod.createPlaceholder(ElemKind::FloatTy, {20, 13}, "Input", false);
+  auto *output =
+      mod.createPlaceholder(ElemKind::FloatTy, {20, 10}, "Output", false);
+
+  auto *FC = F->createFullyConnected(ctx, "FC", input, 10);
+  auto *result = F->createSave("save", FC, output);
+
+  size_t origGraphSize = F->getNodes().size();
+
+  TypeAToTypeBFunctionConverter converter(*F, ElemKind::FloatTy,
+                                          ElemKind::Float16Ty);
+  converter.convert();
+
+  // We should have 4 more nodes:
+  // 1 conversion float to float16 for each input of FC (3)
+  // and 1 conversion float16 to float for the result of FC.
+  EXPECT_EQ(F->getNodes().size(), origGraphSize + 4);
+  // Make sure the save node is still in the function and is unchanged.
+  EXPECT_TRUE(std::find(F->getNodes().begin(), F->getNodes().end(), *result) !=
+              F->getNodes().end());
+  EXPECT_EQ(result->getOutput(), NodeValue(output, 0));
+  // Check that the save is fed from a conversion from float16 to float.
+  auto *convertedBackFCRes = llvm::dyn_cast<ConvertToNode>(result->getInput());
+  ASSERT_NE(convertedBackFCRes, nullptr);
+  EXPECT_EQ(convertedBackFCRes->getElementType(0), ElemKind::FloatTy);
+  auto *convertedFC =
+      llvm::dyn_cast<FullyConnectedNode>(convertedBackFCRes->getInput());
+  ASSERT_NE(convertedFC, nullptr);
+  EXPECT_EQ(convertedFC->getElementType(0), ElemKind::Float16Ty);
+  // Check that all the input of FC are convertTo node with from float to
+  // Float16Ty.
+  for (unsigned idx = 0, end = convertedFC->getNumInputs(); idx != end; ++idx) {
+    auto *convertedFCInput =
+        llvm::dyn_cast<ConvertToNode>(convertedFC->getNthInput(idx));
+    ASSERT_NE(convertedFCInput, nullptr);
+    EXPECT_EQ(convertedFCInput->getElementType(0), ElemKind::Float16Ty);
+    EXPECT_TRUE(llvm::isa<Placeholder>(convertedFCInput->getInput()));
+    EXPECT_EQ(convertedFCInput->getInput().getElementType(), ElemKind::FloatTy);
+  }
+  // At this point we know the input of FC is convertTo(placeholder).
+  // Check that this placeholder is the expected input.
+  EXPECT_EQ(convertedFC->getInput().getNode()->getNthInput(0).getNode(), input);
+}
+
+/// Check that a graph with a simple chain of computation is converted
+/// properly. In particular, check that the intermediate conversion
+/// steps are not eliminated by default.
+/// Namely, check that:
+/// \verbatim
+/// Input: Placeholder(float)
+///    |
+///    V
+///   FC(float)
+///    |
+///    V
+///   ReLU(float)  Output: Placeholder(float)
+///    |            |
+///    |    +-------+
+///    |   /
+///    V  V
+///   Save
+/// \endverbatim
+///
+/// Gets converted into:
+/// \verbatim
+/// Input: Placeholder(float)
+///    |
+///    V
+/// ConvertTo(float16)
+///    |
+///    V
+///   FC(float16)
+///    |
+///    V
+/// ConvertTo(float)
+///    |
+///    V
+/// ConvertTo(float16)
+///    |
+///    V
+///   ReLU(float16)  Output: Placeholder(float)
+///    |              |
+///    V              |
+/// ConvertTo(float)  |
+///    |    +---------+
+///    |   /
+///    V  V
+///   Save
+/// \endverbatim
+///
+/// In particular, the input and output of the network shouldn't be modified.
+TEST_P(AllBackends, SimpleChainOfComputationConversionFloatToFloat16) {
+  Module mod;
+  Function *F = mod.createFunction("test");
+  Context ctx;
+
+  auto *input =
+      mod.createPlaceholder(ElemKind::FloatTy, {20, 13}, "Input", false);
+  auto *output =
+      mod.createPlaceholder(ElemKind::FloatTy, {20, 10}, "Output", false);
+
+  auto *FC = F->createFullyConnected(ctx, "FC", input, 10);
+  auto *ReLU = F->createRELU("ReLU", FC, FC->getType(0));
+  auto *result = F->createSave("save", ReLU, output);
+
+  size_t origGraphSize = F->getNodes().size();
+
+  TypeAToTypeBFunctionConverter converter(*F, ElemKind::FloatTy,
+                                          ElemKind::Float16Ty);
+  converter.convert();
+
+  // We should have 6 more nodes:
+  // 1 conversion float to float16 for each input of FC (3)
+  // 1 conversion float to float16 for the input of ReLU
+  // 1 conversion float16 to float for the result of FC.
+  // 1 conversion float16 to float for the result of ReLU.
+  EXPECT_EQ(F->getNodes().size(), origGraphSize + 6);
+  // Make sure the save node is still in the function and is unchanged.
+  EXPECT_TRUE(std::find(F->getNodes().begin(), F->getNodes().end(), *result) !=
+              F->getNodes().end());
+  EXPECT_EQ(result->getOutput(), NodeValue(output, 0));
+  // Check that the save is fed from a conversion from float16 to float.
+  auto *convertedBackReLURes =
+      llvm::dyn_cast<ConvertToNode>(result->getInput());
+  ASSERT_NE(convertedBackReLURes, nullptr);
+  EXPECT_EQ(convertedBackReLURes->getElementType(0), ElemKind::FloatTy);
+  auto *convertedReLU =
+      llvm::dyn_cast<ReluNode>(convertedBackReLURes->getInput());
+  ASSERT_NE(convertedReLU, nullptr);
+  EXPECT_EQ(convertedReLU->getElementType(0), ElemKind::Float16Ty);
+
+  // Check that the ReLU is fed from a conversion from float to float16.
+  auto *convertedToReLUInput =
+      llvm::dyn_cast<ConvertToNode>(convertedReLU->getInput());
+  ASSERT_NE(convertedToReLUInput, nullptr);
+  EXPECT_EQ(convertedToReLUInput->getElementType(0), ElemKind::Float16Ty);
+
+  // Check that this conversion is fed from a conversion from float16 to float.
+  auto *convertedBackFCRes =
+      llvm::dyn_cast<ConvertToNode>(convertedToReLUInput->getInput());
+  ASSERT_NE(convertedBackFCRes, nullptr);
+  EXPECT_EQ(convertedBackFCRes->getElementType(0), ElemKind::FloatTy);
+  // Check that this conversion comes from the float16 FC node.
+  auto *convertedFC =
+      llvm::dyn_cast<FullyConnectedNode>(convertedBackFCRes->getInput());
+  ASSERT_NE(convertedFC, nullptr);
+  EXPECT_EQ(convertedFC->getElementType(0), ElemKind::Float16Ty);
+  // Check that all the input of FC are convertTo node with from float to
+  // Float16Ty.
+  for (unsigned idx = 0, end = convertedFC->getNumInputs(); idx != end; ++idx) {
+    auto *convertedFCInput =
+        llvm::dyn_cast<ConvertToNode>(convertedFC->getNthInput(idx));
+    ASSERT_NE(convertedFCInput, nullptr);
+    EXPECT_EQ(convertedFCInput->getElementType(0), ElemKind::Float16Ty);
+    EXPECT_TRUE(llvm::isa<Placeholder>(convertedFCInput->getInput()));
+    EXPECT_EQ(convertedFCInput->getInput().getElementType(), ElemKind::FloatTy);
+  }
+  // At this point we know the input of FC is convertTo(placeholder).
+  // Check that this placeholder is the expected input.
+  EXPECT_EQ(convertedFC->getInput().getNode()->getNthInput(0).getNode(), input);
+}
+
+/// Check that the conversion honor the doNotConvertKinds set (here ReLU)
+/// for a graph with a simple chain of computation.
+/// Namely, check that:
+/// \verbatim
+/// Input: Placeholder(float)
+///    |
+///    V
+///   FC(float)
+///    |
+///    V
+///   ReLU(float)  Output: Placeholder(float)
+///    |            |
+///    |    +-------+
+///    |   /
+///    V  V
+///   Save
+/// \endverbatim
+///
+/// Gets converted into:
+/// \verbatim
+/// Input: Placeholder(float)
+///    |
+///    V
+/// ConvertTo(float16)
+///    |
+///    V
+///   FC(float16)
+///    |
+///    V
+/// ConvertTo(float)
+///    |
+///    V
+///   ReLU(float)  Output: Placeholder(float)
+///    |              |
+///    |    +---------+
+///    |   /
+///    V  V
+///   Save
+/// \endverbatim
+///
+/// In particular, the input and output of the network shouldn't be modified.
+TEST_P(AllBackends, DoNotConvertReLUConversionFloatToFloat16) {
+  Module mod;
+  Function *F = mod.createFunction("test");
+  Context ctx;
+
+  auto *input =
+      mod.createPlaceholder(ElemKind::FloatTy, {20, 13}, "Input", false);
+  auto *output =
+      mod.createPlaceholder(ElemKind::FloatTy, {20, 10}, "Output", false);
+
+  auto *FC = F->createFullyConnected(ctx, "FC", input, 10);
+  auto *ReLU = F->createRELU("ReLU", FC, FC->getType(0));
+  auto *result = F->createSave("save", ReLU, output);
+
+  size_t origGraphSize = F->getNodes().size();
+
+  KindSet doNotConvertKinds;
+  doNotConvertKinds.insert(Kinded::Kind::ReluNodeKind);
+  TypeAToTypeBFunctionConverter converter(
+      *F, ElemKind::FloatTy, ElemKind::Float16Ty, &doNotConvertKinds);
+  converter.convert();
+
+  // We should have 4 more nodes:
+  // 1 conversion float to float16 for each input of FC (3)
+  // 1 conversion float16 to float for the result of FC.
+  EXPECT_EQ(F->getNodes().size(), origGraphSize + 4);
+  // Make sure the save node is still in the function and is unchanged.
+  EXPECT_TRUE(std::find(F->getNodes().begin(), F->getNodes().end(), *result) !=
+              F->getNodes().end());
+  EXPECT_EQ(result->getOutput(), NodeValue(output, 0));
+  // Check that the save is fed from a conversion from float16 to float.
+  auto *resultInput = llvm::dyn_cast<ReluNode>(result->getInput());
+  ASSERT_NE(resultInput, nullptr);
+  EXPECT_EQ(resultInput->getElementType(0), ElemKind::FloatTy);
+  EXPECT_EQ(resultInput, ReLU);
+
+  // Check that the ReLU is fed from a conversion from float16 to float.
+  auto *convertedToReLUInput = llvm::dyn_cast<ConvertToNode>(ReLU->getInput());
+  ASSERT_NE(convertedToReLUInput, nullptr);
+  EXPECT_EQ(convertedToReLUInput->getElementType(0), ElemKind::FloatTy);
+
+  // Check that this conversion comes from the float16 FC node.
+  auto *convertedFC =
+      llvm::dyn_cast<FullyConnectedNode>(convertedToReLUInput->getInput());
+  ASSERT_NE(convertedFC, nullptr);
+  EXPECT_EQ(convertedFC->getElementType(0), ElemKind::Float16Ty);
+  // Check that all the input of FC are convertTo node with from float to
+  // Float16Ty.
+  for (unsigned idx = 0, end = convertedFC->getNumInputs(); idx != end; ++idx) {
+    auto *convertedFCInput =
+        llvm::dyn_cast<ConvertToNode>(convertedFC->getNthInput(idx));
+    ASSERT_NE(convertedFCInput, nullptr);
+    EXPECT_EQ(convertedFCInput->getElementType(0), ElemKind::Float16Ty);
+    EXPECT_TRUE(llvm::isa<Placeholder>(convertedFCInput->getInput()));
+    EXPECT_EQ(convertedFCInput->getInput().getElementType(), ElemKind::FloatTy);
+  }
+  // At this point we know the input of FC is convertTo(placeholder).
+  // Check that this placeholder is the expected input.
+  EXPECT_EQ(convertedFC->getInput().getNode()->getNthInput(0).getNode(), input);
+}
+
+/// Check that don't convert types we didn't asked for.
+/// Namely, check that:
+/// \verbatim
+/// Input: Placeholder(float)
+///    |
+///    V
+///   TopK(float, Int64I)
+///    |     |
+///    |     |  Output: Placeholder(Int64I)
+///    |     |    /
+///    |     V   V
+///    |     Save   Output: Placeholder(float)
+///    |            |
+///    |    +-------+
+///    |   /
+///    V  V
+///   Save
+/// \endverbatim
+///
+/// Gets converted into:
+/// \verbatim
+/// Input: Placeholder(float)
+///    |
+///    V
+/// ConvertTo(float16)
+///    |
+///    V
+///   TopK(float, Int64I)
+///    |     |
+///    |     |  Output: Placeholder(Int64I)
+///    |     |    /
+///    |     V   V
+///    |     Save   Output: Placeholder(float)
+///    V               |
+/// ConvertTo(float)   |
+///    |               |
+///    |    +----------+
+///    |   /
+///    V  V
+/// \endverbatim
+///
+/// In particular, the input and outputs of the network shouldn't be modified
+/// as well as the Int64I result.
+TEST_P(AllBackends, int64IConversionFloatToFloat16) {
+  Module mod;
+  Function *F = mod.createFunction("test");
+  Context ctx;
+
+  auto *input =
+      mod.createPlaceholder(ElemKind::FloatTy, {20, 13}, "Input", false);
+  auto *output =
+      mod.createPlaceholder(ElemKind::FloatTy, {20, 3}, "Output", false);
+  auto *outputIdx =
+      mod.createPlaceholder(ElemKind::Int64ITy, {20, 3}, "Output", false);
+
+  auto *topK = F->createTopK("topK", input, 3);
+  auto *result = F->createSave("save", topK->getValues(), output);
+  auto *resultIndices = F->createSave("saveIdx", topK->getIndices(), outputIdx);
+
+  size_t origGraphSize = F->getNodes().size();
+
+  TypeAToTypeBFunctionConverter converter(*F, ElemKind::FloatTy,
+                                          ElemKind::Float16Ty);
+  converter.convert();
+
+  // We should have 2 more nodes:
+  // 1 conversion float to float16 the input of TopK
+  // and 1 conversion float16 to float for the result of TopK.
+  EXPECT_EQ(F->getNodes().size(), origGraphSize + 2);
+  // Make sure the save node is still in the function and is unchanged.
+  EXPECT_TRUE(std::find(F->getNodes().begin(), F->getNodes().end(), *result) !=
+              F->getNodes().end());
+  EXPECT_EQ(result->getOutput(), NodeValue(output, 0));
+  // Check that the save is fed from a conversion from float16 to float.
+  auto *convertedBackTopKRes =
+      llvm::dyn_cast<ConvertToNode>(result->getInput());
+  ASSERT_NE(convertedBackTopKRes, nullptr);
+  EXPECT_EQ(convertedBackTopKRes->getElementType(0), ElemKind::FloatTy);
+  auto *convertedTopK =
+      llvm::dyn_cast<TopKNode>(convertedBackTopKRes->getInput());
+  ASSERT_NE(convertedTopK, nullptr);
+  EXPECT_EQ(convertedTopK->getElementType(0), ElemKind::Float16Ty);
+  EXPECT_EQ(convertedTopK->getElementType(1), ElemKind::Int64ITy);
+  // Check that the input of TopK is a convertTo node from float to
+  // Float16Ty.
+  auto *convertedTopKInput =
+      llvm::dyn_cast<ConvertToNode>(convertedTopK->getInput());
+  ASSERT_NE(convertedTopKInput, nullptr);
+  EXPECT_EQ(convertedTopKInput->getElementType(0), ElemKind::Float16Ty);
+  EXPECT_TRUE(llvm::isa<Placeholder>(convertedTopKInput->getInput()));
+  EXPECT_EQ(convertedTopKInput->getInput().getElementType(), ElemKind::FloatTy);
+  // At this point we know the input of TopK is convertTo(placeholder).
+  // Check that this placeholder is the expected input.
+  EXPECT_EQ(convertedTopK->getInput().getNode()->getNthInput(0).getNode(),
+            input);
+
+  // Now check the Int64ITy part of the graph.
+  // Make sure the save node for the indices is still in the function and is
+  // unchanged.
+  EXPECT_TRUE(std::find(F->getNodes().begin(), F->getNodes().end(),
+                        *resultIndices) != F->getNodes().end());
+  EXPECT_EQ(resultIndices->getOutput(), NodeValue(outputIdx, 0));
+  EXPECT_EQ(resultIndices->getInput(), NodeValue(convertedTopK, 1));
+  EXPECT_EQ(resultIndices->getInput().getElementType(), ElemKind::Int64ITy);
+}
+
+INSTANTIATE_TEST_CASE_P(Interpreter, AllBackends,
+                        ::testing::Values(BackendKind::Interpreter));
+
+#ifdef GLOW_WITH_CPU
+INSTANTIATE_TEST_CASE_P(CPU, AllBackends, ::testing::Values(BackendKind::CPU));
+#endif // GLOW_WITH_CPU
+
+#ifdef GLOW_WITH_OPENCL
+INSTANTIATE_TEST_CASE_P(OpenCL, AllBackends,
+                        ::testing::Values(BackendKind::OpenCL));
+#endif // GLOW_WITH_OPENCL

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -481,6 +481,16 @@ int main(int argc, char **argv) {
       .autoVerify(VerifyKind::SameShape, {"Values", "Indices"});
 
   //===--------------------------------------------------------------------===//
+  //                   Conversions
+  //===--------------------------------------------------------------------===//
+
+  BB.newInstr("ConvertTo")
+      .addOperand("Result", OperandKind::Out)
+      .addOperand("Input", OperandKind::In)
+      .autoVerify(VerifyKind::SameShape, {"Result", "Input"})
+      .autoIRGen();
+
+  //===--------------------------------------------------------------------===//
   //                Backend-Specific Instructions
   //===--------------------------------------------------------------------===//
 

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -521,6 +521,16 @@ int main(int argc, char **argv) {
                     "tensor. The input shape {D_0, D_1, ... D_n} results in "
                     "the outputs {D_0, D_1, ... D_n-1, K}, sorted in "
                     "non-decreasing order.");
+  //===--------------------------------------------------------------------===//
+  //                Conversions
+  //===--------------------------------------------------------------------===//
+
+  BB.newNode("ConvertTo")
+      .addInput("Input")
+      .addResultFromCtorArg()
+      .setDocstring(
+          "Convert the input from its current type to the destination "
+          "type. The input and output types must have the same shapes");
 
   //===--------------------------------------------------------------------===//
   //                Backend-Specific Nodes


### PR DESCRIPTION
Note: The diff will be much more approachable when #1821 and #1820 land, since this PR includes both these PR and the change for this new feature. Reviewing just the last commit of this PR would have the same effect as waiting for #1821 and #1820  to be merged.

*Description*
This patch specializes the FunctionConverter class to feature a converter
from one element type to another.
In essence this new TypeAToTypeBFunctionConverter class scans the
function, morph the node from TypeA to TypeB and inserts the right
conversions to/from typeA and typeB around the converted nodes.

This initial version follows the same schema as the quantization
of function, meaning there are no attempt to eliminate useless conversion.
This feature will be added later.

*Testing*
Tests added.