### PR TITLE
[RFC] Profiling/Tracing prototype support in the Interpreter 

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -87,6 +87,17 @@ if(GLOW_WITH_CPU)
   target_include_directories(resnet-concurrent PUBLIC ${CMAKE_SOURCE_DIR}/lib)
 endif()
 
+add_executable(resnet-tracing
+                 resnet-tracing.cpp)
+target_link_libraries(resnet-tracing
+                      PRIVATE
+                        Backends
+                        DeviceManager
+                        ExecutionEngine
+                        Graph
+                        Importer
+                        Optimizer)
+
 if(GLOW_WITH_BUNDLES)
   add_subdirectory(bundles)
 endif()

--- a/examples/resnet-tracing.cpp
+++ b/examples/resnet-tracing.cpp
@@ -1,0 +1,157 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/Backends/DeviceManager.h"
+#include "glow/Base/Image.h"
+#include "glow/ExecutionEngine/ExecutionEngine.h"
+#include "glow/Graph/Graph.h"
+#include "glow/Importer/Caffe2ModelLoader.h"
+#include "glow/Runtime/RuntimeTypes.h"
+#include "glow/Runtime/TraceLogger.h"
+
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/FileSystem.h"
+
+#include <chrono>
+#include <future>
+
+using namespace glow;
+using namespace glow::runtime;
+
+namespace {
+llvm::cl::OptionCategory category("resnet-tracing Options");
+llvm::cl::opt<std::string>
+    inputImage(llvm::cl::desc("path to input image to classify, which must be "
+                              "a png with standard imagenet normalization"),
+               llvm::cl::init("../tests/images/imagenet/dog_207.png"),
+               llvm::cl::Positional, llvm::cl::cat(category));
+llvm::cl::opt<std::string>
+    outputJson(llvm::cl::desc("path to write output json trace events"),
+               llvm::cl::init("./resnet-tracing.json"), llvm::cl::Positional,
+               llvm::cl::cat(category));
+} // namespace
+
+/// Loads the model into /p module and returns the input and output
+/// Placeholders.
+std::pair<Placeholder *, Placeholder *> loadResnet50Model(TypeRef inputType,
+                                                          Module &module) {
+  Function *F = module.createFunction("resnet50");
+
+  llvm::outs() << "Loading resnet50 model.\n";
+
+  const char inputName[] = "gpu_0/data";
+  Caffe2ModelLoader loader("resnet50/predict_net.pb", "resnet50/init_net.pb",
+                           {inputName}, {inputType}, *F);
+  Placeholder *input =
+      llvm::cast<Placeholder>(cantFail(loader.getNodeValueByName(inputName)));
+  Placeholder *output = cantFail(loader.getSingleOutput());
+
+  return std::make_pair(input, output);
+}
+
+/// Compiles the resnet50 function.
+std::unique_ptr<CompiledFunction> compileModel(Module &module) {
+  auto *backend = createBackend(BackendKind::Interpreter);
+  Function *F = module.getFunction("resnet50");
+
+  llvm::outs() << "Starting compile.\n";
+  backend->optimizeFunction(CompilationMode::Infer, F);
+  return backend->compile(F);
+}
+
+std::future<ResultCode> addToDevice(unsigned int id, DeviceManager *device,
+                                    Module &module, FunctionMapTy functions) {
+  std::shared_ptr<std::promise<ResultCode>> compilePromise(
+      new std::promise<ResultCode>);
+  auto future = compilePromise->get_future();
+
+  device->addNetwork(&module, functions,
+                     [compilePromise, id](const Module *, ResultCode code) {
+                       if (code != ResultCode::Ready) {
+                         llvm::errs() << "Failed to compile model for device "
+                                      << id << ".\n";
+                       } else {
+                         llvm::outs()
+                             << "Successfully added to Device " << id << ".\n";
+                       }
+                       compilePromise->set_value(code);
+                     });
+
+  return future;
+}
+
+/// Run ResNet concurrently on a fixed number of CPU Devices
+int main(int argc, char **argv) {
+  llvm::cl::ParseCommandLineOptions(
+      argc, argv, "Run ResNet and export a json file containing trace events");
+
+  DeviceManager *device = DeviceManager::createDeviceManager(
+      BackendKind::Interpreter, "resnet-tracing");
+  device->init();
+
+  // Load and compile model.
+
+  Module module;
+  TypeRef inputType(module.uniqueType(ElemKind::FloatTy, {1, 3, 224, 224}));
+  Placeholder *input, *output;
+
+  std::tie(input, output) = loadResnet50Model(inputType, module);
+  auto compiledFunction = compileModel(module);
+
+  FunctionMapTy functions;
+  functions.emplace("resnet50", compiledFunction.get());
+
+  auto f = addToDevice(0, device, module, functions);
+  f.wait_for(/* timeout_duration */ std::chrono::seconds(30));
+  if (f.get() != ResultCode::Ready) {
+    return 1;
+  }
+
+  TraceLogger traceLogger(0);
+
+  auto image =
+      readPngImageAndPreprocess(inputImage, ImageNormalizationMode::k0to1,
+                                ImageChannelOrder::BGR, ImageLayout::NCHW,
+                                /* useImagenetNormalization */ true);
+
+  Tensor batch(inputType);
+  batch.getHandle<float>().insertSlice(image, 0);
+
+  auto ctx = llvm::make_unique<Context>();
+  ctx->allocate(module.getPlaceholders());
+  updateInputPlaceholders(*ctx, {input}, {&batch});
+
+  TraceThread traceThread = traceLogger.getTraceThread();
+  ctx->setTraceLogger(&traceThread);
+
+  llvm::outs() << "Starting Run.\n";
+  std::promise<void> finished;
+  device->runFunction("resnet50", std::move(ctx),
+                      [&finished, &ctx](RunIdentifierTy, ResultCode r,
+                                        std::unique_ptr<Context> ctx2) {
+                        ctx = std::move(ctx2);
+                        finished.set_value();
+                      });
+
+  finished.get_future().wait();
+
+  traceLogger.returnTraceThread(std::move(traceThread));
+
+  llvm::outs() << "Dumping json to " << outputJson << ".\n";
+  traceLogger.dumpTraceEvents(outputJson);
+
+  return 0;
+}

