### PR TITLE
[docs/quantization] Tanh+Sigmoid and quantization precision.

### DIFF
--- a/docs/Quantization.md
+++ b/docs/Quantization.md
@@ -63,10 +63,8 @@ provided) and force the output have the same quantization params as the input
 for performance purpose:
 ```
 LocalResponseNormalizationNode                       
-SigmoidNode                                         
 SliceNode                                      
 ReshapeNode                                       
-TanhNode                                       
 TopKNode                                        
 GatherNode                                         
 MaxPoolNode
@@ -128,6 +126,10 @@ not be quantized. For example, to not quantize any Add or Div nodes when running
 the quantized text translator:
 
 ```./bin/text-translator -m en2gr -load-profile=en2gr.yaml -keep-original-precision-for-nodes=Add,Div```
+
+By default, target quantization precision is int8. However, precision can be
+controlled via command line parameter: `quantization-precision`. There are
+two supported values: `Int8` and `Int16`.
 
 ## Caffe2 Quantized Model Support 
 

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -188,10 +188,8 @@ protected:
   // clang-format off
 #define casesForNodesWithIRConstraint                                          \
   IR_CONSTRAINT_CASE(LocalResponseNormalization, Input, Result):               \
-  IR_CONSTRAINT_CASE(Sigmoid, Input, Result):                                  \
   IR_CONSTRAINT_CASE(Slice, Input, Result):                                    \
   IR_CONSTRAINT_CASE(Reshape, Input, Result):                                  \
-  IR_CONSTRAINT_CASE(Tanh, Input, Result):                                     \
   IR_CONSTRAINT_CASE(TopK, Input, Values):                                     \
   IR_CONSTRAINT_CASE(Gather, Data, Result):                                    \
   IR_CONSTRAINT_CASE(MaxPool, Input, Result)


### PR DESCRIPTION
*Description*:
* Tanh and Sigmoid does not need to have the same quantization params (verifier looks good). Code and doc update.
* Docs on quantization-precision param.

*Testing*:
n/a + existing tests for tanh+sigmoid.

*Documentation*:
Doc update here.
