### PR TITLE
build: only support LLVM 8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,22 +88,7 @@ endif ()
 # Top level setup for external backends
 ExternalBackendsInit()
 
-# Prefer LLVM 7.
-find_package(LLVM 7 CONFIG)
-
-# If LLVM 7 not found, try building with LLVM 6.
-if (NOT LLVM_FOUND)
-  # Fallback to LLVM 6
-  find_package(LLVM 6 CONFIG)
-
-  # Fallback to whatever is available.
-  if (NOT LLVM_FOUND)
-    find_package(LLVM CONFIG)
-  endif()
-endif()
-if (NOT LLVM_FOUND)
-  message(FATAL_ERROR "Could not find LLVM. Build LLVM manually and configure the project with -DCMAKE_PREFIX_PATH=/path/to/llvm/install")
-endif()
+find_package(LLVM 8 CONFIG REQUIRED)
 
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")

--- a/lib/Backends/CPU/CMakeLists.txt
+++ b/lib/Backends/CPU/CMakeLists.txt
@@ -4,11 +4,17 @@ else()
   find_program(CLANG_BIN clang++)
 endif()
 
-find_program(LLVM_LINK_BIN
-             NAMES
-               llvm-link-7
-               llvm-link-6.0
-               llvm-link)
+if(TARGET llvm-link)
+  set(LLVM_LINK_BIN $<TARGET_FILE:llvm-link>)
+else()
+  find_program(LLVM_LINK_BIN
+               NAMES
+                 llvm-link-${LLVM_VERSION_MAJOR}
+                 llvm-link-8
+                 llvm-link-7
+                 llvm-link-6.0
+                 llvm-link)
+endif()
 
 set(CMAKE_LLIR_CREATE_SHARED_LIBRARY "${LLVM_LINK_BIN} -o <TARGET> <OBJECTS>")
 set(CMAKE_LLIR_CREATE_SHARED_MODULE "${LLVM_LINK_BIN} -o <TARGET> <OBJECTS>")


### PR DESCRIPTION
Adjust the build to use the `REQUIRED` parameter to `find_package` as we want to
drop support for LLVM 6, and LLVM 8 is the first version available built with
the C++11 ABI.

Make the llvm-link search more resilient to the future by using the
LLVM_VERSION_MAJOR variable to add the suffix.  Additionally, when building
against the build tree, fetch the exported target for llvm-link and use that.

*Description*:
*Testing*:
*Documentation*:
[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
