### PR TITLE
Allow zero sized tensor inputs

### DIFF
--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -127,6 +127,8 @@ onnxStatus Graph::setIOAndRun(uint32_t inputsCount,
       inputTensor = Tensor(inOnnxBuffer, inPhPtr->getType());
     } else {
       char *onnxBuffer = static_cast<char *>(inOnnxBuffer);
+      // If input onnxTensorDescriptor has a NULL buffer pointer, which is a
+      // valid case for empty tensor, skip copying
       if (inOnnxBuffer) {
         inputTensor = Tensor(inPhPtr->getType());
         unsigned elementSize = inPhPtr->getType()->getElementSize();

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -126,11 +126,13 @@ onnxStatus Graph::setIOAndRun(uint32_t inputsCount,
     if (inPhPtr->dims().equals(inOnnxTensorDims)) {
       inputTensor = Tensor(inOnnxBuffer, inPhPtr->getType());
     } else {
-      inputTensor = Tensor(inPhPtr->getType());
-      unsigned elementSize = inPhPtr->getType()->getElementSize();
       char *onnxBuffer = static_cast<char *>(inOnnxBuffer);
-      std::copy(onnxBuffer, onnxBuffer + inOnnxTensorSize * elementSize,
-                inputTensor.getUnsafePtr());
+      if (inOnnxBuffer) {
+        inputTensor = Tensor(inPhPtr->getType());
+        unsigned elementSize = inPhPtr->getType()->getElementSize();
+        std::copy(onnxBuffer, onnxBuffer + inOnnxTensorSize * elementSize,
+                  inputTensor.getUnsafePtr());
+      }
     }
 
     ctx->getPlaceholderBindings()->insert(inPhPtr, std::move(inputTensor));

--- a/lib/Onnxifi/onnxifiGlow.cpp
+++ b/lib/Onnxifi/onnxifiGlow.cpp
@@ -405,8 +405,8 @@ GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxInitGraph)(
   return ONNXIFI_STATUS_SUCCESS;
 }
 
-static bool verifyDescriptors(uint32_t count,
-                              const onnxTensorDescriptorV1 *descriptors) {
+static int verifyDescriptors(uint32_t count,
+                             const onnxTensorDescriptorV1 *descriptors) {
   for (unsigned i = 0; i < count; i++) {
     const auto &descriptor = descriptors[i];
     if (descriptor.tag != ONNXIFI_TAG_TENSOR_DESCRIPTOR_V1) {
@@ -417,7 +417,8 @@ static bool verifyDescriptors(uint32_t count,
       return ONNXIFI_STATUS_INVALID_MEMORY_TYPE;
     }
 
-    if (!descriptor.buffer) {
+    if (!descriptor.buffer &&
+        !(descriptor.dimensions == 1 && descriptor.shape[0] == 0)) {
       return ONNXIFI_STATUS_INVALID_MEMORY_LOCATION;
     }
   }

--- a/lib/Onnxifi/onnxifiGlow.cpp
+++ b/lib/Onnxifi/onnxifiGlow.cpp
@@ -405,8 +405,9 @@ GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxInitGraph)(
   return ONNXIFI_STATUS_SUCCESS;
 }
 
-static int verifyDescriptors(uint32_t count,
-                             const onnxTensorDescriptorV1 *descriptors) {
+/// Sanity check for tensor descriptors
+static onnxStatus verifyDescriptors(uint32_t count,
+                                    const onnxTensorDescriptorV1 *descriptors) {
   for (unsigned i = 0; i < count; i++) {
     const auto &descriptor = descriptors[i];
     if (descriptor.tag != ONNXIFI_TAG_TENSOR_DESCRIPTOR_V1) {


### PR DESCRIPTION
*Description*:
It is possible that input tensor descriptor has a null buffer with dim [0]. For example, we can look up 0 elements in embedding table in current batch. We need to allow this case. Also fix a bug where we return incorrect error code. 

*Testing*:
Internal test. 

*Documentation*:
[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
