### PR TITLE
Add tracing/profiling for the CPU and Interpreter backends

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -77,6 +77,7 @@ if(GLOW_WITH_CPU)
                    resnet-concurrent.cpp)
   target_link_libraries(resnet-concurrent
                         PRIVATE
+                          Backend
                           Backends
                           CPUDeviceManager
                           DeviceManager
@@ -98,7 +99,21 @@ if(GLOW_WITH_CPU)
                           Importer
                           Optimizer)
   target_include_directories(resnet-runtime PUBLIC ${CMAKE_SOURCE_DIR}/lib)
+
+  add_executable(tracing-compare
+                   tracing-compare.cpp)
+  target_link_libraries(tracing-compare
+                        PRIVATE
+                          Backend
+                          Backends
+                          DeviceManager
+                          ExecutionEngine
+                          Graph
+                          Importer
+                          Optimizer
+                          ThreadPool)
 endif()
+
 
 if(GLOW_WITH_BUNDLES)
   add_subdirectory(bundles)

--- a/examples/tracing-compare.cpp
+++ b/examples/tracing-compare.cpp
@@ -1,0 +1,178 @@
+/**
+ * Copyright(c) 2017 - present, Facebook Inc.
+ *
+ * Licensed under the Apache License, Version 2.0(the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/Backends/DeviceManager.h"
+#include "glow/Base/Image.h"
+#include "glow/ExecutionEngine/ExecutionEngine.h"
+#include "glow/Graph/Graph.h"
+#include "glow/Importer/Caffe2ModelLoader.h"
+#include "glow/Runtime/RuntimeTypes.h"
+
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/FileSystem.h"
+
+#include <chrono>
+#include <future>
+
+using namespace glow;
+using namespace glow::runtime;
+
+std::array<BackendKind, 2> supportedBackends({BackendKind::Interpreter,
+                                              BackendKind::CPU});
+
+namespace {
+llvm::cl::OptionCategory category("tracing-compare Options");
+llvm::cl::opt<std::string>
+    inputImage(llvm::cl::desc("path to input image to classify, which must be "
+                              "a png with standard imagenet normalization"),
+               llvm::cl::init("../tests/images/imagenet/dog_207.png"),
+               llvm::cl::Positional, llvm::cl::cat(category));
+llvm::cl::opt<std::string>
+    outputJson(llvm::cl::desc("path to write output json trace events"),
+               llvm::cl::init("./glow-trace.json"), llvm::cl::Positional,
+               llvm::cl::cat(category));
+
+} // namespace
+
+/// Loads the model into /p module and returns the input and output
+/// Placeholders.
+std::pair<Placeholder *, Placeholder *> loadResnet50Model(TypeRef inputType,
+                                                          Module &module) {
+  Function *F = module.createFunction("resnet50");
+
+  llvm::outs() << "Loading resnet50 model.\n";
+
+  const char inputName[] = "gpu_0/data";
+  Caffe2ModelLoader loader("resnet50/predict_net.pb", "resnet50/init_net.pb",
+                           {inputName}, {inputType}, *F);
+  Placeholder *input =
+      llvm::cast<Placeholder>(cantFail(loader.getNodeValueByName(inputName)));
+  Placeholder *output = cantFail(loader.getSingleOutput());
+
+  return std::make_pair(input, output);
+}
+
+/// Compiles the resnet50 function.
+std::unique_ptr<CompiledFunction> compileModel(Module &module,
+                                               BackendKind backendKind) {
+  auto *backend = createBackend(backendKind);
+  Function *F = module.getFunction("resnet50");
+
+  llvm::outs() << "Starting compile.\n";
+  backend->optimizeFunction(CompilationMode::Infer, F);
+  return backend->instrumentAndCompile(F);
+}
+
+std::future<ResultCode> addToDevice(unsigned int id, DeviceManager *device,
+                                    Module &module, FunctionMapTy functions) {
+  std::shared_ptr<std::promise<ResultCode>> compilePromise(
+      new std::promise<ResultCode>);
+  auto future = compilePromise->get_future();
+
+  device->addNetwork(&module, functions,
+                     [compilePromise, id](const Module *, ResultCode code) {
+                       if (code != ResultCode::Ready) {
+                         llvm::errs() << "Failed to compile model for device "
+                                      << id << ".\n";
+                       } else {
+                         llvm::outs()
+                             << "Successfully added to Device " << id << ".\n";
+                       }
+                       compilePromise->set_value(code);
+                     });
+
+  return future;
+}
+
+int main(int argc, char **argv) {
+  llvm::cl::ParseCommandLineOptions(
+      argc, argv, "Run resnet and export a json file containing trace events");
+
+  std::array<DeviceManager *, supportedBackends.size()> devices;
+  for (unsigned i = 0, e = supportedBackends.size(); i < e; ++i) {
+    devices[i] = DeviceManager::createDeviceManager(supportedBackends[i],
+                                                    "tracing-compare");
+    devices[i]->init();
+  }
+
+  // Load and compile model.
+
+  Module module;
+  TypeRef inputType(module.uniqueType(ElemKind::FloatTy, {1, 3, 224, 224}));
+  Placeholder *input, *output;
+
+  std::tie(input, output) = loadResnet50Model(inputType, module);
+
+  std::array<std::unique_ptr<CompiledFunction>, supportedBackends.size()>
+      compiledFunctions;
+
+  for (unsigned i = 0, e = supportedBackends.size(); i < e; ++i) {
+    compiledFunctions[i] = compileModel(module, supportedBackends[i]);
+
+    FunctionMapTy functions;
+    functions.emplace("resnet50", compiledFunctions[i].get());
+
+    auto f = addToDevice(i, devices[i], module, functions);
+    f.wait_for(/* timeout_duration */ std::chrono::seconds(30));
+    if (f.get() != ResultCode::Ready) {
+      return 1;
+    }
+  }
+
+  auto image =
+      readPngImageAndPreprocess(inputImage, ImageNormalizationMode::k0to1,
+                                ImageChannelOrder::BGR, ImageLayout::NCHW,
+                                /* useImagenetNormalization */ true);
+
+  Tensor batch = image.getUnowned(inputType->dims());
+
+  llvm::outs() << "Starting Run.\n";
+  std::array<std::promise<std::unique_ptr<Context>>, supportedBackends.size()>
+      promises;
+
+  for (unsigned i = 0, e = supportedBackends.size(); i < e; ++i) {
+    auto ctx = llvm::make_unique<Context>();
+    ctx->allocate(module.getPlaceholders());
+    updateInputPlaceholders(*ctx, {input}, {&batch});
+
+    devices[i]->runFunction("resnet50", std::move(ctx),
+                            [&promises, i](RunIdentifierTy, ResultCode r,
+                                           std::unique_ptr<Context> ctx) {
+                              promises[i].set_value(std::move(ctx));
+                            });
+  }
+
+  auto ctx = llvm::make_unique<Context>();
+  auto &allEvents = ctx->getTraceEvents();
+
+  allEvents.push_back({"thread_name", 0, "M", 0, {{"name", "Interpreter"}}});
+  allEvents.push_back({"thread_name", 0, "M", 1, {{"name", "CPU"}}});
+
+  for (unsigned i = 0, e = supportedBackends.size(); i < e; ++i) {
+    auto f = promises[i].get_future();
+    f.wait_for(/* timeout_duration */ std::chrono::seconds(30));
+    auto runCtx = f.get();
+    for (auto &event : runCtx->getTraceEvents()) {
+      event.tid = i;
+      allEvents.push_back(event);
+    }
+  }
+
+  llvm::outs() << "Dumping json to " << outputJson << ".\n";
+  TraceEvent::dumpTraceEvents(allEvents, outputJson);
+
+  return 0;
+}

