### PR TITLE
[Loader] Add an option to run a model in fp16

### DIFF
--- a/tools/loader/CMakeLists.txt
+++ b/tools/loader/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(image-classifier
 target_link_libraries(image-classifier
                       PRIVATE
                         Base
+                        Converter
                         Importer
                         ExecutionEngine
                         Quantization)


### PR DESCRIPTION
*Description*
This patch adds an option `-convert-to-fp16` to convert all fp32 operators
into fp16 ones.

We may want to expose more conversion options in the future and change
the `convert-to` option to something taking an enum like fp32-to-fp16.

As part of the conversion mechanism it is possible to choose which nodes
are okay to convert (`-do-not-convert-nodes=<listOfNodes>`).

The conversion process does not alter the inputs and outputs of the
network. Thus, the converted graph will have ConvertToNode at least
at its start and end.

*Testing*
Able to convert and run resnet50 in fp16 with the interpreter.

*Documentation*
None so far, we want the interpreter to fully support fp16 before people
play with it.

Related to #1329