### PR TITLE
[Fix] Windows build fix for Support

### DIFF
--- a/include/glow/Support/Support.h
+++ b/include/glow/Support/Support.h
@@ -113,7 +113,10 @@ inline void report(llvm::StringRef str) { report(str.data()); }
 
 /// Printf-like formatting for std::string.
 const std::string strFormat(const char *format, ...)
+#ifndef _MSC_VER
     __attribute__((__format__(__printf__, 1, 2)));
+#endif
+;
 } // namespace glow
 
 #endif // GLOW_SUPPORT_SUPPORT_H


### PR DESCRIPTION
*Description*: VS doesn't support __attribute__((__format__(__printf__, 1, 2)));. Looking around it doesn't look like in VS there is equivalent or a clean way of doing this check. This fixes compile issue at the expense of slight less compile time checks when compiling with VS.
*Testing*: UtilsTest.exe which tests this function
*Documentation*:
Although VS provides some checks, it won't help here since it's function specific:
https://blogs.msdn.microsoft.com/vcblog/2015/06/22/format-specifiers-checking/
[Optional Fixes #issue]
https://github.com/pytorch/glow/issues/2305
Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
