### PR TITLE
Replace ErrorCode with GlowErrs

### DIFF
--- a/examples/resnet-concurrent.cpp
+++ b/examples/resnet-concurrent.cpp
@@ -115,8 +115,9 @@ void dispatchClassify(unsigned int id, DeviceManager *device, std::string path,
                       std::promise<void> &finished) {
   device->runFunction("resnet50", std::move(context),
                       [id, path, output, &returned,
-                       &finished](RunIdentifierTy, ResultCode r,
+                       &finished](RunIdentifierTy, llvm::Error err,
                                   std::unique_ptr<ExecutionContext> context) {
+                        EXIT_ON_ERR(std::move(err));
                         size_t maxIdx = context->getPlaceholderBindings()
                                             ->get(output)
                                             ->getHandle<>()

--- a/examples/tracing-compare.cpp
+++ b/examples/tracing-compare.cpp
@@ -151,8 +151,9 @@ int main(int argc, char **argv) {
 
     devices[i]->runFunction(
         "resnet50", std::move(context),
-        [&promises, i](RunIdentifierTy, ResultCode r,
+        [&promises, i](RunIdentifierTy, llvm::Error err,
                        std::unique_ptr<ExecutionContext> context) {
+          EXIT_ON_ERR(std::move(err));
           promises[i].set_value(std::move(context));
         });
   }

--- a/include/glow/Backends/DeviceManager.h
+++ b/include/glow/Backends/DeviceManager.h
@@ -89,7 +89,9 @@ public:
               runtime::ResultCBTy resultCB) = 0;
 
   /// Stops execution and shuts down the Device.
-  virtual ResultCode stop(bool block = true) { return ResultCode::Executed; };
+  virtual llvm::Error stop(bool block = true) {
+    return llvm::Error::success();
+  };
 
   /// \returns the type of Backend that powers this Device.
   BackendKind getBackendKind() { return backend_; }

--- a/include/glow/Backends/DummyDeviceManager.h
+++ b/include/glow/Backends/DummyDeviceManager.h
@@ -52,7 +52,8 @@ public:
       if (functions_.count(func.first) != 0) {
         callback(
             module,
-            MAKE_ERR(llvm::formatv("Function {} not found", func.first).str()));
+            MAKE_ERR(GlowErr::ErrorCode::RUNTIME_NET_NOT_FOUND,
+                     llvm::formatv("Function {} not found", func.first).str()));
         return;
       }
     }
@@ -86,7 +87,11 @@ public:
                               ResultCBTy callback) override {
     auto funcIt = functions_.find(functionName);
     if (funcIt == functions_.end()) {
-      callback(0, ResultCode::Failed, std::move(context));
+      callback(
+          0,
+          MAKE_ERR(GlowErr::ErrorCode::RUNTIME_NET_NOT_FOUND,
+                   llvm::formatv("Function {} not found", functionName).str()),
+          std::move(context));
       return 0;
     }
 
@@ -100,7 +105,7 @@ public:
     func->afterRun(bindings);
 
     // Fire the resultCB.
-    callback(0, ResultCode::Executed, std::move(context));
+    callback(0, llvm::Error::success(), std::move(context));
 
     return 0;
   }

--- a/include/glow/Backends/QueueBackedDeviceManager.h
+++ b/include/glow/Backends/QueueBackedDeviceManager.h
@@ -38,7 +38,7 @@ public:
       : DeviceManager(backend, std::move(config)), workThread_(1) {}
 
   virtual ~QueueBackedDeviceManager() {
-    stop(true); // will join workThread_
+    llvm::toString(stop(true)); // will join workThread_
   }
 
   /// Initialize the device.
@@ -82,9 +82,9 @@ public:
   }
 
   /// Stops execution and shuts down the Device.
-  ResultCode stop(bool block = true) override {
+  llvm::Error stop(bool block = true) override {
     workThread_.stop(block);
-    return ResultCode::Executed;
+    return llvm::Error::success();
   }
 
 protected:

--- a/include/glow/Runtime/HostManager/HostManager.h
+++ b/include/glow/Runtime/HostManager/HostManager.h
@@ -85,8 +85,8 @@ public:
   /// Adds the network to the host and does the necessary setup work. This
   /// includes partitioning, provisioning, compiling and initializing
   /// backends. Additionally DAGs are created for each function and stored in
-  /// networks_. Returns a result code to indicate success.
-  ResultCode addNetwork(Module *M);
+  /// networks_. Returns an llvm::Error containing the results of the operation.
+  llvm::Error addNetwork(Module *M);
 
   /// Given \p networkName removes that network from the host. This also
   /// removes the network from any backends setup to execute it.
@@ -96,7 +96,7 @@ public:
   bool networkAdded(llvm::StringRef networkName);
 
   /// Removes all networks from the host, and stops execution on all devices.
-  void clearHost();
+  llvm::Error clearHost();
 
   /// Runs the network specified by \p networkName using
   /// the provided \p context, returns a runIdentifier which refers to the

--- a/include/glow/Runtime/RuntimeTypes.h
+++ b/include/glow/Runtime/RuntimeTypes.h
@@ -19,6 +19,7 @@
 #include "glow/Backends/Backend.h"
 #include "glow/Backends/BackendUtils.h"
 #include "glow/Graph/Graph.h"
+#include "glow/Support/Error.h"
 
 #include <map>
 #include <string>
@@ -38,15 +39,10 @@ using RunIdentifierTy = size_t;
 /// Map of DeviceIDTy -> DeviceManager.
 using DeviceManagerMapTy = std::map<DeviceIDTy, std::unique_ptr<DeviceManager>>;
 
-/// Enum to communicate results when communicating with device at initialization
-/// and runtime.
-enum class ResultCode { Ready, Executed, Failed, Canceled };
-
 /// Callback type used by HostManager and DeviceManager, used to pass results of
 /// an inference request back to the caller.
-using ResultCBTy =
-    std::function<void(runtime::RunIdentifierTy, runtime::ResultCode,
-                       std::unique_ptr<ExecutionContext>)>;
+using ResultCBTy = std::function<void(runtime::RunIdentifierTy, llvm::Error,
+                                      std::unique_ptr<ExecutionContext>)>;
 
 /// Data structure that contains device constraint information for each device.
 /// Used to communicate memory constraints and later costs to the Partitioner.

--- a/lib/Backends/CPU/CPUDeviceManager.cpp
+++ b/lib/Backends/CPU/CPUDeviceManager.cpp
@@ -114,9 +114,10 @@ void CPUDeviceManager::runFunctionImpl(
     std::unique_ptr<ExecutionContext> context, ResultCBTy resultCB) {
   auto funcIt = functions_.find(function);
   if (funcIt == functions_.end()) {
-    llvm::errs() << "Failed to run function: name " << function
-                 << " not found.\n";
-    resultCB(id, ResultCode::Failed, std::move(context));
+    resultCB(id,
+             MAKE_ERR(GlowErr::ErrorCode::RUNTIME_NET_NOT_FOUND,
+                      llvm::formatv("Function {} not found", function).str()),
+             std::move(context));
     return;
   }
 
@@ -126,5 +127,5 @@ void CPUDeviceManager::runFunctionImpl(
   func->execute(context.get());
 
   // Fire the resultCB.
-  resultCB(id, ResultCode::Executed, std::move(context));
+  resultCB(id, llvm::Error::success(), std::move(context));
 }

--- a/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
@@ -110,9 +110,10 @@ void InterpreterDeviceManager::runFunctionImpl(
     std::unique_ptr<ExecutionContext> context, ResultCBTy resultCB) {
   auto funcIt = functions_.find(function);
   if (funcIt == functions_.end()) {
-    llvm::errs() << "Failed to run function: name " << function
-                 << " not found.\n";
-    resultCB(id, ResultCode::Failed, std::move(context));
+    resultCB(id,
+             MAKE_ERR(GlowErr::ErrorCode::RUNTIME_NET_NOT_FOUND,
+                      llvm::formatv("Function {} not found", function).str()),
+             std::move(context));
     return;
   }
 
@@ -122,7 +123,7 @@ void InterpreterDeviceManager::runFunctionImpl(
   func->execute(context.get());
 
   // Fire the resultCB.
-  resultCB(id, ResultCode::Executed, std::move(context));
+  resultCB(id, llvm::Error::success(), std::move(context));
 }
 
 } // namespace runtime

--- a/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
@@ -241,9 +241,10 @@ void OpenCLDeviceManager::runFunctionImpl(
     std::unique_ptr<ExecutionContext> context, ResultCBTy resultCB) {
   auto funcIt = functions_.find(function);
   if (funcIt == functions_.end()) {
-    llvm::errs() << "Failed to run function: name " << function
-                 << " not found.\n";
-    resultCB(id, ResultCode::Failed, std::move(context));
+    resultCB(id,
+             MAKE_ERR(GlowErr::ErrorCode::RUNTIME_NET_NOT_FOUND,
+                      llvm::formatv("Function {} not found", function).str()),
+             std::move(context));
     return;
   }
 
@@ -259,5 +260,5 @@ void OpenCLDeviceManager::runFunctionImpl(
   func->afterRun(bindings);
 
   // Fire the resultCB.
-  resultCB(id, ResultCode::Executed, std::move(context));
+  resultCB(id, llvm::Error::success(), std::move(context));
 }

--- a/lib/Runtime/Executor/ThreadPoolExecutor.h
+++ b/lib/Runtime/Executor/ThreadPoolExecutor.h
@@ -101,11 +101,8 @@ public:
   /// \returns the callback for this execution.
   ResultCBTy getCallback() { return cb_; }
 
-  /// \returns the result code for the execution.
-  ResultCode getResultCode() const { return resultCode_; }
-
-  /// Set result code for the execution.
-  void setResultCode(const ResultCode resultCode);
+  /// \returns the OneErrOnly Error container for the execution.
+  OneErrOnly &getErrorContainer() { return errContainer_; }
 
   /// \returns the run ID for the execution.
   RunIdentifierTy getRunId() const { return runId_; }
@@ -128,8 +125,8 @@ private:
   /// The set of currently executing nodes. This is populated with the roots
   /// when a run starts, and does not become empty until execution finishes.
   std::atomic<unsigned> inflightNodes_;
-  /// Flag that is used to track if a non-success error code was received.
-  std::atomic<ResultCode> resultCode_;
+  /// Value that is used to track if an Error was received.
+  OneErrOnly errContainer_;
   /// Mutex used by bindings insertion functions to make sure only one thread
   /// writes to an ExecutionContext at a time.
   std::mutex bindingsMtx_;
@@ -175,14 +172,14 @@ private:
 
   /// Handle the result returned asynchronously by the DeviceManager.
   /// \p executionState is tracks the state of the run that the node that
-  /// finished executing belongs to, \p is the resultCode returned by the
+  /// finished executing belongs to, \p err is the llvm::Error returned by the
   /// DeviceManager, \p ctx is the ExecutionContext that contains the outputs
   /// produced by \p node during the run.
   ///
   /// The main purpose of this function is to help move computation off of the
   /// DeviceManager thread pool on onto the one owned by this class.
   void handleDeviceManagerResult(std::shared_ptr<ExecutionState> executionState,
-                                 ResultCode resultCode,
+                                 llvm::Error err,
                                  std::unique_ptr<ExecutionContext> ctx,
                                  const DAGNode *node);
 

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -1163,7 +1163,7 @@ static void importPad(std::string fileName, const char *inputName,
     if (expectLoadError) {
       llvm::Error err = llvm::Error::success();
       ONNXModelLoader(NetFilename, {inputName}, {&data.getType()}, *F, &err);
-      EXPECT_TRUE(glow::errorToBool(std::move(err)));
+      EXPECT_TRUE(errToBool(std::move(err)));
       return;
     }
     ONNXModelLoader onnxLD(NetFilename, {inputName}, {&data.getType()}, *F);

--- a/tests/unittests/ProvisionerTest.cpp
+++ b/tests/unittests/ProvisionerTest.cpp
@@ -70,5 +70,5 @@ TEST_F(ProvisionerTest, provisionDag) {
   auto provisioner = Provisioner(devices);
   auto err = provisioner.provision(networks, *mod.get());
   // Expect that there was no Error when provisioning
-  EXPECT_FALSE(glow::errorToBool(std::move(err)));
+  EXPECT_FALSE(errToBool(std::move(err)));
 }


### PR DESCRIPTION
*Description*:
Finish migration from `ErrorCode` to `GlowErr` in Glow runtime. The last step was migrating `ResultCBTy` to include an `llvm::Error` which meant some changes to the state that `Executor` maintains per-run.

*Testing*:
`Ninja check`
Run `resnet-runtime` example binary.

*Documentation*:
Comments