### PR TITLE
[CMake] Don't link with CPUDeviceManager unless GLOW_WITH_CPU=ON

### DIFF
--- a/lib/Runtime/HostManager/CMakeLists.txt
+++ b/lib/Runtime/HostManager/CMakeLists.txt
@@ -10,5 +10,10 @@ target_link_libraries(HostManager
                         Partitioner
                         Provisioner
                         Executor
-                        DeviceManager
-                        CPUDeviceManager)
+                        DeviceManager)
+
+if (GLOW_WITH_CPU)
+  target_link_libraries(HostManager
+                        PRIVATE
+                          CPUDeviceManager)
+endif()


### PR DESCRIPTION
*Description*: Make glow build without the CPU backend which was previously impossible due to HostManager always being linked against CPUDeviceManager.
*Testing*: The build doesn't break, the basic backend tests seem fine.
*Documentation*:
[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
