### PR TITLE
[interpreter] Implement i8 quantized SparseLengthsWeightedSum

### DIFF
--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -63,6 +63,7 @@ bool Interpreter::isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const {
     case Kinded::Kind::SelectNodeKind:
     case Kinded::Kind::SigmoidNodeKind:
     case Kinded::Kind::SliceNodeKind:
+    case Kinded::Kind::SparseLengthsWeightedSumNodeKind:
     case Kinded::Kind::SubNodeKind:
     case Kinded::Kind::TanhNodeKind:
     case Kinded::Kind::TileNodeKind:

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -177,6 +177,8 @@ private:
   template <typename ElemTy>
   void fwdLengthsSumInst_FloatImpl(const LengthsSumInst *I);
 
+  void
+  fwdSparseLengthsWeightedSumInst_I8Impl(const SparseLengthsWeightedSumInst *I);
   template <typename ElemTy>
   void fwdSparseLengthsWeightedSumInst_FloatImpl(
       const SparseLengthsWeightedSumInst *I);

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -1956,7 +1956,7 @@ void InterpreterFunction::fwdSparseLengthsWeightedSumInst_I8Impl(
 
   size_t curIdx = 0;
   for (size_t i = 0; i < segments; i++) {
-    std::vector<float> accum(lineSize);
+    std::vector<float> accum(lineSize, 0.0f);
     for (size_t j = 0; j < LH.raw(i); j++) {
       float weight = dequantize(WH.raw(curIdx), TQP(weights));
       size_t offsetIn = IH.raw(curIdx) * lineSize;

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -603,6 +603,7 @@ void SparseLengthsWeightedSumNode::verify() const {
          "Indices must have index type");
   assert(getLengths().getElementType() == ElemKind::Int64ITy &&
          "Lengths must have index type");
+  assert(getData().dims().size() > 0 && "Data must have at least 1 dimension");
   assert(getIndices().dims().size() == 1 && "Indices must be 1D vector");
   assert(getLengths().dims().size() == 1 && "Lengths must be 1D vector");
   assert(getWeights().dims().size() == 1 && "Weights must be 1D vector");

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -119,6 +119,11 @@ protected:
       auto *SMN = cast<SoftMaxNode>(&node);
       return SMN->getInput().getElementType() == ElemKind::FloatTy;
     }
+    case Kinded::Kind::SparseLengthsWeightedSumNodeKind: {
+      auto *SLS = cast<SparseLengthsWeightedSumNode>(&node);
+      return (SLS->getData().getElementType() == ElemKind::FloatTy) &&
+             (SLS->getWeights().getElementType() == ElemKind::FloatTy);
+    }
     default:
       // Let the general procedure handle this node kind.
       break;


### PR DESCRIPTION
*Description*: Conservative interpreter support.  Dequantize the inputs to float, accumulate as floats (hence the `std::vector<float>` to hold the line-sized accumulator), then quantize the output.
*Testing*: New tests.  I was lazy and duplicated the existing FP tests :-/.
*Documentation*: N/A


