### PR TITLE
[Win32] Remove std::promise<llvm::Error>

### DIFF
--- a/tests/unittests/ExecutorTest.cpp
+++ b/tests/unittests/ExecutorTest.cpp
@@ -615,18 +615,20 @@ TEST_F(ThreadPoolExecutorTest, EmptyDAG) {
   std::unique_ptr<ExecutionContext> executorOutputContext;
 
   // Call Executor::run().
-  std::promise<llvm::Error> promise;
-  std::future<llvm::Error> future = promise.get_future();
+  llvm::Error runErr = llvm::Error::success();
+  std::promise<void> promise;
+  std::future<void> future = promise.get_future();
   executor_->run(nullptr, std::move(testContext), testRunId,
-                 [&promise, &executorRunId, &executorOutputContext](
+                 [&runErr, &promise, &executorRunId, &executorOutputContext](
                      RunIdentifierTy runId, llvm::Error err,
                      std::unique_ptr<ExecutionContext> context) {
                    executorRunId = runId;
                    executorOutputContext = std::move(context);
-                   promise.set_value(std::move(err));
+                   runErr = std::move(err);
+                   promise.set_value();
                  });
 
-  EXPECT_FALSE(errToBool(future.get()));
+  EXPECT_FALSE(errToBool(std::move(runErr)));
 
   EXPECT_EQ(executorRunId, testRunId);
 


### PR DESCRIPTION
*Description*: On Windows the LLVM JIT doesn't always work when executed on a different thread than the compile (see discussion in #2460). Until we work out how to fix that, just have windows build run unit tests in the DummyDeviceManager.
*Testing*: unit tests when forcing the ExecutionEngine through both branches.
*Documentation*:

cc @ayermolo 