### PR TITLE
[cmake] Fix a bunch of dependencies so BUILD_SHARED_LIBS works

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,10 @@ set(CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-set(CMAKE_CXX_VISIBILITY_PRESET hidden)
-set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
+if (NOT BUILD_SHARED_LIBS)
+  set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+  set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
+endif ()
 
 # Export a JSON file with the compilation commands that external tools can use
 # to analyze the source code of the project.

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -6,7 +6,8 @@ target_link_libraries(cifar10
                         ExecutionEngine
                         Graph
                         IR
-                        Support)
+                        Support
+                        LLVMSupport)
 
 add_executable(mnist
                  mnist.cpp)
@@ -17,7 +18,8 @@ target_link_libraries(mnist
                         Graph
                         IR
                         Optimizer
-                        Support)
+                        Support
+                        LLVMSupport)
 
 add_executable(ptb
                  ptb.cpp)
@@ -27,7 +29,8 @@ target_link_libraries(ptb
                         ExecutionEngine
                         Graph
                         IR
-                        Support)
+                        Support
+                        LLVMSupport)
 
 add_executable(char-rnn
                  char-rnn.cpp)
@@ -49,4 +52,5 @@ target_link_libraries(fr2en
                         IR
                         Optimizer
                         Quantization
-                        Support)
+                        Support
+                        LLVMSupport)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -16,6 +16,7 @@ target_link_libraries(mnist
                         ExecutionEngine
                         Graph
                         IR
+                        Optimizer
                         Support)
 
 add_executable(ptb
@@ -36,6 +37,7 @@ target_link_libraries(char-rnn
                         ExecutionEngine
                         Graph
                         IR
+                        Optimizer
                         Support)
 
 add_executable(fr2en
@@ -45,5 +47,6 @@ target_link_libraries(fr2en
                         Base
                         ExecutionEngine
                         IR
+                        Optimizer
                         Quantization
                         Support)

--- a/lib/CodeGen/CMakeLists.txt
+++ b/lib/CodeGen/CMakeLists.txt
@@ -1,1 +1,5 @@
 add_library(CodeGen MemoryAllocator.cpp)
+
+target_link_libraries(CodeGen
+                      PUBLIC
+                        Support)

--- a/lib/CodeGen/CMakeLists.txt
+++ b/lib/CodeGen/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(CodeGen MemoryAllocator.cpp)
 
 target_link_libraries(CodeGen
-                      PUBLIC
+                      PRIVATE
                         Support)

--- a/lib/Graph/CMakeLists.txt
+++ b/lib/Graph/CMakeLists.txt
@@ -1,24 +1,3 @@
-# AutoGenInstr
-set(INSTR_HDR ${GLOW_BINARY_DIR}/glow/AutoGenInstr.h)
-set(INSTR_SRC ${GLOW_BINARY_DIR}/glow/AutoGenInstr.cpp)
-set(INSTR_DEF ${GLOW_BINARY_DIR}/glow/AutoGenInstr.def)
-set(INSTR_BLD_HDR ${GLOW_BINARY_DIR}/glow/AutoGenIRBuilder.h)
-set(INSTR_BLD_SRC ${GLOW_BINARY_DIR}/glow/AutoGenIRBuilder.cpp)
-set(INSTR_IR_GEN ${GLOW_BINARY_DIR}/glow/AutoGenIRGen.h)
-
-add_custom_command(OUTPUT
-                    "${INSTR_HDR}"
-                    "${INSTR_SRC}"
-                    "${INSTR_DEF}"
-                    "${INSTR_BLD_HDR}"
-                    "${INSTR_BLD_SRC}"
-                    "${INSTR_IR_GEN}"
-                    COMMAND InstrGen
-                      ${INSTR_HDR} ${INSTR_SRC} ${INSTR_DEF}
-                      ${INSTR_BLD_HDR} ${INSTR_BLD_SRC} ${INSTR_IR_GEN}
-                    DEPENDS InstrGen
-                    COMMENT "InstrGen: Generating instructions." VERBATIM)
-
 # AutoGenNodes
 set(NODES_HDR ${GLOW_BINARY_DIR}/glow/AutoGenNodes.h)
 set(NODES_SRC ${GLOW_BINARY_DIR}/glow/AutoGenNodes.cpp)
@@ -36,12 +15,6 @@ add_library(Graph
             ${NODES_HDR}
             ${NODES_SRC}
             ${NODES_DEF}
-            ${NODES_BLD}
-            ${INSTR_HDR}
-            ${INSTR_SRC}
-            ${INSTR_DEF}
-            ${INSTR_BLD_HDR}
-            ${INSTR_BLD_SRC}
             Context.cpp
             Node.cpp
             Nodes.cpp
@@ -51,5 +24,6 @@ add_library(Graph
 target_link_libraries(Graph
                       PUBLIC
                         Base
+                        IRGenHeaders
                         Support
                         QuantizationBase)

--- a/lib/IR/CMakeLists.txt
+++ b/lib/IR/CMakeLists.txt
@@ -1,4 +1,27 @@
+# AutoGenInstr
+set(INSTR_HDR ${GLOW_BINARY_DIR}/glow/AutoGenInstr.h)
+set(INSTR_SRC ${GLOW_BINARY_DIR}/glow/AutoGenInstr.cpp)
+set(INSTR_DEF ${GLOW_BINARY_DIR}/glow/AutoGenInstr.def)
+set(INSTR_BLD_HDR ${GLOW_BINARY_DIR}/glow/AutoGenIRBuilder.h)
+set(INSTR_BLD_SRC ${GLOW_BINARY_DIR}/glow/AutoGenIRBuilder.cpp)
+set(INSTR_IR_GEN ${GLOW_BINARY_DIR}/glow/AutoGenIRGen.h)
+
+add_custom_command(OUTPUT
+                    "${INSTR_HDR}"
+                    "${INSTR_SRC}"
+                    "${INSTR_DEF}"
+                    "${INSTR_BLD_HDR}"
+                    "${INSTR_BLD_SRC}"
+                    "${INSTR_IR_GEN}"
+                    COMMAND InstrGen
+                      ${INSTR_HDR} ${INSTR_SRC} ${INSTR_DEF}
+                      ${INSTR_BLD_HDR} ${INSTR_BLD_SRC} ${INSTR_IR_GEN}
+                    DEPENDS InstrGen
+                    COMMENT "InstrGen: Generating instructions." VERBATIM)
+
 add_library(IR
+              ${INSTR_SRC}
+              ${INSTR_BLD_SRC}
               IR.cpp
               IRGen.cpp
               IRUtils.cpp
@@ -11,3 +34,12 @@ target_link_libraries(IR
                         Graph
                         Base
                         Support)
+
+add_library(IRGenHeaders
+              "${INSTR_HDR}"
+              "${INSTR_DEF}"
+              "${INSTR_BLD_HDR}")
+
+set_target_properties(IRGenHeaders
+                      PROPERTIES
+                        LINKER_LANGUAGE CXX)

--- a/lib/Onnxifi/CMakeLists.txt
+++ b/lib/Onnxifi/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(onnxifi-glow-thread-pool
 target_link_libraries(onnxifi-glow
                       PUBLIC
                         ExecutionEngine
+                        Graph
                         Importer
                       PRIVATE
                         onnxifi-glow-thread-pool)

--- a/lib/Quantization/CMakeLists.txt
+++ b/lib/Quantization/CMakeLists.txt
@@ -9,4 +9,5 @@ target_link_libraries(Quantization
                         Converter
                         Graph
                         ExecutionEngine
-                        QuantizationBase)
+                        QuantizationBase
+                        LLVMSupport)

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -3,5 +3,5 @@ add_library(Support
               Random.cpp
               Support.cpp)
 target_link_libraries(Support
-                      PUBLIC
+                      PRIVATE
                         LLVMSupport)

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -3,5 +3,5 @@ add_library(Support
               Random.cpp
               Support.cpp)
 target_link_libraries(Support
-                      INTERFACE
+                      PUBLIC
                         LLVMSupport)

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -9,7 +9,10 @@ add_executable(partitionTest
                partitionTest.cpp)
 target_link_libraries(partitionTest
                       PRIVATE
+                        Backends
                         ExecutionEngine
+                        Graph
+                        Optimizer
                         gtest
                         testMain)
 add_glow_test(partitionTest ${GLOW_BINARY_DIR}/tests/partitionTest)
@@ -60,9 +63,11 @@ add_executable(backendTest
                BackendTest.cpp)
 target_link_libraries(backendTest
                       PRIVATE
+                        Backends
                         Graph
                         IR
                         ExecutionEngine
+                        Optimizer
                         gtest
                         testMain)
 add_glow_test(backendTest ${GLOW_BINARY_DIR}/tests/backendTest)
@@ -74,6 +79,7 @@ target_link_libraries(MLTest
                         Graph
                         IR
                         ExecutionEngine
+                        Optimizer
                         Quantization
                         gtest
                         testMain)
@@ -95,9 +101,11 @@ add_executable(graphTest
                graphTest.cpp)
 target_link_libraries(graphTest
                       PRIVATE
+                        Backends
                         ExecutionEngine
                         Graph
                         IR
+                        Optimizer
                         gtest
                         testMain)
 add_glow_test(graphTest ${GLOW_BINARY_DIR}/tests/graphTest)
@@ -139,8 +147,10 @@ add_executable(quantizationTest
                quantizationTest.cpp)
 target_link_libraries(quantizationTest
                       PRIVATE
+                        Backends
                         ExecutionEngine
                         Graph
+                        Optimizer
                         Quantization
                         gtest
                         testMain)
@@ -162,6 +172,7 @@ target_link_libraries(typeAToTypeBFunctionConverterTest
                         Converter
                         ExecutionEngine
                         Graph
+                        Optimizer
                         gtest
                         testMain)
 add_glow_test(typeAToTypeBFunctionConverterTest
@@ -196,11 +207,13 @@ add_executable(BackendCorrectnessTest
                BackendCorrectnessTest.cpp)
 target_link_libraries(BackendCorrectnessTest
                       PRIVATE
+                        Backends
                         Graph
                         IR
                         ExecutionEngine
-                        Support
+                        Optimizer
                         Quantization
+                        Support
                         gtest
                         testMain)
 

--- a/tools/loader/CMakeLists.txt
+++ b/tools/loader/CMakeLists.txt
@@ -10,7 +10,8 @@ target_link_libraries(image-classifier
                         Graph
                         Importer
                         Optimizer
-                        Quantization)
+                        Quantization
+                        LLVMSupport)
 
 add_executable(text-translator
   Loader.cpp
@@ -24,7 +25,8 @@ target_link_libraries(text-translator
                         Importer
                         ExecutionEngine
                         Optimizer
-                        Quantization)
+                        Quantization
+                        LLVMSupport)
 
 add_executable(model-runner
   Loader.cpp
@@ -38,4 +40,5 @@ target_link_libraries(model-runner
                         Importer
                         ExecutionEngine
                         Optimizer
-                        Quantization)
+                        Quantization
+                        LLVMSupport)

--- a/tools/loader/CMakeLists.txt
+++ b/tools/loader/CMakeLists.txt
@@ -6,8 +6,10 @@ target_link_libraries(image-classifier
                       PRIVATE
                         Base
                         Converter
-                        Importer
                         ExecutionEngine
+                        Graph
+                        Importer
+                        Optimizer
                         Quantization)
 
 add_executable(text-translator
@@ -17,8 +19,11 @@ add_executable(text-translator
 target_link_libraries(text-translator
                       PRIVATE
                         Base
+                        Converter
+                        Graph
                         Importer
                         ExecutionEngine
+                        Optimizer
                         Quantization)
 
 add_executable(model-runner
@@ -28,6 +33,9 @@ add_executable(model-runner
 target_link_libraries(model-runner
                       PRIVATE
                         Base
+                        Converter
+                        Graph
                         Importer
                         ExecutionEngine
+                        Optimizer
                         Quantization)


### PR DESCRIPTION
*Description*: It seems we were getting away with lax dependencies, which were exposed when I tried building with `-DBUILD_SHARED_LIBS=ON`.  (Incrementally relinking tests is somewhat faster with shared libs, which is why I was trying this.)

*Testing*: `ninja all && ninja test`

*Documentation*: None
