### PR TITLE
[converter][easy] Assert destTy == dstKind_ when converting

### DIFF
--- a/lib/Converter/TypeAToTypeBFunctionConverter.cpp
+++ b/lib/Converter/TypeAToTypeBFunctionConverter.cpp
@@ -65,5 +65,6 @@ Node *TypeAToTypeBFunctionConverter::createConversion(Function &function,
 
 void TypeAToTypeBFunctionConverter::convertTensor(Tensor &tensor,
                                                   TypeRef destTy) {
+  assert(destTy->getElementType() == dstKind_);
   tensor.convertToType(dstKind_);
 }


### PR DESCRIPTION
*Description*: Got an unused parameter lint warning and thought this was a good assert to add.
*Testing*: `ninja all && gtest-parallel tests/*Test`
*Documentation*: N/A