### PR TITLE
[Partitioner] Heterogeneous partition testing

### DIFF
--- a/include/glow/Backends/DeviceManager.h
+++ b/include/glow/Backends/DeviceManager.h
@@ -89,6 +89,15 @@ public:
   /// \returns the name of backend that powers this Device.
   llvm::StringRef getBackendName() { return config_.backendName; }
 
+  /// \returns a string with \p name in parameters.
+  llvm::StringRef getParamByName(llvm::StringRef name) const {
+    auto it = config_.parameters.find(name);
+    if (it != config_.parameters.end()) {
+      return it->second;
+    }
+    return "";
+  }
+
   /// \returns the maximum memory (in bytes) available on the device.
   virtual uint64_t getMaximumMemory() const = 0;
 

--- a/include/glow/Graph/Node.h
+++ b/include/glow/Graph/Node.h
@@ -394,6 +394,16 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Node &node);
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Node *node);
 
+/// Helper to get the Kind of a Node (e.g. Kinded::Kind::AddNodeKind) given its
+/// \p nodeName (e.g. Add).
+inline Kinded::Kind getKindFromNodeName(llvm::StringRef nodeName) {
+#define DEF_NODE(CLASS, NAME)                                                  \
+  if (nodeName == #NAME) {                                                     \
+    return Kinded::Kind::CLASS##Kind;                                          \
+  }
+#include "glow/AutoGenNodes.def"
+  LOG(FATAL) << "Unknown node name: " << nodeName.str();
+}
 } // namespace glow
 
 namespace llvm {

--- a/include/glow/Partitioner/Partitioner.h
+++ b/include/glow/Partitioner/Partitioner.h
@@ -34,6 +34,10 @@ struct BackendInfo {
   uint64_t memSize;
   /// Backend pointer.
   Backend *backend = nullptr;
+  /// The non-supported nodes kind.
+  std::set<Kinded::Kind> nonSupportedNodesKinds;
+  /// The supported nodes kind.
+  std::set<Kinded::Kind> supportedNodesKinds;
 };
 
 /// A mapping of newly-created functions along with a set of nodes sets. The

--- a/include/glow/Partitioner/PartitionerUtils.h
+++ b/include/glow/Partitioner/PartitionerUtils.h
@@ -82,5 +82,8 @@ GraphMemInfo updateGraphMemInfoByAddingNode(const NodesSet &currNodes,
 /// Return the memory usage of a given nodes set.
 GraphMemInfo getGraphMemInfo(const NodesSet &nodes);
 
+/// Parse a node name string (e.g. "Div,Add") \p names, \returns a set of
+/// NodeKinds corresponding to the names in the string.
+std::set<Kinded::Kind> generateNodeKindsSet(llvm::StringRef names);
 } // namespace glow
 #endif // GLOW_PARTITIONER_PARTITIONUTILS_H

--- a/include/glow/Runtime/RuntimeTypes.h
+++ b/include/glow/Runtime/RuntimeTypes.h
@@ -51,6 +51,14 @@ struct DeviceInfo {
   uint64_t availableMemory;
   /// Backend Type.
   std::string backendName;
+  /// A string contains the node names(e.g. Add, Div) which are separeted by
+  /// ",". E.g. "Div,Add". In Partitioner, those nodes won't be supported in
+  /// this backend.
+  std::string nonSupportedNodes;
+  /// A string contains the node names(e.g. Add, Div) which are separeted by
+  /// ",". E.g. "Div,Add". In Partitioner, the complementary set of those nodes
+  /// won't be supported in this backend.
+  std::string supportedNodes;
   /// Available SRAM capacity in bytes.
   uint64_t sramCapacity;
   /// Peak compute on device in ops/second. Assumes all ops are in int8.

--- a/lib/Partitioner/PartitionerUtils.cpp
+++ b/lib/Partitioner/PartitionerUtils.cpp
@@ -286,4 +286,17 @@ GraphMemInfo getGraphMemInfo(const NodesSet &nodes) {
   return ret;
 }
 
+std::set<Kinded::Kind> generateNodeKindsSet(llvm::StringRef names) {
+  std::set<Kinded::Kind> nodeKindsSet;
+  llvm::StringRef::size_type pos = names.find(',');
+  while (pos != llvm::StringRef::npos) {
+    nodeKindsSet.insert(getKindFromNodeName(names.substr(0, pos)));
+    names = names.substr(pos + 1);
+    pos = names.find(',');
+  }
+  if (!names.empty()) {
+    nodeKindsSet.insert(getKindFromNodeName(names));
+  }
+  return nodeKindsSet;
+}
 } // namespace glow

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -90,7 +90,8 @@ llvm::Error HostManager::addNetwork(std::unique_ptr<Module> module,
     DeviceInfo info = device.second->getDeviceInfo();
     info.availableMemory = device.second->getAvailableMemory();
     info.backendName = device.second->getBackendName();
-    VLOG(1) << "AVAILABLE DEVICE MEMORY " << info.availableMemory << "\n";
+    info.nonSupportedNodes = device.second->getParamByName("nonSupportedNodes");
+    info.supportedNodes = device.second->getParamByName("supportedNodes");
     deviceInfo.push_back(info);
   }
   // Perform a round of target-independent graph optimizations. This helps the

--- a/tests/images/run.sh
+++ b/tests/images/run.sh
@@ -145,6 +145,10 @@ done
 ./bin/image-classifier tests/images/imagenet/*.png -expected-labels=${imagenetIdxValues} -image-mode=0to1 -m=quant_resnet50 -model-input-name=gpu_0/data_0 -use-imagenet-normalization "$@"
 num_errors=$(($num_errors + $?))
 
+# Heterogeneous partition Resnet50 Caffe2 model test
+./bin/image-classifier tests/images/imagenet/*.png -image-mode=0to1 -m=resnet50 -model-input-name=gpu_0/data -cpu-memory=100000 -load-device-configs="tests/runtime_test/heterogeneousConfigs.yaml" "$@"
+num_errors=$(($num_errors + $?))
+
 # Emotion_ferplus onnx model test
 i=0
 for png_filename in tests/images/EmotionSampleImages/*.png; do

--- a/tests/runtime_test/heterogeneousConfigs.yaml
+++ b/tests/runtime_test/heterogeneousConfigs.yaml
@@ -1,0 +1,15 @@
+---
+- name:     Device1
+  backendName: CPU
+  parameters: |
+    "nonSupportedNodes":"AvgPool"
+    "deviceID" : "0"
+- name:     Device2
+  backendName: CPU
+  parameters: |
+    "nonSupportedNodes":"AvgPool"
+- name:     Device3
+  backendName: Interpreter
+  parameters: |
+    "supportedNodes":""
+...

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -295,17 +295,6 @@ void glow::parseCommandLine(int argc, char **argv) {
   }
 }
 
-/// Helper to get the Kind of a Node (e.g. Kinded::Kind::AddNodeKind) given its
-/// \p nodeName (e.g. Add).
-static Kinded::Kind getKindFromNodeName(llvm::StringRef nodeName) {
-#define DEF_NODE(CLASS, NAME)                                                  \
-  if (nodeName == #NAME) {                                                     \
-    return Kinded::Kind::CLASS##Kind;                                          \
-  }
-#include "glow/AutoGenNodes.def"
-  LOG(FATAL) << "Unknown node name: " << nodeName.str();
-}
-
 /// Helper to get the parameters in DeviceConfig from \p str. The \p str has
 /// multiple lines, and each line with this format : "str1" : "str2".
 static llvm::StringMap<std::string> getBackendParams(std::string &str) {


### PR DESCRIPTION
Summary:
Provide an easier way for using heterogeneous partition : user can define which ops not running on which type of backends.
related to #2814 
Documentation:

[Optional Fixes #issue]

Test Plan:
added unittest;
```
wangm-mbp:buildR wangm$ ./bin/image-classifier tests/images/imagenet/cat_285.png -image-mode=0to1 -m=resnet50 -model-input-name=gpu_0/data -cpu-memory=100000 -load-device-configs="tests/runtime_test/heterogeneousConfigs.yaml" 
Model: resnet50
Running 1 thread(s).
tests/runtime_test/heterogeneousConfigs.yaml
WARNING: Logging before InitGoogleLogging() is written to STDERR
I0628 16:12:13.164857 43896832 Partitioner.cpp:1038] The number of partitions is : 3, and the DAG is dumped into DAG.dot file.
I0628 16:12:13.165649 43896832 Partitioner.cpp:58] Writing dotty graph for DAG after graph partitioning: DAG.dot
I0628 16:12:13.165989 43896832 Partitioner.cpp:1047] 	 Partition 0:
		 Name :	resnet50_part1_part1
		 BackendKind :	CPU
		 Memory :	94929408
		 LogicalDeviceIDs :	1
I0628 16:12:13.166002 43896832 Partitioner.cpp:1047] 	 Partition 1:
		 Name :	resnet50_part2_part1
		 BackendKind :	Interpreter
		 Memory :	409600
		 LogicalDeviceIDs :	2
I0628 16:12:13.166026 43896832 Partitioner.cpp:1047] 	 Partition 2:
		 Name :	resnet50_part3_part1
		 BackendKind :	CPU
		 Memory :	8208200
		 LogicalDeviceIDs :	0
 File: tests/images/imagenet/cat_285.png	Label-K1: 285 (probability: 0.5823)
```
Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
