### PR TITLE
[runtime] Force RuntimeBundle to be properly constructed

### DIFF
--- a/include/glow/Backends/BackendUtils.h
+++ b/include/glow/Backends/BackendUtils.h
@@ -81,7 +81,24 @@ public:
   /// Sets the input and output flags for each symbol in the symbolBundle.
   void setInputsandOutputs();
 
-  RuntimeBundle() = default;
+  /// Computes offsets and total allocation for Constants, Placeholders, and
+  /// Activations to build runtime symbol table. Returns RuntimeBundle.
+  static runtime::RuntimeBundle create(const IRFunction &F,
+                                       MemoryAllocator &constantAllocator,
+                                       MemoryAllocator &placeholderAllocator,
+                                       MemoryAllocator &activationsAllocator);
+
+  /// Build a runtime symbol table from a Function.  Computes Constant and
+  /// Placeholder sizes, but not Activations, since Functions are unserialized.
+  /// Only use this method to generate bundles for backends that do not use
+  /// Glow's IR.
+  static runtime::RuntimeBundle create(const Function &F);
+
+  /// Deleted default constructor.  A properly constructed RuntimeBundle is
+  /// necessary for correct execution using the HostManager.
+  RuntimeBundle() = delete;
+
+  // Constructor.
   RuntimeBundle(SymbolTableTy &symbolTable, size_t constWeight,
                 size_t mutableWeight, size_t activations)
       : symbolTable_(std::move(symbolTable)), constants_(nullptr),
@@ -90,19 +107,6 @@ public:
         activationsMemSize_(activations) {}
 };
 } // namespace runtime
-
-/// Computes offsets and total allocation for Constants, Placeholders, and
-/// Activations to build runtime symbol table. Returns RuntimeBundle.
-runtime::RuntimeBundle
-generateRuntimeBundle(const IRFunction &F, MemoryAllocator &constantAllocator,
-                      MemoryAllocator &placeholderAllocator,
-                      MemoryAllocator &activationsAllocator);
-
-/// Build a runtime symbol table from a Function.  Computes Constant and
-/// Placeholder sizes, but not Activations, since Functions are unserialized.
-/// Only use this method to generate bundles for backends that do not use
-/// Glow's IR.
-runtime::RuntimeBundle generateRuntimeBundle(const Function *F);
 
 } // end namespace glow
 #endif // GLOW_BACKENDS_BACKENDUTILS_H

