### PR TITLE
Make PyTorchModelLoader class decoupled from bindings.

### DIFF
--- a/torch_glow/src/CachingGraphRunner.cpp
+++ b/torch_glow/src/CachingGraphRunner.cpp
@@ -41,7 +41,8 @@ llvm::Error CachingGraphRunner::runGraph(const torch::jit::Node *node,
   std::vector<glow::Placeholder *> outputPlaceholders;
 
   RETURN_IF_ERR(PyTorchModelLoader::loadJITGraph(
-      *f, *graph, inputs, inputPlaceholders, outputPlaceholders));
+      *f, *graph, inputs, inputPlaceholders, outputPlaceholders,
+      getPyTorchLoaderSettings()));
 
   glow::CompilationContext cctx;
   executionEngine_.compile(cctx);

--- a/torch_glow/src/PyTorchLoaderTest.cpp
+++ b/torch_glow/src/PyTorchLoaderTest.cpp
@@ -60,7 +60,8 @@ void convertJitGraphToGlowFunction(torch::jit::Stack &stack,
   std::vector<glow::Placeholder *> inputPlaceholders;
   std::vector<glow::Placeholder *> outputPlaceholders;
   llvm::Error errPtr = glow::PyTorchModelLoader::loadJITGraph(
-      f, graph, inputs, inputPlaceholders, outputPlaceholders);
+      f, graph, inputs, inputPlaceholders, outputPlaceholders,
+      glow::getPyTorchLoaderSettings());
 
   EXPECT_FALSE(errPtr);
 
@@ -107,7 +108,8 @@ TEST(PyTorchModelLoader, Model) {
 
   at::ArrayRef<torch::jit::IValue> inputs(vec);
   errPtr = glow::PyTorchModelLoader::loadJITGraph(
-      *f, *subgraph, inputs, inputPlaceholders, outputPlaceholders);
+      *f, *subgraph, inputs, inputPlaceholders, outputPlaceholders,
+      glow::getPyTorchLoaderSettings());
   EXPECT_FALSE(!errPtr); // TODO
 }
 

--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -16,8 +16,6 @@
 
 #include "PyTorchModelLoader.h"
 
-#include "PyTorchCommon.h"
-
 #include "glow/Support/Error.h"
 #include "glow/Support/Support.h"
 
@@ -1190,11 +1188,12 @@ llvm::Error PyTorchModelLoader::loadJITGraph(
     glow::Function &F, torch::jit::Graph &subgraph,
     at::ArrayRef<torch::jit::IValue> &inputs,
     std::vector<glow::Placeholder *> &inputPlaceholders,
-    std::vector<glow::Placeholder *> &outputPlaceholders) {
+    std::vector<glow::Placeholder *> &outputPlaceholders,
+    const PyTorchLoaderSettings &settings) {
   llvm::Error error = llvm::Error::success();
   MARK_ERR_CHECKED(error);
   PyTorchModelLoader loader(F, subgraph, inputs, inputPlaceholders,
-                            outputPlaceholders, error);
+                            outputPlaceholders, error, settings);
   return error;
 }
 
@@ -1202,7 +1201,8 @@ PyTorchModelLoader::PyTorchModelLoader(
     glow::Function &F, torch::jit::Graph &subgraph,
     at::ArrayRef<torch::jit::IValue> &inputs,
     std::vector<glow::Placeholder *> &inputPlaceholders,
-    std::vector<glow::Placeholder *> &outputPlaceholders, llvm::Error &error)
+    std::vector<glow::Placeholder *> &outputPlaceholders, llvm::Error &error,
+    const PyTorchLoaderSettings &settings)
     : F_(F), inputs_(inputs) {
   auto subgraphInputValues = subgraph.inputs();
 
@@ -1231,7 +1231,7 @@ PyTorchModelLoader::PyTorchModelLoader(
     }
   }
 
-  bool weightFreezingEnabled = getPyTorchLoaderSettings().weightFreezingEnabled;
+  bool weightFreezingEnabled = settings.weightFreezingEnabled;
 
   // Nodes are topologically sorted.
   for (auto node : subgraph.nodes()) {

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -17,9 +17,9 @@
 #ifndef GLOW_TORCH_GLOW_SRC_PYTORCHMODELLOADER_H
 #define GLOW_TORCH_GLOW_SRC_PYTORCHMODELLOADER_H
 
+#include "PyTorchCommon.h"
 #include <llvm/Support/Error.h>
 #include <torch/csrc/jit/custom_operator.h>
-#include <torch/csrc/jit/ir.h>
 
 #include "glow/Graph/Graph.h"
 
@@ -106,7 +106,8 @@ public:
   loadJITGraph(glow::Function &F, torch::jit::Graph &subgraph,
                at::ArrayRef<torch::jit::IValue> &inputs,
                std::vector<glow::Placeholder *> &inputPlaceholders,
-               std::vector<glow::Placeholder *> &outputPlaceholders);
+               std::vector<glow::Placeholder *> &outputPlaceholders,
+               const PyTorchLoaderSettings &settings);
 
 private:
   /// Takes a glow::Function \p F, a jit::Graph \p subgraph to load, and a
@@ -116,7 +117,7 @@ private:
                      at::ArrayRef<torch::jit::IValue> &inputs,
                      std::vector<glow::Placeholder *> &inputPlaceholders,
                      std::vector<glow::Placeholder *> &outputPlaceholders,
-                     llvm::Error &error);
+                     llvm::Error &error, const PyTorchLoaderSettings &settings);
 
   /// Save access to the mapping.
   static const MappingOfMemberFunctions &getSymbolsMapping();


### PR DESCRIPTION
Summary:
PyTorchModelLoader class should take all required settings through public API, not back door accessing global objects/methods.
This is important issue, and developers should think about PyTorchModelLoader class as a library that can be used in multiple projects,
even projects without Python bindings or differnt Python bindings. Therefore the rule of thumb -> send all settings explicitly through public interface.

Reviewed By: jackm321

Differential Revision: D16713074

