### PR TITLE
[ImageClassifier] Add an option to convert the input and output to fp16

### DIFF
--- a/include/glow/Converter/FunctionConverter.h
+++ b/include/glow/Converter/FunctionConverter.h
@@ -100,6 +100,15 @@ protected:
   /// method must be overloaded.
   virtual NodeValue getConversionOutput(Node &conversion) const;
 
+  /// Mutate the outputs of \p node to the expected output target
+  /// type (\see getTargetTypeForOutput) and insert the conversions
+  /// to preserve the type consistency with the rest of the network.
+  void convertOutputs(Node &node);
+
+  /// Insert conversion node for each input of \p node that don't
+  /// match getTargetTypeForInput.
+  void convertInputs(Node &node);
+
   /// Morph \p node into its final form. For the most part
   /// this method should be a noop and just return \p node.
   /// However, this hook provides a way to perform changes

--- a/include/glow/Converter/FunctionConverter.h
+++ b/include/glow/Converter/FunctionConverter.h
@@ -91,8 +91,10 @@ protected:
   virtual bool canConvert(const Node &node) const;
 
   /// Create a conversion with \p val as input and \p destTy as the destination
-  /// type. In other words, creates something like cast val to destTy.
-  virtual Node *createConversion(NodeValue &val, TypeRef destTy) = 0;
+  /// type in \p function. In other words, creates something like cast val to
+  /// destTy.
+  virtual Node *createConversion(Function &function, NodeValue &val,
+                                 TypeRef destTy) = 0;
 
   /// Given a \p conversion, get its output value.
   /// The default implementation returns the zero-th result.

--- a/include/glow/Converter/FunctionConverter.h
+++ b/include/glow/Converter/FunctionConverter.h
@@ -27,6 +27,8 @@ class Context;
 class Function;
 class Node;
 struct NodeValue;
+class Placeholder;
+class Tensor;
 
 /// This class implements the high-level APIs used to convert a function
 /// to one type to another. The actual conversions must be implemented
@@ -111,6 +113,9 @@ protected:
   /// match getTargetTypeForInput.
   void convertInputs(Node &node);
 
+  /// Convert the \p input tensor to the \p destTy destination type.
+  virtual void convertTensor(Tensor &input, TypeRef destTy) = 0;
+
   /// Morph \p node into its final form. For the most part
   /// this method should be a noop and just return \p node.
   /// However, this hook provides a way to perform changes
@@ -158,6 +163,11 @@ public:
   /// cleanUp
   /// \endcode
   void convert();
+
+  /// Modify the type of \p placeholder according to getTargetTypeForOutput.
+  /// If the \p context is provided and \p placeholder has a backing tensor,
+  /// this tensor is also updated.
+  void convertPlaceholder(Placeholder &placeholder, Context *context);
 };
 } // namespace glow
 #endif

--- a/include/glow/Converter/TypeAToTypeBFunctionConverter.h
+++ b/include/glow/Converter/TypeAToTypeBFunctionConverter.h
@@ -61,6 +61,8 @@ protected:
   /// Check if \p node can be converted.
   bool canConvert(const Node &node) const override;
 
+  void convertTensor(Tensor &tensor, TypeRef destTy) override;
+
 public:
   /// Create a type converter from \p fromKind to \p toKind for \p F.
   /// If \p doNotConvertKinds is not nullptr, the nodes which kind

--- a/include/glow/Converter/TypeAToTypeBFunctionConverter.h
+++ b/include/glow/Converter/TypeAToTypeBFunctionConverter.h
@@ -53,9 +53,10 @@ protected:
   /// is used.
   TypeRef getTargetTypeForInput(const Node &use, unsigned idx) const override;
 
-  /// Create a node that converts \p val to \p destTy.
+  /// Create a node in \p function that converts \p val to \p destTy.
   /// \p val and \p destTy must have the same shape.
-  Node *createConversion(NodeValue &val, TypeRef destTy) override;
+  Node *createConversion(Function &function, NodeValue &val,
+                         TypeRef destTy) override;
 
   /// Check if \p node can be converted.
   bool canConvert(const Node &node) const override;

--- a/include/glow/Graph/Node.h
+++ b/include/glow/Graph/Node.h
@@ -278,6 +278,7 @@ public:
   /// If that node does not belong to any function, this
   /// is nullptr.
   const Function *getParent() const { return parent_; }
