### PR TITLE
[Verifier] Check that the type of a constant and its tensor matches

### DIFF
--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -100,6 +100,8 @@ public:
   std::string getDebugDesc() const;
 
   llvm::hash_code getHash() const;
+
+  void verify() const;
 };
 
 /// Placeholder nodes are unbound-storage. The content tensors are attached to

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -287,6 +287,11 @@ static void verifyOutputAndGradOutputTypes(NodeValue output,
          "Types of output and its gradient should be the same");
 }
 
+void Constant::verify() const {
+  assert(*getType() == getPayload().getType() &&
+         "Underlying tensor type doesn't match constant type");
+}
+
 void ConvolutionGradNode::verify() const {
   verifyInputAndGradInputTypes(getInput(), getGradOfInputNamedInput());
   verifyInputAndGradInputTypes(getFilter(), getGradOfInputNamedFilter());

--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -1673,7 +1673,7 @@ static NodeValue convertConstant(Module &mod, Constant &constant,
 }
 
 /// Optimize away ConvertToNode.
-/// This basically turns conversion(conversion A to B) to C"
+/// This basically turns "conversion(conversion A to B) to C"
 /// into noop if the type of A and C are the same.
 ///
 /// This method potentially changes the semantic of the program

--- a/tests/unittests/graphTest.cpp
+++ b/tests/unittests/graphTest.cpp
@@ -1155,4 +1155,33 @@ TEST(Graph, verifyConstantNoWriters) {
   EXPECT_DEATH(M.verify(), "");
 }
 
+/// Check that the verifier will complain if a constant and its
+/// underlying tensor have mismatching types.
+/// Here the constant is updated but not the tensor.
+TEST(Graph, verifyConstantTensorTypeMatchesConstantTypeChanged) {
+  Module M;
+
+  auto *input = M.createConstant(ElemKind::FloatTy, {5}, "input");
+  // Fresh constant should verify just fine.
+  input->verify();
+
+  input->setType(0, M.uniqueType(ElemKind::Float16Ty, {5}));
+
+  EXPECT_DEATH(input->verify(), "");
+}
+
+/// Check that the verifier will complain if a constant and its
+/// underlying tensor have mismatching types.
+/// Here the tensor is updated but not the constant.
+TEST(Graph, verifyConstantTensorTypeMatchesTensorTypeChanged) {
+  Module M;
+
+  auto *input = M.createConstant(ElemKind::FloatTy, {5}, "input");
+  // Fresh constant should verify just fine.
+  input->verify();
+  input->getPayload().convertToType(ElemKind::Float16Ty);
+
+  EXPECT_DEATH(input->verify(), "");
+}
+
 #endif /* NDEBUG */


### PR DESCRIPTION
*Description*
Right now, the type of a constant and the type of its underlying tensor
are stored in two different places. As a result, it is possible to
modify one without modifying the other ending up in a situation
where the constant and its tensor have different types.

This patch makes sure that the verifier reports this problem.

*Testing*
Added test case