### PR TITLE
 [runtime] Perform a round of backend-independent optimizations before partitioning

### DIFF
--- a/include/glow/Optimizer/Optimizer.h
+++ b/include/glow/Optimizer/Optimizer.h
@@ -77,6 +77,12 @@ std::unique_ptr<IRFunction> generateAndOptimizeIR(Function *F, const Backend &B,
 llvm::Error optimizeFunction(Function *F, const Backend &B,
                              CompilationContext &cctx);
 
+/// Optimize the Function \p F given compilation options \p cctx performing
+/// backend-independent optimizations that can be done before lowering.
+/// \returns success if there were no compiler errors; if not, this represents a
+/// compiler error.
+llvm::Error optimizeFunctionBeforeLowering(Function *F,
+                                           CompilationContext &cctx);
 } // namespace glow
 
 #endif // GLOW_OPTIMIZER_OPTIMIZER_H

--- a/lib/Optimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer.cpp
@@ -2845,11 +2845,9 @@ static void transformForPrecisionMode(const Backend &B, Function *F,
   }
 }
 
-// NOTE: When updating this function, please also update the documentation in
-// docs/GraphOptimizationPipeline.md
-llvm::Error glow::optimizeFunction(Function *F, const Backend &B,
-                                   CompilationContext &cctx) {
-  LOG_SCOPE(F->getLogContext(), "glow::optimizeFunction")
+llvm::Error glow::optimizeFunctionBeforeLowering(Function *F,
+                                                 CompilationContext &cctx) {
+  LOG_SCOPE(F->getLogContext(), "glow::optimizeFunctionBeforeLowering")
 
   // Verify the function pre-optimization/lowering.
   assert(F->verify() && "Function must be valid");
@@ -2867,7 +2865,16 @@ llvm::Error glow::optimizeFunction(Function *F, const Backend &B,
 
   // Optimize the graph.
   ::glow::optimize(F, cctx);
+  return llvm::Error::success();
+}
 
+// NOTE: When updating this function, please also update the documentation in
+// docs/GraphOptimizationPipeline.md
+llvm::Error glow::optimizeFunction(Function *F, const Backend &B,
+                                   CompilationContext &cctx) {
+  LOG_SCOPE(F->getLogContext(), "glow::optimizeFunction")
+
+  RETURN_IF_ERR(optimizeFunctionBeforeLowering(F, cctx));
   // Lower the graph into a sequence of low-level linear algebra operations.
   const PrecisionConfiguration &precConfig = cctx.precisionConfig;
   if (precConfig.quantMode == QuantizationMode::Profile) {

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -92,6 +92,11 @@ llvm::Error HostManager::addNetwork(std::unique_ptr<Module> module,
     info.backendName = device.second->getBackendName();
     deviceInfo.push_back(info);
   }
+  // Perform a round of target-independent graph optimizations. This helps the
+  // partitioner to do its job more efficiently.
+  for (Function *F : module->getFunctions()) {
+    RETURN_IF_ERR(optimizeFunctionBeforeLowering(F, cctx));
+  }
   auto partitioner = Partitioner(module.get(), deviceInfo, saturateHost);
   RETURN_IF_ERR(partitioner.Partition(cctx));
   auto nodeList = std::move(partitioner.getPartitionResult());


### PR DESCRIPTION
- Move the logic for backend-independent optimizations performed before lowering into a dedicated function

- Perform a round of backend-independent optimizations before partitioning

   Doing so reduces the number of nodes to be partitioned and partitioner has less work to do.

   When using a custom experimental backend and a heterogeneous partitioning, I've seen the number of partitions produced for Glow's ResNet50 model going down from 101 to 3 after running a round of backend-independent optimizations before partitioning.