### PR TITLE
Dilation support 

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -277,7 +277,10 @@ public:
   /// of steps to take in the input for each output cell. \p pads defines how
   /// many zero padding cells should be added to the input during convolution.
   /// \p group defines the number of groups the input and output channels should
-  /// be divided into and convolved separately.
+  /// be divided into and convolved separately. \p dilation defines factor by
+  /// which gap between 2 neighboring kernel elements is expanded along each
+  /// axis.
+
   ConvolutionNode *createConv(llvm::StringRef name, NodeValue input,
                               NodeValue filter, NodeValue bias, TypeRef outTy,
                               llvm::ArrayRef<unsigned_t> kernels,
@@ -291,7 +294,10 @@ public:
   /// of steps to take in the input for each output cell. \p pad defines how
   /// many zero padding cells should be added to the input during convolution.
   /// \p group defines the number of groups the input and output channels should
-  /// be divided into and convolved separately.
+  /// be divided into and convolved separately. \p dilation defines factor by
+  /// which gap between 2 neighboring kernel elements is expanded along each
+  /// axis.
+
   ConvolutionNode *createConv(llvm::StringRef name, NodeValue input,
                               NodeValue filter, NodeValue bias, TypeRef outTy,
                               unsigned_t kernel, unsigned_t stride,
@@ -928,7 +934,9 @@ public:
   /// to take in the input for each output cell. \p pads defines how many zero
   /// padding cells should be added to the input during convolution. \p group
   /// defines the number of groups the input and output channels should be
-  /// divided into and convolved separately.
+  /// divided into and convolved separately. \p dilation defines factor by
+  /// which gap between 2 neighboring kernel elements is expanded along each
+  /// axis.
   ConvolutionNode *createConv(PlaceholderBindings &bindings,
                               llvm::StringRef name, NodeValue input,
                               size_t outChannels,
@@ -943,7 +951,9 @@ public:
   /// take in the input for each output cell. \p pad defines how many zero
   /// padding cells should be added to the input during convolution. \p group
   /// defines the number of groups the input and output channels should be
-  /// divided into and convolved separately.
+  /// divided into and convolved separately.\p dilation defines factor by
+  /// which gap between 2 neighboring kernel elements is expanded along each
+  /// axis.
   ConvolutionNode *createConv(PlaceholderBindings &bindings,
                               llvm::StringRef name, NodeValue input,
                               size_t outChannels, unsigned_t kernel,

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -282,8 +282,8 @@ public:
                               NodeValue filter, NodeValue bias, TypeRef outTy,
                               llvm::ArrayRef<unsigned_t> kernels,
                               llvm::ArrayRef<unsigned_t> strides,
-                              llvm::ArrayRef<unsigned_t> pads,
-                              unsigned_t group);
+                              llvm::ArrayRef<unsigned_t> pads, unsigned_t group,
+                              unsigned_t dilation = 1);
 
   /// Creates a ConvolutionNode with the given \p name which convolves the 4D
   /// \p input with \p filter and \bias. \p kernel defines the size of the
@@ -295,7 +295,8 @@ public:
   ConvolutionNode *createConv(llvm::StringRef name, NodeValue input,
                               NodeValue filter, NodeValue bias, TypeRef outTy,
                               unsigned_t kernel, unsigned_t stride,
-                              unsigned_t pad, unsigned_t group);
+                              unsigned_t pad, unsigned_t group,
+                              unsigned_t dilation = 1);
 
   /// Creates a Convolution3DNode with the given \p name which convolves the 5D
   /// \p input with \p filter and \bias. \p kernels defines the size of the
@@ -933,8 +934,8 @@ public:
                               size_t outChannels,
                               llvm::ArrayRef<unsigned_t> kernels,
                               llvm::ArrayRef<unsigned_t> strides,
-                              llvm::ArrayRef<unsigned_t> pads,
-                              unsigned_t group);
+                              llvm::ArrayRef<unsigned_t> pads, unsigned_t group,
+                              unsigned_t dilation = 1);
 
   /// Creates a ConvolutionNode with the given \p name which convolves the 4D
   /// \p input. \p kernel defines the size of the height and width dimensions of
@@ -947,7 +948,7 @@ public:
                               llvm::StringRef name, NodeValue input,
                               size_t outChannels, unsigned_t kernel,
                               unsigned_t stride, unsigned_t pad,
-                              unsigned_t group);
+                              unsigned_t group, unsigned_t dilation = 1);
 
   /// Creates a Convolution3DNode with the given \p name which convolves the 5D
   /// \p input. \p kernels defines the size of the height, width, and depth