--- a/include/glow/Graph/Context.h
+++ b/include/glow/Graph/Context.h
@@ -25,6 +25,9 @@ namespace glow {
 
 class Tensor;
 class Placeholder;
+namespace runtime {
+class TraceThread;
+}
 
 /// This class provides a mapping between some graph nodes, which are a symbolic
 /// representation of some computation, and concrete tensors that represent the
@@ -41,6 +44,9 @@ public:
 private:
   /// Maps Placeholders to Tensors.
   PlaceholderMap map_;
+
+  /// Stores trace events for this run. May be nullptr.
+  runtime::TraceThread *traceEvents_{nullptr};
 
 public:
   /// \returns the tensor that corresponds to Placeholder \p P or Null if the
@@ -80,6 +86,13 @@ public:
 
   /// \returns the size in bytes of allocated Tensors owned by Context.
   uint64_t getDataSize() const;
+
+  /// Sets the trace logger for this inference run. \returns the previous logger
+  /// set.
+  runtime::TraceThread *setTraceLogger(runtime::TraceThread *logger);
+
+  /// \returns the TraceThread for this run, used for inferance tracing.
+  runtime::TraceThread *getTraceEvents() { return traceEvents_; }
 
   Context() = default;
 

--- a/include/glow/Runtime/TraceLogger.h
+++ b/include/glow/Runtime/TraceLogger.h
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_RUNTIME_TRACELOGGER_H
+#define GLOW_RUNTIME_TRACELOGGER_H
+
+#include "llvm/ADT/StringRef.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace glow {
+namespace runtime {
+
+/// An individual tracing event, such as the begin or end of an instruction.
+/// Designed to match the Google Trace Event Format for Chrome:
+// https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU
+struct TraceEvent {
+  /// Human readable name for the item, will be used to match up begin and end.
+  std::string name;
+
+  /// Time of the event, in milliseconds since epoch.
+  uint64_t timestamp;
+
+  /// Type of the event, a one char code (see Event Descriptions in the Trace
+  /// Event Format spec). e.g. 'B' for begin event, 'E' for end event.
+  char type;
+
+  /// Thread Id for this event. All Events on the same tid will be shown on the
+  /// same row of the trace.
+  int tid;
+
+  TraceEvent(llvm::StringRef n, uint64_t ts, char c, int t)
+      : name(n), timestamp(ts), type(c), tid(t) {}
+};
+
+/// Aggregator for a single thread of execution's TraceEvents.
+/// All events on this TraceThread share a tid.
+/// This abstraction is designed to to allow concurrent generation of events
+/// without requiring synchronization, but this class is not thread safe.
+class TraceThread {
+  /// TraceEvents for this tid. Can be unordered.
+  std::vector<TraceEvent> traceEvents_;
+
+  /// The Thread Id of this TraceThread.
+  int tid_;
+
+  friend class TraceLogger;
+
+public:
+  TraceThread(int tid);
+
+  /// Create and store a BEGIN (type 'B') TraceEvent with the \name and the
+  /// current timestamp.
+  void beginTraceEvent(llvm::StringRef name);
+
+  /// Create and store an END (type 'E') TraceEvent with the \name and the
+  /// current timestamp. This should match a previous beginTraceEvent.
+  void endTraceEvent(llvm::StringRef name);
+};
+
+/// Aggregator for a single run's TraceEvents, i.e. for a single inference.
+// The usage pattern should be something like:
+//     1. getTraceThread() to get a logger per thread of execution.
+//     2. log events on the traceThread()
+//     3. when the execution is finished, returnTraceThread(traceThread) to
+//        aggregate TraceEvents.
+class TraceLogger {
+  /// TraceEvents for this pid. Can be unordered.
+  std::vector<TraceEvent> traceEvents_;
+
+  /// Thread Id to use for the next TraceThread.
+  int nextThreadId{0};
+
+  /// The Process Id of this trace (unused currently).
+  int pid_;
+
+public:
+  TraceLogger(int pid = 0);
+
+  /// \returns a new TraceThread for the given tid. That TraceThread does not
+  /// share state with the TraceLogger. Ia \p tid is not specified, will use the
+  /// next sequential Thread Id.
+  TraceThread getTraceThread(int tid = -1);
+
+  /// Collects TraceEvents from the provided \p traceThread and moves them into
+  /// the TraceLogger. The TraceThread can still be used, however it's event
+  /// vector is cleared.
+  void returnTraceThread(TraceThread &traceThread);
+  void returnTraceThread(TraceThread &&traceThread);
+
+  /// Writes a JSON file containing TraceEvents to the \p outputPath.
+  void dumpTraceEvents(llvm::StringRef outputPath);
+};
+
+} // namespace runtime
+} // namespace glow
+
+#endif

