### PR TITLE
[utils] Add the imagenet model params to caffe2_pb_runner

### DIFF
--- a/utils/caffe2_pb_runner.py
+++ b/utils/caffe2_pb_runner.py
@@ -118,7 +118,7 @@ model_props = dict(
         224,
         3,
     ),
-    imagenet=Model(
+    rcnn_ilsvrc13=Model(
         "data",
         mode_0to256,
         224,

--- a/utils/caffe2_pb_runner.py
+++ b/utils/caffe2_pb_runner.py
@@ -118,6 +118,12 @@ model_props = dict(
         224,
         3,
     ),
+    imagenet=Model(
+        "data",
+        mode_0to256,
+        224,
+        3,
+    ),
 )
 
 MODEL = args.model_name


### PR DESCRIPTION
*Description*
Add the model parameters for imagenet data to the
caffe2 helper utility.  These values were discovered by comparing
matching the `tests/images/imagenet/{cat,dog,zebra}` images with
the image names listed in Table 8 here: https://arxiv.org/pdf/1311.2524.pdf

I'm not sure if calling this 'imagenet' is correct, but the dataset
associated to the aforementioned paper was provided by the image-net
project: http://www.image-net.org/challenges/LSVRC/2013/

*Testing*
```
python3 /glow/utils/caffe2_pb_runner.py \
    -i /glow/tests/images/imagenet/cat_285.png \
    -d bvlc_reference_rcnn_ilsvrc13/ \
    -m imagenet
```

The result should be something like, of importance is 'index 58' below,
which happens to match the 'cat' label in Table 8 of the paper referenced above.

```
Initial img shape: (224, 224, 4)
Shape of final_image: (1, 3, 224, 224)
The blobs in the workspace after FeedBlob: ['data']
Max index is 58
Predicted class at index 58 with probability 1.9546699523925781
Number of classes 200
Sum of probabilities is -398.8056676387787
```
