### PR TITLE
[BundleSaver] Separate bundle file name from main entry name.

### DIFF
--- a/docs/Backends.md
+++ b/docs/Backends.md
@@ -88,12 +88,13 @@ Additionally, there are virtual functions that backends can override:
     preferred by backends which would like to do their own memory
     optimizations. Returns true by default.
 
-- `virtual void save(Function *F, llvm::StringRef outputDir, llvm::StringRef networkName) const;`
+- `virtual void save(Function *F, llvm::StringRef outputDir,
+                     llvm::StringRef bundleName, llvm::StringRef mainEntryName) const;`
 
   - Save a [standalone executable
     bundle](https://github.com/pytorch/glow/blob/master/docs/AOT.md), where the
-    provided `Function *F` is compiled and then saved to `outputDir` with main
-    entry name `networkName`.
+    provided `Function *F` is compiled and then saved to `outputDir` with bundle
+    name `bundleName` and main entry name `mainEntryName`.
 
 - `virtual bool generateInst(Node *N, IRGenVisitor &irgen) const;`
 

--- a/include/glow/Backend/Backend.h
+++ b/include/glow/Backend/Backend.h
@@ -68,12 +68,12 @@ public:
   virtual llvm::Expected<std::unique_ptr<CompiledFunction>>
   compile(Function *F, const BackendOptions &opts) const = 0;
 
-  /// Save the bundle for \p F for a later standalone execution
-  /// in \p outputDir. Make \p networkName the function name for
-  /// the entry point of the network and prepend all generated
-  /// files with this name.
+  /// Save the bundle for \p F for a later standalone execution in \p outputDir
+  /// under name \p bundleName. Make \p mainEntryName the function name for the
+  /// entry point of the network and prepend all generated files with this name.
   virtual void save(Function *F, llvm::StringRef outputDir,
-                    llvm::StringRef networkName) const {
+                    llvm::StringRef bundleName,
+                    llvm::StringRef mainEntryName) const {
     LOG(FATAL) << "Saving a bundle is not supported by the backend";
   }
 

--- a/include/glow/ExecutionEngine/ExecutionEngine.h
+++ b/include/glow/ExecutionEngine/ExecutionEngine.h
@@ -112,15 +112,6 @@ public:
   void compile(CompilationMode mode, Function *F,
                bool clearOtherFunctions = true);
 
-  /// Save a bundle for a standalone execution given \p cctx. This method takes
-  /// care of everything when preparing the bundle for saving. There is no need
-  /// to invoke the compile method before it.
-  /// Make \p networkName the function name for
-  /// the entry point of the network and prepend all generated
-  /// files with this name.
-  void save(Function *F, CompilationContext &cctx, llvm::StringRef outputDir,
-            llvm::StringRef networkName);
-
   /// Context aware single execution of a function. If more than one
   /// function has been compiled by this ExecutionEngine then a name must be
   /// supplied to specify which function to run.

--- a/include/glow/LLVMIRCodeGen/LLVMBackend.h
+++ b/include/glow/LLVMIRCodeGen/LLVMBackend.h
@@ -67,7 +67,8 @@ public:
   compile(Function *F, const BackendOptions &opts) const override;
 
   virtual void save(Function *F, llvm::StringRef outputDir,
-                    llvm::StringRef networkName) const override;
+                    llvm::StringRef bundleName,
+                    llvm::StringRef mainEntryName) const override;
   /// @}
 
   /// \returns the size of metrics collected for a single TraceEvent.

--- a/include/glow/LLVMIRCodeGen/LLVMIRGen.h
+++ b/include/glow/LLVMIRCodeGen/LLVMIRGen.h
@@ -105,6 +105,8 @@ protected:
   std::unique_ptr<llvm::TargetMachine> TM_;
   /// Information about allocations.
   AllocationsInfo &allocationsInfo_;
+  /// Name of the bundle.
+  std::string bundleName_;
   /// Name of the main entry.
   std::string mainEntryName_;
   /// Instruction number for the module.
@@ -282,6 +284,10 @@ public:
   virtual void performSpecialization();
   /// \returns allocations info.
   virtual AllocationsInfo &getAllocationsInfo() { return allocationsInfo_; }
+  /// \returns the name of the bundle, to be used for filename when saving.
+  llvm::StringRef getBundleName() const;
+  /// Set the name of the bundle.
+  void setBundleName(const std::string &name);
   /// \returns the name of the main entry point.
   /// When JITting, it will be "main". In case of bundling it will be the name
   /// of the bundle.

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -266,10 +266,3 @@ void ExecutionEngine::compile(Function *F, CompilationContext &cctx,
     EXIT_ON_ERR(funcOrErr.takeError());
   }
 }
-
-void ExecutionEngine::save(Function *F, CompilationContext &cctx,
-                           llvm::StringRef outputDir,
-                           llvm::StringRef networkName) {
-  EXIT_ON_ERR(::glow::optimizeFunction(F, *backend_, cctx));
-  backend_->save(F, outputDir, networkName);
-}

--- a/lib/LLVMIRCodeGen/BundleSaver.cpp
+++ b/lib/LLVMIRCodeGen/BundleSaver.cpp
@@ -138,7 +138,7 @@ void BundleSaver::produceBundle(llvm::StringRef outputDir) {
   emitBundleConfig();
 
   auto &M = irgen_->getModule();
-  auto bundleName = irgen_->getMainEntryName();
+  auto bundleName = irgen_->getBundleName();
   std::string extension = (llvmCompiler.empty()) ? ".o" : ".bc";
   auto bundleCodeOutput = (outputDir + "/" + bundleName + extension).str();
   auto bundleWeightsOutput = (outputDir + "/" + bundleName + ".weights").str();
@@ -286,12 +286,14 @@ void BundleSaver::performBundleMemoryAllocation() {
 void BundleSaver::save(llvm::StringRef target, llvm::StringRef arch,
                        llvm::StringRef cpu,
                        const llvm::SmallVectorImpl<std::string> &targetFeatures,
-                       llvm::StringRef outputDir, llvm::StringRef networkName) {
+                       llvm::StringRef outputDir, llvm::StringRef bundleName,
+                       llvm::StringRef mainEnryName) {
   // Object files generation works properly only in small mode.
   irgen_->initTargetMachine(target, arch, cpu, targetFeatures,
                             llvm::CodeModel::Model::Small);
-  irgen_->setMainEntryName(networkName);
   irgen_->setOutputDir(outputDir);
+  irgen_->setBundleName(bundleName);
+  irgen_->setMainEntryName(mainEnryName);
   irgen_->initCodeGen();
   // Perform the address assignment for activations and WeightVars.
   performBundleMemoryAllocation();

--- a/lib/LLVMIRCodeGen/BundleSaver.h
+++ b/lib/LLVMIRCodeGen/BundleSaver.h
@@ -49,12 +49,13 @@ public:
   /// Ctor.
   explicit BundleSaver(const IRFunction *F, const LLVMBackend &llvmBackend);
   /// Save code bundle built for \p target, \p arch, \p cpu and \p
-  /// targetFeatures to \p outputDir. Make \p networkName the function name for
-  /// the entry point of the network and prepend all generated
-  /// files with this name.
+  /// targetFeatures to \p outputDir under name \p bundleName. Make
+  /// \p mainEntryName the function name for the entry point of the network and
+  /// prepend all generated files with this name.
   void save(llvm::StringRef target, llvm::StringRef arch, llvm::StringRef cpu,
             const llvm::SmallVectorImpl<std::string> &targetFeatures,
-            llvm::StringRef outputDir, llvm::StringRef networkName);
+            llvm::StringRef outputDir, llvm::StringRef bundleName,
+            llvm::StringRef mainEntryName);
 };
 
 } // namespace glow

