### PR TITLE
Ported GradCheckTest to EE2

### DIFF
--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -156,7 +156,7 @@ add_executable(GradCheckTest
 target_link_libraries(GradCheckTest
                       PRIVATE
                         Base
-                        ExecutionEngine
+                        ExecutionEngine2
                         Graph
                         IR
                         gtest

--- a/tests/unittests/GradCheckTest.cpp
+++ b/tests/unittests/GradCheckTest.cpp
@@ -15,7 +15,7 @@
  */
 
 #include "glow/Base/Tensor.h"
-#include "glow/ExecutionEngine/ExecutionEngine.h"
+#include "glow/ExecutionEngine/ExecutionEngine2.h"
 #include "glow/Graph/Graph.h"
 #include "glow/Graph/Nodes.h"
 #include "glow/IR/IR.h"
@@ -29,7 +29,13 @@ using llvm::cast;
 
 class GradCheckBase : public ::testing::TestWithParam<std::string> {
 public:
-  ExecutionEngine EE_{GetParam()};
+  ExecutionEngine2 EET_{GetParam()};
+  ExecutionEngine2 EEI_{GetParam()};
+  std::vector<ExecutionEngine2 *> engines_;
+  void SetUp() {
+    engines_.push_back(&EEI_);
+    engines_.push_back(&EET_);
+  }
 };
 
 class InterpreterGrad : public GradCheckBase {};
@@ -77,7 +83,8 @@ void allocateGrads(PlaceholderBindings &bindings,
 /// Analytical grad is based on the gradient output calculated during back
 /// propagation.
 ///
-/// \param EE Execution engine to compile/run network.
+/// \param EET Execution engine to compile/run network for training.
+/// \param EEI Executiuon engine to compile/run network for inference.
 /// \param bindings Placeholder bindings.
 /// \param result Node that contains result of f(x).
 /// \param inputVar Placeholder which gradient is assessed.
@@ -85,16 +92,17 @@ void allocateGrads(PlaceholderBindings &bindings,
 /// training. \param inputs Tensor for \p inputVar placeholder. \param outputs
 /// Tensor for \p expVar placeholder. \param allowedError allowed delta between
 /// analytical and numerical gradients.
-void performGradCheck(ExecutionEngine &EE, PlaceholderBindings &bindings,
-                      SaveNode *result, Placeholder *inputVar,
-                      Placeholder *expVar, Tensor *inputs, Tensor *outputs,
-                      float delta, float allowedError) {
+void performGradCheck(ExecutionEngine2 &EET, ExecutionEngine2 &EEI,
+                      PlaceholderBindings &bindings, Placeholder *result,
+                      Placeholder *inputVar, Placeholder *expVar,
+                      Tensor *inputs, Tensor *outputs, float delta,
+                      float allowedError) {
   TrainingConfig TC;
 
-  auto *F = EE.getModule().getFunction("main");
+  auto *F = EET.getModule().getFunction("main");
 
   // Allocate result, inputVar and expVar.
-  auto resultTensor = bindings.allocate(result->getPlaceholder());
+  bindings.allocate(result);
   bindings.allocate(inputVar);
   bindings.allocate(expVar);
 
@@ -103,20 +111,21 @@ void performGradCheck(ExecutionEngine &EE, PlaceholderBindings &bindings,
   size_t sampleCounter = 0;
 
   // Create a function that trains the network.
-  Function *TF = glow::differentiate(F, TC);
-  EE.compile(CompilationMode::Train, TF);
-
-  // The network might have variables, other than inputVar and expVar.
-  // Train the network until other variables reach some stable local minimum.
-  runBatch(EE, bindings, 300, sampleCounter, {inputVar, expVar},
-           {inputs, outputs});
+  auto *TF = glow::differentiate(F, TC);
 
   // Create a version of the network that records the gradients to some side
   // table instead of updating them.
   VariableGradientsList varGrads;
-  Function *recordNet = glow::differentiate(F, TC, "record", &varGrads);
-  allocateGrads(bindings, varGrads);
-  EE.compile(CompilationMode::Train, recordNet);
+  auto *RF = glow::differentiate(F, TC, "record", &varGrads);
+  auto rfName = RF->getName();
+  auto tfName = TF->getName();
+  EET.compile(CompilationMode::Train);
+  bindings.allocate(EET.getModule().getPlaceholders());
+
+  // The network might have variables, other than inputVar and expVar.
+  // Train the network until other variables reach some stable local minimum.
+  runBatch2(EET, bindings, 300, sampleCounter, {inputVar, expVar},
+            {inputs, outputs}, tfName);
 
   // Clear the gradients of the first layer.
   auto gradVar = getGrad(varGrads, inputVar);
@@ -124,27 +133,37 @@ void performGradCheck(ExecutionEngine &EE, PlaceholderBindings &bindings,
   gradVarTensor->zero();
 
   // Train the network just once to record the values of gradient for inputVar.
-  runBatch(EE, bindings, 1, sampleCounter, {inputVar, expVar},
-           {inputs, outputs});
-
+  runBatch2(EET, bindings, 1, sampleCounter, {inputVar, expVar},
+            {inputs, outputs}, rfName);
   // Compile the original network in inference mode.
-  EE.compile(CompilationMode::Infer, F);
+  EEI.compile(CompilationMode::Infer);
+  PlaceholderBindings inferBindings;
+  inferBindings.allocate(EEI.getModule().getPlaceholders());
+  // Copy values to inferenceBindings. This is needed for any placeholders that
+  // were initialized during function creation.
+  for (auto PH : EEI.getModule().getPlaceholders()) {
+    bindings.copyToTarget(PH->getName(), inferBindings);
+  }
+  auto resultTensor =
+      inferBindings.get(inferBindings.getPlaceholderByName(result->getName()));
 
   auto analyticalGradsH = gradVarTensor->getHandle();
   auto inputsH = inputs->getHandle<>();
   bool allZeroGradients = true;
+  auto inferInput = inferBindings.getPlaceholderByName(inputVar->getName());
+
   for (size_t i = 0; i < analyticalGradsH.size(); i++) {
     auto old = inputsH.raw(i);
     // Calculate f(x+e):
     inputsH.raw(i) = old + delta;
-    updateInputPlaceholders(bindings, {inputVar}, {inputs});
-    EE.run(bindings);
+    updateInputPlaceholders2(inferBindings, {inferInput}, {inputs});
+    EEI.run(inferBindings);
     auto plusLoss = computeL2Loss(outputs, resultTensor);
 
     // Calculate f(x-e):
     inputsH.raw(i) = old - delta;
-    updateInputPlaceholders(bindings, {inputVar}, {inputs});
-    EE.run(bindings);
+    updateInputPlaceholders2(inferBindings, {inferInput}, {inputs});
+    EEI.run(inferBindings);
 
     auto minusLoss = computeL2Loss(outputs, resultTensor);
 
@@ -170,101 +189,108 @@ void performGradCheck(ExecutionEngine &EE, PlaceholderBindings &bindings,
 
 TEST_P(InterpreterGrad, gradientCheckConcat) {
   PlaceholderBindings bindings;
+  Placeholder *A, *Exp, *B;
+  SaveNode *result;
   size_t numOutputElem = 20;
+  for (auto *EE : engines_) {
+    auto &mod = EE->getModule();
+    Function *F = mod.createFunction("main");
 
-  auto &mod = EE_.getModule();
-  Function *F = mod.createFunction("main");
+    A = mod.createPlaceholder(ElemKind::FloatTy, {1, numOutputElem / 2}, "A",
+                              false);
+    B = mod.createPlaceholder(ElemKind::FloatTy, {1, numOutputElem / 2}, "B",
+                              false);
 
-  auto *A = mod.createPlaceholder(ElemKind::FloatTy, {1, numOutputElem / 2},
-                                  "A", false);
-  auto *B = mod.createPlaceholder(ElemKind::FloatTy, {1, numOutputElem / 2},
-                                  "B", false);
+    Exp = mod.createPlaceholder(ElemKind::FloatTy, {1, numOutputElem}, "exp",
+                                false);
+    Node *O = F->createConcat("concat", {A, B}, 1);
+    O = F->createRegression("reg", O, Exp);
+    result = F->createSave("ret", O);
+  }
   bindings.allocate(B)->zero();
-
-  auto *Exp = mod.createPlaceholder(ElemKind::FloatTy, {1, numOutputElem},
-                                    "exp", false);
-  Node *O = F->createConcat("concat", {A, B}, 1);
-  O = F->createRegression("reg", O, Exp);
-  auto *result = F->createSave("ret", O);
-
   Tensor inputs(ElemKind::FloatTy, {{1, numOutputElem / 2}});
   Tensor outputs(ElemKind::FloatTy, {{1, numOutputElem}});
 
   auto inputsH = inputs.getHandle<>();
   auto outputsH = outputs.getHandle<>();
+  auto &trainingMod = EET_.getModule();
+  inputsH.randomize(-1, 1, trainingMod.getPRNG());
+  outputsH.randomize(-1, 1, trainingMod.getPRNG());
 
-  inputsH.randomize(-1, 1, mod.getPRNG());
-  outputsH.randomize(-1, 1, mod.getPRNG());
-
-  performGradCheck(EE_, bindings, result, A, Exp, &inputs, &outputs, 0.001,
-                   0.01);
+  performGradCheck(EET_, EEI_, bindings, result->getPlaceholder(), A, Exp,
+                   &inputs, &outputs, 0.001, 0.01);
 }
 
 TEST_P(InterpreterGrad, gradientCheckMatMul) {
   PlaceholderBindings Bindings;
+  Placeholder *A, *Exp, *B;
+  SaveNode *Result;
   size_t NumDim = 10;
+  for (auto *EE : engines_) {
+    auto &Mod = EE->getModule();
+    Bindings.clear();
+    Function *F = Mod.createFunction("main");
 
-  auto &Mod = EE_.getModule();
-  Function *F = Mod.createFunction("main");
+    A = Mod.createPlaceholder(ElemKind::FloatTy, {NumDim, NumDim}, "A", false);
+    B = Mod.createPlaceholder(ElemKind::FloatTy, {NumDim, NumDim}, "B", false);
 
-  auto *A =
-      Mod.createPlaceholder(ElemKind::FloatTy, {NumDim, NumDim}, "A", false);
-  auto *B =
-      Mod.createPlaceholder(ElemKind::FloatTy, {NumDim, NumDim}, "B", false);
-
-  auto HandleB = Bindings.allocate(B)->getHandle<float>();
-  HandleB.randomize(-1, 1, Mod.getPRNG());
-
-  auto *Exp =
-      Mod.createPlaceholder(ElemKind::FloatTy, {NumDim, NumDim}, "exp", false);
-  Node *MM = F->createMatMul("matmul", A, B);
-  auto *Reg = F->createRegression("reg", MM, Exp);
-  auto *Result = F->createSave("save", Reg);
+    Exp = Mod.createPlaceholder(ElemKind::FloatTy, {NumDim, NumDim}, "exp",
+                                false);
+    auto HandleB = Bindings.allocate(B)->getHandle<float>();
+    HandleB.randomize(-1, 1, Mod.getPRNG());
+    Node *MM = F->createMatMul("matmul", A, B);
+    auto *Reg = F->createRegression("reg", MM, Exp);
+    Result = F->createSave("save", Reg);
+  }
 
   Tensor Inputs(ElemKind::FloatTy, {{NumDim, NumDim}});
   Tensor Outputs(ElemKind::FloatTy, {{NumDim, NumDim}});
 
   auto InputsH = Inputs.getHandle<>();
   auto OutputsH = Outputs.getHandle<>();
+  auto &Mod = EET_.getModule();
 
   InputsH.randomize(-1, 1, Mod.getPRNG());
   OutputsH.randomize(-1, 1, Mod.getPRNG());
 
-  performGradCheck(EE_, Bindings, Result, A, Exp, &Inputs, &Outputs, 0.001,
-                   0.01);
+  performGradCheck(EET_, EEI_, Bindings, Result->getPlaceholder(), A, Exp,
+                   &Inputs, &Outputs, 0.001, 0.01);
 }
 
 TEST_P(InterpreterGrad, gradientCheckBatchedReduceAddAxis0) {
   PlaceholderBindings Bindings;
+  Placeholder *A, *Exp;
+  SaveNode *Result;
   size_t BatchSize = 4;
   size_t NumRows = 3;
   size_t NumCols = 5;
+  for (auto *EE : engines_) {
+    auto &Mod = EE->getModule();
+    Function *F = Mod.createFunction("main");
 
-  auto &Mod = EE_.getModule();
-  Function *F = Mod.createFunction("main");
+    A = Mod.createPlaceholder(ElemKind::FloatTy, {BatchSize, NumRows, NumCols},
+                              "A", false);
 
-  auto *A = Mod.createPlaceholder(ElemKind::FloatTy,
-                                  {BatchSize, NumRows, NumCols}, "A", false);
+    Exp = Mod.createPlaceholder(ElemKind::FloatTy, {NumRows, NumCols}, "exp",
+                                false);
 
-  auto *Exp = Mod.createPlaceholder(ElemKind::FloatTy, {NumRows, NumCols},
-                                    "exp", false);
-
-  TypeRef Ty = Mod.uniqueType(ElemKind::FloatTy, {NumRows, NumCols});
-  Node *BRA = F->createBatchedReduceAdd("BRA", Ty, A, 0 /*axis*/);
-  auto *Reg = F->createRegression("reg", BRA, Exp);
-  auto *Result = F->createSave("save", Reg);
+    TypeRef Ty = Mod.uniqueType(ElemKind::FloatTy, {NumRows, NumCols});
+    Node *BRA = F->createBatchedReduceAdd("BRA", Ty, A, 0 /*axis*/);
+    auto *Reg = F->createRegression("reg", BRA, Exp);
+    Result = F->createSave("save", Reg);
+  }
 
   Tensor Inputs(ElemKind::FloatTy, {{BatchSize, NumRows, NumCols}});
   Tensor Outputs(ElemKind::FloatTy, {{NumRows, NumCols}});
 
   auto InputsH = Inputs.getHandle<>();
   auto OutputsH = Outputs.getHandle<>();
-
+  auto &Mod = EET_.getModule();
   InputsH.randomize(-1, 1, Mod.getPRNG());
   OutputsH.randomize(-1, 1, Mod.getPRNG());
 
-  performGradCheck(EE_, Bindings, Result, A, Exp, &Inputs, &Outputs, 0.001,
-                   0.01);
+  performGradCheck(EET_, EEI_, Bindings, Result->getPlaceholder(), A, Exp,
+                   &Inputs, &Outputs, 0.001, 0.01);
 }
 
 TEST_P(InterpreterGrad, gradientCheckBatchedReduceAddAxis1) {
@@ -272,214 +298,255 @@ TEST_P(InterpreterGrad, gradientCheckBatchedReduceAddAxis1) {
   size_t NumRows = 3;
   size_t BatchSize = 4;
   size_t NumCols = 5;
+  Placeholder *A, *Exp;
+  SaveNode *Result;
+  for (auto *EE : engines_) {
+    auto &Mod = EE->getModule();
+    Function *F = Mod.createFunction("main");
 
-  auto &Mod = EE_.getModule();
-  Function *F = Mod.createFunction("main");
+    A = Mod.createPlaceholder(ElemKind::FloatTy, {NumRows, BatchSize, NumCols},
+                              "A", false);
 
-  auto *A = Mod.createPlaceholder(ElemKind::FloatTy,
-                                  {NumRows, BatchSize, NumCols}, "A", false);
+    Exp = Mod.createPlaceholder(ElemKind::FloatTy, {NumRows, NumCols}, "exp",
+                                false);
 
-  auto *Exp = Mod.createPlaceholder(ElemKind::FloatTy, {NumRows, NumCols},
-                                    "exp", false);
-
-  TypeRef Ty = Mod.uniqueType(ElemKind::FloatTy, {NumRows, NumCols});
-  Node *BRA = F->createBatchedReduceAdd("BRA", Ty, A, 1 /*axis*/);
-  auto *Reg = F->createRegression("reg", BRA, Exp);
-  auto *Result = F->createSave("save", Reg);
+    TypeRef Ty = Mod.uniqueType(ElemKind::FloatTy, {NumRows, NumCols});
+    Node *BRA = F->createBatchedReduceAdd("BRA", Ty, A, 1 /*axis*/);
+    auto *Reg = F->createRegression("reg", BRA, Exp);
+    Result = F->createSave("save", Reg);
+  }
 
   Tensor Inputs(ElemKind::FloatTy, {{NumRows, BatchSize, NumCols}});
   Tensor Outputs(ElemKind::FloatTy, {{NumRows, NumCols}});
 
   auto InputsH = Inputs.getHandle<>();
   auto OutputsH = Outputs.getHandle<>();
-
+  auto &Mod = EET_.getModule();
   InputsH.randomize(-1, 1, Mod.getPRNG());
   OutputsH.randomize(-1, 1, Mod.getPRNG());
 
-  performGradCheck(EE_, Bindings, Result, A, Exp, &Inputs, &Outputs, 0.001,
-                   0.01);
+  performGradCheck(EET_, EEI_, Bindings, Result->getPlaceholder(), A, Exp,
+                   &Inputs, &Outputs, 0.001, 0.01);
 }
 
 TEST_P(InterpreterGrad, gradientCheckGatherVec) {
   PlaceholderBindings Bindings;
+  Placeholder *A, *Exp;
+  SaveNode *Result;
+  for (auto *EE : engines_) {
+    auto &Mod = EE->getModule();
+    Bindings.clear();
+    Function *F = Mod.createFunction("main");
 
-  auto &Mod = EE_.getModule();
-  Function *F = Mod.createFunction("main");
+    A = Mod.createPlaceholder(ElemKind::FloatTy, {3, 4}, "A", false);
+    auto *Indices = Mod.createPlaceholder(ElemKind::Int64ITy, {2}, "I", false);
+    Bindings.allocate(Indices)->getHandle<int64_t>() = {0, 2};
+    Exp = Mod.createPlaceholder(ElemKind::FloatTy, {2, 4}, "exp", false);
 
-  auto *A = Mod.createPlaceholder(ElemKind::FloatTy, {3, 4}, "A", false);
-  auto *Indices = Mod.createPlaceholder(ElemKind::Int64ITy, {2}, "I", false);
-  Bindings.allocate(Indices)->getHandle<int64_t>() = {0, 2};
-  auto *Exp = Mod.createPlaceholder(ElemKind::FloatTy, {2, 4}, "exp", false);
-
-  Node *G = F->createGather("gather", A, Indices, 0 /*batchDims*/);
-  auto *Reg = F->createRegression("reg", G, Exp);
-  auto *Result = F->createSave("save", Reg);
+    Node *G = F->createGather("gather", A, Indices, 0 /*batchDims*/);
+    auto *Reg = F->createRegression("reg", G, Exp);
+    Result = F->createSave("save", Reg);
+  }
 
   Tensor Inputs(ElemKind::FloatTy, {{3, 4}});
   Tensor Outputs(ElemKind::FloatTy, {{2, 4}});
 
   auto InputsH = Inputs.getHandle<>();
   auto OutputsH = Outputs.getHandle<>();
-
+  auto &Mod = EET_.getModule();
   InputsH.randomize(-1, 1, Mod.getPRNG());
   OutputsH.randomize(-1, 1, Mod.getPRNG());
 
-  performGradCheck(EE_, Bindings, Result, A, Exp, &Inputs, &Outputs, 0.001,
-                   0.01);
+  performGradCheck(EET_, EEI_, Bindings, Result->getPlaceholder(), A, Exp,
+                   &Inputs, &Outputs, 0.001, 0.01);
 }
 
 TEST_P(InterpreterGrad, gradientCheckGatherDim) {
   PlaceholderBindings Bindings;
+  Placeholder *A, *Exp;
+  SaveNode *Result;
+  for (auto *EE : engines_) {
+    auto &Mod = EE->getModule();
+    Bindings.clear();
+    Function *F = Mod.createFunction("main");
 
-  auto &Mod = EE_.getModule();
-  Function *F = Mod.createFunction("main");
+    A = Mod.createPlaceholder(ElemKind::FloatTy, {8, 4}, "A", false);
+    auto *Indices =
+        Mod.createPlaceholder(ElemKind::Int64ITy, {2, 2}, "I", false);
+    Bindings.allocate(Indices)->getHandle<int64_t>() = {0, 2, 3, 1};
+    Exp = Mod.createPlaceholder(ElemKind::FloatTy, {2, 2, 4}, "exp", false);
 
-  auto *A = Mod.createPlaceholder(ElemKind::FloatTy, {8, 4}, "A", false);
-  auto *Indices = Mod.createPlaceholder(ElemKind::Int64ITy, {2, 2}, "I", false);
-  Bindings.allocate(Indices)->getHandle<int64_t>() = {0, 2, 3, 1};
-  auto *Exp = Mod.createPlaceholder(ElemKind::FloatTy, {2, 2, 4}, "exp", false);
-
-  Node *G = F->createGather("gather", A, Indices, 0 /*batchDims*/);
-  auto *Reg = F->createRegression("reg", G, Exp);
-  auto *Result = F->createSave("save", Reg);
+    Node *G = F->createGather("gather", A, Indices, 0 /*batchDims*/);
+    auto *Reg = F->createRegression("reg", G, Exp);
+    Result = F->createSave("save", Reg);
+  }
 
   Tensor Inputs(ElemKind::FloatTy, {{8, 4}});
   Tensor Outputs(ElemKind::FloatTy, {{2, 2, 4}});
 
   auto InputsH = Inputs.getHandle<>();
   auto OutputsH = Outputs.getHandle<>();
-
+  auto &Mod = EET_.getModule();
   InputsH.randomize(-1, 1, Mod.getPRNG());
   OutputsH.randomize(-1, 1, Mod.getPRNG());
 
-  performGradCheck(EE_, Bindings, Result, A, Exp, &Inputs, &Outputs, 0.001,
-                   0.01);
+  performGradCheck(EET_, EEI_, Bindings, Result->getPlaceholder(), A, Exp,
+                   &Inputs, &Outputs, 0.001, 0.01);
 }
 
 static void gradientCheckGroupConv(size_t depth, size_t group,
-                                   ExecutionEngine &EE_) {
+                                   ExecutionEngine2 &EET_,
+                                   ExecutionEngine2 &EEI_) {
   PlaceholderBindings bindings;
   size_t numDim = 10;
+  std::vector<ExecutionEngine2 *> engines;
+  engines.push_back(&EEI_);
+  engines.push_back(&EET_);
+  Placeholder *A, *Ex;
+  SaveNode *result;
+  for (auto *EE : engines) {
+    auto &mod = EE->getModule();
+    bindings.clear();
+    Function *F = mod.createFunction("main");
+    A = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim, numDim, depth},
+                              "A", false);
+    Ex = mod.createPlaceholder(
+        ElemKind::FloatTy, {1, numDim + 1, numDim + 1, depth}, "exp", false);
 
-  auto &mod = EE_.getModule();
-  Function *F = mod.createFunction("main");
-  auto *A = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim, numDim, depth},
-                                  "A", false);
-  auto *Ex = mod.createPlaceholder(
-      ElemKind::FloatTy, {1, numDim + 1, numDim + 1, depth}, "exp", false);
-
-  Node *O = F->createConv(bindings, "conv", A, depth, 2, 1, 1, group);
-  O = F->createRegression("reg", O, Ex);
-  auto *result = F->createSave("ret", O);
+    Node *O = F->createConv(bindings, "conv", A, depth, 2, 1, 1, group);
+    O = F->createRegression("reg", O, Ex);
+    result = F->createSave("ret", O);
+  }
 
   Tensor inputs(ElemKind::FloatTy, {1, numDim, numDim, depth});
   Tensor outputs(ElemKind::FloatTy, {1, numDim + 1, numDim + 1, depth});
 
   auto inputsH = inputs.getHandle<>();
   auto outputsH = outputs.getHandle<>();
-
+  auto &mod = EET_.getModule();
   inputsH.randomize(-1, 1, mod.getPRNG());
   outputsH.randomize(-1, 1, mod.getPRNG());
 
-  performGradCheck(EE_, bindings, result, A, Ex, &inputs, &outputs, 0.001,
-                   0.04);
+  performGradCheck(EET_, EEI_, bindings, result->getPlaceholder(), A, Ex,
+                   &inputs, &outputs, 0.001, 0.04);
 }
 
-TEST_P(GradCheck, gradientCheckConv) { gradientCheckGroupConv(1, 1, EE_); }
+TEST_P(GradCheck, gradientCheckConv) {
+  gradientCheckGroupConv(1, 1, EET_, EEI_);
+}
 
 TEST_P(GradCheck, gradientCheckDepthwiseConv) {
-  gradientCheckGroupConv(4, 4, EE_);
+  gradientCheckGroupConv(4, 4, EET_, EEI_);
 }
 
-TEST_P(GradCheck, gradientCheckGroupConv) { gradientCheckGroupConv(4, 2, EE_); }
+TEST_P(GradCheck, gradientCheckGroupConv) {
+  gradientCheckGroupConv(4, 2, EET_, EEI_);
+}
 
 static void gradientCheckDilatedConv(size_t depth, size_t group,
-                                     size_t dilation, ExecutionEngine &EE_) {
+                                     size_t dilation, ExecutionEngine2 &EET_,
+                                     ExecutionEngine2 &EEI_) {
   PlaceholderBindings bindings;
   size_t numDim = 10;
+  std::vector<ExecutionEngine2 *> engines;
+  engines.push_back(&EEI_);
+  engines.push_back(&EET_);
+  Placeholder *A, *Ex;
+  SaveNode *result;
+  for (auto *EE : engines) {
+    auto &mod = EE->getModule();
+    bindings.clear();
+    Function *F = mod.createFunction("main");
+    A = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim, numDim, depth},
+                              "A", false);
+    Ex = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim, numDim, depth},
+                               "exp", false);
 
-  auto &mod = EE_.getModule();
-  Function *F = mod.createFunction("main");
-  auto *A = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim, numDim, depth},
-                                  "A", false);
-  auto *Ex = mod.createPlaceholder(ElemKind::FloatTy,
-                                   {1, numDim, numDim, depth}, "exp", false);
-
-  Node *O = F->createConv(bindings, "conv", A, depth, 2, 1, 1, group, dilation);
-  O = F->createRegression("reg", O, Ex);
-  auto *result = F->createSave("ret", O);
+    Node *O =
+        F->createConv(bindings, "conv", A, depth, 2, 1, 1, group, dilation);
+    O = F->createRegression("reg", O, Ex);
+    result = F->createSave("ret", O);
+  }
 
   Tensor inputs(ElemKind::FloatTy, {1, numDim, numDim, depth});
   Tensor outputs(ElemKind::FloatTy, {1, numDim, numDim, depth});
 
   auto inputsH = inputs.getHandle<>();
   auto outputsH = outputs.getHandle<>();
-
+  auto &mod = EET_.getModule();
   inputsH.randomize(-1, 1, mod.getPRNG());
   outputsH.randomize(-1, 1, mod.getPRNG());
 
-  performGradCheck(EE_, bindings, result, A, Ex, &inputs, &outputs, 0.001,
-                   0.04);
+  performGradCheck(EET_, EEI_, bindings, result->getPlaceholder(), A, Ex,
+                   &inputs, &outputs, 0.001, 0.04);
 }
 
 TEST_P(GradCheck, gradientCheckDilatedConv) {
-  gradientCheckDilatedConv(1, 1, 2, EE_);
+  gradientCheckDilatedConv(1, 1, 2, EET_, EEI_);
 }
 
 TEST_P(InterpreterGrad, gradientCheckAvgPool) {
   PlaceholderBindings bindings;
   size_t numDim = 10;
   size_t numOutputElem = 10;
+  Placeholder *A, *Exp;
+  SaveNode *result;
+  for (auto *EE : engines_) {
+    auto &mod = EE->getModule();
+    bindings.clear();
+    Function *F = mod.createFunction("main");
+    A = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim, numDim, 1}, "A",
+                              false);
+    Exp = mod.createPlaceholder(ElemKind::FloatTy, {1, numOutputElem}, "Exp",
+                                false);
 
-  auto &mod = EE_.getModule();
-  Function *F = mod.createFunction("main");
-  auto *A = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim, numDim, 1},
-                                  "A", false);
-  auto *Exp = mod.createPlaceholder(ElemKind::FloatTy, {1, numOutputElem},
-                                    "Exp", false);
-
-  Node *O = F->createAvgPool("pool", A, 3, 3, 1);
-  O = F->createTanh("tanh", O);
-  O = F->createFullyConnected(bindings, "fc", O, numOutputElem);
-  O = F->createRegression("reg", O, Exp);
-  auto *result = F->createSave("ret", O);
+    Node *O = F->createAvgPool("pool", A, 3, 3, 1);
+    O = F->createTanh("tanh", O);
+    O = F->createFullyConnected(bindings, "fc", O, numOutputElem);
+    O = F->createRegression("reg", O, Exp);
+    result = F->createSave("ret", O);
+  }
 
   Tensor inputs(ElemKind::FloatTy, {1, numDim, numDim, 1});
   Tensor outputs(ElemKind::FloatTy, {1, numOutputElem});
 
   auto inputsH = inputs.getHandle<>();
   auto outputsH = outputs.getHandle<>();
-
+  auto &mod = EET_.getModule();
   inputsH.initXavier(1, mod.getPRNG());
   outputsH.initXavier(1, mod.getPRNG());
 
-  performGradCheck(EE_, bindings, result, A, Exp, &inputs, &outputs, 0.001,
-                   0.004);
+  performGradCheck(EET_, EEI_, bindings, result->getPlaceholder(), A, Exp,
+                   &inputs, &outputs, 0.001, 0.004);
 }
 
 TEST_P(InterpreterGrad, gradientCheckBatchNorm) {
   PlaceholderBindings bindings;
   size_t numDim = 5;
   size_t numOutputElem = numDim * numDim * 3;
+  Placeholder *A, *Ex;
+  SaveNode *result;
+  for (auto *EE : engines_) {
+    auto &mod = EE->getModule();
+    bindings.clear();
+    Function *F = mod.createFunction("main");
+    A = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim, numDim, 3}, "A",
+                              false);
+    Ex = mod.createPlaceholder(ElemKind::FloatTy, {1, numOutputElem}, "exp",
+                               false);
 
-  auto &mod = EE_.getModule();
-  Function *F = mod.createFunction("main");
-  auto *A = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim, numDim, 3},
-                                  "A", false);
-  auto *Ex = mod.createPlaceholder(ElemKind::FloatTy, {1, numOutputElem}, "exp",
-                                   false);
-
-  Node *O = F->createBatchNormalization(bindings, "batch", A, 3, 0.0001, 0.9);
-  O = F->createReshape("reshape", O, {1, numDim * numDim * 3});
-  O = F->createRegression("reg", O, Ex);
-  auto *result = F->createSave("ret", O);
+    Node *O = F->createBatchNormalization(bindings, "batch", A, 3, 0.0001, 0.9);
+    O = F->createReshape("reshape", O, {1, numDim * numDim * 3});
+    O = F->createRegression("reg", O, Ex);
+    result = F->createSave("ret", O);
+  }
 
   Tensor inputs(ElemKind::FloatTy, {1, numDim, numDim, 3});
   Tensor outputs(ElemKind::FloatTy, {1, numOutputElem});
 
   auto inputsH = inputs.getHandle<>();
   auto outputsH = outputs.getHandle<>();
-
+  auto &mod = EET_.getModule();
   inputsH.initXavier(1, mod.getPRNG());
   outputsH.initXavier(1, mod.getPRNG());
 
@@ -487,8 +554,8 @@ TEST_P(InterpreterGrad, gradientCheckBatchNorm) {
     elem = elem * 6 + 4;
   }
 
-  performGradCheck(EE_, bindings, result, A, Ex, &inputs, &outputs, 0.001,
-                   0.004);
+  performGradCheck(EET_, EEI_, bindings, result->getPlaceholder(), A, Ex,
+                   &inputs, &outputs, 0.001, 0.004);
 }
 
 TEST_P(InterpreterGrad, gradientCheckArithmeticDiv) {
@@ -497,72 +564,79 @@ TEST_P(InterpreterGrad, gradientCheckArithmeticDiv) {
   // correct value for A, and then gradient check will be performed.
   PlaceholderBindings bindings;
   size_t numDim = 10;
+  Placeholder *B, *Exp;
+  SaveNode *result;
+  for (auto *EE : engines_) {
+    auto &mod = EE->getModule();
+    bindings.clear();
+    Function *F = mod.createFunction("main");
+    auto *A = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim}, "A", true);
+    B = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim}, "B", false);
+    Exp = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim}, "exp", false);
 
-  auto &mod = EE_.getModule();
-  Function *F = mod.createFunction("main");
-  auto *A = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim}, "A", true);
-  auto *B = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim}, "B", false);
-  auto *Exp =
-      mod.createPlaceholder(ElemKind::FloatTy, {1, numDim}, "exp", false);
+    auto *ATensor = bindings.allocate(A);
+    ATensor->init(Tensor::InitKind::Xavier, 1.0, mod.getPRNG());
 
-  auto *ATensor = bindings.allocate(A);
-  ATensor->init(Tensor::InitKind::Xavier, 1.0, mod.getPRNG());
-
-  Node *O = F->createDiv("div", A, B);
-  O = F->createRegression("reg", O, Exp);
-  auto *result = F->createSave("ret", O);
+    Node *O = F->createDiv("div", A, B);
+    O = F->createRegression("reg", O, Exp);
+    result = F->createSave("ret", O);
+  }
 
   Tensor BValues(ElemKind::FloatTy, {1, numDim});
   Tensor ExpValues(ElemKind::FloatTy, {1, numDim});
   // Random values are in the range, so that all intermediate computations are
   // not too small and not too large.
+  auto &mod = EET_.getModule();
   BValues.getHandle().randomize(0.1, 1, mod.getPRNG());
   ExpValues.getHandle().randomize(0.1, 1, mod.getPRNG());
 
