### PR TITLE
[ONNXifi] Add support for BatchBoxCox operator

### DIFF
--- a/lib/Importer/ONNXIFIModelLoader.cpp
+++ b/lib/Importer/ONNXIFIModelLoader.cpp
@@ -194,6 +194,18 @@ ONNXIFIModelLoader::parseOperators(const void *onnxModel,
       ADD_OP_MAPPING(MinNodeKind, FloatTy);
       ADD_OP_MAPPING(MaxNodeKind, FloatTy);
       ADD_OP_MAPPING(SplatNodeKind, FloatTy);
+    } else if (operation == "BatchBoxCox") {
+      ADD_OP_MAPPING(ReshapeNodeKind, FloatTy);
+      ADD_OP_MAPPING(TileNodeKind, FloatTy);
+      ADD_OP_MAPPING(SplatNodeKind, FloatTy);
+      ADD_OP_MAPPING(AddNodeKind, FloatTy);
+      ADD_OP_MAPPING(MaxNodeKind, FloatTy);
+      ADD_OP_MAPPING(LogNodeKind, FloatTy);
+      ADD_OP_MAPPING(PowNodeKind, FloatTy);
+      ADD_OP_MAPPING(SubNodeKind, FloatTy);
+      ADD_OP_MAPPING(DivNodeKind, FloatTy);
+      ADD_OP_MAPPING(CmpEQNodeKind, FloatTy);
+      ADD_OP_MAPPING(SelectNodeKind, FloatTy);
     }
   }
 #undef ADD_OP_MAPPING

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -493,6 +493,16 @@ bool ONNXModelLoader::loadOperator(const ONNX_NAMESPACE::NodeProto &op) {
     return true;
   }
 
+  if (typeName == "BatchBoxCox") {
+    auto data = getNodeValueOrCreateConstantByName(op.input(0));
+    auto lambda1 = getNodeValueOrCreateConstantByName(op.input(1));
+    auto lambda2 = getNodeValueOrCreateConstantByName(op.input(2));
+
+    auto *node = G_.createBatchBoxCox(opName, data, lambda1, lambda2);
+    addNodeAsOutput(op, node);
+    return true;
+  }
+
   return false;
 }
 

--- a/tests/models/onnxModels/batchBoxCox.onnxtxt
+++ b/tests/models/onnxModels/batchBoxCox.onnxtxt
@@ -1,0 +1,73 @@
+ir_version: 3
+producer_name: "backend-test"
+graph {
+  node {
+    input: "data"
+    input: "lambda1"
+    input: "lambda2"
+    output: "y"
+    op_type: "BatchBoxCox"
+  }
+  name: "test_batchBoxCox"
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: FLOAT
+        shape {
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "lambda1"
+    type {
+      tensor_type {
+        elem_type: FLOAT
+        shape {
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "lambda2"
+    type {
+      tensor_type {
+        elem_type: FLOAT
+        shape {
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: FLOAT
+        shape {
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 9
+}


### PR DESCRIPTION
**Description**
This commit adds support for the `BatchBoxCox` operator to the ONNX model
importer. Most of the work to support this operator was done in an
earlier commit that added support to the Caffe2 loader. Consequently,
this commit only includes code that parses inputs, outputs, and arguments
from an .onnxtxt and calls `Graph::createBatchBoxCox` to implement the
operation.

**Testing**
This commit adds a unit test to onnxImporterTest.cpp to test loading
this operator from a .onnxtxt file.

**Fixes**
This commit fixes #1705.