### PR TITLE
[nfc] Move image processing cli args to Image.{h,cpp}

### DIFF
--- a/include/glow/Base/Image.h
+++ b/include/glow/Base/Image.h
@@ -18,6 +18,8 @@
 
 #include "glow/Base/Tensor.h"
 
+#include "llvm/Support/CommandLine.h"
+
 #include <tuple>
 
 namespace glow {
@@ -41,6 +43,18 @@ enum class ImageChannelOrder {
   BGR,
   RGB,
 };
+
+/// -image_mode flag.
+extern llvm::cl::opt<ImageNormalizationMode> imageNormMode;
+
+/// -image_channel_order flag.
+extern llvm::cl::opt<ImageChannelOrder> imageChannelOrder;
+
+/// -image_layout flag.
+extern llvm::cl::opt<ImageLayout> imageLayout;
+
+/// -use-imagenet-normalization flag.
+extern llvm::cl::opt<bool> useImagenetNormalization;
 
 /// \returns the floating-point range corresponding to enum value \p mode.
 std::pair<float, float> normModeToRange(ImageNormalizationMode mode);

--- a/lib/Base/Image.cpp
+++ b/lib/Base/Image.cpp
@@ -23,6 +23,54 @@ using namespace glow;
 #if WITH_PNG
 #include <png.h>
 
+namespace glow {
+
+llvm::cl::OptionCategory imageCat("Image Processing Options");
+
+llvm::cl::opt<ImageNormalizationMode> imageNormMode(
+    "image_mode", llvm::cl::desc("Specify the image mode:"), llvm::cl::Required,
+    llvm::cl::cat(imageCat),
+    llvm::cl::values(clEnumValN(ImageNormalizationMode::kneg1to1, "neg1to1",
+                                "Values are in the range: -1 and 1"),
+                     clEnumValN(ImageNormalizationMode::k0to1, "0to1",
+                                "Values are in the range: 0 and 1"),
+                     clEnumValN(ImageNormalizationMode::k0to255, "0to255",
+                                "Values are in the range: 0 and 255"),
+                     clEnumValN(ImageNormalizationMode::kneg128to127,
+                                "neg128to127",
+                                "Values are in the range: -128 .. 127")));
+llvm::cl::alias imageNormModeA("i", llvm::cl::desc("Alias for -image_mode"),
+                               llvm::cl::aliasopt(imageNormMode),
+                               llvm::cl::cat(imageCat));
+
+llvm::cl::opt<ImageChannelOrder> imageChannelOrder(
+    "image_channel_order", llvm::cl::desc("Specify the image channel order"),
+    llvm::cl::Optional, llvm::cl::cat(imageCat),
+    llvm::cl::values(clEnumValN(ImageChannelOrder::BGR, "BGR", "Use BGR"),
+                     clEnumValN(ImageChannelOrder::RGB, "RGB", "Use RGB")),
+    llvm::cl::init(ImageChannelOrder::BGR));
+
+llvm::cl::opt<ImageLayout>
+    imageLayout("image_layout",
+                llvm::cl::desc("Specify which image layout to use"),
+                llvm::cl::Optional, llvm::cl::cat(imageCat),
+                llvm::cl::values(clEnumValN(ImageLayout::NCHW, "NCHW",
+                                            "Use NCHW image layout"),
+                                 clEnumValN(ImageLayout::NHWC, "NHWC",
+                                            "Use NHWC image layout")),
+                llvm::cl::init(ImageLayout::NCHW));
+llvm::cl::alias imageLayoutA("l", llvm::cl::desc("Alias for -image_layout"),
+                             llvm::cl::aliasopt(imageLayout),
+                             llvm::cl::cat(imageCat));
+
+llvm::cl::opt<bool> useImagenetNormalization(
+    "use-imagenet-normalization",
+    llvm::cl::desc("Use Imagenet Normalization. This works is in combination "
+                   "with the Image Mode normalization."),
+    llvm::cl::cat(imageCat), llvm::cl::init(false));
+
+} // namespace glow
+
 /// Convert the normalization to numeric floating poing ranges.
 std::pair<float, float> glow::normModeToRange(ImageNormalizationMode mode) {
   switch (mode) {

--- a/lib/Base/Image.cpp
+++ b/lib/Base/Image.cpp
@@ -28,7 +28,7 @@ namespace glow {
 llvm::cl::OptionCategory imageCat("Image Processing Options");
 
 llvm::cl::opt<ImageNormalizationMode> imageNormMode(
-    "image_mode", llvm::cl::desc("Specify the image mode:"), llvm::cl::Required,
+    "image_mode", llvm::cl::desc("Specify the image mode:"),
     llvm::cl::cat(imageCat),
     llvm::cl::values(clEnumValN(ImageNormalizationMode::kneg1to1, "neg1to1",
                                 "Values are in the range: -1 and 1"),
@@ -38,7 +38,9 @@ llvm::cl::opt<ImageNormalizationMode> imageNormMode(
                                 "Values are in the range: 0 and 255"),
                      clEnumValN(ImageNormalizationMode::kneg128to127,
                                 "neg128to127",
-                                "Values are in the range: -128 .. 127")));
+                                "Values are in the range: -128 .. 127")),
+    llvm::cl::init(ImageNormalizationMode::k0to1));
+
 llvm::cl::alias imageNormModeA("i", llvm::cl::desc("Alias for -image_mode"),
                                llvm::cl::aliasopt(imageNormMode),
                                llvm::cl::cat(imageCat));

--- a/tools/loader/ImageClassifier.cpp
+++ b/tools/loader/ImageClassifier.cpp
@@ -53,40 +53,6 @@ llvm::cl::list<std::string> inputImageFilenames(
                    "mode, where the model is compiled once and then can be run "
                    "many times with new input filenames passed via stdin)"),
     llvm::cl::OneOrMore);
