### PR TITLE
[fix]: Pass compilation context instead of compilation mode to glow::fold() in glow::optimizeFunction()

### DIFF
--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -2777,7 +2777,7 @@ llvm::Error glow::optimizeFunction(Function *F, const Backend &B,
   // model converters, like converters from Tensorflow to ONNX). In this
   // situation, such folding can then enable more optimizations and also improve
   // the performance backends that support natively such high-level operators.
-  ::glow::fold(F, cctx.compMode);
+  ::glow::fold(F, cctx);
 
   // Optimize the graph.
   ::glow::optimize(F, cctx);


### PR DESCRIPTION
Summary:
- Previously, we pass compilation mode into fold() inside optimizeFunction(), which will create a new CompilationContext object. We want only one CompilationContext for one entire compilation.
- So I modified the code to pass compilation context instead of compilation mode to glow::fold() in glow::optimizeFunction()

Test Plan:
Test with all glow tests
