### PR TITLE
[ModelRunner] Disable constant folding

### DIFF
--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -19,6 +19,7 @@
 #include "glow/Base/Tensor.h"
 #include "glow/Converter/TypeAToTypeBFunctionConverter.h"
 #include "glow/IR/IR.h"
+#include "glow/Optimizer/GraphOptimizer/CompilationContext.h"
 #include "glow/Optimizer/GraphOptimizer/GraphOptimizer.h"
 #include "glow/Quantization/Quantization.h"
 #include "glow/Quantization/Serialization.h"
@@ -358,12 +359,18 @@ generateDeviceConfigs(std::string &loadDeviceConfigsFile,
 }
 
 void Loader::compile(PlaceholderBindings &bindings) {
+  CompilationContext cctx{&bindings};
+  compile(cctx);
+}
+
+void Loader::compile(CompilationContext &cctx) {
+  cctx.loweredInfoMap = &loweredMap_;
+
   // Dump the DAG before compilation if needed.
   if (!dumpGraphDAGFileBeforeCompilationOpt.empty()) {
     F_->dumpDAG(dumpGraphDAGFileBeforeCompilationOpt.c_str());
   }
 
-  CompilationContext cctx{&bindings, &loweredMap_};
   PrecisionConfiguration &precConfig = cctx.precisionConfig;
 
   // Handle the request to profile the graph in preparation for quantization.

--- a/tools/loader/Loader.h
+++ b/tools/loader/Loader.h
@@ -32,6 +32,7 @@ extern llvm::cl::opt<unsigned> iterationsOpt;
 namespace glow {
 
 class Tensor;
+struct CompilationContext;
 
 /// \return true if emit bundle mode is enabled.
 bool emittingBundle();
@@ -99,6 +100,10 @@ public:
   /// placeholders to concrete tensors. The concrete tensors include
   /// quantization profile guided information.
   void compile(PlaceholderBindings &bindings);
+
+  /// Compiles the Function F_. Handles quantization, emitting bundles, and
+  /// dumping debug information. \p cctx is used for compiling F_.
+  void compile(CompilationContext &cctx);
 
   /// Runs inference, unless emit bundle mode is enabled. \p bindings
   /// binds specific placeholders to concrete tensors. The concrete

--- a/tools/loader/ModelRunner.cpp
+++ b/tools/loader/ModelRunner.cpp
@@ -54,7 +54,11 @@ int main(int argc, char **argv) {
 
   // Compile the model, and perform quantization/emit a bundle/dump debug info
   // if requested from command line.
-  loader.compile(bindings);
+  CompilationContext cctx{&bindings};
+  // Disable constant folding, as the model runner is designed for models with
+  // all Constant inputs.
+  cctx.optimizationOpts.enableConstantFolding = false;
+  loader.compile(cctx);
 
   // If in bundle mode, do not run inference.
   if (!emittingBundle()) {


### PR DESCRIPTION
Summary: The model runner runs models with all constant inputs. Constant folding was essentially shrinking the entire graph down to `Constant -> Save`.

Test Plan: Verified the graph is no longer constant folded away.