-llvm::cl::opt<ImageNormalizationMode> imageNormMode(
-    "image_mode", llvm::cl::desc("Specify the image mode:"), llvm::cl::Required,
-    llvm::cl::cat(imageLoaderCat),
-    llvm::cl::values(clEnumValN(ImageNormalizationMode::kneg1to1, "neg1to1",
-                                "Values are in the range: -1 and 1"),
-                     clEnumValN(ImageNormalizationMode::k0to1, "0to1",
-                                "Values are in the range: 0 and 1"),
-                     clEnumValN(ImageNormalizationMode::k0to255, "0to255",
-                                "Values are in the range: 0 and 255"),
-                     clEnumValN(ImageNormalizationMode::kneg128to127,
-                                "neg128to127",
-                                "Values are in the range: -128 .. 127")));
-llvm::cl::alias imageNormModeA("i", llvm::cl::desc("Alias for -image_mode"),
-                               llvm::cl::aliasopt(imageNormMode),
-                               llvm::cl::cat(imageLoaderCat));
-
-llvm::cl::opt<ImageChannelOrder> imageChannelOrder(
-    "image_channel_order", llvm::cl::desc("Specify the image channel order"),
-    llvm::cl::Optional, llvm::cl::cat(imageLoaderCat),
-    llvm::cl::values(clEnumValN(ImageChannelOrder::BGR, "BGR", "Use BGR"),
-                     clEnumValN(ImageChannelOrder::RGB, "RGB", "Use RGB")),
-    llvm::cl::init(ImageChannelOrder::BGR));
-llvm::cl::opt<ImageLayout>
-    imageLayout("image_layout",
-                llvm::cl::desc("Specify which image layout to use"),
-                llvm::cl::Optional, llvm::cl::cat(imageLoaderCat),
-                llvm::cl::values(clEnumValN(ImageLayout::NCHW, "NCHW",
-                                            "Use NCHW image layout"),
-                                 clEnumValN(ImageLayout::NHWC, "NHWC",
-                                            "Use NHWC image layout")),
-                llvm::cl::init(ImageLayout::NCHW));
-llvm::cl::alias imageLayoutA("l", llvm::cl::desc("Alias for -image_layout"),
-                             llvm::cl::aliasopt(imageLayout),
-                             llvm::cl::cat(imageLoaderCat));
 
 llvm::cl::opt<unsigned> labelOffset(
     "label_offset",
@@ -113,11 +79,6 @@ llvm::cl::opt<bool> convertInAndOutToFp16(
         "Convert the input and output tensors of the network to fp16"),
     llvm::cl::cat(imageLoaderCat));
 
-llvm::cl::opt<bool> useImagenetNormalization(
-    "use-imagenet-normalization",
-    llvm::cl::desc("Use Imagenet Normalization. This works is in combination "
-                   "with the Image Mode normalization."),
-    llvm::cl::cat(imageLoaderCat), llvm::cl::init(false));
 } // namespace
 
 /// Insert \p image into \p batch at \p index.


### PR DESCRIPTION
*Description*: Pull command line options for controlling image processing into Image.{h,cpp} so they can be easily reused by other utilities.
*Testing*: `ninja image-classifier && ./tests/image/run.sh`
*Documentation*: n/a
