### PR TITLE
Add magic numbers to classes sent across onnixifi interface

### DIFF
--- a/include/glow/Base/Traits.h
+++ b/include/glow/Base/Traits.h
@@ -102,6 +102,27 @@ public:
 
 using KindSet = llvm::SmallSet<Kinded::Kind, 4>;
 
+/// Subclasses of this class begin with a uint32_t magic number that can be used
+/// to check if arbitrary chunks of memory are likely to be instances of that
+/// subclass. Note that this enforces that magic_ field has no offset from the
+/// beginning of the subclass in memory. This will only be true if subclasses
+/// inherit from this class first and do not contain a vtable pointer.
+template <typename CH, uint32_t MAGIC> class HasMagic {
+private:
+  /// Magic number initialized from template parameter.
+  const uint32_t magic_ = MAGIC;
+
+public:
+  /// Check that the stored magic_ number matches the correct MAGIC number for
+  /// this class.
+  bool verifyMagic() const {
+    static_assert(offsetof(CH, magic_) == 0,
+                  "magic number should have 0 offset. Maybe it isn't the first "
+                  "inherited class or child class contains a vtable ptr.");
+    return magic_ == MAGIC;
+  }
+};
+
 } // namespace glow
 
 #endif // GLOW_BASE_TRAITS_H

