### PR TITLE
Fix the GLOG CMake file.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,8 @@ file(GLOB_RECURSE header_files include/*.h tools/*.h lib/*.h)
 add_custom_target(CollectHeaders SOURCES ${header_files})
 
 find_package(PNG)
+find_package(glog)
+
 if(PNG_FOUND)
   add_definitions(-DWITH_PNG)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ file(GLOB_RECURSE header_files include/*.h tools/*.h lib/*.h)
 add_custom_target(CollectHeaders SOURCES ${header_files})
 
 find_package(PNG)
-find_package(glog)
+find_package(glog NAMES google-glog glog)
 
 if(PNG_FOUND)
   add_definitions(-DWITH_PNG)

--- a/lib/Base/CMakeLists.txt
+++ b/lib/Base/CMakeLists.txt
@@ -7,7 +7,7 @@ add_library(Base
 target_link_libraries(Base
                       PUBLIC
                         Support
-                        glog)
+                        glog::glog)
 
 if(PNG_FOUND)
   target_sources(Base PRIVATE Image.cpp)


### PR DESCRIPTION
*Description*:

Before this change I was not able to build Glow on my home mac using the
brew glog. This change implements the recommended way to use glog with
CMake from the glog website.

*Testing*: Tested on my mac. The project now builds. 

*Documentation*: None.
