### PR TITLE
Moving method getOutputSave to the common glow code.

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -1081,6 +1081,10 @@ Function *differentiate(Function *F, const TrainingConfig &config,
                         llvm::StringRef newFuncName = "",
                         VariableGradientsList *varGrads = nullptr);
 
+/// \returns the first SaveNode user of the placeholder \p PH or
+/// nullptr if none are found.
+SaveNode *getOutputSave(Function *F, Placeholder *PH);
+
 /// Helper vectors for common transpose shuffles.
 #define NCHW2NHWC                                                              \
   { 0u, 2u, 3u, 1u }

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -2993,3 +2993,19 @@ bool Function::verify() const {
   }
   return isValid;
 }
+
+SaveNode *glow::getOutputSave(Function *F, Placeholder *PH) {
+  // if parent is set for PH, check if it is the same as provided Function.
+  auto *PHP = PH->getParent();
+  if (PHP != nullptr && F != PHP) {
+    return nullptr;
+  }
+  for (auto &use : PH->getUsers()) {
+    if (auto *save = llvm::dyn_cast<SaveNode>(use.getUser())) {
+      if (save->getPlaceholder() == PH) {
+        return save;
+      }
+    }
+  }
+  return nullptr;
+}


### PR DESCRIPTION
*Description*:
Adding getOutputSave method into common glow code.
*Testing*:
GraphTest
*Documentation*:
getOutputSave method will be used across specific backends implementations
[Optional Fixes #issue]
#2692
