### PR TITLE
[NFC] Apply modernize-use-override

### DIFF
--- a/tests/benchmark/GemmBench.cpp
+++ b/tests/benchmark/GemmBench.cpp
@@ -43,7 +43,7 @@ public:
   GemmBench(size_t m, size_t n, size_t k)
       : aDims{m, k}, bDims{k, n}, cDims{m, n} {}
 
-  virtual void setup() override {
+  void setup() override {
     size_t m = cDims[0];
     size_t n = cDims[1];
     size_t k = aDims[1];
@@ -55,11 +55,11 @@ public:
     randomize(m, n, c.data(), n);
   }
 
-  virtual void run() override {
+  void run() override {
     libjit_matmul_f(c.data(), a.data(), b.data(), cDims, aDims, bDims);
   }
 
-  virtual void teardown() override {}
+  void teardown() override {}
 
   double gflops() const { return 2.0 * cDims[0] * cDims[1] * aDims[1] / 1e9; }
 

--- a/tests/unittests/DeviceManagerTest.cpp
+++ b/tests/unittests/DeviceManagerTest.cpp
@@ -29,7 +29,7 @@ using namespace glow::runtime;
 
 class DeviceManagerTest : public ::testing::TestWithParam<BackendKind> {
 public:
-  void SetUp() { backendKind = GetParam(); }
+  void SetUp() override { backendKind = GetParam(); }
 
   BackendKind backendKind;
 };

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -30,7 +30,7 @@ class Operator : public ::testing::TestWithParam<BackendKind> {
 public:
   Operator() : mod_(EE_.getModule()) { F_ = mod_.createFunction("main"); }
 
-  ~Operator() { mod_.clear(); }
+  ~Operator() override { mod_.clear(); }
 
 protected:
   ExecutionEngine EE_{GetParam()};

--- a/tests/unittests/QuantizationTest.cpp
+++ b/tests/unittests/QuantizationTest.cpp
@@ -45,7 +45,7 @@ protected:
   ExecutionEngine profileEE{BackendKind::Interpreter};
   ExecutionEngine backendSpecificEE{BackendKind::Interpreter};
 
-  virtual void SetUp() {
+  void SetUp() override {
     BackendKind backend1;
     BackendKind backend2;
     std::tie(backend1, backend2) = GetParam();


### PR DESCRIPTION
Use C++11’s override and remove virtual where applicable.