### PR TITLE
Add assertAllNodesQuantized option to quantizeFunction()

### DIFF
--- a/examples/bundles/lenet_mnist/Makefile
+++ b/examples/bundles/lenet_mnist/Makefile
@@ -35,7 +35,7 @@ ifeq ($(QUANTIZE),YES)
 build/lenet_mnist.o: profile.yml
 	mkdir -p build
 	# Create bundle with quantized weights and computation graph.
-	${LOADER} ${IMAGES}/3_1020.png -image-mode=0to1 -load-profile=profile.yml -m lenet_mnist -model-input-name=${MODEL_INPUT_NAME} -cpu -emit-bundle build -g
+	${LOADER} ${IMAGES}/3_1020.png -image-mode=0to1 -load-profile=profile.yml -m lenet_mnist -assert-all-nodes-quantized -keep-original-precision-for-nodes=SoftMax -model-input-name=${MODEL_INPUT_NAME} -cpu -emit-bundle build -g
 else
 build/lenet_mnist.o: download_weights
 	mkdir -p build

--- a/examples/bundles/resnet50/CMakeLists.txt
+++ b/examples/bundles/resnet50/CMakeLists.txt
@@ -50,8 +50,8 @@ add_custom_command(
   COMMAND
     image-classifier ${IMAGES}/dog_207.png -g -image-mode=0to1
     -m=${RESNET50_BUNDLE_DIR}/resnet50 -model-input-name=${MODEL_INPUT_NAME}
-    -cpu -emit-bundle ${RESNET50_BUNDLE_DIR} 
-  DEPENDS 
+    -cpu -emit-bundle ${RESNET50_BUNDLE_DIR}
+  DEPENDS
     image-classifier
 )
 add_custom_target(ResNet50BundleNet DEPENDS ${RESNET50_BUNDLE_DIR}/resnet50.o ResNet50BundleNetFiles)
