### PR TITLE
Eliminate duplicate allocation for weights in model loaders

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -152,6 +152,8 @@ public:
 
   Constant *createConstant(llvm::StringRef name, const Tensor &tensor);
 
+  Constant *createConstant(llvm::StringRef name, Tensor &&tensor);
+
   ///@}
 
   /// Verify the correctness of the Module.

--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -101,6 +101,8 @@ public:
 
   void assign(const Tensor *t) { payload_.assign(t); }
 
+  void setPayloadType(TypeRef ty) { payload_.setType(ty); }
+
   std::string getDebugDesc() const;
 
   llvm::hash_code getHash() const;

--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -227,8 +227,7 @@ protected:
   llvm::Error loadRelu(const OpType &op, ArgumentDictionaryTy &dict) {
     const std::string &opName = loadOperatorName(op);
     NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
     auto *R = G_.createRELU(opName, in);
     RETURN_IF_ERR(addNodeAsOutput(op, R));
     return llvm::Error::success();
@@ -241,12 +240,10 @@ protected:
     const std::string &opName = loadOperatorName(op);
 
     NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
 
     NodeValue slope;
-    ASSIGN_VALUE_OR_RETURN_ERR(slope,
-                               getNodeValueOrCreateConstantByName(op.input(1)));
+    ASSIGN_VALUE_OR_RETURN_ERR(slope, getNodeValueByName(op.input(1)));
 
     // Do broadcasting.
     auto targetDim = in.dims();
@@ -262,8 +259,7 @@ protected:
   llvm::Error loadSigmoid(const OpType &op, ArgumentDictionaryTy &dict) {
     const std::string &opName = loadOperatorName(op);
     NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
     auto *S = G_.createSigmoid(opName, in);
     RETURN_IF_ERR(addNodeAsOutput(op, S));
     return llvm::Error::success();
@@ -272,8 +268,7 @@ protected:
   llvm::Error loadTanh(const OpType &op, ArgumentDictionaryTy &dict) {
     const std::string &opName = loadOperatorName(op);
     NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
     auto *T = G_.createTanh(opName, in);
     RETURN_IF_ERR(addNodeAsOutput(op, T));
     return llvm::Error::success();
@@ -282,8 +277,7 @@ protected:
   llvm::Error loadShape(const OpType &op, ArgumentDictionaryTy &dict) {
     const std::string &opName = loadOperatorName(op);
     NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
 
     // This is statically known data, and so we create a Tensor for it.
     Tensor T(ElemKind::Int64ITy, {in.dims().size()});
@@ -302,8 +296,7 @@ protected:
   llvm::Error loadSqrt(const OpType &op, ArgumentDictionaryTy &dict) {
     const std::string &opName = loadOperatorName(op);
     NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
     auto *R = G_.createPow(opName, in, 0.5f);
     RETURN_IF_ERR(addNodeAsOutput(op, R));
     return llvm::Error::success();
@@ -314,8 +307,7 @@ protected:
   llvm::Error loadReciprocal(const OpType &op, ArgumentDictionaryTy &dict) {
     const std::string &opName = loadOperatorName(op);
     NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
     auto *R = G_.createPow(opName, in, -1.0f);
     RETURN_IF_ERR(addNodeAsOutput(op, R));
     return llvm::Error::success();
@@ -324,17 +316,14 @@ protected:
   llvm::Error loadSum(const OpType &op, ArgumentDictionaryTy &dict) {
     if (op.input_size() == 1) {
       NodeValue in;
-      ASSIGN_VALUE_OR_RETURN_ERR(
-          in, getNodeValueOrCreateConstantByName(op.input(0)));
+      ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
       RETURN_IF_ERR(addNodeAsOutput(op, in));
     } else if (op.input_size() == 2) {
       const std::string &opName = loadOperatorName(op);
       NodeValue in0;
-      ASSIGN_VALUE_OR_RETURN_ERR(
-          in0, getNodeValueOrCreateConstantByName(op.input(0)));
+      ASSIGN_VALUE_OR_RETURN_ERR(in0, getNodeValueByName(op.input(0)));
       NodeValue in1;
-      ASSIGN_VALUE_OR_RETURN_ERR(
-          in1, getNodeValueOrCreateConstantByName(op.input(1)));
+      ASSIGN_VALUE_OR_RETURN_ERR(in1, getNodeValueByName(op.input(1)));
       auto *node = G_.createAdd(opName, in0, in1);
       RETURN_IF_ERR(addNodeAsOutput(op, node));
     } else {
@@ -344,8 +333,7 @@ protected:
       inputs.reserve(numInputs);
       for (unsigned i = 0; i < numInputs; i++) {
         NodeValue in;
-        ASSIGN_VALUE_OR_RETURN_ERR(
-            in, getNodeValueOrCreateConstantByName(op.input(i)));
+        ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(i)));
         inputs.push_back(G_.createExpandDims(opName, in, {0}));
       }
       ConcatNode *concat = G_.createConcat(opName, inputs, /* axis */ 0);
@@ -359,8 +347,7 @@ protected:
     const std::string &opName = loadOperatorName(op);
 
     NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
 
     // We do not do training right now on loaded protos. C2 and ONNX do not even
     // have an option for a selected input anyway. So I am creating this as a
@@ -389,8 +376,7 @@ protected:
   llvm::Error loadLRN(const OpType &op, ArgumentDictionaryTy &dict) {
     const std::string &opName = loadOperatorName(op);
     NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
 
     size_t size;
     ASSIGN_VALUE_OR_RETURN_ERR(size, loadInt(dict["size"]));
@@ -418,11 +404,9 @@ protected:
                          ArgumentDictionaryTy &dict) {
     const std::string &opName = loadOperatorName(op);
     NodeValue in0;
-    ASSIGN_VALUE_OR_RETURN_ERR(in0,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in0, getNodeValueByName(op.input(0)));
     NodeValue in1;
-    ASSIGN_VALUE_OR_RETURN_ERR(in1,
-                               getNodeValueOrCreateConstantByName(op.input(1)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in1, getNodeValueByName(op.input(1)));
 
     Node *node = nullptr;
     if (typeName == "Min") {
@@ -441,11 +425,9 @@ protected:
                               bool isBatched) {
     const std::string &opName = loadOperatorName(op);
     NodeValue LHS;
-    ASSIGN_VALUE_OR_RETURN_ERR(LHS,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(LHS, getNodeValueByName(op.input(0)));
     NodeValue RHS;
-    ASSIGN_VALUE_OR_RETURN_ERR(RHS,
-                               getNodeValueOrCreateConstantByName(op.input(1)));
+    ASSIGN_VALUE_OR_RETURN_ERR(RHS, getNodeValueByName(op.input(1)));
 
     bool transLHS = false;
     if (dict.count("trans_a")) {
@@ -497,11 +479,9 @@ protected:
                              ArgumentDictionaryTy &dict) {
     const std::string &opName = loadOperatorName(op);
     NodeValue in0;
-    ASSIGN_VALUE_OR_RETURN_ERR(in0,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in0, getNodeValueByName(op.input(0)));
     NodeValue in1;
-    ASSIGN_VALUE_OR_RETURN_ERR(in1,
-                               getNodeValueOrCreateConstantByName(op.input(1)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in1, getNodeValueByName(op.input(1)));
 
     bool broadcast;
     ASSIGN_VALUE_OR_RETURN_ERR(broadcast, getBroadcast(dict));
@@ -567,8 +547,7 @@ protected:
   llvm::Error loadSplit(const OpType &op, ArgumentDictionaryTy &dict) {
     const std::string &opName = loadOperatorName(op);
     NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
     size_t axis = 0;
     if (dict.count("axis")) {
       ASSIGN_VALUE_OR_RETURN_ERR(axis, loadInt(dict["axis"]));
@@ -592,8 +571,7 @@ protected:
   llvm::Error loadReshape(const OpType &op, ArgumentDictionaryTy &dict) {
     const std::string &opName = loadOperatorName(op);
     NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
 
     // Get the requested shape from the model.
     // First look at input tensors, then at the "shape" attribute.
@@ -661,8 +639,7 @@ protected:
                             llvm::StringRef permArgName) {
     const std::string &opName = loadOperatorName(op);
     NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
 
     // There is a difference between ONNX and Caffe2 specs for Transpose:
     // one contains permutation under name "perm", the other contains it under
@@ -684,8 +661,7 @@ protected:
   llvm::Error loadFlatten(const OpType &op, ArgumentDictionaryTy &dict) {
     const std::string &opName = loadOperatorName(op);
     NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
     int axis = 1;
     if (dict.count("axis")) {
       ASSIGN_VALUE_OR_RETURN_ERR(axis, loadInt(dict["axis"]));
@@ -697,8 +673,7 @@ protected:
 
   llvm::Error loadIdentity(const OpType &op, ArgumentDictionaryTy &dict) {
     NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
     nodeValueByName_[op.output(0)] = in;
     return llvm::Error::success();
   }
@@ -706,8 +681,7 @@ protected:
   llvm::Error loadTopK(const OpType &op, ArgumentDictionaryTy &dict) {
     const std::string &opName = loadOperatorName(op);
     NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
     unsigned_t k;
     ASSIGN_VALUE_OR_RETURN_ERR(k, loadInt(dict["k"]));
 
@@ -732,8 +706,7 @@ protected:
                                   ArgumentDictionaryTy &dict) {
     const std::string &opName = loadOperatorName(op);
     NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
 
     auto shapeAxes = getShape<unsigned_t>(dict["axes"]);
     std::sort(shapeAxes.begin(), shapeAxes.end());
@@ -782,14 +755,11 @@ protected:
   llvm::Error loadBatchOneHot(const OpType &op) {
     const std::string &opName = loadOperatorName(op);
     NodeValue data;
-    ASSIGN_VALUE_OR_RETURN_ERR(data,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(data, getNodeValueByName(op.input(0)));
     NodeValue lengths;
-    ASSIGN_VALUE_OR_RETURN_ERR(lengths,
-                               getNodeValueOrCreateConstantByName(op.input(1)));
+    ASSIGN_VALUE_OR_RETURN_ERR(lengths, getNodeValueByName(op.input(1)));
     NodeValue values;
-    ASSIGN_VALUE_OR_RETURN_ERR(values,
-                               getNodeValueOrCreateConstantByName(op.input(2)));
+    ASSIGN_VALUE_OR_RETURN_ERR(values, getNodeValueByName(op.input(2)));
 
     auto *node = G_.createBatchOneHot(opName, data, lengths, values);
     RETURN_IF_ERR(addNodeAsOutput(op, node));
@@ -798,14 +768,11 @@ protected:
 
   llvm::Error loadSparseLengthsSum(const OpType &op) {
     NodeValue in0;
-    ASSIGN_VALUE_OR_RETURN_ERR(in0,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in0, getNodeValueByName(op.input(0)));
     NodeValue in1;
-    ASSIGN_VALUE_OR_RETURN_ERR(in1,
-                               getNodeValueOrCreateConstantByName(op.input(1)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in1, getNodeValueByName(op.input(1)));
     NodeValue in2;
-    ASSIGN_VALUE_OR_RETURN_ERR(in2,
-                               getNodeValueOrCreateConstantByName(op.input(2)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in2, getNodeValueByName(op.input(2)));
     auto *node = G_.createSparseLengthsSum(loadOperatorName(op), in0, in1, in2);
     RETURN_IF_ERR(addNodeAsOutput(op, node));
     return llvm::Error::success();
@@ -813,17 +780,13 @@ protected:
 
   llvm::Error loadSparseLengthsWeightedSum(const OpType &op) {
     NodeValue in0;
-    ASSIGN_VALUE_OR_RETURN_ERR(in0,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in0, getNodeValueByName(op.input(0)));
     NodeValue in1;
-    ASSIGN_VALUE_OR_RETURN_ERR(in1,
-                               getNodeValueOrCreateConstantByName(op.input(1)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in1, getNodeValueByName(op.input(1)));
     NodeValue in2;
-    ASSIGN_VALUE_OR_RETURN_ERR(in2,
-                               getNodeValueOrCreateConstantByName(op.input(2)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in2, getNodeValueByName(op.input(2)));
     NodeValue in3;
-    ASSIGN_VALUE_OR_RETURN_ERR(in3,
-                               getNodeValueOrCreateConstantByName(op.input(3)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in3, getNodeValueByName(op.input(3)));
     auto *node = G_.createSparseLengthsWeightedSum(loadOperatorName(op), in0,
                                                    in1, in2, in3);
     RETURN_IF_ERR(addNodeAsOutput(op, node));
@@ -832,8 +795,7 @@ protected:
 
   llvm::Error loadLengthsToRanges(const OpType &op) {
     NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
     auto *node = G_.createLengthsToRanges(loadOperatorName(op), in);
     RETURN_IF_ERR(addNodeAsOutput(op, node));
     return llvm::Error::success();
@@ -841,14 +803,11 @@ protected:
 
   llvm::Error loadBatchBoxCox(const OpType &op) {
     NodeValue data;
-    ASSIGN_VALUE_OR_RETURN_ERR(data,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(data, getNodeValueByName(op.input(0)));
     NodeValue lambda1;
-    ASSIGN_VALUE_OR_RETURN_ERR(lambda1,
-                               getNodeValueOrCreateConstantByName(op.input(1)));
+    ASSIGN_VALUE_OR_RETURN_ERR(lambda1, getNodeValueByName(op.input(1)));
     NodeValue lambda2;
-    ASSIGN_VALUE_OR_RETURN_ERR(lambda2,
-                               getNodeValueOrCreateConstantByName(op.input(2)));
+    ASSIGN_VALUE_OR_RETURN_ERR(lambda2, getNodeValueByName(op.input(2)));
     auto *node =
         G_.createBatchBoxCox(loadOperatorName(op), data, lambda1, lambda2);
     RETURN_IF_ERR(addNodeAsOutput(op, node));
@@ -857,11 +816,9 @@ protected:
 
   llvm::Error loadDotProduct(const OpType &op) {
     NodeValue X;
-    ASSIGN_VALUE_OR_RETURN_ERR(X,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(X, getNodeValueByName(op.input(0)));
     NodeValue Y;
-    ASSIGN_VALUE_OR_RETURN_ERR(Y,
-                               getNodeValueOrCreateConstantByName(op.input(1)));
+    ASSIGN_VALUE_OR_RETURN_ERR(Y, getNodeValueByName(op.input(1)));
     auto *node = G_.createDotProduct(loadOperatorName(op), X, Y);
     RETURN_IF_ERR(addNodeAsOutput(op, node));
     return llvm::Error::success();
@@ -871,8 +828,7 @@ protected:
                              const ArgumentDictionaryTy &dict) {
     // Load the input and NaN replacement value:
     NodeValue input;
-    ASSIGN_VALUE_OR_RETURN_ERR(input,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(input, getNodeValueByName(op.input(0)));
     auto valueIt = dict.find("value");
     float value = 0.0f;
     if (valueIt != dict.end()) {
@@ -886,11 +842,9 @@ protected:
   llvm::Error loadLengthsSum(const OpType &op) {
     const std::string &opName = loadOperatorName(op);
     NodeValue data;
-    ASSIGN_VALUE_OR_RETURN_ERR(data,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(data, getNodeValueByName(op.input(0)));
     NodeValue lengths;
-    ASSIGN_VALUE_OR_RETURN_ERR(lengths,
-                               getNodeValueOrCreateConstantByName(op.input(1)));
+    ASSIGN_VALUE_OR_RETURN_ERR(lengths, getNodeValueByName(op.input(1)));
 
     RETURN_ERR_IF_NOT(lengths.dims().size() == 1,
                       "Lengths must be a 1D vector.");
@@ -903,8 +857,7 @@ protected:
   llvm::Error loadExpandDims(const OpType &op,
                              const ArgumentDictionaryTy &dict) {
     NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
     auto dims = dict.find("dims");
     if (dims == dict.end()) {
       RETURN_ERR("Missing dims argument for ExpandDims operator.");
@@ -918,8 +871,7 @@ protected:
 
   llvm::Error loadClip(const OpType &op, const ArgumentDictionaryTy &dict) {
     NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
     float cmin = std::numeric_limits<float>::lowest();
     if (dict.count("min")) {
       ASSIGN_VALUE_OR_RETURN_ERR(cmin, loadFloat(dict.find("min")->second));
@@ -942,14 +894,11 @@ protected:
     }
 
     NodeValue indices;
-    ASSIGN_VALUE_OR_RETURN_ERR(indices,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(indices, getNodeValueByName(op.input(0)));
     NodeValue values;
-    ASSIGN_VALUE_OR_RETURN_ERR(values,
-                               getNodeValueOrCreateConstantByName(op.input(1)));
+    ASSIGN_VALUE_OR_RETURN_ERR(values, getNodeValueByName(op.input(1)));
     NodeValue dataToInferDim;
-    ASSIGN_VALUE_OR_RETURN_ERR(dataToInferDim,
-                               getNodeValueOrCreateConstantByName(op.input(2)));
+    ASSIGN_VALUE_OR_RETURN_ERR(dataToInferDim, getNodeValueByName(op.input(2)));
 
     auto *node = G_.createSparseToDense(loadOperatorName(op), indices, values,
                                         dataToInferDim);
@@ -965,19 +914,15 @@ protected:
     }
 
     NodeValue indices;
-    ASSIGN_VALUE_OR_RETURN_ERR(indices,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(indices, getNodeValueByName(op.input(0)));
     NodeValue values;
-    ASSIGN_VALUE_OR_RETURN_ERR(values,
-                               getNodeValueOrCreateConstantByName(op.input(1)));
+    ASSIGN_VALUE_OR_RETURN_ERR(values, getNodeValueByName(op.input(1)));
     NodeValue defaultValue;
-    ASSIGN_VALUE_OR_RETURN_ERR(defaultValue,
-                               getNodeValueOrCreateConstantByName(op.input(2)));
+    ASSIGN_VALUE_OR_RETURN_ERR(defaultValue, getNodeValueByName(op.input(2)));
 
     NodeValue lengths;
     if (inputSize == 4) {
-      ASSIGN_VALUE_OR_RETURN_ERR(
-          lengths, getNodeValueOrCreateConstantByName(op.input(3)));
+      ASSIGN_VALUE_OR_RETURN_ERR(lengths, getNodeValueByName(op.input(3)));
     } else {
       // If Lengths input is not present, create scalar containing number of
       // index-value pairs.
@@ -1000,11 +945,9 @@ protected:
                             const ArgumentDictionaryTy &dict) {
 
     NodeValue data;
-    ASSIGN_VALUE_OR_RETURN_ERR(data,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(data, getNodeValueByName(op.input(0)));
     NodeValue indices;
-    ASSIGN_VALUE_OR_RETURN_ERR(indices,
-                               getNodeValueOrCreateConstantByName(op.input(1)));
+    ASSIGN_VALUE_OR_RETURN_ERR(indices, getNodeValueByName(op.input(1)));
     size_t batchDims = typeName == "Gather" ? 0 : 1;
 
     if (dict.count("axis")) {
@@ -1025,13 +968,11 @@ protected:
   llvm::Error loadGatherRanges(const std::string &typeName, const OpType &op,
                                const ArgumentDictionaryTy &dict) {
     NodeValue data;
-    ASSIGN_VALUE_OR_RETURN_ERR(data,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(data, getNodeValueByName(op.input(0)));
     RETURN_ERR_IF_NOT(data.dims().size() == 1, "Data must be a 1D vector.");
 
     NodeValue ranges;
-    ASSIGN_VALUE_OR_RETURN_ERR(ranges,
-                               getNodeValueOrCreateConstantByName(op.input(1)));
+    ASSIGN_VALUE_OR_RETURN_ERR(ranges, getNodeValueByName(op.input(1)));
     RETURN_ERR_IF_NOT(ranges.dims().size() == 3, "Ranges must be a 3D vector.");
     RETURN_ERR_IF_NOT(ranges.dims()[2] == 2,
                       "Last dimension of ranges must be 2.");
@@ -1234,7 +1175,7 @@ private:
     }
     return llvm::Error::success();
   }
-}; // namespace glow
+};
 
 } // namespace glow
 

--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -198,25 +198,19 @@ protected:
         return resOrErr.takeError();
       }
 
-      if (auto err = takeErr(createAndRegisterConstant(
-              name, std::move(*loadWeightResult.t)))) {
-        return err;
-      }
+      RETURN_IF_ERR(
+          createAndRegisterConstant(name, std::move(*loadWeightResult.t)));
 
       if (loadWeightResult.biases) {
         auto biasesName = strFormat("%s_loaded_biases", name);
-        if (auto err = takeErr(createAndRegisterConstant(
-                biasesName, std::move(*loadWeightResult.biases)))) {
-          return err;
-        }
+        RETURN_IF_ERR(createAndRegisterConstant(
+            biasesName, std::move(*loadWeightResult.biases)));
       }
 
       if (loadWeightResult.scales) {
         auto scalesName = strFormat("%s_loaded_scales", name);
-        if (auto err = takeErr(createAndRegisterConstant(
-                scalesName, std::move(*loadWeightResult.scales)))) {
-          return err;
-        }
+        RETURN_IF_ERR(createAndRegisterConstant(
+            scalesName, std::move(*loadWeightResult.scales)));
       }
     }
 
@@ -284,11 +278,8 @@ protected:
     T.getHandle<int64_t>() =
         std::vector<int64_t>(in.dims().begin(), in.dims().end());
 
-    if (auto resultOrErr = createAndRegisterConstant(opName, std::move(T))) {
-      return llvm::Error::success();
-    } else {
-      return resultOrErr.takeError();
-    }
+    RETURN_IF_ERR(createAndRegisterConstant(opName, std::move(T)));
+
     return llvm::Error::success();
   }
 

--- a/include/glow/Importer/ProtobufLoader.h
+++ b/include/glow/Importer/ProtobufLoader.h
@@ -110,13 +110,17 @@ protected:
   /// name.
   NodeValue getNodeValueByNameOrNullNodeValue(llvm::StringRef name) const;
 
-  // TODO: comment
+  /// \returns the Constant registered with the given \p name and nullptr if
+  /// no Constant has been registered with this name.
   Constant *getConstantByNameOrNull(llvm::StringRef name) const;
 
-  // TODO: comment
+  /// \returns an llvm::Expected of the Constant registered with the given \p
+  /// name and returns and Error if no Constant has been registered with this
+  /// name.
   llvm::Expected<Constant *> getConstantByName(llvm::StringRef name) const;
 
-  // TODO: comment
+  /// \returns whether or not a Constant has been registered with the given \p
+  /// name.
   bool hasConstantByName(llvm::StringRef name) const;
 
 public:

--- a/include/glow/Importer/ProtobufLoader.h
+++ b/include/glow/Importer/ProtobufLoader.h
@@ -124,12 +124,6 @@ public:
   /// \pre hasNodeByName(name)
   llvm::Expected<NodeValue> getNodeValueByName(llvm::StringRef name) const;
 
-  /// \returns the NodeValue that was registered with the name \p name or
-  /// create a new Constant for a tensor with this name. In case a new
-  /// constant is created, this method registers it under \p name.
-  llvm::Expected<NodeValue>
-  getNodeValueOrCreateConstantByName(llvm::StringRef name);
-
   /// \returns True if the node that's registered using \p name exists.
   bool hasNodeByName(llvm::StringRef name) const;
 

--- a/include/glow/Importer/ProtobufLoader.h
+++ b/include/glow/Importer/ProtobufLoader.h
@@ -95,6 +95,11 @@ protected:
   /// A map from names of the external outputs of the network to Variables.
   llvm::StringMap<Placeholder *> outputVarsByName_;
 
+  // Delete all Constants that have no users. This is useful because some
+  // Constants may have been copied and modified during loading instead of used
+  // directly so they may be unused.
+  void deleteUnusedConstants();
+
   /// Create a new constant that's initialized with \p tensor, and register it
   /// under the name \p name. If an existing Placeholder is already registered
   /// under the same name then the tensor is thrown out and no new Constant

--- a/include/glow/Importer/ProtobufLoader.h
+++ b/include/glow/Importer/ProtobufLoader.h
@@ -92,18 +92,13 @@ protected:
   Function &G_;
   /// Saves network nodes by name.
   llvm::StringMap<NodeValue> nodeValueByName_;
-  /// A list of weight tensors indexed by name.
-  llvm::StringMap<std::unique_ptr<Tensor>> tensors_;
   /// A map from names of the external outputs of the network to Variables.
   llvm::StringMap<Placeholder *> outputVarsByName_;
-
-  /// \returns the tensor that was registered under the name \p name.
-  llvm::Expected<Tensor *> getTensorByName(llvm::StringRef name);
 
   /// Create a new constant that's initialized with \p tensor, and register it
   /// under the name \p name. \returns The newly created constant.
   llvm::Expected<Constant *> createAndRegisterConstant(llvm::StringRef name,
-                                                       const Tensor &tensor);
+                                                       Tensor &&tensor);
 
   /// Create a new Placeholder of type \p T, and register it
   /// under the name \p name. \returns The newly created placeholder.
@@ -115,25 +110,34 @@ protected:
   /// name.
   NodeValue getNodeValueByNameOrNullNodeValue(llvm::StringRef name) const;
 
+  // TODO: comment
+  Constant *getConstantByNameOrNull(llvm::StringRef name) const;
+
+  // TODO: comment
+  llvm::Expected<Constant *> getConstantByName(llvm::StringRef name) const;
+
+  // TODO: comment
+  bool hasConstantByName(llvm::StringRef name) const;
+
 public:
   /// \returns the NodeValue that was registered with the name \p name.
   /// \pre hasNodeByName(name)
   llvm::Expected<NodeValue> getNodeValueByName(llvm::StringRef name) const;
 
-  /// \returns the NodeValue that was registered with the name \p name or create
-  /// a new Constant for a tensor with this name. In case a new constant is
-  /// created, this method registers it under \p name.
+  /// \returns the NodeValue that was registered with the name \p name or
+  /// create a new Constant for a tensor with this name. In case a new
+  /// constant is created, this method registers it under \p name.
   llvm::Expected<NodeValue>
   getNodeValueOrCreateConstantByName(llvm::StringRef name);
 
   /// \returns True if the node that's registered using \p name exists.
   bool hasNodeByName(llvm::StringRef name) const;
 
-  /// Constructs new ProtobufLoader object. It will populate the network into \p
-  /// F. The list \p types and \p names are used to initialized the inputs and
-  /// outputs with specific names and types.
-  /// If \p errPtr is not null then if an error occurs it will get assigned
-  /// there otherwise if an error occurs it will abort.
+  /// Constructs new ProtobufLoader object. It will populate the network into
+  /// \p F. The list \p types and \p names are used to initialized the inputs
+  /// and outputs with specific names and types. If \p errPtr is not null then
+  /// if an error occurs it will get assigned there otherwise if an error
+  /// occurs it will abort.
   ProtobufLoader(llvm::ArrayRef<const char *> tensorNames,
                  llvm::ArrayRef<TypeRef> types, Function &F,
                  llvm::Error *errPtr = nullptr);
@@ -147,10 +151,10 @@ public:
     return outputVarsByName_;
   }
 
-  /// \returns the single final output of the network. The function assumes that
-  /// there is only one output, returns Error otherwise. For image
-  /// classification, this single final output is usually the result of the last
-  /// softmax or regression layer.
+  /// \returns the single final output of the network. The function assumes
+  /// that there is only one output, returns Error otherwise. For image
+  /// classification, this single final output is usually the result of the
+  /// last softmax or regression layer.
   llvm::Expected<Placeholder *> getSingleOutput() {
     RETURN_ERR_IF_NOT(outputVarsByName_.size() == 1,
                       "There must be only one output.");

--- a/include/glow/Importer/ProtobufLoader.h
+++ b/include/glow/Importer/ProtobufLoader.h
@@ -96,9 +96,10 @@ protected:
   llvm::StringMap<Placeholder *> outputVarsByName_;
 
   /// Create a new constant that's initialized with \p tensor, and register it
-  /// under the name \p name. \returns The newly created constant.
-  llvm::Expected<Constant *> createAndRegisterConstant(llvm::StringRef name,
-                                                       Tensor &&tensor);
+  /// under the name \p name. If an existing Placeholder is already registered
+  /// under the same name then the tensor is thrown out and no new Constant
+  /// is created.
+  llvm::Error createAndRegisterConstant(llvm::StringRef name, Tensor &&tensor);
 
   /// Create a new Placeholder of type \p T, and register it
   /// under the name \p name. \returns The newly created placeholder.

--- a/include/glow/Support/Error.h
+++ b/include/glow/Support/Error.h
@@ -226,6 +226,14 @@ inline bool errToBool(llvm::Error err) {
   return false;
 }
 
+template <typename T> llvm::Error takeErr(llvm::Expected<T> e) {
+  if (!bool(e)) {
+    return e.takeError();
+  } else {
+    return llvm::Error::success();
+  }
+}
+
 /// This class holds an llvm::Error provided via the add method. If an Error is
 /// added when the class already holds an Error, it will discard the new Error
 /// in favor of the original one. All methods in OneErrOnly are thread-safe.

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -442,6 +442,8 @@ llvm::StringRef Module::uniqueName(llvm::StringRef name,
 
 Constant *Module::addConstant(Constant *V) {
   V->setName(uniqueName(V->getName(), uniqueVariableNames_));
+  // Replace the Constant's output type with the equivalent unique type for this
+  // Module to maintain the invariant that each type in the Module is unique.
   V->setType(Constant::ResultIndices::OutputIdx, uniqueType(*V->getType()));
   constants_.push_back(V);
   return V;

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -413,6 +413,11 @@ Constant *Module::createConstant(llvm::StringRef name, const Tensor &tensor) {
   return V;
 }
 
+// TODO: delete
+Constant *Module::createConstant(llvm::StringRef name, Tensor &&tensor) {
+  return addConstant(new Constant(name, std::move(tensor)));
+}
+
 llvm::StringRef Module::uniqueName(llvm::StringRef name,
                                    llvm::StringSet<> &stringTable) {
   std::string legalName = legalizeName(name);
@@ -438,6 +443,7 @@ llvm::StringRef Module::uniqueName(llvm::StringRef name,
 
 Constant *Module::addConstant(Constant *V) {
   V->setName(uniqueName(V->getName(), uniqueVariableNames_));
+  V->setType(Constant::ResultIndices::OutputIdx, uniqueType(*V->getType()));
   constants_.push_back(V);
   return V;
 }
@@ -2641,6 +2647,10 @@ void Module::eraseConstant(ConstList::iterator I) {
 void Function::eraseNode(NodesList::iterator I) { nodes_.erase(I); }
 
 Constant *Module::getConstantByName(llvm::StringRef name) const {
+  for (auto *V : getConstants()) {
+    llvm::outs() << "constant name: " << V->getName() << "\n";
+  }
+
   for (auto *V : getConstants()) {
     if (V->getName() == name)
       return V;

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -413,7 +413,6 @@ Constant *Module::createConstant(llvm::StringRef name, const Tensor &tensor) {
   return V;
 }
 
-// TODO: delete
 Constant *Module::createConstant(llvm::StringRef name, Tensor &&tensor) {
   return addConstant(new Constant(name, std::move(tensor)));
 }
@@ -2647,10 +2646,6 @@ void Module::eraseConstant(ConstList::iterator I) {
 void Function::eraseNode(NodesList::iterator I) { nodes_.erase(I); }
 
 Constant *Module::getConstantByName(llvm::StringRef name) const {
-  for (auto *V : getConstants()) {
-    llvm::outs() << "constant name: " << V->getName() << "\n";
-  }
-
   for (auto *V : getConstants()) {
     if (V->getName() == name)
       return V;

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -1062,9 +1062,9 @@ Caffe2ModelLoader::loadInputsWithTensorProtoType(const caffe2::NetDef &net,
         placeholder, createAndRegisterPlaceholder(in.name(), &T.getType()));
     nameToInputVars_.try_emplace(in.name(), placeholder);
   } else {
-    std::unique_ptr<Tensor> T(new Tensor());
-    RETURN_IF_ERR(setTensorType(in, T.get()));
-    RETURN_IF_ERR(createAndRegisterConstant(in.name(), std::move(*T)));
+    Tensor T;
+    RETURN_IF_ERR(setTensorType(in, &T));
+    RETURN_IF_ERR(createAndRegisterConstant(in.name(), std::move(T)));
   }
   return llvm::Error::success();
 }

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -1064,10 +1064,7 @@ Caffe2ModelLoader::loadInputsWithTensorProtoType(const caffe2::NetDef &net,
   } else {
     std::unique_ptr<Tensor> T(new Tensor());
     RETURN_IF_ERR(setTensorType(in, T.get()));
-    if (auto err =
-            takeErr(createAndRegisterConstant(in.name(), std::move(*T)))) {
-      return err;
-    }
+    RETURN_IF_ERR(createAndRegisterConstant(in.name(), std::move(*T)));
   }
   return llvm::Error::success();
 }
@@ -1183,10 +1180,7 @@ llvm::Error Caffe2ModelLoader::loadWeight(const caffe2::OperatorDef &op) {
     } else {
       GLOW_UNREACHABLE("Unhandled GivenTensorFill type");
     }
-    if (auto err = takeErr(
-            createAndRegisterConstant(op.output().Get(0), std::move(*T)))) {
-      return err;
-    }
+    RETURN_IF_ERR(createAndRegisterConstant(op.output().Get(0), std::move(*T)));
     return llvm::Error::success();
   }
 
@@ -1228,9 +1222,7 @@ llvm::Error Caffe2ModelLoader::loadWeight(const caffe2::OperatorDef &op) {
       RETURN_ERR_IF_NOT(i == T->size(),
                         "The number of serialized values does not "
                         "match the size of the tensor.");
-      if (auto err = takeErr(createAndRegisterConstant(o, std::move(*T)))) {
-        return err;
-      }
+      RETURN_IF_ERR(createAndRegisterConstant(o, std::move(*T)));
     }
     return llvm::Error::success();
   }
@@ -1302,9 +1294,7 @@ llvm::Error Caffe2ModelLoader::loadWeight(const caffe2::OperatorDef &op) {
                         "The number of serialized values does not "
                         "match the size of the tensor.");
 
-      if (auto err = takeErr(createAndRegisterConstant(o, std::move(*T)))) {
-        return err;
-      }
+      RETURN_IF_ERR(createAndRegisterConstant(o, std::move(*T)));
     }
 
     return llvm::Error::success();
@@ -1378,9 +1368,8 @@ llvm::Error Caffe2ModelLoader::loadWeight(const caffe2::OperatorDef &op) {
       RETURN_ERR("Unsupported datatype for ConstantFill.");
     }
 
-    if (auto err = takeErr(createAndRegisterConstant(name, std::move(*T)))) {
-      return err;
-    }
+    RETURN_IF_ERR(createAndRegisterConstant(name, std::move(*T)));
+
     return llvm::Error::success();
   }
 
@@ -1422,9 +1411,8 @@ llvm::Error Caffe2ModelLoader::loadWeight(const caffe2::OperatorDef &op) {
       elem = G_.getParent()->getPRNG().nextRandReal(tensorMin, tensorMax);
     }
 
-    if (auto err = takeErr(createAndRegisterConstant(name, std::move(*T)))) {
-      return err;
-    }
+    RETURN_IF_ERR(createAndRegisterConstant(name, std::move(*T)));
+
     return llvm::Error::success();
   }
 

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -261,8 +261,7 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     }
 
     NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
 
     Constant *W;
     ASSIGN_VALUE_OR_RETURN_ERR(W, getConstantByName(op.input(1)));
@@ -387,11 +386,9 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     RETURN_ERR_IF_NOT(dict.count("Y_scale"),
                       "missing Y_scale for quantized output type");
     NodeValue in0;
-    ASSIGN_VALUE_OR_RETURN_ERR(in0,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in0, getNodeValueByName(op.input(0)));
     NodeValue in1;
-    ASSIGN_VALUE_OR_RETURN_ERR(in1,
-                               getNodeValueOrCreateConstantByName(op.input(1)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in1, getNodeValueByName(op.input(1)));
     auto outDims = in0.getType()->dims();
     float yScale;
     ASSIGN_VALUE_OR_RETURN_ERR(yScale, loadFloat(dict["Y_scale"]));
@@ -410,8 +407,7 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     RETURN_ERR_IF_NOT(dict.count("Y_scale"),
                       "missing Y_scale for quantized output type");
     NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
     auto outDims = in.getType()->dims();
     float yScale;
     ASSIGN_VALUE_OR_RETURN_ERR(yScale, loadFloat(dict["Y_scale"]));
@@ -426,8 +422,7 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
 
   if (typeName == "Int8Dequantize") {
     NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
     auto *node = G_.createDequantize(opName, in);
     RETURN_IF_ERR(addNodeAsOutput(op, node));
     return llvm::Error::success();
@@ -437,8 +432,7 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
       typeName == "Int8MaxPool" || typeName == "Int8AveragePool") {
     // Load the inputs:
     NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
     std::vector<unsigned_t> strides;
     ASSIGN_VALUE_OR_RETURN_ERR(strides, getSizeHW(dict, "stride", 1));
     std::vector<unsigned_t> kernels;
@@ -522,8 +516,7 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
 
   if (typeName == "SpatialBN") {
     NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
     Constant *scale;
     ASSIGN_VALUE_OR_RETURN_ERR(scale, getConstantByName(op.input(1)));
     Constant *bias;
@@ -553,8 +546,7 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     inputs.reserve(numInputs);
     for (unsigned i = 0; i < numInputs; i++) {
       NodeValue in;
-      ASSIGN_VALUE_OR_RETURN_ERR(
-          in, getNodeValueOrCreateConstantByName(op.input(i)));
+      ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(i)));
       inputs.push_back(in);
     }
 
@@ -603,8 +595,7 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
   if (typeName == "FC" || typeName == "FCTransposed" || typeName == "Int8FC") {
     // Load the inputs:
     NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
 
     auto originalInputDims = in.getType()->dims();
 
@@ -696,8 +687,7 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
 
   if (typeName == "ChannelShuffle") {
     NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
 
     size_t group;
     ASSIGN_VALUE_OR_RETURN_ERR(group, loadInt(dict["group"]));
@@ -711,8 +701,7 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
 
   if (typeName == "Squeeze") {
     NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
     auto dims = getShape(dict["dims"]);
     Node *node = G_.createSqueeze(opName, in, dims);
     RETURN_IF_ERR(addNodeAsOutput(op, node));
@@ -722,8 +711,7 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
   if (typeName == "Log") {
     // Load the inputs:
     NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
     // Create the log:
     auto *R = G_.createLog(opName, in);
     RETURN_IF_ERR(addNodeAsOutput(op, R));
@@ -733,8 +721,7 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
   if (typeName == "Logit") {
     // Load the input and (optional) epsilon clamping value:
     NodeValue input;
-    ASSIGN_VALUE_OR_RETURN_ERR(input,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(input, getNodeValueByName(op.input(0)));
     auto epsIt = dict.find("eps");
     // default: 1e-6 (as in Caffe2)
     float eps = 1E-6f;
@@ -750,11 +737,9 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
 
   if (typeName == "EQ") {
     NodeValue in0;
-    ASSIGN_VALUE_OR_RETURN_ERR(in0,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in0, getNodeValueByName(op.input(0)));
     NodeValue in1;
-    ASSIGN_VALUE_OR_RETURN_ERR(in1,
-                               getNodeValueOrCreateConstantByName(op.input(1)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in1, getNodeValueByName(op.input(1)));
     auto *node = G_.createCmpEQ(opName, in0, in1);
     RETURN_IF_ERR(addNodeAsOutput(op, node));
     return llvm::Error::success();
@@ -762,8 +747,7 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
 
   if (typeName == "Tile") {
     NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
     unsigned_t tiles;
     ASSIGN_VALUE_OR_RETURN_ERR(tiles, loadInt(dict["tiles"]));
     unsigned_t axis;
@@ -780,8 +764,7 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
   }
   if (typeName == "StopGradient") {
     NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
     // Currently Caffe2 importer only supports inference.
     RETURN_IF_ERR(addNodeAsOutput(op, in));
     return llvm::Error::success();
@@ -794,8 +777,7 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
 
   if (typeName == "NCHW2NHWC") {
     NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
     auto *node = G_.createTranspose(opName, in, NCHW2NHWC);
     RETURN_IF_ERR(addNodeAsOutput(op, node));
     return llvm::Error::success();
@@ -807,16 +789,14 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     // Glow does not support any of these ops now, so implement them as
     // no-ops.
     NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
     RETURN_IF_ERR(addNodeAsOutput(op, in));
     return llvm::Error::success();
   }
 
   if (typeName == "Slice") {
     NodeValue data;
-    ASSIGN_VALUE_OR_RETURN_ERR(data,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(data, getNodeValueByName(op.input(0)));
 
     auto starts = getShape<ssize_t>(dict["starts"]);
     auto ends = getShape<ssize_t>(dict["ends"]);
@@ -852,8 +832,7 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
 
   if (typeName == "Cast") {
     NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
     int to;
     ASSIGN_VALUE_OR_RETURN_ERR(to, loadInt(dict["to"]));
 
@@ -879,14 +858,11 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
 
   if (typeName == "ScatterAssign") {
     NodeValue data;
-    ASSIGN_VALUE_OR_RETURN_ERR(data,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(data, getNodeValueByName(op.input(0)));
     NodeValue indices;
-    ASSIGN_VALUE_OR_RETURN_ERR(indices,
-                               getNodeValueOrCreateConstantByName(op.input(1)));
+    ASSIGN_VALUE_OR_RETURN_ERR(indices, getNodeValueByName(op.input(1)));
     NodeValue slices;
-    ASSIGN_VALUE_OR_RETURN_ERR(slices,
-                               getNodeValueOrCreateConstantByName(op.input(2)));
+    ASSIGN_VALUE_OR_RETURN_ERR(slices, getNodeValueByName(op.input(2)));
 
     Node *SAN = G_.createScatterAssign(opName, data, indices, slices);
     RETURN_IF_ERR(addNodeAsOutput(op, SAN));
@@ -901,11 +877,9 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
 
   if (typeName == "SigmoidCrossEntropyWithLogits") {
     NodeValue logits;
-    ASSIGN_VALUE_OR_RETURN_ERR(logits,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(logits, getNodeValueByName(op.input(0)));
     NodeValue targets;
-    ASSIGN_VALUE_OR_RETURN_ERR(targets,
-                               getNodeValueOrCreateConstantByName(op.input(1)));
+    ASSIGN_VALUE_OR_RETURN_ERR(targets, getNodeValueByName(op.input(1)));
     Node *SCEL =
         G_.createSigmoidCrossEntropyWithLogits(opName, logits, targets);
     RETURN_IF_ERR(addNodeAsOutput(op, SCEL));
@@ -919,12 +893,9 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     // value should be 1.
     unsigned axis = 1;
 
-    ASSIGN_VALUE_OR_RETURN_ERR(X,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
-    ASSIGN_VALUE_OR_RETURN_ERR(w,
-                               getNodeValueOrCreateConstantByName(op.input(1)));
-    ASSIGN_VALUE_OR_RETURN_ERR(b,
-                               getNodeValueOrCreateConstantByName(op.input(2)));
+    ASSIGN_VALUE_OR_RETURN_ERR(X, getNodeValueByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(w, getNodeValueByName(op.input(1)));
+    ASSIGN_VALUE_OR_RETURN_ERR(b, getNodeValueByName(op.input(2)));
 
     if (dict.count("axis")) {
       ASSIGN_VALUE_OR_RETURN_ERR(axis, loadInt(dict["axis"]));
@@ -937,8 +908,7 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
 
   if (typeName == "AveragedLoss") {
     NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
     auto *node = G_.createBatchedReduceMean(opName, in, 0);
     RETURN_IF_ERR(addNodeAsOutput(op, node));
     return llvm::Error::success();
@@ -946,8 +916,7 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
 
   if (typeName == "Mod") {
     NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
     int64_t divisor;
     ASSIGN_VALUE_OR_RETURN_ERR(divisor, loadInt(dict["divisor"]));
 
@@ -987,19 +956,17 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     }
 
     NodeValue data;
-    ASSIGN_VALUE_OR_RETURN_ERR(data,
-                               getNodeValueOrCreateConstantByName(op.input(0)));
+    ASSIGN_VALUE_OR_RETURN_ERR(data, getNodeValueByName(op.input(0)));
     NodeValue weights;
     if (isWeighted) {
-      ASSIGN_VALUE_OR_RETURN_ERR(
-          weights, getNodeValueOrCreateConstantByName(op.input(1)));
+      ASSIGN_VALUE_OR_RETURN_ERR(weights, getNodeValueByName(op.input(1)));
     }
     NodeValue indices;
-    ASSIGN_VALUE_OR_RETURN_ERR(
-        indices, getNodeValueOrCreateConstantByName(op.input(indicesIdx)));
+    ASSIGN_VALUE_OR_RETURN_ERR(indices,
+                               getNodeValueByName(op.input(indicesIdx)));
     NodeValue lengths;
-    ASSIGN_VALUE_OR_RETURN_ERR(
-        lengths, getNodeValueOrCreateConstantByName(op.input(lengthsIdx)));
+    ASSIGN_VALUE_OR_RETURN_ERR(lengths,
+                               getNodeValueByName(op.input(lengthsIdx)));
     Constant *dataC = llvm::dyn_cast<Constant>(data);
 
     const size_t numRows = data.dims()[0];
@@ -1041,9 +1008,8 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
       }
     } else {
       NodeValue scalesBiases;
-      ASSIGN_VALUE_OR_RETURN_ERR(
-          scalesBiases,
-          getNodeValueOrCreateConstantByName(op.input(scalesBiasesIdx)));
+      ASSIGN_VALUE_OR_RETURN_ERR(scalesBiases,
+                                 getNodeValueByName(op.input(scalesBiasesIdx)));
 
       Constant *scalesBiasesC = llvm::dyn_cast<Constant>(scalesBiases);
       RETURN_ERR_IF_NOT(scalesBiasesC, "scales_biases must be Constant.");

--- a/lib/Importer/ONNXIFIModelLoader.cpp
+++ b/lib/Importer/ONNXIFIModelLoader.cpp
@@ -57,6 +57,8 @@ llvm::Expected<std::unique_ptr<ONNXIFIModelLoader>> ONNXIFIModelLoader::parse(
 
     RETURN_IF_ERR(onnxLoader->setOutputNodes(graphDef));
 
+    onnxLoader->deleteUnusedConstants();
+
     loader->onnxNameToInputVars_ = onnxLoader->getInputVarsMapping();
 
     // Keep hold of the context
@@ -87,9 +89,12 @@ llvm::Expected<std::unique_ptr<ONNXIFIModelLoader>> ONNXIFIModelLoader::parse(
 
     loader->onnxNameToInputVars_ = c2Loader->getInputVarsMapping();
 
+    c2Loader->deleteUnusedConstants();
+
     // Keep hold of the context
     loader->core_ = std::move(c2Loader);
   }
+
   return llvm::Expected<std::unique_ptr<ONNXIFIModelLoader>>(std::move(loader));
 }
 } // namespace glow

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -386,8 +386,7 @@ llvm::Error ONNXModelLoader::loadSlice(const ONNX_NAMESPACE::NodeProto &op,
                                        const ArgumentDictionaryTy &dict) {
   const std::string &opName = loadOperatorName(op);
   NodeValue data;
-  ASSIGN_VALUE_OR_RETURN_ERR(data,
-                             getNodeValueOrCreateConstantByName(op.input(0)));
+  ASSIGN_VALUE_OR_RETURN_ERR(data, getNodeValueByName(op.input(0)));
   auto dims = data.dims();
   auto numDims = dims.size();
 
@@ -494,11 +493,9 @@ llvm::Error ONNXModelLoader::loadConv(const ONNX_NAMESPACE::NodeProto &op,
 
   // Load the inputs
   NodeValue in;
-  ASSIGN_VALUE_OR_RETURN_ERR(in,
-                             getNodeValueOrCreateConstantByName(op.input(0)));
+  ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
   NodeValue filterValue;
-  ASSIGN_VALUE_OR_RETURN_ERR(filterValue,
-                             getNodeValueOrCreateConstantByName(op.input(1)));
+  ASSIGN_VALUE_OR_RETURN_ERR(filterValue, getNodeValueByName(op.input(1)));
 
   // Transpose the filter to the right format. Glow expects to read the
   // weights in the format CRSK. ONNX stores the operators as KCRS.
@@ -588,8 +585,7 @@ llvm::Error ONNXModelLoader::loadPool(const ONNX_NAMESPACE::NodeProto &op,
   }
   // Load the inputs:
   NodeValue in;
-  ASSIGN_VALUE_OR_RETURN_ERR(in,
-                             getNodeValueOrCreateConstantByName(op.input(0)));
+  ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
   std::vector<unsigned_t> strides(2, 1);
   if (dict.count("strides")) {
     strides = getShape<unsigned_t>(dict.at("strides"));
@@ -639,8 +635,7 @@ ONNXModelLoader::loadGlobalAveragePool(const ONNX_NAMESPACE::NodeProto &op,
 
   // Load the inputs:
   NodeValue in;
-  ASSIGN_VALUE_OR_RETURN_ERR(in,
-                             getNodeValueOrCreateConstantByName(op.input(0)));
+  ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
   std::vector<unsigned_t> strides(2, 1);
   if (dict.count("strides")) {
     strides = getShape<unsigned_t>(dict.at("strides"));
@@ -666,8 +661,7 @@ llvm::Error ONNXModelLoader::loadSqueeze(const ONNX_NAMESPACE::NodeProto &op,
   const std::string &opName = loadOperatorName(op);
 
   NodeValue in;
-  ASSIGN_VALUE_OR_RETURN_ERR(in,
-                             getNodeValueOrCreateConstantByName(op.input(0)));
+  ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
   auto axes = getShape(dict.at("axes"));
   Node *node = G_.createSqueeze(opName, in, axes);
   RETURN_IF_ERR(addNodeAsOutput(op, node));
@@ -679,8 +673,7 @@ llvm::Error ONNXModelLoader::loadUnsqueeze(const ONNX_NAMESPACE::NodeProto &op,
   const std::string &opName = loadOperatorName(op);
 
   NodeValue in;
-  ASSIGN_VALUE_OR_RETURN_ERR(in,
-                             getNodeValueOrCreateConstantByName(op.input(0)));
+  ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
   auto axes = getShape(dict.at("axes"));
   Node *node = G_.createExpandDims(opName, in, axes);
   RETURN_IF_ERR(addNodeAsOutput(op, node));
@@ -693,8 +686,7 @@ ONNXModelLoader::loadBatchNormalization(const ONNX_NAMESPACE::NodeProto &op,
   const std::string &opName = loadOperatorName(op);
 
   NodeValue in;
-  ASSIGN_VALUE_OR_RETURN_ERR(in,
-                             getNodeValueOrCreateConstantByName(op.input(0)));
+  ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
   Constant *scale;
   ASSIGN_VALUE_OR_RETURN_ERR(scale, getConstantByName(op.input(1)));
   Constant *bias;
@@ -732,8 +724,7 @@ llvm::Error ONNXModelLoader::loadConcat(const ONNX_NAMESPACE::NodeProto &op,
   inputs.reserve(numInputs);
   for (unsigned i = 0; i < numInputs; i++) {
     NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in,
-                               getNodeValueOrCreateConstantByName(op.input(i)));
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(i)));
     inputs.push_back(in);
   }
 
@@ -751,8 +742,7 @@ ONNXModelLoader::loadFCTransposed(const ONNX_NAMESPACE::NodeProto &op,
   const std::string &opName = loadOperatorName(op);
 
   NodeValue in;
-  ASSIGN_VALUE_OR_RETURN_ERR(in,
-                             getNodeValueOrCreateConstantByName(op.input(0)));
+  ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
   if (in.getType()->dims().size() > 2) {
     size_t axis = 1;
     if (dict.count("axis")) {
@@ -792,14 +782,11 @@ llvm::Error ONNXModelLoader::loadGemm(const ONNX_NAMESPACE::NodeProto &op,
   const std::string &opName = loadOperatorName(op);
 
   NodeValue A;
-  ASSIGN_VALUE_OR_RETURN_ERR(A,
-                             getNodeValueOrCreateConstantByName(op.input(0)));
+  ASSIGN_VALUE_OR_RETURN_ERR(A, getNodeValueByName(op.input(0)));
   NodeValue B;
-  ASSIGN_VALUE_OR_RETURN_ERR(B,
-                             getNodeValueOrCreateConstantByName(op.input(1)));
+  ASSIGN_VALUE_OR_RETURN_ERR(B, getNodeValueByName(op.input(1)));
   NodeValue C;
-  ASSIGN_VALUE_OR_RETURN_ERR(C,
-                             getNodeValueOrCreateConstantByName(op.input(2)));
+  ASSIGN_VALUE_OR_RETURN_ERR(C, getNodeValueByName(op.input(2)));
 
   bool broadcastC;
   ASSIGN_VALUE_OR_RETURN_ERR(broadcastC, getBroadcast(dict));
@@ -834,11 +821,9 @@ llvm::Error ONNXModelLoader::loadMatMul(const ONNX_NAMESPACE::NodeProto &op,
   const std::string &opName = loadOperatorName(op);
 
   NodeValue LHS;
-  ASSIGN_VALUE_OR_RETURN_ERR(LHS,
-                             getNodeValueOrCreateConstantByName(op.input(0)));
+  ASSIGN_VALUE_OR_RETURN_ERR(LHS, getNodeValueByName(op.input(0)));
   NodeValue RHS;
-  ASSIGN_VALUE_OR_RETURN_ERR(RHS,
-                             getNodeValueOrCreateConstantByName(op.input(1)));
+  ASSIGN_VALUE_OR_RETURN_ERR(RHS, getNodeValueByName(op.input(1)));
 
   Node *node = G_.createMatMul(opName, LHS, RHS);
   RETURN_IF_ERR(addNodeAsOutput(op, node));
@@ -849,8 +834,7 @@ llvm::Error ONNXModelLoader::loadLeakyRelu(const ONNX_NAMESPACE::NodeProto &op,
                                            const ArgumentDictionaryTy &dict) {
   // Input Type.
   NodeValue input;
-  ASSIGN_VALUE_OR_RETURN_ERR(input,
-                             getNodeValueOrCreateConstantByName(op.input(0)));
+  ASSIGN_VALUE_OR_RETURN_ERR(input, getNodeValueByName(op.input(0)));
   ElemKind inputType = input.getType()->getElementType();
 
   // Only supports float types.
@@ -882,8 +866,7 @@ llvm::Error ONNXModelLoader::loadPad(const ONNX_NAMESPACE::NodeProto &op,
 
   // Input
   NodeValue input;
-  ASSIGN_VALUE_OR_RETURN_ERR(input,
-                             getNodeValueOrCreateConstantByName(op.input(0)));
+  ASSIGN_VALUE_OR_RETURN_ERR(input, getNodeValueByName(op.input(0)));
   auto inputDims = input.dims();
   auto numDims = inputDims.size();
 
@@ -939,8 +922,7 @@ llvm::Error ONNXModelLoader::loadCast(const ONNX_NAMESPACE::NodeProto &op,
 
   // Input type
   NodeValue input;
-  ASSIGN_VALUE_OR_RETURN_ERR(input,
-                             getNodeValueOrCreateConstantByName(op.input(0)));
+  ASSIGN_VALUE_OR_RETURN_ERR(input, getNodeValueByName(op.input(0)));
   ElemKind inputKind = input.getType()->getElementType();
 
   // Target type.
@@ -978,8 +960,7 @@ ONNXModelLoader::loadSpaceToDepth(const ONNX_NAMESPACE::NodeProto &op,
 
   // Input Type
   NodeValue input;
-  ASSIGN_VALUE_OR_RETURN_ERR(input,
-                             getNodeValueOrCreateConstantByName(op.input(0)));
+  ASSIGN_VALUE_OR_RETURN_ERR(input, getNodeValueByName(op.input(0)));
 
   int blockSize = 0;
   if (dict.count("blocksize")) {
@@ -1088,8 +1069,7 @@ llvm::Error ONNXModelLoader::setOutputNodes(ONNX_NAMESPACE::GraphProto &net) {
   for (int i = 0; i < net.output_size(); i++) {
     const auto &outputName = net.output(i).name();
     NodeValue r;
-    ASSIGN_VALUE_OR_RETURN_ERR(r,
-                               getNodeValueOrCreateConstantByName(outputName));
+    ASSIGN_VALUE_OR_RETURN_ERR(r, getNodeValueByName(outputName));
     SaveNode *SN = G_.createSave("save_" + outputName, r);
     outputVarsByName_[outputName] = SN->getPlaceholder();
   }

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -94,10 +94,7 @@ llvm::Error ONNXModelLoader::loadInputs(ONNX_NAMESPACE::GraphProto &net,
     } else {
       std::unique_ptr<Tensor> T(new Tensor());
       RETURN_IF_ERR(setTensorType(in.type(), T.get()));
-      if (auto err =
-              takeErr(createAndRegisterConstant(in.name(), std::move(*T)))) {
-        return err;
-      }
+      RETURN_IF_ERR(createAndRegisterConstant(in.name(), std::move(*T)));
     }
   }
   return llvm::Error::success();
@@ -375,9 +372,7 @@ llvm::Error ONNXModelLoader::loadConstant(const ONNX_NAMESPACE::NodeProto &op,
 
   std::unique_ptr<Tensor> T(new Tensor());
   RETURN_IF_ERR(loadTensor(dict.at("value")->t(), T.get()));
-  if (auto err = takeErr(createAndRegisterConstant(name, std::move(*T)))) {
-    return err;
-  }
+  RETURN_IF_ERR(createAndRegisterConstant(name, std::move(*T)));
 
   return llvm::Error::success();
 }
@@ -1053,10 +1048,7 @@ llvm::Error ONNXModelLoader::loadInitializers(ONNX_NAMESPACE::GraphProto &net) {
   for (const auto &in : net.initializer()) {
     std::unique_ptr<Tensor> T(new Tensor());
     RETURN_IF_ERR(loadTensor(in, T.get()));
-    if (auto err =
-            takeErr(createAndRegisterConstant(in.name(), std::move(*T)))) {
-      return err;
-    }
+    RETURN_IF_ERR(createAndRegisterConstant(in.name(), std::move(*T)));
   }
   return llvm::Error::success();
 }

--- a/lib/Importer/ProtobufLoader.cpp
+++ b/lib/Importer/ProtobufLoader.cpp
@@ -27,11 +27,25 @@ bool isArrayConstant(llvm::ArrayRef<size_t> a) {
   return true;
 }
 
-llvm::Expected<Tensor *> ProtobufLoader::getTensorByName(llvm::StringRef name) {
+Constant *ProtobufLoader::getConstantByNameOrNull(llvm::StringRef name) const {
+  auto it = nodeValueByName_.find(name);
+  if (it == nodeValueByName_.end()) {
+    return nullptr;
+  }
+  auto *res = llvm::dyn_cast<Constant>(it->second.getNode());
+  return res ? res : nullptr;
+}
+
+llvm::Expected<Constant *>
+ProtobufLoader::getConstantByName(llvm::StringRef name) const {
+  auto *ptr = getConstantByNameOrNull(name);
   RETURN_ERR_IF_NOT(
-      tensors_.count(name),
-      llvm::Twine("There is no tensor registered with name ", name).str());
-  return tensors_[name].get();
+      ptr, strFormat("could not find constant with name %s", name.data()));
+  return ptr;
+}
+
+bool ProtobufLoader::hasConstantByName(llvm::StringRef name) const {
+  return getConstantByNameOrNull(name) != nullptr;
 }
 
 llvm::Expected<Placeholder *>
@@ -65,13 +79,13 @@ ProtobufLoader::getNodeValueByName(llvm::StringRef name) const {
 
 llvm::Expected<Constant *>
 ProtobufLoader::createAndRegisterConstant(llvm::StringRef name,
-                                          const Tensor &tensor) {
+                                          Tensor &&tensor) {
   RETURN_ERR_IF_NOT(
       !hasNodeByName(name),
       llvm::Twine("Creating an already existing node ", name).str());
   // Note: We do not support training from models loaded from protos, so
   // trainable is always set to false here.
-  Constant *node = G_.getParent()->createConstant(name, tensor);
+  Constant *node = G_.getParent()->createConstant(name, std::move(tensor));
   nodeValueByName_[name] = node->getOutput();
   return node;
 }
@@ -86,6 +100,7 @@ ProtobufLoader::createAndRegisterPlaceholder(llvm::StringRef name, TypeRef T) {
   return node;
 }
 
+// TODO: rename this?
 llvm::Expected<NodeValue>
 ProtobufLoader::getNodeValueOrCreateConstantByName(llvm::StringRef name) {
   auto node = getNodeValueByNameOrNullNodeValue(name);
@@ -93,11 +108,7 @@ ProtobufLoader::getNodeValueOrCreateConstantByName(llvm::StringRef name) {
     return node;
   }
 
-  Tensor *T;
-  ASSIGN_VALUE_OR_RETURN_ERR(T, getTensorByName(name));
-  Constant *c;
-  ASSIGN_VALUE_OR_RETURN_ERR(c, createAndRegisterConstant(name, *T));
-  return c->getOutput();
+  RETURN_ERR(strFormat("Couldn't find Constant with name %s", name.data()));
 }
 
 bool ProtobufLoader::hasNodeByName(llvm::StringRef name) const {

--- a/lib/Importer/ProtobufLoader.cpp
+++ b/lib/Importer/ProtobufLoader.cpp
@@ -100,17 +100,6 @@ ProtobufLoader::createAndRegisterPlaceholder(llvm::StringRef name, TypeRef T) {
   return node;
 }
 
-// TODO: rename this?
-llvm::Expected<NodeValue>
-ProtobufLoader::getNodeValueOrCreateConstantByName(llvm::StringRef name) {
-  auto node = getNodeValueByNameOrNullNodeValue(name);
-  if (node.getNode()) {
-    return node;
-  }
-
-  RETURN_ERR(strFormat("Couldn't find Constant with name %s", name.data()));
-}
-
 bool ProtobufLoader::hasNodeByName(llvm::StringRef name) const {
   return getNodeValueByNameOrNullNodeValue(name).getNode() != nullptr;
 }

--- a/tests/models/caffe2Models/fill_test_predict_net.pbtxt
+++ b/tests/models/caffe2Models/fill_test_predict_net.pbtxt
@@ -1,0 +1,37 @@
+name: "fill_test_dummy_net"
+op {
+  input: "tensor_fill_float"
+  input: "tensor_fill_float"
+  output: "tensor_fill_float_eq"
+  name: ""
+  type: "EQ"
+}
+op {
+  input: "tensor_int_fill"
+  input: "tensor_int_fill"
+  output: "tensor_int_fill_eq"
+  name: ""
+  type: "EQ"
+}
+op {
+  input: "tensor_int64_fill"
+  input: "tensor_int64_fill"
+  output: "tensor_int64_fill_eq"
+  name: ""
+  type: "EQ"
+}
+op {
+  input: "tensor_string_to_uint8_fill"
+  input: "tensor_string_to_uint8_fill"
+  output: "tensor_string_to_uint8_fill_eq"
+  name: ""
+  type: "EQ"
+}
+external_input: "tensor_fill_float"
+external_input: "tensor_int_fill"
+external_input: "tensor_int64_fill"
+external_input: "tensor_string_to_uint8_fill"
+external_output: "tensor_fill_float_eq"
+external_output: "tensor_int_fill_eq"
+external_output: "tensor_int64_fill_eq"
+external_output: "tensor_string_to_uint8_fill_eq"

--- a/tests/unittests/Caffe2ImporterTest.cpp
+++ b/tests/unittests/Caffe2ImporterTest.cpp
@@ -1567,15 +1567,14 @@ TEST(caffe2, tensorFillsTest) {
     Type unusedTy = Type(ElemKind::FloatTy, {1});
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename,
                                {"unused_output"}, {&unusedTy}, *F);
-    tensorFillFloat = llvm::dyn_cast<Constant>(EXIT_ON_ERR(
-        caffe2LD.getNodeValueOrCreateConstantByName("tensor_fill_float")));
-    tensorIntFill = llvm::dyn_cast<Constant>(EXIT_ON_ERR(
-        caffe2LD.getNodeValueOrCreateConstantByName("tensor_int_fill")));
-    tensorInt64Fill = llvm::dyn_cast<Constant>(EXIT_ON_ERR(
-        caffe2LD.getNodeValueOrCreateConstantByName("tensor_int64_fill")));
-    tensorStringToUInt8Fill = llvm::dyn_cast<Constant>(
-        EXIT_ON_ERR(caffe2LD.getNodeValueOrCreateConstantByName(
-            "tensor_string_to_uint8_fill")));
+    tensorFillFloat = llvm::dyn_cast<Constant>(
+        EXIT_ON_ERR(caffe2LD.getNodeValueByName("tensor_fill_float")));
+    tensorIntFill = llvm::dyn_cast<Constant>(
+        EXIT_ON_ERR(caffe2LD.getNodeValueByName("tensor_int_fill")));
+    tensorInt64Fill = llvm::dyn_cast<Constant>(
+        EXIT_ON_ERR(caffe2LD.getNodeValueByName("tensor_int64_fill")));
+    tensorStringToUInt8Fill = llvm::dyn_cast<Constant>(EXIT_ON_ERR(
+        caffe2LD.getNodeValueByName("tensor_string_to_uint8_fill")));
   }
 
   ASSERT_TRUE(tensorFillFloat);

--- a/tests/unittests/Caffe2ImporterTest.cpp
+++ b/tests/unittests/Caffe2ImporterTest.cpp
@@ -161,8 +161,6 @@ TEST(caffe2, convNHWC) {
 
   // We have 2 placeholders:  1 input and 1 output.
   EXPECT_EQ(mod.getPlaceholders().size(), 2);
-  // We have 2 constants: Weights and bias.
-  EXPECT_EQ(mod.getConstants().size(), 2);
 }
 
 /// Test loading MaxPool with NHWC order input.
@@ -661,7 +659,8 @@ TEST(caffe2, FC) {
 
   // Check the numerical values of the weights and biases.
   {
-    const Constant *constant = mod.getConstantByName("weights");
+    // NOTE: this is weights1 because the weights constant was transposed
+    const Constant *constant = mod.getConstantByName("weights1");
     ASSERT_TRUE(constant);
     const Tensor &weights = constant->getPayload();
     const std::vector<size_t> expectedDimensions = {3, 4};
@@ -677,7 +676,7 @@ TEST(caffe2, FC) {
     }
   }
   {
-    const Constant *constant = mod.getConstantByName("biases");
+    const Constant *constant = mod.getConstantByName("bias");
     ASSERT_TRUE(constant);
     const Tensor &bias = constant->getPayload();
     const std::vector<size_t> expectedDimensions = {4};
@@ -799,7 +798,7 @@ TEST(caffe2, FCTransposed) {
     }
   }
   {
-    const Constant *constant = mod.getConstantByName("biases");
+    const Constant *constant = mod.getConstantByName("bias");
     ASSERT_TRUE(constant);
     const Tensor &bias = constant->getPayload();
     const std::vector<size_t> expectedDimensions = {4};


### PR DESCRIPTION
*Description*:
Instead of copying data from tensor that have already been loaded into constants, move the tensor memory instead. This should cut the amount of allocations for weights in the loaders roughly in half.

When loading weights in model loaders, load them directly into `Contant`s instead of into intermediary Tensors to be collected up later.

*Testing*:
CI
Ran on predictor service and dumped before and after heap profiles (see diff)

*Documentation*:
doxygen