### PR TITLE
Porting lenet-mnist training example to EE2

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -14,7 +14,7 @@ add_executable(mnist
 target_link_libraries(mnist
                       PRIVATE
                         Backends
-                        ExecutionEngine
+                        ExecutionEngine2
                         Graph
                         Importer
                         IR


### PR DESCRIPTION
Summary:
Ported lenet-mnist training example to use EE2.

Test Plan:
output reproduced for the 2 test modes:
* Results: guessed/total:74/80 (model created programatically)
* Results: guessed/total:76/80 (model loaded from a file)
