### PR TITLE
build: remove unused CMake definitions (NFC)

### DIFF
--- a/lib/Backends/CPU/CMakeLists.txt
+++ b/lib/Backends/CPU/CMakeLists.txt
@@ -14,10 +14,6 @@ else()
     set(LLVM_LINK_BIN ${LLVM_BINARY_DIR}/bin/llvm-link)
 endif()
 
-set(CMAKE_LLIR_CREATE_SHARED_LIBRARY "${LLVM_LINK_BIN} -o <TARGET> <OBJECTS>")
-set(CMAKE_LLIR_CREATE_SHARED_MODULE "${LLVM_LINK_BIN} -o <TARGET> <OBJECTS>")
-set(CMAKE_LLIR_CREATE_STATIC_LIBRARY "${LLVM_LINK_BIN} -o <TARGET> <OBJECTS>")
-
 set(CPURunttimeCompilationOptions
       -std=c++14
       -ffast-math


### PR DESCRIPTION
The runtime library is built as a regular library and not with the LLIR linkage
language, so remove the link rules for the LLIR language.

Summary:

Documentation:

Test Plan:

[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
