### PR TITLE
Fixes float literals for MSVC.

### DIFF
--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -4075,7 +4075,7 @@ TEST_P(Operator, SoftMax) {
   // res_0 = exp(1) / sum = ~0.011
   // res_1 = exp(3) / sum = ~0.082
   // And so on.
-  out.getHandle<float>() = {0.011, 0.082, 0.05, 0.605, 0.222, 0.03};
+  out.getHandle<float>() = {0.011f, 0.082f, 0.05f, 0.605f, 0.222f, 0.03f};
   EXPECT_TRUE(out.isEqual(*result, 0.001));
 }
 
@@ -4096,7 +4096,7 @@ TEST_P(InterpOnly, FP16SoftMax) {
 
   auto result = ctx_.get(S->getPlaceholder());
   Tensor out(ElemKind::Float16Ty, {1, 6});
-  out.getHandle<float16_t>() = {0.011, 0.082, 0.05, 0.605, 0.222, 0.03};
+  out.getHandle<float16_t>() = {0.011f, 0.082f, 0.05f, 0.605f, 0.222f, 0.03f};
   EXPECT_TRUE(out.isEqual(*result, 0.001));
 }
 

--- a/tests/unittests/caffe2ImporterTest.cpp
+++ b/tests/unittests/caffe2ImporterTest.cpp
@@ -394,8 +394,8 @@ TEST(caffe2, FC) {
 
   auto result = ctx.get(output)->getHandle();
   std::vector<size_t> expectedDims = {2, 4};
-  std::vector<float> expectedValues = {14.1, 32.2, 50.3,  68.4,
-                                       32.1, 77.2, 122.3, 167.4};
+  std::vector<float> expectedValues = {14.1f, 32.2f, 50.3f,  68.4f,
+                                       32.1f, 77.2f, 122.3f, 167.4f};
   EXPECT_TRUE(result.dims().vec() == expectedDims);
   for (size_t i = 0; i < 2 * 4; i++)
     EXPECT_FLOAT_EQ(result.raw(i), expectedValues[i]);
@@ -442,8 +442,8 @@ TEST(caffe2, FCWithFlatten) {
   EE.run();
   auto result = ctx.get(output)->getHandle();
   std::vector<size_t> expectedDims = {2, 4};
-  std::vector<float> expectedValues = {14.1, 32.2, 50.3,  68.4,
-                                       32.1, 77.2, 122.3, 167.4};
+  std::vector<float> expectedValues = {14.1f, 32.2f, 50.3f,  68.4f,
+                                       32.1f, 77.2f, 122.3f, 167.4f};
   result = ctx.get(output)->getHandle();
   EXPECT_TRUE(result.dims().vec() == expectedDims);
   for (size_t i = 0; i < 2 * 4; i++)
@@ -492,8 +492,8 @@ TEST(caffe2, FCTransposed) {
 
   auto result = ctx.get(output)->getHandle();
   std::vector<size_t> expectedDims = {2, 4};
-  std::vector<float> expectedValues = {14.1, 32.2, 50.3,  68.4,
-                                       32.1, 77.2, 122.3, 167.4};
+  std::vector<float> expectedValues = {14.1f, 32.2f, 50.3f,  68.4f,
+                                       32.1f, 77.2f, 122.3f, 167.4f};
   EXPECT_TRUE(result.dims().vec() == expectedDims);
   for (size_t i = 0; i < 2 * 4; i++)
     EXPECT_FLOAT_EQ(result.raw(i), expectedValues[i]);
@@ -541,8 +541,8 @@ TEST(caffe2, FCTransposedWithFlatten) {
   EE.run();
   auto result = ctx.get(output)->getHandle();
   std::vector<size_t> expectedDims = {2, 4};
-  std::vector<float> expectedValues = {14.1, 32.2, 50.3,  68.4,
-                                       32.1, 77.2, 122.3, 167.4};
+  std::vector<float> expectedValues = {14.1f, 32.2f, 50.3f,  68.4f,
+                                       32.1f, 77.2f, 122.3f, 167.4f};
   result = ctx.get(output)->getHandle();
   EXPECT_TRUE(result.dims().vec() == expectedDims);
   for (size_t i = 0; i < 2 * 4; i++)


### PR DESCRIPTION
*Description*:
MSVC requires the `f` suffix on single-precision `float` literals.  This PR fixes float literals for MSVC. 

