### PR TITLE
libjit: remove the memory allocation on un-packed matmuls.

### DIFF
--- a/lib/Backends/CPU/libjit/libjit_matmul.cpp
+++ b/lib/Backends/CPU/libjit/libjit_matmul.cpp
@@ -225,8 +225,10 @@ template <bool pack>
 void __attribute__((noinline))
 libjit_matmul_outer(size_t m, size_t n, size_t k, const float *a, size_t lda,
                     const float *b, size_t ldb, float *c, size_t ldc) {
-  float *packedB;
-  libjit_aligned_malloc((void **)&packedB, 64, kc * nc);
+  float *packedB = nullptr;
+  if (pack) {
+    libjit_aligned_malloc((void **)&packedB, 64, kc * nc);
+  }
 
   for (size_t p = 0; p < k; p += kc) {
     size_t pb = MIN(k - p, kc);
@@ -243,7 +245,9 @@ libjit_matmul_outer(size_t m, size_t n, size_t k, const float *a, size_t lda,
     }
   }
 
-  libjit_aligned_free(packedB);
+  if (pack) {
+    libjit_aligned_free(packedB);
+  }
 }
 
 #undef C


### PR DESCRIPTION
Summary:
Simple if statement on the sole allocation / deallocation call in the code.
One might consider using TLS for the packed matmuls buffer, so it doesn't need to be reallocated on subsequent calls, but there are a couple of problems with that:

1. LLVM JIT Does not work well with C++'s thread_local keyword, which means we have to resort to target specific code with #ifdef

2. If we do not explicitly free the TLS memory LSAN (by default) will complain about a memory leak: the memory will naturally be deallocated upon thread destruction, Which is what we want, but LSAN does not know that. We could have made the free() operation explicit, but that poses a couple of issues of its own:
2.1) If we used something like std::unique_ptr with a custom lambda, then we have the overhead of a smart pointer and we would have to deal with LLVM JIT misbehaving with C++ pointers
2.2) If we moved the allocation / deallocation code further up the call stack, upon thread creation / destruction, then we are polluting function signatures and have to find a more complex way to deal with threads that only encounter un-packed matmuls

Fixes #2940

Test Plan:
`ninja test`