### PR TITLE
[OpenCL] Add TraceEvent for compiling custom convolution kernels

### DIFF
--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -197,7 +197,8 @@ OpenCLFunction::createProgram(const std::string &source,
   if (program) {
     return program;
   }
-  // Create a new compiled program.
+  // Create a new compiled program. This will also add the program to the cache
+  // because 'program' is a reference to an existing cache item.
   program = clCreateProgramWithSource(ctx, 1, &src, nullptr, &err);
   CHECK(program) << "clCreateProgramWithSource Failed.";
   err = clBuildProgram(program, 0, nullptr, combinedOptions.c_str(), nullptr,
@@ -206,7 +207,7 @@ OpenCLFunction::createProgram(const std::string &source,
     dumpCompileLog(deviceId, program);
   }
   CHECK_EQ(err, CL_SUCCESS) << "clBuildProgram Failed.";
-  // Add this program to the program cache.
+
   return program;
 }
 
@@ -343,7 +344,8 @@ void OpenCLFunction::enqueueKernel(llvm::StringRef name,
   kernelLaunches.push_back(KernelLaunch(kernel, name, kernelType, event));
 }
 
-void OpenCLFunction::executeConvolution(const OCLConvolutionInst *CC) {
+void OpenCLFunction::executeConvolution(const OCLConvolutionInst *CC,
+                                        ExecutionContext *executionContext) {
   auto input = CC->getSrc();
   auto output = CC->getDest();
   auto bias = CC->getBias();
@@ -457,7 +459,10 @@ void OpenCLFunction::executeConvolution(const OCLConvolutionInst *CC) {
     src.append(reinterpret_cast<const char *>(kernels_fwd_conv_cl_src),
                kernels_fwd_conv_cl_src_size);
   }
+  TRACE_EVENT_BEGIN(executionContext, "convCreateProgram");
   auto prog = createProgram(src, options, commands_);
+  TRACE_EVENT_END(executionContext, "convCreateProgram");
+
   auto kernelName = isQuantized ? "conv_forward_mem_i8" : "conv_forward_mem";
   auto kernel = createKernel(kernelName, prog);
   setKernelArg(kernel, 0, deviceBuffer_);
@@ -543,8 +548,6 @@ static void topK(Tensor &outW, Tensor &indW, Tensor &inW, size_t k) {
 }
 
 llvm::Error OpenCLFunction::execute(ExecutionContext *context) {
-  (void)context;
-
   auto clBindings = static_cast<runtime::OpenCLDeviceBindings *>(
       context->getDeviceBindings());
 
@@ -1019,7 +1022,7 @@ llvm::Error OpenCLFunction::execute(ExecutionContext *context) {
     }
 
     if (auto *CC = dyn_cast<OCLConvolutionInst>(&I)) {
-      executeConvolution(CC);
+      executeConvolution(CC, context);
       continue;
     }
 

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -146,7 +146,8 @@ private:
                   ElemKind elemKind);
 
   /// Execution a convolution instruction which uses NCHW format.
-  void executeConvolution(const OCLConvolutionInst *CC);
+  void executeConvolution(const OCLConvolutionInst *CC,
+                          ExecutionContext *executionContext);
   /// Allocate a device buffer of required \p size.
   cl_mem allocDeviceBuffer(uint64_t size);
   /// Frees a device buffer.


### PR DESCRIPTION
**Description**
This commit adds a TraceEvent that covers the time spent during
OpenCLFunction::execute() on compiling custom versions of
convolution kernels according to the parameters of the particular
convolutions present in the function. Depending on the OpenCL
implementation, this time can manifest as mysterious large gaps in the trace file.

**Test Plan**
Generated traces for `tracing-compare` example with AMD OpenCL.

Without this PR:
![Screen Shot 2019-06-19 at 3 27 16 PM](https://user-images.githubusercontent.com/4392003/59805729-f1c5a880-92a6-11e9-9212-c4050302234d.png)

With this PR:
![Screen Shot 2019-06-19 at 3 21 26 PM](https://user-images.githubusercontent.com/4392003/59805740-f8542000-92a6-11e9-91e6-f17290622763.png)
