### PR TITLE
Name nodes by name, output(0), type

### DIFF
--- a/include/glow/Importer/ProtobufLoader.h
+++ b/include/glow/Importer/ProtobufLoader.h
@@ -85,6 +85,9 @@ template <typename T> std::string loadOperatorName(const T &op) {
   if (op.name().length()) {
     return op.name();
   }
+  if (op.output_size() > 0) {
+    return op.output(0);
+  }
   return op.op_type();
 }
 

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -56,6 +56,9 @@ loadOperatorName<caffe2::OperatorDef>(const caffe2::OperatorDef &op) {
   if (op.name().length()) {
     return op.name();
   }
+  if (op.output_size() > 0) {
+    return op.output(0);
+  }
   return op.type();
 }
 }; // namespace glow

--- a/tests/models/caffe2Models/sigmoid.pbtxt
+++ b/tests/models/caffe2Models/sigmoid.pbtxt
@@ -1,0 +1,8 @@
+name: "sigmoid"
+op {
+  type: "Sigmoid"
+  input: "sigmoid_test_input"
+  output: "sigmoid_test_output"
+}
+external_input: "sigmoid_test_input"
+external_output: "sigmoid_test_output"

--- a/tests/unittests/Caffe2ImporterTest.cpp
+++ b/tests/unittests/Caffe2ImporterTest.cpp
@@ -2480,3 +2480,17 @@ TEST(caffe2, importInt8SumRelu) {
 
   EE.compile(CompilationMode::Infer, F);
 }
+
+TEST(caffe2, importNames) {
+  std::string NetDescFilename(GLOW_DATA_PATH
+                              "tests/models/caffe2Models/sigmoid.pbtxt");
+  std::string NetWeightFilename(
+      GLOW_DATA_PATH "tests/models/caffe2Models/empty_init_net.pbtxt");
+  ExecutionEngine EE;
+  auto &mod = EE.getModule();
+  auto *F = mod.createFunction("main");
+  Tensor input(ElemKind::FloatTy, {6});
+  Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename,
+                             {"sigmoid_test_input"}, {&input.getType()}, *F);
+  EXPECT_TRUE(F->getNodeByName("sigmoid_test_output"));
+}


### PR DESCRIPTION
Summary:
With D15859961 we lost the naming of nodes by output, leading to a lot
of things named by type, which makes debugging harder.

Differential Revision: D15981964

