### PR TITLE
[DeviceManager] Update DeviceManager interface

### DIFF
--- a/include/glow/Backends/DeviceManager.h
+++ b/include/glow/Backends/DeviceManager.h
@@ -29,6 +29,10 @@
 namespace glow {
 namespace runtime {
 
+/// Callback signalling success/failure of evicting a function from a Device.
+using EvictFunctionCBTy =
+    std::function<void(std::string functionName, runtime::ResultCode)>;
+
 /// Callback signalling success/failure of loading a Module onto a device.
 using ReadyCBTy = std::function<void(const Module *, runtime::ResultCode)>;
 
@@ -56,7 +60,7 @@ public:
                                             llvm::StringRef name);
 
   /// Initialize the device.
-  virtual void init() {}
+  virtual ResultCode init() { return ResultCode::Executed; }
 
   /// Load the provided module into the device, readyCB will be called when
   /// ready to use.
@@ -66,8 +70,10 @@ public:
                           ReadyCBTy readyCB) = 0;
 
   /// Remove (and delete) the provided function, freeing
-  /// up space on the device.
-  virtual void evictNetwork(std::string functionName) = 0;
+  /// up space on the device. \p evictCB will be called when the operation
+  /// is completed or attempted and failed.
+  virtual void evictNetwork(std::string functionName,
+                            EvictFunctionCBTy evictCB) = 0;
 
   /// Execute the named Function in an already provided network on the device.
   /// functionName must match the name of a function already added.
@@ -78,7 +84,7 @@ public:
               runtime::ResultCBTy resultCB) = 0;
 
   /// Stops execution and shuts down the Device.
-  virtual void stop(bool block = true) {}
+  virtual ResultCode stop(bool block = true) { return ResultCode::Executed; };
 
   /// \returns the type of Backend that powers this Device.
   BackendKind getBackendKind() { return backend_; }

--- a/lib/Backends/CPU/CPUDeviceManager.cpp
+++ b/lib/Backends/CPU/CPUDeviceManager.cpp
@@ -78,9 +78,17 @@ void CPUDeviceManager::addNetworkImpl(const Module *module,
   readyCB(module, ResultCode::Ready);
 }
 
-void CPUDeviceManager::evictNetworkImpl(std::string functionName) {
+void CPUDeviceManager::evictNetworkImpl(std::string functionName,
+                                        EvictFunctionCBTy evictCB) {
+  ResultCode resultCode = ResultCode::Failed;
+
   if (functions_.erase(functionName)) {
     usedMemoryBytes_ -= functionCost_; // TODO: static moduleSize
+    resultCode = ResultCode::Executed;
+  }
+
+  if (evictCB) {
+    evictCB(functionName, resultCode);
   }
 }
 

--- a/lib/Backends/CPU/CPUDeviceManager.h
+++ b/lib/Backends/CPU/CPUDeviceManager.h
@@ -60,7 +60,8 @@ public:
 protected:
   void addNetworkImpl(const Module *module, FunctionMapTy functions,
                       ReadyCBTy cb) override;
-  void evictNetworkImpl(std::string functionName) override;
+  void evictNetworkImpl(std::string functionName,
+                        EvictFunctionCBTy evictCb) override;
   void runFunctionImpl(runtime::RunIdentifierTy id, std::string functionName,
                        std::unique_ptr<Context> ctx, ResultCBTy cb) override;
 };

--- a/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
@@ -75,9 +75,17 @@ void InterpreterDeviceManager::addNetworkImpl(const Module *module,
   readyCB(module, ResultCode::Ready);
 }
 
-void InterpreterDeviceManager::evictNetworkImpl(std::string functionName) {
+void InterpreterDeviceManager::evictNetworkImpl(std::string functionName,
+                                                EvictFunctionCBTy evictCB) {
+  ResultCode resultCode = ResultCode::Failed;
+
   if (functions_.erase(functionName)) {
     usedMemoryBytes_ -= functionCost_; // TODO: static moduleSize
+    resultCode = ResultCode::Executed;
+  }
+
+  if (evictCB) {
+    evictCB(functionName, resultCode);
   }
 }
 

--- a/lib/Backends/Interpreter/InterpreterDeviceManager.h
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.h
@@ -60,7 +60,8 @@ public:
 protected:
   void addNetworkImpl(const Module *module, FunctionMapTy functions,
                       ReadyCBTy cb) override;
-  void evictNetworkImpl(std::string functionName) override;
+  void evictNetworkImpl(std::string functionName,
+                        EvictFunctionCBTy evictCB) override;
   void runFunctionImpl(runtime::RunIdentifierTy id, std::string functionName,
                        std::unique_ptr<Context> ctx, ResultCBTy cb) override;
 };

--- a/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
@@ -167,7 +167,10 @@ void OpenCLDeviceManager::addNetworkImpl(const Module *module,
   readyCB(module, ResultCode::Ready);
 }
 
-void OpenCLDeviceManager::evictNetworkImpl(std::string functionName) {
+void OpenCLDeviceManager::evictNetworkImpl(std::string functionName,
+                                           EvictFunctionCBTy evictCB) {
+  ResultCode resultCode = ResultCode::Failed;
+
   if (functions_.erase(functionName)) {
     auto buffer = buffers_[functionName];
     auto users = buffer->decrementUsers();
@@ -177,6 +180,11 @@ void OpenCLDeviceManager::evictNetworkImpl(std::string functionName) {
       assert(usedMemoryBytes_ >= size);
       usedMemoryBytes_ -= size;
     }
+    resultCode = ResultCode::Executed;
+  }
+
+  if (evictCB) {
+    evictCB(functionName, resultCode);
   }
 }
 

--- a/lib/Backends/OpenCL/OpenCLDeviceManager.h
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.h
@@ -106,7 +106,8 @@ protected:
 
   /// Remove network from the device. Also serialized so concurrency is not an
   /// issue.
-  void evictNetworkImpl(std::string functionName) override;
+  void evictNetworkImpl(std::string functionName,
+                        EvictFunctionCBTy evictCB) override;
 
   /// Run the function on the device, there is a single thread of execution so
   /// only one function can execute at a time.

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -106,7 +106,8 @@ void HostManager::removeNetwork(llvm::StringRef networkName) {
   for (auto &networkName : allNodes) {
     auto networkIterator = networks_.find(networkName);
     if (networkIterator != networks_.end()) {
-      devices_[networkIterator->second->deviceID]->evictNetwork(networkName);
+      devices_[networkIterator->second->deviceID]->evictNetwork(
+          networkName, /*evictCB=*/nullptr);
       networks_.erase(networkIterator);
     }
   }
@@ -129,7 +130,8 @@ void HostManager::clearHost() {
     it.second->stop();
   }
   for (auto &network : networks_) {
-    devices_[network.second->deviceID]->evictNetwork(network.second->name);
+    devices_[network.second->deviceID]->evictNetwork(network.second->name,
+                                                     /*evictCB=*/nullptr);
   }
   networks_.clear();
   roots_.clear();


### PR DESCRIPTION
**Description**
This commit updates the `DeviceManager` interface; `init`/`stop` now
return a `glow::runtime::ResultCode` and `DeviceManager::evictNetwork`
now takes a callback.

**Testing**
This commit modifies `DeviceManager` test to check for the return codes
from `init`, `stop` and `evictNetwork` (via its callback). All tests
pass.

**Fixes**
This commit fixes #2357.
