### PR TITLE
[ModelRunner] Check that there are no external inputs

### DIFF
--- a/tools/loader/Loader.h
+++ b/tools/loader/Loader.h
@@ -21,6 +21,8 @@
 
 #include "llvm/Support/CommandLine.h"
 
+#include <glog/logging.h>
+
 /// Timer option used to indicate if inferences should be timed -time.
 extern llvm::cl::opt<bool> timeOpt;
 /// Iterations used to indicate the number of iterations to run an inferece

--- a/tools/loader/ModelRunner.cpp
+++ b/tools/loader/ModelRunner.cpp
@@ -46,6 +46,10 @@ int main(int argc, char **argv) {
   Placeholder *output = EXIT_ON_ERR(LD->getSingleOutput());
   auto *outputT = bindings.allocate(output);
 
+  CHECK_EQ(0, std::distance(LD->getInputVarsMapping().keys().begin(),
+                            LD->getInputVarsMapping().keys().end()))
+      << "ModelRunner only supports models with no external inputs.";
+
   std::string modelName = loader.getFunction()->getName().str();
 
   // Compile the model, and perform quantization/emit a bundle/dump debug info


### PR DESCRIPTION
`ModelRunner` is not supposed to be used with models that have external inputs. It's a simple test tool to get started with. Check that no external inputs are found after loading the model.

Related to #3221