### PR TITLE
[DeviceManagerTest] Disable CPU-only test when not building with CPU

### DIFF
--- a/tests/unittests/DeviceManagerTest.cpp
+++ b/tests/unittests/DeviceManagerTest.cpp
@@ -392,6 +392,8 @@ TEST_P(DeviceManagerTest, ReuseModule) {
   EXPECT_NE(ctx1, ctx2);
 }
 
+#ifdef GLOW_WITH_CPU
+
 TEST_P(DeviceManagerTest, AvailableMemory) {
   std::vector<std::unique_ptr<CompiledFunction>> backing;
   std::promise<const Module *> promise;
@@ -457,6 +459,8 @@ TEST_P(DeviceManagerTest, AvailableMemory) {
   EXPECT_EQ(cpuCoreDevice.getMaximumMemory(), expectedBytes);
   EXPECT_EQ(cpuCoreDevice.getAvailableMemory(), 0);
 }
+
+#endif // GLOW_WITH_CPU
 
 INSTANTIATE_TEST_CASE_P(Interpreter, DeviceManagerTest,
                         ::testing::Values(BackendKind::Interpreter));


### PR DESCRIPTION
When not building with CPU this was causing the build to break.

Perhaps would be nice to unit test even just building with just the Interpreter backend.

I tried wrapping this in its own gtest CPUOnly case/class but couldn't get it to build successfully. If someone has a better suggestion/fix on this let me know!