### PR TITLE
[support] Add shared_function wrapper to threadpool objects on WIN32

### DIFF
--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -66,8 +66,8 @@ onnxStatus BackendId::checkGraphCompatibility(const void *onnxModel,
   return ONNXIFI_STATUS_SUCCESS;
 }
 
-void Backend::runAsync(const std::function<void(void)> &fn) {
-  threadPool_.submit(fn);
+void Backend::runAsync(std::function<void(void)> &&fn) {
+  threadPool_.submit(std::move(fn));
 }
 
 bool Event::signal() {

--- a/lib/Onnxifi/Base.h
+++ b/lib/Onnxifi/Base.h
@@ -86,7 +86,7 @@ public:
   glow::ExecutionEngine &getEE() { return backendIdPtr_->getEE(); }
 
   /// Run inference async using backend thread pool.
-  void runAsync(const std::function<void(void)> &fn);
+  void runAsync(std::function<void(void)> &&fn);
 
 private:
   BackendIdPtr backendIdPtr_;


### PR DESCRIPTION
*Description*: Visual Studio has a bug where it uses std::function as the backing for std::packaged_task, which doesn't allow non-copyable types in the lambda capture of tasks. This is an issue for us as we use (at least) std::unique_ptr and std::promise which are both noncopyable.

This diff adds a shared_function wrapper (courtesy of @ayermolo) on WIN32, which is copyable even if the lambda function is not.
*Testing*: unit tests with ASAN, manually changed the threadpool to wrap with a std::function (broke build) then enabled the wrapper (fixed build).
*Documentation*: Fixes #2309
