### PR TITLE
[Tracing] Switch back to steady_clock and fix Onnxifi trace events

### DIFF
--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -1748,7 +1748,7 @@ void libjit_write_timestamp(uint64_t *tensor, size_t offset) {
   // Issue #2397 covers migrating this to a libc approach but if you have issues
   // with a lack of C++ symbols at runtime check there first.
   uint64_t ts = std::chrono::duration_cast<std::chrono::microseconds>(
-                    std::chrono::system_clock::now().time_since_epoch())
+                    std::chrono::steady_clock::now().time_since_epoch())
                     .count();
   memcpy(tensor + offset, &ts, sizeof(uint64_t));
 }

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -2899,7 +2899,7 @@ void BoundInterpreterFunction::fwdTraceEventInst(const TraceEventInst *I) {
   auto IH = T->getHandle<int64_t>();
   size_t index = I->getIndex();
   IH.raw(index) = std::chrono::duration_cast<std::chrono::microseconds>(
-                      std::chrono::system_clock::now().time_since_epoch())
+                      std::chrono::steady_clock::now().time_since_epoch())
                       .count();
 }
 

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -1583,11 +1583,11 @@ void OpenCLFunction::translateTraceEvents(ExecutionContext *context) const {
   // The device uses a different clock domain, so we'll assume that the last
   // timestamp and now are close and get the difference between the two
   // timestamps, which we can use to pull event timestamps in to the
-  // system_clock domain.
+  // steady_clock domain.
   // TODO: synchronize clocks better, this can be off the thread was yielded
   // since getting the timestamp in updatePlaceholders.
   int64_t tsOffset = std::chrono::duration_cast<std::chrono::microseconds>(
-                         std::chrono::system_clock().now().time_since_epoch())
+                         std::chrono::steady_clock().now().time_since_epoch())
                          .count();
 
   if (!kernelLaunches_.empty()) {
@@ -1635,7 +1635,7 @@ void OpenCLFunction::translateTraceEvents(ExecutionContext *context) const {
                           ->getHandle<int64_t>();
         const TraceInfo::Event *ev = it->second.second;
 
-        // Convert into usec and move into system_clock domain.
+        // Convert into usec and move into steady_clock domain.
         auto timestamp = (timeEnd / 1000) + tsOffset;
 
         handle.at({ev->startIndex, 0}) = timestamp;
@@ -1644,7 +1644,7 @@ void OpenCLFunction::translateTraceEvents(ExecutionContext *context) const {
     } else {
       // Duration should be usec.
       auto duration = (timeEnd - timeStart) / 1000;
-      // Convert into usec and move into system_clock domain.
+      // Convert into usec and move into steady_clock domain.
       auto startUs = (timeStart / 1000) + tsOffset;
 
       traceEvents.push_back({name, startUs, duration, tid, {{"type", type}}});

--- a/lib/ExecutionContext/TraceEvents.cpp
+++ b/lib/ExecutionContext/TraceEvents.cpp
@@ -71,7 +71,7 @@ void TraceEvent::dumpTraceEvents(
 
 uint64_t TraceEvent::now() {
   return std::chrono::duration_cast<std::chrono::microseconds>(
-             std::chrono::system_clock::now().time_since_epoch())
+             std::chrono::steady_clock::now().time_since_epoch())
       .count();
 }
 


### PR DESCRIPTION
Summary:  `steady_clock` is better than `system_clock` for timestamps since it doesn't jump around across threads. Use the better timer in glow and convert into FB domain at the Onnxifi interface.

Documentation: will update Tracing docs in #3082.

Test Plan: unit tests, manual check with tracing-compare, manual check events on a run with Habana device.