### PR TITLE
[cmake] Make 1 library per lib/ subdirectory

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -96,8 +96,7 @@ if(GLOW_WITH_CPU)
                           ExecutionEngine
                           Graph
                           Importer
-                          Optimizer
-                          ThreadPool)
+                          Optimizer)
 endif()
 
 

--- a/lib/Backends/CMakeLists.txt
+++ b/lib/Backends/CMakeLists.txt
@@ -26,7 +26,6 @@ add_library(Backends
 target_link_libraries(Backends
                       PUBLIC
                         ExecutionContext
-                        ${linked_device_managers}
                       PRIVATE
                         Backend
                         Base
@@ -34,7 +33,7 @@ target_link_libraries(Backends
                         Graph
                         Optimizer)
 
-FOREACH(factory ${linked_factories})
-  make_whole_archive(Backends ${factory})
-  target_link_libraries(Backends PRIVATE ${factory})
+FOREACH(backend ${linked_backends})
+  make_whole_archive(Backends ${backend})
+  target_link_libraries(Backends PRIVATE ${backend})
 ENDFOREACH()

--- a/lib/Backends/CMakeLists.txt
+++ b/lib/Backends/CMakeLists.txt
@@ -26,7 +26,6 @@ add_library(Backends
 target_link_libraries(Backends
                       PUBLIC
                         ExecutionContext
-                        ThreadPool
                         ${linked_device_managers}
                       PRIVATE
                         Backend

--- a/lib/Backends/CPU/CMakeLists.txt
+++ b/lib/Backends/CPU/CMakeLists.txt
@@ -88,5 +88,4 @@ target_link_libraries(CPUBackend
                         LLVMIRCodeGen)
 add_dependencies(CPUBackend CPURuntime)
 
-set(linked_factories ${linked_factories} CPUBackend PARENT_SCOPE)
-set(linked_device_managers ${linked_device_managers} CPUBackend PARENT_SCOPE)
+set(linked_backends ${linked_backends} CPUBackend PARENT_SCOPE)

--- a/lib/Backends/CPU/CMakeLists.txt
+++ b/lib/Backends/CPU/CMakeLists.txt
@@ -102,8 +102,7 @@ target_link_libraries(CPUDeviceManager
                         CPUBackend
                         Graph
                         IR
-                        Optimizer
-                        ThreadPool)
+                        Optimizer)
 
 set(linked_factories ${linked_factories} CPUFactory PARENT_SCOPE)
 set(linked_device_managers ${linked_device_managers} CPUDeviceManager PARENT_SCOPE)

--- a/lib/Backends/CPU/CMakeLists.txt
+++ b/lib/Backends/CPU/CMakeLists.txt
@@ -70,11 +70,12 @@ endif(NOT MSVC)
 
 add_library(CPUBackend
             "${CMAKE_BINARY_DIR}/glow/CPU/libjit_bc.inc"
-            CPUFunction.cpp
-            Transforms.cpp
             CPUBackend.cpp
-            CPULLVMIRGen.cpp)
-
+            CPUDeviceManager.cpp
+            CPUFactory.cpp
+            CPUFunction.cpp
+            CPULLVMIRGen.cpp
+            Transforms.cpp)
 target_link_libraries(CPUBackend
                       PUBLIC
                         Backend
@@ -87,22 +88,5 @@ target_link_libraries(CPUBackend
                         LLVMIRCodeGen)
 add_dependencies(CPUBackend CPURuntime)
 
-add_library(CPUFactory
-              CPUFactory.cpp)
-target_link_libraries(CPUFactory
-                      PRIVATE
-                        CPUBackend)
-
-add_library(CPUDeviceManager
-            CPUDeviceManager.cpp)
-target_link_libraries(CPUDeviceManager
-                      PRIVATE
-                        Base
-                        CodeGen
-                        CPUBackend
-                        Graph
-                        IR
-                        Optimizer)
-
-set(linked_factories ${linked_factories} CPUFactory PARENT_SCOPE)
-set(linked_device_managers ${linked_device_managers} CPUDeviceManager PARENT_SCOPE)
+set(linked_factories ${linked_factories} CPUBackend PARENT_SCOPE)
+set(linked_device_managers ${linked_device_managers} CPUBackend PARENT_SCOPE)

--- a/lib/Backends/Habana/CMakeLists.txt
+++ b/lib/Backends/Habana/CMakeLists.txt
@@ -27,8 +27,7 @@ target_link_libraries(HabanaDeviceManager
                         Base
                         Graph
                         IR
-                        Optimizer
-                        ThreadPool)
+                        Optimizer)
 
 add_library(HabanaFactory
             HabanaFactory.cpp)

--- a/lib/Backends/Habana/CMakeLists.txt
+++ b/lib/Backends/Habana/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_library(Habana
-            Habana.cpp)
+            Habana.cpp
+            HabanaDeviceManager.cpp
+            HabanaFactory.cpp)
 
 target_include_directories(Habana
                            PUBLIC
@@ -14,27 +16,10 @@ target_link_libraries(Habana
                         Graph
                         CodeGen
                         IR
+                        LLVMCore
                         Optimizer
                         QuantizationBase
                         Support)
 
-add_library(HabanaDeviceManager
-            HabanaDeviceManager.cpp)
-target_link_libraries(HabanaDeviceManager
-                      PRIVATE
-                        Backend
-                        Habana
-                        Base
-                        Graph
-                        IR
-                        Optimizer)
-
-add_library(HabanaFactory
-            HabanaFactory.cpp)
-target_link_libraries(HabanaFactory
-                      PRIVATE
-                        Habana
-                        LLVMCore)
-
-set(linked_factories ${linked_factories} HabanaFactory PARENT_SCOPE)
-set(linked_device_managers ${linked_device_managers} HabanaDeviceManager PARENT_SCOPE)
+set(linked_factories ${linked_factories} Habana PARENT_SCOPE)
+set(linked_device_managers ${linked_device_managers} Habana PARENT_SCOPE)

--- a/lib/Backends/Habana/CMakeLists.txt
+++ b/lib/Backends/Habana/CMakeLists.txt
@@ -21,5 +21,4 @@ target_link_libraries(Habana
                         QuantizationBase
                         Support)
 
-set(linked_factories ${linked_factories} Habana PARENT_SCOPE)
-set(linked_device_managers ${linked_device_managers} Habana PARENT_SCOPE)
+set(linked_backends ${linked_backends} Habana PARENT_SCOPE)

--- a/lib/Backends/Interpreter/CMakeLists.txt
+++ b/lib/Backends/Interpreter/CMakeLists.txt
@@ -15,5 +15,4 @@ target_link_libraries(Interpreter
                         Optimizer
                         QuantizationBase)
 
-set(linked_factories ${linked_factories} Interpreter PARENT_SCOPE)
-set(linked_device_managers ${linked_device_managers} Interpreter PARENT_SCOPE)
+set(linked_backends ${linked_backends} Interpreter PARENT_SCOPE)

--- a/lib/Backends/Interpreter/CMakeLists.txt
+++ b/lib/Backends/Interpreter/CMakeLists.txt
@@ -22,8 +22,7 @@ target_link_libraries(InterpreterDeviceManager
                         CodeGen
                         Graph
                         IR
-                        Optimizer
-                        ThreadPool)
+                        Optimizer)
 
 add_library(InterpreterFactory
               InterpreterFactory.cpp)

--- a/lib/Backends/Interpreter/CMakeLists.txt
+++ b/lib/Backends/Interpreter/CMakeLists.txt
@@ -1,35 +1,19 @@
 add_library(Interpreter
               Interpreter.cpp
               InterpreterFunction.cpp
-              InterpreterNodes.cpp)
+              InterpreterNodes.cpp
+              InterpreterDeviceManager.cpp
+              InterpreterFactory.cpp)
 target_link_libraries(Interpreter
                       PRIVATE
                         Backend
                         Base
-                        Graph
                         CodeGen
+                        Graph
                         IR
+                        LLVMCore
                         Optimizer
                         QuantizationBase)
 
