### PR TITLE
Avoid zeroing Tensors unnecessarily

### DIFF
--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -322,7 +322,10 @@ public:
     // If the new size is identical to the allocated size then there is no need
     // to re-allocate the buffer.
     if (type_ == T && getData()) {
-      zero();
+#ifdef GLOW_DEBUG_TENSOR_INIT
+      PseudoRNG rng;
+      init(InitKind::Broadcast, GLOW_DEBUG_TENSOR_INIT, rng);
+#endif
       return;
     }
 
@@ -338,7 +341,11 @@ public:
     assert(size() > 0 && "Tensors must always have positive size.");
     size_t count = size() * type_.getElementSize();
     data_ = reinterpret_cast<char *>(alignedAlloc(count, TensorAlignment));
-    zero(getElementType() == ElemKind::UInt8FusedQTy);
+
+#ifdef GLOW_DEBUG_TENSOR_INIT
+    PseudoRNG rng;
+    init(InitKind::Broadcast, GLOW_DEBUG_TENSOR_INIT, rng);
+#endif
   }
   /// Releases the data buffer and sets the unOwned flag to true. This is useful
   /// for keeping metadata around but not the actual contents.

--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -131,6 +131,9 @@ class Placeholder : public Storage {
   /// Specifies if the placeholder is trainable.
   bool isTrainable_;
 
+  /// Specifies if associated Tensors should be zeroed when allocated.
+  bool allocZero_{false};
+
 public:
   /// Create a new placeholder.
   Placeholder(llvm::StringRef name, TypeRef Ty, bool isTrainable)
@@ -142,6 +145,12 @@ public:
   /// \returns True if the placeholder are trainable during
   /// differentiation.
   bool isTraining() const { return isTrainable_; }
+
+  /// \returns True if associated Tensors should be zeroed when allocated.
+  bool allocZero() const { return allocZero_; }
+
+  /// Sets whether or not associated Tensors should be zeroed.
+  void setAllocZero(bool on = true) { allocZero_ = on; }
 
   static bool classof(const Kinded *k) {
     return k->getKind() == Kinded::Kind::PlaceholderKind;

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -1055,6 +1055,7 @@ void BoundInterpreterFunction::fwdCrossEntropyLossInstFloatImpl(
   auto labels = getWeightHandle<int64_t>(I->getLabels());
   auto CE = getWeightHandle<ElemTy>(I->getCE());
   auto dims = P.dims();
+  CE.clear();
   for (size_t n = 0; n < dims[0]; ++n) {
     assert(labels.raw(n) >= 0 && "Cannot use negative index.");
     size_t y = labels.raw(n);

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1622,7 +1622,7 @@ Function::createQuantizationProfile(PlaceholderBindings &bindings,
   const size_t numberOfBuckets = 2000U;
   auto *histogram = getParent()->createPlaceholder(
       ElemKind::FloatTy, {numberOfBuckets}, "histogram_" + name.str(), false);
-  bindings.allocate(histogram);
+  bindings.allocate(histogram)->zero();
   // Intermediate data used for histogram calculations.
   // Min tensor value seen so far is kept on the first position.
   // Max tensor value seen so far is kept on the second position.

--- a/lib/Graph/PlaceholderBindings.cpp
+++ b/lib/Graph/PlaceholderBindings.cpp
@@ -150,6 +150,12 @@ Tensor *PlaceholderBindings::allocate(Placeholder *P) {
   DCHECK(!map_.count(P)) << "Placeholder with name \"" << P->getName().str()
                          << "\" already registered";
   Tensor *T = new Tensor(P->getType());
+
+  // If this Tensor needs to start zeroed, then zero it.
+  if (P->allocZero()) {
+    T->zero();
+  }
+
   map_[P] = T;
   nameMap_[P->getName()] = P;
   return T;

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -164,6 +164,11 @@ onnxStatus Graph::setIOAndRun(uint32_t inputsCount,
       // pointer (which is a valid case if the tensor is empty).
       if (inOnnxBuffer) {
         memcpy(inputTensor->getUnsafePtr(), inOnnxBuffer, onnxBytes);
+        // Pad remaining space with zeroes.
+        memset(inputTensor->getUnsafePtr() + onnxBytes, 0,
+               inputTensor->getSizeInBytes() - onnxBytes);
+      } else {
+        inputTensor->zero();
       }
       ctx->getPlaceholderBindings()->insert(inPhPtr, inputTensor);
     }

--- a/lib/Optimizer/Lower.cpp
+++ b/lib/Optimizer/Lower.cpp
@@ -358,6 +358,7 @@ static void lowerSGDNode(Function *F, CompilationContext &cctx,
   if (momentum > 0.0) {
     Placeholder *Gsum =
         F->getParent()->createPlaceholder(W.getType(), "gsum", false);
+    Gsum->setAllocZero();
 
     auto *momentumSplat = F->createSplat("learningRateSplat", type, momentum);
     auto *GsumMult = F->createMul("GsumMult", momentumSplat, Gsum);

--- a/lib/Optimizer/Quantization.cpp
+++ b/lib/Optimizer/Quantization.cpp
@@ -51,6 +51,14 @@ void glow::profileQuantization(PlaceholderBindings &bindings, Function *F) {
     if (PH->getOutput().getElementType() != ElemKind::FloatTy) {
       continue;
     }
+
+    /// Don't profile output nodes.
+    if (!PH->getUsers().empty()) {
+      auto *SN = llvm::dyn_cast<SaveNode>(PH->getUsers().begin()->getUser());
+      if (SN) {
+        continue;
+      }
+    }
     nodesToInstrument.insert(PH->getOutput());
   }
 

--- a/tests/unittests/BackendTestUtils.cpp
+++ b/tests/unittests/BackendTestUtils.cpp
@@ -583,7 +583,7 @@ void inferNonSquarePaddingConv(Tensor *out, llvm::StringRef kind) {
   auto *filterTensor = bindings.allocate(filter);
   auto FH = filterTensor->getHandle();
   for (size_t i = 0; i < 128; i++)
-    for (size_t j = 0; j < 16; j++) {
+    for (size_t j = 0; j < 32; j++) {
       FH.at({i, 0, 0, j}) = (i + j) / 100.0;
     }
   auto *zeroBias =
@@ -700,6 +700,7 @@ void inferConvDKKC8(Tensor *out, llvm::StringRef kind) {
   auto *filter = mod.createPlaceholder(ElemKind::FloatTy, {192, 3, 3, 32},
                                        "filter", false);
   auto *filterTensor = bindings.allocate(filter);
+  filterTensor->zero();
   auto FH = filterTensor->getHandle();
   for (size_t i = 0; i < 192; i++)
     for (size_t j = 0; j < 3; j++)

--- a/tests/unittests/GradCheckTest.cpp
+++ b/tests/unittests/GradCheckTest.cpp
@@ -534,9 +534,9 @@ TEST_P(InterpreterGrad, gradientCheckArithmetic) {
   auto *C = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim}, "C", false);
   auto *D = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim}, "D", false);
   auto *E = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim}, "E", false);
-  bindings.allocate(B);
-  bindings.allocate(C);
-  bindings.allocate(D);
+  bindings.allocate(B)->zero();
+  bindings.allocate(C)->zero();
+  bindings.allocate(D)->zero();
 
   // Randomize E to avoid div by zero.
   auto *ETensor = bindings.allocate(E);
@@ -724,16 +724,18 @@ TEST_P(InterpreterGrad, gradientCheckCrossEntropyLoss) {
   Function *F = mod.createFunction("main");
   auto *P =
       mod.createPlaceholder(ElemKind::FloatTy, {batchSize, 4}, "P", false);
-  bindings.allocate(P);
+  bindings.allocate(P)->zero();
   auto *Y =
       mod.createPlaceholder(ElemKind::Int64ITy, {batchSize}, "Labels", false);
-  bindings.allocate(Y);
+  bindings.allocate(Y)->zero();
   Node *CE = F->createCrossEntropyLoss("celoss", P, Y);
   auto *result = F->createSave("ret", CE);
   auto *LTensor = bindings.allocate(result->getPlaceholder());
 
   Tensor inputs(ElemKind::FloatTy, {batchSize, 4});
+  inputs.zero();
   Tensor outputs(ElemKind::Int64ITy, {batchSize});
+  outputs.zero();
 
   auto inputsH = inputs.getHandle();
   auto outputsH = outputs.getHandle<int64_t>();

--- a/tests/unittests/GraphTest.cpp
+++ b/tests/unittests/GraphTest.cpp
@@ -508,8 +508,7 @@ TEST(Graph, QuantizationProfileNodes) {
   // 1 from A
   // 8 from two lowered FCs: MM, BA, weight PH, bias PH
   // 2 from RELU (lowered to Max+Splat)
-  // 2 from float saves (just profile their output PH)
-  EXPECT_EQ(13, numberOfProfileNodes);
+  EXPECT_EQ(11, numberOfProfileNodes);
 }
 
 TEST(Graph, simpleQuant) {

--- a/tests/unittests/HyphenTest.cpp
+++ b/tests/unittests/HyphenTest.cpp
@@ -350,6 +350,7 @@ TEST(HyphenTest, network) {
   // Convert words and hyphens to a tensor representation.
   Tensor inputs(ElemKind::FloatTy, {numSamples, 6, 27});
   Tensor expected(ElemKind::Int64ITy, {numSamples, 1});
+  inputs.zero();
   auto inputHandle = inputs.getHandle<float>();
   auto expectedHandle = expected.getHandle<int64_t>();
   for (size_t i = 0; i != numSamples; i++) {

--- a/tests/unittests/TensorsTest.cpp
+++ b/tests/unittests/TensorsTest.cpp
@@ -244,6 +244,10 @@ TEST(Tensor, concatTensors2D) {
   auto yH = Y.getHandle<>();
   auto zH = Z.getHandle<>();
 
+  // Zero Y and Z but not X.
+  Y.zero();
+  Z.zero();
+
   // Create a nice picture:
   for (size_t i = 0, e = xH.size(); i < e; i++) {
     xH.raw(i) = (float(i) - 30) / 50;
@@ -388,7 +392,9 @@ TEST(Tensor, reset) {
   QH = {5, 9, -2, 4, 3, -10, 21, -9, 0, -51, 73, 2};
 
   A.reset(ElemKind::FloatTy, {5, 2, 6});
+  A.zero();
   QA.reset(ElemKind::Int8QTy, {4, 7, 3, 8}, 1.4, -13);
+  QA.zero();
 
   H = A.getHandle();
   QH = QA.getHandle<int8_t>();
@@ -505,6 +511,7 @@ TEST(Tensor, nonOwnedTensorFollowedByReset) {
   // tensor was unowned and we used to not reset that state
   // as well and were leaking memory.
   T1.reset(F32x2Ty);
+  T1.zero();
   H1 = T1.getHandle<>();
   EXPECT_EQ(int(H1.at({0})), 0);
   EXPECT_EQ(int(H1.at({1})), 0);
@@ -678,15 +685,19 @@ TEST(Tensor, insertWithCountAndAxis) {
 TEST(Tensor, zeroQuantizedTensor) {
   const int32_t offsetQ8 = 0;
   Tensor Q8T(ElemKind::Int8QTy, {3, 4, 5, 6}, 127, offsetQ8);
+  Q8T.zero();
 
   const int32_t offsetUQ8 = 3;
   Tensor UQ8T(ElemKind::UInt8QTy, {3, 4, 5, 6}, 2, offsetUQ8);
+  UQ8T.zero();
 
   const int32_t offsetQ16 = 223;
   Tensor Q16T(ElemKind::Int16QTy, {3, 4, 5}, 1234.7, offsetQ16);
+  Q16T.zero();
 
   const int32_t offsetQ32 = 53452;
   Tensor Q32T(ElemKind::Int32QTy, {3, 4}, 500.4, offsetQ32);
+  Q32T.zero();
 
   auto Q8H = Q8T.getHandle<int8_t>();
   EXPECT_TRUE(Q8H.isZero());
@@ -731,6 +742,7 @@ TEST(Tensor, zeroQuantizedTensor) {
 TEST(Tensor, manuallySetToOffset) {
   const int8_t offsetQ8 = 6;
   Tensor Q8T(ElemKind::Int8QTy, {3, 2}, 10.1, offsetQ8);
+  Q8T.zero();
 
   auto Q8H = Q8T.getHandle<int8_t>();
   EXPECT_TRUE(Q8H.isZero());
@@ -766,7 +778,9 @@ TEST(ZeroDimensionalTensor, handleAssign) {
 
 TEST(ZeroDimensionalTensor, compareAndDumpTwo) {
   Tensor T1(ElemKind::FloatTy, {});
+  T1.zero();
   Tensor T2(ElemKind::FloatTy, {});
+  T2.zero();
 
   EXPECT_TRUE(T1.isEqual(T2));
 

--- a/tools/loader/TextTranslator.cpp
+++ b/tools/loader/TextTranslator.cpp
@@ -304,10 +304,10 @@ int main(int argc, char **argv) {
   // Encoded input sentence. Note that the batch size is 1 for inference models.
   Tensor encoderInputs(ElemKind::Int64ITy, {maxInputLenOpt, /* batchSize */ 1});
 
-  // Inputs other than tokenized input. These should all be initialized to zero
-  // (which they are by default). Note, the init_net already defines these
-  // tensors solely as placeholders (with incorrect shapes/elementtypes/data).
-  // Glow uses these tensors in their place.
+  // Inputs other than tokenized input. These should all be initialized to zero.
+  // Note, the init_net already defines these tensors solely as placeholders
+  // (with incorrect shapes/elementtypes/data). Glow uses these tensors in their
+  // place.
   Tensor attnWeights(ElemKind::FloatTy, {maxInputLenOpt});
   Tensor prevHyposIndices(ElemKind::Int64ITy, {beamSizeOpt});
   Tensor prevScores(ElemKind::FloatTy, {1});
@@ -329,6 +329,13 @@ int main(int argc, char **argv) {
 
   // Allocate tensors to back all inputs and outputs.
   bindings.allocate(loader.getModule()->getPlaceholders());
+
+  // Get all input tensors and zero them.
+  for (const auto *name : inputNames) {
+    Tensor *T = bindings.get(loader.getModule()->getPlaceholderByName(name));
+    DCHECK(T && "input tensor missing!");
+    T->zero();
+  }
 
   Placeholder *encoderInputsVar = llvm::cast<Placeholder>(
       EXIT_ON_ERR(LD.getNodeValueByName("encoder_inputs")));


### PR DESCRIPTION
Summary: We zero tensors whenever they are `reset()`, and we reset Tensors a lot. Instead we should only zero buffers when we really need to. An example is if we're loading a constant from the protobuf into a Tensor it doesn't matter what the original value was.

Many tests broke when I did this, and most of the time I fixed it by intentionally calling `zero()` on the Tensor. Usually it was just because the test expected the result of working on an uninitialized Tensor to be the same between runs (e.g. when doing a comparison against the Interpreter).

A few cases were legitimate bugs hidden by the fact the Tensors happened to be zero, which i've fixed here:
* Quantization Profiling: The Tensor holding the profile is modified in place and needs to be manually zeroed. In this diff I've done it by marking it as "Trainable" which may be slight abuse of the term (we're training the quantizer to choose good params... ?).
* The Interpreters CrossEntropyLoss calculation for floats was modifying its output Tensor without clearing it first.
* Training: When we lowered the SGD node we weren't setting its PH to be trainable. If we guarantee all trainable Tensors are zeroed this works as intended. (Question: should training Tensors always start zero? Isn't it normal to start in a random state?).
* The `inferNonSquarePaddingConv` test helper used the wrong dimensions.
* ThreadPoolExecutor: This was the hardest to work out. The test was incorrectly verifying that output Tensors were consistent when passed into the DeviceManager but that is definitely not true now that we use a TensorPool, and was only passing because Tensors were initialized zero and were never modified (so all Tensors were the same).

Not fixed but weird:
* inferConvDKKC8 test is using the wrong indexes I think, will call out in a comment.

Documentation: Fixes #3037

Test Plan: unit tests under Release and ASAN, Tested again with the GLOW_DEBUG_TENSOR_INIT define set to test when the initial state is definitely not 0.

Manual testing with resnet-runtime shows a **90% reduction in zeroing buffers**:

before:
```
│I0617 21:46:29.172291 451777984 resnet-runtime.cpp:221] resets: 505
│I0617 21:46:29.172297 451777984 resnet-runtime.cpp:222] zeroes: 558

```
after:
```
│I0617 21:43:12.518196 208471488 resnet-runtime.cpp:221] resets: 505
│I0617 21:43:12.518205 208471488 resnet-runtime.cpp:222] zeroes: 53

```

(I determined this with a global atomic, counting code is not in the diff)

Will follow up later with some more prod like tests, but there are decisions here worth getting comment on early.