### PR TITLE
[Quantization] Improve RowwiseQuantizedFullyConnected node to support int32 quantized bias.

### DIFF
--- a/lib/Backends/CPU/libjit/libjit_matmul.cpp
+++ b/lib/Backends/CPU/libjit/libjit_matmul.cpp
@@ -303,7 +303,7 @@ void libjit_matmul_i8(int8_t *outW, const int8_t *lhsW, const int8_t *rhsW,
 
 void libjit_rowwise_quantized_fc_i8(
     int8_t *outW, const int8_t *inW, const int8_t *weightsW,
-    const int8_t *biasW, const int32_t *weightsOffsets, const int32_t *biasPre,
+    const int32_t *biasW, const int32_t *weightsOffsets, const int32_t *biasPre,
     const int32_t *biasPost, const int32_t *biasScale, const int32_t *outPre,
     const int32_t *outPost, const int32_t *outScale, const size_t *outWdims,
     const size_t *inWdims, const size_t *weightsWdims, const size_t *biasWdims,
@@ -323,7 +323,7 @@ void libjit_rowwise_quantized_fc_i8(
         int32_t I = inW[libjit_getXY(inWdims, i, k)];
         sum += (W - weightsOffsets[j]) * (I - inOffset);
       }
-      int32_t B = libjit_scale_i32i8((int32_t)biasW[j] - biasOffset, biasPre[j],
+      int32_t B = libjit_scale_i32i8(biasW[j] - biasOffset, biasPre[j],
                                      biasPost[j], biasScale[j], 0);
       sum += B;
       int32_t scaledSum = libjit_scale_i32i8(sum, outPre[j], outPost[j],

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -1612,7 +1612,7 @@ void InterpreterFunction::fwdRowwiseQuantizedFullyConnectedInst(
   auto inW = getWeightHandle<int8_t>(I->getSrc());
   auto outW = getWeightHandle<int8_t>(I->getDest());
   auto weightsW = getWeightHandle<int8_t>(I->getWeights());
-  auto biasW = getWeightHandle<int8_t>(I->getBias());
+  auto biasW = getWeightHandle<int32_t>(I->getBias());
   auto scalesW = getWeightHandle<float>(I->getScales());
   auto offsetsW = getWeightHandle<int32_t>(I->getOffsets());
   ShapeHW idim(inW.dims());

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -572,7 +572,7 @@ Function::createRowwiseQuantizedFullyConnected(llvm::StringRef name,
   Constant *weights = llvm::cast<Constant>(W);
   size_t numRows = W->getType()->dims()[0];
 
-  // So far, if we want to create a storage with Int8QTy/Int16QTy/Int32QTy,
+  // So far, if we want to create a storage with Int8QTy/Int16QTy,
   // it is assumed to be quantized data and the scale and offset should be
   // provided. But for rowwise quantization, the scales and offsets are stored
   // in vectors separately, we add the dummy scale and offset here.
@@ -580,8 +580,8 @@ Function::createRowwiseQuantizedFullyConnected(llvm::StringRef name,
                                                0.0, 0, "weights.rwqfc");
   auto *scales =
       getParent()->createConstant(ElemKind::FloatTy, {numRows}, "scales.rwqfc");
-  auto *offsets = getParent()->createConstant(ElemKind::Int32QTy, {numRows},
-                                              0.0, 0, "offsets.rwqfc");
+  auto *offsets = getParent()->createConstant(ElemKind::Int32ITy, {numRows},
+                                              "offsets.rwqfc");
 
   quantization::tensorRowwiseQuantization(
       weights->getPayload(), qWeights->getPayload(), scales->getPayload(),

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -4392,7 +4392,7 @@ TEST_P(InterpAndCPU, rowwiseQuantizedFCTest) {
   TypeRef resTy =
       mod_.uniqueType(ElemKind::Int8QTy, fc->getResult().dims(), 0.05, 49);
   TypeRef biasTy =
-      mod_.uniqueType(ElemKind::Int8QTy, bias->dims(), 0.00036, -128);
+      mod_.uniqueType(ElemKind::Int32QTy, bias->dims(), 0.00036, -128);
 
   auto *inputq = F_->createQuantize("input.q", input, inputTy);
   auto *biasq = F_->createQuantize("bias.q", bias, biasTy);


### PR DESCRIPTION
*Description*:
Now we support int32 quantized bias for Conv and FC. Therefore, for RowwiseQuantizedFullyConnected, we would like to support int32 quantized bias as well.

*Testing*: 
ninja check

*Documentation*:
[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
