### PR TITLE
Updated Device Managers to support unpaddedSize field on Tensor.

### DIFF
--- a/lib/Backends/Habana/Habana.cpp
+++ b/lib/Backends/Habana/Habana.cpp
@@ -482,7 +482,7 @@ llvm::Error HabanaFunction::execute(ExecutionContext *context) {
     EnqueueTensorInfo eti;
     llvm::StringRef name = P->getName();
     eti.tensorName = name.data();
-    eti.tensorSize = T->getSizeInBytes();
+    eti.tensorSize = T->getUnpaddedSizeInBytes();
     eti.pTensorData = (char *)ioBuffer->get(P);
 
     copyInputsSizeInBytes += eti.tensorSize;
@@ -504,7 +504,7 @@ llvm::Error HabanaFunction::execute(ExecutionContext *context) {
     EnqueueTensorInfo eti;
     llvm::StringRef name = P->getName();
     eti.tensorName = name.data();
-    eti.tensorSize = T->getSizeInBytes();
+    eti.tensorSize = T->getUnpaddedSizeInBytes();
     eti.pTensorData = (char *)ioBuffer->get(P);
 
     outputInfo.push_back(eti);

--- a/lib/Backends/Interpreter/InterpreterFunction.cpp
+++ b/lib/Backends/Interpreter/InterpreterFunction.cpp
@@ -182,6 +182,23 @@ llvm::Error BoundInterpreterFunction::execute(IRFunction *F,
                                               ExecutionContext *context) {
   {
     auto ev = context->scopedEvent("registerTensors");
+
+    // Find all virtually padded tensors so they can be replaced.
+    std::vector<Placeholder *> virtualPadded;
+    for (auto &ph : context->getPlaceholderBindings()->pairs()) {
+      if (ph.second->getUnpaddedSizeInBytes() < ph.second->getSizeInBytes()) {
+        virtualPadded.push_back(ph.first);
+      }
+    }
+    // Replace all virtually padded tensors with real padding tensors.
+    for (auto &ph : virtualPadded) {
+      auto oldTensor = context->getPlaceholderBindings()->get(ph);
+      Tensor paddedTensor(oldTensor->getType());
+      memcpy(paddedTensor.getUnsafePtr(), oldTensor->getUnsafePtr(),
+             oldTensor->getUnpaddedSizeInBytes());
+      context->getPlaceholderBindings()->erase(ph);
+      context->getPlaceholderBindings()->insert(ph, std::move(paddedTensor));
+    }
     // Register the concrete tensors that back the placeholder tensors.
     for (auto &ph : context->getPlaceholderBindings()->pairs()) {
       auto *w = F->getWeightForNode(ph.first);

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -1508,7 +1508,7 @@ void OpenCLFunction::loadPlaceholders(PlaceholderBindings *bindings) {
     }
     auto symbolInfo = it->second;
     auto addr = symbolInfo.offset;
-    auto numBytes = symbolInfo.size;
+    auto numBytes = PH.second->getUnpaddedSizeInBytes();
     // Issue a non-blocking command to copy the buffer to the device.
     auto buf = PH.second->getUnsafePtr();
     cl_event event{nullptr};
@@ -1537,7 +1537,7 @@ void OpenCLFunction::updatePlaceholders(PlaceholderBindings *bindings) {
     }
     auto symbolInfo = it->second;
     auto addr = symbolInfo.offset;
-    auto numBytes = symbolInfo.size;
+    auto numBytes = PH.second->getUnpaddedSizeInBytes();
     // Issue a non-blocking command to copy the buffer to the device.
     auto buf = PH.second->getUnsafePtr();
     cl_event event{nullptr};

--- a/lib/LLVMIRCodeGen/LLVMCompiledFunction.cpp
+++ b/lib/LLVMIRCodeGen/LLVMCompiledFunction.cpp
@@ -42,7 +42,7 @@ void LLVMCompiledFunction::loadPlaceholders(
     auto symbolInfo = it->second;
     auto payload = PH.second->getUnsafePtr();
     auto addr = symbolInfo.offset;
-    auto numBytes = symbolInfo.size;
+    auto numBytes = PH.second->getUnpaddedSizeInBytes();
     // copy PH to allocated memory.
     memcpy(baseMutableWeightVarsAddress + addr, payload, numBytes);
   }
@@ -59,7 +59,7 @@ void LLVMCompiledFunction::updatePlaceholders(
     }
     auto symbolInfo = it->second;
     auto payload = baseMutableWeightVarsAddress + symbolInfo.offset;
-    auto numBytes = symbolInfo.size;
+    auto numBytes = PH.second->getUnpaddedSizeInBytes();
     auto addr = PH.second->getUnsafePtr();
     // copy PH from allocated memory.
     memcpy(addr, payload, numBytes);


### PR DESCRIPTION
Summary: This PR updates the current Device Managers to use unpaddedSize on the Tensor when copying to the device.

Documentation: NA

Test Plan: ninja test passes. Additional testing will follow when onnxifi is updated. 
