### PR TITLE
Allocate memory for input tensor

### DIFF
--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -109,7 +109,13 @@ onnxStatus Graph::setIOAndRun(uint32_t inputsCount,
 
     auto &inPhPtr = inPhIt->getValue();
 
-    Tensor t(inOnnxBuffer, inPhPtr->getType());
+    std::vector<size_t> dims(inOnnxTensor.dimensions);
+    for (unsigned i = 0; i < inOnnxTensor.dimensions; ++i) {
+      dims[i] = inOnnxTensor.shape[i];
+    }
+    auto actualType = Type::newShape(*(inPhPtr->getType()), dims);
+    Tensor t(inOnnxBuffer, &actualType);
+    t.resize(*inPhPtr->getType());
 
     ctx->getPlaceholderBindings()->insert(inPhPtr, std::move(t));
   }


### PR DESCRIPTION
*Description*:
This diff is wrote by @rdzhabarov. It's a mid-step where Glow will take care of the max batch size input. Later this step can be optimized away. 

*Testing*:
unit test. 
*Documentation*:
[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
