### PR TITLE
[compilationLog]: Refine the locations of LOG_SCOPE

### DIFF
--- a/lib/Backends/CPU/Transforms.cpp
+++ b/lib/Backends/CPU/Transforms.cpp
@@ -121,10 +121,10 @@ static Node *optimizeCPUMaxSplat(MaxNode *MN, Function *F) {
 
 bool CPUBackend::transformPostLowering(Function *F,
                                        CompilationContext &) const {
-  LOG_SCOPE(F->getLogContext(), "CPUBackend::transformPostLowering")
-
   bool changed = false;
   for (auto &node : F->getNodes()) {
+    LOG_SCOPE(F->getLogContext(), "CPUBackend::transformPostLowering")
+
     // Try to replace generic convolution with cpu-optimized version.
     if (auto *CN = dyn_cast<ConvolutionNode>(&node)) {
       if (Node *NCN = optimizeCPUConv(CN, F)) {

--- a/lib/Backends/Habana/Habana.cpp
+++ b/lib/Backends/Habana/Habana.cpp
@@ -1565,10 +1565,10 @@ bool surroundTileWithReshapes(Function *F, TileNode &tile) {
 
 bool HabanaBackend::transformPostLowering(Function *F,
                                           CompilationContext &cctx) const {
-  LOG_SCOPE(F->getLogContext(), "HabanaBackend::transformPostLowering")
-
   bool changed = false;
   for (auto &node : F->getNodes()) {
+    LOG_SCOPE(F->getLogContext(), "HabanaBackend::transformPostLowering")
+
     // Separate any Slice nodes into several that only slice in one dimension
     // at a time.
     if (auto *slice = llvm::dyn_cast<SliceNode>(&node)) {

--- a/lib/Backends/OpenCL/Transforms.cpp
+++ b/lib/Backends/OpenCL/Transforms.cpp
@@ -31,13 +31,13 @@ bool OCLBackend::transformPostLowering(Function *F,
   // NCHW transformation is not supported in training mode yet, because of some
   // issues with gradient nodes.
 
-  LOG_SCOPE(F->getLogContext(), "OCLBackend::transformPostLowering")
-
   if (cctx.compMode == CompilationMode::Train)
     return false;
 
   bool changed = false;
   for (auto &node : F->getNodes()) {
+    LOG_SCOPE(F->getLogContext(), "OCLBackend::transformPostLowering")
+
     if (auto *CN = dyn_cast<ConvolutionNode>(&node)) {
       // TODO: OpenCL fast convolution kernel itself has some issue with group >
       // 1, which will be investigated later. So far, if the group > 1, we just


### PR DESCRIPTION
Summary:
Refine the locations of LOG_SCOPE inside each optimize function.

- Previously, we log the scope at the beginning of each optimization function. But there are multiple iterations (iterate over all nodes) of this optimization going inside one scope, which makes the produced log not entirely showing the changes inside one iteration.
- I propose to move LOG_SCOPE into each iteration of every optimization, such that the produced scoped log blocks are in a finer granularity.

Test Plan:
test with ./bin/image-classifier tests/images/imagenet/cat_285.png -image-mode=0to1 -m=googlenet_v1_slim/googlenet_v1_slim.onnx -model-input-name=input:0 -image-layout=NHWC -backend=CPU -dump-compilation-log=true

The output log of optimizeReshape is shown below:
Before refining:
![Screen Shot 2019-06-18 at 7 25 35 PM](https://user-images.githubusercontent.com/8838608/59732393-e4ed7a00-91fe-11e9-9782-60a6d3534ac1.png)
After refining:
![Screen Shot 2019-06-18 at 6 59 00 PM](https://user-images.githubusercontent.com/8838608/59732398-eae35b00-91fe-11e9-93c8-29755d8adbde.png)

We can see that the scope of optimizeReshape break into small chunks now.
