### PR TITLE
Make HostManager own Devices

### DIFF
--- a/include/glow/Runtime/Executor/Executor.h
+++ b/include/glow/Runtime/Executor/Executor.h
@@ -50,6 +50,10 @@ public:
   /// present in \p context.
   virtual void run(const DAGNode *root, std::unique_ptr<Context> context,
                    RunIdentifierTy runId, ResultCBTy cb) = 0;
+
+  /// Shutdown the Executor. Should block until all active requests are complete
+  /// and prevent new requests from being initiated.
+  virtual void shutdown() = 0;
 };
 
 /// Create an executor of kind \p kind that will call into the DeviceManager

--- a/include/glow/Runtime/Provisioner/Provisioner.h
+++ b/include/glow/Runtime/Provisioner/Provisioner.h
@@ -53,7 +53,7 @@ private:
   const float NETWORK_PADDING_FACTOR = 1.1;
 
   /// List of available DeviceManagers added during initialization.
-  std::vector<std::shared_ptr<DeviceManager>> devices_;
+  std::vector<DeviceManager *> devices_;
 
   /// Index of current deviceManager. This allows a round robin loading of
   /// deviceManagers.

--- a/include/glow/Runtime/RuntimeTypes.h
+++ b/include/glow/Runtime/RuntimeTypes.h
@@ -32,7 +32,7 @@ using DeviceIDTy = size_t;
 using RunIdentifierTy = size_t;
 
 /// Map of DeviceIDTy -> DeviceManager.
-using DeviceManagerMapTy = std::map<DeviceIDTy, std::shared_ptr<DeviceManager>>;
+using DeviceManagerMapTy = std::map<DeviceIDTy, std::unique_ptr<DeviceManager>>;
 
 /// Enum to communicate results when communicating with device at initialization
 /// and runtime.

--- a/lib/Runtime/Executor/ThreadPoolExecutor.h
+++ b/lib/Runtime/Executor/ThreadPoolExecutor.h
@@ -141,13 +141,14 @@ public:
                               unsigned numWorkers = kNumWorkers)
       : threadPool_(numWorkers), deviceManagers_(deviceManagers) {}
 
-  /// Destructor.
-  virtual ~ThreadPoolExecutor();
-
   /// See Executor::run. A particular invocation is specified completely by
   /// the triple (roots, context, runId).
   void run(const DAGNode *root, std::unique_ptr<Context> context,
            RunIdentifierTy runId, ResultCBTy cb) override;
+
+  ~ThreadPoolExecutor() override { shutdown(); }
+
+  void shutdown() override;
 
 private:
   /// Propagate Placeholders from \p ctx into the final output Context for the
@@ -196,6 +197,8 @@ private:
   /// Barrier for making sure all asynchronous requests made to the
   /// DeviceManager return before allowing destruction of the executor.
   InflightBarrier inflightBarrier_;
