### PR TITLE
Redesign isOpSupported()

### DIFF
--- a/docs/Backends.md
+++ b/docs/Backends.md
@@ -33,14 +33,15 @@ are two pure virtual functions all backends must implement:
     If the backend uses Glow low-level IR, it can call `generateAndOptimizeIR()` to generate
     an optimized `IRFunction`.
 
-- `virtual bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const;`
+- `virtual bool isOpSupported(const NodeInfo &NI) const;`
 
-  - Returns whether the backend supports the given operation `opKind` with the
-    given `ElemKind elementTy`. For example, a backend may not support a
-    specific bit-width quantization kind (e.g. `Int16QTy`) at all, or may only
-    support it for certain operations (e.g. `ConvolutionNodeKind`). Any
-    `(opKind, elementTy)` pair passed in that returns true must be supported
-    during `compile()`.
+  - Returns whether the backend can execute a node with given NodeInfo `NI`,
+    containing the node kind and input and output types. For example, a backend
+    may not support a specific bit-width quantization kind (e.g. `Int16QTy`) at
+    all, or may only support it for certain operations
+    (e.g. `ConvolutionNodeKind`). Any `(opKind, inputTypes, outputTypes)` passed
+    in that returns true must be supported by the backed during `compile()` and
+    `execute()`.
 
 Additionally, there are virtual functions that backends can override:
 

--- a/include/glow/Backends/Backend.h
+++ b/include/glow/Backends/Backend.h
@@ -73,9 +73,8 @@ public:
     return false;
   }
 
-  /// \returns true if backend supports given kind of operation with
-  /// the given \p elementTy element type.
-  virtual bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const = 0;
+  /// \returns whether the provided \p NI is supported by the backend.
+  virtual bool isOpSupported(const NodeInfo &NI) const = 0;
 
   /// \returns true if the supplied Node \N should be lowered. By default, all
   /// Nodes are candidates for lowering.

--- a/include/glow/ExecutionEngine/ExecutionEngine.h
+++ b/include/glow/ExecutionEngine/ExecutionEngine.h
@@ -94,9 +94,10 @@ public:
   void insertCompiledFunction(llvm::StringRef name,
                               std::unique_ptr<CompiledFunction> func);
 
-  /// \returns whether operation is supported by the underlying backend.
-  bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const {
-    return backend_->isOpSupported(opKind, elementTy);
+  /// \returns whether a node with the provided \p NI is supported by the
+  /// underlying backend.
+  bool isOpSupported(const NodeInfo &NI) const {
+    return backend_->isOpSupported(NI);
   }
 
   /// Optimize the Function \p f and pass it to the backend to compile it for a

--- a/include/glow/Graph/Node.h
+++ b/include/glow/Graph/Node.h
@@ -254,6 +254,10 @@ public:
     return outTypes_[idx]->getElementType();
   }
 
+  /// \returns whether all of the element types of inTypes_ and outTypes_ are
+  /// all the same and one of those found in \p allowedElemKinds. \p ignoreIn
+  /// and \p ignoreOut represent indices that can be skipped in inTypes_ and
+  /// outTypes_ respectively.
   bool
   allInputsAndOutputsHaveSameElemKind(llvm::ArrayRef<ElemKind> allowedElemKinds,
                                       const IndicesSet &ignoreIn = {},
@@ -267,6 +271,8 @@ public:
     return false;
   }
 
