### PR TITLE
[format.sh] Alternate extensions for C(++) files

### DIFF
--- a/utils/format.sh
+++ b/utils/format.sh
@@ -30,6 +30,9 @@ print_usage() {
 fix_format() {
   find lib tests/unittests/ tools/ include examples \
     -name \*.h -print0 \
+    -o -name \*.hpp -print0 \
+    -o -name \*.c -print0 \
+    -o -name \*.cc -print0 \
     -o -name \*.cpp -print0 \
     -o -name \*.cl -print0 \
   | xargs -0 -P8 -n1 $CLANG_COMMAND -i;


### PR DESCRIPTION
*Description*: that's it
*Testing*: utils/format.sh fix
*Documentation*: na
