### PR TITLE
Removed deviceConfig specialization. Added string map for parameters.

### DIFF
--- a/include/glow/Runtime/RuntimeTypes.h
+++ b/include/glow/Runtime/RuntimeTypes.h
@@ -120,23 +120,25 @@ using DAGListTy = std::vector<DAG>;
 /// device can extend this class to contain information to identify
 /// and configure the device manager. Additionally it needs to set it's kind_
 /// member variable to it's correct BackendKind.
-class DeviceConfig {
+struct DeviceConfig {
   /// An enum indicating what kind of backend this config is for. It is used in
   /// checking the type of config before casting to a derived class.
-  const BackendKind backendKind_;
+  const BackendKind backendKind;
   /// A human readable name to identify the device.
-  std::string name_;
+  std::string name;
 
-public:
-  DeviceConfig(BackendKind kind) : backendKind_(kind) {}
+  /// A map of configuration parameters.
+  llvm::StringMap<std::string> parameters{};
+
+  DeviceConfig(BackendKind kind) : backendKind(kind) {}
   DeviceConfig(BackendKind kind, std::string name)
-      : backendKind_(kind), name_(name) {}
+      : backendKind(kind), name(name) {}
 
-  BackendKind getBackendKind() { return backendKind_; }
+  DeviceConfig(BackendKind kind, std::string name,
+               llvm::StringMap<std::string> parameters)
+      : backendKind(kind), name(name), parameters(parameters) {}
 
-  llvm::StringRef getName() const { return name_; }
-  bool hasName() const { return name_ != ""; }
-  void setName(llvm::StringRef name) { name_ = name; }
+  bool hasName() const { return name != ""; }
 };
 
 } // namespace runtime

--- a/lib/Backends/OpenCL/OpenCLDeviceManager.h
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.h
@@ -97,6 +97,9 @@ public:
 
   llvm::Error init() override;
 
+  /// Parse config object provided at initialization \returns llvm::Error
+  /// indicating success/failure.
+  llvm::Error parseConfig();
   /// Returns the amount of memory in bytes available on the device when no
   /// models are loaded.
   uint64_t getMaximumMemory() const override;
@@ -133,15 +136,6 @@ protected:
   void runFunctionImpl(runtime::RunIdentifierTy id, std::string functionName,
                        std::unique_ptr<ExecutionContext> context,
                        ResultCBTy cb) override;
-};
-/// OpenCL Device Manager config object. This contains the information needed to
-/// target a specifc OpenCL device. This inherits from DeviceConfig and sets
-/// it's inherited member backendKind_ to OpenCL.
-struct OpenCLDeviceConfig : DeviceConfig {
-  OpenCLDeviceConfig() : DeviceConfig(BackendKind::OpenCL) {}
-  unsigned platformId;
-  unsigned deviceId;
-  bool doProfile;
 };
 
 } // namespace runtime

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -39,15 +39,15 @@ HostManager::init(std::vector<std::unique_ptr<DeviceConfig>> configs) {
   DeviceIDTy deviceCount = 0;
 
   if (configs.size() > 0) {
-    backend_.reset(createBackend(configs[0]->getBackendKind()));
+    backend_.reset(createBackend(configs[0]->backendKind));
   }
 
   for (auto &config : configs) {
     if (!config->hasName()) {
-      config->setName(backend_->getBackendName() + std::to_string(deviceCount));
+      config->name = backend_->getBackendName() + std::to_string(deviceCount);
     }
 
-    auto backendKind = config->getBackendKind();
+    auto backendKind = config->backendKind;
     devices_[deviceCount] = std::unique_ptr<DeviceManager>(
         DeviceManager::createDeviceManager(backendKind, std::move(config)));
 


### PR DESCRIPTION
*Description*: An issue brought up in #2799 is that we want the Loader and any other caller to not require device specific code when calling into the runtime. This change adds a string map for holding parameters for Device Managers. The idea being these can be strings passed in from the command line or config files.
*Testing*: Ninja test, resnet-runtime with opencl
*Documentation*: NA