--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -144,13 +144,19 @@ public:
 /// parameters.
 inline std::pair<size_t, size_t> calculateConvPoolOutputDims(
     size_t sx, size_t sy, llvm::ArrayRef<unsigned_t> kernels,
-    llvm::ArrayRef<unsigned_t> strides, llvm::ArrayRef<unsigned_t> pads) {
+    llvm::ArrayRef<unsigned_t> strides, llvm::ArrayRef<unsigned_t> pads,
+    unsigned_t dilation = 1) {
   PaddingTLBR pdim(pads);
   ShapeHW kdim(kernels);
   ShapeHW sdim(strides);
-  size_t outsx =
-      ((sx + pdim.top + pdim.bottom - kdim.height) / sdim.height + 1);
-  size_t outsy = ((sy + pdim.left + pdim.right - kdim.width) / sdim.width + 1);
+  size_t outsx = ((sx + pdim.top + pdim.bottom - kdim.height -
+                   (kdim.height - 1) * (dilation - 1)) /
+                      sdim.height +
+                  1);
+  size_t outsy = ((sy + pdim.left + pdim.right - kdim.width -
+                   (kdim.width - 1) * (dilation - 1)) /
+                      sdim.width +
+                  1);
   return {outsx, outsy};
 }
 

--- a/lib/Backends/CPU/Transforms.cpp
+++ b/lib/Backends/CPU/Transforms.cpp
@@ -54,6 +54,11 @@ static Node *optimizeCPUConv(ConvolutionNode *CN, Function *F) {
     return nullptr;
   }
 
+  // This optimization is not supported with Dilation currently
+  if (CN->getDilation() != 1) {
+    return nullptr;
+  }
+
   // Create a new constant filter with the layout [D/8, K, K, C, 8];
   TypeRef filterTy = filter->getType();
   auto dims = filterTy->dims();

--- a/lib/Backends/CPU/Transforms.cpp
+++ b/lib/Backends/CPU/Transforms.cpp
@@ -54,7 +54,7 @@ static Node *optimizeCPUConv(ConvolutionNode *CN, Function *F) {
     return nullptr;
   }
 
-  // This optimization is not supported with Dilation currently
+  // This optimization is not supported with Dilation currently.
   if (CN->getDilation() != 1) {
     return nullptr;
   }

