### PR TITLE
Add HostManager check that all nodes are supported after optimization

### DIFF
--- a/examples/tracing-compare.cpp
+++ b/examples/tracing-compare.cpp
@@ -82,7 +82,7 @@ std::unique_ptr<CompiledFunction> compileModel(Module &module,
   CompilationContext cctx;
   cctx.mode = CompilationMode::Infer;
   cctx.backendOpts.autoInstrument = true;
-  ::glow::optimizeFunction(F_, *backend, cctx);
+  EXIT_ON_ERR(::glow::optimizeFunction(F_, *backend, cctx));
   return backend->compile(F_, cctx.backendOpts);
 }
 

--- a/include/glow/Optimizer/Optimizer.h
+++ b/include/glow/Optimizer/Optimizer.h
@@ -17,6 +17,7 @@
 #define GLOW_OPTIMIZER_OPTIMIZER_H
 
 #include "glow/Optimizer/CompilationContext.h"
+#include "glow/Support/Error.h"
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
@@ -72,8 +73,10 @@ std::unique_ptr<IRFunction> generateAndOptimizeIR(Function *F, const Backend &B,
                                                   bool shouldShareBuffers);
 
 /// Optimize the Function \p F given compilation options \p cctx for Backend \B.
-void optimizeFunction(Function *F, const Backend &B,
-                      const CompilationContext &cctx);
+/// \returns success if all nodes in the final resulting optimized Function are
+/// supported by \p B; if not, this represents a compiler error.
+llvm::Error optimizeFunction(Function *F, const Backend &B,
+                             const CompilationContext &cctx);
 
 } // namespace glow
 

--- a/include/glow/Support/Error.h
+++ b/include/glow/Support/Error.h
@@ -77,6 +77,8 @@ public:
     RUNTIME_REQUEST_REFUSED,
     // Runtime error, device wasn't found.
     RUNTIME_DEVICE_NOT_FOUND,
+    // Compilation error; node unsupported after optimizations.
+    COMPILE_UNSUPPORTED_NODE_AFTER_OPTIMIZE,
   };
 
   /// GlowErr is not convertable to std::error_code. This is included for
@@ -142,6 +144,8 @@ private:
       return "RUNTIME_REQUEST_REFUSED";
     case ErrorCode::RUNTIME_DEVICE_NOT_FOUND:
       return "RUNTIME_DEVICE_NOT_FOUND";
+    case ErrorCode::COMPILE_UNSUPPORTED_NODE_AFTER_OPTIMIZE:
+      return "COMPILE_UNSUPPORTED_NODE_AFTER_OPTIMIZE";
     };
 
     llvm_unreachable("unsupported ErrorCode");

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -252,7 +252,7 @@ void ExecutionEngine::compile(Function *F, const CompilationContext &cctx,
   assert(!compiledFunctions_.count(name) &&
          "A function with this name has already been compiled.");
 
-  ::glow::optimizeFunction(F, *backend_, cctx);
+  EXIT_ON_ERR(::glow::optimizeFunction(F, *backend_, cctx));
 
   for (const Node &N : F->getNodes()) {
     (void)N;
@@ -267,6 +267,6 @@ void ExecutionEngine::compile(Function *F, const CompilationContext &cctx,
 void ExecutionEngine::save(Function *F, const CompilationContext &cctx,
                            llvm::StringRef outputDir,
                            llvm::StringRef networkName) {
-  ::glow::optimizeFunction(F, *backend_, cctx);
+  EXIT_ON_ERR(::glow::optimizeFunction(F, *backend_, cctx));
   backend_->save(F, outputDir, networkName);
 }

--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -2640,8 +2640,28 @@ void glow::optimize(Function *F, CompilationMode mode) {
   optimize(F, cctx);
 }
 
-void glow::optimizeFunction(Function *F, const Backend &B,
-                            const CompilationContext &cctx) {
+/// \returns an error if any nodes inside \p F are not supported by \p B.
+static llvm::Error checkAllNodesSupported(const Function &F, const Backend &B) {
+  bool allSupported = true;
+  for (const Node &N : F.getNodes()) {
+    if (!B.isOpSupported(N)) {
+      allSupported = false;
+      report("Unsupported node found while compiling Function " +
+             F.getName().str() + " for backend " + B.getBackendName() + ": " +
+             N.getDebugDesc());
+    }
+  }
+  if (!allSupported) {
+    return MAKE_ERR(GlowErr::ErrorCode::COMPILE_UNSUPPORTED_NODE_AFTER_OPTIMIZE,
+                    "Unsupported node(s) found after optimizing Function " +
+                        F.getName().str() + " for backend " +
+                        B.getBackendName());
+  }
+  return llvm::Error::success();
+}
+
+llvm::Error glow::optimizeFunction(Function *F, const Backend &B,
+                                   const CompilationContext &cctx) {
   // Verify the function pre-optimization/lowering.
   assert(F->verify() && "Function must be valid");
 
@@ -2660,4 +2680,6 @@ void glow::optimizeFunction(Function *F, const Backend &B,
     // In particular, DCE is very likely to be useful.
     ::glow::optimize(F, cctx);
   }
+
+  return checkAllNodesSupported(*F, B);
 }

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -63,19 +63,6 @@ HostManager::init(std::vector<std::unique_ptr<DeviceConfig>> configs) {
 
 HostManager::~HostManager() { llvm::toString(clearHost()); }
 
-/// \returns an error if any nodes inside \p F are not supported by \p B.
-static llvm::Error checkAllNodesSupported(Function &F, Backend &B) {
-  for (const Node &N : F.getNodes()) {
-    if (!B.isOpSupported(N)) {
-      return MAKE_ERR(
-          GlowErr::ErrorCode::COMPILE_UNSUPPORTED_NODE_AFTER_OPTIMIZE,
-          "Error while compiling a node from Function " + F.getName().str() +
-              ": " + N.getDebugDesc());
-    }
-  }
-  return llvm::Error::success();
-}
-
 llvm::Error HostManager::addNetwork(std::unique_ptr<Module> module,
                                     bool saturateHost) {
   std::lock_guard<std::mutex> networkLock(networkLock_);
@@ -101,8 +88,7 @@ llvm::Error HostManager::addNetwork(std::unique_ptr<Module> module,
     CompilationContext cctx;
     cctx.mode = CompilationMode::Infer;
     for (auto F : module->getFunctions()) {
-      ::glow::optimizeFunction(F, *backend_, cctx);
-      RETURN_IF_ERR(checkAllNodesSupported(*F, *backend_));
+      RETURN_IF_ERR(::glow::optimizeFunction(F, *backend_, cctx));
     }
   }
   auto partitioner = Partitioner(module.get(), deviceInfo, saturateHost);

--- a/tests/benchmark/RuntimeBench.cpp
+++ b/tests/benchmark/RuntimeBench.cpp
@@ -123,7 +123,7 @@ void setUpDeviceManagerCommon(
 
   // Compile all functions in the module.
   for (auto *function : mod->getFunctions()) {
-    ::glow::optimizeFunction(function, *backend, cctx);
+    EXIT_ON_ERR(::glow::optimizeFunction(function, *backend, cctx));
     std::unique_ptr<CompiledFunction> compiledFunction =
         backend->compile(function);
     funcs.insert(std::make_pair(function->getName(), compiledFunction.get()));

--- a/tests/unittests/DeviceManagerTest.cpp
+++ b/tests/unittests/DeviceManagerTest.cpp
@@ -58,7 +58,7 @@ compileFunctions(BackendKind backendKind, Module *module,
   CompilationContext cctx;
   cctx.mode = CompilationMode::Infer;
   for (auto *F : module->getFunctions()) {
-    ::glow::optimizeFunction(F, *backend, cctx);
+    EXIT_ON_ERR(::glow::optimizeFunction(F, *backend, cctx));
     auto f = backend->compile(F, cctx.backendOpts);
     backing.push_back(std::move(f));
     results.emplace(F->getName(), backing.back().get());

--- a/tests/unittests/HabanaBackendTest.cpp
+++ b/tests/unittests/HabanaBackendTest.cpp
@@ -1495,7 +1495,7 @@ TEST_F(HabanaBackendTest, SingleFunctionMultiThreadMultiDevice) {
   auto backend = std::unique_ptr<Backend>(createBackend(BackendKind::Habana));
   CompilationContext cctx;
   cctx.mode = CompilationMode::Infer;
-  ::glow::optimizeFunction(F_, *backend, cctx);
+  EXIT_ON_ERR(::glow::optimizeFunction(F_, *backend, cctx));
   auto compiledFunction = backend->compile(F_, cctx.backendOpts);
   functions.emplace(F_->getName(), compiledFunction.get());
 

--- a/tests/unittests/TraceEventsTest.cpp
+++ b/tests/unittests/TraceEventsTest.cpp
@@ -268,7 +268,7 @@ TEST_P(TraceEventsTest, automaticInstrumentation) {
   CompilationContext cctx;
   cctx.mode = CompilationMode::Infer;
   cctx.backendOpts.autoInstrument = true;
-  ::glow::optimizeFunction(F, *backend, cctx);
+  EXIT_ON_ERR(::glow::optimizeFunction(F, *backend, cctx));
   EE_.insertCompiledFunction(F->getName(),
                              backend->compile(F, cctx.backendOpts));
 
@@ -308,7 +308,7 @@ TEST_P(TraceEventsTest, manualAndAutomatic) {
   CompilationContext cctx;
   cctx.mode = CompilationMode::Infer;
   cctx.backendOpts.autoInstrument = true;
-  ::glow::optimizeFunction(F, *backend, cctx);
+  EXIT_ON_ERR(::glow::optimizeFunction(F, *backend, cctx));
   EE_.insertCompiledFunction(F->getName(),
                              backend->compile(F, cctx.backendOpts));
 
@@ -358,7 +358,7 @@ TEST_P(TraceEventsTest, twoCompiles) {
   CompilationContext cctx;
   cctx.mode = CompilationMode::Infer;
   cctx.backendOpts.autoInstrument = true;
-  ::glow::optimizeFunction(F, *backend, cctx);
+  EXIT_ON_ERR(::glow::optimizeFunction(F, *backend, cctx));
 
   std::string name = F->getName();
   EE_.insertCompiledFunction(name, backend->compile(F, cctx.backendOpts));


### PR DESCRIPTION
*Description*: This is something we do in the ExecutionEngine. We should also check it somewhere in the HostManager, especially as PRs like #2799 move to using HostManager instead. This error represents some internal compilation error during optimizeFunction.

*Testing*: All unit tests pass.
