### PR TITLE
[ir] Make IRFunction Named

### DIFF
--- a/include/glow/IR/IR.h
+++ b/include/glow/IR/IR.h
@@ -237,7 +237,7 @@ class Value;
 class Node;
 
 /// A function that represents the compilation unit.
-class IRFunction final {
+class IRFunction final : public Named {
 public:
   using VariableMap = std::unordered_map<const Storage *, Value *>;
   using InstListTy = TaggedList<Instruction, InstructionTraits>;

--- a/lib/IR/IR.cpp
+++ b/lib/IR/IR.cpp
@@ -490,7 +490,8 @@ void Instruction::dumpOperands(llvm::raw_ostream &os) const {
   }
 }
 
-IRFunction::IRFunction(Function *G) : G_(G) {}
+IRFunction::IRFunction(Function *G)
+    : Named(G ? G->getName() : llvm::StringRef{}), G_(G) {}
 
 static bool hasResultValue(const Instruction *I) {
   return I->getKind() == Instruction::Kind::AllocActivationInstKind ||
@@ -504,7 +505,7 @@ void IRFunction::dump(llvm::raw_ostream &OS) const {
   // Print all of the variables:
   std::string s;
   llvm::raw_string_ostream sb{s};
-  sb << "function " << G_->getName().str() << "\n";
+  sb << "function " << getName().str() << "\n";
 
   size_t sizeInBytes = 0;
   sb << "declare {\n";


### PR DESCRIPTION
*Description*: We don't usually need a name for an IRFunction, but when we do (e.g. `dump`) we rely on having its parent `Function` available, which isn't guaranteed.  I don't think it's too costly to just copy the name over.
*Testing*: existing tests cover this
*Documentation*: n/a
