### PR TITLE
[image-classifier] Report time per image rather than per batch

### DIFF
--- a/tools/loader/ImageClassifier.cpp
+++ b/tools/loader/ImageClassifier.cpp
@@ -378,7 +378,8 @@ int main(int argc, char **argv) {
     updateInputPlaceholders(bindings, {inputImagePH}, {&inputImageData});
 
     // Perform the inference execution, updating SMT.
-    loader.runInference(bindings);
+    auto batchSize = inputImageData.dims()[0];
+    loader.runInference(bindings, batchSize);
 
     // Print the top-k results from the output Softmax tensor.
     processAndPrintResults(SMT, loader.getFunction()->getName());

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -343,7 +343,7 @@ void Loader::compile(PlaceholderBindings &bindings) {
   }
 }
 
-void Loader::runInference(PlaceholderBindings &bindings) {
+void Loader::runInference(PlaceholderBindings &bindings, size_t batchSize) {
   assert(!emittingBundle() &&
          "No inference is performed in the bundle generation mode.");
 
@@ -356,9 +356,9 @@ void Loader::runInference(PlaceholderBindings &bindings) {
   }
   if (timeOpt) {
     timer.stopTimer();
-    llvm::outs() << llvm::formatv("Wall time per iteration (s): {0:f4}\n",
+    llvm::outs() << llvm::formatv("Wall time per item (s): {0:f4}\n",
                                   timer.getTotalTime().getWallTime() /
-                                      iterationsOpt);
+                                      iterationsOpt / batchSize);
   }
 }
 

--- a/tools/loader/Loader.h
+++ b/tools/loader/Loader.h
@@ -73,7 +73,7 @@ public:
   /// Runs inference, unless emit bundle mode is enabled. \p bindings
   /// binds specific placeholders to concrete tensors. The concrete
   /// tensors include quantization profile guided information.
-  void runInference(PlaceholderBindings &bindings);
+  void runInference(PlaceholderBindings &bindings, size_t batchSize = 1);
 
   /// Generates and serializes the quantization infos after gathering a profile
   /// by running inference one or more times. \p bindings


### PR DESCRIPTION
*Description*: People often care about # of images/second more than batches/second,
since the batch size is a tunable parameter.
*Testing*: image-classifier
*Documentation*: n/a
