### PR TITLE
[WIP][ONNXIFI][Runtime] Create custom error types

### DIFF
--- a/include/glow/Support/Error.h
+++ b/include/glow/Support/Error.h
@@ -45,6 +45,152 @@ template <typename> struct IsLLVMExpected : public std::false_type {};
 template <typename T>
 struct IsLLVMExpected<llvm::Expected<T>> : public std::true_type {};
 
+template <typename ThisErrT> class BaseErr : public llvm::ErrorInfoBase {
+public:
+  static const void *classID() { return &ThisErrT::ID; }
+
+  const void *dynamicClassID() const override { return &ThisErrT::ID; }
+
+  bool isA(const void *const ClassID) const override {
+    return ClassID == classID() || llvm::ErrorInfoBase::isA(ClassID);
+  }
+
+  virtual std::error_code convertToErrorCode() const override {
+    return llvm::inconvertibleErrorCode();
+  }
+
+  void log(llvm::raw_ostream &OS) const override {
+    OS << "file: " << fileName_ << " line: " << lineNumber_ << " error: \"";
+    static_cast<const ThisErrT *>(this)->logErr(OS);
+    OS << "\"";
+  }
+
+protected:
+  BaseErr(llvm::StringRef fileName, int32_t lineNumber) {
+    fileName_ = fileName;
+    lineNumber_ = lineNumber;
+  }
+
+private:
+  int32_t lineNumber_;
+  std::string fileName_;
+};
+
+class ModelLoadingErr final : public BaseErr<ModelLoadingErr> {
+public:
+  // Used by BaseErr.
+  static char ID;
+
+  enum EC {
+    UNKNOWN = 0,
+    UNSUPPORTED_SHAPE = 1,
+    UNSUPPORTED_OPERATOR = 2,
+    UNSUPPORTED_ATTRIBUTE = 3,
+    UNSUPPORTED_DATATYPE = 4,
+  };
+
+  static llvm::StringRef ecToString(const EC ec) {
+    switch (ec) {
+    case UNKNOWN:
+      return "UNKNOWN";
+    case UNSUPPORTED_SHAPE:
+      return "UNSUPPORTED_SHAPE";
+    case UNSUPPORTED_OPERATOR:
+      return "UNSUPPORTED_OPERATOR";
+    case UNSUPPORTED_ATTRIBUTE:
+      return "UNSUPPORTED_ATTRIBUTE";
+    case UNSUPPORTED_DATATYPE:
+      return "UNSUPPORTED_DATATYPE";
+    }
+  }
+
+  ModelLoadingErr(llvm::StringRef fileName, int32_t lineNumber,
+                  llvm::StringRef message, EC ec)
+      : BaseErr(fileName, lineNumber) {
+    message_ = message;
+    ec_ = ec;
+  }
+
+  ModelLoadingErr(llvm::StringRef fileName, int32_t lineNumber,
+                  llvm::StringRef message)
+      : BaseErr(fileName, lineNumber) {
+    message_ = message;
+  }
+
+  void logErr(llvm::raw_ostream &OS) const {
+    OS << "Failed to load model. Encountered " << ecToString(ec_)
+       << " error: " << message_;
+  }
+
+  EC getEC() const { return ec_; }
+
+private:
+  std::string message_;
+  EC ec_ = EC::UNKNOWN;
+};
+
+#define MAKE_MODEL_LOADING_ERR(...)                                            \
+  llvm::make_error<ModelLoadingErr>(__FILE__, __LINE__, __VA_ARGS__)
+
+#define RETURN_MODEL_LOADING_ERR(...)                                          \
+  do {                                                                         \
+    return MAKE_MODEL_LOADING_ERR(__VA_ARGS__);                                \
+  } while (0)
+
+class RuntimeErr final : public BaseErr<RuntimeErr> {
+public:
+  // Used by BaseErr.
+  static char ID;
+
+  enum EC {
+    UNKNOWN = 0,
+    NO_DEVICE_MEMORY = 1,
+    NO_HOST_MEMORY = 2,
+    UNKNOWN_NETWORK = 3,
+    QUEUE_FULL = 4,
+    PARTITION_FAILED = 5,
+  };
+
+  static llvm::StringRef ecToString(const EC ec) {
+    switch (ec) {
+    case UNKNOWN:
+      return "UNKNOWN";
+    case NO_DEVICE_MEMORY:
+      return "NO_DEVICE_MEMORY";
+    case NO_HOST_MEMORY:
+      return "NO_HOST_MEMORY";
+    case UNKNOWN_NETWORK:
+      return "UNKNOWN_NETWORK";
+    case QUEUE_FULL:
+      return "QUEUE_FULL";
+    case PARTITION_FAILED:
+      return "PARTITION_FAILED";
+    }
+  }
+
+  RuntimeErr(llvm::StringRef fileName, int32_t lineNumber, EC ec)
+      : BaseErr(fileName, lineNumber) {
+    ec_ = ec;
+  }
+
+  void logErr(llvm::raw_ostream &OS) const {
+    OS << "Encountered runtime error: " << ecToString(ec_);
+  }
+
+  EC getEC() const { return ec_; }
+
+private:
+  EC ec_ = EC::UNKNOWN;
+};
+
+#define MAKE_RUNTIME_ERR(...)                                                  \
+  llvm::make_error<RuntimeErr>(__FILE__, __LINE__, __VA_ARGS__)
+
+#define RETURN_RUNTIME_ERR(...)                                                \
+  do {                                                                         \
+    return MAKE_RUNTIME_ERR(__VA_ARGS__);                                      \
+  } while (0)
+
 /// Unwraps the T from within an llvm::Expected<T>. If the Expected<T> contains
 /// an error, the program will exit.
 #define EXIT_ON_ERR(...) (exitOnErr(__VA_ARGS__))

