### PR TITLE
[hotfix] Fix unidirectional broadcasting for arithmetic ops (ONNX opset <= 6)

### DIFF
--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -52,6 +52,8 @@ loadArgumentMap(const ONNX_NAMESPACE::NodeProto &op) {
 
 llvm::Expected<bool>
 ONNXModelLoader::getBroadcast(const ArgumentDictionaryTy &dict) {
+  // Starting with opset 7, broadcasting is implicit and doesn't require any
+  // attribute.
   if (opsetVersion_ > 6) {
     return true;
   }
@@ -66,11 +68,14 @@ ONNXModelLoader::getBroadcast(const ArgumentDictionaryTy &dict) {
 
 bool ONNXModelLoader::hasMultidirectionalBroadcast(
     const llvm::StringRef typeName) {
-  if ((typeName == "Add") || (typeName == "Sub") || (typeName == "Mul") ||
-      (typeName == "Div")) {
-    return true;
+  // Before opset 7, broadcasting was unidirectional.
+  if (opsetVersion_ > 6) {
+    if ((typeName == "Add") || (typeName == "Sub") || (typeName == "Mul") ||
+        (typeName == "Div")) {
+      return true;
+    }
+    // TODO: some other operators also support multidirectional broadcasting.
   }
-  // TODO: others operators may also support broadcast
   return false;
 }
 

--- a/tests/models/onnxModels/addUniBroadcastOp6Axis.onnxtxt
+++ b/tests/models/onnxModels/addUniBroadcastOp6Axis.onnxtxt
@@ -1,0 +1,60 @@
+ir_version: 3
+producer_name: "onnx-arith-broadcast"
+opset_import { 
+  version: 6
+}
+
+graph {
+  node {
+    input: "data"
+    input: "const"
+    output: "out"
+    name: "op"
+    op_type: "Add"
+    attribute {
+      name: "broadcast"
+      i: 1
+      type: INT
+    }
+    attribute {
+      name: "axis"
+      i: 2
+      type: INT
+    }
+  }
+  name: "test-model"
+  initializer {
+    dims: 4
+    data_type: FLOAT
+    float_data: 2.0
+    float_data: 2.0
+    float_data: 2.0
+    float_data: 2.0
+    name: "const"
+  }
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: FLOAT
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "out"
+   }
+}

--- a/tests/models/onnxModels/addUniBroadcastOp6NoAxis.onnxtxt
+++ b/tests/models/onnxModels/addUniBroadcastOp6NoAxis.onnxtxt
@@ -1,0 +1,58 @@
+ir_version: 3
+producer_name: "onnx-arith-broadcast"
+opset_import { 
+  version: 6
+}
+
+graph {
+  node {
+    input: "data"
+    input: "const"
+    output: "out"
+    name: "op"
+    op_type: "Add"
+    attribute {
+      name: "broadcast"
+      i: 1
+      type: INT
+    }
+    attribute {
+      name: "axis"
+      i: -1
+      type: INT
+    }
+  }
+  name: "test-model"
+  initializer {
+    dims: 2
+    data_type: FLOAT
+    float_data: 2.0
+    float_data: 2.0
+   name: "const"
+  }
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: FLOAT
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "out"
+   }
+}

--- a/tests/models/onnxModels/divUniBroadcastOp6Axis.onnxtxt
+++ b/tests/models/onnxModels/divUniBroadcastOp6Axis.onnxtxt
@@ -1,0 +1,60 @@
+ir_version: 3
+producer_name: "onnx-arith-broadcast"
+opset_import { 
+  version: 6
+}
+
+graph {
+  node {
+    input: "data"
+    input: "const"
+    output: "out"
+    name: "op"
+    op_type: "Div"
+    attribute {
+      name: "broadcast"
+      i: 1
+      type: INT
+    }
+    attribute {
+      name: "axis"
+      i: 2
+      type: INT
+    }
+  }
+  name: "test-model"
+  initializer {
+    dims: 4
+    data_type: FLOAT
+    float_data: 2.0
+    float_data: 2.0
+    float_data: 2.0
+    float_data: 2.0
+    name: "const"
+  }
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: FLOAT
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "out"
+   }
+}

--- a/tests/models/onnxModels/divUniBroadcastOp6NoAxis.onnxtxt
+++ b/tests/models/onnxModels/divUniBroadcastOp6NoAxis.onnxtxt
@@ -1,0 +1,58 @@
+ir_version: 3
+producer_name: "onnx-arith-broadcast"
+opset_import { 
+  version: 6
+}
+
+graph {
+  node {
+    input: "data"
+    input: "const"
+    output: "out"
+    name: "op"
+    op_type: "Div"
+    attribute {
+      name: "broadcast"
+      i: 1
+      type: INT
+    }
+    attribute {
+      name: "axis"
+      i: -1
+      type: INT
+    }
+  }
+  name: "test-model"
+  initializer {
+    dims: 2
+    data_type: FLOAT
+    float_data: 2.0
+    float_data: 2.0
+   name: "const"
+  }
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: FLOAT
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "out"
+   }
+}

