### PR TITLE
Skip unknown symbols when loading Placeholders.

### DIFF
--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -1488,8 +1488,13 @@ void OpenCLFunction::loadPlaceholders(PlaceholderBindings *bindings) {
     clFinish(commands_);
   }
 
+  auto &symbolTable = runtimeBundle_.getSymbolTable();
   for (auto PH : bindings->pairs()) {
-    auto symbolInfo = runtimeBundle_.getSymbolInfo(PH.first);
+    auto it = symbolTable.find(PH.first->getName());
+    if (it == symbolTable.end()) {
+      continue;
+    }
+    auto symbolInfo = it->second;
     auto addr = symbolInfo.offset;
     auto numBytes = symbolInfo.size;
     // Issue a non-blocking command to copy the buffer to the device.
@@ -1510,8 +1515,13 @@ void OpenCLFunction::loadPlaceholders(PlaceholderBindings *bindings) {
 }
 
 void OpenCLFunction::updatePlaceholders(PlaceholderBindings *bindings) {
+  auto &symbolTable = runtimeBundle_.getSymbolTable();
   for (auto PH : bindings->pairs()) {
-    auto symbolInfo = runtimeBundle_.getSymbolInfo(PH.first);
+    auto it = symbolTable.find(PH.first->getName());
+    if (it == symbolTable.end()) {
+      continue;
+    }
+    auto symbolInfo = it->second;
     auto addr = symbolInfo.offset;
     auto numBytes = symbolInfo.size;
     // Issue a non-blocking command to copy the buffer to the device.

--- a/lib/LLVMIRCodeGen/LLVMCompiledFunction.cpp
+++ b/lib/LLVMIRCodeGen/LLVMCompiledFunction.cpp
@@ -35,9 +35,14 @@ void LLVMCompiledFunction::collectConstants(Module *module) {
 void LLVMCompiledFunction::loadPlaceholders(
     PlaceholderBindings *bindings, uint8_t *baseMutableWeightVarsAddress) {
   // Copy Placeholders into allocated memory.
+  auto &symbolTable = runtimeBundle_.getSymbolTable();
   for (auto PH : bindings->pairs()) {
+    auto it = symbolTable.find(PH.first->getName());
+    if (it == symbolTable.end()) {
+      continue;
+    }
+    auto symbolInfo = it->second;
     auto payload = PH.second->getUnsafePtr();
-    auto symbolInfo = runtimeBundle_.getSymbolInfo(PH.first);
     auto addr = symbolInfo.offset;
     auto numBytes = symbolInfo.size;
     // copy PH to allocated memory.
@@ -48,8 +53,13 @@ void LLVMCompiledFunction::loadPlaceholders(
 void LLVMCompiledFunction::updatePlaceholders(
     PlaceholderBindings *bindings, uint8_t *baseMutableWeightVarsAddress) {
   // Copy placeholders from device back into bindings.
+  auto &symbolTable = runtimeBundle_.getSymbolTable();
   for (auto PH : bindings->pairs()) {
-    auto symbolInfo = runtimeBundle_.getSymbolInfo(PH.first);
+    auto it = symbolTable.find(PH.first->getName());
+    if (it == symbolTable.end()) {
+      continue;
+    }
+    auto symbolInfo = it->second;
     auto payload = baseMutableWeightVarsAddress + symbolInfo.offset;
     auto numBytes = symbolInfo.size;
     auto addr = PH.second->getUnsafePtr();


### PR DESCRIPTION
*Description*: The way we load placeholders right now assumes that all CompiledFunctions know about all symbols in the module (at least when we use `PlaceholderBindings.allocate(module.getPlaceholders())` which we do in a few different places). When loading placeholders we should just skip any that don't have an entry in the symbol table (since they won't be used anyway).
*Testing*: unit tests + the new unit test, which fails on all backends without this change.
*Documentation*: This won't break anything in any other backends, but they probably want to be doing something like this as well.
