### PR TITLE
[Easy] Add transformPostLowering call to checkGraphCompatibility

### DIFF
--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -54,6 +54,8 @@ onnxStatus BackendId::checkGraphCompatibility(const void *onnxModel,
 
   glow::lower(function, /* loweredMap */ nullptr, glowBackend_.get());
 
+  glowBackend_->transformPostLowering(function, CompilationMode::Infer);
+
   const auto &nodes = function->getNodes();
 
   for (const auto &node : nodes) {

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -55,7 +55,7 @@ onnxStatus BackendId::checkGraphCompatibility(const void *onnxModel,
   glow::lower(function, /* loweredMap */ nullptr, glowBackend_.get());
 
   // Call the backend's transformPostLowering to match the normal compilation
-  // pipeline then DCE any nodes that are no longer needed
+  // pipeline then DCE any nodes that are no longer needed.
   if (glowBackend_->transformPostLowering(function, CompilationMode::Infer)) {
     glow::DCE(function);
   }

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -54,7 +54,11 @@ onnxStatus BackendId::checkGraphCompatibility(const void *onnxModel,
 
   glow::lower(function, /* loweredMap */ nullptr, glowBackend_.get());
 
-  glowBackend_->transformPostLowering(function, CompilationMode::Infer);
+  // Call the backend's transformPostLowering to match the normal compilation
+  // pipeline then DCE any nodes that are no longer needed
+  if (glowBackend_->transformPostLowering(function, CompilationMode::Infer)) {
+    glow::DCE(function);
+  }
 
   const auto &nodes = function->getNodes();
 


### PR DESCRIPTION
*Description*:
Graphs should go through transformPostLowering in checkGraphCompatibility because this is what will happen in initNet

*Testing*:
ninja check

*Documentation*:
Fixes #2190 
