### PR TITLE
Remove GLOW_UNREACHABLE

### DIFF
--- a/include/glow/Support/Compiler.h
+++ b/include/glow/Support/Compiler.h
@@ -28,9 +28,6 @@
   ((void)fprintf(stderr, "%s:%u: failed assertion `%s'\n", file, line, e),     \
    abort())
 
-#define GLOW_UNREACHABLE(msg)                                                  \
-  ((void)fprintf(stderr, "%s:%u: %s\n", __FILE__, __LINE__, msg), abort())
-
 #ifdef _WIN32
 #define glow_aligned_malloc(p, a, s)                                           \
   (((*(p)) = _aligned_malloc((s), (a))), *(p) ? 0 : errno)

--- a/lib/Backends/Habana/Habana.cpp
+++ b/lib/Backends/Habana/Habana.cpp
@@ -51,8 +51,6 @@ static synDataType getSynType(ElemKind kind) {
   switch (kind) {
   case ElemKind::FloatTy:
     return syn_type_single;
-  case ElemKind::Float16Ty:
-    GLOW_UNREACHABLE("Unhandled ElemKind: Float16Ty");
   case ElemKind::Int8QTy:
     return syn_type_fixed;
   case ElemKind::UInt8QTy:
@@ -69,10 +67,9 @@ static synDataType getSynType(ElemKind kind) {
     return syn_type_int32;
   case ElemKind::UInt8FusedQTy:
     return syn_type_fixed;
-  case ElemKind::BoolTy:
-    GLOW_UNREACHABLE("Unhandled ElemKind: BoolTy");
+  default:
+    LOG(FATAL) << "Unsupported data type: " << Type::getElementName(kind).str();
   }
-  GLOW_UNREACHABLE("Unhandled data type");
 }
 
 static const char *getKernelSuffix(ElemKind kind) {
@@ -84,7 +81,7 @@ static const char *getKernelSuffix(ElemKind kind) {
   case ElemKind::FloatTy:
     return "_f32";
   default:
-    GLOW_UNREACHABLE("Unhandled data type");
+    LOG(FATAL) << "Unsupported data type: " << Type::getElementName(kind).str();
   }
 }
 

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -144,7 +144,8 @@ static std::string getKernelName(const char *baseName, ElemKind elemTy) {
   case ElemKind::BoolTy:
     return name + "_bW";
   default:
-    GLOW_UNREACHABLE("Unsupported element type");
+    LOG(FATAL) << "Unsupported data type: "
+               << Type::getElementName(elemTy).str();
   }
 }
 
@@ -609,7 +610,7 @@ llvm::Error OpenCLFunction::execute(ExecutionContext *context) {
           }
         }
       } else {
-        GLOW_UNREACHABLE("Invalid instruction.");
+        LOG(FATAL) << "Invalid instruction: " << I.getName().str();
       }
 
       cl_kernel kernel = createKernel(kernelName);
@@ -1401,8 +1402,7 @@ llvm::Error OpenCLFunction::execute(ExecutionContext *context) {
       continue;
     }
 
-    llvm::errs() << "Cannot select: " << I.getKindName() << "\n";
-    GLOW_UNREACHABLE("compilation failed");
+    LOG(FATAL) << "Compilation failed, cannot select: " << I.getKindName();
   }
 
   enqueueEvent.end();


### PR DESCRIPTION
Summary: GLOW_UNREACHABLE is only used in a few places and can be replaced with llvm::Errors or LOG(FATAL) in each case to provide either better error messaging or recoverability

Differential Revision: D15761033

