### PR TITLE
replace runtime PlaceholderBindings with ExecutionContext

### DIFF
--- a/include/glow/Backends/CompiledFunction.h
+++ b/include/glow/Backends/CompiledFunction.h
@@ -17,7 +17,7 @@
 #define GLOW_BACKENDS_COMPILEDFUNCTION_H
 
 #include "glow/Backends/BackendUtils.h"
-#include "glow/Backends/TraceEvents.h"
+#include "glow/Backends/ExecutionContext.h"
 #include "glow/Graph/Nodes.h"
 
 #include <unordered_map>
@@ -39,7 +39,7 @@ public:
   virtual ~CompiledFunction();
   /// Execute the network and allocate Placeholder memory with given
   /// \p bindings providing mapping between Placeholder and populated tensor.
-  virtual void execute(PlaceholderBindings *bindings) = 0;
+  virtual void execute(ExecutionContext *context) = 0;
 
   /// Does any needed initialization work for the Backend.
   /// This includes device init constant memory allocation and copying to
@@ -69,7 +69,7 @@ public:
   const TraceInfo &getTraceInfo() const { return traceInfo_; }
 
   /// Read trace events out of this func and write them into /p bindings
-  virtual void translateTraceEvents(PlaceholderBindings *bindings) const {}
+  virtual void translateTraceEvents(ExecutionContext *bindings) const {}
 
   /// \returns the Kind of Backend used to compile this function.
   virtual BackendKind getCompileBackendKind() const = 0;

--- a/include/glow/Backends/DeviceManager.h
+++ b/include/glow/Backends/DeviceManager.h
@@ -18,8 +18,8 @@
 
 #include "glow/Backends/Backend.h"
 #include "glow/Backends/CompiledFunction.h"
+#include "glow/Backends/ExecutionContext.h"
 #include "glow/Graph/Graph.h"
-#include "glow/Graph/PlaceholderBindings.h"
 #include "glow/Runtime/RuntimeTypes.h"
 
 #include <functional>
@@ -79,11 +79,12 @@ public:
 
   /// Execute the named Function in an already provided network on the device.
   /// functionName must match the name of a function already added.
-  /// PlaceholderBindings should have all Placeholders allocated. resultCB will
-  /// be called with the PlaceholderBindings results filled.
+  /// The ExecutionContext's PlaceholderBindings should have all Placeholders
+  /// allocated. resultCB will be called with the ExecutionContext containing
+  /// output tensors filled, and any generated TraceEvents.
   virtual runtime::RunIdentifierTy
   runFunction(std::string functionName,
-              std::unique_ptr<PlaceholderBindings> bindings,
+              std::unique_ptr<ExecutionContext> context,
               runtime::ResultCBTy resultCB) = 0;
 
   /// Stops execution and shuts down the Device.

--- a/include/glow/Backends/ExecutionContext.h
+++ b/include/glow/Backends/ExecutionContext.h
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_BACKENDS_EXECUTIONCONTEXT_H
+#define GLOW_BACKENDS_EXECUTIONCONTEXT_H
+
+#include "glow/Backends/TraceEvents.h"
+#include "glow/Graph/PlaceholderBindings.h"
+
+#include "llvm/ADT/STLExtras.h"
+
+namespace glow {
+
+enum class BackendKind;
+
+/// Sub-classed per backend, this holds Device specific per-function information
+/// if that is necessary on that particular backend.
+class DeviceBindings {
+  const glow::BackendKind backend_;
+
+public:
+  DeviceBindings(BackendKind kind) : backend_{kind} {}
+  virtual ~DeviceBindings() {}
+
+  virtual std::unique_ptr<DeviceBindings> clone() {
+    return llvm::make_unique<DeviceBindings>(backend_);
+  }
+
+  BackendKind getBackendKind() { return backend_; }
+};
+
+/// The runtime context for a single execution (Inferance or Training) in the
+/// the Glow Execution Engine or HostManager. This class includes the mapping
+/// between Input/Output Placeholders and the materialized Tensors used for this
+/// run, the set of Device specific details required to execute the function,
+/// and stores TraceEvents that were generated as a result of the run.
+class ExecutionContext {
+  std::unique_ptr<PlaceholderBindings> placeholderBindings_;
+  std::unique_ptr<DeviceBindings> deviceBindings_;
+
+  /// Trace Events recorded during this run.
+  std::vector<TraceEvent> traceEvents_;
+
+public:
+  ExecutionContext()
+      : placeholderBindings_(llvm::make_unique<PlaceholderBindings>()) {}
+
+  ExecutionContext(std::unique_ptr<PlaceholderBindings> bindings)
+      : placeholderBindings_(std::move(bindings)) {}
+
+  ExecutionContext(std::unique_ptr<PlaceholderBindings> bindings,
+                   std::unique_ptr<DeviceBindings> devices)
+      : placeholderBindings_(std::move(bindings)),
+        deviceBindings_(std::move(devices)) {}
+
+  /// \returns TraceEvents for the last run.
+  std::vector<TraceEvent> &getTraceEvents() { return traceEvents_; }
+
+  /// \returns a non-owning pointer to the PlaceholderBindings.
+  PlaceholderBindings *getPlaceholderBindings() {
+    return placeholderBindings_.get();
+  }
+
+  /// \returns a const non-owning pointer to the PlaceholderBindings.
+  const PlaceholderBindings *getPlaceholderBindings() const {
+    return placeholderBindings_.get();
+  }
+
+  /// \returns an owning pointer to the PlaceholderBindings.
+  std::unique_ptr<PlaceholderBindings> movePlaceholderBindings() {
+    return std::move(placeholderBindings_);
+  }
+
+  /// \returns a non-owning pointer to the DeviceBindings.
+  DeviceBindings *getDeviceBindings() { return deviceBindings_.get(); }
+
+  /// \returns a const non-owning pointer to the DeviceBindings.
+  const DeviceBindings *getDeviceBindings() const {
+    return deviceBindings_.get();
+  }
+
+  /// Sets the DeviceBindings and \returns the existing value.
+  std::unique_ptr<DeviceBindings>
+  setDeviceBindings(std::unique_ptr<DeviceBindings> bindings) {
+    std::swap(deviceBindings_, bindings);
+    return bindings;
+  }
+
+  /// Clones this ExecutionContext, but does not clone underlying Tensors.
+  ExecutionContext clone() {
+    if (deviceBindings_) {
+      return ExecutionContext(
+          llvm::make_unique<PlaceholderBindings>(placeholderBindings_->clone()),
+          deviceBindings_->clone());
+    } else {
+      return ExecutionContext(llvm::make_unique<PlaceholderBindings>(
+          placeholderBindings_->clone()));
+    }
+  }
+};
+
+} // namespace glow
+
+#endif // GLOW_BACKENDS_EXECUTIONCONTEXT_H

