### PR TITLE
Update error messages to be more descriptive

### DIFF
--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -244,8 +244,9 @@ getSizeHW(ArgumentDictionaryTy &dict, const std::string &name,
 llvm::Expected<caffe2::NetDef>
 Caffe2ModelLoader::loadProtoFile(const std::string &filename) {
   std::ifstream ff(filename, std::ios::in | std::ios::binary);
-  RETURN_ERR_IF_NOT(ff, "Can't find the model or network files.");
-
+  RETURN_ERR_IF_NOT(ff,
+                    strFormat("Can't find the model or network files for %s",
+                              filename.c_str()));
   caffe2::NetDef net;
 
   bool parseNet = false;

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -186,7 +186,9 @@ ONNXModelLoader::loadProto(const void *onnxModel, size_t onnxModelSize) {
 llvm::Expected<ONNX_NAMESPACE::ModelProto>
 ONNXModelLoader::loadProto(const std::string &filename) {
   std::ifstream ff(filename, std::ios::in | std::ios::binary);
-  RETURN_ERR_IF_NOT(ff, "Can't find the model or network files.",
+  RETURN_ERR_IF_NOT(ff,
+                    strFormat("Can't find the model or network files for %s.",
+                              filename.c_str()),
                     GlowErr::ErrorCode::MODEL_LOADER_INVALID_PROTOBUF);
 
   // TODO: intend to find a way to reuse the following function later

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -35,7 +35,9 @@ using namespace std;
 llvm::Expected<ONNX_NAMESPACE::ModelProto>
 loadProto(const std::string &filename) {
   std::ifstream ff(filename, std::ios::in | std::ios::binary);
-  RETURN_ERR_IF_NOT(ff, "Can't find the model or network files.",
+  RETURN_ERR_IF_NOT(ff,
+                    strFormat("Can't find the model or network files for %s.",
+                              filename.c_str()),
                     GlowErr::ErrorCode::MODEL_LOADER_INVALID_PROTOBUF);
   if (filename.find(".onnxtxt") != std::string::npos) {
     std::string str((std::istreambuf_iterator<char>(ff)),


### PR DESCRIPTION
  Add the name of the network or model we are trying to load to the log
  messages we print at failures.

 Fixes #2647 

Test Plan:
 Ran ninja test.
  Checked that the network name gets printed when an error happens at loading.

