### PR TITLE
Enable HostManagerTest for multiple backends

### DIFF
--- a/tests/unittests/HostManagerTest.cpp
+++ b/tests/unittests/HostManagerTest.cpp
@@ -27,15 +27,20 @@ using namespace glow::runtime;
 using DAGNodePairTy = std::pair<std::vector<std::unique_ptr<DAGNode>>,
                                 std::vector<std::unique_ptr<DAGNode>>>;
 
-class HostManagerTest : public ::testing::Test {};
+class HostManagerTest : public ::testing::TestWithParam<BackendKind> {
+public:
+  void SetUp() override { backendKind = GetParam(); }
+  BackendKind backendKind;
+};
+
 std::unique_ptr<Module> setupModule(unsigned functionCount) {
   std::unique_ptr<Module> module = llvm::make_unique<Module>();
   for (unsigned int i = 0; i < functionCount; i++) {
     Function *F = module->createFunction("function" + std::to_string(i));
     auto *X = module->createPlaceholder(ElemKind::FloatTy, {3},
                                         "X" + std::to_string(i), false);
-    auto *pow = F->createPow("Pow" + std::to_string(i), X, 2.0);
-    F->createSave("save" + std::to_string(i), pow);
+    auto *tanh = F->createTanh("tanh" + std::to_string(i), X);
+    F->createSave("save" + std::to_string(i), tanh);
   }
   return module;
 }
