### PR TITLE
[hotfix] fix build of lib/Testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,8 @@ include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
 
 if(NOT EXISTS "${GLOW_SOURCE_DIR}/tests/googletest/googletest")
   message(FATAL_ERROR "No googletest git submodule. Run: git submodule update --init --recursive")
+else()
+    include_directories(${GLOW_SOURCE_DIR}/tests/googletest/googletest/include)
 endif()
 
 if(NOT EXISTS "${GLOW_THIRDPARTY_DIR}/onnx")


### PR DESCRIPTION
*Description*: 
Fix broken build due to #2132 .
Since `Testing` is in `lib/` and `gtest` in `tests`, cmake doesn't seem to properly 'connect' both. Declaring the `gtest` includes at top level like it is already done for `fp16` solves the build issue.
```
glow/lib/Testing/StrCheck.cpp:18:25: fatal error: gtest/gtest.h: No such file or directory
 #include "gtest/gtest.h"
                         ^
compilation terminated.
```

*Testing*: Builds correctly locally

*Documentation*: N/A
