### PR TITLE
Ensure/verify that Instructions and WeightVars have unique names

### DIFF
--- a/include/glow/IR/IRBuilder.h
+++ b/include/glow/IR/IRBuilder.h
@@ -52,7 +52,7 @@ public:
   /// @name High-level, operation-level IRBuilder.
   ///@{
 
-  MaxPoolWithXYInst *createMaxPoolWithXYOp(Value *input,
+  MaxPoolWithXYInst *createMaxPoolWithXYOp(llvm::StringRef name, Value *input,
                                            llvm::ArrayRef<unsigned_t> kernels,
                                            llvm::ArrayRef<unsigned_t> strides,
                                            llvm::ArrayRef<unsigned_t> pads);
@@ -61,19 +61,19 @@ public:
                                llvm::ArrayRef<unsigned_t> strides,
                                llvm::ArrayRef<unsigned_t> pads);
 
-  CrossEntropyLossInst *createCrossEntropyLossOp(Value *P, Value *labels);
+  CrossEntropyLossInst *createCrossEntropyLossOp(llvm::StringRef name, Value *P,
+                                                 Value *labels);
 
   TensorViewInst *createTensorView(ElemKind elemKind,
                                    llvm::ArrayRef<size_t> dims, Value *src,
                                    llvm::StringRef name,
                                    llvm::ArrayRef<size_t> offsets = {});
 
-  LocalResponseNormalizationInst *
-  createLocalResponseNormalizationOp(Value *input, size_t halfWindowSize = 2,
-                                     float alpha = 1e-4, float beta = 0.75,
-                                     float k = 2.0);
+  LocalResponseNormalizationInst *createLocalResponseNormalizationOp(
+      llvm::StringRef name, Value *input, size_t halfWindowSize = 2,
+      float alpha = 1e-4, float beta = 0.75, float k = 2.0);
 
-  TopKInst *createTopKOp(Value *input, size_t k);
+  TopKInst *createTopKOp(llvm::StringRef name, Value *input, size_t k);
 
   Value *createReturnOp(Value *input);
 

--- a/lib/IR/IR.cpp
+++ b/lib/IR/IR.cpp
@@ -20,6 +20,7 @@
 #include "glow/IR/Instrs.h"
 #include "glow/Support/Support.h"
 
+#include "llvm/ADT/StringSet.h"
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/raw_ostream.h"
@@ -303,10 +304,14 @@ static void verifyLiveness(const IRFunction &M) {
 void IRFunction::verify() const {
   InstructionNumbering InstrNumbering(*this);
   assert(!instrs_.empty() && "Instruction list is empty!");
+  llvm::StringSet<> nameSet;
   for (const auto &I : instrs_) {
     I.verifyUseList(InstrNumbering);
     verifyOperandsAccess(&I);
     I.verify();
+    auto it = nameSet.insert(I.getName());
+    (void)it;
+    assert(it.second && "All Instruction and WeightVar names must be unique.");
   }
 
   verifyLiveness(*this);
@@ -317,6 +322,9 @@ void IRFunction::verify() const {
            "Weight and variable must have the same type");
     p.second->verify(*this);
     p.second->verifyUseList(InstrNumbering);
+    auto it = nameSet.insert(p.second->getName());
+    (void)it;
+    assert(it.second && "All Instruction and WeightVar names must be unique.");
   }
 }
 

--- a/lib/IR/IRGen.cpp
+++ b/lib/IR/IRGen.cpp
@@ -155,11 +155,10 @@ public:
     case glow::Kinded::Kind::MaxPoolNodeKind: {
       auto *P = cast<MaxPoolNode>(N);
       auto *in = valueForNode(P->getInput());
-      auto *V = builder_.createMaxPoolWithXYOp(in, P->getKernels(),
-                                               P->getStrides(), P->getPads());
+      auto *V = builder_.createMaxPoolWithXYOp(
+          N->getName(), in, P->getKernels(), P->getStrides(), P->getPads());
       Value *dest = V->getDest();
       nodeToInstr_[N] = V;
-      V->setName(N->getName());
       registerIR(N, dest);
       break;
     }
