### PR TITLE
build: add a helper option to use lld

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,17 @@ endif ()
 # to analyze the source code of the project.
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+if(GLOW_USE_LLD)
+  if(NOT CMAKE_C_COMPILER_ID MATCHES Clang)
+    message(SEND_ERROR "lld requires the use of the clang compiler")
+  endif()
+  if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    message(SEND_ERROR "lld does not support MachO yet")
+  endif()
+  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -fuse-ld=lld")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fuse-ld=lld")
+endif()
+
 include(GlowDefaults)
 include(GlowTestSupport)
 include(GlowExternalBackends)


### PR DESCRIPTION
Add a `GLOW_USE_LLD` option that will switch the build to use lld.  This option
requires `clang`, but can result in reduced build times.

*Description*:
*Testing*:
*Documentation*:
[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
