### PR TITLE
Refactor ONNXFIModelLoader

### DIFF
--- a/include/glow/Importer/ONNXIFIModelLoader.h
+++ b/include/glow/Importer/ONNXIFIModelLoader.h
@@ -29,7 +29,7 @@ class ONNXIFIModelLoader {
 private:
   /// If \p errPtr is not null then if an error occurs it will get assigned
   /// there otherwise if an error occurs it will abort.
-  ONNXIFIModelLoader(llvm::Error *errPtr = nullptr) {}
+  explicit ONNXIFIModelLoader(llvm::Error *errPtr = nullptr) {}
 
   /// The real loader. It can be ONNXModelLoader or Caffe2ModelLoader
   std::unique_ptr<ProtobufLoader> core_{nullptr};

--- a/include/glow/Importer/ONNXIFIModelLoader.h
+++ b/include/glow/Importer/ONNXIFIModelLoader.h
@@ -29,10 +29,7 @@ class ONNXIFIModelLoader {
 private:
   /// If \p errPtr is not null then if an error occurs it will get assigned
   /// there otherwise if an error occurs it will abort.
-  ONNXIFIModelLoader(Function &F, llvm::Error *errPtr = nullptr) : f_(F) {}
-
-  /// Function to be loaded to
-  Function &f_;
+  ONNXIFIModelLoader(llvm::Error *errPtr = nullptr) {}
 
   /// The real loader. It can be ONNXModelLoader or Caffe2ModelLoader
   std::unique_ptr<ProtobufLoader> core_{nullptr};

--- a/include/glow/Importer/ONNXModelLoader.h
+++ b/include/glow/Importer/ONNXModelLoader.h
@@ -55,6 +55,9 @@ class ONNXModelLoader
   /// ONNX model op_version;
   size_t opsetVersion_;
 
+  /// Mapping between ONNX names for inputs and actual Glow input vars.
+  llvm::StringMap<Placeholder *> onnxNameToInputVars_;
+
   /// Load Constant ONNX operator.
   llvm::Error loadConstant(const ONNX_NAMESPACE::NodeProto &op,
                            const ArgumentDictionaryTy &dict);
@@ -130,11 +133,24 @@ protected:
   /// Load the network initializers from the GraphProto.
   llvm::Error loadInitializers(ONNX_NAMESPACE::GraphProto &net);
 
+  friend class ONNXIFIModelLoader;
+
 public:
   /// Creates a ONNX model loader to build \p F.
   /// If \p errPtr is not null then if an error occurs it will get assigned
   /// there otherwise if an error occurs it will abort.
   ONNXModelLoader(Function &F, llvm::Error *errPtr = nullptr);
+
+  /// \returns mapping between ONNX names and actual Glow input vars.
+  const llvm::StringMap<Placeholder *> &getInputVarsMapping() const {
+    return onnxNameToInputVars_;
+  }
+
+  /// Load the inputs from the GraphProto. If \p loadInputsAsPlaceholders is
+  /// true then this will load each graph input as a placeholder otherwise it
+  /// will create an empty tensor for each input.
+  llvm::Error loadInputs(ONNX_NAMESPACE::GraphProto &net,
+                         bool loadInputsAsPlaceholders);
 
   /// \returns Expected<ModelProto> if a ModelProto can be constructed from the
   /// contents of the file \p filename and Error otherwise.

--- a/include/glow/Importer/ProtobufLoader.h
+++ b/include/glow/Importer/ProtobufLoader.h
@@ -142,6 +142,11 @@ public:
   ProtobufLoader &operator=(const ProtobufLoader &) = delete;
   virtual ~ProtobufLoader() = default;
 
+  /// \returns mapping between ONNX names and actual Glow output nodes.
+  const llvm::StringMap<Placeholder *> &getOutputVarsMapping() const {
+    return outputVarsByName_;
+  }
+
   /// \returns the single final output of the network. The function assumes that
   /// there is only one output, returns Error otherwise. For image
   /// classification, this single final output is usually the result of the last

--- a/lib/Importer/ONNXIFIModelLoader.cpp
+++ b/lib/Importer/ONNXIFIModelLoader.cpp
@@ -20,122 +20,10 @@
 
 namespace glow {
 
-/// Creates tensor \p T from the input \p in. Note, there is no data associated
-/// with the Tensor. This method makes sure that the tensor is created with the
-/// proper shape and element type.
-static llvm::Error setTensorType(const ONNX_NAMESPACE::TypeProto &in,
-                                 Tensor *T) {
-  std::vector<size_t> dim;
-  for (auto d : in.tensor_type().shape().dim()) {
-    dim.push_back(d.dim_value());
-  }
-
-  if (in.tensor_type().elem_type() == ONNX_NAMESPACE::TensorProto::FLOAT) {
-    T->reset(ElemKind::FloatTy, dim);
-    return llvm::Error::success();
-  } else if (in.tensor_type().elem_type() ==
-             ONNX_NAMESPACE::TensorProto::INT64) {
-    T->reset(ElemKind::Int64ITy, dim);
-    return llvm::Error::success();
-  } else if (in.tensor_type().elem_type() ==
-             ONNX_NAMESPACE::TensorProto::INT32) {
-    T->reset(ElemKind::Int32ITy, dim);
-    return llvm::Error::success();
-  } else {
-    RETURN_ERR("Only float and index tensors are supported");
-  }
-}
-
-llvm::Error ONNXIFIModelLoader::loadInputs(ONNX_NAMESPACE::GraphProto &net,
-                                           bool loadInputsAsPlaceholders) {
-  for (const auto &in : net.input()) {
-    // Skip static weights.
-    if (tensors_.count(in.name())) {
-      continue;
-    }
-
-    if (loadInputsAsPlaceholders) {
-      Tensor T;
-      RETURN_IF_ERR(setTensorType(in.type(), &T));
-
-      Placeholder *placeholder;
-      ASSIGN_VALUE_OR_RETURN_ERR(
-          placeholder, createAndRegisterPlaceholder(in.name(), &T.getType()));
-      onnxNameToInputVars_.try_emplace(in.name(), placeholder);
-    } else {
-      std::unique_ptr<Tensor> T(new Tensor());
-      RETURN_IF_ERR(setTensorType(in.type(), T.get()));
-      tensors_[in.name()] = std::move(T);
-    }
-  }
-  return llvm::Error::success();
-}
-
-/// Loads tensor \p T from the input \p in.
-static llvm::Error loadWeight(const onnxTensorDescriptorV1 &in, Tensor *T) {
-  // Only support CPU memory tensors.
-  if (in.memoryType != ONNXIFI_MEMORY_TYPE_CPU) {
-    RETURN_ERR("Only support CPU memory tensors.");
-  }
-
-  std::vector<size_t> dims;
-  for (unsigned i = 0; i < in.dimensions; ++i) {
-    dims.push_back(in.shape[i]);
-  }
-
-  if (in.dataType == ONNXIFI_DATATYPE_FLOAT32) {
-    T->reset(ElemKind::FloatTy, dims);
-
-    auto TH = T->getHandle<>();
-    float *data = (float *)in.buffer;
-    for (size_t i = 0; i < TH.size(); ++i) {
-      TH.raw(i) = data[i];
-    }
-  } else if (in.dataType == ONNXIFI_DATATYPE_UINT64 ||
-             in.dataType == ONNXIFI_DATATYPE_INT64) {
-    const bool inDataSigned = in.dataType == ONNXIFI_DATATYPE_INT64;
-    (void)inDataSigned;
-    T->reset(ElemKind::Int64ITy, dims);
-
-    auto TH = T->getHandle<int64_t>();
-    int64_t *data = (int64_t *)in.buffer;
-    for (size_t i = 0; i < TH.size(); ++i) {
-      RETURN_ERR_IF_NOT(
-          (inDataSigned || data[i] >= 0),
-          "Disallow overflow of loaded UINT64 data into Int64ITy.");
-      TH.raw(i) = data[i];
-    }
-  } else if (in.dataType == ONNXIFI_DATATYPE_INT32) {
-    T->reset(ElemKind::Int32ITy, dims);
-
-    auto TH = T->getHandle<int32_t>();
-    int32_t *data = (int32_t *)in.buffer;
-    for (size_t i = 0; i < TH.size(); ++i) {
-      TH.raw(i) = data[i];
-    }
-  } else {
-    RETURN_ERR("Only float and index tensors are supported.");
-  }
-
-  return llvm::Error::success();
-}
-
-llvm::Error ONNXIFIModelLoader::loadWeights(
-    uint32_t weightsCount, const onnxTensorDescriptorV1 *weightDescriptors) {
-  for (uint32_t i = 0; i < weightsCount; ++i) {
-    std::unique_ptr<Tensor> T(new Tensor());
-    RETURN_IF_ERR(loadWeight(weightDescriptors[i], T.get()));
-    tensors_[weightDescriptors[i].name] = std::move(T);
-  }
-
-  return llvm::Error::success();
-}
-
-llvm::Expected<std::unique_ptr<ONNXIFIModelLoader>>
-ONNXIFIModelLoader::parse(const void *onnxModel, uint32_t onnxModelSize,
-                          uint32_t weightsCount,
-                          const onnxTensorDescriptorV1 *weightDescriptors,
-                          Function &F, bool loadInputsAsPlaceholders) {
+llvm::Expected<std::unique_ptr<ONNXIFIModelLoader>> ONNXIFIModelLoader::parse(
+    const void *onnxModel, uint32_t onnxModelSize, uint32_t weightsCount,
+    const onnxTensorDescriptorV1 *weightDescriptors, Function &F,
+    bool loadInputsAsPlaceholders, bool use_onnx) {
   llvm::Error loaderConstructionErr = llvm::Error::success();
   std::unique_ptr<ONNXIFIModelLoader> loader(
       new ONNXIFIModelLoader(F, &loaderConstructionErr));
@@ -143,24 +31,35 @@ ONNXIFIModelLoader::parse(const void *onnxModel, uint32_t onnxModelSize,
     return std::move(loaderConstructionErr);
   }
 
-  ONNX_NAMESPACE::ModelProto modelDef;
-  ASSIGN_VALUE_OR_RETURN_ERR(modelDef,
-                             loader->loadProto(onnxModel, onnxModelSize));
+  if (use_onnx) {
+    std::unique_ptr<ONNXModelLoader> onnxLoader(
+        new ONNXModelLoader(F, &loaderConstructionErr));
+    if (loaderConstructionErr) {
+      return std::move(loaderConstructionErr);
+    }
+    ONNX_NAMESPACE::ModelProto modelDef;
+    ASSIGN_VALUE_OR_RETURN_ERR(modelDef,
+                               onnxLoader->loadProto(onnxModel, onnxModelSize));
 
-  RETURN_IF_ERR(loader->setVersion(modelDef));
+    RETURN_IF_ERR(onnxLoader->setVersion(modelDef));
 
-  RETURN_IF_ERR(loader->loadWeights(weightsCount, weightDescriptors));
+    RETURN_IF_ERR(onnxLoader->loadWeights(weightsCount, weightDescriptors));
 
-  ONNX_NAMESPACE::GraphProto graphDef = modelDef.graph();
+    ONNX_NAMESPACE::GraphProto graphDef = modelDef.graph();
 
-  RETURN_IF_ERR(loader->loadInputs(graphDef, loadInputsAsPlaceholders));
+    RETURN_IF_ERR(onnxLoader->loadInputs(graphDef, loadInputsAsPlaceholders));
 
-  RETURN_IF_ERR(loader->loadInitializers(graphDef));
+    RETURN_IF_ERR(onnxLoader->loadInitializers(graphDef));
 
-  RETURN_IF_ERR(loader->loadNetwork(graphDef));
+    RETURN_IF_ERR(onnxLoader->loadNetwork(graphDef));
 
-  RETURN_IF_ERR(loader->setOutputNodes(graphDef));
+    RETURN_IF_ERR(onnxLoader->setOutputNodes(graphDef));
 
+    loader->onnxNameToInputVars_ = onnxLoader->getInputVarsMapping();
+
+    // Keep hold of the context
+    loader->core_ = std::move(onnxLoader);
+  }
   return llvm::Expected<std::unique_ptr<ONNXIFIModelLoader>>(std::move(loader));
 }
 } // namespace glow

--- a/lib/Importer/ONNXIFIModelLoader.cpp
+++ b/lib/Importer/ONNXIFIModelLoader.cpp
@@ -26,7 +26,7 @@ llvm::Expected<std::unique_ptr<ONNXIFIModelLoader>> ONNXIFIModelLoader::parse(
     bool loadInputsAsPlaceholders, bool use_onnx) {
   llvm::Error loaderConstructionErr = llvm::Error::success();
   std::unique_ptr<ONNXIFIModelLoader> loader(
-      new ONNXIFIModelLoader(F, &loaderConstructionErr));
+      new ONNXIFIModelLoader(&loaderConstructionErr));
   if (loaderConstructionErr) {
     return std::move(loaderConstructionErr);
   }

--- a/lib/Onnxifi/Base.h
+++ b/lib/Onnxifi/Base.h
@@ -36,9 +36,12 @@ namespace onnxifi {
 class BackendId {
 public:
   /// Create Glow ONNXIFI backend identifier with the
-  /// given Glow backend \p kind, \p id and \p concurrency.
-  explicit BackendId(glow::BackendKind kind, int id, int concurrency)
-      : id_(id), concurrency_(concurrency), executionEngine_(kind) {}
+  /// given Glow backend \p kind, \p id, \p concurrency and whether to use onnx
+  /// or caffe2 for models (\p use_onnx).
+  explicit BackendId(glow::BackendKind kind, int id, int concurrency,
+                     bool use_onnx)
+      : id_(id), use_onnx_(use_onnx), concurrency_(concurrency),
+        executionEngine_(kind) {}
 
   bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy);
 
@@ -52,14 +55,18 @@ public:
   /// \returns Execution Engine associated with the Backend.
   glow::ExecutionEngine &getEE() { return executionEngine_; }
 
+  /// \returns the whether use onnx or not
+  bool getUseOnnx() const { return use_onnx_; }
+
   /// \returns the backend id.
-  int getID() { return id_; }
+  int getID() const { return id_; }
 
   /// \returns concurrency for the backend.
-  int getConcurrency() { return concurrency_; }
+  int getConcurrency() const { return concurrency_; }
 
 private:
   int id_;
+  bool use_onnx_;
   int concurrency_;
   glow::ExecutionEngine executionEngine_;
 };

--- a/tests/unittests/GlowOnnxifiManagerTest.cpp
+++ b/tests/unittests/GlowOnnxifiManagerTest.cpp
@@ -24,9 +24,9 @@ using namespace glow::onnxifi;
 
 TEST(GlowOnnxifiManagerTest, BackendIdTest) {
   auto &manager = GlowOnnxifiManager::get();
-  auto *backendId =
-      new glow::onnxifi::BackendId(glow::BackendKind::Interpreter, /*id*/ 1,
-                                   /*concurrency*/ 1);
+  auto *backendId = new glow::onnxifi::BackendId(glow::BackendKind::Interpreter,
+                                                 /*id*/ 1, /*use_onnx*/ true,
+                                                 /*concurrency*/ 1);
   // BackendId isn't valid before it has been added to the manager.
   EXPECT_FALSE(manager.isValid(backendId));
   manager.addBackendId(backendId);
@@ -43,9 +43,9 @@ TEST(GlowOnnxifiManagerTest, BackendIdTest) {
 
 TEST(GlowOnnxifiManagerTest, BackendTest) {
   auto &manager = GlowOnnxifiManager::get();
-  auto *backendId =
-      new glow::onnxifi::BackendId(glow::BackendKind::Interpreter, /*id*/ 1,
-                                   /*concurrency*/ 1);
+  auto *backendId = new glow::onnxifi::BackendId(glow::BackendKind::Interpreter,
+                                                 /*id*/ 1, /*use_onnx*/ true,
+                                                 /*concurrency*/ 1);
   manager.addBackendId(backendId);
 
   auto *backend = manager.createBackend(backendId);
@@ -78,9 +78,9 @@ TEST(GlowOnnxifiManagerTest, EventTest) {
 
 TEST(GlowOnnxifiManagerTest, GraphTest) {
   auto &manager = GlowOnnxifiManager::get();
-  auto *backendId =
-      new glow::onnxifi::BackendId(glow::BackendKind::Interpreter, /*id*/ 1,
-                                   /*concurrency*/ 1);
+  auto *backendId = new glow::onnxifi::BackendId(glow::BackendKind::Interpreter,
+                                                 /*id*/ 1, /*use_onnx*/ true,
+                                                 /*concurrency*/ 1);
   manager.addBackendId(backendId);
   auto *backend = manager.createBackend(backendId);
 
@@ -102,9 +102,9 @@ TEST(GlowOnnxifiManagerTest, GraphTest) {
 
 void createAndDestroyManagerObjects() {
   auto &manager = GlowOnnxifiManager::get();
-  auto *backendId =
-      new glow::onnxifi::BackendId(glow::BackendKind::Interpreter, /*id*/ 1,
-                                   /*concurrency*/ 1);
+  auto *backendId = new glow::onnxifi::BackendId(glow::BackendKind::Interpreter,
+                                                 /*id*/ 1, /*use_onnx*/ true,
+                                                 /*concurrency*/ 1);
   manager.addBackendId(backendId);
   auto *backend = manager.createBackend(backendId);
   auto *event = manager.createEvent();


### PR DESCRIPTION
*Description*:
This PR refactors the ONNXIFIModelLoader to let it not inherit ONNXModelLoader. Instead, it uses it. This can separate the dependency of ONNXIFI on ONNX and allows us to load other models through ONNXIFI interface. 

*Testing*:
Unit tests

*Documentation*:
[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
