### PR TITLE
[TraceEvents][OpenCL] Fix OpenCL trace output

### DIFF
--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -1586,8 +1586,9 @@ void OpenCLFunction::translateTraceEvents(ExecutionContext *context) const {
   // system_clock domain.
   // TODO: synchronize clocks better, this can be off the thread was yielded
   // since getting the timestamp in updatePlaceholders.
-  int64_t tsOffset =
-      std::chrono::system_clock().now().time_since_epoch().count();
+  int64_t tsOffset = std::chrono::duration_cast<std::chrono::microseconds>(
+                         std::chrono::system_clock().now().time_since_epoch())
+                         .count();
 
   if (!kernelLaunches_.empty()) {
     auto &event = kernelLaunches_.back().event_;


### PR DESCRIPTION
**Description**
This commit ensures that traces generated by the OpenCL backend will
render correctly regardless of the default time duration unit returned
by `std::chrono::system_clock().now()`. This function is used in
`TraceEvents::now()` to get the current timestamp but it is cast to
`std::chrono::microseconds` before it is returned. This commit modifies
the call to this function in `OpenCLFunction::translateTraceEvents` to
also cast the result to `std::chrono::microseconds`. Without this, the
events corresponding to OpenCL kernels do not render currently as being
nested inside events that should encompass them (e.g.
`DeviceManager::runFunction`) if the return value of `std::chrono::system_clock().now()` is not in microseconds.

**Testing**
Trace from `tracing-compare` on my laptop after this PR:
<img width="1564" alt="Screen Shot 2019-06-13 at 1 44 33 PM" src="https://user-images.githubusercontent.com/4392003/59470193-d7458800-8deb-11e9-88b2-fcfadc2dc696.png">

Trace from `tracing-compare` on my devserver before this PR:
<img width="1535" alt="Screen Shot 2019-06-13 at 2 40 13 PM" src="https://user-images.githubusercontent.com/4392003/59470254-03f99f80-8dec-11e9-9fdc-7630de6c4343.png">

All of the events that are *not* related to ops are in the sliver near the beginning and all the op events are in the sliver on the right.

Trace from `tracing-compare` on my devserver after this PR:
<img width="1132" alt="Screen Shot 2019-06-13 at 1 56 38 PM" src="https://user-images.githubusercontent.com/4392003/59470250-00feaf00-8dec-11e9-833c-71c1d2f68fa1.png">
