### PR TITLE
[unittests] Move DotProduct numerical tests to OperatorTest.cpp

### DIFF
--- a/tests/unittests/Caffe2ImporterTest.cpp
+++ b/tests/unittests/Caffe2ImporterTest.cpp
@@ -937,13 +937,16 @@ TEST(caffe2, dotProduct1D) {
   constexpr std::size_t kDataSize = 10;
   auto type = mod.uniqueType(ElemKind::FloatTy, {kDataSize});
 
-  // Destroy the loader after the graph is loaded, since it's not used in
-  // the remainder of the test.
+  // Destroy the loader after the graph is loaded to ensure the function F
+  // does not depend on anything stored in it.
   {
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"X", "Y"},
                                {type, type}, *F);
     output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
   }
+
+  // Check that the shape of the output matches that of the expected output.
+  EXPECT_TRUE(output->dims().equals({kDataSize}));
 
   // High level checks on the content of the graph.
   // We have 1 Mul and 1 Output.
@@ -977,13 +980,16 @@ TEST(caffe2, dotProduct2D) {
   constexpr std::size_t kCols = 20;
   auto type = mod.uniqueType(ElemKind::FloatTy, {kRows, kCols});
 
-  // Destroy the loader after the graph is loaded, since it's not used in
-  // the remainder of the test.
+  // Destroy the loader after the graph is loaded to ensure the function F
+  // does not depend on anything stored in it.
   {
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"X", "Y"},
                                {type, type}, *F);
     output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
   }
+
+  // Check that the shape of the output matches that of the expected output.
+  EXPECT_TRUE(output->dims().equals({kRows}));
 
   // High level checks on the content of the graph.
   // We have 1 Mul, 1 BatchedReduceAdd and 1 Output.

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -5064,7 +5064,7 @@ TEST_P(InterpOnly, Modulo2) {
 }
 
 /// Test a DotProduct operator with 1D inputs.
-TEST_P(InterpAndCPU, dotProduct1D) {
+TEST_P(Operator, dotProduct1D) {
   // Input tensors.
   constexpr std::size_t kDataSize = 10;
   auto *X = mod_.createPlaceholder(ElemKind::FloatTy, {kDataSize}, "X", false);

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -5063,6 +5063,94 @@ TEST_P(InterpOnly, Modulo2) {
   }
 }
 
+/// Test a DotProduct operator with 1D inputs.
+TEST_P(InterpAndCPU, dotProduct1D) {
+  // Input tensors.
+  constexpr std::size_t kDataSize = 10;
+  auto *X = mod_.createPlaceholder(ElemKind::FloatTy, {kDataSize}, "X", false);
+  auto *Y = mod_.createPlaceholder(ElemKind::FloatTy, {kDataSize}, "Y", false);
+  auto XH = ctx_.allocate(X)->getHandle();
+  auto YH = ctx_.allocate(Y)->getHandle();
+
+  // Fill inputs with random values.
+  XH.randomize(-3.0, 3.0, mod_.getPRNG());
+  YH.randomize(-3.0, 3.0, mod_.getPRNG());
+
+  // Compute expected output.
+  auto *expected =
+      mod_.createPlaceholder(ElemKind::FloatTy, {kDataSize}, "expected", false);
+  auto expectedH = ctx_.allocate(expected)->getHandle();
+
+  for (std::size_t i = 0; i < kDataSize; ++i) {
+    expectedH.at({i}) = XH.at({i}) * YH.at({i});
+  }
+
+  // Compile and run the model.
+  auto *dotProduct = F_->createDotProduct("prod", X, Y);
+  auto *result = F_->createSave("save", dotProduct);
+  ctx_.allocate(result->getPlaceholder());
+
+  EE_.compile(CompilationMode::Infer, F_);
+  EE_.run(ctx_);
+
+  auto actualH = ctx_.get(result->getPlaceholder())->getHandle();
+
+  // Check that the output tensor is the same as the expected output.
+  EXPECT_EQ(actualH.size(), expectedH.size());
+  for (std::size_t i = 0; i < actualH.size(); ++i) {
+    EXPECT_NEAR(actualH.raw(i), expectedH.raw(i), 0.00001);
+  }
+}
+
+// Test a DotProduct operator with 2D inputs.
+TEST_P(InterpAndCPU, dotProduct2D) {
+  // Input tensors.
+  constexpr std::size_t kRows = 10;
+  constexpr std::size_t kCols = 20;
+  auto *X =
+      mod_.createPlaceholder(ElemKind::FloatTy, {kRows, kCols}, "X", false);
+  auto *Y =
+      mod_.createPlaceholder(ElemKind::FloatTy, {kRows, kCols}, "Y", false);
+  auto XH = ctx_.allocate(X)->getHandle();
+  auto YH = ctx_.allocate(Y)->getHandle();
+
+  // Fill inputs with random values.
+  XH.randomize(-3.0, 3.0, mod_.getPRNG());
+  YH.randomize(-3.0, 3.0, mod_.getPRNG());
+
+  // Compute expected output.
+  auto *expected =
+      mod_.createPlaceholder(ElemKind::FloatTy, {kRows}, "expected", false);
+  auto expectedH = ctx_.allocate(expected)->getHandle();
+
+  for (std::size_t i = 0; i < kRows; ++i) {
+    auto dotProduct = 0.0f;
+
+    // Compute dot product of the i-th row of X and Y.
+    for (std::size_t j = 0; j < kCols; ++j) {
+      dotProduct += (XH.at({i, j}) * YH.at({i, j}));
+    }
+
+    expectedH.at({i}) = dotProduct;
+  }
+
+  // Compile and run the model.
+  auto *dotProduct = F_->createDotProduct("prod", X, Y);
+  auto *result = F_->createSave("save", dotProduct);
+  ctx_.allocate(result->getPlaceholder());
+
+  EE_.compile(CompilationMode::Infer, F_);
+  EE_.run(ctx_);
+
+  auto actualH = ctx_.get(result->getPlaceholder())->getHandle();
+
+  // Check that the output tensor is the same as the expected output.
+  EXPECT_EQ(actualH.size(), expectedH.size());
+  for (std::size_t i = 0; i < actualH.size(); ++i) {
+    EXPECT_NEAR(actualH.raw(i), expectedH.raw(i), 0.00001);
+  }
+}
+
 INSTANTIATE_TEST_CASE_P(Interpreter, InterpOnly,
                         ::testing::Values(BackendKind::Interpreter));
 


### PR DESCRIPTION
*Description*: Caffe2ImporterTest currently tests both that a DotProduct
operator can be loaded and that it produces correct results. With this change,
the numerical checks are moved to OperatorTest.
*Testing*: Unit tests pass.