-  performGradCheck(EE_, bindings, result, B, Exp, &BValues, &ExpValues, 0.0001,
-                   0.001);
+  performGradCheck(EET_, EEI_, bindings, result->getPlaceholder(), B, Exp,
+                   &BValues, &ExpValues, 0.0001, 0.001);
 }
 
 TEST_P(InterpreterGrad, gradientCheckArithmetic) {
   PlaceholderBindings bindings;
   size_t numDim = 20;
+  Placeholder *A, *Exp;
+  SaveNode *result;
+  for (auto *EE : engines_) {
+    auto &mod = EE->getModule();
+    bindings.clear();
+    Function *F = mod.createFunction("main");
+    A = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim}, "A", false);
+    auto *B = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim}, "B", true);
+    auto *C = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim}, "C", false);
+    auto *D = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim}, "D", false);
+    auto *E = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim}, "E", false);
+    bindings.allocate(B)->zero();
+    bindings.allocate(C)->zero();
+    bindings.allocate(D)->zero();
 
-  auto &mod = EE_.getModule();
-  Function *F = mod.createFunction("main");
-  auto *A = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim}, "A", false);
-  auto *B = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim}, "B", true);
-  auto *C = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim}, "C", false);
-  auto *D = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim}, "D", false);
-  auto *E = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim}, "E", false);
-  bindings.allocate(B)->zero();
-  bindings.allocate(C)->zero();
-  bindings.allocate(D)->zero();
+    // Randomize E to avoid div by zero.
+    auto *ETensor = bindings.allocate(E);
+    ETensor->getHandle().randomize(-1, 1, mod.getPRNG());
 
