### PR TITLE
[DOCKER] add Dockerfile for cpu env

### DIFF
--- a/utils/docker/Dockerfile
+++ b/utils/docker/Dockerfile
@@ -1,0 +1,36 @@
+# for CPU env
+FROM ubuntu:16.04
+
+LABEL version="0.1"
+
+# Install Glow dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential \
+        wget \
+        clang-6.0 \
+        llvm-6.0 \
+        llvm-6.0-dev \
+        llvm-6.0-tools \
+        libpng-dev \
+        python-dev \
+        ninja-build \
+# onnx dependencies
+        protobuf-compiler \
+        libprotoc-dev \
+        && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+
+RUN wget --no-check-certificate https://bootstrap.pypa.io/get-pip.py && \
+    python get-pip.py && \
+    rm get-pip.py
+
+# Redirect clang
+RUN ln -s /usr/bin/clang-6.0 /usr/bin/clang
+RUN ln -s /usr/bin/clang++-6.0 /usr/bin/clang++
+
+# Install ninja and (newest version of) cmake through pip
+RUN pip --no-cache-dir install \
+        ninja \
+        cmake \
+        lit

--- a/utils/docker/build.sh
+++ b/utils/docker/build.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+docker build -f Dockerfile -t pytorch/glow-0.1 .


### PR DESCRIPTION
*Description*: 
Docker is very useful tool to setup dev or CI environment
Does glow have any plan to provide the dockerfile like [TVM] (https://github.com/dmlc/tvm/tree/master/docker)?

*Testing*: passed testsuites without OpenCL backend. 

*Documentation*:
[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
