### PR TITLE
[Graph Partitioning] Add optimization to minimize communication cost and number of partitions.

### DIFF
--- a/include/glow/Partitioner/PartitionerUtils.h
+++ b/include/glow/Partitioner/PartitionerUtils.h
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_PARTITIONER_PARTITIONUTILS_H
+#define GLOW_PARTITIONER_PARTITIONUTILS_H
+
+#include "glow/Graph/Graph.h"
+
+namespace glow {
+
+/// The memory usage of a subgraph (i.e. a list of nodes of a function).
+struct GraphMemInfo {
+  // The memory usage of all input nodes (whose predecessors are not included in
+  // this subgraph) of this subgraph.
+  uint64_t inMemSize;
+  // The memory usage of all output nodes (whose successors are not included in
+  // this subgraph) of this subgraph.
+  uint64_t outMemSize;
+  // The memory usage of all constants used in this subgraph.
+  uint64_t constMemSize;
+
+  GraphMemInfo() : inMemSize(0), outMemSize(0), constMemSize(0){};
+};
+
+/// Given \p nodes, return a list of nodes who use any node in this set.
+std::vector<Node *> getOutUsers(const std::set<Node *> &nodes);
+
+/// Given \p nodes, return a list of nodes who use only the nodes in this set or
+/// constant.
+std::vector<Node *>
+getOutUsersWithOnePredecessor(const std::set<Node *> &nodes);
+
+/// Return the memory usage of a given nodes set.
+GraphMemInfo getGraphMemInfo(const std::set<Node *> &nodes);
+} // namespace glow
+#endif // GLOW_PARTITIONER_PARTITIONUTILS_H

