### PR TITLE
[DumpDAG] Report if file can't be opened; choose filename differently.

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -241,6 +241,8 @@ public:
 
   ~Function();
 
+  std::string getFilename() { return getName().rsplit('/').second.str(); }
+
   /// Return the log context.
   std::shared_ptr<LogContext> getLogContext() { return logCtx_; }
 

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -248,6 +248,8 @@ protected:
 
 public:
   void dumpAll(std::ostream &os) {
+    CHECK(os) << "Failed to create file for to dump Graph";
+
     os << "digraph DAG {\n\trankdir=TB;\n";
 
     // Dump vertices:

--- a/lib/Partitioner/Partitioner.cpp
+++ b/lib/Partitioner/Partitioner.cpp
@@ -1048,7 +1048,7 @@ llvm::Error Partitioner::Partition(CompilationContext &cctx) {
     if (dumpPartition) {
       subF->dumpDAG("partitionLogicalID" +
                     std::to_string(mapping.getLogicalDeviceIDList(subF)[0]) +
-                    "__" + subF->getName().str() + "__" +
+                    "__" + subF->getFilename() + "__" +
                     mapping.getPartitionBackendName(subF) + ".dot");
     }
     i++;

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -426,7 +426,7 @@ void Loader::compile(PlaceholderBindings &bindings) {
   if (!dumpGraphDAGFileOpt.empty()) {
     for (auto function : module->getFunctions()) {
       std::string filename =
-          function->getName().str() + "_" + dumpGraphDAGFileOpt;
+          function->getFilename() + "_" + dumpGraphDAGFileOpt;
       function->dumpDAG(filename.c_str());
     }
   }


### PR DESCRIPTION
Right now we may have `resnext/predict_net.pb` as model name. We concat model name with something to get output file name. This is a problem, because resulting filename will have `/` character, referring to a directory that doesn't exist.