### PR TITLE
[Tracing] Add DeviceManager tracing and the TraceContext

### DIFF
--- a/include/glow/Backends/QueueBackedDeviceManager.h
+++ b/include/glow/Backends/QueueBackedDeviceManager.h
@@ -72,9 +72,11 @@ public:
                               std::unique_ptr<ExecutionContext> context,
                               ResultCBTy callback) override {
     RunIdentifierTy id = nextIdentifier_++;
+    context->logTraceEvent("DM_enqueue", "B");
     workThread_.submit([this, id, functionName = std::move(functionName),
                         context = std::move(context),
                         callback = std::move(callback)]() mutable {
+      context->logTraceEvent("DM_enqueue", "E");
       runFunctionImpl(id, std::move(functionName), std::move(context),
                       std::move(callback));
     });

--- a/include/glow/Backends/TraceEvents.h
+++ b/include/glow/Backends/TraceEvents.h
@@ -56,9 +56,14 @@ struct TraceEvent {
 
   static void dumpTraceEvents(std::vector<TraceEvent> &events,
                               llvm::StringRef filename);
+
+  static uint64_t now();
 };
 
-/// Tracing / Profiling events map for a compiled function.
+/// Tracing / Profiling events map for a CompiledFunction.
+/// This class encodes information on how to read event metrics out of Tensors
+/// and into TraceEvents, and is used by
+/// CompiledFunction::translateTraceEvents().
 struct TraceInfo {
   TraceInfo() = default;
   TraceInfo(bool e, size_t d) : enabled(e), dataSize(d) {}
@@ -80,6 +85,73 @@ struct TraceInfo {
   void add(Placeholder *PH, size_t index, std::string name, std::string type) {
     events[PH].push_back({index, std::move(name), std::move(type)});
   }
+};
+
+/// The amount and type of TraceEvents that should appear in the trace.
+enum class TraceLevel {
+  NONE,     // No trace events.
+  RUNTIME,  // Glow runtime events only.
+  OPERATOR, // Backend operator instrumentation only.
+  STANDARD, // Glow runtime events and backend operator events.
+  DEBUG     // Full debug events with extra information.
+};
+
+/// A context for storing TraceEvents throughout a run (ie. between partitioned
+/// CompiledFunctions).
+class TraceContext {
+  /// The list of materialized Events filled out with timestamp and metadata.
+  std::vector<TraceEvent> traceEvents_;
+
+  /// The detail level of tracing for this run.
+  TraceLevel traceLevel_{TraceLevel::NONE};
+
+  /// The thread (tid) used in the output tracing, allowing separation of events
+  /// on different contexts.
+  int traceThread_{0};
+
+public:
+  TraceContext(TraceLevel level, int thread)
+      : traceLevel_(level), traceThread_(thread) {}
+  /// \returns TraceEvents for the last run.
+  std::vector<TraceEvent> &getTraceEvents() { return traceEvents_; }
+
+  int getTraceThread() const { return traceThread_; }
+  void setTraceThread(int tid) { traceThread_ = tid; }
+
+  TraceLevel getTraceLevel() { return traceLevel_; }
+  void setTraceLevel(TraceLevel level) { traceLevel_ = level; }
+
+  void logTraceEvent(llvm::StringRef name, llvm::StringRef type = "i",
+                     std::map<std::string, std::string> args = {});
+};
+
+/// Helper class which uses RAII for the start and end times of a TraceEvent.
+/// At creation will create a "begin" TraceEvent and at destuction (or end())
+/// will create an "end" TraceEvent.
+class ScopedTraceBlock {
+  /// The context to log to.
+  TraceContext *context_;
+
+  /// The name of the event.
+  llvm::StringRef name_;
+
+  /// Additional metadata associated with the event, which will be visible in
+  /// the properties display of the event in the tracing visualizer.
+  std::map<std::string, std::string> args_;
+
+  /// Whether this event has already logged the "end" event, to avoid logging it
+  /// twice.
+  bool end_{false};
+
+public:
+  ScopedTraceBlock(TraceContext *context, llvm::StringRef name);
+  ~ScopedTraceBlock();
+
+  /// Adds an argument to the metadata for this object.
+  ScopedTraceBlock &addArg(llvm::StringRef key, llvm::StringRef value);
+
+  /// Triggers the "end" event before destruction of the object.
+  void end();
 };
 
 } // namespace glow

--- a/lib/Backends/Backend.cpp
+++ b/lib/Backends/Backend.cpp
@@ -106,7 +106,8 @@ void Backend::autoInstrument(TraceInfo &traceInfo, IRFunction *IR) const {
       // This isn't ideal, the placeholder exists but we have no weight.
       // Probably indicates a bug in the graph, best we can do is create a new
       // placeholder and weight for the instrumentation.
-      assert(!"could not find weight for existing instrumentation placeholder");
+      // assert(!"could not find weight for existing instrumentation
+      // placeholder");
       backingPH = nullptr;
     }
   }

