### PR TITLE
[unittests] Enable each test case for specific backends in OperatorTest.cpp.

### DIFF
--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -34,7 +34,7 @@ public:
   ~Operator() override { mod_.clear(); }
 
 protected:
-  bool isEnabledBackend(const std::set<BackendKind>& enabledBackends) {
+  bool isEnabledBackend(const std::set<BackendKind> &enabledBackends) {
     return enabledBackends.find(GetParam()) != enabledBackends.end();
   }
 
@@ -59,7 +59,7 @@ INSTANTIATE_TEST_CASE_P(AllOperatorTest, Operator,
 #endif // GLOW_WITHOPENCL
                             BackendKind::Interpreter));
 
-// TODO(d1jang): Replace return for GTEST_SKIP() so that skipped tests are
+// TODO: Replace return for GTEST_SKIP() so that skipped tests are
 // correctly reported once the macro gets available.
 #define ENABLED_BACKENDS(...)                                                  \
   if (!isEnabledBackend({__VA_ARGS__}))                                        \

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -49,21 +49,21 @@ protected:
 };
 
 // The parameterized test suite is instantiated with all available backends.
-INSTANTIATE_TEST_CASE_P(
-    AllOperatorTest, Operator,
-    ::testing::Values(
+INSTANTIATE_TEST_CASE_P(AllOperatorTest, Operator,
+                        ::testing::Values(
 #ifdef GLOW_WITH_CPU
-        BackendKind::CPU,
+                            BackendKind::CPU,
 #endif // GLOW_WITH_CPU
 #ifdef GLOW_WITH_OPENCL
-        BackendKind::OpenCL,
+                            BackendKind::OpenCL,
 #endif // GLOW_WITHOPENCL
-        BackendKind::Interpreter
-    ));
+                            BackendKind::Interpreter));
 
 // TODO(d1jang): Replace return for GTEST_SKIP() so that skipped tests are
 // correctly reported once the macro gets available.
-#define ENABLED_BACKENDS(...) if(!isEnabledBackend({__VA_ARGS__})) return;
+#define ENABLED_BACKENDS(...)                                                  \
+  if (!isEnabledBackend({__VA_ARGS__}))                                        \
+    return;
 
 TEST_P(Operator, pow) {
   auto *X = mod_.createPlaceholder(ElemKind::FloatTy, {1, 1, 3}, "X", false);

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -34,7 +34,7 @@ public:
   ~Operator() override { mod_.clear(); }
 
 protected:
-  bool isEnabledBackend(const std::set<BackendKind> enabledBackends) {
+  bool isEnabledBackend(const std::set<BackendKind>& enabledBackends) {
     return enabledBackends.find(GetParam()) != enabledBackends.end();
   }
 


### PR DESCRIPTION
*Description*:

What we'd need is to specific backends that each test case is enabled for, however, GTEST is incapable of parameterizing each test case separately since GTEST's parameterization only works per harness.
We could create a new harness for a test case to achieve that, but it's too verbose. This diff proposes a compromise:
We put all test cases under a single harness instantiated for all possible backends -- as a result all test cases will be running for all backends. To whitelist specific backends for each specific test case, ENABLED_BACKENDS(backend1, backend2, ...) is used as a guard for each test to enable it only for specific backends.

*Testing*:

Ran OperationTest to see it passes.

*Documentation*:

Fixes #2170

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
