### PR TITLE
[unittests] Add option to clone a FunctionTensorPair repeatedly inside itself

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -262,6 +262,14 @@ public:
     return N;
   }
 
+  /// Take ownership of \p N by removing it from its original Function, add it
+  /// to the current Function, and also unique its name.
+  void takeOwnershipOfNode(Node *N) {
+    N->getParent()->getNodes().remove(N);
+    N->setName(Module::uniqueName(N->getName(), uniqueNodeNames_));
+    nodes_.push_back(N);
+  }
+
   /// Get the pseudo-random number generator used by this module.
   PseudoRNG &getPRNG() { return getParent()->getPRNG(); }
 

--- a/tests/unittests/BackendCorrectnessTest.cpp
+++ b/tests/unittests/BackendCorrectnessTest.cpp
@@ -442,12 +442,14 @@ TEST_P(BackendCorrectnessTest, convOps) {
 
 TEST_P(BackendCorrectnessTest, basicFCNet) {
   compareAgainstInterpreter(GetParam(), createAndInitBasicFCNet,
-                            ElemKind::FloatTy, ElemKind::FloatTy, 0.0004);
+                            ElemKind::FloatTy, ElemKind::FloatTy, 0.0004f,
+                            parCloneCountOpt);
 }
 
 TEST_P(BackendCorrectnessTest, basicFCNetQuantized) {
   compareAgainstInterpreter(GetParam(), createAndInitBasicFCNet,
-                            ElemKind::Int8QTy, ElemKind::Int8QTy);
+                            ElemKind::Int8QTy, ElemKind::Int8QTy, 0.0001f,
+                            parCloneCountOpt);
 }
 
 TEST_P(CPUOnly, complexNet1) {

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -29,6 +29,8 @@
 
 namespace glow {
 
+extern unsigned parCloneCountOpt;
+
 // A test harness to enable a test case for specific backends. A test suite
 // should subclass this and instantiate it as follows:
 //
@@ -206,12 +208,23 @@ using CreateAndInitFunction =
 /// Function it will be converted using the Converter. If
 /// \p enableRowwiseQuantization then rowwise quantization will be used for
 /// nodes that support it. \p schema represents the quantization schema to use,
-/// if applicable.
+/// if applicable. \p parallelCount represents the number of times to clone the
+/// Function inside itself, so that testing can be done on architectures that
+/// have parallel compute engines.
 void compareAgainstInterpreter(
     BackendKind backendKind, CreateAndInitFunction createAndInitFunction,
     ElemKind interpElemKind, ElemKind backendElemKind,
-    float allowedError = 0.0001, bool enableRowwiseQuantization = false,
+    float allowedError = 0.0001, unsigned parallelCount = 1,
+    bool enableRowwiseQuantization = false,
     quantization::Schema schema = quantization::Schema::Asymmetric);
+
+/// Given some \p FTP representing a Function with a single SaveNode and its
+/// Tensor output, duplicate the Nodes in the Function and their Placeholder
+/// inputs given \p bindings \p parallelCount times. \returns a set of Tensor
+/// pointers for each output of the cloned Function.
+std::unordered_set<Tensor *> cloneFunInsideFun(FunctionTensorPair FTP,
+                                               PlaceholderBindings *bindings,
+                                               unsigned parallelCount);
 
 void inferConvNet(Tensor *inputs, Tensor *filter, Tensor *bias, Tensor *out,
                   BackendKind kind);


### PR DESCRIPTION
Summary: Take a Function with a single SaveNode and copy it repeatedly inside itself. This is to enable stress testing an architecture with many embarrassingly parallel graphs.

Test Plan: Added a couple example tests using this functionality.

For example, for the original matmul test:

<img width="324" alt="Screen Shot 2019-05-23 at 11 12 21 PM" src="https://user-images.githubusercontent.com/1198212/58306414-45c89480-7db0-11e9-9b16-d3bb724478ed.png">

And after cloning it 3 times via `cloneFunInsideFun()`:

<img width="873" alt="Screen Shot 2019-05-23 at 11 12 30 PM" src="https://user-images.githubusercontent.com/1198212/58306418-482aee80-7db0-11e9-88a9-824b16a70928.png">

Note that each Placeholder's corresponding backing tensor is copied in the PlaceholderBindings, so each parallel clone should have the same results.