### PR TITLE
Add log scope information inside optimize, lower, fold, transformForPrecisionMode and transformPostLowering

### DIFF
--- a/lib/Backends/CPU/Transforms.cpp
+++ b/lib/Backends/CPU/Transforms.cpp
@@ -121,6 +121,8 @@ static Node *optimizeCPUMaxSplat(MaxNode *MN, Function *F) {
 
 bool CPUBackend::transformPostLowering(Function *F,
                                        CompilationContext &) const {
+  LOG_SCOPE(F->getLogContext(), "CPUBackend::transformPostLowering")
+
   bool changed = false;
   for (auto &node : F->getNodes()) {
     // Try to replace generic convolution with cpu-optimized version.

--- a/lib/Backends/Habana/Habana.cpp
+++ b/lib/Backends/Habana/Habana.cpp
@@ -1559,6 +1559,8 @@ bool surroundTileWithReshapes(Function *F, TileNode &tile) {
 
 bool HabanaBackend::transformPostLowering(Function *F,
                                           CompilationContext &cctx) const {
+  LOG_SCOPE(F->getLogContext(), "HabanaBackend::transformPostLowering")
+
   bool changed = false;
   for (auto &node : F->getNodes()) {
     // Separate any Slice nodes into several that only slice in one dimension

--- a/lib/Backends/OpenCL/Transforms.cpp
+++ b/lib/Backends/OpenCL/Transforms.cpp
@@ -30,6 +30,9 @@ bool OCLBackend::transformPostLowering(Function *F,
                                        CompilationContext &cctx) const {
   // NCHW transformation is not supported in training mode yet, because of some
   // issues with gradient nodes.
+
+  LOG_SCOPE(F->getLogContext(), "OCLBackend::transformPostLowering")
+
   if (cctx.compMode == CompilationMode::Train)
     return false;
 


### PR DESCRIPTION
Summary:
Add log scope information inside:
- optimize
- lower
- fold 
- transformForPrecisionMode 
- transformPostLowering

Test Plan:
ninja check
<img width="1440" alt="Screen Shot 2019-06-16 at 11 47 58 PM" src="https://user-images.githubusercontent.com/8838608/59583791-34ae3300-9091-11e9-8de6-c839db72a4ad.png">
An example of log output looks like this right now.