### PR TITLE
Ported resnet-runtime to EE2

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -80,7 +80,7 @@ if(GLOW_WITH_CPU)
                         PRIVATE
                           Backends
                           ExecutionContext
-                          ExecutionEngine
+                          ExecutionEngine2
                           HostManager
                           Partitioner
                           Graph

--- a/examples/resnet-runtime.cpp
+++ b/examples/resnet-runtime.cpp
@@ -15,7 +15,7 @@
  */
 
 #include "glow/Base/Image.h"
-#include "glow/ExecutionEngine/ExecutionEngine.h"
+#include "glow/ExecutionEngine/ExecutionEngine2.h"
 #include "glow/Graph/Graph.h"
 #include "glow/Importer/Caffe2ModelLoader.h"
 #include "glow/Runtime/HostManager/HostManager.h"
@@ -200,8 +200,8 @@ int main(int argc, char **argv) {
 
     context->getPlaceholderBindings()->allocate(phList);
     Tensor batch = image.getUnowned(inputShape);
-    updateInputPlaceholders(*(context->getPlaceholderBindings()), {input},
-                            {&batch});
+    updateInputPlaceholders2(*(context->getPlaceholderBindings()), {input},
+                             {&batch});
 
     dispatchClassify(0, hostManager.get(), std::move(path), std::move(context),
                      returned, finished);


### PR DESCRIPTION
Summary: Ported resnet-runtime to EE2

Documentation:

Progress on #3239 

Test Plan: verify builds, run resnet-runtime and sure it runs and images are categorized correctly.