### PR TITLE
Ported resnet-verify to EE2

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -70,7 +70,7 @@ if(GLOW_WITH_CPU)
                    resnet-verify.cpp)
   target_link_libraries(resnet-verify
                         PRIVATE
-                          ExecutionEngine
+                          ExecutionEngine2
                           Graph
                           Importer)
 


### PR DESCRIPTION
Summary: Ported resnet-verify to EE2

Documentation:

Progress on #3239 

Test Plan: Verify everything builds, Run resnet-verify and ensure it completes successfully. I don't think this is run as part of CI. Tested locally on my machine.