### PR TITLE
Bug fixes to partitioner; some restructuring

### DIFF
--- a/include/glow/Backends/DeviceManager.h
+++ b/include/glow/Backends/DeviceManager.h
@@ -102,6 +102,10 @@ public:
 
   /// \returns the DeviceConfig which initialized this device.
   const DeviceConfig &getDeviceConfig() { return config_; }
+
+  /// \returns the DeviceInfo for this device containing peak limits for
+  /// compute and bandwidths (used in partitioning).
+  virtual DeviceInfo getDeviceInfo() const { return DeviceInfo(); }
 };
 
 } // namespace runtime

--- a/lib/Backends/CPU/CPUDeviceManager.cpp
+++ b/lib/Backends/CPU/CPUDeviceManager.cpp
@@ -50,6 +50,17 @@ bool CPUDeviceManager::isMemoryAvailable(uint64_t estimate) const {
   return maxMemoryBytes_ >= (usedMemoryBytes_ + estimate);
 }
 
+DeviceInfo CPUDeviceManager::getDeviceInfo() const {
+  // TODO: these may need to be tweaked depending on specific CPU.
+  DeviceInfo info = DeviceInfo();
+  info.sramCapacity = 256 * 1024 * 1024;
+  info.peakCompute = 2.2 * 1024 * 1024 * 1024 * 1024;
+  info.peakDramBw = 110.0 * 1024 * 1024 * 1024;
+  info.peakSramBw = 1024.0 * 1024 * 1024 * 1024;
+  info.peakPCIeBw = 16.0 * 1024 * 1024 * 1024;
+  return info;
+}
+
 void CPUDeviceManager::addNetworkImpl(const Module *module,
                                       FunctionMapTy functions,
                                       ReadyCBTy readyCB) {

--- a/lib/Backends/CPU/CPUDeviceManager.h
+++ b/lib/Backends/CPU/CPUDeviceManager.h
@@ -56,6 +56,10 @@ public:
   /// etc.
   bool isMemoryAvailable(uint64_t estimate) const override;
 
+  /// Returns the DeviceInfo for this device containing peak limits for
+  /// compute and bandwidths (used in partitioning).
+  DeviceInfo getDeviceInfo() const override;
+
 protected:
   void addNetworkImpl(const Module *module, FunctionMapTy functions,
                       ReadyCBTy cb) override;

--- a/lib/Backends/Habana/HabanaDeviceManager.cpp
+++ b/lib/Backends/Habana/HabanaDeviceManager.cpp
@@ -439,3 +439,13 @@ uint64_t HabanaDeviceManager::getAvailableMemory() const { return freeMemory_; }
 bool HabanaDeviceManager::isMemoryAvailable(uint64_t estimate) const {
   return estimate <= freeMemory_;
 }
+
+DeviceInfo HabanaDeviceManager::getDeviceInfo() const {
+  DeviceInfo info = DeviceInfo();
+  info.sramCapacity = 50 * 1024 * 1024;
+  info.peakCompute = 0.45 * 1024 * 1024 * 1024 * 1024;
+  info.peakDramBw = 30.0 * 1024 * 1024 * 1024;
+  info.peakSramBw = 1024.0 * 1024 * 1024 * 1024;
+  info.peakPCIeBw = 16.0 * 1024 * 1024 * 1024;
+  return info;
+}

--- a/lib/Backends/Habana/HabanaDeviceManager.h
+++ b/lib/Backends/Habana/HabanaDeviceManager.h
@@ -138,6 +138,10 @@ public:
   uint64_t getMaximumMemory() const override;
   uint64_t getAvailableMemory() const override;
   bool isMemoryAvailable(uint64_t estimate) const override;
+
+  /// Returns the DeviceInfo for this device containing peak limits for
+  /// compute and bandwidths (used in partitioning).
+  DeviceInfo getDeviceInfo() const override;
 };
 
 } // namespace runtime

--- a/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
@@ -51,6 +51,17 @@ bool InterpreterDeviceManager::isMemoryAvailable(uint64_t estimate) const {
   return maxMemoryBytes_ >= (usedMemoryBytes_ + estimate);
 }
 
+DeviceInfo InterpreterDeviceManager::getDeviceInfo() const {
+  // TODO: these may need to be tweaked depending on interpreter overheads.
+  DeviceInfo info = DeviceInfo();
+  info.sramCapacity = 256 * 1024 * 1024;
+  info.peakCompute = 2.2 * 1024 * 1024 * 1024 * 1024;
+  info.peakDramBw = 110.0 * 1024 * 1024 * 1024;
+  info.peakSramBw = 1024.0 * 1024 * 1024 * 1024;
+  info.peakPCIeBw = 16.0 * 1024 * 1024 * 1024;
+  return info;
+}
+
 void InterpreterDeviceManager::addNetworkImpl(const Module *module,
                                               FunctionMapTy functions,
                                               ReadyCBTy readyCB) {

--- a/lib/Backends/Interpreter/InterpreterDeviceManager.h
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.h
@@ -56,6 +56,10 @@ public:
   /// etc.
   bool isMemoryAvailable(uint64_t estimate) const override;
 
+  /// Returns the DeviceInfo for this device containing peak limits for
+  /// compute and bandwidths (used in partitioning).
+  DeviceInfo getDeviceInfo() const override;
+
 protected:
   void addNetworkImpl(const Module *module, FunctionMapTy functions,
                       ReadyCBTy cb) override;

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -87,9 +87,10 @@ llvm::Error HostManager::addNetwork(std::unique_ptr<Module> module,
   }
   std::vector<DeviceInfo> deviceInfo;
   for (auto &device : devices_) {
-    DeviceInfo info = DeviceInfo();
+    DeviceInfo info = device.second->getDeviceInfo();
     info.availableMemory = device.second->getAvailableMemory();
     info.backendName = device.second->getBackendName();
+    VLOG(1) << "AVAILABLE DEVICE MEMORY " << info.availableMemory << "\n";
     deviceInfo.push_back(info);
   }
   // Perform a round of target-independent graph optimizations. This helps the


### PR DESCRIPTION
Summary: Bug fixes to performance model in partitioning. Restructure to have DeviceInfo returned by DeviceManagers.

Details:
The changes made are: 
(1) Add compute costs for more kinds of nodes and Habana specific backend nodes
(2) Nits to remove doxygen style comments (from phabricator comments)
(3) Add a getDeviceInfo() function to enable onnxifi path for calling into the roofline.
Differential Revision: D15999942

