### PR TITLE
Avoid copying onnxifi weights where possible

### DIFF
--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -74,10 +74,10 @@ private:
   /// \returns a pointer to the tensor data buffer.
   char *getData() const { return data_; }
 
+public:
   /// \returns true if it is an unowned tensor.
   bool isUnowned() const { return isUnowned_; }
 
-public:
   /// \returns the type of the tensor.
   const Type &getType() const { return type_; }
 

--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -97,7 +97,7 @@ public:
     // If payload is unowned, make an owned copy of the payload for
     // modification.
     if (payload_.isUnowned()) {
-      return payload_ = payload_.clone();
+      payload_ = payload_.clone();
     }
     assert(!payload_.isUnowned() &&
            "Can only modify Constants with owned payloads");

--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -91,8 +91,20 @@ public:
     return k->getKind() == Kinded::Kind::ConstantKind;
   }
 
-  Tensor &getPayload() { return payload_; }
+  /// \returns a mutable reference to the payload tensor. If the payload tensor
+  /// is unowned then it will be converted to an owned copy before returning.
+  Tensor &getPayloadMutable() {
+    // If payload is unowned, make an owned copy of the payload for
+    // modification.
+    if (payload_.isUnowned()) {
+      return payload_ = payload_.clone();
+    }
+    assert(!payload_.isUnowned() &&
+           "Can only modify Constants with owned payloads");
+    return payload_;
+  }
 
+  // Get an immutable reference to the payload tensor.
   const Tensor &getPayload() const { return payload_; }
 
   template <class ElemTy = float> Handle<ElemTy> getHandle() {

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -282,7 +282,7 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     // and "Int8ConvRelu", the weights always follows the "order" arg.
     if (!((typeName != "ConvRelu" && typeName != "Conv") && order == "NHWC")) {
       Tensor tmp;
-      W->getPayload().transpose(&tmp, NCHW2NHWC);
+      W->getPayloadMutable().transpose(&tmp, NCHW2NHWC);
       W = G_.getParent()->createConstant(W->getName(), tmp);
     }
 
@@ -630,7 +630,7 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
 
     if (typeName == "FC" || typeName == "Int8FC") {
       Tensor tmp;
-      W->getPayload().transpose(&tmp, {1, 0});
+      W->getPayloadMutable().transpose(&tmp, {1, 0});
       W = G_.getParent()->createConstant(W->getName(), tmp);
     }
 
@@ -988,7 +988,7 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
         TypeRef fusedTy = G_.getParent()->uniqueType(ElemKind::UInt8FusedQTy,
                                                      dataC->dims(), 0.0, 0);
         dataC->setType(Storage::OutputIdx, fusedTy);
-        dataC->getPayload().setType(fusedTy);
+        dataC->getPayloadMutable().setType(fusedTy);
 
         // We also need to update the data to be unsigned instead of signed.
         auto dataCH = dataC->getHandle<uint8_t>();

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -803,7 +803,7 @@ public:
 
         auto *FRWQSLWS =
             function_.createFusedRowwiseQuantizedSparseLengthsWeightedSum(
-                SLWS->getName(), dataC->getPayload(), weightsF,
+                SLWS->getName(), dataC->getPayloadMutable(), weightsF,
                 SLWS->getIndices(), SLWS->getLengths());
 
         // Fused RWQSLWS stores the fused scales and offsets in trailing

--- a/tests/unittests/GraphTest.cpp
+++ b/tests/unittests/GraphTest.cpp
@@ -1281,17 +1281,14 @@ TEST(Graph, verifyConstantWithUnownedTensorCopiesOnWrite) {
   Tensor unownedT = originalT.getUnowned({3});
 
   auto originalH = originalT.getHandle();
-  auto unownedH = unownedT.getHandle();
 
   for (size_t i = 0; i < originalT.size(); i++) {
     originalH.raw(i) = i;
   }
 
-  // Both Tensors should have the same values because unownedH has the same
-  // underlying memory as originalH.
-  for (size_t i = 0; i < unownedH.size(); i++) {
-    EXPECT_EQ(unownedH.raw(i), i);
-  }
+  // Both Tensors should have the same underlying memory because unownedT shares
+  // originalT's memory.
+  EXPECT_EQ(originalT.getUnsafePtr(), unownedT.getUnsafePtr());
 
   Constant *originalC = M.createConstant("original", std::move(originalT));
   Constant *unownedC = M.createConstant("unowned", std::move(unownedT));
@@ -1335,6 +1332,7 @@ TEST(Graph, verifyConstantWithUnownedTensorCopiesOnWrite) {
   // After getting a mutable reference to the unowned Constant's payload, the
   // underlying memory should have been copied but should still contain the same
   // values as it did previously at this point.
+  EXPECT_NE(unownedCTM.getUnsafePtr(), originalCT.getUnsafePtr());
   for (size_t i = 0; i < unownedCTMH.size(); i++) {
     EXPECT_EQ(unownedCTMH.raw(i), i + 1);
   }

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -2396,10 +2396,10 @@ TEST_P(OperatorTest, FCWithFlatten) {
   Constant *bias = mod_.createConstant(ElemKind::FloatTy, {4}, "bias");
 
   bindings_.allocate(input)->getHandle() = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
-  weights->getPayload().getHandle() = {1.0f, 4.0f, 7.0f, 10.0f, //
-                                       2.0f, 5.0f, 8.0f, 11.0f, //
-                                       3.0f, 6.0f, 9.0f, 12.0f};
-  bias->getPayload().getHandle() = {0.1f, 0.2f, 0.3f, 0.4f};
+  weights->getPayloadMutable().getHandle() = {1.0f, 4.0f, 7.0f, 10.0f, //
+                                              2.0f, 5.0f, 8.0f, 11.0f, //
+                                              3.0f, 6.0f, 9.0f, 12.0f};
+  bias->getPayloadMutable().getHandle() = {0.1f, 0.2f, 0.3f, 0.4f};
 
   auto *FC = F_->createFullyConnected("fc", input, weights, bias);
   auto *S = F_->createSave("save", FC);
@@ -5133,7 +5133,7 @@ TEST_P(OperatorTest, RowwiseQuantizedSparseLengthsWeightedSum) {
   };
 
   Constant *weights = mod_.createConstant(ElemKind::FloatTy, {8}, "weights");
-  weights->getPayload().getHandle<float>() = {
+  weights->getPayloadMutable().getHandle<float>() = {
       3., 1., 0., 0., 0., 0., 2., -0.5,
   };
 
@@ -5246,7 +5246,7 @@ TEST_P(OperatorTest, FusedRowwiseQuantizedSparseLengthsWeightedSum) {
   };
 
   Constant *weights = mod_.createConstant(ElemKind::FloatTy, {8}, "weights");
-  weights->getPayload().getHandle<float>() = {
+  weights->getPayloadMutable().getHandle<float>() = {
       3., 1., 0., 0., 0., 0., 2., -0.5,
   };
 
@@ -5582,8 +5582,8 @@ TEST_P(OperatorTest, Select) {
 TEST_P(OperatorTest, CmpLTE) {
   Constant *A = mod_.createConstant(ElemKind::FloatTy, {5}, "A");
   Constant *B = mod_.createConstant(ElemKind::FloatTy, {5}, "B");
-  A->getPayload().getHandle<float>() = {0.0, 1.0, 2.0, 3.0, 4.0};
-  B->getPayload().getHandle<float>() = {0.0, 1.1, 1.5, 10.1, -1.0};
+  A->getPayloadMutable().getHandle<float>() = {0.0, 1.0, 2.0, 3.0, 4.0};
+  B->getPayloadMutable().getHandle<float>() = {0.0, 1.1, 1.5, 10.1, -1.0};
 
   auto *CMPLTE = F_->createCmpLTE("select", A, B);
   auto *result = F_->createSave("saveCMPLTE", CMPLTE);

--- a/tests/unittests/QuantizationTest.cpp
+++ b/tests/unittests/QuantizationTest.cpp
@@ -445,7 +445,7 @@ TEST(Quantization, enableRowwiseQuantizedFullyConnectedSymmetric) {
   // Note that we generate values for the Weights because they will be used
   // during rowwise-quantization to select each row's scale/offset.
   auto *WC = llvm::cast<Constant>(FC->getWeights());
-  WC->getPayload().getHandle().randomize(-0.7, 1.1, mod.getPRNG());
+  WC->getPayloadMutable().getHandle().randomize(-0.7, 1.1, mod.getPRNG());
   auto *BC = llvm::cast<Constant>(FC->getBias());
 
   TensorQuantizationParams inputTQP = chooseQuantizationParams(
@@ -518,7 +518,7 @@ TEST(Quantization, enableRowwiseQuantizedFullyConnectedSymmetric) {
   ASSERT_TRUE(offsetsNode);
 
   // Because we're using symmetric quantization, the offsets should all be zero.
-  auto offsetsH = offsetsNode->getPayload().getHandle<int32_t>();
+  const auto offsetsH = offsetsNode->getPayload().getHandle<int32_t>();
   EXPECT_TRUE(offsetsH.isZero());
 
   // Make sure that graph can be compiled and run. We check the correctness of
@@ -1712,7 +1712,7 @@ TEST(Quantization, quantizeFunctionConvertConstant) {
   auto *LHS = mod.createPlaceholder(ElemKind::FloatTy, {3, 3}, "lhs", true);
   auto *RHS = mod.createConstant(ElemKind::FloatTy, {3, 3}, "rhs");
   bindings.allocate(LHS)->init(Tensor::InitKind::Xavier, 3, mod.getPRNG());
-  RHS->getPayload().init(Tensor::InitKind::Xavier, 3, mod.getPRNG());
+  RHS->getPayloadMutable().init(Tensor::InitKind::Xavier, 3, mod.getPRNG());
 
   auto *MMN = F->createMatMul("matmul", LHS, RHS);
   auto *save = F->createSave("ret", MMN);

--- a/tests/unittests/TypeAToTypeBFunctionConverterTest.cpp
+++ b/tests/unittests/TypeAToTypeBFunctionConverterTest.cpp
@@ -532,12 +532,12 @@ TEST_P(AllBackends, OptimizeMiddleConversionsFloatToFloat16) {
 
   auto *weights = mod.createConstant(
       mod.uniqueType(ElemKind::FloatTy, {13, 10}), "weights");
-  weights->getPayload().getHandle().randomize(-5.0, 5.0, mod.getPRNG());
+  weights->getPayloadMutable().getHandle().randomize(-5.0, 5.0, mod.getPRNG());
   Tensor origWeights;
   origWeights.assign(&weights->getPayload());
   auto *bias =
       mod.createConstant(mod.uniqueType(ElemKind::FloatTy, {10, 20}), "bias");
-  bias->getPayload().getHandle().randomize(-5.0, 5.0, mod.getPRNG());
+  bias->getPayloadMutable().getHandle().randomize(-5.0, 5.0, mod.getPRNG());
   Tensor origBias;
   origBias.assign(&bias->getPayload());
 
@@ -729,12 +729,12 @@ TEST_P(AllBackends, convertPlaceholderFloatToFloat16) {
 
   auto *weights = mod.createConstant(
       mod.uniqueType(ElemKind::FloatTy, {13, 10}), "weights");
-  weights->getPayload().getHandle().randomize(-5.0, 5.0, mod.getPRNG());
+  weights->getPayloadMutable().getHandle().randomize(-5.0, 5.0, mod.getPRNG());
   Tensor origWeights;
   origWeights.assign(&weights->getPayload());
   auto *bias =
       mod.createConstant(mod.uniqueType(ElemKind::FloatTy, {10, 20}), "bias");
-  bias->getPayload().getHandle().randomize(-5.0, 5.0, mod.getPRNG());
+  bias->getPayloadMutable().getHandle().randomize(-5.0, 5.0, mod.getPRNG());
 
   TypeRef FCTy = mod.uniqueType(ElemKind::FloatTy, {20, 10});
   auto *FC = F->createFullyConnected("FC", input, weights, bias, FCTy);


### PR DESCRIPTION
Summary:
Make it so that Constants can have unowned tensors as their payload and will basically copy-on-write by making sure that when a mutable reference to the payload is requested, the payload will be copied to a new owned tensor if it was previously unowned.
The motivation behind this is to load weights from onnxifi using unowned tensors as often as possible only making a copy if the weight needs to be modified by Glow.
Because Glow currently lacks a UInt8QTy quantized type, all tensors of this type must still be copied and converted to Int8QTy but if a UInt8QTy type is added to Glow then these can be taken as unowned tensors as well.
One thing to consider here is that the lifetime of the memory backing Constants created at model loading time must live for at least as long as the Constants. For our current model loading this is true but it is something that will have to be maintained.

Documentation:
Doxygen

Test Plan:
CI
[WIP] Unit test for unowned Constants.