### PR TITLE
[CompilationLog]: Add Compilation Scope class to track the current compilation phase.

### DIFF
--- a/include/glow/Support/CompilationLog.h
+++ b/include/glow/Support/CompilationLog.h
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_SUPPORT_COMPILATIONLOG_H
+#define GLOW_SUPPORT_COMPILATIONLOG_H
+
+#include "llvm/ADT/StringRef.h"
+
+#include <string>
+
+namespace glow {
+
+/// A class that defines the compilation scope.
+class CompilationScope {
+private:
+  /// Name of current scope.
+  /// Example: "ExecutionEngine::compile"
+  std::string funcName_;
+  std::string scopeName_;
+
+public:
+  /// When the constructor is called, current stack is pushed onto the scope
+  /// stack.
+  CompilationScope(llvm::StringRef funcName, llvm::StringRef scopeName);
+
+  /// When the destructor is called, current stack is popped out from the scope
+  /// stack.
+  ~CompilationScope();
+
+  llvm::StringRef getScopeName() const { return scopeName_; };
+};
+
+/// Dump the compilation log.
+/// \param logContent the content that will be written into the log file.
+void dumpCompilationLog(llvm::StringRef logContent);
+
+/// Dump the compilation log to a certain file.
+/// \param logFilename the file where the log will be written into.
+/// \param logContent the content that will be written into the log file.
+void dumpCompilationLog(llvm::StringRef logFilename,
+                        llvm::StringRef logContent);
+
+} // namespace glow
+
+#endif // GLOW_SUPPORT_COMPILATIONLOG_H

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -19,6 +19,7 @@
 #include "glow/Graph/Graph.h"
 #include "glow/Graph/PlaceholderBindings.h"
 #include "glow/Optimizer/Optimizer.h"
+#include "glow/Support/CompilationLog.h"
 
 #include "llvm/ADT/STLExtras.h"
 
