### PR TITLE
Add tests for symmetric rowwise-quantized FC

### DIFF
--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -5711,6 +5711,15 @@ TEST_P(OperatorStatelessTest, rowwiseQuantizedFCTest) {
                             /* enableRowwiseQuantization */ true);
 }
 
+/// Test RowwiseQuantizedFullyConnected Node with Symmetric quantization.
+TEST_P(OperatorStatelessTest, rowwiseQuantizedFCTestSymmetric) {
+  ENABLED_BACKENDS(Interpreter, CPU);
+  compareAgainstInterpreter(GetParam(), createAndInitBasicRowwiseFCTest,
+                            ElemKind::FloatTy, ElemKind::Int8QTy, 0.06f,
+                            /* enableRowwiseQuantization */ true,
+                            quantization::Schema::Symmetric);
+}
+
 static FunctionTensorPair
 createAndInitBasicSLWSTest(glow::PlaceholderBindings &bindings,
                            glow::ExecutionEngine &EE) {


### PR DESCRIPTION
*Description*: Added tests for rowwise-quantized FC using Symmetric quantization. This included using the schema parameter inside calls to `compareAgainstInterpreter()` when generating NodeQuantizationInfos.

*Testing*: Yup.