### PR TITLE
[Conv3D] Types, plumbing, and verification

### DIFF
--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -90,6 +90,34 @@ struct ShapeNHWC {
   }
 };
 
+struct ShapeNHWCT {
+  size_t n; // Number of samples
+  size_t h; // Height
+  size_t w; // Width
+  size_t c; // Number of Channels
+  size_t t; // Time
+
+  template <typename T> explicit ShapeNHWCT(llvm::ArrayRef<T> shape) {
+    assert(shape.size() == 5 && "Invalid shape");
+    n = shape[0];
+    h = shape[1];
+    w = shape[2];
+    c = shape[3];
+    t = shape[4];
+  }
+
+  static ShapeNHWCT empty() { return ShapeNHWCT(0, 0, 0, 0, 0); }
+
+  explicit ShapeNHWCT(size_t samples, size_t height, size_t width,
+                      size_t channels, size_t time)
+      : n(samples), h(height), w(width), c(channels), t(time) {}
+
+  bool equals(const ShapeNHWCT &other) const {
+    return n == other.n && h == other.h && w == other.w && c == other.c &&
+           t == other.t;
+  }
+};
+
 struct ShapeNCHW {
   size_t n; // Number of samples
   size_t c; // Number of Channels
@@ -144,6 +172,30 @@ struct PaddingTLBR {
   }
 };
 
+struct PaddingTLBRNF {
+  size_t top;
+  size_t left;
+  size_t bottom;
+  size_t right;
+  size_t near;
+  size_t far;
+
+  template <typename T> explicit PaddingTLBRNF(llvm::ArrayRef<T> pads) {
+    assert(pads.size() == 6 && "Invalid padding");
+    top = pads[0];
+    left = pads[1];
+    bottom = pads[2];
+    right = pads[3];
+    near = pads[4];
+    far = pads[5];
+  }
+
+  bool equalPadding() const {
+    return top == left && top == bottom && top == right && top == near &&
+           top == far;
+  }
+};
+
 struct ShapeHW {
   size_t height;
   size_t width;
@@ -155,6 +207,21 @@ struct ShapeHW {
   }
 
   bool isSquare() const { return height == width; }
+};
+
+struct ShapeHWT {
+  size_t height;
+  size_t width;
+  size_t time;
+
+  template <typename T> explicit ShapeHWT(llvm::ArrayRef<T> shape) {
+    assert(shape.size() == 3 && "Invalid shape");
+    height = shape[0];
+    width = shape[1];
+    time = shape[2];
+  }
+
+  bool isCube() const { return height == width && height == time; }
 };
 
 /// Collapse a tensor shape into two sizes: the first n dimensions and the size
@@ -179,6 +246,10 @@ inline bool operator==(const ShapeNHWC &LHS, const ShapeNHWC &RHS) {
 }
 
 inline bool operator==(const ShapeNCHW &LHS, const ShapeNCHW &RHS) {
+  return LHS.equals(RHS);
+}
+
+inline bool operator==(const ShapeNHWCT &LHS, const ShapeNHWCT &RHS) {
   return LHS.equals(RHS);
 }
 

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -242,6 +242,20 @@ public:
                               unsigned_t kernel, unsigned_t stride,
                               unsigned_t pad, unsigned_t group);
 
+  Convolution3DNode *createConv3D(llvm::StringRef name, NodeValue input,
+                                  NodeValue filter, NodeValue bias,
+                                  TypeRef outTy,
+                                  llvm::ArrayRef<unsigned_t> kernels,
+                                  llvm::ArrayRef<unsigned_t> strides,
+                                  llvm::ArrayRef<unsigned_t> pads,
+                                  unsigned_t group);
+
+  Convolution3DNode *createConv3D(llvm::StringRef name, NodeValue input,
+                                  NodeValue filter, NodeValue bias,
+                                  TypeRef outTy, unsigned_t kernel,
+                                  unsigned_t stride, unsigned_t pad,
+                                  unsigned_t group);
+
   ConvertToNode *createConvertTo(llvm::StringRef name, NodeValue input,
                                  TypeRef outTy);
 
