### PR TITLE
[RecSys] Compare against Interpreter. Use Xaiver initialization based on tensor size.

### DIFF
--- a/tests/unittests/RecommendationSystemTest.cpp
+++ b/tests/unittests/RecommendationSystemTest.cpp
@@ -999,23 +999,3 @@ TEST_P(RecommendationSystemTest, RecSys_FP32_Gather_Weights) {
              /* convertToFP16 */ false,
              /* gatherWeights */ true);
 }
-
-/// Test gathering weights for SLWS.
-TEST_P(RecommendationSystemTest, RecSys_FP32_Medium_Gather_Weights) {
-  ENABLED_BACKENDS(CPU);
-
-  // Note that this overrides the parameters provided by command line options if
-  // provided, as this comes after SetUp().
-  tableSizes = {800000, 600000, 700000, 900000, 1200000,
-                800000, 600000, 700000, 900000, 1200000,
-                800000, 600000, 700000, 900000, 1200000};
-  deviceMemCapacity = 1024ULL * 1024 * 1024 * 4; // 4GB.
-  // Since this is bigger than the default set the device memory.
-  EE_.setDeviceMemory(deviceMemCapacity);
-  // Recreate function.
-  F_ = EE_.getModule().createFunction("main");
-  testRecSys(/* quantizeSLWS */ false,
-             /* quantizeFC */ false,
-             /* convertToFP16 */ false,
-             /* gatherWeights */ true);
-}


### PR DESCRIPTION
Summary: A couple improvements to RecSys:
- If we're executing on a non-Interpreter backend, then run on the Interpreter and make sure the results are equal.
- Randomly initialize floating point tensors via Xaiver initialization, using twice the size of the tensor as the filter size. Hopefully this will reduce overflows as the test uses different sizes/configurations.

Test Plan: All tests pass.
