### PR TITLE
Update DAGNode to support network duplication.

### DIFF
--- a/include/glow/Runtime/RuntimeTypes.h
+++ b/include/glow/Runtime/RuntimeTypes.h
@@ -71,17 +71,26 @@ struct DAGNode {
   /// Pointers to the parents of this node. This is used by the executor for
   /// determining if a given node has all dependencies met.
   std::vector<DAGNode *> parents;
-  /// ID of the deviceManager that this network is assigned to.
-  DeviceIDTy deviceID;
+  /// IDs of the deviceManagers that this network is assigned to.
+  std::vector<DeviceIDTy> deviceIDs;
   /// The logicalDevice is an output of the Partitioner to indicate that two
-  /// networks should be assigned to the same device.
-  DeviceIDTy logicalDevice;
+  /// networks should be assigned to the same device. Multiple logical devices
+  /// indicates the network should be duplicated.
+  std::vector<DeviceIDTy> logicalDevices;
+  /// Index of the current deviceID in deviceIDs. This is used by the Executor
+  /// when picking a device to request a network run.
+  unsigned currentDeviceIdx{0};
   /// Name assigned to the sub-network, this is the id that will be passed to
   /// the DeviceManager when requesting a run of the network.
   std::string name;
   /// Runtime bundle containing all the symbol information for this network at
   /// runtime.
   std::unique_ptr<RuntimeBundle> runtimeBundle;
+
+  DeviceIDTy getNextDevice() {
+    currentDeviceIdx++;
+    return deviceIDs[currentDeviceIdx % deviceIDs.size()];
+  }
 };
 
 /// This struct represents a DAG. The first element is the root of a DAG, and

