### PR TITLE
Fix OpenCL memleak and update ExecutionEngine

### DIFF
--- a/include/glow/Backends/CompiledFunction.h
+++ b/include/glow/Backends/CompiledFunction.h
@@ -41,6 +41,10 @@ public:
   virtual void afterRun(const Context &ctx) = 0;
   /// Final cleanup. Release memory, reset device.
   virtual void tearDownRuns() = 0;
+
+protected:
+  /// Flag to ensure setupRuns is only called once.
+  bool runsSetup_{false};
 };
 } // end namespace glow
 

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -107,7 +107,7 @@ public:
   /// Copies outputs from device to tensors in \p ctx.
   void afterRun(const Context &ctx) override;
   /// Final cleanup, currently an empty function in OpenCL.
-  void tearDownRuns() override{};
+  void tearDownRuns() override;
 
 private:
   /// Copy the value from a device to a provided buffer.

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -82,7 +82,6 @@ void ExecutionEngine::run(Context &ctx) {
   function_->beforeRun(ctx);
   function_->execute();
   function_->afterRun(ctx);
-  function_->tearDownRuns();
 }
 
 void glow::runBatch(ExecutionEngine &EE, Context &ctx, size_t iterations,


### PR DESCRIPTION

*Description*: Removed memleak from OpenCL backend and added logic to executionEngine to only call setupRuns and tearDownRuns once.
*Testing*: ninja test all pass
*Documentation*: NA
Partially fixes #2104 