### PR TITLE
Add partial support for LeakyRelu via "folding"

### DIFF
--- a/include/glow/Optimizer/Optimizer.h
+++ b/include/glow/Optimizer/Optimizer.h
@@ -36,6 +36,9 @@ void optimize(IRFunction &M, bool shouldShareBuffers);
 /// Perform optimizations on the graph representation.
 void optimize(Function *F, const CompilationOptions &opts);
 void optimize(Function *F, CompilationMode mode);
+/// Fold nodes that were expressed lowered in the input model.
+void fold(Function *F, const CompilationOptions &opts);
+void fold(Function *F, CompilationMode mode);
 
 /// Lower the high-level neural network nodes found in \p F into low-level
 /// linear algebra operators. If \p B is not a nullptr then it can prevent

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -246,7 +246,15 @@ static Kinded::Kind getKindFromNodeName(llvm::StringRef nodeName) {
 }
 
 void Loader::compile(PlaceholderBindings &bindings) {
-  // Handle the request to profile the graph in preperation for quantization.
+  // Fold low-level operators into higher-level operators.
+  // This is useful when compiling an input model where some high-level
+  // operators have been lowered (this can be for instance a side effect of
+  // model converters, like converters from Tensorflow to ONNX). In this
+  // situation, such folding can then enable more optimizations and also improve
+  // the performance backends that support natively such high-level operators.
+  ::fold(F_, glow::CompilationMode::Infer);
+
+  // Handle the request to profile the graph in preparation for quantization.
   if (!dumpProfileFileOpt.empty()) {
     // Perform the high-level optimizations before instrumenting the graph. This
     // optimization phase will remove stuff like repetitive transpose operations


### PR DESCRIPTION
*Description*:

1) Added partial support for LeakyRelu:
- LeakyRelu Node in the IR
- LeakyRelu lowering for CPU/interpreter backends

2) Added an optimization to fold Max(Mul(Constant, A), A) to LeakyRelu (We've got some model where LeakyRelu is expressed this way).

From this PR, implementing LeakyRelu in importers will be simple for the day someone encounters directly the LeakyRelu operator in an ONNX or Caffe2 model.

For information, here is the ONNX LeakyRelu description:
https://github.com/onnx/onnx/blob/master/docs/Operators.md#LeakyRelu


*Testing*:
- Test node creation and lowering
- Test the folding optim

*Documentation*: N/A
