### PR TITLE
[Partitioner] Saturating the host can only be enabled for single type of backend.

### DIFF
--- a/include/glow/Partitioner/Partitioner.h
+++ b/include/glow/Partitioner/Partitioner.h
@@ -194,7 +194,7 @@ class Partitioner {
   /// Adjust a logicalDevice ID to each DAGNode. It is possible that two
   /// sub-functions need to be assigned into 1 device due to the memory
   /// constraits.
-  void adjustLogicalDeviceID(DAGNode *DAG, int num);
+  void adjustLogicalDeviceID();
 
   /// Duplicates all networks in the module order to saturate the Host.
   void saturateHost(unsigned logicalDeviceCount);
@@ -205,8 +205,8 @@ class Partitioner {
   /// Given the node-function mapping, do the actual partitioning. If \p saveDAG
   /// is true, the DAG will be saved into partitions_, which is the final
   /// partition result.
-  void doPartitioning(llvm::StringRef funcName, std::vector<Function *>,
-                      NodeToFunctionMap &mapping, bool saveDAG);
+  DeviceIDTy doPartitioning(llvm::StringRef funcName, std::vector<Function *>,
+                            NodeToFunctionMap &mapping, bool saveDAG);
 
 public:
   /// \p parent is the module which contains the functions need to be divided.


### PR DESCRIPTION
Summary:
To make things simple, we won't consider saturating the host for heterogeneous partition now. If later users requests come, we can improve this part. 

Documentation:

Test Plan:
ninja check.

[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
