### PR TITLE
Allow for creating quantized Sigmoid and Tanh directly

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -312,6 +312,12 @@ public:
   /// Result type will be implicitly set based on the \p input type.
   SigmoidNode *createSigmoid(llvm::StringRef name, NodeValue input);
 
+  /// Create a Tanh node with the given \p name, \p input and
+  /// output type \p outTy.
+  TanhNode *createTanh(llvm::StringRef name, TypeRef outTy, NodeValue input);
+
+  /// Create a Tanh node with the given \p name and \p input.
+  /// Result type will be implicitly set based on the \p input type.
   TanhNode *createTanh(llvm::StringRef name, NodeValue input);
 
   /// Create a Log node with \p name, which calculates element-wise natural log

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -303,6 +303,13 @@ public:
   /// output type \p outTy.
   ReluNode *createRELU(llvm::StringRef name, NodeValue input, TypeRef outTy);
 
+  /// Create a Sigmoid node with the given \p name, \p input and
+  /// output type \p outTy.
+  SigmoidNode *createSigmoid(llvm::StringRef name, TypeRef outTy,
+                             NodeValue input);
+
+  /// Create a Sigmoid node with the given \p name and \p input.
+  /// Result type will be implicitly set based on the \p input type.
   SigmoidNode *createSigmoid(llvm::StringRef name, NodeValue input);
 
   TanhNode *createTanh(llvm::StringRef name, NodeValue input);

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -646,8 +646,13 @@ ReluNode *Function::createRELU(llvm::StringRef name, NodeValue input) {
   return addNode(new ReluNode(name, input.getType(), input));
 }
 
+SigmoidNode *Function::createSigmoid(llvm::StringRef name, TypeRef outTy,
+                                     NodeValue input) {
+  return addNode(new SigmoidNode(name, outTy, input));
+}
+
 SigmoidNode *Function::createSigmoid(llvm::StringRef name, NodeValue input) {
-  return addNode(new SigmoidNode(name, input));
+  return createSigmoid(name, input.getType(), input);
 }
 
 TanhNode *Function::createTanh(llvm::StringRef name, NodeValue input) {

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -655,8 +655,13 @@ SigmoidNode *Function::createSigmoid(llvm::StringRef name, NodeValue input) {
   return createSigmoid(name, input.getType(), input);
 }
 
+TanhNode *Function::createTanh(llvm::StringRef name, TypeRef outTy,
+                               NodeValue input) {
+  return addNode(new TanhNode(name, outTy, input));
+}
+
 TanhNode *Function::createTanh(llvm::StringRef name, NodeValue input) {
-  return addNode(new TanhNode(name, input));
+  return createTanh(name, input.getType(), input);
 }
 
 SoftMaxNode *Function::createSoftMax(llvm::StringRef name, NodeValue input,

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -247,7 +247,15 @@ static bool verifySigmoid(NodeValue src, NodeValue dest) {
 }
 
 static bool verifyTanh(NodeValue src, NodeValue dest) {
-  return checkSameType(src, dest, dest.getNode());
+  const Node *parent = dest.getNode();
+  bool isValid = checkSameIsQuantized(src.getType(), dest.getType(), parent);
+  if (src.getType()->isQuantizedType()) {
+    isValid &= checkType(src, dest.getElementType(), dest.getNode());
+    isValid &= checkSameShape(src, dest, parent);
+  } else {
+    isValid &= checkSameType(src, dest, parent);
+  }
+  return isValid;
 }
 
 static bool verifySoftMax(NodeValue src, NodeValue dest) {

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -235,7 +235,15 @@ static bool verifyBatchNormalization(NodeValue src, NodeValue dest,
 }
 
 static bool verifySigmoid(NodeValue src, NodeValue dest) {
-  return checkSameType(src, dest, dest.getNode());
+  const Node *parent = dest.getNode();
+  bool isValid = checkSameIsQuantized(src.getType(), dest.getType(), parent);
+  if (src.getType()->isQuantizedType()) {
+    isValid &= checkType(src, dest.getElementType(), dest.getNode());
+    isValid &= checkSameShape(src, dest, parent);
+  } else {
+    isValid &= checkSameType(src, dest, parent);
+  }
+  return isValid;
 }
 
 static bool verifyTanh(NodeValue src, NodeValue dest) {

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -3198,7 +3198,7 @@ TEST_P(InterpAndCPU, Int8Tanh) {
       mod_.uniqueType(ElemKind::Int8QTy, {size}, quantizationParams.scale,
                       quantizationParams.offset);
 
-  auto *intTanh = F_->createIntTanh("int8Tanh", quantize, tanhTy);
+  auto *intTanh = F_->createTanh("int8Tanh", tanhTy, quantize);
   auto *dequantize = F_->createDequantize("dequantize", intTanh);
   auto *saveInt = F_->createSave("int8Save", dequantize);
   ctx_.allocate(saveInt->getPlaceholder());

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -3475,7 +3475,7 @@ TEST_P(InterpAndCPU, Int8Sigmoid) {
   auto sigmoidTy =
       mod_.uniqueType(ElemKind::Int8QTy, {size}, quantizationParams.scale,
                       quantizationParams.offset);
-  auto *intSigmoid = F_->createIntSigmoid("int8Sigmoid", quantize, sigmoidTy);
+  auto *intSigmoid = F_->createSigmoid("int8Sigmoid", sigmoidTy, quantize);
   auto *dequantize = F_->createDequantize("dequantize", intSigmoid);
   auto *saveInt = F_->createSave("int8Save", dequantize);
   ctx_.allocate(saveInt->getPlaceholder());

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -391,7 +391,8 @@ int main(int argc, char **argv) {
           "Src",
       })
       .dataParallel()
-      .autoVerify(VerifyKind::SameType, {"Dest", "Src"})
+      .autoVerify(VerifyKind::SameElementType, {"Dest", "Src"})
+      .autoVerify(VerifyKind::SameShape, {"Dest", "Src"})
       .autoIRGen();
 
   //===--------------------------------------------------------------------===//

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -379,7 +379,8 @@ int main(int argc, char **argv) {
           "Src",
       })
       .dataParallel()
-      .autoVerify(VerifyKind::SameType, {"Dest", "Src"})
+      .autoVerify(VerifyKind::SameElementType, {"Dest", "Src"})
+      .autoVerify(VerifyKind::SameShape, {"Dest", "Src"})
       .autoIRGen();
 
   BB.newInstr("Tanh")

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -384,7 +384,7 @@ int main(int argc, char **argv) {
 
   BB.newNode("Tanh")
       .addInput("Input")
-      .addResult("Input.getType()")
+      .addResultFromCtorArg()
       .addGradient()
       .setDocstring("Applies hyperbolic tangent to each element in the Input "
                     "tensor.");

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -377,7 +377,7 @@ int main(int argc, char **argv) {
 
   BB.newNode("Sigmoid")
       .addInput("Input")
-      .addResult("Input.getType()")
+      .addResultFromCtorArg()
       .addGradient()
       .setDocstring("Applies Sigmoid, 1 / (1 + exp(-x)), to each element in "
                     "the Input tensor.");


### PR DESCRIPTION
*Description*: This allows the OperatorTest for quantized Sigmoid and Tanh to be specified correctly. Previously it directly created the lookup table, however some backends may want to implement it differently/prevent lowering.

*Testing*: Tests were updated