@@ -222,8 +221,7 @@ public:
       auto *CELoss = cast<CrossEntropyLossNode>(N);
       auto *P = valueForNode(CELoss->getP());
       auto *Labels = valueForNode(CELoss->getLabels());
-      auto *V = builder_.createCrossEntropyLossOp(P, Labels);
-      V->setName(N->getName());
+      auto *V = builder_.createCrossEntropyLossOp(N->getName(), P, Labels);
       registerIR(N, V->getCE());
       nodeToInstr_[N] = V;
       break;
@@ -326,9 +324,8 @@ public:
       auto *LR = cast<LocalResponseNormalizationNode>(N);
       auto *in = valueForNode(LR->getInput());
       auto *V = builder_.createLocalResponseNormalizationOp(
-          in, LR->getHalfWindowSize(), LR->getAlpha(), LR->getBeta(),
-          LR->getK());
-      V->setName(N->getName());
+          N->getName(), in, LR->getHalfWindowSize(), LR->getAlpha(),
+          LR->getBeta(), LR->getK());
       nodeToInstr_[N] = V;
       registerIR(N, V->getDest());
       break;
@@ -361,15 +358,13 @@ public:
       auto *R = cast<SaveNode>(N);
       auto *src = valueForNode(R->getInput());
       auto *dest = valueForNode(R->getOutput());
-      auto *V = builder_.createCopyInst("save", dest, src);
-      V->setName(N->getName());
+      builder_.createCopyInst(N->getName(), dest, src);
       break;
     }
     case glow::Kinded::Kind::ConstantKind: {
       auto *V = cast<Constant>(N);
       auto *W = builder_.createWeightVar(V->getType(), V->getName(),
                                          WeightVar::MutabilityKind::Constant);
-      W->setName(N->getName());
       registerIR(N, W);
       break;
     }
@@ -377,7 +372,6 @@ public:
       auto *P = cast<Placeholder>(N);
       auto *W = builder_.createWeightVar(P->getType(), P->getName(),
                                          WeightVar::MutabilityKind::Mutable);
-      W->setName(N->getName());
       registerIR(N, W);
       break;
     }
@@ -395,10 +389,9 @@ public:
       auto *TKN = cast<TopKNode>(N);
       auto *inputTensor = valueForNode(TKN->getInput());
       auto k = TKN->getK();
-      auto *V = builder_.createTopKOp(inputTensor, k);
+      auto *V = builder_.createTopKOp(N->getName(), inputTensor, k);
       registerIR(TKN->getValues(), V->getValues());
       registerIR(TKN->getIndices(), V->getIndices());
-      V->setName(N->getName());
       break;
     }
     }

--- a/tools/ClassGen/InstrBuilder.cpp
+++ b/tools/ClassGen/InstrBuilder.cpp
@@ -381,8 +381,8 @@ void InstrBuilder::emitAutoIRGen(std::ostream &os) const {
        << "__ = builder_.createAllocActivationInst(allocName,"
        << "CN__->get" << nodeResultName << "().getType());\n";
   }
-  os << "  auto *V = builder_.create" << name_ << "Inst(\"" << autoIRGenNodeName
-     << "\"";
+  os << "  auto *V = builder_.create" << name_ << "Inst(N->getName()";
+
   // Pass down all the output operand Values as Instruction's constructor
   // arguments.
   for (auto &kv : nodeResultNameToValueName) {
@@ -403,7 +403,6 @@ void InstrBuilder::emitAutoIRGen(std::ostream &os) const {
   }
   os << ");\n";
 
-  os << "  V->setName(N->getName());\n";
   os << "  if (N->hasPredicate()) { "
         "V->setPredicate(valueForNode(N->getPredicate())); }\n";
   // Register which outputs of a node are mapped to which output operands of the


### PR DESCRIPTION
*Description*: We were using `setName()` in many places on Instructions without checking that the name was unique. This PR removes all problematic calls I found, in AutGenIRGen and in the IRBuilder. I added a verify check to make sure all Instrs and WeightVars have unique names.

*Testing*: Added a unit test.

Fixes https://github.com/pytorch/glow/issues/2179