### PR TITLE
[Quantization] Support int32 quantized bias for quantized Conv

### DIFF
--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -928,8 +928,17 @@ void LLVMIRGen::generateLLVMIRForDataParallelInstr(
 
     auto *stackedOpCall =
         createCall(builder, F, {loopCount, srcPtr, destScale, destOffset});
-    auto *destAddr = builder.CreateGEP(builder.getInt8Ty(), destPtr, loopCount,
-                                       "buffer.element.addr");
+    llvm::Value *destAddr = nullptr;
+    if (dest->getElementType() == ElemKind::Int8QTy) {
+      destAddr = builder.CreateGEP(builder.getInt8Ty(), destPtr, loopCount,
+                                   "buffer.element.addr");
+    } else if (dest->getElementType() == ElemKind::Int32QTy) {
+      destAddr = builder.CreateGEP(builder.getInt32Ty(), destPtr, loopCount,
+                                   "buffer.element.addr");
+    } else {
+      GLOW_ASSERT("Type is not supported.");
+    }
+
     builder.CreateStore(stackedOpCall, destAddr);
     break;
   }

--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -1184,6 +1184,12 @@ int8_t libjit_element_quantize_kernel_i8(size_t idx, const float *inW,
   return (int8_t)MAX(INT8_MIN, MIN(INT8_MAX, result));
 }
 
