### PR TITLE
Define a stats reporting interface

### DIFF
--- a/include/glow/Runtime/StatsExporter.h
+++ b/include/glow/Runtime/StatsExporter.h
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_RUNTIME_STATSEXPORTER_H
+#define GLOW_RUNTIME_STATSEXPORTER_H
+
+#include "llvm/ADT/StringRef.h"
+
+#include <vector>
+
+namespace glow {
+
+/// Interface for exporting runtime statistics.  The base implementation
+/// delegates to any subclass registered via `registerStatsExporter`.
+class StatsExporter {
+public:
+  /// Dtor.
+  virtual ~StatsExporter() {}
+
+  /// Add value to a time series.  May be called concurrently.
+  virtual void addTimeSeriesValue(llvm::StringRef key, double value) = 0;
+
+  /// Increment a counter.  May be called concurrently.
+  virtual void incrementCounter(llvm::StringRef key, int64_t value = 1) = 0;
+
+  /// Set a counter.  May be called concurrently.
+  virtual void setCounter(llvm::StringRef key, int64_t value) = 0;
+};
+
+/// Registry of StatsExporters.
+class StatsExporterRegistry final {
+public:
+  /// Add value to a time series for all registered StatsExporters.
+  void addTimeSeriesValue(llvm::StringRef key, double value);
+
+  /// Increment a counter for all registered StatsExporters.
+  void incrementCounter(llvm::StringRef key, int64_t value = 1);
+
+  /// Set a counter for all registered StatsExporters.
+  void setCounter(llvm::StringRef key, int64_t value);
+
+  /// Register a StatsExporter.
+  void registerStatsExporter(StatsExporter *exporter);
+
+private:
+  /// Registered StatsExporters.
+  std::vector<StatsExporter *> exporters_;
+};
+
+/// Global singleton StatsExporter.
+StatsExporterRegistry *Stats();
+
+} // namespace glow
+
+#endif // GLOW_RUNTIME_STATSEXPORTER_H

--- a/lib/Backends/CPU/CMakeLists.txt
+++ b/lib/Backends/CPU/CMakeLists.txt
@@ -91,6 +91,7 @@ target_link_libraries(CPUBackend
                         IROptimizer
                         GraphOptimizerPipeline
                         QuantizationBase
+                        Runtime
                         LLVMIRCodeGen)
 add_dependencies(CPUBackend CPURuntime)
 

--- a/lib/Backends/CPU/CPUDeviceManager.h
+++ b/lib/Backends/CPU/CPUDeviceManager.h
@@ -17,6 +17,7 @@
 #define GLOW_BACKENDS_CPU_CPUDEVICEMANAGER_H
 
 #include "glow/Backends/QueueBackedDeviceManager.h"
+#include "glow/Runtime/StatsExporter.h"
 
 namespace glow {
 namespace runtime {
@@ -39,10 +40,19 @@ class CPUDeviceManager : public QueueBackedDeviceManager {
   /// This is very arbitrary for the CPU backend.
   const uint64_t functionCost_{1};
 
+  /// String constant for logging number of in-use devices.
+  static constexpr const char *kDevicesUsedCPU = "glow.devices_used.cpu";
+
 public:
-  CPUDeviceManager(const DeviceConfig &config)
+  explicit CPUDeviceManager(const DeviceConfig &config)
       : QueueBackedDeviceManager(config),
-        maxMemoryBytes_(config_.getDeviceMemory(2000000000)) {}
+        maxMemoryBytes_(config_.getDeviceMemory(2000000000)) {
+    Stats()->incrementCounter(kDevicesUsedCPU);
+  }
+
+  ~CPUDeviceManager() override {
+    Stats()->incrementCounter(kDevicesUsedCPU, -1);
+  }
 
   /// Returns the amount of memory in bytes available on the device when no
   /// models are loaded.

--- a/lib/Backends/Habana/CMakeLists.txt
+++ b/lib/Backends/Habana/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(Habana
                         IR
                         LLVMCore
                         QuantizationBase
+                        Runtime
                         Support)
 
 set(linked_backends ${linked_backends} Habana PARENT_SCOPE)

--- a/lib/Backends/Habana/HabanaDeviceManager.cpp
+++ b/lib/Backends/Habana/HabanaDeviceManager.cpp
@@ -16,6 +16,8 @@
 
 #include "HabanaDeviceManager.h"
 
+#include "glow/Runtime/StatsExporter.h"
+
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -61,6 +63,7 @@ HabanaDeviceManager::~HabanaDeviceManager() {
   }
   std::lock_guard<std::mutex> lock(synapseMtx_);
   numActiveDevices_--;
+  Stats()->incrementCounter(kDevicesUsedHabana, -1);
 
   // Explicitly clear this map to force synFree of the managed IOBuffers to
   // happen now, before we synReleaseDevice.  Otherwise synReleaseDevice will
@@ -96,6 +99,7 @@ llvm::Error HabanaDeviceManager::init() {
   }
 
   numActiveDevices_++;
+  Stats()->incrementCounter(kDevicesUsedHabana);
 
   // Fetch initial memory information.
   RETURN_IF_ERR(updateMemoryUsage());

--- a/lib/Backends/Habana/HabanaDeviceManager.h
+++ b/lib/Backends/Habana/HabanaDeviceManager.h
@@ -41,6 +41,9 @@ class HabanaDeviceManager : public DeviceManager {
   static constexpr auto INVALID_TOPOLOGY =
       std::numeric_limits<TopologyId>::max();
 
+  /// String constant for logging number of in-use devices.
+  static constexpr const char *kDevicesUsedHabana = "glow.devices_used.habana";
+
   /// The ID of the device managed by this instance.
   DeviceId deviceId_{INVALID_DEVICE};
   /// The available memory on the device.

--- a/lib/Backends/Interpreter/CMakeLists.txt
+++ b/lib/Backends/Interpreter/CMakeLists.txt
@@ -14,6 +14,7 @@ target_link_libraries(Interpreter
                         LLVMCore
                         IROptimizer
                         GraphOptimizerPipeline
-                        QuantizationBase)
+                        QuantizationBase
+                        Runtime)
 
 set(linked_backends ${linked_backends} Interpreter PARENT_SCOPE)

--- a/lib/Backends/Interpreter/InterpreterDeviceManager.h
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.h
@@ -17,6 +17,7 @@
 #define GLOW_BACKENDS_INTERPRETER_INTERPRETERDEVICEMANAGER_H
 
 #include "glow/Backends/QueueBackedDeviceManager.h"
+#include "glow/Runtime/StatsExporter.h"
 
 namespace glow {
 namespace runtime {
@@ -39,10 +40,20 @@ class InterpreterDeviceManager : public QueueBackedDeviceManager {
   /// This is very arbitrary for the Interpreter backend.
   const uint64_t functionCost_{1};
 
+  /// String constant for logging number of in-use devices.
+  static constexpr const char *kDevicesUsedInterpreter =
+      "glow.devices_used.interpreter";
+
 public:
-  InterpreterDeviceManager(const DeviceConfig &config)
+  explicit InterpreterDeviceManager(const DeviceConfig &config)
       : QueueBackedDeviceManager(config),
-        maxMemoryBytes_(config_.getDeviceMemory(2000000000)) {}
+        maxMemoryBytes_(config_.getDeviceMemory(2000000000)) {
+    Stats()->incrementCounter(kDevicesUsedInterpreter);
+  }
+
+  ~InterpreterDeviceManager() override {
+    Stats()->incrementCounter(kDevicesUsedInterpreter, -1);
+  }
 
   /// Returns the amount of memory in bytes available on the device when no
   /// models are loaded.

--- a/lib/Backends/OpenCL/CMakeLists.txt
+++ b/lib/Backends/OpenCL/CMakeLists.txt
@@ -48,7 +48,8 @@ target_link_libraries(OpenCLBackend
                       LLVMCore
                       IROptimizer
                       GraphOptimizerPipeline
-                      QuantizationBase)
+                      QuantizationBase
+                      Runtime)
 
 target_link_libraries(OpenCLBackend
                       PUBLIC

--- a/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
@@ -23,6 +23,8 @@
 #include "OpenCLDeviceManager.h"
 #include "OpenCL.h"
 
+#include "glow/Runtime/StatsExporter.h"
+
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/raw_ostream.h"
@@ -233,13 +235,16 @@ llvm::Error OpenCLDeviceManager::init() {
   commandQueuePool_.setContext(context_);
   commandQueuePool_.setDevice(deviceId_);
 
+  Stats()->incrementCounter(kDevicesUsedOpenCL);
   return llvm::Error::success();
 }
 
 OpenCLDeviceManager::~OpenCLDeviceManager() {
   clReleaseContext(context_);
   buffers_.clear();
+  Stats()->incrementCounter(kDevicesUsedOpenCL, -1);
 }
+
 uint64_t OpenCLDeviceManager::getMaximumMemory() const {
   return maxMemoryBytes_;
 }

--- a/lib/Backends/OpenCL/OpenCLDeviceManager.h
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.h
@@ -122,6 +122,9 @@ public:
 /// A class controlling a single OpenCL device. Many OpenCLFunctions may be
 /// added, but only one inference is executed at a time.
 class OpenCLDeviceManager : public QueueBackedDeviceManager {
+  /// String constant for logging number of in-use devices.
+  static constexpr const char *kDevicesUsedOpenCL = "glow.devices_used.opencl";
+
   /// Compiled function list by name.
   FunctionMapTy functions_;
 

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -1,3 +1,9 @@
 add_subdirectory(Provisioner)
 add_subdirectory(Executor)
 add_subdirectory(HostManager)
+
+add_library(Runtime
+  StatsExporter.cpp)
+target_link_libraries(Runtime
+  PRIVATE
+  Support)

--- a/lib/Runtime/StatsExporter.cpp
+++ b/lib/Runtime/StatsExporter.cpp
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/Runtime/StatsExporter.h"
+
+#include <vector>
+
+namespace glow {
+
+void StatsExporterRegistry::registerStatsExporter(StatsExporter *exporter) {
+  exporters_.push_back(exporter);
+}
+
+void StatsExporterRegistry::addTimeSeriesValue(llvm::StringRef key,
+                                               double value) {
+  for (auto const &exporter : exporters_) {
+    exporter->addTimeSeriesValue(key, value);
+  }
+}
+
+void StatsExporterRegistry::setCounter(llvm::StringRef key, int64_t value) {
+  for (auto const &exporter : exporters_) {
+    exporter->setCounter(key, value);
+  }
+}
+
+void StatsExporterRegistry::incrementCounter(llvm::StringRef key,
+                                             int64_t value) {
+  for (auto const &exporter : exporters_) {
+    exporter->incrementCounter(key, value);
+  }
+}
+
+StatsExporterRegistry *Stats() {
+  static auto *stats = new StatsExporterRegistry();
+  return stats;
+}
+
+} // namespace glow

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -473,6 +473,16 @@ target_link_libraries(QuantizationTest
 add_glow_test(QuantizationTest ${GLOW_BINARY_DIR}/tests/QuantizationTest --gtest_output=xml:QuantizationTest.xml)
 LIST(APPEND UNOPT_TESTS ./tests/QuantizationTest -optimize-ir=false &&)
 
+add_executable(StatsExporterTest
+               StatsExporterTest.cpp)
+target_link_libraries(StatsExporterTest
+                      PRIVATE
+                        Backends
+                        Runtime
+                        gtest
+                        TestMain)
+add_glow_test(StatsExporterTest ${GLOW_BINARY_DIR}/tests/StatsExporterTest --gtest_output=xml:StatsExporterTest.xml)
+
 add_executable(TensorsTest
                TensorsTest.cpp)
 target_link_libraries(TensorsTest

--- a/tests/unittests/StatsExporterTest.cpp
+++ b/tests/unittests/StatsExporterTest.cpp
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/Runtime/StatsExporter.h"
+#include "glow/Backends/DeviceManager.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+using namespace glow;
+
+class MockStatsExporter : public StatsExporter {
+public:
+  MockStatsExporter() { Stats()->registerStatsExporter(this); }
+
+  ~MockStatsExporter() override {}
+
+  void addTimeSeriesValue(llvm::StringRef key, double value) override {
+    timeSeries[key].push_back(value);
+  }
+
+  void incrementCounter(llvm::StringRef key, int64_t value) override {
+    counters[key] += value;
+  }
+
+  void setCounter(llvm::StringRef key, int64_t value) override {
+    counters[key] = value;
+  }
+
+  void clear() {
+    counters.clear();
+    timeSeries.clear();
+  }
+
+  std::map<std::string, int64_t> counters;
+  std::map<std::string, std::vector<double>> timeSeries;
+} MockStats;
+
+class StatsExporterTest : public ::testing::Test {
+  ~StatsExporterTest() { MockStats.clear(); }
+};
+
+TEST(StatsExporter, Counter) {
+  MockStats.setCounter("foo", 1);
+  ASSERT_EQ(MockStats.counters["foo"], 1);
+  MockStats.setCounter("foo", 3);
+  ASSERT_EQ(MockStats.counters["foo"], 3);
+  MockStats.incrementCounter("foo", 1);
+  ASSERT_EQ(MockStats.counters["foo"], 4);
+  MockStats.incrementCounter("foo", -1);
+  ASSERT_EQ(MockStats.counters["foo"], 3);
+}
+
+TEST(StatsExporter, TimeSeries) {
+  MockStats.addTimeSeriesValue("bar", 1);
+  MockStats.addTimeSeriesValue("bar", 3.14);
+  MockStats.addTimeSeriesValue("bar", 2.71);
+  auto it = MockStats.timeSeries.find("bar");
+  ASSERT_NE(it, MockStats.timeSeries.end());
+  auto const &ts = it->second;
+  ASSERT_EQ(ts.size(), 3);
+  EXPECT_EQ(ts[0], 1);
+  EXPECT_EQ(ts[1], 3.14);
+  EXPECT_EQ(ts[2], 2.71);
+}
+
+TEST(StatsExporter, Device) {
+  using namespace glow::runtime;
+  EXPECT_EQ(MockStats.counters.count("glow.devices_used.interpreter"), 0);
+  {
+    std::unique_ptr<DeviceManager> DM(
+        DeviceManager::createDeviceManager(DeviceConfig("Interpreter")));
+    EXPECT_EQ(MockStats.counters["glow.devices_used.interpreter"], 1);
+  }
+  EXPECT_EQ(MockStats.counters["glow.devices_used.interpreter"], 0);
+}


### PR DESCRIPTION
Summary:
Production users of Glow may want to log statistics.  This diff
introduces an API that allows users to implement logging using custom
components that are loosely coupled to Glow's internals.  A unit test shows the
intended usage: a stats exporter is registered at startup, and Glow will log to
all such registered exporters.

Two statistics classes are defined:
- Counters, for simple numerical values,
- Quantiles, for aggregating statics into a frequency distribution

Currently no implementation of these loggers is provided (though one may be in
the future).  For server-side usage, consider a stats-querying library such as
[fb303](https://github.com/facebookincubator/fb303).

By way of example, this diff logs the number of each device type managed by
Glow.

Differential Revision: D16558211