--- a/include/glow/Backends/CompiledFunction.h
+++ b/include/glow/Backends/CompiledFunction.h
@@ -17,6 +17,7 @@
 #define GLOW_BACKENDS_COMPILEDFUNCTION_H
 
 #include "glow/Backends/BackendUtils.h"
+#include "glow/Backends/TraceEvents.h"
 #include "glow/Graph/Nodes.h"
 
 #include <unordered_map>
@@ -60,11 +61,25 @@ public:
   /// Collects constants for runtime.
   virtual void collectConstants(Module *){};
 
+  /// Setter for TraceEvent lookup. Note: does not enable tracing automatically.
+  void setTraceInfo(TraceInfo &&info) { traceInfo_ = std::move(info); }
+
+  /// Getter for the TraceEvent lookup.
+  TraceInfo &getTraceInfo() { return traceInfo_; }
+  const TraceInfo &getTraceInfo() const { return traceInfo_; }
+
+  /// Read trace events out of this func and write them into /p ctx
+  virtual void translateTraceEvents(Context *ctx) const {}
+
 protected:
   /// Flag to ensure setupRuns is only called once.
   bool runsSetup_{false};
   /// Contains symbol offsets and allocation sizes.
   runtime::RuntimeBundle runtimeBundle_;
+
+  /// Information regarding runtime trace instrumentation present in this
+  /// function.
+  TraceInfo traceInfo_;
 };
 } // end namespace glow
 

