### PR TITLE
[Loader] Allow loading uint8 for fused sls and avoid weights duplication.

### DIFF
--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -118,7 +118,7 @@ bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
   case Kinded::Kind::RowwiseQuantizedSparseLengthsWeightedSumNodeKind:
     return (NI.getInElemTy(
                 RowwiseQuantizedSparseLengthsWeightedSumNode::DataIdx) ==
-            ElemKind::Int8QTy) &&
+            ElemKind::UInt8QTy) &&
            (NI.getInElemTy(
                 RowwiseQuantizedSparseLengthsWeightedSumNode::ScalesIdx) ==
             ElemKind::FloatTy) &&

--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -1194,7 +1194,7 @@ void libjit_sparse_lengths_weighted_sum_grad_f(
 }
 
 void libjit_rowwise_quantized_sparse_lengths_weighted_sum_f(
-    float *dest, int8_t *data, float *scales, float *offsets, float *weights,
+    float *dest, uint8_t *data, float *scales, float *offsets, float *weights,
     size_t *indices, int32_t *lengths, size_t segments, size_t lineSize) {
   memset(dest, 0, segments * lineSize * sizeof(float));
   size_t curIndex = 0;
@@ -1205,8 +1205,7 @@ void libjit_rowwise_quantized_sparse_lengths_weighted_sum_f(
       const float scale = scales[line];
       const float offset = offsets[line];
       for (size_t k = 0; k < lineSize; k++) {
-        const float fData =
-            (scale * ((uint8_t)(data[line * lineSize + k] + 128))) + offset;
+        const float fData = scale * data[line * lineSize + k] + offset;
         dest[i * lineSize + k] += weight * fData;
       }
       curIndex++;

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -228,7 +228,7 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
   case Kinded::Kind::RowwiseQuantizedSparseLengthsWeightedSumNodeKind:
     return (NI.getInElemTy(
                 RowwiseQuantizedSparseLengthsWeightedSumNode::DataIdx) ==
-            ElemKind::Int8QTy) &&
+            ElemKind::UInt8QTy) &&
            (NI.getInElemTy(
                 RowwiseQuantizedSparseLengthsWeightedSumNode::ScalesIdx) ==
             ElemKind::FloatTy) &&

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -2728,7 +2728,7 @@ void BoundInterpreterFunction::fwdRowwiseQuantizedSparseLengthsWeightedSumInst(
 
   size_t lineSize = data->size() / data->dims()[0];
 
-  auto DH = data->getHandle<int8_t>();
+  auto DH = data->getHandle<uint8_t>();
   auto DSH = dataScales->getHandle<float>();
   auto DOH = dataOffsets->getHandle<float>();
   auto WH = weights->getHandle<float>();

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -770,7 +770,7 @@ Function::createRowwiseQuantizedFullyConnected(llvm::StringRef name,
   }
 
   // Note: Using int32_t offset here as that is what RWQ-FC expects.
-  quantization::tensorRowwiseQuantization<int32_t>(
+  quantization::tensorRowwiseQuantization<int32_t, int8_t>(
       wt, qWeights->getPayloadMutable(), scales->getPayloadMutable(),
       offsets->getPayloadMutable(), schema);
 
@@ -1481,15 +1481,15 @@ quantizeDataAndCreateRowwiseQuantizedSparseLengthsWeightedSum(
   // Note: In rwqData, we are using a quantized type, however the scale/offset
   // are set to dummy values 0.0/0. This is because the actually used
   // scale/offset come from dataScales and dataOffsets.
-  Constant *rwqData =
-      F->getParent()->createConstant(ElemKind::Int8QTy, inDims, 0.0, 0, "data");
+  Constant *rwqData = F->getParent()->createConstant(ElemKind::UInt8QTy, inDims,
+                                                     0.0, 0, "data");
   Constant *dataScales = F->getParent()->createConstant(
       ElemKind::FloatTy, {inDims[0]}, "dataScales");
   Constant *dataOffsets = F->getParent()->createConstant(
       ElemKind::FloatTy, {inDims[0]}, "dataOffsets");
 
   // Note: Using float offset here as that is what RWQ-SLWS expects.
-  quantization::tensorRowwiseQuantization<float>(
+  quantization::tensorRowwiseQuantization<float, uint8_t>(
       data, rwqData->getPayloadMutable(), dataScales->getPayloadMutable(),
       dataOffsets->getPayloadMutable(), schema);
   return F->createRowwiseQuantizedSparseLengthsWeightedSum(

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -974,7 +974,7 @@ bool SparseLengthsWeightedSumGradNode::verify() const {
 
 bool RowwiseQuantizedSparseLengthsWeightedSumNode::verify() const {
   bool isValid = checkType(getResult(), ElemKind::FloatTy, this);
-  isValid &= checkType(getData(), ElemKind::Int8QTy, this);
+  isValid &= checkType(getData(), ElemKind::UInt8QTy, this);
   isValid &= checkType(getScales(), ElemKind::FloatTy, this);
   isValid &= checkType(getOffsets(), ElemKind::FloatTy, this);
   isValid &= checkType(getWeights(), ElemKind::FloatTy, this);

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -91,8 +91,9 @@ createAndSetTensorType(const caffe2::TensorProto &in) {
     result.t->reset(ElemKind::Int32ITy, dim);
   } else if (in.data_type() == caffe2::TensorProto::INT64) {
     result.t->reset(ElemKind::Int64ITy, dim);
-  } else if (in.data_type() == caffe2::TensorProto::UINT8 ||
-             in.data_type() == caffe2::TensorProto::INT8) {
+  } else if (in.data_type() == caffe2::TensorProto::UINT8) {
+    result.t->reset(ElemKind::UInt8QTy, dim, 1.0, 0);
+  } else if (in.data_type() == caffe2::TensorProto::INT8) {
     result.t->reset(ElemKind::Int8QTy, dim, 1.0, 0);
   } else {
     RETURN_ERR("Only float and index tensors are supported");
@@ -1443,7 +1444,7 @@ llvm::Error Caffe2ModelLoader::loadWeight(const caffe2::OperatorDef &op) {
 
       size_t pos;
       for (pos = 0; pos < str.size(); pos++) {
-        TH.raw(pos) = (uint8_t)str.c_str()[pos];
+        TH.raw(pos) = (uint8_t)str[pos];
       }
 
       RETURN_ERR_IF_NOT(

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -1149,23 +1149,17 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     Node *node;
     if (isFused) {
       // There is no specific fused quantized type in Caffe2, so we will load
-      // Int8QTy. We then change it from Int8QTy to UInt8FusedQTy here if
+      // UInt8QTy. We then change it from UInt8QTy to UInt8FusedQTy here if
       // necessary -- another user could have already changed it.
       if (dataC->getElementType() != ElemKind::UInt8FusedQTy) {
-        RETURN_ERR_IF_NOT(dataC->getElementType() == ElemKind::Int8QTy,
-                          "Data must be Int8QTy.");
+        RETURN_ERR_IF_NOT(dataC->getElementType() == ElemKind::UInt8QTy,
+                          "Data must be UInt8QTy.");
         // Use dummy 0.0/0 as scale/offset, since the actual scales/offsets
         // are fused inline with the data.
         TypeRef fusedTy = G_.getParent()->uniqueType(ElemKind::UInt8FusedQTy,
                                                      dataC->dims(), 0.0, 0);
         dataC->setType(Storage::OutputIdx, fusedTy);
-        dataC->getPayloadMutable().setType(fusedTy);
-
-        // We also need to update the data to be unsigned instead of signed.
-        auto dataCH = dataC->getHandle<uint8_t>();
-        for (size_t i = 0, e = dataCH.size(); i < e; i++) {
-          dataCH.raw(i) = dataCH.raw(i) + OFFSETSHIFT;
-        }
+        dataC->setPayloadType(fusedTy);
       }
 
       // No other work to do, since the data is already loaded fused, so just
@@ -1440,23 +1434,23 @@ llvm::Error Caffe2ModelLoader::loadWeight(const caffe2::OperatorDef &op) {
         continue;
       }
       auto dim = getShape(dict["shape"]);
-
-      T.reset(ElemKind::Int8QTy, dim, 0.0, 0);
-      auto TH = T.getHandle<int8_t>();
+      T.reset(ElemKind::UInt8QTy, dim, 0.0, 0);
+      auto TH = T.getHandle<uint8_t>();
       RETURN_ERR_IF_NOT(
           dict["values"]->strings().size() == 1,
           "Expect single string input for GivenTensorByteStringToUInt8Fill");
-      const std::string str = dict["values"]->strings().Get(0);
+      const std::string &str = dict["values"]->strings().Get(0);
 
-      // We're loading unsigned data into Int8QTy, so we use OFFSETSHIFT to
-      // convert to signed.
-      size_t i;
-      for (i = 0; i < str.size(); i++) {
-        TH.raw(i) = (uint8_t)str.c_str()[i] - OFFSETSHIFT;
+      size_t pos;
+      for (pos = 0; pos < str.size(); pos++) {
+        TH.raw(pos) = (uint8_t)str.c_str()[pos];
       }
-      RETURN_ERR_IF_NOT(i == T.size(),
-                        "The number of serialized values does not "
-                        "match the size of the tensor.");
+
+      RETURN_ERR_IF_NOT(
+          pos == T.size(),
+          strFormat("The number of serialized values (%li) does not "
+                    "match the size of the tensor (%li).",
+                    pos, T.size()));
       RETURN_IF_ERR(createAndRegisterConstant(o, std::move(T)));
     }
     return llvm::Error::success();
@@ -1696,7 +1690,6 @@ Caffe2ModelLoader::Caffe2ModelLoader(const std::string &netDescFilename,
     // This is to ensure that the same processing done with
     // the same network, even if order of operators is different.
     F.orderNodes();
-
     RETURN_ERR_IF_NOT(F.verify(), "Function verification failed.");
 
     deleteUnusedConstants();

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -322,6 +322,9 @@ llvm::Value *LLVMIRGen::emitValueAddress(llvm::IRBuilder<> &builder,
   case ElemKind::Int8QTy:
     T = llvm::Type::getInt8PtrTy(ctx_);
     break;
+  case ElemKind::UInt8QTy:
+    T = llvm::Type::getInt8PtrTy(ctx_);
+    break;
   case ElemKind::Int16QTy:
     T = llvm::Type::getInt16PtrTy(ctx_);
     break;
@@ -341,8 +344,8 @@ llvm::Value *LLVMIRGen::emitValueAddress(llvm::IRBuilder<> &builder,
     T = llvm::Type::getInt8PtrTy(ctx_);
     break;
   default:
-    llvm_unreachable("Unimplemented");
-    break;
+    LOG(FATAL) << "Unsupported element type: "
+               << Type::getElementName(val->getElementType()).str();
   }
 
   assert(allocationsInfo_.valueNumbers_.count(val));

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -901,9 +901,10 @@ generateNodeQuantizationInfos(PlaceholderBindings &bindings, const Function *F,
 void quantizeFunction(Function *F, const QuantizationConfiguration &quantConfig,
                       const Backend &B, const LoweredInfoMap &loweredMap,
                       const KindSet &doNotQuantizeKinds) {
-  assert((quantConfig.precision == ElemKind::Int8QTy ||
-          quantConfig.precision == ElemKind::Int16QTy) &&
-         "Only Int8 and Int16 quantization supported");
+  DCHECK(quantConfig.precision == ElemKind::Int8QTy ||
+         quantConfig.precision == ElemKind::UInt8QTy ||
+         quantConfig.precision == ElemKind::Int16QTy)
+      << "Only Int8, UInt8, and Int16 quantization supported";
 
   FunctionQuantizer quantizer(*F, B, quantConfig.schema, quantConfig.infos,
                               quantConfig.precision, doNotQuantizeKinds,

--- a/tests/models/caffe2Models/rowwise_quantized_sparse_lengths_sum_init_net.pbtxt
+++ b/tests/models/caffe2Models/rowwise_quantized_sparse_lengths_sum_init_net.pbtxt
@@ -1,7 +1,7 @@
 name: "rowwise_quantized_sparse_lengths_sum_init_net_test"
 op {
   output: "data"
-  type: "Int8GivenTensorFill"
+  type: "GivenTensorByteStringToUInt8Fill"
   arg {
     name: "shape"
     ints: 3
@@ -9,15 +9,7 @@ op {
   }
   arg {
     name: "values"
-    s: "\000\377\000\377\000\377"
-  }
-  arg {
-    name: "Y_zero_point"
-    i: 0
-  }
-  arg {
-    name: "Y_scale"
-    f: 0.0
+    strings: "\000\377\000\377\000\377"
   }
 }
 op {

--- a/tests/unittests/Caffe2ImporterTest.cpp
+++ b/tests/unittests/Caffe2ImporterTest.cpp
@@ -1756,17 +1756,17 @@ TEST(caffe2, tensorFillsTest) {
   auto tensorFillFloatH = tensorFillFloat->getPayload().getHandle<float>();
   auto tensorIntFillH = tensorIntFill->getPayload().getHandle<int32_t>();
   auto tensorInt64FillH = tensorInt64Fill->getPayload().getHandle<int64_t>();
-  // We load GivenTensorByteStringToUInt8Fill as Int8QTy with dummy scale/offset
-  // for now, because it's only used for rowwise-quantized tensors.
+  // We load GivenTensorByteStringToUInt8Fill as UInt8QTy with dummy
+  // scale/offset for now, because it's only used for rowwise-quantized tensors.
   auto tensorStringToUInt8FillH =
-      tensorStringToUInt8Fill->getPayload().getHandle<int8_t>();
+      tensorStringToUInt8Fill->getPayload().getHandle<uint8_t>();
 
   // All fills in fill_test_init_net.pbtxt are set to 0 through 3.
   for (size_t i = 0; i < 4; i++) {
     EXPECT_FLOAT_EQ(tensorFillFloatH.raw(i), (float)i);
     EXPECT_EQ(tensorIntFillH.raw(i), (int32_t)i);
     EXPECT_EQ(tensorInt64FillH.raw(i), (int64_t)i);
-    EXPECT_EQ(tensorStringToUInt8FillH.raw(i), (int8_t)i);
+    EXPECT_EQ(tensorStringToUInt8FillH.raw(i), (uint8_t)(i + 128));
   }
 }
 

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -279,7 +279,7 @@ int main(int argc, char **argv) {
       .addOperand("Lengths", OperandKind::In)
       .autoIRGen()
       .autoVerify(VerifyKind::SameElementType, {"Dest", "ElemKind::FloatTy"})
-      .autoVerify(VerifyKind::SameElementType, {"Data", "ElemKind::Int8QTy"})
+      .autoVerify(VerifyKind::SameElementType, {"Data", "ElemKind::UInt8QTy"})
       .autoVerify(VerifyKind::SameElementType, {"Scales", "ElemKind::FloatTy"})
       .autoVerify(VerifyKind::SameElementType, {"Offsets", "ElemKind::FloatTy"})
       .autoVerify(VerifyKind::SameElementType, {"Weights", "ElemKind::FloatTy"})


### PR DESCRIPTION
Summary:
Data for fused sls could be huge (GBs), avoid sparse lookup table copies for fused slss.
Support for uint8 rowwise quantized non fused slss.

According to C2 docs:
* Non fused version of SLS has uint8 data with scales and offsets as a separate params.
* Fused version has uint8 data with 8 additional bytes per row (4 bytes scale, 4 bytes offset).

Documentation:
n/a

Test Plan:
CI/Internal tests for models.
