### PR TITLE
[opencl ci] Compile Glow with OpenCL and run some unit tests on CI.

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -6,6 +6,24 @@ set -ex
 
 export MAX_JOBS=8
 
+install_pocl() {
+   sudo apt-get install -y ocl-icd-opencl-dev clinfo libhwloc-dev
+   
+   wget https://github.com/pocl/pocl/archive/v1.2.tar.gz
+   tar xf v1.2.tar.gz
+   mkdir build_pocl
+   cd build_pocl
+   cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_ICD=ON ../pocl-1.2
+   make -j`nproc`
+   sudo make install
+
+   sudo mkdir -p /etc/OpenCL/vendors/
+   sudo cp /usr/local/etc/OpenCL/vendors/pocl.icd /etc/OpenCL/vendors/
+
+   clinfo
+   cd ../
+}
+
 # setup sccache wrappers
 if hash sccache 2>/dev/null; then
     SCCACHE_BIN_DIR="/tmp/sccache"
@@ -38,14 +56,17 @@ hash cmake ninja
 cd ${GLOW_DIR}
 mkdir build && cd build
 CMAKE_ARGS=()
-CMAKE_ARGS+=("-DGLOW_WITH_OPENCL=OFF")
 CMAKE_ARGS+=("-DGLOW_WITH_CPU=ON")
 if [[ "$CIRCLE_JOB" == ASAN ]]; then
     CMAKE_ARGS+=("-DGLOW_USE_SANITIZER='Address;Undefined'")
 fi
 if [[ "$CIRCLE_JOB" == DEBUG ]]; then
+    install_pocl
     CMAKE_ARGS+=("-DCMAKE_BUILD_TYPE=Debug")
+    CMAKE_ARGS+=("-DGLOW_WITH_OPENCL=ON")
+    CMAKE_ARGS+=("-DGLOW_RUN_OPENCL_TESTS=OFF")
 else
+    CMAKE_ARGS+=("-DGLOW_WITH_OPENCL=OFF")
     CMAKE_ARGS+=("-DCMAKE_BUILD_TYPE=Release")
 fi
 cmake -GNinja ${CMAKE_ARGS[*]} ../

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ enable_testing()
 
 option(GLOW_WITH_CPU "Build the LLVM-based JIT CPU backend" ON)
 option(GLOW_WITH_OPENCL "Build the OpenCL backend" ON)
+option(GLOW_RUN_OPENCL_TESTS "Run OpenCL tests if Glow is build with OpenCL" ON)
 option(GLOW_BUILD_EXAMPLES "Build the examples" ON)
 option(GLOW_BUILD_TESTS "Build the tests" ON)
 option(GLOW_WITH_BUNDLES "Build bundles" OFF)
@@ -55,6 +56,9 @@ endif ()
 
 if (GLOW_WITH_OPENCL)
   add_definitions(-DGLOW_WITH_OPENCL=1)
+  if (GLOW_RUN_OPENCL_TESTS)
+    add_definitions(-DGLOW_RUN_OPENCL_TESTS=1)
+  endif ()
   find_package(OpenCL REQUIRED)
 endif ()
 

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -30,7 +30,7 @@
 #if defined(__APPLE__) || defined(__MACOSX)
 #include "OpenCL/opencl.h"
 #else
