### PR TITLE
[tracing] [trivial] switch to std::system_clock for timestamps

### DIFF
--- a/lib/Backends/TraceEvents.cpp
+++ b/lib/Backends/TraceEvents.cpp
@@ -66,7 +66,7 @@ void TraceEvent::dumpTraceEvents(
 
 uint64_t TraceEvent::now() {
   return std::chrono::duration_cast<std::chrono::microseconds>(
-             std::chrono::steady_clock::now().time_since_epoch())
+             std::chrono::system_clock::now().time_since_epoch())
       .count();
 }
 


### PR DESCRIPTION
*Description*: Internally we use system_clock for the timestamp domain, changing Glow trace events to match.
*Testing*: unittests
*Documentation*: