### PR TITLE
[NFC] Use llvm-link from the given LLVM build directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,7 @@ endif()
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
+set(LLVM_BIN_DIR ${LLVM_DIR}/../../../bin)
 
 if(NOT EXISTS "${GLOW_SOURCE_DIR}/tests/googlebenchmark/src")
   message(FATAL_ERROR "No googlebenchmark git submodule. Run: git submodule update --init --recursive")

--- a/lib/Backends/CPU/CMakeLists.txt
+++ b/lib/Backends/CPU/CMakeLists.txt
@@ -4,11 +4,7 @@ else()
   find_program(CLANG_BIN clang++)
 endif()
 
-find_program(LLVM_LINK_BIN
-             NAMES
-               llvm-link-7
-               llvm-link-6.0
-               llvm-link)
+set(LLVM_LINK_BIN ${LLVM_BIN_DIR}/llvm-link)
 
 set(CMAKE_LLIR_CREATE_SHARED_LIBRARY "${LLVM_LINK_BIN} -o <TARGET> <OBJECTS>")
 set(CMAKE_LLIR_CREATE_SHARED_MODULE "${LLVM_LINK_BIN} -o <TARGET> <OBJECTS>")


### PR DESCRIPTION
This helps to eliminate mismatch between given LLVM's linker and system's standard llvm-link