### PR TITLE
Removed PH creation from Executor

### DIFF
--- a/include/glow/Runtime/RuntimeTypes.h
+++ b/include/glow/Runtime/RuntimeTypes.h
@@ -87,6 +87,10 @@ struct DAGNode {
   /// runtime.
   std::unique_ptr<RuntimeBundle> runtimeBundle;
 
+  /// Pointer to module the function came from. This is so the executor can
+  /// access the associated PHs for the function that are stored in the Module.
+  Module *module{nullptr};
+
   DeviceIDTy getNextDevice() {
     currentDeviceIdx++;
     return deviceIDs[currentDeviceIdx % deviceIDs.size()];

--- a/lib/Partitioner/Partitioner.cpp
+++ b/lib/Partitioner/Partitioner.cpp
@@ -460,6 +460,7 @@ void Partitioner::doPartitioning(Function *F, NodeToFunctionMap &mapping) {
   nodesDAGNodeTy nodes;
   DAGRoot->logicalDevices = {0};
   DAGRoot->name = F->getName();
+  DAGRoot->module = module_;
   DAGRoot->deviceIDs = {0};
   DAGNode *root = DAGRoot.get();
   llvm::DenseMap<Node *, Node *> currToNew;
@@ -580,6 +581,7 @@ llvm::Error Partitioner::Partition() {
       std::unique_ptr<DAGNode> DAG0 = llvm::make_unique<DAGNode>();
       DAG0->logicalDevices = {0};
       DAG0->name = F->getName();
+      DAG0->module = module_;
       std::unique_ptr<DAGNode> DAG1 = llvm::make_unique<DAGNode>();
       DAG1->logicalDevices = {0};
       DAG1->name = F->getName();

--- a/lib/Runtime/Executor/ThreadPoolExecutor.h
+++ b/lib/Runtime/Executor/ThreadPoolExecutor.h
@@ -111,10 +111,6 @@ public:
   RunIdentifierTy getRunId() const { return runId_; }
 
 private:
-  /// Create a Placeholder with name \p name and type \p type and store it in
-  /// intermediatePlaceholders_. If a Placeholder already exists, return that.
-  Placeholder *createOrGetPlaceholder(llvm::StringRef name, TypeRef type);
-
   /// The run identifier for this execution of a DAG.
   RunIdentifierTy runId_;
   /// The callback that should be called when execution is done.
@@ -141,6 +137,10 @@ private:
   /// Mutex used by bindings insertion functions to make sure only one thread
   /// writes to an ExecutionContext at a time.
   std::mutex bindingsMtx_;
+
+  /// Module for the network. This contains the PHs used by the functions in
+  /// this network.
+  Module *module_{nullptr};
 };
 
 /// This implementation of the Executor interface uses a thread pool to


### PR DESCRIPTION
*Description*: This PR adds a reference to Module in the DAGNode so the executor can use the PHs in the Module rather than needing to create its own.
*Testing*: Updated Executor Test. unit tests pass and resnet-runtime
*Documentation*: Will be added to Runtime doc once runtime doc is added to docs. :D
fixes #2749 
