### PR TITLE
[ONNX] Add a partial support for the Pad operator

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -224,6 +224,9 @@ public:
   /// @name High-level, operation-level IRBuilder.
   ///@{
 
+  PadNode *createPad(llvm::StringRef name, NodeValue input, TypeRef outTy,
+                     unsigned_t mode, llvm::ArrayRef<int> pads, float value);
+
   ConvolutionNode *createConv(llvm::StringRef name, NodeValue input,
                               NodeValue filter, NodeValue bias, TypeRef outTy,
                               llvm::ArrayRef<unsigned_t> kernels,

--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -146,6 +146,9 @@ inline std::pair<size_t, size_t> calculateConvPoolOutputDims(
   return {outsx, outsy};
 }
 
+/// Modes of the padding operation.
+enum PaddingMode { CONSTANT = 0, REFLECT, EDGE };
+
 /// Support for hashing the Nodes. This is required for using
 /// llvm::hash_combine.
 class Node;

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -424,6 +424,20 @@ Placeholder *Module::addPlaceholder(Placeholder *ph) {
   return ph;
 }
 
+/// Check if the 'pads' array has the right size.
+static void assertPadsSize(NodeValue input, llvm::ArrayRef<int> pads) {
+  assert((pads.size() == 2 * input.dims().size()) &&
+         "the pads array must contain 2 values per dimensions");
+}
+
+PadNode *Function::createPad(llvm::StringRef name, NodeValue input,
+                             TypeRef outTy, unsigned_t mode,
+                             llvm::ArrayRef<int> pads, float value) {
+  assertPadsSize(input, pads);
+  auto OT = getParent()->uniqueType(*outTy);
+  return addNode(new PadNode(name, OT, input, mode, pads, value));
+}
+
 /// Check the kernel size for Conv/Pooling ops.
 static void checkKernelSize(ShapeNHWC idim, llvm::ArrayRef<unsigned_t> kernels,
                             llvm::ArrayRef<unsigned_t> pads) {
@@ -694,14 +708,14 @@ Node *Function::createBroadcast(llvm::StringRef name, NodeValue input,
     }
   }
 
-  // Reshape the input node to same number of dimensions as new shape, but with
-  // 1s in place of to-be-brodacasted dimensions.
+  // Reshape the input node to same number of dimensions as new shape, but
+  // with 1s in place of to-be-broadcasted dimensions.
   Node *currNode =
       createReshape(name.str() + ".reshape", input,
                     llvm::ArrayRef<size_t>(reshapeDims, newShape.size()));
 
-  // Create a Tile (which is really a Concat) in each direction that needs to be
-  // broadcasted.
+  // Create a Tile (which is really a Concat) in each direction that needs to
+  // be broadcasted.
   for (size_t i = 0; i < newShape.size(); i++) {
     if (reshapeDims[i] == 1 && newShape[i] != 1) {
       currNode = createTile(name.str() + ".tile" + std::to_string(i), currNode,
@@ -753,8 +767,8 @@ ConcatNode *Function::createConcat(llvm::StringRef name,
 
   ShapeVector shape(inDim.begin(), inDim.end());
 
-  // We are stacking the tensors along a specific dimension. This means that we
-  // increase the size of the tensor along this dimension.
+  // We are stacking the tensors along a specific dimension. This means that
+  // we increase the size of the tensor along this dimension.
   shape[dimension] = 0;
   for (auto I : inputs) {
     shape[dimension] += I.getType()->dims()[dimension];
@@ -907,9 +921,9 @@ ReshapeNode *Function::createExpandDims(llvm::StringRef name, NodeValue input,
                                         llvm::ArrayRef<size_t> axes) {
   assert(!axes.empty() && "Parameter `axes` must be provided.");
 
-  // Dimensions provided in axes are for the output tensor, so we sort them and
-  // unique them to make sure they are processed correctly and in the right
-  // order.
+  // Dimensions provided in axes are for the output tensor, so we sort them
+  // and unique them to make sure they are processed correctly and in the
+  // right order.
   ShapeVector shapeAxes(axes.begin(), axes.end());
   std::sort(shapeAxes.begin(), shapeAxes.end());
   shapeAxes.erase(std::unique(shapeAxes.begin(), shapeAxes.end()),
@@ -937,7 +951,8 @@ ReshapeNode *Function::createExpandDims(llvm::StringRef name, NodeValue input,
     }
   }
 
-  // Create a reshape of the original data with the newly determined dimensions.
+  // Create a reshape of the original data with the newly determined
+  // dimensions.
   return createReshape(name.str() + ".expanddims", input, newDims);
 }
 
@@ -1015,11 +1030,11 @@ ARITHMETIC_FUN_DEF(Pow);
 #undef ARITHMETIC_FUN_DEF
 
 /// This helper function is used only by the functions creating boolean
-/// operations like createCmpEQ and createCmpLTE to compute their output types.
-/// The output type is computed based on the type \p T of the operand of the
-/// logical operation. In case of a quantized type we provide concrete scale and
-/// offset for the type as we know that the output of a boolean operation could
-/// be only 0 or 1.
+/// operations like createCmpEQ and createCmpLTE to compute their output
+/// types. The output type is computed based on the type \p T of the operand
+/// of the logical operation. In case of a quantized type we provide concrete
+/// scale and offset for the type as we know that the output of a boolean
+/// operation could be only 0 or 1.
 ///
 /// \returns the output type for a boolean operation.
 static TypeRef getResultTypeOfBooleanOp(Module &M, TypeRef T) {
@@ -1174,8 +1189,8 @@ Node *Function::createBroadcastedBatchMatMul(llvm::StringRef name,
   assert(MMN->getResult().dims()[1] == P &&
          "Incorrect resulting dimension for batch matmul");
 
-  // Reshape the result back to the expected batch output shape, with the first
-  // dimension the number of batches.
+  // Reshape the result back to the expected batch output shape, with the
+  // first dimension the number of batches.
   return createReshape(name.str() + ".reshapeResult", MMN, {numBatches, N, P});
 }
 
@@ -1220,8 +1235,9 @@ BatchedReduceAddNode *Function::createBatchedReduceAdd(llvm::StringRef name,
                                                        TypeRef outTy,
                                                        NodeValue batch,
                                                        unsigned_t axis) {
-  // Calculate the expected total number of elements in the output tensor based
-  // on the number of elements in the batch divided by the axis dimension.
+  // Calculate the expected total number of elements in the output tensor
+  // based on the number of elements in the batch divided by the axis
+  // dimension.
   const size_t outNumElements = batch.getType()->size() / batch.dims()[axis];
   (void)outNumElements;
   assert(outTy->size() == outNumElements &&
@@ -1563,9 +1579,9 @@ Node *Function::createBatchBoxCox(llvm::StringRef name, NodeValue data,
   auto *BL2 = createBroadcast(name.str() + ".broadcast", lambda2, data.dims(),
                               /*axis=*/1);
 
-  // Add a small epsilon to lambda1 so that we can avoid dividing by zero later.
-  // It doesn't matter that this is technically incorrect because the final
-  // Select will discard the results of this computation.
+  // Add a small epsilon to lambda1 so that we can avoid dividing by zero
+  // later. It doesn't matter that this is technically incorrect because the
+  // final Select will discard the results of this computation.
   auto *eps = createSplat(name.str() + ".eps", BL1->getNthResult(0).getType(),
                           std::numeric_limits<float>::min());
   auto *EBL1 = createAdd(name.str() + ".lambda1eps", BL1, eps);
@@ -1931,7 +1947,8 @@ void Function::createSimpleRNN(Context &ctx, llvm::StringRef namePrefix,
                           getPRNG());
   ctx.allocate(Bhy)->init(glow::Tensor::InitKind::Broadcast, b, getPRNG());
 
-  // Un-roll backpropogation through time as a loop with the shared parameters.
+  // Un-roll backpropogation through time as a loop with the shared
+  // parameters.
   for (unsigned t = 0; t < timeSteps; t++) {
     auto fc1Name = nameBase + ".fc1." + std::to_string(t);
     auto *FC1 = createFullyConnected(fc1Name, Ht, Whh, Bhh);
@@ -2279,9 +2296,9 @@ Function *Function::clone(llvm::StringRef newName,
     newF->addNode(copy);
   }
 
-  // At this point we have a new invalid function that points into nodes in the
-  // original function. Here we update the links between the nodes in the new
-  // function.
+  // At this point we have a new invalid function that points into nodes in
+  // the original function. Here we update the links between the nodes in the
+  // new function.
   for (auto &N : newF->getNodes()) {
     // Fix each one of the inputs of this node.
     for (unsigned inp = 0, e = N.getNumInputs(); inp < e; inp++) {
@@ -2385,7 +2402,8 @@ bool Function::verify() const {
     isValid &= insertAndReport(nameToNode, N, *this);
   }
 
-  // Any node referenced by one of the graph nodes should be part of the Graph.
+  // Any node referenced by one of the graph nodes should be part of the
+  // Graph.
   for (const auto &N : nodes_) {
     for (size_t idx = 0, e = N.getNumInputs(); idx < e; ++idx) {
       auto &input = N.getNthInput(idx);
@@ -2430,9 +2448,9 @@ bool Function::verify() const {
           "Constants can never be used as an overwritten input",
           isa<Constant>(nthInputNode), false, nthInputNode);
 
-      // Unlike Constants, Placeholders can be used at most once as overwritten
-      // inputs. Keep a map of Placeholders to Nodes that used them as
-      // overwritten inputs, which is also used later to check for
+      // Unlike Constants, Placeholders can be used at most once as
+      // overwritten inputs. Keep a map of Placeholders to Nodes that used
+      // them as overwritten inputs, which is also used later to check for
       // read-after-write dependence violations.
       const auto *ph = dyn_cast<Placeholder>(nthInputNode);
       if (!ph) {

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -284,7 +284,12 @@ static bool verifyRegression(NodeValue src, NodeValue dest,
          checkSameType(dest, expected, dest.getNode());
 }
 
-bool PadNode::verify() const { return true; }
+bool PadNode::verify() const {
+  // Pad is currently only supported for constant padding.
+  return expectCompareTrue("only the 'constant' mode is currrently supported",
+                           getMode() == PaddingMode::CONSTANT, true,
+                           getResult().getNode());
+}
 
 bool ConvolutionNode::verify() const {
   return verifyConvolution(getInput(), getResult(), getFilter(), getBias(),

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -284,6 +284,8 @@ static bool verifyRegression(NodeValue src, NodeValue dest,
          checkSameType(dest, expected, dest.getNode());
 }
 
+bool PadNode::verify() const { return true; }
+
 bool ConvolutionNode::verify() const {
   return verifyConvolution(getInput(), getResult(), getFilter(), getBias(),
                            Kernels_, Strides_, Pads_, Group_);

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -681,6 +681,59 @@ llvm::Error ONNXModelLoader::loadOperator(const ONNX_NAMESPACE::NodeProto &op) {
     return llvm::Error::success();
   }
 
+  if (typeName == "Pad") {
+    // Input
+    NodeValue input;
+    ASSIGN_VALUE_OR_RETURN_ERR(input,
+                               getNodeValueOrCreateConstantByName(op.input(0)));
+    auto inputDims = input.dims();
+    auto numDims = inputDims.size();
+
+    // Padding properties.
+    unsigned_t mode = PaddingMode::CONSTANT; // default is constant.
+    if (dict.count("mode")) {
+      std::string modeStr;
+      ASSIGN_VALUE_OR_RETURN_ERR(modeStr, loadStr(dict["mode"]));
+      if (modeStr == "constant") {
+        mode = PaddingMode::CONSTANT;
+      } else if (modeStr == "reflect") {
+        mode = PaddingMode::REFLECT;
+      } else if (modeStr == "edge") {
+        mode = PaddingMode::EDGE;
+      } else {
+        RETURN_ERR("Pad: Invalid mode");
+      }
+    }
+    float value = 0.f; // Default
+    if (dict.count("value")) {
+      ASSIGN_VALUE_OR_RETURN_ERR(value, loadFloat(dict["value"]));
+    }
+
+    // Pads are mandatory.
+    RETURN_ERR_IF_NOT(dict.count("pads"),
+                      "Pad: The 'pads' property is mandatory");
+    auto pads = getShape<int>(dict.at("pads"));
+    RETURN_ERR_IF_NOT(
+        (pads.size() == 2 * numDims),
+        "Pad: the 'pads' array must contain 2 values per dimensions");
+
+    // Compute the output type.
+    std::vector<size_t> outDims(numDims);
+    for (unsigned_t i = 0; i < numDims; i++) {
+      auto new_dim = inputDims[i] + pads[i] + pads[i + numDims];
+      RETURN_ERR_IF_NOT(new_dim > 0,
+                        "The padding can't remove all elements of a dimension");
+      outDims[i] = new_dim;
+    }
+    auto outTy = G_.getParent()->uniqueType(ElemKind::FloatTy, outDims);
+
+    // Create the IR node.
+    Node *N = G_.createPad(opName, input, outTy, mode, pads, value);
+    addNodeAsOutput(op, N);
+
+    return llvm::Error::success();
+  }
+
   RETURN_ERR("Failed to load operator.");
 }
 

--- a/tests/models/onnxModels/padConstant.onnxtxt
+++ b/tests/models/onnxModels/padConstant.onnxtxt
@@ -1,0 +1,67 @@
+ir_version: 3
+producer_name: "test4glow"
+opset_import { 
+  version: 7
+}
+
+graph {
+  name: "test-model"
+  node {
+    input: "data"
+    output: "out"
+    name: "op"
+    op_type: "Pad"
+    
+    attribute {
+      name: "mode"
+      s: "constant"
+      type: STRING
+    }
+    
+    attribute {
+      name: "value"
+      f: 2.55
+      type: FLOAT
+    }
+   
+    attribute {
+      name: "pads"
+      ints: 1
+      ints: 2
+      ints: -2
+      ints: 0
+      
+      ints: 0
+      ints: -2
+      ints: 1
+      ints: 2
+     
+      type: INTS
+    }
+  }
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: FLOAT
+        shape {
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 6
+          }
+          dim {
+            dim_value: 5
+          }
+          dim {
+            dim_value: 7
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "out"
+  }
+}

--- a/tests/models/onnxModels/padConstantPositive.onnxtxt
+++ b/tests/models/onnxModels/padConstantPositive.onnxtxt
@@ -1,0 +1,67 @@
+ir_version: 3
+producer_name: "test4glow"
+opset_import { 
+  version: 7
+}
+
+graph {
+  name: "test-model"
+  node {
+    input: "data"
+    output: "out"
+    name: "op"
+    op_type: "Pad"
+    
+    attribute {
+      name: "mode"
+      s: "constant"
+      type: STRING
+    }
+    
+    attribute {
+      name: "value"
+      f: 2.55
+      type: FLOAT
+    }
+   
+    attribute {
+      name: "pads"
+      ints: 1
+      ints: 2
+      ints: 3
+      ints: 4
+      
+      ints: 0
+      ints: 3
+      ints: 1
+      ints: 2
+     
+      type: INTS
+    }
+  }
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: FLOAT
+        shape {
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 6
+          }
+          dim {
+            dim_value: 5
+          }
+          dim {
+            dim_value: 7
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "out"
+  }
+}

--- a/tests/models/onnxModels/padDefault.onnxtxt
+++ b/tests/models/onnxModels/padDefault.onnxtxt
@@ -1,0 +1,54 @@
+ir_version: 3
+producer_name: "test4glow"
+opset_import { 
+  version: 7
+}
+
+graph {
+  name: "test-model"
+  node {
+    input: "data"
+    output: "out"
+    name: "op"
+    op_type: "Pad"
+    attribute {
+      name: "pads"
+      ints: 1
+      ints: 2
+      ints: -2
+      ints: 0
+      
+      ints: 0
+      ints: -2
+      ints: 1
+      ints: 2
+     
+      type: INTS
+    }
+  }
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: FLOAT
+        shape {
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 6
+          }
+          dim {
+            dim_value: 5
+          }
+          dim {
+            dim_value: 7
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "out"
+  }
+}

--- a/tests/models/onnxModels/padEdge.onnxtxt
+++ b/tests/models/onnxModels/padEdge.onnxtxt
@@ -1,0 +1,61 @@
+ir_version: 3
+producer_name: "test4glow"
+opset_import { 
+  version: 7
+}
+
+graph {
+  name: "test-model"
+  node {
+    input: "data"
+    output: "out"
+    name: "op"
+    op_type: "Pad"
+    
+    attribute {
+      name: "mode"
+      s: "edge"
+      type: STRING
+    }
+       
+    attribute {
+      name: "pads"
+      ints: 1
+      ints: 2
+      ints: -2
+      ints: 0
+      
+      ints: 0
+      ints: -2
+      ints: 1
+      ints: 2
+     
+      type: INTS
+    }
+  }
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: FLOAT
+        shape {
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 6
+          }
+          dim {
+            dim_value: 5
+          }
+          dim {
+            dim_value: 7
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "out"
+  }
+}

--- a/tests/models/onnxModels/padReflect.onnxtxt
+++ b/tests/models/onnxModels/padReflect.onnxtxt
@@ -1,0 +1,61 @@
+ir_version: 3
+producer_name: "test4glow"
+opset_import { 
+  version: 7
+}
+
+graph {
+  name: "test-model"
+  node {
+    input: "data"
+    output: "out"
+    name: "op"
+    op_type: "Pad"
+    
+    attribute {
+      name: "mode"
+      s: "reflect"
+      type: STRING
+    }
+       
+    attribute {
+      name: "pads"
+      ints: 1
+      ints: 2
+      ints: -2
+      ints: 0
+      
+      ints: 0
+      ints: -2
+      ints: 1
+      ints: 2
+     
+      type: INTS
+    }
+  }
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: FLOAT
+        shape {
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 6
+          }
+          dim {
+            dim_value: 5
+          }
+          dim {
+            dim_value: 7
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "out"
+  }
+}

--- a/tests/unittests/onnxImporterTest.cpp
+++ b/tests/unittests/onnxImporterTest.cpp
@@ -17,6 +17,7 @@
 #include "glow/ExecutionEngine/ExecutionEngine.h"
 #include "glow/Graph/Context.h"
 #include "glow/Graph/Graph.h"
+#include "glow/Graph/Nodes.h"
 #include "glow/Importer/ONNXModelLoader.h"
 #include "gtest/gtest.h"
 
@@ -719,4 +720,74 @@ TEST(onnx, importSliceNoAxes) {
   importSliceTest("sliceNoAxes.onnxtxt", "data", {2, 3, 3, 3} /* input */,
                   {0, 1, 1, 1} /* starts */, /* ends: {2, 2, 3, 3} */
                   {2, 1, 2, 2} /* output */);
+}
+
+static void importPad(std::string fileName, const char *inputName,
+                      const llvm::ArrayRef<size_t> inputShape,
+                      const llvm::ArrayRef<ssize_t> starts,
+                      const llvm::ArrayRef<ssize_t> ends, PaddingMode mode,
+                      float value) {
+  ExecutionEngine EE{BackendKind::Interpreter};
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+
+  std::string NetFilename = std::string("tests/models/onnxModels/") + fileName;
+  Context ctx;
+  Placeholder *graphOutputVar;
+  // Destroy the loader after the graph is loaded since the following execution
+  // will not depend on anyting from the loader.
+  {
+    Tensor data;
+    getNCHWData(&data, inputShape[0], inputShape[1], inputShape[2],
+                inputShape[3]);
+    ONNXModelLoader onnxLD(NetFilename, {inputName}, {&data.getType()}, *F);
+    graphOutputVar = EXIT_ON_ERR(onnxLD.getSingleOutput());
+    ctx.allocate(mod.getPlaceholders());
+    updateInputPlaceholdersByName(ctx, &mod, {inputName}, {&data});
+  }
+
+  // ONNX importer loads a Pad operator and adds to the IR:
+  // - a Pad node
+
+  // Check the graph structure.
+  auto *saveNode = getSaveNodeFromDest(graphOutputVar);
+  auto *node = saveNode->getInput().getNode();
+  auto *padNode = llvm::dyn_cast<PadNode>(node);
+  EXPECT_NE(nullptr, padNode);
+
+  // Check Pad node properties.
+  assert(padNode->getMode() == mode);
+  if (mode == PaddingMode::CONSTANT) {
+    EXPECT_EQ(value, padNode->getValue());
+  }
+  // Check the Pad node output shape.
+  std::vector<size_t> expectedOutputShape(inputShape.size());
+  for (unsigned int i = 0; i < inputShape.size(); i++) {
+    expectedOutputShape[i] =
+        size_t(ssize_t(inputShape[i]) + starts[i] + ends[i]);
+  }
+  EXPECT_TRUE(padNode->getResult().dims().vec() == expectedOutputShape);
+}
+
+TEST(onnx, importPadDefault) {
+  importPad("padDefault.onnxtxt", "data", {4, 6, 5, 7} /* input */,
+            {1, 2, -2, 0} /* starts */, {0, -2, 1, 2} /* ends */,
+            PaddingMode::CONSTANT, 0.f);
+}
+
+TEST(onnx, importPadConstant) {
+  importPad("padConstant.onnxtxt", "data", {4, 6, 5, 7} /* input */,
+            {1, 2, -2, 0} /* starts */, {0, -2, 1, 2} /* ends */,
+            PaddingMode::CONSTANT, 2.55f);
+}
+
+TEST(onnx, importPadReflect) {
+  importPad("padReflect.onnxtxt", "data", {4, 6, 5, 7} /* input */,
+            {1, 2, -2, 0} /* starts */, {0, -2, 1, 2} /* ends */,
+            PaddingMode::REFLECT, 0.f /* any */);
+}
+TEST(onnx, importPadEdge) {
+  importPad("padEdge.onnxtxt", "data", {4, 6, 5, 7} /* input */,
+            {1, 2, -2, 0} /* starts */, {0, -2, 1, 2} /* ends */,
+            PaddingMode::EDGE, 0.f /* any */);
 }

--- a/tests/unittests/onnxImporterTest.cpp
+++ b/tests/unittests/onnxImporterTest.cpp
@@ -726,7 +726,7 @@ static void importPad(std::string fileName, const char *inputName,
                       const llvm::ArrayRef<size_t> inputShape,
                       const llvm::ArrayRef<ssize_t> starts,
                       const llvm::ArrayRef<ssize_t> ends, PaddingMode mode,
-                      float value) {
+                      float value, bool testOutput) {
   ExecutionEngine EE{BackendKind::Interpreter};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -767,27 +767,66 @@ static void importPad(std::string fileName, const char *inputName,
         size_t(ssize_t(inputShape[i]) + starts[i] + ends[i]);
   }
   EXPECT_TRUE(padNode->getResult().dims().vec() == expectedOutputShape);
+
+  // Currently, only constant with positive pads is supported at lowering.
+  // We just consider this test case.
+  if (testOutput && mode == PaddingMode::CONSTANT) {
+    // Compile&run the graph, and check the output.
+    EE.compile(CompilationMode::Infer, F);
+    EE.run(ctx);
+    auto result = ctx.get(graphOutputVar)->getHandle();
+    EXPECT_TRUE(result.dims().vec() == expectedOutputShape);
+    size_t indexOutput = 0;
+    size_t indexinput = 0;
+    for (size_t n = 0; n < expectedOutputShape[0]; n++) {
+      for (size_t c = 0; c < expectedOutputShape[1]; c++) {
+        for (size_t h = 0; h < expectedOutputShape[2]; h++) {
+          for (size_t w = 0; w < expectedOutputShape[3]; w++) {
+            float expectedValue = value;
+            if ((n >= size_t(starts[0])) &&
+                (n < (expectedOutputShape[0] - size_t(ends[0]))) &&
+                (c >= size_t(starts[1])) &&
+                (c < (expectedOutputShape[1] - size_t(ends[1]))) &&
+                (h >= size_t(starts[2])) &&
+                (h < (expectedOutputShape[2] - size_t(ends[2]))) &&
+                (w >= size_t(starts[3])) &&
+                (w < (expectedOutputShape[3] - size_t(ends[3])))) {
+              // This is the way 'getNCHWData' initializes data.
+              expectedValue = indexinput++;
+            }
+            EXPECT_FLOAT_EQ(result.raw(indexOutput++), expectedValue);
+          }
+        }
+      }
+    }
+  }
 }
 
 TEST(onnx, importPadDefault) {
   importPad("padDefault.onnxtxt", "data", {4, 6, 5, 7} /* input */,
             {1, 2, -2, 0} /* starts */, {0, -2, 1, 2} /* ends */,
-            PaddingMode::CONSTANT, 0.f);
+            PaddingMode::CONSTANT, 0.f, false);
 }
 
 TEST(onnx, importPadConstant) {
   importPad("padConstant.onnxtxt", "data", {4, 6, 5, 7} /* input */,
             {1, 2, -2, 0} /* starts */, {0, -2, 1, 2} /* ends */,
-            PaddingMode::CONSTANT, 2.55f);
+            PaddingMode::CONSTANT, 2.55f, false);
 }
 
 TEST(onnx, importPadReflect) {
   importPad("padReflect.onnxtxt", "data", {4, 6, 5, 7} /* input */,
             {1, 2, -2, 0} /* starts */, {0, -2, 1, 2} /* ends */,
-            PaddingMode::REFLECT, 0.f /* any */);
+            PaddingMode::REFLECT, 0.f /* any */, false);
 }
 TEST(onnx, importPadEdge) {
   importPad("padEdge.onnxtxt", "data", {4, 6, 5, 7} /* input */,
             {1, 2, -2, 0} /* starts */, {0, -2, 1, 2} /* ends */,
-            PaddingMode::EDGE, 0.f /* any */);
+            PaddingMode::EDGE, 0.f /* any */, false);
+}
+
+TEST(onnx, importPadConstantPositive) {
+  importPad("padConstantPositive.onnxtxt", "data", {4, 6, 5, 7} /* input */,
+            {1, 2, 3, 4} /* starts */, {0, 3, 1, 2} /* ends */,
+            PaddingMode::CONSTANT, 2.55f, true);
 }

--- a/tools/ClassGen/MemberType.cpp
+++ b/tools/ClassGen/MemberType.cpp
@@ -38,3 +38,13 @@ MemberTypeInfo kVectorSizeTTypeInfo{
 MemberTypeInfo kVectorNodeValueTypeInfo{
     MemberType::VectorNodeValue, "NodeValueArrayRef", "std::vector<NodeHandle>",
     "std::vector<NodeValue>"};
+// We currently use 'unsigned_t' to represent a enum in the generic API. It can
+// carry fully the enum information even of the signess of enum is
+// implementation defined.
+// C++03: The underlying type of an enumeration is an integral type that can
+// represent all the enumerator values defined in the enumeration. It is
+// implementation-defined which integral type is used as the underlying type for
+// an enumeration except that the underlying type shall not be larger than int
+// unless the value of an enumerator cannot fit in an int or unsigned int.
+MemberTypeInfo kEnumTypeInfo{MemberType::Unsigned, "unsigned_t", "unsigned_t",
+                             "unsigned_t"};

--- a/tools/ClassGen/MemberType.cpp
+++ b/tools/ClassGen/MemberType.cpp
@@ -29,6 +29,9 @@ MemberTypeInfo kVectorFloatTypeInfo{MemberType::VectorFloat,
 MemberTypeInfo kVectorUnsignedTypeInfo{
     MemberType::VectorUnsigned, "llvm::ArrayRef<unsigned_t>",
     "std::vector<unsigned_t>", "std::vector<unsigned_t>"};
+MemberTypeInfo kVectorSignedTypeInfo{MemberType::VectorSigned,
+                                     "llvm::ArrayRef<int>", "std::vector<int>",
+                                     "std::vector<int>"};
 MemberTypeInfo kVectorSizeTTypeInfo{
     MemberType::VectorSizeT, "llvm::ArrayRef<size_t>", "std::vector<size_t>",
     "std::vector<size_t>"};

--- a/tools/ClassGen/MemberType.h
+++ b/tools/ClassGen/MemberType.h
@@ -55,6 +55,7 @@ extern MemberTypeInfo kVectorUnsignedTypeInfo;
 extern MemberTypeInfo kVectorSignedTypeInfo;
 extern MemberTypeInfo kVectorSizeTTypeInfo;
 extern MemberTypeInfo kVectorNodeValueTypeInfo;
+extern MemberTypeInfo kEnumTypeInfo;
 
 inline const char *getReturnTypename(const MemberTypeInfo *typeInfo) {
   return typeInfo->returnTypename.c_str();

--- a/tools/ClassGen/MemberType.h
+++ b/tools/ClassGen/MemberType.h
@@ -27,6 +27,7 @@ enum class MemberType : unsigned {
   Boolean,
   String,
   VectorFloat,
+  VectorSigned,
   VectorUnsigned,
   VectorSizeT,
   VectorNodeValue,
@@ -51,6 +52,7 @@ extern MemberTypeInfo kBooleanTypeInfo;
 extern MemberTypeInfo kStringTypeInfo;
 extern MemberTypeInfo kVectorFloatTypeInfo;
 extern MemberTypeInfo kVectorUnsignedTypeInfo;
+extern MemberTypeInfo kVectorSignedTypeInfo;
 extern MemberTypeInfo kVectorSizeTTypeInfo;
 extern MemberTypeInfo kVectorNodeValueTypeInfo;
 
@@ -74,6 +76,7 @@ inline const char *getReturnTypename(MemberType type) {
                                "bool",
                                "llvm::StringRef",
                                "llvm::ArrayRef<float>",
+                               "llvm::ArrayRef<int>",
                                "llvm::ArrayRef<unsigned_t>",
                                "llvm::ArrayRef<size_t>",
                                "NodeValueArrayRef",
@@ -88,6 +91,7 @@ inline const char *getStorageTypename(MemberType type) {
                                 "bool",
                                 "std::string",
                                 "std::vector<float>",
+                                "std::vector<int>",
                                 "std::vector<unsigned_t>",
                                 "std::vector<size_t>",
                                 "std::vector<NodeHandle>",
@@ -102,6 +106,7 @@ inline const char *getCtorArgTypename(MemberType type) {
                                 "bool",
                                 "std::string",
                                 "std::vector<float>",
+                                "std::vector<int>",
                                 "std::vector<unsigned_t>",
                                 "std::vector<size_t>",
                                 "std::vector<NodeValue>",

--- a/tools/ClassGen/NodeBuilder.cpp
+++ b/tools/ClassGen/NodeBuilder.cpp
@@ -169,6 +169,8 @@ NodeBuilder &NodeBuilder::addMember(MemberType type, const std::string &name) {
     typeInfo = &kVectorSizeTTypeInfo;
   } else if (type == MemberType::VectorNodeValue) {
     typeInfo = &kVectorNodeValueTypeInfo;
+  } else if (type == MemberType::Enum) {
+    typeInfo = &kEnumTypeInfo;
   } else {
     llvm_unreachable("Type not recognized");
   }

--- a/tools/ClassGen/NodeBuilder.cpp
+++ b/tools/ClassGen/NodeBuilder.cpp
@@ -163,6 +163,8 @@ NodeBuilder &NodeBuilder::addMember(MemberType type, const std::string &name) {
     typeInfo = &kVectorFloatTypeInfo;
   } else if (type == MemberType::VectorUnsigned) {
     typeInfo = &kVectorUnsignedTypeInfo;
+  } else if (type == MemberType::VectorSigned) {
+    typeInfo = &kVectorSignedTypeInfo;
   } else if (type == MemberType::VectorSizeT) {
     typeInfo = &kVectorSizeTTypeInfo;
   } else if (type == MemberType::VectorNodeValue) {
@@ -512,7 +514,8 @@ void NodeBuilder::emitEquator(std::ostream &os) const {
 
 static bool isVectorType(MemberType ty) {
   return ty == MemberType::VectorFloat || ty == MemberType::VectorNodeValue ||
-         ty == MemberType::VectorSizeT || ty == MemberType::VectorUnsigned;
+         ty == MemberType::VectorSizeT || ty == MemberType::VectorUnsigned ||
+         ty == MemberType::VectorSigned;
 }
 
 void NodeBuilder::emitHasher(std::ostream &os) const {

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -58,6 +58,21 @@ int main(int argc, char **argv) {
   //                   Convolution / Pool / FC
   //===--------------------------------------------------------------------===//
 
+  BB.newNode("Pad")
+      .addInput("Input")
+      .addMember(MemberType::Unsigned, "Mode")
+      .addMember(MemberType::VectorSigned, "Pads")
+      .addMember(MemberType::Float, "Value")
+      .addResultFromCtorArg()
+      .setDocstring(
+          "Performs padding of a given input tensor. The Padding information "
+          "must be specified for each dimension of the tensor in Pads (start "
+          "and end padding). In case the padding is negative, it means that "
+          "the tensor must be cropped. Mode defines how extra padding elements "
+          "are created. Supported modes are defined in the PaddingMode enum: "
+          "CONSTANT, REFLECT, EDGE. Value is only used with the CONSTANT "
+          "mode.");
+
   BB.newNode("Convolution")
       .addInput("Input")
       .addInput("Filter")

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -60,7 +60,7 @@ int main(int argc, char **argv) {
 
   BB.newNode("Pad")
       .addInput("Input")
-      .addMember(MemberType::Unsigned, "Mode")
+      .addMember(MemberType::Enum, "Mode")
       .addMember(MemberType::VectorSigned, "Pads")
       .addMember(MemberType::Float, "Value")
       .addResultFromCtorArg()


### PR DESCRIPTION
*Description*: 

This PR adds a partial support for the Pad operator: 1/ a Pad node, 2/ Support of Pad in the ONNX importer, 3/ Some Pad related optimizations. 
ONNX spec: https://github.com/onnx/onnx/blob/master/docs/Operators.md#Pad

This PR is related to a use-case we got where a set of Pad nodes could **all** be merged into Convolution nodes. Due to the fact that Convolution introduces transpose nodes (conv doesn't follow the ONNX/Caffe2 convention and is NHWC), we had to add an extra transpose/pad sink optim. In our use case, all Pad nodes disappear at optimization, so we decided not to spend (much) more effort supporting Pad at the instruction level and in the various backends. This will need to be implemented at a time a real-use case appears with this need or when a 100% coverage of ONNX will be needed.

Notes:
- we discussed a bit padding with @beicy here: #2037
- that ClangFormat decided to change the formatting of some comments that are not part of the Pad code.

*Testing*: 3 families of tests: 1/ Pad ONNX import, 2/ Pad merge into convolution, 3/ Sink transpose over Pad

*Documentation*:
N/A
