### PR TITLE
[support] Move the Onnixifi thread pool into Support/ so it's easier to reuse.

### DIFF
--- a/include/glow/Support/ThreadPool.h
+++ b/include/glow/Support/ThreadPool.h
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef GLOW_ONNXIFI_THREAD_POOL_H
-#define GLOW_ONNXIFI_THREAD_POOL_H
+#ifndef GLOW_SUPPORT_THREADPOOL_H
+#define GLOW_SUPPORT_THREADPOOL_H
 
 #include <atomic>
 #include <condition_variable>
@@ -25,7 +25,6 @@
 #include <vector>
 
 namespace glow {
-namespace onnxifi {
 
 /// Thread pool for asynchronous execution of generic functions.
 class ThreadPool final {
@@ -40,6 +39,9 @@ public:
 
   /// Submit \p fn as a work item for the thread pool.
   void submit(const std::function<void(void)> &fn);
+
+  /// Stop all threads and optionally wait for them to join.
+  void stop(bool block = false);
 
 private:
   /// Main loop run by the workers in the thread pool.
@@ -65,7 +67,6 @@ private:
   /// Vector of worker thread objects.
   std::vector<std::thread> workers_;
 };
-} // namespace onnxifi
 } // namespace glow
 
-#endif // GLOW_ONNXIFI_THREAD_POOL_H
+#endif // GLOW_SUPPORT_THREADPOOL_H

--- a/lib/Onnxifi/Base.h
+++ b/lib/Onnxifi/Base.h
@@ -16,10 +16,9 @@
 #ifndef GLOW_ONNXIFI_BASE_H
 #define GLOW_ONNXIFI_BASE_H
 
-#include "ThreadPool.h"
-
 #include "glow/ExecutionEngine/ExecutionEngine.h"
 #include "glow/Importer/ONNXIFIModelLoader.h"
+#include "glow/Support/ThreadPool.h"
 
 #include "onnx/onnxifi.h"
 

--- a/lib/Onnxifi/CMakeLists.txt
+++ b/lib/Onnxifi/CMakeLists.txt
@@ -11,21 +11,15 @@ add_library(onnxifi-glow-lib
               GlowOnnxifiManager.cpp
               onnxifiGlow.cpp)
 
-add_library(onnxifi-glow-thread-pool
-              ThreadPool.cpp)
-
-
 target_link_libraries(onnxifi-glow-lib
                       PUBLIC
                         ExecutionEngine
                         Importer
-                      PRIVATE
-                        onnxifi-glow-thread-pool)
+                        ThreadPool)
 
 target_link_libraries(onnxifi-glow
                       PUBLIC
                         ExecutionEngine
                         Graph
                         Importer
-                      PRIVATE
-                        onnxifi-glow-thread-pool)
+                        ThreadPool)

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -6,3 +6,8 @@ add_library(Support
 target_link_libraries(Support
                       PRIVATE
                         LLVMSupport)
+
+add_library(ThreadPool
+              ThreadPool.cpp)
+
+

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -191,6 +191,15 @@ target_link_libraries(typeAToTypeBFunctionConverterTest
 add_glow_test(typeAToTypeBFunctionConverterTest
               ${GLOW_BINARY_DIR}/tests/typeAToTypeBFunctionConverterTest --gtest_output=xml:typeAToTypeBFunctionConverterTest.xml)
 
+add_executable(threadPoolTest
+               ThreadPoolTest.cpp)
+target_link_libraries(threadPoolTest
+                      PRIVATE
+                        ThreadPool
+                        gtest
+                        testMain)
+add_glow_test(threadPoolTest ${GLOW_BINARY_DIR}/tests/threadPoolTest --gtest_output=xml:threadPoolTest.xml)
+
 add_executable(UtilsTest
                StrCheck.cpp
                UtilsTest.cpp)
@@ -323,18 +332,6 @@ target_link_libraries(onnxImporterTest
                         testMain)
 add_glow_test(NAME onnxImporterTest
               COMMAND ${GLOW_BINARY_DIR}/tests/onnxImporterTest --gtest_output=xml:onnxImporterTest.xml
-              WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-
-add_executable(onnxifiThreadPoolTest
-               onnxifiThreadPoolTest.cpp)
-target_link_libraries(onnxifiThreadPoolTest
-                      PRIVATE
-                        onnxifi-glow-thread-pool
-                        gtest
-                        testMain)
-target_include_directories(onnxifiThreadPoolTest PRIVATE ${CMAKE_SOURCE_DIR}/lib/Onnxifi)
-add_glow_test(NAME onnxifiThreadPoolTest
-              COMMAND ${GLOW_BINARY_DIR}/tests/onnxifiThreadPoolTest --gtest_output=xml:onnxifiThreadPoolTest.xml
               WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
 add_executable(GlowOnnxifiManagerTest

--- a/tests/unittests/ThreadPoolTest.cpp
+++ b/tests/unittests/ThreadPoolTest.cpp
@@ -13,15 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "ThreadPool.h"
+#include "glow/Support/ThreadPool.h"
 #include "gtest/gtest.h"
 
 #include <future>
 #include <vector>
 
-using namespace glow::onnxifi;
+using namespace glow;
 
-TEST(onnxifiThreadPool, BasicTest) {
+TEST(ThreadPool, BasicTest) {
   const unsigned numWorkers = 100;
   const unsigned numWorkItems = 1000;
   ThreadPool tp(numWorkers);


### PR DESCRIPTION
*Description*: Per @jackm321's suggestion, we should reuse the Onnixifi ThreadPool in the runtime, so moving it into the common area.

I also split out the shutdown stage into a separate function to allow more flexible control of shutting down the pool.
*Testing*: ninja test
*Documentation*: