### PR TITLE
Ported OnnxExporterTest to E2

### DIFF
--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -376,7 +376,7 @@ target_link_libraries(OnnxExporterTest
                         Graph
                         Importer
                         Exporter
-                        ExecutionEngine
+                        ExecutionEngine2
                         gtest
                         TestMain)
 add_glow_test(NAME OnnxExporterTest

--- a/tests/unittests/OnnxExporterTest.cpp
+++ b/tests/unittests/OnnxExporterTest.cpp
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "glow/ExecutionEngine/ExecutionEngine.h"
+#include "glow/ExecutionEngine/ExecutionEngine2.h"
 #include "glow/Exporter/ONNXModelWriter.h"
 #include "glow/Graph/Graph.h"
 #include "glow/Graph/Nodes.h"
@@ -34,7 +34,7 @@ namespace {
 /// On success exports glow graph to the output file in "extended" ONNX format,
 /// i.e. some glow operators don't have presentation in vanilla ONNX standard.
 void testLoadAndSaveONNXModel(const std::string &name) {
-  ExecutionEngine EE{};
+  ExecutionEngine2 EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
 


### PR DESCRIPTION
Summary: Ported OnnxExporterTest to E2

Documentation:

Progress on #3239 

Test Plan: build, verify OnnxExporterTest runs and passes.