### PR TITLE
Remove cloning of functions for quantization and profiling

### DIFF
--- a/examples/fr2en.cpp
+++ b/examples/fr2en.cpp
@@ -174,13 +174,8 @@ struct Model {
           deserializeFromYaml(loadProfileFileOpt)};
 
       // Quantize the graph based on the captured profile.
-      auto *Q = quantization::quantizeFunction(F_, quantConfig,
-                                               *EE_.getBackend(), loweredMap_);
-
-      // Erase the original function so that the redundant variables that are
-      // only referenced by the original function will be removed.
-      Q->getParent()->eraseFunction(F_);
-      F_ = Q;
+      quantization::quantizeFunction(F_, quantConfig, *EE_.getBackend(),
+                                     loweredMap_);
     }
 
     // Do not create constants if we're profiling; the newly allocate histogram

--- a/examples/fr2en.cpp
+++ b/examples/fr2en.cpp
@@ -157,7 +157,7 @@ struct Model {
       ::lower(F_, &loweredMap_);
 
       // Instrument the graph to capture profiles for nodes' outputs.
-      F_ = glow::profileQuantization(bindings, F_);
+      glow::profileQuantization(bindings, F_);
     }
 
     // Load the quantization profile and transform the graph.

--- a/include/glow/Optimizer/Optimizer.h
+++ b/include/glow/Optimizer/Optimizer.h
@@ -61,11 +61,8 @@ void convertPlaceholdersToConstants(Function *F,
 
 /// Instrument function \p F by inserting quantization profile nodes for
 /// capturing stats for quantization. The nodes will refer to tensors allocate
-/// in in context \p bindings. The new quantized function is called \p
-/// newFuncName. If no name is given the method will generate a name.  \returns
-/// a new function with the added quantization nodes.
-Function *profileQuantization(PlaceholderBindings &bindings, Function *F,
-                              llvm::StringRef newFuncName = "");
+/// in context \p bindings.
+void profileQuantization(PlaceholderBindings &bindings, Function *F);
 
 /// Helper to generate and optimize IR from given Function \p F. \p
 /// shouldShareBuffers signifies whether to use the share buffers optimization.

--- a/include/glow/Quantization/Quantization.h
+++ b/include/glow/Quantization/Quantization.h
@@ -42,19 +42,15 @@ std::vector<NodeQuantizationInfo> generateNodeQuantizationInfos(
     const LoweredInfoMap &loweredMap = {}, Schema schema = Schema::Asymmetric,
     ElemKind quantizationPrecision = ElemKind::Int8QTy);
 
-/// Quantizes the function \p F into a new unoptimized partially quantized
-/// function based on configuration from \p quantConfig. This method converts to
-/// integer as many nodes as permitted by the backend \p B.
+/// Quantizes the function \p F into an unoptimized partially quantized function
+/// based on configuration from \p quantConfig. This method converts to integer
+/// as many nodes as permitted by the backend \p B. \p loweredMap contains info
+/// about what nodes were lowered from what, to be used during quantization.
 /// \p doNotQuantizeKinds lists kinds to not quantize, even if a profile was
-/// gathered for them and the backend supports the quantized operation.  This
-/// method clones original function \p F and caller is responsible for cleaning
-/// up/erasing original function \p F if needed. \returns a new quantized
-/// function.
-Function *quantizeFunction(Function *F,
-                           const QuantizationConfiguration &quantConfig,
-                           const Backend &B,
-                           const LoweredInfoMap &loweredMap = {},
-                           const KindSet &doNotQuantizeKinds = {});
+/// gathered for them and the backend supports the quantized operation.
+void quantizeFunction(Function *F, const QuantizationConfiguration &quantConfig,
+                      const Backend &B, const LoweredInfoMap &loweredMap = {},
+                      const KindSet &doNotQuantizeKinds = {});
 
 } // namespace quantization
 } // namespace glow

