### PR TITLE
[convertPlaceholdersToConstants] Only convert PHs from provided F

### DIFF
--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -2667,8 +2667,7 @@ void glow::convertPlaceholdersToConstants(Function *F,
   LOG_SCOPE(F->getLogContext(), "convertPlaceholdersToConstants")
 
   auto *M = F->getParent();
-  auto &placeholders = M->getPlaceholders();
-  for (auto &PH : placeholders) {
+  for (auto &PH : F->findPlaceholders()) {
     if (std::find(phs.begin(), phs.end(), PH) != phs.end()) {
       continue;
     }


### PR DESCRIPTION
Summary: Only consider PHs used by the passed in Function for conversion.

This was discovered due to a cascading series of small issues:
1. Two Functions are in a single Module, `F1` and `F2`
2. `F1` has already allocated the Tensor `T1` (whose values are uninitialized) for its Save `S1`'s output PH `PH1`
3. `convertPlaceholdersToConstants()` is called with `F2`, creating a Constant `C1` for `PH1` using `T1`. However it does not replace `PH1` with it because `replaceAllUsesOfWith()` skipped it due to `S1` not being in `F2`
4. `compile(F2)` is called, which runs the `ConstantDeduplication` pass on the Module, which finds `C1` and inspects the values in `T1` which were uninitialized and thus may have NANs
5. This caused the assertion mentioned in #3328 to fire every ~100 runs or so

Test Plan: No longer fails: `./tests/OperatorTest --gtest_filter=OperatorTest/OperatorTest.NonSquarePaddingConvolution/2 --gtest_repeat=1000 `
