### PR TITLE
Move optimizeFunction into the base Backend.

### DIFF
--- a/include/glow/Backends/Backend.h
+++ b/include/glow/Backends/Backend.h
@@ -82,6 +82,9 @@ public:
   /// \returns true if the Backend wants the buffer sharing optimization
   /// performed.
   virtual bool shouldShareBuffers() const { return true; }
+
+  /// Optimize the Function \p F given compilation mode \p mode.
+  void optimizeFunction(CompilationMode mode, Function *F);
 };
 
 /// Create a backend of kind \p kind.

--- a/include/glow/ExecutionEngine/ExecutionEngine.h
+++ b/include/glow/ExecutionEngine/ExecutionEngine.h
@@ -43,9 +43,6 @@ class ExecutionEngine final {
   /// A glow function compiled for this ExecutionEngine's backend.
   std::unique_ptr<CompiledFunction> function_;
 
-  /// Optimize the Function \p F given compilation mode \p mode.
-  void optimizeFunction(CompilationMode mode, Function *F);
-
 public:
   ExecutionEngine(BackendKind backendKind = BackendKind::Interpreter);
 

--- a/lib/Backends/Backend.cpp
+++ b/lib/Backends/Backend.cpp
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/Backends/Backend.h"
+#include "glow/Graph/Graph.h"
+#include "glow/Optimizer/Optimizer.h"
+
+using namespace glow;
+
+void Backend::optimizeFunction(CompilationMode mode, Function *F) {
+  // Verify the function pre-optimization/lowering.
+  assert(F->verify() && "Function must be valid");
+
+  // Optimize the graph.
+  ::glow::optimize(F, mode);
+
+  // Allow the backend to transform the graph prior to lowering.
+  if (transformPreLowering(F, mode)) {
+    // Optimize the graph again after the backend transformation.
+    // In particular, DCE is very likely to be useful.
+    ::glow::optimize(F, mode);
+  }
+
+  // Lower the graph into a sequence of low-level linear algebra operations.
+  ::glow::lower(F, *this);
+
+  // Optimize the graph again.
+  ::glow::optimize(F, mode);
+
+  // Allow the backend to transform the graph after lowering.
+  if (transformPostLowering(F, mode)) {
+    // Optimize the graph again after the backend transformation.
+    // In particular, DCE is very likely to be useful.
+    ::glow::optimize(F, mode);
+  }
+}

--- a/lib/Backends/CMakeLists.txt
+++ b/lib/Backends/CMakeLists.txt
@@ -1,4 +1,6 @@
-add_library(Backends Backends.cpp)
+add_library(Backends
+              Backend.cpp
+              Backends.cpp)
 
 add_library(BackendUtils BackendUtils.cpp)
 


### PR DESCRIPTION
*Description*: Move optimizeFunction from ExecutionEngine into the base Backend so it can be used outside of the EE. This lets us remove some code duplication.
*Testing*: sanity unittests, shouldn't be any behavoural change.
*Documentation*: