### PR TITLE
Add vertical whitespace between top-level definitions

### DIFF
--- a/include/glow/Backends/BackendUtils.h
+++ b/include/glow/Backends/BackendUtils.h
@@ -73,6 +73,7 @@ public:
         activationsMemSize_(activations) {}
 };
 } // namespace runtime
+
 /// Computes offsets and total allocation for Constants, Placeholders, and
 /// Activations to build runtime symbol table. Returns RuntimeBundle.
 runtime::RuntimeBundle

--- a/include/glow/Graph/Node.h
+++ b/include/glow/Graph/Node.h
@@ -271,6 +271,7 @@ template <> struct simplify_type<glow::NodeValue> {
     return val.getNode();
   }
 };
+
 /// Allow casting NodeValue into Node*.
 template <> struct simplify_type<const glow::NodeValue> {
   typedef glow::Node *SimpleType;
@@ -278,6 +279,7 @@ template <> struct simplify_type<const glow::NodeValue> {
     return val.getNode();
   }
 };
+
 /// Allow casting NodeHandle into Node*.
 template <> struct simplify_type<glow::NodeHandle> {
   typedef glow::Node *SimpleType;

--- a/lib/Backends/BackendUtils.cpp
+++ b/lib/Backends/BackendUtils.cpp
@@ -54,6 +54,7 @@ runtime::RuntimeBundle::getSymbolInfo(const Named *v) const {
   assert(it != symbolTable_.end() && "Symbol not found.");
   return it->second;
 }
+
 runtime::RuntimeBundle
 glow::generateRuntimeBundle(const IRFunction &F,
                             MemoryAllocator &constantAllocator,

--- a/lib/Backends/CPU/AllocationsInfo.cpp
+++ b/lib/Backends/CPU/AllocationsInfo.cpp
@@ -80,6 +80,7 @@ void AllocationsInfo::allocateWeightVars(const IRFunction *F) {
                  << "]\n";
   });
 }
