### PR TITLE
Changed DeviceManager::EvictNetwork to use a string instead of llvm::stringRef

### DIFF
--- a/include/glow/Backends/DeviceManager.h
+++ b/include/glow/Backends/DeviceManager.h
@@ -68,7 +68,7 @@ public:
 
   /// Remove (and delete) the provided function, freeing
   /// up space on the device.
-  virtual void evictNetwork(llvm::StringRef functionName) = 0;
+  virtual void evictNetwork(std::string functionName) = 0;
 
   /// Execute the named Function in an already provided network on the device.
   /// functionName must match the name of a function already added.

--- a/include/glow/Backends/QueueBackedDeviceManager.h
+++ b/include/glow/Backends/QueueBackedDeviceManager.h
@@ -55,7 +55,7 @@ public:
 
   /// Remove (and delete) the provided network and all it's functions, freeing
   /// up space on the device.
-  void evictNetwork(llvm::StringRef functionName) override {
+  void evictNetwork(std::string functionName) override {
     workThread_.submit(
         [this, functionName] { evictNetworkImpl(functionName); });
   }
@@ -89,7 +89,7 @@ protected:
   virtual void addNetworkImpl(const Module *, FunctionMapTy, ReadyCBTy) = 0;
 
   /// Remove the module and reclaim it's memory
-  virtual void evictNetworkImpl(llvm::StringRef functionName) = 0;
+  virtual void evictNetworkImpl(std::string functionName) = 0;
 
   /// Execute provided Function.
   virtual void runFunctionImpl(runtime::RunIdentifierTy, std::string,

--- a/lib/Backends/CPU/CPUDeviceManager.cpp
+++ b/lib/Backends/CPU/CPUDeviceManager.cpp
@@ -69,7 +69,7 @@ void CPUDeviceManager::addNetworkImpl(const Module *module,
   readyCB(module, ResultCode::Ready);
 }
 
-void CPUDeviceManager::evictNetworkImpl(llvm::StringRef functionName) {
+void CPUDeviceManager::evictNetworkImpl(std::string functionName) {
   if (functions_.erase(functionName)) {
     usedMemoryBytes_ -= functionCost_; // TODO: static moduleSize
   }

--- a/lib/Backends/CPU/CPUDeviceManager.h
+++ b/lib/Backends/CPU/CPUDeviceManager.h
@@ -58,7 +58,7 @@ public:
 protected:
   void addNetworkImpl(const Module *module, FunctionMapTy functions,
                       ReadyCBTy cb) override;
-  void evictNetworkImpl(llvm::StringRef functionName) override;
+  void evictNetworkImpl(std::string functionName) override;
   void runFunctionImpl(runtime::RunIdentifierTy id, std::string functionName,
                        std::unique_ptr<Context> ctx, ResultCBTy cb) override;
 };

--- a/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
@@ -69,7 +69,7 @@ void InterpreterDeviceManager::addNetworkImpl(const Module *module,
   readyCB(module, ResultCode::Ready);
 }
 
-void InterpreterDeviceManager::evictNetworkImpl(llvm::StringRef functionName) {
+void InterpreterDeviceManager::evictNetworkImpl(std::string functionName) {
   if (functions_.erase(functionName)) {
     usedMemoryBytes_ -= functionCost_; // TODO: static moduleSize
   }

--- a/lib/Backends/Interpreter/InterpreterDeviceManager.h
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.h
@@ -59,7 +59,7 @@ public:
 protected:
   void addNetworkImpl(const Module *module, FunctionMapTy functions,
                       ReadyCBTy cb) override;
-  void evictNetworkImpl(llvm::StringRef functionName) override;
+  void evictNetworkImpl(std::string functionName) override;
   void runFunctionImpl(runtime::RunIdentifierTy id, std::string functionName,
                        std::unique_ptr<Context> ctx, ResultCBTy cb) override;
 };

--- a/tests/unittests/ExecutorTest.cpp
+++ b/tests/unittests/ExecutorTest.cpp
@@ -49,7 +49,7 @@ public:
   void addNetwork(const Module *module, FunctionMapTy functions,
                   ReadyCBTy readyCB) override {}
 
-  void evictNetwork(llvm::StringRef functionName) override {
+  void evictNetwork(std::string functionName) override {
     // Erase the entry so that the same function name can be used to register
     // another result.
     resultMap_.erase(functionName);


### PR DESCRIPTION
*Description*:  Since the work is done on a separate thread there was no guarantee the string would still be backed when the work was done. So changing interface to a string.
*Testing*: DeviceManager tests pass
*Documentation*: NA