### PR TITLE
Back out "[glow] Use unowned padded tensors to pass partial tensors through onnxifi"

### DIFF
--- a/lib/Backends/Habana/Habana.cpp
+++ b/lib/Backends/Habana/Habana.cpp
@@ -451,12 +451,12 @@ llvm::Error HabanaFunction::execute(ExecutionContext *context) {
     EnqueueTensorInfo eti;
     llvm::StringRef name = P->getName();
     eti.tensorName = name.data();
-    eti.tensorSize = T->getSizeInBytes();
+    eti.tensorSize = T->getUnpaddedSizeInBytes();
     eti.pTensorData = (char *)ioBuffer->get(P);
 
     inputInfo.push_back(eti);
     // Copy from the tensor into the designated IO buffer.
-    memcpy(eti.pTensorData, T->getUnsafePtr(), T->getUnpaddedSizeInBytes());
+    memcpy(eti.pTensorData, T->getUnsafePtr(), eti.tensorSize);
   }
   TRACE_EVENT_END(tc, "copyInputs");
 


### PR DESCRIPTION
Summary:
Unpadded tensors aren't valid everywhere.  Consider SparseLengthsSum:
if the `Lengths` input varies in the batch dimension, an "unpadded" tensor may
read garbage lengths, leading to garbage indices, leading to wild pointer
accesses.  If we want to use this optimization, we have to carefully guard
against cases where the input is used to perform memory indirection.

Differential Revision: D15872450

