### PR TITLE
Enable saturateHost in image-classifier and address a couple resulting bugs

### DIFF
--- a/include/glow/LLVMIRCodeGen/LLVMCompiledFunction.h
+++ b/include/glow/LLVMIRCodeGen/LLVMCompiledFunction.h
@@ -53,6 +53,10 @@ protected:
   /// The LLVM JIT engine. The jit must be initialized after the ctor
   /// initializes the LLVM backends.
   std::unique_ptr<llvm::orc::GlowJIT> JIT_;
+
+  /// The JIT can be accessed from multiple threads but is not thread safe,
+  /// JITLock_ protects it.
+  std::mutex JITLock_;
 };
 } // end namespace glow
 

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -94,8 +94,6 @@ class OpenCLFunction final : public CompiledFunction {
   /// would result in different programs.
   std::unordered_map<ProgramKey, cl_program, ProgramKeyHash> programsCache_;
 
-  /// Information about kernel launches.
-  std::vector<KernelLaunch> kernelLaunches_;
   /// is kernel level profiling (autoInstrumentation) enabled.
   bool kernelProfiling_{false};
   /// Manual trace events:
@@ -133,22 +131,25 @@ private:
   /// \returns number of copied bytes.
   uint64_t copyValueFromDevice(const Value *v,
                                runtime::OpenCLDeviceBindings *devBindings,
+                               std::vector<KernelLaunch> &kernelLaunches,
                                void *buf = nullptr);
   /// Copy value from the provided buffer to the device.
   /// \returns number of copied bytes.
   uint64_t copyValueToDevice(const Value *v,
                              runtime::OpenCLDeviceBindings *devBindings,
+                             std::vector<KernelLaunch> &kernelLaunches,
                              void *buf = nullptr);
   /// Fill the device \p buffer with a given \p value.
   /// \param len number of buffer elements to be filled by the \p value.
   /// Elements are considered to be of the type described by \p elemKind.
   void fillBuffer(cl_mem buffer, uint64_t start, uint64_t len, float value,
-                  ElemKind elemKind,
-                  runtime::OpenCLDeviceBindings *devBindings);
+                  ElemKind elemKind, runtime::OpenCLDeviceBindings *devBindings,
+                  std::vector<KernelLaunch> &kernelLaunches);
 
   /// Execution a convolution instruction which uses NCHW format.
   void executeNCHWConvolution(const ConvolutionInst *CC,
-                              ExecutionContext *executionContext);
+                              ExecutionContext *executionContext,
+                              std::vector<KernelLaunch> &kernelLaunches);
   /// Allocate a device buffer of required \p size.
   cl_mem allocDeviceBuffer(uint64_t size, cl_context clContext);
   /// Frees a device buffer.
@@ -174,14 +175,17 @@ private:
 
   /// Load inputs from \p bindings onto the device.
   void loadPlaceholders(PlaceholderBindings *bindings,
-                        runtime::OpenCLDeviceBindings *devBindings);
+                        runtime::OpenCLDeviceBindings *devBindings,
+                        std::vector<KernelLaunch> &kernelLaunches);
 
   /// Load outputs from the device into \p bindings.
   void updatePlaceholders(PlaceholderBindings *bindings,
-                          runtime::OpenCLDeviceBindings *devBindings);
+                          runtime::OpenCLDeviceBindings *devBindings,
+                          std::vector<KernelLaunch> &kernelLaunches);
 
   /// Read trace events out of this func and write them into /p bindings
-  void translateTraceEvents(ExecutionContext *context) const override;
+  void translateTraceEventsCL(ExecutionContext *context,
+                              std::vector<KernelLaunch> &kernelLaunches);
 };
 
 /// This is the OpenCL backend.

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -419,7 +419,7 @@ void Loader::compile(CompilationContext &cctx) {
                    mainEntryName.empty() ? networkName : mainEntryName);
   } else {
     // Emit IR for the graph and compile it.
-    auto error = hostManager_->addNetwork(std::move(M_), cctx);
+    auto error = hostManager_->addNetwork(std::move(M_), cctx, true);
     EXIT_ON_ERR(std::move(error));
     // After partitioning, the original function may be removed. Need to update
     // F_.


### PR DESCRIPTION
Summary:
This PR enables saturate host in image-classifier, so now if multiple devices are created they will be used. 
As a result of this change bugs in OpenCL and CPUFunctions were exposed this PR fixes those too.

Documentation: 


Test Plan: run image-classifier with num-devices >0 and backends= CPU, Interpreter, and OpenCL.