### PR TITLE
Ported IROptTest to EE2/BackendUtils2

### DIFF
--- a/tests/unittests/IROptTest.cpp
+++ b/tests/unittests/IROptTest.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "BackendTestUtils.h"
+#include "BackendTestUtils2.h"
 #include "glow/Graph/Graph.h"
 #include "glow/IR/IR.h"
 #include "glow/IR/IRBuilder.h"


### PR DESCRIPTION
Summary: This Ports IROptTest to BackendTestUtils2, it's essentially a no-op but this will help ensure a smoother transition.

Documentation:

Progress on #3239 

Test Plan: build, run and pass IROptTest