### PR TITLE
Ported OCLTest to EE2

### DIFF
--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -344,8 +344,8 @@ if(GLOW_WITH_OPENCL)
                           OpenCL::OpenCL
                         PRIVATE
                           Backends
-                          BackendTestUtils
-                          ExecutionEngine
+                          BackendTestUtils2
+                          ExecutionEngine2
                           Graph
                           IR
                           gtest

--- a/tests/unittests/OCLTest.cpp
+++ b/tests/unittests/OCLTest.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "BackendTestUtils.h"
+#include "BackendTestUtils2.h"
 
 // Silence Apple's warning about the deprecation of OpenCL.
 #define CL_SILENCE_DEPRECATION
@@ -24,7 +24,7 @@
 
 #include "../../lib/Backends/OpenCL/OpenCLDeviceManager.h"
 #include "glow/Backends/DeviceManager.h"
-#include "glow/ExecutionEngine/ExecutionEngine.h"
+#include "glow/ExecutionEngine/ExecutionEngine2.h"
 #include "glow/Graph/Graph.h"
 #include "glow/IR/IR.h"
 #include "glow/IR/IRBuilder.h"


### PR DESCRIPTION
Summary: This PR ports OCLTest to EE2 

Documentation:

Progress on #3239 

Test Plan: build all , run OCLTest and verify it passes.
