### PR TITLE
[Operators] Add weight gradient for SparseLengthsWeightedSum

### DIFF
--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -1278,7 +1278,10 @@ void OpenCLFunction::execute(ExecutionContext *context) {
       fillBuffer(deviceBuffer_, runtimeBundle_.getValueOffset(dataGrad),
                  dataGrad->size(), 0, dataGrad->getElementType());
 
-      // Enqueue the kernel.
+      // Enqueue the kernel. Set the global size to 1 so that all segments are
+      // processed sequentially to avoid two kernel instances accumulating into
+      // the same data gradient slice. This could potentially be relaxed by
+      // using an atomic add in the kernel.
       enqueueKernel(I.getName(), commands_, kernel, deviceId_, {1},
                     kernelLaunches_);
       continue;

--- a/lib/IR/IRGen.cpp
+++ b/lib/IR/IRGen.cpp
@@ -389,19 +389,23 @@ void IRGenVisitor::post(Node *parent, Node *N) {
   case glow::Kinded::Kind::SparseLengthsWeightedSumGradNodeKind: {
     auto *SLWSG = cast<SparseLengthsWeightedSumGradNode>(N);
 
+    auto *data = valueForNode(SLWSG->getData());
     auto *weights = valueForNode(SLWSG->getWeights());
     auto *indices = valueForNode(SLWSG->getIndices());
     auto *lengths = valueForNode(SLWSG->getLengths());
 
     auto *destGrad = valueForNode(SLWSG->getGradOfOriginalOutputNamedResult());
-
     auto *dataGrad = builder_.createAllocActivationInst(
         "slws.data.G", SLWSG->getGradOfInputNamedData().getType());
+    auto *weightsGrad = builder_.createAllocActivationInst(
+        "slws.weights.G", SLWSG->getGradOfInputNamedWeights().getType());
 
-    builder_.createSparseLengthsWeightedSumGradInst(
-        N->getName(), weights, indices, lengths, destGrad, dataGrad);
+    builder_.createSparseLengthsWeightedSumGradInst(N->getName(), data, weights,
+                                                    indices, lengths, destGrad,
+                                                    dataGrad, weightsGrad);
 
     registerIR(SLWSG->getGradOfInputNamedData(), dataGrad);
+    registerIR(SLWSG->getGradOfInputNamedWeights(), weightsGrad);
     break;
   }
   }

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -2224,11 +2224,15 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     auto *SI = cast<SparseLengthsWeightedSumGradInst>(I);
     auto *destGrad = SI->getDestGrad();
     auto *dataGrad = SI->getDataGrad();
+    auto *weightsGrad = SI->getWeightsGrad();
+    auto *data = SI->getData();
     auto *weights = SI->getWeights();
     auto *indices = SI->getIndices();
     auto *lengths = SI->getLengths();
     auto *destGradPtr = emitValueAddress(builder, destGrad);
     auto *dataGradPtr = emitValueAddress(builder, dataGrad);
+    auto *weightsGradPtr = emitValueAddress(builder, weightsGrad);
+    auto *dataPtr = emitValueAddress(builder, data);
     auto *weightsPtr = emitValueAddress(builder, weights);
     auto *indicesPtr = emitValueAddress(builder, indices);
     auto *lengthsPtr = emitValueAddress(builder, lengths);
@@ -2240,8 +2244,8 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     auto *F = getFunction("sparse_lengths_weighted_sum_grad",
                           destGrad->getElementType());
     createCall(builder, F,
-               {destGradPtr, dataGradPtr, weightsPtr, indicesPtr, lengthsPtr,
-                segments, lineSize, dataGradRawSize});
+               {destGradPtr, dataGradPtr, weightsGradPtr, dataPtr, weightsPtr,
+                indicesPtr, lengthsPtr, segments, lineSize, dataGradRawSize});
     break;
   }
 

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -237,7 +237,8 @@ int main(int argc, char **argv) {
       .autoVerify(VerifyKind::SameElementType,
                   {"Lengths", "ElemKind::Int32ITy"})
       .autoVerify(VerifyKind::SameShape, {"Weights", "Indices"})
-      .addGradientInstr({"Weights", "Indices", "Lengths"}, {"Dest", "Data"});
+      .addGradientInstr({"Data", "Weights", "Indices", "Lengths"},
+                        {"Dest", "Data", "Weights"});
 
   BB.newInstr("RowwiseQuantizedSparseLengthsWeightedSum")
       .addOperand("Dest", OperandKind::Out)


### PR DESCRIPTION
**Description**
This commit adds support for computing the gradient for the weights
input of `SparseLengthsWeightedSum` for Interpreter, CPU and OpenCL
backends.

**Testing**
This commit adds a test to `MLTest` that is similar to the existing
`SparseLengthsWeightSum` training test, except that it trains the weights
instead of the embeddings.
