### PR TITLE
Added ExecutionEngine2 as the new runtime backed Engine

### DIFF
--- a/include/glow/ExecutionEngine/ExecutionEngine2.h
+++ b/include/glow/ExecutionEngine/ExecutionEngine2.h
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_EXECUTIONENGINE_EXECUTIONENGINE2_H
+#define GLOW_EXECUTIONENGINE_EXECUTIONENGINE2_H
+
+#include "glow/Backend/Backend.h"
+#include "glow/Backend/CompiledFunction.h"
+#include "glow/Backends/DeviceManager.h"
+#include "glow/Base/Train.h"
+#include "glow/Base/Traits.h"
+#include "glow/Graph/Graph.h"
+#include "glow/Graph/PlaceholderBindings.h"
+#include "glow/Runtime/HostManager/HostManager.h"
+
+#include "llvm/ADT/ArrayRef.h"
+
+#include <memory>
+#include <unordered_map>
+
+namespace glow {
+
+/// This is the ExecutionEngine. It owns the Graph, the backend, and the
+/// compiled function.  The Graph, etc in this class are defined as pointers, in
+/// order to erase the type and prevent the internal types from leaking out to
+/// the users of this class.
+class ExecutionEngine2 final {
+  /// Module containing the function and supporting information.
+  std::unique_ptr<Module> module_;
+
+  /// Raw pointer to module_ this is to support module access after the module
+  /// has been added to hostManager_.
+  Module *rawModule_;
+
+  /// Name of the backend being used for compilation and execution.
+  std::string backendName_ = "";
+
+  /// The HostManager for executing the compiled functions.
+  std::unique_ptr<runtime::HostManager> hostManager_;
+
+  /// Glow functions compiled for this ExecutionEngine's backend.
+  std::set<std::string> compiledFunctions_;
+
+  /// Single execution of the given \compiledFunction with the given context
+  /// \bindings.
+  void runInternal(ExecutionContext &context, llvm::StringRef name);
+
+public:
+  ExecutionEngine2(llvm::StringRef backend = "Interpreter");
+
+  ~ExecutionEngine2();
+
+  /// Set the code generator to \p backend. New code will be generated
+  /// using this backend. This clears all previously loaded functions and resets
+  /// the Module.
+  void setBackendName(llvm::StringRef backend);
+
+  /// Get a pointer to the backend.
+  llvm::StringRef getBackendName() const;
+
+  /// \returns the internal graph.
+  Module &getModule() { return *rawModule_; }
+
+  /// Clears the ExecutionEngine and all CompiledFunctions.
+  void clear();
+
+  /// \returns the DAG for the specified \p network.
+  llvm::Expected<runtime::DAG &> getDAG(llvm::StringRef network) {
+    return hostManager_->getNetworkDAG(network);
+  }
+
+  /// Compiles all functions in the Module with the given \p cctx.  This method
+  /// should be invoked before the run method and can only be called once
+  /// without resetting the backend.
+  void compile(CompilationContext &cctx);
+
+  /// A convenience function for the most common type of compile.
+  void compile(CompilationMode mode);
+
+  /// Context aware single execution of a function. If more than one
+  /// function has been compiled by this ExecutionEngine then a name must be
+  /// supplied to specify which function to run.
+  void run(ExecutionContext &context);
+
+  /// Context aware single execution of a function with the given \p
+  /// name.
+  void run(ExecutionContext &context, llvm::StringRef name);
+
+  /// Context aware single execution of a function. If more than one
+  /// function has been compiled by this ExecutionEngine then a name must be
+  /// supplied to specify which function to run.
+  void run(PlaceholderBindings &bindings);
+
+  /// Context aware single execution of a function with the given \p
+  /// name.
+  void run(PlaceholderBindings &bindings, llvm::StringRef name);
+};
+
+//===----------------------------------------------------------------------===//
+//         Helper methods for running the execution engine.
+//===----------------------------------------------------------------------===//
+
+/// This method updates the placeholders in \p ph with the tensor content
+/// values \p inputs, in \p bindings.
+void updateInputPlaceholders2(PlaceholderBindings &bindings,
+                              llvm::ArrayRef<Placeholder *> ph,
+                              llvm::ArrayRef<Tensor *> inputs);
+
+/// This method updates the placeholders in the module. The placeholders are
+/// found by name
+///  in \p ph with the tensor content values \p inputs.
+void updateInputPlaceholdersByName2(PlaceholderBindings &bindings, Module *mod,
+                                    llvm::ArrayRef<llvm::StringRef> ph,
+                                    llvm::ArrayRef<Tensor *> inputs);
+
+/// Runs \p iterations iterations of the compiled function. The method updates a
+/// global counter and future invocations of this method continue running
+/// iterations of the batch at the next available slice.
+///
+/// The method updates the placeholder in \p ph with the tensors \p inputs. The
+/// shape of the slice has to be identical to the shape of slices in the batch.
+/// All dimensions, except for the first (batch) dimension must be identical.
+///
+/// The variable \p sampleCounter is consumed and updated by the function. This
+/// variable records the number of samples that were consumed by the network in
+/// previous iterations. The next input to be loaded is
+/// (sampleCounter % batchsize).
+void runBatch2(ExecutionEngine2 &EE, PlaceholderBindings &bindings,
+               size_t iterations, size_t &sampleCounter,
+               llvm::ArrayRef<Placeholder *> ph,
+               llvm::ArrayRef<Tensor *> inputs, llvm::StringRef name = "");
+
+} // namespace glow
+
+#endif // GLOW_EXECUTIONENGINE_EXECUTIONENGINE2_H

