### PR TITLE
[torch_glow][build] Make setup more robust to cmake build folder changes

### DIFF
--- a/torch_glow/setup.py
+++ b/torch_glow/setup.py
@@ -148,11 +148,14 @@ class cmake_build(setuptools.Command):
             subprocess.check_call(build_args)
 
     def run(self):
-        is_initial_build = not os.path.exists(CMAKE_BUILD_DIR)
-        if is_initial_build:
+        if not os.path.exists(CMAKE_BUILD_DIR):
             os.makedirs(CMAKE_BUILD_DIR)
+
+        is_initial_build = not os.path.exists(
+            os.path.join(CMAKE_BUILD_DIR, "CMakeCache.txt"))
         if is_initial_build or args.run_cmake:
             self._run_cmake()
+
         self._run_build()
 
 


### PR DESCRIPTION
Summary:
The setup.py file doesn't check for the presence of a CMakeCache.txt, which is a better indicator that the build folder was cleaned.

Test Plan:
`python setup.py install`