+  /// Whether the executor is currently shutting down or not.
+  std::atomic<bool> shuttingDown_{false};
 };
 
 } // namespace runtime

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -35,10 +35,9 @@ HostManager::HostManager(const std::vector<DeviceConfig> &configs) {
     backend_.reset(createBackend(configs[0].backendKind));
   }
   for (auto &config : configs) {
-    auto newDevice =
-        std::shared_ptr<DeviceManager>(DeviceManager::createDeviceManager(
+    devices_[deviceCount] =
+        std::unique_ptr<DeviceManager>(DeviceManager::createDeviceManager(
             config.backendKind, config.deviceName));
-    devices_.emplace(deviceCount, std::move(newDevice));
     deviceCount++;
   }
   provisioner_.reset(new Provisioner(devices_));
@@ -119,6 +118,12 @@ bool HostManager::networkAdded(llvm::StringRef networkName) {
 }
 
 void HostManager::clearHost() {
+  // shutdown the executor, blocking on any current inflight and prevent new
+  // requests from being serviced.
+  executor_->shutdown();
+  assert(activeRequestCount_ == 0 &&
+         "All requests should be finished when shutting downt HostManager.");
+
   std::lock_guard<std::mutex> networkLock(networkLock_);
   for (auto &it : devices_) {
     it.second->stop();
@@ -128,8 +133,6 @@ void HostManager::clearHost() {
   }
   networks_.clear();
   roots_.clear();
-
-  activeRequestCount_ = 0;
 }
 
 RunIdentifierTy HostManager::runNetwork(llvm::StringRef networkName,

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -122,7 +122,7 @@ void HostManager::clearHost() {
   // requests from being serviced.
   executor_->shutdown();
   assert(activeRequestCount_ == 0 &&
-         "All requests should be finished when shutting downt HostManager.");
+         "All requests should be finished when shutting down HostManager.");
 
   std::lock_guard<std::mutex> networkLock(networkLock_);
   for (auto &it : devices_) {

--- a/lib/Runtime/Provisioner/Provisioner.cpp
+++ b/lib/Runtime/Provisioner/Provisioner.cpp
@@ -27,7 +27,7 @@ using namespace runtime;
 
 Provisioner::Provisioner(DeviceManagerMapTy &devices) {
   for (auto &device : devices) {
-    devices_.push_back(device.second);
+    devices_.push_back(device.second.get());
   }
 }
 

--- a/tests/unittests/ExecutorTest.cpp
+++ b/tests/unittests/ExecutorTest.cpp
@@ -166,8 +166,6 @@ private:
   ThreadPool threadPool_;
 };
 
-using TestDeviceManagerMapTy =
-    std::unordered_map<DeviceIDTy, std::shared_ptr<TestDeviceManager>>;
 using PlaceholderNameMapTy =
     std::unordered_map<std::string, std::unique_ptr<Placeholder>>;
 using DAGNodeNameMapTy =
@@ -273,7 +271,7 @@ public:
   /// important thing to test is that that Placeholder values are propagated
   /// between Contexts correctly.
   ExecutorTestBuilder(const std::shared_ptr<Executor> &executor,
-                      const TestDeviceManagerMapTy &deviceManagers)
+                      const DeviceManagerMapTy &deviceManagers)
       : executor_(executor), root_(llvm::make_unique<DAGNode>()),
         ctx_(llvm::make_unique<Context>()),
         type_(
@@ -374,10 +372,13 @@ public:
       assert(!"No test device manager found for this device ID");
     }
 
-    std::shared_ptr<TestDeviceManager> deviceManager = it->second;
-    bool registered = deviceManager->registerResult(name, runId, resultCode,
-                                                    std::move(nodeInputCtx),
-                                                    std::move(nodeOutputCtx));
+    auto *deviceManagerPtr = it->second.get();
+    auto testDeviceManagerPtr =
+        static_cast<TestDeviceManager *>(deviceManagerPtr);
+
+    bool registered = testDeviceManagerPtr->registerResult(
+        name, runId, resultCode, std::move(nodeInputCtx),
+        std::move(nodeOutputCtx));
 
     (void)registered;
     assert(registered && "Node registration was not successful");
@@ -533,17 +534,17 @@ private:
   ResultCode resultCode_;
   /// Map from DeviceIDTy -> TestDeviceManager. This enables the construction of
   /// tests with nodes spread across devices.
-  const TestDeviceManagerMapTy &deviceManagers_;
+  const DeviceManagerMapTy &deviceManagers_;
 };
 
 /// This test fixture provides ThreadPoolExecutor, ExecutorTestBuilder,
-/// DeviceManagerMapTy, and TestDeviceManagerMapTy instances to all tests.
+/// DeviceManagerMapTy instances to all tests.
 class ThreadPoolExecutorTest : public ::testing::Test {
 protected:
   ThreadPoolExecutorTest()
       : executor_(std::shared_ptr<Executor>(
             createExecutor(deviceManagerMap_, ExecutorKind::ThreadPool))),
-        testBuilder_(executor_, testDeviceManagerMap_) {}
+        testBuilder_(executor_, deviceManagerMap_) {}
   ~ThreadPoolExecutorTest() = default;
 
   /// The Executor being tested.
@@ -552,8 +553,6 @@ protected:
   ExecutorTestBuilder testBuilder_;
   /// DeviceManager map for initializing executor_.
   DeviceManagerMapTy deviceManagerMap_;
-  /// TestDeviceManager map for initializing testBuilder_.
-  TestDeviceManagerMapTy testDeviceManagerMap_;
 };
 
 /// Tests that an empty DAG is handled correctly.
@@ -610,9 +609,9 @@ TEST_F(ThreadPoolExecutorTest, SingleNode) {
   // the ThreadPoolExecutor has a reference to) and the TestDeviceManager map
   // (which the ExecutorTestBuilder has a reference to).
   auto deviceManager =
-      std::make_shared<TestDeviceManager>(deviceManagerThreads);
-  deviceManagerMap_.insert(std::make_pair(testDeviceId, deviceManager));
-  testDeviceManagerMap_.insert(std::make_pair(testDeviceId, deviceManager));
+      llvm::make_unique<TestDeviceManager>(deviceManagerThreads);
+  deviceManagerMap_.insert(
+      std::make_pair(testDeviceId, std::move(deviceManager)));
 
   // Build the DAG. The DAG created below looks like this:
   /**
@@ -641,9 +640,9 @@ TEST_F(ThreadPoolExecutorTest, ConcurrentSingleNode) {
   // the ThreadPoolExecutor has a reference to) and the TestDeviceManager map
   // (which the ExecutorTestBuilder has a reference to).
   auto deviceManager =
-      std::make_shared<TestDeviceManager>(deviceManagerThreads);
-  deviceManagerMap_.insert(std::make_pair(testDeviceId, deviceManager));
-  testDeviceManagerMap_.insert(std::make_pair(testDeviceId, deviceManager));
+      llvm::make_unique<TestDeviceManager>(deviceManagerThreads);
+  deviceManagerMap_.insert(
+      std::make_pair(testDeviceId, std::move(deviceManager)));
 
   // Mutex for accessing threadsReady and testsPassed.
   std::mutex mtx;
@@ -731,9 +730,9 @@ TEST_F(ThreadPoolExecutorTest, ConcurrentSingleNodeDuplicateRunId) {
   // the ThreadPoolExecutor has a reference to) and the TestDeviceManager map
   // (which the ExecutorTestBuilder has a reference to).
   auto deviceManager =
-      std::make_shared<TestDeviceManager>(deviceManagerThreads);
-  deviceManagerMap_.insert(std::make_pair(testDeviceId, deviceManager));
-  testDeviceManagerMap_.insert(std::make_pair(testDeviceId, deviceManager));
+      llvm::make_unique<TestDeviceManager>(deviceManagerThreads);
+  deviceManagerMap_.insert(
+      std::make_pair(testDeviceId, std::move(deviceManager)));
 
   std::atomic<unsigned> testsPassed{0};
   std::vector<std::thread> threads;
@@ -786,9 +785,9 @@ TEST_F(ThreadPoolExecutorTest, MultiNode) {
   // the ThreadPoolExecutor has a reference to) and the TestDeviceManager map
   // (which the ExecutorTestBuilder has a reference to).
   auto deviceManager =
-      std::make_shared<TestDeviceManager>(deviceManagerThreads);
-  deviceManagerMap_.insert(std::make_pair(testDeviceId, deviceManager));
-  testDeviceManagerMap_.insert(std::make_pair(testDeviceId, deviceManager));
+      llvm::make_unique<TestDeviceManager>(deviceManagerThreads);
+  deviceManagerMap_.insert(
+      std::make_pair(testDeviceId, std::move(deviceManager)));
 
   // Build the DAG. The DAG created below looks like this:
   /**
@@ -839,9 +838,9 @@ TEST_F(ThreadPoolExecutorTest, MultiNodeWithFailure) {
   // the ThreadPoolExecutor has a reference to) and the TestDeviceManager map
   // (which the ExecutorTestBuilder has a reference to).
   auto deviceManager =
-      std::make_shared<TestDeviceManager>(deviceManagerThreads);
-  deviceManagerMap_.insert(std::make_pair(testDeviceId, deviceManager));
-  testDeviceManagerMap_.insert(std::make_pair(testDeviceId, deviceManager));
+      llvm::make_unique<TestDeviceManager>(deviceManagerThreads);
+  deviceManagerMap_.insert(
+      std::make_pair(testDeviceId, std::move(deviceManager)));
 
   // Build the DAG. The DAG created below looks like this:
   /**
@@ -900,9 +899,9 @@ TEST_F(ThreadPoolExecutorTest, MultiNodeMultiDevice) {
   // map (which the ExecutorTestBuilder has a reference to).
   for (DeviceIDTy deviceId : {testDeviceIdA, testDeviceIdB, testDeviceIdC}) {
     auto deviceManager =
-        std::make_shared<TestDeviceManager>(deviceManagerThreads);
-    deviceManagerMap_.insert(std::make_pair(deviceId, deviceManager));
-    testDeviceManagerMap_.insert(std::make_pair(deviceId, deviceManager));
+        llvm::make_unique<TestDeviceManager>(deviceManagerThreads);
+    deviceManagerMap_.insert(
+        std::make_pair(deviceId, std::move(deviceManager)));
   }
 
   // Build the DAG. The DAG created below looks like this:
@@ -956,9 +955,9 @@ TEST_F(ThreadPoolExecutorTest, ConcurrentMultiNode) {
   // (which the ThreadPoolExecutor has a reference to) and the TestDeviceManager
   // map (which the ExecutorTestBuilder has a reference to).
   auto deviceManager =
-      std::make_shared<TestDeviceManager>(deviceManagerThreads);
-  deviceManagerMap_.insert(std::make_pair(testDeviceId, deviceManager));
-  testDeviceManagerMap_.insert(std::make_pair(testDeviceId, deviceManager));
+      llvm::make_unique<TestDeviceManager>(deviceManagerThreads);
+  deviceManagerMap_.insert(
+      std::make_pair(testDeviceId, std::move(deviceManager)));
 
   // Mutex for accessing threadsReady and testsPassed.
   std::mutex mtx;

--- a/tests/unittests/ExecutorTest.cpp
+++ b/tests/unittests/ExecutorTest.cpp
@@ -610,8 +610,7 @@ TEST_F(ThreadPoolExecutorTest, SingleNode) {
   // (which the ExecutorTestBuilder has a reference to).
   auto deviceManager =
       llvm::make_unique<TestDeviceManager>(deviceManagerThreads);
-  deviceManagerMap_.insert(
-      std::make_pair(testDeviceId, std::move(deviceManager)));
+  deviceManagerMap_.emplace(testDeviceId, std::move(deviceManager));
 
   // Build the DAG. The DAG created below looks like this:
   /**
@@ -641,8 +640,7 @@ TEST_F(ThreadPoolExecutorTest, ConcurrentSingleNode) {
   // (which the ExecutorTestBuilder has a reference to).
   auto deviceManager =
       llvm::make_unique<TestDeviceManager>(deviceManagerThreads);
-  deviceManagerMap_.insert(
-      std::make_pair(testDeviceId, std::move(deviceManager)));
+  deviceManagerMap_.emplace(testDeviceId, std::move(deviceManager));
 
   // Mutex for accessing threadsReady and testsPassed.
   std::mutex mtx;
@@ -731,8 +729,7 @@ TEST_F(ThreadPoolExecutorTest, ConcurrentSingleNodeDuplicateRunId) {
   // (which the ExecutorTestBuilder has a reference to).
   auto deviceManager =
       llvm::make_unique<TestDeviceManager>(deviceManagerThreads);
-  deviceManagerMap_.insert(
-      std::make_pair(testDeviceId, std::move(deviceManager)));
+  deviceManagerMap_.emplace(testDeviceId, std::move(deviceManager));
 
   std::atomic<unsigned> testsPassed{0};
   std::vector<std::thread> threads;
@@ -786,8 +783,7 @@ TEST_F(ThreadPoolExecutorTest, MultiNode) {
   // (which the ExecutorTestBuilder has a reference to).
   auto deviceManager =
       llvm::make_unique<TestDeviceManager>(deviceManagerThreads);
-  deviceManagerMap_.insert(
-      std::make_pair(testDeviceId, std::move(deviceManager)));
+  deviceManagerMap_.emplace(testDeviceId, std::move(deviceManager));
 
   // Build the DAG. The DAG created below looks like this:
   /**
@@ -839,8 +835,7 @@ TEST_F(ThreadPoolExecutorTest, MultiNodeWithFailure) {
   // (which the ExecutorTestBuilder has a reference to).
   auto deviceManager =
       llvm::make_unique<TestDeviceManager>(deviceManagerThreads);
-  deviceManagerMap_.insert(
-      std::make_pair(testDeviceId, std::move(deviceManager)));
+  deviceManagerMap_.emplace(testDeviceId, std::move(deviceManager));
 
   // Build the DAG. The DAG created below looks like this:
   /**
@@ -900,8 +895,7 @@ TEST_F(ThreadPoolExecutorTest, MultiNodeMultiDevice) {
   for (DeviceIDTy deviceId : {testDeviceIdA, testDeviceIdB, testDeviceIdC}) {
     auto deviceManager =
         llvm::make_unique<TestDeviceManager>(deviceManagerThreads);
-    deviceManagerMap_.insert(
-        std::make_pair(deviceId, std::move(deviceManager)));
+    deviceManagerMap_.emplace(deviceId, std::move(deviceManager));
   }
 
   // Build the DAG. The DAG created below looks like this:
@@ -956,8 +950,7 @@ TEST_F(ThreadPoolExecutorTest, ConcurrentMultiNode) {
   // map (which the ExecutorTestBuilder has a reference to).
   auto deviceManager =
       llvm::make_unique<TestDeviceManager>(deviceManagerThreads);
-  deviceManagerMap_.insert(
-      std::make_pair(testDeviceId, std::move(deviceManager)));
+  deviceManagerMap_.emplace(testDeviceId, std::move(deviceManager));
 
   // Mutex for accessing threadsReady and testsPassed.
   std::mutex mtx;


### PR DESCRIPTION
*Description*:
Make it so HostManager owns DeviceManagers and the rest of the runtime just uses them. Make the blocking on shutdown in Executor explicit to ensure that no inflight requests will be using DeviceManagers. Prevent processing new requests while shutting down.

*Testing*:
`ninja all`
cd to downloaded_models and `../bin/resnet-runtime ../../tests/images/imagenet`

*Documentation*:
Fixes #2384 
Fixes #2297