### PR TITLE
[NodeGen] Support enum members on nodes

### DIFF
--- a/tools/ClassGen/CMakeLists.txt
+++ b/tools/ClassGen/CMakeLists.txt
@@ -8,11 +8,16 @@ add_executable(InstrGen
 
 target_link_libraries(NodeGen
                       PUBLIC
+                        MemberType
                         Support)
 
 target_link_libraries(InstrGen
                       PUBLIC
+                        MemberType
                         Support)
+
+add_library(MemberType
+              MemberType.cpp)
 
 if(GLOW_WITH_CPU)
   add_subdirectory(Backends/CPU)

--- a/tools/ClassGen/MemberType.cpp
+++ b/tools/ClassGen/MemberType.cpp
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "MemberType.h"
+
+MemberTypeInfo kTypeRefTypeInfo{MemberType::TypeRef, "TypeRef", "TypeRef",
+                                "TypeRef"};
+MemberTypeInfo kFloatTypeInfo{MemberType::Float, "float", "float", "float"};
+MemberTypeInfo kUnsignedTypeInfo{MemberType::Unsigned, "unsigned_t",
+                                 "unsigned_t", "unsigned_t"};
+MemberTypeInfo kBooleanTypeInfo{MemberType::Boolean, "bool", "bool", "bool"};
+MemberTypeInfo kStringTypeInfo{MemberType::String, "std::string", "std::string",
+                               "std::string"};
+MemberTypeInfo kVectorFloatTypeInfo{MemberType::VectorFloat,
+                                    "llvm::ArrayRef<float>",
+                                    "std::vector<float>", "std::vector<float>"};
+MemberTypeInfo kVectorUnsignedTypeInfo{
+    MemberType::VectorUnsigned, "llvm::ArrayRef<unsigned_t>",
+    "std::vector<unsigned_t>", "std::vector<unsigned_t>"};
+MemberTypeInfo kVectorSizeTTypeInfo{
+    MemberType::VectorSizeT, "llvm::ArrayRef<size_t>", "std::vector<size_t>",
+    "std::vector<size_t>"};
+MemberTypeInfo kVectorNodeValueTypeInfo{
+    MemberType::VectorNodeValue, "NodeValueArrayRef", "std::vector<NodeHandle>",
+    "std::vector<NodeValue>"};

--- a/tools/ClassGen/MemberType.h
+++ b/tools/ClassGen/MemberType.h
@@ -30,8 +30,43 @@ enum class MemberType : unsigned {
   VectorUnsigned,
   VectorSizeT,
   VectorNodeValue,
+  Enum,
 };
 
+/// This struct encapsulates all of the information NodeBuilder needs about the
+/// type of a member in order to generate a cloner, hasher, equator, etc.
+struct MemberTypeInfo {
+  MemberType type;
+  std::string returnTypename;
+  std::string storageTypename;
+  std::string ctorArgTypename;
+  std::string forwardDecl;
+};
+
+/// These are instances of MemberTypeInfo for commonly used types.
+extern MemberTypeInfo kTypeRefTypeInfo;
+extern MemberTypeInfo kFloatTypeInfo;
+extern MemberTypeInfo kUnsignedTypeInfo;
+extern MemberTypeInfo kBooleanTypeInfo;
+extern MemberTypeInfo kStringTypeInfo;
+extern MemberTypeInfo kVectorFloatTypeInfo;
+extern MemberTypeInfo kVectorUnsignedTypeInfo;
+extern MemberTypeInfo kVectorSizeTTypeInfo;
+extern MemberTypeInfo kVectorNodeValueTypeInfo;
+
+inline const char *getReturnTypename(const MemberTypeInfo *typeInfo) {
+  return typeInfo->returnTypename.c_str();
+}
+
+inline const char *getStorageTypename(const MemberTypeInfo *typeInfo) {
+  return typeInfo->storageTypename.c_str();
+}
+
+inline const char *getCtorArgTypename(const MemberTypeInfo *typeInfo) {
+  return typeInfo->ctorArgTypename.c_str();
+}
+
+/// TODO: Remove after modifying InstrGen to use MemberTypeInfo as well?
 inline const char *getReturnTypename(MemberType type) {
   const char *returnTypes[] = {"TypeRef",
                                "float",

--- a/tools/ClassGen/NodeBuilder.h
+++ b/tools/ClassGen/NodeBuilder.h
@@ -30,6 +30,88 @@
 #include <vector>
 
 class Builder;
+class NodeBuilder;
+
+class EnumBuilder {
+  struct EnumCase {
+    // The name of the enum case (i.e. <enum type>::<enum case name>).
+    std::string name;
+    // The value of the enum case.
+    int value;
+    // The docstring for the enum case.
+    std::string doc;
+    // Whether or not the value for this case was explicitly defined.
+    bool definedWithValue;
+  };
+  ;
+
+  /// The name of the enum.
+  std::string name_;
+  /// The fully qualified name of the enum (i.e. with all enclosing namespaces).
+  std::string fullyQualifiedName_;
+  /// The containing namespaces for the enum.
+  std::vector<std::string> namespaces_;
+  /// The enum cases.
+  std::vector<EnumCase> enumCases_;
+  /// CPP file stream.
+  std::ofstream &cStream;
+  /// Specifies if this enum is backend specific. If true, a definition
+  /// will not be generated.
+  bool isBackendSpecific_{false};
+  /// Documentation string printed with the class definition.
+  std::string docstring_;
+  /// An integer value that is guaranteed to be unused by the enum at all times.
+  int unusedValue_{0};
+
+public:
+  /// Constructor.
+  EnumBuilder(std::ofstream &C, const std::string &name,
+              bool isBackendSpecific);
+
+  /// Delete copy constructor to force moves and ensure one destructor call.
+  EnumBuilder(const EnumBuilder &src) = delete;
+
+  /// Set the documentation string. Each line will be prepended with "/// ".
+  EnumBuilder &setDocstring(const std::string &docstring) {
+    docstring_ = docstring;
+    return *this;
+  }
+
+  /// Add a new enum case to the enumeration.
+  EnumBuilder &addEnumCase(const std::string &name,
+                           const std::string &doc = "");
+  EnumBuilder &addEnumCaseWithValue(const std::string &name, const int value,
+                                    const std::string &doc = "");
+
+  /// Get a MemberTypeInfo object describing the enum being built by this
+  /// builder instance.
+  MemberTypeInfo getMemberTypeInfo() const;
+
+  /// Destructor.
+  ~EnumBuilder();
+
+private:
+  /// Emit the opening of the namespace that contains the enum.
+  void emitNamespaceOpen(std::ostream &os) const;
+
+  /// Emit the closing of the namespace that contains the enum.
+  void emitNamespaceClose(std::ostream &os) const;
+
+  /// Emit the class-level documentation string, if any.
+  void emitDocstring(std::ostream &os) const;
+
+  /// Emit the forward declaration of the enum.
+  void emitForwardDecl(std::ostream &os) const;
+
+  /// Return the fully qualified name of the enum.
+  std::string getFullyQualifiedName() const { return fullyQualifiedName_; }
+
+  /// Emit the cases of the enum.
+  void emitEnumCases(std::ostream &os) const;
+
+  /// Emit the definition of the enum.
+  void emitEnumDefinition(std::ostream &os) const;
+};
 
 class NodeBuilder {
   /// The node name.
@@ -44,7 +126,7 @@ class NodeBuilder {
   /// argument is the name of the return type. Format: (type, name)
   std::vector<std::pair<std::string, std::string>> nodeOutputs_;
   /// A list of node members. Format: (type, name).
-  std::vector<std::pair<MemberType, std::string>> members_;
+  std::vector<std::pair<const MemberTypeInfo *, std::string>> members_;
   /// The node enum cases.
   std::vector<std::string> enum_;
   /// A list of extra parameter that are declared in the node constructor. The
@@ -83,8 +165,10 @@ public:
   /// Add a member to the node. Format: type, name.
   /// The name should start with a capital letter.
   /// For example: "Filter".
-  NodeBuilder &addMember(MemberType type, const std::string &name) {
-    members_.push_back({type, name});
+  NodeBuilder &addMember(MemberType type, const std::string &name);
+  NodeBuilder &addMember(const MemberTypeInfo *typeInfo,
+                         const std::string &name) {
+    members_.push_back({typeInfo, name});
     return *this;
   }
 
@@ -152,6 +236,9 @@ public:
   ~NodeBuilder();
 
 private:
+  /// Emit required forward declarations for node members.
+  void emitMemberForwardDecls(std::ostream &os) const;
+
   /// Emits the methods that converts an enum case into a textual label.
   void emitEnumModePrinters(std::ostream &os) const;
 
@@ -162,7 +249,7 @@ private:
   void emitClassMembers(std::ostream &os) const;
 
   /// Emit the getter for a accessible class member.
-  void emitMemberGetter(std::ostream &os, MemberType type,
+  void emitMemberGetter(std::ostream &os, const MemberTypeInfo *type,
                         const std::string &name) const;
 
   /// Emit setters/getters for each accessible class member.
@@ -201,6 +288,7 @@ class Builder {
   std::ofstream &hStream;
   std::ofstream &cStream;
   std::ofstream &dStream;
+  std::vector<std::shared_ptr<EnumBuilder>> enumBuilders_;
 
 public:
   /// Create a new top-level builder that holds the three output streams that
@@ -227,6 +315,22 @@ public:
   NodeBuilder newBackendSpecificNode(const std::string &name) {
     const bool isBackendSpecific = true;
     return NodeBuilder(hStream, cStream, dStream, name, isBackendSpecific);
+  }
+
+  /// Declare a new enum and generate code for it.
+  EnumBuilder &newEnum(const std::string &name) {
+    const bool isBackendSpecific = false;
+    auto eb = std::make_shared<EnumBuilder>(cStream, name, isBackendSpecific);
+    enumBuilders_.emplace_back(eb);
+    return *eb;
+  }
+
+  /// Declare a new backend specific enum. This will NOT generate a definition.
+  EnumBuilder &newBackendSpecificEnum(const std::string &name) {
+    const bool isBackendSpecific = true;
+    auto eb = std::make_shared<EnumBuilder>(cStream, name, isBackendSpecific);
+    enumBuilders_.emplace_back(eb);
+    return *eb;
   }
 
   /// Declare the node in the def file but don't generate code for it.


### PR DESCRIPTION
**Description**
This commit adds support for enum members on nodes. An enum type
can be defined within `NodeGen` itself, or defined externally.
In the latter case, it must be declared in `NodeGen` so
that it can be forward declared correctly when defining `Nodes` that
have members of that type.

The API looks something like this:

```
auto e = BB.newEnum("glow::greatBackend::tremendousEnum");
e.addValue("FIRST").addValue("SECOND");
BB.newNode(...).addMember(e, "EnumMember");
```

**Testing**
Tried out new features with a new autogenerated node class with four
different enum members, two of one type and two of another. The two enum
types were declared in different namespaces:

```
  auto &e = BB.newEnum("newbackend::namespace1::enum1");
  e.addEnumCase("FIRST", "first comment");
  e.addEnumCase("SECOND", "second comment");
  e.setDocstring("This is a test docstring. Lorem ipsum doloret something "
                 "something.");
  auto eType = e.getMemberTypeInfo();

  auto &f = BB.newEnum("newbackend::namespace1::namespace2::enum2");
  f.addEnumCaseWithValue("FIRST", 5);
  f.addEnumCaseWithValue("SECOND", 10);
  f.addEnumCaseWithValue("THIRD", 1);
  f.addEnumCase("FOURTH");
  f.setDocstring("This is a test docstring. Lorem ipsum doloret something "
                 "something.");
  auto fType = f.getMemberTypeInfo();

  BB.newNode("EnumMemberTest")
      .addInput("Input")
      .addResultFromCtorArg()
      .addMember(&eType, "EnumMember1")
      .addMember(&eType, "EnumMember2")
      .addMember(MemberType::Float, "someFloat")
      .addMember(&fType, "EnumMember3")
      .addMember(&fType, "EnumMember4");
```

Everything compiled and the generated code looked correct.

**Fixes**
Fixes issue #2053.