+int32_t libjit_element_quantize_kernel_i32(size_t idx, const float *inW,
+                                           float scale, int32_t offset) {
+  int32_t result = (int32_t)nearbyintf(inW[idx] / scale + offset);
+  return result;
+}
+
 float libjit_element_dequantize_kernel_f(size_t idx, const int8_t *inW,
                                          float scale, int32_t offset) {
   return scale * (inW[idx] - offset);

--- a/lib/Backends/CPU/libjit/libjit_conv.cpp
+++ b/lib/Backends/CPU/libjit/libjit_conv.cpp
@@ -418,13 +418,13 @@ void libjit_convolution_f(float *outW, const float *inW, const float *filterW,
 }
 
 void libjit_convolution_i8(
-    int8_t *outW, const int8_t *inW, const int8_t *filterW, const int8_t *biasW,
-    const size_t *outWdims, const size_t *inWdims, const size_t *filterWdims,
-    const size_t *biasWdims, const size_t *kernelSizes, const size_t *strides,
-    const size_t *pads, size_t group, int32_t outOffset, int32_t inOffset,
-    int32_t filterOffset, int32_t biasOffset, int32_t biasPre, int32_t biasPost,
-    int32_t biasScale, int32_t outPre, int32_t outPost, int32_t outScale,
-    unsigned depthUnroll) {
+    int8_t *outW, const int8_t *inW, const int8_t *filterW,
+    const int32_t *biasW, const size_t *outWdims, const size_t *inWdims,
+    const size_t *filterWdims, const size_t *biasWdims,
+    const size_t *kernelSizes, const size_t *strides, const size_t *pads,
+    size_t group, int32_t outOffset, int32_t inOffset, int32_t filterOffset,
+    int32_t biasOffset, int32_t biasPre, int32_t biasPost, int32_t biasScale,
+    int32_t outPre, int32_t outPost, int32_t outScale, unsigned depthUnroll) {
   size_t inChannels = inWdims[3];
   size_t outChannels = outWdims[3];
   size_t inCperG = inChannels / group;

--- a/lib/Backends/OpenCL/kernels_fwd_quantized_conv.cl
+++ b/lib/Backends/OpenCL/kernels_fwd_quantized_conv.cl
@@ -136,7 +136,7 @@ __kernel
                         float c_scale, int d_offset, float d_scale) {
   __global const Dtype *im_in = &mem[im_in_offset];
   __global const Dtype *wg = &mem[wg_offset];
-  __global const Dtype *bias = &mem[bias_offset];
+  __global const int *bias = &mem[bias_offset];
   __global Dtype *im_out = &mem[im_out_offset];
   // Thread identifiers.
   // Local row ID (max: RTSM=TSM/WPTM).
@@ -156,7 +156,7 @@ __kernel
   __global const Dtype *Aptr = wg;
   __global const Dtype *Bptr = im_in + v_B_off * batch;
   __global Dtype *Cptr = im_out + v_C_off * batch;
-  __global const Dtype *Dptr = bias;
+  __global const int *Dptr = bias;
   // Initialize the accumulation registers.
   {
     int4 Creg[WPTM][WPTN / VWN];

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1423,7 +1423,8 @@ BatchOneHotNode *Function::createBatchOneHot(llvm::StringRef name,
 QuantizeNode *Function::createQuantize(llvm::StringRef name, NodeValue input,
                                        TypeRef outTy) {
   assert(input.getType()->isFPType() && "Input must be a floating type");
-  assert(outTy->getElementType() == ElemKind::Int8QTy &&
+  assert((outTy->getElementType() == ElemKind::Int8QTy ||
+          outTy->getElementType() == ElemKind::Int32QTy) &&
          "Output must be a quantized type");
   assert(input.dims().equals(outTy->dims()) &&
          "Different dimensions for input and output");

--- a/lib/IR/Instrs.cpp
+++ b/lib/IR/Instrs.cpp
@@ -90,3 +90,12 @@ void InsertTensorInst::verify() const {
   assert(getAxis() >= 0 && getAxis() < getDest()->dims().size() &&
          "Axis must fit inside Dest dims.");
 }
+
+void QuantizeInst::verify() const {
+  assert((getDest()->getElementType() == ElemKind::Int8QTy ||
+          getDest()->getElementType() == ElemKind::Int32QTy) &&
+         "Invalid type");
+  assert(getSrc()->getElementType() == ElemKind::FloatTy ||
+         getSrc()->getElementType() == ElemKind::Float16Ty && "Invalid type");
+  assert(getSrc()->dims() == getDest()->dims() && "Invalid shape");
+}

--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -1639,8 +1639,9 @@ static NodeValue convertConstant(Module &mod, Constant &constant,
       constantToBeModified.getPayload().convertToType(dstTy->getElementType());
       return NodeValue(&constantToBeModified, 0);
     }
+    case ElemKind::Int32QTy:
     case ElemKind::Int8QTy: {
-      // Quantization: {FloatTy, Float16Ty} -> Int8QTy.
+      // Quantization: {FloatTy, Float16Ty} -> Int8QTy or Int32QTy.
       Constant &constantToBeModified = modifyConstantTyAndGet();
       TensorQuantizationParams params{dstTy->getScale(), dstTy->getOffset()};
       Tensor &tensorToBeModified = constantToBeModified.getPayload();
@@ -1650,8 +1651,8 @@ static NodeValue convertConstant(Module &mod, Constant &constant,
       // teach quantizeTensor how to deal with Float16Ty.
       assert(tensor.getType().isFPType() &&
              "Type quantization not implemented");
-      tensorToBeModified =
-          quantization::quantizeTensor(tensorToBeModified, params);
+      tensorToBeModified = quantization::quantizeTensor(
+          tensorToBeModified, params, dstTy->getElementType());
       return NodeValue(&constantToBeModified, 0);
     }
     default:

--- a/tests/unittests/BackendCorrectnessTest.cpp
+++ b/tests/unittests/BackendCorrectnessTest.cpp
@@ -136,10 +136,10 @@ TEST_P(CPUOnly, quantizedConvTest) {
   PseudoRNG PRNG;
   Tensor inputs(ElemKind::Int8QTy, {20, 41, 32, 6}, 0.025, -7);
   Tensor kernel(ElemKind::Int8QTy, {10, 5, 5, 6}, 0.003, 3);
-  Tensor bias(ElemKind::Int8QTy, {10}, 0.5, -4);
+  Tensor bias(ElemKind::Int32QTy, {10}, 0.5, -4);
   inputs.getHandle<int8_t>().randomize(-128, 127, PRNG);
   kernel.getHandle<int8_t>().randomize(-128, 127, PRNG);
-  bias.getHandle<int8_t>().randomize(-11, 8, PRNG);
+  bias.getHandle<int32_t>().randomize(-11, 8, PRNG);
   std::array<size_t, 4> S{{20, 15, 12, 10}};
   llvm::ArrayRef<size_t> shape(S);
   Tensor out1(ElemKind::Int8QTy, shape, 0.05, -17);

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -1588,7 +1588,7 @@ void checkIntConvolution(ExecutionEngine &EE, Function *F, unsigned convDepth,
   TypeRef inputTy = mod.uniqueType(ElemKind::Int8QTy, input->dims(), 0.01, 0.0);
   TypeRef filterTy =
       mod.uniqueType(ElemKind::Int8QTy, filter->dims(), 0.01, 0.0);
-  TypeRef biasTy = mod.uniqueType(ElemKind::Int8QTy, bias->dims(), 0.04, 0.0);
+  TypeRef biasTy = mod.uniqueType(ElemKind::Int32QTy, bias->dims(), 0.04, 0.0);
 
   auto *inputq = F->createQuantize("input.q", input, inputTy);
   auto *filterq = F->createQuantize("filter.q", filter, filterTy);

--- a/tests/unittests/graphTest.cpp
+++ b/tests/unittests/graphTest.cpp
@@ -344,7 +344,7 @@ TEST(Graph, simpleQuant) {
   auto *filter =
       MD.createPlaceholder(ElemKind::Int8QTy, filterDim, 3.3, 4, "F", true);
   auto *bias =
-      MD.createPlaceholder(ElemKind::Int8QTy, {depth}, 1.3, 5, "B", true);
+      MD.createPlaceholder(ElemKind::Int32QTy, {depth}, 1.3, 5, "B", true);
 
   // Calculate the size and allocate the output buffer.
   auto outSz = calculateConvPoolOutputDims(width, width, kernels, steps, pads);

--- a/tools/ClassGen/Backends/OpenCL/OpenCLSpecificInstrs.h
+++ b/tools/ClassGen/Backends/OpenCL/OpenCLSpecificInstrs.h
@@ -26,7 +26,7 @@ BB.newBackendSpecificInstr("OCLConvolution")
     .addMember(MemberType::VectorUnsigned, "Pads")
     .addMember(MemberType::Unsigned, "Group")
     .autoIRGen()
-    .autoVerify(VerifyKind::SameElementType, {"Dest", "Src", "Filter", "Bias"});
+    .autoVerify(VerifyKind::SameElementType, {"Dest", "Src", "Filter"});
 
 BB.newBackendSpecificInstr("OCLAvgPool")
     .addOperand("Dest", OperandKind::Out)

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -86,8 +86,7 @@ int main(int argc, char **argv) {
       .addMember(MemberType::VectorUnsigned, "Pads")
       .addMember(MemberType::Unsigned, "Group")
       .autoIRGen()
-      .autoVerify(VerifyKind::SameElementType,
-                  {"Dest", "Src", "Filter", "Bias"})
+      .autoVerify(VerifyKind::SameElementType, {"Dest", "Src", "Filter"})
       .addGradientInstr({"Src", "Filter"}, {"Dest", "Src", "Filter", "Bias"});
 
   // MaxPool version caching XY coordinates to speedup gradient-based
@@ -472,9 +471,6 @@ int main(int argc, char **argv) {
   BB.newInstr("Quantize")
       .addOperand("Dest", OperandKind::Out)
       .addOperand("Src", OperandKind::In)
-      .autoVerify(VerifyKind::SameElementType, {"Dest", "ElemKind::Int8QTy"})
-      .autoVerify(VerifyKind::TypeCheck, {"Src", "isFPType()"})
-      .autoVerify(VerifyKind::SameShape, {"Dest", "Src"})
       .dataParallel()
       .autoIRGen();
 


### PR DESCRIPTION
*Description*:

We are working on loading quantized ResNet50 model directly. 
So far, we quantize weights and bias into int8. Both the interpreter and CPU backend support int8 bias. However, this quantized Resnet50 model quantizes weights into int8, but bias into int32. It is because the partial sum of the matrix-matrix multiplication is accumulated into int32, so int32 bias can be added to the int32 partial sum for better accuracy (i.e. int8 bias caused accuracy drop). 
Now we plan to add support of conv with int32 bias and eliminate int8 bias.

*Testing*: 
Added unittest.

*Documentation*:
#1727, #1762