### PR TITLE
Fix optimizeConversions: consider cases where cast changes value

### DIFF
--- a/tests/models/onnxModels/castInt-32-64.onnxtxt
+++ b/tests/models/onnxModels/castInt-32-64.onnxtxt
@@ -1,0 +1,93 @@
+ir_version: 5
+producer_name: "onnx-example"
+graph {
+  node {
+    input: "input"
+    output: "c1"
+    op_type: "Cast"
+    attribute {
+      name: "to"
+      i: 6
+      type: INT
+    }
+  }
+  node {
+    input: "c1"
+    output: "c2"
+    op_type: "Cast"
+    attribute {
+      name: "to"
+      i: 7
+      type: INT
+    }
+  }
+  node {
+    input: "c2"
+    output: "c3"
+    op_type: "Cast"
+    attribute {
+      name: "to"
+      i: 6
+      type: INT
+    }
+  }
+  node {
+    input: "c3"
+    output: "result"
+    op_type: "Cast"
+    attribute {
+      name: "to"
+      i: 1
+      type: INT
+    }
+  }
+  name: "test-model"
+  input {
+    name: "input"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "result"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 10
+}
+


### PR DESCRIPTION
Summary:
The optimizing pass optimizeConversions assumes that the following operation
is always NOOP:

  T1 X = ...;
  T1 Y = T1(T2(X));

and replaces Y with X. In fact, there are at least two cases when such
replacement is invalid:
  - if T1 is a floating-point type and T2 is not, T2(X) may change the value by
    dropping the fractional part;
  - if mantissa of T2 has less significant bits than mantissa of T1, this cast
    may lead to loss of senior significant bits.

In both cases, the said replacement is non-equivalent. Justification that we can
can still perform this transform despite the sematic change because we eliminate
precision loss does not hold, because transform like float -> int -> float
can be done intentionally to strip away fractional part, and this transform
removes a semantically important piece.

This patch fixes that situation.

Fixes #3183

Test Plan:
Added unit test.

