### PR TITLE
Support int32 index for Gather

### DIFF
--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -2153,7 +2153,16 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     auto *numSamplesVal = emitConstSizeT(builder, numSamples);
     auto *sampleSizeVal = emitConstSizeT(builder, sampleSize);
 
-    auto *F = getFunction("gather", dest->getElementType());
+    llvm::Function *F = nullptr;
+    if (indices->getElementType() == ElemKind::Int64ITy) {
+      F = getFunction("gather64", dest->getElementType());
+    } else if (indices->getElementType() == ElemKind::Int32ITy) {
+      F = getFunction("gather32", dest->getElementType());
+    }
+    if (!F) {
+      llvm_unreachable("Cannot get function for Gather. "
+                       "Indices input of Gather has to be int32 or int64");
+    }
     createCall(builder, F,
                {destPtr, dataPtr, indicesPtr, indicesSize, sliceSizeVal,
                 numSamplesVal, sampleSizeVal});

--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -2153,6 +2153,7 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     auto *numSamplesVal = emitConstSizeT(builder, numSamples);
     auto *sampleSizeVal = emitConstSizeT(builder, sampleSize);
 
+    // Dispatching function depeending on the input type of Indices.
     llvm::Function *F = nullptr;
     if (indices->getElementType() == ElemKind::Int64ITy) {
       F = getFunction("gather64", dest->getElementType());

--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -358,8 +358,8 @@ void libjit_topk(T *values, size_t *indices, const T *input, size_t *scratch,
   }
 }
 
-template <typename T>
-void libjit_gather(T *dest, const T *data, const size_t *indices,
+template <typename T, typename IDX>
+void libjit_gather(T *dest, const T *data, const IDX *indices,
                    size_t numIndices, size_t sliceSize, size_t numSamples,
                    size_t sampleSize) {
   // The index of the slice that is being written.
@@ -370,7 +370,7 @@ void libjit_gather(T *dest, const T *data, const size_t *indices,
     size_t sampleStart = sample * sampleSize;
 
     // For each slice that we fetch:
-    for (size_t i = 0; i < numIndices; i++) {
+    for (IDX i = 0; i < numIndices; i++) {
       size_t slice = indices[i];
 
       // Copy the slice.
@@ -878,23 +878,45 @@ void libjit_cross_entropy_loss_f(float *CE, float *P, size_t *labels,
   }
 }
 
-void libjit_gather_f(float *dest, const float *data, const size_t *indices,
-                     size_t numIndices, size_t sliceSize, size_t numSamples,
-                     size_t sampleSize) {
+void libjit_gather64_f(float *dest, const float *data, const size_t *indices,
+                       size_t numIndices, size_t sliceSize, size_t numSamples,
+                       size_t sampleSize) {
   libjit_gather(dest, data, indices, numIndices, sliceSize, numSamples,
                 sampleSize);
 }
 
-void libjit_gather_i8(int8_t *dest, const int8_t *data, const size_t *indices,
-                      size_t numIndices, size_t sliceSize, size_t numSamples,
-                      size_t sampleSize) {
+void libjit_gather64_i8(int8_t *dest, const int8_t *data, const size_t *indices,
+                        size_t numIndices, size_t sliceSize, size_t numSamples,
+                        size_t sampleSize) {
   libjit_gather(dest, data, indices, numIndices, sliceSize, numSamples,
                 sampleSize);
 }
 
-void libjit_gather_u(size_t *dest, const size_t *data, const size_t *indices,
-                     size_t numIndices, size_t sliceSize, size_t numSamples,
-                     size_t sampleSize) {
+void libjit_gather64_u(size_t *dest, const size_t *data, const size_t *indices,
+                       size_t numIndices, size_t sliceSize, size_t numSamples,
+                       size_t sampleSize) {
+  libjit_gather(dest, data, indices, numIndices, sliceSize, numSamples,
+                sampleSize);
+}
+
+void libjit_gather32_f(float *dest, const float *data, const int32_t *indices,
+                       size_t numIndices, size_t sliceSize, size_t numSamples,
+                       size_t sampleSize) {
+  libjit_gather(dest, data, indices, numIndices, sliceSize, numSamples,
+                sampleSize);
+}
+
+void libjit_gather32_i8(int8_t *dest, const int8_t *data,
+                        const int32_t *indices, size_t numIndices,
+                        size_t sliceSize, size_t numSamples,
+                        size_t sampleSize) {
+  libjit_gather(dest, data, indices, numIndices, sliceSize, numSamples,
+                sampleSize);
+}
+
+void libjit_gather32_u(size_t *dest, const size_t *data, const int32_t *indices,
+                       size_t numIndices, size_t sliceSize, size_t numSamples,
+                       size_t sampleSize) {
   libjit_gather(dest, data, indices, numIndices, sliceSize, numSamples,
                 sampleSize);
 }

--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -370,7 +370,7 @@ void libjit_gather(T *dest, const T *data, const IDX *indices,
     size_t sampleStart = sample * sampleSize;
 
     // For each slice that we fetch:
-    for (IDX i = 0; i < numIndices; i++) {
+    for (size_t i = 0; i < numIndices; i++) {
       size_t slice = indices[i];
 
       // Copy the slice.

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -193,6 +193,8 @@ private:
   template <typename ElemTy>
   void fwdLengthsSumInst_FloatImpl(const LengthsSumInst *I);
 
+  template <typename ElemTy> void fwdGatherInstImpl(const GatherInst *I);
+
   void
   fwdSparseLengthsWeightedSumInst_I8Impl(const SparseLengthsWeightedSumInst *I);
   template <typename ElemTy>

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -818,7 +818,8 @@ bool RowwiseQuantizedFullyConnectedNode::verify() const {
 
 bool GatherNode::verify() const {
   bool isValid = checkType(getResult(), getData().getElementType(), this);
-  isValid &= checkType(getIndices(), ElemKind::Int64ITy, this);
+  isValid &= (checkType(getIndices(), ElemKind::Int64ITy, this) ||
+              checkType(getIndices(), ElemKind::Int32ITy, this));
   isValid &= expectCompareTrue(
       "Mismatching number of dimensions", getResult().dims().size(),
       getData().dims().size() + getIndices().dims().size() - 1, this);

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -818,8 +818,9 @@ bool RowwiseQuantizedFullyConnectedNode::verify() const {
 
 bool GatherNode::verify() const {
   bool isValid = checkType(getResult(), getData().getElementType(), this);
-  isValid &= (checkType(getIndices(), ElemKind::Int64ITy, this) ||
-              checkType(getIndices(), ElemKind::Int32ITy, this));
+  isValid &= checkType(
+      getIndices(),
+      llvm::makeArrayRef({ElemKind::Int64ITy, ElemKind::Int32ITy}), this);
   isValid &= expectCompareTrue(
       "Mismatching number of dimensions", getResult().dims().size(),
       getData().dims().size() + getIndices().dims().size() - 1, this);

--- a/lib/Graph/VerifierHelper.cpp
+++ b/lib/Graph/VerifierHelper.cpp
@@ -67,6 +67,12 @@ bool glow::checkType(NodeValue A, ElemKind expectedType, const Node *parent) {
                            expectedType, parent);
 }
 
+bool glow::checkType(NodeValue A, llvm::ArrayRef<ElemKind> expectedTypes,
+                     const Node *parent) {
+  return expectCompareTrue("Mismatching element type", A.getElementType(),
+                           expectedTypes, parent);
+}
+
 bool glow::checkSameIsQuantized(const TypeRef A, const TypeRef B,
                                 const Node *parent) {
   return expectCompareTrue("Mismatching isQuantized", A->isQuantizedType(),

--- a/lib/Importer/ONNXIFIModelLoader.cpp
+++ b/lib/Importer/ONNXIFIModelLoader.cpp
@@ -89,6 +89,14 @@ static bool loadWeight(const onnxTensorDescriptorV1 &in, Tensor *T) {
              "Disallow overflow of loaded UINT64 data into Int64ITy.");
       TH.raw(i) = data[i];
     }
+  } else if (in.dataType == ONNXIFI_DATATYPE_INT32) {
+    T->reset(ElemKind::Int32ITy, dims);
+
+    auto TH = T->getHandle<int32_t>();
+    int32_t *data = (int32_t *)in.buffer;
+    for (size_t i = 0; i < TH.size(); ++i) {
+      TH.raw(i) = data[i];
+    }
   } else {
     llvm_unreachable("Only float and index tensors are supported");
   }

--- a/tests/models/onnxModels/gather.onnxtxt
+++ b/tests/models/onnxModels/gather.onnxtxt
@@ -33,7 +33,7 @@ graph {
     name: "indices"
     type {
       tensor_type {
-        elem_type: FLOAT
+        elem_type: INT32
         shape {
           dim {
             dim_value: 2

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -1073,7 +1073,7 @@ TEST_P(InterpAndCPU, QuantizedTopK) {
   EXPECT_EQ(IH.at({2, 0, 2}), 4);
 }
 
-TEST_P(Operator, Gather) {
+TEST_P(InterpAndCPU, Gather) {
   /*
     DATA  = [
         [1.0, 1.2],
@@ -1101,12 +1101,12 @@ TEST_P(Operator, Gather) {
   */
   auto *data = mod_.createPlaceholder(ElemKind::FloatTy, {3, 2}, "data", false);
   auto *indices =
-      mod_.createPlaceholder(ElemKind::Int64ITy, {2, 4}, "indices", false);
+      mod_.createPlaceholder(ElemKind::Int32ITy, {2, 4}, "indices", false);
 
   ctx_.allocate(data)->getHandle() = {
       1.0f, 1.2f, 2.3f, 3.4f, 4.5f, 5.7f,
   };
-  ctx_.allocate(indices)->getHandle<int64_t>() = {
+  ctx_.allocate(indices)->getHandle<int32_t>() = {
       0, 1, 0, 1, 1, 2, 2, 0,
   };
 

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -1072,8 +1072,73 @@ TEST_P(InterpAndCPU, QuantizedTopK) {
   EXPECT_EQ(VH.at({2, 0, 2}), 3);
   EXPECT_EQ(IH.at({2, 0, 2}), 4);
 }
+TEST_P(InterpAndCPU, Gather64) {
+  /*
+    DATA  = [
+        [1.0, 1.2],
+        [2.3, 3.4],
+        [4.5, 5.7],
+    ]
+    INDICES = [
+        [0, 1, 0, 1],
+        [1, 2, 2, 0],
+    ]
+    OUTPUT = [
+        [
+            [1.0, 1.2],
+            [2.3, 3.4],
+            [1.0, 1.2],
+            [2.3, 3.4],
+        ],
+        [
+            [2.3, 3.4],
+            [4.5, 5.7],
+            [4.5, 5.7],
+            [1.0, 1.2],
+        ],
+    ]
+  */
+  auto *data = mod_.createPlaceholder(ElemKind::FloatTy, {3, 2}, "data", false);
+  auto *indices =
+      mod_.createPlaceholder(ElemKind::Int64ITy, {2, 4}, "indices", false);
 
-TEST_P(InterpAndCPU, Gather) {
+  ctx_.allocate(data)->getHandle() = {
+      1.0f, 1.2f, 2.3f, 3.4f, 4.5f, 5.7f,
+  };
+  ctx_.allocate(indices)->getHandle<int64_t>() = {
+      0, 1, 0, 1, 1, 2, 2, 0,
+  };
+
+  auto R = F_->createGather("gather", data, indices);
+
+  auto *result = F_->createSave("save", R);
+  ctx_.allocate(result->getPlaceholder());
+
+  EE_.compile(CompilationMode::Infer, F_);
+  EE_.run(ctx_);
+
+  auto H = ctx_.get(result->getPlaceholder())->getHandle();
+
+  EXPECT_FLOAT_EQ(H.at({0, 0, 0}), 1.0);
+  EXPECT_FLOAT_EQ(H.at({0, 0, 1}), 1.2);
+  EXPECT_FLOAT_EQ(H.at({0, 1, 0}), 2.3);
+  EXPECT_FLOAT_EQ(H.at({0, 1, 1}), 3.4);
+  EXPECT_FLOAT_EQ(H.at({0, 2, 0}), 1.0);
+  EXPECT_FLOAT_EQ(H.at({0, 2, 1}), 1.2);
+  EXPECT_FLOAT_EQ(H.at({0, 3, 0}), 2.3);
+  EXPECT_FLOAT_EQ(H.at({0, 3, 1}), 3.4);
+
+  EXPECT_FLOAT_EQ(H.at({1, 0, 0}), 2.3);
+  EXPECT_FLOAT_EQ(H.at({1, 0, 1}), 3.4);
+  EXPECT_FLOAT_EQ(H.at({1, 1, 0}), 4.5);
+  EXPECT_FLOAT_EQ(H.at({1, 1, 1}), 5.7);
+  EXPECT_FLOAT_EQ(H.at({1, 2, 0}), 4.5);
+  EXPECT_FLOAT_EQ(H.at({1, 2, 1}), 5.7);
+  EXPECT_FLOAT_EQ(H.at({1, 3, 0}), 1.0);
+  EXPECT_FLOAT_EQ(H.at({1, 3, 1}), 1.2);
+}
+
+TEST_P(InterpAndCPU, Gather32) {
   /*
     DATA  = [
         [1.0, 1.2],

--- a/tests/unittests/onnxImporterTest.cpp
+++ b/tests/unittests/onnxImporterTest.cpp
@@ -612,17 +612,18 @@ TEST(onnx, expandDims) {
 TEST(onnx, gather) {
   ExecutionEngine EE;
   auto &mod = EE.getModule();
-  auto *F = mod.createFunction("main");
   std::string netFilename("tests/models/onnxModels/gather.onnxtxt");
+  auto *F = mod.createFunction("main");
   Placeholder *output;
   Tensor data(ElemKind::FloatTy, {3, 2});
-  Tensor indices(ElemKind::FloatTy, {2, 4});
+  Tensor indices(ElemKind::Int32ITy, {2, 4});
 
   {
     ONNXModelLoader onnxLD(netFilename, {"data", "indices"},
                            {&data.getType(), &indices.getType()}, *F);
     output = onnxLD.getSingleOutput();
   }
+  EE.compile(CompilationMode::Infer, F);
 
   // Verify structure: PH/PH -> Gather -> Save -> PH.
   ASSERT_EQ(mod.getPlaceholders().size(), 3);

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -430,8 +430,6 @@ int main(int argc, char **argv) {
       .addOperand("Indices", OperandKind::In)
       .addMember(MemberType::Unsigned, "BatchDims")
       .autoVerify(VerifyKind::SameElementType, {"Dest", "Data"})
-      .autoVerify(VerifyKind::SameElementType,
-                  {"Indices", "ElemKind::Int64ITy"})
       .autoIRGen();
 
   BB.newInstr("ScatterAssign")


### PR DESCRIPTION
*Description*:
The indices input of `Gather` can be either `int32_t` or `int64_t`,  we need to support both. This PR does this and adds support for Interpreter and CPU backend. 


*Testing*:
Unit test
*Documentation*:
[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
