### PR TITLE
Lower everything before profiling, allowing for lowered profile to be gathered

### DIFF
--- a/include/glow/Optimizer/Optimizer.h
+++ b/include/glow/Optimizer/Optimizer.h
@@ -16,6 +16,8 @@
 #ifndef GLOW_OPTIMIZER_OPTIMIZER_H
 #define GLOW_OPTIMIZER_OPTIMIZER_H
 
+#include "glow/Quantization/Quantization.h"
+
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 
@@ -39,9 +41,14 @@ void optimize(IRFunction &M, bool shouldShareBuffers);
 /// Perform optimizations on the graph representation.
 void optimize(Function *F, CompilationMode mode);
 
-/// Lower the high-level neural network operators into low-level linear algebra
-/// operators.
-void lower(Function *F, const Backend &B);
+/// Lower the high-level neural network nodes found in \p F into low-level
+/// linear algebra operators. \p B can prevent lowering of a node via \ref
+/// Backend::shouldLower(). If \p loweredMap is not a nullptr, then everything
+/// is lowered regardless of the preferences of \p B, and \p loweredMap will
+/// contain a mapping from output names of the nodes found and lowered in \p F
+/// to the output names of the nodes they were lowered from from.
+void lower(Function *F, const Backend &B,
+           LoweredNamesMap *loweredMap = nullptr);
 
 /// Dead code elimination.
 void DCE(Function *F);

--- a/include/glow/Quantization/Quantization.h
+++ b/include/glow/Quantization/Quantization.h
@@ -28,6 +28,12 @@ namespace glow {
 
 class ExecutionEngine;
 
+/// Used to keep track of the origin of lowered Nodes via output names as
+/// determined by NodeQuantizationInfo::generateNodeOutputName(). For example if
+/// some NodeValue X is lowered from some NodeValue Y, then the output name of X
+/// is a key which maps to a set of names which contains the output name of Y.
+using LoweredNamesMap = llvm::StringMap<std::set<std::string>>;
+
 /// Tensor quantization parameters for a given node.
 struct NodeQuantizationInfo {
   std::string nodeOutputName_;
@@ -53,11 +59,15 @@ struct NodeQuantizationInfo {
 namespace quantization {
 
 /// Generate NodeQuantizationInfo for all required nodes from function \p F
-/// using the method specified by \p schema and target quantization
-/// precision \p quantizationPrecision. Profiling values will be written into
-/// context \p ctx.
+/// using the method specified by \p schema and target quantization precision \p
+/// quantizationPrecision. Profiling values will be written into context \p
+/// ctx. \p loweredMap maps from the NodeOutputName of a NodeValue which was
+/// lowered to a vector of the original NodeOutputNames which it replaced; this
+/// map is used to generate infos for the original unlowered NodeValues which no
+/// longer exist in \p F.
 std::vector<NodeQuantizationInfo> generateNodeQuantizationInfos(
-    Context &ctx, const Function *F, Schema schema = Schema::Asymmetric,
+    Context &ctx, const Function *F, const LoweredNamesMap &loweredMap = {},
+    Schema schema = Schema::Asymmetric,
     ElemKind quantizationPrecision = ElemKind::Int8QTy);
 
 /// Quantizes the function \p F into a new unoptimized partially quantized

--- a/lib/Backends/CPU/Transforms.cpp
+++ b/lib/Backends/CPU/Transforms.cpp
@@ -106,8 +106,9 @@ static Node *optimizeCPUMaxSplat(MaxNode *MN, Function *F) {
     input = RS->getResult();
   }
 
-  assert(input.getType() == splat->getResult().getType() &&
-         "Both inputs of Max node must have the same type");
+  assert(input.dims() == splat->getResult().dims() &&
+         input.getElementType() == splat->getResult().getElementType() &&
+         "Element type and dimensions of the max inputs must match.");
 
   return F->addNode(
       new CPUMaxSplatNode(MN->getName(), input, splat->getValue()));

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1482,17 +1482,17 @@ Function::createQuantizationProfile(Context &ctx, llvm::StringRef name,
   // TODO: this size is going to be refined. Just a placeholder now.
   const size_t numberOfBuckets = 2000U;
   auto *histogram = getParent()->createPlaceholder(
-      ElemKind::FloatTy, {numberOfBuckets}, "histogram", false);
+      ElemKind::FloatTy, {numberOfBuckets}, "histogram_" + name.str(), false);
   ctx.allocate(histogram);
   // Intermediate data used for histogram calculations.
   // Min tensor value seen so far is kept on the first position.
   // Max tensor value seen so far is kept on the second position.
   auto *computationInfo = getParent()->createPlaceholder(
-      ElemKind::FloatTy, {2}, "computationInfo", false);
+      ElemKind::FloatTy, {2}, "CI_" + name.str(), false);
   ctx.allocate(computationInfo);
   return addNode(new QuantizationProfileNode(
-      name, input, histogram, computationInfo, input.getNode()->getName().str(),
-      input.getResNo()));
+      "QI_" + name.str(), input, histogram, computationInfo,
+      input.getNode()->getName().str(), input.getResNo()));
 }
 
 IntLookupTableNode *

