### PR TITLE
[ONNXifi] Add support for ReplaceNaN operator

### DIFF
--- a/lib/Importer/ONNXIFIModelLoader.cpp
+++ b/lib/Importer/ONNXIFIModelLoader.cpp
@@ -205,6 +205,9 @@ ONNXIFIModelLoader::parseOperators(const void *onnxModel,
       ADD_OP_MAPPING(SubNodeKind, FloatTy);
       ADD_OP_MAPPING(DivNodeKind, FloatTy);
       ADD_OP_MAPPING(CmpEQNodeKind, FloatTy);
+    } else if (operation == "ReplaceNaN") {
+      ADD_OP_MAPPING(IsNaNNodeKind, FloatTy);
+      ADD_OP_MAPPING(SplatNodeKind, FloatTy);
       ADD_OP_MAPPING(SelectNodeKind, FloatTy);
     } else if (operation == "DotProduct") {
       ADD_OP_MAPPING(BatchedReduceAddNodeKind, FloatTy);

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -519,6 +519,16 @@ bool ONNXModelLoader::loadOperator(const ONNX_NAMESPACE::NodeProto &op) {
     return true;
   }
 
+  if (typeName == "ReplaceNaN") {
+    auto in = getNodeValueOrCreateConstantByName(op.input(0));
+    float replacementValue =
+        dict.count("value") ? loadFloat(dict["value"]) : 0.0f;
+
+    auto *node = G_.createReplaceNaN(opName, in, replacementValue);
+    addNodeAsOutput(op, node);
+    return true;
+  }
+
   return false;
 }
 

--- a/tests/models/onnxModels/replaceNaN.onnxtxt
+++ b/tests/models/onnxModels/replaceNaN.onnxtxt
@@ -1,0 +1,50 @@
+ir_version: 3
+producer_name: "backend-test"
+graph {
+  node {
+    input: "x"
+    output: "y"
+    op_type: "ReplaceNaN"
+    attribute {
+      name: "value"
+      f: 1.0
+      type: FLOAT
+    }
+  }
+  name: "test_replaceNaN"
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: FLOAT
+        shape {
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: FLOAT
+        shape {
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 9
+}


### PR DESCRIPTION
**Description**
This commit adds support for the `ReplaceNaN` operator to the ONNX model
importer. Most of the work to support this operator was done in an
earlier commit that added support for the Caffe2 loader. Consequently,
this commit only includes code that parses inputs, outputs, and arguments
from an .onnxtxt and calls `Graph::createReplaceNaN` to implement the
operation.

**Testing**
This commit adds a unit test to `onnxImporterTest.cpp` to test loading
this operator from a .onnxtxt file.

**Fixes**
This commit fixes #1704.