### PR TITLE
[LLVMIRCodeGen] Minor improvements making LLVMIRCodeGen more customizable by backends

### DIFF
--- a/include/glow/LLVMIRCodeGen/LLVMBackend.h
+++ b/include/glow/LLVMIRCodeGen/LLVMBackend.h
@@ -31,9 +31,27 @@ class PlaceholderBindings;
 class LLVMIRGen;
 
 class LLVMBackend : public BackendUsingGlowIR {
-public:
-  LLVMBackend() = default;
+  /// Target used by this backend.
+  std::string target_;
+  /// Arch used by this backend.
+  std::string arch_;
+  /// Cpu used by this backend.
+  std::string cpu_;
 
+public:
+  LLVMBackend();
+  /// \returns target used by this backend.
+  llvm::StringRef getTarget() const { return target_; }
+  /// Sets target used by this backend.
+  void setTarget(llvm::StringRef target) { target_ = target; }
+  /// \returns arch used by this backend.
+  llvm::StringRef getArch() const { return arch_; }
+  /// Sets arch used by this backend.
+  void setArch(llvm::StringRef arch) { arch_ = arch; }
+  /// \returns cpu used by this backend.
+  llvm::StringRef getCPU() const { return cpu_; }
+  /// Sets cpu used by this backend.
+  void setCPU(llvm::StringRef cpu) { cpu_ = cpu; }
   /// @name Backend methods.
   /// This is the implementation of the Backend interface.
   ///@{

--- a/include/glow/LLVMIRCodeGen/LLVMIRGen.h
+++ b/include/glow/LLVMIRCodeGen/LLVMIRGen.h
@@ -322,6 +322,8 @@ public:
   virtual void markArgAsUnspecialized(llvm::Value *val);
   /// \returns bit-width of the target size_t.
   virtual unsigned getTargetSizeTWidth() const;
+  /// \returns true if a call is eligible for specialization.
+  virtual bool isEligibleForSpecialization(const llvm::CallInst *call);
   /// \returns true if a global symbol \p GV needs to be preserved in the module
   /// and not interalized during optimizations.
   virtual bool preserveSymbol(const llvm::GlobalValue &GV);

--- a/include/glow/LLVMIRCodeGen/LLVMIRGen.h
+++ b/include/glow/LLVMIRCodeGen/LLVMIRGen.h
@@ -322,6 +322,9 @@ public:
   virtual void markArgAsUnspecialized(llvm::Value *val);
   /// \returns bit-width of the target size_t.
   virtual unsigned getTargetSizeTWidth() const;
+  /// \returns true if a global symbol \p GV needs to be preserved in the module
+  /// and not interalized during optimizations.
+  virtual bool preserveSymbol(const llvm::GlobalValue &GV);
 };
 
 } // namespace glow

--- a/lib/LLVMIRCodeGen/FunctionSpecializer.cpp
+++ b/lib/LLVMIRCodeGen/FunctionSpecializer.cpp
@@ -254,6 +254,10 @@ class FunctionSpecializer {
     if (callee && callee->isDeclaration()) {
       return false;
     }
+    // Do not specialize calls if LLVMIRGen is against it.
+    if (!irgen_.isEligibleForSpecialization(call)) {
+      return false;
+    }
     // Do not specialize noinline functions, because it does not improve
     // anything.
     return callee != nullptr &&

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -2357,3 +2357,7 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
 unsigned LLVMIRGen::getTargetSizeTWidth() const {
   return getPointerNumBits(*TM_);
 }
+
+bool LLVMIRGen::isEligibleForSpecialization(const llvm::CallInst *call) {
+  return true;
+}


### PR DESCRIPTION
- Make it possible for backends to provide custom logicto decide which symbols need to be preserved during the LLVM's internalizeModule pass

  Some backends may have a custom logic for deciding which symbols need to be preserved.

- Provide APIs for setting target, arch and cpu properties of LLVMBackend

  Backends can now override these settings by setting these properties to appropriate, backend-specific values.

- Make it possible for backends to provide custom logic to decide which calls are eligible for specialization