### PR TITLE
Enable deduplication of constants with NaNs. (#3328)

### DIFF
--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -1778,11 +1778,8 @@ struct ConstsEqDedup {
     if (lhs->getType() != rhs->getType()) {
       return false;
     }
-    // Only dedup Constants if their data matches exactly, so allowed error is
-    // 0.0.
-    return lhs->getPayload().isEqual(rhs->getPayload(),
-                                     /* allowedError */ 0.0,
-                                     /* verbose */ false);
+    // Only dedup Constants if they're bit exact matches.
+    return lhs->getPayload().isBitwiseEqual(rhs->getPayload());
   }
 };
 

--- a/tests/unittests/GraphOptzTest.cpp
+++ b/tests/unittests/GraphOptzTest.cpp
@@ -2371,6 +2371,57 @@ TEST_F(GraphOptz, VarsCSE) {
   EXPECT_TRUE(input3->getUsers().begin()->getUser() == RN);
 }
 
+TEST_F(GraphOptz, VarsCSENaN) {
+  // Create two variables that are Private, are not trainable, have no writers
+  // and include NaNs. The first two variables have the same data, and so should
+  // be combined via variable CSE.  In particular, the NaN constants should not
+  // prevent the variables from being combine.
+  auto *input1 = mod_.createConstant(ElemKind::FloatTy, {5}, "input1");
+  auto *input2 = mod_.createConstant(ElemKind::FloatTy, {5}, "input2");
+  input1->getHandle() = {0, NAN, 2, NAN, 4};
+  input2->getHandle() = {0, NAN, 2, NAN, 4};
+
+  // Input them each to different nodes, so node CSE does not change them.
+  auto *TN = F_->createTanh("tanh", input1);
+  auto *SN = F_->createSigmoid("sigmoid", input2);
+  auto *CN = F_->createConcat("concat", {TN, SN}, /* axis */ 0);
+  F_->createSave("ret", CN);
+
+  // Initially there are two variables: inputs 1 and 2 (the save uses a
+  // placeholder).
+  EXPECT_EQ(mod_.getConstants().size(), 2);
+
+  CompilationContext cctx;
+  cctx.compMode = CompilationMode::Infer;
+  // Do not perform any compile-time constant folding.
+  cctx.optimizationOpts.enableConstantFolding = false;
+  ::glow::optimize(F_, cctx);
+
+  // Now only one variables is left; input1 and input2 have been combined.
+  EXPECT_EQ(mod_.getConstants().size(), 1);
+
+  // Verify that only one of input1 and input2 exists.
+  Constant *varOneOrTwo = nullptr;
+  for (auto *V : mod_.getConstants()) {
+    if (V == input1 || V == input2) {
+      EXPECT_TRUE(varOneOrTwo == nullptr);
+      varOneOrTwo = V;
+    }
+  }
+  EXPECT_TRUE(varOneOrTwo != nullptr);
+
+  // Verify that the users of the inputs are updated correctly.
+  EXPECT_TRUE(TN->getInput().getNode() == varOneOrTwo);
+  EXPECT_TRUE(SN->getInput().getNode() == varOneOrTwo);
+
+  // Verify that whichever input1/input2 is left over has two users TN and SN.
+  EXPECT_TRUE(varOneOrTwo->getUsers().size() == 2);
+  for (auto &U : varOneOrTwo->getUsers()) {
+    auto *N = U.getUser();
+    EXPECT_TRUE(N == TN || N == SN);
+  }
+}
+
 // Verify that constant input canonicalization works correctly when the
 // arithmetic nodes have multiple users.
 TEST_F(GraphOptz, simplifyArithmeticMultipleUsers) {


### PR DESCRIPTION
Summary:
Constants that contain NaN will not be de-duplicated because isEqual always returns false for this case. Instead, perform a bitwise comparison to achieve the expected behavior.
