### PR TITLE
Improve partitioner/provisioner error messages

### DIFF
--- a/lib/Partitioner/Partitioner.cpp
+++ b/lib/Partitioner/Partitioner.cpp
@@ -609,9 +609,13 @@ llvm::Error Partitioner::Partition() {
   // until the memory limitation reached one by one.
   NodeToFunctionMap partitionMap = selectPartitions(F_, availMem);
 
-  RETURN_ERR_IF_NOT(partitionMap.getPartitions().size() <= deviceInfo_.size(),
-                    "Partition failed: the number of given devices is fewer "
-                    "than the required minimal partitions.");
+  RETURN_ERR_IF_NOT(
+      partitionMap.getPartitions().size() <= deviceInfo_.size(),
+      llvm::formatv(
+          "Partition failed: the number of given devices ({0}) is fewer "
+          "than the required minimal partitions ({1}).",
+          deviceInfo_.size(), partitionMap.getPartitions().size())
+          .str());
 
   doPartitioning(F_, partitionMap);
 

--- a/lib/Runtime/Provisioner/Provisioner.cpp
+++ b/lib/Runtime/Provisioner/Provisioner.cpp
@@ -113,7 +113,11 @@ llvm::Error Provisioner::provision(DAGListTy &networks, Module &module) {
   // Try to add functions to devices in order from largest to smallest.
   for (unsigned i = 0; i < logicalDeviceSize.size(); i++) {
     RETURN_ERR_IF_NOT(logicalDeviceSize[i].second < deviceMemory[i].second,
-                      "Not enough memory to provision functions onto devices");
+                      llvm::formatv("Not enough memory to provision functions "
+                                    "onto devices. Need {0} bytes, have {1}.",
+                                    logicalDeviceSize[i].second,
+                                    deviceMemory[i].second)
+                          .str());
 
     // Load functions on device.
     DeviceIDTy logicalID = logicalDeviceSize[i].first;

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -416,6 +416,7 @@ if(GLOW_WITH_CPU)
                           IR
                           Provisioner
                           DeviceManager
+                          Optimizer
                           gtest
                           TestMain)
   add_glow_test(ProvisionerTest ${GLOW_BINARY_DIR}/tests/ProvisionerTest --gtest_output=xml:ProvisionerTest.xml)


### PR DESCRIPTION
*Description*:
It's useful to know the exact constraints causing the partitioner/provisioner to fail.
 
*Testing*:
PartitionerTest: Observe the improved error message.  Ahh, lovely.
ProvisionerTest: Add a failing case.  Made the net setup use FCs so they have enough weight to possibly fail.

*Documentation*:
Good error messages *are* documentation!
