### PR TITLE
[trivial] Fix debug-shared build

### DIFF
--- a/lib/Importer/CMakeLists.txt
+++ b/lib/Importer/CMakeLists.txt
@@ -43,8 +43,10 @@ target_compile_definitions(Importer
                              -DGOOGLE_PROTOBUF_NO_RTTI)
 target_link_libraries(Importer
                       PRIVATE
+                        Backends
                         Base
                         Graph
+                        GraphOptimizer
                         LLVMSupport
                         Support)
 target_link_libraries(Importer PUBLIC onnx_proto ${PROTOBUF_LIBRARY})


### PR DESCRIPTION
Summary: Debug shared build was broken, the Importer needs some static functions from the GraphOptimizer and Backends. 

Documentation: n/a
Test Plan: ninja test in debug-shared
