### PR TITLE
Prevent integer overflow when using uniform_int_distribution

### DIFF
--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -850,7 +850,7 @@ public:
     assert(low >= std::numeric_limits<ElemTy>::lowest() &&
            high <= std::numeric_limits<ElemTy>::max() &&
            "Cannot initialize outside range of representable values.");
-    std::uniform_int_distribution<int> dist(low, high);
+    std::uniform_int_distribution<long long> dist(low, high);
     switch (getElementType()) {
     default: {
       for (auto &elem : *this) {


### PR DESCRIPTION
Summary:
In the recomandationSystemTest we were generating random data with a range of -INT32_MAX - INT32_MAX, which caused an integer overflow inside uniform_int_distribution. It seems internally in uniform_int_distribution there is a max-min operation which when using the full range will cause an overflow.  The fix is to make the distribution of type long long which will allow the full int32 range.

Documentation: NA

Test Plan: ninja test now passes with asan

Fixes #2982 