### PR TITLE
Migrate CPU Backend to allocate memory at runtime.

### DIFF
--- a/docs/JIT.md
+++ b/docs/JIT.md
@@ -19,12 +19,10 @@ The JIT, on the other hand, generates a single stream of highly optimized
 instructions that don't go back to the interpreter. Moreover, each instruction
 is optimized based on specific information on the context in which the
 instruction is executed. When a matrix multiplication is compiled the JIT knows
-exactly the dimensions of the matrices that are being executed and where the
-tensors are placed in memory. The JIT knows that the buffers do or do-not
-alias, and exactly the number of iterations for the loop. The knowledge enables
+exactly the dimensions of the matrices that are being executed. The knowledge enables
 much better code generation and vectorization. The JIT is also able to eliminate
 all calls to 'malloc', because the memory is statically allocated. The whole
-network is allocated by a single malloc call.
+network is allocated by a single malloc call, all inputs and outputs a single seperate call.
 
 ### How the JIT Works
 
@@ -35,9 +33,8 @@ allocate concrete memory addresses for the AllocActivation instructions in the
 module. The allocation is done by scanning the module and updating the memory
 allocator. After this process the allocator reports the high water mark, which
 is the maximum number of bytes that the network consumes. The allocator assigns
-offsets for each alloc activation within the buffer. Then, the JIT performs a
-single call to 'malloc' to allocates the heap. At this point each activation and
-each weight has a concrete address on the heap.
+offsets for each alloc activation within the buffer. This information is stored
+in a runtimeBundle where a single call to malloc initializes the heap for activations.
 
 Next, the JIT opens a new LLVM functions and prepares for code generation. The
 compiler goes over each low-level instruction and generates a sequence of

--- a/include/glow/Backends/CompiledFunction.h
+++ b/include/glow/Backends/CompiledFunction.h
@@ -16,23 +16,50 @@
 #ifndef GLOW_BACKENDS_COMPILEDFUNCTION_H
 #define GLOW_BACKENDS_COMPILEDFUNCTION_H
 
+#include "glow/Graph/Nodes.h"
 #include <unordered_map>
 
 namespace glow {
 
 class Context;
-
+namespace runtime {
+/// RuntimeSymbolInfo
+/// Contains information for initialization and handling of symbol at runtime.
+struct RuntimeSymbolInfo {
+  /// The size in bytes.
+  size_t size;
+  /// Offset in bytes from the base address.
+  size_t offset;
+};
+/// Runtime Bundle
+/// Contains the information needed to be passed forward from compile time to
+/// runtime. In order to allocate and initialize memory.
+struct RuntimeBundle {
+  /// Map from symbol name to a RuntimeSymbolInfo.
+  std::unordered_map<std::string, RuntimeSymbolInfo> symbolTable;
+  /// Pointer to memory containing the weights for execution.
+  uint8_t *constants;
+  /// Amount of memory needed for weights.
+  const size_t constantWeightVarsMemSize;
+  /// Amount of memory needed for mutable vars.
+  const size_t mutableWeightVarsMemSize;
+  /// Amount of memory needed for activations.
+  const size_t activationsMemSize;
+  RuntimeBundle(size_t constWeight, size_t mutableWeight, size_t activations)
+      : constantWeightVarsMemSize(constWeight),
+        mutableWeightVarsMemSize(mutableWeight),
+        activationsMemSize(activations) {}
+};
+} // end namespace runtime
 /// Interface for executing a compiled function.
 class CompiledFunction {
 public:
   /// Dtor.
   virtual ~CompiledFunction() = default;
-
   /// Execute the network and allocate Placeholder memory with given
   /// \p ctx providing mapping between Placeholder and populated tensor.
   virtual void execute(Context &ctx) = 0;
 };
-
 } // end namespace glow
 
 #endif // GLOW_BACKENDS_COMPILEDFUNCTION_H

