### PR TITLE
[quantization] More flexible general quantization support (int8/int16)

### DIFF
--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -300,8 +300,16 @@ public:
              "Offsets must match.");
       return isEqualImpl<int8_t>(other, allowedError);
     case ElemKind::Int16QTy:
+      assert(getType().getScale() == other.getType().getScale() &&
+             "Scales must match.");
+      assert(getType().getOffset() == other.getType().getOffset() &&
+             "Offsets must match.");
       return isEqualImpl<int16_t>(other, allowedError);
     case ElemKind::Int32QTy:
+      assert(getType().getScale() == other.getType().getScale() &&
+             "Scales must match.");
+      assert(getType().getOffset() == other.getType().getOffset() &&
+             "Offsets must match.");
       return isEqualImpl<int32_t>(other, allowedError);
     case ElemKind::Int32ITy:
       return isEqualImpl<int32_t>(other, allowedError);

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -109,40 +109,40 @@ private:
 #define DEF_BACKEND_SPECIFIC_INSTR(CLASS, NAME)
 #include "glow/AutoGenInstr.def"
 
-  void fwdConvolutionInst_I8Impl(Value *inV, Value *outV, Value *filterV,
-                                 Value *biasV,
-                                 llvm::ArrayRef<unsigned_t> kernelSizes,
-                                 llvm::ArrayRef<unsigned_t> strides,
-                                 llvm::ArrayRef<unsigned_t> pads, size_t group);
+  template <typename ElemTy, typename AccumulatorTy>
+  void fwdConvolutionInstQuantizedImpl(Value *inV, Value *outV, Value *filterV,
+                                       Value *biasV,
+                                       llvm::ArrayRef<unsigned_t> kernelSizes,
+                                       llvm::ArrayRef<unsigned_t> strides,
+                                       llvm::ArrayRef<unsigned_t> pads,
+                                       size_t group);
 
   template <typename ElemTy = float>
-  void fwdConvolutionInst_FloatImpl(Value *inV, Value *outV, Value *filterV,
-                                    Value *biasV,
-                                    llvm::ArrayRef<unsigned_t> kernelSizes,
-                                    llvm::ArrayRef<unsigned_t> strides,
-                                    llvm::ArrayRef<unsigned_t> pads,
-                                    size_t group);
+  void fwdConvolutionInstFloatImpl(Value *inV, Value *outV, Value *filterV,
+                                   Value *biasV,
+                                   llvm::ArrayRef<unsigned_t> kernelSizes,
+                                   llvm::ArrayRef<unsigned_t> strides,
+                                   llvm::ArrayRef<unsigned_t> pads,
+                                   size_t group);
 
-  void fwdAvgPoolInst_I8Impl(const AvgPoolInst *I);
-  template <typename ElemTy>
-  void fwdAvgPoolInst_FloatImpl(const AvgPoolInst *I);
-  template <typename ElemTy> void fwdSoftMaxInst_Impl(const SoftMaxInst *I);
+  void fwdAvgPoolInstI8Impl(const AvgPoolInst *I);
+  template <typename ElemTy> void fwdAvgPoolInstFloatImpl(const AvgPoolInst *I);
+  template <typename ElemTy> void fwdSoftMaxInstImpl(const SoftMaxInst *I);
 
-  void fwdMatMulInst_I8Impl(const glow::MatMulInst *I);
+  void fwdMatMulInstI8Impl(const glow::MatMulInst *I);
   template <typename ElemTy>
-  void fwdMatMulInst_FloatImpl(const glow::MatMulInst *I);
+  void fwdMatMulInstFloatImpl(const glow::MatMulInst *I);
 
-  void fwdElementAddInst_I8Impl(const ElementAddInst *I);
+  void fwdElementAddInstI8Impl(const ElementAddInst *I);
   template <typename ElemTy>
-  void fwdElementAddInst_FloatImpl(const ElementAddInst *I);
+  void fwdElementAddInstFloatImpl(const ElementAddInst *I);
 
-  void fwdElementMaxInst_I8Impl(const ElementMaxInst *I);
+  void fwdElementMaxInstI8Impl(const ElementMaxInst *I);
   template <typename ElemTy>
-  void fwdElementMaxInst_FloatImpl(const ElementMaxInst *I);
+  void fwdElementMaxInstFloatImpl(const ElementMaxInst *I);
 
-  void fwdBatchedAddInst_I8Impl(const BatchedAddInst *I);
   template <typename ElemTy>
-  void fwdBatchedAddInst_FloatImpl(const BatchedAddInst *I);
+  void fwdBatchedAddInstFloatImpl(const BatchedAddInst *I);
 
   template <typename ElemTy>
   void fwdElementCmpEQInstImpl(const glow::ElementCmpEQInst *I);
@@ -150,68 +150,67 @@ private:
   template <typename ElemTy>
   void fwdBatchOneHotImpl(const glow::BatchOneHotInst *I);
 
-  template <typename ElemTy>
-  void fwdSigmoidInst_FloatImpl(const SigmoidInst *I);
+  template <typename ElemTy> void fwdSigmoidInstFloatImpl(const SigmoidInst *I);
 
-  template <typename ElemTy> void fwdTanhInst_FloatImpl(const TanhInst *I);
-
-  template <typename ElemTy>
-  void fwdCrossEntropyLossInst_FloatImpl(const CrossEntropyLossInst *I);
+  template <typename ElemTy> void fwdTanhInstFloatImpl(const TanhInst *I);
 
   template <typename ElemTy>
-  void fwdLocalResponseNormalizationInst_FloatImpl(
+  void fwdCrossEntropyLossInstFloatImpl(const CrossEntropyLossInst *I);
+
+  template <typename ElemTy>
+  void fwdLocalResponseNormalizationInstFloatImpl(
       const glow::LocalResponseNormalizationInst *I);
 
   template <typename ElemTy>
-  void fwdElementSubInst_FloatImpl(const ElementSubInst *I);
+  void fwdElementSubInstFloatImpl(const ElementSubInst *I);
 
   template <typename ElemTy>
-  void fwdElementMulInst_FloatImpl(const ElementMulInst *I);
+  void fwdElementMulInstFloatImpl(const ElementMulInst *I);
 
   template <typename ElemTy>
-  void fwdElementMinInst_FloatImpl(const ElementMinInst *I);
+  void fwdElementMinInstFloatImpl(const ElementMinInst *I);
 
   template <typename ElemTy>
-  void fwdElementCmpLTEInst_FloatImpl(const ElementCmpLTEInst *I);
+  void fwdElementCmpLTEInstFloatImpl(const ElementCmpLTEInst *I);
 
   template <typename ElemTy>
-  void fwdElementPowInst_FloatImpl(const ElementPowInst *I);
+  void fwdElementPowInstFloatImpl(const ElementPowInst *I);
 
   template <typename ElemTy>
-  void fwdElementIsNaNInst_FloatImpl(const ElementIsNaNInst *I);
+  void fwdElementIsNaNInstFloatImpl(const ElementIsNaNInst *I);
 
   template <typename ElemTy>
-  void fwdElementLogInst_FloatImpl(const ElementLogInst *I);
+  void fwdElementLogInstFloatImpl(const ElementLogInst *I);
 
   template <typename ElemTy>
-  void fwdElementSelectInst_FloatImpl(const ElementSelectInst *I);
+  void fwdElementSelectInstFloatImpl(const ElementSelectInst *I);
 
   template <typename ElemTy>
-  void fwdBatchedReduceAddInst_FloatImpl(Value *batch, Value *dest,
-                                         unsigned_t axis,
-                                         const ShapeVector &eBatchDims,
-                                         const ShapeVector &eDestDims);
+  void fwdBatchedReduceAddInstFloatImpl(Value *batch, Value *dest,
+                                        unsigned_t axis,
+                                        const ShapeVector &eBatchDims,
+                                        const ShapeVector &eDestDims);
 
   template <typename ElemTy>
-  void fwdLengthsSumInst_FloatImpl(const LengthsSumInst *I);
+  void fwdLengthsSumInstFloatImpl(const LengthsSumInst *I);
 
   template <typename ElemTy> void fwdGatherInstImpl(const GatherInst *I);
   template <typename ElemTy>
   void fwdGatherRangesInstImpl(const GatherRangesInst *I);
 
   void
-  fwdSparseLengthsWeightedSumInst_I8Impl(const SparseLengthsWeightedSumInst *I);
+  fwdSparseLengthsWeightedSumInstI8Impl(const SparseLengthsWeightedSumInst *I);
   template <typename ElemTy>
-  void fwdSparseLengthsWeightedSumInst_FloatImpl(
+  void fwdSparseLengthsWeightedSumInstFloatImpl(
       const SparseLengthsWeightedSumInst *I);
 
   template <typename ElemTy>
-  void fwdSparseToDenseInst_FloatImpl(const SparseToDenseInst *I);
+  void fwdSparseToDenseInstFloatImpl(const SparseToDenseInst *I);
 
   template <class eTy>
-  void fwdRescaleQuantizedInst_impl(Value *src, Value *dest,
-                                    TensorQuantizationParams &srcQ,
-                                    TensorQuantizationParams &destQ);
+  void fwdRescaleQuantizedInstImpl(Value *src, Value *dest,
+                                   TensorQuantizationParams &srcQ,
+                                   TensorQuantizationParams &destQ);
   ///@}
 };
 

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -129,7 +129,8 @@ private:
   template <typename ElemTy> void fwdAvgPoolInstFloatImpl(const AvgPoolInst *I);
   template <typename ElemTy> void fwdSoftMaxInstImpl(const SoftMaxInst *I);
 
-  void fwdMatMulInstI8Impl(const glow::MatMulInst *I);
+  template <typename ElemTy, typename AccumulatorTy>
+  void fwdMatMulInstQuantizedImpl(const glow::MatMulInst *I);
   template <typename ElemTy>
   void fwdMatMulInstFloatImpl(const glow::MatMulInst *I);
 

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -46,6 +46,9 @@ using namespace glow;
   case ElemKind::Int16QTy:                                                     \
     functionName<int16_t>(__VA_ARGS__);                                        \
     break;                                                                     \
+  case ElemKind::Int32QTy:                                                     \
+    functionName<int32_t>(__VA_ARGS__);                                        \
+    break;                                                                     \
   default:                                                                     \
     llvm_unreachable("Type is not supported");                                 \
   }

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -770,9 +770,9 @@ bool IntLookupTableNode::verify() const {
                         getResult().getType()->isQuantizedType(), true, this);
   isValid &= expectCompareTrue("Mapping should be 1 dimensional",
                                getMapping().dims().size(), size_t(1), this);
