### PR TITLE
[New Operator] [part 1] Import ConvolutionChannelwiseQuantizedNode

### DIFF
--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -523,7 +523,7 @@ public:
 
   /// Transpose the tensor \p src into the empty tensor \p dest. Shuffle the
   /// axis based on the list \p shuffle, where each element is the src index.
-  void transpose(Tensor *dest, llvm::ArrayRef<unsigned_t> shuffle) {
+  void transpose(Tensor *dest, llvm::ArrayRef<unsigned_t> shuffle) const {
     genericTranspose(this, dest, shuffle);
   }
 

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -348,6 +348,23 @@ public:
                                   unsigned_t stride, unsigned_t pad,
                                   unsigned_t group);
 
+  /// Creates a ChannelwiseQuantizedConvolutionNode with the given \p name which
+  /// convolves the 4D \p input with \p filter and \bias. \p scales and \p
+  /// offsets provide individual quantization parameters for each filter group
+  /// in \p filter. \p kernels defines the size of the height and width
+  /// dimensions of the filters. \p strides defines the number of steps to take
+  /// in the input for each output cell. \p pads defines how many zero padding
+  /// cells should be added to the input during convolution. \p group defines
+  /// the number of groups the input and output channels should be divided into
+  /// and convolved separately.
+  /// NOTE: ChannelwiseQuantizedConvolutionNode does not yet have an
+  /// implementation so attempting to run a graph containing this node fails.
+  ChannelwiseQuantizedConvolutionNode *createChannelwiseQuantizedConv(
+      llvm::StringRef name, NodeValue input, Constant *filter, Constant *bias,
+      Constant *scales, Constant *offsets, TypeRef outTy,
+      llvm::ArrayRef<unsigned_t> kernels, llvm::ArrayRef<unsigned_t> strides,
+      llvm::ArrayRef<unsigned_t> pads, unsigned_t group);
+
   ConvertToNode *createConvertTo(llvm::StringRef name, NodeValue input,
                                  TypeRef outTy);
 

--- a/include/glow/Importer/Caffe2ModelLoader.h
+++ b/include/glow/Importer/Caffe2ModelLoader.h
@@ -60,8 +60,16 @@ class Caffe2ModelLoader
   /// in the network.
   llvm::Error loadOperator(const caffe2::OperatorDef &op);
 
-  /// Reads a network (weights or structure) from the serialized protocol buffer
-  /// file.
+  /// Load the Conv or ConvRelu operators.
+  llvm::Error loadConv(const caffe2::OperatorDef &op,
+                       ArgumentDictionaryTy &dict);
+
+  /// Load the Int8Conv or Int8ConvRelu operators.
+  llvm::Error loadConvQuantized(const caffe2::OperatorDef &op,
+                                ArgumentDictionaryTy &dict);
+
+  /// Reads a network (weights or structure) from the serialized protocol
+  /// buffer file.
   llvm::Expected<caffe2::NetDef> loadProtoFile(const std::string &filename);
 
   /// loadInputs calls this function for each member in its target arguments.

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -2077,6 +2077,18 @@ Convolution3DNode *Function::createConv3D(PlaceholderBindings &bindings,
                       pads, group);
 }
 
