### PR TITLE
build: add a check for `llvm-link`, allow overriding

### DIFF
--- a/lib/Backends/CPU/CMakeLists.txt
+++ b/lib/Backends/CPU/CMakeLists.txt
@@ -3,15 +3,19 @@ if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 else()
   find_program(CLANG_BIN clang++)
 endif()
-
 if(NOT CLANG_BIN)
   message(SEND_ERROR "unable to find clang, cannot build the CPU runtime")
 endif()
 
-if(MSVC)
+if(NOT LLVM_LINK_BIN)
+  if(MSVC)
     set(LLVM_LINK_BIN ${LLVM_BINARY_DIR}/$(Configuration)/bin/llvm-link)
-else()
+  else()
     set(LLVM_LINK_BIN ${LLVM_BINARY_DIR}/bin/llvm-link)
+  endif()
+endif()
+if(NOT EXISTS ${LLVM_LINK_BIN})
+  message(SEND_ERROR "unable to find llvm-link, cannot build the CPU runtime")
 endif()
 
 set(CPURunttimeCompilationOptions


### PR DESCRIPTION
Summary:

Allow the user to specify `-DLLVM_LINK_BIN=` rather than assuming that it exists
as a particular location.  This already does not account for configuration types
properly except in the case of MSVC, and does not work well with all ways to
build LLVM.  We should either use the imported target for `llvm-link` as we were
or for now allow this override.

We now report a fatal error if `llvm-link` is not found and the CPU backend is
enabled as that is required to build the runtime.

Documentation:
n/a

Test Plan:
CI
