### PR TITLE
[tracing] Add support for Complete events

### DIFF
--- a/lib/Backend/Backend.cpp
+++ b/lib/Backend/Backend.cpp
@@ -114,7 +114,6 @@ void Backend::autoInstrument(TraceInfo &traceInfo, IRFunction *IR) const {
 
   traceInfo.enabled = true;
   traceInfo.autoInstrumented = true;
-  std::string lastName = "";
   size_t index = 0;
 
   // For each instruction, insert a TraceEventInst to record the timestamp,
@@ -130,14 +129,9 @@ void Backend::autoInstrument(TraceInfo &traceInfo, IRFunction *IR) const {
     }
 
     auto instName = I.getName();
-    // End the previous event.
-    if (lastName != "") {
-      traceInfo.add(backingPH, index, lastName, "E");
-    }
 
     // Start a new event.
-    traceInfo.add(backingPH, index, instName, "B");
-    lastName = instName;
+    traceInfo.add(backingPH, index, index + 1, instName);
 
     it = instructions.insert(it, new TraceEventInst(instName.str() + "_trace",
                                                     backingWeight, index++));
@@ -146,9 +140,6 @@ void Backend::autoInstrument(TraceInfo &traceInfo, IRFunction *IR) const {
     it++;
     it++;
   }
-
-  // Add one more for the end of the function.
-  traceInfo.add(backingPH, index, lastName, "E");
 
   IR->pushInstr(new TraceEventInst("end_trace", backingWeight, index));
 }

--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -1731,7 +1731,7 @@ void libjit_write_timestamp(uint64_t *tensor, size_t offset) {
   // Issue #2397 covers migrating this to a libc approach but if you have issues
   // with a lack of C++ symbols at runtime check there first.
   uint64_t ts = std::chrono::duration_cast<std::chrono::microseconds>(
-                    std::chrono::steady_clock::now().time_since_epoch())
+                    std::chrono::system_clock::now().time_since_epoch())
                     .count();
   memcpy(tensor + offset, &ts, sizeof(uint64_t));
 }

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -2802,7 +2802,7 @@ void BoundInterpreterFunction::fwdTraceEventInst(const TraceEventInst *I) {
   auto IH = T->getHandle<int64_t>();
   size_t index = I->getIndex();
   IH.raw(index) = std::chrono::duration_cast<std::chrono::microseconds>(
-                      std::chrono::steady_clock::now().time_since_epoch())
+                      std::chrono::system_clock::now().time_since_epoch())
                       .count();
 }
 

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -112,8 +112,8 @@ onnxStatus Graph::setIOAndRun(uint32_t inputsCount,
     traceContext = ctx->getTraceContext();
   }
   TRACE_EVENT_SCOPE(traceContext, "Onnxifi::setIOAndRun");
+  TRACE_EVENT_SCOPE_NAMED(traceContext, "adjustInputs", aiEvent);
 
-  TRACE_EVENT_BEGIN(traceContext, "adjustInputs");
   size_t totalInputOnnxTensorSize = 0;
   size_t totalInputGlowTensorSize = 0;
   // Create tensors for input placeholders
