### PR TITLE
Generalize types of arithmetic operations in Interpreter

### DIFF
--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -74,6 +74,10 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
   case Kinded::Kind::MulNodeKind:
   case Kinded::Kind::MaxNodeKind:
   case Kinded::Kind::MinNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+        {ElemKind::FloatTy, ElemKind::Float16Ty, ElemKind::Int8QTy,
+         ElemKind::Int32ITy, ElemKind::Int64ITy});
+
   case Kinded::Kind::AvgPoolNodeKind:
   case Kinded::Kind::MaxPoolNodeKind:
   case Kinded::Kind::MatMulNodeKind:

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -172,11 +172,11 @@ private:
 
   void fwdElementAddInstI8Impl(const ElementAddInst *I);
   template <typename ElemTy>
-  void fwdElementAddInstFloatImpl(const ElementAddInst *I);
+  void fwdElementAddInstArithmeticImpl(const ElementAddInst *I);
 
   void fwdElementMaxInstI8Impl(const ElementMaxInst *I);
   template <typename ElemTy>
-  void fwdElementMaxInstFloatImpl(const ElementMaxInst *I);
+  void fwdElementMaxInstArithmeticImpl(const ElementMaxInst *I);
 
   template <typename ElemTy>
   void fwdBatchedAddInstFloatImpl(const BatchedAddInst *I);
@@ -202,13 +202,13 @@ private:
       const glow::LocalResponseNormalizationInst *I);
 
   template <typename ElemTy>
-  void fwdElementSubInstFloatImpl(const ElementSubInst *I);
+  void fwdElementSubInstArithmeticImpl(const ElementSubInst *I);
 
   template <typename ElemTy>
-  void fwdElementMulInstFloatImpl(const ElementMulInst *I);
+  void fwdElementMulInstArithmeticImpl(const ElementMulInst *I);
 
   template <typename ElemTy>
-  void fwdElementMinInstFloatImpl(const ElementMinInst *I);
+  void fwdElementMinInstArithmeticImpl(const ElementMinInst *I);
 
   template <typename ElemTy>
   void fwdElementCmpLTEInstFloatImpl(const ElementCmpLTEInst *I);


### PR DESCRIPTION
Summary:
This patch makes operations Add, Sub, Mul, Max and Min support integral types as
well as they support float. The main purpose of that is constant folding, that
is why only Interpreter backend is supported so far.

Test Plan:
Added unit tests.
