### PR TITLE
build: report a fatal error if `clang++` is not found

### DIFF
--- a/lib/Backends/CPU/CMakeLists.txt
+++ b/lib/Backends/CPU/CMakeLists.txt
@@ -3,6 +3,11 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 else()
   find_program(CLANG_BIN clang++)
 endif()
+
+if(NOT CLANG_BIN)
+  message(SEND_ERROR "unable to find clang, cannot build the CPU runtime")
+endif()
+
 if(MSVC)
     set(LLVM_LINK_BIN ${LLVM_BINARY_DIR}/$(Configuration)/bin/llvm-link)
 else()


### PR DESCRIPTION
When building with GCC, report an error if `clang++` is not found and the CPU
backend is enabled as `clang` is required for the runtime build.

Summary:

Documentation:

Test Plan:

[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
