### PR TITLE
[NFC][Partitioner] Partitioner Refactoring -part1

### DIFF
--- a/include/glow/Partitioner/PartitionerOptimizer.h
+++ b/include/glow/Partitioner/PartitionerOptimizer.h
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_PARTITIONER_PARTITIONEROPTIMIZER_H
+#define GLOW_PARTITIONER_PARTITIONEROPTIMIZER_H
+
+#include "glow/Partitioner/PartitionerTypes.h"
+
+namespace glow {
+/// By using heuristic algorithm to move nodes among \p partitions, optimize the
+/// total communication cost of running a module and keep the memory usage of
+/// each partition within \p availableMemory.
+void optimizeCommunicationCost(NodeToFunctionMap &partitions,
+                               FunctionToNodesMap &nodesSet, Module *mod,
+                               uint64_t availableMemory);
+
+/// Combine partitions according to the following rules: Rule 1 :if all outside
+/// uses of the nodes in partition1 is in partition2, and the sum of memory
+/// consumption of partition1 and partition2 is less than availableMemory,
+/// combine partition1 and partition2.
+void partitionsCombine(NodeToFunctionMap &partitions,
+                       FunctionToNodesMap &nodesSet, Module *mod,
+                       uint64_t availableMemory);
+
+/// Assign the logicalDevice ID to each partition. The partitions with the same
+/// logicalDevice ID will be assigned on the same physical devices. E.g: there
+/// are 3 partitions node1(6GB) -> node2(14GB) -> node3(6GB). But we only have 2
+/// devices with 16GB memory. The logicalDevice ID assigning rules are:
+/// 1. For each type of backend, if the number of available physical devices is
+/// equal or larger than the number of partitions, different partitions are
+/// assigned with a different logicalDevice ID(i.e. each partition will be put
+/// on a different physical device for execution). E.g. we have 3 partitions
+/// node1->node2->node3, and 3 devices, the logicalDevice ID for each partition
+/// with be (node1, 0), (node2, 1), and (node3, 2).
+/// 2. For each type of backend, if the number of available physical devices is
+/// smaller than the number of partitions, and we can find a way to put all
+/// partitions on those pysical devices, this assignment will be applied and the
+/// partitions on the same physical devices will be assigned the same
+/// logicalDevice ID.  E.g: there are 3 partitions node1(6GB) -> node2(14GB) ->
+/// node3(6GB). But we only have 2 devices with 16GB memory. The assignment will
+/// be : (node1, 0), (node2, 1), (node3, 0).
+/// 3. For each type of backend, if the number of available physical devices is
+/// smaller than the number of partitions, and we can not find a way to put all
+/// partitions on those pysical devices, we assign defferent partitions with
+/// different logicalDevice ID.  E.g: there are 3 partitions node1(6GB) ->
+/// node2(14GB) -> node3(6GB). But we only have 1 device with 16GB memory. The
+/// assignment will be : (node1, 0), (node2, 1), (node3, 2). That is, even we
+/// can put node1 and node3 on the same device, we won't do it.
+DeviceIDTy
+assignLogicalDeviceID(NodeToFunctionMap &mapping,
+                      const std::map<std::string, BackendInfo> &backendMap);
+} // namespace glow
+#endif // GLOW_PARTITIONER_PARTITIONEROPTIMIZER_H

