### PR TITLE
[Benchmarks] Add google benchmark submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "thirdparty/foxi"]
 	path = thirdparty/foxi
 	url = https://github.com/houseroad/foxi.git
+[submodule "googlebenchmark"]
+	path = tests/googlebenchmark
+	url = https://github.com/google/benchmark

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,10 @@ message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
 
+if(NOT EXISTS "${GLOW_SOURCE_DIR}/tests/googlebenchmark/src")
+  message(FATAL_ERROR "No googlebenchmark git submodule. Run: git submodule update --init --recursive")
+endif()
+
 if(NOT EXISTS "${GLOW_SOURCE_DIR}/tests/googletest/googletest")
   message(FATAL_ERROR "No googletest git submodule. Run: git submodule update --init --recursive")
 endif()
@@ -130,6 +134,8 @@ if (GLOW_WITH_BUNDLES AND NOT GLOW_WITH_CPU)
 endif()
 
 if (GLOW_BUILD_TESTS)
+  set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "Disable tests for Google benchmark" FORCE)
+  add_subdirectory(tests/googlebenchmark EXCLUDE_FROM_ALL)
   add_subdirectory(tests/googletest EXCLUDE_FROM_ALL)
   add_subdirectory(tests)
 

--- a/tests/benchmark/CMakeLists.txt
+++ b/tests/benchmark/CMakeLists.txt
@@ -10,4 +10,17 @@ add_executable(ConvBench
 target_link_libraries(ConvBench
                       PRIVATE
                         CPURuntimeNative)
+
+add_executable(DeviceManagerBench
+               DeviceManagerBench.cpp)
+target_link_libraries(DeviceManagerBench
+                      PRIVATE
+                        Backend
+                        Backends
+                        DeviceManager
+                        Graph
+                        IR
+                        ExecutionEngine
+                        Optimizer
+                        benchmark)
 endif()

--- a/tests/benchmark/DeviceManagerBench.cpp
+++ b/tests/benchmark/DeviceManagerBench.cpp
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "benchmark/benchmark.h"
+#include "glow/Backends/DeviceManager.h"
+
+using namespace glow;
+using namespace glow::runtime;
+
+/// Fixture class for reusing DeviceManager setup across benchmarks.
+class CPUDeviceManagerBench : public benchmark::Fixture {
+public:
+  void SetUp(const ::benchmark::State &state) {
+    // Create device manager.
+    device_.reset(DeviceManager::createDeviceManager(BackendKind::CPU));
+  }
+
+  // Pointer to the DeviceManager used for benchmarking.
+  std::unique_ptr<DeviceManager> device_;
+};
+
+// Benchmark for DeviceManager::init().
+BENCHMARK_DEFINE_F(CPUDeviceManagerBench, init)(benchmark::State &state) {
+  // Init the DeviceManager until state requests to stop.
+  for (auto _ : state) {
+    (void)device_->init();
+
+    // Don't including stopping the DeviceManager in the timing for this
+    // benchmark.
+    state.PauseTiming();
+    (void)device_->stop();
+    state.ResumeTiming();
+  }
+}
+
+// Benchmark registration.
+BENCHMARK_REGISTER_F(CPUDeviceManagerBench, init)->Iterations(100);
+
+// Main.
+BENCHMARK_MAIN();


### PR DESCRIPTION
**Description**
This commit adds the Google benchmark library as a submodule to the Glow
project for use in runtime microbenchmarks.

**Testing**
This commit adds a stub for DeviceManager benchmarks to make sure that
the submodule is set up properly:

```
$ ./tests/DeviceManagerBench 
2019-03-25 16:12:46
Running ./tests/DeviceManagerBench
Run on (8 X 3100 MHz CPU s)
CPU Caches:
  L1 Data 32K (x4)
  L1 Instruction 32K (x4)
  L2 Unified 262K (x4)
  L3 Unified 8388K (x1)
Load Average: 2.61, 2.65, 2.57
***WARNING*** Library was built as DEBUG. Timings may be affected.
------------------------------------------------------------------------------------
Benchmark                                          Time             CPU   Iterations
------------------------------------------------------------------------------------
CPUDeviceManagerBench/init/iterations:100       3080 ns         2830 ns          100
```