### PR TITLE
Fix memory allocation issue when we don't have constant weights

### DIFF
--- a/lib/Backends/CPU/AllocationsInfo.cpp
+++ b/lib/Backends/CPU/AllocationsInfo.cpp
@@ -82,9 +82,13 @@ void AllocationsInfo::allocateWeightVars(const IRFunction *F) {
 }
 
 void AllocationsInfo::collectConstants(const IRFunction *F) {
-
   // At compile time condense constants to a single block of memory.
-  // This allows the graph to go away after compile time.
+  // This allows the graph to go away after compile time. If we don't have
+  // constant weights, do nothing.
+  if (constantWeightVarsMemSize_ == 0) {
+    return;
+  }
+
   baseConstantWeightVarsStore_ =
       (uint8_t *)alignedAlloc(constantWeightVarsMemSize_, TensorAlignment);
   for (auto &v : F->getGraph()->getParent()->getConstants()) {


### PR DESCRIPTION
*Description*:
If we don't have constant weights, previous behavior will still asking to allocate for a 0-sized memory, which fails the alignment check when used with jemalloc. This fixes it by not doing any processing if we don't have constant weights. 
*Testing*:
Unit tests. 

*Documentation*:
[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
