### PR TITLE
Inlining std::sort predicate.

### DIFF
--- a/include/glow/Base/Traits.h
+++ b/include/glow/Base/Traits.h
@@ -39,6 +39,11 @@ public:
 
   /// Set the name of the instruction to \p name.
   void setName(llvm::StringRef name) { name_ = name; }
+
+  /// Compares by names, \returns true if name_ < x.name_.
+  bool compareByName(const Named &x) const {
+    return name_.compare(x.name_) > 0;
+  }
 };
 
 /// Subclasses of this class have a type associated with them.

--- a/lib/Partitioner/PartitionerUtils.cpp
+++ b/lib/Partitioner/PartitionerUtils.cpp
@@ -21,10 +21,12 @@ using llvm::isa;
 
 namespace glow {
 
-/// Used to sort 2 Nodes by their name.
-static bool compFunc(Node *n1, Node *n2) {
-  return (n1->getName().compare(n2->getName()) > 0);
-}
+namespace {
+/// Used to sort 2 Nodes by their name, i.e. n1->name < n2->name order.
+auto compFunc = [](const Node *n1, Node *n2) -> bool {
+  return n1->compareByName(*n2);
+};
+} // namespace
 
 /// The nodes in function \p F which be grouped into levels based on how far
 /// (the longest distance) they are from the roots.


### PR DESCRIPTION
*Description*:
Replaced static comparison function with the correspondent lambda.
*Testing*:
ninja test
*Documentation*:
Class Named exposes the comparison function by names.
Any lambda can use it to compare two instances of class Node and make code inlined.
[Optional Fixes #issue]
