### PR TITLE
[compilationLog]: Include input nodevalue's ResNo in the log of nodes creation.

### DIFF
--- a/lib/Graph/Log.cpp
+++ b/lib/Graph/Log.cpp
@@ -87,9 +87,9 @@ void LogContext::logNodeCreation(const Node *newNode) {
   if (!dumpCompilationLogOpt) {
     return;
   }
-  std::vector<Node *> inputs;
+  std::vector<NodeValue> inputs;
   for (size_t idx = 0; idx < newNode->getNumInputs(); idx++) {
-    inputs.push_back(newNode->getNthInput(idx).getNode());
+    inputs.push_back(newNode->getNthInput(idx));
   }
   addLogContent(
       llvm::formatv(
@@ -97,8 +97,9 @@ void LogContext::logNodeCreation(const Node *newNode) {
           getFullScopeName(), newNode->getKindName(), newNode->getName())
           .str());
   for (auto n : inputs) {
-    addLogContent(llvm::formatv(" (Kind: {0}, Name: {1}) ", n->getKindName(),
-                                n->getName())
+    addLogContent(llvm::formatv(" (Kind: {0}, Name: {1}, ResNo: {2}) ",
+                                n.getNode()->getKindName(),
+                                n.getNode()->getName(), n.getResNo())
                       .str());
   }
   addLogContent(" }\n");


### PR DESCRIPTION
Summary:
Include resno of each input nodevalue in the log of nodes creation.

Test Plan:
run GraphOptz.concatReshapes, and the log output of before and after this diff is shown below:
Before:
![Screen Shot 2019-06-17 at 2 35 33 PM](https://user-images.githubusercontent.com/8838608/59638909-7e892e80-910e-11e9-8980-27f385bbbd63.png)

After:
![Screen Shot 2019-06-17 at 2 41 44 PM](https://user-images.githubusercontent.com/8838608/59638918-82b54c00-910e-11e9-9c94-cc9f729ccd7c.png)

