### PR TITLE
[Quantization] Allow the input and output of a quantized AvgPool node have different quantization param.

### DIFF
--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -185,8 +185,7 @@ protected:
   case Kinded::Kind::TanhNodeKind:                                             \
   case Kinded::Kind::TopKNodeKind:                                             \
   case Kinded::Kind::GatherNodeKind:                                           \
-  case Kinded::Kind::MaxPoolNodeKind:                                          \
-  case Kinded::Kind::AvgPoolNodeKind
+  case Kinded::Kind::MaxPoolNodeKind
 
   /// \see FunctionConverter::morphNode.
   /// This method does the final adjustment to the output types


### PR DESCRIPTION

*Description*:
In our previous quantization procedure, we forced the quantized avgpool node output have the same quantization param as the input, which is not necessary. This PR removes this restriction.

*Testing*:
1. added unittest.
2. run 

 ```
>$./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to1 -m=resnet50 -model_input_name=gpu_0/data -dump_profile="profile.yaml"
Model: resnet50_profile
 File: tests/images/imagenet/cat_285.png	Label-K1: 285 (probability: 0.5823)
 File: tests/images/imagenet/dog_207.png	Label-K1: 207 (probability: 0.9616)
 File: tests/images/imagenet/zebra_340.png	Label-K1: 340 (probability: 0.9902)

>$ ./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to1 -m=resnet50 -model_input_name=gpu_0/data -load_profile="profile.yaml"
Model: resnet50
 File: tests/images/imagenet/cat_285.png	Label-K1: 285 (probability: 0.5964)
 File: tests/images/imagenet/dog_207.png	Label-K1: 207 (probability: 0.9521)
 File: tests/images/imagenet/zebra_340.png	Label-K1: 340 (probability: 0.9887)
```
*Documentation*:
[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
