### PR TITLE
[Habana] Certain memory layout is required for faster FC in Habana 0.1.9 version.

### DIFF
--- a/lib/Backends/Habana/Habana.h
+++ b/lib/Backends/Habana/Habana.h
@@ -249,6 +249,8 @@ public:
 
   bool shouldShareBuffers() const override { return false; }
   /// @}
+
+  static bool isVersionBiggerEqualTo(std::string versionToCompare);
 };
 
 } // namespace glow


### PR DESCRIPTION
Summary:
Upstreaming change for Habana.

https://github.com/fb3p/glow-h/commit/2fc75882afee74525409abe0a5c4e9f43e073682

@nrsatish @hyuen 

Test Plan:
Manual run for now (still pending).
