### PR TITLE
[cmake] Require only version 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.5)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 


### PR DESCRIPTION
*Description*: I'm building Glow on Ubuntu 16.04 where the default cmake package is 3.5, and it seems to work happily.  Does anyone know if there's a reason against relaxing this?  @compnerd?
*Testing*: cmake && ninja
*Documentation*: n/a

