### PR TITLE
Replace Quantized Log/Sigmoid/Tanh by IntLookupTable in Quantizer

### DIFF
--- a/include/glow/Graph/Node.h
+++ b/include/glow/Graph/Node.h
@@ -230,6 +230,12 @@ public:
     }
   }
 
+  /// \returns the input types.
+  llvm::ArrayRef<TypeRef> getInTypes() { return inTypes_; }
+
+  /// \returns the output types.
+  llvm::ArrayRef<TypeRef> getOutTypes() { return outTypes_; }
+
   /// \returns the input type located at \p idx.
   const TypeRef getInTy(size_t idx) const {
     assert(idx < inTypes_.size());

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -49,12 +49,6 @@ bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
   case Kinded::Kind::MulNodeKind:
   case Kinded::Kind::MaxNodeKind:
   case Kinded::Kind::MinNodeKind:
-    // Note: Int8QTy Log, Tanh, and Sigmoid are lowered into a lookup
-    // table. However, we do not lower them until after they're quantized. So we
-    // need to return here that they are supported as Int8QTy.
-  case Kinded::Kind::LogNodeKind:
-  case Kinded::Kind::TanhNodeKind:
-  case Kinded::Kind::SigmoidNodeKind:
   case Kinded::Kind::CPUMaxSplatNodeKind:
   case Kinded::Kind::BatchedReduceAddNodeKind:
   case Kinded::Kind::MatMulNodeKind:
@@ -129,6 +123,9 @@ bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
   case Kinded::Kind::CPUConvDKKC8NodeKind:
   case Kinded::Kind::LocalResponseNormalizationNodeKind:
   case Kinded::Kind::LocalResponseNormalizationGradNodeKind:
+  case Kinded::Kind::LogNodeKind:
+  case Kinded::Kind::TanhNodeKind:
+  case Kinded::Kind::SigmoidNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind({ElemKind::FloatTy});
 
   case Kinded::Kind::ConvolutionNodeKind:

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -76,17 +76,14 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
   case Kinded::Kind::MaxPoolNodeKind:
   case Kinded::Kind::MatMulNodeKind:
   case Kinded::Kind::BatchedReduceAddNodeKind:
-    // Note: Int8QTy Log, Tanh, and Sigmoid are lowered into a lookup
-    // table. However, we do not lower them until after they're quantized. So we
-    // need to return here that they are supported as Int8QTy.
-  case Kinded::Kind::LogNodeKind:
-  case Kinded::Kind::TanhNodeKind:
-  case Kinded::Kind::SigmoidNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
         {ElemKind::FloatTy, ElemKind::Float16Ty, ElemKind::Int8QTy});
 
   case Kinded::Kind::PowNodeKind:
   case Kinded::Kind::LocalResponseNormalizationNodeKind:
+  case Kinded::Kind::LogNodeKind:
+  case Kinded::Kind::TanhNodeKind:
+  case Kinded::Kind::SigmoidNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
         {ElemKind::FloatTy, ElemKind::Float16Ty});
 

--- a/lib/Optimizer/Lower.cpp
+++ b/lib/Optimizer/Lower.cpp
@@ -19,8 +19,6 @@
 #include "glow/Graph/Node.h"
 #include "glow/Graph/Nodes.h"
 #include "glow/Optimizer/Optimizer.h"
-#include "glow/Quantization/Base/Base.h"
-#include "glow/Quantization/Quantization.h"
 
 #include "llvm/Support/Casting.h"
 
