### PR TITLE
[Optimization] Sink transpose node below quantized node

### DIFF
--- a/lib/Backends/Habana/Habana.cpp
+++ b/lib/Backends/Habana/Habana.cpp
@@ -1800,30 +1800,6 @@ bool HabanaBackend::transformPostLowering(Function *F,
       changed = true;
       continue;
     }
-
-    // Sink TransposeNode below QuantizedNode.
-    // Motivations:
-    // 1. This way, TransposeNode has to transpose fewer bytes.
-    // 2. In Habana GC's current version, QuantizeNode will have better
-    // performance when
-    //    FCD is large. In typical case, this sequence is encountered at the
-    //    beginning of vision topologies, where the FCD=W so it is large, and
-    //    after the transpose FCD=C=3 so it is small.
-    if (auto *quant = llvm::dyn_cast<QuantizeNode>(&node)) {
-      auto *transpose = llvm::dyn_cast<TransposeNode>(quant->getInput());
-      if (!transpose) {
-        continue;
-      }
-      auto transposeOutTy = F->getParent()->uniqueTypeWithNewShape(
-          quant->getResult().getType(), transpose->getInput().dims());
-      auto *newQuant = F->createQuantize(quant->getName(),
-                                         transpose->getInput(), transposeOutTy);
-      auto *newTranspose = F->createTranspose(transpose->getName(), newQuant,
-                                              transpose->getShuffle());
-      quant->getResult().replaceAllUsesOfWith(newTranspose);
-      changed = true;
-      continue;
-    }
   }
 
   return changed;

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -482,8 +482,7 @@ bool SinkCode::run(Function *F) {
 
       auto newQType = F->getParent()->uniqueTypeWithNewShape(
           Q->getResult().getType(), TR->getInput().dims());
-      auto *newQ =
-          F->createQuantize(Q->getName(), TR->getInput(), newQType);
+      auto *newQ = F->createQuantize(Q->getName(), TR->getInput(), newQType);
       auto *newTR = F->createTranspose(TR->getName(), newQ, TR->getShuffle());
       Q->getResult().replaceAllUsesOfWith(newTR);
       changed = true;

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -472,6 +472,23 @@ bool SinkCode::run(Function *F) {
       node->getNthResult(ArithmeticNode::ResultIdx).replaceAllUsesOfWith(newTR);
     }
 
+    // Sink TransposeNode below QuantizedNode.
+    // If it doesn't work out it will be re-sinked later.
+    if (auto *Q = dyn_cast<QuantizeNode>(node)) {
+      auto *TR = dyn_cast<TransposeNode>(Q->getInput());
+      if (!TR) {
+        continue;
+      }
+
+      auto newQType = F->getParent()->uniqueTypeWithNewShape(
+          Q->getResult().getType(), TR->getInput().dims());
+      auto *newQ =
+          F->createQuantize(Q->getName(), TR->getInput(), newQType);
+      auto *newTR = F->createTranspose(TR->getName(), newQ, TR->getShuffle());
+      Q->getResult().replaceAllUsesOfWith(newTR);
+      changed = true;
+    }
+
     // Sink Transpose below RescaleQuantized.
     // Potentially exposes opportunity to be combined up with Convolution.
     // If it doesn't work out it will be re-sinked later.

--- a/tests/unittests/GraphOptzTest.cpp
+++ b/tests/unittests/GraphOptzTest.cpp
@@ -530,7 +530,7 @@ public:
           ->getResult();
     }
     }
-  };
+  }
 };
 
 TEST_P(GraphOptzSinkTransposeBelowParametrized,

--- a/tests/unittests/GraphOptzTest.cpp
+++ b/tests/unittests/GraphOptzTest.cpp
@@ -527,9 +527,7 @@ public:
           "quantize", T,
           mod_.uniqueType(ElemKind::Int8QTy, T->dims(0), 0.03, 5));
     }
-    default: {
-      return nullptr;
-    }
+    default: { return nullptr; }
     }
   };
 };


### PR DESCRIPTION
Summary:
Adding sink transpose node below quantized node and remove the logic from habana.
In addition refactored tests that are mostly similar to use parametrized testing pattern.

Documentation:
N/A

Fixes https://github.com/pytorch/glow/issues/3006

Test Plan:
Updated unit tests. 
`ninja test` passes.
