### PR TITLE
[PyTorch] Add support for avg_pool2d operator

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -218,6 +218,10 @@ private:
   /// \returns error on failure.
   llvm::Error loadMaxPool2d(const torch::jit::Node *ptNode);
 
+  /// Load a PyTorch avg_pool2d node.
+  /// \returns error on failure.
+  llvm::Error loadAvgPool2d(const torch::jit::Node *ptNode);
+
   /// Load a PyTorch adaptive_avg_pool2d node.
   /// \returns error on failure.
   llvm::Error loadAdaptiveAvgPool2d(const torch::jit::Node *ptNode);

--- a/torch_glow/tests/nodes/avgpool2d_test.py
+++ b/torch_glow/tests/nodes/avgpool2d_test.py
@@ -1,0 +1,26 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import torch
+import torch.nn.functional as F
+
+from tests.utils import jitVsGlow
+
+
+def test_avg_pool2d_basic():
+    """Basic test of the PyTorch avg_pool2d Node on Glow."""
+    def test_f(inputs):
+        return F.avg_pool2d(inputs, 3)
+
+    inputs = torch.randn(1, 4, 5, 5)
+
+    jitVsGlow(test_f, inputs)
+
+
+def test_avg_pool2d_with_args():
+    """Test of the PyTorch avg_pool2d Node with arguments on Glow."""
+    def test_f(inputs):
+        return F.avg_pool2d(inputs, padding=3, kernel_size=7)
+
+    inputs = torch.randn(1, 4, 10, 10)
+
+    jitVsGlow(test_f, inputs)


### PR DESCRIPTION
**Summary:**
This commit adds support for the 2D average pooling operator to the
`PyTorchModelLoader` so that `torch.nn.AvgPool2d` can be executed on Glow.
This operator is required to support
`torch.nn.LocalResponseNormalization` and is also in resnet50.

**Test Plan:**
This commit adds a unit test that runs a graph with an 2D average pooling
node on Glow and the PyTorch CPU backend and checks that the results are
identical.