### PR TITLE
Fix foldChannelShuffle opt

### DIFF
--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -2740,9 +2740,6 @@ getChannelShuffleParams(const ReshapeNode &node) {
 // Fold Reshape->Transpose->Reshape into ChannelShuffle when applicable.
 bool FoldChannelShuffle::run(Function *F, const CompilationContext &cctx) {
   LOG_SCOPE(F->getLogContext(), getName());
-  // FIXME: This optimization doesn't check its applicability carefully enough
-  // and kicks in when it shouldn't.  See GraphOptzTest.NoFoldChannelShuffle.
-  return false;
 
   bool changed = false;
   auto &nodes = F->getNodes();
@@ -2759,6 +2756,11 @@ bool FoldChannelShuffle::run(Function *F, const CompilationContext &cctx) {
 
     auto *RN1 = dyn_cast<ReshapeNode>(TR->getInput());
     if (!RN1) {
+      continue;
+    }
+
+    // Check that the input and output shapes match:
+    if (RN1->getInput().getType() != RN2->getResult().getType()) {
       continue;
     }
 

--- a/tests/unittests/GraphOptzTest.cpp
+++ b/tests/unittests/GraphOptzTest.cpp
@@ -1980,9 +1980,6 @@ TEST_F(GraphFold, foldLeakyReluFromConst) {
 
 /// Testing folding of Reshape->Transpose->Reshape into ChannelShuffle.
 TEST_F(GraphFold, foldChannelShuffle) {
-  // FIXME: foldChannelShuffle is disabled; see GraphOptimizer.cpp.
-  return;
-
   const size_t inputDims[] = {3, 136, 28, 28};
 
   Node *K =


### PR DESCRIPTION
Summary:
Fixes a bug in the optimization - see https://github.com/pytorch/glow/pull/2983 -
Adds a check that the input type / dimensions for the `reshape->transpose->reshape` pattern is equal to the output type. Also enables the disabled optimization test.

Fixes #2984

Test Plan:
`ninja test`
