### PR TITLE
Add TraceEvents to Habana backend and simplify

### DIFF
--- a/lib/Backends/Habana/Habana.h
+++ b/lib/Backends/Habana/Habana.h
@@ -108,7 +108,7 @@ private:
   uint8_t *buffer_;
   /// The number of buffers in the pool.
   unsigned numBuffers_{kDefaultNumBuffers};
-  static constexpr unsigned kDefaultNumBuffers{3};
+  static constexpr unsigned kDefaultNumBuffers{10};
 
   /// Queue of HabanaIOBuffers and a mutex and condition variable for
   /// synchronized access.

--- a/lib/Backends/Habana/HabanaDeviceManager.h
+++ b/lib/Backends/Habana/HabanaDeviceManager.h
@@ -49,9 +49,9 @@ class HabanaDeviceManager : public DeviceManager {
   /// Thread pool for waiting on the results of executing functions.
   std::unique_ptr<ThreadPool> waitPool_;
   /// The default number of workers in run pool (overridable).
-  constexpr static unsigned kNumRunners = 3;
+  constexpr static unsigned kNumRunners = 1;
   /// The default number of workers in wait pool (overridable).
-  constexpr static unsigned kNumWaiters = 3;
+  constexpr static unsigned kNumWaiters = 1;
   /// The number of workers in run pool.
   unsigned numRunners_{kNumRunners};
   /// The number of workers in wait pool.


### PR DESCRIPTION
*Description*: Add in some more detailed trace events into the Habana function and simplify it's threading logic. Multiple Runner and Waiter threads in the HabanaDeviceManager aren't providing any advantage since it's serialized in the H runtime, so put them both down to 1.

This reduces cold start time of the device quite a bit (see below) due to optimistically activating the topology on model load.

before:
![image](https://user-images.githubusercontent.com/701287/56939534-c2bc6300-6abd-11e9-8381-856ca650b970.png)
after:
![image](https://user-images.githubusercontent.com/701287/56939554-d9fb5080-6abd-11e9-8398-beded1cdc56c.png)

*Testing*: manual test with a device
*Documentation*:

