### PR TITLE
Remove most instances GLOW_UNREACHABLE

### DIFF
--- a/include/glow/Backend/Backend.h
+++ b/include/glow/Backend/Backend.h
@@ -77,7 +77,7 @@ public:
   /// files with this name.
   virtual void save(Function *F, llvm::StringRef outputDir,
                     llvm::StringRef networkName) const {
-    GLOW_UNREACHABLE("Saving a bundle is not supported by the backend");
+    LOG(FATAL) << "Saving a bundle is not supported by the backend";
   }
 
   /// Used by the compiler during graph optimization and before code generation,

--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -23,6 +23,8 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 
+#include <glog/logging.h>
+
 #include <cstddef>
 #include <cstdint>
 #include <type_traits>
@@ -472,7 +474,7 @@ struct Type final {
     case ElemKind::BoolTy:
       return std::is_same<ElemTy, bool>::value;
     }
-    GLOW_UNREACHABLE("Invalid type.");
+    LOG(FATAL) << "Invalid type: " << getElementName(Ty).str();
   }
 
   /// \returns true if the type of this Tensor is one of the quantized types.
@@ -515,7 +517,7 @@ struct Type final {
     case ElemKind::BoolTy:
       return sizeof(bool);
     }
-    GLOW_UNREACHABLE("Invalid type.");
+    LOG(FATAL) << "Invalid type: " << getElementName(Ty).str();
   }
 
   /// \return the textual name of the element.

