### PR TITLE
[optimizer] Remove optimize pool optimization.

### DIFF
--- a/tests/unittests/GraphOptzTest.cpp
+++ b/tests/unittests/GraphOptzTest.cpp
@@ -1159,61 +1159,6 @@ TEST_F(GraphOptz, sinkTransposeBelowPad) {
   EXPECT_EQ(F_->getNodes().size(), 3);
 }
 
-TEST_F(GraphOptz, poolBelowReluSwapped) {
-  Node *A =
-      mod_.createPlaceholder(ElemKind::FloatTy, {1, 5, 10, 15}, "input", false);
-  Node *R = F_->createRELU("relu", A);
-  Node *PL = F_->createMaxPool("pool", R, 1, 10, 20);
-  Node *O = F_->createSave("ret", PL);
-
-  EXPECT_EQ(F_->getNodes().size(), 3);
-
-  ::glow::optimize(F_, CompilationMode::Infer);
-
-  // Expecting RELU->Output rather than Pool->Output.
-  EXPECT_TRUE(llvm::isa<SaveNode>(O));
-  EXPECT_TRUE(llvm::isa<ReluNode>(llvm::dyn_cast<SaveNode>(O)->getInput()));
-
-  EXPECT_EQ(F_->getNodes().size(), 3);
-}
-
-TEST_F(GraphOptz, poolBelowReluNotSwappedIfModeNotMax) {
-  Node *A =
-      mod_.createPlaceholder(ElemKind::FloatTy, {1, 5, 10, 15}, "input", false);
-  Node *R = F_->createRELU("relu", A);
-  Node *PL = F_->createAvgPool("pool", R, 1, 10, 20);
-  Node *O = F_->createSave("ret", PL);
-
-  EXPECT_EQ(F_->getNodes().size(), 3);
-
-  ::glow::optimize(F_, CompilationMode::Infer);
-
-  // Expecting Pool->Output (no swap).
-  EXPECT_TRUE(llvm::isa<SaveNode>(O));
-  EXPECT_TRUE(llvm::isa<AvgPoolNode>(llvm::dyn_cast<SaveNode>(O)->getInput()));
-
-  EXPECT_EQ(F_->getNodes().size(), 3);
-}
-
-TEST_F(GraphOptz, poolBelowReluNotSwappedIfNotSingleUse) {
-  Node *A =
-      mod_.createPlaceholder(ElemKind::FloatTy, {1, 5, 10, 15}, "input", false);
-  Node *R = F_->createRELU("relu", A);
-  Node *PL = F_->createMaxPool("pool", R, 1, 10, 20);
-  Node *O = F_->createSave("ret", PL);
-  F_->createSave("ret", R);
-
-  EXPECT_EQ(F_->getNodes().size(), 4);
-
-  ::glow::optimize(F_, CompilationMode::Infer);
-
-  // Expecting Pool->Output (no swap).
-  EXPECT_TRUE(llvm::isa<SaveNode>(O));
-  EXPECT_TRUE(llvm::isa<MaxPoolNode>(llvm::dyn_cast<SaveNode>(O)->getInput()));
-
-  EXPECT_EQ(F_->getNodes().size(), 4);
-}
-
 /// A helper predicate to check if the provided node has the same address as a
 /// pre-defined address provided in constructor. This is useful if you need to
 /// check that a given node is still in the graph. In general, it is not safe to


### PR DESCRIPTION
*Description*:
This might be a controversial change but before https://github.com/pytorch/glow/issues/1641 in place there is no easy way to disable opts per backend.
Many HW backends would benefit from disabling this optimization.

Pros:
1) Sinking Relu below MaxPool might only have benefits in case of buffer sharing is done which potentially have some memory benefit. (We could pass shouldShareBuffers in optimization pass but I'd like to avoid it).

Cons:
1) This eliminates fusion opportunities with convolution as it's typical sequence of conv->relu->pool.
Many HW has fusion of conv + relu.
2) Swapping ops has negative effect on quantization accuracy.

Ideal scenario is having per backend optimizations as described in the https://github.com/pytorch/glow/issues/1641.

*Testing*:
Unit tests.

*Documentation*:
n/a