### PR TITLE
Disable buggy opt foldChannelShuffle

### DIFF
--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -2549,6 +2549,9 @@ getChannelShuffleParams(const ReshapeNode &node) {
 
 // Fold Reshape->Transpose->Reshape into ChannelShuffle when applicable.
 static void foldChannelShuffle(Function *F) {
+  // FIXME: This optimization doesn't check its applicability carefully enough
+  // and kicks in when it shouldn't.  See GraphOptzTest.NoFoldChannelShuffle.
+  return;
 
   auto &nodes = F->getNodes();
   for (auto &node : nodes) {


### PR DESCRIPTION
Summary:
This optimization to replace reshape->transpose->reshape with
ChannelShuffle breaks patterns where the output type isn't the same as the
input type.  I think the pattern check is not strict enough; it seems like it
needs to check the output type as well as which indices are swizzled by the
transpose to make sure it's doing the right thing.

GitHub Test Plan: New test that demonstrates fold() -- which calls
foldChannelShuffle -- breaking (if it is reenabled).

Differential Revision: D15508242

