### PR TITLE
Remove context from Backend::compile

### DIFF
--- a/examples/char-rnn.cpp
+++ b/examples/char-rnn.cpp
@@ -244,7 +244,7 @@ int main(int argc, char **argv) {
   // Run this number of iterations over the input. On each iteration: train the
   // network on the whole input and then generate some sample text.
   for (unsigned i = 0; i < numEpochs; i++) {
-    EE.compile(CompilationMode::Train, TF, ctx);
+    EE.compile(CompilationMode::Train, TF);
 
     // Train the network on the whole input.
     llvm::outs() << "Iteration " << i + 1 << "/" << numEpochs;
@@ -259,7 +259,7 @@ int main(int argc, char **argv) {
     // placeholders to constants.
     auto *OF = F->clone("clone");
     ::glow::convertPlaceholdersToConstants(OF, ctx, {X, res});
-    EE.compile(CompilationMode::Infer, OF, ctx);
+    EE.compile(CompilationMode::Infer, OF);
 
     // Load a few characters to start the text that we generate.
     Tensor currCharInfer(ElemKind::FloatTy, {minibatchSize, numSteps, 128});

--- a/examples/cifar10.cpp
+++ b/examples/cifar10.cpp
@@ -133,7 +133,7 @@ void testCIFAR10() {
   auto *result = ctx.allocate(save->getPlaceholder());
 
   Function *TF = glow::differentiate(F, TC);
-  EE.compile(CompilationMode::Train, TF, ctx);
+  EE.compile(CompilationMode::Train, TF);
 
   // Report progress every this number of training iterations.
   int reportRate = 256;

--- a/examples/fr2en.cpp
+++ b/examples/fr2en.cpp
@@ -179,7 +179,7 @@ struct Model {
       ::glow::convertPlaceholdersToConstants(F_, ctx,
                                              {input_, seqLength_, output_});
     }
-    EE_.compile(CompilationMode::Infer, F_, ctx);
+    EE_.compile(CompilationMode::Infer, F_);
   }
 
 private:

--- a/examples/mnist.cpp
+++ b/examples/mnist.cpp
@@ -134,7 +134,7 @@ void testMNIST() {
 
   Function *TF = glow::differentiate(F, TC);
 
-  EE.compile(CompilationMode::Train, TF, ctx);
+  EE.compile(CompilationMode::Train, TF);
 
   const int numIterations = 30;
 
@@ -160,7 +160,7 @@ void testMNIST() {
   llvm::outs() << "Validating.\n";
 
   ::glow::convertPlaceholdersToConstants(F, ctx, {A, result->getPlaceholder()});
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   auto LIH = labelInputs.getHandle<int64_t>();
 

--- a/examples/ptb.cpp
+++ b/examples/ptb.cpp
@@ -237,7 +237,7 @@ void testPTB() {
 
   Function *TF = glow::differentiate(F, TC);
 
-  EE.compile(CompilationMode::Train, TF, ctx);
+  EE.compile(CompilationMode::Train, TF);
 
   if (!dumpTrainingGraphDAGFileOpt.empty()) {
     llvm::outs() << "Dumping training graph\n";

--- a/include/glow/Backends/Backend.h
+++ b/include/glow/Backends/Backend.h
@@ -40,10 +40,8 @@ public:
   /// Dtor.
   virtual ~Backend() = default;
 
-  /// Generate code for input function \param F. \p ctx is the context that maps
-  /// the graph to the concrete execution environment for a specific function.
-  virtual std::unique_ptr<CompiledFunction>
-  compile(Function *F, const Context &ctx) const = 0;
+  /// Generate code for input function \param F.
+  virtual std::unique_ptr<CompiledFunction> compile(Function *F) const = 0;
 
   /// Save the bundle for \p F for a later standalone execution
   /// in \p outputDir. Make \p networkName the function name for
@@ -93,7 +91,7 @@ public:
   /// maps the graph to the concrete execution environment for a specific
   /// function. This is used only for unit testing.
   virtual std::unique_ptr<CompiledFunction>
-  compileIR(std::unique_ptr<IRFunction> IR, const Context &ctx) const = 0;
+  compileIR(std::unique_ptr<IRFunction> IR) const = 0;
 };
 
 } // namespace glow

--- a/include/glow/Backends/CompiledFunction.h
+++ b/include/glow/Backends/CompiledFunction.h
@@ -61,6 +61,17 @@ public:
   /// Execute the network and allocate Placeholder memory with given
   /// \p ctx providing mapping between Placeholder and populated tensor.
   virtual void execute(Context &ctx) = 0;
+
+  /// Does any needed initialization work for the Backend.
+  /// This includes device init constant memory allocation and copying to
+  /// device.
+  virtual void setupRuns() = 0;
+  /// Per run setup. Copy inputs to device.
+  virtual void beforeRun(const Context &ctx) = 0;
+  /// Per run cleanup. Copy outputs from device.
+  virtual void afterRun(const Context &ctx) = 0;
+  /// Final cleanup. Release memory, reset device.
+  virtual void tearDownRuns() = 0;
 };
 } // end namespace glow
 

--- a/include/glow/Backends/CompiledFunction.h
+++ b/include/glow/Backends/CompiledFunction.h
@@ -60,7 +60,7 @@ public:
   virtual ~CompiledFunction() = default;
   /// Execute the network and allocate Placeholder memory with given
   /// \p ctx providing mapping between Placeholder and populated tensor.
-  virtual void execute(Context &ctx) = 0;
+  virtual void execute() = 0;
 
   /// Does any needed initialization work for the Backend.
   /// This includes device init constant memory allocation and copying to

--- a/include/glow/ExecutionEngine/ExecutionEngine.h
+++ b/include/glow/ExecutionEngine/ExecutionEngine.h
@@ -70,10 +70,8 @@ public:
   }
 
   /// Optimize the graph and pass it to the backend to compile it for a specific
-  /// target. This method should be invoked before the run method. The context
-  /// \p ctx contains the mapping between symbolic values to concrete backing
-  /// tensors.
-  void compile(CompilationMode mode, Function *F, Context &ctx);
+  /// target. This method should be invoked before the run method.
+  void compile(CompilationMode mode, Function *F);
 
   /// Save a bundle for a standalone execution. This method takes care of
   /// everything when preparing the bundle for saving. There is no need to

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -98,8 +98,7 @@ CPUBackend::createIRGen(IRFunction *IR,
 }
 
 std::unique_ptr<CompiledFunction>
-CPUBackend::compileIR(std::unique_ptr<IRFunction> IR,
-                      const Context &ctx) const {
+CPUBackend::compileIR(std::unique_ptr<IRFunction> IR) const {
   AllocationsInfo allocationsInfo;
   std::unique_ptr<LLVMIRGen> irgen = createIRGen(IR.get(), allocationsInfo);
   irgen->initTargetMachine(target.empty() ? "" : target.getValue(),
@@ -121,10 +120,9 @@ CPUBackend::compileIR(std::unique_ptr<IRFunction> IR,
   return llvm::make_unique<CPUFunction>(std::move(JIT), runtimeInfo);
 }
 
-std::unique_ptr<CompiledFunction>
-CPUBackend::compile(Function *F, const Context &ctx) const {
+std::unique_ptr<CompiledFunction> CPUBackend::compile(Function *F) const {
   auto IR = generateAndOptimizeIR(F, shouldShareBuffers());
-  return compileIR(std::move(IR), ctx);
+  return compileIR(std::move(IR));
 }
 
 void CPUBackend::save(Function *F, llvm::StringRef outputDir,

--- a/lib/Backends/CPU/CPUBackend.h
+++ b/lib/Backends/CPU/CPUBackend.h
@@ -43,10 +43,9 @@ public:
   ~CPUBackend() override = default;
 
   std::unique_ptr<CompiledFunction>
-  compileIR(std::unique_ptr<IRFunction> IR, const Context &ctx) const override;
+  compileIR(std::unique_ptr<IRFunction> IR) const override;
 
-  std::unique_ptr<CompiledFunction> compile(Function *F,
-                                            const Context &ctx) const override;
+  std::unique_ptr<CompiledFunction> compile(Function *F) const override;
 
   void save(Function *F, llvm::StringRef outputDir,
             llvm::StringRef networkName) const override;

--- a/lib/Backends/CPU/CPUFunction.cpp
+++ b/lib/Backends/CPU/CPUFunction.cpp
@@ -77,10 +77,7 @@ void CPUFunction::tearDownRuns() {
   }
 }
 
-void CPUFunction::execute(Context &ctx) {
-  setupRuns();
-  beforeRun(ctx);
-
+void CPUFunction::execute() {
   auto sym = JIT_->findSymbol("jitmain");
   assert(sym && "Unable to JIT the code!");
   using JitFuncType =
@@ -91,9 +88,7 @@ void CPUFunction::execute(Context &ctx) {
     JitFuncType funcPtr = reinterpret_cast<JitFuncType>(address.get());
     funcPtr(runtimeBundle_.constants, baseMutableWeightVarsAddress_,
             baseActivationsAddress_);
-    afterRun(ctx);
   } else {
     GLOW_ASSERT(false && "Error getting address.");
   }
-  tearDownRuns();
 }

--- a/lib/Backends/CPU/CPUFunction.h
+++ b/lib/Backends/CPU/CPUFunction.h
@@ -38,19 +38,15 @@ public:
   /// Ctor.
   CPUFunction(std::unique_ptr<llvm::orc::GlowJIT> JIT,
               const runtime::RuntimeBundle &runtimeBundle);
-  /// Copy Function to device, an empty function for CPU.
-  void copyFunctionToDevice(){};
-  /// Copy Constants to device, an empty function for CPU.
-  void copyConstantsToDevice(){};
   /// Allocate Mutable buffers on device this includes Activations and
   /// Placeholders.
-  void allocateMutableBuffersOnDevice();
-  /// Copy Input Placeholder data to device.
-  void copyInputsToDevice(Context &ctx);
-  /// Copy Outputs from Device to Placeholders in \p ctx.
-  void copyOutputsFromDevice(Context &ctx);
-  /// Free all allocations.
-  void freeAllocations();
+  void setupRuns() override;
+  /// Copy Input Placeholder data to position.
+  void beforeRun(const Context &ctx) override;
+  /// Copy Outputs to Placeholders in \p ctx.
+  void afterRun(const Context &ctx) override;
+  /// Final cleanup, free all allocations.
+  void tearDownRuns() override;
   /// \name CompiledFunction interface
   ///@{
   ~CPUFunction() override;

--- a/lib/Backends/CPU/CPUFunction.h
+++ b/lib/Backends/CPU/CPUFunction.h
@@ -50,7 +50,7 @@ public:
   /// \name CompiledFunction interface
   ///@{
   ~CPUFunction() override;
-  void execute(Context &ctx) override;
+  void execute() override;
   ///@}
 };
 } // end namespace glow

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -46,17 +46,15 @@ runtime::RuntimeBundle generateInterpreterRuntimeBundle(const IRFunction *F) {
   return bundle;
 }
 
-std::unique_ptr<CompiledFunction>
-Interpreter::compile(Function *F, const Context &ctx) const {
+std::unique_ptr<CompiledFunction> Interpreter::compile(Function *F) const {
   auto IR = generateAndOptimizeIR(F, shouldShareBuffers());
-  return compileIR(std::move(IR), ctx);
+  return compileIR(std::move(IR));
 }
 
 std::unique_ptr<CompiledFunction>
-Interpreter::compileIR(std::unique_ptr<IRFunction> IR,
-                       const Context &ctx) const {
+Interpreter::compileIR(std::unique_ptr<IRFunction> IR) const {
   runtime::RuntimeBundle bundle = generateInterpreterRuntimeBundle(IR.get());
-  return llvm::make_unique<InterpreterFunction>(std::move(IR), ctx, bundle);
+  return llvm::make_unique<InterpreterFunction>(std::move(IR), bundle);
 }
 
 bool Interpreter::isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const {

--- a/lib/Backends/Interpreter/Interpreter.h
+++ b/lib/Backends/Interpreter/Interpreter.h
@@ -35,10 +35,9 @@ public:
   ~Interpreter() override = default;
 
   std::unique_ptr<CompiledFunction>
-  compileIR(std::unique_ptr<IRFunction> IR, const Context &ctx) const override;
+  compileIR(std::unique_ptr<IRFunction> IR) const override;
 
-  std::unique_ptr<CompiledFunction> compile(Function *F,
-                                            const Context &ctx) const override;
+  std::unique_ptr<CompiledFunction> compile(Function *F) const override;
 
   bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override;
 

--- a/lib/Backends/Interpreter/InterpreterFunction.cpp
+++ b/lib/Backends/Interpreter/InterpreterFunction.cpp
@@ -25,7 +25,6 @@
 using namespace glow;
 
 InterpreterFunction::InterpreterFunction(std::unique_ptr<IRFunction> F,
-                                         const Context &ctx,
                                          const runtime::RuntimeBundle &bundle)
     : F_(std::move(F)), bundle_(bundle) {}
 
@@ -135,9 +134,7 @@ void InterpreterFunction::deleteTensor(const Value *v) {
   tensors_.erase(it);
 }
 
-void InterpreterFunction::execute(Context &ctx) {
-  setupRuns();
-  beforeRun(ctx);
+void InterpreterFunction::execute() {
 // Do the forward pass.
 #define DEF_VALUE(CLASS, NAME)
 #define DEF_INSTR(CLASS, NAME)                                                 \
@@ -155,6 +152,4 @@ void InterpreterFunction::execute(Context &ctx) {
       llvm_unreachable("Invalid instruction.");
     }
   }
-  afterRun(ctx);
-  tearDownRuns();
 }

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -61,15 +61,15 @@ public:
   ~InterpreterFunction() override;
   /// Does any needed initialization work for the Backend, creates tensors from
   /// constants.
-  void setupRuns();
+  void setupRuns() override;
   /// Per run setup, adds references for tensors from \p ctx to
   /// externalTensors_.
-  void beforeRun(const Context &ctx);
+  void beforeRun(const Context &ctx) override;
   /// Per run cleanup, removes references for tensors from \p ctx from
   /// externalTensors_.
-  void afterRun(const Context &ctx);
+  void afterRun(const Context &ctx) override;
   /// Final cleanup, remove created constant Tensors.
-  void tearDownRuns();
+  void tearDownRuns() override;
 
   void execute(Context &ctx) override;
   ///@}

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -53,7 +53,7 @@ class InterpreterFunction final : public CompiledFunction {
   runtime::RuntimeBundle bundle_;
 
 public:
-  InterpreterFunction(std::unique_ptr<IRFunction> F, const Context &ctx,
+  InterpreterFunction(std::unique_ptr<IRFunction> F,
                       const runtime::RuntimeBundle &bundle);
 
   /// \name CompiledFunction interface
@@ -71,7 +71,7 @@ public:
   /// Final cleanup, remove created constant Tensors.
   void tearDownRuns() override;
 
-  void execute(Context &ctx) override;
+  void execute() override;
   ///@}
 
 private:

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -618,9 +618,7 @@ static void topK(Tensor &outW, Tensor &indW, Tensor &inW, size_t k) {
     }
   }
 }
-void OpenCLFunction::execute(Context &ctx) {
-  setupRuns();
-  beforeRun(ctx);
+void OpenCLFunction::execute() {
   for (const auto &I : F_->getInstrs()) {
     // The kernels are named after the name of the instruction, plus the "W"
     // suffix to prevent name colissions for functions like 'tanh' that are also
@@ -1386,7 +1384,6 @@ void OpenCLFunction::execute(Context &ctx) {
     clReleaseKernel(kl.kernel_);
   }
   kernelLaunches_.clear();
-  afterRun(ctx);
 }
 
 uint64_t OpenCLFunction::copyValueToDevice(const Value *v, void *buf) {
@@ -1608,13 +1605,12 @@ cl_mem OpenCLFunction::allocDeviceBuffer(uint64_t size) {
 void OpenCLFunction::freeDeviceBuffer(cl_mem buf) { clReleaseMemObject(buf); }
 
 std::unique_ptr<CompiledFunction>
-OCLBackend::compileIR(std::unique_ptr<IRFunction> IR, const Context &) const {
+OCLBackend::compileIR(std::unique_ptr<IRFunction> IR) const {
   runtime::RuntimeBundle bundle = generateRuntimeBundle(IR.get());
   return llvm::make_unique<OpenCLFunction>(std::move(IR), bundle);
 }
 
-std::unique_ptr<CompiledFunction>
-OCLBackend::compile(Function *F, const Context &ctx) const {
+std::unique_ptr<CompiledFunction> OCLBackend::compile(Function *F) const {
   auto IR = generateAndOptimizeIR(F, shouldShareBuffers());
-  return compileIR(std::move(IR), ctx);
+  return compileIR(std::move(IR));
 }

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -97,7 +97,7 @@ public:
   ///@{
   ~OpenCLFunction() override;
 
-  void execute(Context &ctx) override;
+  void execute() override;
   ///@}
   /// Allocates on device buffer and copies Constant weights to device.
   void setupRuns() override;
@@ -161,10 +161,9 @@ public:
   ~OCLBackend() override = default;
 
   std::unique_ptr<CompiledFunction>
-  compileIR(std::unique_ptr<IRFunction> IR, const Context &ctx) const override;
+  compileIR(std::unique_ptr<IRFunction> IR) const override;
 
-  std::unique_ptr<CompiledFunction> compile(Function *F,
-                                            const Context &ctx) const override;
+  std::unique_ptr<CompiledFunction> compile(Function *F) const override;
 
   bool transformPostLowering(Function *F, CompilationMode mode) const override;
 

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -100,19 +100,13 @@ public:
   void execute(Context &ctx) override;
   ///@}
   /// Allocates on device buffer and copies Constant weights to device.
-  void copyConstantsToDevice();
-  /// Copies Inputs from \p ctx to on device memory.
-  void copyInputsToDevice(const Context &ctx);
+  void setupRuns() override;
+  /// Per run setup, copies Inputs from \p ctx to on device memory.
+  void beforeRun(const Context &ctx) override;
   /// Copies outputs from device to tensors in \p ctx.
-  void copyOutputsFromDevice(const Context &ctx);
-  /// Copy Function to device, an empty function for OpenCL.
-  void copyFunctionToDevice(){};
-  /// Allocate Mutable buffers on device, this is an empty function on OpenCL
-  /// because the OCL backend uses a single buffer which is allocated when
-  /// constants are copied to the device.
-  void allocateMutableBuffersOnDevice(){};
-  /// Frees runtime allocations. This is an empty function for OCL.
-  void freeAllocations(){};
+  void afterRun(const Context &ctx) override;
+  /// Final cleanup, currently an empty function in OpenCL.
+  void tearDownRuns() override{};
 
 private:
   /// Copy the value from a device to a provided buffer.

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -148,10 +148,8 @@ void ExecutionEngine::optimizeFunction(CompilationMode mode, Function *F) {
   }
 }
 
-void ExecutionEngine::compile(CompilationMode mode, Function *F, Context &ctx) {
+void ExecutionEngine::compile(CompilationMode mode, Function *F) {
   optimizeFunction(mode, F);
-  // Make sure that the context has backing tensors for all placeholders.
-  // ctx.allocate(M_.getPlaceholders());
   function_ = backend_->compile(F);
 }
 

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -64,7 +64,7 @@ onnxStatus Graph::initGraph(const void *onnxModel, size_t onnxModelSize,
   onnxOutputToPlaceholder_ = loader->getOutputVarsMapping();
 
   // Emit IR for the graph and compile it.
-  backendPtr_->getEE().compile(CompilationMode::Infer, function_, ctx_);
+  backendPtr_->getEE().compile(CompilationMode::Infer, function_);
 
   return ONNXIFI_STATUS_SUCCESS;
 }

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -109,6 +109,8 @@ void Graph::run(
 
   // Run inference.
   auto &EE = backendPtr_->getEE();
+  auto &mod = EE.getModule();
+  ctx_.allocate(mod.getPlaceholders());
   updateInputPlaceholders(ctx_, phs, tensors);
   EE.run(ctx_);
 

--- a/tests/unittests/BackendCorrectnessTest.cpp
+++ b/tests/unittests/BackendCorrectnessTest.cpp
@@ -47,7 +47,7 @@ static std::vector<NodeQuantizationInfo>
 profileAndGetNodeQuantizationInfo(Context &ctx, ExecutionEngine &EE,
                                   Function *origF) {
   Function *profileF = glow::profileQuantization(ctx, origF);
-  EE.compile(CompilationMode::Infer, profileF, ctx);
+  EE.compile(CompilationMode::Infer, profileF);
 
   EE.run(ctx);
 
@@ -89,8 +89,8 @@ compareAgainstInterpreter(BackendKind backendKind,
     BF = quantization::quantizeFunction(BEE, QI, BF);
   }
 
-  IEE.compile(CompilationMode::Infer, IF, ICtx);
-  BEE.compile(CompilationMode::Infer, BF, BCtx);
+  IEE.compile(CompilationMode::Infer, IF);
+  BEE.compile(CompilationMode::Infer, BF);
 
   IEE.run(ICtx);
   BEE.run(BCtx);

--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -64,7 +64,7 @@ TEST(Interpreter, profileQuantizationForANetwork) {
 
   ctx.allocate(A);
   ctx.allocate(Ex);
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   // TODO: Verify histogram itself, for now just verify min and max.
   // Run inference first time and capture tensor stats.
@@ -135,7 +135,7 @@ TEST_P(BackendTest, simpleInference) {
   ctx.allocate(input);
   ctx.allocate(ex);
   ctx.allocate(S->getPlaceholder());
-  EE_.compile(CompilationMode::Infer, F, ctx);
+  EE_.compile(CompilationMode::Infer, F);
 
   updateInputPlaceholders(ctx, {input}, {&inputs});
   EE_.run(ctx);
@@ -182,7 +182,7 @@ TEST_P(BackendTest, decoupleCodegenFromGraph) {
   auto *pow = F->createPow("Pow1", X, 2.0);
   auto *save = F->createSave("save", pow);
   auto *saveTensor = ctx.allocate(save->getPlaceholder());
-  EE_.compile(CompilationMode::Infer, F, ctx);
+  EE_.compile(CompilationMode::Infer, F);
 
   // Erase all of the functions to ensure that the compiled code does not
   // depend on the graph.
@@ -209,7 +209,7 @@ TEST_P(BackendTest, simplePlaceholderValue) {
   SaveNode *S = F->createSave("ret", input);
   auto *STensor = ctx.allocate(S->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F, ctx);
+  EE_.compile(CompilationMode::Infer, F);
   EE_.run(ctx);
   EXPECT_TRUE(STensor->isEqual(data));
 }

--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -160,8 +160,12 @@ TEST_P(BackendTest, debugPrint) {
 
   std::unique_ptr<BackendUsingGlowIR> backend(
       static_cast<BackendUsingGlowIR *>(createBackend(GetParam())));
-  auto function = backend->compileIR(std::move(IR), ctx);
-  function->execute(ctx);
+  auto function = backend->compileIR(std::move(IR));
+  function->setupRuns();
+  function->beforeRun(ctx);
+  function->execute();
+  function->afterRun(ctx);
+  function->tearDownRuns();
 }
 
 /// This test checks that we can compile a function without depending on the

--- a/tests/unittests/BackendTestUtils.cpp
+++ b/tests/unittests/BackendTestUtils.cpp
@@ -64,7 +64,7 @@ void inferIntLookupTableNet(Tensor *input, Tensor *out,
   auto *result = F->createSave("ret", lookupTable);
   auto *resultTensor = ctx.allocate(result->getPlaceholder());
 
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   updateInputPlaceholders(ctx, {var}, {input});
   EE.run(ctx);
@@ -105,7 +105,7 @@ void inferConvNet(Tensor *inputs, Tensor *filter, Tensor *bias, Tensor *out,
   auto *result = F->createSave("ret", conv, outP);
   auto *resultTensor = ctx.get(result->getPlaceholder());
 
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   updateInputPlaceholders(ctx, {inputP, filterP, biasP},
                           {inputs, filter, bias});
@@ -146,10 +146,10 @@ void trainConvNet(Tensor *inputs, Tensor *kernel1, Tensor *bias1,
   auto *resultTensor = ctx.allocate(result->getPlaceholder());
 
   Function *TF = glow::differentiate(F, TC);
-  EE.compile(CompilationMode::Train, TF, ctx);
+  EE.compile(CompilationMode::Train, TF);
 
   runBatch(EE, ctx, 8, sampleCounter, {var1, var2}, {inputs, selected});
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
   updateInputPlaceholders(ctx, {var1, var2}, {inputs, selected});
   EE.run(ctx);
   out->assign(resultTensor);
@@ -166,7 +166,7 @@ void inferLocalResponseNormalizationNet(Tensor *inputs, Tensor *out,
   auto *result = F->createSave("ret", lrn);
   auto *resultTensor = ctx.allocate(result->getPlaceholder());
 
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   updateInputPlaceholders(ctx, {var}, {inputs});
   EE.run(ctx);
@@ -205,10 +205,10 @@ void trainLocalResponseNormalizationNet(Tensor *inputs, Tensor *weights,
   auto *resultTensor = ctx.allocate(result->getPlaceholder());
 
   Function *TF = glow::differentiate(F, TC);
-  EE.compile(CompilationMode::Train, TF, ctx);
+  EE.compile(CompilationMode::Train, TF);
   runBatch(EE, ctx, 8, sampleCounter, {var1, var2}, {inputs, selected});
 
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   runBatch(EE, ctx, 1, sampleCounter, {var1, var2}, {inputs, selected});
   out->assign(resultTensor);
@@ -244,10 +244,10 @@ void trainAvgPoolNet(Tensor *inputs, Tensor *weights, Tensor *bias,
   auto *resultTensor = ctx.allocate(result->getPlaceholder());
 
   Function *TF = glow::differentiate(F, TC);
-  EE.compile(CompilationMode::Train, TF, ctx);
+  EE.compile(CompilationMode::Train, TF);
 
   runBatch(EE, ctx, 10, sampleCounter, {var1, var2}, {inputs, selected});
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   updateInputPlaceholders(ctx, {var1, var2}, {inputs, selected});
   EE.run(ctx);
@@ -284,10 +284,10 @@ void trainMaxPoolNet(Tensor *inputs, Tensor *weights, Tensor *bias,
   auto *resultTensor = ctx.allocate(result->getPlaceholder());
 
   Function *TF = glow::differentiate(F, TC);
-  EE.compile(CompilationMode::Train, TF, ctx);
+  EE.compile(CompilationMode::Train, TF);
 
   runBatch(EE, ctx, 7, sampleCounter, {var1, var2}, {inputs, selected});
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   runBatch(EE, ctx, 1, sampleCounter, {var1, var2}, {inputs, selected});
   out->assign(resultTensor);
@@ -305,7 +305,7 @@ void inferSmallConv(Tensor *inputs, Tensor *out, BackendKind kind) {
   auto *result = F->createSave("ret", C);
   auto *resultTensor = ctx.allocate(result->getPlaceholder());
 
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   updateInputPlaceholders(ctx, {in}, {inputs});
   EE.run(ctx);
@@ -347,7 +347,7 @@ void inferGroupConv(Tensor *out, BackendKind kind) {
   SaveNode *result = F->createSave("save", CN);
   auto *resultTensor = ctx.allocate(result->getPlaceholder());
 
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   EE.run(ctx);
   out->assign(resultTensor);
@@ -386,7 +386,7 @@ void inferNonSquarePaddingConv(Tensor *out, BackendKind kind) {
   SaveNode *result = F->createSave("save", CN);
   auto *resultTensor = ctx.allocate(result->getPlaceholder());
 
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   EE.run(ctx);
   out->assign(resultTensor);
@@ -426,7 +426,7 @@ void inferNonSquareKernelConv(Tensor *out, BackendKind kind) {
   SaveNode *result = F->createSave("save", CN);
   auto *resultTensor = ctx.allocate(result->getPlaceholder());
 
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   EE.run(ctx);
   out->assign(resultTensor);
@@ -466,7 +466,7 @@ void inferNonSquareStrideConv(Tensor *out, BackendKind kind) {
   SaveNode *result = F->createSave("save", CN);
   auto *resultTensor = ctx.allocate(result->getPlaceholder());
 
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   EE.run(ctx);
   out->assign(resultTensor);
@@ -507,7 +507,7 @@ void inferConvDKKC8(Tensor *out, BackendKind kind) {
   SaveNode *result = F->createSave("save", CN);
   auto *resultTensor = ctx.allocate(result->getPlaceholder());
 
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   EE.run(ctx);
   out->assign(resultTensor);
@@ -539,10 +539,10 @@ void trainSoftMaxNet(Tensor *inputs, Tensor *weights, Tensor *bias,
 
   Function *TF = glow::differentiate(F, TC);
 
-  EE.compile(CompilationMode::Train, TF, ctx);
+  EE.compile(CompilationMode::Train, TF);
 
   runBatch(EE, ctx, 30, sampleCounter, {var1, var2}, {inputs, selected});
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   updateInputPlaceholders(ctx, {var1, var2}, {inputs, selected});
   EE.run(ctx);
@@ -566,7 +566,7 @@ void inferTanhConcatNet(Tensor *input1, Tensor *input2, Tensor *input3,
   auto *result = F->createSave("ret", C2);
   auto *resultTensor = ctx.allocate(result->getPlaceholder());
 
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   updateInputPlaceholders(ctx, {var1, var2, var3}, {input1, input2, input3});
   EE.run(ctx);
@@ -589,7 +589,7 @@ void inferBasicConvNet(Tensor *inputs, Tensor *out, BackendKind kind,
   auto *result = F->createSave("ret", pool);
   auto *resultTensor = ctx.allocate(result->getPlaceholder());
 
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   updateInputPlaceholders(ctx, {var}, {inputs});
   EE.run(ctx);
@@ -642,7 +642,7 @@ void inferMixedNet(Tensor *inputs, Tensor *out, BackendKind kind) {
   ctx.get(cast<Placeholder>(fc->getWeights()))->getHandle().clear(0.4);
   ctx.get(cast<Placeholder>(fc2->getWeights()))->getHandle().clear(3.5);
 
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   updateInputPlaceholders(ctx, {var}, {inputs});
   EE.run(ctx);
@@ -686,7 +686,7 @@ void inferComplexNet1(Tensor *inputs1, Tensor *inputs2, Tensor *inputs3,
   auto *result = F->createSave("ret", sigmoid3);
   auto *resultTensor = ctx.allocate(result->getPlaceholder());
 
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   updateInputPlaceholders(ctx, {var1, var2, var3, var4},
                           {inputs1, inputs2, inputs3, inputs4});
@@ -727,7 +727,7 @@ void inferTinyResnet(Tensor *input, Tensor *out, std::vector<Tensor> &weights,
   initConv(ctx, conv2b, weights[4], weights[5]);
   initConv(ctx, conv2c, weights[6], weights[7]);
 
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   updateInputPlaceholders(ctx, {in}, {input});
   EE.run(ctx);
@@ -760,7 +760,7 @@ void inferExtract3D(Tensor *input, Tensor *out, BackendKind kind) {
   auto *result = F->createSave("ret", e);
   auto *resultTensor = ctx.allocate(result->getPlaceholder());
 
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   updateInputPlaceholders(ctx, {inputs}, {input});
   EE.run(ctx);
@@ -789,7 +789,7 @@ void inferMaxSplat(Tensor *input, Tensor *out, BackendKind kind) {
   auto *result = F->createSave("ret", max2);
   auto *resultTensor = ctx.allocate(result->getPlaceholder());
 
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   updateInputPlaceholders(ctx, {var}, {input});
   EE.run(ctx);

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -24,6 +24,10 @@ namespace glow {
 class MockBackend : public Backend {
   class MockFunction : public CompiledFunction {
     void execute(Context &ctx) override{};
+    void setupRuns() override{};
+    void beforeRun(const Context &ctx) override{};
+    void afterRun(const Context &ctx) override{};
+    void tearDownRuns() override{};
   };
   std::unique_ptr<CompiledFunction> compile(Function *F,
                                             const Context &ctx) const override {

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -23,14 +23,13 @@ namespace glow {
 /// MockBackend used only for unit testing.
 class MockBackend : public Backend {
   class MockFunction : public CompiledFunction {
-    void execute(Context &ctx) override{};
+    void execute() override{};
     void setupRuns() override{};
     void beforeRun(const Context &ctx) override{};
     void afterRun(const Context &ctx) override{};
     void tearDownRuns() override{};
   };
-  std::unique_ptr<CompiledFunction> compile(Function *F,
-                                            const Context &ctx) const override {
+  std::unique_ptr<CompiledFunction> compile(Function *F) const override {
     return llvm::make_unique<MockFunction>();
   }
   bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override {

--- a/tests/unittests/GemmTest.cpp
+++ b/tests/unittests/GemmTest.cpp
@@ -55,7 +55,7 @@ void infer(Tensor *out, Tensor *lhs, Tensor *rhs) {
   auto save = F->createSave("ret", matmul);
   auto *res = ctx.allocate(save->getPlaceholder());
 
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   updateInputPlaceholders(ctx, {lhsVar, rhsVar}, {lhs, rhs});
   EE.run(ctx);

--- a/tests/unittests/HyphenTest.cpp
+++ b/tests/unittests/HyphenTest.cpp
@@ -288,7 +288,7 @@ struct HyphenNetwork {
                            TrainingConfig &TC) {
     // Compilation is destructive because of target-specific lowering.
     // Compile a clone of the inference function.
-    EE.compile(CompilationMode::Infer, infer_->clone(name), ctx_);
+    EE.compile(CompilationMode::Infer, infer_->clone(name));
 
     auto batchSize = TC.batchSize;
     auto numSamples = inputs.dims()[0];
@@ -367,7 +367,7 @@ TEST(HyphenTest, network) {
   size_t sampleCounter = 0;
 
   // Train using mini-batch SGD.
-  EE.compile(CompilationMode::Train, net.train_, net.ctx_);
+  EE.compile(CompilationMode::Train, net.train_);
   runBatch(EE, net.ctx_, 1000, sampleCounter, {net.input_, net.expected_},
            {&inputs, &expected});
 

--- a/tests/unittests/MLTest.cpp
+++ b/tests/unittests/MLTest.cpp
@@ -63,7 +63,7 @@ TEST_P(MLTest, learnSqrt2Placeholder) {
   ctx.allocate(SN->getPlaceholder());
 
   Function *TF = glow::differentiate(F, TC);
-  EE_.compile(CompilationMode::Train, TF, ctx);
+  EE_.compile(CompilationMode::Train, TF);
 
   // Train the network:
   for (int i = 0; i < 100; i++) {
@@ -108,14 +108,14 @@ TEST_P(MLTest, trainASimpleNetwork) {
   expected.getHandle<>() = {0.9f, 0.9f, 0.9f, 0.9f};
 
   Function *TF = glow::differentiate(F, TC);
-  EE_.compile(CompilationMode::Train, TF, ctx);
+  EE_.compile(CompilationMode::Train, TF);
 
   // Train the network. Learn 1000 batches.
   runBatch(EE_, ctx, 1000, sampleCounter, {A, E}, {&inputs, &expected});
 
   // Testing the output vector.
 
-  EE_.compile(CompilationMode::Infer, F, ctx);
+  EE_.compile(CompilationMode::Infer, F);
   updateInputPlaceholders(ctx, {A}, {&inputs});
   EE_.run(ctx);
 
@@ -164,7 +164,7 @@ TEST_P(MLTest, simpleRegression) {
   auto E = expected.getHandle<>();
 
   Function *TF = glow::differentiate(F, TC);
-  EE_.compile(CompilationMode::Train, TF, ctx);
+  EE_.compile(CompilationMode::Train, TF);
 
   // Train the network:
   for (int iter = 0; iter < 1000; iter++) {
@@ -175,7 +175,7 @@ TEST_P(MLTest, simpleRegression) {
   }
 
   // Verify the result of the regression layer.
-  EE_.compile(CompilationMode::Infer, F, ctx);
+  EE_.compile(CompilationMode::Infer, F);
 
   // Test the output:
   for (int iter = 0; iter < 5; iter++) {
@@ -240,13 +240,13 @@ TEST_P(MLTest, learnXor) {
   }
 
   Function *TF = glow::differentiate(F, TC);
-  EE_.compile(CompilationMode::Train, TF, ctx);
+  EE_.compile(CompilationMode::Train, TF);
 
   // Train the network:
   runBatch(EE_, ctx, 2500, sampleCounter, {A, Ex},
            {&trainingSet, &trainingLabels});
 
-  EE_.compile(CompilationMode::Infer, F, ctx);
+  EE_.compile(CompilationMode::Infer, F);
 
   // Prepare the testing tensor:
   for (unsigned i = 0; i < numInputs; i++) {
@@ -319,13 +319,13 @@ TEST_P(MLTest, learnLog) {
   }
 
   Function *TF = glow::differentiate(F, TC);
-  EE_.compile(CompilationMode::Train, TF, ctx);
+  EE_.compile(CompilationMode::Train, TF);
 
   // Train the network:
   runBatch(EE_, ctx, 1000, sampleCounter, {A, Ex},
            {&trainingSet, &trainingLabels});
 
-  EE_.compile(CompilationMode::Infer, F, ctx);
+  EE_.compile(CompilationMode::Infer, F);
 
   // Set the testing data.
   Tensor testSet(ElemKind::FloatTy, {batchSize, 1});
@@ -419,7 +419,7 @@ TEST_P(MLTest, circle) {
   auto *res = ctx.allocate(result->getPlaceholder());
 
   Function *TF = glow::differentiate(F, TC);
-  EE_.compile(CompilationMode::Train, TF, ctx);
+  EE_.compile(CompilationMode::Train, TF);
 
   Tensor coordinates(ElemKind::FloatTy, {numSamples, 2});
   Tensor labels(ElemKind::Int64ITy, {numSamples, 1});
@@ -428,7 +428,7 @@ TEST_P(MLTest, circle) {
   // Training:
   runBatch(EE_, ctx, 4000, sampleCounter, {A, S}, {&coordinates, &labels});
 
-  EE_.compile(CompilationMode::Infer, F, ctx);
+  EE_.compile(CompilationMode::Infer, F);
 
   // Print a diagram that depicts the network decision on a grid.
   Tensor sample(ElemKind::FloatTy, {minibatchSize, 2});
@@ -531,13 +531,13 @@ TEST_P(MLTest, learnSingleValueConcat) {
   expected.getHandle<>().clear(0.9);
 
   Function *TF = glow::differentiate(F, TC);
-  EE_.compile(CompilationMode::Train, TF, ctx);
+  EE_.compile(CompilationMode::Train, TF);
 
   // Train the network:
   runBatch(EE_, ctx, 1000, sampleCounter, {A, B, Ex},
            {&inputs, &inputs, &expected});
 
-  EE_.compile(CompilationMode::Infer, F, ctx);
+  EE_.compile(CompilationMode::Infer, F);
 
   // Testing the output vector.
   updateInputPlaceholders(ctx, {A}, {&inputs});
@@ -635,7 +635,7 @@ void testRNNCell(TCellGenerator cell) {
   Tensor *res = ctx.allocate(result->getPlaceholder());
 
   Function *TF = glow::differentiate(F, TC);
-  EE.compile(CompilationMode::Train, TF, ctx);
+  EE.compile(CompilationMode::Train, TF);
 
   // Values for the input and output variables.
   Tensor inputs(ElemKind::FloatTy, {1, NumVectors, NumElements});
@@ -651,7 +651,7 @@ void testRNNCell(TCellGenerator cell) {
   runBatch(EE, ctx, 1000, sampleCounter, {X, Y}, {&inputs, &expected});
 
   // Testing the output vector.
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   updateInputPlaceholders(ctx, {X}, {&inputs});
   EE.run(ctx);
@@ -721,7 +721,7 @@ TEST_P(MLTest, trainSimpleLinearRegression) {
   Placeholder *B = llvm::cast<Placeholder>(FC->getBias());
 
   Function *TF = glow::differentiate(F, TC);
-  EE_.compile(CompilationMode::Train, TF, ctx);
+  EE_.compile(CompilationMode::Train, TF);
 
   // Train the network doing 100 steps. Learn on 500 samples.
   runBatch(EE_, ctx, 100, sampleCounter, {inputX, expectedY},
@@ -794,7 +794,7 @@ TEST_P(MLTest, classifyPlayerSport) {
   ctx.allocate(result->getPlaceholder());
 
   Function *TF = glow::differentiate(F, TC);
-  EE_.compile(CompilationMode::Train, TF, ctx);
+  EE_.compile(CompilationMode::Train, TF);
 
   Tensor players(ElemKind::FloatTy, {numTrainPlayers, numFeatures});
   Tensor labels(ElemKind::Int64ITy, {numTrainPlayers, 1});
@@ -803,7 +803,7 @@ TEST_P(MLTest, classifyPlayerSport) {
   // Training:
   runBatch(EE_, ctx, 2000, sampleCounter, {A, S}, {&players, &labels});
 
-  EE_.compile(CompilationMode::Infer, F, ctx);
+  EE_.compile(CompilationMode::Infer, F);
 
   std::vector<std::tuple<unsigned, unsigned, Sport>> testPlayers;
   testPlayers.emplace_back(82, 240, Sport::BASKETBALL);
@@ -882,7 +882,7 @@ TEST_P(MLTest, learnSinus) {
   Tensor *res = ctx.allocate(result->getPlaceholder());
 
   Function *TF = glow::differentiate(F, TC);
-  EE_.compile(CompilationMode::Train, TF, ctx);
+  EE_.compile(CompilationMode::Train, TF);
 
   // Learn on numSamples samples.
   runBatch(EE_, ctx, 2700, sampleCounter, {inputX, expectedY},
@@ -898,7 +898,7 @@ TEST_P(MLTest, learnSinus) {
     tensorY.getHandle<>().at({i, 0}) = y;
   }
 
-  EE_.compile(CompilationMode::Infer, F, ctx);
+  EE_.compile(CompilationMode::Infer, F);
   updateInputPlaceholders(ctx, {inputX}, {&tensorX});
   EE_.run(ctx);
   auto resH = res->getHandle<>();
@@ -946,7 +946,7 @@ TEST_P(MLTest, nonLinearClassifier) {
   Tensor *res = ctx.allocate(result->getPlaceholder());
 
   Function *TF = glow::differentiate(F, TC);
-  EE_.compile(CompilationMode::Train, TF, ctx);
+  EE_.compile(CompilationMode::Train, TF);
 
   Tensor samples(ElemKind::FloatTy, {numSamples, 2});
   Tensor labels(ElemKind::Int64ITy, {numSamples, 1});
@@ -962,7 +962,7 @@ TEST_P(MLTest, nonLinearClassifier) {
 
   runBatch(EE_, ctx, 500, sampleCounter, {A, S}, {&samples, &labels});
 
-  EE_.compile(CompilationMode::Infer, F, ctx);
+  EE_.compile(CompilationMode::Infer, F);
 
   std::vector<std::tuple<float, float, size_t>> tests;
   tests.emplace_back(-0.8, -0.8, 0);
@@ -1042,7 +1042,7 @@ TEST_P(InterpreterAndCPU, convNetForImageRecognition) {
   Tensor *res = ctx.allocate(result->getPlaceholder());
 
   Function *TF = glow::differentiate(F, TC);
-  EE.compile(CompilationMode::Train, TF, ctx);
+  EE.compile(CompilationMode::Train, TF);
 
   Tensor images(ElemKind::FloatTy, {numSamples, 8, 8, 1});
   Tensor labels(ElemKind::Int64ITy, {numSamples, 1});
@@ -1053,7 +1053,7 @@ TEST_P(InterpreterAndCPU, convNetForImageRecognition) {
 
   // Profiling:
   Function *PF = glow::profileQuantization(ctx, F);
-  EE.compile(CompilationMode::Infer, PF, ctx);
+  EE.compile(CompilationMode::Infer, PF);
   runBatch(EE, ctx, 100, sampleCounter, {input}, {&images});
 
   // Get the quantization info and build the new quantized graph.
@@ -1064,7 +1064,7 @@ TEST_P(InterpreterAndCPU, convNetForImageRecognition) {
   // Evaluate on the quantized function:
   // Set the execution backend to the backend that we test.
   EE.setBackend(GetParam());
-  EE.compile(CompilationMode::Infer, QP, ctx);
+  EE.compile(CompilationMode::Infer, QP);
 
   // Generate the images used for testing.
   Tensor testImages(ElemKind::FloatTy, {batchSize, 8, 8, 1});
@@ -1141,7 +1141,7 @@ TEST_P(InterpreterAndCPU, testFindPixelRegression) {
   Tensor *res = ctx.allocate(result->getPlaceholder());
 
   Function *TF = glow::differentiate(F, TC);
-  EE.compile(CompilationMode::Train, TF, ctx);
+  EE.compile(CompilationMode::Train, TF);
 
   // --  STEP1 - train the network. --
   Tensor images(ElemKind::FloatTy, {numSamples, 10, 10, 1});
@@ -1155,7 +1155,7 @@ TEST_P(InterpreterAndCPU, testFindPixelRegression) {
 
   // Profiled 'F'.
   Function *PF = glow::profileQuantization(ctx, F);
-  EE.compile(CompilationMode::Infer, PF, ctx);
+  EE.compile(CompilationMode::Infer, PF);
 
   // Run the graph to capture the profile.
   runBatch(EE, ctx, 100, sampleCounter, {input}, {&images});
@@ -1171,7 +1171,7 @@ TEST_P(InterpreterAndCPU, testFindPixelRegression) {
   // Set the execution backend to the backend that we test.
   EE.setBackend(GetParam());
 
-  EE.compile(CompilationMode::Infer, QP, ctx);
+  EE.compile(CompilationMode::Infer, QP);
 
   // Generate the images used for testing.
   Tensor testImages(ElemKind::FloatTy, {batchSize, 10, 10, 1});
@@ -1329,14 +1329,14 @@ TEST_P(MLTest, matrixRotationRecognition) {
   Tensor expected(ElemKind::Int64ITy, {numSamples, 1});
   generateMatrixRotationRecognitionData(matricesA, matricesB, expected, PRNG);
 
-  EE_.compile(CompilationMode::Train, trainingGradientFunction, ctx);
+  EE_.compile(CompilationMode::Train, trainingGradientFunction);
   // Training:
   runBatch(EE_, ctx, 200, sampleCounter,
            {varMatricesA, varMatricesB, varExpected},
            {&matricesA, &matricesB, &expected});
 
   // Switch to inference mode.
-  EE_.compile(CompilationMode::Infer, F, ctx);
+  EE_.compile(CompilationMode::Infer, F);
 
   // At this point we should have overfitted the data.
   // Take a random batch and check that the values match what we expect.

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -70,7 +70,7 @@ TEST_P(Operator, pow) {
   ctx_.allocate(savePlaceholder2);
   ctx_.allocate(savePlaceholder3);
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
 
   EE_.run(ctx_);
 
@@ -99,7 +99,7 @@ TEST_P(InterpAndCPU, replaceNaN) {
   auto *save = F_->createSave("save", RNN);
   auto *saveTensor = ctx_.allocate(save->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
 
   EE_.run(ctx_);
 
@@ -124,7 +124,7 @@ TEST_P(InterpAndCPU, log) {
   auto *save = F_->createSave("save", LN);
   auto *saveTensor = ctx_.allocate(save->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
 
   EE_.run(ctx_);
 
@@ -172,7 +172,7 @@ TEST_P(InterpAndCPU, logit) {
   // i.e., logistic(logit(p)) == p
   auto logistic_test = [](float x) { return 1.0f / (1.0f + std::exp(-x)); };
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   // results: differential test against the oracle
@@ -205,7 +205,7 @@ TEST_P(InterpAndCPU, CmpEQ) {
   auto *save = F_->createSave("save", cmpEQ);
   auto *saveTensor = ctx_.allocate(save->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
 
   EE_.run(ctx_);
 
@@ -232,7 +232,7 @@ TEST_P(Operator, add) {
   auto *S = F_->createSave("save", Pool);
   ctx_.allocate(S->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto result = ctx_.get(S->getPlaceholder())->getHandle();
@@ -258,7 +258,7 @@ TEST_P(InterpOnly, FP16Add) {
   auto *S = F_->createSave("save", Pool);
   ctx_.allocate(S->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto result = ctx_.get(S->getPlaceholder())->getHandle<float16_t>();
@@ -281,7 +281,7 @@ TEST_P(Operator, matmul) {
   auto *save = F_->createSave("save", R);
   auto *saveTensor = ctx_.allocate(save->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto H = saveTensor->getHandle();
@@ -302,7 +302,7 @@ TEST_P(InterpOnly, FP16Matmul) {
   auto *save = F_->createSave("save", R);
   auto *saveTensor = ctx_.allocate(save->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto H = saveTensor->getHandle<float16_t>();
@@ -324,7 +324,7 @@ TEST_P(Operator, BroadcastedBatchMatMul) {
   auto *save = F_->createSave("save", R);
   auto *result = ctx_.allocate(save->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto H = result->getHandle();
@@ -349,7 +349,7 @@ TEST_P(Operator, ParallelBatchMatMul) {
   auto *save = F_->createSave("save", R);
   auto *result = ctx_.allocate(save->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto H = result->getHandle();
@@ -371,7 +371,7 @@ TEST_P(Operator, batchedReduceAdd) {
   auto *save = F_->createSave("save", R);
   auto *result = ctx_.allocate(save->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto H = result->getHandle();
@@ -391,7 +391,7 @@ TEST_P(InterpAndCPU, batchedReduceAddWithAxis) {
   auto *save = F_->createSave("save", R);
   auto *result = ctx_.allocate(save->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto H = result->getHandle();
@@ -421,7 +421,7 @@ TEST_P(InterpAndCPU, batchedReduceAddQuantized) {
   auto *save = F_->createSave("save", R);
   auto OH = ctx_.allocate(save->getPlaceholder())->getHandle<int8_t>();
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   for (size_t i = 0; i < 8; i++) {
@@ -454,7 +454,7 @@ TEST_P(InterpAndCPU, batchedReduceAddQuantizedWithAxis) {
   auto *save = F_->createSave("save", R);
   auto OH = ctx_.allocate(save->getPlaceholder())->getHandle<int8_t>();
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   for (size_t i = 0; i < 2; i++) {
@@ -481,7 +481,7 @@ TEST_P(Operator, batchedReduceMean) {
   auto *save = F_->createSave("save", R);
   auto *result = ctx_.allocate(save->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto H = result->getHandle();
@@ -501,7 +501,7 @@ TEST_P(InterpAndCPU, batchedReduceMeanWithAxis) {
   auto *save = F_->createSave("save", R);
   auto *result = ctx_.allocate(save->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto H = result->getHandle();
@@ -531,7 +531,7 @@ TEST_P(InterpAndCPU, batchedReduceMeanQuantized) {
   auto *save = F_->createSave("save", R);
   auto OH = ctx_.allocate(save->getPlaceholder())->getHandle<int8_t>();
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   for (size_t i = 0; i < 8; i++) {
@@ -564,7 +564,7 @@ TEST_P(InterpAndCPU, batchedReduceMeanQuantizedWithAxis) {
   auto *save = F_->createSave("save", R);
   auto OH = ctx_.allocate(save->getPlaceholder())->getHandle<int8_t>();
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   for (size_t i = 0; i < 2; i++) {
@@ -596,7 +596,7 @@ TEST_P(Operator, BatchedAdd) {
   auto *save = F_->createSave("save", R);
   auto *result = ctx_.allocate(save->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto BH = ctx_.get(batch)->getHandle();
@@ -643,7 +643,7 @@ TEST_P(InterpAndCPU, broadcastSimple) {
   auto *saveQ = F_->createSave("saveQ", QR);
   auto *broadcastedQ = ctx_.allocate(saveQ->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto broadcastedBHandle = broadcasted->getHandle();
@@ -707,7 +707,7 @@ TEST_P(InterpAndCPU, broadcast) {
   auto *saveQ = F_->createSave("saveQ", QR);
   auto *broadcastedQ = ctx_.allocate(saveQ->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto broadcastedBHandle = broadcasted->getHandle();
@@ -759,7 +759,7 @@ TEST_P(Operator, weightedSum) {
   auto *save = F_->createSave("save", WS);
   auto *saveTensor = ctx_.allocate(save->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   // Verify the weighted sum was correctly calculated.
@@ -783,7 +783,7 @@ TEST_P(Operator, minElem) {
   ctx_.allocate(LHS)->getHandle().randomize(-10, 10, PRNG);
   ctx_.allocate(RHS)->getHandle().randomize(-10, 10, PRNG);
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto resultH = result->getHandle();
@@ -809,7 +809,7 @@ TEST_P(Operator, maxElem) {
   ctx_.allocate(LHS)->getHandle().randomize(-10, 10, PRNG);
   ctx_.allocate(RHS)->getHandle().randomize(-10, 10, PRNG);
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto resultH = result->getHandle();
@@ -830,7 +830,7 @@ TEST_P(Operator, ReluSimple) {
 
   ctx_.allocate(in)->getHandle() = {0, -1, -2, -3, 4, 5, 6};
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto resultH = result->getHandle();
@@ -863,7 +863,7 @@ TEST_P(Operator, TopK) {
   F_->createSave("save.values", {R, 0}, values);
   F_->createSave("save.indices", {R, 1}, indices);
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
 
   EE_.run(ctx_);
 
@@ -920,7 +920,7 @@ TEST_P(InterpAndCPU, ConcatTopK) {
   auto *saveIndices = F_->createSave("Save.Indices", CI, indices);
   auto *saveIndicesTensor = ctx_.allocate(saveIndices->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
 
   EE_.run(ctx_);
 
@@ -984,7 +984,7 @@ TEST_P(Operator, matMul) {
   auto *res2 = F_->createSave("save.values", A2);
   ctx_.allocate(res2->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
 
   EE_.run(ctx_);
 
@@ -1017,7 +1017,7 @@ TEST_P(InterpAndCPU, TopK1) {
   auto *indices = F_->createSave("save.indices", {R, 1});
   ctx_.allocate(indices->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto V = ctx_.get(values->getPlaceholder())->getHandle();
@@ -1045,7 +1045,7 @@ TEST_P(InterpAndCPU, QuantizedTopK) {
   auto *indices = F_->createSave("save.indices", TK->getIndices());
   ctx_.allocate(indices->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto VH = ctx_.get(values->getPlaceholder())->getHandle<int8_t>();
@@ -1115,7 +1115,7 @@ TEST_P(Operator, Gather) {
   auto *result = F_->createSave("save", R);
   ctx_.allocate(result->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto H = ctx_.get(result->getPlaceholder())->getHandle();
@@ -1150,7 +1150,7 @@ TEST_P(Operator, Transpose2Dims) {
   auto *result = F_->createSave("saveTranspose", tr);
   ctx_.allocate(result->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   Tensor dest(ElemKind::FloatTy, {13, 20});
@@ -1167,7 +1167,7 @@ TEST_P(InterpOnly, FP16Transpose2Dims) {
   auto *result = F_->createSave("saveTranspose", tr);
   ctx_.allocate(result->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   Tensor dest(ElemKind::Float16Ty, {13, 20});
@@ -1210,7 +1210,7 @@ TEST_P(Operator, Transpose3Dims) {
   // We should have exactly 6 possible permutations for 3 dimensions.
   EXPECT_EQ(6, nbOfShuffle);
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   for (int i = 0; i < 6; ++i) {
@@ -1265,7 +1265,7 @@ TEST_P(InterpAndCPU, GatherSizeT) {
   auto *result = F_->createSave("save", R);
   ctx_.allocate(result->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto H = ctx_.get(result->getPlaceholder())->getHandle<int64_t>();
@@ -1323,7 +1323,7 @@ TEST_P(Operator, BatchedGather) {
   auto *result = F_->createSave("save", R);
   ctx_.allocate(result->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto H = ctx_.get(result->getPlaceholder())->getHandle();
@@ -1351,7 +1351,7 @@ TEST_P(Operator, ScatterAssign) {
   auto *result = F_->createSave("save", R);
   ctx_.allocate(result->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto H = ctx_.get(result->getPlaceholder())->getHandle();
@@ -1393,7 +1393,7 @@ TEST_P(InterpAndCPU, ScatterAssignQuantized) {
   auto *result = F_->createSave("save", DQ);
   ctx_.allocate(result->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto H = ctx_.get(result->getPlaceholder())->getHandle();
@@ -1428,7 +1428,7 @@ TEST_P(Operator, QuantizeAndDequantize) {
   auto *fpResult = F_->createSave("fpSave", fpAdd);
   ctx_.allocate(fpResult->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   EXPECT_TRUE(ctx_.get(result->getPlaceholder())
@@ -1453,7 +1453,7 @@ TEST_P(InterpOnly, FP16QuantizeAndDequantize) {
   auto *fpResult = F_->createSave("fpSave", fpAdd);
   ctx_.allocate(fpResult->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   EXPECT_TRUE(ctx_.get(result->getPlaceholder())
@@ -1488,7 +1488,7 @@ TEST_P(Operator, IntMatMul) {
   auto *result = F_->createSave("save", rq);
   ctx_.allocate(result->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   /*
@@ -1538,7 +1538,7 @@ TEST_P(InterpAndCPU, IntBatchedArith) {
 
   auto *result = F_->createSave("save", rq);
   ctx_.allocate(result->getPlaceholder());
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
 
   EE_.run(ctx_);
 
@@ -1604,7 +1604,7 @@ void checkFloat16Convolution(ExecutionEngine &EE, Function *F,
       ctx.allocate(llvm::cast<Placeholder>(saveFloat16->getOutput()))
           ->getHandle<float16_t>();
 
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   EE.run(ctx);
 
@@ -1662,7 +1662,7 @@ void checkIntConvolution(ExecutionEngine &EE, Function *F, unsigned convDepth,
 
   auto *res = F->createSave("save", sub);
   ctx.allocate(res->getPlaceholder());
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   EE.run(ctx);
   auto H = ctx.get(res->getPlaceholder())->getHandle();
@@ -1703,7 +1703,7 @@ TEST_P(InterpAndCPU, IntConcat) {
 
   auto *res = F_->createSave("save", sub);
   ctx_.allocate(res->getPlaceholder());
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto R = ctx_.get(res->getPlaceholder())->getHandle();
@@ -1747,7 +1747,7 @@ TEST_P(Operator, IntFC) {
   auto *res = F_->createSave("save", sub);
   ctx_.allocate(res->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto H = ctx_.get(res->getPlaceholder())->getHandle();
@@ -1772,7 +1772,7 @@ TEST_P(InterpAndCPU, EntropyLossTest) {
   auto *L = F_->createSave("save", ceLoss);
   ctx_.allocate(L->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto R = ctx_.get(L->getPlaceholder())->getHandle();
@@ -1793,7 +1793,7 @@ TEST_P(Operator, Max) {
   auto *S = F_->createSave("save", Max);
   ctx_.allocate(S->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto result = ctx_.get(S->getPlaceholder())->getHandle<float>();
@@ -1819,7 +1819,7 @@ TEST_P(InterpOnly, FP16Max) {
   auto *S = F_->createSave("save", Max);
   ctx_.allocate(S->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto result = ctx_.get(S->getPlaceholder())->getHandle<float16_t>();
@@ -1850,7 +1850,7 @@ TEST_P(Operator, RescaleNode) {
   auto *output = F_->createSave("save", Z);
   ctx_.allocate(output->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto RI = ctx_.get(input)->getHandle<int8_t>();
@@ -1939,7 +1939,7 @@ TEST_P(InterpAndCPU, QuantizedArithmeticRescaled) {
   ctx_.allocate(O5->getPlaceholder());
   ctx_.allocate(O6->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   for (size_t i = 0; i < len; i++) {
@@ -1979,7 +1979,7 @@ TEST_P(Operator, QuantizedTranspose) {
   auto *fpResult = F_->createSave("fpRet", fpTr);
   ctx_.allocate(fpResult->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   EXPECT_TRUE(ctx_.get(result->getPlaceholder())->isEqual(*ctx_.get(B)));
@@ -2046,7 +2046,7 @@ TEST_P(Operator, QuantizedArithmeticUnrescaled) {
   auto O5H = ctx_.get(O5->getPlaceholder())->getHandle<int8_t>();
   auto O6H = ctx_.get(O6->getPlaceholder())->getHandle<int8_t>();
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   for (size_t i = 0; i < len; i++) {
@@ -2106,7 +2106,7 @@ TEST_P(InterpAndCPU, QuantizedCmpLTEAndSelect) {
   auto *out = F_->createSave("save", select);
   auto OH = ctx_.allocate(out->getPlaceholder())->getHandle<int8_t>();
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   int count_strict = 0;
@@ -2166,7 +2166,7 @@ TEST_P(Operator, TestQuantizedRescaleSequence) {
   // Test a sequence of rescale operations t
   auto *result = F_->createSave("save", DQ);
   auto OH = ctx_.allocate(result->getPlaceholder())->getHandle();
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   for (size_t i = 0; i < len; i++) {
@@ -2205,7 +2205,7 @@ TEST_P(Operator, FCGradientCheck) {
   initB.getHandle() = {-13.1f, 3.14f};
 
   Function *DF = glow::differentiate(F_, TC, "d_main");
-  EE_.compile(CompilationMode::Train, DF, ctx_);
+  EE_.compile(CompilationMode::Train, DF);
   runBatch(EE_, ctx_, 3, sampleCounter, {A, B}, {&initA, &initB});
 
   EXPECT_NEAR(ctx_.get(X)->getHandle().raw(0), -0.21294, 1E-5);
@@ -2241,7 +2241,7 @@ TEST_P(InterpAndCPU, concatVectors) {
     I3.getHandle<int64_t>().at({i + 20}) = i + 50;
   }
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
 
   // Testing the output vector.
   updateInputPlaceholders(ctx_, {V1, V2, V3}, {&I1, &I2, &I3});
@@ -2282,7 +2282,7 @@ TEST_P(InterpAndCPU, concatVectorsRepeated) {
     I2.getHandle<int64_t>().at({i + 10}) = 2;
   }
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
 
   // Testing the output vector.
   updateInputPlaceholders(ctx_, {V1, V2}, {&I1, &I2});
@@ -2327,7 +2327,7 @@ TEST_P(InterpAndCPU, sliceVectors) {
     I.getHandle<int64_t>().at({2, j}) = j + 60;
   }
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
 
   // Testing the output slices.
   updateInputPlaceholders(ctx_, {V}, {&I});
@@ -2383,7 +2383,7 @@ TEST_P(InterpAndCPU, sliceConcatVectors) {
   auto *result = F_->createSave("ret", C2);
   ctx_.allocate(result->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
 
   updateInputPlaceholders(ctx_, {V}, {&I});
   EE_.run(ctx_);
@@ -2425,7 +2425,7 @@ TEST_P(InterpAndCPU, Tile) {
     }
   }
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
 
   updateInputPlaceholders(ctx_, {V}, {&VT});
   EE_.run(ctx_);
@@ -2477,7 +2477,7 @@ TEST_P(InterpAndCPU, QuantizedTile) {
     }
   }
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
 
   updateInputPlaceholders(ctx_, {V}, {&VT});
   EE_.run(ctx_);
@@ -2531,7 +2531,7 @@ TEST_P(Operator, simpleCmpSelectPredication) {
   auto *SN = F_->createSave("ret", data);
   ctx_.allocate(SN->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto H = ctx_.get(SN->getPlaceholder())->getHandle();
@@ -2573,7 +2573,7 @@ TEST_P(Operator, simplePredication) {
   FC1->setPredicate(pred);
   FC2->setPredicate(pred);
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 }
 
@@ -2586,7 +2586,7 @@ TEST_P(InterpAndCPU, ChannelShuffle) {
   SaveNode *S = F_->createSave("save", CS);
   ctx_.allocate(S->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto results = ctx_.get(S->getPlaceholder())->getHandle();
@@ -2611,7 +2611,7 @@ TEST_P(Operator, Squeeze) {
     SaveNode *S = F_->createSave("save", SQZ);
     ctx_.allocate(S->getPlaceholder());
 
-    EE_.compile(CompilationMode::Infer, F_, ctx_);
+    EE_.compile(CompilationMode::Infer, F_);
     EE_.run(ctx_);
 
     auto results = ctx_.get(S->getPlaceholder())->getHandle();
@@ -2628,7 +2628,7 @@ TEST_P(Operator, Squeeze) {
     SaveNode *S = F_->createSave("save", SQZ);
     ctx_.allocate(S->getPlaceholder());
 
-    EE_.compile(CompilationMode::Infer, F_, ctx_);
+    EE_.compile(CompilationMode::Infer, F_);
     EE_.run(ctx_);
 
     auto results = ctx_.get(S->getPlaceholder())->getHandle();
@@ -2653,7 +2653,7 @@ TEST_P(Operator, Squeeze) {
     ctx_.allocate(S1->getPlaceholder());
     ctx_.allocate(S2->getPlaceholder());
 
-    EE_.compile(CompilationMode::Infer, F_, ctx_);
+    EE_.compile(CompilationMode::Infer, F_);
     EE_.run(ctx_);
 
     auto res1 = ctx_.get(S1->getPlaceholder())->getHandle();
@@ -2679,7 +2679,7 @@ TEST_P(Operator, ExpandDims) {
   SaveNode *S = F_->createSave("save", EDN);
   ctx_.allocate(S->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   // Expected dims based on the axes above; inserted new dimensions of 1 in
@@ -2715,7 +2715,7 @@ TEST_P(InterpAndCPU, Split) {
   ctx_.allocate(S3->getPlaceholder());
   ctx_.allocate(S4->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto result = ctx_.get(S1->getPlaceholder())->getHandle();
@@ -2777,7 +2777,7 @@ TEST_P(Operator, IntRelu) {
   auto *save = F_->createSave("save", dequantize);
   ctx_.allocate(mod_.getPlaceholders());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto result = ctx_.get(save->getPlaceholder())->getHandle();
@@ -2799,7 +2799,7 @@ TEST_P(Operator, IntSplat) {
 
   auto *save = F_->createSave("save", dequantize);
   ctx_.allocate(mod_.getPlaceholders());
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto result = ctx_.get(save->getPlaceholder())->getHandle();
@@ -2817,7 +2817,7 @@ TEST_P(InterpOnly, Fp16Splat) {
 
   auto *save = F_->createSave("save", splat);
   ctx_.allocate(mod_.getPlaceholders());
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto result = ctx_.get(save->getPlaceholder())->getHandle<float16_t>();
@@ -2853,7 +2853,7 @@ TEST_P(Operator, GroupConvolution) {
   SaveNode *S = F_->createSave("save", CN);
   ctx_.allocate(S->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto result = ctx_.get(S->getPlaceholder())->getHandle();
@@ -2903,7 +2903,7 @@ TEST_P(Operator, NonSquarePaddingConvolution) {
   SaveNode *S = F_->createSave("save", CN);
   ctx_.allocate(S->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
   Tensor &result = *ctx_.get(S->getPlaceholder());
 
@@ -2924,7 +2924,7 @@ TEST_P(Operator, NonSquarePaddingConvolution) {
   S = refF->createSave("save1", CN);
   ctx_.allocate(S->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, refF, ctx_);
+  EE_.compile(CompilationMode::Infer, refF);
   EE_.run(ctx_);
   Tensor &result1 = *ctx_.get(S->getPlaceholder());
 
@@ -2946,7 +2946,7 @@ TEST_P(Operator, NonSquarePaddingAveragePool) {
   auto *S = F_->createSave("save", Pool);
   ctx_.allocate(S->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
   Tensor &result = *ctx_.get(S->getPlaceholder());
 
@@ -2963,7 +2963,7 @@ TEST_P(Operator, NonSquarePaddingAveragePool) {
   Pool = refF->createAvgPool("pool1", input1, 2, 1, 0);
   S = refF->createSave("save1", Pool);
   ctx_.allocate(S->getPlaceholder());
-  EE_.compile(CompilationMode::Infer, refF, ctx_);
+  EE_.compile(CompilationMode::Infer, refF);
   EE_.run(ctx_);
   Tensor &result1 = *ctx_.get(S->getPlaceholder());
 
@@ -2985,7 +2985,7 @@ TEST_P(Operator, NonSquarePaddingMaxPool) {
   auto *S = F_->createSave("save", Pool);
   ctx_.allocate(S->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   Tensor &result = *ctx_.get(S->getPlaceholder());
@@ -3004,7 +3004,7 @@ TEST_P(Operator, NonSquarePaddingMaxPool) {
   S = refF->createSave("save1", Pool);
   ctx_.allocate(S->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, refF, ctx_);
+  EE_.compile(CompilationMode::Infer, refF);
   EE_.run(ctx_);
 
   Tensor &result1 = *ctx_.get(S->getPlaceholder());
@@ -3021,7 +3021,7 @@ TEST_P(InterpOnly, FP16AvgPool) {
   auto *S = F_->createSave("save", Pool);
   ctx_.allocate(S->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto *result = ctx_.get(S->getPlaceholder());
@@ -3039,7 +3039,7 @@ TEST_P(Operator, AvgPool) {
   auto *S = F_->createSave("save", Pool);
   ctx_.allocate(S->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto *result = ctx_.get(S->getPlaceholder());
@@ -3056,7 +3056,7 @@ TEST_P(Operator, Int8AvgPool) {
   auto *S = F_->createSave("save", Pool);
   ctx_.allocate(S->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto result = ctx_.get(S->getPlaceholder())->getHandle<int8_t>();
@@ -3075,7 +3075,7 @@ TEST_P(Operator, MaxPool) {
   auto *S = F_->createSave("save", pool);
   ctx_.allocate(S->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto result = ctx_.get(S->getPlaceholder());
@@ -3093,7 +3093,7 @@ TEST_P(InterpOnly, FP16MaxPool) {
   auto *S = F_->createSave("save", pool);
   ctx_.allocate(S->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto result = ctx_.get(S->getPlaceholder());
@@ -3110,7 +3110,7 @@ TEST_P(Operator, Int8MaxPool) {
   auto *S = F_->createSave("save", Pool);
   ctx_.allocate(S->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto result = ctx_.get(S->getPlaceholder())->getHandle<int8_t>();
@@ -3148,7 +3148,7 @@ TEST_P(InterpAndCPU, Int8Tanh) {
   auto *saveInt = F_->createSave("int8Save", dequantize);
   ctx_.allocate(saveInt->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto fpResult = ctx_.get(saveFp->getPlaceholder())->getHandle();
@@ -3170,7 +3170,7 @@ TEST_P(Operator, Tanh) {
   auto *save = F_->createSave("Save", tanh);
   ctx_.allocate(save->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto resultH = ctx_.get(save->getPlaceholder())->getHandle();
@@ -3218,7 +3218,7 @@ TEST_P(InterpAndCPU, Int8Log) {
   auto *saveInt = F_->createSave("int8Save", dequantize);
   ctx_.allocate(saveInt->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   // Compare the results of the fp and quantized log.
@@ -3253,7 +3253,7 @@ TEST_P(Operator, NonSquareKernelConvolution) {
   SaveNode *S = F_->createSave("save", CN);
   ctx_.allocate(S->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
   Tensor &result = *ctx_.get(S->getPlaceholder());
 
@@ -3274,7 +3274,7 @@ TEST_P(InterpAndCPU, NonSquareKernelAveragePool) {
   auto *S = F_->createSave("save", Pool);
   ctx_.allocate(S->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
   Tensor &result = *ctx_.get(S->getPlaceholder());
 
@@ -3295,7 +3295,7 @@ TEST_P(InterpAndCPU, NonSquareKernelMaxPool) {
   auto *S = F_->createSave("save", Pool);
   ctx_.allocate(S->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
   Tensor &result = *ctx_.get(S->getPlaceholder());
 
@@ -3330,7 +3330,7 @@ TEST_P(Operator, NonSquareStrideConvolution) {
   SaveNode *S = F_->createSave("save", CN);
   ctx_.allocate(S->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
   Tensor &result = *ctx_.get(S->getPlaceholder());
 
@@ -3351,7 +3351,7 @@ TEST_P(InterpAndCPU, NonSquareStrideAveragePool) {
   auto *S = F_->createSave("save", Pool);
   ctx_.allocate(S->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
   Tensor &result = *ctx_.get(S->getPlaceholder());
 
@@ -3372,7 +3372,7 @@ TEST_P(InterpAndCPU, NonSquareStrideMaxPool) {
   auto *S = F_->createSave("save", Pool);
   ctx_.allocate(S->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
   Tensor &result = *ctx_.get(S->getPlaceholder());
 
@@ -3390,7 +3390,7 @@ TEST_P(InterpAndCPU, SigmoidOverflow) {
   auto *fpSigmoid = F_->createSigmoid("fpSigmoid", input);
   auto *S = F_->createSave("fpSave", fpSigmoid);
   ctx_.allocate(S->getPlaceholder());
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
   Tensor &result = *ctx_.get(S->getPlaceholder());
   static const float ref[] = {1, 0};
@@ -3425,7 +3425,7 @@ TEST_P(InterpAndCPU, Int8Sigmoid) {
   auto *saveInt = F_->createSave("int8Save", dequantize);
   ctx_.allocate(saveInt->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto fpResult = ctx_.get(saveFp->getPlaceholder())->getHandle();
@@ -3450,7 +3450,7 @@ TEST_P(Operator, BatchAdd) {
   auto *S = F_->createSave("save", batchAdd);
   ctx_.allocate(S->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto result = ctx_.get(S->getPlaceholder())->getHandle<float>();
@@ -3477,7 +3477,7 @@ TEST_P(InterpOnly, FP16BatchAdd) {
   auto *S = F_->createSave("save", batchAdd);
   ctx_.allocate(S->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto result = ctx_.get(S->getPlaceholder())->getHandle<float16_t>();
@@ -3501,7 +3501,7 @@ TEST_P(Operator, Sigmoid) {
   auto *save = F_->createSave("Save", sigmoid);
   ctx_.allocate(save->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto RH = ctx_.get(save->getPlaceholder())->getHandle();
@@ -3532,7 +3532,7 @@ TEST_P(InterpAndCPU, IntLookupTable) {
   auto save = F_->createSave("save", lookupTable);
   ctx_.allocate(save->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto result = ctx_.get(save->getPlaceholder())->getHandle<int8_t>();
@@ -3567,7 +3567,7 @@ TEST_P(Operator, testBatchAdd) {
   auto *result = F_->createSave("save", cc);
   ctx_.allocate(result->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto RH = ctx_.get(result->getPlaceholder())->getHandle();
@@ -3620,7 +3620,7 @@ static void quantizedBatchAdd(ExecutionEngine &EE, Function *F, Context &ctx,
   // Remove the reference to the graph nodes to allow DCE to remove them.
   adds.clear();
 
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
   EE.run(ctx);
 
   auto RH = ctx.get(result->getPlaceholder())->getHandle();
@@ -3675,7 +3675,7 @@ TEST_P(InterpAndCPU, LengthsSum) {
   auto *S = F_->createSave("save", R);
   ctx_.allocate(S->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   Tensor &result = *ctx_.get(S->getPlaceholder());
@@ -3722,7 +3722,7 @@ TEST_P(InterpAndCPU, SparseLengthsSum) {
   auto *S = F_->createSave("save", R);
   ctx_.allocate(S->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   Tensor &result = *ctx_.get(S->getPlaceholder());
@@ -3772,7 +3772,7 @@ TEST_P(InterpOnly, SparseLengthsSumI8) {
   auto *S = F_->createSave("save", R);
   ctx_.allocate(S->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   Tensor &result = *ctx_.get(S->getPlaceholder());
@@ -3822,7 +3822,7 @@ TEST_P(InterpAndCPU, SparseLengthsWeightedSum) {
   auto *S = F_->createSave("save", R);
   ctx_.allocate(S->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   Tensor &result = *ctx_.get(S->getPlaceholder());
@@ -3877,7 +3877,7 @@ TEST_P(InterpOnly, SparseLengthsWeightedSumI8) {
   auto *S = F_->createSave("save", R);
   ctx_.allocate(S->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   Tensor &result = *ctx_.get(S->getPlaceholder());
@@ -3918,7 +3918,7 @@ TEST_P(InterpAndCPU, SparseToDense) {
   auto *S = F_->createSave("save", STDN);
   ctx_.allocate(S->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   Tensor &result = *ctx_.get(S->getPlaceholder());
@@ -3949,7 +3949,7 @@ TEST_P(InterpOnly, FP16Reshape) {
   auto *result = F_->createSave("saveTranspose", tr);
   ctx_.allocate(result->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto outputHandle =
@@ -3970,7 +3970,7 @@ TEST_P(Operator, Reshape) {
   auto *result = F_->createSave("saveReshape", RN);
   ctx_.allocate(result->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto outputHandle = ctx_.get(result->getPlaceholder())->getHandle();
@@ -3996,7 +3996,7 @@ TEST_P(Operator, ReshapeInt) {
   auto *result = F_->createSave("saveReshape", RN);
   ctx_.allocate(result->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto outputHandle = ctx_.get(result->getPlaceholder())->getHandle<int64_t>();
@@ -4025,7 +4025,7 @@ TEST_P(Operator, Select) {
   auto *result = F_->createSave("saveSelect", SN);
   ctx_.allocate(result->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto resH = ctx_.get(result->getPlaceholder())->getHandle();
@@ -4064,7 +4064,7 @@ TEST_P(Operator, sliceReshape) {
   ctx_.allocate(resultSSX->getPlaceholder());
   ctx_.allocate(resultRSSX->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
 
   EE_.run(ctx_);
 
@@ -4144,7 +4144,7 @@ TEST_P(Operator, Flatten) {
   ctx_.allocate(save4Dto2Da3->getPlaceholder());
   ctx_.allocate(save4Dto2Da4->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
 
   EE_.run(ctx_);
 
@@ -4192,7 +4192,7 @@ TEST_P(InterpAndCPU, DivSizeT) {
   auto *result = F_->createSave("save", R);
   ctx_.allocate(result->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto H = ctx_.get(result->getPlaceholder())->getHandle<int64_t>();
@@ -4246,7 +4246,7 @@ TEST_P(InterpAndCPU, SigmoidCrossEntropyWithLogits) {
   auto *result = F_->createSave("save", R);
   ctx_.allocate(result->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   Tensor expected(ElemKind::FloatTy, {2, 2});
@@ -4284,7 +4284,7 @@ TEST_P(InterpAndCPU, insertTensorTest) {
   SaveNode *result = F_->createSave("result", IN);
   ctx_.allocate(result->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
 
   EE_.run(ctx_);
 
@@ -4343,7 +4343,7 @@ TEST_P(InterpAndCPU, rowwiseQuantizedFCTest) {
 
   ctx_.allocate(save->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto H = ctx_.get(save->getPlaceholder())->getHandle();
@@ -4367,7 +4367,7 @@ TEST_P(Operator, SoftMax) {
   auto *S = F_->createSave("save", Pool);
   ctx_.allocate(S->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto result = ctx_.get(S->getPlaceholder());
@@ -4393,7 +4393,7 @@ TEST_P(InterpOnly, FP16SoftMax) {
   auto *S = F_->createSave("save", Pool);
   ctx_.allocate(S->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto result = ctx_.get(S->getPlaceholder());
@@ -4417,7 +4417,7 @@ TEST_P(Operator, QuantizeSimple) {
   auto *result = ctx_.allocate(save->getPlaceholder());
 
   EXPECT_EQ(F_->getNodes().size(), 4);
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
 
   EE_.run(ctx_);
   EXPECT_EQ(F_->getNodes().size(), 1);
@@ -4438,7 +4438,7 @@ TEST_P(InterpOnly, ConvertFromFloat16ToFloat) {
   auto *result = F_->createSave("save", convertTo);
   ctx_.allocate(result->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto *outputTensor = ctx_.get(result->getPlaceholder());
@@ -4460,7 +4460,7 @@ TEST_P(InterpOnly, ConvertFromFloatToFloat16) {
   auto *result = F_->createSave("save", convertTo);
   ctx_.allocate(result->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto *outputTensor = ctx_.get(result->getPlaceholder());
@@ -4481,7 +4481,7 @@ TEST_P(InterpOnly, NoopConvertFromFloatToFloat) {
   auto *result = F_->createSave("save", convertTo);
   ctx_.allocate(result->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   auto *outputTensor = ctx_.get(result->getPlaceholder());
@@ -4502,7 +4502,7 @@ TEST_P(InterpAndCPU, LengthsToRanges) {
   auto *S = F_->createSave("save", R);
   ctx_.allocate(S->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   Tensor &result = *ctx_.get(S->getPlaceholder());
@@ -4535,7 +4535,7 @@ TEST_P(InterpOnly, BatchOneHot) {
   auto *S = F_->createSave("save", R);
   ctx_.allocate(S->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_, ctx_);
+  EE_.compile(CompilationMode::Infer, F_);
   EE_.run(ctx_);
 
   Tensor &result = *ctx_.get(S->getPlaceholder());

--- a/tests/unittests/caffe2ImporterTest.cpp
+++ b/tests/unittests/caffe2ImporterTest.cpp
@@ -49,7 +49,7 @@ TEST(caffe2, importConv) {
   }
 
   auto res = ctx.get(output);
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   EE.run(ctx);
   auto result = res->getHandle();
@@ -311,7 +311,7 @@ TEST(caffe2, concatAddAxis) {
   EXPECT_TRUE(output->dims().vec() == expectedDims);
 
   auto res = ctx.get(output);
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   EE.run(ctx);
   // High level check on the content of the graph.
@@ -388,7 +388,7 @@ TEST(caffe2, concat) {
 
   ctx.allocate(mod.getPlaceholders());
   auto res = ctx.get(output);
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   EE.run(ctx);
   // High level check on the content of the graph.
@@ -592,7 +592,7 @@ TEST(caffe2, FC) {
     updateInputPlaceholdersByName(ctx, &mod, {"inputs"}, {&inputs});
   }
 
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
   EE.run(ctx);
 
   auto result = ctx.get(output)->getHandle();
@@ -641,7 +641,7 @@ TEST(caffe2, FCWithFlatten) {
   auto *reshape = llvm::dyn_cast<ReshapeNode>(fcNode->getInput());
   ASSERT_TRUE(reshape);
 
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
   EE.run(ctx);
   auto result = ctx.get(output)->getHandle();
   std::vector<size_t> expectedDims = {2, 4};
@@ -690,7 +690,7 @@ TEST(caffe2, FCTransposed) {
       llvm::dyn_cast<FullyConnectedNode>(saveNode->getInput().getNode());
   ASSERT_TRUE(fcNode);
 
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
   EE.run(ctx);
 
   auto result = ctx.get(output)->getHandle();
@@ -740,7 +740,7 @@ TEST(caffe2, FCTransposedWithFlatten) {
   auto *reshape = llvm::dyn_cast<ReshapeNode>(fcNode1->getInput());
   ASSERT_TRUE(reshape);
 
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
   EE.run(ctx);
   auto result = ctx.get(output)->getHandle();
   std::vector<size_t> expectedDims = {2, 4};
@@ -781,7 +781,7 @@ TEST(caffe2, importClip) {
   }
 
   auto *res = ctx.get(output);
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
   EE.run(ctx);
 
   auto result = res->getHandle();
@@ -828,7 +828,7 @@ TEST(caffe2, importClipDefault) {
   }
 
   auto *res = ctx.get(output);
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
   EE.run(ctx);
 
   auto result = res->getHandle();
@@ -879,7 +879,7 @@ TEST(caffe2, replaceNaN) {
 
   // Compile and run the model.
   auto *res = ctx.get(output);
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
   EE.run(ctx);
 
   auto result = res->getHandle();
@@ -964,7 +964,7 @@ TEST(caffe2, dotProduct1D) {
   // Compile and run the model.
   ctx.allocate(mod.getPlaceholders());
   auto *res = ctx.get(output);
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
   EE.run(ctx);
 
   auto result = res->getHandle();
@@ -1047,7 +1047,7 @@ TEST(caffe2, dotProduct2D) {
 
   // Compile and run the model.
   auto *res = ctx.get(output);
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
   EE.run(ctx);
 
   auto result = res->getHandle();
@@ -1206,7 +1206,7 @@ TEST(caffe2, batchBoxCox) {
 
   // Compile and run the model.
   auto *res = ctx.get(output);
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
   EE.run(ctx);
 
   auto result = res->getHandle();

--- a/tests/unittests/gradCheckTest.cpp
+++ b/tests/unittests/gradCheckTest.cpp
@@ -103,7 +103,7 @@ void performGradCheck(ExecutionEngine &EE, Context &ctx, SaveNode *result,
 
   // Create a function that trains the network.
   Function *TF = glow::differentiate(&F, TC);
-  EE.compile(CompilationMode::Train, TF, ctx);
+  EE.compile(CompilationMode::Train, TF);
 
   // The network might have variables, other than inputVar and expVar.
   // Train the network until other variables reach some stable local minimum.
@@ -114,7 +114,7 @@ void performGradCheck(ExecutionEngine &EE, Context &ctx, SaveNode *result,
   VariableGradientsList varGrads;
   Function *recordNet = glow::differentiate(&F, TC, "record", &varGrads);
   allocateGrads(ctx, varGrads);
-  EE.compile(CompilationMode::Train, recordNet, ctx);
+  EE.compile(CompilationMode::Train, recordNet);
 
   // Clear the gradients of the first layer.
   auto gradVar = getGrad(varGrads, inputVar);
@@ -125,7 +125,7 @@ void performGradCheck(ExecutionEngine &EE, Context &ctx, SaveNode *result,
   runBatch(EE, ctx, 1, sampleCounter, {inputVar, expVar}, {inputs, outputs});
 
   // Compile the original network in inference mode.
-  EE.compile(CompilationMode::Infer, &F, ctx);
+  EE.compile(CompilationMode::Infer, &F);
 
   auto analyticalGradsH = gradVarTensor->getHandle();
   auto inputsH = inputs->getHandle<>();
@@ -547,7 +547,7 @@ TEST_P(InterpreterGrad, gradientCheckCrossEntropyLoss) {
   VariableGradientsList varGrads;
   Function *TF = glow::differentiate(F, TC, "record", &varGrads);
   allocateGrads(ctx, varGrads);
-  EE_.compile(CompilationMode::Train, TF, ctx);
+  EE_.compile(CompilationMode::Train, TF);
 
   auto *gradPlaceholder = getGrad(varGrads, P);
   auto gradTensorHandle = ctx.get(gradPlaceholder)->getHandle();

--- a/tests/unittests/graphGradTest.cpp
+++ b/tests/unittests/graphGradTest.cpp
@@ -63,8 +63,8 @@ TEST(GraphAutoGrad, autoGrad) {
   (void)result;
 
   Function *TF = glow::differentiate(F, TC);
-  EE.compile(CompilationMode::Train, TF, ctx);
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Train, TF);
+  EE.compile(CompilationMode::Infer, F);
 }
 
 TEST(GraphAutoGrad, checkLRNGen) {
@@ -93,8 +93,8 @@ TEST(GraphAutoGrad, checkLRNGen) {
   auto *result = F->createSave("return", SM);
   (void)result;
   Function *TF = glow::differentiate(F, TC);
-  EE.compile(CompilationMode::Train, TF, ctx);
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Train, TF);
+  EE.compile(CompilationMode::Infer, F);
 }
 
 TEST(GraphAutoGrad, cloneAndDiff) {
@@ -174,8 +174,8 @@ TEST(GraphAutoGrad, checkPlaceholderGradTest) {
   EXPECT_EQ(A->getNumUsers(), 1);
 
   Function *TF = glow::differentiate(F, TC);
-  EE.compile(CompilationMode::Train, TF, ctx);
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Train, TF);
+  EE.compile(CompilationMode::Infer, F);
 
   // Check that the Placeholder has multiple users, because at least one write
   /// node will be added.
@@ -205,6 +205,6 @@ TEST(GraphAutoGrad, checkConvertToGradTest) {
   ctx.allocate(result->getPlaceholder());
 
   Function *TF = glow::differentiate(F, TC);
-  EE.compile(CompilationMode::Train, TF, ctx);
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Train, TF);
+  EE.compile(CompilationMode::Infer, F);
 }

--- a/tests/unittests/graphTest.cpp
+++ b/tests/unittests/graphTest.cpp
@@ -362,7 +362,7 @@ TEST(Graph, simpleQuant) {
   Node *O = F->createFullyConnected("fc1", conv, fcFilter, fcBias);
   Context ctx;
   F->createSave("ret", O);
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 }
 
 TEST(Graph, quantizeDequantizeNodes) {
@@ -382,7 +382,7 @@ TEST(Graph, quantizeDequantizeNodes) {
   auto *D = F->createDequantize("dequantize", A);
   Context ctx;
   F->createSave("ret", D);
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 }
 
 TEST(Graph, quantizeGather) {
@@ -395,7 +395,7 @@ TEST(Graph, quantizeGather) {
   auto *gather = F->createGather("gather", input, indices);
   Context ctx;
   F->createSave("ret", gather);
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 }
 
 TEST(Graph, cloneTest) {
@@ -493,7 +493,7 @@ TEST(Graph, NodeValue) {
   auto *S = F->createSave("Save", a);
   auto *res = ctx.allocate(S->getPlaceholder());
 
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   EE.run(ctx);
 
@@ -551,7 +551,7 @@ TEST(Graph, nodesWithPredicates) {
   auto *save = F->createSave("ret", SM);
   ctx.allocate(save->getPlaceholder());
 
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   updateInputPlaceholders(ctx, {input}, {&inputs});
   EE.run(ctx);
@@ -628,7 +628,7 @@ TEST(Graph, schedulingOfSavesOrderProvided) {
   // Copy the value of A.
   Tensor AOrig = ctx.get(A)->clone();
 
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   EE.run(ctx);
   auto *ret = ctx.get(saveNode->getPlaceholder());
@@ -673,7 +673,7 @@ TEST(Graph, schedulingOfSaves) {
   // Copy the value of A.
   Tensor AOrig = ctx.get(A)->clone();
 
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   EE.run(ctx);
   auto *ret = saveNode->getPlaceholder();

--- a/tests/unittests/onnxImporterTest.cpp
+++ b/tests/unittests/onnxImporterTest.cpp
@@ -71,7 +71,7 @@ TEST(onnx, importConv) {
   EXPECT_TRUE(tInNode->getKind() == Kinded::Kind::TransposeNodeKind);
   EXPECT_TRUE(tFilterNode->getKind() == Kinded::Kind::TransposeNodeKind);
 
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
   EE.run(ctx);
   auto result = ctx.get(graphOutputVar)->getHandle();
   std::vector<size_t> expectedDims = {1, 1, 4, 4};
@@ -120,7 +120,7 @@ TEST(onnx, importClip) {
   }
 
   auto *res = ctx.get(output);
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
   EE.run(ctx);
 
   auto result = res->getHandle();
@@ -152,7 +152,7 @@ TEST(onnx, importBatchMatMul) {
     ctx.allocate(mod.getPlaceholders());
   }
   auto *res = ctx.get(output);
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
   EE.run(ctx);
 
   auto result = res->getHandle();
@@ -234,7 +234,7 @@ TEST(onnx, importBatchBoxCox) {
   }
 
   auto *res = ctx.get(output);
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
   EE.run(ctx);
 
   auto result = res->getHandle();
@@ -321,7 +321,7 @@ TEST(onnx, importSumN) {
   }
 
   auto *res = ctx.get(output);
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
   EE.run(ctx);
 
   auto result = res->getHandle();
@@ -370,7 +370,7 @@ TEST(onnx, importSum1) {
   }
 
   auto *res = ctx.get(output);
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
   EE.run(ctx);
 
   auto result = res->getHandle();

--- a/tests/unittests/partitionTest.cpp
+++ b/tests/unittests/partitionTest.cpp
@@ -41,7 +41,7 @@ static void executeSerial(const FunctionDAG &G, Context &ctx,
                           llvm::ArrayRef<Tensor *> inputs) {
   for (auto *F : G.getFunctions()) {
     ExecutionEngine EE;
-    EE.compile(CompilationMode::Infer, F, ctx);
+    EE.compile(CompilationMode::Infer, F);
 
     updateInputPlaceholders(ctx, vars, inputs);
     EE.run(ctx);
@@ -103,7 +103,7 @@ TEST_F(PartitionTest, SerialExecution) {
   Tensor in(ElemKind::FloatTy, {1, 32});
   ExecutionEngine EE;
 
-  EE.compile(CompilationMode::Infer, F_, ctx_);
+  EE.compile(CompilationMode::Infer, F_);
   updateInputPlaceholders(ctx_, {input}, {&in});
   EE.run(ctx_);
   Tensor ref = res.clone();
@@ -149,7 +149,7 @@ TEST_F(PartitionTest, Branchover) {
   Tensor in(ElemKind::FloatTy, {1, 8});
   ExecutionEngine EE;
 
-  EE.compile(CompilationMode::Infer, F_, ctx_);
+  EE.compile(CompilationMode::Infer, F_);
   updateInputPlaceholders(ctx_, {input}, {&in});
   EE.run(ctx_);
   Tensor ref = res.clone();

--- a/tests/unittests/quantizationTest.cpp
+++ b/tests/unittests/quantizationTest.cpp
@@ -192,7 +192,7 @@ TEST(Quantization, quantizeGraph) {
   F = quantization::quantizeFunction(EE, QI, F);
 
   // Make sure that graph can be compiled and run.
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   EE.run(ctx);
 }
@@ -216,7 +216,7 @@ TEST(Quantization, quantizeReLU) {
       {NodeQuantizationInfo::generateNodeOutputName(relu->getName()),
        {0.2f, -128}}};
   F = quantization::quantizeFunction(EE, QI, F);
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   auto *save = llvm::cast<SaveNode>(F->getNodeByName("ret"));
   ASSERT_TRUE(llvm::isa<DequantizeNode>(save->getInput().getNode()));
@@ -300,7 +300,7 @@ TEST_P(Operator, end2end) {
   Function *F2 = F1->clone("main2");
   SaveNode *result1 = cast<SaveNode>(F1->getNodeByName("save"));
   F1 = glow::profileQuantization(ctx, F1);
-  profileEE.compile(CompilationMode::Infer, F1, ctx);
+  profileEE.compile(CompilationMode::Infer, F1);
 
   // Run graph to capture profile.
   profileEE.run(ctx);
@@ -313,7 +313,7 @@ TEST_P(Operator, end2end) {
   SaveNode *result2 = cast<SaveNode>(F2->getNodeByName("save"));
 
   F2 = quantization::quantizeFunction(backendSpecificEE, QI, F2);
-  backendSpecificEE.compile(CompilationMode::Infer, F2, ctx);
+  backendSpecificEE.compile(CompilationMode::Infer, F2);
   backendSpecificEE.run(ctx);
 
   // STEP3 - Compare the results of the original and quantized functions.
@@ -435,7 +435,7 @@ TEST_P(Operator, end2endGRU) {
   SaveNode *result1 = cast<SaveNode>(F1->getNodeByName("save"));
 
   F1 = glow::profileQuantization(ctx, F1);
-  profileEE.compile(CompilationMode::Infer, F1, ctx);
+  profileEE.compile(CompilationMode::Infer, F1);
 
   // Run graph to capture profile.
   profileEE.run(ctx);
@@ -448,7 +448,7 @@ TEST_P(Operator, end2endGRU) {
   SaveNode *result2 = cast<SaveNode>(F2->getNodeByName("save"));
 
   F2 = quantization::quantizeFunction(backendSpecificEE, QI, F2);
-  backendSpecificEE.compile(CompilationMode::Infer, F2, ctx);
+  backendSpecificEE.compile(CompilationMode::Infer, F2);
   backendSpecificEE.run(ctx);
 
   // STEP3 - Compare the results of the original and quantized functions.
@@ -482,7 +482,7 @@ TEST(Quantization, rescaleSameType) {
   auto *result = ctx.allocate(save->getPlaceholder());
 
   EXPECT_EQ(F->getNodes().size(), 3);
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   EE.run(ctx);
   EXPECT_EQ(F->getNodes().size(), 2);
@@ -508,7 +508,7 @@ TEST(Quantization, optimizeRescaleQuantize) {
   auto *result = ctx.allocate(save->getPlaceholder());
 
   EXPECT_EQ(F->getNodes().size(), 4);
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   EE.run(ctx);
   EXPECT_EQ(F->getNodes().size(), 1);
@@ -657,7 +657,7 @@ TEST(Quantization, reluCanUseSymmetricSchema) {
   SaveNode *SN = F->createSave("save", DN);
   auto *res = ctx.allocate(SN->getPlaceholder());
 
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
   EE.run(ctx);
 
   // Verify all negative values were correctly set to zero.
@@ -823,7 +823,7 @@ TEST(Quantization, quantizeGraphPartially) {
 
   // Make sure that graph can be compiled and run.
   ::glow::convertPlaceholdersToConstants(F, ctx, {result});
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   EE.run(ctx);
 
@@ -904,7 +904,7 @@ TEST(Quantization, quantizeGraphPartiallyMultipleNodes) {
 
   // Make sure that graph can be compiled and run.
   ::glow::convertPlaceholdersToConstants(F, ctx, {result});
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   EE.run(ctx);
 
@@ -995,7 +995,7 @@ TEST(Quantization, quantizeGraphPartiallyMultipleKinds) {
 
   // Make sure that graph can be compiled and run.
   ::glow::convertPlaceholdersToConstants(F, ctx, {result});
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   EE.run(ctx);
 
@@ -1105,7 +1105,7 @@ TEST(Quantization, quantizeFunctionConvertConstant) {
   }
 
   // Make sure that graph can be compiled and run.
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   EE.run(ctx);
 }
@@ -1176,7 +1176,7 @@ TEST(Quantization, quantizeSlice) {
   }
 
   // Make sure that graph can be compiled and run.
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   EE.run(ctx);
 }
@@ -1247,7 +1247,7 @@ TEST(Quantization, quantizeReshape) {
   }
 
   // Make sure that graph can be compiled and run.
-  EE.compile(CompilationMode::Infer, F, ctx);
+  EE.compile(CompilationMode::Infer, F);
 
   EE.run(ctx);
 }

--- a/tests/unittests/quantizationTest.cpp
+++ b/tests/unittests/quantizationTest.cpp
@@ -731,9 +731,8 @@ public:
   MockQuantBackend() {
     backend_.reset(createBackend(BackendKind::Interpreter));
   }
-  std::unique_ptr<CompiledFunction> compile(Function *F,
-                                            const Context &ctx) const override {
-    return backend_->compile(F, ctx);
+  std::unique_ptr<CompiledFunction> compile(Function *F) const override {
+    return backend_->compile(F);
   }
   bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override {
     if (opKind == Kinded::Kind::SoftMaxNodeKind ||

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -275,7 +275,7 @@ void Loader::compile(Context &ctx) {
     EE_.save(CompilationMode::Infer, F_, emitBundle, networkName);
   } else {
     // Emit IR for the graph and compile it.
-    EE_.compile(CompilationMode::Infer, F_, ctx);
+    EE_.compile(CompilationMode::Infer, F_);
   }
 
   if (dumpGraphOpt) {


### PR DESCRIPTION
*Description*: Unifies backends to a single run time api and calls setup/teardown from the ExecutionEngine. Removes context from compile and compileIR as it is no longer needed at compile time.
*Testing*: ninja test, run.sh and bundles all look good.
*Documentation*: N/A
Fixes #1904 