### PR TITLE
Disable OpenCL tests temporarily due to sporadic double free in POCL

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -73,7 +73,7 @@ elif [[ "$CIRCLE_JOB" == RELEASE_WITH_EXPENSIVE_TESTS ]]; then
 else
     install_pocl
     CMAKE_ARGS+=("-DCMAKE_BUILD_TYPE=Debug")
-    CMAKE_ARGS+=("-DGLOW_WITH_OPENCL=ON")
+    CMAKE_ARGS+=("-DGLOW_WITH_OPENCL=OFF")
     if [[ "${CIRCLE_JOB}" == "SHARED" ]]; then
         CMAKE_ARGS+=("-DBUILD_SHARED_LIBS=ON")
     fi


### PR DESCRIPTION
*Description*: There's work ongoing to figure this out, but in the meantime we've sorta lost all signal from the Debug build config.  Let's just turn these off until it can get sorted.

*Testing*: This PR
