### PR TITLE
Autodetect number of devices

### DIFF
--- a/include/glow/Backends/DeviceManager.h
+++ b/include/glow/Backends/DeviceManager.h
@@ -54,6 +54,9 @@ public:
   /// Create a device manager based on the device config \p config.
   static DeviceManager *createDeviceManager(const DeviceConfig &config);
 
+  /// Query the system for the number of devices of a specified kind.
+  static unsigned numDevices(llvm::StringRef backendName);
+
   /// Initialize the device.
   virtual llvm::Error init() { return llvm::Error::success(); }
 

--- a/lib/Onnxifi/onnxifiGlow.cpp
+++ b/lib/Onnxifi/onnxifiGlow.cpp
@@ -56,16 +56,9 @@ GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxGetBackendIDs)(
 
   const size_t numBackendsCapacity = *numBackends;
 
-#ifdef GLOW_WITH_CPU
-  constexpr bool withCPU = true;
-#else
-  constexpr bool withCPU = false;
-#endif
-#ifdef GLOW_WITH_HABANA
-  constexpr bool withHabana = true;
-#else
-  constexpr bool withHabana = false;
-#endif
+  using namespace glow::runtime;
+  const bool withCPU = DeviceManager::numDevices("CPU") > 0;
+  const bool withHabana = DeviceManager::numDevices("Habana") > 0;
 
   // Only return quantization backend if GLOW_DUMP_PROFILE.
   if (getenv("GLOW_DUMP_PROFILE")) {


### PR DESCRIPTION
Summary:
I want to make it possible to build a single Glow library
(particularly, libOnnxifi) that can support multiple hardware backends.
Currently the target backend for Onnxifi is statically configured via the
GLOW_WITH_TARGET macros, which means that if you compile libOnnxifi for Habana,
you can't use it on a non-Habana machine.

This diff adds a really simple device detection API to DeviceManager that lets
you query how many devices of a specific type are available.  For CPU I've used
`hardware_concurrency()` and for Habana, I'm parsing `/proc/bus/pci/devices`.

Using that API, Onnxifi can ask at runtime whether Habana chips are available,
and fall back to CPU if not.

Differential Revision: D16110785

