### PR TITLE
[Graph] keep the dotFile

### DIFF
--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -262,7 +262,6 @@ void Module::dumpDAG() {
   llvm::SmallString<64> dotPath;
   llvm::sys::fs::createTemporaryFile("dotty_graph_dump", "dot", dotPath);
   dumpDAG(dotPath);
-  llvm::sys::fs::remove(dotPath);
 }
 
 void Module::dumpDAG(llvm::StringRef dotFilename) {


### PR DESCRIPTION
*Description*: I think we need to keep the dot file after calling dumpDAG(). The use scenario is calling dumpDAG() in somewhere but user can't got the file. 
*Testing*:
*Documentation*:
[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
