### PR TITLE
[Tracing] work around a bug in the Chrome trace visualizer

### DIFF
--- a/lib/ExecutionContext/TraceEvents.cpp
+++ b/lib/ExecutionContext/TraceEvents.cpp
@@ -30,6 +30,17 @@ void TraceEvent::dumpTraceEvents(
   llvm::errs() << "dumping " << events.size() << " trace events to "
                << filename.str() << ".\n";
 
+  // Chrome trace UI has a bug with complete events which are ordered later in
+  // the json than an event they completely enclose, so sort the list of events
+  // by start time and duration.
+  std::sort(events.begin(), events.end(),
+            [](const TraceEvent &a, const TraceEvent &b) {
+              if (a.timestamp == b.timestamp) {
+                return a.duration > b.duration;
+              }
+              return a.timestamp < b.timestamp;
+            });
+
   auto process = processName.empty() ? "glow" : processName;
 
   std::ofstream file(filename);


### PR DESCRIPTION
Summary: Looks like chrome://tracing has a bug when two Complete events have the same start time but the longer of the two occurs later in the json file. Work around this by sorting the TraceEvents by time and duration before dumping.

Before:
![image](https://user-images.githubusercontent.com/701287/59476540-1254b500-8e06-11e9-9322-f8816c3e2a5e.png)

After:
![image](https://user-images.githubusercontent.com/701287/59476565-357f6480-8e06-11e9-8ae1-3d4379524c16.png)

Documentation: n/a

Test Plan: tested manually with a device