### PR TITLE
[trivial] Fix weak ordering compare in PartitonerTests

### DIFF
--- a/lib/Partitioner/Partitioner.cpp
+++ b/lib/Partitioner/Partitioner.cpp
@@ -30,7 +30,7 @@ using llvm::isa;
 // max.
 bool sortMinMemory(const std::pair<Function *, uint64_t> &a,
                    const std::pair<Function *, uint64_t> &b) {
-  return a.second <= b.second;
+  return a.second < b.second;
 }
 
 /// Check if the memory of \p node inputs is calculated already. \returns the


### PR DESCRIPTION
Summary: Inside FB we are very strict about sort ordering, as weak orderings result in non stable sorts. Fix the partitioners DAGNode sorter to be strongly ordered.

Documentation: n/a
Test Plan: ran PartitionerTest inside & outside of fbcode.