### PR TITLE
[compilationContext][lower]: Change the second parameter of glow::lower() from LoweredInfoMap to CompilationContext

### DIFF
--- a/include/glow/Optimizer/Optimizer.h
+++ b/include/glow/Optimizer/Optimizer.h
@@ -43,12 +43,11 @@ void fold(Function *F, CompilationMode mode);
 /// Lower the high-level neural network nodes found in \p F into low-level
 /// linear algebra operators. If \p B is not a nullptr then it can prevent
 /// lowering of a node via \ref Backend::shouldLower(); otherwise everything
-/// will be lowered. If \p loweredMap is not a nullptr, then \p loweredMap will
-/// contain a mapping from output names of the nodes found and lowered in \p F
-/// to the output names of the nodes they were lowered from along with the
-/// NodeKind. \p doNotLowerKinds is a set of NodeKinds which represents all
-/// Nodes that should not be lowered.
-void lower(Function *F, LoweredInfoMap *loweredMap, const Backend *B = nullptr,
+/// will be lowered. \p cctx will contain a mapping of loweredMap from output
+/// names of the nodes found and lowered in \p F to the output names of the
+/// nodes they were lowered from along with the NodeKind. \p doNotLowerKinds is
+/// a set of NodeKinds which represents all Nodes that should not be lowered.
+void lower(Function *F, CompilationContext &cctx, const Backend *B = nullptr,
            const KindSet &doNotLowerKinds = {});
 
 /// Dead code elimination.

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -53,12 +53,12 @@ onnxStatus BackendId::checkGraphCompatibility(const void *onnxModel,
     return ONNXIFI_STATUS_INTERNAL_ERROR;
   }
 
-  glow::lower(function, /* loweredMap */ nullptr, glowBackend_.get());
+  CompilationContext cctx;
+  cctx.compMode = CompilationMode::Infer;
+  glow::lower(function, cctx, glowBackend_.get());
 
   // Call the backend's transformPostLowering to match the normal compilation
   // pipeline then DCE any nodes that are no longer needed.
-  CompilationContext cctx;
-  cctx.compMode = CompilationMode::Infer;
   if (glowBackend_->transformPostLowering(function, cctx)) {
     glow::DCE(function);
   }

--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -2789,11 +2789,11 @@ llvm::Error glow::optimizeFunction(Function *F, const Backend &B,
     // should be lowered. loweredInfoMap logs what is lowered from what for
     // later use when creating quantization infos. Also pass the precision mode
     // kind set as nodes to not lower, specified higher up in the stack.
-    ::glow::lower(F, cctx.loweredInfoMap, /* backend */ nullptr,
+    ::glow::lower(F, cctx, /* backend */ nullptr,
                   precConfig.precisionModeKindSet);
   } else {
     // Lower based on the backend's preferences.
-    ::glow::lower(F, cctx.loweredInfoMap, &B);
+    ::glow::lower(F, cctx, &B);
   }
 
   // Transform given precision mode; may quantize, convert to fp16, or

--- a/tests/unittests/GraphTest.cpp
+++ b/tests/unittests/GraphTest.cpp
@@ -89,7 +89,8 @@ TEST(Graph, simpleTestConv) {
   F->dump();
   auto filePath = F->dumpDAG();
   auto backend = MockBackend();
-  lower(F, /* loweredMap */ nullptr, &backend);
+  CompilationContext cctx;
+  lower(F, cctx, &backend);
   ::optimize(F, CompilationMode::Train);
   M.generateIR(backend);
   M.dump();
@@ -113,7 +114,8 @@ TEST(Graph, simpleTestConv3D) {
   F->dump();
   auto filePath = F->dumpDAG();
   auto backend = MockBackend();
-  lower(F, /* loweredMap */ nullptr, &backend);
+  CompilationContext cctx;
+  lower(F, cctx, &backend);
   ::optimize(F, CompilationMode::Train);
   M.generateIR(backend);
   M.dump();
@@ -138,7 +140,8 @@ TEST(Graph, simpleTestConvCustomLower) {
   F->dump();
   auto filePath = F->dumpDAG();
   auto backend = MockBackendCustomIRGen();
-  lower(F, /* loweredMap */ nullptr, &backend);
+  CompilationContext cctx;
+  lower(F, cctx, &backend);
   ::optimize(F, CompilationMode::Train);
   M.generateIR(MockBackendCustomIRGen());
   M.dump();
@@ -170,7 +173,8 @@ TEST(Graph, float16Conv) {
   EXPECT_EQ(conv->getBias().getElementType(), ElemKind::Float16Ty);
 
   auto backend = MockBackend();
-  lower(F, /* loweredMap */ nullptr, &backend);
+  CompilationContext cctx;
+  lower(F, cctx, &backend);
 
   IRFunction M(F);
 
@@ -203,7 +207,8 @@ TEST(Graph, float16Conv3D) {
   EXPECT_EQ(conv->getBias().getElementType(), ElemKind::Float16Ty);
 
   auto backend = MockBackend();
-  lower(F, /* loweredMap */ nullptr, &backend);
+  CompilationContext cctx;
+  lower(F, cctx, &backend);
 
   IRFunction M(F);
 
@@ -238,7 +243,8 @@ TEST(Graph, float16BatchNorm) {
   EXPECT_EQ(BN->getVar().getElementType(), ElemKind::Float16Ty);
 
   auto backend = MockBackend();
-  lower(F, /* loweredMap */ nullptr, &backend);
+  CompilationContext cctx;
+  lower(F, cctx, &backend);
 
   EXPECT_TRUE(std::all_of(
       F->getNodes().begin(), F->getNodes().end(), [](const Node &node) -> bool {
@@ -376,7 +382,8 @@ TEST(Graph, simpleTestFC) {
   F->dump();
   auto filePath = F->dumpDAG();
   auto backend = MockBackend();
-  lower(F, /* loweredMap */ nullptr, &backend);
+  CompilationContext cctx;
+  lower(F, cctx, &backend);
   ::optimize(F, CompilationMode::Train);
   M.generateIR(backend);
   M.dump();
@@ -672,7 +679,8 @@ unsigned getConvNodeSize(BackendKind kind) {
   F->createSave("save", CN);
 
   std::unique_ptr<Backend> backend(createBackend(kind));
-  lower(F, /* loweredMap */ nullptr, backend.get());
+  CompilationContext cctx;
+  lower(F, cctx, backend.get());
 
   unsigned count = 0;
   for (auto &n : F->getNodes()) {
@@ -1611,7 +1619,8 @@ TEST(Graph, GroupTestConvNoLower) {
   // Now lower, but prevent ConvolutionNodeKinds from being lowered.
   KindSet doNotLower;
   doNotLower.insert(Kinded::Kind::ConvolutionNodeKind);
-  lower(F, /* loweredMap */ nullptr, &backend, doNotLower);
+  CompilationContext cctx;
+  lower(F, cctx, &backend, doNotLower);
 
   {
     // Now have lowered but should still have a single Conv node with group = 8.

--- a/tests/unittests/ProvisionerTest.cpp
+++ b/tests/unittests/ProvisionerTest.cpp
@@ -32,7 +32,8 @@ std::unique_ptr<Module> setupModule(unsigned functionCount) {
     auto *B = mod->createConstant(ElemKind::FloatTy, {1024}, "B");
     auto *FC = F->createFullyConnected("FC", X, W, B);
     F->createSave("save", FC);
-    lower(F, nullptr);
+    CompilationContext cctx;
+    lower(F, cctx);
   }
   return mod;
 }

--- a/tests/unittests/QuantizationTest.cpp
+++ b/tests/unittests/QuantizationTest.cpp
@@ -369,7 +369,8 @@ TEST(Quantization, enableRowwiseQuantizedFullyConnected) {
   bindings.allocate(S->getPlaceholder());
 
   LoweredInfoMap loweredMapForQuant;
-  ::glow::lower(F, &loweredMapForQuant, EE.getBackend());
+  CompilationContext cctx(/* bindings */ nullptr, &loweredMapForQuant);
+  ::glow::lower(F, cctx, EE.getBackend());
 
   // Get the MatMul node and the Batched_Add node.
   Node *matMul, *batchedAdd;
@@ -463,7 +464,8 @@ TEST(Quantization, enableRowwiseQuantizedFullyConnectedSymmetric) {
   EXPECT_EQ(biasTQP.offset, 0);
 
   LoweredInfoMap loweredMapForQuant;
-  ::glow::lower(F, &loweredMapForQuant, EE.getBackend());
+  CompilationContext cctx(/* bindings */ nullptr, &loweredMapForQuant);
+  ::glow::lower(F, cctx, EE.getBackend());
 
   // Get the MatMul node and the Batched_Add node.
   Node *matMul, *batchedAdd;
@@ -1977,7 +1979,8 @@ static void testProfileQuantizationOfFC(bool expectLoweredFC,
   // Lower everything and keep track of the lowered components source nodes via
   // the loweredMap.
   LoweredInfoMap loweredMapForProf;
-  lower(profileF, &loweredMapForProf);
+  CompilationContext cctx(/* bindings */ nullptr, &loweredMapForProf);
+  lower(profileF, cctx);
 
   // Check that the lowered graph only contains the lowered components of the
   // FC (MM and BA) and not the FC itself.
@@ -2041,7 +2044,8 @@ static void testProfileQuantizationOfFC(bool expectLoweredFC,
 
   // Lower the function given the backend's preferences for lowering.
   LoweredInfoMap loweredMapForQuant;
-  lower(backendF, &loweredMapForQuant, backendEE.getBackend());
+  CompilationContext cctx2(/* bindings */ nullptr, &loweredMapForQuant);
+  lower(backendF, cctx2, backendEE.getBackend());
 
   // Check that the backend lowered the function as expected.
   auto *floatFC = findNodeKindOrReturnNull<FullyConnectedNode>(backendF);


### PR DESCRIPTION
Summary:
I modified the parameter of glow::lower() to take compilation context instead of loweredInfoMap.
- We need to be able to access compilation context through the glow::lower() method to all the lowering methods that lower() calls, where we want to produce the log using the functionality of CompilationContext::LogContext.

Test Plan:
Test with all Glow tests