### PR TITLE
[Operators] Support casts i32<->i64<->float<->float16 in Interpreter

### DIFF
--- a/include/glow/Support/Float16.h
+++ b/include/glow/Support/Float16.h
@@ -65,7 +65,8 @@ public:
   /// Cast operators.
   operator double() const { return double(operator float()); }
   operator float() const { return fp16_ieee_to_fp32_value(data_); }
-  operator long long() const { return static_cast<long long>(data_); }
+  operator int64_t() const { return static_cast<int64_t>(data_); }
+  operator int32_t() const { return static_cast<int32_t>(data_); }
 }; // End class float16.
 
 /// Allow float16_t to be passed to an ostream.

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -308,16 +308,21 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
   case Kinded::Kind::IntLookupTableNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind({ElemKind::Int8QTy});
 
-  case Kinded::Kind::ConvertToNodeKind:
-    return ((NI.getInElemTy(ConvertToNode::InputIdx) == ElemKind::FloatTy) &&
-            ((NI.getOutElemTy(ConvertToNode::ResultIdx) ==
-              ElemKind::Float16Ty) ||
-             (NI.getOutElemTy(ConvertToNode::ResultIdx) ==
-              ElemKind::Int64ITy))) ||
-           ((NI.getInElemTy(ConvertToNode::InputIdx) == ElemKind::Float16Ty) &&
-            (NI.getOutElemTy(ConvertToNode::ResultIdx) == ElemKind::FloatTy)) ||
-           ((NI.getInElemTy(ConvertToNode::InputIdx) == ElemKind::Int64ITy) &&
-            (NI.getOutElemTy(ConvertToNode::ResultIdx) == ElemKind::FloatTy));
+  case Kinded::Kind::ConvertToNodeKind: {
+    auto isConversionSupportedFor = [](ElemKind kind) {
+      switch (kind) {
+      case ElemKind::Float16Ty:
+      case ElemKind::FloatTy:
+      case ElemKind::Int32ITy:
+      case ElemKind::Int64ITy:
+        return true;
+      default:
+        return false;
+      }
+    };
+    return isConversionSupportedFor(NI.getInElemTy(ConvertToNode::InputIdx)) &&
+           isConversionSupportedFor(NI.getOutElemTy(ConvertToNode::ResultIdx));
+  }
 
   case Kinded::Kind::TopKNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -7066,40 +7066,29 @@ static void testConvertTo(glow::PlaceholderBindings &bindings_,
   }
 }
 
-/// Test that ConvertTo operator casts correctly from Int64 to Float.
-TEST_P(OperatorTest, ConvertFromInt64ToFloat) {
-  ENABLED_BACKENDS(Interpreter);
-  testConvertTo<int64_t, float>(bindings_, mod_, F_, EE_, ElemKind::Int64ITy,
-                                ElemKind::FloatTy);
-}
+/// Test that ConvertTo operator casts correctly from one type to another.
+#define TEST_CONVERT_TO(T_FROM, T_TO, DTY_FROM, DTY_TO)                        \
+  TEST_P(OperatorTest, ConvertFrom_##T_FROM##_To_##T_TO) {                     \
+    ENABLED_BACKENDS(Interpreter);                                             \
+    testConvertTo<T_FROM, T_TO>(bindings_, mod_, F_, EE_, DTY_FROM, DTY_TO);   \
+  }
+TEST_CONVERT_TO(float, float, ElemKind::FloatTy, ElemKind::FloatTy)
+TEST_CONVERT_TO(float, float16_t, ElemKind::FloatTy, ElemKind::Float16Ty)
+TEST_CONVERT_TO(float, int32_t, ElemKind::FloatTy, ElemKind::Int32ITy)
+TEST_CONVERT_TO(float, int64_t, ElemKind::FloatTy, ElemKind::Int64ITy)
+TEST_CONVERT_TO(float16_t, float, ElemKind::Float16Ty, ElemKind::FloatTy)
+TEST_CONVERT_TO(float16_t, float16_t, ElemKind::Float16Ty, ElemKind::Float16Ty)
+TEST_CONVERT_TO(float16_t, int32_t, ElemKind::Float16Ty, ElemKind::Int32ITy)
+TEST_CONVERT_TO(float16_t, int64_t, ElemKind::Float16Ty, ElemKind::Int64ITy)
+TEST_CONVERT_TO(int32_t, float, ElemKind::Int32ITy, ElemKind::FloatTy)
+TEST_CONVERT_TO(int32_t, float16_t, ElemKind::Int32ITy, ElemKind::Float16Ty)
+TEST_CONVERT_TO(int32_t, int32_t, ElemKind::Int32ITy, ElemKind::Int32ITy)
+TEST_CONVERT_TO(int32_t, int64_t, ElemKind::Int32ITy, ElemKind::Int64ITy)
+TEST_CONVERT_TO(int64_t, float, ElemKind::Int64ITy, ElemKind::FloatTy)
+TEST_CONVERT_TO(int64_t, float16_t, ElemKind::Int64ITy, ElemKind::Float16Ty)
+TEST_CONVERT_TO(int64_t, int32_t, ElemKind::Int64ITy, ElemKind::Int32ITy)
+TEST_CONVERT_TO(int64_t, int64_t, ElemKind::Int64ITy, ElemKind::Int64ITy)
 
-/// Test that ConvertTo operator casts correctly from Float to Int64.
-TEST_P(OperatorTest, ConvertFromFloatToInt64) {
-  ENABLED_BACKENDS(Interpreter);
-  testConvertTo<float, int64_t>(bindings_, mod_, F_, EE_, ElemKind::FloatTy,
-                                ElemKind::Int64ITy);
-}
-
-/// Test that ConvertTo operator casts correctly from Float16 to Float.
-TEST_P(OperatorTest, ConvertFromFloat16ToFloat) {
-  ENABLED_BACKENDS(Interpreter);
-  testConvertTo<float16_t, float>(bindings_, mod_, F_, EE_, ElemKind::Float16Ty,
-                                  ElemKind::FloatTy);
-}
-
-/// Test that ConvertTo operator casts correctly from Float to Float16.
-TEST_P(OperatorTest, ConvertFromFloatToFloat16) {
-  ENABLED_BACKENDS(Interpreter);
-  testConvertTo<float, float16_t>(bindings_, mod_, F_, EE_, ElemKind::FloatTy,
-                                  ElemKind::Float16Ty);
-}
-
-/// Test that ConvertTo operator casts correctly from Float to Float. This is a
-/// noop, but can happen on unoptimized graphs.
-TEST_P(OperatorTest, ConvertFromFloatToFloat) {
-  ENABLED_BACKENDS(Interpreter);
-  testConvertTo<float, float>(bindings_, mod_, F_, EE_, ElemKind::FloatTy,
-                              ElemKind::FloatTy);
-}
+#undef TEST_CONVERT_TO
 
 #undef ENABLED_BACKENDS


### PR DESCRIPTION
The main purpose of that is constant-folding, that is why only the interpreter
backend is supported so far. Can be done for CPU backend separately if needed.

Test Plan:
Added unit tests.

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
