### PR TITLE
[image] Fix build when libpng not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,9 @@ file(GLOB_RECURSE header_files include/*.h tools/*.h lib/*.h)
 add_custom_target(CollectHeaders SOURCES ${header_files})
 
 find_package(PNG)
+if(PNG_FOUND)
+  add_definitions(-DWITH_PNG)
+endif()
 
 if(GLOW_WITH_CPU)
   add_definitions(-DGLOW_WITH_CPU=1)

--- a/include/glow/Base/Image.h
+++ b/include/glow/Base/Image.h
@@ -16,6 +16,10 @@
 #ifndef GLOW_BASE_IMAGE_H
 #define GLOW_BASE_IMAGE_H
 
+#ifndef WITH_PNG
+#error "Using Glow's PNG library requires installing libpng"
+#endif
+
 #include "glow/Base/Tensor.h"
 
 #include <tuple>

--- a/lib/Base/CMakeLists.txt
+++ b/lib/Base/CMakeLists.txt
@@ -8,9 +8,6 @@ target_link_libraries(Base
                         Support)
 if(PNG_FOUND)
   target_sources(Base PRIVATE Image.cpp)
-  target_compile_definitions(Base
-                             PRIVATE
-                               WITH_PNG=1)
   target_include_directories(Base
                              PRIVATE
                                ${PNG_INCLUDE_DIR})

--- a/lib/Base/CMakeLists.txt
+++ b/lib/Base/CMakeLists.txt
@@ -1,13 +1,13 @@
 add_library(Base
               Tensor.cpp
               Type.cpp
-              Image.cpp
               IO.cpp)
 
 target_link_libraries(Base
                       PUBLIC
                         Support)
 if(PNG_FOUND)
+  target_sources(Base PRIVATE Image.cpp)
   target_compile_definitions(Base
                              PRIVATE
                                WITH_PNG=1)

--- a/lib/Base/Image.cpp
+++ b/lib/Base/Image.cpp
@@ -22,7 +22,6 @@
 
 using namespace glow;
 
-#if WITH_PNG
 #include <png.h>
 
 namespace glow {
@@ -383,22 +382,3 @@ Tensor glow::readPngImageAndPreprocess(llvm::StringRef filename,
   }
   return imageData;
 }
-#else
-bool glow::readPngImage(Tensor *T, const char *filename,
-                        std::pair<float, float> range) {
-  GLOW_ASSERT(false && "Not configured with libpng");
-}
-
-bool glow::writePngImage(Tensor *T, const char *filename,
-                         std::pair<float, float> range) {
-  GLOW_ASSERT(false && "Not configured with libpng");
-}
-
-Tensor glow::readPngImageAndPreprocess(llvm::StringRef filename,
-                                       ImageNormalizationMode imageNormMode,
-                                       ImageChannelOrder imageChannelOrder,
-                                       ImageLayout imageLayout,
-                                       bool useImagenetNormalization) {
-  GLOW_ASSERT(false && "Not configured with libpng");
-}
-#endif

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries(tensorsTest
                         testMain)
 add_glow_test(tensorsTest ${GLOW_BINARY_DIR}/tests/tensorsTest)
 
+if(PNG_FOUND)
 add_executable(imageTest
                imageTest.cpp)
 target_link_libraries(imageTest
@@ -32,6 +33,7 @@ target_link_libraries(imageTest
                         testMain)
 add_glow_test(imageTest ${GLOW_BINARY_DIR}/tests/imageTest
               WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+endif()
 
 add_executable(gradCheckTest
                gradCheckTest.cpp)


### PR DESCRIPTION
*Description*: I suspect no one ever builds glow without libpng because it's been broken for a while :-).
*Testing*: Actually pretty hard; I removed find_package(PNG) and got things to compile, but that's still not a guarantee that everything works because libpng is still in my system path, even if I haven't told CMake to go find it.  Anyways, at least it doesn't choke as quickly.
*Documentation*: n/a
