### PR TITLE
[Fix] Fix for windows build with VS. Setting ONNXIFI_PUBLIC to dllexport.

### DIFF
--- a/lib/Onnxifi/CMakeLists.txt
+++ b/lib/Onnxifi/CMakeLists.txt
@@ -24,3 +24,11 @@ target_link_libraries(onnxifi-glow
                         Graph
                         Importer
                         ThreadPool)
+			
+target_compile_definitions(onnxifi-glow
+                           PRIVATE
+                             ONNXIFI_BUILD_LIBRARY)
+
+target_compile_definitions(onnxifi-glow-lib
+                           PRIVATE
+                             ONNXIFI_BUILD_LIBRARY)


### PR DESCRIPTION
*Description*: Defining ONNXIFI_BUILD_LIBRARY so that ONNXIFI_PUBLIC is defined as dllexport in onnxifi.h. 
*Testing*: Unit tests win/linux.
*Documentation*: https://msdn.microsoft.com/hu-hu/library/a90k134d.aspx
[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
