### PR TITLE
removing support in llvm 6 and below

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -24,6 +24,19 @@ install_pocl() {
    cd ../
 }
 
+# Install Glow dependencies
+sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main"
+sudo apt-get update
+sudo apt-get install -y llvm-8 clang-8 llvm-8-dev libpng-dev libgoogle-glog-dev
+
+# Redirect clang
+sudo ln -s /usr/bin/clang-8 /usr/bin/clang
+sudo ln -s /usr/bin/clang++-8 /usr/bin/clang++
+sudo ln -s /usr/bin/llvm-symbolizer-8 /usr/bin/llvm-symbolizer
+
+sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang 50
+sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 50
+
 # setup sccache wrappers
 if hash sccache 2>/dev/null; then
     SCCACHE_BIN_DIR="/tmp/sccache"
@@ -39,15 +52,6 @@ if hash sccache 2>/dev/null; then
 fi
 
 GLOW_DIR=$PWD
-
-# Install Glow dependencies
-sudo apt-get update
-sudo apt-get install -y llvm-6.0 llvm-6.0-dev libpng-dev libgoogle-glog-dev
-
-# Redirect clang
-sudo ln -s /usr/bin/clang-6.0 /usr/bin/clang
-sudo ln -s /usr/bin/clang++-6.0 /usr/bin/clang++
-sudo ln -s /usr/bin/llvm-symbolizer-6.0 /usr/bin/llvm-symbolizer
 
 # Install ninja and (newest version of) cmake through pip
 sudo pip install ninja cmake

