### PR TITLE
[importer] Handle GivenTensorFill like Caffe2

### DIFF
--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -822,70 +822,67 @@ llvm::Error Caffe2ModelLoader::loadNetwork(caffe2::NetDef &net) {
   return llvm::Error::success();
 }
 
+template <typename ElemTy, typename RangeTy>
+static llvm::Error fillTensor(Tensor &T, ElemKind kind,
+                              llvm::ArrayRef<size_t> dim, RangeTy values) {
+  T.reset(kind, dim);
+  auto TH = T.getHandle<ElemTy>();
+  size_t i = 0;
+  for (auto num : values) {
+    TH.raw(i++) = num;
+  }
+  RETURN_ERR_IF_NOT(i == T.size(),
+                    llvm::formatv("Wrong number of values for GivenTensorFill "
+                                  "({0} given, {1} expected)",
+                                  i, T.size())
+                        .str());
+  return llvm::Error::success();
+}
+
 llvm::Error Caffe2ModelLoader::loadWeight(const caffe2::OperatorDef &op) {
   ArgumentDictionaryTy dict = loadArgumentMap(op);
   const std::string &typeName = op.type();
 
-  /// Load tensors with values:
+  // Load tensors with values:
   if (typeName == "GivenTensorFill" || typeName == "GivenTensorIntFill" ||
       typeName == "GivenTensorInt64Fill") {
     /*
-     output: "conv1_w"
-     name: ""
-     type: "GivenTensorFill"
-     arg {
-     name: "shape"
-     ints: 96
-     ints: 3
-     ints: 11
-     ints: 11
-     }
-     arg {
-     name: "values"
-     floats: -0.028315347
+     * op {
+     *   output: "conv1_w"
+     *   name: ""
+     *   type: "GivenTensorFill"
+     *   arg {
+     *     name: "shape"
+     *     ints: 96
+     *     ints: 3
+     *     ints: 11
+     *     ints: 11
+     *   }
+     *   arg {
+     *     name: "values"
+     *     floats: -0.028315347
+     *     ...
+     *   }
+     * }
      */
-
-    for (auto &o : op.output()) {
-      std::unique_ptr<Tensor> T(new Tensor());
-
-      auto dim = getShape(dict["shape"]);
-
-      size_t i = 0;
-#define LOAD_TENSOR_FILL(TYPE_NAME, NATIVE_TYPE, PROTO_TYPE_NAME)              \
-  T->reset(ElemKind::TYPE_NAME, dim);                                          \
-  auto TH = T->getHandle<NATIVE_TYPE>();                                       \
-  for (auto num : dict["values"]->PROTO_TYPE_NAME()) {                         \
-    TH.raw(i++) = num;                                                         \
-  }
-
-      if (dict["values"]->floats_size()) {
-        RETURN_ERR_IF_NOT(
-            typeName != "GivenTensorIntFill" &&
-                typeName != "GivenTensorInt64Fill",
-            "Typename must not be GivenTensorIntFill or GivenTensorInt64Fill");
-        LOAD_TENSOR_FILL(FloatTy, float, floats);
-      } else if (dict["values"]->ints_size()) {
-        if (typeName == "GivenTensorIntFill") {
-          LOAD_TENSOR_FILL(Int32ITy, int32_t, ints);
-        } else if (typeName == "GivenTensorInt64Fill" ||
-                   typeName == "GivenTensorFill") {
-          LOAD_TENSOR_FILL(Int64ITy, int64_t, ints);
-        } else {
-          RETURN_ERR(unexpectedNodeErrorMessage(
-              op, "Unsupported data type for " + typeName));
-        }
-      } else {
-        RETURN_ERR(unexpectedNodeErrorMessage(op, "Unsupported data type for " +
-                                                      typeName));
-      }
-#undef LOAD_TENSOR_FILL
-
-      RETURN_ERR_IF_NOT(i == T->size(),
-                        "The number of serialized values does not "
-                        "match the size of the tensor.");
-      tensors_[o] = std::move(T);
+    auto dim = getShape(dict["shape"]);
+    auto const &values = dict["values"];
+    RETURN_ERR_IF_NOT(op.output_size() == 1,
+                      "GivenTensorFill must have exactly 1 output");
+    std::unique_ptr<Tensor> T(new Tensor());
+    if (typeName == "GivenTensorFill") {
+      RETURN_IF_ERR(
+          fillTensor<float>(*T, ElemKind::FloatTy, dim, values->floats()));
+    } else if (typeName == "GivenTensorIntFill") {
+      RETURN_IF_ERR(
+          fillTensor<int32_t>(*T, ElemKind::Int32ITy, dim, values->ints()));
+    } else if (typeName == "GivenTensorInt64Fill") {
+      RETURN_IF_ERR(
+          fillTensor<int64_t>(*T, ElemKind::Int64ITy, dim, values->ints()));
+    } else {
+      GLOW_UNREACHABLE("Unhandled GivenTensorFill type");
     }
-
+    tensors_[op.output()[0]] = std::move(T);
     return llvm::Error::success();
   }
 

--- a/tests/models/caffe2Models/fill_test_init_net.pbtxt
+++ b/tests/models/caffe2Models/fill_test_init_net.pbtxt
@@ -16,22 +16,6 @@ op {
   }
 }
 op {
-  output: "tensor_fill_int"
-  type: "GivenTensorFill"
-  arg {
-    name: "shape"
-    ints: 2
-    ints: 2
-  }
-  arg {
-    name: "values"
-    ints: 0
-    ints: 1
-    ints: 2
-    ints: 3
-  }
-}
-op {
   output: "tensor_int_fill"
   type: "GivenTensorIntFill"
   arg {

--- a/tests/models/caffe2Models/lengths_to_ranges_init_net.pbtxt
+++ b/tests/models/caffe2Models/lengths_to_ranges_init_net.pbtxt
@@ -1,7 +1,7 @@
 name: "init"
 op {
   output: "input"
-  type: "GivenTensorFill"
+  type: "GivenTensorIntFill"
   arg {
     name: "shape"
     ints: 4

--- a/tests/unittests/Caffe2ImporterTest.cpp
+++ b/tests/unittests/Caffe2ImporterTest.cpp
@@ -1477,7 +1477,7 @@ TEST(caffe2, tensorFillsTest) {
   std::string NetWeightFilename(
       "tests/models/caffe2Models/fill_test_init_net.pbtxt");
 
-  Constant *tensorFillFloat, *tensorFillInt, *tensorIntFill, *tensorInt64Fill;
+  Constant *tensorFillFloat, *tensorIntFill, *tensorInt64Fill;
 
   // Destroy the loader after the graph is loaded since the following execution
   // will not depend on anything from the loader.
@@ -1490,8 +1490,6 @@ TEST(caffe2, tensorFillsTest) {
                                {"unused_output"}, {&unusedTy}, *F);
     tensorFillFloat = llvm::dyn_cast<Constant>(EXIT_ON_ERR(
         caffe2LD.getNodeValueOrCreateConstantByName("tensor_fill_float")));
-    tensorFillInt = llvm::dyn_cast<Constant>(EXIT_ON_ERR(
-        caffe2LD.getNodeValueOrCreateConstantByName("tensor_fill_int")));
     tensorIntFill = llvm::dyn_cast<Constant>(EXIT_ON_ERR(
         caffe2LD.getNodeValueOrCreateConstantByName("tensor_int_fill")));
     tensorInt64Fill = llvm::dyn_cast<Constant>(EXIT_ON_ERR(
@@ -1499,26 +1497,22 @@ TEST(caffe2, tensorFillsTest) {
   }
 
   ASSERT_TRUE(tensorFillFloat);
-  ASSERT_TRUE(tensorFillInt);
   ASSERT_TRUE(tensorIntFill);
   ASSERT_TRUE(tensorInt64Fill);
 
   // All fills in fill_test_init_net.pbtxt use shape {2, 2}.
   const std::vector<size_t> expectedDims = {2, 2};
   ASSERT_TRUE(tensorFillFloat->dims().equals(expectedDims));
-  ASSERT_TRUE(tensorFillInt->dims().equals(expectedDims));
   ASSERT_TRUE(tensorIntFill->dims().equals(expectedDims));
   ASSERT_TRUE(tensorInt64Fill->dims().equals(expectedDims));
 
   auto tensorFillFloatH = tensorFillFloat->getPayload().getHandle<float>();
-  auto tensorFillIntH = tensorFillInt->getPayload().getHandle<int64_t>();
   auto tensorIntFillH = tensorIntFill->getPayload().getHandle<int32_t>();
   auto tensorInt64FillH = tensorInt64Fill->getPayload().getHandle<int64_t>();
 
   // All fills in fill_test_init_net.pbtxt are set to 0 through 3.
   for (size_t i = 0, e = 4; i < e; i++) {
     EXPECT_FLOAT_EQ(tensorFillFloatH.raw(i), (float)i);
-    EXPECT_EQ(tensorFillIntH.raw(i), (int64_t)i);
     EXPECT_EQ(tensorIntFillH.raw(i), (int32_t)i);
     EXPECT_EQ(tensorInt64FillH.raw(i), (int64_t)i);
   }


### PR DESCRIPTION
*Description*: Caffe2 does not accept `ints` with `GivenTensorFill`, only `floats`.  Trying to use `ints` produces a check failure:
```
Check failed: output->numel() == values_.numel() output size: 314 given size: 0
```
I'd like Glow to match C2 semantics so we don't find ourselves executing something that C2 rejects.

There is apparently a `dtype` argument that would allow this, though I haven't added support for it.

*Testing*: Update existing test.

*Documentation*:
