### PR TITLE
[OperatorTest] Enable conv with dilation test only on CPU and Interpreter.

### DIFF
--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -3841,6 +3841,8 @@ TEST_P(OperatorTest, GroupConvolution) {
 }
 
 TEST_P(OperatorTest, DilatedConvolution) {
+  ENABLED_BACKENDS(Interpreter, CPU);
+
   auto *input =
       mod_.createPlaceholder(ElemKind::FloatTy, {1, 4, 1, 1}, "input", false);
   auto IH = bindings_.allocate(input)->getHandle();


### PR DESCRIPTION
Summary:
Enable DilatedConvolution on CPU and Interpreter only.

Need to add dilation support in the follow up (There is general Conv and OCLConv which would probably need some special handling).

Documentation:
n/a

Test Plan:
CI
