### PR TITLE
[habana] Sink Transpose below Quantized Node.

### DIFF
--- a/lib/Backends/Habana/Habana.cpp
+++ b/lib/Backends/Habana/Habana.cpp
@@ -1669,21 +1669,22 @@ bool HabanaBackend::transformPostLowering(
     // Sink TransposeNode below QuantizedNode.
     // Motivations:
     // 1. This way, TransposeNode has to transpose fewer bytes.
-    // 2. In Habana GC's current version, QuantizeNode will have better performance when
-    //    FCD is large. In typical case, this sequence is encountered at the beginning of
-    //    vision topologies, where the FCD=W so it is large, and after the transpose
-    //    FCD=C=3 so it is small.
+    // 2. In Habana GC's current version, QuantizeNode will have better
+    // performance when
+    //    FCD is large. In typical case, this sequence is encountered at the
+    //    beginning of vision topologies, where the FCD=W so it is large, and
+    //    after the transpose FCD=C=3 so it is small.
     if (auto *quant = llvm::dyn_cast<QuantizeNode>(&node)) {
       auto *transpose = llvm::dyn_cast<TransposeNode>(quant->getInput());
       if (!transpose) {
-       continue;
+        continue;
       }
       auto transposeOutTy = F->getParent()->uniqueTypeWithNewShape(
-           quant->getResult().getType(), transpose->getInput().dims());
+          quant->getResult().getType(), transpose->getInput().dims());
       auto *newQuant = F->createQuantize(quant->getName(),
                                          transpose->getInput(), transposeOutTy);
-      auto *newTranspose = F->createTranspose(
-           transpose->getName(), newQuant, transpose->getShuffle());
+      auto *newTranspose = F->createTranspose(transpose->getName(), newQuant,
+                                              transpose->getShuffle());
       quant->getResult().replaceAllUsesOfWith(newTranspose);
       changed = true;
       continue;


### PR DESCRIPTION
Summary:
This is direct porting from the private branch.

From the original PR.

```
Sink TransposeNode below QuantizedNode. Yields big improvement in vision topologies' performance.
Motivations:

This way, TransposeNode has to transpose fewer bytes.
In Habana GC's current version, QuantizeNode will have better performance when FCD is large. In typical case, this sequence is encountered at the beginning of vision topologies, where the FCD=W so it is large, and after the transpose FCD=C=3 so it is small.
```

cc: @sergeigofman

Documentation:
n/a

Test Plan:
CI/local run
