### PR TITLE
[tracing] Add human readable trace thread names

### DIFF
--- a/include/glow/Backends/DeviceManager.h
+++ b/include/glow/Backends/DeviceManager.h
@@ -107,6 +107,9 @@ public:
   /// \returns true if we expect a Module with the estimated constant size will
   /// fit on the device.
   virtual bool isMemoryAvailable(uint64_t estimate) const = 0;
+
+  /// \returns the DeviceConfig which initialized this device.
+  const DeviceConfig *getDeviceConfig() { return config_.get(); }
 };
 
 } // namespace runtime

--- a/include/glow/Runtime/RuntimeTypes.h
+++ b/include/glow/Runtime/RuntimeTypes.h
@@ -112,8 +112,8 @@ public:
 
   BackendKind getBackendKind() { return backendKind_; }
 
-  llvm::StringRef getName() { return name_; }
-  bool hasName() { return name_ != ""; }
+  llvm::StringRef getName() const { return name_; }
+  bool hasName() const { return name_ != ""; }
   void setName(llvm::StringRef name) { name_ = name; }
 };
 

--- a/lib/Runtime/Executor/ThreadPoolExecutor.cpp
+++ b/lib/Runtime/Executor/ThreadPoolExecutor.cpp
@@ -387,6 +387,13 @@ void ThreadPoolExecutor::executeDAGNode(
 
   auto &deviceManager = deviceManagerIt->second;
 
+  // If tracing is enabled, set the thread name for TraceEvents for this node to
+  // be the name of the Device.
+  if (executionState->getRawResultContextPtr()->getTraceContext()) {
+    executionState->getRawResultContextPtr()->getTraceContext()->setThreadName(
+        node->deviceID, deviceManager->getDeviceConfig()->getName());
+  }
+
   // Get the PlaceholderBindings containing all of the inputs for the node.
   std::unique_ptr<ExecutionContext> nodeCtx =
       executionState->getUniqueNodeContextPtr(node);


### PR DESCRIPTION
*Description*: Allow setting the name of threads and the process in the tracing output. This is managed by a map of integer thread id to string name in the TraceContext.
*Testing*: unittests & resnet-runtime example.
*Documentation*:
![image](https://user-images.githubusercontent.com/701287/55692145-8b8bf200-59e8-11e9-8d79-f1027b06e3a4.png)

