### PR TITLE
[ee] Don't leak DeviceManagers

### DIFF
--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -33,8 +33,6 @@ ExecutionEngine::ExecutionEngine(BackendKind backendKind) {
 /// Set the code generator kind to \p backendKind.
 void ExecutionEngine::setBackend(BackendKind backendKind) {
   setBackend(createBackend(backendKind));
-  device_ = runtime::DeviceManager::createDeviceManager(backendKind,
-                                                        "ExecutionEngine");
 }
 
 /// Set the code generator to the given \p backend.


### PR DESCRIPTION
*Description*: This seems like a leak, since we assign device_ in setBackend (below), and LSAN reports it to me, but only when I'm using an experimental private backend.  I don't see any such warning on trunk, which makes me suspicious that I've done something wrong...

*Testing*: 

*Documentation*:
