### PR TITLE
[profiling] Add TraceEventNode for manual tracing

### DIFF
--- a/include/glow/Backends/Backend.h
+++ b/include/glow/Backends/Backend.h
@@ -88,7 +88,7 @@ public:
   virtual bool shouldShareBuffers() const { return true; }
 
   /// Optimize the Function \p F given compilation mode \p mode.
-  void optimizeFunction(CompilationMode mode, Function *F);
+  void optimizeFunction(CompilationMode mode, Function *F) const;
 
   /// \returns true if Backend generated Instruction for Node \p N,
   /// using IRGenVisitor \p irgen.
@@ -96,15 +96,18 @@ public:
     return false;
   }
 
+  virtual size_t getTraceEventDataSize() const { return 0; }
+
 protected:
+  /// Parses the graph \F and builds a TraceInfo structure from any found
+  /// TraceEventNodes.
+  TraceInfo buildManualTraceInfo(Function *F) const;
+
   /// Inserts a TraceEventInst between every instruction, the most basic form of
   /// auto instrumentation. Necessary only if the Backend doesn't provide
   /// profiling/tracing in another way.
-  /// Modifies \p IR and returns a new TraceInfo map.
-  /// \p traceEventDataSize is the size of metrics collected for  a single
-  /// TraceEvent, and should be equal to the Backend's getTraceEventDataSize()
-  /// method.
-  TraceInfo autoInstrument(IRFunction *IR, size_t traceEventDataSize) const;
+  /// Modifies \p IR and updates \p traceInfo.
+  void autoInstrument(TraceInfo &traceInfo, IRFunction *IR) const;
 };
 
 /// Create a backend of kind \p kind.

--- a/include/glow/ExecutionEngine/ExecutionEngine.h
+++ b/include/glow/ExecutionEngine/ExecutionEngine.h
@@ -79,6 +79,10 @@ public:
   /// \returns the compiled function with the given \p name.
   CompiledFunction &getCompiledFunction(llvm::StringRef name);
 
+  /// Stores \p func in the CompiledFunction map, enabling it to be run.
+  void insertCompiledFunction(llvm::StringRef name,
+                              std::unique_ptr<CompiledFunction> func);
+
   /// \returns whether operation is supported by the underlying backend.
   bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const {
     return backend_->isOpSupported(opKind, elementTy);

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -951,6 +951,12 @@ public:
                   std::vector<NodeValue> &outputs);
   /// @}
 
+  /// Create a TraceEvent in the runtime profile, which triggers collection of
+  /// runtime statistics.
+  TraceEventNode *createTraceEvent(llvm::StringRef eventName,
+                                   llvm::StringRef eventType, Node *data,
+                                   unsigned index);
+
   /// Erase the node \p N from the Function.
   void eraseNode(Node *N);
 

--- a/lib/Backends/CPU/CPUBackend.h
+++ b/lib/Backends/CPU/CPUBackend.h
@@ -68,7 +68,10 @@ public:
   /// @}
 
   /// \returns the size of metrics collected for a single TraceEvent.
-  static size_t getTraceEventDataSize() { return sizeof(uint64_t); }
+  static size_t getTraceEventDataSizeStatic() { return sizeof(uint64_t); }
+  size_t getTraceEventDataSize() const override {
+    return CPUBackend::getTraceEventDataSizeStatic();
+  }
 
 protected:
   /// Method that creates the LLVM IR generator. This gives the possibility to

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -25,14 +25,20 @@
 
 using namespace glow;
 std::unique_ptr<CompiledFunction> Interpreter::compile(Function *F) const {
+  TraceInfo traceInfo = buildManualTraceInfo(F);
   auto IR = generateAndOptimizeIR(F, *this, shouldShareBuffers());
-  return compileIR(std::move(IR));
+  auto compiledFunc = compileIR(std::move(IR));
+  compiledFunc->setTraceInfo(std::move(traceInfo));
+  return compiledFunc;
 }
 
 std::unique_ptr<CompiledFunction>
 Interpreter::compileWithoutConstants(Function *F) const {
+  TraceInfo traceInfo = buildManualTraceInfo(F);
   auto IR = generateAndOptimizeIR(F, *this, shouldShareBuffers());
-  return compileIRWithoutConstants(std::move(IR));
+  auto compiledFunc = compileIRWithoutConstants(std::move(IR));
+  compiledFunc->setTraceInfo(std::move(traceInfo));
+  return compiledFunc;
 }
 
 std::unique_ptr<CompiledFunction>
