### PR TITLE
[GLOW] Windows build fix.

### DIFF
--- a/lib/Backends/CPU/CPUDeviceManager.h
+++ b/lib/Backends/CPU/CPUDeviceManager.h
@@ -33,7 +33,7 @@ class CPUDeviceManager : public QueueBackedDeviceManager {
 
   /// Static memory cost of the CPU Function.
   /// This is very arbitrary for the CPU backend.
-  const u_int64_t functionCost_{1};
+  const uint64_t functionCost_{1};
 
 public:
   CPUDeviceManager(llvm::StringRef name = "unnamed", size_t maxMemory = 1000)

--- a/tests/unittests/ProvisionerTest.cpp
+++ b/tests/unittests/ProvisionerTest.cpp
@@ -24,7 +24,7 @@ using DAGNodePairTy = std::pair<std::vector<std::unique_ptr<DAGNode>>,
                                 std::vector<std::unique_ptr<DAGNode>>>;
 
 class ProvisionerTest : public ::testing::Test {};
-std::unique_ptr<Module> setupModule(uint functionCount) {
+std::unique_ptr<Module> setupModule(unsigned functionCount) {
   std::unique_ptr<Module> module = llvm::make_unique<Module>();
   for (unsigned int i = 0; i < functionCount; i++) {
     Function *F = module->createFunction("function" + std::to_string(i));
@@ -36,10 +36,10 @@ std::unique_ptr<Module> setupModule(uint functionCount) {
   return module;
 }
 
-DAGNodePairTy setupDAG(uint rootCount, uint childCount) {
+DAGNodePairTy setupDAG(unsigned rootCount, unsigned childCount) {
   std::vector<std::unique_ptr<DAGNode>> networks;
   std::vector<std::unique_ptr<DAGNode>> children;
-  uint currentFunction = 0;
+  unsigned currentFunction = 0;
   for (unsigned int root = 0; root < rootCount; root++) {
     auto rootNode = llvm::make_unique<DAGNode>();
     auto firstNode = llvm::make_unique<DAGNode>();


### PR DESCRIPTION
*Description*: Small fix for some none standard types.
*Testing*:
*Documentation*:
[Optional Fixes #issue]
For one of them:
https://stackoverflow.com/questions/42979055/should-i-use-c-types-uint8-t-uint64-t-or-u-int8-t-u-int64-t
Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
