### PR TITLE
[runtime] add TensorPool and speed up adjust batch

### DIFF
--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -390,6 +390,15 @@ struct Type final {
     return true;
   }
 
+  /// \returns a hash value for this Type. Hashes for Ty1 and Ty2 are equal if
+  /// Ty1.isEqual(Ty2).
+  llvm::hash_code equals_hash() const {
+    return llvm::hash_combine(
+        elementType_, dims(),
+        // hashing floats is tricky, fall back to std::hash
+        std::hash<float>{}(scale_), offset_);
+  }
+
   ElemKind getElementType() const { return elementType_; }
 
   /// \returns the shape of the tensor.

--- a/include/glow/Graph/PlaceholderBindings.h
+++ b/include/glow/Graph/PlaceholderBindings.h
@@ -67,6 +67,9 @@ public:
   /// Inserts the Placeholder-Tensor pair.
   void insert(Placeholder *P, Tensor &&T);
 
+  /// Inserts the Placeholder-Tensor pair. This takes ownership of the Tensor.
+  void insert(Placeholder *P, Tensor *T);
+
   /// Allocates a tensor to back the placeholder \p P. The new tensor has the
   /// type of P.
   Tensor *allocate(Placeholder *P);

--- a/include/glow/Support/TensorPool.h
+++ b/include/glow/Support/TensorPool.h
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_TENSORPOOL_H
+#define GLOW_TENSORPOOL_H
+
+#include "glow/Base/Tensor.h"
+
+#include <atomic>
+#include <iostream>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
+
+namespace glow {
+
+class TensorPool final {
+private:
+  struct TypeHash {
+    size_t operator()(const Type &t) const { return t.equals_hash(); }
+  };
+
+  struct TypeEquals {
+    bool operator()(const Type &a, const Type &b) const { return a.isEqual(b); }
+  };
+  /// A stack of available Tensors per Type.
+  std::unordered_map<Type, std::vector<Tensor *>, TypeHash, TypeEquals> pools_;
+
+  /// Mutex around pools_;
+  std::mutex lock_;
+
+  /// Whether or not to allow allocation of new buffers if the pool is empty.
+  const bool preventInlineAllocs_{false};
+
+public:
+  /// Statistics relating to the usage of the pool.
+  struct Stats {
+    /// The total number of Types that has ever been available in this pool.
+    std::atomic<uint64_t> totalTypes{0};
+    /// The number of Tensors currently allocated and available.
+    std::atomic<uint64_t> currentBuffers{0};
+    /// The number of Tensor allocations ever done by the pool.
+    std::atomic<uint64_t> totalAllocs{0};
+    /// The number of Tensor allocations that were done inline to get (as
+    /// opposed to reserve).
+    std::atomic<uint64_t> inlineAllocs{0};
+    /// The total number of times a Tensor was retrieved from the pool.
+    std::atomic<uint64_t> totalGets{0};
+    /// The total number of times a Tensor was returned to the pool.
+    std::atomic<uint64_t> totalReclaims{0};
+    /// The total number of times a Tensor was freed (e.g. via clear()).
+    std::atomic<uint64_t> totalFrees{0};
+  } stats_;
+
+  TensorPool(bool preventAllocs = false)
+      : preventInlineAllocs_{preventAllocs} {}
+
+  ~TensorPool() { clear(); }
+
+  /// Retrieve a Tensor with type \p ty from the pool - this type must have
+  /// previously been added by initialize. If the pool is empty this will
+  /// allocate a new Tensor unless preventAllocs was set true at construction
+  /// time.
+  Tensor *get(TypeRef ty);
+
+  /// Return a Tensor \p t to the pool. This Tensor must have been previously
+  /// allocated by this TensorPool.
+  void reclaim(Tensor *t);
+
+  /// Add \p count elements of the provided type \p ty to the pool.
+  void reserve(TypeRef ty, size_t count);
+
+  /// Clear the pool and all allocated Tensors.
+  /// Note: this does not delete tensors that were allocated by the pool but
+  /// were not reclaimed.
+  void clear();
+
+  /// Return statistics about the TensorPool.
+  const Stats &getStats() { return stats_; }
+};
+} // namespace glow
+
+#endif

--- a/lib/Graph/CMakeLists.txt
+++ b/lib/Graph/CMakeLists.txt
@@ -34,6 +34,7 @@ target_link_libraries(Graph
                       PUBLIC
                         Base
                         Support
-                        QuantizationBase)
+                        QuantizationBase
+                        TensorPool)
 
 add_dependencies(Graph AutoGen)

--- a/lib/Onnxifi/Base.h
+++ b/lib/Onnxifi/Base.h
@@ -20,6 +20,7 @@
 #include "glow/ExecutionEngine/ExecutionEngine.h"
 #include "glow/Importer/ONNXIFIModelLoader.h"
 #include "glow/Runtime/RuntimeTypes.h"
+#include "glow/Support/TensorPool.h"
 
 #include "foxi/onnxifi.h"
 #include "foxi/onnxifi_ext.h"
@@ -153,6 +154,9 @@ protected:
   /// Mapping between ONNX name for the output variable and Glow
   /// placeholder for output.
   llvm::StringMap<Placeholder *> onnxOutputToPlaceholder_;
+
+  /// An object pool for tensors, to share allocations.
+  TensorPool tensorPool_;
 };
 
 typedef Graph *GraphPtr;

--- a/lib/Onnxifi/HostManagerOnnxifi.cpp
+++ b/lib/Onnxifi/HostManagerOnnxifi.cpp
@@ -86,6 +86,11 @@ HostManagerGraph::initGraph(const void *onnxModel, size_t onnxModelSize,
   onnxInputToPlaceholder_ = loader->getInputVarsMapping();
   onnxOutputToPlaceholder_ = loader->getOutputVarsMapping();
 
+  // Make sure the pool is ready to go.
+  for (auto &obj : onnxInputToPlaceholder_) {
+    tensorPool_.reserve(obj.second->getType(), 10);
+  }
+
   return static_cast<HostManagerBackendId *>(backendPtr_->getBackendId())
       ->addNetwork(std::move(module));
 }

--- a/lib/Runtime/Executor/ThreadPoolExecutor.cpp
+++ b/lib/Runtime/Executor/ThreadPoolExecutor.cpp
@@ -113,7 +113,8 @@ void ExecutionState::init() {
 
           // allocate into the resultBindings because they have the longest
           // lifetime.
-          resultBindings->allocate(PH);
+          resultBindings->insert(PH,
+                                 intermediateTensorPool_.get(PH->getType()));
           intermediatePlaceholders_.push_back(PH);
         }
 

--- a/lib/Runtime/Executor/ThreadPoolExecutor.h
+++ b/lib/Runtime/Executor/ThreadPoolExecutor.h
@@ -21,6 +21,7 @@
 #include <unordered_map>
 
 #include "glow/Runtime/Executor/Executor.h"
