### PR TITLE
Fix g++-4.8.5 build

### DIFF
--- a/include/glow/Base/TaggedList.h
+++ b/include/glow/Base/TaggedList.h
@@ -287,22 +287,22 @@ template <typename T>
 class TaggedListNode : public tagged_list_details::NodeBase {
 public:
   // Get an iterator pointing at this node.
-  auto getIterator() {
+  tagged_list_details::Iterator<T, false, false> getIterator() {
     return tagged_list_details::Iterator<T, false, false>(this);
   }
 
   // Get a const iterator pointing at this node.
-  auto getIterator() const {
+  tagged_list_details::Iterator<T, false, true> getIterator() const {
     return tagged_list_details::Iterator<T, false, true>(this);
   }
 
   // Get a reverse iterator pointing at this node.
-  auto getReverseIterator() {
+  tagged_list_details::Iterator<T, true, false> getReverseIterator() {
     return tagged_list_details::Iterator<T, true, false>(this);
   }
 
   // Get a const reverse iterator pointing at this node.
-  auto getReverseIterator() const {
+  tagged_list_details::Iterator<T, true, true> getReverseIterator() const {
     return tagged_list_details::Iterator<T, true, true>(this);
   }
 };

--- a/include/glow/Support/Error.h
+++ b/include/glow/Support/Error.h
@@ -171,8 +171,8 @@ private:
 // TODO: extend this to work with llvm::Expected as well.
 #define RETURN_IF_ERR(err)                                                     \
   do {                                                                         \
-    if (auto errV = std::forward<llvm::Error>(err)) {                          \
-      static_assert(IsLLVMError<decltype(errV)>(),                             \
+    if (auto errV = std::forward<llvm::Error>(err)) {                   \
+      static_assert(IsLLVMError<decltype(errV)>::value,                 \
                     "Expected value to be a llvm::Error");                     \
       return std::forward<llvm::Error>(errV);                                  \
     }                                                                          \

--- a/include/glow/Support/Error.h
+++ b/include/glow/Support/Error.h
@@ -171,8 +171,8 @@ private:
 // TODO: extend this to work with llvm::Expected as well.
 #define RETURN_IF_ERR(err)                                                     \
   do {                                                                         \
-    if (auto errV = std::forward<llvm::Error>(err)) {                   \
-      static_assert(IsLLVMError<decltype(errV)>::value,                 \
+    if (auto errV = std::forward<llvm::Error>(err)) {                          \
+      static_assert(IsLLVMError<decltype(errV)>::value,                        \
                     "Expected value to be a llvm::Error");                     \
       return std::forward<llvm::Error>(errV);                                  \
     }                                                                          \

--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -2135,10 +2135,10 @@ static void optimizeQuantization(Function *F) {
 }
 
 template <class T, class U>
-using enable_if_same_t = std::enable_if_t<std::is_same<T, U>::value, U>;
+using enable_if_same_t = std::enable_if<std::is_same<T, U>::value, U>;
 #define FUNCTION_ENABLE_IF_TEMPLATE(NODE_NAME_)                                \
   template <class T, typename... Args>                                         \
-  enable_if_same_t<T, NODE_NAME_##Node> static
+  typename enable_if_same_t<T, NODE_NAME_##Node>::type static
 
 FUNCTION_ENABLE_IF_TEMPLATE(AvgPool) * createNode(Function &F, Args... args) {
   return F.createAvgPool(args...);

--- a/lib/Partitioner/Partitioner.cpp
+++ b/lib/Partitioner/Partitioner.cpp
@@ -203,7 +203,7 @@ void Partitioner::adjustLogicalDeviceID(DAGNode *DAG, int num) {}
 /// Current only partition the representive function.
 void Partitioner::doPartitioning(Function *F, NodeToFunctionMap &mapping) {
   // The dummy node.
-  std::unique_ptr<DAGNode> DAG = std::make_unique<DAGNode>();
+  std::unique_ptr<DAGNode> DAG = llvm::make_unique<DAGNode>();
   DAG->logicalDevice = 0;
   DAG->name = F->getName();
   DAG->deviceID = 0;
@@ -226,7 +226,7 @@ void Partitioner::doPartitioning(Function *F, NodeToFunctionMap &mapping) {
   llvm::DenseMap<Function *, DAGNode *> funcDAG;
   for (auto *subF : mapping.getPartitions()) {
     if (funcDAG.find(subF) == funcDAG.end()) {
-      std::unique_ptr<DAGNode> subDAG = std::make_unique<DAGNode>();
+      std::unique_ptr<DAGNode> subDAG = llvm::make_unique<DAGNode>();
       subDAG->name = subF->getName();
       subDAG->logicalDevice = logicalID++;
       funcDAG[subF] = subDAG.get();
@@ -247,7 +247,7 @@ void Partitioner::doPartitioning(Function *F, NodeToFunctionMap &mapping) {
         // Check if a DAGNode for subF's parent is created or not. If not,
         // create one.
         if (funcDAG.find(inputF) == funcDAG.end()) {
-          std::unique_ptr<DAGNode> subDAG = std::make_unique<DAGNode>();
+          std::unique_ptr<DAGNode> subDAG = llvm::make_unique<DAGNode>();
           subDAG->name = inputF->getName();
           subDAG->logicalDevice = logicalID++;
           funcDAG[inputF] = subDAG.get();
@@ -316,10 +316,10 @@ DAGNodeList &Partitioner::Partition() {
     // No partition is needed. Create DAGNode and return. This root is alway a
     // dummy function.
     for (auto F : module_->getFunctions()) {
-      std::unique_ptr<DAGNode> DAG = std::make_unique<DAGNode>();
+      std::unique_ptr<DAGNode> DAG = llvm::make_unique<DAGNode>();
       DAG->logicalDevice = 0;
       DAG->name = F->getName();
-      std::unique_ptr<DAGNode> DAG1 = std::make_unique<DAGNode>();
+      std::unique_ptr<DAGNode> DAG1 = llvm::make_unique<DAGNode>();
       DAG1->logicalDevice = 0;
       DAG1->name = F->getName();
       DAG1->parents.push_back(DAG.get());

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -299,19 +299,19 @@ target_link_libraries(CPUDeviceTest
                         TestMain)
 add_glow_test(CPUDeviceTest ${GLOW_BINARY_DIR}/tests/CPUDeviceTest --gtest_output=xml:CPUDeviceTest.xml)
 
-add_executable(ProvisionerTest	  
-               ProvisionerTest.cpp) 
-target_link_libraries(ProvisionerTest	
-                      PRIVATE		
-                        Backends		
-                        Graph		
-                        IR		
-                        Provisioner	
+add_executable(ProvisionerTest
+               ProvisionerTest.cpp)
+target_link_libraries(ProvisionerTest
+                      PRIVATE
+                        Backends
+                        Graph
+                        IR
+                        Provisioner
                         DeviceManager
                         CPUDeviceManager
-                        gtest		
-                        TestMain)	
-target_include_directories(ProvisionerTest PUBLIC ${CMAKE_SOURCE_DIR}/lib/Backends/CPU)                        
+                        gtest
+                        TestMain)
+target_include_directories(ProvisionerTest PUBLIC ${CMAKE_SOURCE_DIR}/lib/Backends/CPU)
 add_glow_test(ProvisionerTest ${GLOW_BINARY_DIR}/tests/ProvisionerTest --gtest_output=xml:ProvisionerTest.xml)
 
 endif()
@@ -327,16 +327,16 @@ target_link_libraries(MemoryAllocatorTest
 add_glow_test(MemoryAllocatorTest ${GLOW_BINARY_DIR}/tests/MemoryAllocatorTest --gtest_output=xml:MemoryAllocatorTest.xml)
 
 add_executable(PartitionerTest
-               PartitionerTest.cpp) 
-target_link_libraries(PartitionerTest	
-                      PRIVATE		
-                        Backends	
-                        ExecutionEngine	
-                        Graph		
-                        IR		
-                        Partitioner	
-                        gtest		
-                        TestMain)	
+               PartitionerTest.cpp)
+target_link_libraries(PartitionerTest
+                      PRIVATE
+                        Backends
+                        ExecutionEngine
+                        Graph
+                        IR
+                        Partitioner
+                        gtest
+                        TestMain)
 add_glow_test(PartitionerTest ${GLOW_BINARY_DIR}/tests/PartitionerTest --gtest_output=xml:PartitionerTest.xml)
 
 add_executable(Caffe2ImporterTest

--- a/tests/unittests/CPUDeviceManagerTest.cpp
+++ b/tests/unittests/CPUDeviceManagerTest.cpp
@@ -24,11 +24,10 @@
 
 using namespace glow;
 using namespace glow::runtime;
-using namespace std::chrono_literals;
 
 std::unique_ptr<Module> makeBasicModule(std::string functionName = "main") {
-  std::unique_ptr<Module> module = std::make_unique<Module>();
-  std::unique_ptr<Context> ctx = std::make_unique<Context>();
+  std::unique_ptr<Module> module = llvm::make_unique<Module>();
+  std::unique_ptr<Context> ctx = llvm::make_unique<Context>();
 
   Function *F = module->createFunction(functionName);
   auto *input = module->createPlaceholder(ElemKind::FloatTy, {1, 32, 32, 3},
@@ -88,10 +87,10 @@ TEST(CPUDeviceManagerTest, Basic) {
                                             ResultCode::Ready);
                            });
 
-  future.wait_for(2s);
+  future.wait_for(std::chrono::seconds(2));
   EXPECT_EQ(future.get(), module.get());
 
-  std::unique_ptr<Context> ctx = std::make_unique<Context>();
+  std::unique_ptr<Context> ctx = llvm::make_unique<Context>();
   ctx->allocate(module->getPlaceholders());
 
   Tensor inputs(ElemKind::FloatTy, {1, 32, 32, 3});
@@ -109,7 +108,7 @@ TEST(CPUDeviceManagerTest, Basic) {
                                              result, ResultCode::Executed);
                             });
 
-  runFuture.wait_for(2s);
+  runFuture.wait_for(std::chrono::seconds(2));
 
   EXPECT_NE(runFuture.get(), nullptr);
 }
@@ -130,11 +129,11 @@ TEST(CPUDeviceManagerTest, MultiRun) {
                              callbackHelper(promise, module, result,
                                             ResultCode::Ready);
                            });
-  future.wait_for(2s);
+  future.wait_for(std::chrono::seconds(2));
   EXPECT_EQ(future.get(), module.get());
 
-  std::unique_ptr<Context> ctx1 = std::make_unique<Context>();
-  std::unique_ptr<Context> ctx2 = std::make_unique<Context>();
+  std::unique_ptr<Context> ctx1 = llvm::make_unique<Context>();
+  std::unique_ptr<Context> ctx2 = llvm::make_unique<Context>();
   ctx1->allocate(module->getPlaceholders());
   ctx2->allocate(module->getPlaceholders());
 
@@ -176,7 +175,7 @@ TEST(CPUDeviceManagerTest, MultiRun) {
 TEST(CPUDeviceManagerTest, MultiFunction) {
   auto module = makeBasicModule("func1");
 
-  std::unique_ptr<Context> ctx1 = std::make_unique<Context>();
+  std::unique_ptr<Context> ctx1 = llvm::make_unique<Context>();
   ctx1->allocate(module->getPlaceholders());
 
   Function *F = module->createFunction("func2");
@@ -201,14 +200,14 @@ TEST(CPUDeviceManagerTest, MultiFunction) {
                              callbackHelper(promise, module, result,
                                             ResultCode::Ready);
                            });
-  future.wait_for(2s);
+  future.wait_for(std::chrono::seconds(2));
   EXPECT_EQ(future.get(), module.get());
 
   Tensor inputs(ElemKind::FloatTy, {1, 32, 32, 3});
   updateInputPlaceholders(*ctx1, {module->getPlaceholderByName("input")},
                           {&inputs});
 
-  std::unique_ptr<Context> ctx2 = std::make_unique<Context>(ctx1->clone());
+  std::unique_ptr<Context> ctx2 = llvm::make_unique<Context>(ctx1->clone());
 
   std::promise<std::unique_ptr<Context>> runP1, runP2;
   std::future<std::unique_ptr<Context>> runF1, runF2;
@@ -253,7 +252,7 @@ TEST(CPUDeviceManagerTest, MultiModule) {
                              callbackHelper(promise, module, result,
                                             ResultCode::Ready);
                            });
-  future.wait_for(2s);
+  future.wait_for(std::chrono::seconds(2));
   EXPECT_EQ(future.get(), module1.get());
 
   std::tie(promise, future) = getFutureHelper<const Module *>();
@@ -262,16 +261,16 @@ TEST(CPUDeviceManagerTest, MultiModule) {
                              callbackHelper(promise, module, result,
                                             ResultCode::Ready);
                            });
-  future.wait_for(2s);
+  future.wait_for(std::chrono::seconds(2));
   EXPECT_EQ(future.get(), module2.get());
 
-  std::unique_ptr<Context> ctx1 = std::make_unique<Context>();
+  std::unique_ptr<Context> ctx1 = llvm::make_unique<Context>();
   ctx1->allocate(module1->getPlaceholders());
   Tensor inputs(ElemKind::FloatTy, {1, 32, 32, 3});
   updateInputPlaceholders(*ctx1, {module1->getPlaceholderByName("input")},
                           {&inputs});
 
-  std::unique_ptr<Context> ctx2 = std::make_unique<Context>(ctx1->clone());
+  std::unique_ptr<Context> ctx2 = llvm::make_unique<Context>(ctx1->clone());
   ctx2->allocate(module2->getPlaceholders());
   updateInputPlaceholders(*ctx2, {module2->getPlaceholderByName("input")},
                           {&inputs});
@@ -303,7 +302,7 @@ TEST(CPUDeviceManagerTest, MultiModule) {
 TEST(CPUDeviceManagerTest, ReuseModule) {
   auto module = makeBasicModule("func1");
 
-  std::unique_ptr<Context> ctx1 = std::make_unique<Context>();
+  std::unique_ptr<Context> ctx1 = llvm::make_unique<Context>();
   ctx1->allocate(module->getPlaceholders());
 
   Function *F = module->createFunction("func2");
@@ -335,7 +334,7 @@ TEST(CPUDeviceManagerTest, ReuseModule) {
                              callbackHelper(promise, module, result,
                                             ResultCode::Ready);
                            });
-  future.wait_for(2s);
+  future.wait_for(std::chrono::seconds(2));
   EXPECT_EQ(future.get(), module.get());
 
   std::tie(promise, future) = getFutureHelper<const Module *>();
@@ -344,14 +343,14 @@ TEST(CPUDeviceManagerTest, ReuseModule) {
                              callbackHelper(promise, module, result,
                                             ResultCode::Ready);
                            });
-  future.wait_for(2s);
+  future.wait_for(std::chrono::seconds(2));
   EXPECT_EQ(future.get(), module.get());
 
   Tensor inputs(ElemKind::FloatTy, {1, 32, 32, 3});
   updateInputPlaceholders(*ctx1, {module->getPlaceholderByName("input")},
                           {&inputs});
 
-  std::unique_ptr<Context> ctx2 = std::make_unique<Context>(ctx1->clone());
+  std::unique_ptr<Context> ctx2 = llvm::make_unique<Context>(ctx1->clone());
 
   std::promise<std::unique_ptr<Context>> runP1, runP2;
   std::future<std::unique_ptr<Context>> runF1, runF2;
@@ -399,7 +398,7 @@ TEST(CPUDeviceManagerTest, AvailableMemory) {
         callbackHelper(promise, module, result, ResultCode::Ready);
       });
 
-  future.wait_for(2s);
+  future.wait_for(std::chrono::seconds(2));
   EXPECT_EQ(future.get(), module.get());
 
   EXPECT_EQ(cpuCoreDevice.getMaximumMemory(), expectedBytes);
@@ -416,7 +415,7 @@ TEST(CPUDeviceManagerTest, AvailableMemory) {
         callbackHelper(promise, module, result, ResultCode::Ready);
       });
 
-  future.wait_for(2s);
+  future.wait_for(std::chrono::seconds(2));
   auto *resultModule = future.get();
   EXPECT_NE(resultModule, module2.get());
   EXPECT_NE(resultModule, module.get());
@@ -436,7 +435,7 @@ TEST(CPUDeviceManagerTest, AvailableMemory) {
         callbackHelper(promise, module, result, ResultCode::Ready);
       });
 
-  future.wait_for(2s);
+  future.wait_for(std::chrono::seconds(2));
   EXPECT_EQ(future.get(), module2.get());
 
   EXPECT_EQ(cpuCoreDevice.getMaximumMemory(), expectedBytes);

--- a/tests/unittests/ProvisionerTest.cpp
+++ b/tests/unittests/ProvisionerTest.cpp
@@ -25,7 +25,7 @@ using DAGNodePairTy = std::pair<std::vector<std::unique_ptr<DAGNode>>,
 
 class ProvisionerTest : public ::testing::Test {};
 std::unique_ptr<Module> setupModule(uint functionCount) {
-  std::unique_ptr<Module> module = std::make_unique<Module>();
+  std::unique_ptr<Module> module = llvm::make_unique<Module>();
   for (unsigned int i = 0; i < functionCount; i++) {
     Function *F = module->createFunction("function" + std::to_string(i));
     auto *X = module->createPlaceholder(ElemKind::FloatTy, {3},
@@ -41,14 +41,14 @@ DAGNodePairTy setupDAG(uint rootCount, uint childCount) {
   std::vector<std::unique_ptr<DAGNode>> children;
   uint currentFunction = 0;
   for (unsigned int root = 0; root < rootCount; root++) {
-    auto rootNode = std::make_unique<DAGNode>();
-    auto firstNode = std::make_unique<DAGNode>();
+    auto rootNode = llvm::make_unique<DAGNode>();
+    auto firstNode = llvm::make_unique<DAGNode>();
     rootNode->name = "root" + std::to_string(root);
     rootNode->children.push_back(firstNode.get());
     firstNode->name = "function" + std::to_string(currentFunction);
     currentFunction++;
     for (unsigned int child = 0; child < childCount; child++) {
-      auto newChild = std::make_unique<DAGNode>();
+      auto newChild = llvm::make_unique<DAGNode>();
       newChild->name = "function" + std::to_string(currentFunction);
       currentFunction++;
       firstNode->children.push_back(newChild.get());

--- a/tests/unittests/ThreadPoolTest.cpp
+++ b/tests/unittests/ThreadPoolTest.cpp
@@ -16,6 +16,8 @@
 #include "glow/Support/ThreadPool.h"
 #include "gtest/gtest.h"
 
+#include "llvm/ADT/STLExtras.h"
+
 #include <future>
 #include <vector>
 
@@ -53,7 +55,7 @@ TEST(ThreadPool, BasicTest) {
 TEST(ThreadPool, moveCaptureTest) {
   ThreadPool tp(1);
 
-  std::unique_ptr<int> input = std::make_unique<int>(42);
+  std::unique_ptr<int> input = llvm::make_unique<int>(42);
   int output = 0;
   auto func = [input = std::move(input), &output]() { output = (*input) * 2; };
 


### PR DESCRIPTION
*Description*: As long as CentOS 7 is a target platform we need to support gcc 4.8.5.  Sorry.  I'm going to see if we can use gcc 4.8.5 in CI to enforce this.
*Testing*: ninja test
*Documentation*: n/a
