### PR TITLE
Print stack trace on error signal

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -55,6 +55,7 @@ sudo apt-get install -y llvm-6.0 llvm-6.0-dev libpng-dev
 # Redirect clang
 sudo ln -s /usr/bin/clang-6.0 /usr/bin/clang
 sudo ln -s /usr/bin/clang++-6.0 /usr/bin/clang++
+sudo ln -s /usr/bin/llvm-symbolizer-6.0 /usr/bin/llvm-symbolizer
 
 # Install ninja and (newest version of) cmake through pip
 sudo pip install ninja cmake

--- a/.circleci/suppressions.txt
+++ b/.circleci/suppressions.txt
@@ -1,0 +1,1 @@
+leak:RegisterHandlers

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -7,6 +7,7 @@ set -euxo pipefail
 export GLOW_SRC=$PWD
 export GLOW_BUILD_DIR=${GLOW_SRC}/build
 export LOADER=${GLOW_BUILD_DIR}/bin/image-classifier
+export LSAN_OPTIONS="suppressions=$GLOW_SRC/.circleci/suppressions.txt"
 
 # Pass in which tests to run (one of {test, test_unopt}).
 run_unit_tests() {

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -8,6 +8,7 @@ export GLOW_SRC=$PWD
 export GLOW_BUILD_DIR=${GLOW_SRC}/build
 export LOADER=${GLOW_BUILD_DIR}/bin/image-classifier
 export LSAN_OPTIONS="suppressions=$GLOW_SRC/.circleci/suppressions.txt"
+export ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer
 
 # Pass in which tests to run (one of {test, test_unopt}).
 run_unit_tests() {

--- a/tests/unittests/TestMain.cpp
+++ b/tests/unittests/TestMain.cpp
@@ -15,10 +15,12 @@
  */
 
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Signals.h"
 #include "gtest/gtest.h"
 
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
+  llvm::sys::PrintStackTraceOnErrorSignal(argv[0]);
   llvm::cl::ParseCommandLineOptions(argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -26,6 +26,7 @@
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/Signals.h"
 #include "llvm/Support/Timer.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -323,6 +324,7 @@ void Loader::generateAndSerializeQuantizationInfos(Context &ctx) {
 }
 
 Loader::Loader(int argc, char **argv) {
+  llvm::sys::PrintStackTraceOnErrorSignal(argv[0]);
   llvm::cl::ParseCommandLineOptions(
       argc, argv,
       " The Glow compiler\n\n"


### PR DESCRIPTION
*Description*: Enabling this signal handler makes it quicker to debug a crash since you get a stack trace without needing to run under a debugger.  (Unlike a debugger, this option doesn't seem to give line numbers, which is weird.  But still pretty useful.)
*Testing*: Add an error to one of the unittests and observe that a stack trace is printed.
*Documentation*: n/a
