### PR TITLE
[Tracing] change TraceEvent type from fixed size string to char

### DIFF
--- a/examples/tracing-compare.cpp
+++ b/examples/tracing-compare.cpp
@@ -169,10 +169,10 @@ int main(int argc, char **argv) {
 
   std::vector<TraceEvent> allEvents;
 
-  allEvents.push_back({"thread_name", 0, "M", 0, {{"name", "CPU"}}});
-  allEvents.push_back({"thread_name", 0, "M", 1, {{"name", "Interpreter"}}});
+  allEvents.push_back({"thread_name", 0, 'M', 0, {{"name", "CPU"}}});
+  allEvents.push_back({"thread_name", 0, 'M', 1, {{"name", "Interpreter"}}});
 #if (GLOW_WITH_OPENCL)
-  allEvents.push_back({"thread_name", 0, "M", 2, {{"name", "OpenCL"}}});
+  allEvents.push_back({"thread_name", 0, 'M', 2, {{"name", "OpenCL"}}});
 #endif
 
   for (unsigned i = 0, e = supportedBackends.size(); i < e; ++i) {

--- a/include/glow/ExecutionContext/ExecutionContext.h
+++ b/include/glow/ExecutionContext/ExecutionContext.h
@@ -129,7 +129,7 @@ public:
 
   /// A helper function to log a TraceEvent at the current time, if there is a
   /// TraceContext available.
-  void logTraceEvent(llvm::StringRef name, llvm::StringRef type = "i",
+  void logTraceEvent(llvm::StringRef name, char type = TraceEvent::InstantType,
                      std::map<std::string, std::string> args = {}) {
     TraceContext *traceContext = getTraceContext();
     if (traceContext) {

--- a/include/glow/ExecutionContext/TraceEvents.h
+++ b/include/glow/ExecutionContext/TraceEvents.h
@@ -32,10 +32,10 @@ class PlaceholderBindings;
 /// https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU
 struct TraceEvent {
   /// Event Types.
-  static constexpr auto BeginType = "B";
-  static constexpr auto EndType = "E";
-  static constexpr auto InstantType = "I";
-  static constexpr auto CompleteType = "X";
+  static constexpr auto BeginType = 'B';
+  static constexpr auto EndType = 'E';
+  static constexpr auto InstantType = 'I';
+  static constexpr auto CompleteType = 'X';
 
   /// Human readable name for the item, will be used to match up begin and end.
   std::string name;
@@ -45,7 +45,7 @@ struct TraceEvent {
 
   /// Type of the event, a (usually) one char code (see Event Descriptions in
   /// the Trace Event Format spec). e.g. 'B' for begin event, 'E' for end event.
-  std::string type;
+  char type;
 
   /// Thread Id for this event. All Events on the same tid will be shown on the
   /// same row of the trace.
@@ -57,10 +57,10 @@ struct TraceEvent {
   /// Arbitrary TraceEvent arguments (from spec).
   std::map<std::string, std::string> args;
 
-  TraceEvent(llvm::StringRef n, uint64_t ts, llvm::StringRef c, int t)
+  TraceEvent(llvm::StringRef n, uint64_t ts, char c, int t)
       : name(n), timestamp(ts), type(c), tid(t) {}
 
-  TraceEvent(llvm::StringRef n, uint64_t ts, llvm::StringRef c, int t,
+  TraceEvent(llvm::StringRef n, uint64_t ts, char c, int t,
              std::map<std::string, std::string> a)
       : name(n), timestamp(ts), type(c), tid(t), args(a) {}
 
@@ -102,7 +102,7 @@ struct TraceInfo {
     size_t startIndex;
     size_t endIndex;
     std::string name;
-    std::string type;
+    char type;
 
     // additional info per backend. May not be present.
     std::string context;
@@ -110,11 +110,11 @@ struct TraceInfo {
 
   std::map<Placeholder *, std::vector<Event>> events;
 
-  void add(Placeholder *PH, size_t index, std::string name, std::string type) {
+  void add(Placeholder *PH, size_t index, std::string name, char type) {
     events[PH].push_back({index, 0, std::move(name), std::move(type), ""});
   }
 
-  void add(Placeholder *PH, size_t index, std::string name, std::string type,
+  void add(Placeholder *PH, size_t index, std::string name, char type,
            std::string context) {
     events[PH].push_back(
         {index, 0, std::move(name), std::move(type), std::move(context)});
@@ -170,14 +170,13 @@ public:
   /// Logs a new TraceEvent at the current time with the given \p name, \p
   /// type and optionally additional attributes.
   void
-  logTraceEvent(llvm::StringRef name,
-                llvm::StringRef type = TraceEvent::InstantType,
+  logTraceEvent(llvm::StringRef name, char type = TraceEvent::InstantType,
                 std::map<std::string, std::string> additionalAttributes = {});
 
   // Logs a new TraceEvent at the provided \p timestamp, with the given \p
   // name, \p type and optionally additional attributes.
   void
-  logTraceEvent(llvm::StringRef name, llvm::StringRef type, uint64_t timestamp,
+  logTraceEvent(llvm::StringRef name, char type, uint64_t timestamp,
                 std::map<std::string, std::string> additionalAttributes = {});
 
   /// Logs a new TraceEvent with the Complete event type, the start time is

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -1882,8 +1882,12 @@ TraceInfo OCLBackend::buildManualTraceInfo(Function *F) const {
 
       Placeholder *backing =
           llvm::dyn_cast<Placeholder>(TEN->getData().getNode());
-      info.add(backing, TEN->getIndex(), TEN->getEventName(),
-               TEN->getEventType(), TEN->getName());
+      char type = TraceEvent::InstantType;
+      if (!TEN->getEventType().empty()) {
+        type = TEN->getEventType()[0];
+      }
+      info.add(backing, TEN->getIndex(), TEN->getEventName(), type,
+               TEN->getName());
       info.enabled = true;
     }
   }

--- a/lib/ExecutionContext/TraceEvents.cpp
+++ b/lib/ExecutionContext/TraceEvents.cpp
@@ -82,13 +82,13 @@ size_t TraceEvent::getThreadId() {
 }
 
 void TraceContext::logTraceEvent(
-    llvm::StringRef name, llvm::StringRef type,
+    llvm::StringRef name, char type,
     std::map<std::string, std::string> additionalAttributes) {
   logTraceEvent(name, type, TraceEvent::now(), std::move(additionalAttributes));
 }
 
 void TraceContext::logTraceEvent(
-    llvm::StringRef name, llvm::StringRef type, uint64_t timestamp,
+    llvm::StringRef name, char type, uint64_t timestamp,
     std::map<std::string, std::string> additionalAttributes) {
   if (traceLevel_ == TraceLevel::NONE || traceLevel_ == TraceLevel::OPERATOR) {
     return;

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -224,10 +224,7 @@ void Graph::setTraceEvents(onnxTraceEventList *traceEvents,
   std::vector<onnxTraceEvent *> traceEventsVec;
   for (const auto &glowTraceEvent : traceContext->getTraceEvents()) {
     auto *traceEvent = new onnxTraceEvent();
-    DCHECK_EQ(glowTraceEvent.type.size(), 1)
-        << "Events with types longer than a single char not supported by "
-           "onnxifi";
-    traceEvent->eventType = glowTraceEvent.type[0];
+    traceEvent->eventType = glowTraceEvent.type;
     traceEvent->timestamp = glowTraceEvent.timestamp;
     traceEvent->tid = glowTraceEvent.tid;
     traceEvent->duration = 0;

--- a/tests/unittests/TraceEventsTest.cpp
+++ b/tests/unittests/TraceEventsTest.cpp
@@ -92,9 +92,8 @@ public:
   }
 
   // Compares generated TraceEvents with their expected names and types.
-  void checkEventMetadata(
-      const std::vector<TraceEvent> &traceEvents,
-      std::vector<std::pair<std::string, std::string>> expected) {
+  void checkEventMetadata(const std::vector<TraceEvent> &traceEvents,
+                          std::vector<std::pair<std::string, char>> expected) {
 
     ASSERT_EQ(traceEvents.size(), expected.size());
     unsigned index = 0;
@@ -149,10 +148,10 @@ TEST_P(TraceEventsTest, manualEvents) {
   auto &traceEvents = context.getTraceContext()->getTraceEvents();
 
   ASSERT_EQ(traceEvents.size(), numEvents);
-  checkEventMetadata(traceEvents, {{"first half", "B"},
-                                   {"first half", "E"},
-                                   {"second half", "B"},
-                                   {"second half", "E"}});
+  checkEventMetadata(traceEvents, {{"first half", 'B'},
+                                   {"first half", 'E'},
+                                   {"second half", 'B'},
+                                   {"second half", 'E'}});
 
   checkEventTimestamps(traceEvents);
 
@@ -196,7 +195,7 @@ TEST_P(TraceEventsTest, incompleteCoverage) {
   auto &traceEvents = context.getTraceContext()->getTraceEvents();
 
   ASSERT_GE(traceEvents.size(), numEvents);
-  checkEventMetadata(traceEvents, {{"second half", "B"}, {"second half", "E"}});
+  checkEventMetadata(traceEvents, {{"second half", 'B'}, {"second half", 'E'}});
 
   checkEventTimestamps(traceEvents);
 
@@ -240,7 +239,7 @@ TEST_P(TraceEventsTest, internalGap) {
 
   ASSERT_GE(traceEvents.size(), numEvents);
   checkEventMetadata(traceEvents,
-                     {{"middle section", "B"}, {"middle section", "E"}});
+                     {{"middle section", 'B'}, {"middle section", 'E'}});
 
   checkEventTimestamps(traceEvents);
 
@@ -405,11 +404,11 @@ TEST_P(TraceEventsTest, onlyTraceEvents) {
   auto *eventData = createEventPlaceholder(numEvents);
   unsigned eventId = 0;
 
-  std::vector<std::pair<std::string, std::string>> expected;
+  std::vector<std::pair<std::string, char>> expected;
   for (unsigned eventId = 0; eventId < numEvents; ++eventId) {
     std::string name = "event_" + std::to_string(eventId);
     F->createTraceEvent(name, "X", eventData, eventId);
-    expected.push_back({name, "X"});
+    expected.push_back({name, 'X'});
   }
 
   context.getPlaceholderBindings()->allocate(EE_.getModule().getPlaceholders());


### PR DESCRIPTION
Summary: TraceEvents have a 1 char type value which we were storing as a string internally. Change to a char to save some memory inside the Runtime.

Documentation: n/a we already export chars through Onnxifi.

Test Plan: unit tests, specifically TraceEventTests.