--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -7,7 +7,7 @@ set -ex
 export MAX_JOBS=8
 
 install_pocl() {
-   sudo apt-get install -y ocl-icd-opencl-dev clinfo libhwloc-dev
+   sudo apt-get install -y ocl-icd-opencl-dev clinfo libhwloc-dev libclang-8-dev opencl-headers
 
    git clone https://github.com/pocl/pocl.git
    cd pocl && git checkout 368539f1b34ec84f94edd255961a39925b92066d && cd ../
@@ -27,7 +27,7 @@ install_pocl() {
 # Install Glow dependencies
 sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main"
 sudo apt-get update
-sudo apt-get install -y llvm-8 clang-8 llvm-8-dev libclang-8-dev libpng-dev libgoogle-glog-dev opencl-headers
+sudo apt-get install -y llvm-8 clang-8 llvm-8-dev libpng-dev libgoogle-glog-dev
 
 # Redirect clang
 sudo ln -s /usr/bin/clang-8 /usr/bin/clang

--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -33,23 +33,7 @@ sudo apt-get install -y llvm-8 clang-8 llvm-8-dev libpng-dev libgoogle-glog-dev
 sudo ln -s /usr/bin/clang-8 /usr/bin/clang
 sudo ln -s /usr/bin/clang++-8 /usr/bin/clang++
 sudo ln -s /usr/bin/llvm-symbolizer-8 /usr/bin/llvm-symbolizer
-
-sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang 50
-sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 50
-
-# setup sccache wrappers
-if hash sccache 2>/dev/null; then
-    SCCACHE_BIN_DIR="/tmp/sccache"
-    mkdir -p "$SCCACHE_BIN_DIR"
-    for compiler in cc c++ gcc g++ x86_64-linux-gnu-gcc; do
-        (
-            echo "#!/bin/sh"
-            echo "exec $(which sccache) $(which $compiler) \"\$@\""
-        ) > "$SCCACHE_BIN_DIR/$compiler"
-        chmod +x "$SCCACHE_BIN_DIR/$compiler"
-    done
-    export PATH="$SCCACHE_BIN_DIR:$PATH"
-fi
+sudo ln -s /usr/bin/llvm-config-8 /usr/bin/llvm-config-8.0
 
 GLOW_DIR=$PWD
 
@@ -60,7 +44,11 @@ hash cmake ninja
 # Build glow
 cd ${GLOW_DIR}
 mkdir build && cd build
-CMAKE_ARGS=("-DCMAKE_CXX_FLAGS=-Werror")
+CMAKE_ARGS=("-DCMAKE_CXX_COMPILER=/usr/bin/clang++-8")
+CMAKE_ARGS+=("-DCMAKE_C_COMPILER=/usr/bin/clang-8")
+CMAKE_ARGS+=("-DCMAKE_CXX_COMPILER_LAUNCHER=sccache")
+CMAKE_ARGS+=("-DCMAKE_C_COMPILER_LAUNCHER=sccache")
+CMAKE_ARGS+=("-DCMAKE_CXX_FLAGS=-Werror")
 CMAKE_ARGS+=("-DGLOW_WITH_CPU=ON")
 CMAKE_ARGS+=("-DGLOW_WITH_HABANA=OFF")
 if [[ "${CIRCLE_JOB}" == "ASAN" ]]; then

--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -10,10 +10,10 @@ install_pocl() {
    sudo apt-get install -y ocl-icd-opencl-dev clinfo libhwloc-dev
 
    git clone https://github.com/pocl/pocl.git
-   cd pocl && git checkout 94fba9f510e678cd7f8fc988c01618e1ae93dfdf && cd ../
+   cd pocl && git checkout 368539f1b34ec84f94edd255961a39925b92066d && cd ../
    mkdir build_pocl
    cd build_pocl
-   cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_ICD=ON ../pocl
+   cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=/usr/bin/clang++-8 -DCMAKE_C_COMPILER=/usr/bin/clang-8 -DENABLE_ICD=ON ../pocl
    make -j`nproc`
    sudo make install
 
@@ -27,7 +27,7 @@ install_pocl() {
 # Install Glow dependencies
 sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main"
 sudo apt-get update
-sudo apt-get install -y llvm-8 clang-8 llvm-8-dev libpng-dev libgoogle-glog-dev
+sudo apt-get install -y llvm-8 clang-8 llvm-8-dev libclang-8-dev libpng-dev libgoogle-glog-dev opencl-headers
 
 # Redirect clang
 sudo ln -s /usr/bin/clang-8 /usr/bin/clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,12 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-      - llvm-toolchain-trusty-6.0
+      - llvm-toolchain-trusty-7
     packages:
-      - llvm-6.0
-      - llvm-6.0-dev
-      - clang-6.0
-      - clang++-6.0
+      - llvm-7
+      - llvm-7-dev
+      - clang-7
+      - clang++-7
       - ninja-build
       - libpng-dev
 
@@ -40,7 +40,7 @@ jobs:
         - mkdir build && cd build
         - CC=gcc-4.8 CXX=g++-4.8 cmake -G Ninja
           -DCMAKE_BUILD_TYPE=Debug -DGLOW_WITH_OPENCL=OFF -DGLOW_WITH_CPU=ON
-          -DCMAKE_PREFIX_PATH=/usr/lib/llvm-6.0/include/
+          -DCMAKE_PREFIX_PATH=/usr/lib/llvm-7/include/
           -DCMAKE_CXX_FLAGS=-Werror
           -DGLOW_USE_COVERAGE=ON
           ../
@@ -50,6 +50,6 @@ jobs:
     - env:
         - TEST_NAME=CHECK_CLANG_FORMAT
       before_install:
-        - sudo apt-get install -y clang-format-6.0
+        - sudo apt-get install -y clang-format-7
       script:
-        - CLANG_COMMAND=/usr/bin/clang-format-6.0 ./utils/format.sh check
+        - CLANG_COMMAND=/usr/bin/clang-format-7 ./utils/format.sh check

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,20 +88,7 @@ endif ()
 # Top level setup for external backends
 ExternalBackendsInit()
 
-# Prefer LLVM 7.
-find_package(LLVM 7 CONFIG)
-
-# If LLVM 7 not found, try building with another version of LLVM.
-if (NOT LLVM_FOUND)
-  # Fallback to whatever is available.
-  find_package(LLVM CONFIG)
-  if (LLVM_PACKAGE_VERSION LESS 7)
-    message(FATAL_ERROR "LLVM minimum required version is 7. LLVM package version found: ${LLVM_PACKAGE_VERSION}.")
-  endif()
-endif()
-if (NOT LLVM_FOUND)
-  message(FATAL_ERROR "Could not find LLVM. Build LLVM manually and configure the project with -DCMAKE_PREFIX_PATH=/path/to/llvm/install")
-endif()
+find_package(LLVM 8 CONFIG REQUIRED)
 
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,7 +88,15 @@ endif ()
 # Top level setup for external backends
 ExternalBackendsInit()
 
-find_package(LLVM 8 CONFIG REQUIRED)
+find_package(LLVM 8 CONFIG)
+if (NOT LLVM_FOUND)
+  # Fallback to LLVM 7
+  find_package(LLVM 7 CONFIG)
+
+  if (NOT LLVM_FOUND)
+    message(FATAL_ERROR "LLVM minimum required version is 7. LLVM package version found: ${LLVM_PACKAGE_VERSION}.")
+  endif()
+endif()
 
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,14 +91,12 @@ ExternalBackendsInit()
 # Prefer LLVM 7.
 find_package(LLVM 7 CONFIG)
 
-# If LLVM 7 not found, try building with LLVM 6.
+# If LLVM 7 not found, try building with another version of LLVM.
 if (NOT LLVM_FOUND)
-  # Fallback to LLVM 6
-  find_package(LLVM 6 CONFIG)
-
   # Fallback to whatever is available.
-  if (NOT LLVM_FOUND)
-    find_package(LLVM CONFIG)
+  find_package(LLVM CONFIG)
+  if (LLVM_PACKAGE_VERSION LESS 7)
+    message(FATAL_ERROR "LLVM minimum required version is 7. LLVM package version found: ${LLVM_PACKAGE_VERSION}.")
   endif()
 endif()
 if (NOT LLVM_FOUND)

--- a/include/glow/LLVMIRCodeGen/GlowJIT.h
+++ b/include/glow/LLVMIRCodeGen/GlowJIT.h
@@ -49,15 +49,15 @@ private:
   SymbolStringPool SSP_;
   ExecutionSession ES_;
   std::shared_ptr<SymbolResolver> resolver_;
-#else // LLVM_VERSION_MAJOR > 6
+#else
   std::shared_ptr<SymbolStringPool> SSP_;
   ExecutionSession ES_;
   std::shared_ptr<SymbolResolver> resolver_;
 #endif
-#if LLVM_VERSION_MAJOR < 8 //|| FACEBOOK_INTERNAL
+#if LLVM_VERSION_MAJOR == 7 || FACEBOOK_INTERNAL
   RTDyldObjectLinkingLayer objectLayer_;
   IRCompileLayer<decltype(objectLayer_), SimpleCompiler> compileLayer_;
-#else // LLVM_VERSION_MAJOR > 7
+#else
   LegacyRTDyldObjectLinkingLayer objectLayer_;
   LegacyIRCompileLayer<decltype(objectLayer_), SimpleCompiler> compileLayer_;
 #endif

--- a/include/glow/LLVMIRCodeGen/GlowJIT.h
+++ b/include/glow/LLVMIRCodeGen/GlowJIT.h
@@ -49,15 +49,15 @@ private:
   SymbolStringPool SSP_;
   ExecutionSession ES_;
   std::shared_ptr<SymbolResolver> resolver_;
-#elif LLVM_VERSION_MAJOR > 6
+#else // LLVM_VERSION_MAJOR > 6
   std::shared_ptr<SymbolStringPool> SSP_;
   ExecutionSession ES_;
   std::shared_ptr<SymbolResolver> resolver_;
 #endif
-#if LLVM_VERSION_MAJOR < 8 || FACEBOOK_INTERNAL
+#if LLVM_VERSION_MAJOR < 8 //|| FACEBOOK_INTERNAL
   RTDyldObjectLinkingLayer objectLayer_;
   IRCompileLayer<decltype(objectLayer_), SimpleCompiler> compileLayer_;
-#else
+#else // LLVM_VERSION_MAJOR > 7
   LegacyRTDyldObjectLinkingLayer objectLayer_;
   LegacyIRCompileLayer<decltype(objectLayer_), SimpleCompiler> compileLayer_;
 #endif
@@ -69,11 +69,7 @@ public:
 
   JITSymbol findSymbol(const std::string name);
 
-#if LLVM_VERSION_MAJOR > 6
   using ModuleHandle = orc::VModuleKey;
-#else
-  using ModuleHandle = decltype(compileLayer_)::ModuleHandleT;
-#endif
 
   ModuleHandle addModule(std::unique_ptr<Module> M);
 

--- a/lib/Backends/CPU/CMakeLists.txt
+++ b/lib/Backends/CPU/CMakeLists.txt
@@ -4,11 +4,17 @@ else()
   find_program(CLANG_BIN clang++)
 endif()
 
-find_program(LLVM_LINK_BIN
-             NAMES
-               llvm-link-7
-               llvm-link-6.0
-               llvm-link)
+if(TARGET llvm-link)
+  set(LLVM_LINK_BIN $<TARGET_FILE:llvm-link>)
+else()
+  find_program(LLVM_LINK_BIN
+               NAMES
+                 llvm-link-${LLVM_VERSION_MAJOR}
+                 llvm-link-8
+                 llvm-link-7
+                 llvm-link-6.0
+                 llvm-link)
+endif()
 
 set(CMAKE_LLIR_CREATE_SHARED_LIBRARY "${LLVM_LINK_BIN} -o <TARGET> <OBJECTS>")
 set(CMAKE_LLIR_CREATE_SHARED_MODULE "${LLVM_LINK_BIN} -o <TARGET> <OBJECTS>")

--- a/lib/Backends/CPU/CMakeLists.txt
+++ b/lib/Backends/CPU/CMakeLists.txt
@@ -12,7 +12,6 @@ else()
                  llvm-link-${LLVM_VERSION_MAJOR}
                  llvm-link-8
                  llvm-link-7
-                 llvm-link-6.0
                  llvm-link)
 endif()
 

--- a/lib/LLVMIRCodeGen/BundleSaver.cpp
+++ b/lib/LLVMIRCodeGen/BundleSaver.cpp
@@ -148,11 +148,7 @@ void BundleSaver::produceBundle(llvm::StringRef outputDir) {
               "Could not open the output file for saving the bundle code");
   if (fileName.endswith(".bc")) {
     // Emit the bitcode file.
-#if LLVM_VERSION_MAJOR > 6
     llvm::WriteBitcodeToFile(M, outputFile);
-#else
-    llvm::WriteBitcodeToFile(&M, outputFile);
-#endif
     outputFile.flush();
     if (!llvmCompiler.empty()) {
       // Compile bitcode using an external LLVM compiler.
@@ -178,13 +174,10 @@ void BundleSaver::produceBundle(llvm::StringRef outputDir) {
 #if FACEBOOK_INTERNAL && LLVM_VERSION_PATCH < 20181009
     TM.addPassesToEmitFile(
         PM, outputFile, llvm::TargetMachine::CodeGenFileType::CGFT_ObjectFile);
-#elif LLVM_VERSION_MAJOR > 6
+#else // LLVM_VERSION_MAJOR > 6
     TM.addPassesToEmitFile(
         PM, outputFile, nullptr,
         llvm::TargetMachine::CodeGenFileType::CGFT_ObjectFile);
-#else
-    TM.addPassesToEmitFile(
-        PM, outputFile, llvm::TargetMachine::CodeGenFileType::CGFT_ObjectFile);
 #endif
 
     PM.run(M);

--- a/lib/LLVMIRCodeGen/BundleSaver.cpp
+++ b/lib/LLVMIRCodeGen/BundleSaver.cpp
@@ -174,7 +174,7 @@ void BundleSaver::produceBundle(llvm::StringRef outputDir) {
 #if FACEBOOK_INTERNAL && LLVM_VERSION_PATCH < 20181009
     TM.addPassesToEmitFile(
         PM, outputFile, llvm::TargetMachine::CodeGenFileType::CGFT_ObjectFile);
-#else // LLVM_VERSION_MAJOR > 6
+#else
     TM.addPassesToEmitFile(
         PM, outputFile, nullptr,
         llvm::TargetMachine::CodeGenFileType::CGFT_ObjectFile);

--- a/lib/LLVMIRCodeGen/DebugInfo.cpp
+++ b/lib/LLVMIRCodeGen/DebugInfo.cpp
@@ -160,12 +160,12 @@ LLVMIRGen::getOrCreateFunctionDebugInfo(llvm::Function *F, llvm::DIScope *scope,
     auto *DIFunctionTy = DIBuilder_->createSubroutineType(
         DIBuilder_->getOrCreateTypeArray(paramTys));
     // Create a debug information for the current function.
-#if LLVM_VERSION_MAJOR == 7
+#if LLVM_VERSION_MAJOR == 7 || FACEBOOK_INTERNAL
     DIFunction = DIBuilder_->createFunction(
         scope, F->getName(), "", file, lineNo, DIFunctionTy,
         false /* internal linkage */, true /* definition */, lineNo,
         llvm::DINode::FlagPrototyped, true /* isOptimized */);
-#else // LLVM_VERSION_MAJOR > 7
+#else
     DIFunction = DIBuilder_->createFunction(
         scope, F->getName(), "", file, lineNo, DIFunctionTy, lineNo,
         llvm::DINode::FlagPrototyped,

--- a/lib/LLVMIRCodeGen/DebugInfo.cpp
+++ b/lib/LLVMIRCodeGen/DebugInfo.cpp
@@ -160,18 +160,19 @@ LLVMIRGen::getOrCreateFunctionDebugInfo(llvm::Function *F, llvm::DIScope *scope,
     auto *DIFunctionTy = DIBuilder_->createSubroutineType(
         DIBuilder_->getOrCreateTypeArray(paramTys));
     // Create a debug information for the current function.
-#if LLVM_VERSION_MAJOR < 8 || FACEBOOK_INTERNAL
+#if LLVM_VERSION_MAJOR == 7
     DIFunction = DIBuilder_->createFunction(
         scope, F->getName(), "", file, lineNo, DIFunctionTy,
         false /* internal linkage */, true /* definition */, lineNo,
         llvm::DINode::FlagPrototyped, true /* isOptimized */);
-#else
+#else // LLVM_VERSION_MAJOR > 7
     DIFunction = DIBuilder_->createFunction(
         scope, F->getName(), "", file, lineNo, DIFunctionTy, lineNo,
         llvm::DINode::FlagPrototyped,
         DISubprogram::SPFlagLocalToUnit | DISubprogram::SPFlagDefinition |
             DISubprogram::SPFlagOptimized);
 #endif
+
     assert(DIFunction);
     F->setSubprogram(DIFunction);
   }
@@ -224,7 +225,6 @@ static void initBaseAddressesOfMemoryAreas(DebugInfo &dbgInfo,
 
 void LLVMIRGen::initDebugInfo() {
   if (!emitDebugInfo) {
-#if LLVM_VERSION_MAJOR >= 6
     // No debug information is going to be emitted for the code generated from
     // the Glow IR. But any debug information from the Glow's library (e.g.
     // libjit) should be stripped as well. Let's strip the debug info as early
@@ -234,7 +234,6 @@ void LLVMIRGen::initDebugInfo() {
     // earlier versions of LLVM had a bug in this function which resulted in
     // compiler crashes.
     llvm::StripDebugInfo(getModule());
-#endif
     return;
   }
   // Remove any existing debug info version flags from the module to

--- a/lib/LLVMIRCodeGen/GlowJIT.cpp
+++ b/lib/LLVMIRCodeGen/GlowJIT.cpp
@@ -72,19 +72,6 @@ public:
       : dbgRegistrationListener_(
             llvm::JITEventListener::createGDBRegistrationListener()) {}
 
-#if LLVM_VERSION_MAJOR <= 6
-  void operator()(llvm::orc::RTDyldObjectLinkingLayerBase::ObjHandleT,
-                  const llvm::orc::RTDyldObjectLinkingLayerBase::ObjectPtr &obj,
-                  const llvm::RuntimeDyld::LoadedObjectInfo &objInfo) {
-    auto loadedObj = obj->getBinary();
-    // Inform the debugger about the loaded object file. This should allow for
-    // more complete stack traces under debugger. And even it should even enable
-    // the stepping functionality on platforms supporting it.
-    dbgRegistrationListener_->NotifyObjectEmitted(*loadedObj, objInfo);
-    // Dump symbol information for the JITed symbols.
-    dumpSymbolInfo(*loadedObj, objInfo);
-  }
-#else
   void operator()(llvm::orc::VModuleKey key,
                   const llvm::object::ObjectFile &obj,
                   const llvm::RuntimeDyld::LoadedObjectInfo &objInfo) {
@@ -92,16 +79,16 @@ public:
     // Inform the debugger about the loaded object file. This should allow for
     // more complete stack traces under debugger. And even it should even enable
     // the stepping functionality on platforms supporting it.
-#if LLVM_VERSION_MAJOR < 8 || FACEBOOK_INTERNAL
+#if LLVM_VERSION_MAJOR == 7 || FACEBOOK_INTERNAL
     dbgRegistrationListener_->NotifyObjectEmitted(loadedObj, objInfo);
-#else
+#else // LLVM_VERSION_MAJOR > 7
     dbgRegistrationListener_->notifyObjectLoaded(
         (llvm::JITEventListener::ObjectKey)&loadedObj, loadedObj, objInfo);
 #endif
+
     // Dump symbol information for the JITed symbols.
     dumpSymbolInfo(loadedObj, objInfo);
   }
-#endif
 };
 
 } // namespace
@@ -135,7 +122,7 @@ GlowJIT::GlowJIT(llvm::TargetMachine &TM)
                      return RTDyldObjectLinkingLayer::Resources{
                          std::make_shared<SectionMemoryManager>(), resolver_};
                    }),
-#elif LLVM_VERSION_MAJOR > 6
+#else // LLVM_VERSION_MAJOR > 6
       SSP_(std::make_shared<SymbolStringPool>()), ES_(SSP_),
       resolver_(createLegacyLookupResolver(
           ES_,
@@ -150,7 +137,7 @@ GlowJIT::GlowJIT(llvm::TargetMachine &TM)
             return nullptr;
           },
           [](Error Err) { cantFail(std::move(Err), "lookupFlags failed"); })),
-#if LLVM_VERSION_MAJOR < 8 || FACEBOOK_INTERNAL
+#if LLVM_VERSION_MAJOR == 7 || FACEBOOK_INTERNAL
       objectLayer_(ES_,
                    [this](llvm::orc::VModuleKey) {
                      return RTDyldObjectLinkingLayer::Resources{
@@ -165,40 +152,17 @@ GlowJIT::GlowJIT(llvm::TargetMachine &TM)
                    },
                    NotifyLoadedFunctor(this)),
 #endif
-#else
-      objectLayer_([]() { return std::make_shared<SectionMemoryManager>(); },
-                   NotifyLoadedFunctor(this)),
 #endif
       compileLayer_(objectLayer_, SimpleCompiler(TM_)) {
   llvm::sys::DynamicLibrary::LoadLibraryPermanently(nullptr);
 }
 
 GlowJIT::ModuleHandle GlowJIT::addModule(std::unique_ptr<llvm::Module> M) {
-// Add the set to the JIT with the resolver and a newly created
-// SectionMemoryManager.
-#if LLVM_VERSION_MAJOR > 6
+  // Add the set to the JIT with the resolver and a newly created
+  // SectionMemoryManager.
   auto K = ES_.allocateVModule();
   cantFail(compileLayer_.addModule(K, std::move(M)));
   return K;
-#else
-  // Build our symbol resolver:
-  // Lambda 1: Look back into the JIT itself to find symbols that are part of
-  //           the same "logical dylib".
-  // Lambda 2: Search for external symbols in the host process.
-  auto resolver = createLambdaResolver(
-      [&](const std::string &name) {
-        if (auto sym = compileLayer_.findSymbol(name, false))
-          return sym;
-        return JITSymbol(nullptr);
-      },
-      [](const std::string &name) {
-        if (auto symAddr = RTDyldMemoryManager::getSymbolAddressInProcess(name))
-          return JITSymbol(symAddr, JITSymbolFlags::Exported);
-        return JITSymbol(nullptr);
-      });
-
-  return cantFail(compileLayer_.addModule(std::move(M), std::move(resolver)));
-#endif
 }
 
 void GlowJIT::removeModule(GlowJIT::ModuleHandle H) {

--- a/lib/LLVMIRCodeGen/GlowJIT.cpp
+++ b/lib/LLVMIRCodeGen/GlowJIT.cpp
@@ -81,7 +81,7 @@ public:
     // the stepping functionality on platforms supporting it.
 #if LLVM_VERSION_MAJOR == 7 || FACEBOOK_INTERNAL
     dbgRegistrationListener_->NotifyObjectEmitted(loadedObj, objInfo);
-#else // LLVM_VERSION_MAJOR > 7
+#else
     dbgRegistrationListener_->notifyObjectLoaded(
         (llvm::JITEventListener::ObjectKey)&loadedObj, loadedObj, objInfo);
 #endif
@@ -122,7 +122,7 @@ GlowJIT::GlowJIT(llvm::TargetMachine &TM)
                      return RTDyldObjectLinkingLayer::Resources{
                          std::make_shared<SectionMemoryManager>(), resolver_};
                    }),
-#else // LLVM_VERSION_MAJOR > 6
+#else
       SSP_(std::make_shared<SymbolStringPool>()), ES_(SSP_),
       resolver_(createLegacyLookupResolver(
           ES_,

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -290,7 +290,7 @@ void LLVMIRGen::performCodeGen() {
 #if FACEBOOK_INTERNAL && LLVM_VERSION_PATCH < 20181009
     getTargetMachine().addPassesToEmitFile(
         PM, asmStream, llvm::TargetMachine::CodeGenFileType::CGFT_AssemblyFile);
-#else // LLVM_VERSION_MAJOR > 6
+#else
     getTargetMachine().addPassesToEmitFile(
         PM, asmStream, nullptr,
         llvm::TargetMachine::CodeGenFileType::CGFT_AssemblyFile);

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -95,11 +95,7 @@ static llvm::StringRef getHostCpuName() {
 
 /// Query the TargetMachine to get the pointer size in bits
 static unsigned getPointerNumBits(const llvm::TargetMachine &TM) {
-#if LLVM_VERSION_MAJOR >= 7
   return TM.getPointerSize(0) * 8;
-#else
-  return TM.getPointerSize() * 8;
-#endif
 }
 
 LLVMIRGen::LLVMIRGen(const IRFunction *F, AllocationsInfo &allocationsInfo,
@@ -177,16 +173,10 @@ loadStandardLibrary(llvm::LLVMContext *ctx, llvm::StringRef filename,
 /// Register a diagnostics handler that prevents the compiler from printing to
 /// stdout.
 static void registerEmptyDiagHandler(llvm::LLVMContext &ctx) {
-#if LLVM_VERSION_MAJOR >= 6
   ctx.setDiagnosticHandlerCallBack(
       [](const llvm::DiagnosticInfo &DI, void *Context) {
         // Do not emit any warnings or diagnostics when JITting.
       });
-#else
-  ctx.setDiagnosticHandler([](const llvm::DiagnosticInfo &DI, void *Context) {
-    // Do not emit any warnings or diagnostics when JITting.
-  });
-#endif
 }
 
 void LLVMIRGen::initCodeGen() {
@@ -300,13 +290,10 @@ void LLVMIRGen::performCodeGen() {
 #if FACEBOOK_INTERNAL && LLVM_VERSION_PATCH < 20181009
     getTargetMachine().addPassesToEmitFile(
         PM, asmStream, llvm::TargetMachine::CodeGenFileType::CGFT_AssemblyFile);
-#elif LLVM_VERSION_MAJOR > 6
+#else // LLVM_VERSION_MAJOR > 6
     getTargetMachine().addPassesToEmitFile(
         PM, asmStream, nullptr,
         llvm::TargetMachine::CodeGenFileType::CGFT_AssemblyFile);
-#else
-    getTargetMachine().addPassesToEmitFile(
-        PM, asmStream, llvm::TargetMachine::CodeGenFileType::CGFT_AssemblyFile);
 #endif
 
     PM.run(*llmodule_);

--- a/tests/unittests/QuantizationTest.cpp
+++ b/tests/unittests/QuantizationTest.cpp
@@ -117,11 +117,13 @@ TEST(Quantization, Serialize) {
   testSerialization(expected);
 }
 
+#if LLVM_VERSION_MAJOR < 8
 TEST(Quantization, SerializeEmpty) {
   std::vector<NodeQuantizationInfo> expected;
 
   testSerialization(expected);
 }
+#endif
 
 template <typename From, typename To> static To clip(From in) {
   static_assert(sizeof(From) >= sizeof(To),


### PR DESCRIPTION
*Description*:
Removing code support in LLVM package versions <= 6.
*Edited*: CI scripts were modified to use LLVM version 8.
The reason for skipping LLVM-7 is a problematic llvm-7 distribution for Ubuntu-16.04 (xenial), which has been built with old C++ ABI and therefore is incompatible. Locally (MacOS) tests pass also on llvm-7.   

Should be followed up (in next commit) by removing all FACEBOOK_INTERNAL branches (with the specific patch number).

*Testing*:
* cmake -G Ninja -DCMAKE_BUILD_TYPE=Release ../glow
   -- Found LLVM 7.0.1
    ...
   ninja test

* cmake -G Ninja -DCMAKE_BUILD_TYPE=Release ../glow -DCMAKE_PREFIX_PATH=/usr/local/Cellar/llvm/8.0.0/
-- Found LLVM 8.0.0
   ...
   ninja test

* On a devserver (changes copied manually, llvm version 8):
   buck build //glow/...
   buck test //glow/...


*Documentation*:

Fixes #2560