### PR TITLE
Update foxi and remove onnxTraceEvent name alloc

### DIFF
--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -197,10 +197,10 @@ void Graph::setTraceEvents(onnxTraceEventList *traceEvents,
     traceEvent->eventType = glowTraceEvent.type[0];
     traceEvent->timestamp = glowTraceEvent.timestamp;
     traceEvent->tid = glowTraceEvent.tid;
-    char *eventName = new char[glowTraceEvent.name.size() + 1];
-    assert(eventName);
-    strcpy(eventName, glowTraceEvent.name.c_str());
-    traceEvent->eventName = eventName;
+    traceEvent->duration = 0;
+    strncpy(traceEvent->eventName, glowTraceEvent.name.c_str(),
+            std::min(glowTraceEvent.name.size(),
+                     (size_t)ONNXIFI_TRACE_EVENT_NAME_SIZE));
     traceEventsVec.push_back(traceEvent);
   }
 
@@ -215,7 +215,6 @@ void Graph::releaseTraceEvents(onnxTraceEventList *traceEvents) {
   assert(traceEvents);
   for (uint64_t i = 0; i < traceEvents->numEvents; ++i) {
     onnxTraceEvent *traceEvent = traceEvents->traceEvents[i];
-    delete[] traceEvent->eventName;
     delete traceEvent;
   }
 

--- a/lib/Onnxifi/CMakeLists.txt
+++ b/lib/Onnxifi/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(onnxifi-glow-lib
 target_link_libraries(onnxifi-glow-lib
                       PUBLIC
                         Backends
+                        ExecutionContext
                         ExecutionEngine
                         Graph
                         HostManager
@@ -28,6 +29,7 @@ target_link_libraries(onnxifi-glow-lib
 target_link_libraries(onnxifi-glow
                       PUBLIC
                         Backends
+                        ExecutionContext
                         ExecutionEngine
                         Graph
                         HostManager


### PR DESCRIPTION
*Description*: Pulling the latest version of foxi with some TraceEvents changes. Just updating glow to build and work with no behavioural change. Will add support for `complete` events in a follow up.
*Testing*: build and test
*Documentation*:
