### PR TITLE
[RuntimeBundle] Disable implicit copy for RuntimeBundle

### DIFF
--- a/include/glow/Backend/BackendUtils.h
+++ b/include/glow/Backend/BackendUtils.h
@@ -64,6 +64,8 @@ class RuntimeBundle {
   size_t mutableWeightVarsMemSize_{0};
   /// Amount of memory needed for activations.
   size_t activationsMemSize_{0};
+  /// True if the RuntimeBundle is valid, false if not.
+  bool isValid_{false};
 
 public:
   /// Get Constant Weights memory size.
@@ -118,7 +120,17 @@ public:
       : symbolTable_(std::move(symbolTable)), constants_(nullptr),
         constantWeightVarsMemSize_(constWeight),
         mutableWeightVarsMemSize_(mutableWeight),
-        activationsMemSize_(activations) {}
+        activationsMemSize_(activations), isValid_(true) {}
+
+  // Explicit copy constructor and deleted assignment operator. A RuntimeBundle
+  // should be moved. It should only be copied if absolutely necessary and never
+  // implicitly.
+  explicit RuntimeBundle(const RuntimeBundle &) = default;
+  RuntimeBundle &operator=(const RuntimeBundle &) = delete;
+
+  // Move constructor and assignment operator.
+  RuntimeBundle(RuntimeBundle &&rhs);
+  RuntimeBundle &operator=(RuntimeBundle &&rhs);
 };
 } // namespace runtime
 

--- a/include/glow/Backend/CompiledFunction.h
+++ b/include/glow/Backend/CompiledFunction.h
@@ -31,7 +31,7 @@ public:
   CompiledFunction() = delete;
 
   /// Ctor that accepts runtimeBundle.
-  CompiledFunction(const runtime::RuntimeBundle &bundle);
+  CompiledFunction(runtime::RuntimeBundle &&bundle);
 
   /// Dtor.
   virtual ~CompiledFunction();

--- a/include/glow/LLVMIRCodeGen/LLVMBackend.h
+++ b/include/glow/LLVMIRCodeGen/LLVMBackend.h
@@ -93,7 +93,7 @@ protected:
   /// \returns created CompiledFunction.
   virtual std::unique_ptr<CompiledFunction>
   createCompiledFunction(std::unique_ptr<llvm::orc::GlowJIT> JIT,
-                         const runtime::RuntimeBundle &runtimeBundle) const = 0;
+                         runtime::RuntimeBundle &&runtimeBundle) const = 0;
 
   /// \returns libjit bitcode for the current backend.
   virtual llvm::StringRef getLibjitBitcode() const = 0;

--- a/include/glow/LLVMIRCodeGen/LLVMCompiledFunction.h
+++ b/include/glow/LLVMIRCodeGen/LLVMCompiledFunction.h
@@ -26,7 +26,7 @@ namespace glow {
 class LLVMCompiledFunction : public CompiledFunction {
 public:
   LLVMCompiledFunction(std::unique_ptr<llvm::orc::GlowJIT> JIT,
-                       const runtime::RuntimeBundle &runtimeBundle);
+                       runtime::RuntimeBundle &&runtimeBundle);
 
   /// \name CompiledFunction interface
   ///@{

--- a/lib/Backend/CompiledFunction.cpp
+++ b/lib/Backend/CompiledFunction.cpp
@@ -21,5 +21,5 @@ using namespace glow;
 
 CompiledFunction::~CompiledFunction() { runtimeBundle_.freeConstants(); }
 
-CompiledFunction::CompiledFunction(const runtime::RuntimeBundle &bundle)
-    : runtimeBundle_(bundle){};
+CompiledFunction::CompiledFunction(runtime::RuntimeBundle &&bundle)
+    : runtimeBundle_(std::move(bundle)){};

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -352,8 +352,9 @@ bool CPUBackend::shouldLower(const Node *N) const {
 
 std::unique_ptr<CompiledFunction> CPUBackend::createCompiledFunction(
     std::unique_ptr<llvm::orc::GlowJIT> JIT,
-    const runtime::RuntimeBundle &runtimeBundle) const {
-  return llvm::make_unique<CPUFunction>(std::move(JIT), runtimeBundle);
+    runtime::RuntimeBundle &&runtimeBundle) const {
+  return llvm::make_unique<CPUFunction>(std::move(JIT),
+                                        std::move(runtimeBundle));
 }
 
 std::unique_ptr<LLVMIRGen>

--- a/lib/Backends/CPU/CPUBackend.h
+++ b/lib/Backends/CPU/CPUBackend.h
@@ -56,9 +56,9 @@ public:
               AllocationsInfo &allocationsInfo) const override;
 
 protected:
-  virtual std::unique_ptr<CompiledFunction> createCompiledFunction(
-      std::unique_ptr<llvm::orc::GlowJIT> JIT,
-      const runtime::RuntimeBundle &runtimeBundle) const override;
+  virtual std::unique_ptr<CompiledFunction>
+  createCompiledFunction(std::unique_ptr<llvm::orc::GlowJIT> JIT,
+                         runtime::RuntimeBundle &&runtimeBundle) const override;
 
   virtual llvm::StringRef getLibjitBitcode() const override;
   /// @}

--- a/lib/Backends/CPU/CPUFunction.cpp
+++ b/lib/Backends/CPU/CPUFunction.cpp
@@ -22,8 +22,8 @@
 using namespace glow;
 
 CPUFunction::CPUFunction(std::unique_ptr<llvm::orc::GlowJIT> JIT,
-                         const runtime::RuntimeBundle &runtimeBundle)
-    : LLVMCompiledFunction(std::move(JIT), runtimeBundle) {}
+                         runtime::RuntimeBundle &&runtimeBundle)
+    : LLVMCompiledFunction(std::move(JIT), std::move(runtimeBundle)) {}
 
 llvm::Error CPUFunction::execute(ExecutionContext *context) {
   return LLVMCompiledFunction::execute(context);

--- a/lib/Backends/CPU/CPUFunction.h
+++ b/lib/Backends/CPU/CPUFunction.h
@@ -28,7 +28,7 @@ namespace glow {
 class CPUFunction final : public LLVMCompiledFunction {
 public:
   CPUFunction(std::unique_ptr<llvm::orc::GlowJIT> JIT,
-              const runtime::RuntimeBundle &runtimeBundle);
+              runtime::RuntimeBundle &&runtimeBundle);
 
   /// \name CompiledFunction interface
   ///@{

--- a/lib/Backends/Habana/Habana.cpp
+++ b/lib/Backends/Habana/Habana.cpp
@@ -404,9 +404,9 @@ static llvm::Error dumpTopologyInfo(uint32_t deviceId, uint64_t topologyId) {
   return llvm::Error::success();
 }
 
-HabanaFunction::HabanaFunction(const runtime::RuntimeBundle &bundle,
+HabanaFunction::HabanaFunction(runtime::RuntimeBundle &&bundle,
                                const std::string &recipeName, Function *F)
-    : CompiledFunction(bundle), recipeName_(recipeName) {
+    : CompiledFunction(std::move(bundle)), recipeName_(recipeName) {
   findIOPlaceholders(F);
 }
 

--- a/lib/Backends/Habana/Habana.h
+++ b/lib/Backends/Habana/Habana.h
@@ -248,8 +248,8 @@ private:
 class HabanaFunction final : public CompiledFunction {
 public:
   /// Constructor.
-  HabanaFunction(const runtime::RuntimeBundle &bundle,
-                 const std::string &recipeName, Function *F);
+  HabanaFunction(runtime::RuntimeBundle &&bundle, const std::string &recipeName,
+                 Function *F);
 
   /// @name CompiledFunction interface
   ///@{

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -64,7 +64,8 @@ Interpreter::compileIRWithoutConstants(std::unique_ptr<IRFunction> IR) const {
   runtime::RuntimeBundle bundle = runtime::RuntimeBundle::create(
       *IR, constantWeightsAllocator, placeholderWeightsAllocator,
       activationsAllocator);
-  return llvm::make_unique<InterpreterFunction>(std::move(IR), bundle);
+  return llvm::make_unique<InterpreterFunction>(std::move(IR),
+                                                std::move(bundle));
 }
 
 bool Interpreter::isOpSupported(const NodeInfo &NI) const {

--- a/lib/Backends/Interpreter/InterpreterFunction.cpp
+++ b/lib/Backends/Interpreter/InterpreterFunction.cpp
@@ -25,8 +25,8 @@
 using namespace glow;
 
 InterpreterFunction::InterpreterFunction(std::unique_ptr<IRFunction> F,
-                                         const runtime::RuntimeBundle &bundle)
-    : CompiledFunction(bundle), F_(std::move(F)) {}
+                                         runtime::RuntimeBundle &&bundle)
+    : CompiledFunction(std::move(bundle)), F_(std::move(F)) {}
 
 InterpreterFunction::~InterpreterFunction() {
   for (const auto &p : constants_) {

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -51,7 +51,7 @@ class InterpreterFunction final : public CompiledFunction {
 
 public:
   InterpreterFunction(std::unique_ptr<IRFunction> F,
-                      const runtime::RuntimeBundle &bundle);
+                      runtime::RuntimeBundle &&bundle);
 
   /// \name CompiledFunction interface
   ///@{

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -108,9 +108,9 @@ static void addStringOption(std::vector<std::string> &options,
 }
 
 OpenCLFunction::OpenCLFunction(std::unique_ptr<IRFunction> F,
-                               const runtime::RuntimeBundle &bundle,
+                               runtime::RuntimeBundle &&bundle,
                                TraceInfo traceInfo)
-    : CompiledFunction(bundle), F_(std::move(F)) {
+    : CompiledFunction(std::move(bundle)), F_(std::move(F)) {
   // We need to go through the TraceInfo and pull out some info about manual
   // TraceEvents.
   for (const auto &backingPair : traceInfo.events) {
@@ -1723,7 +1723,7 @@ OCLBackend::compileIR(std::unique_ptr<IRFunction> IR) const {
   runtime::RuntimeBundle bundle =
       runtime::RuntimeBundle::create(*IR, allocator, allocator, allocator);
   std::unique_ptr<CompiledFunction> function =
-      llvm::make_unique<OpenCLFunction>(std::move(IR), bundle,
+      llvm::make_unique<OpenCLFunction>(std::move(IR), std::move(bundle),
                                         std::move(traceInfo));
   auto OCLFunction = static_cast<OpenCLFunction *>(function.get());
   OCLFunction->collectConstants(module);
@@ -1749,7 +1749,7 @@ OCLBackend::compile(Function *F, const BackendOptions &opts) const {
   }
 
   std::unique_ptr<CompiledFunction> compiledFunc =
-      llvm::make_unique<OpenCLFunction>(std::move(IR), bundle,
+      llvm::make_unique<OpenCLFunction>(std::move(IR), std::move(bundle),
                                         std::move(traceInfo));
 
   return llvm::Expected<std::unique_ptr<CompiledFunction>>(

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -106,8 +106,7 @@ class OpenCLFunction final : public CompiledFunction {
 public:
   /// Ctor.
   explicit OpenCLFunction(std::unique_ptr<IRFunction> F,
-                          const runtime::RuntimeBundle &bundle,
-                          TraceInfo traceInfo);
+                          runtime::RuntimeBundle &&bundle, TraceInfo traceInfo);
 
   /// @name CompiledFunction interface
   ///@{

--- a/lib/LLVMIRCodeGen/LLVMBackend.cpp
+++ b/lib/LLVMIRCodeGen/LLVMBackend.cpp
@@ -128,7 +128,7 @@ LLVMBackend::compileIRWithoutConstants(IRFunction *IR) const {
   MemoryAllocator activationsAllocator("Activations", 0);
   auto runtimeInfo = runtime::RuntimeBundle::create(
       *IR, constantAllocator, placeholderAllocator, activationsAllocator);
-  return createCompiledFunction(std::move(JIT), runtimeInfo);
+  return createCompiledFunction(std::move(JIT), std::move(runtimeInfo));
 }
 
 llvm::Expected<std::unique_ptr<CompiledFunction>>

--- a/lib/LLVMIRCodeGen/LLVMCompiledFunction.cpp
+++ b/lib/LLVMIRCodeGen/LLVMCompiledFunction.cpp
@@ -23,8 +23,8 @@ using namespace glow;
 
 LLVMCompiledFunction::LLVMCompiledFunction(
     std::unique_ptr<llvm::orc::GlowJIT> JIT,
-    const runtime::RuntimeBundle &runtimeBundle)
-    : CompiledFunction(runtimeBundle), JIT_(std::move(JIT)) {}
+    runtime::RuntimeBundle &&runtimeBundle)
+    : CompiledFunction(std::move(runtimeBundle)), JIT_(std::move(JIT)) {}
 
 void LLVMCompiledFunction::collectConstants(const Module *module) {
   runtimeBundle_.collectConstants(module);

--- a/tests/benchmark/RuntimeBench.cpp
+++ b/tests/benchmark/RuntimeBench.cpp
@@ -576,7 +576,7 @@ std::unique_ptr<DAG> createSingleNodeDAG(
   singleNode->deviceIDs = {0};
   singleNode->name = "singleNode";
   singleNode->runtimeBundle = llvm::make_unique<RuntimeBundle>(
-      compiledFunctions["singleNode"]->getRuntimeBundle());
+      std::move(compiledFunctions["singleNode"]->getRuntimeBundle()));
 
   std::vector<std::unique_ptr<DAGNode>> nodes;
   nodes.emplace_back(std::move(singleNode));

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -116,8 +116,8 @@ static const auto all_backends = ::testing::Values(
 class MockBackend : public Backend {
   class MockFunction : public CompiledFunction {
   public:
-    MockFunction(const runtime::RuntimeBundle &bundle)
-        : CompiledFunction(bundle) {}
+    MockFunction(runtime::RuntimeBundle &&bundle)
+        : CompiledFunction(std::move(bundle)) {}
 
     llvm::Error execute(ExecutionContext *) override {
       return llvm::Error::success();
@@ -145,8 +145,8 @@ class MockBackend : public Backend {
 class MockBackendCustomIRGen : public Backend {
   class MockFunction : public CompiledFunction {
   public:
-    MockFunction(const runtime::RuntimeBundle &bundle)
-        : CompiledFunction(bundle) {}
+    MockFunction(runtime::RuntimeBundle &&bundle)
+        : CompiledFunction(std::move(bundle)) {}
 
     llvm::Error execute(ExecutionContext *) override {
       return llvm::Error::success();

--- a/tests/unittests/BackendTestUtils2.h
+++ b/tests/unittests/BackendTestUtils2.h
@@ -114,8 +114,8 @@ static const auto all_backends = ::testing::Values(
 class MockBackend : public Backend {
   class MockFunction : public CompiledFunction {
   public:
-    MockFunction(const runtime::RuntimeBundle &bundle)
-        : CompiledFunction(bundle) {}
+    MockFunction(runtime::RuntimeBundle &&bundle)
+        : CompiledFunction(std::move(bundle)) {}
 
     llvm::Error execute(ExecutionContext *) override {
       return llvm::Error::success();
@@ -143,8 +143,8 @@ class MockBackend : public Backend {
 class MockBackendCustomIRGen : public Backend {
   class MockFunction : public CompiledFunction {
   public:
-    MockFunction(const runtime::RuntimeBundle &bundle)
-        : CompiledFunction(bundle) {}
+    MockFunction(runtime::RuntimeBundle &&bundle)
+        : CompiledFunction(std::move(bundle)) {}
 
     llvm::Error execute(ExecutionContext *) override {
       return llvm::Error::success();

--- a/tests/unittests/PartitionerTest.cpp
+++ b/tests/unittests/PartitionerTest.cpp
@@ -471,9 +471,8 @@ public:
 
   class MockFunction : public CompiledFunction {
   public:
-    MockFunction(llvm::StringRef backendName,
-                 const runtime::RuntimeBundle &bundle)
-        : CompiledFunction(bundle), backendName(backendName) {}
+    MockFunction(llvm::StringRef backendName, runtime::RuntimeBundle &&bundle)
+        : CompiledFunction(std::move(bundle)), backendName(backendName) {}
 
     llvm::Error execute(ExecutionContext *) override {
       return llvm::Error::success();


### PR DESCRIPTION
**Summary**
This commit disables implicit copying of `RuntimeBundles`. They should be
moved whenever possible and explicitly copied if moving is not possible.
An example of this is in the `Provisioner`, where the `RuntimeBundle` is
copied from a `CompiledFunction` into its encompassing `DAGNode`. This commit
also adds an `isValid_` flag to the `RuntimeBundle` and sets it to false
after an instance has been moved out of in order to help debug problems
arising from manipulating a stale `RuntimeBundle` instance.

**Test Plan**
`ninja check`

**Fixes**
This PR fixes #3259. 