### PR TITLE
Fix runtime build with BUILD_SHARED_LIBS

### DIFF
--- a/lib/Backends/CPU/CMakeLists.txt
+++ b/lib/Backends/CPU/CMakeLists.txt
@@ -126,4 +126,5 @@ target_link_libraries(CPUDeviceManager
                         CPUBackend
                         Graph
                         IR
-                        Optimizer)
+                        Optimizer
+                        ThreadPool)

--- a/lib/Backends/Interpreter/CMakeLists.txt
+++ b/lib/Backends/Interpreter/CMakeLists.txt
@@ -23,4 +23,5 @@ target_link_libraries(InterpreterDeviceManager
                         Graph
                         Interpreter
                         IR
-                        Optimizer)
+                        Optimizer
+                        ThreadPool)

--- a/lib/Runtime/Executor/CMakeLists.txt
+++ b/lib/Runtime/Executor/CMakeLists.txt
@@ -3,7 +3,7 @@ add_library(Executor
               ThreadPoolExecutor.cpp)
 
 target_link_libraries(Executor
-            PUBLIC
-            ThreadPool
+                      PUBLIC
+                        ThreadPool
 	              PRIVATE
 		        Graph)

--- a/lib/Runtime/Executor/CMakeLists.txt
+++ b/lib/Runtime/Executor/CMakeLists.txt
@@ -3,5 +3,7 @@ add_library(Executor
               ThreadPoolExecutor.cpp)
 
 target_link_libraries(Executor
+            PUBLIC
+            ThreadPool
 	              PRIVATE
 		        Graph)

--- a/lib/Runtime/HostManager/CMakeLists.txt
+++ b/lib/Runtime/HostManager/CMakeLists.txt
@@ -4,6 +4,9 @@ add_library(HostManager
 target_link_libraries(HostManager
                       PRIVATE
                         Backends
+                        Base
+                        Graph
+                        Partitioner
                         Provisioner
                         Executor
                         DeviceManager

--- a/lib/Runtime/Provisioner/CMakeLists.txt
+++ b/lib/Runtime/Provisioner/CMakeLists.txt
@@ -4,4 +4,5 @@ add_library(Provisioner
 target_link_libraries(Provisioner
                       PRIVATE
                         Backends
+                        BackendUtils
                         Graph)


### PR DESCRIPTION
*Description*: This has been broken locally for me for awhile but seems to build fine in circleci so I never worried about it, but that time has passed.
*Testing*: Build with the following config:
`
cmake -GNinja -DCMAKE_CXX_FLAGS=-Werror -DGLOW_WITH_CPU=ON -DCMAKE_BUILD_TYPE=Debug -DGLOW_WITH_OPENCL=ON -DBUILD_SHARED_LIBS=ON ../
`
*Documentation*: I am assuming that circleci passes because it uses an older version of the compiler? Can't quite work out exactly what the difference is.
