### PR TITLE
[runtime] Fix memory usage when reusing allocator in compile

### DIFF
--- a/include/glow/Backend/BackendUtils.h
+++ b/include/glow/Backend/BackendUtils.h
@@ -104,6 +104,13 @@ public:
                                        MemoryAllocator &placeholderAllocator,
                                        MemoryAllocator &activationsAllocator);
 
+  /// Computes offsets and total allocations for Constants, Placeholders, and
+  /// Activations to build runtime symbol table. \returns RuntimeBundle. Uses a
+  /// single allocator \p allocator and allocates all buffers contiguously in
+  /// the same block.
+  static runtime::RuntimeBundle create(const IRFunction &F,
+                                       MemoryAllocator &allocator);
+
   /// Build a runtime symbol table from a Function.  Computes Constant and
   /// Placeholder sizes, but not Activations, since Functions are unserialized.
   /// Only use this method to generate bundles for backends that do not use

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -1724,7 +1724,7 @@ OCLBackend::compileIR(std::unique_ptr<IRFunction> IR) const {
 
   MemoryAllocator allocator("GPU", 0xFFFFFFFF);
   runtime::RuntimeBundle bundle =
-      runtime::RuntimeBundle::create(*IR, allocator, allocator, allocator);
+      runtime::RuntimeBundle::create(*IR, allocator);
   std::unique_ptr<CompiledFunction> function =
       llvm::make_unique<OpenCLFunction>(std::move(IR), std::move(bundle),
                                         std::move(traceInfo));
@@ -1745,7 +1745,7 @@ OCLBackend::compile(Function *F, const BackendOptions &opts) const {
 
   MemoryAllocator allocator("GPU", 0xFFFFFFFF);
   runtime::RuntimeBundle bundle =
-      runtime::RuntimeBundle::create(*IR, allocator, allocator, allocator);
+      runtime::RuntimeBundle::create(*IR, allocator);
 
   if (opts.collectConstants) {
     bundle.collectConstants(F->getParent());


### PR DESCRIPTION
Summary: In the OpenCL backend we allocate all device buffers contiguously by reusing the same memory allocator for Constants, Placeholders and Activations. This diff fixes a bug in that logic which allocated the sum of the current stage and previous stages rather than just the memory needed for the current stage (e.g. we'd set sizes to be Constants, Placeholders + Constants, Activations + Placeholders + Constants).

This means we were allocating about 2-3x as much memory as we needed on the GPU. E.g. in OCLTest::ConvOps:

before:
```
  Constants: 2496
  Placeholders: 9216
  Activations: 12928
  Total alloced: 24640
```

after:
```
  Constants: 2496 
  Placeholders: 6720
  Activations: 3712
  Total alloced: 12928
```

Gets better the bigger the Constants block is, obviously.

Documentation: n/a

Test Plan: unit tests in ASAN and Release (OCLTest, BackendCorrectnessTest & OperatorTest being the important ones).