### PR TITLE
[Tracing] rework TraceEvent verbosity

### DIFF
--- a/include/glow/ExecutionContext/ExecutionContext.h
+++ b/include/glow/ExecutionContext/ExecutionContext.h
@@ -119,17 +119,18 @@ public:
   /// A helper function to create a scoped TraceEvent builder.
   /// If there is no TraceContext, this will still create an object, but it will
   /// do nothing.
-  ScopedTraceBlock scopedEvent(llvm::StringRef name) {
-    return ScopedTraceBlock(getTraceContext(), name);
+  ScopedTraceBlock scopedEvent(llvm::StringRef name, TraceLevel level) {
+    return ScopedTraceBlock(getTraceContext(), level, name);
   }
 
   /// A helper function to log a TraceEvent at the current time, if there is a
   /// TraceContext available.
-  void logTraceEvent(llvm::StringRef name, char type = TraceEvent::InstantType,
+  void logTraceEvent(llvm::StringRef name, TraceLevel level,
+                     char type = TraceEvent::InstantType,
                      std::map<std::string, std::string> args = {}) {
     TraceContext *traceContext = getTraceContext();
     if (traceContext) {
-      traceContext->logTraceEvent(name, type, std::move(args));
+      traceContext->logTraceEvent(name, level, type, std::move(args));
     }
   }
 };

--- a/lib/Backends/CPU/CPUDeviceManager.cpp
+++ b/lib/Backends/CPU/CPUDeviceManager.cpp
@@ -116,8 +116,8 @@ void CPUDeviceManager::evictNetworkImpl(std::string functionName,
 void CPUDeviceManager::runFunctionImpl(
     RunIdentifierTy id, std::string function,
     std::unique_ptr<ExecutionContext> context, ResultCBTy resultCB) {
-  TRACE_EVENT_SCOPE_NAMED(context->getTraceContext(), "DeviceManager::run",
-                          dmRun);
+  TRACE_EVENT_SCOPE_NAMED(context->getTraceContext(), TraceLevel::RUNTIME,
+                          "DeviceManager::run", dmRun);
   auto funcIt = functions_.find(function);
   if (funcIt == functions_.end()) {
     dmRun.addArg("reason", "function not found");

--- a/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
@@ -114,8 +114,8 @@ void InterpreterDeviceManager::evictNetworkImpl(std::string functionName,
 void InterpreterDeviceManager::runFunctionImpl(
     RunIdentifierTy id, std::string function,
     std::unique_ptr<ExecutionContext> context, ResultCBTy resultCB) {
-  TRACE_EVENT_SCOPE_NAMED(context->getTraceContext(), "DeviceManager::run",
-                          dmRun);
+  TRACE_EVENT_SCOPE_NAMED(context->getTraceContext(), TraceLevel::RUNTIME,
+                          "DeviceManager::run", dmRun);
   auto funcIt = functions_.find(function);
   if (funcIt == functions_.end()) {
     dmRun.addArg("reason", "function not found");

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -556,11 +556,12 @@ llvm::Error OpenCLFunction::execute(ExecutionContext *context) {
   kernelProfiling_ = clDoProfile || getTraceInfo().autoInstrumented;
 
   {
-    auto ev = context->scopedEvent("loadPlaceholders");
+    TRACE_EVENT_SCOPE(context, TraceLevel::RUNTIME, "loadPlaceholders");
     loadPlaceholders(context->getPlaceholderBindings());
   }
 
-  auto enqueueEvent = context->scopedEvent("enqueueKernels");
+  TRACE_EVENT_SCOPE_NAMED(context, TraceLevel::RUNTIME, "enqueueKernels",
+                          enqueueEvent);
   for (const auto &I : F_->getInstrs()) {
     // Skip memory allocation instructions as they are NOPs.
     if (isa<AllocActivationInst>(I) || isa<DeallocActivationInst>(I) ||
@@ -1500,18 +1501,18 @@ llvm::Error OpenCLFunction::execute(ExecutionContext *context) {
   clFinish(commands_);
 
   {
-    auto ev = context->scopedEvent("updatePlaceholders");
+    TRACE_EVENT_SCOPE(context, TraceLevel::RUNTIME, "updatePlaceholders");
     updatePlaceholders(context->getPlaceholderBindings());
   }
 
   {
-    auto ev = context->scopedEvent("processInstrumentation");
+    TRACE_EVENT_SCOPE(context, TraceLevel::RUNTIME, "processInstrumentation");
     // Output profiling information.
     translateTraceEvents(context);
   }
 
   {
-    auto ev = context->scopedEvent("releaseKernels");
+    TRACE_EVENT_SCOPE(context, TraceLevel::RUNTIME, "releaseKernels");
     for (auto &kl : kernelLaunches_) {
       clReleaseKernel(kl.kernel_);
     }

--- a/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
@@ -325,8 +325,8 @@ void OpenCLDeviceManager::returnRunCommandQueue(cl_command_queue commands) {
 void OpenCLDeviceManager::runFunctionImpl(
     RunIdentifierTy id, std::string function,
     std::unique_ptr<ExecutionContext> context, ResultCBTy resultCB) {
-  TRACE_EVENT_SCOPE_NAMED(context->getTraceContext(), "DeviceManager::run",
-                          dmRun);
+  TRACE_EVENT_SCOPE_NAMED(context->getTraceContext(), TraceLevel::RUNTIME,
+                          "DeviceManager::run", dmRun);
   auto funcIt = functions_.find(function);
   if (funcIt == functions_.end()) {
     dmRun.addArg("reason", "function not found");

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -111,8 +111,9 @@ onnxStatus Graph::setIOAndRun(uint32_t inputsCount,
     ctx->setTraceContext(llvm::make_unique<TraceContext>(TraceLevel::STANDARD));
     traceContext = ctx->getTraceContext();
   }
-  TRACE_EVENT_SCOPE(traceContext, "Onnxifi::setIOAndRun");
-  TRACE_EVENT_SCOPE_NAMED(traceContext, "adjustInputs", aiEvent);
+  TRACE_EVENT_SCOPE(traceContext, TraceLevel::RUNTIME, "Onnxifi::setIOAndRun");
+  TRACE_EVENT_SCOPE_NAMED(traceContext, TraceLevel::RUNTIME, "adjustInputs",
+                          aiEvent);
 
   // Create tensors for input placeholders
   for (unsigned i = 0; i < inputsCount; ++i) {
@@ -168,7 +169,8 @@ onnxStatus Graph::setIOAndRun(uint32_t inputsCount,
   }
 
   TRACE_EVENT_SCOPE_END_NAMED(aiEvent);
-  TRACE_EVENT_SCOPE_NAMED(traceContext, "setOnnxifiOutputs", soEvent);
+  TRACE_EVENT_SCOPE_NAMED(traceContext, TraceLevel::RUNTIME,
+                          "setOnnxifiOutputs", soEvent);
 
   // Create tensors for output placeholders
   for (unsigned i = 0; i < outputsCount; ++i) {
@@ -227,7 +229,8 @@ void Graph::setTraceEvents(onnxTraceEventList *traceEvents,
   // negate the result.
   int64_t offset =
       steadyTS > systemTS ? -(steadyTS - systemTS) : (systemTS - steadyTS);
-  TRACE_EVENT_SCOPE(traceContext, "Onnxifi::setTraceEvents");
+  TRACE_EVENT_SCOPE(traceContext, TraceLevel::RUNTIME,
+                    "Onnxifi::setTraceEvents");
 
   std::vector<onnxTraceEvent *> traceEventsVec;
   for (const auto &glowTraceEvent : traceContext->getTraceEvents()) {

--- a/lib/Onnxifi/HostManagerOnnxifi.cpp
+++ b/lib/Onnxifi/HostManagerOnnxifi.cpp
@@ -110,7 +110,8 @@ onnxStatus HostManagerGraph::run(std::unique_ptr<ExecutionContext> ctx,
       [outputEvent, traceEvents](runtime::RunIdentifierTy runId,
                                  llvm::Error err,
                                  std::unique_ptr<ExecutionContext> ctx) {
-        TRACE_EVENT_SCOPE(ctx->getTraceContext(), "Onnxifi::callback");
+        TRACE_EVENT_SCOPE(ctx->getTraceContext(), TraceLevel::RUNTIME,
+                          "Onnxifi::callback");
         // If an Error occurred then log it in errToBool and signal the output
         // event.
         if (errToBool(std::move(err))) {

--- a/lib/Runtime/Executor/ThreadPoolExecutor.cpp
+++ b/lib/Runtime/Executor/ThreadPoolExecutor.cpp
@@ -239,7 +239,8 @@ void ThreadPoolExecutor::shutdown() {
 void ThreadPoolExecutor::run(const DAGNode *root,
                              std::unique_ptr<ExecutionContext> context,
                              RunIdentifierTy runId, ResultCBTy cb) {
-  TRACE_EVENT_SCOPE(context->getTraceContext(), "ThreadPoolExecutor::run");
+  TRACE_EVENT_SCOPE(context->getTraceContext(), TraceLevel::RUNTIME,
+                    "ThreadPoolExecutor::run");
 
   // Don't process new requests if the executor is shutting down.
   if (shuttingDown_) {
@@ -281,7 +282,7 @@ void ThreadPoolExecutor::run(const DAGNode *root,
 void ThreadPoolExecutor::executeDAGNode(
     std::shared_ptr<ExecutionState> executionState, DAGNode *node) {
   TRACE_EVENT_SCOPE(executionState->getRawResultContextPtr()->getTraceContext(),
-                    "ThreadPoolExecutor::executeDAGNode");
+                    TraceLevel::RUNTIME, "ThreadPoolExecutor::executeDAGNode");
   DCHECK(executionState->initialized_) << "Run state must be initialized";
   // If execution has already failed due to another node, don't bother running
   // this one.
@@ -338,8 +339,8 @@ void ThreadPoolExecutor::handleDeviceManagerResult(
   DCHECK_NOTNULL(executionState.get());
 
   TraceContext *traceContext = ctx->getTraceContext();
-  TRACE_EVENT_SCOPE_NAMED(traceContext, "ThreadPoolExecutor::handleResult",
-                          traceEvent);
+  TRACE_EVENT_SCOPE_NAMED(traceContext, TraceLevel::RUNTIME,
+                          "ThreadPoolExecutor::handleResult", traceEvent);
 
   auto runWasSuccess = !err;
 
@@ -367,7 +368,8 @@ void ThreadPoolExecutor::handleDeviceManagerResult(
   bool noNodesInflight = executionState->decrementInflightNodes();
 
   if (traceContext) {
-    TRACE_EVENT_END(traceContext, "ThreadPoolExecutor::handleResult");
+    TRACE_EVENT_END(traceContext, TraceLevel::RUNTIME,
+                    "ThreadPoolExecutor::handleResult");
     // Lock is not necessary as we only access on this runs executor.
     executionState->insertIntoTraceContext(traceContext->getTraceEvents());
   }


### PR DESCRIPTION
Summary: Rather than being a weird upward scale with some exceptions, this PR changes the TraceLevel verbosity to be a set of flags which specify kinds of events you want to enable as a bitmask (including the new TraceLevel Request which is coming soon). Also prevent adding new TraceEvents without specifying verbosity so they don't fall through the cracks.

Documentation: updated Tracing.md
Test Plan: unit tests, plus new TraceEventTest
