### PR TITLE
[trivial] Fix Windows build (u_int64_t -> uint64_t)

### DIFF
--- a/lib/Backends/Interpreter/InterpreterDeviceManager.h
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.h
@@ -36,7 +36,7 @@ class InterpreterDeviceManager : public QueueBackedDeviceManager {
 
   /// Static memory cost of the InterpreterFunction.
   /// This is very arbitrary for the Interpreter backend.
-  const u_int64_t functionCost_{1};
+  const uint64_t functionCost_{1};
 
 public:
   InterpreterDeviceManager(llvm::StringRef name = "unnamed",


### PR DESCRIPTION
*Description*: @ayermolo noticed this was wrong, fixing the windows build.
*Testing*: unit tests
*Documentation*: