### PR TITLE
[llvm] A few fixes to build against LLVM 8.0.

### DIFF
--- a/include/glow/LLVMIRCodeGen/GlowJIT.h
+++ b/include/glow/LLVMIRCodeGen/GlowJIT.h
@@ -54,8 +54,13 @@ private:
   ExecutionSession ES_;
   std::shared_ptr<SymbolResolver> resolver_;
 #endif
+#if LLVM_VERSION_MAJOR < 8
   RTDyldObjectLinkingLayer objectLayer_;
   IRCompileLayer<decltype(objectLayer_), SimpleCompiler> compileLayer_;
+#else
+  LegacyRTDyldObjectLinkingLayer objectLayer_;
+  LegacyIRCompileLayer<decltype(objectLayer_), SimpleCompiler> compileLayer_;
+#endif
 
 public:
   GlowJIT(llvm::TargetMachine &TM);

--- a/lib/LLVMIRCodeGen/DebugInfo.cpp
+++ b/lib/LLVMIRCodeGen/DebugInfo.cpp
@@ -30,6 +30,7 @@
 
 using namespace glow;
 using llvm::cast;
+using llvm::DISubprogram;
 using llvm::dyn_cast;
 using llvm::isa;
 
@@ -159,10 +160,18 @@ LLVMIRGen::getOrCreateFunctionDebugInfo(llvm::Function *F, llvm::DIScope *scope,
     auto *DIFunctionTy = DIBuilder_->createSubroutineType(
         DIBuilder_->getOrCreateTypeArray(paramTys));
     // Create a debug information for the current function.
+#if LLVM_VERSION_MAJOR < 8
     DIFunction = DIBuilder_->createFunction(
         scope, F->getName(), "", file, lineNo, DIFunctionTy,
         false /* internal linkage */, true /* definition */, lineNo,
         llvm::DINode::FlagPrototyped, true /* isOptimized */);
+#else
+    DIFunction = DIBuilder_->createFunction(
+        scope, F->getName(), "", file, lineNo, DIFunctionTy, lineNo,
+        llvm::DINode::FlagPrototyped,
+        DISubprogram::SPFlagLocalToUnit | DISubprogram::SPFlagDefinition |
+            DISubprogram::SPFlagOptimized);
+#endif
     assert(DIFunction);
     F->setSubprogram(DIFunction);
   }


### PR DESCRIPTION
*Description*: Some minor fixes to get the master to build against the current LLVM 8.0 release branch.
*Testing*: Similar unit test results than with 7.0. Runs at least the MNIST example network. CIFAR10 still running.
*Documentation*: n/a
