### PR TITLE
[trivial] fix OCL build due to deprecation warning

### DIFF
--- a/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
@@ -47,6 +47,8 @@ namespace runtime {
 DeviceManager *createOCLDeviceManager(const DeviceConfig &config) {
   return new OpenCLDeviceManager(config);
 }
+
+OpenCLBuffer::~OpenCLBuffer() { clReleaseMemObject(buffer_); }
 } // namespace runtime
 } // namespace glow
 

--- a/lib/Backends/OpenCL/OpenCLDeviceManager.h
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.h
@@ -44,7 +44,7 @@ class OpenCLBuffer {
   const size_t size_{0};
 
 public:
-  ~OpenCLBuffer() { clReleaseMemObject(buffer_); }
+  ~OpenCLBuffer();
 
   OpenCLBuffer(cl_mem buffer, size_t size) : buffer_(buffer), size_(size) {}
 


### PR DESCRIPTION
Summary: clReleaseMemObject is deprecated in the OSX OCL lib, which generates a warning which fails the build under -Werror. Moving the OpenCLBuffer dtor to the source file covers it by the CL_SILENCE_DEPRECATION define we have there.
Documentation: n/a
Test Plan: build & test under ASAN.
