### PR TITLE
Refactor HostManager and Provisioner to lessen locking in addNetwork

### DIFF
--- a/include/glow/Runtime/Provisioner/Provisioner.h
+++ b/include/glow/Runtime/Provisioner/Provisioner.h
@@ -42,7 +42,7 @@ public:
                         CompilationContext &cctx);
 
   /// Remove stored compiledFunction.
-  void removeFunction(llvm::StringRef name);
+  llvm::Error removeFunction(llvm::StringRef name);
 
 private:
   /// Pointer to backend used for compilation. This currently gets reset per
@@ -53,8 +53,19 @@ private:
   /// functions.
   std::unordered_map<std::string, std::unique_ptr<CompiledFunction>> functions_;
 
+  /// Set of active functions - these are functions that are currently being
+  /// compiled/added to devices.
+  std::set<std::string> activeFunctions_;
+
+  /// Mutex for functions_ and activeFunctions_ since add/remove can be called
+  /// from multiple threads simultaneously.
+  std::mutex functionsLock_;
+
   /// List of available DeviceManagers added during initialization.
   std::vector<DeviceManager *> devices_;
+
+  /// Helper function to cleanup a failed provision call.
+  void cleanupProvision(llvm::ArrayRef<std::string> names);
 };
 } // namespace runtime
 } // namespace glow

--- a/lib/Backends/CPU/CPUDeviceManager.h
+++ b/lib/Backends/CPU/CPUDeviceManager.h
@@ -19,6 +19,8 @@
 #include "glow/Backends/QueueBackedDeviceManager.h"
 #include "glow/Runtime/StatsExporter.h"
 
+#include <atomic>
+
 namespace glow {
 namespace runtime {
 
@@ -31,10 +33,10 @@ class CPUDeviceManager : public QueueBackedDeviceManager {
 
   /// Maximum available memory on the device, for CPU devices fix to some
   /// constant.
-  uint64_t maxMemoryBytes_{0};
+  std::atomic<uint64_t> maxMemoryBytes_{0};
 
   /// Amount of memory used by all models.
-  uint64_t usedMemoryBytes_{0};
+  std::atomic<uint64_t> usedMemoryBytes_{0};
 
   /// Static memory cost of the CPU Function.
   /// This is very arbitrary for the CPU backend.

--- a/lib/Backends/Interpreter/InterpreterDeviceManager.h
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.h
@@ -31,10 +31,10 @@ class InterpreterDeviceManager : public QueueBackedDeviceManager {
 
   /// Maximum available memory on the device, for local devices fix to some
   /// constant.
-  uint64_t maxMemoryBytes_{0};
+  std::atomic<uint64_t> maxMemoryBytes_{0};
 
   /// Amount of memory used by all models.
-  uint64_t usedMemoryBytes_{0};
+  std::atomic<uint64_t> usedMemoryBytes_{0};
 
   /// Static memory cost of the InterpreterFunction.
   /// This is very arbitrary for the Interpreter backend.

--- a/lib/Backends/OpenCL/OpenCLDeviceManager.h
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.h
@@ -18,6 +18,8 @@
 
 #include "glow/Backends/QueueBackedDeviceManager.h"
 
+#include <atomic>
+
 #if defined(__APPLE__) || defined(__MACOSX)
 #include "OpenCL/opencl.h"
 #else
@@ -132,10 +134,10 @@ class OpenCLDeviceManager : public QueueBackedDeviceManager {
   std::unordered_map<std::string, cl_program> programs_;
 
   /// Maximum available memory on the device.
-  uint64_t maxMemoryBytes_{0};
+  std::atomic<uint64_t> maxMemoryBytes_{0};
 
   /// Amount of memory used by all models.
-  uint64_t usedMemoryBytes_{0};
+  std::atomic<uint64_t> usedMemoryBytes_{0};
 
   /// CL compute device id.
   cl_device_id deviceId_;

--- a/lib/Optimizer/GraphOptimizer/PassManager.cpp
+++ b/lib/Optimizer/GraphOptimizer/PassManager.cpp
@@ -23,6 +23,8 @@
 
 #include <glog/logging.h>
 
+#include <atomic>
+
 using namespace glow;
 
 namespace {
@@ -104,7 +106,7 @@ static bool listContainsString(llvm::ArrayRef<std::string> strList,
 }
 
 /// Global pass counter used to identify each pass.
-static unsigned globalPassCounter = 0;
+static std::atomic<unsigned> globalPassCounter{0};
 
 } // namespace
 

--- a/tests/unittests/HostManagerTest.cpp
+++ b/tests/unittests/HostManagerTest.cpp
@@ -68,7 +68,9 @@ llvm::Error addNetwork(HostManager *manager, std::string name) {
 void addAndRemoveNetwork(HostManager *manager, unsigned int functionNumber) {
   std::string name = "function" + std::to_string(functionNumber);
   errToBool(addNetwork(manager, name));
-  EXPECT_FALSE(errToBool(manager->removeNetwork(name)));
+  // Removal can return an error if the network is in the process of being
+  // added. That is fine we expect it in this test.
+  errToBool(manager->removeNetwork(name));
 }
 
 TEST_F(HostManagerTest, newHostManager) { createHostManager("CPU"); }

--- a/tests/unittests/ProvisionerTest.cpp
+++ b/tests/unittests/ProvisionerTest.cpp
@@ -79,7 +79,7 @@ TEST_F(ProvisionerTest, provisionDag) {
   }
 
   CompilationContext cctx;
-  auto provisioner = Provisioner(devices);
+  Provisioner provisioner(devices);
   auto err = provisioner.provision(networks, *mod.get(), cctx);
   // Expect that there was no Error when provisioning
   EXPECT_FALSE(errToBool(std::move(err)));
@@ -98,8 +98,8 @@ TEST_F(ProvisionerTest, provisionDagFail) {
   }
 
   CompilationContext cctx;
-  auto provisioner = Provisioner(devices);
+  Provisioner provisioner(devices);
   auto err = provisioner.provision(networks, *mod.get(), cctx);
-  // Expect that there was no Error when provisioning
+  // Expect that there was an Error when provisioning
   EXPECT_TRUE(errToBool(std::move(err)));
 }


### PR DESCRIPTION


Summary:
This PR refactors HostManager::addNetwork and the Provisioner. Compiling functions no longer happens under lock.
If a network is in the process of being added and a new add or remove call is made targeting the same network name an error is returned that the network specified is busy.

Documentation:

Fixes #2842 

Test Plan: Ninja check and verify tests pass.