-#include <CL/cl.hpp>
+#include <CL/cl.h>
 #endif
 
 namespace glow {

--- a/tests/unittests/BackendCorrectnessTest.cpp
+++ b/tests/unittests/BackendCorrectnessTest.cpp
@@ -577,6 +577,8 @@ INSTANTIATE_TEST_CASE_P(CPU, CPUOnly, ::testing::Values(BackendKind::CPU));
 #endif // GLOW_WITH_CPU
 
 #ifdef GLOW_WITH_OPENCL
+#ifdef GLOW_RUN_OPENCL_TESTS
 INSTANTIATE_TEST_CASE_P(OpenCL, BackendCorrectnessTest,
                         ::testing::Values(BackendKind::OpenCL));
+#endif
 #endif // GLOW_WITH_OPENCL

--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -275,9 +275,11 @@ INSTANTIATE_TEST_CASE_P(Interpreter, BackendTest,
 
 #ifdef GLOW_WITH_CPU
 INSTANTIATE_TEST_CASE_P(JIT, BackendTest, ::testing::Values(BackendKind::CPU));
-#endif
+#endif // GLOW_WITH_CPU
 
 #ifdef GLOW_WITH_OPENCL
+#ifdef GLOW_RUN_OPENCL_TESTS
 INSTANTIATE_TEST_CASE_P(OpenCL, BackendTest,
                         ::testing::Values(BackendKind::OpenCL));
-#endif
+#endif // GLOW_WITH_OPENCL
+#endif // GLOW_RUN_OPENCL_TESTS

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -187,7 +187,7 @@ target_link_libraries(UtilsTest
                         testMain)
 add_glow_test(UtilsTest ${GLOW_BINARY_DIR}/tests/UtilsTest)
 
-if(GLOW_WITH_OPENCL)
+if(GLOW_WITH_OPENCL AND GLOW_RUN_OPENCL_TESTS)
 add_executable(OCLTest
                BackendTestUtils.cpp
                OCLTest.cpp)

--- a/tests/unittests/MLTest.cpp
+++ b/tests/unittests/MLTest.cpp
@@ -1372,14 +1372,17 @@ INSTANTIATE_TEST_CASE_P(Interpreter, MLTest,
                         ::testing::Values(BackendKind::Interpreter));
 #ifdef GLOW_WITH_CPU
 INSTANTIATE_TEST_CASE_P(JIT, MLTest, ::testing::Values(BackendKind::CPU));
-#endif
+#endif // GLOW_WITH_CPU
+
 #ifdef GLOW_WITH_OPENCL
+#ifdef GLOW_RUN_OPENCL_TESTS
 INSTANTIATE_TEST_CASE_P(OpenCL, MLTest, ::testing::Values(BackendKind::OpenCL));
-#endif
+#endif // GLOW_RUN_OPENCL_TESTS
+#endif // GLOW_WITH_OPENCL
 
 INSTANTIATE_TEST_CASE_P(Interpreter, InterpreterAndCPU,
                         ::testing::Values(BackendKind::Interpreter));
 #ifdef GLOW_WITH_CPU
 INSTANTIATE_TEST_CASE_P(JIT, InterpreterAndCPU,
                         ::testing::Values(BackendKind::CPU));
-#endif
+#endif // GLOW_WITH_CPU

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -4562,6 +4562,8 @@ INSTANTIATE_TEST_CASE_P(CPU, InterpAndCPU, ::testing::Values(BackendKind::CPU));
 #endif // GLOW_WITH_CPU
 
 #ifdef GLOW_WITH_OPENCL
+#ifdef GLOW_RUN_OPENCL_TESTS
 INSTANTIATE_TEST_CASE_P(OpenCL, Operator,
                         ::testing::Values(BackendKind::OpenCL));
+#endif // GLOW_RUN_OPENCL_TESTS
 #endif // GLOW_WITH_OPENCL

--- a/tests/unittests/convTest.cpp
+++ b/tests/unittests/convTest.cpp
@@ -83,6 +83,8 @@ INSTANTIATE_TEST_CASE_P(CPU, ConvCorrectnessTest,
 #endif // GLOW_WITH_CPU
 
 #ifdef GLOW_WITH_OPENCL
+#ifdef GLOW_RUN_OPENCL_TESTS
 INSTANTIATE_TEST_CASE_P(OpenCL, ConvCorrectnessTest,
                         ::testing::Values(BackendKind::OpenCL));
+#endif // GLOW_RUN_OPENCL_TESTS
 #endif // GLOW_WITH_OPENCL


### PR DESCRIPTION
*Description*:
Add an option to compile with OpenCL support but do not run tests.
This is a first step to enable catching issues with OpenCL.

No major changes in build CI time for/after this PR.

See https://github.com/pytorch/glow/issues/1181 for details.

*Testing*:
CI

*Documentation*:
N/A

Follow up needs to enable tests with all the below fixed.
Failing tests:
```
[  FAILED  ] 11 tests, listed below:
[  FAILED  ] OpenCL/Operator.matMul/0, where GetParam() = 4-byte object <01-00 00-00>
[  FAILED  ] OpenCL/Operator.Transpose3Dims/0, where GetParam() = 4-byte object <01-00 00-00>
[  FAILED  ] OpenCL/Operator.ScatterAssign/0, where GetParam() = 4-byte object <01-00 00-00>
[  FAILED  ] OpenCL/Operator.TestQuantizedRescaleSequence/0, where GetParam() = 4-byte object <01-00 00-00>
[  FAILED  ] OpenCL/Operator.Squeeze/0, where GetParam() = 4-byte object <01-00 00-00>
[  FAILED  ] OpenCL/Operator.ExpandDims/0, where GetParam() = 4-byte object <01-00 00-00>
[  FAILED  ] OpenCL/Operator.Reshape/0, where GetParam() = 4-byte object <01-00 00-00>
[  FAILED  ] OpenCL/Operator.ReshapeInt/0, where GetParam() = 4-byte object <01-00 00-00>
[  FAILED  ] OpenCL/Operator.sliceReshape/0, where GetParam() = 4-byte object <01-00 00-00>
[  FAILED  ] OpenCL/Operator.Flatten/0, where GetParam() = 4-byte object <01-00 00-00>
[  FAILED  ] OpenCL/Operator.QuantizeSimple/0, where GetParam() = 4-byte object <01-00 00-00>


[  FAILED  ] OpenCL/BackendTest.simplePlaceholderValue/0, where GetParam() = 4-byte object <01-00 00-00> (103 ms)
```