### PR TITLE
[image] Improve preprocessing command line options

### DIFF
--- a/include/glow/Base/Image.h
+++ b/include/glow/Base/Image.h
@@ -18,8 +18,6 @@
 
 #include "glow/Base/Tensor.h"
 
-#include "llvm/Support/CommandLine.h"
-
 #include <tuple>
 
 namespace glow {
@@ -45,16 +43,16 @@ enum class ImageChannelOrder {
 };
 
 /// -image_mode flag.
-extern llvm::cl::opt<ImageNormalizationMode> imageNormMode;
+extern ImageNormalizationMode imageNormMode;
 
 /// -image_channel_order flag.
-extern llvm::cl::opt<ImageChannelOrder> imageChannelOrder;
+extern ImageChannelOrder imageChannelOrder;
 
 /// -image_layout flag.
-extern llvm::cl::opt<ImageLayout> imageLayout;
+extern ImageLayout imageLayout;
 
 /// -use-imagenet-normalization flag.
-extern llvm::cl::opt<bool> useImagenetNormalization;
+extern bool useImagenetNormalization;
 
 /// \returns the floating-point range corresponding to enum value \p mode.
 std::pair<float, float> normModeToRange(ImageNormalizationMode mode);

--- a/lib/Base/Image.cpp
+++ b/lib/Base/Image.cpp
@@ -39,8 +39,7 @@ llvm::cl::opt<ImageNormalizationMode> imageNormMode(
                      clEnumValN(ImageNormalizationMode::kneg128to127,
                                 "neg128to127",
                                 "Values are in the range: -128 .. 127")),
-    llvm::cl::init(ImageNormalizationMode::k0to1));
-
+    llvm::cl::init(ImageNormalizationMode::k0to255));
 llvm::cl::alias imageNormModeA("i", llvm::cl::desc("Alias for -image_mode"),
                                llvm::cl::aliasopt(imageNormMode),
                                llvm::cl::cat(imageCat));
@@ -67,7 +66,7 @@ llvm::cl::alias imageLayoutA("l", llvm::cl::desc("Alias for -image_layout"),
 
 llvm::cl::opt<bool> useImagenetNormalization(
     "use-imagenet-normalization",
-    llvm::cl::desc("Use Imagenet Normalization. This works is in combination "
+    llvm::cl::desc("Use Imagenet Normalization. This works in combination "
                    "with the Image Mode normalization."),
     llvm::cl::cat(imageCat), llvm::cl::init(false));
 

--- a/lib/Base/Image.cpp
+++ b/lib/Base/Image.cpp
@@ -18,6 +18,8 @@
 #include "glow/Base/Tensor.h"
 #include "glow/Support/Support.h"
 
+#include "llvm/Support/CommandLine.h"
+
 using namespace glow;
 
 #if WITH_PNG
@@ -27,9 +29,10 @@ namespace glow {
 
 llvm::cl::OptionCategory imageCat("Image Processing Options");
 
-llvm::cl::opt<ImageNormalizationMode> imageNormMode(
+ImageNormalizationMode imageNormMode;
+static llvm::cl::opt<ImageNormalizationMode, true> imageNormModeF(
     "image_mode", llvm::cl::desc("Specify the image mode:"),
-    llvm::cl::cat(imageCat),
+    llvm::cl::cat(imageCat), llvm::cl::location(imageNormMode),
     llvm::cl::values(clEnumValN(ImageNormalizationMode::kneg1to1, "neg1to1",
                                 "Values are in the range: -1 and 1"),
                      clEnumValN(ImageNormalizationMode::k0to1, "0to1",
@@ -40,35 +43,43 @@ llvm::cl::opt<ImageNormalizationMode> imageNormMode(
                                 "neg128to127",
                                 "Values are in the range: -128 .. 127")),
     llvm::cl::init(ImageNormalizationMode::k0to255));
-llvm::cl::alias imageNormModeA("i", llvm::cl::desc("Alias for -image_mode"),
-                               llvm::cl::aliasopt(imageNormMode),
-                               llvm::cl::cat(imageCat));
+static llvm::cl::alias imageNormModeA("i",
+                                      llvm::cl::desc("Alias for -image_mode"),
+                                      llvm::cl::aliasopt(imageNormModeF),
+                                      llvm::cl::cat(imageCat));
 
-llvm::cl::opt<ImageChannelOrder> imageChannelOrder(
+ImageChannelOrder imageChannelOrder;
+static llvm::cl::opt<ImageChannelOrder, true> imageChannelOrderF(
     "image_channel_order", llvm::cl::desc("Specify the image channel order"),
     llvm::cl::Optional, llvm::cl::cat(imageCat),
+    llvm::cl::location(imageChannelOrder),
     llvm::cl::values(clEnumValN(ImageChannelOrder::BGR, "BGR", "Use BGR"),
                      clEnumValN(ImageChannelOrder::RGB, "RGB", "Use RGB")),
     llvm::cl::init(ImageChannelOrder::BGR));
 
-llvm::cl::opt<ImageLayout>
-    imageLayout("image_layout",
-                llvm::cl::desc("Specify which image layout to use"),
-                llvm::cl::Optional, llvm::cl::cat(imageCat),
-                llvm::cl::values(clEnumValN(ImageLayout::NCHW, "NCHW",
-                                            "Use NCHW image layout"),
-                                 clEnumValN(ImageLayout::NHWC, "NHWC",
-                                            "Use NHWC image layout")),
-                llvm::cl::init(ImageLayout::NCHW));
-llvm::cl::alias imageLayoutA("l", llvm::cl::desc("Alias for -image_layout"),
-                             llvm::cl::aliasopt(imageLayout),
-                             llvm::cl::cat(imageCat));
+ImageLayout imageLayout;
+static llvm::cl::opt<ImageLayout, true>
+    imageLayoutF("image_layout",
+                 llvm::cl::desc("Specify which image layout to use"),
+                 llvm::cl::Optional, llvm::cl::cat(imageCat),
+                 llvm::cl::location(imageLayout),
+                 llvm::cl::values(clEnumValN(ImageLayout::NCHW, "NCHW",
+                                             "Use NCHW image layout"),
+                                  clEnumValN(ImageLayout::NHWC, "NHWC",
+                                             "Use NHWC image layout")),
+                 llvm::cl::init(ImageLayout::NCHW));
+static llvm::cl::alias imageLayoutA("l",
+                                    llvm::cl::desc("Alias for -image_layout"),
+                                    llvm::cl::aliasopt(imageLayoutF),
+                                    llvm::cl::cat(imageCat));
 
-llvm::cl::opt<bool> useImagenetNormalization(
+bool useImagenetNormalization;
+static llvm::cl::opt<bool, true> useImagenetNormalizationF(
     "use-imagenet-normalization",
     llvm::cl::desc("Use Imagenet Normalization. This works in combination "
                    "with the Image Mode normalization."),
-    llvm::cl::cat(imageCat), llvm::cl::init(false));
+    llvm::cl::cat(imageCat), llvm::cl::location(useImagenetNormalization),
+    llvm::cl::init(false));
 
 } // namespace glow
 


### PR DESCRIPTION
*Description*: Two things here:
- Default `-image_mode` to `0to255`, since that implies no rescaling
- Make it so the flag values are `extern` rather than the `cl::opt`s themselves, so we don't have to include `CommandLine.h` everywhere.
*Testing*: `run.sh`
*Documentation*: n/a
