### PR TITLE
Move DEBUG_TYPE after #includes

### DIFF
--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#define DEBUG_TYPE "opencl"
 
 // Silence Apple's warning about the deprecation of OpenCL.
 #define CL_SILENCE_DEPRECATION
@@ -38,6 +37,8 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Format.h"
 #include "llvm/Support/raw_ostream.h"
+
+#define DEBUG_TYPE "opencl"
 
 using namespace glow;
 using llvm::format;

--- a/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#define DEBUG_TYPE "opencl"
 
 // Silence Apple's warning about the deprecation of OpenCL.
 #define CL_SILENCE_DEPRECATION
@@ -27,6 +26,8 @@
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/raw_ostream.h"
+
+#define DEBUG_TYPE "opencl"
 
 using namespace glow;
 using namespace glow::runtime;

--- a/lib/CodeGen/MemoryAllocator.cpp
+++ b/lib/CodeGen/MemoryAllocator.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#define DEBUG_TYPE "memory-allocator"
-
 #include "glow/CodeGen/MemoryAllocator.h"
 #include "glow/Support/Debug.h"
 #include "glow/Support/Memory.h"
@@ -25,6 +23,8 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/raw_ostream.h"
+
+#define DEBUG_TYPE "memory-allocator"
 
 using namespace glow;
 

--- a/lib/IR/ChildMemSizeBasedScheduler.cpp
+++ b/lib/IR/ChildMemSizeBasedScheduler.cpp
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#define DEBUG_TYPE "graph-scheduler"
 
 #include "GraphScheduler.h"
 
@@ -23,6 +22,8 @@
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
+
+#define DEBUG_TYPE "graph-scheduler"
 
 using llvm::cast;
 using llvm::dyn_cast;

--- a/lib/LLVMIRCodeGen/AllocationsInfo.cpp
+++ b/lib/LLVMIRCodeGen/AllocationsInfo.cpp
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#define DEBUG_TYPE "jit-allocations"
 
 #include "AllocationsInfo.h"
 #include "glow/Backends/CompiledFunction.h"
@@ -28,6 +27,8 @@
 
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/raw_ostream.h"
+
+#define DEBUG_TYPE "jit-allocations"
 
 using namespace glow;
 using llvm::cast;

--- a/lib/LLVMIRCodeGen/BundleSaver.cpp
+++ b/lib/LLVMIRCodeGen/BundleSaver.cpp
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#define DEBUG_TYPE "jit"
 
 #include "BundleSaver.h"
 
@@ -33,6 +32,8 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/raw_ostream.h"
+
+#define DEBUG_TYPE "jit"
 
 using namespace glow;
 using llvm::cast;

--- a/lib/LLVMIRCodeGen/FunctionSpecializer.cpp
+++ b/lib/LLVMIRCodeGen/FunctionSpecializer.cpp
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#define DEBUG_TYPE "ir-function-specializer"
 
 #include "CommandLine.h"
 #include "glow/LLVMIRCodeGen/LLVMBackend.h"
@@ -26,6 +25,8 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/Transforms/Utils/ValueMapper.h"
+
+#define DEBUG_TYPE "ir-function-specializer"
 
 using namespace glow;
 

--- a/lib/Optimizer/IROptimizer.cpp
+++ b/lib/Optimizer/IROptimizer.cpp
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#define DEBUG_TYPE "ir-optimizer"
 
 #include "glow/Backends/Backend.h"
 #include "glow/Graph/Graph.h"
@@ -33,6 +32,8 @@
 #include <iostream>
 #include <unordered_map>
 #include <unordered_set>
+
+#define DEBUG_TYPE "ir-optimizer"
 
 namespace {
 static llvm::cl::opt<bool>


### PR DESCRIPTION
*Description*: Some llvm headers #undef this macro, which leads to undefined symbol errors.  It's safer to #define it after all the other #includes.

*Testing*: build with an fb-internal platform where the issue repros.

*Documentation*: n/a
