### PR TITLE
Fix output constant name for loadShape()

### DIFF
--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -245,7 +245,6 @@ protected:
   }
 
   llvm::Error loadShape(const OpType &op, ArgumentDictionaryTy &dict) {
-    const std::string &opName = loadOperatorName(op);
     NodeValue in;
     ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
 
@@ -254,7 +253,7 @@ protected:
     T.getHandle<int64_t>() =
         std::vector<int64_t>(in.dims().begin(), in.dims().end());
 
-    RETURN_IF_ERR(createAndRegisterConstant(opName, std::move(T)));
+    RETURN_IF_ERR(createAndRegisterConstant(op.output(0), std::move(T)));
 
     return llvm::Error::success();
   }

--- a/tests/models/onnxModels/shape.onnxtxt
+++ b/tests/models/onnxModels/shape.onnxtxt
@@ -1,0 +1,56 @@
+ir_version: 3
+producer_name: "test4glow"
+opset_import {
+  version: 7
+}
+
+graph {
+  node {
+    input: "input"
+    output: "shape_out"
+    name: "s1"
+    op_type: "Shape"
+  }
+  node {
+    input: "shape_out"
+    output: "output"
+    name: "s2"
+    op_type: "Shape"
+  }
+  name: "test-model"
+  input {
+    name: "input"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "output"
+    type {
+      tensor_type {
+        elem_type: 7
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -1657,3 +1657,37 @@ TEST(onnx, autoLoadInputs) {
   EXPECT_EQ(inputs.size(), 1);
   EXPECT_TRUE(inputTensor.getType().isEqual(inputs[inputName]->getType()));
 }
+
+TEST(onnx, shape) {
+  ExecutionEngine EE{BackendKind::Interpreter};
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+
+  std::string netFilename(GLOW_DATA_PATH
+                          "tests/models/onnxModels/shape.onnxtxt");
+
+  PlaceholderBindings bindings;
+  Placeholder *output;
+  {
+    Tensor x(ElemKind::FloatTy, {2, 2, 2, 2});
+    x.getHandle() = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+
+    ONNXModelLoader onnxLD(netFilename, {"input"}, {&x.getType()}, *F);
+    output = EXIT_ON_ERR(onnxLD.getSingleOutput());
+    bindings.allocate(mod.getPlaceholders());
+    updateInputPlaceholdersByName(bindings, &mod, {"input"}, {&x});
+  }
+
+  auto *res = bindings.get(output);
+  EE.compile(CompilationMode::Infer, F);
+  EE.run(bindings);
+
+  auto result = res->getHandle<int64_t>();
+  std::vector<size_t> expectedDims = {1};
+  std::vector<int64_t> expectedValues = {4};
+
+  EXPECT_TRUE(result.dims().vec() == expectedDims);
+  for (size_t i = 0; i < expectedValues.size(); i++) {
+    EXPECT_EQ(result.raw(i), expectedValues[i]);
+  }
+}


### PR DESCRIPTION
Summary:
LoadShape is using wrong name for the value it produces. It should have the
output name, not the producing node name.

Test Plan:
Added ONNX loader test

Fixes #2828

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
