### PR TITLE
[RFC] Should we use glog?

### DIFF
--- a/lib/Quantization/CMakeLists.txt
+++ b/lib/Quantization/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_subdirectory(Base)
 
+find_package(glog REQUIRED)
+
 add_library(Quantization
               Serialization.cpp
               Quantization.cpp)
@@ -10,4 +12,5 @@ target_link_libraries(Quantization
                         Graph
                         ExecutionEngine
                         QuantizationBase
-                        LLVMSupport)
+                        LLVMSupport
+                        glog::glog)

--- a/lib/Quantization/Serialization.cpp
+++ b/lib/Quantization/Serialization.cpp
@@ -17,10 +17,18 @@
 #include "glow/Quantization/Serialization.h"
 #include "glow/Quantization/Quantization.h"
 
+#include "glog/logging.h"
+
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/YAMLParser.h"
 #include "llvm/Support/YAMLTraits.h"
 #include "llvm/Support/raw_ostream.h"
+
+namespace std {
+std::ostream &operator<<(std::ostream &os, llvm::StringRef str) {
+  return os.write(str.data(), str.size());
+}
+}
 
 namespace llvm {
 namespace yaml {
@@ -61,13 +69,13 @@ deserializeFromYaml(llvm::StringRef fileName) {
 
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> text =
       llvm::MemoryBuffer::getFileAsStream(fileName);
-  GLOW_ASSERT(!text.getError() && "Unable to open file");
+  CHECK(!text.getError()) << "Unable to open profile file: " << fileName;
 
   std::unique_ptr<llvm::MemoryBuffer> buffer = std::move(*text);
   llvm::yaml::Input yin(buffer->getBuffer());
   yin >> result;
 
-  GLOW_ASSERT(!yin.error() && "Error reading yaml file");
+  CHECK(!yin.error()) << "Error reading yaml file: " << fileName;
 
   return result;
 }


### PR DESCRIPTION
*Description*:
I imagine this change would be controversial, but thought it'd be worth discussing, esp if there's a clean solution already available in LLVM.  We have a lot of code like:
```
GLOW_ASSERT(!thing_failed && "A thing failed");
```
which doesn't tell you anything about the thing that failed (like, what was the unhandled instruction?)  You can get this information from the debugger by re-running, but that's a bit tedious, shouldn't really be necessary, and is not a great option for debugging things that happen in production.

So I often change those lines to:
```
if (thing_failed) {
  llvm::errs() << "A thing failed because: " << reasons;
  GLOW_UNREACHABLE("A thing failed");
}
```
but that is pretty clunky (multiple lines, redundant strings).

With glog, this is pretty clean:
```
CHECK(!thing_failed) << "A thing failed because: " << reasons;
```
 
The down side, of course, is that we add a dependency (albeit one that is practically standard), and the annoyance that glog uses std::ostream whereas llvm uses llvm::raw_ostream, which leads to eyebrow-raising things like the `operator<<` for llvm::StringRef in this sample PR.

Anyways, I *probably* won't spend a ton more time on this in the immediate future, but I'm curious to hear opinions.  Is this a total non-starter?  Is there an elegant way of handling these cases in LLVM?

*Testing*: n/a

*Documentation*: n/a
