### PR TITLE
[doc] Add a note of LLVM built with assertions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ whereas MacPorts installs it in `/opt/local/libexec/llvm-7.0/`. This means that
 CMake will need to be told where to find LLVM when building; instructions on
 that can be found [here](#building-with-dependencies-llvm).
 
+Also please note that Glow currently builds, but does not work reliably with LLVM built with assertions on, but can crash at run time (see issue [#2537](/pytorch/glow/issues/2537)).
+
 Finally, create a symbolic link to the Homebrew- or MacPorts-installed
 `clang-*` tools so that the `utils/format.sh` script is able to find them later
 on. For a Homebrew-managed installation, run:


### PR DESCRIPTION
*Description*: Glow does not currently work with assertion ON builds, but crashes at least with some of the test cases. I added a note of this to README.md to perhaps help others who struggle with it when starting with Glow.

*Testing*: Not all unit tests pass for me even with the assertions OFF, but many more do.

See Issue #2537. 
