### PR TITLE
Fix quantization when doing parallel clone testing; add check for bitwise accuracy

### DIFF
--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -294,6 +294,11 @@ protected:
       if (val.getElementType() == ElemKind::FloatTy) {
         needsQuantization = true;
         if (!quantizationParamsExist(val)) {
+          CHECK(!assertAllNodesQuantized_)
+              << "Quantization parameters did not exist for an input NodeValue "
+                 "that should have been quantized; input number "
+              << idx << " of node:\n"
+              << node.getDebugDesc();
           return false;
         }
       }
@@ -305,6 +310,11 @@ protected:
       if (val.getElementType() == ElemKind::FloatTy) {
         needsQuantization = true;
         if (!quantizationParamsExist(val)) {
+          CHECK(!assertAllNodesQuantized_)
+              << "Quantization parameters did not exist for a result of a Node "
+                 "that should have been quantized; result number "
+              << idx << " of node:\n"
+              << node.getDebugDesc();
           return false;
         }
       }

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -239,9 +239,12 @@ void compareAgainstInterpreter(
 /// Given some \p FTP representing a Function with a single SaveNode and its
 /// Tensor output, duplicate the Nodes in the Function and their Placeholder
 /// inputs given \p bindings \p parallelCount times. \returns a set of Tensor
-/// pointers for each output of the cloned Function.
+/// pointers for each output of the cloned Function. If the quantization node
+/// info found in \p cctx exists, then all of the node infos will be cloned
+/// accordingly with the names of the newly cloned nodes added to the Function.
 std::unordered_set<Tensor *> cloneFunInsideFun(FunctionTensorPair FTP,
                                                PlaceholderBindings *bindings,
+                                               CompilationContext &cctx,
                                                unsigned parallelCount);
 
 void inferConvNet(Tensor *inputs, Tensor *filter, Tensor *bias, Tensor *out,

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -960,13 +960,14 @@ TEST_P(OperatorTest, matmul_ParCloneTest10) {
   auto *save = F_->createSave("save", R);
   auto *saveTensor = bindings_.allocate(save->getPlaceholder());
 
+  CompilationContext cctx;
   const unsigned parallelCount = 10;
   auto resultTensors = cloneFunInsideFun(std::make_pair(F_, saveTensor),
-                                         &bindings_, parallelCount);
+                                         &bindings_, cctx, parallelCount);
 
   EXPECT_EQ(resultTensors.size(), parallelCount);
 
-  EE_.compile(CompilationMode::Infer);
+  EE_.compile(cctx);
   EE_.run(bindings_);
 
   for (Tensor *T : resultTensors) {


### PR DESCRIPTION
Summary: Previously we were only checking the results from parallel clones against the interpreter result within some threshold. With this change we will also check that all of the parallel clone results from the backend are bitwise accurate.

When implementing this I found that things were currently broken; the quantizer was not erroring out when it should have been (fixed in 1st commit). Additionally we were not copying over the quantization infos for the cloned nodes to find their correct quantization parameters, so without the check from the 1st commit those nodes were just not being quantized.

Test Plan: All tests still pass with the added check; also ran OperatorTests with `--parallel-clone-count=10`.