@@ -74,7 +74,7 @@ add_custom_command(
   OUTPUT
     ${RESNET50_BUNDLE_DIR}/quantized_resnet50.o
   COMMAND
-    image-classifier ${IMAGES}/dog_207.png -g -image-mode=0to1 -load-profile=profile.yml
+    image-classifier ${IMAGES}/dog_207.png -g -image-mode=0to1 -load-profile=profile.yml -assert-all-nodes-quantized -keep-original-precision-for-nodes=SoftMax
     -m=${RESNET50_BUNDLE_DIR}/resnet50 -model-input-name=${MODEL_INPUT_NAME}
     -cpu -emit-bundle ${RESNET50_BUNDLE_DIR} && mv ${RESNET50_BUNDLE_DIR}/resnet50.o ${RESNET50_BUNDLE_DIR}/quantized_resnet50.o
   DEPENDS

--- a/examples/fr2en.cpp
+++ b/examples/fr2en.cpp
@@ -173,7 +173,6 @@ struct Model {
           deserializeFromYaml(loadProfileFileOpt)};
 
       // Quantize the graph based on the captured profile.
-      quantConfig.assertAllNodesQuantized = false;
       auto *Q = quantization::quantizeFunction(F_, quantConfig,
                                                *EE_.getBackend(), loweredMap_);
 

--- a/examples/fr2en.cpp
+++ b/examples/fr2en.cpp
@@ -173,6 +173,7 @@ struct Model {
           deserializeFromYaml(loadProfileFileOpt)};
 
       // Quantize the graph based on the captured profile.
+      quantConfig.assertAllNodesQuantized = false;
       auto *Q = quantization::quantizeFunction(F_, quantConfig,
                                                *EE_.getBackend(), loweredMap_);
 

--- a/include/glow/Quantization/Quantization.h
+++ b/include/glow/Quantization/Quantization.h
@@ -49,6 +49,11 @@ struct QuantizationConfiguration {
   /// \ref quantizeFunction() will generate a name.
   std::string newFuncName{""};
 
+  /// If true, the quantizer will abort when encountering a node that it would
+  /// like to quantize but the backend cannot support. Note that node kinds in
+  /// doNotQuantizeKinds will skip this check and not cause an abort.
+  bool assertAllNodesQuantized{true};
+
   QuantizationConfiguration() = default;
   QuantizationConfiguration(llvm::ArrayRef<NodeQuantizationInfo> i)
       : infos(i) {}

--- a/include/glow/Quantization/Quantization.h
+++ b/include/glow/Quantization/Quantization.h
@@ -52,7 +52,7 @@ struct QuantizationConfiguration {
   /// If true, the quantizer will abort when encountering a node that it would
   /// like to quantize but the backend cannot support. Note that node kinds in
   /// doNotQuantizeKinds will skip this check and not cause an abort.
-  bool assertAllNodesQuantized{true};
+  bool assertAllNodesQuantized{false};
 
   QuantizationConfiguration() = default;
   QuantizationConfiguration(llvm::ArrayRef<NodeQuantizationInfo> i)

--- a/tests/text-translator/en2gr_quantization_test.sh
+++ b/tests/text-translator/en2gr_quantization_test.sh
@@ -22,6 +22,6 @@ TEMP_FILE="$(mktemp)"
 $BIN/text-translator -m "${MODELS_DIR}/en2gr" -keep-original-precision-for-nodes=Add -dump-profile=$TEMP_FILE -quantization-schema=symmetric <<< "My name is Bob ."
 
 # CHECK: mein Name ist Bob \.$
-$BIN/text-translator -m "${MODELS_DIR}/en2gr" -keep-original-precision-for-nodes=Add -load-profile=$TEMP_FILE <<< "My name is Bob ."
+$BIN/text-translator -m "${MODELS_DIR}/en2gr" -keep-original-precision-for-nodes=Add,SoftMax -assert-all-nodes-quantized -load-profile=$TEMP_FILE <<< "My name is Bob ."
 
 rm $TEMP_FILE

--- a/tests/unittests/BackendTestUtils.cpp
+++ b/tests/unittests/BackendTestUtils.cpp
@@ -90,6 +90,7 @@ static void profileAndQuantize(PlaceholderBindings &Ibindings,
                                         schema)};
   quantConfig.enableRowwise = enableRowwiseQuantization;
   quantConfig.schema = schema;
+  quantConfig.assertAllNodesQuantized = true;
 
   if (isQuantizedElemKind(interpElemKind)) {
     quantConfig.precision = interpElemKind;

--- a/tests/unittests/MLTest.cpp
+++ b/tests/unittests/MLTest.cpp
@@ -1073,6 +1073,7 @@ TEST_P(InterpreterAndCPU, convNetForImageRecognition) {
   quantization::QuantizationConfiguration quantConfig{
       quantization::generateNodeQuantizationInfos(bindings, PF,
                                                   loweredMapForProf)};
+  quantConfig.assertAllNodesQuantized = true;
 
   // Softmax is not supported in Int8QTy, so signal the quantizer it's OK to
   // keep it unquantized.
@@ -1197,6 +1198,7 @@ TEST_P(InterpreterAndCPU, testFindPixelRegression) {
   quantization::QuantizationConfiguration quantConfig{
       quantization::generateNodeQuantizationInfos(bindings, PF,
                                                   loweredMapForProf)};
+  quantConfig.assertAllNodesQuantized = true;
 
   // Build the new quantized graph.
   LoweredInfoMap loweredMapForQuant;

--- a/tests/unittests/MLTest.cpp
+++ b/tests/unittests/MLTest.cpp
@@ -1074,11 +1074,16 @@ TEST_P(InterpreterAndCPU, convNetForImageRecognition) {
       quantization::generateNodeQuantizationInfos(bindings, PF,
                                                   loweredMapForProf)};
 
+  // Softmax is not supported in Int8QTy, so signal the quantizer it's OK to
+  // keep it unquantized.
+  KindSet doNotQuantizeKinds;
+  doNotQuantizeKinds.insert(Kinded::Kind::SoftMaxNodeKind);
+
   // Build the new quantized graph.
   LoweredInfoMap loweredMapForQuant;
   lower(F, &loweredMapForQuant, EE.getBackend());
   Function *QP = quantization::quantizeFunction(
-      F, quantConfig, *EE.getBackend(), loweredMapForQuant);
+      F, quantConfig, *EE.getBackend(), loweredMapForQuant, doNotQuantizeKinds);
 
   EE.compile(CompilationMode::Infer, QP);
 

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -1928,20 +1928,6 @@ COMPARE_ARITH_FLOAT_VS_INT8(Max, Interpreter, CPU, OpenCL)
 COMPARE_ARITH_FLOAT_VS_INT8(Min, Interpreter, CPU, OpenCL)
 #undef COMPARE_ARITH_FLOAT_VS_INT8
 
-#define COMPARE_ARITH_FLOAT_VS_INT16(_OP_NAME_, ...)                           \
-  TEST_P(OperatorStatelessTest, Basic##_OP_NAME_##NetFloatVsInt16) {           \
-    ENABLED_BACKENDS(__VA_ARGS__);                                             \
-    compareAgainstInterpreter(GetParam(), createAndInitBasic##_OP_NAME_##Test, \
-                              ElemKind::FloatTy, ElemKind::Int16QTy, 0.02f);   \
-  }
-COMPARE_ARITH_FLOAT_VS_INT16(Add, Interpreter)
-COMPARE_ARITH_FLOAT_VS_INT16(Sub, Interpreter)
-COMPARE_ARITH_FLOAT_VS_INT16(Mul, Interpreter)
-COMPARE_ARITH_FLOAT_VS_INT16(Div, Interpreter)
-COMPARE_ARITH_FLOAT_VS_INT16(Max, Interpreter)
-COMPARE_ARITH_FLOAT_VS_INT16(Min, Interpreter)
-#undef COMPARE_ARITH_FLOAT_VS_INT16
-
 #define COMPARE_ARITH_FLOAT_VS_FLOAT16(_OP_NAME_, ...)                         \
   TEST_P(OperatorStatelessTest, Basic##_OP_NAME_##NetFloatVsFloat16) {         \
     ENABLED_BACKENDS(__VA_ARGS__);                                             \

--- a/tests/unittests/QuantizationTest.cpp
+++ b/tests/unittests/QuantizationTest.cpp
@@ -269,6 +269,7 @@ static void quantizeSimpleConvGraph(ElemKind quantizationPrecision) {
   }};
 
   quantConfig.precision = quantizationPrecision;
+  quantConfig.assertAllNodesQuantized = true;
   F = quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
 
   // Make sure that graph can be compiled and run.
@@ -324,6 +325,7 @@ TEST(Quantization, TestQuantizedInputBeforeQuantizedNode) {
       {NodeQuantizationInfo::generateNodeOutputName(SN->getName()), {0.2f, 0}},
   }};
 
+  quantConfig.assertAllNodesQuantized = true;
   F = quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
 
   // Remove unnecessary conversions.
@@ -375,6 +377,7 @@ TEST(Quantization, enableRowwiseQuantizedFullyConnected) {
   }};
 
   quantConfig.enableRowwise = true;
+  quantConfig.assertAllNodesQuantized = true;
   F = quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
 
   // Check the graph structure after quantization.
@@ -448,6 +451,7 @@ TEST(Quantization, enableRowwiseQuantizedFullyConnectedSymmetric) {
 
   quantConfig.schema = quantization::Schema::Symmetric;
   quantConfig.enableRowwise = true;
+  quantConfig.assertAllNodesQuantized = true;
   F = quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
 
   // Check the graph structure after quantization.
@@ -521,6 +525,7 @@ TEST(Quantization, enableRowwiseQuantizedSLWS) {
   }};
 
   quantConfig.enableRowwise = true;
+  quantConfig.assertAllNodesQuantized = true;
   F = quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
 
   EE.compile(CompilationMode::Infer, F);
@@ -553,6 +558,7 @@ TEST(Quantization, quantizeReLU) {
         {0.2f, 0}},
        {NodeQuantizationInfo::generateNodeOutputName(relu->getName()),
         {0.2f, -128}}}};