+#include "glow/Support/TensorPool.h"
 #include "glow/Support/ThreadPool.h"
 
 namespace glow {
@@ -136,13 +137,13 @@ private:
   /// Mutex used by bindings insertion functions to make sure only one thread
   /// writes to an ExecutionContext at a time.
   std::mutex bindingsMtx_;
-
   /// Module for the network. This contains the PHs used by the functions in
   /// this network.
   Module *module_{nullptr};
-
   /// Root node of the DAG for this run.
   const DAGNode *root_;
+  /// Object pool for intermediate tensors.
+  TensorPool intermediateTensorPool_;
 };
 
 /// This implementation of the Executor interface uses a thread pool to

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -7,3 +7,8 @@ add_library(Support
 target_link_libraries(Support
                       PUBLIC
                         LLVMSupport)
+add_library(TensorPool
+              TensorPool.cpp)
+target_link_libraries(TensorPool
+                      PRIVATE
+                        Base)

--- a/lib/Support/TensorPool.cpp
+++ b/lib/Support/TensorPool.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/Support/TensorPool.h"
+
+namespace glow {
+
+Tensor *TensorPool::get(TypeRef ty) {
+  stats_.totalGets++;
+
+  std::unique_lock<std::mutex> l(lock_);
+
+  auto it = pools_.find(*ty);
+
+  if (it == pools_.end()) {
+    if (preventInlineAllocs_) {
+      return nullptr;
+    }
+
+    stats_.totalTypes++;
+    it = pools_.emplace(*ty, std::vector<Tensor *>()).first;
+  }
+
+  if (it->second.empty()) {
+    if (preventInlineAllocs_) {
+      return nullptr;
+    }
+
+    // Don't need to alloc under the lock.
+    l.unlock();
+    stats_.totalAllocs++;
+    stats_.inlineAllocs++;
+    // Don't add it to the queue because it's being claimed now.
+    return new Tensor(ty, this);
+  }
+
+  auto &queue = it->second;
+  Tensor *t = std::move(queue.back());
+  queue.pop_back();
+  stats_.currentBuffers--;
+  return t;
+}
+
+void TensorPool::reclaim(Tensor *t) {
+  std::lock_guard<std::mutex> l(lock_);
+  auto it = pools_.find(t->getType());
+  assert(it != pools_.end() && "Type has not been initialized");
+  stats_.totalReclaims++;
+  stats_.currentBuffers++;
+  it->second.push_back(t);
+}
+
+void TensorPool::reserve(TypeRef ty, size_t count) {
+  std::vector<Tensor *> temp;
+  temp.reserve(count);
+  for (unsigned i = 0; i < count; ++i) {
+    stats_.totalAllocs++;
+    temp.push_back(new Tensor(ty, this));
+  }
+
+  {
+    std::lock_guard<std::mutex> l(lock_);
+    auto it = pools_.find(*ty);
+    if (it == pools_.end()) {
+      stats_.totalTypes++;
+    }
+
+    std::vector<Tensor *> &queue = pools_[*ty];
+    std::move(temp.begin(), temp.end(), std::back_inserter(queue));
+    stats_.currentBuffers += count;
+  }
+}
+
+void TensorPool::clear() {
+  std::lock_guard<std::mutex> l(lock_);
+  for (auto &p : pools_) {
+    stats_.currentBuffers -= p.second.size();
+    for (auto *t : p.second) {
+      delete t;
+      stats_.totalFrees++;
+    }
+    p.second.clear();
+  }
+  assert(stats_.currentBuffers == 0);
+}
+
+} // namespace glow

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -446,6 +446,16 @@ target_link_libraries(TensorsTest
                         TestMain)
 add_glow_test(TensorsTest ${GLOW_BINARY_DIR}/tests/TensorsTest --gtest_output=xml:TensorsTest.xml)
 
+add_executable(TensorPoolTest
+               TensorPoolTest.cpp)
+target_link_libraries(TensorPoolTest
+                      PRIVATE
+                        Graph
+                        TensorPool
+                        gtest
+                        TestMain)
+add_glow_test(TensorPoolTest ${GLOW_BINARY_DIR}/tests/TensorPoolTest --gtest_output=xml:TensorPoolTest.xml)
+
 add_executable(ThreadPoolTest
                ThreadPoolTest.cpp)
 target_link_libraries(ThreadPoolTest

--- a/tests/unittests/TensorPoolTest.cpp
+++ b/tests/unittests/TensorPoolTest.cpp
@@ -1,0 +1,291 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "glow/Support/TensorPool.h"
+#include "glow/Graph/Graph.h"
+#include "glow/Graph/PlaceholderBindings.h"
+#include "gtest/gtest.h"
+
+#include "llvm/ADT/STLExtras.h"
+
+#include <future>
+#include <vector>
+
+using namespace glow;
+
+/// Can get Tensor from the pool without allocation.
+TEST(TensorPool, BasicTest) {
+  TensorPool pool;
+  Type ty(ElemKind::FloatTy, {1, 2, 3});
+  pool.reserve(&ty, 1);
+
+  Tensor *T = pool.get(&ty);
+  EXPECT_TRUE(T->getType().isEqual(ty));
+  EXPECT_EQ(T->dims(), ty.dims());
+
+  const auto &stats = pool.getStats();
+  EXPECT_EQ(stats.totalTypes, 1);
+  EXPECT_EQ(stats.currentBuffers, 0);
+  EXPECT_EQ(stats.totalAllocs, 1);
+  EXPECT_EQ(stats.inlineAllocs, 0);
+  EXPECT_EQ(stats.totalGets, 1);
+  EXPECT_EQ(stats.totalReclaims, 0);
+
+  pool.reclaim(T);
+}
+
+/// Can get a tensor, return it and get it again without allocation.
+TEST(TensorPool, ReclaimAndGet) {
+  TensorPool pool;
+  Type ty(ElemKind::FloatTy, {1, 2, 3});
+  pool.reserve(&ty, 1);
+
+  Tensor *T = pool.get(&ty);
+  auto *backingPtr = T->getUnsafePtr();
+
+  pool.reclaim(T);
+
+  Tensor *T2 = pool.get(&ty);
+  // They are the same buffer.
+  EXPECT_EQ(T2->getUnsafePtr(), backingPtr);
+
+  const auto &stats = pool.getStats();
+  EXPECT_EQ(stats.totalTypes, 1);
+  EXPECT_EQ(stats.currentBuffers, 0);
+  EXPECT_EQ(stats.totalAllocs, 1);
+  EXPECT_EQ(stats.inlineAllocs, 0);
+  EXPECT_EQ(stats.totalGets, 2);
+  EXPECT_EQ(stats.totalReclaims, 1);
+
+  pool.reclaim(T2);
+}
+
+/// The pool auto resizes when it's empty.
+TEST(TensorPool, Extends) {
+  TensorPool pool;
+  Type ty(ElemKind::FloatTy, {1, 2, 3});
+  pool.reserve(&ty, 1);
+
+  Tensor *T = pool.get(&ty);
+  Tensor *T2 = pool.get(&ty);
+  EXPECT_TRUE(T->getType().isEqual(T2->getType()));
+  EXPECT_TRUE(T->getType().isEqual(ty));
+  EXPECT_TRUE(T2->getType().isEqual(ty));
+
+  // They are not the same buffer.
+  EXPECT_NE(T->getUnsafePtr(), T2->getUnsafePtr());
+
+  const auto &stats = pool.getStats();
+  EXPECT_EQ(stats.totalTypes, 1);
+  EXPECT_EQ(stats.currentBuffers, 0);
+  EXPECT_EQ(stats.totalAllocs, 2);
+  EXPECT_EQ(stats.inlineAllocs, 1);
+  EXPECT_EQ(stats.totalGets, 2);
+  EXPECT_EQ(stats.totalReclaims, 0);
+
+  pool.reclaim(T);
+  pool.reclaim(T2);
+}
+
+/// The pool doesn't resize when you tell it not to.
+TEST(TensorPool, DoesntExtend) {
+  TensorPool pool(true);
+  Type ty(ElemKind::FloatTy, {1, 2, 3});
+  pool.reserve(&ty, 1);
+
+  Tensor *T = pool.get(&ty);
+  Type Tt = T->getType();
+
+  Tensor *T2 = pool.get(&ty);
+  EXPECT_EQ(T2, nullptr);
+
+  pool.reclaim(T);
+
+  T = pool.get(&ty);
+  EXPECT_EQ(Tt, T->getType());
+
+  const auto &stats = pool.getStats();
+  EXPECT_EQ(stats.totalTypes, 1);
+  EXPECT_EQ(stats.currentBuffers, 0);
+  EXPECT_EQ(stats.totalAllocs, 1);
+  EXPECT_EQ(stats.inlineAllocs, 0);
+  EXPECT_EQ(stats.totalGets, 3);
+  EXPECT_EQ(stats.totalReclaims, 1);
+
+  pool.reclaim(T);
+}
+
+/// Still works if you don't reserve it.
+TEST(TensorPool, Noreserve) {
+  TensorPool pool;
+  Type ty(ElemKind::FloatTy, {1, 2, 3});
+
+  Tensor *T = pool.get(&ty);
+  Tensor *T2 = pool.get(&ty);
+
+  EXPECT_TRUE(T->getType().isEqual(T2->getType()));
+
+  const auto &stats = pool.getStats();
+  EXPECT_EQ(stats.totalTypes, 1);
+  EXPECT_EQ(stats.currentBuffers, 0);
+  EXPECT_EQ(stats.totalAllocs, 2);
+  EXPECT_EQ(stats.inlineAllocs, 2);
+  EXPECT_EQ(stats.totalGets, 2);
+  EXPECT_EQ(stats.totalReclaims, 0);
+
+  pool.reclaim(T);
+  pool.reclaim(T2);
+}
+
+/// Can handle multiple types of Tensors.
+TEST(TensorPool, MultipleTypes) {
+  TensorPool pool;
+  Type ty(ElemKind::FloatTy, {1, 2, 3});
+  Type ty2(ElemKind::Int8QTy, {3, 2, 1}, 1.0, 4);
+
+  // Six total buffers.
+  pool.reserve(&ty, 1);
+  pool.reserve(&ty2, 5);
+
+  std::vector<Tensor *> tensors;
+  // Ten total allocs.
+  for (int i = 0; i < 5; ++i) {
+    Tensor *T = pool.get(&ty);
+    Tensor *T2 = pool.get(&ty2);
+    EXPECT_FALSE(T->getType().isEqual(T2->getType()));
+    EXPECT_TRUE(T->getType().isEqual(ty));
+    EXPECT_TRUE(T2->getType().isEqual(ty2));
+    EXPECT_NE(T->dims(), T2->dims());
+    EXPECT_NE(T->getUnsafePtr(), T2->getUnsafePtr());
+
+    tensors.push_back(T);
+    tensors.push_back(T2);
+  }
+
+  const auto &stats = pool.getStats();
+  EXPECT_EQ(stats.totalTypes, 2);
+  EXPECT_EQ(stats.currentBuffers, 0);
+  EXPECT_EQ(stats.totalAllocs, 10);
+  EXPECT_EQ(stats.inlineAllocs, 4); // Four allocs inline.
+  EXPECT_EQ(stats.totalGets, 10);
+  EXPECT_EQ(stats.totalReclaims, 0);
+
+  for (auto &t : tensors) {
+    pool.reclaim(t);
+  }
+
+  const auto &stats2 = pool.getStats();
+  EXPECT_EQ(stats2.totalTypes, 2);
+  EXPECT_EQ(stats2.currentBuffers, 10);
+  EXPECT_EQ(stats.totalReclaims, 10);
+}
+
+/// Reclaims still work with multiple types of Tensors.
+TEST(TensorPool, MultipleTypesReclaim) {
+  TensorPool pool;
+  Type ty(ElemKind::FloatTy, {1, 2, 3});
+  Type ty2(ElemKind::Int8QTy, {3, 2, 1}, 1.0, 4);
+  pool.reserve(&ty, 1);
+  pool.reserve(&ty2, 1);
+
+  Tensor *T = pool.get(&ty);
+  Tensor *T2 = pool.get(&ty2);
+
+  pool.reclaim(T);
+  pool.reclaim(T2);
+
+  T = pool.get(&ty);
+  T2 = pool.get(&ty2);
+
+  pool.reclaim(T);
+  pool.reclaim(T2);
+
+  const auto &stats = pool.getStats();
+  EXPECT_EQ(stats.totalTypes, 2);
+  EXPECT_EQ(stats.currentBuffers, 2);
+  EXPECT_EQ(stats.totalAllocs, 2);
+  EXPECT_EQ(stats.inlineAllocs, 0);
+  EXPECT_EQ(stats.totalGets, 4);
+  EXPECT_EQ(stats.totalReclaims, 4);
+}
+
+/// Inserting a managed Tensor into the PlaceholderBindings does reclaim when
+/// the bindings are cleared or destroyed.
+TEST(TensorPool, PlaceholderBindingsReclaim) {
+  TensorPool pool;
+  Type ty(ElemKind::FloatTy, {1, 2, 3});
+
+  PlaceholderBindings bindings;
+  Module mod;
+
+  auto *PH = mod.createPlaceholder(&ty, "test", false);
+  bindings.insert(PH, pool.get(&ty));
+
+  /// Insert a non managed tensor.
+  auto *PH2 = mod.createPlaceholder(&ty, "test2", false);
+  Tensor T2(ty);
+  bindings.insert(PH2, std::move(T2));
+
+  bindings.clear();
+
+  /// Bindings had two Tensors but only the first was reclaimed.
+  const auto &stats = pool.getStats();
+  EXPECT_EQ(stats.totalTypes, 1);
+  EXPECT_EQ(stats.currentBuffers, 1);
+  EXPECT_EQ(stats.totalAllocs, 1);
+  EXPECT_EQ(stats.inlineAllocs, 1);
+  EXPECT_EQ(stats.totalGets, 1);
+  EXPECT_EQ(stats.totalReclaims, 1);
+
+  bindings.insert(PH, pool.get(&ty));
+
+  bindings.erase(PH);
+  const auto &stats2 = pool.getStats();
+  EXPECT_EQ(stats.currentBuffers, 1);
+  EXPECT_EQ(stats.totalGets, 2);
+  EXPECT_EQ(stats2.totalReclaims, 2);
+}
+
+/// Clearing the Tensor pool removes contents but the pool still works.
+TEST(TensorPool, Clear) {
+  TensorPool pool;
+  Type ty(ElemKind::FloatTy, {1, 2, 3});
+
+  Tensor *T = pool.get(&ty);
+  pool.reclaim(T);
+
+  const auto &stats = pool.getStats();
+  EXPECT_EQ(stats.totalTypes, 1);
+  EXPECT_EQ(stats.currentBuffers, 1);
+  EXPECT_EQ(stats.totalAllocs, 1);
+  EXPECT_EQ(stats.inlineAllocs, 1);
+  EXPECT_EQ(stats.totalGets, 1);
+  EXPECT_EQ(stats.totalReclaims, 1);
+  EXPECT_EQ(stats.totalFrees, 0);
+
+  pool.clear();
+
+  T = pool.get(&ty);
+  pool.reclaim(T);
+
+  const auto &stats2 = pool.getStats();
+  EXPECT_EQ(stats2.totalTypes, 1);
+  EXPECT_EQ(stats2.currentBuffers, 1);
+  EXPECT_EQ(stats2.totalAllocs, 2);
+  EXPECT_EQ(stats2.inlineAllocs, 2);
+  EXPECT_EQ(stats2.totalGets, 2);
+  EXPECT_EQ(stats2.totalReclaims, 2);
+  EXPECT_EQ(stats2.totalFrees, 1);
+}


### PR DESCRIPTION
*Description*: Add in an object pool for sharing Tensor allocations between runs. Nothing fancy just a lock, a map and a queue. The primary goal is to reduce the latency in the adjust batch stage of Onnxifi. Looks like about a 50% reduction in initial latency.

before:
![image](https://user-images.githubusercontent.com/701287/57186683-924b3f00-6e98-11e9-8ffe-a1a1e285336b.png)

after:
![image](https://user-images.githubusercontent.com/701287/57186687-a0995b00-6e98-11e9-9e95-d4931c968fb3.png)

(* these numbers make sense but I'm a little suspicious, the copyInputs phase in the DeviceManager is noticeably longer (450us vs 300us - so still a win). Could be location in cache or maybe that we're not zeroing the tensors anymore?)

*Testing*: unit tests with all modes, but Onnxifi has no tests so take it with a grain of salt. New tests for TensorPool. Manual tests on an H-device.
*Documentation*: