### PR TITLE
[Partitioner] Fix a BFS issue.

### DIFF
--- a/include/glow/Partitioner/PartitionerUtils.h
+++ b/include/glow/Partitioner/PartitionerUtils.h
@@ -35,8 +35,8 @@ struct GraphMemInfo {
   GraphMemInfo() : inMemSize(0), outMemSize(0), constMemSize(0){};
 };
 
-/// A list of <level, nodelist> with BFS order.
-using BFSLevel = std::vector<std::pair<int, std::vector<Node *>>>;
+/// A list of <nodelist> with BFS order.
+using BFSLevel = std::vector<std::vector<Node *>>;
 
 /// Visit nodes if Function \p F in BFS order and return the nodes by levels
 /// (the longest distance between one node and the root).

--- a/lib/Partitioner/Partitioner.cpp
+++ b/lib/Partitioner/Partitioner.cpp
@@ -238,8 +238,8 @@ NodeToFunctionMap Partitioner::selectPartitions(Function *F,
   size_t mem = 0;
   for (int i = level - 1; i >= 0; i--) {
     size_t tmp = 0;
-    for (size_t j = 0, e = bfs[i].second.size(); j < e; j++) {
-      Node *N = bfs[i].second[j];
+    for (size_t j = 0, e = bfs[i].size(); j < e; j++) {
+      Node *N = bfs[i][j];
       tmp += memUsage_[N];
     }
     if (mem + tmp > availableMemory) {
@@ -269,8 +269,8 @@ NodeToFunctionMap Partitioner::selectPartitions(Function *F,
     mapping.createPartition(newF);
     size_t mem = 0;
     for (int i = k > 0 ? cut[k - 1] : level - 1; i > cut[k]; i--) {
-      for (size_t j = 0, e1 = bfs[i].second.size(); j < e1; j++) {
-        Node *N = bfs[i].second[j];
+      for (size_t j = 0, e1 = bfs[i].size(); j < e1; j++) {
+        Node *N = bfs[i][j];
         if (mem + memUsage_[N] > availableMemory) {
           newF = F->getParent()->createFunction(
               std::string(F->getName()) + "_part" + std::to_string(++color));


### PR DESCRIPTION
*Description*:

When I run a testcase for several times, I found the final partitions of each run could be a little bit different. It was caused by the sequence of the nodes of each BFS levels (The key of the map we used is a pointer, which could be different value for each run. ) Therefore, to make sure the results are consistent for each run, I would like to add a sort for each level.

*Testing*:
unittest.
*Documentation*:
[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
