### PR TITLE
Replace cantFails with EXIT_ON_ERRs

### DIFF
--- a/examples/resnet-concurrent.cpp
+++ b/examples/resnet-concurrent.cpp
@@ -62,9 +62,9 @@ std::pair<Placeholder *, Placeholder *> loadResnet50Model(TypeRef inputType,
   const char inputName[] = "gpu_0/data";
   Caffe2ModelLoader loader("resnet50/predict_net.pb", "resnet50/init_net.pb",
                            {inputName}, {inputType}, *F);
-  Placeholder *input =
-      llvm::cast<Placeholder>(cantFail(loader.getNodeValueByName(inputName)));
-  Placeholder *output = cantFail(loader.getSingleOutput());
+  Placeholder *input = llvm::cast<Placeholder>(
+      EXIT_ON_ERR(loader.getNodeValueByName(inputName)));
+  Placeholder *output = EXIT_ON_ERR(loader.getSingleOutput());
 
   return std::make_pair(input, output);
 }

--- a/examples/resnet-runtime.cpp
+++ b/examples/resnet-runtime.cpp
@@ -59,8 +59,8 @@ Placeholder *loadResnet50Model(TypeRef inputType, Module *module,
   const char inputName[] = "gpu_0/data";
   Caffe2ModelLoader loader("resnet50/predict_net.pb", "resnet50/init_net.pb",
                            {inputName}, {inputType}, *F);
-  Placeholder *input =
-      llvm::cast<Placeholder>(cantFail(loader.getNodeValueByName(inputName)));
+  Placeholder *input = llvm::cast<Placeholder>(
+      EXIT_ON_ERR(loader.getNodeValueByName(inputName)));
   return input;
 }
 

--- a/examples/resnet-verify.cpp
+++ b/examples/resnet-verify.cpp
@@ -41,9 +41,9 @@ public:
     // Load and compile ResNet-50.
     Caffe2ModelLoader loader("resnet50/predict_net.pb", "resnet50/init_net.pb",
                              {inputName}, {inputType}, *F);
-    input =
-        llvm::cast<Placeholder>(cantFail(loader.getNodeValueByName(inputName)));
-    output = cantFail(loader.getSingleOutput());
+    input = llvm::cast<Placeholder>(
+        EXIT_ON_ERR(loader.getNodeValueByName(inputName)));
+    output = EXIT_ON_ERR(loader.getSingleOutput());
   }
 
   void bindInput(Tensor *batch) {

--- a/examples/tracing-compare.cpp
+++ b/examples/tracing-compare.cpp
@@ -58,9 +58,9 @@ std::pair<Placeholder *, Placeholder *> loadResnet50Model(TypeRef inputType,
   const char inputName[] = "gpu_0/data";
   Caffe2ModelLoader loader("resnet50/predict_net.pb", "resnet50/init_net.pb",
                            {inputName}, {inputType}, *F);
-  Placeholder *input =
-      llvm::cast<Placeholder>(cantFail(loader.getNodeValueByName(inputName)));
-  Placeholder *output = cantFail(loader.getSingleOutput());
+  Placeholder *input = llvm::cast<Placeholder>(
+      EXIT_ON_ERR(loader.getNodeValueByName(inputName)));
+  Placeholder *output = EXIT_ON_ERR(loader.getSingleOutput());
 
   return std::make_pair(input, output);
 }


### PR DESCRIPTION
*Description*:
I noticed some cantFails in the code where there should be EXIT_ON_ERRs which provides more details on failure and works whether compile with debug or not which is good for examples. Also, this code can actually fail so better to use EXIT_ON_ERR.

*Testing*:
`ninja test`

*Documentation*:
none