### PR TITLE
Ported ParameterSweepTest to EE2

### DIFF
--- a/tests/stress/CMakeLists.txt
+++ b/tests/stress/CMakeLists.txt
@@ -13,8 +13,8 @@ add_executable(ParameterSweepTest
                ParameterSweepTest.cpp)
 target_link_libraries(ParameterSweepTest
                       PRIVATE
-                        BackendTestUtils
-                        ExecutionEngine
+                        BackendTestUtils2
+                        ExecutionEngine2
                         glog::glog
                         gtest
                         Graph

--- a/tests/stress/ParameterSweepTest.cpp
+++ b/tests/stress/ParameterSweepTest.cpp
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-#include "BackendTestUtils.h"
+#include "BackendTestUtils2.h"
 
-#include "glow/ExecutionEngine/ExecutionEngine.h"
+#include "glow/ExecutionEngine/ExecutionEngine2.h"
 #include "glow/Graph/Graph.h"
 #include "glow/Graph/PlaceholderBindings.h"
 #include "glow/Optimizer/GraphOptimizer/GraphOptimizer.h"
@@ -59,7 +59,7 @@ using FourIntTupleConfig =
 /// Create a simple network that has a single fp convolution.
 static FunctionTensorPair
 createAndInitConvNet(glow::PlaceholderBindings &bindings,
-                     glow::ExecutionEngine &EE, size_t size, size_t convDepth,
+                     glow::ExecutionEngine2 &EE, size_t size, size_t convDepth,
                      size_t kernel, size_t stride, size_t pad) {
   PseudoRNG PRNG;
   auto &mod = EE.getModule();
@@ -136,7 +136,7 @@ TEST_P(ConvSweepTest, ConvTest_Float16) {
 /// Create a simple network that has a single fp batch mat mul.
 static FunctionTensorPair
 createAndInitBatchMatMulNet(glow::PlaceholderBindings &bindings,
-                            glow::ExecutionEngine &EE, size_t N, size_t A,
+                            glow::ExecutionEngine2 &EE, size_t N, size_t A,
                             size_t Z, size_t B) {
   PseudoRNG PRNG;
   auto &mod = EE.getModule();
@@ -215,7 +215,7 @@ TEST_P(BatchMatMulSweepTest, BatchMatMulTest_Float16) {
 /// Create a simple network that has a single fp FC.
 static FunctionTensorPair
 createAndInitFCNet(glow::PlaceholderBindings &bindings,
-                   glow::ExecutionEngine &EE, size_t A, size_t Z, size_t B) {
+                   glow::ExecutionEngine2 &EE, size_t A, size_t Z, size_t B) {
   PseudoRNG PRNG;
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -288,7 +288,7 @@ TEST_P(FCSweepTest, FCTest_Float16) {
 /// Create a simple network that has a single fp Concat.
 static FunctionTensorPair
 createAndInitConcatNet(glow::PlaceholderBindings &bindings,
-                       glow::ExecutionEngine &EE, size_t numInputs,
+                       glow::ExecutionEngine2 &EE, size_t numInputs,
                        size_t numDims, size_t maxLength, size_t axis) {
   PseudoRNG PRNG;
   auto &mod = EE.getModule();


### PR DESCRIPTION
Summary: This PR Ports ParameterSweepTest to EE2

Documentation:

Progress on #3239 

Test Plan: Verify everything builds, Run ParameterSweepTest and verify it runs and passes. I don't think CI runs ParameterSweepTest, so verified manually.