### PR TITLE
Bug fix: should use getName() when dump a function in partitioner.

### DIFF
--- a/lib/Partitioner/Partitioner.cpp
+++ b/lib/Partitioner/Partitioner.cpp
@@ -853,7 +853,7 @@ llvm::Error Partitioner::Partition(CompilationContext &cctx) {
     if (dumpPartition) {
       subF->dumpDAG("partitionLogicalID" +
                     std::to_string(mapping.getLogicalDeviceIDList(subF)[0]) +
-                    "__" + subF->getFilename() + "__" +
+                    "__" + subF->getName().str() + "__" +
                     mapping.getPartitionBackendName(subF) + ".dot");
     }
     assert(subF->verify() && "Conversion led to invalid function");


### PR DESCRIPTION
Summary:
In partitioner , there won't be "/" in newly created function, so just use "getName()". Otherwise, the return value would be "null".

Documentation:

[Optional Fixes #issue]

Test Plan:
ninja test + -dump-partition

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
