### PR TITLE
[unittests] Refactor reduced precision tests to prevent backends from needing to execute fp32

### DIFF
--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -267,6 +267,12 @@ enum class ElemKind : unsigned char {
   BoolTy,        // Bool type (bool)
 };
 
+/// \returns whether \p e is a quantized ElemKind.
+inline bool isQuantizedElemKind(ElemKind e) {
+  return e == ElemKind::Int8QTy || e == ElemKind::Int16QTy ||
+         e == ElemKind::Int32QTy || e == ElemKind::UInt8FusedQTy;
+}
+
 /// A class that represents a type of a tensor.
 struct Type final {
   /// Contains the dimensions (sizes) of the tensor. Ex: [sx, sy, sz, ...].
@@ -442,12 +448,7 @@ struct Type final {
   }
 
   /// \returns true if the type of this Tensor is one of the quantized types.
-  bool isQuantizedType() const {
-    return elementType_ == ElemKind::Int8QTy ||
-           elementType_ == ElemKind::Int16QTy ||
-           elementType_ == ElemKind::Int32QTy ||
-           elementType_ == ElemKind::UInt8FusedQTy;
-  }
+  bool isQuantizedType() const { return isQuantizedElemKind(elementType_); }
 
   /// \returns true if the type of this Tensor is one of the floating point
   /// types.

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -76,14 +76,17 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
   case Kinded::Kind::MaxPoolNodeKind:
   case Kinded::Kind::MatMulNodeKind:
   case Kinded::Kind::BatchedReduceAddNodeKind:
+    // Note: Int8QTy Log, Tanh, and Sigmoid are lowered into a lookup
+    // table. However, we do not lower them until after they're quantized. So we
+    // need to return here that they are supported as Int8QTy.
+  case Kinded::Kind::LogNodeKind:
+  case Kinded::Kind::TanhNodeKind:
+  case Kinded::Kind::SigmoidNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
         {ElemKind::FloatTy, ElemKind::Float16Ty, ElemKind::Int8QTy});
 
   case Kinded::Kind::PowNodeKind:
-  case Kinded::Kind::LogNodeKind:
   case Kinded::Kind::LocalResponseNormalizationNodeKind:
-  case Kinded::Kind::SigmoidNodeKind:
-  case Kinded::Kind::TanhNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
         {ElemKind::FloatTy, ElemKind::Float16Ty});
 

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -1604,17 +1604,24 @@ bool OCLBackend::isOpSupported(const NodeInfo &NI) const {
     // the backend to be an OCLPool/OCLConv.
   case Kinded::Kind::AvgPoolNodeKind:
   case Kinded::Kind::MaxPoolNodeKind:
-  case Kinded::Kind::ConvolutionNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
         {ElemKind::FloatTy, ElemKind::Int8QTy});
 
-  case Kinded::Kind::OCLConvolutionNodeKind:
+  case Kinded::Kind::ConvolutionNodeKind:
     if (!NI.getInTy(ConvolutionNode::InputIdx)->isQuantizedType()) {
       return NI.allInputsAndOutputsHaveSameElemKind({ElemKind::FloatTy});
     }
     return NI.allInputsAndOutputsHaveSameElemKind({ElemKind::Int8QTy},
                                                   {ConvolutionNode::BiasIdx}) &&
            (NI.getInElemTy(ConvolutionNode::BiasIdx) == ElemKind::Int32QTy);
