### PR TITLE
[Debug] NFC: Make GLOW_DEBUG use llvm::dbgs stream everywhere

### DIFF
--- a/lib/Backends/CPU/AllocationsInfo.cpp
+++ b/lib/Backends/CPU/AllocationsInfo.cpp
@@ -73,7 +73,7 @@ void AllocationsInfo::allocateWeightVars(const IRFunction *F) {
         valueNumbers_[A.first].first == ValueKind::ConstantWeight
             ? "constant weight"
             : "mutable weight";
-    llvm::errs() << "Allocated " << kind << " " << A.first->getName()
+    llvm::dbgs() << "Allocated " << kind << " " << A.first->getName()
                  << " size: " << A.first->getSizeInBytes()
                  << "  address range:  [" << allocatedAddress_[A.first] << ", "
                  << allocatedAddress_[A.first] + A.first->getSizeInBytes()
@@ -115,7 +115,7 @@ void AllocationsInfo::allocateActivations(const IRFunction *F) {
   }
   DEBUG_GLOW(for (auto &A
                   : allocatedAddress_) {
-    llvm::errs() << "Allocated activation " << A.first->getName()
+    llvm::dbgs() << "Allocated activation " << A.first->getName()
                  << " size: " << A.first->getSizeInBytes()
                  << "  address range:  [" << allocatedAddress_[A.first] << ", "
                  << allocatedAddress_[A.first] + A.first->getSizeInBytes()

--- a/lib/Backends/CPU/BundleSaver.cpp
+++ b/lib/Backends/CPU/BundleSaver.cpp
@@ -134,7 +134,7 @@ void BundleSaver::produceBundle(llvm::StringRef outputDir) {
   auto bundleName = irgen_.getMainEntryName();
   auto bundleCodeOutput = (outputDir + "/" + bundleName + ".o").str();
   auto bundleWeightsOutput = (outputDir + "/" + bundleName + ".weights").str();
-  DEBUG_GLOW(llvm::outs() << "Producing a bundle:\n"
+  DEBUG_GLOW(llvm::dbgs() << "Producing a bundle:\n"
                           << "bundle name: " << bundleName << "\n"
                           << "bundle code: " << bundleCodeOutput << "\n"
                           << "bundle weights:" << bundleWeightsOutput << "\n");

--- a/lib/IR/ChildMemSizeBasedScheduler.cpp
+++ b/lib/IR/ChildMemSizeBasedScheduler.cpp
@@ -43,7 +43,7 @@ void ChildMemSizeBasedScheduler::computeNodeResultsMemorySize() {
       resultSize += N.getType(idx)->getSizeInBytes();
     }
     resultMemSize_[&N] = resultSize;
-    DEBUG_GLOW(llvm::outs()
+    DEBUG_GLOW(llvm::dbgs()
                << "ResultSize of " << N.getName() << ":" << resultSize << "\n");
   }
 }
@@ -72,7 +72,7 @@ void ChildMemSizeBasedScheduler::computeNodeComputationMaxMemorySize() {
         maxSize = maxMemSize_[input];
     }
     maxMemSize_[N] = maxSize;
-    DEBUG_GLOW(llvm::outs()
+    DEBUG_GLOW(llvm::dbgs()
                << "MaxSize of " << N->getName() << ":" << maxSize << "\n");
   }
 }
@@ -133,12 +133,12 @@ void ChildMemSizeBasedScheduler::orderChildNodesAndSchedule(Node *N) {
     }
   }
 
-  DEBUG_GLOW(llvm::outs() << "\nAbout to schedule children of " << N->getName()
+  DEBUG_GLOW(llvm::dbgs() << "\nAbout to schedule children of " << N->getName()
                           << "\n";
-             llvm::outs() << "Children are:\n");
+             llvm::dbgs() << "Children are:\n");
   DEBUG_GLOW(for (auto child
                   : orderedChildren) {
-    llvm::outs() << "Child " << child->getName() << ": "
+    llvm::dbgs() << "Child " << child->getName() << ": "
                  << maxMemSize_[child] - resultMemSize_[child] << "\n";
   });
 
@@ -148,7 +148,7 @@ void ChildMemSizeBasedScheduler::orderChildNodesAndSchedule(Node *N) {
   }
 
   // Schedule the node after all its children are scheduled.
-  DEBUG_GLOW(llvm::outs() << "Scheduled node: " << N->getName() << "\n");
+  DEBUG_GLOW(llvm::dbgs() << "Scheduled node: " << N->getName() << "\n");
   scheduled_.push_back(N);
 }
 


### PR DESCRIPTION
*Description*:
I noticed that GLOW_DEBUG uses different streams across Glow sources and made an assumption that this was not done on purpose. This patch makes GLOW_DEBUG to use llvm::dbgs everywhere.

*Testing*: N/A
*Documentation*: N/A