### PR TITLE
Rename BackendKind to BackendName in a few places

### DIFF
--- a/include/glow/ExecutionContext/ExecutionContext.h
+++ b/include/glow/ExecutionContext/ExecutionContext.h
@@ -23,8 +23,6 @@
 
 namespace glow {
 
-enum class BackendKind;
-
 /// Sub-classed per backend, this holds Device specific per-function information
 /// if that is necessary on that particular backend.
 class DeviceBindings {
@@ -37,8 +35,6 @@ public:
   virtual std::unique_ptr<DeviceBindings> clone() {
     return llvm::make_unique<DeviceBindings>(backend_);
   }
-
-  llvm::StringRef getBackendKind() { return backend_; }
 };
 
 /// The runtime context for a single execution (Inferance or Training) in the

--- a/include/glow/Partitioner/Partitioner.h
+++ b/include/glow/Partitioner/Partitioner.h
@@ -60,7 +60,7 @@ struct FunctionNameComparator {
 using FunctionToNodesMapTy =
     std::map<Function *, NodesSetTy, FunctionNameComparator>;
 
-using FunctionToBackendKindMapTy =
+using FunctionToBackendNameMapTy =
     std::map<Function *, std::string, FunctionNameComparator>;
 
 class NodeToFunctionMap {
@@ -73,7 +73,7 @@ class NodeToFunctionMap {
 
   /// Map of the partitions to the backend which will be used for compiling
   /// this partition.
-  FunctionToBackendKindMapTy functionToBackendName_;
+  FunctionToBackendNameMapTy functionToBackendName_;
 
   /// Map of sub-functions to their memory consumption.
   PartitionCostMapTy partitionCost_;
@@ -239,7 +239,7 @@ class Partitioner {
   /// Duplicates all networks in the module order to saturate the Host.
   void saturateHost(unsigned logicalDeviceCount);
 
-  FunctionToBackendKindMapTy
+  FunctionToBackendNameMapTy
   backendBasedPartition(Function *F, std::vector<Backend *> &backends);
 
   /// Given the node-function mapping, do the actual partitioning. If \p saveDAG

--- a/include/glow/Support/Register.h
+++ b/include/glow/Support/Register.h
@@ -23,9 +23,8 @@ namespace glow {
 
 /// Base factory interface which needs to be implemented
 /// for static registration of arbitrary classes.
-/// For example, CPUFactory : BaseFactory<BackendKind, Backend>
-/// would be responsible for creating CPU backends registred
-/// with BackendKind::CPU key.
+/// For example, CPUFactory would be responsible for creating CPU backends
+/// registred with "CPU" key.
 template <class Key, class Base> class BaseFactory {
 public:
   virtual ~BaseFactory() = default;

--- a/include/glow/Support/Support.h
+++ b/include/glow/Support/Support.h
@@ -127,16 +127,16 @@ struct MultiLineStr {
 struct DeviceConfigHelper {
   /// Device Name.
   std::string name_;
-  /// BackendKind name.
-  std::string kindName_;
+  /// Backend name.
+  std::string backendName_;
   /// A string with multi lines. Each line represents a param.
   MultiLineStr parameters_;
   DeviceConfigHelper() = default;
-  DeviceConfigHelper(std::string &name, std::string &kindName)
-      : name_(name), kindName_(kindName) {}
-  DeviceConfigHelper(std::string &kindName, std::string &name,
+  DeviceConfigHelper(std::string &name, std::string &backendName)
+      : name_(name), backendName_(backendName) {}
+  DeviceConfigHelper(std::string &backendName, std::string &name,
                      MultiLineStr &parameters)
-      : name_(name), kindName_(kindName), parameters_(parameters) {}
+      : name_(name), backendName_(backendName), parameters_(parameters) {}
 };
 
 /// Deserialize quantization infos from the file \p fileName.

--- a/lib/Onnxifi/GlowOnnxifiManager.h
+++ b/lib/Onnxifi/GlowOnnxifiManager.h
@@ -98,8 +98,8 @@ public:
 private:
   GlowOnnxifiManager() = default;
 
-  /// Create a new HostManager managing backends of kind \p backendKind or get
-  /// an existing HostManager for the backendKind if one exists.
+  /// Create a new HostManager managing backends of kind \p backendName or get
+  /// an existing HostManager for the backendName if one exists.
   /// NOTE: This method is not thread safe, the caller should be holding the
   /// mutex m_ when calling it!
   std::shared_ptr<runtime::HostManager>

--- a/lib/Runtime/Provisioner/Provisioner.cpp
+++ b/lib/Runtime/Provisioner/Provisioner.cpp
@@ -141,7 +141,7 @@ llvm::Error Provisioner::provision(DAGListTy &networks, Module &module,
   for (unsigned i = 0; i < logicalDeviceSize.size(); i++) {
     std::string backendName =
         logicalDeviceBackendName[logicalDeviceSize[i].first];
-    // Find the start point of each backendKind device.
+    // Find the start point of each backendName device.
     if (startPos.find(backendName) == startPos.end()) {
       startPos[backendName] = 0;
     }

--- a/lib/Support/Support.cpp
+++ b/lib/Support/Support.cpp
@@ -45,7 +45,7 @@ template <> struct BlockScalarTraits<glow::MultiLineStr> {
 template <> struct MappingTraits<glow::DeviceConfigHelper> {
   static void mapping(IO &io, glow::DeviceConfigHelper &info) {
     io.mapRequired("name", info.name_);
-    io.mapRequired("kindName", info.kindName_);
+    io.mapRequired("backendName", info.backendName_);
     io.mapRequired("parameters", info.parameters_);
   }
 };

--- a/tests/runtime_test/cpuConfigs.yaml
+++ b/tests/runtime_test/cpuConfigs.yaml
@@ -1,11 +1,11 @@
 ---
 - name:     Device1
-  kindName: CPU
+  backendName: CPU
   parameters: |
     "platformID":"1"
     "deviceID" : "0"
 - name:     Device2
-  kindName: CPU
+  backendName: CPU
   parameters: |
     "platformID":"1"
 ...

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -66,7 +66,7 @@ extern unsigned parCloneCountOpt;
     std::string getBackendName() { return std::get<0>(GetParam()); }           \
   }
 
-/// Note that we use std::tuple<BackendKind> here to match other tests which are
+/// Note that we use std::tuple<std::string> here to match other tests which are
 /// parameterized across many other values, e.g. those in ParameterSweepTest.
 DECLARE_STATELESS_BACKEND_TEST(BackendStatelessTest, std::tuple<std::string>);
 

--- a/tests/unittests/PartitionerTest.cpp
+++ b/tests/unittests/PartitionerTest.cpp
@@ -569,7 +569,7 @@ TEST_F(PartitionerTest, SimpleHeterogeneousPartitioning) {
 }
 
 /// Test assigning more than one partitions in to one device for single
-/// backendKind.
+/// backendName.
 TEST_F(PartitionerTest, logicalIDTest0) {
   auto *input1 =
       mod_.createPlaceholder(ElemKind::FloatTy, {2, 10}, "input1", false);

--- a/tests/unittests/SupportTest.cpp
+++ b/tests/unittests/SupportTest.cpp
@@ -61,20 +61,20 @@ TEST(Support, loadYamlFile) {
   // The config file is:
   //---
   //- name:     Device1
-  //  kindName: CPU
+  //  backendName: CPU
   //  parameters: |
   //  "platformID":"1"
   //    "deviceID" : "0"
   //    - name:     Device2
-  //  kindName: CPU
+  //  backendName: CPU
   //  parameters: |
   //  "platformID":"1"
   //...
-  EXPECT_EQ(lists[0].kindName_, "CPU");
+  EXPECT_EQ(lists[0].backendName_, "CPU");
   EXPECT_EQ(lists[0].name_, "Device1");
   EXPECT_EQ(lists[0].parameters_.str,
             "\"platformID\":\"1\"\n\"deviceID\" : \"0\"\n");
-  EXPECT_EQ(lists[1].kindName_, "CPU");
+  EXPECT_EQ(lists[1].backendName_, "CPU");
   EXPECT_EQ(lists[1].name_, "Device2");
   EXPECT_EQ(lists[1].parameters_.str, "\"platformID\":\"1\"\n");
 }

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -325,7 +325,7 @@ static llvm::StringMap<std::string> getBackendParams(std::string &str) {
 
 /// If the device config file \p loadDeviceDoncfigsFile available, load \p
 /// configs from the file. Otherwise, create \p numDevices number of devices
-/// based on \p backendKind.
+/// based on \p backendName.
 static std::vector<std::unique_ptr<runtime::DeviceConfig>>
 generateDeviceConfigs(std::string &loadDeviceConfigsFile,
                       unsigned int numDevices, llvm::StringRef backendName) {
@@ -342,7 +342,7 @@ generateDeviceConfigs(std::string &loadDeviceConfigsFile,
     std::vector<DeviceConfigHelper> lists;
     lists = deserializeDeviceConfigFromYaml(loadDeviceConfigsFile);
     for (unsigned int i = 0; i < lists.size(); ++i) {
-      auto backendName = lists[i].kindName_;
+      auto backendName = lists[i].backendName_;
       auto name = lists[i].name_;
       auto parameters = getBackendParams(lists[i].parameters_.str);
       auto config = llvm::make_unique<runtime::DeviceConfig>(backendName, name,


### PR DESCRIPTION
Summary:
Rename `BackendKind` to `BackendName` in some comments and stuff since #3087 got rid of BackendKind

Documentation:
none

Test Plan:
CI
