### PR TITLE
Wire llvm::Errors into CompiledFunction

### DIFF
--- a/include/glow/Backend/CompiledFunction.h
+++ b/include/glow/Backend/CompiledFunction.h
@@ -19,8 +19,7 @@
 #include "glow/Backend/BackendUtils.h"
 #include "glow/ExecutionContext/ExecutionContext.h"
 #include "glow/Graph/Nodes.h"
-
-#include <unordered_map>
+#include "glow/Support/Error.h"
 
 namespace glow {
 
@@ -39,21 +38,8 @@ public:
   virtual ~CompiledFunction();
   /// Execute the network and allocate Placeholder memory with given
   /// \p bindings providing mapping between Placeholder and populated tensor.
-  virtual void execute(ExecutionContext *context) = 0;
-
-  /// Does any needed initialization work for the Backend.
-  /// This includes device init constant memory allocation and copying to
-  /// device. \deprecated
-  virtual void setupRuns() { runsSetup_ = true; }
-
-  /// Per run setup. Copy inputs to device. \deprecated
-  virtual void beforeRun(const PlaceholderBindings &bindings) {}
-
-  /// Per run cleanup. Copy outputs from device. \deprecated
-  virtual void afterRun(const PlaceholderBindings &bindings) {}
-
-  /// Final cleanup. Release memory, reset device. \deprecated
-  virtual void tearDownRuns() { runsSetup_ = false; }
+  /// \returns an llvm::Error if an error ocurred during execution.
+  virtual llvm::Error execute(ExecutionContext *context) = 0;
 
   /// Getter for the runtimeBundle.
   runtime::RuntimeBundle &getRuntimeBundle() { return runtimeBundle_; }
@@ -75,8 +61,6 @@ public:
   virtual BackendKind getCompileBackendKind() const = 0;
 
 protected:
-  /// Flag to ensure setupRuns is only called once.
-  bool runsSetup_{false};
   /// Contains symbol offsets and allocation sizes.
   runtime::RuntimeBundle runtimeBundle_;
 

--- a/include/glow/Backends/DummyDeviceManager.h
+++ b/include/glow/Backends/DummyDeviceManager.h
@@ -102,15 +102,10 @@ public:
 
     CompiledFunction *func = funcIt->second;
 
-    PlaceholderBindings &bindings = *(context->getPlaceholderBindings());
-
-    func->setupRuns();
-    func->beforeRun(bindings);
-    func->execute(context.get());
-    func->afterRun(bindings);
+    auto executeErr = func->execute(context.get());
 
     // Fire the resultCB.
-    callback(0, llvm::Error::success(), std::move(context));
+    callback(0, std::move(executeErr), std::move(context));
 
     return 0;
   }

--- a/include/glow/LLVMIRCodeGen/LLVMCompiledFunction.h
+++ b/include/glow/LLVMIRCodeGen/LLVMCompiledFunction.h
@@ -30,8 +30,7 @@ public:
 
   /// \name CompiledFunction interface
   ///@{
-  virtual ~LLVMCompiledFunction() override;
-  virtual void execute(ExecutionContext *context) override;
+  virtual llvm::Error execute(ExecutionContext *context) override;
 
   virtual void collectConstants(const Module *module) override;
 

--- a/lib/Backends/CPU/CPUDeviceManager.cpp
+++ b/lib/Backends/CPU/CPUDeviceManager.cpp
@@ -138,13 +138,13 @@ void CPUDeviceManager::runFunctionImpl(
   CompiledFunction *func = funcIt->second;
 
   // Run that function.
-  func->execute(context.get());
+  auto executeErr = func->execute(context.get());
 
   // End the TraceEvent early to avoid time in the CB.
   TRACE_EVENT_END(context->getTraceContext(), eventName)
 
   // Fire the resultCB.
-  resultCB(id, llvm::Error::success(), std::move(context));
+  resultCB(id, std::move(executeErr), std::move(context));
 }
 } // namespace runtime
 } // namespace glow

--- a/lib/Backends/CPU/CPUFunction.cpp
+++ b/lib/Backends/CPU/CPUFunction.cpp
@@ -25,6 +25,6 @@ CPUFunction::CPUFunction(std::unique_ptr<llvm::orc::GlowJIT> JIT,
                          const runtime::RuntimeBundle &runtimeBundle)
     : LLVMCompiledFunction(std::move(JIT), runtimeBundle) {}
 
