### PR TITLE
Fix local shared build

### DIFF
--- a/lib/Backends/Interpreter/CMakeLists.txt
+++ b/lib/Backends/Interpreter/CMakeLists.txt
@@ -29,7 +29,8 @@ add_library(InterpreterFactory
               InterpreterFactory.cpp)
 target_link_libraries(InterpreterFactory
                       PRIVATE
-                        Interpreter)
+                        Interpreter
+                        LLVMCore)
 
 set(linked_factories ${linked_factories} InterpreterFactory PARENT_SCOPE)
 set(linked_device_managers ${linked_device_managers} InterpreterDeviceManager PARENT_SCOPE)

--- a/lib/Backends/OpenCL/CMakeLists.txt
+++ b/lib/Backends/OpenCL/CMakeLists.txt
@@ -59,7 +59,8 @@ add_library(OpenCLFactory
               OpenCLFactory.cpp)
 target_link_libraries(OpenCLFactory
                       PRIVATE
-                        OpenCLBackend)
+                        OpenCLBackend
+                        LLVMCore)
 
 set(linked_factories ${linked_factories} OpenCLFactory PARENT_SCOPE)
 set(linked_device_managers ${linked_device_managers} OpenCLDeviceManager PARENT_SCOPE)


### PR DESCRIPTION
*Description*: @rdzhabarov's Backend Registry addition needs extra dependencies in local SHARED build - at least on my machine. The symbol that is missing for the factories is  llvm::DisableABIBreakingChecks but not sure exactly where that gets called.
*Testing*: build & test shared build locally.
*Documentation*:
