### PR TITLE
[image-classifier] Commonalize command line arguments to hyphen-style

### DIFF
--- a/docs/AOT.md
+++ b/docs/AOT.md
@@ -36,7 +36,7 @@ This document demonstrates how to produce a bundle for the host CPU using the
 directory.
 
 ```
-$image-classifier image.png -image_mode=0to1 -m=resnet50 -model_input_name=gpu_0/data -cpu -emit-bundle build/
+$image-classifier image.png -image-mode=0to1 -m=resnet50 -model-input-name=gpu_0/data -cpu -emit-bundle build/
 ```
 
 The command above would compile the neural network model described by the files
@@ -157,7 +157,7 @@ The CMakeLists.txt provides the following targets:
 * `ResNet50BundleNetFiles`: it downloads the Resnet50 network model in the Caffe2 format.
 * `ResNet50BundleNet`: it generates the bundle files using the Glow image-classifier as described above.
   The concrete command line looks like this:
-  `image-classifier tests/images/imagenet/cat_285.png -image_mode=0to1 -m=resnet50 -model_input_name=gpu_0/data -cpu -emit-bundle <build_dir>`
+  `image-classifier tests/images/imagenet/cat_285.png -image-mode=0to1 -m=resnet50 -model-input-name=gpu_0/data -cpu -emit-bundle <build_dir>`
   It reads the network model from `resnet50` and generates the `resnet50.o`
   and `resnet50.weights` files into the `build_dir` directory.
 * `ResNet50BundleMain`:  it compiles the `main.cpp` file, which is the main file of the project.
@@ -180,9 +180,9 @@ For example, to run the quantized bundle, you just need to execute:
 
 This run performs almost the same steps as non-quantized Resnet50 version
 except it emits bundle based on the quantization profile:
-`image-classifier tests/images/imagenet/cat_285.png -image_mode=0to1 -m=resnet50 -model_input_name=gpu_0/data -load_profile=profile.yml -cpu -emit-bundle build`
+`image-classifier tests/images/imagenet/cat_285.png -image-mode=0to1 -m=resnet50 -model-input-name=gpu_0/data -load-profile=profile.yml -cpu -emit-bundle build`
 
-The `profile.yml` itself is captured at a prior step by executing image-classifier with the `dump_profile` option:
-`image-classifier tests/images/imagenet/*.png -image_mode=0to1 -m=resnet50 -model_input_name=gpu_0/data -dump_profile=profile.yml`.
+The `profile.yml` itself is captured at a prior step by executing image-classifier with the `dump-profile` option:
+`image-classifier tests/images/imagenet/*.png -image-mode=0to1 -m=resnet50 -model-input-name=gpu_0/data -dump-profile=profile.yml`.
 
 See the [CMakeLists.txt](../examples/bundles/resnet50/CMakeLists.txt) for details.

--- a/docs/ModelLoader.md
+++ b/docs/ModelLoader.md
@@ -58,8 +58,8 @@ python export_onnx_model.py --model_name alexnet --model_path alexnet.onnx --mod
 After we get the ONNX model, we can load it and run it in Glow.
 
 ```bash
-# Please keep the model_input_name same with export_onnx_model util function
-${GLOW_PATH}/build/bin/image-classifier ${GLOW_PATH}/tests/images/imagenet/cat_285.png -image_mode=0to1 -m resnet18.onnx -model_input_name=data -cpu
+# Please keep the model-input-name same with export_onnx_model util function
+${GLOW_PATH}/build/bin/image-classifier ${GLOW_PATH}/tests/images/imagenet/cat_285.png -image-mode=0to1 -m resnet18.onnx -model-input-name=data -cpu
 ```
 
 The running results can be:

--- a/docs/Quantization.md
+++ b/docs/Quantization.md
@@ -66,12 +66,12 @@ from Resnet50.
 
 The Glow loader tool provides options to execute both profiling and conversion of a NN graph.
 
