### PR TITLE
[Partitioner] If a proper partition is not found, return an error.

### DIFF
--- a/include/glow/Partitioner/Partitioner.h
+++ b/include/glow/Partitioner/Partitioner.h
@@ -19,6 +19,7 @@
 #include "glow/Graph/Graph.h"
 #include "glow/Partitioner/PartitionerUtils.h"
 #include "glow/Runtime/RuntimeTypes.h"
+#include "glow/Support/Error.h"
 
 namespace glow {
 
@@ -156,8 +157,11 @@ public:
   /// devices.
   Partitioner(Module *parent, const std::vector<DeviceInfo> &devices);
 
-  /// Decompose each function in a module and return a list of DAGNodes.
-  DAGListTy &Partition();
+  /// Decompose each function in a module.
+  llvm::Error Partition();
+
+  /// Get the partitions.
+  DAGListTy &getPartitionResult() { return partitions_; }
 
   /// Get function for computeTime_
   ComputeTimeMapTy getComputeTime() const { return computeTime_; }

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -90,7 +90,8 @@ llvm::Error HostManager::addNetwork(std::unique_ptr<Module> module) {
     }
   }
   auto partitioner = Partitioner(module.get(), deviceInfo);
-  auto nodeList = std::move(partitioner.Partition());
+  RETURN_IF_ERR(partitioner.Partition());
+  auto nodeList = std::move(partitioner.getPartitionResult());
 
   RETURN_IF_ERR(provisioner_->provision(nodeList, *module));
 

--- a/lib/Runtime/Provisioner/Provisioner.cpp
+++ b/lib/Runtime/Provisioner/Provisioner.cpp
@@ -55,10 +55,6 @@ llvm::Error Provisioner::provision(DAGListTy &networks, Module &module) {
     }
   }
 
-  RETURN_ERR_IF_NOT(
-      logicalDevices.size() <= devices_.size(),
-      "Provisioner found more logical devices than physical devices.");
-
   std::vector<std::pair<DeviceIDTy, uint64_t>> logicalDeviceSize;
   std::map<DeviceIDTy, FunctionMapTy> functionMaps;
   // Compile functions and calculate required memory for each logical device.


### PR DESCRIPTION
*Description*:
If the number of devices is fewer than the number of partitions, we used to let Provisioner to report this error. Now we move the error detection into Partitioner.  If a proper partition can't be found, an error is reported.

Testing*:
Added unittest.

*Documentation*:
[Optional Fixes #2661 ]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
