### PR TITLE
Create an optional EXPENSIVE label for tests

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -65,7 +65,7 @@ if [[ "${CIRCLE_JOB}" == "ASAN" ]]; then
 elif [[ "${CIRCLE_JOB}" == "TSAN" ]]; then
     CMAKE_ARGS+=("-DGLOW_USE_SANITIZER='Thread'")
     CMAKE_ARGS+=("-DGLOW_WITH_OPENCL=OFF")
-elif [[ "$CIRCLE_JOB" == RELEASE_WITH_OUTPUTCHECK ]]; then
+elif [[ "$CIRCLE_JOB" == RELEASE_WITH_EXPENSIVE_TESTS ]]; then
     # Download the models and tell cmake where to find them.
     MODELS_DIR="$GLOW_DIR/downloaded_models"
     DOWNLOAD_EXE="$GLOW_DIR/utils/download_caffe2_models.sh"
@@ -77,7 +77,6 @@ elif [[ "$CIRCLE_JOB" == RELEASE_WITH_OUTPUTCHECK ]]; then
     CMAKE_ARGS+=("-DGLOW_MODELS_DIR=$MODELS_DIR")
     CMAKE_ARGS+=("-DGLOW_WITH_OPENCL=OFF")
     CMAKE_ARGS+=("-DCMAKE_BUILD_TYPE=Release")
-    CMAKE_ARGS+=("-DGLOW_BUILD_OUTPUTCHECK_TESTS=ON")
 else
     install_pocl
     CMAKE_ARGS+=("-DCMAKE_BUILD_TYPE=Debug")

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
     environment:
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang6.0-ubuntu16.04:230"
     <<: *linux_default
-  RELEASE_WITH_OUTPUTCHECK:
+  RELEASE_WITH_EXPENSIVE_TESTS:
     environment:
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang6.0-ubuntu16.04:230"
     <<: *linux_default
@@ -97,4 +97,4 @@ workflows:
       - ASAN
       - TSAN
       - SHARED
-      - RELEASE_WITH_OUTPUTCHECK
+      - RELEASE_WITH_EXPENSIVE_TESTS

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -55,8 +55,8 @@ case ${CIRCLE_JOB} in
         # No tests with shared libs; it's similar to DEBUG.
         ;;
 
-    RELEASE_WITH_OUTPUTCHECK)
-        run_unit_tests check
+    RELEASE_WITH_EXPENSIVE_TESTS)
+        run_unit_tests check_expensive
         ;;
 
     *)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,6 @@ option(GLOW_BUILD_EXAMPLES "Build the examples" ON)
 option(GLOW_BUILD_TESTS "Build the tests" ON)
 option(GLOW_WITH_BUNDLES "Build bundles" OFF)
 option(LINK_PROTOBUF_AS_DLL "Link against protobuf build as dynamic libray." OFF)
-option(GLOW_BUILD_OUTPUTCHECK_TESTS "Build tests that run with OutputCheck" OFF)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CXX_STANDARD_REQUIRED ON)
@@ -125,7 +124,12 @@ if (GLOW_BUILD_TESTS)
   # Fetch the dependencies for all the tests.
   get_property(GLOW_TEST_DEPENDS GLOBAL PROPERTY GLOW_TEST_DEPENDS)
 
-  add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND}
+  # All tests except expensive tests
+  add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} -LE EXPENSIVE
+                      DEPENDS ${GLOW_TEST_DEPENDS} USES_TERMINAL)
+
+  # All tests including expensive tests
+  add_custom_target(check_expensive COMMAND ${CMAKE_CTEST_COMMAND}
                       DEPENDS ${GLOW_TEST_DEPENDS} USES_TERMINAL)
 endif()
 

--- a/cmake/modules/GlowTestSupport.cmake
+++ b/cmake/modules/GlowTestSupport.cmake
@@ -16,9 +16,10 @@
 # Unlike the 'test' target, the 'check' target rebuilds the executables
 # before invoking the tests.
 function(add_glow_test)
+  set(options OPTIONAL EXPENSIVE)
   set(oneValueArgs NAME)
   set(multiValueArgs COMMAND DEPENDS)
-  cmake_parse_arguments(ARG "" "${oneValueArgs}"
+  cmake_parse_arguments(ARG "${options}" "${oneValueArgs}"
                           "${multiValueArgs}" ${ARGN})
 
   if (NOT ARG_NAME)
@@ -45,4 +46,11 @@ function(add_glow_test)
 
   # Produce the specific test rule using the default built-in.
   add_test(NAME ${ARG_NAME} COMMAND ${ARG_COMMAND})
+
+  # If the EXPENSIVE argument is passed, add the EXPENSIVE label to the test
+  # so that it will only be run with the other expensive tests with the
+  # ninja check_expensive command
+  if (ARG_EXPENSIVE)
+    set_property(TEST ${ARG_NAME} PROPERTY LABELS EXPENSIVE)
+  endif()
 endfunction()

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -134,18 +134,16 @@ Run them as part of your local build using the following
 ```bash
 cmake -G Ninja <glow_src>  -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_PREFIX_PATH=/usr/local/opt/llvm         \
-      -DGLOW_MODELS_DIR=<downloaded_c2_models>        \
-      -DGLOW_BUILD_OUTPUTCHECK_TESTS=ON
+      -DGLOW_MODELS_DIR=<downloaded_c2_models>
 ```
 Followed by
 ```bash
-ninja output_check_tests
+ninja check_expensive
 ```
 
-The integration tests get run with the other CMake tests using:
-```bash
-ninja check
-```
+Note: `ninja check_expensive` runs all of the tests that `ninja check` runs plus
+any tests that have been marked as EXPENSIVE using add_glow_test(EXPENSIVE ...)
+such as the integration tests.
 
 Note: The difference between `ninja test` and `ninja check` is that
 `ninja check` makes sure the build dependencies are current before

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,7 +6,43 @@ add_subdirectory(benchmark)
 add_subdirectory(models)
 
 # Function which creates a new OutputCheck test that runs test_script.
-function(add_output_check_test test_name test_script)
+function(add_output_check_test)
+  set(oneValueArgs NAME)
+  set(multiValueArgs COMMAND REQUIRES)
+  cmake_parse_arguments(ARG "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  if (NOT ARG_NAME)
+    message(FATAL_ERROR "Name mandatory")
+  endif()
+  
+  if (NOT ARG_COMMAND)
+    message(FATAL_ERROR "Command mandatory")
+  endif()
+
+  # Skip test if it requires CPU and DGLOW_WITH_CPU is OFF.
+  if ("CPU" IN_LIST ARG_REQUIRES)
+    if (NOT GLOW_WITH_CPU)
+      message("Skipping adding test ${ARG_NAME} because it requires CPU backend. Configure with -DGLOW_WITH_CPU.")
+      return()
+    endif()
+  endif()
+
+  # Skip test if it requires downloaded models that aren't provided.
+  if ("MODELS" IN_LIST ARG_REQUIRES)
+    if(NOT EXISTS "${GLOW_MODELS_DIR}")
+      message("Skipping adding test ${ARG_NAME} because it requires a models directory. Configure with -DGLOW_MODELS_DIR.")
+      return()
+    endif()
+  endif()
+
+  # Skip test if it requires RELEASE and was compiled with a different build type.
+  if ("RELEASE" IN_LIST ARG_REQUIRES)
+    if(NOT CMAKE_BUILD_TYPE STREQUAL "Release")
+      message("Skipping adding test ${ARG_NAME} because it requires a Release build. Configure with -DCMAKE_BUILD_TYPE=Release.")
+      return()
+    endif()
+  endif()
+
   set (OUTPUTCHECK_PATH "${GLOW_SOURCE_DIR}/tests/OutputCheck/bin/OutputCheck")
   set (OUTPUTCHECK_RUNNER_PATH "${GLOW_SOURCE_DIR}/tests/run_outputcheck.sh")
 
@@ -16,11 +52,12 @@ function(add_output_check_test test_name test_script)
     OUTPUTCHECK=${OUTPUTCHECK_PATH}
     TEXT_TRANSLATOR=${GLOW_OUTPUT_DIR}/text-translator)
 
-  set(TEST_COMMAND ${SETUP_OUTPUTCHECK_ENV} ${OUTPUTCHECK_RUNNER_PATH} ${test_script})
+  set(TEST_COMMAND ${SETUP_OUTPUTCHECK_ENV} ${OUTPUTCHECK_RUNNER_PATH} ${ARG_COMMAND})
 
-  # Add Glow test.
+  # Add expensive Glow test.
   add_glow_test(
-    NAME ${test_name}
+    EXPENSIVE
+    NAME ${ARG_NAME}
     COMMAND ${TEST_COMMAND}
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
     DEPENDS text-translator)
@@ -32,32 +69,21 @@ function(add_output_check_test test_name test_script)
   set(OUTPUTCHECK_TESTS ${OUTPUTCHECK_TESTS} PARENT_SCOPE)
 endfunction()
 
-if (GLOW_BUILD_OUTPUTCHECK_TESTS)
-  if(NOT EXISTS "${GLOW_MODELS_DIR}")
-    message(FATAL_ERROR "Must provide a valid models directory with -DGLOW_MODELS_DIR.")
-  endif()
+set (TEXT_TRANSLATOR_TESTS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/text-translator")
 
-  # TODO not all tests may require CPU. We should make this requirement more
-  # flexible in the future.
-  if (NOT GLOW_WITH_CPU)
-    message(FATAL_ERROR "Cannot run OutputCheck tests without CPU. Configure with -DGLOW_WITH_CPU.")
-  endif()
+# Create en2gr_cpu_test OutputCheck test.
+add_output_check_test(NAME en2gr_cpu_test
+                      COMMAND ${TEXT_TRANSLATOR_TESTS_DIR}/en2gr_cpu_test.sh
+                      REQUIRES MODELS CPU RELEASE)
 
-  if(NOT CMAKE_BUILD_TYPE STREQUAL "Release")
-    message(WARNING "Some tests run with OutputCheck are extremely slow when not built with Release. To build with release use -DCMAKE_BUILD_TYPE=Release")
-  endif()
+# Create en2gr_quantization_test OutputCheck test.
+add_output_check_test(NAME en2gr_quantization_test
+                      COMMAND ${TEXT_TRANSLATOR_TESTS_DIR}/en2gr_quantization_test.sh
+                      REQUIRES MODELS RELEASE)
 
-  set (TEXT_TRANSLATOR_TESTS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/text-translator")
-
-  add_output_check_test(en2gr_cpu_test
-                        ${TEXT_TRANSLATOR_TESTS_DIR}/en2gr_cpu_test.sh)
-  add_output_check_test(en2gr_quantization_test
-                        ${TEXT_TRANSLATOR_TESTS_DIR}/en2gr_quantization_test.sh)
-
-  # Create target.
-  LIST(APPEND OUTPUTCHECK_TESTS true)
-  add_custom_target(output_check_tests
-    COMMAND ${OUTPUTCHECK_TESTS}
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-    DEPENDS text-translator)
-endif ()
+# Create target for OUTPUTCHECK_TESTS. 
+LIST(APPEND OUTPUTCHECK_TESTS true)
+add_custom_target(output_check_tests
+  COMMAND ${OUTPUTCHECK_TESTS}
+  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+  DEPENDS text-translator)


### PR DESCRIPTION
*Description*:
Create a set of tests with the `EXPENSIVE` label (`add_glow_test(EXPENSIVE ...)`) and only run those tests with `ninja check_expensive`. Make all existing OutputCheck tests use the `EXPENSIVE` label. Build all tests all the time, only run OutputCheck tests when all build requirements were satisfied.

*Testing*:
`ninja check`
`ninja check_expensive`

*Documentation*:
Comments, Updated docs
