### PR TITLE
[Runtime] Use std::shared_ptr to replace raw pointer.

### DIFF
--- a/include/glow/Runtime/RuntimeTypes.h
+++ b/include/glow/Runtime/RuntimeTypes.h
@@ -45,10 +45,10 @@ struct DeviceInfo {
 struct DAGNode {
   /// The children of this node, these are nodes that depend on the current
   /// node.
-  std::vector<DAGNode *> children;
+  std::vector<std::shared_ptr<DAGNode>> children;
   /// Pointers to the parents of this node. This is used by the executor for
   /// determining if a given node has all dependencies met.
-  std::vector<DAGNode *> parents;
+  std::vector<std::weak_ptr<DAGNode>> parents;
   /// ID of the deviceManager that this network is assigned to.
   DeviceIDTy deviceID;
   /// The logicalDevice is an output of the Partitioner to indicate that two


### PR DESCRIPTION
*Description*:
To avoid memory leak, replace the raw pointer with std::shared_ptr.

*Testing*:
ninja check.

*Documentation*:
[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