-add_library(InterpreterDeviceManager
-              InterpreterDeviceManager.cpp)
-target_link_libraries(InterpreterDeviceManager
-                      PRIVATE
-                        Backend
-                        Interpreter
-                        Base
-                        CodeGen
-                        Graph
-                        IR
-                        Optimizer)
-
-add_library(InterpreterFactory
-              InterpreterFactory.cpp)
-target_link_libraries(InterpreterFactory
-                      PRIVATE
-                        Interpreter
-                        LLVMCore)
-
-set(linked_factories ${linked_factories} InterpreterFactory PARENT_SCOPE)
-set(linked_device_managers ${linked_device_managers} InterpreterDeviceManager PARENT_SCOPE)
+set(linked_factories ${linked_factories} Interpreter PARENT_SCOPE)
+set(linked_device_managers ${linked_device_managers} Interpreter PARENT_SCOPE)

--- a/lib/Backends/OpenCL/CMakeLists.txt
+++ b/lib/Backends/OpenCL/CMakeLists.txt
@@ -26,6 +26,8 @@ add_library(OpenCLBackend
             "${CMAKE_BINARY_DIR}/glow/OpenCL/kernels_fwd_conv.cl.inc"
             "${CMAKE_BINARY_DIR}/glow/OpenCL/kernels_fwd_quantized_conv.cl.inc"
             OpenCL.cpp
+            OpenCLDeviceManager.cpp
+            OpenCLFactory.cpp
             Transforms.cpp)
 
 target_link_libraries(OpenCLBackend
@@ -35,6 +37,7 @@ target_link_libraries(OpenCLBackend
                       Graph
                       CodeGen
                       IR
+                      LLVMCore
                       Optimizer
                       QuantizationBase)
 
@@ -42,24 +45,5 @@ target_link_libraries(OpenCLBackend
                       PUBLIC
                       OpenCL::OpenCL)
 
-add_library(OpenCLDeviceManager
-            OpenCLDeviceManager.cpp)
-target_link_libraries(OpenCLDeviceManager
-                      PRIVATE
-                        Backend
-                        OpenCLBackend
-                        Base
-                        CodeGen
-                        Graph
-                        IR
-                        Optimizer)
-
-add_library(OpenCLFactory
-              OpenCLFactory.cpp)
-target_link_libraries(OpenCLFactory
-                      PRIVATE
-                        OpenCLBackend
-                        LLVMCore)
-
-set(linked_factories ${linked_factories} OpenCLFactory PARENT_SCOPE)
-set(linked_device_managers ${linked_device_managers} OpenCLDeviceManager PARENT_SCOPE)
+set(linked_factories ${linked_factories} OpenCLBackend PARENT_SCOPE)
+set(linked_device_managers ${linked_device_managers} OpenCLBackend PARENT_SCOPE)

--- a/lib/Backends/OpenCL/CMakeLists.txt
+++ b/lib/Backends/OpenCL/CMakeLists.txt
@@ -45,5 +45,4 @@ target_link_libraries(OpenCLBackend
                       PUBLIC
                       OpenCL::OpenCL)
 
-set(linked_factories ${linked_factories} OpenCLBackend PARENT_SCOPE)
-set(linked_device_managers ${linked_device_managers} OpenCLBackend PARENT_SCOPE)
+set(linked_backends ${linked_backends} OpenCLBackend PARENT_SCOPE)

--- a/lib/Backends/OpenCL/CMakeLists.txt
+++ b/lib/Backends/OpenCL/CMakeLists.txt
@@ -52,8 +52,7 @@ target_link_libraries(OpenCLDeviceManager
                         CodeGen
                         Graph
                         IR
-                        Optimizer
-                        ThreadPool)
+                        Optimizer)
 
 add_library(OpenCLFactory
               OpenCLFactory.cpp)

