### PR TITLE
[OperatorTest] More missing tests for Gather/GatherRanges

### DIFF
--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -1311,23 +1311,19 @@ void gatherRangesTest(glow::PlaceholderBindings &bindings_, glow::Module &mod_,
   auto *output = F_->createSave("output", R->getOutput());
   auto *lengths = F_->createSave("lengths", R->getLengths());
 
-  bindings_.allocate(output->getPlaceholder());
-  bindings_.allocate(lengths->getPlaceholder());
+  Tensor *outputT = bindings_.allocate(output->getPlaceholder());
+  Tensor *lengthsT = bindings_.allocate(lengths->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_);
   EE_.run(bindings_);
 
-  auto OH = bindings_.get(output->getPlaceholder())->getHandle<DataType>();
-  auto LH = bindings_.get(lengths->getPlaceholder())->getHandle<IndexType>();
+  Tensor expectedOutputT(DTy, {5});
+  expectedOutputT.getHandle<DataType>() = {1, 3, 4, 5, 6};
+  EXPECT_TRUE(outputT->isEqual(expectedOutputT));
 
-  EXPECT_EQ(OH.at({0}), static_cast<DataType>(1));
-  EXPECT_EQ(OH.at({1}), static_cast<DataType>(3));
-  EXPECT_EQ(OH.at({2}), static_cast<DataType>(4));
-  EXPECT_EQ(OH.at({3}), static_cast<DataType>(5));
-  EXPECT_EQ(OH.at({4}), static_cast<DataType>(6));
-
-  EXPECT_EQ(LH.at({0}), static_cast<IndexType>(3));
-  EXPECT_EQ(LH.at({1}), static_cast<IndexType>(2));
+  Tensor expectedLengthsT(ITy, {2});
+  expectedLengthsT.getHandle<IndexType>() = {3, 2};
+  EXPECT_TRUE(lengthsT->isEqual(expectedLengthsT));
 }
 
 /// Test GatherRanges with Int64 data and Int32 indices.

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -1174,25 +1174,12 @@ static void gatherFloatInputTest(glow::PlaceholderBindings &bindings,
   EE.compile(CompilationMode::Infer, F);
   EE.run(bindings);
 
-  auto H = bindings.get(result->getPlaceholder())->getHandle();
+  Tensor *resultT = bindings.get(result->getPlaceholder());
+  Tensor expectedT(ElemKind::FloatTy, {2, 4, 2});
+  expectedT.getHandle<float>() = {1.0, 1.2, 2.3, 3.4, 1.0, 1.2, 2.3, 3.4,
+                                  2.3, 3.4, 4.5, 5.7, 4.5, 5.7, 1.0, 1.2};
 
-  EXPECT_FLOAT_EQ(H.at({0, 0, 0}), 1.0);
-  EXPECT_FLOAT_EQ(H.at({0, 0, 1}), 1.2);
-  EXPECT_FLOAT_EQ(H.at({0, 1, 0}), 2.3);
-  EXPECT_FLOAT_EQ(H.at({0, 1, 1}), 3.4);
-  EXPECT_FLOAT_EQ(H.at({0, 2, 0}), 1.0);
-  EXPECT_FLOAT_EQ(H.at({0, 2, 1}), 1.2);
-  EXPECT_FLOAT_EQ(H.at({0, 3, 0}), 2.3);
-  EXPECT_FLOAT_EQ(H.at({0, 3, 1}), 3.4);
-
-  EXPECT_FLOAT_EQ(H.at({1, 0, 0}), 2.3);
-  EXPECT_FLOAT_EQ(H.at({1, 0, 1}), 3.4);
-  EXPECT_FLOAT_EQ(H.at({1, 1, 0}), 4.5);
-  EXPECT_FLOAT_EQ(H.at({1, 1, 1}), 5.7);
-  EXPECT_FLOAT_EQ(H.at({1, 2, 0}), 4.5);
-  EXPECT_FLOAT_EQ(H.at({1, 2, 1}), 5.7);
-  EXPECT_FLOAT_EQ(H.at({1, 3, 0}), 1.0);
-  EXPECT_FLOAT_EQ(H.at({1, 3, 1}), 1.2);
+  EXPECT_TRUE(resultT->isEqual(expectedT));
 }
 
 /// Test that Gather works with Float data and Int32 indices.
