### PR TITLE
[trivial/test] Run less threads and iterations.

### DIFF
--- a/tests/unittests/GlowOnnxifiManagerTest.cpp
+++ b/tests/unittests/GlowOnnxifiManagerTest.cpp
@@ -122,8 +122,8 @@ void createAndDestroyManagerObjects() {
 }
 
 TEST(GlowOnnxifiManagerTest, Concurrency) {
-  constexpr auto numThreads = 24;
-  constexpr auto numItersPerThread = 1000;
+  constexpr auto numThreads = 12;
+  constexpr auto numItersPerThread = 100;
 
   std::vector<std::thread> threads;
   for (auto i = 0; i < numThreads; ++i) {


### PR DESCRIPTION
*Description*:
Test takes ~30 mins on internal run. Limit # iterations/threads. Should not affect test quality.
*Testing*:
CI
*Documentation*:
n/a

