### PR TITLE
[NodeBuilder] Add Input and Output Indices enums

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -433,7 +433,7 @@ public:
   /// empty, \p input is split to equal sized parts.
   void createSplit(llvm::StringRef name, NodeValue input, unsigned_t outputNum,
                    unsigned_t axis, llvm::ArrayRef<size_t> split,
-                   std::vector<Node *> &outputs);
+                   std::vector<SliceNode *> &outputs);
 
   BatchNormalizationNode *
   createBatchNormalization(llvm::StringRef name, NodeValue input,

--- a/include/glow/Graph/Node.h
+++ b/include/glow/Graph/Node.h
@@ -261,6 +261,14 @@ public:
   }
 };
 
+/// This enum is expected to match the indices order of any Arithmetic node as
+/// defined in Node::isArithmetic().
+namespace ArithmeticNode {
+constexpr unsigned LHSIdx = 0;
+constexpr unsigned RHSIdx = 1;
+constexpr unsigned ResultIdx = 0;
+} // namespace ArithmeticNode
+
 } // namespace glow
 
 namespace llvm {

--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -32,6 +32,10 @@ namespace glow {
 // Placeholder nodes which are unbound.
 class Storage : public Node {
 public:
+  enum ResultIndices {
+    OutputIdx = 0,
+  };
+
   Storage(Kinded::Kind k, llvm::StringRef name) : Node(k, name) {}
 
   /// \return the single output value of the node.

--- a/include/glow/IR/IR.h
+++ b/include/glow/IR/IR.h
@@ -239,7 +239,7 @@ class Node;
 /// A function that represents the compilation unit.
 class IRFunction final {
 public:
-  using VariableMap = std::unordered_map<const Node *, Value *>;
+  using VariableMap = std::unordered_map<const Storage *, Value *>;
   using InstListTy = TaggedList<Instruction, InstructionTraits>;
   using InstrIterator = InstListTy::iterator;
   using InstrConstIterator = InstListTy::const_iterator;
@@ -320,7 +320,7 @@ public:
 
   /// \returns the weight that the variable \p v is lowered into, or null if the
   /// variable is unknown.
-  Value *getWeightForNode(const Node *V) const;
+  Value *getWeightForNode(const Storage *V) const;
 
   /// \returns the list of instructions.
   InstListTy &getInstrs() { return instrs_; }

--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -286,7 +286,7 @@ protected:
 
     // LRN in Caffe2 has a scale_ output, but I believe it's unused for
     // inference. So explicitly only set output 0.
-    nodeValueByName_[op.output(0)] = NodeValue(N, 0);
+    nodeValueByName_[op.output(0)] = N->getResult();
     return llvm::Error::success();
   }
 
@@ -461,13 +461,13 @@ protected:
     if (dict.count("split"))
       split = getShape(dict["split"]);
 
-    std::vector<Node *> outputs;
+    std::vector<SliceNode *> outputs;
     G_.createSplit(opName, in, op.output_size(), axis, split, outputs);
 
     for (int i = 0, e = op.output_size(); i < e; i++) {
       // Each output from Split is a SliceNode which only has a single output,
       // so only use 0 here as the node value result.
-      nodeValueByName_[op.output(i)] = NodeValue(outputs[i], 0);
+      nodeValueByName_[op.output(i)] = outputs[i]->getResult();
     }
     return llvm::Error::success();
   }
@@ -537,7 +537,7 @@ protected:
 
     // Caffe2 sometimes outputs old_shape which goes unused. We do not currently
     // support it, so explicitly only set the first output.
-    nodeValueByName_[op.output(0)] = NodeValue(node, 0);
+    nodeValueByName_[op.output(0)] = node->getResult();
     return true;
   }
 
@@ -583,7 +583,7 @@ protected:
     NodeValue in;
     ASSIGN_VALUE_OR_RETURN_ERR(in,
                                getNodeValueOrCreateConstantByName(op.input(0)));
-    nodeValueByName_[op.output(0)] = NodeValue(in, 0);
+    nodeValueByName_[op.output(0)] = in;
     return llvm::Error::success();
   }
 

--- a/lib/Backends/CPU/Transforms.cpp
+++ b/lib/Backends/CPU/Transforms.cpp
@@ -103,7 +103,7 @@ static Node *optimizeCPUMaxSplat(MaxNode *MN, Function *F) {
            "Types should be quantized");
     auto *RS = F->createRescaleQuantized(MN->getName(), input,
                                          MN->getResult().getType());