--- a/lib/LLVMIRCodeGen/LLVMBackend.cpp
+++ b/lib/LLVMIRCodeGen/LLVMBackend.cpp
@@ -152,11 +152,12 @@ LLVMBackend::compile(Function *F, const BackendOptions &opts) const {
 }
 
 void LLVMBackend::save(Function *F, llvm::StringRef outputDir,
-                       llvm::StringRef networkName) const {
+                       llvm::StringRef bundleName,
+                       llvm::StringRef mainEntryName) const {
   llvm::SmallVector<std::string, 8> targetFeatures(llvmTargetFeatures.begin(),
                                                    llvmTargetFeatures.end());
   auto IR = generateAndOptimizeIR(F, *this, shouldShareBuffers());
   BundleSaver(IR.get(), *this)
       .save(getTarget(), getArch(), getCPU(), targetFeatures, outputDir,
-            networkName);
+            bundleName, mainEntryName);
 }

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -128,6 +128,10 @@ void LLVMIRGen::initTargetMachine(
   assert(TM_ && "Could not initialize the target machine");
 }
 
+llvm::StringRef LLVMIRGen::getBundleName() const { return bundleName_; }
+
+void LLVMIRGen::setBundleName(const std::string &name) { bundleName_ = name; }
+
 std::string LLVMIRGen::getMainEntryName() const {
   return mainEntryName_.empty() ? "main" : mainEntryName_;
 }

--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -40,23 +40,6 @@ public:
   ExecutionEngine EE_{GetParam()};
 };
 
-TEST(Interpreter, NotImplementedSave) {
-  // Interpreter backend does not support a save method.
-  // Exercise it and make sure that it fails.
-  ExecutionEngine EE;
-  PlaceholderBindings bindings;
-  auto &mod = EE.getModule();
-
-  // Create a few nodes to make sure IR can be normally generated.
-  Function *F = mod.createFunction("main");
-  F->createSave("save",
-                mod.createPlaceholder(ElemKind::FloatTy, {2}, "A", false));
-
-  CompilationContext cctx;
-  cctx.compMode = CompilationMode::Infer;
-  EXPECT_DEATH(EE.save(F, cctx, "output", "network"), "");
-}
-
 TEST(Interpreter, profileQuantizationForANetwork) {
   ExecutionEngine EE;
   PlaceholderBindings bindings;

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -182,11 +182,17 @@ llvm::cl::opt<std::string> loadDeviceConfigsFileOpt(
 /// Name of the network being bundled.
 llvm::cl::opt<std::string> networkName(
     "network-name",
-    llvm::cl::desc("Name of the network being bundled. "
-                   "This name is used as both the function name "
-                   "of the entry point to the network "
-                   "and as a prefix for all the files that are generated."),
+    llvm::cl::desc("Name of the network being bundled. This name is used as a "
+                   "prefix for all the files that are generated."),
     llvm::cl::cat(loaderCat));
+
+/// Name of the main entry of the bundle.
+llvm::cl::opt<std::string>
+    mainEntryName("main-entry-name",
+                  llvm::cl::desc("Name of the main entry in the bundle. "
+                                 "This name is used as the function name "
+                                 "of the entry point to the network."),
+                  llvm::cl::cat(loaderCat));
 
 llvm::cl::opt<unsigned> numDevices("num-devices",
                                    llvm::cl::desc("Number of Devices to use"),
@@ -404,7 +410,8 @@ void Loader::compile(PlaceholderBindings &bindings) {
     // Emit IR for the graph, compile it and save as a bundle.
     auto error = ::glow::optimizeFunction(F_, *backend_, cctx);
     EXIT_ON_ERR(std::move(error));
-    backend_->save(F_, emitBundle, networkName);
+    backend_->save(F_, emitBundle, networkName,
+                   mainEntryName.empty() ? networkName : mainEntryName);
   } else {
     // Emit IR for the graph and compile it.
     auto error = hostManager_->addNetwork(std::move(M_), cctx);


### PR DESCRIPTION
I deleted `save()` from ExecutionEngine because it's being deprecated anyway. It was not used anywhere besides 1 unit test.