### PR TITLE
Avoid large stack allocation in libjit matmul

### DIFF
--- a/lib/Backends/CPU/libjit/libjit_defs.h
+++ b/lib/Backends/CPU/libjit/libjit_defs.h
@@ -16,6 +16,7 @@
 #ifndef GLOW_BACKENDS_CPU_LIBJIT_LIBJIT_DEFS_H
 #define GLOW_BACKENDS_CPU_LIBJIT_LIBJIT_DEFS_H
 
+#include <cstdlib>
 #include <stdint.h>
 #include <string.h>
 
@@ -122,5 +123,14 @@ inline int32_t libjit_scale_i32i8(int32_t input, int32_t pre, int32_t post,
   // of overflow and the result will be clipped.
   return ((((input >> pre) * scale) + rtn) >> post) + offset;
 }
+
+#ifdef _WIN32
+#define libjit_aligned_malloc(p, a, s)                                         \
+  (((*(p)) = _aligned_malloc((s), (a))), *(p) ? 0 : errno)
+#define libjit_aligned_free(p) _aligned_free(p)
+#else
+#define libjit_aligned_malloc(p, a, s) posix_memalign(p, a, s)
+#define libjit_aligned_free(p) free(p)
+#endif
 
 #endif // GLOW_BACKENDS_CPU_LIBJIT_LIBJIT_DEFS_H

--- a/lib/Backends/CPU/libjit/libjit_matmul.cpp
+++ b/lib/Backends/CPU/libjit/libjit_matmul.cpp
@@ -225,7 +225,8 @@ template <bool pack>
 void __attribute__((noinline))
 libjit_matmul_outer(size_t m, size_t n, size_t k, const float *a, size_t lda,
                     const float *b, size_t ldb, float *c, size_t ldc) {
-  float packedB[kc * nc] __attribute__((aligned(64)));
+  float *packedB;
+  libjit_aligned_malloc((void **)&packedB, 64, kc * nc);
 
   for (size_t p = 0; p < k; p += kc) {
     size_t pb = MIN(k - p, kc);
@@ -241,6 +242,8 @@ libjit_matmul_outer(size_t m, size_t n, size_t k, const float *a, size_t lda,
       }
     }
   }
+
+  libjit_aligned_free(packedB);
 }
 
 #undef C


### PR DESCRIPTION
*Description*: As a performance optimization the libjit matmul has a branch where if a tensor dimension is >= 1024 it allocates about 2 mb on the stack and does the multiplication in that memory. 

Some systems (looking at you OSX) limit the stack size of created threads such that any graph with a large Tensor would crash if the compiled CPUFunction was run on the DeviceManager or on any new thread.

The fix is to allocate the scratchpad dynamically.
*Testing*: unit tests w/ ASAN.

Also, GemmBench to compare performance regression (3 runs each impl):

```
Alloc on Stack:
utX, outY, lhsX, lhsY, rhsX, rhsY, gflops/s,
1024, 1024,   1024, 1024,   1024,  1024,   108.48
1024, 1024,   1024, 1024,   1024,  1024,   109.21
1024, 1024,   1024, 1024,   1024,  1024,   116.51

  32, 32  ,     32, 1024,   1024,  32  ,   68.75
  32, 32  ,     32, 1024,   1024,  32  ,   74.80
  32, 32  ,     32, 1024,   1024,  32  ,   87.44

Alloc on Heap:
1024, 1024,   1024, 1024,   1024,  1024,   112.94
1024, 1024,   1024, 1024,   1024,  1024,   115.64
1024, 1024,   1024, 1024,   1024,  1024,   118.04

  32, 32  ,     32, 1024,   1024,  32  ,   74.69
  32, 32  ,     32, 1024,   1024,  32  ,   77.70
  32, 32  ,     32, 1024,   1024,  32  ,   63.44
```

Hard to see a clear drop off, but could just be 3 runs isn't enough.
*Documentation*: This was a fun one to find.
