### PR TITLE
[Backends] Change command line memory options to kilobytes

### DIFF
--- a/lib/Backends/CPU/CPUDeviceManager.cpp
+++ b/lib/Backends/CPU/CPUDeviceManager.cpp
@@ -22,16 +22,17 @@
 namespace glow {
 namespace runtime {
 
-uint64_t GlowCPUMemory = 0;
+unsigned GlowCPUMemory = 0;
 
-static llvm::cl::opt<uint64_t, /* ExternalStorage */ true>
-    GlowCPUMemoryOpt("cpu-memory",
-                     llvm::cl::desc("CPU DeviceManager maximum memory"),
-                     llvm::cl::location(GlowCPUMemory));
+static llvm::cl::opt<unsigned, /* ExternalStorage */ true> GlowCPUMemoryOpt(
+    "cpu-memory",
+    llvm::cl::desc("CPU DeviceManager maximum memory in kilobytes."),
+    llvm::cl::location(GlowCPUMemory));
 
 DeviceManager *createCPUDeviceManager(std::unique_ptr<DeviceConfig> config) {
   if (GlowCPUMemory) {
-    return new CPUDeviceManager(std::move(config), GlowCPUMemory);
+    // Convert command line GlowCPUMemory to bytes from kilobytes.
+    return new CPUDeviceManager(std::move(config), GlowCPUMemory * 1024);
   }
   return new CPUDeviceManager(std::move(config));
 }

--- a/lib/Backends/Habana/HabanaDeviceManager.cpp
+++ b/lib/Backends/Habana/HabanaDeviceManager.cpp
@@ -30,11 +30,11 @@ using namespace glow::runtime;
 namespace glow {
 namespace runtime {
 
-uint64_t GlowHabanaMemory = uint64_t{7} << 30; // 7 GB.
+unsigned GlowHabanaMemory = uint64_t{7} << 20; // 7 GB.
 
-static llvm::cl::opt<uint64_t, true> GlowHabanaMemoryOpt(
+static llvm::cl::opt<unsigned, /* ExternalStorage */ true> GlowHabanaMemoryOpt(
     "glow-habana-memory",
-    llvm::cl::desc("Amount of DRAM to allocate per Habana device"),
+    llvm::cl::desc("Amount of DRAM to allocate per Habana device in kilobytes"),
     llvm::cl::location(GlowHabanaMemory));
 
 // TODO: A failed status probably shouldn't be an assert. We should
@@ -116,8 +116,8 @@ llvm::Error HabanaDeviceManager::init() {
 llvm::Error HabanaDeviceManager::updateMemoryUsage() {
   // TODO: Use synGetMemInfo once implemented.
 
-  totalMemory_ = GlowHabanaMemory;
-  freeMemory_ = GlowHabanaMemory;
+  totalMemory_ = GlowHabanaMemory * 1024;
+  freeMemory_ = GlowHabanaMemory * 1024;
 
   // Account for the size used by each function loaded on the card.
   for (const auto &pr : functions_) {

--- a/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
@@ -23,7 +23,7 @@ static llvm::cl::OptionCategory
     InterpreterBackendCat("Glow Interpreter Backend Options");
 llvm::cl::opt<unsigned> interpreterMaxMem(
     "interpreter-memory",
-    llvm::cl::desc("Interpreter DeviceManager maximum memory"),
+    llvm::cl::desc("Interpreter DeviceManager maximum memory in kilobytes"),
     llvm::cl::init(0), llvm::cl::cat(InterpreterBackendCat));
 
 namespace glow {
@@ -32,7 +32,9 @@ namespace runtime {
 DeviceManager *
 createInterpreterDeviceManager(std::unique_ptr<DeviceConfig> config) {
   if (interpreterMaxMem) {
-    return new InterpreterDeviceManager(std::move(config), interpreterMaxMem);
+    // Convert command line interpreterMaxMem to bytes from kilobytes.
+    return new InterpreterDeviceManager(std::move(config),
+                                        interpreterMaxMem * 1024);
   }
   return new InterpreterDeviceManager(std::move(config));
 }

--- a/tests/text-translator/en2gr_cpu_partition_test.sh
+++ b/tests/text-translator/en2gr_cpu_partition_test.sh
@@ -17,4 +17,4 @@
 set -euxo pipefail
 
 # CHECK: ich liebe Musik \.$
-$BIN/text-translator -m "${MODELS_DIR}/en2gr" -cpu -cpu-memory=500000000 -num-devices=2 <<< "I love music ."
+$BIN/text-translator -m "${MODELS_DIR}/en2gr" -cpu -cpu-memory=500000 -num-devices=2 <<< "I love music ."


### PR DESCRIPTION
CI is broken because the `en2gr_cpu_partition_test` tries to set the CPU memory on the command line, but it seems that command line parameters don't work with `uint64_t` on some platforms. I've hit this issue in the past, and I'm not sure why it's the case.