### PR TITLE
Added schema parameter to graph

### DIFF
--- a/examples/fr2en.cpp
+++ b/examples/fr2en.cpp
@@ -173,7 +173,8 @@ struct Model {
 
       // Quantize the graph based on the captured profile.
       auto *Q = glow::quantization::quantizeFunction(
-          EE_, quantizationInfos, ElemKind::Int8QTy, F_, loweredMap_);
+          EE_, quantization::Schema::Asymmetric, quantizationInfos,
+          ElemKind::Int8QTy, F_, loweredMap_);
 
       // Erase the original function so that the redundant variables that are
       // only referenced by the original function will be removed.

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -18,6 +18,7 @@
 
 #include "glow/Base/Type.h"
 #include "glow/Graph/Nodes.h"
+#include "glow/Quantization/Base/Base.h"
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
@@ -328,10 +329,9 @@ public:
   /// creation time. The output is quantized in the regular way, and its type
   /// \p outTy is a quantized type. if \p transposeWeight is true, \p W need to
   /// be transposed first.
-  RowwiseQuantizedFullyConnectedNode *
-  createRowwiseQuantizedFullyConnected(llvm::StringRef name, NodeValue input,
-                                       Constant *W, Node *B, TypeRef outTy,
-                                       bool transposeWeight = false);
+  RowwiseQuantizedFullyConnectedNode *createRowwiseQuantizedFullyConnected(
+      llvm::StringRef name, NodeValue input, Constant *W, Node *B,
+      TypeRef outTy, quantization::Schema schema, bool transposeWeight = false);
 
   /// Implement an operation that computes the row-wise dot product of its
   /// inputs. Consequently, \p X and \p Y must be either 1D or 2D tensors. This
@@ -646,7 +646,8 @@ public:
   /// float input \p data, which is rowwise-quantized internally.
   RowwiseQuantizedSparseLengthsWeightedSumNode *
   createRowwiseQuantizedSparseLengthsSum(llvm::StringRef name, Tensor &data,
-                                         NodeValue indices, NodeValue lengths);
+                                         NodeValue indices, NodeValue lengths,
+                                         quantization::Schema schema);
 
   /// Same as \ref createRowwiseQuantizedSparseLengthsSum(), but i-th slice is
   /// multiplied by weights[i]. len(weights) must be equal to len(indices).
@@ -658,11 +659,9 @@ public:
   /// Same as \ref createRowwiseQuantizedSparseLengthsWeightedSum(), but expects
   /// float input \p data, which is rowwise-quantized internally.
   RowwiseQuantizedSparseLengthsWeightedSumNode *
-  createRowwiseQuantizedSparseLengthsWeightedSum(llvm::StringRef name,
-                                                 Tensor &data,
-                                                 NodeValue weights,
-                                                 NodeValue indices,
-                                                 NodeValue lengths);
+  createRowwiseQuantizedSparseLengthsWeightedSum(
+      llvm::StringRef name, Tensor &data, NodeValue weights, NodeValue indices,
+      NodeValue lengths, quantization::Schema schema);
 
   /// Creates and \returns a node of \p name, performing the SparseLengthsSum
   /// operation, using fused rowwise quantization for the input \p data wherein

--- a/include/glow/Quantization/Base/Base.h
+++ b/include/glow/Quantization/Base/Base.h
@@ -160,7 +160,8 @@ std::vector<int8_t> createMapping(TypeRef inTy, TypeRef outTy,
 /// this must either be int32_t or float.
 template <typename T>
 void tensorRowwiseQuantization(const Tensor &input, Tensor &output,
-                               Tensor &scales, Tensor &offsets) {
+                               Tensor &scales, Tensor &offsets,
+                               quantization::Schema schema) {
   const auto fDims = flattenCdr(input.dims());
   Tensor finalIn = input.getUnowned({fDims.first, fDims.second});
   Tensor finalOut = output.getUnowned({fDims.first, fDims.second});
@@ -182,7 +183,7 @@ void tensorRowwiseQuantization(const Tensor &input, Tensor &output,
 
     if (std::is_same<int32_t, T>::value) {
       TensorQuantizationParams qParams =
-          chooseQuantizationParams(min, max, quantization::Schema::Asymmetric);
+          chooseQuantizationParams(min, max, schema);
       for (size_t j = 0; j < idim.width; j++) {
         destH.at({i, j}) = quantization::quantize(srcH.at({i, j}), qParams);
       }

--- a/include/glow/Quantization/Quantization.h
+++ b/include/glow/Quantization/Quantization.h
@@ -103,7 +103,7 @@ std::vector<NodeQuantizationInfo> generateNodeQuantizationInfos(
 /// nodes will be converted to RowwiseQuantizedFullyConnected. \returns a new
 /// quantized function.
 Function *quantizeFunction(
-    const ExecutionEngine &EE,
+    const ExecutionEngine &EE, quantization::Schema schema,
     llvm::ArrayRef<NodeQuantizationInfo> quantizationInfos,
     ElemKind quantizationPrecision, Function *F,
     const LoweredInfoMap &loweredMap = {}, llvm::StringRef newFuncName = "",

--- a/tests/unittests/BackendCorrectnessTest.cpp
+++ b/tests/unittests/BackendCorrectnessTest.cpp
@@ -442,12 +442,14 @@ TEST_P(BackendCorrectnessTest, convOps) {
 
 TEST_P(BackendCorrectnessTest, basicFCNet) {
   compareAgainstInterpreter(GetParam(), createAndInitBasicFCNet,
-                            ElemKind::FloatTy, ElemKind::FloatTy, 0.0004);
+                            ElemKind::FloatTy, ElemKind::FloatTy,
+                            quantization::Schema::Asymmetric, 0.0004);
 }
 
 TEST_P(BackendCorrectnessTest, basicFCNetQuantized) {
   compareAgainstInterpreter(GetParam(), createAndInitBasicFCNet,
-                            ElemKind::Int8QTy, ElemKind::Int8QTy);
+                            ElemKind::Int8QTy, ElemKind::Int8QTy,
+                            quantization::Schema::Asymmetric);
 }
 
 TEST_P(CPUOnly, complexNet1) {

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -195,6 +195,7 @@ void compareAgainstInterpreter(BackendKind backendKind,
                                CreateAndInitFunction createAndInitFunction,
                                ElemKind interpElemKind,
                                ElemKind backendElemKind,
+                               quantization::Schema schema,
                                float allowedError = 0.0001,
                                bool enableRowwiseQuantization = false);
 

--- a/tests/unittests/MLTest.cpp
+++ b/tests/unittests/MLTest.cpp
@@ -1077,8 +1077,9 @@ TEST_P(InterpreterAndCPU, convNetForImageRecognition) {
   // Build the new quantized graph.
   LoweredInfoMap loweredMapForQuant;
   lower(F, &loweredMapForQuant, EE.getBackend());
-  Function *QP = quantization::quantizeFunction(EE, QI, ElemKind::Int8QTy, F,
-                                                loweredMapForQuant);
+  Function *QP =
+      quantization::quantizeFunction(EE, quantization::Schema::Asymmetric, QI,
+                                     ElemKind::Int8QTy, F, loweredMapForQuant);
 
   EE.compile(CompilationMode::Infer, QP);
 
@@ -1196,8 +1197,9 @@ TEST_P(InterpreterAndCPU, testFindPixelRegression) {
   // Build the new quantized graph.
   LoweredInfoMap loweredMapForQuant;
   lower(F, &loweredMapForQuant, EE.getBackend());
-  Function *QP = quantization::quantizeFunction(EE, QI, ElemKind::Int8QTy, F,
-                                                loweredMapForQuant);
+  Function *QP =
+      quantization::quantizeFunction(EE, quantization::Schema::Asymmetric, QI,
+                                     ElemKind::Int8QTy, F, loweredMapForQuant);
 
   EE.compile(CompilationMode::Infer, QP);
 

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -1848,7 +1848,8 @@ COMPARE_ARITH_FUN(Min)
   TEST_P(OperatorStatelessTest, Basic##_OP_NAME_##NetFloatVsInt8) {            \
     ENABLED_BACKENDS(__VA_ARGS__);                                             \
     compareAgainstInterpreter(GetParam(), createAndInitBasic##_OP_NAME_##Test, \
-                              ElemKind::FloatTy, ElemKind::Int8QTy, 0.02f);    \
+                              ElemKind::FloatTy, ElemKind::Int8QTy,            \
+                              quantization::Schema::Asymmetric, 0.02f);        \
   }
 COMPARE_ARITH_FLOAT_VS_INT8(Add, Interpreter, CPU, OpenCL)
 COMPARE_ARITH_FLOAT_VS_INT8(Sub, Interpreter, CPU, OpenCL)
@@ -1862,7 +1863,8 @@ COMPARE_ARITH_FLOAT_VS_INT8(Min, Interpreter, CPU, OpenCL)
   TEST_P(OperatorStatelessTest, Basic##_OP_NAME_##NetFloatVsInt16) {           \
     ENABLED_BACKENDS(__VA_ARGS__);                                             \
     compareAgainstInterpreter(GetParam(), createAndInitBasic##_OP_NAME_##Test, \
-                              ElemKind::FloatTy, ElemKind::Int16QTy, 0.02f);   \
+                              ElemKind::FloatTy, ElemKind::Int16QTy,           \
+                              quantization::Schema::Asymmetric, 0.02f);        \
   }
 COMPARE_ARITH_FLOAT_VS_INT16(Add, Interpreter)
 COMPARE_ARITH_FLOAT_VS_INT16(Sub, Interpreter)
@@ -1876,7 +1878,8 @@ COMPARE_ARITH_FLOAT_VS_INT16(Min, Interpreter)
   TEST_P(OperatorStatelessTest, Basic##_OP_NAME_##NetFloatVsFloat16) {         \
     ENABLED_BACKENDS(__VA_ARGS__);                                             \
     compareAgainstInterpreter(GetParam(), createAndInitBasic##_OP_NAME_##Test, \
-                              ElemKind::FloatTy, ElemKind::Float16Ty, 0.01f);  \
+                              ElemKind::FloatTy, ElemKind::Float16Ty,          \
+                              quantization::Schema::Asymmetric, 0.01f);        \
   }
 COMPARE_ARITH_FLOAT_VS_FLOAT16(Add, Interpreter)
 COMPARE_ARITH_FLOAT_VS_FLOAT16(Sub, Interpreter)
@@ -2011,35 +2014,41 @@ createAndInitConvDepthTest(glow::PlaceholderBindings &bindings,
 
 TEST_P(OperatorStatelessTest, Int8ConvolutionDepth10) {
   compareAgainstInterpreter(GetParam(), createAndInitConvDepthTest<10>,
-                            ElemKind::FloatTy, ElemKind::Int8QTy, 0.045f);
+                            ElemKind::FloatTy, ElemKind::Int8QTy,
+                            quantization::Schema::Asymmetric, 0.045f);
 }
 
 TEST_P(OperatorStatelessTest, Int16ConvolutionDepth10) {
   ENABLED_BACKENDS(Interpreter);
   compareAgainstInterpreter(GetParam(), createAndInitConvDepthTest<10>,
-                            ElemKind::FloatTy, ElemKind::Int16QTy, 0.03f);
+                            ElemKind::FloatTy, ElemKind::Int16QTy,
+                            quantization::Schema::Asymmetric, 0.03f);
 }
 
 TEST_P(OperatorStatelessTest, Int8ConvolutionDepth8) {
   compareAgainstInterpreter(GetParam(), createAndInitConvDepthTest<8>,
-                            ElemKind::FloatTy, ElemKind::Int8QTy, 0.03f);
+                            ElemKind::FloatTy, ElemKind::Int8QTy,
+                            quantization::Schema::Asymmetric, 0.03f);
 }
 TEST_P(OperatorStatelessTest, Int16ConvolutionDepth8) {
   ENABLED_BACKENDS(Interpreter);
   compareAgainstInterpreter(GetParam(), createAndInitConvDepthTest<8>,
-                            ElemKind::FloatTy, ElemKind::Int16QTy, 0.03f);
+                            ElemKind::FloatTy, ElemKind::Int16QTy,
+                            quantization::Schema::Asymmetric, 0.03f);
 }
 
 TEST_P(OperatorStatelessTest, FP16ConvolutionDepth10) {
   ENABLED_BACKENDS(Interpreter);
   compareAgainstInterpreter(GetParam(), createAndInitConvDepthTest<10>,
-                            ElemKind::FloatTy, ElemKind::Float16Ty, 0.015f);
+                            ElemKind::FloatTy, ElemKind::Float16Ty,
+                            quantization::Schema::Asymmetric, 0.015f);
 }
 
 TEST_P(OperatorStatelessTest, FP16ConvolutionDepth8) {
   ENABLED_BACKENDS(Interpreter);
   compareAgainstInterpreter(GetParam(), createAndInitConvDepthTest<8>,
-                            ElemKind::FloatTy, ElemKind::Float16Ty, 0.015f);
+                            ElemKind::FloatTy, ElemKind::Float16Ty,
+                            quantization::Schema::Asymmetric, 0.015f);
 }
 
 static FunctionTensorPair
