### PR TITLE
[image-classifier]:Add a flag to dump DAG before compilation and optimization.

### DIFF
--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -148,6 +148,11 @@ llvm::cl::OptionCategory
                    "graphs by writing the IR/Graphs to "
                    "given files/stdout");
 
+llvm::cl::opt<std::string> dumpGraphDAGFileBeforeCompilationOpt(
+    "dump-graph-DAG-before-compile",
+    llvm::cl::desc("Specify the file to export the Graph in DOT format"),
+    llvm::cl::value_desc("file.dot"), llvm::cl::cat(modelExportCat));
+
 llvm::cl::opt<std::string> dumpGraphDAGFileOpt(
     "dump-graph-DAG",
     llvm::cl::desc("Specify the file to export the Graph in DOT format"),
@@ -258,6 +263,11 @@ static Kinded::Kind getKindFromNodeName(llvm::StringRef nodeName) {
 }
 
 void Loader::compile(PlaceholderBindings &bindings) {
+  // Dump the DAG before compilation if needed.
+  if (!dumpGraphDAGFileBeforeCompilationOpt.empty()) {
+    F_->dumpDAG(dumpGraphDAGFileBeforeCompilationOpt.c_str());
+  }
+
   // Fold low-level operators into higher-level operators.
   // This is useful when compiling an input model where some high-level
   // operators have been lowered (this can be for instance a side effect of


### PR DESCRIPTION
Summary:
Add a flag -dump-graph-DAG-before-compile so that we can dump the DAG before all optimization and compilation takes place.

Test Plan:
Test with the commands below:
- ./bin/image-classifier tests/images/imagenet/cat_285.png -image-mode=0to1 -m=googlenet_v1_slim/googlenet_v1_slim.onnx -model-input-name=input:0 -image-layout=NHWC -cpu -dump-graph-DAG=2.dot -dump-graph-DAG-before-compile=1.dot
- dot -Tpdf 1.dot > before.pdf
- dot -Tpdf 2.dot > after.pdf

The generated DAGs look like below:

Before compilation and optimization
![Screen Shot 2019-05-16 at 1 59 29 PM](https://user-images.githubusercontent.com/8838608/57886796-ea603a80-77e2-11e9-8c2a-3bc824bbad41.png)


====================================
After compilation and optimization
![Screen Shot 2019-05-16 at 2 01 11 PM](https://user-images.githubusercontent.com/8838608/57886886-15e32500-77e3-11e9-8833-3e8f99a6dc05.png)
