### PR TITLE
Add preprocess-images flag to image-classifier

### DIFF
--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -63,12 +63,6 @@ llvm::cl::opt<bool>
             llvm::cl::desc("Specify whether to run with verbose output"),
             llvm::cl::Optional, llvm::cl::cat(loaderCat));
 
-llvm::cl::opt<bool>
-    timeOpt("time",
-            llvm::cl::desc("Print timer output to stderr detailing how long it "
-                           "takes for the program to execute"),
-            llvm::cl::Optional, llvm::cl::cat(loaderCat));
-
 llvm::cl::opt<unsigned> iterationsOpt(
     "iterations", llvm::cl::desc("Number of iterations to perform"),
     llvm::cl::Optional, llvm::cl::init(1), llvm::cl::cat(loaderCat));
@@ -188,6 +182,13 @@ llvm::cl::opt<std::string> networkName(
                    "and as a prefix for all the files that are generated."),
     llvm::cl::cat(loaderCat));
 } // namespace
+
+// timeOpt is outside the namespace so it can be used by the image-classifier.
+llvm::cl::opt<bool>
+    timeOpt("time",
+            llvm::cl::desc("Print timer output to stderr detailing how long it "
+                           "takes for the program to execute"),
+            llvm::cl::Optional, llvm::cl::cat(loaderCat));
 
 llvm::StringRef Loader::getModelOptPath() {
   assert(modelPathOpt.size() == 1 &&
@@ -435,4 +436,5 @@ Loader::Loader(int argc, char **argv) {
   hostManager_ = llvm::make_unique<runtime::HostManager>(std::move(configs));
   backend_ = createBackend(ExecutionBackend);
   F_ = M_->createFunction(modelPathOpt[0]);
+  functionName_ = modelPathOpt[0];
 }

--- a/tools/loader/Loader.h
+++ b/tools/loader/Loader.h
@@ -38,6 +38,8 @@ class Loader {
   std::string caffe2NetWeightFilename_;
   /// ONNX model file name.
   std::string onnxModelFilename_;
+  /// Name of loaded function.
+  std::string functionName_;
   /// Host Manager for running the model.
   std::unique_ptr<glow::runtime::HostManager> hostManager_;
   /// Backend used for saving bundle and quantization.
@@ -53,9 +55,14 @@ class Loader {
   LoweredInfoMap loweredMap_;
 
 public:
+  /// Getter for the hostManager, this can be useful for calling int othe
+  /// HostManager directly.
+  runtime::HostManager *getHostManager() { return hostManager_.get(); }
   /// Getter for the Function. This should not be called after compile since the
   /// compile process is destructive on the original function.
   Function *getFunction() { return F_; }
+  /// Getter for function name.
+  std::string getFunctionName() { return functionName_; }
   /// Getter for the Module. This should not be called after compile since the
   /// compile process is destructive on the original function and module.
   Module *getModule() { return F_->getParent(); }


### PR DESCRIPTION
Summary:
This will preload all images before classifying them, this is useful for benchmarking.
Documentation: NA

Test Plan: Ninja test, and run image-classifier exercising the new option.