### PR TITLE
[RecommendationSystem] Add FP16 versions of tests

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -416,8 +416,15 @@ public:
       llvm::ArrayRef<unsigned_t> kernels, llvm::ArrayRef<unsigned_t> strides,
       llvm::ArrayRef<unsigned_t> pads, unsigned_t group);
 
+  /// Creates and \returns a ConvertTo Node with name \p name of \p input to
+  /// output type \p outTy.
   ConvertToNode *createConvertTo(llvm::StringRef name, NodeValue input,
                                  TypeRef outTy);
+
+  /// Creates and \returns a ConvertTo Node with name \p name of \p input to
+  /// output ElemKind \p k.
+  ConvertToNode *createConvertTo(llvm::StringRef name, NodeValue input,
+                                 ElemKind k);
 
   MaxPoolNode *createMaxPool(llvm::StringRef name, NodeValue input,
                              llvm::ArrayRef<unsigned_t> kernels,

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -2246,6 +2246,12 @@ ConvertToNode *Function::createConvertTo(llvm::StringRef name, NodeValue input,
   return addNode(new ConvertToNode(name, outTy, input));
 }
 
+ConvertToNode *Function::createConvertTo(llvm::StringRef name, NodeValue input,
+                                         ElemKind k) {
+  auto OT = getParent()->uniqueType(k, input.dims());
+  return addNode(new ConvertToNode(name, OT, input));
+}
+
 FullyConnectedNode *
 Function::createFullyConnected(PlaceholderBindings &bindings,
                                llvm::StringRef name, NodeValue input,

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -1023,12 +1023,8 @@ llvm::Error ONNXModelLoader::loadCast(const ONNX_NAMESPACE::NodeProto &op,
                         (!isQuantizedElemKind(targetKind)),
                     "Unsupported Cast");
 
-  // Create the node.
-  auto inputDims = input.dims();
-  auto outTy = G_.getParent()->uniqueType(targetKind, inputDims);
-
   // Create the IR node.
-  Node *N = G_.createConvertTo(opName, input, outTy);
+  Node *N = G_.createConvertTo(opName, input, targetKind);
   RETURN_IF_ERR(addNodeAsOutput(op, N));
 
   return llvm::Error::success();

--- a/tests/unittests/GraphGradTest.cpp
+++ b/tests/unittests/GraphGradTest.cpp
@@ -196,9 +196,7 @@ TEST(GraphAutoGrad, checkConvertToGradTest) {
   auto inputHandle = bindings.allocate(A)->getHandle<float>();
   inputHandle.randomize(-3.0, 3.0, mod.getPRNG());
 
-  TypeRef outTy = mod.uniqueType(ElemKind::Float16Ty, A->dims());
-
-  auto *convertTo = F->createConvertTo("convertTo", A, outTy);
+  auto *convertTo = F->createConvertTo("convertTo", A, ElemKind::Float16Ty);
   auto *result = F->createSave("save", convertTo);
   bindings.allocate(result->getPlaceholder());
 

--- a/tests/unittests/GraphOptzTest.cpp
+++ b/tests/unittests/GraphOptzTest.cpp
@@ -2646,9 +2646,8 @@ TEST_F(GraphOptz, ConvertPlaceholdersToConstants) {
 TEST_F(GraphOptz, optimizeSameTypeConversions) {
   auto *input1 = mod_.createPlaceholder(ElemKind::FloatTy, {1}, "input1", true);
   auto *input2 = mod_.createPlaceholder(ElemKind::FloatTy, {1}, "input2", true);
-  auto *conv1 = F_->createConvertTo("cast1", input1, input1->getType());
-  auto *conv2 = F_->createConvertTo(
-      "cast2", input2, mod_.uniqueType(ElemKind::Float16Ty, input2->dims()));
+  auto *conv1 = F_->createConvertTo("cast1", input1, ElemKind::FloatTy);
+  auto *conv2 = F_->createConvertTo("cast2", input2, ElemKind::Float16Ty);
   auto *save1 = F_->createSave("save1", conv1);
   auto *save2 = F_->createSave("save1", conv2);
 

--- a/tests/unittests/TypeAToTypeBFunctionConverterTest.cpp
+++ b/tests/unittests/TypeAToTypeBFunctionConverterTest.cpp
@@ -877,8 +877,8 @@ TEST_P(AllBackends, convertExistingConversionToNoop) {
   auto *placeholder =
       mod.createPlaceholder(ElemKind::FloatTy, {20, 13}, "Input", false);
 
-  TypeRef outTy = mod.uniqueType(ElemKind::Float16Ty, placeholder->dims());
-  auto *convert = F->createConvertTo("convert", placeholder, outTy);
+  auto *convert =
+      F->createConvertTo("convert", placeholder, ElemKind::Float16Ty);
   auto *save = F->createSave("save", convert);
 
   size_t origSize = F->getNodes().size();


### PR DESCRIPTION
Add FP16 versions of many of the RecSys tests. This includes versions that use either FP16 or FP32 accumulation.

Also added a `Function::createConvertTo()` that takes an ElemKind, which is more intuitive/easier to use.