### PR TITLE
[OperatorTest][fix] Do not run logit test on OCL

### DIFF
--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -135,7 +135,7 @@ TEST_P(InterpAndCPU, log) {
   }
 }
 
-TEST_P(Operator, logit) {
+TEST_P(InterpAndCPU, logit) {
   auto eps = 1E-6f;                // the default in Caffe2
   constexpr std::size_t size = 10; // sample size for randomized tests
 


### PR DESCRIPTION
Doesn't work because log is not supported