### PR TITLE
[OpenCL] Add pool of reusable command queues

### DIFF
--- a/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
@@ -64,6 +64,77 @@ static llvm::Expected<unsigned> parseInputAsUnsigned(std::string input) {
   return parsed;
 }
 
+OpenCLCommandQueuePool::~OpenCLCommandQueuePool() {
+  // Make sure all queues have been returned to the pool.
+  DCHECK_EQ(queuesAllocated_, queuesAvailable_)
+      << "OpenCLCommandQueue destroyed before all queues returned!";
+  // For each properties -> vector of queues pair:
+  for (auto &kv : queues_) {
+    // For each queue in each vector:
+    for (auto &q : kv.second) {
+      // Release the backing queue.
+      cl_int err = clReleaseCommandQueue(q.backingQueue);
+      DCHECK_EQ(err, CL_SUCCESS)
+          << "clReleaseCommandQueue failed with error code " << err;
+    }
+  }
+}
+
+llvm::Expected<OpenCLCommandQueue> OpenCLCommandQueuePool::requestCommandQueue(
+    cl_command_queue_properties properties) {
+  OpenCLCommandQueue ret;
+  // Get the vector that has queues with the desired properties.
+  std::vector<OpenCLCommandQueue> &srcVec = queues_[properties];
+
+  if (srcVec.empty()) {
+    // The vector is empty. This means a new queus must be created.
+    cl_int err;
+    ret.props = properties;
+    ret.backingQueue =
+        clCreateCommandQueue(context_, device_, properties, &err);
+    RETURN_ERR_IF_NOT(err == CL_SUCCESS,
+                      strFormat("Unable to create command queue: %d", err));
+
+    // If queue creation succeeds, increment the total number of queues. Do not
+    // increment the number of available queues since the newly created one is
+    // about to be given away.
+    ++queuesAllocated_;
+    ++queuesAllocatedByProps_[properties];
+  } else {
+    ret = srcVec.back();
+    srcVec.pop_back();
+    --queuesAvailable_;
+    --queuesAvailableByProps_[properties];
+  }
+
+  return ret;
+}
+
+void OpenCLCommandQueuePool::returnCommandQueue(OpenCLCommandQueue &queue) {
+  // Check that the number of available queues is less than the number of
+  // allocated queues.
+  DCHECK_LE(queuesAvailable_, queuesAllocated_)
+      << "Available queues must be less than allocated queues";
+
+  // Get the vector that has queues with the desired properties.
+  std::vector<OpenCLCommandQueue> &destVec = queues_[queue.props];
+  ++queuesAvailable_;
+  ++queuesAvailableByProps_[queue.props];
+  destVec.emplace_back(std::move(queue));
+}
+
+unsigned OpenCLCommandQueuePool::getNumAllocatedQueuesForProperties(
+    cl_command_queue_properties props) const {
+  auto it = queuesAllocatedByProps_.find(props);
+  return it != queuesAllocatedByProps_.end() ? it->second : 0;
+}
+
+unsigned OpenCLCommandQueuePool::getNumQueuesAvailableForProperties(
+    cl_command_queue_properties props) const {
+  auto it = queuesAvailableByProps_.find(props);
+  return it != queuesAvailableByProps_.end() ? it->second : 0;
+}
+
 llvm::Expected<cl_mem> OpenCLDeviceManager::allocDeviceBuffer(uint64_t size) {
   const uint64_t alignment = 128;
   // Always allocate buffers properly aligned to hold values of any type.
@@ -158,6 +229,9 @@ llvm::Error OpenCLDeviceManager::init() {
   } else {
     maxMemoryBytes_ = mem_size;
   }
+
+  commandQueuePool_.setContext(context_);
+  commandQueuePool_.setDevice(deviceId_);
 
   return llvm::Error::success();
 }
@@ -305,21 +379,16 @@ void OpenCLDeviceManager::evictNetworkImpl(std::string functionName,
   evictCB(functionName, llvm::Error::success());
 }
 
-cl_command_queue
+llvm::Expected<OpenCLCommandQueue>
 OpenCLDeviceManager::requestRunCommandQueue(CompiledFunction *function) {
-  cl_int err;
   auto traceInfo = function->getTraceInfo();
-  cl_command_queue_properties profiling = 0;
-  if (clDoProfile || traceInfo.enabled) {
-    profiling = CL_QUEUE_PROFILING_ENABLE;
-  }
-  cl_command_queue commands =
-      clCreateCommandQueue(context_, deviceId_, profiling, &err);
-  return commands;
+  cl_command_queue_properties props =
+      clDoProfile || traceInfo.enabled ? CL_QUEUE_PROFILING_ENABLE : 0;
+  return commandQueuePool_.requestCommandQueue(props);
 }
 
