### PR TITLE
[build] Fix dynamic backend support on Linux

### DIFF
--- a/cmake/modules/GlowDefaults.cmake
+++ b/cmake/modules/GlowDefaults.cmake
@@ -66,11 +66,6 @@ function(make_whole_archive DST SRC)
       # In MSVC, we will add whole archive in default.
       target_link_libraries(
           ${DST} INTERFACE -WHOLEARCHIVE:$<TARGET_FILE:${SRC}>)
-    else()
-      # Assume everything else is like gcc
-      target_link_libraries(${DST} INTERFACE
-        "-Wl,--whole-archive $<TARGET_FILE:${SRC}> -Wl,--no-whole-archive")
-      set_target_properties(${DST} PROPERTIES LINK_FLAGS "-Wl,--exclude-libs,ALL")
     endif()
   else()
     target_link_libraries(${DST} INTERFACE ${SRC})


### PR DESCRIPTION
This complicated `if` in CMake broke build on my Linux machine, and it only showed up after Bert's PR #2891. The problem was that I could no longer include CPUBackend into a unit test as a direct dependency.

I tested that I can now include CPUBackend into unit test, building with both clang and gcc on Linux.