--- a/include/glow/Runtime/HostManager/HostManager.h
+++ b/include/glow/Runtime/HostManager/HostManager.h
@@ -138,6 +138,9 @@ public:
   /// DeviceManager for each config listed.
   llvm::Error init(std::vector<std::unique_ptr<DeviceConfig>> configs);
 
+  /// Get the network DAG for \p network if it exists.
+  llvm::Expected<DAG &> getNetworkDAG(llvm::StringRef network);
+
   ~HostManager();
 };
 } // namespace runtime

--- a/lib/ExecutionEngine/CMakeLists.txt
+++ b/lib/ExecutionEngine/CMakeLists.txt
@@ -8,3 +8,16 @@ target_link_libraries(ExecutionEngine
                         GraphOptimizer
                         Base
                         Graph)
+
+
+add_library(ExecutionEngine2
+              ExecutionEngine2.cpp)
+
+target_link_libraries(ExecutionEngine2
+                      PRIVATE
+                        Backend
+                        Backends
+                        HostManager
+                        GraphOptimizer
+                        Base
+                        Graph)

--- a/lib/ExecutionEngine/ExecutionEngine2.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine2.cpp
@@ -1,0 +1,207 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/ExecutionEngine/ExecutionEngine2.h"
+#include "glow/Backend/Backend.h"
+#include "glow/Graph/Graph.h"
+#include "glow/Graph/PlaceholderBindings.h"
+#include "glow/Optimizer/GraphOptimizer/GraphOptimizer.h"
+
+#include "llvm/ADT/STLExtras.h"
+
+#include <future>
+
+using namespace glow;
+
+ExecutionEngine2::ExecutionEngine2(llvm::StringRef backend) {
+  setBackendName(backend);
+}
+
+/// Set the code generator to the given \p backend.
+void ExecutionEngine2::setBackendName(llvm::StringRef backend) {
+  module_.reset(new Module);
+  rawModule_ = module_.get();
+  backendName_ = backend;
+  clear();
+
+  if (hostManager_) {
+    EXIT_ON_ERR(hostManager_->clearHost());
+    hostManager_.reset();
+  }
+
+  if (backend != "") {
+    std::vector<std::unique_ptr<runtime::DeviceConfig>> configs;
+    auto config = llvm::make_unique<runtime::DeviceConfig>(backend);
+    configs.push_back(std::move(config));
+    hostManager_ = llvm::make_unique<runtime::HostManager>(std::move(configs));
+  }
+}
+
+llvm::StringRef ExecutionEngine2::getBackendName() const {
+  return backendName_;
+}
+
+ExecutionEngine2::~ExecutionEngine2() {
+  // Call setBackendName with backend="" to clear the EE.
+  setBackendName("");
+}
+
+void ExecutionEngine2::clear() {
+  if (hostManager_) {
+    EXIT_ON_ERR(hostManager_->clearHost());
+  }
+  compiledFunctions_.clear();
+}
+
+void glow::updateInputPlaceholders2(PlaceholderBindings &bindings,
+                                    llvm::ArrayRef<Placeholder *> ph,
+                                    llvm::ArrayRef<Tensor *> inputs) {
+  assert(inputs.size() == ph.size() &&
+         "The number of inputs does not match the number of Placeholders");
+
+  for (int i = 0, e = ph.size(); i < e; i++) {
+    assert(ph[i] && "Invalid value");
+    auto *backingTensor = bindings.get(ph[i]);
+    assert(backingTensor && "Can't find the placeholder");
+    auto dim = inputs[i]->dims();
+    (void)dim;
+    assert(backingTensor->getType().isEqual(inputs[i]->getType()) &&
+           "Mismatch on Placeholder and Tensor types.");
+    backingTensor->assign(inputs[i]);
+  }
+}
+
+void glow::updateInputPlaceholdersByName2(PlaceholderBindings &bindings,
+                                          Module *mod,
+                                          llvm::ArrayRef<llvm::StringRef> ph,
+                                          llvm::ArrayRef<Tensor *> inputs) {
+  assert(inputs.size() == ph.size() &&
+         "The number of inputs does not match the number of Placeholders");
+
+  for (int i = 0, e = ph.size(); i < e; i++) {
+    Placeholder *p = mod->getPlaceholderByName(legalizeName(ph[i]));
+    Tensor *t = inputs[i];
+    assert(t && "Invalid tensor.");
+    assert(p && "Invalid placeholder.");
+    updateInputPlaceholders2(bindings, {p}, {t});
+  }
+}
+
+void ExecutionEngine2::runInternal(ExecutionContext &context,
+                                   llvm::StringRef name) {
+  // Make sure that the bindings have backing tensors for all placeholders.
+  std::unique_ptr<ExecutionContext> contextPtr(&context);
+  std::promise<void> runPromise;
+  auto fut = runPromise.get_future();
+  llvm::Error runErr = llvm::Error::success();
+  hostManager_->runNetwork(
+      name, std::move(contextPtr),
+      [&runPromise, &runErr](runtime::RunIdentifierTy, llvm::Error err,
+                             std::unique_ptr<ExecutionContext> contextPtr) {
+        // Don't delete context.
+        contextPtr.release();
+        runErr = std::move(err);
+        runPromise.set_value();
+      });
+
+  fut.wait();
+  EXIT_ON_ERR(std::move(runErr));
+}
+
+void ExecutionEngine2::run(ExecutionContext &context) {
+  assert(compiledFunctions_.size() == 1 &&
+         "Expected exactly one compiled function.");
+  runInternal(context, *compiledFunctions_.begin());
+}
+
+void ExecutionEngine2::run(ExecutionContext &context, llvm::StringRef name) {
+  runInternal(context, name);
+}
+
+void ExecutionEngine2::run(PlaceholderBindings &bindings) {
+  assert(compiledFunctions_.size() == 1 &&
+         "Expected exactly one compiled function.");
+  std::unique_ptr<PlaceholderBindings> bindingsPtr(&bindings);
+  ExecutionContext context(std::move(bindingsPtr));
+  runInternal(context, *compiledFunctions_.begin());
+  // Don't delete bindings.
+  context.movePlaceholderBindings().release();
+}
+
+void ExecutionEngine2::run(PlaceholderBindings &bindings,
+                           llvm::StringRef name) {
+  std::unique_ptr<PlaceholderBindings> bindingsPtr(&bindings);
+  ExecutionContext context(std::move(bindingsPtr));
+  runInternal(context, name);
+  // Don't delete bindings.
+  context.movePlaceholderBindings().release();
+}
+
+void glow::runBatch2(ExecutionEngine2 &EE, PlaceholderBindings &bindings,
+                     size_t iterations, size_t &sampleCounter,
+                     llvm::ArrayRef<Placeholder *> ph,
+                     llvm::ArrayRef<Tensor *> inputs, llvm::StringRef name) {
+  // This is the size of one batch (the number of samples in the batch).
+  size_t batchSize = ph[0]->getType()->dims()[0];
+
+  assert(!inputs.empty() && "No inputs");
+  assert(inputs.size() == ph.size() &&
+         "The number of inputs does not match the number of placeholders");
+
+  // For each iteration in the batch:
+  for (size_t j = 0; j < iterations; j++) {
+
+    // Update the input placeholders.
+    for (int i = 0, e = ph.size(); i < e; i++) {
+      assert(ph[i] && "Invalid value");
+      auto *backingTensor = bindings.get(ph[i]);
+      assert(backingTensor && "Can't find the backing tensor");
+
+      auto dim = inputs[i]->dims();
+      assert(backingTensor->dims().drop_front() == dim.drop_front() &&
+             "Invalid slice size");
+      // Extract the n'th slice, that must be a tensor.
+      size_t slc = sampleCounter % dim[0];
+      // Pick up one slice from the input tensors, and load it into the
+      // corresponding network Placeholder.
+      backingTensor->copyConsecutiveSlices(inputs[i], slc);
+    }
+
+    // Run the network.
+    if (name == "") {
+      EE.run(bindings);
+    } else {
+      EE.run(bindings, name);
+    }
+    sampleCounter += batchSize;
+  }
+}
+
+void ExecutionEngine2::compile(CompilationMode mode) {
+  CompilationContext cctx;
+  cctx.compMode = mode;
+  compile(cctx);
+}
+
+void ExecutionEngine2::compile(CompilationContext &cctx) {
+  assert(module_.get() && "Compile has already been called.");
+
+  for (auto &function : module_->getFunctions()) {
+    compiledFunctions_.insert(function->getName());
+  }
+
+  EXIT_ON_ERR(hostManager_->addNetwork(std::move(module_), cctx));
+}

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -47,6 +47,14 @@ HostManager::HostManager(
   TEMP_EXIT_ON_ERR(init(std::move(deviceConfigs)));
 }
 
