### PR TITLE
Add Layout field to Conv and Pool nodes and remove OCL specific versions

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -341,14 +341,15 @@ public:
   /// \p group defines the number of groups the input and output channels should
   /// be divided into and convolved separately. \p dilation defines factor by
   /// which gap between 2 neighboring kernel elements is expanded along each
-  /// axis.
+  /// axis. \p layout defines the Tensor layout and must be either NHWC or NCHW.
 
-  ConvolutionNode *createConv(llvm::StringRef name, NodeValue input,
-                              NodeValue filter, NodeValue bias, TypeRef outTy,
-                              llvm::ArrayRef<unsigned_t> kernels,
-                              llvm::ArrayRef<unsigned_t> strides,
-                              llvm::ArrayRef<unsigned_t> pads, unsigned_t group,
-                              unsigned_t dilation = 1);
+  ConvolutionNode *
+  createConv(llvm::StringRef name, NodeValue input, NodeValue filter,
+             NodeValue bias, TypeRef outTy, llvm::ArrayRef<unsigned_t> kernels,
+             llvm::ArrayRef<unsigned_t> strides,
+             llvm::ArrayRef<unsigned_t> pads, unsigned_t group,
+             unsigned_t dilation = 1,
+             ConvolutionLayout layout = ConvolutionLayout::NHWC);
 
   /// Creates a ConvolutionNode with the given \p name which convolves the 4D
   /// \p input with \p filter and \bias. \p kernel defines the size of the
@@ -358,13 +359,14 @@ public:
   /// \p group defines the number of groups the input and output channels should
   /// be divided into and convolved separately. \p dilation defines factor by
   /// which gap between 2 neighboring kernel elements is expanded along each
-  /// axis.
+  /// axis. \p layout defines the Tensor layout and must be either NHWC or NCHW.
 
-  ConvolutionNode *createConv(llvm::StringRef name, NodeValue input,
-                              NodeValue filter, NodeValue bias, TypeRef outTy,
-                              unsigned_t kernel, unsigned_t stride,
-                              unsigned_t pad, unsigned_t group,
-                              unsigned_t dilation = 1);
+  ConvolutionNode *
+  createConv(llvm::StringRef name, NodeValue input, NodeValue filter,
+             NodeValue bias, TypeRef outTy, unsigned_t kernel,
+             unsigned_t stride, unsigned_t pad, unsigned_t group,
+             unsigned_t dilation = 1,
+             ConvolutionLayout layout = ConvolutionLayout::NHWC);
 
   /// Creates a Convolution3DNode with the given \p name which convolves the 5D
   /// \p input with \p filter and \bias. \p kernels defines the size of the
@@ -405,8 +407,9 @@ public:
   /// cells should be added to the input during convolution. \p group defines
   /// the number of groups the input and output channels should be divided into
   /// and convolved separately.
-  /// NOTE: ChannelwiseQuantizedConvolutionNode does not yet have an
-  /// implementation so attempting to run a graph containing this node fails.
+  /// NOTE: ChannelwiseQuantizedConvolutionNode does
+  /// not yet have an implementation so attempting to run a graph containing
+  /// this node fails.
   ChannelwiseQuantizedConvolutionNode *createChannelwiseQuantizedConv(
       llvm::StringRef name, NodeValue input, Constant *filter, Constant *bias,
       Constant *scales, Constant *offsets, TypeRef outTy,
@@ -419,25 +422,28 @@ public:
   MaxPoolNode *createMaxPool(llvm::StringRef name, NodeValue input,
                              llvm::ArrayRef<unsigned_t> kernels,
                              llvm::ArrayRef<unsigned_t> strides,
-                             llvm::ArrayRef<unsigned_t> pads);
+                             llvm::ArrayRef<unsigned_t> pads,
+                             ConvolutionLayout layout = NHWC);
 
   MaxPoolNode *createMaxPool(llvm::StringRef name, NodeValue input,
                              unsigned_t kernel, unsigned_t stride,
-                             unsigned_t pad);
+                             unsigned_t pad, ConvolutionLayout layout = NHWC);
 
   AvgPoolNode *createAvgPool(llvm::StringRef name, NodeValue input,
                              llvm::ArrayRef<unsigned_t> kernels,
                              llvm::ArrayRef<unsigned_t> strides,
-                             llvm::ArrayRef<unsigned_t> pads);
+                             llvm::ArrayRef<unsigned_t> pads,
+                             ConvolutionLayout layout = NHWC);
 
   AvgPoolNode *createAvgPool(llvm::StringRef name, NodeValue input,
                              TypeRef outTy, llvm::ArrayRef<unsigned_t> kernels,
                              llvm::ArrayRef<unsigned_t> strides,
-                             llvm::ArrayRef<unsigned_t> pads);
+                             llvm::ArrayRef<unsigned_t> pads,
+                             ConvolutionLayout layout = NHWC);
 
   AvgPoolNode *createAvgPool(llvm::StringRef name, NodeValue input,
                              unsigned_t kernel, unsigned_t stride,
-                             unsigned_t pad);
+                             unsigned_t pad, ConvolutionLayout layout = NHWC);
 
   /// Creates and \returns an AdaptiveAvgPool node with \p name, \p input, and
   /// \p outTy. The AdaptiveAvgPoolNode will perform average pooling over the
@@ -1100,14 +1106,15 @@ public:
   /// defines the number of groups the input and output channels should be
   /// divided into and convolved separately. \p dilation defines factor by
   /// which gap between 2 neighboring kernel elements is expanded along each
