### PR TITLE
Updated Provisioner to allow round robin network-device allocation

### DIFF
--- a/include/glow/Runtime/Provisioner/Provisioner.h
+++ b/include/glow/Runtime/Provisioner/Provisioner.h
@@ -32,12 +32,14 @@ using DeviceIDtoManagerMapTy =
 /// device.
 class Provisioner final {
 public:
+  Provisioner(DeviceIDtoManagerMapTy &devices);
+
   /// Walks \p networks and assigns each function to a DeviceManager in \p
   /// devices. The Provisioner calls the addNetwork method for each
   /// DeviceManager. Returns a ResultCode indicating if the operation was a
   /// success.
   ResultCode provision(std::vector<std::unique_ptr<DAGNode>> &networks,
-                       DeviceIDtoManagerMapTy &devices, Module &module);
+                       Module &module);
 
 private:
   /// Pointer to backend used for compilation. This currently gets reset per
@@ -51,6 +53,13 @@ private:
   /// Padding factor to account for generated code size. Should be greater
   /// than 1.0.
   const float NETWORK_PADDING_FACTOR = 1.1;
+
+  /// List of available DeviceManagers added during initialization.
+  std::vector<std::shared_ptr<DeviceManager>> devices_;
+
+  /// Index of current deviceManager. This allows a round robin loading of
+  /// deviceManagers.
+  unsigned int nextDevice_{0};
 };
 } // namespace runtime
 } // namespace glow

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -30,7 +30,7 @@ using namespace runtime;
 
 HostManager::HostManager(const std::vector<DeviceConfig> &configs) {
   DeviceIDTy deviceCount = 0;
-  provisioner_.reset(new Provisioner());
+
   if (configs.size() > 0) {
     backend_.reset(createBackend(configs[0].backendKind));
   }
@@ -41,7 +41,7 @@ HostManager::HostManager(const std::vector<DeviceConfig> &configs) {
     devices_.emplace(deviceCount, std::move(newDevice));
     deviceCount++;
   }
-
+  provisioner_.reset(new Provisioner(devices_));
   executor_.reset(createExecutor(devices_));
 }
 
@@ -64,7 +64,7 @@ ResultCode HostManager::addNetwork(Module *M) {
   }
   auto partitioner = Partitioner(M, deviceInfo);
   auto nodeList = std::move(partitioner.Partition());
-  auto result = provisioner_->provision(nodeList.roots, devices_, *M);
+  auto result = provisioner_->provision(nodeList.roots, *M);
 
   for (auto &node : nodeList.roots) {
     roots_.emplace(node->name, std::move(node));

--- a/tests/unittests/ProvisionerTest.cpp
+++ b/tests/unittests/ProvisionerTest.cpp
@@ -63,12 +63,13 @@ DAGNodePairTy setupDAG(unsigned rootCount, unsigned childCount) {
 TEST_F(ProvisionerTest, provisionDag) {
   auto mod = setupModule(6);
   auto networks = setupDAG(2, 0);
-  auto provisioner = Provisioner();
+
   std::map<DeviceIDTy, std::shared_ptr<DeviceManager>> devices;
   for (int i = 0; i < 6; i++) {
     std::unique_ptr<DeviceManager> device(new CPUDeviceManager);
     devices.emplace(i, std::move(device));
   }
-  auto result = provisioner.provision(networks.first, devices, *mod.get());
+  auto provisioner = Provisioner(devices);
+  auto result = provisioner.provision(networks.first, *mod.get());
   EXPECT_EQ(result, ResultCode::Ready);
 }


### PR DESCRIPTION
*Description*: Update the Provisioner to remember the last device it assigned to so it can distribute network assignments. This enables a concurrent resnet50 through HostManager example.
*Testing*: Provisioner and HostManager unit tests pass.