### PR TITLE
[LLVMIRGen] Generate IR for Alloc, Dealloc and TensorView.

### DIFF
--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -786,8 +786,10 @@ void LLVMIRGen::generateLLVMIRForModule(llvm::IRBuilder<> &builder) {
       // Ignore memory management instructions as they are handled by the
       // MemoryManager and are NOPs for a JIT.
       if (isa<AllocActivationInst>(&I) || isa<DeallocActivationInst>(&I) ||
-          isa<TensorViewInst>(&I))
+          isa<TensorViewInst>(&I)) {
+        generateLLVMIRForInstr(builder, &I);
         continue;
+      }
       emitDataParallelKernel(builder, bundle);
       bundle.clear();
       generateLLVMIRForInstr(builder, &I);


### PR DESCRIPTION
Backend inhereting LLVMIRGen may want to generate IR for these instructions.