### PR TITLE
[PyTorch] Cache Glow compilations

### DIFF
--- a/include/glow/Runtime/HostManager/HostManager.h
+++ b/include/glow/Runtime/HostManager/HostManager.h
@@ -18,6 +18,8 @@
 #include "glow/Backend/Backend.h"
 #include "glow/Backends/DeviceManager.h"
 #include "glow/Graph/Graph.h"
+#include "glow/Runtime/Executor/Executor.h"
+#include "glow/Runtime/Provisioner/Provisioner.h"
 #include "glow/Runtime/RuntimeTypes.h"
 
 #include <atomic>
@@ -29,11 +31,6 @@
 
 namespace glow {
 namespace runtime {
-
-class Executor;
-
-class Provisioner;
-
 /// The HostManager serves as an entry point into the Runtime environment. It
 /// provides an interface to add, run, and evict networks from the host. It
 /// handles DeviceManager initialization, houses the Executor, and calls into
@@ -181,10 +178,17 @@ public:
 
   /// A wrapper around runNetwork that provides a blocking interface for an
   /// inference request. Runs the network provided in \p networkName using \p
+  /// context. \returns an llvm::Error indicating success or failure.
+  llvm::Error runNetworkBlocking(llvm::StringRef networkName,
+                                 std::unique_ptr<ExecutionContext> context);
+
+  /// A wrapper around runNetwork that provides a blocking interface for an
+  /// inference request. Runs the network provided in \p networkName using \p
   /// bindings for placeholder bindings. \returns an llvm::Error indicating
   /// success or failure.
   llvm::Error runNetworkBlocking(llvm::StringRef networkName,
                                  PlaceholderBindings &bindings);
+
   /// Initialize the HostManager with the given \p configs creating one
   /// DeviceManager for each config listed.
   llvm::Error init(std::vector<std::unique_ptr<DeviceConfig>> configs);

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -1723,7 +1723,7 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     assert(CI->getLayout() == NHWC &&
            "Glow CPU Backend supports only NHWC Convolutions");
     assert(CI->getFusedActivation() == FusedActivation::NONE &&
-          "Glow CPU Backend does not support fused activations.");
+           "Glow CPU Backend does not support fused activations.");
     auto *dest = CI->getDest();
     auto *src = CI->getSrc();
     auto *filter = CI->getFilter();

--- a/torch_glow/src/CMakeLists.txt
+++ b/torch_glow/src/CMakeLists.txt
@@ -24,8 +24,8 @@ target_link_libraries(PyTorchModelLoader
                       PRIVATE
                         torch
                         c10
-                        ExecutionEngine
                         Support
+                        HostManager
                         Graph
                         Importer)
 

--- a/torch_glow/src/CachingGraphRunner.cpp
+++ b/torch_glow/src/CachingGraphRunner.cpp
@@ -20,41 +20,87 @@
 
 #include "glow/Support/Support.h"
 
+#include <torch/csrc/jit/argument_spec.h>
+#include <torch/csrc/utils/hash.h>
+
 namespace glow {
 
-llvm::Error CachingGraphRunner::runGraph(const torch::jit::Node *node,
-                                         torch::jit::Stack &stack) {
-  // If this is the first time this subgraph has been run then create a new
-  // GraphInfo object to store information about it.
-
+namespace {
+/// Returns a hash that represents a given PT subgraph represented by the PT
+/// node \p node and a set of tensor shape inputs to that subgraph from the \p
+/// stack.
+size_t getGraphHash(const torch::jit::Node *node,
+                    const torch::jit::Stack &stack) {
   const std::shared_ptr<torch::jit::Graph> graph = node->g(at::attr::Subgraph);
   const auto &graphInputs = graph->inputs();
-  const auto numInputs = graphInputs.size();
-  auto inputs = torch::jit::last(stack, numInputs);
-  const char *const functionName = "PyTorchFunction";
+  const auto inputs = torch::jit::last(stack, graphInputs.size());
+  torch::jit::CompleteArgumentSpec spec(/*with_grad*/ false, inputs);
 
-  glow::Function *f = nullptr;
-  // Discard compiled function.
-  executionEngine_.setBackendName(executionEngine_.getBackendName());
-  auto &mod = executionEngine_.getModule();
-  f = mod.createFunction(functionName);
-  std::vector<glow::Placeholder *> inputPlaceholders;
-  std::vector<glow::Placeholder *> outputPlaceholders;
+  return torch::hash_combine(reinterpret_cast<size_t>(node), spec.hashCode());
+}
+
+} // namespace
+
+llvm::Expected<CachingGraphRunner::PerGlowGraphInfo *>
+CachingGraphRunner::loadGraphImpl(const torch::jit::Node *node,
+                                  torch::jit::Stack &stack) {
+  const std::shared_ptr<torch::jit::Graph> graph = node->g(at::attr::Subgraph);
+  RETURN_ERR_IF_NOT(graph, "A subgraph couldn't be found for this node");
+
+  const auto &graphInputs = graph->inputs();
+  auto inputs = torch::jit::last(stack, graphInputs.size());
+
+  size_t hash = getGraphHash(node, stack);
+
+  // If we already have a Glow function compiled for this graph with and the
+  // given inputs then use that.
+  auto it = perGlowGraphInfoMap.find(hash);
+  if (it != perGlowGraphInfoMap.end()) {
+    return it->second.get();
+  }
+
+  auto info = llvm::make_unique<PerGlowGraphInfo>();
+  info->functionName = strFormat("PTFunction%lu", hash);
+  info->hash = hash;
+  info->node = node;
+
+  std::unique_ptr<Module> module = llvm::make_unique<Module>();
+  Function *f = module->createFunction(info->functionName);
 
   RETURN_IF_ERR(PyTorchModelLoader::loadJITGraph(
-      *f, *graph, inputs, inputPlaceholders, outputPlaceholders,
+      *f, *graph, inputs, info->inputPlaceholders, info->outputPlaceholders,
       getPyTorchLoaderSettings()));
 
-  glow::PlaceholderBindings bindings;
-  for (size_t i = 0; i < inputs.size(); ++i) {
-    glow::Placeholder *ph = inputPlaceholders[i];
+  glow::CompilationContext cctx;
+
+  RETURN_IF_ERR(hostManager_->addNetwork(std::move(module), cctx));
+
+  perGlowGraphInfoMap.insert({hash, std::move(info)});
+
+  return perGlowGraphInfoMap[hash].get();
+}
+
+llvm::Error CachingGraphRunner::runGraphImpl(const PerGlowGraphInfo &info,
+                                             torch::jit::Stack &stack) {
+  DCHECK_EQ(getGraphHash(info.node, stack), info.hash)
+      << "Tried to run a graph with incompatible input shapes.";
+
+  size_t numInputs = info.inputPlaceholders.size();
+
+  auto inputs = torch::jit::last(stack, numInputs);
+
+  std::unique_ptr<ExecutionContext> ctx = llvm::make_unique<ExecutionContext>();
+  auto *bindings = ctx->getPlaceholderBindings();
+
+  for (size_t i = 0; i < numInputs; ++i) {
+    glow::Placeholder *ph = info.inputPlaceholders[i];
     glow::TypeRef ty = ph->getType();
     glow::Tensor t(inputs[i].toTensor().data_ptr(), ty);
-    bindings.insert(ph, std::move(t));
+    bindings->insert(ph, std::move(t));
   }
 
   std::vector<at::IValue> outputs;
-  for (auto *ph : outputPlaceholders) {
+  for (auto *ph : info.outputPlaceholders) {
     std::vector<int64_t> sizes;
     for (auto size : ph->dims()) {
       sizes.push_back(static_cast<int64_t>(size));
@@ -65,12 +111,11 @@ llvm::Error CachingGraphRunner::runGraph(const torch::jit::Node *node,
     glow::Tensor t(ptT.data_ptr(), ph->getType());
 
     outputs.push_back(std::move(ptT));
-    bindings.insert(ph, std::move(t));
+    bindings->insert(ph, std::move(t));
   }
 
-  glow::CompilationContext cctx;
-  executionEngine_.compile(cctx);
-  executionEngine_.run(bindings);
+  auto err =
+      hostManager_->runNetworkBlocking(info.functionName, std::move(ctx));
 
   torch::jit::drop(stack, numInputs);
 
@@ -79,13 +124,28 @@ llvm::Error CachingGraphRunner::runGraph(const torch::jit::Node *node,
     stack.push_back(at::IValue(var));
   }
 
+  return err;
+}
+
+llvm::Error CachingGraphRunner::runGraph(const torch::jit::Node *node,
+                                         torch::jit::Stack &stack) {
+  PerGlowGraphInfo *info;
+  ASSIGN_VALUE_OR_RETURN_ERR(info, loadGraphImpl(node, stack));
+  RETURN_IF_ERR(runGraphImpl(*DCHECK_NOTNULL(info), stack));
   return llvm::Error::success();
 }
 
-CachingGraphRunner *CachingGraphRunner::getGraphRunner() {
-  static auto runner_ =
-      std::unique_ptr<CachingGraphRunner>(new CachingGraphRunner());
-  return runner_.get();
-}
+CachingGraphRunner::CachingGraphRunner() {
+  constexpr size_t numGlowDevices = 1;
+  constexpr const char *glowBackendName = "Interpreter";
 
+  std::vector<std::unique_ptr<runtime::DeviceConfig>> deviceConfigs;
+  for (int i = 0; i < numGlowDevices; i++) {
+    deviceConfigs.push_back(
+        llvm::make_unique<runtime::DeviceConfig>(glowBackendName));
+  }
+
+  hostManager_ =
+      llvm::make_unique<runtime::HostManager>(std::move(deviceConfigs));
+}
 } // namespace glow

--- a/torch_glow/src/CachingGraphRunner.h
+++ b/torch_glow/src/CachingGraphRunner.h
@@ -17,10 +17,10 @@
 #ifndef GLOW_TORCH_GLOW_SRC_CACHINGGRAPHRUNNER_H
 #define GLOW_TORCH_GLOW_SRC_CACHINGGRAPHRUNNER_H
 
+#include "glow/Runtime/HostManager/HostManager.h"
+
 #include <torch/csrc/jit/custom_operator.h>
 #include <torch/csrc/jit/ir.h>
-
-#include "glow/Runtime/HostManager/HostManager.h"
 
 namespace glow {
 
@@ -33,10 +33,6 @@ class CachingGraphRunner {
 
     /// Name of the Glow function maintained by HostManager for this subgraph.
     std::string functionName;
-
-    /// The unique hash for the subgraph and input shapes represented by this
-    /// PerGlowGraphInfo.
-    size_t hash;
 
     /// The PyTorch node containing the subgraph that this PerGlowGraphInfo
     /// represents.
@@ -64,9 +60,9 @@ class CachingGraphRunner {
   llvm::Error runGraphImpl(const PerGlowGraphInfo &info,
                            torch::jit::Stack &stack);
 
-public:
   CachingGraphRunner();
 
+public:
   /// Given a PyTorch glow::FusionGroup Node \p node that contains a
   /// PyTorch subgraph and corresponding PyTorch Stack \p stack of inputs, run
   /// that subgraph on those inputs. If this is the first time this node has

--- a/torch_glow/src/CachingGraphRunner.h
+++ b/torch_glow/src/CachingGraphRunner.h
@@ -20,18 +20,52 @@
 #include <torch/csrc/jit/custom_operator.h>
 #include <torch/csrc/jit/ir.h>
 
-#include "glow/ExecutionEngine/ExecutionEngine.h"
+#include "glow/Runtime/HostManager/HostManager.h"
 
 namespace glow {
 
 /// Responsible for maintaining a mapping from PyTorch subgraphs and their
-/// unique input types to compiled Glow Functions.
+/// unique input types to a compiled Glow Function.
 class CachingGraphRunner {
-  /// Glow ExecutionEngine.
-  glow::ExecutionEngine executionEngine_;
+  struct PerGlowGraphInfo {
+    std::vector<glow::Placeholder *> inputPlaceholders;
+    std::vector<glow::Placeholder *> outputPlaceholders;
+
+    /// Name of the Glow function maintained by HostManager for this subgraph.
+    std::string functionName;
+
+    /// The unique hash for the subgraph and input shapes represented by this
+    /// PerGlowGraphInfo.
+    size_t hash;
+
+    /// The PyTorch node containing the subgraph that this PerGlowGraphInfo
+    /// represents.
+    const torch::jit::Node *node;
+  };
+
+  std::unique_ptr<runtime::HostManager> hostManager_;
+  std::unordered_map<size_t, std::unique_ptr<PerGlowGraphInfo>>
+      perGlowGraphInfoMap;
+
+  /// Given a PyTorch node \p node representing a fused subgraph of PyTorch
+  /// nodes and an input stack \p stack, this hashes the node and shape of the
+  /// inputs and checks to see if a matching function was loaded previously. If
+  /// a matching function was loaded previously then its cached
+  /// PerGlowGraphInfo is returned immediately. Otherwise this loads the
+  /// subgraph into the owned HostManager, creates a PerGlowGraphInfo which is
+  /// cached for the given node and the shapes of the inputs, and then \returns
+  /// this PerGlowGraphInfo.
+  llvm::Expected<PerGlowGraphInfo *> loadGraphImpl(const torch::jit::Node *node,
+                                                   torch::jit::Stack &stack);
+
+  /// Given a PerGlowGraphInfo \p info for a subgraph that was previously
+  /// loaded, this runs the Glow function that corresponds to that
+  /// PerGlowGraphInfo in the shape of the inputs with the given \p stack.
+  llvm::Error runGraphImpl(const PerGlowGraphInfo &info,
+                           torch::jit::Stack &stack);
 
 public:
-  CachingGraphRunner() = default;
+  CachingGraphRunner();
 
   /// Given a PyTorch glow::FusionGroup Node \p node that contains a
   /// PyTorch subgraph and corresponding PyTorch Stack \p stack of inputs, run

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -20,9 +20,6 @@
 #include <torch/csrc/jit/ir.h>
 
 namespace glow {
-
-class CachingGraphRunner;
-
 /// Various settings to be used by code that loads PyTorch models. There should
 /// only be one of these and it should be obtained by calling
 /// getPyTorchLoaderSettings().
@@ -33,6 +30,9 @@ struct PyTorchLoaderSettings {
   /// The PyTorch symbol used to identify the Node that contains PyTorch
   /// subgraphs that are compiled for running on Glow.
   bool weightFreezingEnabled = true;
+
+  /// Name of the Glow backend to use with CachingGraphRunner's HostManager.
+  std::string glowBackendName = "Interpreter";
 };
 
 /// \returns the PyTorchLoaderSettings singleton to be used throughout Glow's

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -43,6 +43,11 @@ class PyTorchModelLoader {
       std::unordered_map<const torch::jit::Value *, glow::NodeValue>;
   ValueMap valueMap_;
 
+  /// Indices of stack inputs that were frozen during loading. This set is
+  /// optionally provided by the user of PyTorchModelLoader and will be returned
+  /// to them after loading is complete.
+  std::set<size_t> *frozenInputIndices_ = nullptr;
+
   /// Values in the MappingOfMemberFunctions map. These values contain the
   /// information necessary to load PyTorch nodes such as which
   /// PyTorchModelLoader method to use and which inputs should be considered as
@@ -121,12 +126,15 @@ private:
   /// Takes a glow::Function \p F, a jit::Graph \p subgraph to load, and a
   /// stack of \p inputs for the subgraph to be loaded. Parameter \p settings
   /// control the fusion details. Output parameters \p inputPlaceholders and
-  /// \p outputPlaceholders are filled out.
+  /// \p outputPlaceholders are filled out. \p frozenInputIndices is an optional
+  /// parameter that, if provided, will be filled with the set of stack indices
+  /// that were frozen during loading.
   PyTorchModelLoader(glow::Function &F, torch::jit::Graph &subgraph,
                      at::ArrayRef<torch::jit::IValue> &inputs,
                      std::vector<glow::Placeholder *> &inputPlaceholders,
                      std::vector<glow::Placeholder *> &outputPlaceholders,
-                     llvm::Error &error, const PyTorchLoaderSettings &settings);
+                     llvm::Error &error, const PyTorchLoaderSettings &settings,
+                     std::set<size_t> *frozenInputIndices);
 
   /// Save access to the mapping.
   static const MappingOfMemberFunctions &getSymbolsMapping();

--- a/torch_glow/src/binding.cpp
+++ b/torch_glow/src/binding.cpp
@@ -16,7 +16,6 @@
 
 #include <pybind11/pybind11.h>
 
-#include "CachingGraphRunner.h"
 #include "PyTorchCommon.h"
 #include "PyTorchModelLoader.h"
 #include "TorchGlowTraining.h"


### PR DESCRIPTION
Summary:
Cache compiled Glow functions for each PyTorch subgraph.
Does not cache on input types yet.

Documentation:
Doxygen

Test Plan:
CI
Added prints to `loadGraphImpl` and checked that for each unit test, first time it is run it creates a new Glow function and caches it, second time it uses that cached function.