### PR TITLE
Delete temporary PH when constant folding

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -117,6 +117,11 @@ public:
   /// Erase the constant \p I from the Module.
   void eraseConstant(ConstList::iterator I);
 
+  /// Erase the placeholder \p I from the Module.
+  /// Note: we only provide an iterator version of this, as erasing Placeholders
+  /// is often unsafe.
+  void erasePlaceholder(PlaceholderList::iterator I);
+
   /// \returns a pointer to the first variable with the name \p name or nullptr
   /// if no node has this name.
   Constant *getConstantByName(llvm::StringRef name) const;

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -2821,6 +2821,16 @@ void Module::eraseConstant(ConstList::iterator I) {
   constants_.erase(I);
 }
 
+void Module::erasePlaceholder(PlaceholderList::iterator I) {
+  if (I == placeholders_.end()) {
+    return;
+  }
+
+  logStorageDeletion(functions_, *I);
+  delete *I;
+  placeholders_.erase(I);
+}
+
 void Function::eraseNode(NodesList::iterator I) {
   // Log node deletion.
   logCtx_->logNodeDeletion(*I);

--- a/lib/Optimizer/GraphOptimizer/ConstantFolding.cpp
+++ b/lib/Optimizer/GraphOptimizer/ConstantFolding.cpp
@@ -152,6 +152,11 @@ evaluateConstantOperation(Backend &backend, CompilationContext &cctx, Node *C) {
     auto *constResult =
         mod.createConstant(SN->getName(), std::move(*outputTensor));
     constResults.emplace_back(constResult);
+
+    // Now erase the Placeholder that we created for the SaveNode.
+    auto &vars = mod.getPlaceholders();
+    mod.erasePlaceholder(
+        std::find(vars.begin(), vars.end(), SN->getPlaceholder()));
   }
   // Remove the temporary function.
   mod.eraseFunction(constEvaluationF);


### PR DESCRIPTION
Summary: When evaluating constant folding, we clone the node and all it's dependencies into a new function then add a SaveNode to check its output. This SaveNode comes attached with a Placeholder which is not removed when the temporary function is, this PR manually removes that placeholder when finished with it.

Should be safe because theres no way for the outside world to get a handle to this temporary placeholder.

Found using the Compilation Log, before:

```
[FULL SCOPE: ->glow::optimizeFunctionBeforeLowering->glow::optimize->glow::constantFold] --- CREATE { (Kind: Placeholder, Name: broadcast_InceptionV1_InceptionV1_Conv2d_1a_7x7_BatchNorm_batchnorm_sub__4__cf__1002_0_tile2) <==  }
[FULL SCOPE: ->glow::optimizeFunctionBeforeLowering->glow::optimize->glow::constantFold] --- CREATE { (Kind: Constant, Name: broadcast_InceptionV1_InceptionV1_Conv2d_1a_7x7_BatchNorm_batchnorm_sub__4__cf__1002_0_tile21) <==  }
[FULL SCOPE: ->glow::optimizeFunctionBeforeLowering->glow::optimize->glow::constantFold ] --- NODE_INPUT_CHANGE { User(Kind: Add, Name: InceptionV1_InceptionV1_Conv2d_1a_7x7_BatchNorm_batchnorm_add_1) :: PrevOprValue(Kind: Tile, Name: broadcast_InceptionV1_InceptionV1_Conv2d_1a_7x7_BatchNorm_batchnorm_sub__4__cf__1002_0_tile2, ResNo: 0) -> NewOprValue(Kind: Constant, Name: broadcast_InceptionV1_InceptionV1_Conv2d_1a_7x7_BatchNorm_batchnorm_sub__4__cf__1002_0_tile21, ResNo: 0) }
```

after:

```
[FULL SCOPE: ->glow::optimizeFunctionBeforeLowering->glow::optimize->glow::constantFold] --- CREATE { (Kind: Placeholder, Name: broadcast_InceptionV1_InceptionV1_Conv2d_1a_7x7_BatchNorm_batchnorm_sub__4__cf__1002_0_tile2) <==  }
[FULL SCOPE: ->glow::optimizeFunctionBeforeLowering->glow::optimize->glow::constantFold] --- CREATE { (Kind: Constant, Name: broadcast_InceptionV1_InceptionV1_Conv2d_1a_7x7_BatchNorm_batchnorm_sub__4__cf__1002_0_tile21) <==  }
[FULL SCOPE: ->glow::optimizeFunctionBeforeLowering->glow::optimize->glow::constantFold ] --- DELETE ( (Kind: Placeholder, Name: broadcast_InceptionV1_InceptionV1_Conv2d_1a_7x7_BatchNorm_batchnorm_sub__4__cf__1002_0_tile2) }
[FULL SCOPE: ->glow::optimizeFunctionBeforeLowering->glow::optimize->glow::constantFold ] --- NODE_INPUT_CHANGE { User(Kind: Add, Name: InceptionV1_InceptionV1_Conv2d_1a_7x7_BatchNorm_batchnorm_add_1) :: PrevOprValue(Kind: Tile, Name: broadcast_InceptionV1_InceptionV1_Conv2d_1a_7x7_BatchNorm_batchnorm_sub__4__cf__1002_0_tile2, ResNo: 0) -> NewOprValue(Kind: Constant, Name: broadcast_InceptionV1_InceptionV1_Conv2d_1a_7x7_BatchNorm_batchnorm_sub__4__cf__1002_0_tile21, ResNo: 0) }
```


Documentation: n/a

Test Plan: unit tests