### PR TITLE
[Loader] Add the number of devices to support Runtime end2end testing.

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -86,6 +86,11 @@ add_output_check_test(NAME en2gr_quantization_test
                       COMMAND ${TEXT_TRANSLATOR_TESTS_DIR}/en2gr_quantization_test.sh
                       REQUIRES MODELS RELEASE)
 
+# Create en2gr_cpu_partition_test OutputCheck test.
+add_output_check_test(NAME en2gr_cpu_partition_test
+                      COMMAND ${TEXT_TRANSLATOR_TESTS_DIR}/en2gr_cpu_partition_test.sh
+                      REQUIRES MODELS RELEASE)
+
 # Create an OutputCheck test to run resnet-runtime-test.
 add_output_check_test(NAME resnet_runtime_test
                       COMMAND ${EXAMPLES_TESTS_DIR}/resnet-runtime-test.sh

--- a/tests/text-translator/en2gr_cpu_partition_test.sh
+++ b/tests/text-translator/en2gr_cpu_partition_test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Copyright (c) 2017-present, Facebook, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euxo pipefail
+
+# CHECK: ich liebe Musik \.$
+$BIN/text-translator -m "${MODELS_DIR}/en2gr" -cpu -cpu-memory=500000000 -num-devices=2 <<< "I love music ."

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -192,6 +192,11 @@ llvm::cl::opt<std::string> networkName(
                    "of the entry point to the network "
                    "and as a prefix for all the files that are generated."),
     llvm::cl::cat(loaderCat));
+
+llvm::cl::opt<unsigned> numDevices("num-devices",
+                                   llvm::cl::desc("Number of Devices to use"),
+                                   llvm::cl::init(1), llvm::cl::value_desc("N"),
+                                   llvm::cl::cat(loaderCat));
 } // namespace
 
 llvm::StringRef Loader::getModelOptPath() {
@@ -440,8 +445,10 @@ Loader::Loader(int argc, char **argv) {
   }
   M_.reset(new Module);
   std::vector<std::unique_ptr<runtime::DeviceConfig>> configs;
-  auto config = llvm::make_unique<runtime::DeviceConfig>(ExecutionBackend);
-  configs.push_back(std::move(config));
+  for (unsigned int i = 0; i < numDevices; ++i) {
+    auto config = llvm::make_unique<runtime::DeviceConfig>(ExecutionBackend);
+    configs.push_back(std::move(config));
+  }
   hostManager_ = llvm::make_unique<runtime::HostManager>(std::move(configs));
   backend_ = createBackend(ExecutionBackend);
   F_ = M_->createFunction(modelPathOpt[0]);


### PR DESCRIPTION
Summary:
This PR added an option to allow more than one devices registered  by loader. Therefore, we can do the Runtime end2end test (w/o partitioning) . We use En2gr here as a Runtime e2e test. 

Documentation:

Test Plan:
added `en2gr_cpu_partition_test.sh`
`$BIN/text-translator -m "${MODELS_DIR}/en2gr" -cpu -cpu-memory=500000000 -num-devices=2 <<< "I love music ."`
Manually checked the partition.

[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
