### PR TITLE
[Windows] Fix for CPU cmake.

### DIFF
--- a/lib/Backends/CPU/CMakeLists.txt
+++ b/lib/Backends/CPU/CMakeLists.txt
@@ -14,7 +14,7 @@ if(NOT LLVM_LINK_BIN)
     set(LLVM_LINK_BIN ${LLVM_BINARY_DIR}/bin/llvm-link)
   endif()
 endif()
-if(NOT EXISTS ${LLVM_LINK_BIN})
+if(NOT EXISTS ${LLVM_LINK_BIN} AND NOT MSVC)
   message(SEND_ERROR "unable to find llvm-link, cannot build the CPU runtime")
 endif()
 


### PR DESCRIPTION
Summary:
For windows $(configuration) is not resolved when cmake is ran if build_type is not specified. It will be re resolved when going through UI.
Documentation:

[Optional Fixes #issue]

Test Plan:

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
