### PR TITLE
[OpenCL] Make OpenCLFunction thread safe

### DIFF
--- a/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
@@ -71,6 +71,7 @@ cl_mem OpenCLDeviceManager::allocDeviceBuffer(uint64_t size) {
   GLOW_ASSERT(buf && "Allocation failed!");
   return buf;
 }
+
 OpenCLDeviceManager::OpenCLDeviceManager(std::unique_ptr<DeviceConfig> config)
     : QueueBackedDeviceManager(BackendKind::OpenCL, std::move(config)) {}
 


### PR DESCRIPTION
**Description*
This commit makes `OpenCLFunction` thread-safe by deleting its member
variables for the OpenCL context, device ID, command queue, etc. and
using the instances of these variables passed to `OpenCLFunction::execute`
as part of the `DeviceBindings` inside the `ExecutionContext`.

**Testing**
All unit tests pass.

**Fixes**
This commit fixes #2651.