### PR TITLE
[Runtime] Add config file for Device Config used in Runtime.

### DIFF
--- a/include/glow/Support/Support.h
+++ b/include/glow/Support/Support.h
@@ -119,6 +119,31 @@ inline void report(llvm::StringRef str) { report(str.data()); }
 /// can be inspected under debugger.
 std::string legalizeName(llvm::StringRef name);
 
+/// Data structure for multi string format used in yaml file.
+struct MultiLineStr {
+  std::string str;
+};
+
+/// Data structure used to read the yaml file for Device Configs.
+struct DeviceConfigHelper {
+  /// Device Name.
+  std::string name_;
+  /// BackendKind name.
+  std::string kindName_;
+  /// A string with multi lines. Each line represents a param.
+  MultiLineStr parameters_;
+  DeviceConfigHelper() = default;
+  DeviceConfigHelper(std::string &name, std::string &kindName)
+      : name_(name), kindName_(kindName) {}
+  DeviceConfigHelper(std::string &kindName, std::string &name,
+                     MultiLineStr &parameters)
+      : name_(name), kindName_(kindName), parameters_(parameters) {}
+};
+
+/// Deserialize quantization infos from the file \p fileName.
+std::vector<DeviceConfigHelper>
+deserializeDeviceConfigFromYaml(llvm::StringRef fileName);
+
 /// Printf-like formatting for std::string.
 const std::string strFormat(const char *format, ...)
 #ifndef _MSC_VER

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ add_subdirectory(unittests)
 add_subdirectory(images)
 add_subdirectory(benchmark)
 add_subdirectory(models)
+add_subdirectory(runtime_test)
 
 # External backends
 ExternalBackendsTest()
