### PR TITLE
[cmake] Disable OpenCL support by default.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ enable_testing()
 
 option(GLOW_WITH_CPU "Build the LLVM-based JIT CPU backend" ON)
 option(GLOW_WITH_LLVMIRCODEGEN "Build the LLVM-based code generation library" ON)
-option(GLOW_WITH_OPENCL "Build the OpenCL backend" ON)
+option(GLOW_WITH_OPENCL "Build the OpenCL backend" OFF)
 option(GLOW_WITH_HABANA "Build the Habana backend" OFF)
 option(GLOW_BUILD_EXAMPLES "Build the examples" ON)
 option(GLOW_BUILD_TESTS "Build the tests" ON)


### PR DESCRIPTION
*Description*:
This updated configuration matches the documentation at
https://github.com/pytorch/glow/blob/master/docs/Building.md
Notably, the line:
"By default Glow builds with only the interpreter backend enabled."

It was also mentioned that not everyone has OpenCL installed.  I think
it makes sense to not make OpenCL a requirement; however, I can also see
where it might be expected as a requirement.  I figured I'd at least put
this PR out for discussion.

*Testing*:
The unittests should still build and run correctly:
`ninja all && ninja test`

Fixes #2466 