### PR TITLE
[habana][operator] Implement BatchOneHot

### DIFF
--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -7217,7 +7217,7 @@ TEST_P(OperatorTest, BatchOneHotDataInt64) {
 
 /// Test BatchOneHot with Int32 data and Int32 Lengths.
 TEST_P(OperatorTest, BatchOneHotDataInt32) {
-  ENABLED_BACKENDS(Interpreter);
+  ENABLED_BACKENDS(Interpreter, Habana);
   batchOneHotTest<int32_t>(bindings_, mod_, F_, EE_, ElemKind::Int32ITy);
 }
 


### PR DESCRIPTION
Summary:
Add support for `BatchOneHot` on Habana Backend.
`BatchOneHot` is already supported on Interpreter backend, extending the support to Habana is straightforward with one caveat: only `Int32` is supported for the feature maps, lengths and values.
As such, I enabled the Habana backend only for the `BatchOneHotDataInt32` operator test.

Fixes #3252

Test Plan:
Running operator tests on Habana and making sure `BatchOneHotDataInt32` passes