### PR TITLE
[tracing] Add TraceEvents to ONNXIFI and clean up naming

### DIFF
--- a/include/glow/Backends/TraceEvents.h
+++ b/include/glow/Backends/TraceEvents.h
@@ -207,6 +207,9 @@ public:
     ctx->logTraceEvent(name, type, ts);                                        \
   }
 
+/// Logs a new TraceEvent which begins and ends in the current scope block.
+#define TRACE_EVENT_SCOPE(ctx, name) ScopedTraceBlock __event__(ctx, name);
+
 /// Helper class which uses RAII for the start and end times of a TraceEvent.
 /// At creation will create a "begin" TraceEvent and at destuction (or end())
 /// will create an "end" TraceEvent.

--- a/lib/Backends/Habana/HabanaDeviceManager.cpp
+++ b/lib/Backends/Habana/HabanaDeviceManager.cpp
@@ -256,6 +256,7 @@ void HabanaDeviceManager::runFunctionImpl(RunIdentifierTy runId,
                                           std::string functionName,
                                           std::unique_ptr<ExecutionContext> ctx,
                                           runtime::ResultCBTy resultCB) {
+  TRACE_EVENT_SCOPE(ctx->getTraceContext(), "HabanaDM::runnerThread");
   // Try to find the function with the given name in functions_.
   uint64_t topologyId;
   HabanaFunction *function;
@@ -304,6 +305,7 @@ void HabanaDeviceManager::runFunctionImpl(RunIdentifierTy runId,
                      functionName = std::move(functionName),
                      ctx = std::move(ctx),
                      resultCB = std::move(resultCB)]() mutable {
+    TRACE_EVENT_SCOPE(ctx->getTraceContext(), "HabanaDM::waiterThread");
     TRACE_EVENT_BEGIN(ctx->getTraceContext(), "wait");
     auto &habanaHandle =
         static_cast<HabanaBindings *>(ctx->getDeviceBindings())->getHandle();

--- a/lib/Onnxifi/Base.h
+++ b/lib/Onnxifi/Base.h
@@ -139,7 +139,7 @@ public:
   /// Copy any trace events \p traceContext into \p traceEvents. If
   /// \p traceEvents is null then do nothing.
   static void setTraceEvents(onnxTraceEventList *traceEvents,
-                             const TraceContext &traceContext);
+                             TraceContext *traceContext);
 
   /// Free all memory that was allocated by setTraceEvents when creating \p
   /// traceEvents.

--- a/lib/Onnxifi/InlineOnnxifi.cpp
+++ b/lib/Onnxifi/InlineOnnxifi.cpp
@@ -95,7 +95,7 @@ InlineGraph::run(std::unique_ptr<ExecutionContext> ctx, EventPtr outputEvent,
   }
 
   if (auto *traceContext = ctx->getTraceContext()) {
-    setTraceEvents(traceEvents, *traceContext);
+    setTraceEvents(traceEvents, traceContext);
   }
 
   outputEvent->signal();

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -172,8 +172,7 @@ RunIdentifierTy
 HostManager::runNetwork(llvm::StringRef networkName,
                         std::unique_ptr<ExecutionContext> context,
                         ResultCBTy callback) {
-  ScopedTraceBlock(context->getTraceContext(),
-                   "runFunction_" + networkName.str());
+  TRACE_EVENT_SCOPE(context->getTraceContext(), "HostManager::runNetwork");
   auto currentRun = totalRequestCount_++;
   std::lock_guard<std::mutex> networkLock(networkLock_);
   if (networks_.find(networkName) == networks_.end()) {


### PR DESCRIPTION
*Description*: Add trace events in the ONNXIFI layer so we can can determine latency costs there, also updated the naming of events a bit to make it easier for people who aren't me to interpret the traces.

before:
![image](https://user-images.githubusercontent.com/701287/57183223-922e4d80-6e5e-11e9-8323-34fa3d1db50d.png)

after:
![image](https://user-images.githubusercontent.com/701287/57182958-f6e7a900-6e5a-11e9-8641-d5b9537e6ffa.png)

*Testing*: I did run unit tests, but we don't have coverage of ONNXIFI yet. Ran a manual test on a H device to verify.
*Documentation*: