### PR TITLE
 [cmake] Fix Graph/IR deps so Glow can build with shared libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,10 @@ set(CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-set(CMAKE_CXX_VISIBILITY_PRESET hidden)
-set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
+if (NOT BUILD_SHARED_LIBS)
+  set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+  set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
+endif ()
 
 # Export a JSON file with the compilation commands that external tools can use
 # to analyze the source code of the project.

--- a/lib/Graph/CMakeLists.txt
+++ b/lib/Graph/CMakeLists.txt
@@ -1,24 +1,3 @@
-# AutoGenInstr
-set(INSTR_HDR ${GLOW_BINARY_DIR}/glow/AutoGenInstr.h)
-set(INSTR_SRC ${GLOW_BINARY_DIR}/glow/AutoGenInstr.cpp)
-set(INSTR_DEF ${GLOW_BINARY_DIR}/glow/AutoGenInstr.def)
-set(INSTR_BLD_HDR ${GLOW_BINARY_DIR}/glow/AutoGenIRBuilder.h)
-set(INSTR_BLD_SRC ${GLOW_BINARY_DIR}/glow/AutoGenIRBuilder.cpp)
-set(INSTR_IR_GEN ${GLOW_BINARY_DIR}/glow/AutoGenIRGen.h)
-
-add_custom_command(OUTPUT
-                    "${INSTR_HDR}"
-                    "${INSTR_SRC}"
-                    "${INSTR_DEF}"
-                    "${INSTR_BLD_HDR}"
-                    "${INSTR_BLD_SRC}"
-                    "${INSTR_IR_GEN}"
-                    COMMAND InstrGen
-                      ${INSTR_HDR} ${INSTR_SRC} ${INSTR_DEF}
-                      ${INSTR_BLD_HDR} ${INSTR_BLD_SRC} ${INSTR_IR_GEN}
-                    DEPENDS InstrGen
-                    COMMENT "InstrGen: Generating instructions." VERBATIM)
-
 # AutoGenNodes
 set(NODES_HDR ${GLOW_BINARY_DIR}/glow/AutoGenNodes.h)
 set(NODES_SRC ${GLOW_BINARY_DIR}/glow/AutoGenNodes.cpp)
@@ -36,12 +15,6 @@ add_library(Graph
             ${NODES_HDR}
             ${NODES_SRC}
             ${NODES_DEF}
-            ${NODES_BLD}
-            ${INSTR_HDR}
-            ${INSTR_SRC}
-            ${INSTR_DEF}
-            ${INSTR_BLD_HDR}
-            ${INSTR_BLD_SRC}
             Context.cpp
             Node.cpp
             Nodes.cpp
@@ -55,3 +28,5 @@ target_link_libraries(Graph
                         Base
                         Support
                         QuantizationBase)
+
+add_dependencies(Graph IRGenHeaders)

--- a/lib/IR/CMakeLists.txt
+++ b/lib/IR/CMakeLists.txt
@@ -1,4 +1,33 @@
+# AutoGenInstr
+set(INSTR_HDR ${GLOW_BINARY_DIR}/glow/AutoGenInstr.h)
+set(INSTR_SRC ${GLOW_BINARY_DIR}/glow/AutoGenInstr.cpp)
+set(INSTR_DEF ${GLOW_BINARY_DIR}/glow/AutoGenInstr.def)
+set(INSTR_BLD_HDR ${GLOW_BINARY_DIR}/glow/AutoGenIRBuilder.h)
+set(INSTR_BLD_SRC ${GLOW_BINARY_DIR}/glow/AutoGenIRBuilder.cpp)
+set(INSTR_IR_GEN ${GLOW_BINARY_DIR}/glow/AutoGenIRGen.h)
+
+add_custom_command(OUTPUT
+                    "${INSTR_HDR}"
+                    "${INSTR_SRC}"
+                    "${INSTR_DEF}"
+                    "${INSTR_BLD_HDR}"
+                    "${INSTR_BLD_SRC}"
+                    "${INSTR_IR_GEN}"
+                    COMMAND InstrGen
+                      "${INSTR_HDR}" "${INSTR_SRC}" "${INSTR_DEF}"
+                      "${INSTR_BLD_HDR}" "${INSTR_BLD_SRC}" "${INSTR_IR_GEN}"
+                    DEPENDS InstrGen
+                    COMMENT "InstrGen: Generating instructions." VERBATIM)
+
+add_custom_target(IRGenHeaders
+                  DEPENDS
+                    "${INSTR_HDR}"
+                    "${INSTR_DEF}"
+                    "${INSTR_BLD_HDR}")
+
 add_library(IR
+              "${INSTR_SRC}"
+              "${INSTR_BLD_SRC}"
               IR.cpp
               IRGen.cpp
               IRUtils.cpp

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -12,6 +12,7 @@ target_link_libraries(partitionTest
                         Backends
                         ExecutionEngine
                         Graph
+                        IR
                         Optimizer
                         gtest
                         testMain)


### PR DESCRIPTION
*Description*: I've been wanting to build with shared libraries for a while, if for no other reason than tests will link faster.  I think I've leveled up my cmake skills enough to actually do it.
*Testing*:
```
mkdir build && cd build
cmake -G Ninja ../.. -DCMAKE_PREFIX_PATH=/usr/local/opt/llvm -DBUILD_SHARED_LIBS=ON
ninja all
```
*Documentation*: n/a

Based on #2109.  Github needs stacked diffs.