### PR TITLE
[Partitioner] User-defined partition

### DIFF
--- a/include/glow/Partitioner/Partitioner.h
+++ b/include/glow/Partitioner/Partitioner.h
@@ -204,10 +204,13 @@ class Partitioner {
   /// use all available devices.
   bool saturateHost_;
 
-  // Flag to set if the funcitons in the module are areadly optimized. By
-  // default, the optimization should be done in Partitioner due to
-  // heterogeneous partition.
+  /// Flag to set if the funcitons in the module are areadly optimized. By
+  /// default, the optimization should be done in Partitioner due to
+  /// heterogeneous partition.
   bool optimized_;
+
+  /// The struct contain user-defined partition info.
+  PartitionConfig partitionConfig_;
 
   /// Get the representative function (the one with the largest input) and
   /// update the memSize.
@@ -295,16 +298,25 @@ public:
   /// "Function Family", that is, without considerting the "dynamic stuff" (i.e.
   /// batch size, input/output shape of each op), all the functions are
   /// identical. The required memory and computation cost for each op can be
-  /// found in Module. The \p devices provides the cost model related to
-  /// devices.
+  /// found in Module.
+  /// The \p devices provides the cost model related to devices.
+  /// Saturating the host will be enabled if \p saturateHost is true.
+  /// \p optimized is false by default, which means the functions in this module
+  /// are not optimized. \p partitionConfig contains the user defined partition
+  /// info.
   Partitioner(Module *parent, const std::vector<DeviceInfo> &devices,
-              bool saturateHost = false, bool optimized = false);
+              bool saturateHost = false, bool optimized = false,
+              PartitionConfig partitionConfig = PartitionConfig());
 
   /// Users can create Mock Backends and pass their points to test Graph
   /// Partitioning without actually register them in GLOW.
   Partitioner(Module *parent, const std::vector<DeviceInfo> &devices,
               const std::vector<Backend *> &backends, bool saturateHost = false,
               bool optimized = false);
+
+  /// Based on partitionConfig_ passed into Partitioner, do the user-defined
+  /// partition.
+  llvm::Error PartitionFromConfig();
 
   /// Decompose each function in a module. Now we support partitioning a module
   /// among different type of devices. \p cctx is used during optimization of

--- a/include/glow/Runtime/RuntimeTypes.h
+++ b/include/glow/Runtime/RuntimeTypes.h
@@ -171,6 +171,30 @@ struct HostConfig {
   size_t executorThreads{3};
 };
 
+/// This is struct for user defined partition.
+struct PartitionConfig {
+  /// The name of the function to be partitioned.
+  std::string funcName;
+  /// The number of user defined partitions.
+  /// The partition ids are between 0 and numOfPartitions - 1, inclusive.
+  size_t numOfPartitions;
+  /// The backend for each partition. backendNames.size() == numOfPartitions.
+  std::vector<std::string> backendNames;
+  /// The name for each partition. partitionNames.size() == numOfPartitions.
+  std::vector<std::string> partitionNames;
+  /// The mapping between nodes' name to Partition ids. Assume there are n nodes
+  /// and m partitions. We have 2 types of valid mapping: 1. all nodes are
+  /// mapped to a partition. 2. For i-th (0 <= i < m) partition, the nodes
+  /// mapped to this partition id are not in this map, and the nodes mapped to
+  /// other partitions ids must be in this map. The node's name should be the
+  /// name in Glow function and may be different from the original name from
+  /// models. Since Glow will mangle names to make them unique.
+  llvm::StringMap<size_t> nodeToPartition;
+
+  PartitionConfig() : numOfPartitions(0) {}
+  bool enabled() { return numOfPartitions > 0; }
+};
+
 } // namespace runtime
 } // namespace glow
 #endif // GLOW_RUNTIME_RUNTIMETYPES_H

