### PR TITLE
Properly support Int8ConvRelu and Int8SumRelu

### DIFF
--- a/tests/models/caffe2Models/int8convrelu_init_net.pbtxt
+++ b/tests/models/caffe2Models/int8convrelu_init_net.pbtxt
@@ -1,0 +1,45 @@
+name: "init"
+op {
+  output: "conv_w"
+  type: "Int8GivenTensorFill"
+  arg {
+    name: "shape"
+    ints: 1
+    ints: 1
+    ints: 2
+    ints: 2
+  }
+  arg {
+    name: "values"
+    s: "\1\1\1\1"
+  }
+  arg {
+    name: "Y_scale"
+    f: 1
+  }
+  arg {
+    name: "Y_zero_point"
+    i: 0
+  }
+}
+op {
+  output: "conv_b"
+  type: "Int8GivenIntTensorFill"
+  arg {
+    name: "shape"
+    ints: 1
+  }
+  arg {
+    name: "values"
+    ints: 2
+  }
+  arg {
+    name: "Y_scale"
+    f: 1
+  }
+  arg {
+    name: "Y_zero_point"
+    i: 0
+  }
+}
+

--- a/tests/models/caffe2Models/int8convrelu_pred_net.pbtxt
+++ b/tests/models/caffe2Models/int8convrelu_pred_net.pbtxt
@@ -4,7 +4,7 @@ op {
   input: "conv_w"
   input: "conv_b"
   output: "conv_out"
-  type: "ConvRelu"
+  type: "Int8ConvRelu"
   arg {
     name: "kernel"
     i: 2
@@ -24,6 +24,14 @@ op {
   arg {
     name: "dilation"
     i: 1
+  }
+  arg {
+    name: "Y_scale"
+    f: 1
+  }
+  arg {
+    name: "Y_zero_point"
+    i: 0
   }
 }
 external_output: "conv_out"

--- a/tests/models/caffe2Models/int8sumrelu_init_net.pbtxt
+++ b/tests/models/caffe2Models/int8sumrelu_init_net.pbtxt
@@ -1,0 +1,23 @@
+name: "init"
+op {
+  output: "rhs"
+  type: "Int8GivenTensorFill"
+  arg {
+    name: "shape"
+    ints: 4
+    ints: 2
+  }
+  arg {
+    name: "values"
+    s: "\1\1\1\1\1\1\1\1"
+  }
+  arg {
+    name: "Y_scale"
+    f: 1
+  }
+  arg {
+    name: "Y_zero_point"
+    i: 0
+  }
+}
+

--- a/tests/models/caffe2Models/int8sumrelu_pred_net.pbtxt
+++ b/tests/models/caffe2Models/int8sumrelu_pred_net.pbtxt
@@ -1,0 +1,17 @@
+name: "conv_test"
+op {
+  input: "gpu_0/data_0"
+  input: "rhs"
+  output: "out"
+  type: "Int8SumRelu"
+  arg {
+    name: "Y_scale"
+    f: 1
+  }
+  arg {
+    name: "Y_zero_point"
+    i: 0
+  }
+}
+external_output: "out"
+

--- a/tests/unittests/GraphOptzTest.cpp
+++ b/tests/unittests/GraphOptzTest.cpp
@@ -2870,3 +2870,15 @@ TEST_F(GraphOptz, dceQuantization) {
 
   EXPECT_EQ(F_->getNodes().size(), 2);
 }
+
+TEST_F(GraphOptz, nopRelu) {
+  auto *in = mod_.createPlaceholder(ElemKind::Int8QTy, {3, 5}, 0.3, -128, "lhs",
+                                    false);
+
+  auto *relu = F_->createRELU("relu", in);
+  F_->createSave("save", relu);
+
+  ::glow::optimize(F_, CompilationMode::Infer);
+
+  EXPECT_EQ(F_->getNodes().size(), 1);
+}


### PR DESCRIPTION
We do not add Relu in loader explicitly, because we rely on the Caffe2 protobuf always having scale and offset such, that Relu is not needed. However, it may break. Also, as we go with having more Loaders, we may want more general approach anyway.
