### PR TITLE
Added new compileFunctions method

### DIFF
--- a/include/glow/Backends/Backend.h
+++ b/include/glow/Backends/Backend.h
@@ -45,6 +45,19 @@ public:
   /// \returns the kind of Backend this is.
   virtual BackendKind getBackendKind() const = 0;
 
+  /// Generate code for a vector of functions, \p functions. All compilations
+  /// use the same settings provided by \p opts. This allows the compiler to
+  /// support shared constants between functions.
+  virtual std::vector<std::unique_ptr<CompiledFunction>>
+  compileFunctions(llvm::ArrayRef<Function *> functions,
+                   CompilationOptions &opts) const {
+    std::vector<std::unique_ptr<CompiledFunction>> compiledFunctions;
+    for (auto &function : functions) {
+      compiledFunctions.push_back(compile(function, opts));
+    }
+    return compiledFunctions;
+  }
+
   virtual std::unique_ptr<CompiledFunction> compile(Function *F) const {
     CompilationOptions opts;
     return compile(F, opts);

--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -188,6 +188,23 @@ TEST_P(BackendTest, CompileWithoutConstants) {
   auto function = backend->compile(F, opts);
 }
 
+/// Test compiling a vector of functions completes without error.
+TEST_P(BackendTest, compileVectorOfFunctions) {
+  Module mod;
+  std::vector<Function *> functions;
+  for (unsigned int i = 0; i < 3; i++) {
+    Function *F = mod.createFunction("function" + std::to_string(i));
+    auto *X = mod.createPlaceholder(ElemKind::FloatTy, {3},
+                                    "X" + std::to_string(i), false);
+    auto *pow = F->createPow("Pow" + std::to_string(i), X, 2.0);
+    F->createSave("save" + std::to_string(i), pow);
+    functions.push_back(F);
+  }
+  std::unique_ptr<Backend> backend(createBackend(GetParam()));
+  CompilationOptions opts;
+  auto function = backend->compileFunctions(functions, opts);
+}
+
 /// This test checks that we can compile a function without depending on the
 /// graph representation. We compile some function and then delete the function.
 /// Later we execute the code and check that things work.


### PR DESCRIPTION
*Description*: Added new compileFunctions method which takes an ArrayRef of functions and returns a vector of compiledFunctions. This allows the compile to reason over shared constants between functions. Also added a new unittest and updated backends.md
*Testing*: ninja test
*Documentation*: Updated backends.md
Related to #2045 