### PR TITLE
Created transition BackendTestUtils2

### DIFF
--- a/tests/unittests/BackendTestUtils2.cpp
+++ b/tests/unittests/BackendTestUtils2.cpp
@@ -1,0 +1,1129 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "BackendTestUtils2.h"
+
+#include "glow/Converter/TypeAToTypeBFunctionConverter.h"
+#include "glow/ExecutionEngine/ExecutionEngine2.h"
+#include "glow/Graph/Graph.h"
+#include "glow/IR/IR.h"
+#include "glow/IR/IRBuilder.h"
+#include "glow/IR/Instrs.h"
+#include "glow/Optimizer/GraphOptimizer/GraphOptimizer.h"
+#include "glow/Quantization/Quantization.h"
+
+#include "gtest/gtest.h"
+
+#include "llvm/Support/CommandLine.h"
+
+#include <future>
+
+namespace glow {
+
+llvm::cl::OptionCategory operatorTestCat("OperatorTest Category");
+
+unsigned parCloneCountOpt;
+llvm::cl::opt<unsigned, /* ExternalStorage */ true> parCloneCountI(
+    "parallel-clone-count",
+    llvm::cl::desc(
+        "Number of times to clone a graph in parallel. Intended to stress test "
+        "different backends. This option is not used by all unit "
+        "tests; for now you must check the test to see if so."),
+    llvm::cl::location(parCloneCountOpt), llvm::cl::Optional, llvm::cl::init(1),
+    llvm::cl::cat(operatorTestCat));
+
+using llvm::cast;
+
+namespace {
+// Helpers for creating and intializing placeholders from tensors.
+static Placeholder *createPlaceholder(Module &mod,
+                                      PlaceholderBindings &bindings,
+                                      Tensor *tensor, llvm::StringRef name) {
+  auto *P = mod.createPlaceholder(tensor->getElementType(), tensor->dims(),
+                                  name, false);
+  auto *PTensor = bindings.allocate(P);
+  PTensor->assign(tensor);
+
+  return P;
+}
+
+static Placeholder *createQuantizedPlaceholder(Module &mod,
+                                               PlaceholderBindings &bindings,
+                                               Tensor *tensor, float scale,
+                                               int32_t offset,
+                                               llvm::StringRef name) {
+  auto *P = mod.createPlaceholder(tensor->getElementType(), tensor->dims(),
+                                  scale, offset, name, false);
+  auto *PTensor = bindings.allocate(P);
+  PTensor->assign(tensor);
+
+  return P;
+}
+
+/// Clone, profile, and run \p origF given the \p bindings and \p EE. \returns
+/// the quantization parameters from the profile given the specified \p schema.
+static std::vector<NodeQuantizationInfo>
+profileAndGetNodeQuantizationInfo(PlaceholderBindings &bindings,
+                                  ExecutionEngine2 &EE, Function *origF,
+                                  quantization::Schema schema) {
+  LoweredInfoMap loweredMapForProf;
+  CompilationContext cctx{&bindings, &loweredMapForProf};
+  cctx.precisionConfig.quantMode = QuantizationMode::Profile;
+  EE.compile(cctx);
+  EE.run(bindings);
+  return quantization::generateNodeQuantizationInfos(bindings, origF,
+                                                     loweredMapForProf, schema);
+}
+
+/// Helper that sets up and \returns a pair of configs for both interpreter and
+/// backend being tested.
+static std::pair<CompilationContext, CompilationContext>
+setupInterpAndBackendConfigs(
+    Function *IF, ExecutionEngine2 &IEE, PlaceholderBindings &Ibindings,
+    LoweredInfoMap &ILIM, Function *PF, ExecutionEngine2 &PEE,
+    PlaceholderBindings &pBindings, PlaceholderBindings &Bbindings,
+    LoweredInfoMap &BLIM, ElemKind interpElemKind, ElemKind backendElemKind,
+    quantization::Schema schema, bool enableRowwiseQuantization) {
+  CompilationContext cctxI{&Ibindings, &ILIM};
+  CompilationContext cctxB{&Bbindings, &BLIM};
+  PrecisionConfiguration &precConfigI = cctxI.precisionConfig;
+  PrecisionConfiguration &precConfigB = cctxB.precisionConfig;
+
+  if (isQuantizedElemKind(interpElemKind) ||
+      isQuantizedElemKind(backendElemKind)) {
+    // If either interp or backend need to be quantized then we need to profile
+    // and get quantization infos.
+    auto NQIS = profileAndGetNodeQuantizationInfo(pBindings, PEE, PF, schema);
+
+    if (isQuantizedElemKind(interpElemKind)) {
+      precConfigI.quantMode = QuantizationMode::Quantize;
+      precConfigI.quantConfig.infos = NQIS;
+      precConfigI.quantConfig.enableRowwise = enableRowwiseQuantization;
+      precConfigI.quantConfig.schema = schema;
+      precConfigI.quantConfig.precision = interpElemKind;
+      precConfigI.quantConfig.assertAllNodesQuantized = true;
+    }
+
+    if (isQuantizedElemKind(backendElemKind)) {
+      precConfigB.quantMode = QuantizationMode::Quantize;
+      precConfigB.quantConfig.infos = NQIS;
+      precConfigB.quantConfig.enableRowwise = enableRowwiseQuantization;
+      precConfigB.quantConfig.schema = schema;
+      precConfigB.quantConfig.precision = backendElemKind;
+      precConfigB.quantConfig.assertAllNodesQuantized = true;
+    }
+  }
+
+  precConfigI.convertToFP16 = interpElemKind == ElemKind::Float16Ty;
+  precConfigB.convertToFP16 = backendElemKind == ElemKind::Float16Ty;
+
+  return std::make_pair(cctxI, cctxB);
+}
+} // namespace
+
+void compareAgainstInterpreter(llvm::StringRef backendName,
+                               CreateAndInitFunction createAndInitFunction,
+                               ElemKind interpElemKind,
+                               ElemKind backendElemKind, float allowedError,
+                               unsigned count, bool enableRowwiseQuantization,
+                               quantization::Schema schema) {
+  ExecutionEngine2 IEE{"Interpreter"};
+  ExecutionEngine2 BEE{backendName};
+  ExecutionEngine2 PEE{"Interpreter"};
+  PlaceholderBindings iBindings, bBindings, pBindings;
+
+  LOG(INFO) << "Comparing Interpreter with precision "
+            << Type::getElementName(interpElemKind).str() << " against "
+            << backendName.str() << " with precision "
+            << Type::getElementName(backendElemKind).str();
+
+  // Create the same network on the interpreter and the backend being tested.
+  FunctionTensorPair IFT = createAndInitFunction(iBindings, IEE);
+  FunctionTensorPair BFT = createAndInitFunction(bBindings, BEE);
+  FunctionTensorPair PFT = createAndInitFunction(pBindings, PEE);
+
+  // Clone the Function inside itself many times if desired.
+  std::unordered_set<Tensor *> resultTensors =
+      cloneFunInsideFun(BFT, &bBindings, count);
+  assert(resultTensors.size() == count &&
+         "Should get the same number of Tensors back as count.");
+
+  Function *IF = IFT.first;
+  Function *PF = PFT.first;
+
+  // Set up the configs for interpreter and backend. If one or both functions
+  // will be quantized, then gather a profile the graph on the interpreter, and
+  // then quantize the Functions as requested.
+  LoweredInfoMap ILIM, BLIM;
+  auto configs = setupInterpAndBackendConfigs(
+      IF, IEE, iBindings, ILIM, PF, PEE, pBindings, bBindings, BLIM,
+      interpElemKind, backendElemKind, schema, enableRowwiseQuantization);
+  CompilationContext &cctxI = configs.first;
+  CompilationContext &cctxB = configs.second;
+
+  BEE.compile(cctxB);
+  BEE.run(bBindings);
+
+  // Run the inference
+  IEE.compile(cctxI);
+  IEE.run(iBindings);
+
+  // Compare each of our result tensors to the original.
+  for (Tensor *T : resultTensors) {
+    EXPECT_TRUE(IFT.second->isEqual(*T, allowedError));
+  }
+}
+
+std::unordered_set<Tensor *> cloneFunInsideFun(FunctionTensorPair FTP,
+                                               PlaceholderBindings *bindings,
+                                               unsigned count) {
+  Function *origF = FTP.first;
+
+  // Always save the original Function's Tensor, which we will keep around.
+  std::unordered_set<Tensor *> resultTensors;
+  resultTensors.insert(FTP.second);
+
+  // Nothing to do if we just want the one.
+  if (count == 1) {
+    return resultTensors;
+  }
+
+  Module *mod = origF->getParent();
+
+  // Clone the original Function to repeatedly add it to the original.
+  auto *cloneF = origF->clone("single_clone");
+
+  // We keep the original Function, then clone/add count-1 more.
+  for (size_t i = 1; i < count; i++) {
+    // Clone the clone, and then add all the new nodes to the original function.
+    auto *tmpF = cloneF->clone("tmp" + std::to_string(i));
+    std::unordered_set<Node *> clonedNodes;
+    bool foundSaveNode = false;
+    for (auto &N : tmpF->getNodes()) {
+      clonedNodes.insert(&N);
+
+      // For every Node we add, check if it uses a Placeholder node, and if so
+      // clone it in the Module so that CSE doesn't undo all our hard work.
+      for (size_t j = 0, f = N.getNumInputs(); j < f; j++) {
+        Placeholder *origPH = llvm::dyn_cast<Placeholder>(N.getNthInput(j));
+        if (!origPH) {
+          continue;
+        }
+
+        // Clone the Placeholder, allocate it in the bindings, and replace the
+        // usage of the original node to point to the clone.
+        Placeholder *clonePH = mod->createPlaceholder(
+            origPH->getType(), origPH->getName(), origPH->isTraining());
+        Tensor *oldT = bindings->get(origPH);
+        assert(oldT);
+        Tensor *newT = bindings->allocate(clonePH);
+        newT->assign(oldT);
+        N.setNthInput(j, clonePH);
+
+        // Save the result Tensors to return so we can compare the results of
+        // all of our clones.
+        if (llvm::isa<SaveNode>(N)) {
+          assert(!foundSaveNode &&
+                 "Can only handle Functions with a single SaveNode.");
+          foundSaveNode = true;
+          resultTensors.insert(newT);
+        }
+      }
+    }
+    for (auto &N : clonedNodes) {
+      origF->takeOwnershipOfNode(N);
+    }
+    mod->eraseFunction(tmpF);
+  }
+  // Now erase the clone we used to copy in, as it's no longer needed.
+  mod->eraseFunction(cloneF);
+
+  return resultTensors;
+}
+
+void inferIntLookupTableNet(Tensor *input, Tensor *out,
+                            llvm::ArrayRef<int8_t> table,
+                            llvm::StringRef kind) {
+  PlaceholderBindings bindings;
+  ExecutionEngine2 EE(kind);
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+  auto inTy =
+      mod.uniqueType(ElemKind::Int8QTy, {input->size()},
+                     input->getType().getScale(), input->getType().getOffset());
+  auto var = createQuantizedPlaceholder(mod, bindings, input, inTy->getScale(),
+                                        inTy->getOffset(), "var");
+  auto *lookupTable = F->createIntLookupTable("lookuptable", var, table, inTy);
+  auto *result = F->createSave("ret", lookupTable);
+  auto *resultTensor = bindings.allocate(result->getPlaceholder());
+
+  EE.compile(CompilationMode::Infer);
+
+  updateInputPlaceholders2(bindings, {var}, {input});
+  EE.run(bindings);
+  out->assign(resultTensor);
+}
+
+void inferConvNet(Tensor *inputs, Tensor *filter, Tensor *bias, Tensor *out,
+                  llvm::StringRef kind) {
+  PlaceholderBindings bindings;
+  ExecutionEngine2 EE(kind);
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+  Placeholder *inputP;
+  Placeholder *filterP;
+  Placeholder *biasP;
+  Placeholder *outP;
+  TypeRef OT;
+  if (inputs->getType().isQuantizedType()) {
+    auto &outType = out->getType();
+    auto &inType = inputs->getType();
+    auto &filterType = filter->getType();
+    auto &biasType = bias->getType();
+    inputP = createQuantizedPlaceholder(
+        mod, bindings, inputs, inType.getScale(), inType.getOffset(), "inputP");
+    filterP =
+        createQuantizedPlaceholder(mod, bindings, filter, filterType.getScale(),
+                                   filterType.getOffset(), "filterP");
+    biasP = createQuantizedPlaceholder(mod, bindings, bias, biasType.getScale(),
+                                       biasType.getOffset(), "biasP");
+    outP = createQuantizedPlaceholder(mod, bindings, out, outType.getScale(),
+                                      outType.getOffset(), "outP");
+    OT = F->getParent()->uniqueType(out->getElementType(), out->dims(),
+                                    outType.getScale(), outType.getOffset());
+  } else {
+    inputP = createPlaceholder(mod, bindings, inputs, "inputP");
+    filterP = createPlaceholder(mod, bindings, filter, "filterP");
+    biasP = createPlaceholder(mod, bindings, bias, "biasP");
+    outP = createPlaceholder(mod, bindings, out, "outP");
+    OT = F->getParent()->uniqueType(out->getElementType(), out->dims());
+  }
+  auto *conv = F->createConv("conv", inputP, filterP, biasP, OT, 5, 3, 4, 1);
+  auto *result = F->createSave("ret", conv, outP);
+  auto *resultTensor = bindings.get(result->getPlaceholder());
+
+  EE.compile(CompilationMode::Infer);
+
+  updateInputPlaceholders2(bindings, {inputP, filterP, biasP},
+                           {inputs, filter, bias});
+  EE.run(bindings);
+  out->assign(resultTensor);
+}
+
+void trainConvNet(Tensor *inputs, Tensor *kernel1, Tensor *bias1,
+                  Tensor *kernel2, Tensor *bias2, Tensor *selected,
+                  llvm::ArrayRef<size_t> shape1, llvm::ArrayRef<size_t> shape2,
+                  Tensor *out, llvm::StringRef kind) {
+  ExecutionEngine2 EET(kind);
+  ExecutionEngine2 EEI(kind);
+  std::vector<ExecutionEngine2 *> engines;
+  engines.push_back(&EEI);
+  engines.push_back(&EET);
+  TrainingConfig TC;
+  PlaceholderBindings bindings, inferBindings, trainingBindings;
+
+  // This variable records the number of the next sample to be used for
+  // training.
+  size_t sampleCounter = 0;
+
+  TC.learningRate = 0.03;
+  TC.momentum = 0.3;
+  TC.L2Decay = 0.01;
+  Function *F;
+  Placeholder *var1, *var2;
+  for (auto *EE : engines) {
+    auto &mod = EE->getModule();
+    F = mod.createFunction("main");
+    var1 = createPlaceholder(mod, bindings, inputs, "var1");
+    var2 = createPlaceholder(mod, bindings, selected, "var2");
+    auto *conv1 = F->createConv(bindings, "conv1", var1, 3, {5, 3}, {2, 1},
+                                {2, 1, 2, 1}, 1);
+    bindings.get(cast<Placeholder>(conv1->getFilter()))->assign(kernel1);
+    bindings.get(cast<Placeholder>(conv1->getBias()))->assign(bias1);
+    auto *reshape1 = F->createReshape("reshape1", conv1, shape1);
+    auto *conv2 = F->createConv(bindings, "conv2", reshape1, 2, 2, 2, 0, 1);
+    bindings.get(cast<Placeholder>(conv2->getFilter()))->assign(kernel2);
+    bindings.get(cast<Placeholder>(conv2->getBias()))->assign(bias2);
+    auto *reshape2 = F->createReshape("reshape2", conv2, shape2);
+    auto *softmax = F->createSoftMax("softmax", reshape2, var2);
+    F->createSave("ret", softmax);
+  }
+  trainingBindings.allocate(EET.getModule().getPlaceholders());
+  inferBindings.allocate(EEI.getModule().getPlaceholders());
+  bindings.copyTrainedWeightsTo(trainingBindings);
+  auto *res = inferBindings.get(EEI.getModule().getPlaceholderByName("ret"));
+
+  auto *TF = glow::differentiate(F, TC);
+  auto tfName = TF->getName();
+  auto fName = F->getName();
+  EET.compile(CompilationMode::Train);
+
+  runBatch2(EET, trainingBindings, 8, sampleCounter, {var1, var2},
+            {inputs, selected}, tfName);
+  trainingBindings.copyTrainedWeightsTo(inferBindings);
+  EEI.compile(CompilationMode::Infer);
+  var1 = inferBindings.getPlaceholderByName("var1");
+  var2 = inferBindings.getPlaceholderByName("var2");
+  updateInputPlaceholders2(inferBindings, {var1, var2}, {inputs, selected});
+  EEI.run(inferBindings, fName);
+  out->assign(res);
+}
+
+void inferLocalResponseNormalizationNet(Tensor *inputs, Tensor *out,
+                                        llvm::StringRef kind) {
+  PlaceholderBindings bindings;
+  ExecutionEngine2 EE(kind);
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+  auto *var = createPlaceholder(mod, bindings, inputs, "var");
+  auto *lrn = F->createLocalResponseNormalization("lrn", var, 5, 3.0, 0.5, 1.5);
+  auto *result = F->createSave("ret", lrn);
+  auto *resultTensor = bindings.allocate(result->getPlaceholder());
+
+  EE.compile(CompilationMode::Infer);
+
+  updateInputPlaceholders2(bindings, {var}, {inputs});
+  EE.run(bindings);
+  out->assign(resultTensor);
+}
+
+void trainLocalResponseNormalizationNet(Tensor *inputs, Tensor *weights,
+                                        Tensor *bias, Tensor *selected,
+                                        llvm::ArrayRef<size_t> shape1,
+                                        llvm::ArrayRef<size_t> shape2,
+                                        Tensor *out, llvm::StringRef kind) {
+  PlaceholderBindings bindings, trainingBindings;
+  ExecutionEngine2 EET(kind);
+  ExecutionEngine2 EEI(kind);
+  std::vector<ExecutionEngine2 *> engines{&EEI, &EET};
+  TrainingConfig TC;
+
+  // This variable records the number of the next sample to be used for
+  // training.
+  size_t sampleCounter = 0;
+
+  TC.learningRate = 0.06;
+  TC.momentum = 0.1;
+  TC.L2Decay = 0.01;
+  Placeholder *var1, *var2;
+  std::string fName;
+  for (auto *EE : engines) {
+    auto &mod = EE->getModule();
+    Function *F = mod.createFunction("main");
+    fName = F->getName();
+    var1 = createPlaceholder(mod, bindings, inputs, "var1");
+    var2 = createPlaceholder(mod, bindings, selected, "var2");
+    auto *fc = F->createFullyConnected(bindings, "fc", var1, bias->dims()[0]);
+    bindings.get(cast<Placeholder>(fc->getWeights()))->assign(weights);
+    bindings.get(cast<Placeholder>(fc->getBias()))->assign(bias);
+    auto *reshape1 = F->createReshape("reshape1", fc, shape1);
+    auto *lrn =
+        F->createLocalResponseNormalization("lrn", reshape1, 2, 2.0, 0.5, 1.0);
+    auto *reshape2 = F->createReshape("reshape2", lrn, shape2);
+    auto *softmax = F->createSoftMax("softmax", reshape2, var2);
+    auto *result = F->createSave("ret", softmax);
+    bindings.allocate(result->getPlaceholder());
+  }
+  trainingBindings.allocate(EET.getModule().getPlaceholders());
+  bindings.copyTrainedWeightsTo(trainingBindings);
+  bindings.clear();
+  bindings.allocate(EEI.getModule().getPlaceholders());
+  auto *TF = glow::differentiate(EET.getModule().getFunction(fName), TC);
+  auto tfName = TF->getName();
+  EET.compile(CompilationMode::Train);
+  runBatch2(EET, trainingBindings, 8, sampleCounter, {var1, var2},
+            {inputs, selected}, tfName);
+  trainingBindings.copyTrainedWeightsTo(bindings);
+  var1 = bindings.getPlaceholderByName("var1");
+  var2 = bindings.getPlaceholderByName("var2");
+  EEI.compile(CompilationMode::Infer);
+
+  runBatch2(EEI, bindings, 1, sampleCounter, {var1, var2}, {inputs, selected});
+  out->assign(bindings.get(bindings.getPlaceholderByName("ret")));
+}
+
+void trainAvgPoolNet(Tensor *inputs, Tensor *weights, Tensor *bias,
+                     Tensor *selected, llvm::ArrayRef<size_t> shape1,
+                     llvm::ArrayRef<size_t> shape2, Tensor *out,
+                     llvm::StringRef kind) {
+  ExecutionEngine2 EET(kind);
+  ExecutionEngine2 EEI(kind);
+  std::vector<ExecutionEngine2 *> engines{&EEI, &EET};
+  TrainingConfig TC;
+  PlaceholderBindings bindings, trainingBindings;
+
+  // This variable records the number of the next sample to be used for
+  // training.
+  size_t sampleCounter = 0;
+
+  TC.learningRate = 0.01;
+  TC.momentum = 0.4;
+  TC.L2Decay = 0.01;
+  Placeholder *var1, *var2;
+  std::string fName;
+  for (auto *EE : engines) {
+    auto &mod = EE->getModule();
+    Function *F = mod.createFunction("main");
+    fName = F->getName();
+    var1 = createPlaceholder(mod, bindings, inputs, "var1");
+    var2 = createPlaceholder(mod, bindings, selected, "var2");
+    auto *fc = F->createFullyConnected(bindings, "fc", var1, bias->dims()[0]);
+    bindings.get(cast<Placeholder>(fc->getWeights()))->assign(weights);
+    bindings.get(cast<Placeholder>(fc->getBias()))->assign(bias);
+    auto *reshape1 = F->createReshape("reshape1", fc, shape1);
+    auto *pool = F->createAvgPool("pool", reshape1, 2, 2, 0);
+    auto *reshape2 = F->createReshape("reshape2", pool, shape2);
+    auto *softmax = F->createSoftMax("softmax", reshape2, var2);
+    auto *result = F->createSave("ret", softmax);
+    bindings.allocate(result->getPlaceholder());
+  }
+  trainingBindings.allocate(EET.getModule().getPlaceholders());
+  bindings.copyTrainedWeightsTo(trainingBindings);
+  bindings.clear();
+  bindings.allocate(EEI.getModule().getPlaceholders());
+  auto *TF = glow::differentiate(EET.getModule().getFunction("main"), TC);
+  auto tfName = TF->getName();
+  EET.compile(CompilationMode::Train);
+
+  runBatch2(EET, trainingBindings, 10, sampleCounter, {var1, var2},
+            {inputs, selected}, tfName);
+  trainingBindings.copyTrainedWeightsTo(bindings);
+  var1 = bindings.getPlaceholderByName("var1");
+  var2 = bindings.getPlaceholderByName("var2");
+  EEI.compile(CompilationMode::Infer);
+
+  updateInputPlaceholders2(bindings, {var1, var2}, {inputs, selected});
+  EEI.run(bindings);
+  out->assign(bindings.get(bindings.getPlaceholderByName("ret")));
+}
+
+void trainMaxPoolNet(Tensor *inputs, Tensor *weights, Tensor *bias,
+                     Tensor *selected, llvm::ArrayRef<size_t> shape1,
+                     llvm::ArrayRef<size_t> shape2, Tensor *out,
+                     llvm::StringRef kind) {
+  ExecutionEngine2 EET(kind);
+  ExecutionEngine2 EEI(kind);
+  std::vector<ExecutionEngine2 *> engines;
+  engines.push_back(&EEI);
+  engines.push_back(&EET);
+  TrainingConfig TC;
+  PlaceholderBindings bindings, inferBindings, trainingBindings;
+
+  // This variable records the number of the next sample to be used for
+  // training.
+  size_t sampleCounter = 0;
+
+  TC.learningRate = 0.03;
+  TC.momentum = 0.3;
+  TC.L2Decay = 0.003;
+  Function *F;
+  Placeholder *var1, *var2;
+  for (auto *EE : engines) {
+    bindings.clear();
+    auto &mod = EE->getModule();
+    F = mod.createFunction("main");
+    var1 = createPlaceholder(mod, bindings, inputs, "var1");
+    var2 = createPlaceholder(mod, bindings, selected, "var2");
+    auto *fc = F->createFullyConnected(bindings, "fc", var1, bias->dims()[0]);
+    bindings.get(cast<Placeholder>(fc->getWeights()))->assign(weights);
+    bindings.get(cast<Placeholder>(fc->getBias()))->assign(bias);
+    auto *reshape1 = F->createReshape("reshape1", fc, shape1);
+    auto *pool = F->createMaxPool("pool", reshape1, 5, 3, 4);
+    auto *reshape2 = F->createReshape("reshape2", pool->getResult(), shape2);
+    auto *softmax = F->createSoftMax("softmax", reshape2, var2);
+    F->createSave("ret", softmax);
+  }
+  trainingBindings.allocate(EET.getModule().getPlaceholders());
+  inferBindings.allocate(EEI.getModule().getPlaceholders());
+  bindings.copyTrainedWeightsTo(trainingBindings);
+  auto *res = inferBindings.get(EEI.getModule().getPlaceholderByName("ret"));
+  auto *TF = glow::differentiate(F, TC);
+  auto fName = F->getName();
+  auto tfName = TF->getName();
+  EET.compile(CompilationMode::Train);
+
+  runBatch2(EET, trainingBindings, 7, sampleCounter, {var1, var2},
+            {inputs, selected}, tfName);
+  trainingBindings.copyTrainedWeightsTo(inferBindings);
+  EEI.compile(CompilationMode::Infer);
+  var1 = inferBindings.getPlaceholderByName("var1");
+  var2 = inferBindings.getPlaceholderByName("var2");
+  runBatch2(EEI, inferBindings, 1, sampleCounter, {var1, var2},
+            {inputs, selected}, fName);
+  out->assign(res);
+}
+
+void inferSmallConv(Tensor *inputs, Tensor *out, llvm::StringRef kind) {
+  PlaceholderBindings bindings;
+  ExecutionEngine2 EE(kind);
+  auto &mod = EE.getModule();
+  auto *F = mod.createFunction("main");
+  auto *in = createPlaceholder(mod, bindings, inputs, "in");
+  auto *C = F->createConv(bindings, "conv2a", in, 64, 1, 1, 0, 1);
+  bindings.get(cast<Placeholder>(C->getFilter()))->getHandle().clear(0.3);
+  bindings.get(cast<Placeholder>(C->getBias()))->getHandle().clear(0.4);
+  auto *result = F->createSave("ret", C);
+  auto *resultTensor = bindings.allocate(result->getPlaceholder());
+  convertPlaceholdersToConstants(F, bindings, {in, result->getPlaceholder()});
+
+  EE.compile(CompilationMode::Infer);
+
+  updateInputPlaceholders2(bindings, {in}, {inputs});
+  EE.run(bindings);
+
+  out->assign(resultTensor);
+}
+
+void inferGroupConv(Tensor *out, llvm::StringRef kind) {
+  PlaceholderBindings bindings;
+  ExecutionEngine2 EE(kind);
+  auto &mod = EE.getModule();
+  auto *F = mod.createFunction("main");
+
+  auto *input =
+      mod.createPlaceholder(ElemKind::FloatTy, {1, 2, 1, 32}, "input", false);
+  auto *inputTensor = bindings.allocate(input);
+  auto IH = inputTensor->getHandle();
+  for (size_t i = 0; i < 2 * 32; i++) {
+    IH.raw(i) = (i + 1) / 10.0;
+  }
+
+  auto *filter = mod.createPlaceholder(ElemKind::FloatTy, {128, 1, 1, 16},
+                                       "filter", false);
+  auto *filterTensor = bindings.allocate(filter);
+  auto FH = filterTensor->getHandle();
+  for (size_t i = 0; i < 128; i++)
+    for (size_t j = 0; j < 16; j++) {
+      FH.at({i, 0, 0, j}) = (i + j) / 100.0;
+    }
+  auto *zeroBias =
+      mod.createPlaceholder(ElemKind::FloatTy, {128}, "bias", false);
+  auto *zeroBiasTensor = bindings.allocate(zeroBias);
+  zeroBiasTensor->zero();
+
+  auto outTy = mod.uniqueType(ElemKind::FloatTy, {1, 2, 1, 128});
+
+  ConvolutionNode *CN =
+      F->createConv("Conv", input, filter, zeroBias, outTy, 1, 1, 0, 2);
+  SaveNode *result = F->createSave("save", CN);
+  auto *resultTensor = bindings.allocate(result->getPlaceholder());
+
+  EE.compile(CompilationMode::Infer);
+
+  EE.run(bindings);
+  out->assign(resultTensor);
+}
+
+void inferNonSquarePaddingConv(Tensor *out, llvm::StringRef kind) {
+  PlaceholderBindings bindings;
+  ExecutionEngine2 EE(kind);
+  auto &mod = EE.getModule();
+  auto *F = mod.createFunction("main");
+
+  auto *input =
+      mod.createPlaceholder(ElemKind::FloatTy, {1, 2, 1, 32}, "input", false);
+  auto *inputTensor = bindings.allocate(input);
+  auto IH = inputTensor->getHandle();
+  for (size_t i = 0; i < 2 * 32; i++) {
+    IH.raw(i) = (i + 1) / 10.0;
+  }
+
+  auto *filter = mod.createPlaceholder(ElemKind::FloatTy, {128, 1, 1, 32},
+                                       "filter", false);
+  auto *filterTensor = bindings.allocate(filter);
+  auto FH = filterTensor->getHandle();
+  for (size_t i = 0; i < 128; i++)
+    for (size_t j = 0; j < 32; j++) {
+      FH.at({i, 0, 0, j}) = (i + j) / 100.0;
+    }
+  auto *zeroBias =
+      mod.createPlaceholder(ElemKind::FloatTy, {128}, "bias", false);
+  auto *zeroBiasTensor = bindings.allocate(zeroBias);
+  zeroBiasTensor->zero();
+  auto outTy = mod.uniqueType(ElemKind::FloatTy, {1, 4, 5, 128});
+
+  ConvolutionNode *CN = F->createConv("Conv", input, filter, zeroBias, outTy,
+                                      {1, 1}, {1, 1}, {0, 1, 2, 3}, 1);
+  SaveNode *result = F->createSave("save", CN);
+  auto *resultTensor = bindings.allocate(result->getPlaceholder());
+
+  EE.compile(CompilationMode::Infer);
+
+  EE.run(bindings);
+  out->assign(resultTensor);
+}
+
+void inferNonSquareKernelConv(Tensor *out, llvm::StringRef kind) {
+  PlaceholderBindings bindings;
+  ExecutionEngine2 EE(kind);
+  auto &mod = EE.getModule();
+  auto *F = mod.createFunction("main");
+
+  auto *input =
+      mod.createPlaceholder(ElemKind::FloatTy, {1, 2, 1, 32}, "input", false);
+  auto *inputTensor = bindings.allocate(input);
+  auto IH = inputTensor->getHandle();
+  for (size_t i = 0; i < 2 * 32; i++) {
+    IH.raw(i) = (i + 1) / 10.0;
+  }
+
+  auto *filter = mod.createPlaceholder(ElemKind::FloatTy, {128, 2, 1, 32},
+                                       "filter", false);
+  auto *filterTensor = bindings.allocate(filter);
+  auto FH = filterTensor->getHandle();
+  for (size_t i = 0; i < 128; i++)
+    for (size_t j = 0; j < 2; j++)
+      for (size_t k = 0; k < 32; k++) {
+        FH.at({i, j, 0, k}) = (i + j + k) / 100.0;
+      }
+  auto *zeroBias =
+      mod.createPlaceholder(ElemKind::FloatTy, {128}, "bias", false);
+  auto *zeroBiasTensor = bindings.allocate(zeroBias);
+  zeroBiasTensor->zero();
+  auto outTy = mod.uniqueType(ElemKind::FloatTy, {1, 3, 5, 128});
+
+  ConvolutionNode *CN = F->createConv("Conv", input, filter, zeroBias, outTy,
+                                      {2, 1}, {1, 1}, {0, 1, 2, 3}, 1);
+  SaveNode *result = F->createSave("save", CN);
+  auto *resultTensor = bindings.allocate(result->getPlaceholder());
+
+  EE.compile(CompilationMode::Infer);
+
+  EE.run(bindings);
+  out->assign(resultTensor);
+}
+
+void inferNonSquareStrideConv(Tensor *out, llvm::StringRef kind) {
+  PlaceholderBindings bindings;
+  ExecutionEngine2 EE(kind);
+  auto &mod = EE.getModule();
+  auto *F = mod.createFunction("main");
+
+  auto *input =
+      mod.createPlaceholder(ElemKind::FloatTy, {1, 2, 1, 32}, "input", false);
+  auto *inputTensor = bindings.allocate(input);
+  auto IH = inputTensor->getHandle();
+  for (size_t i = 0; i < 2 * 32; i++) {
+    IH.raw(i) = (i + 1) / 10.0;
+  }
+
+  auto *filter = mod.createPlaceholder(ElemKind::FloatTy, {128, 2, 1, 32},
+                                       "filter", false);
+  auto *filterTensor = bindings.allocate(filter);
+  auto FH = filterTensor->getHandle();
+  for (size_t i = 0; i < 128; i++)
+    for (size_t j = 0; j < 2; j++)
+      for (size_t k = 0; k < 32; k++) {
+        FH.at({i, j, 0, k}) = (i + j + k) / 100.0;
+      }
+  auto *zeroBias =
+      mod.createPlaceholder(ElemKind::FloatTy, {128}, "bias", false);
+  auto *zeroBiasTensor = bindings.allocate(zeroBias);
+  zeroBiasTensor->zero();
+  auto outTy = mod.uniqueType(ElemKind::FloatTy, {1, 2, 5, 128});
+
+  ConvolutionNode *CN = F->createConv("Conv", input, filter, zeroBias, outTy,
+                                      {2, 1}, {2, 1}, {0, 1, 2, 3}, 1);
+  SaveNode *result = F->createSave("save", CN);
+  auto *resultTensor = bindings.allocate(result->getPlaceholder());
+
+  EE.compile(CompilationMode::Infer);
+
+  EE.run(bindings);
+  out->assign(resultTensor);
+}
+
+void inferConvDKKC8(Tensor *out, llvm::StringRef kind) {
+  PlaceholderBindings bindings;
+  ExecutionEngine2 EE(kind);
+  auto &mod = EE.getModule();
+  auto *F = mod.createFunction("main");
+
+  auto *input =
+      mod.createPlaceholder(ElemKind::FloatTy, {3, 3, 3, 32}, "input", false);
+  auto *inputTensor = bindings.allocate(input);
+  auto IH = inputTensor->getHandle();
+  for (size_t i = 0; i < 3 * 3 * 3 * 32; i++) {
+    IH.raw(i) = (i + 1) / 10.0;
+  }
+
+  auto *filter = mod.createPlaceholder(ElemKind::FloatTy, {192, 3, 3, 32},
+                                       "filter", false);
+  auto *filterTensor = bindings.allocate(filter);
+  filterTensor->zero();
+  auto FH = filterTensor->getHandle();
+  for (size_t i = 0; i < 192; i++)
+    for (size_t j = 0; j < 3; j++)
+      for (size_t k = 0; k < 3; k++)
+        for (size_t l = 0; l < 32; l++) {
+          FH.at({i, j, k, k}) = (i + j + k + l) / 200.0;
+        }
+  auto *zeroBias =
+      mod.createPlaceholder(ElemKind::FloatTy, {192}, "bias", false);
+  auto *zeroBiasTensor = bindings.allocate(zeroBias);
+  zeroBiasTensor->zero();
+  auto outTy = mod.uniqueType(ElemKind::FloatTy, {3, 3, 3, 192});
+
+  ConvolutionNode *CN = F->createConv("Conv", input, filter, zeroBias, outTy,
+                                      {3, 3}, {1, 1}, {1, 1, 1, 1}, 1);
+  SaveNode *result = F->createSave("save", CN);
+  auto *resultTensor = bindings.allocate(result->getPlaceholder());
+
+  EE.compile(CompilationMode::Infer);
+
+  EE.run(bindings);
+  out->assign(resultTensor);
+}
+
+void trainSoftMaxNet(Tensor *inputs, Tensor *weights, Tensor *bias,
+                     Tensor *selected, Tensor *out, llvm::StringRef kind) {
+  ExecutionEngine2 EET(kind);
+  ExecutionEngine2 EEI(kind);
+  std::vector<ExecutionEngine2 *> engines;
+  engines.push_back(&EEI);
+  engines.push_back(&EET);
+  TrainingConfig TC;
+  PlaceholderBindings bindings, inferBindings, trainingBindings;
+
+  // This variable records the number of the next sample to be used for
+  // training.
+  size_t sampleCounter = 0;
+
+  TC.learningRate = 0.003;
+  TC.momentum = 0.7;
+  TC.L2Decay = 0.001;
+  Function *F;
+  Placeholder *var1, *var2;
+  for (auto *EE : engines) {
+    auto &mod = EE->getModule();
+    F = mod.createFunction("main");
+    var1 = createPlaceholder(mod, bindings, inputs, "var1");
+    var2 = createPlaceholder(mod, bindings, selected, "var2");
+    auto *fc = F->createFullyConnected(bindings, "fc", var1, bias->dims()[0]);
+    bindings.get(cast<Placeholder>(fc->getWeights()))->assign(weights);
+    bindings.get(cast<Placeholder>(fc->getBias()))->assign(bias);
+    auto *softmax = F->createSoftMax("softmax", fc, var2);
+    F->createSave("ret", softmax);
+  }
+  trainingBindings.allocate(EET.getModule().getPlaceholders());
+  inferBindings.allocate(EEI.getModule().getPlaceholders());
+  bindings.copyTrainedWeightsTo(trainingBindings);
+  auto *res = inferBindings.get(EEI.getModule().getPlaceholderByName("ret"));
+  auto *TF = glow::differentiate(F, TC);
+  auto tfName = TF->getName();
+  auto fName = F->getName();
+
+  EET.compile(CompilationMode::Train);
+
+  runBatch2(EET, trainingBindings, 30, sampleCounter, {var1, var2},
+            {inputs, selected}, tfName);
+  trainingBindings.copyTrainedWeightsTo(inferBindings);
+  EEI.compile(CompilationMode::Infer);
+  var1 = inferBindings.getPlaceholderByName("var1");
+  var2 = inferBindings.getPlaceholderByName("var2");
+  updateInputPlaceholders2(inferBindings, {var1, var2}, {inputs, selected});
+  EEI.run(inferBindings, fName);
+  out->assign(res);
+}
+
+void inferTanhConcatNet(Tensor *input1, Tensor *input2, Tensor *input3,
+                        Tensor *out, llvm::StringRef kind) {
+  PlaceholderBindings bindings;
+  ExecutionEngine2 EE(kind);
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+  auto *var1 = createPlaceholder(mod, bindings, input1, "var1");
+  auto *var2 = createPlaceholder(mod, bindings, input2, "var2");
+  auto *var3 = createPlaceholder(mod, bindings, input3, "var3");
+  auto *T1 = F->createTanh("tanh1", var1);
+  auto *T2 = F->createTanh("tanh2", var2);
+  auto *T3 = F->createTanh("tanh3", var3);
+  Node *C1 = F->createConcat("concat", {T1, T2}, 0);
+  Node *C2 = F->createConcat("concat", {T2, T3, C1, T2}, 0);
+  auto *result = F->createSave("ret", C2);
+  auto *resultTensor = bindings.allocate(result->getPlaceholder());
+
+  EE.compile(CompilationMode::Infer);
+
+  updateInputPlaceholders2(bindings, {var1, var2, var3},
+                           {input1, input2, input3});
+  EE.run(bindings);
+  out->assign(resultTensor);
+}
+
+void inferBasicConvNet(Tensor *inputs, Tensor *out, llvm::StringRef kind,
+                       size_t convDepth) {
+  PlaceholderBindings bindings;
+  ExecutionEngine2 EE(kind);
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+  auto *var = createPlaceholder(mod, bindings, inputs, "var");
+  auto *tr = F->createTranspose("tr", var, NCHW2NHWC);
+  auto *conv = F->createConv(bindings, "conv", tr, convDepth, {5, 5}, {2, 2},
+                             {1, 1, 1, 1}, 1);
+  bindings.get(cast<Placeholder>(conv->getFilter()))->getHandle().clear(0.1);
+  bindings.get(cast<Placeholder>(conv->getBias()))->getHandle().clear(0.2);
+  auto *pool = F->createMaxPool("pool", conv, 2, 2, 0);
+  auto *result = F->createSave("ret", pool->getResult());
+  auto *resultTensor = bindings.allocate(result->getPlaceholder());
+  convertPlaceholdersToConstants(F, bindings, {var, result->getPlaceholder()});
+
+  EE.compile(CompilationMode::Infer);
+
+  updateInputPlaceholders2(bindings, {var}, {inputs});
+  EE.run(bindings);
+  out->assign(resultTensor);
+}
+
+FunctionTensorPair createAndInitBasicFCNet(PlaceholderBindings &bindings,
+                                           ExecutionEngine2 &EE) {
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+
+  auto *var =
+      mod.createPlaceholder(ElemKind::FloatTy, {2, 3, 16, 16}, "var", false);
+  auto *tr = F->createTranspose("tr", var, NCHW2NHWC);
+  auto *fc = F->createFullyConnected(bindings, "fc", tr, 16);
+  auto *rl0 = F->createRELU("relu", fc);
+  auto *fc2 = F->createFullyConnected(bindings, "fc2", rl0, 8);
+  auto *rl1 = F->createRELU("relu", fc2);
+  bindings.get(cast<Placeholder>(fc->getWeights()))->getHandle().clear(0.8);
+  bindings.get(cast<Placeholder>(fc2->getWeights()))->getHandle().clear(1.5);
+  auto *result = F->createSave("ret", rl1);
+  auto *resultTensor = bindings.allocate(result->getPlaceholder());
+
+  PseudoRNG PRNG;
+  bindings.allocate(var)->getHandle().initXavier(1, PRNG);
+
+  return std::make_pair(F, resultTensor);
+}
+
+void inferMixedNet(Tensor *inputs, Tensor *out, llvm::StringRef kind) {
+  PlaceholderBindings bindings;
+  ExecutionEngine2 EE(kind);
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+  auto *var = createPlaceholder(mod, bindings, inputs, "var");
+  auto *selected =
+      mod.createPlaceholder(ElemKind::Int64ITy, {2, 1}, "selected", false);
+
+  auto *tr = F->createTranspose("tr", var, NCHW2NHWC);
+  auto *fc = F->createFullyConnected(bindings, "fc", tr, 16);
+  auto *th0 = F->createTanh("tanh", fc);
+  auto *sg0 = F->createSigmoid("sig", fc);
+  auto *A1 = F->createAdd("add", th0, sg0);
+  auto *fc2 = F->createFullyConnected(bindings, "fc2", A1, 16);
+
+  auto *R = F->createRegression("reg", fc2, fc2);
+  auto *SM = F->createSoftMax("SM", R, selected);
+  auto *result = F->createSave("ret", SM);
+  auto *resultTensor = bindings.allocate(result->getPlaceholder());
+
+  bindings.get(cast<Placeholder>(fc->getWeights()))->getHandle().clear(0.4);
+  bindings.get(cast<Placeholder>(fc2->getWeights()))->getHandle().clear(3.5);
+
+  EE.compile(CompilationMode::Infer);
+
+  updateInputPlaceholders2(bindings, {var}, {inputs});
+  EE.run(bindings);
+  out->assign(resultTensor);
+}
+
+void inferComplexNet1(Tensor *inputs1, Tensor *inputs2, Tensor *inputs3,
+                      Tensor *inputs4, Tensor *out, llvm::StringRef kind) {
+  PlaceholderBindings bindings;
+  ExecutionEngine2 EE(kind);
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+  auto *var1 = createPlaceholder(mod, bindings, inputs1, "var1");
+  auto *var2 = createPlaceholder(mod, bindings, inputs2, "var2");
+  auto *var3 = createPlaceholder(mod, bindings, inputs3, "var3");
+  auto *var4 = createPlaceholder(mod, bindings, inputs4, "var4");
+  auto *conv1 = F->createConv(bindings, "conv1", var1, 6, 4, 1, 2, 1);
+  bindings.get(cast<Placeholder>(conv1->getFilter()))->getHandle().clear(0.5);
+  bindings.get(cast<Placeholder>(conv1->getBias()))->getHandle().clear(0.7);
+  auto *sigmoid1 = F->createSigmoid("sigmoid1", conv1);
+  auto *fc1 = F->createFullyConnected(bindings, "fc1", var2, 2352);
+  bindings.get(cast<Placeholder>(fc1->getWeights()))->getHandle().clear(0.6);
+  auto *reshape1 = F->createReshape("reshape1", fc1, {8, 14, 28, 6});
+  auto *relu1 = F->createRELU("relu1", reshape1);
+  auto *pool1 = F->createMaxPool("pool1", relu1, 2, 2, 1);
+  auto *add = F->createAdd("add", sigmoid1, pool1->getResult());
+  auto *tanh = F->createTanh("tanh", add);
+  auto *fc2 = F->createFullyConnected(bindings, "fc2", var3, 720);
+  bindings.get(cast<Placeholder>(fc2->getWeights()))->getHandle().clear(1.1);
+  auto *reshape2 = F->createReshape("reshape2", fc2, {8, 8, 15, 6});
+  auto *mul = F->createMul("mul", tanh, reshape2);
+  auto *sigmoid2 = F->createSigmoid("sigmoid2", mul);
+  auto *conv2 = F->createConv(bindings, "conv2", sigmoid2, 7, 3, 2, 1, 1);
+  bindings.get(cast<Placeholder>(conv2->getFilter()))->getHandle().clear(0.3);
+  bindings.get(cast<Placeholder>(conv2->getBias()))->getHandle().clear(1.3);
+  auto *reshape3 = F->createReshape("reshape3", conv2, {8, 8, 7, 4});
+  auto *sub = F->createSub("sub", reshape3, var4);
+  auto *relu2 = F->createRELU("relu2", sub);
+  auto *pool2 = F->createAvgPool("pool2", relu2, 3, 2, 1);
+  auto *sigmoid3 = F->createSigmoid("sigmoid3", pool2);
+  auto *result = F->createSave("ret", sigmoid3);
+  auto *resultTensor = bindings.allocate(result->getPlaceholder());
+
+  EE.compile(CompilationMode::Infer);
+
+  updateInputPlaceholders2(bindings, {var1, var2, var3, var4},
+                           {inputs1, inputs2, inputs3, inputs4});
+  EE.run(bindings);
+  out->assign(resultTensor);
+}
+
+namespace {
+// Helper for initializing conv node filter/bias from input tensors.
+static void initConv(PlaceholderBindings &bindings, ConvolutionNode *C,
+                     Tensor &filter, Tensor &bias) {
+  bindings.get(cast<Placeholder>(C->getFilter()))->assign(&filter);
+  bindings.get(cast<Placeholder>(C->getBias()))->assign(&bias);
+}
+} // namespace
+
+void inferTinyResnet(Tensor *input, Tensor *out, std::vector<Tensor> &weights,
+                     llvm::StringRef kind) {
+  PlaceholderBindings bindings;
+  ExecutionEngine2 EE(kind);
+  auto &mod = EE.getModule();
+  auto *F = mod.createFunction("main");
+
+  auto *in = createPlaceholder(mod, bindings, input, "in");
+  auto *conv1 = F->createConv(bindings, "conv1", in, 256, 1, 1, 0, 1);
+  auto *conv2a = F->createConv(bindings, "conv2a", conv1, 64, 1, 1, 0, 1);
+  auto *relu2a = F->createRELU("relu2a", conv2a);
+  auto *conv2b = F->createConv(bindings, "conv2b", relu2a, 64, 3, 1, 1, 1);
+  auto *relu2b = F->createRELU("relu2b", conv2b);
+  auto *conv2c = F->createConv(bindings, "conv2c", relu2b, 256, 1, 1, 0, 1);
+  auto *add = F->createAdd("add", conv2c, conv1);
+  auto *relu = F->createRELU("res2a_relu", add);
+  auto *result = F->createSave("ret", relu);
+  auto *resultTensor = bindings.allocate(result->getPlaceholder());
+
+  initConv(bindings, conv1, weights[0], weights[1]);
+  initConv(bindings, conv2a, weights[2], weights[3]);
+  initConv(bindings, conv2b, weights[4], weights[5]);
+  initConv(bindings, conv2c, weights[6], weights[7]);
+  convertPlaceholdersToConstants(F, bindings, {in, result->getPlaceholder()});
+
+  EE.compile(CompilationMode::Infer);
+
+  updateInputPlaceholders2(bindings, {in}, {input});
+  EE.run(bindings);
+  out->assign(resultTensor);
+}
+
+void inferExtract3D(Tensor *input, Tensor *out, llvm::StringRef kind) {
+  PlaceholderBindings bindings;
+  ExecutionEngine2 EE(kind);
+  auto &mod = EE.getModule();
+  auto *F = mod.createFunction("main");
+
+  auto *inputs = createPlaceholder(mod, bindings, input, "inputs");
+
+  auto *x1 = F->createSlice("ex1", inputs, {0, 5, 0}, {1, 100, 100});
+  auto *x2 = F->createSlice("ex2", inputs, {1, 5, 0}, {2, 100, 100});
+  auto *x3 = F->createSlice("ex3", inputs, {2, 5, 0}, {3, 100, 100});
+  auto *x4 = F->createSlice("ex4", inputs, {3, 5, 0}, {4, 100, 100});
+
+  auto *x12 = F->createConcat("x12", {x1, x2}, 1);
+  auto *x34 = F->createConcat("x34", {x3, x4}, 1);
+  auto *x13 = F->createConcat("x34", {x1, x3}, 1);
+  auto *x24 = F->createConcat("x34", {x2, x4}, 1);
+
+  auto *add1 = F->createAdd("add1", x12, x34);
+  auto *add2 = F->createAdd("add1", x13, x24);
+  auto *add3 = F->createAdd("add1", add1, add2);
+
+  auto *e = F->createSlice("slice", add3, {0, 55, 50}, {1, 150, 100});
+  auto *result = F->createSave("ret", e);
+  auto *resultTensor = bindings.allocate(result->getPlaceholder());
+
+  EE.compile(CompilationMode::Infer);
+
+  updateInputPlaceholders2(bindings, {inputs}, {input});
+  EE.run(bindings);
+  out->assign(resultTensor);
+}
+
+void inferMaxSplat(Tensor *input, Tensor *out, llvm::StringRef kind) {
+  PlaceholderBindings bindings;
+  ExecutionEngine2 EE(kind);
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+
+  auto T =
+      mod.uniqueType(ElemKind::Int8QTy, input->getType().dims(),
+                     input->getType().getScale(), input->getType().getOffset());
+  auto *var = createQuantizedPlaceholder(mod, bindings, input, T->getScale(),
+                                         T->getOffset(), "var");
+  auto *rescale = F->createRescaleQuantized("rescale", var, T);
+
+  auto *splat1 = F->createSplat("splat1", T, 0.0);
+  auto *splat2 = F->createSplat("splat2", T, 5.0);
+
+  auto *max1 = F->createMax("max1", rescale, splat1);
+  auto *max2 = F->createMax("max2", splat2, max1);
+
+  auto *result = F->createSave("ret", max2);
+  auto *resultTensor = bindings.allocate(result->getPlaceholder());
+
+  EE.compile(CompilationMode::Infer);
+
+  updateInputPlaceholders2(bindings, {var}, {input});
+  EE.run(bindings);
+  out->assign(resultTensor);
+}
+
+void insertCompiledFunction(llvm::StringRef name, CompiledFunction *func,
+                            runtime::DeviceManager *device, Module *mod) {
+  runtime::FunctionMapTy functionMap;
+  functionMap[name] = func;
+
+  std::promise<void> addPromise;
+  auto fut = addPromise.get_future();
+  llvm::Error addErr = llvm::Error::success();
+  device->addNetwork(mod, std::move(functionMap),
+                     [&addPromise, &addErr](const Module *, llvm::Error err) {
+                       addErr = std::move(err);
+                       addPromise.set_value();
+                     });
+  fut.wait();
+  EXIT_ON_ERR(std::move(addErr));
+}
+
+void runOnDevice(ExecutionContext &context, llvm::StringRef name,
+                 runtime::DeviceManager *device) {
+  std::unique_ptr<ExecutionContext> contextPtr(&context);
+  std::promise<void> runPromise;
+  auto fut = runPromise.get_future();
+  llvm::Error runErr = llvm::Error::success();
+  device->runFunction(
+      name, std::move(contextPtr),
+      [&runPromise, &runErr](runtime::RunIdentifierTy, llvm::Error err,
+                             std::unique_ptr<ExecutionContext> contextPtr) {
+        // Don't delete context.
+        contextPtr.release();
+        runErr = std::move(err);
+        runPromise.set_value();
+      });
+  fut.wait();
+  EXIT_ON_ERR(std::move(runErr));
+}
+
+} // namespace glow

