### PR TITLE
Share HostManagers in onnxifi BackendIds

### DIFF
--- a/lib/Onnxifi/GlowOnnxifiManager.cpp
+++ b/lib/Onnxifi/GlowOnnxifiManager.cpp
@@ -33,7 +33,7 @@ BackendIdPtr GlowOnnxifiManager::createBackendId(glow::BackendKind kind,
   if (forQuantization) {
     backendId = new onnxifi::BackendId(kind, useOnnx);
   } else {
-    auto *hostManager = getOrCreateHostManager(kind);
+    auto hostManager = getOrCreateHostManager(kind);
     backendId = new onnxifi::HostManagerBackendId(hostManager, kind, useOnnx);
   }
 
@@ -93,21 +93,23 @@ GlowOnnxifiManager::createGraph(BackendPtr backend,
   return graph;
 }
 
-runtime::HostManager *
+std::shared_ptr<runtime::HostManager>
 GlowOnnxifiManager::getOrCreateHostManager(BackendKind backendKind) {
+  std::shared_ptr<runtime::HostManager> hostManager;
+
   auto it = hostManagers_.find(backendKind);
 
-  // If a HostManager doesn't exist yet for this BackendKind then create one
-  if (it == hostManagers_.end()) {
-    auto newHostManager =
-        onnxifi::HostManagerBackendId::createHostManager(backendKind);
-    assert(newHostManager != nullptr);
-    auto ptr = newHostManager.get();
-    hostManagers_[backendKind] = std::move(newHostManager);
-    return ptr;
+  if (it != hostManagers_.end()) {
+    hostManager = it->second.lock();
   }
 
-  return it->second.get();
+  if (!hostManager) {
+    hostManager = onnxifi::HostManagerBackendId::createHostManager(backendKind);
+    assert(hostManager);
+    hostManagers_[backendKind] = hostManager;
+  }
+
+  return hostManager;
 }
 
 bool GlowOnnxifiManager::isValid(BackendIdPtr backendId) const {

--- a/lib/Onnxifi/GlowOnnxifiManager.h
+++ b/lib/Onnxifi/GlowOnnxifiManager.h
@@ -102,7 +102,8 @@ private:
   /// an existing HostManager for the backendKind if one exists.
   /// NOTE: This method is not thread safe, the caller should be holding the
   /// mutex m_ when calling it!
-  runtime::HostManager *getOrCreateHostManager(BackendKind backendKind);
+  std::shared_ptr<runtime::HostManager>
+  getOrCreateHostManager(BackendKind backendKind);
 
   /// The set of all valid glow BackendIds.
   std::unordered_set<BackendIdPtr> backendIds_;
@@ -116,8 +117,11 @@ private:
   /// The set of all valid glow Graphs.
   std::unordered_set<GraphPtr> graphs_;
 
-  /// Map from BackendKind to HostManager managing devices of that kind.
-  std::map<BackendKind, std::unique_ptr<runtime::HostManager>> hostManagers_;
+  /// Map from BackendKind to HostManager managing devices of that kind that is
+  /// shared by all BackendIds using that HostManager. HostManager is stored as
+  /// weak_ptr here so that it will be destructed when the last BackendId using
+  /// it is destroyed not when this singleton is destroyed.
+  std::map<BackendKind, std::weak_ptr<runtime::HostManager>> hostManagers_;
 
   /// Mutex that protects all members of GlowOnnxifiManager.
   /// TODO: can use one mutex per set if performance becomes an issue.

--- a/lib/Onnxifi/HostManagerOnnxifi.h
+++ b/lib/Onnxifi/HostManagerOnnxifi.h
@@ -28,7 +28,7 @@ public:
   /// Create Glow ONNXIFI backend identifier using HostManager with the
   /// given Glow backend \p kind, whether to use onnx or caffe2 for models
   /// (\p useOnnx).
-  HostManagerBackendId(runtime::HostManager *hostManager,
+  HostManagerBackendId(std::shared_ptr<runtime::HostManager> hostManager,
                        glow::BackendKind kind, bool useOnnx)
       : BackendId(kind, useOnnx), hostManager_(hostManager) {}
 
@@ -45,7 +45,7 @@ public:
   createHostManager(glow::BackendKind kind);
 
 private:
-  runtime::HostManager *hostManager_;
+  std::shared_ptr<runtime::HostManager> hostManager_;
 };
 
 class HostManagerGraph : public Graph {


### PR DESCRIPTION
*Description*:
This is important for avoiding static destruction order fiasco between DeviceManagers owned by HostManager and device api. It also ensures that HostManagers don't outlive their usefulness and are destroyed when onnxifi destroys all BackendIds.

*Testing*:
synced to internal, all tests pass

*Documentation*:
updated comments