### PR TITLE
[CI] Make dummy circleci config to avoid failures on master.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,1 @@
+version: 2


### PR DESCRIPTION
*Description*:
Dummy circle ci config.

*Testing*:
CI

*Documentation*:
N/A

Tracking here: https://github.com/pytorch/glow/issues/1836