### PR TITLE
[ci] Extract opencl into separate test.

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -89,13 +89,13 @@ elif [[ "$CIRCLE_JOB" == "COVERAGE" ]]; then
           ../
 elif [[ "$CIRCLE_JOB" == "CHECK_CLANG_FORMAT" ]]; then
     sudo apt-get install -y clang-format-7
-else
+elif [[ "$CIRCLE_JOB" == "OPENCL" ]]; then
     install_pocl
+    CMAKE_ARGS+=("-DGLOW_WITH_OPENCL=ON")
+else
     CMAKE_ARGS+=("-DCMAKE_BUILD_TYPE=Debug")
     if [[ "${CIRCLE_JOB}" == "SHARED" ]]; then
         CMAKE_ARGS+=("-DBUILD_SHARED_LIBS=ON")
-    else
-        CMAKE_ARGS+=("-DGLOW_WITH_OPENCL=ON")
     fi
 fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,10 @@ jobs:
     environment:
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:283"
     <<: *linux_default
+  OPENCL:
+    environment:
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:283"
+    <<: *linux_default 
   ASAN:
     environment:
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:283"
@@ -102,6 +106,7 @@ workflows:
   build:
     jobs:
       - DEBUG
+      - OPENCL
       - ASAN
       - TSAN
       - SHARED

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -50,8 +50,9 @@ run_and_check_resnet50_bundle() {
 cd "${GLOW_BUILD_DIR}"
 case ${CIRCLE_JOB} in
     ASAN)
-        # ASAN is not enabled in onnx, therefore we should skip it for now.
-        # TODO: Enable ASAN test.
+        run_unit_tests check
+        ;;
+    OPENCL)
         run_unit_tests check
         ;;
     TSAN)
@@ -62,11 +63,9 @@ case ${CIRCLE_JOB} in
         run_unit_tests check
         run_unit_tests test_unopt
         ;;
-
     SHARED)
         # No tests with shared libs; it's similar to DEBUG.
         ;;
-
     RELEASE_WITH_EXPENSIVE_TESTS)
         run_unit_tests check_expensive
         run_and_check_lenet_mnist_bundle
@@ -83,7 +82,7 @@ case ${CIRCLE_JOB} in
         ./utils/format.sh check
         ;;
     *)
-        echo "Error, '${CIRCLE_JOB}' not valid mode; Must be one of {ASAN, TSAN, DEBUG, SHARED, RELEASE_WITH_EXPENSIVE_TESTS}."
+        echo "Error, '${CIRCLE_JOB}' not valid mode; Please, check .circleci/test.sh for list of supported tests."
         exit 1
         ;;
 esac


### PR DESCRIPTION
Summary:
* OpenCL ci test runs are flaky, those needs to be fixed separately.
* Extract opencl runs out of the debug runs. Current level of parallelism should allow us to keep total execution time low.

Documentation:
n/a

Test Plan:
ci