### PR TITLE
[C2/ONNX] Add support for GatherRanges operator

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -622,6 +622,19 @@ public:
   GatherNode *createGather(llvm::StringRef name, NodeValue data,
                            NodeValue indices, unsigned_t batchDims = 0);
 
+  /// Gathers entries of \p data in groups specified by the "examples" in
+  /// \p ranges. Each example in \p ranges contains a list of pairs of
+  /// indices of the form (index, length) which specify which entries of \p
+  /// data to gather. The ordering of elements in \p ranges and of pairs
+  /// within an element is preserved in the output. In addition to the result
+  /// of gathering ("output"), the lengths of the ranges gathered by each
+  /// example in \p ranges is also produced as an output ("lengths").
+  /// \p maxOutputSize is the maximum possible size of "output" and is used to
+  /// set its type. Users must use "lengths" to interpret "output" correctly.
+  GatherRangesNode *createGatherRanges(llvm::StringRef name, NodeValue data,
+                                       NodeValue ranges,
+                                       unsigned_t maxOutputSize);
+
   /// Copies each slice from \p slices into \p data at the corresponding index
   /// in \p indices, and \returns this new version of data. For example, given
   /// input data {{1,2},{3,4},{5,6}}, slices {{-3,-4}}, and indices {1}, the

--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -383,6 +383,44 @@ void libjit_gather(T *dest, const T *data, const IDX *indices,
   }
 }
 
+template <typename T, typename U>
+void libjit_gatherranges(T *output, U *lengths, const T *data, const U *ranges,
+                         size_t numExamples, size_t exampleSize) {
+  // Indices into the output and range buffers.
+  size_t outputIdx = 0;
+  size_t rangesIdx = 0;
+
+  // For each example:
+  for (size_t example = 0; example < numExamples; ++example) {
+    // Keep track of the total length of the gathered ranges for the example.
+    U totalLen = 0;
+
+    // For each range:
+    for (size_t range = 0; range < exampleSize; ++range) {
+      // Get the start and length of the range.
+      const U start = ranges[rangesIdx];
+      const U len = ranges[rangesIdx + 1];
+
+      // Copy the specified elements.
+      memcpy(output + outputIdx, data + start, len * sizeof(T));
+
+      // len elements were copied, so increment the output index by len.
+      outputIdx += len;
+
+      // Each range is of the form (start, len), so increment the ranges
+      // index by 2 to get to the next range.
+      rangesIdx += 2;
+
+      // Increment the total length for the example by len.
+      totalLen += len;
+    }
+
+    // Record the total length of gathered ranges for the current example in
+    // the lengths buffer.
+    lengths[example] = totalLen;
+  }
+}
+
 template <typename T>
 void libjit_scatterassign(T *data, const size_t *indices, const T *slices,
                           size_t numIndices, size_t sliceSize) {
@@ -919,6 +957,42 @@ void libjit_gather32_u(size_t *dest, const size_t *data, const int32_t *indices,
                        size_t sampleSize) {
   libjit_gather(dest, data, indices, numIndices, sliceSize, numSamples,
                 sampleSize);
+}
+
+void libjit_gatherranges64_f(float *output, size_t *lengths, const float *data,
+                             const size_t *ranges, size_t numExamples,
+                             size_t exampleSize) {
+  libjit_gatherranges(output, lengths, data, ranges, numExamples, exampleSize);
+}
+
+void libjit_gatherranges64_i8(int8_t *output, size_t *lengths,
+                              const int8_t *data, const size_t *ranges,
+                              size_t numExamples, size_t exampleSize) {
+  libjit_gatherranges(output, lengths, data, ranges, numExamples, exampleSize);
+}
+
+void libjit_gatherranges64_u(size_t *output, size_t *lengths,
+                             const size_t *data, const size_t *ranges,
+                             size_t numExamples, size_t exampleSize) {
+  libjit_gatherranges(output, lengths, data, ranges, numExamples, exampleSize);
+}
+
+void libjit_gatherranges32_f(float *output, int32_t *lengths, const float *data,
+                             const int32_t *ranges, size_t numExamples,
+                             size_t exampleSize) {
+  libjit_gatherranges(output, lengths, data, ranges, numExamples, exampleSize);
+}
+
+void libjit_gatherranges32_i8(int8_t *output, int32_t *lengths,
+                              const int8_t *data, const int32_t *ranges,
+                              size_t numExamples, size_t exampleSize) {
+  libjit_gatherranges(output, lengths, data, ranges, numExamples, exampleSize);
+}
+
+void libjit_gatherranges32_u(size_t *output, int32_t *lengths,
+                             const size_t *data, const int32_t *ranges,
+                             size_t numExamples, size_t exampleSize) {
+  libjit_gatherranges(output, lengths, data, ranges, numExamples, exampleSize);
 }
 
 void libjit_scatterassign_f(float *data, const size_t *indices,

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -196,6 +196,8 @@ private:
   void fwdLengthsSumInst_FloatImpl(const LengthsSumInst *I);
 
   template <typename ElemTy> void fwdGatherInstImpl(const GatherInst *I);
+  template <typename ElemTy>
+  void fwdGatherRangesInstImpl(const GatherRangesInst *I);
 
   void
   fwdSparseLengthsWeightedSumInst_I8Impl(const SparseLengthsWeightedSumInst *I);

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1516,6 +1516,19 @@ GatherNode *Function::createGather(llvm::StringRef name, NodeValue data,
       indices, batchDims));
 }
 
