### PR TITLE
[CPUDeviceManager] Factory for creating devices, additions for HostManager

### DIFF
--- a/include/glow/Backends/DeviceManager.h
+++ b/include/glow/Backends/DeviceManager.h
@@ -43,9 +43,18 @@ protected:
   /// Type of Backend for this Device.
   BackendKind backend_;
 
+  /// Name or address of the device.
+  std::string name_;
+
 public:
-  DeviceManager(BackendKind backend) : backend_(backend) {}
+  DeviceManager(BackendKind backend, llvm::StringRef name = "unnamed")
+      : backend_(backend), name_(name) {}
   virtual ~DeviceManager() {}
+
+  /// Create a device of the type /p backend, with the backend specific
+  /// name/addres /p name.
+  static DeviceManager *createDeviceManager(BackendKind backend,
+                                            llvm::StringRef name);
 
   /// Initialize the device.
   virtual void init() {}
@@ -57,9 +66,9 @@ public:
   virtual void addNetwork(const Module *module, FunctionMapTy functions,
                           ReadyCBTy readyCB) = 0;
 
-  /// Remove (and delete) the provided network and all it's functions, freeing
+  /// Remove (and delete) the provided function, freeing
   /// up space on the device.
-  virtual void evictNetwork(const Module *module) = 0;
+  virtual void evictNetwork(llvm::StringRef functionName) = 0;
 
   /// Execute the named Function in an already provided network on the device.
   /// functionName must match the name of a function already added.

--- a/include/glow/Backends/QueueBackedDeviceManager.h
+++ b/include/glow/Backends/QueueBackedDeviceManager.h
@@ -32,7 +32,7 @@ protected:
   std::atomic<runtime::RunIdentifierTy> nextIdentifier_{1};
 
 public:
-  QueueBackedDeviceManager(BackendKind backend);
+  QueueBackedDeviceManager(BackendKind backend, llvm::StringRef name);
   virtual ~QueueBackedDeviceManager();
 
   /// Initialize the device.
@@ -45,7 +45,7 @@ public:
 
   /// Remove (and delete) the provided network and all it's functions, freeing
   /// up space on the device.
-  void evictNetwork(const Module *module) override;
+  void evictNetwork(llvm::StringRef functionName) override;
 
   /// Execute the named Function in an already provided network on the device.
   /// functionName must match the name of a function already added.
@@ -66,7 +66,7 @@ protected:
   virtual void addNetworkImpl(const Module *, FunctionMapTy, ReadyCBTy) = 0;
 
   /// Remove the module and reclaim it's memory
