### PR TITLE
Add support for ONNX ArgMax operator.

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -631,6 +631,13 @@ public:
   Node *createChannelShuffle(llvm::StringRef name, NodeValue input,
                              size_t group, size_t kernel);
 
+  /// Computes the indices of the max elements of the input tensor along the
+  /// provided \p axis. The resulted tensor has the same rank as the input if \p
+  /// keepDims equal 1. If \p keepdims equals 0, the resulted tensor has the
+  /// reduced dimension pruned. The type of the output tensor is int64.
+  ArgMaxNode *createArgMax(llvm::StringRef name, NodeValue input,
+                           unsigned_t axis, bool keepDims);
+
   /// Removes single-dimensional entries from the shape of a tensor. The
   /// parameter \p axes is a list of positive integers, indicating the
   /// dimensions to squeeze. Impelmented as a single ReshapeNode. This is the

--- a/include/glow/IR/IRBuilder.h
+++ b/include/glow/IR/IRBuilder.h
@@ -58,6 +58,9 @@ public:
                             llvm::ArrayRef<unsigned_t> strides,
                             llvm::ArrayRef<unsigned_t> pads, unsigned_t layout);
 
+  ArgMaxInst *createArgMaxOp(llvm::StringRef name, Value *input,
+                             unsigned_t axis, bool keepDims);
+
   AvgPoolInst *createAvgPoolOp(Value *input, llvm::ArrayRef<unsigned_t> kernels,
                                llvm::ArrayRef<unsigned_t> strides,
                                llvm::ArrayRef<unsigned_t> pads,

--- a/include/glow/Importer/ONNXModelLoader.h
+++ b/include/glow/Importer/ONNXModelLoader.h
@@ -95,6 +95,10 @@ class ONNXModelLoader
   llvm::Error loadUnsqueeze(const ONNX_NAMESPACE::NodeProto &op,
                             const ArgumentDictionaryTy &dict);
 
+  /// Load ArgMax ONNX operator.
+  llvm::Error loadArgMax(const ONNX_NAMESPACE::NodeProto &op,
+                         const ArgumentDictionaryTy &dict);
+
   /// Load BatchNormalization ONNX operator.
   llvm::Error loadBatchNormalization(const ONNX_NAMESPACE::NodeProto &op,
                                      const ArgumentDictionaryTy &dict);

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -66,6 +66,12 @@ bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
                {MaxPoolNode::ArgmaxIdx}) &&
            (NI.getOutElemTy(MaxPoolNode::ArgmaxIdx) == ElemKind::Int64ITy);
 
+  case Kinded::Kind::ArgMaxNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::FloatTy, ElemKind::Int8QTy}, {},
+               {ArgMaxNode::ArgmaxIdx}) &&
+           (NI.getOutElemTy(ArgMaxNode::ArgmaxIdx) == ElemKind::Int64ITy);
+
   case Kinded::Kind::SaveNodeKind:
   case Kinded::Kind::ReshapeNodeKind:
     // These are implemented via a Copy Instruction.

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -102,6 +102,12 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
                {MaxPoolNode::ArgmaxIdx}) &&
            (NI.getOutElemTy(MaxPoolNode::ArgmaxIdx) == ElemKind::Int64ITy);
 
+  case Kinded::Kind::ArgMaxNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::FloatTy, ElemKind::Int8QTy}, {},
+               {ArgMaxNode::ArgmaxIdx}) &&
+           (NI.getOutElemTy(ArgMaxNode::ArgmaxIdx) == ElemKind::Int64ITy);
+
   case Kinded::Kind::PowNodeKind:
   case Kinded::Kind::LocalResponseNormalizationNodeKind:
   case Kinded::Kind::LogNodeKind:

--- a/lib/Exporter/ONNXModelWriter.cpp
+++ b/lib/Exporter/ONNXModelWriter.cpp
@@ -731,6 +731,29 @@ llvm::Error ONNXModelWriter::writeTopK(const TopKNode *node, GraphType &graph) {
   return llvm::Error::success();
 }
 
+llvm::Error ONNXModelWriter::writeArgMax(const ArgMaxNode *node,
+                                         GraphType &graph) {
+  auto *proto = graph.add_node();
+
+  Tensor axis(ElemKind::Int64ITy, {1});
+  Tensor keepDims(ElemKind::BoolTy, {1});
+  auto axisH = axis.getHandle<int64_t>();
+  auto keepDimsH = keepDims.getHandle<int8_t>();
+  axisH.raw(0) = node->getAxis();
+  keepDimsH.raw(0) = node->getKeepDims();
+
+  auto *tensorProto = graph.add_initializer();
+  tensorProto->set_name("axis");
+  writeTensor(axis, tensorProto);
+
+  tensorProto = graph.add_initializer();
+  tensorProto->set_name("keepDims");
+  writeTensor(keepDims, tensorProto);
+  RETURN_IF_ERR(writeAllWithNode("ArgMax", node, proto));
+
+  return llvm::Error::success();
+}
+
 llvm::Error ONNXModelWriter::writePRelu(const PReluNode *node,
                                         GraphType &graph) {
   auto *proto = graph.add_node();

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1913,6 +1913,21 @@ TopKNode *Function::createTopK(llvm::StringRef name, NodeValue input,
       k));
 }
 
+ArgMaxNode *Function::createArgMax(llvm::StringRef name, NodeValue input,
+                                   unsigned_t axis, bool keepDims) {
+  auto inDims = input.dims();
+  ShapeVector newDims;
+  for (size_t i = 0, e = inDims.size(); i < e; i++) {
+    if (i == axis && !keepDims) {
+      continue;
+    } else {
+      newDims.push_back(i == axis ? 1 : inDims[i]);
+    }
+  }
+  auto TR = getParent()->uniqueType(ElemKind::Int64ITy, newDims);
+  return addNode(new ArgMaxNode(name, TR, input, axis, keepDims));
+}
+
 GatherNode *Function::createGather(llvm::StringRef name, NodeValue data,
                                    NodeValue indices, unsigned_t batchDims) {
 

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -1340,6 +1340,36 @@ bool TopKNode::verify() const {
   return isValid;
 }
 
+bool ArgMaxNode::verify() const {
+  bool isValid = true;
+
+  // Check input type.
+  isValid &= checkType(getArgmax(),
+                       llvm::ArrayRef<ElemKind>({ElemKind::Int64ITy}), this);
+
+  isValid &= expectCompareTrue("Input must be a 4D tensor",
+                               getInput().dims().size(), size_t(4), this);
+
+  // Check expected output type.
+  bool keepdims = getKeepDims();
+  const unsigned_t axis = getAxis();
+
+  ShapeVector expDstDims;
+  auto srcDim = getInput().dims();
+  for (size_t i = 0; i < srcDim.size(); i++) {
+    if (i == axis) {
+      if (keepdims) {
+        expDstDims.push_back(1);
+      }
+    } else {
+      expDstDims.push_back(srcDim[i]);
+    }
+  }
+  isValid &= expectCompareTrue("Invalid output dims", getArgmax().dims(),
+                               llvm::makeArrayRef(expDstDims), this);
+  return isValid;
+}
+
 bool RowwiseQuantizedFullyConnectedNode::verify() const {
   auto src = getInput();
   auto weights = getWeights();

--- a/lib/IR/IRBuilder.cpp
+++ b/lib/IR/IRBuilder.cpp
@@ -96,6 +96,25 @@ MaxPoolWithArgmaxInst *IRBuilder::createMaxPoolWithArgmaxOp(
                                      strides, pads, layout);
 }
 
+ArgMaxInst *IRBuilder::createArgMaxOp(llvm::StringRef name, Value *input,
+                                      unsigned_t axis, bool keepDims) {
+  auto idim = input->dims();
+
+  ShapeVector odim;
+  for (size_t i = 0, e = 4; i < e; i++) {
+    if (i == axis && !keepDims) {
+      continue;
+    } else {
+      odim.push_back(i == axis ? 1 : idim[i]);
+    }
+  }
+
+  // Allocate storage for flattened NCHW index of max element.
+  Value *argmax = createAllocActivationInst(name.str() + ".argmax",
+                                            ElemKind::Int64ITy, odim);
+  return createArgMaxInst(name, argmax, input, axis, keepDims);
+}
+
 AvgPoolInst *IRBuilder::createAvgPoolOp(Value *input,
                                         llvm::ArrayRef<unsigned_t> kernels,
                                         llvm::ArrayRef<unsigned_t> strides,

--- a/lib/IR/IRGen.cpp
+++ b/lib/IR/IRGen.cpp
@@ -158,6 +158,14 @@ void IRGenVisitor::post(Node *parent, Node *N) {
     registerIR(P->getArgmax(), argmax);
     break;
   }
+  case glow::Kinded::Kind::ArgMaxNodeKind: {
+    auto *P = cast<ArgMaxNode>(N);
+    auto *in = valueForNode(P->getInput());
+    auto *V = builder_.createArgMaxOp(N->getName(), in, P->getAxis(),
+                                      P->getKeepDims());
+    registerIR(P->getArgmax(), V->getArgmax());
+    break;
+  }
   case glow::Kinded::Kind::MaxPoolGradNodeKind: {
     auto *PG = cast<MaxPoolGradNode>(N);
 

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -2000,6 +2000,22 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     break;
   }
 
+  case Kinded::Kind::ArgMaxInstKind: {
+    auto *AM = cast<ArgMaxInst>(I);
+    auto *argmax = AM->getArgmax();
+    auto *input = AM->getInput();
+    auto *argmaxPtr = emitValueAddress(builder, argmax);
+    auto *inputPtr = emitValueAddress(builder, input);
+
+    auto *srcDims = emitValueDims(builder, input);
+
+    auto *axis = emitConstSizeT(builder, AM->getAxis());
+
+    auto *F = getFunction("arg_max", input->getElementType());
+    createCall(builder, F, {inputPtr, argmaxPtr, srcDims, axis});
+    break;
+  }
+
   case Kinded::Kind::AvgPoolInstKind: {
     auto *PA = cast<AvgPoolInst>(I);
     assert(PA->getLayout() == NHWC &&

--- a/tests/models/onnxModels/ArgMaxDefault.onnxtxt
+++ b/tests/models/onnxModels/ArgMaxDefault.onnxtxt
@@ -1,0 +1,81 @@
+ir_version: 5
+domain: "onnx"
+# ONNX TensorProto.DataType:
+#    UNDEFINED = 0;
+#    FLOAT = 1;
+#    UINT8 = 2;
+#    INT8 = 3;
+#    UINT16 = 4;
+#    INT16 = 5;
+#    INT32 = 6;
+#    INT64 = 7;
+#    STRING = 8;
+#    BOOL = 9;
+#    FLOAT16 = 10;
+#    DOUBLE = 11;
+#    UINT32 = 12;
+#    UINT64 = 13;
+#    COMPLEX64 = 14;
+#    COMPLEX128 = 15;
+graph {
+   initializer {
+       dims: 1   
+       data_type: 7
+       name: "k"
+       int64_data: 2
+   }
+  input {
+    name: "scores"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+         dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 5
+          }
+        }
+      }
+    }
+  }
+   node {
+       input: "input"
+       output: "argmax_scores"	
+       name: "argmax"
+       op_type: "ArgMax"
+   }
+
+output {
+    name: "argmax_scores"
+    type {
+      tensor_type {
+        elem_type: 7
+        shape {
+         dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 5
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 10
+}

--- a/tests/models/onnxModels/ArgMaxKeepDim.onnxtxt
+++ b/tests/models/onnxModels/ArgMaxKeepDim.onnxtxt
@@ -1,0 +1,91 @@
+ir_version: 5
+domain: "onnx"
+# ONNX TensorProto.DataType:
+#    UNDEFINED = 0;
+#    FLOAT = 1;
+#    UINT8 = 2;
+#    INT8 = 3;
+#    UINT16 = 4;
+#    INT16 = 5;
+#    INT32 = 6;
+#    INT64 = 7;
+#    STRING = 8;
+#    BOOL = 9;
+#    FLOAT16 = 10;
+#    DOUBLE = 11;
+#    UINT32 = 12;
+#    UINT64 = 13;
+#    COMPLEX64 = 14;
+#    COMPLEX128 = 15;
+graph {
+   initializer {
+       dims: 1   
+       data_type: 7
+       name: "k"
+       int64_data: 2
+   }
+  input {
+    name: "scores"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+         dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 5
+          }
+        }
+      }
+    }
+  }
+   node {
+       input: "input"
+       output: "argmax_scores"	
+       name: "argmax"
+       op_type: "ArgMax"
+       attribute {
+        name: "axis"
+        i: 2
+        type: INT
+      }
+      attribute {
+        name: "keepDims"
+        i: 2
+        type: INT
+      }
+   }
+
+output {
+    name: "argmax_scores"
+    type {
+      tensor_type {
+        elem_type: 7
+        shape {
+         dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 5
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 10
+}

--- a/tests/models/onnxModels/ArgMaxNoKeepDim.onnxtxt
+++ b/tests/models/onnxModels/ArgMaxNoKeepDim.onnxtxt
@@ -1,0 +1,91 @@
+ir_version: 5
+domain: "onnx"
+# ONNX TensorProto.DataType:
+#    UNDEFINED = 0;
+#    FLOAT = 1;
+#    UINT8 = 2;
+#    INT8 = 3;
+#    UINT16 = 4;
+#    INT16 = 5;
+#    INT32 = 6;
+#    INT64 = 7;
+#    STRING = 8;
+#    BOOL = 9;
+#    FLOAT16 = 10;
+#    DOUBLE = 11;
+#    UINT32 = 12;
+#    UINT64 = 13;
+#    COMPLEX64 = 14;
+#    COMPLEX128 = 15;
+graph {
+   initializer {
+       dims: 1   
+       data_type: 7
+       name: "k"
+       int64_data: 2
+   }
+  input {
+    name: "scores"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+         dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 5
+          }
+        }
+      }
+    }
+  }
+   node {
+       input: "input"
+       output: "argmax_scores"	
+       name: "argmax"
+       op_type: "ArgMax"
+       attribute {
+        name: "axis"
+        i: 1
+        type: INT
+      }
+      attribute {
+        name: "keepDims"
+        i: 0
+        type: INT
+      }
+   }
+
+output {
+    name: "argmax_scores"
+    type {
+      tensor_type {
+        elem_type: 7
+        shape {
+         dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 5
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 10
+}

--- a/tests/unittests/OnnxExporterTest.cpp
+++ b/tests/unittests/OnnxExporterTest.cpp
@@ -97,6 +97,9 @@ TEST(exporter, onnxModels) {
         name.find("simpleConvBiasFail.onnxtxt") != std::string::npos ||
         name.find("Where.onnxtxt") != std::string::npos ||
         name.find("constantOfShapeInt64Fail.onnxtxt") != std::string::npos ||
+        name.find("ArgMaxDefault.onnxtxt") != std::string::npos ||
+        name.find("ArgMaxKeepDim.onnxtxt") != std::string::npos ||
+        name.find("ArgMaxNoKeepDim.onnxtxt") != std::string::npos ||
         name.find("Less.onnxtxt") != std::string::npos) {
       // Ignore invalid ONNX files and graphs without nodes.
       llvm::outs() << "Ignore invalid input files: " << name << "\n";

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -2296,6 +2296,87 @@ TEST(onnx, topK) {
       checkConstFoldedOutput(netFilename, {"scores"}, {&x}, {outputT, indexT}));
 }
 
+TEST(onnx, argMaxKeepDim) {
+  ExecutionEngine EE;
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+
+  std::string netFilename(GLOW_DATA_PATH
+                          "tests/models/onnxModels/ArgMaxKeepDim.onnxtxt");
+
+  PlaceholderBindings bindings;
+  Placeholder *argmaxPH;
+  {
+    Tensor inT(ElemKind::FloatTy, {2, 3, 4, 5});
+
+    ONNXModelLoader onnxLD(netFilename, {"input"}, {&inT.getType()}, *F);
+    argmaxPH = EXIT_ON_ERR(onnxLD.getOutputByName("argmax_scores"));
+    bindings.allocate(mod.getPlaceholders());
+    updateInputPlaceholdersByName(bindings, &mod, {"input"}, {&inT});
+  }
+
+  EE.compile(CompilationMode::Infer);
+  EE.run(bindings);
+
+  auto argmax = bindings.get(argmaxPH)->getHandle<int64_t>();
+  std::vector<size_t> expectedDims = {2, 3, 1, 5};
+  EXPECT_TRUE(argmax.dims().vec() == expectedDims);
+}
+
+TEST(onnx, argMaxNoKeepDim) {
+  ExecutionEngine EE;
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+
+  std::string netFilename(GLOW_DATA_PATH
+                          "tests/models/onnxModels/ArgMaxNoKeepDim.onnxtxt");
+
+  PlaceholderBindings bindings;
+  Placeholder *argmaxPH;
+  {
+    Tensor inT(ElemKind::FloatTy, {2, 3, 4, 5});
+
+    ONNXModelLoader onnxLD(netFilename, {"input"}, {&inT.getType()}, *F);
+    argmaxPH = EXIT_ON_ERR(onnxLD.getOutputByName("argmax_scores"));
+    bindings.allocate(mod.getPlaceholders());
+    updateInputPlaceholdersByName(bindings, &mod, {"input"}, {&inT});
+  }
+
+  EE.compile(CompilationMode::Infer);
+  EE.run(bindings);
+
+  auto argmax = bindings.get(argmaxPH)->getHandle<int64_t>();
+  std::vector<size_t> expectedDims = {2, 4, 5};
+  EXPECT_TRUE(argmax.dims().vec() == expectedDims);
+}
+
+TEST(onnx, argMaxDefault) {
+  ExecutionEngine EE;
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+
+  std::string netFilename(GLOW_DATA_PATH
+                          "tests/models/onnxModels/ArgMaxDefault.onnxtxt");
+
+  PlaceholderBindings bindings;
+  Placeholder *argmaxPH;
+  {
+    Tensor inT(ElemKind::FloatTy, {2, 3, 4, 5});
+
+    ONNXModelLoader onnxLD(netFilename, {"input"}, {&inT.getType()}, *F);
+    argmaxPH = EXIT_ON_ERR(onnxLD.getOutputByName("argmax_scores"));
+    bindings.allocate(mod.getPlaceholders());
+    updateInputPlaceholdersByName(bindings, &mod, {"input"}, {&inT});
+  }
+
+  EE.compile(CompilationMode::Infer);
+  EE.run(bindings);
+
+  auto argmax = bindings.get(argmaxPH)->getHandle<int64_t>();
+  std::vector<size_t> expectedDims = {1, 3, 4, 5};
+  EXPECT_TRUE(argmax.dims().vec() == expectedDims);
+}
+
 TEST(onnx, importMaxPoolWithArgmax) {
   ExecutionEngine EE;
   auto &mod = EE.getModule();

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -155,6 +155,13 @@ int main(int argc, char **argv) {
       .autoVerify(VerifyKind::SameElementType, {"Dest", "Src"})
       .addGradientInstr({"Dest"}, {"Dest", "Src"});
 
+  BB.newInstr("ArgMax")
+      .addOperand("Argmax", OperandKind::Out)
+      .addOperand("Input", OperandKind::In)
+      .addMember(MemberType::Unsigned, "Axis")
+      .addMember(MemberType::Boolean, "KeepDims")
+      .autoVerify(VerifyKind::NoVerify);
+
   BB.newInstr("AdaptiveAvgPool")
       .addOperand("Dest", OperandKind::Out)
       .addOperand("Src", OperandKind::In)

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -144,6 +144,14 @@ int main(int argc, char **argv) {
           "index corresponding to respective max element. Supported layouts "
           "are defined in the ConvolutionLayout enum: NHWC and NCHW.");
 
+  BB.newNode("ArgMax")
+      .addInput("Input")
+      .addMember(MemberType::Unsigned, "Axis")
+      .addMember(MemberType::Boolean, "KeepDims")
+      .addResultFromCtorArg("Argmax")
+      .setDocstring("Finds index of a maximum element along Axis."
+                    "If KeepDims is not true, the axis is removed from output");
+
   BB.newNode("AvgPool")
       .addInput("Input")
       .addMember(MemberType::VectorUnsigned, "Kernels")


### PR DESCRIPTION
Summary:
Added support in CPU, Interpreter.

Documentation:
https://github.com/onnx/onnx/blob/master/docs/Operators.md#argmax

[Optional Fixes #issue]
#3353 

Test Plan:
Added tests for OperatorTest and OnnxImporterTest