+  /// Helper for debugging which \returns a string representation for the
+  /// NodeInfo.
   std::string getDebugDesc() const {
     DescriptionBuilder db(getKindName());
     for (size_t i = 0; i < inTypes_.size(); ++i) {

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -160,54 +160,258 @@ void CPUBackend::save(Function *F, llvm::StringRef outputDir,
   BundleSaver(IR.get()).save(tgt, outputDir, networkName);
 }
 
-bool CPUBackend::isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const {
-  // Check for quantization support.
-  if (elementTy == ElemKind::Int8QTy) {
-    switch (opKind) {
-    case Kinded::Kind::AddNodeKind:
-    case Kinded::Kind::BatchedAddNodeKind:
-    case Kinded::Kind::BatchedReduceAddNodeKind:
-    case Kinded::Kind::CmpLTENodeKind:
-    case Kinded::Kind::ConcatNodeKind:
-    case Kinded::Kind::ConvolutionNodeKind:
-    case Kinded::Kind::DequantizeNodeKind:
-    case Kinded::Kind::DivNodeKind:
-    case Kinded::Kind::FullyConnectedNodeKind:
-    case Kinded::Kind::GatherNodeKind:
-    case Kinded::Kind::LogNodeKind:
-    case Kinded::Kind::MatMulNodeKind:
-    case Kinded::Kind::MaxNodeKind:
-    case Kinded::Kind::MinNodeKind:
-    case Kinded::Kind::MulNodeKind:
-    case Kinded::Kind::AvgPoolNodeKind:
-    case Kinded::Kind::MaxPoolNodeKind:
-    case Kinded::Kind::QuantizeNodeKind:
-    case Kinded::Kind::ReluNodeKind:
-    case Kinded::Kind::RescaleQuantizedNodeKind:
-    case Kinded::Kind::ReshapeNodeKind:
-    case Kinded::Kind::SelectNodeKind:
-    case Kinded::Kind::SliceNodeKind:
-    case Kinded::Kind::SigmoidNodeKind:
-    case Kinded::Kind::SubNodeKind:
-    case Kinded::Kind::TanhNodeKind:
-    case Kinded::Kind::TileNodeKind:
-    case Kinded::Kind::TopKNodeKind:
-    case Kinded::Kind::TransposeNodeKind:
-      return true;
-    default:
-      return false;
+bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
+  // Note: For brevity below, "X ==> Y, Z" signifes that Node X is IRGen'd into
+  // Instructions Y and Z.
+
+  switch (NI.getKind()) {
+  case Kinded::Kind::AddNodeKind:
+  case Kinded::Kind::SubNodeKind:
+  case Kinded::Kind::MulNodeKind:
+  case Kinded::Kind::MaxNodeKind:
+  case Kinded::Kind::MinNodeKind:
+    // Note: Int8QTy Log, Tanh, and Sigmoid are lowered into a lookup
+    // table. However, we do not lower them until after they're quantized. So we
+    // need to return here that they are supported as Int8QTy.
+  case Kinded::Kind::LogNodeKind:
+  case Kinded::Kind::TanhNodeKind:
+  case Kinded::Kind::SigmoidNodeKind:
+  case Kinded::Kind::CPUMaxSplatNodeKind:
+  case Kinded::Kind::BatchedReduceAddNodeKind:
+  case Kinded::Kind::MatMulNodeKind:
+  case Kinded::Kind::AvgPoolNodeKind:
+  case Kinded::Kind::MaxPoolNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+        {ElemKind::FloatTy, ElemKind::Int8QTy});
+
+  case Kinded::Kind::SaveNodeKind:
+  case Kinded::Kind::ReshapeNodeKind:
+    // These are implemented via a Copy Instruction.
+    return NI.allInputsAndOutputsHaveSameElemKind(
+        {ElemKind::FloatTy, ElemKind::Int8QTy, ElemKind::Int32QTy,
+         ElemKind::Int32ITy, ElemKind::Int64ITy, ElemKind::BoolTy});
+
+  case Kinded::Kind::DivNodeKind:
+    // InsertTensor ==> Copy + InsertTensor. Copy supports everything
+    // ReshapeNode above supports, so InsertTensor is the limiting factor.
+  case Kinded::Kind::InsertTensorNodeKind:
+    // Concat ==> Splat + Insert. Both only support the following.
+  case Kinded::Kind::ConcatNodeKind:
+  case Kinded::Kind::SplatNodeKind:
+  case Kinded::Kind::TransposeNodeKind:
+  case Kinded::Kind::SliceNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+        {ElemKind::FloatTy, ElemKind::Int8QTy, ElemKind::Int64ITy});
+
+  case Kinded::Kind::SparseLengthsWeightedSumNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::FloatTy},
+               {SparseLengthsWeightedSumNode::IndicesIdx,
+                SparseLengthsWeightedSumNode::LengthsIdx}) &&
+           (NI.getInElemTy(SparseLengthsWeightedSumNode::IndicesIdx) ==
+            ElemKind::Int64ITy) &&
+           (NI.getInElemTy(SparseLengthsWeightedSumNode::LengthsIdx) ==
+            ElemKind::Int32ITy);
+
+  case Kinded::Kind::RowwiseQuantizedSparseLengthsWeightedSumNodeKind:
+    return (NI.getInElemTy(
+                RowwiseQuantizedSparseLengthsWeightedSumNode::DataIdx) ==
+            ElemKind::Int8QTy) &&
+           (NI.getInElemTy(
+                RowwiseQuantizedSparseLengthsWeightedSumNode::ScalesIdx) ==
+            ElemKind::FloatTy) &&
+           (NI.getInElemTy(
+                RowwiseQuantizedSparseLengthsWeightedSumNode::OffsetsIdx) ==
+            ElemKind::Int32ITy) &&
+           (NI.getInElemTy(
+                RowwiseQuantizedSparseLengthsWeightedSumNode::WeightsIdx) ==
+            ElemKind::FloatTy) &&
+           (NI.getInElemTy(
+                RowwiseQuantizedSparseLengthsWeightedSumNode::IndicesIdx) ==
+            ElemKind::Int64ITy) &&
+           (NI.getInElemTy(
+                RowwiseQuantizedSparseLengthsWeightedSumNode::LengthsIdx) ==
+            ElemKind::Int32ITy) &&
+           (NI.getOutElemTy(
+                RowwiseQuantizedSparseLengthsWeightedSumNode::ResultIdx) ==
+            ElemKind::FloatTy);
+
+  case Kinded::Kind::LengthsToRangesNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind({ElemKind::Int32ITy});
+
+  case Kinded::Kind::IntLookupTableNodeKind:
+  case Kinded::Kind::RescaleQuantizedNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind({ElemKind::Int8QTy});
+
+  case Kinded::Kind::PowNodeKind:
+  case Kinded::Kind::AvgPoolGradNodeKind:
+  case Kinded::Kind::MaxPoolGradNodeKind:
+  case Kinded::Kind::QuantizationProfileNodeKind:
+  case Kinded::Kind::CPUConvDKKC8NodeKind:
+  case Kinded::Kind::LocalResponseNormalizationNodeKind:
+  case Kinded::Kind::LocalResponseNormalizationGradNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind({ElemKind::FloatTy});
+
+  case Kinded::Kind::ConvolutionNodeKind:
+    if (!NI.getInTy(ConvolutionNode::InputIdx)->isQuantizedType()) {
+      return NI.allInputsAndOutputsHaveSameElemKind({ElemKind::FloatTy});
     }
-  }
 
-  if (elementTy == ElemKind::Float16Ty) {
+    return NI.allInputsAndOutputsHaveSameElemKind({ElemKind::Int8QTy},
+                                                  {ConvolutionNode::BiasIdx}) &&
+           (NI.getInElemTy(ConvolutionNode::BiasIdx) == ElemKind::Int32QTy);
+
+  case Kinded::Kind::BatchedAddNodeKind:
+    if (!NI.getInTy(BatchedAddNode::BatchIdx)->isQuantizedType()) {
+      return NI.allInputsAndOutputsHaveSameElemKind({ElemKind::FloatTy});
+    }
+    // Allow for Int8QTy or Int32QTy for the Slice input.
+    return NI.allInputsAndOutputsHaveSameElemKind({ElemKind::Int8QTy},
+                                                  {BatchedAddNode::SliceIdx}) &&
+           ((NI.getInElemTy(BatchedAddNode::SliceIdx) == ElemKind::Int8QTy) ||
+            (NI.getInElemTy(BatchedAddNode::SliceIdx) == ElemKind::Int32QTy));
+
+  case Kinded::Kind::GatherNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::FloatTy, ElemKind::Int8QTy, ElemKind::Int64ITy},
+               {GatherNode::IndicesIdx}) &&
+           ((NI.getInElemTy(GatherNode::IndicesIdx) == ElemKind::Int32ITy) ||
+            (NI.getInElemTy(GatherNode::IndicesIdx) == ElemKind::Int64ITy));
+
+  case Kinded::Kind::GatherRangesNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::FloatTy, ElemKind::Int8QTy, ElemKind::Int64ITy},
+               {GatherRangesNode::RangesIdx}, {GatherRangesNode::LengthsIdx}) &&
+           ((NI.getInElemTy(GatherRangesNode::RangesIdx) ==
+             NI.getOutElemTy(GatherRangesNode::LengthsIdx)) &&
+            ((NI.getOutElemTy(GatherRangesNode::LengthsIdx) ==
+              ElemKind::Int32ITy) ||
+             (NI.getOutElemTy(GatherRangesNode::LengthsIdx) ==
+              ElemKind::Int64ITy)));
+
+  case Kinded::Kind::ScatterAssignNodeKind:
+    // ScatterAssign ==> Copy + ScatterAssign. Copy supports everything
+    // ReshapeNode above supports, however ScatterAssign only supports the
+    // following.
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::FloatTy, ElemKind::Int8QTy},
+               {ScatterAssignNode::IndicesIdx}) &&
+           (NI.getInElemTy(ScatterAssignNode::IndicesIdx) ==
+            ElemKind::Int64ITy);
+
+  case Kinded::Kind::SelectNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::FloatTy, ElemKind::Int8QTy}, {SelectNode::CondIdx}) &&
+           (NI.getInElemTy(SelectNode::CondIdx) == ElemKind::BoolTy);
+
+  case Kinded::Kind::CmpLTENodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::FloatTy, ElemKind::Int8QTy}, {},
+               {CmpLTENode::ResultIdx}) &&
+           (NI.getOutElemTy(CmpLTENode::ResultIdx) == ElemKind::BoolTy);
+
+  case Kinded::Kind::IsNaNNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind({ElemKind::FloatTy}, {},
+                                                  {CmpLTENode::ResultIdx}) &&
+           (NI.getOutElemTy(CmpLTENode::ResultIdx) == ElemKind::BoolTy);
+
+  case Kinded::Kind::CmpEQNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind({ElemKind::Int64ITy}, {},
+                                                  {CmpEQNode::ResultIdx}) &&
+           (NI.getOutElemTy(CmpEQNode::ResultIdx) == ElemKind::BoolTy);
+
+  case Kinded::Kind::TopKNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::FloatTy, ElemKind::Int8QTy}, {},
+               {TopKNode::IndicesIdx}) &&
+           (NI.getOutElemTy(TopKNode::IndicesIdx) == ElemKind::Int64ITy);
+
+  case Kinded::Kind::QuantizeNodeKind:
+    return (NI.getInElemTy(QuantizeNode::InputIdx) == ElemKind::FloatTy) &&
+           ((NI.getOutElemTy(QuantizeNode::ResultIdx) == ElemKind::Int8QTy) ||
+            (NI.getOutElemTy(QuantizeNode::ResultIdx) == ElemKind::Int32QTy));
+
+  case Kinded::Kind::DequantizeNodeKind:
+    return (NI.getInElemTy(DequantizeNode::InputIdx) == ElemKind::Int8QTy) &&
+           (NI.getOutElemTy(DequantizeNode::ResultIdx) == ElemKind::FloatTy);
+
+  case Kinded::Kind::SoftMaxNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind({ElemKind::FloatTy},
+                                                  {SoftMaxNode::SelectedIdx}) &&
+           (NI.getInElemTy(SoftMaxNode::SelectedIdx) == ElemKind::Int64ITy);
+
+  case Kinded::Kind::CrossEntropyLossNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::FloatTy}, {CrossEntropyLossNode::LabelsIdx}) &&
+           (NI.getInElemTy(CrossEntropyLossNode::LabelsIdx) ==
+            ElemKind::Int64ITy);
+
+  case Kinded::Kind::LengthsSumNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::FloatTy}, {LengthsSumNode::LengthsIdx}) &&
+           (NI.getInElemTy(LengthsSumNode::LengthsIdx) == ElemKind::Int32ITy);
+
+  case Kinded::Kind::FusedRowwiseQuantizedSparseLengthsWeightedSumNodeKind:
+    return (NI.getInElemTy(
+                FusedRowwiseQuantizedSparseLengthsWeightedSumNode::DataIdx) ==
+            ElemKind::Int8FusedQTy) &&
+           (NI.getInElemTy(FusedRowwiseQuantizedSparseLengthsWeightedSumNode::
+                               WeightsIdx) == ElemKind::FloatTy) &&
+           (NI.getInElemTy(FusedRowwiseQuantizedSparseLengthsWeightedSumNode::
+                               IndicesIdx) == ElemKind::Int64ITy) &&
+           (NI.getInElemTy(FusedRowwiseQuantizedSparseLengthsWeightedSumNode::
+                               LengthsIdx) == ElemKind::Int32ITy) &&
+           (NI.getOutElemTy(
+                FusedRowwiseQuantizedSparseLengthsWeightedSumNode::ResultIdx) ==
+            ElemKind::FloatTy);
+
+  case Kinded::Kind::RowwiseQuantizedFullyConnectedNodeKind:
+    return (NI.getInElemTy(RowwiseQuantizedFullyConnectedNode::InputIdx) ==
+            ElemKind::Int8QTy) &&
+           (NI.getInElemTy(RowwiseQuantizedFullyConnectedNode::WeightsIdx) ==
+            ElemKind::Int8QTy) &&
+           (NI.getInElemTy(RowwiseQuantizedFullyConnectedNode::ScalesIdx) ==
+            ElemKind::FloatTy) &&
+           (NI.getInElemTy(RowwiseQuantizedFullyConnectedNode::OffsetsIdx) ==
+            ElemKind::Int32ITy) &&
+           (NI.getInElemTy(RowwiseQuantizedFullyConnectedNode::BiasIdx) ==
+            ElemKind::Int32QTy) &&
+           (NI.getOutElemTy(RowwiseQuantizedFullyConnectedNode::ResultIdx) ==
+            ElemKind::Int8QTy);
+
+  case Kinded::Kind::SparseToDenseNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::FloatTy}, {SparseToDenseNode::IndicesIdx}) &&
+           (NI.getInElemTy(SparseToDenseNode::IndicesIdx) ==
+            ElemKind::Int64ITy);
+
+  case Kinded::Kind::SoftMaxGradNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::FloatTy}, {SoftMaxGradNode::SelectedIdx},
+               {SoftMaxGradNode::GradOfInputNamedSelectedIdx}) &&
+           (NI.getInElemTy(SoftMaxGradNode::SelectedIdx) == ElemKind::Int64ITy);
+
+  case Kinded::Kind::ConvolutionGradNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+        {ElemKind::FloatTy}, {},
+        {ConvolutionGradNode::GradOfInputNamedInputIdx});
+
+  case Kinded::Kind::CrossEntropyLossGradNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::FloatTy}, {CrossEntropyLossGradNode::LabelsIdx},
+               {CrossEntropyLossGradNode::GradOfInputNamedLabelsIdx}) &&
+           (NI.getInElemTy(CrossEntropyLossGradNode::LabelsIdx) ==
+            ElemKind::Int64ITy) &&
+           (NI.getOutElemTy(
+                CrossEntropyLossGradNode::GradOfInputNamedLabelsIdx) ==
+            ElemKind::Int64ITy);
+
+  case Kinded::Kind::TraceEventNodeKind:
+    return NI.getInElemTy(TraceEventNode::DataIdx) == ElemKind::Int64ITy;
+
+  default:
     return false;
   }
