### PR TITLE
[PyTorch] Unbreak torch_glow

### DIFF
--- a/torch_glow/src/CMakeLists.txt
+++ b/torch_glow/src/CMakeLists.txt
@@ -26,7 +26,7 @@ target_link_libraries(_torch_glow
                         ExecutionEngine
                         Graph
                         Importer
-                        Interpreter
+			 Support
                         Backends
                         pybind11)
 

--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -129,6 +129,11 @@ PyTorchModelLoader::getSymbolsMapping() {
       {at::Symbol::fromQualString("aten::t_"),
        &PyTorchModelLoader::loadTranspose},
       {at::Symbol::fromQualString("aten::min"), &PyTorchModelLoader::loadMin},
+      {at::Symbol::fromQualString("aten::max"), &PyTorchModelLoader::loadMax},
+      {at::Symbol::fromQualString("aten::exp"), &PyTorchModelLoader::loadExp},
+      {at::Symbol::fromQualString("aten::sqrt"), &PyTorchModelLoader::loadSqrt},
+      {at::Symbol::fromQualString("aten::sqrt_"),
+       &PyTorchModelLoader::loadSqrt},
   };
 
   return symbolLoaderMapping;


### PR DESCRIPTION
**Summary**
`torch_glow` was accidentally broken by #3308 which removed
`PyTorchModelLoader::populateNodeLoaderMapping` and created a static map
in its place. Mappings for for `exp`, `sqrt` and `max` operators were added and
merged while PR #3308 was still a work in progress and they must have
gotten lost in the process of resolving merge conflicts.

**Test Plan**
The unit tests for `exp`, `sqrt` and `max` pass again.
