### PR TITLE
[DO NOT MERGE][WIP] GLOW: Introduce early constant folding on model load

### DIFF
--- a/include/glow/Graph/ConstantFolding.h
+++ b/include/glow/Graph/ConstantFolding.h
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2019-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_GRAPH_CONSTANT_FOLDING_H
+#define GLOW_GRAPH_CONSTANT_FOLDING_H
+
+#include "glow/Base/Tensor.h"
+#include "glow/Base/Type.h"
+
+namespace glow {
+
+template <typename ElemTy>
+void constantFoldGather(Tensor *outT, const Tensor *dataT,
+                        const Tensor *indicesT, const unsigned_t batchDims) {
+  auto &dataTy = dataT->getType();
+
+  size_t out_p = 0;
+  unsigned elementSize = dataTy.getElementSize();
+  // The size of the sample in the batch.
+  size_t dataSampleSize = dataTy.getSliceSize(batchDims) * elementSize;
+  // The size of the slices that we gather.
+  size_t dataSliceSize = dataTy.getSliceSize(batchDims + 1) * elementSize;
+
+  // Calculate the size of each sample in the batch.
+  size_t numSamples = (dataT->size() * elementSize) / dataSampleSize;
+
+  // Calculate number of samples in the batch.
+  size_t batchSize = dataTy.dims()[batchDims];
+  (void)batchSize;
+
+  // For each sample in the batch:
+  for (size_t sample = 0; sample < numSamples; sample++) {
+    size_t sampleStart = sample * dataSampleSize;
+
+    // For each slice (small fragment) that we copy from the source memory:
+    for (size_t i = 0, end = indicesT->size(); i < end; i++) {
+      size_t slice = indicesT->getHandle<ElemTy>().raw(i);
+      assert(slice < batchSize && "Invalid index seen during Gather operation");
+      std::copy(
+          &dataT->getUnsafePtr()[sampleStart + dataSliceSize * slice],
+          &dataT->getUnsafePtr()[sampleStart + dataSliceSize * (slice + 1)],
+          &outT->getUnsafePtr()[out_p]);
+      out_p += dataSliceSize;
+    }
+  }
+}
+
+} // namespace glow
+
+#endif // GLOW_GRAPH_CONSTANT_FOLDING_H

--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -952,8 +952,14 @@ protected:
       batchDims = axis;
     }
 
-    Node *GN = G_.createGather(loadOperatorName(op), data, indices, batchDims);
-    RETURN_IF_ERR(addNodeAsOutput(op, GN));
+    GatherNode *GN =
+        G_.createGather(loadOperatorName(op), data, indices, batchDims);
+    if (GN->isConstantFoldable()) {
+      Tensor CF = GN->constantFold();
+      RETURN_IF_ERR(createAndRegisterConstant(op.output(0), std::move(CF)));
+    } else {
+      RETURN_IF_ERR(addNodeAsOutput(op, GN));
+    }
     return llvm::Error::success();
   }
 

--- a/tests/models/onnxModels/gatherConstantFolding.onnxtxt
+++ b/tests/models/onnxModels/gatherConstantFolding.onnxtxt
@@ -1,0 +1,92 @@
+ir_version: 5
+producer_name: "onnx-example"
+graph {
+  node {
+    input: "input"
+    output: "shape_x"
+    op_type: "Shape"
+  }
+  node {
+    output: "indices"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 4
+        data_type: 7
+        int64_data: 0
+        int64_data: 2
+        int64_data: 3
+        int64_data: 1
+        name: "const_tensor"
+      }
+      type: TENSOR
+    }
+  }
+  node {
+    input: "shape_x"
+    input: "indices"
+    output: "gather"
+    op_type: "Gather"
+    attribute {
+      name: "axis"
+      i: 0
+      type: INT
+    }
+  }
+  node {
+    input: "input"
+    input: "gather"
+    output: "result"
+    op_type: "Reshape"
+  }
+  name: "test-model"
+  input {
+    name: "input"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "result"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 10
+}
+

--- a/tools/ClassGen/NodeBuilder.h
+++ b/tools/ClassGen/NodeBuilder.h
@@ -147,6 +147,8 @@ class NodeBuilder {
   bool hasSideEffects_{false};
   /// Specifies if this Node is backend specific.
   bool isBackendSpecific_{false};
+  /// There is a rule to constant-fold this node.
+  bool hasConstantFolding_{false};
 
 public:
   NodeBuilder(std::ofstream &H, std::ofstream &C, std::ofstream &D,
@@ -226,6 +228,11 @@ public:
                      "input of a node");
   }
 
+  NodeBuilder &addConstantFolding() {
+    hasConstantFolding_ = true;
+    return *this;
+  }
+
   /// Constructs a new gradient node that is based on the current node that we
   /// are building. The gradient node will produce one gradient output for each
   /// input. The rule is that each output becomes an input (named "Output", to
@@ -254,6 +261,9 @@ private:
 
   /// Emit setters/getters for each accessible class member.
   void emitSettersGetters(std::ostream &os) const;
+
+  /// Emit constant folding check and implementation function.
+  void emitConstantFolding(std::ostream &os) const;
 
   /// Emit getters for input/output names and input nodes.
   void emitEdges(std::ostream &os) const;

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -578,6 +578,7 @@ int main(int argc, char **argv) {
       .addInput("Indices")
       .addMember(MemberType::Unsigned, "BatchDims")
       .addResultFromCtorArg()
+      .addConstantFolding()
       .setDocstring("Gathers entries of the outer-most dimension of Data "
                     "indexed by Indices, and concatenates them. Output tensor "
                     "will have dimensions: {I_0, I_1, ... I_n, D_1, D_2, ... "


### PR DESCRIPTION
Summary:
This patch creates infrastructure that allows to constant-fold nodes early of
load, if their inputs are all constant, rather than leave it up to backend to
deal with them later. By doing so, we reduce the size of graph and enable more
models, because some nodes require that some of their inputs are constants.

Theoretically, Constant Folding can be done for all nodes. But this API allows
to implement it for particular nodes only. Two reasons for that:
- We can implement constant-folding incrementally and not make huge changes in
  code;
- We might not want to evalutate some of the nodes on load because of
  performance reasons.

This patch introduces constant folding for Gather node.
We can then add the constant folding to the nodes one by one as we need it.

[Optional Fixes #issue]

Test Plan:
Added unit test.
