### PR TITLE
[Backends] Autodiscovery of registered backends. Minimize changes in Backend CMake.

### DIFF
--- a/lib/Backends/CMakeLists.txt
+++ b/lib/Backends/CMakeLists.txt
@@ -1,20 +1,16 @@
-add_subdirectory(Interpreter)
-
-LIST(APPEND linked_device_managers InterpreterDeviceManager)
-LIST(APPEND linked_factories InterpreterFactory)
-
-if(GLOW_WITH_OPENCL)
-  add_subdirectory(OpenCL)
-  LIST(APPEND linked_factories OpenCLFactory)
-  LIST(APPEND linked_device_managers OpenCLDeviceManager)
-endif()
-
-
-if(GLOW_WITH_CPU)
-  add_subdirectory(CPU)
-  LIST(APPEND linked_factories CPUFactory)
-  LIST(APPEND linked_device_managers CPUDeviceManager)
-endif()
+# Iterate all subdirectories and check whether
+# particular backend is enabled.
+FILE(GLOB subdirs RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*)
+foreach(object ${subdirs})
+  if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${object})
+    set(backendEnabled GLOW_WITH_${object})
+    string(TOUPPER ${backendEnabled} backendEnabled)
+    if(NOT DEFINED ${backendEnabled} OR ${backendEnabled})
+      message("Adding ${object} backend.")
+      add_subdirectory(${object})
+    endif()
+  endif()
+endforeach()
 
 add_library(Backend
               Backend.cpp

--- a/lib/Backends/CMakeLists.txt
+++ b/lib/Backends/CMakeLists.txt
@@ -1,10 +1,14 @@
-# Iterate all subdirectories and check whether
-# particular backend is enabled.
+# Iterate all subdirectories and check whether particular backend is enabled.
 FILE(GLOB subdirs RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*)
 foreach(object ${subdirs})
   if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${object})
     set(backendEnabled GLOW_WITH_${object})
     string(TOUPPER ${backendEnabled} backendEnabled)
+    # Add sub directory for a backend if this backend is enabled
+    # or there is no defined variable for that backend.
+    # For example, Interpreter backend will be added automatically.
+    # While there is GLOW_WITH_CPU variable to control whether
+    # CPU backend is enabled or not.
     if(NOT DEFINED ${backendEnabled} OR ${backendEnabled})
       message("Adding ${object} backend.")
       add_subdirectory(${object})

--- a/lib/Backends/CPU/CMakeLists.txt
+++ b/lib/Backends/CPU/CMakeLists.txt
@@ -106,3 +106,6 @@ target_link_libraries(CPUDeviceManager
                         IR
                         Optimizer
                         ThreadPool)
+
+set(linked_factories ${linked_factories} CPUFactory PARENT_SCOPE)
+set(linked_device_managers ${linked_device_managers} CPUDeviceManager PARENT_SCOPE)

--- a/lib/Backends/Interpreter/CMakeLists.txt
+++ b/lib/Backends/Interpreter/CMakeLists.txt
@@ -31,3 +31,5 @@ target_link_libraries(InterpreterFactory
                       PRIVATE
                         Interpreter)
 
+set(linked_factories ${linked_factories} InterpreterFactory PARENT_SCOPE)
+set(linked_device_managers ${linked_device_managers} InterpreterDeviceManager PARENT_SCOPE)

--- a/lib/Backends/OpenCL/CMakeLists.txt
+++ b/lib/Backends/OpenCL/CMakeLists.txt
@@ -60,3 +60,6 @@ add_library(OpenCLFactory
 target_link_libraries(OpenCLFactory
                       PRIVATE
                         OpenCLBackend)
+
+set(linked_factories ${linked_factories} OpenCLFactory PARENT_SCOPE)
+set(linked_device_managers ${linked_device_managers} OpenCLDeviceManager PARENT_SCOPE)


### PR DESCRIPTION
*Description*:
Move backend and device manager additions to the corresponding backend dirs.
Autodiscovery of backend.

*Testing*:
CI

*Documentation*:
n/a

Addressing some @opti-mix offline comments.
