### PR TITLE
Ported OperatorGradTest to EE2

### DIFF
--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -388,7 +388,7 @@ add_executable(OperatorGradTest
 target_link_libraries(OperatorGradTest
                       PRIVATE
                         Base
-                        ExecutionEngine
+                        ExecutionEngine2
                         Graph
                         gtest
                         TestMain)

--- a/tests/unittests/OperatorGradTest.cpp
+++ b/tests/unittests/OperatorGradTest.cpp
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-#include "BackendTestUtils.h"
+#include "BackendTestUtils2.h"
 
 #include "glow/Base/Tensor.h"
-#include "glow/ExecutionEngine/ExecutionEngine.h"
+#include "glow/ExecutionEngine/ExecutionEngine2.h"
 #include "glow/Graph/Graph.h"
 #include "glow/Graph/Nodes.h"
 
@@ -50,12 +50,13 @@ protected:
     VariableGradientsList varGrads;
     TrainingConfig TC;
     Function *recordNet = glow::differentiate(F_, TC, "record", &varGrads);
+    auto recordName = recordNet->getName();
     allocateGrads(varGrads);
-    EE_.compile(CompilationMode::Train, recordNet);
+    EE_.compile(CompilationMode::Train);
 
     // Train the network just once to record the values of gradient for
     // all variables.
-    EE_.run(bindings_);
+    EE_.run(bindings_, recordName);
 
     return varGrads;
   }


### PR DESCRIPTION
Summary: Ported OperatorGradTest to EE2

Documentation:

Progress on #3239 

Test Plan: verify everything builds, verify OperatorGradTest runs and passes.
