### PR TITLE
Add bias for Habana Gemm node

### DIFF
--- a/lib/Backends/Habana/Habana.cpp
+++ b/lib/Backends/Habana/Habana.cpp
@@ -1092,6 +1092,7 @@ HabanaBackend::compile(Function *F, const BackendOptions &opts) const {
         std::vector<synTensor> inputs;
         inputs.push_back(tensors[MI->getLHS()].get());
         inputs.push_back(tensors[MI->getRHS()].get());
+        inputs.push_back(/* bias */ nullptr);
         chk(synCreateGenericNode(inputs.data(), &tensors[MI].get(),
                                  inputs.size(), 1, nullptr, "gemm",
                                  MI->getName().data(), nullptr, nullptr));


### PR DESCRIPTION
Summary:
Habana is allowing bias for gemm. This commit will fix resnet results
with asymmetric quantization

Differential Revision: D16348533

