### PR TITLE
Ported BackendCorrectnessTest to EE2

### DIFF
--- a/tests/unittests/BackendCorrectnessTest.cpp
+++ b/tests/unittests/BackendCorrectnessTest.cpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include "BackendTestUtils.h"
+#include "BackendTestUtils2.h"
 
-#include "glow/ExecutionEngine/ExecutionEngine.h"
+#include "glow/ExecutionEngine/ExecutionEngine2.h"
 #include "glow/Graph/Graph.h"
 #include "glow/Graph/PlaceholderBindings.h"
 #include "glow/IR/IR.h"

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -41,10 +41,10 @@ add_executable(BackendCorrectnessTest
 target_link_libraries(BackendCorrectnessTest
                       PRIVATE
                         Backends
-                        BackendTestUtils
+                        BackendTestUtils2
                         Graph
                         IR
-                        ExecutionEngine
+                        ExecutionEngine2
                         Quantization
                         Support
                         gtest


### PR DESCRIPTION
Summary: This PR ports BackendCorrectnessTest to EE2.

Documentation:

Progress on #3239 

Test Plan: Verify everything builds, BackendCorrectnessTest runs and passes.