+  quantConfig.assertAllNodesQuantized = true;
   F = quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
   EE.compile(CompilationMode::Infer, F);
 
@@ -589,6 +595,7 @@ TEST(Quantization, quantizeLookupTables) {
         {0.03f, 2}},
        {NodeQuantizationInfo::generateNodeOutputName(TN->getName()),
         {0.04f, 3}}}};
+  quantConfig.assertAllNodesQuantized = true;
   F = quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
   optimize(F, CompilationMode::Infer);
 
@@ -652,6 +659,7 @@ TEST(Quantization, quantizeWithoutLookupTables) {
         {0.03f, 2}},
        {NodeQuantizationInfo::generateNodeOutputName(TN->getName()),
         {0.04f, 3}}}};
+  quantConfig.assertAllNodesQuantized = true;
   F = quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
   optimize(F, CompilationMode::Infer);
 
@@ -785,6 +793,7 @@ testQuantizationEnd2End(ExecutionEngine &profileEE,
   LoweredInfoMap loweredMapForQuant;
   lower(F2, &loweredMapForQuant, backendSpecificEE.getBackend());
   quantConfig.precision = quantizationPrecision;
+  quantConfig.assertAllNodesQuantized = true;
   F2 = quantization::quantizeFunction(
       F2, quantConfig, *backendSpecificEE.getBackend(), loweredMapForQuant,
       keepOriginalPrecisionForNodes);
@@ -958,6 +967,7 @@ TEST_P(Operator, end2endGRU) {
 
   LoweredInfoMap loweredMapForQuant;
   lower(F2, &loweredMapForQuant, backendSpecificEE.getBackend());
+  quantConfig.assertAllNodesQuantized = true;
   F2 = quantization::quantizeFunction(F2, quantConfig,
                                       *backendSpecificEE.getBackend(),
                                       loweredMapForQuant, doNotQuantizeKinds);
@@ -1276,6 +1286,7 @@ TEST(Quantization, quantizeSoftmaxAndLRN) {
        {NodeQuantizationInfo::generateNodeOutputName(SN->getName()),
         {0.4f, 0}}}};
 
+  quantConfig.assertAllNodesQuantized = true;
   F = quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
 
   auto qLRNIt = std::find_if(
@@ -1328,6 +1339,7 @@ TEST(Quantization, quantizeSelect) {
        {NodeQuantizationInfo::generateNodeOutputName(select->getName()),
         selectQP}}};
 
+  quantConfig.assertAllNodesQuantized = true;
   F = quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
 
   auto it = std::find_if(
@@ -1372,6 +1384,7 @@ TEST(Quantization, quantizeAvgPool) {
       {NodeQuantizationInfo::generateNodeOutputName(s->getName()), {0.4f, 0}},
   }};
 
+  quantConfig.assertAllNodesQuantized = true;
   F = quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
 
   auto qPool = std::find_if(F->getNodes().begin(), F->getNodes().end(),
@@ -1421,6 +1434,7 @@ TEST(Quantization, quantizeGraphPartially) {
   KindSet doNotQuantizeKinds;
   doNotQuantizeKinds.insert(Kinded::Kind::TanhNodeKind);
 
+  quantConfig.assertAllNodesQuantized = true;
   auto *QF =
       quantization::quantizeFunction(F, quantConfig, *EE.getBackend(),
                                      /* loweredMap */ {}, doNotQuantizeKinds);
@@ -1503,6 +1517,7 @@ TEST(Quantization, quantizeGraphPartiallyMultipleNodes) {
   KindSet doNotQuantizeKinds;
   doNotQuantizeKinds.insert(Kinded::Kind::TanhNodeKind);
 
+  quantConfig.assertAllNodesQuantized = true;
   auto *QF =
       quantization::quantizeFunction(F, quantConfig, *EE.getBackend(),
                                      /* loweredMap */ {}, doNotQuantizeKinds);
@@ -1595,6 +1610,7 @@ TEST(Quantization, quantizeGraphPartiallyMultipleKinds) {
   doNotQuantizeKinds.insert(Kinded::Kind::TanhNodeKind);
   doNotQuantizeKinds.insert(Kinded::Kind::AddNodeKind);
 
+  quantConfig.assertAllNodesQuantized = true;
   auto *QF =
       quantization::quantizeFunction(F, quantConfig, *EE.getBackend(),
                                      /* loweredMap */ {}, doNotQuantizeKinds);
@@ -1678,6 +1694,7 @@ TEST(Quantization, quantizeFunctionConvertConstant) {
       {NodeQuantizationInfo::generateNodeOutputName(MMN->getName()), {0.6f, 0}},
   }};
 
+  quantConfig.assertAllNodesQuantized = true;
   Function *QF =
       quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
   QF->getParent()->eraseFunction(F);
@@ -1742,6 +1759,7 @@ TEST(Quantization, quantizeSlice) {
        {0.4f, 0}},
   }};
 
+  quantConfig.assertAllNodesQuantized = true;
   Function *QF =
       quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
   QF->getParent()->eraseFunction(F);
@@ -1812,6 +1830,7 @@ TEST(Quantization, quantizeReshape) {
        {0.4f, 0}},
   }};
 
