### PR TITLE
Don't -instrument-debug TensorView nodes.

### DIFF
--- a/lib/Optimizer/IROptimizer/IROptimizer.cpp
+++ b/lib/Optimizer/IROptimizer/IROptimizer.cpp
@@ -1509,6 +1509,12 @@ static void performDebugInstrumentation(IRFunction &M) {
       it = next;
       continue;
     }
+    // Don't instrument tensorview since it can lead to liveness verification
+    // failures if the tensorview happens before any writes to the tensor.
+    if (isa<TensorViewInst>(I)) {
+      it = next;
+      continue;
+    }
     auto instrName = I->getName();
     for (const auto &Op : I->getOperands()) {
       // Dump inputs of the current instruction before the instruction.


### PR DESCRIPTION
Summary:
Don't instrument tensorview since a) it isn't really useful and b) it can lead
to liveness verification failures if the tensorview happens before any writes to
the tensor.

Test Plan:
Ran integrated tests with RA and Debug builds.