-  virtual void evictNetworkImpl(const Module *) = 0;
+  virtual void evictNetworkImpl(llvm::StringRef functionName) = 0;
 
   /// Execute provided Function.
   virtual void runFunctionImpl(runtime::RunIdentifierTy, std::string,

--- a/lib/Backends/CMakeLists.txt
+++ b/lib/Backends/CMakeLists.txt
@@ -30,7 +30,9 @@ target_link_libraries(Backends
                         Base
                         Graph)
 
-add_library(DeviceManager QueueBackedDeviceManager.cpp)
+add_library(DeviceManager
+              DeviceManagers.cpp
+              QueueBackedDeviceManager.cpp)
 
 target_link_libraries(DeviceManager
                       PRIVATE

--- a/lib/Backends/CPU/CPUDeviceManager.h
+++ b/lib/Backends/CPU/CPUDeviceManager.h
@@ -21,23 +21,24 @@
 namespace glow {
 
 class CPUDeviceManager : public QueueBackedDeviceManager {
-  /// Loaded module list.
-  std::map<const Module *, std::set<std::string>> modules_;
-
   /// Compiled function list by name.
   FunctionMapTy functions_;
 
   /// Maximum available memory on the device, for CPU devices fix to some
   /// constant.
-  uint64_t maxMemoryBytes{0};
+  uint64_t maxMemoryBytes_{0};
 
   /// Amount of memory used by all models.
-  uint64_t usedMemoryBytes{0};
+  uint64_t usedMemoryBytes_{0};
+
+  /// Static memory cost of the CPU Function.
+  /// This is very arbitrary for the CPU backend.
+  const u_int64_t functionCost_{1};
 
 public:
-  CPUDeviceManager(size_t MBsPerCore = 16000)
-      : QueueBackedDeviceManager(BackendKind::CPU),
-        maxMemoryBytes(MBsPerCore * 1024 * 1024) {}
+  CPUDeviceManager(llvm::StringRef name = "unnamed", size_t maxMemory = 1000)
+      : QueueBackedDeviceManager(BackendKind::CPU, name),
+        maxMemoryBytes_(maxMemory) {}
 
   uint64_t getMaximumMemory() override;
   uint64_t getAvailableMemory() override;
@@ -46,7 +47,7 @@ public:
 protected:
   void addNetworkImpl(const Module *module, FunctionMapTy functions,
                       ReadyCBTy cb) override;
-  void evictNetworkImpl(const Module *module) override;
+  void evictNetworkImpl(llvm::StringRef functionName) override;
   void runFunctionImpl(runtime::RunIdentifierTy id, std::string functionName,
                        std::unique_ptr<Context> ctx, ResultCBTy cb) override;
 };

--- a/lib/Backends/DeviceManagers.cpp
+++ b/lib/Backends/DeviceManagers.cpp
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/Backends/DeviceManager.h"
+
+#include "llvm/Support/Casting.h"
+
+using namespace glow;
+
+namespace glow {
+/// NOTE: Please add a declaration of a device-specific `create` method here
+/// when you define a new DeviceManager.
+
+/// Create a new instance of the interpreter Device.
+DeviceManager *createInterpreterDeviceManager(llvm::StringRef name) {
+  (void)name;
+  GLOW_UNREACHABLE("Unimplemented");
+}
+
+#if defined(GLOW_WITH_CPU)
+/// Create a new instance of the CPUBackend DeviceManager.
+DeviceManager *createCPUDeviceManager(llvm::StringRef name);
+#else
+DeviceManager *createCPUDeviceManager(llvm::StringRef name) {
+  (void)name;
+  GLOW_UNREACHABLE("Must compile with CPU support");
+}
+#endif
+
+#if defined(GLOW_WITH_OPENCL)
+/// Create a new instance of the OpenCL backend.
+DeviceManager *createOCLDeviceManager(llvm::StringRef name) {
+  (void)name;
+  GLOW_UNREACHABLE("Unimplemented");
+}
+#else
+DeviceManager *createOCLDeviceManager(llvm::StringRef name) {
+  (void)name;
+  GLOW_UNREACHABLE("Must compile with OpenCL support");
+}
+#endif
+} // namespace glow
+
+DeviceManager *DeviceManager::createDeviceManager(BackendKind backendKind,
+                                                  llvm::StringRef name) {
+  switch (backendKind) {
+  case BackendKind::Interpreter:
+    return createInterpreterDeviceManager(name);
+  case BackendKind::OpenCL:
+    return createOCLDeviceManager(name);
+  case BackendKind::CPU:
+    return createCPUDeviceManager(name);
+  }
+
+  // This is to make compiler happy. It can never reach this point as switch
+  // always covers all possible values.
+  llvm_unreachable("unreachable");
+}

--- a/lib/Backends/QueueBackedDeviceManager.cpp
+++ b/lib/Backends/QueueBackedDeviceManager.cpp
@@ -19,8 +19,9 @@
 using namespace glow;
 using namespace glow::runtime;
 
-QueueBackedDeviceManager::QueueBackedDeviceManager(BackendKind backend)
-    : DeviceManager(backend), workThread_(1) {}
+QueueBackedDeviceManager::QueueBackedDeviceManager(BackendKind backend,
+                                                   llvm::StringRef name)
+    : DeviceManager(backend, name), workThread_(1) {}
 
 QueueBackedDeviceManager::~QueueBackedDeviceManager() {
   stop(true); // will join workThread_
@@ -37,8 +38,8 @@ void QueueBackedDeviceManager::addNetwork(const Module *module,
   });
 }
 
-void QueueBackedDeviceManager::evictNetwork(const Module *module) {
-  workThread_.submit([this, module] { evictNetworkImpl(module); });
+void QueueBackedDeviceManager::evictNetwork(llvm::StringRef functionName) {
+  workThread_.submit([this, functionName] { evictNetworkImpl(functionName); });
 }
 
 RunIdentifierTy

--- a/tests/unittests/CPUDeviceManagerTest.cpp
+++ b/tests/unittests/CPUDeviceManagerTest.cpp
@@ -381,10 +381,10 @@ TEST(CPUDeviceManagerTest, AvailableMemory) {
   std::promise<const Module *> promise;
   std::future<const Module *> future;
 
-  CPUDeviceManager cpuCoreDevice(200);
+  CPUDeviceManager cpuCoreDevice("AvailableMemoryTest", 1);
   cpuCoreDevice.init();
 
-  uint64_t expectedBytes = 200 * 1024 * 1024;
+  uint64_t expectedBytes = 1;
   EXPECT_EQ(cpuCoreDevice.getMaximumMemory(), expectedBytes);
   EXPECT_EQ(cpuCoreDevice.getAvailableMemory(), expectedBytes);
   EXPECT_TRUE(cpuCoreDevice.isMemoryAvailable(expectedBytes));
@@ -425,7 +425,7 @@ TEST(CPUDeviceManagerTest, AvailableMemory) {
   EXPECT_EQ(cpuCoreDevice.getAvailableMemory(), 0);
 
   // Evict the first network.
-  cpuCoreDevice.evictNetwork(module.get());
+  cpuCoreDevice.evictNetwork("main");
 
   // And try again, this time with available space.
   std::tie(promise, future) = getFutureHelper<const Module *>();


### PR DESCRIPTION
*Description*: add a createDeviceManager static method for creating devices without needing to pull in backend specific code from lib. Also a couple of requests from @gcatron for use by the HostManager: adding a name parameter to DeviceManager constructor, and changing evictNetwork from taking the Module* to a function name.
*Testing*: unittests with asan.
*Documentation*:
