### PR TITLE
[unittests] Fix FP16QuantizeAndDequantize

### DIFF
--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -1396,7 +1396,7 @@ TEST_P(InterpOnly, FP16QuantizeAndDequantize) {
   ctx_.allocate(fpResult->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_, ctx_);
-  EE_.run();
+  EE_.run(ctx_);
 
   EXPECT_TRUE(ctx_.get(result->getPlaceholder())
                   ->isEqual(*ctx_.get(fpResult->getPlaceholder()), 0.01));


### PR DESCRIPTION
*Description*: FP16QuantizeAndDequantize was merged just before the change adding context to run. Context is now being passed in and everything compiles again.
*Testing*: ninja all and test
*Documentation*: N/A