### PR TITLE
fix loadOperatorName

### DIFF
--- a/include/glow/Importer/ProtobufLoader.h
+++ b/include/glow/Importer/ProtobufLoader.h
@@ -80,9 +80,12 @@ std::vector<ElemTy> getShape(const AttrType *arg) {
 }
 
 /// Returns canonical name for a given operator: either \p name() from proto,
-/// or its first output's name.
+/// or its type name.
 template <typename T> std::string loadOperatorName(const T &op) {
-  return op.name().length() ? op.name() : op.output(0);
+  if (op.name().length()) {
+    return op.name();
+  }
+  return op.op_type();
 }
 
 /// Loads model: graph and weights.

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -48,6 +48,18 @@ using ArgumentDictionaryTy =
 /// Therefore, we can make scale_1 == scale_2, and offset_1 = offset2 - 128
 const int32_t OFFSETSHIFT = 128;
 
+namespace glow {
+/// Template specialization of loadOperatorName for caffe2.
+template <>
+std::string
+loadOperatorName<caffe2::OperatorDef>(const caffe2::OperatorDef &op) {
+  if (op.name().length()) {
+    return op.name();
+  }
+  return op.type();
+}
+}; // namespace glow
+
 /// Legacy padding modes supported in caffe2.  These are used by MaxPool
 /// operators, and are defined in caffe2_legacy.proto in the caffe2 source
 /// tree.


### PR DESCRIPTION
Summary:
previously this function would return the name of the operator and if empty, the first output, this failed when there were no outputs

changed to return the name, and if not found, the type

made a generic implementation and a specialization for caffe2 protobufs

Differential Revision: D15859961

