### PR TITLE
[cmake] Shared library dep for onnxifi-glow-lib

### DIFF
--- a/lib/Onnxifi/CMakeLists.txt
+++ b/lib/Onnxifi/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(onnxifi-glow-thread-pool
 target_link_libraries(onnxifi-glow-lib
                       PUBLIC
                         ExecutionEngine
+                        Graph
                         Importer
                       PRIVATE
                         onnxifi-glow-thread-pool)


### PR DESCRIPTION
*Description*: I don't understand why CI didn't catch this.
*Testing*: cmake -DBUILD_SHARED_LIBS=ON ...
*Documentation*: n/a

