### PR TITLE
[NodeGen] Update the docstring for ConvertToNode. NFC

### DIFF
--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -530,7 +530,10 @@ int main(int argc, char **argv) {
       .addResultFromCtorArg()
       .setDocstring(
           "Convert the input from its current type to the destination "
-          "type. The input and output types must have the same shapes");
+          "type. The input and output types must have the same shapes. "
+          "Moreover the input and output types must not be quantized types. "
+          "Quantized types should use the appropriate Quantize, Dequantize, "
+          "and Rescale nodes.");
 
   //===--------------------------------------------------------------------===//
   //                Backend-Specific Nodes


### PR DESCRIPTION
*Description*
Clarify that the ConvertToNode is not supposed to be used for quantized
types. Instead call out in the docstring that the related quantization
nodes should be used.

Sorry for the delay @jfix71!