### PR TITLE
[Error Handling] Add Error handling to model importer related code

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -53,7 +53,8 @@ add_executable(lenet-loader
 target_link_libraries(lenet-loader
                       PRIVATE
                         ExecutionEngine
-                        Importer)
+                        Importer
+                        Support)
 
 if(GLOW_WITH_BUNDLES)
   add_subdirectory(bundles)

--- a/examples/lenet-loader.cpp
+++ b/examples/lenet-loader.cpp
@@ -38,8 +38,8 @@ int main() {
 
   // Get input and output placeholders.
   auto *input = llvm::cast<glow::Placeholder>(
-      UNWRAP(loader.getNodeValueByName(inputName)));
-  auto *output = UNWRAP(loader.getSingleOutput());
+      EXIT_ON_ERR(loader.getNodeValueByName(inputName)));
+  auto *output = EXIT_ON_ERR(loader.getSingleOutput());
 
   // Read an example PNG and add it to an input batch.
   auto image = glow::readPngImageAndPreprocess(

--- a/examples/lenet-loader.cpp
+++ b/examples/lenet-loader.cpp
@@ -16,6 +16,9 @@
 #include "glow/Base/Image.h"
 #include "glow/ExecutionEngine/ExecutionEngine.h"
 #include "glow/Importer/Caffe2ModelLoader.h"
+#include "glow/Support/Error.h"
+
+using namespace glow;
 
 /// A stripped-down example of how to load a Caffe2 protobuf and perform
 /// inference.
@@ -34,9 +37,9 @@ int main() {
   EE.compile(glow::CompilationMode::Infer, F);
 
   // Get input and output placeholders.
-  auto *input =
-      llvm::cast<glow::Placeholder>(loader.getNodeValueByName(inputName));
-  auto *output = loader.getSingleOutput();
+  auto *input = llvm::cast<glow::Placeholder>(
+      UNWRAP(loader.getNodeValueByName(inputName)));
+  auto *output = UNWRAP(loader.getSingleOutput());
 
   // Read an example PNG and add it to an input batch.
   auto image = glow::readPngImageAndPreprocess(

--- a/include/glow/Importer/Caffe2ModelLoader.h
+++ b/include/glow/Importer/Caffe2ModelLoader.h
@@ -39,25 +39,25 @@ class Value;
 class Caffe2ModelLoader
     : public CommonOperatorLoader<caffe2::OperatorDef, caffe2::Argument> {
   /// Get the broadcast attribute.
-  bool getBroadcast(const ArgumentDictionaryTy &dict) override;
+  llvm::Expected<bool> getBroadcast(const ArgumentDictionaryTy &dict) override;
 
   /// Load the weight tensors from the 'init' file and register them in the map
   /// \p tensors.
-  void loadWeights(caffe2::NetDef &net);
+  llvm::Error loadWeights(caffe2::NetDef &net);
 
   /// Loads an individual weight \p op.
-  void loadWeight(const caffe2::OperatorDef &op);
+  llvm::Error loadWeight(const caffe2::OperatorDef &op);
 
   /// Load the structure of the network from the 'net' file.
-  void loadNetwork(caffe2::NetDef &net);
+  llvm::Error loadNetwork(caffe2::NetDef &net);
 
   /// Load the operator \p op into the network. This creates one or more nodes
   /// in the network.
-  void loadOperator(const caffe2::OperatorDef &op);
+  llvm::Error loadOperator(const caffe2::OperatorDef &op);
 
   /// Reads a network (weights or structure) from the serialized protocol buffer
   /// file.
-  bool loadProtoFile(caffe2::NetDef &net, const std::string &filename);
+  llvm::Expected<caffe2::NetDef> loadProtoFile(const std::string &filename);
 
 public:
   /// Loads the caffe2 model that's represented by a network description file,

--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -762,8 +762,9 @@ protected:
 
   using ProtobufLoader::ProtobufLoader;
 
-  /// If operator type is supported, returns true and creates new operator.
-  /// Otherwise returns false.
+  /// If operator type is supported, returns Expected<true> and creates new operator.
+  /// Returns Operator<false> if operator type is not supported. Returns Error
+  /// if an error occurred
   llvm::Expected<bool> tryLoadCommonOperator(llvm::StringRef typeName,
                                              const OpType &op,
                                              ArgumentDictionaryTy &dict) {

--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -762,9 +762,9 @@ protected:
 
   using ProtobufLoader::ProtobufLoader;
 
-  /// If operator type is supported, returns Expected<true> and creates new operator.
-  /// Returns Operator<false> if operator type is not supported. Returns Error
-  /// if an error occurred
+  /// If operator type is supported, returns Expected<true> and creates new
+  /// operator. Returns Operator<false> if operator type is not supported.
+  /// Returns Error if an error occurred
   llvm::Expected<bool> tryLoadCommonOperator(llvm::StringRef typeName,
                                              const OpType &op,
                                              ArgumentDictionaryTy &dict) {

--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -57,7 +57,7 @@ protected:
                                getNodeValueOrCreateConstantByName(op.input(0)));
     auto *R = G_.createRELU(opName, in);
     addNodeAsOutput(op, R);
-    RETURN_SUCCESS();
+    return llvm::Error::success();
   }
 
   llvm::Error loadSigmoid(const OpType &op, ArgumentDictionaryTy &dict) {
@@ -67,7 +67,7 @@ protected:
                                getNodeValueOrCreateConstantByName(op.input(0)));
     auto *S = G_.createSigmoid(opName, in);
     addNodeAsOutput(op, S);
-    RETURN_SUCCESS();
+    return llvm::Error::success();
   }
 
   llvm::Error loadTanh(const OpType &op, ArgumentDictionaryTy &dict) {
@@ -77,7 +77,7 @@ protected:
                                getNodeValueOrCreateConstantByName(op.input(0)));
     auto *T = G_.createTanh(opName, in);
     addNodeAsOutput(op, T);
-    RETURN_SUCCESS();
+    return llvm::Error::success();
   }
 
   llvm::Error loadShape(const OpType &op, ArgumentDictionaryTy &dict) {
@@ -94,11 +94,11 @@ protected:
         std::vector<int64_t>(in.dims().begin(), in.dims().end());
 
     if (auto resultOrErr = createAndRegisterConstant(opName, *T)) {
-      RETURN_SUCCESS();
+      return llvm::Error::success();
     } else {
       return resultOrErr.takeError();
     }
-    RETURN_SUCCESS();
+    return llvm::Error::success();
   }
 
   /// Loads Sqrt operator, given its protobuf representation and parsed args.
@@ -109,7 +109,7 @@ protected:
                                getNodeValueOrCreateConstantByName(op.input(0)));
     auto *R = G_.createPow(opName, in, 0.5f);
     addNodeAsOutput(op, R);
-    RETURN_SUCCESS();
+    return llvm::Error::success();
   }
 
   /// Loads Reciprocal operator, given its protobuf representation and parsed
@@ -121,7 +121,7 @@ protected:
                                getNodeValueOrCreateConstantByName(op.input(0)));
     auto *R = G_.createPow(opName, in, -1.0f);
     addNodeAsOutput(op, R);
-    RETURN_SUCCESS();
+    return llvm::Error::success();
   }
 
   llvm::Error loadSum(const OpType &op, ArgumentDictionaryTy &dict) {
@@ -155,7 +155,7 @@ protected:
       Node *node = G_.createBatchedReduceAdd(opName, concat, /* axis */ 0);
       addNodeAsOutput(op, node);
     }
-    RETURN_SUCCESS();
+    return llvm::Error::success();
   }
 
   llvm::Error loadSoftmax(const OpType &op, ArgumentDictionaryTy &dict) {
@@ -186,7 +186,7 @@ protected:
     auto origInDims = in.getType()->dims();
     auto *RN = G_.createReshape("reshapeOutput", SM, origInDims);
     addNodeAsOutput(op, RN);
-    RETURN_SUCCESS();
+    return llvm::Error::success();
   }
 
   llvm::Error loadLRN(const OpType &op, ArgumentDictionaryTy &dict) {
@@ -214,7 +214,7 @@ protected:
     // LRN in Caffe2 has a scale_ output, but I believe it's unused for
     // inference. So explicitly only set output 0.
     nodeValueByName_[op.output(0)] = NodeValue(N, 0);
-    RETURN_SUCCESS();
+    return llvm::Error::success();
   }
 
   llvm::Error loadMinMax(llvm::StringRef typeName, const OpType &op,
@@ -237,7 +237,7 @@ protected:
     }
 
     addNodeAsOutput(op, node);
-    RETURN_SUCCESS();
+    return llvm::Error::success();
   }
 
   llvm::Error loadBatchMatMul(const OpType &op, ArgumentDictionaryTy &dict,
@@ -300,7 +300,7 @@ protected:
     }
 
     addNodeAsOutput(op, node);
-    RETURN_SUCCESS();
+    return llvm::Error::success();
   }
 
   llvm::Error loadArithmetic(llvm::StringRef typeName, const OpType &op,
@@ -347,7 +347,7 @@ protected:
     }
 
     addNodeAsOutput(op, node);
-    RETURN_SUCCESS();
+    return llvm::Error::success();
   }
 
   llvm::Error loadSplit(const OpType &op, ArgumentDictionaryTy &dict) {
@@ -372,7 +372,7 @@ protected:
       // so only use 0 here as the node value result.
       nodeValueByName_[op.output(i)] = NodeValue(outputs[i], 0);
     }
-    RETURN_SUCCESS();
+    return llvm::Error::success();
   }
 
   llvm::Expected<bool> loadReshape(const OpType &op,
@@ -465,7 +465,7 @@ protected:
     auto *T = G_.createTranspose(opName, in, perm);
 
     addNodeAsOutput(op, T);
-    RETURN_SUCCESS();
+    return llvm::Error::success();
   }
 
   llvm::Error loadFlatten(const OpType &op, ArgumentDictionaryTy &dict) {
@@ -479,7 +479,7 @@ protected:
     }
     auto *node = G_.createFlatten(opName, in, axis);
     addNodeAsOutput(op, node);
-    RETURN_SUCCESS();
+    return llvm::Error::success();
   }
 
   llvm::Error loadIdentity(const OpType &op, ArgumentDictionaryTy &dict) {
@@ -487,7 +487,7 @@ protected:
     ASSIGN_VALUE_OR_RETURN_ERR(in,
                                getNodeValueOrCreateConstantByName(op.input(0)));
     nodeValueByName_[op.output(0)] = NodeValue(in, 0);
-    RETURN_SUCCESS();
+    return llvm::Error::success();
   }
 
   llvm::Error loadTopK(const OpType &op, ArgumentDictionaryTy &dict) {
@@ -512,7 +512,7 @@ protected:
 
     auto *R = G_.createTopK(opName, in, k);
     addNodeAsOutput(op, R);
-    RETURN_SUCCESS();
+    return llvm::Error::success();
   }
 
   llvm::Error loadReduceMeanOrSum(llvm::StringRef typeName, const OpType &op,
@@ -549,7 +549,7 @@ protected:
     }
 
     addNodeAsOutput(op, node);
-    RETURN_SUCCESS();
+    return llvm::Error::success();
   }
 
   llvm::Error loadBatchOneHot(const OpType &op) {
@@ -566,7 +566,7 @@ protected:
 
     auto *node = G_.createBatchOneHot(opName, data, lengths, values);
     addNodeAsOutput(op, node);
-    RETURN_SUCCESS();
+    return llvm::Error::success();
   }
 
   llvm::Error loadSparseLengthsSum(const OpType &op) {
@@ -581,7 +581,7 @@ protected:
                                getNodeValueOrCreateConstantByName(op.input(2)));
     auto *node = G_.createSparseLengthsSum(loadOperatorName(op), in0, in1, in2);
     addNodeAsOutput(op, node);
-    RETURN_SUCCESS();
+    return llvm::Error::success();
   }
 
   llvm::Error loadSparseLengthsWeightedSum(const OpType &op) {
@@ -600,7 +600,7 @@ protected:
     auto *node = G_.createSparseLengthsWeightedSum(loadOperatorName(op), in0,
                                                    in1, in2, in3);
     addNodeAsOutput(op, node);
-    RETURN_SUCCESS();
+    return llvm::Error::success();
   }
 
   llvm::Error loadLengthsToRanges(const OpType &op) {
@@ -609,7 +609,7 @@ protected:
                                getNodeValueOrCreateConstantByName(op.input(0)));
     auto *node = G_.createLengthsToRanges(loadOperatorName(op), in);
     addNodeAsOutput(op, node);
-    RETURN_SUCCESS();
+    return llvm::Error::success();
   }
 
   llvm::Error loadBatchBoxCox(const OpType &op) {
@@ -625,7 +625,7 @@ protected:
     auto *node =
         G_.createBatchBoxCox(loadOperatorName(op), data, lambda1, lambda2);
     addNodeAsOutput(op, node);
-    RETURN_SUCCESS();
+    return llvm::Error::success();
   }
 
   llvm::Error loadDotProduct(const OpType &op) {
@@ -637,7 +637,7 @@ protected:
                                getNodeValueOrCreateConstantByName(op.input(1)));
     auto *node = G_.createDotProduct(loadOperatorName(op), X, Y);
     addNodeAsOutput(op, node);
-    RETURN_SUCCESS();
+    return llvm::Error::success();
   }
 
   llvm::Error loadReplaceNaN(const OpType &op,
@@ -653,7 +653,7 @@ protected:
     }
     auto *node = G_.createReplaceNaN(loadOperatorName(op), input, value);
     addNodeAsOutput(op, node);
-    RETURN_SUCCESS();
+    return llvm::Error::success();
   }
 
   llvm::Error loadLengthsSum(const OpType &op) {
@@ -670,7 +670,7 @@ protected:
 
     auto *node = G_.createLengthsSum(opName, data, lengths);
     addNodeAsOutput(op, node);
-    RETURN_SUCCESS();
+    return llvm::Error::success();
   }
 
   llvm::Expected<bool> loadExpandDims(const OpType &op,
@@ -705,7 +705,7 @@ protected:
 
     auto *node = G_.createClip(loadOperatorName(op), in, cmin, cmax);
     addNodeAsOutput(op, node);
-    RETURN_SUCCESS();
+    return llvm::Error::success();
   }
 
   llvm::Expected<bool> loadSparseToDense(const OpType &op,

--- a/include/glow/Importer/ONNXIFIModelLoader.h
+++ b/include/glow/Importer/ONNXIFIModelLoader.h
@@ -31,11 +31,11 @@ private:
 
   /// Load the inputs from the GraphProto. This is useful when the
   /// initializers are not available.
-  void loadInputs(ONNX_NAMESPACE::GraphProto &net);
+  llvm::Error loadInputs(ONNX_NAMESPACE::GraphProto &net);
 
   /// Load pre-trained weights from \p weightDescriptors.
-  bool loadWeights(uint32_t weightsCount,
-                   const onnxTensorDescriptorV1 *weightDescriptors);
+  llvm::Error loadWeights(uint32_t weightsCount,
+                          const onnxTensorDescriptorV1 *weightDescriptors);
 
   /// Mapping between ONNX names for inputs and actual Glow input vars.
   llvm::StringMap<Placeholder *> onnxNameToInputVars_;
@@ -54,7 +54,7 @@ public:
   /// \returns unique pointer to ONNXIFIModelLoader if \p onnxModel can be
   /// parsed and static weights can be loaded from the \p wightDescriptors.
   /// \returns nullptr otherwise.
-  static std::unique_ptr<ONNXIFIModelLoader>
+  static llvm::Expected<ONNXIFIModelLoader>
   parse(const void *onnxModel, uint32_t onnxModelSize, uint32_t weightsCount,
         const onnxTensorDescriptorV1 *weightDescriptors, Function &F);
 

--- a/include/glow/Importer/ONNXIFIModelLoader.h
+++ b/include/glow/Importer/ONNXIFIModelLoader.h
@@ -51,10 +51,10 @@ public:
     return outputVarsByName_;
   }
 
-  /// \returns a ONNXIFIModelLoader if \p onnxModel can be
+  /// \returns a unique_ptr<ONNXIFIModelLoader> if \p onnxModel can be
   /// parsed and static weights can be loaded from the \p wightDescriptors.
   /// \returns Error otherwise.
-  static llvm::Expected<ONNXIFIModelLoader>
+  static llvm::Expected<std::unique_ptr<ONNXIFIModelLoader>>
   parse(const void *onnxModel, uint32_t onnxModelSize, uint32_t weightsCount,
         const onnxTensorDescriptorV1 *weightDescriptors, Function &F);
 

--- a/include/glow/Importer/ONNXIFIModelLoader.h
+++ b/include/glow/Importer/ONNXIFIModelLoader.h
@@ -51,9 +51,9 @@ public:
     return outputVarsByName_;
   }
 
-  /// \returns unique pointer to ONNXIFIModelLoader if \p onnxModel can be
+  /// \returns a ONNXIFIModelLoader if \p onnxModel can be
   /// parsed and static weights can be loaded from the \p wightDescriptors.
-  /// \returns nullptr otherwise.
+  /// \returns Error otherwise.
   static llvm::Expected<ONNXIFIModelLoader>
   parse(const void *onnxModel, uint32_t onnxModelSize, uint32_t weightsCount,
         const onnxTensorDescriptorV1 *weightDescriptors, Function &F);

--- a/include/glow/Importer/ONNXModelLoader.h
+++ b/include/glow/Importer/ONNXModelLoader.h
@@ -43,9 +43,8 @@ class ONNXModelLoader
   /// Load the network initializers from the GraphProto.
   llvm::Error loadInitializers(ONNX_NAMESPACE::GraphProto &net);
 
-  /// \returns true if operator \p op can be loaded.
   /// Load the operator \p op into the network. This creates one or more nodes
-  /// in the network.
+  /// in the network. \returns Error if operator \p op cannot be loaded.
   llvm::Error loadOperator(const ONNX_NAMESPACE::NodeProto &op);
 
   /// ONNX model ir_version;
@@ -56,19 +55,19 @@ class ONNXModelLoader
 
 protected:
   /// Load the network operators from the GraphProto.
-  /// \returns true if network can be loaded.
+  /// \returns Error if network cannot be loaded.
   llvm::Error loadNetwork(ONNX_NAMESPACE::GraphProto &net);
 
   /// Set the output nodes of the network \p net. Initializes the map from the
   /// names of the outputs to the save nodes that save each output.
-  /// \returns true if output nodes were found.
+  /// \returns Error if network cannot be loaded.
   llvm::Error setOutputNodes(ONNX_NAMESPACE::GraphProto &net);
 
   /// Set ir verion and op version.
   llvm::Error setVersion(ONNX_NAMESPACE::ModelProto MP);
 
-  /// \returns true if ModelProto \p net can be loaded from the stream \p
-  /// iStream.
+  /// \returns Expected<ModelProto> if a ModelProto can be loaded from the
+  /// stream \p iStream.
   static llvm::Expected<ONNX_NAMESPACE::ModelProto>
   loadProto(google::protobuf::io::ZeroCopyInputStream &iStream);
 
@@ -76,15 +75,15 @@ public:
   /// Creates a ONNX model loader to build \p F.
   ONNXModelLoader(Function &F);
 
-  /// \returns true if ModelProto \p net can be constructed from the content
-  /// of the file \p filename.
-  /// Loads ModelProto \p net from the file containing serialized protobuf.
+  /// \returns Expected<ModelProto> if a ModelProto can be constructed from the
+  /// contents of the file \p filename and Error otherwise.
+  /// Loads ModelProto from the file containing serialized protobuf.
   static llvm::Expected<ONNX_NAMESPACE::ModelProto>
   loadProto(const std::string &filename);
 
-  /// \returns true if ModelProto \p net can be constructed from the in-memory
-  /// serialized protobuf.
-  /// Loads ModelProto \p net from the in-memory serialized protobuf \p
+  /// \returns Expected<ModelProto> if a ModelProto can be constructed from the
+  /// in-memory serialized protobuf.
+  /// Loads ModelProto from the in-memory serialized protobuf \p
   /// onnxModel with the model size \p onnxModelSize.
   static llvm::Expected<ONNX_NAMESPACE::ModelProto>
   loadProto(const void *onnxModel, size_t onnxModelSize);

--- a/include/glow/Importer/ProtobufLoader.h
+++ b/include/glow/Importer/ProtobufLoader.h
@@ -78,15 +78,6 @@ std::vector<ElemTy> getShape(const AttrType *arg) {
   return dim;
 }
 
