### PR TITLE
Adding SLS node instead of reducing to SLWS

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -704,10 +704,10 @@ public:
   /// first Lengths[0] slices are aggregated to Result[0], next Lengths[1]
   /// slices are aggregated to Result[1], etc. I.e. sum(Lengths) must be equal
   /// to len(Indices).
-  SparseLengthsWeightedSumNode *createSparseLengthsSum(llvm::StringRef name,
-                                                       NodeValue data,
-                                                       NodeValue indices,
-                                                       NodeValue lengths);
+  SparseLengthsSumNode *createSparseLengthsSum(llvm::StringRef name,
+                                               NodeValue data,
+                                               NodeValue indices,
+                                               NodeValue lengths);
 
   /// Same as SparseLengthsSum, but i-th slice is multiplied by weights[i].
   /// len(weights) must be equal to len(indices).

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -81,6 +81,15 @@ bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
         {ElemKind::FloatTy, ElemKind::Int8QTy, ElemKind::Int64ITy,
          ElemKind::BoolTy});
 
+  case Kinded::Kind::SparseLengthsSumNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::FloatTy}, {SparseLengthsSumNode::IndicesIdx,
+                                     SparseLengthsSumNode::LengthsIdx}) &&
+           (NI.getInElemTy(SparseLengthsSumNode::IndicesIdx) ==
+            ElemKind::Int64ITy) &&
+           (NI.getInElemTy(SparseLengthsSumNode::LengthsIdx) ==
+            ElemKind::Int32ITy);
+
   case Kinded::Kind::SparseLengthsWeightedSumNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
                {ElemKind::FloatTy},

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -321,9 +321,13 @@ bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
 }
 
 bool CPUBackend::shouldLower(const Node *N) const {
-  if (N->getKind() == Kinded::Kind::ConvolutionNodeKind)
+  switch (N->getKind()) {
+  case Kinded::Kind::ConvolutionNodeKind:
+  case Kinded::Kind::SparseLengthsSumNodeKind:
     return false;
-  return true;
+  default:
+    return true;
+  }
 }
 
 std::unique_ptr<CompiledFunction> CPUBackend::createCompiledFunction(

--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -1126,6 +1126,22 @@ void libjit_lengths_to_ranges_i32(int32_t *ranges, const int32_t *lengths,
   }
 }
 
+void libjit_sparse_lengths_sum_f(float *dest, float *data, size_t *indices,
+                                 int32_t *lengths, size_t segments,
+                                 size_t lineSize) {
+  memset(dest, 0, segments * lineSize * sizeof(float));
+  size_t curIndex = 0;
+  for (size_t i = 0; i < segments; i++) {
+    for (int32_t j = 0; j < lengths[i]; j++) {
+      size_t line = indices[curIndex];
+      for (size_t k = 0; k < lineSize; k++) {
+        dest[i * lineSize + k] += data[line * lineSize + k];
+      }
+      curIndex++;
+    }
+  }
+}
+
 void libjit_sparse_lengths_weighted_sum_f(float *dest, float *data,
                                           float *weights, size_t *indices,
                                           int32_t *lengths, size_t segments,

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -170,6 +170,16 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
            (NI.getOutElemTy(RowwiseQuantizedFullyConnectedNode::ResultIdx) ==
             ElemKind::Int8QTy);
 
+  case Kinded::Kind::SparseLengthsSumNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::FloatTy, ElemKind::Float16Ty, ElemKind::Int8QTy},
+               {SparseLengthsSumNode::IndicesIdx,
+                SparseLengthsSumNode::LengthsIdx}) &&
+           (NI.getInElemTy(SparseLengthsSumNode::IndicesIdx) ==
+            ElemKind::Int64ITy) &&
+           (NI.getInElemTy(SparseLengthsSumNode::LengthsIdx) ==
+            ElemKind::Int32ITy);
+
   case Kinded::Kind::SparseLengthsWeightedSumNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
                {ElemKind::FloatTy, ElemKind::Float16Ty, ElemKind::Int8QTy},

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -392,7 +392,11 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
 }
 
 bool Interpreter::shouldLower(const Node *N) const {
-  if (N->getKind() == Kinded::Kind::ConvolutionNodeKind)
+  switch (N->getKind()) {
+  case Kinded::Kind::ConvolutionNodeKind:
+  case Kinded::Kind::SparseLengthsSumNodeKind:
     return false;
-  return true;
+  default:
+    return true;
+  }
 }

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -238,6 +238,10 @@ private:
   template <typename ElemTy>
   void fwdGatherRangesInstImpl(const GatherRangesInst *I);
 
+  void fwdSparseLengthsSumInstI8Impl(const SparseLengthsSumInst *I);
+  template <typename ElemTy>
+  void fwdSparseLengthsSumInstFloatImpl(const SparseLengthsSumInst *I);
+
   void
   fwdSparseLengthsWeightedSumInstI8Impl(const SparseLengthsWeightedSumInst *I);
   template <typename ElemTy>

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -2342,7 +2342,6 @@ void BoundInterpreterFunction::fwdSparseLengthsSumInstI8Impl(
     return TensorQuantizationParams{T->getType().getScale(),
                                     T->getType().getOffset()};
   };
-  using namespace quantization;
 
   size_t curIdx = 0;
   for (size_t i = 0; i < segments; i++) {
@@ -2350,13 +2349,13 @@ void BoundInterpreterFunction::fwdSparseLengthsSumInstI8Impl(
     for (int32_t j = 0; j < LH.raw(i); j++) {
       size_t offsetIn = IH.raw(curIdx) * lineSize;
       for (size_t k = 0; k < lineSize; k++) {
-        accum[k] += dequantize(DH.raw(offsetIn++), TQP(data));
+        accum[k] += quantization::dequantize(DH.raw(offsetIn++), TQP(data));
       }
       curIdx++;
     }
     size_t offsetOut = i * lineSize;
     for (size_t k = 0; k < lineSize; k++) {
-      OH.raw(offsetOut++) = quantize(accum[k], TQP(out));
+      OH.raw(offsetOut++) = quantization::quantize(accum[k], TQP(out));
     }
   }
 }

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -253,7 +253,6 @@ void ExecutionEngine::compile(Function *F, CompilationContext &cctx,
          "A function with this name has already been compiled.");
 
   EXIT_ON_ERR(::glow::optimizeFunction(F, *backend_, cctx));
-
   for (const Node &N : F->getNodes()) {
     CHECK(backend_->isOpSupported(N))
         << "Backend must support all nodes after high-level optimizations but "

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1374,13 +1374,15 @@ LengthsSumNode *Function::createLengthsSum(llvm::StringRef name, NodeValue data,
   return addNode(new LengthsSumNode(name, outTy, data, lengths));
 }
 
-SparseLengthsWeightedSumNode *
-Function::createSparseLengthsSum(llvm::StringRef name, NodeValue data,
-                                 NodeValue indices, NodeValue lengths) {
-  auto ty =
-      getParent()->uniqueTypeWithNewShape(data.getType(), {indices.dims()[0]});
-  auto ones = createSplat(name.str() + ".ones", ty, 1.0);
-  return createSparseLengthsWeightedSum(name, data, ones, indices, lengths);
+SparseLengthsSumNode *Function::createSparseLengthsSum(llvm::StringRef name,
+                                                       NodeValue data,
+                                                       NodeValue indices,
+                                                       NodeValue lengths) {
+  auto inDims = data.dims();
+  ShapeVector outDims(inDims.begin(), inDims.end());
+  outDims[0] = lengths.dims()[0];
+  auto outTy = getParent()->uniqueTypeWithNewShape(data.getType(), outDims);
+  return addNode(new SparseLengthsSumNode(name, outTy, data, indices, lengths));
 }
 
 SparseLengthsWeightedSumNode *

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -376,8 +376,8 @@ static bool verifyRegression(NodeValue src, NodeValue dest,
          checkSameType(dest, expected, dest.getNode());
 }
 
-static bool verifySparseLengthsdSum(NodeValue dest, NodeValue data,
-                                    NodeValue indices, NodeValue lengths) {
+static bool verifySparseLengthsSum(NodeValue dest, NodeValue data,
+                                   NodeValue indices, NodeValue lengths) {
   bool isValid = checkType(dest, data.getElementType(), dest.getNode());
   isValid &= checkType(indices, ElemKind::Int64ITy, dest.getNode());
   isValid &= checkType(lengths, ElemKind::Int32ITy, dest.getNode());
@@ -935,8 +935,8 @@ bool BatchedReduceMeanNode::verify() const {
 }
 
 bool SparseLengthsSumNode::verify() const {
-  return verifySparseLengthsdSum(getResult(), getData(), getIndices(),
-                                 getLengths());
+  return verifySparseLengthsSum(getResult(), getData(), getIndices(),
+                                getLengths());
 }
 
 bool SparseLengthsWeightedSumNode::verify() const {

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -376,6 +376,20 @@ static bool verifyRegression(NodeValue src, NodeValue dest,
          checkSameType(dest, expected, dest.getNode());
 }
 
+static bool verifySparseLengthsdSum(NodeValue dest, NodeValue data,
+                                    NodeValue indices, NodeValue lengths) {
+  bool isValid = checkType(dest, data.getElementType(), dest.getNode());
+  isValid &= checkType(indices, ElemKind::Int64ITy, dest.getNode());
+  isValid &= checkType(lengths, ElemKind::Int32ITy, dest.getNode());
+  isValid &=
+      expectCompareTrue("Indices must be a 1D vector", indices.dims().size(),
+                        size_t(1), dest.getNode());
+  isValid &=
+      expectCompareTrue("Lengths must be a 1D vector", lengths.dims().size(),
+                        size_t(1), dest.getNode());
+  return isValid;
+}
+
 static bool verifySparseLengthsWeightedSum(NodeValue dest, NodeValue data,
                                            NodeValue weights, NodeValue indices,
                                            NodeValue lengths) {
@@ -918,6 +932,11 @@ bool BatchedReduceMeanNode::verify() const {
       expectCompareTrue("Invalid shape", getBatch().dims().size(), size_t(0),
                         this, CompareOperatorGreaterThan<size_t>());
   return isValid;
+}
+
+bool SparseLengthsSumNode::verify() const {
+  return verifySparseLengthsdSum(getResult(), getData(), getIndices(),
+                                 getLengths());
 }
 
 bool SparseLengthsWeightedSumNode::verify() const {

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -2231,6 +2231,24 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     break;
   }
 
+  case Kinded::Kind::SparseLengthsSumInstKind: {
+    auto *SI = cast<SparseLengthsSumInst>(I);
+    auto *dest = SI->getDest();
+    auto *data = SI->getData();
+    auto *indices = SI->getIndices();
+    auto *lengths = SI->getLengths();
+    auto *destPtr = emitValueAddress(builder, dest);
+    auto *dataPtr = emitValueAddress(builder, data);
+    auto *indicesPtr = emitValueAddress(builder, indices);
+    auto *lengthsPtr = emitValueAddress(builder, lengths);
+    auto *segments = emitConstSizeT(builder, lengths->dims()[0]);
+    auto *lineSize = emitConstSizeT(builder, data->size() / data->dims()[0]);
+    auto *F = getFunction("sparse_lengths_sum", dest->getElementType());
+    createCall(builder, F,
+               {destPtr, dataPtr, indicesPtr, lengthsPtr, segments, lineSize});
+    break;
+  }
+
   case Kinded::Kind::SparseLengthsWeightedSumInstKind: {
     auto *SI = cast<SparseLengthsWeightedSumInst>(I);
     auto *dest = SI->getDest();

--- a/tests/unittests/HabanaTest.cpp
+++ b/tests/unittests/HabanaTest.cpp
@@ -1237,7 +1237,7 @@ TEST_F(Habana, SparseLengthsSum) {
   synTensor sls1Inputs[] = {dataT, i1T, i11T, sbT};
   ns_SparseLengthsSum::Params sls1Params;
   sls1Params.mode = SEPARATE_SC_ZP;
-  synCreateGenericNode(sls1Inputs, &save1T, 4, 1, (void *)&sls1Params,
+  synCreateGenericNode(sls1Inputs, &save1T, 3, 1, (void *)&sls1Params,
                        "sparse_lengths_sum_f32", "sls1", nullptr, nullptr);
 
   // Compile graph.

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -1190,15 +1190,13 @@ TEST(onnx, importSparseLengthsSum) {
   // Verify structure: PH, PH ->  SparseLengthsSum -> Save -> PH.
   //                  PH -> Splat /
   ASSERT_EQ(mod.getPlaceholders().size(), 4);
-  ASSERT_EQ(F->getNodes().size(), 3);
+  ASSERT_EQ(F->getNodes().size(), 2);
   auto *save = getSaveNodeFromDest(output);
-  auto *LS =
-      llvm::dyn_cast<SparseLengthsWeightedSumNode>(save->getInput().getNode());
+  auto *LS = llvm::dyn_cast<SparseLengthsSumNode>(save->getInput().getNode());
   ASSERT_TRUE(LS);
   ASSERT_TRUE(llvm::isa<Placeholder>(LS->getData()));
   ASSERT_TRUE(llvm::isa<Placeholder>(LS->getIndices()));
   ASSERT_TRUE(llvm::isa<Placeholder>(LS->getLengths()));
-  ASSERT_TRUE(llvm::isa<SplatNode>(LS->getWeights()));
 }
 
 /// Test loading LengthsSum from an ONNX model.

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -5082,6 +5082,7 @@ TEST_P(OperatorTest, SparseLengthsSum) {
   };
 
   auto *R = F_->createSparseLengthsSum("SLS", data, indices, lengths);
+
   auto *S = F_->createSave("save", R);
   bindings_.allocate(S->getPlaceholder());
 

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -225,6 +225,18 @@ int main(int argc, char **argv) {
       .autoVerify(VerifyKind::SameElementType,
                   {"Lengths", "ElemKind::Int32ITy"});
 
+  BB.newInstr("SparseLengthsSum")
+      .addOperand("Dest", OperandKind::Out)
+      .addOperand("Data", OperandKind::In)
+      .addOperand("Indices", OperandKind::In)
+      .addOperand("Lengths", OperandKind::In)
+      .autoIRGen()
+      .autoVerify(VerifyKind::SameElementType, {"Dest", "Data"})
+      .autoVerify(VerifyKind::SameElementType,
+                  {"Indices", "ElemKind::Int64ITy"})
+      .autoVerify(VerifyKind::SameElementType,
+                  {"Lengths", "ElemKind::Int32ITy"});
+
   BB.newInstr("SparseLengthsWeightedSum")
       .addOperand("Dest", OperandKind::Out)
       .addOperand("Data", OperandKind::In)

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -374,6 +374,18 @@ int main(int argc, char **argv) {
                     "Lengths[1] slices are added together and stored in "
                     "Result[1], etc.");
 
+  BB.newNode("SparseLengthsSum")
+      .addInput("Data")
+      .addInput("Indices")
+      .addInput("Lengths")
+      .addResultFromCtorArg()
+      .setDocstring("Gathers slices of the outer-most dimension of Data "
+                    "indexed by Indices vector, and then accumulates them into "
+                    "len(Lengths) entries: first Lengths[0] slices are "
+                    "aggregated to Result[0], next Lengths[1] slices are "
+                    "aggregated to Result[1], etc. I.e. sum(Lengths) must be "
+                    "equal to len(Indices).");
+
   BB.newNode("SparseLengthsWeightedSum")
       .addInput("Data")
       .addInput("Weights")


### PR DESCRIPTION
Summary:
Currently SLS is implemented by creating a splat node for constant 1.0  weights and reducing to SLWS. Better performance could be achieved by avoiding the unnecessary weights.
work-in-progress on this stack:
- add Habana impl
- add OpenCL impl
- do the same for the fused operator (SparseLengthsSumFused8BitRowwise) 

update: OpenCL was not implemented, lowering to SLWS was enables instead.  SparseLengthsSumFused8BitRowwise will be added on a separate PR.

Test Plan:

[Optional Fixes #issue]

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
