### PR TITLE
[ModelZoo] Add RCNN ILSVC13 ONNX model

### DIFF
--- a/tests/images/run.sh
+++ b/tests/images/run.sh
@@ -153,7 +153,7 @@ for png_filename in tests/images/EmotionSampleImages/*.png; do
 done
 
 # R-CNN ILSVRC13 ONNX Model: See Table 8 of https://arxiv.org/pdf/1311.2524.pdf
-# for the classication labels, they differ from thoes defined by imagenet.
+# for the classification labels, they differ from those defined by imagenet.
 i=0
 for png_filename in tests/images/imagenet/*.png; do
   ./bin/image-classifier "$png_filename" -expected-labels=${ilsvrc13IdxArray[$i]} -image-mode=0to255 -m=bvlc_reference_rcnn_ilsvrc13/model.onnx -model-input-name=data_0 "$@"

--- a/tests/images/run.sh
+++ b/tests/images/run.sh
@@ -21,6 +21,7 @@ googlenetV4IdxArray=(281 207 340)
 mnistIdxValues="0,1,2,3,4,5,6,7,8,9"
 mnistIdxArray=(0 1 2 3 4 5 6 7 8 9)
 ferplusIdxArray=(4 4 6 1 0 0 3 3 2 2)
+ilsvrc13IdxArray=(58 57 199)
 
 # Accumulate errors
 num_errors=0
@@ -148,6 +149,15 @@ num_errors=$(($num_errors + $?))
 i=0
 for png_filename in tests/images/EmotionSampleImages/*.png; do
   ./bin/image-classifier "$png_filename" -use-imagenet-normalization -expected-labels=${ferplusIdxArray[$i]} -image-mode=0to255 -m=emotion_ferplus/model.onnx -model-input-name=Input3 -compute-softmax "$@"
+  i=$(($i + 1))
+done
+
+# R-CNN ILSVRC13 ONNX Model: See Table 8 of https://arxiv.org/pdf/1311.2524.pdf
+# for the classication labels, they differ from thoes defined by imagenet.
+i=0
+for png_filename in tests/images/imagenet/*.png; do
+  ./bin/image-classifier "$png_filename" -expected-labels=${ilsvrc13IdxArray[$i]} -image-mode=0to255 -m=bvlc_reference_rcnn_ilsvrc13/model.onnx -model-input-name=data_0 "$@"
+  num_errors=$(($num_errors + $?))
   i=$(($i + 1))
 done
 

--- a/utils/download_onnx_models.sh
+++ b/utils/download_onnx_models.sh
@@ -38,3 +38,6 @@ done
 
 wget -nc https://onnxzoo.blob.core.windows.net/models/opset_8/emotion_ferplus/emotion_ferplus.tar.gz
 tar -xzvf emotion_ferplus.tar.gz emotion_ferplus/model.onnx
+
+wget -nc https://s3.amazonaws.com/download.onnx/models/opset_8/bvlc_reference_rcnn_ilsvrc13.tar.gz
+tar -xzvf bvlc_reference_rcnn_ilsvrc13.tar.gz bvlc_reference_rcnn_ilsvrc13/model.onnx


### PR DESCRIPTION
*Description*:
This image classification model currently works with glow.  The
probabilities match those reported by Caffe2 model of this RCNN.  The
labels reported match the following list:  See Table 8
of https://arxiv.org/pdf/1311.2524.pdf

*Testing*:
`ninja all && ./tests/images/run.sh`
or
`bin/image-classifier tests/images/imagenet/cat_285.png -model bvlc_reference_rcnn_ilsvrc13/model.onnx -model-input-name data_0 -image-mode 0to255`

The result should identify that image as "Label-K1: 58"

Fixes #2505 