### PR TITLE
[CMake] fix link order issue

### DIFF
--- a/examples/bundles/lenet_mnist/CMakeLists.txt
+++ b/examples/bundles/lenet_mnist/CMakeLists.txt
@@ -33,14 +33,12 @@ add_custom_target(RunQuantizedLeNetMnistBundle DEPENDS RunQuantizedBundleCommand
 # =================
 # Regular
 add_executable(LeNetMnistBundle $<TARGET_OBJECTS:LeNetMnistBundleMain>)
-set_target_properties(LeNetMnistBundle PROPERTIES LINK_FLAGS "-lpng")
-target_link_libraries(LeNetMnistBundle ${LENET_MNIST_BUNDLE_DIR}/lenet_mnist.o)
+target_link_libraries(LeNetMnistBundle ${LENET_MNIST_BUNDLE_DIR}/lenet_mnist.o png)
 add_dependencies(LeNetMnistBundle LeNetMnistBundleMain LeNetMnistBundleNet)
 
 # Quantized
 add_executable(QuantizedLeNetMnistBundle $<TARGET_OBJECTS:LeNetMnistBundleMain>)
-set_target_properties(QuantizedLeNetMnistBundle PROPERTIES LINK_FLAGS "-lpng")
-target_link_libraries(QuantizedLeNetMnistBundle ${LENET_MNIST_BUNDLE_DIR}/quantized_lenet_mnist.o)
+target_link_libraries(QuantizedLeNetMnistBundle ${LENET_MNIST_BUNDLE_DIR}/quantized_lenet_mnist.o png)
 add_dependencies(QuantizedLeNetMnistBundle LeNetMnistBundleMain QuantizedLeNetMnistBundleNet)
 
 # Glow Bundles

--- a/examples/bundles/resnet50/CMakeLists.txt
+++ b/examples/bundles/resnet50/CMakeLists.txt
@@ -33,14 +33,12 @@ add_custom_target(RunQuantizedResNet50Bundle DEPENDS RunQuantizedBundleCommand Q
 # =================
 # Regular
 add_executable(ResNet50Bundle $<TARGET_OBJECTS:ResNet50BundleMain>)
-set_target_properties(ResNet50Bundle PROPERTIES LINK_FLAGS "-lpng")
-target_link_libraries(ResNet50Bundle ${RESNET50_BUNDLE_DIR}/resnet50.o)
+target_link_libraries(ResNet50Bundle ${RESNET50_BUNDLE_DIR}/resnet50.o png)
 add_dependencies(ResNet50Bundle ResNet50BundleMain ResNet50BundleNet)
 
 # Quantized
 add_executable(QuantizedResNet50Bundle $<TARGET_OBJECTS:ResNet50BundleMain>)
-set_target_properties(QuantizedResNet50Bundle PROPERTIES LINK_FLAGS "-lpng")
-target_link_libraries(QuantizedResNet50Bundle ${RESNET50_BUNDLE_DIR}/quantized_resnet50.o)
+target_link_libraries(QuantizedResNet50Bundle ${RESNET50_BUNDLE_DIR}/quantized_resnet50.o png)
 add_dependencies(QuantizedResNet50Bundle ResNet50BundleMain QuantizedResNet50BundleNet)
 
 # Glow Bundles


### PR DESCRIPTION
*Description*:
```
[100%] Linking CXX executable ../../../bin/LeNetMnistBundle
cd /home/zakk/glow-build/examples/bundles/lenet_mnist && /usr/local/bin/cmake -E cmake_link_script CMakeFiles/LeNetMnistBundle.dir/link.txt --verbose=1
/usr/bin/c++   -Wall -Wnon-virtual-dtor -fno-exceptions -fno-rtti -g -fno-omit-frame-pointer -O0  -lpng CMakeFiles/LeNetMnistBundleMain.dir/main.cpp.o  -o ../../../bin/LeNetMnistBundle lenet_mnist.o 
CMakeFiles/LeNetMnistBundleMain.dir/main.cpp.o: In function `readPngImage(char const*, std::pair<float, float>, float*&, unsigned long*)':
/home/zakk/glow/examples/bundles/lenet_mnist/main.cpp:65: undefined reference to `png_sig_cmp'
/home/zakk/glow/examples/bundles/lenet_mnist/main.cpp:71: undefined reference to `png_create_read_struct'
...
/home/zakk/glow/examples/bundles/lenet_mnist/main.cpp:143: undefined reference to `png_destroy_read_struct'
collect2: error: ld returned 1 exit status
```
main.cpp depend on libpng
replace `set_target_properties` with `target_link_libraries`



*Testing*:
*Documentation*:
[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
