### PR TITLE
[docs] Direct link to glow topic on forums

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ To get started, please refer to the following guides:
 
 ### Communication
 
-* forums: discuss implementations, research, etc. http://discuss.pytorch.org.
+* Forums: discuss implementations, research, etc: https://discuss.pytorch.org/c/glow.
   Make sure to label topic with the ["glow"](https://discuss.pytorch.org/c/glow) category.
 * GitHub issues: bug reports, feature requests, install issues, RFCs, thoughts, etc.
 


### PR DESCRIPTION
I know the "glow" phrase is already a direct link, but I think putting the full topic path front and center will help direct people to the right place.