### PR TITLE
[compilationLog][fix]: Fix the problem that constants can not be logged via logNodeInputChanges.

### DIFF
--- a/lib/Graph/Log.cpp
+++ b/lib/Graph/Log.cpp
@@ -130,18 +130,23 @@ void LogContext::logNodeInputChange(const Node *user,
           "Name: {2}) :: ",
           getFullScopeName(), user->getKindName(), user->getName())
           .str());
-  // prevOpr and newOpr should never be null for the places we intercept.
+
+  // prevOpr.getNode()should never be null.
   addLogContent(
       llvm::formatv("PrevOprValue(Kind: {0}, Name: {1}, ResNo: {2}) -> ",
                     prevOprVal.getNode()->getKindName(),
                     prevOprVal.getNode()->getName(), prevOprVal.getResNo())
           .str());
 
-  addLogContent(
-      llvm::formatv("NewOprValue(Kind: {0}, Name: {1}, ResNo: {2}) }\n",
-                    newOprVal.getNode()->getKindName(),
-                    newOprVal.getNode()->getName(), newOprVal.getResNo())
-          .str());
+  if (newOprVal.getNode()) {
+    addLogContent(
+        llvm::formatv("NewOprValue(Kind: {0}, Name: {1}, ResNo: {2}) }\n",
+                      newOprVal.getNode()->getKindName(),
+                      newOprVal.getNode()->getName(), newOprVal.getResNo())
+            .str());
+  } else {
+    addLogContent("NewOprValue(null) }\n");
+  }
 }
 
 ScopedLogBlock::ScopedLogBlock(LogContext &ctx, llvm::StringRef name)

--- a/lib/Graph/NodeValue.cpp
+++ b/lib/Graph/NodeValue.cpp
@@ -58,7 +58,13 @@ void NodeValue::typeUnsafeReplaceAllUsesOfWith(NodeValue v,
 
     // Log the change of node input(operand).
     if (Function *F = getNode()->getParent()) {
-      F->getLogContext().logNodeInputChange(U.getUser(), *(U.get()), v);
+      F->getLogContext().logNodeInputChange(U.getUser(), *this, v);
+    }
+    // Constant or Placeholder has no associated Function, we need to log the
+    // input changes inside its user's Function.
+    else if (getNode()->getKind() == Kinded::Kind::ConstantKind ||
+             getNode()->getKind() == Kinded::Kind::PlaceholderKind) {
+      userF->getLogContext().logNodeInputChange(U.getUser(), *this, v);
     }
 
     site->setOperand(v.getNode(), v.getResNo());


### PR DESCRIPTION
Summary:
Fix the problem that Constant.replaceAllUsesOfWith() cannot be logged.
-  constant has no Function parent. Function->getLogContext().logNodeInputChange cannot be invoked.
- Use constant's user node's function to log the changes, such that to fix the problem.

Test Plan:
ninja check
