### PR TITLE
[graph] Utilities for hooking intermediate net layers

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -64,6 +64,15 @@ target_link_libraries(lenet-loader
                         Importer
                         Support)
 
+if(GLOW_WITH_CPU)
+  add_executable(resnet-verify
+                   resnet-verify.cpp)
+  target_link_libraries(resnet-verify
+                        PRIVATE
+                          ExecutionEngine
+                          Importer)
+endif()
+
 if(GLOW_WITH_BUNDLES)
   add_subdirectory(bundles)
 endif()

--- a/examples/resnet-verify.cpp
+++ b/examples/resnet-verify.cpp
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "glow/Base/Image.h"
+#include "glow/ExecutionEngine/ExecutionEngine.h"
+#include "glow/Graph/Hook.h"
+#include "glow/Importer/Caffe2ModelLoader.h"
+
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/Format.h"
+
+using namespace glow;
+
+const char inputName[] = "gpu_0/data";
+
+class Tester {
+  Context ctx;
+  ExecutionEngine EE;
+  Module &mod;
+  Function *F;
+  TypeRef inputType;
+  Placeholder *input;
+  Placeholder *output;
+
+public:
+  Tester(BackendKind kind)
+      : EE(kind), mod(EE.getModule()), F(mod.createFunction("resnet50")),
+        inputType(mod.uniqueType(ElemKind::FloatTy, {1, 3, 224, 224})) {
+    // Load and compile ResNet-50.
+    Caffe2ModelLoader loader("resnet50/predict_net.pb", "resnet50/init_net.pb",
+                             {inputName}, {inputType}, *F);
+    input =
+        llvm::cast<Placeholder>(cantFail(loader.getNodeValueByName(inputName)));
+    output = cantFail(loader.getSingleOutput());
+  }
+
+  void bindInput(Tensor *batch) {
+    // Allocate memory for input and bind it to the placeholders.
+    ctx.allocate(mod.getPlaceholders());
+    updateInputPlaceholders(ctx, {input}, {batch});
+  }
+
+  TypeRef getInputType() const { return inputType; }
+
+  Function *getFunction() const { return F; }
+
+  Tensor *hookAndRun(llvm::StringRef name) {
+    auto hook = hookOutput(F, name);
+    auto *out = ctx.allocate(hook.output);
+    EE.compile(CompilationMode::Infer, hook.function);
+    EE.run(ctx);
+    mod.eraseFunction(hook.function);
+    return out;
+  }
+};
+
+/// Compare layer-by-layer execution of ResNet on two backends.
+int main() {
+  Tester interp{BackendKind::Interpreter};
+  Tester cpu{BackendKind::CPU};
+
+  // Read an example PNG and add it to an input batch.
+  auto image = readPngImageAndPreprocess(
+      "tests/images/imagenet/cat_285.png", ImageNormalizationMode::k0to1,
+      ImageChannelOrder::BGR, ImageLayout::NCHW,
+      /* useImagenetNormalization */ true);
+  Tensor batch(interp.getInputType());
+  batch.getHandle<float>().insertSlice(image, 0);
+
+  interp.bindInput(&batch);
+  cpu.bindInput(&batch);
+
+  for (auto const &node : interp.getFunction()->getNodes()) {
+    if (llvm::isa<SaveNode>(&node)) {
+      continue;
+    }
+    llvm::errs() << "Verifying layer: " << node.getName() << "\n";
+    auto *interpOut = interp.hookAndRun(node.getName());
+    auto *cpuOut = cpu.hookAndRun(node.getName());
+    if (!interpOut->isEqual(*cpuOut)) {
+      llvm::errs() << "Results differ\n";
+      dumpImpl(interpOut);
+      dumpImpl(cpuOut);
+      auto IH = interpOut->getHandle<>();
+      auto CH = cpuOut->getHandle<>();
+      for (size_t i = 0, e = interpOut->size(); i < e; i++) {
+        auto diff = std::abs(IH.raw(i) - CH.raw(i));
+        if (diff > 0.0001) {
+          llvm::errs() << llvm::format(
+              "Index: %zu, Interp: %f, CPU: %f, diff: %f\n", i, IH.raw(i),
+              CH.raw(i), diff);
+        }
+      }
+    }
+  }
+
+  return 0;
+}

--- a/include/glow/Graph/Hook.h
+++ b/include/glow/Graph/Hook.h
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_GRAPH_HOOK_H
+#define GLOW_GRAPH_HOOK_H
+
+#include "llvm/ADT/StringRef.h"
+
+namespace glow {
+
+class Function;
+class Node;
+class Placeholder;
+class SaveNode;
+
+struct HookedFunction {
+  Function *function;
+  SaveNode *save;
+  Placeholder *output;
+};
+
+HookedFunction hookOutput(Function *F, Node *node);
+
+HookedFunction hookOutput(Function *F, llvm::StringRef nodeName);
+
+} // namespace glow
+
+#endif // GLOW_GRAPH_HOOK_H

--- a/lib/Graph/CMakeLists.txt
+++ b/lib/Graph/CMakeLists.txt
@@ -16,6 +16,7 @@ add_library(Graph
             ${NODES_SRC}
             ${NODES_DEF}
             Context.cpp
+            Hook.cpp
             Node.cpp
             Nodes.cpp
             NodeValue.cpp

--- a/lib/Graph/Hook.cpp
+++ b/lib/Graph/Hook.cpp
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/Graph/Hook.h"
+
+#include "glow/Graph/Graph.h"
+#include "glow/Graph/Node.h"
+
+#include "llvm/ADT/DenseMap.h"
+
+using namespace glow;
+
+namespace {
+/// Map from original Nodes to cloned Nodes.
+using NodeMap = llvm::DenseMap<Node *, Node *>;
+} // namespace
+
+/// Clone \p node and its sources into \p newF using old-to-new mapping \p
+/// currToNew.
+static Node *recursiveClone(Function *newF, Node *node, NodeMap &currToNew) {
+  Node *copy = node->clone();
+  currToNew[node] = copy;
+  newF->addNode(copy);
+  for (unsigned inp = 0, e = copy->getNumInputs(); inp < e; inp++) {
+    auto input = copy->getNthInput(inp);
+    auto it = currToNew.find(input.getNode());
+    Node *newInput;
+    if (it != currToNew.end()) {
+      newInput = it->second;
+    } else if (llvm::isa<Storage>(input.getNode())) {
+      continue;
+    } else {
+      newInput = recursiveClone(newF, input.getNode(), currToNew);
+    }
+    copy->setNthInput(inp, NodeValue(newInput, input.getResNo()));
+  }
+  return copy;
+}
+
+HookedFunction glow::hookOutput(Function *F, Node *node) {
+  NodeMap currToNew;
+  auto *newF = F->getParent()->createFunction("hook");
+  Node *hooked = recursiveClone(newF, node, currToNew);
+  auto *save = newF->createSave("hook_save", hooked);
+  return HookedFunction{newF, save, save->getPlaceholder()};
+}
+
+HookedFunction glow::hookOutput(Function *F, llvm::StringRef nodeName) {
+  auto *node = F->getNodeByName(nodeName);
+  return hookOutput(F, node);
+}


### PR DESCRIPTION
*Description*:
In bringing up backends, I found it useful to be able to truncate a network at some arbitrary intermediate layer and compare the output against the interpreter.  This is (more or less) the utility I wrote to do it, plus an example of going layer-by-layer through ResNet-50 (which is very slow, but that's OK).

If you're reviewing, the first commit is the hooking logic itself; the second is the example.

I'd like some feedback on whether people think this is generally useful.  If so, happy to do some cleanup and write docs.

*Testing*: `bin/resnet-verify`

*Documentation*: not yet

Fixes #1976 