### PR TITLE
[DeviceConfig] add device memory size configuration to DeviceConfig

### DIFF
--- a/include/glow/Runtime/RuntimeTypes.h
+++ b/include/glow/Runtime/RuntimeTypes.h
@@ -130,7 +130,8 @@ struct DeviceConfig {
   const BackendKind backendKind;
   /// A human readable name to identify the device.
   std::string name;
-
+  /// Device memory size in bytes.
+  uint64_t deviceMemory = 0;
   /// A map of configuration parameters.
   llvm::StringMap<std::string> parameters{};
 
@@ -143,6 +144,14 @@ struct DeviceConfig {
       : backendKind(kind), name(name), parameters(parameters) {}
 
   bool hasName() const { return name != ""; }
+
+  void setDeviceMemory(uint64_t memSize) { deviceMemory = memSize; }
+
+  uint64_t getDeviceMemory() const { return deviceMemory; }
+
+  uint64_t getDeviceMemory(uint64_t defaultMemory) const {
+    return deviceMemory == 0 ? defaultMemory : deviceMemory;
+  }
 };
 
 } // namespace runtime

--- a/lib/Backends/CPU/CPUDeviceManager.cpp
+++ b/lib/Backends/CPU/CPUDeviceManager.cpp
@@ -32,7 +32,9 @@ static llvm::cl::opt<unsigned, /* ExternalStorage */ true> GlowCPUMemoryOpt(
 DeviceManager *createCPUDeviceManager(const DeviceConfig &config) {
   if (GlowCPUMemory) {
     // Convert command line GlowCPUMemory to bytes from kilobytes.
-    return new CPUDeviceManager(config, uint64_t{GlowCPUMemory} * 1024);
+    auto configNew = config;
+    configNew.setDeviceMemory(uint64_t{GlowCPUMemory} * 1024);
+    return new CPUDeviceManager(configNew);
   }
   return new CPUDeviceManager(config);
 }

--- a/lib/Backends/CPU/CPUDeviceManager.h
+++ b/lib/Backends/CPU/CPUDeviceManager.h
@@ -40,8 +40,9 @@ class CPUDeviceManager : public QueueBackedDeviceManager {
   const uint64_t functionCost_{1};
 
 public:
-  CPUDeviceManager(const DeviceConfig &config, size_t maxMemory = 2000000000)
-      : QueueBackedDeviceManager(config), maxMemoryBytes_(maxMemory) {}
+  CPUDeviceManager(const DeviceConfig &config)
+      : QueueBackedDeviceManager(config),
+        maxMemoryBytes_(config_.getDeviceMemory(2000000000)) {}
 
   /// Returns the amount of memory in bytes available on the device when no
   /// models are loaded.

--- a/lib/Backends/DeviceManagers.cpp
+++ b/lib/Backends/DeviceManagers.cpp
@@ -16,7 +16,6 @@
 
 #include "glow/Backends/DeviceManager.h"
 #include "glow/Backends/DummyDeviceManager.h"
-
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/raw_ostream.h"
 

--- a/lib/Backends/Habana/HabanaDeviceManager.cpp
+++ b/lib/Backends/Habana/HabanaDeviceManager.cpp
@@ -114,8 +114,15 @@ llvm::Error HabanaDeviceManager::init() {
 llvm::Error HabanaDeviceManager::updateMemoryUsage() {
   // TODO: Use synGetMemInfo once implemented.
 
-  totalMemory_ = uint64_t{GlowHabanaMemory} * 1024;
-  freeMemory_ = uint64_t{GlowHabanaMemory} * 1024;
+  // Use GlowHabanaMemory if it is defined from GFLAGS or llvm params,
+  // otherwise, fall back to what config says.
+  uint64_t defaultMemory = 7 << 20;
+  if (GlowHabanaMemory == defaultMemory && config_.getDeviceMemory() != 0) {
+    totalMemory_ = config_.getDeviceMemory();
+  } else {
+    totalMemory_ = uint64_t{GlowHabanaMemory} * 1024;
+  }
+  freeMemory_ = totalMemory_;
 
   // Account for the size used by each function loaded on the card.
   for (const auto &pr : functions_) {

--- a/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
@@ -32,8 +32,9 @@ namespace runtime {
 DeviceManager *createInterpreterDeviceManager(const DeviceConfig &config) {
   if (interpreterMaxMem) {
     // Convert command line interpreterMaxMem to bytes from kilobytes.
-    return new InterpreterDeviceManager(config,
-                                        uint64_t{interpreterMaxMem} * 1024);
+    auto configNew = config;
+    configNew.setDeviceMemory(uint64_t{interpreterMaxMem} * 1024);
+    return new InterpreterDeviceManager(configNew);
   }
   return new InterpreterDeviceManager(config);
 }

--- a/lib/Backends/Interpreter/InterpreterDeviceManager.h
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.h
@@ -40,9 +40,9 @@ class InterpreterDeviceManager : public QueueBackedDeviceManager {
   const uint64_t functionCost_{1};
 
 public:
-  InterpreterDeviceManager(const DeviceConfig &config,
-                           size_t maxMemory = 2000000000)
-      : QueueBackedDeviceManager(config), maxMemoryBytes_(maxMemory) {}
+  InterpreterDeviceManager(const DeviceConfig &config)
+      : QueueBackedDeviceManager(config),
+        maxMemoryBytes_(config_.getDeviceMemory(2000000000)) {}
 
   /// Returns the amount of memory in bytes available on the device when no
   /// models are loaded.

--- a/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
@@ -149,7 +149,13 @@ llvm::Error OpenCLDeviceManager::init() {
   if (err != CL_SUCCESS) {
     RETURN_ERR("Error getting device memory limit");
   }
-  maxMemoryBytes_ = mem_size;
+
+  // If limited by deviceConfig, should allow less deviceMemory
+  if (config_.getDeviceMemory() != 0 && config_.getDeviceMemory() < mem_size) {
+    maxMemoryBytes_ = config_.getDeviceMemory();
+  } else {
+    maxMemoryBytes_ = mem_size;
+  }
 
   return llvm::Error::success();
 }

--- a/tests/unittests/HabanaBackendTest.cpp
+++ b/tests/unittests/HabanaBackendTest.cpp
@@ -375,6 +375,21 @@ TEST_F(HabanaBackendTest, FuseConvAddRelu) {
   EXPECT_EQ(F_->getNodes().size(), 4);
 }
 
+TEST_F(HabanaBackendTest, SetDeviceMemory) {
+  uint64_t defaultMemory = (7 << 20);
+  auto configEmpty = glow::runtime::DeviceConfig(BackendKind::Habana);
+  auto configFull = glow::runtime::DeviceConfig(BackendKind::Habana);
+  configFull.setDeviceMemory(32768);
+  // With no commandline or deviceConfig, the memory should be default 7 <<20.
+  glow::runtime::HabanaDeviceManager device1(configEmpty, 1, 1);
+  llvm::Error err1 = device1.init();
+  EXPECT_EQ(defaultMemory * 1024, device1.getMaximumMemory());
+  // With only deviceConfig, the memory should be set by deviceConfig.
+  glow::runtime::HabanaDeviceManager device2(configFull, 1, 1);
+  llvm::Error err2 = device2.init();
+  EXPECT_EQ(32768, device2.getMaximumMemory());
+}
+
 TEST_F(HabanaBackendTest, ConvertFC) {
   HabanaBackend backend;
   auto *input =

--- a/tests/unittests/ProvisionerTest.cpp
+++ b/tests/unittests/ProvisionerTest.cpp
@@ -88,8 +88,9 @@ TEST_F(ProvisionerTest, provisionDagFail) {
 
   DeviceManagerMapTy devices;
   for (int i = 0; i < 6; i++) {
-    std::unique_ptr<DeviceManager> device(
-        new CPUDeviceManager(DeviceConfig(BackendKind::CPU), 1000));
+    auto config = DeviceConfig(BackendKind::CPU);
+    config.setDeviceMemory(1000);
+    std::unique_ptr<DeviceManager> device(new CPUDeviceManager(config));
     devices.emplace(i, std::move(device));
   }
   auto provisioner = Provisioner(devices);


### PR DESCRIPTION
Summary:

- Add deviceMemory member to DeviceConfig struct.
- Add  `setDeviceMemory()` and `getDeviceMemory()` to set (in bytes) and get the deviceMemory the `getDeviceMemory()` will return 0 by default.
- Add corresponding changes to backend (CPU, Interpreter, OpenCL and Habana). 
  - The CPU, Interpreter and Habana backends have options to use commandLine input as the deviceMemory. The commandLine should have higher priority than deviceConfig. 
  - The OpenCL backend used device info to get the maximum deviceMemory. Here the deviceConfig should have higher priority to limit the memory usage.

Test:
- Add test under the `DeviceManagerTest` to set then get device memory size from the
`DeviceConfig`. 
- Add test to DeviceManagerTest(CPU, Interpreter, OpenCL) to guarantee the priority logic mentioned above.
- Habana test is conducted on devgpu058.ash6.facebook.com. The test is included in the HabanaBackendTest.

Fixes:
This PR fixes #2899.
