### PR TITLE
[test] Legalize a name when the placeholer is updated by name.

### DIFF
--- a/include/glow/Support/Support.h
+++ b/include/glow/Support/Support.h
@@ -111,6 +111,11 @@ void report(const char *msg);
 inline void report(const std::string &str) { report(str.c_str()); }
 inline void report(llvm::StringRef str) { report(str.data()); }
 
+/// Legalize \p name used in Module. In GLow module, the name of placeholders
+/// and constants should look like valid C identifiers. Therefore, those symbols
+/// can be inspected under debugger.
+std::string legalizeName(llvm::StringRef name);
+
 /// Printf-like formatting for std::string.
 const std::string strFormat(const char *format, ...)
 #ifndef _MSC_VER

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -103,7 +103,7 @@ void glow::updateInputPlaceholdersByName(PlaceholderBindings &bindings,
          "The number of inputs does not match the number of Placeholders");
 
   for (int i = 0, e = ph.size(); i < e; i++) {
-    Placeholder *p = mod->getPlaceholderByName(ph[i]);
+    Placeholder *p = mod->getPlaceholderByName(legalizeName(ph[i]));
     Tensor *t = inputs[i];
     assert(t && "Invalid tensor.");
     assert(p && "Invalid placeholder.");

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -404,19 +404,7 @@ Constant *Module::createConstant(llvm::StringRef name, const Tensor &tensor) {
 
 llvm::StringRef Module::uniqueName(llvm::StringRef name,
                                    llvm::StringSet<> &stringTable) {
-  std::string legalName;
-
-  // Legalize the name.
-  for (const char c : name) {
-    bool legal = isalpha(c) || isdigit(c) || c == '_';
-    legalName.push_back(legal ? c : '_');
-  }
-
-  // Names must start with some alphabetic character or underscore and can't be
-  // empty.
-  if (legalName.empty() || isdigit(legalName[0])) {
-    legalName = "A" + legalName;
-  }
+  std::string legalName = legalizeName(name);
 
   auto it = stringTable.insert(legalName);
   if (it.second) {

--- a/lib/Support/Support.cpp
+++ b/lib/Support/Support.cpp
@@ -99,4 +99,22 @@ const std::string strFormat(const char *format, ...) {
   va_end(vaArgs);
   return std::string(str.data(), len);
 }
+
+std::string legalizeName(llvm::StringRef name) {
+  std::string legalName;
+
+  // Legalize the name.
+  for (const char c : name) {
+    bool legal = isalpha(c) || isdigit(c) || c == '_';
+    legalName.push_back(legal ? c : '_');
+  }
+
+  // Names must start with some alphabetic character or underscore and can't be
+  // empty.
+  if (legalName.empty() || isdigit(legalName[0])) {
+    legalName = "A" + legalName;
+  }
+  return legalName;
+}
+
 } // namespace glow

--- a/tests/models/caffe2Models/predict_net.pbtxt
+++ b/tests/models/caffe2Models/predict_net.pbtxt
@@ -1,6 +1,6 @@
 name: "conv_test"
 op {
-  input: "data"
+  input: "gpu_0/data_0"
   input: "conv_w"
   input: "conv_b"
   output: "conv_out"

--- a/tests/unittests/Caffe2ImporterTest.cpp
+++ b/tests/unittests/Caffe2ImporterTest.cpp
@@ -46,12 +46,12 @@ TEST(caffe2, importConv) {
   {
     Tensor data;
     getNCHWData(&data, 1, 1, 3, 3);
-    Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"data"},
-                               {&data.getType()}, *F);
+    Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename,
+                               {"gpu_0/data_0"}, {&data.getType()}, *F);
     output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
 
     bindings.allocate(mod.getPlaceholders());
-    updateInputPlaceholdersByName(bindings, &mod, {"data"}, {&data});
+    updateInputPlaceholdersByName(bindings, &mod, {"gpu_0/data_0"}, {&data});
   }
 
   auto res = bindings.get(output);

--- a/tests/unittests/SupportTest.cpp
+++ b/tests/unittests/SupportTest.cpp
@@ -32,3 +32,17 @@ TEST(Support, strFormat) {
   // Output is not a single line.
   EXPECT_FALSE(StrCheck(str2).sameln("string2").sameln("456").sameln("y"));
 }
+
+TEST(Support, legalizeName) {
+  // Check that a name can't be empty.
+  std::string str1 = legalizeName("");
+  EXPECT_TRUE(str1.compare("A") == 0);
+
+  // Check that a name must start with some alphabetic character or underscore.
+  std::string str2 = legalizeName("1abc_/abc");
+  EXPECT_TRUE(str2.compare("A1abc__abc") == 0);
+
+  // Check that a legal name won't be converted.
+  std::string str3 = legalizeName("abc_1aBc");
+  EXPECT_TRUE(str3.compare("abc_1aBc") == 0);
+}


### PR DESCRIPTION
*Description*:
Since one placeholder's name will be legalized before registration, when we update one placeholder by name, the name should be processed in the same way. Otherwise, finding the placeholder may be failed.

*Testing*:
unittest.

*Documentation*:
[Optional Fixes #2565]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