--- a/include/glow/Backends/TraceEvents.h
+++ b/include/glow/Backends/TraceEvents.h
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_BACKENDS_TRACEEVENTS_H
+#define GLOW_BACKENDS_TRACEEVENTS_H
+
+#include "glow/Graph/Nodes.h"
+#include "llvm/ADT/DenseMap.h"
+
+#include <map>
+#include <vector>
+
+namespace glow {
+
+class Context;
+
+/// An individual tracing event, such as the begin or end of an instruction.
+/// Designed to match the Google Trace Event Format for Chrome:
+// https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU
+struct TraceEvent {
+  /// Human readable name for the item, will be used to match up begin and end.
+  std::string name;
+
+  /// Time of the event, in milliseconds since epoch.
+  uint64_t timestamp;
+
+  /// Type of the event, a (usually) one char code (see Event Descriptions in
+  /// the Trace Event Format spec). e.g. 'B' for begin event, 'E' for end event.
+  std::string type;
+
+  /// Thread Id for this event. All Events on the same tid will be shown on the
+  /// same row of the trace.
+  int tid;
+
+  /// Arbitrary TraceEvent arguments (from spec).
+  std::map<std::string, std::string> args;
+
+  TraceEvent(llvm::StringRef n, uint64_t ts, llvm::StringRef c, int t)
+      : name(n), timestamp(ts), type(c), tid(t) {}
+
+  TraceEvent(llvm::StringRef n, uint64_t ts, llvm::StringRef c, int t,
+             std::map<std::string, std::string> a)
+      : name(n), timestamp(ts), type(c), tid(t), args(a) {}
+
+  static void dumpTraceEvents(std::vector<TraceEvent> &events,
+                              llvm::StringRef filename);
+};
+
+/// Tracing / Profiling events map for a compiled function.
+struct TraceInfo {
+  TraceInfo() = default;
+  TraceInfo(bool e, size_t d) : enabled(e), dataSize(d) {}
+
+  /// Whether tracing is enabled for this run.
+  bool enabled{false};
+
+  /// The size of each item in the backing Tensor.
+  size_t dataSize{0};
+
+  struct Event {
+    size_t index;
+    std::string name;
+    std::string type;
+  };
+
+  std::map<Placeholder *, std::vector<Event>> events;
+
+  void add(Placeholder *PH, size_t index, std::string name, std::string type) {
+    events[PH].push_back({index, std::move(name), std::move(type)});
+  }
+};
+
+} // namespace glow
+
+#endif // GLOW_BACKENDS_TRACEEVENTS_H

--- a/include/glow/Graph/Context.h
+++ b/include/glow/Graph/Context.h
@@ -16,6 +16,7 @@
 #ifndef GLOW_BASE_CONTEXT_H
 #define GLOW_BASE_CONTEXT_H
 
