### PR TITLE
Disable CPURuntimeNative for MSVC

### DIFF
--- a/lib/Backends/CPU/CMakeLists.txt
+++ b/lib/Backends/CPU/CMakeLists.txt
@@ -48,10 +48,12 @@ add_custom_command(
   COMMAND include-bin "${CMAKE_BINARY_DIR}/libjit.bc" "${CMAKE_BINARY_DIR}/glow/libjit_bc.inc"
   DEPENDS include-bin CPURuntime)
 
+if (NOT MSVC)
 add_library(CPURuntimeNative
               libjit/libjit.cpp
               libjit/libjit_conv.cpp
               libjit/libjit_matmul.cpp)
+endif()
 
 add_library(CPUBackend
             "${CMAKE_BINARY_DIR}/glow/libjit_bc.inc"

--- a/tests/benchmark/CMakeLists.txt
+++ b/tests/benchmark/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(GLOW_WITH_CPU)
+if(GLOW_WITH_CPU AND NOT MSVC)
 add_executable(GemmBench
                GemmBench.cpp)
 target_link_libraries(GemmBench

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -212,6 +212,7 @@ LIST(APPEND UNOPT_TESTS ./tests/BackendCorrectnessTest -optimize-ir=false &&)
 if(GLOW_WITH_CPU)
 target_sources(BackendCorrectnessTest PUBLIC HyphenTest.cpp)
 
+if (NOT MSVC)
 add_executable(GemmTest
                GemmTest.cpp)
 target_link_libraries(GemmTest
@@ -225,6 +226,7 @@ target_link_libraries(GemmTest
                         testMain)
 add_glow_test(GemmTest ${GLOW_BINARY_DIR}/tests/GemmTest)
 LIST(APPEND UNOPT_TESTS ./tests/GemmTest -optimize-ir=false &&)
+endif()
 
 add_executable(LLVMIRGenTest
                LLVMIRGenTest.cpp)


### PR DESCRIPTION
*Description*:
Disable CPURuntimeNative for MSVC
because libjit can not compiled with cl.exe

Related to  https://github.com/pytorch/glow/issues/1144