### PR TITLE
Resize output of FC with dims > 2

### DIFF
--- a/tests/models/caffe2Models/fcTransposed_4d_init_net.pbtxt
+++ b/tests/models/caffe2Models/fcTransposed_4d_init_net.pbtxt
@@ -1,0 +1,19 @@
+name: "init"
+op {
+  output: "weights"
+  type: "ConstantFill"
+  arg {
+    name: "shape"
+    ints: 2048
+    ints: 9190
+  }
+}
+op {
+  output: "bias"
+  type: "ConstantFill"
+  arg {
+    name: "shape"
+    ints: 9190
+  }
+}
+

--- a/tests/models/caffe2Models/fcTransposed_4d_predict_net.pbtxt
+++ b/tests/models/caffe2Models/fcTransposed_4d_predict_net.pbtxt
@@ -1,0 +1,17 @@
+name: "fc"
+op {
+  input: "inputs"
+  input: "weights"
+  input: "bias"
+  output: "fc_result"
+  name: ""
+  type: "FCTransposed"
+  arg {
+    name: "axis"
+    i: 3
+  }
+}
+external_input: "inputs"
+external_input: "weights"
+external_input: "bias"
+external_output: "fc_result"

--- a/tests/models/caffe2Models/fc_4d_init_net.pbtxt
+++ b/tests/models/caffe2Models/fc_4d_init_net.pbtxt
@@ -1,0 +1,19 @@
+name: "init"
+op {
+  output: "weights"
+  type: "ConstantFill"
+  arg {
+    name: "shape"
+    ints: 9190
+    ints: 2048
+  }
+}
+op {
+  output: "bias"
+  type: "ConstantFill"
+  arg {
+    name: "shape"
+    ints: 9190
+  }
+}
+

--- a/tests/models/caffe2Models/fc_4d_predict_net.pbtxt
+++ b/tests/models/caffe2Models/fc_4d_predict_net.pbtxt
@@ -1,0 +1,17 @@
+name: "fc"
+op {
+  input: "inputs"
+  input: "weights"
+  input: "bias"
+  output: "fc_result"
+  name: ""
+  type: "FC"
+  arg {
+    name: "axis"
+    i: 3
+  }
+}
+external_input: "inputs"
+external_input: "weights"
+external_input: "bias"
+external_output: "fc_result"


### PR DESCRIPTION
*Description*:
We need to match the behavior of Caffe2. When number of input dimensions to FC is greater than 2, Glow flattens down to 2 dimensions using axis but does not reshape the output back to original dimensions before the axis.

*Testing*:
Create a new C2 Graph and test that the output shape is the expected shape.

*Documentation*:
Fixes #2522