### PR TITLE
Added benchmark ability to image-classifier using -iterations

### DIFF
--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -63,16 +63,6 @@ llvm::cl::opt<bool>
             llvm::cl::desc("Specify whether to run with verbose output"),
             llvm::cl::Optional, llvm::cl::cat(loaderCat));
 
-llvm::cl::opt<bool>
-    timeOpt("time",
-            llvm::cl::desc("Print timer output to stderr detailing how long it "
-                           "takes for the program to execute"),
-            llvm::cl::Optional, llvm::cl::cat(loaderCat));
-
-llvm::cl::opt<unsigned> iterationsOpt(
-    "iterations", llvm::cl::desc("Number of iterations to perform"),
-    llvm::cl::Optional, llvm::cl::init(1), llvm::cl::cat(loaderCat));
-
 llvm::cl::opt<std::string> dumpProfileFileOpt(
     "dump-profile",
     llvm::cl::desc("Perform quantization profiling for a given graph "
@@ -188,6 +178,18 @@ llvm::cl::opt<std::string> networkName(
                    "and as a prefix for all the files that are generated."),
     llvm::cl::cat(loaderCat));
 } // namespace
+
+// timeOpt and iterationsOpt are outside the namespace so they can be used by
+// the image-classifier.
+llvm::cl::opt<bool>
+    timeOpt("time",
+            llvm::cl::desc("Print timer output to stderr detailing how long it "
+                           "takes for the program to execute"),
+            llvm::cl::Optional, llvm::cl::cat(loaderCat));
+
+llvm::cl::opt<unsigned> iterationsOpt(
+    "iterations", llvm::cl::desc("Number of iterations to perform"),
+    llvm::cl::Optional, llvm::cl::init(0), llvm::cl::cat(loaderCat));
 
 llvm::StringRef Loader::getModelOptPath() {
   assert(modelPathOpt.size() == 1 &&
@@ -373,12 +375,12 @@ void Loader::compile(PlaceholderBindings &bindings) {
 void Loader::runInference(PlaceholderBindings &bindings, size_t batchSize) {
   assert(!emittingBundle() &&
          "No inference is performed in the bundle generation mode.");
-
+  unsigned iterations = iterationsOpt == 0 ? 1 : iterationsOpt;
   llvm::Timer timer("Infer", "Infer");
   if (timeOpt) {
     timer.startTimer();
   }
-  for (unsigned i = 0; i < iterationsOpt; i++) {
+  for (unsigned i = 0; i < iterations; i++) {
     auto runErr = hostManager_->runNetworkBlocking(modelPathOpt[0], bindings);
     EXIT_ON_ERR(std::move(runErr));
   }
@@ -386,7 +388,7 @@ void Loader::runInference(PlaceholderBindings &bindings, size_t batchSize) {
     timer.stopTimer();
     llvm::outs() << llvm::formatv("Wall time per item (s): {0:f4}\n",
                                   timer.getTotalTime().getWallTime() /
-                                      iterationsOpt / batchSize);
+                                      iterations / batchSize);
   }
 }
 
@@ -435,4 +437,5 @@ Loader::Loader(int argc, char **argv) {
   hostManager_ = llvm::make_unique<runtime::HostManager>(std::move(configs));
   backend_ = createBackend(ExecutionBackend);
   F_ = M_->createFunction(modelPathOpt[0]);
+  functionName_ = modelPathOpt[0];
 }

--- a/tools/loader/Loader.h
+++ b/tools/loader/Loader.h
@@ -19,6 +19,14 @@
 #include "glow/ExecutionEngine/ExecutionEngine.h"
 #include "glow/Runtime/HostManager/HostManager.h"
 
+#include "llvm/Support/CommandLine.h"
+
+/// Timer option used to indicate if inferences should be timed -time.
+extern llvm::cl::opt<bool> timeOpt;
+/// Iterations used to indicate the number of iterations to run an inferece
+/// -iterations.
+extern llvm::cl::opt<unsigned> iterationsOpt;
+
 namespace glow {
 
 class Tensor;
@@ -38,6 +46,8 @@ class Loader {
   std::string caffe2NetWeightFilename_;
   /// ONNX model file name.
   std::string onnxModelFilename_;
+  /// Name of loaded function.
+  std::string functionName_;
   /// Host Manager for running the model.
   std::unique_ptr<glow::runtime::HostManager> hostManager_;
   /// Backend used for saving bundle and quantization.
@@ -53,9 +63,14 @@ class Loader {
   LoweredInfoMap loweredMap_;
 
 public:
+  /// Getter for the hostManager, this can be useful for calling int othe
+  /// HostManager directly.
+  runtime::HostManager *getHostManager() { return hostManager_.get(); }
   /// Getter for the Function. This should not be called after compile since the
   /// compile process is destructive on the original function.
   Function *getFunction() { return F_; }
+  /// Getter for function name.
+  std::string getFunctionName() { return functionName_; }
   /// Getter for the Module. This should not be called after compile since the
   /// compile process is destructive on the original function and module.
   Module *getModule() { return F_->getParent(); }


### PR DESCRIPTION
Summary:
This flag will set image-classifier to run the specified number of inference requests against empty images and print the time taken per image to the terminal
Documentation:NA

Test Plan: tested new functionality and ensured it works and tested image-classifier original functionality is preserved. Also run.sh