-    input = NodeValue(RS, 0);
+    input = RS->getResult();
   }
 
   assert(input.getType() == splat->getResult().getType() &&
@@ -120,7 +120,7 @@ bool CPUBackend::transformPostLowering(Function *F,
     // Try to replace generic convolution with cpu-optimized version.
     if (auto *CN = dyn_cast<ConvolutionNode>(&node)) {
       if (Node *NCN = optimizeCPUConv(CN, F)) {
-        NodeValue(&node, 0).replaceAllUsesOfWith(NCN);
+        CN->getResult().replaceAllUsesOfWith(NCN);
         changed = true;
         continue;
       }
@@ -129,7 +129,7 @@ bool CPUBackend::transformPostLowering(Function *F,
     // Merge Max and Splat nodes into CPUMaxSplat.
     if (auto *MN = dyn_cast<MaxNode>(&node)) {
       if (Node *MSN = optimizeCPUMaxSplat(MN, F)) {
-        NodeValue(&node, 0).replaceAllUsesOfWith(MSN);
+        MN->getResult().replaceAllUsesOfWith(MSN);
         changed = true;
         continue;
       }

--- a/lib/Backends/OpenCL/Transforms.cpp
+++ b/lib/Backends/OpenCL/Transforms.cpp
@@ -42,19 +42,19 @@ bool OCLBackend::transformPostLowering(Function *F,
       if (CN->getGroup() > 1)
         continue;
       auto *NR = convertConvToNCHWConv<OCLConvolutionNode>(CN, F);
-      NodeValue(&node, 0).replaceAllUsesOfWith(NR);
+      CN->getResult().replaceAllUsesOfWith(NR);
       changed = true;
       continue;
     }
     if (auto *PMN = dyn_cast<MaxPoolNode>(&node)) {
       auto *NR = convertPoolToNCHWPool<MaxPoolNode, OCLMaxPoolNode>(PMN, F);
-      NodeValue(&node, 0).replaceAllUsesOfWith(NR);
+      PMN->getResult().replaceAllUsesOfWith(NR);
       changed = true;
       continue;
     }
     if (auto *PAN = dyn_cast<AvgPoolNode>(&node)) {
       auto *NR = convertPoolToNCHWPool<AvgPoolNode, OCLAvgPoolNode>(PAN, F);
-      NodeValue(&node, 0).replaceAllUsesOfWith(NR);
+      PAN->getResult().replaceAllUsesOfWith(NR);
       changed = true;
       continue;
     }

--- a/lib/Converter/FunctionConverter.cpp
+++ b/lib/Converter/FunctionConverter.cpp
@@ -101,12 +101,10 @@ void FunctionConverter::convertOutputs(Node &node) {
       // Thus, if we want to change the value of the output of
       // a save node, we actually have to convert the input.
       if (saveNode && saveNode->getOutput() == val) {
-        unsigned inputIdx = 0;
-        assert(saveNode->getInput() == saveNode->getNthInput(inputIdx) &&
-               "Input is not idx 0");
         NodeValue input = saveNode->getInput();
         Node *conversion = createConversion(*parent, input, targetTy);
-        saveNode->setNthInput(inputIdx, getConversionOutput(*conversion));
+        saveNode->setNthInput(SaveNode::InputIdx,
+                              getConversionOutput(*conversion));
         continue;
       }
 

--- a/lib/Graph/Grad.cpp
+++ b/lib/Graph/Grad.cpp
@@ -222,14 +222,9 @@ Function *glow::differentiate(Function *F, const TrainingConfig &conf,
                     llvm::cast<Placeholder>(var.getNode()));
 
       // Replace the BN's mean and variance with the new mean and variance
-      // calculated from MVN. The indices here are based on the assumed
-      // auto-generated order from NodeGen/NodeBuilder.
-      constexpr size_t idxMean = 3;
-      assert(BN->getNthInput(idxMean) == mean && "Mean idx is incorrect");
-      BN->setNthInput(idxMean, mean);
-      constexpr size_t idxVar = 4;
-      assert(BN->getNthInput(idxVar) == var && "Var idx is incorrect");
-      BN->setNthInput(idxVar, var);
+      // calculated from MVN.
+      BN->setNthInput(BatchNormalizationNode::MeanIdx, mean);
+      BN->setNthInput(BatchNormalizationNode::VarIdx, var);
 
       toAppend.push_back(BN->getGrad(map));
 

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1007,7 +1007,7 @@ ReshapeNode *Function::createFlatten(llvm::StringRef name, NodeValue input,
 void Function::createSplit(llvm::StringRef name, NodeValue input,
                            unsigned_t outputNum, unsigned_t axis,
                            llvm::ArrayRef<size_t> split,
-                           std::vector<Node *> &outputs) {
+                           std::vector<SliceNode *> &outputs) {
   auto inDims = input.dims();
   if (split.empty()) {
     assert(inDims[axis] % outputNum == 0 &&

--- a/lib/Graph/Node.cpp
+++ b/lib/Graph/Node.cpp
@@ -207,22 +207,33 @@ bool Node::hasSideEffects() const {
 }
 
 // NOTE: This is used in conjunction with assuming the 1st input is LHS, and 2nd
-// input is RHS. If adding a new Arithmetic inst, ensure this is the case.
+// input is RHS, and 1st result is Result.
 bool Node::isArithmetic() const {
+  // Each case includes a static assert that the generated nodes that we
+  // consider arithmetic have the expected format/order of LHS, RHS, Result.
+#define ARITHMETIC_NODE_CASE(NODE_NAME_)                                       \
+  static_assert((NODE_NAME_##Node::LHSIdx == ArithmeticNode::LHSIdx &&         \
+                 NODE_NAME_##Node::RHSIdx == ArithmeticNode::RHSIdx &&         \
+                 NODE_NAME_##Node::ResultIdx == ArithmeticNode::ResultIdx),    \
+                #NODE_NAME_                                                    \
+                "Node does not match expected arithmetic node format.");       \
+  case glow::Kinded::Kind::NODE_NAME_##NodeKind:
+
   switch (getKind()) {
-  case glow::Kinded::Kind::AddNodeKind:
-  case glow::Kinded::Kind::MulNodeKind:
-  case glow::Kinded::Kind::SubNodeKind:
-  case glow::Kinded::Kind::DivNodeKind:
-  case glow::Kinded::Kind::MaxNodeKind:
-  case glow::Kinded::Kind::MinNodeKind:
-  case glow::Kinded::Kind::CmpLTENodeKind:
-  case glow::Kinded::Kind::CmpEQNodeKind:
-  case glow::Kinded::Kind::PowNodeKind:
+    ARITHMETIC_NODE_CASE(Add)
+    ARITHMETIC_NODE_CASE(Mul)
+    ARITHMETIC_NODE_CASE(Sub)
+    ARITHMETIC_NODE_CASE(Div)
+    ARITHMETIC_NODE_CASE(Max)
+    ARITHMETIC_NODE_CASE(Min)
+    ARITHMETIC_NODE_CASE(CmpLTE)
+    ARITHMETIC_NODE_CASE(CmpEQ)
+    ARITHMETIC_NODE_CASE(Pow)
     return true;
   default:
     return false;
   }
+#undef ARITHMETIC_NODE_CASE
 }
 
 bool Node::isOverwrittenNthInput(unsigned idx) const {

--- a/lib/IR/IR.cpp
+++ b/lib/IR/IR.cpp
@@ -318,7 +318,7 @@ void IRFunction::verify() const {
 
   for (auto p : variableMap_) {
     (void)p;
-    assert(p.first->getType(0) == p.second->getType() &&
+    assert(p.first->getType() == p.second->getType() &&
            "Weight and variable must have the same type");
     p.second->verify(*this);
     p.second->verifyUseList(InstrNumbering);
@@ -328,7 +328,7 @@ void IRFunction::verify() const {
   }
 }
 
-Value *IRFunction::getWeightForNode(const Node *V) const {
+Value *IRFunction::getWeightForNode(const Storage *V) const {
   auto it = variableMap_.find(V);
   if (it == variableMap_.end()) {
     return nullptr;

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -216,15 +216,21 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     size_t depth = wtag.dims()[0];
 
     // We expect the input to be NHWC.
-    Node *tr;
+    Node *finalIn;
     if (order == "NCHW") {
-      tr = G_.createTranspose(opName, in, NCHW2NHWC);
+      finalIn = G_.createTranspose(opName, in, NCHW2NHWC);
     } else {
-      tr = in;
+      finalIn = in;
     }
 
+    RETURN_ERR_IF_NOT(
+        llvm::isa<TransposeNode>(finalIn) || llvm::isa<Storage>(finalIn),
+        "Internal error: Final input had to be either Storage or Transpose.");
+    TypeRef finalInType = llvm::isa<Storage>(finalIn)
+                              ? finalIn->getType(Storage::OutputIdx)
+                              : finalIn->getType(TransposeNode::ResultIdx);
     // Calculate the size and allocate the output buffer.
-    ShapeNHWC idim = ShapeNHWC(tr->getType(0)->dims());
+    ShapeNHWC idim = ShapeNHWC(finalInType->dims());
     auto outSz =
         calculateConvPoolOutputDims(idim.h, idim.w, kernels, strides, pads);
     std::array<size_t, 4> outDims = {
@@ -288,7 +294,7 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
       bias->assign(&biasTensor);
     }
 
-    Node *node = G_.createConv(opName, tr, filter, bias, outTy, kernels,
+    Node *node = G_.createConv(opName, finalIn, filter, bias, outTy, kernels,
                                strides, pads, group);
 
     if (order == "NCHW") {
@@ -370,11 +376,11 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
       ASSIGN_VALUE_OR_RETURN_ERR(order, loadStr(dict["order"]));
     }
     // We expect the input to be NHWC.
-    Node *tr;
+    Node *finalIn;
     if (order == "NCHW") {
-      tr = G_.createTranspose(opName, in, NCHW2NHWC);
+      finalIn = G_.createTranspose(opName, in, NCHW2NHWC);
     } else {
-      tr = in;
+      finalIn = in;
     }
 
     // If 'global_pooling' is set then the operation will pool over the size of
@@ -393,7 +399,13 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
                         "missing zero point for quantized output type");
       RETURN_ERR_IF_NOT(dict.count("Y_scale"),
                         "missing Y_scale for quantized output type");
-      ShapeNHWC idim = ShapeNHWC(tr->getType(0)->dims());
+      RETURN_ERR_IF_NOT(
+          llvm::isa<TransposeNode>(finalIn) || llvm::isa<Storage>(finalIn),
+          "Internal error: Final input had to be either Storage or Transpose.");
+      TypeRef finalInType = llvm::isa<Storage>(finalIn)
+                                ? finalIn->getType(Storage::OutputIdx)
+                                : finalIn->getType(TransposeNode::ResultIdx);
+      ShapeNHWC idim = ShapeNHWC(finalInType->dims());
       auto outSz =
           calculateConvPoolOutputDims(idim.h, idim.w, kernels, strides, pads);
       std::array<size_t, 4> outDims = {
@@ -401,7 +413,7 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
       if (typeName == "Int8MaxPool") {
         // Int8Maxpool output quantization should be same as the input, so just
         // ignore the given params.
-        node = G_.createMaxPool(opName, tr, kernels, strides, pads);
+        node = G_.createMaxPool(opName, finalIn, kernels, strides, pads);
       } else {
         float yScale;
         ASSIGN_VALUE_OR_RETURN_ERR(yScale, loadFloat(dict["Y_scale"]));
@@ -409,12 +421,12 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
         ASSIGN_VALUE_OR_RETURN_ERR(yZeroPoint, loadInt(dict["Y_zero_point"]));
         auto outTy = G_.getParent()->uniqueType(
             ElemKind::Int8QTy, outDims, yScale, yZeroPoint - OFFSETSHIFT);
-        node = G_.createAvgPool(opName, tr, outTy, kernels, strides, pads);
+        node = G_.createAvgPool(opName, finalIn, outTy, kernels, strides, pads);
       }
     } else if (typeName == "MaxPool") {
-      node = G_.createMaxPool(opName, tr, kernels, strides, pads);
+      node = G_.createMaxPool(opName, finalIn, kernels, strides, pads);
     } else {
-      node = G_.createAvgPool(opName, tr, kernels, strides, pads);
+      node = G_.createAvgPool(opName, finalIn, kernels, strides, pads);
     }
     if (order == "NCHW") {
       // Transpose the output back.
@@ -495,7 +507,15 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     }
     // Concat has multiple outputs in Caffe2, but I believe the other output
     // (split_info) is not used for inference.
-    nodeValueByName_[op.output(0)] = NodeValue(node, 0);
+
+    // If we add the axis then node is a Reshape, otherwise it should be Concat.
+    RETURN_ERR_IF_NOT(
+        llvm::isa<ConcatNode>(node) || llvm::isa<ReshapeNode>(node),
+        "Internal error: Node should either be a Concat or Reshape.");
+    NodeValue finalNode = llvm::isa<ConcatNode>(node)
+                              ? NodeValue(node, ConcatNode::ResultIdx)
+                              : NodeValue(node, ReshapeNode::ResultIdx);
+    nodeValueByName_[op.output(0)] = finalNode;
     return llvm::Error::success();
   }
 

--- a/lib/Importer/ProtobufLoader.cpp
+++ b/lib/Importer/ProtobufLoader.cpp
@@ -69,7 +69,7 @@ ProtobufLoader::createAndRegisterConstant(llvm::StringRef name,
   // Note: We do not support training from models loaded from protos, so
   // trainable is always set to false here.
   Constant *node = G_.getParent()->createConstant(name, tensor);
-  nodeValueByName_[name] = NodeValue(node, 0);
+  nodeValueByName_[name] = node->getOutput();
   return node;
 }
 
@@ -77,7 +77,7 @@ llvm::Expected<Placeholder *>
 ProtobufLoader::createAndRegisterPlaceholder(llvm::StringRef name, TypeRef T) {
   RETURN_ERR_IF_NOT(!hasNodeByName(name), "Creating an already existing node");
   Placeholder *node = G_.getParent()->createPlaceholder(T, name, false);
-  nodeValueByName_[name] = NodeValue(node, 0);
+  nodeValueByName_[name] = node->getOutput();
   return node;
 }
 
@@ -92,7 +92,7 @@ ProtobufLoader::getNodeValueOrCreateConstantByName(llvm::StringRef name) {
   ASSIGN_VALUE_OR_RETURN_ERR(T, getTensorByName(name));
   Constant *c;
   ASSIGN_VALUE_OR_RETURN_ERR(c, createAndRegisterConstant(name, *T));
-  return NodeValue(c, 0);
+  return c->getOutput();
 }
 
 bool ProtobufLoader::hasNodeByName(llvm::StringRef name) const {

--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -506,11 +506,12 @@ static bool sinkCode(Function *F) {
 
 #define ARITHMETIC_CASE(NODE_NAME_)                                            \
   case glow::Kinded::Kind::NODE_NAME_##NodeKind:                               \
-    newAN = F->create##NODE_NAME_(                                             \
-        node->getName(),                                                       \
-        F->getParent()->uniqueTypeWithNewShape(                                \
-            node->getType(0), LTR->getInput().getType()->dims()),              \
-        LTR->getInput(), RTR->getInput());                                     \
+    newAN =                                                                    \
+        F->create##NODE_NAME_(node->getName(),                                 \
+                              F->getParent()->uniqueTypeWithNewShape(          \
+                                  node->getType(ArithmeticNode::ResultIdx),    \
+                                  LTR->getInput().getType()->dims()),          \
+                              LTR->getInput(), RTR->getInput());               \
     break;
 
 #define BOOLEAN_OP_CASE(NODE_NAME_)                                            \
@@ -1831,7 +1832,7 @@ static NodeValue convertConstant(Module &mod, Constant &constant,
            "We should always be able to get a constant from a constant!");
     // This type setting updates the type of the node.
     // The underlying tensor still needs to be converted after this call.
-    oneUseCst->setType(0, dstTy);
+    oneUseCst->setType(Storage::OutputIdx, dstTy);
     return *oneUseCst;
   };
   const Tensor &tensor = constant.getPayload();

--- a/lib/Optimizer/Quantization.cpp
+++ b/lib/Optimizer/Quantization.cpp
@@ -42,7 +42,7 @@ Function *glow::profileQuantization(Context &ctx, Function *F,
   // Add Quantization Profile node to all of the floating point outputs.
   for (auto &node : G->getNodes()) {
     for (unsigned i = 0, e = node.getNumResults(); i < e; ++i) {
-      if (node.getNthResult(i).getElementType() != ElemKind::FloatTy) {
+      if (node.getElementType(i) != ElemKind::FloatTy) {
         continue;
       }
       nodesToInstrument.insert(node.getNthResult(i));

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -172,47 +172,33 @@ protected:
     return function.createDequantize("quantize", val);
   }
 
+  /// All IRConstraint cases below assume that the input and output index that
+  /// they are looking for the type is at idx 0. We statically assert that here
+  /// along with the case.
+  static constexpr unsigned IRConstraintInputIdx = 0;
+  static constexpr unsigned IRConstraintResultIdx = 0;
+#define IR_CONSTRAINT_CASE(NODE_NAME_, INPUT_NAME_, OUTPUT_NAME_)              \
+  static_assert(                                                               \
+      (NODE_NAME_##Node::INPUT_NAME_##Idx == IRConstraintInputIdx &&           \
+       NODE_NAME_##Node::OUTPUT_NAME_##Idx == IRConstraintResultIdx),          \
+      #NODE_NAME_ "Node format is unexpected.");                               \
+  case Kinded::Kind::NODE_NAME_##NodeKind
+
   /// Macro to be put in a switch for all the nodes that have a constraint
   /// where the input and output type must be equals.
   /// Note: The last case of the macro doesn't have ':' so we can put it
   /// where the macro is inserted to keep the nice code formatting.
+  // clang-format off
 #define casesForNodesWithIRConstraint                                          \
-  case Kinded::Kind::LocalResponseNormalizationNodeKind:                       \
-  case Kinded::Kind::SigmoidNodeKind:                                          \
-  case Kinded::Kind::SliceNodeKind:                                            \
-  case Kinded::Kind::ReshapeNodeKind:                                          \
-  case Kinded::Kind::TanhNodeKind:                                             \
-  case Kinded::Kind::TopKNodeKind:                                             \
-  case Kinded::Kind::GatherNodeKind:                                           \
-  case Kinded::Kind::MaxPoolNodeKind
-  /// Note that the above cases all assume that the input and output index that
-  /// they are looking for the type is at idx 0. We statically assert that here.
-  static constexpr unsigned IRConstraintInputResultIdx = 0;
-  static_assert(
-      (LocalResponseNormalizationNode::InputIdx == IRConstraintInputResultIdx &&
-       LocalResponseNormalizationNode::ResultIdx == IRConstraintInputResultIdx),
-      "LRNNode format is unexpected.");
-  static_assert((SigmoidNode::InputIdx == IRConstraintInputResultIdx &&
-                 SigmoidNode::ResultIdx == IRConstraintInputResultIdx),
-                "SigmoidNode format is unexpected.");
-  static_assert((SliceNode::InputIdx == IRConstraintInputResultIdx &&
-                 SliceNode::ResultIdx == IRConstraintInputResultIdx),
-                "SliceNode format is unexpected.");
-  static_assert((ReshapeNode::InputIdx == IRConstraintInputResultIdx &&
-                 ReshapeNode::ResultIdx == IRConstraintInputResultIdx),
-                "ReshapeNode format is unexpected.");
-  static_assert((TanhNode::InputIdx == IRConstraintInputResultIdx &&
-                 TanhNode::ResultIdx == IRConstraintInputResultIdx),
-                "TanhNode format is unexpected.");
-  static_assert((TopKNode::InputIdx == IRConstraintInputResultIdx &&
-                 TopKNode::ValuesIdx == IRConstraintInputResultIdx),
-                "TopKNode format is unexpected.");
-  static_assert((GatherNode::DataIdx == IRConstraintInputResultIdx &&
-                 GatherNode::ResultIdx == IRConstraintInputResultIdx),
-                "GatherNode format is unexpected.");
-  static_assert((MaxPoolNode::InputIdx == IRConstraintInputResultIdx &&
-                 MaxPoolNode::ResultIdx == IRConstraintInputResultIdx),
-                "MaxPoolNode format is unexpected.");
+  IR_CONSTRAINT_CASE(LocalResponseNormalization, Input, Result):               \
+  IR_CONSTRAINT_CASE(Sigmoid, Input, Result):                                  \
+  IR_CONSTRAINT_CASE(Slice, Input, Result):                                    \
+  IR_CONSTRAINT_CASE(Reshape, Input, Result):                                  \
+  IR_CONSTRAINT_CASE(Tanh, Input, Result):                                     \
+  IR_CONSTRAINT_CASE(TopK, Input, Values):                                     \
+  IR_CONSTRAINT_CASE(Gather, Data, Result):                                    \
+  IR_CONSTRAINT_CASE(MaxPool, Input, Result)
+  // clang-format on
 
   /// \see FunctionConverter::morphNode.
   /// This method does the final adjustment to the output types
@@ -260,13 +246,12 @@ protected:
     casesForNodesWithIRConstraint : {
       // The constraints on the IR says that the input type must
       // be the same as the output type.
-      TypeRef inTy = node.getNthInput(IRConstraintInputResultIdx).getType();
-      TypeRef fixedTy =
-          mod_.uniqueType(ElemKind::Int8QTy,
-                          node.getNthResult(IRConstraintInputResultIdx).dims(),
-                          inTy->getScale(), inTy->getOffset());
+      TypeRef inTy = node.getNthInput(IRConstraintInputIdx).getType();
+      TypeRef fixedTy = mod_.uniqueType(
+          ElemKind::Int8QTy, node.getNthResult(IRConstraintResultIdx).dims(),
+          inTy->getScale(), inTy->getOffset());
 
-      node.setType(IRConstraintInputResultIdx, fixedTy);
+      node.setType(IRConstraintResultIdx, fixedTy);
       assert(!lastMorphedNodeWithTypeChanges &&
              "Missed one node to rescale in postprocessing");
       lastMorphedNodeWithTypeChanges = &node;
@@ -314,12 +299,12 @@ protected:
       // These nodes do not change {S,O} of the output, they use the same
       // {S,O} as the input. Make sure that rescale is applied to comply with
       // the taken profile from the node.
-      TypeRef outputTy = getTargetTypeForOutputImpl(
-          NodeValue(&node, IRConstraintInputResultIdx));
+      TypeRef outputTy =
+          getTargetTypeForOutputImpl(NodeValue(&node, IRConstraintResultIdx));
       assert(outputTy->isQuantizedType() && "Node hasn't been quantized yet?!");
       auto outTy = mod_.uniqueType(ElemKind::Int8QTy, outputTy->dims(),
                                    outputTy->getScale(), outputTy->getOffset());
-      NodeValue val = node.getNthResult(IRConstraintInputResultIdx);
+      NodeValue val = node.getNthResult(IRConstraintResultIdx);
       // "node" should have only one use, the dequantize node.
       // Update this use.
       assert(

--- a/tests/unittests/GraphTest.cpp
+++ b/tests/unittests/GraphTest.cpp
@@ -102,9 +102,9 @@ TEST(Graph, float16Conv) {
 
   auto *conv = F->createConv(ctx, "Conv", K, 16, 3, 2, 3, 1);
   EXPECT_TRUE(conv->verify());
-  EXPECT_EQ(conv->getType(0)->getElementType(), ElemKind::Float16Ty);
-  EXPECT_EQ(conv->getFilter().getType()->getElementType(), ElemKind::Float16Ty);
-  EXPECT_EQ(conv->getBias().getType()->getElementType(), ElemKind::Float16Ty);
+  EXPECT_EQ(conv->getResult().getElementType(), ElemKind::Float16Ty);
+  EXPECT_EQ(conv->getFilter().getElementType(), ElemKind::Float16Ty);
+  EXPECT_EQ(conv->getBias().getElementType(), ElemKind::Float16Ty);
 
   lower(F, MockBackend());
 
@@ -118,12 +118,9 @@ TEST(Graph, float16Conv) {
                              });
   ASSERT_TRUE(convIt != M.getInstrs().end());
   const auto *convInst = llvm::cast<ConvolutionInst>(&*convIt);
-  EXPECT_EQ(convInst->getSrc()->getType()->getElementType(),
-            ElemKind::Float16Ty);
-  EXPECT_EQ(convInst->getFilter()->getType()->getElementType(),
-            ElemKind::Float16Ty);
-  EXPECT_EQ(convInst->getBias()->getType()->getElementType(),
-            ElemKind::Float16Ty);
+  EXPECT_EQ(convInst->getSrc()->getElementType(), ElemKind::Float16Ty);
+  EXPECT_EQ(convInst->getFilter()->getElementType(), ElemKind::Float16Ty);
+  EXPECT_EQ(convInst->getBias()->getElementType(), ElemKind::Float16Ty);
 }
 
 /// Check that we can create batchNorm with float16.
@@ -137,11 +134,11 @@ TEST(Graph, float16BatchNorm) {
       F->createBatchNormalization(ctx, "batch", input, 3, 0.0001, 0.9);
 
   EXPECT_TRUE(BN->verify());
-  EXPECT_EQ(BN->getType(0)->getElementType(), ElemKind::Float16Ty);
-  EXPECT_EQ(BN->getScale().getType()->getElementType(), ElemKind::Float16Ty);
-  EXPECT_EQ(BN->getBias().getType()->getElementType(), ElemKind::Float16Ty);
-  EXPECT_EQ(BN->getMean().getType()->getElementType(), ElemKind::Float16Ty);
-  EXPECT_EQ(BN->getVar().getType()->getElementType(), ElemKind::Float16Ty);
+  EXPECT_EQ(BN->getResult().getElementType(), ElemKind::Float16Ty);
+  EXPECT_EQ(BN->getScale().getElementType(), ElemKind::Float16Ty);
+  EXPECT_EQ(BN->getBias().getElementType(), ElemKind::Float16Ty);
+  EXPECT_EQ(BN->getMean().getElementType(), ElemKind::Float16Ty);
+  EXPECT_EQ(BN->getVar().getElementType(), ElemKind::Float16Ty);
 
   lower(F, MockBackend());
 
@@ -1038,35 +1035,35 @@ TEST(Graph, setType) {
   TypeRef origTopKRes0 = M.uniqueType(ElemKind::FloatTy, top5Dims);
   TypeRef origTopKRes1 = M.uniqueType(ElemKind::Int64ITy, top5Dims);
 
-  EXPECT_EQ(topK->getType(0), origTopKRes0);
-  EXPECT_EQ(topK->getType(1), origTopKRes1);
+  EXPECT_EQ(topK->getType(TopKNode::ValuesIdx), origTopKRes0);
+  EXPECT_EQ(topK->getType(TopKNode::IndicesIdx), origTopKRes1);
 
   // Modify the type of result 0 and make sure type 1 is not
   // affected. Similarly the input shouldn't be affected.
   TypeRef inputTy = M.uniqueType(ElemKind::FloatTy, inputDims);
   TypeRef topKRes0 = M.uniqueType(ElemKind::Float16Ty, top5Dims);
-  topK->setType(0, topKRes0);
+  topK->setType(TopKNode::ValuesIdx, topKRes0);
   EXPECT_EQ(input->getType(), inputTy);
-  EXPECT_EQ(topK->getType(0), topKRes0);
-  EXPECT_EQ(topK->getType(1), origTopKRes1);
+  EXPECT_EQ(topK->getType(TopKNode::ValuesIdx), topKRes0);
+  EXPECT_EQ(topK->getType(TopKNode::IndicesIdx), origTopKRes1);
 
   // Make sure the NodeValue API works the same way
   // as the Node::setType API.
-  NodeValue valRes1 = topK->getNthResult(1);
+  NodeValue valRes1 = topK->getNthResult(TopKNode::IndicesIdx);
   valRes1.setType(topKRes0);
   EXPECT_EQ(input->getType(), inputTy);
-  EXPECT_EQ(topK->getType(0), topKRes0);
-  EXPECT_EQ(topK->getType(1), topKRes0);
+  EXPECT_EQ(topK->getType(TopKNode::ValuesIdx), topKRes0);
+  EXPECT_EQ(topK->getType(TopKNode::IndicesIdx), topKRes0);
   EXPECT_EQ(valRes1.getType(), topKRes0);
 
   // Now restore sane types.
-  NodeValue valRes0 = topK->getNthResult(0);
+  NodeValue valRes0 = topK->getNthResult(TopKNode::ValuesIdx);
   valRes0.setType(origTopKRes0);
-  topK->setType(1, origTopKRes1);
+  topK->setType(TopKNode::IndicesIdx, origTopKRes1);
   EXPECT_EQ(input->getType(), inputTy);
-  EXPECT_EQ(topK->getType(0), origTopKRes0);
+  EXPECT_EQ(topK->getType(TopKNode::ValuesIdx), origTopKRes0);
   EXPECT_EQ(valRes0.getType(), origTopKRes0);
-  EXPECT_EQ(topK->getType(1), origTopKRes1);
+  EXPECT_EQ(topK->getType(TopKNode::IndicesIdx), origTopKRes1);
   EXPECT_EQ(valRes1.getType(), origTopKRes1);
 }
 
@@ -1159,7 +1156,7 @@ TEST(Graph, verifyConstantTensorTypeMatchesConstantTypeChanged) {
   // Fresh constant should verify just fine.
   EXPECT_TRUE(input->verify());
 
-  input->setType(0, M.uniqueType(ElemKind::Float16Ty, {5}));
+  input->setType(Storage::OutputIdx, M.uniqueType(ElemKind::Float16Ty, {5}));
 
   EXPECT_FALSE(input->verify());
 }

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -2577,6 +2577,7 @@ TEST_P(Operator, simpleCmpSelectPredication) {
     cnt = F_->createSub("sub1", cnt, const1);
     Node *pred = F_->createCmpLTE("cmp", const0, cnt);
 
+    assert(data->getNumResults() == 1 && "Data should have a single output.");
     Node *const2 = F_->createSplat("const2", data->getType(0), 2.0);
     Node *newData = F_->createMul("mul2x", data, const2);
 

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -2754,10 +2754,10 @@ TEST_P(InterpAndCPU, Split) {
       mod_.createPlaceholder(ElemKind::FloatTy, {1, 2, 6}, "inputs", false);
   ctx_.allocate(inputs)->getHandle() = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
 
-  std::vector<Node *> outputs1;
+  std::vector<SliceNode *> outputs1;
   F_->createSplit("Split1", inputs, /*outputNum = */ 2, /*axis = */ 2,
                   /*split = */ {}, outputs1);
-  std::vector<Node *> outputs2;
+  std::vector<SliceNode *> outputs2;
   F_->createSplit("Split2", inputs, /*outputNum = */ 2, /*axis = */ 2,
                   /*split = */ {2, 4}, outputs2);
   auto S1 = F_->createSave("save1", outputs1[0]);

--- a/tests/unittests/QuantizationTest.cpp
+++ b/tests/unittests/QuantizationTest.cpp
@@ -871,14 +871,18 @@ TEST(Quantization, quantizeSoftmaxAndLRN) {
   auto qLRNIt = std::find_if(
       F->getNodes().begin(), F->getNodes().end(), [](const Node &node) -> bool {
         return llvm::isa<LocalResponseNormalizationNode>(&node) &&
-               node.getNthResult(0).getType()->isQuantizedType();
+               node.getNthResult(LocalResponseNormalizationNode::ResultIdx)
+                   .getType()
+                   ->isQuantizedType();
       });
   ASSERT_NE(qLRNIt, F->getNodes().end());
-  auto qSMIt = std::find_if(
-      F->getNodes().begin(), F->getNodes().end(), [](const Node &node) -> bool {
-        return llvm::isa<SoftMaxNode>(&node) &&
-               node.getNthResult(0).getType()->isQuantizedType();
-      });
+  auto qSMIt = std::find_if(F->getNodes().begin(), F->getNodes().end(),
+                            [](const Node &node) -> bool {
+                              return llvm::isa<SoftMaxNode>(&node) &&
+                                     node.getNthResult(SoftMaxNode::ResultIdx)
+                                         .getType()
+                                         ->isQuantizedType();
+                            });
   ASSERT_NE(qSMIt, F->getNodes().end());
 }
 
@@ -907,11 +911,13 @@ TEST(Quantization, quantizeAvgPool) {
 
   F = quantization::quantizeFunction(EE, QI, F);
 
-  auto qPool = std::find_if(
-      F->getNodes().begin(), F->getNodes().end(), [](const Node &node) -> bool {
-        return llvm::isa<AvgPoolNode>(&node) &&
-               node.getNthResult(0).getType()->isQuantizedType();
-      });
+  auto qPool = std::find_if(F->getNodes().begin(), F->getNodes().end(),
+                            [](const Node &node) -> bool {
+                              return llvm::isa<AvgPoolNode>(&node) &&
+                                     node.getNthResult(AvgPoolNode::ResultIdx)
+                                         .getType()
+                                         ->isQuantizedType();
+                            });
   ASSERT_NE(qPool, F->getNodes().end());
   auto *avgPool = llvm::cast<AvgPoolNode>(qPool);
   ASSERT_NE(avgPool->getInput().getType()->getScale(),

--- a/tests/unittests/TypeAToTypeBFunctionConverterTest.cpp
+++ b/tests/unittests/TypeAToTypeBFunctionConverterTest.cpp
@@ -113,7 +113,11 @@ TEST_P(AllBackends, SimpleOneUseConversionFloatToFloat16) {
   }
   // At this point we know the input of FC is convertTo(placeholder).
   // Check that this placeholder is the expected input.
-  EXPECT_EQ(convertedFC->getInput().getNode()->getNthInput(0).getNode(), input);
+  EXPECT_EQ(convertedFC->getInput()
+                .getNode()
+                ->getNthInput(ConvertToNode::InputIdx)
+                .getNode(),
+            input);
 }
 
 /// Check that a graph with a simple chain of computation is converted
@@ -238,7 +242,11 @@ TEST_P(AllBackends, SimpleChainOfComputationConversionFloatToFloat16) {
   }
   // At this point we know the input of FC is convertTo(placeholder).
   // Check that this placeholder is the expected input.
-  EXPECT_EQ(convertedFC->getInput().getNode()->getNthInput(0).getNode(), input);
+  EXPECT_EQ(convertedFC->getInput()
+                .getNode()
+                ->getNthInput(ConvertToNode::InputIdx)
+                .getNode(),
+            input);
 }
 
 /// Check that the conversion honor the doNotConvertKinds set (here ReLU)
@@ -345,7 +353,11 @@ TEST_P(AllBackends, DoNotConvertReLUConversionFloatToFloat16) {
   }
   // At this point we know the input of FC is convertTo(placeholder).
   // Check that this placeholder is the expected input.
-  EXPECT_EQ(convertedFC->getInput().getNode()->getNthInput(0).getNode(), input);
+  EXPECT_EQ(convertedFC->getInput()
+                .getNode()
+                ->getNthInput(ConvertToNode::InputIdx)
+                .getNode(),
+            input);
 }
 
 /// Check that don't convert types we didn't asked for.
@@ -445,7 +457,10 @@ TEST_P(AllBackends, int64IConversionFloatToFloat16) {
   EXPECT_EQ(convertedTopKInput->getInput().getElementType(), ElemKind::FloatTy);
   // At this point we know the input of TopK is convertTo(placeholder).
   // Check that this placeholder is the expected input.
-  EXPECT_EQ(convertedTopK->getInput().getNode()->getNthInput(0).getNode(),
+  EXPECT_EQ(convertedTopK->getInput()
+                .getNode()
+                ->getNthInput(ConvertToNode::InputIdx)
+                .getNode(),
             input);
 
   // Now check the Int64ITy part of the graph.

--- a/tests/unittests/TypeAToTypeBFunctionConverterTest.cpp
+++ b/tests/unittests/TypeAToTypeBFunctionConverterTest.cpp
@@ -93,18 +93,21 @@ TEST_P(AllBackends, SimpleOneUseConversionFloatToFloat16) {
   // Check that the save is fed from a conversion from float16 to float.
   auto *convertedBackFCRes = llvm::dyn_cast<ConvertToNode>(result->getInput());
   ASSERT_NE(convertedBackFCRes, nullptr);
-  EXPECT_EQ(convertedBackFCRes->getElementType(0), ElemKind::FloatTy);
+  EXPECT_EQ(convertedBackFCRes->getElementType(ConvertToNode::ResultIdx),
+            ElemKind::FloatTy);
   auto *convertedFC =
       llvm::dyn_cast<FullyConnectedNode>(convertedBackFCRes->getInput());
   ASSERT_NE(convertedFC, nullptr);
-  EXPECT_EQ(convertedFC->getElementType(0), ElemKind::Float16Ty);
+  EXPECT_EQ(convertedFC->getElementType(FullyConnectedNode::ResultIdx),
+            ElemKind::Float16Ty);
   // Check that all the input of FC are convertTo node with from float to
   // Float16Ty.
   for (unsigned idx = 0, end = convertedFC->getNumInputs(); idx != end; ++idx) {
     auto *convertedFCInput =
         llvm::dyn_cast<ConvertToNode>(convertedFC->getNthInput(idx));
     ASSERT_NE(convertedFCInput, nullptr);
-    EXPECT_EQ(convertedFCInput->getElementType(0), ElemKind::Float16Ty);
+    EXPECT_EQ(convertedFCInput->getElementType(ConvertToNode::ResultIdx),
+              ElemKind::Float16Ty);
     EXPECT_TRUE(llvm::isa<Placeholder>(convertedFCInput->getInput()));
     EXPECT_EQ(convertedFCInput->getInput().getElementType(), ElemKind::FloatTy);
   }
@@ -194,35 +197,41 @@ TEST_P(AllBackends, SimpleChainOfComputationConversionFloatToFloat16) {
   auto *convertedBackReLURes =
       llvm::dyn_cast<ConvertToNode>(result->getInput());
   ASSERT_NE(convertedBackReLURes, nullptr);
-  EXPECT_EQ(convertedBackReLURes->getElementType(0), ElemKind::FloatTy);
+  EXPECT_EQ(convertedBackReLURes->getElementType(ConvertToNode::ResultIdx),
+            ElemKind::FloatTy);
   auto *convertedReLU =
       llvm::dyn_cast<ReluNode>(convertedBackReLURes->getInput());
   ASSERT_NE(convertedReLU, nullptr);
-  EXPECT_EQ(convertedReLU->getElementType(0), ElemKind::Float16Ty);
+  EXPECT_EQ(convertedReLU->getElementType(ReluNode::ResultIdx),
+            ElemKind::Float16Ty);
 
   // Check that the ReLU is fed from a conversion from float to float16.
   auto *convertedToReLUInput =
       llvm::dyn_cast<ConvertToNode>(convertedReLU->getInput());
   ASSERT_NE(convertedToReLUInput, nullptr);
-  EXPECT_EQ(convertedToReLUInput->getElementType(0), ElemKind::Float16Ty);
+  EXPECT_EQ(convertedToReLUInput->getElementType(ConvertToNode::ResultIdx),
+            ElemKind::Float16Ty);
 
   // Check that this conversion is fed from a conversion from float16 to float.
   auto *convertedBackFCRes =
       llvm::dyn_cast<ConvertToNode>(convertedToReLUInput->getInput());
   ASSERT_NE(convertedBackFCRes, nullptr);
-  EXPECT_EQ(convertedBackFCRes->getElementType(0), ElemKind::FloatTy);
+  EXPECT_EQ(convertedBackFCRes->getElementType(ConvertToNode::ResultIdx),
+            ElemKind::FloatTy);
   // Check that this conversion comes from the float16 FC node.
   auto *convertedFC =
       llvm::dyn_cast<FullyConnectedNode>(convertedBackFCRes->getInput());
   ASSERT_NE(convertedFC, nullptr);
-  EXPECT_EQ(convertedFC->getElementType(0), ElemKind::Float16Ty);
+  EXPECT_EQ(convertedFC->getElementType(FullyConnectedNode::ResultIdx),
+            ElemKind::Float16Ty);
   // Check that all the input of FC are convertTo node with from float to
   // Float16Ty.
   for (unsigned idx = 0, end = convertedFC->getNumInputs(); idx != end; ++idx) {
     auto *convertedFCInput =
         llvm::dyn_cast<ConvertToNode>(convertedFC->getNthInput(idx));
     ASSERT_NE(convertedFCInput, nullptr);
-    EXPECT_EQ(convertedFCInput->getElementType(0), ElemKind::Float16Ty);
+    EXPECT_EQ(convertedFCInput->getElementType(ConvertToNode::ResultIdx),
+              ElemKind::Float16Ty);
     EXPECT_TRUE(llvm::isa<Placeholder>(convertedFCInput->getInput()));
     EXPECT_EQ(convertedFCInput->getInput().getElementType(), ElemKind::FloatTy);
   }
@@ -305,26 +314,30 @@ TEST_P(AllBackends, DoNotConvertReLUConversionFloatToFloat16) {
   // Check that the save is fed from a conversion from float16 to float.
   auto *resultInput = llvm::dyn_cast<ReluNode>(result->getInput());
   ASSERT_NE(resultInput, nullptr);
-  EXPECT_EQ(resultInput->getElementType(0), ElemKind::FloatTy);
+  EXPECT_EQ(resultInput->getElementType(ReluNode::ResultIdx),
+            ElemKind::FloatTy);
   EXPECT_EQ(resultInput, ReLU);
 
   // Check that the ReLU is fed from a conversion from float16 to float.
   auto *convertedToReLUInput = llvm::dyn_cast<ConvertToNode>(ReLU->getInput());
   ASSERT_NE(convertedToReLUInput, nullptr);
-  EXPECT_EQ(convertedToReLUInput->getElementType(0), ElemKind::FloatTy);
+  EXPECT_EQ(convertedToReLUInput->getElementType(ConvertToNode::ResultIdx),
+            ElemKind::FloatTy);
 
   // Check that this conversion comes from the float16 FC node.
   auto *convertedFC =
       llvm::dyn_cast<FullyConnectedNode>(convertedToReLUInput->getInput());
   ASSERT_NE(convertedFC, nullptr);
-  EXPECT_EQ(convertedFC->getElementType(0), ElemKind::Float16Ty);
+  EXPECT_EQ(convertedFC->getElementType(FullyConnectedNode::ResultIdx),
+            ElemKind::Float16Ty);
   // Check that all the input of FC are convertTo node with from float to
   // Float16Ty.
   for (unsigned idx = 0, end = convertedFC->getNumInputs(); idx != end; ++idx) {
     auto *convertedFCInput =
         llvm::dyn_cast<ConvertToNode>(convertedFC->getNthInput(idx));
     ASSERT_NE(convertedFCInput, nullptr);
-    EXPECT_EQ(convertedFCInput->getElementType(0), ElemKind::Float16Ty);
+    EXPECT_EQ(convertedFCInput->getElementType(ConvertToNode::ResultIdx),
+              ElemKind::Float16Ty);
     EXPECT_TRUE(llvm::isa<Placeholder>(convertedFCInput->getInput()));
     EXPECT_EQ(convertedFCInput->getInput().getElementType(), ElemKind::FloatTy);
   }
@@ -410,18 +423,22 @@ TEST_P(AllBackends, int64IConversionFloatToFloat16) {
   auto *convertedBackTopKRes =
       llvm::dyn_cast<ConvertToNode>(result->getInput());
   ASSERT_NE(convertedBackTopKRes, nullptr);
-  EXPECT_EQ(convertedBackTopKRes->getElementType(0), ElemKind::FloatTy);
+  EXPECT_EQ(convertedBackTopKRes->getElementType(ConvertToNode::ResultIdx),
+            ElemKind::FloatTy);
   auto *convertedTopK =
       llvm::dyn_cast<TopKNode>(convertedBackTopKRes->getInput());
   ASSERT_NE(convertedTopK, nullptr);
-  EXPECT_EQ(convertedTopK->getElementType(0), ElemKind::Float16Ty);
-  EXPECT_EQ(convertedTopK->getElementType(1), ElemKind::Int64ITy);
+  EXPECT_EQ(convertedTopK->getElementType(TopKNode::ValuesIdx),
+            ElemKind::Float16Ty);
+  EXPECT_EQ(convertedTopK->getElementType(TopKNode::IndicesIdx),
+            ElemKind::Int64ITy);
   // Check that the input of TopK is a convertTo node from float to
   // Float16Ty.
   auto *convertedTopKInput =
       llvm::dyn_cast<ConvertToNode>(convertedTopK->getInput());
   ASSERT_NE(convertedTopKInput, nullptr);
-  EXPECT_EQ(convertedTopKInput->getElementType(0), ElemKind::Float16Ty);
+  EXPECT_EQ(convertedTopKInput->getElementType(ConvertToNode::ResultIdx),
+            ElemKind::Float16Ty);
   EXPECT_TRUE(llvm::isa<Placeholder>(convertedTopKInput->getInput()));
   EXPECT_EQ(convertedTopKInput->getInput().getElementType(), ElemKind::FloatTy);
   // At this point we know the input of TopK is convertTo(placeholder).
@@ -534,23 +551,27 @@ TEST_P(AllBackends, OptimizeMiddleConversionsFloatToFloat16) {
   auto *convertedBackReLURes =
       llvm::dyn_cast<ConvertToNode>(result->getInput());
   ASSERT_NE(convertedBackReLURes, nullptr);
-  EXPECT_EQ(convertedBackReLURes->getElementType(0), ElemKind::FloatTy);
+  EXPECT_EQ(convertedBackReLURes->getElementType(ConvertToNode::ResultIdx),
+            ElemKind::FloatTy);
   auto *convertedReLU =
       llvm::dyn_cast<ReluNode>(convertedBackReLURes->getInput());
   ASSERT_NE(convertedReLU, nullptr);
-  EXPECT_EQ(convertedReLU->getElementType(0), ElemKind::Float16Ty);
+  EXPECT_EQ(convertedReLU->getElementType(ReluNode::ResultIdx),
+            ElemKind::Float16Ty);
 
   // Check that the ReLU is fed directly by FC float16.
   auto *convertedFC =
       llvm::dyn_cast<FullyConnectedNode>(convertedReLU->getInput());
   ASSERT_NE(convertedFC, nullptr);
-  EXPECT_EQ(convertedFC->getElementType(0), ElemKind::Float16Ty);
+  EXPECT_EQ(convertedFC->getElementType(FullyConnectedNode::ResultIdx),
+            ElemKind::Float16Ty);
   // Check that the input of FC is a convertTo node from "input" from float to
   // Float16Ty.
   auto *convertedFCInput =
       llvm::dyn_cast<ConvertToNode>(convertedFC->getInput());
   ASSERT_NE(convertedFCInput, nullptr);
-  EXPECT_EQ(convertedFCInput->getElementType(0), ElemKind::Float16Ty);
+  EXPECT_EQ(convertedFCInput->getElementType(ConvertToNode::ResultIdx),
+            ElemKind::Float16Ty);
   EXPECT_TRUE(llvm::isa<Placeholder>(convertedFCInput->getInput()));
   EXPECT_EQ(convertedFCInput->getInput().getElementType(), ElemKind::FloatTy);
   EXPECT_EQ(convertedFCInput->getInput().getNode(), input);
@@ -726,23 +747,27 @@ TEST_P(AllBackends, convertPlaceholderFloatToFloat16) {
   auto *convertedBackReLURes =
       llvm::dyn_cast<ConvertToNode>(result->getInput());
   ASSERT_NE(convertedBackReLURes, nullptr);
-  EXPECT_EQ(convertedBackReLURes->getElementType(0), ElemKind::Float16Ty);
+  EXPECT_EQ(convertedBackReLURes->getElementType(ConvertToNode::ResultIdx),
+            ElemKind::Float16Ty);
   auto *convertedReLU =
       llvm::dyn_cast<ReluNode>(convertedBackReLURes->getInput());
   ASSERT_NE(convertedReLU, nullptr);
-  EXPECT_EQ(convertedReLU->getElementType(0), ElemKind::FloatTy);
+  EXPECT_EQ(convertedReLU->getElementType(ReluNode::ResultIdx),
+            ElemKind::FloatTy);
 
   // Check that the ReLU is fed directly by FC float.
   auto *convertedFC =
       llvm::dyn_cast<FullyConnectedNode>(convertedReLU->getInput());
   ASSERT_NE(convertedFC, nullptr);
-  EXPECT_EQ(convertedFC->getElementType(0), ElemKind::FloatTy);
+  EXPECT_EQ(convertedFC->getElementType(FullyConnectedNode::ResultIdx),
+            ElemKind::FloatTy);
   // Check that the input of FC is a convertTo node from "input" from float to
   // Float16Ty.
   auto *convertedFCInput =
       llvm::dyn_cast<ConvertToNode>(convertedFC->getInput());
   ASSERT_NE(convertedFCInput, nullptr);
-  EXPECT_EQ(convertedFCInput->getElementType(0), ElemKind::FloatTy);
+  EXPECT_EQ(convertedFCInput->getElementType(ConvertToNode::ResultIdx),
+            ElemKind::FloatTy);
   EXPECT_TRUE(llvm::isa<Placeholder>(convertedFCInput->getInput()));
   EXPECT_EQ(convertedFCInput->getInput().getElementType(), ElemKind::Float16Ty);
   EXPECT_EQ(convertedFCInput->getInput().getNode(), input);
@@ -761,7 +786,8 @@ TEST_P(AllBackends, convertPlaceholderFloatToFloat16) {
   // Check that the save is fed from a conversion from float16 to float.
   auto *inputToFloat = llvm::dyn_cast<ConvertToNode>(saveOutput2->getInput());
   ASSERT_NE(inputToFloat, nullptr);
-  EXPECT_EQ(inputToFloat->getElementType(0), ElemKind::FloatTy);
+  EXPECT_EQ(inputToFloat->getElementType(ConvertToNode::ResultIdx),
+            ElemKind::FloatTy);
   // Check that this input is "input".
   auto *inputOfF2 = llvm::dyn_cast<Placeholder>(inputToFloat->getInput());
   ASSERT_NE(inputOfF2, nullptr);
@@ -785,12 +811,14 @@ TEST_P(AllBackends, convertPlaceholderFloatToFloat16) {
   // Check that the save is fed from a conversion from float16 to float.
   auto *convertOutput3 = llvm::dyn_cast<ConvertToNode>(saveOutput3->getInput());
   ASSERT_NE(convertOutput3, nullptr);
-  EXPECT_EQ(convertOutput3->getElementType(0), ElemKind::Float16Ty);
+  EXPECT_EQ(convertOutput3->getElementType(ConvertToNode::ResultIdx),
+            ElemKind::Float16Ty);
 
   auto *convertInputFor3 =
       llvm::dyn_cast<ConvertToNode>(convertOutput3->getInput());
   ASSERT_NE(convertInputFor3, nullptr);
-  EXPECT_EQ(convertInputFor3->getElementType(0), ElemKind::FloatTy);
+  EXPECT_EQ(convertInputFor3->getElementType(ConvertToNode::ResultIdx),
+            ElemKind::FloatTy);
   // Check that this input is "input".
   auto *inputOfF3 = llvm::dyn_cast<Placeholder>(convertInputFor3->getInput());
   ASSERT_NE(inputOfF3, nullptr);
@@ -842,12 +870,14 @@ TEST_P(AllBackends, convertExistingConversionToNoop) {
 
   auto *convertToSave = llvm::dyn_cast<ConvertToNode>(save->getInput());
   EXPECT_EQ(convertToSave, convert);
-  EXPECT_EQ(convert->getElementType(0), ElemKind::Float16Ty);
+  EXPECT_EQ(convert->getElementType(ConvertToNode::ResultIdx),
+            ElemKind::Float16Ty);
 
   auto *addedConversion = llvm::dyn_cast<ConvertToNode>(convert->getInput());
   ASSERT_NE(addedConversion, nullptr);
   // At this point both the input and output of convert are FP16.
-  EXPECT_EQ(addedConversion->getElementType(0), ElemKind::Float16Ty);
+  EXPECT_EQ(addedConversion->getElementType(ConvertToNode::ResultIdx),
+            ElemKind::Float16Ty);
 
   EXPECT_EQ(addedConversion->getInput().getNode(), placeholder);
   EXPECT_EQ(placeholder->getElementType(), ElemKind::FloatTy);

--- a/tools/ClassGen/NodeBuilder.cpp
+++ b/tools/ClassGen/NodeBuilder.cpp
@@ -587,6 +587,24 @@ void NodeBuilder::emitDocstring(std::ostream &os) const {
   }
 }
 
+void NodeBuilder::emitIndicesEnum(std::ostream &os) const {
+  os << "  enum InputIndices {\n";
+  for (size_t i = 0; i < nodeInputs_.size(); i++) {
+    os << "    ";
+    os << nodeInputs_[i];
+    os << "Idx = " << i << ",\n";
+  }
+  os << "  };\n\n";
+
+  os << "  enum ResultIndices {\n";
+  for (int i = 0, e = nodeOutputs_.size(); i < e; i++) {
+    os << "    ";
+    os << nodeOutputs_[i].second;
+    os << "Idx = " << i << ",\n";
+  }
+  os << "  };\n\n";
+}
+
 void NodeBuilder::emitNodeClass(std::ostream &os) const {
   emitMemberForwardDecls(os);
 
@@ -600,6 +618,7 @@ void NodeBuilder::emitNodeClass(std::ostream &os) const {
 
   os << "\n public:\n";
 
+  emitIndicesEnum(os);
   emitCtor(os);
   emitSettersGetters(os);
 

--- a/tools/ClassGen/NodeBuilder.h
+++ b/tools/ClassGen/NodeBuilder.h
@@ -276,6 +276,9 @@ private:
   /// Emit the class-level documentation string, if any.
   void emitDocstring(std::ostream &os) const;
 
+  /// Emit enums for each of the node's inputs and results indices.
+  void emitIndicesEnum(std::ostream &os) const;
+
   /// Emit the class definition for the node.
   void emitNodeClass(std::ostream &os) const;
 


### PR DESCRIPTION
As mentioned in https://github.com/pytorch/glow/issues/2194#issuecomment-449008434, there are places where we use indices explicitly to specify inputs or outputs of Nodes. It's a really bad practice as these indices could change if the Node definition or NodeBuilder change. This PR improves the situation by adding input and output indices enums to each node.

There's a commit here with a couple examples of places it can be used to clean things up. There are other places to update if we agree this approach makes sense. It could also be useful for use in the new design of `isOpSupported()` (https://github.com/pytorch/glow/issues/2194).

Here's what the enums look like for the `ConvolutionNode` in `AutoGenNodes.h` with this PR:

```cpp
class ConvolutionNode final : public Node {
  ...
  enum InputIndices {
    InputIdx = 0,
    FilterIdx = 1,
    BiasIdx = 2,
  };

  enum ResultIndices {
    ResultIdx = 0,
  };
```