--- a/lib/Backend/Backend.cpp
+++ b/lib/Backend/Backend.cpp
@@ -40,7 +40,7 @@ TraceInfo Backend::buildManualTraceInfo(Function *F) const {
 
 void Backend::autoInstrument(TraceInfo &traceInfo, IRFunction *IR) const {
   if (getTraceEventDataSize() == 0) {
-    GLOW_UNREACHABLE("Auto instrumentation not supported on this backend");
+    LOG(ERROR) << "Auto instrumentation not supported on this backend";
     return;
   }
 

--- a/lib/Backends/DeviceManagers.cpp
+++ b/lib/Backends/DeviceManagers.cpp
@@ -40,7 +40,7 @@ createCPUDeviceManager(std::unique_ptr<DeviceConfig> config = nullptr);
 DeviceManager *
 createCPUDeviceManager(std::unique_ptr<DeviceConfig> config = nullptr) {
   (void)config;
-  GLOW_UNREACHABLE("Must compile with CPU support");
+  LOG(FATAL) << "Must compile with CPU support";
 }
 #endif
 
@@ -52,7 +52,7 @@ createOCLDeviceManager(std::unique_ptr<DeviceConfig> config = nullptr);
 DeviceManager *
 createOCLDeviceManager(std::unique_ptr<DeviceConfig> config = nullptr) {
   (void)config;
-  GLOW_UNREACHABLE("Must compile with OpenCL support");
+  LOG(FATAL) << "Must compile with OpenCL support";
 }
 #endif
 
@@ -63,7 +63,7 @@ createHabanaDeviceManager(std::unique_ptr<DeviceConfig> config = nullptr);
 DeviceManager *
 createHabanaDeviceManager(std::unique_ptr<DeviceConfig> config = nullptr) {
   (void)config;
-  GLOW_UNREACHABLE("Must compile with Habana support");
+  LOG(FATAL) << "Must compile with Habana support";
 }
 #endif
 } // namespace runtime
@@ -86,7 +86,7 @@ DeviceManager::createDeviceManager(BackendKind backendKind,
     // DummyDeviceManager here, but this is not threadsafe and very simplistic.
     // Strongly recommended that you create a DeviceManager customized for your
     // device.
-    llvm::errs() << "Warning: Creating a DummyDeviceManager.\n";
+    LOG(ERROR) << "Warning: Creating a DummyDeviceManager.\n";
     return new DummyDeviceManager(backendKind, std::move(config));
   }
 

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -255,11 +255,10 @@ void ExecutionEngine::compile(Function *F, CompilationContext &cctx,
   EXIT_ON_ERR(::glow::optimizeFunction(F, *backend_, cctx));
 
   for (const Node &N : F->getNodes()) {
-    if (!backend_->isOpSupported(N)) {
-      llvm::errs() << "Unsupported operator: " << N.getDebugDesc() << "\n";
-      GLOW_UNREACHABLE(
-          "Backend must support all nodes after high-level optimizations.");
-    }
+    CHECK(backend_->isOpSupported(N))
+        << "Backend must support all nodes after high-level optimizations but "
+           "encountered unsupported operator: "
+        << N.getDebugDesc();
   }
 
   auto func = backend_->compile(F, cctx.backendOpts);

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -1210,7 +1210,7 @@ llvm::Error Caffe2ModelLoader::loadWeight(const caffe2::OperatorDef &op) {
       RETURN_IF_ERR(
           fillTensor<int64_t>(T, ElemKind::Int64ITy, dim, values->ints()));
     } else {
-      GLOW_UNREACHABLE("Unhandled GivenTensorFill type");
+      RETURN_ERR(strFormat("Unhandled tensor fill type: %s", typeName.c_str()));
     }
     RETURN_IF_ERR(createAndRegisterConstant(op.output().Get(0), std::move(T)));
     return llvm::Error::success();

--- a/lib/LLVMIRCodeGen/DebugInfo.cpp
+++ b/lib/LLVMIRCodeGen/DebugInfo.cpp
@@ -355,7 +355,7 @@ void LLVMIRGen::emitDebugGlobalVariableForValue(const Value *val) {
     memoryAreaKind = MemoryAreaKind::MutableWeightsMemoryArea;
     break;
   default:
-    GLOW_UNREACHABLE("Unknown memory area kind");
+    LOG(FATAL) << "Unknown memory area kind";
   }
   }
 

--- a/lib/LLVMIRCodeGen/LLVMCompiledFunction.cpp
+++ b/lib/LLVMIRCodeGen/LLVMCompiledFunction.cpp
@@ -94,7 +94,7 @@ llvm::Error LLVMCompiledFunction::execute(ExecutionContext *context) {
   auto *traceContext = context->getTraceContext();
   TRACE_EVENT_SCOPE_NAMED(traceContext, "findJitmainSymbol", fjEvent);
   auto sym = JIT_->findSymbol("jitmain");
-  assert(sym && "Unable to JIT the code!");
+  DCHECK(sym) << "Unable to JIT the code!";
   using JitFuncType =
       void (*)(uint8_t * constantWeightVars, uint8_t * mutableWeightVars,
                uint8_t * activations);
@@ -106,7 +106,7 @@ llvm::Error LLVMCompiledFunction::execute(ExecutionContext *context) {
     funcPtr(runtimeBundle_.getConstants(), baseMutableWeightVarsAddress,
             baseActivationsAddress);
   } else {
-    GLOW_UNREACHABLE("Error getting address");
+    RETURN_ERR("Error getting address");
   }
 
   {
@@ -148,7 +148,8 @@ void LLVMCompiledFunction::translateTraceEvents(
   int tid = TraceEvent::getThreadId();
   for (auto &backing : traceInfo.events) {
     Tensor *backingTensor = bindings->get(backing.first);
-    assert(backingTensor);
+    DCHECK(backingTensor) << "Could not get backing tensor for Placeholder: "
+                          << backing.first->getName().str();
 
     auto &traceEvents = traceContext->getTraceEvents();
     for (const TraceInfo::Event &event : backing.second) {

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -533,7 +533,8 @@ llvm::Function *LLVMIRGen::getFunction(const std::string &name,
   case ElemKind::BoolTy:
     return get("libjit_" + name + "_b");
   default:
-    GLOW_UNREACHABLE("Unsupported element type");
+    LOG(FATAL) << "Unsupported element type: "
+               << Type::getElementName(elemTy).str();
   }
 }
 
@@ -1018,7 +1019,7 @@ void LLVMIRGen::generateLLVMIRForDataParallelInstr(
       destAddr = builder.CreateGEP(builder.getInt32Ty(), destPtr, loopCount,
                                    "buffer.element.addr");
     } else {
-      GLOW_UNREACHABLE("Type is not supported.");
+      LOG(FATAL) << "Type is not supported";
     }
 
     builder.CreateStore(stackedOpCall, destAddr);
@@ -1325,12 +1326,10 @@ void LLVMIRGen::generateLLVMIRForDataParallelInstr(
   }
 
   default:
-#ifndef NDEBUG
-    llvm::errs() << "Cannot select the instruction:\n";
-    I->dump(llvm::errs());
-    llvm::errs() << "\n";
-#endif
-    GLOW_UNREACHABLE("ERROR: Cannot select the instruction.");
+    std::string sBuf;
+    llvm::raw_string_ostream s(sBuf);
+    I->dump(s);
+    LOG(FATAL) << "Cannot select the instruction: " << s.str();
   }
 }
 
@@ -1550,7 +1549,8 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
       } else if (sliceTy->getElementType() == ElemKind::Int32QTy) {
         F = getFunction("batchedadd_i32", dest->getElementType());
       } else {
-        GLOW_UNREACHABLE("Type is not supported.");
+        LOG(FATAL) << "Type is not supported: "
+                   << Type::getElementName(sliceTy->getElementType()).str();
       }
       createCall(builder, F,
                  {destPtr, batchPtr, slicePtr, numSlice, sliceSize, destOffset,
@@ -2382,12 +2382,10 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
   }
 
   default:
-#ifndef NDEBUG
-    llvm::errs() << "Cannot select the instruction:\n";
-    I->dump(llvm::errs());
-    llvm::errs() << "\n";
-#endif
-    GLOW_UNREACHABLE("ERROR: Cannot select the instruction.");
+    std::string sBuf;
+    llvm::raw_string_ostream s(sBuf);
+    I->dump(s);
+    LOG(FATAL) << "Cannot select the instruction: " << s.str();
   }
 }
 

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -339,12 +339,12 @@ protected:
 
     // Quantizer may be set up to die if a node is only skipped during
     // quantization because the backend does not support it as quantized.
-    if (!isOpSupported && assertAllNodesQuantized_) {
-      llvm::errs() << B_.getBackendName()
-                   << " Backend does not support node as quantized in "
-                   << Type::getElementName(quantizationPrecision_) << ":\n"
-                   << node.getDebugDesc();
-      GLOW_UNREACHABLE("Quantizer failed on converting some node.");
+    if (assertAllNodesQuantized_) {
+      CHECK(isOpSupported) << B_.getBackendName()
+                           << " Backend does not support node as quantized in "
+                           << Type::getElementName(quantizationPrecision_).str()
+                           << ":\n"
+                           << node.getDebugDesc();
     }
 
     return isOpSupported;

--- a/tests/unittests/RecommendationSystemTest.cpp
+++ b/tests/unittests/RecommendationSystemTest.cpp
@@ -165,7 +165,7 @@ protected:
       break;
     }
     default:
-      GLOW_UNREACHABLE("unsupported type");
+      LOG(FATAL) << "Unsupported type: " << type->getElementName().str();
     }
 
     return c;

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -277,7 +277,7 @@ static Kinded::Kind getKindFromNodeName(llvm::StringRef nodeName) {
     return Kinded::Kind::CLASS##Kind;                                          \
   }
 #include "glow/AutoGenNodes.def"
