### PR TITLE
[Dump] add dump functions for Glow data structure

### DIFF
--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -25,6 +25,7 @@
 #include "glow/Support/Random.h"
 
 #include "llvm/ADT/ArrayRef.h"
+#include "llvm/Support/raw_ostream.h"
 
 namespace glow {
 
@@ -357,6 +358,27 @@ public:
     std::swap(tensorPool_, other.tensorPool_);
     return *this;
   }
+
+  /// Dump a textual representation of the Tensor into provided output stream.
+  void dump(llvm::raw_ostream &os) const;
+
+  /// Dump a textual representation of the Tensor into default output stream.
+  void dump() const;
+
+  /// Dump a textual representation of a specific number of elements in the
+  /// Tensor into provided output stream.
+  void dump(llvm::raw_ostream &os, unsigned maxNumElem) const;
+
+  /// Dump a textual representation of a specific number of elements in the
+  /// Tensor into default output stream.
+  void dump(unsigned maxNumElem) const;
+
+  /// Dump a textual representation of the Tensor to std::string.
+  std::string toString() const;
+
+  /// Dump a textual representation of a specific number of elements in the
+  /// Tensor to std::string.
+  std::string toString(unsigned maxNumElem) const;
 
   /// \returns true if the content of the other tensor \p other is identical to
   /// this one.
@@ -1003,6 +1025,9 @@ template <class ElemTy> const Handle<ElemTy> Tensor::getHandle() const & {
   return Handle<ElemTy>(const_cast<Tensor *>(this));
 }
 
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Tensor &t);
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Tensor *t);
 } // namespace glow
 
 #endif // GLOW_BASE_TENSOR_H

--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -532,6 +532,15 @@ struct Type final {
     return names[(int)Ty];
   }
 
+  /// Dump a textual representation of the Type into provided output stream.
+  void dump(llvm::raw_ostream &out) const;
+
+  /// Dump a textual representation of the Type into default output stream.
+  void dump() const;
+
+  /// Dump a textual representation of the Type to std::string.
+  std::string toString() const;
+
 private:
   /// Setup the internals of type that store the dimensions. This method is
   /// used by the constructor.

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -163,8 +163,14 @@ public:
   /// Get the pseudo-random number generator used by this module.
   PseudoRNG &getPRNG() { return PRNG_; }
 
-  /// Dumps the textual representation of the network.
+  /// Dump a textual representation of the Module into default output stream.
   void dump() const;
+
+  /// Dump a textual representation of the Module to std::string.
+  std::string toString() const;
+
+  /// Dump a textual representation of the Module into provided output stream.
+  void dump(llvm::raw_ostream &os) const;
 
   /// Dump a dotty graph that depicts the Module.
   void dumpDAG();
@@ -1077,8 +1083,14 @@ public:
   /// \returns true when the function is valid. False otherwise.
   bool verify() const;
 
-  /// Dumps the textual representation of the network.
+  /// Dump a textual representation of the Function into provided output stream.
   void dump() const;
+
+  /// Dump a textual representation of the Function to std::string.
+  std::string toString() const;
+
+  /// Dump a textual representation of the Function into default output stream.
+  void dump(llvm::raw_ostream &os) const;
 
   /// Dump a dotty graph that depicts the function into a file.
   /// \returns full path to the file.
@@ -1128,6 +1140,14 @@ SaveNode *getOutputSave(Function *F, Placeholder *PH);
   { 0u, 2u, 3u, 1u }
 #define NHWC2NCHW                                                              \
   { 0u, 3u, 1u, 2u }
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Module &mod);
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Module *mod);
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Function &F);
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Function *F);
 
 } // namespace glow
 

--- a/include/glow/Graph/Node.h
+++ b/include/glow/Graph/Node.h
@@ -110,6 +110,15 @@ public:
   /// \returns a textual description of the node.
   std::string getDebugDesc() const;
 
+  /// Dump a textual representation of the Node into provided output stream.
+  void dump(llvm::raw_ostream &out) const;
+
+  /// Dump a textual representation of the Node into default output stream.
+  void dump() const;
+
+  /// Dump a textual representation of the Node to std::string.
+  std::string toString() const;
+
   /// \returns copy of the current node. Notice that the new node is not
   /// inserted into any DAG. The caller of this method should add it to some
   /// node-list.
@@ -380,6 +389,10 @@ constexpr unsigned LHSIdx = 0;
 constexpr unsigned RHSIdx = 1;
 constexpr unsigned ResultIdx = 0;
 } // namespace ArithmeticNode
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Node &node);
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Node *node);
 
 } // namespace glow
 

--- a/include/glow/IR/IR.h
+++ b/include/glow/IR/IR.h
@@ -93,11 +93,14 @@ public:
   /// Verify the correctness of the instruction parameters.
   void verify(const IRFunction &M) const;
 
-  /// Print value.
+  /// Dump a textual representation of the Value into provided output stream.
   void dump(llvm::raw_ostream &out) const;
 
-  /// Print value using a default output stream.
+  /// Dump a textual representation of the Value into default output stream.
   void dump() const;
+
+  /// Dump a textual representation of the Value to std::string.
+  std::string toString() const;
 
   /// Print value in context.
   void dumpInContext(llvm::raw_ostream &out) const;
@@ -302,10 +305,15 @@ public:
   /// Verify the correctness of the function.
   void verify() const;
 
-  /// Dump a textual representation of the function.
+  /// Dump a textual representation of the IRFunction into default output
+  /// stream.
   void dump() const;
 
-  /// Dump a textual representation of the function into provided output stream.
+  /// Dump a textual representation of the IRFunction to std::string.
+  std::string toString() const;
+
+  /// Dump a textual representation of the IRFunction into provided output
+  /// stream.
   void dump(llvm::raw_ostream &OS) const;
 
   /// Dump a dotty graph that depicts the function.
@@ -388,6 +396,14 @@ public:
   /// was assigned to this instruction.
   int64_t getInstrNumber(const Instruction *I) const;
 };
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Value &V);
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Value *V);
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const IRFunction &irf);
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const IRFunction *irf);
 
 } // namespace glow
 

--- a/lib/Base/Tensor.cpp
+++ b/lib/Base/Tensor.cpp
@@ -330,6 +330,36 @@ void glow::dumpImpl(const Tensor *T, unsigned maxNumElem) {
 
 void glow::dumpImpl(const Tensor *T) { dumpImpl(T, llvm::outs()); }
 
+// Dump functions.
+void Tensor::dump(llvm::raw_ostream &os) const { dumpImpl(this, os); }
+
+void Tensor::dump() const { dumpImpl(this, llvm::outs()); }
+
+std::string Tensor::toString() const {
+  std::string storage;
+  llvm::raw_string_ostream os(storage);
+  dumpImpl(this, os);
+  return os.str();
+}
+
+void Tensor::dump(llvm::raw_ostream &os, unsigned maxNumElem) const {
+  dumpImpl(this, os, maxNumElem);
+}
+
+void Tensor::dump(unsigned maxNumElem) const {
+  dumpImpl(this, llvm::outs(), maxNumElem);
+}
+
+std::string Tensor::toString(unsigned maxNumElem) const {
+  std::string storage;
+  llvm::raw_string_ostream os(storage);
+  dumpImpl(this, os, maxNumElem);
+  return os.str();
+}
+
+/// Dump a textual representation of a specific number of elements in the Tensor
+/// to std::string.
+
 void glow::genericTranspose(const Tensor *src, Tensor *dest,
                             llvm::ArrayRef<unsigned_t> shuffle) {
   DCHECK(src->dims().size() == shuffle.size())
@@ -523,3 +553,17 @@ size_t Tensor::getUnpaddedSizeInBytes() const {
     return type_.getSizeInBytes();
   }
 }
+
+namespace glow {
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Tensor &t) {
+  t.dump(os);
+  return os;
+}
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Tensor *t) {
+  assert(t != nullptr && "Null Pointer.");
+  t->dump(os);
+  return os;
+}
+
+} // namespace glow

--- a/lib/Base/Type.cpp
+++ b/lib/Base/Type.cpp
@@ -54,4 +54,16 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const TypeRef &type) {
   }
   return os << *type;
 }
