### PR TITLE
Add verbose flag to tests in the coverage target

### DIFF
--- a/cmake/modules/CoverageSupport.cmake
+++ b/cmake/modules/CoverageSupport.cmake
@@ -44,7 +44,7 @@ if(GLOW_USE_COVERAGE)
     COMMAND echo "Cleaning is done. Running tests"
 
     # Run all tests.
-    COMMAND ctest -j 4
+    COMMAND ctest -V -j 4
 
     # Capture lcov counters based on the test run.
     COMMAND ${LCOV_PATH} --no-checksum --directory . --capture --output-file glow_coverage.info


### PR DESCRIPTION
*Description*: Adds the `-V` flag to the test invocation in the coverage target, which means we can debug issues found in the GCC regression test.
*Testing*: Look at the coverage target in travis below.
*Documentation*:
Fixes #2677