### PR TITLE
[Partitioner] Add cost functions to partitioner

### DIFF
--- a/include/glow/Partitioner/Partitioner.h
+++ b/include/glow/Partitioner/Partitioner.h
@@ -25,6 +25,7 @@ namespace glow {
 using namespace runtime;
 
 using MemUsageMapTy = std::unordered_map<Node *, size_t>;
+using ComputeTimeMapTy = std::unordered_map<Node *, float>;
 using NodesSetTy = std::set<Node *>;
 using PartitionCostMapTy = llvm::DenseMap<Function *, GraphMemInfo>;
 
@@ -97,6 +98,9 @@ class Partitioner {
   /// The map of each operator and the corresponding memory size.
   MemUsageMapTy memUsage_;
 
+  /// The map of each operator and the compute runtime.
+  ComputeTimeMapTy computeTime_;
+
   /// Get the representative function (the one with the largest input) and
   /// update the memSize.
   static Function *selectRepFunc(Module *parent, size_t &memSize);
@@ -104,6 +108,9 @@ class Partitioner {
   /// Get the minimal memory requirement for each op in the representive
   /// function.
   void initOpMemUsage();
+
+  /// Inititalize the minimal compute time for each op in the function.
+  void initOpComputeTime();
 
   /// Combine the partitions if necessary : if all outside uses of the nodes in
   /// /// partition1 is in partition2, and the sum of memory consumption of
@@ -140,6 +147,9 @@ public:
 
   /// Decompose each function in a module and return a list of DAGNodes.
   DAGNodeList &Partition();
+
+  /// Get function for computeTime_
+  ComputeTimeMapTy getComputeTime() const { return computeTime_; }
 };
 } // namespace glow
 #endif // GLOW_PARTITIONER_PARTITIONER_H

--- a/include/glow/Runtime/RuntimeTypes.h
+++ b/include/glow/Runtime/RuntimeTypes.h
@@ -48,6 +48,17 @@ using ResultCBTy = std::function<void(
 struct DeviceInfo {
   /// Available memory on device in bytes.
   size_t availableMemory;
+  /// Available SRAM capacity in bytes.
+  size_t sramCapacity;
+  /// Peak compute on device in ops/second. Assumes all ops are in int8.
+  /// TODO: distinguish between data types with different peak flops.
+  float peakCompute;
+  /// Peak memory bandwidth from DRAM on device in bytes/second.
+  float peakDramBw;
+  /// Peak memory bandwidth from SRAM on device in bytes/second.
+  float peakSramBw;
+  /// Peak ingress/egress PCI-E bandwidth from device in bytes/second.
+  float peakPCIeBw;
 };
 
 /// Individual Node in the DAG for a given network. This contains all the

--- a/tests/unittests/PartitionerTest.cpp
+++ b/tests/unittests/PartitionerTest.cpp
@@ -208,3 +208,104 @@ TEST_F(PartitionerTest, Basic2) {
     EXPECT_TRUE(ref.isEqual(test));
   }
 }
+
+/// This one tests the roofline computed with compute, memory and communication
+/// costs
+TEST_F(PartitionerTest, Basic1Roofline) {
+  auto *input =
+      mod_.createPlaceholder(ElemKind::FloatTy, {1, 32}, "input", false);
+  auto *w1 = mod_.createConstant(ElemKind::FloatTy, {32, 16}, "w1");
+  auto *b1 = mod_.createConstant(ElemKind::FloatTy, {16}, "b1");
+  ctx_.allocate(input);
+  w1->getHandle<>().randomize(-2.0, 2.0, mod_.getPRNG());
+  b1->getHandle<>().randomize(-2.0, 2.0, mod_.getPRNG());
+
+  // Initial FC.
+  Node *I = F_->createFullyConnected("initial_fc", input, w1, b1);
+  I = F_->createSigmoid("initial_sigmoid", I);
+
+  // Left branch.
+  auto *w2 = mod_.createConstant(ElemKind::FloatTy, {16, 16}, "w2");
+  auto *b2 = mod_.createConstant(ElemKind::FloatTy, {16}, "b2");
+  w2->getHandle<>().randomize(-2.0, 2.0, mod_.getPRNG());
+  b2->getHandle<>().randomize(-2.0, 2.0, mod_.getPRNG());
+  Node *L = F_->createFullyConnected("left_fc1", I, w2, b2);
+  L = F_->createSigmoid("left_sigmoid1", L);
+  auto *w3 = mod_.createConstant(ElemKind::FloatTy, {16, 8}, "w3");
+  auto *b3 = mod_.createConstant(ElemKind::FloatTy, {8}, "b3");
+  w3->getHandle<>().randomize(-2.0, 2.0, mod_.getPRNG());
+  b3->getHandle<>().randomize(-2.0, 2.0, mod_.getPRNG());
+  L = F_->createFullyConnected("left_fc2", L, w3, b3);
+  L = F_->createSigmoid("left_sigmoid2", L);
+
+  // Right branch.
+  auto *w4 = mod_.createConstant(ElemKind::FloatTy, {16, 16}, "w4");
+  auto *b4 = mod_.createConstant(ElemKind::FloatTy, {16}, "b4");
+  w4->getHandle<>().randomize(-2.0, 2.0, mod_.getPRNG());
+  b4->getHandle<>().randomize(-2.0, 2.0, mod_.getPRNG());
+  Node *R = F_->createFullyConnected("right_fc1", I, w4, b4);
+  R = F_->createSigmoid("right_sigmoid1", R);
+  auto *w5 = mod_.createConstant(ElemKind::FloatTy, {16, 8}, "w5");
+  auto *b5 = mod_.createConstant(ElemKind::FloatTy, {8}, "b5");
+  w5->getHandle<>().randomize(-2.0, 2.0, mod_.getPRNG());
+  b5->getHandle<>().randomize(-2.0, 2.0, mod_.getPRNG());
+  R = F_->createFullyConnected("right_fc2", R, w5, b5);
+  R = F_->createSigmoid("right_sigmoid2", R);
+
+  // Join branches.
+  auto *mul = F_->createMul("mul", L, R);
+  auto *save = F_->createSave("ret", mul);
+  auto &res = *ctx_.allocate(save->getPlaceholder());
+
+  // Infer using the un-partitioned graph.
+  Tensor in(ElemKind::FloatTy, {1, 32});
+  ExecutionEngine EE;
+
+  EE.compile(CompilationMode::Infer, F_);
+  updateInputPlaceholders(ctx_, {input}, {&in});
+  EE.run(ctx_);
+  Tensor ref = res.clone();
+
+  std::unordered_map<Node *, std::string> nodeNamesMap;
+  for (auto &node : F_->getNodes()) {
+    nodeNamesMap[&node] = node.getName();
+  }
+
+  std::vector<DeviceInfo> devices = {{3072, 100, 10, 0.1, 1, 0.05},
+                                     {3072, 100, 10, 0.1, 1, 0.05},
+                                     {3072, 100, 10, 0.1, 1, 0.05}};
+  Partitioner myPartitioner(&mod_, devices);
+
+  DAGNodeList myList = std::move(myPartitioner.Partition());
+
+  // check compute costs
+  std::unordered_map<std::string, float> expectedComputeTime{
+      {"initial_sigmoid", 128},
+      {"left_sigmoid2", 64},
+      {"fc_add_bias3", 192},
+      {"right_sigmoid1", 128},
+      {"mul", 96},
+      {"fc_add_bias2", 96},
+      {"ret", 0},
+      {"fc_dot", 21760},
+      {"left_sigmoid1", 128},
+      {"fc_add_bias", 192},
+      {"fc_dot1", 10240},
+      {"right_sigmoid2", 64},
+      {"fc_add_bias1", 192},
+      {"fc_dot2", 5120},
+      {"fc_dot3", 10240},
+      {"fc_dot4", 5120},
+      {"fc_add_bias4", 96},
+  };
+  ASSERT_EQ(myPartitioner.getComputeTime().size(), expectedComputeTime.size());
+  for (auto &el : myPartitioner.getComputeTime()) {
+    Node *n = el.first;
+    float expected = expectedComputeTime[nodeNamesMap[n].c_str()];
+    float res = el.second;
+    ASSERT_EQ(expected, res);
+  }
+
+  ASSERT_EQ(mod_.getFunctions().size(), 3);
+  ASSERT_EQ(myList.roots.size(), 1);
+}


### PR DESCRIPTION
*Description*: 
The PR adds cost functions in terms of compute and memory bandwidth costs so that later stages in partitioning can use them. 

*Testing*:
Add a test with manually computed bounds into PartitionerTest.

*Documentation*:
The PR adds a field to the Partitioner class: ComputeTimeMapTy computeTime_ in Partitioner.h. It adds a function to fill out these fields. 

The field is a map from each Node in the Function being partitioned to the corresponding roofline for the op. This roofline is computed as the max of compute time, and the SRAM/DRAM read+write times for the inputs and outputs of the node. In order to compute these rooflines, fields have been added to DeviceInfo struct in RuntimeTypes.h

The PR is related to Graph Partitioning #2298