@@ -811,16 +825,28 @@ public:
                            float momentum = 0.9);
 
   ConvolutionNode *createConv(Context &ctx, llvm::StringRef name,
-                              NodeValue input, size_t depth,
+                              NodeValue input, size_t outChannels,
                               llvm::ArrayRef<unsigned_t> kernels,
                               llvm::ArrayRef<unsigned_t> strides,
                               llvm::ArrayRef<unsigned_t> pads,
                               unsigned_t group);
 
   ConvolutionNode *createConv(Context &ctx, llvm::StringRef name,
-                              NodeValue input, size_t depth, unsigned_t kernel,
-                              unsigned_t stride, unsigned_t pad,
-                              unsigned_t group);
+                              NodeValue input, size_t outChannels,
+                              unsigned_t kernel, unsigned_t stride,
+                              unsigned_t pad, unsigned_t group);
+
+  Convolution3DNode *createConv3D(Context &ctx, llvm::StringRef name,
+                                  NodeValue input, size_t outChannels,
+                                  llvm::ArrayRef<unsigned_t> kernels,
+                                  llvm::ArrayRef<unsigned_t> strides,
+                                  llvm::ArrayRef<unsigned_t> pads,
+                                  unsigned_t group);
+
+  Convolution3DNode *createConv3D(Context &ctx, llvm::StringRef name,
+                                  NodeValue input, size_t outChannels,
+                                  unsigned_t kernel, unsigned_t stride,
+                                  unsigned_t pad, unsigned_t group);
 
   /// Create a fully connected node with the given \p name, \p input and \p
   /// output depth. Trainable weight and bias variables are created implicitly.

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -230,6 +230,13 @@ public:
   PadNode *createPad(llvm::StringRef name, NodeValue input, TypeRef outTy,
                      unsigned_t mode, llvm::ArrayRef<int> pads, float value);
 
+  /// Creates a ConvolutionNode with the given \p name which convolves the 4D
+  /// \p input with \p filter and \bias. \p kernels defines the size of the
+  /// height and width dimensions of the filters. \p strides defines the number
+  /// of steps to take in the input for each output cell. \p pads defines how
+  /// many zero padding cells should be added to the input during convolution.
+  /// \p group defines the number of groups the input and output channels should
+  /// be divided into and convolved separately.
   ConvolutionNode *createConv(llvm::StringRef name, NodeValue input,
                               NodeValue filter, NodeValue bias, TypeRef outTy,
                               llvm::ArrayRef<unsigned_t> kernels,
@@ -237,11 +244,26 @@ public:
                               llvm::ArrayRef<unsigned_t> pads,
                               unsigned_t group);
 
+  /// Creates a ConvolutionNode with the given \p name which convolves the 4D
+  /// \p input with \p filter and \bias. \p kernel defines the size of the
+  /// height and width dimensions of the filters. \p stride defines the number
+  /// of steps to take in the input for each output cell. \p pad defines how
+  /// many zero padding cells should be added to the input during convolution.
+  /// \p group defines the number of groups the input and output channels should
+  /// be divided into and convolved separately.
   ConvolutionNode *createConv(llvm::StringRef name, NodeValue input,
                               NodeValue filter, NodeValue bias, TypeRef outTy,
                               unsigned_t kernel, unsigned_t stride,
                               unsigned_t pad, unsigned_t group);
 
