### PR TITLE
[AutoGen] Fix a bug in VectorFloat hashing

### DIFF
--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -214,6 +214,11 @@ struct NodeValue;
 /// FIXME: This is a workaround, because defining the hash_code
 /// hash_value(float) does not work for some reason.
 size_t toBinary(float f);
+/// Convert a collection of floats into a vector of
+/// unsigned integer binary representation.
+/// FIXME: This is a workaround, because defining the hash_code
+/// hash_value(float) does not work for some reason.
+std::vector<size_t> toBinary(llvm::ArrayRef<float> vec);
 llvm::hash_code hash_value(const glow::Tensor &T);
 
 llvm::hash_code hash_value(const glow::Type *T);

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -1465,6 +1465,15 @@ size_t toBinary(float f) {
   memcpy(&ret, &f, sizeof(float));
   return ret;
 }
+/// Convert a collection of floats into a vector of
+/// unsigned integer binary representation.
+std::vector<size_t> toBinary(llvm::ArrayRef<float> vec) {
+  std::vector<size_t> sizeVec(vec.size());
+  std::for_each(vec.begin(), vec.end(), [&sizeVec](float f) -> void {
+    sizeVec.push_back(toBinary(f));
+  });
+  return sizeVec;
+}
 
 llvm::hash_code hash_value(const glow::Tensor &T) { return T.size(); }
 


### PR DESCRIPTION
The `getHash()` automatically generated function for nodes containing `VectorFloat` member type did not compile:

We called `hash_combine_range` on a standard vector of floats. This is not supported.

This PR adds proper hashing for VectorFloat types.

I have encountered this bug while investigating this issue: https://github.com/pytorch/glow/issues/2986

Looking at the Caffe2 implementation, there's a `std::vector<float>` member as can be seen in this header file: https://github.com/pytorch/pytorch/blob/master/caffe2/operators/bucketize_op.h

We did not encounter this before, so auto generation for `VectorFloat` has not been trialled.