### PR TITLE
[ci] Switch to docker image with llvm8 installed.

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -44,6 +44,8 @@ hash cmake ninja
 GLOW_DIR=$PWD
 cd ${GLOW_DIR}
 mkdir build && cd build
+CMAKE_ARGS=("-DCMAKE_CXX_COMPILER=/usr/bin/clang++-8")
+CMAKE_ARGS+=("-DCMAKE_C_COMPILER=/usr/bin/clang-8")
 CMAKE_ARGS+=("-DCMAKE_CXX_COMPILER_LAUNCHER=sccache")
 CMAKE_ARGS+=("-DCMAKE_C_COMPILER_LAUNCHER=sccache")
 CMAKE_ARGS+=("-DCMAKE_CXX_FLAGS=-Werror")

--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -7,7 +7,7 @@ set -ex
 export MAX_JOBS=8
 
 install_pocl() {
-   sudo apt-get install -y ocl-icd-opencl-dev clinfo libhwloc-dev libclang-8-dev opencl-headers
+   sudo apt-get install -y ocl-icd-opencl-dev clinfo libhwloc-dev opencl-headers
 
    git clone https://github.com/pocl/pocl.git
    cd pocl && git checkout 368539f1b34ec84f94edd255961a39925b92066d && cd ../
@@ -26,15 +26,7 @@ install_pocl() {
 
 if [ "${CIRCLE_JOB}" != "CHECK_CLANG_FORMAT" ]; then
     # Install Glow dependencies
-    sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main"
-    sudo apt-get update
-    sudo apt-get install -y llvm-8 clang-8 llvm-8-dev libpng-dev libgoogle-glog-dev
-
-    # Redirect clang
-    sudo ln -s /usr/bin/clang-8 /usr/bin/clang
-    sudo ln -s /usr/bin/clang++-8 /usr/bin/clang++
-    sudo ln -s /usr/bin/llvm-symbolizer-8 /usr/bin/llvm-symbolizer
-    sudo ln -s /usr/bin/llvm-config-8 /usr/bin/llvm-config-8.0
+    sudo apt-get install -y libpng-dev libgoogle-glog-dev
 else
     sudo -E apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
     curl -sSL "https://build.travis-ci.org/files/gpg/llvm-toolchain-trusty-7.asc" | sudo -E apt-key add - 
@@ -50,8 +42,6 @@ hash cmake ninja
 GLOW_DIR=$PWD
 cd ${GLOW_DIR}
 mkdir build && cd build
-CMAKE_ARGS=("-DCMAKE_CXX_COMPILER=/usr/bin/clang++-8")
-CMAKE_ARGS+=("-DCMAKE_C_COMPILER=/usr/bin/clang-8")
 CMAKE_ARGS+=("-DCMAKE_CXX_COMPILER_LAUNCHER=sccache")
 CMAKE_ARGS+=("-DCMAKE_C_COMPILER_LAUNCHER=sccache")
 CMAKE_ARGS+=("-DCMAKE_CXX_FLAGS=-Werror")

--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -26,6 +26,8 @@ install_pocl() {
 
 if [ "${CIRCLE_JOB}" != "CHECK_CLANG_FORMAT" ]; then
     # Install Glow dependencies
+    sudo apt-get update
+
     sudo apt-get install -y libpng-dev libgoogle-glog-dev
 else
     sudo -E apt-add-repository -y "ppa:ubuntu-toolchain-r/test"

--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -28,6 +28,12 @@ if [ "${CIRCLE_JOB}" != "CHECK_CLANG_FORMAT" ]; then
     # Install Glow dependencies
     sudo apt-get update
 
+    # Redirect clang
+    sudo ln -s /usr/bin/clang-8 /usr/bin/clang
+    sudo ln -s /usr/bin/clang++-8 /usr/bin/clang++
+    sudo ln -s /usr/bin/llvm-symbolizer-8 /usr/bin/llvm-symbolizer
+    sudo ln -s /usr/bin/llvm-config-8 /usr/bin/llvm-config-8.0
+
     sudo apt-get install -y libpng-dev libgoogle-glog-dev
 else
     sudo -E apt-add-repository -y "ppa:ubuntu-toolchain-r/test"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,23 +71,23 @@ linux_default: &linux_default
 jobs:
   DEBUG:
     environment:
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:230"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:2"
     <<: *linux_default
   ASAN:
     environment:
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:230"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:2"
     <<: *linux_default
   TSAN:
     environment:
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:230"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:2"
     <<: *linux_default
   SHARED:
     environment:
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:230"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:2"
     <<: *linux_default
   RELEASE_WITH_EXPENSIVE_TESTS:
     environment:
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:230"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:2"
     <<: *linux_default
   COVERAGE:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,27 +71,27 @@ linux_default: &linux_default
 jobs:
   DEBUG:
     environment:
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:281"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:283"
     <<: *linux_default
   ASAN:
     environment:
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:281"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:283"
     <<: *linux_default
   TSAN:
     environment:
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:281"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:283"
     <<: *linux_default
   SHARED:
     environment:
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:281"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:283"
     <<: *linux_default
   RELEASE_WITH_EXPENSIVE_TESTS:
     environment:
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:281"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:283"
     <<: *linux_default
   COVERAGE:
     environment:
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang6.0-ubuntu16.04:230"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:283"
     <<: *linux_default
   CHECK_CLANG_FORMAT:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,23 +71,23 @@ linux_default: &linux_default
 jobs:
   DEBUG:
     environment:
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:2"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:281"
     <<: *linux_default
   ASAN:
     environment:
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:2"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:281"
     <<: *linux_default
   TSAN:
     environment:
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:2"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:281"
     <<: *linux_default
   SHARED:
     environment:
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:2"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:281"
     <<: *linux_default
   RELEASE_WITH_EXPENSIVE_TESTS:
     environment:
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:2"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:281"
     <<: *linux_default
   COVERAGE:
     environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,23 +71,23 @@ linux_default: &linux_default
 jobs:
   DEBUG:
     environment:
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang6.0-ubuntu16.04:230"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:230"
     <<: *linux_default
   ASAN:
     environment:
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang6.0-ubuntu16.04:230"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:230"
     <<: *linux_default
   TSAN:
     environment:
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang6.0-ubuntu16.04:230"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:230"
     <<: *linux_default
   SHARED:
     environment:
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang6.0-ubuntu16.04:230"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:230"
     <<: *linux_default
   RELEASE_WITH_EXPENSIVE_TESTS:
     environment:
-      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang6.0-ubuntu16.04:230"
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:230"
     <<: *linux_default
   COVERAGE:
     environment:


### PR DESCRIPTION
Summary:
Avoid installing llvm8 on each run (llvm apt repo is not stable).

Documentation:
n/a

Test Plan:
circle ci run
