### PR TITLE
[Fix] Small fix for VS regarding type conversion.

### DIFF
--- a/tests/unittests/tensorsTest.cpp
+++ b/tests/unittests/tensorsTest.cpp
@@ -699,7 +699,7 @@ TEST(Tensor, zeroQuantizedTensor) {
 // Verify that if the tensor is set to the offset manually then isZero() is
 // true
 TEST(Tensor, manuallySetToOffset) {
-  const int32_t offsetQ8 = 6;
+  const int8_t offsetQ8 = 6;
   Tensor Q8T(ElemKind::Int8QTy, {3, 2}, 10.1, offsetQ8);
 
   auto Q8H = Q8T.getHandle<int8_t>();


### PR DESCRIPTION
*Description*: Visual studio was reporting error with type narrowing because Q8H that was instantiated as int8_t and initialized with offsetQ8 which is int32_t.
*Testing*: Usual
*Documentation*: NA
[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
