### PR TITLE
[Training] Add support for training SparseLengthsWeightedSum

### DIFF
--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -86,6 +86,21 @@ bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
            (NI.getInElemTy(SparseLengthsWeightedSumNode::LengthsIdx) ==
             ElemKind::Int32ITy);
 
+  case Kinded::Kind::SparseLengthsWeightedSumGradNodeKind:
+    // GradOfInputNamedIndicesIdx and GradOfInputNamedLengthsIdx do not need to
+    // be checked because they are not used.
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::FloatTy},
+               {SparseLengthsWeightedSumGradNode::IndicesIdx,
+                SparseLengthsWeightedSumGradNode::LengthsIdx},
+               {SparseLengthsWeightedSumGradNode::GradOfInputNamedIndicesIdx,
+                SparseLengthsWeightedSumGradNode::
+                    GradOfInputNamedLengthsIdx}) &&
+           (NI.getInElemTy(SparseLengthsWeightedSumGradNode::IndicesIdx) ==
+            ElemKind::Int64ITy) &&
+           (NI.getInElemTy(SparseLengthsWeightedSumGradNode::LengthsIdx) ==
+            ElemKind::Int32ITy);
+
   case Kinded::Kind::RowwiseQuantizedSparseLengthsWeightedSumNodeKind:
     return (NI.getInElemTy(
                 RowwiseQuantizedSparseLengthsWeightedSumNode::DataIdx) ==

--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -1089,6 +1089,30 @@ void libjit_sparse_lengths_weighted_sum_f(float *dest, float *data,
   }
 }
 
+void libjit_sparse_lengths_weighted_sum_grad_f(
+    const float *destGrad, float *dataGrad, const float *weights,
+    const size_t *indices, const int32_t *lengths, size_t segments,
+    size_t lineSize, size_t dataGradRawSize) {
+  // The data gradients not touched by this operation should
+  // be 0, so set the entire buffer to 0 to start with.
+  memset(dataGrad, 0, dataGradRawSize);
+  size_t curIndex = 0;
+  for (size_t i = 0; i < segments; i++) {
+    for (int32_t j = 0; j < lengths[i]; j++) {
+      // For each index in each segment, accumulate into the corresponding data
+      // gradient the product of the gradient of the result it was added to and
+      // the weight that it was multiplied by during the
+      // SparseLengthsWeightedSum operation.
+      float weight = weights[curIndex];
+      size_t line = indices[curIndex];
+      for (size_t k = 0; k < lineSize; k++) {
+        dataGrad[line * lineSize + k] += weight * destGrad[i * lineSize + k];
+      }
+      curIndex++;
+    }
+  }
+}
+
 void libjit_rowwise_quantized_sparse_lengths_weighted_sum_f(
     float *dest, int8_t *data, float *scales, float *offsets, float *weights,
     size_t *indices, int32_t *lengths, size_t segments, size_t lineSize) {

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -187,6 +187,21 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
            (NI.getInElemTy(SparseLengthsWeightedSumNode::LengthsIdx) ==
             ElemKind::Int32ITy);
 
+  case Kinded::Kind::SparseLengthsWeightedSumGradNodeKind:
+    // GradOfInputNamedIndicesIdx and GradOfInputNamedLengthsIdx do not need to
+    // be checked because they are not used.
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::FloatTy},
+               {SparseLengthsWeightedSumGradNode::IndicesIdx,
+                SparseLengthsWeightedSumGradNode::LengthsIdx},
+               {SparseLengthsWeightedSumGradNode::GradOfInputNamedIndicesIdx,
+                SparseLengthsWeightedSumGradNode::
+                    GradOfInputNamedLengthsIdx}) &&
+           (NI.getInElemTy(SparseLengthsWeightedSumGradNode::IndicesIdx) ==
+            ElemKind::Int64ITy) &&
+           (NI.getInElemTy(SparseLengthsWeightedSumGradNode::LengthsIdx) ==
+            ElemKind::Int32ITy);
+
   case Kinded::Kind::RowwiseQuantizedSparseLengthsWeightedSumNodeKind:
     return (NI.getInElemTy(
                 RowwiseQuantizedSparseLengthsWeightedSumNode::DataIdx) ==

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -2361,6 +2361,54 @@ void BoundInterpreterFunction::fwdSparseLengthsWeightedSumInst(
                             I->getData()->getElementType(), I);
 }
 
+void BoundInterpreterFunction::fwdSparseLengthsWeightedSumGradInst(
+    const SparseLengthsWeightedSumGradInst *I) {
+  assert(I->getDataGrad()->getType()->getElementType() == ElemKind::FloatTy &&
+         "Input type must be float");
+
+  auto destGrad = getTensor(I->getDestGrad());
+  auto dataGrad = getTensor(I->getDataGrad());
+  auto weights = getTensor(I->getWeights());
+  auto indices = getTensor(I->getIndices());
+  auto lengths = getTensor(I->getLengths());
+
+  // The data gradients not touched by this operation should
+  // be 0, so set the entire buffer to 0 to start with.
+  dataGrad->zero();
+
+  auto LH = lengths->getHandle<int32_t>();
+  auto IH = indices->getHandle<int64_t>();
+
+  size_t segments = lengths->dims()[0];
+  size_t totalLength = 0;
+  for (size_t i = 0; i < segments; i++) {
+    totalLength += LH.raw(i);
+  }
+  assert(totalLength == indices->dims()[0] &&
+         "sum(Lengths) must be equal to len(Indices)");
+
+  size_t lineSize = dataGrad->size() / dataGrad->dims()[0];
+
+  auto IGH = destGrad->getHandle();
+  auto WH = weights->getHandle();
+  auto OGH = dataGrad->getHandle();
+
+  // For each index in each segment, accumulate into the corresponding data
+  // gradient the product of the gradient of the result it was added to and
+  // the weight that it was multiplied by during the
+  // SparseLengthsWeightedSum operation.
+  size_t curIdx = 0;
+  for (size_t i = 0; i < segments; i++) {
+    size_t offsetIn = i * lineSize;
+    for (size_t j = 0, e = LH.raw(i); j < e; j++) {
+      float weight = WH.raw(curIdx);
+      size_t offsetOut = IH.raw(curIdx++) * lineSize;
+      for (size_t k = 0; k < lineSize; k++)
+        OGH.raw(offsetOut++) += IGH.raw(offsetIn) * weight;
+    }
+  }
+}
+
 void BoundInterpreterFunction::fwdRowwiseQuantizedSparseLengthsWeightedSumInst(
     const RowwiseQuantizedSparseLengthsWeightedSumInst *I) {
   auto *out = getTensor(I->getDest());

--- a/lib/Graph/Grad.cpp
+++ b/lib/Graph/Grad.cpp
@@ -108,6 +108,7 @@ Function *glow::differentiate(Function *F, const TrainingConfig &conf,
     CONVERT_TO_GRAD_NODE(ReluNode)
     CONVERT_TO_GRAD_NODE(SigmoidNode)
     CONVERT_TO_GRAD_NODE(TanhNode)
+    CONVERT_TO_GRAD_NODE(SparseLengthsWeightedSumNode)
 
     if (N->getKind() == Kind::SaveNodeKind) {
       // Swap the src and dest. Send the Zero value as gradient for both sides.

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -2220,6 +2220,31 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     break;
   }
 
+  case Kinded::Kind::SparseLengthsWeightedSumGradInstKind: {
+    auto *SI = cast<SparseLengthsWeightedSumGradInst>(I);
+    auto *destGrad = SI->getDestGrad();
+    auto *dataGrad = SI->getDataGrad();
+    auto *weights = SI->getWeights();
+    auto *indices = SI->getIndices();
+    auto *lengths = SI->getLengths();
+    auto *destGradPtr = emitValueAddress(builder, destGrad);
+    auto *dataGradPtr = emitValueAddress(builder, dataGrad);
+    auto *weightsPtr = emitValueAddress(builder, weights);
+    auto *indicesPtr = emitValueAddress(builder, indices);
+    auto *lengthsPtr = emitValueAddress(builder, lengths);
+    auto *segments = emitConstSizeT(builder, lengths->dims()[0]);
+    auto *dataGradRawSize =
+        emitConstSizeT(builder, dataGrad->size() * sizeof(float));
+    auto *lineSize =
+        emitConstSizeT(builder, dataGrad->size() / dataGrad->dims()[0]);
+    auto *F = getFunction("sparse_lengths_weighted_sum_grad",
+                          destGrad->getElementType());
+    createCall(builder, F,
+               {destGradPtr, dataGradPtr, weightsPtr, indicesPtr, lengthsPtr,
+                segments, lineSize, dataGradRawSize});
+    break;
+  }
+
   case Kinded::Kind::RowwiseQuantizedSparseLengthsWeightedSumInstKind: {
     auto *N = cast<RowwiseQuantizedSparseLengthsWeightedSumInst>(I);
     auto *dest = N->getDest();

--- a/tests/unittests/MLTest.cpp
+++ b/tests/unittests/MLTest.cpp
@@ -1403,6 +1403,79 @@ TEST_P(MLTest, matrixRotationRecognition) {
   EXPECT_LE(errors, 1);
 }
 
+/// Simple test case that learns the embedding table for a
+/// SparseLengthsWeightedSum operator.
+TEST_P(InterpreterAndCPU, learnSparseLengthsWeightedSum) {
+  TrainingConfig TC;
+  TC.learningRate = 0.3;
+  TC.batchSize = 1;
+
+  PlaceholderBindings bindings;
+
+  Module &mod = EE_.getModule();
+  PseudoRNG &PRNG = mod.getPRNG();
+
+  // Create a model consisting of one SparseLengthsWeightedSum operator followed
+  // by a Regression node to get some non-zero gradients.
+  Function *F = mod.createFunction("SparseLengthsWeightedSum");
+  Placeholder *dataP = mod.createPlaceholder(ElemKind::FloatTy, {10}, "dataP",
+                                             /*isTrainable=*/true);
+  Placeholder *indicesP = mod.createPlaceholder(
+      ElemKind::Int64ITy, {10}, "indicesP", /*isTrainable=*/false);
+  Placeholder *weightsP = mod.createPlaceholder(
+      ElemKind::FloatTy, {10}, "weightsP", /*isTrainable=*/false);
+  Placeholder *lengthsP = mod.createPlaceholder(
+      ElemKind::Int32ITy, {5}, "lengthsP", /*isTrainable=*/false);
+  Placeholder *expectedP = mod.createPlaceholder(
+      ElemKind::FloatTy, {5}, "expectedP", /*isTrainable=*/false);
+
+  auto *SLWS = F->createSparseLengthsWeightedSum("SLWS", dataP, weightsP,
+                                                 indicesP, lengthsP);
+  auto *reg = F->createRegression("reg", SLWS, expectedP);
+  auto *result = F->createSave("save", reg);
+
+  // Allocate and randomly initialize embeddings.
+  auto DH = bindings.allocate(dataP)->getHandle();
+  DH.randomize(-5.0, 5.0, PRNG);
+
+  // Allocate and set indices such that input embeddings are reversed.
+  bindings.allocate(indicesP)->getHandle<int64_t>() = {9, 8, 7, 6, 5,
+                                                       4, 3, 2, 1, 0};
+  // Allocate and set weights.
+  bindings.allocate(weightsP)->getHandle() = {0.75, 0.25, 0.75, 0.25, 0.75,
+                                              0.25, 0.75, 0.25, 0.75, 0.25};
+
+  // Allocate and set lengths.
+  bindings.allocate(lengthsP)->getHandle<int32_t>() = {2, 2, 2, 2, 2};
+
+  // Allocate and set expected outputs. The embedding table will be adjusted
+  // during training so that the final result is this.
+  auto EH = bindings.allocate(expectedP)->getHandle();
+  EH = {1, 2, 3, 4, 5};
+
+  // Allocate and store a handle to the result for testing later.
+  auto RH = bindings.allocate(result->getPlaceholder())->getHandle();
+
+  // Train the network.
+  Function *trainingGradientFunction = glow::differentiate(F, TC);
+  EE_.compile(CompilationMode::Train, trainingGradientFunction);
+
+  const size_t numIterations = 1000;
+
+  for (size_t i = 0; i < numIterations; ++i) {
+    EE_.run(bindings);
+  }
+
+  // Switch to inference mode and run the network.
+  EE_.compile(CompilationMode::Infer, F);
+  EE_.run(bindings);
+
+  // Make sure that the network output matches expectations after training.
+  for (size_t j = 0; j < EH.size(); ++j) {
+    EXPECT_NEAR(RH.raw(j), EH.raw(j), 0.02);
+  }
+}
+
 INSTANTIATE_TEST_CASE_P(Interpreter, MLTest,
                         ::testing::Values(BackendKind::Interpreter));
 #ifdef GLOW_WITH_CPU

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -236,7 +236,8 @@ int main(int argc, char **argv) {
                   {"Indices", "ElemKind::Int64ITy"})
       .autoVerify(VerifyKind::SameElementType,
                   {"Lengths", "ElemKind::Int32ITy"})
-      .autoVerify(VerifyKind::SameShape, {"Weights", "Indices"});
+      .autoVerify(VerifyKind::SameShape, {"Weights", "Indices"})
+      .addGradientInstr({"Weights", "Indices", "Lengths"}, {"Dest", "Data"});
 
   BB.newInstr("RowwiseQuantizedSparseLengthsWeightedSum")
       .addOperand("Dest", OperandKind::Out)

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -353,6 +353,7 @@ int main(int argc, char **argv) {
       .addInput("Indices")
       .addInput("Lengths")
       .addResultFromCtorArg()
+      .addGradient()
       .setDocstring("Gathers slices of the outer-most dimension of Data "
                     "indexed by Indices vector, and then accumulates them into "
                     "len(Lengths) entries: first Lengths[0] slices are "


### PR DESCRIPTION
**Description**
This commit adds support for training the `SparseLengthsWeightedSum`
operator. The gradient for this node is computed by initializing the
`data` gradient to be zero, and then accumulating into `dataGradient[index]`
the gradient of the result slice that `data[index]` was added to during
the `SparseLengthsWeightedSum` operation multiplied by `weight[index]`
(the same weight that `data[index]` was multiplied by during the
`SparseLengthsWeightedSum` operator).

**Testing**
This commit adds a unit test to `MLTest` that trains the data input of a
`SparseLengthsWeightedSum` node so that the operation outputs a
specified `Tensor`. The indices, lengths, weights are fixed.