@@ -1256,25 +1243,12 @@ static void gatherInt8InputTest(glow::PlaceholderBindings &bindings,
   EE.compile(CompilationMode::Infer, F);
   EE.run(bindings);
 
-  auto H = bindings.get(result->getPlaceholder())->getHandle<int8_t>();
+  Tensor *resultT = bindings.get(result->getPlaceholder());
+  Tensor expectedT(ElemKind::Int8QTy, {2, 4, 2}, 1.0, 0);
+  expectedT.getHandle<int8_t>() = {1, 2, 3, 4, 1, 2, 3, 4,
+                                   3, 4, 5, 6, 5, 6, 1, 2};
 
-  EXPECT_EQ(H.at({0, 0, 0}), 1);
-  EXPECT_EQ(H.at({0, 0, 1}), 2);
-  EXPECT_EQ(H.at({0, 1, 0}), 3);
-  EXPECT_EQ(H.at({0, 1, 1}), 4);
-  EXPECT_EQ(H.at({0, 2, 0}), 1);
-  EXPECT_EQ(H.at({0, 2, 1}), 2);
-  EXPECT_EQ(H.at({0, 3, 0}), 3);
-  EXPECT_EQ(H.at({0, 3, 1}), 4);
-
-  EXPECT_EQ(H.at({1, 0, 0}), 3);
-  EXPECT_EQ(H.at({1, 0, 1}), 4);
-  EXPECT_EQ(H.at({1, 1, 0}), 5);
-  EXPECT_EQ(H.at({1, 1, 1}), 6);
-  EXPECT_EQ(H.at({1, 2, 0}), 5);
-  EXPECT_EQ(H.at({1, 2, 1}), 6);
-  EXPECT_EQ(H.at({1, 3, 0}), 1);
-  EXPECT_EQ(H.at({1, 3, 1}), 2);
+  EXPECT_TRUE(resultT->isEqual(expectedT));
 }
 
 /// Test that Gather works with Int8 data and Int32 indices.

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -1128,9 +1128,9 @@ TEST_P(OperatorTest, QuantizedTopK) {
 
 /// Helper for testing Gather with different \p ITy / \p IndexType.
 template <typename IndexType>
-static void gatherFloatInputTest(glow::PlaceholderBindings &bindings_,
-                                 glow::Module &mod_, glow::Function *F_,
-                                 glow::ExecutionEngine &EE_, ElemKind ITy) {
+static void gatherFloatInputTest(glow::PlaceholderBindings &bindings,
+                                 glow::Module &mod, glow::Function *F,
+                                 glow::ExecutionEngine &EE, ElemKind ITy) {
   /*
     DATA  = [
         [1.0, 1.2],
@@ -1156,25 +1156,25 @@ static void gatherFloatInputTest(glow::PlaceholderBindings &bindings_,
         ],
     ]
   */
-  auto *data = mod_.createPlaceholder(ElemKind::FloatTy, {3, 2}, "data", false);
-  auto *indices = mod_.createPlaceholder(ITy, {2, 4}, "indices", false);
+  auto *data = mod.createPlaceholder(ElemKind::FloatTy, {3, 2}, "data", false);
+  auto *indices = mod.createPlaceholder(ITy, {2, 4}, "indices", false);
 
-  bindings_.allocate(data)->getHandle() = {
+  bindings.allocate(data)->getHandle() = {
       1.0f, 1.2f, 2.3f, 3.4f, 4.5f, 5.7f,
   };
-  bindings_.allocate(indices)->getHandle<IndexType>() = {
+  bindings.allocate(indices)->getHandle<IndexType>() = {
       0, 1, 0, 1, 1, 2, 2, 0,
   };
 
-  auto *R = F_->createGather("gather", data, indices);
+  auto *R = F->createGather("gather", data, indices);
 
-  auto *result = F_->createSave("save", R);
-  bindings_.allocate(result->getPlaceholder());
+  auto *result = F->createSave("save", R);
+  bindings.allocate(result->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_);
-  EE_.run(bindings_);
+  EE.compile(CompilationMode::Infer, F);
+  EE.run(bindings);
 
-  auto H = bindings_.get(result->getPlaceholder())->getHandle();
+  auto H = bindings.get(result->getPlaceholder())->getHandle();
 
   EXPECT_FLOAT_EQ(H.at({0, 0, 0}), 1.0);
   EXPECT_FLOAT_EQ(H.at({0, 0, 1}), 1.2);
@@ -1209,9 +1209,9 @@ TEST_P(OperatorTest, GatherDataFloatIdxInt64) {
 
 /// Helper for testing Gather with different \p ITy / \p IndexType.
 template <typename IndexType>
-static void gatherInt8InputTest(glow::PlaceholderBindings &bindings_,
-                                glow::Module &mod_, glow::Function *F_,
-                                glow::ExecutionEngine &EE_, ElemKind ITy) {
+static void gatherInt8InputTest(glow::PlaceholderBindings &bindings,
+                                glow::Module &mod, glow::Function *F,
+                                glow::ExecutionEngine &EE, ElemKind ITy) {
   /*
     DATA  = [
         [1, 2],
@@ -1238,25 +1238,25 @@ static void gatherInt8InputTest(glow::PlaceholderBindings &bindings_,
     ]
   */
   auto *data =
-      mod_.createPlaceholder(ElemKind::Int8QTy, {3, 2}, 1.0, 0, "data", false);
-  auto *indices = mod_.createPlaceholder(ITy, {2, 4}, "indices", false);
+      mod.createPlaceholder(ElemKind::Int8QTy, {3, 2}, 1.0, 0, "data", false);
+  auto *indices = mod.createPlaceholder(ITy, {2, 4}, "indices", false);
 
-  bindings_.allocate(data)->getHandle<int8_t>() = {
+  bindings.allocate(data)->getHandle<int8_t>() = {
       1, 2, 3, 4, 5, 6,
   };
-  bindings_.allocate(indices)->getHandle<IndexType>() = {
+  bindings.allocate(indices)->getHandle<IndexType>() = {
       0, 1, 0, 1, 1, 2, 2, 0,
   };
 
-  auto *R = F_->createGather("gather", data, indices);
+  auto *R = F->createGather("gather", data, indices);
 
-  auto *result = F_->createSave("save", R);
-  bindings_.allocate(result->getPlaceholder());
+  auto *result = F->createSave("save", R);
+  bindings.allocate(result->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_);
-  EE_.run(bindings_);
+  EE.compile(CompilationMode::Infer, F);
+  EE.run(bindings);
 
-  auto H = bindings_.get(result->getPlaceholder())->getHandle<int8_t>();
+  auto H = bindings.get(result->getPlaceholder())->getHandle<int8_t>();
 
   EXPECT_EQ(H.at({0, 0, 0}), 1);
   EXPECT_EQ(H.at({0, 0, 1}), 2);


### PR DESCRIPTION
Added a few more tests that we didn't have for `Gather`/`GatherRanges`:

- `Gather` now has Int8 and Float16 data versions

- `GatherRanges` now has Float and Float16 data tests.
