### PR TITLE
[PyTorch] Load transpose op

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -481,6 +481,26 @@ void PyTorchModelLoader::loadAdaptiveAvgPool2d(const torch::jit::Node *ptNode) {
   addGlowNodeValue(outputs[0], output);
 }
 
+void PyTorchModelLoader::loadTranspose(const torch::jit::Node *ptNode) {
+  auto inputs = ptNode->inputs();
+  auto outputs = ptNode->outputs();
+  assert(inputs.size() == 1);
+  assert(outputs.size() == 1);
+
+  glow::NodeValue input = getGlowNodeValue(inputs[0]);
+  glow::NodeValue output;
+
+  if (input.dims().size() == 1) {
+    output = input;
+  } else if (input.dims().size() == 2) {
+    output = f_->createTranspose("transpose", input, {1, 0});
+  } else {
+    assert(false && "Transpose requires input to have rank <= 2");
+  }
+
+  addGlowNodeValue(outputs[0], output);
+}
+
 void PyTorchModelLoader::loadConstant(const torch::jit::Node *ptNode) {
   auto inputs = ptNode->inputs();
   auto outputs = ptNode->outputs();
@@ -594,6 +614,12 @@ void PyTorchModelLoader::populateNodeLoaderMapping() {
       [this](const torch::jit::Node *node) {
         return loadAdaptiveAvgPool2d(node);
       };
+
+  nodeLoaderMapping_[at::Symbol::fromQualString("aten::t")] =
+      [this](const torch::jit::Node *node) { return loadTranspose(node); };
+
+  nodeLoaderMapping_[at::Symbol::fromQualString("aten::t_")] =
+      [this](const torch::jit::Node *node) { return loadTranspose(node); };
 }
 
 void PyTorchModelLoader::loadNode(const torch::jit::Node *node) {

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -151,6 +151,9 @@ private:
 
   /// Load a PyTorch adaptive_avg_pool2d node.
   void loadAdaptiveAvgPool2d(const torch::jit::Node *ptNode);
+
+  /// Load a PyTorch t (transpose) node.
+  void loadTranspose(const torch::jit::Node *ptNode);
 };
 
 #endif // GLOW_IMPORTER_PYTORCH_PYTORCHMODELLOADER_H

--- a/torch_glow/tests/nodes/transpose_test.py
+++ b/torch_glow/tests/nodes/transpose_test.py
@@ -1,0 +1,37 @@
+import torch
+
+from tests.utils import jitVsGlow
+
+ # Test of PyTorch t (transpose) on Glow with 2d inputs.
+def test_transpose_2d():
+
+   def test_f(a):
+        b = a + a
+        return b.t()
+
+   x = torch.randn(7, 4)
+
+   jitVsGlow(test_f, x)
+
+# Test of PyTorch t (transpose) on Glow with 1d inputs.
+def test_transpose_1d():
+
+   def test_f(a):
+        b = a + a
+        return b.t()
+
+   x = torch.randn(7)
+
+   jitVsGlow(test_f, x)
+
+
+# Test of PyTorch t_ (in place transpose) on Glow.
+def test_transpose_inplace():
+
+   def test_f(a):
+        b = a + a
+        return b.t_()
+
+   x = torch.randn(7, 4)
+
+   jitVsGlow(test_f, x)


### PR DESCRIPTION
Summary:
Load PyTorch tranpose ([`torch.t`](https://pytorch.org/docs/stable/torch.html#torch.t)) and inplace transpose (`torch.t_`) operators.

Documentation:
Doxygen

Test Plan:
Added new PyTorch operator tests.
`python setup.py test`
