### PR TITLE
[ExecutionEngine] Initialize DeviceManager instance in setBackend

### DIFF
--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -56,6 +56,10 @@ void ExecutionEngine::setBackend(Backend *backend, bool ownsBackend) {
       device_ = std::unique_ptr<runtime::DeviceManager>(
           runtime::DeviceManager::createDeviceManager(backend->getBackendKind(),
                                                       "ExecutionEngine"));
+      runtime::ResultCode initResult = device_->init();
+      (void)initResult;
+      assert(initResult == runtime::ResultCode::Executed &&
+             "Failed to init device");
     }
   }
 }


### PR DESCRIPTION
**Description**
This commit modifies `ExecutionEngine` to initialize the `DeviceManager`
instance that it creates in `ExecutionEngine::setBackend`. This code has
been working so far because this method is a no-op for
`CPUDeviceManager` and `InterpreterDeviceManager`. This may not be the
case for other `DeviceManagers`.

**Testing**
All tests pass.
