### PR TITLE
[GraphOptimizer] Drop dependency on Backends.

### DIFF
--- a/lib/Optimizer/GraphOptimizer/CMakeLists.txt
+++ b/lib/Optimizer/GraphOptimizer/CMakeLists.txt
@@ -8,8 +8,6 @@ add_library(GraphOptimizer
 
 target_link_libraries(GraphOptimizer
                       PRIVATE
-                        Backend
-                        Backends
                         Converter
                         Graph
                         GraphOptimizerPipeline


### PR DESCRIPTION
Backend may want to call GraphOptimizer, that's why GraphOptimizer should not depend on Backends. Otherwise it may lead to cyclic dependency.