### PR TITLE
Changed loader to use HostManager rather than ExecutionEngine.

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -181,7 +181,7 @@ public:
   /// Erase all the functions, variables, etc.
   void clear();
 
-  /// Strips payloads from constants and deletes functions. This is useful when
+  /// Strips payloads from constants. This is useful when
   /// the Module will be kept around for metadata but we want to reduce memory
   /// use. Unlike clear this leaves PHs and Constants in the module.
   void strip();

--- a/include/glow/Runtime/HostManager/HostManager.h
+++ b/include/glow/Runtime/HostManager/HostManager.h
@@ -91,9 +91,10 @@ public:
   /// operation. This function consumes the \p module so any pointers to data
   /// contained within the module should be considered invalid. If \p
   /// saturateHost is set to true the HostManager will try to use all available
-  /// devices on the host.
+  /// devices on the host. If \p profiling is true,the HostManager will check
+  /// that each function is not partitioned.
   llvm::Error addNetwork(std::unique_ptr<Module> module,
-                         bool saturateHost = false);
+                         bool saturateHost = false, bool profiling = false);
 
   /// Given \p networkName removes that network from the host. This also
   /// removes the network from any backends setup to execute it.
@@ -115,6 +116,13 @@ public:
   RunIdentifierTy runNetwork(llvm::StringRef networkName,
                              std::unique_ptr<ExecutionContext> context,
                              ResultCBTy callback);
+
+  /// A wrapper around runNetwork that provides a blocking interface for an
+  /// inference request. Runs the network provided in \p networkName using \p
+  /// bindings for placeholder bindings. \returns an llvm::Error indicating
+  /// success or failure.
+  llvm::Error runNetworkBlocking(llvm::StringRef networkName,
+                                 PlaceholderBindings &bindings);
   HostManager(std::vector<std::unique_ptr<DeviceConfig>> configs);
 
   /// Initialize the HostManager with the given \p configs creating one

--- a/lib/Backends/Interpreter/InterpreterDeviceManager.h
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.h
@@ -41,7 +41,7 @@ class InterpreterDeviceManager : public QueueBackedDeviceManager {
 
 public:
   InterpreterDeviceManager(std::unique_ptr<DeviceConfig> config = nullptr,
-                           size_t maxMemory = 1000)
+                           size_t maxMemory = 2000000000)
       : QueueBackedDeviceManager(BackendKind::Interpreter, std::move(config)),
         maxMemoryBytes_(maxMemory) {}
 

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -55,7 +55,6 @@ Function *Module::createFunction(llvm::StringRef name) {
 }
 
 void Module::strip() {
-  eraseFunctions();
   for (auto it = constants_.begin(), e = constants_.end(); it != e; it++) {
     Constant *v = *it;
     v->clearPayload();

--- a/tools/loader/CMakeLists.txt
+++ b/tools/loader/CMakeLists.txt
@@ -4,9 +4,11 @@ add_executable(image-classifier
 
 target_link_libraries(image-classifier
                       PRIVATE
+                        Backends
                         Base
                         Converter
                         ExecutionEngine
+                        HostManager
                         Graph
                         Importer
                         Optimizer
@@ -19,9 +21,11 @@ add_executable(text-translator
 
 target_link_libraries(text-translator
                       PRIVATE
+                        Backends
                         Base
                         Converter
                         Graph
+                        HostManager
                         Importer
                         ExecutionEngine
                         Optimizer
@@ -34,9 +38,11 @@ add_executable(model-runner
 
 target_link_libraries(model-runner
                       PRIVATE
+                        Backends
                         Base
                         Converter
                         Graph
+                        HostManager
                         Importer
                         ExecutionEngine
                         Optimizer

--- a/tools/loader/Loader.h
+++ b/tools/loader/Loader.h
@@ -17,6 +17,7 @@
 #define GLOW_TOOLS_LOADER_LOADER_H
 
 #include "glow/ExecutionEngine/ExecutionEngine.h"
+#include "glow/Runtime/HostManager/HostManager.h"
 
 namespace glow {
 
@@ -37,10 +38,14 @@ class Loader {
   std::string caffe2NetWeightFilename_;
   /// ONNX model file name.
   std::string onnxModelFilename_;
-  /// Execution engine for compiling and running.
-  ExecutionEngine EE_{};
+  /// Host Manager for running the model.
+  std::unique_ptr<glow::runtime::HostManager> hostManager_;
+  /// Backend used for saving bundle and quantization.
+  glow::Backend *backend_;
   /// Function containing the model.
   Function *F_{nullptr};
+  /// Module
+  std::unique_ptr<Module> M_;
   /// A map between quantization profiling names of NodeValues that were lowered
   /// from each other. Maps to a set of names of NodeValues and their NodeKinds
   /// that were replaced by the NodeValue (whose output name is the key) that
@@ -48,9 +53,11 @@ class Loader {
   LoweredInfoMap loweredMap_;
 
 public:
-  /// Getter for the Function.
+  /// Getter for the Function. This should not be called after compile since the
+  /// compile process is destructive on the original function.
   Function *getFunction() { return F_; }
-  /// Getter for the Module.
+  /// Getter for the Module. This should not be called after compile since the
+  /// compile process is destructive on the original function and module.
   Module *getModule() { return F_->getParent(); }
   /// Getter for the Caffe2 network file name.
   llvm::StringRef getCaffe2NetDescFilename() { return caffe2NetDescFilename_; }


### PR DESCRIPTION
*Description*: This migrated loader (used in image-classifier) to use HostManager rather than ExecutionEngine. This means that image-classifier now executes through the new runtime.
*Testing*: Ninja test, tested image-classifier on resnet50 manually for cpu, interpreter, and OpenCL. Tested quantization. All tests in run.sh also pass.
*Documentation*: NA
