### PR TITLE
cloneFunInsideFun now deletes tmp functions.

### DIFF
--- a/tests/unittests/BackendTestUtils.cpp
+++ b/tests/unittests/BackendTestUtils.cpp
@@ -252,6 +252,7 @@ std::unordered_set<Tensor *> cloneFunInsideFun(FunctionTensorPair FTP,
     for (auto &N : clonedNodes) {
       origF->takeOwnershipOfNode(N);
     }
+    mod->eraseFunction(tmpF);
   }
   // Now erase the clone we used to copy in, as it's no longer needed.
   mod->eraseFunction(cloneF);


### PR DESCRIPTION
Summary:
This adds additional cleanup to cloneFunInsideFun, deleting the temporary Functions created from cloning.
Documentation:

Test Plan: ninja test
