### PR TITLE
Remove OpenCLFunction dependence on old stateful execute scheme.

### DIFF
--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -97,14 +97,6 @@ public:
   ~OpenCLFunction() override;
 
   void execute(ExecutionContext *context) override;
-  /// Allocates on device buffer and copies Constant weights to device.
-  void setupRuns() override;
-  /// Per run setup, copies Inputs from \p bindings to on device memory.
-  void beforeRun(const PlaceholderBindings &bindings) override;
-  /// Copies outputs from device to tensors in \p bindings.
-  void afterRun(const PlaceholderBindings &bindings) override;
-  /// Final cleanup, currently an empty function in OpenCL.
-  void tearDownRuns() override;
 
   /// Collects constants for runtime.
   void collectConstants(Module *module) override;
@@ -157,6 +149,12 @@ private:
                      cl_device_id device, llvm::ArrayRef<size_t> global,
                      llvm::ArrayRef<size_t> local,
                      std::vector<KernelLaunch> &kernelLaunches);
+
+  /// Load inputs from \p bindings onto the device.
+  void loadPlaceholders(PlaceholderBindings *bindings);
+
+  /// Load outputs from the device into \p bindings.
+  void updatePlaceholders(PlaceholderBindings *bindings);
 };
 
 /// This is the OpenCL backend.


### PR DESCRIPTION
*Description*: As we did with the CPU and Interpreter backend, removing the requirement of calling setupRuns, beforeRuns, afterRuns and tearDownRuns in the OpenCL backend by moving their logic into `execute()`. This is the first step in making OpenCLFunction stateless, but we still need to move the buffers and kernelLaunch vector into DeviceBindings.
*Testing*: unit tests.
*Documentation*: Requires no change to calling code (although we could remove the unnecessary calls to the removed methods).