+ChannelwiseQuantizedConvolutionNode *Function::createChannelwiseQuantizedConv(
+    llvm::StringRef name, NodeValue input, Constant *filter, Constant *bias,
+    Constant *scales, Constant *offsets, TypeRef outTy,
+    llvm::ArrayRef<unsigned_t> kernels, llvm::ArrayRef<unsigned_t> strides,
+    llvm::ArrayRef<unsigned_t> pads, unsigned_t group) {
+  assertConvDims(input, filter, bias, kernels, strides, pads, group);
+  auto OT = getParent()->uniqueType(*outTy);
+  return addNode(new ChannelwiseQuantizedConvolutionNode(
+      name, OT, input, filter, bias, scales, offsets, kernels, strides, pads,
+      group, /*Groupwise*/ true));
+}
+
 ConvertToNode *Function::createConvertTo(llvm::StringRef name, NodeValue input,
                                          TypeRef outTy) {
   return addNode(new ConvertToNode(name, outTy, input));

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -57,7 +57,8 @@ namespace {
 /// Creates tensor \p T from the input \p in. Note, there is no data associated
 /// with the Tensor. This method makes sure that the tensor is created with the
 /// proper shape and element type.
-llvm::Error setTensorType(const caffe2::TensorProto &in, Tensor *T) {
+llvm::Expected<LoadWeightResult>
+createAndSetTensorType(const caffe2::TensorProto &in) {
   std::vector<size_t> dim;
   for (auto d : in.dims()) {
     if (d == 0) {
@@ -65,25 +66,28 @@ llvm::Error setTensorType(const caffe2::TensorProto &in, Tensor *T) {
     }
     dim.push_back(d);
   }
+
+  LoadWeightResult result;
+  result.t = llvm::make_unique<Tensor>();
+
   if (in.data_type() == caffe2::TensorProto::FLOAT) {
-    T->reset(ElemKind::FloatTy, dim);
-    return llvm::Error::success();
-  } else if (in.data_type() == caffe2::TensorProto::INT64) {
-    T->reset(ElemKind::Int64ITy, dim);
-    return llvm::Error::success();
+    result.t->reset(ElemKind::FloatTy, dim);
   } else if (in.data_type() == caffe2::TensorProto::INT32) {
-    T->reset(ElemKind::Int32ITy, dim);
-    return llvm::Error::success();
+    result.t->reset(ElemKind::Int32ITy, dim);
+  } else if (in.data_type() == caffe2::TensorProto::INT64) {
+    result.t->reset(ElemKind::Int64ITy, dim);
   } else if (in.data_type() == caffe2::TensorProto::UINT8 ||
              in.data_type() == caffe2::TensorProto::INT8) {
-    T->reset(ElemKind::Int8QTy, dim, 1.0, 0);
-    return llvm::Error::success();
+    result.t->reset(ElemKind::Int8QTy, dim, 1.0, 0);
   } else {
     RETURN_ERR("Only float and index tensors are supported");
   }
+
+  return llvm::Expected<LoadWeightResult>(std::move(result));
 }
 
-llvm::Error setTensorType(const caffe2::QTensorProto &in, Tensor *T) {
+llvm::Expected<LoadWeightResult>
+createAndSetTensorType(const caffe2::QTensorProto &in) {
   std::vector<size_t> dim;
   for (auto d : in.dims()) {
     if (d == 0) {
@@ -95,20 +99,52 @@ llvm::Error setTensorType(const caffe2::QTensorProto &in, Tensor *T) {
   if (in.axis() != 1) {
     RETURN_ERR("axis must be 1");
   }
-  auto scale = in.scales(0);
-  auto bias = in.biases(0);
-  if (in.data_type() == caffe2::TensorProto::INT8) {
-    T->reset(ElemKind::Int8QTy, dim, scale, bias);
-    return llvm::Error::success();
-  } else if (in.data_type() == caffe2::TensorProto::UINT8) {
-    T->reset(ElemKind::Int8QTy, dim, scale, bias - OFFSETSHIFT);
-    return llvm::Error::success();
-  } else if (in.data_type() == caffe2::TensorProto::INT32) {
-    T->reset(ElemKind::Int32QTy, dim, scale, bias);
-    return llvm::Error::success();
+
+  size_t qparams = static_cast<size_t>(in.scales().size());
+
+  RETURN_ERR_IF_NOT(qparams > 0, "No qparams found");
+
+  RETURN_ERR_IF_NOT(in.biases().size() == in.scales().size(),
+                    "Found a different number of biases and scales");
+
+  LoadWeightResult result;
+  result.t = llvm::make_unique<Tensor>();
+
+  float scale = 1.0;
+  int32_t offset = 0;
+
+  // If only one set of qparams is present then use them, otherwise load the
+  // multiple sets of qparams as separate tensors and use the default qparams
+  // for the main tensor result.t.
+  // TODO: should we check is_multiparam?
+  if (qparams == 1) {
+    scale = in.scales(0);
+    offset = in.biases(0);
   } else {
-    RETURN_ERR("Only uint8 and int32 qtensors are supported");
+    result.scales = llvm::make_unique<Tensor>(ElemKind::FloatTy,
+                                              llvm::makeArrayRef({qparams}));
+    result.offsets = llvm::make_unique<Tensor>(ElemKind::Int32ITy,
+                                               llvm::makeArrayRef({qparams}));
+
+    auto scalesH = result.scales->getHandle<float>();
+    auto offsetsH = result.offsets->getHandle<int32_t>();
+    for (size_t i = 0; i < qparams; ++i) {
+      scalesH.raw(i) = in.scales(i);
+      offsetsH.raw(i) = in.biases(i);
+    }
   }
+
+  if (in.data_type() == caffe2::TensorProto::INT8) {
+    result.t->reset(ElemKind::Int8QTy, dim, scale, offset);
+  } else if (in.data_type() == caffe2::TensorProto::UINT8) {
+    result.t->reset(ElemKind::Int8QTy, dim, scale, offset - OFFSETSHIFT);
+  } else if (in.data_type() == caffe2::TensorProto::INT32) {
+    result.t->reset(ElemKind::Int32QTy, dim, scale, offset);
+  } else {
+    RETURN_ERR("Only int8, uint8, and int32 qtensors are supported");
+  }
+
+  return llvm::Expected<LoadWeightResult>(std::move(result));
 }
 } // namespace
 
@@ -238,6 +274,240 @@ bool Caffe2ModelLoader::hasMultidirectionalBroadcast(
   return false;
 }
 
+llvm::Error Caffe2ModelLoader::loadConv(const caffe2::OperatorDef &op,
+                                        ArgumentDictionaryTy &dict) {
+  const std::string &opName = loadOperatorName(op);
+
+  // Load the inputs:
+  std::vector<unsigned_t> strides;
+  ASSIGN_VALUE_OR_RETURN_ERR(strides, getSizeHW(dict, "stride", 1));
+  std::vector<unsigned_t> pads;
+  ASSIGN_VALUE_OR_RETURN_ERR(pads, getPads(dict));
+  std::vector<unsigned_t> kernels;
+  ASSIGN_VALUE_OR_RETURN_ERR(kernels, getSizeHW(dict, "kernel", 0));
+  unsigned_t group = 1;
+  if (dict.count("group")) {
+    ASSIGN_VALUE_OR_RETURN_ERR(group, loadInt(dict["group"]));
+  }
+  std::string order = "NCHW";
+  if (dict.count("order")) {
+    ASSIGN_VALUE_OR_RETURN_ERR(order, loadStr(dict["order"]));
+  }
+  unsigned_t dilation = 1;
+  if (dict.count("dilation")) {
+    ASSIGN_VALUE_OR_RETURN_ERR(dilation, loadInt(dict["dilation"]));
+  }
+
+  NodeValue in;
+  ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
+
+  Constant *w;
+  ASSIGN_VALUE_OR_RETURN_ERR(w, getConstantByName(op.input(1)));
+
+  // Transpose the weights to the right format. Glow expects to read the
+  // weights in the format CRSK.
+  // C - output_depth, R - filter_height, S - filter_width, K - input_depth.
+  // Caffe2 "Conv" op always stores the weight as CKRS.
+  Tensor wT;
+  w->getPayload().transpose(&wT, NCHW2NHWC);
+  w = G_.getParent()->createConstant(w->getName(), std::move(wT));
+
+  // The structure of the conv weights is: CRSK. We take the C, which is the
+  // number of filters. We use this value to calculate the size of the bias
+  // if it is not specified.
+  size_t depth = w->dims()[0];
+
+  // We expect the input to be NHWC.
+  NodeValue finalIn;
+  if (order == "NCHW") {
+    finalIn = G_.createTranspose(opName, in, NCHW2NHWC)->getResult();
+  } else {
+    finalIn = in;
+  }
+
+  TypeRef finalInType = finalIn.getType();
+
+  // Calculate the size and allocate the output buffer.
+  ShapeNHWC idim = ShapeNHWC(finalInType->dims());
+  auto outSz = calculateConvPoolOutputDims(idim.h, idim.w, kernels, strides,
+                                           pads, dilation);
+  std::array<size_t, 4> outDims = {{idim.n, outSz.first, outSz.second, depth}};
+
+  // Try to find a loaded bias constant.
+  Constant *bias = nullptr;
+  if (op.input_size() > 2) {
+    const auto &biasName = op.input(2);
+    bias = getConstantByNameOrNull(biasName);
+  }
+  // Construct the bias constant if one wasn't found.
+  if (!bias) {
+    Tensor b(ElemKind::FloatTy, {depth});
+    b.zero();
+    bias = G_.getParent()->createConstant("conv.bias", std::move(b));
+  }
+
+  TypeRef outTy = G_.getParent()->uniqueType(ElemKind::FloatTy, outDims);
+
+  Node *node = G_.createConv(opName, finalIn, w, bias, outTy, kernels, strides,
+                             pads, group, dilation);
+  if (op.type() == "ConvRelu") {
+    node = G_.createRELU(opName + ".relu", node);
+  }
+  if (order == "NCHW") {
+    // Transpose the output back.
+    node = G_.createTranspose(opName, node, NHWC2NCHW);
+  }
+  RETURN_IF_ERR(addNodeAsOutput(op, node));
+  return llvm::Error::success();
+}
+
+llvm::Error Caffe2ModelLoader::loadConvQuantized(const caffe2::OperatorDef &op,
+                                                 ArgumentDictionaryTy &dict) {
+  const std::string &opName = loadOperatorName(op);
+
+  // Load the inputs:
+  std::vector<unsigned_t> strides;
+  ASSIGN_VALUE_OR_RETURN_ERR(strides, getSizeHW(dict, "stride", 1));
+  std::vector<unsigned_t> pads;
+  ASSIGN_VALUE_OR_RETURN_ERR(pads, getPads(dict));
+  std::vector<unsigned_t> kernels;
+  ASSIGN_VALUE_OR_RETURN_ERR(kernels, getSizeHW(dict, "kernel", 0));
+  unsigned_t group = 1;
+  if (dict.count("group")) {
+    ASSIGN_VALUE_OR_RETURN_ERR(group, loadInt(dict["group"]));
+  }
+  std::string order = "NCHW";
+  if (dict.count("order")) {
+    ASSIGN_VALUE_OR_RETURN_ERR(order, loadStr(dict["order"]));
+  }
+  bool quantizeGroupwise = false;
+  if (dict.count("quantize_groupwise")) {
+    ASSIGN_VALUE_OR_RETURN_ERR(quantizeGroupwise,
+                               loadInt(dict["quantize_groupwise"]));
+  }
+  unsigned_t dilation = 1;
+  if (dict.count("dilation")) {
+    ASSIGN_VALUE_OR_RETURN_ERR(dilation, loadInt(dict["dilation"]));
+  }
+
+  // Group quantization only applies if there is more than one group.
+  quantizeGroupwise &= group > 1;
+
+  if (quantizeGroupwise && dilation > 1) {
+    RETURN_ERR("Dilation not supported for group quantized convolution");
+  }
+
+  NodeValue in;
+  ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
+
+  Constant *w;
+  ASSIGN_VALUE_OR_RETURN_ERR(w, getConstantByName(op.input(1)));
+
+  // Transpose the weights to the right format. Glow expects to read the
+  // weights in the format CRSK.
+  // C - output_depth, R - filter_height, S - filter_width, K - input_depth.
+  // For Caffe2 "Int8Conv" and "Int8ConvRelu", the weights always follows the
+  // "order" arg.
+  if (order != "NHWC") {
+    Tensor wT;
+    w->getPayload().transpose(&wT, NCHW2NHWC);
+    w = G_.getParent()->createConstant(w->getName(), std::move(wT));
+  }
+
+  // The structure of the conv weights is: CRSK. We take the C, which is the
+  // number of filters. We use this value to calculate the size of the bias
+  // if it is not specified.
+  size_t depth = w->dims()[0];
+
+  // We expect the input to be NHWC.
+  NodeValue finalIn;
+  if (order == "NCHW") {
+    finalIn = G_.createTranspose(opName, in, NCHW2NHWC)->getResult();
+  } else {
+    finalIn = in;
+  }
+
+  TypeRef finalInType = finalIn.getType();
+
+  // Calculate the size and allocate the output buffer.
+  ShapeNHWC idim = ShapeNHWC(finalInType->dims());
+  auto outSz = calculateConvPoolOutputDims(idim.h, idim.w, kernels, strides,
+                                           pads, dilation);
+  std::array<size_t, 4> outDims = {{idim.n, outSz.first, outSz.second, depth}};
+
+  TypeRef outTy;
+
+  RETURN_ERR_IF_NOT(dict.count("Y_zero_point"),
+                    "missing zero point for quantized output type");
+  RETURN_ERR_IF_NOT(dict.count("Y_scale"),
+                    "missing Y_scale for quantized output type");
+
+  // Try to find a loaded bias constant.
+  Constant *bias = nullptr;
+  if (op.input_size() > 2) {
+    const auto &biasName = op.input(2);
+    bias = getConstantByNameOrNull(biasName);
+  }
+  // Construct the bias constant if one wasn't found.
+  if (!bias) {
+    Tensor b(ElemKind::Int32QTy, {depth}, 1.0, 0);
+    b.zero();
+    bias = G_.getParent()->createConstant("conv.bias", std::move(b));
+  }
+
+  RETURN_ERR_IF_NOT(bias->getPayload().size() == depth,
+                    "Loaded bias tensor of incorrect size");
+
+  // Construct output type
+  float scale;
+  ASSIGN_VALUE_OR_RETURN_ERR(scale, loadFloat(dict["Y_scale"]));
+  int32_t offset;
+  ASSIGN_VALUE_OR_RETURN_ERR(offset, loadInt(dict["Y_zero_point"]));
+  outTy = G_.getParent()->uniqueType(ElemKind::Int8QTy, outDims, scale,
+                                     offset - OFFSETSHIFT);
+
+  Node *node;
+
+  if (quantizeGroupwise) {
+    auto wScalesName = strFormat("%s_loaded_scales", op.input(1).c_str());
+    auto wOffsetsName = strFormat("%s_loaded_offsets", op.input(1).c_str());
+    Constant *wScales;
+    Constant *wOffsets;
+    ASSIGN_VALUE_OR_RETURN_ERR(wScales, getConstantByName(wScalesName));
+    ASSIGN_VALUE_OR_RETURN_ERR(wOffsets, getConstantByName(wOffsetsName));
+
+    node = G_.createChannelwiseQuantizedConv(opName, finalIn, w, bias, wScales,
+                                             wOffsets, outTy, kernels, strides,
+                                             pads, group);
+  } else {
+    // If the bias isn't quantized for a non group quantized conv, quantize it.
+    const Tensor &biasTensor = bias->getPayload();
+    if (biasTensor.getElementType() == ElemKind::FloatTy) {
+      TensorQuantizationParams tqp;
+      // Bias quantization params chosen to match the scale of the output
+      // without requiring shifting.
+      tqp.offset = 0;
+      tqp.scale =
+          finalInType->getScale() * w->getPayload().getType().getScale();
+
+      Tensor quantizedBiasTensor =
+          quantization::quantizeTensor(biasTensor, tqp, ElemKind::Int32QTy);
+
+      bias = G_.getParent()->createConstant("conv.bias", quantizedBiasTensor);
+    }
+
+    node = G_.createConv(opName, finalIn, w, bias, outTy, kernels, strides,
+                         pads, group, dilation);
+  }
+
+  if (order == "NCHW") {
+    // Transpose the output back.
+    node = G_.createTranspose(opName, node, NHWC2NCHW);
+  }
+  RETURN_IF_ERR(addNodeAsOutput(op, node));
+  return llvm::Error::success();
+}
+
 llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
   ArgumentDictionaryTy dict = loadArgumentMap(op);
   const std::string &typeName = op.type();
@@ -251,136 +521,12 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
   }
   const std::string &opName = loadOperatorName(op);
 
-  if (typeName == "Conv" || typeName == "ConvRelu" || typeName == "Int8Conv" ||
-      typeName == "Int8ConvRelu") {
-    // Load the inputs:
-    std::vector<unsigned_t> strides;
-    ASSIGN_VALUE_OR_RETURN_ERR(strides, getSizeHW(dict, "stride", 1));
-    std::vector<unsigned_t> pads;
-    ASSIGN_VALUE_OR_RETURN_ERR(pads, getPads(dict));
-    std::vector<unsigned_t> kernels;
-    ASSIGN_VALUE_OR_RETURN_ERR(kernels, getSizeHW(dict, "kernel", 0));
-    unsigned_t group = 1;
-    if (dict.count("group")) {
-      ASSIGN_VALUE_OR_RETURN_ERR(group, loadInt(dict["group"]));
-    }
-    std::string order = "NCHW";
-    if (dict.count("order")) {
-      ASSIGN_VALUE_OR_RETURN_ERR(order, loadStr(dict["order"]));
-    }
+  if (typeName == "Conv" || typeName == "ConvRelu") {
+    return loadConv(op, dict);
+  }
 
-    unsigned_t dilation = 1;
-    if (dict.count("dilation")) {
-      ASSIGN_VALUE_OR_RETURN_ERR(dilation, loadInt(dict["dilation"]));
-    }
-
-    NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
-
-    Constant *W;
-    ASSIGN_VALUE_OR_RETURN_ERR(W, getConstantByName(op.input(1)));
-
-    // Transpose the weights to the right format. Glow expects to read the
-    // weights in the format CRSK.
-    // C - output_depth, R - filter_height, S - filter_width, K - input_depth.
-    // Caffe2 "Conv" op always stores the weight as CKRS, while for "Int8Conv",
-    // and "Int8ConvRelu", the weights always follows the "order" arg.
-    if (!((typeName != "ConvRelu" && typeName != "Conv") && order == "NHWC")) {
-      Tensor tmp;
-      W->getPayloadMutable().transpose(&tmp, NCHW2NHWC);
-      W = G_.getParent()->createConstant(W->getName(), tmp);
-    }
-
-    // The structure of the conv weigts is: NHWC. We take the C, which is the
-    // number of filters. We use this value to calculate the size of the bias
-    // if it is not specified.
-    size_t depth = W->dims()[0];
-
-    // We expect the input to be NHWC.
-    NodeValue finalIn;
-    if (order == "NCHW") {
-      finalIn = G_.createTranspose(opName, in, NCHW2NHWC)->getResult();
-    } else {
-      finalIn = in;
-    }
-
-    TypeRef finalInType = finalIn.getType();
-
-    // Calculate the size and allocate the output buffer.
-    ShapeNHWC idim = ShapeNHWC(finalInType->dims());
-    auto outSz = calculateConvPoolOutputDims(idim.h, idim.w, kernels, strides,
-                                             pads, dilation);
-    std::array<size_t, 4> outDims = {
-        {idim.n, outSz.first, outSz.second, depth}};
-
-    TypeRef outTy;
-    Constant *filter = W;
-    Constant *bias;
-    if (typeName == "Conv" || typeName == "ConvRelu") {
-      // Construct the Bias field.
-      Constant *biasConstant = nullptr;
-
-      // Check if we have a serialized bias.
-      if (op.input_size() > 2) {
-        const auto &biasName = op.input(2);
-        biasConstant = getConstantByNameOrNull(biasName);
-      }
-
-      // If no serialized bias was found then create a zero bias.
-      if (!biasConstant) {
-        Tensor biasTensor(ElemKind::FloatTy, {depth});
-        biasTensor.zero();
-        biasConstant = G_.getParent()->createConstant("conv.bias", biasTensor);
-      }
-
-      outTy = G_.getParent()->uniqueType(ElemKind::FloatTy, outDims);
-      bias = biasConstant;
-    } else {
-      RETURN_ERR_IF_NOT(dict.count("Y_zero_point"),
-                        "missing zero point for quantized output type");
-      RETURN_ERR_IF_NOT(dict.count("Y_scale"),
-                        "missing Y_scale for quantized output type");
-      // Construct the Bias field.
-      Constant *biasConstant = nullptr;
-
-      // Check if we have a serialized bias vector.
-      if (op.input_size() > 2) {
-        const auto &biasName = op.input(2);
-        biasConstant = getConstantByNameOrNull(biasName);
-      }
-
-      // If no serialized bias was found then create a zero bias.
-      if (!biasConstant) {
-        Tensor biasTensor(ElemKind::Int32QTy, {depth}, 1.0, 0);
-        biasTensor.zero();
-        biasConstant = G_.getParent()->createConstant(
-            ElemKind::Int32QTy, biasTensor.dims(),
-            biasTensor.getType().getScale(), biasTensor.getType().getOffset(),
-            "conv.bias");
-        biasConstant->assign(&biasTensor);
-      }
-
-      bias = biasConstant;
-
-      float scale;
-      ASSIGN_VALUE_OR_RETURN_ERR(scale, loadFloat(dict["Y_scale"]));
-      int32_t offset;
-      ASSIGN_VALUE_OR_RETURN_ERR(offset, loadInt(dict["Y_zero_point"]));
-      outTy = G_.getParent()->uniqueType(ElemKind::Int8QTy, outDims, scale,
-                                         offset - OFFSETSHIFT);
-    }
-
-    Node *node = G_.createConv(opName, finalIn, filter, bias, outTy, kernels,
-                               strides, pads, group, dilation);
-    if (typeName == "ConvRelu") {
-      node = G_.createRELU(opName + ".relu", node);
-    }
-    if (order == "NCHW") {
-      // Transpose the output back.
-      node = G_.createTranspose(opName, node, NHWC2NCHW);
-    }
-    RETURN_IF_ERR(addNodeAsOutput(op, node));
-    return llvm::Error::success();
+  if (typeName == "Int8Conv" || typeName == "Int8ConvRelu") {
+    return loadConvQuantized(op, dict);
   }
 
   if (typeName == "Int8SumRelu") {
@@ -1085,18 +1231,54 @@ Caffe2ModelLoader::loadInputsWithTensorProtoType(const caffe2::NetDef &net,
     return llvm::Error::success();
   }
 
-  if (loadInputsAsPlaceholders) {
-    Tensor T;
-    RETURN_IF_ERR(setTensorType(in, &T));
+  LoadWeightResult loadRes;
+  if (auto resOrErr = createAndSetTensorType(in)) {
+    loadRes = std::move(*resOrErr);
+  } else {
+    return resOrErr.takeError();
+  }
 
+  bool multiQParamsLoaded = loadRes.scales || loadRes.offsets;
+  RETURN_ERR_IF_NOT(
+      (!multiQParamsLoaded || (loadRes.scales && loadRes.offsets)),
+      "For tensors with separate qparams, both scales and offsets must be "
+      "loaded");
+
+  if (loadInputsAsPlaceholders) {
     Placeholder *placeholder;
     ASSIGN_VALUE_OR_RETURN_ERR(
-        placeholder, createAndRegisterPlaceholder(in.name(), &T.getType()));
+        placeholder,
+        createAndRegisterPlaceholder(in.name(), &loadRes.t->getType()));
+
     inputVarsByName_.try_emplace(in.name(), placeholder);
+
+    if (multiQParamsLoaded) {
+      auto offsetsName = strFormat("%s_loaded_offsets", in.name().c_str());
+      auto scalesName = strFormat("%s_loaded_scales", in.name().c_str());
+      Placeholder *offsetsPlaceholder;
+      Placeholder *scalesPlaceholder;
+
+      ASSIGN_VALUE_OR_RETURN_ERR(offsetsPlaceholder,
+                                 createAndRegisterPlaceholder(
+                                     offsetsName, &loadRes.offsets->getType()));
+      inputVarsByName_.try_emplace(offsetsName, offsetsPlaceholder);
+
+      ASSIGN_VALUE_OR_RETURN_ERR(
+          scalesPlaceholder,
+          createAndRegisterPlaceholder(scalesName, &loadRes.scales->getType()));
+      inputVarsByName_.try_emplace(scalesName, scalesPlaceholder);
+    }
   } else {
-    Tensor T;
-    RETURN_IF_ERR(setTensorType(in, &T));
-    RETURN_IF_ERR(createAndRegisterConstant(in.name(), std::move(T)));
+    RETURN_IF_ERR(createAndRegisterConstant(in.name(), std::move(*loadRes.t)));
+
+    if (multiQParamsLoaded) {
+      auto offsetsName = strFormat("%s_loaded_offsets", in.name().c_str());
+      auto scalesName = strFormat("%s_loaded_scales", in.name().c_str());
+      RETURN_IF_ERR(
+          createAndRegisterConstant(offsetsName, std::move(*loadRes.offsets)));
+      RETURN_IF_ERR(
+          createAndRegisterConstant(scalesName, std::move(*loadRes.scales)));
+    }
   }
   return llvm::Error::success();
 }
@@ -1323,9 +1505,11 @@ llvm::Error Caffe2ModelLoader::loadWeight(const caffe2::OperatorDef &op) {
           TH.raw(i++) = num;
         }
       }
-      RETURN_ERR_IF_NOT(i == T.size(),
-                        "The number of serialized values does not "
-                        "match the size of the tensor.");
+      RETURN_ERR_IF_NOT(
+          i == T.size(),
+          strFormat("The number of serialized values (%li) does not "
+                    "match the size of the tensor (%li).",
+                    i, T.size()));
 
       RETURN_IF_ERR(createAndRegisterConstant(o, std::move(T)));
     }

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -573,7 +573,7 @@ llvm::Error ONNXModelLoader::loadConv(const ONNX_NAMESPACE::NodeProto &op,
   TransposeNode *filterTransposeNode =
       G_.createTranspose(opName, filterValue, NCHW2NHWC);
 
-  // The structure of the conv weigts is: NHWC. We take the C, which is the
+  // The structure of the conv weights is: CRSK. We take the C, which is the
   // number of filters. We use this value to calculate the size of the bias
   // if it is not specified.
   const NodeValue filterTransposedValue = filterTransposeNode->getResult();

--- a/tests/models/caffe2Models/conv_group_quantized_init_net.pbtxt
+++ b/tests/models/caffe2Models/conv_group_quantized_init_net.pbtxt
@@ -1,0 +1,67 @@
+name: "init"
+op {
+  output: "conv_b"
+  type: "GivenTensorFill"
+  arg {
+    name: "shape"
+    ints: 4
+  }
+  arg {
+    name: "values"
+    floats: 7.0
+    floats: 7.0
+    floats: 7.0
+    floats: 7.0
+  }
+}
+op {
+  output: "conv_w"
+  type: "Int8GivenTensorFill"
+  arg {
+    name: "shape"
+    ints: 4
+    ints: 1
+    ints: 1
+    ints: 2
+  }
+  arg {
+    name: "values"
+    s: "\x80\x81\x80\x81\x80\x81\x80\x81"
+  }
+  arg {
+    name: "Y_scale"
+    f: 1.0
+  }
+  arg {
+    name: "Y_zero_point"
+    i: 0
+  }
+}
+op {
+  output: "conv_w_loaded_scales"
+  type: "GivenTensorFill"
+  arg {
+    name: "shape"
+    ints: 2
+  }
+  arg {
+    name: "values"
+    floats: 6.0
+    floats: 6.0
+  }
+}
+op {
+  output: "conv_w_loaded_offsets"
+  type: "GivenTensorIntFill"
+  arg {
+    name: "shape"
+    ints: 2
+  }
+  arg {
+    name: "values"
+    ints: 5
+    ints: 5
+  }
+}
+
+

--- a/tests/models/caffe2Models/conv_group_quantized_pred_net.pbtxt
+++ b/tests/models/caffe2Models/conv_group_quantized_pred_net.pbtxt
@@ -1,0 +1,41 @@
+name: "conv_group_quantized_test"
+op {
+  input: "input"
+  input: "conv_w"
+  input: "conv_b"
+  output: "conv_out"
+  type: "Int8Conv"
+  arg {
+    name: "kernel"
+    i: 1
+  }
+  arg {
+    name: "group"
+    i: 2
+  }
+  arg {
+    name: "stride"
+    i: 1
+  }
+  arg {
+    name: "pad"
+    i: 1
+  }
+  arg {
+    name: "order"
+    s: "NHWC"
+  }
+  arg {
+    name: "Y_scale"
+    f: 3.14
+  }
+  arg {
+    name: "Y_zero_point"
+    i: 5
+  }
+  arg {
+    name: "quantize_groupwise"
+    i: 1
+  }
+}
+external_output: "conv_out"

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -88,6 +88,24 @@ int main(int argc, char **argv) {
                     "Bias tensors, as well as provided Kernels, Strides, Pads, "
                     "Group and Dilation.");
 
+  BB.newNode("ChannelwiseQuantizedConvolution")
+      .addInput("Input")
+      .addInput("Filter")
+      .addInput("Bias")
+      .addInput("Scales")
+      .addInput("Offsets")
+      .addMember(MemberType::VectorUnsigned, "Kernels")
+      .addMember(MemberType::VectorUnsigned, "Strides")
+      .addMember(MemberType::VectorUnsigned, "Pads")
+      .addMember(MemberType::Unsigned, "Group")
+      .addMember(MemberType::Boolean, "Groupwise")
+      .addResultFromCtorArg()
+      .setDocstring("Performs 2D Convolution using a given Input, Filter, and "
+                    "Bias tensors, as well as provided Kernels, Strides, Pads, "
+                    "and Group. Quantization parameters are provided by Scales "
+                    "and Offsets. If Groupwise is true then the quantization "
+                    "is per-group otherwise it is per-channel.");
+
   BB.newNode("Convolution3D")
       .addInput("Input")
       .addInput("Filter")


### PR DESCRIPTION
Summary:
* Import onnxTensors with multiple quantization parameters. If an onnxTensor has more than one quantization parameter, create separate `Constants` for the scales and offsets so that nodes that consume these can access them.
* Create a ConvolutionChannelwiseQuantizedNode which is a quantized convolution node that has independent quantization parameters for each filter or group of filters. These parameters are stored in separate scales and offsets tensors similar to `RowwiseQuantizedFullyConnectedNode`
* This PR only handles importing the `ConvolutionChannelwiseQuantizedNode` and it's weights and qparams, implementation of this op will be done in a follow up PR. I'm not sure if we will have an instruction for this node or simply default to lowering it to multiple quantized convolutions.

Documentation:
* Doyxgen

Test Plan:
Add operator test