### PR TITLE
Avoid overflow/undefined behavior in RecommendationSystemTest

### DIFF
--- a/tests/unittests/RecommendationSystemTest.cpp
+++ b/tests/unittests/RecommendationSystemTest.cpp
@@ -290,7 +290,7 @@ protected:
     // createRandomizedConstant invocation.
     auto internalTypeF = mod_.uniqueType(ElemKind::FloatTy, {1});
     auto internalTypeQ = mod_.uniqueType(ElemKind::Int8QTy, {1}, 1, 0);
-    auto internalBiasType = mod_.uniqueType(ElemKind::Int32QTy, {1}, 0.0002, 0);
+    auto internalBiasType = mod_.uniqueType(ElemKind::Int32QTy, {1}, 1e-11, 0);
 
     Node *start = N_;
     start = F_->createQuantize(


### PR DESCRIPTION
Summary:
Using very large biases causes the bottom MLP to saturate, which then
causes the BatchMatMul in the interaction layer to overflow (in fp16, at least)
to INF, which then crashes the quantizer since it can't convert INF to an
integer.

Differential Revision: D15459385

