### PR TITLE
[compilationLog][version]: Include version number and latest commit's info in the compilation log.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,22 @@ include_directories(${GLOW_SOURCE_DIR})
 file(GLOB_RECURSE header_files include/*.h tools/*.h lib/*.h)
 add_custom_target(CollectHeaders SOURCES ${header_files})
 
+find_package(Git)
+# Get the commit's short SHA1
+execute_process(COMMAND
+  "${GIT_EXECUTABLE}" log -1 --pretty=format:"%h"
+  WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+  OUTPUT_VARIABLE GIT_SHA1
+  ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+add_definitions("-DGIT_SHA1=${GIT_SHA1}")
+# Get the date of the commit
+execute_process(COMMAND
+  "${GIT_EXECUTABLE}" log -1 --pretty=format:"%ad" --date=short
+  WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+  OUTPUT_VARIABLE GIT_DATE
+  ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+add_definitions("-DGIT_DATE=${GIT_DATE}")
+
 find_package(PNG)
 if(PNG_FOUND)
   add_definitions(-DWITH_PNG)

--- a/include/glow/Graph/Log.h
+++ b/include/glow/Graph/Log.h
@@ -39,6 +39,8 @@ private:
   std::string currentFullScope_;
 
 public:
+  LogContext() { addLogMetaData(); };
+
   /// Add content into the contents vector.
   void addLogContent(llvm::StringRef logContent);
 
@@ -62,6 +64,11 @@ public:
 
   /// Logs the node deletion.
   void logNodeDeletion(const Node &deletedNode);
+
+private:
+  /// Add log metadata which includes version number and latest commit's info
+  /// (hash, date).
+  void addLogMetaData();
 };
 
 /// Logs a new log scope.

--- a/lib/Graph/Log.cpp
+++ b/lib/Graph/Log.cpp
@@ -22,9 +22,29 @@
 
 namespace glow {
 
+/// Log version number.
+static constexpr auto logVersionNo_ = "v1.0.0";
+
 static llvm::cl::opt<bool>
     dumpCompilationLogOpt("dump-compilation-log", llvm::cl::init(false),
                           llvm::cl::desc("Dump compilation log"));
+
+void LogContext::addLogMetaData() {
+  addLogContent("<!-- Log Version: ");
+  addLogContent(logVersionNo_);
+  addLogContent(" -->\n");
+#ifdef GIT_SHA1
+  addLogContent("<!-- Log commit sha1: ");
+  addLogContent(GIT_SHA1);
+  addLogContent(" -->\n");
+#endif
+#ifdef GIT_DATE
+  addLogContent("<!-- Log commit date: ");
+  addLogContent(GIT_DATE);
+  addLogContent(" -->\n");
+#endif
+  addLogContent("\n");
+}
 
 void LogContext::addLogContent(llvm::StringRef logContent) {
   logContents_.push_back(logContent);


### PR DESCRIPTION
Summary:
Include version number and latest commit's info (date, hash) in the beginning of the dumped log. With this provided, we can link a stored log to a particular build of glow.

Test Plan:
Test run with googlenet_v1_slim/googlenet_v1_slim.onnx on image-classifier, and the output of the version and commit's info is shown below:
`<!-- Log Version: v1.0.0 -->`
`<!-- Log commit sha1: 9afe27d9 -->`
`<!-- Log commit date: 2019-06-11 -->`