### PR TITLE
Allow -convert-inout-to-fp16 to be used in combination with -load_profile

### DIFF
--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -371,6 +371,13 @@ struct Type final {
            elementType_ == ElemKind::Int32QTy;
   }
 
+  /// \returns true if the type of this Tensor is one of the floating point
+  /// types.
+  bool isFPType() const {
+    return getElementType() == ElemKind::FloatTy ||
+           getElementType() == ElemKind::Float16Ty;
+  }
+
   /// \return the size of the type element.
   unsigned getElementSize() const { return getElementSize(elementType_); }
 

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -582,6 +582,12 @@ public:
   /// are part of the \p input.
   DequantizeNode *createDequantize(llvm::StringRef name, NodeValue input);
 
+  /// Create dequantization node which transforms quantized tensor to a
+  /// floating point type \p outTy one with given Scale and Offset. Scale and
+  /// Offset params are part of the \p input.
+  DequantizeNode *createDequantize(llvm::StringRef name, NodeValue input,
+                                   TypeRef outTy);
+
   /// Create transformation for quantized tensors to rescale based on the new
   /// Scale and Offset.
   RescaleQuantizedNode *createRescaleQuantized(llvm::StringRef name,

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -1902,12 +1902,9 @@ void InterpreterFunction::fwdQuantizationProfileInst(
   quantization::generateTensorHistogram(inputTensor, currentHistogram, min,
                                         max);
 }
-/// Quantize floating point tensor. Scale and Offset are based on return type
-/// of the instruction \p I.
-void InterpreterFunction::fwdQuantizeInst(const glow::QuantizeInst *I) {
-  auto srcHandle = getWeightHandle(I->getSrc());
-  auto *destTensor = getTensor(I->getDest());
 
+template <typename ElemTy>
+static void fwdQuantize(Handle<ElemTy> srcHandle, Tensor *destTensor) {
   TensorQuantizationParams params{destTensor->getType().getScale(),
                                   destTensor->getType().getOffset()};
 
@@ -1916,18 +1913,55 @@ void InterpreterFunction::fwdQuantizeInst(const glow::QuantizeInst *I) {
     destHandle.raw(i) = quantization::quantize(srcHandle.raw(i), params);
   }
 }
-/// Dequantize integer tensor. Scale and Offset are based
-/// on the source tensor type.
-void InterpreterFunction::fwdDequantizeInst(const glow::DequantizeInst *I) {
-  auto *srcTensor = getTensor(I->getSrc());
-  auto destHandle = getWeightHandle(I->getDest());
 
+/// Quantize floating point tensor. Scale and Offset are based on return type
+/// of the instruction \p I.
+void InterpreterFunction::fwdQuantizeInst(const glow::QuantizeInst *I) {
+  auto *destTensor = getTensor(I->getDest());
+  switch (I->getSrc()->getElementType()) {
+  case ElemKind::FloatTy: {
+    auto srcHandle = getWeightHandle<float>(I->getSrc());
+    fwdQuantize(srcHandle, destTensor);
+    return;
+  }
+  case ElemKind::Float16Ty: {
+    auto srcHandle = getWeightHandle<float16>(I->getSrc());
+    fwdQuantize(srcHandle, destTensor);
+    return;
+  }
+  default:
+    llvm_unreachable("Type not supported");
+  }
+}
+
+template <typename ElemTy>
+static void fwdDequantize(Tensor *srcTensor, Handle<ElemTy> destHandle) {
   TensorQuantizationParams params{srcTensor->getType().getScale(),
                                   srcTensor->getType().getOffset()};
 
   auto srcHandle = srcTensor->getHandle<int8_t>();
   for (size_t i = 0, e = destHandle.size(); i < e; ++i) {
     destHandle.raw(i) = quantization::dequantize(srcHandle.raw(i), params);
+  }
+}
+
+/// Dequantize integer tensor. Scale and Offset are based
+/// on the source tensor type.
+void InterpreterFunction::fwdDequantizeInst(const glow::DequantizeInst *I) {
+  auto *srcTensor = getTensor(I->getSrc());
+  switch (I->getDest()->getElementType()) {
+  case ElemKind::FloatTy: {
+    auto destHandle = getWeightHandle<float>(I->getDest());
+    fwdDequantize(srcTensor, destHandle);
+    return;
+  }
+  case ElemKind::Float16Ty: {
+    auto destHandle = getWeightHandle<float16>(I->getDest());
+    fwdDequantize(srcTensor, destHandle);
+    return;
+  }
+  default:
+    llvm_unreachable("Type not supported");
   }
 }
 

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1414,8 +1414,7 @@ ScatterAssignNode *Function::createScatterAssign(llvm::StringRef name,
 
 QuantizeNode *Function::createQuantize(llvm::StringRef name, NodeValue input,
                                        TypeRef outTy) {
-  assert(input.getElementType() == ElemKind::FloatTy &&
-         "Input must be a floating type");
+  assert(input.getType()->isFPType() && "Input must be a floating type");
   assert(outTy->getElementType() == ElemKind::Int8QTy &&
          "Output must be a quantized type");
   assert(input.dims().equals(outTy->dims()) &&

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1426,10 +1426,16 @@ QuantizeNode *Function::createQuantize(llvm::StringRef name, NodeValue input,
 
 DequantizeNode *Function::createDequantize(llvm::StringRef name,
                                            NodeValue input) {
-  assert(input.getElementType() == ElemKind::Int8QTy &&
-         "Input must be a quantized type");
   TypeRef outTy =
       getParent()->uniqueType(Type(ElemKind::FloatTy, input.dims()));
+  return createDequantize(name, input, outTy);
+}
+
+DequantizeNode *Function::createDequantize(llvm::StringRef name,
+                                           NodeValue input, TypeRef outTy) {
+  assert(input.getElementType() == ElemKind::Int8QTy &&
+         "Input must be a quantized type");
+  assert(outTy->isFPType() && "Output should be an FP type");
   return addNode(new DequantizeNode(name, outTy, input));
 }
 

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -644,14 +644,14 @@ void IntLookupTableNode::verify() const {
 void QuantizeNode::verify() const {
   // Dest must be quantized.
   checkType(getResult(), ElemKind::Int8QTy);
-  // Src must be float.
-  checkType(getInput(), ElemKind::FloatTy);
+  // Src must be an FP type.
+  assert(getInput().getType()->isFPType() && "Invalid type");
   checkSameShape(getResult(), getInput());
 }
 
 void DequantizeNode::verify() const {
-  // Dest must be float.
-  checkType(getResult(), ElemKind::FloatTy);
+  // Dest must be an FP type.
+  assert(getResult().getType()->isFPType() && "Invalid type");
   // Src must be quantized.
   checkType(getInput(), ElemKind::Int8QTy);
   checkSameShape(getResult(), getInput());

--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -1716,6 +1716,11 @@ static void optimizeConversions(Function *F) {
     default:
       break;
     }
+    // If it is a conversion between the same types, it can be eliminated.
+    if (srcVal == NodeValue() &&
+        conversionInput.getType() == dstVal.getType()) {
+      srcVal = conversionInput;
+    }
     // Check if we found a suitable new source for dstVal.
     if (srcVal == NodeValue() || srcVal.getType() != dstVal.getType()) {
       continue;

--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -1648,7 +1648,7 @@ static NodeValue convertConstant(Module &mod, Constant &constant,
       // Add an assert on that, so that if it changes, we adapt the
       // following code. Adapting the code would required to
       // teach quantizeTensor how to deal with Float16Ty.
-      assert(tensor.getElementType() == ElemKind::FloatTy &&
+      assert(tensor.getType().isFPType() &&
              "Type quantization not implemented");
       tensorToBeModified =
           quantization::quantizeTensor(tensorToBeModified, params);

--- a/tools/ClassGen/InstrBuilder.h
+++ b/tools/ClassGen/InstrBuilder.h
@@ -39,6 +39,7 @@ enum class VerifyKind : unsigned char {
   SameShape,
   SameType,
   SameElementType,
+  TypeCheck,
   NoVerify,
 };
 

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -463,14 +463,14 @@ int main(int argc, char **argv) {
       .addOperand("Dest", OperandKind::Out)
       .addOperand("Src", OperandKind::In)
       .autoVerify(VerifyKind::SameElementType, {"Dest", "ElemKind::Int8QTy"})
-      .autoVerify(VerifyKind::SameElementType, {"Src", "ElemKind::FloatTy"})
+      .autoVerify(VerifyKind::TypeCheck, {"Src", "isFPType()"})
       .autoVerify(VerifyKind::SameShape, {"Dest", "Src"})
       .autoIRGen();
 
   BB.newInstr("Dequantize")
       .addOperand("Dest", OperandKind::Out)
       .addOperand("Src", OperandKind::In)
-      .autoVerify(VerifyKind::SameElementType, {"Dest", "ElemKind::FloatTy"})
+      .autoVerify(VerifyKind::TypeCheck, {"Dest", "isFPType()"})
       .autoVerify(VerifyKind::SameElementType, {"Src", "ElemKind::Int8QTy"})
       .autoVerify(VerifyKind::SameShape, {"Dest", "Src"})
       .autoIRGen();


### PR DESCRIPTION
This PR builds on top #1905 and allows for taking any model, converting it into fp16 and then quantizing it. It is useful for running models on the backends without fp32 support.


You can now do the following:
```
bin/image-classifier tests/images/imagenet/cat_285.png -image_mode=0to1 -m=resnet50 -model_input_name=gpu_0/data -convert-to-fp16  -convert-inout-to-fp16 -load_profile resnet50_symmetric_q8.yml
```

The following changes were required:
- updating a bunch of checks/assertions that assumed that only FP32 can be used
- extending the interpreter to support quantize/dequantize with fp16 operands