+llvm::Expected<DAG &> HostManager::getNetworkDAG(llvm::StringRef network) {
+  auto it = networks_.find(network);
+  if (it == networks_.end()) {
+    return MAKE_ERR(GlowErr::ErrorCode::RUNTIME_ERROR, "Network not found.");
+  }
+  return it->second.dag;
+}
+
 llvm::Error
 HostManager::init(std::vector<std::unique_ptr<DeviceConfig>> configs) {
   DeviceIDTy deviceCount = 0;

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -43,9 +43,10 @@ add_executable(BackendTest
 target_link_libraries(BackendTest
                       PRIVATE
                         Backends
+                        HostManager
                         Graph
                         IR
-                        ExecutionEngine
+                        ExecutionEngine2
                         gtest
                         TestMain)
 add_glow_test(BackendTest ${GLOW_BINARY_DIR}/tests/BackendTest --gtest_output=xml:BackendTest.xml)


### PR DESCRIPTION
Summary:
This PR adds a new ExecutionEngine2 which uses Hostmanager. It is currently alongside the original EE. This allows for an incremental migration of unit tests from EE to EE2. Once everything is ported to the new EE we can remove the original EE and rename EE2. This PR also ports BackendTest which verifies the new EE2 is working.
Documentation: EE docs will be updated once migration is complete.

Related to #3213

Test Plan: builds and BackendTest runs successfully