--- a/lib/Support/Error.cpp
+++ b/lib/Support/Error.cpp
@@ -25,4 +25,27 @@ std::string addFileAndLineToError(llvm::StringRef str, llvm::StringRef file,
   return llvm::formatv("Error at file {0} line {1} \"{2}\"", file, line, str);
 }
 
+char ModelLoadingErr::ID = 0;
+char RuntimeErr::ID = 0;
+
+llvm::Error doSomething() {
+  RETURN_MODEL_LOADING_ERR("Glow doesn't support 3D convolution",
+                           ModelLoadingErr::EC::UNSUPPORTED_SHAPE);
+}
+
+/*
+// EXAMPLE FROM DEVICE MANAGER
+using ReadyCB = std::function<void(llvm::Expected<DeviceNetworkID>)>;
+using ResultCB = std::function<void(llvm::Expected<std::unique_ptr<Context>>)>;
+
+addNetwork(networkId, module, [](llvm::Expected<DeviceNetworkID>
+deviceNetworIdOrErr) { if (deviceNetworIdOrErr) {
+    // do whatever this callback does
+    signalResults(llvm::Error::success());
+  } else {
+    signalResults(std::move(deviceNetworIdOrErr.takeError()));
+  }
+}
+
+*/
 } // namespace glow


### PR DESCRIPTION
*Description*:
This PR creates two custom error types for glow, a `ModelLoadingErr` and `RuntimeErr`. `ModelLoadingErr` can be used in model loading code to provide helpful error message when model loading fails as well as provide an error code that can be used to return an appropriate ONNXIFI status.
`RuntimeErr` only contains an error code and it too can also be used to return appropriate ONNXIFI statuses in the event that device or host memory is all consumed for example.

I think `ModelLoadingErr` is basically necessary however I'm not as convinced about creating a `RuntimeErr` as opposed to just using an enum to signify statuses in the runtime. The advantages of using an `RuntimeErr` over an enum are 

1. Guaranteed to be checked.
2. Unified error propagation throughout ONNXIFI and runtime, all code in the runtime and model loading just deals with llvm::Error (no matter what the underlying error type is) and it can either handle errors by type or propagate on anything that isn't `Error::Success` no matter what the type of error is, no need to check specific enum values. For example, if function `A` calls function `B` and function `B` returns an llvm::Error (be it a `ModelLoadingErr`, `RuntimeErr`, or some other error), function `A` can then just return the Error up the stack to the handlers at the ONNXIFI layer without worrying about what specifically went wrong).
3. Can use llvm::Expected syntax.
4. Can add more error information such as a string to explain the situation if necessary.

The cons of using `RuntimeErr` include more complexity than using an enum and higher cost of handling errors when they occur (need to allocate a  `RuntimeErr` if an error occurs).

Thoughts on this?

*Testing*:
n/a
*Documentation*:
not yet