--- a/lib/Onnxifi/InlineOnnxifi.cpp
+++ b/lib/Onnxifi/InlineOnnxifi.cpp
@@ -61,7 +61,7 @@ InlineGraph::initGraph(const void *onnxModel, size_t onnxModelSize,
   if (quantizationStep_ == OnnxifiQuantizationStep::Profile) {
     lower(function_, &loweredMap_, executionEngine_.getBackend());
     PlaceholderBindings dummyCtx;
-    function_ = profileQuantization(dummyCtx, function_);
+    profileQuantization(dummyCtx, function_);
   }
 
   // -- Quantize --

--- a/lib/Onnxifi/InlineOnnxifi.cpp
+++ b/lib/Onnxifi/InlineOnnxifi.cpp
@@ -69,12 +69,8 @@ InlineGraph::initGraph(const void *onnxModel, size_t onnxModelSize,
     quantization::QuantizationConfiguration quantConfig{
         deserializeFromYaml(getProfileFile(modelHash_))};
     quantConfig.schema = quantization::Schema::Symmetric;
-    quantConfig.newFuncName = function_->getName();
-    function_->setName("old");
-    auto *Q = quantization::quantizeFunction(
-        function_, quantConfig, *executionEngine_.getBackend(), loweredMap_);
-    Q->getParent()->eraseFunction(function_);
-    function_ = Q;
+    quantization::quantizeFunction(function_, quantConfig,
+                                   *executionEngine_.getBackend(), loweredMap_);
   }
 
   executionEngine_.compile(CompilationMode::Infer, function_);

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -898,26 +898,20 @@ generateNodeQuantizationInfos(PlaceholderBindings &bindings, const Function *F,
   return quantizationInfos;
 }
 
-Function *quantizeFunction(Function *F,
-                           const QuantizationConfiguration &quantConfig,
-                           const Backend &B, const LoweredInfoMap &loweredMap,
-                           const KindSet &doNotQuantizeKinds) {
+void quantizeFunction(Function *F, const QuantizationConfiguration &quantConfig,
+                      const Backend &B, const LoweredInfoMap &loweredMap,
+                      const KindSet &doNotQuantizeKinds) {
   assert((quantConfig.precision == ElemKind::Int8QTy ||
           quantConfig.precision == ElemKind::Int16QTy) &&
          "Only Int8 and Int16 quantization supported");
-  Function *G = F->clone(quantConfig.newFuncName.empty()
-                             ? F->getName().str() + "_quantized"
-                             : quantConfig.newFuncName);
 
-  FunctionQuantizer quantizer(*G, B, quantConfig.schema, quantConfig.infos,
+  FunctionQuantizer quantizer(*F, B, quantConfig.schema, quantConfig.infos,
                               quantConfig.precision, doNotQuantizeKinds,
                               loweredMap, quantConfig.assertAllNodesQuantized);
   quantizer.convert();
   if (quantConfig.enableRowwise) {
     quantizer.enableRowwise();
   }
-
-  return G;
 }
 
 } // namespace quantization

--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -63,7 +63,7 @@ TEST(Interpreter, profileQuantizationForANetwork) {
   O = F->createRELU("relu", O);
   O = F->createRegression("reg", O, Ex);
 
-  F = ::glow::profileQuantization(ctx, F);
+  ::glow::profileQuantization(ctx, F);
 
   ctx.allocate(A);
   ctx.allocate(Ex);

--- a/tests/unittests/BackendTestUtils.cpp
+++ b/tests/unittests/BackendTestUtils.cpp
@@ -59,10 +59,16 @@ static Placeholder *createQuantizedPlaceholder(Module &mod,
 /// Clone, profile, and run \p origF given the \p ctx and \p EE. \returns the
 /// quantization parameters from the profile, given the lowered info passed in
 /// via \p loweredMap, and the specified \p schema.
-static std::vector<NodeQuantizationInfo> profileAndGetNodeQuantizationInfo(
-    PlaceholderBindings &bindings, ExecutionEngine &EE, Function *origF,
-    const LoweredInfoMap &loweredMap, quantization::Schema schema) {
-  Function *profileF = glow::profileQuantization(bindings, origF);
+static std::vector<NodeQuantizationInfo>
+profileAndGetNodeQuantizationInfo(PlaceholderBindings &bindings,
+                                  ExecutionEngine &EE, Function *origF,
+                                  quantization::Schema schema) {
+  // Lower everything for profiling in a cloned PF, keeping track of lowered
+  // info in loweredMap, which is then used when generating QI.
+  Function *profileF = origF->clone("profile");
+  LoweredInfoMap loweredMap;
+  lower(profileF, &loweredMap, EE.getBackend());
+  glow::profileQuantization(bindings, profileF);
   EE.compile(CompilationMode::Infer, profileF);
 
   EE.run(bindings);
@@ -81,14 +87,8 @@ static void profileAndQuantize(PlaceholderBindings &Ibindings,
                                ElemKind backendElemKind,
                                quantization::Schema schema,
                                bool enableRowwiseQuantization) {
-  // Lower everything for profiling in a cloned PF, keeping track of lowered
-  // info in loweredMap, which is then used when generating QI.
-  Function *PF = IF->clone("profile");
-  LoweredInfoMap loweredMapForProf;
-  lower(PF, &loweredMapForProf, IEE.getBackend());
   quantization::QuantizationConfiguration quantConfig{
-      profileAndGetNodeQuantizationInfo(Ibindings, IEE, PF, loweredMapForProf,
-                                        schema)};
+      profileAndGetNodeQuantizationInfo(Ibindings, IEE, IF, schema)};
   quantConfig.enableRowwise = enableRowwiseQuantization;
   quantConfig.schema = schema;
   quantConfig.assertAllNodesQuantized = true;

--- a/tests/unittests/BackendTestUtils.cpp
+++ b/tests/unittests/BackendTestUtils.cpp
@@ -98,16 +98,16 @@ static void profileAndQuantize(PlaceholderBindings &Ibindings,
     // Lower only as the backends prefer for actually quantizing.
     LoweredInfoMap loweredMapForQuant;
     lower(IF, &loweredMapForQuant, IEE.getBackend());
-    IF = quantization::quantizeFunction(IF, quantConfig, *IEE.getBackend(),
-                                        loweredMapForQuant);
+    quantization::quantizeFunction(IF, quantConfig, *IEE.getBackend(),
+                                   loweredMapForQuant);
   }
   if (isQuantizedElemKind(backendElemKind)) {
     quantConfig.precision = backendElemKind;
     // Lower only as the backends prefer for actually quantizing.
     LoweredInfoMap loweredMapForQuant;
     lower(BF, &loweredMapForQuant, BEE.getBackend());
-    BF = quantization::quantizeFunction(BF, quantConfig, *BEE.getBackend(),
-                                        loweredMapForQuant);
+    quantization::quantizeFunction(BF, quantConfig, *BEE.getBackend(),
+                                   loweredMapForQuant);
   }
 }
 

--- a/tests/unittests/GraphTest.cpp
+++ b/tests/unittests/GraphTest.cpp
@@ -406,7 +406,7 @@ TEST(Graph, QuantizationProfileNodes) {
 
   // Simulate actual usage.
   ::optimize(F, CompilationMode::Infer);
-  F = ::glow::profileQuantization(bindings, F);
+  ::glow::profileQuantization(bindings, F);
   auto backend = MockBackend();
   lower(F, /* loweredMap */ nullptr, &backend);
   ::optimize(F, CompilationMode::Infer);

--- a/tests/unittests/MLTest.cpp
+++ b/tests/unittests/MLTest.cpp
@@ -1061,7 +1061,7 @@ TEST_P(InterpreterAndCPU, convNetForImageRecognition) {
   lower(PF, &loweredMapForProf);
 
   // Profiling:
-  PF = glow::profileQuantization(bindings, PF);
+  glow::profileQuantization(bindings, PF);
   EE.compile(CompilationMode::Infer, PF);
   runBatch(EE, bindings, 100, sampleCounter, {input}, {&images});
 
@@ -1183,7 +1183,7 @@ TEST_P(InterpreterAndCPU, testFindPixelRegression) {
   lower(PF, &loweredMapForProf);
 
   // Profile the fully lowered 'F', 'PF'.
-  PF = glow::profileQuantization(bindings, PF);
+  glow::profileQuantization(bindings, PF);
   EE.compile(CompilationMode::Infer, PF);
 
   // Run the graph to capture the profile.

--- a/tests/unittests/MLTest.cpp
+++ b/tests/unittests/MLTest.cpp
@@ -1083,10 +1083,10 @@ TEST_P(InterpreterAndCPU, convNetForImageRecognition) {
   // Build the new quantized graph.
   LoweredInfoMap loweredMapForQuant;
   lower(F, &loweredMapForQuant, EE.getBackend());
-  Function *QP = quantization::quantizeFunction(
-      F, quantConfig, *EE.getBackend(), loweredMapForQuant, doNotQuantizeKinds);
+  quantization::quantizeFunction(F, quantConfig, *EE.getBackend(),
+                                 loweredMapForQuant, doNotQuantizeKinds);
 
-  EE.compile(CompilationMode::Infer, QP);
+  EE.compile(CompilationMode::Infer, F);
 
   // Generate the images used for testing.
   Tensor testImages(ElemKind::FloatTy, {batchSize, 8, 8, 1});
@@ -1203,10 +1203,10 @@ TEST_P(InterpreterAndCPU, testFindPixelRegression) {
   // Build the new quantized graph.
   LoweredInfoMap loweredMapForQuant;
   lower(F, &loweredMapForQuant, EE.getBackend());
-  Function *QP = quantization::quantizeFunction(
-      F, quantConfig, *EE.getBackend(), loweredMapForQuant);
+  quantization::quantizeFunction(F, quantConfig, *EE.getBackend(),
+                                 loweredMapForQuant);
 
-  EE.compile(CompilationMode::Infer, QP);
+  EE.compile(CompilationMode::Infer, F);
 
   // Generate the images used for testing.
   Tensor testImages(ElemKind::FloatTy, {batchSize, 10, 10, 1});

--- a/tests/unittests/QuantizationTest.cpp
+++ b/tests/unittests/QuantizationTest.cpp
@@ -270,7 +270,7 @@ static void quantizeSimpleConvGraph(ElemKind quantizationPrecision) {
 
   quantConfig.precision = quantizationPrecision;
   quantConfig.assertAllNodesQuantized = true;
-  F = quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
+  quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
 
   // Make sure that graph can be compiled and run.
   EE.compile(CompilationMode::Infer, F);
@@ -326,7 +326,7 @@ TEST(Quantization, TestQuantizedInputBeforeQuantizedNode) {
   }};
 
   quantConfig.assertAllNodesQuantized = true;
-  F = quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
+  quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
 
   // Remove unnecessary conversions.
   optimize(F, CompilationMode::Infer);
@@ -378,7 +378,7 @@ TEST(Quantization, enableRowwiseQuantizedFullyConnected) {
 
   quantConfig.enableRowwise = true;
   quantConfig.assertAllNodesQuantized = true;
-  F = quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
+  quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
 
   // Check the graph structure after quantization.
   auto *saveNode = llvm::dyn_cast<SaveNode>(F->getNodeByName("ret"));
@@ -452,7 +452,7 @@ TEST(Quantization, enableRowwiseQuantizedFullyConnectedSymmetric) {
   quantConfig.schema = quantization::Schema::Symmetric;
   quantConfig.enableRowwise = true;
   quantConfig.assertAllNodesQuantized = true;
-  F = quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
+  quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
 
   // Check the graph structure after quantization.
   auto *saveNode = llvm::dyn_cast<SaveNode>(F->getNodeByName("save"));
@@ -526,7 +526,7 @@ TEST(Quantization, enableRowwiseQuantizedSLWS) {
 
   quantConfig.enableRowwise = true;
   quantConfig.assertAllNodesQuantized = true;
-  F = quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
+  quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
 
   EE.compile(CompilationMode::Infer, F);
 
@@ -559,7 +559,7 @@ TEST(Quantization, quantizeReLU) {
        {NodeQuantizationInfo::generateNodeOutputName(relu->getName()),
         {0.2f, -128}}}};
   quantConfig.assertAllNodesQuantized = true;
-  F = quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
+  quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
   EE.compile(CompilationMode::Infer, F);
 
   auto *save = llvm::cast<SaveNode>(F->getNodeByName("ret"));
@@ -596,7 +596,7 @@ TEST(Quantization, quantizeLookupTables) {
        {NodeQuantizationInfo::generateNodeOutputName(TN->getName()),
         {0.04f, 3}}}};
   quantConfig.assertAllNodesQuantized = true;
-  F = quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
+  quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
   optimize(F, CompilationMode::Infer);
 
   // Note: The scales/offsets used below are those expected based on
@@ -660,7 +660,7 @@ TEST(Quantization, quantizeWithoutLookupTables) {
        {NodeQuantizationInfo::generateNodeOutputName(TN->getName()),
         {0.04f, 3}}}};
   quantConfig.assertAllNodesQuantized = true;
-  F = quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
+  quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
   optimize(F, CompilationMode::Infer);
 
   auto *save = llvm::cast<SaveNode>(F->getNodeByName("ret"));
@@ -794,7 +794,7 @@ testQuantizationEnd2End(ExecutionEngine &profileEE,
   lower(F2, &loweredMapForQuant, backendSpecificEE.getBackend());
   quantConfig.precision = quantizationPrecision;
   quantConfig.assertAllNodesQuantized = true;
-  F2 = quantization::quantizeFunction(
+  quantization::quantizeFunction(
       F2, quantConfig, *backendSpecificEE.getBackend(), loweredMapForQuant,
       keepOriginalPrecisionForNodes);
   backendSpecificEE.compile(CompilationMode::Infer, F2);
@@ -968,9 +968,9 @@ TEST_P(Operator, end2endGRU) {
   LoweredInfoMap loweredMapForQuant;
   lower(F2, &loweredMapForQuant, backendSpecificEE.getBackend());
   quantConfig.assertAllNodesQuantized = true;
-  F2 = quantization::quantizeFunction(F2, quantConfig,
-                                      *backendSpecificEE.getBackend(),
-                                      loweredMapForQuant, doNotQuantizeKinds);
+  quantization::quantizeFunction(F2, quantConfig,
+                                 *backendSpecificEE.getBackend(),
+                                 loweredMapForQuant, doNotQuantizeKinds);
   backendSpecificEE.compile(CompilationMode::Infer, F2);
   backendSpecificEE.run(bindings);
 
@@ -1287,7 +1287,7 @@ TEST(Quantization, quantizeSoftmaxAndLRN) {
         {0.4f, 0}}}};
 
   quantConfig.assertAllNodesQuantized = true;
-  F = quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
+  quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
 
   auto qLRNIt = std::find_if(
       F->getNodes().begin(), F->getNodes().end(), [](const Node &node) -> bool {
@@ -1340,7 +1340,7 @@ TEST(Quantization, quantizeSelect) {
         selectQP}}};
 
   quantConfig.assertAllNodesQuantized = true;
-  F = quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
+  quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
 
   auto it = std::find_if(
       F->getNodes().begin(), F->getNodes().end(),
@@ -1385,7 +1385,7 @@ TEST(Quantization, quantizeAvgPool) {
   }};
 
   quantConfig.assertAllNodesQuantized = true;
-  F = quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
+  quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
 
   auto qPool = std::find_if(F->getNodes().begin(), F->getNodes().end(),
                             [](const Node &node) -> bool {
@@ -1435,11 +1435,8 @@ TEST(Quantization, quantizeGraphPartially) {
   doNotQuantizeKinds.insert(Kinded::Kind::TanhNodeKind);
 
   quantConfig.assertAllNodesQuantized = true;
-  auto *QF =
-      quantization::quantizeFunction(F, quantConfig, *EE.getBackend(),
-                                     /* loweredMap */ {}, doNotQuantizeKinds);
-  QF->getParent()->eraseFunction(F);
-  F = QF;
+  quantization::quantizeFunction(F, quantConfig, *EE.getBackend(),
+                                 /* loweredMap */ {}, doNotQuantizeKinds);
 
   // Make sure that graph can be compiled and run.
   ::glow::convertPlaceholdersToConstants(F, bindings, {result});
@@ -1518,11 +1515,8 @@ TEST(Quantization, quantizeGraphPartiallyMultipleNodes) {
   doNotQuantizeKinds.insert(Kinded::Kind::TanhNodeKind);
 
   quantConfig.assertAllNodesQuantized = true;
-  auto *QF =
-      quantization::quantizeFunction(F, quantConfig, *EE.getBackend(),
-                                     /* loweredMap */ {}, doNotQuantizeKinds);
-  QF->getParent()->eraseFunction(F);
-  F = QF;
+  quantization::quantizeFunction(F, quantConfig, *EE.getBackend(),
+                                 /* loweredMap */ {}, doNotQuantizeKinds);
 
   // Make sure that graph can be compiled and run.
   ::glow::convertPlaceholdersToConstants(F, bindings, {result});
@@ -1611,11 +1605,8 @@ TEST(Quantization, quantizeGraphPartiallyMultipleKinds) {
   doNotQuantizeKinds.insert(Kinded::Kind::AddNodeKind);
 
   quantConfig.assertAllNodesQuantized = true;
-  auto *QF =
-      quantization::quantizeFunction(F, quantConfig, *EE.getBackend(),
-                                     /* loweredMap */ {}, doNotQuantizeKinds);
-  QF->getParent()->eraseFunction(F);
-  F = QF;
+  quantization::quantizeFunction(F, quantConfig, *EE.getBackend(),
+                                 /* loweredMap */ {}, doNotQuantizeKinds);
 
   // Make sure that graph can be compiled and run.
   ::glow::convertPlaceholdersToConstants(F, bindings, {result});
@@ -1695,10 +1686,7 @@ TEST(Quantization, quantizeFunctionConvertConstant) {
   }};
 
   quantConfig.assertAllNodesQuantized = true;
-  Function *QF =
-      quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
-  QF->getParent()->eraseFunction(F);
-  F = QF;
+  quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
 
   optimize(F, CompilationMode::Infer);
 
@@ -1760,10 +1748,7 @@ TEST(Quantization, quantizeSlice) {
   }};
 
   quantConfig.assertAllNodesQuantized = true;
-  Function *QF =
-      quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
-  QF->getParent()->eraseFunction(F);
-  F = QF;
+  quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
 
   optimize(F, CompilationMode::Infer);
 
@@ -1831,10 +1816,7 @@ TEST(Quantization, quantizeReshape) {
   }};
 
   quantConfig.assertAllNodesQuantized = true;
-  Function *QF =
-      quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
-  QF->getParent()->eraseFunction(F);
-  F = QF;
+  quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
 
   optimize(F, CompilationMode::Infer);
 
@@ -2037,8 +2019,8 @@ static void testProfileQuantizationOfFC(bool expectLoweredFC,
   // the quantization infos gathered.
   quantConfig.enableRowwise = rowwiseQuantizeFC;
   quantConfig.assertAllNodesQuantized = true;
-  backendF = quantization::quantizeFunction(
-      backendF, quantConfig, *backendEE.getBackend(), loweredMapForQuant);
+  quantization::quantizeFunction(backendF, quantConfig, *backendEE.getBackend(),
+                                 loweredMapForQuant);
 
   // Compile the graph to remove dead code and optimize away unnecessary
   // quantize nodes.
@@ -2145,22 +2127,22 @@ TEST(Quantization, CheckAssertQuantization) {
         {0.2f, -128}}}};
   quantConfig.precision = ElemKind::Int16QTy;
   quantConfig.assertAllNodesQuantized = true;
-  quantConfig.newFuncName = "quant_1";
 
   // Expect this to die because quantizeFunction() is passed with
   // assertAllNodesQuantized true, and the Interpreter backend does not support
   // Int16QTy ReLU.
-  EXPECT_DEATH(quantization::quantizeFunction(F, quantConfig, *EE.getBackend()),
-               "");
+  Function *QF = F->clone("quant_clone1");
+  EXPECT_DEATH(
+      quantization::quantizeFunction(QF, quantConfig, *EE.getBackend()), "");
 
   {
+    Function *QF = F->clone("quant_clone2");
     quantConfig.assertAllNodesQuantized = false;
-    quantConfig.newFuncName = "quant_2";
 
     // This works fine because quantizeFunction() is passed with
     // assertAllNodesQuantized false, and so the ReLU will not be quantized as
     // the Interpreter does not support Int16QTy ReLU.
-    auto *QF = quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
+    quantization::quantizeFunction(QF, quantConfig, *EE.getBackend());
 
     auto *saveNode = llvm::dyn_cast<SaveNode>(QF->getNodeByName("ret"));
     ASSERT_TRUE(saveNode);
@@ -2170,17 +2152,16 @@ TEST(Quantization, CheckAssertQuantization) {
   }
 
   {
+    Function *QF = F->clone("quant_clone3");
     quantConfig.assertAllNodesQuantized = true;
     KindSet doNotQuantizeKinds;
     doNotQuantizeKinds.insert(Kinded::Kind::ReluNodeKind);
-    quantConfig.newFuncName = "quant_3";
 
     // This works fine because quantizeFunction() is passed with
     // assertAllNodesQuantized true, but we explicitly tell the quantizer to
     // keep ReLU in its original precision.
-    auto *QF =
-        quantization::quantizeFunction(F, quantConfig, *EE.getBackend(),
-                                       /* loweredMap */ {}, doNotQuantizeKinds);
+    quantization::quantizeFunction(QF, quantConfig, *EE.getBackend(),
+                                   /* loweredMap */ {}, doNotQuantizeKinds);
 
     auto *saveNode = llvm::dyn_cast<SaveNode>(QF->getNodeByName("ret"));
     ASSERT_TRUE(saveNode);
@@ -2217,9 +2198,9 @@ TEST(Quantization, QuantizationZeroUsersResult) {
         {0.2f, 0}}}};
   quantConfig.assertAllNodesQuantized = true;
 
-  auto *QF = quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
+  quantization::quantizeFunction(F, quantConfig, *EE.getBackend());
 
-  auto *qSN = llvm::dyn_cast<SaveNode>(QF->getNodeByName("save_indices"));
+  auto *qSN = llvm::dyn_cast<SaveNode>(F->getNodeByName("save_indices"));
   ASSERT_TRUE(qSN);
   auto *qTK = llvm::dyn_cast<TopKNode>(qSN->getInput().getNode());
   ASSERT_TRUE(qTK);

--- a/tests/unittests/QuantizationTest.cpp
+++ b/tests/unittests/QuantizationTest.cpp
@@ -775,7 +775,7 @@ testQuantizationEnd2End(ExecutionEngine &profileEE,
 
   LoweredInfoMap loweredMapForProf;
   lower(F1, &loweredMapForProf);
-  F1 = glow::profileQuantization(bindings, F1);
+  glow::profileQuantization(bindings, F1);
   profileEE.compile(CompilationMode::Infer, F1);
 
   // Run graph to capture profile.
@@ -941,7 +941,7 @@ TEST_P(Operator, end2endGRU) {
 
   LoweredInfoMap loweredMapForProf;
   lower(F1, &loweredMapForProf);
-  F1 = glow::profileQuantization(bindings, F1);
+  glow::profileQuantization(bindings, F1);
   profileEE.compile(CompilationMode::Infer, F1);
 
   // Run graph to capture profile.
@@ -1950,7 +1950,7 @@ static void testProfileQuantizationOfFC(bool expectLoweredFC,
   auto outputNameBA = NodeQuantizationInfo::generateNodeOutputName(
       loweredBA->getName(), BatchedAddNode::ResultIdx);
 
-  profileF = glow::profileQuantization(profilebindings, profileF);
+  glow::profileQuantization(profilebindings, profileF);
 
   // Compile/run to capture profile.
   profileEE.compile(CompilationMode::Infer, profileF);

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -292,7 +292,7 @@ void Loader::compile(PlaceholderBindings &bindings) {
             doNotLowerNodesForProfiling);
 
     // Instrument the graph to capture profiles for nodes' outputs.
-    F_ = ::profileQuantization(bindings, F_);
+    ::profileQuantization(bindings, F_);
   }
 
   // By default, when converting models, all nodes that can be

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -321,27 +321,14 @@ void Loader::compile(PlaceholderBindings &bindings) {
     quantization::QuantizationConfiguration quantConfig{
         deserializeFromYaml(loadProfileFileOpt)};
 
-    // In AOT compilation mode the name of the symbol depends on the name of the
-    // function. Our tutorial expects the quantized name to be identical to the
-    // original name, so we rename the floating-point network and give the
-    // quantized network a new name.
-    quantConfig.newFuncName = F_->getName();
-    F_->setName("old");
-
     // Quantize the graph based on the captured profile.
     quantConfig.precision = quantizationPrecision;
     quantConfig.schema = quantizationSchema;
     quantConfig.enableRowwise = enableRowwiseOpt;
     quantConfig.assertAllNodesQuantized = assertAllNodesQuantizedOpt;
 
-    auto *Q = quantization::quantizeFunction(F_, quantConfig, *EE_.getBackend(),
-                                             loweredMap_,
-                                             keepOriginalPrecisionForNodes);
-
-    // Erase the original function so that the redundant variables that are only
-    // referenced by the original function will be removed.
-    Q->getParent()->eraseFunction(F_);
-    F_ = Q;
+    quantization::quantizeFunction(F_, quantConfig, *EE_.getBackend(),
+                                   loweredMap_, keepOriginalPrecisionForNodes);
   }
 
   if (convertToFP16) {


### PR DESCRIPTION
*Description*: As discussed in #2700, this removes cloning the function for quantization and profiling. If the caller wants the original function after quantization/profiling it should clone the function prior to calling `quantizeFunction()`/`profileQuantization()`.

*Testing*: All tests still pass.
