### PR TITLE
[habana] Don't allocate buffers for intermediate tensors.

### DIFF
--- a/lib/Backends/Habana/Habana.cpp
+++ b/lib/Backends/Habana/Habana.cpp
@@ -145,8 +145,8 @@ public:
 
 /// Enum describing how the tensor will be used by the model.
 enum class IOType {
-  /// Infer the tensor's usage from the nodes using it.
-  Default,
+  /// Intermediate result between nodes.
+  Intermediate,
   /// Tensor is a model input.
   Input,
   /// Tensor is a model output.
@@ -179,11 +179,13 @@ public:
 
   /// Constructor. Create a tensor from Glow IR Value \p V.
   TensorHandle(TypeRef V, llvm::StringRef name, void *buffer = nullptr,
-               IOType ioType = IOType::Default)
+               IOType ioType = IOType::Intermediate)
       : buffer_(buffer), name_(name) {
     if (!buffer_) {
       assert(V->getSizeInBytes());
-      buffer_ = malloc(V->getSizeInBytes());
+      assert(ioType != IOType::Static);
+      buffer_ = malloc(ioType == IOType::Intermediate ? sizeof(float)
+                                                      : V->getSizeInBytes());
       assert(buffer_);
       allocated_ = true;
     }
@@ -670,8 +672,8 @@ allocateGraphTensors(Function *F) {
       tensors.emplace(
           N, TensorHandle(V->getType(), V->getName(), nullptr, IOType::Output));
     } else {
-      tensors.emplace(V, TensorHandle(V->getType(), V->getName(), nullptr,
-                                      IOType::Default));
+      tensors.emplace(
+          V, TensorHandle(V->getType(), V->getName(), nullptr, IOType::Input));
     }
   }
 
@@ -686,7 +688,7 @@ allocateGraphTensors(Function *F) {
     }
     auto result = N.getNthResult(0);
     tensors.emplace(&N, TensorHandle(result.getType(), N.getName(), nullptr,
-                                     IOType::Default));
+                                     IOType::Intermediate));
   }
   return tensors;
 }


### PR DESCRIPTION
*Description*:
Intermediate tensors don't need to be materialized; their host data
pointers just serve as unique identifiers.  So instead of allocating a full
buffer, this diff mallocs a single float, which is an easy (if ever-so-slightly
kludgy) way to guarantee uniqueness.

*Testing*: HabanaBackendTest
