### PR TITLE
[new operator] Support Alias as non-op

### DIFF
--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -960,7 +960,7 @@ protected:
       RETURN_IF_ERR(loadIdentity(op, dict));
       return true;
     }
-    if (typeName == "Identity") {
+    if (typeName == "Identity" || typeName == "Alias") {
       RETURN_IF_ERR(loadIdentity(op, dict));
       return true;
     }

--- a/tests/models/caffe2Models/alias_op_net.pbtxt
+++ b/tests/models/caffe2Models/alias_op_net.pbtxt
@@ -1,0 +1,9 @@
+name: "alias"
+op {
+  input: "X"
+  output: "Y"
+  name: ""
+  type: "Alias"
+}
+external_input: "X"
+external_output: "Y"

--- a/tests/unittests/Caffe2ImporterTest.cpp
+++ b/tests/unittests/Caffe2ImporterTest.cpp
@@ -1573,3 +1573,39 @@ TEST(caffe2, tensorFillsTest) {
     EXPECT_EQ(tensorInt64FillH.raw(i), (int64_t)i);
   }
 }
+
+TEST(caffe2, Alias) {
+  ExecutionEngine EE{BackendKind::Interpreter};
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+
+  llvm::StringRef NetDescFilename(
+      GLOW_DATA_PATH "tests/models/caffe2Models/alias_op_net.pbtxt");
+  std::string NetWeightFilename(
+      GLOW_DATA_PATH "tests/models/caffe2Models/empty_init_net.pbtxt");
+
+  Placeholder *output;
+  Context ctx;
+
+  Tensor input(ElemKind::FloatTy, {1, 2, 3, 4});
+
+  // Destroy the loader after the graph is loaded since the following execution
+  // will not depend on anything from the loader.
+  {
+    // Loaded protos must have at least one external output, so load an unused
+    // output and type to satisfy it. It is named unused_output in
+    // empty_predict_net.pbtxt.
+    Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"X"},
+                               {&input.getType()}, *F);
+    output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
+  }
+
+  ASSERT_TRUE(output);
+
+  // The only node is Save.
+  EXPECT_EQ(F->getNodes().size(), 1);
+
+  auto *saveNode = getSaveNodeFromDest(output);
+  auto *N = llvm::dyn_cast<Placeholder>(saveNode->getInput());
+  EXPECT_TRUE(N);
+}


### PR DESCRIPTION
*Testing*:
`ninja test`

*Documentation*:
`Alias` is non-op in Glow