+  /// Creates a Convolution3DNode with the given \p name which convolves the 5D
+  /// \p input with \p filter and \bias. \p kernels defines the size of the
+  /// height, width, and time dimensions of the filters. \p strides defines the
+  /// the number of steps to take in the input for each output cell. \p pads
+  /// defines how many zero padding cells should be added to the input during
+  /// convolution. \p group defines the number of groups the input and output
+  /// channels should be divided into and convolved separately. \p outTy defines
+  /// the type of the output of the 3d convolution.
   Convolution3DNode *createConv3D(llvm::StringRef name, NodeValue input,
                                   NodeValue filter, NodeValue bias,
                                   TypeRef outTy,
@@ -250,6 +272,14 @@ public:
                                   llvm::ArrayRef<unsigned_t> pads,
                                   unsigned_t group);
 
+  /// Creates a Convolution3DNode with the given \p name which convolves the 5D
+  /// \p input with \p filter and \bias. \p kernel defines the size of the
+  /// height, width, and time dimensions of the filters. \p stride defines the
+  /// the number of steps to take in the input for each output cell. \p pad
+  /// defines how many zero padding cells should be added to the input during
+  /// convolution. \p group defines the number of groups the input and output
+  /// channels should be divided into and convolved separately. \p outTy defines
+  /// the type of the output of the 3d convolution.
   Convolution3DNode *createConv3D(llvm::StringRef name, NodeValue input,
                                   NodeValue filter, NodeValue bias,
                                   TypeRef outTy, unsigned_t kernel,
@@ -824,6 +854,13 @@ public:
                            unsigned_t channelIdx = 0, float epsilon = 1e-5,
                            float momentum = 0.9);
 
+  /// Creates a ConvolutionNode with the given \p name which convolves the 4D
+  /// \p input. \p kernels defines the size of the height and width dimensions
+  /// of the convolutional filters. \p stride defines the the number of steps
+  /// to take in the input for each output cell. \p pads defines how many zero
+  /// padding cells should be added to the input during convolution. \p group
+  /// defines the number of groups the input and output channels should be
+  /// divided into and convolved separately.
   ConvolutionNode *createConv(Context &ctx, llvm::StringRef name,
                               NodeValue input, size_t outChannels,
                               llvm::ArrayRef<unsigned_t> kernels,
@@ -831,11 +868,25 @@ public:
                               llvm::ArrayRef<unsigned_t> pads,
                               unsigned_t group);
 
+  /// Creates a ConvolutionNode with the given \p name which convolves the 4D
+  /// \p input. \p kernel defines the size of the height and width dimensions of
+  /// the convolutional filters. \p stride defines the the number of steps to
+  /// take in the input for each output cell. \p pad defines how many zero
+  /// padding cells should be added to the input during convolution. \p group
+  /// defines the number of groups the input and output channels should be
+  /// divided into and convolved separately.
   ConvolutionNode *createConv(Context &ctx, llvm::StringRef name,
                               NodeValue input, size_t outChannels,
                               unsigned_t kernel, unsigned_t stride,
                               unsigned_t pad, unsigned_t group);
 
+  /// Creates a Convolution3DNode with the given \p name which convolves the 5D
+  /// \p input. \p kernels defines the size of the height, width, and time
+  /// dimensions of the convolutional filters. \p strides defines the the number
+  /// of steps to take in the input for each output cell. \p pads defines how
+  /// many zero padding cells should be added to the input during convolution.
+  /// \p group defines the number of groups the input and output channels should
+  /// be divided into and convolved separately.
   Convolution3DNode *createConv3D(Context &ctx, llvm::StringRef name,
                                   NodeValue input, size_t outChannels,
                                   llvm::ArrayRef<unsigned_t> kernels,
@@ -843,6 +894,13 @@ public:
                                   llvm::ArrayRef<unsigned_t> pads,
                                   unsigned_t group);
 