@@ -55,8 +60,8 @@ void addAndRemoveNetwork(HostManager *manager, unsigned int functionNumber) {
       module->createFunction("function" + std::to_string(functionNumber));
   auto *X = module->createPlaceholder(
       ElemKind::FloatTy, {3}, "X" + std::to_string(functionNumber), false);
-  auto *pow = F->createPow("Pow" + std::to_string(functionNumber), X, 2.0);
-  F->createSave("save" + std::to_string(functionNumber), pow);
+  auto *tanh = F->createTanh("Tanh" + std::to_string(functionNumber), X);
+  F->createSave("save" + std::to_string(functionNumber), tanh);
 
   // Expect this to be an Error because multiple networks with the same name
   // have been added to HostManager
@@ -64,15 +69,15 @@ void addAndRemoveNetwork(HostManager *manager, unsigned int functionNumber) {
   manager->removeNetwork("function" + std::to_string(functionNumber));
 }
 
-TEST_F(HostManagerTest, newHostManager) { createHostManager(BackendKind::CPU); }
+TEST_P(HostManagerTest, newHostManager) { createHostManager(backendKind); }
 
-TEST_F(HostManagerTest, addNetwork) {
+TEST_P(HostManagerTest, addNetwork) {
   auto module = setupModule(6);
-  auto hostManager = createHostManager(BackendKind::CPU);
+  auto hostManager = createHostManager(backendKind);
   ASSERT_FALSE(errToBool(hostManager->addNetwork(std::move(module))));
 }
 
-TEST_F(HostManagerTest, runNetwork) {
+TEST_P(HostManagerTest, runNetwork) {
   std::unique_ptr<Module> module = llvm::make_unique<Module>();
   std::unique_ptr<ExecutionContext> context =
       llvm::make_unique<ExecutionContext>();
@@ -81,12 +86,12 @@ TEST_F(HostManagerTest, runNetwork) {
   auto *X = module->createPlaceholder(ElemKind::FloatTy, {3}, "X", false);
   auto *XTensor = context->getPlaceholderBindings()->allocate(X);
   XTensor->getHandle() = {1., 2., 3.};
-  auto *pow = F->createPow("Pow1", X, 2.0);
-  auto *save = F->createSave("save", pow);
+  auto *tanh = F->createTanh("Tanh1", X);
+  auto *save = F->createSave("save", tanh);
   auto *saveTensor =
       context->getPlaceholderBindings()->allocate(save->getPlaceholder());
 
-  auto hostManager = createHostManager(BackendKind::CPU);
+  auto hostManager = createHostManager(backendKind);
   ASSERT_FALSE(errToBool(hostManager->addNetwork(std::move(module))));
 
   std::promise<void> runNetwork;
@@ -99,9 +104,9 @@ TEST_F(HostManagerTest, runNetwork) {
                               RunIdentifierTy runID, llvm::Error err,
                               std::unique_ptr<ExecutionContext> context_) {
                             auto HX = saveTensor->getHandle();
-                            EXPECT_NEAR(HX.at({0}), 1, 1E-5);
-                            EXPECT_NEAR(HX.at({1}), 4, 1E-5);
-                            EXPECT_NEAR(HX.at({2}), 9, 1E-5);
+                            EXPECT_NEAR(HX.at({0}), std::tanh(1), 1E-5);
+                            EXPECT_NEAR(HX.at({1}), std::tanh(2), 1E-5);
+                            EXPECT_NEAR(HX.at({2}), std::tanh(3), 1E-5);
                             context = std::move(context_);
                             runErr = std::move(err);
                             runNetwork.set_value();
@@ -120,9 +125,9 @@ TEST_F(HostManagerTest, runNetwork) {
                               RunIdentifierTy runID, llvm::Error err,
                               std::unique_ptr<ExecutionContext> context_) {
                             auto HX = saveTensor->getHandle();
-                            EXPECT_NEAR(HX.at({0}), 1, 1E-5);
-                            EXPECT_NEAR(HX.at({1}), 4, 1E-5);
-                            EXPECT_NEAR(HX.at({2}), 9, 1E-5);
+                            EXPECT_NEAR(HX.at({0}), std::tanh(1), 1E-5);
+                            EXPECT_NEAR(HX.at({1}), std::tanh(2), 1E-5);
+                            EXPECT_NEAR(HX.at({2}), std::tanh(3), 1E-5);
                             runErr = std::move(err);
                             newRun.set_value();
                           });
@@ -133,10 +138,10 @@ TEST_F(HostManagerTest, runNetwork) {
 
 /// Test that HostManager properly handles concurrent add/remove requests with
 /// unique network names.
-TEST_F(HostManagerTest, ConcurrentAddRemoveUnique) {
+TEST_P(HostManagerTest, ConcurrentAddRemoveUnique) {
   constexpr auto numThreads = 6;
   constexpr auto numItersPerThread = 20;
-  auto hostManager = createHostManager(BackendKind::CPU);
+  auto hostManager = createHostManager(backendKind);
   std::atomic<unsigned> counter{0};
   std::vector<std::thread> threads;
   for (auto i = 0; i < numThreads; ++i) {
@@ -154,10 +159,10 @@ TEST_F(HostManagerTest, ConcurrentAddRemoveUnique) {
 
 /// Test that HostManager properly handles concurrent add/remove requests with a
 /// duplicate network name.
-TEST_F(HostManagerTest, ConcurrentAddRemoveDuplicate) {
+TEST_P(HostManagerTest, ConcurrentAddRemoveDuplicate) {
   constexpr auto numThreads = 6;
   constexpr auto numItersPerThread = 20;
-  auto hostManager = createHostManager(BackendKind::CPU);
+  auto hostManager = createHostManager(backendKind);
   std::vector<std::thread> threads;
   for (auto i = 0; i < numThreads; ++i) {
     threads.emplace_back([&]() {
@@ -171,3 +176,21 @@ TEST_F(HostManagerTest, ConcurrentAddRemoveDuplicate) {
     t.join();
   }
 }
+
+INSTANTIATE_TEST_CASE_P(Interpreter, HostManagerTest,
+                        ::testing::Values(BackendKind::Interpreter));
+
+#ifdef GLOW_WITH_CPU
+INSTANTIATE_TEST_CASE_P(CPU, HostManagerTest,
+                        ::testing::Values(BackendKind::CPU));
+#endif // GLOW_WITH_CPU
+
+#ifdef GLOW_WITH_OPENCL
+INSTANTIATE_TEST_CASE_P(OpenCL, HostManagerTest,
+                        ::testing::Values(BackendKind::OpenCL));
+#endif // GLOW_WITH_OPENCL
+
+#ifdef GLOW_WITH_HABANA
+INSTANTIATE_TEST_CASE_P(Habana, HostManagerTest,
+                        ::testing::Values(BackendKind::Habana));
+#endif // GLOW_WITH_HABANA


### PR DESCRIPTION
*Description*:

Replace pow with tanh so the test can be enabled for different backends.

*Testing*:

ninja all && ninja test

(This will fail for opencl if you don't have that setup. But #2808 will address that)

