### PR TITLE
[New Operator] Add support LengthsRangeFill operator

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -752,6 +752,14 @@ public:
   LengthsToRangesNode *createLengthsToRanges(llvm::StringRef name,
                                              NodeValue lengths);
 
+  /// Given a vector of \p lengths, \returns a LengthsRangeFillNode. This Node
+  /// calculates a range sequence given \p lengths, where the sum of the
+  /// elements of \p lengths must be no greater than \p maxOutputSize, which is
+  /// used to set the output type.
+  LengthsRangeFillNode *createLengthsRangeFill(llvm::StringRef name,
+                                               NodeValue lengths,
+                                               unsigned_t maxOutputSize);
+
   /// Implements an operation that converts the sparse representation given by
   /// the pair of \p indices and \p values into a dense representation.
   /// This representation contains each value of \p values at the corresponding

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -125,6 +125,7 @@ bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
                 RowwiseQuantizedSparseLengthsWeightedSumNode::ResultIdx) ==
             ElemKind::FloatTy);
 
+  case Kinded::Kind::LengthsRangeFillNodeKind:
   case Kinded::Kind::LengthsToRangesNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind({ElemKind::Int32ITy});
 

--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -1093,6 +1093,16 @@ void libjit_gatherranges32_u(size_t *output, int32_t *lengths,
   libjit_gatherranges(output, lengths, data, ranges, numExamples, exampleSize);
 }
 
+void libjit_lengths_range_fill_i32(const int32_t *lengths, int32_t *output,
+                                   const size_t lengthsSize) {
+  size_t curIdx = 0;
+  for (size_t i = 0, e = lengthsSize; i < e; i++) {
+    for (int32_t j = 0, f = lengths[i]; j < f; j++) {
+      output[curIdx++] = j;
+    }
+  }
+}
+
 void libjit_scatterassign_f(float *data, const size_t *indices,
                             const float *slices, size_t numIndices,
                             size_t sliceSize) {

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -231,6 +231,7 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
                 FusedRowwiseQuantizedSparseLengthsWeightedSumNode::ResultIdx) ==
             ElemKind::FloatTy);
 
+  case Kinded::Kind::LengthsRangeFillNodeKind:
   case Kinded::Kind::LengthsToRangesNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind({ElemKind::Int32ITy});
 

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -2591,6 +2591,18 @@ void BoundInterpreterFunction::fwdLengthsToRangesInst(
   }
 }
 
+void BoundInterpreterFunction::fwdLengthsRangeFillInst(
+    const LengthsRangeFillInst *I) {
+  auto lengthsH = getTensor(I->getLengths())->getHandle<int32_t>();
+  auto resultH = getTensor(I->getDest())->getHandle<int32_t>();
+  size_t curIdx = 0;
+  for (size_t i = 0, e = lengthsH.dims()[0]; i < e; i++) {
+    for (int32_t j = 0, f = lengthsH.at({i}); j < f; j++) {
+      resultH.at({curIdx++}) = j;
+    }
+  }
+}
+
 template <typename ElemTy>
 void BoundInterpreterFunction::fwdSparseToDenseInstFloatImpl(
     const SparseToDenseInst *I) {

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1545,6 +1545,14 @@ LengthsToRangesNode *Function::createLengthsToRanges(llvm::StringRef name,
   return addNode(new LengthsToRangesNode(name, outTy, lengths));
 }
 
+LengthsRangeFillNode *
+Function::createLengthsRangeFill(llvm::StringRef name, NodeValue lengths,
+                                 unsigned_t maxOutputSize) {
+  auto outTy =
+      getParent()->uniqueTypeWithNewShape(lengths.getType(), {maxOutputSize});
+  return addNode(new LengthsRangeFillNode(name, outTy, lengths));
+}
+
 SparseToDenseNode *Function::createSparseToDense(llvm::StringRef name,
                                                  NodeValue indices,
                                                  NodeValue values,

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -981,6 +981,16 @@ bool LengthsToRangesNode::verify() const {
   return isValid;
 }
 
+bool LengthsRangeFillNode::verify() const {
+  bool isValid = checkType(getLengths(), ElemKind::Int32ITy, this);
+  isValid &= checkType(getResult(), getLengths().getElementType(), this);
+  isValid &= expectCompareTrue("Lengths must be a 1D vector",
+                               getLengths().dims().size(), size_t(1), this);
+  isValid &= expectCompareTrue("Result must be a 1D vector",
+                               getResult().dims().size(), size_t(1), this);
+  return isValid;
+}
+
 bool SparseToDenseNode::verify() const {
   bool isValid = checkType(getResult(), getValues().getElementType(), this);
   isValid &= checkType(getIndices(), ElemKind::Int64ITy, this);

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -1049,6 +1049,22 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     return llvm::Error::success();
   }
 
+  if (typeName == "LengthsRangeFill") {
+    NodeValue lengths;
+    ASSIGN_VALUE_OR_RETURN_ERR(lengths, getNodeValueByName(op.input(0)));
+    RETURN_ERR_IF_NOT(lengths.dims().size() == 1,
+                      "lengths must be a 1D vector.");
+
+    unsigned_t maxOutputSize;
+    ASSIGN_VALUE_OR_RETURN_ERR(maxOutputSize,
+                               loadInt(dict.find("maxOutputSize")->second));
+
+    auto *LRF = G_.createLengthsRangeFill(opName, lengths, maxOutputSize);
+    RETURN_IF_ERR(addNodeAsOutput(op, LRF));
+
+    return llvm::Error::success();
+  }
+
   RETURN_ERR(unexpectedNodeErrorMessage(op, "Unsupported operator."));
 }
 

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -2198,6 +2198,22 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     break;
   }
 
