### PR TITLE
Check unchecked Error

### DIFF
--- a/include/glow/Support/Error.h
+++ b/include/glow/Support/Error.h
@@ -186,6 +186,19 @@ private:
       RETURN_ERR(__VA_ARGS__);                                                 \
     }                                                                          \
   } while (0)
+
+/// Marks the Error \p err as as checked. \returns true if it contains an
+/// error value and prints the message in the error value, returns false
+/// otherwise.
+inline bool errorToBool(llvm::Error err) {
+  if (static_cast<bool>(err)) {
+    llvm::errs() << "Converting error to boolean: "
+                 << llvm::toString(std::move(err)) << "\n";
+    return true;
+  }
+  return false;
+}
+
 } // end namespace glow
 
 #endif // GLOW_SUPPORT_ERROR_H

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -966,7 +966,7 @@ static void importPad(std::string fileName, const char *inputName,
     if (expectLoadError) {
       llvm::Error err = llvm::Error::success();
       ONNXModelLoader(NetFilename, {inputName}, {&data.getType()}, *F, &err);
-      EXPECT_TRUE(bool(err));
+      EXPECT_TRUE(errorToBool(std::move(err)));
       return;
     }
     ONNXModelLoader onnxLD(NetFilename, {inputName}, {&data.getType()}, *F);


### PR DESCRIPTION
*Description*:
TIL `llvm::Error::operator bool()` only sets the checked bit [if the error is not filled](https://github.com/llvm-mirror/llvm/blob/9ed230bd09dbdc4d85f34ac3c2b824726245f17e/include/llvm/Support/Error.h#L236).

*Testing*:
Built LLVM from source with `LLVM_ABI_BREAKING_CHECKS` on
Configured glow to use this llvm version with -DCMAKE_PREFIX_PATH
`ninja test`

*Documentation*:
Fixes #2432
