### PR TITLE
Fix Onnxifi lib build dependencies

### DIFF
--- a/lib/Onnxifi/CMakeLists.txt
+++ b/lib/Onnxifi/CMakeLists.txt
@@ -16,6 +16,7 @@ target_link_libraries(onnxifi-glow-lib
                         ExecutionEngine
                         Graph
                         Importer
+                        Optimizer
                         ThreadPool)
 
 target_link_libraries(onnxifi-glow
@@ -23,8 +24,9 @@ target_link_libraries(onnxifi-glow
                         ExecutionEngine
                         Graph
                         Importer
+                        Optimizer
                         ThreadPool)
-			
+
 target_compile_definitions(onnxifi-glow
                            PRIVATE
                              ONNXIFI_BUILD_LIBRARY)


### PR DESCRIPTION
*Description*: Onnxifi/Base.cpp uses glow::lower which needs `Optimizer` as a dependency. I'm not sure why this worked in the CI system.
*Testing*: ninja all in release.
*Documentation*: n/a