--- a/lib/Runtime/Executor/CMakeLists.txt
+++ b/lib/Runtime/Executor/CMakeLists.txt
@@ -3,8 +3,6 @@ add_library(Executor
               ThreadPoolExecutor.cpp)
 
 target_link_libraries(Executor
-                      PUBLIC
-                        ThreadPool
                       PRIVATE
                         ExecutionContext
                         Graph)

--- a/lib/Runtime/HostManager/CMakeLists.txt
+++ b/lib/Runtime/HostManager/CMakeLists.txt
@@ -10,9 +10,3 @@ target_link_libraries(HostManager
                         Partitioner
                         Provisioner
                         Executor)
-
-if (GLOW_WITH_CPU)
-  target_link_libraries(HostManager
-                        PRIVATE
-                          CPUDeviceManager)
-endif()

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -2,10 +2,8 @@ add_library(Support
               Debug.cpp
               Error.cpp
               Random.cpp
-              Support.cpp)
+              Support.cpp
+              ThreadPool.cpp)
 target_link_libraries(Support
                       PUBLIC
                         LLVMSupport)
-
-add_library(ThreadPool
-              ThreadPool.cpp)

--- a/tests/benchmark/CMakeLists.txt
+++ b/tests/benchmark/CMakeLists.txt
@@ -21,7 +21,6 @@ target_link_libraries(RuntimeBench
                       PRIVATE
                         Backend
                         Backends
-                        CPUBackend
                         ExecutionEngine
                         Executor
                         HostManager

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -113,8 +113,7 @@ target_link_libraries(ExecutorTest
         Executor
         Graph
         gtest
-        TestMain
-        ThreadPool)
+        TestMain)
 add_glow_test(ExecutorTest ${GLOW_BINARY_DIR}/tests/ExecutorTest --gtest_output=xml:ExecutorTest.xml)
 
 add_executable(Float16Test
@@ -451,7 +450,7 @@ add_executable(ThreadPoolTest
                ThreadPoolTest.cpp)
 target_link_libraries(ThreadPoolTest
                       PRIVATE
-                        ThreadPool
+                        Support
                         gtest
                         TestMain)
 add_glow_test(ThreadPoolTest ${GLOW_BINARY_DIR}/tests/ThreadPoolTest --gtest_output=xml:ThreadPoolTest.xml)


### PR DESCRIPTION
*Description*: Gets our lib organization all squared away:
- ThreadPool -> Support
- Every Xyz{Backend,DeviceManager,Factory} condensed to a single XyzBackend library
- I made exceptions for Onnxifi (one of the libs is the .so interface library that onnxifi exports) and CPUBackend (since we build a native libjit used for unit testing).

*Testing*:
`ninja check` with shared and static libs
