### PR TITLE
Optimize TransposeNode into ReshapeNode when it moves no data.

### DIFF
--- a/docs/Optimizations.md
+++ b/docs/Optimizations.md
@@ -35,7 +35,8 @@ Below you can see the list of currently supported graph optimizations:
   * Optimization of transpose nodes
 
     This optimization combines multiple consecutive transpose nodes
-    into a single node, and also eliminates identity transpose nodes.
+    into a single node, eliminates identity transpose nodes, and optimizes 
+    transpose nodes into reshape nodes when they actually move no data.
 
   * Sinking of transpose operations below other operations
 


### PR DESCRIPTION
*Description*:
`TransposeNode` is optimized into `ReshapeNode` when it moves no data.  This allows for further optimizations. Currently, the algorithm only looks for cases when dimensions of size 1 are shuffled around. 
*Testing*:
GraphOptzTest: Add a testcase that covers `TransposeNode` substitution with `ReshapeNode`.
OperatorTest: Add a testcase that tests if the optimized model is still functionally correct. 
*Documentation*:
Updated Optimizations.md
Fixes #2629 
