### PR TITLE
build: try to goad CMake into understanding dependencies

### DIFF
--- a/lib/Backends/CPU/CMakeLists.txt
+++ b/lib/Backends/CPU/CMakeLists.txt
@@ -1,70 +1,11 @@
-if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-  set(CLANG_BIN ${CMAKE_CXX_COMPILER})
-else()
-  find_program(CLANG_BIN clang++)
-endif()
-if(NOT CLANG_BIN)
-  message(SEND_ERROR "unable to find clang, cannot build the CPU runtime")
-endif()
 
-if(NOT LLVM_LINK_BIN)
-  if(MSVC)
-    set(LLVM_LINK_BIN ${LLVM_BINARY_DIR}/$(Configuration)/bin/llvm-link)
-  else()
-    set(LLVM_LINK_BIN ${LLVM_BINARY_DIR}/bin/llvm-link)
-  endif()
-endif()
-if(NOT EXISTS ${LLVM_LINK_BIN})
-  message(SEND_ERROR "unable to find llvm-link, cannot build the CPU runtime")
-endif()
+add_subdirectory(libjit)
 
-set(CPURunttimeCompilationOptions
-      -std=c++14
-      -ffast-math
-      -fno-finite-math-only
-      -g0
-      -emit-llvm
-      -O0)
-
-set(libjit_files "libjit;libjit_conv;libjit_matmul")
-
-set(libjit_obj_file_path ${CMAKE_CURRENT_BINARY_DIR}/CPURuntime)
-file(MAKE_DIRECTORY ${libjit_obj_file_path})
-
-set(CPURuntime_OBJS)
-set(CPURuntime_SRCS)
-
-foreach(libjit_src_file ${libjit_files})
-  set(libjit_obj_file ${libjit_obj_file_path}/${libjit_src_file}${CMAKE_C_OUTPUT_EXTENSION})
-  set(libjit_src_file_path ${CMAKE_CURRENT_LIST_DIR}/libjit/${libjit_src_file}.cpp)
-
-  add_custom_command(
-    OUTPUT  ${libjit_obj_file}
-    COMMAND ${CLANG_BIN} -c ${libjit_src_file_path} ${CPURunttimeCompilationOptions} -o ${libjit_obj_file}
-    DEPENDS ${libjit_src_file_path}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})
-
-  list(APPEND CPURuntime_OBJS ${libjit_obj_file})
-  list(APPEND CPURuntime_SRCS ${libjit_src_file_path})
-endforeach()
-
-file(MAKE_DIRECTORY ${GLOW_BINARY_DIR}/CPU)
-add_custom_command(
-    OUTPUT ${GLOW_BINARY_DIR}/CPU/libjit.bc
-    COMMAND ${LLVM_LINK_BIN} -o ${GLOW_BINARY_DIR}/CPU/libjit.bc ${CPURuntime_OBJS}
-    DEPENDS  ${CPURuntime_OBJS} ${CPURuntime_SRCS}
-    WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}")
-
-file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/glow/CPU)
-add_custom_command(
-    OUTPUT ${CMAKE_BINARY_DIR}/glow/CPU/libjit_bc.inc
-    COMMAND include-bin "${CMAKE_BINARY_DIR}/CPU/libjit.bc" "${CMAKE_BINARY_DIR}/glow/CPU/libjit_bc.inc"
-    DEPENDS ${GLOW_BINARY_DIR}/CPU/libjit.bc
-    WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}")
-
+add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/libjit.inc
+  COMMAND include-bin $<TARGET_FILE:JIT> "${CMAKE_CURRENT_BINARY_DIR}/libjit.inc"
+  DEPENDS include-bin JIT)
 add_custom_target(CPURuntime
-  DEPENDS ${CMAKE_BINARY_DIR}/glow/CPU/libjit_bc.inc
-  WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}")
+  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/libjit.inc)
 
 if (NOT MSVC)
   add_library(CPURuntimeNative
@@ -74,7 +15,6 @@ if (NOT MSVC)
 endif(NOT MSVC)
 
 add_library(CPUBackend
-            "${CMAKE_BINARY_DIR}/glow/CPU/libjit_bc.inc"
             CPUBackend.cpp
             CPUDeviceManager.cpp
             CPUFactory.cpp
@@ -92,5 +32,7 @@ target_link_libraries(CPUBackend
                         QuantizationBase
                         LLVMIRCodeGen)
 add_dependencies(CPUBackend CPURuntime)
+target_include_directories(CPUBackend PRIVATE
+  ${CMAKE_CURRENT_BINARY_DIR})
 
 set(linked_backends ${linked_backends} CPUBackend PARENT_SCOPE)

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -36,7 +36,7 @@ using namespace glow;
 /// The resulting file is included here to compile the bitcode image into our
 /// library.
 static const unsigned char libjit_bc[] = {
-#include "glow/CPU/libjit_bc.inc"
+#include "libjit.inc"
 };
 static const size_t libjit_bc_size = sizeof(libjit_bc);
 

--- a/lib/Backends/CPU/libjit/CMakeLists.txt
+++ b/lib/Backends/CPU/libjit/CMakeLists.txt
@@ -1,0 +1,45 @@
+
+set(SAVED_CMAKE_CXX_COMPILER ${CMAKE_CXX_COMPILER})
+
+# -- ensure that we have clang as the compiler
+if(NOT CMAKE_CXX_COMPILER_ID MATCHES Clang)
+  find_program(CLANG_BIN clang++)
+  if(NOT CLANG_BIN)
+    message(SEND_ERROR "unable to find clang, cannot build the CPU runtime")
+  endif()
+  set(CMAKE_CXX_COMPILER ${CLANG_BIN})
+endif()
+
+# -- ensure that we have llvm-link to link with
+if(NOT LLVM_LINK_BIN)
+  if(MSVC)
+    set(LLVM_LINK_BIN ${LLVM_BINARY_DIR}/$(Configuration)/bin/llvm-link)
+  else()
+    set(LLVM_LINK_BIN ${LLVM_BINARY_DIR}/bin/llvm-link)
+  endif()
+endif()
+if(NOT EXISTS ${LLVM_LINK_BIN})
+  message(SEND_ERROR "unable to find llvm-link, cannot build the CPU runtime")
+endif()
+
+# -- setup rules to link the JIT runtime
+set(CMAKE_LLIR_CREATE_SHARED_MODULE "${LLVM_LINK_BIN} -o <TARGET> <OBJECTS>")
+
+# -- build the JIT runtime
+add_library(JIT MODULE
+  libjit.cpp
+  libjit_conv.cpp
+  libjit_matmul.cpp)
+set_target_properties(JIT PROPERTIES
+  CXX_EXTENSIONS FALSE
+  CXX_STANDARD 14
+  CXX_STANDARD_REQUIRED TRUE
+  LINKER_LANGUAGE LLIR
+  OUTPUT_NAME libjit.bc
+  PREFIX ""
+  SUFFIX "")
+target_compile_options(JIT PRIVATE
+  -ffast-math -fno-finite-math-only -emit-llvm -g0 -O0)
+
+set(CMAKE_CXX_COMPILER ${SAVED_CMAKE_CXX_COMPILER})
+


### PR DESCRIPTION
Change the build rules for the JIT to use some more trickery to have CMake track
dependencies itself.  First, we swap out the compiler around the definition of
JIT module to ensure that we build with Clang.  Second, we build the library as
a module to control the link rule invocation.  Third, we change the linker
language to LLIR and provide a custom linker rule to invoke the LLVM linker.
This should hopefully provide more reliable null builds.  As a happy side
effect, the logic is easier to read.

Summary:

Documentation:

Test Plan:

[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