--- a/lib/Backends/CPU/libjit/libjit_conv.cpp
+++ b/lib/Backends/CPU/libjit/libjit_conv.cpp
@@ -523,7 +523,8 @@ void libjit_convolution_grad_f(float *inG, const float *outG, const float *inW,
                                const float *filterW, const size_t *outGdims,
                                const size_t *inWdims, const size_t *filterGdims,
                                const size_t *kernels, const size_t *strides,
-                               const size_t *pads, size_t group) {
+                               const size_t *pads, size_t group,
+                               size_t dilation) {
   // NHWC format is assumed
   // Clear inG, filterG, and biasG
   size_t p = sizeof(float);
@@ -554,8 +555,8 @@ void libjit_convolution_grad_f(float *inG, const float *outG, const float *inW,
 
             for (size_t kx = 0; kx < kernel_h; kx++) {
               for (size_t ky = 0; ky < kernel_w; ky++) {
-                ssize_t ax = x + kx;
-                ssize_t ay = y + ky;
+                ssize_t ax = x + kx * dilation;
+                ssize_t ay = y + ky * dilation;
 
                 if (ax < 0 || ay < 0 || ax >= (ssize_t)inWdims[1] ||
                     ay >= (ssize_t)inWdims[2]) {

--- a/lib/Backends/CPU/libjit/libjit_conv.cpp
+++ b/lib/Backends/CPU/libjit/libjit_conv.cpp
@@ -303,7 +303,7 @@ void libjit_convolution_f(float *outW, const float *inW, const float *filterW,
                           const size_t *inWdims, const size_t *filterWdims,
                           const size_t *biasWdims, const size_t *kernelSizes,
                           const size_t *strides, const size_t *pads,
-                          size_t group, unsigned depthUnroll) {
+                          size_t group, unsigned depthUnroll, size_t dilation) {
   size_t inChannels = inWdims[3];
   size_t outChannels = outWdims[3];
   size_t inCperG = inChannels / group;
@@ -363,8 +363,10 @@ void libjit_convolution_f(float *outW, const float *inW, const float *filterW,
 
                   // Calculate the specific input x,y that we process in this
                   // iteration.
-                  ssize_t inx = (ssize_t)outx * stride_h - pad_t + fx;
-                  ssize_t iny = (ssize_t)outy * stride_w - pad_l + fy;
+                  ssize_t inx =
+                      (ssize_t)outx * stride_h - pad_t + fx * dilation;
+                  ssize_t iny =
+                      (ssize_t)outy * stride_w - pad_l + fy * dilation;
 
                   // Ignore index access below zero (this is due to padding).
                   if (inx < 0 || iny < 0 || inx >= (ssize_t)inWdims[1] ||
@@ -417,14 +419,17 @@ void libjit_convolution_f(float *outW, const float *inW, const float *filterW,
   }           // For each N, the sample in the batch.
 }
 
-void libjit_convolution_i8(
-    int8_t *outW, const int8_t *inW, const int8_t *filterW,
-    const int32_t *biasW, const size_t *outWdims, const size_t *inWdims,
-    const size_t *filterWdims, const size_t *biasWdims,
-    const size_t *kernelSizes, const size_t *strides, const size_t *pads,
-    size_t group, int32_t outOffset, int32_t inOffset, int32_t filterOffset,
-    int32_t biasOffset, int32_t biasPre, int32_t biasPost, int32_t biasScale,
-    int32_t outPre, int32_t outPost, int32_t outScale, unsigned depthUnroll) {
+void libjit_convolution_i8(int8_t *outW, const int8_t *inW,
+                           const int8_t *filterW, const int32_t *biasW,
+                           const size_t *outWdims, const size_t *inWdims,
+                           const size_t *filterWdims, const size_t *biasWdims,
+                           const size_t *kernelSizes, const size_t *strides,
+                           const size_t *pads, size_t group, int32_t outOffset,
+                           int32_t inOffset, int32_t filterOffset,
+                           int32_t biasOffset, int32_t biasPre,
+                           int32_t biasPost, int32_t biasScale, int32_t outPre,
+                           int32_t outPost, int32_t outScale,
+                           unsigned depthUnroll, size_t dilation) {
   size_t inChannels = inWdims[3];
   size_t outChannels = outWdims[3];
   size_t inCperG = inChannels / group;
@@ -459,8 +464,8 @@ void libjit_convolution_i8(
             // For each element in the convolution-filter:
             for (size_t fx = 0; fx < kernel_h; fx++) {
               for (size_t fy = 0; fy < kernel_w; fy++) {
-                ssize_t ox = x + fx;
-                ssize_t oy = y + fy;
+                ssize_t ox = x + fx * dilation;
+                ssize_t oy = y + fy * dilation;
 
                 // Ignore index access below zero (this is due to padding).
                 if (ox < 0 || oy < 0 || ox >= (ssize_t)inWdims[1] ||

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -135,7 +135,7 @@ private:
                                        llvm::ArrayRef<unsigned_t> kernelSizes,
                                        llvm::ArrayRef<unsigned_t> strides,
                                        llvm::ArrayRef<unsigned_t> pads,
-                                       size_t group);
+                                       size_t group, size_t dilation);
 
   template <typename ElemTy = float>
   void fwdConvolutionInstFloatImpl(Value *inV, Value *outV, Value *filterV,
@@ -143,7 +143,7 @@ private:
                                    llvm::ArrayRef<unsigned_t> kernelSizes,
                                    llvm::ArrayRef<unsigned_t> strides,
                                    llvm::ArrayRef<unsigned_t> pads,
-                                   size_t group);
+                                   size_t group, size_t dilation);
 
   template <typename ElemTy, typename AccumulatorTy>
   void fwdConvolution3DInstQuantizedImpl(Value *inV, Value *outV,

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -95,7 +95,7 @@ template <typename ElemTy>
 void BoundInterpreterFunction::fwdConvolutionInstFloatImpl(
     Value *inV, Value *outV, Value *filterV, Value *biasV,
     llvm::ArrayRef<unsigned_t> kernelSizes, llvm::ArrayRef<unsigned_t> strides,
-    llvm::ArrayRef<unsigned_t> pads, size_t group) {
+    llvm::ArrayRef<unsigned_t> pads, size_t group, size_t dilation) {
   staticAssertFloatingPointType(ElemTy);
 
   auto inW = getWeightHandle<ElemTy>(inV);
@@ -134,8 +134,8 @@ void BoundInterpreterFunction::fwdConvolutionInstFloatImpl(
             float sum = 0;
             for (size_t fx = 0; fx < kdim.height; fx++) {
               for (size_t fy = 0; fy < kdim.width; fy++) {
-                ssize_t ox = x + fx;
-                ssize_t oy = y + fy;
+                ssize_t ox = x + fx * dilation;
+                ssize_t oy = y + fy * dilation;
 
                 // Ignore index access below zero (this is due to padding).
                 if (ox < 0 || oy < 0 || ox >= ssize_t(idim.h) ||
@@ -165,7 +165,7 @@ template <typename ElemTy, typename AccumulatorTy>
 void BoundInterpreterFunction::fwdConvolutionInstQuantizedImpl(
     Value *inV, Value *outV, Value *filterV, Value *biasV,
     llvm::ArrayRef<unsigned_t> kernelSizes, llvm::ArrayRef<unsigned_t> strides,
-    llvm::ArrayRef<unsigned_t> pads, size_t group) {
+    llvm::ArrayRef<unsigned_t> pads, size_t group, size_t dilation) {
   auto inW = getWeightHandle<ElemTy>(inV);
   auto outW = getWeightHandle<ElemTy>(outV);
   auto filterW = getWeightHandle<ElemTy>(filterV);
@@ -219,8 +219,8 @@ void BoundInterpreterFunction::fwdConvolutionInstQuantizedImpl(
             AccumulatorTy sum = 0;
             for (size_t fx = 0; fx < kdim.height; fx++) {
               for (size_t fy = 0; fy < kdim.width; fy++) {
-                ssize_t ox = x + fx;
-                ssize_t oy = y + fy;
+                ssize_t ox = x + fx * dilation;
+                ssize_t oy = y + fy * dilation;
 
                 // Ignore index access below zero (this is due to padding).
                 if (ox < 0 || oy < 0 || ox >= ssize_t(idim.h) ||
@@ -266,14 +266,14 @@ void BoundInterpreterFunction::fwdConvolutionInst(const ConvolutionInst *I) {
     dispatchQuantizedWithAccumulationImpl(
         fwdConvolutionInstQuantizedImpl, I->getSrc()->getElementType(),
         I->getSrc(), I->getDest(), I->getFilter(), I->getBias(), kernelSizes,
-        strides, pads, group);
+        strides, pads, group, I->getDilation());
     return;
   }
 
-  dispatchFloatingPointImpl(fwdConvolutionInstFloatImpl,
-                            I->getSrc()->getElementType(), I->getSrc(),
-                            I->getDest(), I->getFilter(), I->getBias(),
-                            kernelSizes, strides, pads, group);
+  dispatchFloatingPointImpl(
+      fwdConvolutionInstFloatImpl, I->getSrc()->getElementType(), I->getSrc(),
+      I->getDest(), I->getFilter(), I->getBias(), kernelSizes, strides, pads,
+      group, I->getDilation());
 }
 
 void BoundInterpreterFunction::fwdConvolutionGradInst(

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -287,6 +287,7 @@ void BoundInterpreterFunction::fwdConvolutionGradInst(
   auto biasG = getWeightHandle(I->getBiasGrad());
 
   size_t group = I->getGroup();
+  size_t dilation = I->getDilation();
 
   inG.clear();
   filterG.clear();
@@ -323,8 +324,8 @@ void BoundInterpreterFunction::fwdConvolutionGradInst(
             // For each element in the convolution-filter:
             for (size_t fx = 0; fx < kdim.height; fx++) {
               for (size_t fy = 0; fy < kdim.width; fy++) {
-                ssize_t ox = x + fx;
-                ssize_t oy = y + fy;
+                ssize_t ox = x + fx * dilation;
+                ssize_t oy = y + fy * dilation;
 
                 // Ignore index access below zero (this is due to padding).
                 if (ox < 0 || oy < 0 || ox >= ssize_t(idim.h) ||

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -555,23 +555,23 @@ ConvolutionNode *Function::createConv(llvm::StringRef name, NodeValue input,
                                       llvm::ArrayRef<unsigned_t> kernels,
                                       llvm::ArrayRef<unsigned_t> strides,
                                       llvm::ArrayRef<unsigned_t> pads,
-                                      unsigned_t group) {
+                                      unsigned_t group, unsigned_t dilation) {
   assertConvDims(input, filter, bias, kernels, strides, pads, group);
   auto OT = getParent()->uniqueType(*outTy);
   return addNode(new ConvolutionNode(name, OT, input, filter, bias, kernels,
-                                     strides, pads, group));
+                                     strides, pads, group, dilation));
 }
 
 ConvolutionNode *Function::createConv(llvm::StringRef name, NodeValue input,
                                       NodeValue filter, NodeValue bias,
                                       TypeRef outTy, unsigned_t kernel,
                                       unsigned_t stride, unsigned_t pad,
-                                      unsigned_t group) {
+                                      unsigned_t group, unsigned_t dilation) {
   llvm::SmallVector<unsigned_t, 4> pads = {pad, pad, pad, pad};
   llvm::SmallVector<unsigned_t, 2> strides = {stride, stride};
   llvm::SmallVector<unsigned_t, 2> kernels = {kernel, kernel};
   return createConv(name, input, filter, bias, outTy, kernels, strides, pads,
-                    group);
+                    group, dilation);
 }
 
 Convolution3DNode *Function::createConv3D(llvm::StringRef name, NodeValue input,
@@ -1946,7 +1946,7 @@ ConvolutionNode *Function::createConv(PlaceholderBindings &bindings,
                                       llvm::ArrayRef<unsigned_t> kernels,
                                       llvm::ArrayRef<unsigned_t> strides,
                                       llvm::ArrayRef<unsigned_t> pads,
-                                      unsigned_t group) {
+                                      unsigned_t group, unsigned_t dilation) {
   ShapeNHWC idim = ShapeNHWC(input.dims());
   ShapeHW kdim(kernels);
   PaddingTLBR pdim(pads);
@@ -1960,8 +1960,8 @@ ConvolutionNode *Function::createConv(PlaceholderBindings &bindings,
   assert(outChannels % group == 0 && "outChannels must be divisible by groups");
 
   // Calculate the size and allocate the output buffer.
-  auto outSz =
-      calculateConvPoolOutputDims(idim.h, idim.w, kernels, strides, pads);
+  auto outSz = calculateConvPoolOutputDims(idim.h, idim.w, kernels, strides,
+                                           pads, dilation);
 
   std::array<size_t, 4> outDims = {
       {idim.n, outSz.first, outSz.second, outChannels}};
@@ -1986,19 +1986,19 @@ ConvolutionNode *Function::createConv(PlaceholderBindings &bindings,
   auto OT = getParent()->uniqueType(inputTy, outDims);
 
   return addNode(new ConvolutionNode(name, OT, input, filter, bias, kernels,
-                                     strides, pads, group));
+                                     strides, pads, group, dilation));
 }
 
 ConvolutionNode *Function::createConv(PlaceholderBindings &bindings,
                                       llvm::StringRef name, NodeValue input,
                                       size_t outChannels, unsigned_t kernel,
                                       unsigned_t stride, unsigned_t pad,
-                                      unsigned_t group) {
+                                      unsigned_t group, unsigned_t dilation) {
   llvm::SmallVector<unsigned_t, 4> pads = {pad, pad, pad, pad};
   llvm::SmallVector<unsigned_t, 2> strides = {stride, stride};
   llvm::SmallVector<unsigned_t, 2> kernels = {kernel, kernel};
   return createConv(bindings, name, input, outChannels, kernels, strides, pads,
-                    group);
+                    group, dilation);
 }
 
 Convolution3DNode *Function::createConv3D(PlaceholderBindings &bindings,

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -108,8 +108,8 @@ static bool verifyConvolution(NodeValue src, NodeValue dest, NodeValue filter,
                               NodeValue bias,
                               llvm::ArrayRef<unsigned_t> kernels,
                               llvm::ArrayRef<unsigned_t> strides,
-                              llvm::ArrayRef<unsigned_t> pads,
-                              unsigned_t group) {
+                              llvm::ArrayRef<unsigned_t> pads, unsigned_t group,
+                              unsigned_t dilation) {
   const Node *parent = dest.getNode();
   bool isValid = checkType(src, dest.getElementType(), parent);
   isValid &= checkType(src, filter.getElementType(), parent);
@@ -134,8 +134,8 @@ static bool verifyConvolution(NodeValue src, NodeValue dest, NodeValue filter,
   isValid &= expectCompareTrue("channels number must be divisible by groups",
                                idim.c % group, size_t(0), parent);
 
-  auto outSz =
-      calculateConvPoolOutputDims(idim.h, idim.w, kernels, strides, pads);
+  auto outSz = calculateConvPoolOutputDims(idim.h, idim.w, kernels, strides,
+                                           pads, dilation);
   isValid &=
       expectCompareTrue("Invalid output dimension N", odim.n, idim.n, parent);
   isValid &= expectCompareTrue("Invalid output dimension H", odim.h,
@@ -406,7 +406,7 @@ bool PadNode::verify() const {
 
 bool ConvolutionNode::verify() const {
   return verifyConvolution(getInput(), getResult(), getFilter(), getBias(),
-                           Kernels_, Strides_, Pads_, Group_);
+                           Kernels_, Strides_, Pads_, Group_, Dilation_);
 }
 
 bool Convolution3DNode::verify() const {
@@ -444,7 +444,7 @@ bool ConvolutionGradNode::verify() const {
   isValid &= verifyConvolution(
       getGradOfInputNamedInput(), getGradOfOriginalOutputNamedResult(),
       getGradOfInputNamedFilter(), getGradOfInputNamedBias(), Kernels_,
-      Strides_, Pads_, Group_);
+      Strides_, Pads_, Group_, Dilation_);
   return isValid;
 }
 

--- a/lib/IR/IRGen.cpp
+++ b/lib/IR/IRGen.cpp
@@ -134,9 +134,10 @@ void IRGenVisitor::post(Node *parent, Node *N) {
     auto *filterG =
         builder_.createAllocActivationInst("conv.filter.G", filter->getType());
 
-    builder_.createConvolutionGradInst(
-        N->getName(), input, filter, outGrad, inG, filterG, biasG,
-        CG->getKernels(), CG->getStrides(), CG->getPads(), CG->getGroup());
+    builder_.createConvolutionGradInst(N->getName(), input, filter, outGrad,
+                                       inG, filterG, biasG, CG->getKernels(),
+                                       CG->getStrides(), CG->getPads(),
+                                       CG->getGroup(), CG->getDilation());
 
     registerIR(CG->getGradOfInputNamedInput(), inG);
     registerIR(CG->getGradOfInputNamedFilter(), filterG);

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -260,6 +260,11 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
       ASSIGN_VALUE_OR_RETURN_ERR(order, loadStr(dict["order"]));
     }
 
+    unsigned_t dilation = 1;
+    if (dict.count("dilation")) {
+      ASSIGN_VALUE_OR_RETURN_ERR(dilation, loadInt(dict["dilation"]));
+    }
+
     NodeValue in;
     ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
 
@@ -294,8 +299,8 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
 
     // Calculate the size and allocate the output buffer.
     ShapeNHWC idim = ShapeNHWC(finalInType->dims());
-    auto outSz =
-        calculateConvPoolOutputDims(idim.h, idim.w, kernels, strides, pads);
+    auto outSz = calculateConvPoolOutputDims(idim.h, idim.w, kernels, strides,
+                                             pads, dilation);
     std::array<size_t, 4> outDims = {
         {idim.n, outSz.first, outSz.second, depth}};
 
@@ -357,7 +362,7 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     }
 
     Node *node = G_.createConv(opName, finalIn, filter, bias, outTy, kernels,
-                               strides, pads, group);
+                               strides, pads, group, dilation);
     if (typeName == "ConvRelu") {
       node = G_.createRELU(opName + ".relu", node);
     }

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -487,8 +487,15 @@ llvm::Error ONNXModelLoader::loadConv(const ONNX_NAMESPACE::NodeProto &op,
   }
 
   unsigned_t dilation = 1;
-  if (dict.count("dilation")) {
-    ASSIGN_VALUE_OR_RETURN_ERR(dilation, loadInt(dict.at("dilation")));
+  if (dict.count("dilations")) {
+    std::vector<unsigned_t> dilations(2, 1);
+    dilations = getShape<unsigned_t>(dict.at("dilations"));
+    RETURN_ERR_IF_NOT(dilations.size() == 2,
+                      "Conv: dilations must be specified for 2 axes.");
+    RETURN_ERR_IF_NOT(dilations[1] == dilations[0],
+                      "Conv: different dilation values along different axes "
+                      "are not supported currently. values must be same.");
+    dilation = dilations[0];
   }
 
   // Load the inputs

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -486,6 +486,11 @@ llvm::Error ONNXModelLoader::loadConv(const ONNX_NAMESPACE::NodeProto &op,
     ASSIGN_VALUE_OR_RETURN_ERR(group, loadInt(dict.at("group")));
   }
 
+  unsigned_t dilation = 1;
+  if (dict.count("dilation")) {
+    ASSIGN_VALUE_OR_RETURN_ERR(dilation, loadInt(dict.at("dilation")));
+  }
+
   // Load the inputs
   NodeValue in;
   ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
@@ -553,13 +558,13 @@ llvm::Error ONNXModelLoader::loadConv(const ONNX_NAMESPACE::NodeProto &op,
   Pads pads;
   ASSIGN_VALUE_OR_RETURN_ERR(pads, getPads(dict, kernelShape, strides, idimHW));
 
-  auto outSz =
-      calculateConvPoolOutputDims(idim.h, idim.w, kernelShape, strides, pads);
+  auto outSz = calculateConvPoolOutputDims(idim.h, idim.w, kernelShape, strides,
+                                           pads, dilation);
   std::array<size_t, 4> outDims = {{idim.n, outSz.first, outSz.second, depth}};
   auto outTy = G_.getParent()->uniqueType(ElemKind::FloatTy, outDims);
 
   auto *node = G_.createConv(opName, tr, filterTransposeNode, bias, outTy,
-                             kernelShape, strides, pads, group);
+                             kernelShape, strides, pads, group, dilation);
 
   // Transpose the output back.
   auto *N = G_.createTranspose(opName, node, NHWC2NCHW);

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -1728,12 +1728,13 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     auto *strides = emitConstSizeTArray(builder, CG->getStrides());
     auto *pads = emitConstSizeTArray(builder, CG->getPads());
     auto *group = emitConstSizeT(builder, CG->getGroup());
+    auto *dilation = emitConstSizeT(builder, CG->getDilation());
 
     auto *F = getFunction("convolution_grad", srcGrad->getElementType());
     createCall(builder, F,
                {srcGradPtr, destGradPtr, srcPtr, filterGradPtr, biasGradPtr,
                 filterPtr, destGradDims, srcDims, filterGradDims, kernels,
-                strides, pads, group});
+                strides, pads, group, dilation});
     break;
   }
 

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -1640,6 +1640,7 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     auto *strides = emitConstSizeTArray(builder, CI->getStrides());
     auto *pads = emitConstSizeTArray(builder, CI->getPads());
     auto *group = emitConstSizeT(builder, CI->getGroup());
+    auto *dilation = emitConstSizeT(builder, CI->getDilation());
 
     const char *kernelName = "convolution";
 
@@ -1696,12 +1697,12 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
                   srcDims,    filterDims, biasDims,   kernels,   strides,
                   pads,       group,      destOffset, srcOffset, filterOffset,
                   biasOffset, biasPre,    biasPost,   biasScale, outPre,
-                  outPost,    outScale,   unrollD});
+                  outPost,    outScale,   unrollD,    dilation});
     } else {
       createCall(builder, F,
                  {destPtr, srcPtr, filterPtr, biasPtr, destDims, srcDims,
-                  filterDims, biasDims, kernels, strides, pads, group,
-                  unrollD});
+                  filterDims, biasDims, kernels, strides, pads, group, unrollD,
+                  dilation});
     }
     break;
   }

--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -731,7 +731,7 @@ static bool mergePadIntoConvolution(Function *F) {
     auto *newCN = F->createConv(CN->getName(), PN->getInput(), CN->getFilter(),
                                 CN->getBias(), CN->getResult().getType(),
                                 CN->getKernels(), CN->getStrides(), newConvPads,
-                                CN->getGroup());
+                                CN->getGroup(), CN->getDilation());
     CN->getResult().replaceAllUsesOfWith(newCN);
     changed = true;
   }
@@ -2359,9 +2359,10 @@ static bool sinkRescaleQuantizedNode(Function *F) {
       auto newF = rescaleF ? rescaleF->getInput() : CN->getFilter();
       auto newB = rescaleB ? rescaleB->getInput() : CN->getBias();
       if (rescaleX || rescaleF || rescaleB) {
-        auto *newCN = F->createConv(
-            CN->getName(), newX, newF, newB, CN->getResult().getType(),
-            CN->getKernels(), CN->getStrides(), CN->getPads(), CN->getGroup());
+        auto *newCN = F->createConv(CN->getName(), newX, newF, newB,
+                                    CN->getResult().getType(), CN->getKernels(),
+                                    CN->getStrides(), CN->getPads(),
+                                    CN->getGroup(), CN->getDilation());
         CN->getResult().replaceAllUsesOfWith(newCN);
         changed = true;
       }

--- a/lib/Optimizer/Lower.cpp
+++ b/lib/Optimizer/Lower.cpp
@@ -580,8 +580,8 @@ static void lowerGroupConvolutionNode(Function *F, LoweredInfoMap *loweredMap,
     auto *bias_slice = F->createSlice(BNG.getName(), bias, {groupId * outCperG},
                                       {(groupId + 1) * outCperG});
     convs.push_back(F->createConv(BNG.getName(), in_slice, filter_slice,
-                                  bias_slice, outTy, kernels, strides, pads,
-                                  1));
+                                  bias_slice, outTy, kernels, strides, pads, 1,
+                                  BNG.getDilation()));
   }
   auto *result = F->createConcat(BNG.getName(), convs, 3);
   replaceAllUsesOfWith(loweredMap, BNG.getResult(), result);

--- a/tests/models/caffe2Models/convrelu_pred_net.pbtxt
+++ b/tests/models/caffe2Models/convrelu_pred_net.pbtxt
@@ -21,5 +21,9 @@ op {
     name: "pad"
     i: 1
   }
+  arg {
+    name: "dilation"
+    i: 1
+  }  
 }
 external_output: "conv_out"

--- a/tests/models/onnxModels/simpleConv.onnxtxt
+++ b/tests/models/onnxModels/simpleConv.onnxtxt
@@ -28,6 +28,12 @@ graph {
       ints: 1
       type: INTS
     }
+    attribute {
+      name: "dilations"
+      ints: 1
+      ints: 1
+      type: INTS
+    }    
   }
   name: "test-model"
   initializer {

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -170,7 +170,7 @@ class MockBackendCustomIRGen : public Backend {
       auto *V = builder_->createConvolutionInst(
           "CustomConvolutionInstruction", Dest__, Src, Filter, Bias,
           CN__->getKernels(), CN__->getStrides(), CN__->getPads(),
-          CN__->getGroup());
+          CN__->getGroup(), CN__->getDilation());
       if (N->hasPredicate()) {
         V->setPredicate(irgen.valueForNode(N->getPredicate()));
       }

--- a/tests/unittests/BasicIRTest.cpp
+++ b/tests/unittests/BasicIRTest.cpp
@@ -159,7 +159,7 @@ TEST(IR, allInstrs) {
 
     builder.createCopyInst("", I1, I0);
     builder.createConvolutionInst("", I3, I1, F0, B0, {7, 7}, {2, 2},
-                                  {3, 3, 3, 3}, 1);
+                                  {3, 3, 3, 3}, 1, 1);
     builder.createMaxPoolInst("", I4, I0, {7, 7}, {2, 2}, {3, 3, 3, 3});
     builder.createSigmoidInst("", I1, I0);
     builder.createTanhInst("", I1, I0);

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -3752,6 +3752,47 @@ TEST_P(OperatorTest, GroupConvolution) {
   EXPECT_FLOAT_EQ(result.at({0, 1, 0, 5}), (13 + 14 + 15 + 16) * 100000);
 }
 
+TEST_P(OperatorTest, DilatedConvolution) {
+  auto *input =
+      mod_.createPlaceholder(ElemKind::FloatTy, {1, 4, 1, 1}, "input", false);
+  auto IH = bindings_.allocate(input)->getHandle();
+  for (size_t i = 0; i < 4; i++) {
+    IH.raw(i) = i + 1;
+  }
+
+  auto filter =
+      mod_.createPlaceholder(ElemKind::FloatTy, {1, 3, 3, 1}, "filter", false);
+  auto FH = bindings_.allocate(filter)->getHandle();
+  for (size_t i = 0; i < 3; i++)
+    for (size_t j = 0; j < 3; j++) {
+      FH.at({0, i, j, 0}) = 1;
+    }
+  FH.at({0, 1, 1, 0}) = 0;
+
+  auto *zeroBias =
+      mod_.createPlaceholder(ElemKind::FloatTy, {1}, "bias", false);
+  bindings_.allocate(zeroBias)->zero();
+
+  auto outTy = mod_.uniqueType(ElemKind::FloatTy, {1, 4, 1, 1});
+
+  ConvolutionNode *CN =
+      F_->createConv("Conv", input, filter, zeroBias, outTy, 3, 1, 2, 1, 2);
+  SaveNode *S = F_->createSave("save", CN);
+  bindings_.allocate(S->getPlaceholder());
+
+  EE_.compile(CompilationMode::Infer, F_);
+  EE_.run(bindings_);
+
+  auto result = bindings_.get(S->getPlaceholder())->getHandle();
+
+  std::vector<size_t> expectedDims = {1, 4, 1, 1};
+  EXPECT_TRUE(result.dims().vec() == expectedDims);
+  EXPECT_FLOAT_EQ(result.at({0, 0, 0, 0}), 3);
+  EXPECT_FLOAT_EQ(result.at({0, 1, 0, 0}), 4);
+  EXPECT_FLOAT_EQ(result.at({0, 2, 0, 0}), 1);
+  EXPECT_FLOAT_EQ(result.at({0, 3, 0, 0}), 2);
+}
+
 /// Test Conv3D with group size of 2 to make sure that group 3d convolution
 /// works as expected.
 TEST_P(OperatorTest, GroupConv3D) {

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -85,6 +85,7 @@ int main(int argc, char **argv) {
       .addMember(MemberType::VectorUnsigned, "Strides")
       .addMember(MemberType::VectorUnsigned, "Pads")
       .addMember(MemberType::Unsigned, "Group")
+      .addMember(MemberType::Unsigned, "Dilation")
       .autoIRGen()
       .autoVerify(VerifyKind::SameElementType, {"Dest", "Src", "Filter"})
       .addGradientInstr({"Src", "Filter"}, {"Dest", "Src", "Filter", "Bias"});

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -81,6 +81,7 @@ int main(int argc, char **argv) {
       .addMember(MemberType::VectorUnsigned, "Strides")
       .addMember(MemberType::VectorUnsigned, "Pads")
       .addMember(MemberType::Unsigned, "Group")
+      .addMember(MemberType::Unsigned, "Dilation")
       .addResultFromCtorArg()
       .addGradient()
       .setDocstring("Performs 2D Convolution using a given Input, Filter, and "

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -86,7 +86,7 @@ int main(int argc, char **argv) {
       .addGradient()
       .setDocstring("Performs 2D Convolution using a given Input, Filter, and "
                     "Bias tensors, as well as provided Kernels, Strides, Pads, "
-                    "and Group.");
+                    "Group and Dilation.");
 
   BB.newNode("Convolution3D")
       .addInput("Input")


### PR DESCRIPTION
Summary:
1. Dilation support in loaders and interpreter
2. Add Dilation support in CPU backend kernel (float and int8)
3. Disable DKKC8 optimization for convolution when dilation!=1
4. Added operator test for dilation (Interp and CPU only)

Documentation:
https://github.com/onnx/onnx/blob/master/docs/Operators.md#Conv

Test Plan:
Unit Tests 

fixes #2767
