### PR TITLE
[Graph] Allow reduction down to zero-dim tensor

### DIFF
--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -339,8 +339,8 @@ TypeRef Module::getVoidTy() { return uniqueType(Type()); }
 /// where the provided \p axes dimensions are removed from the shape.
 static ShapeVector getNewShapeWithoutAxes(llvm::ArrayRef<size_t> dims,
                                           llvm::ArrayRef<unsigned_t> axes) {
-  assert(axes.size() < dims.size() &&
-         "Axes to remove must fit inside dimensions of the provided dims.");
+  assert(axes.size() <= dims.size() &&
+         "Cannot remove more dimensions than exist.");
   ShapeVector newDims(dims.begin(), dims.end());
   ShapeVector shapeAxes(axes.begin(), axes.end());
 


### PR DESCRIPTION
*Description*: Allow for reduction down to zero-dim tensor (scalar). https://github.com/pytorch/glow/pull/2465 changed an assert that disallowed this.

*Testing*: Added missing unit test.
