### PR TITLE
Ported fr2en to EE2

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -49,7 +49,7 @@ add_executable(fr2en
 target_link_libraries(fr2en
                       PRIVATE
                         Base
-                        ExecutionEngine
+                        ExecutionEngine2
                         IR
                         GraphOptimizer
                         Quantization

--- a/examples/fr2en.cpp
+++ b/examples/fr2en.cpp
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "glow/ExecutionEngine/ExecutionEngine.h"
+#include "glow/ExecutionEngine/ExecutionEngine2.h"
 #include "glow/Graph/Graph.h"
 #include "glow/Optimizer/GraphOptimizer/GraphOptimizer.h"
 #include "glow/Quantization/Quantization.h"
@@ -126,7 +126,7 @@ void loadMatrixFromFile(llvm::StringRef filename, Tensor &result) {
 /// few references to input/output Variables.
 struct Model {
   unsigned batchSize_;
-  ExecutionEngine EE_{ExecutionBackend};
+  ExecutionEngine2 EE_{ExecutionBackend};
   Function *F_;
   Vocabulary en_, fr_;
   Placeholder *input_;
@@ -164,7 +164,7 @@ struct Model {
       precConfig.quantConfig.assertAllNodesQuantized = true;
     }
 
-    EE_.compile(F_, cctx);
+    EE_.compile(cctx);
   }
 
 private:
@@ -376,7 +376,8 @@ void Model::translate(const std::vector<std::string> &batch) {
         (words.size() - 1) + j * MAX_LENGTH;
   }
 
-  updateInputPlaceholders(bindings, {input_, seqLength_}, {&input, &seqLength});
+  updateInputPlaceholders2(bindings, {input_, seqLength_},
+                           {&input, &seqLength});
   EE_.run(bindings);
 
   auto OH = bindings.get(output_)->getHandle<int64_t>();


### PR DESCRIPTION
Summary: This PR ports fr2en to EE2.

Documentation:

Progress on #3239 

Test Plan: build, Run fr2en verify that it correctly translates the test phrases.