### PR TITLE
[Verifier] Switch the node verifier from assert to returning bool for the nodes

### DIFF
--- a/include/glow/Graph/Node.h
+++ b/include/glow/Graph/Node.h
@@ -130,7 +130,8 @@ public:
   void visit(const Node *parent, NodeWalker *visitor) const;
 
   /// Verify node.
-  void verify() const;
+  /// \returns True if the node is valid. False otherwise.
+  bool verify() const;
 
   /// Replace all uses of this node with null. This method is used by the
   /// destruction sequence. When the node is deleted we need to unregister all

--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -101,7 +101,7 @@ public:
 
   llvm::hash_code getHash() const;
 
-  void verify() const;
+  bool verify() const;
 };
 
 /// Placeholder nodes are unbound-storage. The content tensors are attached to

--- a/include/glow/Graph/VerifierHelper.h
+++ b/include/glow/Graph/VerifierHelper.h
@@ -1,0 +1,186 @@
+/**
+ * Copyright (c) 2018-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/// This file describes the API used for graph verification.
+/// These are mainly helper class/functions for printing errors and the related
+/// context and doing checks.
+#ifndef GLOW_GRAPH_VERIFIERHELPER_H
+#define GLOW_GRAPH_VERIFIERHELPER_H
+
+#include "glow/Base/Type.h"
+#include "glow/Graph/Graph.h"
+#include "glow/Graph/Node.h"
+#include "glow/Support/Support.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace glow {
+
+//===----------------------------------------------------------------------===//
+//                       Printing
+//===----------------------------------------------------------------------===//
+
+/// Default reportContext function used to print \p a.
+/// The default implementation relies on operator<< being available.
+/// The actual printing is done calling glow::report.
+template <typename Ty> void reportContext(const Ty &a) {
+  std::string storage;
+  llvm::raw_string_ostream stringStream(storage);
+  stringStream << a;
+  report(stringStream.str());
+}
+
+template <typename Ty> void reportContext(const llvm::ArrayRef<Ty> &arrayRef) {
+  bool isFirst = true;
+  report("{");
+  for (auto elt : arrayRef) {
+    if (!isFirst) {
+      report(", ");
+    }
+    isFirst = false;
+    reportContext(elt);
+  }
+  report("}");
+}
+
+void reportContext(ElemKind Ty);
+void reportContext(const ShapeNHWC &shapeNHWC);
+void reportContext(const ShapeNCHW &shapeNCHW);
+void reportContext(const Node *node);
+
+//===----------------------------------------------------------------------===//
+//                       Checks
+//===----------------------------------------------------------------------===//
+
+/// Wrapper around comparison operators.
+/// They are used to specify the behavior of expectCompareTrue
+/// and provide a pretty printer of the operator used when
+/// things fail.
+/// @{
+
+/// Interface that the comparison operator must implement.
+template <typename Ty> struct CompareWithName {
+  virtual ~CompareWithName() {}
+  /// Binary comparison operation.
+  virtual bool operator()(const Ty &a, const Ty &b) const = 0;
+  /// Name of the operator used for pretty printing.
+  virtual llvm::StringRef getCompareName() const = 0;
+};
+
+/// Operator ==.
+template <typename Ty>
+struct CompareOperatorEqual : public CompareWithName<Ty> {
+  bool operator()(const Ty &a, const Ty &b) const override { return a == b; }
+  llvm::StringRef getCompareName() const override { return "Equal"; }
+};
+
+/// Operator >=.
+template <typename Ty>
+struct CompareOperatorGreaterEqual : public CompareWithName<Ty> {
+  bool operator()(const Ty &a, const Ty &b) const override { return a >= b; }
+  llvm::StringRef getCompareName() const override { return "GreaterEqual"; }
+};
+
+/// Operator >.
+template <typename Ty>
+struct CompareOperatorGreaterThan : public CompareWithName<Ty> {
+  bool operator()(const Ty &a, const Ty &b) const override { return a > b; }
+  llvm::StringRef getCompareName() const override { return "GreaterThan"; }
+};
+
+/// Operator <=.
+template <typename Ty>
+struct CompareOperatorLessEqual : public CompareWithName<Ty> {
+  bool operator()(const Ty &a, const Ty &b) const override { return a <= b; }
+  llvm::StringRef getCompareName() const override { return "LessEqual"; }
+};
+/// @}
+
+/// Main API of the verifier.
+/// Check whether \p comp(\p a, \p b) is true.
+/// If that check fails, \p msg is printed out using glow::report
+/// and \p parent (if not nullptr), \p a, and \p b are printed out
+/// using glow::reportContext.
+/// \returns \p comp(\p a, \p b).
+template <typename InputTy>
+bool expectCompareTrue(
+    const char *msg, const InputTy &a, const InputTy &b, const Node *parent,
+    const CompareWithName<InputTy> &comp = CompareOperatorEqual<InputTy>()) {
+  if (comp(a, b)) {
+    return true;
+  }
+  if (parent) {
+    reportContext(parent);
+  }
+  report(msg);
+  report("\nFor comparison `LHS ");
+  report(comp.getCompareName());
+  report(" RHS` with:");
+  report("\nLHS: ");
+  reportContext(a);
+  report("\nRHS: ");
+  reportContext(b);
+  report("\n");
+  return false;
+}
+
+/// Check that the type of the first operand \p A matches the type of the second
+/// operand \p B. \p parent is used to print the context of that check
+/// in case the it fails.
+/// \see expectCompareTrue for more details.
+bool checkSameType(NodeValue A, NodeValue B, const Node *parent);
+
+/// Check that the shape of the first operand \p A matches the shape of the
+/// second operand \p B. \p parent is used to print the context of that check
+/// in case the it fails.
+/// \see expectCompareTrue for more details.
+bool checkSameShape(NodeValue A, NodeValue B, const Node *parent);
+
+/// Check that the element type of the operand \p A matches expected type \p
+/// expected Type. \p parent is used to print the context of that check
+/// in case the it fails.
+/// \see expectCompareTrue for more details.
+bool checkType(NodeValue A, ElemKind expectedType, const Node *parent);
+
+/// Check if \p A and \p B have the same value for isQuantized. \p parent is
+/// used to print the context of that check in case the it fails.
+/// \see expectCompareTrue for more details.
+bool checkSameIsQuantized(const TypeRef A, const TypeRef B, const Node *parent);
+
+/// \return True if \p A is not quantized or has its quantization parameters
+/// match \p scale and \p offset. False otherwise. \p parent is used to print
+/// the context of that check in case the it fails.
+/// \see expectCompareTrue for more details.
+bool checkNotQuantizedOrSameParams(const TypeRef A, float scale, int32_t offset,
+                                   const Node *parent);
+
+/// \return True if \p A is not quantized or matches \p B quantization
+/// parameters. False otherwise.
+/// In particular, this returns false if \p A is quantized and \p B
+/// is not. The opposite is not true.
+/// \p parent is used to print the context of that check
+/// in case the it fails.
+/// \see expectCompareTrue for more details.
+bool checkNotQuantizedOrSameParams(const TypeRef A, const TypeRef B,
+                                   const Node *parent);
+
+/// Check that the type of the first operand \p A matches the type of the second
+/// operand \p B but ignore the actual shape. Use only element type and
+/// quantization parameters in comparison.
+/// \p parent is used to print the context of that check
+/// in case the it fails.
+/// \see expectCompareTrue for more details.
+bool checkTypeIgnoreShape(NodeValue A, NodeValue B, const Node *parent);
+} // namespace glow
+#endif // End of GLOW_GRAPH_VERIFIERHELPER_H.

--- a/include/glow/Support/Support.h
+++ b/include/glow/Support/Support.h
@@ -106,6 +106,10 @@ public:
   operator std::string() { return repr_.str(); }
 };
 
+/// Print \p msg on the error stream.
+void report(const char *msg);
+inline void report(const std::string &str) { report(str.c_str()); }
+inline void report(llvm::StringRef str) { report(str.data()); }
 } // namespace glow
 
 #endif // GLOW_SUPPORT_SUPPORT_H

--- a/lib/Graph/CMakeLists.txt
+++ b/lib/Graph/CMakeLists.txt
@@ -47,7 +47,8 @@ add_library(Graph
             Nodes.cpp
             NodeValue.cpp
             Graph.cpp
-            Grad.cpp)
+            Grad.cpp
+            VerifierHelper.cpp)
 
 target_link_libraries(Graph
                       PUBLIC

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -2395,7 +2395,9 @@ void Function::verify() const {
   for (const auto &N : nodes_) {
     assert(N.getParent() == this &&
            "Node is not linked to the function it belongs");
-    N.verify();
+    bool isValid = N.verify();
+    (void)isValid;
+    assert(isValid && "Found an invalid node");
     // Make sure all the placeholders are at most written once, and that
     // constants are never written to.
     for (size_t idx = 0, e = N.getNumInputs(); idx < e; ++idx) {

--- a/lib/Graph/VerifierHelper.cpp
+++ b/lib/Graph/VerifierHelper.cpp
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2018-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/Graph/VerifierHelper.h"
+
+using namespace glow;
+
+//===----------------------------------------------------------------------===//
+//                       Printing
+//===----------------------------------------------------------------------===//
+
+void glow::reportContext(ElemKind Ty) { report(Type::getElementName(Ty)); }
+
+void glow::reportContext(const ShapeNHWC &shapeNHWC) {
+  report("NHWC: ");
+  reportContext(
+      llvm::makeArrayRef({shapeNHWC.n, shapeNHWC.h, shapeNHWC.w, shapeNHWC.c}));
+}
+
+void glow::reportContext(const ShapeNCHW &shapeNCHW) {
+  report("NCHW: ");
+  reportContext(
+      llvm::makeArrayRef({shapeNCHW.n, shapeNCHW.c, shapeNCHW.h, shapeNCHW.w}));
+}
+
+void glow::reportContext(const Node *node) {
+  report("In '");
+  report(node->getName());
+  report("'");
+  if (node->getParent()) {
+    report(" from '");
+    report(node->getParent()->getName());
+    report("'");
+  }
+  report("\n");
+}
+
+//===----------------------------------------------------------------------===//
+//                       Checks
+//===----------------------------------------------------------------------===//
+
+bool glow::checkSameType(NodeValue A, NodeValue B, const Node *parent) {
+  return expectCompareTrue("Mismatching type", *A.getType(), *B.getType(),
+                           parent);
+}
+
+bool glow::checkSameShape(NodeValue A, NodeValue B, const Node *parent) {
+  return expectCompareTrue("Mismatching dimensions", A.dims(), B.dims(),
+                           parent);
+}
+
+bool glow::checkType(NodeValue A, ElemKind expectedType, const Node *parent) {
+  return expectCompareTrue("Mismatching element type", A.getElementType(),
+                           expectedType, parent);
+}
+
+bool glow::checkSameIsQuantized(const TypeRef A, const TypeRef B,
+                                const Node *parent) {
+  return expectCompareTrue("Mismatching isQuantized", A->isQuantizedType(),
+                           B->isQuantizedType(), parent);
+}
+
+bool glow::checkNotQuantizedOrSameParams(const TypeRef A, float scale,
+                                         int32_t offset, const Node *parent) {
+  if (A->isQuantizedType()) {
+    if (!expectCompareTrue("Mismatching scale", A->getScale(), scale, parent) ||
+        !expectCompareTrue("Mismatching offset", A->getOffset(), offset,
+                           parent)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool glow::checkNotQuantizedOrSameParams(const TypeRef A, const TypeRef B,
+                                         const Node *parent) {
+  if (!B->isQuantizedType()) {
+    return checkSameIsQuantized(A, B, parent);
+  }
+  return checkNotQuantizedOrSameParams(A, B->getScale(), B->getOffset(),
+                                       parent);
+}
+
+bool glow::checkTypeIgnoreShape(NodeValue A, NodeValue B, const Node *parent) {
+  bool isValid = checkType(A, B.getElementType(), parent);
+  isValid &= checkSameIsQuantized(A.getType(), B.getType(), parent);
+  isValid &= checkNotQuantizedOrSameParams(A.getType(), B.getType(), parent);
+  return isValid;
+}

--- a/lib/Support/Support.cpp
+++ b/lib/Support/Support.cpp
@@ -75,4 +75,6 @@ std::string escapeDottyString(const std::string &str) {
   }
   return out;
 }
+
+void report(const char *msg) { errs() << msg; }
 } // namespace glow

--- a/tests/unittests/graphTest.cpp
+++ b/tests/unittests/graphTest.cpp
@@ -1154,6 +1154,7 @@ TEST(Graph, verifyConstantNoWriters) {
 
   EXPECT_DEATH(M.verify(), "");
 }
+#endif /* NDEBUG */
 
 /// Check that the verifier will complain if a constant and its
 /// underlying tensor have mismatching types.
@@ -1163,11 +1164,11 @@ TEST(Graph, verifyConstantTensorTypeMatchesConstantTypeChanged) {
 
   auto *input = M.createConstant(ElemKind::FloatTy, {5}, "input");
   // Fresh constant should verify just fine.
-  input->verify();
+  EXPECT_TRUE(input->verify());
 
   input->setType(0, M.uniqueType(ElemKind::Float16Ty, {5}));
 
-  EXPECT_DEATH(input->verify(), "");
+  EXPECT_FALSE(input->verify());
 }
 
 /// Check that the verifier will complain if a constant and its
@@ -1178,10 +1179,8 @@ TEST(Graph, verifyConstantTensorTypeMatchesTensorTypeChanged) {
 
   auto *input = M.createConstant(ElemKind::FloatTy, {5}, "input");
   // Fresh constant should verify just fine.
-  input->verify();
+  EXPECT_TRUE(input->verify());
   input->getPayload().convertToType(ElemKind::Float16Ty);
 
-  EXPECT_DEATH(input->verify(), "");
+  EXPECT_FALSE(input->verify());
 }
-
-#endif /* NDEBUG */

--- a/tools/ClassGen/Backends/CPU/CPUSpecificNodesVerification.h
+++ b/tools/ClassGen/Backends/CPU/CPUSpecificNodesVerification.h
@@ -15,19 +15,19 @@
  */
 #ifdef GLOW_WITH_CPU
 
