### PR TITLE
[Improvement] Sets linking to local from dll export/import. 

### DIFF
--- a/lib/Backends/CPU/Pipeline.cpp
+++ b/lib/Backends/CPU/Pipeline.cpp
@@ -79,6 +79,16 @@ void LLVMIRGen::optimizeLLVMModule(llvm::Function *F, llvm::TargetMachine &TM) {
   // Next, we remove all of the 'no-inline' attributes that clang in -O0 adds to
   // all functions.
   for (auto &FF : *M) {
+    // For libjit functions that are marked as dllimport or dllexport
+    // This sets them as regular functions.
+    // This allows LLVM to eliminate unused functions,
+    // and speeds up compilation.
+    if (FF.getDLLStorageClass() !=
+        llvm::GlobalValue::DLLStorageClassTypes::DefaultStorageClass) {
+      FF.setLinkage(llvm::GlobalValue::LinkageTypes::InternalLinkage);
+      FF.setDLLStorageClass(llvm::GlobalValue::DefaultStorageClass);
+    }
+
     FF.removeFnAttr(llvm::Attribute::AttrKind::NoInline);
   }
 


### PR DESCRIPTION
*Description*:
If custom backend includes additional libjit functions implementations that have dllexport set, it sets them to internal linkage. This allows LLVM to optimize away functions that are not used, and speeds up compilation, if there are a bunch of them, since it doesn't have to run other optimization passes on those functions.
*Testing*: Unit Tests
*Documentation*:
[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
