### PR TITLE
[Imagenet tests] Add cmake rule for imagenet_299 directory.

### DIFF
--- a/tests/images/CMakeLists.txt
+++ b/tests/images/CMakeLists.txt
@@ -7,6 +7,11 @@ foreach(filename ${files})
   configure_file(${filename} ${CMAKE_CURRENT_BINARY_DIR}/${filename} COPYONLY)
 endforeach(filename)
 
+file(GLOB files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} imagenet_299/*.png)
+foreach(filename ${files})
+  configure_file(${filename} ${CMAKE_CURRENT_BINARY_DIR}/${filename} COPYONLY)
+endforeach(filename)
+
 file(GLOB files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} mnist/*.png)
 foreach(filename ${files})
   configure_file(${filename} ${CMAKE_CURRENT_BINARY_DIR}/${filename} COPYONLY)


### PR DESCRIPTION
*Description*: imagenet_299 directory is not copied to build directory currently, so the test fails to find files from imagenet_299
*Testing*: `tests/images/run.sh`

This is followup to PR #1651