### PR TITLE
[compilationLog]: Log the change to the input(operand) of a node.

### DIFF
--- a/include/glow/Graph/Log.h
+++ b/include/glow/Graph/Log.h
@@ -26,6 +26,8 @@ namespace glow {
 
 class Node;
 
+struct NodeValue;
+
 /// A class for logging all compilation related activities.
 class LogContext {
 private:
@@ -60,10 +62,18 @@ public:
   void logNodeCreation(const Node *newNode);
 
   /// Logs the node replacement.
-  void logNodeReplacement(const Node *oldNode, const Node *newNode);
+  void logNodeValueReplacement(const NodeValue &oldNodeVal,
+                               const NodeValue &newNodeVal);
 
   /// Logs the node deletion.
   void logNodeDeletion(const Node &deletedNode);
+
+  /// Logs node's input changes.
+  /// \p user is the user node of the operands
+  /// \p prevOpr previous operand
+  /// \p newOpr new operand
+  void logNodeInputChange(const Node *user, const NodeValue &prevOprVal,
+                          const NodeValue &newOprVal);
 
 private:
   /// Add log metadata which includes version number and latest commit's info

--- a/lib/Converter/FunctionConverter.cpp
+++ b/lib/Converter/FunctionConverter.cpp
@@ -126,6 +126,12 @@ void FunctionConverter::convertOutputs(Node &node) {
       if (user == conversionVal.getNode()) {
         continue;
       }
+      // Log the change of node input(operand).
+      if (Function *F = node.getParent()) {
+        F->getLogContext().logNodeInputChange(user, *(use.get()),
+                                              conversionVal);
+      }
+
       use.get()->setOperand(conversionVal.getNode(), conversionVal.getResNo());
     }
   }

--- a/lib/Graph/Node.cpp
+++ b/lib/Graph/Node.cpp
@@ -167,6 +167,8 @@ void Node::setNthInput(unsigned idx, NodeValue val) {
   switch (getKind()) {
 #define DEF_NODE(CLASS, NAME)                                                  \
   case glow::Kinded::Kind::CLASS##Kind:                                        \
+    getParent()->getLogContext().logNodeInputChange(                           \
+        this, this->getNthInput(idx), val);                                    \
     return static_cast<CLASS *>(this)->setNthInput(idx, val);
 #include "glow/AutoGenNodes.def"
   default:

--- a/lib/Graph/NodeValue.cpp
+++ b/lib/Graph/NodeValue.cpp
@@ -50,13 +50,18 @@ void NodeValue::replaceAllUsesOfWith(NodeValue v, const Function *F) const {
       continue;
     assert(site->getNode() == node_ && "Invalid user");
     assert(site->getResNo() == getResNo() && "Invalid list of uses");
+
+    // Log the change of node input(operand).
+    if (Function *F = getNode()->getParent()) {
+      F->getLogContext().logNodeInputChange(U.getUser(), *(U.get()), v);
+    }
+
     site->setOperand(v.getNode(), v.getResNo());
   }
 
   // Log all nodes replacement.
-  if (getNode()->getParent()) {
-    getNode()->getParent()->getLogContext().logNodeReplacement(getNode(),
-                                                               v.getNode());
+  if (Function *F = getNode()->getParent()) {
+    F->getLogContext().logNodeValueReplacement(*this, v);
   }
 }
 


### PR DESCRIPTION
Summary:
Log the change to the input(operand) of a node. This is for the case when the input of one node changes after the creation, which may happen at:
- transformForPrecisionMode
  - quantizeFunction(): via invocations to setNthInput() 
  - convertToFP16: via invocations to setOperand() and setOperand()
- several other trivial cases like changing the bias of a Conv node
  - via invocation to setNthInput()

This PR intercepts the implementation of setNthInput() and the certain caller(inside FunctionConverter) to setOperand(), such that the changes to the input of a node is caught and logged.  

Test Plan:
test with Quantization.TestProfileQuantizationOfUnloweredFC, and the log output is attached below:
![Screen Shot 2019-06-14 at 4 17 32 PM](https://user-images.githubusercontent.com/8838608/59543518-86ec2a00-8ec0-11e9-8d36-86d1c5c72eeb.png)

