### PR TITLE
[Quantization][NFC] Move some structs/using to QuantizationBase

### DIFF
--- a/include/glow/Quantization/Quantization.h
+++ b/include/glow/Quantization/Quantization.h
@@ -28,54 +28,6 @@ namespace glow {
 
 class Backend;
 
-/// Tensor quantization parameters for a given node.
-struct NodeQuantizationInfo {
-  std::string nodeOutputName_;
-  TensorQuantizationParams tensorQuantizationParams_;
-
-  NodeQuantizationInfo() = default;
-  NodeQuantizationInfo(const std::string &nodeOutputName,
-                       const TensorQuantizationParams &tensorQuantizationParams)
-      : nodeOutputName_(nodeOutputName),
-        tensorQuantizationParams_(tensorQuantizationParams) {}
-
-  float Scale() const { return tensorQuantizationParams_.scale; }
-  int32_t Offset() const { return tensorQuantizationParams_.offset; }
-
-  /// Get the full node output name based on the node name and output number.
-  /// The following format is used: nodename:outputNumber
-  static std::string generateNodeOutputName(const std::string &nodeName,
-                                            unsigned outputNumber = 0) {
-    return nodeName + ":" + std::to_string(outputNumber);
-  }
-};
-
-/// Struct containing the output name string and node kind for use in the
-/// LoweredInfoMap for keeping track of lowered node info.
-struct NodeNameAndKind : public Named, public Kinded {
-public:
-  NodeNameAndKind(const NodeValue &NV)
-      : Named(NodeQuantizationInfo::generateNodeOutputName(
-            NV.getNode()->getName(), NV.getResNo())),
-        Kinded(NV.getNode()->getKind()) {}
-};
-
-/// Overload < operator for NodeNameAndKind to allow for usage with std::set.
-inline bool operator<(const NodeNameAndKind &x, const NodeNameAndKind &y) {
-  return x.getName() < y.getName();
-}
-
-/// Overload == operator for NodeNameAndKind to allow for usage with std::set.
-inline bool operator==(const NodeNameAndKind &x, const NodeNameAndKind &y) {
-  return x.getName() == y.getName();
-}
-
-/// Used to keep track of the origin of lowered Nodes via output names as
-/// determined by NodeQuantizationInfo::generateNodeOutputName(). For example if
-/// some NodeValue X is lowered from some NodeValue Y, then the output name of X
-/// is a key which maps to a set of names which contains the output name of Y.
-using LoweredInfoMap = llvm::StringMap<std::set<NodeNameAndKind>>;
-
 namespace quantization {
 
 /// Generate NodeQuantizationInfo for all required nodes from function \p F

--- a/include/glow/Quantization/Serialization.h
+++ b/include/glow/Quantization/Serialization.h
@@ -17,7 +17,7 @@
 #ifndef GLOW_QUANTIZATION_SERIALIZATION_H
 #define GLOW_QUANTIZATION_SERIALIZATION_H
 
-#include "glow/Quantization/Quantization.h"
+#include "glow/Quantization/Base/Base.h"
 
 #include "llvm/ADT/APInt.h"
 

--- a/lib/Optimizer/Lower.cpp
+++ b/lib/Optimizer/Lower.cpp
@@ -39,7 +39,9 @@ static void replaceAllUsesOfWith(LoweredInfoMap *loweredMap, NodeValue oldNV,
 
   std::string newOutputName = NodeQuantizationInfo::generateNodeOutputName(
       newNV.getNode()->getName(), newNV.getResNo());
-  (*loweredMap)[newOutputName].insert(NodeNameAndKind(oldNV));
+  (*loweredMap)[newOutputName].insert(
+      NodeNameAndKind(oldNV.getNode()->getName(), oldNV.getResNo(),
+                      oldNV.getNode()->getKind()));
 }
 
 static void lowerAddGradNode(Function *F, LoweredInfoMap *loweredMap,

--- a/lib/Quantization/Base/CMakeLists.txt
+++ b/lib/Quantization/Base/CMakeLists.txt
@@ -4,3 +4,5 @@ add_library(QuantizationBase
 target_link_libraries(QuantizationBase
   PRIVATE
   LLVMSupport)
+
+add_dependencies(QuantizationBase AutoGen)

--- a/lib/Quantization/Serialization.cpp
+++ b/lib/Quantization/Serialization.cpp
@@ -15,7 +15,8 @@
  */
 
 #include "glow/Quantization/Serialization.h"
-#include "glow/Quantization/Quantization.h"
+
+#include "glow/Quantization/Base/Base.h"
 
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/YAMLParser.h"

--- a/tests/unittests/BackendCorrectnessTest.cpp
+++ b/tests/unittests/BackendCorrectnessTest.cpp
@@ -22,7 +22,6 @@
 #include "glow/IR/IR.h"
 #include "glow/IR/IRBuilder.h"
 #include "glow/IR/Instrs.h"
-#include "glow/Quantization/Quantization.h"
 #include "glow/Support/Random.h"
 
 #include "gtest/gtest.h"

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -17,14 +17,13 @@
 #include "glow/Backends/Backend.h"
 #include "glow/ExecutionEngine/ExecutionEngine.h"
 #include "glow/Graph/Graph.h"
-#include "glow/IR/IR.h"
-
-#include "llvm/Support/Casting.h"
-
-#include "glow/Backends/Backend.h"
 #include "glow/Graph/Node.h"
+#include "glow/IR/IR.h"
 #include "glow/IR/IRBuilder.h"
 #include "glow/IR/IRGen.h"
+#include "glow/Quantization/Base/Base.h"
+
+#include "llvm/Support/Casting.h"
 
 #include "gtest/gtest.h"
 

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -21,7 +21,7 @@
 #include "glow/IR/IR.h"
 #include "glow/IR/IRBuilder.h"
 #include "glow/IR/Instrs.h"
-#include "glow/Quantization/Quantization.h"
+#include "glow/Quantization/Base/Base.h"
 
 #include "llvm/Support/raw_ostream.h"
 


### PR DESCRIPTION
These make more sense in `QuantizationBase` and allow other files using them to include less. 

This included changing the constructor for `NodeNameAndKind` to just take the info from the `NodeValue` instead of the `NodeValue` itself, so that it doesn't need to depend on anything from Graph.