### PR TITLE
[testing] Move numerical FC tests to OperatorTest

### DIFF
--- a/tests/unittests/Caffe2ImporterTest.cpp
+++ b/tests/unittests/Caffe2ImporterTest.cpp
@@ -612,6 +612,36 @@ TEST(caffe2, FC) {
       llvm::dyn_cast<FullyConnectedNode>(saveNode->getInput().getNode());
   ASSERT_TRUE(fcNode);
 
+  // Check the numerical values of the weights and biases.
+  {
+    const Constant* constant = mod.getConstantByName("weights");
+    ASSERT_TRUE(constant);
+    const Tensor& weights = constant->getPayload();
+    const std::vector<size_t> expectedDimensions = {3, 4};
+    const std::vector<float> expectedValues = {1.0f, 4.0f, 7.0f, 10.0f,   //
+                                               2.0f, 5.0f, 8.0f, 11.0f,   //
+                                               3.0f, 6.0f, 9.0f, 12.0f};
+    EXPECT_EQ(expectedDimensions, weights.dims().vec());
+    ASSERT_EQ(expectedValues.size(), weights.size());
+    const auto& elements = weights.getHandle();
+    for (size_t i = 0; i < expectedValues.size(); ++i) {
+      EXPECT_FLOAT_EQ(expectedValues.at(i), elements.raw(i)) << "Where i = " << i;
+    }
+  }
+  {
+    const Constant* constant = mod.getConstantByName("biases");
+    ASSERT_TRUE(constant);
+    const Tensor& bias = constant->getPayload();
+    const std::vector<size_t> expectedDimensions = {4};
+    const std::vector<float> expectedValues = {0.1f, 0.2f, 0.3f, 0.4f};
+    EXPECT_EQ(expectedDimensions, bias.dims().vec());
+    ASSERT_EQ(expectedValues.size(), bias.size());
+    const auto& elements = bias.getHandle();
+    for (size_t i = 0; i < expectedValues.size(); ++i) {
+      EXPECT_FLOAT_EQ(expectedValues.at(i), elements.raw(i)) << "Where i = " << i;
+    }
+  }
+
   // We don't actually check that the output is correct, because this is
   // already covered in the Operator.FC/* tests.
 }
