### PR TITLE
[InstGen] LocalResponseNormalization src/dest should not be in-place

### DIFF
--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -156,10 +156,6 @@ int main(int argc, char **argv) {
       .addMember(MemberType::Float, "Beta")
       .addMember(MemberType::Float, "K")
       .setType("Src->getType()")
-      .inplaceOperand({
-          "Dest",
-          "Src",
-      })
       .autoVerify(VerifyKind::SameType, {"Dest", "Src", "Scale"})
       .addGradientInstr({"Dest", "Src", "Scale"}, {"Dest", "Src"});
 


### PR DESCRIPTION
**Description**
This commit removes code that marks the source and destination buffers
of the `LocalResponseNormalization` instruction as in-place. The value of
an output element depends on the values adjacent to the corresponding
input element, so there is no way to perform the local response
normalization operation in-place.

**Testing**
All unit tests pass.

**Fixes**
This commit fixes #2356.