### PR TITLE
[Backends/1] Minimal setup for registering backend based on its name.

### DIFF
--- a/include/glow/Backend/Backend.h
+++ b/include/glow/Backend/Backend.h
@@ -160,11 +160,13 @@ public:
 };
 
 /// Perform Backend Factory registration.
-#define REGISTER_GLOW_BACKEND_FACTORY(FactoryName, BackendClass, BackendName)  \
+#define REGISTER_GLOW_BACKEND_FACTORY(FactoryName, BackendClass)               \
   class FactoryName : public BaseFactory<std::string, Backend> {               \
   public:                                                                      \
     Backend *create() override { return new BackendClass(); }                  \
-    std::string getRegistrationKey() const override { return BackendName; }    \
+    std::string getRegistrationKey() const override {                          \
+      return BackendClass::getName();                                          \
+    }                                                                          \
   };                                                                           \
   static RegisterFactory<std::string, FactoryName, Backend>                    \
       FactoryName##_REGISTERED;

--- a/include/glow/Backend/Backend.h
+++ b/include/glow/Backend/Backend.h
@@ -38,6 +38,21 @@ enum class BackendKind {
   Habana,      // Compile and run the code on a Habana accelerator.
 };
 
+/// Stop gap measure while migrating from BackendKind to backend names.
+/// TODO: Remove this after migration.
+inline std::string BackendKindToString(BackendKind kind) {
+  switch (kind) {
+  case BackendKind::Interpreter:
+    return "Interpreter";
+  case BackendKind::OpenCL:
+    return "OpenCL";
+  case BackendKind::CPU:
+    return "CPU";
+  case BackendKind::Habana:
+    return "Habana";
+  }
+}
+
 // This is the interface that glow backends need to implement.
 class Backend {
 public:
@@ -128,7 +143,11 @@ protected:
 };
 
 /// Create a backend of kind \p kind.
+/// Deprecated. Moving gradualy to the createBackend based on the backend name.
 Backend *createBackend(BackendKind backendKind);
+
+/// Create a backend based on the registered backend name \p backendName.
+Backend *createBackend(llvm::StringRef backendName);
 
 // Backends that use Glow low-level IR should inherit from this class. It allows
 // for unit tests to create low-level IR to compile and run.
@@ -141,16 +160,13 @@ public:
 };
 
 /// Perform Backend Factory registration.
-#define REGISTER_GLOW_BACKEND_FACTORY(FactoryName, BackendClass,               \
-                                      SpecificBackendKind)                     \
-  class FactoryName : public BaseFactory<BackendKind, Backend> {               \
+#define REGISTER_GLOW_BACKEND_FACTORY(FactoryName, BackendClass, BackendName)  \
+  class FactoryName : public BaseFactory<std::string, Backend> {               \
   public:                                                                      \
     Backend *create() override { return new BackendClass(); }                  \
-    BackendKind getRegistrationKey() const override {                          \
-      return BackendKind::SpecificBackendKind;                                 \
-    }                                                                          \
+    std::string getRegistrationKey() const override { return BackendName; }    \
   };                                                                           \
-  static RegisterFactory<BackendKind, FactoryName, Backend>                    \
+  static RegisterFactory<std::string, FactoryName, Backend>                    \
       FactoryName##_REGISTERED;
 
 } // namespace glow

--- a/lib/Backends/Backends.cpp
+++ b/lib/Backends/Backends.cpp
@@ -19,8 +19,14 @@
 namespace glow {
 
 Backend *createBackend(BackendKind backendKind) {
-  auto *backend = FactoryRegistry<BackendKind, Backend>::get(backendKind);
-  CHECK(backend) << "Cannot find registered backend";
+  const std::string &backendName = BackendKindToString(backendKind);
+  return createBackend(backendName);
+}
+
+Backend *createBackend(llvm::StringRef backendName) {
+  auto *backend = FactoryRegistry<std::string, Backend>::get(backendName);
+  CHECK(backend) << strFormat("Cannot find registered backend: %s",
+                              backendName.data());
   return backend;
 }
 

--- a/lib/Backends/CPU/CPUBackend.h
+++ b/lib/Backends/CPU/CPUBackend.h
@@ -37,7 +37,8 @@ public:
   BackendKind getBackendKind() const override { return BackendKind::CPU; }
   virtual ~CPUBackend() override = default;
 
-  std::string getBackendName() const override { return "CPU"; }
+  std::string getBackendName() const override { return getName(); }
+  static std::string getName() { return "CPU"; }
 
   bool transformPostLowering(Function *F,
                              CompilationContext &cctx) const override;

--- a/lib/Backends/CPU/CPUFactory.cpp
+++ b/lib/Backends/CPU/CPUFactory.cpp
@@ -18,6 +18,6 @@
 
 namespace glow {
 
-REGISTER_GLOW_BACKEND_FACTORY(CPUFactory, CPUBackend, CPU);
+REGISTER_GLOW_BACKEND_FACTORY(CPUFactory, CPUBackend, "CPU");
 
 } // namespace glow

--- a/lib/Backends/CPU/CPUFactory.cpp
+++ b/lib/Backends/CPU/CPUFactory.cpp
@@ -18,6 +18,6 @@
 
 namespace glow {
 
-REGISTER_GLOW_BACKEND_FACTORY(CPUFactory, CPUBackend, "CPU");
+REGISTER_GLOW_BACKEND_FACTORY(CPUFactory, CPUBackend);
 
 } // namespace glow

--- a/lib/Backends/Habana/Habana.h
+++ b/lib/Backends/Habana/Habana.h
@@ -234,7 +234,8 @@ public:
 
   BackendKind getBackendKind() const override { return BackendKind::Habana; }
 
-  std::string getBackendName() const override { return "Habana"; }
+  std::string getBackendName() const override { return getName(); }
+  static std::string getName() { return "Habana"; }
 
   llvm::Expected<std::unique_ptr<CompiledFunction>>
   compile(Function *F, const BackendOptions &opts) const override;

--- a/lib/Backends/Habana/HabanaFactory.cpp
+++ b/lib/Backends/Habana/HabanaFactory.cpp
@@ -18,6 +18,6 @@
 
 namespace glow {
 
-REGISTER_GLOW_BACKEND_FACTORY(HabanaFactory, HabanaBackend, "Habana");
+REGISTER_GLOW_BACKEND_FACTORY(HabanaFactory, HabanaBackend);
 
 } // namespace glow

--- a/lib/Backends/Habana/HabanaFactory.cpp
+++ b/lib/Backends/Habana/HabanaFactory.cpp
@@ -18,6 +18,6 @@
 
 namespace glow {
 
-REGISTER_GLOW_BACKEND_FACTORY(HabanaFactory, HabanaBackend, Habana);
+REGISTER_GLOW_BACKEND_FACTORY(HabanaFactory, HabanaBackend, "Habana");
 
 } // namespace glow

--- a/lib/Backends/Interpreter/Interpreter.h
+++ b/lib/Backends/Interpreter/Interpreter.h
@@ -38,7 +38,8 @@ public:
     return BackendKind::Interpreter;
   }
 
-  std::string getBackendName() const override { return "Interpreter"; }
+  std::string getBackendName() const override { return getName(); }
+  static std::string getName() { return "Interpreter"; }
 
   std::unique_ptr<CompiledFunction>
   compileIR(std::unique_ptr<IRFunction> IR) const override;

--- a/lib/Backends/Interpreter/InterpreterFactory.cpp
+++ b/lib/Backends/Interpreter/InterpreterFactory.cpp
@@ -18,6 +18,6 @@
 
 namespace glow {
 
-REGISTER_GLOW_BACKEND_FACTORY(InterpreterFactory, Interpreter, Interpreter);
+REGISTER_GLOW_BACKEND_FACTORY(InterpreterFactory, Interpreter, "Interpreter");
 
 } // namespace glow

--- a/lib/Backends/Interpreter/InterpreterFactory.cpp
+++ b/lib/Backends/Interpreter/InterpreterFactory.cpp
@@ -18,6 +18,6 @@
 
 namespace glow {
 
-REGISTER_GLOW_BACKEND_FACTORY(InterpreterFactory, Interpreter, "Interpreter");
+REGISTER_GLOW_BACKEND_FACTORY(InterpreterFactory, Interpreter);
 
 } // namespace glow

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -193,7 +193,8 @@ public:
 
   BackendKind getBackendKind() const override { return BackendKind::OpenCL; }
 
-  std::string getBackendName() const override { return "OpenCL"; }
+  std::string getBackendName() const override { return getName(); }
+  static std::string getName() { return "OpenCL"; }
 
   std::unique_ptr<CompiledFunction>
   compileIR(std::unique_ptr<IRFunction> IR) const override;

--- a/lib/Backends/OpenCL/OpenCLFactory.cpp
+++ b/lib/Backends/OpenCL/OpenCLFactory.cpp
@@ -18,6 +18,6 @@
 
 namespace glow {
 
-REGISTER_GLOW_BACKEND_FACTORY(OpenCLFactory, OCLBackend, OpenCL);
+REGISTER_GLOW_BACKEND_FACTORY(OpenCLFactory, OCLBackend, "OpenCL");
 
 } // namespace glow

--- a/lib/Backends/OpenCL/OpenCLFactory.cpp
+++ b/lib/Backends/OpenCL/OpenCLFactory.cpp
@@ -18,6 +18,6 @@
 
 namespace glow {
 
-REGISTER_GLOW_BACKEND_FACTORY(OpenCLFactory, OCLBackend, "OpenCL");
+REGISTER_GLOW_BACKEND_FACTORY(OpenCLFactory, OCLBackend);
 
 } // namespace glow


### PR DESCRIPTION
Summary:
First step in backend registration based on the names.

* Register backend based on the string name
* Minimal changes to use createBackend(llvm::StringRef backendName) on a caller side. There will be gradual migration from the BackendKind to backendName version in following PRs.

Documentation:
n/a

Test Plan:
CI

cc: @gcatron 