--- a/include/glow/Backends/QueueBackedDeviceManager.h
+++ b/include/glow/Backends/QueueBackedDeviceManager.h
@@ -65,16 +65,17 @@ public:
 
   /// Execute the named Function in an already provided network on the device.
   /// functionName must match the name of a function already added.
-  /// PlaceholderBindings \p bindings should have all Placeholders allocated.
-  /// resultCB will be called with the bindings results filled.
+  /// The ExecutionContext's PlaceholderBindings should have all Placeholders
+  /// allocated. resultCB will be called with the ExecutionContext containing
+  /// output tensors filled, and any generated TraceEvents.
   RunIdentifierTy runFunction(std::string functionName,
-                              std::unique_ptr<PlaceholderBindings> bindings,
+                              std::unique_ptr<ExecutionContext> context,
                               ResultCBTy callback) override {
     RunIdentifierTy id = nextIdentifier_++;
     workThread_.submit([this, id, functionName = std::move(functionName),
-                        bindings = std::move(bindings),
+                        context = std::move(context),
                         callback = std::move(callback)]() mutable {
-      runFunctionImpl(id, std::move(functionName), std::move(bindings),
+      runFunctionImpl(id, std::move(functionName), std::move(context),
                       std::move(callback));
     });
     return id;
@@ -99,7 +100,7 @@ protected:
 
   /// Execute provided Function.
   virtual void runFunctionImpl(RunIdentifierTy, std::string,
-                               std::unique_ptr<PlaceholderBindings>,
+                               std::unique_ptr<ExecutionContext>,
                                ResultCBTy) = 0;
 };
 } // namespace runtime

