### PR TITLE
Make static methods for Backend

### DIFF
--- a/include/glow/Backends/Backend.h
+++ b/include/glow/Backends/Backend.h
@@ -95,6 +95,25 @@ public:
 
   virtual size_t getTraceEventDataSize() const { return 0; }
 
+  /// Used by the compiler during graph optimization and before code generation,
+  /// giving the backend an opportunity to transform the graph before IRGen. The
+  /// backend may insert backend-specific nodes. The backend is responsible for
+  /// cleaning up after itself. Given a \p backendKind, calls
+  /// transformPostLoweringStatic on the corresponding Backend. \returns True if
+  /// the graph was modified.
+  static bool transformPostLoweringStatic(BackendKind backendKind, Function *F,
+                                          const CompilationOptions &opts);
+
+  /// Given a \p backendKind, calls isOpSupportedStatic on the corresponding
+  /// Backend. \returns True if \returns whether the provided \p NI is supported
+  /// by the backend.
+  static bool isOpSupportedStatic(BackendKind backendKind, const NodeInfo &NI);
+
+  /// Given a \p backendKind, calls isOpSupportedStatic on the corresponding
+  /// backend. \returns true if the supplied Node \N should be lowered. By
+  /// default, all Nodes are candidates for lowering.
+  static bool shouldLowerStatic(BackendKind backendKind, const Node *N);
+
 protected:
   /// Parses the graph \F and builds a TraceInfo structure from any found
   /// TraceEventNodes.
@@ -109,6 +128,25 @@ protected:
 
 /// Create a backend of kind \p kind.
 Backend *createBackend(BackendKind backendKind);
+
+/// Used by the compiler during graph optimization and before code generation,
+/// giving the backend an opportunity to transform the graph before IRGen. The
+/// backend may insert backend-specific nodes. The backend is responsible for
+/// cleaning up after itself. Given a \p backendKind, calls
+/// transformPostLoweringStatic on the corresponding Backend. \returns True if
+/// the graph was modified.
+bool transformPostLoweringStatic(BackendKind backendKind, Function *F,
+                                 const CompilationOptions &opts);
+
+/// Given a \p backendKind, calls isOpSupportedStatic on the corresponding
+/// Backend. \returns True if \returns whether the provided \p NI is supported
+/// by the backend.
+bool isOpSupportedStatic(BackendKind backendKind, const NodeInfo &NI);
+
+/// Given a \p backendKind, calls isOpSupportedStatic on the corresponding
+/// backend. \returns true if the supplied Node \N should be lowered. By
+/// default, all Nodes are candidates for lowering.
+bool shouldLowerStatic(BackendKind backendKind, const Node *N);
 
 // Backends that use Glow low-level IR should inherit from this class. It allows
 // for unit tests to create low-level IR to compile and run.

--- a/include/glow/Optimizer/Optimizer.h
+++ b/include/glow/Optimizer/Optimizer.h
@@ -16,6 +16,7 @@
 #ifndef GLOW_OPTIMIZER_OPTIMIZER_H
 #define GLOW_OPTIMIZER_OPTIMIZER_H
 
+#include "glow/Backends/Backend.h"
 #include "glow/Backends/CompilationOptions.h"
 #include "glow/Quantization/Quantization.h"
 
@@ -38,14 +39,18 @@ void optimize(Function *F, const CompilationOptions &opts);
 void optimize(Function *F, CompilationMode mode);
 
 /// Lower the high-level neural network nodes found in \p F into low-level
-/// linear algebra operators. If \p B is not a nullptr then it can prevent
-/// lowering of a node via \ref Backend::shouldLower(); otherwise everything
-/// will be lowered. If \p loweredMap is not a nullptr, then \p loweredMap will
-/// contain a mapping from output names of the nodes found and lowered in \p F
-/// to the output names of the nodes they were lowered from along with the
-/// NodeKind. \p doNotLowerKinds is a set of NodeKinds which represents all
-/// Nodes that should not be lowered.
-void lower(Function *F, LoweredInfoMap *loweredMap, const Backend *B = nullptr,
+/// linear algebra operators. If \p backend is not a nullptr then it can prevent
+/// lowering of a node via \ref Backend::shouldLower(); likewise if \p
+/// backendKind is not null then Backend::shouldLowerStatic can prevent
+/// lowering; otherwise everything will be lowered. At most of one of backend
+/// and backendKind should be non-null. If \p loweredMap is not a nullptr, then
+/// \p loweredMap will contain a mapping from output names of the nodes found
+/// and lowered in \p F to the output names of the nodes they were lowered from
+/// along with the NodeKind. \p doNotLowerKinds is a set of NodeKinds which
+/// represents all Nodes that should not be lowered.
+void lower(Function *F, LoweredInfoMap *loweredMap,
+           const Backend *backend = nullptr,
+           const BackendKind *backendKind = nullptr,
            const KindSet &doNotLowerKinds = {});
 
 /// Dead code elimination.

--- a/lib/Backends/Backends.cpp
+++ b/lib/Backends/Backends.cpp
@@ -14,9 +14,18 @@
  * limitations under the License.
  */
 
+#include "Interpreter/Interpreter.h"
 #include "glow/Backends/Backend.h"
 #include "glow/Graph/Graph.h"
 #include "glow/Graph/Nodes.h"
+
+#if defined(GLOW_WITH_OPENCL)
+#include "OpenCL/OpenCL.h"
+#endif
+
+#if defined(GLOW_WITH_CPU)
+#include "CPU/CPUBackend.h"
+#endif
 
 #include "llvm/Support/Casting.h"
 
@@ -56,6 +65,82 @@ Backend *glow::createBackend(BackendKind backendKind) {
     return createOCLBackend();
   case BackendKind::CPU:
     return createCPUBackend();
+  }
+
+  // This is to make compiler happy. It can never reach this point as switch
+  // always covers all possible values.
+  llvm_unreachable("unreachable");
+}
+
+bool glow::transformPostLoweringStatic(BackendKind backendKind, Function *F,
+                                       const CompilationOptions &opts) {
+  switch (backendKind) {
+  case BackendKind::Interpreter:
+    return Interpreter::transformPostLoweringStatic(F, opts);
+
+  case BackendKind::OpenCL:
+#if defined(GLOW_WITH_OPENCL)
+    return OCLBackend::transformPostLoweringStatic(F, opts);
+#else
+    GLOW_UNREACHABLE("Must compile with OpenCL support");
+#endif
+
+  case BackendKind::CPU:
+#if defined(GLOW_WITH_CPU)
+    return CPUBackend::transformPostLoweringStatic(F, opts);
+#else
+    GLOW_UNREACHABLE("Must compile with CPU support");
+#endif
+  }
+
+  // This is to make compiler happy. It can never reach this point as switch
+  // always covers all possible values.
+  llvm_unreachable("unreachable");
+}
+
+bool glow::isOpSupportedStatic(BackendKind backendKind, const NodeInfo &NI) {
+  switch (backendKind) {
+  case BackendKind::Interpreter:
+    return Interpreter::isOpSupportedStatic(NI);
+
+  case BackendKind::OpenCL:
+#if defined(GLOW_WITH_OPENCL)
+    return OCLBackend::isOpSupportedStatic(NI);
+#else
+    GLOW_UNREACHABLE("Must compile with OpenCL support");
+#endif
+
+  case BackendKind::CPU:
+#if defined(GLOW_WITH_CPU)
+    return CPUBackend::isOpSupportedStatic(NI);
+#else
+    GLOW_UNREACHABLE("Must compile with CPU support");
+#endif
+  }
+
+  // This is to make compiler happy. It can never reach this point as switch
+  // always covers all possible values.
+  llvm_unreachable("unreachable");
+}
+
+bool glow::shouldLowerStatic(BackendKind backendKind, const Node *N) {
+  switch (backendKind) {
+  case BackendKind::Interpreter:
+    return Interpreter::shouldLowerStatic(N);
+
+  case BackendKind::OpenCL:
+#if defined(GLOW_WITH_OPENCL)
+    return OCLBackend::shouldLowerStatic(N);
+#else
+    GLOW_UNREACHABLE("Must compile with OpenCL support");
+#endif
+
+  case BackendKind::CPU:
+#if defined(GLOW_WITH_CPU)
+    return CPUBackend::shouldLowerStatic(N);
+#else
+    GLOW_UNREACHABLE("Must compile with CPU support");
+#endif
   }
 
   // This is to make compiler happy. It can never reach this point as switch

--- a/lib/Backends/CMakeLists.txt
+++ b/lib/Backends/CMakeLists.txt
@@ -36,7 +36,6 @@ target_link_libraries(Backends
                         Base
                         Graph
                         Interpreter
-                        Optimizer
                         ${linked_backends})
 
 add_library(DeviceManager

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -45,7 +45,7 @@ namespace glow {
 Backend *createCPUBackend() { return new CPUBackend(); }
 } // namespace glow
 
-bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
+bool CPUBackend::isOpSupportedStatic(const NodeInfo &NI) {
   // Note: For brevity below, "X ==> Y, Z" signifes that Node X is IRGen'd into
   // Instructions Y and Z.
 
@@ -299,10 +299,18 @@ bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
   }
 }
 
-bool CPUBackend::shouldLower(const Node *N) const {
+bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
+  return CPUBackend::isOpSupportedStatic(NI);
+}
+
+bool CPUBackend::shouldLowerStatic(const Node *N) {
   if (N->getKind() == Kinded::Kind::ConvolutionNodeKind)
     return false;
   return true;
+}
+
+bool CPUBackend::shouldLower(const Node *N) const {
+  return CPUBackend::shouldLowerStatic(N);
 }
 
 std::unique_ptr<CompiledFunction> CPUBackend::createCompiledFunction(

--- a/lib/Backends/CPU/CPUBackend.h
+++ b/lib/Backends/CPU/CPUBackend.h
@@ -47,6 +47,16 @@ public:
   /// @}
 
 public:
+  /// See Backend::transformPostLoweringStatic.
+  static bool transformPostLoweringStatic(Function *F,
+                                          const CompilationOptions &opts);
+
+  /// See Backend::isOpSupportedStatic.
+  static bool isOpSupportedStatic(const NodeInfo &NI);
+
+  /// See Backend::shouldLowerStatic.
+  static bool shouldLowerStatic(const Node *N);
+
   /// @name LLVMBackend methods.
   /// This is the implementation of the LLVMBackend interface.
   ///@{

--- a/lib/Backends/CPU/Transforms.cpp
+++ b/lib/Backends/CPU/Transforms.cpp
@@ -114,8 +114,8 @@ static Node *optimizeCPUMaxSplat(MaxNode *MN, Function *F) {
       new CPUMaxSplatNode(MN->getName(), input, splat->getValue()));
 }
 
-bool CPUBackend::transformPostLowering(Function *F,
-                                       const CompilationOptions &) const {
+bool CPUBackend::transformPostLoweringStatic(Function *F,
+                                             const CompilationOptions &) {
   bool changed = false;
   for (auto &node : F->getNodes()) {
     // Try to replace generic convolution with cpu-optimized version.
@@ -138,4 +138,9 @@ bool CPUBackend::transformPostLowering(Function *F,
   }
 
   return changed;
+}
+
+bool CPUBackend::transformPostLowering(Function *F,
+                                       const CompilationOptions &opts) const {
+  return CPUBackend::transformPostLoweringStatic(F, opts);
 }

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -65,7 +65,7 @@ Interpreter::compileIRWithoutConstants(std::unique_ptr<IRFunction> IR) const {
   return llvm::make_unique<InterpreterFunction>(std::move(IR), bundle);
 }
 
-bool Interpreter::isOpSupported(const NodeInfo &NI) const {
+bool Interpreter::isOpSupportedStatic(const NodeInfo &NI) {
   switch (NI.getKind()) {
   case Kinded::Kind::AddNodeKind:
   case Kinded::Kind::SubNodeKind:
@@ -358,10 +358,30 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
   }
 }
 
-bool Interpreter::shouldLower(const Node *N) const {
-  if (N->getKind() == Kinded::Kind::ConvolutionNodeKind)
+bool Interpreter::isOpSupported(const NodeInfo &NI) const {
+  return Interpreter::isOpSupportedStatic(NI);
+}
+
+bool Interpreter::shouldLowerStatic(const Node *N) {
+  if (N->getKind() == Kinded::Kind::ConvolutionNodeKind) {
     return false;
+  }
+
   return true;
+}
+
+bool Interpreter::shouldLower(const Node *N) const {
+  return Interpreter::shouldLowerStatic(N);
+}
+
+bool Interpreter::transformPostLoweringStatic(Function *F,
+                                              const CompilationOptions &opts) {
+  return false;
+}
+
+bool Interpreter::transformPostLowering(Function *F,
+                                        const CompilationOptions &opts) const {
+  return Interpreter::transformPostLoweringStatic(F, opts);
 }
 
 namespace glow {

--- a/lib/Backends/Interpreter/Interpreter.h
+++ b/lib/Backends/Interpreter/Interpreter.h
@@ -47,12 +47,25 @@ public:
   std::unique_ptr<CompiledFunction>
   compile(Function *F, const CompilationOptions &opts) const override;
 
+  bool transformPostLowering(Function *F,
+                             const CompilationOptions &opts) const override;
+
   bool isOpSupported(const NodeInfo &NI) const override;
 
   bool shouldLower(const Node *N) const override;
 
   /// @}
-  //
+
+  /// See Backend::transformPostLoweringStatic.
+  static bool transformPostLoweringStatic(Function *F,
+                                          const CompilationOptions &opts);
+
+  /// See Backend::isOpSupportedStatic.
+  static bool isOpSupportedStatic(const NodeInfo &NI);
+
+  /// See Backend::shouldLowerStatic.
+  static bool shouldLowerStatic(const Node *N);
+
   /// \returns the size of metrics collected for a single TraceEvent.
   static size_t getTraceEventDataSizeStatic() { return sizeof(uint64_t); }
   size_t getTraceEventDataSize() const override {

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -1575,7 +1575,7 @@ OCLBackend::compile(Function *F, const CompilationOptions &opts) const {
   return compileIRWithoutConstants(std::move(IR));
 }
 
-bool OCLBackend::isOpSupported(const NodeInfo &NI) const {
+bool OCLBackend::isOpSupportedStatic(const NodeInfo &NI) {
   switch (NI.getKind()) {
   case Kinded::Kind::SplatNodeKind:
   case Kinded::Kind::TransposeNodeKind:
@@ -1689,4 +1689,19 @@ bool OCLBackend::isOpSupported(const NodeInfo &NI) const {
   default:
     return false;
   }
+}
+
+bool OCLBackend::isOpSupported(const NodeInfo &NI) const {
+  return OCLBackend::isOpSupportedStatic(NI);
+}
+
+bool OCLBackend::shouldLowerStatic(const Node *N) {
+  // The group convolution is supported in OpenCL slow convolution kernel.
+  if (N->getKind() == Kinded::Kind::ConvolutionNodeKind)
+    return false;
+  return true;
+}
+
+bool OCLBackend::shouldLower(const Node *N) const {
+  return OCLBackend::shouldLowerStatic(N);
 }

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -185,14 +185,18 @@ public:
 
   bool isOpSupported(const NodeInfo &NI) const override;
 
-  bool shouldLower(const Node *N) const override {
-    // The group convolution is supported in OpenCL slow convolution kernel.
-    if (N->getKind() == Kinded::Kind::ConvolutionNodeKind)
-      return false;
-    return true;
-  }
-
+  bool shouldLower(const Node *N) const override;
   /// @}
+
+  /// See Backend::transformPostLoweringStatic.
+  static bool transformPostLoweringStatic(Function *F,
+                                          const CompilationOptions &opts);
+
+  /// See Backend::isOpSupportedStatic.
+  static bool isOpSupportedStatic(const NodeInfo &NI);
+
+  /// See Backend::shouldLowerStatic.
+  static bool shouldLowerStatic(const Node *N);
 };
 
 } // namespace glow

--- a/lib/Backends/OpenCL/Transforms.cpp
+++ b/lib/Backends/OpenCL/Transforms.cpp
@@ -26,8 +26,8 @@ using llvm::dyn_cast;
 using namespace glow;
 
 /// Perform OpenCL specific post-lowering graph transformation.
-bool OCLBackend::transformPostLowering(Function *F,
-                                       const CompilationOptions &opts) const {
+bool OCLBackend::transformPostLoweringStatic(Function *F,
+                                             const CompilationOptions &opts) {
   // NCHW transformation is not supported in training mode yet, because of some
   // issues with gradient nodes.
   if (opts.mode == CompilationMode::Train)
@@ -60,4 +60,9 @@ bool OCLBackend::transformPostLowering(Function *F,
     }
   }
   return changed;
+}
+
+bool OCLBackend::transformPostLowering(Function *F,
+                                       const CompilationOptions &opts) const {
+  return OCLBackend::transformPostLoweringStatic(F, opts);
 }

--- a/lib/Onnxifi/Base.h
+++ b/lib/Onnxifi/Base.h
@@ -57,7 +57,8 @@ public:
   explicit BackendId(glow::BackendKind kind, int id, int concurrency,
                      bool useOnnx, bool useHostManager)
       : id_(id), useOnnx_(useOnnx), concurrency_(concurrency),
-        glowBackend_(createBackend(kind)), useHostManager_(useHostManager) {}
+        glowBackend_(createBackend(kind)), glowBackendKind_(kind),
+        useHostManager_(useHostManager) {}
 
   bool isOpSupported(const NodeInfo &NI);
 
@@ -99,6 +100,7 @@ private:
   bool useOnnx_;
   int concurrency_;
   std::unique_ptr<glow::Backend> glowBackend_;
+  glow::BackendKind glowBackendKind_;
   bool useHostManager_;
   HostManager hostManager_; // TODO use real HostManager once landed.
 };

--- a/lib/Optimizer/CMakeLists.txt
+++ b/lib/Optimizer/CMakeLists.txt
@@ -5,6 +5,8 @@ add_library(Optimizer
               Quantization.cpp)
 
 target_link_libraries(Optimizer
+                      PUBLIC
+                        Backends
                       PRIVATE
                         Graph
                         IR

--- a/lib/Optimizer/Lower.cpp
+++ b/lib/Optimizer/Lower.cpp
@@ -791,11 +791,20 @@ static void lowerNode(Function *F, Node *node, LoweredInfoMap *loweredMap) {
   }
 }
 
-void glow::lower(Function *F, LoweredInfoMap *loweredMap, const Backend *B,
+void glow::lower(Function *F, LoweredInfoMap *loweredMap,
+                 const Backend *backend, const BackendKind *backendKind,
                  const KindSet &doNotLowerKinds) {
+  assert(!(backend && backendKind) &&
+         "Only backend or backendKind should be provided.");
   auto &nodes = F->getNodes();
   for (auto &N : nodes) {
-    if (B && !B->shouldLower(&N)) {
+    bool shouldLower = true;
+    if (backend) {
+      shouldLower = backend->shouldLower(&N);
+    } else if (backendKind) {
+      shouldLower = shouldLowerStatic(*backendKind, &N);
+    }
+    if (!shouldLower) {
       continue;
     }
     if (doNotLowerKinds.count(N.getKind())) {

--- a/tests/unittests/GraphTest.cpp
+++ b/tests/unittests/GraphTest.cpp
@@ -1482,7 +1482,8 @@ TEST(Graph, GroupTestConvNoLower) {
   // Now lower, but prevent ConvolutionNodeKinds from being lowered.
   KindSet doNotLower;
   doNotLower.insert(Kinded::Kind::ConvolutionNodeKind);
-  lower(F, /* loweredMap */ nullptr, &backend, doNotLower);
+  lower(F, /* loweredMap */ nullptr, &backend,
+        /* backendKind */ nullptr, doNotLower);
 
   {
     // Now have lowered but should still have a single Conv node with group = 8.

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -267,7 +267,7 @@ void Loader::compile(Context &ctx) {
     // generateNodeQuantizationInfos() when writing out the profile, allowing
     // for both lowered and unlowered NodeValues to find their quantization
     // parameters.
-    ::lower(F_, &loweredMap_, /* backend */ nullptr,
+    ::lower(F_, &loweredMap_, /* backend */ nullptr, /* backendKind */ nullptr,
             doNotLowerNodesForProfiling);
 
     // Instrument the graph to capture profiles for nodes' outputs.


### PR DESCRIPTION
*Description*:
`Backend::transformPostLowering`, `Backend::isOpSupported`, and `Backend::shouldLower`, don't need a backend instance to operate so create a static version of each of these functions so that the ONNXIFI layer can call these functions for compatibility checking without needing an actual Backend. This is useful because in the near future HostManager will control all of the backends and they won't be cleanly accessible to ONNXIFI code.

*Testing*:
CI

*Documentation*:
Comments