### PR TITLE
Remove unused placeholder bindings in HabanaFunction

### DIFF
--- a/lib/Backends/Habana/Habana.h
+++ b/lib/Backends/Habana/Habana.h
@@ -229,7 +229,6 @@ public:
 private:
   Function *F_;
   std::string recipeName_;
-  const PlaceholderBindings *ctx_;
   PlaceholderList inputs_;
   PlaceholderList outputs_;
 };

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -255,9 +255,11 @@ void ExecutionEngine::compile(Function *F, const CompilationContext &cctx,
   EXIT_ON_ERR(::glow::optimizeFunction(F, *backend_, cctx));
 
   for (const Node &N : F->getNodes()) {
-    (void)N;
-    assert(backend_->isOpSupported(N) &&
-           "Backend must support all nodes after high-level optimizations.");
+    if (!backend_->isOpSupported(N)) {
+      llvm::errs() << "Unsupported operator: " << N.getDebugDesc() << "\n";
+      GLOW_UNREACHABLE(
+          "Backend must support all nodes after high-level optimizations.");
+    }
   }
 
   auto func = backend_->compile(F, cctx.backendOpts);


### PR DESCRIPTION
Summary:
This was a vestigial thing left over from an earlier implementation of
HabanaFunction.

Differential Revision: D15345326

