### PR TITLE
getSymbolInfo now returns a const reference

### DIFF
--- a/include/glow/Backends/BackendUtils.h
+++ b/include/glow/Backends/BackendUtils.h
@@ -65,7 +65,7 @@ public:
   /// Helper function, gets offset of \p v.
   size_t getValueOffset(const Named *v) const;
   /// Helper function, gets symbol info for \p v.
-  RuntimeSymbolInfo getSymbolInfo(const Named *v) const;
+  const RuntimeSymbolInfo &getSymbolInfo(const Named *v) const;
   /// Get a const reference to the symbol table.
   const SymbolTableTy &getSymbolTable() const { return symbolTable_; }
   /// At compile time condense constants to a single block of memory.

--- a/lib/Backends/BackendUtils.cpp
+++ b/lib/Backends/BackendUtils.cpp
@@ -73,7 +73,7 @@ size_t glow::runtime::RuntimeBundle::getValueOffset(const Named *v) const {
   return it->second.offset;
 }
 
-runtime::RuntimeSymbolInfo
+const runtime::RuntimeSymbolInfo &
 runtime::RuntimeBundle::getSymbolInfo(const Named *v) const {
   auto it = symbolTable_.find(std::string(v->getName()));
   assert(it != symbolTable_.end() && "Symbol not found.");


### PR DESCRIPTION
*Description*: changed RuntimeBundle's getSymbolInfo to now return a const reference. 
*Testing*: ninja test passes
*Documentation*: NA