### PR TITLE
Support multi-dimensional Scatter Assign and Add

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -995,9 +995,11 @@ public:
   /// Copies each slice from \p slices into \p data at the corresponding index
   /// in \p indices, and \returns this new version of data. For example, given
   /// input data {{1,2},{3,4},{5,6}}, slices {{-3,-4}}, and indices {1}, the
-  /// result is {{1,2},{-3,-4},{5,6}}.
-  ScatterAssignNode *createScatterAssign(llvm::StringRef name, NodeValue data,
-                                         NodeValue indices, NodeValue slices);
+  /// result is {{1,2},{-3,-4},{5,6}}. If \p cumulative is true, this node adds
+  /// values instead of copying.
+  ScatterDataNode *createScatterData(llvm::StringRef name, NodeValue data,
+                                     NodeValue indices, NodeValue slices,
+                                     bool cumulative = false);
 
   /// Given 2D matrix \p data, 1D vector \p lengths (of the same size as width
   /// of \p data), and 1D vector \p values (of the same size as sum of

--- a/include/glow/LLVMIRCodeGen/LLVMIRGen.h
+++ b/include/glow/LLVMIRCodeGen/LLVMIRGen.h
@@ -160,6 +160,8 @@ protected:
   /// Generates LLVM IR that materializes the constant \p val.
   llvm::Value *emitConstI8(llvm::IRBuilder<> &builder, int8_t val);
   /// Generates LLVM IR that materializes the constant \p val.
+  llvm::Value *emitConstI1(llvm::IRBuilder<> &builder, bool val);
+  /// Generates LLVM IR that materializes the constant \p val.
   llvm::Value *emitConstSizeT(llvm::IRBuilder<> &builder, size_t val);
   /// Generates LLVM IR that materializes the constant \p val as a constant of
   /// the type specified by \p kind.

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -219,15 +219,14 @@ bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
              (NI.getOutElemTy(GatherRangesNode::LengthsIdx) ==
               ElemKind::Int64ITy)));
 
-  case Kinded::Kind::ScatterAssignNodeKind:
-    // ScatterAssign ==> Copy + ScatterAssign. Copy supports everything
-    // ReshapeNode above supports, however ScatterAssign only supports the
+  case Kinded::Kind::ScatterDataNodeKind:
+    // ScatterData ==> Copy + ScatterData. Copy supports everything
+    // ReshapeNode above supports, however ScatterData only supports the
     // following.
     return NI.allInputsAndOutputsHaveSameElemKind(
                {ElemKind::FloatTy, ElemKind::Int8QTy},
-               {ScatterAssignNode::IndicesIdx}) &&
-           (NI.getInElemTy(ScatterAssignNode::IndicesIdx) ==
-            ElemKind::Int64ITy);
+               {ScatterDataNode::IndicesIdx}) &&
+           (NI.getInElemTy(ScatterDataNode::IndicesIdx) == ElemKind::Int64ITy);
 
   case Kinded::Kind::SelectNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -357,13 +357,13 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
                {TopKNode::IndicesIdx}) &&
            (NI.getOutElemTy(TopKNode::IndicesIdx) == ElemKind::Int64ITy);
 
