### PR TITLE
[ImageClassifier | NFC] Improve topK label printing

### DIFF
--- a/tools/loader/ImageClassifier.cpp
+++ b/tools/loader/ImageClassifier.cpp
@@ -229,7 +229,11 @@ static void printTopKPairs(const std::vector<FloatIndexPair> &topKPairs) {
     // Some models are trained with more classes. E.g. Some imagenet models
     // exported from TensorFlow have 1 extra "neutral" class.
     const size_t label = topKPairs[i].second - labelOffset;
-    llvm::outs() << "   Label-K" << i + 1 << ": " << label << " (probability: "
+    // Tab out the label so it aligns nicely with Label-K1.
+    if (i != 0) {
+      llvm::outs() << "\t\t\t\t\t";
+    }
+    llvm::outs() << "\tLabel-K" << i + 1 << ": " << label << " (probability: "
                  << llvm::format("%0.4f", topKPairs[i].first) << ")\n";
   }
 }
@@ -302,7 +306,7 @@ int main(int argc, char **argv) {
     for (unsigned i = 0; i < inputImageFilenames.size(); i++) {
       Tensor slice = H.extractSlice(i);
       auto SH = slice.getHandle<>();
-      llvm::outs() << " File: " << inputImageFilenames[i] << "\n";
+      llvm::outs() << " File: " << inputImageFilenames[i];
 
       auto topKPairs = getTopKPairs(SH);
       printTopKPairs(topKPairs);


### PR DESCRIPTION
NFC. I didn't like how the topk labels were being printed. This makes it so that the top label is always printed on the same line as the file, and all other labels are on new lines aligned with it. E.g.

```
 File: tests/images/imagenet/cat_285.png        Label-K1: 285 (probability: 0.5823)
                                                Label-K2: 281 (probability: 0.3601)
                                                Label-K3: 282 (probability: 0.0456)
```