### PR TITLE
[Quantization] Add support for fused rowwise-quantizing SLWS

### DIFF
--- a/docs/Quantization.md
+++ b/docs/Quantization.md
@@ -210,13 +210,13 @@ For more specific graph optimizations check [here](Optimizations.md#quantization
 ## Row-wise Quantization
 
 Row-wise (or channel-wise) quantization is an important way to minimize accuracy
-drop.  Glow supports row-wise quantized FullyConnected node
-```RowwiseQuantizedFullyConnected``` which is enabled by an
-image-classifier/loader option "-enable-rowwise".
+drop.  Glow supports row-wise quantized FullyConnected and
+SparseLengthsWeightedSum nodes; They are enabled by the [model
+loader](Testing.md#model-loader) option "-enable-rowwise".
 
 For the regular quantized FC, we quantize the whole weights tensor with the same
 scale and offset, which are computed based on the max and min of the entire
-tensor).  But for row-wise, after getting ```min_i``` and ```max_i``` for each
+tensor.  But for row-wise, after getting ```min_i``` and ```max_i``` for each
 row ```i```, we compute the pair of ```(scale_i, offset_i)``` to quantize each
 element in row ```i```. The figure below shows the quantized FC node and
 RowwiseQuantizedFullyConnected node. Instead of using only one tensor to

--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -134,6 +134,8 @@ public:
           memcpy(&scale, scaleOffsetPtr, sizeof(float));
           memcpy(&offset, scaleOffsetPtr + sizeof(float), sizeof(float));
         }
+        assert(scale != 0.0 &&
+               "Disallow scale = 0.0 for UInt8FusedQTy; causes div by zero.");
         float zero = nearbyintf(-offset / scale);
         std::fill(&data[i * width], scaleOffsetPtr, static_cast<uint8_t>(zero));
       }


### PR DESCRIPTION
*Description*: Previously rowwise-quantized SLWS was only enabled by directly loading it as quantized. This allows for rowwise-quantizing it through our normal profile + quantization flow.

*Testing*: Added two unit tests; tested on other private models.

*Documentation*: Updated.