### PR TITLE
[Caffe2/ONNX] Add support for LengthsSum operator

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -504,6 +504,15 @@ public:
   BatchedAddNode *createBatchedAdd(llvm::StringRef name, TypeRef outTy,
                                    NodeValue batch, NodeValue sample);
 
+  /// Implements an operation that accumulates the values in \p data along the
+  /// first dimension into len(\p lengths) entries by summing together the first
+  /// lengths[0] values, then the subsequent lengths[1] values, etc.
+  /// sum(\p lengths) must equal the first dimension of \p data. This operation
+  /// is similar to SparseLengthsSum but the input is a dense represention
+  /// instead of a sparse one. In other words, it has already been Gathered.
+  LengthsSumNode *createLengthsSum(llvm::StringRef name, NodeValue data,
+                                   NodeValue lengths);
+
   /// Create a node, performing SparseLengthsSum operation:
   /// Gathers slices of the outer-most dimension of Data indexed by Indices
   /// vector, and then accumulates them into len(Lengths) entries:

--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -429,6 +429,21 @@ protected:
     addNodeAsOutput(op, node);
   }
 
+  bool loadLengthsSum(const OpType &op) {
+    const std::string &opName = loadOperatorName(op);
+    auto data = getNodeValueOrCreateConstantByName(op.input(0));
+    auto lengths = getNodeValueOrCreateConstantByName(op.input(1));
+
+    if (lengths.dims().size() != 1) {
+      assert("Lengths must be a 1D vector");
+      return false;
+    }
+
+    auto *node = G_.createLengthsSum(opName, data, lengths);
+    addNodeAsOutput(op, node);
+    return true;
+  }
+
   using ProtobufLoader::ProtobufLoader;
 
   /// If operator type is supported, returns true and creates new operator.
@@ -529,6 +544,9 @@ protected:
     if (typeName == "ReplaceNaN") {
       loadReplaceNaN(op, dict);
       return true;
+    }
+    if (typeName == "LengthsSum") {
+      return loadLengthsSum(op);
     }
     return false;
   }

--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -1760,6 +1760,29 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     break;
   }
 
+  case Kinded::Kind::LengthsSumInstKind: {
+    auto *LS = cast<LengthsSumInst>(I);
+    auto *dest = LS->getDest();
+    auto *data = LS->getData();
+    auto *lengths = LS->getLengths();
+
+    auto *destPtr = emitValueAddress(builder, dest);
+    auto *dataPtr = emitValueAddress(builder, data);
+    auto *lengthsPtr = emitValueAddress(builder, lengths);
+
+    auto *lengthsSize = emitConstSizeT(builder, lengths->size());
+    auto *dataType = data->getType();
+    auto *destSize = emitConstSizeT(builder, dest->size());
+    auto *sliceSize =
+        emitConstSizeT(builder, dataType->size() / dataType->dims()[0]);
+
+    auto *F = getFunction("lengths_sum", data->getElementType());
+    createCall(
+        builder, F,
+        {destPtr, dataPtr, lengthsPtr, destSize, lengthsSize, sliceSize});
+    break;
+  }
+
   case Kinded::Kind::LocalResponseNormalizationInstKind: {
     auto *LRN = cast<LocalResponseNormalizationInst>(I);
     auto *dest = LRN->getDest();

--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -910,6 +910,25 @@ void libjit_sparse_to_dense_f(float *dest, const size_t *indices,
   }
 }
 
+void libjit_lengths_sum_f(float *dest, const float *data, const size_t *lengths,
+                          size_t destSize, size_t lengthsSize,
+                          size_t sliceSize) {
+  memset(dest, 0, destSize * sizeof(float));
+
+  size_t offsetOut = 0;
+  size_t offsetIn = 0;
+
+  for (size_t i = 0; i < lengthsSize; ++i) {
+    for (size_t j = 0; j < lengths[i]; ++j) {
+      for (size_t k = 0; k < sliceSize; ++k) {
+        dest[offsetOut + k] += data[offsetIn + k];
+      }
+      offsetIn += sliceSize;
+    }
+    offsetOut += sliceSize;
+  }
+}
+
 void libjit_local_response_normalization_f(float *outW, const float *inW,
                                            float *scaleCache,
                                            const size_t *outWdims,

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1263,6 +1263,14 @@ BatchedAddNode *Function::createBatchedAdd(llvm::StringRef name, TypeRef outTy,
       new BatchedAddNode(name, getParent()->uniqueType(*outTy), batch, sample));
 }
 
+LengthsSumNode *Function::createLengthsSum(llvm::StringRef name, NodeValue data,
+                                           NodeValue lengths) {
+  ShapeVector outDims(data.dims().begin(), data.dims().end());
+  outDims[0] = lengths.dims()[0];
+  auto outTy = getParent()->uniqueTypeWithNewShape(data.getType(), outDims);
+  return addNode(new LengthsSumNode(name, outTy, data, lengths));
+}
+
 SparseLengthsWeightedSumNode *
 Function::createSparseLengthsSum(llvm::StringRef name, NodeValue data,
                                  NodeValue indices, NodeValue lengths) {

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -580,6 +580,10 @@ void BatchedReduceAddNode::verify() const {
   assert(getBatch().dims().size() > 0 && "Invalid shape");
 }
 
+void LengthsSumNode::verify() const {
+  assert(getLengths().dims().size() == 1 && "Lengths must be a 1D vector");
+}
+
 void SparseLengthsWeightedSumNode::verify() const {
   assert(getResult().getElementType() == getData().getElementType() &&
          "Mismatched element types");

--- a/lib/Importer/ONNXIFIModelLoader.cpp
+++ b/lib/Importer/ONNXIFIModelLoader.cpp
@@ -216,6 +216,8 @@ ONNXIFIModelLoader::parseOperators(const void *onnxModel,
       ADD_OP_MAPPING(LengthsToRangesNodeKind, Int64ITy);
     } else if (operation == "SparseToDense") {
       ADD_OP_MAPPING(SparseToDenseNodeKind, FloatTy);
+    } else if (operation == "LengthsSum") {
+      ADD_OP_MAPPING(LengthsSumNodeKind, FloatTy);
     }
   }
 #undef ADD_OP_MAPPING

--- a/tests/models/caffe2Models/lengths_sum.pbtxt
+++ b/tests/models/caffe2Models/lengths_sum.pbtxt
@@ -1,0 +1,11 @@
+name: "lengthsSum"
+op {
+  input: "data"
+  input: "lengths"
+  output: "result"
+  name: ""
+  type: "LengthsSum"
+}
+external_input: "data"
+external_input: "lengths"
+external_output: "result"

--- a/tests/models/onnxModels/lengths_sum.onnxtxt
+++ b/tests/models/onnxModels/lengths_sum.onnxtxt
@@ -1,0 +1,65 @@
+ir_version: 3
+producer_name: "backend-test"
+graph {
+  node {
+    input: "data"
+    input: "lengths"
+    output: "result"
+    op_type: "LengthsSum"
+  }
+  name: "lengths_sum"
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: FLOAT
+        shape {
+          dim {
+            dim_value: 10
+          }
+	  dim {
+	    dim_value: 2
+	  }
+	  dim {
+	    dim_value: 3
+	  }
+        }
+      }
+    }
+  }
+  input {
+    name: "lengths"
+    type {
+      tensor_type {
+        elem_type: INT64
+        shape {
+          dim {
+            dim_value: 5 
+          }
+	}
+      }
+    }
+  }
+  output {
+    name: "result"
+    type {
+      tensor_type {
+        elem_type: FLOAT
+        shape {
+          dim {
+            dim_value: 5
+          }
+          dim {
+            dim_value: 2
+          }
+	  dim {
+	    dim_value: 3
+	  }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 9
+}

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -204,6 +204,17 @@ int main(int argc, char **argv) {
       .autoVerify(VerifyKind::SameElementType, {"Dest", "Batch"})
       .autoIRGen();
 
+  /// Sums together groups of consecutive slices of Data as per the group sizes
+  /// specified by Lengths.
+  BB.newInstr("LengthsSum")
+      .addOperand("Dest", OperandKind::Out)
+      .addOperand("Data", OperandKind::In)
+      .addOperand("Lengths", OperandKind::In)
+      .autoIRGen()
+      .autoVerify(VerifyKind::SameElementType, {"Dest", "Data"})
+      .autoVerify(VerifyKind::SameElementType,
+                  {"Lengths", "ElemKind::Int64ITy"});
+
   BB.newInstr("SparseLengthsWeightedSum")
       .addOperand("Dest", OperandKind::Out)
       .addOperand("Data", OperandKind::In)

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -294,6 +294,16 @@ int main(int argc, char **argv) {
                     "tensor that has the same dimensions as the input tensor "
                     "without the first dimension.");
 
+  BB.newNode("LengthsSum")
+      .addInput("Data")
+      .addInput("Lengths")
+      .addResultFromCtorArg()
+      .setDocstring("Sums slices of the outermost dimension of Data in groups "
+                    "defined by Lengths. The first Lengths[0] slices are "
+                    "added together and stored in Result[0], the subsequent "
+                    "Lengths[1] slices are added together and stored in "
+                    "Result[1], etc.");
+
   BB.newNode("SparseLengthsWeightedSum")
       .addInput("Data")
       .addInput("Weights")


### PR DESCRIPTION
**Description**
This commit adds support for the `LengthsSum` operator, which
performs a `BatchedReduceAdd` operation on groups of consecutive
zero-axis slices of the `data` input. The sizes of these groups
are defined by the `lengths` input. This operator has implementations in
both the CPU and interpreter backends, and can be imported from a Caffe2
and ONNX model.

**Testing**
This commit adds an interpreter and CPU operator test as well as Caffe2
and ONNX importer tests.

**Fixes**
This commit fixes #1884.
