### PR TITLE
Add command line options to set interpreter max mem and cpu max mem.

### DIFF
--- a/lib/Backends/CPU/CPUDeviceManager.cpp
+++ b/lib/Backends/CPU/CPUDeviceManager.cpp
@@ -16,7 +16,13 @@
 #include "CPUDeviceManager.h"
 #include "CPUFunction.h"
 
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/raw_ostream.h"
+
+static llvm::cl::OptionCategory CPUBackendCat("Glow CPU Backend Options");
+llvm::cl::opt<unsigned>
+    cpuMaxMem("cpu-memory", llvm::cl::desc("CPU DeviceManager maximum memory"),
+              llvm::cl::init(0), llvm::cl::cat(CPUBackendCat));
 
 using namespace glow;
 using namespace glow::runtime;
@@ -24,6 +30,9 @@ using namespace glow::runtime;
 namespace glow {
 namespace runtime {
 DeviceManager *createCPUDeviceManager(std::unique_ptr<DeviceConfig> config) {
+  if (cpuMaxMem) {
+    return new CPUDeviceManager(std::move(config), cpuMaxMem);
+  }
   return new CPUDeviceManager(std::move(config));
 }
 } // namespace runtime

--- a/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
@@ -16,13 +16,24 @@
 #include "InterpreterDeviceManager.h"
 #include "Interpreter.h"
 
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/raw_ostream.h"
+
+static llvm::cl::OptionCategory
+    InterpreterBackendCat("Glow Interpreter Backend Options");
+llvm::cl::opt<unsigned> interpreterMaxMem(
+    "interpreter-memory",
+    llvm::cl::desc("Interpreter DeviceManager maximum memory"),
+    llvm::cl::init(0), llvm::cl::cat(InterpreterBackendCat));
 
 namespace glow {
 namespace runtime {
 
 DeviceManager *
 createInterpreterDeviceManager(std::unique_ptr<DeviceConfig> config) {
+  if (interpreterMaxMem) {
+    return new InterpreterDeviceManager(std::move(config), interpreterMaxMem);
+  }
   return new InterpreterDeviceManager(std::move(config));
 }
 


### PR DESCRIPTION
*Description*: This PR is a quality of life change and adds two new command line options, interpreter-mem and cpu-mem, which set the max memory for the interpreter and cpu device managers respectively. 
*Testing*: ninja test, also ran resnet-runtime with different values and noted that the partitioner could not find a valid partitioning if memory was too low.
*Documentation*: Do we document all of our flags somewhere?
