### PR TITLE
[Caffe2] Add support for SparseToDense operator

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -513,6 +513,19 @@ public:
   LengthsToRangesNode *createLengthsToRanges(llvm::StringRef name,
                                              NodeValue lengths);
 
+  /// Implements an operation that converts the sparse representation given by
+  /// the pair of \p indices and \p values into a dense representation.
+  /// This representation contains each value of \p values at the corresponding
+  /// index given by \p indices. All indices that are not present in \p indices
+  /// are filled with zeroes. \p indices can contain duplicates, and in this
+  /// case, the corresponding values in \p values are added.
+  ///
+  /// \p dataToInferDim acts as a hint about the shape of the output. The first
+  /// dimension of the output is the first dimension of this tensor.
+  SparseToDenseNode *createSparseToDense(llvm::StringRef name,
+                                         NodeValue indices, NodeValue values,
+                                         NodeValue dataToInferDim);
+
   SaveNode *createSave(llvm::StringRef name, NodeValue input);
   SaveNode *createSave(llvm::StringRef name, NodeValue input,
                        Placeholder *output);

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -1759,6 +1759,51 @@ void InterpreterFunction::fwdLengthsToRangesInst(const LengthsToRangesInst *I) {
   }
 }
 
+void InterpreterFunction::fwdSparseToDenseInst(const SparseToDenseInst *I) {
+  auto out = getTensor(I->getDest());
+  auto indices = getTensor(I->getIndices());
+  auto values = getTensor(I->getValues());
+
+  out->zero();
+
+  auto IH = indices->getHandle<int64_t>();
+
+  size_t numIndices = indices->dims()[0];
+  size_t numOutDims = out->dims().size();
+
+  // Convert sparse representation to dense representation by taking
+  // slices of output and values and accumulating the value slice into
+  // the output slice.
+
+  // Dimensions and offsets for the output and values slices. sliceDims
+  // will always be {1, [rest of output dimensions]} since the first dimension
+  // is the index in this operation. sliceOffsets will be {indices[j], 0, ...}
+  // for the output slice and {j, 0, ...} for the values slice so that the
+  // slice at index j gets mapped to index indices[j] in the dense
+  // representation.
+  ShapeVector sliceDims(out->dims().begin(), out->dims().end());
+  ShapeVector sliceOffsets(numOutDims, 0);
+  sliceDims[0] = 1;
+
+  for (size_t j = 0; j < numIndices; ++j) {
+    // Create values slice with offsets {j, 0, ...}.
+    sliceOffsets[0] = j;
+    auto VS = values->getUnowned(sliceDims, sliceOffsets);
+    auto VSH = VS.getHandle<float>();
+
+    // Create output slice with offsets {indices[j], 0, ...}.
+    sliceOffsets[0] = IH.at({j});
+    auto OS = out->getUnowned(sliceDims, sliceOffsets);
+    auto OSH = OS.getHandle<float>();
+
+    // Accumulate values slice into output slice.
+    size_t outputSliceSize = OS.size();
+    for (size_t k = 0; k < outputSliceSize; ++k) {
+      OSH.raw(k) += VSH.raw(k);
+    }
+  }
+}
+
 //===----------------------------------------------------------------------===//
 //                Instructions used by RNN
 //===----------------------------------------------------------------------===//

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1265,6 +1265,18 @@ LengthsToRangesNode *Function::createLengthsToRanges(llvm::StringRef name,
   return addNode(new LengthsToRangesNode(name, outTy, lengths));
 }
 
