### PR TITLE
[New operator] Implement SparseToDenseMask

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -603,6 +603,18 @@ public:
                                          NodeValue indices, NodeValue values,
                                          NodeValue dataToInferDim);
 
+  /// Implements an operation that converts the sparse representation given by
+  /// the pair of \p indices and \p values into a dense representation, which
+  /// only contains IDs from given \p mask. Indices cannot contain duplicates.
+  /// \p lengths is used to distinguish elements that belong to different
+  /// examples of one batch. That is, first \p lengths[0] index-value pairs
+  /// belong to batch's example 0, next \p lengths[1] pairs belong to example 1
+  /// and so on.
+  SparseToDenseMaskNode *
+  createSparseToDenseMask(llvm::StringRef name, NodeValue indices,
+                          NodeValue values, NodeValue defaultValue,
+                          NodeValue lengths, llvm::ArrayRef<int64_t> mask);
+
   SaveNode *createSave(llvm::StringRef name, NodeValue input);
   SaveNode *createSave(llvm::StringRef name, NodeValue input,
                        Placeholder *output);

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1442,6 +1442,22 @@ SparseToDenseNode *Function::createSparseToDense(llvm::StringRef name,
   return addNode(new SparseToDenseNode(name, outTy, indices, values));
 }
 
+SparseToDenseMaskNode *Function::createSparseToDenseMask(
+    llvm::StringRef name, NodeValue indices, NodeValue values,
+    NodeValue defaultValue, NodeValue lengths, llvm::ArrayRef<int64_t> mask) {
+  auto lengthsDims = lengths.dims();
+  auto valueDims = defaultValue.dims();
+  ShapeVector outDims = {mask.size()};
+  // If lengths is 0-dimensional tensor, then there is no batch dimension.
+  if (lengthsDims.size() > 0) {
+    outDims.insert(outDims.begin(), lengthsDims[0]);
+  }
+  outDims.insert(outDims.end(), valueDims.begin(), valueDims.end());
+  auto outTy = getParent()->uniqueTypeWithNewShape(values.getType(), outDims);
+  return addNode(new SparseToDenseMaskNode(name, outTy, indices, values,
+                                           defaultValue, lengths, mask));
+}
+
 SaveNode *Function::createSave(llvm::StringRef name, NodeValue input) {
   auto *dest = getParent()->createPlaceholder(input.getType(), name, false);
 

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -773,6 +773,24 @@ bool SparseToDenseNode::verify() const {
   return isValid;
 }
 
+bool SparseToDenseMaskNode::verify() const {
+  bool isValid = checkType(getResult(), getValues().getElementType(), this);
+  isValid &= checkType(getResult(), getDefaultValue().getElementType(), this);
+  isValid &= checkType(getIndices(), ElemKind::Int64ITy, this);
+  isValid &= checkType(getLengths(), ElemKind::Int32ITy, this);
+  isValid &= expectCompareTrue("Indices must be a 1D vector",
+                               getIndices().dims().size(), size_t(1), this);
+  isValid &= expectCompareTrue("Lengths must be a scalar or 1D vector",
+                               getLengths().dims().size(), {0, 1}, this);
+  isValid &=
+      expectCompareTrue("Indices and Values must have the same first dimension",
+                        getIndices().dims()[0], getValues().dims()[0], this);
+  isValid &= expectCompareTrue(
+      "Values[i] must have the same dimensions as DefaultValue",
+      getValues().dims().slice(1), getDefaultValue().dims(), this);
+  return isValid;
+}
+
 bool SGDNode::verify() const {
   return checkSameType(getGradient(), getWeight(), this);
 }

--- a/tests/models/caffe2Models/sparse_to_dense_mask_op_net.pbtxt
+++ b/tests/models/caffe2Models/sparse_to_dense_mask_op_net.pbtxt
@@ -1,0 +1,21 @@
+name: "sparse_to_dense_mask"
+op {
+  input: "indices"
+  input: "values"
+  input: "defaultValue"
+  arg {
+    name: "mask"
+    ints: 42
+    ints: 100
+    ints: 300
+    ints: 1
+    ints: 0
+    ints: 312
+  }
+  output: "output"
+  type: "SparseToDenseMask"
+}
+external_input: "indices"
+external_input: "values"
+external_input: "defaultValue"
+external_output: "output"

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -266,6 +266,21 @@ int main(int argc, char **argv) {
       .autoVerify(VerifyKind::SameElementType, {"Dest", "Values"})
       .autoIRGen();
 
+  BB.newInstr("SparseToDenseMask")
+      .addOperand("Dest", OperandKind::Out)
+      .addOperand("Indices", OperandKind::In)
+      .addOperand("Values", OperandKind::In)
+      .addOperand("DefaultValue", OperandKind::In)
+      .addOperand("Lengths", OperandKind::In)
+      .addMember(MemberType::VectorInt64, "Mask")
+      .autoVerify(VerifyKind::SameElementType,
+                  {"Dest", "Values", "DefaultValue"})
+      .autoVerify(VerifyKind::SameElementType,
+                  {"Indices", "ElemKind::Int64ITy"})
+      .autoVerify(VerifyKind::SameElementType,
+                  {"Lengths", "ElemKind::Int32ITy"})
+      .autoIRGen();
+
   /// Adds the 'Slice' operand to each one of the slices in the batch.
   BB.newInstr("BatchedAdd")
       .addOperand("Dest", OperandKind::Out)

--- a/tools/ClassGen/MemberType.cpp
+++ b/tools/ClassGen/MemberType.cpp
@@ -29,6 +29,9 @@ MemberTypeInfo kVectorFloatTypeInfo{MemberType::VectorFloat,
 MemberTypeInfo kVectorUnsignedTypeInfo{
     MemberType::VectorUnsigned, "llvm::ArrayRef<unsigned_t>",
     "std::vector<unsigned_t>", "std::vector<unsigned_t>"};
+MemberTypeInfo kVectorInt64TypeInfo{
+    MemberType::VectorInt64, "llvm::ArrayRef<int64_t>", "std::vector<int64_t>",
+    "std::vector<int64_t>"};
 MemberTypeInfo kVectorSignedTypeInfo{MemberType::VectorSigned,
                                      "llvm::ArrayRef<int>", "std::vector<int>",
                                      "std::vector<int>"};

--- a/tools/ClassGen/MemberType.h
+++ b/tools/ClassGen/MemberType.h
@@ -29,6 +29,7 @@ enum class MemberType : unsigned {
   VectorFloat,
   VectorSigned,
   VectorUnsigned,
+  VectorInt64,
   VectorSizeT,
   VectorNodeValue,
   Enum,
@@ -52,6 +53,7 @@ extern MemberTypeInfo kBooleanTypeInfo;
 extern MemberTypeInfo kStringTypeInfo;
 extern MemberTypeInfo kVectorFloatTypeInfo;
 extern MemberTypeInfo kVectorUnsignedTypeInfo;
+extern MemberTypeInfo kVectorInt64TypeInfo;
 extern MemberTypeInfo kVectorSignedTypeInfo;
 extern MemberTypeInfo kVectorSizeTTypeInfo;
 extern MemberTypeInfo kVectorNodeValueTypeInfo;
@@ -79,6 +81,7 @@ inline const char *getReturnTypename(MemberType type) {
                                "llvm::ArrayRef<float>",
                                "llvm::ArrayRef<int>",
                                "llvm::ArrayRef<unsigned_t>",
+                               "llvm::ArrayRef<int64_t>",
                                "llvm::ArrayRef<size_t>",
                                "NodeValueArrayRef",
                                nullptr};
@@ -94,6 +97,7 @@ inline const char *getStorageTypename(MemberType type) {
                                 "std::vector<float>",
                                 "std::vector<int>",
                                 "std::vector<unsigned_t>",
+                                "std::vector<int64_t>",
                                 "std::vector<size_t>",
                                 "std::vector<NodeHandle>",
                                 nullptr};
@@ -109,6 +113,7 @@ inline const char *getCtorArgTypename(MemberType type) {
                                 "std::vector<float>",
                                 "std::vector<int>",
                                 "std::vector<unsigned_t>",
+                                "std::vector<int64_t>",
                                 "std::vector<size_t>",
                                 "std::vector<NodeValue>",
                                 nullptr};

--- a/tools/ClassGen/NodeBuilder.cpp
+++ b/tools/ClassGen/NodeBuilder.cpp
@@ -163,6 +163,8 @@ NodeBuilder &NodeBuilder::addMember(MemberType type, const std::string &name) {
     typeInfo = &kVectorFloatTypeInfo;
   } else if (type == MemberType::VectorUnsigned) {
     typeInfo = &kVectorUnsignedTypeInfo;
+  } else if (type == MemberType::VectorInt64) {
+    typeInfo = &kVectorInt64TypeInfo;
   } else if (type == MemberType::VectorSigned) {
     typeInfo = &kVectorSignedTypeInfo;
   } else if (type == MemberType::VectorSizeT) {
@@ -517,7 +519,7 @@ void NodeBuilder::emitEquator(std::ostream &os) const {
 static bool isVectorType(MemberType ty) {
   return ty == MemberType::VectorFloat || ty == MemberType::VectorNodeValue ||
          ty == MemberType::VectorSizeT || ty == MemberType::VectorUnsigned ||
-         ty == MemberType::VectorSigned;
+         ty == MemberType::VectorInt64 || ty == MemberType::VectorSigned;
 }
 
 void NodeBuilder::emitHasher(std::ostream &os) const {

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -376,6 +376,22 @@ int main(int argc, char **argv) {
           "and in this case, all of the corresponding values in Values "
           "are added together.");
 
+  BB.newNode("SparseToDenseMask")
+      .addInput("Indices")
+      .addInput("Values")
+      .addInput("DefaultValue")
+      .addInput("Lengths")
+      .addMember(MemberType::VectorInt64, "Mask")
+      .addResultFromCtorArg()
+      .setDocstring(
+          "Converts the sparse representation specified by the pair "
+          "(Indices, Values) into a dense one, where compacted tensor only "
+          "contains IDs from given Mask. Indices cannot contain duplicate "
+          "values. Lengths is used to distinguish elements from different "
+          "examples of one batch. That is, first Lengths[0] index-value pairs "
+          "belong to batch's example 0, next Lengths[1] pairs belong to "
+          "example 1, and so on.");
+
   // clang-format off
   BB.newNode("IsNaN")
     .addInput("Input")


### PR DESCRIPTION
*Description*:
It is unfortunate that we now need to create a hash map inside an operator. Luckily, `mask` is known in advance, so we can precompute the hash map. I decided not to do it yet, because the goal of Interpreter backend is simplicity.

*Testing*:
`ninja test`

*Documentation*:
Introduce `SparseToDenseMask` operator, which matches Caffe2 semantics:
https://caffe2.ai/docs/operators-catalogue.html#sparsetodensemask
