### PR TITLE
NFC: Initialize input/output placeholders in HabanaFunction ctor

### DIFF
--- a/lib/Backends/Habana/Habana.h
+++ b/lib/Backends/Habana/Habana.h
@@ -193,8 +193,7 @@ class HabanaFunction final : public CompiledFunction {
 public:
   /// Constructor.
   HabanaFunction(const runtime::RuntimeBundle &bundle,
-                 const std::string &recipeName, PlaceholderList &&inputs,
-                 PlaceholderList &&outputs);
+                 const std::string &recipeName, Function *F);
 
   /// @name CompiledFunction interface
   ///@{
@@ -215,7 +214,9 @@ public:
   const PlaceholderList &getOutputs() const { return outputs_; }
 
 private:
-  Function *F_;
+  /// Build the list of input and output placeholders.
+  void findIOPlaceholders(Function *F);
+
   std::string recipeName_;
   PlaceholderList inputs_;
   PlaceholderList outputs_;


### PR DESCRIPTION
Summary:
Doing it this way avoids std::move-ing around the PlaceholderLists
(and sets up an optimization to appear in another diff).

Differential Revision: D15641299

