### PR TITLE
[Loader] Allow for passing paths to init_net + predict_net

### DIFF
--- a/tests/images/run.sh
+++ b/tests/images/run.sh
@@ -53,6 +53,9 @@ for png_filename in tests/images/imagenet/*.png; do
 done
 runSqueezenetModel "tests/images/imagenet/zebra_340.png" ${imagenetIdxArray[2]} "_0"
 
+./bin/image-classifier tests/images/imagenet/*.png -expected-labels=${imagenetIdxValues} -image-mode=neg128to127 -m=squeezenet/predict_net.pb -m=squeezenet/init_net.pb -model-input-name=data "$@"
+num_errors=$(($num_errors + $?))
+
 
 # Batch processing
 ./bin/image-classifier tests/images/imagenet/*.png -expected-labels=${imagenetIdxValues} -use-imagenet-normalization -image-mode=0to1 -m=resnet50 -model-input-name=gpu_0/data "$@"

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -213,9 +213,17 @@ llvm::cl::opt<unsigned> iterationsOpt(
     "iterations", llvm::cl::desc("Number of iterations to perform"),
     llvm::cl::Optional, llvm::cl::init(0), llvm::cl::cat(loaderCat));
 
-llvm::StringRef Loader::getModelOptPath() {
-  assert(modelPathOpt.size() == 1 && "Model path must be a single path.");
-  return modelPathOpt[0];
+std::string Loader::getModelOptPath() {
+  // If given a single path, return it.
+  if (modelPathOpt.size() == 1 &&
+      llvm::sys::fs::is_directory(*modelPathOpt.begin())) {
+    return *modelPathOpt.begin();
+  }
+
+  // Model path must be to one or more files. Use the path of the first file.
+  size_t found = modelPathOpt[0].find_last_of("/");
+  assert(found != std::string::npos && "Expected path to proto with directory");
+  return modelPathOpt[0].substr(0, found);
 }
 
 llvm::StringRef Loader::getModelOptDir() {

--- a/tools/loader/Loader.h
+++ b/tools/loader/Loader.h
@@ -89,7 +89,7 @@ public:
   llvm::StringRef getOnnxModelFilename() { return onnxModelFilename_; }
   /// Getter for the model path.
   /// \pre (modelPathOpt.size() == 1)
-  static llvm::StringRef getModelOptPath();
+  static std::string getModelOptPath();
   /// Getter for the model path, expected to be a directory.
   /// \pre (modelPathOpt.size() == 1)
   static llvm::StringRef getModelOptDir();


### PR DESCRIPTION
Summary: Specifying paths to each of the protos (e.g. one for `predict_net.pbtxt` and one for `init_net.pb`) was broken. This PR fixes it.

Test Plan: Added case for this in `run.sh`.