### PR TITLE
[importer] Detect legacy (Caffe1) padding and exit.

### DIFF
--- a/tests/models/caffe2Models/maxpool_legacy_padding_predict_net.pbtxt
+++ b/tests/models/caffe2Models/maxpool_legacy_padding_predict_net.pbtxt
@@ -17,7 +17,7 @@ op {
   }
   arg {
     name: "legacy_pad"
-    i: 0
+    i: 3
   }
 }
 external_output: "output"


### PR DESCRIPTION
*Description*:
Caffe1 legacy padding rounds the shape dimensions up for MaxPool
operators and Caffe2 rounds down.  According to Caffe2's
caffe2_legacy.proto definition, legacy padding is deprecated.

During graph generation, Glow might insert Caffe2 MaxPool nodes unaware
of the padding strategy.  If a MaxPool node is defined in the Caffe2
file, that follows the legacy strategy, we result in a model where some
MaxPool nodes will round their shapes up and others will round down.
Instead of introducing this confusion, we reject the deprecated logic in
favor of what we have always done, support non-legacy/Caffe2 padding.

See: https://github.com/pytorch/pytorch/blob/master/caffe2/proto/caffe2_legacy.proto

*Testing*:
`ninja test`  ... nothing should fail, in particular the OperatorTest should pass.
