### PR TITLE
[ONNXifi] Make onnxRunGraph execute Glow graph asynchronously

### DIFF
--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -26,6 +26,10 @@ bool BackendId::isOpSupported(Kinded::Kind opKind, ElemKind elementTy) {
   return executionEngine_.isOpSupported(opKind, elementTy);
 }
 
+void Backend::runAsync(const std::function<void(void)> &fn) {
+  threadPool_.submit(fn);
+}
+
 bool Event::signal() {
   {
     std::lock_guard<std::mutex> guard(mutex_);

--- a/lib/Onnxifi/Base.h
+++ b/lib/Onnxifi/Base.h
@@ -16,6 +16,8 @@
 #ifndef GLOW_ONNXIFI_BASE_H
 #define GLOW_ONNXIFI_BASE_H
 
+#include "ThreadPool.h"
+
 #include "glow/ExecutionEngine/ExecutionEngine.h"
 #include "glow/Importer/ONNXIFIModelLoader.h"
 
@@ -62,8 +64,13 @@ public:
   /// \returns Execution Engine associated with the Backend.
   glow::ExecutionEngine &getEE() { return backendIdPtr_->getEE(); }
 
+  /// Run async using backend thread pool.
+  void runAsync(const std::function<void(void)> &fn);
+
 private:
   BackendIdPtr backendIdPtr_;
+  // ThreadPool instance for the backend.
+  ThreadPool threadPool_;
 };
 
 typedef Backend *BackendPtr;

--- a/lib/Onnxifi/CMakeLists.txt
+++ b/lib/Onnxifi/CMakeLists.txt
@@ -5,7 +5,12 @@ add_library(onnxifi-glow
               Base.cpp
               onnxifiGlow.cpp)
 
+add_library(onnxifi-glow-thread-pool
+              ThreadPool.cpp)
+
 target_link_libraries(onnxifi-glow
                       PUBLIC
                         ExecutionEngine
-                        Importer)
+                        Importer
+                      PRIVATE
+                        onnxifi-glow-thread-pool)

--- a/lib/Onnxifi/ThreadPool.cpp
+++ b/lib/Onnxifi/ThreadPool.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "ThreadPool.h"
+
+#include <iostream>
+
+namespace glow {
+namespace onnxifi {
+
+ThreadPool::ThreadPool(unsigned numWorkers) : shouldStop_(false) {
+  // Intialize all workers and make each one run threadPoolWorkerMain.
+  for (unsigned i = 0; i < numWorkers; i++) {
+    std::thread th(std::bind(&ThreadPool::threadPoolWorkerMain, this));
+    workers_.push_back(std::move(th));
+  }
+}
+
+ThreadPool::~ThreadPool() {
+  // Lock mutex before signalling for threads to stop to make sure
+  // a thread can't wait on the condition variable after checking the
+  // *old* value of shouldStop_.
+  std::unique_lock<std::mutex> lock(workQueueMtx_);
+
+  // Signal to workers to stop.
+  shouldStop_ = true;
+
+  // Notify all worker threads in case any are waiting on the condition
+  // variable.
+  lock.unlock();
+  queueNotEmpty_.notify_all();
+
+  // Join all worker threads.
+  for (auto &w : workers_) {
+    w.join();
+  }
+  workers_.clear();
+}
+
+void ThreadPool::submit(const std::function<void(void)> &fn) {
+  // Add fn to the work queue.
+  std::unique_lock<std::mutex> lock(workQueueMtx_);
+  workQueue_.push(fn);
+  lock.unlock();
+  queueNotEmpty_.notify_one();
+}
+
+void ThreadPool::threadPoolWorkerMain() {
+  std::unique_lock<std::mutex> lock(workQueueMtx_, std::defer_lock);
+
+  while (!shouldStop_) {
+    // Lock the lock after processing a work item.
+    lock.lock();
+
+    // If work queue is empty, wait to be signalled when
+    // a work item is submitted.
+    while (workQueue_.empty() && !shouldStop_) {
+      queueNotEmpty_.wait(lock);
+    }
+
+    // If shouldStop_ was set to false while the thread
+    // was asleep, break out of the main loop.
+    if (shouldStop_) {
+      break;
+    }
+
+    // Pop a work item from the queue, and make sure to unlock
+    // the lock before processing it.
+    auto workItem = workQueue_.front();
+    workQueue_.pop();
+    lock.unlock();
+
+    // Process work item.
+    workItem();
+  }
+}
+} // namespace onnxifi
+} // namespace glow

--- a/lib/Onnxifi/ThreadPool.h
+++ b/lib/Onnxifi/ThreadPool.h
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_ONNXIFI_THREAD_POOL_H
+#define GLOW_ONNXIFI_THREAD_POOL_H
+
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include <vector>
+
+namespace glow {
+namespace onnxifi {
+
+/// Thread pool for asynchronous execution of generic functions.
+class ThreadPool final {
+public:
+  /// Constructor. Initializes a thread pool with \p numWorkers
+  /// threads and has them all run ThreadPool::threadPoolWorkerMain.
+  ThreadPool(unsigned numWorkers = kNumWorkers);
+
+  /// Destructor. Signals to all threads to stop and waits for all of them
+  /// to exit.
+  ~ThreadPool();
+
+  /// Submit \p fn as a work item for the thread pool.
+  void submit(const std::function<void(void)> &fn);
+
+private:
+  /// Main loop run by the workers in the thread pool.
+  void threadPoolWorkerMain();
+
+  /// The default number of workers in the thread pool (overridable).
+  constexpr static unsigned kNumWorkers = 10;
+
+  /// Flag checked by the workers in between work items to determine
+  /// whether they should stop and exit.
+  std::atomic<bool> shouldStop_;
+
+  /// Queue of work items.
+  std::queue<std::function<void(void)>> workQueue_;
+
+  /// Mutex to coordinate access to the work queue.
+  std::mutex workQueueMtx_;
+
+  /// Condition variable to signal to threads when work is added to
+  /// the work queue.
+  std::condition_variable queueNotEmpty_;
+
+  /// Vector of worker thread objects.
+  std::vector<std::thread> workers_;
+};
+} // namespace onnxifi
+} // namespace glow
+
+#endif // GLOW_ONNXIFI_THREAD_POOL_H

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -278,6 +278,18 @@ add_glow_test(NAME onnxImporterTest
               COMMAND ${GLOW_BINARY_DIR}/tests/onnxImporterTest
               WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
+add_executable(onnxifiThreadPoolTest
+               onnxifiThreadPoolTest.cpp)
+target_link_libraries(onnxifiThreadPoolTest
+                      PRIVATE
+                        onnxifi-glow-thread-pool
+                        gtest
+                        testMain)
+target_include_directories(onnxifiThreadPoolTest PRIVATE ${CMAKE_SOURCE_DIR}/lib/Onnxifi)
+add_glow_test(NAME onnxifiThreadPoolTest
+              COMMAND ${GLOW_BINARY_DIR}/tests/onnxifiThreadPoolTest
+              WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+
 LIST(APPEND UNOPT_TESTS
        ./tests/backendTest -optimize-ir=false &&
        ./tests/MLTest -optimize-ir=false &&

--- a/tests/unittests/onnxifiThreadPoolTest.cpp
+++ b/tests/unittests/onnxifiThreadPoolTest.cpp
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "ThreadPool.h"
+#include "gtest/gtest.h"
+
+#include <future>
+#include <vector>
+
+using namespace glow::onnxifi;
+
+TEST(onnxifiThreadPool, BasicTest) {
+  const unsigned numWorkers = 100;
+  const unsigned numWorkItems = 1000;
+  ThreadPool tp(numWorkers);
+
+  // Create vectors to store futures and promises for
+  // communicating results of work done on thread pool.
+  std::vector<std::future<int>> futures;
+  futures.reserve(numWorkItems);
+  std::vector<std::promise<int>> promises(numWorkItems);
+
+  // Submit 'numWorkItems' work items to the thread pool;
+  // each task takes its index and computes and returns
+  // 2x its index.
+  for (unsigned i = 0; i < numWorkItems; ++i) {
+    auto &p = promises[i];
+    futures.emplace_back(p.get_future());
+    tp.submit([&p, i]() { p.set_value(2 * i); });
+  }
+
+  // Check that every future holds the expected result
+  // (2x its index).
+  for (unsigned i = 0; i < numWorkItems; ++i) {
+    futures[i].wait();
+    auto result = futures[i].get();
+    EXPECT_EQ(result, 2 * i);
+  }
+}


### PR DESCRIPTION
**Description**
This commit modifies `onnxRunGraph` to make graph execution asynchronous
by submitting it as a lambda to an instance of `ThreadPool` (a new class
encapsulating a thread pool) stored in the `Backend` class. `ThreadPool`
consists of an adjustable number of threads that continuously pop and
execute an item from a common queue of `std::function<void(void)>` objects.

This commit fixes #1570.

**Testing**
This commit adds a unit test for the new `ThreadPool` class. It has also been tested on two known good ONNXifi tests, `test_concat_2d_axis_1`
and `test_concat_2d_axis_1`:

```
$ .setuptools-cmake-build/onnxifi_test_driver_gtests /tmp/onnx_tests
[==========] Running 2 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 2 tests from ONNXCppAllTest/ONNXCppDriverTest
[ RUN      ] ONNXCppAllTest/ONNXCppDriverTest.ONNXCppDriverUnitTest/test_concat_2d_axis_1
[       OK ] ONNXCppAllTest/ONNXCppDriverTest.ONNXCppDriverUnitTest/test_concat_2d_axis_1 (89 ms)
[ RUN      ] ONNXCppAllTest/ONNXCppDriverTest.ONNXCppDriverUnitTest/test_concat_3d_axis_1
[       OK ] ONNXCppAllTest/ONNXCppDriverTest.ONNXCppDriverUnitTest/test_concat_3d_axis_1 (59 ms)
[----------] 2 tests from ONNXCppAllTest/ONNXCppDriverTest (148 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test case ran. (148 ms total)
[  PASSED  ] 2 tests.
```
 as well as the resnet-50 C2/Glow integration test:
```
$ pytest -s caffe2/python/onnx/test_onnxifi.py 
========================================================================================================= test session starts =========================================================================================================
platform darwin -- Python 3.6.2+, pytest-3.8.2, py-1.7.0, pluggy-0.7.1
plugins: hypothesis-3.76.0

...                                                                                                                                                                                                                 

caffe2/python/onnx/test_onnxifi.py ssBatch size: 1, repeat inference 1 times

...
C2 runtime: 0.414517879486084s
Conversion time: 15.36s
Onnxifi runtime: 0.140455961227417s, improvement: 66.11582559441025%
.

================================================================================================ 1 passed, 2 skipped in 43.76 seconds =================================================================================================
```

Resnet-50 ONNX statistics on master, before this change:
```
C2 runtime: 0.411358118057251s
Conversion time: 15.47s
Onnxifi runtime: 0.1417860984802246s, improvement: 65.53219876883736%
```