### PR TITLE
[Partitioner] partition memory validation

### DIFF
--- a/include/glow/Partitioner/Partitioner.h
+++ b/include/glow/Partitioner/Partitioner.h
@@ -228,10 +228,14 @@ class Partitioner {
   /// devices.
   DeviceIDTy assignLogicalDeviceID(NodeToFunctionMap &partitions);
 
-  /// Check if this partition way \p partitions satisfies number of physical
-  /// devices restriction. I.e. check if the number of logical devices is less
-  /// than the given physical devices.
+  /// Check if \p partitions satisfies number of physical devices restriction.
+  /// I.e. check if the number of logical devices is less than the given
+  /// physical devices.
   llvm::Error logicalDevicesValidation(NodeToFunctionMap &partitions);
+
+  /// Check if the memory usage of each partition meets the physical device
+  /// memory restriction.
+  llvm::Error memoryUsageValidation(NodeToFunctionMap &partitions);
 
   /// Duplicates all networks in the module order to saturate the Host.
   void saturateHost(unsigned logicalDeviceCount);

--- a/tests/unittests/PartitionerTest.cpp
+++ b/tests/unittests/PartitionerTest.cpp
@@ -790,3 +790,21 @@ TEST_F(PartitionerTest, graphMemInfoCalculation2) {
   res2 = getGraphMemInfo(nodes2);
   EXPECT_EQ(res2, GraphMemInfo(96, 32, 544));
 }
+
+/// This one test the memoryUsageValidation in Partitioner : the memory usage of
+/// one single node is larger than the given device memory.
+TEST_F(PartitionerTest, memoryUsageValidation1) {
+  auto *input1 =
+      mod_.createPlaceholder(ElemKind::FloatTy, {2, 10}, "input1", false);
+  auto *input2 =
+      mod_.createPlaceholder(ElemKind::FloatTy, {10, 16}, "input2", false);
+  auto *mul0 = F_->createMatMul("mul0", input1, input2);
+  F_->createSave("ret", mul0);
+
+  std::vector<DeviceInfo> devices = {{500, "Interpreter"},
+                                     {500, "Interpreter"}};
+  Partitioner myPartitioner(&mod_, devices);
+  CompilationContext cctx;
+  auto err = myPartitioner.Partition(cctx);
+  EXPECT_TRUE(errToBool(std::move(err)));
+}


### PR DESCRIPTION
Summary:
Added partition memory usage validation function.  In current partitioner, we requires that the memory usage of each single node should be less than the device memory. After that , in each step , the algorithm will guarantee that the memory is satisfied. 
This validation can check the case that one single node is too large to fit into one device( e.g. the added unnittest).  The error message is like:
```
[ RUN      ] PartitionerTest.memoryUsageValidation1
E0619 14:53:38.690162 369878464 Error.h:244] Converting error to boolean: location: /Users/wangm/NewGLOW/glow/lib/Partitioner/Partitioner.cpp:141 message: Partition failed: the memory usage(848) of one partitoion exceeds the available memory(500) of given devices(Interpreter).
[       OK ] PartitionerTest.memoryUsageValidation1 (1 ms)
```
However, this validation will be more useful in user defined partitions (the feature will be added later) to check if their partition is valid or not.   

Documentation:

[Optional Fixes #issue]

Test Plan:
added unnittest, ninja test.

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
