### PR TITLE
[trivial] switch new OCL event to Complete event

### DIFF
--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -459,9 +459,11 @@ void OpenCLFunction::executeConvolution(const OCLConvolutionInst *CC,
     src.append(reinterpret_cast<const char *>(kernels_fwd_conv_cl_src),
                kernels_fwd_conv_cl_src_size);
   }
-  TRACE_EVENT_BEGIN(executionContext, TraceLevel::RUNTIME, "convCreateProgram");
+
+  TRACE_EVENT_SCOPE_NAMED(executionContext->getTraceContext(),
+                          TraceLevel::RUNTIME, "convCreateProgram", cpEvent);
   auto prog = createProgram(src, options, commands_);
-  TRACE_EVENT_END(executionContext, TraceLevel::RUNTIME, "convCreateProgram");
+  TRACE_EVENT_SCOPE_END_NAMED(cpEvent);
 
   auto kernelName = isQuantized ? "conv_forward_mem_i8" : "conv_forward_mem";
   auto kernel = createKernel(kernelName, prog);


### PR DESCRIPTION
Summary: Meghan added a new event to OCL Function, just changing it to a Complete event so a) trace size is smaller, and b) eliminates chance of a display bug in chome://tracing.

Documentation: 

Test Plan: unit tests + manual with tracing_compare

