### PR TITLE
[CMake] add target AutoGen for explicit dependency check

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_custom_target(AutoGen)
+
 add_subdirectory(Backends)
 add_subdirectory(Base)
 add_subdirectory(CodeGen)

--- a/lib/Graph/CMakeLists.txt
+++ b/lib/Graph/CMakeLists.txt
@@ -10,6 +10,12 @@ add_custom_command(OUTPUT
                    COMMAND NodeGen ${NODES_HDR} ${NODES_SRC} ${NODES_DEF}
                    DEPENDS NodeGen
                    COMMENT "NodeGen: Generating nodes." VERBATIM)
+add_custom_target(AutoGenNode
+                   DEPENDS
+                     "${NODES_HDR}"
+                     "${NODES_SRC}"
+                     "${NODES_DEF}")
+add_dependencies(AutoGen AutoGenNode)
 
 add_library(Graph
             ${NODES_HDR}
@@ -30,4 +36,4 @@ target_link_libraries(Graph
                         Support
                         QuantizationBase)
 
-add_dependencies(Graph IRGenHeaders)
+add_dependencies(Graph AutoGen)

--- a/lib/IR/CMakeLists.txt
+++ b/lib/IR/CMakeLists.txt
@@ -18,12 +18,16 @@ add_custom_command(OUTPUT
                       "${INSTR_BLD_HDR}" "${INSTR_BLD_SRC}" "${INSTR_IR_GEN}"
                     DEPENDS InstrGen
                     COMMENT "InstrGen: Generating instructions." VERBATIM)
-
-add_custom_target(IRGenHeaders
-                  DEPENDS
+add_custom_target(AutoGenInstr
+                   DEPENDS
                     "${INSTR_HDR}"
+                    "${INSTR_SRC}"
                     "${INSTR_DEF}"
-                    "${INSTR_BLD_HDR}")
+                    "${INSTR_BLD_HDR}"
+                    "${INSTR_BLD_SRC}"
+                    "${INSTR_IR_GEN}")
+add_dependencies(AutoGen AutoGenInstr)
+
 
 add_library(IR
               "${INSTR_SRC}"
@@ -42,3 +46,5 @@ target_link_libraries(IR
                         Graph
                         Base
                         Support)
+
+add_dependencies(IR AutoGen)


### PR DESCRIPTION
*Description*: 
If target does not link with Graph/IR.
It may failed with AutoGenXXX header missing during build with -j

AutoGen target is for explicit dependency check with target which using AutoGenXXX headers

*Testing*: no test
*Documentation*: no doc updated
[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.