### PR TITLE
[RecommendationSystemTest] Enable tracing

### DIFF
--- a/lib/ExecutionContext/TraceEvents.cpp
+++ b/lib/ExecutionContext/TraceEvents.cpp
@@ -53,6 +53,13 @@ void TraceEvent::dumpTraceEvents(
   auto process = processName.empty() ? "glow" : processName;
 
   std::ofstream file(filename);
+
+  // Print an error message if the output stream can't be created.
+  if (!file.is_open()) {
+    llvm::errs() << "Unable to open file " << filename << "\n";
+    return;
+  }
+
   file << "[\n";
   /// Set up process name metadata.
   writeMetadataHelper(file, "process_name", 0,

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -400,6 +400,7 @@ target_link_libraries(RecommendationSystemTest
                         Converter
                         Graph
                         IR
+                        ExecutionContext
                         ExecutionEngine
                         Quantization
                         Partitioner


### PR DESCRIPTION
**Description**
This commit enables tracing for RecommendationSystemTest. The traces are
saved to files with a prefix specified by the `-trace-dir` option. The
unique path for each test is obtained by appending to this prefix the
name of its containing test case as well as its name. This commit also
adds code to print an error message if the trace file cannot be
opened for whatever reason.

**Test Plan**
Ran the test with and without the option. With the option, a trace is
dumped for each test 
```
$ ./tests/RecommendationSystemTest -trace-dir=./traces/
...
$ ls traces
RecSys_FP32-0-RecSys-RecommendationSystemTest.json					RecSys_Partitioned_RWQuantized_SLWS_FC_FP16-2-RecSys-RecommendationSystemTest.json
RecSys_FP32-1-RecSys-RecommendationSystemTest.json					RecSys_Partitioned_RWQuantized_SLWS_FP16-0-RecSys-RecommendationSystemTest.json
RecSys_FP32-2-RecSys-RecommendationSystemTest.json					RecSys_Partitioned_RWQuantized_SLWS_FP16-1-RecSys-RecommendationSystemTest.json
RecSys_FP32_Gather_Weights-0-RecSys-RecommendationSystemTest.json			RecSys_Partitioned_RWQuantized_SLWS_FP16-2-RecSys-RecommendationSystemTest.json
RecSys_FP32_Gather_Weights-1-RecSys-RecommendationSystemTest.json			RecSys_RWQuantized_SLWS-0-RecSys-RecommendationSystemTest.json
RecSys_FP32_Gather_Weights-2-RecSys-RecommendationSystemTest.json			RecSys_RWQuantized_SLWS-1-RecSys-RecommendationSystemTest.json-RecSys_FP32_Medium_Gather_Weights-0-RecSys-RecommendationSystemTest.json		RecSys_RWQuantized_SLWS-2-RecSys-RecommendationSystemTest.json
RecSys_FP32_Medium_Gather_Weights-1-RecSys-RecommendationSystemTest.json		RecSys_RWQuantized_SLWS_FC-0-RecSys-RecommendationSystemTest.json-RecSys_FP32_Medium_Gather_Weights-2-RecSys-RecommendationSystemTest.json		RecSys_RWQuantized_SLWS_FC-1-RecSys-RecommendationSystemTest.json
RecSys_FP32_Partitioned-0-RecSys-RecommendationSystemTest.json				RecSys_RWQuantized_SLWS_FC-2-RecSys-RecommendationSystemTest.json
RecSys_FP32_Partitioned-1-RecSys-RecommendationSystemTest.json				RecSys_RWQuantized_SLWS_FC_FP16-0-RecSys-RecommendationSystemTest.json
RecSys_FP32_Partitioned-2-RecSys-RecommendationSystemTest.json				RecSys_RWQuantized_SLWS_FC_FP16-1-RecSys-RecommendationSystemTest.json
RecSys_Partitioned_RWQuantized_SLWS-0-RecSys-RecommendationSystemTest.json		RecSys_RWQuantized_SLWS_FC_FP16-2-RecSys-RecommendationSystemTest.json
RecSys_Partitioned_RWQuantized_SLWS-1-RecSys-RecommendationSystemTest.json		RecSys_RWQuantized_SLWS_FP16-0-RecSys-RecommendationSystemTest.json
RecSys_Partitioned_RWQuantized_SLWS-2-RecSys-RecommendationSystemTest.json		RecSys_RWQuantized_SLWS_FP16-1-RecSys-RecommendationSystemTest.json
RecSys_Partitioned_RWQuantized_SLWS_FC-0-RecSys-RecommendationSystemTest.json		RecSys_RWQuantized_SLWS_FP16-2-RecSys-RecommendationSystemTest.json
RecSys_Partitioned_RWQuantized_SLWS_FC-1-RecSys-RecommendationSystemTest.json		RecSys_SLS_Only-0-RecSys-RecommendationSystemTest.json
RecSys_Partitioned_RWQuantized_SLWS_FC-2-RecSys-RecommendationSystemTest.json		RecSys_SLS_Only-1-RecSys-RecommendationSystemTest.json
RecSys_Partitioned_RWQuantized_SLWS_FC_FP16-0-RecSys-RecommendationSystemTest.json	RecSys_SLS_Only-2-RecSys-RecommendationSystemTest.json
RecSys_Partitioned_RWQuantized_SLWS_FC_FP16-1-RecSys-RecommendationSystemTest.json
$ 
```

and can be viewed with `chrome://tracing`. 

![Screen Shot 2019-07-08 at 5 15 32 PM](https://user-images.githubusercontent.com/4392003/60850406-10330b80-a1a4-11e9-9028-0ec050f70ddc.png)


Without the option, no traces are dumped.
