### PR TITLE
create separate node for fused-quantized-sls and enable lowering to slws

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -764,14 +764,14 @@ public:
   /// them into len(\p lengths) entries: first Lengths[0] slices are aggregated
   /// to Result[0], next Lengths[1] slices are aggregated to Result[1], etc.
   /// I.e. sum(Lengths) must be equal to len(Indices).
-  FusedRowwiseQuantizedSparseLengthsWeightedSumNode *
+  FusedRowwiseQuantizedSparseLengthsSumNode *
   createFusedRowwiseQuantizedSparseLengthsSum(llvm::StringRef name,
                                               Constant *data, NodeValue indices,
                                               NodeValue lengths);
 
   /// Same as \ref createFusedRowwiseQuantizedSparseLengthsSum(), but expects
   /// float input \p data, which is rowwise-quantized and fused internally.
-  FusedRowwiseQuantizedSparseLengthsWeightedSumNode *
+  FusedRowwiseQuantizedSparseLengthsSumNode *
   createFusedRowwiseQuantizedSparseLengthsSum(llvm::StringRef name,
                                               Tensor &data, NodeValue indices,
                                               NodeValue lengths);
@@ -780,7 +780,7 @@ public:
   /// is multiplied by weights[i]. len(weights) must be equal to len(indices).
   FusedRowwiseQuantizedSparseLengthsWeightedSumNode *
   createFusedRowwiseQuantizedSparseLengthsWeightedSum(llvm::StringRef name,
-                                                      Tensor &data,
+                                                      NodeValue data,
                                                       NodeValue weights,
                                                       NodeValue indices,
                                                       NodeValue lengths);
@@ -790,7 +790,7 @@ public:
   /// internally.
   FusedRowwiseQuantizedSparseLengthsWeightedSumNode *
   createFusedRowwiseQuantizedSparseLengthsWeightedSum(llvm::StringRef name,
-                                                      Constant *data,
+                                                      Tensor &data,
                                                       NodeValue weights,
                                                       NodeValue indices,
                                                       NodeValue lengths);

--- a/lib/Optimizer/Lower.cpp
+++ b/lib/Optimizer/Lower.cpp
@@ -864,6 +864,19 @@ static void lowerSparseLengthsSumNode(Function *F, CompilationContext &cctx,
   replaceAllUsesOfWith(cctx.loweredInfoMap, SLSN.getResult(), SLWSN);
 }
 
+static void lowerFusedRowwiseQuantizedSparseLengthsSumNode(
+    Function *F, CompilationContext &cctx,
+    const FusedRowwiseQuantizedSparseLengthsSumNode &FRQSLSN) {
+  auto ty = F->getParent()->uniqueType(ElemKind::FloatTy,
+                                       {FRQSLSN.getIndices().dims()[0]});
+  auto *ones = F->createSplat(FRQSLSN.getName().str() + ".ones", ty, 1.0);
+  auto *FRQSLWSN = F->createFusedRowwiseQuantizedSparseLengthsWeightedSum(
+      FRQSLSN.getName().str(), FRQSLSN.getData(), ones, FRQSLSN.getIndices(),
+      FRQSLSN.getLengths());
+
+  replaceAllUsesOfWith(cctx.loweredInfoMap, FRQSLSN.getResult(), FRQSLWSN);
+}
+
 /// Lowers \p node given Function \p. \p cctx contains a mapping of loweredMap
 /// that will log the lowering info of what was replaced by what via output
 /// names.
@@ -921,6 +934,9 @@ static void lowerNode(Function *F, Node *node, CompilationContext &cctx) {
     lowerBatchMatMulNode(F, cctx, *BMMN);
   } else if (auto *SLSN = dyn_cast<SparseLengthsSumNode>(node)) {
     lowerSparseLengthsSumNode(F, cctx, *SLSN);
+  } else if (auto *FQSLSN =
+                 dyn_cast<FusedRowwiseQuantizedSparseLengthsSumNode>(node)) {
+    lowerFusedRowwiseQuantizedSparseLengthsSumNode(F, cctx, *FQSLSN);
   }
 }
 

--- a/tests/unittests/Caffe2ImporterTest.cpp
+++ b/tests/unittests/Caffe2ImporterTest.cpp
@@ -2320,17 +2320,13 @@ TEST(caffe2, SparseLengthsSumFused8BitRowwise) {
   };
 
   // High level check on the content of the graph. We have 1 rowwise-quantized
-  // SLWS (which implements SLS), 1 Splat for the weights, and 1 save.
-  EXPECT_EQ(F->getNodes().size(), 3);
+  // SLS and 1 save.
+  EXPECT_EQ(F->getNodes().size(), 2);
   SaveNode *saveNode = getSaveNodeFromDest(output);
-  FusedRowwiseQuantizedSparseLengthsWeightedSumNode *FRWQSLS =
-      llvm::dyn_cast<FusedRowwiseQuantizedSparseLengthsWeightedSumNode>(
+  FusedRowwiseQuantizedSparseLengthsSumNode *FRWQSLS =
+      llvm::dyn_cast<FusedRowwiseQuantizedSparseLengthsSumNode>(
           saveNode->getInput().getNode());
   ASSERT_TRUE(FRWQSLS);
-  SplatNode *splatNode =
-      llvm::dyn_cast<SplatNode>(FRWQSLS->getWeights().getNode());
-  ASSERT_TRUE(splatNode);
-  EXPECT_EQ(splatNode->getValue(), 1.0f);
   // Check that the data input is a Constant node with expected ElemKind.
   Constant *data = llvm::dyn_cast<Constant>(FRWQSLS->getData().getNode());
   ASSERT_TRUE(data);

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -442,6 +442,21 @@ int main(int argc, char **argv) {
                     "Offsets are appended to the end of each row. Thus, Data "
                     "must be a two-dimensional tensor.");
 
+  BB.newNode("FusedRowwiseQuantizedSparseLengthsSum")
+      .addInput("Data")
+      .addInput("Indices")
+      .addInput("Lengths")
+      .addResultFromCtorArg()
+      .setDocstring("Gathers slices of the outer-most dimension of Data "
+                    "indexed by Indices vector, and then accumulates them into "
+                    "len(Lengths) entries: first Lengths[0] slices are "
+                    "aggregated to Result[0], next Lengths[1] slices are "
+                    "aggregated to Result[1], etc. I.e. sum(Lengths) must be "
+                    "equal to len(Indices). The input "
+                    "data is fused rowwise-quantized, where the Scales and "
+                    "Offsets are appended to the end of each row. Thus, Data "
+                    "must be a two-dimensional tensor.");
+
   BB.newNode("LengthsToRanges")
       .addInput("Lengths")
       .addResultFromCtorArg()


### PR DESCRIPTION
Summary:
* Create separate node for fused-quantized-SLS
* Enable lowering by default to fused-quantized-SLWS
* For Habana, do not lower (-->kernel exists, import and test)

Phabricator diff: D15817338
(needed D15866346 to land before this for kernel tests to pass)