--- a/tests/models/onnxModels/mulUniBroadcastOp6Axis.onnxtxt
+++ b/tests/models/onnxModels/mulUniBroadcastOp6Axis.onnxtxt
@@ -1,0 +1,60 @@
+ir_version: 3
+producer_name: "onnx-arith-broadcast"
+opset_import { 
+  version: 6
+}
+
+graph {
+  node {
+    input: "data"
+    input: "const"
+    output: "out"
+    name: "op"
+    op_type: "Mul"
+    attribute {
+      name: "broadcast"
+      i: 1
+      type: INT
+    }
+    attribute {
+      name: "axis"
+      i: 2
+      type: INT
+    }
+  }
+  name: "test-model"
+  initializer {
+    dims: 4
+    data_type: FLOAT
+    float_data: 2.0
+    float_data: 2.0
+    float_data: 2.0
+    float_data: 2.0
+    name: "const"
+  }
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: FLOAT
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "out"
+   }
+}

--- a/tests/models/onnxModels/mulUniBroadcastOp6NoAxis.onnxtxt
+++ b/tests/models/onnxModels/mulUniBroadcastOp6NoAxis.onnxtxt
@@ -1,0 +1,58 @@
+ir_version: 3
+producer_name: "onnx-arith-broadcast"
+opset_import { 
+  version: 6
+}
+
+graph {
+  node {
+    input: "data"
+    input: "const"
+    output: "out"
+    name: "op"
+    op_type: "Mul"
+    attribute {
+      name: "broadcast"
+      i: 1
+      type: INT
+    }
+    attribute {
+      name: "axis"
+      i: -1
+      type: INT
+    }
+  }
+  name: "test-model"
+  initializer {
+    dims: 2
+    data_type: FLOAT
+    float_data: 2.0
+    float_data: 2.0
+   name: "const"
+  }
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: FLOAT
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "out"
+   }
+}

--- a/tests/models/onnxModels/subUniBroadcastOp6Axis.onnxtxt
+++ b/tests/models/onnxModels/subUniBroadcastOp6Axis.onnxtxt
@@ -1,0 +1,60 @@
+ir_version: 3
+producer_name: "onnx-arith-broadcast"
+opset_import { 
+  version: 6
+}
+
+graph {
+  node {
+    input: "data"
+    input: "const"
+    output: "out"
+    name: "op"
+    op_type: "Sub"
+    attribute {
+      name: "broadcast"
+      i: 1
+      type: INT
+    }
+    attribute {
+      name: "axis"
+      i: 2
+      type: INT
+    }
+  }
+  name: "test-model"
+  initializer {
+    dims: 4
+    data_type: FLOAT
+    float_data: 2.0
+    float_data: 2.0
+    float_data: 2.0
+    float_data: 2.0
+    name: "const"
+  }
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: FLOAT
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "out"
+   }
+}

