### PR TITLE
Improve error message when synEnqueue fails

### DIFF
--- a/lib/Backends/Habana/CMakeLists.txt
+++ b/lib/Backends/Habana/CMakeLists.txt
@@ -1,7 +1,8 @@
 add_library(Habana
             Habana.cpp
             HabanaDeviceManager.cpp
-            HabanaFactory.cpp)
+            HabanaFactory.cpp
+            HabanaUtils.cpp)
 
 target_include_directories(Habana
                            PUBLIC

--- a/lib/Backends/Habana/Habana.cpp
+++ b/lib/Backends/Habana/Habana.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "Habana.h"
+#include "HabanaUtils.h"
 
 #include "glow/Graph/PlaceholderBindings.h"
 #include "glow/IR/IR.h"
@@ -542,9 +543,9 @@ llvm::Error HabanaFunction::execute(ExecutionContext *context) {
   auto res = synEnqueueByName(
       deviceId, inputInfo.empty() ? &noInputEti : inputInfo.data(),
       inputInfo.size(), outputInfo.data(), outputInfo.size(), &handle);
-  seEvent.addArg("result", std::to_string(res));
+  seEvent.addArg("result", statusStr(res));
   if (res != synSuccess) {
-    return chk_make_err(res);
+    return MAKE_ERR(strFormat("synEnqueueByName failed: %s", statusStr(res)));
   }
   TRACE_EVENT_SCOPE_END_NAMED(seEvent);
 

--- a/lib/Backends/Habana/HabanaUtils.cpp
+++ b/lib/Backends/Habana/HabanaUtils.cpp
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "HabanaUtils.h"
+
+namespace glow {
+const char *statusStr(synStatus status) {
+  static const char *strs[] = {
+      "Success",
+      "Invalid argument",
+      "Command buffer full",
+      "Out of host memory",
+      "Out of device memory",
+      "Object already initialized",
+      "Object not initialized",
+      "Command submission failed",
+      "No device found",
+      "Device type mismatch",
+      "Failed to initialize command buffer",
+      "Failed to free command buffer",
+      "Failed to map command buffer",
+      "Failed to unmap command buffer",
+      "Failed to allocate device memory",
+      "Failed to free device memory",
+      "Not enough devices found",
+      "Device reset",
+      "Unsupported",
+      "Wrong params file",
+      "Device already acquired",
+      "Failed",
+  };
+  static_assert(sizeof(strs) / sizeof(strs[0]) == synFail + 1);
+  if (status < synSuccess || status > synFail) {
+    return "Invalid status";
+  }
+  return strs[status];
+}
+} // namespace glow

--- a/lib/Backends/Habana/HabanaUtils.h
+++ b/lib/Backends/Habana/HabanaUtils.h
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef GLOW_BACKENDS_HABANA_HABANAUTILS_H
+#define GLOW_BACKENDS_HABANA_HABANAUTILS_H
+
+#include <synapse.h>
+
+namespace glow {
+const char *statusStr(synStatus status);
+}
+
+#endif // GLOW_BACKENDS_HABANA_HABANAUTILS_H


### PR DESCRIPTION
Summary:
The current error message simply gives a line number and the raw
status code; this diff decodes the status into a string and reports the failing
function.

There are probably other places that could use this treatment.  Will follow up
if this is accepted.

Differential Revision: D15997655

