### PR TITLE
[graph] Make the "mismatched dimension" error diagnostics more specific. NFC.

### DIFF
--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -223,9 +223,9 @@ static bool verifyFullyConnected(NodeValue src, NodeValue weights,
                                    src.dims().size(), parent);
   isValid &= expectCompareTrue("FC weights must be 2D", size_t(2),
                                weights.dims().size(), parent);
-  isValid &= expectCompareTrue("Mismatch on expected source dimensions",
+  isValid &= expectCompareTrue("Mismatch between source and dest dimensions",
                                src.dims()[0], dest.dims()[0], parent);
-  isValid &= expectCompareTrue("Mismatch on expected source dimensions",
+  isValid &= expectCompareTrue("Mismatch between source and weight dimensions",
                                src.dims()[1], weights.dims()[0], parent);
   isValid &= expectCompareTrue("Inconsistent bias/dest sizes", bias.dims()[0],
                                weights.dims()[1], parent);


### PR DESCRIPTION
*Description*
Originally the error messages were identical.  Making them more specific, and unique, simplifies debugging.