### PR TITLE
[runtime] Reduce multi device startup latency by minimizing lock time

### DIFF
--- a/include/glow/Runtime/HostManager/HostManager.h
+++ b/include/glow/Runtime/HostManager/HostManager.h
@@ -45,6 +45,10 @@ class HostManager final {
     // Module that was used to create this network. Everything except
     // placeholders and types have been removed from it.
     std::shared_ptr<Module> module;
+
+    /// use an atomic refcount rather than just store a shared_ptr for thread
+    /// safety.
+    std::atomic<size_t> refcount;
   };
 
   /// Count of current in-flight networks being run. Atomic to allow

--- a/lib/Runtime/Executor/ThreadPoolExecutor.h
+++ b/lib/Runtime/Executor/ThreadPoolExecutor.h
@@ -61,6 +61,9 @@ public:
                           std::unique_ptr<ExecutionContext> resultContext,
                           ResultCBTy doneCb);
 
+  /// Does the BFS traversal and initializes the ExecutionState.
+  void init();
+
   /// \returns a unique pointer to an input bindings for \p node. This should
   /// not be called at the same time as insertIntoNodeCtx().
   std::unique_ptr<ExecutionContext>
@@ -103,6 +106,9 @@ public:
   /// \returns the run ID for the execution.
   RunIdentifierTy getRunId() const { return runId_; }
 
+  /// Whether or not this node has been initialized.
+  bool initialized_{false};
+
 private:
   /// The run identifier for this execution of a DAG.
   RunIdentifierTy runId_;
@@ -134,6 +140,9 @@ private:
   /// Module for the network. This contains the PHs used by the functions in
   /// this network.
   Module *module_{nullptr};
+
+  /// Root node of the DAG for this run.
+  const DAGNode *root_;
 };
 
 /// This implementation of the Executor interface uses a thread pool to


### PR DESCRIPTION
*Description*: The HostManager and ThreadPoolExecutor hold their respective state locks for the full  duration of the work to set up the run (the HostManager also holds it's lock while the Executor is working) which essentially serializes all executor work into a single thread of execution.This diff changes each to hold their lock for the least possible time during `runFunction`: while accessing shared state.

The effect of this is easiest to see on a system with multiple devices:
(these traces are is based on top of #2854 as well for the nicer events, but this PR doesn't depend on it)

**before**:
![image](https://user-images.githubusercontent.com/701287/57183958-cc045180-6e68-11e9-8abf-68ccb0c9f85f.png)

You can see that while the calls to Onnxifi::setIOAndRun are concurrent on different threads, the HostManager and Executor calls are non overlapping. This means that the second device is waiting for the Executor to do the BFS for the first run before as well as its own run.

**after**:
![image](https://user-images.githubusercontent.com/701287/57183977-24d3ea00-6e69-11e9-9559-7f968b7c9df3.png)

Here the HostManager and ThreadPoolExecutor calls are overlapping, which greatly reduces the delay between starting to run on the first and second cards (here ~60us but that may be mostly the difference in timing on the Onnxifi call). 

*Testing*: unit tests in debug, release and with ASAN. Manual runs with multiple devices on H cards.
*Documentation*:
This does change HostManager behaviour slightly: since all API calls used to be serialized to one concurrent access it was always safe to remove a network as there couldn't be any other usages of it. Now that's not the case, so this enforces the requirement that no outstanding runs of a network exist when the user calls `removeNetwork`.