### PR TITLE
Fix resnet-concurrent example

### DIFF
--- a/examples/resnet-concurrent.cpp
+++ b/examples/resnet-concurrent.cpp
@@ -196,9 +196,11 @@ int main(int argc, char **argv) {
                                   ImageChannelOrder::BGR, ImageLayout::NCHW,
                                   /* useImagenetNormalization */ true);
 
+    Tensor batch = image.getUnowned(inputType->dims());
+
     auto ctx = llvm::make_unique<Context>();
     ctx->allocate(module.getPlaceholders());
-    updateInputPlaceholders(*ctx, {input}, {&image});
+    updateInputPlaceholders(*ctx, {input}, {&batch});
 
     dispatchClassify(started, devices[started % numDevices].get(),
                      std::move(path), output, std::move(ctx), returned,


### PR DESCRIPTION
*Description*: The resnet50 model expects a batch, and we were giving it only a single image which caused a "Mismatch on Placeholder and Tenor types." assertion in the ExecutionEngine. This actually works fine in release, but fixing the debug build is easy.
*Testing*: Ran resnet-concurrent example in Debug.
*Documentation*: