### PR TITLE
[Partitioner] Bug fix: remove duplicated generated "save" node in heterogeneous partition.

### DIFF
--- a/lib/Partitioner/Partitioner.cpp
+++ b/lib/Partitioner/Partitioner.cpp
@@ -578,7 +578,8 @@ DeviceIDTy Partitioner::doPartitioning(llvm::StringRef funcName,
         // It is possible that one input is the output of anther function.
         if (Placeholder *ph = llvm::dyn_cast<Placeholder>(input.getNode())) {
           for (auto &user : ph->getUsers()) {
-            if (llvm::dyn_cast<SaveNode>(user.getUser())) {
+            if (auto *save = llvm::dyn_cast<SaveNode>(user.getUser())) {
+              placeholders[input] = save->getPlaceholder();
               inputF = mapping[user.getUser()];
               break;
             }


### PR DESCRIPTION
Summary:
In Heterogeneous partition, after backendBasedPartition, we got a list of function. Then when we finally create the DAG, it is possible that one input in one function may use the output of another function. In that case, we don't need to generate an "save" node again. i

Documentation:

Test Plan:
ninja test. Check the generated partitions graph manually. 

[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
