### PR TITLE
[cmake] Don't install googletest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,7 @@ if (GLOW_WITH_BUNDLES AND NOT GLOW_WITH_CPU)
 endif()
 
 if (GLOW_BUILD_TESTS)
-  add_subdirectory(tests/googletest)
+  add_subdirectory(tests/googletest EXCLUDE_FROM_ALL)
   add_subdirectory(tests)
 
   # Fetch the dependencies for all the tests.


### PR DESCRIPTION
*Description*: We don't support installing glow system-wide yet, but I tried `ninja install` anyways, and got a bunch of gmock/gtest targets installed.  I think we should exclude them so as not to inadvertently pollute the user's system.

*Testing*: `ninja install` properly does nothing

*Documentation*: n/a

