### PR TITLE
[tracing] Convert all TraceEvent timestamps to microseconds.

### DIFF
--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -1624,7 +1624,7 @@ void libjit_write_timestamp(uint64_t *tensor, size_t offset) {
   // We are using C++ timer here to a avoid issues with gettimeofday
   // Issue #2397 covers migrating this to a libc approach but if you have issues
   // with a lack of C++ symbols at runtime check there first.
-  uint64_t ts = std::chrono::duration_cast<std::chrono::milliseconds>(
+  uint64_t ts = std::chrono::duration_cast<std::chrono::microseconds>(
                     std::chrono::steady_clock::now().time_since_epoch())
                     .count();
   memcpy(tensor + offset, &ts, sizeof(uint64_t));

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -2675,7 +2675,7 @@ void BoundInterpreterFunction::fwdTraceEventInst(const TraceEventInst *I) {
   auto T = getTensor(I->getData());
   auto IH = T->getHandle<int64_t>();
   size_t index = I->getIndex();
-  IH.raw(index) = std::chrono::duration_cast<std::chrono::milliseconds>(
+  IH.raw(index) = std::chrono::duration_cast<std::chrono::microseconds>(
                       std::chrono::steady_clock::now().time_since_epoch())
                       .count();
 }

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -1620,13 +1620,13 @@ void OpenCLFunction::translateTraceEvents(ExecutionContext *context) const {
                           ->getHandle<int64_t>();
         const TraceInfo::Event *ev = it->second.second;
 
-        handle.at({ev->index, 0}) = time_end / 1000000;
-        traceEvents.push_back({ev->name, time_end / 1000000, ev->type, tid});
+        handle.at({ev->index, 0}) = time_end / 1000;
+        traceEvents.push_back({ev->name, time_end / 1000, ev->type, tid});
       }
     } else {
       traceEvents.push_back(
-          {name, time_start / 1000000, "B", tid, {{"type", type}}});
-      traceEvents.push_back({name, time_end / 1000000, "E", tid});
+          {name, time_start / 1000, "B", tid, {{"type", type}}});
+      traceEvents.push_back({name, time_end / 1000, "E", tid});
     }
 
     if (clDoProfile) {


### PR DESCRIPTION
*Description*: The TraceEvent format expects usec not msec, adjusting the domain of auto instrumentation timestamps.
*Testing*: sanity unittests & the tracing-compare example
*Documentation*: