### PR TITLE
Assorted memory-related fixes for HostManager, EE, RecSys

### DIFF
--- a/include/glow/ExecutionEngine/ExecutionEngine.h
+++ b/include/glow/ExecutionEngine/ExecutionEngine.h
@@ -47,7 +47,7 @@ class ExecutionEngine final {
   /// this resets the ExecutionEngine.
   std::string backendName_ = "";
 
-  /// Size of device memory, if 0 device default is used.
+  /// Size of device memory in bytes, if 0 device default is used.
   uint64_t deviceMemory_{0};
 
   /// The HostManager for executing the compiled functions.
@@ -61,7 +61,10 @@ class ExecutionEngine final {
   void runInternal(ExecutionContext &context, llvm::StringRef name);
 
 public:
-  ExecutionEngine(llvm::StringRef backend = "Interpreter");
+  /// Constructor for an ExecutionEngine with \p backend and memory \p
+  /// deviceMemory in bytes.
+  ExecutionEngine(llvm::StringRef backend = "Interpreter",
+                  uint64_t deviceMemory = 0);
 
   ~ExecutionEngine();
 

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -33,10 +33,10 @@ ExecutionEngine::ExecutionEngine(llvm::StringRef backend) {
 
 /// Set the code generator to the given \p backend.
 void ExecutionEngine::setBackendName(llvm::StringRef backend) {
+  clear();
   module_.reset(new Module);
   rawModule_ = module_.get();
   backendName_ = backend;
-  clear();
 
   if (hostManager_) {
     EXIT_ON_ERR(hostManager_->clearHost());
@@ -61,6 +61,7 @@ void ExecutionEngine::clear() {
     EXIT_ON_ERR(hostManager_->clearHost());
   }
   compiledFunctions_.clear();
+  module_.reset(nullptr);
 }
 
 void glow::updateInputPlaceholders(PlaceholderBindings &bindings,

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -27,7 +27,8 @@
 
 using namespace glow;
 
-ExecutionEngine::ExecutionEngine(llvm::StringRef backend) {
+ExecutionEngine::ExecutionEngine(llvm::StringRef backend, uint64_t deviceMemory)
+    : deviceMemory_(deviceMemory) {
   setBackendName(backend);
 }
 

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -74,7 +74,10 @@ DECLARE_STATELESS_BACKEND_TEST(BackendStatelessTest, std::tuple<std::string>);
 
 class BackendTest : public BackendStatelessTest {
 public:
-  BackendTest() : mod_(EE_.getModule()) { F_ = mod_.createFunction("main"); }
+  BackendTest(uint64_t deviceMemory = 0)
+      : EE_(getBackendName(), deviceMemory), mod_(EE_.getModule()) {
+    F_ = mod_.createFunction("main");
+  }
 
 protected:
   ExecutionEngine EE_{getBackendName()};


### PR DESCRIPTION
4 commits here:
- When calling `ExecutionEngine::clear()`, reset the Module
- Add device memory to the EE constructor so we don't need to reset
- Use `HostManager::removeNetwork()` from `HostManager::clearHost()`
- Refactor RecSys to make sure EEs are cleared once done and we save only the result tensor to compare against.