### PR TITLE
[Backend] Add a default implementation of createDeviceManager

### DIFF
--- a/include/glow/Backend/Backend.h
+++ b/include/glow/Backend/Backend.h
@@ -124,7 +124,7 @@ public:
   /// Create device manager corresponding to the backend based on the
   /// deviceConfig.
   virtual runtime::DeviceManager *
-  createDeviceManager(const runtime::DeviceConfig &deviceConfig) = 0;
+  createDeviceManager(const runtime::DeviceConfig &deviceConfig);
 
 protected:
   /// Parses the graph \F and builds a TraceInfo structure from any found

--- a/lib/Backend/Backend.cpp
+++ b/lib/Backend/Backend.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "glow/Backend/Backend.h"
+#include "glow/Backends/DummyDeviceManager.h"
 
 #include "glow/Graph/Graph.h"
 #include "glow/Graph/PlaceholderBindings.h"
@@ -23,6 +24,12 @@
 #include "glow/Optimizer/GraphOptimizerPipeline/Pipeline.h"
 
 using namespace glow;
+
+runtime::DeviceManager *
+Backend::createDeviceManager(const runtime::DeviceConfig &deviceConfig) {
+  LOG(ERROR) << "Warning: Creating a DummyDeviceManager.\n";
+  return new runtime::DummyDeviceManager(deviceConfig);
+}
 
 TraceInfo Backend::buildManualTraceInfo(Function *F) const {
   TraceInfo info(false, getTraceEventDataSize());


### PR DESCRIPTION
**Description**
This commit adds a default implementation of
`Backend::createDeviceManager` which creates and returns a
`DummyDeviceManager`. Now, developers working on new backends do
not have to explicitly override it just to return a
`DummyDeviceManager`. This is useful for backends under development
that do not have `DeviceManager` implementations yet. Currently, a
`DummyDeviceManager` is created only for unregistered backends.

**Testing**
Commented out override of `Backend::createDeviceManager` in the Intepreter
backend and ran `ninja check`. Tests can run and logs show the creation of
the `DummyDeviceManager`, but some tests fail because of some code that is
in the `InterpreterDeviceManager` but not in the DummyDeviceManager 
(e.g. collection of constants). CPU backend tests still use `CPUDeviceManager`.

```
$ ./tests/OperatorTest 
[==========] Running 690 tests from 2 test cases.
[----------] Global test environment set-up.
[----------] 60 tests from OperatorStatelessTest/OperatorStatelessTest
[ RUN      ] OperatorStatelessTest/OperatorStatelessTest.BasicAddNetFloatVsInt8/0
WARNING: Logging before InitGoogleLogging() is written to STDERR
E0821 11:49:28.362766 132208064 Backend.cpp:30] Warning: Creating a DummyDeviceManager.
I0821 11:49:28.363708 132208064 BackendTestUtils.cpp:153] Comparing Interpreter with precision float against CPU with precision i8
E0821 11:49:28.363929 132208064 Backend.cpp:30] Warning: Creating a DummyDeviceManager.
[       OK ] OperatorStatelessTest/OperatorStatelessTest.BasicAddNetFloatVsInt8/0 (153 ms)
[ RUN      ] OperatorStatelessTest/OperatorStatelessTest.BasicAddNetFloatVsInt8/1
E0821 11:49:28.515395 132208064 Backend.cpp:30] Warning: Creating a DummyDeviceManager.
E0821 11:49:28.515457 132208064 Backend.cpp:30] Warning: Creating a DummyDeviceManager.
I0821 11:49:28.515507 132208064 BackendTestUtils.cpp:153] Comparing Interpreter with precision float against Interpreter with precision i8
E0821 11:49:28.515565 132208064 Backend.cpp:30] Warning: Creating a DummyDeviceManager.
[       OK ] OperatorStatelessTest/OperatorStatelessTest.BasicAddNetFloatVsInt8/1 (69 ms)
[ RUN      ] OperatorStatelessTest/OperatorStatelessTest.BasicSubNetFloatVsInt8/0
E0821 11:49:28.584463 132208064 Backend.cpp:30] Warning: Creating a DummyDeviceManager.
I0821 11:49:28.584583 132208064 BackendTestUtils.cpp:153] Comparing Interpreter with precision float against CPU with precision i8
E0821 11:49:28.584645 132208064 Backend.cpp:30] Warning: Creating a DummyDeviceManager.
[       OK ] OperatorStatelessTest/OperatorStatelessTest.BasicSubNetFloatVsInt8/0 (136 ms)
[ RUN      ] OperatorStatelessTest/OperatorStatelessTest.BasicSubNetFloatVsInt8/1
E0821 11:49:28.720796 132208064 Backend.cpp:30] Warning: Creating a DummyDeviceManager.

```