### PR TITLE
[Unittest] Improve RecSys so that float MLP produces results other than 0.

### DIFF
--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -1698,6 +1698,7 @@ libjit_dump_tensor(uint8_t *tensor, size_t *tensorDim, size_t numDimsTensor,
     FloatTy,       // 32-bit float type (float)
     Float16Ty,     // 16-bit float type (half, fp16)
     Int8QTy,       // 8-bit quantized type (int8_t)
+    UInt8QTy,      // unsigned 8-bit quantized type (uint8_t)
     Int16QTy,      // 16-bit quantized type (int16_t)
     Int32QTy,      // 32-bit quantized type (int32_t)
     Int32ITy,      // 32-bit index type (int32_t)

--- a/tests/unittests/RecommendationSystemTest.cpp
+++ b/tests/unittests/RecommendationSystemTest.cpp
@@ -250,7 +250,7 @@ protected:
     auto *end_bias = createRandomizedConstant(mod_, internalType, {output_dim},
                                               "end_bias", 0, 0.00001);
     auto *end_weight = createRandomizedConstant(
-        mod_, internalType, {int_dim, output_dim}, "end_weight", -0.003, 0.003);
+        mod_, internalType, {int_dim, output_dim}, "end_weight", -0.001, 0.003);
 
     FullyConnectedNode *end_layer = F_->createFullyConnected(
         "dense", last, end_weight, end_bias); // Output is size {MB, emb_dim}


### PR DESCRIPTION
Summary: the last FC layer of top-level MLP is essentially a dot product of non-negative vector with a lot of 0 by a vector with equal number of positives and negatives. Due to high number of 0s in LHS vector, it is very likely that we'll get a negative number after reduce, which turns into 0 because of the following Relu. I used skewed distribution instead, so that RHS vector has more positive values, and result is more likely to be positive.

Test Plan: `tests/RecommendationSystemTest`
Added debug prints to ensure the result is not 0 now.

Improves the situation with issue #3012 
