### PR TITLE
[NFC][Runtime] Add DCHECKs to check that callbacks are not null

### DIFF
--- a/lib/Backends/CPU/CPUDeviceManager.cpp
+++ b/lib/Backends/CPU/CPUDeviceManager.cpp
@@ -64,6 +64,8 @@ DeviceInfo CPUDeviceManager::getDeviceInfo() const {
 void CPUDeviceManager::addNetworkImpl(const Module *module,
                                       FunctionMapTy functions,
                                       ReadyCBTy readyCB) {
+  DCHECK(readyCB != nullptr);
+
   // First check for uniqueness of the function name.
   for (const auto &func : functions) {
     if (functions_.count(func.first) != 0) {
@@ -112,6 +114,8 @@ void CPUDeviceManager::addNetworkImpl(const Module *module,
 
 void CPUDeviceManager::evictNetworkImpl(std::string functionName,
                                         EvictFunctionCBTy evictCB) {
+  DCHECK(evictCB != nullptr);
+
   if (functions_.erase(functionName)) {
     usedMemoryBytes_ -= functionCost_; // TODO: static moduleSize
   } else {
@@ -127,6 +131,8 @@ void CPUDeviceManager::evictNetworkImpl(std::string functionName,
 void CPUDeviceManager::runFunctionImpl(
     RunIdentifierTy id, std::string function,
     std::unique_ptr<ExecutionContext> context, ResultCBTy resultCB) {
+  DCHECK(resultCB != nullptr);
+
   TRACE_EVENT_SCOPE_NAMED(context->getTraceContext(), TraceLevel::RUNTIME,
                           "DeviceManager::run", dmRun);
   auto funcIt = functions_.find(function);

--- a/lib/Backends/Habana/HabanaDeviceManager.cpp
+++ b/lib/Backends/Habana/HabanaDeviceManager.cpp
@@ -138,6 +138,8 @@ llvm::Error HabanaDeviceManager::updateMemoryUsage() {
 void HabanaDeviceManager::addNetwork(const Module *module,
                                      FunctionMapTy functions,
                                      ReadyCBTy readyCB) {
+  DCHECK(readyCB != nullptr);
+
   std::unique_lock<std::mutex> lk(instanceMtx_);
   for (const auto &func : functions) {
     // Check if a function with the same name has already been added.
@@ -214,6 +216,8 @@ void HabanaDeviceManager::addNetwork(const Module *module,
 
 void HabanaDeviceManager::evictNetwork(std::string functionName,
                                        EvictFunctionCBTy evictCB) {
+  DCHECK(evictCB != nullptr);
+
   std::unique_lock<std::mutex> lk(instanceMtx_);
 
   // Check if a network with the given name exists on the device.
@@ -272,6 +276,8 @@ void HabanaDeviceManager::runFunctionImpl(RunIdentifierTy runId,
                                           std::string functionName,
                                           std::unique_ptr<ExecutionContext> ctx,
                                           runtime::ResultCBTy resultCB) {
+  DCHECK(resultCB != nullptr);
+
   TRACE_EVENT_SCOPE_NAMED(ctx->getTraceContext(), TraceLevel::RUNTIME,
                           "HabanaDM::runnerThread", trEvent);
   if (ctx->getTraceContext()) {
@@ -342,6 +348,8 @@ void HabanaDeviceManager::runFunctionImpl(RunIdentifierTy runId,
                      functionName = std::move(functionName),
                      ctx = std::move(ctx),
                      resultCB = std::move(resultCB)]() mutable {
+    DCHECK(resultCB != nullptr);
+
     TRACE_EVENT_SCOPE(ctx->getTraceContext(), TraceLevel::RUNTIME,
                       "HabanaDM::waiterThread");
     if (ctx->getTraceContext()) {
@@ -416,6 +424,8 @@ RunIdentifierTy
 HabanaDeviceManager::runFunction(std::string functionName,
                                  std::unique_ptr<ExecutionContext> ctx,
                                  runtime::ResultCBTy resultCB) {
+  DCHECK(resultCB != nullptr);
+
   RunIdentifierTy runId = runIdentifier_++;
   runPool_->submit([this, runId, functionName = std::move(functionName),
                     ctx = std::move(ctx),

--- a/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
@@ -65,6 +65,8 @@ DeviceInfo InterpreterDeviceManager::getDeviceInfo() const {
 void InterpreterDeviceManager::addNetworkImpl(const Module *module,
                                               FunctionMapTy functions,
                                               ReadyCBTy readyCB) {
+  DCHECK(readyCB != nullptr);
+
   // First check for uniqueness of the function name.
   for (const auto &func : functions) {
     if (functions_.count(func.first) != 0) {
@@ -110,6 +112,8 @@ void InterpreterDeviceManager::addNetworkImpl(const Module *module,
 
 void InterpreterDeviceManager::evictNetworkImpl(std::string functionName,
                                                 EvictFunctionCBTy evictCB) {
+  DCHECK(evictCB != nullptr);
+
   if (functions_.erase(functionName)) {
     usedMemoryBytes_ -= functionCost_; // TODO: static moduleSize
   } else {
@@ -125,6 +129,8 @@ void InterpreterDeviceManager::evictNetworkImpl(std::string functionName,
 void InterpreterDeviceManager::runFunctionImpl(
     RunIdentifierTy id, std::string function,
     std::unique_ptr<ExecutionContext> context, ResultCBTy resultCB) {
+  DCHECK(resultCB != nullptr);
+
   TRACE_EVENT_SCOPE_NAMED(context->getTraceContext(), TraceLevel::RUNTIME,
                           "DeviceManager::run", dmRun);
   auto funcIt = functions_.find(function);

--- a/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
@@ -255,6 +255,8 @@ bool OpenCLDeviceManager::isMemoryAvailable(uint64_t estimate) const {
 void OpenCLDeviceManager::addNetworkImpl(const Module *module,
                                          FunctionMapTy functions,
                                          ReadyCBTy readyCB) {
+  DCHECK(readyCB != nullptr);
+
   // First check for uniqueness of the function name.
   for (const auto &func : functions) {
     if (functions_.count(func.first) != 0) {
@@ -360,6 +362,8 @@ void OpenCLDeviceManager::addNetworkImpl(const Module *module,
 
 void OpenCLDeviceManager::evictNetworkImpl(std::string functionName,
                                            EvictFunctionCBTy evictCB) {
+  DCHECK(evictCB != nullptr);
+
   if (functions_.erase(functionName)) {
     auto buffer = buffers_[functionName];
     auto users = buffer->decrementUsers();
@@ -394,6 +398,8 @@ void OpenCLDeviceManager::returnRunCommandQueue(OpenCLCommandQueue &queue) {
 void OpenCLDeviceManager::runFunctionImpl(
     RunIdentifierTy id, std::string function,
     std::unique_ptr<ExecutionContext> context, ResultCBTy resultCB) {
+  DCHECK(resultCB != nullptr);
+
   TRACE_EVENT_SCOPE_NAMED(context->getTraceContext(), TraceLevel::RUNTIME,
                           "DeviceManager::run", dmRun);
   auto funcIt = functions_.find(function);

--- a/lib/Onnxifi/HostManagerOnnxifi.cpp
+++ b/lib/Onnxifi/HostManagerOnnxifi.cpp
@@ -53,6 +53,8 @@ HostManagerBackend::createHostManager(llvm::StringRef backendName) {
 void HostManagerBackend::runNetwork(const Graph *graph,
                                     std::unique_ptr<ExecutionContext> context,
                                     runtime::ResultCBTy callback) {
+  DCHECK(callback != nullptr);
+
   auto hostManagerGraph = static_cast<const HostManagerGraph *>(graph);
   hostManager_->runNetwork(hostManagerGraph->getName(), std::move(context),
                            std::move(callback));

--- a/lib/Runtime/Executor/ThreadPoolExecutor.cpp
+++ b/lib/Runtime/Executor/ThreadPoolExecutor.cpp
@@ -62,7 +62,9 @@ ExecutionState::ExecutionState(RunIdentifierTy id, const DAGNode *root,
                                ResultCBTy doneCb)
     : runId_(id), cb_(doneCb), resultCtx_(std::move(resultContext)),
       inflightNodes_(0), module_(root->module), root_(root),
-      executor_(executor) {}
+      executor_(executor) {
+  DCHECK(cb_ != nullptr);
+}
 
 void ExecutionState::init() {
   // Create a queue for the breadth-first traversal through the graph.
@@ -236,6 +238,8 @@ void ThreadPoolExecutor::shutdown() {
 void ThreadPoolExecutor::run(const DAGNode *root,
                              std::unique_ptr<ExecutionContext> context,
                              RunIdentifierTy runId, ResultCBTy cb) {
+  DCHECK(cb != nullptr);
+
   TRACE_EVENT_SCOPE(context->getTraceContext(), TraceLevel::RUNTIME,
                     "ThreadPoolExecutor::run");
 
@@ -378,6 +382,7 @@ void ThreadPoolExecutor::handleDeviceManagerResult(
     // If there are no nodes inflight, that means all nodes are done. Call
     // the callback and erase the state information.
     ResultCBTy cb = executionState->getCallback();
+    DCHECK(cb != nullptr);
     cb(executionState->getRunId(), executionState->getErrorContainer().get(),
        executionState->getUniqueResultContextPtr());
   }

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -231,6 +231,8 @@ RunIdentifierTy
 HostManager::runNetwork(llvm::StringRef networkName,
                         std::unique_ptr<ExecutionContext> context,
                         ResultCBTy callback) {
+  DCHECK(callback != nullptr);
+
   TRACE_EVENT_SCOPE(context->getTraceContext(), TraceLevel::RUNTIME,
                     "HostManager::runNetwork");
   auto currentRun = totalRequestCount_++;


### PR DESCRIPTION
**Description**
This commit sprinkles `DHECK_NOTNULL` macros over the Glow runtime stack
to check whether any of the callbacks passed around within the runtime
are null. This should never happen, but these `DCHECKS` will help debug if
it ever does.

**Test Plan**
`ninja check` -> all tests pass.

**Fixes**
This pull request fixes #3081.
