### PR TITLE
General Constant Folding for Onnx and Caffe2 Operators in Loader

### DIFF
--- a/include/glow/Importer/Caffe2ModelLoader.h
+++ b/include/glow/Importer/Caffe2ModelLoader.h
@@ -60,6 +60,9 @@ class Caffe2ModelLoader
   /// in the network.
   llvm::Error loadOperator(const caffe2::OperatorDef &op);
 
+  /// \returns True if the operator \p op is successfully folded.
+  llvm::Expected<bool> foldOperator(const caffe2::OperatorDef &op);
+
   /// Load the Conv or ConvRelu operators.
   llvm::Error loadConv(const caffe2::OperatorDef &op,
                        ArgumentDictionaryTy &dict);
@@ -106,6 +109,13 @@ class Caffe2ModelLoader
                     llvm::Error *errPtr = nullptr);
 
   friend class ONNXIFIModelLoader;
+
+  /// \returns success if the folding of operator \p op in the loader
+  /// \p loader is successful. The folding utility uses temporary
+  /// loader \p tmpLoader, and associated temporary function \p F.
+  template <class LoaderType, class OpType>
+  friend llvm::Error constantFoldInLoader(Function *F, LoaderType &tmpLoader,
+                                          LoaderType *loader, const OpType &op);
 
 public:
   /// Loads the caffe2 model that's represented by a network description file,

--- a/include/glow/Importer/ONNXModelLoader.h
+++ b/include/glow/Importer/ONNXModelLoader.h
@@ -56,6 +56,9 @@ class ONNXModelLoader
   /// in the network. \returns Error if operator \p op cannot be loaded.
   llvm::Error loadOperator(const ONNX_NAMESPACE::NodeProto &op);
 
+  /// \returns True if the operator\ op is successfully folded.
+  llvm::Expected<bool> foldOperator(const ONNX_NAMESPACE::NodeProto &op);
+
   /// ONNX model ir_version;
   size_t irVersion_;
 
@@ -194,6 +197,13 @@ protected:
                   bool loadInputsAsPlaceholders, llvm::Error *errPtr = nullptr);
 
   friend class ONNXIFIModelLoader;
+
+  /// \returns success if the folding of operator \p op in the loader
+  /// \p loader is successful. The folding utility uses temporary
+  /// loader \p tmpLoader, and associated temporary function \p F.
+  template <class LoaderType, class OpType>
+  friend llvm::Error constantFoldInLoader(Function *F, LoaderType &tmpLoader,
+                                          LoaderType *loader, const OpType &op);
 
 public:
   /// Creates a ONNX model loader to build \p F.

--- a/include/glow/Support/Error.h
+++ b/include/glow/Support/Error.h
@@ -204,6 +204,20 @@ private:
     }                                                                          \
   } while (0)
 
+/// Takes an llvm::Expected<T> \p lhsOrErr and if it is an Error then returns
+/// false, otherwise takes the value from lhsOrErr and assigns it to \p rhs.
+#define ASSIGN_VALUE_OR_RETURN_FALSE(rhs, lhsOrErr)                            \
+  do {                                                                         \
+    auto lhsOrErrV = (lhsOrErr);                                               \
+    static_assert(IsLLVMExpected<decltype(lhsOrErrV)>(),                       \
+                  "Expected value to be a llvm::Expected");                    \
+    if (lhsOrErrV) {                                                           \
+      rhs = std::move(lhsOrErrV.get());                                        \
+    } else {                                                                   \
+      return false;                                                            \
+    }                                                                          \
+  } while (0)
+
 /// Takes an llvm::Error and returns it if it's not success.
 // TODO: extend this to work with llvm::Expected as well.
 #define RETURN_IF_ERR(err)                                                     \

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -1152,6 +1152,34 @@ llvm::Error ONNXModelLoader::loadTile(const ONNX_NAMESPACE::NodeProto &op,
   return llvm::Error::success();
 }
 
+llvm::Expected<bool>
+ONNXModelLoader::foldOperator(const ONNX_NAMESPACE::NodeProto &op) {
+  const unsigned numInputs = op.input_size();
+  const std::string &typeName = op.op_type();
+  llvm::SmallVector<NodeValue, 4> inputs;
+  inputs.reserve(numInputs);
+  for (unsigned i = 0; i < numInputs; i++) {
+    NodeValue in;
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(i)));
+    inputs.push_back(in);
+  }
+
+  if (!isConstantFoldable(inputs, typeName)) {
+    return false;
+  }
+
+  // Create a temporary lightweight loader to construct function representing
+  // current Op, and then constant fold the function using Interp backend.
+  Function *tmpF = G_.getParent()->createFunction("eval_const_fold__");
+  ONNXModelLoader tmpLoader(*tmpF);
+  tmpLoader.opsetVersion_ = opsetVersion_;
+  bool foldStatus = !errToBool(
+      constantFoldInLoader<ONNXModelLoader, ONNX_NAMESPACE::NodeProto>(
+          tmpF, tmpLoader, this, op));
+  G_.getParent()->eraseFunction(tmpF);
+  return foldStatus;
+}
+
 llvm::Error ONNXModelLoader::loadOperator(const ONNX_NAMESPACE::NodeProto &op) {
   ArgumentDictionaryTy dict = loadArgumentMap(op);
   const std::string &typeName = op.op_type();
@@ -1256,6 +1284,13 @@ llvm::Error ONNXModelLoader::loadNetwork(ONNX_NAMESPACE::GraphProto &net) {
   /// Load the network operators:
   for (int i = 0; i < net.node_size(); i++) {
     auto &op = net.node(i);
+    if (getConstantFoldLoaderOpsFlag()) {
+      auto foldstatus = foldOperator(op);
+      if (foldstatus && foldstatus.get()) {
+        // Folded successfully.
+        continue;
+      }
+    }
     RETURN_IF_ERR(loadOperator(op));
   }
 

--- a/lib/Importer/ProtobufLoader.cpp
+++ b/lib/Importer/ProtobufLoader.cpp
@@ -15,16 +15,52 @@
  */
 
 #include "glow/Importer/ProtobufLoader.h"
-
+#include "llvm/Support/CommandLine.h"
 #include <string>
 
 namespace glow {
+
+llvm::cl::OptionCategory loaderOptCat("Model Loader Options");
+
+static llvm::cl::opt<bool> isConstFoldLoaderOps(
+    "const-fold-ops",
+    llvm::cl::desc(
+        "Performs constant folding on ONNX and Caffe Operators while loading."),
+    llvm::cl::init(false), llvm::cl::cat(loaderOptCat));
 
 bool isArrayConstant(llvm::ArrayRef<size_t> a) {
   for (size_t i = 1; i < a.size(); i++)
     if (a[0] != a[i])
       return false;
   return true;
+}
+
+void setConstantFoldLoaderOpsFlag(bool flag) { isConstFoldLoaderOps = flag; }
+
+bool getConstantFoldLoaderOpsFlag() { return isConstFoldLoaderOps; }
+
+bool ProtobufLoader::isConstantFoldable(llvm::ArrayRef<NodeValue> inputs,
+                                        std::string typeName) const {
+  int numInputs = inputs.size();
+  if (!getConstantFoldLoaderOpsFlag()) {
+    return false;
+  }
+  // foldUnsupportedTypes: List of typenames unsupported for folding.
+  std::string foldUnsupportedTypes[] = {"Constant"};
+  std::string *foo = std::find(std::begin(foldUnsupportedTypes),
+                               std::end(foldUnsupportedTypes), typeName);
+  // Early exit if folding is not supported for current operator.
+  if (foo != std::end(foldUnsupportedTypes)) {
+    return false;
+  }
+
+  // If all the inputs to the operator are constant this op can be folded.
+  bool isConstFoldCandidate = true;
+  for (int i = 0; (i < numInputs) && isConstFoldCandidate; i++) {
+    isConstFoldCandidate =
+        (inputs[i].getNode()->getKind() == Kinded::Kind::ConstantKind);
+  }
+  return isConstFoldCandidate;
 }
 
 Constant *ProtobufLoader::getConstantByNameOrNull(llvm::StringRef name) const {

--- a/lib/Optimizer/GraphOptimizer/Lower.cpp
+++ b/lib/Optimizer/GraphOptimizer/Lower.cpp
@@ -1038,6 +1038,7 @@ static void lowerNode(Function *F, Node *node, CompilationContext &cctx) {
 void glow::lower(Function *F, CompilationContext &cctx, const Backend *B,
                  const KindSet &doNotLowerKinds) {
   LOG_SCOPE(F->getLogContext(), "glow::lower")
+  F->setState(FunctionState::FuncLoaded);
 
   auto &nodes = F->getNodes();
   for (auto &N : nodes) {

--- a/tests/models/caffe2Models/gather_const_fold.pbtxt
+++ b/tests/models/caffe2Models/gather_const_fold.pbtxt
@@ -1,0 +1,24 @@
+name: "gatherConstantFolding"
+op {
+  input: "data"
+  output: "shape_x"
+  name: "shape_x"
+  type: "Shape"
+}
+op {
+  input: "shape_x"
+  input: "index"
+  output: "gather_x"
+  name: "gather_x"
+  type: "Gather"
+}
+op {
+  input: "data"
+  input: "gather_x"
+  output: "result"
+  name: "result"
+  type: "Reshape"
+}
+external_input: "data"
+external_input: "index"
+external_output: "result"

--- a/tests/models/caffe2Models/gather_const_fold_init.pbtxt
+++ b/tests/models/caffe2Models/gather_const_fold_init.pbtxt
@@ -1,0 +1,17 @@
+name: "init"
+op {
+  output: "index"
+  type: "GivenTensorIntFill"
+  arg {
+    name: "shape"
+    ints: 4
+  }
+  arg {
+    name: "values"
+    ints: 0
+    ints: 2
+    ints: 3
+    ints: 1
+  }
+}
+

--- a/tests/models/onnxModels/batchBoxCox.onnxtxt
+++ b/tests/models/onnxModels/batchBoxCox.onnxtxt
@@ -10,7 +10,7 @@ graph {
   }
   name: "test_batchBoxCox"
   input {
-    name: "x"
+    name: "data"
     type {
       tensor_type {
         elem_type: 1

--- a/tests/models/onnxModels/gatherConstantFolding.onnxtxt
+++ b/tests/models/onnxModels/gatherConstantFolding.onnxtxt
@@ -1,0 +1,92 @@
+ir_version: 5
+producer_name: "onnx-example"
+graph {
+  node {
+    input: "input"
+    output: "shape_x"
+    op_type: "Shape"
+  }
+  node {
+    output: "indices"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 4
+        data_type: 7
+        int64_data: 0
+        int64_data: 2
+        int64_data: 3
+        int64_data: 1
+        name: "const_tensor"
+      }
+      type: TENSOR
+    }
+  }
+  node {
+    input: "shape_x"
+    input: "indices"
+    output: "gather"
+    op_type: "Gather"
+    attribute {
+      name: "axis"
+      i: 0
+      type: INT
+    }
+  }
+  node {
+    input: "input"
+    input: "gather"
+    output: "result"
+    op_type: "Reshape"
+  }
+  name: "test-model"
+  input {
+    name: "input"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "result"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 10
+}
+

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -19,6 +19,7 @@
 #include "glow/Graph/Nodes.h"
 #include "glow/Graph/PlaceholderBindings.h"
 #include "glow/Importer/ONNXModelLoader.h"
+#include "llvm/Support/FileSystem.h"
 #include "gtest/gtest.h"
 
 #ifndef GLOW_DATA_PATH
@@ -26,6 +27,143 @@
 #endif
 
 using namespace glow;
+
+#include <fstream>
+using namespace std;
+
+/// Loads onnxtxt model file \p filename and \returns ModelProto object.
+llvm::Expected<ONNX_NAMESPACE::ModelProto>
+loadProto(const std::string &filename) {
+  std::ifstream ff(filename, std::ios::in | std::ios::binary);
+  RETURN_ERR_IF_NOT(ff, "Can't find the model or network files.",
+                    GlowErr::ErrorCode::MODEL_LOADER_INVALID_PROTOBUF);
+  if (filename.find(".onnxtxt") != std::string::npos) {
+    std::string str((std::istreambuf_iterator<char>(ff)),
+                    std::istreambuf_iterator<char>());
+    ONNX_NAMESPACE::ModelProto MP;
+    bool parseNet = google::protobuf::TextFormat::ParseFromString(str, &MP);
+    RETURN_ERR_IF_NOT(parseNet, "Failed to parse ModelProto",
+                      GlowErr::ErrorCode::MODEL_LOADER_INVALID_PROTOBUF);
+    return MP;
+  }
+  RETURN_ERR("Can't load proto file");
+}
+
+/// Saves ModelProto object \p model as onnxtxt model file \p filename
+/// and \returns true if successful.
+llvm::Expected<bool> saveProto(const std::string &filename,
+                               ONNX_NAMESPACE::ModelProto &model) {
+  std::ofstream ff(filename, std::ios::out);
+  RETURN_ERR_IF_NOT(ff, "Can't write the proto file.",
+                    GlowErr::ErrorCode::RUNTIME_ERROR);
+  if (filename.find(".onnxtxt") != std::string::npos) {
+    std::string onnx_message = model.DebugString();
+    ff << onnx_message;
+    ff.close();
+    return true;
+  }
+  ff.close();
+  return false;
+}
+
+/// Replaces placeholders with names \p tensorNames in model proto object \p
+/// model with initializers of same  name and values specified in input tensor
+/// array \p tensors and \returns true if successful.
+llvm::Expected<bool>
+replacePlaceholderWithConstant(ONNX_NAMESPACE::ModelProto &model,
+                               llvm::ArrayRef<const char *> tensorNames,
+                               llvm::ArrayRef<Tensor *> tensors) {
+  ONNX_NAMESPACE::NodeProto np;
+  ONNX_NAMESPACE::GraphProto *gp = model.mutable_graph();
+  RETURN_ERR_IF_NOT(gp, "Can't get mutable graph.",
+                    GlowErr::ErrorCode::RUNTIME_ERROR);
+  for (size_t i = 0; i < tensorNames.size(); i++) {
+    for (int j = 0; j < gp->input_size(); j++) {
+      ONNX_NAMESPACE::ValueInfoProto *valueInfo = gp->mutable_input(j);
+      const std::string &inputName = valueInfo->name();
+      if (inputName != tensorNames[i]) {
+        continue;
+      }
+      std::string newName = "dummy_input" + std::to_string(i);
+      valueInfo->set_name(newName);
+      auto RH = tensors[i]->getHandle<>();
+      ONNX_NAMESPACE::TensorProto *tp = gp->add_initializer();
+      tp->set_name(tensorNames[i]);
+      for (int k = 0; k < tensors[i]->dims().size(); k++) {
+        tp->add_dims(tensors[i]->dims()[k]);
+      }
+      switch (RH.getElementType()) {
+      case ElemKind::FloatTy:
+        tp->set_data_type(ONNX_NAMESPACE::TensorProto::FLOAT);
+        for (int k = 0; k < tensors[i]->size(); k++) {
+          tp->add_float_data(RH.raw(k));
+        }
+        break;
+      case ElemKind::Int64ITy:
+        tp->set_data_type(ONNX_NAMESPACE::TensorProto::INT64);
+        for (int k = 0; k < tensors[i]->size(); k++) {
+          tp->add_int64_data(RH.raw(k));
+        }
+        break;
+      case ElemKind::Int32ITy:
+        tp->set_data_type(ONNX_NAMESPACE::TensorProto::INT32);
+        for (int k = 0; k < tensors[i]->size(); k++) {
+          tp->add_int32_data(RH.raw(k));
+        }
+        break;
+      default:
+        std::cout << "Unsupported datatype";
+        return false;
+      }
+    }
+  }
+  gp->clear_input();
+  return true;
+}
+
+/// Performs constant folding test on the given model file \p NetFilename
+/// by replacing input tensors with name \p tensorNames, and values \p tensors
+/// and then checking against expected output expectedTensors. \returns true
+/// if the test completes without error.
+bool checkConstFoldedOutput(std::string NetFilename,
+                            llvm::ArrayRef<const char *> tensorNames,
+                            llvm::ArrayRef<Tensor *> tensors,
+                            llvm::ArrayRef<Tensor *> expectedTensors) {
+  ONNX_NAMESPACE::ModelProto modelDef;
+  llvm::SmallVector<char, 64> resultPath;
+  llvm::sys::fs::createTemporaryFile("dummy", "onnxtxt", resultPath);
+  std::string netFilename(resultPath.begin(), resultPath.end());
+
+  ASSIGN_VALUE_OR_RETURN_FALSE(modelDef, loadProto(NetFilename));
+  // Replace placeholders in the original onnx model with constants.
+  if (!replacePlaceholderWithConstant(modelDef, tensorNames, tensors))
+    return false;
+  if (!saveProto(netFilename, modelDef))
+    return false;
+  setConstantFoldLoaderOpsFlag(true);
+
+  // It is expected that loading will fold the whole graph and output
+  // nodes will become constants during the loading process.
+  ExecutionEngine EE;
+  Module &mod = EE.getModule();
+  Function *F = mod.createFunction("temp");
+  ONNXModelLoader onnxLD(netFilename, {}, {}, *F);
+  setConstantFoldLoaderOpsFlag(false);
+
+  // The folded output tensors are expected to be constants and should
+  // match the expectedTensors passed in.
+  for (int i = 0; i < modelDef.graph().output_size(); i++) {
+    NodeValue NV;
+    ASSIGN_VALUE_OR_RETURN_FALSE(
+        NV, onnxLD.getNodeValueByName(modelDef.graph().output(i).name()));
+    auto *constOut = llvm::dyn_cast<Constant>(NV.getNode());
+    if (!constOut) {
+      return false;
+    }
+    EXPECT_TRUE(expectedTensors[i]->isEqual(constOut->getPayload()));
+  }
+  return true;
+}
 
 template <class OpType>
 static void
@@ -43,16 +181,15 @@ importArithMultiBroadcastTest(std::string fileName,
   Placeholder *graphOutputVar;
   // Destroy the loader after the graph is loaded since the following execution
   // will not depend on anyting from the loader.
+  Tensor data;
+  getNCHWData(&data, inputShape[0], inputShape[1], inputShape[2],
+              inputShape[3]);
   {
-    Tensor data;
-    getNCHWData(&data, inputShape[0], inputShape[1], inputShape[2],
-                inputShape[3]);
     ONNXModelLoader onnxLD(NetFilename, {"data"}, {&data.getType()}, *F);
     graphOutputVar = EXIT_ON_ERR(onnxLD.getSingleOutput());
     bindings.allocate(mod.getPlaceholders());
     updateInputPlaceholdersByName(bindings, &mod, {"data"}, {&data});
   }
-
   // ONNX importer loads an arithmetic node and inserts:
   // - a Reshape node for each broadcasted operand
   // - a Tile node for each boardcasted dimension
@@ -112,6 +249,9 @@ importArithMultiBroadcastTest(std::string fileName,
   for (size_t i = 0; i < result.getType().size(); i++) {
     EXPECT_FLOAT_EQ(result.raw(i), expectedValues[i]);
   }
+  // Constant Folding Test.
+  EXPECT_TRUE(checkConstFoldedOutput(NetFilename, {"data"}, {&data},
+                                     {bindings.get(graphOutputVar)}));
 }
 
 /// Test loading LeakyRelu op from an ONNX model.
@@ -303,9 +443,9 @@ static void testImportPRelu(std::string filename,
   Placeholder *graphOutputVar;
   // Destroy the loader after the graph is loaded since the following execution
   // will not depend on anyting from the loader.
+  Tensor data(ElemKind::FloatTy, inputShape);
+  data.getHandle().randomize(-4.0, 4.0, mod.getPRNG());
   {
-    Tensor data(ElemKind::FloatTy, inputShape);
-    data.getHandle().randomize(-4.0, 4.0, mod.getPRNG());
     ONNXModelLoader onnxLoader(NetFileName, {"data"}, {&data.getType()}, *F);
     graphOutputVar = EXIT_ON_ERR(onnxLoader.getSingleOutput());
     bindings.allocate(mod.getPlaceholders());
@@ -326,6 +466,10 @@ static void testImportPRelu(std::string filename,
                         std::max<float>(0, dataH.raw(i));
     EXPECT_FLOAT_EQ(result.raw(i), expectedVal);
   }
+
+  // Constant Folding Test.
+  EXPECT_TRUE(checkConstFoldedOutput(NetFileName, {"data"}, {&data},
+                                     {bindings.get(graphOutputVar)}));
 }
 
 TEST(onnx, importPreluSlopeHasSameShape) {
@@ -492,9 +636,9 @@ static void averagePoolTestHelper(std::string &filename,
   Placeholder *graphOutputVar;
   // Destroy the loader after the graph is loaded since the following execution
   // will not depend on anyting from the loader.
+  Tensor data;
+  getNCHWData(&data, 1, 1, 3, 3);
   {
-    Tensor data;
-    getNCHWData(&data, 1, 1, 3, 3);
     ONNXModelLoader onnxLD(NetFilename, {"x"}, {&data.getType()}, *F);
     graphOutputVar = EXIT_ON_ERR(onnxLD.getSingleOutput());
     bindings.allocate(mod.getPlaceholders());
@@ -524,6 +668,10 @@ static void averagePoolTestHelper(std::string &filename,
   for (size_t i = 0, e = expectedValues.size(); i < e; i++) {
     EXPECT_FLOAT_EQ(result.raw(i), expectedValues[i]);
   }
+
+  // Constant Folding Test.
+  EXPECT_TRUE(checkConstFoldedOutput(NetFilename, {"x"}, {&data},
+                                     {bindings.get(graphOutputVar)}));
 }
 
 /// Test loading AveragePool op from a ONNX model.
@@ -585,10 +733,9 @@ TEST(onnx, reduceMean4Dto3D) {
 
   PlaceholderBindings bindings;
   Placeholder *output;
+  Tensor x(ElemKind::FloatTy, {2, 2, 2, 2});
+  x.getHandle() = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
   {
-    Tensor x(ElemKind::FloatTy, {2, 2, 2, 2});
-    x.getHandle() = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
-
     ONNXModelLoader onnxLD(netFilename, {"x"}, {&x.getType()}, *F);
     output = EXIT_ON_ERR(onnxLD.getSingleOutput());
     bindings.allocate(mod.getPlaceholders());
@@ -610,6 +757,10 @@ TEST(onnx, reduceMean4Dto3D) {
   for (size_t i = 0; i < 8; i++) {
     EXPECT_FLOAT_EQ(result.raw(i), expectedValues[i]);
   }
+
+  // Constant Folding Test.
+  EXPECT_TRUE(
+      checkConstFoldedOutput(netFilename, {"x"}, {&x}, {bindings.get(output)}));
 }
 
 /// Test loading ReduceMean op from a ONNX model.
@@ -624,9 +775,10 @@ TEST(onnx, reduceMean4Dto4D) {
 
   PlaceholderBindings bindings;
   Placeholder *output;
+  Tensor x(ElemKind::FloatTy, {2, 2, 2, 2});
+  x.getHandle() = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+
   {
-    Tensor x(ElemKind::FloatTy, {2, 2, 2, 2});
-    x.getHandle() = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
 
     ONNXModelLoader onnxLD(netFilename, {"x"}, {&x.getType()}, *F);
     output = EXIT_ON_ERR(onnxLD.getSingleOutput());
@@ -649,6 +801,10 @@ TEST(onnx, reduceMean4Dto4D) {
   for (size_t i = 0; i < 8; i++) {
     EXPECT_FLOAT_EQ(result.raw(i), expectedValues[i]);
   }
+
+  // Constant Folding Test.
+  EXPECT_TRUE(
+      checkConstFoldedOutput(netFilename, {"x"}, {&x}, {bindings.get(output)}));
 }
 
 /// Test loading ReduceSum op from a ONNX model.
@@ -663,9 +819,10 @@ TEST(onnx, reduceSum4D) {
 
   PlaceholderBindings bindings;
   Placeholder *output;
+  Tensor x(ElemKind::FloatTy, {2, 2, 2, 2});
+  x.getHandle() = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+
   {
-    Tensor x(ElemKind::FloatTy, {2, 2, 2, 2});
-    x.getHandle() = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
 
     ONNXModelLoader onnxLD(netFilename, {"x"}, {&x.getType()}, *F);
     output = EXIT_ON_ERR(onnxLD.getSingleOutput());
@@ -685,6 +842,9 @@ TEST(onnx, reduceSum4D) {
   for (size_t i = 0; i < 8; i++) {
     EXPECT_FLOAT_EQ(result.raw(i), expectedValues[i]);
   }
+  // Constant Folding Test.
+  EXPECT_TRUE(
+      checkConstFoldedOutput(netFilename, {"x"}, {&x}, {bindings.get(output)}));
 }
 
 /// Test loading ReduceMean op from a ONNX model.
@@ -700,9 +860,10 @@ TEST(onnx, reduceMean2AvgPoolKeepDims) {
 
   PlaceholderBindings bindings;
   Placeholder *output;
+  Tensor x(ElemKind::FloatTy, {2, 2, 2, 2});
+  x.getHandle() = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+
   {
-    Tensor x(ElemKind::FloatTy, {2, 2, 2, 2});
-    x.getHandle() = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
 
     ONNXModelLoader onnxLD(netFilename, {"x"}, {&x.getType()}, *F);
     output = EXIT_ON_ERR(onnxLD.getSingleOutput());
@@ -728,6 +889,9 @@ TEST(onnx, reduceMean2AvgPoolKeepDims) {
   for (size_t i = 0; i < 4; i++) {
     EXPECT_FLOAT_EQ(result.raw(i), expectedValues[i]);
   }
+  // Constant Folding Test.
+  EXPECT_TRUE(
+      checkConstFoldedOutput(netFilename, {"x"}, {&x}, {bindings.get(output)}));
 }
 
 /// Test loading ReduceMean op from a ONNX model.
@@ -744,9 +908,10 @@ TEST(onnx, reduceMean2AvgPoolNoKeepDims) {
 
   PlaceholderBindings bindings;
   Placeholder *output;
+  Tensor x(ElemKind::FloatTy, {2, 2, 2, 2});
+  x.getHandle() = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+
   {
-    Tensor x(ElemKind::FloatTy, {2, 2, 2, 2});
-    x.getHandle() = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
 
     ONNXModelLoader onnxLD(netFilename, {"x"}, {&x.getType()}, *F);
     output = EXIT_ON_ERR(onnxLD.getSingleOutput());
@@ -772,6 +937,10 @@ TEST(onnx, reduceMean2AvgPoolNoKeepDims) {
   for (size_t i = 0; i < 4; i++) {
     EXPECT_FLOAT_EQ(result.raw(i), expectedValues[i]);
   }
+
+  // Constant Folding Test.
+  EXPECT_TRUE(
+      checkConstFoldedOutput(netFilename, {"x"}, {&x}, {bindings.get(output)}));
 }
 
 /// Test loading SpaceToDepth op from an ONNX model.
@@ -816,9 +985,10 @@ TEST(onnx, importClip) {
 
   PlaceholderBindings bindings;
   Placeholder *output;
+  Tensor x(ElemKind::FloatTy, {3, 3});
+  x.getHandle() = {1, 2, 3, 40, 5, 6, 7, 8, 90};
+
   {
-    Tensor x(ElemKind::FloatTy, {3, 3});
-    x.getHandle() = {1, 2, 3, 40, 5, 6, 7, 8, 90};
     ONNXModelLoader onnxLD(netFilename, {"x"}, {&x.getType()}, *F);
     output = EXIT_ON_ERR(onnxLD.getSingleOutput());
     bindings.allocate(mod.getPlaceholders());
@@ -838,6 +1008,10 @@ TEST(onnx, importClip) {
   for (size_t i = 0; i < 3 * 3; i++) {
     EXPECT_FLOAT_EQ(result.raw(i), expectedValues[i]);
   }
+
+  // Constant Folding Test.
+  EXPECT_TRUE(
+      checkConstFoldedOutput(netFilename, {"x"}, {&x}, {bindings.get(output)}));
 }
 
 /// Test loading BatchMatMul op from an ONNX model.
@@ -850,14 +1024,20 @@ TEST(onnx, importBatchMatMul) {
 
   PlaceholderBindings bindings;
   Placeholder *output;
+  Tensor inputs_0(ElemKind::FloatTy, {20, 40, 7});
+  Tensor inputs_1(ElemKind::FloatTy, {20, 7, 40});
+  auto data_0 = inputs_0.getHandle();
+  auto data_1 = inputs_1.getHandle();
+  // Fill inputs with random positive values.
+  data_0.randomize(0.0, 5.0, mod.getPRNG());
+  data_1.randomize(1.0, 2.0, mod.getPRNG());
   {
-    Tensor inputs_0(ElemKind::FloatTy, {20, 40, 7});
-    Tensor inputs_1(ElemKind::FloatTy, {20, 7, 40});
     ONNXModelLoader onnxLD(netFilename, {"inputs_0", "inputs_1"},
                            {&inputs_0.getType(), &inputs_1.getType()}, *F);
     output = EXIT_ON_ERR(onnxLD.getSingleOutput());
-
     bindings.allocate(mod.getPlaceholders());
+    updateInputPlaceholdersByName(bindings, &mod, {"inputs_0", "inputs_1"},
+                                  {&inputs_0, &inputs_1});
   }
   auto *res = bindings.get(output);
   EE.compile(CompilationMode::Infer, F);
@@ -897,6 +1077,10 @@ TEST(onnx, importBatchMatMul) {
       ASSERT_TRUE(slice0);
     }
   }
+  // Constant Folding Test.
+  EXPECT_TRUE(checkConstFoldedOutput(netFilename, {"inputs_0", "inputs_1"},
+                                     {&inputs_0, &inputs_1},
+                                     {bindings.get(output)}));
 }
 
 /// Test loading BatchBoxCox op from an ONNX model.
@@ -973,6 +1157,11 @@ TEST(onnx, importBatchBoxCox) {
       EXPECT_FLOAT_EQ(y, result.at({i, j}));
     }
   }
+
+  // Constant Folding Test.
+  EXPECT_TRUE(checkConstFoldedOutput(
+      netFilename, {"data", "lambda1", "lambda2"}, {&data, &lambda1, &lambda2},
+      {bindings.get(output)}));
 }
 
 /// Test loading DotProduct op from an ONNX model.
@@ -1015,13 +1204,13 @@ TEST(onnx, importSumN) {
 
   PlaceholderBindings bindings;
   Placeholder *output;
+  Tensor i0(ElemKind::FloatTy, {3});
+  i0.getHandle() = {1, 2, 3};
+  Tensor i1(ElemKind::FloatTy, {3});
+  i1.getHandle() = {4, 5, 6};
+  Tensor i2(ElemKind::FloatTy, {3});
+  i2.getHandle() = {7, 8, 9};
   {
-    Tensor i0(ElemKind::FloatTy, {3});
-    i0.getHandle() = {1, 2, 3};
-    Tensor i1(ElemKind::FloatTy, {3});
-    i1.getHandle() = {4, 5, 6};
-    Tensor i2(ElemKind::FloatTy, {3});
-    i2.getHandle() = {7, 8, 9};
 
     ONNXModelLoader onnxLD(netFilename, {"i0", "i1", "i2"},
                            {&i0.getType(), &i1.getType(), &i2.getType()}, *F);
@@ -1060,6 +1249,10 @@ TEST(onnx, importSumN) {
         llvm::dyn_cast<ReshapeNode>(concat->getNthInput(i).getNode());
     ASSERT_TRUE(reshape);
   }
+
+  // Constant Folding Test.
+  EXPECT_TRUE(checkConstFoldedOutput(netFilename, {"i0", "i1", "i2"},
+                                     {&i0, &i1, &i2}, {bindings.get(output)}));
 }
 
 /// Test loading Sum with one input and one output
@@ -1072,9 +1265,10 @@ TEST(onnx, importSum1) {
 
   PlaceholderBindings bindings;
   Placeholder *output;
+  Tensor x(ElemKind::FloatTy, {3});
+  x.getHandle() = {1, 2, 3};
+
   {
-    Tensor x(ElemKind::FloatTy, {3});
-    x.getHandle() = {1, 2, 3};
     ONNXModelLoader onnxLD(netFilename, {"x"}, {&x.getType()}, *F);
     output = EXIT_ON_ERR(onnxLD.getSingleOutput());
 
@@ -1100,6 +1294,10 @@ TEST(onnx, importSum1) {
   ASSERT_EQ(F->getNodes().size(), 1);
   auto *save = getSaveNodeFromDest(output);
   ASSERT_TRUE(llvm::isa<Placeholder>(save->getInput().getNode()));
+
+  // Constant Folding Test.
+  EXPECT_TRUE(
+      checkConstFoldedOutput(netFilename, {"x"}, {&x}, {bindings.get(output)}));
 }
 
 /// Test loading LengthsToRanges from an ONNX model.
@@ -1443,6 +1641,33 @@ TEST(onnx, gatherRanges) {
   EXPECT_TRUE(gatherRanges->getLengths().dims().equals({2}));
 }
 
+/// Test loading Gather ops with constant folding from an ONNX model.
+TEST(onnx, gatherOpConstantFoldingAndReshape) {
+  // This test verifies that Gather gets constant-folded, so that the argument
+  // of the reshape becomes constant.
+  ExecutionEngine EE;
+  auto &mod = EE.getModule();
+  std::string netFilename(
+      GLOW_DATA_PATH "tests/models/onnxModels/gatherConstantFolding.onnxtxt");
+  PlaceholderBindings bindings;
+  auto *F = mod.createFunction("main");
+  Placeholder *output;
+  Tensor data(ElemKind::FloatTy, {1, 2, 4, 3});
+  setConstantFoldLoaderOpsFlag(true);
+  {
+    ONNXModelLoader onnxLD(netFilename, {"input"}, {&data.getType()}, *F);
+    output = EXIT_ON_ERR(onnxLD.getSingleOutput());
+    bindings.allocate(mod.getPlaceholders());
+  }
+  EE.compile(CompilationMode::Infer, F);
+  EE.run(bindings);
+  setConstantFoldLoaderOpsFlag(false);
+
+  auto result = bindings.get(output)->getHandle();
+  std::vector<size_t> expectedDims = {1, 4, 3, 2};
+  EXPECT_TRUE(result.dims().vec() == expectedDims);
+}
+
 static void importSliceTest(std::string fileName, const char *inputName,
                             const llvm::ArrayRef<size_t> inputShape,
                             const llvm::ArrayRef<size_t> starts,
@@ -1457,10 +1682,10 @@ static void importSliceTest(std::string fileName, const char *inputName,
   Placeholder *graphOutputVar;
   // Destroy the loader after the graph is loaded since the following execution
   // will not depend on anyting from the loader.
+  Tensor data;
+  getNCHWData(&data, inputShape[0], inputShape[1], inputShape[2],
+              inputShape[3]);
   {
-    Tensor data;
-    getNCHWData(&data, inputShape[0], inputShape[1], inputShape[2],
-                inputShape[3]);
     ONNXModelLoader onnxLD(NetFilename, {inputName}, {&data.getType()}, *F);
     graphOutputVar = EXIT_ON_ERR(onnxLD.getSingleOutput());
     bindings.allocate(mod.getPlaceholders());
@@ -1497,6 +1722,10 @@ static void importSliceTest(std::string fileName, const char *inputName,
       }
     }
   }
+
+  // Constant Folding Test.
+  EXPECT_TRUE(checkConstFoldedOutput(NetFilename, {inputName}, {&data},
+                                     {bindings.get(graphOutputVar)}));
 }
 
 TEST(onnx, importSliceDynamicNoAxes) {
@@ -1762,10 +1991,10 @@ TEST(onnx, shape) {
 
   PlaceholderBindings bindings;
   Placeholder *output;
-  {
-    Tensor x(ElemKind::FloatTy, {2, 2, 2, 2});
-    x.getHandle() = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+  Tensor x(ElemKind::FloatTy, {2, 2, 2, 2});
+  x.getHandle() = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
 
+  {
     ONNXModelLoader onnxLD(netFilename, {"input"}, {&x.getType()}, *F);
     output = EXIT_ON_ERR(onnxLD.getSingleOutput());
     bindings.allocate(mod.getPlaceholders());
@@ -1784,6 +2013,10 @@ TEST(onnx, shape) {
   for (size_t i = 0; i < expectedValues.size(); i++) {
     EXPECT_EQ(result.raw(i), expectedValues[i]);
   }
+
+  // Constant Folding Test.
+  EXPECT_TRUE(checkConstFoldedOutput(netFilename, {"input"}, {&x},
+                                     {bindings.get(output)}));
 }
 
 TEST(onnx, tile) {


### PR DESCRIPTION
**Summary**
- Add constant folding of operators to ONNXModelLoader:
- Add constant folding of operators to Caffe2Loader
- Made Constant folding of Operators an optional feature controlled by command line option const-fold-ops
- Added constant folding test based on gather and reshape to OnnxImporterTests and Caffe2ImporterTest
- Add constant folding test to OnnxImporterTests

**Documentation**
First check if the folding is enabled. If yes, check if current operator is foldable. If yes get the output of a graph where all the inputs are constant and current operator is the only operator in the graph. Run the graph and instead of loading the original opreator load the constant operator with value calculated. When done sequentially during the loader this can fold not just a single operator but a whole subgraph as long as all the inputs to the subgraphs are constants.

**Optional Fixes**
- Fix an issue with batchboxCox batchBoxCox.onnxtxt (needed for general onnx operator folding test)

**Test Plan**
(Test constant folding of ONNX operators with ONNXImporterTest)
First replace placeholders in the original onnx model with constants. After loading the graph get the graph output values without running the GraphProto. If this output is same as output of original graph after running constant folding, the test passes.

A simple network in caffe2 and onnx which requires constant fold to work:
The test gatherOpConstantFoldingAndReshape in ONNxImportertest and Caffe2ImporterTest verifies that Gather gets constant-folded, so that the argument of the reshape becomes constant.

Related to #2168