### PR TITLE
[caffe2ImporterTest] Add eq unittest caffe2ImporterTest

### DIFF
--- a/tests/models/caffe2Models/eq_op_net.pbtxt
+++ b/tests/models/caffe2Models/eq_op_net.pbtxt
@@ -1,0 +1,11 @@
+name: "eq"
+op {
+  input: "X"
+  input: "Y"
+  output: "eq"
+  name: ""
+  type: "EQ"
+}
+external_input: "X"
+external_input: "Y"
+external_output: "eq"


### PR DESCRIPTION
*Description*: Added EQ node test to caffe2ImporterTest. This checks that the node is imported and the graph is the expect shape.
*Testing*: Run caffe2ImporterTest caffe2.EQ1D passes.
#985 
