### PR TITLE
[LLVMIRCodeGen] Initialize all asm parsers

### DIFF
--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -110,6 +110,7 @@ void LLVMIRGen::initTargetMachine(
   llvm::InitializeAllTargets();
   llvm::InitializeAllTargetMCs();
   llvm::InitializeAllAsmPrinters();
+  llvm::InitializeAllAsmParsers();
 
   if (target.empty()) {
     TM_.reset(llvm::EngineBuilder()


### PR DESCRIPTION
This solves the issue with  "LLVM ERROR: Inline asm not supported by this streamer because we don't have an asm parser for this target" reported when compiling libjit by some backends.
