### PR TITLE
Allow findSymbol to find non-exported symbols

### DIFF
--- a/lib/Backends/CPU/GlowJIT.cpp
+++ b/lib/Backends/CPU/GlowJIT.cpp
@@ -173,5 +173,5 @@ llvm::JITSymbol GlowJIT::findSymbol(const std::string name) {
   std::string mangledName;
   raw_string_ostream MangledNameStream(mangledName);
   Mangler::getNameWithPrefix(MangledNameStream, name, DL_);
-  return compileLayer_.findSymbol(MangledNameStream.str(), true);
+  return compileLayer_.findSymbol(MangledNameStream.str(), false);
 }


### PR DESCRIPTION
*Description*:
Call findSymbol with hidden symbol.  Under win32, we can not find symbol with option true,
change to false instead.