-
-  if (elementTy == ElemKind::Int16QTy) {
-    return false;
-  }
-
-  return true;
 }
 
 bool CPUBackend::shouldLower(const Node *N) const {

--- a/lib/Backends/CPU/CPUBackend.h
+++ b/lib/Backends/CPU/CPUBackend.h
@@ -60,7 +60,7 @@ public:
   bool transformPostLowering(Function *F,
                              const CompilationOptions &opts) const override;
 
-  bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override;
+  bool isOpSupported(const NodeInfo &NI) const override;
 
   bool shouldLower(const Node *N) const override;
   /// @}

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -65,55 +65,297 @@ Interpreter::compileIRWithoutConstants(std::unique_ptr<IRFunction> IR) const {
   return llvm::make_unique<InterpreterFunction>(std::move(IR), bundle);
 }
 
-bool Interpreter::isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const {
-  // Check quantization support.
-  if (elementTy == ElemKind::Int8QTy) {
-    switch (opKind) {
-    case Kinded::Kind::AddNodeKind:
-    case Kinded::Kind::BatchedAddNodeKind:
-    case Kinded::Kind::BatchedReduceAddNodeKind:
-    case Kinded::Kind::CmpLTENodeKind:
-    case Kinded::Kind::ConcatNodeKind:
-    case Kinded::Kind::ConvolutionNodeKind:
-    case Kinded::Kind::DequantizeNodeKind:
-    case Kinded::Kind::DivNodeKind:
-    case Kinded::Kind::FullyConnectedNodeKind:
-    case Kinded::Kind::GatherNodeKind:
-    case Kinded::Kind::LogNodeKind:
-    case Kinded::Kind::MatMulNodeKind:
-    case Kinded::Kind::MaxNodeKind:
-    case Kinded::Kind::MinNodeKind:
-    case Kinded::Kind::MulNodeKind:
-    case Kinded::Kind::AvgPoolNodeKind:
-    case Kinded::Kind::MaxPoolNodeKind:
-    case Kinded::Kind::QuantizeNodeKind:
-    case Kinded::Kind::ReluNodeKind:
-    case Kinded::Kind::RescaleQuantizedNodeKind:
-    case Kinded::Kind::ReshapeNodeKind:
-    case Kinded::Kind::SelectNodeKind:
-    case Kinded::Kind::SigmoidNodeKind:
-    case Kinded::Kind::SliceNodeKind:
-    case Kinded::Kind::SparseLengthsWeightedSumNodeKind:
-    case Kinded::Kind::SubNodeKind:
-    case Kinded::Kind::TanhNodeKind:
-    case Kinded::Kind::TileNodeKind:
-    case Kinded::Kind::TopKNodeKind:
-    case Kinded::Kind::TransposeNodeKind:
-    case Kinded::Kind::RowwiseQuantizedFullyConnectedNodeKind:
-      return true;
-    default:
-      return false;
+bool Interpreter::isOpSupported(const NodeInfo &NI) const {
+  switch (NI.getKind()) {
+  case Kinded::Kind::AddNodeKind:
+  case Kinded::Kind::SubNodeKind:
+  case Kinded::Kind::MulNodeKind:
+  case Kinded::Kind::MaxNodeKind:
+  case Kinded::Kind::MinNodeKind:
+  case Kinded::Kind::AvgPoolNodeKind:
+  case Kinded::Kind::MaxPoolNodeKind:
+  case Kinded::Kind::MatMulNodeKind:
+  case Kinded::Kind::BatchedReduceAddNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+        {ElemKind::FloatTy, ElemKind::Float16Ty, ElemKind::Int8QTy});
+
+  case Kinded::Kind::PowNodeKind:
+  case Kinded::Kind::LogNodeKind:
+  case Kinded::Kind::LocalResponseNormalizationNodeKind:
+  case Kinded::Kind::SigmoidNodeKind:
+  case Kinded::Kind::TanhNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+        {ElemKind::FloatTy, ElemKind::Float16Ty});
+
+  case Kinded::Kind::SplatNodeKind:
+  case Kinded::Kind::InsertTensorNodeKind:
+  case Kinded::Kind::DivNodeKind:
+  case Kinded::Kind::ConcatNodeKind:
+  case Kinded::Kind::SliceNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+        {ElemKind::FloatTy, ElemKind::Float16Ty, ElemKind::Int8QTy,
+         ElemKind::Int64ITy});
+
+  case Kinded::Kind::SelectNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::FloatTy, ElemKind::Float16Ty, ElemKind::Int8QTy},
+               {SelectNode::CondIdx}) &&
+           (NI.getInElemTy(SelectNode::CondIdx) == ElemKind::BoolTy);
+
+  case Kinded::Kind::CmpLTENodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::FloatTy, ElemKind::Float16Ty, ElemKind::Int8QTy}, {},
+               {CmpLTENode::ResultIdx}) &&
+           (NI.getOutElemTy(CmpLTENode::ResultIdx) == ElemKind::BoolTy);
+
+  case Kinded::Kind::IsNaNNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::FloatTy, ElemKind::Float16Ty}, {},
+               {CmpLTENode::ResultIdx}) &&
+           (NI.getOutElemTy(CmpLTENode::ResultIdx) == ElemKind::BoolTy);
+
+  case Kinded::Kind::CmpEQNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::FloatTy, ElemKind::Float16Ty, ElemKind::Int64ITy}, {},
+               {CmpEQNode::ResultIdx}) &&
+           (NI.getOutElemTy(CmpEQNode::ResultIdx) == ElemKind::BoolTy);
+
+  case Kinded::Kind::ModuloNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+        {ElemKind::Int32ITy, ElemKind::Int64ITy});
+
+  case Kinded::Kind::ConvolutionNodeKind:
+    if (!NI.getInTy(ConvolutionNode::InputIdx)->isQuantizedType()) {
+      return NI.allInputsAndOutputsHaveSameElemKind(
+          {ElemKind::FloatTy, ElemKind::Float16Ty});
     }
-  }
-  if (elementTy == ElemKind::Float16Ty) {
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::Int8QTy, ElemKind::Int16QTy},
+               {ConvolutionNode::BiasIdx}) &&
+           (NI.getInElemTy(ConvolutionNode::BiasIdx) == ElemKind::Int32QTy);
+
+  case Kinded::Kind::FullyConnectedNodeKind:
+    if (!NI.getInTy(FullyConnectedNode::InputIdx)->isQuantizedType()) {
+      return NI.allInputsAndOutputsHaveSameElemKind(
+          {ElemKind::FloatTy, ElemKind::Float16Ty});
+    }
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::Int8QTy}, {FullyConnectedNode::BiasIdx}) &&
+           (NI.getInElemTy(FullyConnectedNode::BiasIdx) == ElemKind::Int32QTy);
+
+  case Kinded::Kind::BatchedAddNodeKind:
+    if (!NI.getInTy(BatchedAddNode::BatchIdx)->isQuantizedType()) {
+      return NI.allInputsAndOutputsHaveSameElemKind(
+          {ElemKind::FloatTy, ElemKind::Float16Ty});
+    }
+    return NI.allInputsAndOutputsHaveSameElemKind({ElemKind::Int8QTy},
+                                                  {BatchedAddNode::SliceIdx}) &&
+           ((NI.getInElemTy(BatchedAddNode::SliceIdx) == ElemKind::Int8QTy) ||
+            (NI.getInElemTy(BatchedAddNode::SliceIdx) == ElemKind::Int32QTy));
+
+  case Kinded::Kind::RowwiseQuantizedFullyConnectedNodeKind:
+    return (NI.getInElemTy(RowwiseQuantizedFullyConnectedNode::InputIdx) ==
+            ElemKind::Int8QTy) &&
+           (NI.getInElemTy(RowwiseQuantizedFullyConnectedNode::WeightsIdx) ==
+            ElemKind::Int8QTy) &&
+           (NI.getInElemTy(RowwiseQuantizedFullyConnectedNode::ScalesIdx) ==
+            ElemKind::FloatTy) &&
+           (NI.getInElemTy(RowwiseQuantizedFullyConnectedNode::OffsetsIdx) ==
+            ElemKind::Int32ITy) &&
+           (NI.getInElemTy(RowwiseQuantizedFullyConnectedNode::BiasIdx) ==
+            ElemKind::Int32QTy) &&
+           (NI.getOutElemTy(RowwiseQuantizedFullyConnectedNode::ResultIdx) ==
+            ElemKind::Int8QTy);
+
+  case Kinded::Kind::SparseLengthsWeightedSumNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::FloatTy, ElemKind::Float16Ty, ElemKind::Int8QTy},
+               {SparseLengthsWeightedSumNode::IndicesIdx,
+                SparseLengthsWeightedSumNode::LengthsIdx}) &&
+           (NI.getInElemTy(SparseLengthsWeightedSumNode::IndicesIdx) ==
+            ElemKind::Int64ITy) &&
+           (NI.getInElemTy(SparseLengthsWeightedSumNode::LengthsIdx) ==
+            ElemKind::Int32ITy);
+
+  case Kinded::Kind::RowwiseQuantizedSparseLengthsWeightedSumNodeKind:
+    return (NI.getInElemTy(
+                RowwiseQuantizedSparseLengthsWeightedSumNode::DataIdx) ==
+            ElemKind::Int8QTy) &&
+           (NI.getInElemTy(
+                RowwiseQuantizedSparseLengthsWeightedSumNode::ScalesIdx) ==
+            ElemKind::FloatTy) &&
+           (NI.getInElemTy(
+                RowwiseQuantizedSparseLengthsWeightedSumNode::OffsetsIdx) ==
+            ElemKind::Int32ITy) &&
+           (NI.getInElemTy(
+                RowwiseQuantizedSparseLengthsWeightedSumNode::WeightsIdx) ==
+            ElemKind::FloatTy) &&
+           (NI.getInElemTy(
+                RowwiseQuantizedSparseLengthsWeightedSumNode::IndicesIdx) ==
+            ElemKind::Int64ITy) &&
+           (NI.getInElemTy(
+                RowwiseQuantizedSparseLengthsWeightedSumNode::LengthsIdx) ==
+            ElemKind::Int32ITy) &&
+           (NI.getOutElemTy(
+                RowwiseQuantizedSparseLengthsWeightedSumNode::ResultIdx) ==
+            ElemKind::FloatTy);
+
+  case Kinded::Kind::FusedRowwiseQuantizedSparseLengthsWeightedSumNodeKind:
+    return (NI.getInElemTy(
+                FusedRowwiseQuantizedSparseLengthsWeightedSumNode::DataIdx) ==
+            ElemKind::Int8FusedQTy) &&
+           (NI.getInElemTy(FusedRowwiseQuantizedSparseLengthsWeightedSumNode::
+                               WeightsIdx) == ElemKind::FloatTy) &&
+           (NI.getInElemTy(FusedRowwiseQuantizedSparseLengthsWeightedSumNode::
+                               IndicesIdx) == ElemKind::Int64ITy) &&
+           (NI.getInElemTy(FusedRowwiseQuantizedSparseLengthsWeightedSumNode::
+                               LengthsIdx) == ElemKind::Int32ITy) &&
+           (NI.getOutElemTy(
+                FusedRowwiseQuantizedSparseLengthsWeightedSumNode::ResultIdx) ==
+            ElemKind::FloatTy);
+
+  case Kinded::Kind::LengthsToRangesNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind({ElemKind::Int32ITy});
+
+  case Kinded::Kind::GatherNodeKind:
+    // Note: Data and Result can be any data type, but must match.
+    return (NI.getInElemTy(GatherNode::DataIdx) ==
+            NI.getOutElemTy(GatherNode::ResultIdx)) &&
+           ((NI.getInElemTy(GatherNode::IndicesIdx) == ElemKind::Int32ITy) ||
+            (NI.getInElemTy(GatherNode::IndicesIdx) == ElemKind::Int64ITy));
+
+  case Kinded::Kind::BatchOneHotNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::FloatTy, ElemKind::Float16Ty, ElemKind::Int32ITy,
+                ElemKind::Int64ITy},
+               {BatchOneHotNode::LengthsIdx}) &&
+           (NI.getInElemTy(BatchOneHotNode::LengthsIdx) == ElemKind::Int32ITy);
+
+  case Kinded::Kind::QuantizationProfileNodeKind:
+  case Kinded::Kind::AvgPoolGradNodeKind:
+  case Kinded::Kind::MaxPoolGradNodeKind:
+  case Kinded::Kind::LocalResponseNormalizationGradNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind({ElemKind::FloatTy});
+
+  case Kinded::Kind::QuantizeNodeKind:
+    return ((NI.getInElemTy(QuantizeNode::InputIdx) == ElemKind::FloatTy) ||
+            (NI.getInElemTy(QuantizeNode::InputIdx) == ElemKind::Float16Ty)) &&
+           ((NI.getOutElemTy(QuantizeNode::ResultIdx) == ElemKind::Int8QTy) ||
+            (NI.getOutElemTy(QuantizeNode::ResultIdx) == ElemKind::Int16QTy) ||
+            (NI.getOutElemTy(QuantizeNode::ResultIdx) == ElemKind::Int32QTy));
+
+  case Kinded::Kind::DequantizeNodeKind:
+    return ((NI.getInElemTy(DequantizeNode::InputIdx) == ElemKind::Int8QTy) ||
+            (NI.getInElemTy(DequantizeNode::InputIdx) == ElemKind::Int16QTy) ||
+            (NI.getInElemTy(DequantizeNode::InputIdx) == ElemKind::Int32QTy)) &&
+           ((NI.getOutElemTy(DequantizeNode::ResultIdx) == ElemKind::FloatTy) ||
+            (NI.getOutElemTy(DequantizeNode::ResultIdx) ==
+             ElemKind::Float16Ty));
+
+  case Kinded::Kind::RescaleQuantizedNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+        {ElemKind::Int8QTy, ElemKind::Int16QTy, ElemKind::Int32QTy});
+
+  case Kinded::Kind::IntLookupTableNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind({ElemKind::Int8QTy});
+
+  case Kinded::Kind::ConvertToNodeKind:
+    return ((NI.getInElemTy(ConvertToNode::InputIdx) == ElemKind::FloatTy) &&
+            (NI.getOutElemTy(ConvertToNode::ResultIdx) ==
+             ElemKind::Float16Ty)) ||
+           ((NI.getInElemTy(ConvertToNode::InputIdx) == ElemKind::Float16Ty) &&
+            (NI.getOutElemTy(ConvertToNode::ResultIdx) == ElemKind::FloatTy));
+
+  case Kinded::Kind::TopKNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::FloatTy, ElemKind::Float16Ty, ElemKind::Int8QTy}, {},
+               {TopKNode::IndicesIdx}) &&
+           (NI.getOutElemTy(TopKNode::IndicesIdx) == ElemKind::Int64ITy);
+
+  case Kinded::Kind::ScatterAssignNodeKind:
+    return (NI.getInElemTy(ScatterAssignNode::IndicesIdx) ==
+            ElemKind::Int64ITy) &&
+           (NI.getOutElemTy(ScatterAssignNode::ResultIdx) ==
+            NI.getInElemTy(ScatterAssignNode::DataIdx)) &&
+           (NI.getOutElemTy(ScatterAssignNode::ResultIdx) ==
+            NI.getInElemTy(ScatterAssignNode::SlicesIdx));
+
+  case Kinded::Kind::SoftMaxNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::FloatTy, ElemKind::Float16Ty},
+               {SoftMaxNode::SelectedIdx}) &&
+           (NI.getInElemTy(SoftMaxNode::SelectedIdx) == ElemKind::Int64ITy);
+
+  case Kinded::Kind::GatherRangesNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::Int32ITy, ElemKind::Int64ITy},
+               {GatherRangesNode::DataIdx}, {GatherRangesNode::OutputIdx}) &&
+           (NI.getOutElemTy(GatherRangesNode::OutputIdx) ==
+            NI.getInElemTy(GatherRangesNode::DataIdx));
+
+  case Kinded::Kind::CrossEntropyLossNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::FloatTy, ElemKind::Float16Ty},
+               {CrossEntropyLossNode::LabelsIdx}) &&
+           (NI.getInElemTy(CrossEntropyLossNode::LabelsIdx) ==
+            ElemKind::Int64ITy);
+
+  case Kinded::Kind::LengthsSumNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::FloatTy, ElemKind::Float16Ty},
+               {LengthsSumNode::LengthsIdx}) &&
+           (NI.getInElemTy(LengthsSumNode::LengthsIdx) == ElemKind::Int32ITy);
+
+  case Kinded::Kind::SparseToDenseNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::FloatTy, ElemKind::Float16Ty},
+               {SparseToDenseNode::IndicesIdx}) &&
+           (NI.getInElemTy(SparseToDenseNode::IndicesIdx) ==
+            ElemKind::Int64ITy);
+
+  case Kinded::Kind::SparseToDenseMaskNodeKind:
+    return (NI.getInElemTy(SparseToDenseMaskNode::IndicesIdx) ==
+            ElemKind::Int64ITy) &&
+           (NI.getInElemTy(SparseToDenseMaskNode::LengthsIdx) ==
+            ElemKind::Int32ITy) &&
+           (NI.getInElemTy(SparseToDenseMaskNode::ValuesIdx) ==
+            NI.getInElemTy(SparseToDenseMaskNode::DefaultValueIdx)) &&
+           (NI.getInElemTy(SparseToDenseMaskNode::ValuesIdx) ==
+            NI.getOutElemTy(SparseToDenseMaskNode::ResultIdx));
+
+  case Kinded::Kind::TraceEventNodeKind:
+    return NI.getInElemTy(TraceEventNode::DataIdx) == ElemKind::Int64ITy;
+
+  case Kinded::Kind::TransposeNodeKind:
+  case Kinded::Kind::ReshapeNodeKind:
+  case Kinded::Kind::SaveNodeKind:
+    // These work regardless of the underlying type.
+    return true;
+
+  case Kinded::Kind::SoftMaxGradNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::FloatTy}, {SoftMaxGradNode::SelectedIdx},
+               {SoftMaxGradNode::GradOfInputNamedSelectedIdx}) &&
+           (NI.getInElemTy(SoftMaxGradNode::SelectedIdx) == ElemKind::Int64ITy);
+
+  case Kinded::Kind::ConvolutionGradNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+        {ElemKind::FloatTy}, {},
+        {ConvolutionGradNode::GradOfInputNamedInputIdx});
+
+  case Kinded::Kind::CrossEntropyLossGradNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::FloatTy}, {CrossEntropyLossGradNode::LabelsIdx},
+               {CrossEntropyLossGradNode::GradOfInputNamedLabelsIdx}) &&
+           (NI.getInElemTy(CrossEntropyLossGradNode::LabelsIdx) ==
+            ElemKind::Int64ITy) &&
+           (NI.getOutElemTy(
+                CrossEntropyLossGradNode::GradOfInputNamedLabelsIdx) ==
+            ElemKind::Int64ITy);
+
+  default:
     return false;
   }
-
-  if (elementTy == ElemKind::Int16QTy) {
-    return false;
-  }
-
-  return true;
 }
 
 bool Interpreter::shouldLower(const Node *N) const {

--- a/lib/Backends/Interpreter/Interpreter.h
+++ b/lib/Backends/Interpreter/Interpreter.h
@@ -47,7 +47,7 @@ public:
   std::unique_ptr<CompiledFunction>
   compile(Function *F, const CompilationOptions &opts) const override;
 
-  bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override;
+  bool isOpSupported(const NodeInfo &NI) const override;
 
   bool shouldLower(const Node *N) const override;
 

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -183,42 +183,7 @@ public:
   bool transformPostLowering(Function *F,
                              const CompilationOptions &opts) const override;
 
-  bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override {
-    // Check quantization support.
-    if (elementTy == ElemKind::Int8QTy) {
-      switch (opKind) {
-      case Kinded::Kind::AddNodeKind:
-      case Kinded::Kind::ConcatNodeKind:
-      case Kinded::Kind::ConvolutionNodeKind:
-      case Kinded::Kind::DequantizeNodeKind:
-      case Kinded::Kind::DivNodeKind:
-      case Kinded::Kind::FullyConnectedNodeKind:
-      case Kinded::Kind::MaxNodeKind:
-      case Kinded::Kind::MinNodeKind:
-      case Kinded::Kind::MulNodeKind:
-      case Kinded::Kind::MaxPoolNodeKind:
-      case Kinded::Kind::AvgPoolNodeKind:
-      case Kinded::Kind::QuantizeNodeKind:
-      case Kinded::Kind::ReluNodeKind:
-      case Kinded::Kind::RescaleQuantizedNodeKind:
-      case Kinded::Kind::ReshapeNodeKind:
-      case Kinded::Kind::SliceNodeKind:
-      case Kinded::Kind::SplatNodeKind:
-      case Kinded::Kind::SubNodeKind:
-      case Kinded::Kind::TopKInstKind:
-      case Kinded::Kind::TransposeNodeKind:
-        return true;
-      default:
-        return false;
-      }
-    }
-
-    if (elementTy == ElemKind::Int16QTy) {
-      return false;
-    }
-
-    return true;
-  };
+  bool isOpSupported(const NodeInfo &NI) const override;
 
   bool shouldLower(const Node *N) const override {
     // The group convolution is supported in OpenCL slow convolution kernel.

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -226,6 +226,13 @@ void ExecutionEngine::compile(Function *F, const CompilationOptions &opts,
          "A function with this name has already been compiled.");
 
   backend_->optimizeFunction(F, opts);
+
+  for (const Node &N : F->getNodes()) {
+    (void)N;
+    assert(backend_->isOpSupported(N) &&
+           "Backend must support all nodes after high-level optimizations.");
+  }
+
   auto func = backend_->compile(F, opts);
   insertCompiledFunction(name, std::move(func));
 }

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -594,6 +594,16 @@ bool InsertTensorNode::verify() const {
     return false;
   }
 
+  isValid &= checkType(dest, src.getType()->getElementType(), this);
+  if (dest.getType()->isQuantizedType()) {
+    isValid &= expectCompareTrue("Scales of Big and Small must match.",
+                                 src.getType()->getScale(),
+                                 dest.getType()->getScale(), this);
+    isValid &= expectCompareTrue("Offsets of Big and Small must match.",
+                                 src.getType()->getOffset(),
+                                 dest.getType()->getOffset(), this);
+  }
+
   for (unsigned i = 0; i < numDims; i++) {
     // TODO: We could come up with a mechanism to lazy compute that
     // string since it is going to be used only in case of an error.

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -65,10 +65,7 @@ onnxStatus BackendId::checkGraphCompatibility(const void *onnxModel,
   const auto &nodes = function->getNodes();
 
   for (const auto &node : nodes) {
-    // TODO: Make is isOpSupported more able to handle different ElemKinds.
-    bool opSupported =
-        glowBackend_->isOpSupported(node.getKind(), ElemKind::FloatTy);
-    if (!opSupported) {
+    if (!glowBackend_->isOpSupported(node)) {
       // TODO: Use a more specific ONNXIFI error code here to denote what about
       // this operator is not supported (shape, type, etc).
       return ONNXIFI_STATUS_UNSUPPORTED_OPERATOR;

--- a/lib/Onnxifi/Base.h
+++ b/lib/Onnxifi/Base.h
@@ -59,6 +59,8 @@ public:
       : id_(id), useOnnx_(useOnnx), concurrency_(concurrency),
         glowBackend_(createBackend(kind)), useHostManager_(useHostManager) {}
 
+  bool isOpSupported(const NodeInfo &NI);
+
   /// Verify that a given onnx graph is supported by the backend by importing
   /// the onnx graph to a glow function, lowering this function, and checking
   /// that all of the glow nodes that are contained in the lowered graph are

--- a/tests/unittests/BackendCorrectnessTest.cpp
+++ b/tests/unittests/BackendCorrectnessTest.cpp
@@ -264,9 +264,7 @@ public:
   compileIR(std::unique_ptr<IRFunction> IR) const override {
     return backend_->compileIR(std::move(IR));
   }
-  bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override {
-    return true;
-  }
+  bool isOpSupported(const NodeInfo &NI) const override { return true; }
 };
 
 TEST_P(CPUOnly, dataParallelStackingTest) {

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -47,9 +47,7 @@ class MockBackend : public Backend {
     return llvm::make_unique<MockFunction>();
   }
 
-  bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override {
-    return false;
-  }
+  bool isOpSupported(const NodeInfo &NI) const override { return false; }
 
   bool generateInst(Node *N, IRGenVisitor &irgen) const override {
     return false;
@@ -76,9 +74,7 @@ class MockBackendCustomIRGen : public Backend {
     return llvm::make_unique<MockFunction>();
   }
 
-  bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override {
-    return false;
-  }
+  bool isOpSupported(const NodeInfo &NI) const override { return false; }
 
   bool generateInst(Node *N, IRGenVisitor &irgen) const override {
     bool hasChanged = false;

--- a/tests/unittests/QuantizationTest.cpp
+++ b/tests/unittests/QuantizationTest.cpp
@@ -878,15 +878,14 @@ public:
   compile(Function *F, const CompilationOptions &opts) const override {
     return backend_->compile(F, opts);
   }
-
-  bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override {
-    if (opKind == Kinded::Kind::SoftMaxNodeKind ||
-        opKind == Kinded::Kind::LocalResponseNormalizationNodeKind ||
-        opKind == Kinded::Kind::SaveNodeKind ||
-        opKind == Kinded::Kind::SelectNodeKind) {
+  bool isOpSupported(const NodeInfo &NI) const override {
+    if (NI.getKind() == Kinded::Kind::SoftMaxNodeKind ||
+        NI.getKind() == Kinded::Kind::LocalResponseNormalizationNodeKind ||
+        NI.getKind() == Kinded::Kind::SaveNodeKind ||
+        NI.getKind() == Kinded::Kind::SelectNodeKind) {
       return true;
     }
-    return backend_->isOpSupported(opKind, elementTy);
+    return backend_->isOpSupported(NI);
   }
 };
 
@@ -1503,17 +1502,13 @@ class MockBackendUnloweredFC : public MockBackend {
     }
     return true;
   }
-  bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override {
-    return true;
-  }
+  bool isOpSupported(const NodeInfo &NI) const override { return true; }
 };
 
 /// Mock backend that does lower FC nodes.
 class MockBackendLoweredFC : public MockBackend {
   bool shouldLower(const Node *N) const override { return true; }
-  bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override {
-    return true;
-  }
+  bool isOpSupported(const NodeInfo &NI) const override { return true; }
 };
 
 /// Create a simple network with an FC given \p ctx, \p EE, and \p F.

--- a/tests/unittests/QuantizationTest.cpp
+++ b/tests/unittests/QuantizationTest.cpp
@@ -54,6 +54,8 @@ protected:
   }
 };
 
+class InterpAndCPU : public Operator {};
+
 bool operator==(const NodeQuantizationInfo &lhs,
                 const NodeQuantizationInfo &rhs) {
   return lhs.Scale() == rhs.Scale() && lhs.Offset() == rhs.Offset() &&
@@ -484,7 +486,7 @@ TEST_P(Operator, end2endInt8) {
   testQuantizationEnd2End(profileEE, backendSpecificEE, ElemKind::Int8QTy);
 }
 
-TEST_P(Operator, end2endInt16) {
+TEST_P(InterpAndCPU, end2endInt16) {
   testQuantizationEnd2End(profileEE, backendSpecificEE, ElemKind::Int16QTy);
 }
 
@@ -1709,33 +1711,37 @@ INSTANTIATE_TEST_CASE_P(Interpreter, Quantization,
                         ::testing::Values(BackendKind::Interpreter));
 
 #ifdef GLOW_WITH_CPU
+INSTANTIATE_TEST_CASE_P(CPU, Quantization, ::testing::Values(BackendKind::CPU));
+
 INSTANTIATE_TEST_CASE_P(
-    Interpreter, Operator,
-    ::testing::Combine(::testing::Values(BackendKind::Interpreter,
-                                         BackendKind::CPU),
-                       ::testing::Values(BackendKind::Interpreter)));
+    InterpAndCPUProfAndQuant, Operator,
+    ::testing::Combine(
+        ::testing::Values(BackendKind::Interpreter, BackendKind::CPU),
+        ::testing::Values(BackendKind::Interpreter, BackendKind::CPU)));
+
+INSTANTIATE_TEST_CASE_P(
+    InterpAndCPUProfAndQuant, InterpAndCPU,
+    ::testing::Combine(
+        ::testing::Values(BackendKind::Interpreter, BackendKind::CPU),
+        ::testing::Values(BackendKind::Interpreter, BackendKind::CPU)));
+
 #else
 INSTANTIATE_TEST_CASE_P(
-    Interpreter, Operator,
+    InterpreterProfAndQuant, Operator,
     ::testing::Combine(::testing::Values(BackendKind::Interpreter),
                        ::testing::Values(BackendKind::Interpreter)));
-#endif
 
-#ifdef GLOW_WITH_CPU
-INSTANTIATE_TEST_CASE_P(JIT, Quantization, ::testing::Values(BackendKind::CPU));
 INSTANTIATE_TEST_CASE_P(
-    JIT, Operator,
-    ::testing::Combine(::testing::Values(BackendKind::Interpreter,
-                                         BackendKind::CPU),
-                       ::testing::Values(BackendKind::CPU)));
+    Interpreter, InterpAndCPU,
+    ::testing::Combine(::testing::Values(BackendKind::Interpreter),
+                       ::testing::Values(BackendKind::Interpreter)));
 #endif // GLOW_WITH_CPU
 
 #ifdef GLOW_WITH_OPENCL
 INSTANTIATE_TEST_CASE_P(
-    OpenCL, Operator,
-    ::testing::Combine(::testing::Values(BackendKind::Interpreter,
-                                         BackendKind::Interpreter),
+    InterpProfOpenCLQuant, Operator,
+    ::testing::Combine(::testing::Values(BackendKind::Interpreter),
                        ::testing::Values(BackendKind::OpenCL)));
-#endif // GLOW_WITH_CPU
+#endif // GLOW_WITH_OPENCL
 
 } // namespace glow


### PR DESCRIPTION
*Description*: This PR redesigns `isOpSupported()` to allow a backend to specify what ops it supports based on the input and output types of Nodes. It updates all of the open source backends we have.

*Testing*: All tests are passing. I've also done my best to make sure bigger tests (e.g. those in `tests/images/run.sh`) also still work.

*Documentation*: Updated.

Fixes https://github.com/pytorch/glow/issues/2194