### PR TITLE
Fix pt test segfault

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -28,12 +28,13 @@ namespace {
 
 /// \returns a corresponding Glow Type for a given PyTorch CompleteTensorType \p
 /// ptType.
-inline glow::Type ptTypeToGlowType(const c10::ProfiledTensorType &ptType) {
+/// TODO: switch to ProfiledTensorType
+inline glow::Type ptTypeToGlowType(const at::CompleteTensorType &ptType) {
   // TODO: get correct ElemKind
-  DCHECK_EQ(*ptType.scalarType(), at::kFloat)
+  DCHECK_EQ(ptType.scalarType(), at::kFloat)
       << "Only float type supported currently.";
   std::vector<size_t> dims;
-  for (auto &size : ptType.sizes().concrete_sizes().value()) {
+  for (auto &size : ptType.sizes()) {
     dims.push_back(size);
   }
   return glow::Type(glow::ElemKind::FloatTy, dims);
@@ -522,7 +523,7 @@ PyTorchModelLoader::loadValue(const torch::jit::Value *value) {
   RETURN_ERR_IF_NOT(value->isCompleteTensor(),
                     glow::strFormat("Value %s must have CompleteTensor type.",
                                     value->debugNameBase().c_str()));
-  auto ptType = value->type()->cast<at::ProfiledTensorType>();
+  auto ptType = value->type()->cast<at::CompleteTensorType>();
   auto glowType = ptTypeToGlowType(*ptType.get());
   glow::Placeholder *ph = F_.getParent()->createPlaceholder(
       &glowType, "input", /*isTrainable*/ false);


### PR DESCRIPTION
Summary:
Revert glow changes in https://github.com/pytorch/pytorch/pull/24169
PT was updated to use ProfiledTensorType but this breaks glow because we aren't using profiling exeuctor yet.
 
Documentation:
n/a

Test Plan:
CI
