### PR TITLE
[runtime] Use default eviction callback in HostManager

### DIFF
--- a/include/glow/Backends/DeviceManager.h
+++ b/include/glow/Backends/DeviceManager.h
@@ -76,7 +76,8 @@ public:
   /// up space on the device. \p evictCB will be called when the operation
   /// is completed or attempted and failed.
   virtual void evictNetwork(std::string functionName,
-                            EvictFunctionCBTy evictCB) = 0;
+                            EvictFunctionCBTy evictCB = [](std::string,
+                                                           llvm::Error) {}) = 0;
 
   /// Execute the named Function in an already provided network on the device.
   /// functionName must match the name of a function already added.

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -154,7 +154,7 @@ llvm::Error HostManager::clearHost() {
 
   for (auto &network : networks_) {
     for (auto &node : network.second.dag.nodes) {
-      devices_[node->deviceID]->evictNetwork(node->name, /*evictCB=*/nullptr);
+      devices_[node->deviceID]->evictNetwork(node->name);
     }
   }
   networks_.clear();


### PR DESCRIPTION
Summary: Passing nullptr here is kind of brittle; it assumes that the backend's
DeviceManager is aware of the contract that "nullptr" here means "provide a
default behavior".  Instead, let's just provide a NOP callback.  The DM is
always free to log (or not) as it sees fit.

Test Plan: A bit hard to test, but if you remove the default behavior from
CPUDeviceManager and run resnet-runtime, you'll get a runtime failure.

Fixes #2681 