### PR TITLE
Update TopK to handle k as input node 

### DIFF
--- a/tests/models/onnxModels/TopK.onnxtxt
+++ b/tests/models/onnxModels/TopK.onnxtxt
@@ -1,0 +1,101 @@
+ir_version: 5
+domain: "onnx"
+# ONNX TensorProto.DataType:
+#    UNDEFINED = 0;
+#    FLOAT = 1;
+#    UINT8 = 2;
+#    INT8 = 3;
+#    UINT16 = 4;
+#    INT16 = 5;
+#    INT32 = 6;
+#    INT64 = 7;
+#    STRING = 8;
+#    BOOL = 9;
+#    FLOAT16 = 10;
+#    DOUBLE = 11;
+#    UINT32 = 12;
+#    UINT64 = 13;
+#    COMPLEX64 = 14;
+#    COMPLEX128 = 15;
+graph {
+   initializer {
+       dims: 1   
+       data_type: 7
+       name: "k"
+       int64_data: 2
+   }
+  input {
+    name: "scores"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+         dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+   node {
+       input: "scores"
+       input: "k"
+       output: "topscores"	
+       output: "topindices"
+       name: "topk"
+       op_type: "TopK"
+       attribute {
+        name: "axis"
+        i: -1
+        type: INT
+      }
+   }
+
+output {
+    name: "topscores"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+         dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+output {
+    name: "topindices"
+    type {
+      tensor_type {
+        elem_type: 7
+        shape {
+         dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 10
+}


### PR DESCRIPTION
Updated topK to support k as an input node 
https://github.com/onnx/onnx/blob/master/docs/Operators.md#TopK
Added TopK Tests
Added constant folding loader test for multiple outputs

Documentation:

[Optional Fixes #issue]

Test Plan:

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
