### PR TITLE
Fix a bug: quantization profiling flow with partitioning can only be enabled when there is no previous registered network in HM.

### DIFF
--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -113,6 +113,11 @@ llvm::Error HostManager::addNetwork(std::unique_ptr<Module> module,
   auto nodeList = std::move(partitioner.getPartitionResult());
 
   if (cctx.precisionConfig.quantMode == QuantizationMode::Profile) {
+    // Since for profiling the provisioner will be reset, we only allow one
+    // network in one HM.
+    RETURN_ERR_IF_NOT(networks_.size() == 0,
+                      "For quantization profiling flow, there can't be other "
+                      "registered networks before this one");
     // For profiling, we use CPU backend. Overwrite Provisioner and Executor to
     // force the network is compiled and run in profilingBackend.
     // backend.


### PR DESCRIPTION
Summary:
When we enabled quantization profiling flow in Partitioner, we forced Provisioner to be reset. If there are registered networks in HM already, the status will be lost. Therefore, we restrict the quantization profiling flow to only 1 network. 

Documentation:

[Optional Fixes #issue]

Test Plan:
ninja test, ./tests/images/run.sh
Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