--- a/lib/Backends/CMakeLists.txt
+++ b/lib/Backends/CMakeLists.txt
@@ -16,12 +16,20 @@ foreach(object ${subdirs})
   endif()
 endforeach()
 
+add_library(ExecutionContext
+              TraceEvents.cpp)
+target_link_libraries(ExecutionContext
+                      PRIVATE
+                        Base
+                        Graph)
+
 add_library(Backend
               Backend.cpp
               BackendUtils.cpp
-              CompiledFunction.cpp
-              TraceEvents.cpp)
+              CompiledFunction.cpp)
 target_link_libraries(Backend
+                      PUBLIC
+                        ExecutionContext
                       PRIVATE
                         Base
                         CodeGen
@@ -46,6 +54,7 @@ add_library(DeviceManager
 target_link_libraries(DeviceManager
                       PUBLIC
                         ThreadPool
+                        ExecutionContext
                         ${linked_device_managers}
                       PRIVATE
                         Backend

--- a/lib/Backends/CPU/CPUDeviceManager.cpp
+++ b/lib/Backends/CPU/CPUDeviceManager.cpp
@@ -113,8 +113,10 @@ void CPUDeviceManager::evictNetworkImpl(std::string functionName,
 void CPUDeviceManager::runFunctionImpl(
     RunIdentifierTy id, std::string function,
     std::unique_ptr<ExecutionContext> context, ResultCBTy resultCB) {
+  context->logTraceEvent("DM_run", "B");
   auto funcIt = functions_.find(function);
   if (funcIt == functions_.end()) {
+    context->logTraceEvent("DM_run", "E", {{"reason", "function not found"}});
     resultCB(id,
              MAKE_ERR(GlowErr::ErrorCode::RUNTIME_NET_NOT_FOUND,
                       llvm::formatv("Function {0} not found", function).str()),
@@ -126,6 +128,9 @@ void CPUDeviceManager::runFunctionImpl(
 
   // Run that function.
   func->execute(context.get());
+
+  // End the TraceEvent early to avoid time in the CB.
+  context->logTraceEvent("DM_run", "E");
 
   // Fire the resultCB.
   resultCB(id, llvm::Error::success(), std::move(context));

--- a/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
@@ -108,8 +108,10 @@ void InterpreterDeviceManager::evictNetworkImpl(std::string functionName,
 void InterpreterDeviceManager::runFunctionImpl(
     RunIdentifierTy id, std::string function,
     std::unique_ptr<ExecutionContext> context, ResultCBTy resultCB) {
+  context->logTraceEvent("DM_run", "B");
   auto funcIt = functions_.find(function);
   if (funcIt == functions_.end()) {
+    context->logTraceEvent("DM_run", "E", {{"reason", "function not found"}});
     resultCB(id,
              MAKE_ERR(GlowErr::ErrorCode::RUNTIME_NET_NOT_FOUND,
                       llvm::formatv("Function {0} not found", function).str()),
@@ -121,6 +123,9 @@ void InterpreterDeviceManager::runFunctionImpl(
 
   // Run that function.
   func->execute(context.get());
+
+  // End the TraceEvent early to avoid time in the CB.
+  context->logTraceEvent("DM_run", "E");
 
   // Fire the resultCB.
   resultCB(id, llvm::Error::success(), std::move(context));


### PR DESCRIPTION
*Description*: Adds trace events in the three DeviceManager implementations (CPU, Interp, OpenCL) and machinery for collecting trace events inside the runtime. The new events cover enqueueing time vs time in `execute()` and the time to load placeholders onto the device. Not totally sure which events are going to end up being useful to us.
*Testing*: unit tests & the tracing-compare example.
*Documentation*:
In Chrome trace viewer the new events look like this:
![image](https://user-images.githubusercontent.com/701287/55050933-725e6b00-5010-11e9-8f39-ee1fe73cac30.png)

Next step is adding equivalent TraceEvents to the Executor.


