### PR TITLE
[Partitioner] DAG validation

### DIFF
--- a/include/glow/Partitioner/PartitionerValidation.h
+++ b/include/glow/Partitioner/PartitionerValidation.h
@@ -31,5 +31,10 @@ logicalDevicesValidation(const NodeToFunctionMap &partitions,
 llvm::Error
 memoryUsageValidation(const NodeToFunctionMap &partitions,
                       const std::map<std::string, BackendInfo> &backendMap);
+
+/// Check if the current partition is a valid DAG. This check can only be called
+/// after a real partition is created and the DAG is generated.
+llvm::Error dagValidation(const DAG &dag);
+
 } // namespace glow
 #endif // GLOW_PARTITIONER_PARTITIONERVALIDATION_H


### PR DESCRIPTION
Summary:
This PR checks if a partition is a DAG.   This validation is mainly used in user-defined partition so far. But it can be added to anyplace where a partition DAG is already created. 

Documentation:

[Optional Fixes #issue]

Test Plan:
unit test added.

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
