### PR TITLE
[Training] Add support for training SparseLengthsWeightedSum

### DIFF
--- a/examples/char-rnn.cpp
+++ b/examples/char-rnn.cpp
@@ -231,7 +231,7 @@ int main(int argc, char **argv) {
   //// Train the network ////
   Function *F =
       createNetwork(mod, bindings, minibatchSize, numSteps, hiddenSize);
-  Function *TF = differentiate(F, TC);
+  Function *TF = differentiate(F, TC, bindings);
 
   auto *X = mod.getPlaceholderByName("input");
   auto *Y = mod.getPlaceholderByName("expected");

--- a/examples/char-rnn.cpp
+++ b/examples/char-rnn.cpp
@@ -218,12 +218,13 @@ int main(int argc, char **argv) {
   const size_t hiddenSize = 256;
 
   GLOW_ASSERT(text.size() > numSteps && "Text is too short");
-  TrainingConfig TC;
+  TrainingConfig TC(TrainingAlgorithm::StochasticGradientDescent);
+  auto *trainingParams = TC.getParams<SGDParameters>();
 
   ExecutionEngine EE(executionBackend);
-  TC.learningRate = 0.001;
-  TC.momentum = 0.9;
-  TC.batchSize = minibatchSize;
+  trainingParams->learningRate = 0.001;
+  trainingParams->momentum = 0.9;
+  trainingParams->batchSize = minibatchSize;
 
   auto &mod = EE.getModule();
 

--- a/examples/cifar10.cpp
+++ b/examples/cifar10.cpp
@@ -159,15 +159,16 @@ void testCIFAR10() {
   unsigned minibatchSize = 8;
 
   // Construct the network:
-  TrainingConfig TC;
+  TrainingConfig TC(TrainingAlgorithm::StochasticGradientDescent);
+  auto *trainingParams = TC.getParams<SGDParameters>();
 
   ExecutionEngine EE(executionBackend);
   PlaceholderBindings bindings;
 
-  TC.learningRate = 0.001;
-  TC.momentum = 0.9;
-  TC.L2Decay = 0.0001;
-  TC.batchSize = minibatchSize;
+  trainingParams->learningRate = 0.001;
+  trainingParams->momentum = 0.9;
+  trainingParams->L2Decay = 0.0001;
+  trainingParams->batchSize = minibatchSize;
 
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");

--- a/examples/cifar10.cpp
+++ b/examples/cifar10.cpp
@@ -186,7 +186,7 @@ void testCIFAR10() {
   auto *resultPH = createModel(bindings, F, A, E);
   auto *result = bindings.allocate(resultPH);
 
-  Function *TF = glow::differentiate(F, TC);
+  Function *TF = glow::differentiate(F, TC, bindings);
   EE.compile(CompilationMode::Train, TF);
 
   // Report progress every this number of training iterations.

--- a/examples/mnist.cpp
+++ b/examples/mnist.cpp
@@ -100,13 +100,14 @@ void testMNIST() {
   llvm::Timer timer("Training", "Training");
 
   /// The training configuration.
-  TrainingConfig TC;
+  TrainingConfig TC(TrainingAlgorithm::StochasticGradientDescent);
+  auto *trainingParams = TC.getParams<SGDParameters>();
 
   // Construct the network:
-  TC.learningRate = 0.001;
-  TC.momentum = 0.9;
-  TC.L2Decay = 0.001;
-  TC.batchSize = minibatchSize;
+  trainingParams->learningRate = 0.001;
+  trainingParams->momentum = 0.9;
+  trainingParams->L2Decay = 0.001;
+  trainingParams->batchSize = minibatchSize;
 
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");

--- a/examples/mnist.cpp
+++ b/examples/mnist.cpp
@@ -133,7 +133,7 @@ void testMNIST() {
   Tensor *resultTensor = bindings.allocate(result->getPlaceholder());
   bindings.allocate(selected);
 
-  Function *TF = glow::differentiate(F, TC);
+  Function *TF = glow::differentiate(F, TC, bindings);
 
   EE.compile(CompilationMode::Train, TF);
 

--- a/examples/ptb.cpp
+++ b/examples/ptb.cpp
@@ -237,7 +237,7 @@ void testPTB() {
     F->dumpDAG(dumpInitialGraphDAGFileOpt.c_str());
   }
 
-  Function *TF = glow::differentiate(F, TC);
+  Function *TF = glow::differentiate(F, TC, bindings);
 
   EE.compile(CompilationMode::Train, TF);
 

--- a/examples/ptb.cpp
+++ b/examples/ptb.cpp
@@ -191,10 +191,12 @@ void testPTB() {
   PlaceholderBindings bindings;
 
   // Construct the network:
-  TrainingConfig TC;
-  TC.learningRate = learningRate;
-  TC.momentum = 0;
-  TC.batchSize = minibatchSize;
+  TrainingConfig TC(TrainingAlgorithm::StochasticGradientDescent);
+  auto *trainingParams = TC.getParams<SGDParameters>();
+
+  trainingParams->learningRate = learningRate;
+  trainingParams->momentum = 0;
+  trainingParams->batchSize = minibatchSize;
 
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");

--- a/include/glow/Base/Train.h
+++ b/include/glow/Base/Train.h
@@ -27,7 +27,7 @@ namespace glow {
 class Tensor;
 
 /// These are all the supported training algorithms.
-enum class TrainingAlgorithm { None, StochasticGradientDescent };
+enum class TrainingAlgorithm { None, StochasticGradientDescent, Adagrad };
 
 /// This is a list of common parameters that all of the training algorithms use.
 struct TrainingParameters {
@@ -42,6 +42,11 @@ struct SGDParameters : public TrainingParameters {
   float momentum{0.0};
 };
 
+/// Additional training parameters used by Adagrad.
+struct AdagradParameters : public TrainingParameters {
+  float epsilon{1e-5};
+};
+
 /// Combination of training algorithm type and training parameters. Parameters
 /// should be casted to the appropriate type based on the algorithm type.
 struct TrainingConfig {
@@ -50,6 +55,8 @@ struct TrainingConfig {
       : algorithm(algo) {
     if (algorithm == TrainingAlgorithm::StochasticGradientDescent) {
       parameters = llvm::make_unique<SGDParameters>();
+    } else if (algorithm == TrainingAlgorithm::Adagrad) {
+      parameters = llvm::make_unique<AdagradParameters>();
     } else {
       llvm_unreachable("Invalid training algorithm.");
     }

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -18,6 +18,7 @@
 
 #include "glow/Base/Type.h"
 #include "glow/Graph/Nodes.h"
+#include "glow/Graph/PlaceholderBindings.h"
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
@@ -29,8 +30,6 @@
 #include <vector>
 
 namespace glow {
-class PlaceholderBindings;
-
 /// List of Types.
 using TypesList = std::list<Type>;
 /// Intrusive list of Nodes.
@@ -1025,13 +1024,15 @@ using VariableGradientsList =
 
 /// Create a new Function that 'trains' the input Function. We differentiate the
 /// nodes and insert code to update the weights based on the \p config
-/// parameters.
+/// parameters. \p bindings is used to allocate any extra required Placeholders
+/// depending on the training algorithm used.
 /// If \p varGrads is set then instead of inserting code to update the weights,
 /// the procedure adds code to record the last gradient value: a list of
 /// (var, grad_var) pairs associating variables with their gradient variables.
 /// This feature is used by the gradient-check unit tests.
 /// \returns a new function with the name \p newFuncName.
 Function *differentiate(Function *F, const TrainingConfig &config,
+                        PlaceholderBindings &bindings,
                         llvm::StringRef newFuncName = "",
                         VariableGradientsList *varGrads = nullptr);
 

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -97,6 +97,19 @@ bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
            (NI.getInElemTy(SparseLengthsWeightedSumNode::LengthsIdx) ==
             ElemKind::Int32ITy);
 
+  case Kinded::Kind::SparseLengthsWeightedSumGradNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::FloatTy},
+               {SparseLengthsWeightedSumGradNode::IndicesIdx,
+                SparseLengthsWeightedSumGradNode::LengthsIdx},
+               {SparseLengthsWeightedSumGradNode::GradOfInputNamedIndicesIdx,
+                SparseLengthsWeightedSumGradNode::
+                    GradOfInputNamedLengthsIdx}) &&
+           (NI.getInElemTy(SparseLengthsWeightedSumGradNode::IndicesIdx) ==
+            ElemKind::Int64ITy) &&
+           (NI.getInElemTy(SparseLengthsWeightedSumGradNode::LengthsIdx) ==
+            ElemKind::Int32ITy);
+
   case Kinded::Kind::RowwiseQuantizedSparseLengthsWeightedSumNodeKind:
     return (NI.getInElemTy(
                 RowwiseQuantizedSparseLengthsWeightedSumNode::DataIdx) ==

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -180,6 +180,19 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
            (NI.getInElemTy(SparseLengthsWeightedSumNode::LengthsIdx) ==
             ElemKind::Int32ITy);
 
+  case Kinded::Kind::SparseLengthsWeightedSumGradNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::FloatTy},
+               {SparseLengthsWeightedSumGradNode::IndicesIdx,
+                SparseLengthsWeightedSumGradNode::LengthsIdx},
+               {SparseLengthsWeightedSumGradNode::GradOfInputNamedIndicesIdx,
+                SparseLengthsWeightedSumGradNode::
+                    GradOfInputNamedLengthsIdx}) &&
+           (NI.getInElemTy(SparseLengthsWeightedSumGradNode::IndicesIdx) ==
+            ElemKind::Int64ITy) &&
+           (NI.getInElemTy(SparseLengthsWeightedSumGradNode::LengthsIdx) ==
+            ElemKind::Int32ITy);
+
   case Kinded::Kind::RowwiseQuantizedSparseLengthsWeightedSumNodeKind:
     return (NI.getInElemTy(
                 RowwiseQuantizedSparseLengthsWeightedSumNode::DataIdx) ==

--- a/lib/Graph/Grad.cpp
+++ b/lib/Graph/Grad.cpp
@@ -109,6 +109,7 @@ Function *glow::differentiate(Function *F, const TrainingConfig &conf,
     CONVERT_TO_GRAD_NODE(ReluNode)
     CONVERT_TO_GRAD_NODE(SigmoidNode)
     CONVERT_TO_GRAD_NODE(TanhNode)
+    CONVERT_TO_GRAD_NODE(SparseLengthsWeightedSumNode)
 
     if (N->getKind() == Kind::SaveNodeKind) {
       // Swap the src and dest. Send the Zero value as gradient for both sides.

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -933,6 +933,14 @@ bool SGDNode::verify() const {
   return checkSameType(getGradient(), getWeight(), this);
 }
 
+bool AdagradNode::verify() const {
+  // Make sure that the gradient, weight, and momentum tensors are all the same
+  // type.
+  bool isValid = checkSameType(getGradient(), getWeight(), this);
+  isValid &= checkSameType(getGradient(), getMomentum(), this);
+  return isValid;
+}
+
 bool QuantizationProfileNode::verify() const {
   // Make sure that input tensor is a floating point type.
   bool isValid = checkType(getInput(), ElemKind::FloatTy, this);

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -823,6 +823,34 @@ bool SparseLengthsWeightedSumNode::verify() const {
   return isValid;
 }
 
+bool SparseLengthsWeightedSumGradNode::verify() const {
+  // Same checks as SparseLengthsWeightedSumNode.
+  bool isValid =
+      checkType(getOriginalOutputForResult(), getData().getElementType(), this);
+  isValid &= checkType(getWeights(), getData().getElementType(), this);
+  isValid &= checkType(getIndices(), ElemKind::Int64ITy, this);
+  isValid &= checkType(getLengths(), ElemKind::Int32ITy, this);
+  isValid &= expectCompareTrue("Indices must be a 1D vector",
+                               getIndices().dims().size(), size_t(1), this);
+  isValid &= expectCompareTrue("Lengths must be a 1D vector",
+                               getLengths().dims().size(), size_t(1), this);
+  isValid &= expectCompareTrue("Weights must be a 1D vector",
+                               getWeights().dims().size(), size_t(1), this);
+
+  isValid &=
+      expectCompareTrue("Weights and Indices must have the same size",
+                        getWeights().dims()[0], getIndices().dims()[0], this);
+
+  // Checks on gradient inputs/outputs.
+  isValid &= checkSameType(getGradOfOriginalOutputNamedResult(),
+                           getOriginalOutputForResult(), this);
+  isValid &= checkSameType(getGradOfInputNamedData(), getData(), this);
+  isValid &= checkSameType(getGradOfInputNamedWeights(), getWeights(), this);
+  isValid &= checkSameType(getGradOfInputNamedIndices(), getIndices(), this);
+  isValid &= checkSameType(getGradOfInputNamedLengths(), getLengths(), this);
+  return isValid;
+}
+
 bool RowwiseQuantizedSparseLengthsWeightedSumNode::verify() const {
   bool isValid = checkType(getResult(), ElemKind::FloatTy, this);
   isValid &= checkType(getData(), ElemKind::Int8QTy, this);

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -2210,6 +2210,30 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     break;
   }
 
+  case Kinded::Kind::SparseLengthsWeightedSumGradInstKind: {
+    auto *SI = cast<SparseLengthsWeightedSumGradInst>(I);
+    auto *destGrad = SI->getDestGrad();
+    auto *dataGrad = SI->getDataGrad();
+    auto *weights = SI->getWeights();
+    auto *indices = SI->getIndices();
+    auto *lengths = SI->getLengths();
+    auto *destGradPtr = emitValueAddress(builder, destGrad);
+    auto *dataGradPtr = emitValueAddress(builder, dataGrad);
+    auto *weightsPtr = emitValueAddress(builder, weights);
+    auto *indicesPtr = emitValueAddress(builder, indices);
+    auto *lengthsPtr = emitValueAddress(builder, lengths);
+    auto *segments = emitConstSizeT(builder, lengths->dims()[0]);
+    auto *numLines = emitConstSizeT(builder, dataGrad->dims()[0]);
+    auto *lineSize =
+        emitConstSizeT(builder, dataGrad->size() / dataGrad->dims()[0]);
+    auto *F = getFunction("sparse_lengths_weighted_sum_grad",
+                          destGrad->getElementType());
+    createCall(builder, F,
+               {destGradPtr, dataGradPtr, weightsPtr, indicesPtr, lengthsPtr,
+                segments, lineSize, numLines});
+    break;
+  }
+
   case Kinded::Kind::RowwiseQuantizedSparseLengthsWeightedSumInstKind: {
     auto *N = cast<RowwiseQuantizedSparseLengthsWeightedSumInst>(I);
     auto *dest = N->getDest();

--- a/tests/unittests/BackendTestUtils.cpp
+++ b/tests/unittests/BackendTestUtils.cpp
@@ -228,16 +228,18 @@ void trainConvNet(Tensor *inputs, Tensor *kernel1, Tensor *bias1,
                   llvm::ArrayRef<size_t> shape1, llvm::ArrayRef<size_t> shape2,
                   Tensor *out, BackendKind kind) {
   ExecutionEngine EE(kind);
-  TrainingConfig TC;
+  TrainingConfig TC(TrainingAlgorithm::StochasticGradientDescent);
   PlaceholderBindings bindings;
 
   // This variable records the number of the next sample to be used for
   // training.
   size_t sampleCounter = 0;
 
-  TC.learningRate = 0.03;
-  TC.momentum = 0.3;
-  TC.L2Decay = 0.01;
+  auto *trainingParams = TC.getParams<SGDParameters>();
+  trainingParams->learningRate = 0.03;
+  trainingParams->momentum = 0.3;
+  trainingParams->L2Decay = 0.01;
+
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
   auto *var1 = createPlaceholder(mod, bindings, inputs, "var1");
@@ -290,15 +292,17 @@ void trainLocalResponseNormalizationNet(Tensor *inputs, Tensor *weights,
                                         Tensor *out, BackendKind kind) {
   PlaceholderBindings bindings;
   ExecutionEngine EE(kind);
-  TrainingConfig TC;
+  TrainingConfig TC(TrainingAlgorithm::StochasticGradientDescent);
 
   // This variable records the number of the next sample to be used for
   // training.
   size_t sampleCounter = 0;
 
-  TC.learningRate = 0.06;
-  TC.momentum = 0.1;
-  TC.L2Decay = 0.01;
+  auto *trainingParams = TC.getParams<SGDParameters>();
+  trainingParams->learningRate = 0.06;
+  trainingParams->momentum = 0.1;
+  trainingParams->L2Decay = 0.01;
+
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
   auto *var1 = createPlaceholder(mod, bindings, inputs, "var1");
@@ -329,16 +333,18 @@ void trainAvgPoolNet(Tensor *inputs, Tensor *weights, Tensor *bias,
                      llvm::ArrayRef<size_t> shape2, Tensor *out,
                      BackendKind kind) {
   ExecutionEngine EE(kind);
-  TrainingConfig TC;
+  TrainingConfig TC(TrainingAlgorithm::StochasticGradientDescent);
   PlaceholderBindings bindings;
 
   // This variable records the number of the next sample to be used for
   // training.
   size_t sampleCounter = 0;
 
-  TC.learningRate = 0.01;
-  TC.momentum = 0.4;
-  TC.L2Decay = 0.01;
+  auto *trainingParams = TC.getParams<SGDParameters>();
+  trainingParams->learningRate = 0.01;
+  trainingParams->momentum = 0.4;
+  trainingParams->L2Decay = 0.01;
+
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
   auto *var1 = createPlaceholder(mod, bindings, inputs, "var1");
@@ -369,16 +375,18 @@ void trainMaxPoolNet(Tensor *inputs, Tensor *weights, Tensor *bias,
                      llvm::ArrayRef<size_t> shape2, Tensor *out,
                      BackendKind kind) {
   ExecutionEngine EE(kind);
-  TrainingConfig TC;
+  TrainingConfig TC(TrainingAlgorithm::StochasticGradientDescent);
   PlaceholderBindings bindings;
 
   // This variable records the number of the next sample to be used for
   // training.
   size_t sampleCounter = 0;
 
-  TC.learningRate = 0.03;
-  TC.momentum = 0.3;
-  TC.L2Decay = 0.003;
+  auto *trainingParams = TC.getParams<SGDParameters>();
+  trainingParams->learningRate = 0.03;
+  trainingParams->momentum = 0.3;
+  trainingParams->L2Decay = 0.003;
+
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
   auto *var1 = createPlaceholder(mod, bindings, inputs, "var1");
@@ -627,16 +635,18 @@ void inferConvDKKC8(Tensor *out, BackendKind kind) {
 void trainSoftMaxNet(Tensor *inputs, Tensor *weights, Tensor *bias,
                      Tensor *selected, Tensor *out, BackendKind kind) {
   ExecutionEngine EE(kind);
-  TrainingConfig TC;
+  TrainingConfig TC(TrainingAlgorithm::StochasticGradientDescent);
   PlaceholderBindings bindings;
 
   // This variable records the number of the next sample to be used for
   // training.
   size_t sampleCounter = 0;
 
-  TC.learningRate = 0.003;
-  TC.momentum = 0.7;
-  TC.L2Decay = 0.001;
+  auto *trainingParams = TC.getParams<SGDParameters>();
+  trainingParams->learningRate = 0.003;
+  trainingParams->momentum = 0.7;
+  trainingParams->L2Decay = 0.001;
+
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
   auto *var1 = createPlaceholder(mod, bindings, inputs, "var1");

--- a/tests/unittests/BackendTestUtils.cpp
+++ b/tests/unittests/BackendTestUtils.cpp
@@ -257,7 +257,7 @@ void trainConvNet(Tensor *inputs, Tensor *kernel1, Tensor *bias1,
   auto *result = F->createSave("ret", softmax);
   auto *resultTensor = bindings.allocate(result->getPlaceholder());
 
-  Function *TF = glow::differentiate(F, TC);
+  Function *TF = glow::differentiate(F, TC, bindings);
   EE.compile(CompilationMode::Train, TF);
 
   runBatch(EE, bindings, 8, sampleCounter, {var1, var2}, {inputs, selected});
@@ -318,7 +318,7 @@ void trainLocalResponseNormalizationNet(Tensor *inputs, Tensor *weights,
   auto *result = F->createSave("ret", softmax);
   auto *resultTensor = bindings.allocate(result->getPlaceholder());
 
-  Function *TF = glow::differentiate(F, TC);
+  Function *TF = glow::differentiate(F, TC, bindings);
   EE.compile(CompilationMode::Train, TF);
   runBatch(EE, bindings, 8, sampleCounter, {var1, var2}, {inputs, selected});
 
@@ -359,7 +359,7 @@ void trainAvgPoolNet(Tensor *inputs, Tensor *weights, Tensor *bias,
   auto *result = F->createSave("ret", softmax);
   auto *resultTensor = bindings.allocate(result->getPlaceholder());
 
-  Function *TF = glow::differentiate(F, TC);
+  Function *TF = glow::differentiate(F, TC, bindings);
   EE.compile(CompilationMode::Train, TF);
 
   runBatch(EE, bindings, 10, sampleCounter, {var1, var2}, {inputs, selected});
@@ -401,7 +401,7 @@ void trainMaxPoolNet(Tensor *inputs, Tensor *weights, Tensor *bias,
   auto *result = F->createSave("ret", softmax);
   auto *resultTensor = bindings.allocate(result->getPlaceholder());
 
-  Function *TF = glow::differentiate(F, TC);
+  Function *TF = glow::differentiate(F, TC, bindings);
   EE.compile(CompilationMode::Train, TF);
 
   runBatch(EE, bindings, 7, sampleCounter, {var1, var2}, {inputs, selected});
@@ -658,7 +658,7 @@ void trainSoftMaxNet(Tensor *inputs, Tensor *weights, Tensor *bias,
   auto *result = F->createSave("ret", softmax);
   auto *resultTensor = bindings.allocate(result->getPlaceholder());
 
-  Function *TF = glow::differentiate(F, TC);
+  Function *TF = glow::differentiate(F, TC, bindings);
 
   EE.compile(CompilationMode::Train, TF);
 

--- a/tests/unittests/GradCheckTest.cpp
+++ b/tests/unittests/GradCheckTest.cpp
@@ -103,7 +103,7 @@ void performGradCheck(ExecutionEngine &EE, PlaceholderBindings &bindings,
   size_t sampleCounter = 0;
 
   // Create a function that trains the network.
-  Function *TF = glow::differentiate(&F, TC);
+  Function *TF = glow::differentiate(&F, TC, bindings);
   EE.compile(CompilationMode::Train, TF);
 
   // The network might have variables, other than inputVar and expVar.
@@ -114,7 +114,8 @@ void performGradCheck(ExecutionEngine &EE, PlaceholderBindings &bindings,
   // Create a version of the network that records the gradients to some side
   // table instead of updating them.
   VariableGradientsList varGrads;
-  Function *recordNet = glow::differentiate(&F, TC, "record", &varGrads);
+  Function *recordNet =
+      glow::differentiate(&F, TC, bindings, "record", &varGrads);
   allocateGrads(bindings, varGrads);
   EE.compile(CompilationMode::Train, recordNet);
 
@@ -555,7 +556,7 @@ TEST_P(InterpreterGrad, gradientCheckCrossEntropyLoss) {
   outputsH.at({2}) = 1;
 
   VariableGradientsList varGrads;
-  Function *TF = glow::differentiate(F, TC, "record", &varGrads);
+  Function *TF = glow::differentiate(F, TC, bindings, "record", &varGrads);
   allocateGrads(bindings, varGrads);
   EE_.compile(CompilationMode::Train, TF);
 

--- a/tests/unittests/GradCheckTest.cpp
+++ b/tests/unittests/GradCheckTest.cpp
@@ -89,7 +89,7 @@ void performGradCheck(ExecutionEngine &EE, PlaceholderBindings &bindings,
                       SaveNode *result, Placeholder *inputVar,
                       Placeholder *expVar, Tensor *inputs, Tensor *outputs,
                       float delta, float allowedError) {
-  TrainingConfig TC;
+  TrainingConfig TC(TrainingAlgorithm::StochasticGradientDescent);
 
   auto &F = *EE.getModule().getFunction("main");
 
@@ -528,7 +528,7 @@ TEST_P(InterpreterGrad, gradientCheckCrossEntropyLoss) {
   const int testSamples = 5;
   const float stepSize = 1e-4;
   const float delta = 0.015;
-  TrainingConfig TC;
+  TrainingConfig TC(TrainingAlgorithm::StochasticGradientDescent);
   PlaceholderBindings bindings;
 
   auto &mod = EE_.getModule();

--- a/tests/unittests/GraphGradTest.cpp
+++ b/tests/unittests/GraphGradTest.cpp
@@ -63,7 +63,7 @@ TEST(GraphAutoGrad, autoGrad) {
   auto *result = F->createSave("return", SM);
   (void)result;
 
-  Function *TF = glow::differentiate(F, TC);
+  Function *TF = glow::differentiate(F, TC, bindings);
   EE.compile(CompilationMode::Train, TF);
   EE.compile(CompilationMode::Infer, F);
 }
@@ -94,7 +94,7 @@ TEST(GraphAutoGrad, checkLRNGen) {
 
   auto *result = F->createSave("return", SM);
   (void)result;
-  Function *TF = glow::differentiate(F, TC);
+  Function *TF = glow::differentiate(F, TC, bindings);
   EE.compile(CompilationMode::Train, TF);
   EE.compile(CompilationMode::Infer, F);
 }
@@ -130,7 +130,7 @@ TEST(GraphAutoGrad, cloneAndDiff) {
 
   EXPECT_EQ(M.getPlaceholders().size(), 5);
 
-  auto *diffF = differentiate(F, TC);
+  auto *diffF = differentiate(F, TC, bindings);
 
   EXPECT_TRUE(diffF->verify());
 
@@ -176,7 +176,7 @@ TEST(GraphAutoGrad, checkPlaceholderGradTest) {
   // Expect a single user to the trainable input placeholder.
   EXPECT_EQ(A->getNumUsers(), 1);
 
-  Function *TF = glow::differentiate(F, TC);
+  Function *TF = glow::differentiate(F, TC, bindings);
   EE.compile(CompilationMode::Train, TF);
   EE.compile(CompilationMode::Infer, F);
 
@@ -208,7 +208,7 @@ TEST(GraphAutoGrad, checkConvertToGradTest) {
   auto *result = F->createSave("save", convertTo);
   bindings.allocate(result->getPlaceholder());
 
-  Function *TF = glow::differentiate(F, TC);
+  Function *TF = glow::differentiate(F, TC, bindings);
   EE.compile(CompilationMode::Train, TF);
   EE.compile(CompilationMode::Infer, F);
 }

--- a/tests/unittests/GraphGradTest.cpp
+++ b/tests/unittests/GraphGradTest.cpp
@@ -31,13 +31,14 @@ TEST(GraphAutoGrad, autoGrad) {
   ExecutionEngine EE;
   PlaceholderBindings bindings;
 
-  TrainingConfig TC;
+  TrainingConfig TC(TrainingAlgorithm::StochasticGradientDescent);
 
   // Construct the network:
-  TC.learningRate = 0.001;
-  TC.momentum = 0.9;
-  TC.L2Decay = 0.001;
-  TC.L1Decay = 0.001;
+  auto *trainingParams = TC.getParams<SGDParameters>();
+  trainingParams->learningRate = 0.001;
+  trainingParams->momentum = 0.9;
+  trainingParams->L2Decay = 0.001;
+  trainingParams->L1Decay = 0.001;
 
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -69,13 +70,14 @@ TEST(GraphAutoGrad, autoGrad) {
 
 TEST(GraphAutoGrad, checkLRNGen) {
   ExecutionEngine EE;
-  TrainingConfig TC;
+  TrainingConfig TC(TrainingAlgorithm::StochasticGradientDescent);
   PlaceholderBindings bindings;
 
   // Construct the network:
-  TC.learningRate = 0.001;
-  TC.momentum = 0.9;
-  TC.L2Decay = 0.001;
+  auto *trainingParams = TC.getParams<SGDParameters>();
+  trainingParams->learningRate = 0.001;
+  trainingParams->momentum = 0.9;
+  trainingParams->L2Decay = 0.001;
 
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -100,7 +102,7 @@ TEST(GraphAutoGrad, checkLRNGen) {
 TEST(GraphAutoGrad, cloneAndDiff) {
   // The test ensures that unused variables are not touched in differentiation.
   ExecutionEngine EE;
-  TrainingConfig TC;
+  TrainingConfig TC(TrainingAlgorithm::StochasticGradientDescent);
   PlaceholderBindings bindings;
   Module M;
 
@@ -156,11 +158,12 @@ TEST(GraphAutoGrad, cloneAndDiff) {
 /// Check that we can differentiate functions that update Placeholder graphs.
 TEST(GraphAutoGrad, checkPlaceholderGradTest) {
   ExecutionEngine EE;
-  TrainingConfig TC;
+  TrainingConfig TC(TrainingAlgorithm::StochasticGradientDescent);
   PlaceholderBindings bindings;
 
   // Construct the network:
-  TC.learningRate = 0.001;
+  auto *trainingParams = TC.getParams<SGDParameters>();
+  trainingParams->learningRate = 0.001;
 
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -185,11 +188,12 @@ TEST(GraphAutoGrad, checkPlaceholderGradTest) {
 /// Check that we can differentiate functions that use ConvertToNode.
 TEST(GraphAutoGrad, checkConvertToGradTest) {
   ExecutionEngine EE;
-  TrainingConfig TC;
+  TrainingConfig TC(TrainingAlgorithm::StochasticGradientDescent);
   PlaceholderBindings bindings;
 
   // Construct the network:
-  TC.learningRate = 0.001;
+  auto *trainingParams = TC.getParams<SGDParameters>();
+  trainingParams->learningRate = 0.001;
 
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");

--- a/tests/unittests/HyphenTest.cpp
+++ b/tests/unittests/HyphenTest.cpp
@@ -280,7 +280,7 @@ struct HyphenNetwork {
     n = infer_->createSoftMax("output", n, expected_);
     result_ = infer_->createSave("result", n);
     bindings_.allocate(result_->getPlaceholder());
-    train_ = glow::differentiate(infer_, conf);
+    train_ = glow::differentiate(infer_, conf, bindings_);
   }
 
   // Run `inputs` through the inference function and check the results against

--- a/tests/unittests/MLTest.cpp
+++ b/tests/unittests/MLTest.cpp
@@ -38,10 +38,11 @@ class MLTest : public TestRunnerBase {};
 
 /// Use placeholders (and not variables) to learn the square root of two.
 TEST_P(MLTest, learnSqrt2Placeholder) {
-  TrainingConfig TC;
+  TrainingConfig TC(TrainingAlgorithm::StochasticGradientDescent);
   PlaceholderBindings bindings;
 
-  TC.learningRate = 0.03;
+  auto *trainingParams = TC.getParams<SGDParameters>();
+  trainingParams->learningRate = 0.03;
 
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("Square root of 2");
@@ -75,7 +76,7 @@ TEST_P(MLTest, learnSqrt2Placeholder) {
 }
 
 TEST_P(MLTest, trainASimpleNetwork) {
-  TrainingConfig TC;
+  TrainingConfig TC(TrainingAlgorithm::StochasticGradientDescent);
   PlaceholderBindings bindings;
 
   // This variable records the number of the next sample to be used for
@@ -83,7 +84,8 @@ TEST_P(MLTest, trainASimpleNetwork) {
   size_t sampleCounter = 0;
 
   // Learning a single input vector.
-  TC.learningRate = 0.05;
+  auto *trainingParams = TC.getParams<SGDParameters>();
+  trainingParams->learningRate = 0.05;
 
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("trainASimpleNetwork");
@@ -127,7 +129,7 @@ TEST_P(MLTest, trainASimpleNetwork) {
 }
 
 TEST_P(MLTest, simpleRegression) {
-  TrainingConfig TC;
+  TrainingConfig TC(TrainingAlgorithm::StochasticGradientDescent);
   PlaceholderBindings bindings;
 
   // This variable records the number of the next sample to be used for
@@ -140,7 +142,8 @@ TEST_P(MLTest, simpleRegression) {
   const size_t numInputs = 4;
 
   // Learning a single input vector.
-  TC.learningRate = 0.05;
+  auto *trainingParams = TC.getParams<SGDParameters>();
+  trainingParams->learningRate = 0.05;
 
   Tensor inputs(ElemKind::FloatTy, {1, numInputs});
   Tensor expected(ElemKind::FloatTy, {1, numInputs});
@@ -192,7 +195,7 @@ TEST_P(MLTest, simpleRegression) {
 }
 
 TEST_P(MLTest, learnXor) {
-  TrainingConfig TC;
+  TrainingConfig TC(TrainingAlgorithm::StochasticGradientDescent);
   PlaceholderBindings bindings;
 
   unsigned numInputs = 10;
@@ -202,8 +205,9 @@ TEST_P(MLTest, learnXor) {
   size_t sampleCounter = 0;
 
   // Learning a single input vector.
-  TC.learningRate = 0.05;
-  TC.batchSize = numInputs;
+  auto *trainingParams = TC.getParams<SGDParameters>();
+  trainingParams->learningRate = 0.05;
+  trainingParams->batchSize = numInputs;
 
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("learnXor");
@@ -271,7 +275,7 @@ TEST_P(MLTest, learnXor) {
 
 /// Learn the logarithmic function.
 TEST_P(MLTest, learnLog) {
-  TrainingConfig TC;
+  TrainingConfig TC(TrainingAlgorithm::StochasticGradientDescent);
   PlaceholderBindings bindings;
 
   // This variable records the number of the next sample to be used for
@@ -280,8 +284,10 @@ TEST_P(MLTest, learnLog) {
 
   unsigned numInputs = 50;
   unsigned batchSize = 5;
-  TC.learningRate = 0.07;
-  TC.batchSize = batchSize;
+
+  auto *trainingParams = TC.getParams<SGDParameters>();
+  trainingParams->learningRate = 0.07;
+  trainingParams->batchSize = batchSize;
 
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("learnLog");
@@ -386,7 +392,7 @@ void generateCircleData(Tensor &coordinates, Tensor &labels, PseudoRNG &PRNG) {
 /// Example from:
 /// http://cs.stanford.edu/people/karpathy/convnetjs/demo/classify2d.html
 TEST_P(MLTest, circle) {
-  TrainingConfig TC;
+  TrainingConfig TC(TrainingAlgorithm::StochasticGradientDescent);
   PlaceholderBindings bindings;
 
   // This variable records the number of the next sample to be used for
@@ -397,9 +403,10 @@ TEST_P(MLTest, circle) {
 
   // Testing the softmax layer.
   // Learning a single input vector.
-  TC.momentum = 0.9;
-  TC.learningRate = 0.01;
-  TC.batchSize = minibatchSize;
+  auto *trainingParams = TC.getParams<SGDParameters>();
+  trainingParams->momentum = 0.9;
+  trainingParams->learningRate = 0.01;
+  trainingParams->batchSize = minibatchSize;
 
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("circle");
@@ -494,9 +501,10 @@ TEST_P(MLTest, learnSingleValueConcat) {
   size_t sampleCounter = 0;
 
   // Learning a single input vector.
-  TrainingConfig TC;
-  TC.momentum = 0.9;
-  TC.learningRate = 0.01;
+  TrainingConfig TC(TrainingAlgorithm::StochasticGradientDescent);
+  auto *trainingParams = TC.getParams<SGDParameters>();
+  trainingParams->momentum = 0.9;
+  trainingParams->learningRate = 0.01;
 
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("learnSingleValueConcat");
@@ -575,7 +583,7 @@ using TCellGenerator = void (*)(PlaceholderBindings &, Function *,
                                 std::vector<NodeValue> &);
 
 void testRNNCell(TCellGenerator cell) {
-  TrainingConfig TC;
+  TrainingConfig TC(TrainingAlgorithm::StochasticGradientDescent);
 
   // This variable records the number of the next sample to be used for
   // training.
@@ -583,8 +591,10 @@ void testRNNCell(TCellGenerator cell) {
 
   PlaceholderBindings bindings;
   ExecutionEngine EE;
+
   // Learning a single input vector.
-  TC.learningRate = 0.05;
+  auto *trainingParams = TC.getParams<SGDParameters>();
+  trainingParams->learningRate = 0.05;
 
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("testRNNCell");
@@ -673,7 +683,7 @@ TEST_P(MLTest, trainGRU) { testRNNCell(buildGRU); };
 TEST_P(MLTest, trainLSTM) { testRNNCell(buildLSTM); };
 
 TEST_P(MLTest, trainSimpleLinearRegression) {
-  TrainingConfig TC;
+  TrainingConfig TC(TrainingAlgorithm::StochasticGradientDescent);
   PlaceholderBindings bindings;
 
   // Given 1-D vectors x and y, find real numbers m and b such that
@@ -684,8 +694,9 @@ TEST_P(MLTest, trainSimpleLinearRegression) {
   // training.
   size_t sampleCounter = 0;
 
-  TC.learningRate = 0.1;
-  TC.batchSize = numSamples;
+  auto *trainingParams = TC.getParams<SGDParameters>();
+  trainingParams->learningRate = 0.1;
+  trainingParams->batchSize = numSamples;
 
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction(
@@ -768,15 +779,16 @@ TEST_P(MLTest, classifyPlayerSport) {
   const size_t numFeatures = 2;
   const size_t numClasses = 2;
 
-  TrainingConfig TC;
+  TrainingConfig TC(TrainingAlgorithm::StochasticGradientDescent);
   PlaceholderBindings bindings;
 
   // This variable records the number of the next sample to be used for
   // training.
   size_t sampleCounter = 0;
 
-  TC.learningRate = 0.05;
-  TC.batchSize = numTrainPlayers;
+  auto *trainingParams = TC.getParams<SGDParameters>();
+  trainingParams->learningRate = 0.05;
+  trainingParams->batchSize = numTrainPlayers;
 
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("classifyPlayers");
@@ -831,7 +843,7 @@ TEST_P(MLTest, classifyPlayerSport) {
 }
 
 TEST_P(MLTest, learnSinus) {
-  TrainingConfig TC;
+  TrainingConfig TC(TrainingAlgorithm::StochasticGradientDescent);
   PlaceholderBindings bindings;
 
   // This variable records the number of the next sample to be used for
@@ -842,8 +854,9 @@ TEST_P(MLTest, learnSinus) {
   float epsilon = 0.1;
   unsigned numSamples = 50;
 
-  TC.learningRate = 0.2;
-  TC.batchSize = numSamples;
+  auto *trainingParams = TC.getParams<SGDParameters>();
+  trainingParams->learningRate = 0.2;
+  trainingParams->batchSize = numSamples;
 
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("Gradient descent solution for sin(x)");
@@ -922,10 +935,11 @@ TEST_P(MLTest, nonLinearClassifier) {
   size_t sampleCounter = 0;
 
   PlaceholderBindings bindings;
-  TrainingConfig TC;
-  TC.learningRate = 0.01;
-  TC.momentum = 0.9;
-  TC.batchSize = batchSize;
+  TrainingConfig TC(TrainingAlgorithm::StochasticGradientDescent);
+  auto *trainingParams = TC.getParams<SGDParameters>();
+  trainingParams->learningRate = 0.01;
+  trainingParams->momentum = 0.9;
+  trainingParams->batchSize = batchSize;
 
   auto &mod = EE_.getModule();
   Function *F = mod.createFunction("nonLinearClassifier");
@@ -1019,10 +1033,11 @@ TEST_P(InterpreterAndCPU, convNetForImageRecognition) {
   // training.
   size_t sampleCounter = 0;
 
-  TrainingConfig TC;
-  TC.learningRate = 0.01;
-  TC.batchSize = batchSize;
-  TC.momentum = 0.9;
+  TrainingConfig TC(TrainingAlgorithm::StochasticGradientDescent);
+  auto *trainingParams = TC.getParams<SGDParameters>();
+  trainingParams->learningRate = 0.01;
+  trainingParams->batchSize = batchSize;
+  trainingParams->momentum = 0.9;
 
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("convNetForImageRecognition");
@@ -1130,10 +1145,11 @@ TEST_P(InterpreterAndCPU, testFindPixelRegression) {
   // training.
   size_t sampleCounter = 0;
 
-  TrainingConfig TC;
-  TC.learningRate = 0.01;
-  TC.batchSize = batchSize;
-  TC.momentum = 0.9;
+  TrainingConfig TC(TrainingAlgorithm::StochasticGradientDescent);
+  auto *trainingParams = TC.getParams<SGDParameters>();
+  trainingParams->learningRate = 0.01;
+  trainingParams->batchSize = batchSize;
+  trainingParams->momentum = 0.9;
 
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -1308,9 +1324,10 @@ static void generateMatrixRotationRecognitionData(Tensor &matricesA,
 }
 
 TEST_P(MLTest, matrixRotationRecognition) {
-  TrainingConfig TC;
-  TC.learningRate = 0.15;
-  TC.batchSize = 17;
+  TrainingConfig TC(TrainingAlgorithm::StochasticGradientDescent);
+  auto *trainingParams = TC.getParams<SGDParameters>();
+  trainingParams->learningRate = 0.15;
+  trainingParams->batchSize = 17;
   PlaceholderBindings bindings;
 
   // This variable records the number of the next sample to be used for
@@ -1321,11 +1338,11 @@ TEST_P(MLTest, matrixRotationRecognition) {
   PseudoRNG &PRNG = mod.getPRNG();
   Function *F = mod.createFunction("MatrixRotationRecognition");
   Placeholder *varMatricesA = mod.createPlaceholder(
-      ElemKind::FloatTy, {TC.batchSize, 3, 3}, "matrixA", false);
+      ElemKind::FloatTy, {trainingParams->batchSize, 3, 3}, "matrixA", false);
   Placeholder *varMatricesB = mod.createPlaceholder(
-      ElemKind::FloatTy, {TC.batchSize, 3, 3}, "matrixB", false);
+      ElemKind::FloatTy, {trainingParams->batchSize, 3, 3}, "matrixB", false);
   Placeholder *varExpected = mod.createPlaceholder(
-      ElemKind::Int64ITy, {TC.batchSize, 1}, "expected", false);
+      ElemKind::Int64ITy, {trainingParams->batchSize, 1}, "expected", false);
 
   // Simply concatenating the matrices first would probability be as effective
   // but we want to build something more complex than a straight chain of
@@ -1369,7 +1386,7 @@ TEST_P(MLTest, matrixRotationRecognition) {
   // At this point we should have overfitted the data.
   // Take a random batch and check that the values match what we expect.
   auto RHtrain = res->getHandle<>();
-  auto batchSize = TC.batchSize;
+  auto batchSize = trainingParams->batchSize;
   unsigned numBatches = numSamples / batchSize;
   unsigned batchStartIdx = PRNG.nextRandInt(0, numBatches - 1) * batchSize;
 

--- a/tests/unittests/MLTest.cpp
+++ b/tests/unittests/MLTest.cpp
@@ -1499,6 +1499,79 @@ TEST_P(MLTest, matrixRotationRecognition) {
   EXPECT_LE(errors, 1);
 }
 
+/// Simple test case that learns the embedding table for a
+/// SparseLengthsWeightedSum operator.
+TEST_P(InterpreterAndCPU, learnSparseLengthsWeightedSum) {
+  TrainingConfig TC(TrainingAlgorithm::Adagrad);
+  PlaceholderBindings bindings;
+
+  auto *trainingParams = TC.getParams<AdagradParameters>();
+  trainingParams->learningRate = 0.3;
+
+  Module &mod = EE_.getModule();
+  PseudoRNG &PRNG = mod.getPRNG();
+
+  // Create a model consisting of one SparseLengthsWeightedSum operator followed
+  // by a Regression node to get some non-zero gradients.
+  Function *F = mod.createFunction("SparseLengthsWeightedSum");
+  Placeholder *dataP =
+      mod.createPlaceholder(ElemKind::FloatTy, {10}, "dataP", true);
+  Placeholder *indicesP =
+      mod.createPlaceholder(ElemKind::Int64ITy, {10}, "indicesP", false);
+  Placeholder *weightsP =
+      mod.createPlaceholder(ElemKind::FloatTy, {10}, "weightsP", false);
+  Placeholder *lengthsP =
+      mod.createPlaceholder(ElemKind::Int32ITy, {5}, "lengthsP", false);
+  Placeholder *expectedP =
+      mod.createPlaceholder(ElemKind::FloatTy, {5}, "expectedP", false);
+
+  auto *SLWS = F->createSparseLengthsWeightedSum("SLWS", dataP, weightsP,
+                                                 indicesP, lengthsP);
+  auto *reg = F->createRegression("reg", SLWS, expectedP);
+  auto *result = F->createSave("save", reg);
+
+  // Allocate and randomizly initialize embeddings.
+  auto DH = bindings.allocate(dataP)->getHandle();
+  DH.randomize(-5.0, 5.0, PRNG);
+
+  // Allocate and set indices such that input embeddings are reversed.
+  bindings.allocate(indicesP)->getHandle<int64_t>() = {9, 8, 7, 6, 5,
+                                                       4, 3, 2, 1, 0};
+  // Allocate and set weights.
+  bindings.allocate(weightsP)->getHandle() = {0.75, 0.25, 0.75, 0.25, 0.75,
+                                              0.25, 0.75, 0.25, 0.75, 0.25};
+
+  // Allocate and set lengths.
+  bindings.allocate(lengthsP)->getHandle<int32_t>() = {2, 2, 2, 2, 2};
+
+  // Allocate and set expected outputs. The embedding table will be adjusted
+  // during training so that the final result is this.
+  auto EH = bindings.allocate(expectedP)->getHandle();
+  EH = {1, 2, 3, 4, 5};
+
+  // Allocate and store a handle to the result for testing later.
+  auto RH = bindings.allocate(result->getPlaceholder())->getHandle();
+
+  // Train the network.
+  Function *trainingGradientFunction = glow::differentiate(F, TC, bindings);
+  EE_.compile(CompilationMode::Train, trainingGradientFunction);
+
+  const size_t numIterations = 1000;
+
+  for (size_t i = 0; i < numIterations; ++i) {
+    EE_.run(bindings);
+  }
+
+  // Switch to inference mode and run the network.
+  EE_.compile(CompilationMode::Infer, F);
+  EE_.run(bindings);
+
+  // Make sure that the network output matches expectations after training.
+  for (size_t j = 0; j < EH.size(); ++j) {
+    EXPECT_NEAR(RH.raw(j), EH.raw(j), 0.02);
+  }
+}
+
 INSTANTIATE_TEST_CASE_P(Interpreter, MLTest,
                         ::testing::Values(BackendKind::Interpreter));
 #ifdef GLOW_WITH_CPU

--- a/tests/unittests/OperatorGradTest.cpp
+++ b/tests/unittests/OperatorGradTest.cpp
@@ -49,7 +49,8 @@ protected:
     // table instead of updating them.
     VariableGradientsList varGrads;
     TrainingConfig TC;
-    Function *recordNet = glow::differentiate(F_, TC, "record", &varGrads);
+    Function *recordNet =
+        glow::differentiate(F_, TC, bindings_, "record", &varGrads);
     allocateGrads(varGrads);
     EE_.compile(CompilationMode::Train, recordNet);
 

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -2387,7 +2387,7 @@ TEST_P(OperatorTest, FCGradientCheck) {
   // Create net representing A*X+Y=B, where X and Y are trainable, while
   // A and B are fixed. Record gradients for X and Y after 3 steps and compare
   // with reference values.
-  TrainingConfig TC;
+  TrainingConfig TC(TrainingAlgorithm::StochasticGradientDescent);
 
   // This variable records the number of the next sample to be used for
   // training.

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -2414,7 +2414,7 @@ TEST_P(OperatorTest, FCGradientCheck) {
   initA.getHandle() = {4.2f, 9.875f};
   initB.getHandle() = {-13.1f, 3.14f};
 
-  Function *DF = glow::differentiate(F_, TC, "d_main");
+  Function *DF = glow::differentiate(F_, TC, bindings_, "d_main");
   EE_.compile(CompilationMode::Train, DF);
   runBatch(EE_, bindings_, 3, sampleCounter, {A, B}, {&initA, &initB});
 

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -236,7 +236,8 @@ int main(int argc, char **argv) {
                   {"Indices", "ElemKind::Int64ITy"})
       .autoVerify(VerifyKind::SameElementType,
                   {"Lengths", "ElemKind::Int32ITy"})
-      .autoVerify(VerifyKind::SameShape, {"Weights", "Indices"});
+      .autoVerify(VerifyKind::SameShape, {"Weights", "Indices"})
+      .addGradientInstr({"Weights", "Indices", "Lengths"}, {"Dest", "Data"});
 
   BB.newInstr("RowwiseQuantizedSparseLengthsWeightedSum")
       .addOperand("Dest", OperandKind::Out)

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -599,6 +599,19 @@ int main(int argc, char **argv) {
                     "Produces the updated weight that needs to be used "
                     "instead of Weight for the next iteration.");
 
+  BB.newNode("Adagrad")
+      .addInput("Gradient")
+      .addInput("Weight")
+      .addInput("Momentum")
+      .addMember(MemberType::Float, "LearningRate")
+      .addMember(MemberType::Float, "Epsilon")
+      .addResult("Weight.getType()", "UpdatedWeight")
+      .addResult("Momentum.getType()", "UpdatedMomentum")
+      .setDocstring(
+          "Adagrad node used during training. Produces the updated "
+          "weight and momentum that need to be used instead of Weight "
+          "and Momentum for the next iteration.");
+
   //===--------------------------------------------------------------------===//
   //             Nodes used for debugging/profiling/printing
   //===--------------------------------------------------------------------===//

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -346,6 +346,7 @@ int main(int argc, char **argv) {
       .addInput("Indices")
       .addInput("Lengths")
       .addResultFromCtorArg()
+      .addGradient()
       .setDocstring("Gathers slices of the outer-most dimension of Data "
                     "indexed by Indices vector, and then accumulates them into "
                     "len(Lengths) entries: first Lengths[0] slices are "


### PR DESCRIPTION
**Description**
This commit adds support for training the `SparseLengthsWeightedSum`
operator. The gradient for this node is computed by initializing the
`data` gradient to be zero, and then accumulating into `dataGradient[index]`
the gradient of the result slice that `data[index]` was added to during
the `SparseLengthsWeightedSum` operation multiplied by `weight[index]`
(the same weight that `data[index]` was multiplied by during the
`SparseLengthsWeightedSum` operator).
    
**Testing**
This commit adds a unit test to `MLTest` that trains the data input of a
`SparseLengthsWeightedSum` node so that the operation outputs a
specified `Tensor`. The indices, lengths, weights are fixed.