### PR TITLE
[Partitioner] Enable more than one partitions assigned to the same device

### DIFF
--- a/tests/unittests/PartitionerTest.cpp
+++ b/tests/unittests/PartitionerTest.cpp
@@ -486,10 +486,13 @@ static void createSimpleModule(Module &mod) {
       mod.createPlaceholder(ElemKind::FloatTy, {16}, "input1", false);
   auto *input2 =
       mod.createPlaceholder(ElemKind::FloatTy, {16}, "input2", false);
+  auto *input3 =
+      mod.createPlaceholder(ElemKind::FloatTy, {16}, "input3", false);
   auto *sub = F->createSub("sub", input1, input2);
   auto *mul = F->createMul("mul", input1, input2);
-  auto *sum = F->createMul("add", sub, mul);
-  auto *save = F->createSave("ret", sum);
+  auto *sum = F->createAdd("add", sub, mul);
+  auto *sub2 = F->createSub("sub1", sum, input3);
+  auto *save = F->createSave("ret", sub2);
   (void)save;
 }
 
@@ -501,21 +504,21 @@ TEST_F(PartitionerTest, SimpleHeterogeneousPartitioning) {
     // Create two backends which support different ops, then do the partition by
     // assigning the ops to the corresponding abackends.
     std::vector<Backend *> backends;
-    backends.emplace_back(&backendWithoutSub1);
-    backends.emplace_back(&backendWithoutSub2);
     backends.emplace_back(&backendWithoutMul1);
     backends.emplace_back(&backendWithoutMul2);
-    std::vector<DeviceInfo> devices = {{3072, BackendKind::CPU},
-                                       {3072, BackendKind::CPU},
+    backends.emplace_back(&backendWithoutSub1);
+    backends.emplace_back(&backendWithoutSub2);
+    std::vector<DeviceInfo> devices = {{3072, BackendKind::Interpreter},
                                        {3072, BackendKind::Interpreter},
-                                       {3072, BackendKind::Interpreter}};
+                                       {3072, BackendKind::CPU},
+                                       {3072, BackendKind::CPU}};
     auto partitioner =
         Partitioner(&mod_, devices, backends, /* saturateHost */ true);
     CompilationContext cctx;
     auto err = partitioner.Partition(cctx);
     EXPECT_FALSE(errToBool(std::move(err)));
     DAGListTy myList = std::move(partitioner.getPartitionResult());
-    ASSERT_EQ(mod_.getFunctions().size(), 2);
+    ASSERT_EQ(mod_.getFunctions().size(), 3);
     ASSERT_EQ(myList.size(), 1);
     ASSERT_TRUE(checkSaveNode(mod_));
 
@@ -528,6 +531,89 @@ TEST_F(PartitionerTest, SimpleHeterogeneousPartitioning) {
     }
     mod_.clear();
   }
+}
+
+/// Test assigning more than one partitions in to one device for single
+/// backendKind.
+TEST_F(PartitionerTest, logicalIDTest0) {
+  auto *input1 =
+      mod_.createPlaceholder(ElemKind::FloatTy, {2, 10}, "input1", false);
+  auto *input2 =
+      mod_.createPlaceholder(ElemKind::FloatTy, {10, 16}, "input2", false);
+  auto *input3 =
+      mod_.createPlaceholder(ElemKind::FloatTy, {16, 20}, "input3", false);
+  auto *input4 =
+      mod_.createPlaceholder(ElemKind::FloatTy, {20, 1}, "input4", false);
+  auto *input5 =
+      mod_.createPlaceholder(ElemKind::FloatTy, {1, 50}, "input5", false);
+  auto *mul0 = F_->createMatMul("mul0", input1, input2);
+  auto *mul1 = F_->createMatMul("mul1", mul0, input3);
+  auto *mul2 = F_->createMatMul("mul2", mul1, input4);
+  auto *mul3 = F_->createMatMul("mul3", mul2, input5);
+  auto *save = F_->createSave("ret", mul3);
+  (void)save;
+  std::vector<DeviceInfo> devices = {{1500, BackendKind::Interpreter},
+                                     {1500, BackendKind::Interpreter}};
+  // Create two backends which support different ops, then do the partition by
+  // assigning the ops to the corresponding abackends.
+  auto partitioner = Partitioner(&mod_, devices, /* saturateHost */ true);
+  CompilationContext cctx;
+  auto err = partitioner.Partition(cctx);
+  EXPECT_FALSE(errToBool(std::move(err)));
+  DAGListTy myList = std::move(partitioner.getPartitionResult());
+  // Check there are 3 partitions.
+  ASSERT_EQ(mod_.getFunctions().size(), 3);
+  ASSERT_EQ(myList.size(), 1);
+  ASSERT_TRUE(checkSaveNode(mod_));
+
+  for (auto &dag : myList) {
+    // Check number of logical devices;
+    llvm::SmallSet<DeviceIDTy, 4> usedID;
+    for (auto &node : dag.nodes) {
+      ASSERT_EQ(node->logicalDevices.size(), 1);
+      usedID.insert(node->logicalDevices[0]);
+    }
+    // Check there are 2 logical devices.
+    ASSERT_EQ(usedID.size(), 2);
+  }
+  mod_.clear();
+}
+
+/// Test assigning more than one partitions in to one device in Heterogeneous
+/// partition.
+TEST_F(PartitionerTest, logicalIDTest1) {
+  createSimpleModule(mod_);
+  BackendWithoutSub backendWithoutSub1, backendWithoutSub2;
+  BackendWithoutMul backendWithoutMul1, backendWithoutMul2;
+  // Create two backends which support different ops, then do the partition by
+  // assigning the ops to the corresponding abackends.
+  std::vector<Backend *> backends;
+  backends.emplace_back(&backendWithoutMul1);
+  backends.emplace_back(&backendWithoutSub1);
+  std::vector<DeviceInfo> devices = {{3072, BackendKind::Interpreter},
+                                     {3072, BackendKind::CPU}};
+  auto partitioner =
+      Partitioner(&mod_, devices, backends, /* saturateHost */ true);
+  CompilationContext cctx;
+  auto err = partitioner.Partition(cctx);
+  EXPECT_FALSE(errToBool(std::move(err)));
+  DAGListTy myList = std::move(partitioner.getPartitionResult());
+  ASSERT_EQ(mod_.getFunctions().size(), 3);
+  ASSERT_EQ(myList.size(), 1);
+  ASSERT_TRUE(checkSaveNode(mod_));
+
+  for (auto &dag : myList) {
+    // Check number of logical devices;
+    llvm::SmallSet<DeviceIDTy, 4> usedID;
+    for (auto &node : dag.nodes) {
+      // Although the saturateHost is set true, no saturating the host in
+      // heterogeneous partiton.
+      ASSERT_EQ(node->logicalDevices.size(), 1);
+      usedID.insert(node->logicalDevices[0]);
+    }
+    ASSERT_EQ(usedID.size(), 2);
+  }
+  mod_.clear();
 }
 
 /// Check the function getGraphMemInfo to handle more than one outputs of a


### PR DESCRIPTION
Summary:
The PR allows more than one partitions to be assigned into one device.
This happens when the number of generated DAGNodes is larger than the number of devices for any backendKind . E.g:                                
node1(6GB) -> node2(14GB) -> node3(6GB). The memory limitation is 16GB, and there is only 2 devices. So we assign node1 and node3 into one device.  
Documentation:

Test Plan:
added unnitest. 


#2298 
Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