--- a/tests/unittests/BackendTestUtils2.h
+++ b/tests/unittests/BackendTestUtils2.h
@@ -1,0 +1,307 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_TESTS_BACKENDTESTUTILS_H
+#define GLOW_TESTS_BACKENDTESTUTILS_H
+
+#include "glow/Backend/Backend.h"
+#include "glow/ExecutionEngine/ExecutionEngine2.h"
+#include "glow/Graph/Graph.h"
+#include "glow/Graph/Node.h"
+#include "glow/IR/IR.h"
+#include "glow/IR/IRBuilder.h"
+#include "glow/IR/IRGen.h"
+#include "glow/Quantization/Base/Base.h"
+
+#include "llvm/Support/Casting.h"
+
+#include "gtest/gtest.h"
+
+namespace glow {
+
+extern unsigned parCloneCountOpt;
+
+// A test harness to enable a test case for specific backends. A test suite
+// should subclass this and instantiate it as follows:
+//
+// class OperationTest : public BackendTest {
+//   ...
+// };
+//
+// INSTANTIATE_TEST_CASE_P_FOR_BACKEND_TEST(Prefix, OperationTest);
+//
+// A test case is defined using TEST_P(), and ENABLED_BACKENDS() can be used
+// to whitelist certain backends for the test. The absence of ENABLED_BACKENDS()
+// enables the test for all available backends:
+//
+//
+// TEST_P(OperationTest, replaceNaN) {
+//   // Enable this test case only for Interpreter and CPU.
+//   ENABLED_BACKENDS(Interpreter, CPU);
+//   // Regular test code.
+//   ...
+// }
+#define DECLARE_STATELESS_BACKEND_TEST(CLASS_NAME, CONFIG_NAME)                \
+  class CLASS_NAME : public ::testing::TestWithParam<CONFIG_NAME> {            \
+  protected:                                                                   \
+    bool isEnabledBackend(const std::set<std::string> &enabledBackends) {      \
+      return enabledBackends.find(getBackendName()) != enabledBackends.end();  \
+    }                                                                          \
+    const std::string Interpreter = "Interpreter";                             \
+    const std::string CPU = "CPU";                                             \
+    const std::string OpenCL = "OpenCL";                                       \
+    const std::string Habana = "Habana";                                       \
+                                                                               \
+  public:                                                                      \
+    std::string getBackendName() { return std::get<0>(GetParam()); }           \
+  }
+
+/// Note that we use std::tuple<std::string> here to match other tests which are
+/// parameterized across many other values, e.g. those in ParameterSweepTest.
+DECLARE_STATELESS_BACKEND_TEST(BackendStatelessTest, std::tuple<std::string>);
+
+class BackendTest : public BackendStatelessTest {
+public:
+  BackendTest() : mod_(EE_.getModule()) { F_ = mod_.createFunction("main"); }
+
+protected:
+  ExecutionEngine2 EE_{getBackendName()};
+  Module &mod_;
+  Function *F_;
+};
+
+static const auto all_backends = ::testing::Values(
+#ifdef GLOW_WITH_CPU
+    "CPU",
+#endif // GLOW_WITH_CPU
+#ifdef GLOW_WITH_OPENCL
+    "OpenCL",
+#endif // GLOW_WITH_OPENCL
+#ifdef GLOW_WITH_HABANA
+    "Habana",
+#endif // GLOW_WITH_HABANA
+    "Interpreter");
+
+// Instantiate parameterized test suite with all available backends.
+#define INSTANTIATE_TEST_CASE_P_FOR_BACKEND_TEST(prefix, test_case_name)       \
+  INSTANTIATE_TEST_CASE_P(prefix, test_case_name, all_backends)
+
+// Instantiate parameterized test suite with all available backends.
+#define INSTANTIATE_TEST_CASE_P_FOR_BACKEND_COMBINED_TEST(                     \
+    prefix, test_case_name, combine)                                           \
+  INSTANTIATE_TEST_CASE_P(prefix, test_case_name,                              \
+                          ::testing::Combine(all_backends, combine))
+
+// TODO: Replace return for GTEST_SKIP() so that skipped tests are
+// correctly reported once the macro gets available.
+#define ENABLED_BACKENDS(...)                                                  \
+  if (!isEnabledBackend({__VA_ARGS__}))                                        \
+    return;
+
+/// MockBackend used only for unit testing.
+class MockBackend : public Backend {
+  class MockFunction : public CompiledFunction {
+  public:
+    MockFunction(const runtime::RuntimeBundle &bundle)
+        : CompiledFunction(bundle) {}
+
+    llvm::Error execute(ExecutionContext *) override {
+      return llvm::Error::success();
+    }
+
+    std::string getCompileBackendName() const override { return "Interpreter"; }
+  };
+
+  std::string getBackendName() const override { return "Interpreter"; }
+
+  llvm::Expected<std::unique_ptr<CompiledFunction>>
+  compile(Function *F, const BackendOptions &) const override {
+    return llvm::make_unique<MockFunction>(runtime::RuntimeBundle::create(*F));
+  }
+
+  bool isOpSupported(const NodeInfo &NI) const override { return false; }
+
+  bool generateInst(Node *N, IRGenVisitor &irgen) const override {
+    return false;
+  }
+};
+
+/// MockBackendCustomIRGen used only for unit testing to test custom lowering
+/// from Node to Instruction IR.
+class MockBackendCustomIRGen : public Backend {
+  class MockFunction : public CompiledFunction {
+  public:
+    MockFunction(const runtime::RuntimeBundle &bundle)
+        : CompiledFunction(bundle) {}
+
+    llvm::Error execute(ExecutionContext *) override {
+      return llvm::Error::success();
+    }
+
+    std::string getCompileBackendName() const override { return "Interpreter"; }
+  };
+
+  std::string getBackendName() const override { return "Interpreter"; }
+
+  llvm::Expected<std::unique_ptr<CompiledFunction>>
+  compile(Function *F, const BackendOptions &) const override {
+    return llvm::make_unique<MockFunction>(runtime::RuntimeBundle::create(*F));
+  }
+
+  bool isOpSupported(const NodeInfo &NI) const override { return false; }
+
+  bool generateInst(Node *N, IRGenVisitor &irgen) const override {
+    bool hasChanged = false;
+    auto builder_ = irgen.getBuilder();
+    switch (N->getKind()) {
+    case glow::Kinded::Kind::ConvolutionNodeKind: {
+      auto *CN__ = llvm::cast<ConvolutionNode>(N);
+      auto *Src = irgen.valueForNode(CN__->getInput());
+      auto *Filter = irgen.valueForNode(CN__->getFilter());
+      auto *Bias = irgen.valueForNode(CN__->getBias());
+      std::string allocName = std::string(N->getName()) + ".res";
+      auto *Dest__ = builder_->createAllocActivationInst(
+          allocName, CN__->getResult().getType());
+      auto *V = builder_->createConvolutionInst(
+          "CustomConvolutionInstruction", Dest__, Src, Filter, Bias,
+          CN__->getKernels(), CN__->getStrides(), CN__->getPads(),
+          CN__->getGroup(), CN__->getDilation());
+      if (N->hasPredicate()) {
+        V->setPredicate(irgen.valueForNode(N->getPredicate()));
+      }
+      irgen.registerIR(CN__->getResult(), V->getDest());
+      irgen.setNodeToIR(N, V);
+      hasChanged = true;
+      break;
+    }
+    default:
+      break;
+    }
+    return hasChanged;
+  }
+};
+
+/// Pair representing a pointer to a Function with a single output, and the
+/// allocated Tensor that backs the Placeholder of the single output.
+using FunctionTensorPair = std::pair<Function *, Tensor *>;
+
+/// Signature of functions used to create and init a Function. Returns a pair of
+/// the Function created and the Placeholder of the output of the Function.
+using CreateAndInitFunction = std::function<FunctionTensorPair(
+    PlaceholderBindings &, ExecutionEngine2 &)>;
+
+/// Given a method \p createAndInitFunction that creates and initializes a
+/// FloatTy Function with a single output Tensor, \returns a bool representing
+/// if the output Tensor of executing the Function on the Interpreter backend is
+/// equal to executing it on a backend \p backendName. \p interpElemKind
+/// and \p backendElemKind represent the desired ElemKinds for their respective
+/// functions to use. If either require quantization then a profile will first
+/// be gathered on the Interpreter, and then that profile will be used to
+/// quantize one or both. Otherwise if either is Float16Ty then the respective
+/// Function it will be converted using the Converter. If
+/// \p enableRowwiseQuantization then rowwise quantization will be used for
+/// nodes that support it. \p schema represents the quantization schema to use,
+/// if applicable. \p parallelCount represents the number of times to clone the
+/// Function inside itself, so that testing can be done on architectures that
+/// have parallel compute engines.
+void compareAgainstInterpreter(
+    llvm::StringRef backendName, CreateAndInitFunction createAndInitFunction,
+    ElemKind interpElemKind, ElemKind backendElemKind,
+    float allowedError = 0.0001, unsigned parallelCount = 1,
+    bool enableRowwiseQuantization = false,
+    quantization::Schema schema = quantization::Schema::Asymmetric);
+
+/// Given some \p FTP representing a Function with a single SaveNode and its
+/// Tensor output, duplicate the Nodes in the Function and their Placeholder
+/// inputs given \p bindings \p parallelCount times. \returns a set of Tensor
+/// pointers for each output of the cloned Function.
+std::unordered_set<Tensor *> cloneFunInsideFun(FunctionTensorPair FTP,
+                                               PlaceholderBindings *bindings,
+                                               unsigned parallelCount);
+
+void inferConvNet(Tensor *inputs, Tensor *filter, Tensor *bias, Tensor *out,
+                  llvm::StringRef kind);
+
+void trainConvNet(Tensor *inputs, Tensor *kernel1, Tensor *bias1,
+                  Tensor *kernel2, Tensor *bias2, Tensor *selected,
+                  llvm::ArrayRef<size_t> shape1, llvm::ArrayRef<size_t> shape2,
+                  Tensor *out, llvm::StringRef kind);
+
+void inferLocalResponseNormalizationNet(Tensor *inputs, Tensor *out,
+                                        llvm::StringRef kind);
+
+void trainLocalResponseNormalizationNet(Tensor *inputs, Tensor *weights,
+                                        Tensor *bias, Tensor *selected,
+                                        llvm::ArrayRef<size_t> shape1,
+                                        llvm::ArrayRef<size_t> shape2,
+                                        Tensor *out, llvm::StringRef kind);
+void trainAvgPoolNet(Tensor *inputs, Tensor *weights, Tensor *bias,
+                     Tensor *selected, llvm::ArrayRef<size_t> shape1,
+                     llvm::ArrayRef<size_t> shape2, Tensor *out,
+                     llvm::StringRef kind);
+
+void trainMaxPoolNet(Tensor *inputs, Tensor *weights, Tensor *bias,
+                     Tensor *selected, llvm::ArrayRef<size_t> shape1,
+                     llvm::ArrayRef<size_t> shape2, Tensor *out,
+                     llvm::StringRef kind);
+
+void inferIntLookupTableNet(Tensor *input, Tensor *out,
+                            llvm::ArrayRef<int8_t> table, llvm::StringRef kind);
+
+void inferGroupConv(Tensor *out, llvm::StringRef kind);
+
+void inferNonSquarePaddingConv(Tensor *out, llvm::StringRef kind);
+
+void inferNonSquareKernelConv(Tensor *out, llvm::StringRef kind);
+
+void inferNonSquareStrideConv(Tensor *out, llvm::StringRef kind);
+
+void inferConvDKKC8(Tensor *out, llvm::StringRef kind);
+
+void inferSmallConv(Tensor *inputs, Tensor *out, llvm::StringRef kind);
+
+void trainSoftMaxNet(Tensor *inputs, Tensor *weights, Tensor *bias,
+                     Tensor *selected, Tensor *out, llvm::StringRef kind);
+
+void inferBasicConvNet(Tensor *inputs, Tensor *out, llvm::StringRef kind,
+                       size_t convDepth);
+
+void inferTanhConcatNet(Tensor *input1, Tensor *input2, Tensor *input3,
+                        Tensor *out, llvm::StringRef kind);
+
+FunctionTensorPair createAndInitBasicFCNet(PlaceholderBindings &bindings,
+                                           ExecutionEngine2 &EE);
+
+void inferMixedNet(Tensor *inputs, Tensor *out, llvm::StringRef kind);
+
+void inferComplexNet1(Tensor *inputs1, Tensor *inputs2, Tensor *inputs3,
+                      Tensor *inputs4, Tensor *out, llvm::StringRef kind);
+
+void inferTinyResnet(Tensor *input, Tensor *out, std::vector<Tensor> &weights,
+                     llvm::StringRef kind);
+
+void inferExtract3D(Tensor *input, Tensor *out, llvm::StringRef kind);
+
+void inferMaxSplat(Tensor *input, Tensor *out, llvm::StringRef kind);
+
+void insertCompiledFunction(llvm::StringRef name, CompiledFunction *func,
+                            runtime::DeviceManager *device, Module *mod);
+
+void runOnDevice(ExecutionContext &context, llvm::StringRef name,
+                 runtime::DeviceManager *device);
+
+} // namespace glow
+
+#endif // GLOW_TESTS_BACKENDTESTUTILS_H

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -20,6 +20,20 @@ target_link_libraries(BackendTestUtils
                         LLVMSupport
                         gtest)
 
