### PR TITLE
Refactoring ONNIXIFI Loader

### DIFF
--- a/include/glow/Importer/Caffe2ModelLoader.h
+++ b/include/glow/Importer/Caffe2ModelLoader.h
@@ -86,6 +86,25 @@ class Caffe2ModelLoader
   llvm::Error loadInputs(const caffe2::NetDef &net,
                          bool loadInputsAsPlaceholders);
 
+  /// \returns Expected<NetDef> if a NetDef can be constructed from the
+  /// in-memory serialized protobuf.
+  /// Loads ModelProto from the in-memory serialized protobuf \p
+  /// c2Model with the model size \p c2ModelSize.
+  static llvm::Expected<caffe2::NetDef> loadProto(const void *c2Model,
+                                                  size_t c2ModelSize);
+
+  /// Creates a Caffe2 model loader to build \p F.
+  /// Loads the ONNIXFI \p model from memory of \p modelSize size,
+  /// and \p weightsCount, and \p onnxTensorDescriptorV1 correspondent
+  /// descriptors. Converts inputs into placeholder if requested \p
+  /// loadInputsAsPlaceholders. Reports success/failure through optional
+  /// parameter \p errPtr.
+  Caffe2ModelLoader(const void *model, uint32_t modelSize,
+                    uint32_t weightsCount,
+                    const onnxTensorDescriptorV1 *weightDescriptors,
+                    Function &F, bool loadInputsAsPlaceholders,
+                    llvm::Error *errPtr = nullptr);
+
   friend class ONNXIFIModelLoader;
 
 public:
@@ -106,13 +125,6 @@ public:
   /// If \p errPtr is not null then if an error occurs it will get assigned
   /// there otherwise if an error occurs it will abort.
   Caffe2ModelLoader(Function &F, llvm::Error *errPtr);
-
-  /// \returns Expected<NetDef> if a NetDef can be constructed from the
-  /// in-memory serialized protobuf.
-  /// Loads ModelProto from the in-memory serialized protobuf \p
-  /// c2Model with the model size \p c2ModelSize.
-  static llvm::Expected<caffe2::NetDef> loadProto(const void *c2Model,
-                                                  size_t c2ModelSize);
 };
 
 } // namespace glow

--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -184,12 +184,11 @@ class CommonOperatorLoader : public ProtobufLoader {
     return llvm::Error::success();
   }
 
-public:
+protected:
   CommonOperatorLoader(llvm::ArrayRef<const char *> names,
                        llvm::ArrayRef<TypeRef> types, Function &F)
       : ProtobufLoader(names, types, F) {}
 
-protected:
   using ArgumentDictionaryTy =
       std::unordered_map<std::string, const AttrType *>;
 

--- a/include/glow/Importer/ONNXIFIModelLoader.h
+++ b/include/glow/Importer/ONNXIFIModelLoader.h
@@ -27,9 +27,8 @@ namespace glow {
 
 class ONNXIFIModelLoader {
 private:
-  /// If \p errPtr is not null then if an error occurs it will get assigned
-  /// there otherwise if an error occurs it will abort.
-  explicit ONNXIFIModelLoader(llvm::Error *errPtr = nullptr) {}
+  /// Default constructor.
+  explicit ONNXIFIModelLoader() {}
 
   /// The real loader. It can be ONNXModelLoader or Caffe2ModelLoader
   std::unique_ptr<ProtobufLoader> core_{nullptr};

--- a/include/glow/Importer/ONNXModelLoader.h
+++ b/include/glow/Importer/ONNXModelLoader.h
@@ -153,14 +153,6 @@ protected:
   /// Load the network initializers from the GraphProto.
   llvm::Error loadInitializers(ONNX_NAMESPACE::GraphProto &net);
 
-  friend class ONNXIFIModelLoader;
-
-public:
-  /// Creates a ONNX model loader to build \p F.
-  /// If \p errPtr is not null then if an error occurs it will get assigned
-  /// there otherwise if an error occurs it will abort.
-  ONNXModelLoader(Function &F, llvm::Error *errPtr = nullptr);
-
   /// Load the inputs from the GraphProto. If \p loadInputsAsPlaceholders is
   /// true then this will load each graph input as a placeholder otherwise it
   /// will create an empty tensor for each input.
@@ -186,6 +178,24 @@ public:
   llvm::Error checkInputs(ONNX_NAMESPACE::GraphProto &net,
                           llvm::ArrayRef<const char *> tensorNames,
                           llvm::ArrayRef<TypeRef> types);
+
+  /// Creates a ONNX model loader to build \p F.
+  /// Loads the ONNIXFI \p model from memory of \p modelSize size,
+  /// and \p weightsCount, and \p onnxTensorDescriptorV1 correspondent
+  /// descriptors. Converts inputs into placeholder if requested \p
+  /// loadInputsAsPlaceholders. Reports success/failure through optional
+  /// parameter \p errPtr.
+  ONNXModelLoader(const void *model, uint32_t modelSize, uint32_t weightsCount,
+                  const onnxTensorDescriptorV1 *weightDescriptors, Function &F,
+                  bool loadInputsAsPlaceholders, llvm::Error *errPtr = nullptr);
+
+  friend class ONNXIFIModelLoader;
+
+public:
+  /// Creates a ONNX model loader to build \p F.
+  /// If \p errPtr is not null then if an error occurs it will get assigned
+  /// there otherwise if an error occurs it will abort.
+  ONNXModelLoader(Function &F, llvm::Error *errPtr = nullptr);
 
   /// Loads the ONNX model that's represented by a model description file,
   /// serialized in \p modelDescFilename and populates the network into \p F.


### PR DESCRIPTION
Summary: Encapsulate ONIXIFI specific into the correspondent constructors for ONNXModelLoader and Caffe2ModelLoader

Differential Revision: D15745436

