### PR TITLE
Replace CompilationOptions with CompilationContext and BackendOptions

### DIFF
--- a/docs/Backends.md
+++ b/docs/Backends.md
@@ -28,17 +28,17 @@ are two pure virtual functions all backends must implement:
 - `virtual std::unique_ptr<CompiledFunction> compile(Function *F) const;`
 
   - This function takes a `Function *F` to compile with default
-  [`CompilationOptions`](#compilationoptions-abstract-class). It should return a unique pointer to the
+  [`BackendOptions`](#backendoptions-helper-struct). It should return a unique pointer to the
     [`CompiledFunction`](#compiledfunction-abstract-class) of `F`. If the backend uses Glow low-level IR, it can call `generateAndOptimizeIR()` to generate an optimized `IRFunction`.
 
-- `virtual std::unique_ptr<CompiledFunction> compile(Function *F, CompilationOptions &opts) const;`
+- `virtual std::unique_ptr<CompiledFunction> compile(Function *F, BackendOptions &opts) const;`
 
   - This function takes a `Function *F` and the provided
-  [`CompilationOptions`](#compilationoptions-abstract-class). It should return a unique pointer to the
+  [`BackendOptions`](#backendoptions-helper-struct). It should return a unique pointer to the
     [`CompiledFunction`](#compiledfunction-abstract-class) of `F`. If the backend uses Glow low-level IR, it can call `generateAndOptimizeIR()` to generate an optimized `IRFunction`.
 
-- `virtual std::vector<std::unique_ptr<CompiledFunction>> compileFunctions(llvm::ArrayRef<Function *> functions, CompilationOptions &opts) const;`
-    - This function takes an `ArrayRef` of `Function *`s and compiles them using the same `CompilationOptions` object for all functions. This allows the compiler to reason over things like shared constants between functions.
+- `virtual std::vector<std::unique_ptr<CompiledFunction>> compileFunctions(llvm::ArrayRef<Function *> functions, BackendOptions &opts) const;`
+    - This function takes an `ArrayRef` of `Function *`s and compiles them using the same `BackendOptions` object for all functions. This allows the compiler to reason over things like shared constants between functions.
 
 - `virtual bool isOpSupported(const NodeInfo &NI) const;`
 
@@ -52,11 +52,11 @@ are two pure virtual functions all backends must implement:
 
 Additionally, there are virtual functions that backends can override:
 
-- `virtual bool transformPostLowering(Function *F, const CompilationOptions &opts) const;`
+- `virtual bool transformPostLowering(Function *F, const CompilationContext &cctx) const;`
 
   - Allow the backend to transform the `Function *F` after [node
     lowering](https://github.com/pytorch/glow/blob/master/docs/IR.md#node-lowering)
-    occurs, given some `CompilationOptions`. For example, the CPU backend
+    occurs, given the `CompilationContext`. For example, the CPU backend
     prefers to transform MaxNodes, which take a SplatNode as an input, into a
     [backend-specific](https://github.com/pytorch/glow/blob/master/docs/NewBackendSpecificNode.md)
     CPUMaxSplatNode, which takes a scalar value as a member input instead of a
@@ -124,10 +124,9 @@ to a context, and allows the `Function` to be freed after compilation. The symbo
 is stored in a table where the key is the symbol name and the payload contains symbol information
 including, size, offset, type, and whether it is an input or output of the function. `RuntimeBundle` also  contains a pointer that may point to a block of memory that contains the constants for the `CompiledFunction` if that `Backend` uses it.
 
-### `CompilationOptions` Helper Class
+### `BackendOptions` Helper Struct
 
-`CompilationOptions` is a helper class that contains the options for compilation. The options include:
-- `CompilationMode mode` - This can be Infer or Train. Default: Infer
+`BackendOptions` is a helper struct that contains the options relevant to the backend for compilation. The options include:
 - `bool collectConstants` - Whether constants should be collected and stored in the `CompiledFunction`'s [RuntimeBundle](#runtimebundle-helper-class). Default: True
 - `bool autoInstrument` - Whether `TraceEvents` should be inserted for profiling. Default: False
 

--- a/examples/fr2en.cpp
+++ b/examples/fr2en.cpp
@@ -15,6 +15,7 @@
  */
 #include "glow/ExecutionEngine/ExecutionEngine.h"
 #include "glow/Graph/Graph.h"
+#include "glow/Quantization/Quantization.h"
 #include "glow/Quantization/Serialization.h"
 
 #include "llvm/Support/CommandLine.h"

--- a/examples/tracing-compare.cpp
+++ b/examples/tracing-compare.cpp
@@ -79,11 +79,11 @@ std::unique_ptr<CompiledFunction> compileModel(Module &module,
   Function *F_ = F->clone("resnet50" + std::to_string((int)backendKind));
 
   llvm::outs() << "Starting compile on " << (int)backendKind << ".\n";
-  CompilationOptions opts;
-  opts.mode = CompilationMode::Infer;
-  opts.autoInstrument = true;
-  ::glow::optimizeFunction(F_, *backend, opts);
-  return backend->compile(F_, opts);
+  CompilationContext cctx;
+  cctx.mode = CompilationMode::Infer;
+  cctx.backendOpts.autoInstrument = true;
+  ::glow::optimizeFunction(F_, *backend, cctx);
+  return backend->compile(F_, cctx.backendOpts);
 }
 
 std::future<void> addToDevice(unsigned int id, DeviceManager *device,

--- a/include/glow/Backends/Backend.h
+++ b/include/glow/Backends/Backend.h
@@ -16,7 +16,7 @@
 #ifndef GLOW_BACKENDS_BACKEND_H
 #define GLOW_BACKENDS_BACKEND_H
 
-#include "glow/Backends/CompilationOptions.h"
+#include "glow/Backends/BackendOptions.h"
 #include "glow/Backends/CompiledFunction.h"
 #include "glow/Base/Traits.h"
 #include "glow/Optimizer/Optimizer.h"
@@ -54,7 +54,7 @@ public:
   /// support shared constants between functions.
   virtual std::vector<std::unique_ptr<CompiledFunction>>
   compileFunctions(llvm::ArrayRef<Function *> functions,
-                   CompilationOptions &opts) const {
+                   BackendOptions &opts) const {
     std::vector<std::unique_ptr<CompiledFunction>> compiledFunctions;
     for (auto &function : functions) {
       compiledFunctions.push_back(compile(function, opts));
@@ -63,13 +63,13 @@ public:
   }
 
   virtual std::unique_ptr<CompiledFunction> compile(Function *F) const {
-    CompilationOptions opts;
+    BackendOptions opts;
     return compile(F, opts);
   }
 
-  /// Generate code for input function \param F.
+  /// Generate code for input function \param F given settings in \p opts.
   virtual std::unique_ptr<CompiledFunction>
-  compile(Function *F, const CompilationOptions &opts) const = 0;
+  compile(Function *F, const BackendOptions &opts) const = 0;
 
   /// Save the bundle for \p F for a later standalone execution
   /// in \p outputDir. Make \p networkName the function name for
@@ -86,7 +86,7 @@ public:
   /// cleaning up after itself.
   /// \returns True if the graph was modified.
   virtual bool transformPostLowering(Function *F,
-                                     const CompilationOptions &opts) const {
+                                     const CompilationContext &cctx) const {
     return false;
   }
 

--- a/include/glow/Backends/BackendOptions.h
+++ b/include/glow/Backends/BackendOptions.h
@@ -13,21 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef GLOW_BACKENDS_COMPILEOPTIONS_H
-#define GLOW_BACKENDS_COMPILEOPTIONS_H
+#ifndef GLOW_BACKENDS_BACKENDOPTIONS_H
+#define GLOW_BACKENDS_BACKENDOPTIONS_H
 
 namespace glow {
 
-enum class CompilationMode {
-  Train, /// Compile the graph in preperation for training.
-  Infer, /// Compile the graph for inference. Notice that this operation
-         /// changes the graph in a way that is not reversible.
-};
-
-/// Configuration options for the compile() method on Backend.
-struct CompilationOptions {
-  CompilationMode mode{CompilationMode::Infer};
-
+/// Options relevant to Backends during compilation.
+struct BackendOptions {
   /// Allocate and collect constant Tensors in the RuntimeBundle.
   bool collectConstants{true};
 
@@ -37,4 +29,4 @@ struct CompilationOptions {
 
 }; // namespace glow
 
-#endif // GLOW_BACKENDS_COMPILEOPTIONS_H
+#endif // GLOW_BACKENDS_BACKENDOPTIONS_H

--- a/include/glow/ExecutionEngine/ExecutionEngine.h
+++ b/include/glow/ExecutionEngine/ExecutionEngine.h
@@ -101,24 +101,24 @@ public:
   }
 
   /// Optimize the Function \p f and pass it to the backend to compile it for a
-  /// specific target. If \p clearOtherFunctions is false then the function will
-  /// be added to the collection of previously compiled functions otherwise any
-  /// previously compiled functions will be removed first. This method should be
-  /// invoked before the run method.
-  void compile(Function *F, const CompilationOptions &opts,
+  /// specific target, all given \p cctx. If \p clearOtherFunctions is false
+  /// then the function will be added to the collection of previously compiled
+  /// functions otherwise any previously compiled functions will be removed
+  /// first. This method should be invoked before the run method.
+  void compile(Function *F, const CompilationContext &cctx,
                bool clearOtherFunctions = true);
 
   /// A convenience function for the most common type of compile.
   void compile(CompilationMode mode, Function *F,
                bool clearOtherFunctions = true);
 
-  /// Save a bundle for a standalone execution. This method takes care of
-  /// everything when preparing the bundle for saving. There is no need to
-  /// invoke the compile method before it.
+  /// Save a bundle for a standalone execution given \p cctx. This method takes
+  /// care of everything when preparing the bundle for saving. There is no need
+  /// to invoke the compile method before it.
   /// Make \p networkName the function name for
   /// the entry point of the network and prepend all generated
   /// files with this name.
-  void save(Function *F, const CompilationOptions &opts,
+  void save(Function *F, const CompilationContext &cctx,
             llvm::StringRef outputDir, llvm::StringRef networkName);
 
   /// Context aware single execution of a function. If more than one

--- a/include/glow/LLVMIRCodeGen/LLVMBackend.h
+++ b/include/glow/LLVMIRCodeGen/LLVMBackend.h
@@ -46,7 +46,7 @@ public:
   compileIRWithoutConstants(IRFunction *IR) const;
 
   virtual std::unique_ptr<CompiledFunction>
-  compile(Function *F, const CompilationOptions &opts) const override;
+  compile(Function *F, const BackendOptions &opts) const override;
 
   virtual void save(Function *F, llvm::StringRef outputDir,
                     llvm::StringRef networkName) const override;

--- a/include/glow/Optimizer/CompilationContext.h
+++ b/include/glow/Optimizer/CompilationContext.h
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_OPTIMIZER_COMPILATIONCONTEXT_H
+#define GLOW_OPTIMIZER_COMPILATIONCONTEXT_H
+
+#include "glow/Backends/BackendOptions.h"
+#include "glow/Graph/PlaceholderBindings.h"
+#include "glow/Quantization/Base/Base.h"
+
+namespace glow {
+
+/// Context for compilation.
+struct CompilationContext {
+  /// Select whether in Training or Inference mode.
+  enum class CompilationMode {
+    Train, /// Compile the graph in preperation for training.
+    Infer, /// Compile the graph for inference. Notice that this operation
+           /// changes the graph in a way that is not reversible.
+  } mode{CompilationMode::Infer};
+
+  /// Options for the Backend to use.
+  BackendOptions backendOpts;
+};
+
+using CompilationMode = CompilationContext::CompilationMode;
+
+}; // namespace glow
+
+#endif // GLOW_OPTIMIZER_COMPILATIONCONTEXT_H

--- a/include/glow/Optimizer/Optimizer.h
+++ b/include/glow/Optimizer/Optimizer.h
@@ -16,8 +16,7 @@
 #ifndef GLOW_OPTIMIZER_OPTIMIZER_H
 #define GLOW_OPTIMIZER_OPTIMIZER_H
 
-#include "glow/Backends/CompilationOptions.h"
-#include "glow/Quantization/Quantization.h"
+#include "glow/Optimizer/CompilationContext.h"
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
@@ -34,10 +33,10 @@ class Placeholder;
 /// Perform optimizations on the IR representation.
 void optimize(IRFunction &M, bool shouldShareBuffers);
 /// Perform optimizations on the graph representation.
-void optimize(Function *F, const CompilationOptions &opts);
+void optimize(Function *F, const CompilationContext &cctx);
 void optimize(Function *F, CompilationMode mode);
 /// Fold nodes that were expressed lowered in the input model.
-void fold(Function *F, const CompilationOptions &opts);
+void fold(Function *F, const CompilationContext &cctx);
 void fold(Function *F, CompilationMode mode);
 
 /// Lower the high-level neural network nodes found in \p F into low-level
@@ -75,9 +74,9 @@ Function *profileQuantization(PlaceholderBindings &bindings, Function *F,
 std::unique_ptr<IRFunction> generateAndOptimizeIR(Function *F, const Backend &B,
                                                   bool shouldShareBuffers);
 
-/// Optimize the Function \p F given compilation options \p opts for Backend \B.
+/// Optimize the Function \p F given compilation options \p cctx for Backend \B.
 void optimizeFunction(Function *F, const Backend &B,
-                      const CompilationOptions &opts);
+                      const CompilationContext &cctx);
 
 } // namespace glow
 

--- a/include/glow/Quantization/Base/Base.h
+++ b/include/glow/Quantization/Base/Base.h
@@ -120,6 +120,35 @@ enum Schema {
   SymmetricWithUnsigned,
 };
 
+/// Configuration for Quantization, passed into \ref quantizeFunction().
+struct QuantizationConfiguration {
+  /// Infos to use when determining scale and offset for all Nodes inside, and
+  /// Placeholders and Constants referenced by, a Function being quantized.
+  std::vector<NodeQuantizationInfo> infos{};
+
+  /// Precision to use when quantizing a Function.
+  ElemKind precision{ElemKind::Int8QTy};
+
+  /// Schema to use when quantizing a Function.
+  quantization::Schema schema{quantization::Schema::Asymmetric};
+
+  /// Whether to use rowwise quantization when quantizing a Function.
+  bool enableRowwise{false};
+
+  /// New name for the quantized function. If no name is given then
+  /// \ref quantizeFunction() will generate a name.
+  std::string newFuncName{""};
+
+  /// If true, the quantizer will abort when encountering a node that it would
+  /// like to quantize but the backend cannot support. Note that node kinds in
+  /// doNotQuantizeKinds will skip this check and not cause an abort.
+  bool assertAllNodesQuantized{false};
+
+  QuantizationConfiguration() = default;
+  QuantizationConfiguration(llvm::ArrayRef<NodeQuantizationInfo> i)
+      : infos(i) {}
+};
+
 /// \returns the value \p in as clipped to the range of \p DestTy.
 template <class SrcTy, class DestTy> DestTy clip(SrcTy in) {
   static_assert(sizeof(SrcTy) >= sizeof(DestTy), "Invalid types");

--- a/include/glow/Quantization/Quantization.h
+++ b/include/glow/Quantization/Quantization.h
@@ -30,35 +30,6 @@ class Backend;
 
 namespace quantization {
 
-/// Configuration for Quantization, passed into \ref quantizeFunction().
-struct QuantizationConfiguration {
-  /// Infos to use when determining scale and offset for all Nodes inside, and
-  /// Placeholders and Constants referenced by, a Function being quantized.
-  std::vector<NodeQuantizationInfo> infos{};
-
-  /// Precision to use when quantizing a Function.
-  ElemKind precision{ElemKind::Int8QTy};
-
-  /// Schema to use when quantizing a Function.
-  quantization::Schema schema{quantization::Schema::Asymmetric};
-
-  /// Whether to use rowwise quantization when quantizing a Function.
-  bool enableRowwise{false};
-
-  /// New name for the quantized function. If no name is given then
-  /// \ref quantizeFunction() will generate a name.
-  std::string newFuncName{""};
-
-  /// If true, the quantizer will abort when encountering a node that it would
-  /// like to quantize but the backend cannot support. Note that node kinds in
-  /// doNotQuantizeKinds will skip this check and not cause an abort.
-  bool assertAllNodesQuantized{false};
-
-  QuantizationConfiguration() = default;
-  QuantizationConfiguration(llvm::ArrayRef<NodeQuantizationInfo> i)
-      : infos(i) {}
-};
-
 /// Generate NodeQuantizationInfo for all required nodes from function \p F
 /// using the method specified by \p schema and target quantization precision \p
 /// quantizationPrecision. Profiling values will be written into context \p

--- a/lib/Backends/CPU/CPUBackend.h
+++ b/lib/Backends/CPU/CPUBackend.h
@@ -40,7 +40,7 @@ public:
   std::string getBackendName() const override { return "CPU"; }
 
   bool transformPostLowering(Function *F,
-                             const CompilationOptions &opts) const override;
+                             const CompilationContext &cctx) const override;
 
   bool isOpSupported(const NodeInfo &NI) const override;
 

--- a/lib/Backends/CPU/Transforms.cpp
+++ b/lib/Backends/CPU/Transforms.cpp
@@ -115,7 +115,7 @@ static Node *optimizeCPUMaxSplat(MaxNode *MN, Function *F) {
 }
 
 bool CPUBackend::transformPostLowering(Function *F,
-                                       const CompilationOptions &) const {
+                                       const CompilationContext &) const {
   bool changed = false;
   for (auto &node : F->getNodes()) {
     // Try to replace generic convolution with cpu-optimized version.

--- a/lib/Backends/Habana/Habana.cpp
+++ b/lib/Backends/Habana/Habana.cpp
@@ -714,7 +714,7 @@ IOPlaceholders findIOPlaceholders(Function *F) {
 }
 
 std::unique_ptr<CompiledFunction>
-HabanaBackend::compile(Function *F, const CompilationOptions &opts) const {
+HabanaBackend::compile(Function *F, const BackendOptions &opts) const {
   chk(synCreateGraph(synDeviceGoya));
 
   // Allocate all the tensors.
@@ -1480,7 +1480,7 @@ bool surroundTileWithReshapes(Function *F, TileNode &tile) {
 } // namespace
 
 bool HabanaBackend::transformPostLowering(
-    Function *F, const CompilationOptions &opts) const {
+    Function *F, const CompilationContext &cctx) const {
   bool changed = false;
   for (auto &node : F->getNodes()) {
     // Separate any Slice nodes into several that only slice in one dimension

--- a/lib/Backends/Habana/Habana.h
+++ b/lib/Backends/Habana/Habana.h
@@ -249,14 +249,14 @@ public:
   std::string getBackendName() const override { return "Habana"; }
 
   std::unique_ptr<CompiledFunction>
-  compile(Function *F, const CompilationOptions &opts) const override;
+  compile(Function *F, const BackendOptions &opts) const override;
 
   bool isOpSupported(const NodeInfo &NI) const override;
 
   bool shouldLower(const Node *N) const override;
 
   bool transformPostLowering(Function *F,
-                             const CompilationOptions &opts) const override;
+                             const CompilationContext &cctx) const override;
 
   bool shouldShareBuffers() const override { return false; }
   /// @}

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -26,7 +26,7 @@
 using namespace glow;
 
 std::unique_ptr<CompiledFunction>
-Interpreter::compile(Function *F, const CompilationOptions &opts) const {
+Interpreter::compile(Function *F, const BackendOptions &opts) const {
   TraceInfo traceInfo = buildManualTraceInfo(F);
   auto IR = generateAndOptimizeIR(F, *this, shouldShareBuffers());
 

--- a/lib/Backends/Interpreter/Interpreter.h
+++ b/lib/Backends/Interpreter/Interpreter.h
@@ -47,7 +47,7 @@ public:
   compileIRWithoutConstants(std::unique_ptr<IRFunction> IR) const;
 
   std::unique_ptr<CompiledFunction>
-  compile(Function *F, const CompilationOptions &opts) const override;
+  compile(Function *F, const BackendOptions &opts) const override;
 
   bool isOpSupported(const NodeInfo &NI) const override;
 

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -1609,7 +1609,7 @@ OCLBackend::compileIR(std::unique_ptr<IRFunction> IR) const {
 }
 
 std::unique_ptr<CompiledFunction>
-OCLBackend::compile(Function *F, const CompilationOptions &opts) const {
+OCLBackend::compile(Function *F, const BackendOptions &opts) const {
   TraceInfo traceInfo = buildManualTraceInfo(F);
 
   auto IR = generateAndOptimizeIR(F, *this, shouldShareBuffers());

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -198,10 +198,10 @@ public:
   compileIR(std::unique_ptr<IRFunction> IR) const override;
 
   std::unique_ptr<CompiledFunction>
-  compile(Function *F, const CompilationOptions &opts) const override;
+  compile(Function *F, const BackendOptions &opts) const override;
 
   bool transformPostLowering(Function *F,
-                             const CompilationOptions &opts) const override;
+                             const CompilationContext &cctx) const override;
 
   bool isOpSupported(const NodeInfo &NI) const override;
 

--- a/lib/Backends/OpenCL/Transforms.cpp
+++ b/lib/Backends/OpenCL/Transforms.cpp
@@ -27,10 +27,10 @@ using namespace glow;
 
 /// Perform OpenCL specific post-lowering graph transformation.
 bool OCLBackend::transformPostLowering(Function *F,
-                                       const CompilationOptions &opts) const {
+                                       const CompilationContext &cctx) const {
   // NCHW transformation is not supported in training mode yet, because of some
   // issues with gradient nodes.
-  if (opts.mode == CompilationMode::Train)
+  if (cctx.mode == CompilationMode::Train)
     return false;
 
   bool changed = false;

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -236,12 +236,12 @@ void glow::runBatch(ExecutionEngine &EE, PlaceholderBindings &bindings,
 
 void ExecutionEngine::compile(CompilationMode mode, Function *F,
                               bool clearOtherFunctions) {
-  CompilationOptions opts;
-  opts.mode = mode;
-  compile(F, opts, clearOtherFunctions);
+  CompilationContext cctx;
+  cctx.mode = mode;
+  compile(F, cctx, clearOtherFunctions);
 }
 
-void ExecutionEngine::compile(Function *F, const CompilationOptions &opts,
+void ExecutionEngine::compile(Function *F, const CompilationContext &cctx,
                               bool clearOtherFunctions) {
   llvm::StringRef name = F->getName();
 
@@ -252,7 +252,7 @@ void ExecutionEngine::compile(Function *F, const CompilationOptions &opts,
   assert(!compiledFunctions_.count(name) &&
          "A function with this name has already been compiled.");
 
-  ::glow::optimizeFunction(F, *backend_, opts);
+  ::glow::optimizeFunction(F, *backend_, cctx);
 
   for (const Node &N : F->getNodes()) {
     (void)N;
@@ -260,13 +260,13 @@ void ExecutionEngine::compile(Function *F, const CompilationOptions &opts,
            "Backend must support all nodes after high-level optimizations.");
   }
 
-  auto func = backend_->compile(F, opts);
+  auto func = backend_->compile(F, cctx.backendOpts);
   insertCompiledFunction(name, std::move(func));
 }
 
-void ExecutionEngine::save(Function *F, const CompilationOptions &opts,
+void ExecutionEngine::save(Function *F, const CompilationContext &cctx,
                            llvm::StringRef outputDir,
                            llvm::StringRef networkName) {
-  ::glow::optimizeFunction(F, *backend_, opts);
+  ::glow::optimizeFunction(F, *backend_, cctx);
   backend_->save(F, outputDir, networkName);
 }

--- a/lib/LLVMIRCodeGen/LLVMBackend.cpp
+++ b/lib/LLVMIRCodeGen/LLVMBackend.cpp
@@ -127,7 +127,7 @@ LLVMBackend::compileIRWithoutConstants(IRFunction *IR) const {
 }
 
 std::unique_ptr<CompiledFunction>
-LLVMBackend::compile(Function *F, const CompilationOptions &opts) const {
+LLVMBackend::compile(Function *F, const BackendOptions &opts) const {
   TraceInfo traceInfo = buildManualTraceInfo(F);
   auto IR = generateAndOptimizeIR(F, *this, shouldShareBuffers());
 

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -54,9 +54,9 @@ onnxStatus BackendId::checkGraphCompatibility(const void *onnxModel,
 
   // Call the backend's transformPostLowering to match the normal compilation
   // pipeline then DCE any nodes that are no longer needed.
-  CompilationOptions opts;
-  opts.mode = CompilationMode::Infer;
-  if (glowBackend_->transformPostLowering(function, opts)) {
+  CompilationContext cctx;
+  cctx.mode = CompilationMode::Infer;
+  if (glowBackend_->transformPostLowering(function, cctx)) {
     glow::DCE(function);
   }
 

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -85,10 +85,10 @@ llvm::Error HostManager::addNetwork(std::unique_ptr<Module> module,
   // Optimize functions before passing to partitioner.
   // Currently hardcoding inference.
   if (backend_) {
-    CompilationOptions opts;
-    opts.mode = CompilationMode::Infer;
+    CompilationContext cctx;
+    cctx.mode = CompilationMode::Infer;
     for (auto F : module->getFunctions()) {
-      ::glow::optimizeFunction(F, *backend_, opts);
+      ::glow::optimizeFunction(F, *backend_, cctx);
     }
   }
   auto partitioner = Partitioner(module.get(), deviceInfo, saturateHost);

--- a/lib/Runtime/Provisioner/Provisioner.cpp
+++ b/lib/Runtime/Provisioner/Provisioner.cpp
@@ -82,12 +82,12 @@ llvm::Error Provisioner::provision(DAGListTy &networks, Module &module) {
       auto it = functions_.find(node->name);
       if (it == functions_.end()) {
         Function *function = module.getFunction(node->name);
-        CompilationOptions compileOptions;
+        BackendOptions opts;
         // Set collectConstants to false, this is because the DeviceManager will
         // handle moving constants to the device, this way we can eliminate one
         // copy operation.
-        compileOptions.collectConstants = false;
-        auto compiled = backend_->compile(function, compileOptions);
+        opts.collectConstants = false;
+        auto compiled = backend_->compile(function, opts);
         node->runtimeBundle =
             llvm::make_unique<RuntimeBundle>(compiled->getRuntimeBundle());
         functions_.emplace(node->name, std::move(compiled));

--- a/tests/benchmark/RuntimeBench.cpp
+++ b/tests/benchmark/RuntimeBench.cpp
@@ -16,7 +16,6 @@
 
 #include "benchmark/benchmark.h"
 
-#include "glow/Backends/CompilationOptions.h"
 #include "glow/Backends/DeviceManager.h"
 #include "glow/Optimizer/Optimizer.h"
 #include "glow/Runtime/Executor/Executor.h"
@@ -120,11 +119,11 @@ void setUpDeviceManagerCommon(
   }
 
   FunctionMapTy funcs;
-  CompilationOptions opts;
+  CompilationContext cctx;
 
   // Compile all functions in the module.
   for (auto *function : mod->getFunctions()) {
-    ::glow::optimizeFunction(function, *backend, opts);
+    ::glow::optimizeFunction(function, *backend, cctx);
     std::unique_ptr<CompiledFunction> compiledFunction =
         backend->compile(function);
     funcs.insert(std::make_pair(function->getName(), compiledFunction.get()));

--- a/tests/unittests/BackendCorrectnessTest.cpp
+++ b/tests/unittests/BackendCorrectnessTest.cpp
@@ -179,7 +179,7 @@ public:
   std::string getBackendName() const override { return "MockCPUBackend"; }
 
   std::unique_ptr<CompiledFunction>
-  compile(Function *F, const CompilationOptions &opts) const override {
+  compile(Function *F, const BackendOptions &opts) const override {
     return backend_->compile(F, opts);
   }
 

--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -44,9 +44,9 @@ TEST(Interpreter, NotImplementedSave) {
   F->createSave("save",
                 mod.createPlaceholder(ElemKind::FloatTy, {2}, "A", false));
 
-  CompilationOptions opts;
-  opts.mode = CompilationMode::Infer;
-  EXPECT_DEATH(EE.save(F, opts, "output", "network"), "");
+  CompilationContext cctx;
+  cctx.mode = CompilationMode::Infer;
+  EXPECT_DEATH(EE.save(F, cctx, "output", "network"), "");
 }
 
 TEST(Interpreter, profileQuantizationForANetwork) {
@@ -240,7 +240,7 @@ TEST_P(BackendTest, CompileWithoutConstants) {
   auto *save = F->createSave("save", pow);
   ctx.allocate(save->getPlaceholder());
   std::unique_ptr<Backend> backend(createBackend(GetParam()));
-  CompilationOptions opts;
+  BackendOptions opts;
   opts.collectConstants = false;
   auto function = backend->compile(F, opts);
 }
@@ -317,7 +317,7 @@ TEST_P(BackendTest, compileVectorOfFunctions) {
     functions.push_back(F);
   }
   std::unique_ptr<Backend> backend(createBackend(GetParam()));
-  CompilationOptions opts;
+  BackendOptions opts;
   auto function = backend->compileFunctions(functions, opts);
 }
 

--- a/tests/unittests/BackendTestUtils.cpp
+++ b/tests/unittests/BackendTestUtils.cpp
@@ -22,6 +22,7 @@
 #include "glow/IR/IR.h"
 #include "glow/IR/IRBuilder.h"
 #include "glow/IR/Instrs.h"
+#include "glow/Quantization/Quantization.h"
 
 #include "gtest/gtest.h"
 

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -112,7 +112,7 @@ class MockBackend : public Backend {
   std::string getBackendName() const override { return "MockBackend"; }
 
   std::unique_ptr<CompiledFunction>
-  compile(Function *F, const CompilationOptions &) const override {
+  compile(Function *F, const BackendOptions &) const override {
     return llvm::make_unique<MockFunction>(runtime::RuntimeBundle::create(*F));
   }
 
@@ -145,7 +145,7 @@ class MockBackendCustomIRGen : public Backend {
   std::string getBackendName() const override { return "MockBackend"; }
 
   std::unique_ptr<CompiledFunction>
-  compile(Function *F, const CompilationOptions &) const override {
+  compile(Function *F, const BackendOptions &) const override {
     return llvm::make_unique<MockFunction>(runtime::RuntimeBundle::create(*F));
   }
 

--- a/tests/unittests/DeviceManagerTest.cpp
+++ b/tests/unittests/DeviceManagerTest.cpp
@@ -55,11 +55,11 @@ compileFunctions(BackendKind backendKind, Module *module,
                  std::vector<std::unique_ptr<CompiledFunction>> &backing) {
   FunctionMapTy results;
   auto *backend = createBackend(backendKind);
-  CompilationOptions opts;
-  opts.mode = CompilationMode::Infer;
+  CompilationContext cctx;
+  cctx.mode = CompilationMode::Infer;
   for (auto *F : module->getFunctions()) {
-    ::glow::optimizeFunction(F, *backend, opts);
-    auto f = backend->compile(F, opts);
+    ::glow::optimizeFunction(F, *backend, cctx);
+    auto f = backend->compile(F, cctx.backendOpts);
     backing.push_back(std::move(f));
     results.emplace(F->getName(), backing.back().get());
   }

--- a/tests/unittests/HabanaBackendTest.cpp
+++ b/tests/unittests/HabanaBackendTest.cpp
@@ -61,7 +61,7 @@ TEST_F(HabanaBackendTest, SurroundTile) {
   SaveNode *SN = F_->createSave("save", TN);
 
   // Invoke Habana backend specific graph optimisations.
-  bool changed = backend.transformPostLowering(F_, CompilationOptions());
+  bool changed = backend.transformPostLowering(F_, CompilationContext());
   EXPECT_TRUE(changed);
 
   // Invoke dead code elimination.
@@ -112,7 +112,7 @@ TEST_F(HabanaBackendTest, DoNotSurroundTile) {
   F_->createSave("save", TN);
 
   // Invoke Habana backend specific graph optimisations.
-  bool changed = backend.transformPostLowering(F_, CompilationOptions());
+  bool changed = backend.transformPostLowering(F_, CompilationContext());
 
   // Graph should not change since input to Tile is already 4D.
   EXPECT_FALSE(changed);
@@ -140,7 +140,7 @@ TEST_F(HabanaBackendTest, FuseConvRelu) {
   SaveNode *SN = F_->createSave("save", RN);
 
   // Invoke Habana backend specific graph optimisations.
-  bool changed = backend.transformPostLowering(F_, CompilationOptions());
+  bool changed = backend.transformPostLowering(F_, CompilationContext());
   EXPECT_TRUE(changed);
 
   // Now, the graph should look like this:
@@ -213,7 +213,7 @@ TEST_F(HabanaBackendTest, FuseConvAdd) {
   SaveNode *SN = F_->createSave("save", AN);
 
   // Invoke Habana backend specific graph optimisations.
-  bool changed = backend.transformPostLowering(F_, CompilationOptions());
+  bool changed = backend.transformPostLowering(F_, CompilationContext());
   EXPECT_TRUE(changed);
 
   // Now, the graph should look like this:
@@ -303,7 +303,7 @@ TEST_F(HabanaBackendTest, FuseConvAddRelu) {
   SaveNode *SN = F_->createSave("save", RN);
 
   // Invoke Habana backend specific graph optimisations.
-  bool changed = backend.transformPostLowering(F_, CompilationOptions());
+  bool changed = backend.transformPostLowering(F_, CompilationContext());
   EXPECT_TRUE(changed);
 
   // Now, the graph should look like this:
@@ -378,7 +378,7 @@ TEST_F(HabanaBackendTest, ConvertFC) {
   auto *bias = mod_.createConstant(ElemKind::FloatTy, {16}, "bias");
   auto *FC = F_->createFullyConnected("fc", input, weight, bias);
   auto *save = F_->createSave("save", FC);
-  backend.transformPostLowering(F_, CompilationOptions());
+  backend.transformPostLowering(F_, CompilationContext());
   ASSERT_TRUE(save);
   ASSERT_TRUE(llvm::isa<HabanaFullyConnectedNode>(save->getInput()));
 }
@@ -391,7 +391,7 @@ TEST_F(HabanaBackendTest, ConvertConv) {
   ConvolutionNode *conv = F_->createConv(ctx_, "conv", input, 3, 5, 1, 2, 1);
   SaveNode *save = F_->createSave("save", conv);
 
-  bool changed = backend.transformPostLowering(F_, CompilationOptions());
+  bool changed = backend.transformPostLowering(F_, CompilationContext());
   EXPECT_TRUE(changed);
   ASSERT_TRUE(save);
   ASSERT_TRUE(llvm::isa<HabanaConvolutionNode>(save->getInput()));
@@ -1493,10 +1493,10 @@ TEST_F(HabanaBackendTest, SingleFunctionMultiThreadMultiDevice) {
   // Compile function.
   glow::runtime::FunctionMapTy functions;
   auto backend = std::unique_ptr<Backend>(createBackend(BackendKind::Habana));
-  CompilationOptions opts;
-  opts.mode = CompilationMode::Infer;
-  ::glow::optimizeFunction(F_, *backend, opts);
-  auto compiledFunction = backend->compile(F_, opts);
+  CompilationContext cctx;
+  cctx.mode = CompilationMode::Infer;
+  ::glow::optimizeFunction(F_, *backend, cctx);
+  auto compiledFunction = backend->compile(F_, cctx.backendOpts);
   functions.emplace(F_->getName(), compiledFunction.get());
 
   // Add the function to each device.

--- a/tests/unittests/QuantizationTest.cpp
+++ b/tests/unittests/QuantizationTest.cpp
@@ -75,7 +75,7 @@ public:
   std::string getBackendName() const override { return "MockQuantBackend"; }
 
   std::unique_ptr<CompiledFunction>
-  compile(Function *F, const CompilationOptions &opts) const override {
+  compile(Function *F, const BackendOptions &opts) const override {
     return backend_->compile(F, opts);
   }
 

--- a/tests/unittests/TraceEventsTest.cpp
+++ b/tests/unittests/TraceEventsTest.cpp
@@ -138,9 +138,9 @@ TEST_P(TraceEventsTest, manualEvents) {
   F->createTraceEvent("second half", "E", eventData, eventId++);
 
   context.getPlaceholderBindings()->allocate(EE_.getModule().getPlaceholders());
-  CompilationOptions opts;
-  opts.mode = CompilationMode::Infer;
-  EE_.compile(F, opts);
+  CompilationContext cctx;
+  cctx.mode = CompilationMode::Infer;
+  EE_.compile(F, cctx);
 
   updateInputPlaceholders(*context.getPlaceholderBindings(), {inputPH},
                           {&inputs});
@@ -185,9 +185,9 @@ TEST_P(TraceEventsTest, incompleteCoverage) {
   F->createTraceEvent("second half", "E", eventData, eventId++);
 
   context.getPlaceholderBindings()->allocate(EE_.getModule().getPlaceholders());
-  CompilationOptions opts;
-  opts.mode = CompilationMode::Infer;
-  EE_.compile(F, opts);
+  CompilationContext cctx;
+  cctx.mode = CompilationMode::Infer;
+  EE_.compile(F, cctx);
 
   updateInputPlaceholders(*context.getPlaceholderBindings(), {inputPH},
                           {&inputs});
@@ -228,9 +228,9 @@ TEST_P(TraceEventsTest, internalGap) {
   n = part_four(F, context, n);
 
   context.getPlaceholderBindings()->allocate(EE_.getModule().getPlaceholders());
-  CompilationOptions opts;
-  opts.mode = CompilationMode::Infer;
-  EE_.compile(F, opts);
+  CompilationContext cctx;
+  cctx.mode = CompilationMode::Infer;
+  EE_.compile(F, cctx);
 
   updateInputPlaceholders(*context.getPlaceholderBindings(), {inputPH},
                           {&inputs});
@@ -265,11 +265,12 @@ TEST_P(TraceEventsTest, automaticInstrumentation) {
 
   context.getPlaceholderBindings()->allocate(EE_.getModule().getPlaceholders());
   auto *backend = EE_.getBackend();
-  CompilationOptions opts;
-  opts.mode = CompilationMode::Infer;
-  opts.autoInstrument = true;
-  ::glow::optimizeFunction(F, *backend, opts);
-  EE_.insertCompiledFunction(F->getName(), backend->compile(F, opts));
+  CompilationContext cctx;
+  cctx.mode = CompilationMode::Infer;
+  cctx.backendOpts.autoInstrument = true;
+  ::glow::optimizeFunction(F, *backend, cctx);
+  EE_.insertCompiledFunction(F->getName(),
+                             backend->compile(F, cctx.backendOpts));
 
   updateInputPlaceholders(*context.getPlaceholderBindings(), {inputPH},
                           {&inputs});
@@ -304,11 +305,12 @@ TEST_P(TraceEventsTest, manualAndAutomatic) {
 
   context.getPlaceholderBindings()->allocate(EE_.getModule().getPlaceholders());
   auto *backend = EE_.getBackend();
-  CompilationOptions opts;
-  opts.mode = CompilationMode::Infer;
-  opts.autoInstrument = true;
-  ::glow::optimizeFunction(F, *backend, opts);
-  EE_.insertCompiledFunction(F->getName(), backend->compile(F, opts));
+  CompilationContext cctx;
+  cctx.mode = CompilationMode::Infer;
+  cctx.backendOpts.autoInstrument = true;
+  ::glow::optimizeFunction(F, *backend, cctx);
+  EE_.insertCompiledFunction(F->getName(),
+                             backend->compile(F, cctx.backendOpts));
 
   updateInputPlaceholders(*context.getPlaceholderBindings(), {inputPH},
                           {&inputs});
@@ -353,16 +355,16 @@ TEST_P(TraceEventsTest, twoCompiles) {
   context.getPlaceholderBindings()->allocate(EE_.getModule().getPlaceholders());
 
   auto *backend = EE_.getBackend();
-  CompilationOptions opts;
-  opts.mode = CompilationMode::Infer;
-  opts.autoInstrument = true;
-  ::glow::optimizeFunction(F, *backend, opts);
+  CompilationContext cctx;
+  cctx.mode = CompilationMode::Infer;
+  cctx.backendOpts.autoInstrument = true;
+  ::glow::optimizeFunction(F, *backend, cctx);
 
   std::string name = F->getName();
-  EE_.insertCompiledFunction(name, backend->compile(F, opts));
+  EE_.insertCompiledFunction(name, backend->compile(F, cctx.backendOpts));
 
   std::string name2 = name + "2";
-  EE_.insertCompiledFunction(name2, backend->compile(F, opts));
+  EE_.insertCompiledFunction(name2, backend->compile(F, cctx.backendOpts));
 
   updateInputPlaceholders(*context.getPlaceholderBindings(), {inputPH},
                           {&inputs});
@@ -409,9 +411,9 @@ TEST_P(TraceEventsTest, onlyTraceEvents) {
   }
 
   context.getPlaceholderBindings()->allocate(EE_.getModule().getPlaceholders());
-  CompilationOptions opts;
-  opts.mode = CompilationMode::Infer;
-  EE_.compile(F, opts);
+  CompilationContext cctx;
+  cctx.mode = CompilationMode::Infer;
+  EE_.compile(F, cctx);
 
   updateInputPlaceholders(*context.getPlaceholderBindings(), {inputPH},
                           {&inputs});
@@ -460,9 +462,9 @@ TEST_P(TraceEventsTest, multipleBackingTensors) {
   F->createTraceEvent("event3", "E", eventData4, 0);
 
   context.getPlaceholderBindings()->allocate(EE_.getModule().getPlaceholders());
-  CompilationOptions opts;
-  opts.mode = CompilationMode::Infer;
-  EE_.compile(F, opts);
+  CompilationContext cctx;
+  cctx.mode = CompilationMode::Infer;
+  EE_.compile(F, cctx);
 
   updateInputPlaceholders(*context.getPlaceholderBindings(), {inputPH},
                           {&inputs});
@@ -513,9 +515,9 @@ TEST_P(TraceEventsTest, multipleRunsAreDistinct) {
   F->createTraceEvent("second half", "E", eventData, eventId++);
 
   context.getPlaceholderBindings()->allocate(EE_.getModule().getPlaceholders());
-  CompilationOptions opts;
-  opts.mode = CompilationMode::Infer;
-  EE_.compile(F, opts);
+  CompilationContext cctx;
+  cctx.mode = CompilationMode::Infer;
+  EE_.compile(F, cctx);
 
   updateInputPlaceholders(*context.getPlaceholderBindings(), {inputPH},
                           {&inputs});
@@ -554,9 +556,9 @@ TEST_P(TraceEventsTest, deviceManagerEvents) {
 
   context.getPlaceholderBindings()->allocate(EE_.getModule().getPlaceholders());
 
-  CompilationOptions opts;
-  opts.mode = CompilationMode::Infer;
-  EE_.compile(F, opts);
+  CompilationContext cctx;
+  cctx.mode = CompilationMode::Infer;
+  EE_.compile(F, cctx);
 
   updateInputPlaceholders(*context.getPlaceholderBindings(), {inputPH},
                           {&inputs});

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -20,6 +20,7 @@
 #include "glow/Converter/TypeAToTypeBFunctionConverter.h"
 #include "glow/ExecutionEngine/ExecutionEngine.h"
 #include "glow/IR/IR.h"
+#include "glow/Quantization/Quantization.h"
 #include "glow/Quantization/Serialization.h"
 
 #include "llvm/Support/CommandLine.h"
@@ -351,14 +352,14 @@ void Loader::compile(PlaceholderBindings &bindings) {
     ::optimize(F_, glow::CompilationMode::Infer);
   }
 
-  CompilationOptions opts;
-  opts.mode = CompilationMode::Infer;
+  CompilationContext cctx;
+  cctx.mode = CompilationMode::Infer;
   if (emittingBundle()) {
     // Emit IR for the graph, compile it and save as a bundle.
-    EE_.save(F_, opts, emitBundle, networkName);
+    EE_.save(F_, cctx, emitBundle, networkName);
   } else {
     // Emit IR for the graph and compile it.
-    EE_.compile(F_, opts);
+    EE_.compile(F_, cctx);
   }
 
   if (dumpGraphOpt) {


### PR DESCRIPTION
*Description*: This is a step toward landing #2700. Once landed I will add Quantization related members to `CompilationContext` from #2700, e.g. `PrecisionConfiguration`, `PlaceholderBindings`, and `LoweredInfoMap`.

*Testing*: All tests still pass.

*Documentation*: Updated.