### PR TITLE
Make quantization profiling scalable

### DIFF
--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -1630,14 +1630,13 @@ void libjit_write_timestamp(uint64_t *tensor, size_t offset) {
   memcpy(tensor + offset, &ts, sizeof(uint64_t));
 }
 
-// code ported from Profile.cpp: generateTensorHistogram
+/// Update min/max values \p compInfo and histogram \p existingHistogram with
+/// data collected from tensor \p inputTensor.
+/// Note: code ported from Profile.cpp: generateTensorHistogram
 __attribute__((noinline)) void
 libjit_quantization_profile(float *inputTensor, size_t *tensorDim,
                             size_t numDimsTensor, float *compInfo,
                             float *existingHistogram, size_t *histDim) {
-  float minInput = inputTensor[0];
-  float maxInput = inputTensor[0];
-
   size_t tensorSize = 1;
   // calculating total size of the Tensor.
   for (size_t i = 0; i < numDimsTensor; ++i) {
@@ -1646,24 +1645,32 @@ libjit_quantization_profile(float *inputTensor, size_t *tensorDim,
 
   size_t nBins = histDim[0];
 
-  // finding min/max value for entire tensor
-  find_min_max_f(inputTensor, tensorSize, minInput, maxInput);
-
+  // Min/max computed from previous runs. If this is the first run, compInfo is
+  // expected to be initialized as following:
+  // compInfo[0]: std::numeric_limits<float>::max()
+  // compInfo[1]: std::numeric_limits<float>::lowest()
   float min = compInfo[0];
   float max = compInfo[1];
-  if (check_all_zeros(existingHistogram, nBins) == 1) {
-    compInfo[0] = minInput;
-    compInfo[1] = maxInput;
 
+  // Min/max value for entire current input tensor.
+  float minInput;
+  float maxInput;
+  find_min_max_f(inputTensor, tensorSize, minInput, maxInput);
+
+  // Update the global min/max.
+  float newMin = MIN(minInput, min);
+  float newMax = MAX(maxInput, max);
+  compInfo[0] = newMin;
+  compInfo[1] = newMax;
+
+  // Initial profile.
+  if (check_all_zeros(existingHistogram, nBins) == 1) {
     min = minInput;
     max = maxInput;
   }
 
-  // Check if we need to rescale histogram.
-  if (minInput < min || maxInput > max) {
-    float newMin = MIN(minInput, min);
-    float newMax = MAX(maxInput, max);
-
+  // If the min/max range changes, there is the need to rescale the histogram.
+  if (newMin < min || newMax > max) {
     float destBinWidth = (newMax - newMin) / nBins;
     float srcBinWidth = (max - min) / nBins;
     float scaledHistogram[nBins];
@@ -1712,6 +1719,7 @@ libjit_quantization_profile(float *inputTensor, size_t *tensorDim,
     max = newMax;
   }
 
+  // Update the histogram with the values of the current input tensor.
   float binWidth = (max - min) / nBins;
   for (size_t i = 0, e = tensorSize; i < e; ++i) {
     size_t newBin = get_bin(nBins, binWidth, min, inputTensor[i]);

--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -1634,15 +1634,9 @@ void libjit_write_timestamp(uint64_t *tensor, size_t offset) {
 /// data collected from tensor \p inputTensor.
 /// Note: code ported from Profile.cpp: generateTensorHistogram
 __attribute__((noinline)) void
-libjit_quantization_profile(float *inputTensor, size_t *tensorDim,
-                            size_t numDimsTensor, float *compInfo,
-                            float *existingHistogram, size_t *histDim) {
-  size_t tensorSize = 1;
-  // calculating total size of the Tensor.
-  for (size_t i = 0; i < numDimsTensor; ++i) {
-    tensorSize *= tensorDim[i];
-  }
-
+libjit_quantization_profile(float *inputTensor, size_t tensorSize,
+                            float *compInfo, float *existingHistogram,
+                            size_t *histDim) {
   size_t nBins = histDim[0];
 
   // Min/max computed from previous runs. If this is the first run, compInfo is

--- a/lib/Base/Image.cpp
+++ b/lib/Base/Image.cpp
@@ -401,7 +401,7 @@ void glow::loadImagesAndPreprocess(const llvm::ArrayRef<std::string> &filenames,
                                    ImageLayout imageLayout) {
   assert(!filenames.empty() &&
          "There must be at least one filename in filenames.");
-  unsigned numImages = filenames.size();
+  size_t numImages = filenames.size();
 
   // Get image dimensions and check if grayscale or color.
   size_t imgHeight;

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1647,11 +1647,16 @@ Function::createQuantizationProfile(PlaceholderBindings &bindings,
   // Intermediate data used for histogram calculations.
   // Min tensor value seen so far is kept on the first position.
   // Max tensor value seen so far is kept on the second position.
-  auto *computationInfo = getParent()->createPlaceholder(
+  auto *computationInfoPH = getParent()->createPlaceholder(
       ElemKind::FloatTy, {2}, "CI_" + name.str(), false);
-  bindings.allocate(computationInfo);
+  bindings.allocate(computationInfoPH);
+  auto *computationInfoTensor = bindings.get(computationInfoPH);
+  auto handle = computationInfoTensor->getHandle<float>();
+  handle.raw(0) = std::numeric_limits<float>::max();
+  handle.raw(1) = std::numeric_limits<float>::lowest();
+
   return addNode(new QuantizationProfileNode(
-      "QI_" + name.str(), input, histogram, computationInfo,
+      "QI_" + name.str(), input, histogram, computationInfoPH,
       input.getNode()->getName().str(), input.getResNo()));
 }
 

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -1408,17 +1408,14 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     auto *inputTensorInfoPtr = emitValueAddress(builder, inputTensor);
 
     auto *histDims = emitValueDims(builder, hist);
-    auto *inputTensorDims = emitValueDims(builder, inputTensor);
-
     assert(inputTensor->getElementType() == ElemKind::FloatTy &&
            "None float Tensor type for Quantization Profile Instruction.");
-    auto *srcDimsSize =
-        emitConstSizeT(builder, inputTensor->getType()->dims().size());
+    auto *tensorSize = emitConstSizeT(builder, inputTensor->getType()->size());
 
     auto *F = getFunction("quantization_profile");
-    createCall(builder, F,
-               {inputTensorInfoPtr, inputTensorDims, srcDimsSize, compInfoPtr,
-                histPtr, histDims});
+    createCall(
+        builder, F,
+        {inputTensorInfoPtr, tensorSize, compInfoPtr, histPtr, histDims});
     break;
   }
 


### PR DESCRIPTION
*Description*: 
If we want to perform the quantization profile generation on many images. The batch size (which corresponds to number of images passed as parameter) becomes too large and Glow requires a too huge amount of memory. This PR allows to (partially) decouple the image list and the batch size. In such a way, quantization profile generation can be performed on a very large number of images.

Content of this PR:
- new `-minibatch` option that specifies the batch size to be used for the compilation
- Bug fix in the implementation of the `QuantizationProfile` node in libjit. On the contrary to the Interpreter implementation, it was not 'accumulating' profile results across successive inference runs.
- Bug fix in the initialization of `QuantizationProfile` min/max values (was I guess initialized to  the default 0 value, what is incorrect)

*Testing*: Locally with our implementation

*Documentation*: N/A