@@ -171,8 +171,8 @@ onnxStatus Graph::setIOAndRun(uint32_t inputsCount,
                               float(totalInputOnnxTensorSize)
                        << " X)";
 
-  TRACE_EVENT_END(traceContext, "adjustInputs");
-  TRACE_EVENT_BEGIN(traceContext, "setOnnxifiOutputs");
+  TRACE_EVENT_SCOPE_END_NAMED(aiEvent);
+  TRACE_EVENT_SCOPE_NAMED(traceContext, "setOnnxifiOutputs", soEvent);
 
   // Create tensors for output placeholders
   for (unsigned i = 0; i < outputsCount; ++i) {
@@ -207,8 +207,8 @@ onnxStatus Graph::setIOAndRun(uint32_t inputsCount,
     Tensor outputTensor(outOnnxBuffer, outPhPtr->getType());
     ctx->getPlaceholderBindings()->insert(outPhPtr, std::move(outputTensor));
   }
+  TRACE_EVENT_SCOPE_END_NAMED(soEvent);
 
-  TRACE_EVENT_END(traceContext, "setOnnxifiOutputs");
   return run(std::move(ctx), outputEvent, traceEvents);
 }
 

--- a/lib/Onnxifi/HostManagerOnnxifi.cpp
+++ b/lib/Onnxifi/HostManagerOnnxifi.cpp
@@ -109,17 +109,18 @@ onnxStatus HostManagerGraph::run(std::unique_ptr<ExecutionContext> ctx,
       [outputEvent, traceEvents](runtime::RunIdentifierTy runId,
                                  llvm::Error err,
                                  std::unique_ptr<ExecutionContext> ctx) {
-        TRACE_EVENT_BEGIN(ctx->getTraceContext(), "Onnxifi::callback");
+        TRACE_EVENT_SCOPE(ctx->getTraceContext(), "Onnxifi::callback");
         // If an Error occurred then log it in errToBool and signal the output
         // event.
         if (errToBool(std::move(err))) {
           outputEvent->signal();
-          TRACE_EVENT_END(ctx->getTraceContext(), "Onnxifi::callback");
           return;
         }
 
-        // End the trace event before we convert TraceEvents to the ONNX format.
-        TRACE_EVENT_END(ctx->getTraceContext(), "Onnxifi::callback");
+        // End the current trace event before we convert TraceEvents to the ONNX
+        // format.
+        TRACE_EVENT_SCOPE_END();
+
         if (auto *traceContext = ctx->getTraceContext()) {
           setTraceEvents(traceEvents, traceContext);
 

--- a/lib/Runtime/Executor/ThreadPoolExecutor.cpp
+++ b/lib/Runtime/Executor/ThreadPoolExecutor.cpp
@@ -339,7 +339,8 @@ void ThreadPoolExecutor::handleDeviceManagerResult(
   DCHECK_NOTNULL(executionState.get());
 
   TraceContext *traceContext = ctx->getTraceContext();
-  TRACE_EVENT_BEGIN(traceContext, "ThreadPoolExecutor::handleResult");
+  TRACE_EVENT_SCOPE_NAMED(traceContext, "ThreadPoolExecutor::handleResult",
+                          traceEvent);
 
   auto runWasSuccess = !err;
 


### PR DESCRIPTION
Summary: In the Chromium TraceEvent spec, Complete events encode an entire TraceEvent using begin timestamp and duration. In many cases this allows us to replace two events (one for the begin, one for the end) with a single event with an additional parameter. This diff adds support for Complete events in the Glow TraceEvent framework and converts as many of our trace logging events as possible to use this new format.

Changes involved:
* Modified the ScopedTraceBlock to log Complete events at the exit of scope, rather than a Begin at in the constructor and an End at the exit.
* Added new macros for easier usage of scoped trace event blocks: a definition to early exit the scope (we use generally before firing callbacks), and versions which provide an event variable name, which allows nesting scoped events.
* Converted almost all TraceEvents in the runtime to use the SCOPE macros (and so Complete events).
* Updated auto instrumentation on Interpreter, CPU and OpenCL to use Complete events rather than a Begin and End pair. Manual TraceEvents which specify Begin and End still work. This actually simplifies the instrumentation code a bit.
* Changed Interpreter, CPU and OpenCL devices to use std::system_clock timestamp domain to match the Runtime and Habana device. This required a little fudging of device timestamps for OCL which we should come back to.

There should be no functional change to viewing traces, but trace file size is as much as 45% reduced. (verified across resnet-runtime and tracing-compare examples).

Documentation: No changes, we still support the TraceEvent spec.

Test Plan: Unit tests in various modes - added two more for the scoped events, tracing compare output looks like this:

![image](https://user-images.githubusercontent.com/701287/58582334-5c367c00-8206-11e9-92e0-5b46524ab000.png)