### PR TITLE
Remove Habana-specific HabanaReshapeNode

### DIFF
--- a/tests/unittests/HabanaBackendTest.cpp
+++ b/tests/unittests/HabanaBackendTest.cpp
@@ -71,22 +71,22 @@ TEST_F(HabanaBackendTest, SurroundTile) {
   //   Placeholder
   //       |
   //       v
-  //   HabanaReshape
+  //   Reshape
   //       |
   //       v
   //     Tile
   //       |
   //       v
-  //   HabanaReshape
+  //   Reshape
   //       |
   //       v
   //      Save
 
-  auto *RO = llvm::dyn_cast<HabanaReshapeNode>(SN->getInput());
+  auto *RO = llvm::dyn_cast<ReshapeNode>(SN->getInput());
   ASSERT_TRUE(RO);
   TN = llvm::dyn_cast<TileNode>(RO->getInput());
   ASSERT_TRUE(TN);
-  auto *RI = llvm::dyn_cast<HabanaReshapeNode>(TN->getInput());
+  auto *RI = llvm::dyn_cast<ReshapeNode>(TN->getInput());
   ASSERT_TRUE(RI);
   EXPECT_EQ(llvm::dyn_cast<Placeholder>(RI->getInput()), A);
 

--- a/tools/ClassGen/Backends/Habana/HabanaSpecificNodes.h
+++ b/tools/ClassGen/Backends/Habana/HabanaSpecificNodes.h
@@ -56,14 +56,6 @@ BB.newNode("HabanaConvolutionAdd")
                   "extra addend input to allow for a tensor to be added "
                   "to the convolution output.");
 
-BB.newNode("HabanaReshape")
-    .addInput("Input")
-    .addMember(MemberType::VectorSizeT, "Dims")
-    .addResultFromCtorArg()
-    .setDocstring("This is a Habana-specific Reshape node that exists only to "
-                  "bypass generic IR generation of Reshape so that it can "
-                  "be implemented using a Habana kernel.");
-
 BB.includeBackendSpecificVerification("glow/HabanaSpecificNodesVerification.h");
 
 #endif // TOOLS_CLASSGEN_BACKENDS_HABANA_HABANASPECIFICNODES_H

--- a/tools/ClassGen/Backends/Habana/HabanaSpecificNodesVerification.h
+++ b/tools/ClassGen/Backends/Habana/HabanaSpecificNodesVerification.h
@@ -90,7 +90,5 @@ bool HabanaConvolutionAddNode::verify() const {
   return isValid;
 }
 
-bool HabanaReshapeNode::verify() const { return true; }
-
 #endif // TOOLS_CLASSGEN_BACKENDS_HABANA_HABANASPECIFICNODESVERIFICATION_H
 #endif // GLOW_WITH_HABANA


### PR DESCRIPTION
Summary:
We added this a long time back when we were using the instruction IR
to get better codegen control, but it's not necessary anymore.

Differential Revision: D16046760

