### PR TITLE
Port MLTest to EE2, added helper functions to PlaceholderBindings.

### DIFF
--- a/include/glow/Graph/PlaceholderBindings.h
+++ b/include/glow/Graph/PlaceholderBindings.h
@@ -70,6 +70,14 @@ public:
   /// Inserts the Placeholder-Tensor pair. This takes ownership of the Tensor.
   void insert(Placeholder *P, Tensor *T);
 
+  /// Copy values from this PlaceholderBindings to another, \p dst, by \p name.
+  /// This is useful when trained weights need to be transferred between
+  /// bindings of two different modules.
+  void copyToTarget(llvm::StringRef name, PlaceholderBindings &dst);
+
+  /// Transfer all trainable weights to target PlaceholderBindings \p dst.
+  void copyTrainedWeightsTo(PlaceholderBindings &dst);
+
   /// Allocates a tensor to back the placeholder \p P. The new tensor has the
   /// type of P.
   Tensor *allocate(Placeholder *P);

--- a/lib/ExecutionEngine/ExecutionEngine2.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine2.cpp
@@ -102,7 +102,6 @@ void glow::updateInputPlaceholdersByName2(PlaceholderBindings &bindings,
 
 void ExecutionEngine2::runInternal(ExecutionContext &context,
                                    llvm::StringRef name) {
-  // Make sure that the bindings have backing tensors for all placeholders.
   std::unique_ptr<ExecutionContext> contextPtr(&context);
   std::promise<void> runPromise;
   auto fut = runPromise.get_future();

--- a/lib/Graph/PlaceholderBindings.cpp
+++ b/lib/Graph/PlaceholderBindings.cpp
@@ -99,6 +99,22 @@ void PlaceholderBindings::insert(Placeholder *P, Tensor *T) {
   nameMap_[P->getName()] = P;
 }
 
+void PlaceholderBindings::copyToTarget(llvm::StringRef name,
+                                       PlaceholderBindings &dst) {
+  auto *srcPH = this->getPlaceholderByName(name);
+  auto *dstPH = dst.getPlaceholderByName(name);
+  dst.erase(dstPH);
+  dst.insert(dstPH, this->get(srcPH)->clone());
+}
+
+void PlaceholderBindings::copyTrainedWeightsTo(PlaceholderBindings &dst) {
+  for (auto &PH : pairs()) {
+    if (PH.first->isTraining()) {
+      copyToTarget(PH.first->getName(), dst);
+    }
+  }
+}
+
 size_t PlaceholderBindings::count(Placeholder *P) const {
   DCHECK_EQ(map_.size(), nameMap_.size())
       << "Placeholder map and name map out of sync";

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -303,7 +303,7 @@ target_link_libraries(MLTest
         PRIVATE
         Graph
         IR
-        ExecutionEngine
+        ExecutionEngine2
         Quantization
         gtest
         TestMain)

--- a/tests/unittests/MLTest.cpp
+++ b/tests/unittests/MLTest.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "glow/ExecutionEngine/ExecutionEngine.h"
+#include "glow/ExecutionEngine/ExecutionEngine2.h"
 #include "glow/Graph/Graph.h"
 #include "glow/Quantization/Quantization.h"
 
@@ -30,7 +30,15 @@ using llvm::isa;
 
 class TestRunnerBase : public ::testing::TestWithParam<std::string> {
 public:
-  ExecutionEngine EE_{GetParam()};
+  ExecutionEngine2 EEI_{GetParam()};
+  ExecutionEngine2 EET_{GetParam()};
+  std::vector<ExecutionEngine2 *> engines_;
+  void SetUp() override {
+    // The order here is intentional, the tests assume that EET is the last in
+    // the list.
+    engines_.push_back(&EEI_);
+    engines_.push_back(&EET_);
+  }
 };
 
 class InterpreterAndCPU : public TestRunnerBase {};
@@ -43,7 +51,7 @@ TEST_P(MLTest, learnSqrt2Placeholder) {
 
   TC.learningRate = 0.03;
 
-  auto &mod = EE_.getModule();
+  auto &mod = EET_.getModule();
   Function *F = mod.createFunction("Square root of 2");
 
   auto *A = mod.createPlaceholder(ElemKind::FloatTy, {1}, "A", true);
@@ -62,12 +70,13 @@ TEST_P(MLTest, learnSqrt2Placeholder) {
 
   bindings.allocate(SN->getPlaceholder());
 
-  Function *TF = glow::differentiate(F, TC);
-  EE_.compile(CompilationMode::Train, TF);
+  auto *TF = glow::differentiate(F, TC);
+  auto fName = TF->getName();
+  EET_.compile(CompilationMode::Train);
 
   // Train the network:
   for (int i = 0; i < 100; i++) {
-    EE_.run(bindings);
+    EET_.run(bindings, fName);
   }
 
   float res = inputTensor->getHandle().at({0});
@@ -84,22 +93,30 @@ TEST_P(MLTest, trainASimpleNetwork) {
 
   // Learning a single input vector.
   TC.learningRate = 0.05;
+  Function *F;
+  Placeholder *A, *E;
+  for (auto *EE : engines_) {
+    auto &mod = EE->getModule();
+    F = mod.createFunction("trainASimpleNetwork");
 
-  auto &mod = EE_.getModule();
-  Function *F = mod.createFunction("trainASimpleNetwork");
-
-  // Create a variable with 1 input, which is a vector of 4 elements.
-  Placeholder *A = mod.createPlaceholder(ElemKind::FloatTy, {1, 4}, "A", false);
-  Placeholder *E = mod.createPlaceholder(ElemKind::FloatTy, {1, 4}, "E", false);
-  Node *O = F->createFullyConnected(bindings, "fc1", A, 10);
-  O = F->createSigmoid("sig1", O);
-  O = F->createFullyConnected(bindings, "fc2", O, 4);
-  O = F->createRegression("reg", O, E);
-  SaveNode *result = F->createSave("return", O);
-
-  bindings.allocate(A);
-  bindings.allocate(E);
-  auto *res = bindings.allocate(result->getPlaceholder());
+    // Create a variable with 1 input, which is a vector of 4 elements.
+    A = mod.createPlaceholder(ElemKind::FloatTy, {1, 4}, "A", false);
+    E = mod.createPlaceholder(ElemKind::FloatTy, {1, 4}, "E", false);
+    Node *O = F->createFullyConnected(bindings, "fc1", A, 10);
+    O = F->createSigmoid("sig1", O);
+    O = F->createFullyConnected(bindings, "fc2", O, 4);
+    O = F->createRegression("reg", O, E);
+    F->createSave("return", O);
+  }
+  // TODO if PHs aren't zeroed this will not always pass in release. Should
+  // check which operations are sensitive and update them to set AllocZero
+  // properly.
+  for (auto *PH : EET_.getModule().getPlaceholders()) {
+    PH->setAllocZero();
+  }
+  PlaceholderBindings trainingBindings;
+  trainingBindings.allocate(EET_.getModule().getPlaceholders());
+  auto *resPH = EEI_.getModule().getPlaceholderByName("return");
 
   // Values for the input and output variables.
   Tensor inputs(ElemKind::FloatTy, {1, 4});
@@ -107,19 +124,26 @@ TEST_P(MLTest, trainASimpleNetwork) {
   inputs.getHandle<>() = {0.15f, 0.15f, 0.15f, 0.15f};
   expected.getHandle<>() = {0.9f, 0.9f, 0.9f, 0.9f};
 
-  Function *TF = glow::differentiate(F, TC);
-  EE_.compile(CompilationMode::Train, TF);
+  auto *TF = glow::differentiate(F, TC);
+  auto tfName = TF->getName();
+  auto fname = F->getName();
+  EET_.compile(CompilationMode::Train);
 
   // Train the network. Learn 1000 batches.
-  runBatch(EE_, bindings, 1000, sampleCounter, {A, E}, {&inputs, &expected});
+  runBatch2(EET_, trainingBindings, 1000, sampleCounter, {A, E},
+            {&inputs, &expected}, tfName);
 
   // Testing the output vector.
+  PlaceholderBindings inferBindings;
+  inferBindings.allocate(EEI_.getModule().getPlaceholders());
+  A = EEI_.getModule().getPlaceholderByName("A");
+  EEI_.compile(CompilationMode::Infer);
+  trainingBindings.copyTrainedWeightsTo(inferBindings);
+  updateInputPlaceholders2(inferBindings, {A}, {&inputs});
 
-  EE_.compile(CompilationMode::Infer, F);
-  updateInputPlaceholders(bindings, {A}, {&inputs});
-  EE_.run(bindings);
+  EEI_.run(inferBindings, fname);
 
-  auto RNWH = res->getHandle<>();
+  auto RNWH = inferBindings.get(resPH)->getHandle();
   (void)RNWH;
 
   // Test the output:
@@ -128,7 +152,7 @@ TEST_P(MLTest, trainASimpleNetwork) {
 
 TEST_P(MLTest, simpleRegression) {
   TrainingConfig TC;
-  PlaceholderBindings bindings;
+  PlaceholderBindings trainingBindings, inferBindings;
 
   // This variable records the number of the next sample to be used for
   // training.
@@ -144,46 +168,53 @@ TEST_P(MLTest, simpleRegression) {
 
   Tensor inputs(ElemKind::FloatTy, {1, numInputs});
   Tensor expected(ElemKind::FloatTy, {1, numInputs});
-
-  auto &mod = EE_.getModule();
-  Function *F = mod.createFunction("simpleRegression");
-  Placeholder *A =
-      mod.createPlaceholder(ElemKind::FloatTy, {1, numInputs}, "A", false);
-  Placeholder *Ex =
-      mod.createPlaceholder(ElemKind::FloatTy, {1, numInputs}, "E", false);
-  Node *O = F->createFullyConnected(bindings, "fc", A, 4);
-  O = F->createRELU("relu", O);
-  O = F->createRegression("reg", O, Ex);
-  auto *result = F->createSave("result", O);
-
-  bindings.allocate(A);
-  bindings.allocate(Ex);
-  auto *res = bindings.allocate(result->getPlaceholder());
+  Placeholder *A, *Ex;
+  Function *F;
+  for (auto *EE : engines_) {
+    auto &mod = EE->getModule();
+    F = mod.createFunction("simpleRegression");
+    A = mod.createPlaceholder(ElemKind::FloatTy, {1, numInputs}, "A", false);
+    Ex = mod.createPlaceholder(ElemKind::FloatTy, {1, numInputs}, "E", false);
+    Node *O = F->createFullyConnected(inferBindings, "fc", A, 4);
+    O = F->createRELU("relu", O);
+    O = F->createRegression("reg", O, Ex);
+    F->createSave("result", O);
+  }
+  auto resPH = EEI_.getModule().getPlaceholderByName("result");
+  trainingBindings.allocate(EET_.getModule().getPlaceholders());
+  inferBindings.copyTrainedWeightsTo(trainingBindings);
+  inferBindings.clear();
 
   auto I = inputs.getHandle<>();
   auto E = expected.getHandle<>();
 
-  Function *TF = glow::differentiate(F, TC);
-  EE_.compile(CompilationMode::Train, TF);
+  auto *TF = glow::differentiate(F, TC);
+  auto tfName = TF->getName();
+  auto fName = F->getName();
+  EET_.compile(CompilationMode::Train);
 
   // Train the network:
   for (int iter = 0; iter < 1000; iter++) {
     float target = float(iter % 9);
     I = {target, 0., 0., 0.};
     E = {0., target + 1, 0., 0.};
-    runBatch(EE_, bindings, 1, sampleCounter, {A, Ex}, {&inputs, &expected});
+    runBatch2(EET_, trainingBindings, 1, sampleCounter, {A, Ex},
+              {&inputs, &expected}, tfName);
   }
 
   // Verify the result of the regression layer.
-  EE_.compile(CompilationMode::Infer, F);
+  inferBindings.allocate(EEI_.getModule().getPlaceholders());
+  trainingBindings.copyTrainedWeightsTo(inferBindings);
+  A = inferBindings.getPlaceholderByName("A");
+  EEI_.compile(CompilationMode::Infer);
 
   // Test the output:
   for (int iter = 0; iter < 5; iter++) {
     float target = iter % 9 + 1;
     I = {target, 0., 0., 0.};
-    updateInputPlaceholders(bindings, {A}, {&inputs});
-    EE_.run(bindings);
-
+    updateInputPlaceholders2(inferBindings, {A}, {&inputs});
+    EEI_.run(inferBindings, fName);
+    auto *res = inferBindings.get(resPH);
     auto resH = res->getHandle<>();
     (void)resH;
 
@@ -193,7 +224,7 @@ TEST_P(MLTest, simpleRegression) {
 
 TEST_P(MLTest, learnXor) {
   TrainingConfig TC;
-  PlaceholderBindings bindings;
+  PlaceholderBindings trainingBindings, inferBindings;
 
   unsigned numInputs = 10;
 
@@ -204,24 +235,27 @@ TEST_P(MLTest, learnXor) {
   // Learning a single input vector.
   TC.learningRate = 0.05;
   TC.batchSize = numInputs;
+  Placeholder *A, *Ex;
+  Function *F;
+  for (auto *EE : engines_) {
+    auto &mod = EE->getModule();
+    F = mod.createFunction("learnXor");
 
-  auto &mod = EE_.getModule();
-  Function *F = mod.createFunction("learnXor");
+    A = mod.createPlaceholder(ElemKind::FloatTy, {numInputs, 2}, "A", false);
+    Ex = mod.createPlaceholder(ElemKind::FloatTy, {numInputs, 1}, "Ex", false);
 
-  Placeholder *A =
-      mod.createPlaceholder(ElemKind::FloatTy, {numInputs, 2}, "A", false);
-  Placeholder *Ex =
-      mod.createPlaceholder(ElemKind::FloatTy, {numInputs, 1}, "Ex", false);
+    Node *O = F->createFullyConnected(inferBindings, "fc1", A, 6);
+    O = F->createTanh("tanh1", O);
+    O = F->createFullyConnected(inferBindings, "fc2", O, 1);
+    O = F->createRegression("reg", O, Ex);
+    F->createSave("ret", O);
+  }
+  trainingBindings.allocate(EET_.getModule().getPlaceholders());
+  inferBindings.copyTrainedWeightsTo(trainingBindings);
+  inferBindings.clear();
+  inferBindings.allocate(EEI_.getModule().getPlaceholders());
 
-  Node *O = F->createFullyConnected(bindings, "fc1", A, 6);
-  O = F->createTanh("tanh1", O);
-  O = F->createFullyConnected(bindings, "fc2", O, 1);
-  O = F->createRegression("reg", O, Ex);
-  auto *result = F->createSave("ret", O);
-
-  bindings.allocate(A);
-  bindings.allocate(Ex);
-  auto *res = bindings.allocate(result->getPlaceholder());
+  auto *res = inferBindings.get(EEI_.getModule().getPlaceholderByName("ret"));
 
   // Prepare the training set and the testing set.
   Tensor trainingSet(ElemKind::FloatTy, {numInputs, 2});
@@ -239,14 +273,16 @@ TEST_P(MLTest, learnXor) {
     TL.at({i, 0}) = a ^ b;
   }
 
-  Function *TF = glow::differentiate(F, TC);
-  EE_.compile(CompilationMode::Train, TF);
+  auto *TF = glow::differentiate(F, TC);
+  auto tfName = TF->getName();
+  auto fname = F->getName();
+  EET_.compile(CompilationMode::Train);
 
   // Train the network:
-  runBatch(EE_, bindings, 2500, sampleCounter, {A, Ex},
-           {&trainingSet, &trainingLabels});
-
-  EE_.compile(CompilationMode::Infer, F);
+  runBatch2(EET_, trainingBindings, 2500, sampleCounter, {A, Ex},
+            {&trainingSet, &trainingLabels}, tfName);
+  trainingBindings.copyTrainedWeightsTo(inferBindings);
+  EEI_.compile(CompilationMode::Infer);
 
   // Prepare the testing tensor:
   for (unsigned i = 0; i < numInputs; i++) {
@@ -255,9 +291,9 @@ TEST_P(MLTest, learnXor) {
     TS.at({i, 0}) = a;
     TS.at({i, 1}) = b;
   }
-
-  updateInputPlaceholders(bindings, {A}, {&trainingSet});
-  EE_.run(bindings);
+  A = inferBindings.getPlaceholderByName("A");
+  updateInputPlaceholders2(inferBindings, {A}, {&trainingSet});
+  EEI_.run(inferBindings, fname);
 
   auto resH = res->getHandle<>();
 
@@ -272,7 +308,7 @@ TEST_P(MLTest, learnXor) {
 /// Learn the logarithmic function.
 TEST_P(MLTest, learnLog) {
   TrainingConfig TC;
-  PlaceholderBindings bindings;
+  PlaceholderBindings inferBindings, trainingBindings;
 
   // This variable records the number of the next sample to be used for
   // training.
@@ -282,24 +318,27 @@ TEST_P(MLTest, learnLog) {
   unsigned batchSize = 5;
   TC.learningRate = 0.07;
   TC.batchSize = batchSize;
+  Function *F;
+  Placeholder *A, *Ex;
+  for (auto *EE : engines_) {
+    auto &mod = EE->getModule();
+    F = mod.createFunction("learnLog");
 
-  auto &mod = EE_.getModule();
-  Function *F = mod.createFunction("learnLog");
+    A = mod.createPlaceholder(ElemKind::FloatTy, {batchSize, 1}, "A", false);
+    Ex = mod.createPlaceholder(ElemKind::FloatTy, {batchSize, 1}, "Ex", false);
 
-  Placeholder *A =
-      mod.createPlaceholder(ElemKind::FloatTy, {batchSize, 1}, "A", false);
-  Placeholder *Ex =
-      mod.createPlaceholder(ElemKind::FloatTy, {batchSize, 1}, "Ex", false);
+    Node *O = F->createFullyConnected(inferBindings, "fc1", A, 4);
+    O = F->createTanh("tanh1", O);
+    O = F->createFullyConnected(inferBindings, "fc2", O, 1);
+    O = F->createRegression("reg", O, Ex);
+    F->createSave("ret", O);
+  }
+  trainingBindings.allocate(EET_.getModule().getPlaceholders());
+  inferBindings.copyTrainedWeightsTo(trainingBindings);
+  inferBindings.clear();
+  inferBindings.allocate(EEI_.getModule().getPlaceholders());
 
-  Node *O = F->createFullyConnected(bindings, "fc1", A, 4);
-  O = F->createTanh("tanh1", O);
-  O = F->createFullyConnected(bindings, "fc2", O, 1);
-  O = F->createRegression("reg", O, Ex);
-  auto *result = F->createSave("ret", O);
-
-  bindings.allocate(A);
-  bindings.allocate(Ex);
-  auto *res = bindings.allocate(result->getPlaceholder());
+  auto *res = inferBindings.get(EEI_.getModule().getPlaceholderByName("ret"));
 
   // Set the training data.
   Tensor trainingSet(ElemKind::FloatTy, {numInputs, 1});
@@ -318,14 +357,16 @@ TEST_P(MLTest, learnLog) {
     TL.at({i, 0}) = std::log(a);
   }
 
-  Function *TF = glow::differentiate(F, TC);
-  EE_.compile(CompilationMode::Train, TF);
+  auto *TF = glow::differentiate(F, TC);
+  auto tfName = TF->getName();
+  auto fname = F->getName();
+  EET_.compile(CompilationMode::Train);
 
   // Train the network:
-  runBatch(EE_, bindings, 1000, sampleCounter, {A, Ex},
-           {&trainingSet, &trainingLabels});
-
-  EE_.compile(CompilationMode::Infer, F);
+  runBatch2(EET_, trainingBindings, 1000, sampleCounter, {A, Ex},
+            {&trainingSet, &trainingLabels}, tfName);
+  trainingBindings.copyTrainedWeightsTo(inferBindings);
+  EEI_.compile(CompilationMode::Infer);
 
   // Set the testing data.
   Tensor testSet(ElemKind::FloatTy, {batchSize, 1});
@@ -337,12 +378,12 @@ TEST_P(MLTest, learnLog) {
 
   for (size_t i = 0; i < batchSize; i++) {
     // Generate a floating number in the range of [LO_T,HI_T).
-    float a = mod.getPRNG().nextRandReal(LO_T, HI_T);
+    float a = EEI_.getModule().getPRNG().nextRandReal(LO_T, HI_T);
     TES.at({i, 0}) = a;
   }
-
-  updateInputPlaceholders(bindings, {A}, {&testSet});
-  EE_.run(bindings);
+  A = inferBindings.getPlaceholderByName("A");
+  updateInputPlaceholders2(inferBindings, {A}, {&testSet});
+  EEI_.run(inferBindings, fname);
 
   auto resH = res->getHandle<>();
 
@@ -387,7 +428,7 @@ void generateCircleData(Tensor &coordinates, Tensor &labels, PseudoRNG &PRNG) {
 /// http://cs.stanford.edu/people/karpathy/convnetjs/demo/classify2d.html
 TEST_P(MLTest, circle) {
   TrainingConfig TC;
-  PlaceholderBindings bindings;
+  PlaceholderBindings trainingBindings, inferBindings;
 
   // This variable records the number of the next sample to be used for
   // training.
@@ -400,36 +441,44 @@ TEST_P(MLTest, circle) {
   TC.momentum = 0.9;
   TC.learningRate = 0.01;
   TC.batchSize = minibatchSize;
+  Function *F;
+  Placeholder *A, *S;
+  for (auto *EE : engines_) {
+    auto &mod = EE->getModule();
+    F = mod.createFunction("circle");
+    A = mod.createPlaceholder(ElemKind::FloatTy, {minibatchSize, 2}, "A",
+                              false);
+    S = mod.createPlaceholder(ElemKind::Int64ITy, {minibatchSize, 1}, "S",
+                              false);
 
-  auto &mod = EE_.getModule();
-  Function *F = mod.createFunction("circle");
-  Placeholder *A =
-      mod.createPlaceholder(ElemKind::FloatTy, {minibatchSize, 2}, "A", false);
-  Placeholder *S =
-      mod.createPlaceholder(ElemKind::Int64ITy, {minibatchSize, 1}, "S", false);
+    auto *FCL0 = F->createFullyConnected(inferBindings, "fc1", A, 8);
+    auto *T0 = F->createTanh("tanh1", FCL0);
+    auto *FCL1 = F->createFullyConnected(inferBindings, "fc2", T0, 2);
+    auto *SM = F->createSoftMax("soft", FCL1, S);
+    F->createSave("ret", SM);
+  }
+  trainingBindings.allocate(EET_.getModule().getPlaceholders());
+  inferBindings.copyTrainedWeightsTo(trainingBindings);
+  inferBindings.clear();
+  inferBindings.allocate(EEI_.getModule().getPlaceholders());
+  auto *res = inferBindings.get(EEI_.getModule().getPlaceholderByName("ret"));
 
-  auto *FCL0 = F->createFullyConnected(bindings, "fc1", A, 8);
-  auto *T0 = F->createTanh("tanh1", FCL0);
-  auto *FCL1 = F->createFullyConnected(bindings, "fc2", T0, 2);
-  auto *SM = F->createSoftMax("soft", FCL1, S);
-  auto *result = F->createSave("ret", SM);
-
-  bindings.allocate(A);
-  bindings.allocate(S);
-  auto *res = bindings.allocate(result->getPlaceholder());
-
-  Function *TF = glow::differentiate(F, TC);
-  EE_.compile(CompilationMode::Train, TF);
+  auto *TF = glow::differentiate(F, TC);
+  auto tfName = TF->getName();
+  auto fname = F->getName();
+  EET_.compile(CompilationMode::Train);
+  trainingBindings.allocate(EET_.getModule().getPlaceholders());
 
   Tensor coordinates(ElemKind::FloatTy, {numSamples, 2});
   Tensor labels(ElemKind::Int64ITy, {numSamples, 1});
-  generateCircleData(coordinates, labels, mod.getPRNG());
+  generateCircleData(coordinates, labels, EET_.getModule().getPRNG());
 
   // Training:
-  runBatch(EE_, bindings, 4000, sampleCounter, {A, S}, {&coordinates, &labels});
-
-  EE_.compile(CompilationMode::Infer, F);
-
+  runBatch2(EET_, trainingBindings, 4000, sampleCounter, {A, S},
+            {&coordinates, &labels}, tfName);
+  trainingBindings.copyTrainedWeightsTo(inferBindings);
+  EEI_.compile(CompilationMode::Infer);
+  A = inferBindings.getPlaceholderByName("A");
   // Print a diagram that depicts the network decision on a grid.
   Tensor sample(ElemKind::FloatTy, {minibatchSize, 2});
   sample.zero();
@@ -439,8 +488,8 @@ TEST_P(MLTest, circle) {
       sample.getHandle<>().at({0, 0}) = float(x) / 10;
       sample.getHandle<>().at({0, 1}) = float(y) / 10;
 
-      updateInputPlaceholders(bindings, {A}, {&sample});
-      EE_.run(bindings);
+      updateInputPlaceholders2(inferBindings, {A}, {&sample});
+      EEI_.run(inferBindings, fname);
 
       auto SMH = res->getHandle<>();
       auto A = SMH.at({0, 0});
@@ -463,8 +512,8 @@ TEST_P(MLTest, circle) {
     // The dot in the middle must be one.
     sample.getHandle<>().at({0, 0}) = 0;
     sample.getHandle<>().at({0, 1}) = 0;
-    updateInputPlaceholders(bindings, {A}, {&sample});
-    EE_.run(bindings);
+    updateInputPlaceholders2(inferBindings, {A}, {&sample});
+    EEI_.run(inferBindings, fname);
 
     auto SMH = res->getHandle<>();
     auto A = SMH.at({0, 0});
@@ -476,8 +525,8 @@ TEST_P(MLTest, circle) {
     // Far away dot must be zero.
     sample.getHandle<>().at({0, 0}) = 1;
     sample.getHandle<>().at({0, 1}) = 1;
-    updateInputPlaceholders(bindings, {A}, {&sample});
-    EE_.run(bindings);
+    updateInputPlaceholders2(inferBindings, {A}, {&sample});
+    EEI_.run(inferBindings, fname);
     auto SMH = res->getHandle<>();
     auto A = SMH.at({0, 0});
     auto B = SMH.at({0, 1});
@@ -487,7 +536,7 @@ TEST_P(MLTest, circle) {
 
 TEST_P(MLTest, learnSingleValueConcat) {
   unsigned width = 6;
-  PlaceholderBindings bindings;
+  PlaceholderBindings inferBindings, trainingBindings;
 
   // This variable records the number of the next sample to be used for
   // training.
@@ -497,51 +546,54 @@ TEST_P(MLTest, learnSingleValueConcat) {
   TrainingConfig TC;
   TC.momentum = 0.9;
   TC.learningRate = 0.01;
+  Function *F;
+  Placeholder *A, *Ex, *B;
+  for (auto *EE : engines_) {
+    auto &mod = EE->getModule();
+    F = mod.createFunction("learnSingleValueConcat");
 
-  auto &mod = EE_.getModule();
-  Function *F = mod.createFunction("learnSingleValueConcat");
+    Ex = mod.createPlaceholder(ElemKind::FloatTy, {1, width * 2}, "Ex", false);
 
-  Placeholder *Ex =
-      mod.createPlaceholder(ElemKind::FloatTy, {1, width * 2}, "Ex", false);
+    // Left side of the network:
+    A = mod.createPlaceholder(ElemKind::FloatTy, {1, width}, "A", false);
+    Node *L = F->createFullyConnected(inferBindings, "fc1", A, width);
+    L = F->createSigmoid("", L);
 
-  // Left side of the network:
-  Placeholder *A =
-      mod.createPlaceholder(ElemKind::FloatTy, {1, width}, "A", false);
-  Node *L = F->createFullyConnected(bindings, "fc1", A, width);
-  L = F->createSigmoid("", L);
+    // Right side of the network:
+    B = mod.createPlaceholder(ElemKind::FloatTy, {1, width}, "B", false);
+    Node *R = F->createFullyConnected(inferBindings, "fc2", B, width);
+    R = F->createSigmoid("sig", R);
 
-  // Right side of the network:
-  auto *B = mod.createPlaceholder(ElemKind::FloatTy, {1, width}, "B", false);
-  Node *R = F->createFullyConnected(bindings, "fc2", B, width);
-  R = F->createSigmoid("sig", R);
+    // Concat:
+    auto *C = F->createConcat("con", {L, R}, 1);
+    auto *RN = F->createRegression("reg", C, Ex);
+    F->createSave("ret", RN);
+  }
 
-  // Concat:
-  auto *C = F->createConcat("con", {L, R}, 1);
-  auto *RN = F->createRegression("reg", C, Ex);
-  auto *result = F->createSave("ret", RN);
-
-  bindings.allocate(A);
-  bindings.allocate(B);
-  bindings.allocate(Ex);
-  auto *res = bindings.allocate(result->getPlaceholder());
+  trainingBindings.allocate(EET_.getModule().getPlaceholders());
+  inferBindings.copyTrainedWeightsTo(trainingBindings);
+  inferBindings.clear();
+  inferBindings.allocate(EEI_.getModule().getPlaceholders());
+  auto *res = inferBindings.get(EEI_.getModule().getPlaceholderByName("ret"));
 
   Tensor inputs(ElemKind::FloatTy, {1, width});
   Tensor expected(ElemKind::FloatTy, {1, width * 2});
   inputs.getHandle<>().clear(0.15);
   expected.getHandle<>().clear(0.9);
-
-  Function *TF = glow::differentiate(F, TC);
-  EE_.compile(CompilationMode::Train, TF);
+  auto *TF = glow::differentiate(F, TC);
+  auto tfName = TF->getName();
+  EET_.compile(CompilationMode::Train);
+  trainingBindings.allocate(EET_.getModule().getPlaceholders());
 
   // Train the network:
-  runBatch(EE_, bindings, 1000, sampleCounter, {A, B, Ex},
-           {&inputs, &inputs, &expected});
-
-  EE_.compile(CompilationMode::Infer, F);
-
+  runBatch2(EET_, trainingBindings, 1000, sampleCounter, {A, B, Ex},
+            {&inputs, &inputs, &expected}, tfName);
+  trainingBindings.copyTrainedWeightsTo(inferBindings);
+  EEI_.compile(CompilationMode::Infer);
+  A = inferBindings.getPlaceholderByName("A");
   // Testing the output vector.
-  updateInputPlaceholders(bindings, {A}, {&inputs});
-  EE_.run(bindings);
+  updateInputPlaceholders2(inferBindings, {A}, {&inputs});
+  EEI_.run(inferBindings);
   auto RNWH = res->getHandle<>();
   (void)RNWH;
 
@@ -581,62 +633,81 @@ void testRNNCell(TCellGenerator cell) {
   // training.
   size_t sampleCounter = 0;
 
-  PlaceholderBindings bindings;
-  ExecutionEngine EE;
-  // Learning a single input vector.
-  TC.learningRate = 0.05;
-
-  auto &mod = EE.getModule();
-  Function *F = mod.createFunction("testRNNCell");
-
+  PlaceholderBindings inferBindings, trainingBindings;
+  ExecutionEngine2 EEI, EET;
+  std::vector<ExecutionEngine2 *> engines;
+  engines.push_back(&EEI);
+  engines.push_back(&EET);
   const unsigned NumVectors = 3;
   const unsigned NumElements = 4;
-  // Create a variable with 1 input, which is 3 consecutive vectors
-  // of 4 elements each.
-  Placeholder *X = mod.createPlaceholder(
-      ElemKind::FloatTy, {1, NumVectors, NumElements}, "X", false);
-  Placeholder *Y =
-      mod.createPlaceholder(ElemKind::FloatTy, {1, NumVectors}, "Y", false);
-  bindings.allocate(X);
-  bindings.allocate(Y);
+  // Learning a single input vector.
+  TC.learningRate = 0.05;
+  Function *F;
+  Placeholder *X, *Y;
+  for (auto *EE : engines) {
+    auto &mod = EE->getModule();
+    F = mod.createFunction("testRNNCell");
 
-  // Extract a slice for each input.
-  std::vector<NodeValue> XSliced;
+    // Create a variable with 1 input, which is 3 consecutive vectors
+    // of 4 elements each.
+    X = mod.createPlaceholder(ElemKind::FloatTy, {1, NumVectors, NumElements},
+                              "X", false);
+    Y = mod.createPlaceholder(ElemKind::FloatTy, {1, NumVectors}, "Y", false);
+    inferBindings.allocate(X);
+    inferBindings.allocate(Y);
 
-  for (unsigned i = 0; i < NumVectors; ++i) {
-    std::string Name{"X"};
-    Name.append(std::to_string(i + 1));
-    XSliced.push_back(F->createSlice(Name, X, {0, i, 0}, {1, i + 1, 4}));
+    // Extract a slice for each input.
+    std::vector<NodeValue> XSliced;
+
+    for (unsigned i = 0; i < NumVectors; ++i) {
+      std::string Name{"X"};
+      Name.append(std::to_string(i + 1));
+      XSliced.push_back(F->createSlice(Name, X, {0, i, 0}, {1, i + 1, 4}));
+    }
+
+    // Extract a slice for each output.
+    std::vector<Node *> YSliced;
+
+    for (unsigned i = 0; i < NumVectors; ++i) {
+      std::string Name{"Y"};
+      Name.append(std::to_string(i + 1));
+      YSliced.push_back(F->createSlice(Name, Y, {0, i}, {1, i + 1}));
+    }
+
+    const unsigned hiddenSize = 5;
+    const unsigned outputSize = 1;
+
+    std::vector<NodeValue> outputNodes;
+    cell(inferBindings, F, XSliced, hiddenSize, outputSize, outputNodes);
+
+    std::vector<NodeValue> regressionNodes;
+    for (unsigned t = 0; t < NumVectors; t++) {
+      regressionNodes.push_back(
+          F->createRegression("", outputNodes[t], YSliced[t]));
+    };
+
+    auto *R = F->createConcat("O", regressionNodes, 1);
+    F->createSave("result", R);
   }
-
-  // Extract a slice for each output.
-  std::vector<Node *> YSliced;
-
-  for (unsigned i = 0; i < NumVectors; ++i) {
-    std::string Name{"Y"};
-    Name.append(std::to_string(i + 1));
-    YSliced.push_back(F->createSlice(Name, Y, {0, i}, {1, i + 1}));
+  // TODO if PHs aren't zeroed this will not always pass in release. Should
+  // check which operations are sensitive and update them to set AllocZero
+  // properly.
+  for (auto *PH : EEI.getModule().getPlaceholders()) {
+    PH->setAllocZero();
   }
+  for (auto *PH : EET.getModule().getPlaceholders()) {
+    PH->setAllocZero();
+  }
+  trainingBindings.allocate(EET.getModule().getPlaceholders());
+  inferBindings.copyTrainedWeightsTo(trainingBindings);
+  inferBindings.clear();
+  inferBindings.allocate(EEI.getModule().getPlaceholders());
+  auto *res = inferBindings.get(EEI.getModule().getPlaceholderByName("result"));
 
-  const unsigned hiddenSize = 5;
-  const unsigned outputSize = 1;
-
-  std::vector<NodeValue> outputNodes;
-  cell(bindings, F, XSliced, hiddenSize, outputSize, outputNodes);
-
-  std::vector<NodeValue> regressionNodes;
-  for (unsigned t = 0; t < NumVectors; t++) {
-    regressionNodes.push_back(
-        F->createRegression("", outputNodes[t], YSliced[t]));
-  };
-
-  auto *R = F->createConcat("O", regressionNodes, 1);
-  SaveNode *result = F->createSave("result", R);
-
-  Tensor *res = bindings.allocate(result->getPlaceholder());
-
-  Function *TF = glow::differentiate(F, TC);
-  EE.compile(CompilationMode::Train, TF);
+  auto *TF = glow::differentiate(F, TC);
+  auto tfName = TF->getName();
+  auto fname = F->getName();
+  EET.compile(CompilationMode::Train);
 
   // Values for the input and output variables.
   Tensor inputs(ElemKind::FloatTy, {1, NumVectors, NumElements});
@@ -649,13 +720,14 @@ void testRNNCell(TCellGenerator cell) {
   }
 
   // Train the network. Learn 1000 batches.
-  runBatch(EE, bindings, 1000, sampleCounter, {X, Y}, {&inputs, &expected});
-
+  runBatch2(EET, trainingBindings, 1000, sampleCounter, {X, Y},
+            {&inputs, &expected}, tfName);
+  trainingBindings.copyTrainedWeightsTo(inferBindings);
   // Testing the output vector.
-  EE.compile(CompilationMode::Infer, F);
-
-  updateInputPlaceholders(bindings, {X}, {&inputs});
-  EE.run(bindings);
+  EEI.compile(CompilationMode::Infer);
+  X = inferBindings.getPlaceholderByName("X");
+  updateInputPlaceholders2(inferBindings, {X}, {&inputs});
+  EEI.run(inferBindings, fname);
 
   auto RNWH = res->getHandle<>();
   (void)RNWH;
@@ -687,7 +759,7 @@ TEST_P(MLTest, trainSimpleLinearRegression) {
   TC.learningRate = 0.1;
   TC.batchSize = numSamples;
 
-  auto &mod = EE_.getModule();
+  auto &mod = EET_.getModule();
   Function *F = mod.createFunction(
       "Gradient descent solution for simple linear regression");
 
@@ -721,12 +793,13 @@ TEST_P(MLTest, trainSimpleLinearRegression) {
   Placeholder *M = llvm::cast<Placeholder>(FC->getWeights());
   Placeholder *B = llvm::cast<Placeholder>(FC->getBias());
 
-  Function *TF = glow::differentiate(F, TC);
-  EE_.compile(CompilationMode::Train, TF);
+  auto *TF = glow::differentiate(F, TC);
+  auto tfName = TF->getName();
+  EET_.compile(CompilationMode::Train);
 
   // Train the network doing 100 steps. Learn on 500 samples.
-  runBatch(EE_, bindings, 100, sampleCounter, {inputX, expectedY},
-           {&tensorX, &tensorY});
+  runBatch2(EET_, bindings, 100, sampleCounter, {inputX, expectedY},
+            {&tensorX, &tensorY}, tfName);
 
   // Testing trained m and b:
   EXPECT_NEAR(bindings.get(M)->getHandle<>().at({0, 0}), referenceM, 0.01);
@@ -769,7 +842,7 @@ TEST_P(MLTest, classifyPlayerSport) {
   const size_t numClasses = 2;
 
   TrainingConfig TC;
-  PlaceholderBindings bindings;
+  PlaceholderBindings inferBindings, trainingBindings;
 
   // This variable records the number of the next sample to be used for
   // training.
@@ -777,35 +850,42 @@ TEST_P(MLTest, classifyPlayerSport) {
 
   TC.learningRate = 0.05;
   TC.batchSize = numTrainPlayers;
+  Function *F;
+  Placeholder *A, *S;
+  for (auto *EE : engines_) {
+    auto &mod = EE->getModule();
+    F = mod.createFunction("classifyPlayers");
 
-  auto &mod = EE_.getModule();
-  Function *F = mod.createFunction("classifyPlayers");
+    A = mod.createPlaceholder(ElemKind::FloatTy, {numTrainPlayers, numFeatures},
+                              "A", false);
+    S = mod.createPlaceholder(ElemKind::Int64ITy, {numTrainPlayers, 1}, "S",
+                              false);
 
-  Placeholder *A = mod.createPlaceholder(
-      ElemKind::FloatTy, {numTrainPlayers, numFeatures}, "A", false);
-  Placeholder *S = mod.createPlaceholder(ElemKind::Int64ITy,
-                                         {numTrainPlayers, 1}, "S", false);
+    auto *FC = F->createFullyConnected(inferBindings, "fc", A, numClasses);
+    auto *SM = F->createSoftMax("softmax", FC, S);
+    F->createSave("result", SM);
+  }
+  trainingBindings.allocate(EET_.getModule().getPlaceholders());
+  inferBindings.copyTrainedWeightsTo(trainingBindings);
+  inferBindings.clear();
+  inferBindings.allocate(EEI_.getModule().getPlaceholders());
 
-  auto *FC = F->createFullyConnected(bindings, "fc", A, numClasses);
-  auto *SM = F->createSoftMax("softmax", FC, S);
-  SaveNode *result = F->createSave("result", SM);
-
-  bindings.allocate(A);
-  bindings.allocate(S);
-  bindings.allocate(result->getPlaceholder());
-
-  Function *TF = glow::differentiate(F, TC);
-  EE_.compile(CompilationMode::Train, TF);
+  auto *TF = glow::differentiate(F, TC);
+  auto tfName = TF->getName();
+  auto fname = F->getName();
+  EET_.compile(CompilationMode::Train);
 
   Tensor players(ElemKind::FloatTy, {numTrainPlayers, numFeatures});
   Tensor labels(ElemKind::Int64ITy, {numTrainPlayers, 1});
-  generatePlayerData(players, labels, numTrainPlayers, mod.getPRNG());
+  generatePlayerData(players, labels, numTrainPlayers,
+                     EET_.getModule().getPRNG());
 
   // Training:
-  runBatch(EE_, bindings, 2000, sampleCounter, {A, S}, {&players, &labels});
-
-  EE_.compile(CompilationMode::Infer, F);
-
+  runBatch2(EET_, trainingBindings, 2000, sampleCounter, {A, S},
+            {&players, &labels}, tfName);
+  trainingBindings.copyTrainedWeightsTo(inferBindings);
+  EEI_.compile(CompilationMode::Infer);
+  A = inferBindings.getPlaceholderByName("A");
   std::vector<std::tuple<unsigned, unsigned, Sport>> testPlayers;
   testPlayers.emplace_back(82, 240, Sport::BASKETBALL);
   testPlayers.emplace_back(86, 260, Sport::BASKETBALL);
@@ -820,10 +900,11 @@ TEST_P(MLTest, classifyPlayerSport) {
     testPlayersTensor.getHandle<>().at({i, 1}) = std::get<1>(testPlayers[i]);
   }
 
-  updateInputPlaceholders(bindings, {A}, {&testPlayersTensor});
-  EE_.run(bindings);
+  updateInputPlaceholders2(inferBindings, {A}, {&testPlayersTensor});
+  EEI_.run(inferBindings, fname);
 
-  auto SMH = bindings.get(result->getPlaceholder())->getHandle<>();
+  auto SMH = inferBindings.get(inferBindings.getPlaceholderByName("result"))
+                 ->getHandle<>();
   for (size_t i = 0; i < testPlayers.size(); i++) {
     const size_t sport = static_cast<size_t>(std::get<2>(testPlayers[i]));
     EXPECT_NEAR(SMH.at({i, sport}), 1.0, 0.1);
@@ -832,7 +913,7 @@ TEST_P(MLTest, classifyPlayerSport) {
 
 TEST_P(MLTest, learnSinus) {
   TrainingConfig TC;
-  PlaceholderBindings bindings;
+  PlaceholderBindings trainingBindings, inferBindings;
 
   // This variable records the number of the next sample to be used for
   // training.
@@ -841,55 +922,62 @@ TEST_P(MLTest, learnSinus) {
   // Try to learn the sin(x) function.
   float epsilon = 0.1;
   unsigned numSamples = 50;
+  Tensor tensorX(ElemKind::FloatTy, {numSamples, 1});
+  Tensor tensorY(ElemKind::FloatTy, {numSamples, 1});
 
   TC.learningRate = 0.2;
   TC.batchSize = numSamples;
-
-  auto &mod = EE_.getModule();
-  Function *F = mod.createFunction("Gradient descent solution for sin(x)");
 
   // Function that should be learned by the NN
   auto FF = [](float x) -> float {
     // Return a shifted sin(x) value, so that it is in the range [0, 1].
     return (sin(x) + 1) / 2;
   };
+  Function *F;
+  Placeholder *inputX, *expectedY;
+  for (auto *EE : engines_) {
+    auto &mod = EE->getModule();
+    F = mod.createFunction("Gradient descent solution for sin(x)");
 
-  Tensor tensorX(ElemKind::FloatTy, {numSamples, 1});
-  Tensor tensorY(ElemKind::FloatTy, {numSamples, 1});
+    for (unsigned i = 0; i < numSamples; i++) {
+      // Scale x to cover the range [0, 4] as this leads to a good convergence
+      // during training.
+      float x = i / (numSamples / 4.0);
+      float y = FF(x);
+      tensorX.getHandle<>().at({i, 0}) = x;
+      tensorY.getHandle<>().at({i, 0}) = y;
+    }
 
-  for (unsigned i = 0; i < numSamples; i++) {
-    // Scale x to cover the range [0, 4] as this leads to a good convergence
-    // during training.
-    float x = i / (numSamples / 4.0);
-    float y = FF(x);
-    tensorX.getHandle<>().at({i, 0}) = x;
-    tensorY.getHandle<>().at({i, 0}) = y;
+    inputX = mod.createPlaceholder(ElemKind::FloatTy, {numSamples, 1}, "input",
+                                   false);
+
+    expectedY = mod.createPlaceholder(ElemKind::FloatTy, {numSamples, 1},
+                                      "expected", false);
+
+    FullyConnectedNode *FC1 =
+        F->createFullyConnected(inferBindings, "fc1", inputX, 10);
+    Node *O = F->createSigmoid("sigmoid1", FC1);
+    FullyConnectedNode *FC2 =
+        F->createFullyConnected(inferBindings, "fc2", O, 1);
+    Node *R = F->createRegression("reg", FC2, expectedY);
+    F->createSave("return", R);
   }
+  trainingBindings.allocate(EET_.getModule().getPlaceholders());
+  inferBindings.copyTrainedWeightsTo(trainingBindings);
+  inferBindings.clear();
+  inferBindings.allocate(EEI_.getModule().getPlaceholders());
+  auto *res =
+      inferBindings.get(EEI_.getModule().getPlaceholderByName("return"));
 
-  Placeholder *inputX =
-      mod.createPlaceholder(ElemKind::FloatTy, {numSamples, 1}, "input", false);
-
-  Placeholder *expectedY = mod.createPlaceholder(
-      ElemKind::FloatTy, {numSamples, 1}, "expected", false);
-
-  FullyConnectedNode *FC1 =
-      F->createFullyConnected(bindings, "fc1", inputX, 10);
-  Node *O = F->createSigmoid("sigmoid1", FC1);
-  FullyConnectedNode *FC2 = F->createFullyConnected(bindings, "fc2", O, 1);
-  Node *R = F->createRegression("reg", FC2, expectedY);
-  SaveNode *result = F->createSave("return", R);
-
-  bindings.allocate(inputX);
-  bindings.allocate(expectedY);
-  Tensor *res = bindings.allocate(result->getPlaceholder());
-
-  Function *TF = glow::differentiate(F, TC);
-  EE_.compile(CompilationMode::Train, TF);
+  auto *TF = glow::differentiate(F, TC);
+  auto tfName = TF->getName();
+  auto fname = F->getName();
+  EET_.compile(CompilationMode::Train);
 
   // Learn on numSamples samples.
-  runBatch(EE_, bindings, 2700, sampleCounter, {inputX, expectedY},
-           {&tensorX, &tensorY});
-
+  runBatch2(EET_, trainingBindings, 2700, sampleCounter, {inputX, expectedY},
+            {&tensorX, &tensorY}, tfName);
+  trainingBindings.copyTrainedWeightsTo(inferBindings);
   // Create a test set, which is similar, but different from the training set.
   for (unsigned i = 0; i < numSamples; i++) {
     // Scale x to cover the range [0, 4.2] as this leads to a good convergence
@@ -899,10 +987,10 @@ TEST_P(MLTest, learnSinus) {
     tensorX.getHandle<>().at({i, 0}) = x;
     tensorY.getHandle<>().at({i, 0}) = y;
   }
-
-  EE_.compile(CompilationMode::Infer, F);
-  updateInputPlaceholders(bindings, {inputX}, {&tensorX});
-  EE_.run(bindings);
+  inputX = inferBindings.getPlaceholderByName("input");
+  EEI_.compile(CompilationMode::Infer);
+  updateInputPlaceholders2(inferBindings, {inputX}, {&tensorX});
+  EEI_.run(inferBindings, fname);
   auto resH = res->getHandle<>();
 
   for (size_t i = 0; i < numSamples; i++) {
@@ -921,51 +1009,57 @@ TEST_P(MLTest, nonLinearClassifier) {
   // training.
   size_t sampleCounter = 0;
 
-  PlaceholderBindings bindings;
+  PlaceholderBindings inferBindings, trainingBindings;
   TrainingConfig TC;
   TC.learningRate = 0.01;
   TC.momentum = 0.9;
   TC.batchSize = batchSize;
+  Function *F;
+  Placeholder *A, *S;
+  for (auto *EE : engines_) {
+    auto &mod = EE->getModule();
+    F = mod.createFunction("nonLinearClassifier");
 
-  auto &mod = EE_.getModule();
-  Function *F = mod.createFunction("nonLinearClassifier");
+    A = mod.createPlaceholder(ElemKind::FloatTy, {batchSize, 2}, "A", false);
+    S = mod.createPlaceholder(ElemKind::Int64ITy, {batchSize, 1}, "S", false);
 
-  Placeholder *A =
-      mod.createPlaceholder(ElemKind::FloatTy, {batchSize, 2}, "A", false);
-  Placeholder *S =
-      mod.createPlaceholder(ElemKind::Int64ITy, {batchSize, 1}, "S", false);
+    auto *FCL0 = F->createFullyConnected(inferBindings, "fc1", A, 8);
+    auto *T0 = F->createTanh("tanh1", FCL0);
+    auto *FCL1 = F->createFullyConnected(inferBindings, "fc2", T0, 8);
+    auto *T1 = F->createTanh("tanh2", FCL1);
+    auto *FCL2 = F->createFullyConnected(inferBindings, "fc2", T1, 2);
+    auto *SM = F->createSoftMax("soft", FCL2, S);
+    F->createSave("ret", SM);
+  }
+  trainingBindings.allocate(EET_.getModule().getPlaceholders());
+  inferBindings.copyTrainedWeightsTo(trainingBindings);
+  inferBindings.clear();
+  inferBindings.allocate(EEI_.getModule().getPlaceholders());
+  auto *res = inferBindings.get(EEI_.getModule().getPlaceholderByName("ret"));
 
-  auto *FCL0 = F->createFullyConnected(bindings, "fc1", A, 8);
-  auto *T0 = F->createTanh("tanh1", FCL0);
-  auto *FCL1 = F->createFullyConnected(bindings, "fc2", T0, 8);
-  auto *T1 = F->createTanh("tanh2", FCL1);
-  auto *FCL2 = F->createFullyConnected(bindings, "fc2", T1, 2);
-  auto *SM = F->createSoftMax("soft", FCL2, S);
-  SaveNode *result = F->createSave("ret", SM);
-
-  bindings.allocate(A);
-  bindings.allocate(S);
-  Tensor *res = bindings.allocate(result->getPlaceholder());
-
-  Function *TF = glow::differentiate(F, TC);
-  EE_.compile(CompilationMode::Train, TF);
+  auto *TF = glow::differentiate(F, TC);
+  auto tfName = TF->getName();
+  auto fname = F->getName();
+  EET_.compile(CompilationMode::Train);
+  trainingBindings.allocate(EET_.getModule().getPlaceholders());
 
   Tensor samples(ElemKind::FloatTy, {numSamples, 2});
   Tensor labels(ElemKind::Int64ITy, {numSamples, 1});
 
   for (size_t i = 0; i < numSamples; i++) {
-    float x = mod.getPRNG().nextRand();
-    float y = mod.getPRNG().nextRand();
+    float x = EET_.getModule().getPRNG().nextRand();
+    float y = EET_.getModule().getPRNG().nextRand();
     size_t label = (x < 0.0) ^ (y < 0.0);
     samples.getHandle<>().at({i, 0}) = x;
     samples.getHandle<>().at({i, 1}) = y;
     labels.getHandle<int64_t>().at({i, 0}) = label;
   }
 
-  runBatch(EE_, bindings, 500, sampleCounter, {A, S}, {&samples, &labels});
-
-  EE_.compile(CompilationMode::Infer, F);
-
+  runBatch2(EET_, trainingBindings, 500, sampleCounter, {A, S},
+            {&samples, &labels}, tfName);
+  trainingBindings.copyTrainedWeightsTo(inferBindings);
+  EEI_.compile(CompilationMode::Infer);
+  A = inferBindings.getPlaceholderByName("A");
   std::vector<std::tuple<float, float, size_t>> tests;
   tests.emplace_back(-0.8, -0.8, 0);
   tests.emplace_back(0.8, -0.8, 1);
@@ -976,8 +1070,8 @@ TEST_P(MLTest, nonLinearClassifier) {
     Tensor T(ElemKind::FloatTy, {batchSize, 2});
     T.getHandle<>().at({0, 0}) = std::get<0>(tests[i]);
     T.getHandle<>().at({0, 1}) = std::get<1>(tests[i]);
-    updateInputPlaceholders(bindings, {A}, {&T});
-    EE_.run(bindings);
+    updateInputPlaceholders2(inferBindings, {A}, {&T});
+    EEI_.run(inferBindings, fname);
     EXPECT_NEAR(RH.at({0, std::get<2>(tests[i])}), 1.0, 0.2);
   }
 }
@@ -1010,10 +1104,12 @@ static void generateImageData(Tensor &images, Tensor &labels, PseudoRNG &PRNG) {
 /// Use a simple convnet to learn two classes of images: Line and Cross.
 /// This test checks the results of the quantized network.
 TEST_P(InterpreterAndCPU, convNetForImageRecognition) {
-  ExecutionEngine EE{"Interpreter"};
+  EET_.setBackendName("Interpreter");
+  ExecutionEngine2 EEP{"Interpreter"};
+  engines_.emplace(engines_.begin(), &EEP);
   const unsigned numSamples = 500;
   const unsigned batchSize = 7;
-  PlaceholderBindings bindings;
+  PlaceholderBindings inferBindings, trainingBindings, profileBindings;
 
   // This variable records the number of the next sample to be used for
   // training.
@@ -1023,68 +1119,92 @@ TEST_P(InterpreterAndCPU, convNetForImageRecognition) {
   TC.learningRate = 0.01;
   TC.batchSize = batchSize;
   TC.momentum = 0.9;
+  std::string fName;
+  for (auto *EE : engines_) {
+    auto &mod = EE->getModule();
+    Function *F = mod.createFunction("convNetForImageRecognition");
 
-  auto &mod = EE.getModule();
-  Function *F = mod.createFunction("convNetForImageRecognition");
+    Placeholder *input = mod.createPlaceholder(
+        ElemKind::FloatTy, {batchSize, 8, 8, 1}, "input", false);
 
-  Placeholder *input = mod.createPlaceholder(
-      ElemKind::FloatTy, {batchSize, 8, 8, 1}, "input", false);
+    Placeholder *ex =
+        mod.createPlaceholder(ElemKind::Int64ITy, {batchSize, 1}, "exp", false);
 
-  Placeholder *ex =
-      mod.createPlaceholder(ElemKind::Int64ITy, {batchSize, 1}, "exp", false);
+    auto *CV = F->createConv(inferBindings, "conv", input, 1, 3, 1, 0, 1);
+    auto *TANH = F->createTanh("tanh", CV);
+    auto *FCL = F->createFullyConnected(inferBindings, "fc", TANH, 2);
+    auto *SM = F->createSoftMax("sm", FCL, ex);
+    F->createSave("ret", SM);
+    fName = F->getName();
+  }
 
-  auto *CV = F->createConv(bindings, "conv", input, 1, 3, 1, 0, 1);
-  auto *TANH = F->createTanh("tanh", CV);
-  auto *FCL = F->createFullyConnected(bindings, "fc", TANH, 2);
-  auto *SM = F->createSoftMax("sm", FCL, ex);
-  SaveNode *result = F->createSave("ret", SM);
+  auto *mod = &EET_.getModule();
+  auto input = mod->getPlaceholderByName("input");
+  auto ex = mod->getPlaceholderByName("exp");
 
-  bindings.allocate(input);
-  bindings.allocate(ex);
-  Tensor *res = bindings.allocate(result->getPlaceholder());
-
-  Function *TF = glow::differentiate(F, TC);
-  EE.compile(CompilationMode::Train, TF);
+  auto *TF = glow::differentiate(mod->getFunction(fName), TC);
+  auto tfName = TF->getName();
+  EET_.compile(CompilationMode::Train);
+  trainingBindings.allocate(mod->getPlaceholders());
+  inferBindings.copyTrainedWeightsTo(trainingBindings);
 
   Tensor images(ElemKind::FloatTy, {numSamples, 8, 8, 1});
   Tensor labels(ElemKind::Int64ITy, {numSamples, 1});
-  generateImageData(images, labels, mod.getPRNG());
+  generateImageData(images, labels, mod->getPRNG());
 
   // Training:
-  runBatch(EE, bindings, 500, sampleCounter, {input, ex}, {&images, &labels});
+  runBatch2(EET_, trainingBindings, 500, sampleCounter, {input, ex},
+            {&images, &labels}, tfName);
 
+  mod = &EEP.getModule();
+  profileBindings.allocate(mod->getPlaceholders());
   LoweredInfoMap loweredMapForProf;
-  CompilationContext cctxProf{&bindings, &loweredMapForProf};
+  CompilationContext cctxProf{&profileBindings, &loweredMapForProf};
   cctxProf.precisionConfig.quantMode = QuantizationMode::Profile;
 
-  Function *PF = F->clone("profile");
-  EE.compile(PF, cctxProf);
-  runBatch(EE, bindings, 100, sampleCounter, {input}, {&images});
+  auto F = mod->getFunction(fName);
+  input = mod->getPlaceholderByName("input");
+  trainingBindings.copyTrainedWeightsTo(profileBindings);
+  EEP.compile(cctxProf);
+  // Since we are compiling in profiling mode the partitioner will create a new
+  // function from the original. Get the new function.
+  F = mod->getFunctions().front();
+
+  runBatch2(EEP, profileBindings, 100, sampleCounter, {input}, {&images},
+            fName);
 
   // Evaluate on the quantized function:
   // Set the execution backend to the backend that we test.
-  EE.setBackend(GetParam());
+  mod = &EEI_.getModule();
+  inferBindings.clear();
+  inferBindings.allocate(mod->getPlaceholders());
+  trainingBindings.copyTrainedWeightsTo(inferBindings);
 
   LoweredInfoMap loweredMapForQuant;
-  CompilationContext cctxQuant{&bindings, &loweredMapForQuant};
+  CompilationContext cctxQuant{&inferBindings, &loweredMapForQuant};
   PrecisionConfiguration &precConfig = cctxQuant.precisionConfig;
   cctxQuant.precisionConfig.quantMode = QuantizationMode::Quantize;
   precConfig.quantConfig.infos = quantization::generateNodeQuantizationInfos(
-      bindings, PF, loweredMapForProf);
+      profileBindings, F, loweredMapForProf);
   precConfig.quantConfig.assertAllNodesQuantized = true;
 
   // Softmax is not supported in Int8QTy, so signal the quantizer it's OK to
   // keep it unquantized.
   precConfig.precisionModeKindSet.insert(Kinded::Kind::SoftMaxNodeKind);
 
-  EE.compile(F, cctxQuant);
+  F = mod->getFunction("convNetForImageRecognition");
+  EEI_.compile(cctxQuant);
+  input = mod->getPlaceholderByName("input");
 
   // Generate the images used for testing.
   Tensor testImages(ElemKind::FloatTy, {batchSize, 8, 8, 1});
   Tensor testLabels(ElemKind::Int64ITy, {batchSize, 1});
-  generateImageData(testImages, testLabels, mod.getPRNG());
-  updateInputPlaceholders(bindings, {input}, {&testImages});
-  EE.run(bindings);
+  generateImageData(testImages, testLabels, mod->getPRNG());
+  updateInputPlaceholders2(inferBindings, {input}, {&testImages});
+
+  EEI_.run(inferBindings);
+
+  Tensor *res = inferBindings.get(EEI_.getModule().getPlaceholderByName("ret"));
   auto SMH = res->getHandle<>();
   for (size_t i = 0; i < batchSize; i++) {
     bool isLine = testLabels.getHandle<int64_t>().at({i, 0}) == 0;
@@ -1117,8 +1237,10 @@ static void generateRegressionTestData(Tensor &images, Tensor &labels,
 /// This is the "Where's Waldo" test. We place a pixel in a tensor and the
 /// network reports the coordinate of the pixel.
 TEST_P(InterpreterAndCPU, testFindPixelRegression) {
-  ExecutionEngine EE{"Interpreter"};
-  PlaceholderBindings bindings;
+  EET_.setBackendName("Interpreter");
+  ExecutionEngine2 EEP{"Interpreter"};
+  engines_.emplace(engines_.begin(), &EEP);
+  PlaceholderBindings inferBindings, trainingBindings, profileBindings;
 
   const unsigned numSamples = 1000;
   const unsigned batchSize = 10;
@@ -1131,78 +1253,96 @@ TEST_P(InterpreterAndCPU, testFindPixelRegression) {
   TC.learningRate = 0.01;
   TC.batchSize = batchSize;
   TC.momentum = 0.9;
+  std::string fName;
+  for (auto *EE : engines_) {
+    auto &mod = EE->getModule();
+    Function *F = mod.createFunction("main");
 
-  auto &mod = EE.getModule();
-  Function *F = mod.createFunction("main");
+    Placeholder *input = mod.createPlaceholder(
+        ElemKind::FloatTy, {batchSize, 10, 10, 1}, "input", false);
+    Placeholder *ex = mod.createPlaceholder(ElemKind::FloatTy, {batchSize, 2},
+                                            "coordinates", false);
 
-  Placeholder *input = mod.createPlaceholder(
-      ElemKind::FloatTy, {batchSize, 10, 10, 1}, "input", false);
-  Placeholder *ex = mod.createPlaceholder(ElemKind::FloatTy, {batchSize, 2},
-                                          "coordinates", false);
+    // A simple single-layer FC network could solve this program but we use a
+    // two layer FC network to give the compiler something slightly more complex
+    // to work with so we are adding another FC layer.
+    auto *FC0 = F->createFullyConnected(inferBindings, "fc0", input, 6);
+    auto *RL0 = F->createRELU("relu0", FC0);
+    auto *FC1 = F->createFullyConnected(inferBindings, "fc1", RL0, 2);
+    auto *R = F->createRegression("regression", FC1, ex);
+    F->createSave("ret", R);
+    fName = F->getName();
+  }
 
-  // A simple single-layer FC network could solve this program but we use a two
-  // layer FC network to give the compiler something slightly more complex to
-  // work with so we are adding another FC layer.
-  auto *FC0 = F->createFullyConnected(bindings, "fc0", input, 6);
-  auto *RL0 = F->createRELU("relu0", FC0);
-  auto *FC1 = F->createFullyConnected(bindings, "fc1", RL0, 2);
-  auto *R = F->createRegression("regression", FC1, ex);
-  SaveNode *result = F->createSave("ret", R);
+  auto *mod = &EET_.getModule();
+  auto input = mod->getPlaceholderByName("input");
+  auto ex = mod->getPlaceholderByName("coordinates");
 
-  bindings.allocate(input);
-  bindings.allocate(ex);
-  Tensor *res = bindings.allocate(result->getPlaceholder());
+  auto *TF = glow::differentiate(mod->getFunction(fName), TC);
+  auto tfName = TF->getName();
+  EET_.compile(CompilationMode::Train);
+  trainingBindings.allocate(mod->getPlaceholders());
 
-  Function *TF = glow::differentiate(F, TC);
-  EE.compile(CompilationMode::Train, TF);
+  for (auto &PH : inferBindings.pairs()) {
+    inferBindings.copyToTarget(PH.first->getName(), trainingBindings);
+  }
+  inferBindings.clear();
 
   // --  STEP1 - train the network. --
   Tensor images(ElemKind::FloatTy, {numSamples, 10, 10, 1});
   Tensor labels(ElemKind::FloatTy, {numSamples, 2});
-  generateRegressionTestData(images, labels, mod.getPRNG());
+  generateRegressionTestData(images, labels, mod->getPRNG());
 
   // Training:
-  runBatch(EE, bindings, 400, sampleCounter, {input, ex}, {&images, &labels});
+  runBatch2(EET_, trainingBindings, 400, sampleCounter, {input, ex},
+            {&images, &labels}, tfName);
 
   // -- STEP2 - Profile and quantize the network. --
-
+  mod = &EEP.getModule();
+  profileBindings.allocate(mod->getPlaceholders());
   LoweredInfoMap loweredMapForProf;
-  CompilationContext cctxProf{&bindings, &loweredMapForProf};
+  CompilationContext cctxProf{&profileBindings, &loweredMapForProf};
   cctxProf.precisionConfig.quantMode = QuantizationMode::Profile;
 
-  Function *PF = F->clone("profile");
-  EE.compile(PF, cctxProf);
+  input = mod->getPlaceholderByName("input");
+  trainingBindings.copyTrainedWeightsTo(profileBindings);
+  EEP.compile(cctxProf);
+  // Get new function after partitioning.
+  auto F = EEP.getModule().getFunctions().front();
 
   // Run the graph to capture the profile.
-  runBatch(EE, bindings, 100, sampleCounter, {input}, {&images});
+  runBatch2(EEP, profileBindings, 100, sampleCounter, {input}, {&images},
+            fName);
 
   // -- STEP3 - evaluate the quantized function. --
-
-  // Set the execution backend to the backend that we test.
-  EE.setBackend(GetParam());
+  mod = &EEI_.getModule();
+  inferBindings.allocate(mod->getPlaceholders());
+  trainingBindings.copyTrainedWeightsTo(inferBindings);
 
   LoweredInfoMap loweredMapForQuant;
-  CompilationContext cctxQuant{&bindings, &loweredMapForQuant};
+  CompilationContext cctxQuant{&inferBindings, &loweredMapForQuant};
   cctxQuant.precisionConfig.quantMode = QuantizationMode::Quantize;
   cctxQuant.loweredInfoMap = &loweredMapForQuant;
-  cctxQuant.bindings = &bindings;
   cctxQuant.precisionConfig.quantConfig.infos =
-      quantization::generateNodeQuantizationInfos(bindings, PF,
+      quantization::generateNodeQuantizationInfos(profileBindings, F,
                                                   loweredMapForProf);
   cctxQuant.precisionConfig.quantConfig.assertAllNodesQuantized = true;
 
-  EE.compile(F, cctxQuant);
+  F = mod->getFunction(fName);
+  EEI_.compile(cctxQuant);
+  input = mod->getPlaceholderByName("input");
 
   // Generate the images used for testing.
   Tensor testImages(ElemKind::FloatTy, {batchSize, 10, 10, 1});
   Tensor testLabels(ElemKind::FloatTy, {batchSize, 2});
-  generateRegressionTestData(testImages, testLabels, mod.getPRNG());
+  generateRegressionTestData(testImages, testLabels, mod->getPRNG());
 
   // Run the inference:
-  updateInputPlaceholders(bindings, {input}, {&testImages});
-  EE.run(bindings);
+  updateInputPlaceholders2(inferBindings, {input}, {&testImages});
+  EEI_.run(inferBindings);
 
   // A handle to the projected result.
+  Tensor *res = inferBindings.get(EEI_.getModule().getPlaceholderByName("ret"));
   auto RH = res->getHandle<>();
   // A handle to the true label.
   auto LH = testLabels.getHandle<>();
@@ -1303,75 +1443,85 @@ TEST_P(MLTest, matrixRotationRecognition) {
   TrainingConfig TC;
   TC.learningRate = 0.15;
   TC.batchSize = 17;
-  PlaceholderBindings bindings;
+  PlaceholderBindings inferBindings, trainingBindings;
 
   // This variable records the number of the next sample to be used for
   // training.
   size_t sampleCounter = 0;
+  Function *F;
+  Placeholder *varMatricesA, *varMatricesB, *varExpected;
+  for (auto *EE : engines_) {
+    Module &mod = EE->getModule();
+    F = mod.createFunction("MatrixRotationRecognition");
+    varMatricesA = mod.createPlaceholder(
+        ElemKind::FloatTy, {TC.batchSize, 3, 3}, "matrixA", false);
+    varMatricesB = mod.createPlaceholder(
+        ElemKind::FloatTy, {TC.batchSize, 3, 3}, "matrixB", false);
+    varExpected = mod.createPlaceholder(ElemKind::Int64ITy, {TC.batchSize, 1},
+                                        "expected", false);
 
-  Module &mod = EE_.getModule();
-  PseudoRNG &PRNG = mod.getPRNG();
-  Function *F = mod.createFunction("MatrixRotationRecognition");
-  Placeholder *varMatricesA = mod.createPlaceholder(
-      ElemKind::FloatTy, {TC.batchSize, 3, 3}, "matrixA", false);
-  Placeholder *varMatricesB = mod.createPlaceholder(
-      ElemKind::FloatTy, {TC.batchSize, 3, 3}, "matrixB", false);
-  Placeholder *varExpected = mod.createPlaceholder(
-      ElemKind::Int64ITy, {TC.batchSize, 1}, "expected", false);
-
-  // Simply concatenating the matrices first would probability be as effective
-  // but we want to build something more complex than a straight chain of
-  // operators to stress the scheduler.
-  auto *FCA =
-      F->createFullyConnected(bindings, "hidden_matrixA_fc", varMatricesA, 10);
-  auto *FCB =
-      F->createFullyConnected(bindings, "hidden_matrixB_fc", varMatricesB, 10);
-  auto *ReLUA = F->createRELU("hidden_matrixA_ReLU", FCA);
-  auto *ReLUB = F->createRELU("hidden_matrixB_ReLU", FCB);
-  auto *concat = F->createConcat("hidden_concat_A_B", {ReLUA, ReLUB}, 1);
-  auto *hiddenFC = F->createFullyConnected(bindings, "hidden_fc", concat, 30);
-  auto *finalReLU = F->createRELU("hidden_concat_ReLU", hiddenFC);
-  auto *finalFC = F->createFullyConnected(bindings, "output_fc", finalReLU, 2);
-  auto *softMax = F->createSoftMax("output", finalFC, varExpected);
-  SaveNode *result = F->createSave("result", softMax);
-
-  bindings.allocate(varMatricesA);
-  bindings.allocate(varMatricesB);
-  bindings.allocate(varExpected);
-  Tensor *res = bindings.allocate(result->getPlaceholder());
-
-  Function *trainingGradientFunction = glow::differentiate(F, TC);
+    // Simply concatenating the matrices first would probability be as effective
+    // but we want to build something more complex than a straight chain of
+    // operators to stress the scheduler.
+    auto *FCA = F->createFullyConnected(inferBindings, "hidden_matrixA_fc",
+                                        varMatricesA, 10);
+    auto *FCB = F->createFullyConnected(inferBindings, "hidden_matrixB_fc",
+                                        varMatricesB, 10);
+    auto *ReLUA = F->createRELU("hidden_matrixA_ReLU", FCA);
+    auto *ReLUB = F->createRELU("hidden_matrixB_ReLU", FCB);
+    auto *concat = F->createConcat("hidden_concat_A_B", {ReLUA, ReLUB}, 1);
+    auto *hiddenFC =
+        F->createFullyConnected(inferBindings, "hidden_fc", concat, 30);
+    auto *finalReLU = F->createRELU("hidden_concat_ReLU", hiddenFC);
+    auto *finalFC =
+        F->createFullyConnected(inferBindings, "output_fc", finalReLU, 2);
+    auto *softMax = F->createSoftMax("output", finalFC, varExpected);
+    F->createSave("result", softMax);
+  }
+  trainingBindings.allocate(EET_.getModule().getPlaceholders());
+  inferBindings.copyTrainedWeightsTo(trainingBindings);
+  inferBindings.clear();
+  inferBindings.allocate(EEI_.getModule().getPlaceholders());
+  auto *res =
+      inferBindings.get(EEI_.getModule().getPlaceholderByName("result"));
+  auto *TF = glow::differentiate(F, TC);
+  auto tfName = TF->getName();
+  auto fname = F->getName();
 
   // Train the network.
   const unsigned numSamples = 50;
   Tensor matricesA(ElemKind::FloatTy, {numSamples, 3, 3});
   Tensor matricesB(ElemKind::FloatTy, {numSamples, 3, 3});
   Tensor expected(ElemKind::Int64ITy, {numSamples, 1});
-  generateMatrixRotationRecognitionData(matricesA, matricesB, expected, PRNG);
+  generateMatrixRotationRecognitionData(matricesA, matricesB, expected,
+                                        EET_.getModule().getPRNG());
 
-  EE_.compile(CompilationMode::Train, trainingGradientFunction);
+  EET_.compile(CompilationMode::Train);
   // Training:
-  runBatch(EE_, bindings, 200, sampleCounter,
-           {varMatricesA, varMatricesB, varExpected},
-           {&matricesA, &matricesB, &expected});
+  runBatch2(EET_, trainingBindings, 200, sampleCounter,
+            {varMatricesA, varMatricesB, varExpected},
+            {&matricesA, &matricesB, &expected}, tfName);
+  trainingBindings.copyTrainedWeightsTo(inferBindings);
 
   // Switch to inference mode.
-  EE_.compile(CompilationMode::Infer, F);
+  EEI_.compile(CompilationMode::Infer);
 
   // At this point we should have overfitted the data.
   // Take a random batch and check that the values match what we expect.
   auto RHtrain = res->getHandle<>();
   auto batchSize = TC.batchSize;
   unsigned numBatches = numSamples / batchSize;
-  unsigned batchStartIdx = PRNG.nextRandInt(0, numBatches - 1) * batchSize;
-
+  unsigned batchStartIdx =
+      EEI_.getModule().getPRNG().nextRandInt(0, numBatches - 1) * batchSize;
+  varMatricesA = inferBindings.getPlaceholderByName("matrixA");
+  varMatricesB = inferBindings.getPlaceholderByName("matrixB");
   auto batchMatricesA =
       matricesA.getUnowned({batchSize, 3, 3}, {batchStartIdx, 0, 0});
   auto batchMatricesB =
       matricesB.getUnowned({batchSize, 3, 3}, {batchStartIdx, 0, 0});
-  updateInputPlaceholders(bindings, {varMatricesA, varMatricesB},
-                          {&batchMatricesA, &batchMatricesB});
-  EE_.run(bindings);
+  updateInputPlaceholders2(inferBindings, {varMatricesA, varMatricesB},
+                           {&batchMatricesA, &batchMatricesB});
+  EEI_.run(inferBindings, fname);
 
   unsigned errors = 0;
   // Check each output in the batch.
@@ -1395,67 +1545,87 @@ TEST_P(MLTest, learnSparseLengthsWeightedSumEmbeddings) {
   TC.learningRate = 0.3;
   TC.batchSize = 1;
 
-  PlaceholderBindings bindings;
+  PlaceholderBindings trainingBindings, inferBindings;
+  Function *F;
+  Placeholder *dataP, *indicesP, *lengthsP, *expectedP, *weightsP;
+  PseudoRNG &PRNG = EET_.getModule().getPRNG();
+  for (auto *EE : engines_) {
+    Module &mod = EE->getModule();
 
-  Module &mod = EE_.getModule();
-  PseudoRNG &PRNG = mod.getPRNG();
+    // Create a model consisting of one SparseLengthsWeightedSum operator
+    // followed by a Regression node to get some non-zero gradients.
+    F = mod.createFunction("SparseLengthsWeightedSum");
+    dataP = mod.createPlaceholder(ElemKind::FloatTy, {10}, "dataP",
+                                  /*isTrainable=*/true);
+    indicesP = mod.createPlaceholder(ElemKind::Int64ITy, {10}, "indicesP",
+                                     /*isTrainable=*/false);
+    weightsP = mod.createPlaceholder(ElemKind::FloatTy, {10}, "weightsP",
+                                     /*isTrainable=*/false);
+    lengthsP = mod.createPlaceholder(ElemKind::Int32ITy, {5}, "lengthsP",
+                                     /*isTrainable=*/false);
+    expectedP = mod.createPlaceholder(ElemKind::FloatTy, {5}, "expectedP",
+                                      /*isTrainable=*/false);
 
-  // Create a model consisting of one SparseLengthsWeightedSum operator followed
-  // by a Regression node to get some non-zero gradients.
-  Function *F = mod.createFunction("SparseLengthsWeightedSum");
-  Placeholder *dataP = mod.createPlaceholder(ElemKind::FloatTy, {10}, "dataP",
-                                             /*isTrainable=*/true);
-  Placeholder *indicesP = mod.createPlaceholder(
-      ElemKind::Int64ITy, {10}, "indicesP", /*isTrainable=*/false);
-  Placeholder *weightsP = mod.createPlaceholder(
-      ElemKind::FloatTy, {10}, "weightsP", /*isTrainable=*/false);
-  Placeholder *lengthsP = mod.createPlaceholder(
-      ElemKind::Int32ITy, {5}, "lengthsP", /*isTrainable=*/false);
-  Placeholder *expectedP = mod.createPlaceholder(
-      ElemKind::FloatTy, {5}, "expectedP", /*isTrainable=*/false);
-
-  auto *SLWS = F->createSparseLengthsWeightedSum("SLWS", dataP, weightsP,
-                                                 indicesP, lengthsP);
-  auto *reg = F->createRegression("reg", SLWS, expectedP);
-  auto *result = F->createSave("save", reg);
-
+    auto *SLWS = F->createSparseLengthsWeightedSum("SLWS", dataP, weightsP,
+                                                   indicesP, lengthsP);
+    auto *reg = F->createRegression("reg", SLWS, expectedP);
+    F->createSave("save", reg);
+  }
   // Allocate and randomly initialize embeddings.
-  auto DH = bindings.allocate(dataP)->getHandle();
+  auto DH = inferBindings.allocate(dataP)->getHandle();
   DH.randomize(-5.0, 5.0, PRNG);
 
   // Allocate and set indices such that input embeddings are reversed.
-  bindings.allocate(indicesP)->getHandle<int64_t>() = {9, 8, 7, 6, 5,
-                                                       4, 3, 2, 1, 0};
+  inferBindings.allocate(indicesP)->getHandle<int64_t>() = {9, 8, 7, 6, 5,
+                                                            4, 3, 2, 1, 0};
   // Allocate and set weights.
-  bindings.allocate(weightsP)->getHandle() = {0.75, 0.25, 0.75, 0.25, 0.75,
-                                              0.25, 0.75, 0.25, 0.75, 0.25};
+  inferBindings.allocate(weightsP)->getHandle() = {
+      0.75, 0.25, 0.75, 0.25, 0.75, 0.25, 0.75, 0.25, 0.75, 0.25};
 
   // Allocate and set lengths.
-  bindings.allocate(lengthsP)->getHandle<int32_t>() = {2, 2, 2, 2, 2};
+  inferBindings.allocate(lengthsP)->getHandle<int32_t>() = {2, 2, 2, 2, 2};
 
   // Allocate and set expected outputs. The embedding table will be adjusted
   // during training so that the final result is this.
-  auto EH = bindings.allocate(expectedP)->getHandle();
+  auto EH = inferBindings.allocate(expectedP)->getHandle();
   EH = {1, 2, 3, 4, 5};
 
-  // Allocate and store a handle to the result for testing later.
-  auto RH = bindings.allocate(result->getPlaceholder())->getHandle();
+  trainingBindings.allocate(EET_.getModule().getPlaceholders());
+  inferBindings.copyTrainedWeightsTo(trainingBindings);
+  inferBindings.copyToTarget("dataP", trainingBindings);
+  inferBindings.copyToTarget("indicesP", trainingBindings);
+  inferBindings.copyToTarget("weightsP", trainingBindings);
+  inferBindings.copyToTarget("lengthsP", trainingBindings);
+  inferBindings.copyToTarget("expectedP", trainingBindings);
+  inferBindings.clear();
+  inferBindings.allocate(EEI_.getModule().getPlaceholders());
+  EH = trainingBindings.get(trainingBindings.getPlaceholderByName("expectedP"))
+           ->getHandle();
+  auto *res = inferBindings.get(EEI_.getModule().getPlaceholderByName("save"));
 
   // Train the network.
-  Function *trainingGradientFunction = glow::differentiate(F, TC);
-  EE_.compile(CompilationMode::Train, trainingGradientFunction);
+  auto *TF = glow::differentiate(F, TC);
+  auto tfName = TF->getName();
+  auto fname = F->getName();
+  EET_.compile(CompilationMode::Train);
 
   const size_t numIterations = 1000;
 
   for (size_t i = 0; i < numIterations; ++i) {
-    EE_.run(bindings);
+    EET_.run(trainingBindings, tfName);
   }
-
+  trainingBindings.copyTrainedWeightsTo(inferBindings);
+  trainingBindings.copyToTarget("dataP", inferBindings);
+  trainingBindings.copyToTarget("indicesP", inferBindings);
+  trainingBindings.copyToTarget("weightsP", inferBindings);
+  trainingBindings.copyToTarget("lengthsP", inferBindings);
+  trainingBindings.copyToTarget("expectedP", inferBindings);
   // Switch to inference mode and run the network.
-  EE_.compile(CompilationMode::Infer, F);
-  EE_.run(bindings);
+  EEI_.compile(CompilationMode::Infer);
+  EEI_.run(inferBindings, fname);
 
   // Make sure that the network output matches expectations after training.
+  auto RH = res->getHandle();
   for (size_t j = 0; j < EH.size(); ++j) {
     EXPECT_NEAR(RH.raw(j), EH.raw(j), 0.02);
   }
@@ -1468,66 +1638,85 @@ TEST_P(MLTest, learnSparseLengthsWeightedSumWeights) {
   TC.learningRate = 0.001;
   TC.batchSize = 1;
 
-  PlaceholderBindings bindings;
+  PlaceholderBindings trainingBindings, inferBindings;
+  Function *F;
+  Placeholder *dataP, *indicesP, *lengthsP, *expectedP, *weightsP;
+  PseudoRNG &PRNG = EET_.getModule().getPRNG();
+  for (auto *EE : engines_) {
+    Module &mod = EE->getModule();
 
-  Module &mod = EE_.getModule();
-  PseudoRNG &PRNG = mod.getPRNG();
+    // Create a model consisting of one SparseLengthsWeightedSum operator
+    // followed by a Regression node to get some non-zero gradients.
+    F = mod.createFunction("SparseLengthsWeightedSum");
+    dataP = mod.createPlaceholder(ElemKind::FloatTy, {10}, "dataP",
+                                  /*isTrainable=*/false);
+    indicesP = mod.createPlaceholder(ElemKind::Int64ITy, {10}, "indicesP",
+                                     /*isTrainable=*/false);
+    weightsP = mod.createPlaceholder(ElemKind::FloatTy, {10}, "weightsP",
+                                     /*isTrainable=*/true);
+    lengthsP = mod.createPlaceholder(ElemKind::Int32ITy, {5}, "lengthsP",
+                                     /*isTrainable=*/false);
+    expectedP = mod.createPlaceholder(ElemKind::FloatTy, {5}, "expectedP",
+                                      /*isTrainable=*/false);
 
-  // Create a model consisting of one SparseLengthsWeightedSum operator followed
-  // by a Regression node to get some non-zero gradients.
-  Function *F = mod.createFunction("SparseLengthsWeightedSum");
-  Placeholder *dataP = mod.createPlaceholder(ElemKind::FloatTy, {10}, "dataP",
-                                             /*isTrainable=*/false);
-  Placeholder *indicesP = mod.createPlaceholder(
-      ElemKind::Int64ITy, {10}, "indicesP", /*isTrainable=*/false);
-  Placeholder *weightsP = mod.createPlaceholder(
-      ElemKind::FloatTy, {10}, "weightsP", /*isTrainable=*/true);
-  Placeholder *lengthsP = mod.createPlaceholder(
-      ElemKind::Int32ITy, {5}, "lengthsP", /*isTrainable=*/false);
-  Placeholder *expectedP = mod.createPlaceholder(
-      ElemKind::FloatTy, {5}, "expectedP", /*isTrainable=*/false);
-
-  auto *SLWS = F->createSparseLengthsWeightedSum("SLWS", dataP, weightsP,
-                                                 indicesP, lengthsP);
-  auto *reg = F->createRegression("reg", SLWS, expectedP);
-  auto *result = F->createSave("save", reg);
-
+    auto *SLWS = F->createSparseLengthsWeightedSum("SLWS", dataP, weightsP,
+                                                   indicesP, lengthsP);
+    auto *reg = F->createRegression("reg", SLWS, expectedP);
+    F->createSave("save", reg);
+  }
   // Allocate and set embeddings.
-  bindings.allocate(dataP)->getHandle() = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  inferBindings.allocate(dataP)->getHandle() = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 
   // Allocate and set indices such that input embeddings are reversed.
-  bindings.allocate(indicesP)->getHandle<int64_t>() = {9, 8, 7, 6, 5,
-                                                       4, 3, 2, 1, 0};
+  inferBindings.allocate(indicesP)->getHandle<int64_t>() = {9, 8, 7, 6, 5,
+                                                            4, 3, 2, 1, 0};
   // Allocate and randomly initialize weights.
-  auto WH = bindings.allocate(weightsP)->getHandle();
+  auto WH = inferBindings.allocate(weightsP)->getHandle();
   WH.randomize(-1.0, 1.0, PRNG);
 
   // Allocate and set lengths.
-  bindings.allocate(lengthsP)->getHandle<int32_t>() = {2, 2, 2, 2, 2};
+  inferBindings.allocate(lengthsP)->getHandle<int32_t>() = {2, 2, 2, 2, 2};
 
   // Allocate and set expected outputs. The weighs will be adjusted
   // during training so that the final result is this.
-  auto EH = bindings.allocate(expectedP)->getHandle();
+  auto EH = inferBindings.allocate(expectedP)->getHandle();
   EH = {10, 7, 6, 3, 2};
 
-  // Allocate and store a handle to the result for testing later.
-  auto RH = bindings.allocate(result->getPlaceholder())->getHandle();
-
+  trainingBindings.allocate(EET_.getModule().getPlaceholders());
+  inferBindings.copyTrainedWeightsTo(trainingBindings);
+  inferBindings.copyToTarget("dataP", trainingBindings);
+  inferBindings.copyToTarget("indicesP", trainingBindings);
+  inferBindings.copyToTarget("weightsP", trainingBindings);
+  inferBindings.copyToTarget("lengthsP", trainingBindings);
+  inferBindings.copyToTarget("expectedP", trainingBindings);
+  inferBindings.clear();
+  inferBindings.allocate(EEI_.getModule().getPlaceholders());
+  auto *res = inferBindings.get(EEI_.getModule().getPlaceholderByName("save"));
+  EH = trainingBindings.get(trainingBindings.getPlaceholderByName("expectedP"))
+           ->getHandle();
   // Train the network.
-  Function *trainingGradientFunction = glow::differentiate(F, TC);
-  EE_.compile(CompilationMode::Train, trainingGradientFunction);
+  auto *TF = glow::differentiate(F, TC);
+  auto tfName = TF->getName();
+  auto fname = F->getName();
+  EET_.compile(CompilationMode::Train);
 
   const size_t numIterations = 1000;
 
   for (size_t i = 0; i < numIterations; ++i) {
-    EE_.run(bindings);
+    EET_.run(trainingBindings, tfName);
   }
-
+  trainingBindings.copyTrainedWeightsTo(inferBindings);
+  trainingBindings.copyToTarget("dataP", inferBindings);
+  trainingBindings.copyToTarget("indicesP", inferBindings);
+  trainingBindings.copyToTarget("weightsP", inferBindings);
+  trainingBindings.copyToTarget("lengthsP", inferBindings);
+  trainingBindings.copyToTarget("expectedP", inferBindings);
   // Switch to inference mode and run the network.
-  EE_.compile(CompilationMode::Infer, F);
-  EE_.run(bindings);
+  EEI_.compile(CompilationMode::Infer);
+  EEI_.run(inferBindings, fname);
 
   // Make sure that the network output matches expectations after training.
+  auto RH = res->getHandle();
   for (size_t j = 0; j < EH.size(); ++j) {
     EXPECT_NEAR(RH.raw(j), EH.raw(j), 0.02);
   }


### PR DESCRIPTION
Summary: This PR ports MLTest to the new EE2, it also adds two new helper methods to PlaceholderBindings which are used in the port.

Documentation: UnitTest and EE docs will be revisited when closing out #3239.

Work on #3239

Test Plan: MLTest builds and runs with the new EE2
