### PR TITLE
Loading ConstantOfShape ONNX operator as Glow Splat operator

### DIFF
--- a/include/glow/Importer/ONNXModelLoader.h
+++ b/include/glow/Importer/ONNXModelLoader.h
@@ -128,6 +128,10 @@ class ONNXModelLoader
   llvm::Error loadSpaceToDepth(const ONNX_NAMESPACE::NodeProto &op,
                                const ArgumentDictionaryTy &dict);
 
+  /// Load ConstantOfShape ONNX operator.
+  llvm::Error loadConstantOfShape(const ONNX_NAMESPACE::NodeProto &op,
+                                  const ArgumentDictionaryTy &dict);
+
 protected:
   /// Load the network operators from the GraphProto.
   /// \returns Error if network cannot be loaded.

--- a/tests/models/onnxModels/constantOfShape.onnxtxt
+++ b/tests/models/onnxModels/constantOfShape.onnxtxt
@@ -1,0 +1,58 @@
+ir_version: 3
+producer_name: "backend-test"
+graph {
+  node {
+    input: "input"
+    output: "output"
+    op_type: "ConstantOfShape"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 1
+        name: "value_init"
+        raw_data: "\000\000\200\077"
+      }
+      type: TENSOR
+    }
+  }
+  initializer {
+    dims: 2
+    data_type: 7
+    int64_data: 3
+    int64_data: 3
+    name: "input"
+  }
+  input {
+    name: "input"
+    type {
+      tensor_type {
+        elem_type: 7
+        shape {
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "output"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 9
+}

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -1273,6 +1273,24 @@ TEST(onnx, constant) {
   ASSERT_EQ(F->getNodes().size(), 1);
 }
 
+/// Test loading ConstantOfShape from an ONNX model.
+TEST(onnx, constantOfShape) {
+  ExecutionEngine EE;
+  auto &mod = EE.getModule();
+  auto *F = mod.createFunction("main");
+  std::string netFilename(GLOW_DATA_PATH
+                          "tests/models/onnxModels/constantOfShape.onnxtxt");
+  Placeholder *output;
+  {
+    ONNXModelLoader onnxLD(netFilename, {}, {}, *F);
+    output = EXIT_ON_ERR(onnxLD.getSingleOutput());
+    EXPECT_NE(output, nullptr);
+  }
+  // ConstantOfShape -> Save -> PH
+  ASSERT_EQ(mod.getPlaceholders().size(), 1);
+  ASSERT_EQ(F->getNodes().size(), 2);
+}
+
 /// Test loading ExpandDims from an ONNX model.
 TEST(onnx, expandDims) {
   ExecutionEngine EE;


### PR DESCRIPTION
Summary: Glow loaders load ConstantOfShape operator supported by Caffe2 and ONNX as Glow Splat operator with restrictions supporying only float type.

Differential Revision: D15614377

