### PR TITLE
[unittests] Move ConvTest to ParameterSweepTest, and add MatMul to it

### DIFF
--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -76,9 +76,9 @@ add_glow_test(NAME Caffe2ImporterTest
               COMMAND ${GLOW_BINARY_DIR}/tests/Caffe2ImporterTest --gtest_output=xml:Caffe2ImporterTest.xml
               WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
-add_executable(ConvTest
-               ConvTest.cpp)
-target_link_libraries(ConvTest
+add_executable(ParameterSweepTest
+               ParameterSweepTest.cpp)
+target_link_libraries(ParameterSweepTest
                       PRIVATE
                         BackendTestUtils
                         Graph
@@ -88,9 +88,9 @@ target_link_libraries(ConvTest
                         Support
                         gtest
                         TestMain)
-add_glow_test(ConvTest
-              ${GLOW_BINARY_DIR}/tests/ConvTest)
-LIST(APPEND UNOPT_TESTS ./tests/ConvTest -optimize-ir=false &&)
+add_glow_test(ParameterSweepTest
+              ${GLOW_BINARY_DIR}/tests/ParameterSweepTest)
+LIST(APPEND UNOPT_TESTS ./tests/ParameterSweepTest -optimize-ir=false &&)
 
 add_executable(DeviceManagerTest
                DeviceManagerTest.cpp)


### PR DESCRIPTION
Summary: Rename the ConvTest to ParameterSweepTest, and then add MatMul sweep tests to it. I somewhat arbitrarily picked the dimensions for MatMul sweeping. FYI on my macbook it took ~80 seconds to run these tests sequentially, and ~26 seconds in parallel w/ gtest-parallel.

Test Plan: We can use these tests to exercise different configs of important ops on different backends. Note that this also uses the `parCloneCountOpt`, meaning we can use it to clone the Functions of these tests many times to try to test many different parallel execution units of an architecture.
