### PR TITLE
[Operator] Add ElementwiseLinear Caffe2 op

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -339,6 +339,15 @@ public:
   /// \p Y are 2D. \returns either the Mul or BatchedReduceAdd node.
   Node *createDotProduct(llvm::StringRef name, NodeValue X, NodeValue Y);
 
+  /// Create a node that implements the elementwise linear operator. \p X is
+  /// 2D and \p w and \p b are 1D. \p w and \p b are broadcasted to match the
+  /// shape of \p X and then the output is computed by multiplying \p X and
+  /// broadcasted \p w and adding broadcasted \p b. \returns the
+  /// ElementwiseLinearNode. \p axis indicates the axis of the inputs (the other
+  /// axis of \p X is assumed to be the batch index).
+  Node *createElementwiseLinear(llvm::StringRef name, NodeValue X, NodeValue w,
+                                NodeValue b, unsigned axis);
+
   /// Create a ReLU node with the given \p name and \p input.
   /// Result type will be implicitly set based on the \p input type.
   ReluNode *createRELU(llvm::StringRef name, NodeValue input);

--- a/tests/models/caffe2Models/elementwise_linear_default_net.pbtxt
+++ b/tests/models/caffe2Models/elementwise_linear_default_net.pbtxt
@@ -1,0 +1,13 @@
+name: "elementwise_linear"
+op {
+  input: "X"
+  input: "w"
+  input: "b"
+  output: "el_result"
+  name: ""
+  type: "ElementwiseLinear"
+}
+external_input: "X"
+external_input: "w"
+external_input: "b"
+external_output: "el_result"

--- a/tests/models/caffe2Models/elementwise_linear_net.pbtxt
+++ b/tests/models/caffe2Models/elementwise_linear_net.pbtxt
@@ -1,0 +1,17 @@
+name: "elementwise_linear"
+op {
+  input: "X"
+  input: "w"
+  input: "b"
+  output: "el_result"
+  name: ""
+  type: "ElementwiseLinear"
+  arg {
+    name: "axis"
+    i: 0
+  }
+}
+external_input: "X"
+external_input: "w"
+external_input: "b"
+external_output: "el_result"

--- a/tests/unittests/Caffe2ImporterTest.cpp
+++ b/tests/unittests/Caffe2ImporterTest.cpp
@@ -1720,6 +1720,162 @@ TEST(caffe2, Modulo) {
   ASSERT_TRUE(N);
 }
 