--- a/tests/unittests/PartitionerTest.cpp
+++ b/tests/unittests/PartitionerTest.cpp
@@ -155,9 +155,9 @@ TEST_F(PartitionerTest, Basic1) {
   auto err = myPartitioner.Partition(cctx);
   EXPECT_FALSE(errToBool(std::move(err)));
   DAGListTy dagList = std::move(myPartitioner.getPartitionResult());
-  ASSERT_EQ(mod_.getFunctions().size(), 3);
-  ASSERT_EQ(dagList.size(), 1);
-  ASSERT_TRUE(checkSaveNode(mod_));
+  EXPECT_EQ(mod_.getFunctions().size(), 3);
+  EXPECT_EQ(dagList.size(), 1);
+  EXPECT_TRUE(checkSaveNode(mod_));
 
   // Run the paritioned graph and compare the results.
   bindings_.allocate(mod_.getPlaceholders());
@@ -230,15 +230,15 @@ TEST_F(PartitionerTest, Basic2) {
   auto err = myPartitioner.Partition(cctx);
   EXPECT_FALSE(errToBool(std::move(err)));
   DAGListTy dagList = std::move(myPartitioner.getPartitionResult());
-  ASSERT_EQ(mod_.getFunctions().size(), 2);
-  ASSERT_EQ(dagList.size(), 1);
+  EXPECT_EQ(mod_.getFunctions().size(), 2);
+  EXPECT_EQ(dagList.size(), 1);
   ASSERT_TRUE(checkSaveNode(mod_));
 
   for (auto &dag : dagList) {
     for (auto &node : dag.nodes) {
       // Since saturateHost is set true, in this case, there should be 2 copys
       // of the partitions.
-      ASSERT_EQ(node->logicalDevices.size(), 2);
+      EXPECT_EQ(node->logicalDevices.size(), 2);
     }
   }
 
@@ -248,7 +248,7 @@ TEST_F(PartitionerTest, Basic2) {
     bindings_.allocate(mod_.getPlaceholders());
     executeDAG((*it).root.get(), mod_, bindings_, {input}, {&in});
     Tensor test = res.clone();
-    EXPECT_TRUE(ref.isEqual(test));
+    ASSERT_TRUE(ref.isEqual(test));
   }
 }
 
@@ -433,8 +433,8 @@ TEST_F(PartitionerTest, Basic1Roofline) {
     EXPECT_EQ(myPartitioner.getMemUsage(N), expectedMemUsage[p.second]);
   }
 
-  ASSERT_EQ(mod_.getFunctions().size(), 3);
-  ASSERT_EQ(dagList.size(), 1);
+  EXPECT_EQ(mod_.getFunctions().size(), 3);
+  EXPECT_EQ(dagList.size(), 1);
 }
 
 TEST_F(PartitionerTest, SelectRepFunc) {
@@ -549,7 +549,7 @@ static void heterogeneousPartitionValidation(const DAGListTy &dagList,
     for (auto &node : dag.nodes) {
       // Although the saturateHost is set true, no saturating the host in
       // heterogeneous partiton.
-      ASSERT_EQ(node->logicalDevices.size(), 1);
+      EXPECT_EQ(node->logicalDevices.size(), 1);
       if (node->backendName == "CPU") {
         numOfCPUBackends++;
         auto func = mod.getFunction(node->name);
@@ -568,10 +568,10 @@ static void heterogeneousPartitionValidation(const DAGListTy &dagList,
       }
     }
   }
-  ASSERT_EQ(numOfInterpreterBackends, 2);
-  ASSERT_EQ(numOfCPUBackends, 1);
-  ASSERT_EQ(numOfSubNodes, 2);
-  ASSERT_EQ(numOfMulNodes, 1);
+  EXPECT_EQ(numOfInterpreterBackends, 2);
+  EXPECT_EQ(numOfCPUBackends, 1);
+  EXPECT_EQ(numOfSubNodes, 2);
+  EXPECT_EQ(numOfMulNodes, 1);
 }
 
 /// Test using user-defined backends for heterogeneous partition.
@@ -593,8 +593,8 @@ TEST_F(PartitionerTest, SimpleHeterogeneousPartitioning) {
   auto err = partitioner.Partition(cctx);
   EXPECT_FALSE(errToBool(std::move(err)));
   DAGListTy dagList = std::move(partitioner.getPartitionResult());
-  ASSERT_EQ(mod_.getFunctions().size(), 3);
-  ASSERT_EQ(dagList.size(), 1);
+  EXPECT_EQ(mod_.getFunctions().size(), 3);
+  EXPECT_EQ(dagList.size(), 1);
   ASSERT_TRUE(checkSaveNode(mod_));
   heterogeneousPartitionValidation(dagList, mod_);
 
@@ -614,8 +614,8 @@ TEST_F(PartitionerTest, heterogeneousPartitioningWithNonSupportedNodes) {
   auto err = partitioner.Partition(cctx);
   EXPECT_FALSE(errToBool(std::move(err)));
   DAGListTy dagList = std::move(partitioner.getPartitionResult());
-  ASSERT_EQ(mod_.getFunctions().size(), 3);
-  ASSERT_EQ(dagList.size(), 1);
+  EXPECT_EQ(mod_.getFunctions().size(), 3);
+  EXPECT_EQ(dagList.size(), 1);
   ASSERT_TRUE(checkSaveNode(mod_));
   heterogeneousPartitionValidation(dagList, mod_);
 
@@ -638,8 +638,8 @@ TEST_F(PartitionerTest, heterogeneousPartitioningWithSupportedNodes) {
   auto err = partitioner.Partition(cctx);
   EXPECT_FALSE(errToBool(std::move(err)));
   DAGListTy dagList = std::move(partitioner.getPartitionResult());
-  ASSERT_EQ(mod_.getFunctions().size(), 3);
-  ASSERT_EQ(dagList.size(), 1);
+  EXPECT_EQ(mod_.getFunctions().size(), 3);
+  EXPECT_EQ(dagList.size(), 1);
   ASSERT_TRUE(checkSaveNode(mod_));
   heterogeneousPartitionValidation(dagList, mod_);
 
@@ -675,19 +675,19 @@ TEST_F(PartitionerTest, logicalIDTest0) {
   EXPECT_FALSE(errToBool(std::move(err)));
   DAGListTy dagList = std::move(partitioner.getPartitionResult());
   // Check there are 3 partitions.
-  ASSERT_EQ(mod_.getFunctions().size(), 3);
-  ASSERT_EQ(dagList.size(), 1);
+  EXPECT_EQ(mod_.getFunctions().size(), 3);
+  EXPECT_EQ(dagList.size(), 1);
   ASSERT_TRUE(checkSaveNode(mod_));
 
   for (auto &dag : dagList) {
     // Check number of logical devices;
     llvm::SmallSet<DeviceIDTy, 4> usedID;
     for (auto &node : dag.nodes) {
-      ASSERT_EQ(node->logicalDevices.size(), 1);
+      EXPECT_EQ(node->logicalDevices.size(), 1);
       usedID.insert(node->logicalDevices[0]);
     }
     // Check there are 2 logical devices.
-    ASSERT_EQ(usedID.size(), 2);
+    EXPECT_EQ(usedID.size(), 2);
   }
   mod_.clear();
 }
@@ -710,8 +710,8 @@ TEST_F(PartitionerTest, logicalIDTest1) {
   auto err = partitioner.Partition(cctx);
   EXPECT_FALSE(errToBool(std::move(err)));
   DAGListTy dagList = std::move(partitioner.getPartitionResult());
-  ASSERT_EQ(mod_.getFunctions().size(), 3);
-  ASSERT_EQ(dagList.size(), 1);
+  EXPECT_EQ(mod_.getFunctions().size(), 3);
+  EXPECT_EQ(dagList.size(), 1);
   ASSERT_TRUE(checkSaveNode(mod_));
 
   for (auto &dag : dagList) {
@@ -720,10 +720,10 @@ TEST_F(PartitionerTest, logicalIDTest1) {
     for (auto &node : dag.nodes) {
       // Although the saturateHost is set true, no saturating the host in
       // heterogeneous partiton.
-      ASSERT_EQ(node->logicalDevices.size(), 1);
+      EXPECT_EQ(node->logicalDevices.size(), 1);
       usedID.insert(node->logicalDevices[0]);
     }
-    ASSERT_EQ(usedID.size(), 2);
+    EXPECT_EQ(usedID.size(), 2);
   }
   mod_.clear();
 }
@@ -885,4 +885,29 @@ TEST_F(PartitionerTest, memoryUsageValidation1) {
   CompilationContext cctx;
   auto err = myPartitioner.Partition(cctx);
   EXPECT_TRUE(errToBool(std::move(err)));
+}
+
+/// This one tests partition from a user-defined config.
+TEST_F(PartitionerTest, partitionFromConfig) {
+  createSimpleModule(mod_);
+  std::vector<DeviceInfo> devices = {
+      {3072, "Interpreter"}, {3072, "Interpreter"}, {3072, "CPU"}};
+
+  // User-defined partition: 3 partitions (2 interpreter, 1 cpu), Mul nodes to
+  // CPU, others to Interpreter.
+  PartitionConfig partitionConfig;
+  partitionConfig.funcName = "test";
+  partitionConfig.numOfPartitions = 3;
+  partitionConfig.backendNames = {"Interpreter", "CPU", "Interpreter"};
+  partitionConfig.partitionNames = {"p1", "p2", "p3"};
+  partitionConfig.nodeToPartition = {{"sub", 0}, {"mul", 1}};
+  auto partitioner = Partitioner(&mod_, devices, false, false, partitionConfig);
+  CompilationContext cctx;
+  auto err = partitioner.Partition(cctx);
+  EXPECT_FALSE(errToBool(std::move(err)));
+  DAGListTy dagList = std::move(partitioner.getPartitionResult());
+  EXPECT_EQ(mod_.getFunctions().size(), 3);
+  EXPECT_EQ(dagList.size(), 1);
+  ASSERT_TRUE(checkSaveNode(mod_));
+  heterogeneousPartitionValidation(dagList, mod_);
 }


### PR DESCRIPTION
Summary:
This PR added user-defined partition flow. Basically, a struct "PartitionConfig" containing the partition info is passed into Partitioner to enable this flow.  Now we let users have the full control of how to do the partitioning. 
To use this flow, users can write their helper function to generate  PartitionConfig, and call Partitioner directly.
In the following PR, we will add passing PartitionConfig through HostManager from a yaml file. 

Related to #2298
Documentation:

[Optional Fixes #issue] 

Test Plan:
Added unittest. ninja test.

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
