### PR TITLE
Add support for Int32ITy BatchOneHot, and add missing unit tests for all types

### DIFF
--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -239,8 +239,8 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
 
   case Kinded::Kind::BatchOneHotNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
-               {ElemKind::FloatTy, ElemKind::Float16Ty, ElemKind::Int32ITy,
-                ElemKind::Int64ITy},
+               {ElemKind::FloatTy, ElemKind::Float16Ty, ElemKind::Int8QTy,
+                ElemKind::Int32ITy, ElemKind::Int64ITy},
                {BatchOneHotNode::LengthsIdx}) &&
            (NI.getInElemTy(BatchOneHotNode::LengthsIdx) == ElemKind::Int32ITy);
 

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -1268,6 +1268,9 @@ void BoundInterpreterFunction::fwdBatchOneHotInst(
   case ElemKind::Int64ITy:
     fwdBatchOneHotImpl<int64_t>(I);
     break;
+  case ElemKind::Int32ITy:
+    fwdBatchOneHotImpl<int32_t>(I);
+    break;
   case ElemKind::Int8QTy:
     fwdBatchOneHotImpl<int8_t>(I);
     break;


### PR DESCRIPTION
*Description*: Add support for BatchOneHot for `Int32ITy`, and then add tests for all the types we currently support.

*Testing*: Added unit tests for all types.