### PR TITLE
[DeviceConfig] Make device config non optional in device manager.

### DIFF
--- a/examples/tracing-compare.cpp
+++ b/examples/tracing-compare.cpp
@@ -113,7 +113,8 @@ int main(int argc, char **argv) {
 
   std::array<DeviceManager *, supportedBackends.size()> devices;
   for (unsigned i = 0, e = supportedBackends.size(); i < e; ++i) {
-    devices[i] = DeviceManager::createDeviceManager(supportedBackends[i]);
+    devices[i] =
+        DeviceManager::createDeviceManager(DeviceConfig(supportedBackends[i]));
     EXIT_ON_ERR(devices[i]->init());
   }
 

--- a/include/glow/Backends/DeviceManager.h
+++ b/include/glow/Backends/DeviceManager.h
@@ -48,19 +48,15 @@ protected:
   BackendKind backend_;
 
   /// Configuration object for the device.
-  std::unique_ptr<DeviceConfig> config_;
+  DeviceConfig config_;
 
 public:
-  DeviceManager(BackendKind backend,
-                std::unique_ptr<DeviceConfig> config = nullptr)
-      : backend_(backend), config_(std::move(config)) {}
+  DeviceManager(const DeviceConfig &config)
+      : backend_(config.backendKind), config_(config) {}
   virtual ~DeviceManager() {}
 
-  /// Create a device of the type /p backend, with the backend specific
-  /// name/addres /p name.
-  static DeviceManager *
-  createDeviceManager(BackendKind backend,
-                      std::unique_ptr<DeviceConfig> config = nullptr);
+  /// Create a device manager based on the device config \p config.
+  static DeviceManager *createDeviceManager(const DeviceConfig &config);
 
   /// Initialize the device.
   virtual llvm::Error init() { return llvm::Error::success(); }
@@ -109,7 +105,7 @@ public:
   virtual bool isMemoryAvailable(uint64_t estimate) const = 0;
 
   /// \returns the DeviceConfig which initialized this device.
-  const DeviceConfig *getDeviceConfig() { return config_.get(); }
+  const DeviceConfig &getDeviceConfig() { return config_; }
 };
 
 } // namespace runtime