+
+void Type::dump(llvm::raw_ostream &out) const { out << this; }
+
+void Type::dump() const { dump(llvm::outs()); }
+
+std::string Type::toString() const {
+  std::string storage;
+  llvm::raw_string_ostream os(storage);
+  os << this;
+  return os.str();
+}
+
 } // namespace glow

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -100,6 +100,24 @@ void Module::dump() const {
   }
 }
 
+std::string Module::toString() const {
+  std::string storage;
+  llvm::raw_string_ostream os(storage);
+  dump(os);
+  return os.str();
+}
+
+void Module::dump(llvm::raw_ostream &os) const {
+  os << "Module structure:\n";
+  for (auto v : getConstants()) {
+    os << v->getDebugDesc() << "\n";
+  }
+
+  for (auto f : functions_) {
+    os << "Function:" << f->getName() << "\n";
+  }
+}
+
 /// A helper class for visiting and generating the dotty graph file.
 class AbstractDottyPrinter {
 protected:
@@ -2547,7 +2565,21 @@ TraceEventNode *Function::createTraceEvent(llvm::StringRef eventName,
 void Function::dump() const {
   llvm::outs() << "Graph structure " << getName() << ":\n";
   for (auto &n : nodes_) {
-    llvm::outs() << n.getDebugDesc() << "\n";
+    llvm::outs() << n.getDebugDesc();
+  }
+}
+
+std::string Function::toString() const {
+  std::string storage;
+  llvm::raw_string_ostream os(storage);
+  dump(os);
+  return os.str();
+}
+
+void Function::dump(llvm::raw_ostream &os) const {
+  os << "Graph structure " << getName() << ":\n";
+  for (auto &n : nodes_) {
+    os << n.getDebugDesc();
   }
 }
 
@@ -2973,3 +3005,28 @@ SaveNode *glow::getOutputSave(Function *F, Placeholder *PH) {
   }
   return nullptr;
 }
+
+namespace glow {
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Module &mod) {
+  mod.dump(os);
+  return os;
+}
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Module *mod) {
+  assert(mod != nullptr && "Null Pointer.");
+  mod->dump(os);
+  return os;
+}
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Function &F) {
+  F.dump(os);
+  return os;
+}
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Function *F) {
+  assert(F != nullptr && "Null Pointer.");
+  F->dump(os);
+  return os;
+}
+} // namespace glow

--- a/lib/Graph/Node.cpp
+++ b/lib/Graph/Node.cpp
@@ -258,6 +258,12 @@ std::string Node::getDebugDesc() const {
   }
 }
 
+void Node::dump(llvm::raw_ostream &out) const { out << this->getDebugDesc(); }
+
+void Node::dump() const { dump(llvm::outs()); }
+
+std::string Node::toString() const { return this->getDebugDesc(); }
+
 Node *Node::clone() const {
   switch (getKind()) {
 #define DEF_NODE(CLASS, NAME)                                                  \
@@ -281,6 +287,20 @@ void Node::destroyNode(Node *N) {
     llvm_unreachable("Unhandled node");
   }
 }
+
+namespace glow {
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Node &node) {
+  node.dump(os);
+  return os;
+}
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Node *node) {
+  assert(node != nullptr && "Null Pointer.");
+  node->dump(os);
+  return os;
+}
+} // namespace glow
 
 //===----------------------------------------------------------------------===//
 //                       Nodes verification

--- a/lib/IR/IR.cpp
+++ b/lib/IR/IR.cpp
@@ -474,6 +474,13 @@ void Value::dump(llvm::raw_ostream &out) const { dumpIR(this, out); }
 
 void Value::dump() const { dumpIR(this, llvm::outs()); }
 
+std::string Value::toString() const {
+  std::string storage;
+  llvm::raw_string_ostream os(storage);
+  dump(os);
+  return os.str();
+}
+
 void Value::dumpInContext(llvm::raw_ostream &out) const {
   dumpIRInContext(this, out);
 }
@@ -573,6 +580,13 @@ void IRFunction::dump(llvm::raw_ostream &OS) const {
   OS.flush();
 }
 
+std::string IRFunction::toString() const {
+  std::string storage;
+  llvm::raw_string_ostream os(storage);
+  dump(os);
+  return os.str();
+}
+
 //===----------------------------------------------------------------------===//
 // InstructionTraits<Instruction> Implementation
 //===----------------------------------------------------------------------===//
@@ -597,3 +611,28 @@ void InstructionTraits::removeNodeFromList(Instruction *I) {
   assert(I->getParent() && "Not in a list!");
   I->setParent(nullptr);
 }
+
+namespace glow {
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Value &V) {
+  V.dump(os);
+  return os;
+}
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Value *V) {
+  assert(V != nullptr && "Null Pointer.");
+  V->dump(os);
+  return os;
+}
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const IRFunction &irf) {
+  irf.dump(os);
+  return os;
+}
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const IRFunction *irf) {
+  assert(irf != nullptr && "Null Pointer.");
+  irf->dump(os);
+  return os;
+}
+} // namespace glow

--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -499,3 +499,16 @@ INSTANTIATE_TEST_CASE_P(JIT, BackendTest, ::testing::Values(BackendKind::CPU));
 INSTANTIATE_TEST_CASE_P(OpenCL, BackendTest,
                         ::testing::Values(BackendKind::OpenCL));
 #endif // GLOW_WITH_OPENCL
+
+/// Check if the dump function works for Type.
+TEST(BackendTest, dumpType) {
+  Module mod;
+  TypeRef tyA = mod.uniqueType(ElemKind::FloatTy, {1, 32, 32, 3});
+  std::string storage;
+  llvm::raw_string_ostream os(storage);
+  tyA->dump(os);
+  std::string mesA = tyA->toString();
+  std::string expectA = "float<1 x 32 x 32 x 3>";
+  EXPECT_EQ(mesA, expectA);
+  EXPECT_EQ(mesA, os.str());
+}

--- a/tests/unittests/TensorsTest.cpp
+++ b/tests/unittests/TensorsTest.cpp
@@ -16,6 +16,7 @@
 
 #include "glow/Base/Tensor.h"
 #include "glow/Quantization/Base/Base.h"
+#include "llvm/Support/raw_ostream.h"
 
 #include "gtest/gtest.h"
 
@@ -907,4 +908,35 @@ TEST(Tensor, randomizeFused) {
       EXPECT_EQ(TH.at({i, j}), i * 10 + j);
     }
   }
+}
+
+/// Check if dump functions work for Tensor
+TEST(Tensor, dump) {
+  Tensor T = {1.2f, 12.1f, 51.0f, 1515.2f};
+  std::string mes = T.toString();
+  std::string storageT1;
+  llvm::raw_string_ostream osT1(storageT1);
+  T.dump(osT1);
+  std::string expectMes = R"(shape: ( 4 )
+max: 1515.200  min: 1.200
+[1.200, 12.100, 51.000, 1515.200, ]
+)";
+  EXPECT_EQ(mes, expectMes);
+  EXPECT_EQ(mes, osT1.str());
+  std::string storageT2;
+  llvm::raw_string_ostream osT2(storageT2);
+  osT2 << T;
+  EXPECT_EQ(mes, osT2.str());
+  T.dump(2);
+  std::string expectMes2 = R"(shape: ( 4 )
+max: 1515.200  min: 1.200
+[1.200, 12.100, ...]
+)";
+  std::string storageT3;
+  llvm::raw_string_ostream osT3(storageT3);
+  // Only dump 2 elements.
+  T.dump(osT3, 2);
+  std::string mes2 = T.toString(2);
+  EXPECT_EQ(mes2, expectMes2);
+  EXPECT_EQ(mes2, osT3.str());
 }


### PR DESCRIPTION
Summary
- add missing `dump(llvm::raw_ostream &os)`, `dump()` , and `std::string toString()` for glow::Module, glow::Function, glow::IRFunction, glow::Value, glow::Instruction, glow::Tensor, glow::Type and glow::Node.
- add overloading operator `llvm::raw_ostream &operator<<`  for above data structures and their reference.

Test:
add tests in TensorsTest, BackendTest, GraphTest and IROptTest to verify the new dump functions work and the outputs match the expected results.

Fixes:
This PR fixes #2831