--- a/lib/Backends/CPU/BundleSaver.cpp
+++ b/lib/Backends/CPU/BundleSaver.cpp
@@ -56,7 +56,7 @@ void BundleSaver::saveWeights(llvm::StringRef weightsFileName) {
     auto *w = cast<WeightVar>(F_->getWeightForNode(v));
     auto numBytes = w->getSizeInBytes();
     auto payload = v->getPayload().getUnsafePtr();
-    auto addr = allocationsInfo_.allocatedAddressed_[w];
+    auto addr = allocationsInfo_.allocatedAddress_[w];
     if (addr < pos) {
       // The payload was written already. It aliases something we have seen
       // already.
@@ -98,7 +98,7 @@ void BundleSaver::emitSymbolTable() {
   for (auto &v : F_->getGraph()->getParent()->getPlaceholders()) {
     auto *w = cast<WeightVar>(F_->getWeightForNode(v));
     auto size = w->getType()->size();
-    auto addr = allocationsInfo_.allocatedAddressed_[w];
+    auto addr = allocationsInfo_.allocatedAddress_[w];
     // Create an SymbolTableEntry.
     auto *entry = llvm::ConstantStruct::get(
         symbolTableEntryTy,
@@ -259,8 +259,7 @@ void BundleSaver::performBundleMemoryAllocation() {
   allocationsInfo_.allocateActivations(F_);
   // Tell the allocateWeightVars to not reuse any existing addresses for weights
   // and to assign new ones.
-  Context empty;
-  allocationsInfo_.allocateWeightVars(F_, empty, false);
+  allocationsInfo_.allocateWeightVars(F_);
   allocationsInfo_.allocateTensorViews(F_);
 }
 

--- a/lib/Backends/CPU/DebugInfo.cpp
+++ b/lib/Backends/CPU/DebugInfo.cpp
@@ -356,9 +356,9 @@ void LLVMIRGen::emitDebugGlobalVariableForValue(const Value *val) {
   // DWARF operations to be performed with the base address to compute the
   // address of the logical global variable.
   llvm::SmallVector<uint64_t, 4> ops;
-  assert(allocationsInfo_.allocatedAddressed_.count(val) &&
+  assert(allocationsInfo_.allocatedAddress_.count(val) &&
          "The weight should be in the map");
-  auto offset = allocationsInfo_.allocatedAddressed_[val];
+  auto offset = allocationsInfo_.allocatedAddress_[val];
   // Get the value of the global var.
   ops.push_back(llvm::dwarf::DW_OP_deref);
   // Add the offset to the value of the global var to get the address of the

--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -300,7 +300,7 @@ void LLVMIRGen::performCodeGen() {
 
 llvm::Value *LLVMIRGen::emitValueAddress(llvm::IRBuilder<> &builder,
                                          const glow::Value *val) {
-  assert(allocationsInfo_.allocatedAddressed_.count(val) &&
+  assert(allocationsInfo_.allocatedAddress_.count(val) &&
          "Value address was not allocated");
   auto sizeTTy = builder.getIntNTy(sizeof(size_t) * 8);
   llvm::Type *T = nullptr;
@@ -359,7 +359,7 @@ LLVMIRGen::emitConstOffsetsArray(llvm::IRBuilder<> &builder,
     auto *V = I.first;
     auto offset = I.second.second;
     elems[offset] = llvm::ConstantInt::get(
-        sizeTType, allocationsInfo.allocatedAddressed_.lookup(V));
+        sizeTType, allocationsInfo.allocatedAddress_.lookup(V));
   }
   auto *arr = llvm::ConstantArray::get(
       llvm::ArrayType::get(sizeTType, elems.size()), elems);
@@ -684,12 +684,12 @@ void LLVMIRGen::emitDataParallelKernel(
 static bool isOverlappingWithAnyBundleBufferOperands(
     AllocationsInfo &allocationsInfo,
     llvm::SmallVectorImpl<const Instruction *> &bundle, Value *buf) {
-  auto addr1 = allocationsInfo.allocatedAddressed_[buf];
+  auto addr1 = allocationsInfo.allocatedAddress_[buf];
   auto size1 = buf->getSizeInBytes();
   for (auto bi : bundle) {
     for (auto bop : bi->getOperands()) {
       auto buf2 = bop.first;
-      auto addr2 = allocationsInfo.allocatedAddressed_[buf2];
+      auto addr2 = allocationsInfo.allocatedAddress_[buf2];
       auto size2 = buf2->getSizeInBytes();
       // It is fine, if buffers of different data-parallel instructions are
       // allocated exactly the same memory region.

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -76,6 +76,17 @@ void glow::updateInputPlaceholdersByName(Context &ctx, Module *mod,
 
 void ExecutionEngine::run(Context &ctx) {
   assert(function_ && "No function has been compiled");
+  // TODO call runtime functions from EE instead of in the compiled function.
+  // copyFunctionToDevice()
+  // allocateMutableBuffersOnDevice()
+  // copyMutablesToDevice(ctx)
+  // copyMutablesFromDevice(ctx)
+  // freeAllocations()
+  // We are working toward moving memory allocation and initialization to
+  // runtime. As an intermediate the runtime functions are being called within
+  // execute to maintain the current API. Once all backends are ported the API
+  // will expose the runtime functions from the ExecutionEngine interface. This
+  // is related to Issue #1904.
   function_->execute(ctx);
 }
 


### PR DESCRIPTION
*Description*: Migrate CPU Backend to allocate and initialize memory at runtime. Added a new runtimeInfo object that contains information needed for runtime memory allocation. 
*Testing*: ninja test passes, AOT bundles still work, testing with run.sh --iterations=20 -cpu -time showed minimal performance difference.
*Documentation*: N/A
Progress on #1904 
