### PR TITLE
[tracing] Add TraceEvents into the Runtime Execution Engine

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -91,6 +91,7 @@ if(GLOW_WITH_CPU)
   target_link_libraries(resnet-runtime
                         PRIVATE
                           Backends
+                          ExecutionContext
                           ExecutionEngine
                           HostManager
                           Partitioner

--- a/include/glow/Backends/QueueBackedDeviceManager.h
+++ b/include/glow/Backends/QueueBackedDeviceManager.h
@@ -72,11 +72,9 @@ public:
                               std::unique_ptr<ExecutionContext> context,
                               ResultCBTy callback) override {
     RunIdentifierTy id = nextIdentifier_++;
-    context->logTraceEvent("DM_enqueue", "B");
     workThread_.submit([this, id, functionName = std::move(functionName),
                         context = std::move(context),
                         callback = std::move(callback)]() mutable {
-      context->logTraceEvent("DM_enqueue", "E");
       runFunctionImpl(id, std::move(functionName), std::move(context),
                       std::move(callback));
     });

--- a/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
@@ -108,10 +108,11 @@ void InterpreterDeviceManager::evictNetworkImpl(std::string functionName,
 void InterpreterDeviceManager::runFunctionImpl(
     RunIdentifierTy id, std::string function,
     std::unique_ptr<ExecutionContext> context, ResultCBTy resultCB) {
-  context->logTraceEvent("DM_run", "B");
+  TRACE_EVENT_BEGIN(context, "DM_run");
   auto funcIt = functions_.find(function);
   if (funcIt == functions_.end()) {
-    context->logTraceEvent("DM_run", "E", {{"reason", "function not found"}});
+    context->logTraceEvent("DM_run", TraceEvent::EndType,
+                           {{"reason", "function not found"}});
     resultCB(id,
              MAKE_ERR(GlowErr::ErrorCode::RUNTIME_NET_NOT_FOUND,
                       llvm::formatv("Function {0} not found", function).str()),
@@ -125,7 +126,7 @@ void InterpreterDeviceManager::runFunctionImpl(
   func->execute(context.get());
 
   // End the TraceEvent early to avoid time in the CB.
-  context->logTraceEvent("DM_run", "E");
+  TRACE_EVENT_END(context, "DM_run");
 
   // Fire the resultCB.
   resultCB(id, llvm::Error::success(), std::move(context));

--- a/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
@@ -283,10 +283,11 @@ void OpenCLDeviceManager::returnRunCommandQueue(cl_command_queue commands) {
 void OpenCLDeviceManager::runFunctionImpl(
     RunIdentifierTy id, std::string function,
     std::unique_ptr<ExecutionContext> context, ResultCBTy resultCB) {
-  context->logTraceEvent("DM_run", "B");
+  TRACE_EVENT_BEGIN(context, "DM_run");
   auto funcIt = functions_.find(function);
   if (funcIt == functions_.end()) {
-    context->logTraceEvent("DM_run", "E", {{"reason", "function not found"}});
+    context->logTraceEvent("DM_run", TraceEvent::EndType,
+                           {{"reason", "function not found"}});
     resultCB(id,
              MAKE_ERR(GlowErr::ErrorCode::RUNTIME_NET_NOT_FOUND,
                       llvm::formatv("Function {} not found", function).str()),
@@ -312,7 +313,7 @@ void OpenCLDeviceManager::runFunctionImpl(
   returnRunCommandQueue(commands);
 
   // End the TraceEvent early to avoid time in the CB.
-  context->logTraceEvent("DM_run", "E");
+  TRACE_EVENT_END(context, "DM_run");
 
   // Fire the resultCB.
   resultCB(id, llvm::Error::success(), std::move(context));

--- a/lib/Runtime/Executor/CMakeLists.txt
+++ b/lib/Runtime/Executor/CMakeLists.txt
@@ -5,5 +5,6 @@ add_library(Executor
 target_link_libraries(Executor
                       PUBLIC
                         ThreadPool
-	              PRIVATE
-		        Graph)
+                      PRIVATE
+                        ExecutionContext
+                        Graph)

--- a/lib/Runtime/Executor/ThreadPoolExecutor.h
+++ b/lib/Runtime/Executor/ThreadPoolExecutor.h
@@ -89,6 +89,9 @@ public:
   /// getUniqueResultPlaceholderBindingsPtr().
   void insertIntoResultCtx(Placeholder *P, Tensor &&T);
 
+  /// Move all events from the provided vector into the top level resultContxt.
+  void insertIntoTraceContext(std::vector<TraceEvent> &events);
+
   /// \returns a unique pointer to the result bindings. This should not be
   /// called at the same time as getRawResultPlaceholderBindingsPtr() or
   /// insertIntoResultCtx().
@@ -155,7 +158,7 @@ private:
   /// ExecutionContext for the run corresponding to \p executionState.
   void
   propagateOutputPlaceholders(std::shared_ptr<ExecutionState> executionState,
-                              std::unique_ptr<ExecutionContext> ctx);
+                              PlaceholderBindings *bindings);
 
   /// Propagate Placeholders needed by \p node from \p ctx into
   /// the ExecutionContext for \p node within the run corresponding to \p

--- a/tests/examples_tests/resnet-runtime-test.sh
+++ b/tests/examples_tests/resnet-runtime-test.sh
@@ -20,4 +20,4 @@ set -euxo pipefail
 # cat_285.png is wrongly classified as 281
 # CHECK: dog_207\.png: 207$
 cd $MODELS_DIR
-$BIN/resnet-runtime $IMAGES_DIR/imagenet --numDevices=1
+$BIN/resnet-runtime $IMAGES_DIR/imagenet --num-devices=1


### PR DESCRIPTION
*Description*: Adds some simple events in the Executor and the HostManager and adds the plumbing to enable tracing and retrieve TraceEvents (auto instrumentation is not yet supported).

Also fix a couple bugs, particularly we now export timestamps in the right domain. Next steps are to improve the process and thread labels and look at showing thread movement flow.

We treat the whole runtime as a monolithic "thread" even though it has several. Uncertain if we get much from modeling internal threads in the runtime here, open to opinions.

*Testing*: unittests with asan & the upgraded resnet-runtime example 
*Documentation*:
Here's the output of the resnet-runtime example with tracing enabled (6 CPU devices, 100 images):
![image](https://user-images.githubusercontent.com/701287/55439640-1f2d7080-555a-11e9-8c81-5f344074bb60.png)
Thread #50 is a placeholder for the Runtime threads in this example. You can see it is busy on and off in the first 600ms as images are loaded and added to the HostManager, then it does small amounts of work whenever a device finishes an inference. Zooming in a bit:
![image](https://user-images.githubusercontent.com/701287/55439743-687dc000-555a-11e9-9b62-0cb29dfdd520.png)
This shows a couple of interesting info about the runtime:
* We add about 400 microseconds latency from the point where we have "loaded" inference results to the point where the HostManager::runFunction callback is triggered. The majority of the time here is in freeing the weights & activation buffers, so pooling could pay off here. At least we could do the free after triggering the callback to the Executor. (OK so this is the CPU device and it's probably not worth optimizing this, but still, interesting).
* There is about a 20-30 microsecond gap where the DeviceManager is not working on an inference, this is the cost of submitting a task to the Executor's threadpool (the lowest green bar). This is actually time cost on the DeviceManager thread while moving the work to an Executor thread, but we're not using the kind of TraceEvents that can move between threads - will look into it.
