### PR TITLE
Ported TraceEventsTest to EE2

### DIFF
--- a/tests/unittests/BackendTestUtils2.h
+++ b/tests/unittests/BackendTestUtils2.h
@@ -296,6 +296,16 @@ void inferExtract3D(Tensor *input, Tensor *out, llvm::StringRef kind);
 
 void inferMaxSplat(Tensor *input, Tensor *out, llvm::StringRef kind);
 
+/// A helper method to insert a compiledFunction \p func into the deviceManager
+/// \p device.
+void insertCompiledFunction(llvm::StringRef name, CompiledFunction *func,
+                            runtime::DeviceManager *device, Module *mod);
+
+/// A helper method to run the specified function \p name with the provided
+/// ExecutionContext \p context on the specified DeviceManager \p device.
+void runOnDevice(ExecutionContext &context, llvm::StringRef name,
+                 runtime::DeviceManager *device);
+
 } // namespace glow
 
 #endif // GLOW_TESTS_BACKENDTESTUTILS_H

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -506,10 +506,11 @@ add_executable(TraceEventsTest
                TraceEventsTest.cpp)
 target_link_libraries(TraceEventsTest
                       PRIVATE
-                        Backend
+                        Backends
                         Graph
                         IR
-                        ExecutionEngine
+                        ExecutionEngine2
+                        BackendTestUtils2
                         GraphOptimizer
                         gtest
                         TestMain)


### PR DESCRIPTION
Summary: Ported TraceEventsTest to EE2

Documentation:

Progress on #3239 

Test Plan: verify everything builds and TraceEventsTest runs and passes.
