### PR TITLE
Take NodeValue instead of Node * as arguments for createFullyConnected functions

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -350,8 +350,9 @@ public:
   /// \p W, bias \p B, and \p outTy. If \p input is not 2 dimensional then it is
   /// flattened along \p axis. Note, outputDepth is inferred based on \p outTy.
   FullyConnectedNode *createFullyConnected(llvm::StringRef name,
-                                           NodeValue input, Node *W, Node *B,
-                                           TypeRef outTy, unsigned_t axis = 1);
+                                           NodeValue input, NodeValue W,
+                                           NodeValue B, TypeRef outTy,
+                                           unsigned_t axis = 1);
 
   /// Create a row-wise quantized fully connected node. This node is only used
   /// in quantization. Args \p input and \p B are quantized in regular way, \p W
@@ -360,7 +361,7 @@ public:
   /// \p outTy is a quantized type. if \p transposeWeight is true, \p W need to
   /// be transposed first.
   RowwiseQuantizedFullyConnectedNode *createRowwiseQuantizedFullyConnected(
-      llvm::StringRef name, NodeValue input, Constant *W, Node *B,
+      llvm::StringRef name, NodeValue input, Constant *W, NodeValue B,
       TypeRef outTy, quantization::Schema schema, bool transposeWeight = false);
 
   /// Implement an operation that computes the row-wise dot product of its

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -658,8 +658,8 @@ FullyConnectedNode *Function::createFullyConnected(llvm::StringRef name,
 }
 
 FullyConnectedNode *Function::createFullyConnected(llvm::StringRef name,
-                                                   NodeValue input, Node *W,
-                                                   Node *B, TypeRef outTy,
+                                                   NodeValue input, NodeValue W,
+                                                   NodeValue B, TypeRef outTy,
                                                    unsigned_t axis) {
   assert(outTy->dims().size() == 2 && "Invalid number of dimensions");
   assert(outTy->dims()[0] == input.dims()[0] && "Invalid dimensions");
@@ -676,7 +676,7 @@ FullyConnectedNode *Function::createFullyConnected(llvm::StringRef name,
 RowwiseQuantizedFullyConnectedNode *
 Function::createRowwiseQuantizedFullyConnected(llvm::StringRef name,
                                                NodeValue input, Constant *W,
-                                               Node *B, TypeRef outTy,
+                                               NodeValue B, TypeRef outTy,
                                                quantization::Schema schema,
                                                bool transposeWeight) {
   // Since W is constant, quantize it in compilation time.


### PR DESCRIPTION
We generally take operands as `NodeValue`s in such node creation functions. These functions are pretty old and were never converted to use this style.

