### PR TITLE
[tests] Make pad fusion test work with g++ 4.8.5

### DIFF
--- a/tests/unittests/graphOptzTest.cpp
+++ b/tests/unittests/graphOptzTest.cpp
@@ -1790,8 +1790,9 @@ void fusePadIntoConvTest(glow::Module &mod_, glow::Function *F_,
   // Check the graph structure and additional properties after optimization.
   auto *conv = llvm::dyn_cast<ConvolutionNode>(O->getInput());
   ASSERT_NE(conv, nullptr);
-  EXPECT_EQ(conv->dims(0), llvm::makeArrayRef({outPadDims[0], outPadDims[1],
-                                               outPadDims[2], filterDims[0]}));
+  EXPECT_EQ(conv->dims(0),
+            llvm::ArrayRef<size_t>(
+                {outPadDims[0], outPadDims[1], outPadDims[2], filterDims[0]}));
   unsigned_t expectedPads[4];
   for (int i = 0; i < 2; i++) {
     for (int j = 0; j < 2; j++) {


### PR DESCRIPTION
I'm going to keep fighting this battle until someone introduces something that's too hard for me to work around.  Please don't take that as a challenge! :-D.  Seriously I can't believe template argument deduction fails on this.