-
-  isValid &= expectCompareTrue("Mapping should cover whole quantized range",
-                               getMapping().dims()[0], size_t(256), this);
+  isValid &= expectCompareTrue(
+      "Mapping should cover whole quantized range", getMapping().dims()[0],
+      (size_t)(256 * getResult().getType()->getElementSize()), this);
   return isValid;
 }
 

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -163,9 +163,6 @@ protected:
   Node *createConversion(Function &function, NodeValue &val,
                          TypeRef destTy) override {
     if (destTy->isQuantizedType()) {
-      assert((destTy->getElementType() == ElemKind::Int8QTy ||
-              destTy->getElementType() == ElemKind::Int32QTy) &&
-             "We only support int8_t and int32_t quantization now");
       return function_.createQuantize("quantize", val, destTy);
     }
     assert(destTy->getElementType() == ElemKind::FloatTy && "");

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -1736,7 +1736,8 @@ TEST_P(InterpOnly, FP16ConvolutionDepth8) {
   checkFloat16Convolution(EE_, F_, 8);
 }
 
-void checkIntConvolution(ExecutionEngine &EE, Function *F, unsigned convDepth,
+void checkIntConvolution(ExecutionEngine &EE, Function *F,
+                         ElemKind quantizationKind, unsigned convDepth,
                          Context &ctx) {
   // In this test we generate a Floating-point based convolution and an integer
   // convolution. We pass the same values and then subtract the results. We
@@ -1756,10 +1757,10 @@ void checkIntConvolution(ExecutionEngine &EE, Function *F, unsigned convDepth,
   ctx.get(bias)->getHandle().randomize(-2.0, 2.0, mod.getPRNG());
 
   TypeRef resTy =
-      mod.uniqueType(ElemKind::Int8QTy, conv->getResult().dims(), 0.08, 0.0);
-  TypeRef inputTy = mod.uniqueType(ElemKind::Int8QTy, input->dims(), 0.01, 0.0);
+      mod.uniqueType(quantizationKind, conv->getResult().dims(), 0.08, 0.0);
+  TypeRef inputTy = mod.uniqueType(quantizationKind, input->dims(), 0.01, 0.0);
   TypeRef filterTy =
-      mod.uniqueType(ElemKind::Int8QTy, filter->dims(), 0.01, 0.0);
+      mod.uniqueType(quantizationKind, filter->dims(), 0.01, 0.0);
   TypeRef biasTy = mod.uniqueType(ElemKind::Int32QTy, bias->dims(), 0.04, 0.0);
 
   auto *inputq = F->createQuantize("input.q", input, inputTy);
@@ -1787,12 +1788,20 @@ void checkIntConvolution(ExecutionEngine &EE, Function *F, unsigned convDepth,
   }
 }
 
-TEST_P(Operator, IntConvolutionDepth10) {
-  checkIntConvolution(EE_, F_, 10, ctx_);
+TEST_P(Operator, Int8ConvolutionDepth10) {
+  checkIntConvolution(EE_, F_, ElemKind::Int8QTy, 10, ctx_);
 }
 
-TEST_P(Operator, IntConvolutionDepth8) {
-  checkIntConvolution(EE_, F_, 8, ctx_);
+TEST_P(InterpOnly, Int16ConvollutionDepth10) {
+  checkIntConvolution(EE_, F_, ElemKind::Int16QTy, 10, ctx_);
+}
+
+TEST_P(Operator, Int8ConvolutionDepth8) {
+  checkIntConvolution(EE_, F_, ElemKind::Int8QTy, 8, ctx_);
+}
+
+TEST_P(InterpOnly, Int16ConvolutionDepth8) {
+  checkIntConvolution(EE_, F_, ElemKind::Int16QTy, 8, ctx_);
 }
 
 TEST_P(InterpAndCPU, IntConcat) {

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -483,8 +483,8 @@ int main(int argc, char **argv) {
       .addOperand("Dest", OperandKind::Out)
       .addOperand("Src", OperandKind::In)
       .addOperand("Mapping", OperandKind::In)
-      .autoVerify(VerifyKind::SameElementType,
-                  {"Dest", "Src", "ElemKind::Int8QTy"})
+      .autoVerify(VerifyKind::SameElementType, {"Dest", "Src"})
+      .autoVerify(VerifyKind::TypeCheck, {"Dest", "isQuantizedType()"})
       .dataParallel()
       .autoIRGen();
 
@@ -509,8 +509,8 @@ int main(int argc, char **argv) {
   BB.newInstr("RescaleQuantized")
       .addOperand("Dest", OperandKind::Out)
       .addOperand("Src", OperandKind::In)
-      .autoVerify(VerifyKind::SameElementType,
-                  {"Dest", "Src", "ElemKind::Int8QTy"})
+      .autoVerify(VerifyKind::SameElementType, {"Dest", "Src"})
+      .autoVerify(VerifyKind::TypeCheck, {"Dest", "isQuantizedType()"})
       .autoVerify(VerifyKind::SameShape, {"Dest", "Src"})
       .dataParallel()
       .autoIRGen();


### PR DESCRIPTION
*Description*:
* Add macros for quantized ops and quantized ops with accumulation (conv, gemm, etc)
* Int16 support for conv, gemm, rescale quantized, max pool
* Relaxing verifiers to support wider range for quantization formats (including int16) for certain ops

More generic quantization handling to int8/int16, etc.

*Testing*:
* Existing tests should cover base scenarios of int8.
* Will add couple of tests for int16 (although), handling of int16 is not much different except wider accumulators.

*Documentation*:
n/a