### PR TITLE
[fix] Do not allocate memory when size is 0 for CPU backend.

### DIFF
--- a/lib/Backends/CPU/CPUFunction.cpp
+++ b/lib/Backends/CPU/CPUFunction.cpp
@@ -28,11 +28,15 @@ CPUFunction::CPUFunction(std::unique_ptr<llvm::orc::GlowJIT> JIT,
 CPUFunction::~CPUFunction() { alignedFree(runtimeBundle_.constants); }
 
 void CPUFunction::allocateMutableBuffersOnDevice() {
-  baseActivationsAddress_ = (uint8_t *)alignedAlloc(
-      runtimeBundle_.activationsMemSize, TensorAlignment);
+  if (runtimeBundle_.activationsMemSize != 0) {
+    baseActivationsAddress_ = (uint8_t *)alignedAlloc(
+        runtimeBundle_.activationsMemSize, TensorAlignment);
+  }
 
-  baseMutableWeightVarsAddress_ = (uint8_t *)alignedAlloc(
-      runtimeBundle_.mutableWeightVarsMemSize, TensorAlignment);
+  if (runtimeBundle_.mutableWeightVarsMemSize != 0) {
+    baseMutableWeightVarsAddress_ = (uint8_t *)alignedAlloc(
+        runtimeBundle_.mutableWeightVarsMemSize, TensorAlignment);
+  }
 }
 
 void CPUFunction::copyInputsToDevice(Context &ctx) {
@@ -64,8 +68,13 @@ void CPUFunction::copyOutputsFromDevice(Context &ctx) {
 }
 
 void CPUFunction::freeAllocations() {
-  alignedFree(baseMutableWeightVarsAddress_);
-  alignedFree(baseActivationsAddress_);
+  if (baseMutableWeightVarsAddress_) {
+    alignedFree(baseMutableWeightVarsAddress_);
+  }
+
+  if (baseActivationsAddress_) {
+    alignedFree(baseActivationsAddress_);
+  }
 }
 
 void CPUFunction::execute(Context &ctx) {

--- a/lib/Backends/CPU/CPUFunction.h
+++ b/lib/Backends/CPU/CPUFunction.h
@@ -30,9 +30,9 @@ class CPUFunction final : public CompiledFunction {
   /// runtimeBundle contains symbol offsets and allocation sizes.
   runtime::RuntimeBundle runtimeBundle_;
   /// Base address for Activations memory block.
-  uint8_t *baseActivationsAddress_;
+  uint8_t *baseActivationsAddress_{};
   /// Base address for Mutable weights memory block, Inputs and Outputs.
-  uint8_t *baseMutableWeightVarsAddress_;
+  uint8_t *baseMutableWeightVarsAddress_{};
 
 public:
   /// Ctor.


### PR DESCRIPTION
*Description*:
In cases when we need not allocate memory we just bail.

```
grep -ir 'alignedAlloc' lib/
lib//Backends/CPU/AllocationsInfo.cpp:      (uint8_t *)alignedAlloc(constantWeightVarsMemSize_, TensorAlignment);
lib//Backends/CPU/CPUFunction.cpp:    baseActivationsAddress_ = (uint8_t *)alignedAlloc(
lib//Backends/CPU/CPUFunction.cpp:    baseMutableWeightVarsAddress_ = (uint8_t *)alignedAlloc(
```
This should be enough to get going.

*Testing*:
Unit tests + fbcode internal tests.

*Documentation*:
n/a

cc: @yinghai

