### PR TITLE
[Tensor] Introduce Tensor alignments.

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -105,6 +105,11 @@ public:
   /// The new type is identical to \p T, with a new shape \p dims.
   TypeRef uniqueTypeWithNewShape(TypeRef T, llvm::ArrayRef<size_t> dims);
 
+  /// The new type is identical to \p T, with a new shape \p dims and new \p
+  /// alignments.
+  TypeRef uniqueTypeWithNewShape(TypeRef T, llvm::ArrayRef<size_t> dims,
+                                 llvm::ArrayRef<size_t> alignments);
+
   /// Return the void type.
   TypeRef getVoidTy();
 

--- a/lib/Base/Tensor.cpp
+++ b/lib/Base/Tensor.cpp
@@ -380,7 +380,16 @@ void glow::genericTranspose(const Tensor *src, Tensor *dest,
 
   // Resize the tensor to the transposed shape.
   auto destType = Type::newShape(src->getType(), {newSizes, origDims.size()});
-  dest->reset(destType);
+  // genericTranspose function doesn't know how to set non-trivial strides and
+  // alignments and it cannot figure out the correct ones as it can be
+  // backend-specific. Therefore set the type to destType only if it is not set
+  // properly by the caller yet.
+  // Reset should be called anyways to allocate memory for the tensor.
+  if (dest->dims() != destType.dims()) {
+    dest->reset(destType);
+  } else {
+    dest->reset(dest->getType());
+  }
 
   switch (src->getElementType()) {
   case ElemKind::FloatTy: {

--- a/lib/Base/Type.cpp
+++ b/lib/Base/Type.cpp
@@ -42,6 +42,12 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Type &type) {
       os << " x ";
     }
     os << type.sizes_[i];
+    if (type.numSizes_ >= 2 && i < type.numSizes_ - 1 &&
+        type.strides_[i] != type.strides_[i + 1] * type.sizes_[i + 1]) {
+      assert(type.strides_[i] % type.strides_[i + 1] == 0);
+      // Print the alignment only if it is not 1.
+      os << ":" << (type.strides_[i] / type.strides_[i + 1]);
+    }
   }
   os << '>';
 

--- a/lib/Exporter/ONNXModelWriter.cpp
+++ b/lib/Exporter/ONNXModelWriter.cpp
@@ -1153,8 +1153,10 @@ llvm::Error ONNXModelWriter::writeIntLookupTable(const IntLookupTableNode *node,
   NodeValue mapping = node->getMapping();
   if (Constant *c = llvm::dyn_cast<Constant>(mapping.getNode())) {
     auto handle = c->getHandle<int8_t>();
-    addValueAttribute(proto, "values",
-                      llvm::ArrayRef<int8_t>(handle.begin(), handle.end()));
+    auto begin = &handle.raw(0);
+    addValueAttribute(
+        proto, "values",
+        llvm::ArrayRef<int8_t>(begin, begin + handle.actualSize()));
   } else {
     RETURN_ERR("Mapping must be a constant type.");
   }

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -453,6 +453,11 @@ TypeRef Module::uniqueTypeWithNewShape(TypeRef T, llvm::ArrayRef<size_t> dims) {
   return uniqueType(Type::newShape(*T, dims));
 }
 
+TypeRef Module::uniqueTypeWithNewShape(TypeRef T, llvm::ArrayRef<size_t> dims,
+                                       llvm::ArrayRef<size_t> alignments) {
+  return uniqueType(Type::newShape(*T, dims, alignments));
+}
+
 TypeRef Module::uniqueType(const Type &T) {
   for (auto &tp : types_) {
     if (T.isEqual(tp)) {

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -1087,8 +1087,10 @@ ONNXModelLoader::loadConstantOfShape(const ONNX_NAMESPACE::NodeProto &op,
                       "Input element type must be Int64ITy.");
     // Convert 1D tensor of int64_t into llvm::ArrayRef<size_t>.
     auto TH = in->getPayload().getHandle<int64_t>();
-    llvm::ArrayRef<size_t> outputDims = {(const size_t *)TH.begin(),
-                                         (const size_t *)TH.end()};
+    auto begin = &TH.raw(0);
+    auto end = begin + TH.actualSize();
+    llvm::ArrayRef<size_t> outputDims = {(const size_t *)begin,
+                                         (const size_t *)end};
 
     ty = G_.getParent()->uniqueType(T.getType().getElementType(), outputDims);
     switch (T.getType().getElementType()) {

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -24,6 +24,7 @@
 #include "glow/Graph/Nodes.h"
 #include "glow/Graph/PlaceholderBindings.h"
 #include "glow/Graph/Utils.h"
+#include "glow/Graph/VerifierHelper.h"
 #include "glow/Optimizer/GraphOptimizer/FunctionPasses.h"
 #include "glow/Optimizer/GraphOptimizer/PassManager.h"
 #include "glow/Optimizer/GraphOptimizerPipeline/Pipeline.h"
@@ -1675,6 +1676,7 @@ bool TransposeConstants::run(Function *F, const CompilationContext &cctx) {
     // Transpose the value of C into NC.
     genericTranspose(&C->getPayload(), &NC->getPayloadMutable(),
                      TN->getShuffle());
+    NC->getPayloadMutable().setType(NC->getType());
     // Rewrite uses of TN to reference NC.
     TN->getResult().replaceAllUsesOfWith(NC);
     changed = true;
@@ -1880,6 +1882,17 @@ bool OptimizeTransposeIntoReshape::run(Function *F,
     auto inputNode = TR->getInput();
     auto inputDims = inputNode.dims();
     auto outputDims = TR->getResult().dims();
+    // The transformation is not possible if alignments different from 1 are
+    // used for any dimension.
+    if (!inputNode.getType()->isEqual(F->getParent()->uniqueTypeWithNewShape(
+            inputNode.getType(), inputDims))) {
+      continue;
+    }
+    if (!TR->getResult().getType()->isEqual(
+            F->getParent()->uniqueTypeWithNewShape(TR->getResult().getType(),
+                                                   outputDims))) {
+      continue;
+    }
     // Transpose moves no data if input/output dimensions match after they both
     // drop dimensions of size 1. E.g. transposing [1 5 1 15] into [5 15 1 1]
     // produces vectors (1, 3) for both dimensions so optimization is executed.

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -6939,7 +6939,10 @@ TEST_P(OperatorTest, SLSWithZeroLengths) {
             0, embedWidth - 1, mod.getPRNG());
         auto LH = bindings.allocate(lengths)->getHandle<int32_t>();
         LH.clear(0);
-        std::fill(LH.begin(), LH.begin() + 13, 20);
+        auto it = LH.begin();
+        for (int i = 0; i < 13; ++i, ++it) {
+          *it = 20;
+        }
 
         auto *R = F->createFusedRowwiseQuantizedSparseLengthsWeightedSum(
             "RQSLWS", data, weights, indices, lengths);

--- a/tests/unittests/TensorsTest.cpp
+++ b/tests/unittests/TensorsTest.cpp
@@ -846,6 +846,8 @@ static void testInitZeroFused(ElemKind fusedKind, float allowedError) {
   auto TH = T.getHandle<uint8_t>();
   auto *TData = reinterpret_cast<uint8_t *>(T.getUnsafePtr());
   TH.clear(127);
+  auto rowLength = TH.getElementPtr({1, 0});
+  auto width = TH.dims()[1];
 
   // Now set the scale/offset of each row. Set the scale to 0.1 so that we are
   // multiplying by 10 when calculating zero. Offset is dependent on each row.
@@ -853,7 +855,7 @@ static void testInitZeroFused(ElemKind fusedKind, float allowedError) {
   for (size_t i = 0; i < 10; i++) {
     const ScaleOffsetT offset = -(i + 0.7);
     uint8_t *scaleOffsetPtr =
-        &TData[(i + 1) * numTotalColumns] - 2 * sizeof(ScaleOffsetT);
+        &TData[i * rowLength] + width - 2 * sizeof(ScaleOffsetT);
     memcpy(scaleOffsetPtr, &scaleForAllRows, sizeof(ScaleOffsetT));
     memcpy(scaleOffsetPtr + sizeof(ScaleOffsetT), &offset,
            sizeof(ScaleOffsetT));
@@ -870,7 +872,7 @@ static void testInitZeroFused(ElemKind fusedKind, float allowedError) {
   // the same as expected (untouched by initializing to zero).
   for (size_t i = 0; i < 10; i++) {
     uint8_t *scaleOffsetPtr =
-        &TData[(i + 1) * numTotalColumns] - 2 * sizeof(ScaleOffsetT);
+        &TData[i * rowLength] + width - 2 * sizeof(ScaleOffsetT);
     ScaleOffsetT scale, offset;
     memcpy(&scale, scaleOffsetPtr, sizeof(ScaleOffsetT));
     memcpy(&offset, scaleOffsetPtr + sizeof(ScaleOffsetT),


### PR DESCRIPTION
**Summary:**
In many architectures, data array is required (or recommended) to be aligned in memory. Meaning that total size of the array is multiple of X, and its starting memory address is a multiple of X. In case of multi-dimensional array (Tensor), each dimension should also be a multiple of X. It means that Tensor will have "holes" in it, i.e. useful data is padded by "garbage" values.

This PR introduces ability to create arbitrary-aligned Tensors, fixes various operations to work correctly.

**Documentation:**
- Class Type now has `strides_` member, which contains stride for each dimension.
- `Tensor::size()` still returns number of useful elements.
- `Tensor::actualSize()` is new method, returns number of allocated elements, including "holes" used for padding.
- `Tensor::size() <= Tensor::actualSize()` for every Tensor.
- We will not make any guarantees regarding actual value of pad-elements. They could be arbitrary numbers, all code should work correctly with any pads and not depend on their values.

**Test Plan:**
`ninja test`
