### PR TITLE
[OperatorTest] A couple assorted fixes required from recent refactor

### DIFF
--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -1816,7 +1816,7 @@ createAndInitConvDepthTest(glow::PlaceholderBindings &bindings,
 
 TEST_P(OperatorStatelessTest, Int8ConvolutionDepth10) {
   compareAgainstInterpreter(GetParam(), createAndInitConvDepthTest<10>,
-                            ElemKind::FloatTy, ElemKind::Int8QTy, 0.03f);
+                            ElemKind::FloatTy, ElemKind::Int8QTy, 0.045f);
 }
 
 TEST_P(OperatorStatelessTest, Int16ConvolutionDepth10) {
@@ -1838,13 +1838,13 @@ TEST_P(OperatorStatelessTest, Int16ConvolutionDepth8) {
 TEST_P(OperatorStatelessTest, FP16ConvolutionDepth10) {
   ENABLED_BACKENDS(Interpreter);
   compareAgainstInterpreter(GetParam(), createAndInitConvDepthTest<10>,
-                            ElemKind::FloatTy, ElemKind::Float16Ty, 0.01f);
+                            ElemKind::FloatTy, ElemKind::Float16Ty, 0.015f);
 }
 
 TEST_P(OperatorStatelessTest, FP16ConvolutionDepth8) {
   ENABLED_BACKENDS(Interpreter);
   compareAgainstInterpreter(GetParam(), createAndInitConvDepthTest<8>,
-                            ElemKind::FloatTy, ElemKind::Float16Ty, 0.01f);
+                            ElemKind::FloatTy, ElemKind::Float16Ty, 0.015f);
 }
 
 static FunctionTensorPair
@@ -2164,7 +2164,7 @@ createAndInitTransposeNet(glow::PlaceholderBindings &bindings,
 
 TEST_P(OperatorStatelessTest, QuantizedTranspose) {
   compareAgainstInterpreter(GetParam(), createAndInitTransposeNet,
-                            ElemKind::FloatTy, ElemKind::Int8QTy, 0.004f);
+                            ElemKind::FloatTy, ElemKind::Int8QTy, 0.0045f);
 }
 
 TEST_P(OperatorTest, QuantizedArithmeticUnrescaled) {

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -1685,6 +1685,12 @@ TEST_P(OperatorStatelessTest, BasicAddNetFloat16VsInt8) {
                             ElemKind::Float16Ty, ElemKind::Int8QTy, 0.02f);
 }
 
+TEST_P(OperatorStatelessTest, BasicAddNetFloatVsInt16) {
+  ENABLED_BACKENDS(Interpreter);
+  compareAgainstInterpreter(GetParam(), createAndInitBasicAddTest,
+                            ElemKind::FloatTy, ElemKind::Int16QTy, 0.02f);
+}
+
 TEST_P(OperatorTest, IntMatMul) {
   // The scaling factor 1.4x was carefully selected to make sure we don't
   // overflow or underflow the calculation.


### PR DESCRIPTION
A couple fixes due to https://github.com/pytorch/glow/commit/6a909023ec8a695fe955c50de18a2cb853cf8355

1st commit: Accidentally dropped `BasicAddNetFloatVsInt16` 

2nd commit: Increase allowed error threshold for a few tests failing on private backend. Due to differences in quantization implementation.