### PR TITLE
[readme] Update the required llvm version from 5 to 7. NFC.

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ under "Command Line Tools".
 #### Building with dependencies (LLVM)
 
 By default, Glow will use a system provided LLVM.  Note that Glow requires LLVM
-5.0 or later. If you have LLVM installed in a non-default location (for
+7.0 or later. If you have LLVM installed in a non-default location (for
 example, if you installed it using Homebrew on macOS), you need to tell CMake
 where to find llvm using `-DLLVM_DIR`. For example, if LLVM were
 installed in `/usr/local/opt`:


### PR DESCRIPTION
*Description*:
The CMakeLists.txt file requires llvm 7.0 or higher to build Glow.  This patch
updates the version number in the README documentation to reflect the configuration file
constraint.  We should update the instructions in the  building
on Ubuntu 16.04 section too, as that still refers to llvm 6.0.  I was
uncomfortable modifying that section as I cannot test it as written on
my setup at the moment.
