### PR TITLE
Remove transformPreLowering()

### DIFF
--- a/docs/NewBackendSpecificNode.md
+++ b/docs/NewBackendSpecificNode.md
@@ -33,7 +33,9 @@ Here are mainly three steps to add a new backend-specific node in Glow:
 
 1. Add a backend-specific Node `FusedAB` to `XSpecificNodes.h`, and a corresponding backend-specific Instruction `FusedAB` to `XSpecificInstrs.h`. Note that the `FusedABInst` needs to be marked with `autoIRGen()` so that the node is automatically IRGen'd to the instruction, as we currently do not support backend-specific IRGen.
 
-2. Add logic to `XBackend::transformPreLowering()` or `XBackend::transformPostLowering()` (or both) depending on when you want to do the transformation. This logic would look for the pattern of nodes you want to fuse (`A` with a single use by `B`), and replaces all uses of the result of B with the new backend-specific `FusedABNode`.
+2. Add logic to `XBackend::transformPostLowering()` that looks for the pattern
+of nodes you want to fuse (`A` with a single use by `B`), and replaces all uses
+of the result of B with the new backend-specific `FusedABNode`.
 
 3. Have your backend `X` implement `FusedABInst`. For example, for the OpenCL backend, this would mean adding a case to enqueue a kernel for the `FusedABInst` to `OpenCLFunction::execute()`, and then adding the corresponding kernel in `kernels.cl`.
 

--- a/include/glow/Backends/Backend.h
+++ b/include/glow/Backends/Backend.h
@@ -57,20 +57,14 @@ public:
     GLOW_UNREACHABLE("Saving a bundle is not supported by the backend");
   }
 
-  /// @name Backend transform methods for different phases.
-  /// These methods are called by the compiler before code generation and gives
-  /// the backend an opportunity to transform the graph before IRGen. The
-  /// backend may insert target specific nodes. The backend is responsible for
+  /// Used by the compiler during graph optimization and before code generation,
+  /// giving the backend an opportunity to transform the graph before IRGen. The
+  /// backend may insert backend-specific nodes. The backend is responsible for
   /// cleaning up after itself.
   /// \returns True if the graph was modified.
-  ///@{
-  virtual bool transformPreLowering(Function *F, CompilationMode mode) const {
-    return false;
-  }
   virtual bool transformPostLowering(Function *F, CompilationMode mode) const {
     return false;
   }
-  /// @}
 
   /// \returns true if backend supports given kind of operation with
   /// the given \p elementTy element type.

--- a/lib/Backends/Backend.cpp
+++ b/lib/Backends/Backend.cpp
@@ -27,13 +27,6 @@ void Backend::optimizeFunction(CompilationMode mode, Function *F) {
   // Optimize the graph.
   ::glow::optimize(F, mode);
 
-  // Allow the backend to transform the graph prior to lowering.
-  if (transformPreLowering(F, mode)) {
-    // Optimize the graph again after the backend transformation.
-    // In particular, DCE is very likely to be useful.
-    ::glow::optimize(F, mode);
-  }
-
   // Lower the graph into a sequence of low-level linear algebra operations.
   ::glow::lower(F, *this);
 


### PR DESCRIPTION
*Description*: As mentioned in https://github.com/pytorch/glow/issues/2339, I don't think we need `transformPreLowering()` anymore.

1. I don't think any of our backends are using this functionality given the ability to prevent lowering via `shouldLower()`, and then later transform the graph during `transformPostLowering()`.
1. Simplify the compilation pipeline since it doesn't seem useful/used.
1. Now that https://github.com/pytorch/glow/pull/2311 has landed, when quantizing we lower prior to `transformPreLowering()` anyway, so it's a misleading function and could cause bugs and/or confusion.

*Testing*: All unit tests still pass.

*Documentation*: Updated.

Closes https://github.com/pytorch/glow/issues/2339