--- a/lib/Onnxifi/Base.h
+++ b/lib/Onnxifi/Base.h
@@ -33,8 +33,14 @@
 namespace glow {
 namespace onnxifi {
 
+/// Magic numbers for classes passed across onnxifi interface.
+constexpr uint32_t BackendIdMagic = 0xb45900c1;
+constexpr uint32_t BackendMagic = 0xa017731;
+constexpr uint32_t EventMagic = 0x3a949100;
+constexpr uint32_t GraphMagic = 0x6ad67825;
+
 /// BackendId associated with the Glow backend.
-class BackendId {
+class BackendId : public HasMagic<BackendId, BackendIdMagic> {
 public:
   /// Create Glow ONNXIFI backend identifier with the
   /// given Glow backend \p kind, \p id and \p concurrency.
@@ -61,7 +67,7 @@ private:
 
 typedef BackendId *BackendIdPtr;
 
-class Backend {
+class Backend : public HasMagic<Backend, BackendMagic> {
 public:
   explicit Backend(BackendIdPtr backendId)
       : backendIdPtr_(backendId), threadPool_(backendIdPtr_->getConcurrency()) {
@@ -81,7 +87,7 @@ private:
 
 typedef Backend *BackendPtr;
 
-class Event {
+class Event : public HasMagic<Event, EventMagic> {
 public:
   Event() : fired_{false} {}
   /// Signal the event.
@@ -101,7 +107,7 @@ private:
 
 typedef Event *EventPtr;
 
-class Graph {
+class Graph : public HasMagic<Graph, GraphMagic> {
 public:
   explicit Graph(BackendPtr backendPtr) : backendPtr_(backendPtr) {}
 

--- a/lib/Onnxifi/onnxifiGlow.cpp
+++ b/lib/Onnxifi/onnxifiGlow.cpp
@@ -85,12 +85,12 @@ GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxGetBackendIDs)(
 EXTERNC ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI
 GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxReleaseBackendID)(
     onnxBackendID backendID) {
-  auto *backendId = static_cast<glow::onnxifi::BackendIdPtr>(backendID);
-  if (!backendID) {
+  auto *glowBackendId = static_cast<glow::onnxifi::BackendIdPtr>(backendID);
+  if (!glowBackendId || !glowBackendId->verifyMagic()) {
     return ONNXIFI_STATUS_INVALID_ID;
   }
 
-  delete backendId;
+  delete glowBackendId;
   return ONNXIFI_STATUS_SUCCESS;
 }
 
@@ -129,8 +129,8 @@ GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxGetBackendInfo)(
   }
 
   auto *glowBackendId = static_cast<glow::onnxifi::BackendIdPtr>(backendID);
-  if (!glowBackendId) {
-    return ONNXIFI_STATUS_INVALID_POINTER;
+  if (!glowBackendId || !glowBackendId->verifyMagic()) {
+    return ONNXIFI_STATUS_INVALID_ID;
   }
 
   // TODO: support more info type values. Here is the minimal required
@@ -168,8 +168,8 @@ GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxGetBackendCompatibility)(
   }
 
   auto *glowBackendId = static_cast<glow::onnxifi::BackendIdPtr>(backendID);
-  if (!glowBackendId) {
-    return ONNXIFI_STATUS_INVALID_POINTER;
+  if (!glowBackendId || !glowBackendId->verifyMagic()) {
+    return ONNXIFI_STATUS_INVALID_ID;
   }
 
   std::vector<std::pair<glow::Kinded::Kind, glow::ElemKind>> operations =
@@ -200,12 +200,12 @@ GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxInitBackend)(
     return ONNXIFI_STATUS_INVALID_POINTER;
   }
 
-  auto *backendId = static_cast<glow::onnxifi::BackendIdPtr>(backendID);
-  if (!backendId) {
+  auto *glowBackendId = static_cast<glow::onnxifi::BackendIdPtr>(backendID);
+  if (!glowBackendId || !glowBackendId->verifyMagic()) {
     return ONNXIFI_STATUS_INVALID_ID;
   }
 
-  auto *glowBackend = new glow::onnxifi::Backend(backendId);
+  auto *glowBackend = new glow::onnxifi::Backend(glowBackendId);
   *backend = glowBackend;
 
   return ONNXIFI_STATUS_SUCCESS;
@@ -215,7 +215,7 @@ GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxInitBackend)(
 EXTERNC ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI
 GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxReleaseBackend)(onnxBackend backend) {
   auto *glowBackend = static_cast<glow::onnxifi::BackendPtr>(backend);
-  if (!glowBackend) {
+  if (!glowBackend || !glowBackend->verifyMagic()) {
     return ONNXIFI_STATUS_INVALID_BACKEND;
   }
 
@@ -233,7 +233,7 @@ GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxInitEvent)(onnxBackend backend,
   }
 
   auto *glowBackend = static_cast<glow::onnxifi::BackendPtr>(backend);
-  if (!glowBackend) {
+  if (!glowBackend || !glowBackend->verifyMagic()) {
     return ONNXIFI_STATUS_INVALID_BACKEND;
   }
 
@@ -245,7 +245,7 @@ GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxInitEvent)(onnxBackend backend,
 EXTERNC ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI
 GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxSignalEvent)(onnxEvent event) {
   auto *glowEvent = static_cast<glow::onnxifi::EventPtr>(event);
-  if (!event) {
+  if (!glowEvent || !glowEvent->verifyMagic()) {
     return ONNXIFI_STATUS_INVALID_EVENT;
   }
 
@@ -260,7 +260,7 @@ GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxSignalEvent)(onnxEvent event) {
 EXTERNC ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI
 GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxWaitEvent)(onnxEvent event) {
   auto *glowEvent = static_cast<glow::onnxifi::EventPtr>(event);
-  if (!glowEvent) {
+  if (!glowEvent || !glowEvent->verifyMagic()) {
     return ONNXIFI_STATUS_INVALID_EVENT;
   }
 
@@ -279,7 +279,7 @@ GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxGetEventState)(
   *state = ONNXIFI_EVENT_STATE_INVALID;
 
   auto *glowEvent = static_cast<glow::onnxifi::EventPtr>(event);
-  if (!glowEvent) {
+  if (!glowEvent || !glowEvent->verifyMagic()) {
     return ONNXIFI_STATUS_INVALID_EVENT;
   }
 
@@ -292,7 +292,7 @@ GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxGetEventState)(
 EXTERNC ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI
 GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxReleaseEvent)(onnxEvent event) {
   auto *glowEvent = static_cast<glow::onnxifi::EventPtr>(event);
-  if (!glowEvent) {
+  if (!glowEvent || !glowEvent->verifyMagic()) {
     return ONNXIFI_STATUS_INVALID_EVENT;
   }
 
@@ -315,7 +315,7 @@ GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxInitGraph)(
   }
 
   auto *glowBackend = static_cast<glow::onnxifi::BackendPtr>(backend);
-  if (!glowBackend) {
+  if (!glowBackend || !glowBackend->verifyMagic()) {
     return ONNXIFI_STATUS_INVALID_BACKEND;
   }
 
@@ -361,7 +361,7 @@ GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxSetGraphIO)(
   }
 
   auto *glowGraph = static_cast<glow::onnxifi::GraphPtr>(graph);
-  if (!glowGraph) {
+  if (!glowGraph || !glowGraph->verifyMagic()) {
     return ONNXIFI_STATUS_INVALID_GRAPH;
   }
 
@@ -390,7 +390,7 @@ GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxRunGraph)(
   }
 
   auto *glowGraph = static_cast<glow::onnxifi::GraphPtr>(graph);
-  if (!glowGraph) {
+  if (!glowGraph || !glowGraph->verifyMagic()) {
     return ONNXIFI_STATUS_INVALID_GRAPH;
   }
 
@@ -419,7 +419,7 @@ GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxRunGraph)(
 EXTERNC ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI
 GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxReleaseGraph)(onnxGraph graph) {
   auto *glowGraph = static_cast<glow::onnxifi::GraphPtr>(graph);
-  if (!glowGraph) {
+  if (!glowGraph || !glowGraph->verifyMagic()) {
     return ONNXIFI_STATUS_INVALID_GRAPH;
   }
 


### PR DESCRIPTION
*Description*:
Add magic numbers to classes sent across onnixifi interface in order to verify that they probably originated from glow.
*Testing*:
`ninja all && ninja test`
*Documentation*:
doxygen 
fixes #2026 
