### PR TITLE
For Transpose2Reshape optimization make sure DCE is executed.

### DIFF
--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -2464,6 +2464,8 @@ void glow::optimize(Function *F, const CompilationOptions &opts) {
   // Transposes that don't move data are optimized into Reshapes, which enables
   // further optimizations.
   optimizeTransposeIntoReshape(F);
+  // Need to remove old uses that would prohibit Reshape(Constant) optimization.
+  DCE(F);
 
   // Reshapes and transposes can prevent other optimizations from triggering,
   // so try to optimize them out first.


### PR DESCRIPTION
_Description:_
#2630 is incomplete as it doesn't execute DCE after the optimization. DCE is needed to remove old uses, that prohibit other optimizations, e.g. Reshape(Constant) one.
_Testing:_
GraphOptzTest: Add a testcase that tests for Reshape(Constant) w/  Transpose2Reshape optimizations, effectively failing on the current code base.
Fixes #2629 
