### PR TITLE
Move optimizeFunction() to GraphOptimizer

### DIFF
--- a/examples/resnet-concurrent.cpp
+++ b/examples/resnet-concurrent.cpp
@@ -18,6 +18,7 @@
 #include "glow/ExecutionEngine/ExecutionEngine.h"
 #include "glow/Graph/Graph.h"
 #include "glow/Importer/Caffe2ModelLoader.h"
+#include "glow/Optimizer/Optimizer.h"
 #include "glow/Runtime/RuntimeTypes.h"
 
 // We have not written the piece in the HostManager that initializes and creates
@@ -78,7 +79,7 @@ std::unique_ptr<CompiledFunction> compileModel(Module &module) {
 
   CompilationOptions opts;
   opts.mode = CompilationMode::Infer;
-  backend->optimizeFunction(F, opts);
+  ::glow::optimizeFunction(F, *backend, opts);
   return backend->compile(F, opts);
 }
 

--- a/examples/tracing-compare.cpp
+++ b/examples/tracing-compare.cpp
@@ -19,6 +19,7 @@
 #include "glow/ExecutionEngine/ExecutionEngine.h"
 #include "glow/Graph/Graph.h"
 #include "glow/Importer/Caffe2ModelLoader.h"
+#include "glow/Optimizer/Optimizer.h"
 #include "glow/Runtime/RuntimeTypes.h"
 
 #include "llvm/Support/CommandLine.h"
@@ -81,7 +82,7 @@ std::unique_ptr<CompiledFunction> compileModel(Module &module,
   CompilationOptions opts;
   opts.mode = CompilationMode::Infer;
   opts.autoInstrument = true;
-  backend->optimizeFunction(F_, opts);
+  ::glow::optimizeFunction(F_, *backend, opts);
   return backend->compile(F_, opts);
 }
 

--- a/include/glow/Backends/Backend.h
+++ b/include/glow/Backends/Backend.h
@@ -101,9 +101,6 @@ public:
   /// performed.
   virtual bool shouldShareBuffers() const { return true; }
 
