### PR TITLE
[OnnxModelLoader] Add SAME_UPPER/SAME_LOWER auto_pad modes.

### DIFF
--- a/tests/models/onnxModels/averagePool2DAutoPadSameLower.onnxtxt
+++ b/tests/models/onnxModels/averagePool2DAutoPadSameLower.onnxtxt
@@ -1,0 +1,74 @@
+ir_version: 3
+producer_name: "backend-test"
+graph {
+  node {
+    input: "x"
+    output: "y"
+    op_type: "AveragePool"
+    attribute {
+      name: "kernel_shape"
+      ints: 2
+      ints: 2
+      type: INTS
+    }
+    attribute {
+      name: "auto_pad"
+      s: "SAME_LOWER"
+      type: STRING
+    }
+    attribute {
+      name: "strides"
+      ints: 1
+      ints: 1
+      type: INTS
+    }
+  }
+  name: "test_averagepool"
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 9
+}

--- a/tests/models/onnxModels/averagePool2DAutoPadSameUpper.onnxtxt
+++ b/tests/models/onnxModels/averagePool2DAutoPadSameUpper.onnxtxt
@@ -1,0 +1,74 @@
+ir_version: 3
+producer_name: "backend-test"
+graph {
+  node {
+    input: "x"
+    output: "y"
+    op_type: "AveragePool"
+    attribute {
+      name: "kernel_shape"
+      ints: 2
+      ints: 2
+      type: INTS
+    }
+    attribute {
+      name: "auto_pad"
+      s: "SAME_UPPER"
+      type: STRING
+    }
+    attribute {
+      name: "strides"
+      ints: 1
+      ints: 1
+      type: INTS
+    }
+  }
+  name: "test_averagepool"
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 9
+}

--- a/tests/models/onnxModels/averagePool2DAutoPadValid.onnxtxt
+++ b/tests/models/onnxModels/averagePool2DAutoPadValid.onnxtxt
@@ -1,0 +1,74 @@
+ir_version: 3
+producer_name: "backend-test"
+graph {
+  node {
+    input: "x"
+    output: "y"
+    op_type: "AveragePool"
+    attribute {
+      name: "kernel_shape"
+      ints: 2
+      ints: 2
+      type: INTS
+    }
+    attribute {
+      name: "auto_pad"
+      s: "VALID"
+      type: STRING
+    }
+    attribute {
+      name: "strides"
+      ints: 1
+      ints: 1
+      type: INTS
+    }
+  }
+  name: "test_averagepool"
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 9
+}

--- a/tests/models/onnxModels/simpleConvAutoPadSameLower.onnxtxt
+++ b/tests/models/onnxModels/simpleConvAutoPadSameLower.onnxtxt
@@ -1,0 +1,130 @@
+ir_version: 3
+producer_name: "onnx-conv"
+graph {
+  node {
+    input: "data"
+    input: "W"
+    input: "B"
+    output: "y"
+    name: "conv1"
+    op_type: "Conv"
+    attribute {
+      name: "kernel_shape"
+      ints: 2
+      ints: 2
+      type: INTS
+    }
+    attribute {
+      name: "auto_pad"
+      s: "SAME_LOWER"
+      type: STRING
+    }
+    attribute {
+      name: "strides"
+      ints: 1
+      ints: 1
+      type: INTS
+    }
+  }
+  name: "test-model"
+  initializer {
+    dims: 1
+    dims: 1
+    dims: 2
+    dims: 2
+    data_type: 1
+    float_data: 1.0
+    float_data: 1.0
+    float_data: 1.0
+    float_data: 1.0
+    name: "W"
+  }
+  initializer {
+    dims: 1
+    data_type: 1
+    float_data: 2.0
+    name: "B"
+  }
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "W"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "B"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 4
+}

--- a/tests/models/onnxModels/simpleConvAutoPadSameUpper.onnxtxt
+++ b/tests/models/onnxModels/simpleConvAutoPadSameUpper.onnxtxt
@@ -1,0 +1,130 @@
+ir_version: 3
+producer_name: "onnx-conv"
+graph {
+  node {
+    input: "data"
+    input: "W"
+    input: "B"
+    output: "y"
+    name: "conv1"
+    op_type: "Conv"
+    attribute {
+      name: "kernel_shape"
+      ints: 2
+      ints: 2
+      type: INTS
+    }
+    attribute {
+      name: "auto_pad"
+      s: "SAME_UPPER"
+      type: STRING
+    }
+    attribute {
+      name: "strides"
+      ints: 1
+      ints: 1
+      type: INTS
+    }
+  }
+  name: "test-model"
+  initializer {
+    dims: 1
+    dims: 1
+    dims: 2
+    dims: 2
+    data_type: 1
+    float_data: 1.0
+    float_data: 1.0
+    float_data: 1.0
+    float_data: 1.0
+    name: "W"
+  }
+  initializer {
+    dims: 1
+    data_type: 1
+    float_data: 2.0
+    name: "B"
+  }
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "W"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "B"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 4
+}

--- a/tests/models/onnxModels/simpleConvAutoPadValid.onnxtxt
+++ b/tests/models/onnxModels/simpleConvAutoPadValid.onnxtxt
@@ -1,0 +1,130 @@
+ir_version: 3
+producer_name: "onnx-conv"
+graph {
+  node {
+    input: "data"
+    input: "W"
+    input: "B"
+    output: "y"
+    name: "conv1"
+    op_type: "Conv"
+    attribute {
+      name: "kernel_shape"
+      ints: 2
+      ints: 2
+      type: INTS
+    }
+    attribute {
+      name: "auto_pad"
+      s: "VALID"
+      type: STRING
+    }
+    attribute {
+      name: "strides"
+      ints: 1
+      ints: 1
+      type: INTS
+    }
+  }
+  name: "test-model"
+  initializer {
+    dims: 1
+    dims: 1
+    dims: 2
+    dims: 2
+    data_type: 1
+    float_data: 1.0
+    float_data: 1.0
+    float_data: 1.0
+    float_data: 1.0
+    name: "W"
+  }
+  initializer {
+    dims: 1
+    data_type: 1
+    float_data: 2.0
+    name: "B"
+  }
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "W"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "B"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 4
+}


### PR DESCRIPTION
*Description*:

Add support for SAME_UPPER and SAME_LOWER auto_pad modes per the spec at
https://github.com/onnx/onnx/blob/master/docs/Operators.md#Conv

Also applies to AveragePool.

*Testing*:
Added unit tests for VALID/SAME_UPPER/SAME_LOWER.
ninja check

*Issues*:
Related to #2504
