### PR TITLE
[ONNXifi] Add missing header

### DIFF
--- a/lib/Onnxifi/ThreadPool.h
+++ b/lib/Onnxifi/ThreadPool.h
@@ -18,6 +18,7 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <functional>
 #include <mutex>
 #include <queue>
 #include <thread>


### PR DESCRIPTION
*Description*:
Member function `ThreadPool::submit` and data member `workQueue_` use `std::function`. Without including header `<functional>` this causes the build to fail (Linux x86-64, GCC 8.2.1). After adding the missing header the project builds successfully.
