### PR TITLE
Fix unchecked Errors

### DIFF
--- a/examples/mnist.cpp
+++ b/examples/mnist.cpp
@@ -245,6 +245,7 @@ void testMNISTLoadAndTraining() {
   const char *inputName = "data";
 
   llvm::Error errPtr = llvm::Error::success();
+  (void)!!errPtr; // Mark Error as checked before it's assigned to.
   // Load and compile LeNet MNIST model.
   glow::Caffe2ModelLoader loader("lenet_mnist/predict_net.pb",
                                  "lenet_mnist/init_net.pb", {inputName},

--- a/examples/mnist.cpp
+++ b/examples/mnist.cpp
@@ -245,7 +245,7 @@ void testMNISTLoadAndTraining() {
   const char *inputName = "data";
 
   llvm::Error errPtr = llvm::Error::success();
-  (void)!!errPtr; // Mark Error as checked before it's assigned to.
+  MARK_ERR_CHECKED(errPtr);
   // Load and compile LeNet MNIST model.
   glow::Caffe2ModelLoader loader("lenet_mnist/predict_net.pb",
                                  "lenet_mnist/init_net.pb", {inputName},

--- a/include/glow/Support/Error.h
+++ b/include/glow/Support/Error.h
@@ -248,7 +248,6 @@ template <typename T> llvm::Error takeErr(llvm::Expected<T> e) {
 /// added when the class already holds an Error, it will discard the new Error
 /// in favor of the original one. All methods in OneErrOnly are thread-safe.
 class OneErrOnly {
-private:
   llvm::Error err_ = llvm::Error::success();
   std::mutex m_;
 

--- a/include/glow/Support/Error.h
+++ b/include/glow/Support/Error.h
@@ -224,6 +224,18 @@ private:
     }                                                                          \
   } while (0)
 
+/// Marks the given llvm::Error as checked as long as it's value is equal to
+/// llvm::Error::success(). This macro should be used as little as possible but
+/// but is useful for example for creating dummy Errors that can be passed into
+/// fallible constructor by reference to be filled in the event an Error occurs.
+#define MARK_ERR_CHECKED(err)                                                  \
+  do {                                                                         \
+    bool success = !(err);                                                     \
+    (void)success;                                                             \
+    assert(success && "MARK_ERR_CHECKED should not be called on an "           \
+                      "llvm::Error that contains an actual error.");           \
+  } while (0)
+
 /// Marks the Error \p err as as checked. \returns true if it contains an
 /// error value and prints the message in the error value, returns false
 /// otherwise.

--- a/lib/Backends/CPU/CPUDeviceManager.cpp
+++ b/lib/Backends/CPU/CPUDeviceManager.cpp
@@ -101,22 +101,16 @@ void CPUDeviceManager::addNetworkImpl(const Module *module,
 
 void CPUDeviceManager::evictNetworkImpl(std::string functionName,
                                         EvictFunctionCBTy evictCB) {
-  llvm::Error err = llvm::Error::success();
-
   if (functions_.erase(functionName)) {
     usedMemoryBytes_ -= functionCost_; // TODO: static moduleSize
   } else {
-    err =
+    evictCB(
+        functionName,
         MAKE_ERR(GlowErr::ErrorCode::RUNTIME_NET_NOT_FOUND,
                  llvm::formatv("Could not find function with name {0} to evict",
                                functionName)
-                     .str());
-  }
-
-  if (evictCB) {
-    evictCB(functionName, std::move(err));
-  } else {
-    llvm::errs() << llvm::toString(std::move(err));
+                     .str()));
+    return;
   }
 }
 

--- a/lib/Backends/CPU/CPUDeviceManager.cpp
+++ b/lib/Backends/CPU/CPUDeviceManager.cpp
@@ -104,14 +104,13 @@ void CPUDeviceManager::evictNetworkImpl(std::string functionName,
   if (functions_.erase(functionName)) {
     usedMemoryBytes_ -= functionCost_; // TODO: static moduleSize
   } else {
-    evictCB(
-        functionName,
-        MAKE_ERR(GlowErr::ErrorCode::RUNTIME_NET_NOT_FOUND,
-                 llvm::formatv("Could not find function with name {0} to evict",
-                               functionName)
-                     .str()));
+    evictCB(functionName,
+            MAKE_ERR(GlowErr::ErrorCode::RUNTIME_NET_NOT_FOUND,
+                     strFormat("Could not find function with name %s to evict",
+                               functionName.c_str())));
     return;
   }
+  evictCB(functionName, llvm::Error::success());
 }
 
 void CPUDeviceManager::runFunctionImpl(

--- a/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
@@ -99,22 +99,14 @@ void InterpreterDeviceManager::addNetworkImpl(const Module *module,
 
 void InterpreterDeviceManager::evictNetworkImpl(std::string functionName,
                                                 EvictFunctionCBTy evictCB) {
-  llvm::Error err = llvm::Error::success();
-
   if (functions_.erase(functionName)) {
     usedMemoryBytes_ -= functionCost_; // TODO: static moduleSize
   } else {
-    err =
-        MAKE_ERR(GlowErr::ErrorCode::RUNTIME_NET_NOT_FOUND,
-                 llvm::formatv("Could not find function with name {0} to evict",
-                               functionName)
-                     .str());
-  }
-
-  if (evictCB) {
-    evictCB(functionName, std::move(err));
-  } else {
-    llvm::errs() << llvm::toString(std::move(err));
+    evictCB(functionName,
+            MAKE_ERR(GlowErr::ErrorCode::RUNTIME_NET_NOT_FOUND,
+                     strFormat("Could not find function with name %s to evict",
+                               functionName.c_str())));
+    return;
   }
 }
 

--- a/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
@@ -108,6 +108,7 @@ void InterpreterDeviceManager::evictNetworkImpl(std::string functionName,
                                functionName.c_str())));
     return;
   }
+  evictCB(functionName, llvm::Error::success());
 }
 
 void InterpreterDeviceManager::runFunctionImpl(

--- a/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
@@ -305,6 +305,7 @@ void OpenCLDeviceManager::evictNetworkImpl(std::string functionName,
                                functionName.c_str())));
     return;
   }
+  evictCB(functionName, llvm::Error::success());
 }
 
 cl_command_queue

--- a/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
@@ -289,8 +289,6 @@ void OpenCLDeviceManager::addNetworkImpl(const Module *module,
 
 void OpenCLDeviceManager::evictNetworkImpl(std::string functionName,
                                            EvictFunctionCBTy evictCB) {
-  llvm::Error err = llvm::Error::success();
-
   if (functions_.erase(functionName)) {
     auto buffer = buffers_[functionName];
     auto users = buffer->decrementUsers();
@@ -301,17 +299,11 @@ void OpenCLDeviceManager::evictNetworkImpl(std::string functionName,
       usedMemoryBytes_ -= size;
     }
   } else {
-    err =
-        MAKE_ERR(GlowErr::ErrorCode::RUNTIME_NET_NOT_FOUND,
-                 llvm::formatv("Could not find function with name {} to evict",
-                               functionName)
-                     .str());
-  }
-
-  if (evictCB) {
-    evictCB(functionName, std::move(err));
-  } else {
-    LOG(ERROR) << llvm::toString(std::move(err));
+    evictCB(functionName,
+            MAKE_ERR(GlowErr::ErrorCode::RUNTIME_NET_NOT_FOUND,
+                     strFormat("Could not find function with name %s to evict",
+                               functionName.c_str())));
+    return;
   }
 }
 

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -121,6 +121,7 @@ void ExecutionEngine::runInternal(ExecutionContext &context,
   std::promise<void> runPromise;
   auto fut = runPromise.get_future();
   llvm::Error runErr = llvm::Error::success();
+  (void)!!runErr; // Mark Error as checked before it's assigned to.
   device_->runFunction(
       name, std::move(contextPtr),
       [&runPromise, &runErr](runtime::RunIdentifierTy, llvm::Error err,
@@ -189,6 +190,7 @@ void ExecutionEngine::insertCompiledFunction(
   std::promise<void> addPromise;
   auto fut = addPromise.get_future();
   llvm::Error addErr = llvm::Error::success();
+  (void)!!addErr; // Mark Error as checked before it's assigned to.
   device_->addNetwork(&M_, std::move(functionMap),
                       [&addPromise, &addErr](const Module *, llvm::Error err) {
                         addErr = std::move(err);

--- a/lib/Importer/ONNXIFIModelLoader.cpp
+++ b/lib/Importer/ONNXIFIModelLoader.cpp
@@ -29,6 +29,8 @@ llvm::Expected<std::unique_ptr<ONNXIFIModelLoader>> ONNXIFIModelLoader::parse(
 
   std::unique_ptr<ONNXIFIModelLoader> loader(new ONNXIFIModelLoader());
   llvm::Error loaderConstructionErr = llvm::Error::success();
+  // Mark Error as checked before it's assigned to.
+  (void)!!loaderConstructionErr;
 
   if (use_onnx) {
     std::unique_ptr<ONNXModelLoader> onnxLoader(new ONNXModelLoader(

--- a/lib/Importer/ONNXIFIModelLoader.cpp
+++ b/lib/Importer/ONNXIFIModelLoader.cpp
@@ -29,8 +29,7 @@ llvm::Expected<std::unique_ptr<ONNXIFIModelLoader>> ONNXIFIModelLoader::parse(
 
   std::unique_ptr<ONNXIFIModelLoader> loader(new ONNXIFIModelLoader());
   llvm::Error loaderConstructionErr = llvm::Error::success();
-  // Mark Error as checked before it's assigned to.
-  (void)!!loaderConstructionErr;
+  MARK_ERR_CHECKED(loaderConstructionErr);
 
   if (use_onnx) {
     std::unique_ptr<ONNXModelLoader> onnxLoader(new ONNXModelLoader(

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -146,8 +146,9 @@ llvm::Error HostManager::removeNetwork(llvm::StringRef networkName) {
   for (auto &node : nodes) {
     for (auto device : node->deviceIDs) {
       std::promise<void> removeNetwork;
-      llvm::Error removeErr = llvm::Error::success();
       auto done = removeNetwork.get_future();
+      llvm::Error removeErr = llvm::Error::success();
+      (void)!!removeErr; // Mark Error as checked before it's assigned to.
       devices_[device]->evictNetwork(
           node->name,
           [&removeNetwork, &removeErr](std::string name, llvm::Error err) {
@@ -203,6 +204,7 @@ llvm::Error HostManager::runNetworkBlocking(llvm::StringRef networkName,
   std::promise<void> runPromise;
   auto fut = runPromise.get_future();
   llvm::Error runErr = llvm::Error::success();
+  (void)!!runErr; // Mark Error as checked before it's assigned to.
   runNetwork(
       networkName, std::move(context),
       [&runPromise, &runErr](runtime::RunIdentifierTy, llvm::Error err,

--- a/lib/Runtime/Provisioner/Provisioner.cpp
+++ b/lib/Runtime/Provisioner/Provisioner.cpp
@@ -158,9 +158,10 @@ llvm::Error Provisioner::provision(DAGListTy &networks, Module &module,
 
         // Load functions on device.
         DeviceIDTy logicalID = logicalDeviceSize[i].first;
-        llvm::Error addErr = llvm::Error::success();
         std::promise<void> addPromise;
         auto ready = addPromise.get_future();
+        llvm::Error addErr = llvm::Error::success();
+        (void)!!addErr; // Mark Error as checked before it's assigned to.
         devices_[deviceID]->addNetwork(
             &module, functionMaps[logicalID],
             [&addErr, &addPromise](const Module *, llvm::Error err) {

--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -406,7 +406,7 @@ TEST_P(BackendTest, compileVectorOfFunctions) {
   std::unique_ptr<Backend> backend(createBackend(GetParam()));
   BackendOptions opts;
   auto functionOrErr = backend->compileFunctions(functions, opts);
-  EXPECT_TRUE((bool)functionOrErr);
+  ASSERT_TRUE((bool)functionOrErr);
 }
 
 /// This test checks that we can compile a function without depending on the

--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -405,7 +405,8 @@ TEST_P(BackendTest, compileVectorOfFunctions) {
   }
   std::unique_ptr<Backend> backend(createBackend(GetParam()));
   BackendOptions opts;
-  auto function = backend->compileFunctions(functions, opts);
+  auto functionOrErr = backend->compileFunctions(functions, opts);
+  EXPECT_TRUE((bool)functionOrErr);
 }
 
 /// This test checks that we can compile a function without depending on the

--- a/tests/unittests/HostManagerTest.cpp
+++ b/tests/unittests/HostManagerTest.cpp
@@ -102,7 +102,7 @@ TEST_F(HostManagerTest, runNetwork) {
   auto ready = runNetwork.get_future();
 
   llvm::Error runErr = llvm::Error::success();
-
+  (void)!!runErr; // Mark Error as checked before it's assigned to.
   hostManager->runNetwork("main", std::move(context),
                           [&runNetwork, &saveTensor, &context, &runErr](
                               RunIdentifierTy runID, llvm::Error err,
@@ -121,6 +121,7 @@ TEST_F(HostManagerTest, runNetwork) {
 
   // reset runErr
   runErr = llvm::Error::success();
+  (void)!!runErr; // Mark Error as checked before it's assigned to.
 
   std::promise<void> newRun;
   ready = newRun.get_future();
@@ -193,6 +194,7 @@ TEST_F(HostManagerTest, ConfigureHostManager) {
   auto context2 = llvm::make_unique<ExecutionContext>();
 
   llvm::Error runErr = llvm::Error::success();
+  (void)!!runErr; // Mark Error as checked before it's assigned to.
 
   std::shared_ptr<std::mutex> lock = std::make_shared<std::mutex>();
   std::unique_lock<std::mutex> guard(*lock);

--- a/tests/unittests/HostManagerTest.cpp
+++ b/tests/unittests/HostManagerTest.cpp
@@ -101,8 +101,7 @@ TEST_F(HostManagerTest, runNetwork) {
   std::promise<void> runNetwork;
   auto ready = runNetwork.get_future();
 
-  llvm::Error runErr = llvm::Error::success();
-  (void)!!runErr; // Mark Error as checked before it's assigned to.
+  std::unique_ptr<llvm::Error> runErr;
   hostManager->runNetwork("main", std::move(context),
                           [&runNetwork, &saveTensor, &context, &runErr](
                               RunIdentifierTy runID, llvm::Error err,
@@ -112,16 +111,16 @@ TEST_F(HostManagerTest, runNetwork) {
                             EXPECT_NEAR(HX.at({1}), 4, 1E-5);
                             EXPECT_NEAR(HX.at({2}), 9, 1E-5);
                             context = std::move(context_);
-                            runErr = std::move(err);
+                            runErr =
+                                llvm::make_unique<llvm::Error>(std::move(err));
                             runNetwork.set_value();
                           });
 
   ready.wait();
-  EXPECT_FALSE(errToBool(std::move(runErr)));
+  EXPECT_FALSE(errToBool(std::move(*DCHECK_NOTNULL(runErr.get()))));
 
   // reset runErr
-  runErr = llvm::Error::success();
-  (void)!!runErr; // Mark Error as checked before it's assigned to.
+  runErr = nullptr;
 
   std::promise<void> newRun;
   ready = newRun.get_future();
@@ -133,12 +132,13 @@ TEST_F(HostManagerTest, runNetwork) {
                             EXPECT_NEAR(HX.at({0}), 1, 1E-5);
                             EXPECT_NEAR(HX.at({1}), 4, 1E-5);
                             EXPECT_NEAR(HX.at({2}), 9, 1E-5);
-                            runErr = std::move(err);
+                            runErr =
+                                llvm::make_unique<llvm::Error>(std::move(err));
                             newRun.set_value();
                           });
 
   ready.wait();
-  EXPECT_FALSE(errToBool(std::move(runErr)));
+  EXPECT_FALSE(errToBool(std::move(*DCHECK_NOTNULL(runErr.get()))));
 }
 
 /// Test that HostManager properly handles concurrent add/remove requests with
@@ -193,8 +193,7 @@ TEST_F(HostManagerTest, ConfigureHostManager) {
   auto context = llvm::make_unique<ExecutionContext>();
   auto context2 = llvm::make_unique<ExecutionContext>();
 
-  llvm::Error runErr = llvm::Error::success();
-  (void)!!runErr; // Mark Error as checked before it's assigned to.
+  std::unique_ptr<llvm::Error> runErr;
 
   std::shared_ptr<std::mutex> lock = std::make_shared<std::mutex>();
   std::unique_lock<std::mutex> guard(*lock);
@@ -203,6 +202,7 @@ TEST_F(HostManagerTest, ConfigureHostManager) {
   hostManager->runNetwork("main", std::move(context),
                           [lock](RunIdentifierTy runID, llvm::Error err,
                                  std::unique_ptr<ExecutionContext> context_) {
+                            errToBool(std::move(err));
                             std::unique_lock<std::mutex> guard(*lock);
                           });
 
@@ -210,10 +210,10 @@ TEST_F(HostManagerTest, ConfigureHostManager) {
       "main", std::move(context2),
       [&runErr](RunIdentifierTy runID, llvm::Error err,
                 std::unique_ptr<ExecutionContext> context_) {
-        runErr = std::move(err);
+        runErr = llvm::make_unique<llvm::Error>(std::move(err));
       });
 
   // Don't need a future, error CB called inline.
-  EXPECT_TRUE(errToBool(std::move(runErr)));
+  EXPECT_TRUE(errToBool(std::move(*DCHECK_NOTNULL(runErr.get()))));
   guard.unlock();
 }

--- a/tests/unittests/OCLTest.cpp
+++ b/tests/unittests/OCLTest.cpp
@@ -116,10 +116,12 @@ TEST(OpenCLCorrectnessTest, SetDeviceMemory) {
   // No setting at all, default memory size from OpenCL device info.
   OpenCLDeviceManager openCLDeviceDefault(openCLConfigEmpty);
   llvm::Error err1 = openCLDeviceDefault.init();
+  ASSERT_FALSE(errToBool(std::move(err1)));
   uint64_t memSize = openCLDeviceDefault.getMaximumMemory();
   // If limited by deviceConfig.
   OpenCLDeviceManager openCLDeviceSetByDeviceConfig(openCLConfigFull);
   llvm::Error err2 = openCLDeviceSetByDeviceConfig.init();
+  ASSERT_FALSE(errToBool(std::move(err2)));
   EXPECT_EQ(openCLDeviceSetByDeviceConfig.getMaximumMemory(), 32768);
   // If devicConfig defines larger memory size than the OpenCL device info,
   // then fall back to default.
@@ -127,5 +129,6 @@ TEST(OpenCLCorrectnessTest, SetDeviceMemory) {
   openCLConfigLarger.setDeviceMemory(memSize + 10000);
   OpenCLDeviceManager openCLDeviceLarger(openCLConfigLarger);
   llvm::Error err3 = openCLDeviceLarger.init();
+  ASSERT_FALSE(errToBool(std::move(err3)));
   EXPECT_EQ(openCLDeviceLarger.getMaximumMemory(), memSize);
 }

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -1530,7 +1530,7 @@ static void importPad(std::string fileName, const char *inputName,
                 inputShape[3]);
     if (expectLoadError) {
       llvm::Error err = llvm::Error::success();
-      (void)!!err; // Mark Error as checked before it's assigned to.
+      MARK_ERR_CHECKED(err);
       ONNXModelLoader(NetFilename, {inputName}, {&data.getType()}, *F, &err);
       EXPECT_TRUE(errToBool(std::move(err)));
       return;

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -1530,6 +1530,7 @@ static void importPad(std::string fileName, const char *inputName,
                 inputShape[3]);
     if (expectLoadError) {
       llvm::Error err = llvm::Error::success();
+      (void)!!err; // Mark Error as checked before it's assigned to.
       ONNXModelLoader(NetFilename, {inputName}, {&data.getType()}, *F, &err);
       EXPECT_TRUE(errToBool(std::move(err)));
       return;


### PR DESCRIPTION
Summary:
llvm::Errors should always be checked and in debug mode will assert if they aren't checked.
There a several unchecked llvm::Errors in Glow, mostly in tests due to a workaround for MSVC which doesn't like `std::promise<llvm::Error>`s
This PR should fix the existing issues but we still need to setup CI to check this on an ongoing basis.
See #2737 for more details.

Documentation:
n/a

