### PR TITLE
Add FP16 versions of RWQ-SLWS

### DIFF
--- a/docs/Quantization.md
+++ b/docs/Quantization.md
@@ -238,10 +238,12 @@ fused inline with the data. Caffe2 implements nodes with fused storage, such as
 [SparseLengthsWeightedSum](https://caffe2.ai/docs/operators-catalogue.html#sparselengthsweightedsumfused8bitrowwise). Glow
 supports such fused Nodes/Instructions, for example
 `FusedRowwiseQuantizedSparseLengthsWeightedSum`. The `ElemKind` of fused tensors
-is `UInt8FusedQTy`. Tensors with `UInt8FusedQTy` are 2-dimensional, and have an
-extra 8 columns for each row. The first extra 4 bytes are the scale of the row,
-and the second extra 4 bytes are the offset. Note that similar to normal
-row-wise quantized tensors, they use a dummy scale and offset in the Type.
+is either `UInt8FusedQTy` or `UInt8FusedFP16QTy`. Tensors with these `ElemKind`s
+are 2-dimensional, and have extra columns for each row to store scales and
+offsets for that row. `UInt8FusedQTy` stores scales and offsets as float (so
+there are 8 extra columns), while `UInt8FusedFP16QTy` stores them as float16_t
+(so there are 4 extra columns). Note that similar to normal row-wise quantized
+tensors, they use a dummy scale and offset in the Type.
 
 ### Conversion formula when using row-wise quantization
 

--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -138,31 +138,40 @@ public:
       std::fill(&data[0], &data[0] + size(), (int32_t)type_.getOffset());
       break;
     }
-    case ElemKind::UInt8FusedQTy: {
-      assert(dims().size() == 2 && "Fused tensor must be 2-dimensional.");
-      assert(dims()[1] > 8 && "Fused tensor must have more than 8 columns.");
-      const size_t width = dims()[1];
-      auto *data = reinterpret_cast<uint8_t *>(getData());
-      for (size_t i = 0, e = dims()[0]; i < e; i++) {
-        uint8_t *scaleOffsetPtr = &data[(i + 1) * width] - 2 * sizeof(float);
-        float scale, offset;
-        if (resetFusedScalesOffsets) {
-          // Use these as defaults, and copy them into each row.
-          scale = 1.0;
-          offset = 0.0;
-          memcpy(scaleOffsetPtr, &scale, sizeof(float));
-          memcpy(scaleOffsetPtr + sizeof(float), &offset, sizeof(float));
-        } else {
-          memcpy(&scale, scaleOffsetPtr, sizeof(float));
-          memcpy(&offset, scaleOffsetPtr + sizeof(float), sizeof(float));
-        }
-        assert(scale != 0.0 &&
-               "Disallow scale = 0.0 for UInt8FusedQTy; causes div by zero.");
-        float zero = nearbyintf(-offset / scale);
-        std::fill(&data[i * width], scaleOffsetPtr, static_cast<uint8_t>(zero));
-      }
-      break;
-    }
+
+#define FUSED_CASE(ELEM_KIND, DATA_TYPE)                                       \
+  case ElemKind::ELEM_KIND: {                                                  \
+    assert(dims().size() == 2 && "Fused tensor must be 2-dimensional.");       \
+    assert(dims()[1] > 8 && "Fused tensor must have more than 8 columns.");    \
+    const size_t width = dims()[1];                                            \
+    auto *data = reinterpret_cast<uint8_t *>(getData());                       \
+    for (size_t i = 0, e = dims()[0]; i < e; i++) {                            \
+      uint8_t *scaleOffsetPtr =                                                \
+          &data[(i + 1) * width] - 2 * sizeof(DATA_TYPE);                      \
+      DATA_TYPE scale, offset;                                                 \
+      if (resetFusedScalesOffsets) {                                           \
+        /* Use these as defaults, and copy them into each row. */              \
+        scale = 1.0;                                                           \
+        offset = 0.0;                                                          \
+        memcpy(scaleOffsetPtr, &scale, sizeof(DATA_TYPE));                     \
+        memcpy(scaleOffsetPtr + sizeof(DATA_TYPE), &offset,                    \
+               sizeof(DATA_TYPE));                                             \
+      } else {                                                                 \
+        memcpy(&scale, scaleOffsetPtr, sizeof(DATA_TYPE));                     \
+        memcpy(&offset, scaleOffsetPtr + sizeof(DATA_TYPE),                    \
+               sizeof(DATA_TYPE));                                             \
+      }                                                                        \
+      assert((float)scale != 0.0 &&                                            \
+             "Disallow scale = 0.0 for UInt8FusedQTy; causes div by zero.");   \
+      float zero = nearbyintf(((DATA_TYPE)-1) * offset / scale);               \
+      std::fill(&data[i * width], scaleOffsetPtr, static_cast<uint8_t>(zero)); \
+    }                                                                          \
+    break;                                                                     \
+  }
+      FUSED_CASE(UInt8FusedQTy, float);
+      FUSED_CASE(UInt8FusedFP16QTy, float16_t);
+#undef FUSED_CASE
+
     default:
       // Non-quantized tensors are set to 0.
       std::fill(&getData()[0], &getData()[0] + size() * type_.getElementSize(),
@@ -243,7 +252,7 @@ public:
 
   /// Initialize the content of the tensor using the \p init method. The value
   /// \p val is the initialization parameter. \p PRNG is used to generate random
-  /// numbers. Note that if the tensor's kind is UInt8FusedQTy, then the fused
+  /// numbers. Note that if the tensor's kind is Fused, then the fused
   /// scaled/offsets will not be modified.
   void init(InitKind init, float val, PseudoRNG &PRNG);
 
@@ -412,15 +421,17 @@ public:
     }
 
     // For now, make sure that either both or neither of the tensors have
-    // UInt8FusedQTy. While it is possible for an Int8QTy tensor to equal a
-    // UInt8FusedQTy tensor if the UInt8FusedQTy tensor has the same
+    // UInt8FusedQTy or UInt8Fused16QTy. While it is possible for an Int8QTy
+    // tensor to equal a fused tensor if the fused tensor has the same
     // scale/offset on all of its rows, and that scale/offset match that of the
     // Int8QTy, we do not support checking this for now.
     assert(((getElementType() == ElemKind::UInt8FusedQTy &&
              other.getElementType() == ElemKind::UInt8FusedQTy) ||
-            (getElementType() != ElemKind::UInt8FusedQTy &&
+            (getElementType() == ElemKind::UInt8FusedFP16QTy &&
+             other.getElementType() == ElemKind::UInt8FusedFP16QTy) ||
+            (getElementType() != ElemKind::UInt8FusedFP16QTy &&
              other.getElementType() != ElemKind::UInt8FusedQTy)) &&
-           "UInt8FusedQTy only supports comparing against same ElemKind.");
+           "Fused ElemKinds only supports comparing against same ElemKind.");
 
     switch (getElementType()) {
     case ElemKind::FloatTy:
@@ -459,6 +470,8 @@ public:
       // compared as if they were data, so we will return false if any rowwise
       // scale/offset do not match.
     case ElemKind::UInt8FusedQTy:
+      return isEqualImpl<uint8_t>(other, allowedError, verbose);
+    case ElemKind::UInt8FusedFP16QTy:
       return isEqualImpl<uint8_t>(other, allowedError, verbose);
     case ElemKind::BoolTy:
       return isEqualImpl<bool>(other, allowedError, verbose);
@@ -856,25 +869,34 @@ public:
   /// \p allowedError represents the delta from zero that is allowed before
   /// returning false.
   bool isZero(float allowedError = 0.0) const {
+#define RETURN_WHETHER_FUSED_IS_ZERO(DATA_TYPE)                                \
+  assert(dims().size() == 2 && "Fused tensor must be 2-dimensional.");         \
+  assert(dims()[1] > 2 * sizeof(DATA_TYPE) &&                                  \
+         "Fused tensor must have space for scale/offset.");                    \
+  const size_t width = dims()[1];                                              \
+  auto *data = reinterpret_cast<uint8_t *>(tensor_->getUnsafePtr());           \
+  for (size_t i = 0, e = dims()[0]; i < e; i++) {                              \
+    uint8_t *scaleOffsetPtr = &data[(i + 1) * width] - 2 * sizeof(DATA_TYPE);  \
+    DATA_TYPE scale, offset;                                                   \
+    memcpy(&scale, scaleOffsetPtr, sizeof(DATA_TYPE));                         \
+    memcpy(&offset, scaleOffsetPtr + sizeof(DATA_TYPE), sizeof(DATA_TYPE));    \
+    for (size_t j = 0, e = width - 2 * sizeof(DATA_TYPE); j < e; j++) {        \
+      float currVal = (at({i, j}) * (float)scale) + (float)offset;             \
+      if (std::abs(currVal) > allowedError) {                                  \
+        return false;                                                          \
+      }                                                                        \
+    }                                                                          \
+  }                                                                            \
+  return true;
+
     if (getElementType() == ElemKind::UInt8FusedQTy) {
-      assert(dims().size() == 2 && "Fused tensor must be 2-dimensional.");
-      assert(dims()[1] > 8 && "Fused tensor must have more than 8 columns.");
-      const size_t width = dims()[1];
-      auto *data = reinterpret_cast<uint8_t *>(tensor_->getUnsafePtr());
-      for (size_t i = 0, e = dims()[0]; i < e; i++) {
-        uint8_t *scaleOffsetPtr = &data[(i + 1) * width] - 2 * sizeof(float);
-        float scale, offset;
-        memcpy(&scale, scaleOffsetPtr, sizeof(float));
-        memcpy(&offset, scaleOffsetPtr + sizeof(float), sizeof(float));
-        for (size_t j = 0, e = width - 2 * sizeof(float); j < e; j++) {
-          float currVal = (at({i, j}) * scale) + offset;
-          if (std::abs(currVal) > allowedError) {
-            return false;
-          }
-        }
-      }
-      return true;
+      RETURN_WHETHER_FUSED_IS_ZERO(float);
     }
+    if (getElementType() == ElemKind::UInt8FusedFP16QTy) {
+      RETURN_WHETHER_FUSED_IS_ZERO(float16_t);
+    }
+#undef RETURN_WHETHER_FUSED_IS_ZERO
+
     int32_t trueZero = getType().isQuantizedType() ? getType().getOffset() : 0;
     return std::all_of(begin(), end(), [=](ElemTy e) { return e == trueZero; });
   }
@@ -934,16 +956,22 @@ public:
       }
       return;
     }
-    case ElemKind::UInt8FusedQTy: {
-      assert(dims().size() == 2 && "Fused tensor must be 2-dimensional.");
-      assert(dims()[1] > 8 && "Fused tensor must have more than 8 columns.");
-      for (size_t i = 0, e = dims()[0]; i < e; i++) {
-        for (size_t j = 0, f = dims()[1] - 8; j < f; j++) {
-          at({i, j}) = dist(PRNG);
-        }
-      }
-      return;
-    }
+
+#define FUSED_CASE(ELEM_KIND, DATA_TYPE)                                       \
+  case ElemKind::ELEM_KIND: {                                                  \
+    assert(dims().size() == 2 && "Fused tensor must be 2-dimensional.");       \
+    assert(dims()[1] > 2 * sizeof(DATA_TYPE) &&                                \
+           "Fused tensor must have space for scale/offset.");                  \
+    for (size_t i = 0, e = dims()[0]; i < e; i++) {                            \
+      for (size_t j = 0, f = dims()[1] - 2 * sizeof(DATA_TYPE); j < f; j++) {  \
+        at({i, j}) = dist(PRNG);                                               \
+      }                                                                        \
+    }                                                                          \
+    return;                                                                    \
+  }
+      FUSED_CASE(UInt8FusedQTy, float);
+      FUSED_CASE(UInt8FusedFP16QTy, float16_t);
+#undef FUSED_CASE
     }
   }
 

