### PR TITLE
[Importer] Support arg "order" in Caffe2 Conv, MaxPool and AveragePool ops

### DIFF
--- a/tests/models/caffe2Models/avgpool_nhwc_predict_net.pbtxt
+++ b/tests/models/caffe2Models/avgpool_nhwc_predict_net.pbtxt
@@ -1,0 +1,23 @@
+name: "averagePool_test"
+op {
+  input: "inputs"
+  output: "output"
+  type: "AveragePool"
+  arg {
+    name: "order"
+    s: "NHWC"
+  }
+  arg {
+    name: "kernel"
+    i: 2
+  }
+  arg {
+    name: "stride"
+    i: 1
+  }
+  arg {
+    name: "pad"
+    i: 1
+  }
+}
+external_output: "output"

--- a/tests/models/caffe2Models/avgpool_predict_net.pbtxt
+++ b/tests/models/caffe2Models/avgpool_predict_net.pbtxt
@@ -1,0 +1,19 @@
+name: "averagePool_test"
+op {
+  input: "inputs"
+  output: "output"
+  type: "AveragePool"
+  arg {
+    name: "kernel"
+    i: 2
+  }
+  arg {
+    name: "stride"
+    i: 1
+  }
+  arg {
+    name: "pad"
+    i: 1
+  }
+}
+external_output: "output"

--- a/tests/models/caffe2Models/conv_nhwc_init_net.pbtxt
+++ b/tests/models/caffe2Models/conv_nhwc_init_net.pbtxt
@@ -1,0 +1,32 @@
+name: "init"
+op {
+  output: "conv_w"
+  type: "GivenTensorFill"
+  arg {
+    name: "shape"
+    ints: 1
+    ints: 1
+    ints: 2
+    ints: 2
+  }
+  arg {
+    name: "values"
+    floats: 1.0
+    floats: 1.0
+    floats: 1.0
+    floats: 1.0
+  }
+}
+op {
+  output: "conv_b"
+  type: "GivenTensorFill"
+  arg {
+    name: "shape"
+    ints: 1
+  }
+  arg {
+    name: "values"
+    floats: 2.0
+  }
+}
+

--- a/tests/models/caffe2Models/conv_nhwc_predict_net.pbtxt
+++ b/tests/models/caffe2Models/conv_nhwc_predict_net.pbtxt
@@ -1,0 +1,29 @@
+name: "conv_test"
+op {
+  input: "inputs"
+  input: "conv_w"
+  input: "conv_b"
+  output: "conv_out"
+  type: "Conv"
+  arg {
+    name: "order"
+    s: "NHWC"
+  }
+  arg {
+    name: "kernel"
+    i: 2
+  }
+  arg {
+    name: "stride"
+    i: 1
+  }
+  arg {
+    name: "group"
+    i: 1
+  }
+  arg {
+    name: "pad"
+    i: 1
+  }
+}
+external_output: "conv_out"

--- a/tests/models/caffe2Models/maxpool_nhwc_predict_net.pbtxt
+++ b/tests/models/caffe2Models/maxpool_nhwc_predict_net.pbtxt
@@ -1,0 +1,23 @@
+name: "maxpool_test"
+op {
+  input: "inputs"
+  output: "output"
+  type: "MaxPool"
+  arg {
+    name: "order"
+    s: "NHWC"
+  }
+  arg {
+    name: "kernel"
+    i: 2
+  }
+  arg {
+    name: "stride"
+    i: 1
+  }
+  arg {
+    name: "pad"
+    i: 1
+  }
+}
+external_output: "output"

--- a/tests/models/caffe2Models/maxpool_predict_net.pbtxt
+++ b/tests/models/caffe2Models/maxpool_predict_net.pbtxt
@@ -1,0 +1,19 @@
+name: "maxpool_test"
+op {
+  input: "inputs"
+  output: "output"
+  type: "MaxPool"
+  arg {
+    name: "kernel"
+    i: 2
+  }
+  arg {
+    name: "stride"
+    i: 1
+  }
+  arg {
+    name: "pad"
+    i: 1
+  }
+}
+external_output: "output"


### PR DESCRIPTION
*Description*:

Add arg "order" in Caffe2 Conv, MaxPool and AveragePool ops.
The "order" can be "NCHW" (by default) and "NHWC".
 
*Testing*: 
Unittests added.

*Documentation*:
N/A

Needed for https://github.com/pytorch/glow/issues/1727