### PR TITLE
[Easy] Tweak GlowErr message

### DIFF
--- a/include/glow/Support/Error.h
+++ b/include/glow/Support/Error.h
@@ -91,7 +91,7 @@ public:
   /// line number the GlowErr was created on as well as the message and/or error
   /// code the GlowErr was created with.
   void log(llvm::raw_ostream &OS) const override {
-    OS << "file: " << fileName_ << " line: " << lineNumber_;
+    OS << "location: " << fileName_ << ":" << lineNumber_;
     if (ec_ != ErrorCode::UNKNOWN) {
       OS << " error code: " << errorCodeToString(ec_);
     }


### PR DESCRIPTION
*Description*:
Change the message that GlowErr prints out to be file:line so that it can be used more easily with vscode/atom go to line functionality.

*Testing*:
CI

*Documentation*:
None