### PR TITLE
[Importer] Return error when importing a model if verify fails

### DIFF
--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -1196,6 +1196,8 @@ Caffe2ModelLoader::Caffe2ModelLoader(const std::string &netDescFilename,
     RETURN_IF_ERR(loadWeightsFromNet(weightsDef));
     RETURN_IF_ERR(loadNetwork(networkDef));
 
+    RETURN_ERR_IF_NOT(F.verify(), "Function verification failed.");
+
     return llvm::Error::success();
   };
 

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -975,6 +975,8 @@ ONNXModelLoader::ONNXModelLoader(const std::string &modelDescFilename,
 
     RETURN_IF_ERR(setOutputNodes(graphDef));
 
+    RETURN_ERR_IF_NOT(F.verify(), "Function verification failed.");
+
     return llvm::Error::success();
   };
 


### PR DESCRIPTION
**Description**: Now that we have error handling support in place we can return an error after importing a model if the model does not pass verification. Prior to this PR we did not verify Functions at all in Release mode.

**Testing**: All unit tests and run.sh pass. Updated a couple Pad unit tests that are not yet supported/which fail during verification.

Fixes https://github.com/pytorch/glow/issues/2247
Related to https://github.com/pytorch/glow/issues/1517