### PR TITLE
Delay the 'Quantize(Constant)->Constant' optim until after post-lowering.

### DIFF
--- a/include/glow/Optimizer/Optimizer.h
+++ b/include/glow/Optimizer/Optimizer.h
@@ -43,6 +43,9 @@ void optimize(Function *F, CompilationMode mode);
 /// operators.
 void lower(Function *F, const Backend &B);
 
+/// Performs the actual quantization of the constant payload in function \p F.
+bool quantizeConstantsPayload(Function *F);
+
 /// Convert placeholders in Module \p M to constants based on the values in \p
 /// ctx.  Do not convert any placeholders explicitly listed in \p vars.
 void convertPlaceholdersToConstants(Function *F, const Context &ctx,

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -145,6 +145,14 @@ void ExecutionEngine::optimizeFunction(CompilationMode mode, Function *F) {
     // In particular, DCE is very likely to be useful.
     ::glow::optimize(F, mode);
   }
+
+  // Do the actual float ->fix point conversion of constant tensors once all
+  // optimizations are performed in order to get the best quantization accuracy.
+  if (::glow::quantizeConstantsPayload(F)) {
+    // Optimize the graph again after the constant quantization.
+    // In particular, DCE is very likely to be useful.
+    ::glow::optimize(F, mode);
+  }
 }
 
 void ExecutionEngine::compile(CompilationMode mode, Function *F) {

--- a/tests/unittests/quantizationTest.cpp
+++ b/tests/unittests/quantizationTest.cpp
@@ -1198,14 +1198,45 @@ TEST(Quantization, quantizeFunctionConvertConstant) {
     ASSERT_TRUE(LHSQuantize);
     EXPECT_EQ(LHSQuantize->getInput().getNode(), LHS);
 
+    auto *RHSQuantize = llvm::dyn_cast<QuantizeNode>(MMN->getRHS());
+    ASSERT_TRUE(RHSQuantize);
+    EXPECT_EQ(RHSQuantize->getInput().getNode(), RHS);
+  }
+
+  // Make sure that graph can be compiled.
+  EE.compile(CompilationMode::Infer, F);
+
+  {
+    // Verify that the output variable is not quantized, and that it has a
+    // single save node writer, which is also not quantized.
+    EXPECT_TRUE(!result->getType()->isQuantizedType());
+    ASSERT_EQ(result->getUsers().size(), 1);
+    auto *SN = llvm::dyn_cast<SaveNode>(result->getUsers().begin()->getUser());
+    ASSERT_TRUE(SN);
+    EXPECT_TRUE(!SN->getOutput().getType()->isQuantizedType());
+
+    // Verify that the input to save is a dequantize node.
+    auto *DN = llvm::dyn_cast<DequantizeNode>(SN->getInput());
+    ASSERT_TRUE(DN);
+
+    // Verify that the matmul is quantized.
+    auto *MMN = llvm::dyn_cast<MatMulNode>(DN->getInput());
+    ASSERT_TRUE(MMN);
+    EXPECT_TRUE(MMN->getResult().getType()->isQuantizedType());
+
+    // Verify that the variable inputs to the matmul are quantized.
+    // Verify that the constant (RHS) is statically quantized by the
+    // compilation.
+    auto *LHSQuantize = llvm::dyn_cast<QuantizeNode>(MMN->getLHS());
+    ASSERT_TRUE(LHSQuantize);
+    EXPECT_EQ(LHSQuantize->getInput().getNode(), LHS);
+
     auto *RHS = llvm::dyn_cast<Constant>(MMN->getRHS());
     ASSERT_TRUE(RHS);
     EXPECT_TRUE(RHS->getType()->isQuantizedType());
   }
 
-  // Make sure that graph can be compiled and run.
-  EE.compile(CompilationMode::Infer, F);
-
+  // Make sure that graph can run.
   EE.run(ctx);
 }
 


### PR DESCRIPTION
*Description*: 

This PR extracts the `Quantize(Constant)->Constant` optim from `glow::optimize()` and move this merge optimization to after post-lowering.

In addition it:
- modifies the optimizations that expect Constant to be an operand (there is actually only one: mergeTransposeIntoMatMul)
- adds optimizations to allow 'non destructive' nodes (reshape, transpose) to still be merged by `glow::optimize()` into a constant quantized tensor  (`<Node>(Quantize(Constant) -> Quantize(Const)`)


*Testing*:

- Changed existing tests to reflect the fact that Quantize nodes are not optimized out by `glow::optimize()`
- Added test for modified and now optimizations

*Documentation*: N/A

Issue #2165


