### PR TITLE
Converted TypeAToTypeBFunctionConverterTest to EE2

### DIFF
--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -522,7 +522,7 @@ add_executable(TypeAToTypeBFunctionConverterTest
 target_link_libraries(TypeAToTypeBFunctionConverterTest
                       PRIVATE
                         Converter
-                        ExecutionEngine
+                        ExecutionEngine2
                         Graph
                         GraphOptimizer
                         gtest

--- a/tests/unittests/TypeAToTypeBFunctionConverterTest.cpp
+++ b/tests/unittests/TypeAToTypeBFunctionConverterTest.cpp
@@ -17,7 +17,7 @@
 #include "glow/Converter/TypeAToTypeBFunctionConverter.h"
 
 #include "glow/Backend/Backend.h"
-#include "glow/ExecutionEngine/ExecutionEngine.h"
+#include "glow/ExecutionEngine/ExecutionEngine2.h"
 #include "glow/Optimizer/GraphOptimizer/GraphOptimizer.h"
 
 #include "llvm/Support/Casting.h"
@@ -28,7 +28,7 @@ using namespace glow;
 
 struct AllBackends : public ::testing::TestWithParam<std::string> {
 protected:
-  ExecutionEngine EE_{GetParam()};
+  ExecutionEngine2 EE_{GetParam()};
 };
 
 /// Check that a simple graph is converted properly.


### PR DESCRIPTION
Summary: Converted TypeAToTypeBFunctionConverterTest to EE2

Documentation:

Progress on #3329 

Test Plan: build, verify TypeAToTypeBFunctionConverterTest runs and passes.