### PR TITLE
Add unpaddedSize to move ctor/assignment op

### DIFF
--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -348,6 +348,7 @@ public:
     std::swap(type_, other.type_);
     std::swap(isUnowned_, other.isUnowned_);
     std::swap(tensorPool_, other.tensorPool_);
+    std::swap(unpaddedSize_, other.unpaddedSize_);
   }
 
   /// Move assignment operator.
@@ -356,6 +357,7 @@ public:
     std::swap(type_, other.type_);
     std::swap(isUnowned_, other.isUnowned_);
     std::swap(tensorPool_, other.tensorPool_);
+    std::swap(unpaddedSize_, other.unpaddedSize_);
     return *this;
   }
 

--- a/tests/unittests/TensorsTest.cpp
+++ b/tests/unittests/TensorsTest.cpp
@@ -940,3 +940,14 @@ max: 1515.200  min: 1.200
   EXPECT_EQ(mes2, expectMes2);
   EXPECT_EQ(mes2, osT3.str());
 }
+
+/// Test unpadded size.
+TEST(Tensor, unpaddedSize) {
+  Tensor partial(ElemKind::FloatTy, {11});
+  auto paddedType = Type::newShape(partial.getType(), {256});
+  auto bytes = partial.getSizeInBytes();
+  Tensor T(partial.getUnsafePtr(), &paddedType, bytes);
+  EXPECT_EQ(T.getUnpaddedSizeInBytes(), bytes);
+  auto moved = std::move(T);
+  EXPECT_EQ(moved.getUnpaddedSizeInBytes(), bytes);
+}


### PR DESCRIPTION
Summary: Forgot to add this; without swapping the unpaddedSize, moving the Tensor loses the fact that it is, in fact, an unpadded tensor.

Reviewed By: rdzhabarov

Differential Revision: D15794380

