### PR TITLE
Fix addmm test & FusingOptimizer

### DIFF
--- a/torch_glow/src/FusingOptimizer.cpp
+++ b/torch_glow/src/FusingOptimizer.cpp
@@ -35,6 +35,12 @@ graph(%input, %weight, %bias, %4):
   %output = aten::matmul(%input, %weight_t)
   %res = aten::add_(%output, %bias, %4)
   return (%res))IR";
+  std::string mm_add_pattern = R"IR(
+graph(%input, %weight, %bias, %4):
+  %weight_t = aten::t(%weight)
+  %output = aten::mm(%input, %weight_t)
+  %res = aten::add_(%output, %bias, %4)
+  return (%res))IR";
   std::string fused_linear = R"IR(
 graph(%input, %weight, %bias, %4):
   %res = aten::linear(%input, %weight, %bias)
@@ -44,6 +50,11 @@ graph(%input, %weight, %bias, %4):
 graph(%input, %weight):
   %weight_t = aten::t(%weight)
   %output = aten::matmul(%input, %weight_t)
+  return (%output))IR";
+  std::string mm_pattern = R"IR(
+graph(%input, %weight):
+  %weight_t = aten::t(%weight)
+  %output = aten::mm(%input, %weight_t)
   return (%output))IR";
   std::string fused_linear_bias_none = R"IR(
 graph(%input, %weight):
@@ -61,11 +72,21 @@ graph(%input, %weight):
   matmuladd_to_linear.RegisterRewritePattern(matmul_add_pattern, fused_linear);
   matmuladd_to_linear.runOnGraph(graph);
 
+  // replace mm + add pattern to linear
+  torch::jit::SubgraphRewriter mmadd_to_linear;
+  mmadd_to_linear.RegisterRewritePattern(mm_add_pattern, fused_linear);
+  mmadd_to_linear.runOnGraph(graph);
+
   // replace matmul with bias=None pattern to linear
   torch::jit::SubgraphRewriter matmul_to_linear;
   matmul_to_linear.RegisterRewritePattern(matmul_pattern,
                                           fused_linear_bias_none);
   matmul_to_linear.runOnGraph(graph);
+
+  // replace mm with bias=None pattern to linear
+  torch::jit::SubgraphRewriter mm_to_linear;
+  mm_to_linear.RegisterRewritePattern(mm_pattern, fused_linear_bias_none);
+  mm_to_linear.runOnGraph(graph);
 }
 
 } // namespace glow

--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -702,9 +702,8 @@ llvm::Error PyTorchModelLoader::loadLinear(const torch::jit::Node *ptNode) {
     glow::NodeValue bias;
     ASSIGN_VALUE_OR_RETURN_ERR(bias,
                                getGlowNodeValue(inputs[LinearInputs::bias]));
-    return addGlowNodeValue(
-        outputs[0],
-        (F_.createAdd("linear_add", mul->getResult(), bias))->getResult());
+    auto *output = F_.createAdd("linear_add", mul->getResult(), bias);
+    return addGlowNodeValue(outputs[0], output->getResult());
   } else {
     return addGlowNodeValue(outputs[0], mul->getResult());
   }

--- a/torch_glow/tests/nodes/addmm_test.py
+++ b/torch_glow/tests/nodes/addmm_test.py
@@ -7,18 +7,16 @@ from tests.utils import jitVsGlow
 import pytest
 
 
-@pytest.mark.skip(reason="not ready")
 def test_addmm():
 
     def test_f(M, aa, b, bias):
         """Basic test of the PyTorch addmm Node on Glow."""
         a = aa.t()
-        M1 = M.addmm(a, b)
-        M2 = M1.add(bias)
-        return M2
+        M1 = M.addmm(b, a)
+        return M1.add(bias)
 
-    x = torch.randn(10, 6)
-    y = torch.randn(10, 6)
+    x = torch.randn(6, 10)
+    y = torch.randn(6, 10)
     z = torch.randn(6, 6)
     a = torch.randn(6, 6)
 


### PR DESCRIPTION
We did not have fusing of aten::mm in our previous version, which makes addmm test doesnt work in our newest version of pytorch. here we add it in and fixed the operator creating process.