+/// Test loading an ElementwiseLinear operator.
+TEST(caffe2, elementwiseLinear) {
+  ExecutionEngine EE{BackendKind::Interpreter};
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+
+  std::string NetDescFilename(
+      GLOW_DATA_PATH "tests/models/caffe2Models/elementwise_linear_net.pbtxt");
+  std::string NetWeightFilename(
+      GLOW_DATA_PATH "tests/models/caffe2Models/empty_init_net.pbtxt");
+
+  Context ctx;
+  Placeholder *output;
+  Tensor X(ElemKind::FloatTy, {10, 5});
+  Tensor w(ElemKind::FloatTy, {10}), b(ElemKind::FloatTy, {10});
+
+  // Destroy the loader after the graph is loaded since the following execution
+  // will not depend on anyting from the loader.
+  {
+    Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename,
+                               {"X", "w", "b"},
+                               {&X.getType(), &w.getType(), &b.getType()}, *F);
+    output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
+  }
+
+  // Check that the shape of the output matches that of the input.
+  std::vector<size_t> expectedDims = {10, 5};
+  EXPECT_TRUE(output->dims().vec() == expectedDims);
+
+  // High level checks on the content of the graph.
+  // It should look like this:
+  //
+  //            X           w            b
+  //            |           |            |
+  //            |           v            v
+  //            |        Reshape      Reshape
+  //            |           |            |
+  //            |           v            v
+  //            |         Tile         Tile
+  //            |         /             /
+  //            v  v------             /
+  //            Mul                   /
+  //             |   /---------------
+  //             v  v
+  //             Add
+  //              |
+  //              v
+  //             Save
+
+  EXPECT_EQ(F->getNodes().size(), 7);
+  auto *save = getSaveNodeFromDest(output);
+  auto *add = llvm::dyn_cast<AddNode>(save->getInput().getNode());
+  ASSERT_TRUE(add);
+  auto *mul = llvm::dyn_cast<MulNode>(add->getLHS().getNode());
+  ASSERT_TRUE(mul);
+  auto *bTile = llvm::dyn_cast<TileNode>(add->getRHS().getNode());
+  ASSERT_TRUE(bTile);
+  EXPECT_EQ(bTile->getAxis(), 1);
+  auto *XPH = llvm::dyn_cast<Placeholder>(mul->getRHS().getNode());
+  EXPECT_EQ(XPH, mod.getPlaceholderByName("X"));
+  auto *wTile = llvm::dyn_cast<TileNode>(mul->getLHS().getNode());
+  ASSERT_TRUE(wTile);
+  EXPECT_EQ(wTile->getAxis(), 1);
+  auto *bReshape = llvm::dyn_cast<ReshapeNode>(bTile->getInput().getNode());
+  ASSERT_TRUE(bReshape);
+  auto *wReshape = llvm::dyn_cast<ReshapeNode>(wTile->getInput().getNode());
+  ASSERT_TRUE(wReshape);
+  auto *wPH = llvm::dyn_cast<Placeholder>(wReshape->getInput().getNode());
+  EXPECT_EQ(wPH, mod.getPlaceholderByName("w"));
+  auto *bPH = llvm::dyn_cast<Placeholder>(bReshape->getInput().getNode());
+  EXPECT_EQ(bPH, mod.getPlaceholderByName("b"));
+
+  // We have three inputs and one output.
+  EXPECT_EQ(mod.getPlaceholders().size(), 4);
+}
+
+/// Test loading an ElementwiseLinear operator with no axis specified.
+TEST(caffe2, elementwiseLinearUnspecifiedAxis) {
+  ExecutionEngine EE{BackendKind::Interpreter};
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+
+  std::string NetDescFilename(
+      GLOW_DATA_PATH
+      "tests/models/caffe2Models/elementwise_linear_default_net.pbtxt");
+  std::string NetWeightFilename(
+      GLOW_DATA_PATH "tests/models/caffe2Models/empty_init_net.pbtxt");
+
+  Context ctx;
+  Placeholder *output;
+
+  // Since the loader will assume that axis = 1, the 0th dim of the shapes of w
+  // and b must match the 1st dim of X.
+  Tensor X(ElemKind::FloatTy, {5, 10});
+  Tensor w(ElemKind::FloatTy, {10}), b(ElemKind::FloatTy, {10});
+
+  // Destroy the loader after the graph is loaded since the following execution
+  // will not depend on anyting from the loader.
+  {
+    Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename,
+                               {"X", "w", "b"},
+                               {&X.getType(), &w.getType(), &b.getType()}, *F);
+    output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
+  }
+
+  // Check that the shape of the output matches that of the input.
+  std::vector<size_t> expectedDims = {5, 10};
+  EXPECT_TRUE(output->dims().vec() == expectedDims);
+
+  // High level checks on the content of the graph.
+  // It should look like this:
+  //
+  //            X           w            b
+  //            |           |            |
+  //            |           v            v
+  //            |        Reshape      Reshape
+  //            |           |            |
+  //            |           v            v
+  //            |         Tile         Tile
+  //            |         /             /
+  //            v  v------             /
+  //            Mul                   /
+  //             |   /---------------
+  //             v  v
+  //             Add
+  //              |
+  //              v
+  //             Save
+
+  EXPECT_EQ(F->getNodes().size(), 7);
+  auto *save = getSaveNodeFromDest(output);
+  auto *add = llvm::dyn_cast<AddNode>(save->getInput().getNode());
+  ASSERT_TRUE(add);
+  auto *mul = llvm::dyn_cast<MulNode>(add->getLHS().getNode());
+  ASSERT_TRUE(mul);
+  auto *bTile = llvm::dyn_cast<TileNode>(add->getRHS().getNode());
+  ASSERT_TRUE(bTile);
+  EXPECT_EQ(bTile->getAxis(), 0);
+  auto *XPH = llvm::dyn_cast<Placeholder>(mul->getRHS().getNode());
+  EXPECT_EQ(XPH, mod.getPlaceholderByName("X"));
+  auto *wTile = llvm::dyn_cast<TileNode>(mul->getLHS().getNode());
+  ASSERT_TRUE(wTile);
+  EXPECT_EQ(wTile->getAxis(), 0);
+  auto *bReshape = llvm::dyn_cast<ReshapeNode>(bTile->getInput().getNode());
+  ASSERT_TRUE(bReshape);
+  auto *wReshape = llvm::dyn_cast<ReshapeNode>(wTile->getInput().getNode());
+  ASSERT_TRUE(wReshape);
+  auto *wPH = llvm::dyn_cast<Placeholder>(wReshape->getInput().getNode());
+  EXPECT_EQ(wPH, mod.getPlaceholderByName("w"));
+  auto *bPH = llvm::dyn_cast<Placeholder>(bReshape->getInput().getNode());
+  EXPECT_EQ(bPH, mod.getPlaceholderByName("b"));
+
+  // We have three inputs and one output.
+  EXPECT_EQ(mod.getPlaceholders().size(), 4);
+}
+
 /// Test loading SparseLengthsWeightedSum8BitsRowwise. This is created as a
 /// RowwiseQuantizedSparseLengthsWeightedSumNode. The following inputs/outputs
 /// are used/expected for this test. Note that the DATA input is


### PR DESCRIPTION
**Description**
This commit adds support for the `ElementwiseLinear` Caffe2 operator. It
is lowered early in the `glow::Function::createElementwiseLinear`
implementation to `Broadcast`, `Mul` and `Add`.

**Testing**
This commit adds a test for this operator to `OperatorTest` (CPU,
Interpreter and OpenCL backends) and two tests to `Caffe2ImporterTest`;
one that has `axis` specified in the test protobuf and one that does
not. These new tests and all old unit tests all pass.

**Fixes**
This commit fixes #2420.