### PR TITLE
Remove Xavier initialization from non-Float ElemKinds

### DIFF
--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -774,29 +774,13 @@ public:
   /// row of \p input equals to norm of corresponding row of \p result.
   void initXavier(size_t filterSize, PseudoRNG &PRNG) {
     assert(filterSize > 0 && "invalid filter size");
+    assert((getElementType() == ElemKind::FloatTy ||
+            getElementType() == ElemKind::Float16Ty) &&
+           "Only support floating point Xavier initialization.");
     double scale = std::sqrt(3.0 / double(filterSize));
     std::uniform_real_distribution<> dist(-scale, scale);
-    switch (getElementType()) {
-    default: {
-      for (auto &e : *this) {
-        e = dist(PRNG);
-      }
-      return;
-    }
-    case ElemKind::UInt8FusedQTy: {
-      assert(dims().size() == 2 && "Fused tensor must be 2-dimensional.");
-      assert(dims()[1] > 8 && "Fused tensor must have more than 8 columns.");
-      for (size_t i = 0, e = dims()[0]; i < e; i++) {
-        for (size_t j = 0, f = dims()[1] - 8; j < f; j++) {
-          auto v = dist(PRNG);
-          memcpy(&at({i, j}), &v, sizeof(uint8_t));
-        }
-      }
-      return;
-    }
-    case ElemKind::BoolTy: {
-      llvm_unreachable("Undefined to Xavier-initialize Bool Tensor.");
-    }
+    for (auto &e : *this) {
+      e = dist(PRNG);
     }
   }
 
@@ -818,6 +802,9 @@ public:
   typename std::enable_if<std::is_integral<T>::value>::type
   randomize(int low, int high, PseudoRNG &PRNG) {
     assert(low < high && "invalid range");
+    assert(static_cast<ElemTy>(low) >= std::numeric_limits<ElemTy>::lowest() &&
+           static_cast<ElemTy>(high) <= std::numeric_limits<ElemTy>::max() &&
+           "Cannot initialize outside range of representable values.");
     std::uniform_int_distribution<int> dist(low, high);
     for (auto &elem : *this) {
       elem = dist(PRNG);

--- a/lib/Base/Tensor.cpp
+++ b/lib/Base/Tensor.cpp
@@ -461,32 +461,8 @@ void Tensor::init(InitKind init, float val, PseudoRNG &PRNG) {
       getHandle<float16_t>().initXavier(val, PRNG);
       break;
     }
-    case ElemKind::Int8QTy: {
-      getHandle<int8_t>().initXavier(val, PRNG);
-      break;
-    }
-    case ElemKind::Int16QTy: {
-      getHandle<int16_t>().initXavier(val, PRNG);
-      break;
-    }
-    case ElemKind::Int32QTy: {
-      getHandle<int32_t>().initXavier(val, PRNG);
-      break;
-    }
-    case ElemKind::Int32ITy: {
-      getHandle<int32_t>().initXavier(val, PRNG);
-      break;
-    }
-    case ElemKind::Int64ITy: {
-      getHandle<int64_t>().initXavier(val, PRNG);
-      break;
-    }
-    case ElemKind::UInt8FusedQTy: {
-      getHandle<uint8_t>().initXavier(val, PRNG);
-      break;
-    }
-    case ElemKind::BoolTy: {
-      llvm_unreachable("Undefined to Xavier-initialize Bool Tensor.");
+    default: {
+      llvm_unreachable("Undefined to Xavier-initialize non-Float Tensors.");
     }
     }
     break;

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -5366,8 +5366,8 @@ static void testFlatten(glow::PlaceholderBindings &bindings, glow::Module &mod,
                         ElemKind DTy) {
   auto *tensor4D = createPlaceholderConditionallyQuantized(
       mod, DTy, {3, 2, 4, 3}, "4D", false);
-  bindings.allocate(tensor4D)->init(Tensor::InitKind::Xavier, 1.0,
-                                    mod.getPRNG());
+  bindings.allocate(tensor4D)->getHandle<DataType>().randomize(0, 100,
+                                                               mod.getPRNG());
 
   auto *reshape4Dto2DAxis1 = F->createFlatten("flat4Dto2Da1", tensor4D, 1);
   EXPECT_EQ(reshape4Dto2DAxis1->dims(0).size(), 2);
@@ -5398,8 +5398,8 @@ static void testFlatten(glow::PlaceholderBindings &bindings, glow::Module &mod,
   // rank of a tensor, 1D vector means we can flatten it on axis 1.
   auto *tensor1D =
       createPlaceholderConditionallyQuantized(mod, DTy, {15}, "1D", false);
-  bindings.allocate(tensor1D)->init(Tensor::InitKind::Xavier, 1.0,
-                                    mod.getPRNG());
+  bindings.allocate(tensor1D)->getHandle<DataType>().randomize(0, 100,
+                                                               mod.getPRNG());
 
   auto *reshape1Dto2DAxis1 = F->createFlatten("flat1Dto2D", tensor1D, 1);
   EXPECT_EQ(reshape1Dto2DAxis1->dims(0).size(), 2);

--- a/tests/unittests/TensorsTest.cpp
+++ b/tests/unittests/TensorsTest.cpp
@@ -854,26 +854,6 @@ TEST(Tensor, initZeroFused) {
   }
 }
 
-/// Check that initializing a fused tensor with Xavier that the scale and offset
-/// are not changed.
-TEST(Tensor, initXavierFused) {
-  Tensor T(ElemKind::UInt8FusedQTy, {10, 10}, 0.0, 0);
-  PseudoRNG PRNG;
-  auto TH = T.getHandle<uint8_t>();
-  for (size_t i = 0; i < 10; i++) {
-    for (size_t j = 0; j < 10; j++) {
-      TH.at({i, j}) = i * 10 + j;
-    }
-  }
-  T.init(Tensor::InitKind::Xavier, 1, PRNG);
-  for (size_t i = 0; i < 10; i++) {
-    for (size_t j = 2; j < 10; j++) {
-      // Check that the scales/offsets are unchanged.
-      EXPECT_EQ(TH.at({i, j}), i * 10 + j);
-    }
-  }
-}
-
 /// Check that initializing a fused tensor with Broadcast that the scale and
 /// offset are not changed, and broadcast value is set correctly.
 TEST(Tensor, initBroadcastFused) {


### PR DESCRIPTION
*Description*: While looking at https://github.com/pytorch/glow/pull/2593 I decided Xavier initialization doesn't make sense for non-float ElemKinds. If we want random data for integral ElemKinds just use `randomize()`.

*Testing*: Updated tests.