### PR TITLE
[CI] only download resnet50 and en2gr for expensive tests

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -67,7 +67,7 @@ elif [[ "${CIRCLE_JOB}" == "TSAN" ]]; then
 elif [[ "$CIRCLE_JOB" == "RELEASE_WITH_EXPENSIVE_TESTS" ]]; then
     # Download the models and tell cmake where to find them.
     MODELS_DIR="$GLOW_DIR/downloaded_models"
-    DOWNLOAD_EXE="python $GLOW_DIR/utils/download_datasets_and_models.py --all-caffe2-models"
+    DOWNLOAD_EXE="python $GLOW_DIR/utils/download_datasets_and_models.py  -c resnet50 en2gr"
     mkdir $MODELS_DIR
     (
         cd $MODELS_DIR

--- a/utils/download_datasets_and_models.py
+++ b/utils/download_datasets_and_models.py
@@ -162,6 +162,7 @@ def download(path, filename, url):
 
 def download_caffe2_models(outDir, models):
     for modelname in models:
+        print("For model ", modelname);
         for filename in ["predict_net.pbtxt", "predict_net.pb", "init_net.pb"]:
             path = os.path.join(outDir, modelname)
             url = "http://fb-glow-assets.s3.amazonaws.com/models/{}/{}".format(


### PR DESCRIPTION
Summary: We're downloading all models for RELEASE_WITH_EXPENSIVE_TESTS CI build, but looks like we only use resnet and en2gr text translation models.

Documentation:

Test Plan: try to make CI work