-/// Loads array and checks that all elements are the same. Returns array[0].
-template <typename T>
-llvm::Expected<size_t> getConstantArrayHead(const T *arg) {
-  auto dim = getShape(arg);
-  RETURN_ERR_IF_NOT(isArrayConstant(dim),
-                    "Only equal values along each dimensions are supported");
-  return dim[0];
-}
-
 /// Returns canonical name for a given operator: either \p name() from proto,
 /// or its first output's name.
 template <typename T> std::string loadOperatorName(const T &op) {
@@ -146,7 +137,7 @@ public:
   virtual ~ProtobufLoader();
 
   /// \returns the single final output of the network. The function assumes that
-  /// there is only one output, verified via Error. For image
+  /// there is only one output, returns Error otherwise. For image
   /// classification, this single final output is usually the result of the last
   /// softmax or regression layer.
   llvm::Expected<Placeholder *> getSingleOutput() {

--- a/include/glow/Support/Error.h
+++ b/include/glow/Support/Error.h
@@ -21,7 +21,6 @@
 #include "llvm/Support/Error.h"
 
 namespace glow {
-
 namespace detail {
 /// NOTE This should not be used directly, instead use UNWRAP or TEMP_UNWRAP.
 /// Callable that takes an llvm::Error or llvm::Expected<T> and exits the

--- a/include/glow/Support/Error.h
+++ b/include/glow/Support/Error.h
@@ -26,7 +26,7 @@ namespace detail {
 /// Callable that takes an llvm::Error or llvm::Expected<T> and exits the
 /// program if the Error is not equivalent llvm::Error::success() or the
 /// Expected<T> contains an error that is not equivalent llvm::Error::success()
-/// TODO(jackmontgomery) replace this with a function that will print file and
+/// TODO: replace this with a function that will print file and
 /// line numbers also.
 extern llvm::ExitOnError exitOnErr;
 
@@ -89,7 +89,7 @@ struct IsLLVMExpected<llvm::Expected<T>> : public std::true_type {};
   } while (0)
 
 /// Takes an llvm::Error and returns it if it's not success.
-// TODO(jackmontgomery) extend this to work with llvm::Expected as well.
+// TODO: extend this to work with llvm::Expected as well.
 #define RETURN_IF_ERR(err)                                                     \
   do {                                                                         \
     if (auto errV = std::forward<llvm::Error>(err)) {                          \

--- a/include/glow/Support/Error.h
+++ b/include/glow/Support/Error.h
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_SUPPORT_ERROR_H
+#define GLOW_SUPPORT_ERROR_H
+
+#include <type_traits>
+
+#include "llvm/Support/Error.h"
+
+namespace glow {
+
+namespace detail {
+/// NOTE This should not be used directly, instead use UNWRAP or TEMP_UNWRAP.
+/// Callable that takes an llvm::Error or llvm::Expected<T> and exits the
+/// program if the Error is not equivalent llvm::Error::success() or the
+/// Expected<T> contains an error that is not equivalent llvm::Error::success()
+/// TODO(jackmontgomery) replace this with a function that will print file and
+/// line numbers also.
+extern llvm::ExitOnError exitOnErr;
+
+/// Take a message \p str and prepend it with the given \p file and \p line
+/// number. This is useful for augmenting StringErrors with information about
+/// where they were generated.
+std::string addFileAndLineToError(llvm::StringRef str, llvm::StringRef file,
+                                  uint32_t line);
+} // namespace detail
+
+/// Is true_type only if applied to llvm::Error or a descendant.
+template <typename T>
+struct IsLLVMError : public std::is_base_of<llvm::Error, T> {};
+
+/// Is true_type only if applied to llvm::Expected.
+template <typename> struct IsLLVMExpected : public std::false_type {};
+template <typename T>
+struct IsLLVMExpected<llvm::Expected<T>> : public std::true_type {};
+
+/// Unwrap the T from within an llvm::Expected<T>. If the Expected<T> contains
+/// an error, the program will abort.
+#define UNWRAP(...) (detail::exitOnErr(__VA_ARGS__))
+
+/// A temporary placeholder for UNWRAP. This should be used only during
+/// refactoring to temporarily place an UNWRAP and should eventually be
+/// replaced with either an actual UNWRAP or code that will propogate potential
+/// errors up the stack.
+#define TEMP_UNWRAP(...) (UNWRAP(__VA_ARGS__))
+
+/// Make a new llvm::StringError.
+#define MAKE_ERR(str)                                                          \
+  llvm::make_error<llvm::StringError>(                                         \
+      (detail::addFileAndLineToError(str, __FILE__, __LINE__)),                \
+      llvm::inconvertibleErrorCode())
+
+/// Makes a new llvm::StringError and returns it.
+#define RETURN_ERR(str)                                                        \
+  do {                                                                         \
+    return MAKE_ERR(str);                                                      \
+  } while (0)
+
+/// Returns llvm::Error::success().
+#define RETURN_SUCCESS()                                                       \
+  do {                                                                         \
+    return llvm::Error::success();                                             \
+  } while (0)
+
+/// Takes an llvm::Expected<T> \p lhsOrErr and if it is an Error then returns
+/// it, otherwise takes the value from lhsOrErr and assigns it to \p rhs.
+#define ASSIGN_VALUE_OR_RETURN_ERR(rhs, lhsOrErr)                              \
+  do {                                                                         \
+    auto lhsOrErrV = (lhsOrErr);                                               \
+    static_assert(IsLLVMExpected<decltype(lhsOrErrV)>(),                       \
+                  "Expected value to be a llvm::Expected");                    \
+    if (lhsOrErrV) {                                                           \
+      rhs = std::move(lhsOrErrV.get());                                        \
+    } else {                                                                   \
+      return lhsOrErrV.takeError();                                            \
+    }                                                                          \
+  } while (0)
+
+/// Takes an llvm::Error and returns it if it's not success.
+// TODO(jackmontgomery) extend this to work with llvm::Expected as well.
+#define RETURN_IF_ERR(err)                                                     \
+  do {                                                                         \
+    if (auto errV = std::forward<llvm::Error>(err)) {                          \
+      static_assert(IsLLVMError<decltype(errV)>(),                             \
+                    "Expected value to be a llvm::Error");                     \
+      return std::forward<llvm::Error>(errV);                                  \
+    }                                                                          \
+  } while (0)
+
+/// Takes a predicate \p and if it is false then creates a new llvm::StringError
+/// and returns it.
+#define RETURN_ERR_IF_NOT(p, str)                                              \
+  do {                                                                         \
+    if (!(p)) {                                                                \
+      RETURN_ERR(str);                                                         \
+    }                                                                          \
+  } while (0)
+} // end namespace glow
+
+#endif // GLOW_SUPPORT_ERROR_H

--- a/include/glow/Support/Error.h
+++ b/include/glow/Support/Error.h
@@ -21,7 +21,6 @@
 #include "llvm/Support/Error.h"
 
 namespace glow {
-namespace detail {
 /// NOTE This should not be used directly, instead use UNWRAP or TEMP_UNWRAP.
 /// Callable that takes an llvm::Error or llvm::Expected<T> and exits the
 /// program if the Error is not equivalent llvm::Error::success() or the
@@ -35,7 +34,6 @@ extern llvm::ExitOnError exitOnErr;
 /// where they were generated.
 std::string addFileAndLineToError(llvm::StringRef str, llvm::StringRef file,
                                   uint32_t line);
-} // namespace detail
 
 /// Is true_type only if applied to llvm::Error or a descendant.
 template <typename T>
@@ -48,7 +46,7 @@ struct IsLLVMExpected<llvm::Expected<T>> : public std::true_type {};
 
 /// Unwrap the T from within an llvm::Expected<T>. If the Expected<T> contains
 /// an error, the program will abort.
-#define UNWRAP(...) (detail::exitOnErr(__VA_ARGS__))
+#define UNWRAP(...) (exitOnErr(__VA_ARGS__))
 
 /// A temporary placeholder for UNWRAP. This should be used only during
 /// refactoring to temporarily place an UNWRAP and should eventually be
@@ -59,19 +57,13 @@ struct IsLLVMExpected<llvm::Expected<T>> : public std::true_type {};
 /// Make a new llvm::StringError.
 #define MAKE_ERR(str)                                                          \
   llvm::make_error<llvm::StringError>(                                         \
-      (detail::addFileAndLineToError(str, __FILE__, __LINE__)),                \
+      (addFileAndLineToError(str, __FILE__, __LINE__)),                        \
       llvm::inconvertibleErrorCode())
 
 /// Makes a new llvm::StringError and returns it.
 #define RETURN_ERR(str)                                                        \
   do {                                                                         \
     return MAKE_ERR(str);                                                      \
-  } while (0)
-
-/// Returns llvm::Error::success().
-#define RETURN_SUCCESS()                                                       \
-  do {                                                                         \
-    return llvm::Error::success();                                             \
   } while (0)
 
 /// Takes an llvm::Expected<T> \p lhsOrErr and if it is an Error then returns

--- a/include/glow/Support/Error.h
+++ b/include/glow/Support/Error.h
@@ -21,10 +21,11 @@
 #include "llvm/Support/Error.h"
 
 namespace glow {
-/// NOTE This should not be used directly, instead use UNWRAP or TEMP_UNWRAP.
-/// Callable that takes an llvm::Error or llvm::Expected<T> and exits the
-/// program if the Error is not equivalent llvm::Error::success() or the
-/// Expected<T> contains an error that is not equivalent llvm::Error::success()
+/// NOTE This should not be used directly, instead use EXIT_ON_ERR or
+/// TEMP_EXIT_ON_ERR. Callable that takes an llvm::Error or llvm::Expected<T>
+/// and exits the program if the Error is not equivalent llvm::Error::success()
+/// or the Expected<T> contains an error that is not equivalent
+/// llvm::Error::success()
 /// TODO: replace this with a function that will print file and
 /// line numbers also.
 extern llvm::ExitOnError exitOnErr;
@@ -44,15 +45,15 @@ template <typename> struct IsLLVMExpected : public std::false_type {};
 template <typename T>
 struct IsLLVMExpected<llvm::Expected<T>> : public std::true_type {};
 
-/// Unwrap the T from within an llvm::Expected<T>. If the Expected<T> contains
-/// an error, the program will abort.
-#define UNWRAP(...) (exitOnErr(__VA_ARGS__))
+/// Unwraps the T from within an llvm::Expected<T>. If the Expected<T> contains
+/// an error, the program will exit.
+#define EXIT_ON_ERR(...) (exitOnErr(__VA_ARGS__))
 
-/// A temporary placeholder for UNWRAP. This should be used only during
-/// refactoring to temporarily place an UNWRAP and should eventually be
-/// replaced with either an actual UNWRAP or code that will propogate potential
-/// errors up the stack.
-#define TEMP_UNWRAP(...) (UNWRAP(__VA_ARGS__))
+/// A temporary placeholder for EXIT_ON_ERR. This should be used only during
+/// refactoring to temporarily place an EXIT_ON_ERR and should eventually be
+/// replaced with either an actual EXIT_ON_ERR or code that will propogate
+/// potential errors up the stack.
+#define TEMP_EXIT_ON_ERR(...) (EXIT_ON_ERR(__VA_ARGS__))
 
 /// Make a new llvm::StringError.
 #define MAKE_ERR(str)                                                          \

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -1081,11 +1081,11 @@ Caffe2ModelLoader::Caffe2ModelLoader(const std::string &netDescFilename,
                                      llvm::ArrayRef<TypeRef> types, Function &F)
     : CommonOperatorLoader(names, types, F) {
   // The caffe2 network descriptor that we are deserializing.
-  caffe2::NetDef networkDef = UNWRAP(loadProtoFile(netDescFilename));
+  caffe2::NetDef networkDef = EXIT_ON_ERR(loadProtoFile(netDescFilename));
 
   // The caffe2 weights that we are deserializing.
-  caffe2::NetDef weightsDef = UNWRAP(loadProtoFile(netWeightFilename));
+  caffe2::NetDef weightsDef = EXIT_ON_ERR(loadProtoFile(netWeightFilename));
 
-  TEMP_UNWRAP(loadWeights(weightsDef));
-  TEMP_UNWRAP(loadNetwork(networkDef));
+  TEMP_EXIT_ON_ERR(loadWeights(weightsDef));
+  TEMP_EXIT_ON_ERR(loadNetwork(networkDef));
 }

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -18,6 +18,7 @@
 #include "glow/Base/Tensor.h"
 #include "glow/Graph/Graph.h"
 #include "glow/Graph/Nodes.h"
+#include "glow/Support/Error.h"
 
 #include "llvm/Support/Casting.h"
 
@@ -25,7 +26,6 @@
 #include <google/protobuf/io/coded_stream.h>
 #include <google/protobuf/io/zero_copy_stream_impl.h>
 
-#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <fstream>
@@ -58,69 +58,74 @@ static ArgumentDictionaryTy loadArgumentMap(const caffe2::OperatorDef &op) {
   return dict;
 }
 
-static std::vector<unsigned_t> getPads(const ArgumentDictionaryTy &dict) {
+static llvm::Expected<std::vector<unsigned_t>>
+getPads(const ArgumentDictionaryTy &dict) {
   if (dict.count("pad")) {
-    int pad = loadInt(dict.at("pad"));
+    int pad;
+    ASSIGN_VALUE_OR_RETURN_ERR(pad, loadInt(dict.at("pad")));
     std::vector<unsigned_t> pads(4, pad);
     return pads;
   }
   if (dict.count("pad_t")) {
     std::vector<unsigned_t> pads(4);
-    pads[0] = loadInt(dict.at("pad_t"));
-    assert(dict.count("pad_l") && "missing pad_l");
-    pads[1] = loadInt(dict.at("pad_l"));
-    assert(dict.count("pad_b") && "missing pad_b");
-    pads[2] = loadInt(dict.at("pad_b"));
-    assert(dict.count("pad_r") && "missing pad_r");
-    pads[3] = loadInt(dict.at("pad_r"));
+    ASSIGN_VALUE_OR_RETURN_ERR(pads[0], loadInt(dict.at("pad_t")));
+    RETURN_ERR_IF_NOT(dict.count("pad_l"), "missing pad_l");
+    ASSIGN_VALUE_OR_RETURN_ERR(pads[1], loadInt(dict.at("pad_l")));
+    RETURN_ERR_IF_NOT(dict.count("pad_b"), "missing pad_b");
+    ASSIGN_VALUE_OR_RETURN_ERR(pads[2], loadInt(dict.at("pad_b")));
+    RETURN_ERR_IF_NOT(dict.count("pad_r"), "missing pad_r");
+    ASSIGN_VALUE_OR_RETURN_ERR(pads[3], loadInt(dict.at("pad_r")));
     return pads;
   }
   if (dict.count("pads")) {
     return getShape<unsigned_t>(dict.at("pads"));
   }
   // Return default value 0 for pads.
-  return {0, 0, 0, 0};
+  return std::vector<unsigned_t>{0, 0, 0, 0};
 }
 
 /// Translates the "order" field of dictionary \p dict into a channel number.
-static unsigned_t getChannel(const ArgumentDictionaryTy &dict) {
+static llvm::Expected<unsigned_t> getChannel(const ArgumentDictionaryTy &dict) {
   std::string order = "NCHW"; // default
   auto orderIt = dict.find("order");
   if (orderIt != dict.end()) {
-    order = loadStr(orderIt->second);
+    ASSIGN_VALUE_OR_RETURN_ERR(order, loadStr(orderIt->second));
   }
   if (order == "NHWC") {
     return 3;
   } else if (order == "NCHW") {
     return 1;
   }
-  GLOW_ASSERT(false && "Invalid order field");
+  RETURN_ERR("Invalid order field");
 }
 
-static std::vector<unsigned_t> getSizeHW(ArgumentDictionaryTy &dict,
-                                         const std::string &name,
-                                         unsigned_t defaultValue) {
+static llvm::Expected<std::vector<unsigned_t>>
+getSizeHW(ArgumentDictionaryTy &dict, const std::string &name,
+          unsigned_t defaultValue) {
   if (dict.count(name)) {
-    int value = loadInt(dict[name]);
+    int value;
+    ASSIGN_VALUE_OR_RETURN_ERR(value, loadInt(dict[name]));
     std::vector<unsigned_t> result(2, value);
     return result;
   }
   if (dict.count(name + "_h") && dict.count(name + "_w")) {
     std::vector<unsigned_t> result(2);
-    result[0] = loadInt(dict[name + "_h"]);
-    result[1] = loadInt(dict[name + "_w"]);
+    ASSIGN_VALUE_OR_RETURN_ERR(result[0], loadInt(dict[name + "_h"]));
+    ASSIGN_VALUE_OR_RETURN_ERR(result[1], loadInt(dict[name + "_w"]));
     return result;
   }
   if (dict.count(name + "s")) {
     return getShape<unsigned_t>(dict.at(name + "s"));
   }
-  return {defaultValue, defaultValue};
+  return std::vector<unsigned_t>{defaultValue, defaultValue};
 }
 
-bool Caffe2ModelLoader::loadProtoFile(caffe2::NetDef &net,
-                                      const std::string &filename) {
+llvm::Expected<caffe2::NetDef>
+Caffe2ModelLoader::loadProtoFile(const std::string &filename) {
   std::ifstream ff(filename, std::ios::in | std::ios::binary);
-  GLOW_ASSERT(ff && "Can't find the model or network files.");
+  RETURN_ERR_IF_NOT(ff, "Can't find the model or network files.");
+
+  caffe2::NetDef net;
 
   bool parseNet = false;
   if (filename.find(".pbtxt") != std::string::npos) {
@@ -136,37 +141,56 @@ bool Caffe2ModelLoader::loadProtoFile(caffe2::NetDef &net,
     parseNet = net.ParseFromCodedStream(&codedstr);
   }
 
-  GLOW_ASSERT(parseNet && "Failed to parse the network descriptor.");
-  return true;
+  RETURN_ERR_IF_NOT(parseNet, "Failed to parse the network descriptor.");
+  return net;
 }
 
-bool Caffe2ModelLoader::getBroadcast(const ArgumentDictionaryTy &dict) {
-  return dict.count("broadcast") && (loadInt(dict.at("broadcast")) == 1);
+llvm::Expected<bool>
+Caffe2ModelLoader::getBroadcast(const ArgumentDictionaryTy &dict) {
+  if (!dict.count("broadcast")) {
+    return false;
+  }
+  int broadcast;
+  ASSIGN_VALUE_OR_RETURN_ERR(broadcast, loadInt(dict.at("broadcast")));
+  return broadcast == 1;
 }
 
-void Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
+llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
   ArgumentDictionaryTy dict = loadArgumentMap(op);
   const std::string &typeName = op.type();
 
   // Check if operator is supported in parent class, CommonOperatorLoader.
-  if (tryLoadCommonOperator(typeName, op, dict)) {
-    // If operator is supported, CommonOperatorLoader loaded it to the Graph.
-    return;
+  bool loadCommonOperatorSuccess;
+  ASSIGN_VALUE_OR_RETURN_ERR(loadCommonOperatorSuccess,
+                             tryLoadCommonOperator(typeName, op, dict));
+  if (loadCommonOperatorSuccess) {
+    RETURN_SUCCESS();
   }
-
   const std::string &opName = loadOperatorName(op);
 
   if (typeName == "Conv" || typeName == "Int8Conv" ||
       typeName == "Int8ConvRelu") {
     // Load the inputs:
-    std::vector<unsigned_t> strides = getSizeHW(dict, "stride", 1);
-    std::vector<unsigned_t> pads = getPads(dict);
-    std::vector<unsigned_t> kernels = getSizeHW(dict, "kernel", 0);
-    unsigned_t group = dict.count("group") ? loadInt(dict["group"]) : 1;
-    std::string order = dict.count("order") ? loadStr(dict["order"]) : "NCHW";
+    std::vector<unsigned_t> strides;
+    ASSIGN_VALUE_OR_RETURN_ERR(strides, getSizeHW(dict, "stride", 1));
+    std::vector<unsigned_t> pads;
+    ASSIGN_VALUE_OR_RETURN_ERR(pads, getPads(dict));
+    std::vector<unsigned_t> kernels;
+    ASSIGN_VALUE_OR_RETURN_ERR(kernels, getSizeHW(dict, "kernel", 0));
+    unsigned_t group = 1;
+    if (dict.count("group")) {
+      ASSIGN_VALUE_OR_RETURN_ERR(group, loadInt(dict["group"]));
+    }
+    std::string order = "NCHW";
+    if (dict.count("order")) {
+      ASSIGN_VALUE_OR_RETURN_ERR(order, loadStr(dict["order"]));
+    }
 
-    auto in = getNodeValueOrCreateConstantByName(op.input(0));
-    Tensor *w = getTensorByName(op.input(1));
+    NodeValue in;
+    ASSIGN_VALUE_OR_RETURN_ERR(in,
+                               getNodeValueOrCreateConstantByName(op.input(0)));
+    Tensor *w;
+    ASSIGN_VALUE_OR_RETURN_ERR(w, getTensorByName(op.input(1)));
 
     // Transpose the weights to the right format. Glow expects to read the
     // weights in the format CRSK.
@@ -262,7 +286,7 @@ void Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
       node = G_.createTranspose(opName, node, NHWC2NCHW);
     }
     addNodeAsOutput(op, node);
-    return;
+    RETURN_SUCCESS();
   }
 
   if (typeName == "Int8SumRelu") {
@@ -307,11 +331,19 @@ void Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
   if (typeName == "MaxPool" || typeName == "AveragePool" ||
       typeName == "Int8MaxPool" || typeName == "Int8AveragePool") {
     // Load the inputs:
-    auto in = getNodeValueOrCreateConstantByName(op.input(0));
-    std::vector<unsigned_t> strides = getSizeHW(dict, "stride", 1);
-    std::vector<unsigned_t> kernels = getSizeHW(dict, "kernel", 0);
-    std::vector<unsigned_t> pads = getPads(dict);
-    std::string order = dict.count("order") ? loadStr(dict["order"]) : "NCHW";
+    NodeValue in;
+    ASSIGN_VALUE_OR_RETURN_ERR(in,
+                               getNodeValueOrCreateConstantByName(op.input(0)));
+    std::vector<unsigned_t> strides;
+    ASSIGN_VALUE_OR_RETURN_ERR(strides, getSizeHW(dict, "stride", 1));
+    std::vector<unsigned_t> kernels;
+    ASSIGN_VALUE_OR_RETURN_ERR(kernels, getSizeHW(dict, "kernel", 0));
+    std::vector<unsigned_t> pads;
+    ASSIGN_VALUE_OR_RETURN_ERR(pads, getPads(dict));
+    std::string order = "NCHW";
+    if (dict.count("order")) {
+      ASSIGN_VALUE_OR_RETURN_ERR(order, loadStr(dict["order"]));
+    }
     // We expect the input to be NHWC.
     Node *tr;
     if (order == "NCHW") {
@@ -361,22 +393,29 @@ void Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
       node = G_.createTranspose(opName, node, NHWC2NCHW);
     }
     addNodeAsOutput(op, node);
-    return;
+    RETURN_SUCCESS();
   }
 
   if (typeName == "SpatialBN") {
-    auto in = getNodeValueOrCreateConstantByName(op.input(0));
-    auto *scale = getTensorByName(op.input(1));
-    auto *bias = getTensorByName(op.input(2));
-    auto *mean = getTensorByName(op.input(3));
-    auto *var = getTensorByName(op.input(4));
+    NodeValue in;
+    ASSIGN_VALUE_OR_RETURN_ERR(in,
+                               getNodeValueOrCreateConstantByName(op.input(0)));
+    Tensor *scale;
+    ASSIGN_VALUE_OR_RETURN_ERR(scale, getTensorByName(op.input(1)));
+    Tensor *bias;
+    ASSIGN_VALUE_OR_RETURN_ERR(bias, getTensorByName(op.input(2)));
+    Tensor *mean;
+    ASSIGN_VALUE_OR_RETURN_ERR(mean, getTensorByName(op.input(3)));
+    Tensor *var;
+    ASSIGN_VALUE_OR_RETURN_ERR(var, getTensorByName(op.input(4)));
     float epsilon = 1e-5f; // default
     auto epsilonIt = dict.find("epsilon");
     if (epsilonIt != dict.end()) {
-      epsilon = loadFloat(epsilonIt->second);
+      ASSIGN_VALUE_OR_RETURN_ERR(epsilon, loadFloat(epsilonIt->second));
     }
 
-    auto channel = getChannel(dict);
+    unsigned_t channel;
+    ASSIGN_VALUE_OR_RETURN_ERR(channel, getChannel(dict));
     auto *scaleV = G_.getParent()->createConstant("scale", *scale);
     auto *biasV = G_.getParent()->createConstant("bias", *bias);
     auto *meanV = G_.getParent()->createConstant("mean", *mean);
@@ -385,7 +424,7 @@ void Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
                                              varV, channel, epsilon);
 
     addNodeAsOutput(op, node);
-    return;
+    RETURN_SUCCESS();
   }
 
   if (typeName == "Concat") {
@@ -393,24 +432,34 @@ void Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     llvm::SmallVector<NodeValue, 4> inputs;
     inputs.reserve(numInputs);
     for (unsigned i = 0; i < numInputs; i++) {
-      inputs.push_back(getNodeValueOrCreateConstantByName(op.input(i)));
+      NodeValue in;
+      ASSIGN_VALUE_OR_RETURN_ERR(
+          in, getNodeValueOrCreateConstantByName(op.input(i)));
+      inputs.push_back(in);
     }
 
     // If axis exists it takes priority over channel.
-    unsigned_t channel =
-        dict.count("axis") ? loadInt(dict["axis"]) : getChannel(dict);
+    unsigned_t channel;
+    if (dict.count("axis")) {
+      ASSIGN_VALUE_OR_RETURN_ERR(channel, loadInt(dict["axis"]));
+    } else {
+      ASSIGN_VALUE_OR_RETURN_ERR(channel, getChannel(dict));
+    }
 
     Node *node = G_.createConcat(opName, inputs, channel);
 
-    unsigned_t addAxis = dict.count("add_axis") ? loadInt(dict["add_axis"]) : 0;
+    unsigned_t addAxis = 0;
+    if (dict.count("add_axis")) {
+      ASSIGN_VALUE_OR_RETURN_ERR(addAxis, loadInt(dict["add_axis"]));
+    }
 
     if (addAxis) {
       // When add axis is used, this means we have to add a new dimension before
       // the axis, instead of merging on the axis.
       std::vector<size_t> outputDims = inputs[0].dims();
       for (const auto &input : inputs) {
-        GLOW_ASSERT(
-            outputDims[channel] == input.dims()[channel] &&
+        RETURN_ERR_IF_NOT(
+            outputDims[channel] == input.dims()[channel],
             "inputs need all to have the same dims for concat with add_axis");
       }
       outputDims.insert(outputDims.begin() + channel, numInputs);
@@ -419,21 +468,32 @@ void Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     // Concat has multiple outputs in Caffe2, but I believe the other output
     // (split_info) is not used for inference.
     nodeValueByName_[op.output(0)] = NodeValue(node, 0);
-    return;
+    RETURN_SUCCESS();
   }
 
   if (typeName == "FC" || typeName == "FCTransposed" || typeName == "Int8FC") {
     // Load the inputs:
-    auto in = getNodeValueOrCreateConstantByName(op.input(0));
+    NodeValue in;
+    ASSIGN_VALUE_OR_RETURN_ERR(in,
+                               getNodeValueOrCreateConstantByName(op.input(0)));
     if (in.getType()->dims().size() > 2) {
-      size_t axis = dict.count("axis") ? loadInt(dict["axis"]) : 1;
+      size_t axis = 1;
+      if (dict.count("axis")) {
+        ASSIGN_VALUE_OR_RETURN_ERR(axis, loadInt(dict["axis"]));
+      }
+
       in = G_.createFlatten("fc.in", in, axis);
     }
 
     // Load weights.
-    Tensor *w = getTensorByName(op.input(1));
-    Tensor *b = getTensorByName(op.input(2));
-    unsigned_t axis_w = dict.count("axis_w") ? loadInt(dict["axis_w"]) : 1;
+    Tensor *w;
+    ASSIGN_VALUE_OR_RETURN_ERR(w, getTensorByName(op.input(1)));
+    Tensor *b;
+    ASSIGN_VALUE_OR_RETURN_ERR(b, getTensorByName(op.input(2)));
+    unsigned_t axis_w = 1;
+    if (dict.count("axis_w")) {
+      ASSIGN_VALUE_OR_RETURN_ERR(axis_w, loadInt(dict["axis_w"]));
+    }
 
     // Caffe2 stores the transposed W matrix. In here we first coerce W to a 2D
     // matrix size if necessay and then transpose it back.
@@ -479,146 +539,181 @@ void Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
 
     // Save the outputs:
     addNodeAsOutput(op, node);
-    return;
+    RETURN_SUCCESS();
   }
 
   if (typeName == "ChannelShuffle") {
-    auto in = getNodeValueOrCreateConstantByName(op.input(0));
+    NodeValue in;
+    ASSIGN_VALUE_OR_RETURN_ERR(in,
+                               getNodeValueOrCreateConstantByName(op.input(0)));
 
-    size_t group = loadInt(dict["group"]);
-    size_t kernel = loadInt(dict["kernel"]);
+    size_t group;
+    ASSIGN_VALUE_OR_RETURN_ERR(group, loadInt(dict["group"]));
+    size_t kernel;
+    ASSIGN_VALUE_OR_RETURN_ERR(kernel, loadInt(dict["kernel"]));
 
     Node *node = G_.createChannelShuffle(opName, in, group, kernel);
     addNodeAsOutput(op, node);
-    return;
+    RETURN_SUCCESS();
   }
 
   if (typeName == "Squeeze") {
-    auto in = getNodeValueOrCreateConstantByName(op.input(0));
+    NodeValue in;
+    ASSIGN_VALUE_OR_RETURN_ERR(in,
+                               getNodeValueOrCreateConstantByName(op.input(0)));
     auto dims = getShape(dict["dims"]);
     Node *node = G_.createSqueeze(opName, in, dims);
     addNodeAsOutput(op, node);
-    return;
+    RETURN_SUCCESS();
   }
 
   if (typeName == "Log") {
     // Load the inputs:
-    auto in = getNodeValueOrCreateConstantByName(op.input(0));
+    NodeValue in;
+    ASSIGN_VALUE_OR_RETURN_ERR(in,
+                               getNodeValueOrCreateConstantByName(op.input(0)));
     // Create the log:
     auto *R = G_.createLog(opName, in);
     addNodeAsOutput(op, R);
-    return;
+    RETURN_SUCCESS();
   }
 
   if (typeName == "Logit") {
     // Load the input and (optional) epsilon clamping value:
-    auto input = getNodeValueOrCreateConstantByName(op.input(0));
+    NodeValue input;
+    ASSIGN_VALUE_OR_RETURN_ERR(input,
+                               getNodeValueOrCreateConstantByName(op.input(0)));
     auto epsIt = dict.find("eps");
     // default: 1e-6 (as in Caffe2)
-    auto eps = epsIt != dict.end() ? loadFloat(epsIt->second) : 1E-6f;
+    float eps = 1E-6f;
+    if (epsIt != dict.end()) {
+      ASSIGN_VALUE_OR_RETURN_ERR(eps, loadFloat(epsIt->second));
+    }
+
     auto *node = G_.createLogit(opName, input, eps);
     // Save the outputs:
     addNodeAsOutput(op, node);
-    return;
+    RETURN_SUCCESS();
   }
 
   if (typeName == "EQ") {
-    auto in0 = getNodeValueOrCreateConstantByName(op.input(0));
-    auto in1 = getNodeValueOrCreateConstantByName(op.input(1));
+    NodeValue in0;
+    ASSIGN_VALUE_OR_RETURN_ERR(in0,
+                               getNodeValueOrCreateConstantByName(op.input(0)));
+    NodeValue in1;
+    ASSIGN_VALUE_OR_RETURN_ERR(in1,
+                               getNodeValueOrCreateConstantByName(op.input(1)));
     auto *node = G_.createCmpEQ(opName, in0, in1);
     addNodeAsOutput(op, node);
-    return;
+    RETURN_SUCCESS();
   }
 
   if (typeName == "Tile") {
-    auto in = getNodeValueOrCreateConstantByName(op.input(0));
-    unsigned_t tiles = loadInt(dict["tiles"]);
-    unsigned_t axis = loadInt(dict["axis"]);
+    NodeValue in;
+    ASSIGN_VALUE_OR_RETURN_ERR(in,
+                               getNodeValueOrCreateConstantByName(op.input(0)));
+    unsigned_t tiles;
+    ASSIGN_VALUE_OR_RETURN_ERR(tiles, loadInt(dict["tiles"]));
+    unsigned_t axis;
+    ASSIGN_VALUE_OR_RETURN_ERR(axis, loadInt(dict["axis"]));
 
     auto *node = G_.createTile(opName, in, tiles, axis);
     addNodeAsOutput(op, node);
-    return;
+    RETURN_SUCCESS();
   }
 
   if (typeName == "Free") {
     // Glow frees memory automatically.
-    return;
+    RETURN_SUCCESS();
   }
   if (typeName == "StopGradient") {
-    auto in = getNodeValueOrCreateConstantByName(op.input(0));
+    NodeValue in;
+    ASSIGN_VALUE_OR_RETURN_ERR(in,
+                               getNodeValueOrCreateConstantByName(op.input(0)));
     // Currently Caffe2 importer only supports inference.
     addNodeAsOutput(op, in);
-    return;
+    RETURN_SUCCESS();
   }
 
   if (typeName == "Transpose") {
-    return loadTranspose(op, dict, "axes");
+    RETURN_IF_ERR(loadTranspose(op, dict, "axes"));
+    RETURN_SUCCESS();
   }
 
   if (typeName == "NCHW2NHWC") {
-    auto in = getNodeValueOrCreateConstantByName(op.input(0));
+    NodeValue in;
+    ASSIGN_VALUE_OR_RETURN_ERR(in,
+                               getNodeValueOrCreateConstantByName(op.input(0)));
     auto *node = G_.createTranspose(opName, in, NCHW2NHWC);
     addNodeAsOutput(op, node);
-    return;
+    RETURN_SUCCESS();
   }
 
   if (typeName == "CopyCPUToMKL" || typeName == "CopyMKLToCPU" ||
       typeName == "Copy" || typeName == "EnsureCPUOutput" ||
       typeName == "EnsureDense") {
     // Glow does not support any of these ops now, so implement them as no-ops.
-    auto in = getNodeValueOrCreateConstantByName(op.input(0));
+    NodeValue in;
+    ASSIGN_VALUE_OR_RETURN_ERR(in,
+                               getNodeValueOrCreateConstantByName(op.input(0)));
     addNodeAsOutput(op, in);
-    return;
+    RETURN_SUCCESS();
   }
 
   if (typeName == "Slice") {
-    auto data = getNodeValueOrCreateConstantByName(op.input(0));
+    NodeValue data;
+    ASSIGN_VALUE_OR_RETURN_ERR(data,
+                               getNodeValueOrCreateConstantByName(op.input(0)));
 
     auto starts = getShape<ssize_t>(dict["starts"]);
     auto ends = getShape<ssize_t>(dict["ends"]);
 
     std::vector<size_t> newStarts, newEnds;
-    assert(starts.size() == ends.size());
+    RETURN_ERR_IF_NOT(starts.size() == ends.size(),
+                      "Slice starts and ends must be the same size.");
     for (size_t i = 0; i < starts.size(); i++) {
       ssize_t newStart = starts[i];
       if (newStart == -1) {
         newStart = data.dims()[i];
       }
-      assert(newStart >= 0 && "Indices should never be negative.");
+      RETURN_ERR_IF_NOT(newStart >= 0, "Indices should never be negative.");
       newStarts.push_back(newStart);
 
       ssize_t newEnd = ends[i];
       if (newEnd == -1) {
         newEnd = data.dims()[i];
       }
-      assert(newEnd >= 0 && "Indices should never be negative.");
+      RETURN_ERR_IF_NOT(newEnd >= 0, "Indices should never be negative.");
       newEnds.push_back(newEnd);
     }
 
     Node *SN = G_.createSlice(opName, data, newStarts, newEnds);
     addNodeAsOutput(op, SN);
-    return;
+    RETURN_SUCCESS();
   }
 
   if (typeName == "MatMul") {
-    loadBatchMatMul(op, dict, false);
-    return;
+    RETURN_IF_ERR(loadBatchMatMul(op, dict, false));
+    RETURN_SUCCESS();
   }
 
   if (typeName == "Cast") {
-    auto in = getNodeValueOrCreateConstantByName(op.input(0));
-    int to = loadInt(dict["to"]);
+    NodeValue in;
+    ASSIGN_VALUE_OR_RETURN_ERR(in,
+                               getNodeValueOrCreateConstantByName(op.input(0)));
+    int to;
+    ASSIGN_VALUE_OR_RETURN_ERR(to, loadInt(dict["to"]));
 
     switch (to) {
     case caffe2::TensorProto_DataType_FLOAT: {
-      assert(in.getElementType() == ElemKind::FloatTy &&
-             "Can only cast float to float.");
+      RETURN_ERR_IF_NOT(in.getElementType() == ElemKind::FloatTy,
+                        "Can only cast float to float.");
       break;
     }
     case caffe2::TensorProto_DataType_INT32:
     case caffe2::TensorProto_DataType_INT64: {
-      assert(in.getElementType() == ElemKind::Int64ITy &&
-             "Can only cast int to int.");
+      RETURN_ERR_IF_NOT(in.getElementType() == ElemKind::Int64ITy,
+                        "Can only cast int to int.");
       break;
     }
     default:
@@ -626,63 +721,77 @@ void Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     }
 
     addNodeAsOutput(op, in);
-    return;
+    RETURN_SUCCESS();
   }
 
   if (typeName == "ScatterAssign") {
-    auto data = getNodeValueOrCreateConstantByName(op.input(0));
-    auto indices = getNodeValueOrCreateConstantByName(op.input(1));
-    auto slices = getNodeValueOrCreateConstantByName(op.input(2));
+    NodeValue data;
+    ASSIGN_VALUE_OR_RETURN_ERR(data,
+                               getNodeValueOrCreateConstantByName(op.input(0)));
+    NodeValue indices;
+    ASSIGN_VALUE_OR_RETURN_ERR(indices,
+                               getNodeValueOrCreateConstantByName(op.input(1)));
+    NodeValue slices;
+    ASSIGN_VALUE_OR_RETURN_ERR(slices,
+                               getNodeValueOrCreateConstantByName(op.input(2)));
 
     Node *SAN = G_.createScatterAssign(opName, data, indices, slices);
     addNodeAsOutput(op, SAN);
-    return;
+    RETURN_SUCCESS();
   }
 
   if (typeName == "ConstantFill" || typeName == "GivenTensorIntFill" ||
       typeName == "GivenTensorInt64Fill") {
-    loadWeight(op);
-    return;
+    RETURN_IF_ERR(loadWeight(op));
+    RETURN_SUCCESS();
   }
 
   if (typeName == "SigmoidCrossEntropyWithLogits") {
-    auto logits = getNodeValueOrCreateConstantByName(op.input(0));
-    auto targets = getNodeValueOrCreateConstantByName(op.input(1));
+    NodeValue logits;
+    ASSIGN_VALUE_OR_RETURN_ERR(logits,
+                               getNodeValueOrCreateConstantByName(op.input(0)));
+    NodeValue targets;
+    ASSIGN_VALUE_OR_RETURN_ERR(targets,
+                               getNodeValueOrCreateConstantByName(op.input(1)));
     Node *SCEL =
         G_.createSigmoidCrossEntropyWithLogits(opName, logits, targets);
     addNodeAsOutput(op, SCEL);
-    return;
+    RETURN_SUCCESS();
   }
 
   if (typeName == "AveragedLoss") {
-    auto in = getNodeValueOrCreateConstantByName(op.input(0));
+    NodeValue in;
+    ASSIGN_VALUE_OR_RETURN_ERR(in,
+                               getNodeValueOrCreateConstantByName(op.input(0)));
     auto *node = G_.createBatchedReduceMean(opName, in, 0);
     addNodeAsOutput(op, node);
-    return;
+    RETURN_SUCCESS();
   }
 
-  unexpectedNodeError(op, "Unsupported operator.");
+  RETURN_ERR(unexpectedNodeErrorMessage(op, "Unsupported operator."));
 }
 
-void Caffe2ModelLoader::loadNetwork(caffe2::NetDef &net) {
+llvm::Error Caffe2ModelLoader::loadNetwork(caffe2::NetDef &net) {
   /// Load the network operators:
   for (int i = 0; i < net.op_size(); i++) {
     auto &op = net.op(i);
-    loadOperator(op);
+    RETURN_IF_ERR(loadOperator(op));
   }
 
-  assert(net.external_output_size() &&
-         "Network needs external outputs defined.");
+  RETURN_ERR_IF_NOT(net.external_output_size(),
+                    "Network needs external outputs defined.");
 
   for (int i = 0; i < net.external_output_size(); i++) {
     auto &outputName = net.external_output(i);
-    auto r = getNodeValueByName(outputName);
+    NodeValue r;
+    ASSIGN_VALUE_OR_RETURN_ERR(r, getNodeValueByName(outputName));
     auto *SN = G_.createSave("save_" + outputName, r);
     outputVarsByName_[outputName] = SN->getPlaceholder();
   }
+  RETURN_SUCCESS();
 }
 
-void Caffe2ModelLoader::loadWeight(const caffe2::OperatorDef &op) {
+llvm::Error Caffe2ModelLoader::loadWeight(const caffe2::OperatorDef &op) {
   ArgumentDictionaryTy dict = loadArgumentMap(op);
   const std::string &typeName = op.type();
 
@@ -734,13 +843,14 @@ void Caffe2ModelLoader::loadWeight(const caffe2::OperatorDef &op) {
         unexpectedNodeError(op, "Unsupported data type for " + typeName);
       }
     } else {
-      unexpectedNodeError(op, "Unsupported data type for " + typeName);
+      RETURN_ERR(unexpectedNodeError(op, "Unsupported data type for " + typeName));
     }
 #undef LOAD_TENSOR_FILL
 
-    assert(i == T->size() && "The number of serialized values does not "
-                             "match the size of the tensor.");
-    return;
+    RETURN_ERR_IF_NOT(i == T->size(),
+                      "The number of serialized values does not "
+                      "match the size of the tensor.");
+    RETURN_SUCCESS();
   }
 
   // Load quantized tensors:
@@ -826,7 +936,7 @@ void Caffe2ModelLoader::loadWeight(const caffe2::OperatorDef &op) {
     // If the tensor is pre-populated by the user of this class then we don't
     // need to allocate a new tensor.
     if (tensors_.count(name)) {
-      return;
+      RETURN_SUCCESS();
     }
 
     auto *T = new Tensor();
@@ -838,24 +948,28 @@ void Caffe2ModelLoader::loadWeight(const caffe2::OperatorDef &op) {
     if (dict.count("shape")) {
       dims = getShape(dict["shape"]);
     } else {
-      assert(op.input_size() > 0 &&
-             "If no shape provided, must have input shape.");
+      RETURN_ERR_IF_NOT(op.input_size() > 0,
+                        "If no shape provided, must have input shape.");
       // It must be registered as a tensor because it must be statically set
       // already, as shapes must be statically known.
-      auto *in = getTensorByName(op.input(0));
+      Tensor *in;
+      ASSIGN_VALUE_OR_RETURN_ERR(in, getTensorByName(op.input(0)));
       dims = in->dims();
     }
 
-    int to = dict.count("dtype") ? loadInt(dict["dtype"])
-                                 : caffe2::TensorProto_DataType_FLOAT;
+    int to = caffe2::TensorProto_DataType_FLOAT;
+    if (dict.count("dtype")) {
+      ASSIGN_VALUE_OR_RETURN_ERR(to, loadInt(dict["dtype"]));
+    }
 
     switch (to) {
     case caffe2::TensorProto_DataType_FLOAT: {
       T->reset(ElemKind::FloatTy, dims);
       auto TH = T->getHandle<float>();
-      auto f = (dict.count("value") && dict["value"]->has_f())
-                   ? loadFloat(dict["value"])
-                   : 0.0f;
+      float f = 0.0f;
+      if ((dict.count("value") && dict["value"]->has_f())) {
+        ASSIGN_VALUE_OR_RETURN_ERR(f, loadFloat(dict["value"]));
+      }
       TH.clear(f);
       break;
     }
@@ -864,17 +978,18 @@ void Caffe2ModelLoader::loadWeight(const caffe2::OperatorDef &op) {
     case caffe2::TensorProto_DataType_BOOL: {
       T->reset(ElemKind::Int64ITy, dims);
       auto TH = T->getHandle<int64_t>();
-      auto i = (dict.count("value") && dict["value"]->has_i())
-                   ? loadInt(dict["value"])
-                   : 0;
+      int i = 0;
+      if ((dict.count("value") && dict["value"]->has_i())) {
+        ASSIGN_VALUE_OR_RETURN_ERR(i, loadInt(dict["value"]));
+      }
       TH.clear(i);
       break;
     }
     default:
-      llvm_unreachable("Unsupported datatype for ConstantFill.");
+      RETURN_ERR("Unsupported datatype for ConstantFill.");
     }
 
-    return;
+    RETURN_SUCCESS();
   }
 
   if (typeName == "UniformFill") {
@@ -902,8 +1017,10 @@ void Caffe2ModelLoader::loadWeight(const caffe2::OperatorDef &op) {
     auto dim = getShape(dict["shape"]);
     T->reset(ElemKind::FloatTy, dim);
     auto TH = T->getHandle<>();
-    float tensorMin = loadFloat(dict["min"]);
-    float tensorMax = loadFloat(dict["max"]);
+    float tensorMin;
+    ASSIGN_VALUE_OR_RETURN_ERR(tensorMin, loadFloat(dict["min"]));
+    float tensorMax;
+    ASSIGN_VALUE_OR_RETURN_ERR(tensorMax, loadFloat(dict["max"]));
 
 #ifndef NDEBUG
     llvm::outs() << "The model contains UniformFill operator, which generates"
@@ -913,16 +1030,17 @@ void Caffe2ModelLoader::loadWeight(const caffe2::OperatorDef &op) {
     for (size_t i = 0, e = T->size(); i != e; i++) {
       TH.raw(i) = G_.getParent()->getPRNG().nextRandReal(tensorMin, tensorMax);
     }
-    return;
+    RETURN_SUCCESS();
   }
 
-  unexpectedNodeError(op, "Unsupported weight kind");
+  RETURN_ERR(unexpectedNodeErrorMessage(op, "Unsupported weight kind"));
 }
 
-void Caffe2ModelLoader::loadWeights(caffe2::NetDef &net) {
+llvm::Error Caffe2ModelLoader::loadWeights(caffe2::NetDef &net) {
   for (auto &op : net.op()) {
-    loadWeight(op);
+    RETURN_IF_ERR(loadWeight(op));
   }
+  RETURN_SUCCESS();
 }
 
 Caffe2ModelLoader::Caffe2ModelLoader(const std::string &netDescFilename,
@@ -930,13 +1048,12 @@ Caffe2ModelLoader::Caffe2ModelLoader(const std::string &netDescFilename,
                                      llvm::ArrayRef<const char *> names,
                                      llvm::ArrayRef<TypeRef> types, Function &F)
     : CommonOperatorLoader(names, types, F) {
-  // The caffe2 weights that we are deserializing.
-  caffe2::NetDef weightsDef;
   // The caffe2 network descriptor that we are deserializing.
-  caffe2::NetDef networkDef;
+  caffe2::NetDef networkDef = UNWRAP(loadProtoFile(netDescFilename));
 
-  loadProtoFile(networkDef, netDescFilename);
-  loadProtoFile(weightsDef, netWeightFilename);
-  loadWeights(weightsDef);
-  loadNetwork(networkDef);
+  // The caffe2 weights that we are deserializing.
+  caffe2::NetDef weightsDef = UNWRAP(loadProtoFile(netWeightFilename));
+
+  TEMP_UNWRAP(loadWeights(weightsDef));
+  TEMP_UNWRAP(loadNetwork(networkDef));
 }

--- a/lib/Importer/ONNXIFIModelLoader.cpp
+++ b/lib/Importer/ONNXIFIModelLoader.cpp
@@ -129,26 +129,26 @@ llvm::Error ONNXIFIModelLoader::loadWeights(
   RETURN_SUCCESS();
 }
 
-llvm::Expected<ONNXIFIModelLoader> ONNXIFIModelLoader::parse(
+llvm::Expected<std::unique_ptr<ONNXIFIModelLoader>> ONNXIFIModelLoader::parse(
     const void *onnxModel, uint32_t onnxModelSize, uint32_t weightsCount,
     const onnxTensorDescriptorV1 *weightDescriptors, Function &F) {
-  ONNXIFIModelLoader loader(F);
+  std::unique_ptr<ONNXIFIModelLoader> loader(new ONNXIFIModelLoader(F));
 
   ONNX_NAMESPACE::ModelProto modelDef;
   ASSIGN_VALUE_OR_RETURN_ERR(modelDef,
-                             loader.loadProto(onnxModel, onnxModelSize));
+                             loader->loadProto(onnxModel, onnxModelSize));
 
-  RETURN_IF_ERR(loader.setVersion(modelDef));
+  RETURN_IF_ERR(loader->setVersion(modelDef));
 
-  RETURN_IF_ERR(loader.loadWeights(weightsCount, weightDescriptors));
+  RETURN_IF_ERR(loader->loadWeights(weightsCount, weightDescriptors));
 
   ONNX_NAMESPACE::GraphProto graphDef = modelDef.graph();
 
-  RETURN_IF_ERR(loader.loadInputs(graphDef));
+  RETURN_IF_ERR(loader->loadInputs(graphDef));
 
-  RETURN_IF_ERR(loader.loadNetwork(graphDef));
+  RETURN_IF_ERR(loader->loadNetwork(graphDef));
 
-  RETURN_IF_ERR(loader.setOutputNodes(graphDef));
+  RETURN_IF_ERR(loader->setOutputNodes(graphDef));
 
   return loader;
 }

--- a/lib/Importer/ONNXIFIModelLoader.cpp
+++ b/lib/Importer/ONNXIFIModelLoader.cpp
@@ -32,15 +32,15 @@ static llvm::Error setTensorType(const ONNX_NAMESPACE::TypeProto &in,
 
   if (in.tensor_type().elem_type() == ONNX_NAMESPACE::TensorProto::FLOAT) {
     T->reset(ElemKind::FloatTy, dim);
-    RETURN_SUCCESS();
+    return llvm::Error::success();
   } else if (in.tensor_type().elem_type() ==
              ONNX_NAMESPACE::TensorProto::INT64) {
     T->reset(ElemKind::Int64ITy, dim);
-    RETURN_SUCCESS();
+    return llvm::Error::success();
   } else if (in.tensor_type().elem_type() ==
              ONNX_NAMESPACE::TensorProto::INT32) {
     T->reset(ElemKind::Int32ITy, dim);
-    RETURN_SUCCESS();
+    return llvm::Error::success();
   } else {
     RETURN_ERR("Only float and index tensors are supported");
   }
@@ -61,7 +61,7 @@ llvm::Error ONNXIFIModelLoader::loadInputs(ONNX_NAMESPACE::GraphProto &net) {
       return varOrErr.takeError();
     }
   }
-  RETURN_SUCCESS();
+  return llvm::Error::success();
 }
 
 /// Loads tensor \p T from the input \p in.
@@ -110,7 +110,7 @@ static llvm::Error loadWeight(const onnxTensorDescriptorV1 &in, Tensor *T) {
     RETURN_ERR("Only float and index tensors are supported.");
   }
 
-  RETURN_SUCCESS();
+  return llvm::Error::success();
 }
 
 llvm::Error ONNXIFIModelLoader::loadWeights(
@@ -126,7 +126,7 @@ llvm::Error ONNXIFIModelLoader::loadWeights(
     tensors_[weightDescriptors[i].name] = T;
   }
 
-  RETURN_SUCCESS();
+  return llvm::Error::success();
 }
 
 llvm::Expected<std::unique_ptr<ONNXIFIModelLoader>> ONNXIFIModelLoader::parse(

--- a/lib/Importer/ONNXIFIModelLoader.cpp
+++ b/lib/Importer/ONNXIFIModelLoader.cpp
@@ -56,7 +56,8 @@ llvm::Error ONNXIFIModelLoader::loadInputs(ONNX_NAMESPACE::GraphProto &net) {
     Tensor T;
     RETURN_IF_ERR(setTensorType(in.type(), &T));
     if (auto varOrErr = createAndRegisterPlaceholder(in.name(), &T.getType())) {
-      onnxNameToInputVars_.try_emplace(in.name(), UNWRAP(std::move(varOrErr)));
+      onnxNameToInputVars_.try_emplace(in.name(),
+                                       EXIT_ON_ERR(std::move(varOrErr)));
     } else {
       return varOrErr.takeError();
     }
@@ -158,7 +159,7 @@ ONNXIFIModelLoader::parseOperators(const void *onnxModel,
                                    size_t onnxModelSize) {
   std::vector<std::pair<Kinded::Kind, ElemKind>> result;
   ONNX_NAMESPACE::ModelProto modelDef =
-      TEMP_UNWRAP(ONNXModelLoader::loadProto(onnxModel, onnxModelSize));
+      TEMP_EXIT_ON_ERR(ONNXModelLoader::loadProto(onnxModel, onnxModelSize));
 
   ONNX_NAMESPACE::GraphProto graph = modelDef.graph();
 

--- a/lib/Importer/ONNXIFIModelLoader.cpp
+++ b/lib/Importer/ONNXIFIModelLoader.cpp
@@ -151,7 +151,7 @@ llvm::Expected<std::unique_ptr<ONNXIFIModelLoader>> ONNXIFIModelLoader::parse(
 
   RETURN_IF_ERR(loader->setOutputNodes(graphDef));
 
-  return loader;
+  return llvm::Expected<std::unique_ptr<ONNXIFIModelLoader>>(std::move(loader));
 }
 
 std::vector<std::pair<Kinded::Kind, ElemKind>>

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -764,15 +764,15 @@ ONNXModelLoader::ONNXModelLoader(const std::string &modelDescFilename,
     : CommonOperatorLoader(tensorNames, types, F) {
   // The ONNX model that we are deserializing.
   ONNX_NAMESPACE::ModelProto modelDef =
-      TEMP_UNWRAP(loadProto(modelDescFilename));
+      TEMP_EXIT_ON_ERR(loadProto(modelDescFilename));
 
-  TEMP_UNWRAP(setVersion(modelDef));
+  TEMP_EXIT_ON_ERR(setVersion(modelDef));
 
   ONNX_NAMESPACE::GraphProto graphDef = modelDef.graph();
-  TEMP_UNWRAP(checkInputs(graphDef, tensorNames, types));
+  TEMP_EXIT_ON_ERR(checkInputs(graphDef, tensorNames, types));
 
-  TEMP_UNWRAP(loadInitializers(graphDef));
-  TEMP_UNWRAP(loadNetwork(graphDef));
+  TEMP_EXIT_ON_ERR(loadInitializers(graphDef));
+  TEMP_EXIT_ON_ERR(loadNetwork(graphDef));
 
-  TEMP_UNWRAP(setOutputNodes(graphDef));
+  TEMP_EXIT_ON_ERR(setOutputNodes(graphDef));
 }

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -427,8 +427,8 @@ llvm::Error ONNXModelLoader::loadOperator(const ONNX_NAMESPACE::NodeProto &op) {
 
     // Calculate the size and allocate the output buffer.
     ShapeNHWC idim = ShapeNHWC(tr->getResult().dims());
-    auto outSz = calculateConvPoolOutputDims(idim.h, idim.w, kernelShape,
-                                             strides, pads);
+    auto outSz =
+        calculateConvPoolOutputDims(idim.h, idim.w, kernelShape, strides, pads);
     std::array<size_t, 4> outDims = {
         {idim.n, outSz.first, outSz.second, depth}};
     auto outTy = G_.getParent()->uniqueType(ElemKind::FloatTy, outDims);

--- a/lib/Importer/ProtobufLoader.cpp
+++ b/lib/Importer/ProtobufLoader.cpp
@@ -110,7 +110,7 @@ ProtobufLoader::ProtobufLoader(llvm::ArrayRef<const char *> tensorNames,
   assert(tensorNames.size() == types.size() && "Invalid initialization list");
   for (unsigned i = 0; i < tensorNames.size(); i++) {
     assert(!hasNodeByName(tensorNames[i]) && "Input names have duplicate");
-    TEMP_UNWRAP(createAndRegisterPlaceholder(tensorNames[i], types[i]));
+    TEMP_EXIT_ON_ERR(createAndRegisterPlaceholder(tensorNames[i], types[i]));
   }
 }
 

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -54,11 +54,12 @@ onnxStatus Graph::initGraph(const void *onnxModel, size_t onnxModelSize,
   function_ = backendPtr_->getEE().getModule().createFunction("inference");
 
   // TODO: make better error reporting.
-  ONNXIFIModelLoader loader = TEMP_UNWRAP(ONNXIFIModelLoader::parse(
-      onnxModel, onnxModelSize, weightCount, weightDescriptors, *function_));
+  std::unique_ptr<ONNXIFIModelLoader> loader = TEMP_UNWRAP(
+      ONNXIFIModelLoader::parse(onnxModel, onnxModelSize, weightCount,
+                                weightDescriptors, *function_));
 
-  onnxInputToPlaceholder_ = loader.getInputVarsMapping();
-  onnxOutputToPlaceholder_ = loader.getOutputVarsMapping();
+  onnxInputToPlaceholder_ = loader->getInputVarsMapping();
+  onnxOutputToPlaceholder_ = loader->getOutputVarsMapping();
 
   // Emit IR for the graph and compile it.
   backendPtr_->getEE().compile(CompilationMode::Infer, function_);

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -53,15 +53,12 @@ onnxStatus Graph::initGraph(const void *onnxModel, size_t onnxModelSize,
   // TODO: support multiple functions here.
   function_ = backendPtr_->getEE().getModule().createFunction("inference");
 
-  std::unique_ptr<ONNXIFIModelLoader> loader = ONNXIFIModelLoader::parse(
-      onnxModel, onnxModelSize, weightCount, weightDescriptors, *function_);
   // TODO: make better error reporting.
-  if (!loader) {
-    return ONNXIFI_STATUS_INTERNAL_ERROR;
-  }
+  ONNXIFIModelLoader loader = TEMP_UNWRAP(ONNXIFIModelLoader::parse(
+      onnxModel, onnxModelSize, weightCount, weightDescriptors, *function_));
 
-  onnxInputToPlaceholder_ = loader->getInputVarsMapping();
-  onnxOutputToPlaceholder_ = loader->getOutputVarsMapping();
+  onnxInputToPlaceholder_ = loader.getInputVarsMapping();
+  onnxOutputToPlaceholder_ = loader.getOutputVarsMapping();
 
   // Emit IR for the graph and compile it.
   backendPtr_->getEE().compile(CompilationMode::Infer, function_);

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -54,7 +54,7 @@ onnxStatus Graph::initGraph(const void *onnxModel, size_t onnxModelSize,
   function_ = backendPtr_->getEE().getModule().createFunction("inference");
 
   // TODO: make better error reporting.
-  std::unique_ptr<ONNXIFIModelLoader> loader = TEMP_UNWRAP(
+  std::unique_ptr<ONNXIFIModelLoader> loader = TEMP_EXIT_ON_ERR(
       ONNXIFIModelLoader::parse(onnxModel, onnxModelSize, weightCount,
                                 weightDescriptors, *function_));
 

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(Support
               Debug.cpp
+              Error.cpp
               Random.cpp
               Support.cpp)
 target_link_libraries(Support

--- a/lib/Support/Error.cpp
+++ b/lib/Support/Error.cpp
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/Support/Error.h"
+#include "llvm/Support/FormatVariadic.h"
+
+namespace glow {
+namespace detail {
+llvm::ExitOnError exitOnErr("Encountered an error, exiting.\n");
+
+std::string addFileAndLineToError(llvm::StringRef str, llvm::StringRef file,
+                                  uint32_t line) {
+  return llvm::formatv("Error at file {0} line {1} \"{2}\"", file, line, str);
+}
+} // namespace detail
+
+} // namespace glow

--- a/lib/Support/Error.cpp
+++ b/lib/Support/Error.cpp
@@ -18,13 +18,11 @@
 #include "llvm/Support/FormatVariadic.h"
 
 namespace glow {
-namespace detail {
 llvm::ExitOnError exitOnErr("Encountered an error, exiting.\n");
 
 std::string addFileAndLineToError(llvm::StringRef str, llvm::StringRef file,
                                   uint32_t line) {
   return llvm::formatv("Error at file {0} line {1} \"{2}\"", file, line, str);
 }
-} // namespace detail
 
 } // namespace glow

--- a/tests/unittests/caffe2ImporterTest.cpp
+++ b/tests/unittests/caffe2ImporterTest.cpp
@@ -42,7 +42,7 @@ TEST(caffe2, importConv) {
     getNCHWData(&data, 1, 1, 3, 3);
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"data"},
                                {&data.getType()}, *F);
-    output = caffe2LD.getSingleOutput();
+    output = UNWRAP(caffe2LD.getSingleOutput());
 
     ctx.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(ctx, &mod, {"data"}, {&data});
@@ -84,7 +84,7 @@ TEST(caffe2, convNHWC) {
   {
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"inputs"},
                                {&inputs.getType()}, *F);
-    output = caffe2LD.getSingleOutput();
+    output = UNWRAP(caffe2LD.getSingleOutput());
   }
 
   // High level check on the content of the graph. We have 1 conv and 1 save.
@@ -121,7 +121,7 @@ TEST(caffe2, maxPoolNHWC) {
   {
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"inputs"},
                                {&inputs.getType()}, *F);
-    output = caffe2LD.getSingleOutput();
+    output = UNWRAP(caffe2LD.getSingleOutput());
   }
 
   // High level check on the content of the graph. We have 1 maxpool and 1 save.
@@ -158,7 +158,7 @@ TEST(caffe2, maxPool) {
   {
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"inputs"},
                                {&inputs.getType()}, *F);
-    output = caffe2LD.getSingleOutput();
+    output = UNWRAP(caffe2LD.getSingleOutput());
   }
 
   // High level check on the content of the graph. We have 1 maxpool, 1 save
@@ -202,7 +202,7 @@ TEST(caffe2, avgPoolNHWC) {
   {
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"inputs"},
                                {&inputs.getType()}, *F);
-    output = caffe2LD.getSingleOutput();
+    output = UNWRAP(caffe2LD.getSingleOutput());
   }
 
   // High level check on the content of the graph. We have 1 maxpool and 1 save.
@@ -239,7 +239,7 @@ TEST(caffe2, avgPool) {
   {
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"inputs"},
                                {&inputs.getType()}, *F);
-    output = caffe2LD.getSingleOutput();
+    output = UNWRAP(caffe2LD.getSingleOutput());
   }
 
   // High level check on the content of the graph. We have 1 maxpool, 1 save
@@ -298,7 +298,7 @@ TEST(caffe2, concatAddAxis) {
         NetDescFilename, NetWeightFilename,
         {"inputs_0", "inputs_1", "inputs_2"},
         {&inputs_0.getType(), &inputs_1.getType(), &inputs_2.getType()}, *F);
-    output = caffe2LD.getSingleOutput();
+    output = UNWRAP(caffe2LD.getSingleOutput());
 
     ctx.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(ctx, &mod,
@@ -374,7 +374,7 @@ TEST(caffe2, concat) {
         NetDescFilename, NetWeightFilename,
         {"inputs_0", "inputs_1", "inputs_2"},
         {&inputs_0.getType(), &inputs_1.getType(), &inputs_2.getType()}, *F);
-    output = caffe2LD.getSingleOutput();
+    output = UNWRAP(caffe2LD.getSingleOutput());
 
     ctx.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(ctx, &mod,
@@ -447,7 +447,7 @@ TEST(caffe2, batchedMatmulRHS) {
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename,
                                {"inputs_0", "inputs_1"},
                                {&inputs_0.getType(), &inputs_1.getType()}, *F);
-    output = caffe2LD.getSingleOutput();
+    output = UNWRAP(caffe2LD.getSingleOutput());
   }
 
   // Check that the shape of the output matches what Caffe2 expects.
@@ -507,7 +507,7 @@ TEST(caffe2, parallelBatchedMatmulRHS) {
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename,
                                {"inputs_0", "inputs_1"},
                                {&inputs_0.getType(), &inputs_1.getType()}, *F);
-    output = caffe2LD.getSingleOutput();
+    output = UNWRAP(caffe2LD.getSingleOutput());
   }
 
   // Check that the shape of the output matches what Caffe2 expects.
@@ -587,7 +587,7 @@ TEST(caffe2, FC) {
     // bias : {0.1f, 0.2f, 0.3f, 0.4f};
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"inputs"},
                                {&inputs.getType()}, *F);
-    output = caffe2LD.getSingleOutput();
+    output = UNWRAP(caffe2LD.getSingleOutput());
     ctx.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(ctx, &mod, {"inputs"}, {&inputs});
   }
@@ -626,7 +626,7 @@ TEST(caffe2, FCWithFlatten) {
     // bias : {0.1f, 0.2f, 0.3f, 0.4f};
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"inputs"},
                                {&inputs.getType()}, *F);
-    output = caffe2LD.getSingleOutput();
+    output = UNWRAP(caffe2LD.getSingleOutput());
     ctx.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(ctx, &mod, {"inputs"}, {&inputs});
   }
@@ -678,7 +678,7 @@ TEST(caffe2, FCTransposed) {
     // bias : {0.1f, 0.2f, 0.3f, 0.4f};
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"inputs"},
                                {&inputs.getType()}, *F);
-    output = caffe2LD.getSingleOutput();
+    output = UNWRAP(caffe2LD.getSingleOutput());
     ctx.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(ctx, &mod, {"inputs"}, {&inputs});
   }
@@ -725,7 +725,7 @@ TEST(caffe2, FCTransposedWithFlatten) {
     // bias : {0.1f, 0.2f, 0.3f, 0.4f};
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"inputs"},
                                {&inputs.getType()}, *F);
-    output = caffe2LD.getSingleOutput();
+    output = UNWRAP(caffe2LD.getSingleOutput());
     ctx.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(ctx, &mod, {"inputs"}, {&inputs});
   }
@@ -775,7 +775,7 @@ TEST(caffe2, importClip) {
   {
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"inputs_0"},
                                {&inputs_0.getType()}, *F);
-    output = caffe2LD.getSingleOutput();
+    output = UNWRAP(caffe2LD.getSingleOutput());
     ctx.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(ctx, &mod, {"inputs_0"}, {&inputs_0});
   }
@@ -822,7 +822,7 @@ TEST(caffe2, importClipDefault) {
   {
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"inputs_0"},
                                {&inputs_0.getType()}, *F);
-    output = caffe2LD.getSingleOutput();
+    output = UNWRAP(caffe2LD.getSingleOutput());
     ctx.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(ctx, &mod, {"inputs_0"}, {&inputs_0});
   }
@@ -868,7 +868,7 @@ TEST(caffe2, replaceNaN) {
   {
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"input"},
                                {&input.getType()}, *F);
-    output = caffe2LD.getSingleOutput();
+    output = UNWRAP(caffe2LD.getSingleOutput());
     ctx.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(ctx, &mod, {"input"}, {&input});
   }
@@ -940,7 +940,7 @@ TEST(caffe2, dotProduct1D) {
   {
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"X", "Y"},
                                {&X.getType(), &Y.getType()}, *F);
-    output = caffe2LD.getSingleOutput();
+    output = UNWRAP(caffe2LD.getSingleOutput());
     ctx.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(ctx, &mod, {"X", "Y"}, {&X, &Y});
   }
@@ -1020,7 +1020,7 @@ TEST(caffe2, dotProduct2D) {
   {
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"X", "Y"},
                                {&X.getType(), &Y.getType()}, *F);
-    output = caffe2LD.getSingleOutput();
+    output = UNWRAP(caffe2LD.getSingleOutput());
     ctx.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(ctx, &mod, {"X", "Y"}, {&X, &Y});
   }
@@ -1119,7 +1119,7 @@ TEST(caffe2, batchBoxCox) {
     Caffe2ModelLoader caffe2LD(
         NetDescFilename, NetWeightFilename, {"data", "lambda1", "lambda2"},
         {&data.getType(), &lambda1.getType(), &lambda2.getType()}, *F);
-    output = caffe2LD.getSingleOutput();
+    output = UNWRAP(caffe2LD.getSingleOutput());
     ctx.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(ctx, &mod, {"data", "lambda1", "lambda2"},
                                   {&data, &lambda1, &lambda2});
@@ -1239,7 +1239,7 @@ TEST(caffe2, EQ1D) {
   {
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"X", "Y"},
                                {&X.getType(), &Y.getType()}, *F);
-    output = caffe2LD.getSingleOutput();
+    output = UNWRAP(caffe2LD.getSingleOutput());
   }
 
   // High level checks on the content of the graph.
@@ -1272,7 +1272,7 @@ TEST(caffe2, LengthsToRanges) {
   // Destroy the loader after the graph is loaded
   {
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {}, {}, *F);
-    output = caffe2LD.getSingleOutput();
+    output = UNWRAP(caffe2LD.getSingleOutput());
   }
 
   // High level checks on the content of the graph.
@@ -1309,7 +1309,7 @@ TEST(caffe2, Logit) {
   {
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"inputs_0"},
                                {&X.getType()}, *F);
-    output = caffe2LD.getSingleOutput();
+    output = UNWRAP(caffe2LD.getSingleOutput());
   }
 
   // Check that the shape of the output matches what Caffe2 expects.
@@ -1355,7 +1355,7 @@ TEST(caffe2, sparseToDense) {
         NetDescFilename, NetWeightFilename,
         {"indices", "values", "dataToInferDim"},
         {&indices.getType(), &values.getType(), &dataToInferDim.getType()}, *F);
-    output = caffe2LD.getSingleOutput();
+    output = UNWRAP(caffe2LD.getSingleOutput());
     ctx.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(ctx, &mod, {"indices", "values"},
                                   {&indices, &values});
@@ -1399,7 +1399,7 @@ TEST(caffe2, testNCHW2NHWC) {
   {
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"inputs"},
                                {&inputs.getType()}, *F);
-    output = caffe2LD.getSingleOutput();
+    output = UNWRAP(caffe2LD.getSingleOutput());
     ctx.allocate(mod.getPlaceholders());
   }
 
@@ -1445,7 +1445,7 @@ TEST(caffe2, lengthsSum) {
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename,
                                {"data", "lengths"},
                                {&data.getType(), &lengths.getType()}, *F);
-    output = caffe2LD.getSingleOutput();
+    output = UNWRAP(caffe2LD.getSingleOutput());
   }
 
   // Check that the shape of the output matches that of the expected output.

--- a/tests/unittests/caffe2ImporterTest.cpp
+++ b/tests/unittests/caffe2ImporterTest.cpp
@@ -1488,14 +1488,14 @@ TEST(caffe2, tensorFillsTest) {
     Type unusedTy = Type(ElemKind::FloatTy, {1});
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename,
                                {"unused_output"}, {&unusedTy}, *F);
-    tensorFillFloat = llvm::dyn_cast<Constant>(
-        caffe2LD.getNodeValueOrCreateConstantByName("tensor_fill_float"));
+    tensorFillFloat = llvm::dyn_cast<Constant>(UNWRAP(
+        caffe2LD.getNodeValueOrCreateConstantByName("tensor_fill_float")));
     tensorFillInt = llvm::dyn_cast<Constant>(
-        caffe2LD.getNodeValueOrCreateConstantByName("tensor_fill_int"));
+        UNWRAP(caffe2LD.getNodeValueOrCreateConstantByName("tensor_fill_int")));
     tensorIntFill = llvm::dyn_cast<Constant>(
-        caffe2LD.getNodeValueOrCreateConstantByName("tensor_int_fill"));
-    tensorInt64Fill = llvm::dyn_cast<Constant>(
-        caffe2LD.getNodeValueOrCreateConstantByName("tensor_int64_fill"));
+        UNWRAP(caffe2LD.getNodeValueOrCreateConstantByName("tensor_int_fill")));
+    tensorInt64Fill = llvm::dyn_cast<Constant>(UNWRAP(
+        caffe2LD.getNodeValueOrCreateConstantByName("tensor_int64_fill")));
   }
 
   ASSERT_TRUE(tensorFillFloat);

--- a/tests/unittests/caffe2ImporterTest.cpp
+++ b/tests/unittests/caffe2ImporterTest.cpp
@@ -42,7 +42,7 @@ TEST(caffe2, importConv) {
     getNCHWData(&data, 1, 1, 3, 3);
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"data"},
                                {&data.getType()}, *F);
-    output = UNWRAP(caffe2LD.getSingleOutput());
+    output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
 
     ctx.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(ctx, &mod, {"data"}, {&data});
@@ -84,7 +84,7 @@ TEST(caffe2, convNHWC) {
   {
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"inputs"},
                                {&inputs.getType()}, *F);
-    output = UNWRAP(caffe2LD.getSingleOutput());
+    output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
   }
 
   // High level check on the content of the graph. We have 1 conv and 1 save.
@@ -121,7 +121,7 @@ TEST(caffe2, maxPoolNHWC) {
   {
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"inputs"},
                                {&inputs.getType()}, *F);
-    output = UNWRAP(caffe2LD.getSingleOutput());
+    output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
   }
 
   // High level check on the content of the graph. We have 1 maxpool and 1 save.
@@ -158,7 +158,7 @@ TEST(caffe2, maxPool) {
   {
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"inputs"},
                                {&inputs.getType()}, *F);
-    output = UNWRAP(caffe2LD.getSingleOutput());
+    output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
   }
 
   // High level check on the content of the graph. We have 1 maxpool, 1 save
