### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ jobs:
         - mkdir build && cd build
         - CC=gcc-4.8 CXX=g++-4.8 cmake -G Ninja
           -DCMAKE_BUILD_TYPE=Debug -DGLOW_WITH_OPENCL=OFF -DGLOW_WITH_CPU=ON
-          -DCMAKE_PREFIX_PATH=/usr/lib/llvm-7/include/
+          -DLLVM_DIR=/usr/lib/llvm-7/cmake
           -DCMAKE_CXX_FLAGS=-Werror
           -DGLOW_USE_COVERAGE=ON
           ../

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,20 +105,9 @@ endif ()
 # Top level setup for external backends
 ExternalBackendsInit()
 
-find_package(LLVM 8 CONFIG)
-if (NOT LLVM_FOUND)
-  # Fallback to LLVM 7
-  find_package(LLVM 7 CONFIG)
-
-  if (NOT LLVM_FOUND)
-    # Fallback to whatever is available.
-    find_package(LLVM CONFIG)
-
-    if (NOT LLVM_FOUND OR LLVM_PACKAGE_VERSION VERSION_LESS "7.0")
-      message(FATAL_ERROR "LLVM minimum required version is 7. LLVM package version found: ${LLVM_PACKAGE_VERSION}.")
-    endif()
-
-  endif()
+find_package(LLVM CONFIG)
+if(NOT LLVM_FOUND OR LLVM_VERSION VERSION_LESS 7.0)
+  message(SEND_ERROR "LLVM >= 7.0 is required to build Glow")
 endif()
 
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")


### PR DESCRIPTION
Use `LLVM_DIR` rather than `CMAKE_PREFIX_PATH` to locate LLVM.  This is more modern, and avoids the problem of searching for multiple versions as we have provided an absolute path to the location of the CMake module for LLVM.

*Description*:
*Testing*:
*Documentation*:
[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
