### PR TITLE
Adds network duplication support to the Provisioner

### DIFF
--- a/tests/unittests/ProvisionerTest.cpp
+++ b/tests/unittests/ProvisionerTest.cpp
@@ -44,7 +44,7 @@ DAGListTy setupDAG(unsigned rootCount, unsigned childCount) {
     rootNode->name = "root" + std::to_string(root);
     rootNode->children.push_back(firstNode.get());
     firstNode->name = "function" + std::to_string(currentFunction);
-    firstNode->logicalDevices = {0};
+    firstNode->logicalDevices = {0, 1};
     currentFunction++;
     for (unsigned int child = 0; child < childCount; child++) {
       auto newChild = llvm::make_unique<DAGNode>();


### PR DESCRIPTION
*Description*: This PR adds the logic to the provisioner to support loading a network on multiple devices. This is done by assigning more than one logicalDevice to the DAGNode for the function.
*Testing*: Extended the Provisioner test to duplicate networks. 
*Documentation*: NA
