### PR TITLE
Add ConvRelu shape/input info in Caffe2ModelLoader.cpp

### DIFF
--- a/tests/models/caffe2Models/convrelu_init_net.pbtxt
+++ b/tests/models/caffe2Models/convrelu_init_net.pbtxt
@@ -1,0 +1,32 @@
+name: "init"
+op {
+  output: "conv_w"
+  type: "GivenTensorFill"
+  arg {
+    name: "shape"
+    ints: 1
+    ints: 1
+    ints: 2
+    ints: 2
+  }
+  arg {
+    name: "values"
+    floats: 1.0
+    floats: 1.0
+    floats: 1.0
+    floats: 1.0
+  }
+}
+op {
+  output: "conv_b"
+  type: "GivenTensorFill"
+  arg {
+    name: "shape"
+    ints: 1
+  }
+  arg {
+    name: "values"
+    floats: 2.0
+  }
+}
+

--- a/tests/models/caffe2Models/convrelu_pred_net.pbtxt
+++ b/tests/models/caffe2Models/convrelu_pred_net.pbtxt
@@ -1,0 +1,25 @@
+name: "conv_test"
+op {
+  input: "gpu_0/data_0"
+  input: "conv_w"
+  input: "conv_b"
+  output: "conv_out"
+  type: "ConvRelu"
+  arg {
+    name: "kernel"
+    i: 2
+  }
+  arg {
+    name: "stride"
+    i: 1
+  }
+  arg {
+    name: "group"
+    i: 1
+  }
+  arg {
+    name: "pad"
+    i: 1
+  }
+}
+external_output: "conv_out"


### PR DESCRIPTION
*Description*:
The ConvRelu is same to Conv or Int8Conv, so just use it directly.

