### PR TITLE
[Interpreter] Implement peer-to-peer communication primitives

### DIFF
--- a/include/glow/Backend/Backend.h
+++ b/include/glow/Backend/Backend.h
@@ -128,6 +128,9 @@ public:
     return false;
   }
 
+  /// \returns whether peer-to-peer communication is supported by the backend.
+  virtual bool isPeerToPeerSupported() const { return false; }
+
   virtual size_t getTraceEventDataSize() const { return 0; }
 
 protected:

--- a/include/glow/Backends/DeviceManager.h
+++ b/include/glow/Backends/DeviceManager.h
@@ -104,6 +104,18 @@ public:
   /// fit on the device.
   virtual bool isMemoryAvailable(uint64_t estimate) const = 0;
 
+  /// \returns whether peer-to-peer communication is supported by the device.
+  virtual bool isPeerToPeerSupported() const { return false; }
+
+  /// \returns the device address of the Placeholder \p P in the function \p
+  /// function or an error if the device does not support peer to peer
+  /// communication.
+  virtual llvm::Expected<uintptr_t>
+  getPlaceholderAddress(std::string function, const Placeholder *P) {
+    return MAKE_ERR(GlowErr::ErrorCode::RUNTIME_ERROR,
+                    "Backend does not support peer to peer communication");
+  }
+
   /// \returns the DeviceConfig which initialized this device.
   const DeviceConfig &getDeviceConfig() { return config_; }
 };

--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -441,6 +441,8 @@ public:
       return isEqualImpl<uint8_t>(other, allowedError, verbose);
     case ElemKind::BoolTy:
       return isEqualImpl<bool>(other, allowedError, verbose);
+    case ElemKind::AddrTy:
+      return isEqualImpl<uintptr_t>(other, /*allowedError=*/0, verbose);
     }
 
     // This is to make compiler happy. It can never reach this point as switch

--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -275,6 +275,7 @@ enum class ElemKind : unsigned char {
   Int64ITy,      // 64-bit index type (int64_t)
   UInt8FusedQTy, // 8-bit quantized type with fused scale/offset (uint8_t)
   BoolTy,        // Bool type (bool)
+  AddrTy,        // Address type (uintptr_t)
 };
 
 /// \returns whether \p e is a quantized ElemKind.
@@ -473,6 +474,8 @@ struct Type final {
       return std::is_same<ElemTy, uint8_t>::value;
     case ElemKind::BoolTy:
       return std::is_same<ElemTy, bool>::value;
+    case ElemKind::AddrTy:
+      return std::is_same<ElemTy, uintptr_t>::value;
     }
     LOG(FATAL) << "Invalid type: " << getElementName(Ty).str();
   }
@@ -516,6 +519,8 @@ struct Type final {
       return sizeof(uint8_t);
     case ElemKind::BoolTy:
       return sizeof(bool);
+    case ElemKind::AddrTy:
+      return sizeof(uintptr_t);
     }
     LOG(FATAL) << "Invalid type: " << getElementName(Ty).str();
   }

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -838,6 +838,18 @@ public:
   SaveNode *createSave(llvm::StringRef name, NodeValue input,
                        Placeholder *output);
 
+  /// Creates a SendNode named \p name that sends \p input to \p address. A
+  /// ReceiveNode that listens on the same address will receive the sent data.
+  /// The node also writes the input to a Placeholder.
+  SendNode *createSend(llvm::StringRef name, NodeValue input,
+                       Placeholder *address);
+
+  /// Creates a ReceiveNode named \p name that receives a Tensor of type \p
+  /// outTy by listening on \p address and writes the data to its output. The
+  /// node also writes the input to a Placeholder.
+  ReceiveNode *createReceive(llvm::StringRef name, TypeRef outTy,
+                             Placeholder *address);
+
   /// Create quantization profile node named \p name for the output tensor from
   /// \p input in PlaceholderBindings \p bindings. Capture observed node name in
   /// quantization profile node as original node can be replaced during lowering

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -352,6 +352,8 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
   case Kinded::Kind::TransposeNodeKind:
   case Kinded::Kind::ReshapeNodeKind:
   case Kinded::Kind::SaveNodeKind:
+  case Kinded::Kind::SendNodeKind:
+  case Kinded::Kind::ReceiveNodeKind:
     // These work regardless of the underlying type.
     return true;
 

--- a/lib/Backends/Interpreter/Interpreter.h
+++ b/lib/Backends/Interpreter/Interpreter.h
@@ -54,6 +54,8 @@ public:
 
   bool shouldLower(const Node *N) const override;
 
+  bool isPeerToPeerSupported() const override { return true; }
+
   /// @}
   //
   /// \returns the size of metrics collected for a single TraceEvent.

--- a/lib/Base/Tensor.cpp
+++ b/lib/Base/Tensor.cpp
@@ -293,6 +293,8 @@ void glow::dumpAsciiImpl(const Tensor *T, llvm::raw_ostream &os) {
     return dumpAsciiGenericImpl(T->getHandle<uint8_t>(), os);
   case ElemKind::BoolTy:
     return dumpAsciiGenericImpl(T->getHandle<bool>(), os);
+  case ElemKind::AddrTy:
+    return dumpAsciiGenericImpl(T->getHandle<uintptr_t>(), os);
   }
 }
 
@@ -321,6 +323,8 @@ void glow::dumpImpl(const Tensor *T, llvm::raw_ostream &os,
     return dumpGenericImpl(T->getHandle<uint8_t>(), os, maxNumElem);
   case ElemKind::BoolTy:
     return dumpGenericImpl(T->getHandle<bool>(), os, maxNumElem);
+  case ElemKind::AddrTy:
+    return dumpGenericImpl(T->getHandle<uintptr_t>(), os, maxNumElem);
   }
 }
 
@@ -436,6 +440,12 @@ void glow::genericTranspose(const Tensor *src, Tensor *dest,
     transposeSelectImpl(srcH, destH, shuffle);
     return;
   }
+  case ElemKind::AddrTy: {
+    auto srcH = src->getHandle<uintptr_t>();
+    auto destH = dest->getHandle<uintptr_t>();
+    transposeSelectImpl(srcH, destH, shuffle);
+    return;
+  }
   }
 }
 
