### PR TITLE
Refactor Backend::compile so it takes an options struct.

### DIFF
--- a/examples/tracing-compare.cpp
+++ b/examples/tracing-compare.cpp
@@ -73,7 +73,9 @@ std::unique_ptr<CompiledFunction> compileModel(Module &module,
 
   llvm::outs() << "Starting compile.\n";
   backend->optimizeFunction(CompilationMode::Infer, F);
-  return backend->instrumentAndCompile(F);
+  CompileOptions opts;
+  opts.autoInstrument = true;
+  return backend->compile(F, opts);
 }
 
 std::future<ResultCode> addToDevice(unsigned int id, DeviceManager *device,

--- a/lib/Backends/CPU/CPUBackend.h
+++ b/lib/Backends/CPU/CPUBackend.h
@@ -51,13 +51,8 @@ public:
   std::unique_ptr<CompiledFunction>
   compileIRWithoutConstants(IRFunction *IR) const;
 
-  std::unique_ptr<CompiledFunction> compile(Function *F) const override;
-
   std::unique_ptr<CompiledFunction>
-  instrumentAndCompile(Function *F) const override;
-
-  std::unique_ptr<CompiledFunction>
-  compileWithoutConstants(Function *F) const override;
+  compile(Function *F, const CompileOptions &opts) const override;
 
   void save(Function *F, llvm::StringRef outputDir,
             llvm::StringRef networkName) const override;

--- a/lib/Backends/Interpreter/Interpreter.h
+++ b/lib/Backends/Interpreter/Interpreter.h
@@ -44,13 +44,8 @@ public:
   std::unique_ptr<CompiledFunction>
   compileIRWithoutConstants(std::unique_ptr<IRFunction> IR) const;
 
-  std::unique_ptr<CompiledFunction> compile(Function *F) const override;
-
   std::unique_ptr<CompiledFunction>
-  instrumentAndCompile(Function *F) const override;
-
-  std::unique_ptr<CompiledFunction>
-  compileWithoutConstants(Function *F) const override;
+  compile(Function *F, const CompileOptions &opts) const override;
 
   bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override;
 

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -1559,13 +1559,18 @@ OCLBackend::compileIRWithoutConstants(std::unique_ptr<IRFunction> IR) const {
       generateRuntimeBundle(*IR, allocator, allocator, allocator);
   return llvm::make_unique<OpenCLFunction>(std::move(IR), bundle);
 }
-std::unique_ptr<CompiledFunction> OCLBackend::compile(Function *F) const {
-  auto IR = generateAndOptimizeIR(F, *this, shouldShareBuffers());
-  return compileIR(std::move(IR));
-}
 
 std::unique_ptr<CompiledFunction>
-OCLBackend::compileWithoutConstants(Function *F) const {
+OCLBackend::compile(Function *F, const CompileOptions &opts) const {
+  if (opts.autoInstrument) {
+    GLOW_UNREACHABLE("Instrumentation not supported on this Backend");
+  }
+
   auto IR = generateAndOptimizeIR(F, *this, shouldShareBuffers());
+
+  if (opts.collectConstants) {
+    return compileIR(std::move(IR));
+  }
+
   return compileIRWithoutConstants(std::move(IR));
 }

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -177,9 +177,8 @@ public:
   std::unique_ptr<CompiledFunction>
   compileIRWithoutConstants(std::unique_ptr<IRFunction> IR) const;
 
-  std::unique_ptr<CompiledFunction> compile(Function *F) const override;
   std::unique_ptr<CompiledFunction>
-  compileWithoutConstants(Function *F) const override;
+  compile(Function *F, const CompileOptions &opts) const override;
 
   bool transformPostLowering(Function *F, CompilationMode mode) const override;
 

--- a/tests/unittests/BackendCorrectnessTest.cpp
+++ b/tests/unittests/BackendCorrectnessTest.cpp
@@ -255,14 +255,11 @@ public:
 
   BackendKind getBackendKind() const override { return BackendKind::CPU; }
 
-  std::unique_ptr<CompiledFunction> compile(Function *F) const override {
-    return backend_->compile(F);
+  std::unique_ptr<CompiledFunction>
+  compile(Function *F, const CompileOptions &opts) const override {
+    return backend_->compile(F, opts);
   }
 
-  std::unique_ptr<CompiledFunction>
-  compileWithoutConstants(Function *F) const override {
-    return backend_->compile(F);
-  }
   std::unique_ptr<CompiledFunction>
   compileIR(std::unique_ptr<IRFunction> IR) const override {
     return backend_->compileIR(std::move(IR));

--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -168,8 +168,8 @@ TEST_P(BackendTest, debugPrint) {
   function->tearDownRuns();
 }
 
-/// Test the compileWithoutConstants method on the backend completes without
-/// error.
+/// Test the compile method on the backend completes without error when
+/// collectConstants is false.
 TEST_P(BackendTest, CompileWithoutConstants) {
   Module mod;
   Context ctx;
@@ -181,7 +181,9 @@ TEST_P(BackendTest, CompileWithoutConstants) {
   auto *save = F->createSave("save", pow);
   ctx.allocate(save->getPlaceholder());
   std::unique_ptr<Backend> backend(createBackend(GetParam()));
-  auto function = backend->compileWithoutConstants(F);
+  CompileOptions opts;
+  opts.collectConstants = false;
+  auto function = backend->compile(F, opts);
 }
 
 /// This test checks that we can compile a function without depending on the

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -42,12 +42,8 @@ class MockBackend : public Backend {
     return BackendKind::Interpreter;
   }
 
-  std::unique_ptr<CompiledFunction> compile(Function *F) const override {
-    return llvm::make_unique<MockFunction>();
-  }
-
   std::unique_ptr<CompiledFunction>
-  compileWithoutConstants(Function *F) const override {
+  compile(Function *F, const CompileOptions &) const override {
     return llvm::make_unique<MockFunction>();
   }
 
@@ -75,12 +71,8 @@ class MockBackendCustomIRGen : public Backend {
     return BackendKind::Interpreter;
   }
 
-  std::unique_ptr<CompiledFunction> compile(Function *F) const override {
-    return llvm::make_unique<MockFunction>();
-  }
-
   std::unique_ptr<CompiledFunction>
-  compileWithoutConstants(Function *F) const override {
+  compile(Function *F, const CompileOptions &) const override {
     return llvm::make_unique<MockFunction>();
   }
 

--- a/tests/unittests/QuantizationTest.cpp
+++ b/tests/unittests/QuantizationTest.cpp
@@ -874,14 +874,11 @@ public:
     return BackendKind::Interpreter;
   }
 
-  std::unique_ptr<CompiledFunction> compile(Function *F) const override {
-    return backend_->compile(F);
+  std::unique_ptr<CompiledFunction>
+  compile(Function *F, const CompileOptions &opts) const override {
+    return backend_->compile(F, opts);
   }
 
-  std::unique_ptr<CompiledFunction>
-  compileWithoutConstants(Function *F) const override {
-    return backend_->compile(F);
-  }
   bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override {
     if (opKind == Kinded::Kind::SoftMaxNodeKind ||
         opKind == Kinded::Kind::LocalResponseNormalizationNodeKind ||

--- a/tests/unittests/TraceEventsTest.cpp
+++ b/tests/unittests/TraceEventsTest.cpp
@@ -239,7 +239,9 @@ TEST_P(TraceEventsTest, automaticInstrumentation) {
   ctx.allocate(EE_.getModule().getPlaceholders());
   auto *backend = EE_.getBackend();
   backend->optimizeFunction(CompilationMode::Infer, F);
-  EE_.insertCompiledFunction(F->getName(), backend->instrumentAndCompile(F));
+  CompileOptions opts;
+  opts.autoInstrument = true;
+  EE_.insertCompiledFunction(F->getName(), backend->compile(F, opts));
 
   updateInputPlaceholders(ctx, {inputPH}, {&inputs});
   EE_.run(ctx);
@@ -272,7 +274,9 @@ TEST_P(TraceEventsTest, manualAndAutomatic) {
   ctx.allocate(EE_.getModule().getPlaceholders());
   auto *backend = EE_.getBackend();
   backend->optimizeFunction(CompilationMode::Infer, F);
-  EE_.insertCompiledFunction(F->getName(), backend->instrumentAndCompile(F));
+  CompileOptions opts;
+  opts.autoInstrument = true;
+  EE_.insertCompiledFunction(F->getName(), backend->compile(F, opts));
 
   updateInputPlaceholders(ctx, {inputPH}, {&inputs});
   EE_.run(ctx);


### PR DESCRIPTION
*Description*: We have 3 different methods in the Backend to invoke compile: `compileWithoutConstants()`, `instrumentAndCompile()` and the plain `compile()` (uh oh what if you want to compile without constants but with instrumentation?!). This PR collapses the three down to a single compile() function which takes a CompileOptions struct which indicates how the compile should be done. At the moment it's got only those options (collectConstants & autoInstrument).
*Testing*: unit tests.
*Documentation*: This changes the Backend interface and so all backends will need an update, but I kept the standard `compile()`to make migration easier.