### PR TITLE
Glow fix error macros

### DIFF
--- a/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
@@ -21,7 +21,7 @@
 
 static llvm::cl::OptionCategory
     InterpreterBackendCat("Glow Interpreter Backend Options");
-llvm::cl::opt<unsigned> interpreterMaxMem(
+static llvm::cl::opt<unsigned> interpreterMaxMem(
     "interpreter-memory",
     llvm::cl::desc("Interpreter DeviceManager maximum memory in kilobytes"),
     llvm::cl::init(0), llvm::cl::cat(InterpreterBackendCat));


### PR DESCRIPTION
Summary:

Documentation:
Fix Error.h file macros, any namespace should be referred explicitly and all macros must be outside any namespaces

[Optional Fixes #issue]

Test Plan:

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
