### PR TITLE
Add support for ONNXIFI_DATATYPE_UINT8 and caffe2::TensorProto::UINT8

### DIFF
--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -75,8 +75,17 @@ inline llvm::Error loadWeight(const onnxTensorDescriptorV1 &in, Tensor *T) {
     for (size_t i = 0; i < TH.size(); ++i) {
       TH.raw(i) = data[i];
     }
+  } else if (in.dataType == ONNXIFI_DATATYPE_UINT8) {
+    T->reset(ElemKind::Int8QTy, dims, 1.0, 0);
+
+    auto TH = T->getHandle<int8_t>();
+    uint8_t *data = (uint8_t *)in.buffer;
+    for (size_t i = 0; i < TH.size(); ++i) {
+      constexpr uint8_t OFFSETSHIFT = 128;
+      TH.raw(i) = static_cast<int8_t>((((uint8_t)data[i]) - OFFSETSHIFT));
+    }
   } else {
-    RETURN_ERR("Only float and index tensors are supported.");
+    RETURN_ERR("Only float, index, and int8 tensors are supported.");
   }
 
   return llvm::Error::success();

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -70,6 +70,9 @@ llvm::Error setTensorType(const caffe2::TensorProto &in, Tensor *T) {
   } else if (in.data_type() == caffe2::TensorProto::INT32) {
     T->reset(ElemKind::Int32ITy, dim);
     return llvm::Error::success();
+  } else if (in.data_type() == caffe2::TensorProto::UINT8) {
+    T->reset(ElemKind::Int8QTy, dim, 1.0, 0);
+    return llvm::Error::success();
   } else {
     RETURN_ERR("Only float and index tensors are supported");
   }


### PR DESCRIPTION
*Description*: For now, support loading uint8 types into `Int8QTy`. We load with a dummy scale and offset; this is currently only used for rowwise-quantized data, where we already use a dummy scale and offset.

*Testing*: This enables some internal tests to pass.