### PR TITLE
add a test that compares SLSW between c2 and H

### DIFF
--- a/lib/Onnxifi/onnxifiGlow.cpp
+++ b/lib/Onnxifi/onnxifiGlow.cpp
@@ -18,6 +18,7 @@
 #include "GlowOnnxifiManager.h"
 
 #include "glow/Importer/ONNXIFIModelLoader.h"
+#include <glog/logging.h>
 
 /// Allow defining names for onnxifi implementation.
 #ifndef GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER
@@ -465,8 +466,12 @@ GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxSetIOAndRunGraph)(
     const onnxTensorDescriptorV1 *outputDescriptors,
     onnxMemoryFenceV1 *outputFence, onnxTraceEventList *traceEvents) {
   auto &manager = glow::onnxifi::GlowOnnxifiManager::get();
-
-  if (!inputDescriptors || !outputDescriptors || !outputFence) {
+  if ((inputsCount && !inputDescriptors) ||
+      (outputsCount && !outputDescriptors) || !outputFence) {
+    LOG(ERROR) << "inputsCount " << inputsCount << ", outputsCount "
+               << outputsCount << ", inputDescriptors: " << inputDescriptors
+               << ", outputDescriptors: " << outputDescriptors
+               << ", outputFence: " << outputFence;
     return ONNXIFI_STATUS_INVALID_POINTER;
   }
 


### PR DESCRIPTION
Summary:
add a test that tries out SLS in the cpu as well as H and verifies it is fine

found a bug in Glow about input parameters, when there are none, it is ok for the input param to be none

Reviewed By: benjibc

Differential Revision: D15410717