-```dump_profile=profile.yaml``` option is used to dump per node's output profile data
+```dump-profile=profile.yaml``` option is used to dump per node's output profile data
 into the ```profile.yaml``` file.
 This information can be used in the process of quantized conversion.
 For example, you can run the following command to capture profile for Resnet50.
 ```
-./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to1 -m=resnet50 -model_input_name=gpu_0/data -dump_profile="profile.yaml"
+./bin/image-classifier tests/images/imagenet/*.png -image-mode=0to1 -m=resnet50 -model-input-name=gpu_0/data -dump-profile="profile.yaml"
 ```
 By default, the loader will produce quantized results using asymmetric ranges.
 That is ranges not necessarily centered on 0. The loader supports three modes
@@ -92,14 +92,14 @@ the quantization process, where schema is ```asymmetric```,
 ```symmetric```, or ```symmetric_with_uint8```.
 
 
-```load_profile=profile.yaml``` option is used to quantize graph based on the
+```load-profile=profile.yaml``` option is used to quantize graph based on the
 captured profile in ```profile.yaml``` file. Important note, graph structure
 should not be changed between a step of capturing profile and a step of quantizing
 the graph.
 For example, you can run the following command to load the profile and quantize
 the graph.
 ```
-./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to1 -m=resnet50 -model_input_name=gpu_0/data -load_profile="profile.yaml"
+./bin/image-classifier tests/images/imagenet/*.png -image-mode=0to1 -m=resnet50 -model-input-name=gpu_0/data -load-profile="profile.yaml"
 ```
 
 By default, all nodes that can be quantized will be quantized. However, we may
@@ -109,11 +109,11 @@ disabling quantization of all nodes of a specific kind which are found in the
 graph. For example, if the loaded model sees high accuracy loss when
 element-wise Add is quantized, it can be left in floating point. This can be
 done by passing on the command line the node name via the option
-`-do_not_quantize_nodes`. Multiple node kinds can be specified to not be
-quantized. For example, to not quantize any Add or Div nodes when running the
-quantized text translator:
+`-keep-original-precision-for-nodes`. Multiple node kinds can be specified to
+not be quantized. For example, to not quantize any Add or Div nodes when running
+the quantized text translator:
 
-```./bin/text-translator -m en2gr -load_profile=en2gr.yaml -do_not_quantize_nodes=Add,Div```
+```./bin/text-translator -m en2gr -load-profile=en2gr.yaml -keep-original-precision-for-nodes=Add,Div```
 
 ## Compiler Optimizations
 

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -45,7 +45,7 @@ can be used to calculate Top-1 and Top-5 accuracy. It can be run via a command
 like the following:
 
 ```
-python utils/imagenet_topk_accuracy_driver.py --batch-size=10 --validation-images-dir=${PATH_TO_IMAGES} --image-classifier-cmd="${PATH_TO_IMAGE_CLASSIFIER_BINARY} -image_mode=0to1 -m=${PATH_TO_RESNET50_PROTOS_DIR} -model_input_name=gpu_0/data -cpu -topk=5 -"
+python utils/imagenet_topk_accuracy_driver.py --batch-size=10 --validation-images-dir=${PATH_TO_IMAGES} --image-classifier-cmd="${PATH_TO_IMAGE_CLASSIFIER_BINARY} -image-mode=0to1 -m=${PATH_TO_RESNET50_PROTOS_DIR} -model-input-name=gpu_0/data -cpu -topk=5 -"
 ```
 
 Note that the `--image-classifier-cmd` must include `-topk=5` for printing the
