### PR TITLE
[runtime] Initialize RuntimeBundle safely

### DIFF
--- a/include/glow/Backends/BackendUtils.h
+++ b/include/glow/Backends/BackendUtils.h
@@ -43,13 +43,13 @@ class RuntimeBundle {
   /// Map from symbol name to a RuntimeSymbolInfo.
   SymbolTableTy symbolTable_;
   /// Pointer to memory containing the weights for execution.
-  uint8_t *constants_;
+  uint8_t *constants_{nullptr};
   /// Amount of memory needed for weights.
-  size_t constantWeightVarsMemSize_;
+  size_t constantWeightVarsMemSize_{0};
   /// Amount of memory needed for mutable vars.
-  size_t mutableWeightVarsMemSize_;
+  size_t mutableWeightVarsMemSize_{0};
   /// Amount of memory needed for activations.
-  size_t activationsMemSize_;
+  size_t activationsMemSize_{0};
 
 public:
   /// Get Constant Weights memory size.


### PR DESCRIPTION
*Description*: RuntimeBundle has a default constructor but no default initializers for its members.  But the destructor reads `constants_` to determine if it needs to free, and thus can free a garbage pointer.

*Testing*: This must have been missed because all our backends now create compiled functions with runtime bundles?  But I have a private backend that does not use runtime bundle, and thus hit this problem.  In an ideal world I would write a test case demonstrating this crash...

*Documentation*:
