### PR TITLE
Extending ONNXModelLoader to support load of the specific Glow ops

### DIFF
--- a/include/glow/Exporter/ONNXModelWriter.h
+++ b/include/glow/Exporter/ONNXModelWriter.h
@@ -50,10 +50,6 @@ class ONNXModelWriter : public CommonOperatorWriter<ONNX_TRAITS> {
   size_t opsetVersion_;
   /// Keeps the track of already visited or processed nodes.
   ReportedNodes reportedNodes_;
-  /// Converts \p glowType to \p protoType.
-  static typename TensorType::DataType convertType(const Type &glowType);
-  /// Writes Glow tensor \p T to proto output \p out.
-  static void writeTensor(const Tensor &T, TensorType *out);
   /// Writes tensor shape from placeholder \p PH into protpbuf \p valueProto.
   static void tensorShapeFromPlaceholder(const Placeholder *PH,
                                          ValueInfoType *valueProto);
@@ -69,6 +65,11 @@ class ONNXModelWriter : public CommonOperatorWriter<ONNX_TRAITS> {
   static bool hasUsesOfKind(const Node *node, Kinded::Kind kind);
 
 public:
+  /// Converts \p glowType to \p protoType.
+  static typename TensorType::DataType convertType(const Type &glowType);
+  /// Writes Glow tensor \p T to proto output \p out.
+  static void writeTensor(const Tensor &T, TensorType *out);
+
   /// Creates an ONNX model writer to serialize \p F graph into file
   /// \p modelFilename, writing \p irVersion and \p opsetVersion.
   /// If \p errPtr is not null then if an error occurs it will get assigned
@@ -80,8 +81,8 @@ public:
 private:
   /// \returns error for the unexpected node kind.
   static llvm::Error writeUnexpectedKind(const Node *node) {
-    RETURN_ERR(strFormat("Glow can not export node %s, unsupported kind: %d.",
-                         node->getName().str().c_str(), node->getKind()));
+    RETURN_ERR(strFormat("Glow can not export node %s, unsupported kind: %s.",
+                         node->getName().str().c_str(), node->getKindName()));
   }
 
   /// Declares the overriden all pure virtual methods, declared in base class.

--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -332,7 +332,7 @@ protected:
         inputs.push_back(G_.createExpandDims(opName, in, {0}));
       }
       ConcatNode *concat = G_.createConcat(opName, inputs, /* axis */ 0);
-      Node *node = G_.createBatchedReduceAdd(opName, concat, /* axis */ 0);
+      Node *node = G_.createBatchedReduceAdd(opName, concat, /* axis */ {0});
       RETURN_IF_ERR(addNodeAsOutput(op, node));
     }
     return llvm::Error::success();

--- a/include/glow/Importer/ONNXModelLoader.h
+++ b/include/glow/Importer/ONNXModelLoader.h
@@ -133,7 +133,8 @@ class ONNXModelLoader
 
   /// Load ConstantOfShape ONNX operator.
   llvm::Error loadConstantOfShape(const ONNX_NAMESPACE::NodeProto &op,
-                                  const ArgumentDictionaryTy &dict);
+                                  const ArgumentDictionaryTy &dict,
+                                  bool isSplat);
 
   /// Load Tile ONNX operator.
   llvm::Error loadTile(const ONNX_NAMESPACE::NodeProto &op,
@@ -141,6 +142,76 @@ class ONNXModelLoader
 
   /// Load Where ONNX operator.
   llvm::Error loadWhere(const ONNX_NAMESPACE::NodeProto &op,
+                        const ArgumentDictionaryTy &dict);
+
+  /// Load Glow specific operators, not defined in ONNX format
+  /// Load Glow CmpEQ operator.
+  llvm::Error loadCmpEQ(const ONNX_NAMESPACE::NodeProto &op,
+                        const ArgumentDictionaryTy &dict);
+
+  /// Load Glow CmpLTE operator.
+  llvm::Error loadCmpLTE(const ONNX_NAMESPACE::NodeProto &op,
+                         const ArgumentDictionaryTy &dict);
+
+  /// Load Glow Select operator.
+  llvm::Error loadSelect(const ONNX_NAMESPACE::NodeProto &op,
+                         const ArgumentDictionaryTy &dict);
+
+  /// Load Glow Quantize operator.
+  llvm::Error loadQuantize(const ONNX_NAMESPACE::NodeProto &op,
+                           const ArgumentDictionaryTy &dict);
+
+  /// Load Glow ConvertTo operator.
+  llvm::Error loadConvertTo(const ONNX_NAMESPACE::NodeProto &op,
+                            const ArgumentDictionaryTy &dict);
+
+  /// Load Glow Dequantize operator.
+  llvm::Error loadDequantize(const ONNX_NAMESPACE::NodeProto &op,
+                             const ArgumentDictionaryTy &dict);
+
+  /// Load Glow Regression operator.
+  llvm::Error loadRegression(const ONNX_NAMESPACE::NodeProto &op,
+                             const ArgumentDictionaryTy &dict);
+
+  /// Load Glow BatchedAdd operator.
+  llvm::Error loadBatchedAdd(const ONNX_NAMESPACE::NodeProto &op,
+                             const ArgumentDictionaryTy &dict);
+
+  /// Load Glow ScatterAssign operator.
+  llvm::Error loadScatterAssign(const ONNX_NAMESPACE::NodeProto &op,
+                                const ArgumentDictionaryTy &dict);
+
+  /// Load Glow IntLookupTable operator.
+  llvm::Error loadIntLookupTable(const ONNX_NAMESPACE::NodeProto &op,
+                                 const ArgumentDictionaryTy &dict);
+
+  /// Load Glow LengthsRangeFill operator.
+  llvm::Error loadLengthsRangeFill(const ONNX_NAMESPACE::NodeProto &op,
+                                   const ArgumentDictionaryTy &dict);
+
+  /// Load Glow RescaleQuantized operator.
+  llvm::Error loadRescaleQuantized(const ONNX_NAMESPACE::NodeProto &op,
+                                   const ArgumentDictionaryTy &dict);
+
+  /// Load Glow RowwiseQuantizedSparseLengthsWeightedSum operator.
+  llvm::Error loadRowwiseQuantizedSparseLengthsWeightedSum(
+      const ONNX_NAMESPACE::NodeProto &op, const ArgumentDictionaryTy &dict);
+
+  /// Load Glow FusedRowwiseQuantizedSparseLengthsWeightedSum operator.
+  llvm::Error loadFusedRowwiseQuantizedSparseLengthsWeightedSum(
+      const ONNX_NAMESPACE::NodeProto &op, const ArgumentDictionaryTy &dict);
+
+  /// Load Glow RowwiseQuantizedFullyConnected operator.
+  llvm::Error
+  loadRowwiseQuantizedFullyConnected(const ONNX_NAMESPACE::NodeProto &op,
+                                     const ArgumentDictionaryTy &dict);
+
+  /// Load Glow FullyConnected operator.
+  llvm::Error loadFullyConnected(const ONNX_NAMESPACE::NodeProto &op,
+                                 const ArgumentDictionaryTy &dict);
+
+  /// Load Glow Splat operator.
+  llvm::Error loadSplat(const ONNX_NAMESPACE::NodeProto &op,
                         const ArgumentDictionaryTy &dict);
 
 protected:
@@ -210,6 +281,12 @@ protected:
                                           LoaderType *loader, const OpType &op);
 
 public:
+  /// \returns ONNX model ir_version;
+  size_t getIrVersion() const { return irVersion_; };
+
+  /// \returns ONNX model op_version;
+  size_t getOpSetVersion() const { return opsetVersion_; };
+
   /// Creates a ONNX model loader to build \p F.
   /// If \p errPtr is not null then if an error occurs it will get assigned
   /// there otherwise if an error occurs it will abort.

--- a/lib/Exporter/ONNXModelWriter.cpp
+++ b/lib/Exporter/ONNXModelWriter.cpp
@@ -35,6 +35,15 @@ template <typename T> struct AttributeAssigner<false, llvm::ArrayRef<T>> {
   }
 };
 
+// Specialization for 1D, 1 element Tensor container types
+template <> struct AttributeAssigner<false, Tensor> {
+  static void assign(ONNX_NAMESPACE::AttributeProto *attr, const Tensor &T) {
+    auto *proto = attr->mutable_t();
+    ONNXModelWriter::writeTensor(T, proto);
+    attr->set_type(ONNX_NAMESPACE::AttributeProto::TENSOR);
+  }
+};
+
 // Specialization for string type
 template <> struct AttributeAssigner<false, std::string> {
   static void assign(ONNX_NAMESPACE::AttributeProto *attr,
@@ -70,23 +79,62 @@ void addValueAttribute(ONNX_NAMESPACE::NodeProto *proto,
                                                                    container);
 }
 
-/// Helper function to recursively get inputs for the broadcast node.
-/// Broadcast node get constructed as a chain of Reshape->Tile->...->Tile.
-const Node *unwindBroadcastInput(const TileNode *tile,
-                                 ReportedNodes &reporter) {
+/// Helper function to recursively rewind Tile \p node.
+/// Optionally, if provided fills out the repeats \p repeats.
+/// Returns the first Tile in a chain of Tiles.
+const TileNode *unwindTile(const TileNode *node, std::vector<size_t> *repeats,
+                           ReportedNodes &reporter) {
+  // unwind Tile
+  // Keep track of detected <axis, count> pairs.
+  std::vector<std::pair<unsigned_t, unsigned_t>> info;
+  const TileNode *tile = node;
   while (tile) {
-    reporter.insert(tile);
-    if (const ReshapeNode *RN =
-            llvm::dyn_cast<ReshapeNode>(tile->getInput().getNode())) {
-      return RN;
-    } else if (const TileNode *TN =
-                   llvm::dyn_cast<TileNode>(tile->getInput().getNode())) {
+    // Insert counts and axises in reverse order,
+    // cause rewind algorithm navigates from the bottom to the top.
+    info.insert(info.begin(), {tile->getAxis(), tile->getCount()});
+
+    if (const auto *TN = llvm::dyn_cast<TileNode>(tile->getInput().getNode())) {
+      reporter.insert(TN);
       tile = TN;
     } else {
-      return nullptr;
+      break;
+    }
+  }
+
+  if (repeats) {
+    unsigned_t numDims = tile->getInput().dims().size();
+    // axis is in a normal case will have [0, 1, ..., numDims - 1] values,
+    // in extreme case []. Find missing indices and insert count 1.
+    auto aB = info.begin();
+
+    for (unsigned_t i = 0; i < numDims; ++i, ++aB) {
+      if (aB == info.end() || aB->first != i) {
+        aB = info.insert(aB, {i, 1});
+      }
+    }
+
+    for (size_t b = 0, e = info.size(); b < e; ++b) {
+      repeats->push_back(info[b].second);
     }
   }
   return tile;
+}
+
+/// Helper function to recursively get inputs for the broadcast node.
+/// Broadcast node get constructed as a chain of Reshape->Tile->...->Tile.
+const Node *unwindBroadcastInput(const TileNode *tile,
+                                 std::vector<size_t> *repeats,
+                                 ReportedNodes &reporter) {
+  tile = unwindTile(tile, repeats, reporter);
+  DCHECK(tile);
+
+  reporter.insert(tile);
+  if (const ReshapeNode *RN =
+          llvm::dyn_cast<ReshapeNode>(tile->getInput().getNode())) {
+    return RN;
+  } else {
+    return nullptr;
+  }
 }
 
 /// Writes all outputs from Node \p node to protobuf \p proto.
@@ -106,6 +154,22 @@ void outputsToProto(const Node *node, ONNX_NAMESPACE::NodeProto *proto) {
       }
     }
   }
+}
+
+/// Write the output of the provided type only of node outputs.
+bool outputKindToProto(Kinded::Kind kind, const Node *node,
+                       ONNX_NAMESPACE::NodeProto *proto) {
+  bool found = false;
+  for (const auto &use : node->getUsers()) {
+    const auto *user = use.getUser();
+    if (user->getKind() == Kinded::Kind::SaveNodeKind) {
+      proto->add_output(user->getName());
+    } else if (user->getKind() == kind) {
+      found = true;
+      outputsToProto(user, proto);
+    }
+  }
+  return found;
 }
 
 /// Writes all inputs from Node \p node to protobuf \p proto.
@@ -164,28 +228,83 @@ llvm::Error writeArithmetic(const std::string &opName, const T *node,
   proto->set_op_type(opName);
   outputsToProto(node, proto);
 
-  const auto *LHS = node->getLHS().getNode();
-  if (const TileNode *TN = llvm::dyn_cast<TileNode>(LHS)) {
-    const ReshapeNode *RN =
-        llvm::dyn_cast<ReshapeNode>(unwindBroadcastInput(TN, reporter));
+  auto LHS = node->getLHS();
+  if (const TileNode *TN = llvm::dyn_cast<TileNode>(LHS.getNode())) {
+    reporter.insert(TN);
+    const ReshapeNode *RN = llvm::dyn_cast<ReshapeNode>(
+        unwindBroadcastInput(TN, nullptr /* repeats */, reporter));
     RETURN_ERR_IF_NOT(RN, "Can't unwind Tile node.");
-    proto->add_input(RN->getInput().getNode()->getName());
     reporter.insert(RN);
-  } else {
-    proto->add_input(LHS->getName());
+    LHS = RN->getInput();
   }
 
-  const auto *RHS = node->getRHS().getNode();
-  if (const TileNode *TN = llvm::dyn_cast<TileNode>(RHS)) {
-    const ReshapeNode *RN =
-        llvm::dyn_cast<ReshapeNode>(unwindBroadcastInput(TN, reporter));
+  int axis = -1;
+  auto RHS = node->getRHS();
+  if (const TileNode *TN = llvm::dyn_cast<TileNode>(RHS.getNode())) {
+    reporter.insert(TN);
+    // unwind broadcast with tiles repeats.
+    std::vector<size_t> repeats;
+    const ReshapeNode *RN = llvm::dyn_cast<ReshapeNode>(
+        unwindBroadcastInput(TN, &repeats, reporter));
     RETURN_ERR_IF_NOT(RN, "Can't unwind Tile node.");
-    proto->add_input(RN->getInput().getNode()->getName());
     reporter.insert(RN);
-  } else {
-    proto->add_input(RHS->getName());
+    RHS = RN->getInput();
+
+    if (LHS.dims() != RHS.dims()) {
+      // Extract axis from available shapes, ie. input origin,
+      // reshape and target repeats.
+      llvm::ArrayRef<size_t> origin = RHS.dims();
+      llvm::ArrayRef<size_t> reshape = RN->getDims();
+      DCHECK(reshape.size() == repeats.size());
+      DCHECK(repeats.size() >= origin.size());
+
+      // Replace target repeats dimension if it equal 1 and the correspondent
+      // reshape dimension isn't.
+      for (size_t b = 0, e = repeats.size(); b < e; ++b) {
+        if (repeats[b] == 1 && reshape[b] != 1) {
+          repeats[b] = reshape[b];
+        }
+      }
+
+      for (int b = 0, e = repeats.size() - origin.size(); b <= e && axis == -1;
+           ++b) {
+        axis = b;
+        for (size_t i = 0; i < origin.size(); ++i) {
+          if (origin[i] != repeats[i + b] &&
+              (origin[i] != 1 || reshape[i + b] != 1)) {
+            axis = -1;
+            break;
+          }
+        }
+      }
+    }
   }
+
+  proto->add_input(LHS.getNode()->getName());
+  proto->add_input(RHS.getNode()->getName());
+
+  // Check if the shapes of LHS and RHS are different and broadcast attribute is
+  // required.
+  if (LHS.dims() != RHS.dims()) {
+    addValueAttribute(proto, "axis", axis);
+    addValueAttribute(proto, "broadcast", 1UL);
+  }
+
   return llvm::Error::success();
+}
+
+void tensorShapeFromInput(const std::string &name, TypeRef ty,
+                          ONNX_NAMESPACE::ValueInfoProto *valueProto) {
+  valueProto->set_name(name);
+  auto *type = valueProto->mutable_type();
+  auto *tensorType = type->mutable_tensor_type();
+  tensorType->set_elem_type(ONNXModelWriter::convertType(*ty));
+  auto *tensorShape = tensorType->mutable_shape();
+  const auto &dims = ty->dims();
+  for (unsigned b = 0, e = dims.size(); b < e; ++b) {
+    auto *tensorDims = tensorShape->add_dim();
+    tensorDims->set_dim_value(dims[b]);
+  }
 }
 
 } // namespace
@@ -211,51 +330,55 @@ ONNXModelWriter::ONNXModelWriter(const std::string &modelFilename, Function &F,
     opsetImportProto->set_version(opsetVersion);
     auto *graphProto = modelProto.mutable_graph();
     graphProto->set_name("glow");
-
-    // Use post order graph traversal.
+    // Use pre order graph traversal.
     // If node is constant with uses, turned into "input" and create a tensor
     // If node is placeholder with uses, turned into "input" with tensor shape,
     // except the case when placeholder has use as SaveNode.
     // Otherwise call common operators method or special operators and write
     // protobuf inputs from node inputs and protobuf outputs from uses.
-    GraphPostOrderVisitor visitor(G_);
-    for (const auto *N : visitor.getPostOrder()) {
+    GraphPreOrderVisitor visitor(G_);
+    for (const auto *N : visitor.getPreOrder()) {
       if (reportedNodes_.count(N)) {
         continue;
       }
 
       const auto kind = N->getKind();
-      if (kind == Kinded::Kind::PlaceholderKind ||
-          kind == Kinded::Kind::ConstantKind) {
+      // Handle placeholders cases.
+      if (kind == Kinded::Kind::PlaceholderKind) {
         if (hasUsesOfKind(N, Kinded::Kind::SaveNodeKind)) {
           // Storage as an input to SaveNode - ignore it.
           continue;
         }
-
-        // Handle placeholders cases.
-        if (kind == Kinded::Kind::PlaceholderKind) {
-          const auto *PH = llvm::cast<Placeholder>(N);
-          // Write global input, output only tensor shape.
-          auto *inputProto = graphProto->add_input();
-          tensorShapeFromPlaceholder(PH, inputProto);
-        } else {
-          // Write global initializer, output tensor bytes.
-          const auto *C = llvm::cast<Constant>(N);
-          auto *tensorProto = graphProto->add_initializer();
-          tensorProto->set_name(C->getName());
-          writeTensor(C->getPayload(), tensorProto);
-        }
+        const auto *PH = llvm::cast<Placeholder>(N);
+        // Write global input, output only tensor shape.
+        auto *inputProto = graphProto->add_input();
+        tensorShapeFromPlaceholder(PH, inputProto);
+      } else if (kind == Kinded::Kind::ConstantKind) {
+        // Write global initializer, output tensor bytes.
+        const auto *C = llvm::cast<Constant>(N);
+        auto *tensorProto = graphProto->add_initializer();
+        tensorProto->set_name(C->getName());
+        writeTensor(C->getPayload(), tensorProto);
       } else if (kind == Kinded::Kind::SaveNodeKind) {
         // Save node case, find input and use its name as a global output,
         // output only shape.
-        const auto *PH = llvm::cast<SaveNode>(N)->getPlaceholder();
-        auto *outputProto = graphProto->add_output();
-        tensorShapeFromPlaceholder(PH, outputProto);
+        const SaveNode *SN = llvm::cast<SaveNode>(N);
+        const auto *PH = SN->getPlaceholder();
+        auto *out = graphProto->add_output();
+        tensorShapeFromPlaceholder(PH, out);
       } else {
         RETURN_IF_ERR(writeOperator(N, *graphProto));
       }
       reportedNodes_.insert(N);
     }
+
+    // Nodes has been added in a reverse order from SaveNode up to the inputs,
+    // we need to rearrange all nodes in the reverse order before serialization.
+    auto *nodes = graphProto->mutable_node();
+    for (size_t i = 0, n = nodes->size(); i < n / 2; ++i) {
+      nodes->SwapElements(i, n - i - 1);
+    }
+
     return writeModel(modelProto, textMode);
   };
 
@@ -304,17 +427,7 @@ void ONNXModelWriter::writeTensor(const Tensor &T, TensorType *out) {
 
 void ONNXModelWriter::tensorShapeFromPlaceholder(const Placeholder *PH,
                                                  ValueInfoType *valueProto) {
-  valueProto->set_name(PH->getName());
-  auto *type = valueProto->mutable_type();
-  auto *tensorType = type->mutable_tensor_type();
-  auto *glowType = PH->getType();
-  tensorType->set_elem_type(convertType(*glowType));
-  auto *tensorShape = tensorType->mutable_shape();
-  const auto &dims = glowType->dims();
-  for (unsigned b = 0, e = dims.size(); b < e; ++b) {
-    auto *tensorDims = tensorShape->add_dim();
-    tensorDims->set_dim_value(dims[b]);
-  }
+  tensorShapeFromInput(PH->getName(), PH->getType(), valueProto);
 }
 
 llvm::Error ONNXModelWriter::writeAllWithNode(const std::string &opName,
@@ -346,7 +459,7 @@ bool ONNXModelWriter::hasUsesOfKind(const Node *node, Kinded::Kind kind) {
 //===-----------------------------------------------------------------===//
 llvm::Error ONNXModelWriter::writePad(const PadNode *node, GraphType &graph) {
   auto *proto = graph.add_node();
-  // Find dictionary entries.
+  // Add dictionary entries.
   switch (node->getMode()) {
   case PaddingMode::CONSTANT:
     addValueAttribute(proto, "mode", std::string("constant"));
@@ -368,49 +481,40 @@ llvm::Error ONNXModelWriter::writePad(const PadNode *node, GraphType &graph) {
     addValueAttribute(proto, "value", value);
   }
 
-  return writeAllWithNode(node->getName(), node, proto);
+  return writeAllWithNode("Pad", node, proto);
 }
 
 llvm::Error ONNXModelWriter::writeConcat(const ConcatNode *node,
                                          GraphType &graph) {
   auto *proto = graph.add_node();
-  // Find dictionary entries.
+  // Add dictionary entries.
   addValueAttribute(proto, "axis", node->getDim());
 
-  return writeAllWithNode(node->getName(), node, proto);
-}
-
-llvm::Error ONNXModelWriter::writeMaxPool(const MaxPoolNode *node,
-                                          GraphType &graph) {
-  auto *proto = graph.add_node();
-  // Find dictionary entries.
-  addValueAttribute(proto, "kernel_shape", node->getKernels());
-  addValueAttribute(proto, "strides", node->getStrides());
-  addValueAttribute(proto, "pads", node->getPads());
-
-  return writeAllWithNode(node->getName(), node, proto);
+  return writeAllWithNode("Concat", node, proto);
 }
 
 llvm::Error ONNXModelWriter::writeTranspose(const TransposeNode *node,
                                             GraphType &graph) {
-  // Convolution node creates transpose for input weights and output results.
-  // Therefore check first if this transpose has Convolution node as uses.
-  if (hasUsesOfKind(node, Kinded::Kind::ConvolutionNodeKind)) {
+  // Some nodes create transpose for outputs.
+  auto *input = node->getInput().getNode();
+  if (llvm::dyn_cast<ConvolutionNode>(input) ||
+      llvm::dyn_cast<AvgPoolNode>(input) ||
+      llvm::dyn_cast<MaxPoolNode>(input) ||
+      llvm::dyn_cast<SpaceToDepthNode>(input)) {
     return llvm::Error::success();
   }
 
   auto *proto = graph.add_node();
-  // Find dictionary entries.
+  // Add dictionary entries.
   addValueAttribute(proto, "perm", node->getShuffle());
 
-  return writeAllWithNode(node->getName(), node, proto);
+  return writeAllWithNode("Transpose", node, proto);
 }
 
 llvm::Error ONNXModelWriter::writeConvolution(const ConvolutionNode *node,
                                               GraphType &graph) {
   auto *proto = graph.add_node();
-  // Find dictionary entries.
-  addValueAttribute(proto, "kernel_shape", node->getKernels());
+  // Add dictionary entries.
   addValueAttribute(proto, "strides", node->getStrides());
   addValueAttribute(proto, "pads", node->getPads());
   addValueAttribute(proto, "group", node->getGroup());
@@ -421,11 +525,8 @@ llvm::Error ONNXModelWriter::writeConvolution(const ConvolutionNode *node,
   const Node *input = node->getInput().getNode();
   if (const TransposeNode *TN = llvm::dyn_cast<TransposeNode>(input)) {
     proto->add_input(TN->getInput().getNode()->getName());
-    addValueAttribute(proto, "kernel_shape", TN->getResult().dims());
   } else {
     proto->add_input(input->getName());
-
-    addValueAttribute(proto, "kernel_shape", node->getKernels());
   }
 
   const Node *filter = node->getFilter().getNode();
@@ -435,10 +536,13 @@ llvm::Error ONNXModelWriter::writeConvolution(const ConvolutionNode *node,
     proto->add_input(filter->getName());
   }
 
+  proto->add_input(node->getBias().getNode()->getName());
+
   proto->set_name(node->getName());
   proto->set_op_type("Conv");
 
-  outputsToProto(node, proto);
+  // Use the output of transpose node.
+  outputKindToProto(Kinded::Kind::TransposeNodeKind, node, proto);
 
   return llvm::Error::success();
 }
@@ -447,32 +551,54 @@ llvm::Error
 ONNXModelWriter::writeBatchedReduceMean(const BatchedReduceMeanNode *node,
                                         GraphType &graph) {
   auto *proto = graph.add_node();
-  // Find dictionary entries.
+  // Add dictionary entries.
   addValueAttribute(proto, "axes", node->getAxes());
 
-  return writeAllWithNode("ReduceMean", node, proto);
+  proto->set_name(node->getName());
+  proto->set_op_type("ReduceMean");
+  inputsToProto(node, proto);
+
+  // Use the output of reshape node.
+  if (outputKindToProto(Kinded::Kind::ReshapeNodeKind, node, proto)) {
+    // Add dictionary entries.
+    addValueAttribute(proto, "keepdims", 1);
+  }
+
+  return llvm::Error::success();
 }
 
 llvm::Error
 ONNXModelWriter::writeBatchedReduceAdd(const BatchedReduceAddNode *node,
                                        GraphType &graph) {
   auto *proto = graph.add_node();
-  // Find dictionary entries.
-  addValueAttribute(proto, "axes", node->getAxis());
+  // Add dictionary entries.
+  unsigned_t axis = node->getAxis();
+  llvm::ArrayRef<unsigned_t> axes(axis);
+  addValueAttribute(proto, "axes", axes);
 
-  return writeAllWithNode("ReduceSum", node, proto);
+  proto->set_name(node->getName());
+  proto->set_op_type("ReduceSum");
+  inputsToProto(node, proto);
+
+  // Use the output of reshape node.
+  if (outputKindToProto(Kinded::Kind::ReshapeNodeKind, node, proto)) {
+    // Add dictionary entries.
+    addValueAttribute(proto, "keepdims", 1);
+  }
+
+  return llvm::Error::success();
 }
 
 llvm::Error
 ONNXModelWriter::writeBatchNormalization(const BatchNormalizationNode *node,
                                          GraphType &graph) {
   auto *proto = graph.add_node();
-  // Find dictionary entries.
+  // Add dictionary entries.
   addValueAttribute(proto, "epsilon", node->getEpsilon());
   addValueAttribute(proto, "momentum", node->getMomentum());
 
   proto->set_name(node->getName());
-  proto->set_op_type(node->getName());
+  proto->set_op_type("BatchNormalization");
 
   proto->add_input(node->getInput().getNode()->getName());
   proto->add_input(node->getScale().getNode()->getName());
@@ -488,7 +614,7 @@ llvm::Error
 ONNXModelWriter::writeMeanVarNormalization(const MeanVarNormalizationNode *node,
                                            GraphType &graph) {
   auto *proto = graph.add_node();
-  // Find dictionary entries.
+  // Add dictionary entries.
   addValueAttribute(proto, "channel", node->getChannelIdx());
   addValueAttribute(proto, "momentum", node->getMomentum());
 
@@ -503,11 +629,13 @@ ONNXModelWriter::writeMeanVarNormalization(const MeanVarNormalizationNode *node,
 llvm::Error ONNXModelWriter::writeSlice(const SliceNode *node,
                                         GraphType &graph) {
   auto *proto = graph.add_node();
-  // Find dictionary entries.
+  // Add dictionary entries.
   auto starts = node->getStart();
   auto outs = node->getInput().dims();
   RETURN_ERR_IF_NOT(starts.size() == outs.size(),
                     "Mismatch starts and result dimensions.");
+
+  RETURN_IF_ERR(writeAllWithNode("Slice", node, proto));
 
   if (opsetVersion_ >= 10) {
     Tensor oneDimTensorStarts(ElemKind::Int64ITy, {starts.size()});
@@ -523,9 +651,12 @@ llvm::Error ONNXModelWriter::writeSlice(const SliceNode *node,
     auto *tensorProto = graph.add_initializer();
     tensorProto->set_name(node->getName().str() + "_starts");
     writeTensor(oneDimTensorStarts, tensorProto);
+    proto->add_input(node->getName().str() + "_starts");
+
     tensorProto = graph.add_initializer();
     tensorProto->set_name(node->getName().str() + "_ends");
     writeTensor(oneDimTensorEnds, tensorProto);
+    proto->add_input(node->getName().str() + "_ends");
   } else {
     auto *attrStarts = proto->add_attribute();
     attrStarts->set_name("starts");
@@ -539,7 +670,7 @@ llvm::Error ONNXModelWriter::writeSlice(const SliceNode *node,
       attrEnds->add_ints(outs[b] + starts[b]);
     }
   }
-  return writeAllWithNode("Slice", node, proto);
+  return llvm::Error::success();
 }
 
 llvm::Error ONNXModelWriter::writePow(const PowNode *node, GraphType &graph) {
@@ -574,10 +705,19 @@ llvm::Error ONNXModelWriter::writePow(const PowNode *node, GraphType &graph) {
 
 llvm::Error ONNXModelWriter::writeTopK(const TopKNode *node, GraphType &graph) {
   auto *proto = graph.add_node();
-  // Find dictionary entries.
-  addValueAttribute(proto, "k", node->getK());
 
-  return writeAllWithNode("topK", node, proto);
+  Tensor scalar(ElemKind::Int64ITy, {1});
+  auto handle = scalar.getHandle<int64_t>();
+  handle.raw(0) = node->getK();
+
+  auto *tensorProto = graph.add_initializer();
+  tensorProto->set_name("k");
+  writeTensor(scalar, tensorProto);
+
+  RETURN_IF_ERR(writeAllWithNode("TopK", node, proto));
+
+  proto->add_input("k");
+  return llvm::Error::success();
 }
 
 llvm::Error ONNXModelWriter::writePRelu(const PReluNode *node,
@@ -589,9 +729,10 @@ llvm::Error ONNXModelWriter::writePRelu(const PReluNode *node,
 
   const auto *slope = node->getSlope().getNode();
   if (const auto *tile = llvm::dyn_cast<TileNode>(slope)) {
-    slope = unwindBroadcastInput(tile, reportedNodes_);
+    reportedNodes_.insert(tile);
+    slope = unwindBroadcastInput(tile, nullptr /* repeats */, reportedNodes_);
   }
-  if (const SplatNode *SN = llvm::dyn_cast_or_null<SplatNode>(slope)) {
+  if (const SplatNode *SN = llvm::dyn_cast<SplatNode>(slope)) {
     // Conversion a scalar to a tensor is required.
     Tensor scalar = {SN->getValue()};
     auto *tensorProto = graph.add_initializer();
@@ -599,8 +740,7 @@ llvm::Error ONNXModelWriter::writePRelu(const PReluNode *node,
     writeTensor(scalar, tensorProto);
     proto->add_input(SN->getName());
     reportedNodes_.insert(SN);
-  } else if (const ReshapeNode *RN =
-                 llvm::dyn_cast_or_null<ReshapeNode>(slope)) {
+  } else if (const ReshapeNode *RN = llvm::dyn_cast<ReshapeNode>(slope)) {
     proto->add_input(RN->getInput().getNode()->getName());
     reportedNodes_.insert(RN);
   } else {
@@ -614,7 +754,7 @@ llvm::Error ONNXModelWriter::writePRelu(const PReluNode *node,
 llvm::Error ONNXModelWriter::writeGather(const GatherNode *node,
                                          GraphType &graph) {
   auto *proto = graph.add_node();
-  // Find dictionary entries.
+  // Add dictionary entries.
   auto batchDims = node->getBatchDims();
 
   if (batchDims != 0) {
@@ -637,27 +777,30 @@ llvm::Error ONNXModelWriter::writeBatchMatMul(const BatchMatMulNode *node,
 
 llvm::Error ONNXModelWriter::writeReshape(const ReshapeNode *node,
                                           GraphType &graph) {
-  // Dimensions into the constant tensor
-  auto dims = node->getDims();
-  Tensor oneDimTensor(ElemKind::Int64ITy, {dims.size()});
-  auto handle = oneDimTensor.getHandle<int64_t>();
-  for (size_t b = 0, e = dims.size(); b < e; ++b) {
-    handle.raw(b) = dims[b];
+  // ReduceMean/ReduceSum nodes create reshape for the output.
+  // Therefore check if this reshape has BatchedReduceMean/BatchedReduceAdd
+  // node as input.
+  const Node *input = node->getInput().getNode();
+  if (llvm::dyn_cast<BatchedReduceMeanNode>(input) ||
+      llvm::dyn_cast<BatchedReduceAddNode>(input)) {
+    return llvm::Error::success();
   }
-  auto *tensorProto = graph.add_initializer();
-  tensorProto->set_name(node->getName());
-  writeTensor(oneDimTensor, tensorProto);
 
-  return writeAll("Reshape", node, graph);
+  auto *proto = graph.add_node();
+
+  // Add ints type attribute.
+  addValueAttribute(proto, "shape", node->getDims());
+
+  return writeAllWithNode("Reshape", node, proto);
 }
 
 llvm::Error ONNXModelWriter::writeBucketize(const BucketizeNode *node,
                                             GraphType &graph) {
   auto *proto = graph.add_node();
-  // Find dictionary entries.
+  // Add dictionary entries.
   addValueAttribute(proto, "boundaries", node->getBoundaries());
 
-  return writeAllWithNode(node->getName(), node, proto);
+  return writeAllWithNode("Bucketize", node, proto);
 }
 
 llvm::Error ONNXModelWriter::writeSoftMax(const SoftMaxNode *node,
@@ -674,31 +817,31 @@ llvm::Error ONNXModelWriter::writeSoftMax(const SoftMaxNode *node,
 llvm::Error ONNXModelWriter::writeReplaceNaN(const ReplaceNaNNode *node,
                                              GraphType &graph) {
   auto *proto = graph.add_node();
-  // Find dictionary entries.
+  // Add dictionary entries.
   float value = node->getValue();
   if (value != 0.0f) {
     addValueAttribute(proto, "value", value);
   }
-  return writeAllWithNode(node->getName(), node, proto);
+  return writeAllWithNode("ReplaceNaN", node, proto);
 }
 
 llvm::Error ONNXModelWriter::writeGatherRanges(const GatherRangesNode *node,
                                                GraphType &graph) {
   auto *proto = graph.add_node();
-  // Find dictionary entries.
+  // Add dictionary entries.
   addValueAttribute(proto, "maxOutputSize", node->getOutput().dims()[0]);
 
-  return writeAllWithNode(node->getName(), node, proto);
+  return writeAllWithNode("GatherRanges", node, proto);
 }
 
 llvm::Error
 ONNXModelWriter::writeSparseToDenseMask(const SparseToDenseMaskNode *node,
                                         GraphType &graph) {
   auto *proto = graph.add_node();
-  // Find dictionary entries.
+  // Add dictionary entries.
   addValueAttribute(proto, "mask", node->getMask());
 
-  return writeAllWithNode(node->getName(), node, proto);
+  return writeAllWithNode("SparseToDenseMask", node, proto);
 }
 
 llvm::Error
@@ -710,7 +853,7 @@ ONNXModelWriter::writeAdaptiveAvgPool(const AdaptiveAvgPoolNode *node,
   std::vector<size_t> output_size{outShape.h, outShape.w};
   addValueAttribute(proto, "output_size", llvm::makeArrayRef(output_size));
 
-  return writeAllWithNode(node->getName(), node, proto);
+  return writeAllWithNode("AdaptiveAvgPool", node, proto);
 }
 
 llvm::Error ONNXModelWriter::writeLocalResponseNormalization(
@@ -727,7 +870,7 @@ llvm::Error ONNXModelWriter::writeLocalResponseNormalization(
       "Can't find Transpose Node as part of LocalResponseNormalization Node.");
   proto->add_input(TN->getInput().getNode()->getName());
   reportedNodes_.insert(TN);
-  // Find dictionary entries.
+  // Add dictionary entries.
   addValueAttribute(proto, "size", 2 * node->getHalfWindowSize());
   addValueAttribute(proto, "alpha", node->getAlpha());
   addValueAttribute(proto, "beta", node->getBeta());
@@ -740,7 +883,7 @@ llvm::Error ONNXModelWriter::writeBatchBoxCox(const BatchBoxCoxNode *node,
                                               GraphType &graph) {
   auto *proto = graph.add_node();
   addValueAttribute(proto, "epsilon", node->getEpsilon());
-  return writeAllWithNode(node->getName(), node, proto);
+  return writeAllWithNode("BatchBoxCox", node, proto);
 }
 
 //===-----------------------------------------------------------------===//
@@ -749,109 +892,157 @@ llvm::Error ONNXModelWriter::writeBatchBoxCox(const BatchBoxCoxNode *node,
 llvm::Error ONNXModelWriter::writeModulo(const ModuloNode *node,
                                          GraphType &graph) {
   auto *proto = graph.add_node();
-  // Find dictionary entries.
+  // Add dictionary entries.
   addValueAttribute(proto, "divisor", node->getDivisor());
   addValueAttribute(proto, "sign_follow_divisor",
                     node->getSignFollowDivisor() ? 1 : 0);
 
-  return writeAllWithNode(node->getName(), node, proto);
+  return writeAllWithNode("Modulo", node, proto);
 }
 
-llvm::Error ONNXModelWriter::writeAvgPool(const AvgPoolNode *node,
-                                          GraphType &graph) {
-  auto *proto = graph.add_node();
-  // Find dictionary entries.
+namespace {
+template <typename T>
+void writePool(const T *node, ONNX_NAMESPACE::NodeProto *proto) {
+  // Add dictionary entries.
   addValueAttribute(proto, "kernel_shape", node->getKernels());
   addValueAttribute(proto, "strides", node->getStrides());
   addValueAttribute(proto, "pads", node->getPads());
 
-  return writeAllWithNode(node->getName(), node, proto);
+  proto->set_name(node->getName());
+
+  const Node *input = node->getInput().getNode();
+  if (const TransposeNode *TN = llvm::dyn_cast<TransposeNode>(input)) {
+    proto->add_input(TN->getInput().getNode()->getName());
+  } else {
+    proto->add_input(input->getName());
+  }
+
+  // Use the output of transpose node, if any.
+  outputKindToProto(Kinded::Kind::TransposeNodeKind, node, proto);
+}
+} // namespace
+
+llvm::Error ONNXModelWriter::writeAvgPool(const AvgPoolNode *node,
+                                          GraphType &graph) {
+  auto *proto = graph.add_node();
+  proto->set_op_type("AveragePool");
+  writePool(node, proto);
+  return llvm::Error::success();
+}
+
+llvm::Error ONNXModelWriter::writeMaxPool(const MaxPoolNode *node,
+                                          GraphType &graph) {
+  auto *proto = graph.add_node();
+  proto->set_op_type("MaxPool");
+  writePool(node, proto);
+  return llvm::Error::success();
 }
 
 llvm::Error ONNXModelWriter::writeConvolution3D(const Convolution3DNode *node,
                                                 GraphType &graph) {
   auto *proto = graph.add_node();
-  // Find dictionary entries.
+  // Add dictionary entries.
   addValueAttribute(proto, "kernel_shape", node->getKernels());
   addValueAttribute(proto, "strides", node->getStrides());
   addValueAttribute(proto, "pads", node->getPads());
   addValueAttribute(proto, "group", node->getGroup());
 
-  return writeAllWithNode(node->getName(), node, proto);
+  return writeAllWithNode("Convolution3D", node, proto);
 }
 
 llvm::Error ONNXModelWriter::writeSpaceToDepth(const SpaceToDepthNode *node,
                                                GraphType &graph) {
   auto *proto = graph.add_node();
-  // Find dictionary entries.
-  addValueAttribute(proto, "block_size", node->getBlockSize());
 
-  return writeAllWithNode(node->getName(), node, proto);
+  // Find input from Transpose node
+  const TransposeNode *TN =
+      llvm::dyn_cast<TransposeNode>(node->getInput().getNode());
+  RETURN_ERR_IF_NOT(TN,
+                    "Can't find Transpose Node as part of SpaceToDepth Node.");
+  proto->add_input(TN->getInput().getNode()->getName());
+  reportedNodes_.insert(TN);
+
+  proto->set_name(node->getName());
+  proto->set_op_type("SpaceToDepth");
+  // Add dictionary entries.
+  addValueAttribute(proto, "blocksize", node->getBlockSize());
+
+  // Use the output of transpose node, if any.
+  outputKindToProto(Kinded::Kind::TransposeNodeKind, node, proto);
+  return llvm::Error::success();
 }
 
 llvm::Error ONNXModelWriter::writeChannelShuffle(const ChannelShuffleNode *node,
                                                  GraphType &graph) {
   auto *proto = graph.add_node();
-  // Find dictionary entries.
+  // Add dictionary entries.
   addValueAttribute(proto, "group", node->getGroup());
   addValueAttribute(proto, "kernel", node->getKernel());
 
-  return writeAllWithNode(node->getName(), node, proto);
+  return writeAllWithNode("ChannelShuffle", node, proto);
 }
 
 llvm::Error
 ONNXModelWriter::writeQuantizationProfile(const QuantizationProfileNode *node,
                                           GraphType &graph) {
   auto *proto = graph.add_node();
-  // Find dictionary entries.
+  // Add dictionary entries.
   addValueAttribute(proto, "name", node->getProfiledNodeName());
   addValueAttribute(proto, "number", node->getProfiledOutputNumber());
 
-  return writeAllWithNode(node->getName(), node, proto);
+  return writeAllWithNode("QuantizationProfile", node, proto);
 }
 
 llvm::Error ONNXModelWriter::writeTraceEvent(const TraceEventNode *node,
                                              GraphType &graph) {
   auto *proto = graph.add_node();
-  // Find dictionary entries.
+  // Add dictionary entries.
   addValueAttribute(proto, "name", node->getEventName());
   addValueAttribute(proto, "type", node->getEventType());
   addValueAttribute(proto, "index", node->getIndex());
 
-  return writeAllWithNode(node->getName(), node, proto);
+  return writeAllWithNode("TraceEvent", node, proto);
 }
 
 llvm::Error ONNXModelWriter::writeInsertTensor(const InsertTensorNode *node,
                                                GraphType &graph) {
   auto *proto = graph.add_node();
-  // Find dictionary entries.
+  // Add dictionary entries.
   addValueAttribute(proto, "start", node->getStart());
   addValueAttribute(proto, "count", node->getCount());
   addValueAttribute(proto, "axis", node->getAxis());
 
-  return writeAllWithNode(node->getName(), node, proto);
+  return writeAllWithNode("InsertTensor", node, proto);
 }
 
 llvm::Error ONNXModelWriter::writeChannelwiseQuantizedConvolution(
     const ChannelwiseQuantizedConvolutionNode *node, GraphType &graph) {
   auto *proto = graph.add_node();
-  // Find dictionary entries.
+  // Add dictionary entries.
   addValueAttribute(proto, "kernel_shape", node->getKernels());
   addValueAttribute(proto, "strides", node->getStrides());
   addValueAttribute(proto, "pads", node->getPads());
   addValueAttribute(proto, "group", node->getGroup());
   addValueAttribute(proto, "group_wise", node->getGroupwise() ? 1 : 0);
 
-  return writeAllWithNode(node->getName(), node, proto);
+  return writeAllWithNode("ChannelwiseQuantizedConvolution", node, proto);
 }
 
 llvm::Error ONNXModelWriter::writeSplat(const SplatNode *node,
                                         GraphType &graph) {
   auto *proto = graph.add_node();
-  // Find dictionary entries.
-  addValueAttribute(proto, "value", node->getValue());
+  // Convert value to tensor with result shape
+  Tensor tensor(ElemKind::FloatTy, node->getResult().dims());
+  auto handle = tensor.getHandle<>();
+  float value = node->getValue();
+  for (size_t b = 0, e = tensor.size(); b < e; ++b) {
+    handle.raw(b) = value;
+  }
 
-  return writeAllWithNode(node->getName(), node, proto);
+  // Add dictionary entries.
+  addValueAttribute(proto, "value", tensor);
+
+  return writeAllWithNode("Splat", node, proto);
 }
 
 llvm::Error ONNXModelWriter::writeAdd(const AddNode *node, GraphType &graph) {
@@ -884,34 +1075,173 @@ DEF_ALL_WRITER_NODE(Log)
 DEF_ALL_WRITER_NODE(Exp)
 DEF_ALL_WRITER_NODE(Relu)
 DEF_ALL_WRITER_NODE(Tanh)
-DEF_ALL_WRITER_NODE(Tile)
 DEF_ALL_WRITER_NODE(IsNaN)
 DEF_ALL_WRITER_NODE(Sigmoid)
 DEF_ALL_WRITER_NODE(LengthsSum)
 DEF_ALL_WRITER_NODE(BatchOneHot)
-DEF_ALL_WRITER_NODE(SparseToDense)
 DEF_ALL_WRITER_NODE(LengthsToRanges)
 DEF_ALL_WRITER_NODE(SparseLengthsSum)
 DEF_ALL_WRITER_NODE(SparseLengthsWeightedSum)
-DEF_ALL_WRITER_NODE(FusedRowwiseQuantizedSparseLengthsSum)
 
 // Glow nodes with default exporting algorithm.
 DEF_ALL_WRITER_NODE(CmpEQ)
 DEF_ALL_WRITER_NODE(CmpLTE)
-DEF_ALL_WRITER_NODE(Select)
-DEF_ALL_WRITER_NODE(Quantize)
-DEF_ALL_WRITER_NODE(ConvertTo)
 DEF_ALL_WRITER_NODE(BatchedAdd)
 DEF_ALL_WRITER_NODE(Dequantize)
 DEF_ALL_WRITER_NODE(Regression)
 DEF_ALL_WRITER_NODE(ScatterAssign)
-DEF_ALL_WRITER_NODE(IntLookupTable)
-DEF_ALL_WRITER_NODE(LengthsRangeFill)
-DEF_ALL_WRITER_NODE(RescaleQuantized)
 DEF_ALL_WRITER_NODE(RowwiseQuantizedFullyConnected)
 DEF_ALL_WRITER_NODE(RowwiseQuantizedSparseLengthsWeightedSum)
+DEF_ALL_WRITER_NODE(FusedRowwiseQuantizedSparseLengthsSum)
 DEF_ALL_WRITER_NODE(FusedRowwiseQuantizedSparseLengthsWeightedSum)
-DEF_ALL_WRITER_NODE(FullyConnected)
+
+llvm::Error ONNXModelWriter::writeConvertTo(const ConvertToNode *node,
+                                            GraphType &graph) {
+  auto *proto = graph.add_node();
+  // Add dictionary entries.
+  addValueAttribute(proto, "shape", node->getResult().dims());
+
+  return writeAllWithNode("ConvertTo", node, proto);
+}
+
+llvm::Error ONNXModelWriter::writeSelect(const SelectNode *node,
+                                         GraphType &graph) {
+  auto *proto = graph.add_node();
+  // Add dictionary entries.
+  addValueAttribute(proto, "shape", node->getResult().dims());
+
+  return writeAllWithNode("Select", node, proto);
+}
+
+llvm::Error ONNXModelWriter::writeQuantize(const QuantizeNode *node,
+                                           GraphType &graph) {
+  auto *proto = graph.add_node();
+  auto outTy = node->getResult().getType();
+  // Add dictionary entries.
+  addValueAttribute(proto, "scale", outTy->getScale());
+  addValueAttribute(proto, "offset", outTy->getOffset());
+
+  return writeAllWithNode("Quantize", node, proto);
+}
+
+llvm::Error ONNXModelWriter::writeIntLookupTable(const IntLookupTableNode *node,
+                                                 GraphType &graph) {
+  auto *proto = graph.add_node();
+  // Add dictionary entries.
+  addValueAttribute(proto, "shape", node->getResult().dims());
+  NodeValue mapping = node->getMapping();
+  if (Constant *c = llvm::dyn_cast<Constant>(mapping.getNode())) {
+    auto handle = c->getHandle<int8_t>();
+    addValueAttribute(proto, "values",
+                      llvm::ArrayRef<int8_t>(handle.begin(), handle.end()));
+  } else {
+    RETURN_ERR("Mapping must be a constant type.");
+  }
+
+  return writeAllWithNode("IntLookupTable", node, proto);
+}
+
+llvm::Error
+ONNXModelWriter::writeLengthsRangeFill(const LengthsRangeFillNode *node,
+                                       GraphType &graph) {
+  auto *proto = graph.add_node();
+  // Add dictionary entries.
+  addValueAttribute(proto, "size", node->getResult().dims()[0]);
+
+  return writeAllWithNode("LengthsRangeFill", node, proto);
+}
+
+llvm::Error
+ONNXModelWriter::writeRescaleQuantized(const RescaleQuantizedNode *node,
+                                       GraphType &graph) {
+  auto *proto = graph.add_node();
+  auto outTy = node->getResult().getType();
+  // Add dictionary entries.
+  addValueAttribute(proto, "scale", outTy->getScale());
+  addValueAttribute(proto, "offset", outTy->getOffset());
+
+  return writeAllWithNode("RescaleQuantized", node, proto);
+}
+
+llvm::Error ONNXModelWriter::writeFullyConnected(const FullyConnectedNode *node,
+                                                 GraphType &graph) {
+  auto *proto = graph.add_node();
+  proto->set_name(node->getName());
+  proto->set_op_type("FCTransposed");
+
+  const auto *input = node->getInput().getNode();
+
+  if (const auto *reshape = llvm::dyn_cast<ReshapeNode>(input)) {
+    proto->add_input(reshape->getInput().getNode()->getName());
+    reportedNodes_.insert(reshape);
+  } else {
+    proto->add_input(input->getName());
+  }
+
+  proto->add_input(node->getWeights().getNode()->getName());
+  proto->add_input(node->getBias().getNode()->getName());
+  outputsToProto(node, proto);
+  return llvm::Error::success();
+}
+
+llvm::Error ONNXModelWriter::writeSparseToDense(const SparseToDenseNode *node,
+                                                GraphType &graph) {
+  auto *proto = graph.add_node();
+
+  RETURN_IF_ERR(writeAllWithNode("SparseToDense", node, proto));
+
+  // Write dataToInferDim as additional input with initialization.
+  auto values = node->getValues();
+  auto out = node->getResult();
+  ShapeVector outDims(values.dims().begin(), values.dims().end());
+  outDims[0] = out.dims()[0];
+
+  auto outTy =
+      G_.getParent()->uniqueTypeWithNewShape(values.getType(), outDims);
+  auto *inputProto = graph.add_input();
+  tensorShapeFromInput("dataToInferDim", outTy, inputProto);
+  proto->add_input("dataToInferDim");
+  return llvm::Error::success();
+}
+
+llvm::Error ONNXModelWriter::writeTile(const TileNode *node, GraphType &graph) {
+  auto *proto = graph.add_node();
+
+  // unwind Tile
+  std::vector<size_t> repeats;
+  const TileNode *tile = unwindTile(node, &repeats, reportedNodes_);
+
+  proto->set_name("Tile");
+  proto->set_op_type("Tile");
+  // Use inputs from top tile.
+  inputsToProto(tile, proto);
+  // Use outputs from bottom tile.
+  outputsToProto(node, proto);
+
+  // Add node indices
+  auto *indices = graph.add_node();
+  indices->set_name("Constant");
+  indices->set_op_type("Constant");
+  indices->add_output("indices");
+
+  unsigned_t numDims = tile->getInput().dims().size();
+
+  DCHECK(repeats.size() == numDims);
+  // Create and populate Tensor.
+  Tensor oneDimTensor(ElemKind::Int64ITy, {numDims});
+  auto handle = oneDimTensor.getHandle<int64_t>();
+
+  for (size_t b = 0, e = repeats.size(); b < e; ++b) {
+    handle.raw(b) = repeats[b];
+  }
+
+  // Add Tensor type attribute.
+  addValueAttribute(indices, "value", oneDimTensor);
+  // Add indices as input to the Tile node
+  proto->add_input("indices");
+
+  return llvm::Error::success();
+}
 
 // Unsupported for export Glow nodes.
 #define DEF_UNSUPPORTED_STORAGE(NAME)                                          \
@@ -961,22 +1291,22 @@ DEF_UNSUPPORTED_NODE(LocalResponseNormalizationGrad)
 llvm::Error ONNXModelWriter::writeCPUMaxSplat(const CPUMaxSplatNode *node,
                                               GraphType &graph) {
   auto *proto = graph.add_node();
-  // Find dictionary entries.
+  // Add dictionary entries.
   addValueAttribute(proto, "value", node->getSplatValue());
 
-  return writeAllWithNode(node->getName(), node, proto);
+  return writeAllWithNode("CPUMaxSplat", node, proto);
 }
 
 llvm::Error ONNXModelWriter::writeCPUConvDKKC8(const CPUConvDKKC8Node *node,
                                                GraphType &graph) {
   auto *proto = graph.add_node();
-  // Find dictionary entries.
+  // Add dictionary entries.
   addValueAttribute(proto, "kernel_shape", node->getKernels());
   addValueAttribute(proto, "strides", node->getStrides());
   addValueAttribute(proto, "pads", node->getPads());
   addValueAttribute(proto, "group", node->getGroup());
 
-  return writeAllWithNode(node->getName(), node, proto);
+  return writeAllWithNode("CPUConvDKKC8", node, proto);
 }
 
 #endif // GLOW_WITH_CPU
@@ -986,47 +1316,47 @@ llvm::Error ONNXModelWriter::writeCPUConvDKKC8(const CPUConvDKKC8Node *node,
 llvm::Error ONNXModelWriter::writeOCLConvolution(const OCLConvolutionNode *node,
                                                  GraphType &graph) {
   auto *proto = graph.add_node();
-  // Find dictionary entries.
+  // Add dictionary entries.
   addValueAttribute(proto, "kernels", node->getKernels());
   addValueAttribute(proto, "strides", node->getStrides());
   addValueAttribute(proto, "pads", node->getPads());
   addValueAttribute(proto, "group", node->getGroup());
   addValueAttribute(proto, "dilation", node->getDilation());
 
-  return writeAllWithNode(node->getName(), node, proto);
+  return writeAllWithNode("OCLConvolution", node, proto);
 }
 
 llvm::Error ONNXModelWriter::writeOCLAvgPool(const OCLAvgPoolNode *node,
                                              GraphType &graph) {
   auto *proto = graph.add_node();
-  // Find dictionary entries.
+  // Add dictionary entries.
   addValueAttribute(proto, "kernel", node->getKernel());
   addValueAttribute(proto, "stride", node->getStride());
   addValueAttribute(proto, "pads", node->getPads());
 
-  return writeAllWithNode(node->getName(), node, proto);
+  return writeAllWithNode("OCLAvgPool", node, proto);
 }
 
 llvm::Error ONNXModelWriter::writeOCLMaxPool(const OCLMaxPoolNode *node,
                                              GraphType &graph) {
   auto *proto = graph.add_node();
-  // Find dictionary entries.
+  // Add dictionary entries.
   addValueAttribute(proto, "kernel", node->getKernel());
   addValueAttribute(proto, "stride", node->getStride());
   addValueAttribute(proto, "pads", node->getPads());
 
-  return writeAllWithNode(node->getName(), node, proto);
+  return writeAllWithNode("OCLMaxPool", node, proto);
 }
 
 llvm::Error
 ONNXModelWriter::writeOCLBatchedReduceAdd(const OCLBatchedReduceAddNode *node,
                                           GraphType &graph) {
   auto *proto = graph.add_node();
-  // Find dictionary entries.
+  // Add dictionary entries.
   addValueAttribute(proto, "axis", node->getAxis());
   addValueAttribute(proto, "source_axis", node->getAxisSrcSliceSize());
 
-  return writeAllWithNode(node->getName(), node, proto);
+  return writeAllWithNode("OCLBatchedReduceAdd", node, proto);
 }
 
 #endif // GLOW_WITH_OPENCL

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -589,8 +589,7 @@ llvm::Error ONNXModelLoader::loadConv(const ONNX_NAMESPACE::NodeProto &op,
   // Extra check when the 'kernel_shape' attribute exists.
   // The 'kernel_shape' attribute is redundant not mandatory.
   if (dict.count("kernel_shape")) {
-    std::vector<unsigned_t> kernelShapeAttribute =
-        getShape<unsigned_t>(dict.at("kernel_shape"));
+    auto kernelShapeAttribute = getShape<unsigned_t>(dict.at("kernel_shape"));
     RETURN_ERR_IF_NOT(
         (kernelShape[0] == kernelShapeAttribute[0] &&
          kernelShape[1] == kernelShapeAttribute[1]),
@@ -657,8 +656,7 @@ llvm::Error ONNXModelLoader::loadPool(const ONNX_NAMESPACE::NodeProto &op,
   if (dict.count("strides")) {
     strides = getShape<unsigned_t>(dict.at("strides"));
   }
-  std::vector<unsigned_t> kernels =
-      getShape<unsigned_t>(dict.at("kernel_shape"));
+  auto kernels = getShape<unsigned_t>(dict.at("kernel_shape"));
 
   if (in.dims().size() != 4 || kernels.size() != 2) {
     // Glow only handles 2D pooling currently.
@@ -1064,18 +1062,22 @@ ONNXModelLoader::loadSpaceToDepth(const ONNX_NAMESPACE::NodeProto &op,
 
 llvm::Error
 ONNXModelLoader::loadConstantOfShape(const ONNX_NAMESPACE::NodeProto &op,
-                                     const ArgumentDictionaryTy &dict) {
+                                     const ArgumentDictionaryTy &dict,
+                                     bool isSplat) {
   Tensor T(ElemKind::FloatTy, {1});
   T.getHandle().raw(0) = 0.0;
 
   if (dict.count("value")) {
     RETURN_IF_ERR(loadTensor(dict.at("value")->t(), &T));
-    RETURN_ERR_IF_NOT(T.dims().size() == 1, "Value must be a 1D vector.");
-    RETURN_ERR_IF_NOT(T.getType().getElementType() == ElemKind::FloatTy ||
-                          T.getType().getElementType() == ElemKind::Int64ITy ||
-                          T.getType().getElementType() == ElemKind::Int32ITy,
-                      T.getType().getElementName().str() +
-                          " type Value is not supported.");
+    if (!isSplat) {
+      // Validate tensor only for ConstantOfShape operator.
+      RETURN_ERR_IF_NOT(T.dims().size() == 1, "Value must be a 1D vector.");
+      RETURN_ERR_IF_NOT(
+          T.getType().getElementType() == ElemKind::FloatTy ||
+              T.getType().getElementType() == ElemKind::Int64ITy ||
+              T.getType().getElementType() == ElemKind::Int32ITy,
+          T.getType().getElementName().str() + " type Value is not supported.");
+    }
   }
 
   TypeRef ty;
@@ -1116,7 +1118,7 @@ ONNXModelLoader::loadConstantOfShape(const ONNX_NAMESPACE::NodeProto &op,
       SN = G_.createSplat(loadOperatorName(op), ty, T.getHandle().raw(0));
     }
   } else {
-    ty = G_.getParent()->uniqueType(ElemKind::FloatTy, {1});
+    ty = G_.getParent()->uniqueType(T.getType().getElementType(), T.dims());
     SN = G_.createSplat(loadOperatorName(op), ty, T.getHandle().raw(0));
   }
   RETURN_IF_ERR(addNodeAsOutput(op, SN));
@@ -1201,6 +1203,257 @@ llvm::Error ONNXModelLoader::loadWhere(const ONNX_NAMESPACE::NodeProto &op,
   return llvm::Error::success();
 }
 
+llvm::Error ONNXModelLoader::loadCmpEQ(const ONNX_NAMESPACE::NodeProto &op,
+                                       const ArgumentDictionaryTy &dict) {
+  NodeValue LHS;
+  ASSIGN_VALUE_OR_RETURN_ERR(LHS, getNodeValueByName(op.input(0)));
+  NodeValue RHS;
+  ASSIGN_VALUE_OR_RETURN_ERR(RHS, getNodeValueByName(op.input(1)));
+
+  Node *N = G_.createCmpEQ(loadOperatorName(op), LHS, RHS);
+
+  RETURN_IF_ERR(addNodeAsOutput(op, N));
+  return llvm::Error::success();
+}
+
+llvm::Error ONNXModelLoader::loadCmpLTE(const ONNX_NAMESPACE::NodeProto &op,
+                                        const ArgumentDictionaryTy &dict) {
+  NodeValue LHS;
+  ASSIGN_VALUE_OR_RETURN_ERR(LHS, getNodeValueByName(op.input(0)));
+  NodeValue RHS;
+  ASSIGN_VALUE_OR_RETURN_ERR(RHS, getNodeValueByName(op.input(1)));
+
+  Node *N = G_.createCmpLTE(loadOperatorName(op), LHS, RHS);
+
+  RETURN_IF_ERR(addNodeAsOutput(op, N));
+  return llvm::Error::success();
+}
+
+llvm::Error ONNXModelLoader::loadSelect(const ONNX_NAMESPACE::NodeProto &op,
+                                        const ArgumentDictionaryTy &dict) {
+  NodeValue Cond;
+  ASSIGN_VALUE_OR_RETURN_ERR(Cond, getNodeValueByName(op.input(0)));
+  NodeValue LHS;
+  ASSIGN_VALUE_OR_RETURN_ERR(LHS, getNodeValueByName(op.input(1)));
+  NodeValue RHS;
+  ASSIGN_VALUE_OR_RETURN_ERR(RHS, getNodeValueByName(op.input(2)));
+
+  auto shape = getShape<size_t>(dict.at("shape"));
+
+  auto outTy = G_.getParent()->uniqueType(LHS.getElementType(), shape);
+  Node *N = G_.createSelect(loadOperatorName(op), outTy, Cond, LHS, RHS);
+
+  RETURN_IF_ERR(addNodeAsOutput(op, N));
+  return llvm::Error::success();
+}
+
+llvm::Error ONNXModelLoader::loadQuantize(const ONNX_NAMESPACE::NodeProto &op,
+                                          const ArgumentDictionaryTy &dict) {
+  NodeValue in;
+  ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
+  float scale;
+  ASSIGN_VALUE_OR_RETURN_ERR(scale, loadFloat(dict.at("scale")));
+  unsigned_t offset;
+  ASSIGN_VALUE_OR_RETURN_ERR(offset, loadInt(dict.at("offset")));
+
+  auto outDims = in.getType()->dims();
+  auto outTy =
+      G_.getParent()->uniqueType(ElemKind::Int8QTy, outDims, scale, offset);
+  Node *N = G_.createQuantize(loadOperatorName(op), in, outTy);
+
+  RETURN_IF_ERR(addNodeAsOutput(op, N));
+  return llvm::Error::success();
+}
+
+llvm::Error ONNXModelLoader::loadConvertTo(const ONNX_NAMESPACE::NodeProto &op,
+                                           const ArgumentDictionaryTy &dict) {
+  NodeValue in;
+  ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
+
+  auto shape = getShape<size_t>(dict.at("shape"));
+
+  auto outTy = G_.getParent()->uniqueType(in.getElementType(), shape);
+  Node *N = G_.createConvertTo(loadOperatorName(op), in, outTy);
+
+  RETURN_IF_ERR(addNodeAsOutput(op, N));
+  return llvm::Error::success();
+}
+
+llvm::Error ONNXModelLoader::loadDequantize(const ONNX_NAMESPACE::NodeProto &op,
+                                            const ArgumentDictionaryTy &dict) {
+  NodeValue in;
+  ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
+
+  Node *N = G_.createDequantize(loadOperatorName(op), in);
+
+  RETURN_IF_ERR(addNodeAsOutput(op, N));
+  return llvm::Error::success();
+}
+
+llvm::Error ONNXModelLoader::loadRegression(const ONNX_NAMESPACE::NodeProto &op,
+                                            const ArgumentDictionaryTy &dict) {
+  NodeValue in;
+  ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
+  NodeValue expected;
+  ASSIGN_VALUE_OR_RETURN_ERR(expected, getNodeValueByName(op.input(1)));
+
+  Node *N = G_.createRegression(loadOperatorName(op), in, expected);
+
+  RETURN_IF_ERR(addNodeAsOutput(op, N));
+  return llvm::Error::success();
+}
+
+llvm::Error ONNXModelLoader::loadBatchedAdd(const ONNX_NAMESPACE::NodeProto &op,
+                                            const ArgumentDictionaryTy &dict) {
+  NodeValue batch;
+  ASSIGN_VALUE_OR_RETURN_ERR(batch, getNodeValueByName(op.input(0)));
+  NodeValue sample;
+  ASSIGN_VALUE_OR_RETURN_ERR(sample, getNodeValueByName(op.input(1)));
+
+  Node *N = G_.createBatchedAdd(loadOperatorName(op), batch, sample);
+
+  RETURN_IF_ERR(addNodeAsOutput(op, N));
+  return llvm::Error::success();
+}
+
+llvm::Error
+ONNXModelLoader::loadScatterAssign(const ONNX_NAMESPACE::NodeProto &op,
+                                   const ArgumentDictionaryTy &dict) {
+  NodeValue data;
+  ASSIGN_VALUE_OR_RETURN_ERR(data, getNodeValueByName(op.input(0)));
+  NodeValue indices;
+  ASSIGN_VALUE_OR_RETURN_ERR(indices, getNodeValueByName(op.input(1)));
+  NodeValue slices;
+  ASSIGN_VALUE_OR_RETURN_ERR(slices, getNodeValueByName(op.input(2)));
+
+  Node *N = G_.createScatterAssign(loadOperatorName(op), data, indices, slices);
+
+  RETURN_IF_ERR(addNodeAsOutput(op, N));
+  return llvm::Error::success();
+}
+
+llvm::Error
+ONNXModelLoader::loadIntLookupTable(const ONNX_NAMESPACE::NodeProto &op,
+                                    const ArgumentDictionaryTy &dict) {
+  NodeValue in;
+  ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
+
+  auto values = getShape<int8_t>(dict.at("values"));
+  auto shape = getShape<size_t>(dict.at("shape"));
+
+  auto outTy = G_.getParent()->uniqueType(in.getElementType(), shape);
+  Node *N = G_.createIntLookupTable(loadOperatorName(op), in, values, outTy);
+
+  RETURN_IF_ERR(addNodeAsOutput(op, N));
+  return llvm::Error::success();
+}
+
+llvm::Error
+ONNXModelLoader::loadLengthsRangeFill(const ONNX_NAMESPACE::NodeProto &op,
+                                      const ArgumentDictionaryTy &dict) {
+  NodeValue lengths;
+  ASSIGN_VALUE_OR_RETURN_ERR(lengths, getNodeValueByName(op.input(0)));
+  unsigned_t size;
+  ASSIGN_VALUE_OR_RETURN_ERR(size, loadInt(dict.at("size")));
+
+  Node *N = G_.createLengthsRangeFill(loadOperatorName(op), lengths, size);
+
+  RETURN_IF_ERR(addNodeAsOutput(op, N));
+  return llvm::Error::success();
+}
+
+llvm::Error
+ONNXModelLoader::loadRescaleQuantized(const ONNX_NAMESPACE::NodeProto &op,
+                                      const ArgumentDictionaryTy &dict) {
+  NodeValue in;
+  ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
+  float scale;
+  ASSIGN_VALUE_OR_RETURN_ERR(scale, loadFloat(dict.at("scale")));
+  unsigned_t offset;
+  ASSIGN_VALUE_OR_RETURN_ERR(offset, loadInt(dict.at("offset")));
+
+  auto inTy = in.getType();
+  auto outTy = G_.getParent()->uniqueType(inTy->getElementType(), inTy->dims(),
+                                          scale, offset);
+
+  Node *N = G_.createRescaleQuantized(loadOperatorName(op), in, outTy);
+
+  RETURN_IF_ERR(addNodeAsOutput(op, N));
+  return llvm::Error::success();
+}
+
+llvm::Error ONNXModelLoader::loadRowwiseQuantizedSparseLengthsWeightedSum(
+    const ONNX_NAMESPACE::NodeProto &op, const ArgumentDictionaryTy &dict) {
+  Constant *data;
+  ASSIGN_VALUE_OR_RETURN_ERR(data, getConstantByName(op.input(0)));
+  Constant *scales;
+  ASSIGN_VALUE_OR_RETURN_ERR(scales, getConstantByName(op.input(1)));
+  Constant *offsets;
+  ASSIGN_VALUE_OR_RETURN_ERR(offsets, getConstantByName(op.input(2)));
+  NodeValue weights;
+  ASSIGN_VALUE_OR_RETURN_ERR(weights, getNodeValueByName(op.input(3)));
+  NodeValue indices;
+  ASSIGN_VALUE_OR_RETURN_ERR(indices, getNodeValueByName(op.input(4)));
+  NodeValue lengths;
+  ASSIGN_VALUE_OR_RETURN_ERR(lengths, getNodeValueByName(op.input(5)));
+
+  Node *N = G_.createRowwiseQuantizedSparseLengthsWeightedSum(
+      loadOperatorName(op), data, scales, offsets, weights, indices, lengths);
+
+  RETURN_IF_ERR(addNodeAsOutput(op, N));
+  return llvm::Error::success();
+}
+
+llvm::Error ONNXModelLoader::loadFusedRowwiseQuantizedSparseLengthsWeightedSum(
+    const ONNX_NAMESPACE::NodeProto &op, const ArgumentDictionaryTy &dict) {
+  NodeValue data;
+  ASSIGN_VALUE_OR_RETURN_ERR(data, getNodeValueByName(op.input(0)));
+  NodeValue weights;
+  ASSIGN_VALUE_OR_RETURN_ERR(weights, getNodeValueByName(op.input(1)));
+  NodeValue indices;
+  ASSIGN_VALUE_OR_RETURN_ERR(indices, getNodeValueByName(op.input(2)));
+  NodeValue lengths;
+  ASSIGN_VALUE_OR_RETURN_ERR(lengths, getNodeValueByName(op.input(3)));
+
+  Node *N = G_.createFusedRowwiseQuantizedSparseLengthsWeightedSum(
+      loadOperatorName(op), data, weights, indices, lengths);
+
+  RETURN_IF_ERR(addNodeAsOutput(op, N));
+  return llvm::Error::success();
+}
+
+llvm::Error
+ONNXModelLoader::loadFullyConnected(const ONNX_NAMESPACE::NodeProto &op,
+                                    const ArgumentDictionaryTy &dict) {
+  NodeValue in;
+  ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
+  Constant *W;
+  ASSIGN_VALUE_OR_RETURN_ERR(W, getConstantByName(op.input(1)));
+  Constant *B;
+  ASSIGN_VALUE_OR_RETURN_ERR(B, getConstantByName(op.input(2)));
+
+  unsigned_t axis = 1;
+  if (dict.count("axis")) {
+    ASSIGN_VALUE_OR_RETURN_ERR(axis, loadInt(dict.at("axis")));
+  }
+
+  Node *N = G_.createFullyConnected(loadOperatorName(op), in, W, B, axis);
+
+  RETURN_IF_ERR(addNodeAsOutput(op, N));
+  return llvm::Error::success();
+}
+
+llvm::Error ONNXModelLoader::loadSplat(const ONNX_NAMESPACE::NodeProto &op,
+                                       const ArgumentDictionaryTy &dict) {
+  return loadConstantOfShape(op, dict, true /* isSplat */);
+}
+
+llvm::Error ONNXModelLoader::loadRowwiseQuantizedFullyConnected(
+    const ONNX_NAMESPACE::NodeProto &op, const ArgumentDictionaryTy &dict) {
+  // TODO
+  RETURN_ERR("Not implemented.");
+}
+
 llvm::Error ONNXModelLoader::loadOperator(const ONNX_NAMESPACE::NodeProto &op) {
   ArgumentDictionaryTy dict = loadArgumentMap(op);
   const std::string &typeName = op.op_type();
@@ -1265,13 +1518,65 @@ llvm::Error ONNXModelLoader::loadOperator(const ONNX_NAMESPACE::NodeProto &op) {
     return loadSpaceToDepth(op, dict);
   }
   if (typeName == "ConstantOfShape") {
-    return loadConstantOfShape(op, dict);
+    return loadConstantOfShape(op, dict, false /* isSplat */);
   }
   if (typeName == "Tile") {
     return loadTile(op, dict);
   }
   if (typeName == "Where") {
     return loadWhere(op, dict);
+  }
+  // Glow specific operators
+  if (typeName == "CmpEQ") {
+    return loadCmpEQ(op, dict);
+  }
+  if (typeName == "CmpLTE") {
+    return loadCmpLTE(op, dict);
+  }
+  if (typeName == "Select") {
+    return loadSelect(op, dict);
+  }
+  if (typeName == "Quantize") {
+    return loadQuantize(op, dict);
+  }
+  if (typeName == "ConvertTo") {
+    return loadConvertTo(op, dict);
+  }
+  if (typeName == "Dequantize") {
+    return loadDequantize(op, dict);
+  }
+  if (typeName == "Regression") {
+    return loadRegression(op, dict);
+  }
+  if (typeName == "BatchedAdd") {
+    return loadBatchedAdd(op, dict);
+  }
+  if (typeName == "ScatterAssign") {
+    return loadScatterAssign(op, dict);
+  }
+  if (typeName == "IntLookupTable") {
+    return loadIntLookupTable(op, dict);
+  }
+  if (typeName == "LengthsRangeFill") {
+    return loadLengthsRangeFill(op, dict);
+  }
+  if (typeName == "RescaleQuantized") {
+    return loadRescaleQuantized(op, dict);
+  }
+  if (typeName == "RowwiseQuantizedSparseLengthsWeightedSum") {
+    return loadRowwiseQuantizedSparseLengthsWeightedSum(op, dict);
+  }
+  if (typeName == "FusedRowwiseQuantizedSparseLengthsWeightedSum") {
+    return loadFusedRowwiseQuantizedSparseLengthsWeightedSum(op, dict);
+  }
+  if (typeName == "FullyConnected") {
+    return loadFullyConnected(op, dict);
+  }
+  if (typeName == "RowwiseQuantizedFullyConnected") {
+    return loadRowwiseQuantizedFullyConnected(op, dict);
+  }
+  if (typeName == "Splat") {
+    return loadSplat(op, dict);
   }
 
   RETURN_ERR("Failed to load operator " + typeName + " .",

--- a/tests/unittests/OnnxExporterTest.cpp
+++ b/tests/unittests/OnnxExporterTest.cpp
@@ -38,8 +38,13 @@ void testLoadAndSaveONNXModel(const std::string &name) {
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
 
+  size_t irVer = 0, opsetVer = 0;
   llvm::Error err = llvm::Error::success();
-  ONNXModelLoader onnxLD(name, {}, {}, *F, &err);
+  {
+    ONNXModelLoader onnxLD(name, {}, {}, *F, &err);
+    irVer = onnxLD.getIrVersion();
+    opsetVer = onnxLD.getOpSetVersion();
+  }
 
   ASSERT_FALSE(handleErrors(std::move(err), [&name](const GlowErr &GE) {
     llvm::errs() << "ONNXModelLoader failed to load model: " << name << ": ";
@@ -48,9 +53,19 @@ void testLoadAndSaveONNXModel(const std::string &name) {
   }));
 
   std::string outputFilename(name + ".output.onnxtxt");
-  { ONNXModelWriter onnxWR(outputFilename, *F, 1, 1, &err, true); }
+  { ONNXModelWriter onnxWR(outputFilename, *F, irVer, opsetVer, &err, true); }
+
+  if (err) {
+    llvm::errs() << "ONNXModelWriter failed to write model: " << name << ".\n";
+    llvm::sys::fs::remove(outputFilename);
+    EXPECT_FALSE(err);
+  }
+
+  Function *R = mod.createFunction("reload");
+  { ONNXModelLoader onnxLD(outputFilename, {}, {}, *R, &err); }
   llvm::sys::fs::remove(outputFilename);
-  EXPECT_FALSE(err) << "file name: " << name;
+  EXPECT_FALSE(err) << "ONNXModelLoader failed to reload model: "
+                    << outputFilename;
 }
 } // namespace
 
@@ -62,9 +77,36 @@ TEST(exporter, onnxModels) {
        !code && dirIt != llvm::sys::fs::directory_iterator();
        dirIt.increment(code)) {
     auto name = dirIt->path();
-    if (name.find("preluInvalidBroadcastSlope.onnxtxt") != std::string::npos) {
+    if (name.find("/preluInvalidBroadcastSlope.onnxtxt") != std::string::npos ||
+        name.find("/padReflect.onnxtxt") != std::string::npos ||
+        name.find("/gatherConstantFolding.onnxtxt") != std::string::npos ||
+        name.find("/averagePool3D.onnxtxt") != std::string::npos ||
+        name.find("/sparseLengthsSum.onnxtxt") != std::string::npos ||
+        name.find("/constantOfShapeInt32Fail.onnxtxt") != std::string::npos ||
+        name.find("/padEdge.onnxtxt") != std::string::npos ||
+        name.find("/castToFloat.onnxtxt") != std::string::npos ||
+        name.find("/castToFloat16.onnxtxt") != std::string::npos ||
+        name.find("/castToInt64.onnxtxt") != std::string::npos ||
+        name.find("/castToInt32.onnxtxt") != std::string::npos ||
+        name.find("/Where.onnxtxt") != std::string::npos ||
+        name.find("/constantOfShapeInt64Fail.onnxtxt") != std::string::npos) {
+      // Ignore invalid ONNX files and graphs without nodes.
+      llvm::outs() << "Ignore invalid input files: " << name << "\n";
       continue;
     }
+    if (name.find("/constant.onnxtxt") != std::string::npos ||
+        name.find("/shape.onnxtxt") != std::string::npos ||
+        name.find("/sum1.onnxtxt") != std::string::npos) {
+      // Ignore invalid ONNX files and graphs without nodes.
+      llvm::outs() << "Ignore empty graph file: " << name << "\n";
+      continue;
+    }
+    if (name.find(".output.onnxtxt") != std::string::npos) {
+      // Ignore output files - debugging mode only.
+      llvm::outs() << "Ignore output file: " << name << "\n";
+      continue;
+    }
+
     testLoadAndSaveONNXModel(dirIt->path());
   }
 }


### PR DESCRIPTION


Summary:
Glow uses ONNX protobufs for Graph serialization (writer) and deserialization (loader).
Documentation:

[Optional Fixes #issue]

Test Plan:

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