@@ -254,104 +252,6 @@ static void lowerPadNode(Function *F, LoweredInfoMap *loweredMap,
   auto *insert =
       F->createInsertTensor(P.getName(), constant, P.getInput(), orig);
   replaceAllUsesOfWith(loweredMap, P.getResult(), insert);
-}
-
-/// Lower a quantized Log by creating an IntLookupTable with a new mapping given
-/// the input and output quantization parameters.
-static void lowerQuantizedLogNode(Function *F, LoweredInfoMap *loweredMap,
-                                  const LogNode *LN) {
-  TypeRef outTy = LN->getResult().getType();
-  TypeRef inTy = LN->getInput().getType();
-
-  auto inputRange = inTy->getQuantizedValueRange();
-  (void)inputRange;
-  assert(inputRange.first >= 0 &&
-         "Input range must not be negative since this is input to log().");
-
-  // Pass a function returning log here to create the mapping. Note that the
-  // interval is always extended to include zero, so we check if the input is
-  // zero and if so use log(float min), i.e. closest positive value to zero,
-  // as -inf is unsupported to convert to int.
-  auto logFun = [](float a) {
-    return (a == 0.0) ? log(std::numeric_limits<float>::min()) : log(a);
-  };
-  std::vector<int8_t> mapping =
-      glow::quantization::createMapping(inTy, outTy, logFun);
-
-  // Create a new int lookup table with this newly calculated mapping to
-  // implement this quantized log.
-  IntLookupTableNode *ILT = F->createIntLookupTable(
-      LN->getName().str() + ".log", LN->getInput(), mapping, outTy);
-
-  replaceAllUsesOfWith(loweredMap, LN->getResult(), ILT);
-}
-
-static void lowerQuantizedTanhNode(Function *F, LoweredInfoMap *loweredMap,
-                                   const TanhNode *TN) {
-  // Quantized tanh operator expects input to be in a certain floating point
-  // range. This operator works based on the precomputed table and has to
-  // process input in a range of [-3.0, 3.0]. Tanh asymptotically approaches
-  // +/-1.0 and is already +/-.995 at +/-3.0.
-  // The output quantization parameters are chosen to represent the floating
-  // point range of [-1.0, 1.0].
-  auto inputQuantizationParams =
-      glow::quantization::chooseQuantizationParams(-3.0, 3.0);
-  auto tanhInTy = F->getParent()->uniqueType(
-      ElemKind::Int8QTy, TN->getResult().dims(), inputQuantizationParams.scale,
-      inputQuantizationParams.offset);
-
-  // Make sure input is clipped in [-3.0, 3.0] floating point range.
-  auto *rescaleInputNode =
-      F->createRescaleQuantized(TN->getName(), TN->getInput(), tanhInTy);
-
-  // Make sure output is clipped in [-1.0, 1.0] floating point range.
-  auto outputQuantizationParams =
-      glow::quantization::chooseQuantizationParams(-1.0, 1.0);
-  auto resultOutTy = F->getParent()->uniqueType(
-      ElemKind::Int8QTy, rescaleInputNode->getResult().dims(),
-      outputQuantizationParams.scale, outputQuantizationParams.offset);
-
-  auto *quantizedNode =
-      F->createIntTanh(TN->getName(), rescaleInputNode, resultOutTy);
-
-  auto *rescaleOutputNode = F->createRescaleQuantized(
-      TN->getName(), quantizedNode, TN->getResult().getType());
-
-  replaceAllUsesOfWith(loweredMap, TN->getResult(), rescaleOutputNode);
-}
-
-static void lowerQuantizedSigmoidNode(Function *F, LoweredInfoMap *loweredMap,
-                                      const SigmoidNode *SN) {
-  // Quantized sigmoid operator expects input to be in a certain floating
-  // point range. This operator works based on the precomputed table and has
-  // to process input in a range of [-6.0, 6.0]. Sigmoid asymptotically
-  // approaches 0 at -inf and 1 at +inf. It has values of 0.00247262 and
-  // 0.997527 at -6.0 and 6.0 correspondingly. The output quantization
-  // parameters are chosen to represent the floating point range of [0, 1.0].
-  auto inputQuantizationParams =
-      glow::quantization::chooseQuantizationParams(-6.0, 6.0);
-  auto sigmoidInTy = F->getParent()->uniqueType(
-      ElemKind::Int8QTy, SN->getResult().dims(), inputQuantizationParams.scale,
-      inputQuantizationParams.offset);
-
-  // Make sure input is clipped in [-6.0, 6.0] floating point range.
-  auto *rescaleInputNode =
-      F->createRescaleQuantized(SN->getName(), SN->getInput(), sigmoidInTy);
-
-  // Make sure output is clipped in [0.0, 1.0] floating point range.
-  auto outputQuantizationParams =
-      glow::quantization::chooseQuantizationParams(0.0, 1.0);
-  auto resultOutTy = F->getParent()->uniqueType(
-      ElemKind::Int8QTy, rescaleInputNode->getResult().dims(),
-      outputQuantizationParams.scale, outputQuantizationParams.offset);
-
-  auto *quantizedNode =
-      F->createIntSigmoid(SN->getName(), rescaleInputNode, resultOutTy);
-
-  auto *rescaleOutputNode = F->createRescaleQuantized(
-      SN->getName(), quantizedNode, SN->getResult().getType());
-
-  replaceAllUsesOfWith(loweredMap, SN->getResult(), rescaleOutputNode);
 }
 
 static void lowerSGDNode(Function *F, LoweredInfoMap *loweredMap,
@@ -827,18 +727,6 @@ static void lowerNode(Function *F, Node *node, LoweredInfoMap *loweredMap) {
   } else if (auto *CN = dyn_cast<ConvolutionNode>(node)) {
     if (CN->getGroup() > 1)
       lowerGroupConvolutionNode(F, loweredMap, *CN);
-  } else if (auto *SN = dyn_cast<SigmoidNode>(node)) {
-    if (SN->getResult().getType()->isQuantizedType()) {
-      lowerQuantizedSigmoidNode(F, loweredMap, SN);
-    }
-  } else if (auto *TN = dyn_cast<TanhNode>(node)) {
-    if (TN->getResult().getType()->isQuantizedType()) {
-      lowerQuantizedTanhNode(F, loweredMap, TN);
-    }
-  } else if (auto *LN = dyn_cast<LogNode>(node)) {
-    if (LN->getResult().getType()->isQuantizedType()) {
-      lowerQuantizedLogNode(F, loweredMap, LN);
-    }
   } else if (auto *TN = dyn_cast<TileNode>(node)) {
     lowerTileNode(F, loweredMap, *TN);
   }

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -253,7 +253,7 @@ protected:
 
   /// Macro to be put in a switch for all nodes that may need to be replaced by
   /// a LookupTable if the backend doesn't support the quantized node directly.
-#define casesForIntLookupTableReplacement                                      \
+#define CASES_FOR_INT_LOOKUP_TABLE_REPLACEMENT                                 \
   case Kinded::Kind::LogNodeKind:                                              \
   case Kinded::Kind::TanhNodeKind:                                             \
   case Kinded::Kind::SigmoidNodeKind
@@ -318,7 +318,7 @@ protected:
     // convert them.  Otherwise, return whether we can support them as lookup
     // tables instead, and they will be quantized as lookup tables.
     switch (node.getKind()) {
-    casesForIntLookupTableReplacement:
+    CASES_FOR_INT_LOOKUP_TABLE_REPLACEMENT:
       if (isOpSupported) {
         return true;
       }
@@ -378,7 +378,7 @@ protected:
   /// Note: The last case of the macro doesn't have ':' so we can put it
   /// where the macro is inserted to keep the nice code formatting.
   // clang-format off
-#define casesForSingleMatchingInOutType                                        \
+#define CASES_FOR_SINGLE_MATCHING_IN_OUT_TYPE                                  \
   CASE_SINGLE_MATCHING_INOUT_TYPE(LocalResponseNormalization, Input, Result):  \
   CASE_SINGLE_MATCHING_INOUT_TYPE(Slice, Input, Result):                       \
   CASE_SINGLE_MATCHING_INOUT_TYPE(Reshape, Input, Result):                     \
@@ -430,7 +430,7 @@ protected:
     switch (node.getKind()) {
       // Those cases need to be in sync with postProcessing, so we generate them
       // using macros.
-    casesForSingleMatchingInOutType : {
+    CASES_FOR_SINGLE_MATCHING_IN_OUT_TYPE : {
       // The constraints on the IR says that the input type must
       // be the same as the output type.
       TypeRef inTy =
@@ -483,7 +483,7 @@ protected:
       CASE_ALL_INS_MATCH_SINGLE_OUT(InsertTensor);
 #undef CASE_ALL_INS_MATCH_SINGLE_OUT
 
-    casesForSingleMatchingInOutType : {
+    CASES_FOR_SINGLE_MATCHING_IN_OUT_TYPE : {
       // Check that the main loop hands us the node in the order we expect:
       // morph then postprocessing.
       // If the assert breaks, that means that morphNode and postprocessing
@@ -515,7 +515,7 @@ protected:
       break;
     }
 
-    casesForIntLookupTableReplacement : {
+    CASES_FOR_INT_LOOKUP_TABLE_REPLACEMENT : {
       // If these nodes aren't supported then we convert them to a lookup table.
       NodeInfo NI(node);
       if (B_.isOpSupported(NI)) {


### PR DESCRIPTION
*Description*: This was previously done during lowering (i.e. quantize these nodes and then later lower them to IntLookupTables), but it was kind of a hack and required a backend to report that it supported these nodes as quantized even though it really only supported them as IntLookTables.

*Testing*: Added two missing unit tests. All other unit tests pass. Also tested on en2gr.