### PR TITLE
Check type of CompiledFunction in DeviceManager before adding

### DIFF
--- a/include/glow/Backends/CompiledFunction.h
+++ b/include/glow/Backends/CompiledFunction.h
@@ -25,6 +25,7 @@
 namespace glow {
 
 class Context;
+enum class BackendKind;
 /// Interface for executing a compiled function.
 class CompiledFunction {
 public:
@@ -70,6 +71,9 @@ public:
 
   /// Read trace events out of this func and write them into /p ctx
   virtual void translateTraceEvents(Context *ctx) const {}
+
+  /// \returns the Kind of Backend used to compile this function.
+  virtual BackendKind getCompileBackendKind() const = 0;
 
 protected:
   /// Flag to ensure setupRuns is only called once.

--- a/lib/Backends/CPU/CPUDeviceManager.cpp
+++ b/lib/Backends/CPU/CPUDeviceManager.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "CPUDeviceManager.h"
+#include "CPUFunction.h"
 
 #include "llvm/Support/raw_ostream.h"
 
@@ -49,6 +50,12 @@ void CPUDeviceManager::addNetworkImpl(const Module *module,
                    << func.first << ".\n";
       readyCB(module, ResultCode::Failed);
       return;
+    }
+
+    if (func.second->getCompileBackendKind() != BackendKind::CPU) {
+      llvm::errs() << "Failed to add network: function " << func.first
+                   << " is not a CPUFunction.\n";
+      readyCB(module, ResultCode::Failed);
     }
   }
 

--- a/lib/Backends/CPU/CPUFunction.h
+++ b/lib/Backends/CPU/CPUFunction.h
@@ -18,6 +18,7 @@
 
 #include "GlowJIT.h"
 
+#include "glow/Backends/Backend.h"
 #include "glow/Backends/BackendUtils.h"
 #include "glow/Backends/CompiledFunction.h"
 
@@ -41,6 +42,11 @@ public:
 
   /// Read trace events out of this func and write them into /p ctx
   void translateTraceEvents(Context *ctx) const override;
+
+  /// \returns the Kind of Backend used to compile this function.
+  virtual BackendKind getCompileBackendKind() const override {
+    return BackendKind::CPU;
+  }
   ///@}
   //
 

--- a/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "InterpreterDeviceManager.h"
+#include "Interpreter.h"
 
 #include "llvm/Support/raw_ostream.h"
 
@@ -46,6 +47,12 @@ void InterpreterDeviceManager::addNetworkImpl(const Module *module,
                    << func.first << ".\n";
       readyCB(module, ResultCode::Failed);
       return;
+    }
+
+    if (func.second->getCompileBackendKind() != BackendKind::Interpreter) {
+      llvm::errs() << "Failed to add network: function " << func.first
+                   << " is not an InterpreterFunction.\n";
+      readyCB(module, ResultCode::Failed);
     }
   }
 

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -16,6 +16,7 @@
 #ifndef GLOW_BACKENDS_INTERPRETER_INTERPRETERFUNCTION_H
 #define GLOW_BACKENDS_INTERPRETER_INTERPRETERFUNCTION_H
 
+#include "glow/Backends/Backend.h"
 #include "glow/Backends/BackendUtils.h"
 #include "glow/Backends/CompiledFunction.h"
 #include "glow/Base/Tensor.h"
@@ -67,6 +68,11 @@ public:
 
   /// Read trace events out of this func and write them into /p ctx
   void translateTraceEvents(Context *ctx) const override;
+
+  /// \returns the Kind of Backend used to compile this function.
+  virtual BackendKind getCompileBackendKind() const override {
+    return BackendKind::Interpreter;
+  }
   ///@}
 };
 

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -108,6 +108,11 @@ public:
 
   /// Collects constants for runtime.
   void collectConstants(Module *module) override;
+
+  /// \returns the Kind of Backend used to compile this function.
+  virtual BackendKind getCompileBackendKind() const override {
+    return BackendKind::OpenCL;
+  }
   ///@}
 
   /// Returns IR function pointer.

--- a/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
@@ -22,6 +22,7 @@
 #define CL_USE_DEPRECATED_OPENCL_1_2_APIS
 
 #include "OpenCLDeviceManager.h"
