### PR TITLE
Ported char-rnn to EE2

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -38,7 +38,7 @@ add_executable(char-rnn
 target_link_libraries(char-rnn
                       PRIVATE
                         Backends
-                        ExecutionEngine
+                        ExecutionEngine2
                         Graph
                         IR
                         GraphOptimizer


### PR DESCRIPTION
Summary: Ported char-rnn to EE2

Documentation:

Progress on #3239 

Test Plan: Build and run char-rnn and check output.

Example run.. 
![Screen Shot 2019-07-30 at 5 28 23 PM](https://user-images.githubusercontent.com/10839509/62174648-8cc29100-b2ef-11e9-9e43-639d0d86d388.png)