+add_library(BackendTestUtils2
+            BackendTestUtils2.cpp)
+target_link_libraries(BackendTestUtils2
+                      PRIVATE
+                        Base
+                        Converter
+                        ExecutionEngine2
+                        Graph
+                        GraphOptimizer
+                        Quantization
+                        QuantizationBase
+                        LLVMSupport
+                        gtest)
+
 # Test executables, sorted alphabetically.
 
 add_executable(BackendCorrectnessTest
@@ -246,10 +260,10 @@ if(GLOW_WITH_CPU)
                  HyphenTest.cpp)
   target_link_libraries(HyphenTest
                         PRIVATE
-                          BackendTestUtils
+                          BackendTestUtils2
                           Graph
                           IR
-                          ExecutionEngine
+                          ExecutionEngine2
                           Quantization
                           Support
                           gtest

--- a/tests/unittests/HyphenTest.cpp
+++ b/tests/unittests/HyphenTest.cpp
@@ -20,9 +20,9 @@
 // compiler with a small end-to-end example. The toy network is small
 // enough that it can be trained as part of the unit test suite.
 
-#include "BackendTestUtils.h"
+#include "BackendTestUtils2.h"
 
-#include "glow/ExecutionEngine/ExecutionEngine.h"
+#include "glow/ExecutionEngine/ExecutionEngine2.h"
 #include "glow/Graph/Graph.h"
 #include "glow/IR/IR.h"
 #include "glow/IR/IRBuilder.h"
@@ -283,18 +283,14 @@ struct HyphenNetwork {
 
   // Run `inputs` through the inference function and check the results against
   // `hyphens`. Return the number of errors.
-  unsigned inferenceErrors(ExecutionEngine &EE, llvm::StringRef name,
+  unsigned inferenceErrors(ExecutionEngine2 &EE, llvm::StringRef fName,
                            Tensor &inputs, const vector<bool> &hyphens,
                            TrainingConfig &TC) {
-    // Compilation is destructive because of target-specific lowering.
-    // Compile a clone of the inference function.
-    auto *CF = infer_->clone(name);
-    EE.compile(CompilationMode::Infer, CF);
-
     auto batchSize = TC.batchSize;
     auto numSamples = inputs.dims()[0];
     EXPECT_LE(batchSize, numSamples);
-    auto resultHandle = bindings_.get(result_->getPlaceholder())->getHandle<>();
+    auto resultHandle =
+        bindings_.get(bindings_.getPlaceholderByName("result"))->getHandle<>();
     unsigned errors = 0;
 
     for (size_t bi = 0; bi < numSamples; bi += batchSize) {
@@ -305,8 +301,8 @@ struct HyphenNetwork {
         bi = numSamples - batchSize;
       }
       auto batchInputs = inputs.getUnowned({batchSize, 6, 27}, {bi, 0, 0});
-      updateInputPlaceholders(bindings_, {input_}, {&batchInputs});
-      EE.run(bindings_);
+      updateInputPlaceholders2(bindings_, {input_}, {&batchInputs});
+      EE.run(bindings_, fName);
 
       // Check each output in the batch.
       for (size_t i = 0; i != batchSize; i++) {
@@ -323,8 +319,18 @@ struct HyphenNetwork {
 };
 } // namespace
 
+// Copy values from one PlaceholderBindings to another by name. This allows for
+// training a network on one EE then using the trained weights on another.
+void copyBetweenBindings(llvm::StringRef name, PlaceholderBindings &src,
+                         PlaceholderBindings &dst) {
+  auto srcPH = src.getPlaceholderByName(name);
+  auto dstPH = dst.getPlaceholderByName(name);
+  dst.erase(dstPH);
+  dst.insert(dstPH, src.get(srcPH)->clone());
+}
+
 TEST(HyphenTest, network) {
-  ExecutionEngine EE("CPU");
+  ExecutionEngine2 EE("CPU");
 
   // Convert the training data to word windows and labels.
   vector<string> words;
@@ -363,21 +369,32 @@ TEST(HyphenTest, network) {
   TC.learningRate = 0.8;
   TC.batchSize = 50;
   HyphenNetwork net(EE.getModule(), TC);
+  auto fName = net.infer_->getName();
+  auto tfName = net.train_->getName();
 
   // This variable records the number of the next sample to be used for
   // training.
   size_t sampleCounter = 0;
 
   // Train using mini-batch SGD.
-  EE.compile(CompilationMode::Train, net.train_);
-  runBatch(EE, net.bindings_, 1000, sampleCounter, {net.input_, net.expected_},
-           {&inputs, &expected});
+  EE.compile(CompilationMode::Train);
+  runBatch2(EE, net.bindings_, 1000, sampleCounter, {net.input_, net.expected_},
+            {&inputs, &expected}, tfName);
 
   // Now test inference on the trained network.
   // Note that we have probably overfitted the data, so we expect 100% accuracy.
-  EXPECT_EQ(net.inferenceErrors(EE, "cpu", inputs, hyphens, TC), 0);
+  EXPECT_EQ(net.inferenceErrors(EE, fName, inputs, hyphens, TC), 0);
 
   // See of the interpreter gets the same result.
-  EE.setBackend("Interpreter");
-  EXPECT_EQ(net.inferenceErrors(EE, "interpreter", inputs, hyphens, TC), 0);
+
+  ExecutionEngine2 EE2("CPU");
+  HyphenNetwork netInterpreter(EE2.getModule(), TC);
+  EE2.compile(CompilationMode::Train);
+  // Copy the trained weights from the CPU run.
+  copyBetweenBindings("bias", net.bindings_, netInterpreter.bindings_);
+  copyBetweenBindings("bias1", net.bindings_, netInterpreter.bindings_);
+  copyBetweenBindings("weights", net.bindings_, netInterpreter.bindings_);
+  copyBetweenBindings("weights1", net.bindings_, netInterpreter.bindings_);
+
+  EXPECT_EQ(netInterpreter.inferenceErrors(EE2, fName, inputs, hyphens, TC), 0);
 }


### PR DESCRIPTION
Summary:
Created transition BackendTestUtils2 which is a copy of BackendTestUtils that has been ported to EE2. This is an intermediate step so tests can be ported one at a time. Once all users of BackendTestUtils have been ported BackendTestUtils2 will replace BackendTestUtils. Also ported HyphenTest which uses the new BackendUtils2.

Documentation: NA

Work on #3239 

Test Plan: ninja check, verify HyphenTest passes.
