### PR TITLE
Make createCall a method in LLVMIRGen

### DIFF
--- a/include/glow/LLVMIRCodeGen/LLVMBackend.h
+++ b/include/glow/LLVMIRCodeGen/LLVMBackend.h
@@ -30,16 +30,6 @@ struct AllocationsInfo;
 class PlaceholderBindings;
 class LLVMIRGen;
 
-/// Helper function to create a new CallInst, with the specified \p builder, \p
-/// callee, and \p args. Verifies that the function signature is correct,
-/// and then creates and \returns the CallInst.
-/// \param builder the IR builder to be used for creating the Call instruction.
-/// \param callee the function to be called.
-/// \param args arguments to be passed in this call.
-/// \returns generated Call instruction.
-llvm::CallInst *createCall(llvm::IRBuilder<> &builder, llvm::Function *callee,
-                           llvm::ArrayRef<llvm::Value *> args);
-
 class LLVMBackend : public BackendUsingGlowIR {
 public:
   LLVMBackend() = default;

--- a/include/glow/LLVMIRCodeGen/LLVMIRGen.h
+++ b/include/glow/LLVMIRCodeGen/LLVMIRGen.h
@@ -256,6 +256,15 @@ public:
                                       const glow::Instruction *I);
   /// Emit LLVM-IR for the whole IRFunction.
   virtual void generateLLVMIRForModule(llvm::IRBuilder<> &builder);
+  /// Helper function to create a new CallInst, with the specified \p builder,
+  /// \p callee, and \p args. Verifies that the function signature is correct,
+  /// and then creates and \returns the CallInst.
+  /// \param builder the IR builder to be used for creating the Call
+  /// instruction. \param callee the function to be called. \param args
+  /// arguments to be passed in this call. \returns generated Call instruction
+  virtual llvm::CallInst *createCall(llvm::IRBuilder<> &builder,
+                                     llvm::Function *callee,
+                                     llvm::ArrayRef<llvm::Value *> args);
   /// \returns a libjit API function by name.
   llvm::Function *getFunction(const std::string &name);
   /// \returns a libjit API function by name and tensor element type.

--- a/lib/LLVMIRCodeGen/BundleSaver.cpp
+++ b/lib/LLVMIRCodeGen/BundleSaver.cpp
@@ -208,7 +208,7 @@ void BundleSaver::emitBundleEntryFunction() {
   // use of it.
   auto *entryF = irgen_->getModule().getFunction("main");
   entryF->setLinkage(llvm::Function::InternalLinkage);
-  createCall(builder, entryF, initFunctionCallArgs);
+  irgen_->createCall(builder, entryF, initFunctionCallArgs);
   // Terminate the function.
   builder.CreateRetVoid();
   // Create the debug info for the bundle entry point function.

--- a/lib/LLVMIRCodeGen/FunctionSpecializer.cpp
+++ b/lib/LLVMIRCodeGen/FunctionSpecializer.cpp
@@ -262,8 +262,8 @@ class FunctionSpecializer {
 
 public:
   FunctionSpecializer(llvm::Function *entryF,
-                      llvm::DenseSet<llvm::Value *> &dontSpec)
-      : entryF_(entryF), dontSpecializeArgsSet_(dontSpec) {}
+                      llvm::DenseSet<llvm::Value *> &dontSpec, LLVMIRGen &irgen)
+      : entryF_(entryF), dontSpecializeArgsSet_(dontSpec), irgen_(irgen) {}
 
   /// Specialize a single call.
   /// \returns the specialized Call instruction if it was possible to specialize
@@ -304,7 +304,7 @@ public:
     // Generate a call of the specialized function before the current call
     // instruction.
     builder.SetInsertPoint(call);
-    return createCall(builder, specializedF, argsForSpecialized);
+    return irgen_.createCall(builder, specializedF, argsForSpecialized);
   }
 
   void run() {
@@ -430,12 +430,14 @@ private:
   /// A reference to a set of values that the specializer was requested not to
   /// specialize.
   llvm::DenseSet<llvm::Value *> &dontSpecializeArgsSet_;
+  /// LLVMIRGen to be used.
+  LLVMIRGen &irgen_;
 };
 
 } // namespace
 
 void LLVMIRGen::performSpecialization() {
   FunctionSpecializer FuncSpecializer(llmodule_->getFunction("main"),
-                                      dontSpecializeArgsSet_);
+                                      dontSpecializeArgsSet_, *this);
   FuncSpecializer.run();
 }

--- a/lib/LLVMIRCodeGen/LLVMBackend.cpp
+++ b/lib/LLVMIRCodeGen/LLVMBackend.cpp
@@ -70,7 +70,7 @@ static void emitJitMain(LLVMIRGen &irgen) {
   // use of it.
   auto *entryF = irgen.getModule().getFunction(irgen.getMainEntryName());
   entryF->setLinkage(llvm::Function::InternalLinkage);
-  createCall(builder, entryF, initFunctionCallArgs);
+  irgen.createCall(builder, entryF, initFunctionCallArgs);
   // Terminate the function.
   builder.CreateRetVoid();
   // Create the debug info for the entry point function.
@@ -147,21 +147,4 @@ void LLVMBackend::save(Function *F, llvm::StringRef outputDir,
   std::string tgt = target.empty() ? "" : target.getValue();
   auto IR = generateAndOptimizeIR(F, *this, shouldShareBuffers());
   BundleSaver(IR.get(), *this).save(tgt, outputDir, networkName);
-}
-
-llvm::CallInst *glow::createCall(llvm::IRBuilder<> &builder,
-                                 llvm::Function *callee,
-                                 llvm::ArrayRef<llvm::Value *> args) {
-#ifndef NDEBUG
-  llvm::FunctionType *FTy = callee->getFunctionType();
-  assert((args.size() == FTy->getNumParams() ||
-          (FTy->isVarArg() && args.size() > FTy->getNumParams())) &&
-         "Calling a function with bad signature: wrong number of arguments.");
-
-  for (unsigned i = 0; i != args.size(); ++i)
-    assert((i >= FTy->getNumParams() ||
-            FTy->getParamType(i) == args[i]->getType()) &&
-           "Calling a function with a bad signature: argument type mismatch.");
-#endif
-  return builder.CreateCall(callee, args);
 }

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -548,6 +548,24 @@ llvm::Function *LLVMIRGen::getFunction(const std::string &name,
   }
 }
 
+llvm::CallInst *LLVMIRGen::createCall(llvm::IRBuilder<> &builder,
+                                      llvm::Function *callee,
+                                      llvm::ArrayRef<llvm::Value *> args) {
+#ifndef NDEBUG
+  llvm::FunctionType *FTy = callee->getFunctionType();
+  assert((args.size() == FTy->getNumParams() ||
+          (FTy->isVarArg() && args.size() > FTy->getNumParams())) &&
+         "Calling a function with bad signature: wrong number of arguments.");
+
+  for (unsigned i = 0; i != args.size(); ++i) {
+    assert((i >= FTy->getNumParams() ||
+            FTy->getParamType(i) == args[i]->getType()) &&
+           "Calling a function with a bad signature: argument type mismatch.");
+  }
+#endif
+  return builder.CreateCall(callee, args);
+}
+
 std::pair<llvm::BasicBlock *, llvm::BasicBlock *>
 LLVMIRGen::createLoop(llvm::IRBuilder<> &builder, llvm::LLVMContext &ctx,
                       llvm::Value *numElements) const {


### PR DESCRIPTION
This allows for redefinition of createCall by backends, which can be very useful if there is a need to e.g. add custom run-time processing for each call (e.g. logging the names of all functions being called).
