### PR TITLE
[ci] Symbolize ASAN stack traces

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -55,6 +55,7 @@ sudo apt-get install -y llvm-6.0 llvm-6.0-dev libpng-dev
 # Redirect clang
 sudo ln -s /usr/bin/clang-6.0 /usr/bin/clang
 sudo ln -s /usr/bin/clang++-6.0 /usr/bin/clang++
+sudo ln -s /usr/bin/llvm-symbolizer-6.0 /usr/bin/llvm-symbolizer
 
 # Install ninja and (newest version of) cmake through pip
 sudo pip install ninja cmake

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -7,6 +7,7 @@ set -euxo pipefail
 export GLOW_SRC=$PWD
 export GLOW_BUILD_DIR=${GLOW_SRC}/build
 export LOADER=${GLOW_BUILD_DIR}/bin/image-classifier
+export ASAN_SYMBOLIZER_PATH=/usr/bin/llvm-symbolizer
 
 # Pass in which tests to run (one of {test, test_unopt}).
 run_unit_tests() {


### PR DESCRIPTION
*Description*: So that we can actually debug ASAN failures that occur in CI but not locally
*Testing*: Used to debug #2227 
*Documentation*: n/a