@@ -202,7 +202,7 @@ TEST(caffe2, avgPoolNHWC) {
   {
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"inputs"},
                                {&inputs.getType()}, *F);
-    output = UNWRAP(caffe2LD.getSingleOutput());
+    output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
   }
 
   // High level check on the content of the graph. We have 1 maxpool and 1 save.
@@ -239,7 +239,7 @@ TEST(caffe2, avgPool) {
   {
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"inputs"},
                                {&inputs.getType()}, *F);
-    output = UNWRAP(caffe2LD.getSingleOutput());
+    output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
   }
 
   // High level check on the content of the graph. We have 1 maxpool, 1 save
@@ -298,7 +298,7 @@ TEST(caffe2, concatAddAxis) {
         NetDescFilename, NetWeightFilename,
         {"inputs_0", "inputs_1", "inputs_2"},
         {&inputs_0.getType(), &inputs_1.getType(), &inputs_2.getType()}, *F);
-    output = UNWRAP(caffe2LD.getSingleOutput());
+    output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
 
     ctx.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(ctx, &mod,
@@ -374,7 +374,7 @@ TEST(caffe2, concat) {
         NetDescFilename, NetWeightFilename,
         {"inputs_0", "inputs_1", "inputs_2"},
         {&inputs_0.getType(), &inputs_1.getType(), &inputs_2.getType()}, *F);
-    output = UNWRAP(caffe2LD.getSingleOutput());
+    output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
 
     ctx.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(ctx, &mod,
@@ -447,7 +447,7 @@ TEST(caffe2, batchedMatmulRHS) {
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename,
                                {"inputs_0", "inputs_1"},
                                {&inputs_0.getType(), &inputs_1.getType()}, *F);
-    output = UNWRAP(caffe2LD.getSingleOutput());
+    output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
   }
 
   // Check that the shape of the output matches what Caffe2 expects.
@@ -507,7 +507,7 @@ TEST(caffe2, parallelBatchedMatmulRHS) {
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename,
                                {"inputs_0", "inputs_1"},
                                {&inputs_0.getType(), &inputs_1.getType()}, *F);
-    output = UNWRAP(caffe2LD.getSingleOutput());
+    output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
   }
 
   // Check that the shape of the output matches what Caffe2 expects.
@@ -587,7 +587,7 @@ TEST(caffe2, FC) {
     // bias : {0.1f, 0.2f, 0.3f, 0.4f};
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"inputs"},
                                {&inputs.getType()}, *F);
-    output = UNWRAP(caffe2LD.getSingleOutput());
+    output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
     ctx.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(ctx, &mod, {"inputs"}, {&inputs});
   }
@@ -626,7 +626,7 @@ TEST(caffe2, FCWithFlatten) {
     // bias : {0.1f, 0.2f, 0.3f, 0.4f};
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"inputs"},
                                {&inputs.getType()}, *F);
-    output = UNWRAP(caffe2LD.getSingleOutput());
+    output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
     ctx.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(ctx, &mod, {"inputs"}, {&inputs});
   }
@@ -678,7 +678,7 @@ TEST(caffe2, FCTransposed) {
     // bias : {0.1f, 0.2f, 0.3f, 0.4f};
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"inputs"},
                                {&inputs.getType()}, *F);
-    output = UNWRAP(caffe2LD.getSingleOutput());
+    output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
     ctx.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(ctx, &mod, {"inputs"}, {&inputs});
   }
@@ -725,7 +725,7 @@ TEST(caffe2, FCTransposedWithFlatten) {
     // bias : {0.1f, 0.2f, 0.3f, 0.4f};
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"inputs"},
                                {&inputs.getType()}, *F);
