### PR TITLE
[Converter] Optimize intermediate conversions away

### DIFF
--- a/include/glow/Converter/TypeAToTypeBFunctionConverter.h
+++ b/include/glow/Converter/TypeAToTypeBFunctionConverter.h
@@ -23,16 +23,11 @@
 
 namespace glow {
 
-class Function;
-class Module;
-
 /// This helper class converts values of typeA into values of typeB.
 /// The nodes producing these values are morphed into the new type
 /// and proper conversions from/to typeA and typeB are inserted.
 class TypeAToTypeBFunctionConverter : public FunctionConverter {
 protected:
-  /// Module of the function to be converted.
-  Module &mod_;
   /// Destination type of the conversions.
   ElemKind dstKind_;
   /// Source type of the conversions. I.e., the values of this

--- a/include/glow/Quantization/Base/Base.h
+++ b/include/glow/Quantization/Base/Base.h
@@ -76,6 +76,11 @@ enum Schema {
 /// parameters \p TQP.
 int8_t quantize(float input, const TensorQuantizationParams &TQP);
 
+/// Converts a floating point \p tensor to int8 based on the quantization
+/// parameters \p TQP.
+Tensor quantizeTensor(const Tensor &tensor,
+                      const TensorQuantizationParams &TQP);
+
 /// Converts int8 quantized value back to floating point number based on
 /// the quantization parameters \p TQP.
 float dequantize(int8_t input, const TensorQuantizationParams &TQP);

--- a/lib/Converter/TypeAToTypeBFunctionConverter.cpp
+++ b/lib/Converter/TypeAToTypeBFunctionConverter.cpp
@@ -23,8 +23,7 @@ using namespace glow;
 TypeAToTypeBFunctionConverter::TypeAToTypeBFunctionConverter(
     Function &F, ElemKind fromKind, ElemKind toKind,
     const KindSet *doNotConvertKinds)
-    : FunctionConverter(F), mod_(*F.getParent()), dstKind_(toKind),
-      srcKind_(fromKind) {
+    : FunctionConverter(F), dstKind_(toKind), srcKind_(fromKind) {
   if (doNotConvertKinds) {
     doNotConvertKinds_ = *doNotConvertKinds;
   }

--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -1635,13 +1635,10 @@ static void optimizeQuantization(Function *F) {
         auto *NC = F->getParent()->createConstant(Q->getResult().getType(),
                                                   C->getName());
         // Quantize C into NC.
-        auto srcHandle = C->getHandle();
-        auto destHandle = NC->getHandle<int8_t>();
         TensorQuantizationParams params{Q->getResult().getType()->getScale(),
                                         Q->getResult().getType()->getOffset()};
-        for (size_t i = 0, e = destHandle.size(); i < e; ++i) {
-          destHandle.raw(i) = quantization::quantize(srcHandle.raw(i), params);
-        }
+        NC->getPayload() =
+            quantization::quantizeTensor(C->getPayload(), params);
         Q->getResult().replaceAllUsesOfWith(NC);
         continue;
       }

--- a/lib/Quantization/Base/Base.cpp
+++ b/lib/Quantization/Base/Base.cpp
@@ -27,6 +27,19 @@ int8_t quantize(float input, const TensorQuantizationParams &TQP) {
   return quantization::clip<int32_t, int8_t>((int32_t)nearbyintf(result));
 }
 
+Tensor quantizeTensor(const Tensor &tensor,
+                      const TensorQuantizationParams &TQP) {
+  Tensor tmp(ElemKind::Int8QTy, tensor.dims(), TQP.scale, TQP.offset);
+  assert(tensor.getElementType() == ElemKind::FloatTy &&
+         "Type not supported yet");
+  auto srcHandle = tensor.getHandle();
+  auto destHandle = tmp.getHandle<int8_t>();
+  for (size_t i = 0, e = destHandle.size(); i < e; ++i) {
+    destHandle.raw(i) = quantization::quantize(srcHandle.raw(i), TQP);
+  }
+  return tmp;
+}
+
 float dequantize(int8_t input, const TensorQuantizationParams &TQP) {
   return TQP.scale * (input - TQP.offset);
 }

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -266,8 +266,6 @@ protected:
   }
 
 private:
-  /// Shortcut to the module of function_.
-  Module &mod_;
   /// Execution engine used to check is a quantized operator is
   /// supported.
   const ExecutionEngine &EE_;
@@ -284,8 +282,7 @@ public:
   FunctionQuantizer(Function &F, const ExecutionEngine &EE,
                     llvm::ArrayRef<NodeQuantizationInfo> quantizationInfos,
                     const KindSet &doNotQuantizeKinds)
-      : FunctionConverter(F), mod_(*F.getParent()), EE_(EE),
-        doNotQuantizeKinds_(doNotQuantizeKinds) {
+      : FunctionConverter(F), EE_(EE), doNotQuantizeKinds_(doNotQuantizeKinds) {
     // Build a mapping between node name and TensorQuantizatonParams.
     for (const auto &quantizationInfo : quantizationInfos) {
       nodeToTQP_.emplace(quantizationInfo.nodeOutputName_,

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -339,6 +339,7 @@ quantizeFunction(const ExecutionEngine &EE,
 
   FunctionQuantizer quantizer(*G, EE, quantizationInfos, doNotQuantizeKinds);
   quantizer.convert();
+  quantizer.optimizeConversions();
 
   return G;
 }

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -265,6 +265,21 @@ protected:
     }
   }
 
+  /// Check if \p tensor can be converted to \p dstTy.
+  /// \see FunctionConverter::canConvert.
+  bool canConvert(const Tensor &tensor, TypeRef dstTy) const override {
+    return !tensor.getType().isQuantizedType() && dstTy->isQuantizedType();
+  }
+
+  /// Convert a \p tensor to \p dstTy.
+  /// \see FunctionConverter::convertTensor.
+  void convertTensor(Tensor &tensor, TypeRef dstTy) override {
+    assert(dstTy->getElementType() == ElemKind::Int8QTy &&
+           "Type not supported yet");
+    TensorQuantizationParams params{dstTy->getScale(), dstTy->getOffset()};
+    tensor = quantizeTensor(tensor, params);
+  }
+
 private:
   /// Execution engine used to check is a quantized operator is
   /// supported.


### PR DESCRIPTION
Note: After this PR lands, the only conversions left in ResNet50 converted to FP16 are the input and output of the networks. I'm working on adding a nice setup for this so that it will be easy to run a fully converted model with pre- and post- function for copying the input and output at the right place while running a model without conversions in the way.

*Description*
After converting a model we often end up with patterns like this:
```
conversion (conversion A to B) to C
```
Where A and C are actually the same type.

This PR adds a method to optimize away this kind of conversions as well as the conversions applied to constants. 

This optimization is not performed during the main conversion procedure (FunctionConverter::convert) because it potentially changes the semantic of the program when B would have incured some precision loss (e.g., float(int64_t(float (A))) != float(A)).

This works seamlessly for the FunctionQuantizer and the TypeAToTypeBFunctionConverter.

*Testing*
Added test case.