@@ -2066,7 +2075,8 @@ createAndInitBasicConcatTest(glow::PlaceholderBindings &bindings,
 TEST_P(OperatorStatelessTest, IntConcat) {
   ENABLED_BACKENDS(Interpreter, CPU);
   compareAgainstInterpreter(GetParam(), createAndInitBasicConcatTest,
-                            ElemKind::FloatTy, ElemKind::Int8QTy, 0.05f);
+                            ElemKind::FloatTy, ElemKind::Int8QTy,
+                            quantization::Schema::Asymmetric, 0.05f);
 }
 
 TEST_P(OperatorTest, FCWithFlatten) {
@@ -2126,7 +2136,8 @@ createAndInitBasicFCTest(glow::PlaceholderBindings &bindings,
 
 TEST_P(OperatorStatelessTest, IntFC) {
   compareAgainstInterpreter(GetParam(), createAndInitBasicFCTest,
-                            ElemKind::FloatTy, ElemKind::Int8QTy, 0.05f);
+                            ElemKind::FloatTy, ElemKind::Int8QTy,
+                            quantization::Schema::Asymmetric, 0.05f);
 }
 
 TEST_P(OperatorTest, EntropyLossTest) {
@@ -2333,7 +2344,8 @@ createAndInitTransposeNet(glow::PlaceholderBindings &bindings,
 
 TEST_P(OperatorStatelessTest, QuantizedTranspose) {
   compareAgainstInterpreter(GetParam(), createAndInitTransposeNet,
-                            ElemKind::FloatTy, ElemKind::Int8QTy, 0.0045f);
+                            ElemKind::FloatTy, ElemKind::Int8QTy,
+                            quantization::Schema::Asymmetric, 0.0045f);
 }
 
 TEST_P(OperatorTest, QuantizedArithmeticUnrescaled) {
@@ -3843,13 +3855,15 @@ createAndInitBasicTanhTest(glow::PlaceholderBindings &bindings,
 TEST_P(OperatorStatelessTest, Int8Tanh) {
   ENABLED_BACKENDS(Interpreter, CPU);
   compareAgainstInterpreter(GetParam(), createAndInitBasicTanhTest,
-                            ElemKind::FloatTy, ElemKind::Int8QTy, 0.005f);
+                            ElemKind::FloatTy, ElemKind::Int8QTy,
+                            quantization::Schema::Asymmetric, 0.005f);
 }
 
 TEST_P(OperatorStatelessTest, Tanh_Float16) {
   ENABLED_BACKENDS(Interpreter);
   compareAgainstInterpreter(GetParam(), createAndInitBasicTanhTest,
-                            ElemKind::FloatTy, ElemKind::Float16Ty, 0.001f);
+                            ElemKind::FloatTy, ElemKind::Float16Ty,
+                            quantization::Schema::Asymmetric, 0.001f);
 }
 
 /// Verify that the Tanh operator works correctly.
@@ -3902,7 +3916,8 @@ createAndInitBasicLogTest(glow::PlaceholderBindings &bindings,
 TEST_P(OperatorStatelessTest, Int8Log) {
   ENABLED_BACKENDS(Interpreter, CPU);
   compareAgainstInterpreter(GetParam(), createAndInitBasicLogTest,
-                            ElemKind::FloatTy, ElemKind::Int8QTy, 0.1f);
+                            ElemKind::FloatTy, ElemKind::Int8QTy,
+                            quantization::Schema::Asymmetric, 0.1f);
 }
 
 /// Check Non-square kernel for conv.
@@ -4288,7 +4303,8 @@ createAndInitBasicSigmoidTest(glow::PlaceholderBindings &bindings,
 TEST_P(OperatorStatelessTest, Int8Sigmoid) {
   ENABLED_BACKENDS(Interpreter, CPU);
   compareAgainstInterpreter(GetParam(), createAndInitBasicSigmoidTest,
-                            ElemKind::FloatTy, ElemKind::Int8QTy, 0.005f);
+                            ElemKind::FloatTy, ElemKind::Int8QTy,
+                            quantization::Schema::Asymmetric, 0.005f);
 }
 
 /// Check that the batch add operator works properly.
@@ -4830,7 +4846,8 @@ TEST_P(OperatorTest, RowwiseQuantizedSparseLengthsWeightedSum) {
   };
 
   auto *R = F_->createRowwiseQuantizedSparseLengthsWeightedSum(
-      "RQSLWS", data, weights, indices, lengths);
+      "RQSLWS", data, weights, indices, lengths,
+      quantization::Schema::Asymmetric);
   SaveNode *S = F_->createSave("save", R);
   bindings_.allocate(S->getPlaceholder());
 
@@ -4885,8 +4902,8 @@ TEST_P(OperatorTest, RowwiseQuantizedSparseLengthsSum) {
       2, 0, 2, 1, 3,
   };
 
-  auto *R = F_->createRowwiseQuantizedSparseLengthsSum("RQSLWS", data, indices,
-                                                       lengths);
+  auto *R = F_->createRowwiseQuantizedSparseLengthsSum(
+      "RQSLWS", data, indices, lengths, quantization::Schema::Asymmetric);
   SaveNode *S = F_->createSave("save", R);
   bindings_.allocate(S->getPlaceholder());
 
@@ -5629,7 +5646,8 @@ createAndInitBasicRowwiseFCTest(glow::PlaceholderBindings &bindings,
 TEST_P(OperatorStatelessTest, rowwiseQuantizedFCTest) {
   ENABLED_BACKENDS(Interpreter, CPU);
   compareAgainstInterpreter(GetParam(), createAndInitBasicRowwiseFCTest,
-                            ElemKind::FloatTy, ElemKind::Int8QTy, 0.06f,
+                            ElemKind::FloatTy, ElemKind::Int8QTy,
+                            quantization::Schema::Asymmetric, 0.06f,
                             /* enableRowwiseQuantization */ true);
 }
 
@@ -5686,7 +5704,8 @@ createAndInitBasicSLWSTest(glow::PlaceholderBindings &bindings,
 TEST_P(OperatorStatelessTest, rowwiseQuantizedSLWSTest) {
   ENABLED_BACKENDS(Interpreter);
   compareAgainstInterpreter(GetParam(), createAndInitBasicSLWSTest,
-                            ElemKind::FloatTy, ElemKind::Int8QTy, 0.01f,
+                            ElemKind::FloatTy, ElemKind::Int8QTy,
+                            quantization::Schema::Asymmetric, 0.01f,
                             /* enableRowwiseQuantization */ true);
 }
 

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -308,8 +308,8 @@ void Loader::compile(PlaceholderBindings &bindings) {
 
     // Quantize the graph based on the captured profile.
     auto *Q = quantization::quantizeFunction(
-        EE_, quantizationInfos, quantizationPrecision, F_, loweredMap_, oldName,
-        keepOriginalPrecisionForNodes, enableRowwiseOpt);
+        EE_, quantizationSchema, quantizationInfos, quantizationPrecision, F_,
+        loweredMap_, oldName, keepOriginalPrecisionForNodes, enableRowwiseOpt);
 
     // Erase the original function so that the redundant variables that are only
     // referenced by the original function will be removed.


### PR DESCRIPTION
*Description*: Right now schema is hard coded in some of the glow function. Changing to use the command line option. Follow up step can be storing it and loading it from profile to avoid potential issue with profile being created under one quantization and used under another.
*Testing*: UnitTests
*Documentation*:
[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
