### PR TITLE
[runtime] Build runtime bundle with only Function (no IR)

### DIFF
--- a/include/glow/Backends/BackendUtils.h
+++ b/include/glow/Backends/BackendUtils.h
@@ -98,5 +98,11 @@ generateRuntimeBundle(const IRFunction &F, MemoryAllocator &constantAllocator,
                       MemoryAllocator &placeholderAllocator,
                       MemoryAllocator &activationsAllocator);
 
+/// Build a runtime symbol table from a Function.  Computes Constant and
+/// Placeholder sizes, but not Activations, since Functions are unserialized.
+/// Only use this method to generate bundles for backends that do not use
+/// Glow's IR.
+runtime::RuntimeBundle generateRuntimeBundle(const Function *F);
+
 } // end namespace glow
 #endif // GLOW_BACKENDS_BACKENDUTILS_H

--- a/lib/Backends/BackendUtils.cpp
+++ b/lib/Backends/BackendUtils.cpp
@@ -80,6 +80,39 @@ runtime::RuntimeBundle::getSymbolInfo(const Named *v) const {
   return it->second;
 }
 
+runtime::RuntimeBundle glow::generateRuntimeBundle(const Function *F) {
+  std::unordered_map<std::string, runtime::RuntimeSymbolInfo> symbolTable;
+
+  MemoryAllocator constants("constants", 0);
+  MemoryAllocator placeholders("placeholders", 0);
+
+  // Allocate constants.
+  for (auto const *V : F->getParent()->getConstants()) {
+    auto size = V->getType()->getSizeInBytes();
+    auto offset = constants.allocate(size, V);
+    runtime::RuntimeSymbolInfo symbol;
+    symbol.offset = offset;
+    symbol.size = size;
+    symbol.type = *V->getType();
+    symbolTable.emplace(V->getName(), symbol);
+  }
+
+  // Allocate placeholders.
+  for (auto const *V : F->getParent()->getPlaceholders()) {
+    auto size = V->getType()->getSizeInBytes();
+    auto offset = placeholders.allocate(size, V);
+    runtime::RuntimeSymbolInfo symbol;
+    symbol.offset = offset;
+    symbol.size = size;
+    symbol.type = *V->getType();
+    symbolTable.emplace(V->getName(), symbol);
+  }
+
+  return runtime::RuntimeBundle(symbolTable, constants.getMaxMemoryUsage(),
+                                placeholders.getMaxMemoryUsage(),
+                                /*activationsMaxSize*/ 0);
+}
+
 runtime::RuntimeBundle
 glow::generateRuntimeBundle(const IRFunction &F,
                             MemoryAllocator &constantAllocator,


### PR DESCRIPTION
*Description*: Apparently the runtime (provisioner, I guess?) needs a symbol table to properly set up the placeholders for the partitioned subgraphs.  Since some backends don't use IRFunction we need a way to generate a symbol table for them, hence this diff.

*Testing*: used internally (sorry)

*Documentation*: We should probably add something to Backends.md.
