### PR TITLE
add thread names + metadata

### DIFF
--- a/include/glow/ExecutionContext/TraceEvents.h
+++ b/include/glow/ExecutionContext/TraceEvents.h
@@ -198,6 +198,11 @@ public:
 
   /// Sets the human readable \p name for thread \tid.
   void setThreadName(int tid, llvm::StringRef name);
+
+  /// Sets the human readable \p name for the current thread (by
+  /// TraceEvent::getThreadId()).
+  void setThreadName(llvm::StringRef name);
+
   /// \returns the list of human readable thread names.
   std::map<int, std::string> &getThreadNames() { return threadNames_; }
 

--- a/include/glow/Runtime/Executor/ThreadPoolExecutor.h
+++ b/include/glow/Runtime/Executor/ThreadPoolExecutor.h
@@ -85,7 +85,7 @@ public:
   bool incrementNodeParentsDone(const DAGNode *node, unsigned increment = 1);
 
   /// Move all events from the provided vector into the top level resultContxt.
-  void insertIntoTraceContext(std::vector<TraceEvent> &events);
+  void insertIntoTraceContext(TraceContext *runCtx);
 
   /// Remove intermediate placeholders not required in the final output.
   void removeIntermediatePlaceholders();

--- a/lib/ExecutionContext/TraceEvents.cpp
+++ b/lib/ExecutionContext/TraceEvents.cpp
@@ -145,6 +145,10 @@ void TraceContext::setThreadName(int tid, llvm::StringRef name) {
   threadNames_[tid] = name;
 }
 
+void TraceContext::setThreadName(llvm::StringRef name) {
+  setThreadName(TraceEvent::getThreadId(), name);
+}
+
 void TraceContext::dump(llvm::StringRef filename,
                         const std::string &processName) {
   TraceEvent::dumpTraceEvents(getTraceEvents(), filename,

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -111,6 +111,7 @@ onnxStatus Graph::setIOAndRun(uint32_t inputsCount,
   if (traceEvents || GlowDumpDebugTraces) {
     ctx->setTraceContext(llvm::make_unique<TraceContext>(TraceLevel::STANDARD));
     traceContext = ctx->getTraceContext();
+    traceContext->setThreadName("Onnxifi");
   }
   TRACE_EVENT_SCOPE(traceContext, TraceLevel::RUNTIME, "Onnxifi::setIOAndRun");
   TRACE_EVENT_SCOPE_NAMED(traceContext, TraceLevel::RUNTIME, "adjustInputs",

--- a/lib/Runtime/Executor/ThreadPoolExecutor.cpp
+++ b/lib/Runtime/Executor/ThreadPoolExecutor.cpp
@@ -193,15 +193,12 @@ bool ExecutionState::incrementNodeParentsDone(const DAGNode *node,
   return (newValue == numParents);
 }
 
-void ExecutionState::insertIntoTraceContext(std::vector<TraceEvent> &events) {
+void ExecutionState::insertIntoTraceContext(TraceContext *runCtx) {
   if (!resultCtx_->getTraceContext()) {
-    events.clear();
     return;
   }
 
-  std::move(
-      events.begin(), events.end(),
-      std::back_inserter(resultCtx_->getTraceContext()->getTraceEvents()));
+  resultCtx_->getTraceContext()->merge(runCtx);
 }
 
 void ExecutionState::removeIntermediatePlaceholders() {
@@ -371,7 +368,7 @@ void ThreadPoolExecutor::handleDeviceManagerResult(
     TRACE_EVENT_END(traceContext, TraceLevel::RUNTIME,
                     "ThreadPoolExecutor::handleResult");
     // Lock is not necessary as we only access on this runs executor.
-    executionState->insertIntoTraceContext(traceContext->getTraceEvents());
+    executionState->insertIntoTraceContext(traceContext);
   }
 
   if (noNodesInflight) {


### PR DESCRIPTION
Summary:
Add thread names to the glow trace for Glow Runtime threads and HabanaDeviceManager threads:

{F162990954}

Add some metadata to certain ops in the HabanaFunction and HabanaDeviceManager:

{F162991061}

Reviewed By: hyuen

Differential Revision: D15948594

