### PR TITLE
[CI] Make large host for pytorch.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,6 @@ jobs:
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:283"
     <<: *linux_default
   PYTORCH:
-    resource_class: 2xlarge+
     environment:
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py3.6-clang7-ubuntu16.04:287"
     <<: *linux_default


### PR DESCRIPTION
Summary:
2xlarge+ is not currently available. 

Some comments from https://github.com/pytorch/glow/pull/3164

Documentation:
n/a

cc: @zrphercule 