### PR TITLE
[unittests] New BackendCorrectnessTest API enabling easy quantization

### DIFF
--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -34,6 +34,10 @@ class MockBackend : public Backend {
   }
 };
 
+/// Pair representing a pointer to a Function with a single output, and the
+/// allocated Tensor that backs the Placeholder of the single output.
+using FunctionTensorPair = std::pair<Function *, Tensor *>;
+
 void inferConvNet(Tensor *inputs, Tensor *filter, Tensor *bias, Tensor *out,
                   BackendKind kind);
 
@@ -84,7 +88,7 @@ void inferBasicConvNet(Tensor *inputs, Tensor *out, BackendKind kind,
 void inferTanhConcatNet(Tensor *input1, Tensor *input2, Tensor *input3,
                         Tensor *out, BackendKind kind);
 
-void inferBasicFCNet(Tensor *inputs, Tensor *out, BackendKind kind);
+FunctionTensorPair createAndInitBasicFCNet(Context &ctx, ExecutionEngine &EE);
 
 void inferMixedNet(Tensor *inputs, Tensor *out, BackendKind kind);
 

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -188,6 +188,7 @@ target_link_libraries(BackendCorrectnessTest
                         IR
                         ExecutionEngine
                         Support
+                        Quantization
                         gtest
                         testMain)
 

--- a/tests/unittests/OCLTest.cpp
+++ b/tests/unittests/OCLTest.cpp
@@ -40,19 +40,6 @@ TEST(OpenCLCorrectnessTest, convOps) {
   EXPECT_TRUE(out1.isEqual(out2));
 }
 
-TEST(OpenCLCorrectnessTest, basicFCNet) {
-  PseudoRNG PRNG;
-  Tensor inputs(ElemKind::FloatTy, {2, 3, 16, 16});
-  inputs.getHandle().initXavier(1, PRNG);
-  Tensor out1;
-  Tensor out2;
-
-  inferBasicFCNet(&inputs, &out1, BackendKind::OpenCL);
-  inferBasicFCNet(&inputs, &out2, BackendKind::Interpreter);
-
-  EXPECT_TRUE(out1.isEqual(out2));
-}
-
 TEST(OpenCLCorrectnessTest, inferMixedNet) {
   PseudoRNG PRNG;
   Tensor inputs(ElemKind::FloatTy, {2, 3, 16, 16});


### PR DESCRIPTION
*Description*: Our BackendCorrectnessTests are all float. We ideally would also test them quantized. It is preferable not to have to rewrite them all quantized. This PR intends to provide a better API for constructing a Function, optionally profiling/quantizing it, and then comparing its output to the Interpreter. For now I only did this for `BasicFCNet` as a trial -- if it's agreed this is a good direction I will convert over the other BackendCorrectnessTests in a future PR.

*Testing*: ninja test

*Documentation*: N/A