### PR TITLE
Added new BackendHints object 

### DIFF
--- a/include/glow/Backends/BackendOptions.h
+++ b/include/glow/Backends/BackendOptions.h
@@ -16,7 +16,22 @@
 #ifndef GLOW_BACKENDS_BACKENDOPTIONS_H
 #define GLOW_BACKENDS_BACKENDOPTIONS_H
 
+#include "llvm/ADT/SmallVector.h"
+#include <string>
+#include <vector>
+
 namespace glow {
+class Storage;
+
+/// Hints provided to the Backend, the backend is not required to honor them.
+struct BackendHints {
+  /// Number of execution units to reserve, these are the processing elements
+  /// like cores, 0 for unspecified.
+  unsigned executionUnits{0};
+
+  /// Storage nodes to be pinned to SRAM listed in order of priority.
+  std::vector<std::string> SRAMPrioritization;
+};
 
 /// Options relevant to Backends during compilation.
 struct BackendOptions {
@@ -25,6 +40,9 @@ struct BackendOptions {
 
   /// Insert TraceEvents between all instructions for profiling.
   bool autoInstrument{false};
+
+  /// Hints for the compiler for this compilation.
+  BackendHints backendHints;
 };
 
 }; // namespace glow

--- a/include/glow/Runtime/RuntimeTypes.h
+++ b/include/glow/Runtime/RuntimeTypes.h
@@ -18,6 +18,7 @@
 
 #include "glow/Backend/Backend.h"
 #include "glow/Backend/BackendUtils.h"
+#include "glow/Backends/BackendOptions.h"
 #include "glow/Graph/Graph.h"
 #include "glow/Support/Error.h"
 
@@ -98,6 +99,11 @@ struct DAGNode {
   /// Runtime bundle containing all the symbol information for this network at
   /// runtime.
   std::unique_ptr<RuntimeBundle> runtimeBundle;
+
+  /// Backend Hints object, this is populated by the Partitioner and is used
+  /// to communicated hints to the compiler, like SRAM pinning and resource
+  /// reservation.
+  BackendHints backendHints{};
 
   /// Pointer to module the function came from. This is so the executor can
   /// access the associated PHs for the function that are stored in the Module.


### PR DESCRIPTION
Summary:

This PR adds a new BackendHints object and adds it to BackendOptions and DAGNode.
This PR also adds the plumbing for BackendHints created by the Partitioner to be piped through the Provisioner to the Backend. 
Currently there are two hints:
SRAM Pinning - An ordered list of Storage nodes to be pinned to SRAM. Order denotes priority.
Resource Reservation - An unsigned integer for the number of execution units to use for the function.

The plan is that new passes in the Partitioner will determine these hints and populate the backendHints field of the DAGNode for the function. This is then passed to the backend by the Provisioner. 

Documentation: Once the design is agreed on, Backends.md will need to be updated discussing the hints.

Related to #3235 

Test Plan: ninja test