-  // Randomize E to avoid div by zero.
-  auto *ETensor = bindings.allocate(E);
-  ETensor->getHandle().randomize(-1, 1, mod.getPRNG());
+    Exp = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim}, "exp", false);
 
-  auto *Exp =
-      mod.createPlaceholder(ElemKind::FloatTy, {1, numDim}, "exp", false);
-
-  Node *O = F->createMul("mul", A, B);
-  O = F->createAdd("add", O, C);
-  O = F->createSub("sub", D, O);
-  O = F->createDiv("div", O, E);
-  O = F->createRegression("reg", O, Exp);
-  auto *result = F->createSave("ret", O);
+    Node *O = F->createMul("mul", A, B);
+    O = F->createAdd("add", O, C);
+    O = F->createSub("sub", D, O);
+    O = F->createDiv("div", O, E);
+    O = F->createRegression("reg", O, Exp);
+    result = F->createSave("ret", O);
+  }
 
   Tensor inputs(ElemKind::FloatTy, {1, numDim});
   Tensor outputs(ElemKind::FloatTy, {1, numDim});
 
   auto inputsH = inputs.getHandle<>();
   auto outputsH = outputs.getHandle<>();
-
+  auto &mod = EET_.getModule();
   inputsH.randomize(-1, 1, mod.getPRNG());
   outputsH.randomize(-1, 1, mod.getPRNG());
 