--- a/include/glow/Backends/CompiledFunction.h
+++ b/include/glow/Backends/CompiledFunction.h
@@ -30,7 +30,7 @@ enum class BackendKind;
 class CompiledFunction {
 public:
   /// Default Ctor.
-  CompiledFunction() = default;
+  CompiledFunction() = delete;
 
   /// Ctor that accepts runtimeBundle.
   CompiledFunction(const runtime::RuntimeBundle &bundle);

--- a/include/glow/Runtime/RuntimeTypes.h
+++ b/include/glow/Runtime/RuntimeTypes.h
@@ -81,7 +81,7 @@ struct DAGNode {
   std::string name;
   /// Runtime bundle containing all the symbol information for this network at
   /// runtime.
-  RuntimeBundle runtimeBundle;
+  std::unique_ptr<RuntimeBundle> runtimeBundle;
 };
 
 /// This struct represents a DAG. The first element is the root of a DAG, and

--- a/lib/Backends/BackendUtils.cpp
+++ b/lib/Backends/BackendUtils.cpp
@@ -17,6 +17,7 @@
 #include "glow/IR/Instrs.h"
 
 using namespace glow;
+
 using llvm::cast;
 using llvm::isa;
 
@@ -80,14 +81,14 @@ runtime::RuntimeBundle::getSymbolInfo(const Named *v) const {
   return it->second;
 }
 
-runtime::RuntimeBundle glow::generateRuntimeBundle(const Function *F) {
+runtime::RuntimeBundle runtime::RuntimeBundle::create(const Function &F) {
   std::unordered_map<std::string, runtime::RuntimeSymbolInfo> symbolTable;
 
   MemoryAllocator constants("constants", 0);
   MemoryAllocator placeholders("placeholders", 0);
 
   // Allocate constants.
-  for (auto const *V : F->getParent()->getConstants()) {
+  for (auto const *V : F.getParent()->getConstants()) {
     auto size = V->getType()->getSizeInBytes();
     auto offset = constants.allocate(size, V);
     runtime::RuntimeSymbolInfo symbol;
@@ -98,7 +99,7 @@ runtime::RuntimeBundle glow::generateRuntimeBundle(const Function *F) {
   }
 
   // Allocate placeholders.
-  for (auto const *V : F->getParent()->getPlaceholders()) {
+  for (auto const *V : F.getParent()->getPlaceholders()) {
     auto size = V->getType()->getSizeInBytes();
     auto offset = placeholders.allocate(size, V);
     runtime::RuntimeSymbolInfo symbol;
@@ -114,10 +115,10 @@ runtime::RuntimeBundle glow::generateRuntimeBundle(const Function *F) {
 }
 
 runtime::RuntimeBundle
-glow::generateRuntimeBundle(const IRFunction &F,
-                            MemoryAllocator &constantAllocator,
-                            MemoryAllocator &placeholderAllocator,
-                            MemoryAllocator &activationsAllocator) {
+runtime::RuntimeBundle::create(const IRFunction &F,
+                               MemoryAllocator &constantAllocator,
+                               MemoryAllocator &placeholderAllocator,
+                               MemoryAllocator &activationsAllocator) {
   // Handle Constants, Placeholders, and Activations, in that order.
   // Symbol table mapping symbol name to offset for runtime.
   std::unordered_map<std::string, runtime::RuntimeSymbolInfo> symbolTable;

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -59,9 +59,9 @@ Interpreter::compileIRWithoutConstants(std::unique_ptr<IRFunction> IR) const {
   MemoryAllocator constantWeightsAllocator("ConstantWeights", 0);
   MemoryAllocator placeholderWeightsAllocator("PlaceholderWeights", 0);
   MemoryAllocator activationsAllocator("Activations", 0);
-  runtime::RuntimeBundle bundle =
-      generateRuntimeBundle(*IR, constantWeightsAllocator,
-                            placeholderWeightsAllocator, activationsAllocator);
+  runtime::RuntimeBundle bundle = runtime::RuntimeBundle::create(
+      *IR, constantWeightsAllocator, placeholderWeightsAllocator,
+      activationsAllocator);
   return llvm::make_unique<InterpreterFunction>(std::move(IR), bundle);
 }
 

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -1569,8 +1569,8 @@ OCLBackend::compileIR(std::unique_ptr<IRFunction> IR) const {
 std::unique_ptr<CompiledFunction>
 OCLBackend::compileIRWithoutConstants(std::unique_ptr<IRFunction> IR) const {
   MemoryAllocator allocator("GPU", 0xFFFFFFFF);
-  runtime::RuntimeBundle bundle =
-      generateRuntimeBundle(*IR, allocator, allocator, allocator);
+  auto bundle =
+      runtime::RuntimeBundle::create(*IR, allocator, allocator, allocator);
   return llvm::make_unique<OpenCLFunction>(std::move(IR), bundle);
 }
 

--- a/lib/LLVMIRCodeGen/LLVMBackend.cpp
+++ b/lib/LLVMIRCodeGen/LLVMBackend.cpp
@@ -121,7 +121,7 @@ LLVMBackend::compileIRWithoutConstants(IRFunction *IR) const {
   MemoryAllocator constantAllocator("ConstantWeights", 0);
   MemoryAllocator placeholderAllocator("Placeholders", 0);
   MemoryAllocator activationsAllocator("Activations", 0);
-  runtime::RuntimeBundle runtimeInfo = generateRuntimeBundle(
+  auto runtimeInfo = runtime::RuntimeBundle::create(
       *IR, constantAllocator, placeholderAllocator, activationsAllocator);
   return createCompiledFunction(std::move(JIT), runtimeInfo);
 }

--- a/lib/Runtime/Executor/ThreadPoolExecutor.cpp
+++ b/lib/Runtime/Executor/ThreadPoolExecutor.cpp
@@ -275,7 +275,7 @@ void ThreadPoolExecutor::propagatePlaceholdersForNode(
     std::shared_ptr<ExecutionState> executionState, const DAGNode *node,
     const ExecutionContext *ctx) {
   // Get the symbol table for the node.
-  const SymbolTableTy &symbolTable = (node->runtimeBundle).getSymbolTable();
+  const SymbolTableTy &symbolTable = node->runtimeBundle->getSymbolTable();
 
   for (const auto &symbolPair : symbolTable) {
     const auto &symbolName = symbolPair.first;

--- a/lib/Runtime/Provisioner/Provisioner.cpp
+++ b/lib/Runtime/Provisioner/Provisioner.cpp
@@ -70,11 +70,12 @@ llvm::Error Provisioner::provision(DAGListTy &networks, Module &module) {
       CompilationOptions compileOptions;
       compileOptions.collectConstants = false;
       auto compiled = backend_->compile(function, compileOptions);
-      node->runtimeBundle = compiled->getRuntimeBundle();
-      node->runtimeBundle.setInputsandOutputs();
+      node->runtimeBundle =
+          llvm::make_unique<RuntimeBundle>(compiled->getRuntimeBundle());
+      node->runtimeBundle->setInputsandOutputs();
       functionMap.emplace(node->name, compiled.get());
       functions_.emplace(node->name, std::move(compiled));
-      totalMemory += node->runtimeBundle.getConstantWeightSize();
+      totalMemory += node->runtimeBundle->getConstantWeightSize();
     }
     logicalDeviceSize.push_back(std::make_pair(device.first, totalMemory));
     functionMaps.emplace(device.first, functionMap);

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -95,6 +95,10 @@ static const auto all_backends = ::testing::Values(
 /// MockBackend used only for unit testing.
 class MockBackend : public Backend {
   class MockFunction : public CompiledFunction {
+  public:
+    MockFunction(const runtime::RuntimeBundle &bundle)
+        : CompiledFunction(bundle) {}
+
     void execute(ExecutionContext *) override {}
 
     BackendKind getCompileBackendKind() const override {
@@ -108,7 +112,7 @@ class MockBackend : public Backend {
 
   std::unique_ptr<CompiledFunction>
   compile(Function *F, const CompilationOptions &) const override {
-    return llvm::make_unique<MockFunction>();
+    return llvm::make_unique<MockFunction>(runtime::RuntimeBundle::create(*F));
   }
 
   bool isOpSupported(const NodeInfo &NI) const override { return false; }
@@ -122,6 +126,10 @@ class MockBackend : public Backend {
 /// from Node to Instruction IR.
 class MockBackendCustomIRGen : public Backend {
   class MockFunction : public CompiledFunction {
+  public:
+    MockFunction(const runtime::RuntimeBundle &bundle)
+        : CompiledFunction(bundle) {}
+
     void execute(ExecutionContext *) override {}
 
     BackendKind getCompileBackendKind() const override {
@@ -135,7 +143,7 @@ class MockBackendCustomIRGen : public Backend {
 
   std::unique_ptr<CompiledFunction>
   compile(Function *F, const CompilationOptions &) const override {
-    return llvm::make_unique<MockFunction>();
+    return llvm::make_unique<MockFunction>(runtime::RuntimeBundle::create(*F));
   }
 
   bool isOpSupported(const NodeInfo &NI) const override { return false; }

--- a/tests/unittests/ExecutorTest.cpp
+++ b/tests/unittests/ExecutorTest.cpp
@@ -393,9 +393,10 @@ public:
     // Set the name, device ID, and RuntimeBundle of the new node.
     newNode->name = name;
     newNode->deviceID = deviceId;
-    newNode->runtimeBundle =
-        RuntimeBundle(symbolTable, /*constWeight=*/0, /*mutableWeight=*/0,
-                      /*activations=*/0);
+
+    newNode->runtimeBundle = llvm::make_unique<RuntimeBundle>(
+        symbolTable, /*constWeight=*/0, /*mutableWeight=*/0,
+        /*activations=*/0);
 
     // Register node result with the appropriate DeviceManager.
     auto it = deviceManagers_.find(deviceId);
@@ -483,7 +484,7 @@ private:
     // Input symbols for the entire test are the inputs of all nodes that have
     // no parents.
     for (const auto &node : root_->children) {
-      const SymbolTableTy &symbolTable = (node->runtimeBundle).getSymbolTable();
+      const SymbolTableTy &symbolTable = node->runtimeBundle->getSymbolTable();
 
       for (const auto &symbolPair : symbolTable) {
         const auto &symbolName = symbolPair.first;
@@ -506,7 +507,7 @@ private:
     // Input symbols for the entire test are the outputs of all nodes that have
     // no children.
     for (const auto &node : leaves_) {
-      const SymbolTableTy &symbolTable = (node->runtimeBundle).getSymbolTable();
+      const SymbolTableTy &symbolTable = node->runtimeBundle->getSymbolTable();
 
       for (const auto &symbolPair : symbolTable) {
         const auto &symbolName = symbolPair.first;


### PR DESCRIPTION
*Description*: I was bitten hard today because the backend I was working on didn't build a RuntimeBundle (because it doesn't need one), and I discovered only through lots of debugging that the Provisioner requires the symbol table from a runtime bundle.  To help prevent others from making this mistake, let's make the illegal state (of a dummy RuntimeBundle hanging out in CompiledFunction) unrepresentable by deleting its default constructor.

I was going to force everything to use the static factory methods, but that got really messy in ExecutorTest so I gave up, and will allow people to shoot themselves in the foot as long as the type RuntimeBundle(SymbolTable(), 0, 0, 0) while doing so.

*Testing*: existing unit tests

*Documentation*: n/a

Stacked on #2611 