### PR TITLE
Build ExecutionEngine on DeviceManager

### DIFF
--- a/include/glow/Backends/Backend.h
+++ b/include/glow/Backends/Backend.h
@@ -41,6 +41,9 @@ public:
   /// Dtor.
   virtual ~Backend() = default;
 
+  /// \returns the kind of Backend this is.
+  virtual BackendKind getBackendKind() const = 0;
+
   /// Generate code for input function \param F.
   virtual std::unique_ptr<CompiledFunction> compile(Function *F) const = 0;
 

--- a/include/glow/Backends/CompiledFunction.h
+++ b/include/glow/Backends/CompiledFunction.h
@@ -37,7 +37,7 @@ public:
       : runtimeBundle_(bundle){};
 
   /// Dtor.
-  virtual ~CompiledFunction() = default;
+  virtual ~CompiledFunction() { runtimeBundle_.freeConstants(); }
   /// Execute the network and allocate Placeholder memory with given
   /// \p ctx providing mapping between Placeholder and populated tensor.
   virtual void execute(Context *ctx) = 0;

--- a/include/glow/Backends/DummyDeviceManager.h
+++ b/include/glow/Backends/DummyDeviceManager.h
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_BACKENDS_INLINEDEVICEMANAGER_H
+#define GLOW_BACKENDS_INLINEDEVICEMANAGER_H
+
+#include "glow/Backends/DeviceManager.h"
+#include "glow/Runtime/RuntimeTypes.h"
+
+#include <atomic>
+
+namespace glow {
+namespace runtime {
+
+/// The DummyDeviceManager is a simple DeviceManager implementation that
+/// provides execution for backends that are in development. It is explicitly
+/// not threadsafe and runs provided CompiledFunction's in the caller thread.
+class DummyDeviceManager : public DeviceManager {
+  /// Compiled function list by name.
+  FunctionMapTy functions_;
+
+public:
+  DummyDeviceManager(BackendKind backend, llvm::StringRef name)
+      : DeviceManager(backend, name) {}
+
+  /// The DummyDeviceManager is a simple wrapper for testing, if you need
+  /// memory guards you should implement a DeviceManager for your device.
+  uint64_t getMaximumMemory() const override { return 100; }
+  uint64_t getAvailableMemory() const override { return 100; }
+  bool isMemoryAvailable(uint64_t) const override { return true; }
+
+  /// Load the provided module into the device, readyCB will be called when
+  /// ready to use.
+  /// \p functions contains the list of functions to load, keyed by their name
+  /// (as used in runFunction).
+  void addNetwork(const Module *module, FunctionMapTy functions,
+                  ReadyCBTy callback) override {
+    for (const auto &func : functions) {
+      if (functions_.count(func.first) != 0) {
+        callback(module, ResultCode::Failed);
+        return;
+      }
+    }
+
+    for (const auto &func : functions) {
+      if (func.second->getRuntimeBundle().getConstants() == nullptr) {
+        func.second->getRuntimeBundle().collectConstants(module);
+      }
+      functions_.emplace(func.first, func.second);
+    }
+
+    // Fire the ready CB.
+    callback(module, ResultCode::Ready);
+  }
+
+  /// Remove (and delete) the provided function, freeing
+  /// up space on the device.
+  void evictNetwork(std::string functionName,
+                    EvictFunctionCBTy evictCB) override {
+    functions_.erase(functionName);
+    evictCB(functionName, ResultCode::Executed);
+  }
+
+  /// Execute the named Function in an already provided network on the device.
+  /// functionName must match the name of a function already added.
+  /// Context should have all Placeholders allocated. resultCB will be called
+  /// with the Context results filled.
+  RunIdentifierTy runFunction(std::string functionName,
+                              std::unique_ptr<Context> ctx,
+                              ResultCBTy callback) override {
+    auto funcIt = functions_.find(functionName);
+    if (funcIt == functions_.end()) {
+      callback(0, ResultCode::Failed, std::move(ctx));
+      return 0;
+    }
+
+    CompiledFunction *func = funcIt->second;
+
+    func->setupRuns();
+    func->beforeRun(*ctx.get());
+    func->execute(ctx.get());
+    func->afterRun(*ctx.get());
+
+    // Fire the resultCB.
+    callback(0, ResultCode::Executed, std::move(ctx));
+
+    return 0;
+  }
+};
+
+} // namespace runtime
+} // namespace glow
+
+#endif // GLOW_BACKENDS_INLINEDEVICEMANAGER_H

--- a/lib/Backends/BackendUtils.cpp
+++ b/lib/Backends/BackendUtils.cpp
@@ -34,6 +34,7 @@ void glow::runtime::RuntimeBundle::setInputsandOutputs() {
 void glow::runtime::RuntimeBundle::freeConstants() {
   if (constants_) {
     glow::alignedFree(constants_);
+    constants_ = nullptr;
   }
 }
 void glow::runtime::RuntimeBundle::collectConstants(const Module *M) {
@@ -45,6 +46,7 @@ void glow::runtime::RuntimeBundle::collectConstants(const Module *M) {
     return;
   }
 
+  assert(constants_ == nullptr && "constants already allocated");
   constants_ =
       (uint8_t *)alignedAlloc(constantWeightVarsMemSize_, TensorAlignment);
 

--- a/lib/Backends/CMakeLists.txt
+++ b/lib/Backends/CMakeLists.txt
@@ -17,10 +17,12 @@ endif()
 
 add_library(Backend
               Backend.cpp
+              BackendUtils.cpp
               TraceEvents.cpp)
 target_link_libraries(Backend
                       PRIVATE
                         Base
+                        CodeGen
                         Graph
                         IR
                         Optimizer)
@@ -28,19 +30,14 @@ target_link_libraries(Backend
 add_library(Backends
               Backends.cpp)
 target_link_libraries(Backends
+                      PUBLIC
+                        Backend
                       PRIVATE
-                        BackendUtils
                         Base
                         Graph
                         Interpreter
                         Optimizer
                         ${linked_backends})
-
-add_library(BackendUtils BackendUtils.cpp)
-target_link_libraries(BackendUtils
-                      PRIVATE
-                      CodeGen
-                      IR)
 
 add_library(DeviceManager
               DeviceManagers.cpp)

--- a/lib/Backends/CPU/CMakeLists.txt
+++ b/lib/Backends/CPU/CMakeLists.txt
@@ -86,7 +86,6 @@ target_link_libraries(CPUBackend
                         Backend
                         Base
                         CodeGen
-                        BackendUtils
                         Graph
                         IR
                         Optimizer
@@ -121,7 +120,6 @@ add_library(CPUDeviceManager
 target_link_libraries(CPUDeviceManager
                       PRIVATE
                         Backends
-                        BackendUtils
                         Base
                         CodeGen
                         CPUBackend

--- a/lib/Backends/CPU/CPUBackend.h
+++ b/lib/Backends/CPU/CPUBackend.h
@@ -43,6 +43,8 @@ public:
   ///@{
   ~CPUBackend() override = default;
 
+  BackendKind getBackendKind() const override { return BackendKind::CPU; }
+
   std::unique_ptr<CompiledFunction>
   compileIR(std::unique_ptr<IRFunction> IR) const override;
 

--- a/lib/Backends/CPU/CPUDeviceManager.cpp
+++ b/lib/Backends/CPU/CPUDeviceManager.cpp
@@ -67,7 +67,9 @@ void CPUDeviceManager::addNetworkImpl(const Module *module,
 
   // Add to the function name lookup map.
   for (const auto &func : functions) {
-    func.second->getRuntimeBundle().collectConstants(module);
+    if (func.second->getRuntimeBundle().getConstants() == nullptr) {
+      func.second->getRuntimeBundle().collectConstants(module);
+    }
     functions_.emplace(func.first, func.second);
     usedMemoryBytes_ += functionCost_; // TODO:: static moduleSize
   }

--- a/lib/Backends/CPU/CPUFunction.cpp
+++ b/lib/Backends/CPU/CPUFunction.cpp
@@ -25,10 +25,7 @@ CPUFunction::CPUFunction(std::unique_ptr<llvm::orc::GlowJIT> JIT,
                          const runtime::RuntimeBundle &runtimeBundle)
     : CompiledFunction(runtimeBundle), JIT_(std::move(JIT)) {}
 
-CPUFunction::~CPUFunction() {
-  alignedFree(runtimeBundle_.getConstants());
-  tearDownRuns();
-}
+CPUFunction::~CPUFunction() { tearDownRuns(); }
 
 void CPUFunction::collectConstants(Module *module) {
   runtimeBundle_.collectConstants(module);

--- a/lib/Backends/DeviceManagers.cpp
+++ b/lib/Backends/DeviceManagers.cpp
@@ -15,8 +15,10 @@
  */
 
 #include "glow/Backends/DeviceManager.h"
+#include "glow/Backends/DummyDeviceManager.h"
 
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/raw_ostream.h"
 
 using namespace glow;
 using namespace glow::runtime;
@@ -61,7 +63,12 @@ DeviceManager *DeviceManager::createDeviceManager(BackendKind backendKind,
   case BackendKind::CPU:
     return createCPUDeviceManager(name);
   default:
-    GLOW_UNREACHABLE("not supported backend");
+    // As a fallback to make developing new Backends easier we'll create a
+    // DummyDeviceManager here, but this is not threadsafe and very simplistic.
+    // Strongly recommended that you create a DeviceManager customized for your
+    // device.
+    llvm::errs() << "Warning: Creating a DummyDeviceManager.\n";
+    return new DummyDeviceManager(backendKind, name);
   }
 
   // This is to make compiler happy. It can never reach this point as switch

--- a/lib/Backends/Interpreter/CMakeLists.txt
+++ b/lib/Backends/Interpreter/CMakeLists.txt
@@ -8,7 +8,6 @@ target_link_libraries(Interpreter
                         Base
                         Graph
                         CodeGen
-                        BackendUtils
                         IR
                         Optimizer
                         QuantizationBase)
@@ -17,8 +16,8 @@ add_library(InterpreterDeviceManager
               InterpreterDeviceManager.cpp)
 target_link_libraries(InterpreterDeviceManager
                       PRIVATE
+                        Backend
                         Backends
-                        BackendUtils
                         Base
                         CodeGen
                         Graph

--- a/lib/Backends/Interpreter/Interpreter.h
+++ b/lib/Backends/Interpreter/Interpreter.h
@@ -34,6 +34,10 @@ public:
   ///@{
   ~Interpreter() override = default;
 
+  BackendKind getBackendKind() const override {
+    return BackendKind::Interpreter;
+  }
+
   std::unique_ptr<CompiledFunction>
   compileIR(std::unique_ptr<IRFunction> IR) const override;
 

--- a/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
@@ -64,7 +64,9 @@ void InterpreterDeviceManager::addNetworkImpl(const Module *module,
 
   // Add to the function name lookup map.
   for (const auto &func : functions) {
-    func.second->getRuntimeBundle().collectConstants(module);
+    if (func.second->getRuntimeBundle().getConstants() == nullptr) {
+      func.second->getRuntimeBundle().collectConstants(module);
+    }
     functions_.emplace(func.first, func.second);
     usedMemoryBytes_ += functionCost_; // TODO:: static moduleSize
   }

--- a/lib/Backends/Interpreter/InterpreterFunction.cpp
+++ b/lib/Backends/Interpreter/InterpreterFunction.cpp
@@ -34,7 +34,6 @@ InterpreterFunction::~InterpreterFunction() {
   }
   constants_.clear();
 
-  alignedFree(runtimeBundle_.getConstants());
   tearDownRuns();
 }
 

--- a/lib/Backends/OpenCL/CMakeLists.txt
+++ b/lib/Backends/OpenCL/CMakeLists.txt
@@ -31,7 +31,6 @@ add_library(OpenCL
 target_link_libraries(OpenCL
                       PRIVATE
                       Backend
-                      BackendUtils
                       Base
                       Graph
                       CodeGen
@@ -47,8 +46,8 @@ add_library(OpenCLDeviceManager
             OpenCLDeviceManager.cpp)
 target_link_libraries(OpenCLDeviceManager
                       PRIVATE
+                        Backend
                         Backends
-                        BackendUtils
                         Base
                         CodeGen
                         OpenCL

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -170,6 +170,8 @@ public:
   ///@{
   ~OCLBackend() override = default;
 
+  BackendKind getBackendKind() const override { return BackendKind::OpenCL; }
+
   std::unique_ptr<CompiledFunction>
   compileIR(std::unique_ptr<IRFunction> IR) const override;
   std::unique_ptr<CompiledFunction>

--- a/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
@@ -125,7 +125,9 @@ void OpenCLDeviceManager::addNetworkImpl(const Module *module,
   // Collect constants once, since currently the bundle grabs everything in the
   // module.
   auto bundle = functions.begin()->second->getRuntimeBundle();
-  bundle.collectConstants(module);
+  if (bundle.getConstants() == nullptr) {
+    bundle.collectConstants(module);
+  }
   size_t sizeInBytes = bundle.getConstantWeightSize();
   if (usedMemoryBytes_ + sizeInBytes > maxMemoryBytes_) {
     llvm::errs() << "Failed to add network: not enough memory.\n";

--- a/lib/ExecutionEngine/CMakeLists.txt
+++ b/lib/ExecutionEngine/CMakeLists.txt
@@ -5,6 +5,7 @@ target_link_libraries(ExecutionEngine
                       PRIVATE
                         Backend
                         Backends
+                        DeviceManager
                         Optimizer
                         Base
                         Graph)

--- a/lib/Runtime/Provisioner/CMakeLists.txt
+++ b/lib/Runtime/Provisioner/CMakeLists.txt
@@ -3,6 +3,6 @@ add_library(Provisioner
 
 target_link_libraries(Provisioner
                       PRIVATE
+                        Backend
                         Backends
-                        BackendUtils
                         Graph)

--- a/tests/unittests/BackendCorrectnessTest.cpp
+++ b/tests/unittests/BackendCorrectnessTest.cpp
@@ -252,6 +252,9 @@ public:
     backend_.reset(
         static_cast<BackendUsingGlowIR *>(createBackend(BackendKind::CPU)));
   }
+
+  BackendKind getBackendKind() const override { return BackendKind::CPU; }
+
   std::unique_ptr<CompiledFunction> compile(Function *F) const override {
     return backend_->compile(F);
   }

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -38,6 +38,10 @@ class MockBackend : public Backend {
     }
   };
 
+  BackendKind getBackendKind() const override {
+    return BackendKind::Interpreter;
+  }
+
   std::unique_ptr<CompiledFunction> compile(Function *F) const override {
     return llvm::make_unique<MockFunction>();
   }
@@ -66,6 +70,10 @@ class MockBackendCustomIRGen : public Backend {
       return BackendKind::Interpreter;
     }
   };
+
+  BackendKind getBackendKind() const override {
+    return BackendKind::Interpreter;
+  }
 
   std::unique_ptr<CompiledFunction> compile(Function *F) const override {
     return llvm::make_unique<MockFunction>();

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -79,7 +79,6 @@ add_executable(DeviceManagerTest
                DeviceManagerTest.cpp)
 target_link_libraries(DeviceManagerTest
                       PRIVATE
-                        Backend
                         Backends
                         DeviceManager
                         Graph
@@ -407,7 +406,6 @@ add_executable(TraceEventsTest
                TraceEventsTest.cpp)
 target_link_libraries(TraceEventsTest
                       PRIVATE
-                        Backend
                         Backends
                         Graph
                         IR

--- a/tests/unittests/QuantizationTest.cpp
+++ b/tests/unittests/QuantizationTest.cpp
@@ -869,6 +869,11 @@ public:
   MockQuantBackend() {
     backend_.reset(createBackend(BackendKind::Interpreter));
   }
+
+  BackendKind getBackendKind() const override {
+    return BackendKind::Interpreter;
+  }
+
   std::unique_ptr<CompiledFunction> compile(Function *F) const override {
     return backend_->compile(F);
   }


### PR DESCRIPTION
*Description*: There are currently two ways to execute a compiled function: using the ExecutionEngine, or using the DeviceManager. The ExecutionEngine has a good interface but it would be good to have a single path to maintain for execution. This is the first part of making that change: backing the ExecutionEngine by a DeviceManager.
*Testing*: unit tests
*Documentation*: We'll fall back to the DummyDeviceManager if the BackendKind does not have a DeviceManager of its own, but this should be a short term solution.