### PR TITLE
[Interpreter] FullyConnectedNodeKind is not supported by Interpreter backend

### DIFF
--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -144,15 +144,6 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
                {Convolution3DNode::BiasIdx}) &&
            (NI.getInElemTy(Convolution3DNode::BiasIdx) == ElemKind::Int32QTy);
 
-  case Kinded::Kind::FullyConnectedNodeKind:
-    if (!NI.getInTy(FullyConnectedNode::InputIdx)->isQuantizedType()) {
-      return NI.allInputsAndOutputsHaveSameElemKind(
-          {ElemKind::FloatTy, ElemKind::Float16Ty});
-    }
-    return NI.allInputsAndOutputsHaveSameElemKind(
-               {ElemKind::Int8QTy}, {FullyConnectedNode::BiasIdx}) &&
-           (NI.getInElemTy(FullyConnectedNode::BiasIdx) == ElemKind::Int32QTy);
-
   case Kinded::Kind::BatchedAddNodeKind:
     if (!NI.getInTy(BatchedAddNode::BatchIdx)->isQuantizedType()) {
       return NI.allInputsAndOutputsHaveSameElemKind(


### PR DESCRIPTION

*Description*:

For non-quantized FC node, Interpreter::isOpSupported() should return false since this FC node is lowered before isOpSupported check.

*Testing*:
ninja check, run.sh
*Documentation*:
[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
