### PR TITLE
Where operator

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -1094,6 +1094,10 @@ public:
                                    llvm::StringRef eventType, Node *data,
                                    unsigned index);
 
+  /// Creates Where Node.
+  WhereNode *createWhere(llvm::StringRef name, NodeValue condition, NodeValue X,
+                         NodeValue Y);
+
   /// Erase the node \p N from the Function.
   void eraseNode(Node *N);
 

--- a/include/glow/Importer/ONNXModelLoader.h
+++ b/include/glow/Importer/ONNXModelLoader.h
@@ -132,6 +132,10 @@ class ONNXModelLoader
   llvm::Error loadConstantOfShape(const ONNX_NAMESPACE::NodeProto &op,
                                   const ArgumentDictionaryTy &dict);
 
+  /// Load Where ONNX operator.
+  llvm::Error loadWhere(const ONNX_NAMESPACE::NodeProto &op,
+                        const ArgumentDictionaryTy &dict);
+
 protected:
   /// Load the network operators from the GraphProto.
   /// \returns Error if network cannot be loaded.

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -315,6 +315,11 @@ bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
   case Kinded::Kind::TraceEventNodeKind:
     return NI.getInElemTy(TraceEventNode::DataIdx) == ElemKind::Int64ITy;
 
+  case Kinded::Kind::WhereNodeKind:
+    // check that x.type == y.type == out.type is done in node verification.
+    return NI.getOutElemTy(WhereNode::OutIdx) == ElemKind::FloatTy ||
+           NI.getOutElemTy(WhereNode::OutIdx) == ElemKind::Int8QTy;
+
   default:
     return false;
   }

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -365,6 +365,11 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
     // These work regardless of the underlying type.
     return true;
 
+  case Kinded::Kind::WhereNodeKind:
+    // check that x.type == y.type == out.type is done in node verification.
+    return NI.getOutElemTy(WhereNode::OutIdx) == ElemKind::FloatTy ||
+           NI.getOutElemTy(WhereNode::OutIdx) == ElemKind::Int8QTy;
+
   case Kinded::Kind::SoftMaxGradNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
                {ElemKind::FloatTy}, {SoftMaxGradNode::SelectedIdx},

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -257,6 +257,9 @@ private:
                                    TensorQuantizationParams &destQ);
 
   template <typename ElemTy> void fwdModuloInstImpl(glow::ModuloInst const *I);
+
+  template <typename ElemTy> void fwdWhereInstImpl(glow::WhereInst const *I);
+
   ///@}
 };
 

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -1286,6 +1286,16 @@ bool SpaceToDepthNode::verify() const {
   return sameType && dimTransform;
 }
 
+bool WhereNode::verify() const {
+  NodeValue X = getX();
+  NodeValue Y = getY();
+
+  if (X.getType() != Y.getType()) {
+    return false;
+  }
+  return true;
+}
+
 bool SaveNode::verify() const {
   return checkSameType(getInput(), getOutput(), this);
 }

--- a/tests/models/onnxModels/Where.onnxtxt
+++ b/tests/models/onnxModels/Where.onnxtxt
@@ -1,0 +1,110 @@
+ir_version: 5
+domain: "onnx"
+# ONNX TensorProto.DataType:
+#    UNDEFINED = 0;
+#    FLOAT = 1;
+#    UINT8 = 2;
+#    INT8 = 3;
+#    UINT16 = 4;
+#    INT16 = 5;
+#    INT32 = 6;
+#    INT64 = 7;
+#    STRING = 8;
+#    BOOL = 9;
+#    FLOAT16 = 10;
+#    DOUBLE = 11;
+#    UINT32 = 12;
+#    UINT64 = 13;
+#    COMPLEX64 = 14;
+#    COMPLEX128 = 15;
+graph {
+   input {
+    name: "Condition"
+    type {
+      tensor_type {
+        elem_type: 9
+        shape {
+        dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "X"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+         dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "Y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+         dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+   node {
+       input: "Condition"
+       input: "X"
+       input: "Y"
+       output: "Out"
+       name: "WhereNode"
+       op_type: "Where"
+       domain: ""
+   }
+
+output {
+    name: "Out"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 10
+}

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -648,6 +648,18 @@ int main(int argc, char **argv) {
       .autoIRGen();
 
   //===--------------------------------------------------------------------===//
+  //                Post Processing
+  //===--------------------------------------------------------------------===//
+
+  BB.newInstr("Where")
+      .addOperand("Out", OperandKind::Out)
+      .addOperand("Condition", OperandKind::In)
+      .addOperand("X", OperandKind::In)
+      .addOperand("Y", OperandKind::In)
+      .autoVerify(VerifyKind::SameElementType, {"X", "Y", "Out"})
+      .autoIRGen();
+
+  //===--------------------------------------------------------------------===//
   //                Backend-Specific Instructions
   //===--------------------------------------------------------------------===//
 

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -779,6 +779,21 @@ int main(int argc, char **argv) {
           "and Rescale nodes.");
 
   //===--------------------------------------------------------------------===//
+  //                Post Processing
+  //===--------------------------------------------------------------------===//
+
+  BB.newNode("Where")
+      .addInput("Condition")
+      .addInput("X")
+      .addInput("Y")
+      .addResultFromCtorArg("Out")
+      .setDocstring("Return elements, either from X or Y, depending on "
+                    "condition (with Numpy-style broadcasting support). Where "
+                    "behaves like numpy.where with three parameters: "
+                    "https://docs.scipy.org/doc/numpy/reference/generated/"
+                    "numpy.where.html");
+
+  //===--------------------------------------------------------------------===//
   //                Backend-Specific Nodes
   //===--------------------------------------------------------------------===//
 


### PR DESCRIPTION
Summary: CPU + Interpreter + Importer Test + Operator Tests
Implementation of Where Operator with multi directional broadcast support.*

*Two restrictions on that. Rank of X, Y, Cond must be equal.
Cond tensor must much first K dimensions of X,Y rest that don't match must be 1.

To support multi directional broadcast Broadcast "nodes" are added if necessary for X,Y. There is a more generic code in loader, but I think it better handle it within the create function. This way if it's called from multiple places it is handled under the hood automatically.
Documentation:
https://github.com/onnx/onnx/blob/master/docs/Operators.md#Where
[Optional Fixes #issue]

Test Plan:
Unit Tests
Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
