### PR TITLE
More shared library fixes

### DIFF
--- a/lib/Backends/CPU/CMakeLists.txt
+++ b/lib/Backends/CPU/CMakeLists.txt
@@ -18,7 +18,7 @@ set(CPURunttimeCompileOptions
       -ffast-math
       -fno-finite-math-only
       -g0
-      -emit-llvm 
+      -emit-llvm
       -O0)
 
 set(libjit_files "libjit;libjit_conv;libjit_matmul")
@@ -82,7 +82,7 @@ add_library(CPUBackend
 
 llvm_map_components_to_libnames(LLVM_TARGET_LIBRARIES ${LLVM_TARGETS_TO_BUILD})
 target_link_libraries(CPUBackend
-                      PRIVATE
+                      PUBLIC
                         Base
                         CodeGen
                         BackendUtils

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -4,10 +4,8 @@ add_library(Support
               Random.cpp
               Support.cpp)
 target_link_libraries(Support
-                      PRIVATE
+                      PUBLIC
                         LLVMSupport)
 
 add_library(ThreadPool
               ThreadPool.cpp)
-
-


### PR DESCRIPTION
*Description*: that's it
*Testing*: On CentOS 7 (or at least FB's variant):`cmake ../.. -G Ninja -DBUILD_SHARED_LIBS=ON  -DGLOW_WITH_OPENCL=OFF && ninja all`
*Documentation*: n/a
