### PR TITLE
window fixes

### DIFF
--- a/lib/Backends/BackendUtils.cpp
+++ b/lib/Backends/BackendUtils.cpp
@@ -89,7 +89,7 @@ bool isOutput(const Placeholder *PH) {
         continue;
       }
       auto input = use.getUser()->getNthInput(i);
-      if (input == PH) {
+      if (input.getNode() == PH) {
         return true;
       }
     }
@@ -105,7 +105,7 @@ bool isInput(const Placeholder *PH) {
     if (auto *save = dyn_cast<SaveNode>(use.getUser())) {
       auto input = save->getInput();
       // If the PH is not an input to the saveNode we keep looking.
-      if (input != PH) {
+      if (input.getNode() != PH) {
         continue;
       }
     }

--- a/lib/Backends/CPU/CMakeLists.txt
+++ b/lib/Backends/CPU/CMakeLists.txt
@@ -3,8 +3,11 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 else()
   find_program(CLANG_BIN clang++)
 endif()
-
-set(LLVM_LINK_BIN ${LLVM_BINARY_DIR}/bin/llvm-link)
+if(MSVC)
+    set(LLVM_LINK_BIN ${LLVM_BINARY_DIR}/$(Configuration)/bin/llvm-link)
+else()
+    set(LLVM_LINK_BIN ${LLVM_BINARY_DIR}/bin/llvm-link)
+endif()
 
 set(CMAKE_LLIR_CREATE_SHARED_LIBRARY "${LLVM_LINK_BIN} -o <TARGET> <OBJECTS>")
 set(CMAKE_LLIR_CREATE_SHARED_MODULE "${LLVM_LINK_BIN} -o <TARGET> <OBJECTS>")


### PR DESCRIPTION
*Description*: Updated cmake to work with windows also. On windows with VS bin folder is under ${Configuration}. Made comparison explicit with node. On windows it was resulting in build failure.
*Testing*: Unit Tests
*Documentation*:
[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