--- a/lib/Graph/CMakeLists.txt
+++ b/lib/Graph/CMakeLists.txt
@@ -34,6 +34,7 @@ target_link_libraries(Graph
                       PUBLIC
                         Base
                         Support
-                        QuantizationBase)
+                        QuantizationBase
+                        TraceLogger)
 
 add_dependencies(Graph AutoGen)

--- a/lib/Graph/Context.cpp
+++ b/lib/Graph/Context.cpp
@@ -17,6 +17,7 @@
 #include "glow/Graph/Context.h"
 #include "glow/Base/Tensor.h"
 #include "glow/Graph/Nodes.h"
+#include "glow/Runtime/TraceLogger.h"
 
 using namespace glow;
 
@@ -98,6 +99,11 @@ uint64_t Context::getDataSize() const {
     size += T->getSizeInBytes();
   }
   return size;
+}
+
+runtime::TraceThread *Context::setTraceLogger(runtime::TraceThread *logger) {
+  std::swap(traceEvents_, logger);
+  return logger;
 }
 
 Context::Context(llvm::ArrayRef<Placeholder *> placeholders,

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -1,1 +1,4 @@
 add_subdirectory(Provisioner)
+
+add_library(TraceLogger
+  TraceLogger.cpp)

--- a/lib/Runtime/TraceLogger.cpp
+++ b/lib/Runtime/TraceLogger.cpp
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/Runtime/TraceLogger.h"
+
+#include "llvm/Support/raw_ostream.h"
+
+#include <chrono>
+#include <fstream>
+
+using namespace std::chrono;
+
+namespace glow {
+namespace runtime {
+
+uint64_t timestamp_now() {
+  return duration_cast<milliseconds>(system_clock::now().time_since_epoch())
+      .count();
+}
+
+TraceThread::TraceThread(int tid) : tid_(tid) {}
+
+void TraceThread::beginTraceEvent(llvm::StringRef name) {
+  traceEvents_.push_back(TraceEvent(name, timestamp_now(), 'B', tid_));
+}
+
+void TraceThread::endTraceEvent(llvm::StringRef name) {
+  traceEvents_.push_back(TraceEvent(name, timestamp_now(), 'E', tid_));
+}
+
+TraceLogger::TraceLogger(int pid) : pid_(pid) {}
+
+TraceThread TraceLogger::getTraceThread(int tid) {
+  if (tid < 0) {
+    tid = nextThreadId++;
+  }
+
+  return TraceThread(tid);
+}
+
+void TraceLogger::returnTraceThread(TraceThread &traceThread) {
+  traceEvents_.insert(traceEvents_.end(),
+                      std::make_move_iterator(traceThread.traceEvents_.begin()),
+                      std::make_move_iterator(traceThread.traceEvents_.end()));
+}
+
+void TraceLogger::returnTraceThread(TraceThread &&traceThread) {
+  returnTraceThread(traceThread);
+}
+
+void TraceLogger::dumpTraceEvents(llvm::StringRef path) {
+  llvm::errs() << "dumping " << traceEvents_.size() << " trace events.\n";
+
+  std::ofstream file(path);
+  file << "[\n";
+  for (const auto &event : traceEvents_) {
+    file << "{\"name\": \"" << event.name
+         << "\", \"cat\": \"glow,interpreter\", \"ph\": \"" << event.type
+         << "\", \"ts\": " << event.timestamp << ", \"pid\": " << pid_
+         << ", \"tid\": " << event.tid << "},\n";
+  }
+  // Skip the ending bracket since that is allowed.
+  file.close();
+}
+
+} // namespace runtime
+} // namespace glow


### PR DESCRIPTION
*Description*: @jackm321 and I have been chatting about what Profiling/Tracing might look like in glow, so I've hacked up machinery and support for it in the in the Interpreter backend. The new example will write a JSON file in the Google Chrome Trace Events format, which can be dropped into their profile UI to give us a visual representation of the time cost of each IR node.

My thinking about how this fits into the Runtime is that the Executor would keep one TraceLogger for the run, and create a new TraceThread for each DAGNode, which would let us group execution by accelerator.

This is just a proposal, very interested in comments on design choices, how this might suit different backends, etc.
*Testing*: unit tests under ASAN & release as normal.
*Documentation*:
Attached is the output of one run of resnet50 in the Interpreter, you can drop it into `chrome://tracing` and have a look around. (you may have to rename the file back to `.json`first).

[resnet-tracing.txt](https://github.com/pytorch/glow/files/2819179/resnet-tracing.txt)

And it should look like this: 

![resnet-tracing](https://user-images.githubusercontent.com/701287/52091554-a023b800-2569-11e9-8bc2-764b2f6b4fcc.png)

