### PR TITLE
[Verifier] Switch the node verifier from assert to returning bool for the function and module

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -154,7 +154,8 @@ public:
   ///@}
 
   /// Verify the correctness of the Module.
-  void verify() const;
+  /// \returns true when the function is valid. False otherwise.
+  bool verify() const;
 
   /// Get the pseudo-random number generator used by this module.
   PseudoRNG &getPRNG() { return PRNG_; }
@@ -739,7 +740,8 @@ public:
                   llvm::DenseMap<Node *, Node *> *map = nullptr);
 
   /// Verify the correctness of the Function.
-  void verify() const;
+  /// \returns true when the function is valid. False otherwise.
+  bool verify() const;
 
   /// Dumps the textual representation of the network.
   void dump() const;

--- a/include/glow/Graph/VerifierHelper.h
+++ b/include/glow/Graph/VerifierHelper.h
@@ -58,6 +58,7 @@ void reportContext(ElemKind Ty);
 void reportContext(const ShapeNHWC &shapeNHWC);
 void reportContext(const ShapeNCHW &shapeNCHW);
 void reportContext(const Node *node);
+void reportContext(const Function *function);
 
 //===----------------------------------------------------------------------===//
 //                       Checks
@@ -113,15 +114,16 @@ struct CompareOperatorLessEqual : public CompareWithName<Ty> {
 /// and \p parent (if not nullptr), \p a, and \p b are printed out
 /// using glow::reportContext.
 /// \returns \p comp(\p a, \p b).
-template <typename InputTy>
+template <typename InputTy, typename ParentTy>
 bool expectCompareTrue(
-    const char *msg, const InputTy &a, const InputTy &b, const Node *parent,
+    const char *msg, const InputTy &a, const InputTy &b, const ParentTy *parent,
     const CompareWithName<InputTy> &comp = CompareOperatorEqual<InputTy>()) {
   if (comp(a, b)) {
     return true;
   }
   if (parent) {
     reportContext(parent);
+    report("\n");
   }
   report(msg);
   report("\nFor comparison `LHS ");

--- a/lib/Converter/FunctionConverter.cpp
+++ b/lib/Converter/FunctionConverter.cpp
@@ -154,6 +154,8 @@ void FunctionConverter::convertInputs(Node &node) {
 }
 
 void FunctionConverter::convert() {
+  assert(function_.verify() && "Input function must be valid");
+
   // Traverse all nodes.
   // Check what the conversion should look like, if any.
   // Convert the node appropriately.
@@ -196,7 +198,7 @@ void FunctionConverter::convert() {
   // function.
   cleanUp();
 
-  function_.verify();
+  assert(function_.verify() && "Conversion led to invalid function");
 }
 
 void FunctionConverter::convertPlaceholder(Placeholder &placeholder,

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -122,7 +122,7 @@ void glow::runBatch(ExecutionEngine &EE, Context &ctx, size_t iterations,
 
 void ExecutionEngine::optimizeFunction(CompilationMode mode, Function *F) {
   // Verify the function pre-optimization/lowering.
-  F->verify();
+  assert(F->verify() && "Function must be valid");
 
   // Optimize the graph.
   ::glow::optimize(F, mode);

--- a/lib/Graph/VerifierHelper.cpp
+++ b/lib/Graph/VerifierHelper.cpp
@@ -40,12 +40,16 @@ void glow::reportContext(const Node *node) {
   report("In '");
   report(node->getName());
   report("'");
-  if (node->getParent()) {
-    report(" from '");
-    report(node->getParent()->getName());
-    report("'");
+  if (const Function *function = node->getParent()) {
+    report(" ");
+    reportContext(function);
   }
-  report("\n");
+}
+
+void glow::reportContext(const Function *function) {
+  report("From '");
+  report(function->getName());
+  report("'");
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/IR/IRGen.cpp
+++ b/lib/IR/IRGen.cpp
@@ -408,7 +408,7 @@ public:
 } // namespace
 
 void IRFunction::generateIR() {
-  G_->verify();
+  assert(G_->verify() && "Invalid function");
   // Schedule the nodes.
   NodesPtrList ScheduledNodes;
   scheduleGraph(ScheduledNodes);

--- a/tests/unittests/graphGradTest.cpp
+++ b/tests/unittests/graphGradTest.cpp
@@ -130,7 +130,7 @@ TEST(GraphAutoGrad, cloneAndDiff) {
 
   auto *diffF = differentiate(F, TC);
 
-  diffF->verify();
+  EXPECT_TRUE(diffF->verify());
 
   EXPECT_EQ(M.getFunctions().size(), 3);
   EXPECT_EQ(M.getPlaceholders().size(), 5);

--- a/tests/unittests/typeAToTypeBFunctionConverterTest.cpp
+++ b/tests/unittests/typeAToTypeBFunctionConverterTest.cpp
@@ -852,7 +852,7 @@ TEST_P(AllBackends, convertExistingConversionToNoop) {
   EXPECT_EQ(addedConversion->getInput().getNode(), placeholder);
   EXPECT_EQ(placeholder->getElementType(), ElemKind::FloatTy);
 
-  F->verify();
+  EXPECT_TRUE(F->verify());
 }
 
 INSTANTIATE_TEST_CASE_P(Interpreter, AllBackends,


### PR DESCRIPTION
*Description*
This patch extends the work already done for the nodes to the function
and module. Essentially, this moves the verify method of the related
classes from assert based to returning a bool.
Thus, the caller can decided whether this should only be run in assert
mode or anytime, e.g., for error checking.

On top of that, this commit provides more context when things break
using the same framework (VerifierHelper) that we introduced for the
nodes.

*Testing*
Updated test cases

Related to #1517.