### PR TITLE
[Backends/3] Remove backend kind shared enum.

### DIFF
--- a/include/glow/Backend/Backend.h
+++ b/include/glow/Backend/Backend.h
@@ -31,28 +31,6 @@ class Node;
 class PlaceholderBindings;
 class IRGenVisitor;
 
-enum class BackendKind {
-  Interpreter, // Execute the network with the built-in interpreter.
-  OpenCL,      // Run the code on an OpenCL device.
-  CPU,         // Compile and run the code on the host.
-  Habana,      // Compile and run the code on a Habana accelerator.
-};
-
-/// Stop gap measure while migrating from BackendKind to backend names.
-/// TODO: Remove this after migration.
-inline std::string BackendKindToString(BackendKind kind) {
-  switch (kind) {
-  case BackendKind::Interpreter:
-    return "Interpreter";
-  case BackendKind::OpenCL:
-    return "OpenCL";
-  case BackendKind::CPU:
-    return "CPU";
-  case BackendKind::Habana:
-    return "Habana";
-  }
-}
-
 // This is the interface that glow backends need to implement.
 class Backend {
 public:
@@ -139,10 +117,6 @@ protected:
   /// Modifies \p IR and updates \p traceInfo.
   void autoInstrument(TraceInfo &traceInfo, IRFunction *IR) const;
 };
-
-/// Create a backend of kind \p kind.
-/// Deprecated. Moving gradualy to the createBackend based on the backend name.
-Backend *createBackend(BackendKind backendKind);
 
 /// Create a backend based on the registered backend name \p backendName.
 Backend *createBackend(llvm::StringRef backendName);

--- a/include/glow/ExecutionContext/ExecutionContext.h
+++ b/include/glow/ExecutionContext/ExecutionContext.h
@@ -28,17 +28,17 @@ enum class BackendKind;
 /// Sub-classed per backend, this holds Device specific per-function information
 /// if that is necessary on that particular backend.
 class DeviceBindings {
-  const glow::BackendKind backend_;
+  const std::string backend_;
 
 public:
-  DeviceBindings(BackendKind kind) : backend_{kind} {}
+  DeviceBindings(llvm::StringRef backend) : backend_{backend} {}
   virtual ~DeviceBindings() {}
 
   virtual std::unique_ptr<DeviceBindings> clone() {
     return llvm::make_unique<DeviceBindings>(backend_);
   }
 
-  BackendKind getBackendKind() { return backend_; }
+  llvm::StringRef getBackendKind() { return backend_; }
 };
 
 /// The runtime context for a single execution (Inferance or Training) in the

--- a/lib/Backends/Backends.cpp
+++ b/lib/Backends/Backends.cpp
@@ -18,11 +18,6 @@
 
 namespace glow {
 
-Backend *createBackend(BackendKind backendKind) {
-  const std::string &backendName = BackendKindToString(backendKind);
-  return createBackend(backendName);
-}
-
 Backend *createBackend(llvm::StringRef backendName) {
   auto *backend = FactoryRegistry<std::string, Backend>::get(backendName);
 

--- a/lib/Backends/Habana/Habana.h
+++ b/lib/Backends/Habana/Habana.h
@@ -158,7 +158,7 @@ private:
 class HabanaBindings : public DeviceBindings {
 public:
   HabanaBindings(uint32_t deviceId, uint64_t topologyId)
-      : DeviceBindings(BackendKind::Habana), deviceId_(deviceId),
+      : DeviceBindings(HabanaBackend::getName()), deviceId_(deviceId),
         topologyId_(topologyId) {}
 
   virtual ~HabanaBindings() {}

--- a/lib/Backends/Habana/Habana.h
+++ b/lib/Backends/Habana/Habana.h
@@ -155,6 +155,35 @@ private:
   std::vector<EnqueueTensorInfo> outputInfo_;
 };
 
+class HabanaBackend final : public Backend {
+public:
+  /// Constructor.
+  HabanaBackend() = default;
+
+  /// @name Backend methods.
+  /// This is the implementation of the Backend interface.
+  ///@{
+  ~HabanaBackend() override = default;
+
+  std::string getBackendName() const override { return getName(); }
+  static std::string getName() { return "Habana"; }
+
+  llvm::Expected<std::unique_ptr<CompiledFunction>>
+  compile(Function *F, const BackendOptions &opts) const override;
+
+  bool isOpSupported(const NodeInfo &NI) const override;
+
+  bool shouldLower(const Node *N) const override;
+
+  bool transformPostLowering(Function *F,
+                             CompilationContext &cctx) const override;
+
+  bool shouldShareBuffers() const override { return false; }
+  /// @}
+
+  static bool isVersionBiggerEqualTo(std::string versionToCompare);
+};
+
 class HabanaBindings : public DeviceBindings {
 public:
   HabanaBindings(uint32_t deviceId, uint64_t topologyId)
@@ -218,35 +247,6 @@ private:
   std::string recipeName_;
   PlaceholderList inputs_;
   PlaceholderList outputs_;
-};
-
-class HabanaBackend final : public Backend {
-public:
-  /// Constructor.
-  HabanaBackend() = default;
-
-  /// @name Backend methods.
-  /// This is the implementation of the Backend interface.
-  ///@{
-  ~HabanaBackend() override = default;
-
-  std::string getBackendName() const override { return getName(); }
-  static std::string getName() { return "Habana"; }
-
-  llvm::Expected<std::unique_ptr<CompiledFunction>>
-  compile(Function *F, const BackendOptions &opts) const override;
-
-  bool isOpSupported(const NodeInfo &NI) const override;
-
-  bool shouldLower(const Node *N) const override;
-
-  bool transformPostLowering(Function *F,
-                             CompilationContext &cctx) const override;
-
-  bool shouldShareBuffers() const override { return false; }
-  /// @}
-
-  static bool isVersionBiggerEqualTo(std::string versionToCompare);
 };
 
 } // namespace glow

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -232,7 +232,7 @@ namespace runtime {
 struct OpenCLDeviceBindings : DeviceBindings {
   OpenCLDeviceBindings(cl_mem buffer, cl_command_queue commands,
                        cl_device_id device, cl_context ctx)
-      : DeviceBindings(BackendKind::OpenCL), deviceBuffer{buffer},
+      : DeviceBindings(OCLBackend::getName()), deviceBuffer{buffer},
         commandQueue{commands}, deviceId{device}, context{ctx} {}
 
   /// CL memory buffer. Currently this contains both mutable and immutable

--- a/tests/unittests/GraphTest.cpp
+++ b/tests/unittests/GraphTest.cpp
@@ -419,7 +419,7 @@ TEST(Graph, QuantizationProfileNodes) {
   LoweredInfoMap loweredMapForProf;
   CompilationContext cctx{&bindings, &loweredMapForProf};
   cctx.precisionConfig.quantMode = QuantizationMode::Profile;
-  std::unique_ptr<Backend> backend(createBackend(BackendKind::Interpreter));
+  std::unique_ptr<Backend> backend(createBackend("Interpreter"));
   EXIT_ON_ERR(::optimizeFunction(F, *backend, cctx));
 
   size_t numberOfProfileNodes =
@@ -668,7 +668,7 @@ TEST(Graph, nodesWithPredicates) {
 }
 
 // Return the number of ConvolutionNode after lower.
-unsigned getConvNodeSize(BackendKind kind) {
+unsigned getConvNodeSize(llvm::StringRef kind) {
   Module mod;
   Function *F = mod.createFunction("main");
   IRFunction M(F);
@@ -689,7 +689,7 @@ unsigned getConvNodeSize(BackendKind kind) {
     }
   }
 
-  if (kind == BackendKind::Interpreter) {
+  if (kind == "Interpreter") {
     EXPECT_EQ(count, 1);
   }
 
@@ -699,16 +699,16 @@ unsigned getConvNodeSize(BackendKind kind) {
 // Check the unrolling grouped convolution opt status:
 // -- disabled for Interpreter, CPU and OpenCL backend,
 TEST(Graph, disableUnrollingGroupConv) {
-  unsigned numberOfNodesInterpreter = getConvNodeSize(BackendKind::Interpreter);
+  unsigned numberOfNodesInterpreter = getConvNodeSize("Interpreter");
   (void)numberOfNodesInterpreter;
 
 #ifdef GLOW_WITH_CPU
-  unsigned numberOfNodesCPU = getConvNodeSize(BackendKind::CPU);
+  unsigned numberOfNodesCPU = getConvNodeSize("CPU");
   EXPECT_EQ(numberOfNodesCPU, numberOfNodesInterpreter);
 #endif // GLOW_WITH_CPU
 
 #ifdef GLOW_WITH_OPENCL
-  unsigned numberOfNodesOpenCL = getConvNodeSize(BackendKind::OpenCL);
+  unsigned numberOfNodesOpenCL = getConvNodeSize("OpenCL");
   EXPECT_EQ(numberOfNodesOpenCL, numberOfNodesInterpreter);
 #endif // GLOW_WITH_OPENCL
 }


### PR DESCRIPTION
Summary:
Removed last piece of backend kind from the code base.

Documentation:
n/a, updated earlier.

Test Plan:
CI

cc: @opti-mix @gcatron 
