### PR TITLE
[Runtime] Add runtime Executor class

### DIFF
--- a/include/glow/Backends/BackendUtils.h
+++ b/include/glow/Backends/BackendUtils.h
@@ -29,13 +29,19 @@ struct RuntimeSymbolInfo {
   size_t offset;
   /// Type of symbol.
   Type type;
+  /// Is the symbol an input for the function.
+  bool input;
+  /// Is the symbol an output for the function.
+  bool output;
 };
+
+using SymbolTableTy = std::unordered_map<std::string, RuntimeSymbolInfo>;
 
 /// Contains the information needed to be passed forward from compile time to
 /// runtime. In order to allocate and initialize memory.
 class RuntimeBundle {
   /// Map from symbol name to a RuntimeSymbolInfo.
-  std::unordered_map<std::string, RuntimeSymbolInfo> symbolTable_;
+  SymbolTableTy symbolTable_;
   /// Pointer to memory containing the weights for execution.
   uint8_t *constants_;
   /// Amount of memory needed for weights.
@@ -60,6 +66,8 @@ public:
   size_t getValueOffset(const Named *v) const;
   /// Helper function, gets symbol info for \p v.
   RuntimeSymbolInfo getSymbolInfo(const Named *v) const;
+  /// Get a const reference to the symbol table.
+  const SymbolTableTy &getSymbolTable() const { return symbolTable_; }
   /// At compile time condense constants to a single block of memory.
   /// This allows the graph to go away after compile time.
   /// Allocates a block of memory of size \p constantMaxSize then walks the
@@ -69,8 +77,8 @@ public:
   void collectConstants(const Module *M);
 
   RuntimeBundle() = default;
-  RuntimeBundle(std::unordered_map<std::string, RuntimeSymbolInfo> &symbolTable,
-                size_t constWeight, size_t mutableWeight, size_t activations)
+  RuntimeBundle(SymbolTableTy &symbolTable, size_t constWeight,
+                size_t mutableWeight, size_t activations)
       : symbolTable_(std::move(symbolTable)), constants_(nullptr),
         constantWeightVarsMemSize_(constWeight),
         mutableWeightVarsMemSize_(mutableWeight),

--- a/include/glow/Graph/Context.h
+++ b/include/glow/Graph/Context.h
@@ -38,14 +38,28 @@ public:
   /// Maps placeholders to the tensors that back them.
   using PlaceholderMap = std::unordered_map<Placeholder *, Tensor *>;
 
+  /// Maps Placeholder names to Placeholders.
+  using PlaceholderNameMap = std::unordered_map<std::string, Placeholder *>;
+
 private:
   /// Maps Placeholders to Tensors.
   PlaceholderMap map_;
 
+  /// Maps Placeholder names to Placeholders.
+  PlaceholderNameMap nameMap_;
+
 public:
+  /// \returns true if \p A and \p B contain the same Placeholders mapped to
+  /// equivalent Tensors.
+  static bool compare(const Context *A, const Context *B);
+
   /// \returns the tensor that corresponds to Placeholder \p P or Null if the
   /// tensor is not found.
   Tensor *get(Placeholder *P) const;
+
+  /// \returns the Placeholder named \name or null of the Placeholder is not
+  /// found.
+  Placeholder *getPlaceholderByName(llvm::StringRef name) const;
 
   /// Inserts the Placeholder-Tensor pair.
   void insert(Placeholder *P, Tensor &&T);
@@ -88,7 +102,8 @@ public:
   Context(llvm::ArrayRef<Placeholder *> placeholders,
           llvm::ArrayRef<Tensor *> inputs);
 
-  Context(Context &&other) : map_(std::move(other.map_)) {}
+  Context(Context &&other)
+      : map_(std::move(other.map_)), nameMap_(std::move(other.nameMap_)) {}
 
   ~Context() { clear(); };
 

--- a/include/glow/Runtime/Executor/Executor.h
+++ b/include/glow/Runtime/Executor/Executor.h
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_RUNTIME_EXECUTOR_H
+#define GLOW_RUNTIME_EXECUTOR_H
+
+#include "glow/Runtime/RuntimeTypes.h"
+
+#include <functional>
+#include <memory>
+#include <unordered_map>
+
+namespace glow {
+
+class Context;
+class DeviceManager;
+
+namespace runtime {
+
+/// This enum lists the available executors.
+enum class ExecutorKind {
+  ThreadPool, // Executor backed by a thread pool.
+};
+
+/// This is an interface to an executor that can run and results the results of
+/// a partitioned graph.
+class Executor {
+public:
+  /// Map of DeviceIDTy -> DeviceManager, used when selecting a DeviceManager
+  /// to use to execute a DAGNode.
+  using DeviceManagerMapTy =
+      std::unordered_map<DeviceIDTy, std::shared_ptr<DeviceManager>>;
+
+  /// Callback signalling the success/failure of running a DAG. The arguments
+  /// are the run identifier of the invocation, the execution result code and
+  /// a Context containing outputs.
+  using DoneCbTy = std::function<void(RunIdentifierTy, ResultCode,
+                                      std::unique_ptr<Context>)>;
+  /// Destructor.
+  virtual ~Executor() = default;
+
+  /// Run the DAG specified by \p root using \p context and call \cb with the
+  /// results. \p runId is used to identify the run for logging and metrics
+  /// purposes.
+  /// cb will be called with a result code, the run ID and a Context containing
+  /// placeholder-tensor mappings for the nodes in the DAG that have
+  /// no postrequisites (i.e. the final results) in addition to the mappings
+  /// present in \p context.
+  virtual void run(const DAGNode *root, std::unique_ptr<Context> context,
+                   RunIdentifierTy runId, DoneCbTy cb) = 0;
+};
+
+/// Create an executor of kind \p kind that will call into the DeviceManager
+/// instances provided in \deviceManagers. \returns a pointer to the
+/// executor.
+Executor *createExecutor(const Executor::DeviceManagerMapTy &deviceManagers,
+                         ExecutorKind executorKind = ExecutorKind::ThreadPool);
+
+} // namespace runtime
+} // namespace glow
+#endif

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(Provisioner)
+add_subdirectory(Executor)

--- a/lib/Runtime/Executor/CMakeLists.txt
+++ b/lib/Runtime/Executor/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_library(Executor
+              Executor.cpp
+              ThreadPoolExecutor.cpp)
+
+target_link_libraries(Executor
+	              PRIVATE
+		        Graph)

--- a/lib/Runtime/Executor/Executor.cpp
+++ b/lib/Runtime/Executor/Executor.cpp
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/Runtime/Executor/Executor.h"
+#include "ThreadPoolExecutor.h"
+#include "llvm/Support/Casting.h"
+
+namespace glow {
+namespace runtime {
+
+Executor *createExecutor(const Executor::DeviceManagerMapTy &deviceManagers,
+                         ExecutorKind executorKind) {
+  switch (executorKind) {
+  case ExecutorKind::ThreadPool:
+    return new ThreadPoolExecutor(deviceManagers);
+  }
+
+  // This is to make compiler happy. It can never reach this point as the switch
+  // statement above always covers all possible values.
+  llvm_unreachable("unreachable");
+}
+
+} // namespace runtime
+} // namespace glow

--- a/lib/Runtime/Executor/ThreadPoolExecutor.cpp
+++ b/lib/Runtime/Executor/ThreadPoolExecutor.cpp
@@ -1,0 +1,357 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ThreadPoolExecutor.h"
+
+#include "glow/Backends/DeviceManager.h"
+#include "glow/Graph/Context.h"
+
+#include <queue>
+#include <unordered_set>
+
+namespace glow {
+namespace runtime {
+
+ExecutionState::ExecutionState(RunIdentifierTy id, const DAGNode *root,
+                               std::unique_ptr<Context> resultContext,
+                               DoneCbTy doneCb)
+    : runId_(id), cb_(doneCb), resultCtx_(std::move(resultContext)),
+      inflightNodes_(0), resultCode_(ResultCode::Ready) {
+  // Create a queue for the breadth-first traversal through the graph.
+  std::queue<const DAGNode *> bfsQueue;
+
+  // Place the root nodes in the queue.
+  for (const auto &node : root->children) {
+    bfsQueue.push(node);
+  }
+
+  // Breadth-first search.
+  while (!bfsQueue.empty()) {
+    // Get the next node in the BFS queue.
+    const DAGNode *node = bfsQueue.front();
+    bfsQueue.pop();
+
+    // Make a counter for the number of node parents done.
+    nodeParentsDone_[node] = 0;
+
+    // Make an (empty) input Context for the node.
+    inputCtxs_.insert(std::make_pair(node, llvm::make_unique<Context>()));
+
+    // Push all unvisited children onto the BFS queue.
+    for (const auto &child : node->children) {
+      // Use nodeParentsDone_ as a set of nodes that have been visited already
+      // to avoid visiting a node more than once.
+      if (!nodeParentsDone_.count(child)) {
+        bfsQueue.push(child);
+      }
+    }
+  }
+}
+
+void ExecutionState::insertIntoNodeCtx(const DAGNode *node, Placeholder *P,
+                                       Tensor &&T) {
+  // Get a raw pointer to the input Context for the node. It should have
+  // been created in the constructor.
+  auto ctxIt = inputCtxs_.find(node);
+
+  if (ctxIt == inputCtxs_.end()) {
+    assert(!"Input context not found but should exist!");
+  }
+
+  Context *ctx = (ctxIt->second).get();
+  assert(ctx && "Input context for node is null");
+
+  // Insert the placeholder-tensor pair.
+  std::lock_guard<std::mutex> lock(contextMtx_);
+  ctx->insert(P, std::move(T));
+}
+
+std::unique_ptr<Context>
+ExecutionState::getUniqueNodeContextPtr(const DAGNode *node) {
+  // The input Context for the node should have been created in the constructor.
+  auto ctxIt = inputCtxs_.find(node);
+
+  if (ctxIt == inputCtxs_.end()) {
+    assert(!"Input context not found but should exist!");
+  }
+
+  return std::move(ctxIt->second);
+}
+
+void ExecutionState::incrementInflightNodes(unsigned increment) {
+  inflightNodes_ += increment;
+}
+
+bool ExecutionState::decrementInflightNodes(unsigned decrement) {
+  // fetch_sub must be used here so that the function returns true to only one
+  // caller.
+  unsigned previousValue = inflightNodes_.fetch_sub(decrement);
+
+  // The decrement should never be more than the value of the counter at the
+  // time of decrement.
+  if (previousValue < decrement) {
+    assert(!"More decrements than increments to inflight nodes!");
+  }
+
+  // Return true when the counter hits zero.
+  return (previousValue == decrement);
+}
+
+bool ExecutionState::incrementNodeParentsDone(const DAGNode *node,
+                                              unsigned increment) {
+  // Get the parents done counter for the node. It should have
+  // been created in the constructor.
+  auto it = nodeParentsDone_.find(node);
+
+  if (it == nodeParentsDone_.end()) {
+    assert(!"Node parents done counter should exist but not found!");
+  }
+
+  // fetch_add must be used here so that the function returns true to only
+  // one caller.
+  unsigned numParents = (node->parents).size();
+  unsigned previousValue = (it->second).fetch_add(increment);
+  unsigned newValue = previousValue + increment;
+
+  // The new value of the counter cannot exceed the number of parents that
+  // the node has.
+  if (newValue > numParents) {
+    assert(!"Node parents done counter incremented beyond limit!");
+  }
+
+  // Return true only when the counter hits the total numer of parents.
+  return (newValue == numParents);
+}
+
+void ExecutionState::insertIntoResultCtx(Placeholder *P, Tensor &&T) {
+  // The result Context should have been been created in the constructor
+  // and should not yet have been moved out if this function is being called.
+  assert(resultCtx_ && "Execution result context should exist!");
+  std::lock_guard<std::mutex> lock(contextMtx_);
+  Tensor *tensor = resultCtx_->get(P);
+
+  if (tensor) {
+    *tensor = std::move(T);
+  } else {
+    resultCtx_->insert(P, std::move(T));
+  }
+}
+
+std::unique_ptr<Context> ExecutionState::getUniqueResultContextPtr() {
+  // The result Context should have been been created in the constructor.
+  assert(resultCtx_ && "Execution result context should exist!");
+  return std::move(resultCtx_);
+}
+
+Context *ExecutionState::getRawResultContextPtr() const {
+  // The result Context should have been been created in the constructor
+  // and should not yet have been moved out if this function is being called.
+  assert(resultCtx_ && "Execution result context should exist!");
+  return resultCtx_.get();
+}
+
+void ExecutionState::setResultCode(const ResultCode resultCode) {
+  // If resultCode_ is ResultCode::Failed, that should "stick". In other words,
+  // once a run has failed due to one node, the fact that the other nodes
+  // executed sucessfully does not change the result code of the run.
+  if (resultCode_ != ResultCode::Failed) {
+    resultCode_ = resultCode;
+  }
+}
+
+ThreadPoolExecutor::~ThreadPoolExecutor() {
+  // Lock executionStatesMutex_ here to satisfy TSAN.
+  std::lock_guard<std::mutex> lock(executionStatesMutex_);
+  (void)lock;
+}
+
+void ThreadPoolExecutor::run(const DAGNode *root,
+                             std::unique_ptr<Context> context,
+                             RunIdentifierTy runId, DoneCbTy cb) {
+  // If list of roots is empty, there is nothing to do. Give back the
+  // context so the caller can reuse it.
+  if (!root) {
+    cb(runId, ResultCode::Executed, std::move(context));
+    return;
+  }
+
+  std::shared_ptr<ExecutionState> executionState = nullptr;
+  {
+    std::lock_guard<std::mutex> lock(executionStatesMutex_);
+
+    // If the given run ID corresponds to a run already in progress, there is
+    // also nothing to do, but return an error. Give back the context so the
+    // caller can reuse it.
+    if (executionStates_.find(runId) != executionStates_.end()) {
+      cb(runId, ResultCode::Failed, std::move(context));
+      return;
+    }
+
+    // Otherwise, create execution state tracker object for this run ID.
+    executionState = std::make_shared<ExecutionState>(
+        runId, root, std::move(context), std::move(cb));
+    executionStates_.insert(std::make_pair(runId, executionState));
+  }
+
+  // Execute all child nodes of root.
+
+  // Mark the child nodes as "inflight" (i.e. currently executing). This must be
+  // done here instead of inside executeDAGNode() so that a node can be
+  // executed while placeholders are being propagated for the next node without
+  // the callback for that node deleting the execution state.
+  executionState->incrementInflightNodes((root->children).size());
+
+  for (auto const &node : root->children) {
+    // Propagate placeholders from the given starter Context into the input
+    // Context for the current node being processed.
+    propagatePlaceholdersForNode(executionState, node,
+                                 executionState->getRawResultContextPtr());
+
+    // Execute the node.
+    executeDAGNode(executionState, node);
+  }
+}
+
+void ThreadPoolExecutor::propagatePlaceholdersForNode(
+    std::shared_ptr<ExecutionState> executionState, const DAGNode *node,
+    const Context *ctx) {
+  // Get the symbol table for the node.
+  const SymbolTableTy &symbolTable = (node->runtimeBundle).getSymbolTable();
+
+  for (const auto &symbolPair : symbolTable) {
+    const auto &symbolName = symbolPair.first;
+    const auto &symbolInfo = symbolPair.second;
+
+    if (symbolInfo.input) {
+      // If the symbol is an input, look for a Placeholder in ctx with
+      // the same name and copy the corresponding Tensor into the input Context
+      // being prepared for the node.
+      auto *placeholder = ctx->getPlaceholderByName(symbolName);
+
+      if (placeholder) {
+        const auto *tensor = ctx->get(placeholder);
+        executionState->insertIntoNodeCtx(node, placeholder, tensor->clone());
+      }
+    }
+  }
+}
+
+void ThreadPoolExecutor::executeDAGNode(
+    std::shared_ptr<ExecutionState> executionState, const DAGNode *node) {
+  // If execution has already failed due to another node, don't bother running
+  // this one.
+  if (executionState->getResultCode() == ResultCode::Failed) {
+    // Mark the node as no longer executing.
+    executionState->decrementInflightNodes();
+    return;
+  }
+
+  // Get the DeviceManager that can run the node.
+  auto deviceManagerIt = deviceManagers_.find(node->deviceID);
+
+  if (deviceManagerIt == deviceManagers_.end()) {
+    // Mark the node as no longer executing.
+    executionState->decrementInflightNodes();
+    executionState->setResultCode(ResultCode::Failed);
+    return;
+  }
+
+  std::shared_ptr<DeviceManager> deviceManager = deviceManagerIt->second;
+
+  // Get the Context containing all of the inputs for the node.
+  std::unique_ptr<Context> nodeCtx =
+      executionState->getUniqueNodeContextPtr(node);
+  // Run the node using the DeviceManager.
+  deviceManager->runFunction(
+      node->name, std::move(nodeCtx),
+      [this, executionState, node](RunIdentifierTy id, ResultCode resultCode,
+                                   std::unique_ptr<Context> resultCtx) {
+        // Immediately move the handling of the result onto threadPool_ to
+        // avoid doing work on the DeviceManager thread.
+        this->threadPool_.submit([this, executionState, node, resultCode,
+                                  ctx = std::move(resultCtx)]() mutable {
+          this->handleDeviceManagerResult(executionState, resultCode,
+                                          std::move(ctx), node);
+        });
+      });
+}
+
+void ThreadPoolExecutor::propagateOutputPlaceholders(
+    std::shared_ptr<ExecutionState> executionState,
+    std::unique_ptr<Context> ctx) {
+  // Copy all of the Placeholders in ctx into the result Context for the run.
+  for (const auto &phTensorPair : ctx->pairs()) {
+    auto *placeholder = phTensorPair.first;
+    auto *tensor = phTensorPair.second;
+
+    executionState->insertIntoResultCtx(placeholder, std::move(*tensor));
+  }
+}
+
+void ThreadPoolExecutor::handleDeviceManagerResult(
+    std::shared_ptr<ExecutionState> executionState, ResultCode resultCode,
+    std::unique_ptr<Context> ctx, const DAGNode *node) {
+  // If executionState is null, that means that the object was deleted
+  // while a node was executing. That should never happen.
+  assert(executionState && "Execution state should not be null");
+
+  // Set the result code for the run.
+  executionState->setResultCode(resultCode);
+
+  // If the DeviceManager executed the node, propagate its output Placeholders
+  // to its children or the result Context as appropriate.
+  if (executionState->getResultCode() == ResultCode::Executed) {
+    if ((node->children).empty()) {
+      // If the node has no children, propagate its outputs to the result
+      // Context for the run.
+      propagateOutputPlaceholders(executionState, std::move(ctx));
+    } else {
+      // If the node has children, propagate its outputs to the input Contexts
+      // for any of its children that need them as inputs.
+      for (auto &child : node->children) {
+        propagatePlaceholdersForNode(executionState, child, ctx.get());
+
+        // Execute any child that has no parent nodes left to execute.
+        bool childReadyToExecute =
+            executionState->incrementNodeParentsDone(child);
+        if (childReadyToExecute) {
+          // Mark the node as "inflight" (i.e. currently executing).
+          executionState->incrementInflightNodes();
+          executeDAGNode(executionState, child);
+        }
+      }
+    }
+  }
+
+  // Now, check if all nodes in the graph are done. If so, the callback can be
+  // called and all state associated with the run can be erased.
+  bool noNodesInflight = executionState->decrementInflightNodes();
+
+  if (noNodesInflight) {
+    // If there are no nodes inflight, that means all nodes are done. Call
+    // the callback and erase the state information.
+    DoneCbTy cb = executionState->getCallback();
+    cb(executionState->getRunId(), executionState->getResultCode(),
+       executionState->getUniqueResultContextPtr());
+
+    // Clean up the state stored for the run.
+    std::lock_guard<std::mutex> lock(executionStatesMutex_);
+    executionStates_.erase(executionState->getRunId());
+  }
+}
+
+} // namespace runtime
+} // namespace glow

--- a/lib/Runtime/Executor/ThreadPoolExecutor.h
+++ b/lib/Runtime/Executor/ThreadPoolExecutor.h
@@ -1,0 +1,178 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_RUNTIME_THREAD_POOL_EXECUTOR_H
+#define GLOW_RUNTIME_THREAD_POOL_EXECUTOR_H
+
+#include <mutex>
+#include <unordered_map>
+
+#include "glow/Runtime/Executor/Executor.h"
+#include "glow/Support/ThreadPool.h"
+
+namespace glow {
+namespace runtime {
+
+/// This class keeps track of the state of execution for a run (identified
+/// by the runId).
+class ExecutionState final {
+public:
+  using DoneCbTy = Executor::DoneCbTy;
+
+  /// Constructor.
+  explicit ExecutionState(RunIdentifierTy id, const DAGNode *root,
+                          std::unique_ptr<Context> resultContext,
+                          DoneCbTy doneCb);
+
+  /// Insert the placeholder-tensor pair (\p P, \p T) into the input context
+  /// for \p node. This should not be called at the same time as
+  /// getUniqueNodeContextPtr().
+  void insertIntoNodeCtx(const DAGNode *node, Placeholder *P, Tensor &&T);
+
+  /// \returns a unique pointer to an input context for \p node. This should not
+  /// be called at the same time as insertIntoNodeCtx().
+  std::unique_ptr<Context> getUniqueNodeContextPtr(const DAGNode *node);
+
+  /// Increment the count of inflight nodes by \p increment (default is 1).
+  void incrementInflightNodes(unsigned increment = 1);
+
+  /// Decrement the count of inflight nodes by the \p decrement (default is 1).
+  /// \returns true if there are no nodes inflight after the decrement
+  /// operation.
+  bool decrementInflightNodes(unsigned decrement = 1);
+
+  /// Increment the count of completed parent nodes for \p node. \returns
+  /// true if all parents are done after the increment operation, false
+  /// otherwise.
+  bool incrementNodeParentsDone(const DAGNode *node, unsigned increment = 1);
+
+  /// Insert the placeholder-tensor pair (\p P, \p T) into the result context.
+  /// This should not be called at the same time as getUniqueResultContextPtr().
+  void insertIntoResultCtx(Placeholder *P, Tensor &&T);
+
+  /// \returns a unique pointer to the result context. This should not be
+  /// called at the same time as getRawResultContextPtr() or
+  /// insertIntoResultCtx().
+  std::unique_ptr<Context> getUniqueResultContextPtr();
+
+  /// \returns a raw pointer to the result context. This should be not called
+  /// at the same time as getUniqueResultContextPtr().
+  Context *getRawResultContextPtr() const;
+
+  /// \returns the callback for this execution.
+  DoneCbTy getCallback() { return cb_; }
+
+  /// \returns the result code for the execution.
+  ResultCode getResultCode() const { return resultCode_; }
+
+  /// Set result code for the execution.
+  void setResultCode(const ResultCode resultCode);
+
+  /// \returns the run ID for the execution.
+  RunIdentifierTy getRunId() const { return runId_; }
+
+private:
+  /// The run identifier for this execution of a DAG.
+  RunIdentifierTy runId_;
+  /// The callback that should be called when execution is done.
+  DoneCbTy cb_;
+  /// The Context object containing the results of the execution (i.e. the
+  /// outputs of the DAGNodes that have no children).
+  std::unique_ptr<Context> resultCtx_;
+  /// Counters for how many of each nodes parents are done. These are needed
+  /// in order to determine when a node is ready to be executed.
+  std::unordered_map<const DAGNode *, std::atomic<unsigned>> nodeParentsDone_;
+  /// Input Contexts for all of the nodes. These are gradually populated as
+  /// a node's parents finish.
+  std::unordered_map<const DAGNode *, std::unique_ptr<Context>> inputCtxs_;
+  /// The set of currently executing nodes. This is populated with the roots
+  /// when a run starts, and does not become empty until execution finishes.
+  std::atomic<unsigned> inflightNodes_;
+  /// Flag that is used to track if a non-success error code was received.
+  std::atomic<ResultCode> resultCode_;
+  /// Mutex used by context insertion functions to make sure only one thread
+  /// writes to a Context at a time.
+  std::mutex contextMtx_;
+};
+
+/// This implementation of the Executor interface uses a thread pool to
+/// handle and process multiple concurrent execution runs.
+class ThreadPoolExecutor final : public Executor {
+public:
+  using DeviceManagerMapTy = Executor::DeviceManagerMapTy;
+  using DoneCbTy = Executor::DoneCbTy;
+
+  /// Constructor.
+  explicit ThreadPoolExecutor(const DeviceManagerMapTy &deviceManagers,
+                              unsigned numWorkers = kNumWorkers)
+      : threadPool_(numWorkers), deviceManagers_(deviceManagers) {}
+
+  /// Destructor.
+  virtual ~ThreadPoolExecutor();
+
+  /// See Executor::run. A particular invocation is specified completely by
+  /// the triple (roots, context, runId).
+  void run(const DAGNode *root, std::unique_ptr<Context> context,
+           RunIdentifierTy runId, DoneCbTy cb) override;
+
+private:
+  /// Propagate Placeholders from \p ctx into the final output Context for the
+  /// run corresponding to \p executionState.
+  void
+  propagateOutputPlaceholders(std::shared_ptr<ExecutionState> executionState,
+                              std::unique_ptr<Context> ctx);
+
+  /// Propagate Placeholders needed by \p node from \p ctx into
+  /// the Context for \p node within the run corresponding to \p executionState.
+  void
+  propagatePlaceholdersForNode(std::shared_ptr<ExecutionState> executionState,
+                               const DAGNode *node, const Context *ctx);
+
+  /// Execute the DAG node specified by \p node within the run corresponding to
+  /// \p executionState.
+  void executeDAGNode(std::shared_ptr<ExecutionState> executionState,
+                      const DAGNode *node);
+
+  /// Handle the result returned asynchronously by the DeviceManager.
+  /// \p executionState is tracks the state of the run that the node that
+  /// finished executing belongs to, \p is the resultCode returned by the
+  /// DeviceManager, \p ctx is the Context that contains the outputs produced by
+  /// \p node during the run.
+  ///
+  /// The main purpose of this function is to help move computation off of the
+  /// DeviceManager thread pool on onto the one owned by this class.
+  void handleDeviceManagerResult(std::shared_ptr<ExecutionState> executionState,
+                                 ResultCode resultCode,
+                                 std::unique_ptr<Context> ctx,
+                                 const DAGNode *node);
+
+  /// The default number of workers in the thread pool.
+  constexpr static unsigned kNumWorkers = 3;
+  /// The thread pool used to drive execution.
+  ThreadPool threadPool_;
+  /// Map of available DeviceManagers.
+  const DeviceManagerMapTy &deviceManagers_;
+  /// Map from run ID to the ExecutionState containing the state for the run.
+  std::unordered_map<RunIdentifierTy, std::shared_ptr<ExecutionState>>
+      executionStates_;
+  /// Lock for executionStates_. This is needed to synchronize access to
+  /// executionStateLocks_ so that multiple threads and can perform insertion
+  /// and lookup concurrently.
+  std::mutex executionStatesMutex_;
+};
+
+} // namespace runtime
+} // namespace glow
+#endif

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -351,6 +351,18 @@ target_link_libraries(QuantizationTest
 add_glow_test(QuantizationTest ${GLOW_BINARY_DIR}/tests/QuantizationTest --gtest_output=xml:QuantizationTest.xml)
 LIST(APPEND UNOPT_TESTS ./tests/QuantizationTest -optimize-ir=false &&)
 
+add_executable(ExecutorTest
+               ExecutorTest.cpp)
+target_link_libraries(ExecutorTest
+                      PRIVATE
+                        DeviceManager
+                        Executor
+                        Graph
+                        gtest
+                        TestMain
+                        ThreadPool)
+add_glow_test(ExecutorTest ${GLOW_BINARY_DIR}/tests/ExecutorTest --gtest_output=xml:ExecutorTest.xml)
+
 add_executable(TensorsTest
                TensorsTest.cpp)
 target_link_libraries(TensorsTest

--- a/tests/unittests/ExecutorTest.cpp
+++ b/tests/unittests/ExecutorTest.cpp
@@ -1,0 +1,1063 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/Runtime/Executor/Executor.h"
+#include "glow/Backends/DeviceManager.h"
+#include "glow/Support/Support.h"
+#include "glow/Support/ThreadPool.h"
+
+#include "gtest/gtest.h"
+
+#include <chrono>
+#include <future>
+#include <thread>
+#include <unordered_set>
+
+using namespace glow;
+using namespace glow::runtime;
+
+/// This is an implementation of DeviceManager tailored for testing Executor
+/// implementations. registerResult() gives the caller the ability to
+/// dictate precisely what a subsequent call to runFunction() should return.
+/// registerResult() should be called before calling Executor::run() in each
+/// test. The rest of the implementation of the DeviceManager interface exists
+/// to satisfy the compiler.
+class TestDeviceManager final : public DeviceManager {
+public:
+  TestDeviceManager(unsigned numWorkers)
+      : DeviceManager(BackendKind::Interpreter), threadPool_(numWorkers) {}
+
+  /// The functions below are the interface for DeviceManager. See
+  /// glow::DeviceManager for descriptions of what they do. Since this
+  /// class exists only to help test Executor implementations, the only
+  /// important function is runFunction().
+  void init() override {}
+
+  void addNetwork(const Module *module, FunctionMapTy functions,
+                  ReadyCBTy readyCB) override {}
+
+  void evictNetwork(llvm::StringRef functionName) override {
+    // Erase the entry so that the same function name can be used to register
+    // another result.
+    resultMap_.erase(functionName);
+  }
+
+  /// Look up the previously registered response for \p functionName and
+  /// call \p resultCB with it after checking that \ctx contains the
+  /// expected Placeholder-Tensor mappings.
+  void doRunFunction(std::string functionName, std::shared_ptr<Context> ctx,
+                     ResultCBTy resultCB) {
+    RunIdentifierTy runId = 0;
+    ResultCode resultCode = ResultCode::Failed;
+    std::unique_ptr<Context> resultContext = nullptr;
+
+    // Retrieve the registered response for the function if there is one.
+    if (ctx && resultCB && resultMap_.count(functionName)) {
+      std::unique_ptr<RunFunctionResult> registeredResult =
+          std::move(resultMap_[functionName]);
+
+      // Check that ctx contains the expected Placeholder-Tensor mappings.
+      std::unique_ptr<Context> inputContext =
+          std::move(registeredResult->inputContext);
+
+      if (Context::compare(ctx.get(), inputContext.get())) {
+        // If ctx contains all expected mappings, overwrite the default
+        // runId, resultCode and resultContext with the registered ones.
+        runId = registeredResult->runId;
+        resultCode = registeredResult->resultCode;
+        resultContext = std::move(registeredResult->resultContext);
+      }
+    }
+
+    resultCB(runId, resultCode, std::move(resultContext));
+  }
+
+  /// Do not call this at the same time as registerResult().
+  runtime::RunIdentifierTy runFunction(std::string functionName,
+                                       std::unique_ptr<Context> ctx,
+                                       ResultCBTy resultCB) override {
+    // Give the call to the thread pool to process to make the tests
+    // multithreaded if needed.
+    std::shared_ptr<Context> sharedCtx = std::move(ctx);
+    this->threadPool_.submit([this, functionName, sharedCtx, resultCB]() {
+      this->doRunFunction(functionName, sharedCtx, resultCB);
+    });
+    return 0;
+  }
+
+  void stop(bool /*block*/) override {}
+
+  uint64_t getMaximumMemory() const override {
+    return std::numeric_limits<uint64_t>::max();
+  }
+
+  uint64_t getAvailableMemory() const override {
+    return std::numeric_limits<uint64_t>::max();
+  }
+
+  bool isMemoryAvailable(uint64_t /*estimate*/) const override { return true; }
+
+  /// Register a result that should be returned by the subsequent call to
+  /// runFunction with the same \p functionName. The callback for that call
+  /// to runFunction will be called with \p runId, \p resultCode, and \p
+  /// \p resultContext if the context passed in to runFunction matches \p
+  /// inputContext. \returns true if registration was successful, false if not.
+  /// Do not call this at the same time as runFunction().
+  bool registerResult(const std::string &functionName, RunIdentifierTy runId,
+                      ResultCode resultCode,
+                      std::unique_ptr<Context> inputContext,
+                      std::unique_ptr<Context> resultContext) {
+    bool registered = false;
+
+    if (!resultMap_.count(functionName)) {
+      // If the function name has not already been registered, insert it into
+      // resultMap_.
+      std::tie(std::ignore, registered) = resultMap_.insert(std::make_pair(
+          functionName, llvm::make_unique<RunFunctionResult>(
+                            runId, resultCode, std::move(inputContext),
+                            std::move(resultContext))));
+    }
+
+    return registered;
+  }
+
+private:
+  /// This struct wraps all of the data needed to reply to a runFunction() call.
+  /// It exists so that that all of these things can be stored in one map.
+  struct RunFunctionResult {
+    /// The run ID that should be returned.
+    RunIdentifierTy runId;
+    /// The result code that should be returned.
+    ResultCode resultCode;
+    /// The expected input Context for the invocation.
+    std::unique_ptr<Context> inputContext;
+    /// The result Context that should be returned.
+    std::unique_ptr<Context> resultContext;
+
+    /// Constructor.
+    RunFunctionResult(RunIdentifierTy run, ResultCode result,
+                      std::unique_ptr<Context> inputCtx,
+                      std::unique_ptr<Context> resultCtx)
+        : runId(run), resultCode(result), inputContext(std::move(inputCtx)),
+          resultContext(std::move(resultCtx)) {}
+  };
+
+  /// Map of function name -> RunFunctionResult instance containing the
+  /// RunFunctionResult instance for the function.
+  using TestDeviceManagerResultMapTy =
+      std::unordered_map<std::string, std::unique_ptr<RunFunctionResult>>;
+
+  /// Map for storing registered results.
+  TestDeviceManagerResultMapTy resultMap_;
+  /// Thread pool for executing runFunction() in a multithreaded fashion.
+  ThreadPool threadPool_;
+};
+
+using TestDeviceManagerMapTy =
+    std::unordered_map<DeviceIDTy, std::shared_ptr<TestDeviceManager>>;
+using PlaceholderNameMapTy =
+    std::unordered_map<std::string, std::unique_ptr<Placeholder>>;
+using DAGNodeNameMapTy =
+    std::unordered_map<std::string, std::unique_ptr<DAGNode>>;
+
+/// This class serves as an interface to a test created by ExecutorTestBuilder.
+/// It also contains the resources necessary to run the test. Instances are
+/// meant to be created only by ExecutorTestBuilder.
+class ExecutorTest final {
+public:
+  /// Constructor.
+  ExecutorTest(const std::shared_ptr<Executor> &executor,
+               std::unique_ptr<DAGNode> root, std::unique_ptr<Type> type,
+               DAGNodeNameMapTy nodes, PlaceholderNameMapTy placeholders,
+               std::unique_ptr<Context> inputCtx,
+               std::unique_ptr<Context> outputCtx, RunIdentifierTy runId,
+               ResultCode resultCode)
+      : executor_(executor), root_(std::move(root)), type_(std::move(type)),
+        nodes_(std::move(nodes)), placeholders_(std::move(placeholders)),
+        inputCtx_(std::move(inputCtx)), outputCtx_(std::move(outputCtx)),
+        runId_(runId), resultCode_(resultCode), testRun_(false) {}
+
+  /// Run the test.
+  bool run() {
+    if (testRun_) {
+      assert(!"Test has already been run!");
+    }
+
+    // Variables for storing runId and resultCode actually returned by
+    // Executor::run() via its callback.
+    RunIdentifierTy executorRunId;
+    ResultCode executorResultCode;
+    std::unique_ptr<Context> executorOutputCtx;
+
+    // Call Executor::run().
+    std::promise<void> promise;
+    std::future<void> future = promise.get_future();
+    executor_->run(root_.get(), std::move(inputCtx_), runId_,
+                   [&promise, &executorRunId, &executorResultCode,
+                    &executorOutputCtx](RunIdentifierTy runId, ResultCode code,
+                                        std::unique_ptr<Context> context) {
+                     executorRunId = runId;
+                     executorResultCode = code;
+                     executorOutputCtx = std::move(context);
+                     promise.set_value();
+                   });
+
+    future.wait();
+
+    // Check that the values returned in the Executor callback match
+    // expectations.
+    bool runIdsMatch = executorRunId == runId_;
+    bool resultCodesMatch = executorResultCode == resultCode_;
+    bool runFailed = executorResultCode == ResultCode::Failed;
+    bool contextsMatch =
+        Context::compare(executorOutputCtx.get(), outputCtx_.get());
+
+    // If the run failed, we shouldn't expect contextsMatch to be true.
+    bool testPassed =
+        runIdsMatch && resultCodesMatch && (runFailed || contextsMatch);
+
+    testRun_ = true;
+
+    return testPassed;
+  }
+
+private:
+  /// The Executor to run the test with.
+  std::shared_ptr<Executor> executor_;
+  /// The root node of the DAG being tested.
+  std::unique_ptr<DAGNode> root_;
+  /// The Type for all of the Placeholders that will be used during execution.
+  std::unique_ptr<Type> type_;
+  /// All nodes in the DAG.
+  DAGNodeNameMapTy nodes_;
+  /// All Placeholders that will be used during execution.
+  PlaceholderNameMapTy placeholders_;
+  /// The input Context that should be passed to Executor::run() when running
+  /// the test.
+  std::unique_ptr<Context> inputCtx_;
+  /// The expected Context that the Executor should return.
+  std::unique_ptr<Context> outputCtx_;
+  /// The run ID that should be passed to Executor::run() when running
+  /// the test.
+  RunIdentifierTy runId_;
+  /// The expected result code that the Executor should return.
+  ResultCode resultCode_;
+  /// Tracks whether or not the test has already been run.
+  bool testRun_;
+};
+
+/// This class helps build tests for testing Executor implementations. It
+/// presents a simple interface for executor DAG construction; nodes are added
+/// by specifying its parents, device ID, and named inputs and outputs. This
+/// builder class takes care of all of the work needed to actually run this DAG:
+/// creation of Placeholders and Tensors for all inputs and outputs; creation of
+/// input/output Context for each node to verify that each one receives the
+/// correct input and produces the correct output; and registration with
+/// the TestDeviceManager.
+class ExecutorTestBuilder final {
+public:
+  /// Constructor. The exact value of type_ doesn't really matter since the
+  /// important thing to test is that that Placeholder values are propagated
+  /// between Contexts correctly.
+  ExecutorTestBuilder(const std::shared_ptr<Executor> &executor,
+                      const TestDeviceManagerMapTy &deviceManagers)
+      : executor_(executor), root_(llvm::make_unique<DAGNode>()),
+        ctx_(llvm::make_unique<Context>()),
+        type_(
+            std::unique_ptr<Type>(new Type(ElemKind::FloatTy, {32, 64, 128}))),
+        resultCode_(ResultCode::Executed), deviceManagers_(deviceManagers) {}
+
+  /// Add a node named \p name to the DAG with parents \p parents that runs on a
+  /// device specified by \p deviceId. A RuntimeBundle is created for the node
+  /// with runtime symbol information created from \p inputs and \p outputs.
+  /// \p runId is the run ID for the node and \p resultCode is the desired
+  /// execution status. If \p parents is empty, the new node is added as a child
+  /// of the root.
+  void addNode(const std::string &name, DeviceIDTy deviceId,
+               llvm::ArrayRef<llvm::StringRef> parents,
+               llvm::ArrayRef<llvm::StringRef> inputs,
+               llvm::ArrayRef<llvm::StringRef> outputs, RunIdentifierTy runId,
+               ResultCode resultCode) {
+    auto newNode = llvm::make_unique<DAGNode>();
+    auto *newNodeRawPtr = newNode.get();
+
+    // If this is the first node being added, record the run ID for the graph.
+    // Otherwise, make sure that the runId matches that of the previous nodes.
+    if (nodes_.empty()) {
+      runId_ = runId;
+    } else {
+      assert(runId == runId_ && "Node run ID does not match rest of graph!");
+    }
+
+    // If the result code for this node is ResultCode::Failed, set the expected
+    // result code for the entire test to ResultCode::Failed.
+    resultCode_ = resultCode == ResultCode::Failed ? resultCode : resultCode_;
+
+    // Add parents to the list of parents in the new node and add the newNode
+    // to the list of children in the parents. If the parent list is empty,
+    // make the root the only parent. Also, update the set of known leaves
+    // by removing any parents of the new node from it. This will be useful
+    // later.
+    if (!parents.empty()) {
+      for (const auto &parent : parents) {
+        auto it = nodes_.find(parent);
+        if (it == nodes_.end()) {
+          assert(!"Parent specified for node not found!");
+        }
+        DAGNode *parentPtr = (it->second).get();
+        (newNode->parents).emplace_back(parentPtr);
+        (parentPtr->children).emplace_back(newNodeRawPtr);
+        leaves_.erase(parentPtr);
+      }
+    } else {
+      (newNode->parents).emplace_back(root_.get());
+      (root_->children).emplace_back(newNode.get());
+    }
+
+    // Iterate through inputs and outputs and:
+    // 1) Create Placeholders and Tensors for inputs/output names that have not
+    //    been mapped to a Placeholder yet.
+    // 2) Assemble the input Context that the node is expected to be called with
+    //    and the Context that the node should produce as output.
+    // 3) Generate the symbol table for the new node by generating
+    //    RuntimeSymbolInfo objects for each input and output.
+    SymbolTableTy symbolTable;
+    size_t offset = 0;
+
+    auto nodeInputCtx = llvm::make_unique<Context>();
+    auto nodeOutputCtx = llvm::make_unique<Context>();
+
+    for (const auto &input : inputs) {
+      insertSymbolIntoContext(input, nodeInputCtx.get());
+
+      RuntimeSymbolInfo runtimeSymbolInfo{
+          /*size=*/type_->getSizeInBytes(), /*offset=*/offset,
+          /*type=*/*type_, /*input=*/true, /*output=*/false};
+      symbolTable.insert(std::make_pair(input, runtimeSymbolInfo));
+      offset += type_->getSizeInBytes();
+    }
+
+    for (const auto &output : outputs) {
+      insertSymbolIntoContext(output, nodeOutputCtx.get());
+
+      RuntimeSymbolInfo runtimeSymbolInfo{
+          /*size=*/type_->getSizeInBytes(), /*offset=*/offset,
+          /*type=*/*type_, /*input=*/false, /*output=*/true};
+      symbolTable.insert(std::make_pair(output, runtimeSymbolInfo));
+      offset += type_->getSizeInBytes();
+    }
+
+    // Set the name, device ID, and RuntimeBundle of the new node.
+    newNode->name = name;
+    newNode->deviceID = deviceId;
+    newNode->runtimeBundle =
+        RuntimeBundle(symbolTable, /*constWeight=*/0, /*mutableWeight=*/0,
+                      /*activations=*/0);
+
+    // Register node result with the appropriate DeviceManager.
+    auto it = deviceManagers_.find(deviceId);
+
+    if (it == deviceManagers_.end()) {
+      assert(!"No test device manager found for this device ID");
+    }
+
+    std::shared_ptr<TestDeviceManager> deviceManager = it->second;
+    bool registered = deviceManager->registerResult(name, runId, resultCode,
+                                                    std::move(nodeInputCtx),
+                                                    std::move(nodeOutputCtx));
+
+    (void)registered;
+    assert(registered && "Node registration was not successful");
+
+    // Add the new node to nodes_ and leaves_.
+    nodes_.insert(std::make_pair(name, std::move(newNode)));
+    leaves_.insert(newNodeRawPtr);
+  }
+
+  /// Emit the test built so far and clear any state in the builder.
+  ExecutorTest emitTest() {
+    // Get the input and output symbol names for the whole DAG.
+    std::vector<std::string> inputSymbols = gatherInputSymbols();
+    std::vector<std::string> outputSymbols = gatherOutputSymbols();
+
+    // Generate the input and output Contexts for the test. This input Context
+    // contains the input Placeholders of all root nodes and output Placeholders
+    // of all leaves (but backed by zero tensors). This is the Context that
+    // needs to be passed to Executor::run() to run the test. The output Context
+    // contains the same Placeholders as the input Context, but the leaves'
+    // output Placeholders are mapped to their expected output Tensors. This
+    // Context is used to verify that the one returned by the Executor is
+    // correct.
+    auto inputCtx = llvm::make_unique<Context>();
+    auto outputCtx = llvm::make_unique<Context>();
+
+    for (const auto &symbol : inputSymbols) {
+      insertSymbolIntoContext(symbol, inputCtx.get());
+      insertSymbolIntoContext(symbol, outputCtx.get());
+    }
+
+    for (const auto &symbol : outputSymbols) {
+      auto *placeholder = ctx_->getPlaceholderByName(symbol);
+      if (!placeholder) {
+        assert(!"Placeholder for DAG output not found!");
+      }
+      inputCtx->allocate(placeholder)->zero();
+      insertSymbolIntoContext(symbol, outputCtx.get());
+    }
+
+    // Create the test object.
+    ExecutorTest test(executor_, std::move(root_), std::move(type_),
+                      std::move(nodes_), std::move(placeholders_),
+                      std::move(inputCtx), std::move(outputCtx), runId_,
+                      resultCode_);
+
+    // Reset builder state to allow a new test to be constructed with this
+    // instance.
+    root_ = llvm::make_unique<DAGNode>();
+    ctx_->clear();
+    type_ = std::unique_ptr<Type>(new Type(ElemKind::FloatTy, {1, 2, 2}));
+    nodes_.clear();
+    leaves_.clear();
+    placeholders_.clear();
+    resultCode_ = ResultCode::Executed;
+
+    return test;
+  }
+
+private:
+  /// Collect all input symbol names for the test. \returns a vector containing
+  /// the names of all test input symbols.
+  std::vector<std::string> gatherInputSymbols() const {
+    std::vector<std::string> inputSymbols;
+
+    // Input symbols for the entire test are the inputs of all nodes that have
+    // no parents.
+    for (const auto &node : root_->children) {
+      const SymbolTableTy &symbolTable = (node->runtimeBundle).getSymbolTable();
+
+      for (const auto &symbolPair : symbolTable) {
+        const auto &symbolName = symbolPair.first;
+        const auto &symbolInfo = symbolPair.second;
+
+        if (symbolInfo.input) {
+          inputSymbols.emplace_back(symbolName);
+        }
+      }
+    }
+
+    return inputSymbols;
+  }
+
+  /// Collect all output symbol names for the test. \returns a vector containing
+  /// the names of all test output symbols.
+  std::vector<std::string> gatherOutputSymbols() const {
+    std::vector<std::string> outputSymbols;
+
+    // Input symbols for the entire test are the outputs of all nodes that have
+    // no children.
+    for (const auto &node : leaves_) {
+      const SymbolTableTy &symbolTable = (node->runtimeBundle).getSymbolTable();
+
+      for (const auto &symbolPair : symbolTable) {
+        const auto &symbolName = symbolPair.first;
+        const auto &symbolInfo = symbolPair.second;
+
+        if (symbolInfo.output) {
+          outputSymbols.emplace_back(symbolName);
+        }
+      }
+    }
+
+    return outputSymbols;
+  }
+
+  /// Insert a Placeholder named \p name with type type_ into \p context
+  /// and generate a random Tensor for it. If this Placeholder has already been
+  /// mapped for the test being created, reuse the existing value.
+  void insertSymbolIntoContext(llvm::StringRef name, Context *context) {
+    auto it = placeholders_.find(name);
+
+    if (it == placeholders_.end()) {
+      // This is a new symbol. Create a Placeholder and an initialize and new
+      // Tensor for it.
+      auto placeholder = llvm::make_unique<Placeholder>(name, type_.get(),
+                                                        /*trainable=*/false);
+      auto *tensor = ctx_->allocate(placeholder.get());
+      tensor->init(Tensor::InitKind::Xavier, 1.0, rng_);
+      context->insert(placeholder.get(), tensor->clone());
+      placeholders_[name] = std::move(placeholder);
+    } else {
+      // This is a symbol that already has an associated Placeholder and Tensor.
+      // Copy that Tensor.
+      auto *placeholder = (it->second).get();
+      const auto *tensor = ctx_->get(placeholder);
+      context->insert(placeholder, tensor->clone());
+    }
+  }
+
+  /// The Executor being tested.
+  std::shared_ptr<Executor> executor_;
+  /// The root of the DAG being constructed.
+  std::unique_ptr<DAGNode> root_;
+  /// This Context holds all created and initialized Placeholders for the test.
+  std::unique_ptr<Context> ctx_;
+  /// The Type for all Placeholders and Tensors in the test. The exact value
+  /// is not important; the main thing being tested is the propagation of
+  /// Placeholders and Tensors as the DAG executes.
+  std::unique_ptr<Type> type_;
+  /// PRNG for filling Tensors.
+  PseudoRNG rng_;
+  /// The nodes in the DAG being constructed.
+  DAGNodeNameMapTy nodes_;
+  /// The leaves in the DAG being constructed. This helps collect output symbols
+  /// during test emission.
+  std::unordered_set<const DAGNode *> leaves_;
+  /// All Placeholders in the test.
+  PlaceholderNameMapTy placeholders_;
+  /// The run ID for the DAG.
+  RunIdentifierTy runId_;
+  /// The expected result code for the DAG.
+  ResultCode resultCode_;
+  /// Map from DeviceIDTy -> TestDeviceManager. This enables the construction of
+  /// tests with nodes spread across devices.
+  const TestDeviceManagerMapTy &deviceManagers_;
+};
+
+/// This test fixture provides ThreadPoolExecutor, ExecutorTestBuilder,
+/// DeviceManagerMapTy, and TestDeviceManagerMapTy instances to all tests.
+class ThreadPoolExecutorTest : public ::testing::Test {
+protected:
+  ThreadPoolExecutorTest()
+      : executor_(std::shared_ptr<Executor>(
+            createExecutor(deviceManagerMap_, ExecutorKind::ThreadPool))),
+        testBuilder_(executor_, testDeviceManagerMap_) {}
+  ~ThreadPoolExecutorTest() = default;
+
+  /// The Executor being tested.
+  std::shared_ptr<Executor> executor_;
+  /// An ExecutorTestBuilder instance for creating tests.
+  ExecutorTestBuilder testBuilder_;
+  /// DeviceManager map for initializing executor_.
+  Executor::DeviceManagerMapTy deviceManagerMap_;
+  /// TestDeviceManager map for initializing testBuilder_.
+  TestDeviceManagerMapTy testDeviceManagerMap_;
+};
+
+/// Tests that an empty DAG is handled correctly.
+TEST_F(ThreadPoolExecutorTest, EmptyDAG) {
+  constexpr RunIdentifierTy testRunId = 10;
+
+  // Make a Context with one Placeholder in it to make sure Executor::run()
+  // doesn't modify it when the root given to it is null. Make two identical
+  // copies; one to give to Executor::run(), and another to compare the
+  // returned Context with.
+  PseudoRNG rng;
+  auto type = std::unique_ptr<Type>(new Type(ElemKind::FloatTy, {1, 2, 2}));
+  auto placeholder = llvm::make_unique<Placeholder>("a", type.get(),
+                                                    /*trainable=*/false);
+  auto testCtx = llvm::make_unique<Context>();
+  auto refCtx = llvm::make_unique<Context>();
+  auto *tensor = testCtx->allocate(placeholder.get());
+  tensor->init(Tensor::InitKind::Xavier, 1.0, rng);
+  refCtx->insert(placeholder.get(), tensor->clone());
+
+  // Variables for storing runId and resultCode actually returned by
+  // Executor::run() via its callback.
+  RunIdentifierTy executorRunId;
+  ResultCode executorResultCode;
+  std::unique_ptr<Context> executorOutputCtx;
+
+  // Call Executor::run().
+  std::promise<void> promise;
+  std::future<void> future = promise.get_future();
+  executor_->run(nullptr, std::move(testCtx), testRunId,
+                 [&promise, &executorRunId, &executorResultCode,
+                  &executorOutputCtx](RunIdentifierTy runId, ResultCode code,
+                                      std::unique_ptr<Context> context) {
+                   executorRunId = runId;
+                   executorResultCode = code;
+                   executorOutputCtx = std::move(context);
+                   promise.set_value();
+                 });
+
+  future.wait();
+
+  EXPECT_EQ(executorRunId, testRunId);
+  EXPECT_EQ(executorResultCode, ResultCode::Executed);
+  EXPECT_TRUE(Context::compare(refCtx.get(), executorOutputCtx.get()));
+}
+
+/// Tests that a single node can run correctly.
+TEST_F(ThreadPoolExecutorTest, SingleNode) {
+  constexpr RunIdentifierTy testRunId = 10;
+  constexpr DeviceIDTy testDeviceId = 111;
+  constexpr unsigned deviceManagerThreads = 1;
+
+  // Make a TestDeviceManager and insert into the DeviceManagerMap map (which
+  // the ThreadPoolExecutor has a reference to) and the TestDeviceManager map
+  // (which the ExecutorTestBuilder has a reference to).
+  auto deviceManager =
+      std::make_shared<TestDeviceManager>(deviceManagerThreads);
+  deviceManagerMap_.insert(std::make_pair(testDeviceId, deviceManager));
+  testDeviceManagerMap_.insert(std::make_pair(testDeviceId, deviceManager));
+
+  // Build the DAG. The DAG created below looks like this:
+  /**
+   *         root
+   *          |
+   *          v
+   *         net
+   **/
+
+  testBuilder_.addNode("net", testDeviceId,
+                       /*parents=*/{}, {"netInput"}, {"netOutput"}, testRunId,
+                       ResultCode::Executed);
+
+  ExecutorTest test = testBuilder_.emitTest();
+  EXPECT_TRUE(test.run());
+}
+
+/// Tests that several instances of a single node DAG can be run in parallel.
+TEST_F(ThreadPoolExecutorTest, ConcurrentSingleNode) {
+  constexpr RunIdentifierTy baseTestRunId = 10;
+  constexpr DeviceIDTy testDeviceId = 111;
+  constexpr unsigned deviceManagerThreads = 3;
+  constexpr unsigned numConcurrentRuns = 1000;
+
+  // Make a TestDeviceManager and insert into the DeviceManagerMap map (which
+  // the ThreadPoolExecutor has a reference to) and the TestDeviceManager map
+  // (which the ExecutorTestBuilder has a reference to).
+  auto deviceManager =
+      std::make_shared<TestDeviceManager>(deviceManagerThreads);
+  deviceManagerMap_.insert(std::make_pair(testDeviceId, deviceManager));
+  testDeviceManagerMap_.insert(std::make_pair(testDeviceId, deviceManager));
+
+  // Mutex for accessing threadsReady and testsPassed.
+  std::mutex mtx;
+  // Condition variables for signalling between the test runner threads
+  // and this thread. These are used to implement a barrier that ensures
+  // all test runner threads have been created and are executing before any
+  // are allowed to run a test (in order to try and increase the number of
+  // threads that call Executor::run() at the same time).
+  std::condition_variable driverCV, threadCV;
+  // Counters for implementing the aforementioned barrier and tracking the
+  // number of tests that pass.
+  unsigned threadsReady = 0, testsPassed = 0;
+  std::vector<std::thread> threads;
+  for (unsigned i = 0; i < numConcurrentRuns; ++i) {
+    // Build the DAG. The DAG created below looks like this:
+    /**
+     *         root
+     *          |
+     *          v
+     *         net
+     **/
+
+    // The names must be distinct since the DeviceManager distinguishes based
+    // on function name. The run IDs must also be distinct (hence the +i).
+    testBuilder_.addNode(strFormat("net_%d", i), testDeviceId,
+                         /*parents=*/{}, {"netInput"}, {"netOutput"},
+                         baseTestRunId + i, ResultCode::Executed);
+    ExecutorTest t = testBuilder_.emitTest();
+
+    std::thread th([&mtx, &driverCV, &threadCV, &threadsReady, &testsPassed,
+                    test = std::move(t)]() mutable {
+      std::unique_lock<std::mutex> lock(mtx);
+      // Increment threadsReady to mark this thread as ready to run the test.
+      threadsReady++;
+      // If threadsReady == numConcurrentRuns, this thread is the last to be
+      // initialized and execute, so signal the driver that all threads are
+      // ready.
+      if (threadsReady == numConcurrentRuns) {
+        driverCV.notify_one();
+      }
+      // Wait for the driver's signal.
+      threadCV.wait(lock);
+      // Unlock the mutex to let all other threads run their tests concurrently.
+      lock.unlock();
+      bool passed = test.run();
+      lock.lock();
+
+      if (passed) {
+        testsPassed++;
+      }
+    });
+    threads.emplace_back(std::move(th));
+  }
+
+  std::unique_lock<std::mutex> lock(mtx);
+  // If threadsReady != numConcurrentRuns, not all threads are ready to run
+  // their tests. Wait until they are.
+  if (threadsReady != numConcurrentRuns) {
+    driverCV.wait(lock);
+  }
+  // Wake up all test runners.
+  threadCV.notify_all();
+  lock.unlock();
+
+  // Join all threads.
+  for (unsigned i = 0; i < numConcurrentRuns; ++i) {
+    threads[i].join();
+  }
+
+  // All tests should pass.
+  EXPECT_EQ(testsPassed, numConcurrentRuns);
+}
+
+/// Tests that successive calls to ThreadPoolExecutor::run() with the same
+/// runId returns ResultCode::Failed.
+TEST_F(ThreadPoolExecutorTest, ConcurrentSingleNodeDuplicateRunId) {
+  constexpr RunIdentifierTy testRunId = 10;
+  constexpr DeviceIDTy testDeviceId = 111;
+  constexpr unsigned deviceManagerThreads = 1;
+  constexpr unsigned numConcurrentRuns = 100;
+
+  // Make a TestDeviceManager and insert into the DeviceManagerMap map (which
+  // the ThreadPoolExecutor has a reference to) and the TestDeviceManager map
+  // (which the ExecutorTestBuilder has a reference to).
+  auto deviceManager =
+      std::make_shared<TestDeviceManager>(deviceManagerThreads);
+  deviceManagerMap_.insert(std::make_pair(testDeviceId, deviceManager));
+  testDeviceManagerMap_.insert(std::make_pair(testDeviceId, deviceManager));
+
+  std::atomic<unsigned> testsPassed{0};
+  std::vector<std::thread> threads;
+  std::vector<ExecutorTest> tests;
+
+  // Build all tests.
+  for (unsigned i = 0; i < numConcurrentRuns; ++i) {
+    // Build the DAG. The DAG created below looks like this:
+    /**
+     *         root
+     *          |
+     *          v
+     *         net
+     **/
+
+    testBuilder_.addNode(strFormat("net_%d", i), testDeviceId,
+                         /*parents=*/{}, {"netInput"}, {"netOutput"}, testRunId,
+                         ResultCode::Executed);
+    tests.emplace_back(testBuilder_.emitTest());
+  }
+
+  // Run all tests.
+  for (unsigned i = 0; i < numConcurrentRuns; ++i) {
+    std::thread th([&testsPassed, test = std::move(tests[i])]() mutable {
+      bool passed = test.run();
+      if (passed) {
+        testsPassed++;
+      }
+    });
+    threads.emplace_back(std::move(th));
+  }
+
+  // Join all threads.
+  for (unsigned i = 0; i < numConcurrentRuns; ++i) {
+    threads[i].join();
+  }
+
+  // At least one test should pass. Depending on the interleaving, the
+  // rest can all pass or all fail or anything in between.
+  EXPECT_GE(testsPassed, 1);
+}
+
+/// Tests that a DAG with multiple nodes can run correctly.
+TEST_F(ThreadPoolExecutorTest, MultiNode) {
+  constexpr RunIdentifierTy testRunId = 10;
+  constexpr DeviceIDTy testDeviceId = 111;
+  constexpr unsigned deviceManagerThreads = 3;
+
+  // Make a TestDeviceManager and insert into the DeviceManagerMap map (which
+  // the ThreadPoolExecutor has a reference to) and the TestDeviceManager map
+  // (which the ExecutorTestBuilder has a reference to).
+  auto deviceManager =
+      std::make_shared<TestDeviceManager>(deviceManagerThreads);
+  deviceManagerMap_.insert(std::make_pair(testDeviceId, deviceManager));
+  testDeviceManagerMap_.insert(std::make_pair(testDeviceId, deviceManager));
+
+  // Build the DAG. The DAG created below looks like this:
+  /**
+   *           root
+   *         /      \
+   *        v       v
+   *      alpha    beta
+   *        \       /
+   *         v     v
+   *          gamma
+   *         /    \
+   *        v     v
+   *     delta   eps
+   **/
+
+  testBuilder_.addNode("alpha", testDeviceId,
+                       /*parents=*/{}, /*inputs=*/{"alphaIn"},
+                       /*outputs=*/{"alphaOut"}, testRunId,
+                       ResultCode::Executed);
+  testBuilder_.addNode("beta", testDeviceId,
+                       /*parents=*/{}, /*inputs=*/{"betaIn"},
+                       /*outputs=*/{"betaOut"}, testRunId,
+                       ResultCode::Executed);
+  testBuilder_.addNode("gamma", testDeviceId,
+                       /*parents=*/{"alpha", "beta"},
+                       /*inputs=*/{"alphaOut", "betaOut"},
+                       /*outputs=*/{"deltaIn", "epsIn"}, testRunId,
+                       ResultCode::Executed);
+  testBuilder_.addNode("delta", testDeviceId,
+                       /*parents=*/{"gamma"}, /*inputs=*/{"deltaIn"},
+                       /*outputs=*/{"deltaOut"}, testRunId,
+                       ResultCode::Executed);
+  testBuilder_.addNode("eps", testDeviceId,
+                       /*parents=*/{"gamma"}, /*inputs=*/{"epsIn"},
+                       /*outputs=*/{"epsOut"}, testRunId, ResultCode::Executed);
+
+  ExecutorTest test = testBuilder_.emitTest();
+  EXPECT_TRUE(test.run());
+}
+
+/// Tests that a DAG with a node that fails can run correctly.
+TEST_F(ThreadPoolExecutorTest, MultiNodeWithFailure) {
+  constexpr RunIdentifierTy testRunId = 10;
+  constexpr DeviceIDTy testDeviceId = 111;
+  constexpr unsigned deviceManagerThreads = 3;
+
+  // Make a TestDeviceManager and insert into the DeviceManagerMap map (which
+  // the ThreadPoolExecutor has a reference to) and the TestDeviceManager map
+  // (which the ExecutorTestBuilder has a reference to).
+  auto deviceManager =
+      std::make_shared<TestDeviceManager>(deviceManagerThreads);
+  deviceManagerMap_.insert(std::make_pair(testDeviceId, deviceManager));
+  testDeviceManagerMap_.insert(std::make_pair(testDeviceId, deviceManager));
+
+  // Build the DAG. The DAG created below looks like this:
+  /**
+   *             root
+   *           /      \
+   *          v       v
+   *        alpha    delta
+   *          |       |
+   *          v       v
+   *        beta     eps
+   *          |       |
+   *          v       v
+   *        gamma    zeta
+   **/
+
+  testBuilder_.addNode("alpha", testDeviceId,
+                       /*parents=*/{}, /*inputs=*/{"alphaIn"},
+                       /*outputs=*/{"alphaOut"}, testRunId,
+                       ResultCode::Executed);
+  testBuilder_.addNode("beta", testDeviceId,
+                       /*parents=*/{"alpha"}, /*inputs=*/{"alphaOut"},
+                       /*outputs=*/{"betaOut"}, testRunId,
+                       ResultCode::Executed);
+  testBuilder_.addNode("gamma", testDeviceId,
+                       /*parents=*/{"beta"},
+                       /*inputs=*/{"betaOut"},
+                       /*outputs=*/{"gammaOut"}, testRunId,
+                       ResultCode::Executed);
+  testBuilder_.addNode("delta", testDeviceId,
+                       /*parents=*/{}, /*inputs=*/{"deltaIn"},
+                       /*outputs=*/{"deltaOut"}, testRunId,
+                       ResultCode::Executed);
+  testBuilder_.addNode("eps", testDeviceId,
+                       /*parents=*/{"delta"}, /*inputs=*/{"deltaOut"},
+                       /*outputs=*/{"epsOut"}, testRunId, ResultCode::Failed);
+  testBuilder_.addNode("zeta", testDeviceId,
+                       /*parents=*/{"eps"}, /*inputs=*/{"epsOut"},
+                       /*outputs=*/{"zetaOut"}, testRunId,
+                       ResultCode::Executed);
+
+  ExecutorTest test = testBuilder_.emitTest();
+  EXPECT_TRUE(test.run());
+}
+
+/// Tests that a DAG with nodes spread across multiple devices can run
+/// correctly.
+TEST_F(ThreadPoolExecutorTest, MultiNodeMultiDevice) {
+  constexpr RunIdentifierTy testRunId = 10;
+  constexpr DeviceIDTy testDeviceIdA = 111;
+  constexpr DeviceIDTy testDeviceIdB = 112;
+  constexpr DeviceIDTy testDeviceIdC = 113;
+  constexpr unsigned deviceManagerThreads = 3;
+
+  // Make TestDeviceManagers and insert them into the DeviceManagerMap map
+  // (which the ThreadPoolExecutor has a reference to) and the TestDeviceManager
+  // map (which the ExecutorTestBuilder has a reference to).
+  for (DeviceIDTy deviceId : {testDeviceIdA, testDeviceIdB, testDeviceIdC}) {
+    auto deviceManager =
+        std::make_shared<TestDeviceManager>(deviceManagerThreads);
+    deviceManagerMap_.insert(std::make_pair(deviceId, deviceManager));
+    testDeviceManagerMap_.insert(std::make_pair(deviceId, deviceManager));
+  }
+
+  // Build the DAG. The DAG created below looks like this:
+  /**
+   *           root
+   *         /      \
+   *        v       v
+   *      alpha    beta
+   *        \       /
+   *         v     v
+   *          gamma
+   *         /    \
+   *        v     v
+   *     delta   eps
+   **/
+
+  testBuilder_.addNode("alpha", testDeviceIdA,
+                       /*parents=*/{}, /*inputs=*/{"alphaIn"},
+                       /*outputs=*/{"alphaOut"}, testRunId,
+                       ResultCode::Executed);
+  testBuilder_.addNode("beta", testDeviceIdB,
+                       /*parents=*/{}, /*inputs=*/{"betaIn"},
+                       /*outputs=*/{"betaOut"}, testRunId,
+                       ResultCode::Executed);
+  testBuilder_.addNode("gamma", testDeviceIdC,
+                       /*parents=*/{"alpha", "beta"},
+                       /*inputs=*/{"alphaOut", "betaOut"},
+                       /*outputs=*/{"deltaIn", "epsIn"}, testRunId,
+                       ResultCode::Executed);
+  testBuilder_.addNode("delta", testDeviceIdA,
+                       /*parents=*/{"gamma"}, /*inputs=*/{"deltaIn"},
+                       /*outputs=*/{"deltaOut"}, testRunId,
+                       ResultCode::Executed);
+  testBuilder_.addNode("eps", testDeviceIdB,
+                       /*parents=*/{"gamma"}, /*inputs=*/{"epsIn"},
+                       /*outputs=*/{"epsOut"}, testRunId, ResultCode::Executed);
+
+  ExecutorTest test = testBuilder_.emitTest();
+  EXPECT_TRUE(test.run());
+}
+
+/// Tests that several instances of a DAG with multiple nodes can run correctly
+/// in parallel.
+TEST_F(ThreadPoolExecutorTest, ConcurrentMultiNode) {
+  constexpr RunIdentifierTy baseTestRunId = 10;
+  constexpr DeviceIDTy testDeviceId = 111;
+  constexpr unsigned deviceManagerThreads = 3;
+  constexpr unsigned numConcurrentRuns = 1000;
+
+  // Make a TestDeviceManager and insert it into the DeviceManagerMap map
+  // (which the ThreadPoolExecutor has a reference to) and the TestDeviceManager
+  // map (which the ExecutorTestBuilder has a reference to).
+  auto deviceManager =
+      std::make_shared<TestDeviceManager>(deviceManagerThreads);
+  deviceManagerMap_.insert(std::make_pair(testDeviceId, deviceManager));
+  testDeviceManagerMap_.insert(std::make_pair(testDeviceId, deviceManager));
+
+  // Mutex for accessing threadsReady and testsPassed.
+  std::mutex mtx;
+  // Condition variables for signalling between the test runner threads
+  // and this thread. These are used to implement a barrier that ensures
+  // all test runner threads have been created and are executing before any
+  // are allowed to run a test (in order to try and increase the number of
+  // threads that call Executor::run() at the same time).
+  std::condition_variable driverCV, threadCV;
+  // Counters for implementing the aforementioned barrier and tracking the
+  // number of tests that pass.
+  unsigned threadsReady = 0, testsPassed = 0;
+  std::vector<std::thread> threads;
+  for (unsigned i = 0; i < numConcurrentRuns; ++i) {
+    // Build the DAG. The DAG created below looks like this:
+    /**
+     *           root
+     *         /      \
+     *        v       v
+     *      alpha    beta
+     *        \       /
+     *         v     v
+     *          gamma
+     *         /    \
+     *        v     v
+     *     delta   eps
+     **/
+
+    // The names must be distinct for each run since the DeviceManager
+    // distinguishes based on function name.
+    std::string alpha = strFormat("alpha_%d", i);
+    std::string beta = strFormat("beta_%d", i);
+    std::string gamma = strFormat("gamma_%d", i);
+    std::string delta = strFormat("delta_%d", i);
+    std::string eps = strFormat("eps_%d", i);
+
+    // The run IDs must be distinct as well to distinguish all the concurrent
+    // runs from each other.
+    testBuilder_.addNode(alpha, testDeviceId,
+                         /*parents=*/{}, /*inputs=*/{"alphaIn"},
+                         /*outputs=*/{"alphaOut"}, baseTestRunId + i,
+                         ResultCode::Executed);
+    testBuilder_.addNode(beta, testDeviceId,
+                         /*parents=*/{}, /*inputs=*/{"betaIn"},
+                         /*outputs=*/{"betaOut"}, baseTestRunId + i,
+                         ResultCode::Executed);
+    testBuilder_.addNode(gamma, testDeviceId,
+                         /*parents=*/{alpha, beta},
+                         /*inputs=*/{"alphaOut", "betaOut"},
+                         /*outputs=*/{"deltaIn", "epsIn"}, baseTestRunId + i,
+                         ResultCode::Executed);
+    testBuilder_.addNode(delta, testDeviceId,
+                         /*parents=*/{gamma}, /*inputs=*/{"deltaIn"},
+                         /*outputs=*/{"deltaOut"}, baseTestRunId + i,
+                         ResultCode::Executed);
+    testBuilder_.addNode(eps, testDeviceId,
+                         /*parents=*/{gamma}, /*inputs=*/{"epsIn"},
+                         /*outputs=*/{"epsOut"}, baseTestRunId + i,
+                         ResultCode::Executed);
+
+    ExecutorTest t = testBuilder_.emitTest();
+    std::thread th([&mtx, &driverCV, &threadCV, &threadsReady, &testsPassed,
+                    test = std::move(t)]() mutable {
+      std::unique_lock<std::mutex> lock(mtx);
+      // Increment threadsReady to mark this thread as ready to run the test.
+      threadsReady++;
+      // If threadsReady == numConcurrentRuns, this thread is the last to be
+      // initialized and execute, so signal the driver that all threads are
+      // ready.
+      if (threadsReady == numConcurrentRuns) {
+        driverCV.notify_one();
+      }
+      // Wait for the driver's signal.
+      threadCV.wait(lock);
+      // Unlock the mutex to let all other threads run their tests concurrently.
+      lock.unlock();
+      bool passed = test.run();
+      lock.lock();
+
+      if (passed) {
+        testsPassed++;
+      }
+    });
+    threads.emplace_back(std::move(th));
+  }
+
+  std::unique_lock<std::mutex> lock(mtx);
+  // If threadsReady != numConcurrentRuns, not all threads are ready to run
+  // their tests. Wait until they are.
+  if (threadsReady != numConcurrentRuns) {
+    driverCV.wait(lock);
+  }
+  // Wake up all test runners.
+  threadCV.notify_all();
+  lock.unlock();
+
+  // Join all threads.
+  for (unsigned i = 0; i < numConcurrentRuns; ++i) {
+    threads[i].join();
+  }
+
+  // All tests should pass.
+  EXPECT_EQ(testsPassed, numConcurrentRuns);
+}


### PR DESCRIPTION
**Description**
This commit adds `Executor`, an interface for a component of the Glow
runtime that is capable of running a partitioned directed acyclic Glow
graph and returning the results of that execution. This commit also adds
`ThreadPoolExecutor`, an implementation of this interface that runs
graphs using a thread pool. The  workers essentially do a
concurrent breadth-first search through the node graph to execute all
nodes, repeatedly copying partition components outputs to their descendents along
the way.

**Testing**
This commit adds eight unit tests for the following scenarios:
- empty graph
- single node
- several instances of a single node graph at once
- duplicate runIds
- multi node graph
- multi node graph with a node that fails
- multi node graph with nodes running on multiple devices
- several instances of a multi node graph at once

**Documentation**
Comments.
