### PR TITLE
Run a round of DCE before any other graph optimizations

### DIFF
--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -2089,6 +2089,11 @@ void glow::convertPlaceholdersToConstants(Function *F, const Context &ctx,
 }
 
 void glow::optimize(Function *F, CompilationMode mode) {
+  // Optimize may be called after backend specific transformations and some
+  // nodes may have become unused. It is a good idea to remove them, before
+  // proceeding with any further optimizations.
+  DCE(F);
+
   // Sink transpose operations in an attempt to cancel them out.
   // Perform code sinking until a fixed-point is reached.
   // On big functions, the number of iterations until the fixpoint


### PR DESCRIPTION
*Description*:

Optimizer may be called after backend specific transformations and some nodes may have become unused. It is a good idea to remove them, before proceeding with any further optimizations. Without it some optimizations do not kick in as they may check for the number of users of a given node and count the unused nodes as users as well.

I caught this issue when I was investigating why transpose(constant) is not optimized away at compile time after some backend-specific transformations. The reason was that the constant was used by the newly created transpose node and dead, but not yet removed node that initially used it.

*Testing*:
ninja test

