### PR TITLE
[runtime] Moved context use to runtime for Interpreter Backend

### DIFF
--- a/include/glow/Backends/CompiledFunction.h
+++ b/include/glow/Backends/CompiledFunction.h
@@ -30,6 +30,8 @@ struct RuntimeSymbolInfo {
   size_t size;
   /// Offset in bytes from the base address.
   size_t offset;
+  /// Type of symbol.
+  Type type;
 };
 /// Runtime Bundle
 /// Contains the information needed to be passed forward from compile time to

--- a/lib/Backends/Interpreter/CMakeLists.txt
+++ b/lib/Backends/Interpreter/CMakeLists.txt
@@ -6,6 +6,8 @@ target_link_libraries(Interpreter
                       PRIVATE
                         Base
                         Graph
+                        CodeGen
+                        BackendUtils
                         IR
                         Optimizer
                         QuantizationBase)


### PR DESCRIPTION
[runtime] Moved context use to runtime for Interpreter Backend

*Description*: Migrated use of passed in context from compile to execute for Interpreter. This is work on #1904.
*Testing*: Ninja test all pass. run.sh --iterations=10 -interpreter -time looks good with no significant time difference.
*Documentation*: N/A
Progress on #1904