+  /// Creates a Convolution3DNode with the given \p name which convolves the 5D
+  /// \p input. \p kernel defines the size of the height, width, and time
+  /// dimensions of the convolutional filters. \p stride defines the the number
+  /// of steps to take in the input for each output cell. \p pad defines how
+  /// many zero padding cells should be added to the input during convolution.
+  /// \p group defines the number of groups the input and output channels should
+  /// be divided into and convolved separately.
   Convolution3DNode *createConv3D(Context &ctx, llvm::StringRef name,
                                   NodeValue input, size_t outChannels,
                                   unsigned_t kernel, unsigned_t stride,

--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -150,6 +150,25 @@ inline std::pair<size_t, size_t> calculateConvPoolOutputDims(
   return {outsx, outsy};
 }
 
+/// Calculate the size of the output tensor based on the 3D convolution/pooling
+/// parameters \p inH \p inW, \p inT which are the input's height, width, and
+/// time respectively.
+inline ShapeHWT calculate3DConvPoolOutputDims(
+    size_t inH, size_t inW, size_t inT, llvm::ArrayRef<unsigned_t> kernels,
+    llvm::ArrayRef<unsigned_t> strides, llvm::ArrayRef<unsigned_t> pads) {
+  PaddingTLBRNF pdim(pads);
+  ShapeHWT kdim(kernels);
+  ShapeHWT sdim(strides);
+
+  size_t outH =
+      ((inH + pdim.top + pdim.bottom - kdim.height) / sdim.height + 1);
+  size_t outW = ((inW + pdim.left + pdim.right - kdim.width) / sdim.width + 1);
+  size_t outT = ((inT + pdim.near + pdim.far - kdim.time) / sdim.time + 1);
+
+  llvm::SmallVector<size_t, 3> outDims{outH, outW, outT};
+  return ShapeHWT(llvm::makeArrayRef(outDims));
+}
+
 /// Modes of the padding operation.
 enum PaddingMode { CONSTANT = 0, REFLECT, EDGE };
 

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -348,6 +348,20 @@ void BoundInterpreterFunction::fwdConvolutionGradInst(
   }         // N
 }
 
+void BoundInterpreterFunction::fwdConvolution3DInst(
+    const Convolution3DInst *I) {
+  (void)I;
+  // TODO
+  llvm_unreachable("not yet implemented");
+}
+
+void BoundInterpreterFunction::fwdConvolution3DGradInst(
+    const Convolution3DGradInst *I) {
+  (void)I;
+  // TODO
+  llvm_unreachable("not yet implemented");
+}
+
 //===----------------------------------------------------------------------===//
 //                       Pooling
 //===----------------------------------------------------------------------===//

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -467,6 +467,20 @@ static void checkKernelSize(ShapeNHWC idim, llvm::ArrayRef<unsigned_t> kernels,
          "Kernel size is too large");
 }
 
