### PR TITLE
[tests] Fix out-of-bounds access in RecSysTest

### DIFF
--- a/tests/unittests/RecommendationSystemTest.cpp
+++ b/tests/unittests/RecommendationSystemTest.cpp
@@ -412,7 +412,7 @@ protected:
                                  "weight_indices" + std::to_string(i), false);
       fillStableRandomIndex(
           bindings_.allocate(weightIndices)->getHandle<int32_t>(), 2001, 0,
-          sum - 1);
+          weights_size - 1);
 
       auto *weights = F_->createGather("weight_gather" + std::to_string(i),
                                        weightsConst, weightIndices, 0);


### PR DESCRIPTION
Summary: We were generating gather indices based on the size of the indices tensor itself rather than the size of the weights tensor we were gathering from.

Fixes #3026

Test Plan:
Running the test 10x without this diff usually segfaults; with this diff I've run >50 times.
```
ninja RecommendationSystemTest && ./tests/RecommendationSystemTest --gtest_filter=RecSys/RecommendationSystemTest.RecSys_FP32_Gather_Weights/0 --gtest_repeat=50
```

