### PR TITLE
[circleci] Fixing SNI warning/error.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ linux_default: &linux_default
         export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_FOR_ECR_READ_WRITE}
         export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY_FOR_ECR_READ_WRITE}
         
-        sudo pip install --upgrade setuptools
+        sudo pip install --upgrade pip setuptools
         sudo pip install awscli==1.16.35 -qqq
         # Upgrade SSL module to avoid old SSL warnings
         sudo pip install --user --upgrade pyOpenSSL ndg-httpsclient pyasn1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,12 @@ linux_default: &linux_default
         set -e
         export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_FOR_ECR_READ_WRITE}
         export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY_FOR_ECR_READ_WRITE}
+        
+        sudo pip install --upgrade setuptools
         sudo pip install awscli==1.16.35 -qqq
+        # Upgrade SSL module to avoid old SSL warnings
+        sudo pip install --user --upgrade pyOpenSSL ndg-httpsclient pyasn1
+
         eval $(aws ecr get-login --region us-east-1 --no-include-email)
 
         docker pull ${DOCKER_IMAGE}


### PR DESCRIPTION
*Description*:
Try to fix.
```
/usr/local/lib/python2.7/dist-packages/urllib3/util/ssl_.py:369: SNIMissingWarning: An HTTPS request has been made, but the SNI (Server Name Indication) extension to TLS is not available on this platform. This may cause the server to present an incorrect TLS certificate, which can cause validation failures. You can upgrade to a newer version of Python to solve this. For more information, see https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  SNIMissingWarning

An error occurred (UnrecognizedClientException) when calling the GetAuthorizationToken operation: The security token included in the request is invalid.
Error response from daemon: Get https://308535385114.dkr.ecr.us-east-1.amazonaws.com/v2/caffe2/py2-clang6.0-ubuntu16.04/manifests/213: no basic auth credentials
Exited with code 1
```

*Testing*:
CircleCI run.

*Documentation*:
N/A