### PR TITLE
[cmake] Fix dependence structure to allow shared libs

### DIFF
--- a/lib/Backends/CMakeLists.txt
+++ b/lib/Backends/CMakeLists.txt
@@ -1,14 +1,3 @@
-add_library(Backends
-              Backend.cpp
-              Backends.cpp)
-
-add_library(BackendUtils BackendUtils.cpp)
-
-target_link_libraries(BackendUtils
-                      PRIVATE
-                      CodeGen
-                      IR)
-
 add_subdirectory(Interpreter)
 
 if(GLOW_WITH_OPENCL)
@@ -20,21 +9,40 @@ endif()
 if(GLOW_WITH_CPU)
   add_subdirectory(CPU)
   LIST(APPEND linked_backends CPUBackend)
+  LIST(APPEND linked_device_managers CPUDeviceManager)
 endif()
 
+add_library(Backends
+              Backend.cpp
+              Backends.cpp)
 target_link_libraries(Backends
                       PRIVATE
                         BackendUtils
-                        Interpreter
-                        ${linked_backends}
                         Base
-                        Graph)
+                        Graph
+                        Interpreter
+                        Optimizer
+                        ${linked_backends})
+
+add_library(BackendUtils BackendUtils.cpp)
+target_link_libraries(BackendUtils
+                      PRIVATE
+                      CodeGen
+                      IR)
 
 add_library(DeviceManager
               DeviceManagers.cpp
               QueueBackedDeviceManager.cpp)
-
 target_link_libraries(DeviceManager
+                      PRIVATE
+                        Backends
+                        Graph
+                        ThreadPool
+                        ${linked_device_managers})
+
+add_library(QueueBackedDeviceManager
+            QueueBackedDeviceManager.cpp)
+target_link_libraries(QueueBackedDeviceManager
                       PRIVATE
                         Backends
                         Graph

--- a/lib/Backends/CPU/CMakeLists.txt
+++ b/lib/Backends/CPU/CMakeLists.txt
@@ -124,7 +124,7 @@ target_link_libraries(CPUDeviceManager
                       Base
                       CodeGen
                       CPUBackend
-                      DeviceManager
                       Graph
                       IR
-                      Optimizer)
+                      Optimizer
+                      QueueBackedDeviceManager)

--- a/lib/Importer/CMakeLists.txt
+++ b/lib/Importer/CMakeLists.txt
@@ -45,6 +45,7 @@ target_link_libraries(Importer
                       PRIVATE
                         Base
                         Graph
+                        LLVMSupport
                         Support)
 target_link_libraries(Importer PUBLIC onnx_proto ${PROTOBUF_LIBRARY})
 

--- a/lib/Runtime/Provisioner/CMakeLists.txt
+++ b/lib/Runtime/Provisioner/CMakeLists.txt
@@ -3,4 +3,5 @@ add_library(Provisioner
 
 target_link_libraries(Provisioner
                       PRIVATE
-                        Backends)
+                        Backends
+                        Graph)


### PR DESCRIPTION
*Description*: I think we were getting away with some questionable dependencies because our Linux CI build is more permissive than our macOS build (That's a guess.  Maybe it's a cmake versioning issue, or maybe it's something else.  Anyways.)

The most interesting stuff here is the DeviceManager library refactoring.  It's similar to our Backends library, in that there's an "interface" component (the Backend and DeviceManager pure virtual base classes) and a "factory" component (the createBackend and createDeviceManager methods that know how to create all possible derived classes).  Rolling both the interface and factory into one library creates circular dependences with the derived class libraries; luckily the "interface" is header-only, so the derived classes don't actually need to depend on the base-class library; the base-class library just has to depend on the derived class libraries.  Backwards seems that, know I.  But it works, and we thus regain the ability to build with shared libs on macOS!

Sorry in advance If none of that made sense.

*Testing*: `cmake .. -G Ninja -DBUILD_SHARED_LIBS=ON && ninja all`

*Documentation*: n/a