-  case Kinded::Kind::ScatterAssignNodeKind:
-    return (NI.getInElemTy(ScatterAssignNode::IndicesIdx) ==
+  case Kinded::Kind::ScatterDataNodeKind:
+    return (NI.getInElemTy(ScatterDataNode::IndicesIdx) ==
             ElemKind::Int64ITy) &&
-           (NI.getOutElemTy(ScatterAssignNode::ResultIdx) ==
-            NI.getInElemTy(ScatterAssignNode::DataIdx)) &&
-           (NI.getOutElemTy(ScatterAssignNode::ResultIdx) ==
-            NI.getInElemTy(ScatterAssignNode::SlicesIdx));
+           (NI.getOutElemTy(ScatterDataNode::ResultIdx) ==
+            NI.getInElemTy(ScatterDataNode::DataIdx)) &&
+           (NI.getOutElemTy(ScatterDataNode::ResultIdx) ==
+            NI.getInElemTy(ScatterDataNode::SlicesIdx));
 
   case Kinded::Kind::SoftMaxNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -245,6 +245,12 @@ private:
   template <typename ElemTy> void fwdGatherInstImpl(const GatherInst *I);
   template <typename ElemTy>
   void fwdGatherRangesInstImpl(const GatherRangesInst *I);
+  template <typename ElemTy>
+  void fwdScatterDataInstCopyImpl(const ScatterDataInst *I);
+  template <typename ElemTy>
+  void fwdScatterDataInstAddFloatImpl(const ScatterDataInst *I);
+  template <typename ElemTy>
+  void fwdScatterDataInstAddQuantizedImpl(const ScatterDataInst *I);
 
   void fwdSparseLengthsSumInstI8Impl(const SparseLengthsSumInst *I);
   template <typename ElemTy>

--- a/lib/Backends/OpenCL/kernels.cl
+++ b/lib/Backends/OpenCL/kernels.cl
@@ -1599,20 +1599,19 @@ __kernel void gatherW(__global void *mem, cl_uint32_t dest, cl_uint32_t src,
           numSamples, destSampleSize, srcSampleSize);
 }
 
