### PR TITLE
[PyTorch] Use ProfiledTensorType

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -128,7 +128,7 @@ elif [[ "$CIRCLE_JOB" == "PYTORCH" ]]; then
     source venv/bin/activate
     git clone https://github.com/pytorch/pytorch.git --recursive
     cd pytorch
-    git checkout 3b5daef6dec7b541a74e33a9a0b0646941b0440d
+    git checkout 7f86fb8995d9990fe1eac5a18335523cb3da7f09
     pip install -r requirements.txt
     python setup.py install
     cd ${GLOW_DIR}

--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -28,15 +28,18 @@ namespace {
 
 /// \returns a corresponding Glow Type for a given PyTorch CompleteTensorType \p
 /// ptType.
-/// TODO: switch to ProfiledTensorType
-inline glow::Type ptTypeToGlowType(const at::CompleteTensorType &ptType) {
+inline glow::Type ptTypeToGlowType(const c10::ProfiledTensorType &ptType) {
   // TODO: get correct ElemKind
-  DCHECK_EQ(ptType.scalarType(), at::kFloat)
+  DCHECK_EQ(*ptType.scalarType(), at::kFloat)
       << "Only float type supported currently.";
+
+  const auto concreteSizes = ptType.sizes().concrete_sizes().value();
+
   std::vector<size_t> dims;
-  for (auto &size : ptType.sizes()) {
-    dims.push_back(size);
+  for (const auto &size : concreteSizes) {
+    dims.push_back(static_cast<size_t>(size));
   }
+
   return glow::Type(glow::ElemKind::FloatTy, dims);
 }
 
@@ -523,8 +526,8 @@ PyTorchModelLoader::loadValue(const torch::jit::Value *value) {
   RETURN_ERR_IF_NOT(value->isCompleteTensor(),
                     glow::strFormat("Value %s must have CompleteTensor type.",
                                     value->debugNameBase().c_str()));
-  auto ptType = value->type()->cast<at::CompleteTensorType>();
-  auto glowType = ptTypeToGlowType(*ptType.get());
+  auto glowType =
+      ptTypeToGlowType(*value->type()->expect<at::ProfiledTensorType>());
   glow::Placeholder *ph = F_.getParent()->createPlaceholder(
       &glowType, "input", /*isTrainable*/ false);
   RETURN_IF_ERR(addGlowNodeValue(value, ph->getOutput()));


### PR DESCRIPTION
Summary:
Fixes glow build.
All the other tensor types went away so we'll use this one. Eventually we should enable (at least under a flag) the profiling executor but for now we just create ProfiledTensorTypes manually from graph inputs.

Documentation:
n/a

Test Plan:
python setup.py test
