### PR TITLE
Make Glow build in a subdirectory

### DIFF
--- a/lib/Backends/CPU/CMakeLists.txt
+++ b/lib/Backends/CPU/CMakeLists.txt
@@ -55,15 +55,15 @@ add_custom_command(
     DEPENDS  ${CPURuntime_OBJS} ${CPURuntime_SRCS}
     WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}")
 
-file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/glow/CPU)
+file(MAKE_DIRECTORY ${GLOW_BINARY_DIR}/glow/CPU)
 add_custom_command(
-    OUTPUT ${CMAKE_BINARY_DIR}/glow/CPU/libjit_bc.inc
-    COMMAND include-bin "${CMAKE_BINARY_DIR}/CPU/libjit.bc" "${CMAKE_BINARY_DIR}/glow/CPU/libjit_bc.inc"
+    OUTPUT ${GLOW_BINARY_DIR}/glow/CPU/libjit_bc.inc
+    COMMAND include-bin "${GLOW_BINARY_DIR}/CPU/libjit.bc" "${GLOW_BINARY_DIR}/glow/CPU/libjit_bc.inc"
     DEPENDS ${GLOW_BINARY_DIR}/CPU/libjit.bc
     WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}")
 
 add_custom_target(CPURuntime
-  DEPENDS ${CMAKE_BINARY_DIR}/glow/CPU/libjit_bc.inc
+  DEPENDS ${GLOW_BINARY_DIR}/glow/CPU/libjit_bc.inc
   WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}")
 
 if (NOT MSVC)
@@ -74,7 +74,7 @@ if (NOT MSVC)
 endif(NOT MSVC)
 
 add_library(CPUBackend
-            "${CMAKE_BINARY_DIR}/glow/CPU/libjit_bc.inc"
+            "${GLOW_BINARY_DIR}/glow/CPU/libjit_bc.inc"
             CPUBackend.cpp
             CPUDeviceManager.cpp
             CPUFactory.cpp

--- a/tests/benchmark/CMakeLists.txt
+++ b/tests/benchmark/CMakeLists.txt
@@ -15,8 +15,8 @@ add_executable(RuntimeBench
                RuntimeBench.cpp)
 target_include_directories(RuntimeBench
                            PRIVATE
-                             ${CMAKE_SOURCE_DIR}/lib/Backends/CPU
-                             ${CMAKE_SOURCE_DIR}/lib/Backends/Interpreter)
+                             ${GLOW_SOURCE_DIR}/lib/Backends/CPU
+                             ${GLOW_SOURCE_DIR}/lib/Backends/Interpreter)
 target_link_libraries(RuntimeBench
                       PRIVATE
                         Backend


### PR DESCRIPTION
Summary: Update CMakeLists.txt to use the current binary dir instead of the top-level binary dir, which allows other projects to depend on Glow via add_subdirectory.

Documentation: None

Related issue: https://github.com/pytorch/glow/issues/3219

Test Plan: ran `cmake` as instructed in the readme, then `ninja clean` and `ninja all`.