### PR TITLE
[docs] Add a nits checklist to CodingStandards

### DIFF
--- a/docs/CodingStandards.md
+++ b/docs/CodingStandards.md
@@ -74,3 +74,16 @@ people's changes! Anybody is allowed to review code and comment on patches.
 
 All changes, by all developers, must be reviewed before they are committed to
 the repository.
+
+### Nits checklist
+
+There are some common issues that we flag in PRs that can be solved
+mechanically.  Going through this checklist before submitting a PR will speed up
+the review process by eliminating round-trips for feedback.
+
+* Remember copyright headers on new source files.
+* Prefer `llvm::StringRef` to `std::string`.
+* Comments are complete sentences: begin with a capital, end with a period.
+* Add Doxygen comments to every new class, method, function, global, etc.
+* Boolean arguments should be tagged with a /* name_of_param */ comment.
+* Always clang-format!  (The linter will catch this, but it never hurts.)


### PR DESCRIPTION
*Description*:
I've noticed myself making repetitive, kind of trivial mistakes on PRs, so I wrote up a checklist of things that I've forgotten more than once.  Since these are often issues for others as well, I thought it'd be helpful to put in our coding standards.

These are probably documented elsewhere, e.g., the LLVM coding standards, but having a succinct list should make it easier to sanity check.  (Of course, almost all of these could be checked by a linter, but I don't know how to get that done quickly.)

*Testing*: n/a

*Documentation*: n/a
