### PR TITLE
Support int32 and Boolean types for Concat in Interpreter

### DIFF
--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -88,15 +88,19 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
     return NI.allInputsAndOutputsHaveSameElemKind(
         {ElemKind::FloatTy, ElemKind::Float16Ty});
 
-  case Kinded::Kind::SplatNodeKind:
-  case Kinded::Kind::InsertTensorNodeKind:
   case Kinded::Kind::DivNodeKind:
-  case Kinded::Kind::ConcatNodeKind:
   case Kinded::Kind::SliceNodeKind:
   case Kinded::Kind::SpaceToDepthNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
         {ElemKind::FloatTy, ElemKind::Float16Ty, ElemKind::Int8QTy,
          ElemKind::Int64ITy});
+
+  case Kinded::Kind::SplatNodeKind:
+  case Kinded::Kind::InsertTensorNodeKind:
+  case Kinded::Kind::ConcatNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+        {ElemKind::FloatTy, ElemKind::Float16Ty, ElemKind::Int8QTy,
+         ElemKind::Int32ITy, ElemKind::Int64ITy, ElemKind::BoolTy});
 
   case Kinded::Kind::SelectNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -1120,6 +1120,10 @@ void BoundInterpreterFunction::fwdSplatInst(const glow::SplatInst *I) {
     return T->getHandle<int64_t>().clear(I->getValue());
   }
 
+  if (k == ElemKind::Int32ITy) {
+    return T->getHandle<int32_t>().clear(I->getValue());
+  }
+
   if (k == ElemKind::FloatTy) {
     return T->getHandle<float>().clear(I->getValue());
   }
@@ -1135,6 +1139,10 @@ void BoundInterpreterFunction::fwdSplatInst(const glow::SplatInst *I) {
     TensorQuantizationParams destQ{destTy->getScale(), destTy->getOffset()};
     float val = I->getValue();
     return T->getHandle<int8_t>().clear(quantization::quantize(val, destQ));
+  }
+
+  if (k == ElemKind::BoolTy) {
+    return T->getHandle<bool>().clear(static_cast<bool>(I->getValue()));
   }
 
   llvm_unreachable("Unsupported tensor type");
@@ -1153,9 +1161,11 @@ void BoundInterpreterFunction::fwdInsertTensorInst(
   }
 
   TYPED_INSERT(int64_t, ElemKind::Int64ITy);
+  TYPED_INSERT(int32_t, ElemKind::Int32ITy);
   TYPED_INSERT(float, ElemKind::FloatTy);
   TYPED_INSERT(float16_t, ElemKind::Float16Ty);
   TYPED_INSERT(int8_t, ElemKind::Int8QTy);
+  TYPED_INSERT(bool, ElemKind::BoolTy);
 #undef TYPED_INSERT
 
   llvm_unreachable("Unsupported tensor type");

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -3042,10 +3042,22 @@ TEST_P(OperatorTest, concatVectors_Int64) {
   testConcatVectors<int64_t>(bindings_, mod_, F_, EE_, ElemKind::Int64ITy);
 }
 
+/// Test concatenating vectors that are Int32ITy.
+TEST_P(OperatorTest, concatVectors_Int32) {
+  ENABLED_BACKENDS(Interpreter);
+  testConcatVectors<int32_t>(bindings_, mod_, F_, EE_, ElemKind::Int32ITy);
+}
+
 /// Test concatenating vectors that are Int8Qty.
 TEST_P(OperatorTest, concatVectors_Int8) {
   ENABLED_BACKENDS(Interpreter, CPU);
   testConcatVectors<int8_t>(bindings_, mod_, F_, EE_, ElemKind::Int8QTy);
+}
+
+/// Test concatenating vectors that are BoolTy.
+TEST_P(OperatorTest, concatVectors_Bool) {
+  ENABLED_BACKENDS(Interpreter);
+  testConcatVectors<bool>(bindings_, mod_, F_, EE_, ElemKind::BoolTy);
 }
 
 /// Test concatenating vectors that are FloatTy.
@@ -3121,11 +3133,28 @@ TEST_P(OperatorTest, concatVectorsRepeated_Int64) {
 
 /// Check that concatenating two tensors repeatedly is correct. This is
 /// intended to verify that IRGen to InsertTensor instructions with axis/count
+/// works correctly. Testing Int32ITy data.
+TEST_P(OperatorTest, concatVectorsRepeated_Int32) {
+  ENABLED_BACKENDS(Interpreter);
+  testConcatVectorsRepeated<int32_t>(bindings_, mod_, F_, EE_,
+                                     ElemKind::Int32ITy);
+}
+
+/// Check that concatenating two tensors repeatedly is correct. This is
+/// intended to verify that IRGen to InsertTensor instructions with axis/count
 /// works correctly. Testing Int8QTy data.
 TEST_P(OperatorTest, concatVectorsRepeated_Int8) {
   ENABLED_BACKENDS(Interpreter, CPU);
   testConcatVectorsRepeated<int8_t>(bindings_, mod_, F_, EE_,
                                     ElemKind::Int8QTy);
+}
+
+/// Check that concatenating two tensors repeatedly is correct. This is
+/// intended to verify that IRGen to InsertTensor instructions with axis/count
+/// works correctly. Testing BoolTy data.
+TEST_P(OperatorTest, concatVectorsRepeated_Bool) {
+  ENABLED_BACKENDS(Interpreter);
+  testConcatVectorsRepeated<bool>(bindings_, mod_, F_, EE_, ElemKind::BoolTy);
 }
 
 /// Check that concatenating two tensors repeatedly is correct. This is

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -3032,7 +3032,7 @@ static void testConcatVectors(glow::PlaceholderBindings &bindings,
   (void)RNWH;
 
   for (size_t i = 0; i < 60; i++) {
-    EXPECT_NEAR(RNWH.at({i}), i, 0.001);
+    EXPECT_NEAR(RNWH.at({i}), static_cast<DataType>(i), 0.001);
   }
 }
 


### PR DESCRIPTION
Summary:
This patch adds support for Concat and related nodes for int32 and Boolean types
in interpreter. The main purpose of this is to leverage constant-folding to get rid of
such tensors, that's why no CPU support added so far (will be done if needed).

Test Plan:
Added unit tests
