### PR TITLE
Remove unneeded print

### DIFF
--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -1373,7 +1373,6 @@ void LLVMIRGen::generateLLVMIRForDataParallelInstr(
       destAddr = builder.CreateGEP(builder.getInt32Ty(), destPtr, loopCount,
                                    "buffer.element.addr");
     }
-    destAddr->print(errs());
     builder.CreateStore(stackedOpCall, destAddr);
     break;
   }


### PR DESCRIPTION
Summary:

Removed print that is not needed when lowering modulo operator.

Test Plan:
ninja test
