### PR TITLE
[LLVMIRCodeGen] Support using an external LLVM compiler for converting LLVM bitcode files into object files

### DIFF
--- a/lib/LLVMIRCodeGen/CommandLine.cpp
+++ b/lib/LLVMIRCodeGen/CommandLine.cpp
@@ -32,3 +32,13 @@ llvm::cl::list<std::string>
     llvmTargetFeatures("target-feature",
                        llvm::cl::desc("LLVM target/CPU features to be used"),
                        llvm::cl::CommaSeparated, llvm::cl::ZeroOrMore);
+
+llvm::cl::opt<std::string>
+    llvmCompiler("llvm-compiler",
+                 llvm::cl::desc("External LLVM compiler (e.g. llc) to use for "
+                                "compiling LLVM bitcode into machine code"));
+
+llvm::cl::list<std::string> llvmCompilerOptions(
+    "llvm-compiler-opt",
+    llvm::cl::desc("Options to pass to the external LLVM compiler"),
+    llvm::cl::ZeroOrMore);

--- a/lib/LLVMIRCodeGen/CommandLine.h
+++ b/lib/LLVMIRCodeGen/CommandLine.h
@@ -35,5 +35,10 @@ extern llvm::cl::opt<std::string> llvmCPU;
 /// be comma-separated and prefixed with +.
 /// Used as  -target-feature=+featureA,+featureB.
 extern llvm::cl::list<std::string> llvmTargetFeatures;
+//// External LLVM compiler (e.g. llc) to use for compiling LLVM bitcode into
+/// machine code.
+extern llvm::cl::opt<std::string> llvmCompiler;
+/// Set of options to pass to the external LLVM compiler.
+extern llvm::cl::list<std::string> llvmCompilerOptions;
 
 #endif // GLOW_LLVMIRCODEGEN_COMMANDLINE_H


### PR DESCRIPTION
Add new command-line options:
*  `-llvm-compiler` specifies the which compiler binary should be run (path)
* `-llvm-compiler-opt` specify options to be passed to the external compiler.

Testing:

```
#Compile ResNet50 bundle using an external LLVM compiler.
bin/image-classifier tests/images/imagenet/*.png  -image-mode=0to1 \
-m=resnet50 -model-input-name=gpu_0/data -emit-bundle . \
-cpu -llvm-compiler /usr/local/opt/llvm/bin/llc
```

Fixes #2636