### PR TITLE
Fixes GlowJIT.cpp for MSVC.

### DIFF
--- a/lib/Backends/CPU/GlowJIT.cpp
+++ b/lib/Backends/CPU/GlowJIT.cpp
@@ -137,7 +137,7 @@ GlowJIT::GlowJIT(llvm::TargetMachine &TM)
   llvm::sys::DynamicLibrary::LoadLibraryPermanently(nullptr);
 }
 
-GlowJIT::ModuleHandle GlowJIT::addModule(std::unique_ptr<Module> M) {
+GlowJIT::ModuleHandle GlowJIT::addModule(std::unique_ptr<llvm::Module> M) {
 // Add the set to the JIT with the resolver and a newly created
 // SectionMemoryManager.
 #if LLVM_VERSION_MAJOR > 6


### PR DESCRIPTION

*Description*:
Fixes GlowJIT.cpp for MSVC by
Change the function prototype from
GlowJIT::ModuleHandle GlowJIT::addModule(std::unique_ptr<Module> M)
to
GlowJIT::ModuleHandle GlowJIT::addModule(std::unique_ptr<llvm::Module> M) {
