### PR TITLE
[runtime] Added return values for removeNetwork

### DIFF
--- a/examples/resnet-runtime.cpp
+++ b/examples/resnet-runtime.cpp
@@ -52,7 +52,6 @@ llvm::cl::opt<std::string> tracePath("trace-path",
                                      llvm::cl::init(""),
                                      llvm::cl::cat(category));
 llvm::cl::opt<BackendKind> backend(
-<<<<<<< HEAD
     llvm::cl::desc("Backend to use:"), llvm::cl::Optional,
     llvm::cl::values(clEnumValN(BackendKind::Interpreter, "interpreter",
                                 "Use interpreter (default option)"),

--- a/examples/resnet-runtime.cpp
+++ b/examples/resnet-runtime.cpp
@@ -52,6 +52,7 @@ llvm::cl::opt<std::string> tracePath("trace-path",
                                      llvm::cl::init(""),
                                      llvm::cl::cat(category));
 llvm::cl::opt<BackendKind> backend(
+<<<<<<< HEAD
     llvm::cl::desc("Backend to use:"), llvm::cl::Optional,
     llvm::cl::values(clEnumValN(BackendKind::Interpreter, "interpreter",
                                 "Use interpreter (default option)"),

--- a/include/glow/Runtime/HostManager/HostManager.h
+++ b/include/glow/Runtime/HostManager/HostManager.h
@@ -98,7 +98,7 @@ public:
 
   /// Given \p networkName removes that network from the host. This also
   /// removes the network from any backends setup to execute it.
-  void removeNetwork(llvm::StringRef networkName);
+  llvm::Error removeNetwork(llvm::StringRef networkName);
 
   /// Returns true if \p networkName is already added to the host.
   bool networkAdded(llvm::StringRef networkName);

--- a/include/glow/Runtime/HostManager/HostManager.h
+++ b/include/glow/Runtime/HostManager/HostManager.h
@@ -98,7 +98,7 @@ public:
 
   /// Given \p networkName removes that network from the host. This also
   /// removes the network from any backends setup to execute it.
-  /// returns an llvm::Error indicating success or failure of the operation
+  /// \returns an llvm::Error indicating success or failure of the operation.
   llvm::Error removeNetwork(llvm::StringRef networkName);
 
   /// Returns true if \p networkName is already added to the host.

--- a/include/glow/Runtime/HostManager/HostManager.h
+++ b/include/glow/Runtime/HostManager/HostManager.h
@@ -98,6 +98,7 @@ public:
 
   /// Given \p networkName removes that network from the host. This also
   /// removes the network from any backends setup to execute it.
+  /// Returns an llvm::Error indicating success or failure of the operation
   llvm::Error removeNetwork(llvm::StringRef networkName);
 
   /// Returns true if \p networkName is already added to the host.

--- a/include/glow/Runtime/HostManager/HostManager.h
+++ b/include/glow/Runtime/HostManager/HostManager.h
@@ -98,7 +98,7 @@ public:
 
   /// Given \p networkName removes that network from the host. This also
   /// removes the network from any backends setup to execute it.
-  /// Returns an llvm::Error indicating success or failure of the operation
+  /// returns an llvm::Error indicating success or failure of the operation
   llvm::Error removeNetwork(llvm::StringRef networkName);
 
   /// Returns true if \p networkName is already added to the host.

--- a/include/glow/Support/Error.h
+++ b/include/glow/Support/Error.h
@@ -77,6 +77,8 @@ public:
     RUNTIME_REQUEST_REFUSED,
     // Runtime error, device wasn't found.
     RUNTIME_DEVICE_NOT_FOUND,
+    // Runtime error, network busy to perform any operation on it.
+    RUNTIME_NET_BUSY,
     // Compilation error; node unsupported after optimizations.
     COMPILE_UNSUPPORTED_NODE_AFTER_OPTIMIZE,
   };
@@ -144,6 +146,8 @@ private:
       return "RUNTIME_REQUEST_REFUSED";
     case ErrorCode::RUNTIME_DEVICE_NOT_FOUND:
       return "RUNTIME_DEVICE_NOT_FOUND";
+    case ErrorCode::RUNTIME_NET_BUSY:
+      return "RUNTIME_NET_BUSY";
     case ErrorCode::COMPILE_UNSUPPORTED_NODE_AFTER_OPTIMIZE:
       return "COMPILE_UNSUPPORTED_NODE_AFTER_OPTIMIZE";
     };

--- a/lib/Onnxifi/Base.h
+++ b/lib/Onnxifi/Base.h
@@ -61,7 +61,9 @@ public:
                           std::unique_ptr<ExecutionContext> context,
                           runtime::ResultCBTy callback) {}
 
-  virtual void removeNetwork(const Graph *graph) {}
+  virtual onnxStatus removeNetwork(const Graph *graph) {
+    return ONNXIFI_STATUS_SUCCESS;
+  }
 
 protected:
   bool useOnnx_;

--- a/lib/Onnxifi/HostManagerOnnxifi.cpp
+++ b/lib/Onnxifi/HostManagerOnnxifi.cpp
@@ -62,9 +62,15 @@ onnxStatus HostManagerBackendId::addNetwork(std::unique_ptr<Module> module) {
   return ONNXIFI_STATUS_SUCCESS;
 }
 
-void HostManagerBackendId::removeNetwork(const Graph *graph) {
+onnxStatus HostManagerBackendId::removeNetwork(const Graph *graph) {
   auto hostManagerGraph = static_cast<const HostManagerGraph *>(graph);
-  hostManager_->removeNetwork(hostManagerGraph->getName());
+  auto error = hostManager_->removeNetwork(hostManagerGraph->getName());
+
+  if (errorToBool(std::move(error))) {
+    return ONNXIFI_STATUS_INTERNAL_ERROR;
+  }
+
+  return ONNXIFI_STATUS_SUCCESS;
 }
 
 onnxStatus

--- a/lib/Onnxifi/HostManagerOnnxifi.h
+++ b/lib/Onnxifi/HostManagerOnnxifi.h
@@ -37,7 +37,7 @@ public:
 
   onnxStatus addNetwork(std::unique_ptr<Module> module);
 
-  void removeNetwork(const Graph *graph) override;
+  onnxStatus removeNetwork(const Graph *graph) override;
 
   // \returns a unique_ptr to a new HostManager for the given BackendKind \p
   // kind.

--- a/tests/unittests/HostManagerTest.cpp
+++ b/tests/unittests/HostManagerTest.cpp
@@ -61,7 +61,8 @@ void addAndRemoveNetwork(HostManager *manager, unsigned int functionNumber) {
   // Expect this to be an Error because multiple networks with the same name
   // have been added to HostManager
   errToBool(manager->addNetwork(std::move(module)));
-  manager->removeNetwork("function" + std::to_string(functionNumber));
+  ASSERT_FALSE(errToBool(
+      manager->removeNetwork("function" + std::to_string(functionNumber))));
 }
 
 TEST_F(HostManagerTest, newHostManager) { createHostManager(BackendKind::CPU); }

--- a/tests/unittests/HostManagerTest.cpp
+++ b/tests/unittests/HostManagerTest.cpp
@@ -61,7 +61,7 @@ void addAndRemoveNetwork(HostManager *manager, unsigned int functionNumber) {
   // Expect this to be an Error because multiple networks with the same name
   // have been added to HostManager
   errToBool(manager->addNetwork(std::move(module)));
-  ASSERT_FALSE(errToBool(
+  EXPECT_FALSE(errToBool(
       manager->removeNetwork("function" + std::to_string(functionNumber))));
 }
 


### PR DESCRIPTION
Summary:
Added return parameter for removeNetwork method in HostManager to indicate the error case, instead of asserting silently. Also modified the remove network interface in BackendId and HostManagerBackendId to report the error via Onnxifi. 

Documentation:

Test Plan:

[Optional Fixes #issue] #2855 

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
