### PR TITLE
[graph] Add clone() method for Module, copying all non-placeholder nodes

### DIFF
--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -92,7 +92,7 @@ public:
   const Tensor &getPayload() const { return payload_; }
 
   template <class ElemTy = float> Handle<ElemTy> getHandle() {
-    return getPayload().getHandle<ElemTy>();
+    return payload_.getHandle<ElemTy>();
   }
 
   void assign(const Tensor *t) { payload_.assign(t); }
@@ -102,12 +102,14 @@ public:
   llvm::hash_code getHash() const;
 
   bool verify() const;
+
+  Constant *clone() const;
 };
 
 /// Placeholder nodes are unbound-storage. The content tensors are attached to
 /// this node at runtime. Placeholders are used as inputs and output nodes to
 /// the network.
-class Placeholder : public Storage {
+class Placeholder : public Storage, public Refcounted {
   /// Specifies if the placeholder is trainable.
   bool isTrainable_;
 
@@ -119,6 +121,8 @@ public:
     addResult(Ty);
   }
 
+  virtual ~Placeholder() {}
+
   /// \returns True if the placeholder are trainable during
   /// differentiation.
   bool isTraining() const { return isTrainable_; }
@@ -126,6 +130,8 @@ public:
   static bool classof(const Kinded *k) {
     return k->getKind() == Kinded::Kind::PlaceholderKind;
   }
+
+  Placeholder *clone() const;
 
   std::string getDebugDesc() const;
 

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -330,6 +330,14 @@ bool Constant::verify() const {
                            *getType(), getPayload().getType(), this);
 }
 
+Constant *Constant::clone() const {
+  return new Constant(getName(), payload_.clone());
+}
+
+Placeholder *Placeholder::clone() const {
+  return new Placeholder(getName(), Node::getType(0), isTrainable_);
+}
+
 bool ConvolutionGradNode::verify() const {
   bool isValid = verifyInputAndGradInputTypes(getInput(),
                                               getGradOfInputNamedInput(), this);


### PR DESCRIPTION
*Description*: Add ability to clone a `Module`, which creates a copy of the graph and all constants but that shares Placeholders and Types.
** For Constants: we copy the backing Tensor memory, since compiling Functions in a Module can be destructive of the Constant representation.
** For Placeholders we now have multiple Modules holding a raw ptr, and need a count to manage lifetimes. The obvious solution is to use a shared_ptr here but that would change a lot of interfaces and I wasn't sure about it. Instead I've added a `Refcounted` trait which has a similar effect. I think we should work out the right ownership model here sometime soon.
** For Types we can just keep a shared_ptr to the list since it is not modified after graph create time. There is no thread safety across cloned Modules, just as there is no thread safety when using a single Module.
*Testing*: ninja test with the new test verifying cloned modules share only Placeholder objects in the graph.
*Documentation*: n/a