### PR TITLE
[glow-h] Die loudly if !isOpSupported during compilation

### DIFF
--- a/lib/Backends/Habana/Habana.cpp
+++ b/lib/Backends/Habana/Habana.cpp
@@ -732,6 +732,10 @@ HabanaBackend::compile(Function *F, const CompilationOptions &opts) const {
   std::vector<TensorHandle> tempTensors;
 
   for (const auto &I : F->getNodes()) {
+    if (!isOpSupported(I)) {
+      llvm::errs() << "Unsupported operator: " << I.getDebugDesc() << "\n";
+      GLOW_UNREACHABLE("Unsupported operator");
+    }
     switch (I.getKind()) {
     case Kinded::Kind::HabanaFullyConnectedNodeKind: {
       auto *NI = llvm::cast<HabanaFullyConnectedNode>(&I);


### PR DESCRIPTION
Summary:
To fully sanity check our compilation results, check isOpSupported for
each node while compiling.  Specifically, fp32 convolution is not supported by
H and we were silently miscompiling code as a result.

Differential Revision: D14841987
