### PR TITLE
Truncate 64-bit indices to 32

### DIFF
--- a/lib/Backends/Habana/Habana.h
+++ b/lib/Backends/Habana/Habana.h
@@ -271,10 +271,20 @@ private:
   /// Build the list of input and output placeholders.
   void findIOPlaceholders(Function *F);
 
+  /// Path to the saved recipe file.
   std::string recipeName_;
+
+  /// List of model input placeholders.
   PlaceholderList inputs_;
+
+  /// List of model output placeholders.
   PlaceholderList outputs_;
+
+  /// Set of inputs that can be partial tensors.
   std::unordered_set<const Placeholder *> partialInputs_;
+
+  /// Set of inputs that are 64-bit ints.
+  std::unordered_set<const Placeholder *> downcastInt64Inputs_;
 };
 
 } // namespace glow


### PR DESCRIPTION
Summary:
We've found that PCIe transfers are a bottleneck for networks that do
a large number of embedding lookups.  Part of the problem is that these indices
are often unnecessarily specified as int64 due to ML framework defaults.
Ideally we'd fix the framework, but as a workaround we forcibly truncate these indices to 32 bits.

Differential Revision: D15609734

