### PR TITLE
always generate TraceEvents when doing debug dumping

### DIFF
--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -21,6 +21,8 @@
 
 namespace glow {
 namespace onnxifi {
+extern bool GlowDumpDebugTraces;
+
 namespace {
 const char *compatibilityFunctionName = "check";
 } // namespace
@@ -99,7 +101,7 @@ onnxStatus Graph::setIOAndRun(uint32_t inputsCount,
   auto ctx = llvm::make_unique<ExecutionContext>();
 
   TraceContext *traceContext = nullptr;
-  if (traceEvents) {
+  if (traceEvents || GlowDumpDebugTraces) {
     ctx->setTraceContext(llvm::make_unique<TraceContext>(TraceLevel::STANDARD));
     traceContext = ctx->getTraceContext();
   }


### PR DESCRIPTION
Summary: If dumping debug traces to disk, make sure there are always events enabled.

Differential Revision: D15326163

