### PR TITLE
Fix resnet-runtime when using opencl

### DIFF
--- a/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
@@ -124,7 +124,7 @@ void OpenCLDeviceManager::addNetworkImpl(const Module *module,
   }
   // Collect constants once, since currently the bundle grabs everything in the
   // module.
-  auto bundle = functions.begin()->second->getRuntimeBundle();
+  auto &bundle = functions.begin()->second->getRuntimeBundle();
   if (bundle.getConstants() == nullptr) {
     bundle.collectConstants(module);
   }

--- a/lib/Runtime/Provisioner/Provisioner.cpp
+++ b/lib/Runtime/Provisioner/Provisioner.cpp
@@ -76,7 +76,7 @@ Provisioner::provision(std::vector<std::unique_ptr<DAGNode>> &networks,
     FunctionMapTy functionMap;
     for (auto &node : device.second) {
       Function *function = module.getFunction(node->name);
-      auto compileOptions = CompilationOptions();
+      CompilationOptions compileOptions;
       compileOptions.collectConstants = false;
       auto compiled = backend_->compile(function, compileOptions);
       node->runtimeBundle = compiled->getRuntimeBundle();
@@ -119,6 +119,10 @@ Provisioner::provision(std::vector<std::unique_ptr<DAGNode>> &networks,
     auto result = ready.get();
     if (!result) {
       return ResultCode::Failed;
+    }
+    // Set deviceID for each node added
+    for (auto &node : logicalDevices[logicalID]) {
+      node->deviceID = deviceID;
     }
   }
   return ResultCode::Ready;


### PR DESCRIPTION
*Description*: Fixed provisioner not updating node->deviceId, and fixed opencl device manager not collecting constants properly
*Testing*: ninja test and resnet-runtime
*Documentation*: