### PR TITLE
Conv3d on interpreter

### DIFF
--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -90,31 +90,31 @@ struct ShapeNHWC {
   }
 };
 
-struct ShapeNHWCT {
+struct ShapeNHWDC {
   size_t n; // Number of samples
   size_t h; // Height
   size_t w; // Width
+  size_t d; // Depth
   size_t c; // Number of Channels
-  size_t t; // Time
 
-  template <typename T> explicit ShapeNHWCT(llvm::ArrayRef<T> shape) {
+  template <typename T> explicit ShapeNHWDC(llvm::ArrayRef<T> shape) {
     assert(shape.size() == 5 && "Invalid shape");
     n = shape[0];
     h = shape[1];
     w = shape[2];
-    c = shape[3];
-    t = shape[4];
+    d = shape[3];
+    c = shape[4];
   }
 
-  static ShapeNHWCT empty() { return ShapeNHWCT(0, 0, 0, 0, 0); }
+  static ShapeNHWDC empty() { return ShapeNHWDC(0, 0, 0, 0, 0); }
 
-  explicit ShapeNHWCT(size_t samples, size_t height, size_t width,
-                      size_t channels, size_t time)
-      : n(samples), h(height), w(width), c(channels), t(time) {}
+  explicit ShapeNHWDC(size_t samples, size_t height, size_t width, size_t depth,
+                      size_t channels)
+      : n(samples), h(height), w(width), d(depth), c(channels) {}
 
-  bool equals(const ShapeNHWCT &other) const {
-    return n == other.n && h == other.h && w == other.w && c == other.c &&
-           t == other.t;
+  bool equals(const ShapeNHWDC &other) const {
+    return n == other.n && h == other.h && w == other.w && d == other.d &&
+           c == other.c;
   }
 };
 
@@ -172,21 +172,21 @@ struct PaddingTLBR {
   }
 };
 
-struct PaddingTLBRNF {
+struct PaddingTLNBRF {
   size_t top;
   size_t left;
+  size_t near;
   size_t bottom;
   size_t right;
-  size_t near;
   size_t far;
 
-  template <typename T> explicit PaddingTLBRNF(llvm::ArrayRef<T> pads) {
+  template <typename T> explicit PaddingTLNBRF(llvm::ArrayRef<T> pads) {
     assert(pads.size() == 6 && "Invalid padding");
     top = pads[0];
     left = pads[1];
-    bottom = pads[2];
-    right = pads[3];
-    near = pads[4];
+    near = pads[2];
+    bottom = pads[3];
+    right = pads[4];
     far = pads[5];
   }
 
@@ -209,19 +209,19 @@ struct ShapeHW {
   bool isSquare() const { return height == width; }
 };
 
-struct ShapeHWT {
+struct ShapeHWD {
   size_t height;
   size_t width;
-  size_t time;
+  size_t depth;
 
-  template <typename T> explicit ShapeHWT(llvm::ArrayRef<T> shape) {
+  template <typename T> explicit ShapeHWD(llvm::ArrayRef<T> shape) {
     assert(shape.size() == 3 && "Invalid shape");
     height = shape[0];
     width = shape[1];
-    time = shape[2];
+    depth = shape[2];
   }
 
-  bool isCube() const { return height == width && height == time; }
+  bool isCube() const { return height == width && height == depth; }
 };
 
 /// Collapse a tensor shape into two sizes: the first n dimensions and the size
@@ -249,7 +249,7 @@ inline bool operator==(const ShapeNCHW &LHS, const ShapeNCHW &RHS) {
   return LHS.equals(RHS);
 }
 
-inline bool operator==(const ShapeNHWCT &LHS, const ShapeNHWCT &RHS) {
+inline bool operator==(const ShapeNHWDC &LHS, const ShapeNHWDC &RHS) {
   return LHS.equals(RHS);
 }
 

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -258,7 +258,7 @@ public:
 
   /// Creates a Convolution3DNode with the given \p name which convolves the 5D
   /// \p input with \p filter and \bias. \p kernels defines the size of the
-  /// height, width, and time dimensions of the filters. \p strides defines the
+  /// height, width, and depth dimensions of the filters. \p strides defines the
   /// the number of steps to take in the input for each output cell. \p pads
   /// defines how many zero padding cells should be added to the input during
   /// convolution. \p group defines the number of groups the input and output
@@ -274,7 +274,7 @@ public:
 
   /// Creates a Convolution3DNode with the given \p name which convolves the 5D
   /// \p input with \p filter and \bias. \p kernel defines the size of the
-  /// height, width, and time dimensions of the filters. \p stride defines the
+  /// height, width, and depth dimensions of the filters. \p stride defines the
   /// the number of steps to take in the input for each output cell. \p pad
   /// defines how many zero padding cells should be added to the input during
   /// convolution. \p group defines the number of groups the input and output
@@ -897,7 +897,7 @@ public:
                               unsigned_t group);
 
   /// Creates a Convolution3DNode with the given \p name which convolves the 5D
-  /// \p input. \p kernels defines the size of the height, width, and time
+  /// \p input. \p kernels defines the size of the height, width, and depth
   /// dimensions of the convolutional filters. \p strides defines the the number
   /// of steps to take in the input for each output cell. \p pads defines how
   /// many zero padding cells should be added to the input during convolution.
@@ -912,7 +912,7 @@ public:
                                   unsigned_t group);
 
   /// Creates a Convolution3DNode with the given \p name which convolves the 5D
-  /// \p input. \p kernel defines the size of the height, width, and time
+  /// \p input. \p kernel defines the size of the height, width, and depth
   /// dimensions of the convolutional filters. \p stride defines the the number
   /// of steps to take in the input for each output cell. \p pad defines how
   /// many zero padding cells should be added to the input during convolution.

--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -152,21 +152,21 @@ inline std::pair<size_t, size_t> calculateConvPoolOutputDims(
 
 /// Calculate the size of the output tensor based on the 3D convolution/pooling
 /// parameters \p inH \p inW, \p inT which are the input's height, width, and
-/// time respectively.
-inline ShapeHWT calculate3DConvPoolOutputDims(
-    size_t inH, size_t inW, size_t inT, llvm::ArrayRef<unsigned_t> kernels,
+/// depth respectively.
+inline ShapeHWD calculate3DConvPoolOutputDims(
+    size_t inH, size_t inW, size_t inD, llvm::ArrayRef<unsigned_t> kernels,
     llvm::ArrayRef<unsigned_t> strides, llvm::ArrayRef<unsigned_t> pads) {
-  PaddingTLBRNF pdim(pads);
-  ShapeHWT kdim(kernels);
-  ShapeHWT sdim(strides);
+  PaddingTLNBRF pdim(pads);
+  ShapeHWD kdim(kernels);
+  ShapeHWD sdim(strides);
 
   size_t outH =
       ((inH + pdim.top + pdim.bottom - kdim.height) / sdim.height + 1);
   size_t outW = ((inW + pdim.left + pdim.right - kdim.width) / sdim.width + 1);
-  size_t outT = ((inT + pdim.near + pdim.far - kdim.time) / sdim.time + 1);
+  size_t outD = ((inD + pdim.near + pdim.far - kdim.depth) / sdim.depth + 1);
 
-  llvm::SmallVector<size_t, 3> outDims{outH, outW, outT};
-  return ShapeHWT(llvm::makeArrayRef(outDims));
+  llvm::SmallVector<size_t, 3> outDims{outH, outW, outD};
+  return ShapeHWD(llvm::makeArrayRef(outDims));
 }
 
 /// Modes of the padding operation.

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -137,6 +137,16 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
                {ConvolutionNode::BiasIdx}) &&
            (NI.getInElemTy(ConvolutionNode::BiasIdx) == ElemKind::Int32QTy);
 
+  case Kinded::Kind::Convolution3DNodeKind:
+    if (!NI.getInTy(Convolution3DNode::InputIdx)->isQuantizedType()) {
+      return NI.allInputsAndOutputsHaveSameElemKind(
+          {ElemKind::FloatTy, ElemKind::Float16Ty});
+    }
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::Int8QTy, ElemKind::Int16QTy},
+               {Convolution3DNode::BiasIdx}) &&
+           (NI.getInElemTy(Convolution3DNode::BiasIdx) == ElemKind::Int32QTy);
+
   case Kinded::Kind::FullyConnectedNodeKind:
     if (!NI.getInTy(FullyConnectedNode::InputIdx)->isQuantizedType()) {
       return NI.allInputsAndOutputsHaveSameElemKind(

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -145,6 +145,22 @@ private:
                                    llvm::ArrayRef<unsigned_t> pads,
                                    size_t group);
 
+  template <typename ElemTy, typename AccumulatorTy>
+  void fwdConvolution3DInstQuantizedImpl(Value *inV, Value *outV,
+                                         Value *filterV, Value *biasV,
+                                         llvm::ArrayRef<unsigned_t> kernelSizes,
+                                         llvm::ArrayRef<unsigned_t> strides,
+                                         llvm::ArrayRef<unsigned_t> pads,
+                                         size_t group);
+
+  template <typename ElemTy = float>
+  void fwdConvolution3DInstFloatImpl(Value *inV, Value *outV, Value *filterV,
+                                     Value *biasV,
+                                     llvm::ArrayRef<unsigned_t> kernelSizes,
+                                     llvm::ArrayRef<unsigned_t> strides,
+                                     llvm::ArrayRef<unsigned_t> pads,
+                                     size_t group);
+
   void fwdAvgPoolInstI8Impl(const AvgPoolInst *I);
   template <typename ElemTy> void fwdAvgPoolInstFloatImpl(const AvgPoolInst *I);
   template <typename ElemTy> void fwdSoftMaxInstImpl(const SoftMaxInst *I);

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -476,16 +476,16 @@ static void checkKernelSize(ShapeNHWC idim, llvm::ArrayRef<unsigned_t> kernels,
 }
 
 /// Check the kernel size for 3D Conv/Pooling ops.
-static void check3DKernelSize(ShapeNHWCT idim,
+static void check3DKernelSize(ShapeNHWDC idim,
                               llvm::ArrayRef<unsigned_t> kernels,
                               llvm::ArrayRef<unsigned_t> pads) {
-  PaddingTLBRNF pdim(pads);
+  PaddingTLNBRF pdim(pads);
   (void)pdim;
-  ShapeHWT kdim(kernels);
+  ShapeHWD kdim(kernels);
   (void)kdim;
   assert((idim.w + pdim.left + pdim.right) >= kdim.width &&
          (idim.h + pdim.top + pdim.bottom) >= kdim.height &&
-         (idim.t + pdim.near + pdim.far) >= kdim.time &&
+         (idim.d + pdim.near + pdim.far) >= kdim.depth &&
          "Kernel size is too large");
 }
 
@@ -523,22 +523,22 @@ static void assertConv3DDims(NodeValue input, NodeValue filter, NodeValue bias,
                              llvm::ArrayRef<unsigned_t> pads,
                              unsigned_t group) {
 
-  ShapeNHWCT idim(input.dims());
-  ShapeHWT kdim(kernels);
+  ShapeNHWDC idim(input.dims());
+  ShapeHWD kdim(kernels);
   (void)kdim;
   check3DKernelSize(idim, kernels, pads);
   assert(idim.c % group == 0 && "channels number must be divisible by groups");
 
-  // NOTE: here the N in NHWCT is abnormal because it is the number of filters
+  // NOTE: here the N in NHWDC is abnormal because it is the number of filters
   // (and therefore the number of output channels of the 3d conv) and not the
   // batch size. The rest of the dimensions are representative of the input
   // dimensions to the convolution.
-  ShapeNHWCT filterDims(filter.dims());
+  ShapeNHWDC filterDims(filter.dims());
   (void)filterDims;
 
   assert(filterDims.n % group == 0 && filterDims.h == kdim.height &&
-         filterDims.w == kdim.width && filterDims.c == idim.c / group &&
-         filterDims.t == kdim.time && "Invalid filter dims");
+         filterDims.w == kdim.width && filterDims.d == kdim.depth &&
+         filterDims.c == idim.c / group && "Invalid filter dims");
 
   assert(bias.getType()->size() == filterDims.n && "Invalid bias size");
 }
@@ -2028,25 +2028,25 @@ Convolution3DNode *Function::createConv3D(PlaceholderBindings &bindings,
                                           llvm::ArrayRef<unsigned_t> strides,
                                           llvm::ArrayRef<unsigned_t> pads,
                                           unsigned_t group) {
-  ShapeNHWCT idim(input.dims());
-  ShapeHWT kdim(kernels);
+  ShapeNHWDC idim(input.dims());
+  ShapeHWD kdim(kernels);
 
   assert(group > 0 && "group should be larger than 0");
   assert(idim.c % group == 0 && "channels number must be divisible by groups");
   assert(outChannels % group == 0 && "outChannels must be divisible by groups");
 
   // Calculate the size and allocate the output buffer.
-  auto outSz = calculate3DConvPoolOutputDims(idim.h, idim.w, idim.t, kernels,
+  auto outSz = calculate3DConvPoolOutputDims(idim.h, idim.w, idim.d, kernels,
                                              strides, pads);
 
   std::array<size_t, 5> outDims = {
-      {idim.n, outSz.height, outSz.width, outChannels, outSz.time}};
+      {idim.n, outSz.height, outSz.width, outSz.depth, outChannels}};
 
   // Allocate the Filter and Bias tensors.
   std::array<size_t, 5> filterDim = {
-      {outChannels, kdim.height, kdim.width, idim.c / group, kdim.time}};
+      {outChannels, kdim.height, kdim.width, kdim.depth, idim.c / group}};
 
-  size_t fanIn = kdim.height * kdim.width * kdim.time * idim.c;
+  size_t fanIn = kdim.height * kdim.width * kdim.depth * idim.c;
   ElemKind inputTy = input.getType()->getElementType();
   assert((inputTy == ElemKind::FloatTy || inputTy == ElemKind::Float16Ty) &&
          "Convolution3D on non-floating point type?");

--- a/tests/unittests/ConvTest.cpp
+++ b/tests/unittests/ConvTest.cpp
@@ -57,7 +57,7 @@ void singleConvNet(Tensor *input, Tensor *out, BackendKind kind,
   out->assign(resultTensor);
 }
 
-/// Test a few configurations of the fp convolution by comparing the retuls to
+/// Test a few configurations of the fp convolution by comparing the results to
 /// the interpreter.
 TEST_P(ConvCorrectnessTest, convTest) {
   PseudoRNG PRNG;

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -3123,7 +3123,7 @@ TEST_P(OperatorTest, GroupConvolution) {
   auto result = bindings_.get(S->getPlaceholder())->getHandle();
 
   std::vector<size_t> expectedDims = {1, 2, 1, 6};
-  EXPECT_TRUE(result.dims().vec() == expectedDims);
+  ASSERT_TRUE(result.dims().vec() == expectedDims);
   EXPECT_FLOAT_EQ(result.at({0, 0, 0, 0}), 1 + 2 + 3 + 4);
   EXPECT_FLOAT_EQ(result.at({0, 0, 0, 1}), (1 + 2 + 3 + 4) * 10);
   EXPECT_FLOAT_EQ(result.at({0, 0, 0, 2}), (1 + 2 + 3 + 4) * 100);
@@ -3136,6 +3136,74 @@ TEST_P(OperatorTest, GroupConvolution) {
   EXPECT_FLOAT_EQ(result.at({0, 1, 0, 3}), (13 + 14 + 15 + 16) * 1000);
   EXPECT_FLOAT_EQ(result.at({0, 1, 0, 4}), (13 + 14 + 15 + 16) * 10000);
   EXPECT_FLOAT_EQ(result.at({0, 1, 0, 5}), (13 + 14 + 15 + 16) * 100000);
+}
+
+TEST_P(OperatorTest, GroupConv3D) {
+  ENABLED_BACKENDS(Interpreter);
+
+  auto *input = mod_.createPlaceholder(ElemKind::FloatTy, {1, 2, 1, 2, 8},
+                                       "input", false);
+  auto IH = bindings_.allocate(input)->getHandle();
+  for (size_t i = 0; i < 2 * 2 * 8; i++) {
+    IH.raw(i) = i + 1;
+  }
+
+  auto filter = mod_.createPlaceholder(ElemKind::FloatTy, {6, 1, 1, 1, 4},
+                                       "filter", false);
+  auto FH = bindings_.allocate(filter)->getHandle();
+  for (size_t i = 0; i < 6; i++)
+    for (size_t j = 0; j < 4; j++) {
+      FH.at({i, 0, 0, 0, j}) = pow(10.0, i);
+    }
+
+  auto *zeroBias =
+      mod_.createPlaceholder(ElemKind::FloatTy, {6}, "bias", false);
+  bindings_.allocate(zeroBias)->zero();
+
+  auto outTy = mod_.uniqueType(ElemKind::FloatTy, {1, 2, 1, 2, 6});
+
+  Convolution3DNode *CN =
+      F_->createConv3D("Conv3D", input, filter, zeroBias, outTy, 1, 1, 0, 2);
+  SaveNode *S = F_->createSave("save", CN);
+  bindings_.allocate(S->getPlaceholder());
+
+  ::glow::convertPlaceholdersToConstants(F_, bindings_,
+                                         {input, S->getPlaceholder()});
+  EE_.compile(CompilationMode::Infer, F_);
+  EE_.run(bindings_);
+
+  auto result = bindings_.get(S->getPlaceholder())->getHandle();
+
+  std::vector<size_t> expectedDims = {1, 2, 1, 2, 6};
+  ASSERT_TRUE(result.dims().vec() == expectedDims);
+
+  EXPECT_FLOAT_EQ(result.at({0, 0, 0, 0, 0}), 1 + 2 + 3 + 4);
+  EXPECT_FLOAT_EQ(result.at({0, 0, 0, 0, 1}), (1 + 2 + 3 + 4) * 10);
+  EXPECT_FLOAT_EQ(result.at({0, 0, 0, 0, 2}), (1 + 2 + 3 + 4) * 100);
+  EXPECT_FLOAT_EQ(result.at({0, 0, 0, 0, 3}), (5 + 6 + 7 + 8) * 1000);
+  EXPECT_FLOAT_EQ(result.at({0, 0, 0, 0, 4}), (5 + 6 + 7 + 8) * 10000);
+  EXPECT_FLOAT_EQ(result.at({0, 0, 0, 0, 5}), (5 + 6 + 7 + 8) * 100000);
+
+  EXPECT_FLOAT_EQ(result.at({0, 0, 0, 1, 0}), 9 + 10 + 11 + 12);
+  EXPECT_FLOAT_EQ(result.at({0, 0, 0, 1, 1}), (9 + 10 + 11 + 12) * 10);
+  EXPECT_FLOAT_EQ(result.at({0, 0, 0, 1, 2}), (9 + 10 + 11 + 12) * 100);
+  EXPECT_FLOAT_EQ(result.at({0, 0, 0, 1, 3}), (13 + 14 + 15 + 16) * 1000);
+  EXPECT_FLOAT_EQ(result.at({0, 0, 0, 1, 4}), (13 + 14 + 15 + 16) * 10000);
+  EXPECT_FLOAT_EQ(result.at({0, 0, 0, 1, 5}), (13 + 14 + 15 + 16) * 100000);
+
+  EXPECT_FLOAT_EQ(result.at({0, 1, 0, 0, 0}), 17 + 18 + 19 + 20);
+  EXPECT_FLOAT_EQ(result.at({0, 1, 0, 0, 1}), (17 + 18 + 19 + 20) * 10);
+  EXPECT_FLOAT_EQ(result.at({0, 1, 0, 0, 2}), (17 + 18 + 19 + 20) * 100);
+  EXPECT_FLOAT_EQ(result.at({0, 1, 0, 0, 3}), (21 + 22 + 23 + 24) * 1000);
+  EXPECT_FLOAT_EQ(result.at({0, 1, 0, 0, 4}), (21 + 22 + 23 + 24) * 10000);
+  EXPECT_FLOAT_EQ(result.at({0, 1, 0, 0, 5}), (21 + 22 + 23 + 24) * 100000);
+
+  EXPECT_FLOAT_EQ(result.at({0, 1, 0, 1, 0}), 25 + 26 + 27 + 28);
+  EXPECT_FLOAT_EQ(result.at({0, 1, 0, 1, 1}), (25 + 26 + 27 + 28) * 10);
+  EXPECT_FLOAT_EQ(result.at({0, 1, 0, 1, 2}), (25 + 26 + 27 + 28) * 100);
+  EXPECT_FLOAT_EQ(result.at({0, 1, 0, 1, 3}), (29 + 30 + 31 + 32) * 1000);
+  EXPECT_FLOAT_EQ(result.at({0, 1, 0, 1, 4}), (29 + 30 + 31 + 32) * 10000);
+  EXPECT_FLOAT_EQ(result.at({0, 1, 0, 1, 5}), (29 + 30 + 31 + 32) * 100000);
 }
 
 /// Check non-square padding for convolution. The first conv has non-square
@@ -3187,6 +3255,79 @@ TEST_P(OperatorTest, NonSquarePaddingConvolution) {
   Function *refF = mod_.createFunction("mainRef");
   CN = refF->createConv("Conv1", input1, filter, zeroBias, outTy, {2, 2},
                         {1, 1}, {0, 0, 0, 0}, 1);
+  S = refF->createSave("save1", CN);
+  bindings_.allocate(S->getPlaceholder());
+
+  ::glow::convertPlaceholdersToConstants(F_, bindings_,
+                                         {input, input1, S->getPlaceholder()});
+  EE_.compile(CompilationMode::Infer, refF);
+  EE_.run(bindings_);
+  Tensor &result1 = *bindings_.get(S->getPlaceholder());
+
+  EXPECT_TRUE(result.isEqual(result1));
+}
+
+/// Check non-cubic padding for conv3D. The first conv3D has non-cubic
+/// padding, while the second one has zero padding. The second conv3D's input is
+/// the same as the first one's after-padding input. All other parameters of
+/// the two conv3Ds are the same.
+TEST_P(OperatorTest, NonCubicPaddingConv3D) {
+  ENABLED_BACKENDS(Interpreter);
+
+  auto *input = mod_.createPlaceholder(ElemKind::FloatTy, {1, 4, 4, 4, 1},
+                                       "input", false);
+  auto IH = bindings_.allocate(input)->getHandle();
+  int nextVal = 1;
+  for (size_t i = 0; i < 4; i++) {
+    for (size_t j = 0; j < 4; j++) {
+      for (size_t k = 0; k < 4; k++) {
+        IH.at({0, i, j, k, 0}) = static_cast<float>(nextVal++);
+      } // D
+    }   // W
+  }     // H
+
+  auto filter = mod_.createPlaceholder(ElemKind::FloatTy, {2, 2, 2, 2, 1},
+                                       "filter", false);
+  auto FH = bindings_.allocate(filter)->getHandle();
+  for (size_t i = 0; i < 2 * 2 * 2 * 2; i++) {
+    FH.raw(i) = pow(2.0, i);
+  }
+  auto *zeroBias =
+      mod_.createPlaceholder(ElemKind::FloatTy, {2}, "bias", false);
+  bindings_.allocate(zeroBias)->zero();
+
+  auto outTy = mod_.uniqueType(ElemKind::FloatTy, {1, 4, 8, 12, 2});
+
+  Convolution3DNode *CN =
+      F_->createConv3D("Conv3D", input, filter, zeroBias, outTy, {2, 2, 2},
+                       {1, 1, 1}, {0, 2, 5, 1, 3, 4}, 1);
+  SaveNode *S = F_->createSave("save", CN);
+  bindings_.allocate(S->getPlaceholder());
+
+  ::glow::convertPlaceholdersToConstants(F_, bindings_,
+                                         {input, S->getPlaceholder()});
+  EE_.compile(CompilationMode::Infer, F_);
+  EE_.run(bindings_);
+  Tensor &result = *bindings_.get(S->getPlaceholder());
+
+  // Create the reference conv3D operator whose input is the same as the
+  // after-padding-input above.
+  auto *input1 = mod_.createPlaceholder(ElemKind::FloatTy, {1, 5, 9, 13, 1},
+                                        "input1", false);
+  bindings_.allocate(input1)->zero();
+  auto IH1 = bindings_.get(input1)->getHandle();
+  nextVal = 1;
+  for (size_t i = 0; i < 4; i++) {
+    for (size_t j = 2; j < 6; j++) {
+      for (size_t k = 5; k < 9; k++) {
+        IH1.at({0, i, j, k, 0}) = static_cast<float>(nextVal++);
+      } // D
+    }   // W
+  }     // H
+
+  Function *refF = mod_.createFunction("mainRef");
+  CN = refF->createConv3D("Conv3D_1", input1, filter, zeroBias, outTy,
+                          {2, 2, 2}, {1, 1, 1}, {0, 0, 0, 0, 0, 0}, 1);
   S = refF->createSave("save1", CN);
   bindings_.allocate(S->getPlaceholder());
 
@@ -3504,6 +3645,133 @@ TEST_P(OperatorTest, NonSquareKernelConvolution) {
     EXPECT_EQ(result.getHandle().raw(i), ref[i]);
 }
 
+/// Check Non-cubic kernel for conv3D.
+TEST_P(OperatorTest, NonCubicKernelConv3D) {
+  ENABLED_BACKENDS(Interpreter);
+
+  auto *input = mod_.createPlaceholder(ElemKind::FloatTy, {1, 4, 4, 4, 1},
+                                       "input", false);
+  auto IH = bindings_.allocate(input)->getHandle();
+  int nextVal = 1;
+  for (size_t i = 0; i < 4; i++) {
+    for (size_t j = 0; j < 4; j++) {
+      for (size_t k = 0; k < 4; k++) {
+        IH.at({0, i, j, k, 0}) = static_cast<float>(nextVal++);
+      } // D
+    }   // W
+  }     // H
+
+  auto filter = mod_.createPlaceholder(ElemKind::FloatTy, {1, 1, 2, 3, 1},
+                                       "filter", false);
+  auto FH = bindings_.allocate(filter)->getHandle();
+  nextVal = 1;
+  for (size_t i = 0; i < 1; i++) {
+    for (size_t j = 0; j < 2; j++) {
+      for (size_t k = 0; k < 3; k++) {
+        FH.at({0, i, j, k, 0}) = static_cast<float>(nextVal++);
+      } // D
+    }   // W
+  }     // H
+
+  auto *zeroBias =
+      mod_.createPlaceholder(ElemKind::FloatTy, {1}, "bias", false);
+  bindings_.allocate(zeroBias)->zero();
+
+  auto outTy = mod_.uniqueType(ElemKind::FloatTy, {1, 4, 3, 2, 1});
+
+  Convolution3DNode *CN =
+      F_->createConv3D("Conv3D", input, filter, zeroBias, outTy, {1, 2, 3},
+                       {1, 1, 1}, {0, 0, 0, 0, 0, 0}, 1);
+  SaveNode *S = F_->createSave("save", CN);
+  bindings_.allocate(S->getPlaceholder());
+
+  ::glow::convertPlaceholdersToConstants(F_, bindings_,
+                                         {input, S->getPlaceholder()});
+  EE_.compile(CompilationMode::Infer, F_);
+  EE_.run(bindings_);
+  Tensor &result = *bindings_.get(S->getPlaceholder());
+
+  static const float ref[] = {106, 127, 190,  211,  274,  295,  442,  463,
+                              526, 547, 610,  631,  778,  799,  862,  883,
+                              946, 967, 1114, 1135, 1198, 1219, 1282, 1303};
+  for (size_t i = 0; i < 4 * 3 * 2; i++) {
+    EXPECT_EQ(result.getHandle().raw(i), ref[i]);
+  }
+}
+
+/// Check Non-cubic kernel for conv3D with quantized input, filters, and bias.
+TEST_P(OperatorTest, NonCubicKernelConv3DQuantized) {
+  ENABLED_BACKENDS(Interpreter);
+
+  auto *input = mod_.createPlaceholder(ElemKind::FloatTy, {1, 4, 4, 4, 1},
+                                       "input", false);
+  auto IH = bindings_.allocate(input)->getHandle();
+  int nextVal = 1;
+  for (size_t i = 0; i < 4; i++) {
+    for (size_t j = 0; j < 4; j++) {
+      for (size_t k = 0; k < 4; k++) {
+        IH.at({0, i, j, k, 0}) = static_cast<float>(nextVal++);
+      } // D
+    }   // W
+  }     // H
+
+  auto qInType = mod_.uniqueType(ElemKind::Int16QTy, {1, 4, 4, 4, 1}, 0.1, 0);
+  auto *qInput = F_->createQuantize("q_input", input, qInType);
+
+  auto filter = mod_.createPlaceholder(ElemKind::FloatTy, {1, 1, 2, 3, 1},
+                                       "filter", false);
+  auto FH = bindings_.allocate(filter)->getHandle();
+  nextVal = 1;
+  for (size_t i = 0; i < 1; i++) {
+    for (size_t j = 0; j < 2; j++) {
+      for (size_t k = 0; k < 3; k++) {
+        FH.at({0, i, j, k, 0}) = static_cast<float>(nextVal++);
+      } // D
+    }   // W
+  }     // H
+
+  auto qFilterType =
+      mod_.uniqueType(ElemKind::Int16QTy, {1, 1, 2, 3, 1}, 0.1, 0);
+  auto *qFilter = F_->createQuantize("q_filter", filter, qFilterType);
+
+  auto *bias = mod_.createPlaceholder(ElemKind::FloatTy, {1}, "bias", false);
+  bindings_.allocate(bias)->zero();
+
+  auto qBiasType = mod_.uniqueType(ElemKind::Int32QTy, {1}, 0.1, 0);
+  auto *qBias = F_->createQuantize("q_bias", bias, qBiasType);
+
+  auto outTy = mod_.uniqueType(ElemKind::FloatTy, {1, 4, 3, 2, 1});
+
+  Convolution3DNode *CN =
+      F_->createConv3D("Conv3D", input, filter, bias, outTy, {1, 2, 3},
+                       {1, 1, 1}, {0, 0, 0, 0, 0, 0}, 1);
+
+  auto qOutTy = mod_.uniqueType(ElemKind::Int16QTy, {1, 4, 3, 2, 1}, 0.1, 0);
+
+  Convolution3DNode *qCN =
+      F_->createConv3D("q_Conv3D", qInput, qFilter, qBias, qOutTy, {1, 2, 3},
+                       {1, 1, 1}, {0, 0, 0, 0, 0, 0}, 1);
+
+  SaveNode *S = F_->createSave("save", CN);
+
+  auto *deQ = F_->createDequantize("deQ_result", qCN);
+  SaveNode *qS = F_->createSave("save", deQ);
+
+  bindings_.allocate(S->getPlaceholder());
+
+  ::glow::convertPlaceholdersToConstants(F_, bindings_,
+                                         {input, S->getPlaceholder()});
+  EE_.compile(CompilationMode::Infer, F_);
+  EE_.run(bindings_);
+
+  Tensor &result = *bindings_.get(S->getPlaceholder());
+  Tensor &qResult = *bindings_.get(qS->getPlaceholder());
+
+  for (size_t i = 0; i < 4 * 3 * 2; i++) {
+    EXPECT_NEAR(qResult.getHandle().raw(i), result.getHandle().raw(i), 0.5);
+  }
+}
+
 /// Check Non-square kernel for AveragePool.
 TEST_P(OperatorTest, NonSquareKernelAveragePool) {
   ENABLED_BACKENDS(Interpreter, CPU);
@@ -3585,6 +3853,58 @@ TEST_P(OperatorTest, NonSquareStrideConvolution) {
   static const float ref[] = {44, 64, 41, 47};
   for (size_t i = 0; i < 4; i++)
     EXPECT_EQ(result.getHandle().raw(i), ref[i]);
+}
+
+/// Check Non-cubic stride for conv3D.
+TEST_P(OperatorTest, NonCubicStrideConv3D) {
+  ENABLED_BACKENDS(Interpreter);
+
+  auto *input = mod_.createPlaceholder(ElemKind::FloatTy, {1, 4, 4, 4, 1},
+                                       "input", false);
+  auto IH = bindings_.allocate(input)->getHandle();
+  int nextVal = 1;
+  for (size_t i = 0; i < 4; i++) {
+    for (size_t j = 0; j < 4; j++) {
+      for (size_t k = 0; k < 4; k++) {
+        IH.at({0, i, j, k, 0}) = static_cast<float>(nextVal++);
+      } // D
+    }   // W
+  }     // H
+
+  auto filter = mod_.createPlaceholder(ElemKind::FloatTy, {1, 2, 2, 2, 1},
+                                       "filter", false);
+  auto FH = bindings_.allocate(filter)->getHandle();
+  nextVal = 1;
+  for (size_t i = 0; i < 2; i++) {
+    for (size_t j = 0; j < 2; j++) {
+      for (size_t k = 0; k < 2; k++) {
+        FH.at({0, i, j, k, 0}) = static_cast<float>(nextVal++);
+      } // D
+    }   // W
+  }     // H
+
+  auto *zeroBias =
+      mod_.createPlaceholder(ElemKind::FloatTy, {1}, "bias", false);
+  bindings_.allocate(zeroBias)->zero();
+
+  auto outTy = mod_.uniqueType(ElemKind::FloatTy, {1, 2, 2, 2, 1});
+
+  Convolution3DNode *CN =
+      F_->createConv3D("Conv3D", input, filter, zeroBias, outTy, {2, 2, 2},
+                       {3, 2, 3}, {0, 0, 0, 1, 1, 1}, 1);
+  SaveNode *S = F_->createSave("save", CN);
+  bindings_.allocate(S->getPlaceholder());
+
+  ::glow::convertPlaceholdersToConstants(F_, bindings_,
+                                         {input, S->getPlaceholder()});
+  EE_.compile(CompilationMode::Infer, F_);
+  EE_.run(bindings_);
+  Tensor &result = *bindings_.get(S->getPlaceholder());
+
+  static const float ref[] = {560, 296, 848, 424, 524, 220, 604, 252};
+  for (size_t i = 0; i < 8; i++) {
+    EXPECT_EQ(result.getHandle().raw(i), ref[i]);
+  }
 }
 
 /// Check Non-square stride for AveragePool.


### PR DESCRIPTION
*Description*:
3D convolution implementation for interpreter backend (quantized and non-quantized).
Next steps include: CPU implementation, import conv3D in c2 model loader, implement backwards passes

*Testing*:
New unit tests added. Some reference outputs are computed in test when easy to do so, the others are from convolution computed by hand.

*Documentation*:
Comments in code