### PR TITLE
[Image] Fix writePngImage 90 degree rotation and black image output issues

### DIFF
--- a/lib/Base/Image.cpp
+++ b/lib/Base/Image.cpp
@@ -227,9 +227,9 @@ bool glow::writePngImage(Tensor *T, const char *filename,
     png_byte *row = row_pointers[y];
     for (size_t x = 0; x < width; x++) {
       png_byte *ptr = &(row[x * 4]);
-      ptr[0] = H.at({x, y, 0}) * scale + bias;
-      ptr[1] = H.at({x, y, 1}) * scale + bias;
-      ptr[2] = H.at({x, y, 2}) * scale + bias;
+      ptr[0] = (H.at({y, x, 0}) - bias) / scale;
+      ptr[1] = (H.at({y, x, 1}) - bias) / scale;
+      ptr[2] = (H.at({y, x, 2}) - bias) / scale;
       ptr[3] = 0xff;
     }
   }
@@ -247,7 +247,7 @@ bool glow::writePngImage(Tensor *T, const char *filename,
     free(row_pointers[y]);
   }
   free(row_pointers);
-  png_destroy_read_struct(&png_ptr, &info_ptr, (png_infopp)NULL);
+  png_destroy_write_struct(&png_ptr, &info_ptr);
   fclose(fp);
   return false;
 }

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -23,6 +23,16 @@ target_link_libraries(tensorsTest
                         testMain)
 add_glow_test(tensorsTest ${GLOW_BINARY_DIR}/tests/tensorsTest)
 
+add_executable(imageTest
+               imageTest.cpp)
+target_link_libraries(imageTest
+                      PRIVATE
+                        Base
+                        gtest
+                        testMain)
+add_glow_test(imageTest ${GLOW_BINARY_DIR}/tests/imageTest
+              WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+
 add_executable(gradCheckTest
                gradCheckTest.cpp)
 target_link_libraries(gradCheckTest

--- a/tests/unittests/imageTest.cpp
+++ b/tests/unittests/imageTest.cpp
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/Base/Image.h"
+
+#include "llvm/Support/FileSystem.h"
+
+#include "gtest/gtest.h"
+
+#include <cstdio>
+#include <utility>
+
+using namespace glow;
+
+TEST(Image, writePngImage) {
+  auto range = std::make_pair(0.f, 1.f);
+  Tensor localCopy;
+  bool loadSuccess =
+      !readPngImage(&localCopy, "tests/images/imagenet/cat_285.png", range);
+  ASSERT_TRUE(loadSuccess);
+
+  llvm::SmallVector<char, 10> resultPath;
+  llvm::sys::fs::createTemporaryFile("prefix", "suffix", resultPath);
+  std::string outfilename(resultPath.begin(), resultPath.end());
+
+  bool storeSuccess = !writePngImage(&localCopy, outfilename.c_str(), range);
+  ASSERT_TRUE(storeSuccess);
+
+  Tensor secondLocalCopy;
+  loadSuccess = !readPngImage(&secondLocalCopy, outfilename.c_str(), range);
+  ASSERT_TRUE(loadSuccess);
+  EXPECT_TRUE(secondLocalCopy.isEqual(localCopy, 0.01));
+
+  // Delete the temporary file.
+  std::remove(outfilename.c_str());
+}


### PR DESCRIPTION
*Description*
The 90 degree rotation was simply a swapping of the column and row indices
when accessing the tensor.
The black image output was a misuse of the range input. The range represents
the range of values the image should have, not the range of values the input
tensor has.

In other words, we were doing:
- read: tensor = image * scale + bias
- write: image = tensor * scale + bias

Whereas we should be doing:
- read: tensor = image * scale + bias
- write: image = (tensor - bias ) / scale

Fixing both these issues makes the image being written properly.

*Testing*
The added test loads an existing image into a tensor, then writes it
into an image and finally load that image back.
The tensor obtained from the final image loading is expected to be
the same (modulo scale and bias rounding) as the one from the
original image.