### PR TITLE
[bundles] Fix number of symbols in bundle

### DIFF
--- a/lib/LLVMIRCodeGen/BundleSaver.cpp
+++ b/lib/LLVMIRCodeGen/BundleSaver.cpp
@@ -265,7 +265,7 @@ void BundleSaver::emitBundleConfig() {
                              irgen_->getAllocationsInfo().activationsMemSize_),
 
       llvm::ConstantInt::get(uint64TType, TensorAlignment),
-      llvm::ConstantInt::get(uint64TType, F_->findConstants().size()),
+      llvm::ConstantInt::get(uint64TType, F_->findPlaceholders().size()),
 
       symbolTable));
 }


### PR DESCRIPTION
Summary: BundleSaver writes the number of non mutable symbols as the symbol table length, but the symbol table only contains mutable symbols.

Documentation: n/a

fixes #3019

Test Plan: no tests for bundles (☹️) but tested manually by enumerating symbols in the bundle code.
