### PR TITLE
Auto assign placeholders for inputs without weights.

### DIFF
--- a/include/glow/Importer/ONNXModelLoader.h
+++ b/include/glow/Importer/ONNXModelLoader.h
@@ -187,6 +187,7 @@ public:
   /// serialized in \p modelDescFilename and populates the network into \p F.
   /// The types in \p types match the list of names \p tensorNames and used as
   /// inputs to the network.
+  /// If \p names and \p types are empty loader fills inputs automatically.
   /// If \p errPtr is not null then if an error occurs it will get assigned
   /// there otherwise if an error occurs it will abort.
   ONNXModelLoader(const std::string &modelDescFilename,

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -1202,6 +1202,12 @@ ONNXModelLoader::ONNXModelLoader(const std::string &modelDescFilename,
     RETURN_IF_ERR(checkInputs(graphDef, tensorNames, types));
 
     RETURN_IF_ERR(loadInitializers(graphDef));
+
+    if (tensorNames.empty() && types.empty()) {
+      // Detect inputs without initializers and create placeholders.
+      RETURN_IF_ERR(loadInputs(graphDef, /* loadInputsAsPlaceholders */ true));
+    }
+
     RETURN_IF_ERR(loadNetwork(graphDef));
 
     RETURN_IF_ERR(setOutputNodes(graphDef));

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -1642,3 +1642,18 @@ TEST(onnx, batchNormPR2304) {
       llvm::dyn_cast<BatchNormalizationNode>(trNode->getInput().getNode());
   EXPECT_NE(nullptr, bnNode);
 }
+
+/// Test constructor for auto loading inputs case.
+TEST(onnx, autoLoadInputs) {
+  ExecutionEngine EE;
+  auto &mod = EE.getModule();
+  std::string netFilename(GLOW_DATA_PATH
+                          "tests/models/onnxModels/batchNormPR2304.onnxtxt");
+  auto *F = mod.createFunction("main");
+  Tensor inputTensor(ElemKind::FloatTy, {1, 2, 10, 10});
+  llvm::StringRef inputName = "input";
+  ONNXModelLoader onnxLD(netFilename, {}, {}, *F);
+  auto inputs = onnxLD.getInputVarsMapping();
+  EXPECT_EQ(inputs.size(), 1);
+  EXPECT_TRUE(inputTensor.getType().isEqual(inputs[inputName]->getType()));
+}


### PR DESCRIPTION
Summary:
ONNX Loader can automatically create placeholders for the existed inputs without weights.
Usually it's only one input. If caller provides names and types for inputs code would work as before,
otherwise algorithm in constructor will create non-trainable placeholders for such inputs.

Differential Revision: D15538665

