### PR TITLE
Return error if we import tensor with 0 dims

### DIFF
--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -55,6 +55,9 @@ namespace {
 llvm::Error setTensorType(const caffe2::TensorProto &in, Tensor *T) {
   std::vector<size_t> dim;
   for (auto d : in.dims()) {
+    if (d == 0) {
+      RETURN_ERR("0 dimemsion is not supported");
+    }
     dim.push_back(d);
   }
 


### PR DESCRIPTION
*Description*:
Detect 0 dim tensors earlier and return error so that it doesn't goes down into the code and crash the process. 

*Testing*:
*Documentation*:
Fixes https://github.com/pytorch/glow/issues/2369

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