+#include "OpenCL.h"
 
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/raw_ostream.h"
@@ -113,6 +114,12 @@ void OpenCLDeviceManager::addNetworkImpl(const Module *module,
                    << func.first << ".\n";
       readyCB(module, ResultCode::Failed);
       return;
+    }
+
+    if (func.second->getCompileBackendKind() != BackendKind::OpenCL) {
+      llvm::errs() << "Failed to add network: function " << func.first
+                   << " is not an OpenCL Function.\n";
+      readyCB(module, ResultCode::Failed);
     }
   }
   // Collect constants once, since currently the bundle grabs everything in the

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "glow/Backends/Backend.h"
 #include "glow/ExecutionEngine/ExecutionEngine.h"
 #include "glow/Graph/Graph.h"
 #include "glow/IR/IR.h"
@@ -31,6 +32,10 @@ namespace glow {
 class MockBackend : public Backend {
   class MockFunction : public CompiledFunction {
     void execute(Context *) override {}
+
+    BackendKind getCompileBackendKind() const override {
+      return BackendKind::Interpreter;
+    }
   };
 
   std::unique_ptr<CompiledFunction> compile(Function *F) const override {
@@ -56,6 +61,10 @@ class MockBackend : public Backend {
 class MockBackendCustomIRGen : public Backend {
   class MockFunction : public CompiledFunction {
     void execute(Context *) override {}
+
+    BackendKind getCompileBackendKind() const override {
+      return BackendKind::Interpreter;
+    }
   };
 
   std::unique_ptr<CompiledFunction> compile(Function *F) const override {

--- a/tests/unittests/DeviceManagerTest.cpp
+++ b/tests/unittests/DeviceManagerTest.cpp
@@ -394,7 +394,7 @@ TEST_P(DeviceManagerTest, ReuseModule) {
 
 #ifdef GLOW_WITH_CPU
 
-TEST_P(DeviceManagerTest, AvailableMemory) {
+TEST(DeviceManagerTest, AvailableMemory) {
   std::vector<std::unique_ptr<CompiledFunction>> backing;
   std::promise<const Module *> promise;
   std::future<const Module *> future;
@@ -411,7 +411,7 @@ TEST_P(DeviceManagerTest, AvailableMemory) {
   auto module = makeBasicModule();
   std::tie(promise, future) = getFutureHelper<const Module *>();
   cpuCoreDevice.addNetwork(
-      module.get(), compileFunctions(backendKind, module.get(), backing),
+      module.get(), compileFunctions(BackendKind::CPU, module.get(), backing),
       [&promise](const Module *module, ResultCode result) {
         callbackHelper(promise, module, result, ResultCode::Ready);
       });
@@ -428,7 +428,7 @@ TEST_P(DeviceManagerTest, AvailableMemory) {
   auto module2 = makeBasicModule();
   std::tie(promise, future) = getFutureHelper<const Module *>();
   cpuCoreDevice.addNetwork(
-      module2.get(), compileFunctions(backendKind, module2.get(), backing),
+      module2.get(), compileFunctions(BackendKind::CPU, module2.get(), backing),
       [&promise](const Module *module, ResultCode result) {
         callbackHelper(promise, module, result, ResultCode::Ready);
       });
@@ -448,7 +448,7 @@ TEST_P(DeviceManagerTest, AvailableMemory) {
   // And try again, this time with available space.
   std::tie(promise, future) = getFutureHelper<const Module *>();
   cpuCoreDevice.addNetwork(
-      module2.get(), compileFunctions(backendKind, module2.get(), backing),
+      module2.get(), compileFunctions(BackendKind::CPU, module2.get(), backing),
       [&promise](const Module *module, ResultCode result) {
         callbackHelper(promise, module, result, ResultCode::Ready);
       });


### PR DESCRIPTION
*Description*: Adds a `getCompileBackendKind()`method to CompiledFunction which returns the kind of backend used to create it. In the DeviceManager we can use this to prevent CompiledFunctions of the wrong type from being added.
*Testing*: Ran unit test, found and fixed a bad DeviceManagerTest.
*Documentation*: fixes #2410 

Worth noting this adds a new pure virtual method to CompiledFunction, so new Backends will need to fill this out in their CompiledFunction-subclasses.