### PR TITLE
Check llvm::Errors everywhere in tests

### DIFF
--- a/lib/ExecutionEngine/ExecutionEngine2.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine2.cpp
@@ -19,6 +19,7 @@
 #include "glow/Graph/Graph.h"
 #include "glow/Graph/PlaceholderBindings.h"
 #include "glow/Optimizer/GraphOptimizer/GraphOptimizer.h"
+#include "glow/Support/Error.h"
 
 #include "llvm/ADT/STLExtras.h"
 
@@ -109,6 +110,7 @@ void ExecutionEngine2::runInternal(ExecutionContext &context,
   std::promise<void> runPromise;
   auto fut = runPromise.get_future();
   llvm::Error runErr = llvm::Error::success();
+  MARK_ERR_CHECKED(runErr);
   hostManager_->runNetwork(
       name, std::move(contextPtr),
       [&runPromise, &runErr](runtime::RunIdentifierTy, llvm::Error err,

--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -132,6 +132,7 @@ TEST(RuntimeBundle, BundleSymbolInfo) {
 
   EE.compile(CompilationMode::Infer);
   auto dag = EE.getDAG("main");
+  ASSERT_TRUE((bool)dag);
   assert(dag->nodes.size() > 0 && "Empty DAG list");
   auto table = dag->nodes[0]->runtimeBundle->getSymbolTable();
   // Check that placeholders and constants are correctly labelled.
@@ -190,7 +191,9 @@ TEST(RuntimeBundle, ContiguousPlaceholder) {
   bindings.allocate(A);
   bindings.allocate(Ex);
   EE.compile(cctx);
-  auto &table = EE.getDAG("main")->nodes[0]->runtimeBundle->getSymbolTable();
+  auto dag = EE.getDAG("main");
+  ASSERT_TRUE((bool)dag);
+  auto &table = dag->nodes[0]->runtimeBundle->getSymbolTable();
 
   std::vector<glow::runtime::RuntimeSymbolInfo> tableContainer;
   // Only check placeholders.
@@ -320,6 +323,7 @@ TEST_P(BackendTest, debugPrint) {
   std::promise<void> addPromise;
   auto fut = addPromise.get_future();
   llvm::Error addErr = llvm::Error::success();
+  MARK_ERR_CHECKED(addErr);
   device->addNetwork(&EE_.getModule(), std::move(functionMap),
                      [&addPromise, &addErr](const Module *, llvm::Error err) {
                        addErr = std::move(err);
@@ -331,6 +335,7 @@ TEST_P(BackendTest, debugPrint) {
   std::promise<void> runPromise;
   fut = runPromise.get_future();
   llvm::Error runErr = llvm::Error::success();
+  MARK_ERR_CHECKED(runErr);
   device->runFunction(name, std::move(ctx),
                       [&runPromise, &runErr,
                        &ctx](runtime::RunIdentifierTy, llvm::Error err,

--- a/tests/unittests/OnnxExporterTest.cpp
+++ b/tests/unittests/OnnxExporterTest.cpp
@@ -41,10 +41,12 @@ void testLoadAndSaveONNXModel(const std::string &name) {
   llvm::Error err = llvm::Error::success();
   ONNXModelLoader onnxLD(name, {}, {}, *F, &err);
 
-  if (err) {
-    llvm::errs() << "ONNXModelLoader failed to load model: " << name << ".\n";
-    return;
-  }
+  ASSERT_FALSE(handleErrors(std::move(err), [&name](const GlowErr &GE) {
+    llvm::errs() << "ONNXModelLoader failed to load model: " << name << ": ";
+    GE.log(llvm::errs());
+    llvm::errs() << "\n";
+  }));
+
   std::string outputFilename(name + ".output.onnxtxt");
   { ONNXModelWriter onnxWR(outputFilename, *F, 1, 1, &err, true); }
   llvm::sys::fs::remove(outputFilename);


### PR DESCRIPTION
Summary: Using an llvm debug build results in some tests aborting because errors aren't checked.

Test Plan: ninja check

Fixes #2537

