### PR TITLE
Added openCLDeviceBindings and moved OpenCLCompiledFunction to use them.

### DIFF
--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -165,11 +165,8 @@ TEST_P(BackendTest, debugPrint) {
   IRBuilder(IR.get()).createDebugPrintInst("print", *IR->getWeights().begin());
 
   auto function = backend->compileIR(std::move(IR));
-  function->setupRuns();
-  function->beforeRun(*ctx->getPlaceholderBindings());
-  function->execute(ctx.get());
-  function->afterRun(*ctx->getPlaceholderBindings());
-  function->tearDownRuns();
+  EE_.insertCompiledFunction("main", std::move(function));
+  EE_.run(*ctx.get());
 }
 
 /// Test the compile method on the backend completes without error when


### PR DESCRIPTION
*Description*: Added support for DeviceBindings to the OpenCL implementation and migrated to use them for memory buffers and CL device information. This moves allocation out of the execute method. The compiledFunction is still not thread safe, it currently uses member variables to pass state it will require this to change #2651 .
*Testing*: ninja test
*Documentation*: NA