### PR TITLE
[build_llvm] Build LLVM in Release mode to reduce memory pressure

### DIFF
--- a/utils/build_llvm.sh
+++ b/utils/build_llvm.sh
@@ -12,7 +12,7 @@ mkdir -p llvm_install
 BASE=$PWD
 
 cd llvm_build
-cmake ../llvm_src/ -G Ninja -DCMAKE_INSTALL_PREFIX="$BASE/llvm_install" -DCMAKE_BUILD_TYPE=RelWithDebInfo
+cmake ../llvm_src/ -G Ninja -DCMAKE_INSTALL_PREFIX="$BASE/llvm_install" -DCMAKE_BUILD_TYPE=Release
 cmake --build . --target install
 
 echo "Built LLVM into " "$BASE/llvm_install"


### PR DESCRIPTION
*Description*: Our `build_llvm.sh` script uses RelWithDebInfo mode, which works OK on Darwin, but seems to cause crazy memory usage during linking on most Linuxes I've tried (Ubuntu, CentOS), leading to oomkiller invocation and general badness.  Since most glow developers don't need to debug LLVM internals, let's default to Release mode here.

As an aside, I'd be inclined to advise devs to get LLVM from a package manager, but it's often pretty hard to get recent LLVM versions from package managers, so I fall back on build locally a lot.
*Testing*: Tried it.
*Documentation*: N/A
Fixes #1628 (even though that was already closed)
