### PR TITLE
Lower ReduceMean in Lower or optimize with AvgPool when possible.

### DIFF
--- a/docs/Optimizations.md
+++ b/docs/Optimizations.md
@@ -67,6 +67,12 @@ Below you can see the list of currently supported graph optimizations:
     This optimization performs a classic CSE with a goal of avoiding of any
     results that were computed already.
 
+  * Optimization of ReduceMean nodes
+
+    This optimization performs substitions of ReduceMean with AvgPool node if
+    the reduce parameters are suitable: input is 4D with last two dimensions
+    to be reduced. 
+
 #### Quantization specific optimizations
 
 Majority of the common optimizations above can be used on a quantized graph.

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -564,27 +564,31 @@ public:
   Node *createParallelBatchMatMul(llvm::StringRef name, NodeValue lhs,
                                   NodeValue rhs);
 
+  /// Create a node, performing BatchedReduceAdd operation. Output type is
+  /// based on the input \p batch type with dimensions specified with \p axes
+  /// removed.
   BatchedReduceAddNode *createBatchedReduceAdd(llvm::StringRef name,
                                                NodeValue batch,
-                                               unsigned_t axis);
+                                               llvm::ArrayRef<unsigned_t> axes);
 
+  /// Create a node, performing BatchedReduceAdd operation. Output type
+  /// matches input \p outTy type.
   BatchedReduceAddNode *createBatchedReduceAdd(llvm::StringRef name,
                                                TypeRef outTy, NodeValue batch,
-                                               unsigned_t axis);
+                                               llvm::ArrayRef<unsigned_t> axes);
 
-  /// Implements a batched reduce mean of the \p batch on the provided \p axis
-  /// with output type \p outTy with three nodes: a BatchedReduceAdd followed by
-  /// a DivNode with a SplatNode of the length of the \p axis
-  /// dimension. \returns the final DivNode.
-  DivNode *createBatchedReduceMean(llvm::StringRef name, TypeRef outTy,
-                                   NodeValue batch, unsigned_t axis);
+  /// Create a node, performing BatchedReduceMean operation. Output type
+  /// matches input \p outTy type.
+  BatchedReduceMeanNode *
+  createBatchedReduceMean(llvm::StringRef name, TypeRef outTy, NodeValue batch,
+                          llvm::ArrayRef<unsigned_t> axes);
 
-  /// Implements a batched reduce mean of the \p batch on the provided \p axis
-  /// with three nodes: a BatchedReduceAdd followed by a DivNode with a
-  /// SplatNode of the length of the \p axis dimension. \returns the final
-  /// DivNode.
-  DivNode *createBatchedReduceMean(llvm::StringRef name, NodeValue batch,
-                                   unsigned_t axis);
+  /// Create a node, performing BatchedReduceMean operation. Output type is
+  /// based on the input \p batch type with dimensions specified with \p axes
+  /// removed.
+  BatchedReduceMeanNode *
+  createBatchedReduceMean(llvm::StringRef name, NodeValue batch,
+                          llvm::ArrayRef<unsigned_t> axes);
 
   BatchedAddNode *createBatchedAdd(llvm::StringRef name, NodeValue batch,
                                    NodeValue sample);

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -796,6 +796,15 @@ bool LengthsSumNode::verify() const {
                            getLengths().dims().size(), size_t(1), this);
 }
 
+bool BatchedReduceMeanNode::verify() const {
+  bool isValid = checkType(getResult(), getBatch().getElementType(), this);
+
+  isValid &=
+      expectCompareTrue("Invalid shape", getBatch().dims().size(), size_t(0),
+                        this, CompareOperatorGreaterThan<size_t>());
+  return isValid;
+}
+
 bool SparseLengthsWeightedSumNode::verify() const {
   bool isValid = checkType(getResult(), getData().getElementType(), this);
   isValid &= checkType(getWeights(), getData().getElementType(), this);

--- a/tests/models/onnxModels/reduceMean2AvgPool.onnxtxt
+++ b/tests/models/onnxModels/reduceMean2AvgPool.onnxtxt
@@ -1,0 +1,68 @@
+ir_version: 3
+producer_name: "glow-test"
+graph {
+  node {
+    input: "x"
+    output: "y"
+    op_type: "ReduceMean"
+    attribute {
+      name: "axes"
+      ints: 3
+      ints: 2
+      type: INTS
+    }
+    attribute {
+      name: "keepdims"
+      i: 1
+      type: INT
+    }
+  }
+  name: "test_reducemean_2_avgpool"
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 9
+}

--- a/tests/models/onnxModels/reduceMean2AvgPoolNoKeep.onnxtxt
+++ b/tests/models/onnxModels/reduceMean2AvgPoolNoKeep.onnxtxt
@@ -1,0 +1,68 @@
+ir_version: 3
+producer_name: "glow-test"
+graph {
+  node {
+    input: "x"
+    output: "y"
+    op_type: "ReduceMean"
+    attribute {
+      name: "axes"
+      ints: 3
+      ints: 2
+      type: INTS
+    }
+    attribute {
+      name: "keepdims"
+      i: 0
+      type: INT
+    }
+  }
+  name: "test_reducemean_2_avgpool"
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 9
+}

--- a/tests/models/onnxModels/reduceMean4Dto3D.onnxtxt
+++ b/tests/models/onnxModels/reduceMean4Dto3D.onnxtxt
@@ -1,0 +1,64 @@
+ir_version: 3
+producer_name: "glow-test"
+graph {
+  node {
+    input: "x"
+    output: "y"
+    op_type: "ReduceMean"
+    attribute {
+      name: "axes"
+      ints: 3
+      type: INTS
+    }
+    attribute {
+      name: "keepdims"
+      i: 0
+      type: INT
+    }
+  }
+  name: "test_reducemean_4d3d"
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 9
+}

--- a/tests/models/onnxModels/reduceMean4Dto4D.onnxtxt
+++ b/tests/models/onnxModels/reduceMean4Dto4D.onnxtxt
@@ -1,0 +1,64 @@
+ir_version: 3
+producer_name: "glow-test"
+graph {
+  node {
+    input: "x"
+    output: "y"
+    op_type: "ReduceMean"
+    attribute {
+      name: "axes"
+      ints: 3
+      type: INTS
+    }
+    attribute {
+      name: "keepdims"
+      i: 1
+      type: INT
+    }
+  }
+  name: "test_reducemean_4d4d"
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 9
+}

--- a/tests/models/onnxModels/reduceSum4D.onnxtxt
+++ b/tests/models/onnxModels/reduceSum4D.onnxtxt
@@ -1,0 +1,67 @@
+ir_version: 3
+producer_name: "glow-test"
+graph {
+  node {
+    input: "x"
+    output: "y"
+    op_type: "ReduceSum"
+    attribute {
+      name: "axes"
+      ints: 3
+      type: INTS
+    }
+    attribute {
+      name: "keepdims"
+      i: 1
+      type: INT
+    }
+  }
+  name: "test_reduce_sum_4d"
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 9
+}

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -323,6 +323,13 @@ int main(int argc, char **argv) {
                     "tensor that has the same dimensions as the input tensor "
                     "without the first dimension.");
 
+  BB.newNode("BatchedReduceMean")
+      .addInput("Batch")
+      .addMember(MemberType::VectorUnsigned, "Axes")
+      .addResultFromCtorArg()
+      .setDocstring("Performs Average Mean operation on the Input given "
+                    "Axes.");
+
   BB.newNode("LengthsSum")
       .addInput("Data")
       .addInput("Lengths")


### PR DESCRIPTION
*Description*: 
`reduceMeanOrSum`  Importer function is split into into `reduceSum` and `reduceMean`. `reduceMean` is not lowered in Importer but in Optimizer. `reduceMean` is also optimized with `AvgPool` node if the reduce parameters are suitable:  input is 4D, last two dimensions are reduced, `keepdims=true`. 
*Testing*: 
OnnxImporterTest:  Add 4 reduce* testcases that run 4 newly added `reduce*.onnxtxt` models.
GraphOptzTest: Add a testcase that covers ReduceMean substitution with AvgPool.
OperatorTest: Add testcases that covered both optimized and lowered ReduceMean transformations.
*Documentation*: 
Updated Optimizations.md
Fixes #2343 
