### PR TITLE
[Tracing] Add support for thread and process name metadata.

### DIFF
--- a/include/glow/ExecutionContext/TraceEvents.h
+++ b/include/glow/ExecutionContext/TraceEvents.h
@@ -36,6 +36,8 @@ struct TraceEvent {
   static constexpr auto EndType = 'E';
   static constexpr auto InstantType = 'I';
   static constexpr auto CompleteType = 'X';
+  /// MetadataType is used for the thread name mapping.
+  static constexpr auto MetadataType = 'M';
 
   /// Human readable name for the item, will be used to match up begin and end.
   std::string name;

--- a/utils/glow-trace-concat.sh
+++ b/utils/glow-trace-concat.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "["
+tail -q -n +2 $@ | grep -h '"ph":"M"' | sort | uniq
+tail -q -n +2 $@ | grep -h -v '"ph":"M"'


### PR DESCRIPTION
Summary: Add support for setting thread names and including them efficiently in the trace using the Metadata event type. 

Output looks like this (not much change since we were hacking it together in tracing-compare):

![image](https://user-images.githubusercontent.com/701287/59313155-a5ee8000-8c64-11e9-9f78-ebb5593c8b12.png)

json file looks like this:
```
[
{"cat": "__metadata", "ph":"M", "ts":0, "pid":0, "tid":0, "name":"process_name", "args": {"name":"tracing-compare"} },
{"cat": "__metadata", "ph":"M", "ts":0, "pid":0, "tid":0, "name":"thread_name", "args": {"name":"CPU"} },
{"cat": "__metadata", "ph":"M", "ts":0, "pid":0, "tid":1, "name":"thread_name", "args": {"name":"Interpreter"} },
{"cat": "__metadata", "ph":"M", "ts":0, "pid":0, "tid":2, "name":"thread_name", "args": {"name":"OpenCL"} },
{"name": "allocBuffers", "cat": "glow","ph": "X", "ts": 1560293092212516, "pid": 0, "tid": 0, "dur": 8},
{"name": "loadPlaceholders", "cat": "glow","ph": "X", "ts": 1560293092212529, "pid": 0, "tid": 0, "dur": 416},
...
```

Documentation: Doesn't change much since we already claimed to support thread names

Since our json files have a metadata "header" now, I added a script in utils to concatenate trace files together, since thats something we do regularly.

We don't support multiple PIDs yet, but they'll probably be useful.

Test Plan: unit tests & manual testing with tracing-compare example
