### PR TITLE
[unbreak][unittests] Fix shared build for BackendTestUtils

### DIFF
--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -9,8 +9,13 @@ add_library(BackendTestUtils
             BackendTestUtils.cpp)
 target_link_libraries(BackendTestUtils
                       PRIVATE
+                        Base
                         Converter
+                        ExecutionEngine
+                        Graph
+                        Optimizer
                         Quantization
+                        QuantizationBase
                         LLVMSupport
                         gtest)
 


### PR DESCRIPTION
Forgot to include all necessary libs for BackendTestUtils in https://github.com/pytorch/glow/pull/2474. Don't know why this is breaking locally on Mac but not on the CI shared build...