### PR TITLE
Refactor optimize() functions to take a CompileOptions

### DIFF
--- a/examples/resnet-concurrent.cpp
+++ b/examples/resnet-concurrent.cpp
@@ -75,8 +75,11 @@ std::unique_ptr<CompiledFunction> compileModel(Module &module) {
   Function *F = module.getFunction("resnet50");
 
   llvm::outs() << "Starting compile.\n";
-  backend->optimizeFunction(CompilationMode::Infer, F);
-  return backend->compile(F);
+
+  CompilationOptions opts;
+  opts.mode = CompilationMode::Infer;
+  backend->optimizeFunction(F, opts);
+  return backend->compile(F, opts);
 }
 
 /// Loads the CompliedFunction into device \p device.

--- a/examples/tracing-compare.cpp
+++ b/examples/tracing-compare.cpp
@@ -72,9 +72,10 @@ std::unique_ptr<CompiledFunction> compileModel(Module &module,
   Function *F = module.getFunction("resnet50");
 
   llvm::outs() << "Starting compile.\n";
-  backend->optimizeFunction(CompilationMode::Infer, F);
-  CompileOptions opts;
+  CompilationOptions opts;
+  opts.mode = CompilationMode::Infer;
   opts.autoInstrument = true;
+  backend->optimizeFunction(F, opts);
   return backend->compile(F, opts);
 }
 

--- a/include/glow/Backends/Backend.h
+++ b/include/glow/Backends/Backend.h
@@ -16,6 +16,7 @@
 #ifndef GLOW_BACKENDS_BACKEND_H
 #define GLOW_BACKENDS_BACKEND_H
 
+#include "glow/Backends/CompilationOptions.h"
 #include "glow/Backends/CompiledFunction.h"
 #include "glow/Base/Traits.h"
 #include "glow/Optimizer/Optimizer.h"
@@ -35,15 +36,6 @@ enum class BackendKind {
   CPU,         // Compile and run the code on the host.
 };
 
-/// Configuration options for the compile() method on Backend.
-struct CompileOptions {
-  /// Allocate and collect constant Tensors in the RuntimeBundle.
-  bool collectConstants{true};
-
-  /// Insert TraceEvents between all instructions for profiling.
-  bool autoInstrument{false};
-};
-
 // This is the interface that glow backends need to implement.
 class Backend {
 public:
@@ -54,13 +46,13 @@ public:
   virtual BackendKind getBackendKind() const = 0;
 
   virtual std::unique_ptr<CompiledFunction> compile(Function *F) const {
-    CompileOptions opts;
+    CompilationOptions opts;
     return compile(F, opts);
   }
 
   /// Generate code for input function \param F.
   virtual std::unique_ptr<CompiledFunction>
-  compile(Function *F, const CompileOptions &opts) const = 0;
+  compile(Function *F, const CompilationOptions &opts) const = 0;
 
   /// Save the bundle for \p F for a later standalone execution
   /// in \p outputDir. Make \p networkName the function name for
@@ -76,7 +68,8 @@ public:
   /// backend may insert backend-specific nodes. The backend is responsible for
   /// cleaning up after itself.
   /// \returns True if the graph was modified.
-  virtual bool transformPostLowering(Function *F, CompilationMode mode) const {
+  virtual bool transformPostLowering(Function *F,
+                                     const CompilationOptions &opts) const {
     return false;
   }
 
@@ -92,8 +85,8 @@ public:
   /// performed.
   virtual bool shouldShareBuffers() const { return true; }
 
-  /// Optimize the Function \p F given compilation mode \p mode.
-  void optimizeFunction(CompilationMode mode, Function *F) const;
+  /// Optimize the Function \p F given compilation options \p opts.
+  void optimizeFunction(Function *F, const CompilationOptions &opts) const;
 
   /// \returns true if Backend generated Instruction for Node \p N,
   /// using IRGenVisitor \p irgen.

--- a/include/glow/Backends/CompilationOptions.h
+++ b/include/glow/Backends/CompilationOptions.h
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_BACKENDS_COMPILEOPTIONS_H
+#define GLOW_BACKENDS_COMPILEOPTIONS_H
+
+namespace glow {
+
+enum class CompilationMode {
+  Train, /// Compile the graph in preperation for training.
+  Infer, /// Compile the graph for inference. Notice that this operation
+         /// changes the graph in a way that is not reversible.
+};
+
+/// Configuration options for the compile() method on Backend.
+struct CompilationOptions {
+  CompilationMode mode{CompilationMode::Infer};
+
+  /// Allocate and collect constant Tensors in the RuntimeBundle.
+  bool collectConstants{true};
+
+  /// Insert TraceEvents between all instructions for profiling.
+  bool autoInstrument{false};
+};
+
+}; // namespace glow
+
+#endif // GLOW_BACKENDS_COMPILEOPTIONS_H

--- a/include/glow/ExecutionEngine/ExecutionEngine.h
+++ b/include/glow/ExecutionEngine/ExecutionEngine.h
@@ -104,6 +104,10 @@ public:
   /// be added to the collection of previously compiled functions otherwise any
   /// previously compiled functions will be removed first. This method should be
   /// invoked before the run method.
+  void compile(Function *F, const CompilationOptions &opts,
+               bool clearOtherFunctions = true);
+
+  /// A convenience function for the most common type of compile.
   void compile(CompilationMode mode, Function *F,
                bool clearOtherFunctions = true);
 
@@ -113,8 +117,8 @@ public:
   /// Make \p networkName the function name for
   /// the entry point of the network and prepend all generated
   /// files with this name.
-  void save(CompilationMode mode, Function *F, llvm::StringRef outputDir,
-            llvm::StringRef networkName);
+  void save(Function *F, const CompilationOptions &opts,
+            llvm::StringRef outputDir, llvm::StringRef networkName);
 
   /// Context aware single execution of a function. If more than one function
   /// has been compiled by this ExecutionEngine then a name must be supplied

--- a/include/glow/Optimizer/Optimizer.h
+++ b/include/glow/Optimizer/Optimizer.h
@@ -16,6 +16,7 @@
 #ifndef GLOW_OPTIMIZER_OPTIMIZER_H
 #define GLOW_OPTIMIZER_OPTIMIZER_H
 
+#include "glow/Backends/CompilationOptions.h"
 #include "glow/Quantization/Quantization.h"
 
 #include "llvm/ADT/ArrayRef.h"
@@ -30,15 +31,10 @@ class Module;
 class Context;
 class Placeholder;
 
-enum class CompilationMode {
-  Train, /// Compile the graph in preperation for training.
-  Infer, /// Compile the graph for inference. Notice that this operation
-         /// changes the graph in a way that is not reversible.
-};
-
 /// Perform optimizations on the IR representation.
 void optimize(IRFunction &M, bool shouldShareBuffers);
 /// Perform optimizations on the graph representation.
+void optimize(Function *F, const CompilationOptions &opts);
 void optimize(Function *F, CompilationMode mode);
 
 /// Lower the high-level neural network nodes found in \p F into low-level

--- a/lib/Backends/Backend.cpp
+++ b/lib/Backends/Backend.cpp
@@ -22,24 +22,25 @@
 
 using namespace glow;
 
-void Backend::optimizeFunction(CompilationMode mode, Function *F) const {
+void Backend::optimizeFunction(Function *F,
+                               const CompilationOptions &opts) const {
   // Verify the function pre-optimization/lowering.
   assert(F->verify() && "Function must be valid");
 
   // Optimize the graph.
-  ::glow::optimize(F, mode);
+  ::glow::optimize(F, opts);
 
   // Lower the graph into a sequence of low-level linear algebra operations.
   ::glow::lower(F, /* loweredMap */ nullptr, this);
 
   // Optimize the graph again.
-  ::glow::optimize(F, mode);
+  ::glow::optimize(F, opts);
 
   // Allow the backend to transform the graph after lowering.
-  if (transformPostLowering(F, mode)) {
+  if (transformPostLowering(F, opts)) {
     // Optimize the graph again after the backend transformation.
     // In particular, DCE is very likely to be useful.
-    ::glow::optimize(F, mode);
+    ::glow::optimize(F, opts);
   }
 }
 

--- a/lib/Backends/CPU/CMakeLists.txt
+++ b/lib/Backends/CPU/CMakeLists.txt
@@ -13,7 +13,7 @@ set(CMAKE_LLIR_CREATE_SHARED_LIBRARY "${LLVM_LINK_BIN} -o <TARGET> <OBJECTS>")
 set(CMAKE_LLIR_CREATE_SHARED_MODULE "${LLVM_LINK_BIN} -o <TARGET> <OBJECTS>")
 set(CMAKE_LLIR_CREATE_STATIC_LIBRARY "${LLVM_LINK_BIN} -o <TARGET> <OBJECTS>")
 
-set(CPURunttimeCompileOptions
+set(CPURunttimeCompilationOptions
       -std=c++14
       -ffast-math
       -fno-finite-math-only
@@ -35,7 +35,7 @@ foreach(libjit_src_file ${libjit_files})
 
   add_custom_command(
     OUTPUT  ${libjit_obj_file}
-    COMMAND ${CLANG_BIN} -c ${libjit_src_file_path} ${CPURunttimeCompileOptions} -o ${libjit_obj_file}
+    COMMAND ${CLANG_BIN} -c ${libjit_src_file_path} ${CPURunttimeCompilationOptions} -o ${libjit_obj_file}
     DEPENDS ${libjit_src_file_path}
     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})
 

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -134,7 +134,7 @@ CPUBackend::compileIRWithoutConstants(IRFunction *IR) const {
 }
 
 std::unique_ptr<CompiledFunction>
-CPUBackend::compile(Function *F, const CompileOptions &opts) const {
+CPUBackend::compile(Function *F, const CompilationOptions &opts) const {
   TraceInfo traceInfo = buildManualTraceInfo(F);
   auto IR = generateAndOptimizeIR(F, *this, shouldShareBuffers());
 

--- a/lib/Backends/CPU/CPUBackend.h
+++ b/lib/Backends/CPU/CPUBackend.h
@@ -52,12 +52,13 @@ public:
   compileIRWithoutConstants(IRFunction *IR) const;
 
   std::unique_ptr<CompiledFunction>
-  compile(Function *F, const CompileOptions &opts) const override;
+  compile(Function *F, const CompilationOptions &opts) const override;
 
   void save(Function *F, llvm::StringRef outputDir,
             llvm::StringRef networkName) const override;
 
-  bool transformPostLowering(Function *F, CompilationMode mode) const override;
+  bool transformPostLowering(Function *F,
+                             const CompilationOptions &opts) const override;
 
   bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override;
 

--- a/lib/Backends/CPU/Transforms.cpp
+++ b/lib/Backends/CPU/Transforms.cpp
@@ -115,7 +115,7 @@ static Node *optimizeCPUMaxSplat(MaxNode *MN, Function *F) {
 }
 
 bool CPUBackend::transformPostLowering(Function *F,
-                                       CompilationMode mode) const {
+                                       const CompilationOptions &) const {
   bool changed = false;
   for (auto &node : F->getNodes()) {
     // Try to replace generic convolution with cpu-optimized version.

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -26,7 +26,7 @@
 using namespace glow;
 
 std::unique_ptr<CompiledFunction>
-Interpreter::compile(Function *F, const CompileOptions &opts) const {
+Interpreter::compile(Function *F, const CompilationOptions &opts) const {
   TraceInfo traceInfo = buildManualTraceInfo(F);
   auto IR = generateAndOptimizeIR(F, *this, shouldShareBuffers());
 

--- a/lib/Backends/Interpreter/Interpreter.h
+++ b/lib/Backends/Interpreter/Interpreter.h
@@ -45,7 +45,7 @@ public:
   compileIRWithoutConstants(std::unique_ptr<IRFunction> IR) const;
 
   std::unique_ptr<CompiledFunction>
-  compile(Function *F, const CompileOptions &opts) const override;
+  compile(Function *F, const CompilationOptions &opts) const override;
 
   bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override;
 

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -1561,7 +1561,7 @@ OCLBackend::compileIRWithoutConstants(std::unique_ptr<IRFunction> IR) const {
 }
 
 std::unique_ptr<CompiledFunction>
-OCLBackend::compile(Function *F, const CompileOptions &opts) const {
+OCLBackend::compile(Function *F, const CompilationOptions &opts) const {
   if (opts.autoInstrument) {
     GLOW_UNREACHABLE("Instrumentation not supported on this Backend");
   }

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -178,9 +178,10 @@ public:
   compileIRWithoutConstants(std::unique_ptr<IRFunction> IR) const;
 
   std::unique_ptr<CompiledFunction>
-  compile(Function *F, const CompileOptions &opts) const override;
+  compile(Function *F, const CompilationOptions &opts) const override;
 
-  bool transformPostLowering(Function *F, CompilationMode mode) const override;
+  bool transformPostLowering(Function *F,
+                             const CompilationOptions &opts) const override;
 
   bool isOpSupported(Kinded::Kind opKind, ElemKind elementTy) const override {
     // Check quantization support.

--- a/lib/Backends/OpenCL/Transforms.cpp
+++ b/lib/Backends/OpenCL/Transforms.cpp
@@ -27,10 +27,10 @@ using namespace glow;
 
 /// Perform OpenCL specific post-lowering graph transformation.
 bool OCLBackend::transformPostLowering(Function *F,
-                                       CompilationMode mode) const {
+                                       const CompilationOptions &opts) const {
   // NCHW transformation is not supported in training mode yet, because of some
   // issues with gradient nodes.
-  if (mode == CompilationMode::Train)
+  if (opts.mode == CompilationMode::Train)
     return false;
 
   bool changed = false;

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -209,6 +209,13 @@ void glow::runBatch(ExecutionEngine &EE, Context &ctx, size_t iterations,
 
 void ExecutionEngine::compile(CompilationMode mode, Function *F,
                               bool clearOtherFunctions) {
+  CompilationOptions opts;
+  opts.mode = mode;
+  compile(F, opts, clearOtherFunctions);
+}
+
+void ExecutionEngine::compile(Function *F, const CompilationOptions &opts,
+                              bool clearOtherFunctions) {
   llvm::StringRef name = F->getName();
 
   if (clearOtherFunctions) {
@@ -218,14 +225,14 @@ void ExecutionEngine::compile(CompilationMode mode, Function *F,
   assert(!compiledFunctions_.count(name) &&
          "A function with this name has already been compiled.");
 
-  backend_->optimizeFunction(mode, F);
-  auto func = backend_->compile(F);
+  backend_->optimizeFunction(F, opts);
+  auto func = backend_->compile(F, opts);
   insertCompiledFunction(name, std::move(func));
 }
 
-void ExecutionEngine::save(CompilationMode mode, Function *F,
+void ExecutionEngine::save(Function *F, const CompilationOptions &opts,
                            llvm::StringRef outputDir,
                            llvm::StringRef networkName) {
-  backend_->optimizeFunction(mode, F);
+  backend_->optimizeFunction(F, opts);
   backend_->save(F, outputDir, networkName);
 }

--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -2365,7 +2365,7 @@ void glow::convertPlaceholdersToConstants(Function *F, const Context &ctx,
   }
 }
 
-void glow::optimize(Function *F, CompilationMode mode) {
+void glow::optimize(Function *F, const CompilationOptions &opts) {
   // Optimize may be called after backend specific transformations and some
   // nodes may have become unused. It is a good idea to remove them, before
   // proceeding with any further optimizations.
@@ -2383,7 +2383,7 @@ void glow::optimize(Function *F, CompilationMode mode) {
   // Reshapes and transposes can prevent other optimizations from triggering,
   // so try to optimize them out first.
   optimizeReshape(F);
-  if (mode == CompilationMode::Infer) {
+  if (opts.mode == CompilationMode::Infer) {
     transposeConstants(F);
   }
 
@@ -2408,7 +2408,7 @@ void glow::optimize(Function *F, CompilationMode mode) {
   // Perform Dead Code Elimination.
   DCE(F);
 
-  if (mode == CompilationMode::Infer) {
+  if (opts.mode == CompilationMode::Infer) {
     // Merge batch normalization operations.
     // Do after transpose constant folding, as weight transposes can prevent
     // the optimization from triggering.
@@ -2445,4 +2445,10 @@ void glow::optimize(Function *F, CompilationMode mode) {
 
   // Perform Dead Code Elimination.
   DCE(F);
+}
+
+void glow::optimize(Function *F, CompilationMode mode) {
+  CompilationOptions opts;
+  opts.mode = mode;
+  optimize(F, opts);
 }

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -57,8 +57,10 @@ ResultCode HostManager::addNetwork(Module *M) {
   // Optimize functions before passing to partitioner.
   // Currently hardcoding inference.
   if (backend_) {
+    CompilationOptions opts;
+    opts.mode = CompilationMode::Infer;
     for (auto F : M->getFunctions()) {
-      backend_->optimizeFunction(CompilationMode::Infer, F);
+      backend_->optimizeFunction(F, opts);
     }
   }
   auto partitioner = Partitioner(M, deviceInfo);

--- a/tests/unittests/BackendCorrectnessTest.cpp
+++ b/tests/unittests/BackendCorrectnessTest.cpp
@@ -256,7 +256,7 @@ public:
   BackendKind getBackendKind() const override { return BackendKind::CPU; }
 
   std::unique_ptr<CompiledFunction>
-  compile(Function *F, const CompileOptions &opts) const override {
+  compile(Function *F, const CompilationOptions &opts) const override {
     return backend_->compile(F, opts);
   }
 

--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -43,7 +43,9 @@ TEST(Interpreter, NotImplementedSave) {
   F->createSave("save",
                 mod.createPlaceholder(ElemKind::FloatTy, {2}, "A", false));
 
-  EXPECT_DEATH(EE.save(CompilationMode::Infer, F, "output", "network"), "");
+  CompilationOptions opts;
+  opts.mode = CompilationMode::Infer;
+  EXPECT_DEATH(EE.save(F, opts, "output", "network"), "");
 }
 
 TEST(Interpreter, profileQuantizationForANetwork) {
@@ -181,7 +183,7 @@ TEST_P(BackendTest, CompileWithoutConstants) {
   auto *save = F->createSave("save", pow);
   ctx.allocate(save->getPlaceholder());
   std::unique_ptr<Backend> backend(createBackend(GetParam()));
-  CompileOptions opts;
+  CompilationOptions opts;
   opts.collectConstants = false;
   auto function = backend->compile(F, opts);
 }

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -43,7 +43,7 @@ class MockBackend : public Backend {
   }
 
   std::unique_ptr<CompiledFunction>
-  compile(Function *F, const CompileOptions &) const override {
+  compile(Function *F, const CompilationOptions &) const override {
     return llvm::make_unique<MockFunction>();
   }
 
@@ -72,7 +72,7 @@ class MockBackendCustomIRGen : public Backend {
   }
 
   std::unique_ptr<CompiledFunction>
-  compile(Function *F, const CompileOptions &) const override {
+  compile(Function *F, const CompilationOptions &) const override {
     return llvm::make_unique<MockFunction>();
   }
 

--- a/tests/unittests/DeviceManagerTest.cpp
+++ b/tests/unittests/DeviceManagerTest.cpp
@@ -55,9 +55,11 @@ compileFunctions(BackendKind backendKind, Module *module,
                  std::vector<std::unique_ptr<CompiledFunction>> &backing) {
   FunctionMapTy results;
   auto *backend = createBackend(backendKind);
+  CompilationOptions opts;
+  opts.mode = CompilationMode::Infer;
   for (auto *F : module->getFunctions()) {
-    backend->optimizeFunction(CompilationMode::Infer, F);
-    auto f = backend->compile(F);
+    backend->optimizeFunction(F, opts);
+    auto f = backend->compile(F, opts);
     backing.push_back(std::move(f));
     results.emplace(F->getName(), backing.back().get());
   }

--- a/tests/unittests/QuantizationTest.cpp
+++ b/tests/unittests/QuantizationTest.cpp
@@ -875,7 +875,7 @@ public:
   }
 
   std::unique_ptr<CompiledFunction>
-  compile(Function *F, const CompileOptions &opts) const override {
+  compile(Function *F, const CompilationOptions &opts) const override {
     return backend_->compile(F, opts);
   }
 

--- a/tests/unittests/TraceEventsTest.cpp
+++ b/tests/unittests/TraceEventsTest.cpp
@@ -129,7 +129,9 @@ TEST_P(TraceEventsTest, manualEvents) {
   F->createTraceEvent("second half", "E", eventData, eventId++);
 
   ctx.allocate(EE_.getModule().getPlaceholders());
-  EE_.compile(CompilationMode::Infer, F);
+  CompilationOptions opts;
+  opts.mode = CompilationMode::Infer;
+  EE_.compile(F, opts);
 
   updateInputPlaceholders(ctx, {inputPH}, {&inputs});
   EE_.run(ctx);
@@ -170,7 +172,9 @@ TEST_P(TraceEventsTest, incompleteCoverage) {
   F->createTraceEvent("second half", "E", eventData, eventId++);
 
   ctx.allocate(EE_.getModule().getPlaceholders());
-  EE_.compile(CompilationMode::Infer, F);
+  CompilationOptions opts;
+  opts.mode = CompilationMode::Infer;
+  EE_.compile(F, opts);
 
   updateInputPlaceholders(ctx, {inputPH}, {&inputs});
   EE_.run(ctx);
@@ -207,7 +211,9 @@ TEST_P(TraceEventsTest, internalGap) {
   n = part_four(F, ctx, n);
 
   ctx.allocate(EE_.getModule().getPlaceholders());
-  EE_.compile(CompilationMode::Infer, F);
+  CompilationOptions opts;
+  opts.mode = CompilationMode::Infer;
+  EE_.compile(F, opts);
 
   updateInputPlaceholders(ctx, {inputPH}, {&inputs});
   EE_.run(ctx);
@@ -238,9 +244,10 @@ TEST_P(TraceEventsTest, automaticInstrumentation) {
 
   ctx.allocate(EE_.getModule().getPlaceholders());
   auto *backend = EE_.getBackend();
-  backend->optimizeFunction(CompilationMode::Infer, F);
-  CompileOptions opts;
+  CompilationOptions opts;
+  opts.mode = CompilationMode::Infer;
   opts.autoInstrument = true;
+  backend->optimizeFunction(F, opts);
   EE_.insertCompiledFunction(F->getName(), backend->compile(F, opts));
 
   updateInputPlaceholders(ctx, {inputPH}, {&inputs});
@@ -273,9 +280,10 @@ TEST_P(TraceEventsTest, manualAndAutomatic) {
 
   ctx.allocate(EE_.getModule().getPlaceholders());
   auto *backend = EE_.getBackend();
-  backend->optimizeFunction(CompilationMode::Infer, F);
-  CompileOptions opts;
+  CompilationOptions opts;
+  opts.mode = CompilationMode::Infer;
   opts.autoInstrument = true;
+  backend->optimizeFunction(F, opts);
   EE_.insertCompiledFunction(F->getName(), backend->compile(F, opts));
 
   updateInputPlaceholders(ctx, {inputPH}, {&inputs});
@@ -308,7 +316,9 @@ TEST_P(TraceEventsTest, onlyTraceEvents) {
   }
 
   ctx.allocate(EE_.getModule().getPlaceholders());
-  EE_.compile(CompilationMode::Infer, F);
+  CompilationOptions opts;
+  opts.mode = CompilationMode::Infer;
+  EE_.compile(F, opts);
 
   updateInputPlaceholders(ctx, {inputPH}, {&inputs});
   EE_.run(ctx);
@@ -353,7 +363,9 @@ TEST_P(TraceEventsTest, multipleBackingTensors) {
   F->createTraceEvent("event3", "E", eventData4, 0);
 
   ctx.allocate(EE_.getModule().getPlaceholders());
-  EE_.compile(CompilationMode::Infer, F);
+  CompilationOptions opts;
+  opts.mode = CompilationMode::Infer;
+  EE_.compile(F, opts);
 
   updateInputPlaceholders(ctx, {inputPH}, {&inputs});
   EE_.run(ctx);
@@ -401,7 +413,9 @@ TEST_P(TraceEventsTest, multipleRunsAreDistinct) {
   F->createTraceEvent("second half", "E", eventData, eventId++);
 
   ctx.allocate(EE_.getModule().getPlaceholders());
-  EE_.compile(CompilationMode::Infer, F);
+  CompilationOptions opts;
+  opts.mode = CompilationMode::Infer;
+  EE_.compile(F, opts);
 
   updateInputPlaceholders(ctx, {inputPH}, {&inputs});
 

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -325,12 +325,14 @@ void Loader::compile(Context &ctx) {
     ::optimize(F_, glow::CompilationMode::Infer);
   }
 
+  CompilationOptions opts;
+  opts.mode = CompilationMode::Infer;
   if (emittingBundle()) {
     // Emit IR for the graph, compile it and save as a bundle.
-    EE_.save(CompilationMode::Infer, F_, emitBundle, networkName);
+    EE_.save(F_, opts, emitBundle, networkName);
   } else {
     // Emit IR for the graph and compile it.
-    EE_.compile(CompilationMode::Infer, F_);
+    EE_.compile(F_, opts);
   }
 
   if (dumpGraphOpt) {


### PR DESCRIPTION
*Description*: As a follow up #2451, push the CompileOptions struct down into the Optimize functions as well for future expansion of optimization configuration. I kept the existing CompilationMode function to ease transition.
*Testing*: unit tests, w/ ASAN.
*Documentation*:
This changes the Backend interface and will require updating any new backends.