+#include "glow/Backends/TraceEvents.h"
 #include "llvm/ADT/ArrayRef.h"
 
 #include <list>
@@ -47,6 +48,9 @@ private:
 
   /// Maps Placeholder names to Placeholders.
   PlaceholderNameMap nameMap_;
+
+  /// Trace Events recorded during this run.
+  std::vector<TraceEvent> traceEvents_;
 
 public:
   /// \returns true if \p A and \p B contain the same Placeholders mapped to
@@ -94,6 +98,9 @@ public:
 
   /// \returns the size in bytes of allocated Tensors owned by Context.
   uint64_t getDataSize() const;
+
+  /// \returns TraceEvents for the last run.
+  std::vector<TraceEvent> &getTraceEvents() { return traceEvents_; }
 
   Context() = default;
 

--- a/lib/Backends/CMakeLists.txt
+++ b/lib/Backends/CMakeLists.txt
@@ -14,8 +14,17 @@ if(GLOW_WITH_CPU)
   LIST(APPEND linked_device_managers CPUDeviceManager)
 endif()
 
-add_library(Backends
+add_library(Backend
               Backend.cpp
+              TraceEvents.cpp)
+target_link_libraries(Backend
+                      PRIVATE
+                        Base
+                        Graph
+                        IR
+                        Optimizer)
+
+add_library(Backends
               Backends.cpp)
 target_link_libraries(Backends
                       PRIVATE

--- a/lib/Backends/CPU/CMakeLists.txt
+++ b/lib/Backends/CPU/CMakeLists.txt
@@ -83,6 +83,7 @@ add_library(CPUBackend
 llvm_map_components_to_libnames(LLVM_TARGET_LIBRARIES ${LLVM_TARGETS_TO_BUILD})
 target_link_libraries(CPUBackend
                       PUBLIC
+                        Backend
                         Base
                         CodeGen
                         BackendUtils

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -19,6 +19,7 @@
 #include "CPUFunction.h"
 
 #include "glow/Backends/BackendUtils.h"
+#include "glow/Graph/Context.h"
 #include "glow/Graph/Graph.h"
 #include "glow/IR/Instrs.h"
 #include "glow/Support/Debug.h"
@@ -135,6 +136,15 @@ CPUBackend::compileIRWithoutConstants(IRFunction *IR) const {
 std::unique_ptr<CompiledFunction> CPUBackend::compile(Function *F) const {
   auto IR = generateAndOptimizeIR(F, *this, shouldShareBuffers());
   return compileIR(std::move(IR));
+}
+
+std::unique_ptr<CompiledFunction>
+CPUBackend::instrumentAndCompile(Function *F) const {
+  auto IR = generateAndOptimizeIR(F, *this, shouldShareBuffers());
+  auto traceInfo = autoInstrument(IR.get(), getTraceEventDataSize());
+  auto compiledFunc = compileIR(std::move(IR));
+  compiledFunc->setTraceInfo(std::move(traceInfo));
+  return compiledFunc;
 }
 
 std::unique_ptr<CompiledFunction>

--- a/lib/Backends/CPU/CPUBackend.h
+++ b/lib/Backends/CPU/CPUBackend.h
@@ -26,6 +26,8 @@
 
 namespace glow {
 
+class Context;
+
 /// Helper function to create a new CallInst, with the specified \p builder, \p
 /// callee, and \p args. Verifies that the function signature is correct,
 /// and then creates and \returns the CallInst.
@@ -34,7 +36,6 @@ llvm::CallInst *createCall(llvm::IRBuilder<> &builder, llvm::Function *callee,
 
 class CPUBackend : public BackendUsingGlowIR {
 public:
-  /// Ctor.
   CPUBackend() = default;
 
   /// @name Backend methods.
@@ -51,6 +52,9 @@ public:
   std::unique_ptr<CompiledFunction> compile(Function *F) const override;
 
   std::unique_ptr<CompiledFunction>
+  instrumentAndCompile(Function *F) const override;
+
+  std::unique_ptr<CompiledFunction>
   compileWithoutConstants(Function *F) const override;
 
   void save(Function *F, llvm::StringRef outputDir,
@@ -62,6 +66,9 @@ public:
 
   bool shouldLower(const Node *N) const override;
   /// @}
+
+  /// \returns the size of metrics collected for a single TraceEvent.
+  static size_t getTraceEventDataSize() { return sizeof(uint64_t); }
 
 protected:
   /// Method that creates the LLVM IR generator. This gives the possibility to

--- a/lib/Backends/CPU/CPUFunction.cpp
+++ b/lib/Backends/CPU/CPUFunction.cpp
@@ -96,4 +96,29 @@ void CPUFunction::execute(Context *ctx) {
 
   alignedFree(baseMutableWeightVarsAddress);
   alignedFree(baseActivationsAddress);
+
+  translateTraceEvents(ctx);
+}
+
+void CPUFunction::translateTraceEvents(Context *ctx) const {
+  auto &traceInfo = getTraceInfo();
+  if (!traceInfo.enabled) {
+    return;
+  }
+
+  int tid = 0;
+  for (auto &backing : traceInfo.events) {
+    tid++;
+    Tensor *backingTensor = ctx->get(backing.first);
+    assert(backingTensor);
+
+    auto &traceEvents = ctx->getTraceEvents();
+    for (const TraceInfo::Event &event : backing.second) {
+      uint64_t ts{0};
+      memcpy(&ts,
+             backingTensor->getUnsafePtr() + (event.index * traceInfo.dataSize),
+             traceInfo.dataSize);
+      traceEvents.push_back({event.name, ts, event.type, tid});
+    }
+  }
 }

--- a/lib/Backends/CPU/CPUFunction.h
+++ b/lib/Backends/CPU/CPUFunction.h
@@ -29,7 +29,6 @@ class CPUFunction final : public CompiledFunction {
   std::unique_ptr<llvm::orc::GlowJIT> JIT_;
 
 public:
-  /// Ctor.
   CPUFunction(std::unique_ptr<llvm::orc::GlowJIT> JIT,
               const runtime::RuntimeBundle &runtimeBundle);
 
@@ -39,7 +38,12 @@ public:
   void execute(Context *ctx) override;
 
   void collectConstants(Module *module) override;
+
+  /// Read trace events out of this func and write them into /p ctx
+  void translateTraceEvents(Context *ctx) const override;
   ///@}
+  //
+
 private:
   /// Load constant tensors from \p ctx into \p weightsAddress, as defined by
   /// the RuntimeBundle (pre-run).

--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -2388,6 +2388,16 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     break;
   }
 
+  case Kinded::Kind::TraceEventInstKind: {
+    auto *TEI = llvm::cast<TraceEventInst>(I);
+    auto *data = TEI->getData();
+    auto *offset = emitConstSizeT(builder, TEI->getIndex());
+    auto *dataPtr = emitValueAddress(builder, data);
+    auto *F = getFunction("write_timestamp");
+    createCall(builder, F, {dataPtr, offset});
+    break;
+  }
+
   default:
 #ifndef NDEBUG
     llvm::errs() << "Cannot select the instruction:\n";

--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include <assert.h>
+#include <chrono>
 #include <math.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -1553,6 +1554,16 @@ libjit_dump_tensor(uint8_t *tensor, size_t *tensorDim, size_t numDimsTensor,
     printf("Dumping this type of payload is not supported: %zu\n", elemKind);
     break;
   }
+}
+
+void libjit_write_timestamp(uint64_t *tensor, size_t offset) {
+  // We are using C++ timer here to a avoid issues with gettimeofday
+  // Issue #2397 covers migrating this to a libc approach but if you have issues
+  // with a lack of C++ symbols at runtime check there first.
+  uint64_t ts = std::chrono::duration_cast<std::chrono::milliseconds>(
+                    std::chrono::steady_clock::now().time_since_epoch())
+                    .count();
+  memcpy(tensor + offset, &ts, sizeof(uint64_t));
 }
 
 static void find_min_max_f(float *tensor, size_t size, float &min, float &max) {

--- a/lib/Backends/Interpreter/CMakeLists.txt
+++ b/lib/Backends/Interpreter/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(Interpreter
               InterpreterNodes.cpp)
 target_link_libraries(Interpreter
                       PRIVATE
+                        Backend
                         Base
                         Graph
                         CodeGen

--- a/lib/Backends/Interpreter/Interpreter.h
+++ b/lib/Backends/Interpreter/Interpreter.h
@@ -43,12 +43,19 @@ public:
   std::unique_ptr<CompiledFunction> compile(Function *F) const override;
 
   std::unique_ptr<CompiledFunction>
+  instrumentAndCompile(Function *F) const override;
+
+  std::unique_ptr<CompiledFunction>
   compileWithoutConstants(Function *F) const override;
 
   bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override;
 
   bool shouldLower(const Node *N) const override;
+
   /// @}
+  //
+  /// \returns the size of metrics collected for a single TraceEvent.
+  static size_t getTraceEventDataSize() { return sizeof(uint64_t); }
 };
 
 } // namespace glow

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -64,6 +64,9 @@ public:
 
   /// Get reference to IR function.
   IRFunction *getIR() { return F_.get(); }
+
+  /// Read trace events out of this func and write them into /p ctx
+  void translateTraceEvents(Context *ctx) const override;
   ///@}
 };
 

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -24,6 +24,8 @@
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <chrono>
+
 using namespace glow;
 
 #define dispatchFloatingPointImpl(functionName, elemTy, ...)                   \
@@ -2473,6 +2475,15 @@ void BoundInterpreterFunction::fwdDebugPrintInst(const DebugPrintInst *I) {
   llvm::outs() << "\n";
   dumpImpl(getTensor(V));
   llvm::outs() << "\n";
+}
+
+void BoundInterpreterFunction::fwdTraceEventInst(const TraceEventInst *I) {
+  auto T = getTensor(I->getData());
+  auto IH = T->getHandle<int64_t>();
+  size_t index = I->getIndex();
+  IH.raw(index) = std::chrono::duration_cast<std::chrono::milliseconds>(
+                      std::chrono::steady_clock::now().time_since_epoch())
+                      .count();
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Backends/OpenCL/CMakeLists.txt
+++ b/lib/Backends/OpenCL/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(OpenCL
 
 target_link_libraries(OpenCL
                       PRIVATE
+                      Backend
                       BackendUtils
                       Base
                       Graph

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -1298,6 +1298,11 @@ void OpenCLFunction::execute(Context *ctx) {
       continue;
     }
 
+    if (auto *TE = dyn_cast<TraceEventInst>(&I)) {
+      llvm::outs() << "skipping TraceEvent on OpenCL: unimplemented\n";
+      continue;
+    }
+
     // For TopKInst, we perform the computation on the host side, as sorting on
     // GPU is complex and we may not get too much benefit from it. We copy the
     // tensor from GPU memory to host memory, perform the computation, and then

--- a/lib/Backends/TraceEvents.cpp
+++ b/lib/Backends/TraceEvents.cpp
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/Backends/TraceEvents.h"
+
+#include "llvm/Support/raw_ostream.h"
+
+#include <fstream>
+
+namespace glow {
+
+void TraceEvent::dumpTraceEvents(std::vector<TraceEvent> &events,
+                                 llvm::StringRef filename) {
+  llvm::errs() << "dumping " << events.size() << " trace events.\n";
+
+  std::ofstream file(filename);
+  file << "[\n";
+  for (const auto &event : events) {
+    file << "{\"name\": \"" << event.name;
+    file << "\", \"cat\": \"glow\",";
+    file << "\"ph\": \"" << event.type;
+    file << "\", \"ts\": " << event.timestamp;
+    file << ", \"pid\": " << 0;
+    file << ", \"tid\": " << event.tid;
+
+    if (!event.args.empty()) {
+      file << ", \"args\": {";
+      bool first{true};
+      for (auto &pair : event.args) {
+        // Start with a comma unless it's the first item in the list.
+        file << (first ? "" : ", ");
+        first = false;
+        file << "\"" << pair.first << "\" : \"" << pair.second << "\"";
+      }
+      file << "}";
+    }
+    file << "},\n";
+  }
+  // Skip the ending bracket since that is allowed.
+  file.close();
+}
+} // namespace glow

--- a/lib/ExecutionEngine/CMakeLists.txt
+++ b/lib/ExecutionEngine/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(ExecutionEngine
 
 target_link_libraries(ExecutionEngine
                       PRIVATE
+                        Backend
                         Backends
                         Optimizer
                         Base

--- a/lib/Runtime/HostManager/CMakeLists.txt
+++ b/lib/Runtime/HostManager/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(HostManager
 
 target_link_libraries(HostManager
                       PRIVATE
+                        Backend
                         Backends
                         Base
                         Graph

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -79,6 +79,7 @@ add_executable(DeviceManagerTest
                DeviceManagerTest.cpp)
 target_link_libraries(DeviceManagerTest
                       PRIVATE
+                        Backend
                         Backends
                         DeviceManager
                         Graph
@@ -220,6 +221,7 @@ add_executable(IROptTest
                IROptTest.cpp)
 target_link_libraries(IROptTest
                       PRIVATE
+                        Backends
                         Graph
                         IR
                         Optimizer
@@ -232,6 +234,7 @@ if(GLOW_WITH_CPU)
                  LLVMIRGenTest.cpp)
   target_link_libraries(LLVMIRGenTest
                         PRIVATE
+                          Backends
                           CPUBackend
                           IR
                           Support
@@ -284,6 +287,7 @@ add_executable(OnnxImporterTest
                OnnxImporterTest.cpp)
 target_link_libraries(OnnxImporterTest
                       PRIVATE
+                        Backends
                         Graph
                         Importer
                         ExecutionEngine
@@ -338,18 +342,18 @@ if(GLOW_WITH_CPU)
 
 add_executable(HostManagerTest
                HostManagerTest.cpp)
-target_link_libraries(HostManagerTest	
-                      PRIVATE		
+target_link_libraries(HostManagerTest
+                      PRIVATE
                         Backends
                         HostManager
-                        Executor		
-                        Graph		
-                        IR		
+                        Executor
+                        Graph
+                        IR
                         Partitioner
-                        Provisioner	
+                        Provisioner
                         DeviceManager
-                        gtest		
-                        TestMain)	
+                        gtest
+                        TestMain)
 target_include_directories(HostManagerTest PUBLIC ${CMAKE_SOURCE_DIR}/lib/Backends)
 add_glow_test(HostManagerTest ${GLOW_BINARY_DIR}/tests/HostManagerTest --gtest_output=xml:ProvisionerTest.xml)
 

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -547,6 +547,11 @@ int main(int argc, char **argv) {
       .addOperand("Src", OperandKind::In)
       .autoVerify(VerifyKind::NoVerify);
 
+  BB.newInstr("TraceEvent")
+      .addOperand("Data", OperandKind::In)
+      .addMember(MemberType::Unsigned, "Index")
+      .autoVerify(VerifyKind::NoVerify);
+
   //===--------------------------------------------------------------------===//
   //             Instructions used for quantization
   //===--------------------------------------------------------------------===//


### PR DESCRIPTION
*Description*: Implement auto instrumentation and handling of TraceEvents in the CPU and Interpreter backends. If instrumentation is enabled then every Instruction in the IR will be timed. 

The included example (tracing-compare) runs resnet50 on both the CPU and Interpreter backends and outputs a json file in the chromium TraceEvents format, which can be loaded in the chrome about://tracing page. It looks like this:

<img width="1169" alt="tracing-compare" src="https://user-images.githubusercontent.com/701287/52601440-accec880-2e13-11e9-8763-903f8528f5f0.png">

*Testing*: The example and manual testing. Will write unit tests in a follow up.
*Documentation*:
 