### PR TITLE
Added torch.mm operator to PyTorchModelLoader as Glow MatMul.

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -309,7 +309,8 @@ PyTorchModelLoader::getSymbolsMapping() {
             AvgPoolInputs::ceil_mode,
             AvgPoolInputs::count_include_pad,
             AvgPoolInputs::divisor_override,
-        }}});
+        }},
+       {{"aten::mm"}, &PyTorchModelLoader::loadMatMul, {}}});
 
   return symbolLoaderMapping;
 }
@@ -972,6 +973,20 @@ llvm::Error PyTorchModelLoader::loadMin(const torch::jit::Node *ptNode) {
 
   auto output = F_.createMin("min", lhs, rhs);
   return addGlowNodeValue(outputs[0], output);
+}
+
+llvm::Error PyTorchModelLoader::loadMatMul(const torch::jit::Node *ptNode) {
+  auto inputs = ptNode->inputs();
+  auto outputs = ptNode->outputs();
+  RETURN_IF_ERR(checkInputAndOutputSizes(inputs, 2, outputs, 1));
+
+  glow::NodeValue lhs;
+  ASSIGN_VALUE_OR_RETURN_ERR(lhs, getGlowNodeValue(inputs[0]));
+  glow::NodeValue rhs;
+  ASSIGN_VALUE_OR_RETURN_ERR(rhs, getGlowNodeValue(inputs[1]));
+
+  auto *glowNode = F_.createMatMul("MatMul", lhs, rhs);
+  return addGlowNodeValue(outputs[0], glowNode);
 }
 
 llvm::Error PyTorchModelLoader::loadConstant(const torch::jit::Node *ptNode) {

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -237,6 +237,10 @@ private:
   /// Load a PyTorch min node.
   /// \returns error on failure.
   llvm::Error loadMin(const torch::jit::Node *ptNode);
+
+  /// Load a PyTorch matmul (n x k) x (k x m) -> (n x m) node.
+  /// \returns error on failure.
+  llvm::Error loadMatMul(const torch::jit::Node *ptNode);
 };
 } // namespace glow
 

--- a/torch_glow/tests/nodes/mm_test.py
+++ b/torch_glow/tests/nodes/mm_test.py
@@ -1,0 +1,19 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import torch
+
+from tests.utils import jitVsGlow
+
+
+def test_mm_basic():
+    """Test of the PyTorch MatMul Node on Glow."""
+
+    def test_mm(a, b, t):
+        r = torch.mm(a, b)
+        return r.mm(t)
+
+    lhs = torch.randn(2, 3)
+    rhs = torch.randn(3, 4)
+    t = torch.randn(4, 2)
+
+    jitVsGlow(test_mm, lhs, rhs, t)


### PR DESCRIPTION
Summary:
Added MatMul  operator support for PyTorchModelLoader class for aten:mm PyTorch operator.
Documentation:

[Optional Fixes #issue]

Test Plan:

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
