### PR TITLE
[GraphScheduler] Add a simple topological sort graph scheduler

### DIFF
--- a/lib/IR/CMakeLists.txt
+++ b/lib/IR/CMakeLists.txt
@@ -4,7 +4,9 @@ add_library(IR
               IRUtils.cpp
               IRBuilder.cpp
               Instrs.cpp
-              GraphScheduler.cpp)
+              GraphScheduler.cpp
+              ChildMemSizeBasedScheduler.cpp
+              TopologicalSortBasedScheduler.cpp)
 
 target_link_libraries(IR
                       PUBLIC

--- a/lib/IR/ChildMemSizeBasedScheduler.cpp
+++ b/lib/IR/ChildMemSizeBasedScheduler.cpp
@@ -1,0 +1,168 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#define DEBUG_TYPE "graph-scheduler"
+
+#include "GraphScheduler.h"
+
+#include "glow/Graph/Utils.h"
+#include "glow/Support/Debug.h"
+
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
+
+using llvm::cast;
+using llvm::dyn_cast;
+using llvm::isa;
+
+namespace glow {
+/// \returns true if a node \p N is scheduled already.
+bool ChildMemSizeBasedScheduler::isScheduled(const Node *N) const {
+  return std::find(scheduled_.begin(), scheduled_.end(), N) != scheduled_.end();
+}
+
+/// Computes the amount of memory required to keep the result
+/// of each node.
+void ChildMemSizeBasedScheduler::computeNodeResultsMemorySize() {
+  for (auto &N : G_.getNodes()) {
+    int64_t resultSize = 0;
+    for (size_t idx = 0, e = N.getNumResults(); idx < e; ++idx) {
+      resultSize += N.getType(idx)->getSizeInBytes();
+    }
+    resultMemSize_[&N] = resultSize;
+    DEBUG_GLOW(llvm::outs()
+               << "ResultSize of " << N.getName() << ":" << resultSize << "\n");
+  }
+}
+
+/// Computes the max amount of memory required during the computation
+/// of children for each node.
+void ChildMemSizeBasedScheduler::computeNodeComputationMaxMemorySize() {
+  // Traverse nodes in such a way, that dependnecies are processed
+  // before the node using them.
+  GraphPostOrderVisitor visitor(G_);
+  for (auto *N : visitor.getPostOrder()) {
+    int64_t maxSize = (N->getNumInputs() > 0)
+                          ? std::max(resultMemSize_[N->getNthInput(0)],
+                                     maxMemSize_[N->getNthInput(0)])
+                          : 0;
+    for (size_t idx = 1, e = N->getNumInputs(); idx < e; ++idx) {
+      const auto &input = N->getNthInput(idx);
+      // Skip operands that do not require memory allocations for storing
+      // their results.
+      if (isa<Storage>(input))
+        continue;
+      assert(resultMemSize_.count(input) > 0);
+      assert(maxMemSize_.count(input) > 0);
+      maxSize += resultMemSize_[input];
+      if (maxSize < maxMemSize_[input])
+        maxSize = maxMemSize_[input];
+    }
+    maxMemSize_[N] = maxSize;
+    DEBUG_GLOW(llvm::outs()
+               << "MaxSize of " << N->getName() << ":" << maxSize << "\n");
+  }
+}
+
+/// Order children by (maxSize - resultSize). It gives more
+/// priority to the nodes that free more memory after
+/// their computation.
+void ChildMemSizeBasedScheduler::orderChildNodesAndSchedule(Node *N) {
+  // Each child should be scheduled just once.
+  if (isScheduled(N))
+    return;
+  // Do not explicitly schedule storage nodes.
+  if (isa<Storage>(N))
+    return;
+  // A set of node's sorted children.
+  llvm::SmallVector<Node *, 8> orderedChildren;
+  for (int idx = 0, e = N->getNumInputs(); idx < e; ++idx) {
+    orderedChildren.push_back(N->getNthInput(idx));
+  }
+
+  if (N->hasPredicate()) {
+    orderedChildren.push_back(N->getPredicate());
+  }
+
+  // SaveNode hack:
+  // We don't model memory dependencies, but we still need to honor them.
+  // Make sure the SaveNode happens after the last use of the output
+  // placeholder.
+  if (auto *save = dyn_cast<SaveNode>(N)) {
+    auto *destination = save->getOutput().getNode();
+    for (NodeUse &use : destination->getUsers()) {
+      Node *user = use.getUser();
+      if (user == save) {
+        continue;
+      }
+      // Storage nodes may have users scattered across different functions.
+      // Only accounts for the ones in that function.
+      if (&G_ != user->getParent()) {
+        continue;
+      }
+      assert(!isa<SaveNode>(user) &&
+             "Placeholder must be saved at most once in each function");
+      orderedChildren.push_back(user);
+    }
+  }
+
+  // Order children by (maxSize - resultSize). It gives more
+  // priority to the nodes that free more memory after
+  // their computation.
+  for (size_t j = 0, e = orderedChildren.size(); j < e; ++j) {
+    for (size_t i = j; i > 0; --i) {
+      auto &currentChild = orderedChildren[i];
+      auto &prevChild = orderedChildren[i - 1];
+      if (maxMemSize_[currentChild] - resultMemSize_[currentChild] >
+          maxMemSize_[prevChild] - resultMemSize_[prevChild]) {
+        std::swap(currentChild, prevChild);
+      }
+    }
+  }
+
+  DEBUG_GLOW(llvm::outs() << "\nAbout to schedule children of " << N->getName()
+                          << "\n";
+             llvm::outs() << "Children are:\n");
+  DEBUG_GLOW(for (auto child
+                  : orderedChildren) {
+    llvm::outs() << "Child " << child->getName() << ": "
+                 << maxMemSize_[child] - resultMemSize_[child] << "\n";
+  });
+
+  // Process the children according to the computed ordering.
+  for (auto child : orderedChildren) {
+    orderChildNodesAndSchedule(child);
+  }
+
+  // Schedule the node after all its children are scheduled.
+  DEBUG_GLOW(llvm::outs() << "Scheduled node: " << N->getName() << "\n");
+  scheduled_.push_back(N);
+}
+
+void ChildMemSizeBasedScheduler::scheduleNodes() {
+  /// Try to schedule all root nodes.
+  for (auto &N : G_.getNodes()) {
+    if (N.getNumUsers() == 0)
+      orderChildNodesAndSchedule(&N);
+  }
+}
+
+void ChildMemSizeBasedScheduler::schedule() {
+  computeNodeResultsMemorySize();
+  computeNodeComputationMaxMemorySize();
+  scheduleNodes();
+}
+} // namespace glow

--- a/lib/IR/GraphScheduler.cpp
+++ b/lib/IR/GraphScheduler.cpp
@@ -13,161 +13,37 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#define DEBUG_TYPE "graph-scheduler"
-
 #include "GraphScheduler.h"
 
-#include "glow/Graph/Graph.h"
-#include "glow/Graph/Nodes.h"
-#include "glow/Graph/Utils.h"
-#include "glow/IR/IR.h"
-#include "glow/Support/Debug.h"
-
-#include "llvm/Support/Casting.h"
-#include "llvm/Support/Debug.h"
-#include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/CommandLine.h"
 
 using namespace glow;
 
-using llvm::cast;
-using llvm::dyn_cast;
-using llvm::isa;
+namespace {
+llvm::cl::OptionCategory graphSchedulerCat("Graph Scheduler Options");
 
-/// \returns true if a node \p N is scheduled already.
-bool ChildMemSizeBasedScheduler::isScheduled(const Node *N) const {
-  return std::find(scheduled_.begin(), scheduled_.end(), N) != scheduled_.end();
-}
+llvm::cl::opt<SchedulerKind> graphScheduler(
+    llvm::cl::desc("Scheduler to use:"),
+    llvm::cl::values(clEnumValN(SchedulerKind::ChildMemSizeBased,
+                                "child-mem-size-based",
+                                "Use ChildMemSizeBased"),
+                     clEnumValN(SchedulerKind::TopologicalSortBased,
+                                "topological-sort-based",
+                                "Use TopologicalSortBased")),
+    llvm::cl::init(SchedulerKind::ChildMemSizeBased),
+    llvm::cl::cat(graphSchedulerCat));
+} // namespace
 
-/// Computes the amount of memory required to keep the result
-/// of each node.
-void ChildMemSizeBasedScheduler::computeNodeResultsMemorySize() {
-  for (auto &N : G_.getNodes()) {
-    int64_t resultSize = 0;
-    for (size_t idx = 0, e = N.getNumResults(); idx < e; ++idx) {
-      resultSize += N.getType(idx)->getSizeInBytes();
-    }
-    resultMemSize_[&N] = resultSize;
-    DEBUG_GLOW(llvm::outs()
-               << "ResultSize of " << N.getName() << ":" << resultSize << "\n");
+namespace glow {
+Scheduler *createScheduler(SchedulerKind schedulerKind, Function &G,
+                           NodesPtrList &scheduled) {
+  switch (schedulerKind) {
+  case SchedulerKind::ChildMemSizeBased:
+    return new ChildMemSizeBasedScheduler(G, scheduled);
+  case SchedulerKind::TopologicalSortBased:
+    return new TopologicalSortBasedScheduler(G, scheduled);
   }
-}
-
-/// Computes the max amount of memory required during the computation
-/// of children for each node.
-void ChildMemSizeBasedScheduler::computeNodeComputationMaxMemorySize() {
-  // Traverse nodes in such a way, that dependnecies are processed
-  // before the node using them.
-  GraphPostOrderVisitor visitor(G_);
-  for (auto *N : visitor.getPostOrder()) {
-    int64_t maxSize = (N->getNumInputs() > 0)
-                          ? std::max(resultMemSize_[N->getNthInput(0)],
-                                     maxMemSize_[N->getNthInput(0)])
-                          : 0;
-    for (size_t idx = 1, e = N->getNumInputs(); idx < e; ++idx) {
-      const auto &input = N->getNthInput(idx);
-      // Skip operands that do not require memory allocations for storing
-      // their results.
-      if (isa<Storage>(input))
-        continue;
-      assert(resultMemSize_.count(input) > 0);
-      assert(maxMemSize_.count(input) > 0);
-      maxSize += resultMemSize_[input];
-      if (maxSize < maxMemSize_[input])
-        maxSize = maxMemSize_[input];
-    }
-    maxMemSize_[N] = maxSize;
-    DEBUG_GLOW(llvm::outs()
-               << "MaxSize of " << N->getName() << ":" << maxSize << "\n");
-  }
-}
-
-/// Order children by (maxSize - resultSize). It gives more
-/// priority to the nodes that free more memory after
-/// their computation.
-void ChildMemSizeBasedScheduler::orderChildNodesAndSchedule(Node *N) {
-  // Each child should be scheduled just once.
-  if (isScheduled(N))
-    return;
-  // Do not explicitly schedule storage nodes.
-  if (isa<Storage>(N))
-    return;
-  // A set of node's sorted children.
-  llvm::SmallVector<Node *, 8> orderedChildren;
-  for (int idx = 0, e = N->getNumInputs(); idx < e; ++idx) {
-    orderedChildren.push_back(N->getNthInput(idx));
-  }
-
-  if (N->hasPredicate()) {
-    orderedChildren.push_back(N->getPredicate());
-  }
-
-  // SaveNode hack:
-  // We don't model memory dependencies, but we still need to honor them.
-  // Make sure the SaveNode happens after the last use of the output
-  // placeholder.
-  if (auto *save = dyn_cast<SaveNode>(N)) {
-    auto *destination = save->getOutput().getNode();
-    for (NodeUse &use : destination->getUsers()) {
-      Node *user = use.getUser();
-      if (user == save) {
-        continue;
-      }
-      // Storage nodes may have users scattered across different functions.
-      // Only accounts for the ones in that function.
-      if (&G_ != user->getParent()) {
-        continue;
-      }
-      assert(!isa<SaveNode>(user) &&
-             "Placeholder must be saved at most once in each function");
-      orderedChildren.push_back(user);
-    }
-  }
-
-  // Order children by (maxSize - resultSize). It gives more
-  // priority to the nodes that free more memory after
-  // their computation.
-  for (size_t j = 0, e = orderedChildren.size(); j < e; ++j) {
-    for (size_t i = j; i > 0; --i) {
-      auto &currentChild = orderedChildren[i];
-      auto &prevChild = orderedChildren[i - 1];
-      if (maxMemSize_[currentChild] - resultMemSize_[currentChild] >
-          maxMemSize_[prevChild] - resultMemSize_[prevChild]) {
-        std::swap(currentChild, prevChild);
-      }
-    }
-  }
-
-  DEBUG_GLOW(llvm::outs() << "\nAbout to schedule children of " << N->getName()
-                          << "\n";
-             llvm::outs() << "Children are:\n");
-  DEBUG_GLOW(for (auto child
-                  : orderedChildren) {
-    llvm::outs() << "Child " << child->getName() << ": "
-                 << maxMemSize_[child] - resultMemSize_[child] << "\n";
-  });
-
-  // Process the children according to the computed ordering.
-  for (auto child : orderedChildren) {
-    orderChildNodesAndSchedule(child);
-  }
-
-  // Schedule the node after all its children are scheduled.
-  DEBUG_GLOW(llvm::outs() << "Scheduled node: " << N->getName() << "\n");
-  scheduled_.push_back(N);
-}
-
-void ChildMemSizeBasedScheduler::scheduleNodes() {
-  /// Try to schedule all root nodes.
-  for (auto &N : G_.getNodes()) {
-    if (N.getNumUsers() == 0)
-      orderChildNodesAndSchedule(&N);
-  }
-}
-
-void ChildMemSizeBasedScheduler::schedule() {
-  computeNodeResultsMemorySize();
-  computeNodeComputationMaxMemorySize();
-  scheduleNodes();
+  llvm_unreachable("unreachable");
 }
 
 void IRFunction::scheduleGraph(NodesPtrList &Schedule) {
@@ -178,13 +54,15 @@ void IRFunction::scheduleGraph(NodesPtrList &Schedule) {
   for (auto &N : G_->getParent()->getPlaceholders()) {
     Schedule.push_back(N);
   }
-  ChildMemSizeBasedScheduler CMSBScheduler(*G_, Schedule);
-  CMSBScheduler.schedule();
   auto numVars = G_->getParent()->getConstants().size();
   auto numPlaceholders = G_->getParent()->getPlaceholders().size();
   (void)numVars;
   (void)numPlaceholders;
-  assert(CMSBScheduler.getSchedule().size() ==
+  std::unique_ptr<Scheduler> scheduler{
+      createScheduler(graphScheduler, *G_, Schedule)};
+  scheduler->schedule();
+  assert(scheduler->getSchedule().size() ==
              G_->getNodes().size() + numPlaceholders + numVars &&
          "All graph nodes have to be scheduled");
 }
+} // namespace glow

--- a/lib/IR/GraphScheduler.h
+++ b/lib/IR/GraphScheduler.h
@@ -21,6 +21,15 @@
 #include <unordered_map>
 
 namespace glow {
+
+/// Specifies the kind of graph scheduling to perform.
+enum class SchedulerKind {
+  /// This is a heuristics that tries to minimize memory usage.
+  ChildMemSizeBased,
+  /// Performs a standard topological search
+  TopologicalSortBased,
+};
+
 class Scheduler {
 protected:
   /// Graph being processed.
@@ -79,6 +88,24 @@ public:
 
   void schedule() override;
 };
+
+/// This is a simple scheduler based on topological sort based
+/// on post order traversal.
+
+class TopologicalSortBasedScheduler : public Scheduler {
+  std::unordered_map<const Node *, int64_t> indegree_;
+
+public:
+  TopologicalSortBasedScheduler(Function &G, NodesPtrList &Schedule)
+      : Scheduler(G, Schedule) {}
+
+  ~TopologicalSortBasedScheduler() override = default;
+
+  void schedule() override;
+};
+
+Scheduler *createScheduler(SchedulerKind schedulerKind, Function &G,
+                           NodesPtrList &scheduled);
 
 } // namespace glow
 

--- a/lib/IR/TopologicalSortBasedScheduler.cpp
+++ b/lib/IR/TopologicalSortBasedScheduler.cpp
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "GraphScheduler.h"
+
+#include "glow/Graph/Utils.h"
+
+#include <queue>
+
+using llvm::isa;
+
+namespace glow {
+void TopologicalSortBasedScheduler::schedule() {
+  GraphPostOrderVisitor gpov(G_);
+  auto PostOrderNodes = gpov.getPostOrder();
+  for (auto &N : PostOrderNodes) {
+    if (isa<Storage>(N)) {
+      continue;
+    }
+    scheduled_.push_back(N);
+  }
+}
+} // namespace glow


### PR DESCRIPTION
*Description*: Add a simple topological sort graph scheduler
*Testing*:
*Documentation*:

There are many scheduling policies to mapping a computation graph to a certain backend. This PR adds a simple topological sort based graph scheduler and exposes a command line interface for users.
