### PR TITLE
[Provisioner] Remove NETWORK_PADDING_FACTOR

### DIFF
--- a/include/glow/Runtime/Provisioner/Provisioner.h
+++ b/include/glow/Runtime/Provisioner/Provisioner.h
@@ -51,10 +51,6 @@ private:
   /// functions.
   std::unordered_map<std::string, std::unique_ptr<CompiledFunction>> functions_;
 
-  /// Padding factor to account for generated code size. Should be greater
-  /// than 1.0.
-  const float NETWORK_PADDING_FACTOR = 1.1;
-
   /// List of available DeviceManagers added during initialization.
   std::vector<DeviceManager *> devices_;
 };

--- a/lib/Runtime/Provisioner/Provisioner.cpp
+++ b/lib/Runtime/Provisioner/Provisioner.cpp
@@ -103,8 +103,7 @@ llvm::Error Provisioner::provision(DAGListTy &networks, Module &module) {
 
   // Try to add functions to devices in order from largest to smallest.
   for (unsigned i = 0; i < logicalDeviceSize.size(); i++) {
-    RETURN_ERR_IF_NOT(logicalDeviceSize[i].second * NETWORK_PADDING_FACTOR <
-                          deviceMemory[i].second,
+    RETURN_ERR_IF_NOT(logicalDeviceSize[i].second < deviceMemory[i].second,
                       "Not enough memory to provision functions onto devices");
 
     // Load functions on device.


### PR DESCRIPTION
*Description*:
No need to use the factor. NETWORK_PADDING_FACTOR was added to reflect the memory use of the instruction. 

*Testing*:
*Documentation*:
[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
