### PR TITLE
[LLVMIRCodeGen] Fix LLVM debug info generation

### DIFF
--- a/lib/LLVMIRCodeGen/DebugInfo.cpp
+++ b/lib/LLVMIRCodeGen/DebugInfo.cpp
@@ -213,7 +213,7 @@ static void initBaseAddressesOfMemoryAreas(DebugInfo &dbgInfo,
     // make sure it is not removed by optimizations.
     auto baseAddressVar = new llvm::GlobalVariable(
         M, builder.getInt8PtrTy(), /* isConst */ false,
-        llvm::GlobalValue::CommonLinkage, nullptr, name);
+        llvm::GlobalValue::ExternalLinkage, nullptr, name);
     baseAddressVar->setInitializer(
         llvm::ConstantPointerNull::get(builder.getInt8PtrTy()));
     // Initialize the variable by the corresponding base address passed to
@@ -423,7 +423,7 @@ void LLVMIRGen::generateDebugInfo() {
 
   // Emit the debug info for weight variables and activations variables used by
   // the Glow IR. Represent those variables as global variables.
-  for (auto &v : F_->getGraph()->getParent()->getConstants()) {
+  for (auto &v : F_->findConstants()) {
     auto *w = cast<WeightVar>(F_->getWeightForNode(v));
     emitDebugGlobalVariableForValue(w);
   }


### PR DESCRIPTION
- Global variables holding base addresses of different memory areas should be global, otherwise symbol lookup does not work properly with the latest ORC JIT and Glow's JIT cannot even run the compiled NN model due to unresolved symbols

- When emitting information about constants consider only constants used by the current IRFunction
