### PR TITLE
Undo bug introduced in my last PR

### DIFF
--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -726,7 +726,7 @@ llvm::Error ONNXModelLoader::loadConcat(const ONNX_NAMESPACE::NodeProto &op,
   const std::string &opName = loadOperatorName(op);
 
   const unsigned numInputs = op.input_size();
-  llvm::SmallVector<NodeValue, 4> inputs(4);
+  llvm::SmallVector<NodeValue, 4> inputs;
   inputs.reserve(numInputs);
   for (unsigned i = 0; i < numInputs; i++) {
     NodeValue in;


### PR DESCRIPTION
*Description*:
Accidentally changed this line when I was converting some other items to SmallVector.

*Testing*:

./bin/image-classifier tests/images/imagenet_299/cat_281_299.png   -image-mode=0to1 -m=googlenet_v4_slim/googlenet_v4_slim.onnx -model-input-name=input:0 -image-layout=NHWC -label-offset=1

Before: seg fault.
After: works OK.