+GatherRangesNode *Function::createGatherRanges(llvm::StringRef name,
+                                               NodeValue data, NodeValue ranges,
+                                               unsigned_t maxOutputSize) {
+  auto numRanges = ranges.dims()[0];
+  return addNode(new GatherRangesNode(
+      name,
+      /*OutputTy=*/
+      getParent()->uniqueTypeWithNewShape(data.getType(), {maxOutputSize}),
+      /*LengthsTy=*/
+      getParent()->uniqueTypeWithNewShape(ranges.getType(), numRanges), data,
+      ranges));
+}
+
 ScatterAssignNode *Function::createScatterAssign(llvm::StringRef name,
                                                  NodeValue data,
                                                  NodeValue indices,

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -862,6 +862,27 @@ bool GatherNode::verify() const {
   return isValid;
 }
 
+bool GatherRangesNode::verify() const {
+  bool isValid = expectCompareTrue("Data must be 1D", getData().dims().size(),
+                                   size_t(1), this);
+  isValid &= expectCompareTrue("Ranges must be 3D", getRanges().dims().size(),
+                               size_t(3), this);
+  isValid &= expectCompareTrue("Last dimension of Ranges must be equal to 2",
+                               getRanges().dims()[2], size_t(2), this);
+  isValid &= expectCompareTrue("Output must be 1D", getOutput().dims().size(),
+                               size_t(1), this);
+  isValid &= expectCompareTrue("Lengths must be 1D", getLengths().dims().size(),
+                               size_t(1), this);
+  isValid &=
+      expectCompareTrue("Number of examples must match number of lengths",
+                        getRanges().dims()[0], getLengths().dims()[0], this);
+
+  isValid &= checkTypeIgnoreShape(getOutput(), getData(), this);
+  isValid &= checkTypeIgnoreShape(getRanges(), getLengths(), this);
+
+  return isValid;
+}
+
 bool ScatterAssignNode::verify() const {
   const auto &slicesDims = getSlices().dims();
   const auto &dataDims = getData().dims();

--- a/tests/models/caffe2Models/gather_ranges.pbtxt
+++ b/tests/models/caffe2Models/gather_ranges.pbtxt
@@ -1,0 +1,17 @@
+name: "gatherRanges"
+op {
+  input: "data"
+  input: "ranges"
+  output: "output"
+  output: "lengths"
+  arg {
+    name: "maxOutputSize"
+    i: 5
+  }
+  name: ""
+  type: "GatherRanges"
+}
+external_input: "data"
+external_input: "ranges"
+external_output: "output"
+external_output: "lengths"

--- a/tests/models/onnxModels/gatherranges.onnxtxt
+++ b/tests/models/onnxModels/gatherranges.onnxtxt
@@ -1,0 +1,78 @@
+ir_version: 3
+producer_name: "backend-test"
+graph {
+  node {
+    op_type: "GatherRanges"
+    input: "data"
+    input: "ranges"
+    output: "output"
+    output: "lengths"
+    attribute {
+      name: "maxOutputSize"
+      i: 5
+      type: INT
+    }
+  }
+  name: "test_gather_ranges"
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: FLOAT
+        shape {
+          dim {
+            dim_value: 6
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "ranges"
+    type {
+      tensor_type {
+        elem_type: INT32
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "output"
+    type {
+      tensor_type {
+        elem_type: FLOAT
+        shape {
+          dim {
+            dim_value: 5
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "lengths"
+    type {
+      tensor_type {
+        elem_type: INT32
+        shape {
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 9
+}

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -434,6 +434,15 @@ int main(int argc, char **argv) {
       .autoVerify(VerifyKind::SameElementType, {"Dest", "Data"})
       .autoIRGen();
 
+  BB.newInstr("GatherRanges")
+      .addOperand("Output", OperandKind::Out)
+      .addOperand("Lengths", OperandKind::Out)
+      .addOperand("Data", OperandKind::In)
+      .addOperand("Ranges", OperandKind::In)
+      .autoVerify(VerifyKind::SameElementType, {"Data", "Output"})
+      .autoVerify(VerifyKind::SameElementType, {"Ranges", "Lengths"})
+      .autoIRGen();
+
   BB.newInstr("ScatterAssign")
       .addOperand("Data", OperandKind::InOut)
       .addOperand("Indices", OperandKind::In)

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -448,6 +448,20 @@ int main(int argc, char **argv) {
                     "batch and will concat the result of the gather operation "
                     "on each sample in the batch.");
 
+  BB.newNode("GatherRanges")
+      .addInput("Data")
+      .addInput("Ranges")
+      .addResultFromCtorArg("Output")
+      .addResultFromCtorArg("Lengths")
+      .setDocstring("Gathers entries of Data into Output in groups specified "
+                    "by the elements of Ranges. Each element of Ranges "
+                    "contains a list of pairs of indices of the form (index, "
+                    "length) which specify which entries of data to gather. "
+                    "The ordering of elements in Ranges and of pairs within an "
+                    "element is preserved in Output. Lengths contains the "
+                    "lengths of the ranges gathered by each list of pairs in "
+                    "Ranges.");
+
   BB.newNode("ScatterAssign")
       .addInput("Data")
       .addInput("Indices")


### PR DESCRIPTION
**Description**
This commit adds support for the [`GatherRanges` operator (click me!)](https://caffe2.ai/docs/operators-catalogue.html#gatherranges). This operator
is not lowered and this commit includes interpreter and CPU backend
implementations for it.

**Testing**
This commit adds two unit tests (one with 32-bit ranges and another with
64-bit ranges) to `OperatorTest` that check operator correctness and one
unit test to `OnnxImporterTest` to check that the operator can be loaded
from a `.onnxtxt` correctly.

**Fixes**
This commit fixes #2210.