@@ -89,6 +90,11 @@ add_output_check_test(NAME en2gr_quantization_test
 # Create en2gr_cpu_partition_test OutputCheck test.
 add_output_check_test(NAME en2gr_cpu_partition_test
                       COMMAND ${TEXT_TRANSLATOR_TESTS_DIR}/en2gr_cpu_partition_test.sh
+                      REQUIRES MODELS RELEASE)
+
+# Create en2gr_cpu_config_test OutputCheck test.
+add_output_check_test(NAME en2gr_cpu_config_test
+                      COMMAND ${TEXT_TRANSLATOR_TESTS_DIR}/en2gr_cpu_config_test.sh
                       REQUIRES MODELS RELEASE)
 
 # Create an OutputCheck test to run resnet-runtime-test.

--- a/tests/runtime_test/CMakeLists.txt
+++ b/tests/runtime_test/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Copy the models to the build directory.
+
+file(GLOB files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.yaml)
+foreach(filename ${files})
+  configure_file(${filename} ${CMAKE_CURRENT_BINARY_DIR}/${filename} COPYONLY)
+endforeach(filename)
+

--- a/tests/runtime_test/cpuConfigs.yaml
+++ b/tests/runtime_test/cpuConfigs.yaml
@@ -1,0 +1,12 @@
+---
+- name:     Device1
+  kindName: CPU
+  parameters: |
+    "platformID":"1"
+    "deviceID" : "0"
+- name:     Device2
+  kindName: CPU
+  parameters: |
+    "platformID":"1"
+...
+

--- a/tests/text-translator/en2gr_cpu_config_test.sh
+++ b/tests/text-translator/en2gr_cpu_config_test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Copyright (c) 2017-present, Facebook, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euxo pipefail
+
+# CHECK: ich liebe Musik \.$
+$BIN/text-translator -m "${MODELS_DIR}/en2gr" -cpu -cpu-memory=500000 -load-device-configs="tests/runtime_test/cpuConfigs.yaml" <<< "I love music ."

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -522,7 +522,9 @@ target_link_libraries(UtilsTest
                         Testing
                         gtest
                         TestMain)
-add_glow_test(UtilsTest ${GLOW_BINARY_DIR}/tests/UtilsTest --gtest_output=xml:UtilsTest.xml)
+add_glow_test(NAME UtilsTest 
+              COMMAND ${GLOW_BINARY_DIR}/tests/UtilsTest --gtest_output=xml:UtilsTest.xml
+              WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
 LIST(APPEND UNOPT_TESTS true)
 add_custom_target(test_unopt ${UNOPT_TESTS}

--- a/tests/unittests/SupportTest.cpp
+++ b/tests/unittests/SupportTest.cpp
@@ -18,6 +18,10 @@
 #include "glow/Testing/StrCheck.h"
 #include "gtest/gtest.h"
 
+#ifndef GLOW_DATA_PATH
+#define GLOW_DATA_PATH
+#endif
+
 using namespace glow;
 using glow::StrCheck;
 
@@ -45,4 +49,32 @@ TEST(Support, legalizeName) {
   // Check that a legal name won't be converted.
   std::string str3 = legalizeName("abc_1aBc");
   EXPECT_TRUE(str3.compare("abc_1aBc") == 0);
+}
+
+/// Check the reading Device config from a yaml file.
+TEST(Support, loadYamlFile) {
+  std::string yamlFilename(GLOW_DATA_PATH "tests/runtime_test/cpuConfigs.yaml");
+  std::vector<DeviceConfigHelper> lists;
+  lists = deserializeDeviceConfigFromYaml(yamlFilename);
+  EXPECT_EQ(lists.size(), 2);
+  // Check the loading items.
+  // The config file is:
+  //---
+  //- name:     Device1
+  //  kindName: CPU
+  //  parameters: |
+  //  "platformID":"1"
+  //    "deviceID" : "0"
+  //    - name:     Device2
+  //  kindName: CPU
+  //  parameters: |
+  //  "platformID":"1"
+  //...
+  EXPECT_EQ(lists[0].kindName_, "CPU");
+  EXPECT_EQ(lists[0].name_, "Device1");
+  EXPECT_EQ(lists[0].parameters_.str,
+            "\"platformID\":\"1\"\n\"deviceID\" : \"0\"\n");
+  EXPECT_EQ(lists[1].kindName_, "CPU");
+  EXPECT_EQ(lists[1].name_, "Device2");
+  EXPECT_EQ(lists[1].parameters_.str, "\"platformID\":\"1\"\n");
 }

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -31,6 +31,8 @@
 #include "llvm/Support/Timer.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <sstream>
+
 using namespace glow;
 
 /// -enable-rowwise : Command line option to enable rowwise quantized
@@ -174,6 +176,13 @@ llvm::cl::opt<bool> assertAllNodesQuantizedOpt(
         "whitelist node kinds that are allowed to be left unquantized."),
     llvm::cl::init(false), llvm::cl::cat(loaderCat));
 
+/// The device configs file used for Runtime.
+llvm::cl::opt<std::string> loadDeviceConfigsFileOpt(
+    "load-device-configs",
+    llvm::cl::desc("Load device configs used in Runtime"),
+    llvm::cl::value_desc("profile.yaml"), llvm::cl::Optional,
+    llvm::cl::cat(loaderCat));
+
 /// Name of the network being bundled.
 llvm::cl::opt<std::string> networkName(
     "network-name",
@@ -269,6 +278,74 @@ static Kinded::Kind getKindFromNodeName(llvm::StringRef nodeName) {
   }
 #include "glow/AutoGenNodes.def"
   GLOW_UNREACHABLE("Unknown node name.");
+}
+
+/// Helper to get the BackendKind type from a backend's \p name. Need to be
+/// updated if a new backend comes.
+static BackendKind getBackendKindFromName(std::string &name) {
+  const llvm::StringMap<BackendKind> mapping(
+      {{"CPU", BackendKind::CPU},
+       {"Interpreter", BackendKind::Interpreter},
+       {"OpenCL", BackendKind::OpenCL},
+       {"Habana", BackendKind::Habana}});
+  if (mapping.find(name) == mapping.end()) {
+    GLOW_UNREACHABLE("Unknown backendKind name.");
+  }
+  return mapping.lookup(name);
+}
+
+/// Helper to get the parameters in DeviceConfig from \p str. The \p str has
+/// multiple lines, and each line with this format : "str1" : "str2".
+static llvm::StringMap<std::string> getBackendParams(std::string &str) {
+  llvm::StringMap<std::string> ret{};
+  std::string s;
+  std::istringstream f(str.c_str());
+  while (getline(f, s, '\n')) {
+    // Abstract the mapping from each line's string:
+    // ""str1" : "str2"" => ret["str1"] = "str2";
+    size_t pos1, pos2, pos3, pos4;
+    pos1 = s.find('"');
+    assert(pos1 != std::string::npos && "invalid string format");
+    pos2 = s.find('"', pos1 + 1);
+    assert(pos2 != std::string::npos && "invalid string format");
+    pos3 = s.find('"', pos2 + 1);
+    assert(pos3 != std::string::npos && "invalid string format");
+    pos4 = s.find('"', pos3 + 1);
+    assert(pos4 != std::string::npos && "invalid string format");
+    ret[s.substr(pos1 + 1, pos2 - pos1 - 1)] =
+        s.substr(pos3 + 1, pos4 - pos3 - 1);
+  }
+  return ret;
+}
+
+/// If the device config file \p loadDeviceDoncfigsFile available, load \p
+/// configs from the file. Otherwise, create \p numDevices number of devices
+/// based on \p backendKind.
+static std::vector<std::unique_ptr<runtime::DeviceConfig>>
+generateDeviceConfigs(std::string &loadDeviceConfigsFile,
+                      unsigned int numDevices, BackendKind backendKind) {
+  std::vector<std::unique_ptr<runtime::DeviceConfig>> configs;
+  if (loadDeviceConfigsFile.empty()) {
+    // If there is no device config file, use numDevices to generate the
+    // configs.
+    for (unsigned int i = 0; i < numDevices; ++i) {
+      auto config = llvm::make_unique<runtime::DeviceConfig>(backendKind);
+      configs.push_back(std::move(config));
+    }
+  } else {
+    // Get the configs from the config file.
+    std::vector<DeviceConfigHelper> lists;
+    lists = deserializeDeviceConfigFromYaml(loadDeviceConfigsFile);
+    for (unsigned int i = 0; i < lists.size(); ++i) {
+      auto backendKind = getBackendKindFromName(lists[i].kindName_);
+      auto name = lists[i].name_;
+      auto parameters = getBackendParams(lists[i].parameters_.str);
+      auto config = llvm::make_unique<runtime::DeviceConfig>(backendKind, name,
+                                                             parameters);
+      configs.push_back(std::move(config));
+    }
+  }
+  return configs;
 }
 
 void Loader::compile(PlaceholderBindings &bindings) {
@@ -401,11 +478,11 @@ Loader::Loader(int argc, char **argv) {
     caffe2NetWeightFilename_ = modelPathOpt[1];
   }
   M_.reset(new Module);
-  std::vector<std::unique_ptr<runtime::DeviceConfig>> configs;
-  for (unsigned int i = 0; i < numDevices; ++i) {
-    auto config = llvm::make_unique<runtime::DeviceConfig>(ExecutionBackend);
-    configs.push_back(std::move(config));
-  }
+
+  std::vector<std::unique_ptr<runtime::DeviceConfig>> configs =
+      generateDeviceConfigs(loadDeviceConfigsFileOpt, numDevices,
+                            ExecutionBackend);
+
   hostManager_ = llvm::make_unique<runtime::HostManager>(std::move(configs));
   backend_ = createBackend(ExecutionBackend);
   F_ = M_->createFunction(modelPathOpt[0]);


### PR DESCRIPTION
Summary:
Enable Loader to get device configs from a config yaml file. 
Now there are 2 ways in Loader to get the DeviceConfigs: 
1) If the config file is provided, use the file;
2) otherwise, use the "num-devices" which is 1 by default.


Documentation:

Test Plan:
The config file example is :
```
---
- name:     Device1
  kindName: CPU
  parameters: |
    "platformID":"1"
    "deviceID" : "0"
- name:     Device2
  kindName: CPU
  parameters: |
    "platformID":"1"
...
```
The command line: 
`./bin/text-translator -m "en2gr" -cpu -cpu-memory=500000 -load-device-configs="configs.yaml" <<< "I love music ."`

[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