-    output = UNWRAP(caffe2LD.getSingleOutput());
+    output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
     ctx.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(ctx, &mod, {"inputs"}, {&inputs});
   }
@@ -775,7 +775,7 @@ TEST(caffe2, importClip) {
   {
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"inputs_0"},
                                {&inputs_0.getType()}, *F);
-    output = UNWRAP(caffe2LD.getSingleOutput());
+    output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
     ctx.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(ctx, &mod, {"inputs_0"}, {&inputs_0});
   }
@@ -822,7 +822,7 @@ TEST(caffe2, importClipDefault) {
   {
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"inputs_0"},
                                {&inputs_0.getType()}, *F);
-    output = UNWRAP(caffe2LD.getSingleOutput());
+    output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
     ctx.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(ctx, &mod, {"inputs_0"}, {&inputs_0});
   }
@@ -868,7 +868,7 @@ TEST(caffe2, replaceNaN) {
   {
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"input"},
                                {&input.getType()}, *F);
-    output = UNWRAP(caffe2LD.getSingleOutput());
+    output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
     ctx.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(ctx, &mod, {"input"}, {&input});
   }
@@ -940,7 +940,7 @@ TEST(caffe2, dotProduct1D) {
   {
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"X", "Y"},
                                {&X.getType(), &Y.getType()}, *F);
-    output = UNWRAP(caffe2LD.getSingleOutput());
+    output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
     ctx.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(ctx, &mod, {"X", "Y"}, {&X, &Y});
   }
@@ -1020,7 +1020,7 @@ TEST(caffe2, dotProduct2D) {
   {
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"X", "Y"},
                                {&X.getType(), &Y.getType()}, *F);
-    output = UNWRAP(caffe2LD.getSingleOutput());
+    output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
     ctx.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(ctx, &mod, {"X", "Y"}, {&X, &Y});
   }
@@ -1119,7 +1119,7 @@ TEST(caffe2, batchBoxCox) {
     Caffe2ModelLoader caffe2LD(
         NetDescFilename, NetWeightFilename, {"data", "lambda1", "lambda2"},
         {&data.getType(), &lambda1.getType(), &lambda2.getType()}, *F);
-    output = UNWRAP(caffe2LD.getSingleOutput());
+    output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
     ctx.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(ctx, &mod, {"data", "lambda1", "lambda2"},
                                   {&data, &lambda1, &lambda2});
@@ -1239,7 +1239,7 @@ TEST(caffe2, EQ1D) {
   {
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"X", "Y"},
                                {&X.getType(), &Y.getType()}, *F);
-    output = UNWRAP(caffe2LD.getSingleOutput());
+    output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
   }
 
   // High level checks on the content of the graph.
@@ -1272,7 +1272,7 @@ TEST(caffe2, LengthsToRanges) {
   // Destroy the loader after the graph is loaded
   {
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {}, {}, *F);
-    output = UNWRAP(caffe2LD.getSingleOutput());
+    output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
   }
 
   // High level checks on the content of the graph.
@@ -1309,7 +1309,7 @@ TEST(caffe2, Logit) {
   {
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"inputs_0"},
                                {&X.getType()}, *F);
-    output = UNWRAP(caffe2LD.getSingleOutput());
+    output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
   }
 
   // Check that the shape of the output matches what Caffe2 expects.
@@ -1355,7 +1355,7 @@ TEST(caffe2, sparseToDense) {
         NetDescFilename, NetWeightFilename,
         {"indices", "values", "dataToInferDim"},
         {&indices.getType(), &values.getType(), &dataToInferDim.getType()}, *F);
-    output = UNWRAP(caffe2LD.getSingleOutput());
+    output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
     ctx.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(ctx, &mod, {"indices", "values"},
                                   {&indices, &values});
@@ -1399,7 +1399,7 @@ TEST(caffe2, testNCHW2NHWC) {
   {
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"inputs"},
                                {&inputs.getType()}, *F);
-    output = UNWRAP(caffe2LD.getSingleOutput());
+    output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
     ctx.allocate(mod.getPlaceholders());
   }
 
@@ -1445,7 +1445,7 @@ TEST(caffe2, lengthsSum) {
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename,
                                {"data", "lengths"},
                                {&data.getType(), &lengths.getType()}, *F);
-    output = UNWRAP(caffe2LD.getSingleOutput());
+    output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
   }
 
   // Check that the shape of the output matches that of the expected output.
@@ -1488,13 +1488,13 @@ TEST(caffe2, tensorFillsTest) {
     Type unusedTy = Type(ElemKind::FloatTy, {1});
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename,
                                {"unused_output"}, {&unusedTy}, *F);
