### PR TITLE
[ONNXIFI] Add timeouts and statuses to onnxifi events

### DIFF
--- a/lib/Onnxifi/Base.h
+++ b/lib/Onnxifi/Base.h
@@ -80,10 +80,16 @@ class Event {
 public:
   Event() : fired_{false} {}
   /// Signal the event.
-  bool signal();
+  bool signal(onnxStatus status);
 
   /// Wait until the event is signalled.
-  void wait();
+  onnxStatus wait();
+
+  /// Wait until the event is signalled or until at least \p timeoutMs
+  /// milliseconds have elapsed. \returns a pair with the first value being a
+  /// boolean that is true if the event was signalled (no timeout occurred) and
+  /// the second is the value of the event's status.
+  std::pair<bool, onnxStatus> waitFor(size_t timeoutMs);
 
   /// Check if event was signalled.
   bool isSignalled() { return fired_; }
@@ -92,6 +98,9 @@ private:
   std::atomic<bool> fired_;
   std::mutex mutex_;
   std::condition_variable cond_;
+  /// Used to hold an onnxStatus that will be passed for the signaller of the
+  /// event to a waiter. Should only be accessed while holding mutex_.
+  onnxStatus status_ = ONNXIFI_STATUS_SUCCESS;
 };
 
 typedef Event *EventPtr;

--- a/lib/Onnxifi/HostManagerOnnxifi.cpp
+++ b/lib/Onnxifi/HostManagerOnnxifi.cpp
@@ -124,7 +124,7 @@ onnxStatus HostManagerGraph::run(std::unique_ptr<ExecutionContext> ctx,
         // If an Error occurred then log it in errToBool and signal the output
         // event.
         if (errToBool(std::move(err))) {
-          outputEvent->signal();
+          outputEvent->signal(ONNXIFI_STATUS_INTERNAL_ERROR);
           return;
         }
 
@@ -148,7 +148,7 @@ onnxStatus HostManagerGraph::run(std::unique_ptr<ExecutionContext> ctx,
           }
         }
 
-        outputEvent->signal();
+        outputEvent->signal(ONNXIFI_STATUS_SUCCESS);
       });
 
   return ONNXIFI_STATUS_SUCCESS;

--- a/lib/Onnxifi/InlineOnnxifi.cpp
+++ b/lib/Onnxifi/InlineOnnxifi.cpp
@@ -93,7 +93,7 @@ onnxStatus InlineGraph::run(std::unique_ptr<ExecutionContext> ctx,
     setTraceEvents(traceEvents, traceContext);
   }
 
-  outputEvent->signal();
+  outputEvent->signal(ONNXIFI_STATUS_SUCCESS);
   return ONNXIFI_STATUS_SUCCESS;
 }
 


### PR DESCRIPTION
Summary:
see #2702
Add a timeout mechanism and a way to pass onnxStatuses from onnxifi event signallers to waiters. This enables waiting for Glow to return results for only a finite period of time and also enable Glow to pass statuses back to the caller in case a failure has occurred.

Documentation:
doxygen

Test Plan:
CI
These changes are backwards compatible so will make the corresponding changes in c2 in a followup and test the functionality there.