### PR TITLE
[ONNXIFI] Move ExecutionEngine to Graph

### DIFF
--- a/include/glow/ExecutionEngine/ExecutionEngine.h
+++ b/include/glow/ExecutionEngine/ExecutionEngine.h
@@ -39,7 +39,11 @@ class ExecutionEngine final {
   /// The Module that represents the high-level program.
   Module M_;
   /// The network execution backend.
-  std::unique_ptr<Backend> backend_;
+  Backend *backend_ = nullptr;
+  /// Whether or not the ExecutionEngine owns the backend or is just using
+  /// a backend provided from elsewhere. If ownsBackend is true,
+  /// ~ExecutionEngine will delete the backend_.
+  bool ownsBackend_ = false;
   /// A glow function compiled for this ExecutionEngine's backend.
   std::unique_ptr<CompiledFunction> function_;
 
@@ -52,8 +56,10 @@ public:
   /// using this backend.
   void setBackend(BackendKind backendKind);
 
-  /// Set the code generator to a custom \p backend.
-  void setBackend(Backend *backend);
+  /// Set the code generator to a custom \p backend. If \p ownsBackend is false
+  /// then ExecutionEngine will use the given backend without owning it which
+  /// means that ~ExecutionEngine will not delete it.
+  void setBackend(Backend *backend, bool ownsBackend = true);
 
   /// Get a pointer to the backend.
   const Backend *getBackend() const;

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -33,7 +33,7 @@ void ExecutionEngine::setBackend(BackendKind backendKind) {
   function_.reset();
 }
 
-/// Set the code generator kind to \p backend.
+/// Set the code generator to the given \p backend.
 void ExecutionEngine::setBackend(Backend *backend) {
   backend_.reset(backend);
   function_.reset();

--- a/lib/Onnxifi/CMakeLists.txt
+++ b/lib/Onnxifi/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(onnxifi-glow-lib
 
 target_link_libraries(onnxifi-glow-lib
                       PUBLIC
+                        Backends
                         ExecutionEngine
                         Graph
                         Importer
@@ -21,6 +22,7 @@ target_link_libraries(onnxifi-glow-lib
 
 target_link_libraries(onnxifi-glow
                       PUBLIC
+                        Backends
                         ExecutionEngine
                         Graph
                         Importer


### PR DESCRIPTION
*Description*:
Enable running multiple onnxifi graphs on the same onnxifi backend by moving the ExecutionEngine (and thus all state) to the onnxifi graph. This diff also enables ExecutionEngine to run with Backends that it does not own.
Next steps include:

- Make Backend::isOpSupported and Backend::shouldLower static so we can call them from HostManager as well without issue.
- Make onnxifi::Graph and onnxifi::Backend abstract classes and create a new type of graph and backend that integrates more closely with the HostManager interface.

*Testing*:
`ninja test`
sync to fbcode and run tests

*Documentation*:
doxygen