--- a/lib/Partitioner/CMakeLists.txt
+++ b/lib/Partitioner/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(Partitioner
-            Partitioner.cpp)
+	      PartitionerUtils.cpp
+	      Partitioner.cpp)
 
 target_link_libraries(Partitioner
                       PRIVATE

--- a/lib/Partitioner/PartitionerUtils.cpp
+++ b/lib/Partitioner/PartitionerUtils.cpp
@@ -1,0 +1,130 @@
+
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/Partitioner/PartitionerUtils.h"
+
+#include <set>
+
+namespace glow {
+
+/// Given \p nodes, return a list of nodes who are not in this set but use any
+/// node in this set.
+std::vector<Node *> getOutUsers(const std::set<Node *> &nodes) {
+  std::vector<Node *> ret;
+  for (std::set<Node *>::iterator it = nodes.begin(); it != nodes.end(); ++it) {
+    Node *cur = *it;
+    for (auto &U : cur->getUsers()) {
+      if (nodes.count(U.getUser())) {
+        continue;
+      }
+      ret.push_back(U.getUser());
+    }
+  }
+  return ret;
+}
+
+/// Given \p nodes, return a list of nodes who are not in this set but use only
+/// the nodes in this set or constant.
+std::vector<Node *>
+getOutUsersWithOnePredecessor(const std::set<Node *> &nodes) {
+  std::vector<Node *> ret;
+  for (std::set<Node *>::iterator it = nodes.begin(); it != nodes.end(); ++it) {
+    Node *cur = *it;
+    for (auto &U : cur->getUsers()) {
+      Node *user = U.getUser();
+      if (nodes.count(user)) {
+        continue;
+      }
+      bool flag = true;
+      for (int i = 0, e = user->getNumInputs(); i < e; i++) {
+        Node *in = user->getNthInput(i).getNode();
+        if (llvm::isa<Storage>(in) || nodes.count(in)) {
+          continue;
+        }
+        flag = false;
+        break;
+      }
+      if (flag) {
+        ret.push_back(user);
+      }
+    }
+  }
+  return ret;
+}
+
+GraphMemInfo getGraphMemInfo(const std::set<Node *> &nodes) {
+  GraphMemInfo ret;
+  std::set<Node *> nSet;
+  for (std::set<Node *>::iterator it = nodes.begin(); it != nodes.end(); ++it) {
+    Node *cur = *it;
+    // For Save onde, the only required memory is for output.
+    if (auto *SN = llvm::dyn_cast<SaveNode>(cur)) {
+      Storage *out = llvm::dyn_cast<Storage>(SN->getOutput().getNode());
+      ret.outMemSize += out->getType()->getSizeInBytes();
+      continue;
+    }
+    // Check the inputs of each node in this subgraph and decide if it
+    // contributes to the memory usage:
+    for (int i = 0, e = cur->getNumInputs(); i < e; i++) {
+      Node *node = cur->getNthInput(i).getNode();
+      if (nodes.count(node) || nSet.count(node)) {
+        // This input belongs to this subgraph or it has been considered
+        // already, nothing to do.
+        continue;
+      }
+      nSet.insert(node);
+      Storage *in = llvm::dyn_cast<Storage>(node);
+      if (in) {
+        uint64_t size = in->getType()->getSizeInBytes();
+        if (node->getKind() == Kinded::Kind::ConstantKind) {
+          // Constant.
+          ret.constMemSize += size;
+        } else {
+          // PlaceHolder for Input.
+          ret.inMemSize += size;
+        }
+      } else {
+        // In this case, this input is neither a storage type node nor belongs
+        // to this subgraph. Therefore, when creating paritions, we need to add
+        // a PlaceHolder for the data from outside.
+        for (auto &U : node->getUsers()) {
+          if (U.getUser() == cur) {
+            ret.inMemSize += node->getType(0)->getSizeInBytes();
+            break;
+          }
+        }
+      }
+    }
+    // Check the outputs of each node in this subgraph and decide if it
+    // contributes to the memory usage. Although at the stage, the output may
+    // not be a storage node, after real partitioning, a Save node will be added
+    // to hold the output:
+    for (int i = 0, e = cur->getNumResults(); i < e; i++) {
+      for (auto &U : cur->getNthResult(i).getNode()->getUsers()) {
+        Node *node = U.getUser();
+        if (nodes.count(node) || nSet.count(node)) {
+          // The output belongs to this subgraph, nothing needs to do.
+          continue;
+        }
+        nSet.insert(node);
+        ret.outMemSize += cur->getType(i)->getSizeInBytes();
+      }
+    }
+  }
+  return ret;
+}
+} // namespace glow

--- a/tests/unittests/PartitionerTest.cpp
+++ b/tests/unittests/PartitionerTest.cpp
@@ -196,7 +196,7 @@ TEST_F(PartitionerTest, Basic2) {
   Partitioner myPartitioner(&mod_, devices);
 
   DAGNodeList myList = std::move(myPartitioner.Partition());
-  ASSERT_EQ(mod_.getFunctions().size(), 3);
+  ASSERT_EQ(mod_.getFunctions().size(), 2);
   ASSERT_EQ(myList.roots.size(), 1);
 
   // Run the paritioned graph and compare the results.


### PR DESCRIPTION
*Description*:
Based on the initial partitions, this PR adds:
1) Adjust the initial partition (moving nodes from one partition to another partition) to minimize the communication cost.
2) Combine the partitions if necessary.

*Testing*:
For unittest PartitionerTest::Basic1, the communication cost is `288 bytes->256 bytes`.
For PartitionerTest::Basic2, the communication cost is `160 bytes->64 bytes`. And the number of partitions is `3 -> 2`.  The following 2 pics shows the initial partition and optimized partitions:
**The initial partition ( Memory 2048 bytes. 3 partitions, with memory (1152 bytes, 1152 bytes, 1376 bytes)**
![f1](https://user-images.githubusercontent.com/37386895/52371353-1dd44180-2a0a-11e9-82c1-36c22a679b25.png)

**The optimized partition (Memory 2048 bytes. 2 partitions, with memory (1728, 1728) :**
![new2](https://user-images.githubusercontent.com/37386895/52370747-8f12f500-2a08-11e9-93b0-f4184545f383.png)

*Documentation*: #2298
[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
