### PR TITLE
[GraphGradTest][trivial] Fix incorrect check from GE to GT

### DIFF
--- a/tests/unittests/GraphGradTest.cpp
+++ b/tests/unittests/GraphGradTest.cpp
@@ -178,8 +178,8 @@ TEST(GraphAutoGrad, checkPlaceholderGradTest) {
   EE.compile(CompilationMode::Infer, F);
 
   // Check that the Placeholder has multiple users, because at least one write
-  /// node will be added.
-  EXPECT_GE(A->getNumUsers(), 1);
+  // node will be added.
+  EXPECT_GT(A->getNumUsers(), 1);
 }
 
 /// Check that we can differentiate functions that use ConvertToNode.


### PR DESCRIPTION
The test was supposed to check that users is `> 1`, not `>=`.