### PR TITLE
[habana] Fall back to looking up Placeholders by name

### DIFF
--- a/lib/Backends/Habana/Habana.cpp
+++ b/lib/Backends/Habana/Habana.cpp
@@ -459,6 +459,10 @@ void HabanaFunction::execute(ExecutionContext *context) {
   auto *bindings = context->getPlaceholderBindings();
   for (auto *P : getInputs()) {
     Tensor *T = bindings->get(P);
+    if (!T) {
+      T = bindings->get(bindings->getPlaceholderByName(P->getName()));
+    }
+    GLOW_ASSERT(T);
 
     EnqueueTensorInfo eti;
     llvm::StringRef name = P->getName();
@@ -474,6 +478,10 @@ void HabanaFunction::execute(ExecutionContext *context) {
   // Set up output buffers and record bindings for enqueuing.
   for (auto *P : getOutputs()) {
     Tensor *T = bindings->get(P);
+    if (!T) {
+      T = bindings->get(bindings->getPlaceholderByName(P->getName()));
+    }
+    GLOW_ASSERT(T);
 
     EnqueueTensorInfo eti;
     llvm::StringRef name = P->getName();

--- a/lib/Backends/Habana/HabanaDeviceManager.cpp
+++ b/lib/Backends/Habana/HabanaDeviceManager.cpp
@@ -317,6 +317,9 @@ void HabanaDeviceManager::runFunctionImpl(RunIdentifierTy runId,
       auto bindings = ctx->getPlaceholderBindings();
       for (const auto &ph : function->getOutputs()) {
         auto *tensor = bindings->get(ph);
+        if (!tensor) {
+          tensor = bindings->get(bindings->getPlaceholderByName(ph->getName()));
+        }
         memcpy(tensor->getUnsafePtr(), ioBuffer->get(ph),
                ph->getType()->getSizeInBytes());
       }


### PR DESCRIPTION
*Description*: (backport from glow-h) Since #2668 we may have copied placeholders with the same name but a different pointer. Sometimes we need to fall back to searching by name.
*Testing*: sanity unittests, but really tested in glow-h
*Documentation*: I don't really like this change and would love an alternative.