### PR TITLE
 [ImageClassifier] Fix slicing of different dim sizes of softmax

### DIFF
--- a/tests/images/run.sh
+++ b/tests/images/run.sh
@@ -4,7 +4,7 @@
 ./bin/image-classifier tests/images/imagenet/*.png -image_mode=neg128to127 -m=vgg19 -model_input_name=data "$@"
 ./bin/image-classifier tests/images/imagenet/*.png -image_mode=neg128to127 -m=squeezenet -model_input_name=data "$@"
 ./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to256 -m=zfnet512 -model_input_name=gpu_0/data "$@"
-./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to1 -m=densenet121 -model_input_name=data "$@"
+./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to1 -m=densenet121 -model_input_name=data -compute_softmax "$@"
 ./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to1 -m=shufflenet -model_input_name=gpu_0/data "$@"
 ./bin/image-classifier tests/images/mnist/*.png -image_mode=0to1 -m=lenet_mnist -model_input_name=data "$@"
 ./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to256 -m=inception_v1 -model_input_name=data "$@"
@@ -22,7 +22,7 @@ for png_filename in tests/images/imagenet/*.png; do
   ./bin/image-classifier "$png_filename" -image_mode=0to256 -m=zfnet512/model.onnx -model_input_name=gpu_0/data_0 "$@"
 done
 for png_filename in tests/images/imagenet/*.png; do
-  ./bin/image-classifier "$png_filename" -image_mode=0to1 -m=densenet121/model.onnx -model_input_name=data_0 "$@"
+  ./bin/image-classifier "$png_filename" -image_mode=0to1 -m=densenet121/model.onnx -model_input_name=data_0 -compute_softmax "$@"
 done
 ./bin/image-classifier tests/images/imagenet/zebra_340.png -image_mode=0to1 -m=shufflenet/model.onnx -model_input_name=gpu_0/data_0 "$@"
 for png_filename in tests/images/mnist/*.png; do


### PR DESCRIPTION
*Description*: Allow softmax to have at least 2 dimensions: batchSize, numLabels, and then trailing 1s. I moved this to use `getUnowned()` instead of `extractSlice()`, as the latter creates a copy of the slice which we do not need. 

I also added `-compute-softmax` to densenet121 in run.sh, and cleaned up one other place we had leftover naming from the Variable -> Placeholder migration.

*Testing*: `run.sh`

Fixes issue as mentioned in https://github.com/pytorch/glow/pull/1937