-void OpenCLDeviceManager::returnRunCommandQueue(cl_command_queue commands) {
-  clReleaseCommandQueue(commands);
+void OpenCLDeviceManager::returnRunCommandQueue(OpenCLCommandQueue &queue) {
+  commandQueuePool_.returnCommandQueue(queue);
 }
 
 void OpenCLDeviceManager::runFunctionImpl(
@@ -340,20 +409,30 @@ void OpenCLDeviceManager::runFunctionImpl(
 
   CompiledFunction *func = funcIt->second;
 
+  TRACE_EVENT_SCOPE(context->getTraceContext(), TraceEvent::TraceLevel::RUNTIME,
+                    "requestRunCommandQueue");
   // Get a command queue for this run.
-  cl_command_queue commands = requestRunCommandQueue(func);
+  OpenCLCommandQueue queue;
+  auto queueOrError = requestRunCommandQueue(func);
 
+  if (queueOrError) {
+    queue = std::move(queueOrError.get());
+  } else {
+    resultCB(id, queueOrError.takeError(), std::move(context));
+  }
+
+  TRACE_EVENT_SCOPE_END();
   // Create and set deviceBindings for call. This contains all the state needed
   // for the function to run on a device.
   auto clBindings = llvm::make_unique<runtime::OpenCLDeviceBindings>(
-      buffers_[function]->getBuffer(), commands, deviceId_, context_);
+      buffers_[function]->getBuffer(), queue.backingQueue, deviceId_, context_);
   context->setDeviceBindings(std::move(clBindings));
 
   // Run that function.
   auto executeErr = func->execute(context.get());
 
   // Return the command queue.
-  returnRunCommandQueue(commands);
+  returnRunCommandQueue(queue);
 
   // End the TraceEvent early to avoid time in the CB.
   TRACE_EVENT_SCOPE_END_NAMED(dmRun);

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -325,6 +325,8 @@ if(GLOW_WITH_OPENCL)
   add_executable(OCLTest
                  OCLTest.cpp)
   target_link_libraries(OCLTest
+                        PUBLIC
+                          OpenCL::OpenCL
                         PRIVATE
                           BackendTestUtils
                           ExecutionEngine

--- a/tests/unittests/OCLTest.cpp
+++ b/tests/unittests/OCLTest.cpp
@@ -16,6 +16,12 @@
 
 #include "BackendTestUtils.h"
 
+// Silence Apple's warning about the deprecation of OpenCL.
+#define CL_SILENCE_DEPRECATION
+
+// Silence warnings about using deprecated OpenCL 1.2 functions.
+#define CL_USE_DEPRECATED_OPENCL_1_2_APIS
+
 #include "../../lib/Backends/OpenCL/OpenCLDeviceManager.h"
 #include "glow/Backends/DeviceManager.h"
 #include "glow/ExecutionEngine/ExecutionEngine.h"
@@ -24,6 +30,17 @@
 #include "glow/IR/IRBuilder.h"
 #include "glow/IR/Instrs.h"
 #include "gtest/gtest.h"
+
+/// Takes an llvm::Expected<T> \p rhsOrErrV, asserts that it is not an error,
+/// and takes the value from rhsOrErrV and assigns it to \p lhs.
+#define ASSERT_AND_ASSIGN_VALUE(lhs, rhsOrErrV)                                \
+  do {                                                                         \
+    if (rhsOrErrV) {                                                           \
+      lhs = std::move(rhsOrErrV.get());                                        \
+    } else {                                                                   \
+      ASSERT_TRUE(false);                                                      \
+    }                                                                          \
+  } while (0)
 
 using namespace glow;
 using llvm::cast;
@@ -131,4 +148,106 @@ TEST(OpenCLCorrectnessTest, SetDeviceMemory) {
   llvm::Error err3 = openCLDeviceLarger.init();
   ASSERT_FALSE(errToBool(std::move(err3)));
   EXPECT_EQ(openCLDeviceLarger.getMaximumMemory(), memSize);
+}
+
+class OpenCLCommandQueuePoolTest : public ::testing::Test {
+protected:
+  void SetUp() override {
+    // Get an OpenCL platform ID.
+    std::vector<cl_platform_id> platforms(1);
+    cl_int err = clGetPlatformIDs(1, platforms.data(), NULL);
+    ASSERT_EQ(err, CL_SUCCESS) << "clGetPlatformIDs failed.";
+
+    // Get an OpenCL device ID.
+    cl_platform_id platform_id_used = platforms[0];
+    std::vector<cl_device_id> devices(1);
+    err = clGetDeviceIDs(platform_id_used, CL_DEVICE_TYPE_ALL, 1,
+                         devices.data(), NULL);
+    ASSERT_EQ(err, CL_SUCCESS) << "clGetDeviceIDs failed";
+
+    // Create an OpenCL context.
+    device_ = devices[0];
+    context_ = clCreateContext(nullptr, 1, &device_, nullptr, nullptr, nullptr);
+    ASSERT_TRUE(context_) << "clCreateContext failed";
+
+    // Set the context and device on the pool to prepare for the tests.
+    pool_.setContext(context_);
+    pool_.setDevice(device_);
+  }
+
+  void TearDown() override {
+    // Release the context.
+    cl_int err = clReleaseContext(context_);
+    ASSERT_EQ(err, CL_SUCCESS) << "clReleaseContext failed";
+  }
+
+  cl_context context_{nullptr};
+  cl_device_id device_{0};
+  runtime::OpenCLCommandQueuePool pool_;
+};
+
+/// Tests that the command queue pool returns an error when a queue is requested
+/// but the pool is not correctly initialized.
+TEST_F(OpenCLCommandQueuePoolTest, ErrorWhenNotInitialized) {
+  // Set the context and device to nonsensical values.
+  pool_.setContext(nullptr);
+  pool_.setDevice(0);
+
+  // A request for a command queue should return an llvm::Error.
+  ASSERT_FALSE(pool_.requestCommandQueue());
+}
+
+/// Tests that the pool reuses queues.
+TEST_F(OpenCLCommandQueuePoolTest, QueueReuse) {
+  cl_command_queue backingQueue1, backingQueue2;
+  runtime::OpenCLCommandQueue queue;
+
+  // Request a queue.
+  llvm::Expected<runtime::OpenCLCommandQueue> queueOrError =
+      pool_.requestCommandQueue(0);
+  ASSERT_AND_ASSIGN_VALUE(queue, queueOrError);
+  backingQueue1 = queue.backingQueue;
+
+  // Put it back and request another.
+  pool_.returnCommandQueue(queue);
+  queueOrError = pool_.requestCommandQueue(0);
+  ASSERT_AND_ASSIGN_VALUE(queue, queueOrError);
+  backingQueue2 = queue.backingQueue;
+
+  // The retuned queues should have been the same and only one should have been
+  // allocated.
+  EXPECT_EQ(backingQueue1, backingQueue2);
+  EXPECT_EQ(pool_.getNumAllocatedQueues(), 1);
+  EXPECT_EQ(pool_.getNumAllocatedQueuesForProperties(0), 1);
+
+  pool_.returnCommandQueue(queue);
+}
+
+/// Tests that the pool does not reuse queues if the requested properties are
+/// different.
+TEST_F(OpenCLCommandQueuePoolTest, NoQueueReuseWithDifferentProps) {
+  cl_command_queue backingQueue1, backingQueue2;
+  runtime::OpenCLCommandQueue queue;
+
+  // Request a queue.
+  llvm::Expected<runtime::OpenCLCommandQueue> queueOrError =
+      pool_.requestCommandQueue(0);
+  ASSERT_AND_ASSIGN_VALUE(queue, queueOrError);
+  backingQueue1 = queue.backingQueue;
+
+  // Put it back and request another with profiling enabled.
+  pool_.returnCommandQueue(queue);
+  queueOrError = pool_.requestCommandQueue(CL_QUEUE_PROFILING_ENABLE);
+  ASSERT_AND_ASSIGN_VALUE(queue, queueOrError);
+  backingQueue2 = queue.backingQueue;
+
+  // The retuned queues should not have been the same and two should have been
+  // allocated; one with profiling enabled and one without.
+  EXPECT_NE(backingQueue1, backingQueue2);
+  EXPECT_EQ(pool_.getNumAllocatedQueues(), 2);
+  EXPECT_EQ(pool_.getNumAllocatedQueuesForProperties(0), 1);
+  EXPECT_EQ(pool_.getNumAllocatedQueuesForProperties(CL_QUEUE_PROFILING_ENABLE),
+            1);
+
+  pool_.returnCommandQueue(queue);
 }


### PR DESCRIPTION
**Description**
The creation of OpenCL command queues can take varying amounts of time
depending on the implementation. This commit adds
`OpenCLCommandQueuePool`, a class that manages a pool of command queues
separated by their queue properties and reuses queues when possible
instead of allocating a new one (which it does when all else fails).

**Test Plan**
Manual examination of traces, new unit tests.

DLRM training trace before this diff:
![Screen Shot 2019-06-25 at 6 53 59 PM](https://user-images.githubusercontent.com/4392003/60145355-9f8af880-977a-11e9-81d0-b77d467fbf90.png)

DLRM training trace after this diff:
![Screen Shot 2019-06-25 at 6 53 20 PM](https://user-images.githubusercontent.com/4392003/60145361-a285e900-977a-11e9-8a20-e871d7ca87a3.png)

Each minibatch (after the first one) takes around 6 ms instead of 17 ms (65% reduction).
