### PR TITLE
[memory leak] Fix memory leak when parsing onnx model

### DIFF
--- a/lib/Importer/ONNXIFIModelLoader.cpp
+++ b/lib/Importer/ONNXIFIModelLoader.cpp
@@ -46,9 +46,9 @@ void ONNXIFIModelLoader::loadInputs(ONNX_NAMESPACE::GraphProto &net) {
       continue;
     }
 
-    Tensor *T = new Tensor();
-    setTensorType(in.type(), T);
-    Placeholder *var = createAndRegisterPlaceholder(in.name(), &T->getType());
+    Tensor T;
+    setTensorType(in.type(), &T);
+    Placeholder *var = createAndRegisterPlaceholder(in.name(), &T.getType());
     onnxNameToInputVars_.try_emplace(in.name(), var);
   }
 }


### PR DESCRIPTION
*Description*:
Allocate tensor on a stack and fix memory leak when parsing.

*Testing*:
Unit tests. The leak itself should be handled by ASAN on fbcode run.

*Documentation*:
N/A

cc: @yinghai  
