### PR TITLE
[Runtime] Added saturateHost flag and method to partitioner

### DIFF
--- a/include/glow/Partitioner/Partitioner.h
+++ b/include/glow/Partitioner/Partitioner.h
@@ -112,6 +112,10 @@ class Partitioner {
   /// The map of each operator and the compute runtime.
   ComputeTimeMapTy computeTime_;
 
+  /// Flag to set if the Partitioner should attempt to saturate the host, and
+  /// use all available devices.
+  bool saturateHost_;
+
   /// Get the representative function (the one with the largest input) and
   /// update the memSize.
   static Function *selectRepFunc(Module *parent, uint64_t &memSize);
@@ -144,6 +148,9 @@ class Partitioner {
   /// constraits.
   void adjustLogicalDeviceID(DAGNode *DAG, int num);
 
+  /// Duplicates all networks in the module order to saturate the Host.
+  void saturateHost(unsigned logicalDeviceCount);
+
   /// Given the node-function mapping, do the actual partitioning.
   void doPartitioning(Function *F, NodeToFunctionMap &mapping);
 
@@ -155,7 +162,8 @@ public:
   /// identical. The required memory and computation cost for each op can be
   /// found in Module. The \p devices provides the cost model related to
   /// devices.
-  Partitioner(Module *parent, const std::vector<DeviceInfo> &devices);
+  Partitioner(Module *parent, const std::vector<DeviceInfo> &devices,
+              bool saturateHost = false);
 
   /// Decompose each function in a module.
   llvm::Error Partition();

--- a/include/glow/Runtime/HostManager/HostManager.h
+++ b/include/glow/Runtime/HostManager/HostManager.h
@@ -91,8 +91,11 @@ public:
   /// backends. Additionally DAGs are created for each function and stored
   /// in networks_. Returns an llvm::Error containing the results of the
   /// operation. This function consumes the \p module so any pointers to data
-  /// contained within the module should be considered invalid.
-  llvm::Error addNetwork(std::unique_ptr<Module> module);
+  /// contained within the module should be considered invalid. If \p
+  /// saturateHost is set to true the HostManager will try to use all available
+  /// devices on the host.
+  llvm::Error addNetwork(std::unique_ptr<Module> module,
+                         bool saturateHost = false);
 
   /// Given \p networkName removes that network from the host. This also
   /// removes the network from any backends setup to execute it.

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -63,7 +63,8 @@ HostManager::init(std::vector<std::unique_ptr<DeviceConfig>> configs) {
 
 HostManager::~HostManager() { llvm::toString(clearHost()); }
 
-llvm::Error HostManager::addNetwork(std::unique_ptr<Module> module) {
+llvm::Error HostManager::addNetwork(std::unique_ptr<Module> module,
+                                    bool saturateHost) {
   std::lock_guard<std::mutex> networkLock(networkLock_);
   auto functions = module->getFunctions();
   for (auto &F : functions) {
@@ -90,7 +91,7 @@ llvm::Error HostManager::addNetwork(std::unique_ptr<Module> module) {
       ::glow::optimizeFunction(F, *backend_, opts);
     }
   }
-  auto partitioner = Partitioner(module.get(), deviceInfo);
+  auto partitioner = Partitioner(module.get(), deviceInfo, saturateHost);
   RETURN_IF_ERR(partitioner.Partition());
   auto nodeList = std::move(partitioner.getPartitionResult());
 

--- a/lib/Runtime/Provisioner/Provisioner.cpp
+++ b/lib/Runtime/Provisioner/Provisioner.cpp
@@ -131,7 +131,7 @@ llvm::Error Provisioner::provision(DAGListTy &networks, Module &module) {
     RETURN_IF_ERR(addErr);
     // Set deviceID for each node added
     for (auto &node : logicalDevices[logicalID]) {
-      node->deviceIDs = {deviceID};
+      node->deviceIDs.push_back(deviceID);
     }
   }
   return llvm::Error::success();


### PR DESCRIPTION
*Description*: This PR adds a new saturateHost method to the Partitioner. If the saturateHost flag is set the Partitioner will duplicate networks to use all available devices on the host.
*Testing*: updated resnet-runtime to use new method, runs across multiple devices correctly.
*Documentation*: NA
