### PR TITLE
[Quantization] Perform quantization opts in a loop together with DCE

### DIFF
--- a/tests/unittests/GraphOptzTest.cpp
+++ b/tests/unittests/GraphOptzTest.cpp
@@ -2852,3 +2852,21 @@ TEST_F(GraphOptz, convertBroadcastedBatchMatMulToMatMul) {
   EXPECT_EQ(countNodeKind(F_, Kinded::Kind::MatMulNodeKind), 1);
   EXPECT_EQ(countNodeKind(F_, Kinded::Kind::BatchMatMulNodeKind), 0);
 }
+
+TEST_F(GraphOptz, dceQuantization) {
+  auto *lhs =
+      mod_.createPlaceholder(ElemKind::Int8QTy, {3, 5}, 0.3, 15, "lhs", false);
+  auto *weights =
+      mod_.createConstant(ElemKind::Int8QTy, {3, 5}, 0.3, 15, "weights");
+
+  auto *add = F_->createAdd("add", lhs, weights);
+  auto *t1 = mod_.uniqueType(ElemKind::Int8QTy, {3, 5}, 0.2, 0);
+  auto *rs1 = F_->createRescaleQuantized("rs1", add, t1);
+  auto *t2 = mod_.uniqueType(ElemKind::Int8QTy, {3, 5}, 0.1, 1);
+  auto *rs2 = F_->createRescaleQuantized("rs2", rs1, t2);
+  F_->createSave("save", rs2);
+
+  ::glow::optimize(F_, CompilationMode::Infer);
+
+  EXPECT_EQ(F_->getNodes().size(), 2);
+}


### PR DESCRIPTION
Problem:
sometimes we have the following graph to optimize:
`Conv1 -> Rescale1 -> Rescale2 -> Conv2`
We want to get the following after Quantization opts:
`Conv1' -> Conv2`

But this may not happen, because we do optimizations step-by-step, and always check that optimized Conv has one user. This is what can happen after one step:
```
Conv1 -> Rescale1 -> Rescale2     Conv2
     \                            ^
      --> Rescale12 -------------/
```
Now `Conv1` has 2 users (one just added and one dead), so that `Rescale12` can't be combined into it.

Solution is to run DCE in a loop together with Quantization opts, while something changes.

It's possible to speed up optimization process by highlighting maximal chains and dealing with them one by one starting from head. E.g. in example above find `Conv1 -> Rescale1 -> Rescale2`, and process it all at once by replacing with `Conv1'`. It is doable, but code would be more complex and more difficult to maintain.