### PR TITLE
[interp] Loosen checking on SparseLengthsSum lengths

### DIFF
--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -2279,7 +2279,7 @@ void BoundInterpreterFunction::fwdSparseLengthsWeightedSumInstFloatImpl(
   for (size_t i = 0; i < segments; i++) {
     totalLength += LH.raw(i);
   }
-  assert(totalLength == indices->dims()[0] &&
+  assert(totalLength <= indices->dims()[0] &&
          "sum(Lengths) must be equal to len(Indices)");
 
   size_t lineSize = data->size() / data->dims()[0];
@@ -2319,7 +2319,7 @@ void BoundInterpreterFunction::fwdSparseLengthsWeightedSumInstI8Impl(
   for (size_t i = 0; i < segments; i++) {
     totalLength += LH.raw(i);
   }
-  assert(totalLength == indices->dims()[0] &&
+  assert(totalLength <= indices->dims()[0] &&
          "sum(Lengths) must be equal to len(Indices)");
 
   size_t lineSize = data->size() / data->dims()[0];
@@ -2381,7 +2381,7 @@ void BoundInterpreterFunction::fwdRowwiseQuantizedSparseLengthsWeightedSumInst(
   for (size_t i = 0; i < segments; i++) {
     totalLength += LH.raw(i);
   }
-  assert(totalLength == indices->dims()[0] &&
+  assert(totalLength <= indices->dims()[0] &&
          "sum(Lengths) must be equal to len(Indices)");
 
   size_t lineSize = data->size() / data->dims()[0];
@@ -2429,7 +2429,7 @@ void BoundInterpreterFunction::
   for (size_t i = 0; i < segments; i++) {
     totalLength += LH.raw(i);
   }
-  assert(totalLength == indices->dims()[0] &&
+  assert(totalLength <= indices->dims()[0] &&
          "sum(Lengths) must be equal to len(Indices)");
 
   const size_t inLineSize = data->size() / data->dims()[0];


### PR DESCRIPTION
*Description*: Surprisingly, Caffe2 doesn't check this rigorously, which causes some internal integration tests to fail.  Arguably Caffe2 should be stricter, but it doesn't really hurt anything as far as I can tell.
*Testing*: internal test
*Documentation*: n/a
