### PR TITLE
[easy] Clean up temporary files

### DIFF
--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -250,6 +250,7 @@ void Module::dumpDAG() {
   llvm::SmallString<64> dotPath;
   llvm::sys::fs::createTemporaryFile("dotty_graph_dump", "dot", dotPath);
   dumpDAG(dotPath);
+  llvm::sys::fs::remove(dotPath);
 }
 
 void Module::dumpDAG(llvm::StringRef dotFilename) {
@@ -2177,6 +2178,7 @@ void Function::dumpDAG() {
   llvm::SmallString<64> dotPath;
   llvm::sys::fs::createTemporaryFile("dotty_graph_dump", "dot", dotPath);
   dumpDAG(dotPath);
+  llvm::sys::fs::remove(dotPath);
 }
 
 void Function::dumpDAG(llvm::StringRef dotFilename) {

--- a/tests/unittests/quantizationTest.cpp
+++ b/tests/unittests/quantizationTest.cpp
@@ -57,7 +57,7 @@ void testSerialization(const std::vector<NodeQuantizationInfo> &expected) {
   serializeToYaml(filePath, expected);
   std::vector<NodeQuantizationInfo> deserialized =
       deserializeFromYaml(filePath);
-
+  llvm::sys::fs::remove(filePath);
   EXPECT_EQ(expected, deserialized);
 }
 


### PR DESCRIPTION
*Description*: We use `llvm::sys::fs::createTemporaryFile` but don't always clean up afterwards.  Fix it!
*Testing*: `ninja check`
*Documentation*: N/A
Fixes #1982 
