### PR TITLE
[habana] Support non 0 quantized offset

### DIFF
--- a/lib/Backends/Habana/Habana.cpp
+++ b/lib/Backends/Habana/Habana.cpp
@@ -260,10 +260,7 @@ public:
                              synMemoryHost, false, name_.data());
     if (V->isQuantizedType() &&
         V->getElementType() != ElemKind::UInt8FusedQTy) {
-      GLOW_ASSERT(V->getOffset() == 0 &&
-                  "Only symmetric quantization is supported");
-      // TODO: Figure out how offset/zero_point works:
-      // desc.m_quantizationParams[0].m_zp = V->getOffset();
+      desc.m_quantizationParams[0].m_zp = V->getOffset();
       desc.m_quantizationParams[0].m_scale = V->getScale();
       desc.m_quantizationParams[0].m_qDataType = elemType;
     }


### PR DESCRIPTION
Summary: Add support for non 0 offset for quantized ops.

Differential Revision: D14808564
