### PR TITLE
Update README.md to include opencl-headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ following command should install the required dependencies:
 
   ```bash
   sudo apt-get install clang clang-6.0 cmake graphviz libpng-dev \
-      libprotobuf-dev llvm-6.0 ninja-build protobuf-compiler wget
+      libprotobuf-dev llvm-6.0 ninja-build protobuf-compiler wget opencl-headers
   ```
 
 It may be desirable to use `update-alternatives` to manage the version of


### PR DESCRIPTION
Fails to build without OpenCL, added this to the install requirements.

*Description*:
*Testing*:
*Documentation*:
[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
