### PR TITLE
Commonalize DeviceManagerConfig and DeviceConfig

### DIFF
--- a/examples/resnet-runtime.cpp
+++ b/examples/resnet-runtime.cpp
@@ -103,16 +103,14 @@ int main(int argc, char **argv) {
   llvm::outs() << "Initializing " << numDevices
                << " CPU Devices on HostManager.\n";
 
-  std::vector<DeviceManagerConfig> configs;
+  std::vector<std::unique_ptr<DeviceConfig>> configs;
   for (unsigned int i = 0; i < numDevices; ++i) {
-    auto config = DeviceManagerConfig();
-    config.deviceConfig = nullptr;
-    config.backendKind = BackendKind::CPU;
+    auto config = llvm::make_unique<DeviceConfig>(BackendKind::CPU);
     configs.push_back(std::move(config));
   }
 
   std::unique_ptr<HostManager> hostManager =
-      llvm::make_unique<HostManager>(configs);
+      llvm::make_unique<HostManager>(std::move(configs));
 
   // Load model, create a context, and add to HostManager.
 

--- a/include/glow/Backends/Backend.h
+++ b/include/glow/Backends/Backend.h
@@ -47,6 +47,8 @@ public:
   /// \returns the kind of Backend this is.
   virtual BackendKind getBackendKind() const = 0;
 
+  virtual std::string getBackendName() const = 0;
+
   /// Generate code for a vector of functions, \p functions. All compilations
   /// use the same settings provided by \p opts. This allows the compiler to
   /// support shared constants between functions.

--- a/include/glow/Runtime/HostManager/HostManager.h
+++ b/include/glow/Runtime/HostManager/HostManager.h
@@ -29,11 +29,6 @@
 namespace glow {
 namespace runtime {
 
-struct DeviceManagerConfig {
-  std::unique_ptr<DeviceConfig> deviceConfig;
-  BackendKind backendKind;
-};
-
 class Executor;
 
 class Provisioner;
@@ -119,11 +114,11 @@ public:
   RunIdentifierTy runNetwork(llvm::StringRef networkName,
                              std::unique_ptr<ExecutionContext> context,
                              ResultCBTy callback);
-  HostManager(const std::vector<DeviceManagerConfig> &configs);
+  HostManager(std::vector<std::unique_ptr<DeviceConfig>> configs);
 
   /// Initialize the HostManager with the given \p configs creating one
   /// DeviceManager for each config listed.
-  llvm::Error init(const std::vector<DeviceManagerConfig> &configs);
+  llvm::Error init(std::vector<std::unique_ptr<DeviceConfig>> configs);
 
   ~HostManager();
 };

--- a/include/glow/Runtime/RuntimeTypes.h
+++ b/include/glow/Runtime/RuntimeTypes.h
@@ -103,12 +103,18 @@ using DAGListTy = std::vector<DAG>;
 /// member variable to it's correct BackendKind.
 class DeviceConfig {
   const BackendKind backendKind_;
-
-protected:
-  DeviceConfig(BackendKind kind) : backendKind_(kind) {}
+  std::string name_;
 
 public:
+  DeviceConfig(BackendKind kind) : backendKind_(kind) {}
+  DeviceConfig(BackendKind kind, std::string name)
+      : backendKind_(kind), name_(name) {}
+
   BackendKind getBackendKind() { return backendKind_; }
+
+  llvm::StringRef getName() { return name_; }
+  bool hasName() { return name_ != ""; }
+  void setName(llvm::StringRef name) { name_ = name; }
 };
 
 } // namespace runtime

--- a/lib/Backends/CPU/CPUBackend.h
+++ b/lib/Backends/CPU/CPUBackend.h
@@ -37,6 +37,8 @@ public:
   BackendKind getBackendKind() const override { return BackendKind::CPU; }
   virtual ~CPUBackend() override = default;
 
+  std::string getBackendName() const override { return "CPU"; }
+
   bool transformPostLowering(Function *F,
                              const CompilationOptions &opts) const override;
 

--- a/lib/Backends/Habana/Habana.h
+++ b/lib/Backends/Habana/Habana.h
@@ -151,6 +151,8 @@ public:
 
   BackendKind getBackendKind() const override { return BackendKind::Habana; }
 
+  std::string getBackendName() const override { return "Habana"; }
+
   std::unique_ptr<CompiledFunction>
   compile(Function *F, const CompilationOptions &opts) const override;
 

--- a/lib/Backends/Interpreter/Interpreter.h
+++ b/lib/Backends/Interpreter/Interpreter.h
@@ -38,6 +38,8 @@ public:
     return BackendKind::Interpreter;
   }
 
