### PR TITLE
[tensor] Add begin/end iterators to tensor handle and use them

### DIFF
--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -490,15 +490,15 @@ protected:
       ASSIGN_VALUE_OR_RETURN_ERR(constShapeTensor,
                                  getTensorByName(op.input(1)));
       auto TH = constShapeTensor->getHandle<int64_t>();
-      for (size_t i = 0, e = constShapeTensor->size(); i != e; i++) {
-        requestedDims.push_back(TH.at({i}));
+      for (auto dim : TH) {
+        requestedDims.push_back(dim);
       }
     } else if (dict.count("shape")) {
       RETURN_ERR_IF_NOT(op.input_size() == 1,
                         "Cannot specify new shape by both argument and input.");
       std::vector<int64_t> protoDims = getShape<int64_t>(dict["shape"]);
-      for (size_t i = 0, e = protoDims.size(); i != e; i++) {
-        requestedDims.push_back(protoDims[i]);
+      for (auto dim : protoDims) {
+        requestedDims.push_back(dim);
       }
     } else {
       RETURN_ERR("Missing output shape information for the Reshape operator.");

--- a/lib/Base/Tensor.cpp
+++ b/lib/Base/Tensor.cpp
@@ -87,9 +87,9 @@ static void dumpGenericImpl(Handle<ElemTy> handle, llvm::raw_ostream &os) {
   ElemTy mx = handle.raw(0);
   ElemTy mn = handle.raw(0);
 
-  for (size_t i = 0, e = handle.size(); i < e; i++) {
-    mx = std::max(mx, handle.raw(i));
-    mn = std::min(mn, handle.raw(i));
+  for (auto elem : handle) {
+    mx = std::max(mx, elem);
+    mn = std::min(mn, elem);
   }
 
   // Check for zero tensor.

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -51,8 +51,7 @@ const int32_t OFFSETSHIFT = 128;
 /// Translates the protocol buffer node \p op into a random access map.
 static ArgumentDictionaryTy loadArgumentMap(const caffe2::OperatorDef &op) {
   ArgumentDictionaryTy dict;
-  for (auto i = 0, e = op.arg_size(); i < e; i++) {
-    const caffe2::Argument &arg = op.arg(i);
+  for (auto &arg : op.arg()) {
     dict[arg.name()] = &arg;
   }
   return dict;
@@ -1066,8 +1065,8 @@ llvm::Error Caffe2ModelLoader::loadWeight(const caffe2::OperatorDef &op) {
                  << " random numbers. This could be source of discrepancy.\n";
 #endif // NDEBUG
     // Uniformly generate random numbers in [tensorMin; tensorMax).
-    for (size_t i = 0, e = T->size(); i != e; i++) {
-      TH.raw(i) = G_.getParent()->getPRNG().nextRandReal(tensorMin, tensorMax);
+    for (auto &elem : TH) {
+      elem = G_.getParent()->getPRNG().nextRandReal(tensorMin, tensorMax);
     }
 
     tensors_[name] = std::move(T);

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -70,8 +70,7 @@ using ArgumentDictionaryTy =
 static ArgumentDictionaryTy
 loadArgumentMap(const ONNX_NAMESPACE::NodeProto &op) {
   ArgumentDictionaryTy dict;
-  for (auto i = 0, e = op.attribute_size(); i < e; i++) {
-    const ONNX_NAMESPACE::AttributeProto &arg = op.attribute(i);
+  for (auto &arg : op.attribute()) {
     dict[arg.name()] = &arg;
   }
   return dict;

--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -1043,8 +1043,7 @@ static void mergeBatchedAdd(Function *F) {
 
     // Create the new slices. These slices will replace the original scalar
     // batched-add nodes.
-    for (int i = 0, e = order.size(); i < e; i++) {
-      auto *orig = order[i];
+    for (auto *orig : order) {
       newSlices.push_back(F->createSlice(orig->getName(), BA, orig->getStart(),
                                          orig->getResult().getType()));
     }

--- a/lib/Quantization/Base/Profile.cpp
+++ b/lib/Quantization/Base/Profile.cpp
@@ -99,8 +99,8 @@ void generateTensorHistogram(const Handle<float> inputTensor,
   }
 
   float binWidth = (max - min) / nBins;
-  for (size_t i = 0, e = inputTensor.size(); i < e; ++i) {
-    size_t newBin = getBin(nBins, binWidth, min, inputTensor.raw(i));
+  for (auto elem : inputTensor) {
+    size_t newBin = getBin(nBins, binWidth, min, elem);
     existingHistogram.raw(newBin)++;
   }
 }

--- a/tests/unittests/Caffe2ImporterTest.cpp
+++ b/tests/unittests/Caffe2ImporterTest.cpp
@@ -1511,7 +1511,7 @@ TEST(caffe2, tensorFillsTest) {
   auto tensorInt64FillH = tensorInt64Fill->getPayload().getHandle<int64_t>();
 
   // All fills in fill_test_init_net.pbtxt are set to 0 through 3.
-  for (size_t i = 0, e = 4; i < e; i++) {
+  for (size_t i = 0; i < 4; i++) {
     EXPECT_FLOAT_EQ(tensorFillFloatH.raw(i), (float)i);
     EXPECT_EQ(tensorIntFillH.raw(i), (int32_t)i);
     EXPECT_EQ(tensorInt64FillH.raw(i), (int64_t)i);

--- a/tests/unittests/GradCheckTest.cpp
+++ b/tests/unittests/GradCheckTest.cpp
@@ -286,9 +286,8 @@ TEST_P(InterpreterGrad, gradientCheckBatchNorm) {
   inputsH.initXavier(1, mod.getPRNG());
   outputsH.initXavier(1, mod.getPRNG());
 
-  for (int i = 0, e = inputsH.size(); i < e; i++) {
-    inputsH.raw(i) *= 6;
-    inputsH.raw(i) += 4;
+  for (auto &elem : inputsH) {
+    elem = elem * 6 + 4;
   }
 
   performGradCheck(EE_, ctx, result, A, Ex, &inputs, &outputs, 0.001, 0.004);

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -1723,8 +1723,8 @@ void checkIntConvolution(ExecutionEngine &EE, Function *F, unsigned convDepth,
   auto H = ctx.get(res->getPlaceholder())->getHandle();
 
   // Check that the difference in the results is less than 0.1.
-  for (int i = 0, e = H.size(); i < e; i++) {
-    EXPECT_NEAR(H.raw(i), 0, 0.1);
+  for (auto elem : H) {
+    EXPECT_NEAR(elem, 0, 0.1);
   }
 }
 
@@ -1763,8 +1763,8 @@ TEST_P(InterpAndCPU, IntConcat) {
 
   auto R = ctx_.get(res->getPlaceholder())->getHandle();
   // Check that the difference in the results is less than 0.2.
-  for (int i = 0, e = R.size(); i < e; i++) {
-    EXPECT_NEAR(R.raw(i), 0, 0.2);
+  for (auto elem : R) {
+    EXPECT_NEAR(elem, 0, 0.2);
   }
 }
 
@@ -1809,8 +1809,8 @@ TEST_P(Operator, IntFC) {
   // Check that there aren't too many elements with a difference in the results
   // of greater than 0.2.
   int count = 0;
-  for (int i = 0, e = H.size(); i < e; i++) {
-    if (std::abs(H.raw(i)) > 0.2) {
+  for (auto elem : H) {
+    if (std::abs(elem) > 0.2) {
       count++;
     }
   }
@@ -4404,8 +4404,8 @@ TEST_P(InterpAndCPU, rowwiseQuantizedFCTest) {
   auto H = ctx_.get(save->getPlaceholder())->getHandle();
 
   // The difference in the results should be less than 0.05.
-  for (int i = 0, e = H.size(); i < e; i++) {
-    EXPECT_LE(std::abs(H.raw(i)), 0.05);
+  for (auto elem : H) {
+    EXPECT_LE(std::abs(elem), 0.05);
   }
 }
 

--- a/tests/unittests/TensorsTest.cpp
+++ b/tests/unittests/TensorsTest.cpp
@@ -57,8 +57,8 @@ TEST(Tensor, randomizeInt) {
   H.randomize(-50, 50, PRNG);
 
   // Check that all of the numbers fall in the range -50 to 50.
-  for (size_t i = 0, e = H.size(); i < e; i++) {
-    EXPECT_NEAR(H.raw(i), 0, 50);
+  for (auto elem : H) {
+    EXPECT_NEAR(elem, 0, 50);
   }
 }
 
@@ -69,8 +69,8 @@ TEST(Tensor, randomizeFloat16) {
   H.randomize(-50, 50, PRNG);
 
   // Check that all of the numbers fall in the range -50 to 50.
-  for (size_t i = 0, e = H.size(); i < e; i++) {
-    EXPECT_NEAR(H.raw(i), 0, 50);
+  for (auto elem : H) {
+    EXPECT_NEAR(elem, 0, 50);
   }
 }
 
@@ -666,33 +666,33 @@ TEST(Tensor, zeroQuantizedTensor) {
 
   auto Q8H = Q8T.getHandle<int8_t>();
   EXPECT_TRUE(Q8H.isZero());
-  for (size_t i = 0, e = Q8H.size(); i < e; i++) {
-    EXPECT_EQ(Q8H.raw(i), offsetQ8);
+  for (auto elem : Q8H) {
+    EXPECT_EQ(elem, offsetQ8);
   }
 
   auto Q16H = Q16T.getHandle<int16_t>();
   EXPECT_TRUE(Q16H.isZero());
-  for (size_t i = 0, e = Q16H.size(); i < e; i++) {
-    EXPECT_EQ(Q16H.raw(i), offsetQ16);
+  for (auto elem : Q16H) {
+    EXPECT_EQ(elem, offsetQ16);
   }
 
   auto Q32H = Q32T.getHandle<int32_t>();
   EXPECT_TRUE(Q32H.isZero());
-  for (size_t i = 0, e = Q32H.size(); i < e; i++) {
-    EXPECT_EQ(Q32H.raw(i), offsetQ32);
+  for (auto elem : Q32H) {
+    EXPECT_EQ(elem, offsetQ32);
   }
 
   Q32H = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
   EXPECT_FALSE(Q32H.isZero());
 
-  for (size_t i = 0, e = Q32H.size(); i < e; i++) {
-    EXPECT_NE(Q32H.raw(i), offsetQ32);
+  for (auto elem : Q32H) {
+    EXPECT_NE(elem, offsetQ32);
   }
 
   Q32T.zero();
   EXPECT_TRUE(Q32H.isZero());
-  for (size_t i = 0, e = Q32H.size(); i < e; i++) {
-    EXPECT_EQ(Q32H.raw(i), offsetQ32);
+  for (auto elem : Q32H) {
+    EXPECT_EQ(elem, offsetQ32);
   }
 }
 

--- a/tools/loader/ImageClassifier.cpp
+++ b/tools/loader/ImageClassifier.cpp
@@ -255,12 +255,12 @@ template <typename ElemTy> static void applySoftmax(Handle<ElemTy> H) {
   assert(H.dims().size() == 1 && "H must be a Handle of a 1d Tensor.");
   float denominator = 0.0f;
 
-  for (size_t i = 0, e = H.size(); i < e; ++i) {
-    denominator += std::exp(static_cast<float>(H.raw(i)));
+  for (auto elem : H) {
+    denominator += std::exp(static_cast<float>(elem));
   }
 
-  for (size_t j = 0, e = H.size(); j < e; ++j) {
-    H.raw(j) = std::exp(static_cast<float>(H.raw(j))) / denominator;
+  for (auto &elem : H) {
+    elem = std::exp(static_cast<float>(elem)) / denominator;
   }
 }
 


### PR DESCRIPTION
*Description*: Allows (1) iteration of a tensor's contents with range-based for loops, and (2) use of std:: algorithms.
*Testing*: unit tests, image-classifier with resnet50
*Documentation*: doxygen

