### PR TITLE
[fix] Fix memory leak when allocate Tensor object.

### DIFF
--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -112,6 +112,12 @@ void Graph::run(
   updateInputPlaceholders(ctx_, phs, tensors);
   EE.run(ctx_);
 
+  // Tensors do not own underlying memory for input buffer,
+  // just delete memory allocated for the tensor object itself.
+  for (size_t i = 0; i < tensors.size(); ++i) {
+    delete tensors[i];
+  }
+
   // Copy outputs to the addresses specified in the outputPlaceholderToBuffer.
   for (auto outputVar : outputPlaceholderToBuffer) {
     void *outputAddress = reinterpret_cast<void *>(outputVar.second);


### PR DESCRIPTION
*Description*:
We allocate memory for the Tensor object but do not free it. Fix this.
Note, underlying tensor data is unowned by tensor so we should be fine to delete tensor.

From the internal tool:
```
==87496==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 80 byte(s) in 1 object(s) allocated from:
     #0 libtools_build_sanitizers_asan-ubsan-py.so+0x29708 operator new(unsigned long)
     #1 glow/glow/lib/Onnxifi/Base.cpp:106       glow::onnxifi::Graph::run(llvm::DenseMap<...> const&, llvm::DenseMap<...> const&)
```

*Testing*:
onnxifi_driver tests.

*Documentation*:
N/A

cc: @yinghai 