@@ -504,6 +514,10 @@ void Tensor::init(InitKind init, float val, PseudoRNG &PRNG) {
     }
     case ElemKind::BoolTy: {
       getHandle<bool>().clear(val);
+      break;
+    }
+    case ElemKind::AddrTy: {
+      getHandle<uintptr_t>().clear(val);
       break;
     }
     }

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1602,6 +1602,25 @@ SaveNode *Function::createSave(llvm::StringRef name, NodeValue input,
   return addNode(new SaveNode(name, input, output));
 }
 
+SendNode *Function::createSend(llvm::StringRef name, NodeValue input,
+                               Placeholder *address) {
+  // Create a Placeholder to store the input of the Send node (for debugging).
+  auto *dest = getParent()->createPlaceholder(
+      input.getType(), name.str() + "PH", /*isTrainable=*/false);
+  auto *send = new SendNode(name, input, address, dest);
+  return addNode(send);
+}
+
+ReceiveNode *Function::createReceive(llvm::StringRef name, TypeRef outTy,
+                                     Placeholder *address) {
+  // Create a Placeholder to store the output of the Receive node (for
+  // debugging).
+  auto *dest = getParent()->createPlaceholder(outTy, name.str() + "PH",
+                                              /*isTrainable=*/false);
+  auto *recv = new ReceiveNode(name, outTy, address, dest);
+  return addNode(recv);
+}
+
 QuantizationProfileNode *
 Function::createQuantizationProfile(PlaceholderBindings &bindings,
                                     llvm::StringRef name, NodeValue input) {

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -1271,6 +1271,28 @@ bool SaveNode::verify() const {
   return checkSameType(getInput(), getOutput(), this);
 }
 
+bool SendNode::verify() const {
+  // Input and output should have the same type.
+  bool isValid = checkSameType(getInput(), getOutput(), this);
+  // The type of the address input should be AddrTy.
+  isValid &= checkType(getAddress(), ElemKind::AddrTy, this);
+  // Only one address can be used at one time. Sending to multiple recipients
+  // requires multiple SendNodes.
+  isValid &= getAddress().getType()->size() == 1;
+
+  return isValid;
+}
+
+bool ReceiveNode::verify() const {
+  // The type of the address input should be AddrTy.
+  bool isValid = checkType(getAddress(), ElemKind::AddrTy, this);
+  // Only one address can be used at one time. Receiving a value from multiple
+  // addresses is not supported.
+  isValid &= getAddress().getType()->size() == 1;
+
+  return isValid;
+}
+
 bool LogNode::verify() const {
   if (getResult().getType()->isQuantizedType()) {
     return checkSameShape(getInput(), getResult(), this);

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -243,6 +243,8 @@ llvm::Type *LLVMIRGen::getElementType(llvm::IRBuilder<> &builder,
     static_assert(sizeof(bool) == sizeof(int8_t),
                   "Bool is expected to be the same size as int8.");
     return builder.getInt8Ty();
+  case ElemKind::AddrTy:
+    llvm_unreachable("Not implemented");
   }
   return nullptr;
 }
@@ -487,6 +489,8 @@ llvm::Value *LLVMIRGen::emitConst(llvm::IRBuilder<> &builder, float val,
     return builder.getInt8(static_cast<int8_t>(val));
   case ElemKind::BoolTy:
     return builder.getInt8(static_cast<int8_t>(val));
+  case ElemKind::AddrTy:
+    llvm_unreachable("Not implemented");
   }
   llvm_unreachable("Unknown element type");
 }

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -423,6 +423,20 @@ target_link_libraries(RecommendationSystemTest
                         TestMain)
 add_glow_test(EXPENSIVE RecommendationSystemTest ${GLOW_BINARY_DIR}/tests/RecommendationSystemTest --gtest_output=xml:RecommendationSystemTest.xml)
 
+add_executable(PeerToPeerTest
+               PeerToPeerTest.cpp)
+target_link_libraries(PeerToPeerTest
+                      PRIVATE
+                        Backend
+                        Backends
+                        Graph
+                        IR
+                        ExecutionEngine
+                        Optimizer
+                        gtest
+                        TestMain)
+add_glow_test(PeerToPeerTest ${GLOW_BINARY_DIR}/tests/PeerToPeerTest --gtest_output=xml:PeerToPeerTest.xml)
+
 if(GLOW_WITH_CPU)
   add_executable(ProvisionerTest
                  ProvisionerTest.cpp)

--- a/tests/unittests/DeviceManagerTest.cpp
+++ b/tests/unittests/DeviceManagerTest.cpp
@@ -18,6 +18,7 @@
 #include "glow/Backends/DummyDeviceManager.h"
 
 #include "../../lib/Backends/CPU/CPUDeviceManager.h"
+#include "../../lib/Backends/Interpreter/InterpreterDeviceManager.h"
 #include "glow/ExecutionEngine/ExecutionEngine.h"
 #include "glow/Optimizer/Optimizer.h"
 

--- a/tests/unittests/PeerToPeerTest.cpp
+++ b/tests/unittests/PeerToPeerTest.cpp
@@ -1,0 +1,679 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../../lib/Backends/Interpreter/InterpreterDeviceManager.h"
+#include "glow/Backends/DeviceManager.h"
+#include "glow/Optimizer/Optimizer.h"
+
+#include "gtest/gtest.h"
+
+#include <chrono>
+#include <future>
+
+/// This macro asserts if \p lhsOrErr is an error, thus failing the containing
+/// test, and assigns its value to \p lhs if not.
+#define ASSIGN_VALUE_OR_ASSERT(rhs, lhsOrErr)                                  \
+  do {                                                                         \
+    auto lhsOrErrV = (lhsOrErr);                                               \
+    static_assert(IsLLVMExpected<decltype(lhsOrErrV)>(),                       \
+                  "Expected value to be a llvm::Expected");                    \
+    ASSERT_FALSE(!lhsOrErrV);                                                  \
+    rhs = std::move(lhsOrErrV.get());                                          \
+  } while (0)
+
+using namespace glow;
+using namespace glow::runtime;
+
+/// Fixture class for peer-to-peer communication tests.
+class PeerToPeerTest : public ::testing::TestWithParam<BackendKind> {
+public:
+  void SetUp() override {
+    // Ensure that the backend being tested supports peer-to-peer communication.
+    auto backend = std::unique_ptr<Backend>(createBackend(backendKind));
+    ASSERT_TRUE(backend->isPeerToPeerSupported());
+  }
+
+  /// The backend kind being tested.
+  BackendKind backendKind{GetParam()};
+};
+
+/// Helper function to compile functions in a \p module and store the compiled
+/// functions into \p backing. Only functions whose names appear in \p allow are
+/// compiled.
+FunctionMapTy
+compileFunctions(BackendKind backendKind, Module *module,
+                 std::vector<std::unique_ptr<CompiledFunction>> &backing,
+                 llvm::ArrayRef<llvm::StringRef> allow = {}) {
+  FunctionMapTy results;
+  auto backend = std::unique_ptr<Backend>(createBackend(backendKind));
+  CompilationContext cctx;
+  cctx.compMode = CompilationMode::Infer;
+  for (auto *F : module->getFunctions()) {
+    bool skip = true;
+
+    // Don't skip compilation if the function's name is in the allow list.
+    for (const auto &a : allow) {
+      if (F->getName() == a) {
+        skip = false;
+        break;
+      }
+    }
+
+    if (skip) {
+      continue;
+    }
+
+    EXIT_ON_ERR(::glow::optimizeFunction(F, *backend, cctx));
+    auto f = EXIT_ON_ERR(backend->compile(F, cctx.backendOpts));
+    backing.push_back(std::move(f));
+    results.emplace(F->getName(), backing.back().get());
+  }
+
+  return results;
+}
+
+/// Helper function to create a future-promise pair of a specific type.
+template <typename ResultType>
+std::pair<std::promise<ResultType>, std::future<ResultType>> getFutureHelper() {
+  std::promise<ResultType> promise;
+  auto future = promise.get_future();
+  return std::make_pair(std::move(promise), std::move(future));
+}
+
+/// Helper function to fulfill a promise.
+template <typename ResultType>
+void callbackHelper(std::promise<ResultType> &promise, ResultType res,
+                    llvm::Error err) {
+  promise.set_value(!errToBool(std::move(err)) ? std::move(res) : ResultType());
+}
+
+/// Tests peer-to-peer communication with a single sender and single receiver.
+TEST_P(PeerToPeerTest, SingleSenderSingleReceiver) {
+  // Create sender and receiver backends.
+  auto sender = std::unique_ptr<DeviceManager>(
+      DeviceManager::createDeviceManager(backendKind));
+  auto receiver = std::unique_ptr<DeviceManager>(
+      DeviceManager::createDeviceManager(backendKind));
+
+  ASSERT_FALSE(errToBool(sender->init()));
+  ASSERT_FALSE(errToBool(receiver->init()));
+
+  auto module = llvm::make_unique<Module>();
+
+  // Create the sender function. It implements the operation 1 + 2 and sends the
+  // result (3) to the receiver function using a SendNode.
+  Function *senderFn = module->createFunction("senderFn");
+  auto *senderFnLHS = module->createConstant(ElemKind::FloatTy, {1}, "lhs");
+  auto senderLHSH = senderFnLHS->getPayload().getHandle();
+  senderLHSH = {1};
+  auto *senderFnRHS = module->createConstant(ElemKind::FloatTy, {1}, "rhs");
+  auto senderRHSH = senderFnRHS->getPayload().getHandle();
+  senderRHSH = {2};
+  auto *senderFnAdd = senderFn->createAdd("add", senderFnLHS, senderFnRHS);
+  auto *address =
+      module->createPlaceholder(ElemKind::AddrTy, {1}, "address", false);
+  auto *send = senderFn->createSend("send", senderFnAdd, address);
+
+  // Create the receiver function. It receives the result of the sender function
+  // and adds 1 to it (the result should be 4).
+  Function *receiverFn = module->createFunction("receiverFn");
+  auto *recv = receiverFn->createReceive(
+      "recv", senderFnAdd->getResult().getType(), address);
+  auto *receiverFnRHS = module->createConstant(ElemKind::FloatTy, {1}, "rhs");
+  auto receiverRHSH = receiverFnRHS->getPayload().getHandle();
+  receiverRHSH = {1};
+  auto *receiverFnAdd = receiverFn->createAdd("add", recv, receiverFnRHS);
+  auto *save = receiverFn->createSave("save", receiverFnAdd);
+
+  // Compile the sender and receiver functions.
+  std::vector<std::unique_ptr<CompiledFunction>> senderBacking, receiverBacking;
+  FunctionMapTy senderFunctions = compileFunctions(
+      BackendKind::Interpreter, module.get(), senderBacking, {"senderFn"});
+  FunctionMapTy receiverFunctions = compileFunctions(
+      BackendKind::Interpreter, module.get(), receiverBacking, {"receiverFn"});
+
+  // Add the sender and receiver functions to their respective devices.
+  std::promise<const Module *> p1, p2;
+  std::future<const Module *> f1, f2;
+
+  std::tie(p1, f1) = getFutureHelper<const Module *>();
+  sender->addNetwork(module.get(), senderFunctions,
+                     [&p1](const Module *module, llvm::Error err) {
+                       callbackHelper(p1, module, std::move(err));
+                     });
+  f1.wait();
+  EXPECT_EQ(f1.get(), module.get());
+
+  std::tie(p2, f2) = getFutureHelper<const Module *>();
+  receiver->addNetwork(module.get(), receiverFunctions,
+                       [&p2](const Module *module, llvm::Error err) {
+                         callbackHelper(p2, module, std::move(err));
+                       });
+  f2.wait();
+  EXPECT_EQ(f2.get(), module.get());
+
+  // Create and set ExecutionContexts for the sender and receiver.
+  auto senderCtx = llvm::make_unique<ExecutionContext>();
+  auto receiverCtx = llvm::make_unique<ExecutionContext>();
+
+  senderCtx->getPlaceholderBindings()->allocate(send->getPlaceholder());
+  auto AH1 = senderCtx->getPlaceholderBindings()
+                 ->allocate(address)
+                 ->getHandle<uintptr_t>();
+
+  // Get the receiver's address for the ReceiveNode Placeholder from the
+  // receiver device and set the address input of the SendNode to this value.
+  uintptr_t addr;
+  ASSIGN_VALUE_OR_ASSERT(
+      addr, receiver->getPlaceholderAddress(receiverFn->getName(),
+                                            recv->getPlaceholder()));
+  AH1 = {addr};
+
+  receiverCtx->getPlaceholderBindings()->allocate(recv->getPlaceholder());
+  auto AH2 = receiverCtx->getPlaceholderBindings()
+                 ->allocate(address)
+                 ->getHandle<uintptr_t>();
+
+  // Set the address input of the ReceiveNode to the same address as the
+  // SendNode.
+  AH2 = {addr};
+  receiverCtx->getPlaceholderBindings()->allocate(save->getPlaceholder());
+
+  // Try to run this setup five times to make sure that peer-to-peer
+  // communication works several times and state is managed correctly.
+  for (size_t i = 0; i < 5; ++i) {
+    // Clear the final result tensor to make sure an iteration does not reuse
+    // data from the previous iteration.
+    receiverCtx->getPlaceholderBindings()
+        ->get(save->getPlaceholder())
+        ->getHandle()
+        .clear();
+
+    // Run the sender and receiver functions.
+    std::promise<std::unique_ptr<ExecutionContext>> runP1, runP2;
+    std::future<std::unique_ptr<ExecutionContext>> runF1, runF2;
+    std::tie(runP1, runF1) =
+        getFutureHelper<std::unique_ptr<ExecutionContext>>();
+    std::tie(runP2, runF2) =
+        getFutureHelper<std::unique_ptr<ExecutionContext>>();
+
+    sender->runFunction("senderFn", std::move(senderCtx),
+                        [&runP1](RunIdentifierTy, llvm::Error err,
+                                 std::unique_ptr<ExecutionContext> context) {
+                          callbackHelper(runP1, std::move(context),
+                                         std::move(err));
+                        });
+
+    receiver->runFunction("receiverFn", std::move(receiverCtx),
+                          [&runP2](RunIdentifierTy, llvm::Error err,
+                                   std::unique_ptr<ExecutionContext> context) {
+                            callbackHelper(runP2, std::move(context),
+                                           std::move(err));
+                          });
+
+    // Wait for the functions to finish running.
+    senderCtx = runF1.get();
+    receiverCtx = runF2.get();
+    ASSERT_TRUE(senderCtx);
+    ASSERT_TRUE(receiverCtx);
+    EXPECT_NE(senderCtx, receiverCtx);
+
+    // As mentioned earlier, the final result should be 4.
+    auto RH = receiverCtx->getPlaceholderBindings()
+                  ->get(save->getPlaceholder())
+                  ->getHandle();
+    ASSERT_EQ(RH.raw(0), 4);
+  }
+}
+
+/// Tests peer-to-peer communication with a single sender and multiple
+/// receivers.
+TEST_P(PeerToPeerTest, SingleSenderMultipleReceivers) {
+  // Create one sender and two receiver devices.
+  auto sender = std::unique_ptr<DeviceManager>(
+      DeviceManager::createDeviceManager(backendKind));
+  auto receiver1 = std::unique_ptr<DeviceManager>(
+      DeviceManager::createDeviceManager(backendKind));
+  auto receiver2 = std::unique_ptr<DeviceManager>(
+      DeviceManager::createDeviceManager(backendKind));
+
+  ASSERT_FALSE(errToBool(sender->init()));
+  ASSERT_FALSE(errToBool(receiver1->init()));
+  ASSERT_FALSE(errToBool(receiver2->init()));
+
+  auto module = llvm::make_unique<Module>();
+
+  // Create the sender function. This function computes 1 + 2 and sends the
+  // result to two receivers using two SendNodes.
+  Function *senderFn = module->createFunction("senderFn");
+  auto *senderFnLHS = module->createConstant(ElemKind::FloatTy, {1}, "lhs");
+  auto senderLHSH = senderFnLHS->getPayload().getHandle();
+  senderLHSH = {1};
+  auto *senderFnRHS = module->createConstant(ElemKind::FloatTy, {1}, "rhs");
+  auto senderRHSH = senderFnRHS->getPayload().getHandle();
+  senderRHSH = {2};
+  auto *senderFnAdd = senderFn->createAdd("add", senderFnLHS, senderFnRHS);
+  auto *address1 =
+      module->createPlaceholder(ElemKind::AddrTy, {1}, "address1", false);
+  auto *address2 =
+      module->createPlaceholder(ElemKind::AddrTy, {1}, "address2", false);
+  auto *send1 = senderFn->createSend("send1", senderFnAdd, address1);
+  auto *send2 = senderFn->createSend("send2", senderFnAdd, address2);
+
+  // Create the first receiver function. This function adds 1 to the result
+  // received from the sender function and saves the result (which should be 3).
+  Function *receiver1Fn = module->createFunction("receiver1Fn");
+  auto *receiver1Recv = receiver1Fn->createReceive(
+      "recv", senderFnAdd->getResult().getType(), address1);
+  auto *receiver1RHS = module->createConstant(ElemKind::FloatTy, {1}, "rhs");
+  auto receiver1RHSH = receiver1RHS->getPayload().getHandle();
+  receiver1RHSH = {1};
+  auto *receiver1Add =
+      receiver1Fn->createAdd("add", receiver1Recv, receiver1RHS);
+  auto *receiver1Save = receiver1Fn->createSave("save", receiver1Add);
+
+  // Create the first receiver function. This function adds 2 to the result
+  // received from the sender function and saves the result (which should be 4).
+  Function *receiver2Fn = module->createFunction("receiver2Fn");
+  auto *receiver2Recv = receiver2Fn->createReceive(
+      "recv", senderFnAdd->getResult().getType(), address2);
+  auto *receiver2RHS = module->createConstant(ElemKind::FloatTy, {1}, "rhs");
+  auto receiver2RHSH = receiver2RHS->getPayload().getHandle();
+  receiver2RHSH = {2};
+  auto *receiver2Add =
+      receiver2Fn->createAdd("add", receiver2Recv, receiver2RHS);
+  auto *receiver2Save = receiver2Fn->createSave("save", receiver2Add);
+
+  // Compile the functions.
+  std::vector<std::unique_ptr<CompiledFunction>> senderBacking,
+      receiver1Backing, receiver2Backing;
+  FunctionMapTy senderFunctions = compileFunctions(
+      BackendKind::Interpreter, module.get(), senderBacking, {"senderFn"});
+  FunctionMapTy receiver1Functions =
+      compileFunctions(BackendKind::Interpreter, module.get(), receiver1Backing,
+                       {"receiver1Fn"});
+  FunctionMapTy receiver2Functions =
+      compileFunctions(BackendKind::Interpreter, module.get(), receiver2Backing,
+                       {"receiver2Fn"});
+
+  // Add the functions to their respective devices.
+  std::promise<const Module *> p1, p2, p3;
+  std::future<const Module *> f1, f2, f3;
+
+  std::tie(p1, f1) = getFutureHelper<const Module *>();
+  sender->addNetwork(module.get(), senderFunctions,
+                     [&p1](const Module *module, llvm::Error err) {
+                       callbackHelper(p1, module, std::move(err));
+                     });
+  f1.wait();
+  EXPECT_EQ(f1.get(), module.get());
+
+  std::tie(p2, f2) = getFutureHelper<const Module *>();
+  receiver1->addNetwork(module.get(), receiver1Functions,
+                        [&p2](const Module *module, llvm::Error err) {
+                          callbackHelper(p2, module, std::move(err));
+                        });
+  f2.wait();
+  EXPECT_EQ(f2.get(), module.get());
+
+  std::tie(p3, f3) = getFutureHelper<const Module *>();
+  receiver2->addNetwork(module.get(), receiver2Functions,
+                        [&p3](const Module *module, llvm::Error err) {
+                          callbackHelper(p3, module, std::move(err));
+                        });
+  f3.wait();
+  EXPECT_EQ(f3.get(), module.get());
+
+  // Create and set ExecutionContexts for each function.
+  auto senderCtx = llvm::make_unique<ExecutionContext>();
+  auto receiver1Ctx = llvm::make_unique<ExecutionContext>();
+  auto receiver2Ctx = llvm::make_unique<ExecutionContext>();
+
+  senderCtx->getPlaceholderBindings()->allocate(send1->getPlaceholder());
+  senderCtx->getPlaceholderBindings()->allocate(send2->getPlaceholder());
+  auto AH1 = senderCtx->getPlaceholderBindings()
+                 ->allocate(address1)
+                 ->getHandle<uintptr_t>();
+  auto AH2 = senderCtx->getPlaceholderBindings()
+                 ->allocate(address2)
+                 ->getHandle<uintptr_t>();
+
+  // Get the addresses of the ReceiveNode Placeholders from the receiver devices
+  // and set the address inputs of the sender's SendNodes to these addresses.
+  uintptr_t addr1, addr2;
+  ASSIGN_VALUE_OR_ASSERT(
+      addr1, receiver1->getPlaceholderAddress(receiver1Fn->getName(),
+                                              receiver1Recv->getPlaceholder()));
+  ASSIGN_VALUE_OR_ASSERT(
+      addr2, receiver2->getPlaceholderAddress(receiver2Fn->getName(),
+                                              receiver2Recv->getPlaceholder()));
+  AH1 = {addr1};
+  AH2 = {addr2};
+
+  receiver1Ctx->getPlaceholderBindings()->allocate(
+      receiver1Recv->getPlaceholder());
+  AH1 = receiver1Ctx->getPlaceholderBindings()
+            ->allocate(address1)
+            ->getHandle<uintptr_t>();
+  // Set the address of this receiver's ReceiveNode to the same as the first
+  // SendNode in the sender.
+  AH1 = {addr1};
+  receiver1Ctx->getPlaceholderBindings()->allocate(
+      receiver1Save->getPlaceholder());
+
+  receiver2Ctx->getPlaceholderBindings()->allocate(
+      receiver2Recv->getPlaceholder());
+  AH2 = receiver2Ctx->getPlaceholderBindings()
+            ->allocate(address2)
+            ->getHandle<uintptr_t>();
+  // Set the address of this receiver's ReceiveNode to the same as the second
+  // SendNode in the sender.
+  AH2 = {addr2};
+  receiver2Ctx->getPlaceholderBindings()->allocate(
+      receiver2Save->getPlaceholder());
+
+  // Run all three functions.
+  std::promise<std::unique_ptr<ExecutionContext>> runP1, runP2, runP3;
+  std::future<std::unique_ptr<ExecutionContext>> runF1, runF2, runF3;
+  std::tie(runP1, runF1) = getFutureHelper<std::unique_ptr<ExecutionContext>>();
+  std::tie(runP2, runF2) = getFutureHelper<std::unique_ptr<ExecutionContext>>();
+  std::tie(runP3, runF3) = getFutureHelper<std::unique_ptr<ExecutionContext>>();
+
+  sender->runFunction("senderFn", std::move(senderCtx),
+                      [&runP1](RunIdentifierTy, llvm::Error err,
+                               std::unique_ptr<ExecutionContext> context) {
+                        callbackHelper(runP1, std::move(context),
+                                       std::move(err));
+                      });
+
+  receiver1->runFunction("receiver1Fn", std::move(receiver1Ctx),
+                         [&runP2](RunIdentifierTy, llvm::Error err,
+                                  std::unique_ptr<ExecutionContext> context) {
+                           callbackHelper(runP2, std::move(context),
+                                          std::move(err));
+                         });
+
+  receiver2->runFunction("receiver2Fn", std::move(receiver2Ctx),
+                         [&runP3](RunIdentifierTy, llvm::Error err,
+                                  std::unique_ptr<ExecutionContext> context) {
+                           callbackHelper(runP3, std::move(context),
+                                          std::move(err));
+                         });
+
+  // Wait for the functions to finish.
+  senderCtx = runF1.get();
+  receiver1Ctx = runF2.get();
+  receiver2Ctx = runF3.get();
+  ASSERT_TRUE(senderCtx);
+  ASSERT_TRUE(receiver1Ctx);
+  ASSERT_TRUE(receiver2Ctx);
+  EXPECT_NE(senderCtx, receiver1Ctx);
+  EXPECT_NE(receiver1Ctx, receiver2Ctx);
+  EXPECT_NE(senderCtx, receiver2Ctx);
+
+  // The sender should send 3 to which the first receiver adds 1, which should
+  // yield 4.
+  auto RH1 = receiver1Ctx->getPlaceholderBindings()
+                 ->get(receiver1Save->getPlaceholder())
+                 ->getHandle();
+  ASSERT_EQ(RH1.raw(0), 4);
+
+  // The sender should send 3 to which the first receiver adds 2, which should
+  // yield 5.
+  auto RH2 = receiver2Ctx->getPlaceholderBindings()
+                 ->get(receiver2Save->getPlaceholder())
+                 ->getHandle();
+  ASSERT_EQ(RH2.raw(0), 5);
+}
+
+/// Tests peer-to-peer communication with multiple senders and multiple
+/// receivers.
+TEST_P(PeerToPeerTest, MultipleSendersMultipleReceivers) {
+  // Create two sender and two receiver devices.
+  auto sender1 = std::unique_ptr<DeviceManager>(
+      DeviceManager::createDeviceManager(backendKind));
+  auto sender2 = std::unique_ptr<DeviceManager>(
+      DeviceManager::createDeviceManager(backendKind));
+  auto receiver1 = std::unique_ptr<DeviceManager>(
+      DeviceManager::createDeviceManager(backendKind));
+  auto receiver2 = std::unique_ptr<DeviceManager>(
+      DeviceManager::createDeviceManager(backendKind));
+
+  ASSERT_FALSE(errToBool(sender1->init()));
+  ASSERT_FALSE(errToBool(sender2->init()));
+  ASSERT_FALSE(errToBool(receiver1->init()));
+  ASSERT_FALSE(errToBool(receiver2->init()));
+
+  auto module = llvm::make_unique<Module>();
+
+  // Create the first sender function. This function computes 1 + 2 and sends
+  // the result to the first receiver.
+  Function *sender1Fn = module->createFunction("sender1Fn");
+  auto *sender1FnLHS = module->createConstant(ElemKind::FloatTy, {1}, "lhs");
+  auto sender1LHSH = sender1FnLHS->getPayload().getHandle();
+  sender1LHSH = {1};
+  auto *sender1FnRHS = module->createConstant(ElemKind::FloatTy, {1}, "rhs");
+  auto sender1RHSH = sender1FnRHS->getPayload().getHandle();
+  sender1RHSH = {2};
+  auto *sender1FnAdd = sender1Fn->createAdd("add", sender1FnLHS, sender1FnRHS);
+  auto *address1 =
+      module->createPlaceholder(ElemKind::AddrTy, {1}, "address1", false);
+  auto *send1 = sender1Fn->createSend("send1", sender1FnAdd, address1);
+
+  // Create the second sender function. This function computes 3 + 4 and sends
+  // the result to the second receiver.
+  Function *sender2Fn = module->createFunction("sender2Fn");
+  auto *sender2FnLHS = module->createConstant(ElemKind::FloatTy, {1}, "lhs");
+  auto sender2LHSH = sender2FnLHS->getPayload().getHandle();
+  sender2LHSH = {3};
+  auto *sender2FnRHS = module->createConstant(ElemKind::FloatTy, {1}, "rhs");
+  auto sender2RHSH = sender2FnRHS->getPayload().getHandle();
+  sender2RHSH = {4};
+  auto *sender2FnAdd = sender2Fn->createAdd("add", sender2FnLHS, sender2FnRHS);
+  auto *address2 =
+      module->createPlaceholder(ElemKind::AddrTy, {1}, "address2", false);
+  auto *send2 = sender2Fn->createSend("send2", sender2FnAdd, address2);
+
+  // Create the first receiver function. This function recieves the result of
+  // the first sender function, adds 1 to to it and saves the result.
+  Function *receiver1Fn = module->createFunction("receiver1Fn");
+  auto *receiver1Recv = receiver1Fn->createReceive(
+      "recv", sender1FnAdd->getResult().getType(), address1);
+  auto *receiver1RHS = module->createConstant(ElemKind::FloatTy, {1}, "rhs");
+  auto receiver1RHSH = receiver1RHS->getPayload().getHandle();
+  receiver1RHSH = {1};
+  auto *receiver1Add =
+      receiver1Fn->createAdd("add", receiver1Recv, receiver1RHS);
+  auto *receiver1Save = receiver1Fn->createSave("save", receiver1Add);
+
+  // Create the second receiver function. This function recieves the result of
+  // the second sender function, adds 2 to to it and saves the result.
+  Function *receiver2Fn = module->createFunction("receiver2Fn");
+  auto *receiver2Recv = receiver2Fn->createReceive(
+      "recv", sender2FnAdd->getResult().getType(), address2);
+  auto *receiver2RHS = module->createConstant(ElemKind::FloatTy, {1}, "rhs");
+  auto receiver2RHSH = receiver2RHS->getPayload().getHandle();
+  receiver2RHSH = {2};
+  auto *receiver2Add =
+      receiver2Fn->createAdd("add", receiver2Recv, receiver2RHS);
+  auto *receiver2Save = receiver2Fn->createSave("save", receiver2Add);
+
+  // Compile all functions.
+  std::vector<std::unique_ptr<CompiledFunction>> sender1Backing, sender2Backing,
+      receiver1Backing, receiver2Backing;
+  FunctionMapTy sender1Functions = compileFunctions(
+      BackendKind::Interpreter, module.get(), sender1Backing, {"sender1Fn"});
+  FunctionMapTy sender2Functions = compileFunctions(
+      BackendKind::Interpreter, module.get(), sender2Backing, {"sender2Fn"});
+  FunctionMapTy receiver1Functions =
+      compileFunctions(BackendKind::Interpreter, module.get(), receiver1Backing,
+                       {"receiver1Fn"});
+  FunctionMapTy receiver2Functions =
+      compileFunctions(BackendKind::Interpreter, module.get(), receiver2Backing,
+                       {"receiver2Fn"});
+
+  // Add all functions to their respective devices.
+  std::promise<const Module *> p1, p2, p3, p4;
+  std::future<const Module *> f1, f2, f3, f4;
+
+  std::tie(p1, f1) = getFutureHelper<const Module *>();
+  sender1->addNetwork(module.get(), sender1Functions,
+                      [&p1](const Module *module, llvm::Error err) {
+                        callbackHelper(p1, module, std::move(err));
+                      });
+  f1.wait();
+  EXPECT_EQ(f1.get(), module.get());
+
+  std::tie(p2, f2) = getFutureHelper<const Module *>();
+  sender2->addNetwork(module.get(), sender2Functions,
+                      [&p2](const Module *module, llvm::Error err) {
+                        callbackHelper(p2, module, std::move(err));
+                      });
+  f2.wait();
+  EXPECT_EQ(f2.get(), module.get());
+
+  std::tie(p3, f3) = getFutureHelper<const Module *>();
+  receiver1->addNetwork(module.get(), receiver1Functions,
+                        [&p3](const Module *module, llvm::Error err) {
+                          callbackHelper(p3, module, std::move(err));
+                        });
+  f3.wait();
+  EXPECT_EQ(f3.get(), module.get());
+
+  std::tie(p4, f4) = getFutureHelper<const Module *>();
+  receiver2->addNetwork(module.get(), receiver2Functions,
+                        [&p4](const Module *module, llvm::Error err) {
+                          callbackHelper(p4, module, std::move(err));
+                        });
+  f4.wait();
+  EXPECT_EQ(f4.get(), module.get());
+
+  // Create and set ExecutionContexts for each function.
+  auto sender1Ctx = llvm::make_unique<ExecutionContext>();
+  auto sender2Ctx = llvm::make_unique<ExecutionContext>();
+  auto receiver1Ctx = llvm::make_unique<ExecutionContext>();
+  auto receiver2Ctx = llvm::make_unique<ExecutionContext>();
+
+  sender1Ctx->getPlaceholderBindings()->allocate(send1->getPlaceholder());
+  sender2Ctx->getPlaceholderBindings()->allocate(send2->getPlaceholder());
+
+  // Get the addresses of the Placeholders of the ReceiveNodes in the two
+  // receivers and assign those addresses to the address inputs of the SendNodes
+  // in the corresponding senders.
+  uintptr_t addr1, addr2;
+  ASSIGN_VALUE_OR_ASSERT(
+      addr1, receiver1->getPlaceholderAddress(receiver1Fn->getName(),
+                                              receiver1Recv->getPlaceholder()));
+  ASSIGN_VALUE_OR_ASSERT(
+      addr2, receiver2->getPlaceholderAddress(receiver2Fn->getName(),
+                                              receiver2Recv->getPlaceholder()));
+  auto AH1 = sender1Ctx->getPlaceholderBindings()
+                 ->allocate(address1)
+                 ->getHandle<uintptr_t>();
+  auto AH2 = sender2Ctx->getPlaceholderBindings()
+                 ->allocate(address2)
+                 ->getHandle<uintptr_t>();
+  AH1 = {addr1};
+  AH2 = {addr2};
+
+  receiver1Ctx->getPlaceholderBindings()->allocate(
+      receiver1Recv->getPlaceholder());
+  AH1 = receiver1Ctx->getPlaceholderBindings()
+            ->allocate(address1)
+            ->getHandle<uintptr_t>();
+  // Set the address of this receiver's ReceiveNode to the same as the first
+  // sender's SendNode.
+  AH1 = {addr1};
+  receiver1Ctx->getPlaceholderBindings()->allocate(
+      receiver1Save->getPlaceholder());
+
+  receiver2Ctx->getPlaceholderBindings()->allocate(
+      receiver2Recv->getPlaceholder());
+  AH2 = receiver2Ctx->getPlaceholderBindings()
+            ->allocate(address2)
+            ->getHandle<uintptr_t>();
+  // Set the address of this receiver's ReceiveNode to the same as the second
+  // sender's SendNode.
+  AH2 = {addr2};
+  receiver2Ctx->getPlaceholderBindings()->allocate(
+      receiver2Save->getPlaceholder());
+
+  // Run all of the functions.
+  std::promise<std::unique_ptr<ExecutionContext>> runP1, runP2, runP3, runP4;
+  std::future<std::unique_ptr<ExecutionContext>> runF1, runF2, runF3, runF4;
+  std::tie(runP1, runF1) = getFutureHelper<std::unique_ptr<ExecutionContext>>();
+  std::tie(runP2, runF2) = getFutureHelper<std::unique_ptr<ExecutionContext>>();
+  std::tie(runP3, runF3) = getFutureHelper<std::unique_ptr<ExecutionContext>>();
+  std::tie(runP4, runF4) = getFutureHelper<std::unique_ptr<ExecutionContext>>();
+
+  sender1->runFunction("sender1Fn", std::move(sender1Ctx),
+                       [&runP1](RunIdentifierTy, llvm::Error err,
+                                std::unique_ptr<ExecutionContext> context) {
+                         callbackHelper(runP1, std::move(context),
+                                        std::move(err));
+                       });
+
+  sender2->runFunction("sender2Fn", std::move(sender2Ctx),
+                       [&runP2](RunIdentifierTy, llvm::Error err,
+                                std::unique_ptr<ExecutionContext> context) {
+                         callbackHelper(runP2, std::move(context),
+                                        std::move(err));
+                       });
+
+  receiver1->runFunction("receiver1Fn", std::move(receiver1Ctx),
+                         [&runP3](RunIdentifierTy, llvm::Error err,
+                                  std::unique_ptr<ExecutionContext> context) {
+                           callbackHelper(runP3, std::move(context),
+                                          std::move(err));
+                         });
+
+  receiver2->runFunction("receiver2Fn", std::move(receiver2Ctx),
+                         [&runP4](RunIdentifierTy, llvm::Error err,
+                                  std::unique_ptr<ExecutionContext> context) {
+                           callbackHelper(runP4, std::move(context),
+                                          std::move(err));
+                         });
+
+  // Wait for all of the functions to complete.
+  sender1Ctx = runF1.get();
+  sender2Ctx = runF2.get();
+  receiver1Ctx = runF3.get();
+  receiver2Ctx = runF4.get();
+  ASSERT_TRUE(sender1Ctx);
+  ASSERT_TRUE(sender2Ctx);
+  ASSERT_TRUE(receiver1Ctx);
+  ASSERT_TRUE(receiver2Ctx);
+  EXPECT_NE(sender1Ctx, sender2Ctx);
+  EXPECT_NE(receiver1Ctx, receiver2Ctx);
+
+  // The first sender computes and sends 1 + 2 and the receiver adds 1, so the
+  // result should be 4.
+  auto RH1 = receiver1Ctx->getPlaceholderBindings()
+                 ->get(receiver1Save->getPlaceholder())
+                 ->getHandle();
+  ASSERT_EQ(RH1.raw(0), 4);
+
+  // The first sender computes and sends 3 + 4 and the receiver adds 2, so the
+  // result should be 9.
+  auto RH2 = receiver2Ctx->getPlaceholderBindings()
+                 ->get(receiver2Save->getPlaceholder())
+                 ->getHandle();
+  ASSERT_EQ(RH2.raw(0), 9);
+}
+
+/// Instantiate peer-to-peer tests for the Interpreter backend.
+INSTANTIATE_TEST_CASE_P(Interpreter, PeerToPeerTest,
+                        ::testing::Values(BackendKind::Interpreter));

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -73,6 +73,24 @@ int main(int argc, char **argv) {
       .dataParallel();
 
   //===--------------------------------------------------------------------===//
+  //                   Peer-to-Peer Communication
+  //===--------------------------------------------------------------------===//
+
+  BB.newInstr("Send")
+      .addOperand("Src", OperandKind::In)
+      .addOperand("Addr", OperandKind::In)
+      .setType("Src->getType()")
+      .inplaceOperand({"Src", "Addr"})
+      .autoVerify(VerifyKind::NoVerify);
+
+  BB.newInstr("Recv")
+      .addOperand("Dest", OperandKind::Out)
+      .addOperand("Addr", OperandKind::In)
+      .setType("Dest->getType()")
+      .inplaceOperand({"Dest", "Addr"})
+      .autoVerify(VerifyKind::NoVerify);
+
+  //===--------------------------------------------------------------------===//
   //                   Convolution / Pool / FC
   //===--------------------------------------------------------------------===//
 

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -54,6 +54,31 @@ int main(int argc, char **argv) {
                     "this node and all of its ancestor nodes. Generally "
                     "intended to save the final result of a network.");
 
+  BB.newNode("Send")
+      .addInput("Input")
+      .addInput("Address")
+      .addInput("Output")
+      .addExtraMethod("Placeholder *getPlaceholder() const;",
+                      "Placeholder *SendNode::getPlaceholder() const { return "
+                      "llvm::cast<Placeholder>(Output_.getNode()); };")
+      .addOverwrittenInput("Output")
+      .setHasSideEffects(true)
+      .setDocstring(
+          "Sends the Tensor to the Receive nodes listening on the same "
+          "Address.");
+
+  BB.newNode("Receive")
+      .addInput("Address")
+      .addInput("Output")
+      .addExtraMethod(
+          "Placeholder *getPlaceholder() const;",
+          "Placeholder *ReceiveNode::getPlaceholder() const { return "
+          "llvm::cast<Placeholder>(Output_.getNode()); };")
+      .addOverwrittenInput("Output")
+      .addResultFromCtorArg()
+      .setHasSideEffects(true)
+      .setDocstring("Receives a Tensor sent by a SendNode to Address");
+
   //===--------------------------------------------------------------------===//
   //                   Convolution / Pool / FC
   //===--------------------------------------------------------------------===//


### PR DESCRIPTION
**Description**
This commit implements peer-to-peer communication for the Interpreter
backend. This feature can be used to send/receive Tensors from a
function on one device to/from a second function on another device
without using host memory as an intermediary (which is the status quo).

This commit adds Send and Receive nodes to the graph IR to explictly
represent these operations as well as corresponding send and receive
instructions in the instruction IR. A SendNode and ReceiveNode are
"paired" at execution time using the Tensor bound to their "address"
inputs. This is a Tensor of shape {1} that contains some sort of token
or address that the backend can interpret however it wants to transmit
data between the Send and Receive nodes to which that token is bound.
In addition to sending and receiving data using peer-to-peer
communication, the Send and Receive nodes also write the data they
send/receive to a Placeholder so that they can be inspected (e.g. for
debugging).

In the case of the Interpreter backend, the "token" mentioned above is
the address of the ReceiveNode's Placeholder, and the data is
transferred using a future-promise pair of type Tensor (i.e.
std::future<Tensor> and std::promise<Tensor>). Each tuple of (function
name, placeholder address) maps to a future-promise pair, and the
Interpreter implementation of send fulfills the promise, and the
implementation of recv waits on the future.

**Testing**
This commit adds a new unit test, PeerToPeerTest, which tests
sending/receiving data with one sender + one receiver, one sender with
multiple send nodes and multiple receivers, and multiple senders and
multiple receivers.
```
$ ./tests/PeerToPeerTest 
[==========] Running 3 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 3 tests from Interpreter/PeerToPeerTest
[ RUN      ] Interpreter/PeerToPeerTest.SingleSenderSingleReceiver/0
[       OK ] Interpreter/PeerToPeerTest.SingleSenderSingleReceiver/0 (6 ms)
[ RUN      ] Interpreter/PeerToPeerTest.SingleSenderMultipleReceivers/0
[       OK ] Interpreter/PeerToPeerTest.SingleSenderMultipleReceivers/0 (1 ms)
[ RUN      ] Interpreter/PeerToPeerTest.MultipleSendersMultipleReceivers/0
[       OK ] Interpreter/PeerToPeerTest.MultipleSendersMultipleReceivers/0 (2 ms)
[----------] 3 tests from Interpreter/PeerToPeerTest (11 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 1 test case ran. (11 ms total)
[  PASSED  ] 3 tests.

```
**Documentation**
Once the design is finalized after a few rounds of code review,
documentation will be added to reflect the updated design.