### PR TITLE
[debugging] Make -debug-glow-only option take a list of comma-separated debug types names

### DIFF
--- a/lib/Support/Debug.cpp
+++ b/lib/Support/Debug.cpp
@@ -30,17 +30,20 @@ static llvm::cl::opt<bool, true>
               llvm::cl::Hidden, llvm::cl::location(DebugFlag));
 
 /// -debug-glow-only - Command line option to enable debug output for specific
-/// passes.
-static llvm::cl::opt<std::string, true>
+/// debug types. Multiple comma-separated debug types names can be provided.
+static llvm::cl::list<std::string>
     DebugGlowOnly("debug-glow-only",
-                  llvm::cl::desc("Enable a specific type of debug output"),
-                  llvm::cl::Hidden, llvm::cl::location(DebugOnlyType));
+                  llvm::cl::desc("Enable specific types of debug output"),
+                  llvm::cl::CommaSeparated, llvm::cl::Hidden);
 
 namespace glow {
 
 /// Exported boolean set by -debug-glow option.
 bool DebugFlag = false;
 
-bool isCurrentDebugType(const char *type) { return DebugOnlyType == type; }
+bool isCurrentDebugType(const char *type) {
+  return std::find(DebugGlowOnly.begin(), DebugGlowOnly.end(), type) !=
+         DebugGlowOnly.end();
+}
 
 } // namespace glow


### PR DESCRIPTION
The original `-debug-only` in LLVM always had this semantics. This PR follows the LLVM lead and makes the `-debug-glow-only` option more flexible as it allows for using multiple debug types at once.
