### PR TITLE
QuantizationTest intermittent segfault fix.

### DIFF
--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -1743,13 +1743,14 @@ OCLBackend::compile(Function *F, const BackendOptions &opts) const {
   MemoryAllocator allocator("GPU", 0xFFFFFFFF);
   runtime::RuntimeBundle bundle =
       runtime::RuntimeBundle::create(*IR, allocator, allocator, allocator);
-  std::unique_ptr<CompiledFunction> compiledFunc =
-      llvm::make_unique<OpenCLFunction>(std::move(IR), bundle,
-                                        std::move(traceInfo));
 
   if (opts.collectConstants) {
     bundle.collectConstants(F->getParent());
   }
+
+  std::unique_ptr<CompiledFunction> compiledFunc =
+      llvm::make_unique<OpenCLFunction>(std::move(IR), bundle,
+                                        std::move(traceInfo));
 
   return llvm::Expected<std::unique_ptr<CompiledFunction>>(
       std::move(compiledFunc));


### PR DESCRIPTION
Summary:
Moved collect constants in OCL backend to before creation of the compiled function. This fixes an intermittant segfault in quantizationTest.

Documentation:

Test Plan: ninja check, notice quantizationTest now passes reliably
