### PR TITLE
Ported RecommendationSystemTest to EE2.

### DIFF
--- a/include/glow/ExecutionEngine/ExecutionEngine2.h
+++ b/include/glow/ExecutionEngine/ExecutionEngine2.h
@@ -47,6 +47,9 @@ class ExecutionEngine2 final {
   /// Name of the backend being used for compilation and execution.
   std::string backendName_ = "";
 
+  /// Size of device memory, if 0 device default is used.
+  uint64_t deviceMemory_{0};
+
   /// The HostManager for executing the compiled functions.
   std::unique_ptr<runtime::HostManager> hostManager_;
 
@@ -66,6 +69,13 @@ public:
   /// using this backend. This clears all previously loaded functions and resets
   /// the Module.
   void setBackendName(llvm::StringRef backend);
+
+  /// Set the device memory to \p mem. This will reset the existing device,
+  /// clearing all existing functions and resetting the module.
+  void setDeviceMemory(uint64_t mem) {
+    deviceMemory_ = mem;
+    setBackendName(backendName_);
+  }
 
   /// Get a pointer to the backend.
   llvm::StringRef getBackendName() const;

--- a/lib/ExecutionEngine/ExecutionEngine2.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine2.cpp
@@ -45,6 +45,9 @@ void ExecutionEngine2::setBackendName(llvm::StringRef backend) {
   if (backend != "") {
     std::vector<std::unique_ptr<runtime::DeviceConfig>> configs;
     auto config = llvm::make_unique<runtime::DeviceConfig>(backend);
+    if (deviceMemory_) {
+      config->setDeviceMemory(deviceMemory_);
+    }
     configs.push_back(std::move(config));
     hostManager_ = llvm::make_unique<runtime::HostManager>(std::move(configs));
   }

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -428,12 +428,12 @@ add_executable(RecommendationSystemTest
                RecommendationSystemTest.cpp)
 target_link_libraries(RecommendationSystemTest
                       PRIVATE
-                        BackendTestUtils
+                        BackendTestUtils2
                         Converter
                         Graph
                         IR
                         ExecutionContext
-                        ExecutionEngine
+                        ExecutionEngine2
                         Quantization
                         Partitioner
                         gtest


### PR DESCRIPTION
Summary: This PR ports the RecommendationSystemTest to the new EE2. Additionally this adds a new feature to EE2, the ability to set the memory of the device. This allows programmatically setting the EE device memory to support graphs larger than the default.

Documentation: NA

Work on #3239 

Test Plan: verify everything builds, and RecomendationSystemTest runs and passes.
