### PR TITLE
[Partitioner] Handle more than one outputs for a single node when calculating the memory usage.

### DIFF
--- a/include/glow/Partitioner/PartitionerUtils.h
+++ b/include/glow/Partitioner/PartitionerUtils.h
@@ -33,12 +33,23 @@ struct GraphMemInfo {
   uint64_t constMemSize;
 
   GraphMemInfo() : inMemSize(0), outMemSize(0), constMemSize(0){};
+  GraphMemInfo(uint64_t inMem, uint64_t outMem, uint64_t constMem)
+      : inMemSize(inMem), outMemSize(outMem), constMemSize(constMem){};
 
   // Get the total memory size of each partition.
   uint64_t getTotalMemSize() const {
     return inMemSize + outMemSize + constMemSize;
   }
+
+  bool equals(const GraphMemInfo &other) const {
+    return inMemSize == other.inMemSize && outMemSize == other.outMemSize &&
+           constMemSize == other.constMemSize;
+  }
 };
+
+inline bool operator==(const GraphMemInfo &LHS, const GraphMemInfo &RHS) {
+  return LHS.equals(RHS);
+}
 
 /// A list of <nodelist> with BFS order.
 using BFSLevel = std::vector<std::vector<Node *>>;

--- a/lib/Partitioner/Partitioner.cpp
+++ b/lib/Partitioner/Partitioner.cpp
@@ -228,8 +228,8 @@ void Partitioner::initOpComputeTime(Function *F) {
     }
 
     // Repeat for outputs
-    if (node.getNumResults() > 0) {
-      auto myty = node.getType(0);
+    for (size_t i = 0, e = node.getNumResults(); i < e; i++) {
+      auto myty = node.getType(i);
       uint64_t sizeOutput = myty->getSizeInBytes();
       if (sizeOutput > sramCapacity) {
         sizeDram += sizeOutput;


### PR DESCRIPTION
Summary:
This PR fixed the issue described in #2885.  

Documentation:

Fixes #2885

Test Plan:
Added unittest. Ninja test. ./tests/image/run.sh