-  performGradCheck(EE_, bindings, result, A, Exp, &inputs, &outputs, 0.01,
-                   0.004);
+  performGradCheck(EET_, EEI_, bindings, result->getPlaceholder(), A, Exp,
+                   &inputs, &outputs, 0.01, 0.004);
 }
 
 TEST_P(InterpreterGrad, gradientCheckFCConcatTanh) {
@@ -570,146 +644,158 @@ TEST_P(InterpreterGrad, gradientCheckFCConcatTanh) {
   PlaceholderBindings bindings;
   size_t numInputElem = 20;
   size_t numOutputElem = 10;
+  Placeholder *A, *Exp;
+  SaveNode *result;
+  for (auto *EE : engines_) {
+    auto &mod = EE->getModule();
+    bindings.clear();
+    Function *F = mod.createFunction("main");
+    A = mod.createPlaceholder(ElemKind::FloatTy, {1, numInputElem}, "A", false);
+    Exp = mod.createPlaceholder(ElemKind::FloatTy, {1, numOutputElem}, "Exp",
+                                false);
 
-  auto &mod = EE_.getModule();
-  Function *F = mod.createFunction("main");
-  auto *A =
-      mod.createPlaceholder(ElemKind::FloatTy, {1, numInputElem}, "A", false);
-  auto *Exp = mod.createPlaceholder(ElemKind::FloatTy, {1, numOutputElem},
-                                    "Exp", false);
-
-  Node *FA = F->createFullyConnected(bindings, "fc", A, numOutputElem);
-  FA = F->createTanh("tanh", FA);
-  FA = F->createRegression("reg", FA, Exp);
-  auto *result = F->createSave("ret", FA);
-
+    Node *FA = F->createFullyConnected(bindings, "fc", A, numOutputElem);
+    FA = F->createTanh("tanh", FA);
+    FA = F->createRegression("reg", FA, Exp);
+    result = F->createSave("ret", FA);
+  }
   Tensor inputs(ElemKind::FloatTy, {{1, numInputElem}});
   Tensor outputs(ElemKind::FloatTy, {{1, numOutputElem}});
 
   auto inputsH = inputs.getHandle<>();
   auto outputsH = outputs.getHandle<>();
-
+  auto &mod = EET_.getModule();
   inputsH.initXavier(1, mod.getPRNG());
   outputsH.initXavier(1, mod.getPRNG());
 
-  performGradCheck(EE_, bindings, result, A, Exp, &inputs, &outputs, 0.0001,
-                   0.001);
+  performGradCheck(EET_, EEI_, bindings, result->getPlaceholder(), A, Exp,
+                   &inputs, &outputs, 0.0001, 0.001);
 }
 
 TEST_P(InterpreterGrad, gradientCheckFC) {
   PlaceholderBindings bindings;
   size_t numInputElem = 20;
   size_t numOutputElem = 10;
+  Placeholder *A, *Exp;
+  SaveNode *result;
+  for (auto *EE : engines_) {
+    auto &mod = EE->getModule();
+    bindings.clear();
+    Function *F = mod.createFunction("main");
+    A = mod.createPlaceholder(ElemKind::FloatTy, {1, numInputElem}, "A", false);
+    Exp = mod.createPlaceholder(ElemKind::FloatTy, {1, numOutputElem}, "Exp",
+                                false);
 
-  auto &mod = EE_.getModule();
-  Function *F = mod.createFunction("main");
-  auto *A =
-      mod.createPlaceholder(ElemKind::FloatTy, {1, numInputElem}, "A", false);
-  auto *Exp = mod.createPlaceholder(ElemKind::FloatTy, {1, numOutputElem},
-                                    "Exp", false);
-
-  Node *FA = F->createFullyConnected(bindings, "fc", A, numOutputElem);
-  FA = F->createRegression("reg", FA, Exp);
-  auto *result = F->createSave("ret", FA);
+    Node *FA = F->createFullyConnected(bindings, "fc", A, numOutputElem);
+    FA = F->createRegression("reg", FA, Exp);
+    result = F->createSave("ret", FA);
+  }
 
   Tensor inputs(ElemKind::FloatTy, {{1, numInputElem}});
   Tensor outputs(ElemKind::FloatTy, {{1, numOutputElem}});
 
   auto inputsH = inputs.getHandle<>();
   auto outputsH = outputs.getHandle<>();
-
+  auto &mod = EET_.getModule();
   inputsH.initXavier(1, mod.getPRNG());
   outputsH.initXavier(1, mod.getPRNG());
 
-  performGradCheck(EE_, bindings, result, A, Exp, &inputs, &outputs, 0.0001,
-                   0.0001);
+  performGradCheck(EET_, EEI_, bindings, result->getPlaceholder(), A, Exp,
+                   &inputs, &outputs, 0.0001, 0.0001);
 }
 
 TEST_P(InterpreterGrad, gradientCheckSigmoid) {
   PlaceholderBindings bindings;
   size_t numInputElem = 20;
   size_t numOutputElem = 20;
+  Placeholder *A, *Exp;
+  SaveNode *result;
+  for (auto *EE : engines_) {
+    auto &mod = EE->getModule();
+    Function *F = mod.createFunction("main");
+    A = mod.createPlaceholder(ElemKind::FloatTy, {1, numInputElem}, "A", false);
+    Exp = mod.createPlaceholder(ElemKind::FloatTy, {1, numOutputElem}, "Exp",
+                                false);
 
-  auto &mod = EE_.getModule();
-  Function *F = mod.createFunction("main");
-  auto *A =
-      mod.createPlaceholder(ElemKind::FloatTy, {1, numInputElem}, "A", false);
-  auto *Exp = mod.createPlaceholder(ElemKind::FloatTy, {1, numOutputElem},
-                                    "Exp", false);
-
-  Node *FA = F->createSigmoid("sig", A);
-  FA = F->createRegression("reg", FA, Exp);
-  auto *result = F->createSave("ret", FA);
+    Node *FA = F->createSigmoid("sig", A);
+    FA = F->createRegression("reg", FA, Exp);
+    result = F->createSave("ret", FA);
+  }
 
   Tensor inputs(ElemKind::FloatTy, {{1, numInputElem}});
   Tensor outputs(ElemKind::FloatTy, {{1, numOutputElem}});
 
   auto inputsH = inputs.getHandle<>();
   auto outputsH = outputs.getHandle<>();
-
+  auto &mod = EET_.getModule();
   inputsH.initXavier(1, mod.getPRNG());
   outputsH.initXavier(1, mod.getPRNG());
 
-  performGradCheck(EE_, bindings, result, A, Exp, &inputs, &outputs, 0.001,
-                   0.01);
+  performGradCheck(EET_, EEI_, bindings, result->getPlaceholder(), A, Exp,
+                   &inputs, &outputs, 0.001, 0.01);
 }
 
 TEST_P(InterpreterGrad, gradientCheckRelu) {
   PlaceholderBindings bindings;
   size_t numInputElem = 20;
   size_t numOutputElem = 20;
+  Placeholder *A, *Exp;
+  SaveNode *result;
+  for (auto *EE : engines_) {
+    auto &mod = EE->getModule();
+    Function *F = mod.createFunction("main");
+    A = mod.createPlaceholder(ElemKind::FloatTy, {1, numInputElem}, "A", false);
+    Exp = mod.createPlaceholder(ElemKind::FloatTy, {1, numOutputElem}, "Exp",
+                                false);
 
-  auto &mod = EE_.getModule();
-  Function *F = mod.createFunction("main");
-  auto *A =
-      mod.createPlaceholder(ElemKind::FloatTy, {1, numInputElem}, "A", false);
-  auto *Exp = mod.createPlaceholder(ElemKind::FloatTy, {1, numOutputElem},
-                                    "Exp", false);
-
-  Node *FA = F->createRELU("relu", A);
-  FA = F->createRegression("reg", FA, Exp);
-  auto *result = F->createSave("ret", FA);
+    Node *FA = F->createRELU("relu", A);
+    FA = F->createRegression("reg", FA, Exp);
+    result = F->createSave("ret", FA);
+  }
 
   Tensor inputs(ElemKind::FloatTy, {{1, numInputElem}});
   Tensor outputs(ElemKind::FloatTy, {{1, numOutputElem}});
 
   auto inputsH = inputs.getHandle<>();
   auto outputsH = outputs.getHandle<>();
-
+  auto &mod = EET_.getModule();
   inputsH.initXavier(1, mod.getPRNG());
   outputsH.initXavier(1, mod.getPRNG());
 
-  performGradCheck(EE_, bindings, result, A, Exp, &inputs, &outputs, 0.001,
-                   0.01);
+  performGradCheck(EET_, EEI_, bindings, result->getPlaceholder(), A, Exp,
+                   &inputs, &outputs, 0.001, 0.01);
 }
 
 TEST_P(InterpreterGrad, gradientCheckTranspose) {
   // Using the same gradient check test setup as gradientCheck_FC_Concat_RELU
   PlaceholderBindings bindings;
   size_t numOutputElem = 10;
-
-  auto &mod = EE_.getModule();
-  Function *F = mod.createFunction("main");
-  auto *A =
-      mod.createPlaceholder(ElemKind::FloatTy, {1, 5, 10, 5}, "input", false);
-  auto *Exp = mod.createPlaceholder(ElemKind::FloatTy, {1, numOutputElem},
-                                    "exp", false);
-  Node *TA = F->createTranspose("transpose", A, NHWC2NCHW);
-  TA = F->createFullyConnected(bindings, "fc", TA, numOutputElem);
-  TA = F->createRegression("regress", TA, Exp);
-  auto *result = F->createSave("ret", TA);
+  Placeholder *A, *Exp;
+  SaveNode *result;
+  for (auto *EE : engines_) {
+    auto &mod = EE->getModule();
+    bindings.clear();
+    Function *F = mod.createFunction("main");
+    A = mod.createPlaceholder(ElemKind::FloatTy, {1, 5, 10, 5}, "input", false);
+    Exp = mod.createPlaceholder(ElemKind::FloatTy, {1, numOutputElem}, "exp",
+                                false);
+    Node *TA = F->createTranspose("transpose", A, NHWC2NCHW);
+    TA = F->createFullyConnected(bindings, "fc", TA, numOutputElem);
+    TA = F->createRegression("regress", TA, Exp);
+    result = F->createSave("ret", TA);
+  }
 
   Tensor inputs(ElemKind::FloatTy, {1, 5, 10, 5});
   Tensor outputs(ElemKind::FloatTy, {1, numOutputElem});
 
   auto inputsH = inputs.getHandle<>();
   auto outputsH = outputs.getHandle<>();
-
+  auto &mod = EET_.getModule();
   inputsH.randomize(-1, 1, mod.getPRNG());
   outputsH.randomize(-1, 1, mod.getPRNG());
 
-  performGradCheck(EE_, bindings, result, A, Exp, &inputs, &outputs, 0.0001,
-                   0.001);
+  performGradCheck(EET_, EEI_, bindings, result->getPlaceholder(), A, Exp,
+                   &inputs, &outputs, 0.0001, 0.001);
 }
 
 TEST_P(InterpreterGrad, gradientCheckCrossEntropyLoss) {
@@ -720,7 +806,7 @@ TEST_P(InterpreterGrad, gradientCheckCrossEntropyLoss) {
   TrainingConfig TC;
   PlaceholderBindings bindings;
 
-  auto &mod = EE_.getModule();
+  auto &mod = EET_.getModule();
   Function *F = mod.createFunction("main");
   auto *P =
       mod.createPlaceholder(ElemKind::FloatTy, {batchSize, 4}, "P", false);
@@ -746,9 +832,9 @@ TEST_P(InterpreterGrad, gradientCheckCrossEntropyLoss) {
   outputsH.at({2}) = 1;
 
   VariableGradientsList varGrads;
-  Function *TF = glow::differentiate(F, TC, "record", &varGrads);
+  glow::differentiate(F, TC, "record", &varGrads);
   allocateGrads(bindings, varGrads);
-  EE_.compile(CompilationMode::Train, TF);
+  EET_.compile(CompilationMode::Train);
 
   auto *gradPlaceholder = getGrad(varGrads, P);
   auto gradTensorHandle = bindings.get(gradPlaceholder)->getHandle();
@@ -756,24 +842,24 @@ TEST_P(InterpreterGrad, gradientCheckCrossEntropyLoss) {
   for (int i = 0; i < testSamples; ++i) {
     inputsH.randomize(0.0, 1.0, mod.getPRNG());
     for (size_t j = 0; j < inputsH.size(); ++j) {
-      updateInputPlaceholders(bindings, {P, Y}, {&inputs, &outputs});
-      EE_.run(bindings);
+      updateInputPlaceholders2(bindings, {P, Y}, {&inputs, &outputs});
+      EET_.run(bindings, "record");
       LTensor->zero();
       auto x = inputsH.raw(j);
       auto g = gradTensorHandle.raw(j);
       inputsH.raw(j) = x + stepSize;
-      updateInputPlaceholders(bindings, {P, Y}, {&inputs, &outputs});
-      EE_.run(bindings);
+      updateInputPlaceholders2(bindings, {P, Y}, {&inputs, &outputs});
+      EET_.run(bindings, "record");
       auto lp = LTensor->getHandle().raw(0);
       inputsH.raw(j) = x - stepSize;
       LTensor->zero();
-      updateInputPlaceholders(bindings, {P, Y}, {&inputs, &outputs});
-      EE_.run(bindings);
+      updateInputPlaceholders2(bindings, {P, Y}, {&inputs, &outputs});
+      EET_.run(bindings, "record");
       auto lm = LTensor->getHandle().raw(0);
       auto diff = (lp - lm) / (2 * stepSize);
       inputsH.raw(j) = x;
-      updateInputPlaceholders(bindings, {P, Y}, {&inputs, &outputs});
-      EE_.run(bindings);
+      updateInputPlaceholders2(bindings, {P, Y}, {&inputs, &outputs});
+      EET_.run(bindings, "record");
       EXPECT_NEAR(diff, g, delta);
     }
   }


### PR DESCRIPTION
Summary: This PR ports GradCheckTest to the new EE2

Documentation:

Work on #3239 

Test Plan: verify everything builds and GradCheckTest runs and passes.
