### PR TITLE
Expose binding.cpp glow integration functions publicly.

### DIFF
--- a/torch_glow/src/binding.cpp
+++ b/torch_glow/src/binding.cpp
@@ -69,6 +69,12 @@ void registerPass() {
 }
 } // namespace
 
+// Integrate Glow PyTorch compilation pass.
+void integrateGlowPyTorchPass() {
+  registerGlowOp();
+  registerPass();
+}
+
 /// The torch_glow pybind11 module.
 PYBIND11_MODULE(_torch_glow, m) {
   registerGlowOp();

--- a/torch_glow/src/binding.h
+++ b/torch_glow/src/binding.h
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace glow {
+
+// Add Glow Compilation Pass into PyTorch.
+void integrateGlowPyTorchPass();
+
+} // namespace glow
+


### PR DESCRIPTION
Make registerGlowOp and registerPass publicly available through
integrateGlowPytorchPass function.

Summary: Expose Glow Pass integration functions publicly.

Documentation:

[Optional Fixes #issue]

Test Plan: Small compilation change.

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
