### PR TITLE
[quantization] Choose symmetric params even with infinities

### DIFF
--- a/lib/Quantization/Base/Base.cpp
+++ b/lib/Quantization/Base/Base.cpp
@@ -277,7 +277,10 @@ TensorQuantizationParams chooseQuantizationParams(float min, float max,
     }
   }
 
-  double scale = (max - min) / ((double)qmax - qmin);
+  min = std::max(min, std::numeric_limits<float>::lowest());
+  max = std::min(max, std::numeric_limits<float>::max());
+
+  double scale = ((double)max - min) / ((double)qmax - qmin);
 
   // Dequantization uses the following formula scale * (X - offset), so
   // scale should not be equal to zero.

--- a/tests/unittests/QuantizationTest.cpp
+++ b/tests/unittests/QuantizationTest.cpp
@@ -739,6 +739,18 @@ TEST(Quantization, chooseQuantizationSymmetric) {
   EXPECT_NEAR(symmetricParams.scale, 16.0 / 255, 0.001);
 }
 
+/// Check quantization symmetry in presence of infinities.
+TEST(Quantization, chooseQuantizationSymmetricInf) {
+  auto sym = quantization::Schema::Symmetric;
+  EXPECT_EQ(chooseQuantizationParams(-INFINITY, INFINITY, sym).offset, 0);
+  EXPECT_EQ(chooseQuantizationParams(INFINITY, INFINITY, sym).offset, 0);
+  EXPECT_EQ(chooseQuantizationParams(-INFINITY, -INFINITY, sym).offset, 0);
+  EXPECT_EQ(chooseQuantizationParams(-INFINITY, 1.0f, sym).offset, 0);
+  EXPECT_EQ(chooseQuantizationParams(-INFINITY, -1.0f, sym).offset, 0);
+  EXPECT_EQ(chooseQuantizationParams(-1.0f, INFINITY, sym).offset, 0);
+  EXPECT_EQ(chooseQuantizationParams(1.0f, INFINITY, sym).offset, 0);
+}
+
 /// Check that Relu can use our symmetric quantization schema.
 TEST(Quantization, reluCanUseSymmetricSchema) {
   Context ctx;


### PR DESCRIPTION
*Description*: This case is kind of pathological, but symmetric quantization was failing to find a proper zero point when min/max was infinite.  Work around it by forcing infinities to lowest/max as appropriate.
*Testing*: New QuantizationTest
*Documentation*: n/a
