### PR TITLE
Ported cifar10 to EE2

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -3,7 +3,7 @@ add_executable(cifar10
 target_link_libraries(cifar10
                       PRIVATE
                         Backends
-                        ExecutionEngine
+                        ExecutionEngine2
                         Graph
                         IR
                         Support


### PR DESCRIPTION
Summary: This PR ports the cifar10 example to EE2

Documentation:

Progress on #3239 

Test Plan: verify everything builds, run cifar10 and verify it runs and properly trains the network with the same results as before.