### PR TITLE
Make build_llvm take RELEASE from environment if provided

### DIFF
--- a/utils/build_llvm.sh
+++ b/utils/build_llvm.sh
@@ -17,7 +17,7 @@
 
 set -euo pipefail
 
-RELEASE=release_80
+RELEASE=${RELEASE:-release_80}
 if [ ! -e "./llvm/" ]; then
     git clone --depth=1 -b "$RELEASE" https://github.com/llvm-mirror/llvm.git llvm
 fi


### PR DESCRIPTION
*Description*: For testing on CentOS I need to set this to release_70, so might as well make it slightly more configurable.
*Testing*: Used it.

