### PR TITLE
[trivial] Move loweredMapInfo to use llvm::SmallSet

### DIFF
--- a/include/glow/Quantization/Base/Base.h
+++ b/include/glow/Quantization/Base/Base.h
@@ -21,6 +21,8 @@
 #include "glow/Base/Traits.h"
 #include "glow/Base/Type.h"
 
+#include "llvm/ADT/SmallSet.h"
+
 #include <algorithm>
 #include <cassert>
 #include <cstdlib>
@@ -103,7 +105,7 @@ inline bool operator==(const NodeNameAndKind &x, const NodeNameAndKind &y) {
 /// determined by NodeQuantizationInfo::generateNodeOutputName(). For example if
 /// some NodeValue X is lowered from some NodeValue Y, then the output name of X
 /// is a key which maps to a set of names which contains the output name of Y.
-using LoweredInfoMap = llvm::StringMap<std::set<NodeNameAndKind>>;
+using LoweredInfoMap = llvm::StringMap<llvm::SmallSet<NodeNameAndKind, 2>>;
 
 namespace quantization {
 

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -627,7 +627,7 @@ private:
     // from a FullyConnectedNode.
     auto &set = it->getValue();
     for (auto i = set.begin(), e = set.end(); i != e; ++i) {
-      if (i->getKind() == glow::Kinded::Kind::FullyConnectedNodeKind) {
+      if ((*i).getKind() == glow::Kinded::Kind::FullyConnectedNodeKind) {
         return true;
       }
     }
@@ -821,7 +821,7 @@ findAndInsertLoweredInfos(llvm::StringRef currName,
   // and then recursively find and insert other names in case currOrigName was
   // also lowered from a previous node.
   for (auto i = currSet.begin(), e = currSet.end(); i != e; ++i) {
-    llvm::StringRef currOrigName = i->getName();
+    llvm::StringRef currOrigName = (*i).getName();
     quantizationInfos.emplace_back(currOrigName, TQP);
     findAndInsertLoweredInfos(currOrigName, loweredMap, quantizationInfos, TQP);
   }


### PR DESCRIPTION
Since we're using LLVM 7 and above now, SmallSet is now iterable 😄 