### PR TITLE
Add copyOutputs trace event to HabanaDeviceManager

### DIFF
--- a/lib/Backends/Habana/HabanaDeviceManager.cpp
+++ b/lib/Backends/Habana/HabanaDeviceManager.cpp
@@ -336,6 +336,7 @@ void HabanaDeviceManager::runFunctionImpl(RunIdentifierTy runId,
     } else {
       // Copy the execution outputs from the designated IO buffer back to the
       // PlaceholderBindings inside ctx.
+      TRACE_EVENT_BEGIN(ctx->getTraceContext(), "copyOutputs");
       auto bindings = ctx->getPlaceholderBindings();
       for (const auto &ph : function->getOutputs()) {
         auto *tensor = bindings->get(ph);
@@ -345,6 +346,7 @@ void HabanaDeviceManager::runFunctionImpl(RunIdentifierTy runId,
         memcpy(tensor->getUnsafePtr(), ioBuffer->get(ph),
                ph->getType()->getSizeInBytes());
       }
+      TRACE_EVENT_END(ctx->getTraceContext(), "copyOutputs");
 
       // Return the IO buffer to the IO buffer pool.
       ioBufferPool->put(std::move(ioBuffer));


### PR DESCRIPTION
*Description*:
Add an additional trace event to capture time spent copying outputs from device buffers.

*Testing*:
CI
![Screen Shot 2019-05-10 at 12 56 09 PM](https://user-images.githubusercontent.com/1740091/57732140-3ed3b080-7651-11e9-875e-e502d5f64e8e.png)

*Documentation*:
n/a