### PR TITLE
Fix Habana-enabling logic in BackendTestUtils

### DIFF
--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -79,10 +79,10 @@ static const auto all_backends = ::testing::Values(
 #endif // GLOW_WITH_CPU
 #ifdef GLOW_WITH_OPENCL
     BackendKind::OpenCL,
-#endif // GLOW_WITHOPENCL
-#ifdef ENABLE_HABANA_IN_TESTS
+#endif // GLOW_WITH_OPENCL
+#ifdef GLOW_WITH_HABANA
     BackendKind::Habana,
-#endif // ENABLE_HABANA_IN_TESTS
+#endif // GLOW_WITH_HABANA
     BackendKind::Interpreter);
 
 // Instantiate parameterized test suite with all available backends.


### PR DESCRIPTION
Summary:
ENABLE_HABANA_IN_TESTS was a temporary hack; we can use the standard
GLOW_WITH_HABANA now

Differential Revision: D15447609

