### PR TITLE
Use isOpSupported() correctly for Interpreter with fp16

### DIFF
--- a/include/glow/Converter/FunctionConverter.h
+++ b/include/glow/Converter/FunctionConverter.h
@@ -19,6 +19,7 @@
 #define GLOW_CONVERTER_FUNCTIONCONVERTER_H
 
 #include "glow/Base/Type.h"
+#include "glow/ExecutionEngine/ExecutionEngine.h"
 
 #include <utility> // For std::pair.
 
@@ -37,6 +38,9 @@ class FunctionConverter {
 protected:
   /// The function to be converted.
   Function &function_;
+
+  /// Execution engine used to check if an operator is supported.
+  const ExecutionEngine &EE_;
 
   /// \return the type that \p out needs to have at the end of the conversion
   /// procedure. In other words, this is the type this value will have at the
@@ -139,12 +143,14 @@ protected:
   virtual void cleanUp() {}
 
 public:
-  /// Create a function converter for \p F.
+  /// Create a function converter for \p F. The backend from the \p EE is used
+  /// when determining if the backend supports the destination type.
   ///
   /// \note This method will modify \p F when calling ::convert.
   ///       If one wants to keep the original function around,
   ///       they need to clone it before creating this converter.
-  FunctionConverter(Function &F) : function_(F) {}
+  FunctionConverter(Function &F, const ExecutionEngine &EE)
+      : function_(F), EE_(EE) {}
 
   virtual ~FunctionConverter() {}
 

--- a/include/glow/Converter/TypeAToTypeBFunctionConverter.h
+++ b/include/glow/Converter/TypeAToTypeBFunctionConverter.h
@@ -66,8 +66,10 @@ protected:
 public:
   /// Create a type converter from \p fromKind to \p toKind for \p F.
   /// If \p doNotConvertKinds is not nullptr, the nodes which kind
-  /// is in this set won't be converted.
-  TypeAToTypeBFunctionConverter(Function &F, ElemKind fromKind, ElemKind toKind,
+  /// is in this set won't be converted. Conversion to the \p toKind is done
+  /// only as permitted by what is supported by the backend in \p EE.
+  TypeAToTypeBFunctionConverter(Function &F, const ExecutionEngine &EE,
+                                ElemKind fromKind, ElemKind toKind,
                                 const KindSet *doNotConvertKinds = nullptr);
 };
 } // namespace glow

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -174,7 +174,7 @@ bool CPUBackend::isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const {
     }
   }
 
-  return true;
+  return elementTy == ElemKind::FloatTy;
 }
 
 bool CPUBackend::shouldLower(const Node *N) const {

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -80,11 +80,57 @@ bool Interpreter::isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const {
       return false;
     }
   }
+
   if (elementTy == ElemKind::Float16Ty) {
-    return false;
+    switch (opKind) {
+    case Kinded::Kind::TileNodeKind:
+    case Kinded::Kind::ReshapeNodeKind:
+    case Kinded::Kind::TransposeNodeKind:
+    case Kinded::Kind::GatherNodeKind:
+    case Kinded::Kind::ConvolutionNodeKind:
+    case Kinded::Kind::FullyConnectedNodeKind:
+    case Kinded::Kind::AvgPoolNodeKind:
+    case Kinded::Kind::MaxPoolNodeKind:
+    case Kinded::Kind::SigmoidNodeKind:
+    case Kinded::Kind::TanhNodeKind:
+    case Kinded::Kind::SoftMaxNodeKind:
+    case Kinded::Kind::CrossEntropyLossNodeKind:
+    case Kinded::Kind::BatchOneHotNodeKind:
+    case Kinded::Kind::LocalResponseNormalizationNodeKind:
+    case Kinded::Kind::AddNodeKind:
+    case Kinded::Kind::SubNodeKind:
+    case Kinded::Kind::MulNodeKind:
+    case Kinded::Kind::DivNodeKind:
+    case Kinded::Kind::MaxNodeKind:
+    case Kinded::Kind::MinNodeKind:
+    case Kinded::Kind::CmpLTENodeKind:
+    case Kinded::Kind::CmpEQNodeKind:
+    case Kinded::Kind::ReluNodeKind:
+    case Kinded::Kind::PowNodeKind:
+    case Kinded::Kind::IsNaNNodeKind:
+    case Kinded::Kind::LogNodeKind:
+    case Kinded::Kind::SelectNodeKind:
+    case Kinded::Kind::MatMulNodeKind:
+    case Kinded::Kind::BatchedAddNodeKind:
+    case Kinded::Kind::BatchedReduceAddNodeKind:
+    case Kinded::Kind::LengthsSumNodeKind:
+    case Kinded::Kind::SparseLengthsWeightedSumNodeKind:
+    case Kinded::Kind::SparseToDenseNodeKind:
+    case Kinded::Kind::TopKNodeKind:
+    case Kinded::Kind::BatchNormalizationNodeKind:
+    case Kinded::Kind::SliceNodeKind:
+    case Kinded::Kind::ConcatNodeKind:
+    case Kinded::Kind::PadNodeKind:
+    case Kinded::Kind::ConvertToNodeKind:
+    case Kinded::Kind::SplatNodeKind:
+    case Kinded::Kind::SigmoidCrossEntropyWithLogitsNodeKind:
+      return true;
+    default:
+      return false;
+    }
   }
 
