### PR TITLE
[PyTorch] Add support for elementwise max operator

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -197,6 +197,18 @@ void PyTorchModelLoader::loadSub(const torch::jit::Node *ptNode) {
   addGlowNodeValue(outputs[0], glowNode->getResult());
 }
 
+void PyTorchModelLoader::loadMax(const torch::jit::Node *ptNode) {
+  auto inputs = ptNode->inputs();
+  auto outputs = ptNode->outputs();
+  assert(inputs.size() == 2);
+  assert(outputs.size() == 1);
+
+  glow::NodeValue lhs = getGlowNodeValue(inputs[0]);
+  glow::NodeValue rhs = getGlowNodeValue(inputs[1]);
+  glow::MaxNode *glowNode = f_->createMax("max", lhs, rhs);
+  addGlowNodeValue(outputs[0], glowNode->getResult());
+}
+
 void PyTorchModelLoader::loadRelu(const torch::jit::Node *ptNode) {
   auto inputs = ptNode->inputs();
   auto outputs = ptNode->outputs();
@@ -618,6 +630,9 @@ void PyTorchModelLoader::populateNodeLoaderMapping() {
       [this](const torch::jit::Node *node) { return loadSub(node); };
   nodeLoaderMapping_[at::Symbol::fromQualString("aten::sub_")] =
       [this](const torch::jit::Node *node) { return loadSub(node); };
+
+  nodeLoaderMapping_[at::Symbol::fromQualString("aten::max")] =
+      [this](const torch::jit::Node *node) { return loadMax(node); };
 
   nodeLoaderMapping_[at::Symbol::fromQualString("aten::relu")] =
       [this](const torch::jit::Node *node) { return loadRelu(node); };

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -137,6 +137,9 @@ private:
   /// Load a PyTorch sub node.
   void loadSub(const torch::jit::Node *ptNode);
 
+  /// Load a PyTorch max node.
+  void loadMax(const torch::jit::Node *ptNode);
+
   /// Load a PyTorch relu node.
   void loadRelu(const torch::jit::Node *ptNode);
 

--- a/torch_glow/tests/nodes/max_test.py
+++ b/torch_glow/tests/nodes/max_test.py
@@ -1,0 +1,18 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import torch
+import torch_glow
+from tests.utils import jitVsGlow
+
+
+def test_elementwise_max():
+    """Test of the PyTorch max Node on Glow."""
+
+    def elementwise_max(a, b):
+        c = torch.max(a, b)
+        return torch.max(c, c)
+
+    x = torch.randn(4)
+    y = torch.randn(4)
+
+    jitVsGlow(elementwise_max, x, y)


### PR DESCRIPTION
**Summary**
This commit adds support for the elementwise max operator to the
PyTorchModelLoader so that `torch.max(a, b)` can be executed on Glow.

**Test Plan**
This commit adds a unit test that runs a graph with two max nodes on Glow and
the PyTorch CPU backend and checks that the results are identical.