### PR TITLE
[Tiny/Loader] Remove noop training nodes for inference.

### DIFF
--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -990,7 +990,7 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     // Glow frees memory automatically.
     return llvm::Error::success();
   }
-  if (typeName == "StopGradient") {
+  if (typeName == "StopGradient" || typeName == "ScaleGradient") {
     NodeValue in;
     ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
     // Currently Caffe2 importer only supports inference.


### PR DESCRIPTION
Summary:
Remove ScaleGradient node from the inference net.
Could be useful for loading protobufs with Glow as a standalone compiler (as well as through onnxifi).

Documentation:
n/a

[Optional Fixes #issue]

Test Plan: trivial