### PR TITLE
Added TensorView enums to SymbolCategory

### DIFF
--- a/include/glow/Backends/BackendUtils.h
+++ b/include/glow/Backends/BackendUtils.h
@@ -22,9 +22,14 @@
 namespace glow {
 namespace runtime {
 
-/// An enum to indicate what type each symbol in the bundle is. Current options
-/// are activations, constants, and placeholders.
-enum class SymbolCategory { Activation, Placeholder, Constant };
+/// An enum to indicate what type each symbol in the bundle is.
+enum class SymbolCategory {
+  Activation,
+  Placeholder,
+  Constant,
+  PlaceholderTensorView,
+  ConstantTensorView
+};
 
 /// Contains information for initialization and handling of symbol at runtime.
 struct RuntimeSymbolInfo {

--- a/lib/Backends/BackendUtils.cpp
+++ b/lib/Backends/BackendUtils.cpp
@@ -191,8 +191,13 @@ runtime::RuntimeBundle::create(const IRFunction &F,
                       (offsetLength * TV->getType()->getElementSize());
       symbol.size = TV->getSizeInBytes();
       symbol.type = *TV->getType();
-      symbol.symbolCategory =
+      auto parentCategory =
           symbolTable.find(tvSource->getName())->second.symbolCategory;
+      if (parentCategory == SymbolCategory::Placeholder) {
+        symbol.symbolCategory = SymbolCategory::PlaceholderTensorView;
+      } else {
+        symbol.symbolCategory = SymbolCategory::ConstantTensorView;
+      }
       symbolTable.emplace(std::string(TV->getName()), symbol);
       continue;
     }

--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -281,7 +281,7 @@ TEST_P(BackendTest, BundleSymbolCategory) {
   // Check that tensor views have the same label as their parent symbol. In this
   // case same as "input".
   EXPECT_EQ(table.find("tensorview_reshape")->second.symbolCategory,
-            table.find(input->getName())->second.symbolCategory);
+            glow::runtime::SymbolCategory::PlaceholderTensorView);
 }
 
 /// Test compiling a vector of functions completes without error.


### PR DESCRIPTION
*Description*: This PR adds two new symbol Categories, TensorViewPlaceholder, and TensorViewConstant. This allows us to differentiate between the view and weight.
*Testing*: ninja test
*Documentation*: NA