### PR TITLE
[ci] Run coverage test with gcc-4.8.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,11 +34,11 @@ jobs:
         - utils/install_protobuf.sh
         - sudo apt-get install -y lcov
         - sudo pip install awscli --upgrade
-        - sudo apt-get install -qq g++-5
-        - sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-5 90
+        - sudo apt-get install -qq g++-4.8
+        - sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-4.8 90
       install:
         - mkdir build && cd build
-        - CC=gcc-5 CXX=g++-5 cmake -G Ninja
+        - CC=gcc-4.8 CXX=g++-4.8 cmake -G Ninja
           -DCMAKE_BUILD_TYPE=Debug -DGLOW_WITH_OPENCL=OFF -DGLOW_WITH_CPU=OFF
           -DCMAKE_PREFIX_PATH=/usr/lib/llvm-6.0/include/
           -DCMAKE_CXX_FLAGS=-Werror


### PR DESCRIPTION
*Description*: For compatibility with CentOS 7 I want to keep Glow building with gcc 4.8.5.
*Testing*: this diff
*Documentation*: n/a
