### PR TITLE
[Unittest] Improve the testing of convolutions. 

### DIFF
--- a/tests/unittests/BackendCorrectnessTest.cpp
+++ b/tests/unittests/BackendCorrectnessTest.cpp
@@ -485,8 +485,8 @@ TEST_P(BackendCorrectnessTest, softmaxGradTest) {
 TEST_P(BackendCorrectnessTest, convOps) {
   PseudoRNG PRNG;
   // Construct networks with a different convolution depth.
-  for (auto depth : {4, 12, 128}) {
-    Tensor inputs(ElemKind::FloatTy, {2, 3, 16, 16});
+  for (auto depth : {4, 64, 128}) {
+    Tensor inputs(ElemKind::FloatTy, {2, 32, 16, 16});
     inputs.getHandle().initXavier(1, PRNG);
     Tensor out1;
     Tensor out2;
@@ -539,14 +539,14 @@ TEST_P(BackendCorrectnessTest, tinyResnet) {
   using Dims = llvm::ArrayRef<size_t>;
   weights.emplace_back(ElemKind::FloatTy, Dims{256, 1, 1, 64});
   weights.emplace_back(ElemKind::FloatTy, Dims{256});
-  weights.emplace_back(ElemKind::FloatTy, Dims{64, 1, 1, 64});
+  weights.emplace_back(ElemKind::FloatTy, Dims{64, 1, 1, 256});
   weights.emplace_back(ElemKind::FloatTy, Dims{64});
   weights.emplace_back(ElemKind::FloatTy, Dims{64, 3, 3, 64});
   weights.emplace_back(ElemKind::FloatTy, Dims{64});
   weights.emplace_back(ElemKind::FloatTy, Dims{256, 1, 1, 64});
   weights.emplace_back(ElemKind::FloatTy, Dims{256});
   for (auto &T : weights) {
-    T.getHandle().initXavier(1.0, PRNG);
+    T.getHandle().initXavier(10.0, PRNG);
   }
 
   Tensor out1;

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -202,6 +202,22 @@ add_glow_test(OCLTest ${GLOW_BINARY_DIR}/tests/OCLTest)
 LIST(APPEND UNOPT_TESTS ./tests/OCLTest -optimize-ir=false &&)
 endif()
 
+add_executable(convCorrectnessTest
+               convTest.cpp)
+target_link_libraries(convCorrectnessTest
+                      PRIVATE
+                        Graph
+                        IR
+                        ExecutionEngine
+                        Support
+                        gtest
+                        testMain)
+
+add_glow_test(convCorrectnessTest
+              ${GLOW_BINARY_DIR}/tests/convCorrectnessTest)
+
+LIST(APPEND UNOPT_TESTS ./tests/convCorrectnessTest -optimize-ir=false &&)
+
 add_executable(BackendCorrectnessTest
                BackendTestUtils.cpp
                BackendCorrectnessTest.cpp)

--- a/tests/unittests/OCLTest.cpp
+++ b/tests/unittests/OCLTest.cpp
@@ -34,8 +34,8 @@ TEST(OpenCLCorrectnessTest, convOps) {
   Tensor out1;
   Tensor out2;
 
-  inferBasicConvNet(&inputs, &out1, BackendKind::OpenCL, 64);
-  inferBasicConvNet(&inputs, &out2, BackendKind::Interpreter, 64);
+  inferBasicConvNet(&inputs, &out1, BackendKind::OpenCL, 8);
+  inferBasicConvNet(&inputs, &out2, BackendKind::Interpreter, 8);
 
   EXPECT_TRUE(out1.isEqual(out2));
 }

--- a/tests/unittests/OCLTest.cpp
+++ b/tests/unittests/OCLTest.cpp
@@ -34,8 +34,8 @@ TEST(OpenCLCorrectnessTest, convOps) {
   Tensor out1;
   Tensor out2;
 
-  inferBasicConvNet(&inputs, &out1, BackendKind::OpenCL, 4);
-  inferBasicConvNet(&inputs, &out2, BackendKind::Interpreter, 4);
+  inferBasicConvNet(&inputs, &out1, BackendKind::OpenCL, 64);
+  inferBasicConvNet(&inputs, &out2, BackendKind::Interpreter, 64);
 
   EXPECT_TRUE(out1.isEqual(out2));
 }

--- a/tests/unittests/convTest.cpp
+++ b/tests/unittests/convTest.cpp
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/ExecutionEngine/ExecutionEngine.h"
+#include "glow/Graph/Context.h"
+#include "glow/Graph/Graph.h"
+#include "glow/Support/Random.h"
+
+#include "gtest/gtest.h"
+
+#include "llvm/ADT/STLExtras.h"
+
+using namespace glow;
+using llvm::cast;
+
+class ConvCorrectnessTest : public ::testing::TestWithParam<BackendKind> {
+protected:
+  BackendKind backendKind_{GetParam()};
+};
+
+/// Create a simple network that has a single fp convolution.
+void singleConvNet(Tensor *input, Tensor *out, BackendKind kind,
+                   size_t convDepth, size_t kernel, size_t stride, size_t pad) {
+  Context ctx;
+  ExecutionEngine EE(kind);
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+  auto *var = mod.createPlaceholder(input->getElementType(), input->dims(),
+                                    "var", false);
+  ctx.allocate(var)->assign(input);
+
+  auto *conv =
+      F->createConv(ctx, "conv", var, convDepth, kernel, stride, pad, 1);
+  ctx.get(cast<Placeholder>(conv->getFilter()))->getHandle().clear(0.1);
+  ctx.get(cast<Placeholder>(conv->getBias()))->getHandle().clear(0.1);
+  auto *result = F->createSave("ret", conv);
+  auto *resultTensor = ctx.allocate(result->getPlaceholder());
+  convertPlaceholdersToConstants(F, ctx, {var, result->getPlaceholder()});
+
+  EE.compile(CompilationMode::Infer, F);
+
+  updateInputPlaceholders(ctx, {var}, {input});
+  EE.run(ctx);
+  out->assign(resultTensor);
+}
+
+/// Test a few configurations of the fp convolution by comparing the retuls to
+/// the interpreter.
+TEST_P(ConvCorrectnessTest, convTest) {
+  PseudoRNG PRNG;
+  for (size_t depth : {8, 64}) {
+    for (size_t kernel : {1, 3}) {
+      for (size_t size : {7, 5, 15}) {
+        Tensor input(ElemKind::FloatTy, {1, size, size, depth});
+        input.getHandle().initXavier(1, PRNG);
+        Tensor out1;
+        Tensor out2;
+        singleConvNet(&input, &out1, backendKind_, depth, kernel, 1, 0);
+        singleConvNet(&input, &out2, BackendKind::Interpreter, depth, kernel, 1,
+                      0);
+        EXPECT_TRUE(out1.isEqual(out2, 0.001));
+      }
+    }
+  }
+}
+
+#ifdef GLOW_WITH_CPU
+INSTANTIATE_TEST_CASE_P(CPU, ConvCorrectnessTest,
+                        ::testing::Values(BackendKind::CPU));
+#endif // GLOW_WITH_CPU
+
+#ifdef GLOW_WITH_OPENCL
+INSTANTIATE_TEST_CASE_P(OpenCL, ConvCorrectnessTest,
+                        ::testing::Values(BackendKind::OpenCL));
+#endif // GLOW_WITH_OPENCL


### PR DESCRIPTION
*Description*:

I played with our implementation of convolutions in an attempt to figure out how to implement matrix multiplication using a convolution using @bertmaher 's method. During the investigation I discovered that when I break our convolutions the unit tests still pass. This PR improves the test coverage using two methods: 

    [Test] Add a new unit test to verify float convolutions. -- On my machine the test passes in 4.1 seconds in debug mode.

    [Test] Improve a few unit tests. - -This commit fixes a few places in our test that made the CPU backend test only the slow fallback code.

*Testing*: This is a test.
*Documentation*: Inline. 