-    tensorFillFloat = llvm::dyn_cast<Constant>(UNWRAP(
+    tensorFillFloat = llvm::dyn_cast<Constant>(EXIT_ON_ERR(
         caffe2LD.getNodeValueOrCreateConstantByName("tensor_fill_float")));
-    tensorFillInt = llvm::dyn_cast<Constant>(
-        UNWRAP(caffe2LD.getNodeValueOrCreateConstantByName("tensor_fill_int")));
-    tensorIntFill = llvm::dyn_cast<Constant>(
-        UNWRAP(caffe2LD.getNodeValueOrCreateConstantByName("tensor_int_fill")));
-    tensorInt64Fill = llvm::dyn_cast<Constant>(UNWRAP(
+    tensorFillInt = llvm::dyn_cast<Constant>(EXIT_ON_ERR(
+        caffe2LD.getNodeValueOrCreateConstantByName("tensor_fill_int")));
+    tensorIntFill = llvm::dyn_cast<Constant>(EXIT_ON_ERR(
+        caffe2LD.getNodeValueOrCreateConstantByName("tensor_int_fill")));
+    tensorInt64Fill = llvm::dyn_cast<Constant>(EXIT_ON_ERR(
         caffe2LD.getNodeValueOrCreateConstantByName("tensor_int64_fill")));
   }
 

--- a/tests/unittests/onnxImporterTest.cpp
+++ b/tests/unittests/onnxImporterTest.cpp
@@ -40,7 +40,7 @@ TEST(onnx, importConv) {
     Tensor data;
     getNCHWData(&data, 1, 1, 3, 3);
     ONNXModelLoader onnxLD(NetFilename, {"data"}, {&data.getType()}, *F);
-    graphOutputVar = onnxLD.getSingleOutput();
+    graphOutputVar = UNWRAP(onnxLD.getSingleOutput());
     ctx.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(ctx, &mod, {"data"}, {&data});
   }
@@ -113,7 +113,7 @@ TEST(onnx, importClip) {
     Tensor x(ElemKind::FloatTy, {3, 3});
     x.getHandle() = {1, 2, 3, 40, 5, 6, 7, 8, 90};
     ONNXModelLoader onnxLD(netFilename, {"x"}, {&x.getType()}, *F);
-    output = onnxLD.getSingleOutput();
+    output = UNWRAP(onnxLD.getSingleOutput());
     ctx.allocate(mod.getPlaceholders());
 
     updateInputPlaceholdersByName(ctx, &mod, {"x"}, {&x});
@@ -147,7 +147,7 @@ TEST(onnx, importBatchMatMul) {
     Tensor inputs_1(ElemKind::FloatTy, {20, 7, 40});
     ONNXModelLoader onnxLD(netFilename, {"inputs_0", "inputs_1"},
                            {&inputs_0.getType(), &inputs_1.getType()}, *F);
-    output = onnxLD.getSingleOutput();
+    output = UNWRAP(onnxLD.getSingleOutput());
 
     ctx.allocate(mod.getPlaceholders());
   }
@@ -226,7 +226,7 @@ TEST(onnx, importBatchBoxCox) {
     ONNXModelLoader onnxLD(
         netFilename, {"data", "lambda1", "lambda2"},
         {&data.getType(), &lambda1.getType(), &lambda2.getType()}, *F);
-    output = onnxLD.getSingleOutput();
+    output = UNWRAP(onnxLD.getSingleOutput());
     ctx.allocate(mod.getPlaceholders());
 
     updateInputPlaceholdersByName(ctx, &mod, {"data", "lambda1", "lambda2"},
@@ -280,7 +280,7 @@ TEST(onnx, importDotProduct) {
 
     ONNXModelLoader onnxLD(netFilename, {"x", "y"},
                            {&x.getType(), &y.getType()}, *F);
-    output = onnxLD.getSingleOutput();
+    output = UNWRAP(onnxLD.getSingleOutput());
   }
 
   // Just verify the structure.
@@ -313,7 +313,7 @@ TEST(onnx, importSumN) {
 
     ONNXModelLoader onnxLD(netFilename, {"i0", "i1", "i2"},
                            {&i0.getType(), &i1.getType(), &i2.getType()}, *F);
-    output = onnxLD.getSingleOutput();
+    output = UNWRAP(onnxLD.getSingleOutput());
 
     ctx.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(ctx, &mod, {"i0", "i1", "i2"},
@@ -363,7 +363,7 @@ TEST(onnx, importSum1) {
     Tensor x(ElemKind::FloatTy, {3});
     x.getHandle() = {1, 2, 3};
     ONNXModelLoader onnxLD(netFilename, {"x"}, {&x.getType()}, *F);
-    output = onnxLD.getSingleOutput();
+    output = UNWRAP(onnxLD.getSingleOutput());
 
     ctx.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(ctx, &mod, {"x"}, {&x});
@@ -399,7 +399,7 @@ TEST(onnx, importLengthsToRanges) {
   {
     Tensor lengths(ElemKind::Int32ITy, {4});
     ONNXModelLoader onnxLD(netFilename, {"lengths"}, {&lengths.getType()}, *F);
-    output = onnxLD.getSingleOutput();
+    output = UNWRAP(onnxLD.getSingleOutput());
   }
   // Verify structure: PH -> LengthsToRanges -> Save -> PH.
   ASSERT_EQ(mod.getPlaceholders().size(), 2);
@@ -425,7 +425,7 @@ TEST(onnx, importReplaceNaN) {
 
   {
     ONNXModelLoader onnxLD(netFilename, {"x"}, {&x.getType()}, *F);
-    output = onnxLD.getSingleOutput();
+    output = UNWRAP(onnxLD.getSingleOutput());
     ctx.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(ctx, &mod, {"x"}, {&x});
   }
@@ -469,7 +469,7 @@ TEST(onnx, importSparseToDense) {
     ONNXModelLoader onnxLD(
         netFilename, {"indices", "values", "dataToInferDim"},
         {&indices.getType(), &values.getType(), &dataToInferDim.getType()}, *F);
-    output = onnxLD.getSingleOutput();
+    output = UNWRAP(onnxLD.getSingleOutput());
   }
 
   // Verify structure: Inputs -> SparseToDense -> Save.
@@ -502,7 +502,7 @@ TEST(onnx, importSparseLengthsSum) {
     ONNXModelLoader onnxLD(
         netFilename, {"data", "indices", "lengths"},
         {&data.getType(), &indices.getType(), &lengths.getType()}, *F);
-    output = onnxLD.getSingleOutput();
+    output = UNWRAP(onnxLD.getSingleOutput());
   }
   // Verify structure: PH, PH ->  SparseLengthsSum -> Save -> PH.
   //                  PH -> Splat /
@@ -530,7 +530,7 @@ TEST(onnx, importLengthsSum) {
     Tensor lengths(ElemKind::Int32ITy, {5});
     ONNXModelLoader onnxLD(netFilename, {"data", "lengths"},
                            {&data.getType(), &lengths.getType()}, *F);
-    output = onnxLD.getSingleOutput();
+    output = UNWRAP(onnxLD.getSingleOutput());
   }
   // Verify structure: PH, PH -> LengthsSum -> Save -> PH.
   ASSERT_EQ(mod.getPlaceholders().size(), 3);
@@ -556,7 +556,7 @@ TEST(onnx, FCTransposedWithFlatten) {
     Tensor data(ElemKind::FloatTy, {2, 1, 3});
     data.getHandle() = {1, 2, 3, 4, 5, 6};
     ONNXModelLoader onnxLD(netFilename, {"data"}, {&data.getType()}, *F);
-    output = onnxLD.getSingleOutput();
+    output = UNWRAP(onnxLD.getSingleOutput());
   }
 
   // High level check on the content of the graph. We have 1 reshape, 1 FC,
@@ -579,7 +579,7 @@ TEST(onnx, constant) {
   Placeholder *output;
   {
     ONNXModelLoader onnxLD(netFilename, {}, {}, *F);
-    output = onnxLD.getSingleOutput();
+    output = UNWRAP(onnxLD.getSingleOutput());
     EXPECT_NE(output, nullptr);
   }
   // Constant -> Save -> PH
@@ -597,7 +597,7 @@ TEST(onnx, expandDims) {
   {
     Tensor x(ElemKind::FloatTy, {2, 2});
     ONNXModelLoader onnxLD(netFilename, {"x"}, {&x.getType()}, *F);
-    output = onnxLD.getSingleOutput();
+    output = UNWRAP(onnxLD.getSingleOutput());
   }
 
   // Verify structure: PH -> Reshape -> Save -> PH.
@@ -622,7 +622,7 @@ TEST(onnx, gather) {
   {
     ONNXModelLoader onnxLD(netFilename, {"data", "indices"},
                            {&data.getType(), &indices.getType()}, *F);
-    output = onnxLD.getSingleOutput();
+    output = UNWRAP(onnxLD.getSingleOutput());
   }
   EE.compile(CompilationMode::Infer, F);
 

--- a/tests/unittests/onnxImporterTest.cpp
+++ b/tests/unittests/onnxImporterTest.cpp
@@ -40,7 +40,7 @@ TEST(onnx, importConv) {
     Tensor data;
     getNCHWData(&data, 1, 1, 3, 3);
     ONNXModelLoader onnxLD(NetFilename, {"data"}, {&data.getType()}, *F);
-    graphOutputVar = UNWRAP(onnxLD.getSingleOutput());
+    graphOutputVar = EXIT_ON_ERR(onnxLD.getSingleOutput());
     ctx.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(ctx, &mod, {"data"}, {&data});
   }
@@ -113,7 +113,7 @@ TEST(onnx, importClip) {
     Tensor x(ElemKind::FloatTy, {3, 3});
     x.getHandle() = {1, 2, 3, 40, 5, 6, 7, 8, 90};
     ONNXModelLoader onnxLD(netFilename, {"x"}, {&x.getType()}, *F);
-    output = UNWRAP(onnxLD.getSingleOutput());
+    output = EXIT_ON_ERR(onnxLD.getSingleOutput());
     ctx.allocate(mod.getPlaceholders());
 
     updateInputPlaceholdersByName(ctx, &mod, {"x"}, {&x});
@@ -147,7 +147,7 @@ TEST(onnx, importBatchMatMul) {
     Tensor inputs_1(ElemKind::FloatTy, {20, 7, 40});
     ONNXModelLoader onnxLD(netFilename, {"inputs_0", "inputs_1"},
                            {&inputs_0.getType(), &inputs_1.getType()}, *F);
-    output = UNWRAP(onnxLD.getSingleOutput());
+    output = EXIT_ON_ERR(onnxLD.getSingleOutput());
 
     ctx.allocate(mod.getPlaceholders());
   }
@@ -226,7 +226,7 @@ TEST(onnx, importBatchBoxCox) {
     ONNXModelLoader onnxLD(
         netFilename, {"data", "lambda1", "lambda2"},
         {&data.getType(), &lambda1.getType(), &lambda2.getType()}, *F);
-    output = UNWRAP(onnxLD.getSingleOutput());
+    output = EXIT_ON_ERR(onnxLD.getSingleOutput());
     ctx.allocate(mod.getPlaceholders());
 
     updateInputPlaceholdersByName(ctx, &mod, {"data", "lambda1", "lambda2"},
@@ -280,7 +280,7 @@ TEST(onnx, importDotProduct) {
 
     ONNXModelLoader onnxLD(netFilename, {"x", "y"},
                            {&x.getType(), &y.getType()}, *F);
-    output = UNWRAP(onnxLD.getSingleOutput());
+    output = EXIT_ON_ERR(onnxLD.getSingleOutput());
   }
 
   // Just verify the structure.
@@ -313,7 +313,7 @@ TEST(onnx, importSumN) {
 
     ONNXModelLoader onnxLD(netFilename, {"i0", "i1", "i2"},
                            {&i0.getType(), &i1.getType(), &i2.getType()}, *F);
-    output = UNWRAP(onnxLD.getSingleOutput());
+    output = EXIT_ON_ERR(onnxLD.getSingleOutput());
 
     ctx.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(ctx, &mod, {"i0", "i1", "i2"},
@@ -363,7 +363,7 @@ TEST(onnx, importSum1) {
     Tensor x(ElemKind::FloatTy, {3});
     x.getHandle() = {1, 2, 3};
     ONNXModelLoader onnxLD(netFilename, {"x"}, {&x.getType()}, *F);
-    output = UNWRAP(onnxLD.getSingleOutput());
+    output = EXIT_ON_ERR(onnxLD.getSingleOutput());
 
     ctx.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(ctx, &mod, {"x"}, {&x});
@@ -399,7 +399,7 @@ TEST(onnx, importLengthsToRanges) {
   {
     Tensor lengths(ElemKind::Int32ITy, {4});
     ONNXModelLoader onnxLD(netFilename, {"lengths"}, {&lengths.getType()}, *F);
-    output = UNWRAP(onnxLD.getSingleOutput());
+    output = EXIT_ON_ERR(onnxLD.getSingleOutput());
   }
   // Verify structure: PH -> LengthsToRanges -> Save -> PH.
   ASSERT_EQ(mod.getPlaceholders().size(), 2);
@@ -425,7 +425,7 @@ TEST(onnx, importReplaceNaN) {
 
   {
     ONNXModelLoader onnxLD(netFilename, {"x"}, {&x.getType()}, *F);
-    output = UNWRAP(onnxLD.getSingleOutput());
+    output = EXIT_ON_ERR(onnxLD.getSingleOutput());
     ctx.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(ctx, &mod, {"x"}, {&x});
   }
@@ -469,7 +469,7 @@ TEST(onnx, importSparseToDense) {
     ONNXModelLoader onnxLD(
         netFilename, {"indices", "values", "dataToInferDim"},
         {&indices.getType(), &values.getType(), &dataToInferDim.getType()}, *F);
-    output = UNWRAP(onnxLD.getSingleOutput());
+    output = EXIT_ON_ERR(onnxLD.getSingleOutput());
   }
 
   // Verify structure: Inputs -> SparseToDense -> Save.
@@ -502,7 +502,7 @@ TEST(onnx, importSparseLengthsSum) {
     ONNXModelLoader onnxLD(
         netFilename, {"data", "indices", "lengths"},
         {&data.getType(), &indices.getType(), &lengths.getType()}, *F);
-    output = UNWRAP(onnxLD.getSingleOutput());
+    output = EXIT_ON_ERR(onnxLD.getSingleOutput());
   }
   // Verify structure: PH, PH ->  SparseLengthsSum -> Save -> PH.
   //                  PH -> Splat /
@@ -530,7 +530,7 @@ TEST(onnx, importLengthsSum) {
     Tensor lengths(ElemKind::Int32ITy, {5});
     ONNXModelLoader onnxLD(netFilename, {"data", "lengths"},
                            {&data.getType(), &lengths.getType()}, *F);
-    output = UNWRAP(onnxLD.getSingleOutput());
+    output = EXIT_ON_ERR(onnxLD.getSingleOutput());
   }
   // Verify structure: PH, PH -> LengthsSum -> Save -> PH.
   ASSERT_EQ(mod.getPlaceholders().size(), 3);
@@ -556,7 +556,7 @@ TEST(onnx, FCTransposedWithFlatten) {
     Tensor data(ElemKind::FloatTy, {2, 1, 3});
     data.getHandle() = {1, 2, 3, 4, 5, 6};
     ONNXModelLoader onnxLD(netFilename, {"data"}, {&data.getType()}, *F);
-    output = UNWRAP(onnxLD.getSingleOutput());
+    output = EXIT_ON_ERR(onnxLD.getSingleOutput());
   }
 
   // High level check on the content of the graph. We have 1 reshape, 1 FC,
@@ -579,7 +579,7 @@ TEST(onnx, constant) {
   Placeholder *output;
   {
     ONNXModelLoader onnxLD(netFilename, {}, {}, *F);
-    output = UNWRAP(onnxLD.getSingleOutput());
+    output = EXIT_ON_ERR(onnxLD.getSingleOutput());
     EXPECT_NE(output, nullptr);
   }
   // Constant -> Save -> PH
@@ -597,7 +597,7 @@ TEST(onnx, expandDims) {
   {
     Tensor x(ElemKind::FloatTy, {2, 2});
     ONNXModelLoader onnxLD(netFilename, {"x"}, {&x.getType()}, *F);
-    output = UNWRAP(onnxLD.getSingleOutput());
+    output = EXIT_ON_ERR(onnxLD.getSingleOutput());
   }
 
   // Verify structure: PH -> Reshape -> Save -> PH.
@@ -622,7 +622,7 @@ TEST(onnx, gather) {
   {
     ONNXModelLoader onnxLD(netFilename, {"data", "indices"},
                            {&data.getType(), &indices.getType()}, *F);
-    output = UNWRAP(onnxLD.getSingleOutput());
+    output = EXIT_ON_ERR(onnxLD.getSingleOutput());
   }
   EE.compile(CompilationMode::Infer, F);
 
@@ -653,7 +653,7 @@ static void importSliceTest(std::string fileName, const char *inputName,
     getNCHWData(&data, inputShape[0], inputShape[1], inputShape[2],
                 inputShape[3]);
     ONNXModelLoader onnxLD(NetFilename, {inputName}, {&data.getType()}, *F);
-    graphOutputVar = UNWRAP(onnxLD.getSingleOutput());
+    graphOutputVar = EXIT_ON_ERR(onnxLD.getSingleOutput());
     ctx.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(ctx, &mod, {inputName}, {&data});
   }

--- a/tests/unittests/onnxImporterTest.cpp
+++ b/tests/unittests/onnxImporterTest.cpp
@@ -653,7 +653,7 @@ static void importSliceTest(std::string fileName, const char *inputName,
     getNCHWData(&data, inputShape[0], inputShape[1], inputShape[2],
                 inputShape[3]);
     ONNXModelLoader onnxLD(NetFilename, {inputName}, {&data.getType()}, *F);
-    graphOutputVar = onnxLD.getSingleOutput();
+    graphOutputVar = UNWRAP(onnxLD.getSingleOutput());
     ctx.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(ctx, &mod, {inputName}, {&data});
   }

--- a/tools/loader/ImageClassifier.cpp
+++ b/tools/loader/ImageClassifier.cpp
@@ -185,11 +185,11 @@ buildAndCompileAndGetInAndOutPair(Loader &loader, Context &ctx,
   // The image name that the model expects must be passed on the command line.
   const char *inputName = modelInputName.c_str();
   Placeholder *inputImagePH =
-      llvm::cast<Placeholder>(UNWRAP(LD->getNodeValueByName(inputName)));
+      llvm::cast<Placeholder>(EXIT_ON_ERR(LD->getNodeValueByName(inputName)));
 
   // Get the Tensor from the Placeholder that the final expected Softmax writes
   // into at the end of image inference.
-  Placeholder *SMPH = UNWRAP(LD->getSingleOutput());
+  Placeholder *SMPH = EXIT_ON_ERR(LD->getSingleOutput());
   Tensor *SMT = ctx.get(SMPH);
 
   return std::make_pair(inputImagePH, SMT);

--- a/tools/loader/ImageClassifier.cpp
+++ b/tools/loader/ImageClassifier.cpp
@@ -185,11 +185,11 @@ buildAndCompileAndGetInAndOutPair(Loader &loader, Context &ctx,
   // The image name that the model expects must be passed on the command line.
   const char *inputName = modelInputName.c_str();
   Placeholder *inputImagePH =
-      llvm::cast<Placeholder>(LD->getNodeValueByName(inputName));
+      llvm::cast<Placeholder>(UNWRAP(LD->getNodeValueByName(inputName)));
 
   // Get the Tensor from the Placeholder that the final expected Softmax writes
   // into at the end of image inference.
-  Placeholder *SMPH = LD->getSingleOutput();
+  Placeholder *SMPH = UNWRAP(LD->getSingleOutput());
   Tensor *SMT = ctx.get(SMPH);
 
   return std::make_pair(inputImagePH, SMT);

--- a/tools/loader/ModelRunner.cpp
+++ b/tools/loader/ModelRunner.cpp
@@ -42,7 +42,7 @@ int main(int argc, char **argv) {
     LD.reset(new ONNXModelLoader(loader.getOnnxModelFilename(), {}, {},
                                  *loader.getFunction()));
   }
-  Placeholder *output = LD->getSingleOutput();
+  Placeholder *output = UNWRAP(LD->getSingleOutput());
   auto *outputT = ctx.allocate(output);
 
   // Compile the model, and perform quantization/emit a bundle/dump debug info

--- a/tools/loader/ModelRunner.cpp
+++ b/tools/loader/ModelRunner.cpp
@@ -42,7 +42,7 @@ int main(int argc, char **argv) {
     LD.reset(new ONNXModelLoader(loader.getOnnxModelFilename(), {}, {},
                                  *loader.getFunction()));
   }
-  Placeholder *output = UNWRAP(LD->getSingleOutput());
+  Placeholder *output = EXIT_ON_ERR(LD->getSingleOutput());
   auto *outputT = ctx.allocate(output);
 
   // Compile the model, and perform quantization/emit a bundle/dump debug info

--- a/tools/loader/TextTranslator.cpp
+++ b/tools/loader/TextTranslator.cpp
@@ -330,7 +330,7 @@ int main(int argc, char **argv) {
   ctx.allocate(loader.getModule()->getPlaceholders());
 
   Placeholder *encoderInputsVar =
-      llvm::cast<Placeholder>(LD.getNodeValueByName("encoder_inputs"));
+      llvm::cast<Placeholder>(UNWRAP(LD.getNodeValueByName("encoder_inputs")));
 
   // Compile the model, and perform quantization/emit a bundle/dump debug info
   // if requested from command line.
@@ -339,11 +339,11 @@ int main(int argc, char **argv) {
   assert(!emittingBundle() && "Bundle mode has not been tested.");
 
   Placeholder *outputTokenBeamList =
-      LD.getOutputByName("output_token_beam_list");
+      UNWRAP(LD.getOutputByName("output_token_beam_list"));
   Placeholder *outputScoreBeamList =
-      LD.getOutputByName("output_score_beam_list");
+      UNWRAP(LD.getOutputByName("output_score_beam_list"));
   Placeholder *outputPrevIndexBeamList =
-      LD.getOutputByName("output_prev_index_beam_list");
+      UNWRAP(LD.getOutputByName("output_prev_index_beam_list"));
 
   while (loadNextInputTranslationText(&encoderInputs)) {
     // Update the inputs.

--- a/tools/loader/TextTranslator.cpp
+++ b/tools/loader/TextTranslator.cpp
@@ -329,8 +329,8 @@ int main(int argc, char **argv) {
   // Allocate tensors to back all inputs and outputs.
   ctx.allocate(loader.getModule()->getPlaceholders());
 
-  Placeholder *encoderInputsVar =
-      llvm::cast<Placeholder>(UNWRAP(LD.getNodeValueByName("encoder_inputs")));
+  Placeholder *encoderInputsVar = llvm::cast<Placeholder>(
+      EXIT_ON_ERR(LD.getNodeValueByName("encoder_inputs")));
 
   // Compile the model, and perform quantization/emit a bundle/dump debug info
   // if requested from command line.
@@ -339,11 +339,11 @@ int main(int argc, char **argv) {
   assert(!emittingBundle() && "Bundle mode has not been tested.");
 
   Placeholder *outputTokenBeamList =
-      UNWRAP(LD.getOutputByName("output_token_beam_list"));
+      EXIT_ON_ERR(LD.getOutputByName("output_token_beam_list"));
   Placeholder *outputScoreBeamList =
-      UNWRAP(LD.getOutputByName("output_score_beam_list"));
+      EXIT_ON_ERR(LD.getOutputByName("output_score_beam_list"));
   Placeholder *outputPrevIndexBeamList =
-      UNWRAP(LD.getOutputByName("output_prev_index_beam_list"));
+      EXIT_ON_ERR(LD.getOutputByName("output_prev_index_beam_list"));
 
   while (loadNextInputTranslationText(&encoderInputs)) {
     // Update the inputs.


### PR DESCRIPTION
**Description**:
07e0f13 implements error handling for the model importer portion of the compiler using llvm::Error/Expect. Instead of `assert`ing, fallible code must return either a valid result or an Error containing a string message explaining the problem and this Error can be propagated up the call stack to the compiler interface where it can be dealt with properly and reported back to the user. There are some helper macros to improve the ergonomics of creating and handling errors implemented in `Support/Error.h` and `Support/Error.cpp`.

**Testing**:
`ninja check`
ran C2 onnx integration tests with `pytest -s caffe2/python/onnx/test_onnxifi.py`, 3/3 tests passed
**Documentation**:
Doxygen comments
