### PR TITLE
Pass ownership of Module to HostManager

### DIFF
--- a/examples/resnet-runtime.cpp
+++ b/examples/resnet-runtime.cpp
@@ -116,17 +116,19 @@ int main(int argc, char **argv) {
 
   // Load model, create a context, and add to HostManager.
 
+  std::vector<size_t> inputShape{1, 3, 224, 224};
+
   Placeholder *input;
   std::vector<Placeholder *> inputs;
-  std::vector<std::unique_ptr<Module>> modules;
+  std::vector<PlaceholderList> phLists;
   for (unsigned int i = 0; i < numDevices; i++) {
     std::unique_ptr<Module> module = llvm::make_unique<Module>();
-    TypeRef inputType = module->uniqueType(ElemKind::FloatTy, {1, 3, 224, 224});
+    TypeRef inputType = module->uniqueType(ElemKind::FloatTy, inputShape);
     input = loadResnet50Model(inputType, module.get(), i);
     inputs.push_back(input);
     llvm::outs() << "Adding to HostManager\n";
-    EXIT_ON_ERR(hostManager->addNetwork(module.get()));
-    modules.push_back(std::move(module));
+    phLists.push_back(module->getPlaceholders());
+    EXIT_ON_ERR(hostManager->addNetwork(std::move(module)));
   }
 
   llvm::outs() << "Loading files from " << inputDirectory << "\n";
@@ -142,8 +144,6 @@ int main(int argc, char **argv) {
 
   size_t started = 0;
   std::atomic<size_t> returned{0};
-
-  auto inputType = modules[0]->uniqueType(ElemKind::FloatTy, {1, 3, 224, 224});
 
   // Run up to maxImages classifications.
   unsigned int currDevice{0};
@@ -166,9 +166,8 @@ int main(int argc, char **argv) {
     std::unique_ptr<ExecutionContext> context =
         llvm::make_unique<ExecutionContext>();
 
-    context->getPlaceholderBindings()->allocate(
-        modules[index]->getPlaceholders());
-    Tensor batch = image.getUnowned(inputType->dims());
+    context->getPlaceholderBindings()->allocate(phLists[index]);
+    Tensor batch = image.getUnowned(inputShape);
     updateInputPlaceholders(*(context->getPlaceholderBindings()),
                             {inputs[index]}, {&batch});
 

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -176,8 +176,9 @@ public:
   /// Erase all of the functions from the module.
   void eraseFunctions();
 
-  /// Erase all the functions, variables, etc.
-  void clear();
+  /// Erase all the functions, variables, etc. If \p clearPlaceholders is false
+  /// then placeholders in the module will not be cleared out.
+  void clear(bool clearPlaceholders = true);
 
   /// Erase a function \p F from the module.
   void eraseFunction(Function *F);

--- a/include/glow/Runtime/RuntimeTypes.h
+++ b/include/glow/Runtime/RuntimeTypes.h
@@ -89,13 +89,6 @@ struct DAGNode {
 using rootDAGNodeTy = std::unique_ptr<DAGNode>;
 using nodesDAGNodeTy = std::vector<std::unique_ptr<DAGNode>>;
 struct DAG {
-  DAG(){};
-  DAG(rootDAGNodeTy &&rootDAG, nodesDAGNodeTy &&nodesDAG)
-      : root(std::move(rootDAG)), nodes(std::move(nodesDAG)) {}
-
-  DAG(DAG &&node_)
-      : root(std::move(node_.root)), nodes(std::move(node_.nodes)) {}
-
   rootDAGNodeTy root;
   nodesDAGNodeTy nodes;
 };

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -54,20 +54,25 @@ Function *Module::createFunction(llvm::StringRef name) {
   return F;
 }
 
-void Module::clear() {
+void Module::clear(bool clearPlaceholders) {
   eraseFunctions();
 
   for (auto it = constants_.begin(), e = constants_.end(); it != e; it++) {
     Constant *v = *it;
     delete v;
   }
-  for (auto it = placeholders_.begin(), e = placeholders_.end(); it != e;
-       it++) {
-    Placeholder *p = *it;
-    delete p;
-  }
+
   constants_.clear();
-  placeholders_.clear();
+
+  if (clearPlaceholders) {
+    for (auto it = placeholders_.begin(), e = placeholders_.end(); it != e;
+         it++) {
+      Placeholder *p = *it;
+      delete p;
+    }
+
+    placeholders_.clear();
+  }
 }
 
 Module::~Module() { clear(); }

--- a/lib/Onnxifi/HostManagerOnnxifi.h
+++ b/lib/Onnxifi/HostManagerOnnxifi.h
@@ -35,7 +35,7 @@ public:
   void runNetwork(const Graph *graph, std::unique_ptr<ExecutionContext> context,
                   runtime::ResultCBTy callback) override;
 
-  onnxStatus addNetwork(Module *module);
+  onnxStatus addNetwork(std::unique_ptr<Module> module);
 
   void removeNetwork(const Graph *graph) override;
 
@@ -76,7 +76,6 @@ public:
   const std::string &getName() const { return netName_; }
 
 private:
-  Module m_;
   std::string netName_;
 };
 

--- a/lib/Partitioner/Partitioner.cpp
+++ b/lib/Partitioner/Partitioner.cpp
@@ -508,8 +508,10 @@ void Partitioner::doPartitioning(Function *F, NodeToFunctionMap &mapping) {
     }
   }
 
-  // Push the DAG {root, nodes} into partitions_.
-  partitions_.emplace_back(std::move(DAGRoot), std::move(nodes));
+  DAG dag;
+  dag.root = std::move(DAGRoot);
+  dag.nodes = std::move(nodes);
+  partitions_.push_back(std::move(dag));
 
   // Update links between nodes in the cloned functions. Add placeholders (and
   // save nodes) where a link crosses a partition boundary.


### PR DESCRIPTION
*Description*:
Make it so that HostManager and runtime owns the Module. HostManager will take ownership of Module in `addNetwork` and keeps the PlaceHolders around internally.

*Testing*:
`ninja check`
Run resnet-runtime example

*Documentation*:
comments
Fixes #2567 