### PR TITLE
[Support] switch from std::function to std::packaged_task in ThreadPool

### DIFF
--- a/tests/unittests/ThreadPoolTest.cpp
+++ b/tests/unittests/ThreadPoolTest.cpp
@@ -49,3 +49,29 @@ TEST(ThreadPool, BasicTest) {
     EXPECT_EQ(result, 2 * i);
   }
 }
+
+TEST(ThreadPool, moveCaptureTest) {
+  ThreadPool tp(1);
+
+  std::unique_ptr<int> input = std::make_unique<int>(42);
+  int output = 0;
+  auto func = [input = std::move(input), &output]() { output = (*input) * 2; };
+
+  auto done = tp.submit(std::move(func));
+
+  done.wait();
+  EXPECT_EQ(output, 84);
+}
+
+TEST(ThreadPool, completionFutureTest) {
+  ThreadPool tp(1);
+
+  int input = 42, output = 0;
+  std::packaged_task<void(void)> task(
+      [&input, &output]() { output = input * 3; });
+
+  auto done = tp.submit(std::move(task));
+
+  done.wait();
+  EXPECT_EQ(output, 126);
+}


### PR DESCRIPTION
*Description*: The ThreadPool is storing tasks as std::functions which prevents using move only types in the lambda capture. std::packaged_task is a better abstraction for one time run lambdas and does not have this limitation. We'll have to monitor performance of the thread pool as we scale up.
*Testing*: ninja test, but especially two new ThreadPool tests - one which verifies move-only captures, and another which demonstrates we can use the packaged_tasks's included future to tell when the task has executed.
*Documentation*: n/a