### PR TITLE
[Lowering/Loader] Add CLI option and plumbing to disable lowering specified node kinds.

### DIFF
--- a/docs/Quantization.md
+++ b/docs/Quantization.md
@@ -85,6 +85,24 @@ For example, you can run the following command to capture profile for Resnet50.
 ```
 ./bin/image-classifier tests/images/imagenet/*.png -image-mode=0to1 -m=resnet50 -model-input-name=gpu_0/data -dump-profile="profile.yaml"
 ```
+
+By default, everything will be lowered for profiling. This allows for the
+lowered components of nodes to be profiled, allowing for good precision of
+complex nodes. For example, the `SigmoidCrossEntropyWithLogitsNode` has many
+internal nodes that it is lowered to. Without profiling the internal nodes,
+there would be no information on how best to quantize its internal nodes that it
+is lowered to.
+
+Lowering all nodes may cause performance issues for some models, e.g. if a model
+has group Convolutions which explode the size of the graph when lowered, leading
+to long compilation and run time during profiling. Thus, we allow for disabling
+certain NodeKinds for profiling. This means that during quantization, these
+nodes should also not be lowered by the backend. This can be done using the
+command line option `-do-not-lower-nodes-for-profiling` (note: multiple Nodes
+can be listed via comma separation). For example:
+
+```./bin/image-classifier tests/images/imagenet/*.png -image-mode=0to1 -m=shufflenet -model-input-name=gpu_0/data -dump-profile="shufflenet.yaml" -do-not-lower-nodes-for-profiling=Convolution```
+
 By default, the loader will produce quantized results using asymmetric ranges.
 That is ranges not necessarily centered on 0. The loader supports three modes
 or schemas of quantization: asymmetric, symmetric, and symmetric with uint8. The symmetric schema

--- a/include/glow/Optimizer/Optimizer.h
+++ b/include/glow/Optimizer/Optimizer.h
@@ -47,8 +47,10 @@ void optimize(Function *F, CompilationMode mode);
 /// will be lowered. If \p loweredMap is not a nullptr, then \p loweredMap will
 /// contain a mapping from output names of the nodes found and lowered in \p F
 /// to the output names of the nodes they were lowered from along with the
-/// NodeKind.
-void lower(Function *F, LoweredInfoMap *loweredMap, const Backend *B = nullptr);
+/// NodeKind. \p doNotLowerKinds is a set of NodeKinds which represents all
+/// Nodes that should not be lowered.
+void lower(Function *F, LoweredInfoMap *loweredMap, const Backend *B = nullptr,
+           const KindSet &doNotLowerKinds = {});
 
 /// Dead code elimination.
 void DCE(Function *F);

--- a/lib/Optimizer/Lower.cpp
+++ b/lib/Optimizer/Lower.cpp
@@ -791,10 +791,14 @@ static void lowerNode(Function *F, Node *node, LoweredInfoMap *loweredMap) {
   }
 }
 
-void glow::lower(Function *F, LoweredInfoMap *loweredMap, const Backend *B) {
+void glow::lower(Function *F, LoweredInfoMap *loweredMap, const Backend *B,
+                 const KindSet &doNotLowerKinds) {
   auto &nodes = F->getNodes();
   for (auto &N : nodes) {
     if (B && !B->shouldLower(&N)) {
+      continue;
+    }
+    if (doNotLowerKinds.count(N.getKind())) {
       continue;
     }
     lowerNode(F, &N, loweredMap);


### PR DESCRIPTION
*Description*: Add option on the command line for loaders to prevent lowering during profiling. By default everything will be lowered for profiling. However this may cause performance issues for some models, e.g. if a model has group Convolutions which explode the size of the graph when lowered. Thus, this PR allows for disabling certain NodeKinds for profiling. This means that during quantization, these nodes should also not be lowered by the backend.

*Testing*: Added test. Also verified shufflenet works with the new command line option while making profiling much faster (what is was previously).

*Documentation*: Added documentation.

Fixes https://github.com/pytorch/glow/issues/2413