-  return true;
+  return elementTy == ElemKind::FloatTy;
 }
 
 bool Interpreter::shouldLower(const Node *N) const {

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -197,7 +197,7 @@ public:
         return false;
       }
     }
-    return true;
+    return elementTy == ElemKind::FloatTy;
   };
 
   bool shouldLower(const Node *N) const override {

--- a/lib/Converter/CMakeLists.txt
+++ b/lib/Converter/CMakeLists.txt
@@ -5,4 +5,5 @@ add_library(Converter
 target_link_libraries(Converter
                       PRIVATE
                         Base
-                        Graph)
+                        Graph
+                        ExecutionEngine)

--- a/lib/Converter/FunctionConverter.cpp
+++ b/lib/Converter/FunctionConverter.cpp
@@ -13,14 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#define DEBUG_TYPE "function-converter"
+
 #include "glow/Converter/FunctionConverter.h"
 
 #include "glow/Graph/Context.h"
 #include "glow/Graph/Graph.h" // For Function.
 #include "glow/Graph/Node.h"  // For Node.
 #include "glow/Graph/Nodes.h" // For Placeholder and Constant.
+#include "glow/Support/Debug.h"
 
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
 
 using namespace glow;
 
@@ -181,6 +186,8 @@ void FunctionConverter::convert() {
     --nodeIt;
     Node &node = *nodeIt;
     if (!canConvert(node)) {
+      DEBUG_GLOW(llvm::dbgs()
+                 << "Cannot convert Node \"" << node.getName() << "\"\n");
       continue;
     }
     // Mutate the output types and insert the conversion to keep our

--- a/lib/Converter/TypeAToTypeBFunctionConverter.cpp
+++ b/lib/Converter/TypeAToTypeBFunctionConverter.cpp
@@ -22,9 +22,9 @@
 using namespace glow;
 
 TypeAToTypeBFunctionConverter::TypeAToTypeBFunctionConverter(
-    Function &F, ElemKind fromKind, ElemKind toKind,
+    Function &F, const ExecutionEngine &EE, ElemKind fromKind, ElemKind toKind,
     const KindSet *doNotConvertKinds)
-    : FunctionConverter(F), mod_(*F.getParent()), dstKind_(toKind),
+    : FunctionConverter(F, EE), mod_(*F.getParent()), dstKind_(toKind),
       srcKind_(fromKind) {
   if (doNotConvertKinds) {
     doNotConvertKinds_ = *doNotConvertKinds;

--- a/lib/Converter/TypeAToTypeBFunctionConverter.cpp
+++ b/lib/Converter/TypeAToTypeBFunctionConverter.cpp
@@ -32,6 +32,9 @@ TypeAToTypeBFunctionConverter::TypeAToTypeBFunctionConverter(
 }
 
 bool TypeAToTypeBFunctionConverter::canConvert(const Node &node) const {
+  if (!EE_.isOpSupported(node.getKind(), dstKind_)) {
+    return false;
+  }
   if (doNotConvertKinds_.count(node.getKind())) {
     return false;
   }

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -340,9 +340,6 @@ protected:
 private:
   /// Shortcut to the module of function_.
   Module &mod_;
-  /// Execution engine used to check is a quantized operator is
-  /// supported.
-  const ExecutionEngine &EE_;
   /// Set of node kinds that should not be quantized.
   const KindSet &doNotQuantizeKinds_;
   /// Map the (name of a node, idx) to its quantization parameters.
@@ -359,7 +356,7 @@ public:
   FunctionQuantizer(Function &F, const ExecutionEngine &EE,
                     llvm::ArrayRef<NodeQuantizationInfo> quantizationInfos,
                     const KindSet &doNotQuantizeKinds)
-      : FunctionConverter(F), mod_(*F.getParent()), EE_(EE),
+      : FunctionConverter(F, EE), mod_(*F.getParent()),
         doNotQuantizeKinds_(doNotQuantizeKinds) {
     // Build a mapping between node name and TensorQuantizatonParams.
     for (const auto &quantizationInfo : quantizationInfos) {

--- a/tests/unittests/typeAToTypeBFunctionConverterTest.cpp
+++ b/tests/unittests/typeAToTypeBFunctionConverterTest.cpp
@@ -78,7 +78,7 @@ TEST_P(AllBackends, SimpleOneUseConversionFloatToFloat16) {
 
   size_t origGraphSize = F->getNodes().size();
 
-  TypeAToTypeBFunctionConverter converter(*F, ElemKind::FloatTy,
+  TypeAToTypeBFunctionConverter converter(*F, EE_, ElemKind::FloatTy,
                                           ElemKind::Float16Ty);
   converter.convert();
 
@@ -176,7 +176,7 @@ TEST_P(AllBackends, SimpleChainOfComputationConversionFloatToFloat16) {
 
   size_t origGraphSize = F->getNodes().size();
 
-  TypeAToTypeBFunctionConverter converter(*F, ElemKind::FloatTy,
+  TypeAToTypeBFunctionConverter converter(*F, EE_, ElemKind::FloatTy,
                                           ElemKind::Float16Ty);
   converter.convert();
 
@@ -291,7 +291,7 @@ TEST_P(AllBackends, DoNotConvertReLUConversionFloatToFloat16) {
   KindSet doNotConvertKinds;
   doNotConvertKinds.insert(Kinded::Kind::ReluNodeKind);
   TypeAToTypeBFunctionConverter converter(
-      *F, ElemKind::FloatTy, ElemKind::Float16Ty, &doNotConvertKinds);
+      *F, EE_, ElemKind::FloatTy, ElemKind::Float16Ty, &doNotConvertKinds);
   converter.convert();
 
   // We should have 4 more nodes:
@@ -394,7 +394,7 @@ TEST_P(AllBackends, int64IConversionFloatToFloat16) {
 
   size_t origGraphSize = F->getNodes().size();
 
-  TypeAToTypeBFunctionConverter converter(*F, ElemKind::FloatTy,
+  TypeAToTypeBFunctionConverter converter(*F, EE_, ElemKind::FloatTy,
                                           ElemKind::Float16Ty);
   converter.convert();
 
@@ -516,7 +516,7 @@ TEST_P(AllBackends, OptimizeMiddleConversionsFloatToFloat16) {
 
   size_t origGraphSize = F->getNodes().size();
 
-  TypeAToTypeBFunctionConverter converter(*F, ElemKind::FloatTy,
+  TypeAToTypeBFunctionConverter converter(*F, EE_, ElemKind::FloatTy,
                                           ElemKind::Float16Ty);
   converter.convert();
 
@@ -705,7 +705,7 @@ TEST_P(AllBackends, convertPlaceholderFloatToFloat16) {
   size_t f2OrigGraphSize = F2->getNodes().size();
   size_t f3OrigGraphSize = F3->getNodes().size();
 
-  TypeAToTypeBFunctionConverter converter(*F, ElemKind::FloatTy,
+  TypeAToTypeBFunctionConverter converter(*F, EE_, ElemKind::FloatTy,
                                           ElemKind::Float16Ty);
   for (auto *placeholder : mod.getPlaceholders()) {
     if (output2 == placeholder) {
@@ -834,7 +834,7 @@ TEST_P(AllBackends, convertExistingConversionToNoop) {
 
   size_t origSize = F->getNodes().size();
 
-  TypeAToTypeBFunctionConverter converter(*F, ElemKind::FloatTy,
+  TypeAToTypeBFunctionConverter converter(*F, EE_, ElemKind::FloatTy,
                                           ElemKind::Float16Ty);
   converter.convert();
 

--- a/tests/unittests/typeAToTypeBFunctionConverterTest.cpp
+++ b/tests/unittests/typeAToTypeBFunctionConverterTest.cpp
@@ -25,10 +25,14 @@
 
 using namespace glow;
 
-struct AllBackends : public ::testing::TestWithParam<BackendKind> {
+struct ConvertTest : public ::testing::TestWithParam<BackendKind> {
 protected:
   ExecutionEngine EE_{GetParam()};
 };
+
+class AllBackends : public ConvertTest {};
+
+class InterpOnly : public ConvertTest {};
 
 /// Check that a simple graph is converted properly.
 /// Namely, check that:
@@ -63,7 +67,7 @@ protected:
 /// \endverbatim
 ///
 /// In particular, the input and output of the network shouldn't be modified.
-TEST_P(AllBackends, SimpleOneUseConversionFloatToFloat16) {
+TEST_P(InterpOnly, SimpleOneUseConversionFloatToFloat16) {
   Module mod;
   Function *F = mod.createFunction("test");
   Context ctx;
@@ -160,7 +164,7 @@ TEST_P(AllBackends, SimpleOneUseConversionFloatToFloat16) {
 /// \endverbatim
 ///
 /// In particular, the input and output of the network shouldn't be modified.
-TEST_P(AllBackends, SimpleChainOfComputationConversionFloatToFloat16) {
+TEST_P(InterpOnly, SimpleChainOfComputationConversionFloatToFloat16) {
   Module mod;
   Function *F = mod.createFunction("test");
   Context ctx;
@@ -272,7 +276,7 @@ TEST_P(AllBackends, SimpleChainOfComputationConversionFloatToFloat16) {
 /// \endverbatim
 ///
 /// In particular, the input and output of the network shouldn't be modified.
-TEST_P(AllBackends, DoNotConvertReLUConversionFloatToFloat16) {
+TEST_P(InterpOnly, DoNotConvertReLUConversionFloatToFloat16) {
   Module mod;
   Function *F = mod.createFunction("test");
   Context ctx;
@@ -376,7 +380,7 @@ TEST_P(AllBackends, DoNotConvertReLUConversionFloatToFloat16) {
 ///
 /// In particular, the input and outputs of the network shouldn't be modified
 /// as well as the Int64I result.
-TEST_P(AllBackends, int64IConversionFloatToFloat16) {
+TEST_P(InterpOnly, int64IConversionFloatToFloat16) {
   Module mod;
   Function *F = mod.createFunction("test");
   Context ctx;
@@ -485,7 +489,7 @@ TEST_P(AllBackends, int64IConversionFloatToFloat16) {
 /// \endverbatim
 ///
 /// In particular, the input and output of the network shouldn't be modified.
-TEST_P(AllBackends, OptimizeMiddleConversionsFloatToFloat16) {
+TEST_P(InterpOnly, OptimizeMiddleConversionsFloatToFloat16) {
   Module mod;
   Function *F = mod.createFunction("test");
   Context ctx;
@@ -822,7 +826,7 @@ TEST_P(AllBackends, convertPlaceholderFloatToFloat16) {
 /// |
 /// V
 /// Save
-TEST_P(AllBackends, convertExistingConversionToNoop) {
+TEST_P(InterpOnly, convertExistingConversionToNoop) {
   Module mod;
   Function *F = mod.createFunction("test");
   auto *placeholder =
@@ -855,6 +859,8 @@ TEST_P(AllBackends, convertExistingConversionToNoop) {
   EXPECT_TRUE(F->verify());
 }
 
+INSTANTIATE_TEST_CASE_P(Interpreter, InterpOnly,
+                        ::testing::Values(BackendKind::Interpreter));
 INSTANTIATE_TEST_CASE_P(Interpreter, AllBackends,
                         ::testing::Values(BackendKind::Interpreter));
 

--- a/tools/loader/ImageClassifier.cpp
+++ b/tools/loader/ImageClassifier.cpp
@@ -172,7 +172,8 @@ buildAndCompileAndGetInAndOutPair(Loader &loader, Context &ctx,
   // converted later.
   if (convertInAndOutToFp16) {
     TypeAToTypeBFunctionConverter converter(
-        *loader.getFunction(), ElemKind::FloatTy, ElemKind::Float16Ty);
+        *loader.getFunction(), loader.getExecutionEngine(), ElemKind::FloatTy,
+        ElemKind::Float16Ty);
     for (auto *placeholder : loader.getModule()->getPlaceholders()) {
       converter.convertPlaceholder(*placeholder, &ctx);
     }

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -272,7 +272,7 @@ void Loader::compile(Context &ctx) {
   }
 
   if (convertToFP16) {
-    TypeAToTypeBFunctionConverter converter(*F_, ElemKind::FloatTy,
+    TypeAToTypeBFunctionConverter converter(*F_, EE_, ElemKind::FloatTy,
                                             ElemKind::Float16Ty,
                                             &keepOriginalPrecisionForNodes);
     converter.convert();

--- a/tools/loader/Loader.h
+++ b/tools/loader/Loader.h
@@ -47,6 +47,8 @@ public:
   Function *getFunction() { return F_; }
   /// Getter for the Module.
   Module *getModule() { return F_->getParent(); }
+  /// Getter for the ExecutionEngine.
+  const ExecutionEngine &getExecutionEngine() { return EE_; }
   /// Getter for the Caffe2 network file name.
   llvm::StringRef getCaffe2NetDescFilename() { return caffe2NetDescFilename_; }
   /// Getter for the Caffe2 weights file name.


### PR DESCRIPTION
*Description*: Add all the nodes we support for fp16 to the Interpreter's `isOpSupported()`. We were previously returning false for all fp16 nodes. This is clearly incorrect; we should use the `isOpSupported()` API correctly. The FunctionQuantizer was already doing this. For this I added the EE to the FunctionConverter and removed it from FunctionQuantizer.

*Testing*: All tests still pass. Also checked some networks (e.g. Resnet50, shufflenet, etc.) to make sure the graph still appears the same.