### PR TITLE
Ported GraphTest to EE2

### DIFF
--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -204,7 +204,7 @@ target_link_libraries(GraphTest
                       PRIVATE
                         Backend
                         Backends
-                        ExecutionEngine
+                        ExecutionEngine2
                         Graph
                         IR
                         GraphOptimizer


### PR DESCRIPTION
Summary: This PR ports GraphTest to EE2

Documentation:

Progress on #3239 

Test Plan: Verify everything builds and GraphTest runs and passes.