### PR TITLE
[compilationLog]: Remove logNodesReplacement as its functionality overlaps with logNodeInputChange

### DIFF
--- a/include/glow/Graph/Log.h
+++ b/include/glow/Graph/Log.h
@@ -61,10 +61,6 @@ public:
   /// Logs the node creation with a list of input nodes.
   void logNodeCreation(const Node *newNode);
 
-  /// Logs the node replacement.
-  void logNodeValueReplacement(const NodeValue &oldNodeVal,
-                               const NodeValue &newNodeVal);
-
   /// Logs the node deletion.
   void logNodeDeletion(const Node &deletedNode);
 

--- a/lib/Graph/Log.cpp
+++ b/lib/Graph/Log.cpp
@@ -105,23 +105,6 @@ void LogContext::logNodeCreation(const Node *newNode) {
   addLogContent(" }\n");
 }
 
-/// Logs the node replacement.
-void LogContext::logNodeValueReplacement(const NodeValue &oldNodeVal,
-                                         const NodeValue &newNodeVal) {
-  if (!dumpCompilationLogOpt) {
-    return;
-  }
-  addLogContent(
-      llvm::formatv("[FULL SCOPE: {0} ] --- REPLACE ( OldNodeVal(Kind: {1}, "
-                    "Name: {2}, ResNo: {3}) ==>  NewNodeVal(Kind: {4}, Name: "
-                    "{5}, ResNo: {6}) }\n",
-                    getFullScopeName(), oldNodeVal.getNode()->getKindName(),
-                    oldNodeVal.getNode()->getName(), oldNodeVal.getResNo(),
-                    newNodeVal.getNode()->getKindName(),
-                    newNodeVal.getNode()->getName(), newNodeVal.getResNo())
-          .str());
-}
-
 /// Logs the node deletion.
 void LogContext::logNodeDeletion(const Node &deletedNode) {
   if (!dumpCompilationLogOpt) {

--- a/lib/Graph/NodeValue.cpp
+++ b/lib/Graph/NodeValue.cpp
@@ -58,11 +58,6 @@ void NodeValue::replaceAllUsesOfWith(NodeValue v, const Function *F) const {
 
     site->setOperand(v.getNode(), v.getResNo());
   }
-
-  // Log all nodes replacement.
-  if (Function *F = getNode()->getParent()) {
-    F->getLogContext().logNodeValueReplacement(*this, v);
-  }
 }
 
 unsigned NodeValue::getNumUsers() const {


### PR DESCRIPTION
Summary:
Propose to remove logNodesReplacement as it does the same thing as logNodeInputChange, with the latter one also producing more detailed information.

Test Plan:
test with GraphOptz.concatReshapes. I compare the log before and after removing logNodesReplacement in below
Before removing:
![Screen Shot 2019-06-17 at 1 22 13 PM](https://user-images.githubusercontent.com/8838608/59634697-3e24b300-9104-11e9-9508-193d466aea0a.png)

After removing:
![Screen Shot 2019-06-17 at 1 26 56 PM](https://user-images.githubusercontent.com/8838608/59634718-47158480-9104-11e9-99ea-f522588cf390.png)

As we can see that REPLACE produces almost same information as NODE_INPUT_CHANGE.