@@ -85,11 +85,11 @@ currently does not support models that contain control flow (e.g. the
 [RecurrentNetwork operator from
 Caffe2](https://caffe2.ai/docs/operators-catalogue.html#recurrentnetwork)), the
 input model must be unrolled to some maximum input and output length. These can
-be specified on the command line via `-min_output_len` and
-`-max_output_len`. Additionally, the beam search size can be specified via
-`-beam_size`. The default options for the `text-translator` match those for the
+be specified on the command line via `-max-input-len` and
+`-max-output-len`. Additionally, the beam search size can be specified via
+`-beam-size`. The default options for the `text-translator` match those for the
 en2gr model currently downloaded via `utils/download_caffe2_models.sh`
-(`-max_input_len=10`, `-max_output_len=14`, `-beam_size=6`).
+(`-max-input-len=10`, `-max-output-len=14`, `-beam-size=6`).
 
 ## Caffe2 and ONNX Models
 

--- a/examples/bundles/lenet_mnist/CMakeLists.txt
+++ b/examples/bundles/lenet_mnist/CMakeLists.txt
@@ -50,8 +50,8 @@ add_custom_command(
   OUTPUT
     ${LENET_MNIST_BUNDLE_DIR}/lenet_mnist.o
   COMMAND
-    image-classifier ${IMAGES}/3_1020.png -g -image_mode=0to1
-    -m=${LENET_MNIST_BUNDLE_DIR}/lenet_mnist -model_input_name=${MODEL_INPUT_NAME}
+    image-classifier ${IMAGES}/3_1020.png -g -image-mode=0to1
+    -m=${LENET_MNIST_BUNDLE_DIR}/lenet_mnist -model-input-name=${MODEL_INPUT_NAME}
     -cpu -emit-bundle ${LENET_MNIST_BUNDLE_DIR}
   DEPENDS
     image-classifier
@@ -63,9 +63,9 @@ add_custom_command(
   OUTPUT
     ${LENET_MNIST_BUNDLE_DIR}/profile.yml
   COMMAND
-    image-classifier ${IMAGES}/*.png -image_mode=0to1
-    -dump_profile=${LENET_MNIST_BUNDLE_DIR}/profile.yml
-    -m=${LENET_MNIST_BUNDLE_DIR}/lenet_mnist -model_input_name=${MODEL_INPUT_NAME}
+    image-classifier ${IMAGES}/*.png -image-mode=0to1
+    -dump-profile=${LENET_MNIST_BUNDLE_DIR}/profile.yml
+    -m=${LENET_MNIST_BUNDLE_DIR}/lenet_mnist -model-input-name=${MODEL_INPUT_NAME}
   DEPENDS
     image-classifier
 )
@@ -76,8 +76,8 @@ add_custom_command(
   OUTPUT
     ${LENET_MNIST_BUNDLE_DIR}/quantized_lenet_mnist.o
   COMMAND
-    image-classifier ${IMAGES}/3_1020.png -g -image_mode=0to1 -load_profile=profile.yml
-    -m=${LENET_MNIST_BUNDLE_DIR}/lenet_mnist -model_input_name=${MODEL_INPUT_NAME}
+    image-classifier ${IMAGES}/3_1020.png -g -image-mode=0to1 -load-profile=profile.yml
+    -m=${LENET_MNIST_BUNDLE_DIR}/lenet_mnist -model-input-name=${MODEL_INPUT_NAME}
     -cpu -emit-bundle ${LENET_MNIST_BUNDLE_DIR} && mv ${LENET_MNIST_BUNDLE_DIR}/lenet_mnist.o ${LENET_MNIST_BUNDLE_DIR}/quantized_lenet_mnist.o
   DEPENDS
     image-classifier

--- a/examples/bundles/lenet_mnist/Makefile
+++ b/examples/bundles/lenet_mnist/Makefile
@@ -29,17 +29,17 @@ lenet_mnist: build/main.o build/lenet_mnist.o
 profile.yml: download_weights
 	# Capture quantization profile based on all inputs.
 	# Note, Interpreter backend is used to collect the profile data.
-	${LOADER} ${IMAGES}/*.png -image_mode=0to1 -dump_profile=profile.yml -m lenet_mnist -model_input_name=${MODEL_INPUT_NAME}
+	${LOADER} ${IMAGES}/*.png -image-mode=0to1 -dump-profile=profile.yml -m lenet_mnist -model-input-name=${MODEL_INPUT_NAME}
 
 ifeq ($(QUANTIZE),YES)
 build/lenet_mnist.o: profile.yml
 	mkdir -p build
 	# Create bundle with quantized weights and computation graph.
-	${LOADER} ${IMAGES}/3_1020.png -image_mode=0to1 -load_profile=profile.yml -m lenet_mnist -model_input_name=${MODEL_INPUT_NAME} -cpu -emit-bundle build -g
+	${LOADER} ${IMAGES}/3_1020.png -image-mode=0to1 -load-profile=profile.yml -m lenet_mnist -model-input-name=${MODEL_INPUT_NAME} -cpu -emit-bundle build -g
 else
 build/lenet_mnist.o: download_weights
 	mkdir -p build
-	${LOADER} ${IMAGES}/3_1020.png -image_mode=0to1 -m lenet_mnist -model_input_name=${MODEL_INPUT_NAME} -cpu -emit-bundle build -g
+	${LOADER} ${IMAGES}/3_1020.png -image-mode=0to1 -m lenet_mnist -model-input-name=${MODEL_INPUT_NAME} -cpu -emit-bundle build -g
 endif
 
 build/main.o: main.cpp

--- a/examples/bundles/resnet50/CMakeLists.txt
+++ b/examples/bundles/resnet50/CMakeLists.txt
@@ -50,8 +50,8 @@ add_custom_command(
   OUTPUT
     ${RESNET50_BUNDLE_DIR}/resnet50.o
   COMMAND
-    image-classifier ${IMAGES}/dog_207.png -g -image_mode=0to1
-    -m=${RESNET50_BUNDLE_DIR}/resnet50 -model_input_name=${MODEL_INPUT_NAME}
+    image-classifier ${IMAGES}/dog_207.png -g -image-mode=0to1
+    -m=${RESNET50_BUNDLE_DIR}/resnet50 -model-input-name=${MODEL_INPUT_NAME}
     -cpu -emit-bundle ${RESNET50_BUNDLE_DIR} 
   DEPENDS 
     image-classifier
@@ -63,9 +63,9 @@ add_custom_command(
   OUTPUT
     ${RESNET50_BUNDLE_DIR}/profile.yml
   COMMAND
-    image-classifier ${IMAGES}/*.png -image_mode=0to1
-    -dump_profile=${RESNET50_BUNDLE_DIR}/profile.yml
-    -m=${RESNET50_BUNDLE_DIR}/resnet50 -model_input_name=${MODEL_INPUT_NAME}
+    image-classifier ${IMAGES}/*.png -image-mode=0to1
+    -dump-profile=${RESNET50_BUNDLE_DIR}/profile.yml
+    -m=${RESNET50_BUNDLE_DIR}/resnet50 -model-input-name=${MODEL_INPUT_NAME}
   DEPENDS
     image-classifier
 )
@@ -76,8 +76,8 @@ add_custom_command(
   OUTPUT
     ${RESNET50_BUNDLE_DIR}/quantized_resnet50.o
   COMMAND
-    image-classifier ${IMAGES}/dog_207.png -g -image_mode=0to1 -load_profile=profile.yml
-    -m=${RESNET50_BUNDLE_DIR}/resnet50 -model_input_name=${MODEL_INPUT_NAME}
+    image-classifier ${IMAGES}/dog_207.png -g -image-mode=0to1 -load-profile=profile.yml
+    -m=${RESNET50_BUNDLE_DIR}/resnet50 -model-input-name=${MODEL_INPUT_NAME}
     -cpu -emit-bundle ${RESNET50_BUNDLE_DIR} && mv ${RESNET50_BUNDLE_DIR}/resnet50.o ${RESNET50_BUNDLE_DIR}/quantized_resnet50.o
   DEPENDS
     image-classifier

--- a/examples/fr2en.cpp
+++ b/examples/fr2en.cpp
@@ -35,7 +35,7 @@ namespace {
 llvm::cl::OptionCategory debugCat("Glow Debugging Options");
 
 llvm::cl::opt<std::string> dumpGraphDAGFileOpt(
-    "dumpGraphDAG",
+    "dump-graph-DAG",
     llvm::cl::desc("Dump the graph to the given file in DOT format."),
     llvm::cl::value_desc("file.dot"), llvm::cl::cat(debugCat));
 
@@ -69,14 +69,14 @@ llvm::cl::opt<BackendKind> ExecutionBackend(
 llvm::cl::OptionCategory quantizationCat("Quantization Options");
 
 llvm::cl::opt<std::string> dumpProfileFileOpt(
-    "dump_profile",
+    "dump-profile",
     llvm::cl::desc("Perform quantization profiling for a given graph "
                    "and dump result to the file."),
     llvm::cl::value_desc("profile.yaml"), llvm::cl::Optional,
     llvm::cl::cat(quantizationCat));
 
 llvm::cl::opt<std::string> loadProfileFileOpt(
-    "load_profile",
+    "load-profile",
     llvm::cl::desc("Load quantization profile file and quantize the graph"),
     llvm::cl::value_desc("profile.yaml"), llvm::cl::Optional,
     llvm::cl::cat(quantizationCat));

--- a/include/glow/Base/Image.h
+++ b/include/glow/Base/Image.h
@@ -46,13 +46,13 @@ enum class ImageChannelOrder {
   RGB,
 };
 
-/// -image_mode flag.
+/// -image-mode flag.
 extern ImageNormalizationMode imageNormMode;
 
-/// -image_channel_order flag.
+/// -image-channel-order flag.
 extern ImageChannelOrder imageChannelOrder;
 
-/// -image_layout flag.
+/// -image-layout flag.
 extern ImageLayout imageLayout;
 
 /// -use-imagenet-normalization flag.

--- a/lib/Base/Image.cpp
+++ b/lib/Base/Image.cpp
@@ -30,7 +30,7 @@ llvm::cl::OptionCategory imageCat("Image Processing Options");
 
 ImageNormalizationMode imageNormMode;
 static llvm::cl::opt<ImageNormalizationMode, true> imageNormModeF(
-    "image_mode", llvm::cl::desc("Specify the image mode:"),
+    "image-mode", llvm::cl::desc("Specify the image mode:"),
     llvm::cl::cat(imageCat), llvm::cl::location(imageNormMode),
     llvm::cl::values(clEnumValN(ImageNormalizationMode::kneg1to1, "neg1to1",
                                 "Values are in the range: -1 and 1"),
@@ -43,13 +43,13 @@ static llvm::cl::opt<ImageNormalizationMode, true> imageNormModeF(
                                 "Values are in the range: -128 .. 127")),
     llvm::cl::init(ImageNormalizationMode::k0to255));
 static llvm::cl::alias imageNormModeA("i",
-                                      llvm::cl::desc("Alias for -image_mode"),
+                                      llvm::cl::desc("Alias for -image-mode"),
                                       llvm::cl::aliasopt(imageNormModeF),
                                       llvm::cl::cat(imageCat));
 
 ImageChannelOrder imageChannelOrder;
 static llvm::cl::opt<ImageChannelOrder, true> imageChannelOrderF(
-    "image_channel_order", llvm::cl::desc("Specify the image channel order"),
+    "image-channel-order", llvm::cl::desc("Specify the image channel order"),
     llvm::cl::Optional, llvm::cl::cat(imageCat),
     llvm::cl::location(imageChannelOrder),
     llvm::cl::values(clEnumValN(ImageChannelOrder::BGR, "BGR", "Use BGR"),
@@ -58,7 +58,7 @@ static llvm::cl::opt<ImageChannelOrder, true> imageChannelOrderF(
 
 ImageLayout imageLayout;
 static llvm::cl::opt<ImageLayout, true>
-    imageLayoutF("image_layout",
+    imageLayoutF("image-layout",
                  llvm::cl::desc("Specify which image layout to use"),
                  llvm::cl::Optional, llvm::cl::cat(imageCat),
                  llvm::cl::location(imageLayout),
@@ -68,7 +68,7 @@ static llvm::cl::opt<ImageLayout, true>
                                              "Use NHWC image layout")),
                  llvm::cl::init(ImageLayout::NCHW));
 static llvm::cl::alias imageLayoutA("l",
-                                    llvm::cl::desc("Alias for -image_layout"),
+                                    llvm::cl::desc("Alias for -image-layout"),
                                     llvm::cl::aliasopt(imageLayoutF),
                                     llvm::cl::cat(imageCat));
 

--- a/tests/images/run.sh
+++ b/tests/images/run.sh
@@ -1,43 +1,43 @@
 #!/usr/bin/env bash
 
-./bin/image-classifier tests/images/imagenet/*.png -use-imagenet-normalization -image_mode=0to1 -m=resnet50 -model_input_name=gpu_0/data "$@"
-./bin/image-classifier tests/images/imagenet/*.png -image_mode=neg128to127 -m=vgg19 -model_input_name=data "$@"
-./bin/image-classifier tests/images/imagenet/*.png -image_mode=neg128to127 -m=squeezenet -model_input_name=data "$@"
-./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to255 -m=zfnet512 -model_input_name=gpu_0/data "$@"
-./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to1 -m=densenet121 -model_input_name=data -compute_softmax "$@"
-./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to1 -m=shufflenet -model_input_name=gpu_0/data "$@"
-./bin/image-classifier tests/images/mnist/*.png -image_mode=0to1 -m=lenet_mnist -model_input_name=data "$@"
-./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to255 -m=inception_v1 -model_input_name=data "$@"
-./bin/image-classifier tests/images/imagenet/*.png -image_mode=0to255 -m=bvlc_alexnet -model_input_name=data "$@"
+./bin/image-classifier tests/images/imagenet/*.png -use-imagenet-normalization -image-mode=0to1 -m=resnet50 -model-input-name=gpu_0/data "$@"
+./bin/image-classifier tests/images/imagenet/*.png -image-mode=neg128to127 -m=vgg19 -model-input-name=data "$@"
+./bin/image-classifier tests/images/imagenet/*.png -image-mode=neg128to127 -m=squeezenet -model-input-name=data "$@"
+./bin/image-classifier tests/images/imagenet/*.png -image-mode=0to255 -m=zfnet512 -model-input-name=gpu_0/data "$@"
+./bin/image-classifier tests/images/imagenet/*.png -image-mode=0to1 -m=densenet121 -model-input-name=data -compute-softmax "$@"
+./bin/image-classifier tests/images/imagenet/*.png -image-mode=0to1 -m=shufflenet -model-input-name=gpu_0/data "$@"
+./bin/image-classifier tests/images/mnist/*.png -image-mode=0to1 -m=lenet_mnist -model-input-name=data "$@"
+./bin/image-classifier tests/images/imagenet/*.png -image-mode=0to255 -m=inception_v1 -model-input-name=data "$@"
+./bin/image-classifier tests/images/imagenet/*.png -image-mode=0to255 -m=bvlc_alexnet -model-input-name=data "$@"
 for png_filename in tests/images/imagenet/*.png; do
-  ./bin/image-classifier "$png_filename" -use-imagenet-normalization -image_mode=0to1 -m=resnet50/model.onnx -model_input_name=gpu_0/data_0 "$@"
+  ./bin/image-classifier "$png_filename" -use-imagenet-normalization -image-mode=0to1 -m=resnet50/model.onnx -model-input-name=gpu_0/data_0 "$@"
 done
 for png_filename in tests/images/imagenet/*.png; do
-  ./bin/image-classifier "$png_filename" -image_mode=neg128to127 -m=vgg19/model.onnx -model_input_name=data_0 "$@"
+  ./bin/image-classifier "$png_filename" -image-mode=neg128to127 -m=vgg19/model.onnx -model-input-name=data_0 "$@"
 done
 for png_filename in tests/images/imagenet/*.png; do
-  ./bin/image-classifier "$png_filename" -image_mode=neg128to127 -m=squeezenet/model.onnx -model_input_name=data_0 "$@"
+  ./bin/image-classifier "$png_filename" -image-mode=neg128to127 -m=squeezenet/model.onnx -model-input-name=data_0 "$@"
 done
 for png_filename in tests/images/imagenet/*.png; do
-  ./bin/image-classifier "$png_filename" -image_mode=0to255 -m=zfnet512/model.onnx -model_input_name=gpu_0/data_0 "$@"
+  ./bin/image-classifier "$png_filename" -image-mode=0to255 -m=zfnet512/model.onnx -model-input-name=gpu_0/data_0 "$@"
 done
 for png_filename in tests/images/imagenet/*.png; do
-  ./bin/image-classifier "$png_filename" -image_mode=0to1 -m=densenet121/model.onnx -model_input_name=data_0 -compute_softmax "$@"
+  ./bin/image-classifier "$png_filename" -image-mode=0to1 -m=densenet121/model.onnx -model-input-name=data_0 -compute-softmax "$@"
 done
-./bin/image-classifier tests/images/imagenet/zebra_340.png -image_mode=0to1 -m=shufflenet/model.onnx -model_input_name=gpu_0/data_0 "$@"
+./bin/image-classifier tests/images/imagenet/zebra_340.png -image-mode=0to1 -m=shufflenet/model.onnx -model-input-name=gpu_0/data_0 "$@"
 for png_filename in tests/images/mnist/*.png; do
-  ./bin/image-classifier "$png_filename" -image_mode=0to1 -m=mnist.onnx -model_input_name=data_0 "$@"
+  ./bin/image-classifier "$png_filename" -image-mode=0to1 -m=mnist.onnx -model-input-name=data_0 "$@"
 done
 for png_filename in tests/images/imagenet/*.png; do
-  ./bin/image-classifier "$png_filename" -image_mode=0to255 -m=inception_v1/model.onnx -model_input_name=data_0 "$@"
+  ./bin/image-classifier "$png_filename" -image-mode=0to255 -m=inception_v1/model.onnx -model-input-name=data_0 "$@"
 done
 for png_filename in tests/images/imagenet/*.png; do
-  ./bin/image-classifier "$png_filename" -image_mode=0to255 -m=bvlc_alexnet/model.onnx -model_input_name=data_0 "$@"
+  ./bin/image-classifier "$png_filename" -image-mode=0to255 -m=bvlc_alexnet/model.onnx -model-input-name=data_0 "$@"
 done
 #Inference test for TF ONNX models
 for png_filename in tests/images/imagenet/*.png; do
-  ./bin/image-classifier "$png_filename" -image_mode=0to1 -m=googlenet_v1_slim/googlenet_v1_slim.onnx -model_input_name=input:0 -image_layout=NHWC -label_offset=1 "$@"
+  ./bin/image-classifier "$png_filename" -image-mode=0to1 -m=googlenet_v1_slim/googlenet_v1_slim.onnx -model-input-name=input:0 -image-layout=NHWC -label-offset=1 "$@"
 done
 for png_filename in tests/images/imagenet_299/*.png; do
-  ./bin/image-classifier "$png_filename" -image_mode=0to1 -m=googlenet_v4_slim/googlenet_v4_slim.onnx -model_input_name=input:0 -image_layout=NHWC -label_offset=1 "$@"
+  ./bin/image-classifier "$png_filename" -image-mode=0to1 -m=googlenet_v4_slim/googlenet_v4_slim.onnx -model-input-name=input:0 -image-layout=NHWC -label-offset=1 "$@"
 done

--- a/tools/loader/ImageClassifier.cpp
+++ b/tools/loader/ImageClassifier.cpp
@@ -46,12 +46,12 @@ llvm::cl::list<std::string> inputImageFilenames(
     llvm::cl::OneOrMore);
 
 llvm::cl::opt<unsigned> labelOffset(
-    "label_offset",
+    "label-offset",
     llvm::cl::desc("Label offset for TF ONNX models with 1001 classes"),
     llvm::cl::Optional, llvm::cl::init(0), llvm::cl::cat(imageLoaderCat));
 
 llvm::cl::opt<bool> computeSoftmax(
-    "compute_softmax", llvm::cl::desc("Compute softmax of the network output"),
+    "compute-softmax", llvm::cl::desc("Compute softmax of the network output"),
     llvm::cl::Optional, llvm::cl::init(false), llvm::cl::cat(imageLoaderCat));
 
 llvm::cl::opt<unsigned> topKCount(
@@ -59,7 +59,7 @@ llvm::cl::opt<unsigned> topKCount(
     llvm::cl::Optional, llvm::cl::init(1), llvm::cl::cat(imageLoaderCat));
 
 llvm::cl::opt<std::string> modelInputName(
-    "model_input_name",
+    "model-input-name",
     llvm::cl::desc("The name of the variable for the model's input image."),
     llvm::cl::value_desc("string_name"), llvm::cl::Required,
     llvm::cl::cat(imageLoaderCat));

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -64,7 +64,7 @@ llvm::cl::opt<unsigned> iterationsOpt(
     llvm::cl::Optional, llvm::cl::init(1), llvm::cl::cat(loaderCat));
 
 llvm::cl::opt<std::string> dumpProfileFileOpt(
-    "dump_profile",
+    "dump-profile",
     llvm::cl::desc("Perform quantization profiling for a given graph "
                    "and dump result to the file."),
     llvm::cl::value_desc("profile.yaml"), llvm::cl::Optional,
@@ -85,7 +85,7 @@ llvm::cl::opt<quantization::Schema> quantizationSchema(
     llvm::cl::init(quantization::Schema::Asymmetric), llvm::cl::cat(loaderCat));
 
 llvm::cl::opt<std::string> loadProfileFileOpt(
-    "load_profile",
+    "load-profile",
     llvm::cl::desc("Load quantization profile file and quantize the graph"),
     llvm::cl::value_desc("profile.yaml"), llvm::cl::Optional,
     llvm::cl::cat(loaderCat));
@@ -117,11 +117,11 @@ llvm::cl::OptionCategory
                    "given files/stdout");
 
 llvm::cl::opt<std::string> dumpGraphDAGFileOpt(
-    "dumpGraphDAG",
+    "dump-graph-DAG",
     llvm::cl::desc("Specify the file to export the Graph in DOT format"),
     llvm::cl::value_desc("file.dot"), llvm::cl::cat(modelExportCat));
 
-llvm::cl::opt<bool> dumpGraphOpt("dumpGraph",
+llvm::cl::opt<bool> dumpGraphOpt("dump-graph",
                                  llvm::cl::desc("Prints Graph to stdout"),
                                  llvm::cl::cat(modelExportCat));
 

--- a/tools/loader/TextTranslator.cpp
+++ b/tools/loader/TextTranslator.cpp
@@ -31,25 +31,25 @@ namespace {
 llvm::cl::OptionCategory textTranslatorCat("Text Translator Options");
 
 llvm::cl::opt<unsigned>
-    maxInputLenOpt("max_input_len",
+    maxInputLenOpt("max-input-len",
                    llvm::cl::desc("Maximum allowed length of the input "
                                   "sentence. Specified by the input model."),
                    llvm::cl::Optional, llvm::cl::init(10),
                    llvm::cl::cat(textTranslatorCat));
 
 llvm::cl::opt<unsigned>
-    maxOutputLenOpt("max_output_len",
+    maxOutputLenOpt("max-output-len",
                     llvm::cl::desc("Maximum allowed length of the output "
                                    "sentence. Specified by the input model."),
                     llvm::cl::Optional, llvm::cl::init(14),
                     llvm::cl::cat(textTranslatorCat));
 
 llvm::cl::opt<unsigned> beamSizeOpt(
-    "beam_size", llvm::cl::desc("Beam size used by the input model."),
+    "beam-size", llvm::cl::desc("Beam size used by the input model."),
     llvm::cl::Optional, llvm::cl::init(6), llvm::cl::cat(textTranslatorCat));
 
 llvm::cl::opt<double>
-    lengthPenaltyOpt("length_penalty",
+    lengthPenaltyOpt("length-penalty",
                      llvm::cl::desc("Length penalty to use when determining "
                                     "highest likelihood output sentence."),
                      llvm::cl::Optional, llvm::cl::init(0.0f),

--- a/utils/imagenet_topk_accuracy_driver.py
+++ b/utils/imagenet_topk_accuracy_driver.py
@@ -198,12 +198,12 @@ def verify_spawn_cmd(image_classifier_cmd):
     if "image-classifier" in split_cmd[0]:
         assert "-" in split_cmd, "Streaming mode must be used."
         assert "-topk=5" in split_cmd, "-topk=5 must be used."
-        assert any("-model_input_name=" in s for s in split_cmd), (
-            "image-classifier requires -model_input_name to be specified.")
+        assert any("-model-input-name=" in s for s in split_cmd), (
+            "image-classifier requires -model-input-name to be specified.")
         assert any("-m=" in s for s in split_cmd), (
             "image-classifier requires -m to be specified")
-        assert any("-image_mode=" in s for s in split_cmd), (
-            "image-classifier requires -image_mode to be specified")
+        assert any("-image-mode=" in s for s in split_cmd), (
+            "image-classifier requires -image-mode to be specified")
 
 ## Prints the Top-1 and Top-5 accuracy given @param total_image_count, @param
 # top1_count, and @param top5_count.


### PR DESCRIPTION
*Description*: Search and replace command line options in camelCaseStyle or underscore_style to use hyphen-style. Changed model-loader, image-classifier, text-translator and fr2en example.
*Testing*: Ran run.sh, and manually followed instructions in AOT.md to dump a profile, load a profile and emit a bundle. 
*Documentation*:
grepped docs for each changed option and updated them.
fixes #1965.