### PR TITLE
Refactor LoweredNamesMap to LoweredInfoMap and correctly quantized BAs lowered from FCs

### DIFF
--- a/examples/fr2en.cpp
+++ b/examples/fr2en.cpp
@@ -153,7 +153,7 @@ struct Model {
 
       // Lower everything for profile and log lowered info in loweredMap_. Used
       // later when creating quantization infos.
-      ::lower(F_, *EE_.getBackend(), &loweredMap_);
+      ::lowerEverything(F_, &loweredMap_);
 
       // Instrument the graph to capture profiles for nodes' outputs.
       F_ = glow::profileQuantization(ctx, F_);
@@ -167,13 +167,13 @@ struct Model {
       glow::optimize(F_, CompilationMode::Infer);
 
       // Lower however the backend prefers.
-      ::lower(F_, *EE_.getBackend());
+      ::lower(F_, *EE_.getBackend(), &loweredMap_);
 
       auto quantizationInfos = deserializeFromYaml(loadProfileFileOpt);
 
       // Quantize the graph based on the captured profile.
-      auto *Q = glow::quantization::quantizeFunction(EE_, quantizationInfos,
-                                                     ElemKind::Int8QTy, F_);
+      auto *Q = glow::quantization::quantizeFunction(
+          EE_, quantizationInfos, ElemKind::Int8QTy, F_, loweredMap_);
 
       // Erase the original function so that the redundant variables that are
       // only referenced by the original function will be removed.

--- a/examples/fr2en.cpp
+++ b/examples/fr2en.cpp
@@ -131,7 +131,7 @@ struct Model {
   Placeholder *seqLength_;
   Placeholder *output_;
   Context ctx;
-  LoweredNamesMap loweredMap_;
+  LoweredInfoMap loweredMap_;
 
   void loadLanguages();
   void loadEncoder();

--- a/examples/fr2en.cpp
+++ b/examples/fr2en.cpp
@@ -153,7 +153,7 @@ struct Model {
 
       // Lower everything for profile and log lowered info in loweredMap_. Used
       // later when creating quantization infos.
-      ::lowerEverything(F_, &loweredMap_);
+      ::lower(F_, &loweredMap_);
 
       // Instrument the graph to capture profiles for nodes' outputs.
       F_ = glow::profileQuantization(ctx, F_);
@@ -167,7 +167,7 @@ struct Model {
       glow::optimize(F_, CompilationMode::Infer);
 
       // Lower however the backend prefers.
-      ::lower(F_, *EE_.getBackend(), &loweredMap_);
+      ::lower(F_, &loweredMap_, EE_.getBackend());
 
       auto quantizationInfos = deserializeFromYaml(loadProfileFileOpt);
 

--- a/include/glow/Optimizer/Optimizer.h
+++ b/include/glow/Optimizer/Optimizer.h
@@ -43,12 +43,18 @@ void optimize(Function *F, CompilationMode mode);
 
 /// Lower the high-level neural network nodes found in \p F into low-level
 /// linear algebra operators. \p B can prevent lowering of a node via \ref
-/// Backend::shouldLower(). If \p loweredMap is not a nullptr, then everything
-/// is lowered regardless of the preferences of \p B, and \p loweredMap will
-/// contain a mapping from output names of the nodes found and lowered in \p F
-/// to the output names of the nodes they were lowered from along with the
-/// NodeKind.
+/// Backend::shouldLower(). If \p loweredMap is not a nullptr, then \p
+/// loweredMap will contain a mapping from output names of the nodes found and
+/// lowered in \p F to the output names of the nodes they were lowered from
+/// along with the NodeKind.
 void lower(Function *F, const Backend &B, LoweredInfoMap *loweredMap = nullptr);
+
+/// Lower the high-level neural network nodes found in \p F into low-level
+/// linear algebra operators. All nodes are fully lowered. If \p loweredMap is
+/// not a nullptr, then \p loweredMap will contain a mapping from output names
+/// of the nodes found and lowered in \p F to the output names of the nodes they
+/// were lowered from along with the NodeKind.
+void lowerEverything(Function *F, LoweredInfoMap *loweredMap = nullptr);
 
 /// Dead code elimination.
 void DCE(Function *F);

--- a/include/glow/Optimizer/Optimizer.h
+++ b/include/glow/Optimizer/Optimizer.h
@@ -46,9 +46,9 @@ void optimize(Function *F, CompilationMode mode);
 /// Backend::shouldLower(). If \p loweredMap is not a nullptr, then everything
 /// is lowered regardless of the preferences of \p B, and \p loweredMap will
 /// contain a mapping from output names of the nodes found and lowered in \p F
-/// to the output names of the nodes they were lowered from from.
-void lower(Function *F, const Backend &B,
-           LoweredNamesMap *loweredMap = nullptr);
+/// to the output names of the nodes they were lowered from along with the
+/// NodeKind.
+void lower(Function *F, const Backend &B, LoweredInfoMap *loweredMap = nullptr);
 
 /// Dead code elimination.
 void DCE(Function *F);

--- a/include/glow/Optimizer/Optimizer.h
+++ b/include/glow/Optimizer/Optimizer.h
@@ -42,19 +42,13 @@ void optimize(IRFunction &M, bool shouldShareBuffers);
 void optimize(Function *F, CompilationMode mode);
 
 /// Lower the high-level neural network nodes found in \p F into low-level
-/// linear algebra operators. \p B can prevent lowering of a node via \ref
-/// Backend::shouldLower(). If \p loweredMap is not a nullptr, then \p
-/// loweredMap will contain a mapping from output names of the nodes found and
-/// lowered in \p F to the output names of the nodes they were lowered from
-/// along with the NodeKind.
-void lower(Function *F, const Backend &B, LoweredInfoMap *loweredMap = nullptr);
-
-/// Lower the high-level neural network nodes found in \p F into low-level
-/// linear algebra operators. All nodes are fully lowered. If \p loweredMap is
-/// not a nullptr, then \p loweredMap will contain a mapping from output names
-/// of the nodes found and lowered in \p F to the output names of the nodes they
-/// were lowered from along with the NodeKind.
-void lowerEverything(Function *F, LoweredInfoMap *loweredMap = nullptr);
+/// linear algebra operators. If \p B is not a nullptr then it can prevent
+/// lowering of a node via \ref Backend::shouldLower(); otherwise everything
+/// will be lowered. If \p loweredMap is not a nullptr, then \p loweredMap will
+/// contain a mapping from output names of the nodes found and lowered in \p F
+/// to the output names of the nodes they were lowered from along with the
+/// NodeKind.
+void lower(Function *F, LoweredInfoMap *loweredMap, const Backend *B = nullptr);
 
 /// Dead code elimination.
 void DCE(Function *F);

--- a/include/glow/Quantization/Quantization.h
+++ b/include/glow/Quantization/Quantization.h
@@ -102,13 +102,12 @@ std::vector<NodeQuantizationInfo> generateNodeQuantizationInfos(
 /// \p enableRowwise is true, during quantization, all quantized FullyConnected
 /// nodes will be converted to RowwiseQuantizedFullyConnected. \returns a new
 /// quantized function.
-Function *
-quantizeFunction(const ExecutionEngine &EE,
-                 llvm::ArrayRef<NodeQuantizationInfo> quantizationInfos,
-                 ElemKind quantizationPrecision, Function *F,
-                 llvm::StringRef newFuncName = "",
-                 const KindSet &doNotQuantizeKinds = {},
-                 bool enableRowwise = false);
+Function *quantizeFunction(
+    const ExecutionEngine &EE,
+    llvm::ArrayRef<NodeQuantizationInfo> quantizationInfos,
+    ElemKind quantizationPrecision, Function *F,
+    const LoweredInfoMap &loweredMap = {}, llvm::StringRef newFuncName = "",
+    const KindSet &doNotQuantizeKinds = {}, bool enableRowwise = false);
 
 } // namespace quantization
 } // namespace glow

--- a/include/glow/Quantization/Quantization.h
+++ b/include/glow/Quantization/Quantization.h
@@ -28,12 +28,6 @@ namespace glow {
 
 class ExecutionEngine;
 
-/// Used to keep track of the origin of lowered Nodes via output names as
-/// determined by NodeQuantizationInfo::generateNodeOutputName(). For example if
-/// some NodeValue X is lowered from some NodeValue Y, then the output name of X
-/// is a key which maps to a set of names which contains the output name of Y.
-using LoweredNamesMap = llvm::StringMap<std::set<std::string>>;
-
 /// Tensor quantization parameters for a given node.
 struct NodeQuantizationInfo {
   std::string nodeOutputName_;
@@ -56,6 +50,32 @@ struct NodeQuantizationInfo {
   }
 };
 
+/// Struct containing the output name string and node kind for use in the
+/// LoweredInfoMap for keeping track of lowered node info.
+struct NodeNameAndKind : public Named, public Kinded {
+public:
+  NodeNameAndKind(const NodeValue &NV)
+      : Named(NodeQuantizationInfo::generateNodeOutputName(
+            NV.getNode()->getName(), NV.getResNo())),
+        Kinded(NV.getNode()->getKind()) {}
+};
+
+/// Overload < operator for NodeNameAndKind to allow for usage with std::set.
+inline bool operator<(const NodeNameAndKind &x, const NodeNameAndKind &y) {
+  return x.getName() < y.getName();
+}
+
+/// Overload == operator for NodeNameAndKind to allow for usage with std::set.
+inline bool operator==(const NodeNameAndKind &x, const NodeNameAndKind &y) {
+  return x.getName() == y.getName();
+}
+
+/// Used to keep track of the origin of lowered Nodes via output names as
+/// determined by NodeQuantizationInfo::generateNodeOutputName(). For example if
+/// some NodeValue X is lowered from some NodeValue Y, then the output name of X
+/// is a key which maps to a set of names which contains the output name of Y.
+using LoweredInfoMap = llvm::StringMap<std::set<NodeNameAndKind>>;
+
 namespace quantization {
 
 /// Generate NodeQuantizationInfo for all required nodes from function \p F
@@ -66,7 +86,7 @@ namespace quantization {
 /// map is used to generate infos for the original unlowered NodeValues which no
 /// longer exist in \p F.
 std::vector<NodeQuantizationInfo> generateNodeQuantizationInfos(
-    Context &ctx, const Function *F, const LoweredNamesMap &loweredMap = {},
+    Context &ctx, const Function *F, const LoweredInfoMap &loweredMap = {},
     Schema schema = Schema::Asymmetric,
     ElemKind quantizationPrecision = ElemKind::Int8QTy);
 

--- a/lib/Backends/Backend.cpp
+++ b/lib/Backends/Backend.cpp
@@ -30,7 +30,7 @@ void Backend::optimizeFunction(CompilationMode mode, Function *F) {
   ::glow::optimize(F, mode);
 
   // Lower the graph into a sequence of low-level linear algebra operations.
-  ::glow::lower(F, *this);
+  ::glow::lower(F, /* loweredMap */ nullptr, this);
 
   // Optimize the graph again.
   ::glow::optimize(F, mode);

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -52,7 +52,7 @@ onnxStatus BackendId::checkGraphCompatibility(const void *onnxModel,
     return ONNXIFI_STATUS_INTERNAL_ERROR;
   }
 
-  glow::lower(function, *glowBackend_);
+  glow::lower(function, /* loweredMap */ nullptr, glowBackend_.get());
 
   const auto &nodes = function->getNodes();
 

--- a/lib/Optimizer/Lower.cpp
+++ b/lib/Optimizer/Lower.cpp
@@ -31,7 +31,7 @@ using llvm::dyn_cast;
 /// optionally maps from \p newNV to \p oldNV in \p loweredMap. This map can be
 /// used to determine the NodeOutputNames of NodeValues that were already
 /// created.
-static void replaceAllUsesOfWith(LoweredNamesMap *loweredMap, NodeValue oldNV,
+static void replaceAllUsesOfWith(LoweredInfoMap *loweredMap, NodeValue oldNV,
                                  NodeValue newNV) {
   oldNV.replaceAllUsesOfWith(newNV);
 
@@ -39,14 +39,12 @@ static void replaceAllUsesOfWith(LoweredNamesMap *loweredMap, NodeValue oldNV,
     return;
   }
 
-  std::string oldOutputName = NodeQuantizationInfo::generateNodeOutputName(
-      oldNV.getNode()->getName(), oldNV.getResNo());
   std::string newOutputName = NodeQuantizationInfo::generateNodeOutputName(
       newNV.getNode()->getName(), newNV.getResNo());
-  (*loweredMap)[newOutputName].insert(oldOutputName);
+  (*loweredMap)[newOutputName].insert(NodeNameAndKind(oldNV));
 }
 
-static void lowerAddGradNode(Function *F, LoweredNamesMap *loweredMap,
+static void lowerAddGradNode(Function *F, LoweredInfoMap *loweredMap,
                              const AddGradNode &node) {
   /// The chain rule for addition:
   /// delta(LHS) = dF/dLHS * delta(OUT) = 1 * delta(OUT)
@@ -56,7 +54,7 @@ static void lowerAddGradNode(Function *F, LoweredNamesMap *loweredMap,
   replaceAllUsesOfWith(loweredMap, node.getGradOfInputNamedRHS(), outG);
 }
 
-static void lowerMulGradNode(Function *F, LoweredNamesMap *loweredMap,
+static void lowerMulGradNode(Function *F, LoweredInfoMap *loweredMap,
                              const MulGradNode &node) {
   /// The chain rule for multiplication:
   /// delta(LHS) = dF/dLHS * delta(OUT) = RHS * delta(OUT)
@@ -71,7 +69,7 @@ static void lowerMulGradNode(Function *F, LoweredNamesMap *loweredMap,
   replaceAllUsesOfWith(loweredMap, node.getGradOfInputNamedRHS(), rhsResult);
 }
 
-static void lowerSubGradNode(Function *F, LoweredNamesMap *loweredMap,
+static void lowerSubGradNode(Function *F, LoweredInfoMap *loweredMap,
                              const SubGradNode &node) {
   /// The chain rule for subtraction:
   /// delta(LHS) = dF/dLHS * delta(OUT) = 1 * delta(OUT)
@@ -82,7 +80,7 @@ static void lowerSubGradNode(Function *F, LoweredNamesMap *loweredMap,
   replaceAllUsesOfWith(loweredMap, node.getGradOfInputNamedLHS(), outG);
   replaceAllUsesOfWith(loweredMap, node.getGradOfInputNamedRHS(), sub);
 }
-static void lowerDivGradNode(Function *F, LoweredNamesMap *loweredMap,
+static void lowerDivGradNode(Function *F, LoweredInfoMap *loweredMap,
                              const DivGradNode &node) {
   /// The chain rule for division:
   /// delta(LHS) = dF/dLHS * delta(OUT) = (1 / RHS) * delta(OUT)
@@ -104,13 +102,13 @@ static void lowerDivGradNode(Function *F, LoweredNamesMap *loweredMap,
   replaceAllUsesOfWith(loweredMap, node.getGradOfInputNamedRHS(), rhsResult);
 }
 
-static void lowerRegressionNode(LoweredNamesMap *loweredMap,
+static void lowerRegressionNode(LoweredInfoMap *loweredMap,
                                 const RegressionNode &node) {
   auto input = node.getInput();
   replaceAllUsesOfWith(loweredMap, node.getResult(), input);
 }
 
-static void lowerRegressionGradNode(Function *F, LoweredNamesMap *loweredMap,
+static void lowerRegressionGradNode(Function *F, LoweredInfoMap *loweredMap,
                                     const RegressionGradNode &node) {
   auto outG = node.getInput();
 
@@ -121,7 +119,7 @@ static void lowerRegressionGradNode(Function *F, LoweredNamesMap *loweredMap,
   replaceAllUsesOfWith(loweredMap, node.getGradOfInputNamedExpected(), expG);
 }
 
-static void lowerFullyConnectedNode(Function *F, LoweredNamesMap *loweredMap,
+static void lowerFullyConnectedNode(Function *F, LoweredInfoMap *loweredMap,
                                     const FullyConnectedNode &FC) {
   auto *X = F->createFlatten("fc.1X", FC.getInput(), 1);
 
@@ -140,8 +138,7 @@ static void lowerFullyConnectedNode(Function *F, LoweredNamesMap *loweredMap,
   }
 }
 
-static void lowerFullyConnectedGradNode(Function *F,
-                                        LoweredNamesMap *loweredMap,
+static void lowerFullyConnectedGradNode(Function *F, LoweredInfoMap *loweredMap,
                                         const FullyConnectedGradNode &FCG) {
   // Follow the lowering from here:
   // https://github.com/huyouare/CS231n/blob/master/assignment2/cs231n/layers.py#L53
@@ -164,7 +161,7 @@ static void lowerFullyConnectedGradNode(Function *F,
   replaceAllUsesOfWith(loweredMap, FCG.getGradOfInputNamedBias(), db);
 }
 
-static void lowerReluGradNode(Function *F, LoweredNamesMap *loweredMap,
+static void lowerReluGradNode(Function *F, LoweredInfoMap *loweredMap,
                               const ReluGradNode &RG) {
   // ReluGrad: if the input value is greater than zero then let the gradient
   // pass.
@@ -176,7 +173,7 @@ static void lowerReluGradNode(Function *F, LoweredNamesMap *loweredMap,
   replaceAllUsesOfWith(loweredMap, RG.getGradOfInputNamedInput(), res);
 }
 
-static void lowerTanhGradNode(Function *F, LoweredNamesMap *loweredMap,
+static void lowerTanhGradNode(Function *F, LoweredInfoMap *loweredMap,
                               const TanhGradNode &THG) {
   // Tanh grad is calculated as:
   // inG = (1 - outW * outW) * outG
@@ -194,7 +191,7 @@ static void lowerTanhGradNode(Function *F, LoweredNamesMap *loweredMap,
   replaceAllUsesOfWith(loweredMap, THG.getGradOfInputNamedInput(), grad);
 }
 
-static void lowerSigmoidGradNode(Function *F, LoweredNamesMap *loweredMap,
+static void lowerSigmoidGradNode(Function *F, LoweredInfoMap *loweredMap,
                                  const SigmoidGradNode &THG) {
   // Sigmoid grad is calculated as:
   // inG = outW * (1 - outW) * outG;
@@ -213,7 +210,7 @@ static void lowerSigmoidGradNode(Function *F, LoweredNamesMap *loweredMap,
   replaceAllUsesOfWith(loweredMap, THG.getGradOfInputNamedInput(), grad);
 }
 
-static void lowerReluNode(Function *F, LoweredNamesMap *loweredMap,
+static void lowerReluNode(Function *F, LoweredInfoMap *loweredMap,
                           const ReluNode &R) {
   // Relu is a max between zero and the input value.
   SplatNode *zero = F->createSplat("zero", R.getResult().getType(), 0.0);
@@ -222,7 +219,7 @@ static void lowerReluNode(Function *F, LoweredNamesMap *loweredMap,
   replaceAllUsesOfWith(loweredMap, R.getResult(), relu);
 }
 
-static void lowerPadNode(Function *F, LoweredNamesMap *loweredMap,
+static void lowerPadNode(Function *F, LoweredInfoMap *loweredMap,
                          const PadNode &P) {
   auto *outputType = P.getResult().getType();
   auto dims = outputType->dims();
@@ -252,7 +249,7 @@ static void lowerPadNode(Function *F, LoweredNamesMap *loweredMap,
 
 /// Lower a quantized Log by creating an IntLookupTable with a new mapping given
 /// the input and output quantization parameters.
-static void lowerQuantizedLogNode(Function *F, LoweredNamesMap *loweredMap,
+static void lowerQuantizedLogNode(Function *F, LoweredInfoMap *loweredMap,
                                   const LogNode *LN) {
   TypeRef outTy = LN->getResult().getType();
   TypeRef inTy = LN->getInput().getType();
@@ -280,7 +277,7 @@ static void lowerQuantizedLogNode(Function *F, LoweredNamesMap *loweredMap,
   replaceAllUsesOfWith(loweredMap, LN->getResult(), ILT);
 }
 
-static void lowerQuantizedTanhNode(Function *F, LoweredNamesMap *loweredMap,
+static void lowerQuantizedTanhNode(Function *F, LoweredInfoMap *loweredMap,
                                    const TanhNode *TN) {
   // Quantized tanh operator expects input to be in a certain floating point
   // range. This operator works based on the precomputed table and has to
@@ -314,7 +311,7 @@ static void lowerQuantizedTanhNode(Function *F, LoweredNamesMap *loweredMap,
   replaceAllUsesOfWith(loweredMap, TN->getResult(), rescaleOutputNode);
 }
 
-static void lowerQuantizedSigmoidNode(Function *F, LoweredNamesMap *loweredMap,
+static void lowerQuantizedSigmoidNode(Function *F, LoweredInfoMap *loweredMap,
                                       const SigmoidNode *SN) {
   // Quantized sigmoid operator expects input to be in a certain floating
   // point range. This operator works based on the precomputed table and has
@@ -348,7 +345,7 @@ static void lowerQuantizedSigmoidNode(Function *F, LoweredNamesMap *loweredMap,
   replaceAllUsesOfWith(loweredMap, SN->getResult(), rescaleOutputNode);
 }
 
-static void lowerSGDNode(Function *F, LoweredNamesMap *loweredMap,
+static void lowerSGDNode(Function *F, LoweredInfoMap *loweredMap,
                          const SGDNode &SGD) {
   NodeValue W = SGD.getWeight();
   NodeValue G = SGD.getGradient();
@@ -415,8 +412,7 @@ static void lowerSGDNode(Function *F, LoweredNamesMap *loweredMap,
   replaceAllUsesOfWith(loweredMap, SGD.getUpdatedWeight(), newW);
 }
 
-static void lowerBatchNormalizationNode(Function *F,
-                                        LoweredNamesMap *loweredMap,
+static void lowerBatchNormalizationNode(Function *F, LoweredInfoMap *loweredMap,
                                         const BatchNormalizationNode &BN) {
   auto in = BN.getInput();
   auto out = BN.getResult();
@@ -461,7 +457,7 @@ static void lowerBatchNormalizationNode(Function *F,
 }
 
 static void lowerMeanVarNormalizationNode(Function *F,
-                                          LoweredNamesMap *loweredMap,
+                                          LoweredInfoMap *loweredMap,
                                           const MeanVarNormalizationNode &MVN) {
   auto in = MVN.getInput();
 
@@ -540,7 +536,7 @@ static void lowerMeanVarNormalizationNode(Function *F,
 }
 
 static void lowerBatchNormalizationGradNode(Function *F,
-                                            LoweredNamesMap *loweredMap,
+                                            LoweredInfoMap *loweredMap,
                                             BatchNormalizationGradNode &BNG) {
   auto inW = BNG.getInput();
   auto outG = BNG.getGradOfOriginalOutputNamedResult();
@@ -637,7 +633,7 @@ static void lowerBatchNormalizationGradNode(Function *F,
   replaceAllUsesOfWith(loweredMap, BNG.getGradOfInputNamedVar(), zeroSplat);
 }
 
-static void lowerGroupConvolutionNode(Function *F, LoweredNamesMap *loweredMap,
+static void lowerGroupConvolutionNode(Function *F, LoweredInfoMap *loweredMap,
                                       const ConvolutionNode &BNG) {
   // When Group parameter is more than 1, ConvolutionNode can be represented as
   // a Concatenation of smaller dimension Convolutions. Input channels will be
@@ -681,7 +677,7 @@ static void lowerGroupConvolutionNode(Function *F, LoweredNamesMap *loweredMap,
 }
 
 static void lowerSigmoidCrossEntropyWithLogitsNode(
-    Function *F, LoweredNamesMap *loweredMap,
+    Function *F, LoweredInfoMap *loweredMap,
     const SigmoidCrossEntropyWithLogitsNode &SCEL) {
   // Following Caffe2 implementation closely to lower this Node.
   // https://github.com/caffe2/caffe2/blob/master/caffe2/operators/cross_entropy_op.cc
@@ -722,7 +718,7 @@ static void lowerSigmoidCrossEntropyWithLogitsNode(
 }
 
 /// Lower Tile nodes to InsertTensor nodes with correct axis and count.
-static void lowerTileNode(Function *F, LoweredNamesMap *loweredMap,
+static void lowerTileNode(Function *F, LoweredInfoMap *loweredMap,
                           const TileNode &TN) {
   auto input = TN.getInput();
 
@@ -736,7 +732,7 @@ static void lowerTileNode(Function *F, LoweredNamesMap *loweredMap,
   replaceAllUsesOfWith(loweredMap, TN.getResult(), IN);
 }
 
-void glow::lower(Function *F, const Backend &B, LoweredNamesMap *loweredMap) {
+void glow::lower(Function *F, const Backend &B, LoweredInfoMap *loweredMap) {
   auto &nodes = F->getNodes();
 
   // If loweredMap is not a nullptr then we should lower everything. loweredMap

--- a/lib/Optimizer/Lower.cpp
+++ b/lib/Optimizer/Lower.cpp
@@ -791,8 +791,15 @@ static void lowerNode(Function *F, Node *node, LoweredInfoMap *loweredMap) {
   }
 }
 
-/// Cleanup \p F after lowering.
-static void cleanup(Function *F) {
+void glow::lower(Function *F, LoweredInfoMap *loweredMap, const Backend *B) {
+  auto &nodes = F->getNodes();
+  for (auto &N : nodes) {
+    if (B && !B->shouldLower(&N)) {
+      continue;
+    }
+    lowerNode(F, &N, loweredMap);
+  }
+
   for (auto it = F->getNodes().begin(), e = F->getNodes().end(); it != e;) {
     auto cur = &*(it++);
     if (dyn_cast<SGDNode>(cur)) {
@@ -802,23 +809,4 @@ static void cleanup(Function *F) {
 
   // Remove nodes that were lowered.
   DCE(F);
-}
-
-void glow::lowerEverything(Function *F, LoweredInfoMap *loweredMap) {
-  auto &nodes = F->getNodes();
-  for (auto &N : nodes) {
-    lowerNode(F, &N, loweredMap);
-  }
-  cleanup(F);
-}
-
-void glow::lower(Function *F, const Backend &B, LoweredInfoMap *loweredMap) {
-  auto &nodes = F->getNodes();
-  for (auto &N : nodes) {
-    if (!B.shouldLower(&N)) {
-      continue;
-    }
-    lowerNode(F, &N, loweredMap);
-  }
-  cleanup(F);
 }

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -491,7 +491,7 @@ namespace quantization {
 /// quantizationInfos along with \p TQP.
 static void
 findAndInsertLoweredInfos(llvm::StringRef currName,
-                          const LoweredNamesMap &loweredMap,
+                          const LoweredInfoMap &loweredMap,
                           std::vector<NodeQuantizationInfo> &quantizationInfos,
                           const TensorQuantizationParams &TQP) {
   auto currSetIt = loweredMap.find(currName);
@@ -507,7 +507,7 @@ findAndInsertLoweredInfos(llvm::StringRef currName,
   // and then recursively find and insert other names in case currOrigName was
   // also lowered from a previous node.
   for (auto i = currSet.begin(), e = currSet.end(); i != e; ++i) {
-    llvm::StringRef currOrigName = *i;
+    llvm::StringRef currOrigName = i->getName();
     quantizationInfos.emplace_back(currOrigName, TQP);
     findAndInsertLoweredInfos(currOrigName, loweredMap, quantizationInfos, TQP);
   }
@@ -515,7 +515,7 @@ findAndInsertLoweredInfos(llvm::StringRef currName,
 
 std::vector<NodeQuantizationInfo>
 generateNodeQuantizationInfos(Context &ctx, const Function *F,
-                              const LoweredNamesMap &loweredMap, Schema schema,
+                              const LoweredInfoMap &loweredMap, Schema schema,
                               ElemKind quantizationPrecision) {
   std::vector<NodeQuantizationInfo> quantizationInfos;
 

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -556,8 +556,8 @@ Function *
 quantizeFunction(const ExecutionEngine &EE,
                  llvm::ArrayRef<NodeQuantizationInfo> quantizationInfos,
                  ElemKind quantizationPrecision, Function *F,
-                 llvm::StringRef newFuncName, const KindSet &doNotQuantizeKinds,
-                 bool enableRowwise) {
+                 const LoweredInfoMap &loweredMap, llvm::StringRef newFuncName,
+                 const KindSet &doNotQuantizeKinds, bool enableRowwise) {
   assert((quantizationPrecision == ElemKind::Int8QTy ||
           quantizationPrecision == ElemKind::Int16QTy) &&
          "Only Int8 and Int16 quantization supported");

--- a/tests/unittests/BackendCorrectnessTest.cpp
+++ b/tests/unittests/BackendCorrectnessTest.cpp
@@ -47,7 +47,7 @@ namespace {
 static std::vector<NodeQuantizationInfo>
 profileAndGetNodeQuantizationInfo(Context &ctx, ExecutionEngine &EE,
                                   Function *origF,
-                                  const LoweredNamesMap &loweredMap) {
+                                  const LoweredInfoMap &loweredMap) {
   Function *profileF = glow::profileQuantization(ctx, origF);
   EE.compile(CompilationMode::Infer, profileF);
 
@@ -88,7 +88,7 @@ compareAgainstInterpreter(BackendKind backendKind,
     // Lower everything for profiling in a cloned PF, keeping track of lowered
     // info in loweredMap, which is then used when generating QI.
     Function *PF = IF->clone("profile");
-    LoweredNamesMap loweredMap;
+    LoweredInfoMap loweredMap;
     lower(PF, *IEE.getBackend(), &loweredMap);
     std::vector<NodeQuantizationInfo> QI =
         profileAndGetNodeQuantizationInfo(ICtx, IEE, PF, loweredMap);

--- a/tests/unittests/BackendCorrectnessTest.cpp
+++ b/tests/unittests/BackendCorrectnessTest.cpp
@@ -89,7 +89,7 @@ compareAgainstInterpreter(BackendKind backendKind,
     // info in loweredMap, which is then used when generating QI.
     Function *PF = IF->clone("profile");
     LoweredInfoMap loweredMap;
-    lower(PF, *IEE.getBackend(), &loweredMap);
+    lowerEverything(PF, &loweredMap);
     std::vector<NodeQuantizationInfo> QI =
         profileAndGetNodeQuantizationInfo(ICtx, IEE, PF, loweredMap);
 
@@ -97,8 +97,10 @@ compareAgainstInterpreter(BackendKind backendKind,
     // functions of the Interpreter and Backend.
     lower(IF, *IEE.getBackend());
     lower(BF, *BEE.getBackend());
-    IF = quantization::quantizeFunction(IEE, QI, ElemKind::Int8QTy, IF);
-    BF = quantization::quantizeFunction(BEE, QI, ElemKind::Int8QTy, BF);
+    IF = quantization::quantizeFunction(IEE, QI, ElemKind::Int8QTy, IF,
+                                        loweredMap);
+    BF = quantization::quantizeFunction(BEE, QI, ElemKind::Int8QTy, BF,
+                                        loweredMap);
   }
 
   IEE.compile(CompilationMode::Infer, IF);

--- a/tests/unittests/GraphTest.cpp
+++ b/tests/unittests/GraphTest.cpp
@@ -87,9 +87,10 @@ TEST(Graph, simpleTestConv) {
   F->createSave("Save", K);
   F->dump();
   F->dumpDAG();
-  lower(F, MockBackend());
+  auto backend = MockBackend();
+  lower(F, /* loweredMap */ nullptr, &backend);
   ::optimize(F, CompilationMode::Train);
-  M.generateIR(MockBackend());
+  M.generateIR(backend);
   M.dump();
   EXPECT_GT(M.getInstrs().size(), 0);
 }
@@ -109,9 +110,10 @@ TEST(Graph, simpleTestConv3D) {
   F->createSave("Save", K);
   F->dump();
   F->dumpDAG();
-  lower(F, MockBackend());
+  auto backend = MockBackend();
+  lower(F, /* loweredMap */ nullptr, &backend);
   ::optimize(F, CompilationMode::Train);
-  M.generateIR(MockBackend());
+  M.generateIR(backend);
   M.dump();
   EXPECT_GT(M.getInstrs().size(), 0);
 }
@@ -132,7 +134,8 @@ TEST(Graph, simpleTestConvCustomLower) {
   F->createSave("Save", K);
   F->dump();
   F->dumpDAG();
-  lower(F, MockBackendCustomIRGen());
+  auto backend = MockBackendCustomIRGen();
+  lower(F, /* loweredMap */ nullptr, &backend);
   ::optimize(F, CompilationMode::Train);
   M.generateIR(MockBackendCustomIRGen());
   M.dump();
@@ -162,11 +165,12 @@ TEST(Graph, float16Conv) {
   EXPECT_EQ(conv->getFilter().getElementType(), ElemKind::Float16Ty);
   EXPECT_EQ(conv->getBias().getElementType(), ElemKind::Float16Ty);
 
-  lower(F, MockBackend());
+  auto backend = MockBackend();
+  lower(F, /* loweredMap */ nullptr, &backend);
 
   IRFunction M(F);
 
-  M.generateIR(MockBackend());
+  M.generateIR(backend);
   EXPECT_GT(M.getInstrs().size(), 0);
   auto convIt = std::find_if(M.getInstrs().begin(), M.getInstrs().end(),
                              [](const Instruction &inst) -> bool {
@@ -196,7 +200,8 @@ TEST(Graph, float16BatchNorm) {
   EXPECT_EQ(BN->getMean().getElementType(), ElemKind::Float16Ty);
   EXPECT_EQ(BN->getVar().getElementType(), ElemKind::Float16Ty);
 
-  lower(F, MockBackend());
+  auto backend = MockBackend();
+  lower(F, /* loweredMap */ nullptr, &backend);
 
   EXPECT_TRUE(std::all_of(
       F->getNodes().begin(), F->getNodes().end(), [](const Node &node) -> bool {
@@ -333,9 +338,10 @@ TEST(Graph, simpleTestFC) {
   F->createSave("Save", O);
   F->dump();
   F->dumpDAG();
-  lower(F, MockBackend());
+  auto backend = MockBackend();
+  lower(F, /* loweredMap */ nullptr, &backend);
   ::optimize(F, CompilationMode::Train);
-  M.generateIR(MockBackend());
+  M.generateIR(backend);
   M.dump();
   EXPECT_GT(M.getInstrs().size(), 0);
 }
@@ -368,7 +374,8 @@ TEST(Graph, QuantizationProfileNodes) {
   // Simulate actual usage.
   ::optimize(F, CompilationMode::Infer);
   F = ::glow::profileQuantization(ctx, F);
-  lower(F, MockBackend());
+  auto backend = MockBackend();
+  lower(F, /* loweredMap */ nullptr, &backend);
   ::optimize(F, CompilationMode::Infer);
 
   size_t numberOfProfileNodes =
@@ -623,7 +630,7 @@ unsigned getConvNodeSize(BackendKind kind) {
   F->createSave("save", CN);
 
   std::unique_ptr<Backend> backend(createBackend(kind));
-  lower(F, *backend);
+  lower(F, /* loweredMap */ nullptr, backend.get());
 
   unsigned count = 0;
   for (auto &n : F->getNodes()) {

--- a/tests/unittests/MLTest.cpp
+++ b/tests/unittests/MLTest.cpp
@@ -1054,7 +1054,7 @@ TEST_P(InterpreterAndCPU, convNetForImageRecognition) {
   // Lower everything before profiling. The loweredMap will be used when
   // generating the profile to ensure all lowered components' profiles are
   // contained.
-  LoweredNamesMap loweredMap;
+  LoweredInfoMap loweredMap;
   Function *PF = F->clone("profile");
   lower(PF, *EE.getBackend(), &loweredMap);
 
@@ -1163,7 +1163,7 @@ TEST_P(InterpreterAndCPU, testFindPixelRegression) {
   // Lower everything before profiling. The loweredMap will be used when
   // generating the profile to ensure all lowered components' profiles are
   // contained.
-  LoweredNamesMap loweredMap;
+  LoweredInfoMap loweredMap;
   Function *PF = F->clone("profile");
   lower(PF, *EE.getBackend(), &loweredMap);
 

--- a/tests/unittests/QuantizationTest.cpp
+++ b/tests/unittests/QuantizationTest.cpp
@@ -409,7 +409,7 @@ void testQuantizationEnd2End(ExecutionEngine &profileEE,
   Function *F2 = F1->clone("main2");
   SaveNode *result1 = cast<SaveNode>(F1->getNodeByName("save"));
 
-  LoweredNamesMap loweredMap;
+  LoweredInfoMap loweredMap;
   lower(F1, *profileEE.getBackend(), &loweredMap);
   F1 = glow::profileQuantization(ctx, F1);
   profileEE.compile(CompilationMode::Infer, F1);
@@ -1513,7 +1513,7 @@ static void testProfileQuantizationOfFC(bool expectLoweredFC) {
 
   // Lower everything and keep track of the lowered components source nodes via
   // the loweredMap.
-  LoweredNamesMap loweredMap;
+  LoweredInfoMap loweredMap;
   lower(profileF, *profileEE.getBackend(), &loweredMap);
 
   // Check that the lowered graph only contains the lowered components of the

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -245,7 +245,7 @@ void Loader::compile(Context &ctx) {
     // generateNodeQuantizationInfos() when writing out the profile, allowing
     // for both lowered and unlowered NodeValues to find their quantization
     // parameters.
-    ::lower(F_, *EE_.getBackend(), &loweredMap_);
+    ::lowerEverything(F_, &loweredMap_);
 
     // Instrument the graph to capture profiles for nodes' outputs.
     F_ = ::profileQuantization(ctx, F_);
@@ -272,7 +272,7 @@ void Loader::compile(Context &ctx) {
     // lowered, however all lowered and unlowered components have a profile, and
     // so the backend can lower however it prefers and always find all of its
     // NodeValue's quantization parameters.
-    ::lower(F_, *EE_.getBackend());
+    ::lower(F_, *EE_.getBackend(), &loweredMap_);
 
     auto quantizationInfos = deserializeFromYaml(loadProfileFileOpt);
 
@@ -285,7 +285,7 @@ void Loader::compile(Context &ctx) {
 
     // Quantize the graph based on the captured profile.
     auto *Q = quantization::quantizeFunction(
-        EE_, quantizationInfos, quantizationPrecision, F_, oldName,
+        EE_, quantizationInfos, quantizationPrecision, F_, loweredMap_, oldName,
         keepOriginalPrecisionForNodes, enableRowwiseOpt);
 
     // Erase the original function so that the redundant variables that are only

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -245,7 +245,7 @@ void Loader::compile(Context &ctx) {
     // generateNodeQuantizationInfos() when writing out the profile, allowing
     // for both lowered and unlowered NodeValues to find their quantization
     // parameters.
-    ::lowerEverything(F_, &loweredMap_);
+    ::lower(F_, &loweredMap_);
 
     // Instrument the graph to capture profiles for nodes' outputs.
     F_ = ::profileQuantization(ctx, F_);
@@ -272,7 +272,7 @@ void Loader::compile(Context &ctx) {
     // lowered, however all lowered and unlowered components have a profile, and
     // so the backend can lower however it prefers and always find all of its
     // NodeValue's quantization parameters.
-    ::lower(F_, *EE_.getBackend(), &loweredMap_);
+    ::lower(F_, &loweredMap_, EE_.getBackend());
 
     auto quantizationInfos = deserializeFromYaml(loadProfileFileOpt);
 

--- a/tools/loader/Loader.h
+++ b/tools/loader/Loader.h
@@ -42,9 +42,10 @@ class Loader {
   /// Function containing the model.
   Function *F_{nullptr};
   /// A map between quantization profiling names of NodeValues that were lowered
-  /// from each other. Maps to a set of NodeValues that were replaced by the
-  /// NodeValue (key) that replaced them.
-  LoweredNamesMap loweredMap_;
+  /// from each other. Maps to a set of names of NodeValues and their NodeKinds
+  /// that were replaced by the NodeValue (whose output name is the key) that
+  /// replaced them.
+  LoweredInfoMap loweredMap_;
 
 public:
   /// Getter for the Function.


### PR DESCRIPTION
*Description*: Refactor LoweredNamesMap to LoweredInfoMap. The LoweredInfoMap maps to a set of NodeNameAndKind structs containing the node's outputName and NodeKind. This is used to correctly quantized BAs lowered from FCs, so that during quantization we know if a batched add came from a fully connected. This also requires keeping track of the LoweredInfoMap prior to quantization, whereas before it was only prior to profiling.

*Testing*: Added to unit tests to verify the batched add is Int32QTy, and correct scale/offset.

Fixes https://github.com/pytorch/glow/issues/2395