### PR TITLE
[examples] Fix resnet-runtime for the Interpreter

### DIFF
--- a/include/glow/Backends/CompiledFunction.h
+++ b/include/glow/Backends/CompiledFunction.h
@@ -59,7 +59,7 @@ public:
   runtime::RuntimeBundle &getRuntimeBundle() { return runtimeBundle_; }
 
   /// Collects constants for runtime.
-  virtual void collectConstants(Module *){};
+  virtual void collectConstants(const Module *){};
 
   /// Setter for TraceEvent lookup. Note: does not enable tracing automatically.
   void setTraceInfo(TraceInfo &&info) { traceInfo_ = std::move(info); }

--- a/include/glow/LLVMIRCodeGen/LLVMCompiledFunction.h
+++ b/include/glow/LLVMIRCodeGen/LLVMCompiledFunction.h
@@ -33,7 +33,7 @@ public:
   virtual ~LLVMCompiledFunction() override;
   virtual void execute(ExecutionContext *context) override;
 
-  virtual void collectConstants(Module *module) override;
+  virtual void collectConstants(const Module *module) override;
 
   /// Read trace events out of this func and write them into /p bindings
   virtual void translateTraceEvents(ExecutionContext *context) const override;

--- a/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
@@ -83,7 +83,7 @@ void InterpreterDeviceManager::addNetworkImpl(const Module *module,
   // Add to the function name lookup map.
   for (const auto &func : functions) {
     if (func.second->getRuntimeBundle().getConstants() == nullptr) {
-      func.second->getRuntimeBundle().collectConstants(module);
+      func.second->collectConstants(module);
     }
     functions_.emplace(func.first, func.second);
     usedMemoryBytes_ += functionCost_; // TODO:: static moduleSize

--- a/lib/Backends/Interpreter/InterpreterFunction.cpp
+++ b/lib/Backends/Interpreter/InterpreterFunction.cpp
@@ -37,7 +37,7 @@ InterpreterFunction::~InterpreterFunction() {
   tearDownRuns();
 }
 
-void InterpreterFunction::collectConstants(Module *module) {
+void InterpreterFunction::collectConstants(const Module *module) {
   runtimeBundle_.collectConstants(module);
   if (constants_.empty()) {
     if (runtimeBundle_.getConstantWeightSize()) {

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -60,7 +60,7 @@ public:
   void execute(ExecutionContext *context) override;
 
   /// Collects constants for runtime.
-  void collectConstants(Module *module) override;
+  void collectConstants(const Module *module) override;
 
   /// Get reference to IR function.
   IRFunction *getIR() { return F_.get(); }

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -1504,7 +1504,7 @@ cl_mem OpenCLFunction::allocDeviceBuffer(uint64_t size) {
 
 void OpenCLFunction::freeDeviceBuffer(cl_mem buf) { clReleaseMemObject(buf); }
 
-void OpenCLFunction::collectConstants(Module *module) {
+void OpenCLFunction::collectConstants(const Module *module) {
   runtimeBundle_.collectConstants(module);
 }
 

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -115,7 +115,7 @@ public:
   void execute(ExecutionContext *context) override;
 
   /// Collects constants for runtime.
-  void collectConstants(Module *module) override;
+  void collectConstants(const Module *module) override;
 
   /// \returns the Kind of Backend used to compile this function.
   virtual BackendKind getCompileBackendKind() const override {

--- a/lib/LLVMIRCodeGen/LLVMCompiledFunction.cpp
+++ b/lib/LLVMIRCodeGen/LLVMCompiledFunction.cpp
@@ -28,7 +28,7 @@ LLVMCompiledFunction::LLVMCompiledFunction(
 
 LLVMCompiledFunction::~LLVMCompiledFunction() { tearDownRuns(); }
 
-void LLVMCompiledFunction::collectConstants(Module *module) {
+void LLVMCompiledFunction::collectConstants(const Module *module) {
   runtimeBundle_.collectConstants(module);
 }
 


### PR DESCRIPTION
**Description**
This commit fixes the `resnet-runtime` example for the Interpreter
backend. This wasn't working because constants (i.e. weights and biases)
were not being set before the execution of an `InterpreterFunction`.

**Testing**
The `resnet-runtime` example now passes on the Interpreter backend.

```
$ ../build_RELEASE/bin/resnet-runtime ../glow/tests/images/imagenet/ -interpreter-memory 2000000000
Initializing 5 Interpreter Devices on HostManager.
Loading resnet50 model.
Loading files from ../glow/tests/images/imagenet/
Started run ID: 0
Started run ID: 1
Started run ID: 2
(0) ../glow/tests/images/imagenet/zebra_340.png: 340
(0) ../glow/tests/images/imagenet/cat_285.png: 281
(0) ../glow/tests/images/imagenet/dog_207.png: 207
Finished classifying 3 images.
```