### PR TITLE
Moved OpenCL memory allocation to runtime.

### DIFF
--- a/include/glow/Backends/BackendUtils.h
+++ b/include/glow/Backends/BackendUtils.h
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_BACKENDS_BACKENDUTILS_H
+#define GLOW_BACKENDS_BACKENDUTILS_H
+
+#include "glow/Backends/CompiledFunction.h"
+#include "glow/IR/IR.h"
+
+namespace glow {
+/// At compile time condense constants to a single block of memory.
+/// This allows the graph to go away after compile time.
+/// Allocates a block of memory of size \p constantMaxSize then walks the given
+/// function \p F and and copies weights to their address as specified by
+/// offsets contained in \p symbolTable.
+uint8_t *collectConstants(
+    const IRFunction *F, uint64_t constantMaxSize,
+    const std::unordered_map<std::string, runtime::RuntimeSymbolInfo>
+        &symbolTable);
+/// Helper function to retrieve offset for Value: \p v from \p symbolTable.
+size_t
+getValueOffset(Value *v,
+               const std::unordered_map<std::string, runtime::RuntimeSymbolInfo>
+                   &symbolTable);
+} // end namespace glow
+
+#endif // GLOW_BACKENDS_BACKENDUTILS_H

--- a/lib/Backends/BackendUtils.cpp
+++ b/lib/Backends/BackendUtils.cpp
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "glow/Backends/BackendUtils.h"
+#include "glow/IR/Instrs.h"
+
+using namespace glow;
+using llvm::cast;
+using llvm::isa;
+
+uint8_t *glow::collectConstants(
+    const IRFunction *F, uint64_t constantMaxSize,
+    const std::unordered_map<std::string, runtime::RuntimeSymbolInfo>
+        &symbolTable) {
+
+  // At compile time condense constants to a single block of memory.
+  // This allows the graph to go away after compile time.
+  uint8_t *baseConstantWeightVarsStore =
+      (uint8_t *)alignedAlloc(constantMaxSize, TensorAlignment);
+  for (auto &v : F->getGraph()->getParent()->getConstants()) {
+    assert(isa<WeightVar>(F->getWeightForNode(v)));
+    auto *w = cast<WeightVar>(F->getWeightForNode(v));
+    auto payload = v->getPayload().getUnsafePtr();
+    auto numBytes = w->getSizeInBytes();
+    auto it = symbolTable.find(std::string(w->getName()));
+    assert(it != symbolTable.end() && "Symbol not found.");
+    auto addr = it->second.offset;
+    // Copy weight to offset.
+    memcpy(baseConstantWeightVarsStore + addr, payload, numBytes);
+  }
+  return baseConstantWeightVarsStore;
+}
+
+/// Helper function, gets offset of \p v from \p symbolTable.
+size_t glow::getValueOffset(
+    Value *v, const std::unordered_map<std::string, runtime::RuntimeSymbolInfo>
+                  &symbolTable) {
+  auto it = symbolTable.find(std::string(v->getName()));
+  assert(it != symbolTable.end() && "Symbol not found.");
+  return it->second.offset;
+}

--- a/lib/Backends/CMakeLists.txt
+++ b/lib/Backends/CMakeLists.txt
@@ -1,5 +1,11 @@
 add_library(Backends Backends.cpp)
 
+add_library(BackendUtils BackendUtils.cpp)
+
+target_link_libraries(BackendUtils
+                      PRIVATE
+                      IR)
+
 add_subdirectory(Interpreter)
 
 if(GLOW_WITH_OPENCL)
@@ -15,6 +21,7 @@ endif()
 
 target_link_libraries(Backends
                       PRIVATE
+                        BackendUtils
                         Interpreter
                         ${linked_backends}
                         Base

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -78,9 +78,10 @@ void ExecutionEngine::run(Context &ctx) {
   assert(function_ && "No function has been compiled");
   // TODO call runtime functions from EE instead of in the compiled function.
   // copyFunctionToDevice()
+  // copyConstantsToDevice()
   // allocateMutableBuffersOnDevice()
-  // copyMutablesToDevice(ctx)
-  // copyMutablesFromDevice(ctx)
+  // copyInputsToDevice(ctx)
+  // copyOutputsFromDevice(ctx)
   // freeAllocations()
   // We are working toward moving memory allocation and initialization to
   // runtime. As an intermediate the runtime functions are being called within


### PR DESCRIPTION
*Description*: Move OpenCL memory allocation to runtime. This is in support of #1904. 
*Testing*: Ran ninja test all pass. run.sh --iterations=10 -opencl -time. Accuracy is the same as master now. Time is almost identical for all except resnet 50. 
Master:
Wall time per iteration (s): 0.1335
   ---User Time---   --System Time--   --User+System--   ---Wall Time---  --- Name ---
   1.1925 (100.0%)   0.1420 (100.0%)   1.3345 (100.0%)   1.3350 (100.0%)  Infer
   1.1925 (100.0%)   0.1420 (100.0%)   1.3345 (100.0%)   1.3350 (100.0%)  Total
Wall time per iteration (s): 0.4013
Current Branch:
Wall time per iteration (s): 0.1628
   ---User Time---   --System Time--   --User+System--   ---Wall Time---  --- Name ---
   0.8187 (100.0%)   0.1483 (100.0%)   0.9670 (100.0%)   1.6282 (100.0%)  Infer
   0.8187 (100.0%)   0.1483 (100.0%)   0.9670 (100.0%)   1.6282 (100.0%)  Total
Wall time per iteration (s): 0.7370

*Documentation*: N/A
Progress on #1904 