+  quantConfig.assertAllNodesQuantized = true;
   Function *QF =
       quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
   QF->getParent()->eraseFunction(F);
@@ -2017,6 +2036,7 @@ static void testProfileQuantizationOfFC(bool expectLoweredFC,
   // Quantize the function given the current backend we're testing along with
   // the quantization infos gathered.
   quantConfig.enableRowwise = rowwiseQuantizeFC;
+  quantConfig.assertAllNodesQuantized = true;
   backendF = quantization::quantizeFunction(
       backendF, quantConfig, *backendEE.getBackend(), loweredMapForQuant);
 

--- a/tests/unittests/QuantizationTest.cpp
+++ b/tests/unittests/QuantizationTest.cpp
@@ -33,11 +33,7 @@ namespace glow {
 
 using llvm::cast;
 
-class Quantization : public ::testing::TestWithParam<BackendKind> {
-protected:
-  ExecutionEngine interpreterEE{BackendKind::Interpreter};
-  ExecutionEngine backendSpecificEE{GetParam()};
-};
+class Quantization : public ::testing::TestWithParam<BackendKind> {};
 
 class Operator
     : public ::testing::TestWithParam<::std::tuple<BackendKind, BackendKind>> {

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -167,6 +167,17 @@ llvm::cl::opt<std::string>
                llvm::cl::desc("Output directory for the bundle serialization"),
                llvm::cl::cat(loaderCat));
 
+llvm::cl::opt<bool> assertAllNodesQuantizedOpt(
+    "assert-all-nodes-quantized",
+    llvm::cl::desc(
+        "Debugging tool, used to assert the quantizer quantizes all nodes in "
+        "the model, or abort otherwise. When false, nodes that are unsupported "
+        "as quantized by the backend will be left unquantized, and may have "
+        "their inputs dequantized/outputs quantized as necessary. Can be used "
+        "in conjunction with -keep-original-precision-for-nodes to explicitly "
+        "whitelist node kinds that are allowed to be left unquantized."),
+    llvm::cl::init(false), llvm::cl::cat(loaderCat));
+
 /// Name of the network being bundled.
 llvm::cl::opt<std::string> networkName(
     "network-name",
@@ -320,6 +331,7 @@ void Loader::compile(PlaceholderBindings &bindings) {
     quantConfig.precision = quantizationPrecision;
     quantConfig.schema = quantizationSchema;
     quantConfig.enableRowwise = enableRowwiseOpt;
+    quantConfig.assertAllNodesQuantized = assertAllNodesQuantizedOpt;
 
     auto *Q = quantization::quantizeFunction(F_, quantConfig, *EE_.getBackend(),
                                              loweredMap_,


### PR DESCRIPTION
*Description*: This PR adds an `assertAllNodesQuantized` option to `quantizeFunction()`. If true, the Quantizer will die if it would have skipped quantizing a node because the backend does not support it as quantized. This is intended to be used by unit testing/testing bigger models via the Loader. For now it is disabled by default in the Loader, but by default true for `quantizeFunction()`. The motivation is explained in #2464.

*Testing*: Added tests for this functionality specifically. Also updated/removed tests where applicable.

*Documentation*: Added command line option with documentation on what it's for; added doxygen.

Fixes #2464
