### PR TITLE
[runtime] propagate backendOpts to provisioner

### DIFF
--- a/examples/resnet-runtime.cpp
+++ b/examples/resnet-runtime.cpp
@@ -62,6 +62,12 @@ llvm::cl::opt<BackendKind> backend(
                      clEnumValN(BackendKind::Habana, "habana", "Use Habana")),
     llvm::cl::init(BackendKind::CPU), llvm::cl::cat(category));
 
+llvm::cl::opt<bool>
+    autoInstrument("auto-instrument",
+                   llvm::cl::desc("Add instrumentation for operator tracing"),
+                   llvm::cl::Optional, llvm::cl::init(false),
+                   llvm::cl::cat(category));
+
 std::mutex eventLock;
 std::unique_ptr<TraceContext> traceContext;
 
@@ -155,6 +161,7 @@ int main(int argc, char **argv) {
   input = loadResnet50Model(inputType, module.get(), 0);
   phList = module->getPlaceholders();
   CompilationContext cctx;
+  cctx.backendOpts.autoInstrument = autoInstrument;
   EXIT_ON_ERR(hostManager->addNetwork(std::move(module), cctx,
                                       /*saturateHost*/ true));
 

--- a/include/glow/Runtime/Provisioner/Provisioner.h
+++ b/include/glow/Runtime/Provisioner/Provisioner.h
@@ -33,11 +33,13 @@ class Provisioner final {
 public:
   Provisioner(DeviceManagerMapTy &devices);
 
-  /// Walks \p networks and assigns each function to a DeviceManager in \p
-  /// devices. The Provisioner calls the addNetwork method for each
-  /// DeviceManager. Returns a GlowErr indicating if the operation was a
-  /// success.
-  llvm::Error provision(DAGListTy &networks, Module &module);
+  /// Traverses the DAG \p networks and:
+  ///   1. Retrieves each node's Function from the provided \p module.
+  ///   2. Compiles it using the provided CompilationContext \p cctx.
+  ///   3. Assigns a device and calls addNetwork on the chosen device(s).
+  /// \returns a GlowErr indicating if the operation was a success.
+  llvm::Error provision(DAGListTy &networks, Module &module,
+                        CompilationContext &cctx);
 
   /// Remove stored compiledFunction.
   void removeFunction(llvm::StringRef name);

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -97,7 +97,7 @@ llvm::Error HostManager::addNetwork(std::unique_ptr<Module> module,
     }
   }
 
-  RETURN_IF_ERR(provisioner_->provision(nodeList, *module));
+  RETURN_IF_ERR(provisioner_->provision(nodeList, *module, cctx));
 
   // Clear constants contents from the module then put it in a
   // shared_ptr to be shared between all of the networks created from each

--- a/tests/unittests/ProvisionerTest.cpp
+++ b/tests/unittests/ProvisionerTest.cpp
@@ -76,8 +76,10 @@ TEST_F(ProvisionerTest, provisionDag) {
         new CPUDeviceManager(DeviceConfig(BackendKind::CPU)));
     devices.emplace(i, std::move(device));
   }
+
+  CompilationContext cctx;
   auto provisioner = Provisioner(devices);
-  auto err = provisioner.provision(networks, *mod.get());
+  auto err = provisioner.provision(networks, *mod.get(), cctx);
   // Expect that there was no Error when provisioning
   EXPECT_FALSE(errToBool(std::move(err)));
 }
@@ -92,8 +94,10 @@ TEST_F(ProvisionerTest, provisionDagFail) {
         new CPUDeviceManager(DeviceConfig(BackendKind::CPU), 1000));
     devices.emplace(i, std::move(device));
   }
+
+  CompilationContext cctx;
   auto provisioner = Provisioner(devices);
-  auto err = provisioner.provision(networks, *mod.get());
+  auto err = provisioner.provision(networks, *mod.get(), cctx);
   // Expect that there was no Error when provisioning
   EXPECT_TRUE(errToBool(std::move(err)));
 }


### PR DESCRIPTION
Summary: The HostManager addNetwork call takes in a CompilationContext but does not use it. This fixes the HM to pass the context through to the provisioner and use it when compiling.

Documentation: Fixes #2992

Test Plan: Tested with new argument to resnet-runtime:

```
./bin/resnet-runtime --trace-path trace.json
(0) ../tests/images/imagenet/zebra_340.png: 340
(0) ../tests/images/imagenet/cat_285.png: 281
(0) ../tests/images/imagenet/dog_207.png: 207
I0607 14:55:35.043989 327415232 resnet-runtime.cpp:219] Finished classifying 3 images.
dumping 39 trace events to trace.json.
```

Enabling auto-instrument:

```
./bin/resnet-runtime --trace-path trace.json --auto-instrument
(0) ../tests/images/imagenet/cat_285.png: 281
(0)  ../tests/images/imagenet/zebra_340.png: 340
(0) ../tests/images/imagenet/dog_207.png: 207
I0607 14:55:22.365221 201782720 resnet-runtime.cpp:219] Finished classifying 3 images.
dumping 756 trace events to trace.json.
```