### PR TITLE
Fix overflow of Sigmoid in CPU Backend

### DIFF
--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -746,8 +746,8 @@ int8_t libjit_elementselect_kernel_i8(size_t idx, const int8_t *cond,
 }
 
 DEFINE_DATA_PARALLEL_KERNEL_FUNC(libjit_sigmoid_kernel_f) {
-  float e = expf(LHS[idx]);
-  return e / (e + 1);
+  float e = expf(-LHS[idx]);
+  return 1 / (e + 1);
 }
 DEFINE_DATA_PARALLEL_KERNEL_WITH_IMM_OPERAND(libjit_element_maxsplat_kernel_f,
                                              float, MAX(LHS[idx], val))
@@ -1287,8 +1287,8 @@ void libjit_softmax_grad_f(float *inG, float *outW, const size_t *selectedW,
 
 void libjit_sigmoid_f(const float *inW, float *outW, size_t numElem) {
   for (size_t i = 0; i < numElem; i++) {
-    float e = expf(inW[i]);
-    outW[i] = e / (e + 1);
+    float e = expf(-inW[i]);
+    outW[i] = 1 / (e + 1);
   }
 }
 


### PR DESCRIPTION
*Description*:
Previous CPU backend implementation of Sigmoid does `e^x/(e^x + 1)` which is prone to overflow. This PR uses `1/(1 + e^{-x})`. 
*Testing*:
Added a unit test. Without this fix, it will fail. 
*Documentation*:
N/A