### PR TITLE
Enable calling into runtime from onnxifi

### DIFF
--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -23,8 +23,8 @@
 namespace glow {
 namespace onnxifi {
 namespace {
-const std::string inferenceFunctionName = "inference";
-const std::string compatibilityFunctionName = "check";
+const char *inferenceFunctionName = "inference";
+const char *compatibilityFunctionName = "check";
 } // namespace
 
 onnxStatus BackendId::checkGraphCompatibility(const void *onnxModel,
@@ -156,7 +156,7 @@ void Graph::run(
     phs.push_back(var);
   }
 
-  auto ctx = std::make_unique<Context>();
+  auto ctx = llvm::make_unique<Context>();
 
   // Run inference.
   auto &EE = backendPtr_->getEE();

--- a/lib/Onnxifi/Base.h
+++ b/lib/Onnxifi/Base.h
@@ -34,7 +34,9 @@ namespace onnxifi {
 
 // TODO get rid of this once HostManager is landed.
 struct HostManager {
-  bool addNetwork(Module *M) { return true; }
+  bool addNetwork(Module *M) {
+    llvm_unreachable("HostManager is not yet implemented.");
+  }
 };
 
 // TODO use the actual type here once available.
@@ -45,8 +47,11 @@ using ResultCBTy =
 class BackendId {
 public:
   /// Create Glow ONNXIFI backend identifier with the
-  /// given Glow backend \p kind, \p id, \p concurrency and whether to use onnx
-  /// or caffe2 for models (\p use_onnx).
+  /// given Glow backend \p kind, \p id, \p concurrency, whether to use onnx
+  /// or caffe2 for models (\p useInnx), and whether to use HostManager instead
+  /// of ExecutionEngine for running graphs (useHostManager).
+  /// NOTE: useHostManager is not yet supported as HostManager is yet to be
+  /// fully implemented.
   explicit BackendId(glow::BackendKind kind, int id, int concurrency,
                      bool useOnnx, bool useHostManager)
       : id_(id), useOnnx_(useOnnx), concurrency_(concurrency),

--- a/lib/Onnxifi/onnxifiGlow.cpp
+++ b/lib/Onnxifi/onnxifiGlow.cpp
@@ -66,18 +66,18 @@ GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxGetBackendIDs)(
   // TODO: change concurrency level to std::thread::hardware_concurrency()
   // when Glow CPU backend can handle concurrent execution.
   // For now, limit concurrent execution to a single worker thread..
-  auto *cpuBackendOnnx =
-      new glow::onnxifi::BackendId(glow::BackendKind::CPU, /*id*/ 1,
-                                   /*concurrency*/ 1, /*use_onnx*/ true);
+  auto *cpuBackendOnnx = new glow::onnxifi::BackendId(
+      glow::BackendKind::CPU, /*id*/ 1,
+      /*concurrency*/ 1, /*useOnnx*/ true, /*useHostManager*/ false);
   auto *interpreterBackendOnnx = new glow::onnxifi::BackendId(
       glow::BackendKind::Interpreter,
-      /*id*/ 2, /*concurrency*/ 1, /*use_onnx*/ true);
-  auto *cpuBackendC2 =
-      new glow::onnxifi::BackendId(glow::BackendKind::CPU, /*id*/ 3,
-                                   /*concurrency*/ 1, /*use_onnx*/ false);
+      /*id*/ 2, /*concurrency*/ 1, /*useOnnx*/ true, /*useHostManager*/ false);
+  auto *cpuBackendC2 = new glow::onnxifi::BackendId(
+      glow::BackendKind::CPU, /*id*/ 3,
+      /*concurrency*/ 1, /*useOnnx*/ false, /*useHostManager*/ false);
   auto *interpreterBackendC2 = new glow::onnxifi::BackendId(
       glow::BackendKind::Interpreter,
-      /*id*/ 4, /*concurrency*/ 1, /*use_onnx*/ false);
+      /*id*/ 4, /*concurrency*/ 1, /*useOnnx*/ false, /*useHostManager*/ false);
   manager.addBackendId(cpuBackendOnnx);
   manager.addBackendId(interpreterBackendOnnx);
   manager.addBackendId(cpuBackendC2);
@@ -88,7 +88,7 @@ GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxGetBackendIDs)(
   backendIDs[2] = cpuBackendC2;
   backendIDs[3] = interpreterBackendC2;
 #else
-  *numBackends = 2;
+  *numBackends = 3;
 
   // In case backendIDs is nullptr or does not have enough capacity just return
   // the total number of supported backends.
@@ -98,16 +98,22 @@ GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxGetBackendIDs)(
 
   auto *interpreterBackendOnnx = new glow::onnxifi::BackendId(
       glow::BackendKind::Interpreter,
-      /*id*/ 1, /*concurrency*/ 1, /*use_onnx*/ true);
+      /*id*/ 1, /*concurrency*/ 1, /*useOnnx*/ true, /*useHostManager*/ false);
   auto *interpreterBackendC2 = new glow::onnxifi::BackendId(
       glow::BackendKind::Interpreter,
-      /*id*/ 2, /*concurrency*/ 1, /*use_onnx*/ false);
+      /*id*/ 2, /*concurrency*/ 1, /*useOnnx*/ false, /*useHostManager*/ false);
+  auto *interpreterBackendC2HostManager = new glow::onnxifi::BackendId(
+      glow::BackendKind::Interpreter,
+      /*id*/ 2, /*concurrency*/ 1, /*useOnnx*/ false, /*useOnnx*/ false,
+      /*useHostManager*/ true);
 
   manager.addBackendId(interpreterBackendOnnx);
   manager.addBackendId(interpreterBackendC2);
+  manager.addBackendId(interpreterBackendC2HostManager);
 
   backendIDs[0] = interpreterBackendOnnx;
   backendIDs[1] = interpreterBackendC2;
+  backendIDs[2] = interpreterBackendC2HostManager;
 #endif
 
   return ONNXIFI_STATUS_SUCCESS;

--- a/lib/Onnxifi/onnxifiGlow.cpp
+++ b/lib/Onnxifi/onnxifiGlow.cpp
@@ -104,7 +104,7 @@ GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxGetBackendIDs)(
       /*id*/ 2, /*concurrency*/ 1, /*useOnnx*/ false, /*useHostManager*/ false);
   auto *interpreterBackendC2HostManager = new glow::onnxifi::BackendId(
       glow::BackendKind::Interpreter,
-      /*id*/ 2, /*concurrency*/ 1, /*useOnnx*/ false, /*useOnnx*/ false,
+      /*id*/ 2, /*concurrency*/ 1, /*useOnnx*/ false,
       /*useHostManager*/ true);
 
   manager.addBackendId(interpreterBackendOnnx);