--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -265,23 +265,40 @@ inline bool operator==(const ShapeNHWDC &LHS, const ShapeNHWDC &RHS) {
 /// When adding new type, note that this enum definition must match with
 /// ElemKind definition in Glow/lib/Backends/CPU/libjit/libjit.cpp
 enum class ElemKind : unsigned char {
-  FloatTy,       // 32-bit float type (float)
-  Float16Ty,     // 16-bit float type (half, fp16)
-  Int8QTy,       // 8-bit quantized type (int8_t)
-  UInt8QTy,      // unsigned 8-bit quantized type (uint8_t)
-  Int16QTy,      // 16-bit quantized type (int16_t)
-  Int32QTy,      // 32-bit quantized type (int32_t)
-  Int32ITy,      // 32-bit index type (int32_t)
-  Int64ITy,      // 64-bit index type (int64_t)
-  UInt8FusedQTy, // 8-bit quantized type with fused scale/offset (uint8_t)
-  BoolTy,        // Bool type (bool)
+  // 32-bit float type (float)
+  FloatTy,
+  // 16-bit float type (half, fp16)
+  Float16Ty,
+  // 8-bit quantized type (int8_t)
+  Int8QTy,
+  // unsigned 8-bit quantized type (uint8_t)
+  UInt8QTy,
+  // 16-bit quantized type (int16_t)
+  Int16QTy,
+  // 32-bit quantized type (int32_t)
+  Int32QTy,
+  // 32-bit index type (int32_t)
+  Int32ITy,
+  // 64-bit index type (int64_t)
+  Int64ITy,
+  // 8-bit quantized type with fused scale/offset (uint8_t)
+  UInt8FusedQTy,
+  // 8-bit quantized type with fused FP16 scale/offset (uint8_t)
+  UInt8FusedFP16QTy,
+  // Bool type (bool)
+  BoolTy,
 };
 
 /// \returns whether \p e is a quantized ElemKind.
 inline bool isQuantizedElemKind(ElemKind e) {
   return e == ElemKind::Int8QTy || e == ElemKind::UInt8QTy ||
          e == ElemKind::Int16QTy || e == ElemKind::Int32QTy ||
-         e == ElemKind::UInt8FusedQTy;
+         e == ElemKind::UInt8FusedQTy || e == ElemKind::UInt8FusedFP16QTy;
+}
+
+/// \returns whether \p e is a fused quantized ElemKind.
+inline bool isFusedQuantizedElemKind(ElemKind e) {
+  return e == ElemKind::UInt8FusedQTy || e == ElemKind::UInt8FusedFP16QTy;
 }
 
 /// A class that represents a type of a tensor.
@@ -471,6 +488,8 @@ struct Type final {
       return std::is_same<ElemTy, int64_t>::value;
     case ElemKind::UInt8FusedQTy:
       return std::is_same<ElemTy, uint8_t>::value;
+    case ElemKind::UInt8FusedFP16QTy:
+      return std::is_same<ElemTy, uint8_t>::value;
     case ElemKind::BoolTy:
       return std::is_same<ElemTy, bool>::value;
     }
@@ -514,6 +533,8 @@ struct Type final {
       return sizeof(int64_t);
     case ElemKind::UInt8FusedQTy:
       return sizeof(uint8_t);
+    case ElemKind::UInt8FusedFP16QTy:
+      return sizeof(uint8_t);
     case ElemKind::BoolTy:
       return sizeof(bool);
     }
@@ -528,8 +549,8 @@ struct Type final {
   /// \return the textual name of the element \p Ty.
   static llvm::StringRef getElementName(ElemKind Ty) {
     static const char *names[] = {
-        "float", "float16", "i8",      "ui8",      "i16",
-        "i32",   "index32", "index64", "ui8fused", "bool",
+        "float",   "float16", "i8",       "ui8",          "i16",  "i32",
+        "index32", "index64", "ui8fused", "ui8fusedfp16", "bool",
     };
     return names[(int)Ty];
   }

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -830,17 +830,21 @@ public:
   /// accumulates them into len(\p lengths) entries: first Lengths[0] slices are
   /// aggregated to Result[0], next Lengths[1] slices are aggregated to
   /// Result[1], etc. I.e. sum(Lengths) must be equal to len(Indices).
+  /// \p precision represents what precision to use for Scale, Offset, and
+  /// Result.
   RowwiseQuantizedSparseLengthsWeightedSumNode *
-  createRowwiseQuantizedSparseLengthsSum(llvm::StringRef name, Constant *data,
-                                         Constant *scales, Constant *offsets,
-                                         NodeValue indices, NodeValue lengths);
+  createRowwiseQuantizedSparseLengthsSum(
+      llvm::StringRef name, Constant *data, Constant *scales, Constant *offsets,
+      NodeValue indices, NodeValue lengths,
+      ElemKind precision = ElemKind::FloatTy);
 
   /// Same as \ref createRowwiseQuantizedSparseLengthsSum(), but expects
   /// float input \p data, which is rowwise-quantized internally.
   RowwiseQuantizedSparseLengthsWeightedSumNode *
   createRowwiseQuantizedSparseLengthsSum(llvm::StringRef name, Tensor &data,
                                          NodeValue indices, NodeValue lengths,
-                                         quantization::Schema schema);
+                                         quantization::Schema schema,
+                                         ElemKind precision);
 
   /// Same as \ref createRowwiseQuantizedSparseLengthsSum(), but i-th slice is
   /// multiplied by weights[i]. len(weights) must be equal to len(indices).

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -867,18 +867,20 @@ public:
   /// dimension of data indexed by the \p indices vector, and then accumulates
   /// them into len(\p lengths) entries: first Lengths[0] slices are aggregated
   /// to Result[0], next Lengths[1] slices are aggregated to Result[1], etc.
-  /// I.e. sum(Lengths) must be equal to len(Indices).
+  /// I.e. sum(Lengths) must be equal to len(Indices). \p precision represents
+  /// what precision to use for Scale, Offset, and Result.
+
   FusedRowwiseQuantizedSparseLengthsSumNode *
-  createFusedRowwiseQuantizedSparseLengthsSum(llvm::StringRef name,
-                                              Constant *data, NodeValue indices,
-                                              NodeValue lengths);
+  createFusedRowwiseQuantizedSparseLengthsSum(
+      llvm::StringRef name, Constant *data, NodeValue indices,
+      NodeValue lengths, ElemKind precision = ElemKind::FloatTy);
 
   /// Same as \ref createFusedRowwiseQuantizedSparseLengthsSum(), but expects
   /// float input \p data, which is rowwise-quantized and fused internally.
   FusedRowwiseQuantizedSparseLengthsSumNode *
-  createFusedRowwiseQuantizedSparseLengthsSum(llvm::StringRef name,
-                                              Tensor &data, NodeValue indices,
-                                              NodeValue lengths);
+  createFusedRowwiseQuantizedSparseLengthsSum(
+      llvm::StringRef name, Tensor &data, NodeValue indices, NodeValue lengths,
+      ElemKind precision = ElemKind::FloatTy);
 
   /// Same as \ref createFusedRowwiseQuantizedSparseLengthsSum(), but i-th slice
   /// is multiplied by weights[i]. len(weights) must be equal to len(indices).

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -851,14 +851,16 @@ public:
   RowwiseQuantizedSparseLengthsWeightedSumNode *
   createRowwiseQuantizedSparseLengthsWeightedSum(
       llvm::StringRef name, Constant *data, Constant *scales, Constant *offsets,
-      NodeValue weights, NodeValue indices, NodeValue lengths);
+      NodeValue weights, NodeValue indices, NodeValue lengths,
+      ElemKind precision = ElemKind::FloatTy);
 
   /// Same as \ref createRowwiseQuantizedSparseLengthsWeightedSum(), but expects
   /// float input \p data, which is rowwise-quantized internally.
   RowwiseQuantizedSparseLengthsWeightedSumNode *
   createRowwiseQuantizedSparseLengthsWeightedSum(
       llvm::StringRef name, Tensor &data, NodeValue weights, NodeValue indices,
-      NodeValue lengths, quantization::Schema schema);
+      NodeValue lengths, quantization::Schema schema,
+      ElemKind precision = ElemKind::FloatTy);
 
   /// Creates and \returns a node of \p name, performing the SparseLengthsSum
   /// operation, using fused rowwise quantization for the input \p data wherein
@@ -869,7 +871,6 @@ public:
   /// to Result[0], next Lengths[1] slices are aggregated to Result[1], etc.
   /// I.e. sum(Lengths) must be equal to len(Indices). \p precision represents
   /// what precision to use for Scale, Offset, and Result.
-
   FusedRowwiseQuantizedSparseLengthsSumNode *
   createFusedRowwiseQuantizedSparseLengthsSum(
       llvm::StringRef name, Constant *data, NodeValue indices,
@@ -885,21 +886,18 @@ public:
   /// Same as \ref createFusedRowwiseQuantizedSparseLengthsSum(), but i-th slice
   /// is multiplied by weights[i]. len(weights) must be equal to len(indices).
   FusedRowwiseQuantizedSparseLengthsWeightedSumNode *
-  createFusedRowwiseQuantizedSparseLengthsWeightedSum(llvm::StringRef name,
-                                                      NodeValue data,
-                                                      NodeValue weights,
-                                                      NodeValue indices,
-                                                      NodeValue lengths);
+  createFusedRowwiseQuantizedSparseLengthsWeightedSum(
+      llvm::StringRef name, NodeValue data, NodeValue weights,
+      NodeValue indices, NodeValue lengths,
+      ElemKind precision = ElemKind::FloatTy);
 
   /// Same as \ref createFusedRowwiseQuantizedSparseLengthsWeightedSum(), but
   /// expects float input \p data, which is rowwise-quantized and fused
   /// internally.
   FusedRowwiseQuantizedSparseLengthsWeightedSumNode *
-  createFusedRowwiseQuantizedSparseLengthsWeightedSum(llvm::StringRef name,
-                                                      Tensor &data,
-                                                      NodeValue weights,
-                                                      NodeValue indices,
-                                                      NodeValue lengths);
+  createFusedRowwiseQuantizedSparseLengthsWeightedSum(
+      llvm::StringRef name, Tensor &data, NodeValue weights, NodeValue indices,
+      NodeValue lengths, ElemKind precision = ElemKind::FloatTy);
 
   /// Given a vector of segment lengths, calculates offsets of each segment and
   /// packs them next to the lengths. For the input vector of length N the

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -253,6 +253,19 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
             ElemKind::Int32ITy);
 
   case Kinded::Kind::FusedRowwiseQuantizedSparseLengthsWeightedSumNodeKind:
+    if (NI.getInElemTy(
+            FusedRowwiseQuantizedSparseLengthsWeightedSumNode::DataIdx) ==
+        ElemKind::UInt8FusedFP16QTy) {
+      return (NI.getInElemTy(FusedRowwiseQuantizedSparseLengthsWeightedSumNode::
+                                 WeightsIdx) == ElemKind::Float16Ty) &&
+             (NI.getInElemTy(FusedRowwiseQuantizedSparseLengthsWeightedSumNode::
+                                 IndicesIdx) == ElemKind::Int64ITy) &&
+             (NI.getInElemTy(FusedRowwiseQuantizedSparseLengthsWeightedSumNode::
+                                 LengthsIdx) == ElemKind::Int32ITy) &&
+             (NI.getOutElemTy(
+                  FusedRowwiseQuantizedSparseLengthsWeightedSumNode::
+                      ResultIdx) == ElemKind::Float16Ty);
+    }
     return (NI.getInElemTy(
                 FusedRowwiseQuantizedSparseLengthsWeightedSumNode::DataIdx) ==
             ElemKind::UInt8FusedQTy) &&

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -237,27 +237,20 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
             ElemKind::Int32ITy);
 
   case Kinded::Kind::RowwiseQuantizedSparseLengthsWeightedSumNodeKind:
-    return (NI.getInElemTy(
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::FloatTy, ElemKind::Float16Ty},
+               {RowwiseQuantizedSparseLengthsWeightedSumNode::DataIdx,
+                RowwiseQuantizedSparseLengthsWeightedSumNode::IndicesIdx,
+                RowwiseQuantizedSparseLengthsWeightedSumNode::LengthsIdx}) &&
+           (NI.getInElemTy(
                 RowwiseQuantizedSparseLengthsWeightedSumNode::DataIdx) ==
             ElemKind::UInt8QTy) &&
-           (NI.getInElemTy(
-                RowwiseQuantizedSparseLengthsWeightedSumNode::ScalesIdx) ==
-            ElemKind::FloatTy) &&
-           (NI.getInElemTy(
-                RowwiseQuantizedSparseLengthsWeightedSumNode::OffsetsIdx) ==
-            ElemKind::FloatTy) &&
-           (NI.getInElemTy(
-                RowwiseQuantizedSparseLengthsWeightedSumNode::WeightsIdx) ==
-            ElemKind::FloatTy) &&
            (NI.getInElemTy(
                 RowwiseQuantizedSparseLengthsWeightedSumNode::IndicesIdx) ==
             ElemKind::Int64ITy) &&
            (NI.getInElemTy(
                 RowwiseQuantizedSparseLengthsWeightedSumNode::LengthsIdx) ==
-            ElemKind::Int32ITy) &&
-           (NI.getOutElemTy(
-                RowwiseQuantizedSparseLengthsWeightedSumNode::ResultIdx) ==
-            ElemKind::FloatTy);
+            ElemKind::Int32ITy);
 
   case Kinded::Kind::FusedRowwiseQuantizedSparseLengthsWeightedSumNodeKind:
     return (NI.getInElemTy(

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -265,6 +265,10 @@ private:
                                    TensorQuantizationParams &destQ);
 
   template <typename ElemTy> void fwdModuloInstImpl(glow::ModuloInst const *I);
+
+  template <typename T>
+  void fwdRowwiseQuantizedSparseLengthsWeightedSumImpl(
+      const RowwiseQuantizedSparseLengthsWeightedSumInst *I);
   ///@}
 };
 

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -269,6 +269,10 @@ private:
   template <typename T>
   void fwdRowwiseQuantizedSparseLengthsWeightedSumImpl(
       const RowwiseQuantizedSparseLengthsWeightedSumInst *I);
+
+  template <typename T>
+  void fwdFusedRowwiseQuantizedSparseLengthsWeightedSumImpl(
+      const FusedRowwiseQuantizedSparseLengthsWeightedSumInst *I);
   ///@}
 };
 

--- a/lib/Exporter/ONNXModelWriter.cpp
+++ b/lib/Exporter/ONNXModelWriter.cpp
@@ -276,6 +276,7 @@ ONNXModelWriter::convertType(const Type &glowType) {
   case ElemKind::Int8QTy:
     return TensorType::INT8;
   case ElemKind::UInt8FusedQTy:
+  case ElemKind::UInt8FusedFP16QTy:
   case ElemKind::UInt8QTy:
     return TensorType::UINT8;
   case ElemKind::Int16QTy:

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1625,22 +1625,22 @@ Function::createRowwiseQuantizedSparseLengthsSum(
 /// \p lenghtsDims to compute output dimensions.
 static TypeRef getOutputTypeOfFusedRowwiseQuantizedSLS(
     Function *F, const llvm::ArrayRef<size_t> &inDims,
-    const llvm::ArrayRef<size_t> &lengthsDims) {
+    const llvm::ArrayRef<size_t> &lengthsDims, ElemKind scaleOffsetKind) {
   ShapeVector outDims(inDims.begin(), inDims.end());
   outDims[0] = lengthsDims[0];
   // The output column count is the same as the input column count, but without
   // the extra 8 bytes for the fused scale/offset, as the output is not
   // UInt8FusedQTy.
-  outDims[1] -= 8;
-  return F->getParent()->uniqueType(ElemKind::FloatTy, outDims);
+  outDims[1] -= (scaleOffsetKind == ElemKind::FloatTy) ? 8 : 4;
+  return F->getParent()->uniqueType(scaleOffsetKind, outDims);
 }
 
 FusedRowwiseQuantizedSparseLengthsWeightedSumNode *
 Function::createFusedRowwiseQuantizedSparseLengthsWeightedSum(
     llvm::StringRef name, NodeValue data, NodeValue weights, NodeValue indices,
     NodeValue lengths) {
-  auto outTy = getOutputTypeOfFusedRowwiseQuantizedSLS(this, data.dims(),
-                                                       lengths.dims());
+  auto outTy = getOutputTypeOfFusedRowwiseQuantizedSLS(
+      this, data.dims(), lengths.dims(), weights.getElementType());
   return addNode(new FusedRowwiseQuantizedSparseLengthsWeightedSumNode(
       name, outTy, data, weights, indices, lengths));
 }
@@ -1649,9 +1649,10 @@ FusedRowwiseQuantizedSparseLengthsSumNode *
 Function::createFusedRowwiseQuantizedSparseLengthsSum(llvm::StringRef name,
                                                       Constant *data,
                                                       NodeValue indices,
-                                                      NodeValue lengths) {
-  auto outTy = getOutputTypeOfFusedRowwiseQuantizedSLS(this, data->dims(),
-                                                       lengths.dims());
+                                                      NodeValue lengths,
+                                                      ElemKind precision) {
+  auto outTy = getOutputTypeOfFusedRowwiseQuantizedSLS(
+      this, data->dims(), lengths.dims(), precision);
   return addNode(new FusedRowwiseQuantizedSparseLengthsSumNode(
       name, outTy, data, indices, lengths));
 }
@@ -1661,9 +1662,8 @@ Function::createFusedRowwiseQuantizedSparseLengthsSum(llvm::StringRef name,
 /// RowwiseQuantizedSparseLengthsSumNode. Function \p F uses float Tensor \p
 /// data to create a rowwise qunatized Constant \p rwqData, which contains fused
 /// scales and offsets.
-static Constant *
-quantizeDataForFusedRowwiseQuantizedSparseLengthsWeightedSum(Function *F,
-                                                             Tensor &data) {
+static Constant *quantizeDataForFusedRowwiseQuantizedSparseLengthsWeightedSum(
+    Function *F, Tensor &data, ElemKind precision) {
   // For fused rowwise quantization, we must have a two-dimensional input. If
   // passed in a single dimensional data Tensor then add an extra dimension.
   const auto fDims = flattenCdr(data.dims());
@@ -1674,12 +1674,26 @@ quantizeDataForFusedRowwiseQuantizedSparseLengthsWeightedSum(Function *F,
   // scale/offset are fused inline with each row. Also, we expand the second
   // dimension to include space for the scale/offset, each 4 bytes
   // (float/int32_t).
-  Constant *rwqData = F->getParent()->createConstant(
-      ElemKind::UInt8FusedQTy, {fDims.first, fDims.second + 8}, 0.0, 0, "data");
-
-  quantization::tensorFusedRowwiseQuantization(fData,
-                                               rwqData->getPayloadMutable());
-  return rwqData;
+  switch (precision) {
+  case ElemKind::FloatTy: {
+    Constant *rwqData = F->getParent()->createConstant(
+        ElemKind::UInt8FusedQTy,
+        {fDims.first, fDims.second + 2 * sizeof(float)}, 0.0, 0, "data");
+    quantization::tensorFusedRowwiseQuantization<float>(
+        fData, rwqData->getPayloadMutable());
+    return rwqData;
+  }
+  case ElemKind::Float16Ty: {
+    Constant *rwqData = F->getParent()->createConstant(
+        ElemKind::UInt8FusedFP16QTy,
+        {fDims.first, fDims.second + 2 * sizeof(float16_t)}, 0.0, 0, "data");
+    quantization::tensorFusedRowwiseQuantization<float16_t>(
+        fData, rwqData->getPayloadMutable());
+    return rwqData;
+  }
+  default:
+    LOG(FATAL) << "Invalid type for FusedRowwiswQuantization.";
+  }
 }
 
 FusedRowwiseQuantizedSparseLengthsWeightedSumNode *
@@ -1687,7 +1701,8 @@ Function::createFusedRowwiseQuantizedSparseLengthsWeightedSum(
     llvm::StringRef name, Tensor &data, NodeValue weights, NodeValue indices,
     NodeValue lengths) {
   Constant *rwqData =
-      quantizeDataForFusedRowwiseQuantizedSparseLengthsWeightedSum(this, data);
+      quantizeDataForFusedRowwiseQuantizedSparseLengthsWeightedSum(
+          this, data, weights.getType()->getElementType());
   return createFusedRowwiseQuantizedSparseLengthsWeightedSum(
       name, rwqData, weights, indices, lengths);
 }
@@ -1696,11 +1711,13 @@ FusedRowwiseQuantizedSparseLengthsSumNode *
 Function::createFusedRowwiseQuantizedSparseLengthsSum(llvm::StringRef name,
                                                       Tensor &data,
                                                       NodeValue indices,
-                                                      NodeValue lengths) {
+                                                      NodeValue lengths,
+                                                      ElemKind precision) {
   Constant *rwqData =
-      quantizeDataForFusedRowwiseQuantizedSparseLengthsWeightedSum(this, data);
-  return this->createFusedRowwiseQuantizedSparseLengthsSum(name, rwqData,
-                                                           indices, lengths);
+      quantizeDataForFusedRowwiseQuantizedSparseLengthsWeightedSum(this, data,
+                                                                   precision);
+  return this->createFusedRowwiseQuantizedSparseLengthsSum(
+      name, rwqData, indices, lengths, precision);
 }
 
 LengthsToRangesNode *Function::createLengthsToRanges(llvm::StringRef name,

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1630,9 +1630,10 @@ static TypeRef getOutputTypeOfFusedRowwiseQuantizedSLS(
   ShapeVector outDims(inDims.begin(), inDims.end());
   outDims[0] = lengthsDims[0];
   // The output column count is the same as the input column count, but without
-  // the extra 8 bytes for the fused scale/offset, as the output is not
-  // UInt8FusedQTy.
-  outDims[1] -= (scaleOffsetKind == ElemKind::FloatTy) ? 8 : 4;
+  // the extra bytes for the fused scale/offset, as the output is not fused.
+  outDims[1] -=
+      2 * ((scaleOffsetKind == ElemKind::FloatTy) ? sizeof(float)
+                                                  : sizeof(float16_t));
   return F->getParent()->uniqueType(scaleOffsetKind, outDims);
 }
 

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -1015,13 +1015,7 @@ bool SparseLengthsWeightedSumGradNode::verify() const {
 }
 
 bool RowwiseQuantizedSparseLengthsWeightedSumNode::verify() const {
-  bool isValid = checkType(getResult(), ElemKind::FloatTy, this);
-  isValid &= checkType(getData(), ElemKind::UInt8QTy, this);
-  isValid &= checkType(getScales(), ElemKind::FloatTy, this);
-  isValid &= checkType(getOffsets(), ElemKind::FloatTy, this);
-  isValid &= checkType(getWeights(), ElemKind::FloatTy, this);
-  isValid &= checkType(getIndices(), ElemKind::Int64ITy, this);
-  isValid &= checkType(getLengths(), ElemKind::Int32ITy, this);
+  bool isValid = checkType(getData(), ElemKind::UInt8QTy, this);
   isValid &= expectCompareTrue("Indices must be a 1D vector",
                                getIndices().dims().size(), size_t(1), this);
   isValid &= expectCompareTrue("Lengths must be a 1D vector",

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -243,6 +243,8 @@ llvm::Type *LLVMIRGen::getElementType(llvm::IRBuilder<> &builder,
     return builder.getInt32Ty();
   case ElemKind::UInt8FusedQTy:
     return builder.getInt8Ty();
+  case ElemKind::UInt8FusedFP16QTy:
+    return builder.getInt8Ty();
   case ElemKind::BoolTy:
     static_assert(sizeof(bool) == sizeof(int8_t),
                   "Bool is expected to be the same size as int8.");
@@ -338,6 +340,9 @@ llvm::Value *LLVMIRGen::emitValueAddress(llvm::IRBuilder<> &builder,
     T = llvm::Type::getInt32PtrTy(ctx_);
     break;
   case ElemKind::UInt8FusedQTy:
+    T = llvm::Type::getInt8PtrTy(ctx_);
+    break;
+  case ElemKind::UInt8FusedFP16QTy:
     T = llvm::Type::getInt8PtrTy(ctx_);
     break;
   case ElemKind::BoolTy:
@@ -491,6 +496,8 @@ llvm::Value *LLVMIRGen::emitConst(llvm::IRBuilder<> &builder, float val,
   case ElemKind::Int32ITy:
     return builder.getInt32(static_cast<int32_t>(val));
   case ElemKind::UInt8FusedQTy:
+    return builder.getInt8(static_cast<int8_t>(val));
+  case ElemKind::UInt8FusedFP16QTy:
     return builder.getInt8(static_cast<int8_t>(val));
   case ElemKind::BoolTy:
     return builder.getInt8(static_cast<int8_t>(val));

--- a/lib/Optimizer/GraphOptimizer/Lower.cpp
+++ b/lib/Optimizer/GraphOptimizer/Lower.cpp
@@ -1010,8 +1010,9 @@ static void lowerSparseLengthsSumNode(Function *F, CompilationContext &cctx,
 static void lowerFusedRowwiseQuantizedSparseLengthsSumNode(
     Function *F, CompilationContext &cctx,
     const FusedRowwiseQuantizedSparseLengthsSumNode &FRQSLSN) {
-  auto ty = F->getParent()->uniqueType(ElemKind::FloatTy,
-                                       {FRQSLSN.getIndices().dims()[0]});
+  auto ty = F->getParent()->uniqueType(
+      FRQSLSN.getResult().getType()->getElementType(),
+      {FRQSLSN.getIndices().dims()[0]});
   auto *ones = F->createSplat(FRQSLSN.getName().str() + ".ones", ty, 1.0);
   auto *FRQSLWSN = F->createFusedRowwiseQuantizedSparseLengthsWeightedSum(
       FRQSLSN.getName().str(), FRQSLSN.getData(), ones, FRQSLSN.getIndices(),

--- a/lib/Optimizer/GraphOptimizer/Lower.cpp
+++ b/lib/Optimizer/GraphOptimizer/Lower.cpp
@@ -1010,13 +1010,13 @@ static void lowerSparseLengthsSumNode(Function *F, CompilationContext &cctx,
 static void lowerFusedRowwiseQuantizedSparseLengthsSumNode(
     Function *F, CompilationContext &cctx,
     const FusedRowwiseQuantizedSparseLengthsSumNode &FRQSLSN) {
-  auto ty = F->getParent()->uniqueType(
-      FRQSLSN.getResult().getType()->getElementType(),
-      {FRQSLSN.getIndices().dims()[0]});
+  ElemKind precision = FRQSLSN.getResult().getType()->getElementType();
+  auto ty =
+      F->getParent()->uniqueType(precision, {FRQSLSN.getIndices().dims()[0]});
   auto *ones = F->createSplat(FRQSLSN.getName().str() + ".ones", ty, 1.0);
   auto *FRQSLWSN = F->createFusedRowwiseQuantizedSparseLengthsWeightedSum(
       FRQSLSN.getName().str(), FRQSLSN.getData(), ones, FRQSLSN.getIndices(),
-      FRQSLSN.getLengths());
+      FRQSLSN.getLengths(), precision);
 
   replaceAllUsesOfWith(cctx.loweredInfoMap, FRQSLSN.getResult(), FRQSLWSN);
 }

--- a/tests/stress/SparseLengthsSumTest.cpp
+++ b/tests/stress/SparseLengthsSumTest.cpp
@@ -44,7 +44,8 @@ TEST_P(SparseLengthsSum, Big) {
     fData.getHandle<float>().randomize(-1.0, 1.0, mod_.getPRNG());
     auto *C = mod_.createConstant(ElemKind::UInt8FusedQTy, {dataRows[i], 80},
                                   0.0, 0, "data");
-    quantization::tensorFusedRowwiseQuantization(fData, C->getPayloadMutable());
+    quantization::tensorFusedRowwiseQuantization<float>(fData,
+                                                        C->getPayloadMutable());
     data.push_back(C);
   }
   for (int i = 0; i < 13; i++) {

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -5963,7 +5963,7 @@ static void testRowwiseQuantizedSparseLengthsWeightedSum(
 
   auto *R = F->createRowwiseQuantizedSparseLengthsWeightedSum(
       "RQSLWS", data, weights, indices, lengths,
-      quantization::Schema::Asymmetric);
+      quantization::Schema::Asymmetric, DTy);
   SaveNode *S = F->createSave("save", R);
   bindings.allocate(S->getPlaceholder());
 
@@ -6162,7 +6162,7 @@ static void testFusedRowwiseQuantizedSparseLengthsWeightedSum(
   };
 
   auto *R = F->createFusedRowwiseQuantizedSparseLengthsWeightedSum(
-      "RQSLWS", data, weights, indices, lengths);
+      "RQSLWS", data, weights, indices, lengths, DTy);
   SaveNode *S = F->createSave("save", R);
   bindings.allocate(S->getPlaceholder());
 

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -5924,7 +5924,7 @@ TEST_P(OperatorTest, SparseLengthsWeightedSumI8) {
 template <typename DataType>
 static void testRowwiseQuantizedSparseLengthsWeightedSum(
     glow::PlaceholderBindings &bindings, glow::Module &mod, glow::Function *F,
-    glow::ExecutionEngine &EE, ElemKind DTy) {
+    glow::ExecutionEngine &EE, ElemKind DTy, float allowedError) {
   /*
     DATA  =   [2.0, -0.5, 13]
     WEIGHTS = [3, 1, 0, 0, 0, 0, 2, -0.5]
@@ -5979,29 +5979,28 @@ static void testRowwiseQuantizedSparseLengthsWeightedSum(
       25,
   };
 
-  EXPECT_TRUE(expected.isEqual(result, 0.01));
+  EXPECT_TRUE(expected.isEqual(result, allowedError));
 }
 
 /// Test RWQ-SLWS with Float Weights, Scales, Offsets, and Output.
 TEST_P(OperatorTest, RowwiseQuantizedSparseLengthsWeightedSum_Float) {
   ENABLED_BACKENDS(Interpreter, CPU);
   testRowwiseQuantizedSparseLengthsWeightedSum<float>(bindings_, mod_, F_, EE_,
-                                                      ElemKind::FloatTy);
+                                                      ElemKind::FloatTy, 0.01);
 }
 
 /// Test RWQ-SLWS with Float16 Weights, Scales, Offsets, and Output.
 TEST_P(OperatorTest, RowwiseQuantizedSparseLengthsWeightedSum_Float16) {
   ENABLED_BACKENDS(Interpreter);
   testRowwiseQuantizedSparseLengthsWeightedSum<float16_t>(
-      bindings_, mod_, F_, EE_, ElemKind::Float16Ty);
+      bindings_, mod_, F_, EE_, ElemKind::Float16Ty, 0.02);
 }
 
 /// Helper to test RowwiseQuantizedSparseLengthsWeightedSum using \p DTy.
 template <typename DataType>
-static void
-testRowwiseQuantizedSparseLengthsSum(glow::PlaceholderBindings &bindings,
-                                     glow::Module &mod, glow::Function *F,
-                                     glow::ExecutionEngine &EE, ElemKind DTy) {
+static void testRowwiseQuantizedSparseLengthsSum(
+    glow::PlaceholderBindings &bindings, glow::Module &mod, glow::Function *F,
+    glow::ExecutionEngine &EE, ElemKind DTy, float allowedError) {
   /*
     DATA  = [
         [1.0, 1.2],
@@ -6049,21 +6048,21 @@ testRowwiseQuantizedSparseLengthsSum(glow::PlaceholderBindings &bindings,
       5.5f, 6.9f, 0.0f, 0.0f, 6.8f, 9.1f, 1.0f, 1.2f, 3.0f, 3.6f,
   };
 
-  EXPECT_TRUE(expected.isEqual(result, 0.03));
+  EXPECT_TRUE(expected.isEqual(result, allowedError));
 }
 
 /// Test RWQ-SLS with Float Weights, Scales, Offsets, and Output.
 TEST_P(OperatorTest, RowwiseQuantizedSparseLengthsSum_Float) {
   ENABLED_BACKENDS(Interpreter, CPU);
   testRowwiseQuantizedSparseLengthsSum<float>(bindings_, mod_, F_, EE_,
-                                              ElemKind::FloatTy);
+                                              ElemKind::FloatTy, 0.025);
 }
 
 /// Test RWQ-SLS with Float16 Weights, Scales, Offsets, and Output.
 TEST_P(OperatorTest, RowwiseQuantizedSparseLengthsSum_Float16) {
   ENABLED_BACKENDS(Interpreter);
   testRowwiseQuantizedSparseLengthsSum<float16_t>(bindings_, mod_, F_, EE_,
-                                                  ElemKind::Float16Ty);
+                                                  ElemKind::Float16Ty, 0.025);
 }
 
 TEST_P(OperatorTest, RepeatedSLSWithPartialTensors) {
@@ -6121,11 +6120,11 @@ TEST_P(OperatorTest, RepeatedSLSWithPartialTensors) {
   }
 }
 
-/// Helper to test RowwiseQuantizedSparseLengthsWeightedSum using \p DTy.
+/// Helper to test FusedRowwiseQuantizedSparseLengthsWeightedSum using \p DTy.
 template <typename DataType>
 static void testFusedRowwiseQuantizedSparseLengthsWeightedSum(
     glow::PlaceholderBindings &bindings, glow::Module &mod, glow::Function *F,
-    glow::ExecutionEngine &EE, ElemKind DTy) {
+    glow::ExecutionEngine &EE, ElemKind DTy, float allowedError) {
   /*
     DATA  =   [[2.0, -0.5, 13]]
     WEIGHTS = [3, 1, 0, 0, 0, 0, 2, -0.5]
@@ -6179,26 +6178,28 @@ static void testFusedRowwiseQuantizedSparseLengthsWeightedSum(
       25,
   };
 
-  EXPECT_TRUE(expected.isEqual(result, 0.02));
+  EXPECT_TRUE(expected.isEqual(result, allowedError));
 }
 
 /// Test Fused-RWQ-SLWS in Float.
 TEST_P(OperatorTest, FusedRowwiseQuantizedSparseLengthsWeightedSum_Float) {
   ENABLED_BACKENDS(Interpreter, CPU, Habana);
   testFusedRowwiseQuantizedSparseLengthsWeightedSum<float>(
-      bindings_, mod_, F_, EE_, ElemKind::FloatTy);
+      bindings_, mod_, F_, EE_, ElemKind::FloatTy, 0.01);
 }
 
 /// Test Fused-RWQ-SLWS in Float16.
 TEST_P(OperatorTest, FusedRowwiseQuantizedSparseLengthsWeightedSum_Float16) {
   ENABLED_BACKENDS(Interpreter);
   testFusedRowwiseQuantizedSparseLengthsWeightedSum<float16_t>(
-      bindings_, mod_, F_, EE_, ElemKind::Float16Ty);
+      bindings_, mod_, F_, EE_, ElemKind::Float16Ty, 0.02);
 }
 
-TEST_P(OperatorTest, FusedRowwiseQuantizedSparseLengthsSum) {
-  ENABLED_BACKENDS(Interpreter, CPU, Habana);
-
+/// Helper to test FusedRowwiseQuantizedSparseLengthsSum using \p DTy.
+template <typename DataType>
+static void testFusedRowwiseQuantizedSparseLengthsSum(
+    glow::PlaceholderBindings &bindings, glow::Module &mod, glow::Function *F,
+    glow::ExecutionEngine &EE, ElemKind DTy, float allowedError) {
   /*
     DATA  = [
         [1.0, 1.2],
@@ -6220,33 +6221,47 @@ TEST_P(OperatorTest, FusedRowwiseQuantizedSparseLengthsSum) {
       1.0f, 1.2f, 2.3f, 3.4f, 4.5f, 5.7f,
   };
 
-  Placeholder *indices = mod_.createPlaceholder(
+  Placeholder *indices = mod.createPlaceholder(
       ElemKind::Int64ITy, {8}, "indices", /* isTrainable */ false);
-  Placeholder *lengths = mod_.createPlaceholder(
+  Placeholder *lengths = mod.createPlaceholder(
       ElemKind::Int32ITy, {5}, "lengths", /* isTrainable */ false);
 
-  bindings_.allocate(indices)->getHandle<int64_t>() = {
+  bindings.allocate(indices)->getHandle<int64_t>() = {
       2, 0, 1, 2, 0, 0, 0, 0,
   };
-  bindings_.allocate(lengths)->getHandle<int32_t>() = {
+  bindings.allocate(lengths)->getHandle<int32_t>() = {
       2, 0, 2, 1, 3,
   };
 
-  auto *R = F_->createFusedRowwiseQuantizedSparseLengthsSum("RQSLWS", data,
-                                                            indices, lengths);
-  SaveNode *S = F_->createSave("save", R);
-  bindings_.allocate(S->getPlaceholder());
+  auto *R = F->createFusedRowwiseQuantizedSparseLengthsSum(
+      "RQSLWS", data, indices, lengths, DTy);
+  SaveNode *S = F->createSave("save", R);
+  bindings.allocate(S->getPlaceholder());
 
-  EE_.compile(CompilationMode::Infer, F_);
-  EE_.run(bindings_);
+  EE.compile(CompilationMode::Infer, F);
+  EE.run(bindings);
 
-  Tensor &result = *bindings_.get(S->getPlaceholder());
-  Tensor expected(ElemKind::FloatTy, {5, 2});
-  expected.getHandle() = {
+  Tensor &result = *bindings.get(S->getPlaceholder());
+  Tensor expected(DTy, {5, 2});
+  expected.getHandle<DataType>() = {
       5.5f, 6.9f, 0.0f, 0.0f, 6.8f, 9.1f, 1.0f, 1.2f, 3.0f, 3.6f,
   };
 
-  EXPECT_TRUE(expected.isEqual(result, 0.03));
+  EXPECT_TRUE(expected.isEqual(result, allowedError));
+}
+
+/// Test Fused-RWQ-SLS in Float.
+TEST_P(OperatorTest, FusedRowwiseQuantizedSparseLengthsSum_Float) {
+  ENABLED_BACKENDS(Interpreter, CPU, Habana);
+  testFusedRowwiseQuantizedSparseLengthsSum<float>(bindings_, mod_, F_, EE_,
+                                                   ElemKind::FloatTy, 0.025);
+}
+
+/// Test Fused-RWQ-SLS in Float16.
+TEST_P(OperatorTest, FusedRowwiseQuantizedSparseLengthsSum_Float16) {
+  ENABLED_BACKENDS(Interpreter);
+  testFusedRowwiseQuantizedSparseLengthsSum<float16_t>(
+      bindings_, mod_, F_, EE_, ElemKind::Float16Ty, 0.025);
 }
 
 /// Test SLS when some input tensors are constants.

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -285,11 +285,7 @@ int main(int argc, char **argv) {
       .addOperand("Indices", OperandKind::In)
       .addOperand("Lengths", OperandKind::In)
       .autoIRGen()
-      .autoVerify(VerifyKind::SameElementType, {"Dest", "ElemKind::FloatTy"})
       .autoVerify(VerifyKind::SameElementType, {"Data", "ElemKind::UInt8QTy"})
-      .autoVerify(VerifyKind::SameElementType, {"Scales", "ElemKind::FloatTy"})
-      .autoVerify(VerifyKind::SameElementType, {"Offsets", "ElemKind::FloatTy"})
-      .autoVerify(VerifyKind::SameElementType, {"Weights", "ElemKind::FloatTy"})
       .autoVerify(VerifyKind::SameElementType,
                   {"Indices", "ElemKind::Int64ITy"})
       .autoVerify(VerifyKind::SameElementType,

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -299,10 +299,6 @@ int main(int argc, char **argv) {
       .addOperand("Indices", OperandKind::In)
       .addOperand("Lengths", OperandKind::In)
       .autoIRGen()
-      .autoVerify(VerifyKind::SameElementType, {"Dest", "ElemKind::FloatTy"})
-      .autoVerify(VerifyKind::SameElementType,
-                  {"Data", "ElemKind::UInt8FusedQTy"})
-      .autoVerify(VerifyKind::SameElementType, {"Weights", "ElemKind::FloatTy"})
       .autoVerify(VerifyKind::SameElementType,
                   {"Indices", "ElemKind::Int64ITy"})
       .autoVerify(VerifyKind::SameElementType,


### PR DESCRIPTION
Summary: Add support for FP16 RWQ-SLWS, fused and unfused. In this version of the op, the per-row scale/offset are FP16, the weights are  FP16, and the output is FP16. In the Interpreter kernels, each value from the embedding is dequantized to FP16, accumulation occurs in FP32, and then is casted back down to FP16 for the result.

For the Fused case, I added in a new `ElemKind::UInt8FusedFP16QTy`. This type has 4 extra bytes per row instead of 8, to save FP16 scale/offset.

Documentation: Updated.

Test Plan: Added FP16 versions of all OperatorTests for RWQ-SLWS/SLS, fused and unfused.