### PR TITLE
[cleanup][NFC] Remove uses of explicit result indices where possible

### DIFF
--- a/examples/char-rnn.cpp
+++ b/examples/char-rnn.cpp
@@ -171,7 +171,7 @@ static Function *createNetwork(Module &mod, PlaceholderBindings &bindings,
                                   "expected", false);
   bindings.allocate(Y);
 
-  std::vector<Node *> slicesX;
+  std::vector<NodeValue> slicesX;
   std::vector<Node *> expectedX;
 
   for (unsigned t = 0; t < numSteps; t++) {

--- a/examples/ptb.cpp
+++ b/examples/ptb.cpp
@@ -207,7 +207,7 @@ void testPTB() {
                                   "selected", false);
   bindings.allocate(Y);
 
-  std::vector<Node *> slicesX;
+  std::vector<NodeValue> slicesX;
 
   for (unsigned t = 0; t < numSteps; t++) {
     auto XtName = "X." + std::to_string(t);

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -994,9 +994,9 @@ public:
   // The dimensionality of the output variables is \p batchSize x \p outputSize.
   void createSimpleRNN(PlaceholderBindings &bindings,
                        llvm::StringRef namePrefix,
-                       const llvm::ArrayRef<Node *> inputs, unsigned batchSize,
-                       unsigned hiddenSize, unsigned outputSize,
-                       std::vector<NodeValue> &outputs);
+                       const llvm::ArrayRef<NodeValue> inputs,
+                       unsigned batchSize, unsigned hiddenSize,
+                       unsigned outputSize, std::vector<NodeValue> &outputs);
 
   /// Create an unrolled single-layer GRU cell with \p hiddenSize
   /// dimensionality of the hidden state and \p outputSize dimensionality of the
@@ -1007,7 +1007,7 @@ public:
   /// activation of the output layer, unrolled over time.
   // The dimensionality of the output variables is \p batchSize x \p outputSize.
   void createGRU(PlaceholderBindings &bindings, llvm::StringRef namePrefix,
-                 const llvm::ArrayRef<Node *> inputs, unsigned batchSize,
+                 const llvm::ArrayRef<NodeValue> inputs, unsigned batchSize,
                  unsigned hiddenSize, unsigned outputSize,
                  std::vector<NodeValue> &outputs);
 
@@ -1020,7 +1020,7 @@ public:
   /// activation of the output layer, unrolled over time.
   // The dimensionality of the output variables is \p batchSize x \p outputSize.
   void createLSTM(PlaceholderBindings &bindings, llvm::StringRef namePrefix,
-                  const llvm::ArrayRef<Node *> inputs, unsigned batchSize,
+                  const llvm::ArrayRef<NodeValue> inputs, unsigned batchSize,
                   unsigned hiddenSize, unsigned outputSize,
                   std::vector<NodeValue> &outputs);
   /// @}

--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -749,8 +749,7 @@ protected:
       keepDims = (bool)keepdims;
     }
 
