### PR TITLE
Wrap onnxGetExtensionFunctionAddress in GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER

### DIFF
--- a/lib/Onnxifi/onnxifiGlow.cpp
+++ b/lib/Onnxifi/onnxifiGlow.cpp
@@ -548,8 +548,9 @@ GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxReleaseGraph)(onnxGraph graph) {
 }
 
 ONNXIFI_PUBLIC ONNXIFI_CHECK_RESULT onnxStatus ONNXIFI_ABI
-onnxGetExtensionFunctionAddress(onnxBackendID backendID, const char *name,
-                                onnxExtensionFunctionPointer *function) {
+GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxGetExtensionFunctionAddress)(
+    onnxBackendID backendID, const char *name,
+    onnxExtensionFunctionPointer *function) {
   if (!name || !function) {
     return ONNXIFI_STATUS_INVALID_POINTER;
   }


### PR DESCRIPTION
*Description*:
Fix the fact that onnxGetExtensionFunctionAddress was never wrapped in GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER.

*Testing*:

*Documentation*:
none