### PR TITLE
[habana] Fuse FC and Relu ops for habana backend.

### DIFF
--- a/lib/Backends/Habana/Habana.cpp
+++ b/lib/Backends/Habana/Habana.cpp
@@ -799,7 +799,7 @@ HabanaBackend::compile(Function *F, const BackendOptions &opts) const {
 
       if (NI->getInput().getType()->isQuantizedType()) {
         auto params = llvm::make_unique<synFCParams>();
-        params->activation.reluEnable = false;
+        params->activation.reluEnable = NI->getDoRelu();
         chk(synFullyConnected(
             tensors[NI->getInput()].get(), tensors[NI->getWeights()].get(),
             tensors[NI->getBias()].get(), tensors[NI].get(), *params, ""));
@@ -810,7 +810,7 @@ HabanaBackend::compile(Function *F, const BackendOptions &opts) const {
         inputs.push_back(tensors[NI->getWeights()].get());
         inputs.push_back(tensors[NI->getBias()].get());
 
-        auto params = makeFCFPParams(false);
+        auto params = makeFCFPParams(NI->getDoRelu());
         chk(synCreateGenericNode(
             inputs.data(), &tensors[NI].get(), 3, 1, params.get(),
             getKernelName("fully_connected", NI->getResult().getElementType())
@@ -1475,7 +1475,24 @@ bool fuseConvRelu(Function *F, HabanaConvolutionNode &conv, ReluNode &relu) {
   return true;
 }
 
-/// Fuse any sum of Conv + Node into Node -> FusedConvAdd.
+/// Fuse fully connected followed by relu into a single FusedFCRelu node.
+bool fuseFCRelu(Function *F, HabanaFullyConnectedNode &fc, ReluNode &relu) {
+  // fully connected should have only a single use.
+  if (!fc.getResult().hasOneUse()) {
+    return false;
+  }
+
+  auto fusedOpName = fc.getName().str() + "." + relu.getName().str() + ".fused";
+  auto *fusedNode = new HabanaFullyConnectedNode(
+      fusedOpName, relu.getResult().getType(), fc.getInput(), fc.getWeights(),
+      fc.getBias(), /*doRelu=*/true);
+  F->addNode(fusedNode);
+
+  relu.getResult().replaceAllUsesOfWith(fusedNode);
+  return true;
+}
+
+/// Fuse any sum of Conv + Nodse into Node -> FusedConvAdd.
 bool fuseConvAdd(Function *F, AddNode &add) {
   // Perform this transformation:
   // Conv --> Add
@@ -1633,10 +1650,20 @@ bool HabanaBackend::transformPostLowering(
           F->createTranspose("weight_transpose", FC->getWeights(), {1, 0});
       auto *NF = F->addNode(
           new HabanaFullyConnectedNode(FC->getName(), FC->getResult().getType(),
-                                       FC->getInput(), weights, FC->getBias()));
+                                       FC->getInput(), weights, FC->getBias(),
+                                       /*doRelu=*/false));
       FC->getResult().replaceAllUsesOfWith(NF);
       changed = true;
       continue;
+    }
+
+    // Fuse fully connected followed by relu.
+    if (auto *relu = llvm::dyn_cast<ReluNode>(&node)) {
+      if (auto *fc = llvm::dyn_cast<HabanaFullyConnectedNode>(
+              relu->getInput().getNode())) {
+        changed |= fuseFCRelu(F, *fc, *relu);
+        continue;
+      }
     }
 
     // Replace Conv with HabanaConv for better control over code generation.

--- a/tools/ClassGen/Backends/Habana/HabanaSpecificInstrs.h
+++ b/tools/ClassGen/Backends/Habana/HabanaSpecificInstrs.h
@@ -23,6 +23,7 @@ BB.newBackendSpecificInstr("HabanaFullyConnected")
     .addOperand("Src", OperandKind::In)
     .addOperand("Weights", OperandKind::In)
     .addOperand("Bias", OperandKind::In)
+    .addMember(MemberType::Boolean, "DoRelu")
     .autoIRGen()
     .autoVerify(VerifyKind::SameElementType, {"Dest", "Src", "Weights"});
 

--- a/tools/ClassGen/Backends/Habana/HabanaSpecificNodes.h
+++ b/tools/ClassGen/Backends/Habana/HabanaSpecificNodes.h
@@ -21,6 +21,7 @@ BB.newNode("HabanaFullyConnected")
     .addInput("Input")
     .addInput("Weights")
     .addInput("Bias")
+    .addMember(MemberType::Boolean, "DoRelu")
     .addResultFromCtorArg()
     .setDocstring(
         "This is a Habana-specific FC that combines weights and bias.");


### PR DESCRIPTION
Summary:
Porting changes to open source Habana backend (+ fixing params in quantized fc).
Fuse FC and Relu.
Handle quantized fc properly when it's followed by ReLU.

cc: @sergeigofman
Documentation:
n/a

Test Plan:
Internal CI/Local run
