### PR TITLE
Reduce PCI transfers of partial transfers

### DIFF
--- a/include/glow/Backend/Backend.h
+++ b/include/glow/Backend/Backend.h
@@ -98,6 +98,10 @@ public:
   /// performed.
   virtual bool shouldShareBuffers() const { return true; }
 
+  /// \returns true if the Backend supports partial, unpadded tensors for
+  /// inputs that can have variable size (e.g., embedding indices).
+  virtual bool supportsPartialTensors() const { return false; }
+
   /// \returns true if Backend generated Instruction for Node \p N,
   /// using IRGenVisitor \p irgen.
   virtual bool generateInst(Node *N, IRGenVisitor &irgen) const {

--- a/lib/Backends/Habana/Habana.h
+++ b/lib/Backends/Habana/Habana.h
@@ -179,6 +179,8 @@ public:
                              CompilationContext &cctx) const override;
 
   bool shouldShareBuffers() const override { return false; }
+
+  bool supportsPartialTensors() const override { return true; }
   /// @}
 
   static bool isVersionBiggerEqualTo(std::string versionToCompare);
@@ -247,6 +249,7 @@ private:
   std::string recipeName_;
   PlaceholderList inputs_;
   PlaceholderList outputs_;
+  std::unordered_set<const Placeholder *> partialInputs_;
 };
 
 } // namespace glow

--- a/lib/Backends/Habana/HabanaDeviceManager.cpp
+++ b/lib/Backends/Habana/HabanaDeviceManager.cpp
@@ -86,6 +86,10 @@ llvm::Error HabanaDeviceManager::init() {
   // Synapse API.
   if (numActiveDevices_ == 0) {
     LOG(INFO) << "Using version " << synGetVersion();
+    // This environment variable tells Synapse to allow enqueueing tensors that
+    // are smaller than the declared size, which offers a significant savings
+    // in PCI traffic for embedding lookups.
+    setenv("IGNORE_ENQUEUE_SIZE_VALIDATION", "1", /*overwrite*/ 1);
     chk(synInitialize());
   }
 

--- a/lib/Onnxifi/Base.h
+++ b/lib/Onnxifi/Base.h
@@ -58,6 +58,9 @@ public:
   /// \returns the whether use onnx or not.
   bool getUseOnnx() const { return useOnnx_; }
 
+  /// \returns a reference to the backend.
+  const glow::Backend &getBackend() const { return *glowBackend_; }
+
   virtual void runNetwork(const Graph *graph,
                           std::unique_ptr<ExecutionContext> context,
                           runtime::ResultCBTy callback) {}


### PR DESCRIPTION
Summary:
Synapse 0.1.9 has a secret feature to allow enqueues of partial
tensors.  Let's take advantage of this for embedding indices/weights.

Reviewed By: rdzhabarov

Differential Revision: D15895782

