### PR TITLE
[PlaceholderBindings] Add DCHECK to insert to check that types match

### DIFF
--- a/lib/Graph/PlaceholderBindings.cpp
+++ b/lib/Graph/PlaceholderBindings.cpp
@@ -78,6 +78,10 @@ PlaceholderBindings::getPlaceholderByName(llvm::StringRef name) const {
 }
 
 void PlaceholderBindings::insert(Placeholder *P, Tensor &&T) {
+  DCHECK(T.getType().isEqual(*P->getType()))
+      << "Placeholder " << P->getName().str() << " has type "
+      << P->getType()->toString() << " but Tensor has type "
+      << T.getType().toString() << "\n";
   DCHECK(!map_.count(P)) << "Placeholder with name \"" << P->getName().str()
                          << "\" already registered";
   // Take ownership over the tensor.


### PR DESCRIPTION
**Description**
This commit adds a debug-mode check to `PlaceholderBindings::insert`
that checks that the types of the `Placeholder` and `Tensor` passed to
the method match. It is currently possible to bind a `Placeholder`
to any `Tensor` and that seems like a recipe for disaster. It will still
be possible after this commit, but will crash if the project is built in
Debug mode.

**Test Plan**
All unit tests pass.