### PR TITLE
[Quantization] Enable RowwiseQuantizedFullyConnected under the option -enable-rowwise

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -276,10 +276,12 @@ public:
   /// in quantization. Args \p input and \p B are quantized in regular way, \p W
   /// is the constant weights and will be row-wise quantized during node
   /// creation time. The output is quantized in the regular way, and its type
-  /// \p outTy is a quantized type.
+  /// \p outTy is a quantized type. if \p transposeWeight is true, \p W need to
+  /// be transposed first.
   RowwiseQuantizedFullyConnectedNode *
   createRowwiseQuantizedFullyConnected(llvm::StringRef name, NodeValue input,
-                                       Constant *W, Node *B, TypeRef outTy);
+                                       Constant *W, Node *B, TypeRef outTy,
+                                       bool transposeWeight = false);
 
   /// Implement an operation that computes the row-wise dot product of its
   /// inputs. Consequently, \p X and \p Y must be either 1D or 2D tensors. This

--- a/include/glow/Quantization/Quantization.h
+++ b/include/glow/Quantization/Quantization.h
@@ -66,13 +66,16 @@ generateNodeQuantizationInfos(Context &ctx, const Function *F,
 /// This method clones original function \p F and caller is responsible for
 /// cleaning up/erasing original function \p F if needed. Any nodes of kinds
 /// contained in \p doNotQuantizeKinds will not be quantized, even if a profile
-/// was gathered for them and the backend supports the quantized operation.
-/// \returns a new quantized function.
+/// was gathered for them and the backend supports the quantized operation. If
+/// \p enableRowwise is true, during quantization, all quantized FullyConnected
+/// nodes will be converted to RowwiseQuantizedFullyConnected. \returns a new
+/// quantized function.
 Function *
 quantizeFunction(const ExecutionEngine &EE,
                  llvm::ArrayRef<NodeQuantizationInfo> quantizationInfos,
                  Function *F, llvm::StringRef newFuncName = "",
-                 const KindSet &doNotQuantizeKinds = {});
+                 const KindSet &doNotQuantizeKinds = {},
+                 bool enableRowwise = false);
 
 } // namespace quantization
 } // namespace glow

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -31,6 +31,14 @@
 
 using namespace glow;
 
+/// -enable-rowwise : Command line option to enable rowwise quantized
+/// fullyconnected in quantization producure.
+bool enableRowwiseOpt;
+static llvm::cl::opt<bool, true>
+    enableRowwiseF("enable-rowwise",
+                   llvm::cl::desc("Enable rowwise quantized fully connected."),
+                   llvm::cl::location(enableRowwiseOpt), llvm::cl::init(false));
+
 namespace {
 llvm::cl::OptionCategory loaderCat("Loader Options");
 
@@ -254,7 +262,8 @@ void Loader::compile(Context &ctx) {
 
     // Quantize the graph based on the captured profile.
     auto *Q = quantization::quantizeFunction(
-        EE_, quantizationInfos, F_, oldName, keepOriginalPrecisionForNodes);
+        EE_, quantizationInfos, F_, oldName, keepOriginalPrecisionForNodes,
+        enableRowwiseOpt);
 
     // Erase the original function so that the redundant variables that are only
     // referenced by the original function will be removed.


### PR DESCRIPTION
*Description*:
This PR adds a option to enable RowwiseQuantizedFullyConnected in Glow's quantization procedure:
When a FC node needs to be quantized, if both of the conditions are satisfied, we replace the quantized FC node by RowwiseQuantizedFullyConnected:
1. The weights of this FC is constant.
2. -enable-rowwise is set or set enableRowwise param in                                                                                                        
  quantization::quantizeFunction to true. In unittest, the later one is used.
 
*Testing*:
Added unittest.
Also manually checked -enable-rowwise opt.

*Documentation*:
[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