+
+  case Kinded::Kind::OCLConvolutionNodeKind:
+    if (!NI.getInTy(OCLConvolutionNode::InputIdx)->isQuantizedType()) {
+      return NI.allInputsAndOutputsHaveSameElemKind({ElemKind::FloatTy});
+    }
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::Int8QTy}, {OCLConvolutionNode::BiasIdx}) &&
+           (NI.getInElemTy(OCLConvolutionNode::BiasIdx) == ElemKind::Int32QTy);
 
   case Kinded::Kind::TopKNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -111,6 +111,29 @@ class MockBackendCustomIRGen : public Backend {
 /// allocated Tensor that backs the Placeholder of the single output.
 using FunctionTensorPair = std::pair<Function *, Tensor *>;
 
+/// Signature of functions used to create and init a Function. Returns a pair of
+/// the Function created and the Placeholder of the output of the Function.
+using CreateAndInitFunction =
+    std::function<FunctionTensorPair(Context &, ExecutionEngine &)>;
+
+/// Given a method \p createAndInitFunction that creates and initializes a
+/// FloatTy Function with a single output Tensor, \returns a bool representing
+/// if the output Tensor of executing the Function on the Interpreter backend is
+/// equal to executing it on a backend of kind \p backendKind. \p interpElemKind
+/// and \p backendElemKind represent the desired ElemKinds for their respective
+/// functions to use. If either require quantization then a profile will first
+/// be gathered on the Interpreter, and then that profile will be used to
+/// quantize one or both. Otherwise if either is Float16Ty then the respective
+/// Function it will be converted using the Converter. If
+/// \p enableRowwiseQuantization then rowwise quantization will be used for
+/// nodes that support it.
+void compareAgainstInterpreter(BackendKind backendKind,
+                               CreateAndInitFunction createAndInitFunction,
+                               ElemKind interpElemKind,
+                               ElemKind backendElemKind,
+                               float allowedError = 0.0001,
+                               bool enableRowwiseQuantization = false);
+
 void inferConvNet(Tensor *inputs, Tensor *filter, Tensor *bias, Tensor *out,
                   BackendKind kind);
 

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -5,12 +5,21 @@ target_link_libraries(TestMain
                         LLVMSupport
                         gtest)
 
+add_library(BackendTestUtils
+            BackendTestUtils.cpp)
+target_link_libraries(BackendTestUtils
+                      PRIVATE
+                        Converter
+                        Quantization
+                        LLVMSupport
+                        gtest)
+
 add_executable(BackendCorrectnessTest
-               BackendTestUtils.cpp
                BackendCorrectnessTest.cpp)
 target_link_libraries(BackendCorrectnessTest
                       PRIVATE
                         Backends
+                        BackendTestUtils
                         Graph
                         IR
                         ExecutionEngine
@@ -189,10 +198,10 @@ LIST(APPEND UNOPT_TESTS ./tests/GraphTest -optimize-ir=false &&)
 
 if(GLOW_WITH_CPU)
   add_executable(HyphenTest
-                 BackendTestUtils.cpp
                  HyphenTest.cpp)
   target_link_libraries(HyphenTest
                         PRIVATE
+                          BackendTestUtils
                           Graph
                           IR
                           ExecutionEngine
@@ -269,10 +278,10 @@ LIST(APPEND UNOPT_TESTS ./tests/MLTest -optimize-ir=false &&)
 
 if(GLOW_WITH_OPENCL)
   add_executable(OCLTest
-                 BackendTestUtils.cpp
                  OCLTest.cpp)
   target_link_libraries(OCLTest
                         PRIVATE
+                          BackendTestUtils
                           ExecutionEngine
                           Graph
                           IR
@@ -301,6 +310,7 @@ add_executable(OperatorTest
                OperatorTest.cpp)
 target_link_libraries(OperatorTest
                       PRIVATE
+                        BackendTestUtils
                         Graph
                         IR
                         ExecutionEngine
@@ -387,7 +397,7 @@ add_executable(TensorsTest
                TensorsTest.cpp)
 target_link_libraries(TensorsTest
                       PRIVATE
-                        Backend  
+                        Backend
                         Base
                         gtest
                         TestMain)


### PR DESCRIPTION
*Description*: Some of our unit tests were executing a graph that included both fp32 and reduced precision nodes on the backend to compare their execution. However, not all backends support fp32. 

This PR refactors `compareAgainstInterpreter()` to support executing a graph on both the Interpreter and some other backend, including profiling if we need to quantize, and comparing the results.

This should simplify adding tests for new operators into the future, as you only need to specify the fp32 graph, and then can call into `compareAgainstInterpreter()` to get comparisons of that graph in any precision desired and compared to any backend desired.

*Testing*: Updated all unittests that are listed in https://github.com/pytorch/glow/issues/2396. This included adjusting some allowed errors given we use new quantization parameters, and disabling some quantized tests on backends that were not being quantized at all in the first place (see https://github.com/pytorch/glow/issues/2464).

Fixes https://github.com/pytorch/glow/issues/2396