### PR TITLE
[trivial/fix] Run device manager test on CPU only when CPU is enabled.

### DIFF
--- a/tests/unittests/DeviceManagerTest.cpp
+++ b/tests/unittests/DeviceManagerTest.cpp
@@ -392,7 +392,7 @@ TEST_P(DeviceManagerTest, ReuseModule) {
   EXPECT_NE(ctx1, ctx2);
 }
 
-TEST(CPUDeviceManagerTest, AvailableMemory) {
+TEST_P(DeviceManagerTest, AvailableMemory) {
   std::vector<std::unique_ptr<CompiledFunction>> backing;
   std::promise<const Module *> promise;
   std::future<const Module *> future;
@@ -409,7 +409,7 @@ TEST(CPUDeviceManagerTest, AvailableMemory) {
   auto module = makeBasicModule();
   std::tie(promise, future) = getFutureHelper<const Module *>();
   cpuCoreDevice.addNetwork(
-      module.get(), compileFunctions(BackendKind::CPU, module.get(), backing),
+      module.get(), compileFunctions(backendKind, module.get(), backing),
       [&promise](const Module *module, ResultCode result) {
         callbackHelper(promise, module, result, ResultCode::Ready);
       });
@@ -426,7 +426,7 @@ TEST(CPUDeviceManagerTest, AvailableMemory) {
   auto module2 = makeBasicModule();
   std::tie(promise, future) = getFutureHelper<const Module *>();
   cpuCoreDevice.addNetwork(
-      module2.get(), compileFunctions(BackendKind::CPU, module2.get(), backing),
+      module2.get(), compileFunctions(backendKind, module2.get(), backing),
       [&promise](const Module *module, ResultCode result) {
         callbackHelper(promise, module, result, ResultCode::Ready);
       });
@@ -446,7 +446,7 @@ TEST(CPUDeviceManagerTest, AvailableMemory) {
   // And try again, this time with available space.
   std::tie(promise, future) = getFutureHelper<const Module *>();
   cpuCoreDevice.addNetwork(
-      module2.get(), compileFunctions(BackendKind::CPU, module2.get(), backing),
+      module2.get(), compileFunctions(backendKind, module2.get(), backing),
       [&promise](const Module *module, ResultCode result) {
         callbackHelper(promise, module, result, ResultCode::Ready);
       });


### PR DESCRIPTION
*Description*:
Currently Device Manager CPU test gets run even if Glow was not compiled with CPU support. Fix this.

```
[5/12] Linking CXX executable tests/DeviceManagerTest
FAILED: tests/DeviceManagerTest 
: && /bin/c++  -Wall -Wnon-virtual-dtor -fno-exceptions -fno-rtti -Wno-psabi -g -fno-omit-frame-pointer -O0   tests/unittests/CMakeFiles/DeviceManagerTest.dir/DeviceManagerTest.cpp.o  -o tests/DeviceManagerTest  lib/Backends/libBackends.a lib/Backends/libDeviceManager.a lib/Graph/libGraph.a lib/IR/libIR.a lib/ExecutionEngine/libExecutionEngine.a lib/Optimizer/libOptimizer.a tests/googletest/googlemock/gtest/libgtestd.a tests/unittests/libTestMain.a lib/Support/libThreadPool.a lib/Backends/Interpreter/libInterpreterDeviceManager.a lib/Backends/libBackends.a lib/Backends/Interpreter/libInterpreter.a lib/Backends/Homa/libHoma.a lib/Backends/libBackendUtils.a lib/CodeGen/libCodeGen.a lib/Optimizer/libOptimizer.a lib/IR/libIR.a lib/Graph/libGraph.a lib/Quantization/Base/libQuantizationBase.a lib/Base/libBase.a lib/Support/libSupport.a /usr/lib64/libpng.so tests/googletest/googlemock/gtest/libgtestd.a -pthread /home/rdzhabarov/src/glow-h/llvm_install/lib/libLLVMSupport.a -lz -lrt -ldl -lpthread -lm /home/rdzhabarov/src/glow-h/llvm_install/lib/libLLVMDemangle.a && :
tests/unittests/CMakeFiles/DeviceManagerTest.dir/DeviceManagerTest.cpp.o: In function `CPUDeviceManagerTest_AvailableMemory_Test::TestBody()':
/home/rdzhabarov/src/glow-h/tests/unittests/DeviceManagerTest.cpp:404: undefined reference to `glow::CPUDeviceManager::getMaximumMemory() const'
/home/rdzhabarov/src/glow-h/tests/unittests/DeviceManagerTest.cpp:405: undefined reference to `glow::CPUDeviceManager::getAvailableMemory() const'
/home/rdzhabarov/src/glow-h/tests/unittests/DeviceManagerTest.cpp:406: undefined reference to `glow::CPUDeviceManager::isMemoryAvailable(unsigned long) const'
```

*Testing*:
CI

*Documentation*:
n/a