### PR TITLE
[Operator] Support Max pool with Argmax output

### DIFF
--- a/include/glow/IR/IRBuilder.h
+++ b/include/glow/IR/IRBuilder.h
@@ -52,10 +52,9 @@ public:
   /// @name High-level, operation-level IRBuilder.
   ///@{
 
-  MaxPoolWithXYInst *createMaxPoolWithXYOp(llvm::StringRef name, Value *input,
-                                           llvm::ArrayRef<unsigned_t> kernels,
-                                           llvm::ArrayRef<unsigned_t> strides,
-                                           llvm::ArrayRef<unsigned_t> pads);
+  MaxPoolWithArgmaxInst *createMaxPoolWithArgmaxOp(
+      llvm::StringRef name, Value *input, llvm::ArrayRef<unsigned_t> kernels,
+      llvm::ArrayRef<unsigned_t> strides, llvm::ArrayRef<unsigned_t> pads);
 
   AvgPoolInst *createAvgPoolOp(Value *input, llvm::ArrayRef<unsigned_t> kernels,
                                llvm::ArrayRef<unsigned_t> strides,

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -53,9 +53,14 @@ bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
   case Kinded::Kind::BatchedReduceAddNodeKind:
   case Kinded::Kind::MatMulNodeKind:
   case Kinded::Kind::AvgPoolNodeKind:
-  case Kinded::Kind::MaxPoolNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
         {ElemKind::FloatTy, ElemKind::Int8QTy});
+
+  case Kinded::Kind::MaxPoolNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::FloatTy, ElemKind::Int8QTy}, {},
+               {MaxPoolNode::ArgmaxIdx}) &&
+           (NI.getOutElemTy(MaxPoolNode::ArgmaxIdx) == ElemKind::Int64ITy);
 
   case Kinded::Kind::SaveNodeKind:
   case Kinded::Kind::ReshapeNodeKind:
@@ -148,7 +153,6 @@ bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
 
   case Kinded::Kind::PowNodeKind:
   case Kinded::Kind::AvgPoolGradNodeKind:
-  case Kinded::Kind::MaxPoolGradNodeKind:
   case Kinded::Kind::QuantizationProfileNodeKind:
   case Kinded::Kind::CPUConvDKKC8NodeKind:
   case Kinded::Kind::LocalResponseNormalizationNodeKind:
@@ -158,6 +162,17 @@ bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
   case Kinded::Kind::SigmoidNodeKind:
   case Kinded::Kind::ExpNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind({ElemKind::FloatTy});
+
+  case Kinded::Kind::MaxPoolGradNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::FloatTy},
+               {MaxPoolGradNode::OriginalOutputForArgmaxIdx,
+                MaxPoolGradNode::GradOfOriginalOutputNamedArgmaxIdx}) &&
+           (NI.getInElemTy(MaxPoolGradNode::OriginalOutputForArgmaxIdx) ==
+            ElemKind::Int64ITy) &&
+           (NI.getInElemTy(
+                MaxPoolGradNode::GradOfOriginalOutputNamedArgmaxIdx) ==
+            ElemKind::Int64ITy);
 
   case Kinded::Kind::ConvolutionNodeKind:
     if (!NI.getInTy(ConvolutionNode::InputIdx)->isQuantizedType()) {

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -1071,7 +1071,7 @@ llvm::Error OpenCLFunction::execute(ExecutionContext *context) {
       continue;
     }
 
-    if (auto *PM = dyn_cast<MaxPoolWithXYInst>(&I)) {
+    if (auto *PM = dyn_cast<MaxPoolWithArgmaxInst>(&I)) {
       // This is a naive implementation that parallelizes using three dims:
       // the X and the Y in the output filter.
       cl_kernel kernel = createKernel(kernelName);
@@ -1096,7 +1096,7 @@ llvm::Error OpenCLFunction::execute(ExecutionContext *context) {
       continue;
     }
 
-    if (auto *PMG = dyn_cast<MaxPoolWithXYGradInst>(&I)) {
+    if (auto *PMG = dyn_cast<MaxPoolWithArgmaxGradInst>(&I)) {
       cl_kernel kernel = createKernel(kernelName);
       setKernelArg(kernel, 0, deviceBuffer_);
       auto numArgs = setKernelArgsForBuffers(kernel, I, 1, runtimeBundle_);

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -731,8 +731,10 @@ MaxPoolNode *Function::createMaxPool(llvm::StringRef name, NodeValue input,
       calculateConvPoolOutputDims(idim.h, idim.w, kernels, strides, pads);
   auto OT = getParent()->uniqueTypeWithNewShape(
       input.getType(), {idim.n, outSz.first, outSz.second, idim.c});
+  auto AMT = getParent()->uniqueType(
+      ElemKind::Int64ITy, {idim.n, outSz.first, outSz.second, idim.c});
 
-  return addNode(new MaxPoolNode(name, OT, input, kernels, strides, pads));
+  return addNode(new MaxPoolNode(name, OT, AMT, input, kernels, strides, pads));
 }
 
 MaxPoolNode *Function::createMaxPool(llvm::StringRef name, NodeValue input,

--- a/lib/IR/IRGen.cpp
+++ b/lib/IR/IRGen.cpp
@@ -151,7 +151,7 @@ void IRGenVisitor::post(Node *parent, Node *N) {
                                              P->getStrides(), P->getPads());
     Value *dest = V->getDest();
     nodeToInstr_[N] = V;
-    registerIR(N, dest);
+    registerIR(P->getResult(), dest);
     break;
   }
   case glow::Kinded::Kind::MaxPoolGradNodeKind: {

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -1860,13 +1860,13 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     break;
   }
 
-  case Kinded::Kind::MaxPoolWithXYInstKind: {
-    auto *PMXY = cast<MaxPoolWithXYInst>(I);
+  case Kinded::Kind::MaxPoolWithArgmaxInstKind: {
+    auto *PMXY = cast<MaxPoolWithArgmaxInst>(I);
     auto *dest = PMXY->getDest();
     auto *src = PMXY->getSrc();
     auto *destPtr = emitValueAddress(builder, dest);
     auto *srcPtr = emitValueAddress(builder, src);
-    auto *srcXYPtr = emitValueAddress(builder, PMXY->getSrcXY());
+    auto *argmaxPtr = emitValueAddress(builder, PMXY->getArgmax());
 
     auto *destDims = emitValueDims(builder, dest);
     auto *srcDims = emitValueDims(builder, src);
@@ -1875,26 +1875,26 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     auto *strides = emitConstSizeTArray(builder, PMXY->getStrides());
     auto *pads = emitConstSizeTArray(builder, PMXY->getPads());
 
-    auto *F = getFunction("max_pool_xy", dest->getElementType());
-    createCall(
-        builder, F,
-        {srcPtr, destPtr, srcXYPtr, srcDims, destDims, kernels, strides, pads});
+    auto *F = getFunction("max_pool_argmax", dest->getElementType());
+    createCall(builder, F,
+               {srcPtr, destPtr, argmaxPtr, srcDims, destDims, kernels, strides,
+                pads});
     break;
   }
 
-  case Kinded::Kind::MaxPoolWithXYGradInstKind: {
-    auto *PMG = cast<MaxPoolWithXYGradInst>(I);
+  case Kinded::Kind::MaxPoolWithArgmaxGradInstKind: {
+    auto *PMG = cast<MaxPoolWithArgmaxGradInst>(I);
     auto *srcGrad = PMG->getSrcGrad();
     auto *srcGradPtr = emitValueAddress(builder, srcGrad);
     auto *destGradPtr = emitValueAddress(builder, PMG->getDestGrad());
-    auto *srcXYPtr = emitValueAddress(builder, PMG->getSrcXY());
+    auto *argmaxPtr = emitValueAddress(builder, PMG->getArgmax());
 
     auto *srcGradDims = emitValueDims(builder, srcGrad);
     auto *destDims = emitValueDims(builder, PMG->getDest());
 
-    auto *F = getFunction("max_pool_xy_grad", srcGrad->getElementType());
+    auto *F = getFunction("max_pool_argmax_grad", srcGrad->getElementType());
     createCall(builder, F,
-               {srcGradPtr, destGradPtr, srcXYPtr, srcGradDims, destDims});
+               {srcGradPtr, destGradPtr, argmaxPtr, srcGradDims, destDims});
     break;
   }
 

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -2354,9 +2354,12 @@ static bool sinkDownRescaleToPoolingNode(Function &F, T *PN) {
                              PN->getKernels(), PN->getStrides(), PN->getPads());
     auto rescaleOutTy = F.getParent()->uniqueTypeWithNewShape(
         rescale->getResult().getType(), PN->getResult().dims());
-    auto *newRescale =
-        F.createRescaleQuantized(rescale->getName(), newPN, rescaleOutTy);
+    auto *newRescale = F.createRescaleQuantized(
+        rescale->getName(), newPN->getResult(), rescaleOutTy);
     PN->getResult().replaceAllUsesOfWith(newRescale);
+    for (size_t i = 1; i < PN->getNumResults(); i++) {
+      PN->getNthResult(i).replaceAllUsesOfWith(newPN->getNthResult(i));
+    }
     changed = true;
   }
 

--- a/lib/Optimizer/IROptimizer/IROptimizer.cpp
+++ b/lib/Optimizer/IROptimizer/IROptimizer.cpp
@@ -1547,13 +1547,13 @@ void performPeepholeOptimizations(IRFunction &M) {
     auto cur = it;
     auto *I = &*cur;
     it = std::next(it);
-    // MaxPoolWithXYInst -> MaxPoolInst.
-    if (auto *PMI = dyn_cast<MaxPoolWithXYInst>(I)) {
-      auto *SrcXY = PMI->getSrcXY();
+    // MaxPoolWithArgmaxInst -> MaxPoolInst.
+    if (auto *PMI = dyn_cast<MaxPoolWithArgmaxInst>(I)) {
+      auto *argmax = PMI->getArgmax();
       // Optimize only if the cache is an allocation and
       // it has exactly 2 users: the current instruction and
       // a deallocation.
-      if (!isa<AllocActivationInst>(SrcXY) || SrcXY->getNumUsers() != 2) {
+      if (!isa<AllocActivationInst>(argmax) || argmax->getNumUsers() != 2) {
         continue;
       }
 

--- a/tests/models/onnxModels/maxPoolWithArgmax.onnxtxt
+++ b/tests/models/onnxModels/maxPoolWithArgmax.onnxtxt
@@ -1,0 +1,93 @@
+ir_version: 3
+producer_name: "backend-test"
+graph {
+  node {
+    input: "input"
+    output: "result"
+    output: "indices"
+    op_type: "MaxPool"
+    attribute {
+      name: "kernel_shape"
+      ints: 2
+      ints: 2
+      type: INTS
+    }
+    attribute {
+      name: "strides"
+      ints: 2
+      ints: 2
+      type: INTS
+    }
+  }
+  name: "test-model"
+  input {
+    name: "input"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "result"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "indices"
+    type {
+      tensor_type {
+        elem_type: 7
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 9
+}
+

--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -249,15 +249,17 @@ TEST_P(BackendTest, simpleInference) {
   auto *RL0 = F->createRELU("relu1", CV0);
   auto *MP0 = F->createMaxPool("pool1", RL0, 2, 2, 0);
 
-  auto *CV1 = F->createConv(bindings, "conv2", MP0, 20, 5, 1, 2, 1);
+  auto *CV1 =
+      F->createConv(bindings, "conv2", MP0->getResult(), 20, 5, 1, 2, 1);
   auto *RL1 = F->createRELU("relu2", CV1);
   auto *MP1 = F->createMaxPool("pool2", RL1, 2, 2, 0);
 
-  auto *CV2 = F->createConv(bindings, "conv3", MP1, 20, 5, 1, 2, 1);
+  auto *CV2 =
+      F->createConv(bindings, "conv3", MP1->getResult(), 20, 5, 1, 2, 1);
   auto *RL2 = F->createRELU("relu3", CV2);
   auto *MP2 = F->createMaxPool("pool3", RL2, 2, 2, 0);
 
-  auto *FCL1 = F->createFullyConnected(bindings, "fc", MP2, 10);
+  auto *FCL1 = F->createFullyConnected(bindings, "fc", MP2->getResult(), 10);
   auto *RL3 = F->createRELU("relu4", FCL1);
   auto *SM = F->createSoftMax("sm", RL3, ex);
   auto *S = F->createSave("ret", SM);

--- a/tests/unittests/BackendTestUtils.cpp
+++ b/tests/unittests/BackendTestUtils.cpp
@@ -489,7 +489,7 @@ void trainMaxPoolNet(Tensor *inputs, Tensor *weights, Tensor *bias,
   bindings.get(cast<Placeholder>(fc->getBias()))->assign(bias);
   auto *reshape1 = F->createReshape("reshape1", fc, shape1);
   auto *pool = F->createMaxPool("pool", reshape1, 5, 3, 4);
-  auto *reshape2 = F->createReshape("reshape2", pool, shape2);
+  auto *reshape2 = F->createReshape("reshape2", pool->getResult(), shape2);
   auto *softmax = F->createSoftMax("softmax", reshape2, var2);
   auto *result = F->createSave("ret", softmax);
   auto *resultTensor = bindings.allocate(result->getPlaceholder());
@@ -800,7 +800,7 @@ void inferBasicConvNet(Tensor *inputs, Tensor *out, llvm::StringRef kind,
   bindings.get(cast<Placeholder>(conv->getFilter()))->getHandle().clear(0.1);
   bindings.get(cast<Placeholder>(conv->getBias()))->getHandle().clear(0.2);
   auto *pool = F->createMaxPool("pool", conv, 2, 2, 0);
-  auto *result = F->createSave("ret", pool);
+  auto *result = F->createSave("ret", pool->getResult());
   auto *resultTensor = bindings.allocate(result->getPlaceholder());
   convertPlaceholdersToConstants(F, bindings, {var, result->getPlaceholder()});
 
@@ -884,7 +884,7 @@ void inferComplexNet1(Tensor *inputs1, Tensor *inputs2, Tensor *inputs3,
   auto *reshape1 = F->createReshape("reshape1", fc1, {8, 14, 28, 6});
   auto *relu1 = F->createRELU("relu1", reshape1);
   auto *pool1 = F->createMaxPool("pool1", relu1, 2, 2, 1);
-  auto *add = F->createAdd("add", sigmoid1, pool1);
+  auto *add = F->createAdd("add", sigmoid1, pool1->getResult());
   auto *tanh = F->createTanh("tanh", add);
   auto *fc2 = F->createFullyConnected(bindings, "fc2", var3, 720);
   bindings.get(cast<Placeholder>(fc2->getWeights()))->getHandle().clear(1.1);

--- a/tests/unittests/BasicIRTest.cpp
+++ b/tests/unittests/BasicIRTest.cpp
@@ -143,7 +143,7 @@ TEST(IR, allInstrs) {
     auto *ComputationInfo =
         builder.createWeightVar(ElemKind::FloatTy, {2}, "ComputationInfo");
 
-    auto *XY = builder.createWeightVar(ElemKind::Int64ITy, {1, 12, 12, 3, 2});
+    auto *argmax = builder.createWeightVar(ElemKind::Int64ITy, {1, 12, 12, 3});
     auto *B0 = builder.createWeightVar(T2, "B0");
     auto *B1 =
         builder.createWeightVar(ElemKind::FloatTy, {32}, "B1", MK::Mutable);
@@ -156,7 +156,7 @@ TEST(IR, allInstrs) {
     F0->setName("filter");
     F1->setName("FC_filter");
     E0->setName("expected");
-    XY->setName("srcXY");
+    argmax->setName("argmax");
 
     builder.createCopyInst("", I1, I0);
     builder.createConvolutionInst("", I3, I1, F0, B0, {7, 7}, {2, 2},
@@ -292,16 +292,16 @@ TEST(IR, InstUniqueNames) {
     it = nameSet.insert(V2->getName());
     EXPECT_TRUE(it.second);
 
-    MaxPoolWithXYInst *MP1 =
-        builder.createMaxPoolWithXYOp(name, V1, {2, 2}, {1, 1}, {0, 2, 1, 3});
+    MaxPoolWithArgmaxInst *MP1 = builder.createMaxPoolWithArgmaxOp(
+        name, V1, {2, 2}, {1, 1}, {0, 2, 1, 3});
     it = nameSet.insert(MP1->getName());
     EXPECT_TRUE(it.second);
 
-    // IRBuilder::createMaxPoolWithXYOp() creates alloc activation insts
+    // IRBuilder::createMaxPoolWithArgmaxOp() creates alloc activation insts
     // internally, so we dealloc them here to keep the instruction list
     // well-formed.
     DeallocActivationInst *DAI1 =
-        builder.createDeallocActivationInst(name, MP1->getSrcXY());
+        builder.createDeallocActivationInst(name, MP1->getArgmax());
     it = nameSet.insert(DAI1->getName());
     EXPECT_TRUE(it.second);
 

--- a/tests/unittests/GraphGradTest.cpp
+++ b/tests/unittests/GraphGradTest.cpp
@@ -48,11 +48,12 @@ TEST(GraphAutoGrad, autoGrad) {
   auto *RL0 = F->createRELU("relu1", CV0);
   auto *MP0 = F->createMaxPool("pool1", RL0, 3, 3, 0);
 
-  auto *CV1 = F->createConv(bindings, "conv2", MP0, 16, 5, 1, 2, 1);
+  auto *CV1 =
+      F->createConv(bindings, "conv2", MP0->getResult(), 16, 5, 1, 2, 1);
   auto *RL1 = F->createRELU("conv23", CV1);
   auto *MP1 = F->createMaxPool("pool2", RL1, 3, 3, 0);
 
-  auto *FCL1 = F->createFullyConnected(bindings, "fc3", MP1, 10);
+  auto *FCL1 = F->createFullyConnected(bindings, "fc3", MP1->getResult(), 10);
   auto *RL2 = F->createRELU("relu3", FCL1);
   auto *selected =
       mod.createPlaceholder(ElemKind::Int64ITy, {10, 1}, "selected", false);

--- a/tests/unittests/GraphOptzTest.cpp
+++ b/tests/unittests/GraphOptzTest.cpp
@@ -2226,7 +2226,7 @@ TEST_F(GraphOptz, sinkRescaledQuantizedNode) {
   auto *transpose = F_->createTranspose("transpose", rescale2, {0, 2, 3, 1});
   auto *maxpool =
       F_->createMaxPool("maxpool", transpose, {2, 2}, {1, 1}, {0, 0, 0, 0});
-  auto *save = F_->createSave("ret", maxpool);
+  auto *save = F_->createSave("ret", maxpool->getResult());
 
   EXPECT_EQ(F_->getNodes().size(), 7);
   ::glow::optimize(F_, CompilationMode::Infer);

--- a/tests/unittests/GraphTest.cpp
+++ b/tests/unittests/GraphTest.cpp
@@ -733,7 +733,7 @@ TEST(Graph, nodesWithPredicates) {
   RL0->setPredicate(pred);
   MP0->setPredicate(pred);
 
-  auto *FCL1 = F->createFullyConnected(bindings, "fc", MP0, 10);
+  auto *FCL1 = F->createFullyConnected(bindings, "fc", MP0->getResult(), 10);
   auto *RL3 = F->createRELU("relu4", FCL1);
   auto *SM = F->createSoftMax("sm", RL3, ex);
   auto *save = F->createSave("ret", SM);

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -4317,7 +4317,7 @@ TEST_P(OperatorTest, NonSquarePaddingMaxPool) {
     IH.raw(i) = i + 1;
   }
   auto *Pool = F_->createMaxPool("pool", input, {2, 2}, {1, 1}, {0, 2, 1, 3});
-  auto *S = F_->createSave("save", Pool);
+  auto *S = F_->createSave("save", Pool->getResult());
   bindings_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_);
@@ -4336,7 +4336,7 @@ TEST_P(OperatorTest, NonSquarePaddingMaxPool) {
 
   Function *refF = mod_.createFunction("mainRef");
   Pool = refF->createMaxPool("pool1", input1, 2, 1, 0);
-  S = refF->createSave("save1", Pool);
+  S = refF->createSave("save1", Pool->getResult());
   bindings_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, refF);
@@ -4409,7 +4409,7 @@ TEST_P(OperatorTest, MaxPool) {
       mod_.createPlaceholder(ElemKind::FloatTy, {1, 3, 3, 1}, "input", false);
   bindings_.allocate(input)->getHandle() = {0., 1., 2., 3., 4., 5., 6., 7., 8.};
   auto *pool = F_->createMaxPool("pool", input, {2, 2}, {1, 1}, {0, 0, 0, 0});
-  auto *S = F_->createSave("save", pool);
+  auto *S = F_->createSave("save", pool->getResult());
   bindings_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_);
@@ -4429,7 +4429,7 @@ TEST_P(OperatorTest, FP16MaxPool) {
   bindings_.allocate(input)->getHandle<float16_t>() = {0., 1., 2., 3., 4.,
                                                        5., 6., 7., 8.};
   auto *pool = F_->createMaxPool("pool", input, {2, 2}, {1, 1}, {0, 0, 0, 0});
-  auto *S = F_->createSave("save", pool);
+  auto *S = F_->createSave("save", pool->getResult());
   bindings_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_);
@@ -4446,7 +4446,7 @@ TEST_P(OperatorTest, Int8MaxPool) {
                                        "input", false);
   bindings_.allocate(input)->getHandle<int8_t>() = {0, 1, 2, 3, 4, 5, 6, 7, 8};
   auto *Pool = F_->createMaxPool("pool", input, {2, 2}, {1, 1}, {0, 0, 0, 0});
-  auto *S = F_->createSave("save", Pool);
+  auto *S = F_->createSave("save", Pool->getResult());
   bindings_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_);
@@ -4754,7 +4754,7 @@ TEST_P(OperatorTest, NonSquareKernelMaxPool) {
     IH.raw(i) = i + 1;
   }
   auto *Pool = F_->createMaxPool("pool", input, {2, 3}, {1, 1}, {0, 0, 0, 0});
-  auto *S = F_->createSave("save", Pool);
+  auto *S = F_->createSave("save", Pool->getResult());
   bindings_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_);
@@ -4891,7 +4891,7 @@ TEST_P(OperatorTest, NonSquareStrideMaxPool) {
     IH.raw(i) = i + 1;
   }
   auto *Pool = F_->createMaxPool("pool", input, {2, 2}, {3, 2}, {0, 0, 1, 1});
-  auto *S = F_->createSave("save", Pool);
+  auto *S = F_->createSave("save", Pool->getResult());
   bindings_.allocate(S->getPlaceholder());
 
   EE_.compile(CompilationMode::Infer, F_);

--- a/tests/unittests/QuantizationTest.cpp
+++ b/tests/unittests/QuantizationTest.cpp
@@ -758,7 +758,7 @@ static Function *createSimpleGraphForQuantization(Module *M,
   auto *RL = F->createRELU("relu", CV);
   auto *MP = F->createMaxPool("maxPool", RL, 2, 2, 1);
   // Just add noop transpose.
-  auto *T = F->createTranspose("transpose", MP, {0, 1, 2, 3});
+  auto *T = F->createTranspose("transpose", MP->getResult(), {0, 1, 2, 3});
   // Noop reshape, make sure conversion quantization procedure works well.
   auto *R = F->createReshape("reshape", T, T->getResult().dims());
   auto *AP = F->createAvgPool("avgPool", R, 2, 2, 1);

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -119,17 +119,18 @@ int main(int argc, char **argv) {
       .autoVerify(VerifyKind::SameElementType, {"Dest", "Src", "Filter"})
       .addGradientInstr({"Src", "Filter"}, {"Dest", "Src", "Filter", "Bias"});
 
-  // MaxPool version caching XY coordinates to speedup gradient-based
+  // MaxPool version caching Argmax flattened coordinates. It is both used by
+  // itself, and also to restore XY coordinates to speedup gradient-based
   // computations.
-  BB.newInstr("MaxPoolWithXY")
+  BB.newInstr("MaxPoolWithArgmax")
       .addOperand("Dest", OperandKind::Out)
       .addOperand("Src", OperandKind::In)
-      .addOperand("SrcXY", OperandKind::Out)
+      .addOperand("Argmax", OperandKind::Out)
       .addMember(MemberType::VectorUnsigned, "Kernels")
       .addMember(MemberType::VectorUnsigned, "Strides")
       .addMember(MemberType::VectorUnsigned, "Pads")
       .autoVerify(VerifyKind::SameElementType, {"Dest", "Src"})
-      .addGradientInstr({"Dest", "SrcXY"}, {"Dest", "Src"});
+      .addGradientInstr({"Dest", "Argmax"}, {"Dest", "Src"});
 
   BB.newInstr("MaxPool")
       .addOperand("Dest", OperandKind::Out)

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -125,10 +125,13 @@ int main(int argc, char **argv) {
       .addMember(MemberType::VectorUnsigned, "Kernels")
       .addMember(MemberType::VectorUnsigned, "Strides")
       .addMember(MemberType::VectorUnsigned, "Pads")
-      .addResultFromCtorArg()
+      .addResultFromCtorArg("Result")
+      .addResultFromCtorArg("Argmax")
       .addGradient()
-      .setDocstring("Performs a Max Pool operation on the Input given provided "
-                    "Kernels, Strides, and Pads.");
+      .setDocstring(
+          "Performs a Max Pool with Argmax operation on the Input "
+          "given provided Kernels, Strides, and Pads. Argmax is a flattened "
+          "NCHW index corresponding to respective max element.");
 
   BB.newNode("AvgPool")
       .addInput("Input")

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -131,7 +131,7 @@ int main(int argc, char **argv) {
       .setDocstring(
           "Performs a Max Pool with Argmax operation on the Input "
           "given provided Kernels, Strides, and Pads. Argmax is a flattened "
-          "NCHW index corresponding to respective max element.");
+          "NHWC index corresponding to respective max element.");
 
   BB.newNode("AvgPool")
       .addInput("Input")


### PR DESCRIPTION
Summary:
This patch adds support for Argmax output of MaxPool node which is present in ONNX.
In order to do so, it replaces MaxPoolWithXY instructions with MaxPoolWithArgmax which
contains linearized NCHW indices of respective max elements. X and Y may be extracted
from this index using simple formula.

Fixes #3053

Test Plan:
Added node and ONNX unit tests.
