### PR TITLE
[tensor] Improve file I/O routine

### DIFF
--- a/lib/Base/IO.cpp
+++ b/lib/Base/IO.cpp
@@ -22,30 +22,26 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
-static uint64_t filesize(llvm::StringRef filename) {
-  uint64_t result;
-  auto err = llvm::sys::fs::file_size(filename, result);
-  GLOW_ASSERT(!err);
-  return result;
-}
-
 namespace glow {
 
 void writeToFile(const Tensor &T, llvm::StringRef filename) {
   FILE *fp = fopen(filename.data(), "wb");
   GLOW_ASSERT(fp);
-  auto nitems =
-      fwrite(T.getUnsafePtr(), T.getType().getElementSize(), T.size(), fp);
+  auto nitems = fwrite(&T.getType(), sizeof(Type), 1, fp);
+  GLOW_ASSERT(nitems == 1);
+  nitems = fwrite(T.getUnsafePtr(), T.getType().getElementSize(), T.size(), fp);
   GLOW_ASSERT(nitems == T.size());
   fclose(fp);
 }
 
 void readFromFile(Tensor &T, llvm::StringRef filename) {
-  GLOW_ASSERT(T.getType().getSizeInBytes() == filesize(filename));
   FILE *fp = fopen(filename.data(), "rb");
   GLOW_ASSERT(fp);
-  auto nitems =
-      fread(T.getUnsafePtr(), T.getType().getElementSize(), T.size(), fp);
+  Type type;
+  auto nitems = fread(&type, sizeof(Type), 1, fp);
+  GLOW_ASSERT(nitems == 1);
+  T.reset(type);
+  nitems = fread(T.getUnsafePtr(), T.getType().getElementSize(), T.size(), fp);
   GLOW_ASSERT(nitems == T.size());
   fclose(fp);
 }

--- a/tests/unittests/UtilsTest.cpp
+++ b/tests/unittests/UtilsTest.cpp
@@ -57,11 +57,10 @@ TEST(Utils, deterministicPRNG) {
 TEST(Utils, readWriteTensor) {
   llvm::SmallString<64> path;
   llvm::sys::fs::createTemporaryFile("tensor", "bin", path);
-  ShapeVector dims({2, 2, 2});
-  Tensor output(ElemKind::FloatTy, dims);
+  Tensor output(ElemKind::FloatTy, {2, 1, 4});
   output.getHandle() = {1, 2, 3, 4, 5, 6, 7, 8};
   writeToFile(output, path);
-  Tensor input(ElemKind::FloatTy, dims);
+  Tensor input;
   readFromFile(input, path);
   llvm::sys::fs::remove(path);
   EXPECT_TRUE(output.isEqual(input));


### PR DESCRIPTION
Description: Needing to know the tensor type out-of-band makes it a lot harder
to use these routines for instrumentation and debugging.  Since these tensor
dumps aren't intended to be a real serialization format, we can just
fwrite/fread the Type struct to get the information we want.

Testing: Modify existing test to not rely on type knowledge.