-    Node *node = nullptr;
-
+    NodeValue node;
     if (typeName == "ReduceMean") {
       node = G_.createBatchedReduceMean(opName, in, axes);
     } else {
@@ -760,7 +759,7 @@ protected:
     // Our batched reduce add/mean does not keep the dim; reshape if necessary.
     if (keepDims) {
 
-      std::vector<size_t> shape = node->dims(0);
+      std::vector<size_t> shape = node.dims();
 
       // Add removed axes. Requires increasing order sort - done above.
       for (const auto &axis : shapeAxes) {

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -2137,13 +2137,13 @@ Node *Function::createElementwiseLinear(llvm::StringRef name, NodeValue X,
 
 void Function::createGRU(PlaceholderBindings &bindings,
                          llvm::StringRef namePrefix,
-                         llvm::ArrayRef<Node *> inputs, unsigned batchSize,
+                         llvm::ArrayRef<NodeValue> inputs, unsigned batchSize,
                          unsigned hiddenSize, unsigned outputSize,
                          std::vector<NodeValue> &outputs) {
   std::string nameBase = namePrefix;
   const unsigned timeSteps = inputs.size();
   assert(timeSteps > 0 && "empty input");
-  const unsigned inputSize = inputs.front()->dims(0).back();
+  const unsigned inputSize = inputs.front().dims().back();
   assert(inputSize > 0 && "input dimensionality is zero");
 
   // Initialize the state to zero.
@@ -2285,14 +2285,14 @@ void Function::createGRU(PlaceholderBindings &bindings,
 
 void Function::createSimpleRNN(PlaceholderBindings &bindings,
                                llvm::StringRef namePrefix,
-                               llvm::ArrayRef<Node *> inputs,
+                               llvm::ArrayRef<NodeValue> inputs,
                                unsigned batchSize, unsigned hiddenSize,
                                unsigned outputSize,
                                std::vector<NodeValue> &outputs) {
   std::string nameBase = namePrefix;
   const unsigned timeSteps = inputs.size();
   assert(timeSteps > 0 && "empty input");
-  const unsigned inputSize = inputs.front()->dims(0).back();
+  const unsigned inputSize = inputs.front().dims().back();
   assert(inputSize > 0 && "input dimensionality is zero");
 
   // Initialize the state to zero.
@@ -2348,13 +2348,13 @@ void Function::createSimpleRNN(PlaceholderBindings &bindings,
 
 void Function::createLSTM(PlaceholderBindings &bindings,
                           llvm::StringRef namePrefix,
-                          llvm::ArrayRef<Node *> inputs, unsigned batchSize,
+                          llvm::ArrayRef<NodeValue> inputs, unsigned batchSize,
                           unsigned hiddenSize, unsigned outputSize,
                           std::vector<NodeValue> &outputs) {
   std::string nameBase = namePrefix;
   const unsigned timeSteps = inputs.size();
   assert(timeSteps > 0 && "empty input");
-  const unsigned inputSize = inputs.front()->dims(0).back();
+  const unsigned inputSize = inputs.front().dims().back();
   assert(inputSize > 0 && "input dimensionality is zero");
 
   // Initialize the hidden and cell states to zero.

--- a/lib/Partitioner/Partitioner.cpp
+++ b/lib/Partitioner/Partitioner.cpp
@@ -126,10 +126,10 @@ void Partitioner::initOpComputeTime() {
     if (node.getKind() == Kinded::Kind::SparseLengthsWeightedSumNodeKind) {
       auto *SLWSN = llvm::dyn_cast<SparseLengthsWeightedSumNode>(&node);
       /// compute how many entries of the embedding table we look up
-      auto numLookups = SLWSN->getIndices().getNode()->dims(0).front();
+      auto numLookups = SLWSN->getIndices().dims().front();
       /// compute how many bytes we read per lookup
-      auto tableSize = SLWSN->getData().getNode()->getType(0)->getSizeInBytes();
-      auto numRows = SLWSN->getData().getNode()->dims(0).front();
+      auto tableSize = SLWSN->getData().getType()->getSizeInBytes();
+      auto numRows = SLWSN->getData().dims().front();
       auto sizePerLookup = tableSize / numRows;
       /// compute total bytes read
       uint64_t sizeInput = numLookups * sizePerLookup;
@@ -142,13 +142,13 @@ void Partitioner::initOpComputeTime() {
       }
 
       /// we also read the indices, weights and lengths arrays
-      sizeSram += SLWSN->getIndices().getNode()->getType(0)->getSizeInBytes();
-      sizeSram += SLWSN->getWeights().getNode()->getType(0)->getSizeInBytes();
-      sizeSram += SLWSN->getLengths().getNode()->getType(0)->getSizeInBytes();
+      sizeSram += SLWSN->getIndices().getType()->getSizeInBytes();
+      sizeSram += SLWSN->getWeights().getType()->getSizeInBytes();
+      sizeSram += SLWSN->getLengths().getType()->getSizeInBytes();
     } else {
       /// for all other ops, iterate through all inputs and get size in bytes
       for (int i = 0; i < n; i++) {
-        auto ty = node.getNthInput(i).getNode()->getType(0);
+        auto ty = node.getNthInput(i).getType();
         uint64_t sizeInput = ty->getSizeInBytes();
         if (sizeInput > sramCapacity) {
           sizeDram += sizeInput;

--- a/tests/unittests/Caffe2ImporterTest.cpp
+++ b/tests/unittests/Caffe2ImporterTest.cpp
@@ -1418,7 +1418,7 @@ TEST(caffe2, SparseToDenseMask) {
   ASSERT_TRUE(N);
 
   // Check that no batch dimension was added because Lengths was not given.
-  EXPECT_TRUE(N->dims(0).equals({6, 10, 20, 30}));
+  EXPECT_TRUE(N->getResult().dims().equals({6, 10, 20, 30}));
   // Check that mask was read correctly.
   EXPECT_TRUE(N->getMask().equals({42, 100, 300, 1, 0, 312}));
 }

--- a/tests/unittests/MLTest.cpp
+++ b/tests/unittests/MLTest.cpp
@@ -550,29 +550,29 @@ TEST_P(MLTest, learnSingleValueConcat) {
 }
 
 void buildGRU(PlaceholderBindings &bindings, Function *F,
-              const std::vector<Node *> &slicesX, unsigned hiddenSize,
+              const std::vector<NodeValue> &slicesX, unsigned hiddenSize,
               unsigned outputSize, std::vector<NodeValue> &outputs) {
   return F->createGRU(bindings, "GRU", slicesX, 1, hiddenSize, outputSize,
                       outputs);
 };
 
 void buildRNN(PlaceholderBindings &bindings, Function *F,
-              const std::vector<Node *> &slicesX, unsigned hiddenSize,
+              const std::vector<NodeValue> &slicesX, unsigned hiddenSize,
               unsigned outputSize, std::vector<NodeValue> &outputs) {
   return F->createSimpleRNN(bindings, "SimpleRNN", slicesX, 1, hiddenSize,
                             outputSize, outputs);
 };
 
 void buildLSTM(PlaceholderBindings &bindings, Function *F,
-               const std::vector<Node *> &slicesX, unsigned hiddenSize,
+               const std::vector<NodeValue> &slicesX, unsigned hiddenSize,
                unsigned outputSize, std::vector<NodeValue> &outputs) {
   return F->createLSTM(bindings, "LSTM", slicesX, 1, hiddenSize, outputSize,
                        outputs);
 };
 
 using TCellGenerator = void (*)(PlaceholderBindings &, Function *,
-                                const std::vector<Node *> &, unsigned, unsigned,
-                                std::vector<NodeValue> &);
+                                const std::vector<NodeValue> &, unsigned,
+                                unsigned, std::vector<NodeValue> &);
 
 void testRNNCell(TCellGenerator cell) {
   TrainingConfig TC;
@@ -601,7 +601,7 @@ void testRNNCell(TCellGenerator cell) {
   bindings.allocate(Y);
 
   // Extract a slice for each input.
-  std::vector<Node *> XSliced;
+  std::vector<NodeValue> XSliced;
 
   for (unsigned i = 0; i < NumVectors; ++i) {
     std::string Name{"X"};

--- a/tests/unittests/OperatorGradTest.cpp
+++ b/tests/unittests/OperatorGradTest.cpp
@@ -36,8 +36,8 @@ protected:
   /// outputNode's forward value, because RegressionNode's grad is outputNode-0.
   ///
   /// \param outputNode Node that contains result of H(Vars).
-  VariableGradientsList computeVarGrads(Node *outputNode) {
-    auto *Exp = mod_.createPlaceholder(ElemKind::FloatTy, outputNode->dims(0),
+  VariableGradientsList computeVarGrads(NodeValue outputNode) {
+    auto *Exp = mod_.createPlaceholder(ElemKind::FloatTy, outputNode.dims(),
                                        "exp", false);
     bindings_.allocate(Exp)->zero();
 

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -3358,7 +3358,7 @@ TEST_P(OperatorTest, simpleCmpSelectPredication) {
   bindings_.allocate(inputs)->getHandle().clear(1);
 
   Node *cnt = counters;
-  Node *data = inputs;
+  NodeValue data = inputs;
   Node *const1 = F_->createSplat("const1", counters->getType(), 1.0);
   Node *const0 = F_->createSplat("const0", counters->getType(), 0.0);
 
@@ -3366,8 +3366,7 @@ TEST_P(OperatorTest, simpleCmpSelectPredication) {
     cnt = F_->createSub("sub1", cnt, const1);
     Node *pred = F_->createCmpLTE("cmp", const0, cnt);
 
-    assert(data->getNumResults() == 1 && "Data should have a single output.");
-    Node *const2 = F_->createSplat("const2", data->getType(0), 2.0);
+    Node *const2 = F_->createSplat("const2", data.getType(), 2.0);
     Node *newData = F_->createMul("mul2x", data, const2);
 
     data = F_->createSelect("select", pred, newData, data);
@@ -5689,29 +5688,29 @@ static void testFlatten(glow::PlaceholderBindings &bindings, glow::Module &mod,
   bindings.allocate(tensor4D)->getHandle<DataType>().randomize(0, 100,
                                                                mod.getPRNG());
 
-  auto *reshape4Dto2DAxis1 = F->createFlatten("flat4Dto2Da1", tensor4D, 1);
-  EXPECT_EQ(reshape4Dto2DAxis1->dims(0).size(), 2);
-  EXPECT_EQ(reshape4Dto2DAxis1->dims(0)[0], 3);
-  EXPECT_EQ(reshape4Dto2DAxis1->dims(0)[1], 24);
+  NodeValue reshape4Dto2DAxis1 = F->createFlatten("flat4Dto2Da1", tensor4D, 1);
+  EXPECT_EQ(reshape4Dto2DAxis1.dims().size(), 2);
+  EXPECT_EQ(reshape4Dto2DAxis1.dims()[0], 3);
+  EXPECT_EQ(reshape4Dto2DAxis1.dims()[1], 24);
 
-  auto *reshape4Dto2DAxis2 = F->createFlatten("flat4Dto2Da2", tensor4D, 2);
-  EXPECT_EQ(reshape4Dto2DAxis2->dims(0).size(), 2);
-  EXPECT_EQ(reshape4Dto2DAxis2->dims(0)[0], 6);
-  EXPECT_EQ(reshape4Dto2DAxis2->dims(0)[1], 12);
+  NodeValue reshape4Dto2DAxis2 = F->createFlatten("flat4Dto2Da2", tensor4D, 2);
+  EXPECT_EQ(reshape4Dto2DAxis2.dims().size(), 2);
+  EXPECT_EQ(reshape4Dto2DAxis2.dims()[0], 6);
+  EXPECT_EQ(reshape4Dto2DAxis2.dims()[1], 12);
 
-  auto *reshape4Dto2DAxis3 = F->createFlatten("flat4Dto2Da3", tensor4D, 3);
-  EXPECT_EQ(reshape4Dto2DAxis3->dims(0).size(), 2);
-  EXPECT_EQ(reshape4Dto2DAxis3->dims(0)[0], 24);
-  EXPECT_EQ(reshape4Dto2DAxis3->dims(0)[1], 3);
+  NodeValue reshape4Dto2DAxis3 = F->createFlatten("flat4Dto2Da3", tensor4D, 3);
+  EXPECT_EQ(reshape4Dto2DAxis3.dims().size(), 2);
+  EXPECT_EQ(reshape4Dto2DAxis3.dims()[0], 24);
+  EXPECT_EQ(reshape4Dto2DAxis3.dims()[1], 3);
 
   // Now, let us do the fifth (4) axis.
   // This comes straight from caffe2 because flattening is
   // supported for every axis up and including the rank of a tensor.
   // The rank of this tensor is 4, so axis 4 is fine.
-  auto *reshape4Dto2DAxis4 = F->createFlatten("flat4Dto2Da4", tensor4D, 4);
-  EXPECT_EQ(reshape4Dto2DAxis4->dims(0).size(), 2);
-  EXPECT_EQ(reshape4Dto2DAxis4->dims(0)[0], 72);
-  EXPECT_EQ(reshape4Dto2DAxis4->dims(0)[1], 1);
+  NodeValue reshape4Dto2DAxis4 = F->createFlatten("flat4Dto2Da4", tensor4D, 4);
+  EXPECT_EQ(reshape4Dto2DAxis4.dims().size(), 2);
+  EXPECT_EQ(reshape4Dto2DAxis4.dims()[0], 72);
+  EXPECT_EQ(reshape4Dto2DAxis4.dims()[1], 1);
 
   // This one is weird because we flatten something that is already flat, but
   // again because flattening is supported for every axis up and including the
@@ -5721,10 +5720,10 @@ static void testFlatten(glow::PlaceholderBindings &bindings, glow::Module &mod,
   bindings.allocate(tensor1D)->getHandle<DataType>().randomize(0, 100,
                                                                mod.getPRNG());
 
-  auto *reshape1Dto2DAxis1 = F->createFlatten("flat1Dto2D", tensor1D, 1);
-  EXPECT_EQ(reshape1Dto2DAxis1->dims(0).size(), 2);
-  EXPECT_EQ(reshape1Dto2DAxis1->dims(0)[0], 15);
-  EXPECT_EQ(reshape1Dto2DAxis1->dims(0)[1], 1);
+  NodeValue reshape1Dto2DAxis1 = F->createFlatten("flat1Dto2D", tensor1D, 1);
+  EXPECT_EQ(reshape1Dto2DAxis1.dims().size(), 2);
+  EXPECT_EQ(reshape1Dto2DAxis1.dims()[0], 15);
+  EXPECT_EQ(reshape1Dto2DAxis1.dims()[1], 1);
 
   // Save all the reshapes so that the optimizations won't kill the network.
   auto *save1Dto2D = F->createSave("save1Dto2D", reshape1Dto2DAxis1);


### PR DESCRIPTION
Summary: This is intended to be NFC. There were many places where we were using `dims(0)`/`getType(0)`. This use of explicit result indices should be avoided. I removed almost all of them, mostly just replacing them with `NodeValue::dims()`/`NodeValue::getType()` instead.

Test Plan: All tests pass.
