### PR TITLE
Use Int32ITy for Lengths input of Sparse matrix operators

### DIFF
--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -318,6 +318,9 @@ llvm::Value *LLVMIRGen::emitValueAddress(llvm::IRBuilder<> &builder,
   case ElemKind::Int64ITy:
     T = llvm::Type::getInt64PtrTy(ctx_);
     break;
+  case ElemKind::Int32ITy:
+    T = llvm::Type::getInt32PtrTy(ctx_);
+    break;
   default:
     llvm_unreachable("Unimplemented");
     break;

--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -909,9 +909,9 @@ void libjit_scatterassign_i8(int8_t *data, const size_t *indices,
   libjit_scatterassign(data, indices, slices, numIndices, sliceSize);
 }
 
-void libjit_lengths_to_ranges_u(size_t *ranges, const size_t *lengths,
-                                size_t size) {
-  size_t offset = 0;
+void libjit_lengths_to_ranges_i32(int32_t *ranges, const int32_t *lengths,
+                                  size_t size) {
+  int32_t offset = 0;
   for (size_t i = 0; i < size; i++) {
     auto length = lengths[i];
     ranges[i * 2] = offset;
@@ -922,12 +922,12 @@ void libjit_lengths_to_ranges_u(size_t *ranges, const size_t *lengths,
 
 void libjit_sparse_lengths_weighted_sum_f(float *dest, float *data,
                                           float *weights, size_t *indices,
-                                          size_t *lengths, size_t segments,
+                                          int32_t *lengths, size_t segments,
                                           size_t lineSize) {
   memset(dest, 0, segments * lineSize * sizeof(float));
   size_t curIndex = 0;
   for (size_t i = 0; i < segments; i++) {
-    for (size_t j = 0; j < lengths[i]; j++) {
+    for (int32_t j = 0; j < lengths[i]; j++) {
       float weight = weights[curIndex];
       size_t line = indices[curIndex];
       for (size_t k = 0; k < lineSize; k++) {
@@ -954,16 +954,16 @@ void libjit_sparse_to_dense_f(float *dest, const size_t *indices,
   }
 }
 
-void libjit_lengths_sum_f(float *dest, const float *data, const size_t *lengths,
-                          size_t destSize, size_t lengthsSize,
-                          size_t sliceSize) {
+void libjit_lengths_sum_f(float *dest, const float *data,
+                          const int32_t *lengths, size_t destSize,
+                          size_t lengthsSize, size_t sliceSize) {
   memset(dest, 0, destSize * sizeof(float));
 
   size_t offsetOut = 0;
   size_t offsetIn = 0;
 
   for (size_t i = 0; i < lengthsSize; ++i) {
-    for (size_t j = 0; j < lengths[i]; ++j) {
+    for (int32_t j = 0; j < lengths[i]; ++j) {
       for (size_t k = 0; k < sliceSize; ++k) {
         dest[offsetOut + k] += data[offsetIn + k];
       }

--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -677,6 +677,7 @@ DEFINE_DATA_PARALLEL_KERNEL(libjit_elementmin_kernel_f, float,
 DEFINE_DATA_PARALLEL_KERNEL(libjit_copy_kernel_f, float, LHS[idx])
 DEFINE_DATA_PARALLEL_KERNEL(libjit_copy_kernel_u, size_t, LHS[idx])
 DEFINE_DATA_PARALLEL_KERNEL(libjit_copy_kernel_i8, int8_t, LHS[idx])
+DEFINE_DATA_PARALLEL_KERNEL(libjit_copy_kernel_i32, int32_t, LHS[idx])
 DEFINE_DATA_PARALLEL_KERNEL(libjit_element_cmp_lte_kernel_f, float,
                             LHS[idx] <= RHS[idx] ? 1.0 : 0.0)
 DEFINE_DATA_PARALLEL_KERNEL(libjit_element_cmp_eq_kernel_u, size_t,

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -1932,7 +1932,7 @@ void InterpreterFunction::fwdSparseLengthsWeightedSumInst_I8Impl(
   out->zero();
 
   auto IH = indices->getHandle<int64_t>();
-  auto LH = lengths->getHandle<int64_t>();
+  auto LH = lengths->getHandle<int32_t>();
 
   size_t segments = lengths->dims()[0];
   size_t totalLength = 0;
@@ -1957,7 +1957,7 @@ void InterpreterFunction::fwdSparseLengthsWeightedSumInst_I8Impl(
   size_t curIdx = 0;
   for (size_t i = 0; i < segments; i++) {
     std::vector<float> accum(lineSize, 0.0f);
-    for (size_t j = 0; j < LH.raw(i); j++) {
+    for (int32_t j = 0; j < LH.raw(i); j++) {
       float weight = dequantize(WH.raw(curIdx), TQP(weights));
       size_t offsetIn = IH.raw(curIdx) * lineSize;
       for (size_t k = 0; k < lineSize; k++) {

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -1849,7 +1849,7 @@ void InterpreterFunction::fwdLengthsSumInst_FloatImpl(const LengthsSumInst *I) {
 
   out->zero();
 
-  auto LH = lengths->getHandle<int64_t>();
+  auto LH = lengths->getHandle<int32_t>();
 
   size_t segments = lengths->dims()[0];
   size_t sliceSize = data->size() / data->dims()[0];
@@ -1860,7 +1860,7 @@ void InterpreterFunction::fwdLengthsSumInst_FloatImpl(const LengthsSumInst *I) {
   size_t offsetIn = 0;
   size_t offsetOut = 0;
   for (size_t i = 0; i < segments; i++) {
-    for (size_t j = 0, e = LH.raw(i); j < e; j++) {
+    for (int32_t j = 0, e = LH.raw(i); j < e; j++) {
       for (size_t k = 0; k < sliceSize; k++) {
         OH.raw(offsetOut + k) += DH.raw(offsetIn + k);
       }
@@ -1892,7 +1892,7 @@ void InterpreterFunction::fwdSparseLengthsWeightedSumInst_FloatImpl(
   out->zero();
 
   auto IH = indices->getHandle<int64_t>();
-  auto LH = lengths->getHandle<int64_t>();
+  auto LH = lengths->getHandle<int32_t>();
 
   size_t segments = lengths->dims()[0];
   size_t totalLength = 0;
@@ -1982,9 +1982,9 @@ void InterpreterFunction::fwdSparseLengthsWeightedSumInst(
 }
 
 void InterpreterFunction::fwdLengthsToRangesInst(const LengthsToRangesInst *I) {
-  auto ranges = getTensor(I->getDest())->getHandle<int64_t>();
-  auto lengths = getTensor(I->getLengths())->getHandle<int64_t>();
-  int64_t offset = 0;
+  auto ranges = getTensor(I->getDest())->getHandle<int32_t>();
+  auto lengths = getTensor(I->getLengths())->getHandle<int32_t>();
+  int32_t offset = 0;
   for (size_t i = 0; i < lengths.dims()[0]; i++) {
     auto length = lengths.at({i});
     ranges.at({i, 0}) = offset;

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -601,7 +601,7 @@ void SparseLengthsWeightedSumNode::verify() const {
          "Mismatched element types");
   assert(getIndices().getElementType() == ElemKind::Int64ITy &&
          "Indices must have index type");
-  assert(getLengths().getElementType() == ElemKind::Int64ITy &&
+  assert(getLengths().getElementType() == ElemKind::Int32ITy &&
          "Lengths must have index type");
   assert(getData().dims().size() > 0 && "Data must have at least 1 dimension");
   assert(getIndices().dims().size() == 1 && "Indices must be 1D vector");
@@ -614,8 +614,7 @@ void SparseLengthsWeightedSumNode::verify() const {
 void LengthsToRangesNode::verify() const {
   assert(getResult().getElementType() == getLengths().getElementType() &&
          "Mismatched element types");
-  // TODO: Lengths should be Int32ITy once that type is implemented.
-  assert(getLengths().getElementType() == ElemKind::Int64ITy &&
+  assert(getLengths().getElementType() == ElemKind::Int32ITy &&
          "Lengths must have index type");
   assert(getLengths().dims().size() == 1 && "Lengths must be 1D vector");
   assert(getResult().dims().size() == 2 && "Ranges must be 2D vector");

--- a/lib/Importer/ONNXIFIModelLoader.cpp
+++ b/lib/Importer/ONNXIFIModelLoader.cpp
@@ -34,6 +34,9 @@ static void setTensorType(const ONNX_NAMESPACE::TypeProto &in, Tensor *T) {
   } else if (in.tensor_type().elem_type() ==
              ONNX_NAMESPACE::TensorProto::INT64) {
     T->reset(ElemKind::Int64ITy, dim);
+  } else if (in.tensor_type().elem_type() ==
+             ONNX_NAMESPACE::TensorProto::INT32) {
+    T->reset(ElemKind::Int32ITy, dim);
   } else {
     assert(false && "Only float and index tensors are supported");
   }

--- a/tests/models/onnxModels/lengths_to_ranges.onnxtxt
+++ b/tests/models/onnxModels/lengths_to_ranges.onnxtxt
@@ -11,7 +11,7 @@ graph {
     name: "lengths"
     type {
       tensor_type {
-        elem_type: INT64
+        elem_type: INT32
         shape {
           dim {
             dim_value: 4
@@ -24,7 +24,7 @@ graph {
     name: "ranges"
     type {
       tensor_type {
-        elem_type: INT64
+        elem_type: INT32
         shape {
           dim {
             dim_value: 4

--- a/tests/models/onnxModels/sparseLengthsSum.onnxtxt
+++ b/tests/models/onnxModels/sparseLengthsSum.onnxtxt
@@ -1,28 +1,39 @@
 ir_version: 3
-producer_name: "backend-test"
+producer_name: "caffe2"
 graph {
   node {
     input: "data"
+    input: "indices"
     input: "lengths"
-    output: "result"
-    op_type: "LengthsSum"
+    output: "out"
+    name: ""
+    op_type: "SparseLengthsSum"
   }
-  name: "lengths_sum"
   input {
-    name: "data"
+    name: "weights"
     type {
       tensor_type {
         elem_type: FLOAT
         shape {
           dim {
-            dim_value: 10
+            dim_value: 2
           }
-	  dim {
-	    dim_value: 2
-	  }
-	  dim {
-	    dim_value: 3
-	  }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "indices"
+    type {
+      tensor_type {
+        elem_type: INT64
+        shape {
+          dim {
+            dim_value: 2
+          }
         }
       }
     }
@@ -34,32 +45,30 @@ graph {
         elem_type: INT32
         shape {
           dim {
-            dim_value: 5 
+            dim_value: 2
           }
-	}
+        }
       }
     }
   }
   output {
-    name: "result"
+    name: "out"
     type {
       tensor_type {
         elem_type: FLOAT
         shape {
           dim {
-            dim_value: 5
-          }
-          dim {
             dim_value: 2
           }
-	  dim {
-	    dim_value: 3
-	  }
+          dim {
+            dim_value: 1
+          }
         }
       }
     }
   }
 }
 opset_import {
-  version: 9
+  domain: ""
+  version: 7
 }

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -3756,7 +3756,7 @@ TEST_P(InterpOnly, SparseLengthsSumI8) {
   auto *indices =
       mod_.createPlaceholder(ElemKind::Int64ITy, {8}, "indices", false);
   auto *lengths =
-      mod_.createPlaceholder(ElemKind::Int64ITy, {5}, "lengths", false);
+      mod_.createPlaceholder(ElemKind::Int32ITy, {5}, "lengths", false);
 
   ctx_.allocate(data)->getHandle<int8_t>() = {
       11, 13, 24, 35, 46, 58,
@@ -3764,7 +3764,7 @@ TEST_P(InterpOnly, SparseLengthsSumI8) {
   ctx_.allocate(indices)->getHandle<int64_t>() = {
       2, 0, 1, 2, 0, 0, 0, 0,
   };
-  ctx_.allocate(lengths)->getHandle<int64_t>() = {
+  ctx_.allocate(lengths)->getHandle<int32_t>() = {
       2, 0, 2, 1, 3,
   };
 
@@ -3852,7 +3852,7 @@ TEST_P(InterpOnly, SparseLengthsWeightedSumI8) {
   auto *indices =
       mod_.createPlaceholder(ElemKind::Int64ITy, {8}, "indices", false);
   auto *lengths =
-      mod_.createPlaceholder(ElemKind::Int64ITy, {4}, "lengths", false);
+      mod_.createPlaceholder(ElemKind::Int32ITy, {4}, "lengths", false);
 
   ctx_.allocate(data)->getHandle<int8_t>() = {
       4,
@@ -3865,7 +3865,7 @@ TEST_P(InterpOnly, SparseLengthsWeightedSumI8) {
   ctx_.allocate(indices)->getHandle<int64_t>() = {
       1, 0, 2, 0, 1, 2, 2, 0,
   };
-  ctx_.allocate(lengths)->getHandle<int64_t>() = {
+  ctx_.allocate(lengths)->getHandle<int32_t>() = {
       3,
       0,
       3,

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -3665,11 +3665,11 @@ TEST_P(InterpAndCPU, LengthsSum) {
   */
   auto *data = mod_.createPlaceholder(ElemKind::FloatTy, {6, 2}, "data", false);
   auto *lengths =
-      mod_.createPlaceholder(ElemKind::Int64ITy, {4}, "lengths", false);
+      mod_.createPlaceholder(ElemKind::Int32ITy, {4}, "lengths", false);
 
   ctx_.allocate(data)->getHandle() = {1.0f, 1.2f, 2.3f, 3.4f, 4.5f, 3.7f,
                                       3.0f, 2.9f, 1.1f, 1.4f, 2.8f, 8.4f};
-  ctx_.allocate(lengths)->getHandle<int64_t>() = {2, 0, 3, 1};
+  ctx_.allocate(lengths)->getHandle<int32_t>() = {2, 0, 3, 1};
 
   auto R = F_->createLengthsSum("LS", data, lengths);
   auto *S = F_->createSave("save", R);
@@ -3706,7 +3706,7 @@ TEST_P(InterpAndCPU, SparseLengthsSum) {
   auto *indices =
       mod_.createPlaceholder(ElemKind::Int64ITy, {8}, "indices", false);
   auto *lengths =
-      mod_.createPlaceholder(ElemKind::Int64ITy, {5}, "lengths", false);
+      mod_.createPlaceholder(ElemKind::Int32ITy, {5}, "lengths", false);
 
   ctx_.allocate(data)->getHandle() = {
       1.0f, 1.2f, 2.3f, 3.4f, 4.5f, 5.7f,
@@ -3714,7 +3714,7 @@ TEST_P(InterpAndCPU, SparseLengthsSum) {
   ctx_.allocate(indices)->getHandle<int64_t>() = {
       2, 0, 1, 2, 0, 0, 0, 0,
   };
-  ctx_.allocate(lengths)->getHandle<int64_t>() = {
+  ctx_.allocate(lengths)->getHandle<int32_t>() = {
       2, 0, 2, 1, 3,
   };
 
@@ -3797,7 +3797,7 @@ TEST_P(InterpAndCPU, SparseLengthsWeightedSum) {
   auto *indices =
       mod_.createPlaceholder(ElemKind::Int64ITy, {8}, "indices", false);
   auto *lengths =
-      mod_.createPlaceholder(ElemKind::Int64ITy, {4}, "lengths", false);
+      mod_.createPlaceholder(ElemKind::Int32ITy, {4}, "lengths", false);
 
   ctx_.allocate(data)->getHandle() = {
       2.0,
@@ -3810,7 +3810,7 @@ TEST_P(InterpAndCPU, SparseLengthsWeightedSum) {
   ctx_.allocate(indices)->getHandle<int64_t>() = {
       1, 0, 2, 0, 1, 2, 2, 0,
   };
-  ctx_.allocate(lengths)->getHandle<int64_t>() = {
+  ctx_.allocate(lengths)->getHandle<int32_t>() = {
       3,
       0,
       3,
@@ -4494,9 +4494,9 @@ TEST_P(InterpAndCPU, LengthsToRanges) {
     OUTPUT =  [[0, 1], [1, 3], [4, 0], [4, 2]]
   */
   auto *lengths =
-      mod_.createPlaceholder(ElemKind::Int64ITy, {4}, "lengths", false);
+      mod_.createPlaceholder(ElemKind::Int32ITy, {4}, "lengths", false);
 
-  ctx_.allocate(lengths)->getHandle<int64_t>() = {1, 3, 0, 2};
+  ctx_.allocate(lengths)->getHandle<int32_t>() = {1, 3, 0, 2};
 
   auto R = F_->createLengthsToRanges("LTR", lengths);
   auto *S = F_->createSave("save", R);
@@ -4506,8 +4506,8 @@ TEST_P(InterpAndCPU, LengthsToRanges) {
   EE_.run(ctx_);
 
   Tensor &result = *ctx_.get(S->getPlaceholder());
-  Tensor expected(ElemKind::Int64ITy, {4, 2});
-  expected.getHandle<int64_t>() = {
+  Tensor expected(ElemKind::Int32ITy, {4, 2});
+  expected.getHandle<int32_t>() = {
       0, 1, 1, 3, 4, 0, 4, 2,
   };
 

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -213,7 +213,7 @@ int main(int argc, char **argv) {
       .autoIRGen()
       .autoVerify(VerifyKind::SameElementType, {"Dest", "Data"})
       .autoVerify(VerifyKind::SameElementType,
-                  {"Lengths", "ElemKind::Int64ITy"});
+                  {"Lengths", "ElemKind::Int32ITy"});
 
   BB.newInstr("SparseLengthsWeightedSum")
       .addOperand("Dest", OperandKind::Out)
@@ -226,16 +226,16 @@ int main(int argc, char **argv) {
       .autoVerify(VerifyKind::SameElementType,
                   {"Indices", "ElemKind::Int64ITy"})
       .autoVerify(VerifyKind::SameElementType,
-                  {"Lengths", "ElemKind::Int64ITy"})
+                  {"Lengths", "ElemKind::Int32ITy"})
       .autoVerify(VerifyKind::SameShape, {"Weights", "Indices"});
 
   BB.newInstr("LengthsToRanges")
       .addOperand("Dest", OperandKind::Out)
       .addOperand("Lengths", OperandKind::In)
       .autoIRGen()
-      .autoVerify(VerifyKind::SameElementType, {"Dest", "ElemKind::Int64ITy"})
+      .autoVerify(VerifyKind::SameElementType, {"Dest", "ElemKind::Int32ITy"})
       .autoVerify(VerifyKind::SameElementType,
-                  {"Lengths", "ElemKind::Int64ITy"});
+                  {"Lengths", "ElemKind::Int32ITy"});
 
   /// Converts the given sparse representation into a dense one.
   BB.newInstr("SparseToDense")


### PR DESCRIPTION
*Description*:
`Lengths` for sparse matrix related operators should be `int32` instead of `int64`. We introduced `Int32ITy` a while ago but didn't really use it. This PR fixes that. Affected ops includes `SparseLengths(Weighted)Sum`, `LengthsSum` and `LengthsToRanges`. 

Also fixes Interpreter and CPU backend. 

*Testing*:
unittest. 

*Documentation*:
[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