@@ -654,6 +684,36 @@ TEST(caffe2, FCWithFlatten) {
   ASSERT_TRUE(fcNode);
   auto *reshape = llvm::dyn_cast<ReshapeNode>(fcNode->getInput());
   ASSERT_TRUE(reshape);
+
+  // Check the numerical values of the weights and biases.
+  {
+    const Constant* constant = mod.getConstantByName("weights");
+    ASSERT_TRUE(constant);
+    const Tensor& weights = constant->getPayload();
+    const std::vector<size_t> expectedDimensions = {3, 4};
+    const std::vector<float> expectedValues = {1.0f, 4.0f, 7.0f, 10.0f,   //
+                                               2.0f, 5.0f, 8.0f, 11.0f,   //
+                                               3.0f, 6.0f, 9.0f, 12.0f};
+    EXPECT_EQ(expectedDimensions, weights.dims().vec());
+    ASSERT_EQ(expectedValues.size(), weights.size());
+    const auto& elements = weights.getHandle();
+    for (size_t i = 0; i < expectedValues.size(); ++i) {
+      EXPECT_FLOAT_EQ(expectedValues.at(i), elements.raw(i)) << "Where i = " << i;
+    }
+  }
+  {
+    const Constant* constant = mod.getConstantByName("biases");
+    ASSERT_TRUE(constant);
+    const Tensor& bias = constant->getPayload();
+    const std::vector<size_t> expectedDimensions = {4};
+    const std::vector<float> expectedValues = {0.1f, 0.2f, 0.3f, 0.4f};
+    EXPECT_EQ(expectedDimensions, bias.dims().vec());
+    ASSERT_EQ(expectedValues.size(), bias.size());
+    const auto& elements = bias.getHandle();
+    for (size_t i = 0; i < expectedValues.size(); ++i) {
+      EXPECT_FLOAT_EQ(expectedValues.at(i), elements.raw(i)) << "Where i = " << i;
+    }
+  }
 
   // We don't actually check that the output is correct, because this is
   // already covered in the Operator.FCWithFlatten/* tests.

--- a/tests/unittests/Caffe2ImporterTest.cpp
+++ b/tests/unittests/Caffe2ImporterTest.cpp
@@ -610,7 +610,7 @@ TEST(caffe2, FC) {
   auto *saveNode = getSaveNodeFromDest(output);
   auto *fcNode =
       llvm::dyn_cast<FullyConnectedNode>(saveNode->getInput().getNode());
-  ASSERT_TRUE(fcNode);
+  EXPECT_TRUE(fcNode);
 
   // Check the numerical values of the weights and biases.
   {
@@ -623,7 +623,7 @@ TEST(caffe2, FC) {
                                                3.0f, 6.0f, 9.0f, 12.0f};
     EXPECT_EQ(expectedDimensions, weights.dims().vec());
     ASSERT_EQ(expectedValues.size(), weights.size());
-    const auto &elements = weights.getHandle();
+    const auto elements = weights.getHandle();
     for (size_t i = 0; i < expectedValues.size(); ++i) {
       EXPECT_FLOAT_EQ(expectedValues.at(i), elements.raw(i))
           << "Where i = " << i;
@@ -637,7 +637,7 @@ TEST(caffe2, FC) {
     const std::vector<float> expectedValues = {0.1f, 0.2f, 0.3f, 0.4f};
     EXPECT_EQ(expectedDimensions, bias.dims().vec());
     ASSERT_EQ(expectedValues.size(), bias.size());
-    const auto &elements = bias.getHandle();
+    const auto elements = bias.getHandle();
     for (size_t i = 0; i < expectedValues.size(); ++i) {
       EXPECT_FLOAT_EQ(expectedValues.at(i), elements.raw(i))
           << "Where i = " << i;
@@ -698,7 +698,7 @@ TEST(caffe2, FCWithFlatten) {
                                                3.0f, 6.0f, 9.0f, 12.0f};
     EXPECT_EQ(expectedDimensions, weights.dims().vec());
     ASSERT_EQ(expectedValues.size(), weights.size());
-    const auto &elements = weights.getHandle();
+    const auto elements = weights.getHandle();
     for (size_t i = 0; i < expectedValues.size(); ++i) {
       EXPECT_FLOAT_EQ(expectedValues.at(i), elements.raw(i))
           << "Where i = " << i;
@@ -712,7 +712,7 @@ TEST(caffe2, FCWithFlatten) {
     const std::vector<float> expectedValues = {0.1f, 0.2f, 0.3f, 0.4f};
     EXPECT_EQ(expectedDimensions, bias.dims().vec());
     ASSERT_EQ(expectedValues.size(), bias.size());
-    const auto &elements = bias.getHandle();
+    const auto elements = bias.getHandle();
     for (size_t i = 0; i < expectedValues.size(); ++i) {
       EXPECT_FLOAT_EQ(expectedValues.at(i), elements.raw(i))
           << "Where i = " << i;
@@ -772,7 +772,7 @@ TEST(caffe2, FCTransposed) {
                                                3.0f, 6.0f, 9.0f, 12.0f};
     EXPECT_EQ(expectedDimensions, weights.dims().vec());
     ASSERT_EQ(expectedValues.size(), weights.size());
-    const auto &elements = weights.getHandle();
+    const auto elements = weights.getHandle();
     for (size_t i = 0; i < expectedValues.size(); ++i) {
       EXPECT_FLOAT_EQ(expectedValues.at(i), elements.raw(i))
           << "Where i = " << i;
@@ -786,7 +786,7 @@ TEST(caffe2, FCTransposed) {
     const std::vector<float> expectedValues = {0.1f, 0.2f, 0.3f, 0.4f};
     EXPECT_EQ(expectedDimensions, bias.dims().vec());
     ASSERT_EQ(expectedValues.size(), bias.size());
-    const auto &elements = bias.getHandle();
+    const auto elements = bias.getHandle();
     for (size_t i = 0; i < expectedValues.size(); ++i) {
       EXPECT_FLOAT_EQ(expectedValues.at(i), elements.raw(i))
           << "Where i = " << i;
@@ -847,7 +847,7 @@ TEST(caffe2, FCTransposedWithFlatten) {
                                                3.0f, 6.0f, 9.0f, 12.0f};
     EXPECT_EQ(expectedDimensions, weights.dims().vec());
     ASSERT_EQ(expectedValues.size(), weights.size());
-    const auto &elements = weights.getHandle();
+    const auto elements = weights.getHandle();
     for (size_t i = 0; i < expectedValues.size(); ++i) {
       EXPECT_FLOAT_EQ(expectedValues.at(i), elements.raw(i))
           << "Where i = " << i;
@@ -861,7 +861,7 @@ TEST(caffe2, FCTransposedWithFlatten) {
     const std::vector<float> expectedValues = {0.1f, 0.2f, 0.3f, 0.4f};
     EXPECT_EQ(expectedDimensions, bias.dims().vec());
     ASSERT_EQ(expectedValues.size(), bias.size());
-    const auto &elements = bias.getHandle();
+    const auto elements = bias.getHandle();
     for (size_t i = 0; i < expectedValues.size(); ++i) {
       EXPECT_FLOAT_EQ(expectedValues.at(i), elements.raw(i))
           << "Where i = " << i;

--- a/tests/unittests/Caffe2ImporterTest.cpp
+++ b/tests/unittests/Caffe2ImporterTest.cpp
@@ -605,16 +605,15 @@ TEST(caffe2, FC) {
     updateInputPlaceholdersByName(ctx, &mod, {"inputs"}, {&inputs});
   }
 
-  EE.compile(CompilationMode::Infer, F);
-  EE.run(ctx);
+  // High level check on the content of the graph. We have 1 FC node and 1 save.
+  EXPECT_EQ(F->getNodes().size(), 2);
+  auto *saveNode = getSaveNodeFromDest(output);
+  auto *fcNode =
+      llvm::dyn_cast<FullyConnectedNode>(saveNode->getInput().getNode());
+  ASSERT_TRUE(fcNode);
 
-  auto result = ctx.get(output)->getHandle();
-  std::vector<size_t> expectedDims = {2, 4};
-  std::vector<float> expectedValues = {14.1f, 32.2f, 50.3f,  68.4f,
-                                       32.1f, 77.2f, 122.3f, 167.4f};
-  EXPECT_TRUE(result.dims().vec() == expectedDims);
-  for (size_t i = 0; i < 2 * 4; i++)
-    EXPECT_FLOAT_EQ(result.raw(i), expectedValues[i]);
+  // We don't actually check that the output is correct, because this is
+  // already covered in the Operator.FC/* tests.
 }
 
 /// Test loading a FC node : I * transpose(W) + B, where I is need to be
@@ -656,16 +655,8 @@ TEST(caffe2, FCWithFlatten) {
   auto *reshape = llvm::dyn_cast<ReshapeNode>(fcNode->getInput());
   ASSERT_TRUE(reshape);
 
-  EE.compile(CompilationMode::Infer, F);
-  EE.run(ctx);
-  auto result = ctx.get(output)->getHandle();
-  std::vector<size_t> expectedDims = {2, 4};
-  std::vector<float> expectedValues = {14.1f, 32.2f, 50.3f,  68.4f,
-                                       32.1f, 77.2f, 122.3f, 167.4f};
-  result = ctx.get(output)->getHandle();
-  EXPECT_TRUE(result.dims().vec() == expectedDims);
-  for (size_t i = 0; i < 2 * 4; i++)
-    EXPECT_FLOAT_EQ(result.raw(i), expectedValues[i]);
+  // We don't actually check that the output is correct, because this is
+  // already covered in the Operator.FCWithFlatten/* tests.
 }
 
 /// Test loading a FCTransposed node: I * W + B
@@ -706,16 +697,8 @@ TEST(caffe2, FCTransposed) {
       llvm::dyn_cast<FullyConnectedNode>(saveNode->getInput().getNode());
   ASSERT_TRUE(fcNode);
 
-  EE.compile(CompilationMode::Infer, F);
-  EE.run(ctx);
-
-  auto result = ctx.get(output)->getHandle();
-  std::vector<size_t> expectedDims = {2, 4};
-  std::vector<float> expectedValues = {14.1f, 32.2f, 50.3f,  68.4f,
-                                       32.1f, 77.2f, 122.3f, 167.4f};
-  EXPECT_TRUE(result.dims().vec() == expectedDims);
-  for (size_t i = 0; i < 2 * 4; i++)
-    EXPECT_FLOAT_EQ(result.raw(i), expectedValues[i]);
+  // We don't actually check that the output is correct, because this is
+  // already covered in the Operator.FCWithFlatten/* tests.
 }
 
 /// Test loading a FCTransposed node: I * W + B, where I is need to be flatten.
@@ -757,16 +740,8 @@ TEST(caffe2, FCTransposedWithFlatten) {
   auto *reshape = llvm::dyn_cast<ReshapeNode>(fcNode1->getInput());
   ASSERT_TRUE(reshape);
 
-  EE.compile(CompilationMode::Infer, F);
-  EE.run(ctx);
-  auto result = ctx.get(output)->getHandle();
-  std::vector<size_t> expectedDims = {2, 4};
-  std::vector<float> expectedValues = {14.1f, 32.2f, 50.3f,  68.4f,
-                                       32.1f, 77.2f, 122.3f, 167.4f};
-  result = ctx.get(output)->getHandle();
-  EXPECT_TRUE(result.dims().vec() == expectedDims);
-  for (size_t i = 0; i < 2 * 4; i++)
-    EXPECT_FLOAT_EQ(result.raw(i), expectedValues[i]);
+  // We don't actually check that the output is correct, because this is
+  // already covered in the Operator.FCWithFlatten/* tests.
 }
 
 /// Test loading clip op from a Caffe2 model.

--- a/tests/unittests/Caffe2ImporterTest.cpp
+++ b/tests/unittests/Caffe2ImporterTest.cpp
@@ -614,31 +614,33 @@ TEST(caffe2, FC) {
 
   // Check the numerical values of the weights and biases.
   {
-    const Constant* constant = mod.getConstantByName("weights");
+    const Constant *constant = mod.getConstantByName("weights");
     ASSERT_TRUE(constant);
-    const Tensor& weights = constant->getPayload();
+    const Tensor &weights = constant->getPayload();
     const std::vector<size_t> expectedDimensions = {3, 4};
-    const std::vector<float> expectedValues = {1.0f, 4.0f, 7.0f, 10.0f,   //
-                                               2.0f, 5.0f, 8.0f, 11.0f,   //
+    const std::vector<float> expectedValues = {1.0f, 4.0f, 7.0f, 10.0f, //
+                                               2.0f, 5.0f, 8.0f, 11.0f, //
                                                3.0f, 6.0f, 9.0f, 12.0f};
     EXPECT_EQ(expectedDimensions, weights.dims().vec());
     ASSERT_EQ(expectedValues.size(), weights.size());
-    const auto& elements = weights.getHandle();
+    const auto &elements = weights.getHandle();
     for (size_t i = 0; i < expectedValues.size(); ++i) {
-      EXPECT_FLOAT_EQ(expectedValues.at(i), elements.raw(i)) << "Where i = " << i;
+      EXPECT_FLOAT_EQ(expectedValues.at(i), elements.raw(i))
+          << "Where i = " << i;
     }
   }
   {
-    const Constant* constant = mod.getConstantByName("biases");
+    const Constant *constant = mod.getConstantByName("biases");
     ASSERT_TRUE(constant);
-    const Tensor& bias = constant->getPayload();
+    const Tensor &bias = constant->getPayload();
     const std::vector<size_t> expectedDimensions = {4};
     const std::vector<float> expectedValues = {0.1f, 0.2f, 0.3f, 0.4f};
     EXPECT_EQ(expectedDimensions, bias.dims().vec());
     ASSERT_EQ(expectedValues.size(), bias.size());
-    const auto& elements = bias.getHandle();
+    const auto &elements = bias.getHandle();
     for (size_t i = 0; i < expectedValues.size(); ++i) {
-      EXPECT_FLOAT_EQ(expectedValues.at(i), elements.raw(i)) << "Where i = " << i;
+      EXPECT_FLOAT_EQ(expectedValues.at(i), elements.raw(i))
+          << "Where i = " << i;
     }
   }
 
@@ -687,31 +689,33 @@ TEST(caffe2, FCWithFlatten) {
 
   // Check the numerical values of the weights and biases.
   {
-    const Constant* constant = mod.getConstantByName("weights");
+    const Constant *constant = mod.getConstantByName("weights");
     ASSERT_TRUE(constant);
-    const Tensor& weights = constant->getPayload();
+    const Tensor &weights = constant->getPayload();
     const std::vector<size_t> expectedDimensions = {3, 4};
-    const std::vector<float> expectedValues = {1.0f, 4.0f, 7.0f, 10.0f,   //
-                                               2.0f, 5.0f, 8.0f, 11.0f,   //
+    const std::vector<float> expectedValues = {1.0f, 4.0f, 7.0f, 10.0f, //
+                                               2.0f, 5.0f, 8.0f, 11.0f, //
                                                3.0f, 6.0f, 9.0f, 12.0f};
     EXPECT_EQ(expectedDimensions, weights.dims().vec());
     ASSERT_EQ(expectedValues.size(), weights.size());
-    const auto& elements = weights.getHandle();
+    const auto &elements = weights.getHandle();
     for (size_t i = 0; i < expectedValues.size(); ++i) {
-      EXPECT_FLOAT_EQ(expectedValues.at(i), elements.raw(i)) << "Where i = " << i;
+      EXPECT_FLOAT_EQ(expectedValues.at(i), elements.raw(i))
+          << "Where i = " << i;
     }
   }
   {
-    const Constant* constant = mod.getConstantByName("biases");
+    const Constant *constant = mod.getConstantByName("biases");
     ASSERT_TRUE(constant);
-    const Tensor& bias = constant->getPayload();
+    const Tensor &bias = constant->getPayload();
     const std::vector<size_t> expectedDimensions = {4};
     const std::vector<float> expectedValues = {0.1f, 0.2f, 0.3f, 0.4f};
     EXPECT_EQ(expectedDimensions, bias.dims().vec());
     ASSERT_EQ(expectedValues.size(), bias.size());
-    const auto& elements = bias.getHandle();
+    const auto &elements = bias.getHandle();
     for (size_t i = 0; i < expectedValues.size(); ++i) {
-      EXPECT_FLOAT_EQ(expectedValues.at(i), elements.raw(i)) << "Where i = " << i;
+      EXPECT_FLOAT_EQ(expectedValues.at(i), elements.raw(i))
+          << "Where i = " << i;
     }
   }
 
@@ -757,6 +761,38 @@ TEST(caffe2, FCTransposed) {
       llvm::dyn_cast<FullyConnectedNode>(saveNode->getInput().getNode());
   ASSERT_TRUE(fcNode);
 
+  // Check the numerical values of the weights and biases.
+  {
+    const Constant *constant = mod.getConstantByName("weights");
+    ASSERT_TRUE(constant);
+    const Tensor &weights = constant->getPayload();
+    const std::vector<size_t> expectedDimensions = {3, 4};
+    const std::vector<float> expectedValues = {1.0f, 4.0f, 7.0f, 10.0f, //
+                                               2.0f, 5.0f, 8.0f, 11.0f, //
+                                               3.0f, 6.0f, 9.0f, 12.0f};
+    EXPECT_EQ(expectedDimensions, weights.dims().vec());
+    ASSERT_EQ(expectedValues.size(), weights.size());
+    const auto &elements = weights.getHandle();
+    for (size_t i = 0; i < expectedValues.size(); ++i) {
+      EXPECT_FLOAT_EQ(expectedValues.at(i), elements.raw(i))
+          << "Where i = " << i;
+    }
+  }
+  {
+    const Constant *constant = mod.getConstantByName("biases");
+    ASSERT_TRUE(constant);
+    const Tensor &bias = constant->getPayload();
+    const std::vector<size_t> expectedDimensions = {4};
+    const std::vector<float> expectedValues = {0.1f, 0.2f, 0.3f, 0.4f};
+    EXPECT_EQ(expectedDimensions, bias.dims().vec());
+    ASSERT_EQ(expectedValues.size(), bias.size());
+    const auto &elements = bias.getHandle();
+    for (size_t i = 0; i < expectedValues.size(); ++i) {
+      EXPECT_FLOAT_EQ(expectedValues.at(i), elements.raw(i))
+          << "Where i = " << i;
+    }
+  }
+
   // We don't actually check that the output is correct, because this is
   // already covered in the Operator.FCWithFlatten/* tests.
 }
@@ -799,6 +835,38 @@ TEST(caffe2, FCTransposedWithFlatten) {
   ASSERT_TRUE(fcNode1);
   auto *reshape = llvm::dyn_cast<ReshapeNode>(fcNode1->getInput());
   ASSERT_TRUE(reshape);
+
+  // Check the numerical values of the weights and biases.
+  {
+    const Constant *constant = mod.getConstantByName("weights");
+    ASSERT_TRUE(constant);
+    const Tensor &weights = constant->getPayload();
+    const std::vector<size_t> expectedDimensions = {3, 4};
+    const std::vector<float> expectedValues = {1.0f, 4.0f, 7.0f, 10.0f, //
+                                               2.0f, 5.0f, 8.0f, 11.0f, //
+                                               3.0f, 6.0f, 9.0f, 12.0f};
+    EXPECT_EQ(expectedDimensions, weights.dims().vec());
+    ASSERT_EQ(expectedValues.size(), weights.size());
+    const auto &elements = weights.getHandle();
+    for (size_t i = 0; i < expectedValues.size(); ++i) {
+      EXPECT_FLOAT_EQ(expectedValues.at(i), elements.raw(i))
+          << "Where i = " << i;
+    }
+  }
+  {
+    const Constant *constant = mod.getConstantByName("biases");
+    ASSERT_TRUE(constant);
+    const Tensor &bias = constant->getPayload();
+    const std::vector<size_t> expectedDimensions = {4};
+    const std::vector<float> expectedValues = {0.1f, 0.2f, 0.3f, 0.4f};
+    EXPECT_EQ(expectedDimensions, bias.dims().vec());
+    ASSERT_EQ(expectedValues.size(), bias.size());
+    const auto &elements = bias.getHandle();
+    for (size_t i = 0; i < expectedValues.size(); ++i) {
+      EXPECT_FLOAT_EQ(expectedValues.at(i), elements.raw(i))
+          << "Where i = " << i;
+    }
+  }
 
   // We don't actually check that the output is correct, because this is
   // already covered in the Operator.FCWithFlatten/* tests.

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -1867,8 +1867,9 @@ TEST_P(Operator, FCWithFlatten) {
   std::vector<float> expectedValues = {14.1f, 32.2f, 50.3f,  68.4f,
                                        32.1f, 77.2f, 122.3f, 167.4f};
   EXPECT_TRUE(result.dims().vec() == expectedDimensions);
-  for (size_t i = 0; i < 2 * 4; i++)
+  for (size_t i = 0; i < 2 * 4; i++) {
     EXPECT_FLOAT_EQ(result.raw(i), expectedValues[i]);
+  }
 }
 
 TEST_P(Operator, IntFC) {

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -1842,34 +1842,6 @@ TEST_P(InterpAndCPU, IntConcat) {
   }
 }
 
-TEST_P(Operator, FC) {
-  auto *input =
-      mod_.createPlaceholder(ElemKind::FloatTy, {2, 3}, "input", false);
-  auto *weights =
-      mod_.createPlaceholder(ElemKind::FloatTy, {3, 4}, "weights", true);
-  auto *bias = mod_.createPlaceholder(ElemKind::FloatTy, {4}, "bias", true);
-
-  ctx_.allocate(input)->getHandle() = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
-  ctx_.allocate(weights)->getHandle() = {1.0f, 4.0f,  7.0f, 10.0f, 2.0f, 5.0f,
-                                         8.0f, 11.0f, 3.0f, 6.0f,  9.0f, 12.0f};
-  ctx_.allocate(bias)->getHandle() = {0.1f, 0.2f, 0.3f, 0.4f};
-
-  auto *FC = F_->createFullyConnected("fc", input, weights, bias);
-  auto *S = F_->createSave("save", FC);
-  ctx_.allocate(S->getPlaceholder());
-
-  EE_.compile(CompilationMode::Infer, F_);
-  EE_.run(ctx_);
-
-  auto result = ctx_.get(S->getPlaceholder())->getHandle();
-  std::vector<size_t> expectedDimensions = {2, 4};
-  std::vector<float> expectedValues = {14.1f, 32.2f, 50.3f,  68.4f,
-                                       32.1f, 77.2f, 122.3f, 167.4f};
-  EXPECT_TRUE(result.dims().vec() == expectedDimensions);
-  for (size_t i = 0; i < 2 * 4; i++)
-    EXPECT_FLOAT_EQ(result.raw(i), expectedValues[i]);
-}
-
 TEST_P(Operator, FCWithFlatten) {
   auto *input =
       mod_.createPlaceholder(ElemKind::FloatTy, {2, 1, 3}, "input", false);
@@ -1878,8 +1850,9 @@ TEST_P(Operator, FCWithFlatten) {
   auto *bias = mod_.createPlaceholder(ElemKind::FloatTy, {4}, "bias", true);
 
   ctx_.allocate(input)->getHandle() = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
-  ctx_.allocate(weights)->getHandle() = {1.0f, 4.0f,  7.0f, 10.0f, 2.0f, 5.0f,
-                                         8.0f, 11.0f, 3.0f, 6.0f,  9.0f, 12.0f};
+  ctx_.allocate(weights)->getHandle() = {1.0f, 4.0f, 7.0f, 10.0f, //
+                                         2.0f, 5.0f, 8.0f, 11.0f, //
+                                         3.0f, 6.0f, 9.0f, 12.0f};
   ctx_.allocate(bias)->getHandle() = {0.1f, 0.2f, 0.3f, 0.4f};
 
   auto *FC = F_->createFullyConnected("fc", input, weights, bias);


### PR DESCRIPTION
Move the parts of `Caffe2ImporterTest` that check numerical correctness over to `OperatorTest`, to better separate FC operator loading tests from numerical correctness tests.