--- a/include/glow/ExecutionEngine/ExecutionEngine.h
+++ b/include/glow/ExecutionEngine/ExecutionEngine.h
@@ -56,7 +56,7 @@ class ExecutionEngine final {
 
   /// Single execution of the given \compiledFunction with the given context
   /// \bindings.
-  void runInternal(PlaceholderBindings &bindings, llvm::StringRef name,
+  void runInternal(ExecutionContext &context, llvm::StringRef name,
                    CompiledFunction &compiledFunction);
 
 public:
@@ -121,12 +121,21 @@ public:
   void save(Function *F, const CompilationOptions &opts,
             llvm::StringRef outputDir, llvm::StringRef networkName);
 
-  /// PlaceholderBindings aware single execution of a function. If more than one
+  /// Context aware single execution of a function. If more than one
+  /// function has been compiled by this ExecutionEngine then a name must be
+  /// supplied to specify which function to run.
+  void run(ExecutionContext &context);
+
+  /// Context aware single execution of a function with the given \p
+  /// name.
+  void run(ExecutionContext &context, llvm::StringRef name);
+
+  /// Context aware single execution of a function. If more than one
   /// function has been compiled by this ExecutionEngine then a name must be
   /// supplied to specify which function to run.
   void run(PlaceholderBindings &bindings);
 
-  /// PlaceholderBindings aware single execution of a function with the given \p
+  /// Context aware single execution of a function with the given \p
   /// name.
   void run(PlaceholderBindings &bindings, llvm::StringRef name);
 };

--- a/include/glow/Graph/PlaceholderBindings.h
+++ b/include/glow/Graph/PlaceholderBindings.h
@@ -50,9 +50,6 @@ private:
   /// Maps Placeholder names to Placeholders.
   PlaceholderNameMap nameMap_;
 
-  /// Trace Events recorded during this run.
-  std::vector<TraceEvent> traceEvents_;
-
 public:
   /// \returns true if \p A and \p B contain the same Placeholders mapped to
   /// equivalent Tensors.
@@ -101,9 +98,6 @@ public:
   /// \returns the size in bytes of allocated Tensors owned by
   /// PlaceholderBindings.
   uint64_t getDataSize() const;
-
-  /// \returns TraceEvents for the last run.
-  std::vector<TraceEvent> &getTraceEvents() { return traceEvents_; }
 
   PlaceholderBindings() = default;
 

--- a/include/glow/LLVMIRCodeGen/LLVMCompiledFunction.h
+++ b/include/glow/LLVMIRCodeGen/LLVMCompiledFunction.h
@@ -31,13 +31,12 @@ public:
   /// \name CompiledFunction interface
   ///@{
   virtual ~LLVMCompiledFunction() override;
-  virtual void execute(PlaceholderBindings *bindings) override;
+  virtual void execute(ExecutionContext *context) override;
 
   virtual void collectConstants(Module *module) override;
 
   /// Read trace events out of this func and write them into /p bindings
-  virtual void
-  translateTraceEvents(PlaceholderBindings *bindings) const override;
+  virtual void translateTraceEvents(ExecutionContext *context) const override;
   ///@}
   //
 

--- a/include/glow/Runtime/Executor/Executor.h
+++ b/include/glow/Runtime/Executor/Executor.h
@@ -49,7 +49,7 @@ public:
   /// no postrequisites (i.e. the final results) in addition to the mappings
   /// present in \p bindings.
   virtual void run(const DAGNode *root,
-                   std::unique_ptr<PlaceholderBindings> bindings,
+                   std::unique_ptr<ExecutionContext> context,
                    RunIdentifierTy runId, ResultCBTy cb) = 0;
 
   /// Shutdown the Executor. Should block until all active requests are complete

--- a/include/glow/Runtime/HostManager/HostManager.h
+++ b/include/glow/Runtime/HostManager/HostManager.h
@@ -109,7 +109,7 @@ public:
   /// concurrently from mutliple threads.
   /// Returns -1 if networkName not found or too many active requests.
   RunIdentifierTy runNetwork(llvm::StringRef networkName,
-                             std::unique_ptr<PlaceholderBindings> context,
+                             std::unique_ptr<ExecutionContext> context,
                              ResultCBTy callback);
   HostManager(const std::vector<DeviceManagerConfig> &configs);
   ~HostManager();

--- a/include/glow/Runtime/RuntimeTypes.h
+++ b/include/glow/Runtime/RuntimeTypes.h
@@ -26,6 +26,9 @@
 #include <vector>
 
 namespace glow {
+
+class ExecutionContext;
+
 namespace runtime {
 
 class DeviceManager;
@@ -43,7 +46,7 @@ enum class ResultCode { Ready, Executed, Failed, Canceled };
 /// an inference request back to the caller.
 using ResultCBTy =
     std::function<void(runtime::RunIdentifierTy, runtime::ResultCode,
-                       std::unique_ptr<PlaceholderBindings>)>;
+                       std::unique_ptr<ExecutionContext>)>;
 
 /// Data structure that contains device constraint information for each device.
 /// Used to communicate memory constraints and later costs to the Partitioner.

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -20,7 +20,6 @@
 
 #include "glow/Backends/BackendUtils.h"
 #include "glow/Graph/Graph.h"
-#include "glow/Graph/PlaceholderBindings.h"
 #include "glow/IR/Instrs.h"
 #include "glow/LLVMIRCodeGen/LLVMIRGen.h"
 #include "glow/Support/Debug.h"

--- a/lib/Backends/CPU/CPUBackend.h
+++ b/lib/Backends/CPU/CPUBackend.h
@@ -25,7 +25,6 @@
 
 namespace glow {
 
-class PlaceholderBindings;
 class NodeInfo;
 
 class CPUBackend : public LLVMBackend {

--- a/lib/Backends/CPU/CPUDeviceManager.cpp
+++ b/lib/Backends/CPU/CPUDeviceManager.cpp
@@ -96,20 +96,20 @@ void CPUDeviceManager::evictNetworkImpl(std::string functionName,
 
 void CPUDeviceManager::runFunctionImpl(
     RunIdentifierTy id, std::string function,
-    std::unique_ptr<PlaceholderBindings> bindings, ResultCBTy resultCB) {
+    std::unique_ptr<ExecutionContext> context, ResultCBTy resultCB) {
   auto funcIt = functions_.find(function);
   if (funcIt == functions_.end()) {
     llvm::errs() << "Failed to run function: name " << function
                  << " not found.\n";
-    resultCB(id, ResultCode::Failed, std::move(bindings));
+    resultCB(id, ResultCode::Failed, std::move(context));
     return;
   }
 
   CompiledFunction *func = funcIt->second;
 
   // Run that function.
-  func->execute(bindings.get());
+  func->execute(context.get());
 
   // Fire the resultCB.
-  resultCB(id, ResultCode::Executed, std::move(bindings));
+  resultCB(id, ResultCode::Executed, std::move(context));
 }

--- a/lib/Backends/CPU/CPUDeviceManager.h
+++ b/lib/Backends/CPU/CPUDeviceManager.h
@@ -63,7 +63,7 @@ protected:
   void evictNetworkImpl(std::string functionName,
                         EvictFunctionCBTy evictCb) override;
   void runFunctionImpl(runtime::RunIdentifierTy id, std::string functionName,
-                       std::unique_ptr<PlaceholderBindings> bindings,
+                       std::unique_ptr<ExecutionContext> context,
                        ResultCBTy cb) override;
 };
 

--- a/lib/Backends/CPU/CPUFunction.cpp
+++ b/lib/Backends/CPU/CPUFunction.cpp
@@ -25,6 +25,6 @@ CPUFunction::CPUFunction(std::unique_ptr<llvm::orc::GlowJIT> JIT,
                          const runtime::RuntimeBundle &runtimeBundle)
     : LLVMCompiledFunction(std::move(JIT), runtimeBundle) {}
 
-void CPUFunction::execute(PlaceholderBindings *bindings) {
-  LLVMCompiledFunction::execute(bindings);
+void CPUFunction::execute(ExecutionContext *context) {
+  LLVMCompiledFunction::execute(context);
 }

--- a/lib/Backends/CPU/CPUFunction.h
+++ b/lib/Backends/CPU/CPUFunction.h
@@ -33,7 +33,7 @@ public:
   /// \name CompiledFunction interface
   ///@{
   ~CPUFunction() override = default;
-  void execute(PlaceholderBindings *bindings) override;
+  void execute(ExecutionContext *context) override;
 
   /// \returns the Kind of Backend used to compile this function.
   virtual BackendKind getCompileBackendKind() const override {

--- a/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
@@ -94,22 +94,22 @@ void InterpreterDeviceManager::evictNetworkImpl(std::string functionName,
 
 void InterpreterDeviceManager::runFunctionImpl(
     RunIdentifierTy id, std::string function,
-    std::unique_ptr<PlaceholderBindings> bindings, ResultCBTy resultCB) {
+    std::unique_ptr<ExecutionContext> context, ResultCBTy resultCB) {
   auto funcIt = functions_.find(function);
   if (funcIt == functions_.end()) {
     llvm::errs() << "Failed to run function: name " << function
                  << " not found.\n";
-    resultCB(id, ResultCode::Failed, std::move(bindings));
+    resultCB(id, ResultCode::Failed, std::move(context));
     return;
   }
 
   CompiledFunction *func = funcIt->second;
 
   // Run that function.
-  func->execute(bindings.get());
+  func->execute(context.get());
 
   // Fire the resultCB.
-  resultCB(id, ResultCode::Executed, std::move(bindings));
+  resultCB(id, ResultCode::Executed, std::move(context));
 }
 
 } // namespace runtime

--- a/lib/Backends/Interpreter/InterpreterDeviceManager.h
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.h
@@ -63,7 +63,7 @@ protected:
   void evictNetworkImpl(std::string functionName,
                         EvictFunctionCBTy evictCB) override;
   void runFunctionImpl(runtime::RunIdentifierTy id, std::string functionName,
-                       std::unique_ptr<PlaceholderBindings> bindings,
+                       std::unique_ptr<ExecutionContext> context,
                        ResultCBTy cb) override;
 };
 

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -19,8 +19,8 @@
 #include "glow/Backends/Backend.h"
 #include "glow/Backends/BackendUtils.h"
 #include "glow/Backends/CompiledFunction.h"
+#include "glow/Backends/ExecutionContext.h"
 #include "glow/Base/Tensor.h"
-#include "glow/Graph/PlaceholderBindings.h"
 #include "glow/Quantization/Base/Base.h"
 
 #include "llvm/ADT/ArrayRef.h"
@@ -30,7 +30,6 @@
 
 namespace glow {
 
-class PlaceholderBindings;
 class IRFunction;
 class Value;
 class Tensor;
@@ -58,7 +57,7 @@ public:
   ///@{
   ~InterpreterFunction() override;
 
-  void execute(PlaceholderBindings *bindings) override;
+  void execute(ExecutionContext *context) override;
 
   /// Collects constants for runtime.
   void collectConstants(Module *module) override;
@@ -66,8 +65,8 @@ public:
   /// Get reference to IR function.
   IRFunction *getIR() { return F_.get(); }
 
-  /// Read trace events out of this func and write them into /p bindings
-  void translateTraceEvents(PlaceholderBindings *bindings) const override;
+  /// Read trace events out of this func and write them into /p context
+  void translateTraceEvents(ExecutionContext *context) const override;
 
   /// \returns the Kind of Backend used to compile this function.
   virtual BackendKind getCompileBackendKind() const override {
@@ -94,7 +93,7 @@ public:
 
   ~BoundInterpreterFunction();
 
-  void execute(IRFunction *F, PlaceholderBindings *bindings);
+  void execute(IRFunction *F, ExecutionContext *context);
 
 private:
   /// \returns a pointer to the tensor that is saved under \p v.

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -622,8 +622,8 @@ static void topK(Tensor &outW, Tensor &indW, Tensor &inW, size_t k) {
   }
 }
 
-void OpenCLFunction::execute(PlaceholderBindings *bindings) {
-  (void)bindings;
+void OpenCLFunction::execute(ExecutionContext *context) {
+  (void)context;
 
   for (const auto &I : F_->getInstrs()) {
     // Skip memory allocation instructions as they are NOPs.

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -19,10 +19,10 @@
 #include "glow/Backends/Backend.h"
 #include "glow/Backends/BackendUtils.h"
 #include "glow/Backends/CompiledFunction.h"
+#include "glow/Backends/ExecutionContext.h"
 #include "glow/Base/Tensor.h"
 #include "glow/Base/Traits.h"
 #include "glow/Graph/Node.h"
-#include "glow/Graph/PlaceholderBindings.h"
 #include "glow/IR/IR.h"
 #include "llvm/ADT/ArrayRef.h"
 
@@ -96,7 +96,7 @@ public:
   ///@{
   ~OpenCLFunction() override;
 
-  void execute(PlaceholderBindings *bindings) override;
+  void execute(ExecutionContext *context) override;
   /// Allocates on device buffer and copies Constant weights to device.
   void setupRuns() override;
   /// Per run setup, copies Inputs from \p bindings to on device memory.

--- a/lib/Backends/OpenCL/OpenCLDeviceManager.h
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.h
@@ -117,7 +117,7 @@ protected:
   /// Run the function on the device, there is a single thread of execution so
   /// only one function can execute at a time.
   void runFunctionImpl(runtime::RunIdentifierTy id, std::string functionName,
-                       std::unique_ptr<PlaceholderBindings> bindings,
+                       std::unique_ptr<ExecutionContext> context,
                        ResultCBTy cb) override;
 };
 /// OpenCL Device Manager config object. This contains the information needed to

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -143,26 +143,26 @@ void HostManager::clearHost() {
 
 RunIdentifierTy
 HostManager::runNetwork(llvm::StringRef networkName,
-                        std::unique_ptr<PlaceholderBindings> bindings,
+                        std::unique_ptr<ExecutionContext> context,
                         ResultCBTy callback) {
 
   auto currentRun = totalRequestCount_++;
   std::lock_guard<std::mutex> networkLock(networkLock_);
   if (roots_.find(networkName) == roots_.end()) {
-    callback(currentRun, ResultCode::Failed, std::move(bindings));
+    callback(currentRun, ResultCode::Failed, std::move(context));
     return currentRun;
   }
   if (activeRequestCount_ >= activeRequestLimit_) {
-    callback(currentRun, ResultCode::Canceled, std::move(bindings));
+    callback(currentRun, ResultCode::Canceled, std::move(context));
     return currentRun;
   }
   activeRequestCount_++;
-  executor_->run(roots_[networkName].get(), std::move(bindings), currentRun,
+  executor_->run(roots_[networkName].get(), std::move(context), currentRun,
                  [&activeRequest = this->activeRequestCount_,
                   callback](RunIdentifierTy runID, ResultCode result,
-                            std::unique_ptr<PlaceholderBindings> bindings) {
+                            std::unique_ptr<ExecutionContext> context) {
                    --activeRequest;
-                   callback(runID, result, std::move(bindings));
+                   callback(runID, result, std::move(context));
                  });
   return currentRun;
 }

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -31,7 +31,7 @@ namespace glow {
 /// MockBackend used only for unit testing.
 class MockBackend : public Backend {
   class MockFunction : public CompiledFunction {
-    void execute(PlaceholderBindings *) override {}
+    void execute(ExecutionContext *) override {}
 
     BackendKind getCompileBackendKind() const override {
       return BackendKind::Interpreter;
@@ -58,7 +58,7 @@ class MockBackend : public Backend {
 /// from Node to Instruction IR.
 class MockBackendCustomIRGen : public Backend {
   class MockFunction : public CompiledFunction {
-    void execute(PlaceholderBindings *) override {}
+    void execute(ExecutionContext *) override {}
 
     BackendKind getCompileBackendKind() const override {
       return BackendKind::Interpreter;

--- a/tests/unittests/DeviceManagerTest.cpp
+++ b/tests/unittests/DeviceManagerTest.cpp
@@ -104,35 +104,36 @@ TEST_P(DeviceManagerTest, Basic) {
   future.wait_for(std::chrono::seconds(2));
   EXPECT_EQ(future.get(), module.get());
 
-  std::unique_ptr<PlaceholderBindings> bindings =
-      llvm::make_unique<PlaceholderBindings>();
-  bindings->allocate(module->getPlaceholders());
+  std::unique_ptr<ExecutionContext> context =
+      llvm::make_unique<ExecutionContext>();
+  context->getPlaceholderBindings()->allocate(module->getPlaceholders());
 
   Tensor input1(ElemKind::FloatTy, {1});
   Tensor output1(ElemKind::FloatTy, {1});
   input1.getHandle().clear(2);
   output1.getHandle().clear(4);
 
-  updateInputPlaceholders(
-      *bindings, {module->getPlaceholderByName("main_input")}, {&input1});
+  updateInputPlaceholders(*context->getPlaceholderBindings(),
+                          {module->getPlaceholderByName("main_input")},
+                          {&input1});
 
-  std::promise<std::unique_ptr<PlaceholderBindings>> runPromise;
-  std::future<std::unique_ptr<PlaceholderBindings>> runFuture;
+  std::promise<std::unique_ptr<ExecutionContext>> runPromise;
+  std::future<std::unique_ptr<ExecutionContext>> runFuture;
 
   std::tie(runPromise, runFuture) =
-      getFutureHelper<std::unique_ptr<PlaceholderBindings>>();
-  device->runFunction(
-      "main", std::move(bindings),
-      [&runPromise](RunIdentifierTy, ResultCode result,
-                    std::unique_ptr<PlaceholderBindings> bindings_) {
-        callbackHelper(runPromise, std::move(bindings_), result,
-                       ResultCode::Executed);
-      });
+      getFutureHelper<std::unique_ptr<ExecutionContext>>();
+  device->runFunction("main", std::move(context),
+                      [&runPromise](RunIdentifierTy, ResultCode result,
+                                    std::unique_ptr<ExecutionContext> context) {
+                        callbackHelper(runPromise, std::move(context), result,
+                                       ResultCode::Executed);
+                      });
 
   runFuture.wait_for(std::chrono::seconds(2));
-  bindings = runFuture.get();
-  ASSERT_TRUE(bindings);
-  Tensor *result1 = bindings->get(module->getPlaceholderByName("main_output"));
+  context = runFuture.get();
+  ASSERT_TRUE(context);
+  Tensor *result1 = context->getPlaceholderBindings()->get(
+      module->getPlaceholderByName("main_output"));
   ASSERT_TRUE(result1);
   EXPECT_TRUE(result1->isEqual(output1));
 
@@ -161,12 +162,12 @@ TEST_P(DeviceManagerTest, MultiRun) {
   future.wait_for(std::chrono::seconds(2));
   EXPECT_EQ(future.get(), module.get());
 
-  std::unique_ptr<PlaceholderBindings> bindings1 =
-      llvm::make_unique<PlaceholderBindings>();
-  std::unique_ptr<PlaceholderBindings> bindings2 =
-      llvm::make_unique<PlaceholderBindings>();
-  bindings1->allocate(module->getPlaceholders());
-  bindings2->allocate(module->getPlaceholders());
+  std::unique_ptr<ExecutionContext> context1 =
+      llvm::make_unique<ExecutionContext>();
+  std::unique_ptr<ExecutionContext> context2 =
+      llvm::make_unique<ExecutionContext>();
+  context1->getPlaceholderBindings()->allocate(module->getPlaceholders());
+  context2->getPlaceholderBindings()->allocate(module->getPlaceholders());
 
   Tensor input1(ElemKind::FloatTy, {1});
   Tensor input2(ElemKind::FloatTy, {1});
@@ -178,40 +179,42 @@ TEST_P(DeviceManagerTest, MultiRun) {
   output1.getHandle().clear(4.0f);
   output2.getHandle().clear(9.0f);
 
-  updateInputPlaceholders(
-      *bindings1, {module->getPlaceholderByName("main_input")}, {&input1});
-  updateInputPlaceholders(
-      *bindings2, {module->getPlaceholderByName("main_input")}, {&input2});
+  updateInputPlaceholders(*context1->getPlaceholderBindings(),
+                          {module->getPlaceholderByName("main_input")},
+                          {&input1});
+  updateInputPlaceholders(*context2->getPlaceholderBindings(),
+                          {module->getPlaceholderByName("main_input")},
+                          {&input2});
 
-  std::promise<std::unique_ptr<PlaceholderBindings>> runP1, runP2;
-  std::future<std::unique_ptr<PlaceholderBindings>> runF1, runF2;
-  std::tie(runP1, runF1) =
-      getFutureHelper<std::unique_ptr<PlaceholderBindings>>();
-  std::tie(runP2, runF2) =
-      getFutureHelper<std::unique_ptr<PlaceholderBindings>>();
+  std::promise<std::unique_ptr<ExecutionContext>> runP1, runP2;
+  std::future<std::unique_ptr<ExecutionContext>> runF1, runF2;
+  std::tie(runP1, runF1) = getFutureHelper<std::unique_ptr<ExecutionContext>>();
+  std::tie(runP2, runF2) = getFutureHelper<std::unique_ptr<ExecutionContext>>();
 
-  device->runFunction("main", std::move(bindings1),
+  device->runFunction("main", std::move(context1),
                       [&runP1](RunIdentifierTy, ResultCode result,
-                               std::unique_ptr<PlaceholderBindings> bindings_) {
-                        callbackHelper(runP1, std::move(bindings_), result,
+                               std::unique_ptr<ExecutionContext> context) {
+                        callbackHelper(runP1, std::move(context), result,
                                        ResultCode::Executed);
                       });
 
-  device->runFunction("main", std::move(bindings2),
+  device->runFunction("main", std::move(context2),
                       [&runP2](RunIdentifierTy, ResultCode result,
-                               std::unique_ptr<PlaceholderBindings> bindings_) {
-                        callbackHelper(runP2, std::move(bindings_), result,
+                               std::unique_ptr<ExecutionContext> context) {
+                        callbackHelper(runP2, std::move(context), result,
                                        ResultCode::Executed);
                       });
 
-  bindings1 = runF1.get();
-  bindings2 = runF2.get();
-  ASSERT_TRUE(bindings1);
-  ASSERT_TRUE(bindings2);
-  EXPECT_NE(bindings1, bindings2);
+  context1 = runF1.get();
+  context2 = runF2.get();
+  ASSERT_TRUE(context1);
+  ASSERT_TRUE(context2);
+  EXPECT_NE(context1, context2);
 
-  Tensor *result1 = bindings1->get(module->getPlaceholderByName("main_output"));
-  Tensor *result2 = bindings2->get(module->getPlaceholderByName("main_output"));
+  Tensor *result1 = context1->getPlaceholderBindings()->get(
+      module->getPlaceholderByName("main_output"));
+  Tensor *result2 = context2->getPlaceholderBindings()->get(
+      module->getPlaceholderByName("main_output"));
   ASSERT_TRUE(result1);
   ASSERT_TRUE(result2);
   EXPECT_TRUE(result1->isEqual(output1));
@@ -225,11 +228,11 @@ TEST_P(DeviceManagerTest, MultiRun) {
 TEST_P(DeviceManagerTest, MultiFunction) {
   auto module = makeBasicModule("func1");
 
-  std::unique_ptr<PlaceholderBindings> bindings1 =
-      llvm::make_unique<PlaceholderBindings>();
-  std::unique_ptr<PlaceholderBindings> bindings2 =
-      llvm::make_unique<PlaceholderBindings>();
-  bindings1->allocate(module->getPlaceholders());
+  std::unique_ptr<ExecutionContext> context1 =
+      llvm::make_unique<ExecutionContext>();
+  std::unique_ptr<ExecutionContext> context2 =
+      llvm::make_unique<ExecutionContext>();
+  context1->getPlaceholderBindings()->allocate(module->getPlaceholders());
 
   Function *F = module->createFunction("func2");
   auto *inP = module->getPlaceholderByName("func1_input");
@@ -238,8 +241,8 @@ TEST_P(DeviceManagerTest, MultiFunction) {
   auto *p = F->createPow("pow3", inP, 3.0f);
   F->createSave("ret2", p, outP);
 
-  bindings2->allocate(inP);
-  bindings2->allocate(outP);
+  context2->getPlaceholderBindings()->allocate(inP);
+  context2->getPlaceholderBindings()->allocate(outP);
 
   std::vector<std::unique_ptr<CompiledFunction>> backing;
   FunctionMapTy functions =
@@ -267,42 +270,42 @@ TEST_P(DeviceManagerTest, MultiFunction) {
   Tensor output2(ElemKind::FloatTy, {1});
   output2.getHandle().clear(8.0f);
 
-  updateInputPlaceholders(
-      *bindings1, {module->getPlaceholderByName("func1_input")}, {&input});
-  updateInputPlaceholders(
-      *bindings2, {module->getPlaceholderByName("func1_input")}, {&input});
+  updateInputPlaceholders(*context1->getPlaceholderBindings(),
+                          {module->getPlaceholderByName("func1_input")},
+                          {&input});
+  updateInputPlaceholders(*context2->getPlaceholderBindings(),
+                          {module->getPlaceholderByName("func1_input")},
+                          {&input});
 
-  std::promise<std::unique_ptr<PlaceholderBindings>> runP1, runP2;
-  std::future<std::unique_ptr<PlaceholderBindings>> runF1, runF2;
-  std::tie(runP1, runF1) =
-      getFutureHelper<std::unique_ptr<PlaceholderBindings>>();
-  std::tie(runP2, runF2) =
-      getFutureHelper<std::unique_ptr<PlaceholderBindings>>();
+  std::promise<std::unique_ptr<ExecutionContext>> runP1, runP2;
+  std::future<std::unique_ptr<ExecutionContext>> runF1, runF2;
+  std::tie(runP1, runF1) = getFutureHelper<std::unique_ptr<ExecutionContext>>();
+  std::tie(runP2, runF2) = getFutureHelper<std::unique_ptr<ExecutionContext>>();
 
-  device->runFunction("func1", std::move(bindings1),
+  device->runFunction("func1", std::move(context1),
                       [&runP1](RunIdentifierTy, ResultCode result,
-                               std::unique_ptr<PlaceholderBindings> bindings_) {
-                        callbackHelper(runP1, std::move(bindings_), result,
+                               std::unique_ptr<ExecutionContext> context) {
+                        callbackHelper(runP1, std::move(context), result,
                                        ResultCode::Executed);
                       });
 
-  device->runFunction("func2", std::move(bindings2),
+  device->runFunction("func2", std::move(context2),
                       [&runP2](RunIdentifierTy, ResultCode result,
-                               std::unique_ptr<PlaceholderBindings> bindings_) {
-                        callbackHelper(runP2, std::move(bindings_), result,
+                               std::unique_ptr<ExecutionContext> context) {
+                        callbackHelper(runP2, std::move(context), result,
                                        ResultCode::Executed);
                       });
 
-  bindings1 = runF1.get();
-  bindings2 = runF2.get();
-  ASSERT_TRUE(bindings1);
-  ASSERT_TRUE(bindings2);
-  EXPECT_NE(bindings1, bindings2);
+  context1 = runF1.get();
+  context2 = runF2.get();
+  ASSERT_TRUE(context1);
+  ASSERT_TRUE(context2);
+  EXPECT_NE(context1, context2);
 
-  Tensor *result1 =
-      bindings1->get(module->getPlaceholderByName("func1_output"));
-  Tensor *result2 =
-      bindings2->get(module->getPlaceholderByName("func2_output"));
+  Tensor *result1 = context1->getPlaceholderBindings()->get(
+      module->getPlaceholderByName("func1_output"));
+  Tensor *result2 = context2->getPlaceholderBindings()->get(
+      module->getPlaceholderByName("func2_output"));
   ASSERT_TRUE(result1);
   ASSERT_TRUE(result2);
   EXPECT_TRUE(result1->isEqual(output1));
@@ -346,57 +349,57 @@ TEST_P(DeviceManagerTest, MultiModule) {
   future.wait_for(std::chrono::seconds(2));
   EXPECT_EQ(future.get(), module2.get());
 
-  std::unique_ptr<PlaceholderBindings> bindings1 =
-      llvm::make_unique<PlaceholderBindings>();
-  bindings1->allocate(module1->getPlaceholders());
+  std::unique_ptr<ExecutionContext> context1 =
+      llvm::make_unique<ExecutionContext>();
+  context1->getPlaceholderBindings()->allocate(module1->getPlaceholders());
   Tensor input(ElemKind::FloatTy, {1});
   input.getHandle().clear(2.0f);
   Tensor output(ElemKind::FloatTy, {1});
   output.getHandle().clear(4.0f);
 
-  updateInputPlaceholders(
-      *bindings1, {module1->getPlaceholderByName("func1_input")}, {&input});
+  updateInputPlaceholders(*context1->getPlaceholderBindings(),
+                          {module1->getPlaceholderByName("func1_input")},
+                          {&input});
 
-  std::unique_ptr<PlaceholderBindings> bindings2 =
-      llvm::make_unique<PlaceholderBindings>();
-  bindings2->allocate(module2->getPlaceholders());
-  updateInputPlaceholders(
-      *bindings2, {module2->getPlaceholderByName("func2_input")}, {&input});
+  std::unique_ptr<ExecutionContext> context2 =
+      llvm::make_unique<ExecutionContext>();
+  context2->getPlaceholderBindings()->allocate(module2->getPlaceholders());
+  updateInputPlaceholders(*context2->getPlaceholderBindings(),
+                          {module2->getPlaceholderByName("func2_input")},
+                          {&input});
 
-  std::promise<std::unique_ptr<PlaceholderBindings>> runP1, runP2;
-  std::future<std::unique_ptr<PlaceholderBindings>> runF1, runF2;
-  std::tie(runP1, runF1) =
-      getFutureHelper<std::unique_ptr<PlaceholderBindings>>();
-  std::tie(runP2, runF2) =
-      getFutureHelper<std::unique_ptr<PlaceholderBindings>>();
+  std::promise<std::unique_ptr<ExecutionContext>> runP1, runP2;
+  std::future<std::unique_ptr<ExecutionContext>> runF1, runF2;
+  std::tie(runP1, runF1) = getFutureHelper<std::unique_ptr<ExecutionContext>>();
+  std::tie(runP2, runF2) = getFutureHelper<std::unique_ptr<ExecutionContext>>();
 
-  device->runFunction("func1", std::move(bindings1),
+  device->runFunction("func1", std::move(context1),
                       [&runP1](RunIdentifierTy, ResultCode result,
-                               std::unique_ptr<PlaceholderBindings> bindings_) {
-                        callbackHelper(runP1, std::move(bindings_), result,
+                               std::unique_ptr<ExecutionContext> context) {
+                        callbackHelper(runP1, std::move(context), result,
                                        ResultCode::Executed);
                       });
 
-  device->runFunction("func2", std::move(bindings2),
+  device->runFunction("func2", std::move(context2),
                       [&runP2](RunIdentifierTy, ResultCode result,
-                               std::unique_ptr<PlaceholderBindings> bindings_) {
-                        callbackHelper(runP2, std::move(bindings_), result,
+                               std::unique_ptr<ExecutionContext> context) {
+                        callbackHelper(runP2, std::move(context), result,
                                        ResultCode::Executed);
                       });
 
-  bindings1 = runF1.get();
-  bindings2 = runF2.get();
-  ASSERT_TRUE(bindings1);
-  ASSERT_TRUE(bindings2);
-  EXPECT_NE(bindings1, bindings2);
+  context1 = runF1.get();
+  context2 = runF2.get();
+  ASSERT_TRUE(context1);
+  ASSERT_TRUE(context2);
+  EXPECT_NE(context1, context2);
 
-  Tensor *result1 =
-      bindings1->get(module1->getPlaceholderByName("func1_output"));
+  Tensor *result1 = context1->getPlaceholderBindings()->get(
+      module1->getPlaceholderByName("func1_output"));
   ASSERT_TRUE(result1);
   EXPECT_TRUE(result1->isEqual(output));
 
-  Tensor *result2 =
-      bindings2->get(module2->getPlaceholderByName("func2_output"));
+  Tensor *result2 = context2->getPlaceholderBindings()->get(
+      module2->getPlaceholderByName("func2_output"));
   ASSERT_TRUE(result2);
   EXPECT_TRUE(result2->isEqual(output));
 
@@ -408,11 +411,11 @@ TEST_P(DeviceManagerTest, MultiModule) {
 TEST_P(DeviceManagerTest, ReuseModule) {
   auto module = makeBasicModule("func1");
 
-  std::unique_ptr<PlaceholderBindings> bindings1 =
-      llvm::make_unique<PlaceholderBindings>();
-  std::unique_ptr<PlaceholderBindings> bindings2 =
-      llvm::make_unique<PlaceholderBindings>();
-  bindings1->allocate(module->getPlaceholders());
+  std::unique_ptr<ExecutionContext> context1 =
+      llvm::make_unique<ExecutionContext>();
+  std::unique_ptr<ExecutionContext> context2 =
+      llvm::make_unique<ExecutionContext>();
+  context1->getPlaceholderBindings()->allocate(module->getPlaceholders());
 
   Function *F = module->createFunction("func2");
   auto *inP = module->getPlaceholderByName("func1_input");
@@ -421,8 +424,8 @@ TEST_P(DeviceManagerTest, ReuseModule) {
   auto *p = F->createPow("pow3", inP, 3.0f);
   F->createSave("ret2", p, outP);
 
-  bindings2->allocate(inP);
-  bindings2->allocate(outP);
+  context2->getPlaceholderBindings()->allocate(inP);
+  context2->getPlaceholderBindings()->allocate(outP);
 
   std::vector<std::unique_ptr<CompiledFunction>> backing;
   FunctionMapTy functions =
@@ -466,45 +469,45 @@ TEST_P(DeviceManagerTest, ReuseModule) {
   Tensor output2(ElemKind::FloatTy, {1});
   output2.getHandle().clear(8.0f);
 
-  updateInputPlaceholders(
-      *bindings1, {module->getPlaceholderByName("func1_input")}, {&input});
-  updateInputPlaceholders(
-      *bindings2, {module->getPlaceholderByName("func1_input")}, {&input});
+  updateInputPlaceholders(*context1->getPlaceholderBindings(),
+                          {module->getPlaceholderByName("func1_input")},
+                          {&input});
+  updateInputPlaceholders(*context2->getPlaceholderBindings(),
+                          {module->getPlaceholderByName("func1_input")},
+                          {&input});
 
-  std::promise<std::unique_ptr<PlaceholderBindings>> runP1, runP2;
-  std::future<std::unique_ptr<PlaceholderBindings>> runF1, runF2;
-  std::tie(runP1, runF1) =
-      getFutureHelper<std::unique_ptr<PlaceholderBindings>>();
-  std::tie(runP2, runF2) =
-      getFutureHelper<std::unique_ptr<PlaceholderBindings>>();
+  std::promise<std::unique_ptr<ExecutionContext>> runP1, runP2;
+  std::future<std::unique_ptr<ExecutionContext>> runF1, runF2;
+  std::tie(runP1, runF1) = getFutureHelper<std::unique_ptr<ExecutionContext>>();
+  std::tie(runP2, runF2) = getFutureHelper<std::unique_ptr<ExecutionContext>>();
 
-  device->runFunction("func1", std::move(bindings1),
+  device->runFunction("func1", std::move(context1),
                       [&runP1](RunIdentifierTy, ResultCode result,
-                               std::unique_ptr<PlaceholderBindings> bindings_) {
-                        callbackHelper(runP1, std::move(bindings_), result,
+                               std::unique_ptr<ExecutionContext> context) {
+                        callbackHelper(runP1, std::move(context), result,
                                        ResultCode::Executed);
                       });
 
-  device->runFunction("func2", std::move(bindings2),
+  device->runFunction("func2", std::move(context2),
                       [&runP2](RunIdentifierTy, ResultCode result,
-                               std::unique_ptr<PlaceholderBindings> bindings_) {
-                        callbackHelper(runP2, std::move(bindings_), result,
+                               std::unique_ptr<ExecutionContext> context) {
+                        callbackHelper(runP2, std::move(context), result,
                                        ResultCode::Executed);
                       });
 
-  bindings1 = runF1.get();
-  bindings2 = runF2.get();
-  ASSERT_TRUE(bindings1);
-  ASSERT_TRUE(bindings2);
-  EXPECT_NE(bindings1, bindings2);
+  context1 = runF1.get();
+  context2 = runF2.get();
+  ASSERT_TRUE(context1);
+  ASSERT_TRUE(context2);
+  EXPECT_NE(context1, context2);
 
-  Tensor *result1 =
-      bindings1->get(module->getPlaceholderByName("func1_output"));
+  Tensor *result1 = context1->getPlaceholderBindings()->get(
+      module->getPlaceholderByName("func1_output"));
   ASSERT_TRUE(result1);
   EXPECT_TRUE(result1->isEqual(output1));
 
-  Tensor *result2 =
-      bindings2->get(module->getPlaceholderByName("func2_output"));
+  Tensor *result2 = context2->getPlaceholderBindings()->get(
+      module->getPlaceholderByName("func2_output"));
   ASSERT_TRUE(result2);
   EXPECT_TRUE(result2->isEqual(output2));
 
@@ -611,28 +614,30 @@ TEST(DeviceManagerTest, DummyDeviceManager) {
   // no need to wait.
   EXPECT_EQ(future.get(), module.get());
 
-  std::unique_ptr<PlaceholderBindings> bindings1 =
-      llvm::make_unique<PlaceholderBindings>();
-  bindings1->allocate(module->getPlaceholders());
+  std::unique_ptr<ExecutionContext> context1 =
+      llvm::make_unique<ExecutionContext>();
+  context1->getPlaceholderBindings()->allocate(module->getPlaceholders());
 
   Tensor input1(ElemKind::FloatTy, {1});
   Tensor output1(ElemKind::FloatTy, {1});
   input1.getHandle().clear(2.0f);
   output1.getHandle().clear(4.0f);
 
-  updateInputPlaceholders(
-      *bindings1, {module->getPlaceholderByName("main_input")}, {&input1});
+  updateInputPlaceholders(*context1->getPlaceholderBindings(),
+                          {module->getPlaceholderByName("main_input")},
+                          {&input1});
 
   deviceManager.runFunction(
-      "main", std::move(bindings1),
-      [&bindings1](RunIdentifierTy, ResultCode result,
-                   std::unique_ptr<PlaceholderBindings> bindings_) {
-        bindings1 = std::move(bindings_);
+      "main", std::move(context1),
+      [&context1](RunIdentifierTy, ResultCode result,
+                  std::unique_ptr<ExecutionContext> context) {
+        context1 = std::move(context);
       });
 
-  ASSERT_TRUE(bindings1);
+  ASSERT_TRUE(context1);
 
-  Tensor *result1 = bindings1->get(module->getPlaceholderByName("main_output"));
+  Tensor *result1 = context1->getPlaceholderBindings()->get(
+      module->getPlaceholderByName("main_output"));
   ASSERT_TRUE(result1);
   EXPECT_TRUE(result1->isEqual(output1));
 


### PR DESCRIPTION
*Description*: Adds the new runtime ExecutionContext which includes PlaceholderBindings (previously: Context), DeviceBindings and TraceEvents storage, allowing us to (among other things) finish the OpenCL DeviceManager.
*Testing*: Unit tests debug, release and shared. Ran example code and verified.
*Documentation*: This is a breaking change to the Backend (due to change in execute() argument) but I broke that yesterday so pretty much a wash.