### PR TITLE
[CPUDeviceManager] Relax restriction of addNetwork to allow reusing the Module*.

### DIFF
--- a/lib/Backends/CPU/CPUDeviceManager.h
+++ b/lib/Backends/CPU/CPUDeviceManager.h
@@ -22,7 +22,7 @@ namespace glow {
 
 class CPUDeviceManager : public QueueBackedDeviceManager {
   /// Loaded module list.
-  std::map<const Module *, FunctionMapTy> modules_;
+  std::map<const Module *, std::set<std::string>> modules_;
 
   /// Compiled function list by name.
   FunctionMapTy functions_;


### PR DESCRIPTION
*Description*: We assumed that all functions in the module would be added to a given device at the same time, but this isn't a useful or necessary restriction. Also simplified the module map, we didn't use the CompiledFunction* here.
*Testing*: CPUDeviceManager tests + a new test.
*Documentation*: n/a