### PR TITLE
[Tensor] Fix incorrect cast in assert

### DIFF
--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -802,8 +802,8 @@ public:
   typename std::enable_if<std::is_integral<T>::value>::type
   randomize(int low, int high, PseudoRNG &PRNG) {
     assert(low < high && "invalid range");
-    assert(static_cast<ElemTy>(low) >= std::numeric_limits<ElemTy>::lowest() &&
-           static_cast<ElemTy>(high) <= std::numeric_limits<ElemTy>::max() &&
+    assert(low >= std::numeric_limits<ElemTy>::lowest() &&
+           high <= std::numeric_limits<ElemTy>::max() &&
            "Cannot initialize outside range of representable values.");
     std::uniform_int_distribution<int> dist(low, high);
     switch (getElementType()) {


### PR DESCRIPTION
This static_cast shouldn't have been there; it was causing this assert to always pass.