+  case Kinded::Kind::LengthsRangeFillInstKind: {
+    auto *LRFI = llvm::cast<LengthsRangeFillInst>(I);
+    auto *dest = LRFI->getDest();
+    auto *lengths = LRFI->getLengths();
+
+    auto *destPtr = emitValueAddress(builder, dest);
+    auto *lengthsPtr = emitValueAddress(builder, lengths);
+
+    auto *lengthsSize = emitConstSizeT(builder, lengths->size());
+
+    // Dispatching function depending on the input type of Ranges.
+    auto *F = getFunction("lengths_range_fill", dest->getElementType());
+    createCall(builder, F, {lengthsPtr, destPtr, lengthsSize});
+    break;
+  }
+
   case Kinded::Kind::ScatterAssignInstKind: {
     auto *SAI = llvm::cast<ScatterAssignInst>(I);
     auto *data = SAI->getData();

--- a/tests/models/caffe2Models/lengths_range_fill_predict_net.pbtxt
+++ b/tests/models/caffe2Models/lengths_range_fill_predict_net.pbtxt
@@ -1,0 +1,13 @@
+name: "lengths_ranges_fill"
+op {
+  input: "lengths"
+  output: "result"
+  name: ""
+  type: "LengthsRangeFill"
+  arg {
+    name: "maxOutputSize"
+    i: 8
+  }
+}
+external_input: "lengths"
+external_output: "result"

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -6142,6 +6142,33 @@ TEST_P(OperatorTest, LengthsToRanges) {
   EXPECT_TRUE(expected.isEqual(result));
 }
 
+/// Test that LengthsRangeFill works.
+TEST_P(OperatorTest, LengthsRangeFill) {
+  ENABLED_BACKENDS(Interpreter, CPU);
+
+  /*
+    LENGTHS = [4, 3, 1]
+    OUTPUT =  [0, 1, 2, 3, 0, 1, 2, 0]
+  */
+  auto *lengths =
+      mod_.createPlaceholder(ElemKind::Int32ITy, {3}, "lengths", false);
+
+  bindings_.allocate(lengths)->getHandle<int32_t>() = {4, 3, 1};
+
+  auto *LRF = F_->createLengthsRangeFill("LRF", lengths, /* maxOutputSize */ 8);
+  auto *S = F_->createSave("save", LRF);
+  bindings_.allocate(S->getPlaceholder());
+
+  EE_.compile(CompilationMode::Infer, F_);
+  EE_.run(bindings_);
+
+  Tensor &result = *bindings_.get(S->getPlaceholder());
+  Tensor expected(ElemKind::Int32ITy, {8});
+  expected.getHandle<int32_t>() = {0, 1, 2, 3, 0, 1, 2, 0};
+
+  EXPECT_TRUE(expected.isEqual(result));
+}
+
 /// Helper for testing BatchOneHot with different \p DTy.
 template <typename DataType>
 void batchOneHotTest(glow::PlaceholderBindings &bindings, glow::Module &mod,

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -285,6 +285,14 @@ int main(int argc, char **argv) {
       .autoVerify(VerifyKind::SameElementType,
                   {"Lengths", "ElemKind::Int32ITy"});
 
+  BB.newInstr("LengthsRangeFill")
+      .addOperand("Dest", OperandKind::Out)
+      .addOperand("Lengths", OperandKind::In)
+      .autoIRGen()
+      .autoVerify(VerifyKind::SameElementType, {"Dest", "ElemKind::Int32ITy"})
+      .autoVerify(VerifyKind::SameElementType,
+                  {"Lengths", "ElemKind::Int32ITy"});
+
   /// Converts the given sparse representation into a dense one.
   BB.newInstr("SparseToDense")
       .addOperand("Dest", OperandKind::Out)

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -419,6 +419,12 @@ int main(int argc, char **argv) {
                     "input vector of length N the output is a Nx2 matrix with "
                     "(offset, lengths) packaged for each segment.");
 
+  BB.newNode("LengthsRangeFill")
+      .addInput("Lengths")
+      .addResultFromCtorArg()
+      .setDocstring(
+          "Converts an input Lengths 1D vector into a range sequence.");
+
   BB.newNode("SparseToDense")
       .addInput("Indices")
       .addInput("Values")


### PR DESCRIPTION
Summary: Add support LengthsRangeFill operator. Added Interpreter and CPU support. Note that this operator assumes a `maxOutputSize` is defined in the proto, as discussed in https://github.com/pytorch/glow/issues/1699.

Test Plan: Added tests in OperatorTest and Caffe2ImporterTest

Fixes https://github.com/pytorch/glow/issues/1699