+
 void AllocationsInfo::allocateActivations(const IRFunction *F) {
   // Use a memory allocator with no upper bound on how much memory we can
   // allocate.

--- a/lib/Backends/CPU/AllocationsInfo.h
+++ b/lib/Backends/CPU/AllocationsInfo.h
@@ -31,6 +31,7 @@ class Context;
 namespace runtime {
 class RuntimeBundle;
 }
+
 /// Information about allocations for activations, constant weight variables
 /// and mutable weight variables.
 struct AllocationsInfo {

--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -926,6 +926,7 @@ void libjit_scatterassign_f(float *data, const size_t *indices,
                             size_t sliceSize) {
   libjit_scatterassign(data, indices, slices, numIndices, sliceSize);
 }
+
 void libjit_scatterassign_i8(int8_t *data, const size_t *indices,
                              const int8_t *slices, size_t numIndices,
                              size_t sliceSize) {
@@ -1081,6 +1082,7 @@ void libjit_max_pool_i8(const int8_t *inW, int8_t *outW, const size_t *inWdims,
   libjit_max_pool_generic(inW, outW, inWdims, outWdims, kernelSizes, strides,
                           pads);
 }
+
 void libjit_max_pool_f(const float *inW, float *outW, const size_t *inWdims,
                        const size_t *outWdims, size_t *kernelSizes,
                        size_t *strides, size_t *pads) {

--- a/lib/Backends/Interpreter/InterpreterFunction.cpp
+++ b/lib/Backends/Interpreter/InterpreterFunction.cpp
@@ -37,6 +37,7 @@ InterpreterFunction::~InterpreterFunction() {
   externalTensors_.clear();
   alignedFree(bundle_.getConstants());
 }
+
 void InterpreterFunction::setupRuns() {
   if (bundle_.getConstantWeightSize()) {
     for (const auto &v : F_->getGraph()->getParent()->getConstants()) {
@@ -47,6 +48,7 @@ void InterpreterFunction::setupRuns() {
     }
   }
 }
+
 void InterpreterFunction::beforeRun(const Context &ctx) {
   // Register the concrete tensors that back the placeholder tensors.
   for (auto &ph : ctx.pairs()) {

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -1500,6 +1500,7 @@ void OpenCLFunction::afterRun(const Context &ctx) {
   }
   kernelLaunches_.clear();
 }
+
 cl_mem OpenCLFunction::allocDeviceBuffer(uint64_t size) {
   const uint64_t alignment = 128;
   // Always allocate buffers properly aligned to hold values of any type.

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -2108,6 +2108,7 @@ void Function::createLSTM(Context &ctx, llvm::StringRef namePrefix,
     outputs.push_back(O);
   }
 };
+
 //===----------------------------------------------------------------------===//
 //                   Graph dumping and printing
 //===----------------------------------------------------------------------===//

--- a/lib/Graph/Node.cpp
+++ b/lib/Graph/Node.cpp
@@ -129,6 +129,7 @@ unsigned Node::getNumInputs() const {
     llvm_unreachable("Unhandled node");
   }
 }
+
 std::string Node::getInputName(unsigned idx) const {
   switch (getKind()) {
 #define DEF_NODE(CLASS, NAME)                                                  \
@@ -139,6 +140,7 @@ std::string Node::getInputName(unsigned idx) const {
     llvm_unreachable("Unhandled node");
   }
 }
+
 NodeValue Node::getNthInput(unsigned idx) {
   switch (getKind()) {
 #define DEF_NODE(CLASS, NAME)                                                  \

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -34,6 +34,7 @@ llvm::hash_code Constant::getHash() const {
 llvm::hash_code Placeholder::getHash() const {
   return llvm::hash_combine(getName());
 }
+
 //===----------------------------------------------------------------------===//
 //                        Visitor methods
 //===----------------------------------------------------------------------===//

--- a/lib/IR/IRBuilder.cpp
+++ b/lib/IR/IRBuilder.cpp
@@ -76,6 +76,7 @@ MaxPoolWithXYInst *IRBuilder::createMaxPoolWithXYOp(
   return createMaxPoolWithXYInst("pool", dest, input, srcXY, kernels, strides,
                                  pads);
 }
+
 AvgPoolInst *IRBuilder::createAvgPoolOp(Value *input,
                                         llvm::ArrayRef<unsigned_t> kernels,
                                         llvm::ArrayRef<unsigned_t> strides,

--- a/lib/Optimizer/IROptimizer.cpp
+++ b/lib/Optimizer/IROptimizer.cpp
@@ -490,6 +490,7 @@ void makeWeightsConst(IRFunction &M) {
     }
   }
 }
+
 #ifndef NDEBUG
 /// Dump a live intervals map.
 static void LLVM_ATTRIBUTE_UNUSED dump(IRFunction &M,

--- a/lib/Optimizer/Lower.cpp
+++ b/lib/Optimizer/Lower.cpp
@@ -34,6 +34,7 @@ static void lowerAddGradNode(Function *F, const AddGradNode &node) {
   node.getGradOfInputNamedLHS().replaceAllUsesOfWith(outG);
   node.getGradOfInputNamedRHS().replaceAllUsesOfWith(outG);
 }
+
 static void lowerMulGradNode(Function *F, const MulGradNode &node) {
   /// The chain rule for multiplication:
   /// delta(LHS) = dF/dLHS * delta(OUT) = RHS * delta(OUT)
@@ -47,6 +48,7 @@ static void lowerMulGradNode(Function *F, const MulGradNode &node) {
   node.getGradOfInputNamedLHS().replaceAllUsesOfWith(lhsResult);
   node.getGradOfInputNamedRHS().replaceAllUsesOfWith(rhsResult);
 }
+
 static void lowerSubGradNode(Function *F, const SubGradNode &node) {
   /// The chain rule for subtraction:
   /// delta(LHS) = dF/dLHS * delta(OUT) = 1 * delta(OUT)
@@ -57,6 +59,7 @@ static void lowerSubGradNode(Function *F, const SubGradNode &node) {
   node.getGradOfInputNamedLHS().replaceAllUsesOfWith(outG);
   node.getGradOfInputNamedRHS().replaceAllUsesOfWith(sub);
 }
+
 static void lowerDivGradNode(Function *F, const DivGradNode &node) {
   /// The chain rule for division:
   /// delta(LHS) = dF/dLHS * delta(OUT) = (1 / RHS) * delta(OUT)


### PR DESCRIPTION
*Description*: This change is pretty trivial, but I think enforcing the rule consistently makes the code base feel cleaner and less haphazard.
*Testing*: n/a
*Documentation*: n/a

