### PR TITLE
[ONNX] Support load of int32 Tensor

### DIFF
--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -181,6 +181,8 @@ static void loadTensor(const ONNX_NAMESPACE::TensorProto &in, Tensor *T) {
       llvm_unreachable("Unsupported Tensor format.");
     }
   } else if (in.data_type() == ONNX_NAMESPACE::TensorProto::INT32) {
+    // There are few cases when we will have int32 tensors. For example, the
+    // second output of Concat from Caffe2 concat op is int32
     T->reset(ElemKind::Int32ITy, dim);
 
     if (in.int32_data_size() > 0) {

--- a/tests/models/onnxModels/constant.onnxtxt
+++ b/tests/models/onnxModels/constant.onnxtxt
@@ -1,0 +1,34 @@
+ir_version: 3
+producer_name: "backend-test"
+graph {
+  node {
+    output: "output"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 3
+        data_type: INT32
+        name: "split_info"
+        raw_data: "\001\000\000\000\001\000\000\000\001\000\000\000"
+      }
+      type: TENSOR
+    }
+  }
+  output {
+    name: "output"
+    type {
+      tensor_type {
+        elem_type: INT32
+        shape {
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 9
+}

--- a/tests/unittests/onnxImporterTest.cpp
+++ b/tests/unittests/onnxImporterTest.cpp
@@ -570,6 +570,22 @@ TEST(onnx, FCTransposedWithFlatten) {
   ASSERT_TRUE(reshape);
 }
 
+/// Test loading Constant from an ONNX model.
+TEST(onnx, constant) {
+  ExecutionEngine EE;
+  auto &mod = EE.getModule();
+  auto *F = mod.createFunction("main");
+  std::string netFilename("tests/models/onnxModels/constant.onnxtxt");
+  Placeholder *output;
+  {
+    ONNXModelLoader onnxLD(netFilename, {}, {}, *F);
+    output = onnxLD.getSingleOutput();
+  }
+  // Constant -> Save -> PH
+  ASSERT_EQ(mod.getPlaceholders().size(), 1);
+  ASSERT_EQ(F->getNodes().size(), 1);
+}
+
 /// Test loading ExpandDims from an ONNX model.
 TEST(onnx, expandDims) {
   ExecutionEngine EE;


### PR DESCRIPTION
*Description*:
We need to support load of int32 tensor too because Caffe2 concat will output such tensors. In addition, at output, we need to consider outputing that tensor instead of the node. 

*Testing*:
Unit test

*Documentation*:
[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
