### PR TITLE
Modify compilation to only use function symbols

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -200,6 +200,9 @@ class Function final : public Named {
   /// A list of nodes that the Function owns.
   NodesList nodes_;
 
+  /// A list of metadata PHs associated with the function.
+  std::vector<Placeholder *> metadataPlaceholders_;
+
   /// Stores a list of unique node names that were used by the module at some
   /// point.
   llvm::StringSet<> uniqueNodeNames_{};
@@ -213,7 +216,28 @@ public:
 
   ~Function();
 
+  /// Add placeholder for metadata such as profiling.
+  void addMetadataPlaceholder(Placeholder *PH) {
+    metadataPlaceholders_.push_back(PH);
+  }
+
+  /// Get list of metadata placeholders.
+  const std::vector<Placeholder *> &getMetadataPlaceholders() const {
+    return metadataPlaceholders_;
+  }
+
   Module *getParent() { return parent_; }
+
+  /// Search the Module containing the function to gather and return a list of
+  /// placeholders that are used by the Function.
+  PlaceholderList findPlaceholders();
+  PlaceholderList findPlaceholders() const;
+
+  /// Search the Module containing the function to gather and return a list of
+  /// constants that are used by the Function.
+  ConstList findConstants();
+  ConstList findConstants() const;
+
   const Module *getParent() const { return parent_; }
 
   /// Inserts the node \p N to the list of nodes, and returns the inserted node.

--- a/include/glow/IR/IR.h
+++ b/include/glow/IR/IR.h
@@ -320,6 +320,12 @@ public:
   /// \returns the variable map.
   VariableMap &getVariableMap() { return variableMap_; }
 
+  /// Returns a list of constants associated with function.
+  std::vector<const Constant *> findConstants() const;
+
+  /// Returns a list of placeholders associated with the function.
+  std::vector<const Placeholder *> findPlaceholders() const;
+
   /// \returns the weight that the variable \p v is lowered into, or null if the
   /// variable is unknown.
   Value *getWeightForNode(const Storage *V) const;

--- a/lib/Backends/Backend.cpp
+++ b/lib/Backends/Backend.cpp
@@ -121,6 +121,9 @@ void Backend::autoInstrument(TraceInfo &traceInfo, IRFunction *IR) const {
     assert(backingPH);
   }
 
+  // Add Placeholder to the graph so we can add it to the runtimeBundle later.
+  F->addMetadataPlaceholder(backingPH);
+
   // If we don't have a weight we need to create one too, whether or not we just
   // created a Placeholder.
   if (!backingWeight) {

--- a/lib/Backends/BackendUtils.cpp
+++ b/lib/Backends/BackendUtils.cpp
@@ -88,7 +88,7 @@ runtime::RuntimeBundle runtime::RuntimeBundle::create(const Function &F) {
   MemoryAllocator placeholders("placeholders", 0);
 
   // Allocate constants.
-  for (auto const *V : F.getParent()->getConstants()) {
+  for (auto const *V : F.findConstants()) {
     auto size = V->getType()->getSizeInBytes();
     auto offset = constants.allocate(size, V);
     runtime::RuntimeSymbolInfo symbol;
@@ -99,7 +99,7 @@ runtime::RuntimeBundle runtime::RuntimeBundle::create(const Function &F) {
   }
 
   // Allocate placeholders.
-  for (auto const *V : F.getParent()->getPlaceholders()) {
+  for (auto const *V : F.findPlaceholders()) {
     auto size = V->getType()->getSizeInBytes();
     auto offset = placeholders.allocate(size, V);
     runtime::RuntimeSymbolInfo symbol;
@@ -123,7 +123,7 @@ runtime::RuntimeBundle::create(const IRFunction &F,
   // Symbol table mapping symbol name to offset for runtime.
   std::unordered_map<std::string, runtime::RuntimeSymbolInfo> symbolTable;
   // Compute the offsets for Constants.
-  for (auto &v : F.getGraph()->getParent()->getConstants()) {
+  for (auto &v : F.findConstants()) {
     assert(isa<WeightVar>(F.getWeightForNode(v)) && "Expected WeightVar");
     auto *w = cast<WeightVar>(F.getWeightForNode(v));
     auto numBytes = w->getSizeInBytes();
@@ -137,7 +137,7 @@ runtime::RuntimeBundle::create(const IRFunction &F,
   auto constantMaxSize = constantAllocator.getMaxMemoryUsage();
 
   // Compute the offsets for Placeholders.
-  for (auto &v : F.getGraph()->getParent()->getPlaceholders()) {
+  for (auto &v : F.findPlaceholders()) {
     // Get the WeightVar for each Placeholder to calculate offsets.
     assert(isa<WeightVar>(F.getWeightForNode(v)) && "Expected WeightVar");
     auto *w = cast<WeightVar>(F.getWeightForNode(v));

--- a/lib/Backends/Interpreter/InterpreterFunction.cpp
+++ b/lib/Backends/Interpreter/InterpreterFunction.cpp
@@ -41,7 +41,7 @@ void InterpreterFunction::collectConstants(Module *module) {
   runtimeBundle_.collectConstants(module);
   if (constants_.empty()) {
     if (runtimeBundle_.getConstantWeightSize()) {
-      for (const auto &v : module->getConstants()) {
+      for (const auto &v : F_->findConstants()) {
         auto symbolInfo = runtimeBundle_.getSymbolInfo(v);
         auto addr = runtimeBundle_.getConstants() + symbolInfo.offset;
         auto tensor = new Tensor(addr, &symbolInfo.type);

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -2712,6 +2712,58 @@ void Function::eraseNode(Node *N) {
   eraseNode(N->getIterator());
 }
 
+PlaceholderList Function::findPlaceholders() {
+  PlaceholderList list;
+  for (auto &PH : parent_->getPlaceholders()) {
+    for (auto &user : PH->getUsers()) {
+      if (user.getUser()->getParent() == this) {
+        list.push_back(PH);
+        break;
+      }
+    }
+  }
+  return list;
+}
+
+PlaceholderList Function::findPlaceholders() const {
+  PlaceholderList list;
+  for (auto &PH : parent_->getPlaceholders()) {
+    for (auto &user : PH->getUsers()) {
+      if (user.getUser()->getParent() == this) {
+        list.push_back(PH);
+        break;
+      }
+    }
+  }
+  return list;
+}
+
+ConstList Function::findConstants() {
+  ConstList list;
+  for (auto &constant : parent_->getConstants()) {
+    for (auto &user : constant->getUsers()) {
+      if (user.getUser()->getParent() == this) {
+        list.push_back(constant);
+        break;
+      }
+    }
+  }
+  return list;
+}
+
+ConstList Function::findConstants() const {
+  ConstList list;
+  for (auto &constant : parent_->getConstants()) {
+    for (auto &user : constant->getUsers()) {
+      if (user.getUser()->getParent() == this) {
+        list.push_back(constant);
+        break;
+      }
+    }
+  }
+  return list;
+}
+
 Function *Function::clone(llvm::StringRef newName,
                           llvm::DenseMap<Node *, Node *> *map) {
   Module *M = getParent();

--- a/lib/IR/GraphScheduler.cpp
+++ b/lib/IR/GraphScheduler.cpp
@@ -48,14 +48,20 @@ Scheduler *createScheduler(SchedulerKind schedulerKind, Function &G,
 
 void IRFunction::scheduleGraph(NodesPtrList &Schedule) {
   Schedule.clear();
-  for (auto &N : G_->getParent()->getConstants()) {
+  auto constants = G_->findConstants();
+  auto placeholders = G_->findPlaceholders();
+  for (auto &N : constants) {
     Schedule.push_back(N);
   }
-  for (auto &N : G_->getParent()->getPlaceholders()) {
+  for (auto &N : placeholders) {
     Schedule.push_back(N);
   }
-  auto numVars = G_->getParent()->getConstants().size();
-  auto numPlaceholders = G_->getParent()->getPlaceholders().size();
+  for (auto &N : G_->getMetadataPlaceholders()) {
+    Schedule.push_back(N);
+  }
+  auto numVars = constants.size();
+  auto numPlaceholders =
+      placeholders.size() + G_->getMetadataPlaceholders().size();
   (void)numVars;
   (void)numPlaceholders;
   std::unique_ptr<Scheduler> scheduler{

--- a/lib/IR/IR.cpp
+++ b/lib/IR/IR.cpp
@@ -428,6 +428,26 @@ static void dumpIRInContext(const Value *V, llvm::raw_ostream &out) {
   }
 }
 
+std::vector<const Constant *> IRFunction::findConstants() const {
+  std::vector<const Constant *> constants;
+  for (auto &node : variableMap_) {
+    if (const Constant *constant = dyn_cast<const Constant>(node.first)) {
+      constants.push_back(constant);
+    }
+  }
+  return constants;
+}
+
+std::vector<const Placeholder *> IRFunction::findPlaceholders() const {
+  std::vector<const Placeholder *> placeholders;
+  for (auto &node : variableMap_) {
+    if (const Placeholder *PH = dyn_cast<const Placeholder>(node.first)) {
+      placeholders.push_back(PH);
+    }
+  }
+  return placeholders;
+}
+
 /// Dump the instruction numbers of all users of \p V.
 static void dumpUsers(const Value *V, llvm::raw_ostream &out,
                       InstructionNumbering &InstrNumbering) {

--- a/lib/LLVMIRCodeGen/AllocationsInfo.cpp
+++ b/lib/LLVMIRCodeGen/AllocationsInfo.cpp
@@ -43,7 +43,7 @@ void AllocationsInfo::allocateWeightVars(const IRFunction *F) {
 
   // Compute the new offsets for all the weights, do not reuse their current
   // addresses. Process all constant WeightVars first.
-  for (auto &v : F->getGraph()->getParent()->getConstants()) {
+  for (auto &v : F->findConstants()) {
     assert(isa<WeightVar>(F->getWeightForNode(v)) && "Expected WeightVar");
     auto *w = cast<WeightVar>(F->getWeightForNode(v));
     auto numBytes = w->getSizeInBytes();
@@ -52,7 +52,7 @@ void AllocationsInfo::allocateWeightVars(const IRFunction *F) {
   }
 
   // Compute the offsets and total memory requirements for Placeholders.
-  for (auto &v : F->getGraph()->getParent()->getPlaceholders()) {
+  for (auto &v : F->findPlaceholders()) {
     // Get the WeightVar for each Placeholder to calculate offsets.
     assert(isa<WeightVar>(F->getWeightForNode(v)) && "Expected WeightVar");
     auto *w = cast<WeightVar>(F->getWeightForNode(v));
@@ -174,14 +174,14 @@ void AllocationsInfo::allocateTensorViews(const IRFunction *F) {
 void AllocationsInfo::numberValues(const IRFunction *F) {
   size_t valueIdx = 0;
   // Assign numbers to all weights.
-  for (auto &v : F->getGraph()->getParent()->getConstants()) {
+  for (auto &v : F->findConstants()) {
     assert(isa<WeightVar>(F->getWeightForNode(v)));
     auto *w = cast<WeightVar>(F->getWeightForNode(v));
     valueNumbers_[w] = std::make_pair(ValueKind::ConstantWeight, valueIdx++);
   }
 
   // Assign numbers to all placeholders.
-  for (auto &v : F->getGraph()->getParent()->getPlaceholders()) {
+  for (auto &v : F->findPlaceholders()) {
     assert(isa<WeightVar>(F->getWeightForNode(v)));
     auto *w = cast<WeightVar>(F->getWeightForNode(v));
     valueNumbers_[w] = std::make_pair(ValueKind::MutableWeight, valueIdx++);

--- a/lib/LLVMIRCodeGen/BundleSaver.cpp
+++ b/lib/LLVMIRCodeGen/BundleSaver.cpp
@@ -53,7 +53,7 @@ void BundleSaver::saveWeights(llvm::StringRef weightsFileName) {
   // it should be configurable and set by the client.
   size_t pos = 0;
   size_t maxPos = 0;
-  for (auto &v : F_->getGraph()->getParent()->getConstants()) {
+  for (auto &v : F_->findConstants()) {
     auto *w = cast<WeightVar>(F_->getWeightForNode(v));
     auto numBytes = w->getSizeInBytes();
     auto payload = v->getPayload().getUnsafePtr();
@@ -96,7 +96,7 @@ void BundleSaver::emitSymbolTable() {
   llvm::SmallVector<llvm::Constant *, 128> entries;
   // Iterate over all Placeholders and record information about their names,
   // offset, size and kind.
-  for (auto &v : F_->getGraph()->getParent()->getPlaceholders()) {
+  for (auto &v : F_->findPlaceholders()) {
     auto *w = cast<WeightVar>(F_->getWeightForNode(v));
     auto size = w->getType()->size();
     auto addr = allocationsInfo_.allocatedAddress_[w];
@@ -251,8 +251,7 @@ void BundleSaver::emitBundleConfig() {
       llvm::ConstantInt::get(SizeTType,
                              irgen_->getAllocationsInfo().activationsMemSize_),
       llvm::ConstantInt::get(SizeTType, TensorAlignment),
-      llvm::ConstantInt::get(
-          SizeTType, F_->getGraph()->getParent()->getConstants().size()),
+      llvm::ConstantInt::get(SizeTType, F_->findConstants().size()),
       symbolTable));
 }
 

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -1429,7 +1429,7 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     // Value.
     Tensor scalesT;
     auto *F_ = getIRFunction();
-    for (auto &v : F_->getGraph()->getParent()->getConstants()) {
+    for (auto &v : F_->findConstants()) {
       assert(isa<WeightVar>(F_->getWeightForNode(v)));
       auto *w = cast<glow::Value>(F_->getWeightForNode(v));
       if (w == RWQFC->getScales()) {


### PR DESCRIPTION
*Description*: This PR modifies compilation to no longer check all placeholders/constants in the module. It now uses symbols that are associated with the function being compiled. 
*Testing*: ninja test and check_expensive pass
*Documentation*:  NA
Fixes #2548 
