### PR TITLE
[OpenCL] Move hexified OpenCL kernels from glow/ to glow/OpenCL

### DIFF
--- a/lib/Backends/OpenCL/CMakeLists.txt
+++ b/lib/Backends/OpenCL/CMakeLists.txt
@@ -1,30 +1,30 @@
 add_custom_command(
-  OUTPUT "${CMAKE_BINARY_DIR}/glow/kernels.inc"
+  OUTPUT "${CMAKE_BINARY_DIR}/glow/OpenCL/kernels.cl.inc"
   COMMAND include-bin
           "${CMAKE_CURRENT_SOURCE_DIR}/kernels.cl"
-          "${CMAKE_BINARY_DIR}/glow/kernels.inc"
+          "${CMAKE_BINARY_DIR}/glow/OpenCL/kernels.cl.inc"
   DEPENDS include-bin CPURuntime "${CMAKE_CURRENT_SOURCE_DIR}/kernels.cl")
 
 add_custom_command(
-  OUTPUT "${CMAKE_BINARY_DIR}/glow/kernels_fwd_conv.inc"
+  OUTPUT "${CMAKE_BINARY_DIR}/glow/OpenCL/kernels_fwd_conv.cl.inc"
   COMMAND include-bin
           "${CMAKE_CURRENT_SOURCE_DIR}/kernels_fwd_conv.cl"
-          "${CMAKE_BINARY_DIR}/glow/kernels_fwd_conv.inc"
+          "${CMAKE_BINARY_DIR}/glow/OpenCL/kernels_fwd_conv.cl.inc"
   DEPENDS include-bin CPURuntime
           "${CMAKE_CURRENT_SOURCE_DIR}/kernels_fwd_conv.cl")
 
 add_custom_command(
-  OUTPUT "${CMAKE_BINARY_DIR}/glow/kernels_fwd_quantized_conv.inc"
+  OUTPUT "${CMAKE_BINARY_DIR}/glow/OpenCL/kernels_fwd_quantized_conv.cl.inc"
   COMMAND include-bin
           "${CMAKE_CURRENT_SOURCE_DIR}/kernels_fwd_quantized_conv.cl"
-          "${CMAKE_BINARY_DIR}/glow/kernels_fwd_quantized_conv.inc"
+          "${CMAKE_BINARY_DIR}/glow/OpenCL/kernels_fwd_quantized_conv.cl.inc"
   DEPENDS include-bin CPURuntime
           "${CMAKE_CURRENT_SOURCE_DIR}/kernels_fwd_quantized_conv.cl")
 
 add_library(OpenCLBackend
-            "${CMAKE_BINARY_DIR}/glow/kernels.inc"
-            "${CMAKE_BINARY_DIR}/glow/kernels_fwd_conv.inc"
-            "${CMAKE_BINARY_DIR}/glow/kernels_fwd_quantized_conv.inc"
+            "${CMAKE_BINARY_DIR}/glow/OpenCL/kernels.cl.inc"
+            "${CMAKE_BINARY_DIR}/glow/OpenCL/kernels_fwd_conv.cl.inc"
+            "${CMAKE_BINARY_DIR}/glow/OpenCL/kernels_fwd_quantized_conv.cl.inc"
             OpenCL.cpp
             Transforms.cpp)
 

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -56,14 +56,14 @@ typedef uint32_t cl_size_t;
 
 // This defines kernels for optimized convolutions.
 static const unsigned char kernels_fwd_conv_cl_src[] = {
-#include "glow/kernels_fwd_conv.inc"
+#include "glow/OpenCL/kernels_fwd_conv.cl.inc"
 };
 static const size_t kernels_fwd_conv_cl_src_size =
     sizeof(kernels_fwd_conv_cl_src);
 
 // This defines kernels for quantized optimized convolutions.
 static const unsigned char kernels_fwd_quantized_conv_cl_src[] = {
-#include "glow/kernels_fwd_quantized_conv.inc"
+#include "glow/OpenCL/kernels_fwd_quantized_conv.cl.inc"
 };
 static const size_t kernels_fwd_quantized_conv_cl_src_size =
     sizeof(kernels_fwd_quantized_conv_cl_src);

--- a/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
@@ -34,7 +34,7 @@ using namespace glow::runtime;
 
 // This defines kernels for most operations.
 static const unsigned char kernels_cl_src[] = {
-#include "glow/kernels.inc"
+#include "glow/OpenCL/kernels.cl.inc"
 };
 static const size_t kernels_cl_src_size = sizeof(kernels_cl_src);
 


### PR DESCRIPTION
**Description**
This commit moves the hexified OpenCL kernels from `glow/...` to
`glow/OpenCL/...`.

**Testing**
Ran `OCLTest` and it passed.
