### PR TITLE
[Runtime] Use uint64_t for memory size type

### DIFF
--- a/include/glow/Partitioner/Partitioner.h
+++ b/include/glow/Partitioner/Partitioner.h
@@ -24,7 +24,7 @@ namespace glow {
 
 using namespace runtime;
 
-using MemUsageMapTy = std::unordered_map<Node *, size_t>;
+using MemUsageMapTy = std::unordered_map<Node *, uint64_t>;
 using ComputeTimeMapTy = std::unordered_map<Node *, float>;
 using NodesSetTy = std::set<Node *>;
 using PartitionCostMapTy = llvm::DenseMap<Function *, GraphMemInfo>;
@@ -93,7 +93,7 @@ class Partitioner {
   DAGListTy partitions_;
 
   /// Total memory (bytes) requested by one module.
-  size_t memSize_;
+  uint64_t memSize_;
 
   /// The map of each operator and the corresponding memory size.
   MemUsageMapTy memUsage_;
@@ -103,7 +103,7 @@ class Partitioner {
 
   /// Get the representative function (the one with the largest input) and
   /// update the memSize.
-  static Function *selectRepFunc(Module *parent, size_t &memSize);
+  static Function *selectRepFunc(Module *parent, uint64_t &memSize);
 
   /// Get the minimal memory requirement for each op in the representive
   /// function.
@@ -118,14 +118,15 @@ class Partitioner {
   /// and partition2.
   void partitionsCombine(NodeToFunctionMap &partitions,
                          FunctionToNodesMapTy &nodesSet,
-                         size_t availableMemory);
+                         uint64_t availableMemory);
 
   /// After getting the intial partitions, ajust the partitions to miminize
   /// communication and computation cost.
-  void partitionsAdjust(NodeToFunctionMap &partitions, size_t availableMemory);
+  void partitionsAdjust(NodeToFunctionMap &partitions,
+                        uint64_t availableMemory);
 
   /// Assign nodes to partitions and return the mapping.
-  NodeToFunctionMap selectPartitions(Function *F, size_t availableMemory);
+  NodeToFunctionMap selectPartitions(Function *F, uint64_t availableMemory);
 
   /// Adjust a logicalDevice ID to each DAGNode. It is possible that two
   /// sub-functions need to be assigned into 1 device due to the memory

--- a/include/glow/Partitioner/PartitionerUtils.h
+++ b/include/glow/Partitioner/PartitionerUtils.h
@@ -25,12 +25,12 @@ namespace glow {
 struct GraphMemInfo {
   // The memory usage of all input nodes (whose predecessors are not included in
   // this subgraph) of this subgraph.
-  size_t inMemSize;
+  uint64_t inMemSize;
   // The memory usage of all output nodes (whose successors are not included in
   // this subgraph) of this subgraph.
-  size_t outMemSize;
+  uint64_t outMemSize;
   // The memory usage of all constants used in this subgraph.
-  size_t constMemSize;
+  uint64_t constMemSize;
 
   GraphMemInfo() : inMemSize(0), outMemSize(0), constMemSize(0){};
 };

--- a/include/glow/Runtime/RuntimeTypes.h
+++ b/include/glow/Runtime/RuntimeTypes.h
@@ -48,9 +48,9 @@ using ResultCBTy = std::function<void(runtime::RunIdentifierTy, llvm::Error,
 /// Used to communicate memory constraints and later costs to the Partitioner.
 struct DeviceInfo {
   /// Available memory on device in bytes.
-  size_t availableMemory;
+  uint64_t availableMemory;
   /// Available SRAM capacity in bytes.
-  size_t sramCapacity;
+  uint64_t sramCapacity;
   /// Peak compute on device in ops/second. Assumes all ops are in int8.
   /// TODO: distinguish between data types with different peak flops.
   float peakCompute;

--- a/lib/Partitioner/PartitionerUtils.cpp
+++ b/lib/Partitioner/PartitionerUtils.cpp
@@ -155,7 +155,7 @@ GraphMemInfo getGraphMemInfo(const std::set<Node *> &nodes) {
       nSet.insert(node);
       Storage *in = llvm::dyn_cast<Storage>(node);
       if (in) {
-        size_t size = in->getType()->getSizeInBytes();
+        uint64_t size = in->getType()->getSizeInBytes();
         if (node->getKind() == Kinded::Kind::ConstantKind) {
           // Constant.
           ret.constMemSize += size;


### PR DESCRIPTION
*Description*:
Use uint64_t to replace size_t everywhere for memory size type since it's guaranteed to be a 64 bit int. size_t will in practice always be 64 bit but it could be different if we run on a different architecture.

*Testing*:
ninja check, resnet-runtime

*Documentation*:
[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