@@ -57,8 +63,9 @@ Interpreter::compileIRWithoutConstants(std::unique_ptr<IRFunction> IR) const {
 
 std::unique_ptr<CompiledFunction>
 Interpreter::instrumentAndCompile(Function *F) const {
+  TraceInfo traceInfo = buildManualTraceInfo(F);
   auto IR = generateAndOptimizeIR(F, *this, shouldShareBuffers());
-  auto traceInfo = autoInstrument(IR.get(), getTraceEventDataSize());
+  autoInstrument(traceInfo, IR.get());
   auto compiledFunc = compileIR(std::move(IR));
   compiledFunc->setTraceInfo(std::move(traceInfo));
   return compiledFunc;

--- a/lib/Backends/Interpreter/Interpreter.h
+++ b/lib/Backends/Interpreter/Interpreter.h
@@ -55,7 +55,10 @@ public:
   /// @}
   //
   /// \returns the size of metrics collected for a single TraceEvent.
-  static size_t getTraceEventDataSize() { return sizeof(uint64_t); }
+  static size_t getTraceEventDataSizeStatic() { return sizeof(uint64_t); }
+  size_t getTraceEventDataSize() const override {
+    return Interpreter::getTraceEventDataSizeStatic();
+  }
 };
 
 } // namespace glow

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -114,6 +114,12 @@ CompiledFunction &ExecutionEngine::getCompiledFunction(llvm::StringRef name) {
   return *functionIt->second;
 }
 
+void ExecutionEngine::insertCompiledFunction(
+    llvm::StringRef name, std::unique_ptr<CompiledFunction> func) {
+  assert(compiledFunctions_.find(name) == compiledFunctions_.end());
+  compiledFunctions_[name] = std::move(func);
+}
+
 void glow::runBatch(ExecutionEngine &EE, Context &ctx, size_t iterations,
                     size_t &sampleCounter, llvm::ArrayRef<Placeholder *> ph,
                     llvm::ArrayRef<Tensor *> inputs) {

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -2506,6 +2506,13 @@ void Function::createLSTM(Context &ctx, llvm::StringRef namePrefix,
   }
 };
 
+TraceEventNode *Function::createTraceEvent(llvm::StringRef eventName,
+                                           llvm::StringRef eventType,
+                                           Node *data, unsigned index) {
+  std::string name = (getName() + "_" + eventName + "_instrumentation").str();
+  return addNode(new TraceEventNode(name, data, eventName, eventType, index));
+}
+
 //===----------------------------------------------------------------------===//
 //                   Graph dumping and printing
 //===----------------------------------------------------------------------===//

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -573,6 +573,8 @@ bool TransposeNode::verify() const {
 
 bool SplatNode::verify() const { return true; }
 
+bool TraceEventNode::verify() const { return true; }
+
 bool InsertTensorNode::verify() const {
   auto dest = getBig();
   auto src = getSmall();

--- a/lib/IR/IRGen.cpp
+++ b/lib/IR/IRGen.cpp
@@ -380,6 +380,13 @@ void IRGenVisitor::post(Node *parent, Node *N) {
     registerIR(TKN->getIndices(), V->getIndices());
     break;
   }
+
+  case glow::Kinded::Kind::TraceEventNodeKind: {
+    auto *TEN = cast<TraceEventNode>(N);
+    auto *dataTensor = valueForNode(TEN->getData());
+    builder_.createTraceEventInst(TEN->getName(), dataTensor, TEN->getIndex());
+    break;
+  }
   }
 }
 

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -403,6 +403,21 @@ target_link_libraries(ThreadPoolTest
                         TestMain)
 add_glow_test(ThreadPoolTest ${GLOW_BINARY_DIR}/tests/ThreadPoolTest --gtest_output=xml:ThreadPoolTest.xml)
 
