### PR TITLE
[Nodes] Make lengths input of `BatchOneHot` int32

### DIFF
--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -898,7 +898,7 @@ void InterpreterFunction::fwdScatterAssignInst(
 template <typename ElemTy>
 void InterpreterFunction::fwdBatchOneHotImpl(const glow::BatchOneHotInst *I) {
   auto dataH = getWeightHandle<ElemTy>(I->getData());
-  auto lengthsH = getWeightHandle<int64_t>(I->getLengths());
+  auto lengthsH = getWeightHandle<int32_t>(I->getLengths());
   auto valuesH = getWeightHandle<ElemTy>(I->getValues());
   auto destH = getWeightHandle<ElemTy>(I->getDest());
 

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -879,6 +879,8 @@ bool BatchOneHotNode::verify() const {
 
   isValid &= expectCompareTrue("Lengths should be a single dimensional vectors",
                                lengthsDims.size(), size_t(1), this);
+  isValid &= checkType(getLengths(), ElemKind::Int32ITy, this);
+
   isValid &= expectCompareTrue("Values should be a single dimensional vectors",
                                valuesDims.size(), size_t(1), this);
 

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -4588,12 +4588,12 @@ TEST_P(InterpOnly, BatchOneHot) {
   */
   auto *data = mod_.createPlaceholder(ElemKind::FloatTy, {3, 2}, "data", false);
   auto *lengths =
-      mod_.createPlaceholder(ElemKind::Int64ITy, {2}, "lengths", false);
+      mod_.createPlaceholder(ElemKind::Int32ITy, {2}, "lengths", false);
   auto *values =
       mod_.createPlaceholder(ElemKind::FloatTy, {6}, "values", false);
 
   ctx_.allocate(data)->getHandle<float>() = {5, 0, 11, 3, 0, 5};
-  ctx_.allocate(lengths)->getHandle<int64_t>() = {4, 2};
+  ctx_.allocate(lengths)->getHandle<int32_t>() = {4, 2};
   ctx_.allocate(values)->getHandle<float>() = {5, 0, 11, 0, 5, 0};
 
   auto R = F_->createBatchOneHot("BOH", data, lengths, values);

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -446,7 +446,7 @@ int main(int argc, char **argv) {
       .addOperand("Values", OperandKind::In)
       .autoVerify(VerifyKind::SameElementType, {"Values", "Data", "Dest"})
       .autoVerify(VerifyKind::SameElementType,
-                  {"Lengths", "ElemKind::Int64ITy"})
+                  {"Lengths", "ElemKind::Int32ITy"})
       .autoIRGen();
 
   //===--------------------------------------------------------------------===//


### PR DESCRIPTION
**Description**
This commit modifies the `BatchOneHot` operator to use 32-bit integer
values in the `lengths` input rather than 64-bit integers. This change
was supposed to be part of an earlier commit that migrated the index
inputs of all sparse operators to 32-bit integer, but it was overlooked
at the time.

**Testing**
This commit modifies the operator test for `BatchOneHot` to use 32-bit
integers. The modified test passes, as do all other unit tests.

**Fixes**
This pull request fixes #2033.
