### PR TITLE
ONNXModelLoader can automatically create input placeholders.

### DIFF
--- a/include/glow/Importer/ONNXModelLoader.h
+++ b/include/glow/Importer/ONNXModelLoader.h
@@ -187,6 +187,7 @@ public:
   /// serialized in \p modelDescFilename and populates the network into \p F.
   /// The types in \p types match the list of names \p tensorNames and used as
   /// inputs to the network.
+  /// If \p names and \p types are empty loader fills inputs automatically.
   /// If \p errPtr is not null then if an error occurs it will get assigned
   /// there otherwise if an error occurs it will abort.
   ONNXModelLoader(const std::string &modelDescFilename,

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -1136,7 +1136,12 @@ ONNXModelLoader::ONNXModelLoader(const std::string &modelDescFilename,
     RETURN_IF_ERR(setVersion(modelDef));
 
     ONNX_NAMESPACE::GraphProto graphDef = modelDef.graph();
-    RETURN_IF_ERR(checkInputs(graphDef, tensorNames, types));
+
+    if (tensorNames.empty() && types.empty()) {
+      RETURN_IF_ERR(loadInputs(graphDef, true));
+    } else {
+      RETURN_IF_ERR(checkInputs(graphDef, tensorNames, types));
+    }
 
     RETURN_IF_ERR(loadInitializers(graphDef));
     RETURN_IF_ERR(loadNetwork(graphDef));

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -1636,3 +1636,19 @@ TEST(onnx, batchNormPR2304) {
       llvm::dyn_cast<BatchNormalizationNode>(trNode->getInput().getNode());
   EXPECT_NE(nullptr, bnNode);
 }
+
+/// Test constructor for auto loading inputs case.
+TEST(onnx, autoLoadInputs) {
+  ExecutionEngine EE;
+  auto &mod = EE.getModule();
+  std::string netFilename(GLOW_DATA_PATH
+                          "tests/models/onnxModels/batchNormPR2304.onnxtxt");
+  auto *F = mod.createFunction("main");
+  Tensor inputTensor(ElemKind::FloatTy, {1, 2, 10, 10});
+  llvm::StringRef inputName = "input";
+  ONNXModelLoader onnxLD(netFilename, {}, {}, *F);
+  auto inputs = onnxLD.getInputVarsMapping();
+  EXPECT_EQ(inputs.size(), 1);
+  EXPECT_EQ(inputs["input"]->getName(), inputName);
+  EXPECT_TRUE(inputTensor.getType().isEqual(inputs["input"]->getType()));
+}


### PR DESCRIPTION
Summary:
For inference mode ONNXModelLoader constructor can detect and create Placeholders for model inputs.
Caller may not know in advance inputs, auto-detection is a useful feature.

Differential Revision: D15475110

