### PR TITLE
[Quantization] Support int32 quantized bias of FullyConnected.

### DIFF
--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -1564,39 +1564,36 @@ void InterpreterFunction::fwdRowwiseQuantizedFullyConnectedInst(
 //===----------------------------------------------------------------------===//
 //                       Batched operations
 //===----------------------------------------------------------------------===//
+template <class T>
+static void fwdBatchedAdd(Tensor *batch, Tensor *slice, Tensor *dest) {
+  auto batchH = batch->getHandle<int8_t>();
+  auto sliceH = slice->getHandle<T>();
+  auto destH = dest->getHandle<int8_t>();
 
-void InterpreterFunction::fwdBatchedAddInst_I8Impl(
-    const glow::BatchedAddInst *I) {
-  assert(getTensor(I->getBatch())->getType().isQuantizedType() &&
-         "Wrong function");
-  auto batch = getWeightHandle<int8_t>(I->getBatch());
-  auto slice = getWeightHandle<int8_t>(I->getSlice());
-  auto dest = getWeightHandle<int8_t>(I->getDest());
+  auto batchTy = batch->getType();
+  auto sliceTy = slice->getType();
+  auto destTy = dest->getType();
 
-  auto batchTy = I->getBatch()->getType();
-  auto sliceTy = I->getSlice()->getType();
-  auto destTy = I->getDest()->getType();
+  float sliceScale = sliceTy.getScale();
+  float batchScale = batchTy.getScale();
+  float destScale = destTy.getScale();
 
-  float sliceScale = sliceTy->getScale();
-  float batchScale = batchTy->getScale();
-  float destScale = destTy->getScale();
+  int32_t sliceOffset = sliceTy.getOffset();
+  int32_t batchOffset = batchTy.getOffset();
+  int32_t destOffset = destTy.getOffset();
 
-  int32_t sliceOffset = sliceTy->getOffset();
-  int32_t batchOffset = batchTy->getOffset();
-  int32_t destOffset = destTy->getOffset();
-
-  auto bdim = flattenCdr(batch.dims());
-  assert(slice.size() == bdim.second && "Invalid slice size");
-  assert(batch.dims().drop_front() == slice.dims() && "Invalid batch size");
+  auto bdim = flattenCdr(batchH.dims());
+  assert(sliceH.size() == bdim.second && "Invalid slice size");
+  assert(batchH.dims().drop_front() == sliceH.dims() && "Invalid batch size");
 
   // For each layer in the batch:
   for (size_t n = 0; n < bdim.first; n++) {
-    size_t base = batch.getElementPtr({n});
+    size_t base = batchH.getElementPtr({n});
 
     // For each element in the slice.
     for (size_t i = 0; i < bdim.second; i++) {
-      int32_t batchVal = batch.raw(base + i);
-      int32_t sliceVal = slice.raw(i);
+      int32_t batchVal = batchH.raw(base + i);
+      int32_t sliceVal = sliceH.raw(i);
       // We increase the size of the integer up to 16 bits for more accurate
       // arithmetic.
       const float largeScale = float(1) / (1 << 15);
@@ -1606,9 +1603,25 @@ void InterpreterFunction::fwdBatchedAddInst_I8Impl(
       int32_t S =
           std::round(float(sliceVal - sliceOffset) * (sliceScale / largeScale));
       int32_t R = B + S;
-      dest.raw(base + i) = quantization::clip<int32_t, int8_t>(
+      destH.raw(base + i) = quantization::clip<int32_t, int8_t>(
           std::round(float(R) * (largeScale / destScale) + destOffset));
     }
+  }
+}
+
+void InterpreterFunction::fwdBatchedAddInst_I8Impl(
+    const glow::BatchedAddInst *I) {
+  assert(getTensor(I->getBatch())->getType().isQuantizedType() &&
+         "This function only support quantized type.");
+  auto batchW = getTensor(I->getBatch());
+  auto sliceW = getTensor(I->getSlice());
+  auto destW = getTensor(I->getDest());
+  if (sliceW->getType().getElementType() == ElemKind::Int8QTy) {
+    fwdBatchedAdd<int8_t>(batchW, sliceW, destW);
+  } else if (sliceW->getType().getElementType() == ElemKind::Int32QTy) {
+    fwdBatchedAdd<int32_t>(batchW, sliceW, destW);
+  } else {
+    assert("Type is not supported.");
   }
 }
 

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -675,6 +675,7 @@ void OpenCLFunction::execute(Context &ctx) {
       setKernelArg(kernel, 0, deviceBuffer_);
       auto numArgs = setKernelArgsForBuffers(kernel, I, 1, tensors_);
       auto numMandatoryArgs = numArgs;
+      (void)numMandatoryArgs;
 
       if (auto *SI = dyn_cast<SplatInst>(&I)) {
         // Pass the splat as a parameter.
@@ -931,6 +932,10 @@ void OpenCLFunction::execute(Context &ctx) {
     }
 
     if (auto *BA = dyn_cast<BatchedAddInst>(&I)) {
+      if (isQuantized &&
+          BA->getSlice()->getType()->getElementType() == ElemKind::Int32QTy) {
+        kernelName += "_32";
+      }
       cl_kernel kernel = createKernel(kernelName);
       setKernelArg(kernel, 0, deviceBuffer_);
       auto numArgs = setKernelArgsForBuffers(kernel, I, 1, tensors_);

--- a/lib/Backends/OpenCL/kernels.cl
+++ b/lib/Backends/OpenCL/kernels.cl
@@ -586,6 +586,35 @@ __kernel void batchedadd_i8W(__global void *mem, cl_uint32_t dest,
                  sliceScaleParams.post, sliceScaleParams.scale);
 }
 
+__kernel void batchedadd_i8K_32(
+    __global cl_int8_t *dest, __global cl_int8_t *batch,
+    __global cl_int32_t *slice, cl_uint32_t numSlice, cl_uint32_t sliceSize,
+    cl_int32_t destOffset, cl_int32_t batchOffset, cl_int32_t sliceOffset,
+    cl_int32_t batchPre, cl_int32_t batchPost, cl_int32_t batchScale,
+    cl_int32_t slicePre, cl_int32_t slicePost, cl_int32_t sliceScale) {
+  size_t s = get_global_id(0);
+  for (size_t n = 0; n < numSlice; n++) {
+    cl_int32_t batchVal = batch[n * sliceSize + s] - batchOffset;
+    cl_int32_t sliceVal = slice[s] - sliceOffset;
+    cl_int32_t x = scale_i32i8(batchVal, batchPre, batchPost, batchScale, 0);
+    cl_int32_t y = scale_i32i8(sliceVal, slicePre, slicePost, sliceScale, 0);
+    dest[n * sliceSize + s] = clip(x + y + destOffset);
+  }
+}
+
+__kernel void batchedadd_i8W_32(__global void *mem, cl_uint32_t dest,
+                                cl_uint32_t batch, cl_uint32_t slice,
+                                cl_uint32_t numSlice, cl_uint32_t sliceSize,
+                                cl_int32_t destOffset,
+                                QuantizationTransform32To8 batchScaleParams,
+                                QuantizationTransform32To8 sliceScaleParams) {
+  batchedadd_i8K_32(
+      &mem[dest], &mem[batch], &mem[slice], numSlice, sliceSize, destOffset,
+      batchScaleParams.offset, sliceScaleParams.offset, batchScaleParams.pre,
+      batchScaleParams.post, batchScaleParams.scale, sliceScaleParams.pre,
+      sliceScaleParams.post, sliceScaleParams.scale);
+}
+
 /// Size of the tile to be used for matrix multiplication.
 /// The kernel can only be executed by the OpenCL backends that allow
 /// workgroups with sizes which are at least as big as a tile.

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -187,6 +187,10 @@ static void verifyFullyConnected(NodeValue src, NodeValue weights,
   assert(bias.dims()[0] == weights.dims()[1] &&
          weights.dims()[1] == dest.dims()[1] &&
          "Inconsistent bias/weights/dest sizes.");
+
+  if (src.getElementType() == ElemKind::Int8QTy) {
+    assert(bias.getElementType() == ElemKind::Int32QTy && "Invalid Type");
+  }
 }
 
 static void verifyPool(NodeValue src, NodeValue dest,
@@ -569,9 +573,15 @@ void BatchedAddNode::verify() const {
   assert(getBatch().dims() == getResult().dims() && "Invalid dest type");
   (void)batchShape;
   (void)rhsShape;
-  assert(getBatch().getType()->getElementType() ==
-             getSlice().getType()->getElementType() &&
-         "Mismatched element types");
+  if (getBatch().getType()->getElementType() == ElemKind::Int8QTy) {
+    assert((getSlice().getType()->getElementType() == ElemKind::Int8QTy ||
+            getSlice().getType()->getElementType() == ElemKind::Int32QTy) &&
+           "Mismatched element types");
+  } else {
+    assert(getBatch().getType()->getElementType() ==
+               getSlice().getType()->getElementType() &&
+           "Mismatched element types");
+  }
 }
 
 void BatchedReduceAddNode::verify() const {

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -79,6 +79,16 @@ protected:
           weights.getNode()->getNthResult(0).getType()->getScale();
       return mod_.uniqueType(ElemKind::Int32QTy, val.dims(),
                              scaleInput * scaleWeights, TQP.offset);
+    } else if (use.getKind() == glow::Kinded::Kind::FullyConnectedNodeKind &&
+               idx == 2) {
+      auto fcN = llvm::dyn_cast<FullyConnectedNode>(&use);
+      NodeValue input = fcN->getInput();
+      NodeValue weights = fcN->getWeights();
+      float scaleInput = input.getNode()->getNthResult(0).getType()->getScale();
+      float scaleWeights =
+          weights.getNode()->getNthResult(0).getType()->getScale();
+      return mod_.uniqueType(ElemKind::Int32QTy, val.dims(),
+                             scaleInput * scaleWeights, TQP.offset);
     } else {
       return mod_.uniqueType(ElemKind::Int8QTy, val.dims(), TQP.scale,
                              TQP.offset);

--- a/tests/unittests/graphTest.cpp
+++ b/tests/unittests/graphTest.cpp
@@ -358,7 +358,7 @@ TEST(Graph, simpleQuant) {
   auto *fcFilter =
       MD.createPlaceholder(ElemKind::Int8QTy, {s, 6}, 0.4, 2, "F", true);
   auto *fcBias =
-      MD.createPlaceholder(ElemKind::Int8QTy, {6}, 0.4, 2, "B", true);
+      MD.createPlaceholder(ElemKind::Int32QTy, {6}, 0.4, 2, "B", true);
   Node *O = F->createFullyConnected("fc1", conv, fcFilter, fcBias);
   Context ctx;
   F->createSave("ret", O);


### PR DESCRIPTION
*Description*:
As #1876 stated, now we support FC with int32 bias.

*Testing*:
unittests added. Can dump and profile resnet50.

*Documentation*:
#1727 
[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