-  GLOW_UNREACHABLE("Unknown node name.");
+  LOG(FATAL) << "Unknown node name: " << nodeName.str();
 }
 
 /// Helper to get the BackendKind type from a backend's \p name. Need to be
@@ -288,9 +288,8 @@ static BackendKind getBackendKindFromName(std::string &name) {
        {"Interpreter", BackendKind::Interpreter},
        {"OpenCL", BackendKind::OpenCL},
        {"Habana", BackendKind::Habana}});
-  if (mapping.find(name) == mapping.end()) {
-    GLOW_UNREACHABLE("Unknown backendKind name.");
-  }
+  CHECK(mapping.find(name) != mapping.end())
+      << "Unknown backendKind name: " << name;
   return mapping.lookup(name);
 }
 

--- a/tools/loader/ModelRunner.cpp
+++ b/tools/loader/ModelRunner.cpp
@@ -66,7 +66,7 @@ int main(int argc, char **argv) {
       outputT->getHandle<int8_t>().dump();
       break;
     default:
-      GLOW_UNREACHABLE("Unexpected output type");
+      LOG(FATAL) << "Unexpected output type";
     }
 
     // If profiling, generate and serialize the quantization infos now that we


### PR DESCRIPTION
Summary:
Remove all of the easy to remove `GLOW_UNREACHABLE`. The remaining instances of `GLOW_UNREACHABLE` should be handled using llvm::Errors but aren't yet in a context where an llvm::Error can be returned

Documentation:
none

Test Plan:
CI