### PR TITLE
[Partitioner] Add helper function to dump a DAG after partitioning.

### DIFF
--- a/include/glow/Partitioner/Partitioner.h
+++ b/include/glow/Partitioner/Partitioner.h
@@ -143,6 +143,10 @@ class Partitioner {
   /// The backend pointers.
   std::vector<Backend *> backends_;
 
+  /// The map between BackendKind and its name. It is used for generating debug
+  /// info.
+  std::map<BackendKind, std::string> backendName_;
+
   /// The result of module partitioning.
   DAGListTy partitions_;
 
@@ -245,6 +249,11 @@ public:
 
   /// Get the partitions.
   DAGListTy &getPartitionResult() { return partitions_; }
+
+  /// Dump the partition result to a dot file. Since now all functions belong to
+  /// a function family and they have the same partition, we only dump the one
+  /// function's partition.
+  void dumpDAG(llvm::StringRef dotFilename) const;
 
   /// Get function for computeTime_
   ComputeTimeMapTy getComputeTime() const { return computeTime_; }

--- a/include/glow/Support/Support.h
+++ b/include/glow/Support/Support.h
@@ -58,6 +58,9 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
 /// The char '\n' becomes '\'+'n' and quotes are handled correctly.
 std::string escapeDottyString(const std::string &str);
 
+/// \returns the node color based on \p index which is used in dot file.
+const char *getDotFileNodeColor(size_t index);
+
 /// Add quotes to the string \p in.
 inline std::string quote(const std::string &in) { return '"' + in + '"'; }
 

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -162,16 +162,7 @@ protected:
 
     // Pick a color based on the node kind.
     unsigned colorIdx = llvm::hash_value(llvm::StringRef(N->getKindName()));
-
-    static const char *colorNames[] = {
-        "AliceBlue",      "CadetBlue1",   "Coral",      "DarkOliveGreen1",
-        "DarkSeaGreen1",  "GhostWhite",   "Khaki1",     "LavenderBlush1",
-        "LemonChiffon1",  "LightSkyBlue", "MistyRose1", "MistyRose2",
-        "PaleTurquoise2", "PeachPuff1",   "PowderBlue", "Salmon",
-        "Thistle1",       "Thistle3",     "Wheat1",     "Yellow2",
-    };
-    unsigned arrayLen = sizeof(colorNames) / sizeof(colorNames[0]);
-    auto nodeColor = colorNames[colorIdx % arrayLen];
+    auto nodeColor = getDotFileNodeColor(colorIdx);
 
     if (isa<Constant>(N)) {
       os << "\tfillcolor=Snow3 color=DeepSkyBlue4\n";

--- a/lib/Partitioner/Partitioner.cpp
+++ b/lib/Partitioner/Partitioner.cpp
@@ -15,6 +15,13 @@
  */
 
 #include "glow/Partitioner/Partitioner.h"
+#include "glow/Support/Support.h"
+
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/Format.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <fstream>
 
 using namespace glow;
 using llvm::isa;
@@ -33,6 +40,57 @@ static uint64_t updateUsedMem(const std::set<Storage *> &usedStorage,
     }
   }
   return ret;
+}
+
+void Partitioner::dumpDAG(llvm::StringRef dotFilename) const {
+  if (partitions_.size() == 0)
+    return;
+  auto *root = partitions_[0].root.get();
+  llvm::outs() << "Writing dotty graph for DAG after graph partitioning: "
+               << dotFilename << '\n';
+  std::ofstream myfile;
+  myfile.open(dotFilename);
+  myfile << "digraph DAG {\n\trankdir=TB;\n";
+  // Dump DAGNodes
+  std::vector<DAGNode *> nodes;
+  llvm::SmallSet<DAGNode *, 10> used;
+  nodes.push_back(root);
+  int cur = 0;
+  int num = 1;
+  while (cur < num) {
+    auto *node = nodes[cur];
+    for (size_t i = 0; i < node->children.size(); i++) {
+      auto child = node->children[i];
+      DescriptionBuilder db(child->name.c_str());
+      db.addParam("BackendKind", backendName_.at(child->backendKind));
+      myfile << child->name << " [ label = \"" << escapeDottyString(db) << "\"";
+      myfile << "\tshape = \"record\"\n";
+      myfile << "\tstyle=\"filled,rounded\"\n";
+      auto colorIdx = llvm::hash_value(
+          llvm::StringRef(backendName_.at(child->backendKind)));
+      myfile << "\tfillcolor=" << getDotFileNodeColor(colorIdx) << "\n";
+      myfile << "penwidth = 2];\n";
+      if (used.count(child) == 0) {
+        nodes.push_back(child);
+        used.insert(child);
+        num++;
+      }
+    }
+    cur++;
+  }
+
+  // Dump edges.
+  for (size_t i = 0; i < nodes.size(); i++) {
+    auto *root = nodes[i];
+    for (size_t j = 0; j < root->children.size(); j++) {
+      auto child = root->children[j];
+      myfile << root->name << " -> " << child->name << ";";
+    }
+  }
+  myfile << "}";
+
+  myfile.close();
+  return;
 }
 
 Partitioner::Partitioner(Module *parent, const std::vector<DeviceInfo> &devices,
@@ -737,6 +795,11 @@ llvm::Error Partitioner::Partition() {
   std::vector<Backend *> backends;
   std::vector<std::unique_ptr<Backend>> backendHolder;
   getBackendMap(backendMap, backendHolder, backends);
+
+  // Assign the backend name to its BackendKind.
+  for (size_t i = 0, e = backends.size(); i < e; i++) {
+    backendName_[backends[i]->getBackendKind()] = backends[i]->getBackendName();
+  }
 
   // Step 0: Find the representative function for running partitioning
   // algorithm.

--- a/lib/Support/Support.cpp
+++ b/lib/Support/Support.cpp
@@ -117,4 +117,17 @@ std::string legalizeName(llvm::StringRef name) {
   return legalName;
 }
 
+/// \returns the color based on \p index which is used in dot file.
+const char *getDotFileNodeColor(size_t index) {
+  static const char *colorNames[] = {
+      "AliceBlue",      "CadetBlue1",   "Coral",      "DarkOliveGreen1",
+      "DarkSeaGreen1",  "GhostWhite",   "Khaki1",     "LavenderBlush1",
+      "LemonChiffon1",  "LightSkyBlue", "MistyRose1", "MistyRose2",
+      "PaleTurquoise2", "PeachPuff1",   "PowderBlue", "Salmon",
+      "Thistle1",       "Thistle3",     "Wheat1",     "Yellow2",
+  };
+  unsigned arrayLen = sizeof(colorNames) / sizeof(colorNames[0]);
+  return colorNames[index % arrayLen];
+}
+
 } // namespace glow


### PR DESCRIPTION
Summary:
This PR dump a dot file from the partition result. Since now all functions belong to a function family and they have the same partition, we only dump the one function's partition. For each node, so far we show the function name and the backendKind, which are the most important info in my mind.  
The following is the Heterogeneous partition example:
![dag1](https://user-images.githubusercontent.com/37386895/57913545-aa7c7000-7841-11e9-86b7-4fd1c6593fd7.png)
Documentation:

Test Plan:


[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
