### PR TITLE
Clarify DAGNode-related type names

### DIFF
--- a/include/glow/Runtime/RuntimeTypes.h
+++ b/include/glow/Runtime/RuntimeTypes.h
@@ -99,16 +99,17 @@ struct DAGNode {
 
 /// This struct represents a DAG. The first element is the root of a DAG, and
 /// the second one is a list of all rest nodes in this DAG.
-using rootDAGNodeTy = std::unique_ptr<DAGNode>;
-using nodesDAGNodeTy = std::vector<std::unique_ptr<DAGNode>>;
+using DAGNodePtr = std::unique_ptr<DAGNode>;
+using DAGNodePtrVec = std::vector<std::unique_ptr<DAGNode>>;
+
 struct DAG {
   /// This is a root node it does not map directly to a loaded function. It
   /// contains the name of the network, a list of children, and a reference to
   /// the Module the function came from.
-  rootDAGNodeTy root;
+  DAGNodePtr root;
   /// This is a vector of all the DAGNodes. Structure is encoded in the DAGNodes
   /// with pointers to parents and children.
-  nodesDAGNodeTy nodes;
+  DAGNodePtrVec nodes;
 };
 
 /// This list contains all the created DAGNodes from the Partitioner. The

--- a/lib/Partitioner/Partitioner.cpp
+++ b/lib/Partitioner/Partitioner.cpp
@@ -456,8 +456,8 @@ void Partitioner::saturateHost(unsigned logicalDeviceCount) {
 /// Current only partition the representative function.
 void Partitioner::doPartitioning(Function *F, NodeToFunctionMap &mapping) {
   // The dummy node.
-  rootDAGNodeTy DAGRoot = llvm::make_unique<DAGNode>();
-  nodesDAGNodeTy nodes;
+  DAGNodePtr DAGRoot = llvm::make_unique<DAGNode>();
+  DAGNodePtrVec nodes;
   DAGRoot->logicalDevices = {0};
   DAGRoot->name = F->getName();
   DAGRoot->module = module_;
@@ -587,7 +587,7 @@ llvm::Error Partitioner::Partition() {
       DAG1->name = F->getName();
       DAG1->parents.push_back(DAG0.get());
       DAG0->children.push_back(DAG1.get());
-      nodesDAGNodeTy nodes;
+      DAGNodePtrVec nodes;
       nodes.push_back(std::move(DAG1));
       partitions_.push_back({std::move(DAG0), std::move(nodes)});
     }

--- a/tests/unittests/ProvisionerTest.cpp
+++ b/tests/unittests/ProvisionerTest.cpp
@@ -38,7 +38,7 @@ DAGListTy setupDAG(unsigned rootCount, unsigned childCount) {
   DAGListTy partitions;
   unsigned currentFunction = 0;
   for (unsigned int root = 0; root < rootCount; root++) {
-    nodesDAGNodeTy nodes;
+    DAGNodePtrVec nodes;
     auto rootNode = llvm::make_unique<DAGNode>();
     auto firstNode = llvm::make_unique<DAGNode>();
     rootNode->name = "root" + std::to_string(root);


### PR DESCRIPTION
*Description*:
{root,nodes}DAGNodeTy don't follow our naming convention (begin with capital letter) and are kind of hard to understand without looking up the definitions.

*Testing*:
`ninja all`
