### PR TITLE
[Importer] Error out if bias specified but failed to load (#3216)

### DIFF
--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -605,7 +605,7 @@ llvm::Error ONNXModelLoader::loadConv(const ONNX_NAMESPACE::NodeProto &op,
   if (op.input_size() > 2) {
     auto &biasTensorName = op.input(2);
     // Load the serialized bias vector.
-    bias = getConstantByNameOrNull(biasTensorName);
+    ASSIGN_VALUE_OR_RETURN_ERR(bias, getConstantByName(biasTensorName));
   }
 
   // If a serialized bias wasn't found then create a zero bias.

--- a/tests/models/onnxModels/simpleConvBiasFail.onnxtxt
+++ b/tests/models/onnxModels/simpleConvBiasFail.onnxtxt
@@ -1,0 +1,139 @@
+ir_version: 3
+producer_name: "onnx-conv"
+graph {
+  node {
+    input: "data"
+    input: "W"
+    input: "Q"
+    output: "y"
+    name: "conv1"
+    op_type: "Conv"
+    attribute {
+      name: "kernel_shape"
+      ints: 2
+      ints: 2
+      type: INTS
+    }
+    attribute {
+      name: "pads"
+      ints: 1
+      ints: 1
+      ints: 1
+      ints: 1
+      type: INTS
+    }
+    attribute {
+      name: "strides"
+      ints: 1
+      ints: 1
+      type: INTS
+    }
+    attribute {
+      name: "dilations"
+      ints: 1
+      ints: 1
+      type: INTS
+    }    
+  }
+  name: "test-model"
+  initializer {
+    dims: 1
+    dims: 1
+    dims: 2
+    dims: 2
+    data_type: 1
+    float_data: 1.0
+    float_data: 1.0
+    float_data: 1.0
+    float_data: 1.0
+    name: "W"
+  }
+  initializer {
+    dims: 1
+    data_type: 1
+    float_data: 2.0
+    name: "B"
+  }
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "W"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "B"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 4
+}

--- a/tests/unittests/OnnxExporterTest.cpp
+++ b/tests/unittests/OnnxExporterTest.cpp
@@ -94,6 +94,7 @@ TEST(exporter, onnxModels) {
         name.find("castToFloat16.onnxtxt") != std::string::npos ||
         name.find("castToInt64.onnxtxt") != std::string::npos ||
         name.find("castToInt32.onnxtxt") != std::string::npos ||
+        name.find("simpleConvBiasFail.onnxtxt") != std::string::npos ||
         name.find("Where.onnxtxt") != std::string::npos ||
         name.find("constantOfShapeInt64Fail.onnxtxt") != std::string::npos) {
       // Ignore invalid ONNX files and graphs without nodes.

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -576,6 +576,32 @@ static void convTestHelper(std::string &filename,
   }
 }
 
+/// Test to ensure error handling for missing bias
+/// input is handled correctly. Remaining input is
+/// still sane to make sure it only fails for the
+/// intended case.
+TEST(onnx, importConvBiasFail) {
+
+  ExecutionEngine EE{};
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+
+  std::string NetFilename(GLOW_DATA_PATH
+                          "tests/models/onnxModels/simpleConvBiasFail.onnxtxt");
+  
+  // Destroy the loader after the graph is loaded since the following execution
+  // will not depend on anyting from the loader.
+  {
+    Tensor data;
+    getNCHWData(&data, 1, 1, 3, 3);
+    //	Tensor data(ElemKind::FloatTy, {1, 3, 32, 32, 32});
+    //	ONNXModelLoader(NetFilename, {"data"}, {&data.getType()}, *F);
+    EXPECT_DEATH(ONNXModelLoader(NetFilename, {"data"}, {&data.getType()}, *F),
+                 "");
+  }
+
+}
+
 /// Test loading conv op from a ONNX model.
 /// The input is N*C*H*W (1*1*3*3), the kernels is {2, 2},
 /// strides is {1, 1}, pads is {1, 1, 1, 1}, group is 1.

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -576,31 +576,6 @@ static void convTestHelper(std::string &filename,
   }
 }
 
-/// Test to ensure error handling for missing bias
-/// input is handled correctly. Remaining input is
-/// still sane to make sure it only fails for the
-/// intended case.
-TEST(onnx, importConvBiasFail) {
-
-  ExecutionEngine EE{};
-  auto &mod = EE.getModule();
-  Function *F = mod.createFunction("main");
-
-  std::string NetFilename(GLOW_DATA_PATH
-                          "tests/models/onnxModels/simpleConvBiasFail.onnxtxt");
-  
-  // Destroy the loader after the graph is loaded since the following execution
-  // will not depend on anyting from the loader.
-  {
-    Tensor data;
-    getNCHWData(&data, 1, 1, 3, 3);
-
-    EXPECT_DEATH(ONNXModelLoader(NetFilename, {"data"}, {&data.getType()}, *F),
-                 "");
-  }
-
-}
-
 /// Test loading conv op from a ONNX model.
 /// The input is N*C*H*W (1*1*3*3), the kernels is {2, 2},
 /// strides is {1, 1}, pads is {1, 1, 1, 1}, group is 1.
@@ -640,6 +615,29 @@ TEST(onnx, importConvAutoPadSameLower) {
   std::vector<size_t> expectedDims = {1, 1, 3, 3};
   std::vector<float> expectedValues = {2, 3, 5, 5, 10, 14, 11, 22, 26};
   convTestHelper(filename, expectedDims, expectedValues);
+}
+
+/// Test to ensure error handling for missing bias
+/// input is handled correctly. Remaining input is
+/// still sane to make sure it only fails for the
+/// intended case.
+TEST(onnx, importConvBiasFail) {
+  ExecutionEngine EE{};
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+
+  std::string NetFilename(GLOW_DATA_PATH
+                          "tests/models/onnxModels/simpleConvBiasFail.onnxtxt");
+
+  // Destroy the loader after the graph is loaded since the following execution
+  // will not depend on anyting from the loader.
+  {
+    Tensor data;
+    getNCHWData(&data, 1, 1, 3, 3);
+
+    EXPECT_DEATH(ONNXModelLoader(NetFilename, {"data"}, {&data.getType()}, *F),
+                 "");
+  }
 }
 
 /// Helper method to run the AveragePool operator test cases.

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -594,8 +594,7 @@ TEST(onnx, importConvBiasFail) {
   {
     Tensor data;
     getNCHWData(&data, 1, 1, 3, 3);
-    //	Tensor data(ElemKind::FloatTy, {1, 3, 32, 32, 32});
-    //	ONNXModelLoader(NetFilename, {"data"}, {&data.getType()}, *F);
+
     EXPECT_DEATH(ONNXModelLoader(NetFilename, {"data"}, {&data.getType()}, *F),
                  "");
   }


### PR DESCRIPTION
Summary
Return error if a bias was specified for the Conv operator but
it failed to load. Previous behavior was to (silently) use a
default bias. This change makes the failure explicit for better
handling downstream.

Documentation:
N/A

[Optional Fixes #issue]
Fixes #3216

Test Plan:
Unit tests 100% passing

