### PR TITLE
[RuntimeBundle::create] change the allocation of placeholders to be contiguous

### DIFF
--- a/include/glow/Backend/BackendUtils.h
+++ b/include/glow/Backend/BackendUtils.h
@@ -120,5 +120,49 @@ public:
 };
 } // namespace runtime
 
+/// If \p PH is an output placeholder in the Function \p F,
+/// \returns true.
+/// This is determined by checking if the PH has a user which uses the PH as an
+/// overwritten input.
+bool isOutput(const Placeholder *PH, const Function &F);
+
+/// If \p PH is an input placeholderin the Function \p F,
+/// \returns true.
+/// This is determined by checking if the PH is the input to a saveNode or is
+/// used by a non saveNode.
+bool isInput(const Placeholder *PH, const Function &F);
+
+/// If \p PH is an output placeholder in the IRFunction \p F,
+/// \returns true.
+/// This is determined by checking if the PH has weights which are referenced by
+/// other Instructions as OperandKind::InOut or OperandKind::Out.
+bool isOutput(const Placeholder *PH, const IRFunction &F);
+
+/// If \p PH is an input placeholder in the IRFunction \p F,
+/// \returns true.
+/// This is determined by checking if the PH is always used as an @in parameter
+/// by the current function.
+bool isInput(const Placeholder *PH, const IRFunction &F);
+
+/// Contains information for placeholder during allocation.
+struct PlaceholderInputOutputInfo {
+  /// The placeholder address.
+  const Placeholder *addr;
+  /// Is the placeholder an input for the function.
+  bool isInput;
+  /// Is the placeholder an onput for the function.
+  bool isOutput;
+};
+
+using ContiguousPlaceholders = std::vector<PlaceholderInputOutputInfo>;
+
+/// Convert placeholders to be ordered as input|inputOutput|output|neither.
+/// Packed into {Placeholder *, isInput, isOutput} as
+/// PlaceholderInputOutputInfo. FUN could be Function or IRFunction. ARR could
+/// be std::list<Placeholder *> or std::vector<const Placeholder *>
+template <typename FUN, typename ARR>
+ContiguousPlaceholders getContiguousPlaceHolder(const ARR &holders,
+                                                const FUN &F);
+
 } // end namespace glow
 #endif // GLOW_BACKENDS_BACKENDUTILS_H

--- a/lib/LLVMIRCodeGen/AllocationsInfo.cpp
+++ b/lib/LLVMIRCodeGen/AllocationsInfo.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "glow/LLVMIRCodeGen/AllocationsInfo.h"
+#include "glow/Backend/BackendUtils.h"
 #include "glow/Backend/CompiledFunction.h"
 #include "glow/CodeGen/MemoryAllocator.h"
 #include "glow/Graph/Graph.h"
@@ -51,8 +52,15 @@ void AllocationsInfo::allocateWeightVars(const IRFunction *F) {
     allocatedAddress_[w] = addr;
   }
 
+  // Placeholders should be allocated in a order of
+  // intput|inputOutput|output|neither.
+  auto contiguousPlaceholders =
+      getContiguousPlaceHolder(F->findPlaceholders(), *F);
+
   // Compute the offsets and total memory requirements for Placeholders.
-  for (auto &v : F->findPlaceholders()) {
+  for (auto it = contiguousPlaceholders.begin();
+       it != contiguousPlaceholders.end(); it++) {
+    auto &v = it->addr;
     // Get the WeightVar for each Placeholder to calculate offsets.
     assert(isa<WeightVar>(F->getWeightForNode(v)) && "Expected WeightVar");
     auto *w = cast<WeightVar>(F->getWeightForNode(v));


### PR DESCRIPTION
Summary:
- modify the `runtime::RuntimeBundle::create()` to allocate the placeholders contiguously (Input|InputOutput|Output). So in principle, it may require only a single DMA of a big contiguous block of memory to move input or output.

- adjust the `AllocationsInfo::allocateWeightVars()` to match the order.

This PR fixes #2819 .

Test Plan:
Add test to BackendTest to make sure placeholders are allocated in the contiguous order.

