### PR TITLE
[PyTorch] Add support for reciprocal operator

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -116,6 +116,10 @@ PyTorchModelLoader::getSymbolsMapping() {
       {at::Symbol::fromQualString("aten::relu"), &PyTorchModelLoader::loadRelu},
       {at::Symbol::fromQualString("aten::relu_"),
        &PyTorchModelLoader::loadRelu},
+      {at::Symbol::fromQualString("aten::reciprocal"),
+       &PyTorchModelLoader::loadReciprocal},
+      {at::Symbol::fromQualString("aten::reciprocal_"),
+       &PyTorchModelLoader::loadReciprocal},
       {at::Symbol::fromQualString("aten::_convolution"),
        &PyTorchModelLoader::loadConvolution},
       {at::Symbol::fromQualString("aten::batch_norm"),
@@ -296,6 +300,17 @@ void PyTorchModelLoader::loadSqrt(const torch::jit::Node *ptNode) {
 
   glow::NodeValue input = getGlowNodeValue(inputs[0]);
   glow::PowNode *glowNode = F_.createPow("sqrt", input, /*exp=*/0.5);
+  addGlowNodeValue(outputs[0], glowNode->getResult());
+}
+
+void PyTorchModelLoader::loadReciprocal(const torch::jit::Node *ptNode) {
+  auto inputs = ptNode->inputs();
+  auto outputs = ptNode->outputs();
+  assert(inputs.size() == 1);
+  assert(outputs.size() == 1);
+
+  glow::NodeValue input = getGlowNodeValue(inputs[0]);
+  glow::PowNode *glowNode = F_.createPow("reciprocal", input, /*exp=*/-1);
   addGlowNodeValue(outputs[0], glowNode->getResult());
 }
 

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -109,6 +109,9 @@ private:
   /// Load a PyTorch sqrt node.
   void loadSqrt(const torch::jit::Node *ptNode);
 
+  /// Load a PyTorch reciprocal node.
+  void loadReciprocal(const torch::jit::Node *ptNode);
+
   /// Load a PyTorch _convolution node.
   void loadConvolution(const torch::jit::Node *ptNode);
 

--- a/torch_glow/tests/nodes/reciprocal_test.py
+++ b/torch_glow/tests/nodes/reciprocal_test.py
@@ -1,0 +1,28 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import torch
+import torch_glow
+from tests.utils import jitVsGlow
+
+
+def test_reciprocal():
+    """Test of the PyTorch reciprocal Node on Glow."""
+
+    def reciprocal(a):
+        return torch.reciprocal(a + a)
+
+    x = torch.randn(4)
+
+    jitVsGlow(reciprocal, x)
+
+
+def test_inplace_reciprocal():
+    """Test of the PyTorch inplace reciprocal Node on Glow."""
+
+    def reciprocal_inplace(a):
+        b = a + a
+        return b.reciprocal_()
+
+    x = torch.randn(4)
+
+    jitVsGlow(reciprocal_inplace, x)


### PR DESCRIPTION
**Summary**
This commit adds support for the elementwise reciprocal operator to the
`PyTorchModelLoader` so that `torch.reciprocal(a)` and `a.reciprocal_()`
(inplace version) can be executed on Glow.

**Test Plan**
This commit adds two unit tests (one for the inplace version and one for
the out of place version) that runs a graph with two reciprocal nodes on
Glow and the PyTorch CPU backend and checks that the results are
identical.

```
tests/nodes/reciprocal_test.py::test_reciprocal PASSED                                                                                                                            [ 66%]
tests/nodes/reciprocal_test.py::test_inplace_reciprocal PASSED                                                                                                                    [ 70%]
```
