### PR TITLE
Append the buffer name to dealloc inst names so we don't run out of unique names.

### DIFF
--- a/lib/IR/IRBuilder.cpp
+++ b/lib/IR/IRBuilder.cpp
@@ -48,7 +48,7 @@ void IRBuilder::deallocateActiveInstrs() {
       continue;
     }
 
-    createDeallocActivationInst("dealloc", AA);
+    createDeallocActivationInst("dealloc." + AA->getName().str(), AA);
   }
 }
 


### PR DESCRIPTION
*Description*: 
This should also speed up dealloc instruction creation since the unique
name formation is a linear search.

fixes https://github.com/pytorch/glow/issues/2557

*Testing*:
CI, unit tests