### PR TITLE
[tracing] add automatic thread ids

### DIFF
--- a/examples/resnet-runtime.cpp
+++ b/examples/resnet-runtime.cpp
@@ -129,7 +129,7 @@ int main(int argc, char **argv) {
   // If tracing is enabled, create a TraceContext to merge each runs events
   // into.
   if (!tracePath.empty()) {
-    traceContext = llvm::make_unique<TraceContext>(TraceLevel::STANDARD, 0);
+    traceContext = llvm::make_unique<TraceContext>(TraceLevel::STANDARD);
   }
 
   // Load model, create a context, and add to HostManager.
@@ -181,7 +181,7 @@ int main(int argc, char **argv) {
     std::unique_ptr<ExecutionContext> context =
         llvm::make_unique<ExecutionContext>();
     context->setTraceContext(
-        llvm::make_unique<TraceContext>(TraceLevel::STANDARD, 50));
+        llvm::make_unique<TraceContext>(TraceLevel::STANDARD));
 
     context->getPlaceholderBindings()->allocate(phList);
     Tensor batch = image.getUnowned(inputShape);

--- a/examples/tracing-compare.cpp
+++ b/examples/tracing-compare.cpp
@@ -152,7 +152,7 @@ int main(int argc, char **argv) {
   for (unsigned i = 0, e = supportedBackends.size(); i < e; ++i) {
     auto context = llvm::make_unique<ExecutionContext>();
     context->setTraceContext(
-        llvm::make_unique<TraceContext>(TraceLevel::STANDARD, i));
+        llvm::make_unique<TraceContext>(TraceLevel::STANDARD));
     context->getPlaceholderBindings()->allocate(module.getPlaceholders());
     updateInputPlaceholders(*(context->getPlaceholderBindings()), {input},
                             {&batch});

--- a/include/glow/Backends/TraceEvents.h
+++ b/include/glow/Backends/TraceEvents.h
@@ -65,7 +65,11 @@ struct TraceEvent {
                   const std::string &processName = "",
                   const std::map<int, std::string> &threadNames = {});
 
+  // Return the current time in microseconds in the timestamp domain.
   static uint64_t now();
+
+  // Returns a unique id associated with the current thread.
+  static size_t getThreadId();
 };
 
 /// Tracing / Profiling events map for a CompiledFunction.
@@ -122,34 +126,23 @@ class TraceContext {
   /// The list of materialized Events filled out with timestamp and metadata.
   std::vector<TraceEvent> traceEvents_;
 
-  /// Human readable name mapping for traceThreads_.
+  /// Human readable name mapping for trace Threads.
   std::map<int, std::string> threadNames_;
 
   /// The detail level of tracing for this run.
   TraceLevel traceLevel_{TraceLevel::NONE};
 
-  /// The thread (tid) used in the output tracing, allowing separation of events
-  /// on different contexts.
-  int traceThread_{-1};
-
   /// Lock around traceEvents_.
   std::mutex lock_;
 
 public:
-  TraceContext(TraceLevel level, int thread)
-      : traceLevel_(level), traceThread_(thread) {}
+  TraceContext(TraceLevel level) : traceLevel_(level) {}
 
   /// \returns TraceEvents for the last run.
   std::vector<TraceEvent> &getTraceEvents() { return traceEvents_; }
 
   /// \returns TraceEvents for the last run.
   llvm::ArrayRef<TraceEvent> getTraceEvents() const { return traceEvents_; }
-
-  /// \returns the integer thread id used for logged events in this context.
-  int getTraceThread() const { return traceThread_; }
-
-  /// Sets the integer thread id used for logged events in this context.
-  void setTraceThread(int tid) { traceThread_ = tid; }
 
   /// \returns the level of verbosity allowed for TraceEvents.
   TraceLevel getTraceLevel() { return traceLevel_; }

--- a/lib/Backends/Interpreter/InterpreterFunction.cpp
+++ b/lib/Backends/Interpreter/InterpreterFunction.cpp
@@ -76,7 +76,7 @@ void InterpreterFunction::translateTraceEvents(
 
   PlaceholderBindings *bindings = context->getPlaceholderBindings();
 
-  int tid = traceContext->getTraceThread();
+  int tid = TraceEvent::getThreadId();
   auto &traceEvents = traceContext->getTraceEvents();
   for (auto &backing : traceInfo.events) {
     Tensor *backingTensor = bindings->get(backing.first);

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -1517,7 +1517,7 @@ void OpenCLFunction::translateTraceEvents(ExecutionContext *context) const {
 
   std::unordered_map<std::string, cl_ulong> kernelToDuration;
   auto &traceEvents = context->getTraceContext()->getTraceEvents();
-  int tid = context->getTraceContext()->getTraceThread();
+  int tid = TraceEvent::getThreadId();
   std::vector<cl_ulong> manualTimestamps;
 
   for (auto &kl : kernelLaunches_) {

--- a/lib/LLVMIRCodeGen/LLVMCompiledFunction.cpp
+++ b/lib/LLVMIRCodeGen/LLVMCompiledFunction.cpp
@@ -103,8 +103,10 @@ void LLVMCompiledFunction::execute(ExecutionContext *context) {
   if (address) {
     JitFuncType funcPtr = reinterpret_cast<JitFuncType>(address.get());
     TRACE_EVENT_END(context, "findJitmainSymbol");
+    TRACE_EVENT_BEGIN(context, "execute");
     funcPtr(runtimeBundle_.getConstants(), baseMutableWeightVarsAddress,
             baseActivationsAddress);
+    TRACE_EVENT_END(context, "execute");
   } else {
     GLOW_UNREACHABLE("Error getting address");
   }
@@ -143,7 +145,7 @@ void LLVMCompiledFunction::translateTraceEvents(
 
   PlaceholderBindings *bindings = context->getPlaceholderBindings();
 
-  int tid = traceContext->getTraceThread();
+  int tid = TraceEvent::getThreadId();
   for (auto &backing : traceInfo.events) {
     Tensor *backingTensor = bindings->get(backing.first);
     assert(backingTensor);

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -99,9 +99,7 @@ onnxStatus Graph::setIOAndRun(uint32_t inputsCount,
   auto ctx = llvm::make_unique<ExecutionContext>();
 
   if (traceEvents) {
-    // TODO: get thread ID
-    ctx->setTraceContext(
-        llvm::make_unique<TraceContext>(TraceLevel::STANDARD, 0));
+    ctx->setTraceContext(llvm::make_unique<TraceContext>(TraceLevel::STANDARD));
   }
 
   // Create tensors for input placeholders

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -172,14 +172,6 @@ RunIdentifierTy
 HostManager::runNetwork(llvm::StringRef networkName,
                         std::unique_ptr<ExecutionContext> context,
                         ResultCBTy callback) {
-  auto *resultTraceContext = context->getTraceContext();
-
-  // Set the thread name for TraceEvents in the Runtime.
-  if (resultTraceContext) {
-    resultTraceContext->setThreadName(resultTraceContext->getTraceThread(),
-                                      "Glow Runtime (host)");
-  }
-
   ScopedTraceBlock(context->getTraceContext(),
                    "runFunction_" + networkName.str());
   auto currentRun = totalRequestCount_++;

--- a/tests/unittests/TraceEventsTest.cpp
+++ b/tests/unittests/TraceEventsTest.cpp
@@ -119,7 +119,7 @@ public:
 TEST_P(TraceEventsTest, manualEvents) {
   ExecutionContext context;
   context.setTraceContext(
-      llvm::make_unique<TraceContext>(TraceLevel::OPERATOR, 0));
+      llvm::make_unique<TraceContext>(TraceLevel::OPERATOR));
 
   size_t numEvents = 4;
   auto *eventData = createEventPlaceholder(numEvents);
@@ -168,7 +168,7 @@ TEST_P(TraceEventsTest, manualEvents) {
 TEST_P(TraceEventsTest, incompleteCoverage) {
   ExecutionContext context;
   context.setTraceContext(
-      llvm::make_unique<TraceContext>(TraceLevel::OPERATOR, 0));
+      llvm::make_unique<TraceContext>(TraceLevel::OPERATOR));
 
   size_t numEvents = 2;
   auto *eventData = createEventPlaceholder(numEvents);
@@ -212,7 +212,7 @@ TEST_P(TraceEventsTest, incompleteCoverage) {
 TEST_P(TraceEventsTest, internalGap) {
   ExecutionContext context;
   context.setTraceContext(
-      llvm::make_unique<TraceContext>(TraceLevel::OPERATOR, 0));
+      llvm::make_unique<TraceContext>(TraceLevel::OPERATOR));
 
   size_t numEvents = 2;
   auto *eventData = createEventPlaceholder(numEvents);
@@ -256,7 +256,7 @@ TEST_P(TraceEventsTest, internalGap) {
 TEST_P(TraceEventsTest, automaticInstrumentation) {
   ExecutionContext context;
   context.setTraceContext(
-      llvm::make_unique<TraceContext>(TraceLevel::OPERATOR, 0));
+      llvm::make_unique<TraceContext>(TraceLevel::OPERATOR));
 
   auto *n = part_one(F, context);
   n = part_two(F, context, n);
@@ -284,7 +284,7 @@ TEST_P(TraceEventsTest, automaticInstrumentation) {
 TEST_P(TraceEventsTest, manualAndAutomatic) {
   ExecutionContext context;
   context.setTraceContext(
-      llvm::make_unique<TraceContext>(TraceLevel::OPERATOR, 0));
+      llvm::make_unique<TraceContext>(TraceLevel::OPERATOR));
 
   size_t numEvents = 4;
   auto *eventData = createEventPlaceholder(numEvents);
@@ -333,7 +333,7 @@ TEST_P(TraceEventsTest, manualAndAutomatic) {
 TEST_P(TraceEventsTest, twoCompiles) {
   ExecutionContext context;
   context.setTraceContext(
-      llvm::make_unique<TraceContext>(TraceLevel::OPERATOR, 0));
+      llvm::make_unique<TraceContext>(TraceLevel::OPERATOR));
 
   size_t numEvents = 4;
   auto *eventData = createEventPlaceholder(numEvents);
@@ -348,7 +348,7 @@ TEST_P(TraceEventsTest, twoCompiles) {
 
   ExecutionContext context2{context.clone()};
   context2.setTraceContext(
-      llvm::make_unique<TraceContext>(TraceLevel::OPERATOR, 0));
+      llvm::make_unique<TraceContext>(TraceLevel::OPERATOR));
 
   context.getPlaceholderBindings()->allocate(EE_.getModule().getPlaceholders());
 
@@ -395,7 +395,7 @@ TEST_P(TraceEventsTest, twoCompiles) {
 TEST_P(TraceEventsTest, onlyTraceEvents) {
   ExecutionContext context;
   context.setTraceContext(
-      llvm::make_unique<TraceContext>(TraceLevel::OPERATOR, 0));
+      llvm::make_unique<TraceContext>(TraceLevel::OPERATOR));
 
   size_t numEvents = 16;
   auto *eventData = createEventPlaceholder(numEvents);
@@ -435,7 +435,7 @@ TEST_P(TraceEventsTest, onlyTraceEvents) {
 TEST_P(TraceEventsTest, multipleBackingTensors) {
   ExecutionContext context;
   context.setTraceContext(
-      llvm::make_unique<TraceContext>(TraceLevel::OPERATOR, 0));
+      llvm::make_unique<TraceContext>(TraceLevel::OPERATOR));
 
   size_t numEvents = 6;
   auto *eventData1 = createEventPlaceholder(3);
@@ -494,7 +494,7 @@ TEST_P(TraceEventsTest, multipleBackingTensors) {
 TEST_P(TraceEventsTest, multipleRunsAreDistinct) {
   ExecutionContext context;
   context.setTraceContext(
-      llvm::make_unique<TraceContext>(TraceLevel::OPERATOR, 0));
+      llvm::make_unique<TraceContext>(TraceLevel::OPERATOR));
 
   size_t numEvents = 4;
   auto *eventData = createEventPlaceholder(numEvents);
@@ -522,7 +522,7 @@ TEST_P(TraceEventsTest, multipleRunsAreDistinct) {
 
   ExecutionContext context2{context.clone()};
   context2.setTraceContext(
-      llvm::make_unique<TraceContext>(TraceLevel::OPERATOR, 0));
+      llvm::make_unique<TraceContext>(TraceLevel::OPERATOR));
 
   // run twice
   EE_.run(context);
@@ -545,7 +545,7 @@ TEST_P(TraceEventsTest, multipleRunsAreDistinct) {
 TEST_P(TraceEventsTest, deviceManagerEvents) {
   ExecutionContext context;
   context.setTraceContext(
-      llvm::make_unique<TraceContext>(TraceLevel::STANDARD, 0));
+      llvm::make_unique<TraceContext>(TraceLevel::STANDARD));
 
   auto *n = part_one(F, context);
   n = part_two(F, context, n);


### PR DESCRIPTION
*Description*: Replace Manual setting of thread id with automatic ids, which eliminates issues where multiple work was happening "concurrently". This disables thread names for now.
*Testing*: unit tests, tracing-compare and resnet-runtime
*Documentation*:
