### PR TITLE
Fix RuntimeBenchmark.

### DIFF
--- a/tests/benchmark/RuntimeBench.cpp
+++ b/tests/benchmark/RuntimeBench.cpp
@@ -576,7 +576,7 @@ std::unique_ptr<DAG> createSingleNodeDAG(
   singleNode->deviceIDs = {0};
   singleNode->name = "singleNode";
   singleNode->runtimeBundle = llvm::make_unique<RuntimeBundle>(
-      std::move(compiledFunctions["singleNode"]->getRuntimeBundle()));
+      compiledFunctions["singleNode"]->getRuntimeBundle());
 
   std::vector<std::unique_ptr<DAGNode>> nodes;
   nodes.emplace_back(std::move(singleNode));


### PR DESCRIPTION
Summary: This fixes runtimeBenchmark. The runtimeBundle was being moved out of the compiledFunction causing a segfault when the function tried to run.

Documentation:


Test Plan: compile and run RuntimeBenchmark