--- a/include/glow/Partitioner/PartitionerTypes.h
+++ b/include/glow/Partitioner/PartitionerTypes.h
@@ -1,0 +1,195 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_PARTITIONER_PARTITIONERTYPES_H
+#define GLOW_PARTITIONER_PARTITIONERTYPES_H
+
+#include "glow/Graph/Graph.h"
+#include "glow/Runtime/RuntimeTypes.h"
+
+namespace glow {
+
+using namespace runtime;
+
+using NodesSet = std::set<Node *>;
+
+/// The memory usage of a subgraph (i.e. a list of nodes of a function).
+struct GraphMemInfo {
+  // The memory usage of all input nodes (whose predecessors are not included in
+  // this subgraph) of this subgraph.
+  uint64_t inMemSize;
+  // The memory usage of all output nodes (whose successors are not included in
+  // this subgraph) of this subgraph.
+  uint64_t outMemSize;
+  // The memory usage of all constants used in this subgraph.
+  uint64_t constMemSize;
+
+  GraphMemInfo() : inMemSize(0), outMemSize(0), constMemSize(0){};
+  GraphMemInfo(uint64_t inMem, uint64_t outMem, uint64_t constMem)
+      : inMemSize(inMem), outMemSize(outMem), constMemSize(constMem){};
+
+  // Get the total memory size of each partition.
+  uint64_t getTotalMemSize() const {
+    return inMemSize + outMemSize + constMemSize;
+  }
+
+  bool equals(const GraphMemInfo &other) const {
+    return inMemSize == other.inMemSize && outMemSize == other.outMemSize &&
+           constMemSize == other.constMemSize;
+  }
+};
+
+inline bool operator==(const GraphMemInfo &LHS, const GraphMemInfo &RHS) {
+  return LHS.equals(RHS);
+}
+
+/// A list of <nodelist> with BFS order.
+using BFSLevel = std::vector<std::vector<Node *>>;
+
+/// Data structure that contains the info for each type of backend used for
+/// partitioning.
+struct BackendInfo {
+  /// Num of the devices which has the same type of backend.
+  size_t num = 0;
+  /// The memory constraints for this backend.
+  uint64_t memSize;
+  /// Backend pointer.
+  Backend *backend = nullptr;
+  /// The non-supported nodes kind.
+  std::set<Kinded::Kind> nonSupportedNodesKinds;
+  /// The supported nodes kind.
+  std::set<Kinded::Kind> supportedNodesKinds;
+};
+
+/// A mapping of newly-created functions along with a set of nodes sets. The
+/// overloaded compare function to make sure the map is sorted by the key's
+/// name(i.e. the function's name) which makes the optimization sequence is
+/// consistent for each run.
+struct FunctionNameComparator {
+  bool operator()(const Function *lhs, const Function *rhs) const {
+    return strcmp(lhs->getName().data(), rhs->getName().data()) < 0;
+  }
+};
+using FunctionToNodesMap =
+    std::map<Function *, NodesSet, FunctionNameComparator>;
+
+using FunctionToBackendNameMap =
+    std::map<Function *, std::string, FunctionNameComparator>;
+
+class NodeToFunctionMap {
+  /// Helper structure for building a partition. Records mapping of nodes in
+  /// the original function to destination partitions, along with a list of the
+  /// newly-created functions;
+  using Map = llvm::DenseMap<Node *, Function *>;
+
+  using PartitionCostMap = llvm::DenseMap<Function *, GraphMemInfo>;
+
+  /// Newly-created partitions.
+  FunctionList functions_;
+
+  /// Map of nodes in the original function to their target partition.
+  Map nodeToFunction_;
+
+  /// Map of the partitions to the backend which will be used for compiling
+  /// this partition.
+  FunctionToBackendNameMap functionToBackendName_;
+
+  /// Map of sub-functions to their memory consumption.
+  PartitionCostMap partitionCost_;
+
+  /// Map of partitions and the logicalDeviceID. The partitions with the same
+  /// logcialDeviceID will be assigned into the same physical device.
+  std::map<Function *, std::vector<DeviceIDTy>> logicalDeviceIDMap_;
+
+public:
+  /// Create a new partition \p F, and map it with \p backendName.
+  void createPartition(Function *F, llvm::StringRef backendName) {
+    functions_.emplace_back(F);
+    functionToBackendName_[F] = backendName;
+  }
+
+  std::string getPartitionBackendName(Function *F) const {
+    DCHECK(functionToBackendName_.find(F) != functionToBackendName_.end())
+        << "Unknown partition in Function: " << F->getName().str();
+    return functionToBackendName_.find(F)->second;
+  }
+
+  /// Add a new Node->Function mapping.
+  void add(Node *N, Function *F) { nodeToFunction_[N] = F; }
+
+  /// Get list of functions contained in this map.
+  const FunctionList &getPartitions() const { return functions_; }
+
+  /// Get the list of logical device ID related to this function \p F.
+  const std::vector<DeviceIDTy> getLogicalDeviceIDList(Function *F) const {
+    if (logicalDeviceIDMap_.find(F) == logicalDeviceIDMap_.end()) {
+      return {};
+    }
+    return logicalDeviceIDMap_.at(F);
+  }
+
+  void appendLogicalDeviceID(Function *F, DeviceIDTy id) {
+    if (logicalDeviceIDMap_.find(F) == logicalDeviceIDMap_.end()) {
+      logicalDeviceIDMap_.emplace(
+          std::make_pair(F, std::vector<DeviceIDTy>{id}));
+    } else {
+      logicalDeviceIDMap_[F].push_back(id);
+    }
+  }
+  /// attach \p map to current mapping.
+  void insert(NodeToFunctionMap &map) {
+    FunctionList flist = map.getPartitions();
+    for (auto it = flist.begin(); it != flist.end(); ++it) {
+      Function *func = *it;
+      auto backendName = map.getPartitionBackendName(func);
+      createPartition(func, backendName);
+      GraphMemInfo cost = map.getGraphMemInfo(func);
+      setGraphMemInfo(func, cost);
+    }
+    for (auto it = map.begin(); it != map.end(); ++it) {
+      Node *n = it->first;
+      Function *f = it->second;
+      add(n, f);
+    }
+  }
+
+  /// Map API.
+  Map::iterator find(Node *N) { return nodeToFunction_.find(N); }
+  Map::iterator begin() { return nodeToFunction_.begin(); }
+  Map::iterator end() { return nodeToFunction_.end(); }
+  Function *operator[](Node *n) { return nodeToFunction_[n]; }
+
+  void deletePartition(Function *func) {
+    functions_.remove(func);
+    functionToBackendName_.erase(func);
+    partitionCost_.erase(func);
+  }
+
+  /// Set the memory consumption \p cost for a partition \p func.
+  void setGraphMemInfo(Function *func, GraphMemInfo cost) {
+    partitionCost_[func] = cost;
+  }
+
+  /// Get the memory consumption for a partition \p func.
+  GraphMemInfo getGraphMemInfo(Function *func) const {
+    if (partitionCost_.find(func) == partitionCost_.end()) {
+      return GraphMemInfo{};
+    }
+    return partitionCost_.find(func)->second;
+  }
+};
+
+} // namespace glow
+#endif // GLOW_RUNTIME_PARTITIONERTYPES_H

--- a/include/glow/Partitioner/PartitionerUtils.h
+++ b/include/glow/Partitioner/PartitionerUtils.h
@@ -17,44 +17,10 @@
 #define GLOW_PARTITIONER_PARTITIONUTILS_H
 
 #include "glow/Graph/Graph.h"
+#include "glow/Partitioner/PartitionerTypes.h"
 #include "llvm/ADT/DenseMap.h"
 
 namespace glow {
-using NodesSet = std::set<Node *>;
-
-/// The memory usage of a subgraph (i.e. a list of nodes of a function).
-struct GraphMemInfo {
-  // The memory usage of all input nodes (whose predecessors are not included in
-  // this subgraph) of this subgraph.
-  uint64_t inMemSize;
-  // The memory usage of all output nodes (whose successors are not included in
-  // this subgraph) of this subgraph.
-  uint64_t outMemSize;
-  // The memory usage of all constants used in this subgraph.
-  uint64_t constMemSize;
-
-  GraphMemInfo() : inMemSize(0), outMemSize(0), constMemSize(0){};
-  GraphMemInfo(uint64_t inMem, uint64_t outMem, uint64_t constMem)
-      : inMemSize(inMem), outMemSize(outMem), constMemSize(constMem){};
-
-  // Get the total memory size of each partition.
-  uint64_t getTotalMemSize() const {
-    return inMemSize + outMemSize + constMemSize;
-  }
-
-  bool equals(const GraphMemInfo &other) const {
-    return inMemSize == other.inMemSize && outMemSize == other.outMemSize &&
-           constMemSize == other.constMemSize;
-  }
-};
-
-inline bool operator==(const GraphMemInfo &LHS, const GraphMemInfo &RHS) {
-  return LHS.equals(RHS);
-}
-
-/// A list of <nodelist> with BFS order.
-using BFSLevel = std::vector<std::vector<Node *>>;
-
 /// Visit nodes if Function \p F in BFS order and return the nodes by levels
 /// (the longest distance between one node and the root).
 BFSLevel getBFSLevel(Function *F);
@@ -85,5 +51,8 @@ GraphMemInfo getGraphMemInfo(const NodesSet &nodes);
 /// Parse a node name string (e.g. "Div,Add") \p names, \returns a set of
 /// NodeKinds corresponding to the names in the string.
 std::set<Kinded::Kind> generateNodeKindsSet(llvm::StringRef names);
+
+/// Log the info of current partition \p partitions.
+void logPartitionInfo(const NodeToFunctionMap &partitions);
 } // namespace glow
 #endif // GLOW_PARTITIONER_PARTITIONUTILS_H

--- a/include/glow/Partitioner/PartitionerValidation.h
+++ b/include/glow/Partitioner/PartitionerValidation.h
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_PARTITIONER_PARTITIONERVALIDATION_H
+#define GLOW_PARTITIONER_PARTITIONERVALIDATION_H
+
+#include "glow/Partitioner/PartitionerTypes.h"
+
+namespace glow {
+/// Check if \p partitions satisfies number of physical devices restriction.
+/// I.e. check if the number of logical devices is less than the given
+/// physical devices.
+llvm::Error
+logicalDevicesValidation(const NodeToFunctionMap &partitions,
+                         const std::map<std::string, BackendInfo> &backendMap);
+
+/// Check if the memory usage of each partition meets the physical device
+/// memory restriction.
+llvm::Error
+memoryUsageValidation(const NodeToFunctionMap &partitions,
+                      const std::map<std::string, BackendInfo> &backendMap);
+} // namespace glow
+#endif // GLOW_PARTITIONER_PARTITIONERVALIDATION_H

--- a/lib/Partitioner/CMakeLists.txt
+++ b/lib/Partitioner/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_library(Partitioner
               PartitionerUtils.cpp
+              PartitionerOptimizer.cpp
+              PartitionerValidation.cpp
               Partitioner.cpp)
 
 target_link_libraries(Partitioner

--- a/lib/Partitioner/PartitionerOptimizer.cpp
+++ b/lib/Partitioner/PartitionerOptimizer.cpp
@@ -1,0 +1,252 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/Partitioner/PartitionerOptimizer.h"
+#include "glow/Partitioner/PartitionerUtils.h"
+#include <unordered_set>
+
+namespace glow {
+using llvm::isa;
+
+// Sorted the std::pair<DAGNode *, uint64_t> based on the second from min to
+// max.
+bool sortMinMemory(const std::pair<Function *, uint64_t> &a,
+                   const std::pair<Function *, uint64_t> &b) {
+  return a.second < b.second;
+}
+
+void optimizeCommunicationCost(NodeToFunctionMap &partitions,
+                               FunctionToNodesMap &nodesSet, Module *mod,
+                               uint64_t availableMemory) {
+  // Move/Exchange nodes between any two connected partitions, until no gain is
+  // get.
+  // Step1 Move: Assume Partition1 -> Partition2, try to move nodes from
+  // Partition2 to Partition1 if those nodes only use the nodes in
+  // Partition1(recursively) and the move won't make Partition1's memory exceeds
+  // the memory constraint, and the communication cost is minimized.
+  bool gain = true;
+  while (gain) {
+    // gain is initialized as false, it will be set to be true if there is at
+    // least one node can be moved from one set to another set.
+    gain = false;
+    for (FunctionToNodesMap::iterator it = nodesSet.begin();
+         it != nodesSet.end(); ++it) {
+      NodesSet &curSet = (*it).second;
+      std::vector<Node *> outUsers = getOutUsersWithOnePredecessor(curSet);
+      if (outUsers.empty()) {
+        continue;
+      }
+      Function *cur = (*it).first;
+      GraphMemInfo curCost = partitions.getGraphMemInfo(cur);
+      // Check if a node can be moved to current node set (i.e curSet).
+      for (int i = 0, e = outUsers.size(); i < e; i++) {
+        // Get the new cost if outUsers[i] is added.
+        GraphMemInfo newCurCost =
+            updateGraphMemInfoByAddingNode(curSet, curCost, outUsers[i]);
+
+        // Rule 1: this move won't break memory constraint.
+        if (newCurCost.getTotalMemSize() > availableMemory) {
+          continue;
+        }
+        // Rule 2: this move won't cause constant duplication.
+        bool cont = false;
+        for (int j = 0, e1 = outUsers[i]->getNumInputs(); j < e1; j++) {
+          auto in = outUsers[i]->getNthInput(j);
+          if (isa<Storage>(in.getNode()) && !in.hasOneUse()) {
+            cont = true;
+            break;
+          }
+        }
+        if (cont) {
+          continue;
+        }
+        // Rule 3: this move won't increase communication cost. Even if this
+        // move won't change communication cost, according to rule 1 and rule 2,
+        // the memory consumption of the partition where this node (i.e
+        // outUsers[i]) belongs can be reduced. Therefore, it may trigger later
+        // node movement or partitionsCombine.
+        Function *suc = partitions[outUsers[i]];
+        uint64_t outMem = getOutMemPerNode(nodesSet[suc], outUsers[i]);
+        if (newCurCost.outMemSize - outMem <= curCost.outMemSize) {
+          // Move this node to current node set.
+          curSet.insert(outUsers[i]);
+          nodesSet[suc].erase(outUsers[i]);
+          curCost = newCurCost;
+          // Update the partitions.
+          partitions.add(outUsers[i], cur);
+          partitions.setGraphMemInfo(cur, newCurCost);
+          if (nodesSet[suc].empty()) {
+            // It is possible that after moving a node from Partition2 to
+            // Partition1, Partition2 become empty. Remove the empty partition.
+            partitions.deletePartition(suc);
+            nodesSet.erase(suc);
+            mod->eraseFunction(suc);
+          } else {
+            GraphMemInfo newCost = getGraphMemInfo(nodesSet[suc]);
+            partitions.setGraphMemInfo(suc, newCost);
+          }
+          gain = true;
+        }
+      }
+    }
+  }
+}
+
+void partitionsCombine(NodeToFunctionMap &partitions,
+                       FunctionToNodesMap &nodesSet, Module *mod,
+                       uint64_t availableMemory) {
+
+  size_t origPartitions = 0;
+
+  // Do the combination until the size of partitions is stable.
+  while (partitions.getPartitions().size() != origPartitions) {
+    origPartitions = partitions.getPartitions().size();
+    // Rule 1:
+    for (FunctionToNodesMap::iterator it = nodesSet.begin();
+         it != nodesSet.end(); ++it) {
+      std::vector<Node *> outUsers = getOutUsers((*it).second);
+      if (outUsers.empty()) {
+        continue;
+      }
+
+      bool flag = true;
+      for (int i = 1, e = outUsers.size(); i < e; i++) {
+        if (partitions[outUsers[i]] != partitions[outUsers[i - 1]]) {
+          flag = false;
+          break;
+        }
+      }
+      if (flag) {
+        // This partition only has one successor.
+        Function *cur = (*it).first;
+        Function *suc = partitions[outUsers[0]];
+        NodesSet tmp = (nodesSet.find(suc))->second;
+        GraphMemInfo cost1 = partitions.getGraphMemInfo(cur);
+        GraphMemInfo cost2 = partitions.getGraphMemInfo(suc);
+        if (cost1.getTotalMemSize() + cost2.getTotalMemSize() -
+                cost1.outMemSize <
+            availableMemory) {
+          // We can combine the two partitions to fit one device.
+          for (NodesSet::iterator it2 = tmp.begin(); it2 != tmp.end(); ++it2) {
+            partitions.add(*it2, cur);
+          }
+          GraphMemInfo newCost;
+          newCost.constMemSize = cost1.constMemSize + cost2.constMemSize;
+          newCost.inMemSize =
+              cost1.inMemSize + cost2.inMemSize - cost1.outMemSize;
+          newCost.outMemSize = cost2.outMemSize;
+          partitions.setGraphMemInfo((*it).first, newCost);
+          (*it).second.insert(tmp.begin(), tmp.end());
+          partitions.deletePartition(suc);
+          nodesSet.erase(suc);
+          mod->eraseFunction(suc);
+        }
+      }
+    }
+  }
+}
+
+DeviceIDTy
+assignLogicalDeviceID(NodeToFunctionMap &mapping,
+                      const std::map<std::string, BackendInfo> &backendMap) {
+  DeviceIDTy logicalDeviceID = 0;
+
+  std::map<std::string, std::vector<Function *>> backendFuncMap;
+  for (auto &func : mapping.getPartitions()) {
+    // Traverse the partitions, and get list of partitions with each
+    // backendName.
+    auto backendName = mapping.getPartitionBackendName(func);
+    if (backendFuncMap.find(backendName) == backendFuncMap.end()) {
+      backendFuncMap.emplace(backendName, std::vector<Function *>{func});
+    } else {
+      backendFuncMap[backendName].push_back(func);
+    }
+  }
+
+  // For each type of the backend, assign the logicalDevice ID.
+  for (const auto &p : backendFuncMap) {
+    if (mapping.getPartitions().size() <= backendMap.at(p.first).num) {
+      // There is enough device with this backendName, no need to adjust the
+      // logical ID.
+      for (auto &func : p.second) {
+        mapping.appendLogicalDeviceID(func, logicalDeviceID++);
+      }
+      continue;
+    }
+    // Get the list of functions with current BackendName, and sort it based on
+    // used memory from min to max.
+    std::vector<std::pair<Function *, uint64_t>> nodeSize;
+    for (size_t i = 0, e = p.second.size(); i < e; i++) {
+      Function *function = p.second[i];
+      uint64_t totalMem = mapping.getGraphMemInfo(function).getTotalMemSize();
+      nodeSize.push_back(std::make_pair(p.second[i], totalMem));
+    }
+    std::sort(nodeSize.begin(), nodeSize.end(), sortMinMemory);
+
+    // Assume we have n devices(NOTE: here the n devices have the same available
+    // memory size, and the following algorithm can find the accurate result. If
+    // the memory size are differnt, this assignment issue will be a NP problem
+    // -- multiple knapsack problem, and the following algorithm becomes greedy
+    // and the result may not be optimal), and m partitions, where m > n. If
+    // these m partitions can be assigned to n devices, there must be 1 device
+    // have at least (m - 1)/n + 1 partitions(Pigeonhole principle). Based on
+    // this theory, the algorithm is: Given N devices, and M partitions:
+    // Step 1 : sort the partitions from min to max based on their memory usage.
+    std::sort(nodeSize.begin(), nodeSize.end(), sortMinMemory);
+    // Step 2 : let n = N, m = M.
+    size_t m = p.second.size();
+    size_t n = backendMap.at(p.first).num;
+    while (m > 0) {
+      // Step 3 : find the first k partitions whose total memory usage still
+      // under the memory limitation (k should be max).
+      uint64_t usedMem = 0;
+      size_t numOfPartitionsWithSameID = (m - 1) / n + 1;
+      size_t start = p.second.size() - m;
+      size_t i;
+      for (i = start; i < p.second.size(); i++) {
+        if (usedMem + nodeSize[i].second > backendMap.at(p.first).memSize) {
+          break;
+        }
+        usedMem += nodeSize[i].second;
+      }
+      // Step 4 : if k = start - i found in step 3 is smaller than (m - 1) / n +
+      // 1, this means we can't find a proper assignment to fit the number of
+      // devices. Assign each partition with a unique logicalDevice ID and
+      // return.
+      if (i - start < numOfPartitionsWithSameID) {
+        // Can't find a proper assignment. Assign each partition a unique
+        // logicalDevice ID and return;
+        logicalDeviceID = 0;
+        for (auto &func : mapping.getPartitions()) {
+          mapping.appendLogicalDeviceID(func, logicalDeviceID++);
+        }
+        return logicalDeviceID;
+      }
+
+      // Step 5 : Assign these partitions which are assigned to one device with
+      // the same logical ID.
+      for (size_t j = start; j < i; j++) {
+        mapping.appendLogicalDeviceID(nodeSize[j].first, logicalDeviceID);
+      }
+      logicalDeviceID++;
+      // Step 6 : Update the left number of devices and partitions.
+      n--;
+      m = m - (i - start);
+    }
+  }
+  return logicalDeviceID;
+}
+} // namespace glow

--- a/lib/Partitioner/PartitionerUtils.cpp
+++ b/lib/Partitioner/PartitionerUtils.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "glow/Partitioner/PartitionerUtils.h"
+#include "glow/Partitioner/PartitionerTypes.h"
 #include <unordered_set>
 
 using llvm::isa;
@@ -298,5 +299,19 @@ std::set<Kinded::Kind> generateNodeKindsSet(llvm::StringRef names) {
     nodeKindsSet.insert(getKindFromNodeName(names));
   }
   return nodeKindsSet;
+}
+
+void logPartitionInfo(const NodeToFunctionMap &partitions) {
+  int i = 0;
+  for (Function *subF : partitions.getPartitions()) {
+    LOG(INFO) << "\t Partition " << i++ << ":\n"
+              << "\t\t Name :\t" << subF->getName().str() << "\n"
+              << "\t\t BackendKind :\t"
+              << partitions.getPartitionBackendName(subF) << "\n"
+              << "\t\t Memory :\t"
+              << partitions.getGraphMemInfo(subF).getTotalMemSize() << "\n"
+              << "\t\t LogicalDeviceIDs :\t"
+              << partitions.getLogicalDeviceIDList(subF)[0] << "\n";
+  }
 }
 } // namespace glow

--- a/lib/Partitioner/PartitionerValidation.cpp
+++ b/lib/Partitioner/PartitionerValidation.cpp
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "glow/Partitioner/PartitionerValidation.h"
+
+namespace glow {
+llvm::Error
+logicalDevicesValidation(const NodeToFunctionMap &partitions,
+                         const std::map<std::string, BackendInfo> &backendMap) {
+  std::map<std::string, std::set<DeviceIDTy>> partitionsNum;
+  for (auto &func : partitions.getPartitions()) {
+    auto backendName = partitions.getPartitionBackendName(func);
+    if (partitionsNum.find(backendName) == partitionsNum.end()) {
+      partitionsNum.emplace(backendName, std::set<DeviceIDTy>{});
+    }
+    auto logicalIDList = partitions.getLogicalDeviceIDList(func);
+    for (size_t i = 0, e = logicalIDList.size(); i < e; i++) {
+      partitionsNum[backendName].insert(logicalIDList[i]);
+    }
+    auto backendNum = backendMap.at(backendName).num;
+    RETURN_ERR_IF_NOT(
+        partitionsNum[backendName].size() <= backendNum,
+        llvm::formatv("Partition failed: the number of given({0}) devices({1}) "
+                      "is fewer than the required minimal partitions({2}).",
+                      backendName, backendNum,
+                      partitionsNum[backendName].size())
+            .str());
+  }
+  return llvm::Error::success();
+}
+
+llvm::Error
+memoryUsageValidation(const NodeToFunctionMap &partitions,
+                      const std::map<std::string, BackendInfo> &backendMap) {
+  for (auto &func : partitions.getPartitions()) {
+    auto backendName = partitions.getPartitionBackendName(func);
+    auto usedMemSize = partitions.getGraphMemInfo(func).getTotalMemSize();
+    auto availableMemSize = backendMap.at(backendName).memSize;
+    RETURN_ERR_IF_NOT(
+        usedMemSize <= availableMemSize,
+        llvm::formatv(
+            "Partition failed: the memory usage({0}) of one partition exceeds "
+            "the available memory({1}) of given devices({2}).",
+            usedMemSize, availableMemSize, backendName)
+            .str());
+  }
+  return llvm::Error::success();
+}
+} // namespace glow


### PR DESCRIPTION
Summary:
This PR is the first step of Partitioner refactoring:
1) Move the types used in Partitioner from Partitioner.h to PartitionerTypes.h
2) Move the partition optimizations from Partitioner class to a separate file PartitionerOptimization.cpp
3) Move the partition validation from Partitioner class to a separate file PartitionerValidation.cpp.

Documentation:

[Optional Fixes #issue]
#2298 
Test Plan:
current test.
Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
