### PR TITLE
Disable tests that depend on Gather

### DIFF
--- a/tests/unittests/HabanaBackendTest.cpp
+++ b/tests/unittests/HabanaBackendTest.cpp
@@ -1650,6 +1650,8 @@ TEST_F(HabanaBackendTest, FCPerf) {
 }
 
 // Test performance of Gather.
+#if 0
+// Disable Gather tests since Gather appears to be broken.
 TEST_F(HabanaBackendTest, GatherPerf) {
   // Create function.
   auto *data = mod_.createPlaceholder(ElemKind::FloatTy, {50}, "data", false);
@@ -1780,6 +1782,7 @@ TEST_F(HabanaBackendTest, BatchedGatherMultipleRuns) {
     }
   }
 }
+#endif
 
 TEST_F(HabanaBackendTest, MergeFCRelu) {
   auto *FCi = mod_.createPlaceholder(ElemKind::FloatTy, {2, 2}, "input", false);

--- a/tests/unittests/RecommendationSystemTest.cpp
+++ b/tests/unittests/RecommendationSystemTest.cpp
@@ -879,7 +879,7 @@ TEST_P(RecommendationSystemTest, RecSys_SLS_Only) {
 
 /// Test gathering weights for SLWS.
 TEST_P(RecommendationSystemTest, RecSys_FP32_Gather_Weights) {
-  ENABLED_BACKENDS(CPU, Habana);
+  ENABLED_BACKENDS(CPU);
 
   testRecSys(/* quantizeSLWS */ false,
              /* quantizeFC */ false,
@@ -889,7 +889,7 @@ TEST_P(RecommendationSystemTest, RecSys_FP32_Gather_Weights) {
 
 /// Test gathering weights for SLWS.
 TEST_P(RecommendationSystemTest, RecSys_FP32_Medium_Gather_Weights) {
-  ENABLED_BACKENDS(CPU, Habana);
+  ENABLED_BACKENDS(CPU);
 
   // Note that this overrides the parameters provided by command line options if
   // provided, as this comes after SetUp().


### PR DESCRIPTION
Summary:
Gather is disabled on Habana because it appears to cause sporadic
problems in large nets.

Reviewed By: rdzhabarov

Differential Revision: D16036090