-void CPUMaxSplatNode::verify() const {
-  assert(getInput().getType() == getResult().getType() && "Invalid type");
-  assert(getInput().dims() == getResult().dims() && "Invalid shape");
+#include "glow/Graph/VerifierHelper.h"
+
+bool CPUMaxSplatNode::verify() const {
+  return checkSameType(getInput(), getResult(), this);
 }
 
-void CPUConvDKKC8Node::verify() const {
+bool CPUConvDKKC8Node::verify() const {
   ShapeNHWC idim(getInput().getType()->dims());
   ShapeNHWC odim(getResult().getType()->dims());
   auto outSz = calculateConvPoolOutputDims(idim.h, idim.w, getKernels(),
                                            getStrides(), getPads());
   ShapeNHWC exp(idim.n, outSz.first, outSz.second, getBias().dims()[0]);
-  (void)exp;
-  assert(exp == odim && "Invalid output dimensions");
+  return expectCompareTrue("Invalid output dimensions", exp, odim, this);
 }
 
 #endif // GLOW_WITH_CPU

--- a/tools/ClassGen/Backends/OpenCL/OpenCLSpecificNodesVerification.h
+++ b/tools/ClassGen/Backends/OpenCL/OpenCLSpecificNodesVerification.h
@@ -16,17 +16,18 @@
 
 #ifdef GLOW_WITH_OPENCL
 
-void OCLConvolutionNode::verify() const {
+#include "glow/Graph/VerifierHelper.h"
+
+bool OCLConvolutionNode::verify() const {
   ShapeNCHW idim(getInput().getType()->dims());
   ShapeNCHW odim(getResult().getType()->dims());
   auto outSz = calculateConvPoolOutputDims(idim.h, idim.w, getKernels(),
                                            getStrides(), getPads());
   ShapeNCHW exp(idim.n, getBias().dims()[0], outSz.first, outSz.second);
-  (void)exp;
-  assert(exp == odim && "Invalid output dimensions");
+  return expectCompareTrue("Invalid output dimensions", exp, odim, this);
 }
 
-void OCLAvgPoolNode::verify() const {}
+bool OCLAvgPoolNode::verify() const { return true; }
 
-void OCLMaxPoolNode::verify() const {}
+bool OCLMaxPoolNode::verify() const { return true; }
 #endif // GLOW_WITH_OPENCL

--- a/tools/ClassGen/NodeBuilder.cpp
+++ b/tools/ClassGen/NodeBuilder.cpp
@@ -429,7 +429,7 @@ void NodeBuilder::emitNodeClass(std::ostream &os) const {
      << "  llvm::hash_code getHash() const;\n"
      << "  void visit(Node *parent, NodeWalker *visitor);\n"
      << "  Node* clone() const;\n"
-     << "  void verify() const;\n";
+     << "  bool verify() const;\n";
 
   if (!enum_.empty()) {
     os << "  const char *getModeStr() const { return getModeStr(mode_); }\n"


### PR DESCRIPTION
*Description*
The verifier is a valuable tool to validate if an input graph is valid.
Right now, a lot of checks are *not* done in the loader because it knows
the verifier will catch them. However, the verifier does nothing
in release mode and thus we cannot rely on it in that mode.

To be able to use the verifier in release mode, we need to refactor it
so that it does not rely on asserts anymore.

This patch goes in that direction by doing the switch for the classes
related to Node.
Moreover, since the use case from the verifier switches from purely
debugging to error reporting, this patch improves the way error are
reported. In particular, it prints details on the node that fails so
that a potential user doesn't have to debug the compiler to see what
is wrong with the input graph.

E.g., before this patch, the graphTest would print:
Assertion failed: (*getType() == getPayload().getType() &&
                   "Underlying tensor type doesn't match constant type"),
function verify, file ../lib/Graph/Nodes.cpp, line 298.

Now we would get:
In 'input'
Underlying tensor type doesn't match constant type
For comparison `LHS Equal RHS` with:
LHS: float16<5>
RHS: float<5>

That means we don't need to run the debugger anymore to see what is
wrong and we get this diagnostic in release mode as well.
The bonus point is that we can now test the verifier as we add more tests.
(This patch doesn't add all those tests.)

Couple of design points:
- All the reporting goes through glow::report so that if we want a mode
  where all the reports are silented, we just have to change this function
- The intermediate call to verify in the compiler will stay but would be
  wrapped into assert so that we don't pay the verify price in release mode

The next step is to switch the graph and module, then to add a verifier
call in the loader that would trigger proper error reporting (instead of
crashing).

*Testing*
Updated existing tests.
Ran resnet50 in release and debug mode.

Related to issue #1517