-void CPUFunction::execute(ExecutionContext *context) {
-  LLVMCompiledFunction::execute(context);
+llvm::Error CPUFunction::execute(ExecutionContext *context) {
+  return LLVMCompiledFunction::execute(context);
 }

--- a/lib/Backends/CPU/CPUFunction.h
+++ b/lib/Backends/CPU/CPUFunction.h
@@ -33,7 +33,7 @@ public:
   /// \name CompiledFunction interface
   ///@{
   ~CPUFunction() override = default;
-  void execute(ExecutionContext *context) override;
+  llvm::Error execute(ExecutionContext *context) override;
 
   /// \returns the Kind of Backend used to compile this function.
   virtual BackendKind getCompileBackendKind() const override {

--- a/lib/Backends/Habana/Habana.cpp
+++ b/lib/Backends/Habana/Habana.cpp
@@ -451,11 +451,7 @@ HabanaFunction::~HabanaFunction() {
   GLOW_ASSERT(!llvm::sys::fs::remove(recipeName_ + ".bin"));
 }
 
-void HabanaFunction::setupRuns() {}
-
-void HabanaFunction::beforeRun(const PlaceholderBindings &ctx) {}
-
-void HabanaFunction::execute(ExecutionContext *context) {
+llvm::Error HabanaFunction::execute(ExecutionContext *context) {
   auto *tc = context->getTraceContext();
   TRACE_EVENT_BEGIN(tc, "execute");
 
@@ -538,11 +534,8 @@ void HabanaFunction::execute(ExecutionContext *context) {
       ->setHandle(HabanaWaitHandle(deviceId, handle, std::move(inputInfo),
                                    std::move(outputInfo)));
   TRACE_EVENT_END(tc, "execute");
+  return llvm::Error::success();
 }
-
-void HabanaFunction::afterRun(const PlaceholderBindings &ctx) {}
-
-void HabanaFunction::tearDownRuns() {}
 
 static std::unique_ptr<synConvolutionParams> makeSynConvolutionParams(
     llvm::ArrayRef<unsigned_t> kernel, llvm::ArrayRef<unsigned_t> stride,

--- a/lib/Backends/Habana/Habana.h
+++ b/lib/Backends/Habana/Habana.h
@@ -202,19 +202,7 @@ public:
 
   const std::string &getRecipeName() const { return recipeName_; }
 
-  void execute(ExecutionContext *context) override;
-
-  /// Allocates on device buffer and copies Constant weights to device.
-  void setupRuns() override;
-
-  /// Per run setup, copies Inputs from \p ctx to on device memory.
-  void beforeRun(const PlaceholderBindings &ctx) override;
-
-  /// Copies outputs from device to tensors in \p ctx.
-  void afterRun(const PlaceholderBindings &ctx) override;
-
-  /// Final cleanup.
-  void tearDownRuns() override;
+  llvm::Error execute(ExecutionContext *context) override;
   ///@}
 
   /// \returns the Kind of Backend used to compile this function.

--- a/lib/Backends/Habana/HabanaDeviceManager.cpp
+++ b/lib/Backends/Habana/HabanaDeviceManager.cpp
@@ -298,7 +298,12 @@ void HabanaDeviceManager::runFunctionImpl(RunIdentifierTy runId,
       llvm::make_unique<HabanaBindings>(deviceId_, topologyId);
   deviceBindings->setIOBuffer(ioBufferPool->get());
   ctx->setDeviceBindings(std::move(deviceBindings));
-  function->execute(ctx.get());
+
+  auto executeErr = function->execute(ctx.get());
+  if (executeErr) {
+    resultCB(runId, std::move(executeRes), std::move(ctx));
+    return;
+  }
 
   // Give the handle to the wait thread pool to wait on and call the callback
   // for.

--- a/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
@@ -136,13 +136,13 @@ void InterpreterDeviceManager::runFunctionImpl(
   CompiledFunction *func = funcIt->second;
 
   // Run that function.
-  func->execute(context.get());
+  auto executeErr = func->execute(context.get());
 
   // End the TraceEvent early to avoid time in the CB.
   TRACE_EVENT_END(context, "DM_run");
 
   // Fire the resultCB.
-  resultCB(id, llvm::Error::success(), std::move(context));
+  resultCB(id, std::move(executeErr), std::move(context));
 }
 
 } // namespace runtime

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -57,7 +57,7 @@ public:
   ///@{
   ~InterpreterFunction() override;
 
-  void execute(ExecutionContext *context) override;
+  llvm::Error execute(ExecutionContext *context) override;
 
   /// Collects constants for runtime.
   void collectConstants(const Module *module) override;
@@ -93,7 +93,7 @@ public:
 
   ~BoundInterpreterFunction();
 
-  void execute(IRFunction *F, ExecutionContext *context);
+  llvm::Error execute(IRFunction *F, ExecutionContext *context);
 
 private:
   /// \returns a pointer to the tensor that is saved under \p v.

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -539,7 +539,7 @@ static void topK(Tensor &outW, Tensor &indW, Tensor &inW, size_t k) {
   }
 }
 
-void OpenCLFunction::execute(ExecutionContext *context) {
+llvm::Error OpenCLFunction::execute(ExecutionContext *context) {
   (void)context;
 
   auto clBindings = static_cast<runtime::OpenCLDeviceBindings *>(
@@ -1427,6 +1427,8 @@ void OpenCLFunction::execute(ExecutionContext *context) {
     }
     kernelLaunches_.clear();
   }
+
+  return llvm::Error::success();
 }
 
 uint64_t OpenCLFunction::copyValueToDevice(const Value *v, void *buf) {

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -113,7 +113,7 @@ public:
   ///@{
   ~OpenCLFunction() override;
 
-  void execute(ExecutionContext *context) override;
+  llvm::Error execute(ExecutionContext *context) override;
 
   /// Collects constants for runtime.
   void collectConstants(const Module *module) override;

--- a/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
@@ -343,7 +343,7 @@ void OpenCLDeviceManager::runFunctionImpl(
   context->setDeviceBindings(std::move(clBindings));
 
   // Run that function.
-  func->execute(context.get());
+  auto executeErr = func->execute(context.get());
 
   // Return the command queue.
   returnRunCommandQueue(commands);
@@ -352,5 +352,5 @@ void OpenCLDeviceManager::runFunctionImpl(
   TRACE_EVENT_END(context, "DM_run");
 
   // Fire the resultCB.
-  resultCB(id, llvm::Error::success(), std::move(context));
+  resultCB(id, std::move(executeErr), std::move(context));
 }

--- a/lib/LLVMIRCodeGen/LLVMCompiledFunction.cpp
+++ b/lib/LLVMIRCodeGen/LLVMCompiledFunction.cpp
@@ -26,8 +26,6 @@ LLVMCompiledFunction::LLVMCompiledFunction(
     const runtime::RuntimeBundle &runtimeBundle)
     : CompiledFunction(runtimeBundle), JIT_(std::move(JIT)) {}
 
-LLVMCompiledFunction::~LLVMCompiledFunction() { tearDownRuns(); }
-
 void LLVMCompiledFunction::collectConstants(const Module *module) {
   runtimeBundle_.collectConstants(module);
 }
@@ -68,7 +66,7 @@ void LLVMCompiledFunction::updatePlaceholders(
   }
 }
 
-void LLVMCompiledFunction::execute(ExecutionContext *context) {
+llvm::Error LLVMCompiledFunction::execute(ExecutionContext *context) {
   uint8_t *baseActivationsAddress{nullptr};
 
   /// Base address for Mutable weights memory block, Inputs and Outputs.
@@ -127,6 +125,8 @@ void LLVMCompiledFunction::execute(ExecutionContext *context) {
     auto ev = context->scopedEvent("processInstrumentation");
     translateTraceEvents(context);
   }
+
+  return llvm::Error::success();
 }
 
 void LLVMCompiledFunction::translateTraceEvents(

--- a/tests/unittests/BackendCorrectnessTest.cpp
+++ b/tests/unittests/BackendCorrectnessTest.cpp
@@ -251,11 +251,7 @@ TEST_P(CPUOnly, dataParallelStackingTest) {
 
   MockCPUBackend backend;
   auto function = backend.compileIR(std::move(M));
-  function->setupRuns();
-  function->beforeRun(*ctx->getPlaceholderBindings());
-  function->execute(ctx.get());
-  function->afterRun(*ctx->getPlaceholderBindings());
-  function->tearDownRuns();
+  ASSERT_FALSE(errToBool(function->execute(ctx.get())));
   auto H = outputTensor->getHandle();
   EXPECT_EQ(H.at(0), 3);
   EXPECT_EQ(H.at(1), 4);

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -102,7 +102,9 @@ class MockBackend : public Backend {
     MockFunction(const runtime::RuntimeBundle &bundle)
         : CompiledFunction(bundle) {}
 
-    void execute(ExecutionContext *) override {}
+    llvm::Error execute(ExecutionContext *) override {
+      return llvm::Error::success();
+    }
 
     BackendKind getCompileBackendKind() const override {
       return BackendKind::Interpreter;
@@ -135,7 +137,9 @@ class MockBackendCustomIRGen : public Backend {
     MockFunction(const runtime::RuntimeBundle &bundle)
         : CompiledFunction(bundle) {}
 
-    void execute(ExecutionContext *) override {}
+    llvm::Error execute(ExecutionContext *) override {
+      return llvm::Error::success();
+    }
 
     BackendKind getCompileBackendKind() const override {
       return BackendKind::Interpreter;

--- a/tests/unittests/PartitionerTest.cpp
+++ b/tests/unittests/PartitionerTest.cpp
@@ -436,7 +436,9 @@ class MockBackend : public Backend {
     MockFunction(const runtime::RuntimeBundle &bundle)
         : CompiledFunction(bundle) {}
 
-    void execute(ExecutionContext *) override {}
+    llvm::Error execute(ExecutionContext *) override {
+      return llvm::Error::success();
+    }
 
     BackendKind getCompileBackendKind() const override {
       return BackendKind::Interpreter;


### PR DESCRIPTION
Summary:
* Return llvm::Error from CompiledFunction::execute() and handle results in DeviceManagers. Right now `execute()` methods mostly behave the same, will add more legit error handling internal to each in followups.
* Remove unused CompiledFunction methods `setupRuns`, `beforeRun`, `afterRun`, `tearDownRuns`.

Documentation:
doxygen

Test Plan:
CI