### PR TITLE
Move all precision transformation into optimizeFunction()

### DIFF
--- a/docs/GraphOptimizationPipeline.md
+++ b/docs/GraphOptimizationPipeline.md
@@ -1,0 +1,151 @@
+## Glow Graph Optimization Pipeline
+
+This document describes the optimization pipeline and how to configure it for
+varying precision configurations. Note that the terms "Graph" and "Function" are
+often used interchangably.
+
+### Graph (Function) Optimization Stages and Order
+
+`glow::optimizeFunction()` is used to drive the optimization pipeline of a
+Function. Inside `optimizeFunction()`, a Function is optimized by the following
+optimization stages in order:
+
+- `fold()`
+- `optimize()`
+- `lower()`
+- `transformForPrecisionMode()`
+- `optimize()`
+- `Backend::transformPostLowering()`
+- `optimize()`
+- `checkAllNodesSupported()`
+
+Note that optimize is called many times, usually after every other stage. This
+is because the other stages may add or change the graph in some ways that allow
+for previously inapplicable optimizations to now occur, or new nodes may be able
+to take advantage of the optimizations.
+
+### Descriptions of Optimization Stages
+
+- `glow::fold()`: Fold low-level Nodes into higher-level Nodes. This is useful
+  when compiling an input model where some high-level operators have been
+  lowered (this can be for instance a side effect of model converters, like
+  converters from Tensorflow to ONNX). In this situation, such folding can then
+  enable more optimizations and also improve the performance of backends that
+  support natively such high-level operators. Folding is done first, as we want
+  to raise the graph to a higher level in order to take advantage of high-level
+  optimizations and allow for backends to prevent lowering on them as well if
+  desired.
+
+- `glow::lower()`: Lowers high-level Nodes into lower-level Nodes. This allows
+  backends to be agnostic to higher-level representations of Nodes. For example,
+  a backend may support an LSTM if it supports all of the sub-nodes found inside
+  an LSTM. However, it does not need to be responsible for understanding that it
+  supports an LSTM. This future-proofs the backend, allowing it to support
+  future high-level complex nodes without understanding their higher-level
+  semantics. Note that [Backends can prevent
+  lowering](Backends.md#backend-abstract-class) if preferred via
+  `Backend::shouldLower()`.
+
+- `transformForPrecisionMode()`: Transforms the graph depending on requested
+  precision configuration. There are a few different options here:
+
+  - `Profile`: Add special profiling nodes to the graph to gather a histogram of
+    values flowing through each Node in the graph. This can then be used to
+    automatically quantize the graph.
+
+  - `Quantize`: Quantize the graph, given a previously gathered profile as
+    mentioned above. This converts all Float inputs and outputs of each Node if
+    the backend supports the node as quantized.
+
+  - `ConvertToFP16`: Convert all Float inputs and outputs of Nodes to
+    Float16. Note that this does not require any sort of profile. It can also be
+    performed alongside Quantization to get a mixed precision graph.
+
+- `Backend::transformPostLowering()`: Allow the Backend to transform the
+  graph. This includes swapping in its own backend-specific nodes. More info can
+  be found [here](Backends.md#backend-abstract-class) and
+  [here](NewBackendSpecificNode.md#steps).
+
+- `glow::optimize()`: Performs a series of graph optimizations, as listed
+  [here](Optimizations.md#set-of-supported-graph-optimizations). Many of these
+  are common compiler optimizations, such as DCE and CSE. Others are more ML and
+  linear algebra related, such as fusing BatchNormalization into Convolutions in
+  inference mode, or combining a series of Transpose operations into a single
+  Transpose.
+
+- `checkAllNodesSupported()`: Given some Backend that we are optimizing the
+  Graph for, this verifies that the backend supports each of the nodes after the
+  entire optimization pipeline is complete, via
+  [Backend::isOpSupported()](Backends.md#backend-abstract-class). If any node is
+  not supported it will return an error, which `optimizeFunction()` will then
+  return up the stack.
+
+## How to call `glow::optimizeFunction()`
+
+Here we describe the API for `glow::optimizeFunction()` and how to use it in
+different modes.
+
+```
+llvm::Error glow::optimizeFunction(Function *F, const Backend &B,
+                                   const CompilationContext &cctx);
+```
+
+An error is returned if something goes wrong during the optimization pipeline,
+for example if a Node is no longer supported by the backend after optimizations,
+or if the CompilationContext is not set up correctly.
+
+- `F`: The Function (graph) to optimize. It will be transformed; if the caller
+  would like to keep an original copy of the Function it is responsible for
+  cloning it before calling `optimizeFunction()`.
+
+- `B`: The Backend for which we are optimizing `F`. It is able to control what
+  is lowered (`Backend::shouldLower()`), to specify what should be quantized
+  (`Backend::isOpSupported()`); and to transform the graph however it wishes
+  (`Backend::transformPostLowering()`).
+
+- `cctx`: The CompilationContext, containing important data structures to keep
+  some state before/after compilation is complete, as well as configuration
+  information for what kinds of transformations to perform.
+
+  - `PlaceholderBindings *bindings`: Mapping between Placeholders and Tensors
+    for this compilation run. For example, this is used when instrumenting a
+    Function for quantizaiton profiling, to create Placeholders and their
+    Tensors for inserted `QuantizationProfileNodes`.
+
+  - `LoweredInfoMap *loweredInfoMap`: Mapping from each Node output name in a
+    Function (corresponding to unique NodeValues in a Function), to a set of
+    `NodeNameAndKind` (which is a pair of Node output name and Kind). This is
+    used to keep track of what Nodes are lowered into what other Nodes, for use
+    during Profiling and Quantization.
+
+  - `enum class CompilationMode compMode`: This is set to either `Train` or
+    `Infer`, depending on what the Function is being used for. Some
+    optimizations may only be performed during one of these modes.
+
+  - `struct BackendOptions backendOpts`: Different options for compilation after
+    graph optimizations have been completed. [See
+    here](Backends.md#backendoptions-helper-struct) for more info.
+
+  - `struct PrecisionConfiguration precisionConfig`: Configuration for different
+    precision modes, used during `transformForPrecisionMode()`. Contains the
+    following:
+
+    - `enum class QuantizationMode quantMode`: One of `None`, `Quantize`, or
+      `Profile`, as previously mentioned above.
+
+    - `quantization::QuantizationConfiguration quantConfig`: Configuration for
+      quantization, including the quantizaion precision `ElemKind`
+      (e.g. `Int8QTy`, `Int16QTy`, etc.),
+      [schema](Quantization.md#how-to-perform-nn-conversion) (e.g. Asymmetric,
+      Symmetric, etc.), whether to use rowwise quantization, etc.
+
+    - `bool convertToFP16`: Whether to convert all found `FloatTy` to
+      `Float16Ty` in the Function. This is performed after Quantization, and so
+      can be used together to get a mixed precision model.
+
+    - `KindSet precisionModeKindSet`: A set of node kinds. This has different
+      uses depending on the precision mode. If in profiling mode, this
+      represents node kinds that should not be lowered ([mentioned
+      here](Quantization.md#how-to-perform-nn-conversion)). If performing
+      quantization or FP16 conversion this represents node kinds that should not
+      be converted, and should instead be left in FloatTy.

--- a/examples/resnet-runtime.cpp
+++ b/examples/resnet-runtime.cpp
@@ -151,8 +151,8 @@ int main(int argc, char **argv) {
   TypeRef inputType = module->uniqueType(ElemKind::FloatTy, inputShape);
   input = loadResnet50Model(inputType, module.get(), 0);
   phList = module->getPlaceholders();
-  EXIT_ON_ERR(
-      hostManager->addNetwork(std::move(module), /*saturateHost*/ true));
+  EXIT_ON_ERR(hostManager->addNetwork(std::move(module), CompilationContext(),
+                                      /*saturateHost*/ true));
 
   llvm::outs() << "Loading files from " << inputDirectory << "\n";
   std::error_code code;

--- a/examples/tracing-compare.cpp
+++ b/examples/tracing-compare.cpp
@@ -80,7 +80,7 @@ std::unique_ptr<CompiledFunction> compileModel(Module &module,
 
   llvm::outs() << "Starting compile on " << (int)backendKind << ".\n";
   CompilationContext cctx;
-  cctx.mode = CompilationMode::Infer;
+  cctx.compMode = CompilationMode::Infer;
   cctx.backendOpts.autoInstrument = true;
   EXIT_ON_ERR(::glow::optimizeFunction(F_, *backend, cctx));
   return backend->compile(F_, cctx.backendOpts);

--- a/include/glow/Optimizer/CompilationContext.h
+++ b/include/glow/Optimizer/CompilationContext.h
@@ -19,11 +19,44 @@
 #include "glow/Backends/BackendOptions.h"
 #include "glow/Graph/PlaceholderBindings.h"
 #include "glow/Quantization/Base/Base.h"
+#include "glow/Support/Error.h"
 
 namespace glow {
 
+/// Configuration for different precision modes.
+struct PrecisionConfiguration {
+  /// Enum for what kind of transformation should be done for Quantization.
+  enum class QuantizationMode {
+    None,     /// Perform no transformations for quantization.
+    Quantize, /// Quantize the graph using previously gathered statistics.
+    Profile,  /// Add profiling nodes for quantization statistics gathering.
+  } quantMode{QuantizationMode::None};
+
+  /// Configuration for Quantization.
+  quantization::QuantizationConfiguration quantConfig;
+
+  /// Whether to convert the FloatTy to Float16Ty in the Function.
+  bool convertToFP16{false};
+
+  /// Used during Quantization and convertToFP16 to keep the original precision
+  /// of specific node kinds (i.e. quantization/FP16 conversion would be skipped
+  /// for any node kinds found here). Used during profiling to prevent nodes
+  /// from being lowered before instrumenting the graph (e.g. do not lower group
+  /// convolutions for profiling; see `-do-not-lower-nodes-for-profiling` in
+  /// docs/Quantization.md).
+  KindSet precisionModeKindSet;
+};
+
+using QuantizationMode = PrecisionConfiguration::QuantizationMode;
+
 /// Context for compilation.
 struct CompilationContext {
+  /// Used during Profiling.
+  PlaceholderBindings *bindings{nullptr};
+
+  /// Used during Quantization and Profiling.
+  LoweredInfoMap *loweredInfoMap{nullptr};
+
   /// Select whether in Training or Inference mode.
   enum class CompilationMode {
     Train, /// Compile the graph in preperation for training.
@@ -33,6 +66,43 @@ struct CompilationContext {
 
   /// Options for the Backend to use.
   BackendOptions backendOpts;
+
+  /// Configuration for different precision modes.
+  PrecisionConfiguration precisionConfig;
+
+  CompilationContext(PlaceholderBindings *bindings_ = nullptr,
+                     LoweredInfoMap *loweredInfoMap_ = nullptr)
+      : bindings(bindings_), loweredInfoMap(loweredInfoMap_) {}
+
+  /// \returns an error if the CompilationContext is malformed for whatever
+  /// configuration it is set up for, otherwise returns success.
+  llvm::Error verify() const {
+    switch (precisionConfig.quantMode) {
+    case QuantizationMode::Profile:
+      RETURN_ERR_IF_NOT(bindings, GlowErr::ErrorCode::COMPILE_CONTEXT_MALFORMED,
+                        "In Profiling mode, but bindings was not set.\n");
+
+      RETURN_ERR_IF_NOT(loweredInfoMap,
+                        GlowErr::ErrorCode::COMPILE_CONTEXT_MALFORMED,
+                        "In Profiling mode, but loweredInfoMap was not set.\n");
+
+      RETURN_ERR_IF_NOT(!precisionConfig.convertToFP16,
+                        GlowErr::ErrorCode::COMPILE_CONTEXT_MALFORMED,
+                        "Converting to FP16 while profiling is unsupported.\n");
+      break;
+
+    case QuantizationMode::Quantize:
+      RETURN_ERR_IF_NOT(
+          loweredInfoMap, GlowErr::ErrorCode::COMPILE_CONTEXT_MALFORMED,
+          "In Quantization mode, but loweredInfoMap was not set.\n");
+      break;
+
+    case QuantizationMode::None:
+      break;
+    }
+
+    return llvm::Error::success();
+  }
 };
 
 using CompilationMode = CompilationContext::CompilationMode;

--- a/include/glow/Optimizer/CompilationContext.h
+++ b/include/glow/Optimizer/CompilationContext.h
@@ -62,7 +62,7 @@ struct CompilationContext {
     Train, /// Compile the graph in preperation for training.
     Infer, /// Compile the graph for inference. Notice that this operation
            /// changes the graph in a way that is not reversible.
-  } mode{CompilationMode::Infer};
+  } compMode{CompilationMode::Infer};
 
   /// Options for the Backend to use.
   BackendOptions backendOpts;

--- a/include/glow/Partitioner/Partitioner.h
+++ b/include/glow/Partitioner/Partitioner.h
@@ -238,14 +238,18 @@ public:
                      std::vector<Backend *> &backends);
 
   /// If there is no need to do any partition, just generate the DAGNode based
-  /// on current functions in this module.
+  /// on current functions in this module for backend \p backendKind found in \p
+  /// backendMap. \p cctx is used during optimization of the Function. \returns
+  /// whether there was an error encountered.
   llvm::Error
   createDAGWithoutPartition(BackendKind backendKind,
-                            std::map<BackendKind, BackendInfo> &backendMap);
+                            std::map<BackendKind, BackendInfo> &backendMap,
+                            const CompilationContext &cctx);
 
   /// Decompose each function in a module. Now we support partitioning a module
-  /// among different type of devices.
-  llvm::Error Partition();
+  /// among different type of devices. \p cctx is used during optimization of
+  /// the Function. \returns whether there was an error encountered.
+  llvm::Error Partition(const CompilationContext &cctx = CompilationContext());
 
   /// Get the partitions.
   DAGListTy &getPartitionResult() { return partitions_; }

--- a/include/glow/Runtime/HostManager/HostManager.h
+++ b/include/glow/Runtime/HostManager/HostManager.h
@@ -86,15 +86,15 @@ class HostManager final {
 public:
   /// Adds the network to the host and does the necessary setup work. This
   /// includes partitioning, provisioning, compiling and initializing
-  /// backends. Additionally DAGs are created for each function and stored
-  /// in networks_. Returns an llvm::Error containing the results of the
+  /// backends. Additionally DAGs are created for each function and stored in
+  /// networks_. \returns an llvm::Error containing the results of the
   /// operation. This function consumes the \p module so any pointers to data
-  /// contained within the module should be considered invalid. If \p
-  /// saturateHost is set to true the HostManager will try to use all available
-  /// devices on the host. If \p profiling is true,the HostManager will check
-  /// that each function is not partitioned.
+  /// contained within the module should be considered invalid. The function is
+  /// optimized based on \p cctx. If \p saturateHost is set to true the
+  /// HostManager will try to use all available devices on the host.
   llvm::Error addNetwork(std::unique_ptr<Module> module,
-                         bool saturateHost = false, bool profiling = false);
+                         const CompilationContext &cctx = CompilationContext(),
+                         bool saturateHost = false);
 
   /// Given \p networkName removes that network from the host. This also
   /// removes the network from any backends setup to execute it.

--- a/include/glow/Support/Error.h
+++ b/include/glow/Support/Error.h
@@ -79,6 +79,8 @@ public:
     RUNTIME_DEVICE_NOT_FOUND,
     // Compilation error; node unsupported after optimizations.
     COMPILE_UNSUPPORTED_NODE_AFTER_OPTIMIZE,
+    // Compilation error; Compilation context not correctly setup.
+    COMPILE_CONTEXT_MALFORMED,
   };
 
   /// GlowErr is not convertable to std::error_code. This is included for
@@ -146,6 +148,8 @@ private:
       return "RUNTIME_DEVICE_NOT_FOUND";
     case ErrorCode::COMPILE_UNSUPPORTED_NODE_AFTER_OPTIMIZE:
       return "COMPILE_UNSUPPORTED_NODE_AFTER_OPTIMIZE";
+    case ErrorCode::COMPILE_CONTEXT_MALFORMED:
+      return "COMPILE_CONTEXT_MALFORMED";
     };
 
     llvm_unreachable("unsupported ErrorCode");

--- a/lib/Backends/OpenCL/Transforms.cpp
+++ b/lib/Backends/OpenCL/Transforms.cpp
@@ -30,7 +30,7 @@ bool OCLBackend::transformPostLowering(Function *F,
                                        const CompilationContext &cctx) const {
   // NCHW transformation is not supported in training mode yet, because of some
   // issues with gradient nodes.
-  if (cctx.mode == CompilationMode::Train)
+  if (cctx.compMode == CompilationMode::Train)
     return false;
 
   bool changed = false;

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -237,7 +237,7 @@ void glow::runBatch(ExecutionEngine &EE, PlaceholderBindings &bindings,
 void ExecutionEngine::compile(CompilationMode mode, Function *F,
                               bool clearOtherFunctions) {
   CompilationContext cctx;
-  cctx.mode = mode;
+  cctx.compMode = mode;
   compile(F, cctx, clearOtherFunctions);
 }
 

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -57,7 +57,7 @@ onnxStatus BackendId::checkGraphCompatibility(const void *onnxModel,
   // Call the backend's transformPostLowering to match the normal compilation
   // pipeline then DCE any nodes that are no longer needed.
   CompilationContext cctx;
-  cctx.mode = CompilationMode::Infer;
+  cctx.compMode = CompilationMode::Infer;
   if (glowBackend_->transformPostLowering(function, cctx)) {
     glow::DCE(function);
   }

--- a/lib/Onnxifi/GlowOnnxifiManager.cpp
+++ b/lib/Onnxifi/GlowOnnxifiManager.cpp
@@ -71,17 +71,16 @@ EventPtr GlowOnnxifiManager::createEvent() {
   return event;
 }
 
-GraphPtr
-GlowOnnxifiManager::createGraph(BackendPtr backend,
-                                OnnxifiQuantizationStep quantizationStep) {
+GraphPtr GlowOnnxifiManager::createGraph(BackendPtr backend,
+                                         QuantizationMode quantizationMode) {
   assert(isValid(backend));
 
   GraphPtr graph;
 
-  if (quantizationStep == OnnxifiQuantizationStep::None) {
+  if (quantizationMode == QuantizationMode::None) {
     graph = new onnxifi::HostManagerGraph(backend);
   } else {
-    graph = new onnxifi::InlineGraph(backend, quantizationStep);
+    graph = new onnxifi::InlineGraph(backend, quantizationMode);
   }
 
   std::lock_guard<std::mutex> lock(m_);

--- a/lib/Onnxifi/GlowOnnxifiManager.h
+++ b/lib/Onnxifi/GlowOnnxifiManager.h
@@ -59,9 +59,9 @@ public:
 
   /// Create a new glow Graph associated with \p backend.
   /// Can be called safely by multiple threads concurrently.
-  GraphPtr createGraph(
-      BackendPtr backend,
-      OnnxifiQuantizationStep quantizationStep = OnnxifiQuantizationStep::None);
+  GraphPtr
+  createGraph(BackendPtr backend,
+              QuantizationMode quantizationMode = QuantizationMode::None);
 
   /// Check if \p backendId is a BackendId created and managed by glow.
   /// Can be called safely by multiple threads concurrently.

--- a/lib/Onnxifi/InlineOnnxifi.h
+++ b/lib/Onnxifi/InlineOnnxifi.h
@@ -23,18 +23,12 @@
 namespace glow {
 namespace onnxifi {
 
-enum class OnnxifiQuantizationStep : char {
-  None,     // Don't perform any quantization steps
-  Profile,  // Insert profiling nodes and dump quantization profiles
-  Quantize, // Load quantization profile and insert quantize/dequantize nodes
-};
-
 /// Onnxifi Graph whose run method just executes the underlying function on the
 /// same thread that calls its setIOAndRun function.
 class InlineGraph : public Graph {
 public:
-  InlineGraph(BackendPtr backendPtr, OnnxifiQuantizationStep quantizationStep)
-      : Graph(backendPtr), quantizationStep_(quantizationStep) {}
+  InlineGraph(BackendPtr backendPtr, QuantizationMode quantizationMode)
+      : Graph(backendPtr), quantizationMode_(quantizationMode) {}
 
   /// Init Glow graph based on the ONNX model \p onnxModel and
   /// static trained weights \p weightDescriptors.
@@ -48,7 +42,7 @@ public:
 private:
   ExecutionEngine executionEngine_;
   Function *function_;
-  OnnxifiQuantizationStep quantizationStep_;
+  QuantizationMode quantizationMode_;
 
   /// A map between quantization profiling names of NodeValues that were lowered
   /// from each other. Maps to a set of NodeValues that were replaced by the

--- a/lib/Onnxifi/onnxifiGlow.cpp
+++ b/lib/Onnxifi/onnxifiGlow.cpp
@@ -392,16 +392,16 @@ GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxInitGraph)(
     return ONNXIFI_STATUS_INVALID_BACKEND;
   }
 
-  glow::onnxifi::OnnxifiQuantizationStep quantizationStep;
+  glow::QuantizationMode quantizationMode;
   if (getenv("GLOW_DUMP_PROFILE")) {
-    quantizationStep = glow::onnxifi::OnnxifiQuantizationStep::Profile;
+    quantizationMode = glow::QuantizationMode::Profile;
   } else if (getenv("GLOW_LOAD_PROFILE")) {
-    quantizationStep = glow::onnxifi::OnnxifiQuantizationStep::Quantize;
+    quantizationMode = glow::QuantizationMode::Quantize;
   } else {
-    quantizationStep = glow::onnxifi::OnnxifiQuantizationStep::None;
+    quantizationMode = glow::QuantizationMode::None;
   }
 
-  auto *glowGraph = manager.createGraph(glowBackend, quantizationStep);
+  auto *glowGraph = manager.createGraph(glowBackend, quantizationMode);
   auto ret = glowGraph->initGraph(onnxModel, onnxModelSize, weightsCount,
                                   weightDescriptors);
   if (ret != ONNXIFI_STATUS_SUCCESS) {

--- a/lib/Optimizer/CMakeLists.txt
+++ b/lib/Optimizer/CMakeLists.txt
@@ -7,6 +7,8 @@ add_library(Optimizer
 target_link_libraries(Optimizer
                       PRIVATE
                         Backend
+                        Converter
                         Graph
                         IR
+                        Quantization
                         QuantizationBase)

--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "glow/Backend/Backend.h"
+#include "glow/Converter/TypeAToTypeBFunctionConverter.h"
 #include "glow/Graph/Graph.h"
 #include "glow/Graph/Node.h"
 #include "glow/Graph/Nodes.h"
@@ -22,6 +23,7 @@
 #include "glow/Graph/Utils.h"
 #include "glow/Optimizer/Optimizer.h"
 #include "glow/Quantization/Base/Base.h"
+#include "glow/Quantization/Quantization.h"
 
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/CommandLine.h"
@@ -2720,16 +2722,79 @@ static llvm::Error checkAllNodesSupported(const Function &F, const Backend &B) {
   return llvm::Error::success();
 }
 
+/// Helper function that may transform \p F given preferences of \p cctx and
+/// \p B. The specific transformations are done based on the
+/// PrecisionConfiguration found in \p cctx. This could include quantization,
+/// profiling, and FP16 conversion.
+static void transformForPrecisionMode(const Backend &B, Function *F,
+                                      const CompilationContext &cctx) {
+  const PrecisionConfiguration &precConfig = cctx.precisionConfig;
+
+  switch (precConfig.quantMode) {
+  case QuantizationMode::Profile: {
+    assert(cctx.bindings);
+    glow::profileQuantization(*cctx.bindings, F);
+    break;
+  }
+
+  case QuantizationMode::Quantize: {
+    quantization::quantizeFunction(F, precConfig.quantConfig, B,
+                                   *cctx.loweredInfoMap,
+                                   precConfig.precisionModeKindSet);
+    break;
+  }
+
+  case QuantizationMode::None: {
+    break;
+  }
+  }
+
+  if (precConfig.convertToFP16) {
+    TypeAToTypeBFunctionConverter converter(*F, ElemKind::FloatTy,
+                                            ElemKind::Float16Ty,
+                                            &precConfig.precisionModeKindSet);
+    converter.convert();
+  }
+}
+
+// NOTE: When updating this function, please also update the documentation in
+// docs/GraphOptimizationPipeline.md
 llvm::Error glow::optimizeFunction(Function *F, const Backend &B,
                                    const CompilationContext &cctx) {
   // Verify the function pre-optimization/lowering.
   assert(F->verify() && "Function must be valid");
 
+  // Verify that the CompilationContext is set up correctly.
+  RETURN_IF_ERR(cctx.verify());
+
+  // Fold low-level operators into higher-level operators.
+  // This is useful when compiling an input model where some high-level
+  // operators have been lowered (this can be for instance a side effect of
+  // model converters, like converters from Tensorflow to ONNX). In this
+  // situation, such folding can then enable more optimizations and also improve
+  // the performance backends that support natively such high-level operators.
+  ::glow::fold(F, glow::CompilationMode::Infer);
+
   // Optimize the graph.
   ::glow::optimize(F, cctx);
 
   // Lower the graph into a sequence of low-level linear algebra operations.
-  ::glow::lower(F, /* loweredMap */ nullptr, &B);
+  const PrecisionConfiguration &precConfig = cctx.precisionConfig;
+  if (precConfig.quantMode == QuantizationMode::Profile) {
+    // When profiling, pass a nullptr for the backend, signaling that all nodes
+    // should be lowered. loweredInfoMap logs what is lowered from what for
+    // later use when creating quantization infos. Also pass the precision mode
+    // kind set as nodes to not lower, specified higher up in the stack.
+    ::glow::lower(F, cctx.loweredInfoMap, /* backend */ nullptr,
+                  precConfig.precisionModeKindSet);
+  } else {
+    // Lower based on the backend's preferences.
+    ::glow::lower(F, cctx.loweredInfoMap, &B);
+  }
+
+  // Transform given precision mode; may quantize, convert to fp16, or
+  // instrument with profiling nodes. This must be done after lowering.
+  transformForPrecisionMode(B, F, cctx);
 
   // Optimize the graph again.
   ::glow::optimize(F, cctx);

--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -2598,7 +2598,7 @@ void glow::fold(Function *F, const CompilationContext &cctx) {
 
 void glow::fold(Function *F, CompilationMode mode) {
   CompilationContext cctx;
-  cctx.mode = mode;
+  cctx.compMode = mode;
   fold(F, cctx);
 }
 
@@ -2626,7 +2626,7 @@ void glow::optimize(Function *F, const CompilationContext &cctx) {
   // Reshapes and transposes can prevent other optimizations from triggering,
   // so try to optimize them out first.
   optimizeReshape(F);
-  if (cctx.mode == CompilationMode::Infer) {
+  if (cctx.compMode == CompilationMode::Infer) {
     transposeConstants(F);
   }
 
@@ -2654,7 +2654,7 @@ void glow::optimize(Function *F, const CompilationContext &cctx) {
   // Perform Dead Code Elimination.
   DCE(F);
 
-  if (cctx.mode == CompilationMode::Infer) {
+  if (cctx.compMode == CompilationMode::Infer) {
     // Merge batch normalization operations.
     // Do after transpose constant folding, as weight transposes can prevent
     // the optimization from triggering.
@@ -2698,7 +2698,7 @@ void glow::optimize(Function *F, const CompilationContext &cctx) {
 
 void glow::optimize(Function *F, CompilationMode mode) {
   CompilationContext cctx;
-  cctx.mode = mode;
+  cctx.compMode = mode;
   optimize(F, cctx);
 }
 
@@ -2773,7 +2773,7 @@ llvm::Error glow::optimizeFunction(Function *F, const Backend &B,
   // model converters, like converters from Tensorflow to ONNX). In this
   // situation, such folding can then enable more optimizations and also improve
   // the performance backends that support natively such high-level operators.
-  ::glow::fold(F, glow::CompilationMode::Infer);
+  ::glow::fold(F, cctx.compMode);
 
   // Optimize the graph.
   ::glow::optimize(F, cctx);

--- a/lib/Partitioner/Partitioner.cpp
+++ b/lib/Partitioner/Partitioner.cpp
@@ -752,12 +752,11 @@ void Partitioner::getBackendMap(
 }
 
 llvm::Error Partitioner::createDAGWithoutPartition(
-    BackendKind backendKind, std::map<BackendKind, BackendInfo> &backendMap) {
+    BackendKind backendKind, std::map<BackendKind, BackendInfo> &backendMap,
+    const CompilationContext &cctx) {
   for (auto F : module_->getFunctions()) {
     if (!optimized_) {
       auto backend = backendMap[backendKind].backend;
-      CompilationContext cctx;
-      cctx.compMode = CompilationMode::Infer;
       RETURN_IF_ERR(::glow::optimizeFunction(F, *backend, cctx));
     }
     std::unique_ptr<DAGNode> DAG0 = llvm::make_unique<DAGNode>();
@@ -781,7 +780,7 @@ llvm::Error Partitioner::createDAGWithoutPartition(
   return llvm::Error::success();
 }
 
-llvm::Error Partitioner::Partition() {
+llvm::Error Partitioner::Partition(const CompilationContext &cctx) {
   // Prepare the mapping between BackendKind and BackendInfo.
   std::map<BackendKind, BackendInfo> backendMap;
   std::vector<Backend *> backends;
@@ -808,7 +807,7 @@ llvm::Error Partitioner::Partition() {
     if (memSize_ < backendMap[backendKind].memSize) {
       // No partition is needed. Create DAGNode and return. This root is alway a
       // dummy function.
-      return createDAGWithoutPartition(backendKind, backendMap);
+      return createDAGWithoutPartition(backendKind, backendMap, cctx);
     }
   } else {
     funcToBackend = backendBasedPartition(F_, backends);
@@ -817,8 +816,6 @@ llvm::Error Partitioner::Partition() {
 
   // Step 2 : optimize each functions based on its backend type and apply the
   // partition algorithm.
-  CompilationContext cctx;
-  cctx.compMode = CompilationMode::Infer;
   NodeToFunctionMap mapping;
   std::vector<Function *> funcs;
   for (auto i = funcToBackend.begin(); i != funcToBackend.end(); ++i) {

--- a/lib/Partitioner/Partitioner.cpp
+++ b/lib/Partitioner/Partitioner.cpp
@@ -757,7 +757,7 @@ llvm::Error Partitioner::createDAGWithoutPartition(
     if (!optimized_) {
       auto backend = backendMap[backendKind].backend;
       CompilationContext cctx;
-      cctx.mode = CompilationMode::Infer;
+      cctx.compMode = CompilationMode::Infer;
       RETURN_IF_ERR(::glow::optimizeFunction(F, *backend, cctx));
     }
     std::unique_ptr<DAGNode> DAG0 = llvm::make_unique<DAGNode>();
@@ -818,7 +818,7 @@ llvm::Error Partitioner::Partition() {
   // Step 2 : optimize each functions based on its backend type and apply the
   // partition algorithm.
   CompilationContext cctx;
-  cctx.mode = CompilationMode::Infer;
+  cctx.compMode = CompilationMode::Infer;
   NodeToFunctionMap mapping;
   std::vector<Function *> funcs;
   for (auto i = funcToBackend.begin(); i != funcToBackend.end(); ++i) {

--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -63,11 +63,13 @@ TEST(Interpreter, profileQuantizationForANetwork) {
   O = F->createRELU("relu", O);
   O = F->createRegression("reg", O, Ex);
 
-  ::glow::profileQuantization(bindings, F);
+  LoweredInfoMap loweredMap;
+  CompilationContext cctx{&bindings, &loweredMap};
+  cctx.precisionConfig.quantMode = QuantizationMode::Profile;
 
   bindings.allocate(A);
   bindings.allocate(Ex);
-  EE.compile(CompilationMode::Infer, F);
+  EE.compile(F, cctx);
 
   // TODO: Verify histogram itself, for now just verify min and max.
   // Run inference first time and capture tensor stats.

--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -45,7 +45,7 @@ TEST(Interpreter, NotImplementedSave) {
                 mod.createPlaceholder(ElemKind::FloatTy, {2}, "A", false));
 
   CompilationContext cctx;
-  cctx.mode = CompilationMode::Infer;
+  cctx.compMode = CompilationMode::Infer;
   EXPECT_DEATH(EE.save(F, cctx, "output", "network"), "");
 }
 

--- a/tests/unittests/DeviceManagerTest.cpp
+++ b/tests/unittests/DeviceManagerTest.cpp
@@ -64,7 +64,7 @@ compileFunctions(BackendKind backendKind, Module *module,
   FunctionMapTy results;
   auto *backend = createBackend(backendKind);
   CompilationContext cctx;
-  cctx.mode = CompilationMode::Infer;
+  cctx.compMode = CompilationMode::Infer;
   for (auto *F : module->getFunctions()) {
     EXIT_ON_ERR(::glow::optimizeFunction(F, *backend, cctx));
     auto f = backend->compile(F, cctx.backendOpts);

--- a/tests/unittests/TraceEventsTest.cpp
+++ b/tests/unittests/TraceEventsTest.cpp
@@ -139,7 +139,7 @@ TEST_P(TraceEventsTest, manualEvents) {
 
   context.getPlaceholderBindings()->allocate(EE_.getModule().getPlaceholders());
   CompilationContext cctx;
-  cctx.mode = CompilationMode::Infer;
+  cctx.compMode = CompilationMode::Infer;
   EE_.compile(F, cctx);
 
   updateInputPlaceholders(*context.getPlaceholderBindings(), {inputPH},
@@ -186,7 +186,7 @@ TEST_P(TraceEventsTest, incompleteCoverage) {
 
   context.getPlaceholderBindings()->allocate(EE_.getModule().getPlaceholders());
   CompilationContext cctx;
-  cctx.mode = CompilationMode::Infer;
+  cctx.compMode = CompilationMode::Infer;
   EE_.compile(F, cctx);
 
   updateInputPlaceholders(*context.getPlaceholderBindings(), {inputPH},
@@ -229,7 +229,7 @@ TEST_P(TraceEventsTest, internalGap) {
 
   context.getPlaceholderBindings()->allocate(EE_.getModule().getPlaceholders());
   CompilationContext cctx;
-  cctx.mode = CompilationMode::Infer;
+  cctx.compMode = CompilationMode::Infer;
   EE_.compile(F, cctx);
 
   updateInputPlaceholders(*context.getPlaceholderBindings(), {inputPH},
@@ -266,7 +266,7 @@ TEST_P(TraceEventsTest, automaticInstrumentation) {
   context.getPlaceholderBindings()->allocate(EE_.getModule().getPlaceholders());
   auto *backend = EE_.getBackend();
   CompilationContext cctx;
-  cctx.mode = CompilationMode::Infer;
+  cctx.compMode = CompilationMode::Infer;
   cctx.backendOpts.autoInstrument = true;
   EXIT_ON_ERR(::glow::optimizeFunction(F, *backend, cctx));
   EE_.insertCompiledFunction(F->getName(),
@@ -306,7 +306,7 @@ TEST_P(TraceEventsTest, manualAndAutomatic) {
   context.getPlaceholderBindings()->allocate(EE_.getModule().getPlaceholders());
   auto *backend = EE_.getBackend();
   CompilationContext cctx;
-  cctx.mode = CompilationMode::Infer;
+  cctx.compMode = CompilationMode::Infer;
   cctx.backendOpts.autoInstrument = true;
   EXIT_ON_ERR(::glow::optimizeFunction(F, *backend, cctx));
   EE_.insertCompiledFunction(F->getName(),
@@ -356,7 +356,7 @@ TEST_P(TraceEventsTest, twoCompiles) {
 
   auto *backend = EE_.getBackend();
   CompilationContext cctx;
-  cctx.mode = CompilationMode::Infer;
+  cctx.compMode = CompilationMode::Infer;
   cctx.backendOpts.autoInstrument = true;
   EXIT_ON_ERR(::glow::optimizeFunction(F, *backend, cctx));
 
@@ -412,7 +412,7 @@ TEST_P(TraceEventsTest, onlyTraceEvents) {
 
   context.getPlaceholderBindings()->allocate(EE_.getModule().getPlaceholders());
   CompilationContext cctx;
-  cctx.mode = CompilationMode::Infer;
+  cctx.compMode = CompilationMode::Infer;
   EE_.compile(F, cctx);
 
   updateInputPlaceholders(*context.getPlaceholderBindings(), {inputPH},
@@ -463,7 +463,7 @@ TEST_P(TraceEventsTest, multipleBackingTensors) {
 
   context.getPlaceholderBindings()->allocate(EE_.getModule().getPlaceholders());
   CompilationContext cctx;
-  cctx.mode = CompilationMode::Infer;
+  cctx.compMode = CompilationMode::Infer;
   EE_.compile(F, cctx);
 
   updateInputPlaceholders(*context.getPlaceholderBindings(), {inputPH},
@@ -516,7 +516,7 @@ TEST_P(TraceEventsTest, multipleRunsAreDistinct) {
 
   context.getPlaceholderBindings()->allocate(EE_.getModule().getPlaceholders());
   CompilationContext cctx;
-  cctx.mode = CompilationMode::Infer;
+  cctx.compMode = CompilationMode::Infer;
   EE_.compile(F, cctx);
 
   updateInputPlaceholders(*context.getPlaceholderBindings(), {inputPH},
@@ -557,7 +557,7 @@ TEST_P(TraceEventsTest, deviceManagerEvents) {
   context.getPlaceholderBindings()->allocate(EE_.getModule().getPlaceholders());
 
   CompilationContext cctx;
-  cctx.mode = CompilationMode::Infer;
+  cctx.compMode = CompilationMode::Infer;
   EE_.compile(F, cctx);
 
   updateInputPlaceholders(*context.getPlaceholderBindings(), {inputPH},

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -323,8 +323,7 @@ void Loader::compile(PlaceholderBindings &bindings) {
     backend_->save(F_, emitBundle, networkName);
   } else {
     // Emit IR for the graph and compile it.
-    auto error = hostManager_->addNetwork(std::move(M_), /*saturateHost*/ false,
-                                          profilingGraph());
+    auto error = hostManager_->addNetwork(std::move(M_), cctx);
     EXIT_ON_ERR(std::move(error));
   }
   if (dumpGraphOpt) {

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -211,10 +211,12 @@ bool glow::emittingBundle() { return !emitBundle.empty(); }
 bool glow::profilingGraph() { return !dumpProfileFileOpt.empty(); }
 
 static bool commandLineIsInvalid() {
-  if (!dumpProfileFileOpt.empty() && !loadProfileFileOpt.empty()) {
-    llvm::errs() << "Loader: the -" << dumpProfileFileOpt.ArgStr << " and -"
-                 << loadProfileFileOpt.ArgStr
-                 << " options may not be specified together.\n";
+  if (!dumpProfileFileOpt.empty() &&
+      (!loadProfileFileOpt.empty() || convertToFP16)) {
+    llvm::errs() << "Loader: the -" << dumpProfileFileOpt.ArgStr
+                 << " option cannot be specified at the same time as either -"
+                 << loadProfileFileOpt.ArgStr << " or -" << convertToFP16.ArgStr
+                 << ".\n";
     return true;
   }
 
@@ -273,89 +275,43 @@ void Loader::compile(PlaceholderBindings &bindings) {
     F_->dumpDAG(dumpGraphDAGFileBeforeCompilationOpt.c_str());
   }
 
-  // Fold low-level operators into higher-level operators.
-  // This is useful when compiling an input model where some high-level
-  // operators have been lowered (this can be for instance a side effect of
-  // model converters, like converters from Tensorflow to ONNX). In this
-  // situation, such folding can then enable more optimizations and also improve
-  // the performance backends that support natively such high-level operators.
-  ::fold(F_, glow::CompilationMode::Infer);
+  CompilationContext cctx{&bindings, &loweredMap_};
+  PrecisionConfiguration &precConfig = cctx.precisionConfig;
 
   // Handle the request to profile the graph in preparation for quantization.
   if (!dumpProfileFileOpt.empty()) {
-    // Perform the high-level optimizations before instrumenting the graph. This
-    // optimization phase will remove stuff like repetitive transpose operations
-    // perform CSE, etc.
-    ::optimize(F_, glow::CompilationMode::Infer);
+    precConfig.quantMode = QuantizationMode::Profile;
 
     // By default everything will be lowered for profiling. However this may
     // cause performance issues for some models, e.g. if a model has group
     // Convolutions which explode the size of the graph when lowered. Thus allow
     // for disabling certain NodeKinds for profiling. This means that during
     // quantization, these nodes should also not be lowered by the backend.
-    KindSet doNotLowerNodesForProfiling;
     for (llvm::StringRef kindName : doNotLowerNodesForProfilingOpt) {
-      doNotLowerNodesForProfiling.insert(getKindFromNodeName(kindName));
+      precConfig.precisionModeKindSet.insert(getKindFromNodeName(kindName));
     }
-
-    // Lower everything, keeping track of what NodeValues were lowered to other
-    // NodeValues via the loweredMap_. This loweredMap_ is passed to
-    // generateNodeQuantizationInfos() when writing out the profile, allowing
-    // for both lowered and unlowered NodeValues to find their quantization
-    // parameters.
-    ::lower(F_, &loweredMap_, /* backend */ nullptr,
-            doNotLowerNodesForProfiling);
-
-    // Instrument the graph to capture profiles for nodes' outputs.
-    ::profileQuantization(bindings, F_);
+  } else {
+    // By default, when converting models, all nodes that can be converted are
+    // converted. However, some models may need to keep higher precision for
+    // some nodes to prevent high accuracy loss. Those nodes are gathered via
+    // the keepOriginalPrecisionForNodesOpt option and passed to the related
+    // conversion function.
+    for (llvm::StringRef kindName : keepOriginalPrecisionForNodesOpt) {
+      precConfig.precisionModeKindSet.insert(getKindFromNodeName(kindName));
+    }
   }
 
-  // By default, when converting models, all nodes that can be
-  // converted are converted. However, some models may need to
-  // keep higher precision for some nodes to prevent high accuracy loss.
-  // Those nodes are gathered via the keepOriginalPrecisionForNodesOpt
-  // option and passed to the related conversion function.
-  KindSet keepOriginalPrecisionForNodes;
-  for (llvm::StringRef kindName : keepOriginalPrecisionForNodesOpt) {
-    keepOriginalPrecisionForNodes.insert(getKindFromNodeName(kindName));
-  }
-
-  // Load the quantization profile and transform the graph.
   if (!loadProfileFileOpt.empty()) {
-    // The profiled graph was optimized before it was instrumentated. In this
-    // part of the code we repeat the same transformation in order to create
-    // the same graph structure.
-    ::optimize(F_, glow::CompilationMode::Infer);
-
-    // Lower as the backend prefers. When generating the profile everything was
-    // lowered, however all lowered and unlowered components have a profile, and
-    // so the backend can lower however it prefers and always find all of its
-    // NodeValue's quantization parameters.
-    ::lower(F_, &loweredMap_, backend_);
-
-    quantization::QuantizationConfiguration quantConfig{
-        deserializeFromYaml(loadProfileFileOpt)};
-
-    // Quantize the graph based on the captured profile.
-    quantConfig.precision = quantizationPrecision;
-    quantConfig.schema = quantizationSchema;
-    quantConfig.enableRowwise = enableRowwiseOpt;
-    quantConfig.assertAllNodesQuantized = assertAllNodesQuantizedOpt;
-
-    quantization::quantizeFunction(F_, quantConfig, *backend_, loweredMap_,
-                                   keepOriginalPrecisionForNodes);
+    precConfig.quantMode = QuantizationMode::Quantize;
+    precConfig.quantConfig.precision = quantizationPrecision;
+    precConfig.quantConfig.infos = deserializeFromYaml(loadProfileFileOpt);
+    precConfig.quantConfig.schema = quantizationSchema;
+    precConfig.quantConfig.enableRowwise = enableRowwiseOpt;
+    precConfig.quantConfig.assertAllNodesQuantized = assertAllNodesQuantizedOpt;
   }
 
-  if (convertToFP16) {
-    TypeAToTypeBFunctionConverter converter(*F_, ElemKind::FloatTy,
-                                            ElemKind::Float16Ty,
-                                            &keepOriginalPrecisionForNodes);
-    converter.convert();
-    ::optimize(F_, glow::CompilationMode::Infer);
-  }
+  precConfig.convertToFP16 = convertToFP16;
 
-  CompilationContext cctx;
-  cctx.mode = CompilationMode::Infer;
   // Store a raw pointer to the Module, we pass the unique_ptr to HostManager
   // but the Module is stored by Hostmanager so the pointer will remain valid.
   auto module = M_.get();


### PR DESCRIPTION
Summary: Move quantization/profiling/fp16 conversion into `optimizeFunction()`. This means we can call lower just once in a normal way, instead of forcing it to occur twice. Also cleans up callers to `compile()` so they do not need to worry about when/how to quantize/profile/convert to fp16.

Documentation: Added.

Test Plan: All tests pass.

Fixes https://github.com/pytorch/glow/issues/2648
