### PR TITLE
Remove Backends dependency on Backend

### DIFF
--- a/include/glow/Backends/CompiledFunction.h
+++ b/include/glow/Backends/CompiledFunction.h
@@ -33,11 +33,10 @@ public:
   CompiledFunction() = default;
 
   /// Ctor that accepts runtimeBundle.
-  CompiledFunction(const runtime::RuntimeBundle &bundle)
-      : runtimeBundle_(bundle){};
+  CompiledFunction(const runtime::RuntimeBundle &bundle);
 
   /// Dtor.
-  virtual ~CompiledFunction() { runtimeBundle_.freeConstants(); }
+  virtual ~CompiledFunction();
   /// Execute the network and allocate Placeholder memory with given
   /// \p ctx providing mapping between Placeholder and populated tensor.
   virtual void execute(Context *ctx) = 0;

--- a/lib/Backends/CMakeLists.txt
+++ b/lib/Backends/CMakeLists.txt
@@ -18,6 +18,7 @@ endif()
 add_library(Backend
               Backend.cpp
               BackendUtils.cpp
+              CompiledFunction.cpp
               TraceEvents.cpp)
 target_link_libraries(Backend
                       PRIVATE
@@ -30,8 +31,6 @@ target_link_libraries(Backend
 add_library(Backends
               Backends.cpp)
 target_link_libraries(Backends
-                      PUBLIC
-                        Backend
                       PRIVATE
                         Base
                         Graph
@@ -46,6 +45,7 @@ target_link_libraries(DeviceManager
                         ThreadPool
                         ${linked_device_managers}
                       PRIVATE
+                        Backend  
                         Backends
                         Graph
                         ThreadPool)

--- a/lib/Backends/CompiledFunction.cpp
+++ b/lib/Backends/CompiledFunction.cpp
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/Backends/CompiledFunction.h"
+#include "glow/Backends/BackendUtils.h"
+
+using namespace glow;
+
+CompiledFunction::~CompiledFunction() { runtimeBundle_.freeConstants(); }
+
+CompiledFunction::CompiledFunction(const runtime::RuntimeBundle &bundle)
+    : runtimeBundle_(bundle){};

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -79,6 +79,7 @@ add_executable(DeviceManagerTest
                DeviceManagerTest.cpp)
 target_link_libraries(DeviceManagerTest
                       PRIVATE
+                        Backend
                         Backends
                         DeviceManager
                         Graph
@@ -175,6 +176,7 @@ add_executable(GraphTest
                GraphTest.cpp)
 target_link_libraries(GraphTest
                       PRIVATE
+                        Backend
                         Backends
                         ExecutionEngine
                         Graph
@@ -191,7 +193,6 @@ if(GLOW_WITH_CPU)
                  HyphenTest.cpp)
   target_link_libraries(HyphenTest
                         PRIVATE
-                          Backends
                           Graph
                           IR
                           ExecutionEngine
@@ -220,7 +221,7 @@ add_executable(IROptTest
                IROptTest.cpp)
 target_link_libraries(IROptTest
                       PRIVATE
-                        Backends
+                        Backend
                         Graph
                         IR
                         Optimizer
@@ -233,7 +234,7 @@ if(GLOW_WITH_CPU)
                  LLVMIRGenTest.cpp)
   target_link_libraries(LLVMIRGenTest
                         PRIVATE
-                          Backends
+                          Backend
                           CPUBackend
                           IR
                           Support
@@ -286,7 +287,7 @@ add_executable(OnnxImporterTest
                OnnxImporterTest.cpp)
 target_link_libraries(OnnxImporterTest
                       PRIVATE
-                        Backends
+                        Backend
                         Graph
                         Importer
                         ExecutionEngine
@@ -314,7 +315,6 @@ add_executable(PartitionerTest
                PartitionerTest.cpp)
 target_link_libraries(PartitionerTest
                       PRIVATE
-                        Backends
                         ExecutionEngine
                         Graph
                         IR
@@ -328,7 +328,6 @@ if(GLOW_WITH_CPU)
                  ProvisionerTest.cpp)
   target_link_libraries(ProvisionerTest
                         PRIVATE
-                          Backends
                           Graph
                           IR
                           Provisioner
@@ -343,7 +342,6 @@ add_executable(HostManagerTest
                HostManagerTest.cpp)
 target_link_libraries(HostManagerTest
                       PRIVATE
-                        Backends
                         HostManager
                         Executor
                         Graph
@@ -362,6 +360,7 @@ add_executable(QuantizationTest
                QuantizationTest.cpp)
 target_link_libraries(QuantizationTest
                       PRIVATE
+                        Backend
                         Backends
                         ExecutionEngine
                         Graph
@@ -388,6 +387,7 @@ add_executable(TensorsTest
                TensorsTest.cpp)
 target_link_libraries(TensorsTest
                       PRIVATE
+                        Backend  
                         Base
                         gtest
                         TestMain)
@@ -406,7 +406,7 @@ add_executable(TraceEventsTest
                TraceEventsTest.cpp)
 target_link_libraries(TraceEventsTest
                       PRIVATE
-                        Backends
+                        Backend
                         Graph
                         IR
                         ExecutionEngine


### PR DESCRIPTION
*Description*:
`Backends` shouldn't depend on `Backend` and it's doing so makes it easy to add a cyclic dependencies when adding static functions to backends.
Also move `CompiledFunction` methods that depend on other symbols in `Backend` target to cpp file.

*Testing*:
CI

*Documentation*:
None