### PR TITLE
[Error handling] Remove last asserts from loaders

### DIFF
--- a/include/glow/Importer/Caffe2ModelLoader.h
+++ b/include/glow/Importer/Caffe2ModelLoader.h
@@ -70,10 +70,13 @@ public:
   /// \p netWeightFilename, and populates the network in \p F.
   /// The list \p types and \p names are used to initialized the inputs and
   /// outputs with specific names and types.
+  /// If \p errPtr is not null then if an error occurs it will get assigned
+  /// there otherwise if an error occurs it will abort.
   Caffe2ModelLoader(const std::string &netDescFilename,
                     const std::string &netWeightFilename,
                     llvm::ArrayRef<const char *> names,
-                    llvm::ArrayRef<TypeRef> types, Function &F);
+                    llvm::ArrayRef<TypeRef> types, Function &F,
+                    llvm::Error *errPtr = nullptr);
 };
 
 } // namespace glow

--- a/include/glow/Importer/ONNXIFIModelLoader.h
+++ b/include/glow/Importer/ONNXIFIModelLoader.h
@@ -27,7 +27,10 @@ namespace glow {
 
 class ONNXIFIModelLoader : public ONNXModelLoader {
 private:
-  ONNXIFIModelLoader(Function &F) : ONNXModelLoader(F) {}
+  /// If \p errPtr is not null then if an error occurs it will get assigned
+  /// there otherwise if an error occurs it will abort.
+  ONNXIFIModelLoader(Function &F, llvm::Error *errPtr = nullptr)
+      : ONNXModelLoader(F, errPtr) {}
 
   /// Load the inputs from the GraphProto. This is useful when the
   /// initializers are not available.
@@ -62,9 +65,10 @@ public:
   /// the \p onnxModel is not supported by the ONNX model parser.
   /// \returns std::vector of Glow operation kind and element kind otherwise.
   ///          It represents a mapping between ONNX nodes and Glow operations.
+  /// \returns llvm::Error if an error was encountered
   ///
   /// \param onnxModel contains a single ONNX operator.
-  static std::vector<std::pair<Kinded::Kind, ElemKind>>
+  static llvm::Expected<std::vector<std::pair<Kinded::Kind, ElemKind>>>
   parseOperators(const void *onnxModel, size_t onnxModelSize);
 };
 

--- a/include/glow/Importer/ONNXIFIModelLoader.h
+++ b/include/glow/Importer/ONNXIFIModelLoader.h
@@ -65,7 +65,7 @@ public:
   /// the \p onnxModel is not supported by the ONNX model parser.
   /// \returns std::vector of Glow operation kind and element kind otherwise.
   ///          It represents a mapping between ONNX nodes and Glow operations.
-  /// \returns llvm::Error if an error was encountered
+  /// \returns llvm::Error if an error was encountered.
   ///
   /// \param onnxModel contains a single ONNX operator.
   static llvm::Expected<std::vector<std::pair<Kinded::Kind, ElemKind>>>

--- a/include/glow/Importer/ONNXModelLoader.h
+++ b/include/glow/Importer/ONNXModelLoader.h
@@ -128,7 +128,9 @@ protected:
 
 public:
   /// Creates a ONNX model loader to build \p F.
-  ONNXModelLoader(Function &F);
+  /// If \p errPtr is not null then if an error occurs it will get assigned
+  /// there otherwise if an error occurs it will abort.
+  ONNXModelLoader(Function &F, llvm::Error *errPtr = nullptr);
 
   /// \returns Expected<ModelProto> if a ModelProto can be constructed from the
   /// contents of the file \p filename and Error otherwise.
@@ -154,9 +156,12 @@ public:
   /// serialized in \p modelDescFilename and populates the network into \p F.
   /// The types in \p types match the list of names \p tensorNames and used as
   /// inputs to the network.
+  /// If \p errPtr is not null then if an error occurs it will get assigned
+  /// there otherwise if an error occurs it will abort.
   ONNXModelLoader(const std::string &modelDescFilename,
                   llvm::ArrayRef<const char *> tensorNames,
-                  llvm::ArrayRef<TypeRef> types, Function &F);
+                  llvm::ArrayRef<TypeRef> types, Function &F,
+                  llvm::Error *errPtr = nullptr);
 };
 
 } // namespace glow

--- a/include/glow/Importer/ProtobufLoader.h
+++ b/include/glow/Importer/ProtobufLoader.h
@@ -131,8 +131,11 @@ public:
   /// Constructs new ProtobufLoader object. It will populate the network into \p
   /// F. The list \p types and \p names are used to initialized the inputs and
   /// outputs with specific names and types.
+  /// If \p errPtr is not null then if an error occurs it will get assigned
+  /// there otherwise if an error occurs it will abort.
   ProtobufLoader(llvm::ArrayRef<const char *> tensorNames,
-                 llvm::ArrayRef<TypeRef> types, Function &F);
+                 llvm::ArrayRef<TypeRef> types, Function &F,
+                 llvm::Error *errPtr = nullptr);
 
   virtual ~ProtobufLoader();
 

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -1088,8 +1088,8 @@ Caffe2ModelLoader::Caffe2ModelLoader(const std::string &netDescFilename,
                                      llvm::ArrayRef<TypeRef> types, Function &F,
                                      llvm::Error *errPtr)
     : CommonOperatorLoader(names, types, F, errPtr) {
-  // lambda to setup the Caffe2ModelLoader and return any llvm::Errors that were
-  // raised
+  // Lambda to setup the Caffe2ModelLoader and return any llvm::Errors that were
+  // raised.
   auto setup = [&]() -> llvm::Error {
     // The caffe2 network descriptor that we are deserializing.
     caffe2::NetDef networkDef;

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -1088,6 +1088,11 @@ Caffe2ModelLoader::Caffe2ModelLoader(const std::string &netDescFilename,
                                      llvm::ArrayRef<TypeRef> types, Function &F,
                                      llvm::Error *errPtr)
     : CommonOperatorLoader(names, types, F, errPtr) {
+  // if errPtr already contains an error then don't continue with constructor
+  if (errPtr && *errPtr) {
+    return;
+  }
+
   // Lambda to setup the Caffe2ModelLoader and return any llvm::Errors that were
   // raised.
   auto setup = [&]() -> llvm::Error {

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -1085,14 +1085,29 @@ llvm::Error Caffe2ModelLoader::loadWeights(caffe2::NetDef &net) {
 Caffe2ModelLoader::Caffe2ModelLoader(const std::string &netDescFilename,
                                      const std::string &netWeightFilename,
                                      llvm::ArrayRef<const char *> names,
-                                     llvm::ArrayRef<TypeRef> types, Function &F)
-    : CommonOperatorLoader(names, types, F) {
-  // The caffe2 network descriptor that we are deserializing.
-  caffe2::NetDef networkDef = EXIT_ON_ERR(loadProtoFile(netDescFilename));
+                                     llvm::ArrayRef<TypeRef> types, Function &F,
+                                     llvm::Error *errPtr)
+    : CommonOperatorLoader(names, types, F, errPtr) {
+  // lambda to setup the Caffe2ModelLoader and return any llvm::Errors that were
+  // raised
+  auto setup = [&]() -> llvm::Error {
+    // The caffe2 network descriptor that we are deserializing.
+    caffe2::NetDef networkDef;
+    ASSIGN_VALUE_OR_RETURN_ERR(networkDef, loadProtoFile(netDescFilename));
 
-  // The caffe2 weights that we are deserializing.
-  caffe2::NetDef weightsDef = EXIT_ON_ERR(loadProtoFile(netWeightFilename));
+    // The caffe2 weights that we are deserializing.
+    caffe2::NetDef weightsDef;
+    ASSIGN_VALUE_OR_RETURN_ERR(weightsDef, loadProtoFile(netWeightFilename));
 
-  TEMP_EXIT_ON_ERR(loadWeights(weightsDef));
-  TEMP_EXIT_ON_ERR(loadNetwork(networkDef));
+    RETURN_IF_ERR(loadWeights(weightsDef));
+    RETURN_IF_ERR(loadNetwork(networkDef));
+
+    return llvm::Error::success();
+  };
+
+  if (errPtr) {
+    *errPtr = setup();
+  } else {
+    EXIT_ON_ERR(setup());
+  }
 }

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -843,6 +843,11 @@ ONNXModelLoader::ONNXModelLoader(const std::string &modelDescFilename,
                                  llvm::ArrayRef<TypeRef> types, Function &F,
                                  llvm::Error *errPtr)
     : CommonOperatorLoader(tensorNames, types, F, errPtr) {
+  // if errPtr already contains an error then don't continue with constructor
+  if (errPtr && *errPtr) {
+    return;
+  }
+
   // Lambda to setup the ONNXModelLoader and return any llvm::Errors that were
   // raised.
   auto setup = [&]() -> llvm::Error {

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -843,8 +843,8 @@ ONNXModelLoader::ONNXModelLoader(const std::string &modelDescFilename,
                                  llvm::ArrayRef<TypeRef> types, Function &F,
                                  llvm::Error *errPtr)
     : CommonOperatorLoader(tensorNames, types, F, errPtr) {
-  // lambda to setup the ONNXModelLoader and return any llvm::Errors that were
-  // raised
+  // Lambda to setup the ONNXModelLoader and return any llvm::Errors that were
+  // raised.
   auto setup = [&]() -> llvm::Error {
     // The ONNX model that we are deserializing.
     ONNX_NAMESPACE::ModelProto modelDef;

--- a/lib/Importer/ProtobufLoader.cpp
+++ b/lib/Importer/ProtobufLoader.cpp
@@ -117,7 +117,7 @@ ProtobufLoader::ProtobufLoader(llvm::ArrayRef<const char *> tensorNames,
   auto setup = [&]() -> llvm::Error {
     RETURN_ERR_IF_NOT(tensorNames.size() == types.size(),
                       "Invalid initialization list");
-    for (unsigned i = 0; i < tensorNames.size(); i++) {
+    for (size_t i = 0, e = tensorNames.size(); i < e; i++) {
       RETURN_ERR_IF_NOT(!hasNodeByName(tensorNames[i]),
                         "Input names have duplicate");
       auto placeholderOrErr =

--- a/lib/Importer/ProtobufLoader.cpp
+++ b/lib/Importer/ProtobufLoader.cpp
@@ -107,8 +107,8 @@ ProtobufLoader::ProtobufLoader(llvm::ArrayRef<const char *> tensorNames,
   // compatible with the version of the headers we compiled against.
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
-  // lambda to setup the ProtobufLoader and return any llvm::Errors that were
-  // raised
+  // Lambda to setup the ProtobufLoader and return any llvm::Errors that were
+  // raised.
   auto setup = [&]() -> llvm::Error {
     RETURN_ERR_IF_NOT(tensorNames.size() == types.size(),
                       "Invalid initialization list");

--- a/lib/Importer/ProtobufLoader.cpp
+++ b/lib/Importer/ProtobufLoader.cpp
@@ -107,6 +107,11 @@ ProtobufLoader::ProtobufLoader(llvm::ArrayRef<const char *> tensorNames,
   // compatible with the version of the headers we compiled against.
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
+  // if errPtr already contains an error then don't continue with constructor
+  if (errPtr && *errPtr) {
+    return;
+  }
+
   // Lambda to setup the ProtobufLoader and return any llvm::Errors that were
   // raised.
   auto setup = [&]() -> llvm::Error {

--- a/lib/Onnxifi/onnxifiGlow.cpp
+++ b/lib/Onnxifi/onnxifiGlow.cpp
@@ -176,8 +176,15 @@ GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxGetBackendCompatibility)(
     return ONNXIFI_STATUS_INVALID_POINTER;
   }
 
-  std::vector<std::pair<glow::Kinded::Kind, glow::ElemKind>> operations =
-      glow::ONNXIFIModelLoader::parseOperators(onnxModel, onnxModelSize);
+  std::vector<std::pair<glow::Kinded::Kind, glow::ElemKind>> operations;
+
+  if (auto operationsOrErr =
+          glow::ONNXIFIModelLoader::parseOperators(onnxModel, onnxModelSize)) {
+    operations = std::move(*operationsOrErr);
+  } else {
+    // TODO also print error
+    return ONNXIFI_STATUS_INTERNAL_ERROR;
+  }
 
   // TODO: Make better error reporting.
   if (operations.empty()) {


### PR DESCRIPTION
*Description*:
This diff removes the last asserts and unhandled errors from the model loading layer. These are the asserts and errors that were in the model loader constructors which makes them uniquely unergonomic to deal with. The general pattern employed here for handling errors that may occur during construction is to have each constructor take an extra parameter that is a pointer to an error and if any errors are raised and if that pointer is not null then assign the error to the error pointer and return early otherwise if an error occurs but the pointer to the error parameter is null then abort. These error pointers get passed down the inheritance chain to each constructor.
This diff also handles any error that may have occurred during model loading in `onnxGetBackendCompatibility()` at the top level and returns a ONNXIFI_STATUS_INTERNAL_ERROR.

*Testing*:
`ninja all`, `ninja check`
ran caffe2 onnx tests with `pytest -s caffe2/python/onnx/test_onnxifi.py` 3/3 tests pass

*Documentation*:
doxygen