+add_executable(TraceEventsTest
+               TraceEventsTest.cpp)
+target_link_libraries(TraceEventsTest
+                      PRIVATE
+                        Backend
+                        Backends
+                        Graph
+                        IR
+                        ExecutionEngine
+                        Optimizer
+                        gtest
+                        TestMain)
+add_glow_test(TraceEventsTest ${GLOW_BINARY_DIR}/tests/TraceEventsTest --gtest_output=xml:TraceEventsTest.xml)
+LIST(APPEND UNOPT_TESTS ./tests/TraceEventsTest -optimize-ir=false &&)
+
 add_executable(TypeAToTypeBFunctionConverterTest
                TypeAToTypeBFunctionConverterTest.cpp)
 target_link_libraries(TypeAToTypeBFunctionConverterTest

--- a/tests/unittests/TraceEventsTest.cpp
+++ b/tests/unittests/TraceEventsTest.cpp
@@ -1,0 +1,435 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/ExecutionEngine/ExecutionEngine.h"
+#include "glow/Graph/Context.h"
+#include "glow/Graph/Graph.h"
+#include "glow/IR/IRBuilder.h"
+
+#include "gtest/gtest.h"
+
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace glow;
+
+class TraceEventsTest : public ::testing::TestWithParam<BackendKind> {
+public:
+  ExecutionEngine EE_{GetParam()};
+  Tensor inputs{ElemKind::FloatTy, {1, 32, 32, 3}};
+  Placeholder *inputPH;
+
+  Function *F;
+
+  void SetUp() override {
+    auto &mod = EE_.getModule();
+    inputPH = mod.createPlaceholder(ElemKind::FloatTy, {1, 32, 32, 3}, "input",
+                                    false);
+    F = mod.createFunction("main");
+    F->setName("interpret");
+  }
+
+  // Split a sample network into four parts to make it easy to insert
+  // TraceEventNodes.
+  Node *part_one(Function *F, Context &ctx) {
+    auto *CV0 = F->createConv(ctx, "conv1", inputPH, 16, 5, 1, 2, 1);
+    auto *RL0 = F->createRELU("relu1", CV0);
+    auto *MP0 = F->createMaxPool("pool1", RL0, 2, 2, 0);
+    return MP0;
+  }
+
+  Node *part_two(Function *F, Context &ctx, Node *last) {
+    auto *CV1 = F->createConv(ctx, "conv2", last, 20, 5, 1, 2, 1);
+    auto *RL1 = F->createRELU("relu2", CV1);
+    auto *MP1 = F->createMaxPool("pool2", RL1, 2, 2, 0);
+    return MP1;
+  }
+
+  Node *part_three(Function *F, Context &ctx, Node *last) {
+    auto *CV2 = F->createConv(ctx, "conv3", last, 20, 5, 1, 2, 1);
+    auto *RL2 = F->createRELU("relu3", CV2);
+    auto *MP2 = F->createMaxPool("pool3", RL2, 2, 2, 0);
+    return MP2;
+  }
+
+  Node *part_four(Function *F, Context &ctx, Node *last) {
+    auto *ex = F->getParent()->createPlaceholder(ElemKind::Int64ITy, {1, 1},
+                                                 "exp", false);
+    auto *FCL1 = F->createFullyConnected(ctx, "fc", last, 10);
+    auto *RL3 = F->createRELU("relu4", FCL1);
+    auto *SM = F->createSoftMax("sm", RL3, ex);
+    auto *S = F->createSave("ret", SM);
+    return S;
+  }
+
+  Placeholder *createEventPlaceholder(size_t numEvents) {
+    return EE_.getModule().createPlaceholder(
+        ElemKind::Int64ITy,
+        {numEvents, EE_.getBackend()->getTraceEventDataSize() /
+                        Type::getElementSize(ElemKind::Int64ITy)},
+        "", false);
+  }
+
+  // Compares generated TraceEvents with their expected names and types.
+  void checkEventMetadata(
+      const std::vector<TraceEvent> &traceEvents,
+      std::vector<std::pair<std::string, std::string>> expected) {
+
+    ASSERT_EQ(traceEvents.size(), expected.size());
+    unsigned index = 0;
+    for (auto &pair : expected) {
+      ASSERT_EQ(pair.first, traceEvents[index].name);
+      ASSERT_EQ(pair.second, traceEvents[index].type);
+      index++;
+    }
+  }
+
+  // Check timestamps are non-zero and monotonically increasing.
+  void checkEventTimestamps(const std::vector<TraceEvent> &traceEvents) {
+    uint64_t last = 0;
+    for (const auto &event : traceEvents) {
+      ASSERT_NE(event.timestamp, 0);
+      ASSERT_GE(event.timestamp, last);
+      last = event.timestamp;
+    }
+  }
+};
+
+TEST_P(TraceEventsTest, manualEvents) {
+  Context ctx;
+
+  size_t numEvents = 4;
+  auto *eventData = createEventPlaceholder(numEvents);
+  unsigned eventId = 0;
+
+  F->createTraceEvent("first half", "B", eventData, eventId++);
+  auto *n = part_one(F, ctx);
+  n = part_two(F, ctx, n);
+
+  F->createTraceEvent("first half", "E", eventData, eventId++);
+  F->createTraceEvent("second half", "B", eventData, eventId++);
+
+  n = part_three(F, ctx, n);
+  n = part_four(F, ctx, n);
+
+  F->createTraceEvent("second half", "E", eventData, eventId++);
+
+  ctx.allocate(EE_.getModule().getPlaceholders());
+  EE_.compile(CompilationMode::Infer, F);
+
+  updateInputPlaceholders(ctx, {inputPH}, {&inputs});
+  EE_.run(ctx);
+
+  auto &traceEvents = ctx.getTraceEvents();
+
+  ASSERT_EQ(traceEvents.size(), numEvents);
+  checkEventMetadata(traceEvents, {{"first half", "B"},
+                                   {"first half", "E"},
+                                   {"second half", "B"},
+                                   {"second half", "E"}});
+
+  checkEventTimestamps(traceEvents);
+
+  // Check that each timestamp matches the tensor
+  auto eventHandle = ctx.get(eventData)->getHandle<int64_t>();
+  eventId = 0;
+  for (const auto &event : traceEvents) {
+    ASSERT_EQ(event.timestamp, eventHandle.at({eventId++, 0}));
+  }
+}
+
+TEST_P(TraceEventsTest, incompleteCoverage) {
+  Context ctx;
+
+  size_t numEvents = 2;
+  auto *eventData = createEventPlaceholder(numEvents);
+  unsigned eventId = 0;
+
+  auto *n = part_one(F, ctx);
+  n = part_two(F, ctx, n);
+
+  F->createTraceEvent("second half", "B", eventData, eventId++);
+
+  n = part_three(F, ctx, n);
+  n = part_four(F, ctx, n);
+
+  F->createTraceEvent("second half", "E", eventData, eventId++);
+
+  ctx.allocate(EE_.getModule().getPlaceholders());
+  EE_.compile(CompilationMode::Infer, F);
+
+  updateInputPlaceholders(ctx, {inputPH}, {&inputs});
+  EE_.run(ctx);
+
+  auto &traceEvents = ctx.getTraceEvents();
+
+  ASSERT_EQ(traceEvents.size(), numEvents);
+  checkEventMetadata(traceEvents, {{"second half", "B"}, {"second half", "E"}});
+
+  checkEventTimestamps(traceEvents);
+
+  // Check that each timestamp matches the tensor
+  auto eventHandle = ctx.get(eventData)->getHandle<int64_t>();
+  eventId = 0;
+  for (const auto &event : traceEvents) {
+    ASSERT_EQ(event.timestamp, eventHandle.at({eventId++, 0}));
+  }
+}
+
+TEST_P(TraceEventsTest, internalGap) {
+  Context ctx;
+
+  size_t numEvents = 2;
+  auto *eventData = createEventPlaceholder(numEvents);
+  unsigned eventId = 0;
+
+  auto *n = part_one(F, ctx);
+
+  F->createTraceEvent("middle section", "B", eventData, eventId++);
+  n = part_two(F, ctx, n);
+  n = part_three(F, ctx, n);
+  F->createTraceEvent("middle section", "E", eventData, eventId++);
+
+  n = part_four(F, ctx, n);
+
+  ctx.allocate(EE_.getModule().getPlaceholders());
+  EE_.compile(CompilationMode::Infer, F);
+
+  updateInputPlaceholders(ctx, {inputPH}, {&inputs});
+  EE_.run(ctx);
+
+  auto &traceEvents = ctx.getTraceEvents();
+
+  ASSERT_EQ(traceEvents.size(), numEvents);
+  checkEventMetadata(traceEvents,
+                     {{"middle section", "B"}, {"middle section", "E"}});
+
+  checkEventTimestamps(traceEvents);
+
+  // Check that each timestamp matches the tensor
+  auto eventHandle = ctx.get(eventData)->getHandle<int64_t>();
+  eventId = 0;
+  for (const auto &event : traceEvents) {
+    ASSERT_EQ(event.timestamp, eventHandle.at({eventId++, 0}));
+  }
+}
+
+TEST_P(TraceEventsTest, automaticInstrumentation) {
+  Context ctx;
+
+  auto *n = part_one(F, ctx);
+  n = part_two(F, ctx, n);
+  n = part_three(F, ctx, n);
+  n = part_four(F, ctx, n);
+
+  ctx.allocate(EE_.getModule().getPlaceholders());
+  auto *backend = EE_.getBackend();
+  backend->optimizeFunction(CompilationMode::Infer, F);
+  EE_.insertCompiledFunction(F->getName(), backend->instrumentAndCompile(F));
+
+  updateInputPlaceholders(ctx, {inputPH}, {&inputs});
+  EE_.run(ctx);
+
+  auto &traceEvents = ctx.getTraceEvents();
+
+  ASSERT_GT(traceEvents.size(), 0);
+  checkEventTimestamps(traceEvents);
+}
+
+TEST_P(TraceEventsTest, manualAndAutomatic) {
+  Context ctx;
+
+  size_t numEvents = 4;
+  auto *eventData = createEventPlaceholder(numEvents);
+  unsigned eventId = 0;
+
+  F->createTraceEvent("first half", "B", eventData, eventId++);
+  auto *n = part_one(F, ctx);
+  n = part_two(F, ctx, n);
+
+  F->createTraceEvent("first half", "E", eventData, eventId++);
+  F->createTraceEvent("second half", "B", eventData, eventId++);
+
+  n = part_three(F, ctx, n);
+  n = part_four(F, ctx, n);
+
+  F->createTraceEvent("second half", "E", eventData, eventId++);
+
+  ctx.allocate(EE_.getModule().getPlaceholders());
+  auto *backend = EE_.getBackend();
+  backend->optimizeFunction(CompilationMode::Infer, F);
+  EE_.insertCompiledFunction(F->getName(), backend->instrumentAndCompile(F));
+
+  updateInputPlaceholders(ctx, {inputPH}, {&inputs});
+  EE_.run(ctx);
+
+  auto &traceEvents = ctx.getTraceEvents();
+
+  ASSERT_GT(traceEvents.size(), numEvents);
+  size_t manualEvents = 0;
+  for (const auto &event : traceEvents) {
+    if (event.name == "first half" || event.name == "second half") {
+      manualEvents++;
+    }
+  }
+  ASSERT_EQ(manualEvents, numEvents);
+}
+
+TEST_P(TraceEventsTest, onlyTraceEvents) {
+  Context ctx;
+
+  size_t numEvents = 16;
+  auto *eventData = createEventPlaceholder(numEvents);
+  unsigned eventId = 0;
+
+  std::vector<std::pair<std::string, std::string>> expected;
+  for (unsigned eventId = 0; eventId < numEvents; ++eventId) {
+    std::string name = "event_" + std::to_string(eventId);
+    F->createTraceEvent(name, "X", eventData, eventId);
+    expected.push_back({name, "X"});
+  }
+
+  ctx.allocate(EE_.getModule().getPlaceholders());
+  EE_.compile(CompilationMode::Infer, F);
+
+  updateInputPlaceholders(ctx, {inputPH}, {&inputs});
+  EE_.run(ctx);
+
+  auto &traceEvents = ctx.getTraceEvents();
+
+  ASSERT_EQ(traceEvents.size(), numEvents);
+  checkEventMetadata(traceEvents, expected);
+  checkEventTimestamps(traceEvents);
+
+  // Check that each timestamp matches the tensor
+  auto eventHandle = ctx.get(eventData)->getHandle<int64_t>();
+  eventId = 0;
+  for (const auto &event : traceEvents) {
+    ASSERT_EQ(event.timestamp, eventHandle.at({eventId++, 0}));
+  }
+}
+
+TEST_P(TraceEventsTest, multipleBackingTensors) {
+  Context ctx;
+
+  size_t numEvents = 6;
+  auto *eventData1 = createEventPlaceholder(3);
+  auto *eventData2 = createEventPlaceholder(3);
+
+  F->createTraceEvent("event1", "B", eventData1, 0);
+  auto *n = part_one(F, ctx);
+  F->createTraceEvent("event1", "E", eventData1, 1);
+
+  F->createTraceEvent("event2", "B", eventData2, 0);
+  n = part_two(F, ctx, n);
+  F->createTraceEvent("event2", "E", eventData2, 1);
+
+  // now lets split between two tensors
+
+  auto *eventData3 = createEventPlaceholder(1);
+  auto *eventData4 = createEventPlaceholder(1);
+
+  F->createTraceEvent("event3", "B", eventData3, 0);
+  n = part_three(F, ctx, n);
+  n = part_four(F, ctx, n);
+  F->createTraceEvent("event3", "E", eventData4, 0);
+
+  ctx.allocate(EE_.getModule().getPlaceholders());
+  EE_.compile(CompilationMode::Infer, F);
+
+  updateInputPlaceholders(ctx, {inputPH}, {&inputs});
+  EE_.run(ctx);
+
+  auto &traceEvents = ctx.getTraceEvents();
+
+  ASSERT_EQ(traceEvents.size(), numEvents);
+
+  // Can't use checkEventMetadata since events aren't ordered
+  size_t event1{0}, event2{0}, event3{0};
+  for (const auto &event : traceEvents) {
+    if (event.name == "event1") {
+      event1++;
+    } else if (event.name == "event2") {
+      event2++;
+    } else if (event.name == "event3") {
+      event3++;
+    } else {
+      ASSERT_FALSE("unknown event name");
+    }
+  }
+
+  ASSERT_EQ(event1, 2);
+  ASSERT_EQ(event2, 2);
+  ASSERT_EQ(event3, 2);
+}
+
+TEST_P(TraceEventsTest, multipleRunsAreDistinct) {
+  Context ctx;
+
+  size_t numEvents = 4;
+  auto *eventData = createEventPlaceholder(numEvents);
+  unsigned eventId = 0;
+
+  F->createTraceEvent("first half", "B", eventData, eventId++);
+  auto *n = part_one(F, ctx);
+  n = part_two(F, ctx, n);
+
+  F->createTraceEvent("first half", "E", eventData, eventId++);
+  F->createTraceEvent("second half", "B", eventData, eventId++);
+
+  n = part_three(F, ctx, n);
+  n = part_four(F, ctx, n);
+
+  F->createTraceEvent("second half", "E", eventData, eventId++);
+
+  ctx.allocate(EE_.getModule().getPlaceholders());
+  EE_.compile(CompilationMode::Infer, F);
+
+  updateInputPlaceholders(ctx, {inputPH}, {&inputs});
+
+  Context ctx2{ctx.clone()};
+
+  // run twice
+  EE_.run(ctx);
+  EE_.run(ctx2);
+
+  auto &traceEvents = ctx.getTraceEvents();
+  auto &traceEvents2 = ctx2.getTraceEvents();
+
+  ASSERT_EQ(traceEvents.size(), numEvents);
+  ASSERT_EQ(traceEvents2.size(), numEvents);
+
+  for (unsigned i = 0; i < numEvents; ++i) {
+    ASSERT_EQ(traceEvents[i].name, traceEvents[i].name);
+    ASSERT_EQ(traceEvents[i].type, traceEvents[i].type);
+    // timestamps are not equal
+    ASSERT_EQ(traceEvents[i].timestamp, traceEvents[i].timestamp);
+  }
+}
+
+INSTANTIATE_TEST_CASE_P(Interpreter, TraceEventsTest,
+                        ::testing::Values(BackendKind::Interpreter));
+
+#ifdef GLOW_WITH_CPU
+INSTANTIATE_TEST_CASE_P(JIT, TraceEventsTest,
+                        ::testing::Values(BackendKind::CPU));
+#endif // GLOW_WITH_CPU
+
+#ifdef GLOW_WITH_OPENCL
+// INSTANTIATE_TEST_CASE_P(OpenCL, TraceEventsTest,
+//                        ::testing::Values(BackendKind::OpenCL));
+#endif // GLOW_WITH_OPENCL

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -593,6 +593,18 @@ int main(int argc, char **argv) {
                     "instead of Weight for the next iteration.");
 
   //===--------------------------------------------------------------------===//
+  //             Nodes used for debugging/profiling/printing
+  //===--------------------------------------------------------------------===//
+
+  BB.newNode("TraceEvent")
+      .addInput("Data")
+      .addMember(MemberType::String, "EventName")
+      .addMember(MemberType::String, "EventType")
+      .addMember(MemberType::Unsigned, "Index")
+      .setHasSideEffects(true)
+      .setDocstring("Inserts a TraceEvent for profiling.");
+
+  //===--------------------------------------------------------------------===//
   //                Nodes used by quantization.
   //===--------------------------------------------------------------------===//
 


### PR DESCRIPTION
*Description*: To support profiling the graph as provided (ie. before optimization) this adds TraceEventNodes: Nodes in the graph that explicitly trigger metrics collection. They get compiled right down to TraceEventInstrs which are handled the same way as the automatic instrumentation.
*Testing*: new unit tests!
*Documentation*:
This diff demonstrates the need to refactor various calls to compile, which is next on the list.
Also I guess it would be nice to simplify adding TraceEventNodes and automate generation of the backing Tensor.