### PR TITLE
[loader] Allow for running inference many times before serializing quantization infos

### DIFF
--- a/tools/loader/ImageClassifier.cpp
+++ b/tools/loader/ImageClassifier.cpp
@@ -457,9 +457,11 @@ int main(int argc, char **argv) {
     processAndPrintResults(SMVarT, loader.getFunction()->getName());
   }
 
-  // If profiling the model, serialize the quantization infos now that we have
-  // run inference one or more times. If not profiling, this call does nothing.
-  loader.serializeQuantizationInfos(ctx);
+  // If profiling, generate and serialize the quantization infos now that we
+  // have run inference one or more times to gather the profile.
+  if (profilingGraph()) {
+    loader.generateAndSerializeQuantizationInfos(ctx);
+  }
 
   return 0;
 }

--- a/tools/loader/ImageClassifier.cpp
+++ b/tools/loader/ImageClassifier.cpp
@@ -457,5 +457,9 @@ int main(int argc, char **argv) {
     processAndPrintResults(SMVarT, loader.getFunction()->getName());
   }
 
+  // If profiling the model, serialize the quantization infos now that we have
+  // run inference one or more times. If not profiling, this call does nothing.
+  loader.serializeQuantizationInfos(ctx);
+
   return 0;
 }

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -301,7 +301,9 @@ void Loader::runInference(Context &ctx) {
                                   timer.getTotalTime().getWallTime() /
                                       iterationsOpt);
   }
+}
 
+void Loader::serializeQuantizationInfos(Context &ctx) {
   if (!dumpProfileFileOpt.empty()) {
     std::vector<NodeQuantizationInfo> QI =
         quantization::generateNodeQuantizationInfos(ctx, F_,

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -155,6 +155,8 @@ llvm::StringRef Loader::getModelOptPath() {
 
 bool glow::emittingBundle() { return !emitBundle.empty(); }
 
+bool glow::profilingGraph() { return !dumpProfileFileOpt.empty(); }
+
 static bool commandLineIsInvalid() {
   if (!dumpProfileFileOpt.empty() && !loadProfileFileOpt.empty()) {
     llvm::errs() << "Loader: the -" << dumpProfileFileOpt.ArgStr << " and -"
@@ -303,13 +305,12 @@ void Loader::runInference(Context &ctx) {
   }
 }
 
-void Loader::serializeQuantizationInfos(Context &ctx) {
-  if (!dumpProfileFileOpt.empty()) {
-    std::vector<NodeQuantizationInfo> QI =
-        quantization::generateNodeQuantizationInfos(ctx, F_,
-                                                    quantizationSchema);
-    serializeToYaml(dumpProfileFileOpt, QI);
-  }
+void Loader::generateAndSerializeQuantizationInfos(Context &ctx) {
+  assert(!dumpProfileFileOpt.empty() &&
+         "Filename to dump serialized profile to must not be empty.");
+  std::vector<NodeQuantizationInfo> QI =
+      quantization::generateNodeQuantizationInfos(ctx, F_, quantizationSchema);
+  serializeToYaml(dumpProfileFileOpt, QI);
 }
 
 Loader::Loader(int argc, char **argv) {

--- a/tools/loader/Loader.h
+++ b/tools/loader/Loader.h
@@ -25,6 +25,9 @@ class Tensor;
 /// \return true if emit bundle mode is enabled.
 bool emittingBundle();
 
+/// \return true if profiling the graph.
+bool profilingGraph();
+
 /// Driver class for loading, compiling, and running inference for ONNX and
 /// Caffe2 models.
 class Loader {
@@ -67,11 +70,11 @@ public:
   /// tensors include quantization profile guided information.
   void runInference(Context &ctx);
 
-  /// Serializes the quantization infos generated after generating a profile by
-  /// running inference one or more times. \p ctx is the context that binds
+  /// Generates and serializes the quantization infos after gathering a profile
+  /// by running inference one or more times. \p ctx is the context that binds
   /// specific placeholders to concrete tensors. The concrete tensors include
   /// quantization profile guided information.
-  void serializeQuantizationInfos(Context &ctx);
+  void generateAndSerializeQuantizationInfos(Context &ctx);
 
   /// Create the Loader driver object, and parse/verify the command line
   /// parameters.

--- a/tools/loader/Loader.h
+++ b/tools/loader/Loader.h
@@ -67,6 +67,12 @@ public:
   /// tensors include quantization profile guided information.
   void runInference(Context &ctx);
 
+  /// Serializes the quantization infos generated after generating a profile by
+  /// running inference one or more times. \p ctx is the context that binds
+  /// specific placeholders to concrete tensors. The concrete tensors include
+  /// quantization profile guided information.
+  void serializeQuantizationInfos(Context &ctx);
+
   /// Create the Loader driver object, and parse/verify the command line
   /// parameters.
   Loader(int argc, char **argv);

--- a/tools/loader/ModelRunner.cpp
+++ b/tools/loader/ModelRunner.cpp
@@ -58,9 +58,11 @@ int main(int argc, char **argv) {
     // Print out the result of output operator.
     outputT->getHandle().dump();
 
-    // If profiling the model, serialize the quantization infos now that we have
-    // run inference. If not profiling, this call does nothing.
-    loader.serializeQuantizationInfos(ctx);
+    // If profiling, generate and serialize the quantization infos now that we
+    // have run inference to gather the profile.
+    if (profilingGraph()) {
+      loader.generateAndSerializeQuantizationInfos(ctx);
+    }
   }
 
   return 0;

--- a/tools/loader/ModelRunner.cpp
+++ b/tools/loader/ModelRunner.cpp
@@ -57,6 +57,10 @@ int main(int argc, char **argv) {
 
     // Print out the result of output operator.
     outputT->getHandle().dump();
+
+    // If profiling the model, serialize the quantization infos now that we have
+    // run inference. If not profiling, this call does nothing.
+    loader.serializeQuantizationInfos(ctx);
   }
 
   return 0;

--- a/tools/loader/TextTranslator.cpp
+++ b/tools/loader/TextTranslator.cpp
@@ -355,5 +355,9 @@ int main(int argc, char **argv) {
                                       ctx.get(outputPrevIndexBeamList));
   }
 
+  // If profiling the model, serialize the quantization infos now that we have
+  // run inference. If not profiling, this call does nothing.
+  loader.serializeQuantizationInfos(ctx);
+
   return 0;
 }


### PR DESCRIPTION
*Description*: We may want to quantize models given many inputs that we do not want to or can't fit in a single batch. This allows for running inference many times to gather a profile on a larger set of inputs.

*Testing*: Manually ran the loaders to make sure it works as expected.

*Documentation*: N/A