### PR TITLE
Always DCE after lowering

### DIFF
--- a/include/glow/Optimizer/Optimizer.h
+++ b/include/glow/Optimizer/Optimizer.h
@@ -43,6 +43,9 @@ void optimize(Function *F, CompilationMode mode);
 /// operators.
 void lower(Function *F, const Backend &B);
 
+/// Dead code elimination.
+void DCE(Function *F);
+
 /// Convert placeholders in Module \p M to constants based on the values in \p
 /// ctx.  Do not convert any placeholders explicitly listed in \p vars.
 void convertPlaceholdersToConstants(Function *F, const Context &ctx,

--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -56,7 +56,6 @@ static bool shouldDeleteNode(Node *N) {
   return true;
 }
 
-/// Dead code elimination.
 void glow::DCE(Function *F) {
   auto &nodes = F->getNodes();
   auto &consts = F->getParent()->getConstants();

--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -57,7 +57,7 @@ static bool shouldDeleteNode(Node *N) {
 }
 
 /// Dead code elimination.
-static void DCE(Function *F) {
+void glow::DCE(Function *F) {
   auto &nodes = F->getNodes();
   auto &consts = F->getParent()->getConstants();
 

--- a/lib/Optimizer/Lower.cpp
+++ b/lib/Optimizer/Lower.cpp
@@ -763,4 +763,7 @@ void glow::lower(Function *F, const Backend &B) {
     if (dyn_cast<SGDNode>(cur))
       F->eraseNode(cur);
   }
+
+  // Remove nodes that were lowered.
+  DCE(F);
 }

--- a/tests/unittests/GraphTest.cpp
+++ b/tests/unittests/GraphTest.cpp
@@ -101,6 +101,7 @@ TEST(Graph, float16Conv) {
   Node *K = MD.createConstant(ElemKind::Float16Ty, {4, 320, 200, 3}, "input");
 
   auto *conv = F->createConv(ctx, "Conv", K, 16, 3, 2, 3, 1);
+  F->createSave("Save", conv);
   EXPECT_TRUE(conv->verify());
   EXPECT_EQ(conv->getResult().getElementType(), ElemKind::Float16Ty);
   EXPECT_EQ(conv->getFilter().getElementType(), ElemKind::Float16Ty);


### PR DESCRIPTION
*Description*:
DCE should be performed after lowering like in other graph optimizations that can produce dead code. This may incur an extra call to DCE here or there but this should be relatively low overhead and the trade off is that the various places around the compiler that call lower() do not need to worry about manually doing DCE themselves.

*Testing*:
`ninja all`

*Documentation*:
doxygen
