### PR TITLE
[Instructions] Add memory-related verification for operands

### DIFF
--- a/lib/IR/IR.cpp
+++ b/lib/IR/IR.cpp
@@ -115,6 +115,17 @@ void Instruction::verifyUseList(
 }
 
 void Instruction::verify() const {
+  // All operands of instructions must be either memory (AllocActivation or
+  // WeightVar), or a TensorView of such.
+  for (const auto &opPair : getOperands()) {
+    const Value *op = opPair.first;
+    (void)op;
+    assert((isa<AllocActivationInst>(op) || isa<WeightVar>(op) ||
+            isa<TensorViewInst>(op)) &&
+           "Operands must be one of {AllocActivation, WeightVar, TensorView}");
+  }
+
+  // Perform Instruction-specific verification.
 #define DEF_INSTR(CLASS, NAME)                                                 \
   if (auto *X = dyn_cast<const CLASS>(this))                                   \
     X->verify();

--- a/lib/IR/Instrs.cpp
+++ b/lib/IR/Instrs.cpp
@@ -54,11 +54,6 @@ void CopyInst::verify() const {
   (void)dest;
   (void)src;
   assert(dest->getType() == src->getType() && "Invalid type.");
-  // The operands of the copy instruction must be variables.
-  assert(isa<AllocActivationInst>(dest) || isa<WeightVar>(dest) ||
-         isa<TensorViewInst>(dest));
-  assert(isa<AllocActivationInst>(src) || isa<WeightVar>(src) ||
-         isa<TensorViewInst>(src));
 }
 
 void TensorViewInst::verify() const {

--- a/tests/unittests/BasicIRTest.cpp
+++ b/tests/unittests/BasicIRTest.cpp
@@ -218,3 +218,51 @@ TEST(IR, predicateIR) {
     M.verify();
   }
 }
+
+/// Note that IRFunction validation uses asserts, so these tests only die when
+/// asserts are turned on.
+#ifndef NDEBUG
+
+/// Check that the verify call dies when verifying an IRFunction with a
+/// non-memory/view Instruction with another non-memory/view Instruction as
+/// an input operand.
+TEST(IR, VerifyDiesOnInvalidInputOperand) {
+  Module mod;
+  Function *F = mod.createFunction("InvalidOperands");
+  IRFunction M(F);
+  {
+    IRBuilder builder(&M);
+    auto *LHS = builder.createWeightVar(ElemKind::FloatTy, {10, 10});
+    auto *RHS = builder.createWeightVar(ElemKind::FloatTy, {10, 10});
+    auto *O = builder.createWeightVar(ElemKind::FloatTy, {10, 10});
+    auto *EAI = builder.createElementAddInst("Add", O, LHS, RHS);
+
+    // Invalid to use a non-memory/view Instruction as input operand.
+    builder.createElementAddInst("Add", O, EAI, RHS);
+
+    EXPECT_DEATH(M.verify(), "");
+  }
+}
+
+/// Check that the verify call dies when verifying an IRFunction with a
+/// non-memory/view Instruction with another non-memory/view Instruction as
+/// an output operand.
+TEST(IR, VerifyDiesOnInvalidOutputOperand) {
+  Module mod;
+  Function *F = mod.createFunction("InvalidOperands");
+  IRFunction M(F);
+  {
+    IRBuilder builder(&M);
+    auto *LHS = builder.createWeightVar(ElemKind::FloatTy, {10, 10});
+    auto *RHS = builder.createWeightVar(ElemKind::FloatTy, {10, 10});
+    auto *O = builder.createWeightVar(ElemKind::FloatTy, {10, 10});
+    auto *EAI = builder.createElementAddInst("Add", O, LHS, RHS);
+
+    // Invalid to use a non-memory/view Instruction as output operand.
+    builder.createElementAddInst("Add", EAI, LHS, RHS);
+
+    EXPECT_DEATH(M.verify(), "");
+  }
+}
+
+#endif /* NDEBUG */


### PR DESCRIPTION
*Description*: It seems that previously there was no verification to make sure Instructions are correctly using memory instructions. This adds more verification for these.
*Testing*: Added a couple tests.