### PR TITLE
[C2 loader] Make sure that node ordering persists for loaded C2 models.

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -228,6 +228,15 @@ public:
 
   Module *getParent() { return parent_; }
 
+  /// Perform ordering of nodes_ based on node's name.
+  /// This is to make sure that performing optimizations have a deterministic
+  /// behavior on the graphs which have the same ops but different ordering in
+  /// nodes_.
+  void orderNodes() {
+    nodes_.sort(
+        [](const Node &a, const Node &b) { return a.getName() < b.getName(); });
+  }
+
   /// Search the Module containing the function to gather and return a list of
   /// placeholders that are used by the Function.
   PlaceholderList findPlaceholders();

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -1473,6 +1473,10 @@ Caffe2ModelLoader::Caffe2ModelLoader(const std::string &netDescFilename,
     RETURN_IF_ERR(loadWeightsFromNet(weightsDef));
     RETURN_IF_ERR(loadNetwork(networkDef));
 
+    // This is to ensure that the same processing done with
+    // the same network, even if order of operators is different.
+    F.orderNodes();
+
     RETURN_ERR_IF_NOT(F.verify(), "Function verification failed.");
 
     return llvm::Error::success();

--- a/lib/Importer/ONNXIFIModelLoader.cpp
+++ b/lib/Importer/ONNXIFIModelLoader.cpp
@@ -81,6 +81,10 @@ llvm::Expected<std::unique_ptr<ONNXIFIModelLoader>> ONNXIFIModelLoader::parse(
     // loadNetwork, maybe we should make it a separate function?
     RETURN_IF_ERR(c2Loader->loadNetwork(networkDef));
 
+    // This is to ensure that the same processing done with
+    // the same network, even if order of operators is different.
+    F.orderNodes();
+
     loader->onnxNameToInputVars_ = c2Loader->getInputVarsMapping();
 
     // Keep hold of the context


### PR DESCRIPTION
*Description*:
In the context of hand crafted partitions we need to make sure that C2 graphs coming to Glow will be deterministic through the optimization phase.

This PR sorts nodes by name ensuring same traversal order for same C2 graphs, even if nodes are supplied in a different order.

*Testing*:
Unit tests

*Documentation*:
n/a
