### PR TITLE
[Trivial] Windows Debug OnnxExporterFix fix

### DIFF
--- a/tests/unittests/OnnxExporterTest.cpp
+++ b/tests/unittests/OnnxExporterTest.cpp
@@ -60,7 +60,7 @@ TEST(exporter, onnxModels) {
        !code && dirIt != llvm::sys::fs::directory_iterator();
        dirIt.increment(code)) {
     auto name = dirIt->path();
-    if (name == "tests/models/onnxModels/preluInvalidBroadcastSlope.onnxtxt") {
+    if (name.find("preluInvalidBroadcastSlope.onnxtxt") != std::string::npos) {
       continue;
     }
     testLoadAndSaveONNXModel(dirIt->path());


### PR DESCRIPTION
Summary: Slashes in windows are different so checking full path doesn't work.

Documentation:

[Optional Fixes #issue]

Test Plan: UnitTests

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
