### PR TITLE
[glow/runtime] First cut DeviceManager with CPU backend

### DIFF
--- a/include/glow/Backends/DeviceManager.h
+++ b/include/glow/Backends/DeviceManager.h
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_BACKENDS_DEVICEMANAGER_H
+#define GLOW_BACKENDS_DEVICEMANAGER_H
+
+#include "glow/Backends/Backend.h"
+#include "glow/Graph/Context.h"
+#include "glow/Graph/Graph.h"
+#include "glow/Support/ThreadPool.h"
+
+#include <atomic>
+#include <condition_variable>
+#include <deque>
+#include <mutex>
+#include <thread>
+#include <unordered_map>
+
+namespace glow {
+
+using DeviceNetworkID = size_t;
+
+enum ResultCode { READY, EXECUTED, FAILED, CANCELLED };
+
+using ReadyCB = std::function<void(DeviceNetworkID, ResultCode)>;
+using ResultCB = std::function<void(ResultCode, std::unique_ptr<Context>)>;
+
+class DeviceManager {
+protected:
+  /// Lookup for Modules.
+  std::unordered_map<DeviceNetworkID, std::unique_ptr<Module>> modules_;
+  /// The network execution backend.
+  std::unique_ptr<Backend> backend_;
+  /// Thread which interfaces with the device.
+  ThreadPool workThread_;
+  /// Next available network ID.
+  std::atomic<DeviceNetworkID> nextNetworkID_{1};
+
+public:
+  DeviceManager(std::unique_ptr<Backend> backend);
+  virtual ~DeviceManager();
+
+  /// Initialize the device.
+  void init();
+
+  /// Load the provided module into the device, readyCB will be called when
+  /// ready to use
+  void addNetwork(DeviceNetworkID networkId, std::unique_ptr<Module> module,
+                  ReadyCB readyCB);
+
+  /// Remove (and delete) the provided network, freeing up space on the device.
+  void evictNetwork(DeviceNetworkID networkId);
+
+  /// Execute the named Function in an already provided network on the device.
+  /// functionName must match the name of a function in the Module.
+  /// Context should have all Placeholders allocated. resultCB will be called
+  /// with the Context results filled.
+  void runFunction(DeviceNetworkID moduleID, llvm::StringRef functionName,
+                   std::unique_ptr<Context> ctx, ResultCB resultCB);
+
+  /// Stops execution and shuts down the Device.
+  void stop(bool block = true);
+
+  /// \returns the maximum memory (in bytes) available on the device.
+  virtual uint64_t getMaximumMemory() = 0;
+
+  /// \returns the currently available memory (in MB) available on the device,
+  /// for provisioning new networks.
+  virtual uint64_t getAvailableMemory() = 0;
+
+  /// \returns true if we expect a Module with the estimated constant size will
+  /// fit on the device.
+  virtual bool isMemoryAvailable(uint64_t estimate) = 0;
+
+  /// Returns an available DeviceNetworkID to use for a new network.
+  DeviceNetworkID getNextDeviceNetworkID() { return nextNetworkID_++; }
+
+protected:
+  /// Operator handling methods to be implemented in subclasses (i.e. per Device
+  /// type)
+
+  /// Load and compile the Module
+  virtual void addNetworkImpl(DeviceNetworkID id,
+                              std::unique_ptr<Module> module, ReadyCB cb) = 0;
+
+  /// Remove the module and reclaim it's memory
+  virtual void evictNetworkImpl(DeviceNetworkID id) = 0;
+
+  /// Execute provided Function
+  virtual void runFunctionImpl(DeviceNetworkID id, llvm::StringRef function,
+                               std::unique_ptr<Context> ctx, ResultCB cb) = 0;
+};
+
+} // namespace glow
+
+#endif // GLOW_BACKENDS_DEVICEMANAGER_H

--- a/lib/Backends/CMakeLists.txt
+++ b/lib/Backends/CMakeLists.txt
@@ -2,6 +2,8 @@ add_library(Backends Backends.cpp)
 
 add_library(BackendUtils BackendUtils.cpp)
 
+add_library(DeviceManager DeviceManager.cpp)
+
 target_link_libraries(BackendUtils
                       PRIVATE
                       CodeGen
@@ -27,3 +29,9 @@ target_link_libraries(Backends
                         ${linked_backends}
                         Base
                         Graph)
+
+target_link_libraries(DeviceManager
+                      PRIVATE
+                        Backends
+                        Graph
+                        ThreadPool)

--- a/lib/Backends/CPU/CMakeLists.txt
+++ b/lib/Backends/CPU/CMakeLists.txt
@@ -108,3 +108,18 @@ if(LLVM_VERSION_MAJOR VERSION_GREATER 6)
                           LLVMOrcJIT)
 endif()
 add_dependencies(CPUBackend CPURuntime)
