### PR TITLE
[glow-h] Optimize before compiling on H

### DIFF
--- a/lib/Backends/Habana/Habana.cpp
+++ b/lib/Backends/Habana/Habana.cpp
@@ -706,6 +706,8 @@ IOPlaceholders findIOPlaceholders(Function *F) {
 
 std::unique_ptr<CompiledFunction>
 HabanaBackend::compile(Function *F, const CompilationOptions &opts) const {
+  optimizeFunction(F, opts);
+
   chk(synCreateGraph(synDeviceGoya));
 
   // Allocate all the tensors.


### PR DESCRIPTION
Summary:
The host manager doesn't do this, which is a bug on its part I guess,
but the Habana backend needs it because it expects specialized operator versions.
