### PR TITLE
Add BatchMatMul node to allow backends to prevent lowering

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -596,20 +596,11 @@ public:
   MatMulNode *createMatMul(llvm::StringRef name, TypeRef outTy, NodeValue lhs,
                            NodeValue rhs);
 
-  /// \p lhs is a 3d matrix, where the leading dimension is the batch size. \p
-  /// rhs is a 2d matrix, which every batch from \p lhs (a 2d matrix) is
-  /// multiplied by. This is implemented via reshaping \p lhs to be a 2d matrix,
-  /// multiplying by \p rhs, and then reshaping the result back to 3d.
-  Node *createBroadcastedBatchMatMul(llvm::StringRef name, NodeValue lhs,
-                                     NodeValue rhs);
-
   /// \p lhs and \p rhs are 3d matrices, where the leading dimension is the
   /// batch size. For each batch element number i, lhs.slice(i) is multiplied by
-  /// rhs.slice(i). This is implemented by unrolling loop over batch size and
-  /// issuing multiple slice, reshape and matmul instructions, and then
-  /// concatenating results and bringing them back to 3d shape.
-  Node *createParallelBatchMatMul(llvm::StringRef name, NodeValue lhs,
-                                  NodeValue rhs);
+  /// rhs.slice(i).
+  BatchMatMulNode *createBatchMatMul(llvm::StringRef name, NodeValue lhs,
+                                     NodeValue rhs);
 
   /// Create a node, performing BatchedReduceAdd operation. Output type is
   /// based on the input \p batch type with dimensions specified with \p axes

--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -477,14 +477,7 @@ protected:
     // BatchMatMul sometimes is actually just a matmul, depending on dimensions
     // of inputs. Thus, only do batch matmul if LHS is 3-dimensional.
     if (isBatched && LHS.dims().size() == 3) {
-      // BatchMatMul can be either multiplication of K matrices and another
-      // K matrices, or broadcasted multiplication of K matrices and one other
-      // matrix.
-      if (RHS.dims().size() == 3) {
-        node = G_.createParallelBatchMatMul(opName, LHS, RHS);
-      } else {
-        node = G_.createBroadcastedBatchMatMul(opName, LHS, RHS);
-      }
+      node = G_.createBatchMatMul(opName, LHS, RHS);
     } else {
       node = G_.createMatMul(opName, LHS, RHS);
     }

--- a/tests/unittests/GraphOptzTest.cpp
+++ b/tests/unittests/GraphOptzTest.cpp
@@ -2188,16 +2188,16 @@ TEST_F(GraphOptz, sinkRescaledQuantizedNode) {
                                        "input", true);
 
   // slice -> rescale -> reshape -> rescale -> transpose -> maxpool -> save.
-  auto *slice = F_->createSlice("slice", input, {0, 0}, {3, 3});
+  auto *slice = F_->createSlice("slice", input, {0, 0}, {2, 4});
   auto *rescale = F_->createRescaleQuantized(
-      "rescale", slice, mod_.uniqueType(ElemKind::Int8QTy, {3, 3}, 0.4, 10));
-  auto *reshape = F_->createReshape("reshape", rescale, {1, 1, 3, 3});
+      "rescale", slice, mod_.uniqueType(ElemKind::Int8QTy, {2, 4}, 0.4, 10));
+  auto *reshape = F_->createReshape("reshape", rescale, {1, 2, 2, 2});
   auto *rescale2 = F_->createRescaleQuantized(
       "rescale", reshape,
-      mod_.uniqueType(ElemKind::Int8QTy, {1, 1, 3, 3}, 0.3, 9));
+      mod_.uniqueType(ElemKind::Int8QTy, {1, 2, 2, 2}, 0.3, 9));
   auto *transpose = F_->createTranspose("transpose", rescale2, {0, 2, 3, 1});
   auto *maxpool =
-      F_->createMaxPool("maxpool", transpose, {3, 3}, {1, 1}, {0, 0, 0, 0});
+      F_->createMaxPool("maxpool", transpose, {2, 2}, {1, 1}, {0, 0, 0, 0});
   auto *save = F_->createSave("ret", maxpool);
 
   EXPECT_EQ(F_->getNodes().size(), 7);

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -356,7 +356,7 @@ TEST_P(OperatorTest, BroadcastedBatchMatMul) {
                                           -1, -2, -3, -4, -5, -6};
   bindings_.allocate(rhs)->getHandle() = {7, 10};
 
-  auto *R = F_->createBroadcastedBatchMatMul("BMM", lhs, rhs);
+  auto *R = F_->createBatchMatMul("BMM", lhs, rhs);
 
   auto *save = F_->createSave("save", R);
   auto *result = bindings_.allocate(save->getPlaceholder());
@@ -382,7 +382,7 @@ TEST_P(OperatorTest, ParallelBatchMatMul) {
                                           -1, -2, -3, -4, -5, -6};
   bindings_.allocate(rhs)->getHandle() = {7, 10, 12, -1};
 
-  auto *R = F_->createParallelBatchMatMul("BMM", lhs, rhs);
+  auto *R = F_->createBatchMatMul("BMM", lhs, rhs);
 
   auto *save = F_->createSave("save", R);
   auto *result = bindings_.allocate(save->getPlaceholder());

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -312,8 +312,16 @@ int main(int argc, char **argv) {
       .addInput("LHS")
       .addInput("RHS")
       .addResultFromCtorArg()
-      .setDocstring("Performs matrix multiplication between the LHS RHS."
+      .setDocstring("Performs matrix multiplication between the LHS and RHS."
                     "Example: (A, Z) x (Z, B) => (A, B)");
+
+  BB.newNode("BatchMatMul")
+      .addInput("LHS")
+      .addInput("RHS")
+      .addResultFromCtorArg()
+      .setDocstring("Performs batch matrix multiplication between the LHS and "
+                    "RHS. The operands are a stack of two dimensional "
+                    "matrices. Example: (N, A, Z) x (N, Z, B) => (N, A, B)");
 
   BB.newNode("BatchedReduceAdd")
       .addInput("Batch")


### PR DESCRIPTION
*Description*: Some backends may prefer to consume an unlowered BatchMatMul. This PR adds one back in, and lowers it to a series of Slices, MatMuls, and a Concat. There is also an optimization to convert a BatchMatMul with a broadcasted RHS into a single MatMul as was previously directly implemented in `createBroadcastedBatchMatMul()`

*Testing*: Updated/added tests. This included a commit to fix the `sinkRescaledQuantizedNode` test, as it was not updated to account for the optimization converting Transposes to Reshapes where applicable, which the new extra `optimizeReshape()` pass uncovered.