+
+add_library(CPUDeviceManager
+            CPUDeviceManager.cpp)
+target_link_libraries(CPUDeviceManager
+                      PRIVATE
+                      Backends
+                      BackendUtils
+                      Base
+                      CodeGen
+                      CPUBackend
+                      DeviceManager
+                      Graph
+                      IR
+                      Optimizer
+                      QuantizationBase)

--- a/lib/Backends/CPU/CPUDeviceManager.cpp
+++ b/lib/Backends/CPU/CPUDeviceManager.cpp
@@ -1,0 +1,145 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "CPUDeviceManager.h"
+
+using namespace glow;
+
+uint64_t CPUDeviceManager::getMaximumMemory() { return maxMemoryBytes; }
+
+uint64_t CPUDeviceManager::getAvailableMemory() {
+  return maxMemoryBytes - usedMemoryBytes;
+}
+
+bool CPUDeviceManager::isMemoryAvailable(uint64_t estimate) {
+  // No fuzz factor for the CPU device.
+  return maxMemoryBytes >= (usedMemoryBytes + estimate);
+}
+
+// Lifted from ExcutionEngine.cpp
+// TODO this could be a generic helper function somewhere?
+void CPUDeviceManager::optimizeFunction(CompilationMode mode, Function *F) {
+  // Verify the function pre-optimization/lowering.
+  assert(F->verify() && "Function must be valid");
+
+  // Optimize the graph.
+  ::glow::optimize(F, mode);
+
+  // Allow the backend to transform the graph prior to lowering.
+  if (backend_->transformPreLowering(F, mode)) {
+    // Optimize the graph again after the backend transformation.
+    // In particular, DCE is very likely to be useful.
+    ::glow::optimize(F, mode);
+  }
+
+  // Lower the graph into a sequence of low-level linear algebra operations.
+  ::glow::lower(F, *backend_);
+
+  // Optimize the graph again.
+  ::glow::optimize(F, mode);
+
+  // Allow the backend to transform the graph after lowering.
+  if (backend_->transformPostLowering(F, mode)) {
+    // Optimize the graph again after the backend transformation.
+    // In particular, DCE is very likely to be useful.
+    ::glow::optimize(F, mode);
+  }
+}
+
+void CPUDeviceManager::addNetworkImpl(DeviceNetworkID id,
+                                      std::unique_ptr<Module> module,
+                                      ReadyCB readyCB) {
+  auto modIt = modules_.find(id);
+  if (modIt != modules_.end()) {
+    // Already have a module with this ID.
+    // TODO: should we replace it?
+    readyCB(id, FAILED);
+    return;
+  }
+
+  // TODO: we should update usedMemory but we don't currently have a nice way
+  // to determine the meory used by the module. I'll come back to this, but for
+  // now we'll guess (badly).
+  size_t moduleSize = 200 * 1024 * 1024;
+
+  if (usedMemoryBytes + moduleSize > maxMemoryBytes) {
+    readyCB(id, FAILED);
+    return;
+  }
+
+  // Compile the functions.
+  auto &functions = module->getFunctions();
+  for (auto *F : functions) {
+    optimizeFunction(CompilationMode::Infer, F);
+    functions_[F] = backend_->compile(F);
+  }
+
+  modules_.emplace_hint(modIt, id, std::move(module));
+  usedMemoryBytes += moduleSize;
+
+  // Fire the ready CB
+  readyCB(id, READY);
+}
+
+void CPUDeviceManager::evictNetworkImpl(DeviceNetworkID id) {
+  auto modIt = modules_.find(id);
+  if (modIt == modules_.end()) {
+    // nothing to do
+    return;
+  }
+
+  std::unique_ptr<Module> module = std::move(modIt->second);
+  auto &functions = module->getFunctions();
+  for (auto *F : functions) {
+    functions_.erase(F);
+  }
+  modules_.erase(modIt);
+  usedMemoryBytes -= 200 * 1024 * 1024; // TODO: static moduleSize
+  assert(usedMemoryBytes >= 0);
+}
+
+void CPUDeviceManager::runFunctionImpl(DeviceNetworkID id,
+                                       llvm::StringRef function,
+                                       std::unique_ptr<Context> ctx,
+                                       ResultCB resultCB) {
+  auto modIt = modules_.find(id);
+  if (modIt == modules_.end()) {
+    resultCB(FAILED, std::move(ctx));
+    return;
+  }
+
+  auto *F = modIt->second->getFunction(function);
+  if (!F) {
+    resultCB(FAILED, std::move(ctx));
+    return;
+  }
+
+  auto funcIt = functions_.find(F);
+  if (funcIt == functions_.end()) {
+    resultCB(FAILED, std::move(ctx));
+    return;
+  }
+
+  // TODO: verify that context has been allocated already?
+  ctx->allocate(modIt->second->getPlaceholders());
+  funcIt->second->setupRuns();
+  funcIt->second->beforeRun(*ctx);
+  funcIt->second->execute();
+  funcIt->second->afterRun(*ctx);
+  funcIt->second->tearDownRuns();
+
+  // fire the ResultCB
+  resultCB(EXECUTED, std::move(ctx));
+}

