### PR TITLE
Silence Apple's warning about the deprecation of OpenCL

### DIFF
--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -15,6 +15,9 @@
  */
 #define DEBUG_TYPE "opencl"
 
+// Silence Apple's warning about the deprecation of OpenCL.
+#define CL_SILENCE_DEPRECATION
+
 #include "OpenCL.h"
 
 #include "glow/CodeGen/MemoryAllocator.h"


### PR DESCRIPTION
*Description*:
Starting with MacOS Mojave, using OpenCL results in a bunch of compiler warnings, because Apple is going to deprecate OpenCL. The warnings suggest defining CL_SILENCE_DEPRECATION to silence any such warnings.

*Testing*:
ninja test
