### PR TITLE
Add Tensor release and Module strip.

### DIFF
--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -293,7 +293,14 @@ public:
     data_ = reinterpret_cast<char *>(alignedAlloc(count, TensorAlignment));
     zero(getElementType() == ElemKind::UInt8FusedQTy);
   }
+  /// Releases the data buffer and sets the unOwned flag to true. This is useful
+  /// for keeping metadata around but not the actual contents.
+  void release() {
+    if (!isUnowned())
+      alignedFree(getData());
 
+    isUnowned_ = true;
+  }
   ~Tensor() {
     if (!isUnowned()) {
       alignedFree(getData());

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -176,9 +176,13 @@ public:
   /// Erase all of the functions from the module.
   void eraseFunctions();
 
-  /// Erase all the functions, variables, etc. If \p clearPlaceholders is false
-  /// then placeholders in the module will not be cleared out.
-  void clear(bool clearPlaceholders = true);
+  /// Erase all the functions, variables, etc.
+  void clear();
+
+  /// Strips payloads from constants and deletes functions. This is useful when
+  /// the Module will be kept around for metadata but we want to reduce memory
+  /// use. Unlike clear this leaves PHs and Constants in the module.
+  void strip();
 
   /// Erase a function \p F from the module.
   void eraseFunction(Function *F);

--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -105,6 +105,8 @@ public:
 
   llvm::hash_code getHash() const;
 
+  void clearPayload() { payload_.release(); }
+
   bool verify() const;
 };
 

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -54,7 +54,15 @@ Function *Module::createFunction(llvm::StringRef name) {
   return F;
 }
 
-void Module::clear(bool clearPlaceholders) {
+void Module::strip() {
+  eraseFunctions();
+  for (auto it = constants_.begin(), e = constants_.end(); it != e; it++) {
+    Constant *v = *it;
+    v->clearPayload();
+  }
+}
+
+void Module::clear() {
   eraseFunctions();
 
   for (auto it = constants_.begin(), e = constants_.end(); it != e; it++) {
@@ -64,15 +72,13 @@ void Module::clear(bool clearPlaceholders) {
 
   constants_.clear();
 
-  if (clearPlaceholders) {
-    for (auto it = placeholders_.begin(), e = placeholders_.end(); it != e;
-         it++) {
-      Placeholder *p = *it;
-      delete p;
-    }
-
-    placeholders_.clear();
+  for (auto it = placeholders_.begin(), e = placeholders_.end(); it != e;
+       it++) {
+    Placeholder *p = *it;
+    delete p;
   }
+
+  placeholders_.clear();
 }
 
 Module::~Module() { clear(); }

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -97,10 +97,10 @@ llvm::Error HostManager::addNetwork(std::unique_ptr<Module> module,
 
   RETURN_IF_ERR(provisioner_->provision(nodeList, *module));
 
-  // Clear everything but placeholders from the module then put it a shared_ptr
-  // to be shared between all of the networks created from each function in the
-  // module.
-  module->clear(/* clearPlaceholders */ false);
+  // Clear functions and constants contents from the module then put it a
+  // shared_ptr to be shared between all of the networks created from each
+  // function in the module.
+  module->strip();
   auto sharedModule = std::shared_ptr<Module>(std::move(module));
 
   for (auto &node : nodeList) {


### PR DESCRIPTION
*Description*: This fixes an issue with OpenCL in the runtime. The module was being cleared but OpenCL needs tensor type information. This adds a new release method to the tensor that frees the data and converts the tensor to an unowned tensor. This also introduces a strip method to the module that releases constants memory and frees functions.

*Testing*: ninja test, and resnet-runtime with openCL
*Documentation*: 