### PR TITLE
ChannelwiseQuantizedConvolutionNode impl

### DIFF
--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -292,6 +292,16 @@ public:
     return unownedTensor;
   }
 
+  /// This is the same as \ref getUnowned() but it produces an owned tensor
+  /// instead. \returns owned tensor copied from the data buffer of the current
+  /// tensor but having different dimensions \p dims. \p offsets represents an
+  /// optional offset into the tensor representing the location of the first
+  /// element to start a subview from.
+  Tensor getOwnedSlice(llvm::ArrayRef<size_t> dims,
+                       llvm::ArrayRef<size_t> offsets = {}) const {
+    return getUnowned(dims, offsets).clone();
+  }
+
   /// Reset the shape and type of this tensor to match the shape and type of
   /// \p other.
   void reset(const Tensor *other) { reset(other->getType()); }

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -136,6 +136,20 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
                {ConvolutionNode::BiasIdx}) &&
            (NI.getInElemTy(ConvolutionNode::BiasIdx) == ElemKind::Int32QTy);
 
+  case Kinded::Kind::ChannelwiseQuantizedConvolutionNodeKind:
+    return (NI.getInElemTy(ChannelwiseQuantizedConvolutionNode::InputIdx) ==
+            ElemKind::Int8QTy) &&
+           (NI.getInElemTy(ChannelwiseQuantizedConvolutionNode::FilterIdx) ==
+            ElemKind::Int8QTy) &&
+           (NI.getInElemTy(ChannelwiseQuantizedConvolutionNode::BiasIdx) ==
+            ElemKind::FloatTy) &&
+           (NI.getInElemTy(ChannelwiseQuantizedConvolutionNode::ScalesIdx) ==
+            ElemKind::FloatTy) &&
+           (NI.getInElemTy(ChannelwiseQuantizedConvolutionNode::OffsetsIdx) ==
+            ElemKind::Int32ITy) &&
+           (NI.getOutElemTy(ChannelwiseQuantizedConvolutionNode::ResultIdx) ==
+            ElemKind::Int8QTy);
+
   case Kinded::Kind::Convolution3DNodeKind:
     if (!NI.getInTy(Convolution3DNode::InputIdx)->isQuantizedType()) {
       return NI.allInputsAndOutputsHaveSameElemKind(
@@ -395,6 +409,7 @@ bool Interpreter::shouldLower(const Node *N) const {
   switch (N->getKind()) {
   case Kinded::Kind::ConvolutionNodeKind:
   case Kinded::Kind::SparseLengthsSumNodeKind:
+  case Kinded::Kind::ChannelwiseQuantizedConvolutionNodeKind:
     return false;
   default:
     return true;

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -560,6 +560,104 @@ void BoundInterpreterFunction::fwdConvolution3DGradInst(
   llvm_unreachable("not yet implemented");
 }
 
+void BoundInterpreterFunction::fwdChannelwiseQuantizedConvolutionInst(
+    const ChannelwiseQuantizedConvolutionInst *I) {
+  assert(I->getGroupwise() && "Non-groupwise not supported");
+
+  using AccumulatorTy = int32_t;
+
+  auto inW = getWeightHandle<int8_t>(I->getSrc());
+  auto outW = getWeightHandle<int8_t>(I->getDest());
+  auto filterW = getWeightHandle<int8_t>(I->getFilter());
+  auto biasW = getWeightHandle<float>(I->getBias());
+  auto scalesW = getWeightHandle<float>(I->getScales());
+  auto offsetsW = getWeightHandle<int32_t>(I->getOffsets());
+
+  llvm::ArrayRef<unsigned_t> kernelSizes = I->getKernels();
+  llvm::ArrayRef<unsigned_t> pads = I->getPads();
+  llvm::ArrayRef<unsigned_t> strides = I->getStrides();
+  size_t group = I->getGroup();
+
+  ShapeNHWC odim(outW.dims());
+  ShapeNHWC idim(inW.dims());
+  ShapeHW kdim(kernelSizes);
+  ShapeHW sdim(strides);
+
+  assert(idim.c % group == 0 && "Input channels must be divisible by group.");
+  assert(odim.c % group == 0 && "Output channels must be divisible by group.");
+  size_t inCperG = idim.c / group;
+  size_t outCperG = odim.c / group;
+
+  PaddingTLBR pdim(pads);
+
+  auto &inTy = inW.getType();
+  auto &outTy = outW.getType();
+
+  float inScale = inTy.getScale();
+  float outScale = outTy.getScale();
+
+  int32_t inOffset = inTy.getOffset();
+  int32_t outOffset = outTy.getOffset();
+
+  // For each input in the batch:
+  for (size_t n = 0; n < idim.n; n++) {
+    // For each group of input channels:
+    for (size_t g = 0; g < group; g++) {
+
+      // get groupwise qparams params
+      int32_t filterOffset = offsetsW.at(g);
+      float filterScale = scalesW.at(g);
+      float matMulScale = inScale * filterScale;
+
+      // For each output channel in the group:
+      for (size_t d = g * outCperG; d < (g + 1) * outCperG; d++) {
+
+        // For each convolution 'jump' in the input tensor:
+        ssize_t x = -ssize_t(pdim.top);
+        for (size_t ax = 0; ax < odim.h; x += sdim.height, ax++) {
+          ssize_t y = -ssize_t(pdim.left);
+          for (size_t ay = 0; ay < odim.w; y += sdim.width, ay++) {
+
+            // For each element in the convolution-filter:
+            AccumulatorTy sum = 0;
+            for (size_t fx = 0; fx < kdim.height; fx++) {
+              for (size_t fy = 0; fy < kdim.width; fy++) {
+                ssize_t ox = x + fx;
+                ssize_t oy = y + fy;
+
+                // Ignore index access below zero (this is due to padding).
+                if (ox < 0 || oy < 0 || ox >= ssize_t(idim.h) ||
+                    oy >= ssize_t(idim.w)) {
+                  continue;
+                }
+                for (size_t fd = 0; fd < inCperG; fd++) {
+
+                  AccumulatorTy F = filterW.at({d, fx, fy, fd});
+                  AccumulatorTy I =
+                      inW.at({n, (size_t)ox, (size_t)oy, g * inCperG + fd});
+                  // We represent the element multiplication with offset as
+                  // (value - offset).
+                  sum += (F - filterOffset) * (I - inOffset);
+                }
+              }
+            }
+
+            // Scale the bias to match the scale of the matrix multiplication.
+            AccumulatorTy B = std::round(biasW.at({d}) / matMulScale);
+
+            // Add the bias:
+            sum += B;
+
+            // Scale the result back to the expected destination scale.
+            outW.at({n, ax, ay, d}) = quantization::clip<AccumulatorTy, int8_t>(
+                std::round(float(sum) * (matMulScale / outScale) + outOffset));
+          } // W
+        }   // H
+      }     // C
+    }       // G
+  }         // N
+}
+
 //===----------------------------------------------------------------------===//
 //                       Pooling
 //===----------------------------------------------------------------------===//

--- a/lib/Optimizer/Lower.cpp
+++ b/lib/Optimizer/Lower.cpp
@@ -647,6 +647,94 @@ static void lowerGroupConvolutionNode(Function *F, CompilationContext &cctx,
   replaceAllUsesOfWith(cctx.loweredInfoMap, BNG.getResult(), result);
 }
 
+static void lowerChannelwiseQuantizedConvolutionNode(
+    Function *F, CompilationContext &cctx,
+    const ChannelwiseQuantizedConvolutionNode &CQC) {
+  // ChannelwiseQuantizedConvolutionNode can be represented as a Concatenation
+  // of smaller dimension quantized Convolutions each with their own qparams.
+  // Input channels will be divided into equal groups of consecutive channels.
+  // These will be separately convolved each with its own filter and bias.
+  // This will result in 4 * Group + 1 nodes.
+
+  // Only lowering of groupwise, not channelwise is supported so far.
+  if (!CQC.getGroupwise()) {
+    return;
+  }
+
+  llvm::ArrayRef<unsigned_t> kernels = CQC.getKernels();
+  llvm::ArrayRef<unsigned_t> pads = CQC.getPads();
+  llvm::ArrayRef<unsigned_t> strides = CQC.getStrides();
+  unsigned_t group = CQC.getGroup();
+  auto in = CQC.getInput();
+
+  Constant *filter = llvm::cast<Constant>(CQC.getFilter());
+  Constant *bias = llvm::cast<Constant>(CQC.getBias());
+  Constant *scales = llvm::cast<Constant>(CQC.getScales());
+  Constant *offsets = llvm::cast<Constant>(CQC.getOffsets());
+
+  ShapeNHWC idim = ShapeNHWC(in.dims());
+  ShapeHW kdim(kernels);
+  unsigned inCperG = idim.c / group;
+  unsigned outCperG = filter->dims()[0] / group;
+
+  auto convOutDims = CQC.getResult().dims().vec();
+  convOutDims[3] = outCperG;
+
+  auto filterDims = filter->dims().vec();
+  filterDims[0] = outCperG;
+  filterDims[3] = inCperG;
+
+  // Final output type of each convolution after rescaling
+  auto finalConvOutTy = F->getParent()->uniqueTypeWithNewShape(
+      CQC.getResult().getType(), convOutDims);
+
+  auto scalesHandle = scales->getHandle<float>();
+  auto offsetsHandle = offsets->getHandle<int32_t>();
+
+  Module *M = F->getParent();
+
+  std::vector<NodeValue> branches;
+  for (unsigned_t groupId = 0; groupId < group; groupId++) {
+    float filterScale = scalesHandle.raw(groupId);
+    int32_t filterOffset = offsetsHandle.raw(groupId);
+
+    SliceNode *inSlice =
+        F->createSlice(CQC.getName(), in, {0, 0, 0, groupId * inCperG},
+                       {idim.n, idim.h, idim.w, (groupId + 1) * inCperG});
+
+    // Create quantized filter sliced Constant.
+    Tensor slicedFilterTensor = filter->getPayload().getOwnedSlice(
+        filterDims, {outCperG * groupId, 0, 0, 0});
+    auto quantizedFilterType = slicedFilterTensor.getType();
+    quantizedFilterType.scale_ = filterScale;
+    quantizedFilterType.offset_ = filterOffset;
+    slicedFilterTensor.setType(&quantizedFilterType);
+    Constant *slicedFilterConst =
+        M->createConstant(strFormat("%s_filter", CQC.getName().data()),
+                          std::move(slicedFilterTensor));
+
+    // Create bias sliced Constant. Bias's scale should always be inputScale *
+    // filterScale.
+    TensorQuantizationParams tqp;
+    tqp.offset = 0;
+    tqp.scale = inSlice->getInput().getType()->getScale() * filterScale;
+    Tensor slicedBiasTensor =
+        bias->getPayload().getOwnedSlice({outCperG}, {outCperG * groupId});
+    Tensor quantizedSlicedBiasTensor =
+        quantization::quantizeTensor(slicedBiasTensor, tqp, ElemKind::Int32QTy);
+    Constant *slicedBias =
+        M->createConstant(CQC.getName(), std::move(quantizedSlicedBiasTensor));
+
+    ConvolutionNode *convNode = F->createConv(
+        strFormat("%s_bias", CQC.getName().data()), inSlice, slicedFilterConst,
+        slicedBias, finalConvOutTy, kernels, strides, pads,
+        /* group */ 1);
+    branches.push_back(convNode);
+  }
+  auto *result = F->createConcat(CQC.getName(), branches, /* dimension */ 3);
+  replaceAllUsesOfWith(cctx.loweredInfoMap, CQC.getResult(), result);
+}
+
 static void lowerSigmoidCrossEntropyWithLogitsNode(
     Function *F, CompilationContext &cctx,
     const SigmoidCrossEntropyWithLogitsNode &SCEL) {
@@ -911,6 +999,8 @@ static void lowerNode(Function *F, Node *node, CompilationContext &cctx) {
   } else if (auto *CN = dyn_cast<ConvolutionNode>(node)) {
     if (CN->getGroup() > 1)
       lowerGroupConvolutionNode(F, cctx, *CN);
+  } else if (auto *CQC = dyn_cast<ChannelwiseQuantizedConvolutionNode>(node)) {
+    lowerChannelwiseQuantizedConvolutionNode(F, cctx, *CQC);
   } else if (auto *TN = dyn_cast<TileNode>(node)) {
     lowerTileNode(F, cctx, *TN);
   } else if (auto *CSN = dyn_cast<ChannelShuffleNode>(node)) {

--- a/tests/unittests/GraphTest.cpp
+++ b/tests/unittests/GraphTest.cpp
@@ -158,6 +158,84 @@ TEST(Graph, simpleTestConvCustomLower) {
   llvm::sys::fs::remove(filePath);
 }
 
+/// Test lowering groupwise quantized convolution expressed using
+/// ChannelwiseQuantizedConvNode to multiple regular quantized convolutions.
+TEST(Graph, ConvChannelwiseQuantizedLower) {
+  Module M;
+  Function *F = M.createFunction("F");
+
+  constexpr size_t groups = 2;
+  constexpr size_t depth = 4;
+  constexpr size_t inputChannels = 4;
+
+  // Expect NHWC.
+  Node *inputPH = M.createPlaceholder(
+      ElemKind::Int8QTy, {1, 10, 10, inputChannels}, /* scale */ 1.0,
+      /* offset */ 0, "input", true);
+
+  Tensor filterTensor(ElemKind::Int8QTy, {depth, 1, 1, inputChannels / groups},
+                      /* scale */ 1.0,
+                      /* offset */ 0);
+  filterTensor.init(Tensor::InitKind::Broadcast, 1, M.getPRNG());
+  Constant *filter = M.createConstant("filter", filterTensor);
+
+  Tensor biasTensor(ElemKind::FloatTy, {depth});
+  biasTensor.init(Tensor::InitKind::Broadcast, 2, M.getPRNG());
+  Constant *bias = M.createConstant("bias", biasTensor);
+
+  Tensor scalesTensor(ElemKind::FloatTy, {groups});
+  scalesTensor.getHandle<float>().raw(0) = 1.0;
+  scalesTensor.getHandle<float>().raw(1) = 3.0;
+  Constant *scales = M.createConstant("scales", scalesTensor);
+
+  Tensor offsetsTensor(ElemKind::Int32ITy, {groups});
+  offsetsTensor.getHandle<int32_t>().raw(0) = 2;
+  offsetsTensor.getHandle<int32_t>().raw(1) = 4;
+  Constant *offsets = M.createConstant("offsets", offsetsTensor);
+
+  auto *outQTy = M.uniqueType(glow::ElemKind::Int8QTy, {1, 10, 10, depth},
+                              /* scale */ 1.5, /* offset */ 6);
+
+  auto *channelwiseQuantizedConvNode = F->createChannelwiseQuantizedConv(
+      "channelwise_qconv", inputPH, filter, bias, scales, offsets, outQTy,
+      /* kernels */ {1, 1},
+      /* strides */ {1, 1},
+      /* pads */ {0, 0, 0, 0},
+      /* group */ groups);
+
+  SaveNode *saveNode = F->createSave("save", channelwiseQuantizedConvNode);
+
+  auto backend = MockBackend();
+  CompilationContext cctx;
+  lower(F, cctx, &backend);
+
+  // Now verify the lowered graph.
+
+  auto concatNode = llvm::dyn_cast<ConcatNode>(saveNode->getInput().getNode());
+  ASSERT_TRUE(concatNode != nullptr);
+
+  auto concatInputs = concatNode->getInputs();
+  EXPECT_EQ(concatInputs.size(), groups) << "Should have one conv per group";
+
+  for (size_t i = 0; i < concatInputs.size(); ++i) {
+    auto convNode = llvm::dyn_cast<ConvolutionNode>(concatInputs[i].getNode());
+    ASSERT_TRUE(concatNode != nullptr);
+    // Check that each conv has the expected filter qparams.
+    auto *filterTy = convNode->getFilter().getType();
+    ASSERT_TRUE(filterTy != nullptr);
+    EXPECT_TRUE(filterTy->isQuantizedType());
+    EXPECT_EQ(filterTy->getScale(), float(1 + 2 * i));
+    EXPECT_EQ(filterTy->getOffset(), 2 + 2 * i);
+
+    // Check that each conv has the expected output qparams.
+    auto *outTy = convNode->getType(ConvolutionNode::ResultIdx);
+    ASSERT_TRUE(outTy != nullptr);
+    EXPECT_TRUE(outTy->isQuantizedType());
+    EXPECT_EQ(outTy->getScale(), 1.5);
+    EXPECT_EQ(outTy->getOffset(), 6);
+  }
+}
+
 /// Check that we can create convolution with float16.
 TEST(Graph, float16Conv) {
   Module MD;

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -90,6 +90,22 @@ int main(int argc, char **argv) {
       .autoVerify(VerifyKind::SameElementType, {"Dest", "Src", "Filter"})
       .addGradientInstr({"Src", "Filter"}, {"Dest", "Src", "Filter", "Bias"});
 
+  BB.newInstr("ChannelwiseQuantizedConvolution")
+      .addOperand("Dest", OperandKind::Out)
+      .addOperand("Src", OperandKind::In)
+      .addOperand("Filter", OperandKind::In)
+      .addOperand("Bias", OperandKind::In)
+      .addOperand("Scales", OperandKind::In)
+      .addOperand("Offsets", OperandKind::In)
+      .addMember(MemberType::VectorUnsigned, "Kernels")
+      .addMember(MemberType::VectorUnsigned, "Strides")
+      .addMember(MemberType::VectorUnsigned, "Pads")
+      .addMember(MemberType::Unsigned, "Group")
+      .addMember(MemberType::Boolean, "Groupwise")
+      .autoIRGen()
+      .autoVerify(VerifyKind::SameElementType,
+                  {"Dest", "Src", "Filter", "ElemKind::Int8QTy"});
+
   BB.newInstr("Convolution3D")
       .addOperand("Dest", OperandKind::Out)
       .addOperand("Src", OperandKind::In)


### PR DESCRIPTION
Summary:
* Create an interpreter implementation for ChannelwiseQuantizedConvolutionNode
* Add a lowering pass that converts ChannelwiseQuantizedConvolutionNode to a concatination of regular quantized convolutions

Differential Revision: D15838460