@@ -243,6 +244,9 @@ void ExecutionEngine::compile(CompilationMode mode, Function *F,
 
 void ExecutionEngine::compile(Function *F, const CompilationContext &cctx,
                               bool clearOtherFunctions) {
+  // Dump compilation log
+  CompilationScope cscope(F->getName(), "ExecutionEngine::compile");
+
   llvm::StringRef name = F->getName();
 
   if (clearOtherFunctions) {

--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -24,6 +24,7 @@
 #include "glow/Optimizer/Optimizer.h"
 #include "glow/Quantization/Base/Base.h"
 #include "glow/Quantization/Quantization.h"
+#include "glow/Support/CompilationLog.h"
 
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/CommandLine.h"
@@ -2606,6 +2607,9 @@ void glow::fold(Function *F, CompilationMode mode) {
 }
 
 void glow::optimize(Function *F, const CompilationContext &cctx) {
+  // Dump compilation log
+  CompilationScope cscope(F->getName(), "glow::optimize");
+
   // Optimize may be called after backend specific transformations and some
   // nodes may have become unused. It is a good idea to remove them, before
   // proceeding with any further optimizations.
@@ -2764,6 +2768,9 @@ static void transformForPrecisionMode(const Backend &B, Function *F,
 // docs/GraphOptimizationPipeline.md
 llvm::Error glow::optimizeFunction(Function *F, const Backend &B,
                                    const CompilationContext &cctx) {
+  // Dump compilation log
+  CompilationScope cscope(F->getName(), "glow::optimizeFunction");
+
   // Verify the function pre-optimization/lowering.
   assert(F->verify() && "Function must be valid");
 

--- a/lib/Partitioner/Partitioner.cpp
+++ b/lib/Partitioner/Partitioner.cpp
@@ -21,6 +21,7 @@
 #include "llvm/Support/Format.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include "glow/Support/CompilationLog.h"
 #include <fstream>
 
 using namespace glow;
@@ -782,6 +783,8 @@ llvm::Error Partitioner::createDAGWithoutPartition(
 }
 
 llvm::Error Partitioner::Partition(const CompilationContext &cctx) {
+  CompilationScope cscope("", "Partitioner::Partition");
+
   // Prepare the mapping between BackendKind and BackendInfo.
   std::map<BackendKind, BackendInfo> backendMap;
   std::vector<Backend *> backends;

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -3,7 +3,8 @@ add_library(Support
               Error.cpp
               Random.cpp
               Support.cpp
-              ThreadPool.cpp)
+              ThreadPool.cpp
+              CompilationLog.cpp)
 target_link_libraries(Support
                       PUBLIC
                         LLVMSupport)

--- a/lib/Support/CompilationLog.cpp
+++ b/lib/Support/CompilationLog.cpp
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/Support/CompilationLog.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <fstream>
+
+namespace glow {
+auto constexpr defaultCompileLogFilename = "compile.log";
+static llvm::cl::opt<bool>
+    dumpCompilationLogOpt("dump-compilation-log",
+                          llvm::cl::desc("Dump compilation log"));
+
+CompilationScope::CompilationScope(llvm::StringRef funcName,
+                                   llvm::StringRef scopeName)
+    : funcName_(funcName), scopeName_(scopeName) {
+  if (dumpCompilationLogOpt) {
+    std::string startScopeMsg =
+        "\n---Entering the compilation scope: " + funcName_ + " -> " +
+        scopeName_;
+    dumpCompilationLog(startScopeMsg.append(scopeName_));
+  }
+}
+
+CompilationScope::~CompilationScope() {
+  if (dumpCompilationLogOpt) {
+    std::string endScopeMsg =
+        "\n---Leaving the compilation scope: " + funcName_ + " -> " +
+        scopeName_;
+    dumpCompilationLog(endScopeMsg);
+  }
+}
+
+void dumpCompilationLog(llvm::StringRef logContent) {
+  dumpCompilationLog(defaultCompileLogFilename, logContent);
+}
+void dumpCompilationLog(llvm::StringRef logFilename,
+                        llvm::StringRef logContent) {
+  llvm::outs() << "Writing compilation log file for Module to: " << logFilename
+               << '\n';
+  std::error_code EC;
+  llvm::raw_fd_ostream myfile(logFilename, EC, llvm::sys::fs::OF_Append);
+  myfile << logContent << "\n";
+}
+
+} // namespace glow

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -22,6 +22,7 @@
 #include "glow/Quantization/Quantization.h"
 #include "glow/Quantization/Serialization.h"
 #include "glow/Runtime/RuntimeTypes.h"
+#include "glow/Support/CompilationLog.h"
 
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/FileSystem.h"
@@ -272,6 +273,9 @@ static Kinded::Kind getKindFromNodeName(llvm::StringRef nodeName) {
 }
 
 void Loader::compile(PlaceholderBindings &bindings) {
+  // Dump compilation log
+  CompilationScope cscope("", "Loader::compile");
+
   // Dump the DAG before compilation if needed.
   if (!dumpGraphDAGFileBeforeCompilationOpt.empty()) {
     F_->dumpDAG(dumpGraphDAGFileBeforeCompilationOpt.c_str());


### PR DESCRIPTION
Summary:

- Implement a Compilation Scope class such that
  - Has a scope name which contains the function name and the compilation phase it's currently at. Example: `googlenet_v1_slim/googlenet_v1_slim.onnx -> glow::optimize`
  - Whenever one object of CompilationScope is initialized, a message stating entering this compilation scope will be printed out to the compilation log
  - When the object destructor is called, a message stating leaving this compilation scope will be printed out to the compilation log
  - The CompilationScope will only be initialized in the beginning of one function and will be auto-collected when the function returns.

- Also implement a helper function dumpCompilationLog to dump the compilation log into a file.

Test Plan:
I intercepted five functions in the Glow codebase right now (there should be more):
- ExecutionEngine::compile()
- Loader::compile()
- glow::optimize()
- glow::optimizeFunction()
- Partitioner::Partition()

The scope at the each phase would be dumped by the helper function.

I tested by running image-classifer, with the following command `./bin/image-classifier tests/images/imagenet/cat_285.png -image-mode=0to1 -m=googlenet_v1_slim/googlenet_v1_slim.onnx -model-input-name=input:0 -image-layout=NHWC -cpu -dump-compilation-log=true`

Below is the dumped log:
`---Entering the compilation scope: Loader::compile`

`---Entering the compilation scope: Partitioner::Partition`

`---Entering the compilation scope: googlenet_v1_slim/googlenet_v1_slim.onnx -> glow::optimizeFunction`

`---Entering the compilation scope: googlenet_v1_slim/googlenet_v1_slim.onnx -> glow::optimize`

`---Leaving the compilation scope: googlenet_v1_slim/googlenet_v1_slim.onnx -> glow::optimize`

`---Entering the compilation scope: googlenet_v1_slim/googlenet_v1_slim.onnx -> glow::optimize`

`---Leaving the compilation scope: googlenet_v1_slim/googlenet_v1_slim.onnx -> glow::optimize`

`---Entering the compilation scope: googlenet_v1_slim/googlenet_v1_slim.onnx -> glow::optimize`

`---Leaving the compilation scope: googlenet_v1_slim/googlenet_v1_slim.onnx -> glow::optimize`

`---Leaving the compilation scope: googlenet_v1_slim/googlenet_v1_slim.onnx -> glow::optimizeFunction`

`---Leaving the compilation scope: Partitioner::Partition`

`---Leaving the compilation scope: Loader::compile`



 

