### PR TITLE
Update scripts for calling protoc with caffe2 models

### DIFF
--- a/utils/decode_caffe2_protoc.sh
+++ b/utils/decode_caffe2_protoc.sh
@@ -14,16 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Encodes a textual pbtxt file of a Caffe2 model to binary pb format.
+# Decodes a binary pb file of a Caffe2 model to textual pbtxt format.
 if [ -z "$1" ]; then
-    echo "Usage: $(basename "$0") pbtxt"
+    echo "Usage: $(basename "$0") pb"
     exit 1
 fi
 
-PBTXT="$1"
+PB="$1"
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 LIB_DIR="$SCRIPT_DIR/../lib/Importer"
 
-protoc --encode=caffe2.NetDef -I "$LIB_DIR" "$LIB_DIR/caffe2.proto" < "$PBTXT"
+protoc --decode=caffe2.NetDef -I "$LIB_DIR" "$LIB_DIR/caffe2.proto" < "$PB"


### PR DESCRIPTION
*Description*:
Fix proto path in `encode_caffe2_protoc.sh`.
Create a `decode_caffe2_protoc.sh` that decodes `.pb` to `.pbtxt`.

*Testing*:
* encode:
  * ran `./utils/encode_caffe2_protoc.sh ./build/downloaded_models/resnet50/predict_net.pbtxt | diff ./build/downloaded_models/resnet50/predict_net.pb -`
  * no changes observed
* decode:
  * ran: `./utils/decode_caffe2_protoc.sh ./build/downloaded_models/resnet50/predict_net.pb | diff ./build/downloaded_models/resnet50/predict_net.pbtxt -`
  * observed the following changes that look like rounding errors, not sure if they are significant: https://gist.github.com/jackm321/a1ad4cb3c2cb882093a906fe91aea675

*Documentation*:
comments in script