--- a/tests/unittests/GlowOnnxifiManagerTest.cpp
+++ b/tests/unittests/GlowOnnxifiManagerTest.cpp
@@ -24,9 +24,10 @@ using namespace glow::onnxifi;
 
 TEST(GlowOnnxifiManagerTest, BackendIdTest) {
   auto &manager = GlowOnnxifiManager::get();
-  auto *backendId = new glow::onnxifi::BackendId(glow::BackendKind::Interpreter,
-                                                 /*id*/ 1, /*use_onnx*/ true,
-                                                 /*concurrency*/ 1);
+  auto *backendId = new glow::onnxifi::BackendId(
+      glow::BackendKind::Interpreter,
+      /*id*/ 1,
+      /*concurrency*/ 1, /*use_onnx*/ true, /*useHostManager*/ false);
   // BackendId isn't valid before it has been added to the manager.
   EXPECT_FALSE(manager.isValid(backendId));
   manager.addBackendId(backendId);
@@ -43,9 +44,10 @@ TEST(GlowOnnxifiManagerTest, BackendIdTest) {
 
 TEST(GlowOnnxifiManagerTest, BackendTest) {
   auto &manager = GlowOnnxifiManager::get();
-  auto *backendId = new glow::onnxifi::BackendId(glow::BackendKind::Interpreter,
-                                                 /*id*/ 1, /*use_onnx*/ true,
-                                                 /*concurrency*/ 1);
+  auto *backendId = new glow::onnxifi::BackendId(
+      glow::BackendKind::Interpreter,
+      /*id*/ 1,
+      /*concurrency*/ 1, /*use_onnx*/ true, /*useHostManager*/ false);
   manager.addBackendId(backendId);
 
   auto *backend = manager.createBackend(backendId);
@@ -78,9 +80,10 @@ TEST(GlowOnnxifiManagerTest, EventTest) {
 
 TEST(GlowOnnxifiManagerTest, GraphTest) {
   auto &manager = GlowOnnxifiManager::get();
-  auto *backendId = new glow::onnxifi::BackendId(glow::BackendKind::Interpreter,
-                                                 /*id*/ 1, /*use_onnx*/ true,
-                                                 /*concurrency*/ 1);
+  auto *backendId = new glow::onnxifi::BackendId(
+      glow::BackendKind::Interpreter,
+      /*id*/ 1,
+      /*concurrency*/ 1, /*use_onnx*/ true, /*useHostManager*/ false);
   manager.addBackendId(backendId);
   auto *backend = manager.createBackend(backendId);
 
@@ -102,9 +105,10 @@ TEST(GlowOnnxifiManagerTest, GraphTest) {
 
 void createAndDestroyManagerObjects() {
   auto &manager = GlowOnnxifiManager::get();
-  auto *backendId = new glow::onnxifi::BackendId(glow::BackendKind::Interpreter,
-                                                 /*id*/ 1, /*use_onnx*/ true,
-                                                 /*concurrency*/ 1);
+  auto *backendId = new glow::onnxifi::BackendId(
+      glow::BackendKind::Interpreter,
+      /*id*/ 1,
+      /*concurrency*/ 1, /*use_onnx*/ true, /*useHostManager*/ false);
   manager.addBackendId(backendId);
   auto *backend = manager.createBackend(backendId);
   auto *event = manager.createEvent();


### PR DESCRIPTION
*Description*:
Enable calling into the Glow runtime from ONNXIFI through the HostManager.
This diff enables running onnxifi inference through HostManager once HostManager is implemented.

This diff is intended to get end-to-end support for the runtime working but there are many things that we cannot yet do such as multiple runs with the same Graph, running multiple onnxifi Graphs on the same onnxifi Backend, etc. To enable these things, some more larger refactoring steps will be needed in followups including 1. Moving all resources necessary for running graphs into BackendId, 2. Abstracting BackendId to enable separate implementations for HostManager and ExecutionEngine backed BackendIds (module is still always owned by ExecutionEngine no matter what), 3 move all graph state into the graph itself to enable running multiple times with different contexts, 4 move components necessary for compatibility check into runtime and separate the ExecutionEngine from the HostManager implementations.

Depends on #2284.

*Testing*:
`ninja test`, CI

*Documentation*:
doxygen