### PR TITLE
[NFC][OperatorTest] Rename ConvertFrom tests to use ElemKind

### DIFF
--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -7856,26 +7856,27 @@ static void testConvertTo(glow::PlaceholderBindings &bindings_,
 
 /// Test that ConvertTo operator casts correctly from one type to another.
 #define TEST_CONVERT_TO(T_FROM, T_TO, DTY_FROM, DTY_TO)                        \
-  TEST_P(OperatorTest, ConvertFrom_##T_FROM##_To_##T_TO) {                     \
+  TEST_P(OperatorTest, ConvertFrom_##DTY_FROM##_To_##DTY_TO) {                 \
     ENABLED_BACKENDS(Interpreter);                                             \
-    testConvertTo<T_FROM, T_TO>(bindings_, mod_, F_, EE_, DTY_FROM, DTY_TO);   \
+    testConvertTo<T_FROM, T_TO>(bindings_, mod_, F_, EE_, ElemKind::DTY_FROM,  \
+                                ElemKind::DTY_TO);                             \
   }
-TEST_CONVERT_TO(float, float, ElemKind::FloatTy, ElemKind::FloatTy)
-TEST_CONVERT_TO(float, float16_t, ElemKind::FloatTy, ElemKind::Float16Ty)
-TEST_CONVERT_TO(float, int32_t, ElemKind::FloatTy, ElemKind::Int32ITy)
-TEST_CONVERT_TO(float, int64_t, ElemKind::FloatTy, ElemKind::Int64ITy)
-TEST_CONVERT_TO(float16_t, float, ElemKind::Float16Ty, ElemKind::FloatTy)
-TEST_CONVERT_TO(float16_t, float16_t, ElemKind::Float16Ty, ElemKind::Float16Ty)
-TEST_CONVERT_TO(float16_t, int32_t, ElemKind::Float16Ty, ElemKind::Int32ITy)
-TEST_CONVERT_TO(float16_t, int64_t, ElemKind::Float16Ty, ElemKind::Int64ITy)
-TEST_CONVERT_TO(int32_t, float, ElemKind::Int32ITy, ElemKind::FloatTy)
-TEST_CONVERT_TO(int32_t, float16_t, ElemKind::Int32ITy, ElemKind::Float16Ty)
-TEST_CONVERT_TO(int32_t, int32_t, ElemKind::Int32ITy, ElemKind::Int32ITy)
-TEST_CONVERT_TO(int32_t, int64_t, ElemKind::Int32ITy, ElemKind::Int64ITy)
-TEST_CONVERT_TO(int64_t, float, ElemKind::Int64ITy, ElemKind::FloatTy)
-TEST_CONVERT_TO(int64_t, float16_t, ElemKind::Int64ITy, ElemKind::Float16Ty)
-TEST_CONVERT_TO(int64_t, int32_t, ElemKind::Int64ITy, ElemKind::Int32ITy)
-TEST_CONVERT_TO(int64_t, int64_t, ElemKind::Int64ITy, ElemKind::Int64ITy)
+TEST_CONVERT_TO(float, float, FloatTy, FloatTy)
+TEST_CONVERT_TO(float, float16_t, FloatTy, Float16Ty)
+TEST_CONVERT_TO(float, int32_t, FloatTy, Int32ITy)
+TEST_CONVERT_TO(float, int64_t, FloatTy, Int64ITy)
+TEST_CONVERT_TO(float16_t, float, Float16Ty, FloatTy)
+TEST_CONVERT_TO(float16_t, float16_t, Float16Ty, Float16Ty)
+TEST_CONVERT_TO(float16_t, int32_t, Float16Ty, Int32ITy)
+TEST_CONVERT_TO(float16_t, int64_t, Float16Ty, Int64ITy)
+TEST_CONVERT_TO(int32_t, float, Int32ITy, FloatTy)
+TEST_CONVERT_TO(int32_t, float16_t, Int32ITy, Float16Ty)
+TEST_CONVERT_TO(int32_t, int32_t, Int32ITy, Int32ITy)
+TEST_CONVERT_TO(int32_t, int64_t, Int32ITy, Int64ITy)
+TEST_CONVERT_TO(int64_t, float, Int64ITy, FloatTy)
+TEST_CONVERT_TO(int64_t, float16_t, Int64ITy, Float16Ty)
+TEST_CONVERT_TO(int64_t, int32_t, Int64ITy, Int32ITy)
+TEST_CONVERT_TO(int64_t, int64_t, Int64ITy, Int64ITy)
 
 #undef TEST_CONVERT_TO
 
@@ -7918,32 +7919,29 @@ static void testConvertToAndBack(glow::PlaceholderBindings &bindings_,
 
 /// Test that ConvertTo operator casts correctly from one type to another.
 #define TEST_CAST_2WAYS(T_FROM, T_TO, DTY_FROM, DTY_TO, NOOP_CAST)             \
-  TEST_P(OperatorTest, ConvertFrom_##T_FROM##_To_##T_TO##_AndBack) {           \
+  TEST_P(OperatorTest, ConvertFrom_##DTY_FROM##_To_##DTY_TO##_AndBack) {       \
     ENABLED_BACKENDS(Interpreter);                                             \
-    testConvertToAndBack<T_FROM, T_TO>(bindings_, mod_, F_, EE_, DTY_FROM,     \
-                                       DTY_TO, NOOP_CAST);                     \
+    testConvertToAndBack<T_FROM, T_TO>(bindings_, mod_, F_, EE_,               \
+                                       ElemKind::DTY_FROM, ElemKind::DTY_TO,   \
+                                       NOOP_CAST);                             \
   }
-TEST_CAST_2WAYS(float, float, ElemKind::FloatTy, ElemKind::FloatTy, true)
-TEST_CAST_2WAYS(float, float16_t, ElemKind::FloatTy, ElemKind::Float16Ty, false)
-TEST_CAST_2WAYS(float, int32_t, ElemKind::FloatTy, ElemKind::Int32ITy, false)
-TEST_CAST_2WAYS(float, int64_t, ElemKind::FloatTy, ElemKind::Int64ITy, false)
-TEST_CAST_2WAYS(float16_t, float, ElemKind::Float16Ty, ElemKind::FloatTy, true)
-TEST_CAST_2WAYS(float16_t, float16_t, ElemKind::Float16Ty, ElemKind::Float16Ty,
-                true)
-TEST_CAST_2WAYS(float16_t, int32_t, ElemKind::Float16Ty, ElemKind::Int32ITy,
-                false)
-TEST_CAST_2WAYS(float16_t, int64_t, ElemKind::Float16Ty, ElemKind::Int64ITy,
-                false)
-TEST_CAST_2WAYS(int32_t, float, ElemKind::Int32ITy, ElemKind::FloatTy, false)
-TEST_CAST_2WAYS(int32_t, float16_t, ElemKind::Int32ITy, ElemKind::Float16Ty,
-                false)
-TEST_CAST_2WAYS(int32_t, int32_t, ElemKind::Int32ITy, ElemKind::Int32ITy, true)
-TEST_CAST_2WAYS(int32_t, int64_t, ElemKind::Int32ITy, ElemKind::Int64ITy, true)
-TEST_CAST_2WAYS(int64_t, float, ElemKind::Int64ITy, ElemKind::FloatTy, false)
-TEST_CAST_2WAYS(int64_t, float16_t, ElemKind::Int64ITy, ElemKind::Float16Ty,
-                false)
-TEST_CAST_2WAYS(int64_t, int32_t, ElemKind::Int64ITy, ElemKind::Int32ITy, false)
-TEST_CAST_2WAYS(int64_t, int64_t, ElemKind::Int64ITy, ElemKind::Int64ITy, true)
+TEST_CAST_2WAYS(float, float, FloatTy, FloatTy, /* castIsNoOp */ true)
+TEST_CAST_2WAYS(float, float16_t, FloatTy, Float16Ty, /* castIsNoOp */ false)
+TEST_CAST_2WAYS(float, int32_t, FloatTy, Int32ITy, /* castIsNoOp */ false)
+TEST_CAST_2WAYS(float, int64_t, FloatTy, Int64ITy, /* castIsNoOp */ false)
+TEST_CAST_2WAYS(float16_t, float, Float16Ty, FloatTy, /* castIsNoOp */ true)
+TEST_CAST_2WAYS(float16_t, float16_t, Float16Ty, Float16Ty,
+                /* castIsNoOp */ true)
+TEST_CAST_2WAYS(float16_t, int32_t, Float16Ty, Int32ITy, /* castIsNoOp */ false)
+TEST_CAST_2WAYS(float16_t, int64_t, Float16Ty, Int64ITy, /* castIsNoOp */ false)
+TEST_CAST_2WAYS(int32_t, float, Int32ITy, FloatTy, /* castIsNoOp */ false)
+TEST_CAST_2WAYS(int32_t, float16_t, Int32ITy, Float16Ty, /* castIsNoOp */ false)
+TEST_CAST_2WAYS(int32_t, int32_t, Int32ITy, Int32ITy, /* castIsNoOp */ true)
+TEST_CAST_2WAYS(int32_t, int64_t, Int32ITy, Int64ITy, /* castIsNoOp */ true)
+TEST_CAST_2WAYS(int64_t, float, Int64ITy, FloatTy, /* castIsNoOp */ false)
+TEST_CAST_2WAYS(int64_t, float16_t, Int64ITy, Float16Ty, /* castIsNoOp */ false)
+TEST_CAST_2WAYS(int64_t, int32_t, Int64ITy, Int32ITy, /* castIsNoOp */ false)
+TEST_CAST_2WAYS(int64_t, int64_t, Int64ITy, Int64ITy, /* castIsNoOp */ true)
 
 #undef TEST_CAST_2WAYS
 


### PR DESCRIPTION
I prefer this naming -- it's more clear what exactly we're testing, since from the Glow perspective these conversions happen on ElemKinds and not on native data types. Also we have many ElemKinds mapped to native data types (e.g. `Int32QTy` and `Int32ITy` both map to `int32_t`). E.g.:

```
old: OperatorTest/OperatorTest.ConvertFrom_float_To_int32_t/1
new: OperatorTest/OperatorTest.ConvertFrom_FloatTy_To_Int32ITy/1
```