### PR TITLE
Test temporary files must have unique names, cause some testing frame…

### DIFF
--- a/tests/unittests/OnnxExporterTest.cpp
+++ b/tests/unittests/OnnxExporterTest.cpp
@@ -52,7 +52,13 @@ void testLoadAndSaveONNXModel(const std::string &name) {
     llvm::errs() << "\n";
   }));
 
-  std::string outputFilename(name + ".output.onnxtxt");
+  llvm::SmallString<64> path;
+  auto tempFileRes =
+      llvm::sys::fs::createTemporaryFile("exporter", ".output.onnxtxt", path);
+
+  EXPECT_EQ(tempFileRes.value(), 0);
+
+  std::string outputFilename(path.c_str());
   { ONNXModelWriter onnxWR(outputFilename, *F, irVer, opsetVer, &err, true); }
 
   if (err) {


### PR DESCRIPTION
…works execute the same tests in multile threads.

Summary:

Documentation:

[Optional Fixes #issue]

Test Plan:

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