+/// Check the kernel size for 3D Conv/Pooling ops.
+static void check3DKernelSize(ShapeNHWCT idim,
+                              llvm::ArrayRef<unsigned_t> kernels,
+                              llvm::ArrayRef<unsigned_t> pads) {
+  PaddingTLBRNF pdim(pads);
+  (void)pdim;
+  ShapeHWT kdim(kernels);
+  (void)kdim;
+  assert((idim.w + pdim.left + pdim.right) >= kdim.width &&
+         (idim.h + pdim.top + pdim.bottom) >= kdim.height &&
+         (idim.t + pdim.near + pdim.far) >= kdim.time &&
+         "Kernel size is too large");
+}
+
 /// Check that the dimensions that are passed in when the convolution is
 /// constructed are correct.
 static void assertConvDims(NodeValue input, NodeValue filter, NodeValue bias,
@@ -486,6 +500,32 @@ static void assertConvDims(NodeValue input, NodeValue filter, NodeValue bias,
   (void)filterDims;
 
   assert(bias.getType()->size() == filterDims[0] && "Invalid bias size");
+}
+
+static void assertConv3DDims(NodeValue input, NodeValue filter, NodeValue bias,
+                             llvm::ArrayRef<unsigned_t> kernels,
+                             llvm::ArrayRef<unsigned_t> strides,
+                             llvm::ArrayRef<unsigned_t> pads,
+                             unsigned_t group) {
+
+  ShapeNHWCT idim(input.dims());
+  ShapeHWT kdim(kernels);
+  (void)kdim;
+  check3DKernelSize(idim, kernels, pads);
+  assert(idim.c % group == 0 && "channels number must be divisible by groups");
+
+  // NOTE: here the N in NHWCT is abnormal because it is the number of filters
+  // (and therefore the number of output channels of the 3d conv) and not the
+  // batch size. The rest of the dimensions are representative of the input
+  // dimensions to the convolution.
+  ShapeNHWCT filterDims(filter.dims());
+
+  assert(filterDims.n % group == 0 && filterDims.h == kdim.height &&
+         filterDims.w == kdim.width && filterDims.c == idim.c / group &&
+         filterDims.t == kdim.time && "Invalid filter dims");
+  (void)filterDims;
+
+  assert(bias.getType()->size() == filterDims.n && "Invalid bias size");
 }
 
 ConvolutionNode *Function::createConv(llvm::StringRef name, NodeValue input,
@@ -511,6 +551,31 @@ ConvolutionNode *Function::createConv(llvm::StringRef name, NodeValue input,
   llvm::SmallVector<unsigned_t, 2> kernels = {kernel, kernel};
   return createConv(name, input, filter, bias, outTy, kernels, strides, pads,
                     group);
+}
+
+Convolution3DNode *Function::createConv3D(llvm::StringRef name, NodeValue input,
+                                          NodeValue filter, NodeValue bias,
+                                          TypeRef outTy,
+                                          llvm::ArrayRef<unsigned_t> kernels,
+                                          llvm::ArrayRef<unsigned_t> strides,
+                                          llvm::ArrayRef<unsigned_t> pads,
+                                          unsigned_t group) {
+  assertConv3DDims(input, filter, bias, kernels, strides, pads, group);
+  auto OT = getParent()->uniqueType(*outTy);
+  return addNode(new Convolution3DNode(name, OT, input, filter, bias, kernels,
+                                       strides, pads, group));
+}
+
+Convolution3DNode *Function::createConv3D(llvm::StringRef name, NodeValue input,
+                                          NodeValue filter, NodeValue bias,
+                                          TypeRef outTy, unsigned_t kernel,
+                                          unsigned_t stride, unsigned_t pad,
+                                          unsigned_t group) {
+  llvm::SmallVector<unsigned_t, 6> pads = {pad, pad, pad, pad, pad, pad};
+  llvm::SmallVector<unsigned_t, 3> strides = {stride, stride, stride};
+  llvm::SmallVector<unsigned_t, 3> kernels = {kernel, kernel, kernel};
+  return createConv3D(name, input, filter, bias, outTy, kernels, strides, pads,
+                      group);
 }
 
 MaxPoolNode *Function::createMaxPool(llvm::StringRef name, NodeValue input,
@@ -1902,7 +1967,7 @@ Function::createBatchNormalization(Context &ctx, llvm::StringRef name,
 }
 
 ConvolutionNode *Function::createConv(Context &ctx, llvm::StringRef name,
-                                      NodeValue input, size_t depth,
+                                      NodeValue input, size_t outChannels,
                                       llvm::ArrayRef<unsigned_t> kernels,
                                       llvm::ArrayRef<unsigned_t> strides,
                                       llvm::ArrayRef<unsigned_t> pads,
@@ -1917,17 +1982,18 @@ ConvolutionNode *Function::createConv(Context &ctx, llvm::StringRef name,
 
   assert(group > 0 && "group should be larger than 0");
   assert(idim.c % group == 0 && "channels number must be divisible by groups");
-  assert(depth % group == 0 && "depth must be divisible by groups");
+  assert(outChannels % group == 0 && "outChannels must be divisible by groups");
 
   // Calculate the size and allocate the output buffer.
   auto outSz =
       calculateConvPoolOutputDims(idim.h, idim.w, kernels, strides, pads);
 
-  std::array<size_t, 4> outDims = {{idim.n, outSz.first, outSz.second, depth}};
+  std::array<size_t, 4> outDims = {
+      {idim.n, outSz.first, outSz.second, outChannels}};
 
   // Allocate the Filter and Bias tensors.
   std::array<size_t, 4> filterDim = {
-      {depth, kdim.height, kdim.width, idim.c / group}};
+      {outChannels, kdim.height, kdim.width, idim.c / group}};
   size_t fanIn = kdim.height * kdim.width * idim.c;
   ElemKind inputTy = input.getType()->getElementType();
   assert((inputTy == ElemKind::FloatTy || inputTy == ElemKind::Float16Ty) &&
@@ -1936,7 +2002,8 @@ ConvolutionNode *Function::createConv(Context &ctx, llvm::StringRef name,
       getParent()->createPlaceholder(inputTy, filterDim, "filter", true);
   ctx.allocate(filter)->init(glow::Tensor::InitKind::Xavier, fanIn, getPRNG());
 
-  auto *bias = getParent()->createPlaceholder(inputTy, {depth}, "bias", true);
+  auto *bias =
+      getParent()->createPlaceholder(inputTy, {outChannels}, "bias", true);
   ctx.allocate(bias)->init(glow::Tensor::InitKind::Broadcast, 0.1, getPRNG());
 
   auto OT = getParent()->uniqueType(inputTy, outDims);
@@ -1946,13 +2013,73 @@ ConvolutionNode *Function::createConv(Context &ctx, llvm::StringRef name,
 }
 
 ConvolutionNode *Function::createConv(Context &ctx, llvm::StringRef name,
-                                      NodeValue input, size_t depth,
+                                      NodeValue input, size_t outChannels,
                                       unsigned_t kernel, unsigned_t stride,
                                       unsigned_t pad, unsigned_t group) {
   llvm::SmallVector<unsigned_t, 4> pads = {pad, pad, pad, pad};
   llvm::SmallVector<unsigned_t, 2> strides = {stride, stride};
   llvm::SmallVector<unsigned_t, 2> kernels = {kernel, kernel};
-  return createConv(ctx, name, input, depth, kernels, strides, pads, group);
+  return createConv(ctx, name, input, outChannels, kernels, strides, pads,
+                    group);
+}
+
+Convolution3DNode *Function::createConv3D(Context &ctx, llvm::StringRef name,
+                                          NodeValue input, size_t outChannels,
+                                          llvm::ArrayRef<unsigned_t> kernels,
+                                          llvm::ArrayRef<unsigned_t> strides,
+                                          llvm::ArrayRef<unsigned_t> pads,
+                                          unsigned_t group) {
+  ShapeNHWCT idim(input.dims());
+  ShapeHWT kdim(kernels);
+  PaddingTLBRNF pdim(pads);
+  (void)pdim;
+  assert((idim.w + pdim.left + pdim.right) >= kdim.width &&
+         (idim.h + pdim.top + pdim.bottom) >= kdim.height &&
+         (idim.t + pdim.near + pdim.far) >= kdim.time &&
+         "buffer too small for selected stride");
+
+  assert(group > 0 && "group should be larger than 0");
+  assert(idim.c % group == 0 && "channels number must be divisible by groups");
+  assert(outChannels % group == 0 && "outChannels must be divisible by groups");
+
+  // Calculate the size and allocate the output buffer.
+  auto outSz = calculate3DConvPoolOutputDims(idim.h, idim.w, idim.t, kernels,
+                                             strides, pads);
+
+  std::array<size_t, 5> outDims = {
+      {idim.n, outSz.height, outSz.width, outChannels, outSz.time}};
+
+  // Allocate the Filter and Bias tensors.
+  std::array<size_t, 5> filterDim = {
+      {outChannels, kdim.height, kdim.width, idim.c / group, kdim.time}};
+
+  size_t fanIn = kdim.height * kdim.width * kdim.time * idim.c;
+  ElemKind inputTy = input.getType()->getElementType();
+  assert((inputTy == ElemKind::FloatTy || inputTy == ElemKind::Float16Ty) &&
+         "Convolution3D on non-floating point type?");
+  auto *filter =
+      getParent()->createPlaceholder(inputTy, filterDim, "filter", true);
+  ctx.allocate(filter)->init(glow::Tensor::InitKind::Xavier, fanIn, getPRNG());
+
+  auto *bias =
+      getParent()->createPlaceholder(inputTy, {outChannels}, "bias", true);
+  ctx.allocate(bias)->init(glow::Tensor::InitKind::Broadcast, 0.1, getPRNG());
+
+  auto OT = getParent()->uniqueType(inputTy, outDims);
+
+  return addNode(new Convolution3DNode(name, OT, input, filter, bias, kernels,
+                                       strides, pads, group));
+}
+
+Convolution3DNode *Function::createConv3D(Context &ctx, llvm::StringRef name,
+                                          NodeValue input, size_t outChannels,
+                                          unsigned_t kernel, unsigned_t stride,
+                                          unsigned_t pad, unsigned_t group) {
+  llvm::SmallVector<unsigned_t, 6> pads = {pad, pad, pad, pad, pad, pad};
+  llvm::SmallVector<unsigned_t, 3> strides = {stride, stride, stride};
+  llvm::SmallVector<unsigned_t, 3> kernels = {kernel, kernel, kernel};
+  return createConv3D(ctx, name, input, outChannels, kernels, strides, pads,
+                      group);
 }
 
 ConvertToNode *Function::createConvertTo(llvm::StringRef name, NodeValue input,

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -2031,12 +2031,6 @@ Convolution3DNode *Function::createConv3D(Context &ctx, llvm::StringRef name,
                                           unsigned_t group) {
   ShapeNHWCT idim(input.dims());
   ShapeHWT kdim(kernels);
-  PaddingTLBRNF pdim(pads);
-  (void)pdim;
-  assert((idim.w + pdim.left + pdim.right) >= kdim.width &&
-         (idim.h + pdim.top + pdim.bottom) >= kdim.height &&
-         (idim.t + pdim.near + pdim.far) >= kdim.time &&
-         "buffer too small for selected stride");
 
   assert(group > 0 && "group should be larger than 0");
   assert(idim.c % group == 0 && "channels number must be divisible by groups");
@@ -2066,6 +2060,8 @@ Convolution3DNode *Function::createConv3D(Context &ctx, llvm::StringRef name,
   ctx.allocate(bias)->init(glow::Tensor::InitKind::Broadcast, 0.1, getPRNG());
 
   auto OT = getParent()->uniqueType(inputTy, outDims);
+
+  assertConv3DDims(input, filter, bias, kernels, strides, pads, group);
 
   return addNode(new Convolution3DNode(name, OT, input, filter, bias, kernels,
                                        strides, pads, group));

--- a/tests/unittests/GraphTest.cpp
+++ b/tests/unittests/GraphTest.cpp
@@ -71,6 +71,7 @@ TEST(Graph, clear) {
   EXPECT_EQ(M.getFunctions().size(), 0);
 }
 
+/// Check that a createConv can be run.
 TEST(Graph, simpleTestConv) {
   Module MD;
   Function *F = MD.createFunction("F");
@@ -93,6 +94,7 @@ TEST(Graph, simpleTestConv) {
   EXPECT_GT(M.getInstrs().size(), 0);
 }
 
+/// Check that a createConv3D can be run.
 TEST(Graph, simpleTestConv3D) {
   Module MD;
   Function *F = MD.createFunction("F");

--- a/tests/unittests/GraphTest.cpp
+++ b/tests/unittests/GraphTest.cpp
@@ -93,6 +93,27 @@ TEST(Graph, simpleTestConv) {
   EXPECT_GT(M.getInstrs().size(), 0);
 }
 
+TEST(Graph, simpleTestConv3D) {
+  Module MD;
+  Function *F = MD.createFunction("F");
+  IRFunction M(F);
+  Context ctx;
+  Node *K = MD.createPlaceholder(ElemKind::FloatTy, {4, 320, 200, 3, 100},
+                                 "input", true);
+  K = F->createConv3D(ctx, /* name */ "Conv3D", /* input */ K,
+                      /* outChannels */ 16, /* kernel */ 3, /* stride */ 2,
+                      /* pad */ 3, /* group */ 1);
+  K = F->createRELU("Relu", K);
+  F->createSave("Save", K);
+  F->dump();
+  F->dumpDAG();
+  lower(F, MockBackend());
+  ::optimize(F, CompilationMode::Train);
+  M.generateIR(MockBackend());
+  M.dump();
+  EXPECT_GT(M.getInstrs().size(), 0);
+}
+
 /// Tests custom lowering from Node to Instruction IR
 TEST(Graph, simpleTestConvCustomLower) {
   Module MD;

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -89,6 +89,19 @@ int main(int argc, char **argv) {
       .autoVerify(VerifyKind::SameElementType, {"Dest", "Src", "Filter"})
       .addGradientInstr({"Src", "Filter"}, {"Dest", "Src", "Filter", "Bias"});
 
+  BB.newInstr("Convolution3D")
+      .addOperand("Dest", OperandKind::Out)
+      .addOperand("Src", OperandKind::In)
+      .addOperand("Filter", OperandKind::In)
+      .addOperand("Bias", OperandKind::In)
+      .addMember(MemberType::VectorUnsigned, "Kernels")
+      .addMember(MemberType::VectorUnsigned, "Strides")
+      .addMember(MemberType::VectorUnsigned, "Pads")
+      .addMember(MemberType::Unsigned, "Group")
+      .autoIRGen()
+      .autoVerify(VerifyKind::SameElementType, {"Dest", "Src", "Filter"})
+      .addGradientInstr({"Src", "Filter"}, {"Dest", "Src", "Filter", "Bias"});
+
   // MaxPool version caching XY coordinates to speedup gradient-based
   // computations.
   BB.newInstr("MaxPoolWithXY")

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -83,7 +83,21 @@ int main(int argc, char **argv) {
       .addMember(MemberType::Unsigned, "Group")
       .addResultFromCtorArg()
       .addGradient()
-      .setDocstring("Performs Convolution using a given Input, Filter, and "
+      .setDocstring("Performs 2D Convolution using a given Input, Filter, and "
+                    "Bias tensors, as well as provided Kernels, Strides, Pads, "
+                    "and Group.");
+
+  BB.newNode("Convolution3D")
+      .addInput("Input")
+      .addInput("Filter")
+      .addInput("Bias")
+      .addMember(MemberType::VectorUnsigned, "Kernels")
+      .addMember(MemberType::VectorUnsigned, "Strides")
+      .addMember(MemberType::VectorUnsigned, "Pads")
+      .addMember(MemberType::Unsigned, "Group")
+      .addResultFromCtorArg()
+      .addGradient()
+      .setDocstring("Performs 3D Convolution using a given Input, Filter, and "
                     "Bias tensors, as well as provided Kernels, Strides, Pads, "
                     "and Group.");
 


### PR DESCRIPTION
*Description*:
Create a new `Convolution3D` node and instruction and the associated verification and graph node creation methods. Interpreter implementation for `Convolution3DInst` and `Convolution3DGradInst` will be implemented next pr.
I considered using the existing `Convolution` node and gating everything on the dimensionality of the inputs because they share the same input and output structure however there wasn't much to be gained by doing this because much of the verification code can't be shared and neither will the backend implementation be able to be shared likely so it seemed better to just create the correct node up front during loading and not worry about which implementation to use after that.

*Testing*:
`ninja all`
Added a very basic test.

*Documentation*:
Doxygen