### PR TITLE
[habana][operator] Implement LengthsRangeFill

### DIFF
--- a/lib/Backends/Habana/Habana.cpp
+++ b/lib/Backends/Habana/Habana.cpp
@@ -1315,6 +1315,14 @@ HabanaBackend::compile(Function *F, const BackendOptions &opts) const {
       multiInputs.emplace_back(std::move(inputs));
       break;
     }
+    case Kinded::Kind::LengthsRangeFillNodeKind: {
+      auto *LRFNode = llvm::cast<LengthsRangeFillNode>(&I);
+      chk(synCreateGenericNode(&tensors[LRFNode->getLengths()].get(),
+                               &tensors[LRFNode].get(), 1, 1, nullptr,
+                               "lengths_range_fill_i32",
+                               LRFNode->getName().data(), nullptr, nullptr));
+      break;
+    }
     case Kinded::Kind::SparseLengthsSumNodeKind: {
       auto *RI = llvm::cast<SparseLengthsSumNode>(&I);
       std::vector<synTensor> inputs = {
@@ -1501,6 +1509,7 @@ bool HabanaBackend::isOpSupported(const NodeInfo &NI) const {
   case Kinded::Kind::TanhNodeKind:
   case Kinded::Kind::TileNodeKind:
   case Kinded::Kind::TransposeNodeKind:
+  case Kinded::Kind::LengthsRangeFillNodeKind:
   case Kinded::Kind::LengthsSumNodeKind:
   case Kinded::Kind::SparseLengthsSumNodeKind:
   case Kinded::Kind::SparseLengthsWeightedSumNodeKind:

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -7134,7 +7134,7 @@ TEST_P(OperatorTest, LengthsToRanges) {
 
 /// Test that LengthsRangeFill works.
 TEST_P(OperatorTest, LengthsRangeFill) {
-  ENABLED_BACKENDS(Interpreter, CPU);
+  ENABLED_BACKENDS(Interpreter, CPU, Habana);
 
   /*
     LENGTHS = [4, 3, 1]


### PR DESCRIPTION
Summary:
Add support for `LengthsRangeFill` on Habana Backend.
`LengthsRangeFill` is already supported on CPU backend, extending the support to Habana is straightforward.

Fixes #3255

Test Plan:
Running operator tests on Habana and making sure `LengthsRangeFill` passes