### PR TITLE
[Improvement] Custom translation from Node IR

### DIFF
--- a/docs/Backends.md
+++ b/docs/Backends.md
@@ -96,6 +96,11 @@ Additionally, there are virtual functions that backends can override:
     provided `Function *F` is compiled and then saved to `outputDir` with main
     entry name `networkName`.
 
+- `virtual bool generateInst(Node *N, IRGenVisitor &irgen) const;`
+
+  - Allow the backend to custom lower from Node to Instruction IR. 
+    Returns true if lowering is performed, false otherwise.
+
 ### `CompiledFunction` Abstract Class
 
 `CompiledFunction` is an abstract class that represents the result of

--- a/include/glow/Backends/Backend.h
+++ b/include/glow/Backends/Backend.h
@@ -27,6 +27,7 @@ namespace glow {
 class IRFunction;
 class Node;
 class Context;
+class IRGenVisitor;
 
 enum class BackendKind {
   Interpreter, // Execute the network with the built-in interpreter.
@@ -85,6 +86,12 @@ public:
 
   /// Optimize the Function \p F given compilation mode \p mode.
   void optimizeFunction(CompilationMode mode, Function *F);
+
+  /// \returns true if Backend generated Instruction for Node \p N,
+  /// using IRGenVisitor \p irgen.
+  virtual bool generateInst(Node *N, IRGenVisitor &irgen) const {
+    return false;
+  }
 };
 
 /// Create a backend of kind \p kind.

--- a/include/glow/IR/IR.h
+++ b/include/glow/IR/IR.h
@@ -232,6 +232,7 @@ private:
   void createNode(const Instruction &);
 };
 
+class Backend;
 class WeightVar;
 class Value;
 class Node;
@@ -276,7 +277,8 @@ public:
 
   /// Generate IR from the graph nodes. If the compilation mode is 'training'
   /// then this procedure will also generate the code for the backward pass.
-  void generateIR();
+  /// It allows Backend /p B to custom translate from a Node to Instruction IR.
+  void generateIR(const Backend &B);
 
   /// Wipe out the content of the function. This allows the function to be used
   /// again for another round of code generation.

--- a/include/glow/IR/IRGen.h
+++ b/include/glow/IR/IRGen.h
@@ -1,0 +1,82 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_IR_IRGEN_H
+#define GLOW_IR_IRGEN_H
+
+#include "glow/Backends/Backend.h"
+#include "glow/Graph/Graph.h"
+#include "glow/Graph/Nodes.h"
+#include "glow/IR/IR.h"
+#include "glow/IR/IRBuilder.h"
+
+#include <unordered_set>
+
+//===----------------------------------------------------------------------===//
+//              IRGen visitor - the code that generates the IR.
+//===----------------------------------------------------------------------===//
+
+namespace glow {
+
+/// This class implements \p NodeWalker interface to translate from Node to
+/// Instruction IR.
+class IRGenVisitor : public NodeWalker {
+private:
+  using NodeValueToDestTy = std::unordered_map<NodeValue, Value *>;
+  using NodeToInstrTy = std::unordered_map<Node *, Instruction *>;
+
+  /// A set of visited nodes.
+  std::unordered_set<Node *> visited_;
+  /// Holds the mapping between graph nodes to the destination buffers.
+  NodeValueToDestTy generatedNodeDest_;
+  /// Holds the mapping between graph nodes and the lowered instructions. This
+  /// map is used by instructions that want to inspect the generated
+  /// instructions. For example, gradient instructions that look at operands
+  /// that do not exist at the graph level. Not all variables are representible.
+  NodeToInstrTy nodeToInstr_;
+
+  /// The function that we are building.
+  IRFunction *F_;
+  /// The builder that adds instructions into the function.
+  IRBuilder builder_;
+  /// The Backend /p B is used for custom lowering of Node to Instruction IR.
+  const Backend &B_;
+
+public:
+  bool shouldVisit(Node *parent, Node *N) override;
+
+  explicit IRGenVisitor(IRFunction *M, const Backend &B)
+      : F_(M), builder_(F_), B_(B) {}
+
+  /// \returns the generated instruction for the node \p N.
+  Value *valueForNode(NodeValue N);
+
+  /// Saves the generated IR in \p v for the node \p N.
+  void registerIR(NodeValue N, Value *v);
+
+  /// Adds to Node \p N --> Instruction \p inst map.
+  void setNodeToIR(Node *N, Instruction *inst);
+
+  /// Return Instruction that is mapped to Node \p N.
+  /// If mapping doesn't exists returns nullptr.
+  Instruction *getNodeToIR(Node *N);
+
+  void post(Node *parent, Node *N) override;
+
+  IRBuilder *getBuilder() { return &builder_; }
+};
+
+} // namespace glow
+#endif // GLOW_IR_IRGEN_H

