### PR TITLE
Remove GLOW_ASSERTs from Habana

### DIFF
--- a/include/glow/Support/Compiler.h
+++ b/include/glow/Support/Compiler.h
@@ -22,12 +22,6 @@
 #define __has_builtin(builtin) 0
 #endif
 
-#define GLOW_ASSERT(e)                                                         \
-  ((void)((e) ? ((void)0) : GLOW_ASSERT_IMPL(#e, __FILE__, __LINE__)))
-#define GLOW_ASSERT_IMPL(e, file, line)                                        \
-  ((void)fprintf(stderr, "%s:%u: failed assertion `%s'\n", file, line, e),     \
-   abort())
-
 #ifdef _WIN32
 #define glow_aligned_malloc(p, a, s)                                           \
   (((*(p)) = _aligned_malloc((s), (a))), *(p) ? 0 : errno)

--- a/tests/unittests/HabanaTest.cpp
+++ b/tests/unittests/HabanaTest.cpp
@@ -31,7 +31,7 @@
 #include <thread>
 #include <vector>
 
-#define chk(STATUS) GLOW_ASSERT(STATUS == synSuccess)
+#define chk(X) CHECK_EQ((X), synSuccess) << "Expected synStatus be synSuccess";
 
 class Habana : public ::testing::Test {
 protected:


### PR DESCRIPTION
Summary:
Remove the remaining `GLOW_ASSERT`s and delete the macro.
Where possible, return an llvm::Error, otherwise use CHECK

Reviewed By: bertmaher

Differential Revision: D15764024