+  std::string getBackendName() const override { return "Interpreter"; }
+
   std::unique_ptr<CompiledFunction>
   compileIR(std::unique_ptr<IRFunction> IR) const override;
 

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -184,6 +184,8 @@ public:
 
   BackendKind getBackendKind() const override { return BackendKind::OpenCL; }
 
+  std::string getBackendName() const override { return "OpenCL"; }
+
   std::unique_ptr<CompiledFunction>
   compileIR(std::unique_ptr<IRFunction> IR) const override;
 

--- a/lib/Onnxifi/HostManagerOnnxifi.cpp
+++ b/lib/Onnxifi/HostManagerOnnxifi.cpp
@@ -21,12 +21,11 @@ namespace onnxifi {
 
 std::unique_ptr<runtime::HostManager>
 HostManagerBackendId::createHostManager(glow::BackendKind kind) {
-  std::vector<runtime::DeviceManagerConfig> configs;
-  runtime::DeviceManagerConfig config;
-  config.deviceConfig = nullptr;
-  config.backendKind = kind;
+  std::vector<std::unique_ptr<runtime::DeviceConfig>> configs;
+
+  auto config = llvm::make_unique<runtime::DeviceConfig>(kind);
   configs.push_back(std::move(config));
-  return llvm::make_unique<runtime::HostManager>(configs);
+  return llvm::make_unique<runtime::HostManager>(std::move(configs));
 }
 
 void HostManagerBackendId::runNetwork(const Graph *graph,

--- a/tests/unittests/BackendCorrectnessTest.cpp
+++ b/tests/unittests/BackendCorrectnessTest.cpp
@@ -177,6 +177,7 @@ public:
   }
 
   BackendKind getBackendKind() const override { return BackendKind::CPU; }
+  std::string getBackendName() const override { return "MockCPUBackend"; }
 
   std::unique_ptr<CompiledFunction>
   compile(Function *F, const CompilationOptions &opts) const override {

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -110,6 +110,8 @@ class MockBackend : public Backend {
     return BackendKind::Interpreter;
   }
 
+  std::string getBackendName() const override { return "MockBackend"; }
+
   std::unique_ptr<CompiledFunction>
   compile(Function *F, const CompilationOptions &) const override {
     return llvm::make_unique<MockFunction>(runtime::RuntimeBundle::create(*F));
@@ -140,6 +142,8 @@ class MockBackendCustomIRGen : public Backend {
   BackendKind getBackendKind() const override {
     return BackendKind::Interpreter;
   }
+
+  std::string getBackendName() const override { return "MockBackend"; }
 
   std::unique_ptr<CompiledFunction>
   compile(Function *F, const CompilationOptions &) const override {

--- a/tests/unittests/HostManagerTest.cpp
+++ b/tests/unittests/HostManagerTest.cpp
@@ -41,13 +41,11 @@ std::unique_ptr<Module> setupModule(unsigned functionCount) {
 }
 
 std::unique_ptr<HostManager> createHostManager(BackendKind kind) {
-  std::vector<DeviceManagerConfig> configs;
-  auto config = DeviceManagerConfig();
-  config.deviceConfig = nullptr;
-  config.backendKind = kind;
+  std::vector<std::unique_ptr<DeviceConfig>> configs;
+  auto config = llvm::make_unique<DeviceConfig>(kind);
   configs.push_back(std::move(config));
   std::unique_ptr<HostManager> hostManager =
-      llvm::make_unique<HostManager>(configs);
+      llvm::make_unique<HostManager>(std::move(configs));
   return hostManager;
 }
 

--- a/tests/unittests/QuantizationTest.cpp
+++ b/tests/unittests/QuantizationTest.cpp
@@ -76,6 +76,8 @@ public:
     return BackendKind::Interpreter;
   }
 
+  std::string getBackendName() const override { return "MockQuantBackend"; }
+
   std::unique_ptr<CompiledFunction>
   compile(Function *F, const CompilationOptions &opts) const override {
     return backend_->compile(F, opts);


### PR DESCRIPTION
*Description*: We currently have two structs for configuring devices: DeviceManagerConfig (used by the HostManager) and DeviceConfig (used by the DeviceManager). This is unnecessary and confusing, so removing DeviceManagerConfig and plumbing DeviceConfig all the way through.

Also, added a `getBackendName()` to get a string name for a device which can be used for logging and, in the next PR, used to generate the trace log.
*Testing*: unit tests, asan, etc
*Documentation*: This is a breaking change for Backends which need to implement the `getBackendName()` method.
