### PR TITLE
Use partial unpadded tensors when supported by backend

### DIFF
--- a/include/glow/Backend/Backend.h
+++ b/include/glow/Backend/Backend.h
@@ -98,6 +98,10 @@ public:
   /// performed.
   virtual bool shouldShareBuffers() const { return true; }
 
+  /// \returns true if the Backend supports partial, unpadded tensors for
+  /// inputs that can have variable size (e.g., embedding indices).
+  virtual bool supportsPartialTensors() const { return false; }
+
   /// \returns true if Backend generated Instruction for Node \p N,
   /// using IRGenVisitor \p irgen.
   virtual bool generateInst(Node *N, IRGenVisitor &irgen) const {

--- a/lib/Backends/Habana/Habana.h
+++ b/lib/Backends/Habana/Habana.h
@@ -179,6 +179,8 @@ public:
                              CompilationContext &cctx) const override;
 
   bool shouldShareBuffers() const override { return false; }
+
+  bool supportsPartialTensors() const override { return true; }
   /// @}
 
   static bool isVersionBiggerEqualTo(std::string versionToCompare);
@@ -247,6 +249,7 @@ private:
   std::string recipeName_;
   PlaceholderList inputs_;
   PlaceholderList outputs_;
+  std::unordered_set<const Placeholder *> partialInputs_;
 };
 
 } // namespace glow

--- a/lib/Onnxifi/Base.h
+++ b/lib/Onnxifi/Base.h
@@ -58,6 +58,9 @@ public:
   /// \returns the whether use onnx or not.
   bool getUseOnnx() const { return useOnnx_; }
 
+  /// \returns a reference to the backend.
+  const glow::Backend &getBackend() const { return *glowBackend_; }
+
   virtual void runNetwork(const Graph *graph,
                           std::unique_ptr<ExecutionContext> context,
                           runtime::ResultCBTy callback) {}


### PR DESCRIPTION
Summary:
This is take 2 on partial tensor support.  There are two components:

1. The backend needs to declare its support for partial tensors.  Since the
backend may have to do padding in some cases, partiality needs to be opt-in.

2. The Habana backend is our proof-of-concept here; it needs to check the types
of consuming operators to determine which are candidates for partial transfers.
Currently, only the indices and weights of SparseLengths(Weighted)Sum are
candidates.

Differential Revision: D15889467