-__kernel void scatterassignK(__global float *data,
-                             __global cl_uint64_t *indices,
-                             __global const float *slices,
-                             cl_uint32_t sliceSize) {
+__kernel void scatterdataK(__global float *data, __global cl_uint64_t *indices,
+                           __global const float *slices,
+                           cl_uint32_t sliceSize) {
   int idx = get_global_id(0);
   cl_uint64_t destDataIdx = indices[idx];
   memcpy_float(data + destDataIdx * sliceSize, slices + idx * sliceSize,
                sliceSize);
 }
 
-__kernel void scatterassignW(__global void *mem, cl_uint32_t data,
-                             cl_uint32_t indices, cl_uint32_t slices,
-                             cl_uint32_t sliceSize) {
-  scatterassignK(&mem[data], &mem[indices], &mem[slices], sliceSize);
+__kernel void scatterdataW(__global void *mem, cl_uint32_t data,
+                           cl_uint32_t indices, cl_uint32_t slices,
+                           cl_uint32_t sliceSize) {
+  scatterdataK(&mem[data], &mem[indices], &mem[slices], sliceSize);
 }
 
 __kernel void sparselengthsweightedsumK(__global float *dest,

--- a/lib/Exporter/ONNXModelWriter.cpp
+++ b/lib/Exporter/ONNXModelWriter.cpp
@@ -1089,7 +1089,6 @@ DEF_ALL_WRITER_NODE(CmpLTE)
 DEF_ALL_WRITER_NODE(BatchedAdd)
 DEF_ALL_WRITER_NODE(Dequantize)
 DEF_ALL_WRITER_NODE(Regression)
-DEF_ALL_WRITER_NODE(ScatterAssign)
 DEF_ALL_WRITER_NODE(RowwiseQuantizedFullyConnected)
 DEF_ALL_WRITER_NODE(RowwiseQuantizedSparseLengthsWeightedSum)
 DEF_ALL_WRITER_NODE(FusedRowwiseQuantizedSparseLengthsSum)
@@ -1264,6 +1263,8 @@ DEF_UNSUPPORTED_STORAGE(Storage)
 DEF_UNSUPPORTED_NODE(SGD)
 // Artificial node.
 DEF_UNSUPPORTED_NODE(Save)
+// TODO: Turn to ScatterNd when it is supported in ONNX.
+DEF_UNSUPPORTED_NODE(ScatterData)
 // Gradient nodes.
 DEF_UNSUPPORTED_NODE(AddGrad)
 DEF_UNSUPPORTED_NODE(DivGrad)

--- a/lib/Graph/Grad.cpp
+++ b/lib/Graph/Grad.cpp
@@ -299,8 +299,8 @@ Function *glow::differentiate(Function *F, const TrainingConfig &conf,
       NodeValue Data = GN->getData();
       NodeValue Indices = GN->getIndices();
 
-      // Reshape indices into a one-dimensional Tensor (Vector).
-      std::vector<size_t> IndicesDims{Indices.getType()->size()};
+      // Reshape indices into a two-dimensional Tensor (Vector).
+      std::vector<size_t> IndicesDims{Indices.getType()->size(), 1};
       auto *RI = G->createReshape("reshape.indices.grad", Indices, IndicesDims);
 
       // Reshape Gradient into N-k dimension, where k is Index dimensions,
@@ -319,9 +319,9 @@ Function *glow::differentiate(Function *F, const TrainingConfig &conf,
       // to the correspondent Data Tensors, where Vector value
       // points to Data Tensor.
       auto *SN = G->createSplat("splat.grad", Data.getType(), 0);
-      auto *SA = new ScatterAssignNode("scatter.assign.grad", SN->getResult(),
-                                       RI->getResult(),
-                                       RG ? RG->getResult() : OutputG);
+      auto *SA = new ScatterDataNode(
+          "scatter.assign.grad", SN->getResult(), RI->getResult(),
+          RG ? RG->getResult() : OutputG, /*cumulative*/ false);
       toAppend.push_back(SA);
       map.addGradient(Data, SA);
       continue;

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1911,11 +1911,11 @@ GatherRangesNode *Function::createGatherRanges(llvm::StringRef name,
       ranges));
 }
 
-ScatterAssignNode *Function::createScatterAssign(llvm::StringRef name,
-                                                 NodeValue data,
-                                                 NodeValue indices,
-                                                 NodeValue slices) {
-  return addNode(new ScatterAssignNode(name, data, indices, slices));
+ScatterDataNode *Function::createScatterData(llvm::StringRef name,
+                                             NodeValue data, NodeValue indices,
+                                             NodeValue slices,
+                                             bool cumulative) {
+  return addNode(new ScatterDataNode(name, data, indices, slices, cumulative));
 }
 
 BatchOneHotNode *Function::createBatchOneHot(llvm::StringRef name,

--- a/lib/IR/IRGen.cpp
+++ b/lib/IR/IRGen.cpp
@@ -298,16 +298,16 @@ void IRGenVisitor::post(Node *parent, Node *N) {
     registerIR(N, dest);
     break;
   }
-  case glow::Kinded::Kind::ScatterAssignNodeKind: {
-    auto *SAI = cast<ScatterAssignNode>(N);
-    auto *dataTensor = valueForNode(SAI->getData());
-    auto *indicesTensor = valueForNode(SAI->getIndices());
-    auto *slicesTensor = valueForNode(SAI->getSlices());
-    auto *dest = builder_.createAllocActivationInst(SAI->getName(),
-                                                    SAI->getResult().getType());
-    builder_.createCopyInst("copy.scatterassign", dest, dataTensor);
-    builder_.createScatterAssignInst("scatterassign", dest, indicesTensor,
-                                     slicesTensor);
+  case glow::Kinded::Kind::ScatterDataNodeKind: {
+    auto *SDI = cast<ScatterDataNode>(N);
+    auto *dataTensor = valueForNode(SDI->getData());
+    auto *indicesTensor = valueForNode(SDI->getIndices());
+    auto *slicesTensor = valueForNode(SDI->getSlices());
+    auto *dest = builder_.createAllocActivationInst(SDI->getName(),
+                                                    SDI->getResult().getType());
+    builder_.createCopyInst("copy.scatterdata", dest, dataTensor);
+    builder_.createScatterDataInst("scatterdata", dest, indicesTensor,
+                                   slicesTensor, SDI->getCumulative());
     registerIR(N, dest);
     break;
   }

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -1092,7 +1092,10 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     NodeValue slices;
     ASSIGN_VALUE_OR_RETURN_ERR(slices, getNodeValueByName(op.input(2)));
 
-    Node *SAN = G_.createScatterAssign(opName, data, indices, slices);
+    assert(indices.dims().size() == 1 && "Indices should be 1-dimensional!");
+    NodeValue indices2D =
+        G_.createReshape("indices.2d", indices, {indices.dims()[0], 1});
+    Node *SAN = G_.createScatterData(opName, data, indices2D, slices);
     RETURN_IF_ERR(addNodeAsOutput(op, SAN));
     return llvm::Error::success();
   }

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -1326,7 +1326,7 @@ ONNXModelLoader::loadScatterAssign(const ONNX_NAMESPACE::NodeProto &op,
   NodeValue slices;
   ASSIGN_VALUE_OR_RETURN_ERR(slices, getNodeValueByName(op.input(2)));
 
-  Node *N = G_.createScatterAssign(loadOperatorName(op), data, indices, slices);
+  Node *N = G_.createScatterData(loadOperatorName(op), data, indices, slices);
 
   RETURN_IF_ERR(addNodeAsOutput(op, N));
   return llvm::Error::success();

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -2415,12 +2415,12 @@ TEST_P(OperatorTest, BatchedGather) {
   EXPECT_FLOAT_EQ(H.at({2, 1}), 1.2);
 }
 
-TEST_P(OperatorTest, ScatterAssign) {
+TEST_P(OperatorTest, ScatterData) {
   ENABLED_BACKENDS(Interpreter, CPU, OpenCL);
 
   auto *data = mod_.createPlaceholder(ElemKind::FloatTy, {5, 2}, "data", false);
   auto *indices =
-      mod_.createPlaceholder(ElemKind::Int64ITy, {2}, "indices", false);
+      mod_.createPlaceholder(ElemKind::Int64ITy, {2, 1}, "indices", false);
   auto *slices =
       mod_.createPlaceholder(ElemKind::FloatTy, {2, 2}, "slices", false);
 
@@ -2428,7 +2428,7 @@ TEST_P(OperatorTest, ScatterAssign) {
   bindings_.allocate(indices)->getHandle<int64_t>() = {1, 3};
   bindings_.allocate(slices)->getHandle() = {-3, -4, -7, -8};
 
-  auto *R = F_->createScatterAssign("scatterassign", data, indices, slices);
+  auto *R = F_->createScatterData("scatterdata", data, indices, slices);
 
   auto *result = F_->createSave("save", R);
   bindings_.allocate(result->getPlaceholder());
@@ -2450,12 +2450,12 @@ TEST_P(OperatorTest, ScatterAssign) {
   EXPECT_FLOAT_EQ(H.at({4, 1}), 10.0);
 }
 
-TEST_P(OperatorTest, ScatterAssignQuantized) {
+TEST_P(OperatorTest, ScatterDataQuantized) {
   ENABLED_BACKENDS(Interpreter, CPU);
 
   auto *data = mod_.createPlaceholder(ElemKind::FloatTy, {5, 2}, "data", false);
   auto *indices =
-      mod_.createPlaceholder(ElemKind::Int64ITy, {2}, "indices", false);
+      mod_.createPlaceholder(ElemKind::Int64ITy, {2, 1}, "indices", false);
   auto *slices =
       mod_.createPlaceholder(ElemKind::FloatTy, {2, 2}, "slices", false);
 
@@ -2471,7 +2471,7 @@ TEST_P(OperatorTest, ScatterAssignQuantized) {
 
   auto *dataQ = F_->createQuantize("quantizeQ", data, dataTy);
   auto *slicesQ = F_->createQuantize("quantizeS", slices, slicesTy);
-  auto *SA = F_->createScatterAssign("scatterassign", dataQ, indices, slicesQ);
+  auto *SA = F_->createScatterData("scatterdata", dataQ, indices, slicesQ);
   auto *DQ = F_->createDequantize("dequantize", SA);
 
   auto *result = F_->createSave("save", DQ);
@@ -2492,6 +2492,238 @@ TEST_P(OperatorTest, ScatterAssignQuantized) {
   EXPECT_NEAR(H.at({3, 1}), -8.0, 0.05);
   EXPECT_NEAR(H.at({4, 0}), 9.0, 0.05);
   EXPECT_NEAR(H.at({4, 1}), 10.0, 0.05);
+}
+
+TEST_P(OperatorTest, ScatterDataNDimensionalSimple) {
+  ENABLED_BACKENDS(Interpreter, CPU);
+
+  // Data = {{1,2},{3,4},{5,6}}
+  // Slices = {-3,-4}
+  // Indices = {{1,0},{1,1}}
+  // Result = {{1,2},{-3,-4},{5,6}}
+  auto *data = mod_.createPlaceholder(ElemKind::FloatTy, {3, 2}, "data", false);
+  auto *indices =
+      mod_.createPlaceholder(ElemKind::Int64ITy, {2, 2}, "indices", false);
+  auto *slices =
+      mod_.createPlaceholder(ElemKind::FloatTy, {2}, "slices", false);
+
+  // Fill tensor with consecutive data.
+  std::vector<float> init(6);
+  std::iota(init.begin(), init.end(), 1);
+  bindings_.allocate(data)->getHandle() = init;
+  bindings_.allocate(indices)->getHandle<int64_t>() = {1, 0, 1, 1};
+  bindings_.allocate(slices)->getHandle() = {-3., -4.};
+  auto *R = F_->createScatterData("scatterdata", data, indices, slices);
+
+  auto *result = F_->createSave("save", R);
+  bindings_.allocate(result->getPlaceholder());
+
+  EE_.compile(CompilationMode::Infer);
+  EE_.run(bindings_);
+
+  std::vector<size_t> expectedDims = {3, 2};
+  std::vector<float> expectedValues = {1., 2., -3., -4., 5., 6.};
+  auto H = bindings_.get(result->getPlaceholder())->getHandle();
+  EXPECT_TRUE(H.dims().vec() == expectedDims);
+  for (size_t i = 0; i < expectedValues.size(); i++) {
+    EXPECT_EQ(expectedValues[i], H.raw(i));
+  }
+}
+
+TEST_P(OperatorTest, ScatterDataNDimensional) {
+  ENABLED_BACKENDS(Interpreter, CPU);
+
+  // In tensor 2x4x4x3, make two updates with 2-dimensional slices by
+  // 2-dimensional indices:
+  // 1. By index [0, 3], set [[-1.,  -2.,  -3.]
+  //                          [-4.,  -5.,  -6.]
+  //                          [-7.,  -8.,  -9.]
+  //                          [-10., -11., -12.]];
+  //
+  // 2. By index [1, 1], set [[-13., -14., -15.]
+  //                          [-16., -17., -18.]
+  //                          [-19., -20., -21.]
+  //                          [-22., -23., -24.]];
+  //
+  auto *data =
+      mod_.createPlaceholder(ElemKind::FloatTy, {2, 4, 4, 3}, "data", false);
+  auto *indices =
+      mod_.createPlaceholder(ElemKind::Int64ITy, {2, 2}, "indices", false);
+  auto *slices =
+      mod_.createPlaceholder(ElemKind::FloatTy, {2, 4, 3}, "slices", false);
+
+  // Fill tensor with consecutive data.
+  std::vector<float> init(2 * 4 * 4 * 3);
+  std::iota(init.begin(), init.end(), 0);
+  bindings_.allocate(data)->getHandle() = init;
+  bindings_.allocate(indices)->getHandle<int64_t>() = {0, 3, 1, 1};
+  std::vector<float> initUpdates;
+  for (int32_t i = -1; i > -25; i--) {
+    initUpdates.push_back(static_cast<float>(i));
+  }
+  bindings_.allocate(slices)->getHandle() = initUpdates;
+
+  auto *R = F_->createScatterData("scatterdata", data, indices, slices);
+
+  auto *result = F_->createSave("save", R);
+  bindings_.allocate(result->getPlaceholder());
+
+  EE_.compile(CompilationMode::Infer);
+  EE_.run(bindings_);
+
+  std::vector<size_t> expectedDims = {2, 4, 4, 3};
+  std::vector<float> expectedValues = {
+      0.0f,   1.0f,   2.0f,   3.0f,   4.0f,   5.0f,
+      6.0f,   7.0f,   8.0f,   9.0f,   10.0f,  11.0f,
+
+      12.0f,  13.0f,  14.0f,  15.0f,  16.0f,  17.0f,
+      18.0f,  19.0f,  20.0f,  21.0f,  22.0f,  23.0f,
+
+      24.0f,  25.0f,  26.0f,  27.0f,  28.0f,  29.0f,
+      30.0f,  31.0f,  32.0f,  33.0f,  34.0f,  35.0f,
+
+      -1.0f,  -2.0f,  -3.0f,  -4.0f,  -5.0f,  -6.0f,
+      -7.0f,  -8.0f,  -9.0f,  -10.0f, -11.0f, -12.0f,
+
+      48.0f,  49.0f,  50.0f,  51.0f,  52.0f,  53.0f,
+      54.0f,  55.0f,  56.0f,  57.0f,  58.0f,  59.0f,
+
+      -13.0f, -14.0f, -15.0f, -16.0f, -17.0f, -18.0f,
+      -19.0f, -20.0f, -21.0f, -22.0f, -23.0f, -24.0f,
+
+      72.0f,  73.0f,  74.0f,  75.0f,  76.0f,  77.0f,
+      78.0f,  79.0f,  80.0f,  81.0f,  82.0f,  83.0f,
+
+      84.0f,  85.0f,  86.0f,  87.0f,  88.0f,  89.0f,
+      90.0f,  91.0f,  92.0f,  93.0f,  94.0f,  95.0f};
+  auto H = bindings_.get(result->getPlaceholder())->getHandle();
+  EXPECT_TRUE(H.dims().vec() == expectedDims);
+  for (size_t i = 0; i < expectedValues.size(); i++) {
+    EXPECT_EQ(expectedValues[i], H.raw(i));
+  }
+}
+
+TEST_P(OperatorTest, ScatterAddQuantized) {
+  ENABLED_BACKENDS(Interpreter, CPU);
+
+  auto *data = mod_.createPlaceholder(ElemKind::FloatTy, {5, 2}, "data", false);
+  auto *indices =
+      mod_.createPlaceholder(ElemKind::Int64ITy, {2, 1}, "indices", false);
+  auto *slices =
+      mod_.createPlaceholder(ElemKind::FloatTy, {2, 2}, "slices", false);
+
+  bindings_.allocate(data)->getHandle() = {1, 2, -3, -8, 5, 6, 7, 8, 9, 10};
+  bindings_.allocate(indices)->getHandle<int64_t>() = {1, 3};
+  bindings_.allocate(slices)->getHandle() = {3, -8, -7, 8};
+
+  auto qParams = glow::quantization::chooseQuantizationParams(-11, 11);
+  auto dataTy =
+      mod_.uniqueType(ElemKind::Int8QTy, {5, 2}, qParams.scale, qParams.offset);
+  auto slicesTy =
+      mod_.uniqueType(ElemKind::Int8QTy, {2, 2}, qParams.scale, qParams.offset);
+
+  auto *dataQ = F_->createQuantize("quantizeQ", data, dataTy);
+  auto *slicesQ = F_->createQuantize("quantizeS", slices, slicesTy);
+  auto *SA = F_->createScatterData("scatteradd", dataQ, indices, slicesQ,
+                                   /*Cumulative*/ true);
+  auto *DQ = F_->createDequantize("dequantize", SA);
+
+  auto *result = F_->createSave("save", DQ);
+  bindings_.allocate(result->getPlaceholder());
+
+  EE_.compile(CompilationMode::Infer);
+  EE_.run(bindings_);
+
+  auto H = bindings_.get(result->getPlaceholder())->getHandle();
+
+  EXPECT_NEAR(H.at({0, 0}), 1.0, 0.05);
+  EXPECT_NEAR(H.at({0, 1}), 2.0, 0.05);
+  EXPECT_NEAR(H.at({1, 0}), 0.0, 0.05);
+  EXPECT_NEAR(H.at({1, 1}), -11.0, 0.05);
+  EXPECT_NEAR(H.at({2, 0}), 5.0, 0.05);
+  EXPECT_NEAR(H.at({2, 1}), 6.0, 0.05);
+  EXPECT_NEAR(H.at({3, 0}), 0.0, 0.05);
+  EXPECT_NEAR(H.at({3, 1}), 11.0, 0.05);
+  EXPECT_NEAR(H.at({4, 0}), 9.0, 0.05);
+  EXPECT_NEAR(H.at({4, 1}), 10.0, 0.05);
+}
+
+TEST_P(OperatorTest, ScatterAddNDimensionalSimple) {
+  ENABLED_BACKENDS(Interpreter, CPU);
+  // Test that scatter addition works.
+  // Data = {{1,2},{3,4},{5,6}}
+  // Slices = {-3,-4}
+  // Indices = {{1,0},{1,1}}
+  // Result = {{1,2},{0,0},{5,6}}
+  auto *data = mod_.createPlaceholder(ElemKind::FloatTy, {3, 2}, "data", false);
+  auto *indices =
+      mod_.createPlaceholder(ElemKind::Int64ITy, {2, 2}, "indices", false);
+  auto *slices =
+      mod_.createPlaceholder(ElemKind::FloatTy, {2}, "slices", false);
+
+  // Fill tensor with consecutive data.
+  std::vector<float> init;
+  for (int32_t i = 1; i < 7; i++) {
+    init.push_back(static_cast<float>(i));
+  }
+  bindings_.allocate(data)->getHandle() = init;
+  bindings_.allocate(indices)->getHandle<int64_t>() = {1, 0, 1, 1};
+  bindings_.allocate(slices)->getHandle() = {-3., -4.};
+  auto *R = F_->createScatterData("scatteradd", data, indices, slices,
+                                  /*Cumulative*/ true);
+
+  auto *result = F_->createSave("save", R);
+  bindings_.allocate(result->getPlaceholder());
+
+  EE_.compile(CompilationMode::Infer);
+  EE_.run(bindings_);
+
+  std::vector<size_t> expectedDims = {3, 2};
+  std::vector<float> expectedValues = {1., 2., 0., 0., 5., 6.};
+  auto H = bindings_.get(result->getPlaceholder())->getHandle();
+  EXPECT_TRUE(H.dims().vec() == expectedDims);
+  for (size_t i = 0; i < expectedValues.size(); i++) {
+    EXPECT_EQ(expectedValues[i], H.raw(i));
+  }
+}
+
+TEST_P(OperatorTest, ScatterAddNDimensionalDuplicatingIndices) {
+  ENABLED_BACKENDS(Interpreter, CPU);
+  // Test that scatter addition with duplicating indices works.
+  // Data = {{1,2},{3,4},{5,6}}
+  // Slices = {-3,-4,-3,-4}
+  // Indices = {{1,0},{1,1}{1,0},{1,1}}
+  // Result = {{1,2},{-3,-4},{5,6}}
+  auto *data = mod_.createPlaceholder(ElemKind::FloatTy, {3, 2}, "data", false);
+  auto *indices =
+      mod_.createPlaceholder(ElemKind::Int64ITy, {4, 2}, "indices", false);
+  auto *slices =
+      mod_.createPlaceholder(ElemKind::FloatTy, {4}, "slices", false);
+
+  // Fill tensor with consecutive data.
+  std::vector<float> init;
+  for (int32_t i = 1; i < 7; i++) {
+    init.push_back(static_cast<float>(i));
+  }
+  bindings_.allocate(data)->getHandle() = init;
+  bindings_.allocate(indices)->getHandle<int64_t>() = {1, 0, 1, 1, 1, 0, 1, 1};
+  bindings_.allocate(slices)->getHandle() = {-3., -4., -3., -4.};
+  auto *R = F_->createScatterData("scatteradd", data, indices, slices,
+                                  /*Cumulative*/ true);
+
+  auto *result = F_->createSave("save", R);
+  bindings_.allocate(result->getPlaceholder());
+
+  EE_.compile(CompilationMode::Infer);
+  EE_.run(bindings_);
+
+  std::vector<size_t> expectedDims = {3, 2};
+  std::vector<float> expectedValues = {1., 2., -3., -4., 5., 6.};
+  auto H = bindings_.get(result->getPlaceholder())->getHandle();
+  EXPECT_TRUE(H.dims().vec() == expectedDims);
+  for (size_t i = 0; i < expectedValues.size(); i++) {
+    EXPECT_EQ(expectedValues[i], H.raw(i));
+  }
 }
 
 #define COMPARE_ARITH_FUN(_OP_NAME_)                                           \

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -566,10 +566,11 @@ int main(int argc, char **argv) {
       .autoVerify(VerifyKind::SameElementType, {"Ranges", "Lengths"})
       .autoIRGen();
 
-  BB.newInstr("ScatterAssign")
+  BB.newInstr("ScatterData")
       .addOperand("Data", OperandKind::InOut)
       .addOperand("Indices", OperandKind::In)
       .addOperand("Slices", OperandKind::In)
+      .addMember(MemberType::Boolean, "Cumulative")
       .autoVerify(VerifyKind::SameElementType,
                   {"Indices", "ElemKind::Int64ITy"});
 

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -661,15 +661,24 @@ int main(int argc, char **argv) {
                     "lengths of the ranges gathered by each list of pairs in "
                     "Ranges.");
 
-  BB.newNode("ScatterAssign")
+  BB.newNode("ScatterData")
       .addInput("Data")
       .addInput("Indices")
       .addInput("Slices")
+      .addMember(MemberType::Boolean, "Cumulative")
       .addResult("Data.getType()")
-      .setDocstring("Copies each slice from Slices into Data at the "
-                    "corresponding index in Indices. For example, given input "
-                    "Data {{1,2},{3,4},{5,6}}, Slices {{-3,-4}}, and Indices "
-                    "{1}, the result is {{1,2},{-3,-4},{5,6}}.");
+      .setDocstring(
+          "Copies each slice from Slices into Data at the "
+          "corresponding index in Indices. For example, given input "
+          "Data {{1,2},{3,4},{5,6}}, Slices {{-3,-4}}, and Indices "
+          "{{1}}, the result is {{1,2},{-3,-4},{5,6}}. It also supports "
+          "multi-dimensional indices. For example, given input Data "
+          "{{1,2},{3,4},{5,6}}, Slices {-3,-4}, and Indices {{1,0},{1,1}} also "
+          "produces {{1,2},{-3,-4},{5,6}}. If Cumulative is true, the node "
+          "adds values from Slices to Data instead of copying. For example, "
+          "given input Data {{1,2},{3,4},{5,6}}, Slices {{-3,-4}}, and Indices "
+          "{1}, the result is {{1,2},{0,0},{5,6}}. If an index is specified "
+          "several times, its updates will be added several times as well.");
 
   BB.newNode("Tile")
       .addInput("Input")


### PR DESCRIPTION
Summary:

This patch generalizes ScatterAssign node. It makes it capable of setting (N-K)
dimensional values by K-dimensional indices to N-dimensional destination.
Without this patch, only K=1 is supported.

It also adds "Cumulative" flag to ScatterAssign instruction. If it is set to
True, then the instruction will add values from Updates to Data by specified
indices instead of copying.

ScatterAssign node is renamed to ScatterData (with optionally set Cumulative
flag) to better reflect its new functionality after changes.

Added support for Interpreter and CPU backends only. OpenCL support can be
added separately by request.

This patch is a preparation step to support of ScatterNd node.

Based on discussion #3153

Test Plan:
Added unit tests. NFCI for existing nodes.

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