-  /// Optimize the Function \p F given compilation options \p opts.
-  void optimizeFunction(Function *F, const CompilationOptions &opts) const;
-
   /// \returns true if Backend generated Instruction for Node \p N,
   /// using IRGenVisitor \p irgen.
   virtual bool generateInst(Node *N, IRGenVisitor &irgen) const {

--- a/include/glow/Optimizer/Optimizer.h
+++ b/include/glow/Optimizer/Optimizer.h
@@ -75,6 +75,10 @@ Function *profileQuantization(PlaceholderBindings &bindings, Function *F,
 std::unique_ptr<IRFunction> generateAndOptimizeIR(Function *F, const Backend &B,
                                                   bool shouldShareBuffers);
 
+/// Optimize the Function \p F given compilation options \p opts for Backend \B.
+void optimizeFunction(Function *F, const Backend &B,
+                      const CompilationOptions &opts);
+
 } // namespace glow
 
 #endif // GLOW_OPTIMIZER_OPTIMIZER_H

--- a/lib/Backends/Backend.cpp
+++ b/lib/Backends/Backend.cpp
@@ -18,31 +18,8 @@
 #include "glow/Graph/Graph.h"
 #include "glow/Graph/PlaceholderBindings.h"
 #include "glow/IR/Instrs.h"
-#include "glow/Optimizer/Optimizer.h"
 
 using namespace glow;
-
-void Backend::optimizeFunction(Function *F,
-                               const CompilationOptions &opts) const {
-  // Verify the function pre-optimization/lowering.
-  assert(F->verify() && "Function must be valid");
-
-  // Optimize the graph.
-  ::glow::optimize(F, opts);
-
-  // Lower the graph into a sequence of low-level linear algebra operations.
-  ::glow::lower(F, /* loweredMap */ nullptr, this);
-
-  // Optimize the graph again.
-  ::glow::optimize(F, opts);
-
-  // Allow the backend to transform the graph after lowering.
-  if (transformPostLowering(F, opts)) {
-    // Optimize the graph again after the backend transformation.
-    // In particular, DCE is very likely to be useful.
-    ::glow::optimize(F, opts);
-  }
-}
 
 TraceInfo Backend::buildManualTraceInfo(Function *F) const {
   TraceInfo info(false, getTraceEventDataSize());

--- a/lib/Backends/CMakeLists.txt
+++ b/lib/Backends/CMakeLists.txt
@@ -37,8 +37,7 @@ target_link_libraries(Backend
                         Base
                         CodeGen
                         Graph
-                        IR
-                        Optimizer)
+                        IR)
 add_library(Backends
               Backends.cpp)
 

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -252,7 +252,7 @@ void ExecutionEngine::compile(Function *F, const CompilationOptions &opts,
   assert(!compiledFunctions_.count(name) &&
          "A function with this name has already been compiled.");
 
-  backend_->optimizeFunction(F, opts);
+  ::glow::optimizeFunction(F, *backend_, opts);
 
   for (const Node &N : F->getNodes()) {
     (void)N;
@@ -267,6 +267,6 @@ void ExecutionEngine::compile(Function *F, const CompilationOptions &opts,
 void ExecutionEngine::save(Function *F, const CompilationOptions &opts,
                            llvm::StringRef outputDir,
                            llvm::StringRef networkName) {
-  backend_->optimizeFunction(F, opts);
+  ::glow::optimizeFunction(F, *backend_, opts);
   backend_->save(F, outputDir, networkName);
 }

--- a/lib/Optimizer/CMakeLists.txt
+++ b/lib/Optimizer/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(Optimizer
 
 target_link_libraries(Optimizer
                       PRIVATE
+                        Backend
                         Graph
                         IR
                         QuantizationBase)

--- a/lib/Runtime/HostManager/CMakeLists.txt
+++ b/lib/Runtime/HostManager/CMakeLists.txt
@@ -3,10 +3,10 @@ add_library(HostManager
 
 target_link_libraries(HostManager
                       PRIVATE
-                        Backend
                         Backends
                         Base
                         Graph
+                        Optimizer
                         Partitioner
                         Provisioner
                         Executor

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -17,6 +17,7 @@
 #include "glow/Runtime/HostManager/HostManager.h"
 #include "glow/Backends/DeviceManager.h"
 #include "glow/Graph/PlaceholderBindings.h"
+#include "glow/Optimizer/Optimizer.h"
 #include "glow/Partitioner/Partitioner.h"
 #include "glow/Runtime/Executor/Executor.h"
 #include "glow/Runtime/Provisioner/Provisioner.h"
@@ -86,7 +87,7 @@ llvm::Error HostManager::addNetwork(std::unique_ptr<Module> module) {
     CompilationOptions opts;
     opts.mode = CompilationMode::Infer;
     for (auto F : module->getFunctions()) {
-      backend_->optimizeFunction(F, opts);
+      ::glow::optimizeFunction(F, *backend_, opts);
     }
   }
   auto partitioner = Partitioner(module.get(), deviceInfo);

--- a/tests/benchmark/RuntimeBench.cpp
+++ b/tests/benchmark/RuntimeBench.cpp
@@ -18,6 +18,7 @@
 
 #include "glow/Backends/CompilationOptions.h"
 #include "glow/Backends/DeviceManager.h"
+#include "glow/Optimizer/Optimizer.h"
 #include "glow/Runtime/Executor/Executor.h"
 #include "glow/Runtime/HostManager/HostManager.h"
 
@@ -123,7 +124,7 @@ void setUpDeviceManagerCommon(
 
   // Compile all functions in the module.
   for (auto *function : mod->getFunctions()) {
-    backend->optimizeFunction(function, opts);
+    ::glow::optimizeFunction(function, *backend, opts);
     std::unique_ptr<CompiledFunction> compiledFunction =
         backend->compile(function);
     funcs.insert(std::make_pair(function->getName(), compiledFunction.get()));

--- a/tests/unittests/DeviceManagerTest.cpp
+++ b/tests/unittests/DeviceManagerTest.cpp
@@ -19,6 +19,7 @@
 
 #include "../../lib/Backends/CPU/CPUDeviceManager.h"
 #include "glow/ExecutionEngine/ExecutionEngine.h"
+#include "glow/Optimizer/Optimizer.h"
 
 #include "gtest/gtest.h"
 
@@ -57,7 +58,7 @@ compileFunctions(BackendKind backendKind, Module *module,
   CompilationOptions opts;
   opts.mode = CompilationMode::Infer;
   for (auto *F : module->getFunctions()) {
-    backend->optimizeFunction(F, opts);
+    ::glow::optimizeFunction(F, *backend, opts);
     auto f = backend->compile(F, opts);
     backing.push_back(std::move(f));
     results.emplace(F->getName(), backing.back().get());

--- a/tests/unittests/HabanaBackendTest.cpp
+++ b/tests/unittests/HabanaBackendTest.cpp
@@ -19,6 +19,7 @@
 #include "glow/ExecutionEngine/ExecutionEngine.h"
 #include "glow/Graph/Graph.h"
 #include "glow/Graph/PlaceholderBindings.h"
+#include "glow/Optimizer/Optimizer.h"
 
 #include "gtest/gtest.h"
 
@@ -1494,7 +1495,7 @@ TEST_F(HabanaBackendTest, SingleFunctionMultiThreadMultiDevice) {
   auto *backend = createBackend(BackendKind::Habana);
   CompilationOptions opts;
   opts.mode = CompilationMode::Infer;
-  backend->optimizeFunction(F_, opts);
+  ::glow::optimizeFunction(F_, *backend, opts);
   auto compiledFunction = backend->compile(F_, opts);
   functions.emplace(F_->getName(), compiledFunction.get());
 

--- a/tests/unittests/TraceEventsTest.cpp
+++ b/tests/unittests/TraceEventsTest.cpp
@@ -18,6 +18,7 @@
 #include "glow/ExecutionEngine/ExecutionEngine.h"
 #include "glow/Graph/Graph.h"
 #include "glow/IR/IRBuilder.h"
+#include "glow/Optimizer/Optimizer.h"
 
 #include "gtest/gtest.h"
 
@@ -267,7 +268,7 @@ TEST_P(TraceEventsTest, automaticInstrumentation) {
   CompilationOptions opts;
   opts.mode = CompilationMode::Infer;
   opts.autoInstrument = true;
-  backend->optimizeFunction(F, opts);
+  ::glow::optimizeFunction(F, *backend, opts);
   EE_.insertCompiledFunction(F->getName(), backend->compile(F, opts));
 
   updateInputPlaceholders(*context.getPlaceholderBindings(), {inputPH},
@@ -306,7 +307,7 @@ TEST_P(TraceEventsTest, manualAndAutomatic) {
   CompilationOptions opts;
   opts.mode = CompilationMode::Infer;
   opts.autoInstrument = true;
-  backend->optimizeFunction(F, opts);
+  ::glow::optimizeFunction(F, *backend, opts);
   EE_.insertCompiledFunction(F->getName(), backend->compile(F, opts));
 
   updateInputPlaceholders(*context.getPlaceholderBindings(), {inputPH},
@@ -355,7 +356,7 @@ TEST_P(TraceEventsTest, twoCompiles) {
   CompilationOptions opts;
   opts.mode = CompilationMode::Infer;
   opts.autoInstrument = true;
-  backend->optimizeFunction(F, opts);
+  ::glow::optimizeFunction(F, *backend, opts);
 
   std::string name = F->getName();
   EE_.insertCompiledFunction(name, backend->compile(F, opts));


### PR DESCRIPTION
*Description*: For #2700, the library containing `optimizeFunction()` (prior to this PR in `Backend`) must depend on `Quantization`. `Quantization` already depends on `Backend`, so #2700 would create a cyclic dependence. This PR moves `optimizeFunction()` to `GraphOptimizer.cpp`, removing the cyclic dependence for #2700 . I think `optimizeFunction()` more naturally fits into `Optimizer` anyway. 

TL;DR:

Before: `Quantization --> Backend --> Optimizer`

Before (with #2700): `Quantization <--> Backend --> Optimizer`

After: `Quantization --> Backend <-- Optimizer`

After (with #2700): 
```
Quantization <-- Optimizer
           \     /
            v   v
           Backend
```
*Testing*: Everything still builds/passes.
