### PR TITLE
[new operators] Support Alias and EnforceFinite as no-ops

### DIFF
--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -960,7 +960,13 @@ protected:
       RETURN_IF_ERR(loadIdentity(op, dict));
       return true;
     }
-    if (typeName == "Identity") {
+    if (typeName == "EnforceFinite") {
+      // Load as Identity operation, because in Caffe2 this op does not change
+      // any data. It only raises error if some tensor element is Inf or NaN.
+      RETURN_IF_ERR(loadIdentity(op, dict));
+      return true;
+    }
+    if (typeName == "Identity" || typeName == "Alias") {
       RETURN_IF_ERR(loadIdentity(op, dict));
       return true;
     }

--- a/tests/models/caffe2Models/alias_op_net.pbtxt
+++ b/tests/models/caffe2Models/alias_op_net.pbtxt
@@ -1,0 +1,9 @@
+name: "alias"
+op {
+  input: "X"
+  output: "Y"
+  name: ""
+  type: "Alias"
+}
+external_input: "X"
+external_output: "Y"

--- a/tests/models/caffe2Models/enforcefinite_op_net.pbtxt
+++ b/tests/models/caffe2Models/enforcefinite_op_net.pbtxt
@@ -1,0 +1,9 @@
+name: "EnforceFinite"
+op {
+  input: "X"
+  output: "Y"
+  name: ""
+  type: "EnforceFinite"
+}
+external_input: "X"
+external_output: "Y"


### PR DESCRIPTION
*Documentation*:
Adds support of `Alias` and `EnforceFinite` operators.