--- a/tests/models/onnxModels/subUniBroadcastOp6NoAxis.onnxtxt
+++ b/tests/models/onnxModels/subUniBroadcastOp6NoAxis.onnxtxt
@@ -1,0 +1,58 @@
+ir_version: 3
+producer_name: "onnx-arith-broadcast"
+opset_import { 
+  version: 6
+}
+
+graph {
+  node {
+    input: "data"
+    input: "const"
+    output: "out"
+    name: "op"
+    op_type: "Sub"
+    attribute {
+      name: "broadcast"
+      i: 1
+      type: INT
+    }
+    attribute {
+      name: "axis"
+      i: -1
+      type: INT
+    }
+  }
+  name: "test-model"
+  initializer {
+    dims: 2
+    data_type: FLOAT
+    float_data: 2.0
+    float_data: 2.0
+   name: "const"
+  }
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: FLOAT
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "out"
+   }
+}

--- a/tests/unittests/onnxImporterTest.cpp
+++ b/tests/unittests/onnxImporterTest.cpp
@@ -25,6 +25,8 @@ using namespace glow;
 template <class OpType>
 static void
 importArithMultiBroadcastTest(std::string fileName,
+                              llvm::ArrayRef<size_t> inputShape, bool multi,
+                              int numLeftTile, int numRightTile,
                               const std::function<float(float, float)> &op) {
   ExecutionEngine EE{BackendKind::Interpreter};
   auto &mod = EE.getModule();
@@ -37,7 +39,8 @@ importArithMultiBroadcastTest(std::string fileName,
   // will not depend on anyting from the loader.
   {
     Tensor data;
-    getNCHWData(&data, 1, 3, 1, 2);
+    getNCHWData(&data, inputShape[0], inputShape[1], inputShape[2],
+                inputShape[3]);
     ONNXModelLoader onnxLD(NetFilename, {"data"}, {&data.getType()}, *F);
     graphOutputVar = EXIT_ON_ERR(onnxLD.getSingleOutput());
     ctx.allocate(mod.getPlaceholders());
@@ -53,58 +56,128 @@ importArithMultiBroadcastTest(std::string fileName,
   auto *opNode = llvm::dyn_cast<OpType>(node);
   EXPECT_NE(nullptr, opNode);
 
-  // Left operand (1 dimension to broadcast)
-  auto *lhsTileNode = llvm::dyn_cast<TileNode>(opNode->getLHS().getNode());
-  EXPECT_NE(nullptr, lhsTileNode);
-  auto *lhsReshape =
-      llvm::dyn_cast<ReshapeNode>(lhsTileNode->getInput().getNode());
-  EXPECT_NE(nullptr, lhsReshape);
+  // Left operand (numLeftTile dimensions to broadcast)
+  if (numLeftTile > 0) {
+    TileNode *tileNode = llvm::dyn_cast<TileNode>(opNode->getLHS().getNode());
+    EXPECT_NE(nullptr, tileNode);
+    for (int i = 1; i < numLeftTile; i++) {
+      tileNode = llvm::dyn_cast<TileNode>(tileNode->getInput().getNode());
+      EXPECT_NE(nullptr, tileNode);
+    }
+    auto *reshapeNode =
+        llvm::dyn_cast<ReshapeNode>(tileNode->getInput().getNode());
+    EXPECT_NE(nullptr, reshapeNode);
+  }
 
-  // Right operand (2 dimensions to broadcast)
-  auto *rhsNode = opNode->getRHS().getNode();
-  EXPECT_NE(nullptr, rhsNode);
-  auto *rhsTileNode = llvm::dyn_cast<TileNode>(opNode->getRHS().getNode());
-  EXPECT_NE(nullptr, rhsTileNode);
-  auto *rhsTileNode2 =
-      llvm::dyn_cast<TileNode>(rhsTileNode->getInput().getNode());
-  EXPECT_NE(nullptr, rhsTileNode2);
-  auto *rhsReshape =
-      llvm::dyn_cast<ReshapeNode>(rhsTileNode2->getInput().getNode());
-  EXPECT_NE(nullptr, rhsReshape);
+  // Right operand (numRightTile dimensions to broadcast)
+  if (numRightTile > 0) {
+    TileNode *tileNode = llvm::dyn_cast<TileNode>(opNode->getRHS().getNode());
+    EXPECT_NE(nullptr, tileNode);
+    for (int i = 1; i < numRightTile; i++) {
+      tileNode = llvm::dyn_cast<TileNode>(tileNode->getInput().getNode());
+      EXPECT_NE(nullptr, tileNode);
+    }
+    auto *reshapeNode =
+        llvm::dyn_cast<ReshapeNode>(tileNode->getInput().getNode());
+    EXPECT_NE(nullptr, reshapeNode);
+  }
 
   // Compile&run the graph, and check the output
   EE.compile(CompilationMode::Infer, F);
   EE.run(ctx);
   auto result = ctx.get(graphOutputVar)->getHandle();
   std::vector<size_t> expectedDims = {1, 3, 4, 2};
-  std::vector<float> expectedValues = {
-      op(0, 2), op(1, 2), op(0, 2), op(1, 2), op(0, 2), op(1, 2),
-      op(0, 2), op(1, 2), op(2, 2), op(3, 2), op(2, 2), op(3, 2),
-      op(2, 2), op(3, 2), op(2, 2), op(3, 2), op(4, 2), op(5, 2),
-      op(4, 2), op(5, 2), op(4, 2), op(5, 2), op(4, 2), op(5, 2)};
+  std::vector<float> expectedValues;
+
+  if (multi) {
+    expectedValues = {op(0, 2), op(1, 2), op(0, 2), op(1, 2), op(0, 2),
+                      op(1, 2), op(0, 2), op(1, 2), op(2, 2), op(3, 2),
+                      op(2, 2), op(3, 2), op(2, 2), op(3, 2), op(2, 2),
+                      op(3, 2), op(4, 2), op(5, 2), op(4, 2), op(5, 2),
+                      op(4, 2), op(5, 2), op(4, 2), op(5, 2)};
+  } else {
+    expectedValues = {op(0, 2),  op(1, 2),  op(2, 2),  op(3, 2),  op(4, 2),
+                      op(5, 2),  op(6, 2),  op(7, 2),  op(8, 2),  op(9, 2),
+                      op(10, 2), op(11, 2), op(12, 2), op(13, 2), op(14, 2),
+                      op(15, 2), op(16, 2), op(17, 2), op(18, 2), op(19, 2),
+                      op(20, 2), op(21, 2), op(22, 2), op(23, 2)};
+  }
   EXPECT_TRUE(result.dims().vec() == expectedDims);
-  for (size_t i = 0; i < result.getType().size(); i++)
+  for (size_t i = 0; i < result.getType().size(); i++) {
     EXPECT_FLOAT_EQ(result.raw(i), expectedValues[i]);
+  }
 }
 
 TEST(onnx, importAddMultiBroadcastOp7) {
   importArithMultiBroadcastTest<AddNode>(
-      "addMultiBroadcastOp7.onnxtxt", [](float a, float b) { return a + b; });
+      "addMultiBroadcastOp7.onnxtxt", {1, 3, 1, 2}, true, 1, 2,
+      [](float a, float b) { return a + b; });
+}
+
+TEST(onnx, importAddUniBroadcastOp6NoAxis) {
+  importArithMultiBroadcastTest<AddNode>(
+      "addUniBroadcastOp6NoAxis.onnxtxt", {1, 3, 4, 2}, false, 0, 2,
+      [](float a, float b) { return a + b; });
+}
+
+TEST(onnx, importAddUniBroadcastOp6Axis) {
+  importArithMultiBroadcastTest<AddNode>(
+      "addUniBroadcastOp6Axis.onnxtxt", {1, 3, 4, 2}, false, 0, 2,
+      [](float a, float b) { return a + b; });
 }
 
 TEST(onnx, importSubMultiBroadcastOp7) {
   importArithMultiBroadcastTest<SubNode>(
-      "subMultiBroadcastOp7.onnxtxt", [](float a, float b) { return a - b; });
+      "subMultiBroadcastOp7.onnxtxt", {1, 3, 1, 2}, true, 1, 2,
+      [](float a, float b) { return a - b; });
+}
+
+TEST(onnx, importSubUniBroadcastOp6NoAxis) {
+  importArithMultiBroadcastTest<SubNode>(
+      "subUniBroadcastOp6NoAxis.onnxtxt", {1, 3, 4, 2}, false, 0, 2,
+      [](float a, float b) { return a - b; });
+}
+
+TEST(onnx, importSubUniBroadcastOp6Axis) {
+  importArithMultiBroadcastTest<SubNode>(
+      "subUniBroadcastOp6Axis.onnxtxt", {1, 3, 4, 2}, false, 0, 2,
+      [](float a, float b) { return a - b; });
 }
 
 TEST(onnx, importMulMultiBroadcastOp7) {
   importArithMultiBroadcastTest<MulNode>(
-      "mulMultiBroadcastOp7.onnxtxt", [](float a, float b) { return a * b; });
+      "mulMultiBroadcastOp7.onnxtxt", {1, 3, 1, 2}, true, 1, 2,
+      [](float a, float b) { return a * b; });
+}
+
+TEST(onnx, importMulUniBroadcastOp6NoAxis) {
+  importArithMultiBroadcastTest<MulNode>(
+      "mulUniBroadcastOp6NoAxis.onnxtxt", {1, 3, 4, 2}, false, 0, 2,
+      [](float a, float b) { return a * b; });
+}
+
+TEST(onnx, importMulUniBroadcastOp6Axis) {
+  importArithMultiBroadcastTest<MulNode>(
+      "mulUniBroadcastOp6Axis.onnxtxt", {1, 3, 4, 2}, false, 0, 2,
+      [](float a, float b) { return a * b; });
 }
 
 TEST(onnx, importDivMultiBroadcastOp7) {
   importArithMultiBroadcastTest<DivNode>(
-      "divMultiBroadcastOp7.onnxtxt", [](float a, float b) { return a / b; });
+      "divMultiBroadcastOp7.onnxtxt", {1, 3, 1, 2}, true, 1, 2,
+      [](float a, float b) { return a / b; });
+}
+
+TEST(onnx, importDivUniBroadcastOp6NoAxis) {
+  importArithMultiBroadcastTest<DivNode>(
+      "divUniBroadcastOp6NoAxis.onnxtxt", {1, 3, 4, 2}, false, 0, 2,
+      [](float a, float b) { return a / b; });
+}
+
+TEST(onnx, importDivUniBroadcastOp6Axis) {
+  importArithMultiBroadcastTest<DivNode>(
+      "divUniBroadcastOp6Axis.onnxtxt", {1, 3, 4, 2}, false, 0, 2,
+      [](float a, float b) { return a / b; });
 }
 
 /// Test loading conv op from a ONNX model.


### PR DESCRIPTION
*Description*:
My previous PR about broadcasting added the support for multidirectional broadcasting (ONNX opset 7+). But by doing extra tests, i noticed that it broke the unidirectional broadcasting in some cases for ONNX opset <7. This PR fixes this and enables a fully functional broadcasting for any ONNX opset. 
I also take advantage of this fix to add tests for ONNX unidirectional broadcasting.
Some information:
- ONNX unidirectional broadcasting: https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Mul-6
- Caffe2 unidirectional broadcasting : https://caffe2.ai/docs/operators-catalogue.html#mul
- ONNX multidirectional broadcasting: https://github.com/onnx/onnx/blob/master/docs/Broadcasting.md

*Testing*: 
Added tests for ONNX arithmetic operation with unidirectional broadcasting (opset 6), with 2 situations: axis == -1 and axis != -1.

*Documentation*: N/A
