### PR TITLE
[ExecutionEngine] Create runctx and execute(ctx) functions

### DIFF
--- a/examples/char-rnn.cpp
+++ b/examples/char-rnn.cpp
@@ -276,7 +276,7 @@ int main(int argc, char **argv) {
     for (unsigned i = 0; i < generateChars; i++) {
       // Generate a char:
       updateInputPlaceholders(ctx, {X}, {&currCharInfer});
-      EE.run();
+      EE.run(ctx);
 
       // Pick a char at random from the softmax distribution.
       char c = getPredictedChar(*T, 0, numSteps - 1);

--- a/examples/cifar10.cpp
+++ b/examples/cifar10.cpp
@@ -160,7 +160,7 @@ void testCIFAR10() {
       Tensor sample(ElemKind::FloatTy, {minibatchSize, 32, 32, 3});
       sample.copyConsecutiveSlices(&images, minibatchSize * i);
       updateInputPlaceholders(ctx, {A}, {&sample});
-      EE.run();
+      EE.run(ctx);
 
       for (unsigned int iter = 0; iter < minibatchSize; iter++) {
         auto T = result->getHandle<>().extractSlice(iter);

--- a/examples/fr2en.cpp
+++ b/examples/fr2en.cpp
@@ -392,7 +392,7 @@ void Model::translate(const std::vector<std::string> &batch) {
   }
 
   updateInputPlaceholders(ctx, {input_, seqLength_}, {&input, &seqLength});
-  EE_.run();
+  EE_.run(ctx);
 
   auto OH = ctx.get(output_)->getHandle<int64_t>();
   for (unsigned j = 0; j < batch.size(); j++) {

--- a/examples/mnist.cpp
+++ b/examples/mnist.cpp
@@ -170,7 +170,7 @@ void testMNIST() {
 
   for (int iter = numIterations; iter < numIterations + 10; iter++) {
     inputTensor->copyConsecutiveSlices(&imageInputs, minibatchSize * iter);
-    EE.run();
+    EE.run(ctx);
 
     for (unsigned i = 0; i < minibatchSize; i++) {
       auto T = resultTensor->getHandle<>().extractSlice(i);

--- a/include/glow/Backends/CompiledFunction.h
+++ b/include/glow/Backends/CompiledFunction.h
@@ -20,14 +20,17 @@
 
 namespace glow {
 
+class Context;
+
 /// Interface for executing a compiled function.
 class CompiledFunction {
 public:
   /// Dtor.
   virtual ~CompiledFunction() = default;
 
-  /// Execute the network.
-  virtual void execute() = 0;
+  /// Execute the network and allocate Placeholder memory with given
+  /// \p ctx providing mapping between Placeholder and populated tensor.
+  virtual void execute(Context &ctx) = 0;
 };
 
 } // end namespace glow

--- a/include/glow/ExecutionEngine/ExecutionEngine.h
+++ b/include/glow/ExecutionEngine/ExecutionEngine.h
@@ -81,8 +81,8 @@ public:
   void save(CompilationMode mode, Function *F, llvm::StringRef outputDir,
             llvm::StringRef networkName);
 
-  /// Runs a single execution of the function.
-  void run();
+  /// Context aware single execution of the function.
+  void run(Context &ctx);
 };
 
 //===----------------------------------------------------------------------===//

--- a/lib/Backends/CPU/CPUFunction.cpp
+++ b/lib/Backends/CPU/CPUFunction.cpp
@@ -26,7 +26,7 @@ CPUFunction::CPUFunction(std::unique_ptr<llvm::orc::GlowJIT> JIT, void *heap)
 
 CPUFunction::~CPUFunction() { alignedFree(heap_); }
 
-void CPUFunction::execute() {
+void CPUFunction::execute(Context &ctx) {
   auto sym = JIT_->findSymbol("jitmain");
   assert(sym && "Unable to JIT the code!");
   using JitFuncType = void (*)(void);

--- a/lib/Backends/CPU/CPUFunction.h
+++ b/lib/Backends/CPU/CPUFunction.h
@@ -38,7 +38,7 @@ public:
   ///@{
   ~CPUFunction() override;
 
-  void execute() override;
+  void execute(Context &ctx) override;
   ///@}
 };
 

--- a/lib/Backends/Interpreter/InterpreterFunction.cpp
+++ b/lib/Backends/Interpreter/InterpreterFunction.cpp
@@ -107,7 +107,7 @@ void InterpreterFunction::deleteTensor(const Value *v) {
   tensors_.erase(it);
 }
 
-void InterpreterFunction::execute() {
+void InterpreterFunction::execute(Context &ctx) {
 // Do the forward pass.
 #define DEF_VALUE(CLASS, NAME)
 #define DEF_INSTR(CLASS, NAME)                                                 \

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -55,7 +55,7 @@ public:
   ///@{
   ~InterpreterFunction() override;
 
-  void execute() override;
+  void execute(Context &ctx) override;
   ///@}
 
 private:

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -618,8 +618,7 @@ static void topK(Tensor &outW, Tensor &indW, Tensor &inW, size_t k) {
     }
   }
 }
-
-void OpenCLFunction::execute() {
+void OpenCLFunction::execute(Context &ctx) {
   auto copiedToDeviceBytes = copyMutableWeightsToDevice();
   (void)copiedToDeviceBytes;
   DEBUG_GLOW(llvm::dbgs() << "Copied " << copiedToDeviceBytes

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -99,7 +99,7 @@ public:
   ///@{
   ~OpenCLFunction() override;
 
-  void execute() override;
+  void execute(Context &ctx) override;
   ///@}
 
 private:

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -74,9 +74,9 @@ void glow::updateInputPlaceholdersByName(Context &ctx, Module *mod,
   }
 }
 
-void ExecutionEngine::run() {
+void ExecutionEngine::run(Context &ctx) {
   assert(function_ && "No function has been compiled");
-  function_->execute();
+  function_->execute(ctx);
 }
 
 void glow::runBatch(ExecutionEngine &EE, Context &ctx, size_t iterations,
@@ -109,7 +109,7 @@ void glow::runBatch(ExecutionEngine &EE, Context &ctx, size_t iterations,
     }
 
     // Run the network.
-    EE.run();
+    EE.run(ctx);
     sampleCounter += batchSize;
   }
 }

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -84,7 +84,7 @@ onnxStatus Graph::run() {
   // Run inference.
   auto &EE = backendPtr_->getEE();
   updateInputPlaceholders(ctx_, phs, tensors);
-  EE.run();
+  EE.run(ctx_);
 
   // Copy outputs to the addresses specified in the outputNodeToBuffer_.
   for (auto outputVar : outputNodeToBuffer_) {

--- a/tests/unittests/BackendCorrectnessTest.cpp
+++ b/tests/unittests/BackendCorrectnessTest.cpp
@@ -49,7 +49,7 @@ profileAndGetNodeQuantizationInfo(Context &ctx, ExecutionEngine &EE,
   Function *profileF = glow::profileQuantization(ctx, origF);
   EE.compile(CompilationMode::Infer, profileF, ctx);
 
-  EE.run();
+  EE.run(ctx);
 
   return quantization::generateNodeQuantizationInfos(ctx, profileF);
 }
@@ -92,8 +92,8 @@ compareAgainstInterpreter(BackendKind backendKind,
   IEE.compile(CompilationMode::Infer, IF, ICtx);
   BEE.compile(CompilationMode::Infer, BF, BCtx);
 
-  IEE.run();
-  BEE.run();
+  IEE.run(ICtx);
+  BEE.run(BCtx);
 
   return IFT.second->isEqual(*BFT.second, allowedError);
 }
@@ -309,7 +309,7 @@ TEST_P(CPUOnly, dataParallelStackingTest) {
   }
 
   MockCPUBackend backend;
-  backend.compileIR(std::move(M), ctx)->execute();
+  backend.compileIR(std::move(M), ctx)->execute(ctx);
   auto H = outputTensor->getHandle();
   EXPECT_EQ(H.at(0), 3);
   EXPECT_EQ(H.at(1), 4);

--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -69,7 +69,7 @@ TEST(Interpreter, profileQuantizationForANetwork) {
   // TODO: Verify histogram itself, for now just verify min and max.
   // Run inference first time and capture tensor stats.
   updateInputPlaceholders(ctx, {A}, {&inputs});
-  EE.run();
+  EE.run(ctx);
 
   QuantizationProfileNode *profile{nullptr};
   // Find QPN for node A.
@@ -96,7 +96,7 @@ TEST(Interpreter, profileQuantizationForANetwork) {
   // Run inference for the second time with new min and max.
   inputs.getHandle() = {0.2f, 1.6f, 0.5f, 1.3f};
   updateInputPlaceholders(ctx, {A}, {&inputs});
-  EE.run();
+  EE.run(ctx);
   min = CI.raw(0);
   max = CI.raw(1);
   EXPECT_NEAR(0.2, min, 0.00001);
@@ -138,7 +138,7 @@ TEST_P(BackendTest, simpleInference) {
   EE_.compile(CompilationMode::Infer, F, ctx);
 
   updateInputPlaceholders(ctx, {input}, {&inputs});
-  EE_.run();
+  EE_.run(ctx);
 }
 
 /// Test that the DebugPrint instruction works correctly for the backend. Note
@@ -161,7 +161,7 @@ TEST_P(BackendTest, debugPrint) {
   std::unique_ptr<BackendUsingGlowIR> backend(
       static_cast<BackendUsingGlowIR *>(createBackend(GetParam())));
   auto function = backend->compileIR(std::move(IR), ctx);
-  function->execute();
+  function->execute(ctx);
 }
 
 /// This test checks that we can compile a function without depending on the
@@ -186,7 +186,7 @@ TEST_P(BackendTest, decoupleCodegenFromGraph) {
 
   // We can run the compiled code without having the graph representation
   // around.
-  EE_.run();
+  EE_.run(ctx);
 
   auto HX = saveTensor->getHandle();
   EXPECT_NEAR(HX.at({0}), 1, 1E-5);
@@ -206,7 +206,7 @@ TEST_P(BackendTest, simplePlaceholderValue) {
   auto *STensor = ctx.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F, ctx);
-  EE_.run();
+  EE_.run(ctx);
   EXPECT_TRUE(STensor->isEqual(data));
 }
 

--- a/tests/unittests/BackendTestUtils.cpp
+++ b/tests/unittests/BackendTestUtils.cpp
@@ -67,7 +67,7 @@ void inferIntLookupTableNet(Tensor *input, Tensor *out,
   EE.compile(CompilationMode::Infer, F, ctx);
 
   updateInputPlaceholders(ctx, {var}, {input});
-  EE.run();
+  EE.run(ctx);
   out->assign(resultTensor);
 }
 
@@ -109,7 +109,7 @@ void inferConvNet(Tensor *inputs, Tensor *filter, Tensor *bias, Tensor *out,
 
   updateInputPlaceholders(ctx, {inputP, filterP, biasP},
                           {inputs, filter, bias});
-  EE.run();
+  EE.run(ctx);
   out->assign(resultTensor);
 }
 
@@ -151,7 +151,7 @@ void trainConvNet(Tensor *inputs, Tensor *kernel1, Tensor *bias1,
   runBatch(EE, ctx, 8, sampleCounter, {var1, var2}, {inputs, selected});
   EE.compile(CompilationMode::Infer, F, ctx);
   updateInputPlaceholders(ctx, {var1, var2}, {inputs, selected});
-  EE.run();
+  EE.run(ctx);
   out->assign(resultTensor);
 }
 
@@ -169,7 +169,7 @@ void inferLocalResponseNormalizationNet(Tensor *inputs, Tensor *out,
   EE.compile(CompilationMode::Infer, F, ctx);
 
   updateInputPlaceholders(ctx, {var}, {inputs});
-  EE.run();
+  EE.run(ctx);
   out->assign(resultTensor);
 }
 
@@ -250,7 +250,7 @@ void trainAvgPoolNet(Tensor *inputs, Tensor *weights, Tensor *bias,
   EE.compile(CompilationMode::Infer, F, ctx);
 
   updateInputPlaceholders(ctx, {var1, var2}, {inputs, selected});
-  EE.run();
+  EE.run(ctx);
   out->assign(resultTensor);
 }
 
@@ -308,7 +308,7 @@ void inferSmallConv(Tensor *inputs, Tensor *out, BackendKind kind) {
   EE.compile(CompilationMode::Infer, F, ctx);
 
   updateInputPlaceholders(ctx, {in}, {inputs});
-  EE.run();
+  EE.run(ctx);
 
   out->assign(resultTensor);
 }
@@ -349,7 +349,7 @@ void inferGroupConv(Tensor *out, BackendKind kind) {
 
   EE.compile(CompilationMode::Infer, F, ctx);
 
-  EE.run();
+  EE.run(ctx);
   out->assign(resultTensor);
 }
 
@@ -388,7 +388,7 @@ void inferNonSquarePaddingConv(Tensor *out, BackendKind kind) {
 
   EE.compile(CompilationMode::Infer, F, ctx);
 
-  EE.run();
+  EE.run(ctx);
   out->assign(resultTensor);
 }
 
@@ -428,7 +428,7 @@ void inferNonSquareKernelConv(Tensor *out, BackendKind kind) {
 
   EE.compile(CompilationMode::Infer, F, ctx);
 
-  EE.run();
+  EE.run(ctx);
   out->assign(resultTensor);
 }
 
@@ -468,7 +468,7 @@ void inferNonSquareStrideConv(Tensor *out, BackendKind kind) {
 
   EE.compile(CompilationMode::Infer, F, ctx);
 
-  EE.run();
+  EE.run(ctx);
   out->assign(resultTensor);
 }
 
@@ -509,7 +509,7 @@ void inferConvDKKC8(Tensor *out, BackendKind kind) {
 
   EE.compile(CompilationMode::Infer, F, ctx);
 
-  EE.run();
+  EE.run(ctx);
   out->assign(resultTensor);
 }
 
@@ -545,7 +545,7 @@ void trainSoftMaxNet(Tensor *inputs, Tensor *weights, Tensor *bias,
   EE.compile(CompilationMode::Infer, F, ctx);
 
   updateInputPlaceholders(ctx, {var1, var2}, {inputs, selected});
-  EE.run();
+  EE.run(ctx);
   out->assign(resultTensor);
 }
 
@@ -569,7 +569,7 @@ void inferTanhConcatNet(Tensor *input1, Tensor *input2, Tensor *input3,
   EE.compile(CompilationMode::Infer, F, ctx);
 
   updateInputPlaceholders(ctx, {var1, var2, var3}, {input1, input2, input3});
-  EE.run();
+  EE.run(ctx);
   out->assign(resultTensor);
 }
 
@@ -592,7 +592,7 @@ void inferBasicConvNet(Tensor *inputs, Tensor *out, BackendKind kind,
   EE.compile(CompilationMode::Infer, F, ctx);
 
   updateInputPlaceholders(ctx, {var}, {inputs});
-  EE.run();
+  EE.run(ctx);
   out->assign(resultTensor);
 }
 
@@ -645,7 +645,7 @@ void inferMixedNet(Tensor *inputs, Tensor *out, BackendKind kind) {
   EE.compile(CompilationMode::Infer, F, ctx);
 
   updateInputPlaceholders(ctx, {var}, {inputs});
-  EE.run();
+  EE.run(ctx);
   out->assign(resultTensor);
 }
 
@@ -690,7 +690,7 @@ void inferComplexNet1(Tensor *inputs1, Tensor *inputs2, Tensor *inputs3,
 
   updateInputPlaceholders(ctx, {var1, var2, var3, var4},
                           {inputs1, inputs2, inputs3, inputs4});
-  EE.run();
+  EE.run(ctx);
   out->assign(resultTensor);
 }
 
@@ -730,7 +730,7 @@ void inferTinyResnet(Tensor *input, Tensor *out, std::vector<Tensor> &weights,
   EE.compile(CompilationMode::Infer, F, ctx);
 
   updateInputPlaceholders(ctx, {in}, {input});
-  EE.run();
+  EE.run(ctx);
   out->assign(resultTensor);
 }
 
@@ -763,7 +763,7 @@ void inferExtract3D(Tensor *input, Tensor *out, BackendKind kind) {
   EE.compile(CompilationMode::Infer, F, ctx);
 
   updateInputPlaceholders(ctx, {inputs}, {input});
-  EE.run();
+  EE.run(ctx);
   out->assign(resultTensor);
 }
 
@@ -792,7 +792,7 @@ void inferMaxSplat(Tensor *input, Tensor *out, BackendKind kind) {
   EE.compile(CompilationMode::Infer, F, ctx);
 
   updateInputPlaceholders(ctx, {var}, {input});
-  EE.run();
+  EE.run(ctx);
   out->assign(resultTensor);
 }
 

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -23,7 +23,7 @@ namespace glow {
 /// MockBackend used only for unit testing.
 class MockBackend : public Backend {
   class MockFunction : public CompiledFunction {
-    void execute() override {}
+    void execute(Context &ctx) override{};
   };
   std::unique_ptr<CompiledFunction> compile(Function *F,
                                             const Context &ctx) const override {

--- a/tests/unittests/GemmTest.cpp
+++ b/tests/unittests/GemmTest.cpp
@@ -58,7 +58,7 @@ void infer(Tensor *out, Tensor *lhs, Tensor *rhs) {
   EE.compile(CompilationMode::Infer, F, ctx);
 
   updateInputPlaceholders(ctx, {lhsVar, rhsVar}, {lhs, rhs});
-  EE.run();
+  EE.run(ctx);
 
   out->assign(res);
 }

--- a/tests/unittests/HyphenTest.cpp
+++ b/tests/unittests/HyphenTest.cpp
@@ -305,7 +305,7 @@ struct HyphenNetwork {
       }
       auto batchInputs = inputs.getUnowned({batchSize, 6, 27}, {bi, 0, 0});
       updateInputPlaceholders(ctx_, {input_}, {&batchInputs});
-      EE.run();
+      EE.run(ctx_);
 
       // Check each output in the batch.
       for (size_t i = 0; i != batchSize; i++) {

--- a/tests/unittests/MLTest.cpp
+++ b/tests/unittests/MLTest.cpp
@@ -67,7 +67,7 @@ TEST_P(MLTest, learnSqrt2Placeholder) {
 
   // Train the network:
   for (int i = 0; i < 100; i++) {
-    EE_.run();
+    EE_.run(ctx);
   }
 
   float res = inputTensor->getHandle().at({0});
@@ -117,7 +117,7 @@ TEST_P(MLTest, trainASimpleNetwork) {
 
   EE_.compile(CompilationMode::Infer, F, ctx);
   updateInputPlaceholders(ctx, {A}, {&inputs});
-  EE_.run();
+  EE_.run(ctx);
 
   auto RNWH = res->getHandle<>();
   (void)RNWH;
@@ -182,7 +182,7 @@ TEST_P(MLTest, simpleRegression) {
     float target = iter % 9 + 1;
     I = {target, 0., 0., 0.};
     updateInputPlaceholders(ctx, {A}, {&inputs});
-    EE_.run();
+    EE_.run(ctx);
 
     auto resH = res->getHandle<>();
     (void)resH;
@@ -257,7 +257,7 @@ TEST_P(MLTest, learnXor) {
   }
 
   updateInputPlaceholders(ctx, {A}, {&trainingSet});
-  EE_.run();
+  EE_.run(ctx);
 
   auto resH = res->getHandle<>();
 
@@ -342,7 +342,7 @@ TEST_P(MLTest, learnLog) {
   }
 
   updateInputPlaceholders(ctx, {A}, {&testSet});
-  EE_.run();
+  EE_.run(ctx);
 
   auto resH = res->getHandle<>();
 
@@ -440,7 +440,7 @@ TEST_P(MLTest, circle) {
       sample.getHandle<>().at({0, 1}) = float(y) / 10;
 
       updateInputPlaceholders(ctx, {A}, {&sample});
-      EE_.run();
+      EE_.run(ctx);
 
       auto SMH = res->getHandle<>();
       auto A = SMH.at({0, 0});
@@ -464,7 +464,7 @@ TEST_P(MLTest, circle) {
     sample.getHandle<>().at({0, 0}) = 0;
     sample.getHandle<>().at({0, 1}) = 0;
     updateInputPlaceholders(ctx, {A}, {&sample});
-    EE_.run();
+    EE_.run(ctx);
 
     auto SMH = res->getHandle<>();
     auto A = SMH.at({0, 0});
@@ -477,7 +477,7 @@ TEST_P(MLTest, circle) {
     sample.getHandle<>().at({0, 0}) = 1;
     sample.getHandle<>().at({0, 1}) = 1;
     updateInputPlaceholders(ctx, {A}, {&sample});
-    EE_.run();
+    EE_.run(ctx);
     auto SMH = res->getHandle<>();
     auto A = SMH.at({0, 0});
     auto B = SMH.at({0, 1});
@@ -541,7 +541,7 @@ TEST_P(MLTest, learnSingleValueConcat) {
 
   // Testing the output vector.
   updateInputPlaceholders(ctx, {A}, {&inputs});
-  EE_.run();
+  EE_.run(ctx);
   auto RNWH = res->getHandle<>();
   (void)RNWH;
 
@@ -654,7 +654,7 @@ void testRNNCell(TCellGenerator cell) {
   EE.compile(CompilationMode::Infer, F, ctx);
 
   updateInputPlaceholders(ctx, {X}, {&inputs});
-  EE.run();
+  EE.run(ctx);
 
   auto RNWH = res->getHandle<>();
   (void)RNWH;
@@ -820,7 +820,7 @@ TEST_P(MLTest, classifyPlayerSport) {
   }
 
   updateInputPlaceholders(ctx, {A}, {&testPlayersTensor});
-  EE_.run();
+  EE_.run(ctx);
 
   auto SMH = ctx.get(result->getPlaceholder())->getHandle<>();
   for (size_t i = 0; i < testPlayers.size(); i++) {
@@ -900,7 +900,7 @@ TEST_P(MLTest, learnSinus) {
 
   EE_.compile(CompilationMode::Infer, F, ctx);
   updateInputPlaceholders(ctx, {inputX}, {&tensorX});
-  EE_.run();
+  EE_.run(ctx);
   auto resH = res->getHandle<>();
 
   for (size_t i = 0; i < numSamples; i++) {
@@ -975,7 +975,7 @@ TEST_P(MLTest, nonLinearClassifier) {
     T.getHandle<>().at({0, 0}) = std::get<0>(tests[i]);
     T.getHandle<>().at({0, 1}) = std::get<1>(tests[i]);
     updateInputPlaceholders(ctx, {A}, {&T});
-    EE_.run();
+    EE_.run(ctx);
     EXPECT_NEAR(RH.at({0, std::get<2>(tests[i])}), 1.0, 0.2);
   }
 }
@@ -1071,7 +1071,7 @@ TEST_P(InterpreterAndCPU, convNetForImageRecognition) {
   Tensor testLabels(ElemKind::Int64ITy, {batchSize, 1});
   generateImageData(testImages, testLabels, mod.getPRNG());
   updateInputPlaceholders(ctx, {input}, {&testImages});
-  EE.run();
+  EE.run(ctx);
   auto SMH = res->getHandle<>();
   for (size_t i = 0; i < batchSize; i++) {
     bool isLine = testLabels.getHandle<int64_t>().at({i, 0}) == 0;
@@ -1180,7 +1180,7 @@ TEST_P(InterpreterAndCPU, testFindPixelRegression) {
 
   // Run the inference:
   updateInputPlaceholders(ctx, {input}, {&testImages});
-  EE.run();
+  EE.run(ctx);
 
   // A handle to the projected result.
   auto RH = res->getHandle<>();
@@ -1351,7 +1351,7 @@ TEST_P(MLTest, matrixRotationRecognition) {
       matricesB.getUnowned({batchSize, 3, 3}, {batchStartIdx, 0, 0});
   updateInputPlaceholders(ctx, {varMatricesA, varMatricesB},
                           {&batchMatricesA, &batchMatricesB});
-  EE_.run();
+  EE_.run(ctx);
 
   unsigned errors = 0;
   // Check each output in the batch.

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -72,7 +72,7 @@ TEST_P(Operator, pow) {
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
 
-  EE_.run();
+  EE_.run(ctx_);
 
   auto HX = ctx_.get(savePlaceholder1)->getHandle();
   EXPECT_NEAR(HX.at({0, 0, 0}), 25, 1E-5);
@@ -101,7 +101,7 @@ TEST_P(InterpAndCPU, replaceNaN) {
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
 
-  EE_.run();
+  EE_.run(ctx_);
 
   auto saveH = saveTensor->getHandle();
 
@@ -126,7 +126,7 @@ TEST_P(InterpAndCPU, log) {
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
 
-  EE_.run();
+  EE_.run(ctx_);
 
   auto saveH = saveTensor->getHandle();
 
@@ -149,7 +149,7 @@ TEST_P(InterpAndCPU, CmpEQ) {
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
 
-  EE_.run();
+  EE_.run(ctx_);
 
   auto saveH = saveTensor->getHandle<int64_t>();
   for (size_t i = 0; i < 7; ++i) {
@@ -175,7 +175,7 @@ TEST_P(Operator, add) {
   ctx_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto result = ctx_.get(S->getPlaceholder())->getHandle();
   auto handleA = ctx_.get(inputA)->getHandle();
@@ -201,7 +201,7 @@ TEST_P(InterpOnly, FP16Add) {
   ctx_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto result = ctx_.get(S->getPlaceholder())->getHandle<float16_t>();
   auto handleA = ctx_.get(inputA)->getHandle<float16_t>();
@@ -224,7 +224,7 @@ TEST_P(Operator, matmul) {
   auto *saveTensor = ctx_.allocate(save->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto H = saveTensor->getHandle();
   EXPECT_NEAR(H.at({0, 0}), 27, 0.001);
@@ -245,7 +245,7 @@ TEST_P(InterpOnly, FP16Matmul) {
   auto *saveTensor = ctx_.allocate(save->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto H = saveTensor->getHandle<float16_t>();
   EXPECT_NEAR(H.at({0, 0}), 27, 0.001);
@@ -267,7 +267,7 @@ TEST_P(Operator, BroadcastedBatchMatMul) {
   auto *result = ctx_.allocate(save->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto H = result->getHandle();
   EXPECT_NEAR(H.at({0, 0, 0}), 27, 0.001);
@@ -292,7 +292,7 @@ TEST_P(Operator, ParallelBatchMatMul) {
   auto *result = ctx_.allocate(save->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto H = result->getHandle();
   EXPECT_NEAR(H.at({0, 0, 0}), 27, 0.001);
@@ -314,7 +314,7 @@ TEST_P(Operator, batchedReduceAdd) {
   auto *result = ctx_.allocate(save->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto H = result->getHandle();
   EXPECT_NEAR(H.at({0}), 11, 0.001);
@@ -334,7 +334,7 @@ TEST_P(InterpAndCPU, batchedReduceAddWithAxis) {
   auto *result = ctx_.allocate(save->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto H = result->getHandle();
   EXPECT_NEAR(H.at({0, 0}), 6, 0.001);
@@ -364,7 +364,7 @@ TEST_P(InterpAndCPU, batchedReduceAddQuantized) {
   auto OH = ctx_.allocate(save->getPlaceholder())->getHandle<int8_t>();
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   for (size_t i = 0; i < 8; i++) {
     std::array<int32_t, 3> b{{BH.at({0, i}), BH.at({1, i}), BH.at({2, i})}};
@@ -397,7 +397,7 @@ TEST_P(InterpAndCPU, batchedReduceAddQuantizedWithAxis) {
   auto OH = ctx_.allocate(save->getPlaceholder())->getHandle<int8_t>();
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   for (size_t i = 0; i < 2; i++) {
     for (size_t j = 0; j < 4; j++) {
@@ -424,7 +424,7 @@ TEST_P(Operator, batchedReduceMean) {
   auto *result = ctx_.allocate(save->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto H = result->getHandle();
   EXPECT_NEAR(H.at({0}), 5.5, 0.001);
@@ -444,7 +444,7 @@ TEST_P(InterpAndCPU, batchedReduceMeanWithAxis) {
   auto *result = ctx_.allocate(save->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto H = result->getHandle();
   EXPECT_NEAR(H.at({0, 0}), 2.0, 0.001);
@@ -474,7 +474,7 @@ TEST_P(InterpAndCPU, batchedReduceMeanQuantized) {
   auto OH = ctx_.allocate(save->getPlaceholder())->getHandle<int8_t>();
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   for (size_t i = 0; i < 8; i++) {
     std::array<int32_t, 3> b{{BH.at({0, i}), BH.at({1, i}), BH.at({2, i})}};
@@ -507,7 +507,7 @@ TEST_P(InterpAndCPU, batchedReduceMeanQuantizedWithAxis) {
   auto OH = ctx_.allocate(save->getPlaceholder())->getHandle<int8_t>();
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   for (size_t i = 0; i < 2; i++) {
     for (size_t j = 0; j < 4; j++) {
@@ -539,7 +539,7 @@ TEST_P(Operator, BatchedAdd) {
   auto *result = ctx_.allocate(save->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto BH = ctx_.get(batch)->getHandle();
   auto RH = result->getHandle();
@@ -586,7 +586,7 @@ TEST_P(InterpAndCPU, broadcastSimple) {
   auto *broadcastedQ = ctx_.allocate(saveQ->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto broadcastedBHandle = broadcasted->getHandle();
   auto broadcastedQBHandle = broadcastedQ->getHandle<int8_t>();
@@ -650,7 +650,7 @@ TEST_P(InterpAndCPU, broadcast) {
   auto *broadcastedQ = ctx_.allocate(saveQ->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto broadcastedBHandle = broadcasted->getHandle();
   auto broadcastedQBHandle = broadcastedQ->getHandle<int8_t>();
@@ -702,7 +702,7 @@ TEST_P(Operator, weightedSum) {
   auto *saveTensor = ctx_.allocate(save->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   // Verify the weighted sum was correctly calculated.
   auto resultH = saveTensor->getHandle();
@@ -726,7 +726,7 @@ TEST_P(Operator, minElem) {
   ctx_.allocate(RHS)->getHandle().randomize(-10, 10, PRNG);
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto resultH = result->getHandle();
   auto LHSH = ctx_.get(LHS)->getHandle();
@@ -752,7 +752,7 @@ TEST_P(Operator, maxElem) {
   ctx_.allocate(RHS)->getHandle().randomize(-10, 10, PRNG);
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto resultH = result->getHandle();
   auto LHSH = ctx_.get(LHS)->getHandle();
@@ -773,7 +773,7 @@ TEST_P(Operator, ReluSimple) {
   ctx_.allocate(in)->getHandle() = {0, -1, -2, -3, 4, 5, 6};
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto resultH = result->getHandle();
 
@@ -807,7 +807,7 @@ TEST_P(Operator, TopK) {
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
 
-  EE_.run();
+  EE_.run(ctx_);
 
   auto V = ctx_.get(values)->getHandle();
   auto I = ctx_.get(indices)->getHandle<int64_t>();
@@ -864,7 +864,7 @@ TEST_P(InterpAndCPU, ConcatTopK) {
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
 
-  EE_.run();
+  EE_.run(ctx_);
 
   auto V = saveValuesTensor->getHandle();
   auto I = saveIndicesTensor->getHandle<int64_t>();
@@ -928,7 +928,7 @@ TEST_P(Operator, matMul) {
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
 
-  EE_.run();
+  EE_.run(ctx_);
 
   auto R0 = ctx_.get(res0->getPlaceholder())->getHandle();
   auto R1 = ctx_.get(res1->getPlaceholder())->getHandle();
@@ -960,7 +960,7 @@ TEST_P(InterpAndCPU, TopK1) {
   ctx_.allocate(indices->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto V = ctx_.get(values->getPlaceholder())->getHandle();
   auto I = ctx_.get(indices->getPlaceholder())->getHandle<int64_t>();
@@ -988,7 +988,7 @@ TEST_P(InterpAndCPU, QuantizedTopK) {
   ctx_.allocate(indices->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto VH = ctx_.get(values->getPlaceholder())->getHandle<int8_t>();
   auto IH = ctx_.get(indices->getPlaceholder())->getHandle<int64_t>();
@@ -1058,7 +1058,7 @@ TEST_P(Operator, Gather) {
   ctx_.allocate(result->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto H = ctx_.get(result->getPlaceholder())->getHandle();
 
@@ -1093,7 +1093,7 @@ TEST_P(Operator, Transpose2Dims) {
   ctx_.allocate(result->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   Tensor dest(ElemKind::FloatTy, {13, 20});
   ctx_.get(A)->transpose(&dest, {1, 0});
@@ -1110,7 +1110,7 @@ TEST_P(InterpOnly, FP16Transpose2Dims) {
   ctx_.allocate(result->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   Tensor dest(ElemKind::Float16Ty, {13, 20});
   ctx_.get(A)->transpose(&dest, {1, 0});
@@ -1153,7 +1153,7 @@ TEST_P(Operator, Transpose3Dims) {
   EXPECT_EQ(6, nbOfShuffle);
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   for (int i = 0; i < 6; ++i) {
     Tensor dest(ElemKind::FloatTy, {dims[shuffles[i][0]], dims[shuffles[i][1]],
@@ -1208,7 +1208,7 @@ TEST_P(InterpAndCPU, GatherSizeT) {
   ctx_.allocate(result->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto H = ctx_.get(result->getPlaceholder())->getHandle<int64_t>();
 
@@ -1266,7 +1266,7 @@ TEST_P(Operator, BatchedGather) {
   ctx_.allocate(result->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto H = ctx_.get(result->getPlaceholder())->getHandle();
   EXPECT_FLOAT_EQ(H.at({0, 0}), 1.0);
@@ -1294,7 +1294,7 @@ TEST_P(Operator, ScatterAssign) {
   ctx_.allocate(result->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto H = ctx_.get(result->getPlaceholder())->getHandle();
 
@@ -1336,7 +1336,7 @@ TEST_P(InterpAndCPU, ScatterAssignQuantized) {
   ctx_.allocate(result->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto H = ctx_.get(result->getPlaceholder())->getHandle();
 
@@ -1371,7 +1371,7 @@ TEST_P(Operator, QuantizeAndDequantize) {
   ctx_.allocate(fpResult->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   EXPECT_TRUE(ctx_.get(result->getPlaceholder())
                   ->isEqual(*ctx_.get(fpResult->getPlaceholder())));
@@ -1406,7 +1406,7 @@ TEST_P(Operator, IntMatMul) {
   ctx_.allocate(result->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   /*
    Test the following matrix multiplication:
@@ -1457,7 +1457,7 @@ TEST_P(InterpAndCPU, IntBatchedArith) {
   ctx_.allocate(result->getPlaceholder());
   EE_.compile(CompilationMode::Infer, F_, ctx_);
 
-  EE_.run();
+  EE_.run(ctx_);
 
   // A = [8.7, 6.5, 4.3, 2.1, 1.0, -5.1, -4.0, -12.0, 0.2]
   // B = [-9.1, -0.4, 1.3, 2.2, -8.1, 7.6, -6.4, 10.0, 9.1]
@@ -1523,7 +1523,7 @@ void checkFloat16Convolution(ExecutionEngine &EE, Function *F,
 
   EE.compile(CompilationMode::Infer, F, ctx);
 
-  EE.run();
+  EE.run(ctx);
 
   // Check that the difference in the results is less than 0.1.
   for (int i = 0, e = floatOut.size(); i < e; i++) {
@@ -1581,7 +1581,7 @@ void checkIntConvolution(ExecutionEngine &EE, Function *F, unsigned convDepth,
   ctx.allocate(res->getPlaceholder());
   EE.compile(CompilationMode::Infer, F, ctx);
 
-  EE.run();
+  EE.run(ctx);
   auto H = ctx.get(res->getPlaceholder())->getHandle();
 
   // Check that the difference in the results is less than 0.1.
@@ -1621,7 +1621,7 @@ TEST_P(InterpAndCPU, IntConcat) {
   auto *res = F_->createSave("save", sub);
   ctx_.allocate(res->getPlaceholder());
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto R = ctx_.get(res->getPlaceholder())->getHandle();
   // Check that the difference in the results is less than 0.2.
@@ -1665,7 +1665,7 @@ TEST_P(InterpAndCPU, IntFC) {
   ctx_.allocate(res->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto H = ctx_.get(res->getPlaceholder())->getHandle();
   // Check that there aren't too many elements with a difference in the results
@@ -1690,7 +1690,7 @@ TEST_P(InterpAndCPU, EntropyLossTest) {
   ctx_.allocate(L->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto R = ctx_.get(L->getPlaceholder())->getHandle();
   EXPECT_NEAR(R.at({0}), -log(0.5) - log(0.3), 0.1);
@@ -1711,7 +1711,7 @@ TEST_P(Operator, Max) {
   ctx_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto result = ctx_.get(S->getPlaceholder())->getHandle<float>();
   auto handleA = ctx_.get(inputA)->getHandle<float>();
@@ -1737,7 +1737,7 @@ TEST_P(InterpOnly, FP16Max) {
   ctx_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto result = ctx_.get(S->getPlaceholder())->getHandle<float16_t>();
   auto handleA = ctx_.get(inputA)->getHandle<float16_t>();
@@ -1768,7 +1768,7 @@ TEST_P(Operator, RescaleNode) {
   ctx_.allocate(output->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto RI = ctx_.get(input)->getHandle<int8_t>();
   auto RO = ctx_.get(output->getPlaceholder())->getHandle<int8_t>();
@@ -1857,7 +1857,7 @@ TEST_P(InterpAndCPU, QuantizedArithmeticRescaled) {
   ctx_.allocate(O6->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   for (size_t i = 0; i < len; i++) {
     auto max = std::max(AH.at({i}), BH.at({i}));
@@ -1897,7 +1897,7 @@ TEST_P(Operator, QuantizedTranspose) {
   ctx_.allocate(fpResult->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   EXPECT_TRUE(ctx_.get(result->getPlaceholder())->isEqual(*ctx_.get(B)));
   EXPECT_TRUE(ctx_.get(fpResult->getPlaceholder())->isEqual(*ctx_.get(B)));
@@ -1964,7 +1964,7 @@ TEST_P(Operator, QuantizedArithmeticUnrescaled) {
   auto O6H = ctx_.get(O6->getPlaceholder())->getHandle<int8_t>();
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   for (size_t i = 0; i < len; i++) {
     float a = TQA->getScale() * (QAH.at({i}) - TQA->getOffset());
@@ -2024,7 +2024,7 @@ TEST_P(InterpAndCPU, QuantizedCmpLTEAndSelect) {
   auto OH = ctx_.allocate(out->getPlaceholder())->getHandle<int8_t>();
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   int count_strict = 0;
   int count = 0;
@@ -2084,7 +2084,7 @@ TEST_P(Operator, TestQuantizedRescaleSequence) {
   auto *result = F_->createSave("save", DQ);
   auto OH = ctx_.allocate(result->getPlaceholder())->getHandle();
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   for (size_t i = 0; i < len; i++) {
     EXPECT_NEAR(AH.at({i}), OH.at({i}), 1.0);
@@ -2162,7 +2162,7 @@ TEST_P(InterpAndCPU, concatVectors) {
 
   // Testing the output vector.
   updateInputPlaceholders(ctx_, {V1, V2, V3}, {&I1, &I2, &I3});
-  EE_.run();
+  EE_.run(ctx_);
 
   auto RNWH = ctx_.get(result->getPlaceholder())->getHandle<int64_t>();
   (void)RNWH;
@@ -2203,7 +2203,7 @@ TEST_P(InterpAndCPU, concatVectorsRepeated) {
 
   // Testing the output vector.
   updateInputPlaceholders(ctx_, {V1, V2}, {&I1, &I2});
-  EE_.run();
+  EE_.run(ctx_);
 
   auto outH = ctx_.get(result->getPlaceholder())->getHandle<int64_t>();
 
@@ -2248,7 +2248,7 @@ TEST_P(InterpAndCPU, sliceVectors) {
 
   // Testing the output slices.
   updateInputPlaceholders(ctx_, {V}, {&I});
-  EE_.run();
+  EE_.run(ctx_);
 
   auto RNWH1 = ctx_.get(result1->getPlaceholder())->getHandle<int64_t>();
   auto RNWH2 = ctx_.get(result2->getPlaceholder())->getHandle<int64_t>();
@@ -2303,7 +2303,7 @@ TEST_P(InterpAndCPU, sliceConcatVectors) {
   EE_.compile(CompilationMode::Infer, F_, ctx_);
 
   updateInputPlaceholders(ctx_, {V}, {&I});
-  EE_.run();
+  EE_.run(ctx_);
 
   const size_t expected[7][4] = {{300, 301, 302, 303}, {400, 401, 402, 403},
                                  {100, 101, 302, 303}, {200, 201, 402, 403},
@@ -2345,7 +2345,7 @@ TEST_P(InterpAndCPU, Tile) {
   EE_.compile(CompilationMode::Infer, F_, ctx_);
 
   updateInputPlaceholders(ctx_, {V}, {&VT});
-  EE_.run();
+  EE_.run(ctx_);
 
   // Testing the output vector with axis 0.
   auto res0 = ctx_.get(result0->getPlaceholder())->getHandle<float>();
@@ -2397,7 +2397,7 @@ TEST_P(InterpAndCPU, QuantizedTile) {
   EE_.compile(CompilationMode::Infer, F_, ctx_);
 
   updateInputPlaceholders(ctx_, {V}, {&VT});
-  EE_.run();
+  EE_.run(ctx_);
 
   // Testing the output vector with axis 0.
   auto res0 = ctx_.get(result0->getPlaceholder())->getHandle<float>();
@@ -2449,7 +2449,7 @@ TEST_P(Operator, simpleCmpSelectPredication) {
   ctx_.allocate(SN->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto H = ctx_.get(SN->getPlaceholder())->getHandle();
   ASSERT_NEAR(H.at(0), 1, 0.001);
@@ -2491,7 +2491,7 @@ TEST_P(Operator, simplePredication) {
   FC2->setPredicate(pred);
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 }
 
 TEST_P(InterpAndCPU, ChannelShuffle) {
@@ -2504,7 +2504,7 @@ TEST_P(InterpAndCPU, ChannelShuffle) {
   ctx_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto results = ctx_.get(S->getPlaceholder())->getHandle();
 
@@ -2529,7 +2529,7 @@ TEST_P(Operator, Squeeze) {
     ctx_.allocate(S->getPlaceholder());
 
     EE_.compile(CompilationMode::Infer, F_, ctx_);
-    EE_.run();
+    EE_.run(ctx_);
 
     auto results = ctx_.get(S->getPlaceholder())->getHandle();
     std::vector<size_t> expectedDims = {2, 1, 5};
@@ -2546,7 +2546,7 @@ TEST_P(Operator, Squeeze) {
     ctx_.allocate(S->getPlaceholder());
 
     EE_.compile(CompilationMode::Infer, F_, ctx_);
-    EE_.run();
+    EE_.run(ctx_);
 
     auto results = ctx_.get(S->getPlaceholder())->getHandle();
     std::vector<size_t> expectedDims = {2, 5};
@@ -2571,7 +2571,7 @@ TEST_P(Operator, Squeeze) {
     ctx_.allocate(S2->getPlaceholder());
 
     EE_.compile(CompilationMode::Infer, F_, ctx_);
-    EE_.run();
+    EE_.run(ctx_);
 
     auto res1 = ctx_.get(S1->getPlaceholder())->getHandle();
     EXPECT_TRUE(res1.dims().vec() == std::vector<size_t>());
@@ -2597,7 +2597,7 @@ TEST_P(Operator, ExpandDims) {
   ctx_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   // Expected dims based on the axes above; inserted new dimensions of 1 in
   // every unique axes location, based on the output tensor shape.
@@ -2633,7 +2633,7 @@ TEST_P(InterpAndCPU, Split) {
   ctx_.allocate(S4->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto result = ctx_.get(S1->getPlaceholder())->getHandle();
   EXPECT_EQ(result.dims().vec(), std::vector<size_t>({1, 2, 3}));
@@ -2695,7 +2695,7 @@ TEST_P(Operator, IntRelu) {
   ctx_.allocate(mod_.getPlaceholders());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto result = ctx_.get(save->getPlaceholder())->getHandle();
   float expectedValue = std::max(0.0f, splatValue);
@@ -2717,7 +2717,7 @@ TEST_P(Operator, IntSplat) {
   auto *save = F_->createSave("save", dequantize);
   ctx_.allocate(mod_.getPlaceholders());
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto result = ctx_.get(save->getPlaceholder())->getHandle();
   for (size_t i = 0; i < result.size(); i++) {
@@ -2735,7 +2735,7 @@ TEST_P(InterpOnly, Fp16Splat) {
   auto *save = F_->createSave("save", splat);
   ctx_.allocate(mod_.getPlaceholders());
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto result = ctx_.get(save->getPlaceholder())->getHandle<float16_t>();
   for (size_t i = 0; i < result.size(); i++) {
@@ -2771,7 +2771,7 @@ TEST_P(Operator, GroupConvolution) {
   ctx_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto result = ctx_.get(S->getPlaceholder())->getHandle();
 
@@ -2821,7 +2821,7 @@ TEST_P(Operator, NonSquarePaddingConvolution) {
   ctx_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
   Tensor &result = *ctx_.get(S->getPlaceholder());
 
   // Create the reference conv operator whose input is the same as the
@@ -2842,7 +2842,7 @@ TEST_P(Operator, NonSquarePaddingConvolution) {
   ctx_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, refF, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
   Tensor &result1 = *ctx_.get(S->getPlaceholder());
 
   EXPECT_TRUE(result.isEqual(result1));
@@ -2864,7 +2864,7 @@ TEST_P(Operator, NonSquarePaddingAveragePool) {
   ctx_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
   Tensor &result = *ctx_.get(S->getPlaceholder());
 
   auto *input1 =
@@ -2881,7 +2881,7 @@ TEST_P(Operator, NonSquarePaddingAveragePool) {
   S = refF->createSave("save1", Pool);
   ctx_.allocate(S->getPlaceholder());
   EE_.compile(CompilationMode::Infer, refF, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
   Tensor &result1 = *ctx_.get(S->getPlaceholder());
 
   EXPECT_TRUE(result.isEqual(result1));
@@ -2903,7 +2903,7 @@ TEST_P(Operator, NonSquarePaddingMaxPool) {
   ctx_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   Tensor &result = *ctx_.get(S->getPlaceholder());
 
@@ -2922,7 +2922,7 @@ TEST_P(Operator, NonSquarePaddingMaxPool) {
   ctx_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, refF, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   Tensor &result1 = *ctx_.get(S->getPlaceholder());
 
@@ -2939,7 +2939,7 @@ TEST_P(InterpOnly, FP16AvgPool) {
   ctx_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto *result = ctx_.get(S->getPlaceholder());
   Tensor out(ElemKind::Float16Ty, {1, 2, 2, 1});
@@ -2957,7 +2957,7 @@ TEST_P(Operator, AvgPool) {
   ctx_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto *result = ctx_.get(S->getPlaceholder());
   Tensor out(ElemKind::FloatTy, {1, 2, 2, 1});
@@ -2974,7 +2974,7 @@ TEST_P(Operator, Int8AvgPool) {
   ctx_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto result = ctx_.get(S->getPlaceholder())->getHandle<int8_t>();
   Tensor out(ElemKind::Int8QTy, {2, 2}, 1, 0);
@@ -2993,7 +2993,7 @@ TEST_P(Operator, MaxPool) {
   ctx_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto result = ctx_.get(S->getPlaceholder());
   Tensor out(ElemKind::FloatTy, {1, 2, 2, 1});
@@ -3011,7 +3011,7 @@ TEST_P(InterpOnly, FP16MaxPool) {
   ctx_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto result = ctx_.get(S->getPlaceholder());
   Tensor out(ElemKind::Float16Ty, {1, 2, 2, 1});
@@ -3028,7 +3028,7 @@ TEST_P(Operator, Int8MaxPool) {
   ctx_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto result = ctx_.get(S->getPlaceholder())->getHandle<int8_t>();
   Tensor out(ElemKind::Int8QTy, {2, 2}, 1, 0);
@@ -3066,7 +3066,7 @@ TEST_P(InterpAndCPU, Int8Tanh) {
   ctx_.allocate(saveInt->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto fpResult = ctx_.get(saveFp->getPlaceholder())->getHandle();
   auto intResult = ctx_.get(saveInt->getPlaceholder())->getHandle();
@@ -3088,7 +3088,7 @@ TEST_P(Operator, Tanh) {
   ctx_.allocate(save->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto resultH = ctx_.get(save->getPlaceholder())->getHandle();
   auto inputH = ctx_.get(input)->getHandle();
@@ -3136,7 +3136,7 @@ TEST_P(InterpAndCPU, Int8Log) {
   ctx_.allocate(saveInt->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   // Compare the results of the fp and quantized log.
   auto &fpResult = *ctx_.get(saveFp->getPlaceholder());
@@ -3171,7 +3171,7 @@ TEST_P(Operator, NonSquareKernelConvolution) {
   ctx_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
   Tensor &result = *ctx_.get(S->getPlaceholder());
 
   static const float ref[] = {106, 127, 190, 211, 274, 295};
@@ -3192,7 +3192,7 @@ TEST_P(InterpAndCPU, NonSquareKernelAveragePool) {
   ctx_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
   Tensor &result = *ctx_.get(S->getPlaceholder());
 
   static const float ref[] = {4, 5, 8, 9, 12, 13};
@@ -3213,7 +3213,7 @@ TEST_P(InterpAndCPU, NonSquareKernelMaxPool) {
   ctx_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
   Tensor &result = *ctx_.get(S->getPlaceholder());
 
   static const float ref[] = {7, 8, 11, 12, 15, 16};
@@ -3248,7 +3248,7 @@ TEST_P(Operator, NonSquareStrideConvolution) {
   ctx_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
   Tensor &result = *ctx_.get(S->getPlaceholder());
 
   static const float ref[] = {44, 64, 41, 47};
@@ -3269,7 +3269,7 @@ TEST_P(InterpAndCPU, NonSquareStrideAveragePool) {
   ctx_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
   Tensor &result = *ctx_.get(S->getPlaceholder());
 
   static const float ref[] = {3.5, 5.5, 6.75, 7.75};
@@ -3290,7 +3290,7 @@ TEST_P(InterpAndCPU, NonSquareStrideMaxPool) {
   ctx_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
   Tensor &result = *ctx_.get(S->getPlaceholder());
 
   static const float ref[] = {6, 8, 14, 16};
@@ -3325,7 +3325,7 @@ TEST_P(InterpAndCPU, Int8Sigmoid) {
   ctx_.allocate(saveInt->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto fpResult = ctx_.get(saveFp->getPlaceholder())->getHandle();
   auto intResult = ctx_.get(saveInt->getPlaceholder())->getHandle();
@@ -3350,7 +3350,7 @@ TEST_P(Operator, BatchAdd) {
   ctx_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto result = ctx_.get(S->getPlaceholder())->getHandle<float>();
   auto handleInput = ctx_.get(input)->getHandle<float>();
@@ -3377,7 +3377,7 @@ TEST_P(InterpOnly, FP16BatchAdd) {
   ctx_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto result = ctx_.get(S->getPlaceholder())->getHandle<float16_t>();
   auto handleInput = ctx_.get(input)->getHandle<float16_t>();
@@ -3401,7 +3401,7 @@ TEST_P(Operator, Sigmoid) {
   ctx_.allocate(save->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto RH = ctx_.get(save->getPlaceholder())->getHandle();
   auto inH = ctx_.get(input)->getHandle();
@@ -3432,7 +3432,7 @@ TEST_P(InterpAndCPU, IntLookupTable) {
   ctx_.allocate(save->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto result = ctx_.get(save->getPlaceholder())->getHandle<int8_t>();
   for (size_t i = 0; i < size; ++i) {
@@ -3467,7 +3467,7 @@ TEST_P(Operator, testBatchAdd) {
   ctx_.allocate(result->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto RH = ctx_.get(result->getPlaceholder())->getHandle();
   auto IH = ctx_.get(input)->getHandle();
@@ -3519,7 +3519,7 @@ TEST_P(Operator, testQuantizedBatchAdd) {
   adds.clear();
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto RH = ctx_.get(result->getPlaceholder())->getHandle();
   auto IH = ctx_.get(input)->getHandle();
@@ -3573,7 +3573,7 @@ TEST_P(InterpOnly, SparseLengthsSum) {
   ctx_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   Tensor &result = *ctx_.get(S->getPlaceholder());
   Tensor expected(ElemKind::FloatTy, {5, 2});
@@ -3624,7 +3624,7 @@ TEST_P(InterpOnly, SparseLengthsWeightedSum) {
   ctx_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   Tensor &result = *ctx_.get(S->getPlaceholder());
   Tensor expected(ElemKind::FloatTy, {4});
@@ -3665,7 +3665,7 @@ TEST_P(InterpOnly, SparseToDense) {
   ctx_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   Tensor &result = *ctx_.get(S->getPlaceholder());
 
@@ -3696,7 +3696,7 @@ TEST_P(InterpOnly, FP16Reshape) {
   ctx_.allocate(result->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto outputHandle =
       ctx_.get(result->getPlaceholder())->getHandle<float16_t>();
@@ -3717,7 +3717,7 @@ TEST_P(Operator, Reshape) {
   ctx_.allocate(result->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto outputHandle = ctx_.get(result->getPlaceholder())->getHandle();
   ASSERT_EQ(outputHandle.size(), inputHandle.size());
@@ -3743,7 +3743,7 @@ TEST_P(Operator, ReshapeInt) {
   ctx_.allocate(result->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto outputHandle = ctx_.get(result->getPlaceholder())->getHandle<int64_t>();
   ASSERT_EQ(outputHandle.size(), inputHandle.size());
@@ -3772,7 +3772,7 @@ TEST_P(Operator, Select) {
   ctx_.allocate(result->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto resH = ctx_.get(result->getPlaceholder())->getHandle();
   EXPECT_EQ(resH.at({0}), 20.0);
@@ -3812,7 +3812,7 @@ TEST_P(Operator, sliceReshape) {
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
 
-  EE_.run();
+  EE_.run(ctx_);
 
   // Verify the slice has the same data as the original X.
   auto SXH = ctx_.get(resultSX->getPlaceholder())->getHandle();
@@ -3892,7 +3892,7 @@ TEST_P(Operator, Flatten) {
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
 
-  EE_.run();
+  EE_.run(ctx_);
 
   // Verify the reshapes have the same data as the original value.
   auto tensor4DH = ctx_.get(tensor4D)->getHandle();
@@ -3939,7 +3939,7 @@ TEST_P(InterpAndCPU, DivSizeT) {
   ctx_.allocate(result->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto H = ctx_.get(result->getPlaceholder())->getHandle<int64_t>();
 
@@ -3993,7 +3993,7 @@ TEST_P(InterpAndCPU, SigmoidCrossEntropyWithLogits) {
   ctx_.allocate(result->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   Tensor expected(ElemKind::FloatTy, {2, 2});
   expected.getHandle() = {
@@ -4032,7 +4032,7 @@ TEST_P(InterpAndCPU, insertTensorTest) {
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
 
-  EE_.run();
+  EE_.run(ctx_);
 
   // Verify the output looks as expected (pictured above).
   auto resultH = ctx_.get(result->getPlaceholder())->getHandle<int64_t>();
@@ -4090,7 +4090,7 @@ TEST_P(InterpAndCPU, rowwiseQuantizedFCTest) {
   ctx_.allocate(save->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto H = ctx_.get(save->getPlaceholder())->getHandle();
 
@@ -4114,7 +4114,7 @@ TEST_P(Operator, SoftMax) {
   ctx_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto result = ctx_.get(S->getPlaceholder());
   Tensor out(ElemKind::FloatTy, {1, 6});
@@ -4140,7 +4140,7 @@ TEST_P(InterpOnly, FP16SoftMax) {
   ctx_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto result = ctx_.get(S->getPlaceholder());
   Tensor out(ElemKind::Float16Ty, {1, 6});
@@ -4165,7 +4165,7 @@ TEST_P(Operator, QuantizeSimple) {
   EXPECT_EQ(F_->getNodes().size(), 4);
   EE_.compile(CompilationMode::Infer, F_, ctx_);
 
-  EE_.run();
+  EE_.run(ctx_);
   EXPECT_EQ(F_->getNodes().size(), 1);
 
   auto RH = result->getHandle();
@@ -4185,7 +4185,7 @@ TEST_P(InterpOnly, ConvertFromFloat16ToFloat) {
   ctx_.allocate(result->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto *outputTensor = ctx_.get(result->getPlaceholder());
   Tensor convertedInput = ctx_.get(A)->clone();
@@ -4207,7 +4207,7 @@ TEST_P(InterpOnly, ConvertFromFloatToFloat16) {
   ctx_.allocate(result->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto *outputTensor = ctx_.get(result->getPlaceholder());
   Tensor convertedInput = ctx_.get(A)->clone();
@@ -4228,7 +4228,7 @@ TEST_P(InterpOnly, NoopConvertFromFloatToFloat) {
   ctx_.allocate(result->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   auto *outputTensor = ctx_.get(result->getPlaceholder());
   EXPECT_TRUE(inputTensor->isEqual(*outputTensor));
@@ -4249,7 +4249,7 @@ TEST_P(InterpAndCPU, LengthsToRanges) {
   ctx_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   Tensor &result = *ctx_.get(S->getPlaceholder());
   Tensor expected(ElemKind::Int64ITy, {4, 2});
@@ -4282,7 +4282,7 @@ TEST_P(InterpOnly, BatchOneHot) {
   ctx_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   Tensor &result = *ctx_.get(S->getPlaceholder());
   Tensor expected(ElemKind::FloatTy, {3, 6});

--- a/tests/unittests/caffe2ImporterTest.cpp
+++ b/tests/unittests/caffe2ImporterTest.cpp
@@ -51,7 +51,7 @@ TEST(caffe2, importConv) {
   auto res = ctx.get(output);
   EE.compile(CompilationMode::Infer, F, ctx);
 
-  EE.run();
+  EE.run(ctx);
   auto result = res->getHandle();
   std::vector<size_t> expectedDims = {1, 1, 4, 4};
   std::vector<float> expectedValues = {2,  3,  5,  4,  5, 10, 14, 9,
@@ -313,7 +313,7 @@ TEST(caffe2, concatAddAxis) {
   auto res = ctx.get(output);
   EE.compile(CompilationMode::Infer, F, ctx);
 
-  EE.run();
+  EE.run(ctx);
   // High level check on the content of the graph.
   // We have 1 reshape, 1 concat, and 1 save.
   EXPECT_EQ(F->getNodes().size(), 3);
@@ -390,7 +390,7 @@ TEST(caffe2, concat) {
   auto res = ctx.get(output);
   EE.compile(CompilationMode::Infer, F, ctx);
 
-  EE.run();
+  EE.run(ctx);
   // High level check on the content of the graph.
   // We have 1 concat, and 1 save.
   EXPECT_EQ(F->getNodes().size(), 2);
@@ -593,7 +593,7 @@ TEST(caffe2, FC) {
   }
 
   EE.compile(CompilationMode::Infer, F, ctx);
-  EE.run();
+  EE.run(ctx);
 
   auto result = ctx.get(output)->getHandle();
   std::vector<size_t> expectedDims = {2, 4};
@@ -642,7 +642,7 @@ TEST(caffe2, FCWithFlatten) {
   ASSERT_TRUE(reshape);
 
   EE.compile(CompilationMode::Infer, F, ctx);
-  EE.run();
+  EE.run(ctx);
   auto result = ctx.get(output)->getHandle();
   std::vector<size_t> expectedDims = {2, 4};
   std::vector<float> expectedValues = {14.1f, 32.2f, 50.3f,  68.4f,
@@ -691,7 +691,7 @@ TEST(caffe2, FCTransposed) {
   ASSERT_TRUE(fcNode);
 
   EE.compile(CompilationMode::Infer, F, ctx);
-  EE.run();
+  EE.run(ctx);
 
   auto result = ctx.get(output)->getHandle();
   std::vector<size_t> expectedDims = {2, 4};
@@ -741,7 +741,7 @@ TEST(caffe2, FCTransposedWithFlatten) {
   ASSERT_TRUE(reshape);
 
   EE.compile(CompilationMode::Infer, F, ctx);
-  EE.run();
+  EE.run(ctx);
   auto result = ctx.get(output)->getHandle();
   std::vector<size_t> expectedDims = {2, 4};
   std::vector<float> expectedValues = {14.1f, 32.2f, 50.3f,  68.4f,
@@ -782,7 +782,7 @@ TEST(caffe2, importClip) {
 
   auto *res = ctx.get(output);
   EE.compile(CompilationMode::Infer, F, ctx);
-  EE.run();
+  EE.run(ctx);
 
   auto result = res->getHandle();
   std::vector<size_t> expectedDims = {5, 5};
@@ -829,7 +829,7 @@ TEST(caffe2, importClipDefault) {
 
   auto *res = ctx.get(output);
   EE.compile(CompilationMode::Infer, F, ctx);
-  EE.run();
+  EE.run(ctx);
 
   auto result = res->getHandle();
   std::vector<size_t> expectedDims = {5, 5};
@@ -880,7 +880,7 @@ TEST(caffe2, replaceNaN) {
   // Compile and run the model.
   auto *res = ctx.get(output);
   EE.compile(CompilationMode::Infer, F, ctx);
-  EE.run();
+  EE.run(ctx);
 
   auto result = res->getHandle();
 
@@ -965,7 +965,7 @@ TEST(caffe2, dotProduct1D) {
   ctx.allocate(mod.getPlaceholders());
   auto *res = ctx.get(output);
   EE.compile(CompilationMode::Infer, F, ctx);
-  EE.run();
+  EE.run(ctx);
 
   auto result = res->getHandle();
   // Check that the output tensor is the same as the expected output.
@@ -1048,7 +1048,7 @@ TEST(caffe2, dotProduct2D) {
   // Compile and run the model.
   auto *res = ctx.get(output);
   EE.compile(CompilationMode::Infer, F, ctx);
-  EE.run();
+  EE.run(ctx);
 
   auto result = res->getHandle();
 
@@ -1207,7 +1207,7 @@ TEST(caffe2, batchBoxCox) {
   // Compile and run the model.
   auto *res = ctx.get(output);
   EE.compile(CompilationMode::Infer, F, ctx);
-  EE.run();
+  EE.run(ctx);
 
   auto result = res->getHandle();
 

--- a/tests/unittests/gradCheckTest.cpp
+++ b/tests/unittests/gradCheckTest.cpp
@@ -134,13 +134,13 @@ void performGradCheck(ExecutionEngine &EE, Context &ctx, SaveNode *result,
     // Calculate f(x+e):
     inputsH.raw(i) = old + delta;
     updateInputPlaceholders(ctx, {inputVar}, {inputs});
-    EE.run();
+    EE.run(ctx);
     auto plusLoss = computeL2Loss(outputs, resultTensor);
 
     // Calculate f(x-e):
     inputsH.raw(i) = old - delta;
     updateInputPlaceholders(ctx, {inputVar}, {inputs});
-    EE.run();
+    EE.run(ctx);
 
     auto minusLoss = computeL2Loss(outputs, resultTensor);
 
@@ -556,23 +556,23 @@ TEST_P(InterpreterGrad, gradientCheckCrossEntropyLoss) {
     inputsH.randomize(0.0, 1.0, mod.getPRNG());
     for (size_t j = 0; j < inputsH.size(); ++j) {
       updateInputPlaceholders(ctx, {P, Y}, {&inputs, &outputs});
-      EE_.run();
+      EE_.run(ctx);
       LTensor->zero();
       auto x = inputsH.raw(j);
       auto g = gradTensorHandle.raw(j);
       inputsH.raw(j) = x + stepSize;
       updateInputPlaceholders(ctx, {P, Y}, {&inputs, &outputs});
-      EE_.run();
+      EE_.run(ctx);
       auto lp = LTensor->getHandle().raw(0);
       inputsH.raw(j) = x - stepSize;
       LTensor->zero();
       updateInputPlaceholders(ctx, {P, Y}, {&inputs, &outputs});
-      EE_.run();
+      EE_.run(ctx);
       auto lm = LTensor->getHandle().raw(0);
       auto diff = (lp - lm) / (2 * stepSize);
       inputsH.raw(j) = x;
       updateInputPlaceholders(ctx, {P, Y}, {&inputs, &outputs});
-      EE_.run();
+      EE_.run(ctx);
       EXPECT_NEAR(diff, g, delta);
     }
   }

--- a/tests/unittests/graphTest.cpp
+++ b/tests/unittests/graphTest.cpp
@@ -495,7 +495,7 @@ TEST(Graph, NodeValue) {
 
   EE.compile(CompilationMode::Infer, F, ctx);
 
-  EE.run();
+  EE.run(ctx);
 
   EXPECT_EQ(res->getHandle().raw(0), 24);
 }
@@ -554,7 +554,7 @@ TEST(Graph, nodesWithPredicates) {
   EE.compile(CompilationMode::Infer, F, ctx);
 
   updateInputPlaceholders(ctx, {input}, {&inputs});
-  EE.run();
+  EE.run(ctx);
 }
 
 // Return the number of ConvolutionNode after lower.
@@ -630,7 +630,7 @@ TEST(Graph, schedulingOfSavesOrderProvided) {
 
   EE.compile(CompilationMode::Infer, F, ctx);
 
-  EE.run();
+  EE.run(ctx);
   auto *ret = ctx.get(saveNode->getPlaceholder());
   auto handleAOrig = AOrig.getHandle<>();
   auto handleB = ctx.get(B)->getHandle<>();
@@ -675,7 +675,7 @@ TEST(Graph, schedulingOfSaves) {
 
   EE.compile(CompilationMode::Infer, F, ctx);
 
-  EE.run();
+  EE.run(ctx);
   auto *ret = saveNode->getPlaceholder();
   auto handleAOrig = AOrig.getHandle<>();
   auto handleB = ctx.get(B)->getHandle<>();

--- a/tests/unittests/onnxImporterTest.cpp
+++ b/tests/unittests/onnxImporterTest.cpp
@@ -72,7 +72,7 @@ TEST(onnx, importConv) {
   EXPECT_TRUE(tFilterNode->getKind() == Kinded::Kind::TransposeNodeKind);
 
   EE.compile(CompilationMode::Infer, F, ctx);
-  EE.run();
+  EE.run(ctx);
   auto result = ctx.get(graphOutputVar)->getHandle();
   std::vector<size_t> expectedDims = {1, 1, 4, 4};
   std::vector<float> expectedValues = {2,  3,  5,  4,  5, 10, 14, 9,
@@ -121,7 +121,7 @@ TEST(onnx, importClip) {
 
   auto *res = ctx.get(output);
   EE.compile(CompilationMode::Infer, F, ctx);
-  EE.run();
+  EE.run(ctx);
 
   auto result = res->getHandle();
   std::vector<size_t> expectedDims = {3, 3};
@@ -177,7 +177,7 @@ TEST(onnx, importBatchBoxCox) {
 
   auto *res = ctx.get(output);
   EE.compile(CompilationMode::Infer, F, ctx);
-  EE.run();
+  EE.run(ctx);
 
   auto result = res->getHandle();
 
@@ -264,7 +264,7 @@ TEST(onnx, importSumN) {
 
   auto *res = ctx.get(output);
   EE.compile(CompilationMode::Infer, F, ctx);
-  EE.run();
+  EE.run(ctx);
 
   auto result = res->getHandle();
   std::vector<size_t> expectedDims = {3};
@@ -313,7 +313,7 @@ TEST(onnx, importSum1) {
 
   auto *res = ctx.get(output);
   EE.compile(CompilationMode::Infer, F, ctx);
-  EE.run();
+  EE.run(ctx);
 
   auto result = res->getHandle();
   std::vector<size_t> expectedDims = {3};

--- a/tests/unittests/partitionTest.cpp
+++ b/tests/unittests/partitionTest.cpp
@@ -44,7 +44,7 @@ static void executeSerial(const FunctionDAG &G, Context &ctx,
     EE.compile(CompilationMode::Infer, F, ctx);
 
     updateInputPlaceholders(ctx, vars, inputs);
-    EE.run();
+    EE.run(ctx);
   }
 }
 
@@ -105,7 +105,7 @@ TEST_F(PartitionTest, SerialExecution) {
 
   EE.compile(CompilationMode::Infer, F_, ctx_);
   updateInputPlaceholders(ctx_, {input}, {&in});
-  EE.run();
+  EE.run(ctx_);
   Tensor ref = res.clone();
 
   // Infer using the partitioned graph.
@@ -151,7 +151,7 @@ TEST_F(PartitionTest, Branchover) {
 
   EE.compile(CompilationMode::Infer, F_, ctx_);
   updateInputPlaceholders(ctx_, {input}, {&in});
-  EE.run();
+  EE.run(ctx_);
   Tensor ref = res.clone();
 
   // Infer using the partitioned graph.

--- a/tests/unittests/quantizationTest.cpp
+++ b/tests/unittests/quantizationTest.cpp
@@ -137,7 +137,7 @@ TEST(Quantization, quantizeGraph) {
   // Make sure that graph can be compiled and run.
   EE.compile(CompilationMode::Infer, F, ctx);
 
-  EE.run();
+  EE.run(ctx);
 }
 
 /// Quantize ReLU node and make sure that quantized version
@@ -246,7 +246,7 @@ TEST_P(Operator, end2end) {
   interpreterEE.compile(CompilationMode::Infer, F1, ctx);
 
   // Run graph to capture profile.
-  interpreterEE.run();
+  interpreterEE.run(ctx);
 
   // Get quantization infos and build new quantized graph.
   std::vector<NodeQuantizationInfo> QI =
@@ -257,7 +257,7 @@ TEST_P(Operator, end2end) {
 
   F2 = quantization::quantizeFunction(backendSpecificEE, QI, F2);
   backendSpecificEE.compile(CompilationMode::Infer, F2, ctx);
-  backendSpecificEE.run();
+  backendSpecificEE.run(ctx);
 
   // STEP3 - Compare the results of the original and quantized functions.
   auto result1Handle = ctx.get(result1->getPlaceholder())->getHandle();
@@ -381,7 +381,7 @@ TEST_P(Operator, end2endGRU) {
   interpreterEE.compile(CompilationMode::Infer, F1, ctx);
 
   // Run graph to capture profile.
-  interpreterEE.run();
+  interpreterEE.run(ctx);
 
   // Get quantization infos and build new quantized graph.
   std::vector<NodeQuantizationInfo> QI =
@@ -392,7 +392,7 @@ TEST_P(Operator, end2endGRU) {
 
   F2 = quantization::quantizeFunction(backendSpecificEE, QI, F2);
   backendSpecificEE.compile(CompilationMode::Infer, F2, ctx);
-  backendSpecificEE.run();
+  backendSpecificEE.run(ctx);
 
   // STEP3 - Compare the results of the original and quantized functions.
   auto result1Handle = ctx.get(result1->getPlaceholder())->getHandle();
@@ -427,7 +427,7 @@ TEST(Quantization, rescaleSameType) {
   EXPECT_EQ(F->getNodes().size(), 3);
   EE.compile(CompilationMode::Infer, F, ctx);
 
-  EE.run();
+  EE.run(ctx);
   EXPECT_EQ(F->getNodes().size(), 2);
 
   auto RH = result->getHandle();
@@ -453,7 +453,7 @@ TEST(Quantization, optimizeRescaleQuantize) {
   EXPECT_EQ(F->getNodes().size(), 4);
   EE.compile(CompilationMode::Infer, F, ctx);
 
-  EE.run();
+  EE.run(ctx);
   EXPECT_EQ(F->getNodes().size(), 1);
 
   auto RH = result->getHandle();
@@ -601,7 +601,7 @@ TEST(Quantization, reluCanUseSymmetricSchema) {
   auto *res = ctx.allocate(SN->getPlaceholder());
 
   EE.compile(CompilationMode::Infer, F, ctx);
-  EE.run();
+  EE.run(ctx);
 
   // Verify all negative values were correctly set to zero.
   auto RH = res->getHandle();
@@ -769,7 +769,7 @@ TEST(Quantization, quantizeGraphPartially) {
   ::glow::convertPlaceholdersToConstants(F, ctx, {result});
   EE.compile(CompilationMode::Infer, F, ctx);
 
-  EE.run();
+  EE.run(ctx);
 
   {
     // Verify that the output variable is not quantized, and that it has a
@@ -850,7 +850,7 @@ TEST(Quantization, quantizeGraphPartiallyMultipleNodes) {
   ::glow::convertPlaceholdersToConstants(F, ctx, {result});
   EE.compile(CompilationMode::Infer, F, ctx);
 
-  EE.run();
+  EE.run(ctx);
 
   {
     // Verify that the output variable is not quantized, and that it has a
@@ -941,7 +941,7 @@ TEST(Quantization, quantizeGraphPartiallyMultipleKinds) {
   ::glow::convertPlaceholdersToConstants(F, ctx, {result});
   EE.compile(CompilationMode::Infer, F, ctx);
 
-  EE.run();
+  EE.run(ctx);
 
   {
     // Verify that the output variable is not quantized, and that it has a
@@ -1051,7 +1051,7 @@ TEST(Quantization, quantizeFunctionConvertConstant) {
   // Make sure that graph can be compiled and run.
   EE.compile(CompilationMode::Infer, F, ctx);
 
-  EE.run();
+  EE.run(ctx);
 }
 
 INSTANTIATE_TEST_CASE_P(Interpreter, Quantization,

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -293,7 +293,7 @@ void Loader::runInference(Context &ctx) {
     timer.startTimer();
   }
   for (unsigned i = 0; i < iterationsOpt; i++) {
-    EE_.run();
+    EE_.run(ctx);
   }
   if (timeOpt) {
     timer.stopTimer();


### PR DESCRIPTION
*Description*: Create runctx and execute(ctx) functions for moving placeholder memory allocation from compile time to run time and update tests.
*Testing*: Ninja all
*Documentation*: N/A
Progress on #1904 This would bring us to completion of the second step.