### PR TITLE
Added new priority_queue for ordering queded requests

### DIFF
--- a/examples/resnet-runtime.cpp
+++ b/examples/resnet-runtime.cpp
@@ -96,9 +96,8 @@ void dispatchClassify(unsigned int id, HostManager *hostManager,
                       std::promise<void> &finished) {
   auto runid = hostManager->runNetwork(
       "resnet50" + std::to_string(id), std::move(context),
-      [id, path, &returned,
-       &finished](RunIdentifierTy, llvm::Error err,
-                  std::unique_ptr<ExecutionContext> context) {
+      [path, &returned, &finished](RunIdentifierTy runid, llvm::Error err,
+                                   std::unique_ptr<ExecutionContext> context) {
         EXIT_ON_ERR(std::move(err));
         auto *bindings = context->getPlaceholderBindings();
         size_t maxIdx =
@@ -108,7 +107,7 @@ void dispatchClassify(unsigned int id, HostManager *hostManager,
                 .second;
         // This output is verified by OutputCheck in tests so must be written to
         // stdout.
-        llvm::outs() << "(" << id << ") " << path << ": " << maxIdx << "\n";
+        llvm::outs() << "(" << runid << ") " << path << ": " << maxIdx << "\n";
 
         if (!tracePath.empty()) {
           std::lock_guard<std::mutex> l(eventLock);

--- a/include/glow/Runtime/HostManager/HostManager.h
+++ b/include/glow/Runtime/HostManager/HostManager.h
@@ -23,6 +23,7 @@
 #include <atomic>
 #include <map>
 #include <mutex>
+#include <queue>
 #include <unordered_map>
 #include <vector>
 
@@ -50,6 +51,37 @@ class HostManager final {
     /// safety.
     std::atomic<size_t> refcount{0};
   };
+  /// Container for inference requests waiting in the queue.
+  struct InferRequest {
+    /// Name of the network the requested run is for.
+    std::string networkName;
+
+    /// The execution context for the request.
+    std::unique_ptr<ExecutionContext> context;
+
+    /// The user provided callback to run after execution finishes.
+    ResultCBTy callback;
+
+    /// The specified priority for the run.
+    uint64_t priority;
+
+    /// The runtime generated ID for the run request.
+    uint64_t requestID;
+
+    // Define greater than operator to allow sorting in priority_heap for queue
+    // reqests. If priority is the same fall back to order of submission.
+    bool operator>(const InferRequest &inferReq) const {
+      if (priority == inferReq.priority) {
+        return requestID > inferReq.requestID;
+      }
+      return priority > inferReq.priority;
+    }
+    InferRequest(std::string networkName,
+                 std::unique_ptr<ExecutionContext> context, ResultCBTy callback,
+                 uint64_t priority, uint64_t requestID)
+        : networkName{networkName}, context{std::move(context)},
+          callback{callback}, priority{priority}, requestID{requestID} {}
+  };
 
   /// Count of current in-flight networks being run. Atomic to allow
   /// concurrency in runNetwork.
@@ -58,6 +90,12 @@ class HostManager final {
   /// Count of total requests, this is used as a run ID. Atomic to allow
   /// concurrency in runNetwork.
   std::atomic<size_t> totalRequestCount_{0};
+
+  /// Priority queue for queued requests. This is a min-heap so lowest value is
+  /// popped first.
+  std::priority_queue<InferRequest, std::vector<InferRequest>,
+                      std::greater<InferRequest>>
+      inferQueue_;
 
   /// Configuration parameters for this Runtime Host.
   const HostConfig config_{};
@@ -87,6 +125,9 @@ class HostManager final {
 
   /// Set of networks in the process of being added.
   std::set<std::string> processingNetworks_;
+
+  /// Method to dispatch a new run to the executor.
+  void dispatchNextRun();
 
 public:
   /// Default constructor.
@@ -131,9 +172,12 @@ public:
   /// Note: This method is intended to be thread-safe, it will be called
   /// concurrently from multiple threads.
   /// Returns -1 if networkName not found or too many active requests.
+  /// The parameter \p priority is used to indicate queueing priority, priority
+  /// is lowest number first and in case of a tie the request that was submitted
+  /// first will go first.
   RunIdentifierTy runNetwork(llvm::StringRef networkName,
                              std::unique_ptr<ExecutionContext> context,
-                             ResultCBTy callback);
+                             ResultCBTy callback, uint64_t priority = 0);
 
   /// A wrapper around runNetwork that provides a blocking interface for an
   /// inference request. Runs the network provided in \p networkName using \p

--- a/include/glow/Runtime/RuntimeTypes.h
+++ b/include/glow/Runtime/RuntimeTypes.h
@@ -171,8 +171,10 @@ struct DeviceConfig {
 /// Options configuring Host components of the Runtime, such as the Partitioner
 /// and Executor.
 struct HostConfig {
-  /// Number of outstanding or concurrent networks before rate limiting.
-  size_t maxActiveRequests{100};
+  /// Number of outstanding or concurrent networks before queueing.
+  size_t maxActiveRequests{10};
+  /// Number of requests to queue up before refusing further requests.
+  size_t maxQueueSize{100};
   /// Number of threads to allocate to the Executor.
   size_t executorThreads{3};
 };

--- a/lib/Onnxifi/Base.h
+++ b/lib/Onnxifi/Base.h
@@ -63,7 +63,8 @@ public:
 
   virtual void runNetwork(const Graph *graph,
                           std::unique_ptr<ExecutionContext> context,
-                          runtime::ResultCBTy callback) {}
+                          runtime::ResultCBTy callback, uint64_t priority = 0) {
+  }
 
   virtual onnxStatus removeNetwork(const Graph *graph) {
     return ONNXIFI_STATUS_SUCCESS;

--- a/lib/Onnxifi/HostManagerOnnxifi.cpp
+++ b/lib/Onnxifi/HostManagerOnnxifi.cpp
@@ -52,12 +52,13 @@ HostManagerBackend::createHostManager(llvm::StringRef backendName) {
 
 void HostManagerBackend::runNetwork(const Graph *graph,
                                     std::unique_ptr<ExecutionContext> context,
-                                    runtime::ResultCBTy callback) {
+                                    runtime::ResultCBTy callback,
+                                    uint64_t priority) {
   DCHECK(callback != nullptr);
 
   auto hostManagerGraph = static_cast<const HostManagerGraph *>(graph);
   hostManager_->runNetwork(hostManagerGraph->getName(), std::move(context),
-                           std::move(callback));
+                           std::move(callback), priority);
 }
 
 onnxStatus HostManagerBackend::addNetwork(std::unique_ptr<Module> module) {

--- a/lib/Onnxifi/HostManagerOnnxifi.h
+++ b/lib/Onnxifi/HostManagerOnnxifi.h
@@ -33,7 +33,7 @@ public:
       : Backend(backendName, useOnnx), hostManager_(hostManager) {}
 
   void runNetwork(const Graph *graph, std::unique_ptr<ExecutionContext> context,
-                  runtime::ResultCBTy callback) override;
+                  runtime::ResultCBTy callback, uint64_t priority = 0) override;
 
   onnxStatus addNetwork(std::unique_ptr<Module> module);
 

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -316,10 +316,44 @@ llvm::Error HostManager::runNetworkBlocking(llvm::StringRef networkName,
   return std::move(*DCHECK_NOTNULL(runErr.get()));
 }
 
+void HostManager::dispatchNextRun() {
+
+  std::lock_guard<std::mutex> networkLock(networkLock_);
+  if (inferQueue_.size()) {
+    // Get the next request, unfortunately priority_queue only
+    // provides a const ref to the top element, since we need to move
+    // it we first cast it to remove the const.
+    auto request = std::move(const_cast<InferRequest &>(inferQueue_.top()));
+    inferQueue_.pop();
+    executor_->run(
+        networks_[request.networkName].dag.root.get(),
+        std::move(request.context), request.requestID,
+        [this, callback = request.callback, name = request.networkName](
+            RunIdentifierTy runID, llvm::Error err,
+            std::unique_ptr<ExecutionContext> context) {
+          {
+            std::lock_guard<std::mutex> networkLock(networkLock_);
+            auto it = networks_.find(name);
+            if (it != networks_.end()) {
+              it->second.refcount--;
+            }
+          }
+          TRACE_EVENT_INSTANT(context->getTraceContext(), TraceLevel::RUNTIME,
+                              "finish_" + name);
+          callback(runID, std::move(err), std::move(context));
+          dispatchNextRun();
+        });
+  } else {
+    // Decrement the activeRequest counter so new requests can
+    // launched.
+    --activeRequestCount_;
+  }
+}
+
 RunIdentifierTy
 HostManager::runNetwork(llvm::StringRef networkName,
                         std::unique_ptr<ExecutionContext> context,
-                        ResultCBTy callback) {
+                        ResultCBTy callback, uint64_t priority) {
   DCHECK(callback != nullptr);
 
   TRACE_EVENT_SCOPE(context->getTraceContext(), TraceLevel::RUNTIME,
@@ -334,47 +368,43 @@ HostManager::runNetwork(llvm::StringRef networkName,
       network = &it->second;
       network->refcount++;
     }
+
+    if (network == nullptr) {
+      callback(
+          currentRun,
+          MAKE_ERR(GlowErr::ErrorCode::RUNTIME_NET_NOT_FOUND,
+                   llvm::formatv("Function {0} not found", networkName).str()),
+          std::move(context));
+      return currentRun;
+    }
+    // Setup the request
+    InferRequest queuedRequest(networkName, std::move(context), callback,
+                               priority, currentRun);
+    // Put the request in the queue.
+    auto queueSize = inferQueue_.size();
+    if (queueSize >= config_.maxQueueSize) {
+      // The queue is full, return an error.
+      network->refcount--;
+      callback(
+          currentRun,
+          MAKE_ERR(
+              GlowErr::ErrorCode::RUNTIME_REQUEST_REFUSED,
+              strFormat(
+                  "The number of allowed queued requests has been exceeded. "
+                  "queued requests: %lu allowed requests: %zu",
+                  queueSize, config_.maxQueueSize)),
+          std::move(context));
+      return currentRun;
+    }
+    inferQueue_.push(std::move(queuedRequest));
   }
 
-  if (network == nullptr) {
-    callback(
-        currentRun,
-        MAKE_ERR(GlowErr::ErrorCode::RUNTIME_NET_NOT_FOUND,
-                 llvm::formatv("Function {0} not found", networkName).str()),
-        std::move(context));
-    return currentRun;
-  }
-
+  // If we haven't reached maxActiveRequests kick off next request.
   size_t activeRequestCount = activeRequestCount_++;
-  if (activeRequestCount >= config_.maxActiveRequests) {
-    activeRequestCount_--;
-    network->refcount--;
-    callback(
-        currentRun,
-        MAKE_ERR(GlowErr::ErrorCode::RUNTIME_REQUEST_REFUSED,
-                 strFormat("The number of allowed requests has been exceeded. "
-                           "active requests: %lu allowed requests: %zu",
-                           activeRequestCount, config_.maxActiveRequests)),
-        std::move(context));
+  if (activeRequestCount < config_.maxActiveRequests) {
+    dispatchNextRun();
     return currentRun;
   }
-
-  executor_->run(networks_[networkName].dag.root.get(), std::move(context),
-                 currentRun,
-                 [this, callback, name = networkName.str()](
-                     RunIdentifierTy runID, llvm::Error err,
-                     std::unique_ptr<ExecutionContext> context) {
-                   {
-                     std::lock_guard<std::mutex> networkLock(networkLock_);
-                     auto it = networks_.find(name);
-                     if (it != networks_.end()) {
-                       it->second.refcount--;
-                     }
-                   }
-                   TRACE_EVENT_INSTANT(context->getTraceContext(),
-                                       TraceLevel::RUNTIME, "finish_" + name);
-                   callback(runID, std::move(err), std::move(context));
-                   --activeRequestCount_;
-                 });
+  activeRequestCount_--;
   return currentRun;
 }

--- a/tests/unittests/HostManagerTest.cpp
+++ b/tests/unittests/HostManagerTest.cpp
@@ -188,6 +188,7 @@ TEST_F(HostManagerTest, ConcurrentAddRemoveDuplicate) {
 TEST_F(HostManagerTest, ConfigureHostManager) {
   HostConfig config;
   config.maxActiveRequests = 1;
+  config.maxQueueSize = 0;
   auto hostManager = createHostManager("Interpreter", std::move(config));
 
   EXPECT_FALSE(errToBool(addNetwork(hostManager.get(), "main")));
@@ -205,7 +206,6 @@ TEST_F(HostManagerTest, ConfigureHostManager) {
                           [lock](RunIdentifierTy runID, llvm::Error err,
                                  std::unique_ptr<ExecutionContext> context_) {
                             errToBool(std::move(err));
-                            std::unique_lock<std::mutex> guard(*lock);
                           });
 
   hostManager->runNetwork(
@@ -214,8 +214,68 @@ TEST_F(HostManagerTest, ConfigureHostManager) {
                 std::unique_ptr<ExecutionContext> context_) {
         runErr = llvm::make_unique<llvm::Error>(std::move(err));
       });
-
+  guard.unlock();
   // Don't need a future, error CB called inline.
   EXPECT_TRUE(errToBool(std::move(*DCHECK_NOTNULL(runErr.get()))));
-  guard.unlock();
+}
+
+/// Test that the HostManager properly enqueues requests.
+TEST_F(HostManagerTest, QueueTest) {
+  HostConfig config;
+  // Setup the hostmanager to allow 1 active and 2 queued requests for a total
+  // of 3 requests in the system.
+  config.maxActiveRequests = 1;
+  auto hostManager = createHostManager("Interpreter", std::move(config));
+
+  EXPECT_FALSE(errToBool(addNetwork(hostManager.get(), "main")));
+
+  auto context = llvm::make_unique<ExecutionContext>();
+  auto context2 = llvm::make_unique<ExecutionContext>();
+  auto context3 = llvm::make_unique<ExecutionContext>();
+  auto context4 = llvm::make_unique<ExecutionContext>();
+  std::promise<unsigned> run1p, run2p, run3p, dispatched;
+  auto dispatchDone = dispatched.get_future();
+  auto run1f = run1p.get_future();
+  auto run2f = run2p.get_future();
+  auto run3f = run3p.get_future();
+  std::atomic<unsigned> counter{0};
+
+  // The first will go right to dispatch since there will be no inflight
+  // requests.
+  hostManager->runNetwork("main", std::move(context),
+                          [&run1p, &counter, &dispatchDone](
+                              RunIdentifierTy runID, llvm::Error err,
+                              std::unique_ptr<ExecutionContext> context) {
+                            EXIT_ON_ERR(std::move(err));
+                            run1p.set_value(counter++);
+                            dispatchDone.wait();
+                          });
+  // Set the priority of the second to 1.
+  hostManager->runNetwork(
+      "main", std::move(context2),
+      [&run2p, &counter](RunIdentifierTy runID, llvm::Error err,
+                         std::unique_ptr<ExecutionContext> context) {
+        EXIT_ON_ERR(std::move(err));
+        run2p.set_value(counter++);
+      },
+      1);
+
+  // Set the priority of the run3 to 0 so it should be first in the queue
+  // after run1.
+  hostManager->runNetwork(
+      "main", std::move(context3),
+      [&run3p, &counter](RunIdentifierTy runID, llvm::Error err,
+                         std::unique_ptr<ExecutionContext> context) {
+        EXIT_ON_ERR(std::move(err));
+        run3p.set_value(counter++);
+      },
+      0);
+  /// Wait for all three to finish.
+  dispatched.set_value(0);
+  auto res1 = run1f.get();
+  auto res2 = run2f.get();
+  auto res3 = run3f.get();
+  // Should expect them to finish in order: 1, 3, 2. Check atomic value
+  EXPECT_GT(res3, res1);
+  EXPECT_GT(res2, res3);
 }


### PR DESCRIPTION
Summary: This PR adds an optional priority field to runNetwork on HostManager. Also it adds a priority queue. 
When a request is made of the HostManager the following happens:
The request is added to the priorityQueue if the max queue size limit has been reached return an error immediately. 
If there are less active requests than the activeRequestLimit dispatchNextRun() is called.
If the activeLimit has been reached return.


Documentation: Updated in code documentation for new data structure and priority parameter in runNetwork.


Test Plan: Added a new QueueTest to HostManagerTest. 