### PR TITLE
[image] Factor out PNG processing

### DIFF
--- a/include/glow/Base/Image.h
+++ b/include/glow/Base/Image.h
@@ -21,6 +21,26 @@
 #include <tuple>
 
 namespace glow {
+
+enum class ImageNormalizationMode {
+  kneg1to1,     // Values are in the range: -1 and 1.
+  k0to1,        // Values are in the range: 0 and 1.
+  k0to255,      // Values are in the range: 0 and 255.
+  kneg128to127, // Values are in the range: -128 .. 127
+};
+
+enum class ImageLayout {
+  NCHW,
+  NHWC,
+};
+
+enum class ImageChannelOrder {
+  BGR,
+  RGB,
+};
+
+std::pair<float, float> normModeToRange(ImageNormalizationMode mode);
+
 /// Reads a png image header from png file \p filename and \returns a tuple
 /// containing height, width, and a bool if it is grayscale or not.
 std::tuple<size_t, size_t, bool> getPngInfo(const char *filename);
@@ -40,6 +60,11 @@ bool writePngImage(Tensor *T, const char *filename,
                    std::pair<float, float> range,
                    bool useImagenetNormalization = false);
 
+Tensor readPngImageAndPreprocess(const std::string &filename,
+                                 ImageNormalizationMode imageNormMode,
+                                 ImageChannelOrder imageChannelOrder,
+                                 ImageLayout imageLayer,
+                                 bool useImagenetNormalization);
 } // namespace glow
 
 #endif // GLOW_BASE_IMAGE_H

