### PR TITLE
[ci] Only run EXPENSIVE tests in RELEASE_WITH_EXPENSIVE

### DIFF
--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -37,14 +37,14 @@ case ${CIRCLE_JOB} in
     ASAN)
         # ASAN is not enabled in onnx, therefore we should skip it for now.
         # TODO: Enable ASAN test.
-        run_unit_tests test
+        run_unit_tests check
         ;;
     TSAN)
         # Run only Glow tests.
-        run_unit_tests test
+        run_unit_tests check
         ;;
     DEBUG)
-        run_unit_tests test
+        run_unit_tests check
         run_unit_tests test_unopt
         run_and_check_bundle YES
         run_and_check_bundle NO


### PR DESCRIPTION
Summary: I noticed that RecommendationSystemTest is marked expensive but is running on TSAN and DEBUG builds, which causes a timeout (after I added some extra-expensive tests in #2964.  Digging a bit, I don't think the default `ninja test` target knows what to do with `EXPENSIVE` labels, but `ninja check` seems to behave correctly.

GitHub Test Plan: Check CircleCI on this diff to see if RecSys ran

Test Plan: Check CircleCI
