### PR TITLE
[FunctionQuantizer] Fix rescaling happening in the middle of nodes

### DIFF
--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -436,9 +436,11 @@ bool CrossEntropyLossGradNode::verify() const {
 }
 
 bool ReshapeNode::verify() const {
-  return expectCompareTrue("Reshape into a different size",
-                           getResult().getType()->size(),
-                           getInput().getType()->size(), this);
+  bool isValid = expectCompareTrue("Reshape into a different size",
+                                   getResult().getType()->size(),
+                                   getInput().getType()->size(), this);
+  isValid &= checkTypeIgnoreShape(getResult(), getInput(), this);
+  return isValid;
 }
 
 bool TransposeNode::verify() const {
@@ -451,8 +453,10 @@ bool TransposeNode::verify() const {
     shape.push_back(dims[Shuffle_[i]]);
   }
 
-  return expectCompareTrue("Invalid transpose dims", dest.dims(),
-                           llvm::makeArrayRef(shape), this);
+  bool isValid = expectCompareTrue("Invalid transpose dims", dest.dims(),
+                                   llvm::makeArrayRef(shape), this);
+  isValid &= checkTypeIgnoreShape(dest, src, this);
+  return isValid;
 }
 
 bool SplatNode::verify() const { return true; }
@@ -524,6 +528,7 @@ bool SliceNode::verify() const {
                                  src.dims()[i], this,
                                  CompareOperatorLessEqual<size_t>());
   }
+  isValid &= checkNotQuantizedOrSameParams(dest.getType(), src.getType(), this);
   return isValid;
 }
 


### PR DESCRIPTION
*Description*
Some nodes, at least in their interpreter implementation, expect that
their inputs and outputs are scaled with the exact same parameters.
These constraints were not enforced in the function quantizer for
the slice, transpose, and reshape nodes leading to a mismatch between
how the consumers of a value expect it to be quantized and how it
was actually quantized.

This patch teaches the function quantizer how to fix those constraints
for these additional nodes (the mechanism already existed) and adds
checks in the verifier to catch this kind of problem earlier.

*Testing*
Added test cases, but only for two nodes. Given they all use the same
code path I didn't bother adding them all.

Related to issue #1989.