### PR TITLE
Add in new ElemKind::BoolTy for use with Compare, Select instructions

### DIFF
--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -344,6 +344,8 @@ public:
       // scale/offset do not match.
     case ElemKind::Int8FusedQTy:
       return isEqualImpl<int8_t>(other, allowedError);
+    case ElemKind::BoolTy:
+      return isEqualImpl<bool>(other, allowedError);
     }
 
     // This is to make compiler happy. It can never reach this point as switch
@@ -746,6 +748,9 @@ public:
         }
       }
       return;
+    }
+    case ElemKind::BoolTy: {
+      llvm_unreachable("Undefined to Xavier-initialize Bool Tensor.");
     }
     }
   }

--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -264,6 +264,7 @@ enum class ElemKind : unsigned char {
   Int32ITy,     // 32-bit index type (int32_t)
   Int64ITy,     // 64-bit index type (int64_t)
   Int8FusedQTy, // 8-bit quantized type with fused scale/offset (int8_t)
+  BoolTy,       // Bool type (bool)
 };
 
 /// A class that represents a type of a tensor.
@@ -434,6 +435,8 @@ struct Type final {
       return std::is_same<ElemTy, int64_t>::value;
     case ElemKind::Int8FusedQTy:
       return std::is_same<ElemTy, int8_t>::value;
+    case ElemKind::BoolTy:
+      return std::is_same<ElemTy, bool>::value;
     }
     GLOW_UNREACHABLE("Invalid type.");
   }
@@ -478,6 +481,8 @@ struct Type final {
       return sizeof(int64_t);
     case ElemKind::Int8FusedQTy:
       return sizeof(int8_t);
+    case ElemKind::BoolTy:
+      return sizeof(bool);
     }
     GLOW_UNREACHABLE("Invalid type.");
   }
@@ -490,7 +495,8 @@ struct Type final {
   /// \return the textual name of the element \p Ty.
   static llvm::StringRef getElementName(ElemKind Ty) {
     static const char *names[] = {
-        "float", "float16", "i8", "i16", "i32", "index32", "index64", "i8fused",
+        "float",   "float16", "i8",      "i16",  "i32",
+        "index32", "index64", "i8fused", "bool",
     };
     return names[(int)Ty];
   }

--- a/lib/Backends/CPU/LLVMIRGen.cpp
+++ b/lib/Backends/CPU/LLVMIRGen.cpp
@@ -239,6 +239,10 @@ llvm::Type *LLVMIRGen::getElementType(llvm::IRBuilder<> &builder,
     return builder.getInt32Ty();
   case ElemKind::Int8FusedQTy:
     return builder.getInt8Ty();
+  case ElemKind::BoolTy:
+    static_assert(sizeof(bool) == sizeof(int8_t),
+                  "Bool is expected to be the same size as int8.");
+    return builder.getInt8Ty();
   }
   return nullptr;
 }
@@ -327,6 +331,9 @@ llvm::Value *LLVMIRGen::emitValueAddress(llvm::IRBuilder<> &builder,
     T = llvm::Type::getInt32PtrTy(ctx_);
     break;
   case ElemKind::Int8FusedQTy:
+    T = llvm::Type::getInt8PtrTy(ctx_);
+    break;
+  case ElemKind::BoolTy:
     T = llvm::Type::getInt8PtrTy(ctx_);
     break;
   default:
@@ -475,6 +482,8 @@ llvm::Value *LLVMIRGen::emitConst(llvm::IRBuilder<> &builder, float val,
   case ElemKind::Int32ITy:
     return builder.getInt32(static_cast<int32_t>(val));
   case ElemKind::Int8FusedQTy:
+    return builder.getInt8(static_cast<int8_t>(val));
+  case ElemKind::BoolTy:
     return builder.getInt8(static_cast<int8_t>(val));
   }
   llvm_unreachable("Unknown element type");

--- a/lib/Base/Tensor.cpp
+++ b/lib/Base/Tensor.cpp
@@ -285,6 +285,8 @@ void glow::dumpAsciiImpl(const Tensor *T, llvm::raw_ostream &os) {
     return dumpAsciiGenericImpl(T->getHandle<int64_t>(), os);
   case ElemKind::Int8FusedQTy:
     return dumpAsciiGenericImpl(T->getHandle<int8_t>(), os);
+  case ElemKind::BoolTy:
+    return dumpAsciiGenericImpl(T->getHandle<bool>(), os);
   }
 }
 
@@ -308,6 +310,8 @@ void glow::dumpImpl(const Tensor *T, llvm::raw_ostream &os) {
     return dumpGenericImpl(T->getHandle<int64_t>(), os);
   case ElemKind::Int8FusedQTy:
     return dumpGenericImpl(T->getHandle<int8_t>(), os);
+  case ElemKind::BoolTy:
+    return dumpGenericImpl(T->getHandle<bool>(), os);
   }
 }
 
@@ -375,6 +379,12 @@ void glow::genericTranspose(const Tensor *src, Tensor *dest,
   case ElemKind::Int8FusedQTy: {
     llvm_unreachable("Transposing Int8FusedQTy is unsupported.");
   }
+  case ElemKind::BoolTy: {
+    auto srcH = src->getHandle<bool>();
+    auto destH = dest->getHandle<bool>();
+    transposeSelectImpl(srcH, destH, shuffle);
+    return;
+  }
   }
 }
 
@@ -433,6 +443,10 @@ void Tensor::init(InitKind init, float val, PseudoRNG &PRNG) {
       }
       break;
     }
+    case ElemKind::BoolTy: {
+      getHandle<bool>().clear(val);
+      break;
+    }
     }
     break;
   }
@@ -470,6 +484,9 @@ void Tensor::init(InitKind init, float val, PseudoRNG &PRNG) {
     case ElemKind::Int8FusedQTy: {
       getHandle<int8_t>().initXavier(val, PRNG);
       break;
+    }
+    case ElemKind::BoolTy: {
+      llvm_unreachable("Undefined to Xavier-initialize Bool Tensor.");
     }
     }
     break;

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1150,42 +1150,22 @@ ARITHMETIC_FUN_DEF(Min);
 ARITHMETIC_FUN_DEF(Pow);
 #undef ARITHMETIC_FUN_DEF
 
-/// This helper function is used only by the functions creating boolean
-/// operations like createCmpEQ and createCmpLTE to compute their output
-/// types. The output type is computed based on the type \p T of the operand
-/// of the logical operation. In case of a quantized type we provide concrete
-/// scale and offset for the type as we know that the output of a boolean
-/// operation could be only 0 or 1.
-///
-/// \returns the output type for a boolean operation.
-static TypeRef getResultTypeOfBooleanOp(Module &M, TypeRef T) {
-  TypeRef OT;
-  if (T->isQuantizedType()) {
-    OT = M.uniqueType(T->getElementType(), T->dims(), 1.0, 0);
-  } else {
-    OT = M.uniqueType(*T);
-  }
-  return OT;
-}
-
-// For the quantized CmpLTE instruction, we require that the scale params be
-// (1.0, 0), so that the actual value and comparison value match.
 CmpLTENode *Function::createCmpLTE(llvm::StringRef name, NodeValue LHS,
                                    NodeValue RHS) {
   assert(LHS.dims() == RHS.dims() && "Invalid operand shapes");
-  TypeRef OT = getResultTypeOfBooleanOp(*getParent(), LHS.getType());
+  TypeRef OT = getParent()->uniqueType(ElemKind::BoolTy, LHS.dims());
   return addNode(new CmpLTENode(name, OT, LHS, RHS));
 }
 
 CmpEQNode *Function::createCmpEQ(llvm::StringRef name, NodeValue LHS,
                                  NodeValue RHS) {
   assert(LHS.dims() == RHS.dims() && "Invalid operand shapes");
-  TypeRef OT = getResultTypeOfBooleanOp(*getParent(), LHS.getType());
+  TypeRef OT = getParent()->uniqueType(ElemKind::BoolTy, LHS.dims());
   return addNode(new CmpEQNode(name, OT, LHS, RHS));
 }
 
 IsNaNNode *Function::createIsNaN(llvm::StringRef name, NodeValue input) {
-  TypeRef OT = getResultTypeOfBooleanOp(*getParent(), input.getType());
+  TypeRef OT = getParent()->uniqueType(ElemKind::BoolTy, input.dims());
   return addNode(new IsNaNNode(name, OT, input));
 }
 

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -207,21 +207,6 @@ protected:
   CASE_SINGLE_MATCHING_INOUT_TYPE(MaxPool, Input, Result)
   // clang-format on
 
-  /// All CmpNode IR Constraint cases below require that the output has scale
-  /// 1.0, offset 0.
-  static constexpr unsigned CmpNodeIRConstraintResultIdx = 0;
-#define CASE_CMP_NODE(NODE_NAME_)                                              \
-  static_assert(NODE_NAME_##Node::ResultIdx == CmpNodeIRConstraintResultIdx,   \
-                #NODE_NAME_ "Node format is unexpected.");                     \
-  case Kinded::Kind::NODE_NAME_##NodeKind
-
-  // clang-format off
-#define casesForCmpNodes                                                       \
-  CASE_CMP_NODE(CmpLTE):                                                       \
-  CASE_CMP_NODE(CmpEQ):                                                        \
-  CASE_CMP_NODE(IsNaN)
-  // clang-format on
-
   /// \see FunctionConverter::morphNode.
   /// This method does the final adjustment to the output types
   /// when the profile and the IR constraints do not agree.
@@ -279,13 +264,6 @@ protected:
       assert(!lastMorphedNodeWithTypeChanges &&
              "Missed one node to rescale in postprocessing");
       lastMorphedNodeWithTypeChanges = &node;
-      return node;
-    }
-    casesForCmpNodes : {
-      TypeRef OT =
-          mod_.uniqueType(quantizationPrecision_,
-                          node.dims(CmpNodeIRConstraintResultIdx), 1.0, 0);
-      node.setType(CmpNodeIRConstraintResultIdx, OT);
       return node;
     }
     default:

--- a/tests/unittests/GraphTest.cpp
+++ b/tests/unittests/GraphTest.cpp
@@ -807,14 +807,9 @@ TEST(Graph, cmpOutputTypes) {
   // Create cmp nodes using quantized inputs.
   auto *cmpNode1 = F->createCmpEQ("cmpeq", qv1, qv2);
   auto *cmpNode2 = F->createCmpLTE("cmplte", qv1, qv2);
-  // Check that the output type of cmp nodes is quantized, has scale 1.0 and
-  // offset 0.
-  EXPECT_TRUE(cmpNode1->getResult().getType()->isQuantizedType());
-  EXPECT_EQ(cmpNode1->getResult().getType()->getScale(), 1.0);
-  EXPECT_EQ(cmpNode1->getResult().getType()->getOffset(), 0);
-  EXPECT_TRUE(cmpNode2->getResult().getType()->isQuantizedType());
-  EXPECT_EQ(cmpNode2->getResult().getType()->getScale(), 1.0);
-  EXPECT_EQ(cmpNode2->getResult().getType()->getOffset(), 0);
+  // Check that the output type of cmp nodes is BoolKind.
+  EXPECT_TRUE(cmpNode1->getResult().getElementType() == ElemKind::BoolTy);
+  EXPECT_TRUE(cmpNode2->getResult().getElementType() == ElemKind::BoolTy);
 
   // Define a non-quantized type.
   auto nqType3 = F->getParent()->uniqueType(ElemKind::FloatTy, {1, 3});
@@ -824,12 +819,9 @@ TEST(Graph, cmpOutputTypes) {
   // Create cmp nodes using non-quantized inputs.
   auto *cmpNode3 = F->createCmpEQ("cmpeq", nqv3, nqv4);
   auto *cmpNode4 = F->createCmpLTE("cmplte", nqv3, nqv4);
-  // Check that output of cmp nodes is a non-quantized type matching the type of
-  // inputs.
-  EXPECT_FALSE(cmpNode3->getResult().getType()->isQuantizedType());
-  EXPECT_EQ(cmpNode3->getResult().getType(), nqv3->getType());
-  EXPECT_FALSE(cmpNode4->getResult().getType()->isQuantizedType());
-  EXPECT_EQ(cmpNode4->getResult().getType(), nqv3->getType());
+  // Check that the output type of cmp nodes is BoolKind.
+  EXPECT_TRUE(cmpNode3->getResult().getElementType() == ElemKind::BoolTy);
+  EXPECT_TRUE(cmpNode4->getResult().getElementType() == ElemKind::BoolTy);
 }
 
 /// Check that the users of value are equal to expectedUsers.

--- a/tests/unittests/IROptTest.cpp
+++ b/tests/unittests/IROptTest.cpp
@@ -49,11 +49,13 @@ TEST(Optimizer, dseBasic) {
                                     WeightVar::MutabilityKind::Constant);
   auto *input2 = bb.createWeightVar(glow::ElemKind::FloatTy, {1}, "input2",
                                     WeightVar::MutabilityKind::Constant);
+  auto *input3 = bb.createWeightVar(glow::ElemKind::BoolTy, {1}, "input3",
+                                    WeightVar::MutabilityKind::Constant);
   auto *output = bb.createWeightVar(glow::ElemKind::FloatTy, {1}, "output",
                                     WeightVar::MutabilityKind::Mutable);
 
   bb.createElementAddInst("elem_add1", output, input1, input1);
-  bb.createElementSelectInst("select", output, input1, output, input2);
+  bb.createElementSelectInst("select", output, input3, output, input2);
   bb.createElementAddInst("elem_add2", output, input2, input2);
 
   optimize(M, MockBackend().shouldShareBuffers());

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -208,7 +208,7 @@ TEST_P(InterpAndCPU, CmpEQ) {
 
   EE_.run(ctx_);
 
-  auto saveH = saveTensor->getHandle<int64_t>();
+  auto saveH = saveTensor->getHandle<bool>();
   for (size_t i = 0; i < 7; ++i) {
     EXPECT_FALSE(saveH.at({0, i}));
   }
@@ -4517,8 +4517,8 @@ TEST_P(Operator, ReshapeInt) {
 
 /// Verify that the Select operator works correctly.
 TEST_P(Operator, Select) {
-  auto *A = mod_.createPlaceholder(ElemKind::FloatTy, {5}, "A", false);
-  ctx_.allocate(A)->getHandle() = {0.0, 1.0, 1.0, 0.0, 0.0};
+  auto *A = mod_.createPlaceholder(ElemKind::BoolTy, {5}, "A", false);
+  ctx_.allocate(A)->getHandle<bool>() = {false, true, true, false, false};
 
   auto SNTy = mod_.uniqueType(ElemKind::FloatTy, {5});
   SplatNode *SN10 = F_->createSplat("zero", SNTy, 10.0);

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -4539,6 +4539,28 @@ TEST_P(Operator, Select) {
   EXPECT_EQ(resH.at({4}), 20.0);
 }
 
+/// Verify that the CmpLTE operator works correctly.
+TEST_P(Operator, CmpLTE) {
+  Constant *A = mod_.createConstant(ElemKind::FloatTy, {5}, "A");
+  Constant *B = mod_.createConstant(ElemKind::FloatTy, {5}, "B");
+  A->getPayload().getHandle<float>() = {0.0, 1.0, 2.0, 3.0, 4.0};
+  B->getPayload().getHandle<float>() = {0.0, 1.1, 1.5, 10.1, -1.0};
+
+  auto *CMPLTE = F_->createCmpLTE("select", A, B);
+  auto *result = F_->createSave("saveCMPLTE", CMPLTE);
+  Tensor *resultT = ctx_.allocate(result->getPlaceholder());
+
+  EE_.compile(CompilationMode::Infer, F_);
+  EE_.run(ctx_);
+
+  auto resH = resultT->getHandle<bool>();
+  EXPECT_TRUE(resH.at({0}));
+  EXPECT_TRUE(resH.at({1}));
+  EXPECT_FALSE(resH.at({2}));
+  EXPECT_TRUE(resH.at({3}));
+  EXPECT_FALSE(resH.at({4}));
+}
+
 /// Stack many slices/reshapes together. Some of these may be turned into tensor
 /// views stacked onto each other.
 TEST_P(Operator, sliceReshape) {

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -374,29 +374,28 @@ int main(int argc, char **argv) {
       .addOperand("Dest", OperandKind::Out)
       .addOperand("LHS", OperandKind::In)
       .addOperand("RHS", OperandKind::In)
-      .inplaceOperand({"Dest", "LHS", "RHS"})
       .dataParallel()
       .autoVerify(VerifyKind::SameShape, {"Dest", "LHS", "RHS"})
+      .autoVerify(VerifyKind::SameElementType, {"LHS", "RHS"})
+      .autoVerify(VerifyKind::SameElementType, {"Dest", "ElemKind::BoolTy"})
       .autoIRGen("CmpLTE");
 
   BB.newInstr("ElementCmpEQ")
       .addOperand("Dest", OperandKind::Out)
       .addOperand("LHS", OperandKind::In)
       .addOperand("RHS", OperandKind::In)
-      .inplaceOperand({"Dest", "LHS", "RHS"})
       .dataParallel()
-      .autoVerify(VerifyKind::SameShape, {"Dest", "LHS", "RHS"})
+      .autoVerify(VerifyKind::SameType, {"LHS", "RHS"})
+      .autoVerify(VerifyKind::SameShape, {"Dest", "LHS"})
+      .autoVerify(VerifyKind::SameElementType, {"Dest", "ElemKind::BoolTy"})
       .autoIRGen("CmpEQ");
 
   BB.newInstr("ElementIsNaN")
       .addOperand("Dest", OperandKind::Out)
       .addOperand("Src", OperandKind::In)
-      .inplaceOperand({
-          "Dest",
-          "Src",
-      })
       .dataParallel()
       .autoVerify(VerifyKind::SameShape, {"Dest", "Src"})
+      .autoVerify(VerifyKind::SameElementType, {"Dest", "ElemKind::BoolTy"})
       .autoIRGen("IsNaN");
 
   BB.newInstr("ElementPow")
@@ -426,7 +425,9 @@ int main(int argc, char **argv) {
       .addOperand("RHS", OperandKind::In)
       .inplaceOperand({"Dest", "LHS", "RHS", "Cond"})
       .dataParallel()
-      .autoVerify(VerifyKind::SameShape, {"Dest", "Cond", "LHS", "RHS"})
+      .autoVerify(VerifyKind::SameShape, {"Dest", "LHS", "RHS", "Cond"})
+      .autoVerify(VerifyKind::SameElementType, {"Dest", "LHS", "RHS"})
+      .autoVerify(VerifyKind::SameElementType, {"Cond", "ElemKind::BoolTy"})
       .autoIRGen("Select");
 
   BB.newInstr("Modulo")


### PR DESCRIPTION
*Description*: Add in a new `ElemKind::BoolTy`. This removes the hacky implementation we had before for which just used the same `ElemKind` for the bool result/input. Note that I went with `BoolTy` instead of `PredicateTy`, but I can switch it if preferred.

While this is implemented with `bool` in the Interpreter, I used `int8_t` in the CPU/OpenCL backends.

*Testing*: Updated all impacted tests, and added a simple test for testing CmpLTE by itself.

Closes https://github.com/pytorch/glow/issues/1581