### PR TITLE
Make GlowErr error strings formattable with strFormat

### DIFF
--- a/include/glow/Backends/DummyDeviceManager.h
+++ b/include/glow/Backends/DummyDeviceManager.h
@@ -50,11 +50,8 @@ public:
                   ReadyCBTy callback) override {
     for (const auto &func : functions) {
       if (functions_.count(func.first) != 0) {
-        callback(
-            module,
-            MAKE_ERR(
-                GlowErr::ErrorCode::RUNTIME_NET_NOT_FOUND,
-                llvm::formatv("Function {0} not found", func.first).str()));
+        callback(module, MAKE_ERR(GlowErr::ErrorCode::RUNTIME_NET_NOT_FOUND,
+                                  "Function %s not found", func.first.c_str()));
         return;
       }
     }
@@ -88,11 +85,10 @@ public:
                               ResultCBTy callback) override {
     auto funcIt = functions_.find(functionName);
     if (funcIt == functions_.end()) {
-      callback(
-          0,
-          MAKE_ERR(GlowErr::ErrorCode::RUNTIME_NET_NOT_FOUND,
-                   llvm::formatv("Function {0} not found", functionName).str()),
-          std::move(context));
+      callback(0,
+               MAKE_ERR(GlowErr::ErrorCode::RUNTIME_NET_NOT_FOUND,
+                        "Function %s not found", functionName.c_str()),
+               std::move(context));
       return 0;
     }
 

--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -663,8 +663,8 @@ protected:
     if (axes.size() > 1) {
       auto it = std::unique(shapeAxes.begin(), shapeAxes.end());
       if (it != shapeAxes.end()) {
-        RETURN_ERR("Axes values are not unique.",
-                   GlowErr::ErrorCode::MODEL_LOADER_UNSUPPORTED_SHAPE);
+        RETURN_ERR(GlowErr::ErrorCode::MODEL_LOADER_UNSUPPORTED_SHAPE,
+                   "Axes values are not unique.");
       }
     }
 

--- a/include/glow/Importer/ProtobufLoader.h
+++ b/include/glow/Importer/ProtobufLoader.h
@@ -43,11 +43,10 @@ bool isArrayConstant(const llvm::ArrayRef<size_t> a);
 
 /// Prints a single serialized protocol buffer node. This method is useful for
 /// debugging the network and printing errors.
-template <typename T>
-std::string unexpectedNodeErrorMessage(const T &node, llvm::StringRef message) {
+template <typename T> std::string nodeToString(const T &node) {
   std::string str;
   google::protobuf::TextFormat::PrintToString(node, &str);
-  return llvm::formatv("{0}\n{1}", message, str);
+  return str;
 }
 
 /// Reads a single integer.

--- a/lib/Backends/CPU/CPUDeviceManager.cpp
+++ b/lib/Backends/CPU/CPUDeviceManager.cpp
@@ -48,22 +48,16 @@ void CPUDeviceManager::addNetworkImpl(const Module *module,
     if (functions_.count(func.first) != 0) {
       readyCB(
           module,
-          MAKE_ERR(
-              llvm::formatv(
-                  "Failed to add network: already have a function called {0}",
-                  func.first)
-                  .str()));
+          MAKE_ERR("Failed to add network: already have a function called %s",
+                   func.first.c_str()));
       return;
     }
 
     if (func.second->getCompileBackendKind() != BackendKind::CPU) {
       readyCB(
           module,
-          MAKE_ERR(
-              llvm::formatv(
-                  "Failed to add network: function {0} is not a CPUFunction",
-                  func.first)
-                  .str()));
+          MAKE_ERR("Failed to add network: function %s is not a CPUFunction",
+                   func.first.c_str()));
       return;
     }
   }
@@ -96,11 +90,9 @@ void CPUDeviceManager::evictNetworkImpl(std::string functionName,
   if (functions_.erase(functionName)) {
     usedMemoryBytes_ -= functionCost_; // TODO: static moduleSize
   } else {
-    err =
-        MAKE_ERR(GlowErr::ErrorCode::RUNTIME_NET_NOT_FOUND,
-                 llvm::formatv("Could not find function with name {0} to evict",
-                               functionName)
-                     .str());
+    err = MAKE_ERR(GlowErr::ErrorCode::RUNTIME_NET_NOT_FOUND,
+                   "Could not find function with name %s to evict",
+                   functionName.c_str());
   }
 
   if (evictCB) {
@@ -121,7 +113,7 @@ void CPUDeviceManager::runFunctionImpl(
                            {{"reason", "function not found"}});
     resultCB(id,
              MAKE_ERR(GlowErr::ErrorCode::RUNTIME_NET_NOT_FOUND,
-                      llvm::formatv("Function {0} not found", function).str()),
+                      "Function %s not found", function.c_str()),
              std::move(context));
     return;
   }

--- a/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
@@ -46,19 +46,15 @@ void InterpreterDeviceManager::addNetworkImpl(const Module *module,
     if (functions_.count(func.first) != 0) {
       readyCB(
           module,
-          MAKE_ERR(
-              llvm::formatv(
-                  "Failed to add network: already have a function called {0}",
-                  func.first)
-                  .str()));
+          MAKE_ERR("Failed to add network: already have a function called %s",
+                   func.first.c_str()));
       return;
     }
 
     if (func.second->getCompileBackendKind() != BackendKind::Interpreter) {
-      readyCB(module, MAKE_ERR(llvm::formatv("Failed to add network: function "
-                                             "{0} is not a InterpreterFunction",
-                                             func.first)
-                                   .str()));
+      readyCB(module, MAKE_ERR("Failed to add network: function "
+                               "%s is not a InterpreterFunction",
+                               func.first.c_str()));
       return;
     }
   }
@@ -91,11 +87,9 @@ void InterpreterDeviceManager::evictNetworkImpl(std::string functionName,
   if (functions_.erase(functionName)) {
     usedMemoryBytes_ -= functionCost_; // TODO: static moduleSize
   } else {
-    err =
-        MAKE_ERR(GlowErr::ErrorCode::RUNTIME_NET_NOT_FOUND,
-                 llvm::formatv("Could not find function with name {0} to evict",
-                               functionName)
-                     .str());
+    err = MAKE_ERR(GlowErr::ErrorCode::RUNTIME_NET_NOT_FOUND,
+                   "Could not find function with name %s to evict",
+                   functionName.c_str());
   }
 
   if (evictCB) {
@@ -115,7 +109,7 @@ void InterpreterDeviceManager::runFunctionImpl(
                            {{"reason", "function not found"}});
     resultCB(id,
              MAKE_ERR(GlowErr::ErrorCode::RUNTIME_NET_NOT_FOUND,
-                      llvm::formatv("Function {0} not found", function).str()),
+                      "Function %s not found", function.c_str()),
              std::move(context));
     return;
   }

--- a/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
@@ -144,22 +144,16 @@ void OpenCLDeviceManager::addNetworkImpl(const Module *module,
     if (functions_.count(func.first) != 0) {
       readyCB(
           module,
-          MAKE_ERR(
-              llvm::formatv(
-                  "Failed to add network: already have a function called {}",
-                  func.first)
-                  .str()));
+          MAKE_ERR("Failed to add network: already have a function called %s",
+                   func.first.c_str()));
       return;
     }
 
     if (func.second->getCompileBackendKind() != BackendKind::OpenCL) {
-      readyCB(
-          module,
-          MAKE_ERR(
-              llvm::formatv(
-                  "Failed to add network: function {} is not a OpenCL Function",
-                  func.first)
-                  .str()));
+      readyCB(module,
+              MAKE_ERR(
+                  "Failed to add network: function %s is not a OpenCL Function",
+                  func.first.c_str()));
     }
   }
   // Collect constants once, since currently the bundle grabs everything in the
@@ -249,11 +243,9 @@ void OpenCLDeviceManager::evictNetworkImpl(std::string functionName,
       usedMemoryBytes_ -= size;
     }
   } else {
-    err =
-        MAKE_ERR(GlowErr::ErrorCode::RUNTIME_NET_NOT_FOUND,
-                 llvm::formatv("Could not find function with name {} to evict",
-                               functionName)
-                     .str());
+    err = MAKE_ERR(GlowErr::ErrorCode::RUNTIME_NET_NOT_FOUND,
+                   "Could not find function with name %s to evict",
+                   functionName.c_str());
   }
 
   if (evictCB) {
@@ -290,7 +282,7 @@ void OpenCLDeviceManager::runFunctionImpl(
                            {{"reason", "function not found"}});
     resultCB(id,
              MAKE_ERR(GlowErr::ErrorCode::RUNTIME_NET_NOT_FOUND,
-                      llvm::formatv("Function {} not found", function).str()),
+                      "Function %s not found", function.c_str()),
              std::move(context));
     return;
   }

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -660,8 +660,8 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
 
       size_t totalOriginalOutputSize = node->getNthResult(0).getType()->size();
       RETURN_ERR_IF_NOT(totalReshapeSize == totalOriginalOutputSize,
-                        strFormat("Cannot reshape from size %lu to size %lu",
-                                  totalOriginalOutputSize, totalReshapeSize));
+                        "Cannot reshape from size %lu to size %lu",
+                        totalOriginalOutputSize, totalReshapeSize);
 
       node = G_.createReshape("fc.out", node, reshapeDims);
     }
@@ -1059,7 +1059,7 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     return llvm::Error::success();
   }
 
-  RETURN_ERR(unexpectedNodeErrorMessage(op, "Unsupported operator."));
+  RETURN_ERR("Unsupported operator:\n%s", nodeToString(op).c_str());
 }
 
 template <class TensorProtoType>
@@ -1145,10 +1145,9 @@ static llvm::Error fillTensor(Tensor &T, ElemKind kind,
   T.reset(kind, dim);
   auto TH = T.getHandle<ElemTy>();
   RETURN_ERR_IF_NOT((size_t)values.size() == T.size(),
-                    llvm::formatv("Wrong number of values for GivenTensorFill "
-                                  "({0} given, {1} expected)",
-                                  values.size(), T.size())
-                        .str());
+                    "Wrong number of values for GivenTensorFill "
+                    "(%lu given, %lu expected)",
+                    values.size(), T.size());
   size_t i = 0;
   for (auto num : values) {
     TH.raw(i++) = num;
@@ -1433,7 +1432,7 @@ llvm::Error Caffe2ModelLoader::loadWeight(const caffe2::OperatorDef &op) {
     return llvm::Error::success();
   }
 
-  RETURN_ERR(unexpectedNodeErrorMessage(op, "Unsupported weight kind"));
+  RETURN_ERR("Unsupported weight kind:\n%s", nodeToString(op).c_str());
 }
 
 llvm::Error Caffe2ModelLoader::loadWeightsFromNet(caffe2::NetDef &net) {

--- a/lib/Importer/ProtobufLoader.cpp
+++ b/lib/Importer/ProtobufLoader.cpp
@@ -28,19 +28,17 @@ bool isArrayConstant(llvm::ArrayRef<size_t> a) {
 }
 
 llvm::Expected<Tensor *> ProtobufLoader::getTensorByName(llvm::StringRef name) {
-  RETURN_ERR_IF_NOT(
-      tensors_.count(name),
-      llvm::Twine("There is no tensor registered with name ", name).str());
+  RETURN_ERR_IF_NOT(tensors_.count(name),
+                    "There is no tensor registered with name %s", name.data());
   return tensors_[name].get();
 }
 
 llvm::Expected<Placeholder *>
 ProtobufLoader::getOutputByName(llvm::StringRef name) const {
   auto it = outputVarsByName_.find(name);
-  RETURN_ERR_IF_NOT(
-      it != outputVarsByName_.end(),
-      llvm::Twine("No external output Variable was registered with name ", name)
-          .str());
+  RETURN_ERR_IF_NOT(it != outputVarsByName_.end(),
+                    "No external output Variable was registered with name %s",
+                    name.data());
   return it->second;
 }
 
@@ -56,8 +54,7 @@ ProtobufLoader::getNodeValueByNameOrNullNodeValue(llvm::StringRef name) const {
 
 llvm::Expected<NodeValue>
 ProtobufLoader::getNodeValueByName(llvm::StringRef name) const {
-  RETURN_ERR_IF_NOT(hasNodeByName(name),
-                    llvm::Twine("No node under name ", name).str());
+  RETURN_ERR_IF_NOT(hasNodeByName(name), "No node under name %s", name.data());
   auto node = getNodeValueByNameOrNullNodeValue(name);
   RETURN_ERR_IF_NOT(node.getNode(), "Null is under that name??");
   return node;
@@ -66,9 +63,8 @@ ProtobufLoader::getNodeValueByName(llvm::StringRef name) const {
 llvm::Expected<Constant *>
 ProtobufLoader::createAndRegisterConstant(llvm::StringRef name,
                                           const Tensor &tensor) {
-  RETURN_ERR_IF_NOT(
-      !hasNodeByName(name),
-      llvm::Twine("Creating an already existing node ", name).str());
+  RETURN_ERR_IF_NOT(!hasNodeByName(name),
+                    "Creating an already existing node %s", name.data());
   // Note: We do not support training from models loaded from protos, so
   // trainable is always set to false here.
   Constant *node = G_.getParent()->createConstant(name, tensor);
@@ -78,9 +74,8 @@ ProtobufLoader::createAndRegisterConstant(llvm::StringRef name,
 
 llvm::Expected<Placeholder *>
 ProtobufLoader::createAndRegisterPlaceholder(llvm::StringRef name, TypeRef T) {
-  RETURN_ERR_IF_NOT(
-      !hasNodeByName(name),
-      llvm::Twine("Creating an already existing node ", name).str());
+  RETURN_ERR_IF_NOT(!hasNodeByName(name),
+                    "Creating an already existing node %s", name.data());
   Placeholder *node = G_.getParent()->createPlaceholder(T, name, false);
   nodeValueByName_[name] = node->getOutput();
   return node;

--- a/tests/unittests/ExecutorTest.cpp
+++ b/tests/unittests/ExecutorTest.cpp
@@ -55,10 +55,7 @@ public:
 
     if (!resultMap_.erase(functionName)) {
       err = MAKE_ERR(
-          GlowErr::ErrorCode::RUNTIME_NET_NOT_FOUND,
-          llvm::formatv("Could not find function with name {0} to evict",
-                        functionName)
-              .str());
+          GlowErr::ErrorCode::RUNTIME_NET_NOT_FOUND, "Could not find function with name %s to evict", functionName.c_str());
     }
 
     if (evictCB) {


### PR DESCRIPTION
*Description*:
For error macros (MAKE_ERR, RETURN_ERR, RETURN_ERR_IF_NOT, etc) this PR makes it possible to instead of passing an error string, you can pass a printf-style format string followed by accompanying printf arguments and the error message will be generated from this.

See examples in in PR for more details.

*Testing*:
`ninja check`

*Documentation*:
comments