### PR TITLE
[Operator] Add Support for ReduceMin Operator

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -783,6 +783,13 @@ public:
                                                TypeRef outTy, NodeValue batch,
                                                llvm::ArrayRef<unsigned_t> axes);
 
+  /// Create a node, performing BatchedReduceMin operation. Output type is
+  /// based on the input \p batch type with dimensions specified with \p axes
+  /// removed.
+  BatchedReduceMinNode *createBatchedReduceMin(llvm::StringRef name,
+                                               NodeValue batch,
+                                               llvm::ArrayRef<unsigned_t> axes);
+
   /// Create a node, performing BatchedReduceMean operation. Output type
   /// matches input \p outTy type.
   BatchedReduceMeanNode *

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -44,6 +44,10 @@ bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
   // Note: For brevity below, "X ==> Y, Z" signifes that Node X is IRGen'd into
   // Instructions Y and Z.
   switch (NI.getKind()) {
+  case Kinded::Kind::BatchedReduceMinNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+        {ElemKind::FloatTy, ElemKind::Int32ITy, ElemKind::Int64ITy});
+
   case Kinded::Kind::AddNodeKind:
   case Kinded::Kind::SubNodeKind:
   case Kinded::Kind::MulNodeKind:

--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -13,9 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <algorithm>
 #include <assert.h>
 #include <chrono>
 #include <math.h>
+#include <numeric>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -763,6 +765,39 @@ libjit_space_to_depth_generic(const T *inPtr, T *outPtr, size_t blockSize,
     }
   }
 }
+/// The dimensions passed in here are pre-expanded in LLVMIRGen with 1s so that
+/// we can iterate over the shape here, regardless of the shape of the tensor.
+template <typename T>
+static void libjit_reducemin(T *dest, const T *batch, size_t destSize,
+                             const size_t *destDims, const size_t *batchDims,
+                             T init) {
+  for (size_t i = 0; i < destSize; i++) {
+    dest[i] = init;
+  }
+
+  unsigned int axis[6];
+  for (size_t i = 0; i < 6; i++) {
+    axis[i] = (destDims[i] > 1);
+  }
+
+  for (size_t x = 0, dx = 0; x < batchDims[0]; x++, dx += axis[0]) {
+    for (size_t y = 0, dy = 0; y < batchDims[1]; y++, dy += axis[1]) {
+      for (size_t z = 0, dz = 0; z < batchDims[2]; z++, dz += axis[2]) {
+        for (size_t w = 0, dw = 0; w < batchDims[3]; w++, dw += axis[3]) {
+          for (size_t q = 0, dq = 0; q < batchDims[4]; q++, dq += axis[4]) {
+            for (size_t r = 0, dr = 0; r < batchDims[5]; r++, dr += axis[5]) {
+              T fdest =
+                  dest[libjit_getXYZWQR(destDims, dx, dy, dz, dw, dq, dr)];
+              T fnew = batch[libjit_getXYZWQR(batchDims, x, y, z, w, q, r)];
+              dest[libjit_getXYZWQR(destDims, dx, dy, dz, dw, dq, dr)] =
+                  std::min(fdest, fnew);
+            }
+          }
+        }
+      }
+    }
+  }
+}
 } // namespace
 
 extern "C" {
@@ -905,7 +940,7 @@ int8_t libjit_element_cmp_eq_kernel_u(size_t idx, const size_t *LHS,
 }
 
 int8_t libjit_element_is_nan_kernel_f(size_t idx, const float *input) {
-  return isnan(input[idx]) ? 1 : 0;
+  return std::isnan(input[idx]) ? 1 : 0;
 }
 
 int8_t libjit_element_cmp_lte_kernel_f(size_t idx, const float *LHS,
@@ -1031,6 +1066,24 @@ void libjit_batchedreduceadd_f(float *dest, const float *batch, size_t destSize,
                                     I[5])] +=
                   batch[libjit_getXYZWQR(batchDims, x, y, z, w, q, r)];
             }
+}
+
+void libjit_reducemin_f(float *dest, const float *batch, size_t destSize,
+                        const size_t *destDims, const size_t *batchDims) {
+  libjit_reducemin(dest, batch, destSize, destDims, batchDims,
+                   std::numeric_limits<float>::max());
+}
+
+void libjit_reducemin_i32(int32_t *dest, const int32_t *batch, size_t destSize,
+                          const size_t *destDims, const size_t *batchDims) {
+  libjit_reducemin(dest, batch, destSize, destDims, batchDims,
+                   std::numeric_limits<int32_t>::max());
+}
+
+void libjit_reducemin_u(int64_t *dest, const int64_t *batch, size_t destSize,
+                        const size_t *destDims, const size_t *batchDims) {
+  libjit_reducemin(dest, batch, destSize, destDims, batchDims,
+                   std::numeric_limits<int64_t>::max());
 }
 
 /// Same as the non-quantized version, the dimensions here are pre-expanded in

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -70,6 +70,11 @@ Interpreter::compileIRWithoutConstants(std::unique_ptr<IRFunction> IR) const {
 
 bool Interpreter::isOpSupported(const NodeInfo &NI) const {
   switch (NI.getKind()) {
+  case Kinded::Kind::BatchedReduceMinNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+        {ElemKind::FloatTy, ElemKind::Float16Ty, ElemKind::Int32ITy,
+         ElemKind::Int64ITy});
+
   case Kinded::Kind::AddNodeKind:
   case Kinded::Kind::SubNodeKind:
   case Kinded::Kind::MulNodeKind:

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -243,6 +243,11 @@ private:
                                         const ShapeVector &eDestDims);
 
   template <typename ElemTy>
+  void fwdBatchedReduceMinInstImpl(Value *batch, Value *dest,
+                                   const ShapeVector &eBatchDims,
+                                   const ShapeVector &eDestDims, ElemTy max);
+
+  template <typename ElemTy>
   void fwdLengthsSumInstFloatImpl(const LengthsSumInst *I);
 
   template <typename ElemTy> void fwdGatherInstImpl(const GatherInst *I);

--- a/lib/Exporter/ONNXModelWriter.cpp
+++ b/lib/Exporter/ONNXModelWriter.cpp
@@ -591,6 +591,16 @@ ONNXModelWriter::writeBatchedReduceAdd(const BatchedReduceAddNode *node,
 }
 
 llvm::Error
+ONNXModelWriter::writeBatchedReduceMin(const BatchedReduceMinNode *node,
+                                       GraphType &graph) {
+  auto *proto = graph.add_node();
+  // Find dictionary entries.
+  addValueAttribute(proto, "axes", node->getAxes());
+
+  return writeAllWithNode("ReduceMin", node, proto);
+}
+
+llvm::Error
 ONNXModelWriter::writeBatchNormalization(const BatchNormalizationNode *node,
                                          GraphType &graph) {
   auto *proto = graph.add_node();

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1491,6 +1491,15 @@ Function::createBatchedReduceMean(llvm::StringRef name, NodeValue batch,
   return createBatchedReduceMean(name, OT, batch, axes);
 }
 
+BatchedReduceMinNode *
+Function::createBatchedReduceMin(llvm::StringRef name, NodeValue batch,
+                                 llvm::ArrayRef<unsigned_t> axes) {
+  // Create new shape with specified dimensions either reduced or removed.
+  auto outDims = getNewShapeWithoutAxes(batch.dims(), axes);
+  auto OT = getParent()->uniqueType(batch.getType()->getElementType(), outDims);
+  return addNode(new BatchedReduceMinNode(name, OT, batch, axes));
+}
+
 BatchedAddNode *Function::createBatchedAdd(llvm::StringRef name,
                                            NodeValue batch, NodeValue sample) {
   return addNode(new BatchedAddNode(name, batch.getType(), batch, sample));

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -1054,6 +1054,15 @@ bool BatchedReduceMeanNode::verify() const {
   return isValid;
 }
 
+bool BatchedReduceMinNode::verify() const {
+  bool isValid = checkType(getResult(), getBatch().getElementType(), this);
+
+  isValid &=
+      expectCompareTrue("Invalid shape", getBatch().dims().size(), size_t(0),
+                        this, CompareOperatorGreaterThan<size_t>());
+  return isValid;
+}
+
 bool SparseLengthsSumNode::verify() const {
   return verifySparseLengthsSum(getResult(), getData(), getIndices(),
                                 getLengths());

--- a/tests/models/onnxModels/reduceMin.onnxtxt
+++ b/tests/models/onnxModels/reduceMin.onnxtxt
@@ -1,0 +1,68 @@
+ir_version: 3
+producer_name: "glow-test"
+graph {
+  node {
+    input: "x"
+    output: "y"
+    op_type: "ReduceMin"
+    attribute {
+      name: "axes"
+      ints: 3
+      ints: 2
+      type: INTS
+    }
+    attribute {
+      name: "keepdims"
+      i: 1
+      type: INT
+    }
+  }
+  name: "test_reducemin"
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 1
+}

--- a/tests/models/onnxModels/reduceMinDefaultAxis.onnxtxt
+++ b/tests/models/onnxModels/reduceMinDefaultAxis.onnxtxt
@@ -1,0 +1,62 @@
+ir_version: 3
+producer_name: "glow-test"
+graph {
+  node {
+    input: "x"
+    output: "y"
+    op_type: "ReduceMin"
+    attribute {
+      name: "keepdims"
+      i: 1
+      type: INT
+    }
+  }
+  name: "test_reducemin"
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 1
+}

--- a/tests/models/onnxModels/reduceMinNoKeep.onnxtxt
+++ b/tests/models/onnxModels/reduceMinNoKeep.onnxtxt
@@ -1,0 +1,68 @@
+ir_version: 3
+producer_name: "glow-test"
+graph {
+  node {
+    input: "x"
+    output: "y"
+    op_type: "ReduceMin"
+    attribute {
+      name: "axes"
+      ints: 3
+      ints: 2
+      type: INTS
+    }
+    attribute {
+      name: "keepdims"
+      i: 0
+      type: INT
+    }
+  }
+  name: "test_reducemin"
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 1
+}

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -241,6 +241,16 @@ int main(int argc, char **argv) {
       .autoVerify(VerifyKind::SameElementType, {"Dest", "Batch"})
       .autoIRGen();
 
+  /// Calculates minimum of all of the layers in the batch along the axes
+  /// dimensions and produce a tensor that has the same dimensions as the input.
+  /// tensor without the Axes dimension.
+  BB.newInstr("BatchedReduceMin")
+      .addOperand("Dest", OperandKind::Out)
+      .addOperand("Batch", OperandKind::In)
+      .addMember(MemberType::VectorUnsigned, "Axes")
+      .autoVerify(VerifyKind::SameElementType, {"Dest", "Batch"})
+      .autoIRGen();
+
   /// Sums together groups of consecutive slices of Data as per the group sizes
   /// specified by Lengths.
   BB.newInstr("LengthsSum")

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -397,6 +397,13 @@ int main(int argc, char **argv) {
       .setDocstring("Performs Average Mean operation on the Input given "
                     "Axes.");
 
+  BB.newNode("BatchedReduceMin")
+      .addInput("Batch")
+      .addMember(MemberType::VectorUnsigned, "Axes")
+      .addResultFromCtorArg()
+      .setDocstring("Performs Reduce Min operation on the Input given "
+                    "Axes.");
+
   BB.newNode("ChannelShuffle")
       .addInput("Input")
       .addMember(MemberType::Unsigned, "Group")


### PR DESCRIPTION
Summary:
CPUBackend supports: Flt, Int32, Int64
Interpreter supports: Flt, FP16, Int32, Int64
Default Axis Support for ReduceOps

Documentation:
[Optional Fixes #issue]

Test Plan:
Added ReduceMin Operator Test
Added ReduceMin ONNXLoader Test

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