--- a/lib/Backends/CPU/CPUDeviceManager.h
+++ b/lib/Backends/CPU/CPUDeviceManager.h
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_BACKENDS_CPUDEVICEMANAGER_H
+#define GLOW_BACKENDS_CPUDEVICEMANAGER_H
+
+#include "glow/Backends/Backend.h"
+#include "glow/Backends/CompiledFunction.h"
+#include "glow/Backends/DeviceManager.h"
+
+namespace glow {
+
+class CPUDeviceManager : public DeviceManager {
+  /// Loaded module list.
+  std::unordered_map<DeviceNetworkID, std::unique_ptr<Module>> modules_;
+  /// Compiled function list.
+  std::unordered_map<Function *, std::unique_ptr<CompiledFunction>> functions_;
+
+  /// Maximum available memory on the device, for CPU devices fix to some
+  /// constant.
+  uint64_t maxMemoryBytes{0};
+  /// Amount of memory used by all models.
+  uint64_t usedMemoryBytes{0};
+
+public:
+  CPUDeviceManager(size_t MBsPerCore = 16000)
+      : DeviceManager(
+            std::unique_ptr<Backend>(createBackend(BackendKind::CPU))),
+        maxMemoryBytes(MBsPerCore * 1024 * 1024) {}
+
+  uint64_t getMaximumMemory() override;
+  uint64_t getAvailableMemory() override;
+  bool isMemoryAvailable(uint64_t estimate) override;
+
+protected:
+  void optimizeFunction(CompilationMode mode, Function *F);
+
+  void addNetworkImpl(DeviceNetworkID id, std::unique_ptr<Module> module,
+                      ReadyCB cb) override;
+  void evictNetworkImpl(DeviceNetworkID id) override;
+  void runFunctionImpl(DeviceNetworkID id, llvm::StringRef function,
+                       std::unique_ptr<Context> ctx, ResultCB cb) override;
+};
+
+} // namespace glow
+
+#endif // GLOW_BACKENBDS_CPUDEVICEMANAGER_H

--- a/lib/Backends/DeviceManager.cpp
+++ b/lib/Backends/DeviceManager.cpp
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/Backends/DeviceManager.h"
+
+using namespace glow;
+
+DeviceManager::DeviceManager(std::unique_ptr<Backend> backend)
+    : backend_(std::move(backend)), workThread_(1) {}
+
+DeviceManager::~DeviceManager() {
+  stop(true); // will join workThread_
+}
+
+void DeviceManager::init() {}
+
+void DeviceManager::addNetwork(DeviceNetworkID moduleID,
+                               std::unique_ptr<Module> module,
+                               ReadyCB callback) {
+  workThread_.submit([this, moduleID, m = std::move(module),
+                      c = std::move(callback)]() mutable {
+    addNetworkImpl(moduleID, std::move(m), std::move(c));
+  });
+}
+
+void DeviceManager::evictNetwork(DeviceNetworkID moduleID) {
+  workThread_.submit([this, moduleID] { evictNetworkImpl(moduleID); });
+}
+
+void DeviceManager::runFunction(DeviceNetworkID moduleID,
+                                llvm::StringRef functionName,
+                                std::unique_ptr<Context> ctx,
+                                ResultCB callback) {
+  workThread_.submit([this, moduleID, functionName = std::move(functionName),
+                      ctx = std::move(ctx),
+                      callback = std::move(callback)]() mutable {
+    runFunctionImpl(moduleID, std::move(functionName), std::move(ctx),
+                    std::move(callback));
+  });
+}
+
+void DeviceManager::stop(bool block) { workThread_.stop(block); }

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -296,6 +296,22 @@ target_link_libraries(LLVMIRGenTest
 target_include_directories(LLVMIRGenTest PUBLIC ${CMAKE_SOURCE_DIR}/lib/Backends/CPU)
 add_glow_test(LLVMIRGenTest ${GLOW_BINARY_DIR}/tests/LLVMIRGenTest --gtest_output=xml:LLVMIRGenTest.xml)
 
+add_executable(cpuDeviceTest
+               CPUDeviceManagerTest.cpp)
+target_link_libraries(cpuDeviceTest
+                      PRIVATE
+                        Backends
+                        DeviceManager
+                        CPUDeviceManager
+                        Graph
+                        IR
+                        ExecutionEngine
+                        Optimizer
+                        gtest
+                        testMain)
+target_include_directories(cpuDeviceTest PUBLIC ${CMAKE_SOURCE_DIR}/lib/Backends/CPU)
+add_glow_test(cpuDeviceTest ${GLOW_BINARY_DIR}/tests/cpuDeviceTest --gtest_output=xml:cpuDeviceTest.xml)
+
 endif()
 
 add_executable(memoryAllocatorTest

--- a/tests/unittests/CPUDeviceManagerTest.cpp
+++ b/tests/unittests/CPUDeviceManagerTest.cpp
@@ -1,0 +1,189 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CPUDeviceManager.h"
+#include "glow/ExecutionEngine/ExecutionEngine.h"
+
+#include "gtest/gtest.h"
+
+#include <chrono>
+#include <future>
+
+using namespace glow;
+using namespace std::chrono_literals;
+
+std::pair<std::promise<DeviceNetworkID>, std::future<DeviceNetworkID>>
+getFutureHelper() {
+  std::promise<DeviceNetworkID> promise;
+  auto future = promise.get_future();
+  return std::make_pair(std::move(promise), std::move(future));
+}
+
+void addNetworkCallbackHelper(std::promise<DeviceNetworkID> &promise,
+                              DeviceNetworkID id, ResultCode result) {
+  promise.set_value(result == READY ? id : 0);
+}
+
+TEST(CPUDeviceManagerTest, Basic) {
+  std::unique_ptr<Module> module = std::make_unique<Module>();
+  std::unique_ptr<Context> ctx = std::make_unique<Context>();
+
+  Function *F = module->createFunction("main");
+
+  auto *input = module->createPlaceholder(ElemKind::FloatTy, {1, 32, 32, 3},
+                                          "input", false);
+
+  auto *ex =
+      module->createPlaceholder(ElemKind::Int64ITy, {1, 1}, "exp", false);
+
+  auto *CV0 = F->createConv(*ctx, "conv1", input, 16, 5, 1, 2, 1);
+  auto *RL0 = F->createRELU("relu1", CV0);
+  auto *MP0 = F->createMaxPool("pool1", RL0, 2, 2, 0);
+
+  auto *CV1 = F->createConv(*ctx, "conv2", MP0, 20, 5, 1, 2, 1);
+  auto *RL1 = F->createRELU("relu2", CV1);
+  auto *MP1 = F->createMaxPool("pool2", RL1, 2, 2, 0);
+
+  auto *CV2 = F->createConv(*ctx, "conv3", MP1, 20, 5, 1, 2, 1);
+  auto *RL2 = F->createRELU("relu3", CV2);
+  auto *MP2 = F->createMaxPool("pool3", RL2, 2, 2, 0);
+
+  auto *FCL1 = F->createFullyConnected(*ctx, "fc", MP2, 10);
+  auto *RL3 = F->createRELU("relu4", FCL1);
+  auto *SM = F->createSoftMax("sm", RL3, ex);
+  auto *S = F->createSave("ret", SM);
+
+  CPUDeviceManager cpuCoreDevice;
+  cpuCoreDevice.init();
+
+  std::promise<DeviceNetworkID> promise;
+  std::future<DeviceNetworkID> future;
+  std::tie(promise, future) = getFutureHelper();
+
+  cpuCoreDevice.addNetwork(1, std::move(module),
+                           [&promise](DeviceNetworkID id, ResultCode result) {
+                             addNetworkCallbackHelper(promise, id, result);
+                           });
+
+  future.wait_for(2s);
+  EXPECT_EQ(future.get(), 1);
+
+  ctx->allocate(input);
+  ctx->allocate(ex);
+  ctx->allocate(S->getPlaceholder());
+
+  Tensor inputs(ElemKind::FloatTy, {1, 32, 32, 3});
+  updateInputPlaceholders(*ctx, {input}, {&inputs});
+
+  std::tie(promise, future) = getFutureHelper();
+  cpuCoreDevice.runFunction(
+      1, "main", std::move(ctx),
+      [&promise, &ctx](ResultCode result, std::unique_ptr<Context> ctx_) {
+        if (result == EXECUTED) {
+          ctx = std::move(ctx_);
+          promise.set_value(1);
+        } else {
+          promise.set_exception(
+              std::make_exception_ptr(std::runtime_error("not ready")));
+        }
+      });
+
+  future.wait_for(2s);
+
+  EXPECT_NE(ctx, nullptr);
+}
+
+std::unique_ptr<Module> makeBasicModule() {
+  std::unique_ptr<Module> module = std::make_unique<Module>();
+  std::unique_ptr<Context> ctx = std::make_unique<Context>();
+
+  Function *F = module->createFunction("main");
+  auto *input = module->createPlaceholder(ElemKind::FloatTy, {1, 32, 32, 3},
+                                          "input", false);
+
+  auto *FC = F->createFullyConnected(*ctx, "fc", input, 10);
+  F->createSave("ret", FC);
+
+  return module;
+}
+
+TEST(CPUDeviceManagerTest, availableMemory) {
+  CPUDeviceManager cpuCoreDevice(200);
+  cpuCoreDevice.init();
+
+  uint64_t expectedBytes = 200 * 1024 * 1024;
+  EXPECT_EQ(cpuCoreDevice.getMaximumMemory(), expectedBytes);
+  EXPECT_EQ(cpuCoreDevice.getAvailableMemory(), expectedBytes);
+  EXPECT_TRUE(cpuCoreDevice.isMemoryAvailable(expectedBytes));
+  EXPECT_FALSE(cpuCoreDevice.isMemoryAvailable(expectedBytes + 1));
+
+  auto module = makeBasicModule();
+
+  std::promise<DeviceNetworkID> promise;
+  std::future<DeviceNetworkID> future;
+
+  std::tie(promise, future) = getFutureHelper();
+
+  auto networkOne = cpuCoreDevice.getNextDeviceNetworkID();
+  cpuCoreDevice.addNetwork(networkOne, std::move(module),
+                           [&promise](DeviceNetworkID id, ResultCode result) {
+                             addNetworkCallbackHelper(promise, id, result);
+                           });
+
+  future.wait_for(2s);
+  EXPECT_EQ(future.get(), networkOne);
+
+  EXPECT_EQ(cpuCoreDevice.getMaximumMemory(), expectedBytes);
+  EXPECT_EQ(cpuCoreDevice.getAvailableMemory(), 0);
+  EXPECT_FALSE(cpuCoreDevice.isMemoryAvailable(expectedBytes));
+  EXPECT_FALSE(cpuCoreDevice.isMemoryAvailable(1));
+
+  // Let's try again.
+  module = makeBasicModule();
+  std::tie(promise, future) = getFutureHelper();
+
+  auto networkTwo = cpuCoreDevice.getNextDeviceNetworkID();
+  cpuCoreDevice.addNetwork(networkTwo, std::move(module),
+                           [&promise](DeviceNetworkID id, ResultCode result) {
+                             addNetworkCallbackHelper(promise, id, result);
+                           });
+
+  future.wait_for(2s);
+  auto returnedId = future.get();
+  EXPECT_NE(returnedId, networkTwo);
+  EXPECT_EQ(returnedId, 0);
+
+  EXPECT_EQ(cpuCoreDevice.getMaximumMemory(), expectedBytes);
+  EXPECT_EQ(cpuCoreDevice.getAvailableMemory(), 0);
+
+  // Evict the first network.
+  cpuCoreDevice.evictNetwork(1);
+
+  module = makeBasicModule();
+  std::tie(promise, future) = getFutureHelper();
+
+  auto networkThree = cpuCoreDevice.getNextDeviceNetworkID();
+  cpuCoreDevice.addNetwork(networkThree, std::move(module),
+                           [&promise](DeviceNetworkID id, ResultCode result) {
+                             addNetworkCallbackHelper(promise, id, result);
+                           });
+
+  future.wait_for(2s);
+  EXPECT_EQ(future.get(), networkThree);
+
+  EXPECT_EQ(cpuCoreDevice.getMaximumMemory(), expectedBytes);
+  EXPECT_EQ(cpuCoreDevice.getAvailableMemory(), 0);
+}


### PR DESCRIPTION
*Description*: A first prototype of the DeviceManager, which is the interface to a single inference Device. Per our design discussion the interface supports three operations:

** addNetwork() - compile and load a module (or sub module) onto the device ready to be executed.
** evictNetwork() - unload a module from the device and from memory.
** runFunction() - run a Function (subgraph) with the provided context and callback with results.

The DeviceManager operates in it's own thread, which for the CPU backend implemented here also does compilation and running of the function.

*Testing*: Ported one unit test model to the new execution scheme as an example POC. A better test would be parallelizing the execution, however.
*Documentation*:
Part of the high level Runtime issue #2045.