### PR TITLE
Add resnet examples to EXPENSIVE tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -50,7 +50,8 @@ function(add_output_check_test)
   set(SETUP_OUTPUTCHECK_ENV ${CMAKE_COMMAND} -E env
     MODELS_DIR=${GLOW_MODELS_DIR}
     OUTPUTCHECK=${OUTPUTCHECK_PATH}
-    TEXT_TRANSLATOR=${GLOW_OUTPUT_DIR}/text-translator)
+    TEXT_TRANSLATOR=${GLOW_OUTPUT_DIR}/text-translator
+    BIN=${CMAKE_BINARY_DIR}/bin)
 
   set(TEST_COMMAND ${SETUP_OUTPUTCHECK_ENV} ${OUTPUTCHECK_RUNNER_PATH} ${ARG_COMMAND})
 
@@ -70,6 +71,7 @@ function(add_output_check_test)
 endfunction()
 
 set (TEXT_TRANSLATOR_TESTS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/text-translator")
+set (EXAMPLES_TESTS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/examples_tests")
 
 # Create en2gr_cpu_test OutputCheck test.
 add_output_check_test(NAME en2gr_cpu_test
@@ -81,9 +83,19 @@ add_output_check_test(NAME en2gr_quantization_test
                       COMMAND ${TEXT_TRANSLATOR_TESTS_DIR}/en2gr_quantization_test.sh
                       REQUIRES MODELS RELEASE)
 
+# Create an OutputCheck test to run resnet-runtime-test.
+add_output_check_test(NAME resnet_runtime_test
+                      COMMAND ${EXAMPLES_TESTS_DIR}/resnet-runtime-test.sh
+                      REQUIRES MODELS)
+
+# Create an OutputCheck test to run resnet-concurrent-test.
+add_output_check_test(NAME resnet_concurrent_test
+                      COMMAND ${EXAMPLES_TESTS_DIR}/resnet-concurrent-test.sh
+                      REQUIRES MODELS)
+
 # Create target for OUTPUTCHECK_TESTS. 
 LIST(APPEND OUTPUTCHECK_TESTS true)
 add_custom_target(output_check_tests
   COMMAND ${OUTPUTCHECK_TESTS}
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-  DEPENDS text-translator)
+  DEPENDS text-translator resnet-runtime resnet-concurrent)

--- a/tests/examples_tests/resnet-concurrent-test.sh
+++ b/tests/examples_tests/resnet-concurrent-test.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Copyright (c) 2017-present, Facebook, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euxo pipefail
+
+# CHECK: zebra_340\.png: 340$
+# cat_285.png is wrongly classified as 281
+# CHECK: dog_207\.png: 207$
+cd $MODELS_DIR
+$BIN/resnet-concurrent

--- a/tests/examples_tests/resnet-runtime-test.sh
+++ b/tests/examples_tests/resnet-runtime-test.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Copyright (c) 2017-present, Facebook, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euxo pipefail
+
+# CHECK: zebra_340\.png: 340$
+# cat_285.png is wrongly classified as 281
+# CHECK: dog_207\.png: 207$
+cd $MODELS_DIR
+$BIN/resnet-runtime


### PR DESCRIPTION
*Description*:
Add EXPENSIVE tests to run resnet-runtime and resnet-concurrent examples in CI.

*Testing*:
`ninja check_expensive`

*Documentation*:
Comments

fixes #2493 