### PR TITLE
[Graph] Implement Logit operator

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -298,6 +298,21 @@ public:
   LogNode *createLog(llvm::StringRef name, NodeValue input,
                      TypeRef outTy = nullptr);
 
+  /// Create a series of nodes with \p name that implements an element-wise
+  /// logit transform. For each element of the \p input x, this is
+  /// defined as:
+  ///
+  /// y = log(x / (1 - x))
+  ///
+  /// where the \p input is clamped in (\p eps, 1 - \p eps), and
+  /// the transform parameter \p eps is a positive value (< 0.5)
+  /// (needed to avoid degenerate probabilities of 0 or 1,
+  /// which would result in taking the logarithm of zero).
+  /// The transform itself is implemented using element-wise Clip, Sub,
+  /// Splat, Div, and Log nodes.
+  /// \returns the final node.
+  Node *createLogit(llvm::StringRef name, NodeValue input, float eps);
+
   SoftMaxNode *createSoftMax(llvm::StringRef name, NodeValue input,
                              NodeValue selected, TypeRef outTy = nullptr);
 

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1066,6 +1066,32 @@ LogNode *Function::createLog(llvm::StringRef name, NodeValue input,
   return addNode(new LogNode(name, outTy ? outTy : input.getType(), input));
 }
 
+Node *Function::createLogit(llvm::StringRef name, NodeValue input, float eps) {
+  assert(eps > 0.0f && "Clamping parameter eps must be strictly positive.");
+  assert(eps < 0.5f && "Clamping parameter eps must be less than 0.5.");
+
+  // Compute clamped x using clip(x, eps, 1 - eps).
+  auto epsComplement = 1.0f - eps;
+  auto *MaxN = createClip(name.str() + ".clip", input, eps, epsComplement);
+
+  // Compute the logit transform of clamped x,
+  // log(numerator / denominator),
+  // where numerator = clamped x = MaxN,
+  // and denominator = 1 - clamped x = 1 - MaxN.
+
+  // Compute denominator = 1 - clamped x.
+  auto *onesSplat =
+      createSplat(name.str() + ".onesSplat", input.getType(), 1.0f);
+
+  auto *SN = createSub(name.str() + ".sub", onesSplat, MaxN);
+
+  // Compute the quotient = numerator / denominator.
+  auto *DN = createDiv(name.str() + ".div", MaxN, SN);
+
+  // Compute and return the logit transform (the final node).
+  return createLog(name.str() + ".log", DN);
+}
+
 SelectNode *Function::createSelect(llvm::StringRef name, TypeRef outTy,
                                    NodeValue Cond, NodeValue LHS,
                                    NodeValue RHS) {

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -412,6 +412,18 @@ void Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     return;
   }
 
+  if (typeName == "Logit") {
+    // Load the input and (optional) epsilon clamping value:
+    auto input = getNodeValueOrCreateConstantByName(op.input(0));
+    auto epsIt = dict.find("eps");
+    // default: 1e-6 (as in Caffe2)
+    auto eps = epsIt != dict.end() ? loadFloat(epsIt->second) : 1E-6f;
+    auto *node = G_.createLogit(opName, input, eps);
+    // Save the outputs:
+    addNodeAsOutput(op, node);
+    return;
+  }
+
   if (typeName == "EQ") {
     auto in0 = getNodeValueOrCreateConstantByName(op.input(0));
     auto in1 = getNodeValueOrCreateConstantByName(op.input(1));

--- a/tests/models/caffe2Models/logit_op_net.pbtxt
+++ b/tests/models/caffe2Models/logit_op_net.pbtxt
@@ -1,0 +1,13 @@
+name: "logit"
+op {
+  input: "inputs_0"
+  output: "logit_result"
+  name: ""
+  type: "Logit"
+  arg {
+    name: "eps"
+    f: 1e-6
+  }
+}
+external_input: "inputs_0"
+external_output: "logit_result"


### PR DESCRIPTION
*Description*: This implements the Logit operator (Graph node and Caffe2 model loader support).

Domain asserts on the `eps` value correspond to the following ones in `caffe2::LogitFunctor`: `CAFFE_ENFORCE_GT(eps_, 0.0);`, `CAFFE_ENFORCE_LT(eps_, 0.5);`.
Cf. https://github.com/pytorch/pytorch/blob/master/caffe2/operators/logit_op.h

*Testing*:
- differential testing (oracle: comparison against C++ re-implementation using randomized inputs),
- property-based randomized testing (zero-sum property for the log-odds for complementary events probabilities; right-inverse property of the logit function with respect to the logistic function),
- Caffe2 model importer test (Output shape, high level checks on the content of the graph).

*Documentation*: Comments in the interface and the implementation (including the implementation and testing strategy)

[Fixes #1873]
