### PR TITLE
[LLVMIRCodeGen] Make LLVMIRCodeGen more cross-compilation friendly

### DIFF
--- a/include/glow/LLVMIRCodeGen/LLVMIRGen.h
+++ b/include/glow/LLVMIRCodeGen/LLVMIRGen.h
@@ -302,7 +302,7 @@ public:
   /// The module cannot be used by the LLVMIRGen afterwards.
   std::unique_ptr<llvm::Module> borrowModule() { return std::move(llmodule_); }
   /// \returns current LLVM module.
-  llvm::Module &getModule() { return *llmodule_; }
+  llvm::Module &getModule() const { return *llmodule_; }
   /// \returns the IR function.
   const IRFunction *getIRFunction() { return F_; }
   /// Set output directory for bundles, debug info files, etc.
@@ -322,6 +322,9 @@ public:
   virtual void markArgAsUnspecialized(llvm::Value *val);
   /// \returns bit-width of the target size_t.
   virtual unsigned getTargetSizeTWidth() const;
+  /// \returns the sizeof(size_t) of the actual target-specific size_t type that
+  /// was used to compile libjit into LLVM bitcode.
+  unsigned getLibjitSizeTWidth() const;
   /// \returns true if a call is eligible for specialization.
   virtual bool isEligibleForSpecialization(const llvm::CallInst *call);
   /// \returns true if a global symbol \p GV needs to be preserved in the module

--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -781,6 +781,10 @@ DEFINE_DATA_PARALLEL_KERNEL_QUANTIZED(libjit_elementmin_kernel_i8, int8_t,
 DEFINE_DATA_PARALLEL_KERNEL_QUANTIZED_M(libjit_element_mul_kernel_i8, lhs *rhs)
 DEFINE_DATA_PARALLEL_KERNEL_QUANTIZED_M(libjit_element_div_kernel_i8, lhs / rhs)
 
+/// This is a variable used by Glow backends to determine the actual type used
+/// for size_t when libjit was compiled.
+size_t libjit_sizeTVar;
+
 int8_t libjit_element_cmp_eq_kernel_u(size_t idx, const size_t *LHS,
                                       const size_t *RHS) {
   return LHS[idx] == RHS[idx] ? 1 : 0;


### PR DESCRIPTION
Determine the size of size_t from the actual libjit bitcode, rather than from the TargetMachine. This seems to be more reliable as libjit kernels are the ones being invoked and the type used by the codegen should exactly match whatever size_t type was used to compile libjit into LLVM bitcode.

Related to #2836 