### PR TITLE
add onnxifi quantization support

### DIFF
--- a/include/glow/Importer/Caffe2ModelLoader.h
+++ b/include/glow/Importer/Caffe2ModelLoader.h
@@ -67,6 +67,14 @@ class Caffe2ModelLoader
   /// Mapping between Caffe2 tensor names for inputs and actual Glow input vars.
   llvm::StringMap<Placeholder *> nameToInputVars_;
 
+  /// loadInputs calls this function for each member in its target arguments.
+  /// Currently we are supporting two tensorprototypes:
+  /// caffe2::TensorProto, caffe2::QTensorProto
+  template <class TensorProtoType>
+  llvm::Error loadInputsWithTensorProtoType(const caffe2::NetDef &net,
+                                            bool loadInputsAsPlaceholders,
+                                            const TensorProtoType &in);
+
   /// Load the inputs from the NetDef. If \p loadInputsAsPlaceholders is
   /// true then this will load each graph input as a placeholder otherwise it
   /// will create an empty tensor for each input.

--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -77,7 +77,6 @@ inline llvm::Error loadWeight(const onnxTensorDescriptorV1 &in, Tensor *T) {
     } else if (in.dataType == ONNXIFI_DATATYPE_UINT64 ||
                in.dataType == ONNXIFI_DATATYPE_INT64) {
       const bool inDataSigned = in.dataType == ONNXIFI_DATATYPE_INT64;
-      (void)inDataSigned;
       T->reset(ElemKind::Int64ITy, dims);
 
       auto TH = T->getHandle<int64_t>();

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -1066,6 +1066,7 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
 
   RETURN_ERR(unexpectedNodeErrorMessage(op, "Unsupported operator."));
 }
+
 template <class TensorProtoType>
 llvm::Error
 Caffe2ModelLoader::loadInputsWithTensorProtoType(const caffe2::NetDef &net,
@@ -1219,8 +1220,8 @@ llvm::Error Caffe2ModelLoader::loadWeight(const caffe2::OperatorDef &op) {
       arg {
       name: "values"
       s:
-"\000\377\152\232\115\072\000\000\200\077\000\377\050\132\215\073\063\063\023\100\000\377\314\063\232\073\000\000\220\100"
-  }
+      "\000\377\152\232\115\072\000\000\200\077\000\377\050\132\215\073\063\063\023\100\000\377\314\063\232\073\000\000\220\100"
+      }
      */
 
     for (auto &o : op.output()) {

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -43,8 +43,8 @@ using ArgumentDictionaryTy =
 /// In Glow, the activations are quantized to int_8. Therefore, for the offset
 /// read from quantized caffe2 model, we need to subtract 128(i.e. INT8_MIN) to
 /// make the activations becomes int8_t.
-/// For Glow: -127 <= orig_fp32/scale_1 + offset_1 < 128
-/// For Caffe2: 0 <= orig_fp32/scale_2 + offset_2 < 255
+/// For Glow: -128 <= orig_fp32/scale_1 + offset_1 <= 127
+/// For Caffe2: 0 <= orig_fp32/scale_2 + offset_2 <= 255
 /// Therefore, we can make scale_1 == scale_2, and offset_1 = offset2 - 128
 const int32_t OFFSETSHIFT = 128;
 

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -60,7 +60,6 @@ llvm::Error setTensorType(const caffe2::TensorProto &in, Tensor *T) {
     }
     dim.push_back(d);
   }
-
   if (in.data_type() == caffe2::TensorProto::FLOAT) {
     T->reset(ElemKind::FloatTy, dim);
     return llvm::Error::success();
@@ -75,6 +74,26 @@ llvm::Error setTensorType(const caffe2::TensorProto &in, Tensor *T) {
     return llvm::Error::success();
   } else {
     RETURN_ERR("Only float and index tensors are supported");
+  }
+}
+
+llvm::Error setTensorType(const caffe2::QTensorProto &in, Tensor *T) {
+  std::vector<size_t> dim;
+  for (auto d : in.dims()) {
+    if (d == 0) {
+      RETURN_ERR("0 dimemsion qtensor is not supported");
+    }
+    dim.push_back(d);
+  }
+
+  if (in.data_type() == caffe2::TensorProto::UINT8) {
+    T->reset(ElemKind::Int8QTy, dim, in.scale(), in.bias() - OFFSETSHIFT);
+    return llvm::Error::success();
+  } else if (in.data_type() == caffe2::TensorProto::INT32) {
+    T->reset(ElemKind::Int32QTy, dim, in.scale(), in.bias());
+    return llvm::Error::success();
+  } else {
+    RETURN_ERR("Only uint8 and int32 qtensors are supported");
   }
 }
 } // namespace
@@ -1047,38 +1066,59 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
 
   RETURN_ERR(unexpectedNodeErrorMessage(op, "Unsupported operator."));
 }
+template <class TensorProtoType>
+llvm::Error
+Caffe2ModelLoader::loadInputsWithTensorProtoType(const caffe2::NetDef &net,
+                                                 bool loadInputsAsPlaceholders,
+                                                 const TensorProtoType &in) {
+  // Skip static weights
+  if (tensors_.count(in.name())) {
+    return llvm::Error::success();
+  }
+
+  if (loadInputsAsPlaceholders) {
+    Tensor T;
+    RETURN_IF_ERR(setTensorType(in, &T));
+
+    Placeholder *placeholder;
+    ASSIGN_VALUE_OR_RETURN_ERR(
+        placeholder, createAndRegisterPlaceholder(in.name(), &T.getType()));
+    nameToInputVars_.try_emplace(in.name(), placeholder);
+  } else {
+    std::unique_ptr<Tensor> T(new Tensor());
+    RETURN_IF_ERR(setTensorType(in, T.get()));
+    tensors_[in.name()] = std::move(T);
+  }
+  return llvm::Error::success();
+}
 
 llvm::Error Caffe2ModelLoader::loadInputs(const caffe2::NetDef &net,
                                           bool loadInputsAsPlaceholders) {
-  const caffe2::Argument *arg = nullptr;
-  for (auto i = 0, e = net.arg_size(); i < e; ++i) {
+  const caffe2::Argument *arg = nullptr, *qarg = nullptr;
+  for (auto i = 0, e = net.arg_size(); i < e && (!arg || !qarg); ++i) {
     if (net.arg(i).name() == "input_shape_info") {
       arg = &net.arg(i);
-      break;
+    } else if (net.arg(i).name() == "input_qshape_info") {
+      qarg = &net.arg(i);
     }
   }
+
+  // Load all regular tensor input
   if (arg) {
     for (const auto &in : arg->tensors()) {
-      // Skip static weights
-      if (tensors_.count(in.name())) {
-        continue;
-      }
-
-      if (loadInputsAsPlaceholders) {
-        Tensor T;
-        RETURN_IF_ERR(setTensorType(in, &T));
-
-        Placeholder *placeholder;
-        ASSIGN_VALUE_OR_RETURN_ERR(
-            placeholder, createAndRegisterPlaceholder(in.name(), &T.getType()));
-        nameToInputVars_.try_emplace(in.name(), placeholder);
-      } else {
-        std::unique_ptr<Tensor> T(new Tensor());
-        RETURN_IF_ERR(setTensorType(in, T.get()));
-        tensors_[in.name()] = std::move(T);
-      }
+      RETURN_IF_ERR(loadInputsWithTensorProtoType<caffe2::TensorProto>(
+          net, loadInputsAsPlaceholders, in));
     }
   }
+
+  // Load all quantized tensor input
+  if (qarg) {
+    for (const auto &in : qarg->qtensors()) {
+      RETURN_IF_ERR(loadInputsWithTensorProtoType<caffe2::QTensorProto>(
+          net, loadInputsAsPlaceholders, in));
+    }
+  }
+
   return llvm::Error::success();
 }
 
@@ -1179,8 +1219,8 @@ llvm::Error Caffe2ModelLoader::loadWeight(const caffe2::OperatorDef &op) {
       arg {
       name: "values"
       s:
-      "\000\377\152\232\115\072\000\000\200\077\000\377\050\132\215\073\063\063\023\100\000\377\314\063\232\073\000\000\220\100"
-      }
+"\000\377\152\232\115\072\000\000\200\077\000\377\050\132\215\073\063\063\023\100\000\377\314\063\232\073\000\000\220\100"
+  }
      */
 
     for (auto &o : op.output()) {

--- a/lib/Importer/caffe2.proto
+++ b/lib/Importer/caffe2.proto
@@ -163,6 +163,7 @@ message Argument {
   repeated bytes strings = 7;
   repeated TensorProto tensors = 11;
   repeated NetDef nets = 9;
+  repeated QTensorProto qtensors = 12;
 }
 
 // DeviceType that Caffe2 currently supports.


### PR DESCRIPTION
*Description*:
This the onnxifi quantization support in glow side, we accept two quantized tensors, intQ32ty and int8Qty.
*Testing*:
Only internal test is supported now, using resnet50_quantized.