+  Function *getParent() { return parent_; }
   /// Set the link to the function that holds this node.
   void setParent(Function *parent) { parent_ = parent; }
 

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -1963,6 +1963,11 @@ void InterpreterFunction::fwdIntLookupTableInst(const IntLookupTableInst *I) {
 void InterpreterFunction::fwdConvertToInst(const glow::ConvertToInst *I) {
   Tensor *source = getTensor(I->getInput());
   Tensor *dest = getTensor(I->getResult());
+  if (source->getType() == dest->getType()) {
+    // This is a noop conversion.
+    dest->copyRawFrom(source);
+    return;
+  }
   switch (source->getElementType()) {
   case ElemKind::FloatTy:
     assert(dest->getElementType() == ElemKind::Float16Ty &&

--- a/lib/Converter/FunctionConverter.cpp
+++ b/lib/Converter/FunctionConverter.cpp
@@ -74,7 +74,7 @@ void FunctionConverter::convertOutputs(Node &node) {
     // of the conversion works properly.
     val.setType(targetTy);
     // Create the conversion.
-    Node *conversion = createConversion(val, origTy);
+    Node *conversion = createConversion(function_, val, origTy);
     // "conversion" uses val so after this call,
     // we will get a use of conversion inside conversion.
     NodeValue conversionVal = getConversionOutput(*conversion);
@@ -108,7 +108,7 @@ void FunctionConverter::convertInputs(Node &node) {
     assert(targetTy->dims() == val.getType()->dims() &&
            "Conversion does not preserve shape");
     // Create the conversion.
-    Node *conversion = createConversion(val, targetTy);
+    Node *conversion = createConversion(function_, val, targetTy);
     node.setNthInput(idx, getConversionOutput(*conversion));
   }
 }

--- a/lib/Converter/TypeAToTypeBFunctionConverter.cpp
+++ b/lib/Converter/TypeAToTypeBFunctionConverter.cpp
@@ -51,12 +51,13 @@ TypeAToTypeBFunctionConverter::getTargetTypeForInput(const Node &use,
   return getTargetTypeForOutput(use.getNthInput(idx));
 }
 
-Node *TypeAToTypeBFunctionConverter::createConversion(NodeValue &val,
+Node *TypeAToTypeBFunctionConverter::createConversion(Function &function,
+                                                      NodeValue &val,
                                                       TypeRef destTy) {
   assert(((destTy->getElementType() == dstKind_ &&
            val.getType()->getElementType() == srcKind_) ||
           (destTy->getElementType() == srcKind_ &&
            val.getType()->getElementType() == dstKind_)) &&
          "Unexpected conversion type");
-  return function_.createConvertTo(val.getNode()->getName(), val, destTy);
+  return function.createConvertTo(val.getNode()->getName(), val, destTy);
 }

--- a/lib/Converter/TypeAToTypeBFunctionConverter.cpp
+++ b/lib/Converter/TypeAToTypeBFunctionConverter.cpp
@@ -16,6 +16,7 @@
 
 #include "glow/Converter/TypeAToTypeBFunctionConverter.h"
 
+#include "glow/Base/Tensor.h"
 #include "glow/Graph/Graph.h"
 
 using namespace glow;
@@ -60,4 +61,9 @@ Node *TypeAToTypeBFunctionConverter::createConversion(Function &function,
            val.getType()->getElementType() == dstKind_)) &&
          "Unexpected conversion type");
   return function.createConvertTo(val.getNode()->getName(), val, destTy);
+}
+
+void TypeAToTypeBFunctionConverter::convertTensor(Tensor &tensor,
+                                                  TypeRef destTy) {
+  tensor.convertToType(dstKind_);
 }

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -310,7 +310,6 @@ void ConvertToNode::verify() const {
   (void)srcTy;
   TypeRef dstTy = getResult().getType();
   (void)dstTy;
-  assert(srcTy != dstTy && "Nothing to convert");
   assert(!srcTy->isQuantizedType() && !dstTy->isQuantizedType() &&
          "Quantized conversion should use Dequantize, Quantize and Rescale");
 }

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -266,6 +266,14 @@ protected:
     }
   }
 
+  void convertTensor(Tensor &tensor, TypeRef destTy) override {
+    assert(tensor.getElementType() == ElemKind::FloatTy &&
+           destTy->getElementType() == ElemKind::Int8QTy &&
+           "Dequantization not implemented");
+
+    tensor = quantizeTensor(tensor, {destTy->getScale(), destTy->getOffset()});
+  }
+
 private:
   /// Shortcut to the module of function_.
   Module &mod_;

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -110,8 +110,8 @@ protected:
     return true;
   }
 
-  /// Create either a QuantizeNode or DequantizeNode base on the \p destTy
-  /// and the type of \p val.
+  /// Create either a QuantizeNode or DequantizeNode in \p function based on the
+  /// \p destTy and the type of \p val.
   /// Basically, if \p val's type is floating point, this creates a
   /// QuantizeNode of \p val.
   /// If \p val's type is a quantized type, this creates a
@@ -119,13 +119,14 @@ protected:
   ///
   /// \pre One of t\p val's type and \p destTy must be FloatTy and
   ///      the other must be a quantized type.
-  Node *createConversion(NodeValue &val, TypeRef destTy) override {
+  Node *createConversion(Function &function, NodeValue &val,
+                         TypeRef destTy) override {
     if (destTy->isQuantizedType()) {
       assert(destTy->getElementType() == ElemKind::Int8QTy && "");
       return function_.createQuantize("quantize", val, destTy);
     }
     assert(destTy->getElementType() == ElemKind::FloatTy && "");
-    return function_.createDequantize("quantize", val);
+    return function.createDequantize("quantize", val);
   }
 
   /// \see FunctionConverter::morphNode.


### PR DESCRIPTION
    [ImageClassifier] Add a convert-inout-to-fp16 option
    
    *Description*
    This teaches the image-classifier how to convert the input and output
    of a network to fp16.
    
    *Testing*
    Ran resnet50 with -convert-inout-to-fp16