-  /// axis.
+  /// axis. \p layout defines the Tensor layout and must be either NHWC or NCHW.
   ConvolutionNode *createConv(PlaceholderBindings &bindings,
                               llvm::StringRef name, NodeValue input,
                               size_t outChannels,
                               llvm::ArrayRef<unsigned_t> kernels,
                               llvm::ArrayRef<unsigned_t> strides,
                               llvm::ArrayRef<unsigned_t> pads, unsigned_t group,
-                              unsigned_t dilation = 1);
+                              unsigned_t dilation = 1,
+                              ConvolutionLayout layout = NHWC);
 
   /// Creates a ConvolutionNode with the given \p name which convolves the 4D
   /// \p input. \p kernel defines the size of the height and width dimensions of
@@ -1117,12 +1124,13 @@ public:
   /// defines the number of groups the input and output channels should be
   /// divided into and convolved separately.\p dilation defines factor by
   /// which gap between 2 neighboring kernel elements is expanded along each
-  /// axis.
+  /// axis. \p layout defines the Tensor layout and must be either NHWC or NCHW.
   ConvolutionNode *createConv(PlaceholderBindings &bindings,
                               llvm::StringRef name, NodeValue input,
                               size_t outChannels, unsigned_t kernel,
                               unsigned_t stride, unsigned_t pad,
-                              unsigned_t group, unsigned_t dilation = 1);
+                              unsigned_t group, unsigned_t dilation = 1,
+                              ConvolutionLayout layout = NHWC);
 
   /// Creates a Convolution3DNode with the given \p name which convolves the 5D
   /// \p input. \p kernels defines the size of the height, width, and depth

--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -203,6 +203,9 @@ inline ShapeHWD calculate3DConvPoolOutputDims(
 /// Modes of the padding operation.
 enum PaddingMode { CONSTANT = 0, REFLECT, EDGE };
 
+/// Convolution Layouts.
+enum ConvolutionLayout { NHWC = 0, NCHW };
+
 /// Support for hashing the Nodes. This is required for using
 /// llvm::hash_combine.
 class Node;

--- a/include/glow/IR/IRBuilder.h
+++ b/include/glow/IR/IRBuilder.h
@@ -52,13 +52,16 @@ public:
   /// @name High-level, operation-level IRBuilder.
   ///@{
 
-  MaxPoolWithArgmaxInst *createMaxPoolWithArgmaxOp(
-      llvm::StringRef name, Value *input, llvm::ArrayRef<unsigned_t> kernels,
-      llvm::ArrayRef<unsigned_t> strides, llvm::ArrayRef<unsigned_t> pads);
+  MaxPoolWithArgmaxInst *
+  createMaxPoolWithArgmaxOp(llvm::StringRef name, Value *input,
+                            llvm::ArrayRef<unsigned_t> kernels,
+                            llvm::ArrayRef<unsigned_t> strides,
+                            llvm::ArrayRef<unsigned_t> pads, unsigned_t layout);
 
   AvgPoolInst *createAvgPoolOp(Value *input, llvm::ArrayRef<unsigned_t> kernels,
                                llvm::ArrayRef<unsigned_t> strides,
-                               llvm::ArrayRef<unsigned_t> pads);
+                               llvm::ArrayRef<unsigned_t> pads,
+                               unsigned_t layout);
 
   CrossEntropyLossInst *createCrossEntropyLossOp(llvm::StringRef name, Value *P,
                                                  Value *labels);

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -282,6 +282,8 @@ void BoundInterpreterFunction::fwdConvolutionInstQuantizedImpl(
 }
 
 void BoundInterpreterFunction::fwdConvolutionInst(const ConvolutionInst *I) {
+  assert(I->getLayout() == NHWC &&
+         "Glow Interpreter supports only NHWC Convolutions");
   auto kernelSizes = I->getKernels();
   auto pads = I->getPads();
   auto strides = I->getStrides();
@@ -303,6 +305,8 @@ void BoundInterpreterFunction::fwdConvolutionInst(const ConvolutionInst *I) {
 
 void BoundInterpreterFunction::fwdConvolutionGradInst(
     const ConvolutionGradInst *I) {
+  assert(I->getLayout() == NHWC &&
+         "Glow Interpreter supports only NHWC Convolutions");
   auto inW = getWeightHandle(I->getSrc());
   auto inG = getWeightHandle(I->getSrcGrad());
   auto outG = getWeightHandle(I->getDestGrad());
@@ -753,6 +757,7 @@ static void fwdMaxPool(Tensor *inW, Tensor *outW, Tensor *argmaxW,
 }
 
 void BoundInterpreterFunction::fwdMaxPoolInst(const MaxPoolInst *I) {
+  assert(I->getLayout() == NHWC && "Glow Interpreter supports only NHWC Pools");
   auto inW = getTensor(I->getSrc());
   auto outW = getTensor(I->getDest());
 
@@ -770,6 +775,7 @@ void BoundInterpreterFunction::fwdMaxPoolInst(const MaxPoolInst *I) {
 
 void BoundInterpreterFunction::fwdMaxPoolWithArgmaxInst(
     const MaxPoolWithArgmaxInst *I) {
+  assert(I->getLayout() == NHWC && "Glow Interpreter supports only NHWC Pools");
   auto inW = getTensor(I->getSrc());
   auto outW = getTensor(I->getDest());
   auto argmaxW = getTensor(I->getArgmax());
@@ -888,6 +894,7 @@ void BoundInterpreterFunction::fwdAvgPoolInstI8Impl(const AvgPoolInst *I) {
 }
 
 void BoundInterpreterFunction::fwdAvgPoolInst(const AvgPoolInst *I) {
+  assert(I->getLayout() == NHWC && "Glow Interpreter supports only NHWC Pools");
   if (I->getSrc()->getType()->isQuantizedType()) {
     fwdAvgPoolInstI8Impl(I);
     return;

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -37,7 +37,7 @@
 
 namespace glow {
 
-class OCLConvolutionInst;
+class ConvolutionInst;
 class Value;
 
 /// A helper struct with information about kernels launches.
@@ -145,8 +145,8 @@ private:
                   ElemKind elemKind);
 
   /// Execution a convolution instruction which uses NCHW format.
-  void executeConvolution(const OCLConvolutionInst *CC,
-                          ExecutionContext *executionContext);
+  void executeNCHWConvolution(const ConvolutionInst *CC,
+                              ExecutionContext *executionContext);
   /// Allocate a device buffer of required \p size.
   cl_mem allocDeviceBuffer(uint64_t size);
   /// Frees a device buffer.

--- a/lib/Exporter/ONNXModelWriter.cpp
+++ b/lib/Exporter/ONNXModelWriter.cpp
@@ -513,6 +513,7 @@ llvm::Error ONNXModelWriter::writeTranspose(const TransposeNode *node,
 
 llvm::Error ONNXModelWriter::writeConvolution(const ConvolutionNode *node,
                                               GraphType &graph) {
+  assert(node->getLayout() == NHWC && "can only write NHWC Convolutions");
   auto *proto = graph.add_node();
   // Add dictionary entries.
   addValueAttribute(proto, "strides", node->getStrides());
@@ -913,6 +914,7 @@ llvm::Error ONNXModelWriter::writeModulo(const ModuloNode *node,
 namespace {
 template <typename T>
 void writePool(const T *node, ONNX_NAMESPACE::NodeProto *proto) {
+  assert(node->getLayout() == NHWC && "can only write NHWC Pools");
   // Add dictionary entries.
   addValueAttribute(proto, "kernel_shape", node->getKernels());
   addValueAttribute(proto, "strides", node->getStrides());
@@ -1323,41 +1325,6 @@ llvm::Error ONNXModelWriter::writeCPUConvDKKC8(const CPUConvDKKC8Node *node,
 #endif // GLOW_WITH_CPU
 
 #ifdef GLOW_WITH_OPENCL
-
-llvm::Error ONNXModelWriter::writeOCLConvolution(const OCLConvolutionNode *node,
-                                                 GraphType &graph) {
-  auto *proto = graph.add_node();
-  // Add dictionary entries.
-  addValueAttribute(proto, "kernels", node->getKernels());
-  addValueAttribute(proto, "strides", node->getStrides());
-  addValueAttribute(proto, "pads", node->getPads());
-  addValueAttribute(proto, "group", node->getGroup());
-  addValueAttribute(proto, "dilation", node->getDilation());
-
-  return writeAllWithNode("OCLConvolution", node, proto);
-}
-
-llvm::Error ONNXModelWriter::writeOCLAvgPool(const OCLAvgPoolNode *node,
-                                             GraphType &graph) {
-  auto *proto = graph.add_node();
-  // Add dictionary entries.
-  addValueAttribute(proto, "kernel", node->getKernel());
-  addValueAttribute(proto, "stride", node->getStride());
-  addValueAttribute(proto, "pads", node->getPads());
-
-  return writeAllWithNode("OCLAvgPool", node, proto);
-}
-
-llvm::Error ONNXModelWriter::writeOCLMaxPool(const OCLMaxPoolNode *node,
-                                             GraphType &graph) {
-  auto *proto = graph.add_node();
-  // Add dictionary entries.
-  addValueAttribute(proto, "kernel", node->getKernel());
-  addValueAttribute(proto, "stride", node->getStride());
-  addValueAttribute(proto, "pads", node->getPads());
-
-  return writeAllWithNode("OCLMaxPool", node, proto);
-}
 
 llvm::Error
 ONNXModelWriter::writeOCLBatchedReduceAdd(const OCLBatchedReduceAddNode *node,

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -104,6 +104,28 @@ std::string Placeholder::getDebugDesc() const {
 //                       Nodes verification
 //===----------------------------------------------------------------------===//
 
+static bool verifyConvFilter(const Node *parent, NodeValue filter,
+                             const ShapeNHWC &idim, const ShapeNHWC &odim,
+                             const ShapeHW &kdim, unsigned_t group) {
+  const size_t filterDims[] = {odim.c, kdim.height, kdim.width,
+                               idim.c / (size_t)group};
+  return expectCompareTrue("Invalid filter dimensions",
+                           filter.getType()->dims(),
+                           llvm::makeArrayRef(filterDims), parent);
+}
+
+static bool verifyConvFilter(const Node *parent, NodeValue filter,
+                             const ShapeNCHW &idim, const ShapeNCHW &odim,
+                             const ShapeHW &kdim, unsigned_t group) {
+  const size_t filterDims[] = {odim.c, idim.c / (size_t)group, kdim.height,
+                               kdim.width};
+
+  return expectCompareTrue("Invalid filter dimensions",
+                           filter.getType()->dims(),
+                           llvm::makeArrayRef(filterDims), parent);
+}
+
+template <typename Shape>
 static bool verifyConvolution(NodeValue src, NodeValue dest, NodeValue filter,
                               NodeValue bias,
                               llvm::ArrayRef<unsigned_t> kernels,
@@ -123,8 +145,8 @@ static bool verifyConvolution(NodeValue src, NodeValue dest, NodeValue filter,
       isValid &= checkType(bias, ElemKind::Int32QTy, parent);
     }
   }
-  ShapeNHWC idim(src.getType()->dims());
-  ShapeNHWC odim(dest.getType()->dims());
+  Shape idim(src.getType()->dims());
+  Shape odim(dest.getType()->dims());
   PaddingTLBR pdim(pads);
   ShapeHW kdim(kernels);
   isValid &= expectCompareTrue("buffer height too small for selected stride",
@@ -147,11 +169,8 @@ static bool verifyConvolution(NodeValue src, NodeValue dest, NodeValue filter,
   isValid &= expectCompareTrue("Invalid output dimension C", odim.c % group,
                                size_t(0), parent);
 
-  const size_t filterDims[] = {odim.c, kdim.height, kdim.width,
-                               idim.c / (size_t)group};
-  isValid &=
-      expectCompareTrue("Invalid filter dimensions", filter.getType()->dims(),
-                        llvm::makeArrayRef(filterDims), parent);
+  isValid &= verifyConvFilter(parent, filter, idim, odim, kdim, group);
+
   const size_t biasDims[] = {odim.c};
   isValid &=
       expectCompareTrue("Invalid bias dimensions", bias.getType()->dims(),
@@ -240,13 +259,14 @@ static bool verifyFullyConnected(NodeValue src, NodeValue weights,
   return isValid;
 }
 
+template <typename Shape>
 static bool verifyPool(NodeValue src, NodeValue dest,
                        llvm::ArrayRef<unsigned_t> kernels,
                        llvm::ArrayRef<unsigned_t> strides,
                        llvm::ArrayRef<unsigned_t> pads, bool isAvgPool = true) {
   const Node *parent = dest.getNode();
-  ShapeNHWC idim = ShapeNHWC(src.getType()->dims());
-  ShapeNHWC odim = ShapeNHWC(dest.getType()->dims());
+  Shape idim(src.getType()->dims());
+  Shape odim(dest.getType()->dims());
   PaddingTLBR pdim(pads);
   ShapeHW kdim(kernels);
 
@@ -260,7 +280,9 @@ static bool verifyPool(NodeValue src, NodeValue dest,
 
   auto outSz =
       calculateConvPoolOutputDims(idim.h, idim.w, kernels, strides, pads);
-  ShapeNHWC exp(idim.n, outSz.first, outSz.second, idim.c);
+  Shape exp(idim);
+  exp.h = outSz.first;
+  exp.w = outSz.second;
   isValid &=
       expectCompareTrue("Unexpected output dimensions", exp, odim, parent);
 
@@ -421,8 +443,15 @@ bool PadNode::verify() const {
 }
 
 bool ConvolutionNode::verify() const {
-  return verifyConvolution(getInput(), getResult(), getFilter(), getBias(),
-                           Kernels_, Strides_, Pads_, Group_, Dilation_);
+  if (getLayout() == NHWC) {
+    return verifyConvolution<ShapeNHWC>(getInput(), getResult(), getFilter(),
+                                        getBias(), Kernels_, Strides_, Pads_,
+                                        Group_, Dilation_);
+  } else {
+    return verifyConvolution<ShapeNCHW>(getInput(), getResult(), getFilter(),
+                                        getBias(), Kernels_, Strides_, Pads_,
+                                        Group_, Dilation_);
+  }
 }
 
 bool ChannelwiseQuantizedConvolutionNode::verify() const {
@@ -433,9 +462,10 @@ bool ChannelwiseQuantizedConvolutionNode::verify() const {
     return false;
   }
 
-  isValid = verifyConvolution(getInput(), getResult(), getFilter(), getBias(),
-                              Kernels_, Strides_, Pads_, Group_,
-                              /* dilation */ 1, /* checkBiasType */ false);
+  isValid =
+      verifyConvolution<ShapeNHWC>(getInput(), getResult(), getFilter(),
+                                   getBias(), Kernels_, Strides_, Pads_, Group_,
+                                   /* dilation */ 1, /* checkBiasType */ false);
 
   isValid &= checkType(getBias(), ElemKind::FloatTy, this);
   isValid &= checkType(getInput(), ElemKind::Int8QTy, this);
@@ -492,10 +522,18 @@ bool ConvolutionGradNode::verify() const {
       verifyInputAndGradInputTypes(getBias(), getGradOfInputNamedBias(), this);
   isValid &= verifyOutputAndGradOutputTypes(
       getOriginalOutputForResult(), getGradOfOriginalOutputNamedResult(), this);
-  isValid &= verifyConvolution(
-      getGradOfInputNamedInput(), getGradOfOriginalOutputNamedResult(),
-      getGradOfInputNamedFilter(), getGradOfInputNamedBias(), Kernels_,
-      Strides_, Pads_, Group_, Dilation_);
+  if (getLayout() == NHWC) {
+    isValid &= verifyConvolution<ShapeNHWC>(
+        getGradOfInputNamedInput(), getGradOfOriginalOutputNamedResult(),
+        getGradOfInputNamedFilter(), getGradOfInputNamedBias(), Kernels_,
+        Strides_, Pads_, Group_, Dilation_);
+  } else {
+    isValid &= verifyConvolution<ShapeNCHW>(
+        getGradOfInputNamedInput(), getGradOfOriginalOutputNamedResult(),
+        getGradOfInputNamedFilter(), getGradOfInputNamedBias(), Kernels_,
+        Strides_, Pads_, Group_, Dilation_);
+  }
+
   return isValid;
 }
 
@@ -526,12 +564,25 @@ bool ConvertToNode::verify() const {
 }
 
 bool MaxPoolNode::verify() const {
-  return verifyPool(getInput(), getResult(), Kernels_, Strides_, Pads_,
-                    /* isAvgPool */ false);
+  if (getLayout() == NHWC) {
+    return verifyPool<ShapeNHWC>(getInput(), getResult(), Kernels_, Strides_,
+                                 Pads_,
+                                 /* isAvgPool */ false);
+  } else {
+    return verifyPool<ShapeNCHW>(getInput(), getResult(), Kernels_, Strides_,
+                                 Pads_,
+                                 /* isAvgPool */ false);
+  }
 }
 
 bool AvgPoolNode::verify() const {
-  return verifyPool(getInput(), getResult(), Kernels_, Strides_, Pads_);
+  if (getLayout() == NHWC) {
+    return verifyPool<ShapeNHWC>(getInput(), getResult(), Kernels_, Strides_,
+                                 Pads_);
+  } else {
+    return verifyPool<ShapeNCHW>(getInput(), getResult(), Kernels_, Strides_,
+                                 Pads_);
+  }
 }
 
 bool AdaptiveAvgPoolNode::verify() const {
@@ -574,9 +625,16 @@ bool MaxPoolGradNode::verify() const {
                                               getGradOfInputNamedInput(), this);
   isValid &= verifyOutputAndGradOutputTypes(
       getOriginalOutputForResult(), getGradOfOriginalOutputNamedResult(), this);
-  isValid &= verifyPool(getGradOfInputNamedInput(),
-                        getGradOfOriginalOutputNamedResult(), Kernels_,
-                        Strides_, Pads_, /* isAvgPool */ false);
+
+  if (getLayout() == NHWC) {
+    isValid &= verifyPool<ShapeNHWC>(
+        getGradOfInputNamedInput(), getGradOfOriginalOutputNamedResult(),
+        Kernels_, Strides_, Pads_, /* isAvgPool */ false);
+  } else {
+    isValid &= verifyPool<ShapeNCHW>(
+        getGradOfInputNamedInput(), getGradOfOriginalOutputNamedResult(),
+        Kernels_, Strides_, Pads_, /* isAvgPool */ false);
+  }
   return isValid;
 }
 
@@ -585,9 +643,17 @@ bool AvgPoolGradNode::verify() const {
                                               getGradOfInputNamedInput(), this);
   isValid &= verifyOutputAndGradOutputTypes(
       getOriginalOutputForResult(), getGradOfOriginalOutputNamedResult(), this);
-  isValid &= verifyPool(getGradOfInputNamedInput(),
-                        getGradOfOriginalOutputNamedResult(), Kernels_,
-                        Strides_, Pads_);
+
+  if (getLayout() == NHWC) {
+    isValid &= verifyPool<ShapeNHWC>(getGradOfInputNamedInput(),
+                                     getGradOfOriginalOutputNamedResult(),
+                                     Kernels_, Strides_, Pads_);
+  } else {
+    isValid &= verifyPool<ShapeNCHW>(getGradOfInputNamedInput(),
+                                     getGradOfOriginalOutputNamedResult(),
+                                     Kernels_, Strides_, Pads_);
+  }
+
   return isValid;
 }
 

--- a/lib/IR/IRGen.cpp
+++ b/lib/IR/IRGen.cpp
@@ -134,10 +134,10 @@ void IRGenVisitor::post(Node *parent, Node *N) {
     auto *filterG =
         builder_.createAllocActivationInst("conv.filter.G", filter->getType());
 
-    builder_.createConvolutionGradInst(N->getName(), input, filter, outGrad,
-                                       inG, filterG, biasG, CG->getKernels(),
-                                       CG->getStrides(), CG->getPads(),
-                                       CG->getGroup(), CG->getDilation());
+    builder_.createConvolutionGradInst(
+        N->getName(), input, filter, outGrad, inG, filterG, biasG,
+        CG->getKernels(), CG->getStrides(), CG->getPads(), CG->getGroup(),
+        CG->getDilation(), CG->getLayout());
 
     registerIR(CG->getGradOfInputNamedInput(), inG);
     registerIR(CG->getGradOfInputNamedFilter(), filterG);
@@ -148,7 +148,8 @@ void IRGenVisitor::post(Node *parent, Node *N) {
     auto *P = cast<MaxPoolNode>(N);
     auto *in = valueForNode(P->getInput());
     auto *V = builder_.createMaxPoolWithArgmaxOp(
-        N->getName(), in, P->getKernels(), P->getStrides(), P->getPads());
+        N->getName(), in, P->getKernels(), P->getStrides(), P->getPads(),
+        P->getLayout());
     Value *dest = V->getDest();
     Value *argmax = V->getArgmax();
     nodeToInstr_[N] = V;
@@ -172,7 +173,7 @@ void IRGenVisitor::post(Node *parent, Node *N) {
 
     builder_.createMaxPoolWithArgmaxGradInst(
         N->getName(), outW, PI->getArgmax(), outG, inG, PG->getKernels(),
-        PG->getStrides(), PG->getPads());
+        PG->getStrides(), PG->getPads(), PG->getLayout());
     registerIR(PG->getGradOfInputNamedInput(), inG);
     break;
   }
@@ -188,7 +189,7 @@ void IRGenVisitor::post(Node *parent, Node *N) {
 
     builder_.createAvgPoolGradInst(N->getName(), outW, outG, inG,
                                    PG->getKernels(), PG->getStrides(),
-                                   PG->getPads());
+                                   PG->getPads(), PG->getLayout());
     registerIR(PG->getGradOfInputNamedInput(), inG);
     break;
   }

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -1667,6 +1667,8 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
 
   case Kinded::Kind::ConvolutionInstKind: {
     auto *CI = cast<ConvolutionInst>(I);
+    assert(CI->getLayout() == NHWC &&
+           "Glow CPU Backend supports only NHWC Convolutions");
     auto *dest = CI->getDest();
     auto *src = CI->getSrc();
     auto *filter = CI->getFilter();
@@ -1883,6 +1885,8 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
 
   case Kinded::Kind::MaxPoolInstKind: {
     auto *PM = cast<MaxPoolInst>(I);
+    assert(PM->getLayout() == NHWC &&
+           "Glow CPU Backend supports only NHWC Pools");
     auto *dest = PM->getDest();
     auto *src = PM->getSrc();
     auto *destPtr = emitValueAddress(builder, dest);
@@ -1903,6 +1907,8 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
 
   case Kinded::Kind::MaxPoolWithArgmaxInstKind: {
     auto *PMXY = cast<MaxPoolWithArgmaxInst>(I);
+    assert(PMXY->getLayout() == NHWC &&
+           "Glow CPU Backend supports only NHWC Pools");
     auto *dest = PMXY->getDest();
     auto *src = PMXY->getSrc();
     auto *destPtr = emitValueAddress(builder, dest);
@@ -1941,6 +1947,8 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
 
   case Kinded::Kind::AvgPoolInstKind: {
     auto *PA = cast<AvgPoolInst>(I);
+    assert(PA->getLayout() == NHWC &&
+           "Glow CPU Backend supports only NHWC Pools");
     auto *dest = PA->getDest();
     auto *src = PA->getSrc();
     auto *destPtr = emitValueAddress(builder, dest);

--- a/lib/Optimizer/IROptimizer/IROptimizer.cpp
+++ b/lib/Optimizer/IROptimizer/IROptimizer.cpp
@@ -1557,9 +1557,9 @@ void performPeepholeOptimizations(IRFunction &M) {
         continue;
       }
 
-      auto *newI = B.createMaxPoolInst(PMI->getName(), PMI->getDest(),
-                                       PMI->getSrc(), PMI->getKernels(),
-                                       PMI->getStrides(), PMI->getPads());
+      auto *newI = B.createMaxPoolInst(
+          PMI->getName(), PMI->getDest(), PMI->getSrc(), PMI->getKernels(),
+          PMI->getStrides(), PMI->getPads(), PMI->getLayout());
       it = M.moveInstruction(I, newI);
       M.eraseInstruction(I);
       continue;

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -179,7 +179,7 @@ class MockBackendCustomIRGen : public Backend {
       auto *V = builder_->createConvolutionInst(
           "CustomConvolutionInstruction", Dest__, Src, Filter, Bias,
           CN__->getKernels(), CN__->getStrides(), CN__->getPads(),
-          CN__->getGroup(), CN__->getDilation());
+          CN__->getGroup(), CN__->getDilation(), CN__->getLayout());
       if (N->hasPredicate()) {
         V->setPredicate(irgen.valueForNode(N->getPredicate()));
       }

--- a/tests/unittests/BackendTestUtils2.h
+++ b/tests/unittests/BackendTestUtils2.h
@@ -177,7 +177,7 @@ class MockBackendCustomIRGen : public Backend {
       auto *V = builder_->createConvolutionInst(
           "CustomConvolutionInstruction", Dest__, Src, Filter, Bias,
           CN__->getKernels(), CN__->getStrides(), CN__->getPads(),
-          CN__->getGroup(), CN__->getDilation());
+          CN__->getGroup(), CN__->getDilation(), CN__->getLayout());
       if (N->hasPredicate()) {
         V->setPredicate(irgen.valueForNode(N->getPredicate()));
       }

--- a/tests/unittests/BasicIRTest.cpp
+++ b/tests/unittests/BasicIRTest.cpp
@@ -160,8 +160,8 @@ TEST(IR, allInstrs) {
 
     builder.createCopyInst("", I1, I0);
     builder.createConvolutionInst("", I3, I1, F0, B0, {7, 7}, {2, 2},
-                                  {3, 3, 3, 3}, 1, 1);
-    builder.createMaxPoolInst("", I4, I0, {7, 7}, {2, 2}, {3, 3, 3, 3});
+                                  {3, 3, 3, 3}, 1, 1, NHWC);
+    builder.createMaxPoolInst("", I4, I0, {7, 7}, {2, 2}, {3, 3, 3, 3}, NHWC);
     builder.createSigmoidInst("", I1, I0);
     builder.createTanhInst("", I1, I0);
     builder.createSoftMaxInst("", I1, I0);
@@ -186,7 +186,7 @@ TEST(IR, casting) {
     auto *res = bb.createAllocActivationInst("sigmoid.res", input->getType());
     auto *sig = bb.createSigmoidInst("sigmoid", res, input);
     auto *pool =
-        bb.createAvgPoolOp(sig->getDest(), {7, 7}, {2, 2}, {3, 3, 3, 3});
+        bb.createAvgPoolOp(sig->getDest(), {7, 7}, {2, 2}, {3, 3, 3, 3}, NHWC);
 
     EXPECT_EQ(isa<AvgPoolInst>(pool), true);
     EXPECT_EQ(isa<AvgPoolInst>(input), false);
@@ -293,7 +293,7 @@ TEST(IR, InstUniqueNames) {
     EXPECT_TRUE(it.second);
 
     MaxPoolWithArgmaxInst *MP1 = builder.createMaxPoolWithArgmaxOp(
-        name, V1, {2, 2}, {1, 1}, {0, 2, 1, 3});
+        name, V1, {2, 2}, {1, 1}, {0, 2, 1, 3}, NHWC);
     it = nameSet.insert(MP1->getName());
     EXPECT_TRUE(it.second);
 

--- a/tools/ClassGen/Backends/OpenCL/OpenCLSpecificInstrs.h
+++ b/tools/ClassGen/Backends/OpenCL/OpenCLSpecificInstrs.h
@@ -16,38 +16,6 @@
 
 #ifdef GLOW_WITH_OPENCL
 
-BB.newBackendSpecificInstr("OCLConvolution")
-    .addOperand("Dest", OperandKind::Out)
-    .addOperand("Src", OperandKind::In)
-    .addOperand("Filter", OperandKind::In)
-    .addOperand("Bias", OperandKind::In)
-    .addMember(MemberType::VectorUnsigned, "Kernels")
-    .addMember(MemberType::VectorUnsigned, "Strides")
-    .addMember(MemberType::VectorUnsigned, "Pads")
-    .addMember(MemberType::Unsigned, "Group")
-    .addMember(MemberType::Unsigned, "Dilation")
-    .autoIRGen()
-    .autoVerify(VerifyKind::SameElementType, {"Dest", "Src", "Filter"});
-
-BB.newBackendSpecificInstr("OCLAvgPool")
-    .addOperand("Dest", OperandKind::Out)
-    .addOperand("Src", OperandKind::In)
-    .addMember(MemberType::Unsigned, "Kernel")
-    .addMember(MemberType::Unsigned, "Stride")
-    .addMember(MemberType::VectorUnsigned, "Pads")
-    .autoIRGen()
-    .autoVerify(VerifyKind::SameElementType, {"Dest", "Src"})
-    .addGradientInstr({"Dest"}, {"Dest", "Src"});
-
-BB.newBackendSpecificInstr("OCLMaxPool")
-    .addOperand("Dest", OperandKind::Out)
-    .addOperand("Src", OperandKind::In)
-    .addMember(MemberType::Unsigned, "Kernel")
-    .addMember(MemberType::Unsigned, "Stride")
-    .addMember(MemberType::VectorUnsigned, "Pads")
-    .autoIRGen()
-    .autoVerify(VerifyKind::SameElementType, {"Dest", "Src"});
-
 BB.newBackendSpecificInstr("OCLBatchedReduceAdd")
     .addOperand("Dest", OperandKind::Out)
     .addOperand("Src", OperandKind::In)

--- a/tools/ClassGen/Backends/OpenCL/OpenCLSpecificNodes.h
+++ b/tools/ClassGen/Backends/OpenCL/OpenCLSpecificNodes.h
@@ -16,42 +16,6 @@
 
 #ifdef GLOW_WITH_OPENCL
 
-BB.newNode("OCLConvolution")
-    .addInput("Input")
-    .addInput("Filter")
-    .addInput("Bias")
-    .addMember(MemberType::VectorUnsigned, "Kernels")
-    .addMember(MemberType::VectorUnsigned, "Strides")
-    .addMember(MemberType::VectorUnsigned, "Pads")
-    .addMember(MemberType::Unsigned, "Group")
-    .addMember(MemberType::Unsigned, "Dilation")
-    .addResultFromCtorArg()
-    .setDocstring(
-        "This is an OpenCL-specific convolution implementation where the "
-        "filter, the bias and the input are in the HCHW format");
-
-BB.newNode("OCLAvgPool")
-    .addInput("Input")
-    .addMember(MemberType::Unsigned, "Kernel")
-    .addMember(MemberType::Unsigned, "Stride")
-    .addMember(MemberType::VectorUnsigned, "Pads")
-    .addResultFromCtorArg()
-    .setDocstring(
-        "This is an OpenCL-specific Average Pool operation on the Input given "
-        "provided Kernel, Stride, and Pads. The input and output are in NCHW "
-        "format");
-
-BB.newNode("OCLMaxPool")
-    .addInput("Input")
-    .addMember(MemberType::Unsigned, "Kernel")
-    .addMember(MemberType::Unsigned, "Stride")
-    .addMember(MemberType::VectorUnsigned, "Pads")
-    .addResultFromCtorArg()
-    .setDocstring(
-        "This is an OpenCL-specific Max Pool operation on the Input given "
-        "provided "
-        "Kernel, Stride, and Pads. The input and output are in NCHW format");
-
 BB.newNode("OCLBatchedReduceAdd")
     .addInput("Input")
     .addInput("DestSliceSizes")

--- a/tools/ClassGen/Backends/OpenCL/OpenCLSpecificNodesVerification.h
+++ b/tools/ClassGen/Backends/OpenCL/OpenCLSpecificNodesVerification.h
@@ -18,19 +18,6 @@
 
 #include "glow/Graph/VerifierHelper.h"
 
-bool OCLConvolutionNode::verify() const {
-  ShapeNCHW idim(getInput().getType()->dims());
-  ShapeNCHW odim(getResult().getType()->dims());
-  auto outSz = calculateConvPoolOutputDims(
-      idim.h, idim.w, getKernels(), getStrides(), getPads(), getDilation());
-  ShapeNCHW exp(idim.n, getBias().dims()[0], outSz.first, outSz.second);
-  return expectCompareTrue("Invalid output dimensions", exp, odim, this);
-}
-
-bool OCLAvgPoolNode::verify() const { return true; }
-
-bool OCLMaxPoolNode::verify() const { return true; }
-
 bool OCLBatchedReduceAddNode::verify() const {
   Constant *destSliceSizes =
       llvm::dyn_cast<Constant>(getDestSliceSizes().getNode());

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -86,6 +86,7 @@ int main(int argc, char **argv) {
       .addMember(MemberType::VectorUnsigned, "Pads")
       .addMember(MemberType::Unsigned, "Group")
       .addMember(MemberType::Unsigned, "Dilation")
+      .addMember(MemberType::Unsigned, "Layout")
       .autoIRGen()
       .autoVerify(VerifyKind::SameElementType, {"Dest", "Src", "Filter"})
       .addGradientInstr({"Src", "Filter"}, {"Dest", "Src", "Filter", "Bias"});
@@ -129,6 +130,7 @@ int main(int argc, char **argv) {
       .addMember(MemberType::VectorUnsigned, "Kernels")
       .addMember(MemberType::VectorUnsigned, "Strides")
       .addMember(MemberType::VectorUnsigned, "Pads")
+      .addMember(MemberType::Unsigned, "Layout")
       .autoVerify(VerifyKind::SameElementType, {"Dest", "Src"})
       .addGradientInstr({"Dest", "Argmax"}, {"Dest", "Src"});
 
@@ -138,6 +140,7 @@ int main(int argc, char **argv) {
       .addMember(MemberType::VectorUnsigned, "Kernels")
       .addMember(MemberType::VectorUnsigned, "Strides")
       .addMember(MemberType::VectorUnsigned, "Pads")
+      .addMember(MemberType::Unsigned, "Layout")
       .autoVerify(VerifyKind::SameElementType, {"Dest", "Src"});
 
   BB.newInstr("AvgPool")
@@ -146,6 +149,7 @@ int main(int argc, char **argv) {
       .addMember(MemberType::VectorUnsigned, "Kernels")
       .addMember(MemberType::VectorUnsigned, "Strides")
       .addMember(MemberType::VectorUnsigned, "Pads")
+      .addMember(MemberType::Unsigned, "Layout")
       .autoIRGen()
       .autoVerify(VerifyKind::SameElementType, {"Dest", "Src"})
       .addGradientInstr({"Dest"}, {"Dest", "Src"});

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -82,11 +82,13 @@ int main(int argc, char **argv) {
       .addMember(MemberType::VectorUnsigned, "Pads")
       .addMember(MemberType::Unsigned, "Group")
       .addMember(MemberType::Unsigned, "Dilation")
+      .addMember(MemberType::Enum, "Layout")
       .addResultFromCtorArg()
       .addGradient()
       .setDocstring("Performs 2D Convolution using a given Input, Filter, and "
                     "Bias tensors, as well as provided Kernels, Strides, Pads, "
-                    "Group and Dilation.");
+                    "Group and Dilation. Supported Layouts are defined in the "
+                    "ConvoltionLayout enum: NHWC and NCHW.");
 
   BB.newNode("ChannelwiseQuantizedConvolution")
       .addInput("Input")
@@ -125,23 +127,28 @@ int main(int argc, char **argv) {
       .addMember(MemberType::VectorUnsigned, "Kernels")
       .addMember(MemberType::VectorUnsigned, "Strides")
       .addMember(MemberType::VectorUnsigned, "Pads")
+      .addMember(MemberType::Enum, "Layout")
       .addResultFromCtorArg("Result")
       .addResultFromCtorArg("Argmax")
       .addGradient()
       .setDocstring(
           "Performs a Max Pool with Argmax operation on the Input "
           "given provided Kernels, Strides, and Pads. Argmax is a flattened "
-          "NHWC index corresponding to respective max element.");
+          "index corresponding to respective max element. Supported layouts "
+          "are defined in the ConvolutionLayout enum: NHWC and NCHW.");
 
   BB.newNode("AvgPool")
       .addInput("Input")
       .addMember(MemberType::VectorUnsigned, "Kernels")
       .addMember(MemberType::VectorUnsigned, "Strides")
       .addMember(MemberType::VectorUnsigned, "Pads")
+      .addMember(MemberType::Enum, "Layout")
       .addResultFromCtorArg()
       .addGradient()
-      .setDocstring("Performs an Average Pool operation on the Input given "
-                    "provided Kernels, Strides, and Pads.");
+      .setDocstring(
+          "Performs an Average Pool operation on the Input given "
+          "provided Kernels, Strides, and Pads. Supported layouts are defined "
+          "in the ConvolutionLayout enum: NHWC and NCHW.");
 
   BB.newNode("AdaptiveAvgPool")
       .addInput("Input")


### PR DESCRIPTION
Summary: For convolutions in glow we use NHWC layout, but it's more efficient to use NCHW on GPUS. To enable this the OCL backend adds some specific OCLConvolution, OCLMaxPool and OCLAvgPool nodes and transforms general Conv and Pool nodes into them by shuffling dimensions and adding TransposeNodes.

This PR adds a field `Layout` to ConvolutionNode, MaxPoolNode and AvgPoolNode which can be either NHWC or NCHW. The OCL backend still transforms these nodes but into the same node type with the layout set to NCHW (we still add transposes). This will allow us to reuse this logic in other backends with the same NCHW preference without needing multiple identical BackendConvolutionNodes (etc).

This **DOES NOT** add NCHW convolution support to any backends, or change any OCL kernels - it just removes OCL specific nodes in favour of more general ones.

This was a consensus decision, but worth thinking about whether or no the code is clearer after this change or not too.

Documentation: deleted the section in docs referencing these nodes.

Test Plan: ninja test in various modes (debug, release, asan). Ran resnet-runtime on OCL, ran image-classifier on OCL, tracing-compare across interp, cpu and ocl.