### PR TITLE
Trivial Fix for llvm assert.

### DIFF
--- a/lib/Backends/CPU/CPUDeviceManager.cpp
+++ b/lib/Backends/CPU/CPUDeviceManager.cpp
@@ -19,7 +19,7 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/raw_ostream.h"
 
-static llvm::cl::OptionCategory CPUBackendCat("Glow CPU Backend Options");
+static llvm::cl::OptionCategory CPUBackendCat("Glow CPU DeviceManager Options");
 llvm::cl::opt<unsigned>
     cpuMaxMem("cpu-memory", llvm::cl::desc("CPU DeviceManager maximum memory"),
               llvm::cl::init(0), llvm::cl::cat(CPUBackendCat));


### PR DESCRIPTION
*Description*: There is name conflict when OptionCategory gets created between CPUDeviceManager.cpp and OptionCategory.cpp. The underlying llvm object is global.
*Testing*: UnitTests
*Documentation*:
[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
