### PR TITLE
[unittests] OperationGradTest: add a unittest for conv operator.

### DIFF
--- a/tests/unittests/OperatorGradTest.cpp
+++ b/tests/unittests/OperatorGradTest.cpp
@@ -141,7 +141,7 @@ TEST_P(OperatorGradTest, conv) {
   // dO_1_1   | 0 | 0 | 0 | 0 |T00|T01| 0 |T10|T11
   //
   // Based on the table above, dF/dX can be easily computed by
-  // dF/dX_i_j = sum(dO_k_l/dX_i_j) for all k,l.
+  // dF/dX_i_j = sum(dF/dO_k_l * dO_k_l/dX_i_j) for all k,l.
 
   Tensor expected(ElemKind::FloatTy, {1, 3, 3, 1});
   expected.getHandle() = {20 * 0, // row 0.

--- a/tests/unittests/OperatorGradTest.cpp
+++ b/tests/unittests/OperatorGradTest.cpp
@@ -150,7 +150,7 @@ TEST_P(OperatorGradTest, conv) {
                           20 * 2 + 38 * 0, // row 1.
                           20 * 3 + 26 * 2 + 38 * 1 + 44 * 0,
                           26 * 3 + 44 * 1,
-                          38 * 2,  // row 2.
+                          38 * 2, // row 2.
                           38 * 3 + 44 * 2,
                           44 * 3};
   EXPECT_TRUE(expected.isEqual(*getGradTensor(varGrads, X)));


### PR DESCRIPTION
*Description*:

This PR adds a unittest for conv to OperationGradTest.

*Testing*:

Ran OperationGradTest

*Documentation*:

This is a very basic test for "conv" operator and more tests will follow to enhance its coverage.

Partially fixing #2513

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
