### PR TITLE
Prevent errors from use of deprecated OpenCL 1.2 function

### DIFF
--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -18,6 +18,9 @@
 // Silence Apple's warning about the deprecation of OpenCL.
 #define CL_SILENCE_DEPRECATION
 
+// Silence warnings about using deprecated OpenCL 1.2 functions.
+#define CL_USE_DEPRECATED_OPENCL_1_2_APIS
+
 #include "OpenCL.h"
 
 #include "glow/Backends/BackendUtils.h"


### PR DESCRIPTION
*Description*: This commit allows for building with -Werror without incurring failures due to the usage of the deprecated clCreateCommandQueue() function in the OpenCL backend.  This commit should allow #2064  to succeed.

*Testing*: Tested build with -Werror and -DGLOW_WITH_OPENCL=ON on Ubuntu 16.04.1 laptop (with OCL runtime installed).