### PR TITLE
[DeviceManagers] If there is no device manager for the new backend, just fail.

### DIFF
--- a/lib/Backends/DeviceManagers.cpp
+++ b/lib/Backends/DeviceManagers.cpp
@@ -63,6 +63,8 @@ DeviceManager *DeviceManager::createDeviceManager(BackendKind backendKind,
     return createOCLDeviceManager(name);
   case BackendKind::CPU:
     return createCPUDeviceManager(name);
+  default:
+    GLOW_UNREACHABLE("not supported backend");
   }
 
   // This is to make compiler happy. It can never reach this point as switch


### PR DESCRIPTION
Was working on some other backend and figured this was failing to compile.