### PR TITLE
[ONNX] Add ONNX support for SparseToDense operator

### DIFF
--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -2108,6 +2108,30 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     break;
   }
 
+  case Kinded::Kind::SparseToDenseInstKind: {
+    auto *STDI = llvm::cast<SparseToDenseInst>(I);
+    auto *indices = STDI->getIndices();
+    auto *values = STDI->getValues();
+    auto *dest = STDI->getDest();
+
+    auto *indicesPtr = emitValueAddress(builder, indices);
+    auto *valuesPtr = emitValueAddress(builder, values);
+    auto *destPtr = emitValueAddress(builder, dest);
+
+    auto *indicesSize = emitConstSizeT(builder, indices->size());
+    auto *destSize = emitConstSizeT(builder, dest->size());
+
+    auto *valuesType = values->getType();
+    auto *valueSize =
+        emitConstSizeT(builder, valuesType->size() / valuesType->dims()[0]);
+
+    auto *F = getFunction("sparse_to_dense", dest->getElementType());
+    createCall(
+        builder, F,
+        {destPtr, indicesPtr, valuesPtr, indicesSize, destSize, valueSize});
+    break;
+  }
+
   case Kinded::Kind::DebugPrintInstKind: {
     auto *DPI = llvm::cast<DebugPrintInst>(I);
     auto *src = DPI->getSrc();

--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -894,6 +894,22 @@ void libjit_lengths_to_ranges_u(size_t *ranges, const size_t *lengths,
   }
 }
 
+void libjit_sparse_to_dense_f(float *dest, const size_t *indices,
+                              const float *values, size_t numIndices,
+                              size_t destSize, size_t valueSize) {
+  memset(dest, 0, destSize * sizeof(float));
+
+  for (size_t i = 0, valuesOffset = 0; i < numIndices;
+       ++i, valuesOffset += valueSize) {
+    size_t idx = indices[i];
+    size_t destOffset = idx * valueSize;
+
+    for (size_t j = 0; j < valueSize; ++j) {
+      dest[destOffset + j] += values[valuesOffset + j];
+    }
+  }
+}
+
 void libjit_local_response_normalization_f(float *outW, const float *inW,
                                            float *scaleCache,
                                            const size_t *outWdims,

--- a/lib/Importer/ONNXIFIModelLoader.cpp
+++ b/lib/Importer/ONNXIFIModelLoader.cpp
@@ -214,6 +214,8 @@ ONNXIFIModelLoader::parseOperators(const void *onnxModel,
       ADD_OP_MAPPING(MulNodeKind, FloatTy);
     } else if (operation == "LengthsToRanges") {
       ADD_OP_MAPPING(LengthsToRangesNodeKind, Int64ITy);
+    } else if (operation == "SparseToDense") {
+      ADD_OP_MAPPING(SparseToDenseNodeKind, FloatTy);
     }
   }
 #undef ADD_OP_MAPPING

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -529,6 +529,21 @@ bool ONNXModelLoader::loadOperator(const ONNX_NAMESPACE::NodeProto &op) {
     return true;
   }
 
+  if (typeName == "SparseToDense") {
+    if (op.input_size() != 3) {
+      return false;
+    }
+
+    auto indices = getNodeValueOrCreateConstantByName(op.input(0));
+    auto values = getNodeValueOrCreateConstantByName(op.input(1));
+    auto dataToInferDim = getNodeValueOrCreateConstantByName(op.input(2));
+
+    auto *node =
+        G_.createSparseToDense(opName, indices, values, dataToInferDim);
+    addNodeAsOutput(op, node);
+    return true;
+  }
+
   return false;
 }
 

--- a/tests/models/onnxModels/sparseToDense.onnxtxt
+++ b/tests/models/onnxModels/sparseToDense.onnxtxt
@@ -1,0 +1,85 @@
+ir_version: 3
+producer_name: "backend-test"
+graph {
+  node {
+    input: "indices"
+    input: "values"
+    input: "dataToInferDim"
+    output: "y"
+    op_type: "SparseToDense"
+  }
+  name: "test_SparseToDense"
+  input {
+    name: "indices"
+    type {
+      tensor_type {
+        elem_type: INT64
+        shape {
+          dim {
+            dim_value: 5
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "values"
+    type {
+      tensor_type {
+        elem_type: FLOAT
+        shape {
+          dim {
+            dim_value: 5
+          }
+	  dim {
+	    dim_value: 10
+	  }
+	  dim {
+	    dim_value: 5
+	  }
+        }
+      }
+    }
+  }
+  input {
+    name: "dataToInferDim"
+    type {
+      tensor_type {
+        elem_type: FLOAT
+        shape {
+	  dim {
+            dim_value: 20 
+          }
+	  dim {
+	    dim_value: 10
+	  }
+	  dim {
+	    dim_value: 5
+	  }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: FLOAT
+        shape {
+	  dim {
+            dim_value: 20 
+          }
+	  dim {
+	    dim_value: 10
+	  }
+	  dim {
+	    dim_value: 5
+	  }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 9
+}

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -3663,7 +3663,7 @@ TEST_P(InterpOnly, SparseLengthsWeightedSum) {
   EXPECT_TRUE(expected.isEqual(result));
 }
 
-TEST_P(InterpOnly, SparseToDense) {
+TEST_P(InterpAndCPU, SparseToDense) {
   // Create and initialize inputs. Make input 3D to make sure
   // multidimensional values are handled properly.
   constexpr size_t kNumIndices = 4;


### PR DESCRIPTION
**Description**
This commit adds support for importing the `SparseToDense` operator from
an ONNX model and running it on the CPU backend.

**Testing**
This commit modifies the existing operator test for `SparseToDense` to
run on both CPU and interpreter, and adds a test to the ONNX importer
test to make sure it is imported correctly from a .onnxtxt file.
