### PR TITLE
[BackendUtils] Fix BackendUtils allocation

### DIFF
--- a/lib/Backends/BackendUtils.cpp
+++ b/lib/Backends/BackendUtils.cpp
@@ -27,6 +27,10 @@ uint8_t *glow::collectConstants(
 
   // At compile time condense constants to a single block of memory.
   // This allows the graph to go away after compile time.
+  // If there are no constants return nullptr.
+  if (constantMaxSize == 0) {
+    return nullptr;
+  }
   uint8_t *baseConstantWeightVarsStore =
       (uint8_t *)alignedAlloc(constantMaxSize, TensorAlignment);
   for (auto &v : F->getGraph()->getParent()->getConstants()) {

--- a/lib/Backends/Interpreter/InterpreterFunction.cpp
+++ b/lib/Backends/Interpreter/InterpreterFunction.cpp
@@ -39,10 +39,12 @@ InterpreterFunction::~InterpreterFunction() {
   alignedFree(bundle_.constants);
 }
 void InterpreterFunction::setupRuns() {
-  for (const auto &s : bundle_.symbolTable) {
-    auto addr = bundle_.constants + s.second.offset;
-    auto tensor = new Tensor(addr, &s.second.type);
-    constants_.emplace(s.first, tensor);
+  if (bundle_.constantWeightVarsMemSize) {
+    for (const auto &s : bundle_.symbolTable) {
+      auto addr = bundle_.constants + s.second.offset;
+      auto tensor = new Tensor(addr, &s.second.type);
+      constants_.emplace(s.first, tensor);
+    }
   }
 }
 void InterpreterFunction::beforeRun(const Context &ctx) {


### PR DESCRIPTION

*Description*:Updated BackendUtils to not call alignedAlloc on size 0.
Fixed OpenCL backend to not copy size 0 constants to card.
*Testing*: ninja test and run.sh look good.
*Documentation*: NA