### PR TITLE
[CPU] Add CPU backend Support for Modulo operator

### DIFF
--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -167,6 +167,10 @@ bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
   case Kinded::Kind::ExpNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind({ElemKind::FloatTy});
 
+  case Kinded::Kind::ModuloNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+        {ElemKind::Int32ITy, ElemKind::Int64ITy});
+
   case Kinded::Kind::MaxPoolGradNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
                {ElemKind::FloatTy},

--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -822,6 +822,40 @@ DEFINE_DATA_PARALLEL_KERNEL_QUANTIZED_M(libjit_element_div_kernel_i8, lhs / rhs)
 /// for size_t when libjit was compiled.
 size_t libjit_sizeTVar;
 
+/// Specialize the Modulo kernel into two functions based on the
+/// value of SignFollowDivisor.
+int64_t libjit_element_modulo_kernel_sign_follow_u(size_t idx,
+                                                   const int64_t divisor,
+                                                   const int64_t *input) {
+  int64_t res = input[idx] % divisor;
+  if (res && ((res > 0) != (divisor > 0))) {
+    res += divisor;
+  }
+  return res;
+}
+
+int64_t libjit_element_modulo_kernel_no_sign_follow_u(size_t idx,
+                                                      const int64_t divisor,
+                                                      const int64_t *input) {
+  return input[idx] % divisor;
+}
+
+int32_t libjit_element_modulo_kernel_sign_follow_i32(size_t idx,
+                                                     const int64_t divisor,
+                                                     const int32_t *input) {
+  int32_t res = input[idx] % divisor;
+  if (res && ((res > 0) != (divisor > 0))) {
+    res += divisor;
+  }
+  return res;
+}
+
+int32_t libjit_element_modulo_kernel_no_sign_follow_i32(size_t idx,
+                                                        const int64_t divisor,
+                                                        const int32_t *input) {
+  return input[idx] % divisor;
+}
+
 int8_t libjit_element_cmp_eq_kernel_u(size_t idx, const size_t *LHS,
                                       const size_t *RHS) {
   return LHS[idx] == RHS[idx] ? 1 : 0;


### PR DESCRIPTION
 This adds more support for issue #2330

Summary:

 The current implementation for the Modulo operator only has an
 interpreter support. This PR adds support for a CPU backend.

Documentation:
  Add CPU backend support by defining jit kernels and calling them for the CPU backend.

Fixes #2330 

Test Plan:
  Updated the tests Modulo1 and Modulo2 to run for a CPU backend.
  ran ninja test
