### PR TITLE
[Quantization] Add QuantizationConfiguration struct for quantizeFunction()

### DIFF
--- a/examples/fr2en.cpp
+++ b/examples/fr2en.cpp
@@ -169,12 +169,12 @@ struct Model {
       // Lower however the backend prefers.
       ::lower(F_, &loweredMap_, EE_.getBackend());
 
-      auto quantizationInfos = deserializeFromYaml(loadProfileFileOpt);
+      quantization::QuantizationConfiguration quantConfig{
+          deserializeFromYaml(loadProfileFileOpt)};
 
       // Quantize the graph based on the captured profile.
-      auto *Q = glow::quantization::quantizeFunction(
-          *EE_.getBackend(), quantization::Schema::Asymmetric,
-          quantizationInfos, ElemKind::Int8QTy, F_, loweredMap_);
+      auto *Q = quantization::quantizeFunction(F_, quantConfig,
+                                               *EE_.getBackend(), loweredMap_);
 
       // Erase the original function so that the redundant variables that are
       // only referenced by the original function will be removed.

--- a/include/glow/Quantization/Quantization.h
+++ b/include/glow/Quantization/Quantization.h
@@ -48,6 +48,10 @@ struct QuantizationConfiguration {
   /// New name for the quantized function. If no name is given then
   /// \ref quantizeFunction() will generate a name.
   std::string newFuncName{""};
+
+  QuantizationConfiguration() = default;
+  QuantizationConfiguration(llvm::ArrayRef<NodeQuantizationInfo> i)
+      : infos(i) {}
 };
 
 /// Generate NodeQuantizationInfo for all required nodes from function \p F

--- a/lib/Onnxifi/InlineOnnxifi.cpp
+++ b/lib/Onnxifi/InlineOnnxifi.cpp
@@ -66,12 +66,13 @@ InlineGraph::initGraph(const void *onnxModel, size_t onnxModelSize,
 
   // -- Quantize --
   if (quantizationStep_ == OnnxifiQuantizationStep::Quantize) {
-    auto QI = deserializeFromYaml(getProfileFile(modelHash_));
-    std::string oldName = function_->getName();
+    quantization::QuantizationConfiguration quantConfig{
+        deserializeFromYaml(getProfileFile(modelHash_))};
+    quantConfig.schema = quantization::Schema::Symmetric;
+    quantConfig.newFuncName = function_->getName();
     function_->setName("old");
     auto *Q = quantization::quantizeFunction(
-        *executionEngine_.getBackend(), quantization::Schema::Symmetric, QI,
-        ElemKind::Int8QTy, function_, loweredMap_, oldName, {}, false);
+        function_, quantConfig, *executionEngine_.getBackend(), loweredMap_);
     Q->getParent()->eraseFunction(function_);
     function_ = Q;
   }

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -866,28 +866,22 @@ generateNodeQuantizationInfos(PlaceholderBindings &bindings, const Function *F,
   return quantizationInfos;
 }
 
-Function *
-quantizeFunction(const Backend &B, quantization::Schema schema,
-                 llvm::ArrayRef<NodeQuantizationInfo> quantizationInfos,
-                 ElemKind quantizationPrecision, Function *F,
-                 const LoweredInfoMap &loweredMap, llvm::StringRef newFuncName,
-                 const KindSet &doNotQuantizeKinds, bool enableRowwise) {
-  assert((quantizationPrecision == ElemKind::Int8QTy ||
-          quantizationPrecision == ElemKind::Int16QTy) &&
+Function *quantizeFunction(Function *F,
+                           const QuantizationConfiguration &quantConfig,
+                           const Backend &B, const LoweredInfoMap &loweredMap,
+                           const KindSet &doNotQuantizeKinds) {
+  assert((quantConfig.precision == ElemKind::Int8QTy ||
+          quantConfig.precision == ElemKind::Int16QTy) &&
          "Only Int8 and Int16 quantization supported");
-  std::string tmpName;
-  if (newFuncName.empty()) {
-    tmpName = std::string(F->getName()) + "_quantized";
-    newFuncName = tmpName;
-  }
+  Function *G = F->clone(quantConfig.newFuncName.empty()
+                             ? quantConfig.newFuncName + "_quantized"
+                             : quantConfig.newFuncName);
 
-  Function *G = F->clone(newFuncName);
-
-  FunctionQuantizer quantizer(*G, B, schema, quantizationInfos,
-                              quantizationPrecision, doNotQuantizeKinds,
+  FunctionQuantizer quantizer(*G, B, quantConfig.schema, quantConfig.infos,
+                              quantConfig.precision, doNotQuantizeKinds,
                               loweredMap);
   quantizer.convert();
-  if (enableRowwise) {
+  if (quantConfig.enableRowwise) {
     quantizer.enableRowwise();
   }
 

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -874,7 +874,7 @@ Function *quantizeFunction(Function *F,
           quantConfig.precision == ElemKind::Int16QTy) &&
          "Only Int8 and Int16 quantization supported");
   Function *G = F->clone(quantConfig.newFuncName.empty()
-                             ? quantConfig.newFuncName + "_quantized"
+                             ? F->getName().str() + "_quantized"
                              : quantConfig.newFuncName);
 
   FunctionQuantizer quantizer(*G, B, quantConfig.schema, quantConfig.infos,


### PR DESCRIPTION
*Description*: This PR changes `quantizeFunction()` by moving many of its current params into a simple aggregate struct `QuantizationConfiguration`. #2700 includes many of these parameters in `CompilationOptions`; I will rebase it on this PR to instead include `QuantizationConfiguration`. #2746 also adds another param which will be wrapped into `QuantizationConfiguration` too.

*Testing*: Updated all tests.
