### PR TITLE
Refactoring Glow loaders to support training. Part I.

### DIFF
--- a/include/glow/Importer/Caffe2ModelLoader.h
+++ b/include/glow/Importer/Caffe2ModelLoader.h
@@ -64,9 +64,6 @@ class Caffe2ModelLoader
   /// file.
   llvm::Expected<caffe2::NetDef> loadProtoFile(const std::string &filename);
 
-  /// Mapping between Caffe2 tensor names for inputs and actual Glow input vars.
-  llvm::StringMap<Placeholder *> nameToInputVars_;
-
   /// loadInputs calls this function for each member in its target arguments.
   /// Currently we are supporting two tensorprototypes:
   /// caffe2::TensorProto, caffe2::QTensorProto
@@ -106,13 +103,8 @@ public:
   /// in-memory serialized protobuf.
   /// Loads ModelProto from the in-memory serialized protobuf \p
   /// c2Model with the model size \p c2ModelSize.
-  llvm::Expected<caffe2::NetDef> loadProto(const void *c2Model,
-                                           size_t c2ModelSize);
-
-  /// \returns mapping between Caffe2 tensor names and actual Glow input vars.
-  const llvm::StringMap<Placeholder *> &getInputVarsMapping() const {
-    return nameToInputVars_;
-  }
+  static llvm::Expected<caffe2::NetDef> loadProto(const void *c2Model,
+                                                  size_t c2ModelSize);
 };
 
 } // namespace glow

--- a/include/glow/Importer/ONNXIFIModelLoader.h
+++ b/include/glow/Importer/ONNXIFIModelLoader.h
@@ -34,13 +34,10 @@ private:
   /// The real loader. It can be ONNXModelLoader or Caffe2ModelLoader
   std::unique_ptr<ProtobufLoader> core_{nullptr};
 
-  /// Mapping between ONNX names for inputs and actual Glow input vars.
-  llvm::StringMap<Placeholder *> onnxNameToInputVars_;
-
 public:
   /// \returns mapping between ONNX names and actual Glow input vars.
   const llvm::StringMap<Placeholder *> &getInputVarsMapping() const {
-    return onnxNameToInputVars_;
+    return core_->getInputVarsMapping();
   }
 
   /// \returns mapping between ONNX names and actual Glow output nodes.

--- a/include/glow/Importer/ONNXModelLoader.h
+++ b/include/glow/Importer/ONNXModelLoader.h
@@ -62,9 +62,6 @@ class ONNXModelLoader
   /// ONNX model op_version;
   size_t opsetVersion_;
 
-  /// Mapping between ONNX names for inputs and actual Glow input vars.
-  llvm::StringMap<Placeholder *> onnxNameToInputVars_;
-
   /// Load Constant ONNX operator.
   llvm::Error loadConstant(const ONNX_NAMESPACE::NodeProto &op,
                            const ArgumentDictionaryTy &dict);
@@ -159,11 +156,6 @@ public:
   /// If \p errPtr is not null then if an error occurs it will get assigned
   /// there otherwise if an error occurs it will abort.
   ONNXModelLoader(Function &F, llvm::Error *errPtr = nullptr);
-
-  /// \returns mapping between ONNX names and actual Glow input vars.
-  const llvm::StringMap<Placeholder *> &getInputVarsMapping() const {
-    return onnxNameToInputVars_;
-  }
 
   /// Load the inputs from the GraphProto. If \p loadInputsAsPlaceholders is
   /// true then this will load each graph input as a placeholder otherwise it

--- a/include/glow/Importer/ProtobufLoader.h
+++ b/include/glow/Importer/ProtobufLoader.h
@@ -94,6 +94,8 @@ protected:
   llvm::StringMap<NodeValue> nodeValueByName_;
   /// A map from names of the external outputs of the network to Variables.
   llvm::StringMap<Placeholder *> outputVarsByName_;
+  /// A map from names of the external inputs of the network to Variables.
+  llvm::StringMap<Placeholder *> inputVarsByName_;
 
   // Delete all Constants that have no users. This is useful because some
   // Constants may have been copied and modified during loading instead of used
@@ -150,9 +152,14 @@ public:
   ProtobufLoader &operator=(const ProtobufLoader &) = delete;
   virtual ~ProtobufLoader() = default;
 
-  /// \returns mapping between ONNX names and actual Glow output nodes.
+  /// \returns mapping between external names and actual Glow output nodes.
   const llvm::StringMap<Placeholder *> &getOutputVarsMapping() const {
     return outputVarsByName_;
+  }
+
+  /// \returns mapping between external names and actual Glow input nodes.
+  const llvm::StringMap<Placeholder *> &getInputVarsMapping() const {
+    return inputVarsByName_;
   }
 
   /// \returns the single final output of the network. The function assumes

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -71,11 +71,15 @@ bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
     // Concat ==> Splat + Insert. Both only support the following.
   case Kinded::Kind::ConcatNodeKind:
   case Kinded::Kind::SplatNodeKind:
-  case Kinded::Kind::TransposeNodeKind:
   case Kinded::Kind::SliceNodeKind:
   case Kinded::Kind::SpaceToDepthNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
         {ElemKind::FloatTy, ElemKind::Int8QTy, ElemKind::Int64ITy});
+
+  case Kinded::Kind::TransposeNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+        {ElemKind::FloatTy, ElemKind::Int8QTy, ElemKind::Int64ITy,
+         ElemKind::BoolTy});
 
   case Kinded::Kind::SparseLengthsWeightedSumNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(

--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -1612,6 +1612,12 @@ void libjit_transpose_u(const size_t *inW, size_t *outW, const size_t *idim,
   libjit_transpose_generic(inW, outW, idim, odim, shuffle, numDims);
 }
 
+void libjit_transpose_b(const bool *inW, bool *outW, const size_t *idim,
+                        const size_t *odim, const size_t *shuffle,
+                        size_t numDims) {
+  libjit_transpose_generic(inW, outW, idim, odim, shuffle, numDims);
+}
+
 void libjit_insert_tensor_f(float *tensor, float *slice, size_t *offset,
                             size_t *tensorDim, size_t *sliceDim,
                             size_t numDimsTensor, size_t numDimsSlice,

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -1069,7 +1069,7 @@ Caffe2ModelLoader::loadInputsWithTensorProtoType(const caffe2::NetDef &net,
     Placeholder *placeholder;
     ASSIGN_VALUE_OR_RETURN_ERR(
         placeholder, createAndRegisterPlaceholder(in.name(), &T.getType()));
-    nameToInputVars_.try_emplace(in.name(), placeholder);
+    inputVarsByName_.try_emplace(in.name(), placeholder);
   } else {
     Tensor T;
     RETURN_IF_ERR(setTensorType(in, &T));

--- a/lib/Importer/ONNXIFIModelLoader.cpp
+++ b/lib/Importer/ONNXIFIModelLoader.cpp
@@ -59,8 +59,6 @@ llvm::Expected<std::unique_ptr<ONNXIFIModelLoader>> ONNXIFIModelLoader::parse(
 
     onnxLoader->deleteUnusedConstants();
 
-    loader->onnxNameToInputVars_ = onnxLoader->getInputVarsMapping();
-
     // Keep hold of the context
     loader->core_ = std::move(onnxLoader);
   } else {
@@ -86,8 +84,6 @@ llvm::Expected<std::unique_ptr<ONNXIFIModelLoader>> ONNXIFIModelLoader::parse(
     // This is to ensure that the same processing done with
     // the same network, even if order of operators is different.
     F.orderNodes();
-
-    loader->onnxNameToInputVars_ = c2Loader->getInputVarsMapping();
 
     c2Loader->deleteUnusedConstants();
 

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -90,7 +90,7 @@ llvm::Error ONNXModelLoader::loadInputs(ONNX_NAMESPACE::GraphProto &net,
       Placeholder *placeholder;
       ASSIGN_VALUE_OR_RETURN_ERR(
           placeholder, createAndRegisterPlaceholder(in.name(), &T.getType()));
-      onnxNameToInputVars_.try_emplace(in.name(), placeholder);
+      inputVarsByName_.try_emplace(in.name(), placeholder);
     } else {
       Tensor T;
       RETURN_IF_ERR(setTensorType(in.type(), &T));

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -1864,6 +1864,25 @@ TEST_P(OperatorTest, FP16Transpose2Dims) {
   EXPECT_TRUE(bindings_.get(result->getPlaceholder())->isEqual(dest));
 }
 
+/// Check that transpose is supported for BoolTy.
+TEST_P(OperatorTest, BoolTranspose2Dims) {
+  ENABLED_BACKENDS(Interpreter, CPU);
+
+  auto *A = mod_.createPlaceholder(ElemKind::BoolTy, {20, 13}, "A", false);
+  bindings_.allocate(A)->getHandle<bool>().randomize(0, 1, mod_.getPRNG());
+
+  auto *tr = F_->createTranspose("tr", A, {1, 0});
+  auto *result = F_->createSave("saveTranspose", tr);
+  bindings_.allocate(result->getPlaceholder());
+
+  EE_.compile(CompilationMode::Infer, F_);
+  EE_.run(bindings_);
+
+  Tensor dest(ElemKind::BoolTy, {13, 20});
+  bindings_.get(A)->transpose(&dest, {1, 0});
+  EXPECT_TRUE(bindings_.get(result->getPlaceholder())->isEqual(dest));
+}
+
 /// Helper to check if the code generation of transposes
 /// is correct for tensors with 3 dimensions using \p DTy.
 /// Note: This assumes that Tensor::transpose is correct.


### PR DESCRIPTION
Summary: Glow loaders has been designed only for inference, changing internals to support training as well.

Reviewed By: artemrakhov

Differential Revision: D15418551