--- a/include/glow/Backends/DummyDeviceManager.h
+++ b/include/glow/Backends/DummyDeviceManager.h
@@ -32,9 +32,7 @@ class DummyDeviceManager : public DeviceManager {
   FunctionMapTy functions_;
 
 public:
-  DummyDeviceManager(BackendKind backend,
-                     std::unique_ptr<DeviceConfig> config = nullptr)
-      : DeviceManager(backend, std::move(config)) {}
+  DummyDeviceManager(const DeviceConfig &config) : DeviceManager(config) {}
 
   /// The DummyDeviceManager is a simple wrapper for testing, if you need
   /// memory guards you should implement a DeviceManager for your device.

--- a/include/glow/Backends/QueueBackedDeviceManager.h
+++ b/include/glow/Backends/QueueBackedDeviceManager.h
@@ -33,9 +33,8 @@ protected:
   std::atomic<RunIdentifierTy> nextIdentifier_{1};
 
 public:
-  QueueBackedDeviceManager(BackendKind backend,
-                           std::unique_ptr<DeviceConfig> config)
-      : DeviceManager(backend, std::move(config)), workThread_(1) {}
+  QueueBackedDeviceManager(const DeviceConfig &config)
+      : DeviceManager(config), workThread_(1) {}
 
   virtual ~QueueBackedDeviceManager() {
     llvm::toString(stop(true)); // will join workThread_

--- a/lib/Backends/CPU/CPUDeviceManager.cpp
+++ b/lib/Backends/CPU/CPUDeviceManager.cpp
@@ -29,13 +29,12 @@ static llvm::cl::opt<unsigned, /* ExternalStorage */ true> GlowCPUMemoryOpt(
     llvm::cl::desc("CPU DeviceManager maximum memory in kilobytes."),
     llvm::cl::location(GlowCPUMemory));
 
-DeviceManager *createCPUDeviceManager(std::unique_ptr<DeviceConfig> config) {
+DeviceManager *createCPUDeviceManager(const DeviceConfig &config) {
   if (GlowCPUMemory) {
     // Convert command line GlowCPUMemory to bytes from kilobytes.
-    return new CPUDeviceManager(std::move(config),
-                                uint64_t{GlowCPUMemory} * 1024);
+    return new CPUDeviceManager(config, uint64_t{GlowCPUMemory} * 1024);
   }
-  return new CPUDeviceManager(std::move(config));
+  return new CPUDeviceManager(config);
 }
 
 uint64_t CPUDeviceManager::getMaximumMemory() const { return maxMemoryBytes_; }

--- a/lib/Backends/CPU/CPUDeviceManager.h
+++ b/lib/Backends/CPU/CPUDeviceManager.h
@@ -40,10 +40,8 @@ class CPUDeviceManager : public QueueBackedDeviceManager {
   const uint64_t functionCost_{1};
 
 public:
-  CPUDeviceManager(std::unique_ptr<DeviceConfig> config = nullptr,
-                   size_t maxMemory = 2000000000)
-      : QueueBackedDeviceManager(BackendKind::CPU, std::move(config)),
-        maxMemoryBytes_(maxMemory) {}
+  CPUDeviceManager(const DeviceConfig &config, size_t maxMemory = 2000000000)
+      : QueueBackedDeviceManager(config), maxMemoryBytes_(maxMemory) {}
 
   /// Returns the amount of memory in bytes available on the device when no
   /// models are loaded.

--- a/lib/Backends/DeviceManagers.cpp
+++ b/lib/Backends/DeviceManagers.cpp
@@ -29,16 +29,13 @@ namespace runtime {
 /// when you define a new DeviceManager.
 
 /// Create a new instance of the interpreter Device.
-DeviceManager *
-createInterpreterDeviceManager(std::unique_ptr<DeviceConfig> config = nullptr);
+DeviceManager *createInterpreterDeviceManager(const DeviceConfig &config);
 
 #if defined(GLOW_WITH_CPU)
 /// Create a new instance of the CPUBackend DeviceManager.
-DeviceManager *
-createCPUDeviceManager(std::unique_ptr<DeviceConfig> config = nullptr);
+DeviceManager *createCPUDeviceManager(const DeviceConfig &config);
 #else
-DeviceManager *
-createCPUDeviceManager(std::unique_ptr<DeviceConfig> config = nullptr) {
+DeviceManager *createCPUDeviceManager(const DeviceConfig &config) {
   (void)config;
   LOG(FATAL) << "Must compile with CPU support";
 }
@@ -46,22 +43,18 @@ createCPUDeviceManager(std::unique_ptr<DeviceConfig> config = nullptr) {
 
 #if defined(GLOW_WITH_OPENCL)
 /// Create a new instance of the OpenCL backend.
-DeviceManager *
-createOCLDeviceManager(std::unique_ptr<DeviceConfig> config = nullptr);
+DeviceManager *createOCLDeviceManager(const DeviceConfig &config);
 #else
-DeviceManager *
-createOCLDeviceManager(std::unique_ptr<DeviceConfig> config = nullptr) {
+DeviceManager *createOCLDeviceManager(const DeviceConfig &config) {
   (void)config;
   LOG(FATAL) << "Must compile with OpenCL support";
 }
 #endif
 
 #if defined(GLOW_WITH_HABANA)
-DeviceManager *
-createHabanaDeviceManager(std::unique_ptr<DeviceConfig> config = nullptr);
+DeviceManager *createHabanaDeviceManager(const DeviceConfig &config);
 #else
-DeviceManager *
-createHabanaDeviceManager(std::unique_ptr<DeviceConfig> config = nullptr) {
+DeviceManager *createHabanaDeviceManager(const DeviceConfig &config) {
   (void)config;
   LOG(FATAL) << "Must compile with Habana support";
 }
@@ -69,25 +62,23 @@ createHabanaDeviceManager(std::unique_ptr<DeviceConfig> config = nullptr) {
 } // namespace runtime
 } // namespace glow
 
-DeviceManager *
-DeviceManager::createDeviceManager(BackendKind backendKind,
-                                   std::unique_ptr<DeviceConfig> config) {
-  switch (backendKind) {
+DeviceManager *DeviceManager::createDeviceManager(const DeviceConfig &config) {
+  switch (config.backendKind) {
   case BackendKind::Interpreter:
-    return createInterpreterDeviceManager(std::move(config));
+    return createInterpreterDeviceManager(config);
   case BackendKind::OpenCL:
-    return createOCLDeviceManager(std::move(config));
+    return createOCLDeviceManager(config);
   case BackendKind::CPU:
-    return createCPUDeviceManager(std::move(config));
+    return createCPUDeviceManager(config);
   case BackendKind::Habana:
-    return createHabanaDeviceManager(std::move(config));
+    return createHabanaDeviceManager(config);
   default:
     // As a fallback to make developing new Backends easier we'll create a
     // DummyDeviceManager here, but this is not threadsafe and very simplistic.
     // Strongly recommended that you create a DeviceManager customized for your
     // device.
     LOG(ERROR) << "Warning: Creating a DummyDeviceManager.\n";
-    return new DummyDeviceManager(backendKind, std::move(config));
+    return new DummyDeviceManager(config);
   }
 
   // This is to make compiler happy. It can never reach this point as switch

--- a/lib/Backends/Habana/HabanaDeviceManager.cpp
+++ b/lib/Backends/Habana/HabanaDeviceManager.cpp
@@ -42,9 +42,8 @@ static llvm::cl::opt<unsigned, /* ExternalStorage */ true> GlowHabanaMemoryOpt(
 #define chk(X) GLOW_ASSERT((X) == synSuccess)
 
 /// Factory function for creating a HabanaDeviceManager.
-DeviceManager *
-createHabanaDeviceManager(std::unique_ptr<DeviceConfig> config = nullptr) {
-  return new HabanaDeviceManager(std::move(config));
+DeviceManager *createHabanaDeviceManager(const DeviceConfig &config) {
+  return new HabanaDeviceManager(config);
 }
 } // namespace runtime
 } // namespace glow
@@ -54,11 +53,10 @@ unsigned HabanaDeviceManager::numActiveDevices_{0};
 std::mutex HabanaDeviceManager::synapseMtx_;
 std::atomic<RunIdentifierTy> HabanaDeviceManager::runIdentifier_;
 
-HabanaDeviceManager::HabanaDeviceManager(std::unique_ptr<DeviceConfig> config,
+HabanaDeviceManager::HabanaDeviceManager(const DeviceConfig &config,
                                          unsigned numRunners,
                                          unsigned numWaiters)
-    : DeviceManager(BackendKind::Habana, std::move(config)),
-      numRunners_(numRunners), numWaiters_(numWaiters) {}
+    : DeviceManager(config), numRunners_(numRunners), numWaiters_(numWaiters) {}
 
 HabanaDeviceManager::~HabanaDeviceManager() {
   // If a device was never successfully acquired, there's nothing to clean up.

--- a/lib/Backends/Habana/HabanaDeviceManager.h
+++ b/lib/Backends/Habana/HabanaDeviceManager.h
@@ -112,7 +112,7 @@ class HabanaDeviceManager : public DeviceManager {
 
 public:
   /// Constructor.
-  HabanaDeviceManager(std::unique_ptr<DeviceConfig> config = nullptr,
+  HabanaDeviceManager(const DeviceConfig &config,
                       unsigned numRunners = kNumRunners,
                       unsigned numWaiters = kNumWaiters);
 

--- a/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
@@ -29,14 +29,13 @@ llvm::cl::opt<unsigned> interpreterMaxMem(
 namespace glow {
 namespace runtime {
 
-DeviceManager *
-createInterpreterDeviceManager(std::unique_ptr<DeviceConfig> config) {
+DeviceManager *createInterpreterDeviceManager(const DeviceConfig &config) {
   if (interpreterMaxMem) {
     // Convert command line interpreterMaxMem to bytes from kilobytes.
-    return new InterpreterDeviceManager(std::move(config),
+    return new InterpreterDeviceManager(config,
                                         uint64_t{interpreterMaxMem} * 1024);
   }
-  return new InterpreterDeviceManager(std::move(config));
+  return new InterpreterDeviceManager(config);
 }
 
 uint64_t InterpreterDeviceManager::getMaximumMemory() const {

--- a/lib/Backends/Interpreter/InterpreterDeviceManager.h
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.h
@@ -40,10 +40,9 @@ class InterpreterDeviceManager : public QueueBackedDeviceManager {
   const uint64_t functionCost_{1};
 
 public:
-  InterpreterDeviceManager(std::unique_ptr<DeviceConfig> config = nullptr,
+  InterpreterDeviceManager(const DeviceConfig &config,
                            size_t maxMemory = 2000000000)
-      : QueueBackedDeviceManager(BackendKind::Interpreter, std::move(config)),
-        maxMemoryBytes_(maxMemory) {}
+      : QueueBackedDeviceManager(config), maxMemoryBytes_(maxMemory) {}
 
   /// Returns the amount of memory in bytes available on the device when no
   /// models are loaded.

--- a/lib/Backends/OpenCL/OpenCLDeviceManager.h
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.h
@@ -91,7 +91,7 @@ class OpenCLDeviceManager : public QueueBackedDeviceManager {
   std::string name_;
 
 public:
-  OpenCLDeviceManager(std::unique_ptr<DeviceConfig> config = nullptr);
+  OpenCLDeviceManager(const DeviceConfig &config);
 
   ~OpenCLDeviceManager();
 

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -55,7 +55,7 @@ void ExecutionEngine::setBackend(Backend *backend, bool ownsBackend) {
     if (backend) {
       device_ = std::unique_ptr<runtime::DeviceManager>(
           runtime::DeviceManager::createDeviceManager(
-              backend->getBackendKind()));
+              runtime::DeviceConfig(backend->getBackendKind())));
       EXIT_ON_ERR(device_->init());
     }
   }

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -45,9 +45,8 @@ HostManager::init(std::vector<std::unique_ptr<DeviceConfig>> configs) {
       config->name = "config" + std::to_string(deviceCount);
     }
 
-    auto backendKind = config->backendKind;
     devices_[deviceCount] = std::unique_ptr<DeviceManager>(
-        DeviceManager::createDeviceManager(backendKind, std::move(config)));
+        DeviceManager::createDeviceManager(*config));
 
     RETURN_IF_ERR(devices_[deviceCount]->init());
 

--- a/tests/benchmark/RuntimeBench.cpp
+++ b/tests/benchmark/RuntimeBench.cpp
@@ -109,7 +109,8 @@ void setUpDeviceManagerCommon(
 
   // Create and initialize the DeviceManager instance.
   deviceManager = std::unique_ptr<DeviceManager>(
-      DeviceManager::createDeviceManager(backend->getBackendKind()));
+      DeviceManager::createDeviceManager(
+        DeviceConfig(backend->getBackendKind())));
   bool error = errToBool(deviceManager->init());
 
   if (error) {

--- a/tests/unittests/DeviceManagerTest.cpp
+++ b/tests/unittests/DeviceManagerTest.cpp
@@ -33,7 +33,7 @@ class DeviceManagerTest : public ::testing::TestWithParam<BackendKind> {
 public:
   void SetUp() override {
     backendKind = GetParam();
-    device.reset(DeviceManager::createDeviceManager(backendKind));
+    device.reset(DeviceManager::createDeviceManager(DeviceConfig(backendKind)));
     ASSERT_TRUE(device.get());
     ASSERT_FALSE(errToBool(device->init()));
   }
@@ -555,7 +555,7 @@ TEST(DeviceManagerTest, AvailableMemory) {
   std::vector<std::unique_ptr<CompiledFunction>> backing;
   std::promise<const Module *> promise;
   std::future<const Module *> future;
-  CPUDeviceManager cpuCoreDevice(nullptr, 1);
+  CPUDeviceManager cpuCoreDevice(DeviceConfig(BackendKind::CPU), 1);
   ASSERT_FALSE(errToBool(cpuCoreDevice.init()));
 
   uint64_t expectedBytes = 1;
@@ -627,7 +627,7 @@ TEST(DeviceManagerTest, AvailableMemory) {
 }
 
 TEST(DeviceManagerTest, DummyDeviceManager) {
-  DummyDeviceManager deviceManager(BackendKind::Interpreter);
+  DummyDeviceManager deviceManager{DeviceConfig(BackendKind::Interpreter)};
   ASSERT_FALSE(errToBool(deviceManager.init()));
 
   auto module = makeBasicModule();

--- a/tests/unittests/ExecutorTest.cpp
+++ b/tests/unittests/ExecutorTest.cpp
@@ -37,8 +37,8 @@ using namespace glow::runtime;
 /// to satisfy the compiler.
 class TestDeviceManager final : public runtime::DeviceManager {
 public:
-  TestDeviceManager(unsigned numWorkers)
-      : DeviceManager(BackendKind::Interpreter), threadPool_(numWorkers) {}
+  TestDeviceManager(unsigned numWorkers, const DeviceConfig &deviceConfig)
+      : DeviceManager(deviceConfig), threadPool_(numWorkers) {}
 
   /// The functions below are the interface for DeviceManager. See
   /// glow::DeviceManager for descriptions of what they do. Since this
@@ -673,8 +673,8 @@ TEST_F(ThreadPoolExecutorTest, SingleNode) {
   // Make a TestDeviceManager and insert into the DeviceManagerMap map (which
   // the ThreadPoolExecutor has a reference to) and the TestDeviceManager map
   // (which the ExecutorTestBuilder has a reference to).
-  auto deviceManager =
-      llvm::make_unique<TestDeviceManager>(deviceManagerThreads);
+  auto deviceManager = llvm::make_unique<TestDeviceManager>(
+      deviceManagerThreads, DeviceConfig(BackendKind::Interpreter));
   deviceManagerMap_.emplace(testDeviceId, std::move(deviceManager));
 
   // Build the DAG. The DAG created below looks like this:
@@ -703,8 +703,8 @@ TEST_F(ThreadPoolExecutorTest, ConcurrentSingleNode) {
   // Make a TestDeviceManager and insert into the DeviceManagerMap map (which
   // the ThreadPoolExecutor has a reference to) and the TestDeviceManager map
   // (which the ExecutorTestBuilder has a reference to).
-  auto deviceManager =
-      llvm::make_unique<TestDeviceManager>(deviceManagerThreads);
+  auto deviceManager = llvm::make_unique<TestDeviceManager>(
+      deviceManagerThreads, DeviceConfig(BackendKind::Interpreter));
   deviceManagerMap_.emplace(testDeviceId, std::move(deviceManager));
 
   // Mutex for accessing threadsReady and testsPassed.
@@ -792,8 +792,8 @@ TEST_F(ThreadPoolExecutorTest, ConcurrentSingleNodeDuplicateRunId) {
   // Make a TestDeviceManager and insert into the DeviceManagerMap map (which
   // the ThreadPoolExecutor has a reference to) and the TestDeviceManager map
   // (which the ExecutorTestBuilder has a reference to).
-  auto deviceManager =
-      llvm::make_unique<TestDeviceManager>(deviceManagerThreads);
+  auto deviceManager = llvm::make_unique<TestDeviceManager>(
+      deviceManagerThreads, DeviceConfig(BackendKind::Interpreter));
   deviceManagerMap_.emplace(testDeviceId, std::move(deviceManager));
 
   std::atomic<unsigned> testsPassed{0};
@@ -846,8 +846,8 @@ TEST_F(ThreadPoolExecutorTest, MultiNode) {
   // Make a TestDeviceManager and insert into the DeviceManagerMap map (which
   // the ThreadPoolExecutor has a reference to) and the TestDeviceManager map
   // (which the ExecutorTestBuilder has a reference to).
-  auto deviceManager =
-      llvm::make_unique<TestDeviceManager>(deviceManagerThreads);
+  auto deviceManager = llvm::make_unique<TestDeviceManager>(
+      deviceManagerThreads, DeviceConfig(BackendKind::Interpreter));
   deviceManagerMap_.emplace(testDeviceId, std::move(deviceManager));
 
   // Build the DAG. The DAG created below looks like this:
@@ -894,8 +894,8 @@ TEST_F(ThreadPoolExecutorTest, MultiNodeWithFailure) {
   // Make a TestDeviceManager and insert into the DeviceManagerMap map (which
   // the ThreadPoolExecutor has a reference to) and the TestDeviceManager map
   // (which the ExecutorTestBuilder has a reference to).
-  auto deviceManager =
-      llvm::make_unique<TestDeviceManager>(deviceManagerThreads);
+  auto deviceManager = llvm::make_unique<TestDeviceManager>(
+      deviceManagerThreads, DeviceConfig(BackendKind::Interpreter));
   deviceManagerMap_.emplace(testDeviceId, std::move(deviceManager));
 
   // Build the DAG. The DAG created below looks like this:
@@ -949,8 +949,8 @@ TEST_F(ThreadPoolExecutorTest, MultiNodeMultiDevice) {
   // (which the ThreadPoolExecutor has a reference to) and the TestDeviceManager
   // map (which the ExecutorTestBuilder has a reference to).
   for (DeviceIDTy deviceId : {testDeviceIdA, testDeviceIdB, testDeviceIdC}) {
-    auto deviceManager =
-        llvm::make_unique<TestDeviceManager>(deviceManagerThreads);
+    auto deviceManager = llvm::make_unique<TestDeviceManager>(
+        deviceManagerThreads, DeviceConfig(BackendKind::Interpreter));
     deviceManagerMap_.emplace(deviceId, std::move(deviceManager));
   }
 
@@ -1000,8 +1000,8 @@ TEST_F(ThreadPoolExecutorTest, ConcurrentMultiNode) {
   // Make a TestDeviceManager and insert it into the DeviceManagerMap map
   // (which the ThreadPoolExecutor has a reference to) and the TestDeviceManager
   // map (which the ExecutorTestBuilder has a reference to).
-  auto deviceManager =
-      llvm::make_unique<TestDeviceManager>(deviceManagerThreads);
+  auto deviceManager = llvm::make_unique<TestDeviceManager>(
+      deviceManagerThreads, DeviceConfig(BackendKind::Interpreter));
   deviceManagerMap_.emplace(testDeviceId, std::move(deviceManager));
 
   // Mutex for accessing threadsReady and testsPassed.

--- a/tests/unittests/HabanaBackendTest.cpp
+++ b/tests/unittests/HabanaBackendTest.cpp
@@ -1462,7 +1462,8 @@ TEST_F(HabanaBackendTest, SingleFunctionMultiThreadMultiDevice) {
   std::vector<std::unique_ptr<DeviceManager>> deviceManagers;
 
   for (unsigned i = 0; i < maxDeviceManagers; ++i) {
-    DeviceManager *deviceManager = new glow::runtime::HabanaDeviceManager();
+    DeviceManager *deviceManager = new glow::runtime::HabanaDeviceManager(
+        runtime::DeviceConfig(BackendKind::Habana));
 
     if (deviceManager->init()) {
       delete deviceManager;

--- a/tests/unittests/ProvisionerTest.cpp
+++ b/tests/unittests/ProvisionerTest.cpp
@@ -72,7 +72,8 @@ TEST_F(ProvisionerTest, provisionDag) {
 
   DeviceManagerMapTy devices;
   for (int i = 0; i < 6; i++) {
-    std::unique_ptr<DeviceManager> device(new CPUDeviceManager);
+    std::unique_ptr<DeviceManager> device(
+        new CPUDeviceManager(DeviceConfig(BackendKind::CPU)));
     devices.emplace(i, std::move(device));
   }
   auto provisioner = Provisioner(devices);
@@ -87,7 +88,8 @@ TEST_F(ProvisionerTest, provisionDagFail) {
 
   DeviceManagerMapTy devices;
   for (int i = 0; i < 6; i++) {
-    std::unique_ptr<DeviceManager> device(new CPUDeviceManager(nullptr, 1000));
+    std::unique_ptr<DeviceManager> device(
+        new CPUDeviceManager(DeviceConfig(BackendKind::CPU), 1000));
     devices.emplace(i, std::move(device));
   }
   auto provisioner = Provisioner(devices);


### PR DESCRIPTION
Summary:
* Make deviceConfig non optional.
* @superwizard2019 is adding deviceMemory to the config and it's super confusing to pass deviceConfig which could be null, memory as part of the config and memory in a separate arg.
* Do not need to pass backendKind and config in the same time, get rid of backendKind.

Following PR for deviceMemory: https://github.com/pytorch/glow/pull/2959

Documentation:
n/a

Test Plan:
CI
