### PR TITLE
[Windows Fix] A more localized fix for onnx_proto compilation issues using VS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,18 +67,6 @@ if (GLOW_WITH_OPENCL)
   find_package(OpenCL REQUIRED)
 endif ()
 
-# sets pre processor flag so some of glow projects
-# can link against protobuf libray that is build as DLL.
-if(MSVC AND LINK_PROTOBUF_AS_DLL)
-  # For protobuf warning when it is build as dll.
-  # Supresses a warning that is treated as error.
-  # Basically one of the header files has interface class
-  # containing STL string. Which might cause issues
-  # if things are build with different compilers.
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4251")
-  add_definitions(-DPROTOBUF_USE_DLLS)
-endif()
-
 # Prefer LLVM 7.
 find_package(LLVM 7 CONFIG)
 

--- a/lib/Importer/CMakeLists.txt
+++ b/lib/Importer/CMakeLists.txt
@@ -48,3 +48,17 @@ target_link_libraries(Importer
                         Support)
 target_link_libraries(Importer PUBLIC onnx_proto ${PROTOBUF_LIBRARY})
 
+if (MSVC AND LINK_PROTOBUF_AS_DLL)
+  # For protobuf warning when it is build as dll.
+  # Supresses a warning that is treated as error.
+  # Basically one of the header files has interface class
+  # containing STL string. Which might cause issues
+  # if things are build with different compilers.
+  #
+  # Sets general warning level as 2 for this project.
+  # There are few warnings that are treated as errors that
+  # come from VS include headers
+  target_compile_options(onnx_proto PUBLIC /wd4251)
+  target_compile_options(onnx_proto PUBLIC /W2)
+  target_compile_definitions(onnx_proto PUBLIC -DPROTOBUF_USE_DLLS)
+endif()


### PR DESCRIPTION
*Description*:
This is a more localized version of #2228.
After rebasing against glow master, and dropping all local commits also found out /w2 flag I had set globally was suppressing some warning from VS header files that were treated as errors in onnx_proto.
*Testing*: Unit Tests
*Documentation*:
[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
