### PR TITLE
[Graph Partitioner] Improve and polish getBFSLevel function.

### DIFF
--- a/include/glow/Partitioner/Partitioner.h
+++ b/include/glow/Partitioner/Partitioner.h
@@ -20,12 +20,6 @@
 #include "glow/Partitioner/PartitionerUtils.h"
 #include "glow/Runtime/RuntimeTypes.h"
 
-#include "llvm/ADT/DenseMap.h"
-
-#include <map>
-#include <set>
-#include <string>
-
 namespace glow {
 
 using namespace runtime;

--- a/include/glow/Partitioner/PartitionerUtils.h
+++ b/include/glow/Partitioner/PartitionerUtils.h
@@ -17,6 +17,7 @@
 #define GLOW_PARTITIONER_PARTITIONUTILS_H
 
 #include "glow/Graph/Graph.h"
+#include "llvm/ADT/DenseMap.h"
 
 namespace glow {
 
@@ -24,15 +25,22 @@ namespace glow {
 struct GraphMemInfo {
   // The memory usage of all input nodes (whose predecessors are not included in
   // this subgraph) of this subgraph.
-  uint64_t inMemSize;
+  size_t inMemSize;
   // The memory usage of all output nodes (whose successors are not included in
   // this subgraph) of this subgraph.
-  uint64_t outMemSize;
+  size_t outMemSize;
   // The memory usage of all constants used in this subgraph.
-  uint64_t constMemSize;
+  size_t constMemSize;
 
   GraphMemInfo() : inMemSize(0), outMemSize(0), constMemSize(0){};
 };
+
+/// A list of <level, nodelist> with BFS order.
+using BFSLevel = std::vector<std::pair<int, std::vector<Node *>>>;
+
+/// Visit nodes if Function \p F in BFS order and return the nodes by levels
+/// (the longest distance between one node and the root).
+BFSLevel getBFSLevel(Function *F);
 
 /// Given \p nodes, return a list of nodes who use any node in this set.
 std::vector<Node *> getOutUsers(const std::set<Node *> &nodes);


### PR DESCRIPTION
*Description*:
This PR : 
1. Polished the BFS data structure. 
2. Using the longest distance between a node and the root as this node's level.  Therefore, we won't need to test and eliminate this case in the future : partition1 uses some nodes from partition2 while partition2 uses some nodes in partition1. 

*Testing*:
Current tests, Resnet50.

*Documentation*: #2298 
[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