--- a/include/glow/Base/Image.h
+++ b/include/glow/Base/Image.h
@@ -22,6 +22,7 @@
 
 namespace glow {
 
+/// Pixel value ranges.
 enum class ImageNormalizationMode {
   kneg1to1,     // Values are in the range: -1 and 1.
   k0to1,        // Values are in the range: 0 and 1.
@@ -29,16 +30,19 @@ enum class ImageNormalizationMode {
   kneg128to127, // Values are in the range: -128 .. 127
 };
 
+/// Layout of image dimensions (batch, channels, height, width).
 enum class ImageLayout {
   NCHW,
   NHWC,
 };
 
+/// Order of color channels (red, green, blue).
 enum class ImageChannelOrder {
   BGR,
   RGB,
 };
 
+/// \returns the floating-point range corresponding to enum value \p mode.
 std::pair<float, float> normModeToRange(ImageNormalizationMode mode);
 
 /// Reads a png image header from png file \p filename and \returns a tuple
@@ -60,10 +64,16 @@ bool writePngImage(Tensor *T, const char *filename,
                    std::pair<float, float> range,
                    bool useImagenetNormalization = false);
 
-Tensor readPngImageAndPreprocess(const std::string &filename,
+/// Read a png image and preprocess it according to several parameters.
+/// \param filename the png file to read.
+/// \param imageNormMode normalize values to this range.
+/// \param imageChannelOrder the order of color channels.
+/// \param imageLayout the order of dimensions (channel, height, and width).
+/// \param useImagenetNormalization use special normalization for Imagenet.
+Tensor readPngImageAndPreprocess(llvm::StringRef filename,
                                  ImageNormalizationMode imageNormMode,
                                  ImageChannelOrder imageChannelOrder,
-                                 ImageLayout imageLayer,
+                                 ImageLayout imageLayout,
                                  bool useImagenetNormalization);
 } // namespace glow
 

--- a/lib/Base/Image.cpp
+++ b/lib/Base/Image.cpp
@@ -291,20 +291,15 @@ Tensor glow::readPngImageAndPreprocess(const std::string &filename,
                                        ImageChannelOrder imageChannelOrder,
                                        ImageLayout imageLayout,
                                        bool useImagenetNormalization) {
-  // Get image dimensions and check if grayscale or color.
-  size_t imgHeight;
-  size_t imgWidth;
-  bool isGray;
-  std::tie(imgHeight, imgWidth, isGray) = getPngInfo(filename.c_str());
-
-  const size_t numChannels = isGray ? 1 : 3;
-
   Tensor imageData;
   auto range = normModeToRange(imageNormMode);
   bool loadSuccess = !readPngImage(&imageData, filename.c_str(), range,
                                    useImagenetNormalization);
   GLOW_ASSERT(loadSuccess && "Error reading input image.");
-
+  size_t imgHeight = imageData.dims()[0];
+  size_t imgWidth = imageData.dims()[1];
+  size_t numChannels = imageData.dims()[2];
+ 
   // PNG images are NHWC and RGB.  Convert if needed.
   // Convert to requested channel ordering.
   if (imageChannelOrder == ImageChannelOrder::BGR) {
@@ -339,7 +334,7 @@ bool glow::writePngImage(Tensor *T, const char *filename,
   GLOW_ASSERT(false && "Not configured with libpng");
 }
 
-Tensor glow::readPngImageAndPreprocess(const std::string &filename,
+Tensor glow::readPngImageAndPreprocess(llvm::StringRef filename,
                                        ImageNormalizationMode imageNormMode,
                                        ImageChannelOrder imageChannelOrder,
                                        ImageLayout imageLayout,

--- a/lib/Base/Image.cpp
+++ b/lib/Base/Image.cpp
@@ -286,14 +286,14 @@ bool glow::writePngImage(Tensor *T, const char *filename,
   return false;
 }
 
-Tensor glow::readPngImageAndPreprocess(const std::string &filename,
+Tensor glow::readPngImageAndPreprocess(llvm::StringRef filename,
                                        ImageNormalizationMode imageNormMode,
                                        ImageChannelOrder imageChannelOrder,
                                        ImageLayout imageLayout,
                                        bool useImagenetNormalization) {
   Tensor imageData;
   auto range = normModeToRange(imageNormMode);
-  bool loadSuccess = !readPngImage(&imageData, filename.c_str(), range,
+  bool loadSuccess = !readPngImage(&imageData, filename.data(), range,
                                    useImagenetNormalization);
   GLOW_ASSERT(loadSuccess && "Error reading input image.");
   size_t imgHeight = imageData.dims()[0];

--- a/lib/Base/Image.cpp
+++ b/lib/Base/Image.cpp
@@ -299,7 +299,7 @@ Tensor glow::readPngImageAndPreprocess(llvm::StringRef filename,
   size_t imgHeight = imageData.dims()[0];
   size_t imgWidth = imageData.dims()[1];
   size_t numChannels = imageData.dims()[2];
- 
+
   // PNG images are NHWC and RGB.  Convert if needed.
   // Convert to requested channel ordering.
   if (imageChannelOrder == ImageChannelOrder::BGR) {

--- a/tools/loader/ImageClassifier.cpp
+++ b/tools/loader/ImageClassifier.cpp
@@ -34,23 +34,6 @@
 
 using namespace glow;
 
-enum class ImageNormalizationMode {
-  kneg1to1,     // Values are in the range: -1 and 1.
-  k0to1,        // Values are in the range: 0 and 1.
-  k0to255,      // Values are in the range: 0 and 255.
-  kneg128to127, // Values are in the range: -128 .. 127
-};
-
-enum class ImageLayout {
-  NCHW,
-  NHWC,
-};
-
-enum class ImageChannelOrder {
-  BGR,
-  RGB,
-};
-
 ImageNormalizationMode strToImageNormalizationMode(const std::string &str) {
   return llvm::StringSwitch<ImageNormalizationMode>(str)
       .Case("neg1to1", ImageNormalizationMode::kneg1to1)
@@ -58,22 +41,6 @@ ImageNormalizationMode strToImageNormalizationMode(const std::string &str) {
       .Case("0to255", ImageNormalizationMode::k0to255)
       .Case("neg128to127", ImageNormalizationMode::kneg128to127);
   GLOW_ASSERT(false && "Unknown image format");
-}
-
-/// Convert the normalization to numeric floating poing ranges.
-std::pair<float, float> normModeToRange(ImageNormalizationMode mode) {
-  switch (mode) {
-  case ImageNormalizationMode::kneg1to1:
-    return {-1., 1.};
-  case ImageNormalizationMode::k0to1:
-    return {0., 1.0};
-  case ImageNormalizationMode::k0to255:
-    return {0., 255.0};
-  case ImageNormalizationMode::kneg128to127:
-    return {-128., 127.};
-  default:
-    GLOW_ASSERT(false && "Image format not defined.");
-  }
 }
 
 namespace {
@@ -153,68 +120,46 @@ llvm::cl::opt<bool> useImagenetNormalization(
     llvm::cl::cat(imageLoaderCat), llvm::cl::init(false));
 } // namespace
 
+/// Insert \p image into \p batch at \p index.
+template <typename Ty>
+void insertImage(Handle<Ty> &batch, const Handle<Ty> &image, size_t index) {
+  auto dims = image.dims();
+  for (size_t i = 0; i < dims[0]; i++) {
+    for (size_t j = 0; j < dims[1]; j++) {
+      for (size_t k = 0; k < dims[2]; k++) {
+        batch.at({index, i, j, k}) = image.at({i, j, k});
+      }
+    }
+  }
+}
+
 /// Loads and normalizes all PNGs into a tensor in the NHWC format with the
 /// requested channel ordering.
 void loadImagesAndPreprocess(const llvm::cl::list<std::string> &filenames,
                              Tensor *inputImageData) {
   assert(!filenames.empty() &&
          "There must be at least one filename in filenames.");
-  auto range = normModeToRange(imageNormMode);
   unsigned numImages = filenames.size();
 
-  // Get first image's dimensions and check if grayscale or color.
-  size_t imgHeight, imgWidth;
-  bool isGray;
-  std::tie(imgHeight, imgWidth, isGray) = getPngInfo(filenames[0].c_str());
-  const size_t numChannels = isGray ? 1 : 3;
-
-  // N x C x H x W
-  inputImageData->reset(ElemKind::FloatTy,
-                        {numImages, numChannels, imgHeight, imgWidth});
+  Tensor initial =
+      readPngImageAndPreprocess(filenames[0], imageNormMode, imageChannelOrder,
+                                imageLayout, useImagenetNormalization);
+  auto IH = initial.getHandle();
+  inputImageData->reset(
+      ElemKind::FloatTy,
+      {numImages, initial.dims()[0], initial.dims()[1], initial.dims()[2]});
   auto IIDH = inputImageData->getHandle<>();
+  insertImage(IIDH, IH, 0);
 
-  // We iterate over all the png files, reading them all into our inputImageData
-  // tensor for processing
-  for (unsigned n = 0; n < filenames.size(); n++) {
-    Tensor localCopy;
-    // PNG images are loaded as NHWC & RGB
-    bool loadSuccess = !readPngImage(&localCopy, filenames[n].c_str(), range,
-                                     useImagenetNormalization);
-    GLOW_ASSERT(loadSuccess && "Error reading input image.");
-    auto imageH = localCopy.getHandle<>();
-
-    auto dims = localCopy.dims();
-    assert((dims[0] == imgHeight && dims[1] == imgWidth) &&
-           "All images must have the same Height and Width");
-    assert(dims[2] == numChannels &&
-           "All images must have the same number of channels");
-    assert((imageChannelOrder == ImageChannelOrder::BGR ||
-            imageChannelOrder == ImageChannelOrder::RGB) &&
-           "Invalid image format");
-
-    // Convert to NCHW with the requested channel ordering.
-    for (unsigned z = 0; z < numChannels; z++) {
-      for (unsigned y = 0; y < dims[1]; y++) {
-        for (unsigned x = 0; x < dims[0]; x++) {
-          if (imageChannelOrder == ImageChannelOrder::BGR) {
-            IIDH.at({n, numChannels - 1 - z, x, y}) = (imageH.at({x, y, z}));
-          } else { // RGB
-            IIDH.at({n, z, x, y}) = (imageH.at({x, y, z}));
-          }
-        }
-      }
-    }
-  }
-
-  // For ONNX graphs with input in NHWC layout, we transpose the image data.
-  switch (imageLayout) {
-  case ImageLayout::NCHW:
-    break;
-  case ImageLayout::NHWC:
-    Tensor dataNHWC;
-    inputImageData->transpose(&dataNHWC, NCHW2NHWC);
-    *inputImageData = std::move(dataNHWC);
-    break;
+  for (size_t n = 1; n < filenames.size(); n++) {
+    Tensor localCopy = readPngImageAndPreprocess(filenames[n], imageNormMode,
+                                                 imageChannelOrder, imageLayout,
+                                                 useImagenetNormalization);
+    assert(std::equal(localCopy.dims().begin(), localCopy.dims().end(),
+                      initial.dims().begin()) &&
+           "All images must have the same dimensions");
+    auto LH = localCopy.getHandle();
+    insertImage(IIDH, LH, n);
   }
 }
 


### PR DESCRIPTION
*Description*: I'd like to use correctly-processed PNGs in a standalone utility, so I thought factoring this functionality out of the ImageClassifier executable would make sense.
*Testing*: ./tests/image/run.sh
*Documentation*: N/A
Part of #1976