### PR TITLE
[Runtime Efficiency] Avoid unnecessary tensor copies when propagating Placeholders

### DIFF
--- a/include/glow/Graph/PlaceholderBindings.h
+++ b/include/glow/Graph/PlaceholderBindings.h
@@ -67,6 +67,10 @@ public:
   /// Inserts the Placeholder-Tensor pair.
   void insert(Placeholder *P, Tensor &&T);
 
+  /// Remove the placeholder \p P and return the backing tensor if it is mapped
+  /// otherwise return nullptr,
+  Tensor *remove(Placeholder *P);
+
   /// Allocates a tensor to back the placeholder \p P. The new tensor has the
   /// type of P.
   Tensor *allocate(Placeholder *P);

--- a/lib/Graph/PlaceholderBindings.cpp
+++ b/lib/Graph/PlaceholderBindings.cpp
@@ -81,6 +81,21 @@ void PlaceholderBindings::insert(Placeholder *P, Tensor &&T) {
   nameMap_[P->getName()] = P;
 }
 
+Tensor *PlaceholderBindings::remove(Placeholder *P) {
+  auto it = map_.find(P);
+
+  if (it == map_.end()) {
+    return nullptr;
+  }
+
+  Tensor *t = it->second;
+
+  map_.erase(it);
+  nameMap_.erase(P->getName());
+
+  return t;
+}
+
 size_t PlaceholderBindings::count(Placeholder *P) const {
   assert((map_.size() == nameMap_.size()) &&
          "Placeholder map and name map out of sync");

--- a/lib/Runtime/Executor/ThreadPoolExecutor.h
+++ b/lib/Runtime/Executor/ThreadPoolExecutor.h
@@ -170,11 +170,12 @@ private:
 
   /// Propagate Placeholders needed by \p node from \p ctx into
   /// the ExecutionContext for \p node within the run corresponding to \p
-  /// executionState.
+  /// executionState. If \p cloneTensors then copy tensor values into tensors in
+  /// executionState otherwise destructively move them instead.
   void
   propagatePlaceholdersForNode(std::shared_ptr<ExecutionState> executionState,
-                               const DAGNode *node,
-                               const ExecutionContext *ctx);
+                               const DAGNode *node, ExecutionContext *ctx,
+                               bool cloneTensors);
 
   /// Execute the DAG node specified by \p node within the run corresponding to
   /// \p executionState.


### PR DESCRIPTION
*Description*:
If a `DagNode` has only one child then there should be only one user of a given output placeholder from that `DagNode` and so copying the output placeholders' backing tensors is unnecessary, they can just be moved. If a `DagNode` has multiple children then the first N-1 children can get copies and we don't have to copy for the Nth `DagNode`.

*Testing*:
* Will sync internally and test
* Will update/add ExecutorTest unit tests

*Documentation*:
doxygen