--- a/lib/Optimizer/Quantization.cpp
+++ b/lib/Optimizer/Quantization.cpp
@@ -65,8 +65,9 @@ Function *glow::profileQuantization(Context &ctx, Function *F,
     nodesToInstrument.insert(PH->getOutput());
   }
 
-  for (const auto &node : nodesToInstrument) {
-    G->createQuantizationProfile(ctx, "QuantizationProfile", node);
+  for (const auto &NV : nodesToInstrument) {
+    G->createQuantizationProfile(ctx, "QP_" + NV.getNode()->getName().str(),
+                                 NV);
   }
 
   return G;

--- a/tests/unittests/BackendCorrectnessTest.cpp
+++ b/tests/unittests/BackendCorrectnessTest.cpp
@@ -42,16 +42,18 @@ class CPUOnly : public BackendCorrectnessTest {};
 namespace {
 
 /// Clone, profile, and run \p origF given the \p ctx and \p EE. \returns the
-/// quantization parameters from the profile.
+/// quantization parameters from the profile, given the lowered info passed in
+/// via \p loweredMap.
 static std::vector<NodeQuantizationInfo>
 profileAndGetNodeQuantizationInfo(Context &ctx, ExecutionEngine &EE,
-                                  Function *origF) {
+                                  Function *origF,
+                                  const LoweredNamesMap &loweredMap) {
   Function *profileF = glow::profileQuantization(ctx, origF);
   EE.compile(CompilationMode::Infer, profileF);
 
   EE.run(ctx);
 
-  return quantization::generateNodeQuantizationInfos(ctx, profileF);
+  return quantization::generateNodeQuantizationInfos(ctx, profileF, loweredMap);
 }
 
 /// Signature of functions used to create and init a Function. Returns a pair of
@@ -83,8 +85,18 @@ compareAgainstInterpreter(BackendKind backendKind,
   // Profile the graph on the interpreter to get quantization info, and then
   // quantize both the Interpreter and Backend Functions with this info.
   if (quantize) {
+    // Lower everything for profiling in a cloned PF, keeping track of lowered
+    // info in loweredMap, which is then used when generating QI.
+    Function *PF = IF->clone("profile");
+    LoweredNamesMap loweredMap;
+    lower(PF, *IEE.getBackend(), &loweredMap);
     std::vector<NodeQuantizationInfo> QI =
-        profileAndGetNodeQuantizationInfo(ICtx, IEE, IF);
+        profileAndGetNodeQuantizationInfo(ICtx, IEE, PF, loweredMap);
+
+    // Lower only as the backends prefer for actually quantizing the two
+    // functions of the Interpreter and Backend.
+    lower(IF, *IEE.getBackend());
+    lower(BF, *BEE.getBackend());
     IF = quantization::quantizeFunction(IEE, QI, ElemKind::Int8QTy, IF);
     BF = quantization::quantizeFunction(BEE, QI, ElemKind::Int8QTy, BF);
   }

--- a/tests/unittests/QuantizationTest.cpp
+++ b/tests/unittests/QuantizationTest.cpp
@@ -383,7 +383,9 @@ static Function *createSimpleGraphForQuantization(Module *M, Context &ctx,
   auto *MMN = F->createMatMul("batchedreduceadd", O, TN);
   auto *BRAN = F->createBatchedReduceAdd("batchedreduceadd", MMN, 0);
   auto *TLN = F->createTile("tile", BRAN, 2, 0);
-  auto *save = F->createSave("save", TLN);
+  auto *SN = F->createSplat("splat", TLN->getResult().getType(), 100.0);
+  auto *MN = F->createMax("max", SN, TLN);
+  auto *save = F->createSave("save", MN);
   ctx.allocate(save->getPlaceholder());
   return F;
 }

--- a/tests/unittests/QuantizationTest.cpp
+++ b/tests/unittests/QuantizationTest.cpp
@@ -385,7 +385,9 @@ static Function *createSimpleGraphForQuantization(Module *M, Context &ctx,
   auto *TLN = F->createTile("tile", BRAN, 2, 0);
   auto *SN = F->createSplat("splat", TLN->getResult().getType(), 100.0);
   auto *MN = F->createMax("max", SN, TLN);
-  auto *save = F->createSave("save", MN);
+  auto *CLTE = F->createCmpLTE("cmplte", MN, SN);
+  auto *SLN = F->createSelect("select", CLTE, SN, MN);
+  auto *save = F->createSave("save", SLN);
   ctx.allocate(save->getPlaceholder());
   return F;
 }

--- a/tools/loader/Loader.h
+++ b/tools/loader/Loader.h
@@ -41,6 +41,10 @@ class Loader {
   ExecutionEngine EE_{};
   /// Function containing the model.
   Function *F_{nullptr};
+  /// A map between quantization profiling names of NodeValues that were lowered
+  /// from each other. Maps to a set of NodeValues that were replaced by the
+  /// NodeValue (key) that replaced them.
+  LoweredNamesMap loweredMap_;
 
 public:
   /// Getter for the Function.


### PR DESCRIPTION
This is a somewhat controversial change, but something I've considered for a while and it seems it could solve a couple pain points we're running into right now.

Basically, when doing profiling, lower *everything*, but keep track of what was lowered from what. This allows us to get quantization parameters of lowered nodes, while still allowing for profiles to stay backend-agnostic.

E.g. if we lower an FC to MM + BA, we keep track of that via a StringStringMap, mapping between their quantization output names (e.g. `ba:0` maps to `fc:0`, as we did `FCResult.replaceAllUsesOfWith(BAResult)`).

This map is used to write both the unlowered and lowered names into the profile. So before this PR, the profile would contain just `fc:0`. With this PR, the profile would additionally contain `mm:0` and `ba:0`, where the quantization parameters for `fc:0` and `ba:0` are the same. This means `mm:0` is slightly better specified based on actually gathering a profile for it. A backend can then find the quantization parameters of any nodes regardless of whether it lowers a node or not.

This is much more important for more complex nodes we lower, for example `SigmoidCrossEntropyWithLogitsNode`, which really can't be accurately profiled/quantized right now because it is lowered. This could enable us to add actual nodes for others that are "directly lowered" in Graph.cpp, for example LSTM.

This would also enable us to get rid of `getLoweredComponentInfo()` from https://github.com/pytorch/glow/pull/2235, which I'm not a huge fan of.

Fixes https://github.com/pytorch/glow/issues/1465