--- a/lib/Partitioner/Partitioner.cpp
+++ b/lib/Partitioner/Partitioner.cpp
@@ -439,10 +439,9 @@ void Partitioner::doPartitioning(Function *F, NodeToFunctionMap &mapping) {
   // The dummy node.
   rootDAGNodeTy DAGRoot = llvm::make_unique<DAGNode>();
   nodesDAGNodeTy nodes;
-  DAGRoot->logicalDevice = 0;
+  DAGRoot->logicalDevices = {0};
   DAGRoot->name = F->getName();
-  DAGRoot->deviceID = 0;
-  DAGRoot->logicalDevice = 0;
+  DAGRoot->deviceIDs = {0};
   DAGNode *root = DAGRoot.get();
   llvm::DenseMap<Node *, Node *> currToNew;
 
@@ -455,14 +454,14 @@ void Partitioner::doPartitioning(Function *F, NodeToFunctionMap &mapping) {
 
   // For any dependency that crosses a partition, add a placeholder and save
   // node. Record the dependence in the function graph.
-  int logicalID = 0;
+  DeviceIDTy logicalID = 0;
   std::unordered_map<NodeValue, Placeholder *> placeholders;
   llvm::DenseMap<Function *, DAGNode *> funcDAG;
   for (auto *subF : mapping.getPartitions()) {
     if (funcDAG.find(subF) == funcDAG.end()) {
       std::unique_ptr<DAGNode> subDAG = llvm::make_unique<DAGNode>();
       subDAG->name = subF->getName();
-      subDAG->logicalDevice = logicalID++;
+      subDAG->logicalDevices = {logicalID++};
       funcDAG[subF] = subDAG.get();
       nodes.push_back(std::move(subDAG));
     }
@@ -484,7 +483,7 @@ void Partitioner::doPartitioning(Function *F, NodeToFunctionMap &mapping) {
         if (funcDAG.find(inputF) == funcDAG.end()) {
           std::unique_ptr<DAGNode> subDAG = llvm::make_unique<DAGNode>();
           subDAG->name = inputF->getName();
-          subDAG->logicalDevice = logicalID++;
+          subDAG->logicalDevices = {logicalID++};
           funcDAG[inputF] = subDAG.get();
           nodes.push_back(std::move(subDAG));
         }
@@ -557,10 +556,10 @@ llvm::Error Partitioner::Partition() {
     // dummy function.
     for (auto F : module_->getFunctions()) {
       std::unique_ptr<DAGNode> DAG0 = llvm::make_unique<DAGNode>();
-      DAG0->logicalDevice = 0;
+      DAG0->logicalDevices = {0};
       DAG0->name = F->getName();
       std::unique_ptr<DAGNode> DAG1 = llvm::make_unique<DAGNode>();
-      DAG1->logicalDevice = 0;
+      DAG1->logicalDevices = {0};
       DAG1->name = F->getName();
       DAG1->parents.push_back(DAG0.get());
       DAG0->children.push_back(DAG1.get());

--- a/lib/Runtime/Executor/ThreadPoolExecutor.h
+++ b/lib/Runtime/Executor/ThreadPoolExecutor.h
@@ -179,7 +179,7 @@ private:
   /// Execute the DAG node specified by \p node within the run corresponding to
   /// \p executionState.
   void executeDAGNode(std::shared_ptr<ExecutionState> executionState,
-                      const DAGNode *node);
+                      DAGNode *node);
 
   /// Handle the result returned asynchronously by the DeviceManager.
   /// \p executionState is tracks the state of the run that the node that

--- a/lib/Runtime/Provisioner/Provisioner.cpp
+++ b/lib/Runtime/Provisioner/Provisioner.cpp
@@ -58,11 +58,11 @@ llvm::Error Provisioner::provision(DAGListTy &networks, Module &module) {
 
   for (auto &network : networks) {
     for (auto &node : network.nodes) {
-      auto it = logicalDevices.find(node->logicalDevice);
+      auto it = logicalDevices.find(node->logicalDevices[0]);
       if (it != logicalDevices.end()) {
         it->second.push_back(node.get());
       } else {
-        logicalDevices.emplace(node->logicalDevice,
+        logicalDevices.emplace(node->logicalDevices[0],
                                std::vector<DAGNode *>{node.get()});
       }
     }
@@ -122,7 +122,7 @@ llvm::Error Provisioner::provision(DAGListTy &networks, Module &module) {
     RETURN_IF_ERR(addErr);
     // Set deviceID for each node added
     for (auto &node : logicalDevices[logicalID]) {
-      node->deviceID = deviceID;
+      node->deviceIDs = {deviceID};
     }
   }
   return llvm::Error::success();

--- a/tests/benchmark/RuntimeBench.cpp
+++ b/tests/benchmark/RuntimeBench.cpp
@@ -571,7 +571,7 @@ std::unique_ptr<DAG> createSingleNodeDAG(
   root->children.emplace_back(singleNode.get());
 
   singleNode->parents.emplace_back(root.get());
-  singleNode->deviceID = 0;
+  singleNode->deviceIDs = {0};
   singleNode->name = "singleNode";
   singleNode->runtimeBundle = llvm::make_unique<RuntimeBundle>(
       compiledFunctions["singleNode"]->getRuntimeBundle());

--- a/tests/unittests/ExecutorTest.cpp
+++ b/tests/unittests/ExecutorTest.cpp
@@ -402,7 +402,7 @@ public:
 
     // Set the name, device ID, and RuntimeBundle of the new node.
     newNode->name = name;
-    newNode->deviceID = deviceId;
+    newNode->deviceIDs = {deviceId};
 
     newNode->runtimeBundle = llvm::make_unique<RuntimeBundle>(
         symbolTable, /*constWeight=*/0, /*mutableWeight=*/0,

--- a/tests/unittests/ProvisionerTest.cpp
+++ b/tests/unittests/ProvisionerTest.cpp
@@ -44,10 +44,12 @@ DAGListTy setupDAG(unsigned rootCount, unsigned childCount) {
     rootNode->name = "root" + std::to_string(root);
     rootNode->children.push_back(firstNode.get());
     firstNode->name = "function" + std::to_string(currentFunction);
+    firstNode->logicalDevices = {0};
     currentFunction++;
     for (unsigned int child = 0; child < childCount; child++) {
       auto newChild = llvm::make_unique<DAGNode>();
       newChild->name = "function" + std::to_string(currentFunction);
+      newChild->logicalDevices = {0};
       currentFunction++;
       firstNode->children.push_back(newChild.get());
       nodes.push_back(std::move(newChild));


### PR DESCRIPTION
*Description*: This PR updates the DAGNode data structure to support networks being duplicated on multiple devices. This is the first step, the next step would be updating the provisioner and partitioner to handle duplication.
*Testing*: ninja test, and resnet-runtime
*Documentation*: NA