+SparseToDenseNode *Function::createSparseToDense(llvm::StringRef name,
+                                                 NodeValue indices,
+                                                 NodeValue values,
+                                                 NodeValue dataToInferDim) {
+  // The dimensions of the output are the same as the values tensor except for
+  // the first dimension, which should match that of dataToInferDim.
+  ShapeVector outDims(values.dims().begin(), values.dims().end());
+  outDims[0] = dataToInferDim.dims()[0];
+  auto outTy = getParent()->uniqueTypeWithNewShape(values.getType(), outDims);
+  return addNode(new SparseToDenseNode(name, outTy, indices, values));
+}
+
 SaveNode *Function::createSave(llvm::StringRef name, NodeValue input) {
   auto *dest = getParent()->createPlaceholder(input.getType(), name, false);
 

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -604,6 +604,16 @@ void LengthsToRangesNode::verify() const {
   assert(getResult().dims()[1] == 2 && "Inner dimension of Ranges must be 2");
 }
 
+void SparseToDenseNode::verify() const {
+  assert(getResult().getElementType() == getValues().getElementType() &&
+         "Mismatched element types");
+  assert(getIndices().getElementType() == ElemKind::Int64ITy &&
+         "Indices must have integer type");
+  assert(getIndices().dims().size() == 1 && "Indices must be a 1D vector");
+  assert(getIndices().dims()[0] == getValues().dims()[0] &&
+         "Indices and Values must have the same first dimension");
+}
+
 void SGDNode::verify() const {
   assert(getGradient().getType() == getWeight().getType() &&
          "Invalid weight or gradient type");

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -641,6 +641,17 @@ void Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     return;
   }
 
+  if (typeName == "SparseToDense") {
+    auto indices = getNodeValueOrCreateConstantByName(op.input(0));
+    auto values = getNodeValueOrCreateConstantByName(op.input(1));
+    auto dataToInferDim = getNodeValueOrCreateConstantByName(op.input(2));
+
+    auto *node =
+        G_.createSparseToDense(opName, indices, values, dataToInferDim);
+    addNodeAsOutput(op, node);
+    return;
+  }
+
   unexpectedNodeError(op, "Unsupported operator.");
 }
 

--- a/tests/models/caffe2Models/sparse_to_dense.pbtxt
+++ b/tests/models/caffe2Models/sparse_to_dense.pbtxt
@@ -1,0 +1,13 @@
+name: "sparseToDense"
+op {
+  input: "indices"
+  input: "values"
+  input: "dataToInferDim"
+  output: "dense_result"
+  name: ""
+  type: "SparseToDense"
+}
+external_input: "indices"
+external_input: "values"
+external_input: "dataToInferDim"
+external_output: "dense_result"

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -227,6 +227,14 @@ int main(int argc, char **argv) {
       .autoVerify(VerifyKind::SameElementType,
                   {"Lengths", "ElemKind::Int64ITy"});
 
+  /// Converts the given sparse representation into a dense one.
+  BB.newInstr("SparseToDense")
+      .addOperand("Dest", OperandKind::Out)
+      .addOperand("Indices", OperandKind::In)
+      .addOperand("Values", OperandKind::In)
+      .autoVerify(VerifyKind::SameElementType, {"Dest", "Values"})
+      .autoIRGen();
+
   /// Adds the 'Slice' operand to each one of the slices in the batch.
   BB.newInstr("BatchedAdd")
       .addOperand("Dest", OperandKind::Out)

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -318,6 +318,19 @@ int main(int argc, char **argv) {
                     "input vector of length N the output is a Nx2 matrix with "
                     "(offset, lengths) packaged for each segment.");
 
+  BB.newNode("SparseToDense")
+      .addInput("Indices")
+      .addInput("Values")
+      .addResultFromCtorArg()
+      .setDocstring(
+          "Converts the sparse representation specified by the pair "
+          "(Indices, Values) into a dense one. This dense "
+          "representation contains each value from Values at the "
+          "corresponding index specified in Indices. Unspecified indices "
+          "are filled with zeroes. Indices may contain duplicate values "
+          "and in this case, all of the corresponding values in Values "
+          "are added together.");
+
   // clang-format off
   BB.newNode("IsNaN")
     .addInput("Input")


### PR DESCRIPTION
**Description**
This commit adds support for the `SparseToDense` Caffe2 operator. This
operator takes a sparse representation of a tensor specified by an array
of indices and an array of tensor values and converts it into a dense
representation. In this dense representation, `values[i]` is stored at
`indices[i]`, and the rest of the dense representation is zero-filled.
Indices can appear twice in the sparse representation, and in this case, all
corresponding values are summed and stored in dense representation.

This operator is implemented as its own Glow node and instruction.

**Testing**
This commit adds tests for this operator to `caffe2ImporterTest.cpp` and
`OperatorTest.cpp`.

**Fixes**
This commit fixes #1702.