--- a/include/glow/Optimizer/Optimizer.h
+++ b/include/glow/Optimizer/Optimizer.h
@@ -61,7 +61,9 @@ Function *profileQuantization(Context &ctx, Function *F,
 
 /// Helper to generate and optimize IR from given Function \p F. \p
 /// shouldShareBuffers signifies whether to use the share buffers optimization.
-std::unique_ptr<IRFunction> generateAndOptimizeIR(Function *F,
+/// Backend /p B is used to allow for custom lowering from Node to
+/// Instruction IR.
+std::unique_ptr<IRFunction> generateAndOptimizeIR(Function *F, const Backend &B,
                                                   bool shouldShareBuffers);
 
 } // namespace glow

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -133,20 +133,20 @@ CPUBackend::compileIRWithoutConstants(IRFunction *IR) const {
 }
 
 std::unique_ptr<CompiledFunction> CPUBackend::compile(Function *F) const {
-  auto IR = generateAndOptimizeIR(F, shouldShareBuffers());
+  auto IR = generateAndOptimizeIR(F, *this, shouldShareBuffers());
   return compileIR(std::move(IR));
 }
 
 std::unique_ptr<CompiledFunction>
 CPUBackend::compileWithoutConstants(Function *F) const {
-  auto IR = generateAndOptimizeIR(F, shouldShareBuffers());
+  auto IR = generateAndOptimizeIR(F, *this, shouldShareBuffers());
   return compileIRWithoutConstants(IR.get());
 }
 
 void CPUBackend::save(Function *F, llvm::StringRef outputDir,
                       llvm::StringRef networkName) const {
   std::string tgt = target.empty() ? "" : target.getValue();
-  auto IR = generateAndOptimizeIR(F, shouldShareBuffers());
+  auto IR = generateAndOptimizeIR(F, *this, shouldShareBuffers());
   BundleSaver(IR.get()).save(tgt, outputDir, networkName);
 }
 

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -25,13 +25,13 @@
 
 using namespace glow;
 std::unique_ptr<CompiledFunction> Interpreter::compile(Function *F) const {
-  auto IR = generateAndOptimizeIR(F, shouldShareBuffers());
+  auto IR = generateAndOptimizeIR(F, *this, shouldShareBuffers());
   return compileIR(std::move(IR));
 }
 
 std::unique_ptr<CompiledFunction>
 Interpreter::compileWithoutConstants(Function *F) const {
-  auto IR = generateAndOptimizeIR(F, shouldShareBuffers());
+  auto IR = generateAndOptimizeIR(F, *this, shouldShareBuffers());
   return compileIRWithoutConstants(std::move(IR));
 }
 

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -1547,12 +1547,12 @@ OCLBackend::compileIRWithoutConstants(std::unique_ptr<IRFunction> IR) const {
   return llvm::make_unique<OpenCLFunction>(std::move(IR), bundle);
 }
 std::unique_ptr<CompiledFunction> OCLBackend::compile(Function *F) const {
-  auto IR = generateAndOptimizeIR(F, shouldShareBuffers());
+  auto IR = generateAndOptimizeIR(F, *this, shouldShareBuffers());
   return compileIR(std::move(IR));
 }
 
 std::unique_ptr<CompiledFunction>
 OCLBackend::compileWithoutConstants(Function *F) const {
-  auto IR = generateAndOptimizeIR(F, shouldShareBuffers());
+  auto IR = generateAndOptimizeIR(F, *this, shouldShareBuffers());
   return compileIRWithoutConstants(std::move(IR));
 }

--- a/lib/Optimizer/IROptimizer.cpp
+++ b/lib/Optimizer/IROptimizer.cpp
@@ -1593,9 +1593,10 @@ void performPeepholeOptimizations(IRFunction &M) {
 }
 
 std::unique_ptr<IRFunction>
-glow::generateAndOptimizeIR(Function *F, bool shouldShareBuffers) {
+glow::generateAndOptimizeIR(Function *F, const Backend &B,
+                            bool shouldShareBuffers) {
   auto IR = llvm::make_unique<IRFunction>(F);
-  IR->generateIR();
+  IR->generateIR(B);
   ::glow::optimize(*IR, shouldShareBuffers);
   return IR;
 }

--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -154,12 +154,12 @@ TEST_P(BackendTest, debugPrint) {
   auto *IVTensor = ctx.allocate(IV);
   IVTensor->assign(&input);
 
-  auto IR = llvm::make_unique<IRFunction>(F);
-  IR->generateIR();
-  IRBuilder(IR.get()).createDebugPrintInst("print", *IR->getWeights().begin());
-
   std::unique_ptr<BackendUsingGlowIR> backend(
       static_cast<BackendUsingGlowIR *>(createBackend(GetParam())));
+  auto IR = llvm::make_unique<IRFunction>(F);
+  IR->generateIR(*backend.get());
+  IRBuilder(IR.get()).createDebugPrintInst("print", *IR->getWeights().begin());
+
   auto function = backend->compileIR(std::move(IR));
   function->setupRuns();
   function->beforeRun(ctx);


### PR DESCRIPTION
*Description*:  Extending framework to support custom translation from Node IR to Instruction IR. Right now there is auto generated lowering for custom nodes to custom instruction IR. This allows more flexibility. For example regularly supported Node that can be lowered to something custom BE adds for Instruction IR

Refactored `IRGenVisitor` to a header so that it can be used by a backend to generate custom Instructions during IRGen. Otherwise no real change to IRGen or the `IRGenVisitor`. A couple helper functions were added too. And then there's an extra call to `Backend::generateInst()` at the beginning of `post()` to check if the backend wants to IRGen the current node, otherwise our default IRGen logic takes place.

*Testing*: Unit tests
*Documentation*:
fixes https://github.com/pytorch/glow/issues/2211

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
