### PR TITLE
[PyTorch] Add support for sqrt operator

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -231,6 +231,17 @@ void PyTorchModelLoader::loadExp(const torch::jit::Node *ptNode) {
   addGlowNodeValue(outputs[0], glowNode->getResult());
 }
 
+void PyTorchModelLoader::loadSqrt(const torch::jit::Node *ptNode) {
+  auto inputs = ptNode->inputs();
+  auto outputs = ptNode->outputs();
+  assert(inputs.size() == 1);
+  assert(outputs.size() == 1);
+
+  glow::NodeValue input = getGlowNodeValue(inputs[0]);
+  glow::PowNode *glowNode = f_->createPow("sqrt", input, /*exp=*/0.5);
+  addGlowNodeValue(outputs[0], glowNode->getResult());
+}
+
 void PyTorchModelLoader::loadConvolution(const torch::jit::Node *ptNode) {
   auto inputs = ptNode->inputs();
   auto outputs = ptNode->outputs();
@@ -641,6 +652,11 @@ void PyTorchModelLoader::populateNodeLoaderMapping() {
 
   nodeLoaderMapping_[at::Symbol::fromQualString("aten::exp")] =
       [this](const torch::jit::Node *node) { return loadExp(node); };
+
+  nodeLoaderMapping_[at::Symbol::fromQualString("aten::sqrt")] =
+      [this](const torch::jit::Node *node) { return loadSqrt(node); };
+  nodeLoaderMapping_[at::Symbol::fromQualString("aten::sqrt_")] =
+      [this](const torch::jit::Node *node) { return loadSqrt(node); };
 
   nodeLoaderMapping_[at::Symbol::fromQualString("aten::_convolution")] =
       [this](const torch::jit::Node *node) { return loadConvolution(node); };

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -146,6 +146,9 @@ private:
   /// Load a PyTorch exp node.
   void loadExp(const torch::jit::Node *ptNode);
 
+  /// Load a PyTorch sqrt node.
+  void loadSqrt(const torch::jit::Node *ptNode);
+
   /// Load a PyTorch _convolution node.
   void loadConvolution(const torch::jit::Node *ptNode);
 

--- a/torch_glow/tests/nodes/sqrt_test.py
+++ b/torch_glow/tests/nodes/sqrt_test.py
@@ -1,0 +1,31 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import torch
+import torch_glow
+from tests.utils import jitVsGlow
+
+
+def test_sqrt_basic():
+    """Test of the PyTorch sqrt Node on Glow."""
+
+    def sqrt_basic(a):
+        b = torch.sqrt(a)
+        return torch.sqrt(b)
+
+    # Make sure the input is positive and not super close to zero.
+    x = torch.rand(4) + 5
+
+    jitVsGlow(sqrt_basic, x)
+
+
+def test_sqrt_inplace():
+    """Test of the PyTorch inplace sqrt Node on Glow."""
+
+    def sqrt_inplace(a):
+        b = a.sqrt_()
+        return b.sqrt_()
+
+    # Make sure the input is positive and not super close to zero.
+    x = torch.rand(4) + 5
+
+    jitVsGlow(sqrt_inplace, x)


### PR DESCRIPTION
**Summary**
This commit adds support for the elementwise sqrt operator to the
`PyTorchModelLoader` so that `torch.sqrt(a)` can be executed on Glow.

**Test Plan**
This commit adds a unit test that runs a graph with two sqrt nodes on Glow and
the PyTorch CPU backend and checks that the results are identical.