### PR TITLE
Provide Backend instead of EE to Quantizer

### DIFF
--- a/examples/fr2en.cpp
+++ b/examples/fr2en.cpp
@@ -173,8 +173,8 @@ struct Model {
 
       // Quantize the graph based on the captured profile.
       auto *Q = glow::quantization::quantizeFunction(
-          EE_, quantization::Schema::Asymmetric, quantizationInfos,
-          ElemKind::Int8QTy, F_, loweredMap_);
+          *EE_.getBackend(), quantization::Schema::Asymmetric,
+          quantizationInfos, ElemKind::Int8QTy, F_, loweredMap_);
 
       // Erase the original function so that the redundant variables that are
       // only referenced by the original function will be removed.

--- a/include/glow/Quantization/Quantization.h
+++ b/include/glow/Quantization/Quantization.h
@@ -26,7 +26,7 @@
 
 namespace glow {
 
-class ExecutionEngine;
+class Backend;
 
 /// Tensor quantization parameters for a given node.
 struct NodeQuantizationInfo {
@@ -103,7 +103,7 @@ std::vector<NodeQuantizationInfo> generateNodeQuantizationInfos(
 /// nodes will be converted to RowwiseQuantizedFullyConnected. \returns a new
 /// quantized function.
 Function *quantizeFunction(
-    const ExecutionEngine &EE, quantization::Schema schema,
+    const Backend &B, quantization::Schema schema,
     llvm::ArrayRef<NodeQuantizationInfo> quantizationInfos,
     ElemKind quantizationPrecision, Function *F,
     const LoweredInfoMap &loweredMap = {}, llvm::StringRef newFuncName = "",

--- a/lib/Onnxifi/InlineOnnxifi.cpp
+++ b/lib/Onnxifi/InlineOnnxifi.cpp
@@ -73,7 +73,7 @@ InlineGraph::initGraph(const void *onnxModel, size_t onnxModelSize,
     std::string oldName = function_->getName();
     function_->setName("old");
     auto *Q = quantization::quantizeFunction(
-        executionEngine_, quantization::Schema::Symmetric, QI,
+        *executionEngine_.getBackend(), quantization::Schema::Symmetric, QI,
         ElemKind::Int8QTy, function_, loweredMap_, oldName, {}, false);
     Q->getParent()->eraseFunction(function_);
     function_ = Q;

--- a/lib/Quantization/CMakeLists.txt
+++ b/lib/Quantization/CMakeLists.txt
@@ -8,6 +8,6 @@ target_link_libraries(Quantization
                       PRIVATE
                         Converter
                         Graph
-                        ExecutionEngine
+                        Backend
                         QuantizationBase
                         LLVMSupport)

--- a/tests/unittests/BackendTestUtils.cpp
+++ b/tests/unittests/BackendTestUtils.cpp
@@ -93,17 +93,17 @@ static void profileAndQuantize(PlaceholderBindings &Ibindings,
     // Lower only as the backends prefer for actually quantizing.
     LoweredInfoMap loweredMapForQuant;
     lower(IF, &loweredMapForQuant, IEE.getBackend());
-    IF = quantization::quantizeFunction(IEE, schema, QI, interpElemKind, IF,
-                                        loweredMapForQuant, "quant", {},
-                                        enableRowwiseQuantization);
+    IF = quantization::quantizeFunction(*IEE.getBackend(), schema, QI,
+                                        interpElemKind, IF, loweredMapForQuant,
+                                        "quant", {}, enableRowwiseQuantization);
   }
   if (isQuantizedElemKind(backendElemKind)) {
     // Lower only as the backends prefer for actually quantizing.
     LoweredInfoMap loweredMapForQuant;
     lower(BF, &loweredMapForQuant, BEE.getBackend());
-    BF = quantization::quantizeFunction(BEE, schema, QI, backendElemKind, BF,
-                                        loweredMapForQuant, "quant", {},
-                                        enableRowwiseQuantization);
+    BF = quantization::quantizeFunction(*BEE.getBackend(), schema, QI,
+                                        backendElemKind, BF, loweredMapForQuant,
+                                        "quant", {}, enableRowwiseQuantization);
   }
 }
 

--- a/tests/unittests/GradCheckTest.cpp
+++ b/tests/unittests/GradCheckTest.cpp
@@ -91,7 +91,7 @@ void performGradCheck(ExecutionEngine &EE, PlaceholderBindings &bindings,
                       float delta, float allowedError) {
   TrainingConfig TC;
 
-  auto &F = *EE.getModule().getFunction("main");
+  auto *F = EE.getModule().getFunction("main");
 
   // Allocate result, inputVar and expVar.
   auto resultTensor = bindings.allocate(result->getPlaceholder());
@@ -103,7 +103,7 @@ void performGradCheck(ExecutionEngine &EE, PlaceholderBindings &bindings,
   size_t sampleCounter = 0;
 
   // Create a function that trains the network.
-  Function *TF = glow::differentiate(&F, TC);
+  Function *TF = glow::differentiate(F, TC);
   EE.compile(CompilationMode::Train, TF);
 
   // The network might have variables, other than inputVar and expVar.
@@ -114,7 +114,7 @@ void performGradCheck(ExecutionEngine &EE, PlaceholderBindings &bindings,
   // Create a version of the network that records the gradients to some side
   // table instead of updating them.
   VariableGradientsList varGrads;
-  Function *recordNet = glow::differentiate(&F, TC, "record", &varGrads);
+  Function *recordNet = glow::differentiate(F, TC, "record", &varGrads);
   allocateGrads(bindings, varGrads);
   EE.compile(CompilationMode::Train, recordNet);
 
@@ -128,7 +128,7 @@ void performGradCheck(ExecutionEngine &EE, PlaceholderBindings &bindings,
            {inputs, outputs});
 
   // Compile the original network in inference mode.
-  EE.compile(CompilationMode::Infer, &F);
+  EE.compile(CompilationMode::Infer, F);
 
   auto analyticalGradsH = gradVarTensor->getHandle();
   auto inputsH = inputs->getHandle<>();

--- a/tests/unittests/HyphenTest.cpp
+++ b/tests/unittests/HyphenTest.cpp
@@ -288,7 +288,8 @@ struct HyphenNetwork {
                            TrainingConfig &TC) {
     // Compilation is destructive because of target-specific lowering.
     // Compile a clone of the inference function.
-    EE.compile(CompilationMode::Infer, infer_->clone(name));
+    auto *CF = infer_->clone(name);
+    EE.compile(CompilationMode::Infer, CF);
 
     auto batchSize = TC.batchSize;
     auto numSamples = inputs.dims()[0];

--- a/tests/unittests/MLTest.cpp
+++ b/tests/unittests/MLTest.cpp
@@ -1077,9 +1077,9 @@ TEST_P(InterpreterAndCPU, convNetForImageRecognition) {
   // Build the new quantized graph.
   LoweredInfoMap loweredMapForQuant;
   lower(F, &loweredMapForQuant, EE.getBackend());
-  Function *QP =
-      quantization::quantizeFunction(EE, quantization::Schema::Asymmetric, QI,
-                                     ElemKind::Int8QTy, F, loweredMapForQuant);
+  Function *QP = quantization::quantizeFunction(
+      *EE.getBackend(), quantization::Schema::Asymmetric, QI, ElemKind::Int8QTy,
+      F, loweredMapForQuant);
 
   EE.compile(CompilationMode::Infer, QP);
 
@@ -1197,9 +1197,9 @@ TEST_P(InterpreterAndCPU, testFindPixelRegression) {
   // Build the new quantized graph.
   LoweredInfoMap loweredMapForQuant;
   lower(F, &loweredMapForQuant, EE.getBackend());
-  Function *QP =
-      quantization::quantizeFunction(EE, quantization::Schema::Asymmetric, QI,
-                                     ElemKind::Int8QTy, F, loweredMapForQuant);
+  Function *QP = quantization::quantizeFunction(
+      *EE.getBackend(), quantization::Schema::Asymmetric, QI, ElemKind::Int8QTy,
+      F, loweredMapForQuant);
 
   EE.compile(CompilationMode::Infer, QP);
 

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -308,8 +308,9 @@ void Loader::compile(PlaceholderBindings &bindings) {
 
     // Quantize the graph based on the captured profile.
     auto *Q = quantization::quantizeFunction(
-        EE_, quantizationSchema, quantizationInfos, quantizationPrecision, F_,
-        loweredMap_, oldName, keepOriginalPrecisionForNodes, enableRowwiseOpt);
+        *EE_.getBackend(), quantizationSchema, quantizationInfos,
+        quantizationPrecision, F_, loweredMap_, oldName,
+        keepOriginalPrecisionForNodes, enableRowwiseOpt);
 
     // Erase the original function so that the redundant variables that are only
     // referenced by the original function will be removed.


### PR DESCRIPTION
This allows the Quantizer to depend on Backend instead of ExecutionEngine.