### PR TITLE
[OpenCL] Add OpenCL implementation of SparseLengthsWeightedSum

### DIFF
--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -1224,6 +1224,36 @@ void OpenCLFunction::execute(ExecutionContext *context) {
       continue;
     }
 
+    if (auto *SLWS = dyn_cast<SparseLengthsWeightedSumInst>(&I)) {
+      cl_kernel kernel = createKernel(kernelName);
+      // Set the device buffer as the first argument.
+      setKernelArg(kernel, 0, deviceBuffer_);
+      // Set all buffer arguments from the instruction (data, dest, weights,
+      // indices, lengths) as subsequent arguments.
+      auto numArgs = setKernelArgsForBuffers(kernel, I, 1, runtimeBundle_);
+
+      // Set the size of one slice of data as the last argument.
+      auto *data = SLWS->getData();
+      size_t dataSliceSize = data->size() / data->dims()[0];
+      setKernelArg<cl_uint>(kernel, numArgs + 1, dataSliceSize);
+
+      // Zero the destination buffer so that the kernel can accumulate (+=) into
+      // it.
+      auto *dest = SLWS->getDest();
+      fillBuffer(deviceBuffer_, runtimeBundle_.getValueOffset(dest),
+                 dest->size(), 0, dest->getElementType());
+
+      // Get the number of segments. The output for each segment will be
+      // computed in parallel by setting the global size equal to the number of
+      // segments.
+      size_t segments = SLWS->getLengths()->size();
+
+      // Enqueue the kernel.
+      enqueueKernel(I.getName(), commands_, kernel, deviceId_, {segments},
+                    kernelLaunches_);
+      continue;
+    }
+
     if (auto *DP = dyn_cast<DebugPrintInst>(&I)) {
       clFinish(commands_);
       auto *V = DP->getSrc();
@@ -1706,6 +1736,16 @@ bool OCLBackend::isOpSupported(const NodeInfo &NI) const {
                {ElemKind::FloatTy}, {ScatterAssignNode::IndicesIdx}) &&
            (NI.getInElemTy(ScatterAssignNode::IndicesIdx) ==
             ElemKind::Int64ITy);
+
+  case Kinded::Kind::SparseLengthsWeightedSumNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::FloatTy},
+               {SparseLengthsWeightedSumNode::IndicesIdx,
+                SparseLengthsWeightedSumNode::LengthsIdx}) &&
+           (NI.getInElemTy(SparseLengthsWeightedSumNode::IndicesIdx) ==
+            ElemKind::Int64ITy) &&
+           (NI.getInElemTy(SparseLengthsWeightedSumNode::LengthsIdx) ==
+            ElemKind::Int32ITy);
 
   case Kinded::Kind::QuantizeNodeKind:
     return (NI.getInElemTy(QuantizeNode::InputIdx) == ElemKind::FloatTy) &&

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -4639,7 +4639,7 @@ TEST_P(OperatorTest, LengthsSum) {
 }
 
 TEST_P(OperatorTest, SparseLengthsSum) {
-  ENABLED_BACKENDS(Interpreter, CPU);
+  ENABLED_BACKENDS(Interpreter, CPU, OpenCL);
 
   /*
     DATA  = [
@@ -4741,7 +4741,7 @@ TEST_P(OperatorTest, SparseLengthsSumI8) {
 }
 
 TEST_P(OperatorTest, SparseLengthsWeightedSum) {
-  ENABLED_BACKENDS(Interpreter, CPU);
+  ENABLED_BACKENDS(Interpreter, CPU, OpenCL);
 
   /*
     DATA  =   [2.0, -0.5, 13]


### PR DESCRIPTION
**Description**
This commit adds an OpenCL implementation of `SparseLengthsWeightedSum`.
It is very similar to the CPU backend implementation; the only difference
is that the outputs for each segment are computed in parallel.

**Testing**
This commit enables `SparseLengthsSum` and `SparseLengthsWeightedSum` operator tests for
OpenCL and they pass. 

```
$ ./tests/OperatorTest --gtest_filter=*\.SparseLengths*Sum/*
Note: Google Test filter = *.SparseLengths*Sum/*
[==========] Running 6 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 6 tests from OperatorTest/OperatorTest
[ RUN      ] OperatorTest/OperatorTest.SparseLengthsSum/0
[       OK ] OperatorTest/OperatorTest.SparseLengthsSum/0 (69 ms)
[ RUN      ] OperatorTest/OperatorTest.SparseLengthsSum/1
[       OK ] OperatorTest/OperatorTest.SparseLengthsSum/1 (32 ms)
[ RUN      ] OperatorTest/OperatorTest.SparseLengthsSum/2
[       OK ] OperatorTest/OperatorTest.SparseLengthsSum/2 (1 ms)
[ RUN      ] OperatorTest/OperatorTest.SparseLengthsWeightedSum/0
[       OK ] OperatorTest/OperatorTest.SparseLengthsWeightedSum/0 (55 ms)
[ RUN      ] OperatorTest/OperatorTest.SparseLengthsWeightedSum/1
[       OK ] OperatorTest/OperatorTest.SparseLengthsWeightedSum/1 (11 ms)
[ RUN      ] OperatorTest/OperatorTest.SparseLengthsWeightedSum/2
[       OK ] OperatorTest/OperatorTest.SparseLengthsWeightedSum/2 (1 ms)
[----------] 6 tests from OperatorTest/OperatorTest (169 ms total)

[----------] Global test environment tear-down
[==========] 6 tests from 1 test case ran. (169 ms total)
[  PASSED  ] 6 tests.
```

All other unit tests pass.
