### PR TITLE
[fix] Fix uni-directional broadcasting 

### DIFF
--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -327,8 +327,8 @@ protected:
     bool broadcast;
     ASSIGN_VALUE_OR_RETURN_ERR(broadcast, getBroadcast(dict));
 
-    Node *finalIn0 = nullptr;
-    Node *finalIn1 = nullptr;
+    NodeValue finalIn0 = in0;
+    NodeValue finalIn1 = in1;
 
     if (broadcast) {
       // Broadcasting can be:
@@ -364,12 +364,8 @@ protected:
           // Align trailing most dimensions.
           axis = in0.dims().size() - in1.dims().size();
         }
-        finalIn0 = in0;
         finalIn1 = G_.createBroadcast(opName, in1, in0.dims(), axis);
       }
-    } else {
-      finalIn0 = in0;
-      finalIn1 = in1;
     }
 
     Node *node = nullptr;

--- a/tests/models/onnxModels/UniBroadcastIssue2135.onnxtxt
+++ b/tests/models/onnxModels/UniBroadcastIssue2135.onnxtxt
@@ -1,0 +1,65 @@
+ir_version: 3
+
+producer_name: "onnx-arith-broadcast"
+opset_import { 
+  version: 6
+}
+
+graph {
+  name: "test-model"
+
+node {
+    name: "top"
+    op_type: "TopK"
+    input: "data"
+    output: "top_values"
+    output: "top_indexes"
+    attribute {
+      name: "k"
+      i: 5
+      type: INT
+    }
+  }
+  
+  node {
+    name: "div"
+    op_type: "Div"
+    input: "top_values"
+    input: "scalar"
+    output: "out"
+    attribute {
+      name: "broadcast"
+      i: 1
+      type: INT
+    }
+    attribute {
+      name: "axis"
+      i: -1
+      type: INT
+    }
+  }
+  
+  initializer {
+    dims: 1
+    data_type: FLOAT
+    float_data: 2.0
+    name: "scalar"
+  }
+  
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: FLOAT
+        shape {
+          dim {
+            dim_value: 20
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "out"
+   }
+}

--- a/tests/unittests/onnxImporterTest.cpp
+++ b/tests/unittests/onnxImporterTest.cpp
@@ -181,6 +181,19 @@ TEST(onnx, importDivUniBroadcastOp6Axis) {
       [](float a, float b) { return a / b; });
 }
 
+/// This tests reproduces issue #2135.
+TEST(onnx, importUniBroadcastMultiOutput) {
+  ExecutionEngine EE{BackendKind::Interpreter};
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+
+  std::string NetFilename =
+      std::string("tests/models/onnxModels/UniBroadcastIssue2135.onnxtxt");
+  Tensor data(ElemKind::FloatTy, {20});
+  ONNXModelLoader onnxLD(NetFilename, {"data"}, {&data.getType()}, *F);
+  (void)onnxLD;
+}
+
 /// Test loading conv op from a ONNX model.
 /// The input is N*C*H*W (1*1*3*3), the kernels is {2, 2},
 /// strides is {1, 1}, pads is {1, 1, 1, 1}, group is 1.


### PR DESCRIPTION
*Description*: 
Hopefully, this is the last iteration for broadcasting :)

There were an issue when handling the unidirectional broadcasting (Caffe2 and ONNX opset <7) with an `in0` operand that has multiple outputs (TopK in the particular failing case).

The problem is due to  `NodeValue `-> `Node *` -> `NodeValue` conversion chain that fails in the last stage because `Node *` -> `NodeValue` can't be implicitly done when the node has multiple outputs.

This fix just removes the useless initial `NodeValue` -> `Node * ` conversion.

*Testing*: 

The problem has been detected with Caffe2, but I reproduced the issue with ONNX that I'm more familiar with (Caffe2 and ONNX opset <6 almost behave the same way for broadcasting). I added reproducer test `importUniBroadcastMultiOutput`.

*Documentation*: N/A

Fixes #2135 

