### PR TITLE
[Function] Fix a nasty bug in eraseNode(Node *)

### DIFF
--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -2171,9 +2171,11 @@ void Function::eraseNode(Node *N) {
   if (Constant *V = dyn_cast<Constant>(N)) {
     return getParent()->eraseConstant(V);
   }
-  auto I = std::find(nodes_.begin(), nodes_.end(), *N);
-  assert(I != nodes_.end() && "Could not find node to delete!");
-  eraseNode(I);
+  assert(std::find_if(nodes_.begin(), nodes_.end(),
+                      [N](const Node &node) -> bool { return &node == N; }) !=
+             nodes_.end() &&
+         "Could not find node to delete!");
+  eraseNode(N->getIterator());
 }
 
 Function *Function::clone(llvm::StringRef newName,


### PR DESCRIPTION
*Description*
Prior to this patch, Function::eraseNode(Node *N) would erase a node
with the same value as N, but not necessarily N. This means that
as soon as two nodes were identical, there was a non-zero chance
that deleting one would actually make the other one being a dangling
pointer.

*Testing*
Added test case.
The added test case would assert (Could not find node to delete) in
debug mode and segmentation fault in release mode without this patch.