### PR TITLE
    [OpenCL] Add OpenCL implementation of SparseLengthsWeightedSumGrad

### DIFF
--- a/tests/unittests/MLTest.cpp
+++ b/tests/unittests/MLTest.cpp
@@ -1405,7 +1405,7 @@ TEST_P(MLTest, matrixRotationRecognition) {
 
 /// Simple test case that learns the embedding table for a
 /// SparseLengthsWeightedSum operator.
-TEST_P(InterpreterAndCPU, learnSparseLengthsWeightedSum) {
+TEST_P(MLTest, learnSparseLengthsWeightedSum) {
   TrainingConfig TC;
   TC.learningRate = 0.3;
   TC.batchSize = 1;


### PR DESCRIPTION
**Description**
This commit adds an OpenCL implementation of `SparseLengthsWeightedSumGrad`. This implementation is identical to the CPU backend implementation. It is difficult to parallelize this operation without giving each global ID its own copy of the dataGrad buffer and adding together the copies at the end. As a result, this has been left as a future work item.
    
**Testing**
This commit enables `learnSparseLengthsWeightedSum` for the OpenCL backend in MLTest and it passes.

```
...
[ RUN      ] OpenCL/MLTest.learnSparseLengthsWeightedSum/0
[       OK ] OpenCL/MLTest.learnSparseLengthsWeightedSum/0 (338 ms)
...
```