### PR TITLE
[OperatorTests] Fill in many missing tests across various ElemKinds

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -846,9 +846,12 @@ public:
   /// itself is implemented using elementwise Max, Add, Log (if lambda1 == 0),
   /// Pow, Splat, Sub, and Div (if lambda1 != 0) nodes with a Splat and Select
   /// node to select between the two cases listed above. \returns the final
-  /// Select node.
+  /// Select node. \p epsilon is used to ensure we do not divide by zero when
+  /// calculating the lambda == 0 case, as we use a Select to choose which
+  /// result to use, and so both paths are executed.
   Node *createBatchBoxCox(llvm::StringRef name, NodeValue input,
-                          NodeValue lambda1, NodeValue lambda2);
+                          NodeValue lambda1, NodeValue lambda2,
+                          float epsilon = std::numeric_limits<float>::min());
 
   /// Create a series of nodes for the Clip operator. It limits the given input
   /// within an interval specified by the `min` and `max` arguments.

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1848,7 +1848,8 @@ Node *Function::createWeightedSum(llvm::StringRef name,
 }
 
 Node *Function::createBatchBoxCox(llvm::StringRef name, NodeValue data,
-                                  NodeValue lambda1, NodeValue lambda2) {
+                                  NodeValue lambda1, NodeValue lambda2,
+                                  float epsilon) {
   assert((lambda1.dims() == lambda2.dims()) &&
          "lambda1 and lambda2 must have the same shape");
   assert((lambda1.getType()->getElementType() == lambda2.getElementType()) &&
@@ -1880,8 +1881,7 @@ Node *Function::createBatchBoxCox(llvm::StringRef name, NodeValue data,
   // Add a small epsilon to lambda1 so that we can avoid dividing by zero
   // later. It doesn't matter that this is technically incorrect because the
   // final Select will discard the results of this computation.
-  auto *eps = createSplat(name.str() + ".eps", typeBL1,
-                          std::numeric_limits<float>::min());
+  auto *eps = createSplat(name.str() + ".eps", typeBL1, epsilon);
   auto *EBL1 = createAdd(name.str() + ".lambda1eps", BL1, eps);
 
   // Compute data + BL2, which is needed regardless of whether

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1364,7 +1364,7 @@ BatchedReduceAddNode *
 Function::createBatchedReduceAdd(llvm::StringRef name, NodeValue batch,
                                  llvm::ArrayRef<unsigned_t> axes) {
   auto outDims = getNewShapeWithoutAxes(batch.dims(), axes);
-  auto OT = getParent()->uniqueType(batch.getType()->getElementType(), outDims);
+  auto OT = getParent()->uniqueTypeWithNewShape(batch.getType(), outDims);
   return createBatchedReduceAdd(name, OT, batch, axes);
 }
 

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -3760,6 +3760,12 @@ TEST_P(OperatorStatelessTest, Int8Tanh) {
                             ElemKind::FloatTy, ElemKind::Int8QTy, 0.005f);
 }
 
+TEST_P(OperatorStatelessTest, Tanh_Float16) {
+  ENABLED_BACKENDS(Interpreter);
+  compareAgainstInterpreter(GetParam(), createAndInitBasicTanhTest,
+                            ElemKind::FloatTy, ElemKind::Float16Ty, 0.001f);
+}
+
 /// Verify that the Tanh operator works correctly.
 TEST_P(OperatorTest, Tanh) {
   constexpr size_t size = 10;


### PR DESCRIPTION
We have many operators which are not being tested with different ElemKinds -- most gaps in fp16/int8. I tried to address many of the gaps here, reusing the existing logic for the test as much as possible.