### PR TITLE
[PyTorch] Cache graphs per node using input shapes

### DIFF
--- a/torch_glow/src/CachingGraphRunner.h
+++ b/torch_glow/src/CachingGraphRunner.h
@@ -24,54 +24,61 @@
 
 namespace glow {
 
-/// Responsible for maintaining a mapping from PyTorch subgraphs and their
-/// unique input types to a compiled Glow Function.
+/// For a given PyTorch JIT graph, this class is responsible for maintaining a
+/// mapping from PyTorch input information to Glow Function used to run that
+/// graph in Glow.
 class CachingGraphRunner {
+  /// Information that is stored per-Glow graph for running it using
+  /// HostManager.
   struct PerGlowGraphInfo {
+    /// Input and output placeholders to the Glow function.
     std::vector<glow::Placeholder *> inputPlaceholders;
     std::vector<glow::Placeholder *> outputPlaceholders;
 
     /// Name of the Glow function maintained by HostManager for this subgraph.
     std::string functionName;
-
-    /// The PyTorch node containing the subgraph that this PerGlowGraphInfo
-    /// represents.
-    const torch::jit::Node *node;
   };
 
-  std::unique_ptr<runtime::HostManager> hostManager_;
-  std::unordered_map<size_t, std::unique_ptr<PerGlowGraphInfo>>
-      perGlowGraphInfoMap;
+  /// The PyTorch JIT Graph that this CachingGraphRunner caches Glow functions
+  /// for.
+  torch::jit::Graph *graph_ = nullptr;
 
-  /// Given a PyTorch node \p node representing a fused subgraph of PyTorch
-  /// nodes and an input stack \p stack, this hashes the node and shape of the
-  /// inputs and checks to see if a matching function was loaded previously. If
-  /// a matching function was loaded previously then its cached
-  /// PerGlowGraphInfo is returned immediately. Otherwise this loads the
+  /// The HostManager used to store and run Glow graphs.
+  runtime::HostManager *hostManager_ = nullptr;
+
+  /// Mapping from hash of PyTorch inputs to PerGlowGraphInfo for the Glow
+  /// function that will run inputs matching that hash.
+  std::unordered_map<size_t, std::unique_ptr<PerGlowGraphInfo>>
+      perGlowGraphInfoMap_;
+
+  /// Given a PyTorch input stack \p stack, this generates a hash from the
+  /// values on the stack and checks to see if a matching function was loaded
+  /// previously. If a matching function was loaded previously then its cached
+  /// info is returned immediately. Otherwise this loads the
   /// subgraph into the owned HostManager, creates a PerGlowGraphInfo which is
-  /// cached for the given node and the shapes of the inputs, and then \returns
-  /// this PerGlowGraphInfo.
-  llvm::Expected<PerGlowGraphInfo *> loadGraphImpl(const torch::jit::Node *node,
-                                                   torch::jit::Stack &stack);
+  /// cached for the given inputs, and then \returns this PerGlowGraphInfo.
+  llvm::Expected<PerGlowGraphInfo *> loadImpl(torch::jit::Stack &stack);
 
   /// Given a PerGlowGraphInfo \p info for a subgraph that was previously
   /// loaded, this runs the Glow function that corresponds to that
   /// PerGlowGraphInfo in the shape of the inputs with the given \p stack.
-  llvm::Error runGraphImpl(const PerGlowGraphInfo &info,
-                           torch::jit::Stack &stack);
+  llvm::Error runImpl(const PerGlowGraphInfo &info,
+                      torch::jit::Stack &stack) const;
 
-  CachingGraphRunner();
+  /// Given a \p stack of inputs, computes the hash for the inputs on the stack.
+  size_t computeGraphHash(const c10::ArrayRef<c10::IValue> inputs) const;
 
 public:
-  /// Given a PyTorch glow::FusionGroup Node \p node that contains a
-  /// PyTorch subgraph and corresponding PyTorch Stack \p stack of inputs, run
-  /// that subgraph on those inputs. If this is the first time this node has
-  /// been seen then this first loads it as a Glow Function and compiles.
-  /// \returns error of failure.
-  llvm::Error runGraph(const torch::jit::Node *node, torch::jit::Stack &stack);
+  CachingGraphRunner(torch::jit::Graph *graph,
+                     runtime::HostManager *hostManager);
 
-  /// Manages a CachingGraphRunner singleton.
-  static CachingGraphRunner *getGraphRunner();
+  ~CachingGraphRunner();
+
+  /// Given a PyTorch Stack \p stack of inputs, run he stored PyTorch graph on
+  /// those inputs. If this is the first time this PyTorch graph has been run
+  /// with inputs matching the hash of those on the stack then this first loads
+  /// it as a Glow Function and compiles. \returns error of failure.
+  llvm::Error run(torch::jit::Stack &stack);
 };
 } // namespace glow
 

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -25,7 +25,7 @@
 
 namespace glow {
 
-/// Loads PyTorch JIT IR subgraphs as a Glow Function.
+/// Loads PyTorch JIT IR graphs as a Glow Function.
 class PyTorchModelLoader {
   /// Glow Function created outside this class.
   glow::Function &F_;
@@ -36,7 +36,7 @@ class PyTorchModelLoader {
 
   /// The reference PyTorch inputs used for loading. This is required for shape
   /// information.
-  at::ArrayRef<torch::jit::IValue> &inputs_;
+  const at::ArrayRef<torch::jit::IValue> &inputs_;
 
   /// Mapping from PyTorch Values to Glow NodeValues created during loading.
   using ValueMap =
@@ -110,27 +110,27 @@ public:
   /// Glow::ElemKind.
   static glow::ElemKind convertScalarType(c10::ScalarType ty);
 
-  /// Takes a glow::Function \p F, a jit::Graph \p subgraph to load, and a
-  /// stack of \p inputs for the subgraph to be loaded. Parameter \p
+  /// Takes a glow::Function \p F, a jit::Graph \p graph to load, and a
+  /// stack of \p inputs for the graph to be loaded. Parameter \p
   /// settings control the fusion details. Output parameters \p
   /// inputPlaceholders and \p outputPlaceholders are filled out. \returns
   /// error on failure.
   static llvm::Error
-  loadJITGraph(glow::Function &F, torch::jit::Graph &subgraph,
-               at::ArrayRef<torch::jit::IValue> &inputs,
+  loadJITGraph(glow::Function &F, const torch::jit::Graph &graph,
+               const at::ArrayRef<torch::jit::IValue> &inputs,
                std::vector<glow::Placeholder *> &inputPlaceholders,
                std::vector<glow::Placeholder *> &outputPlaceholders,
                const PyTorchLoaderSettings &settings);
 
 private:
-  /// Takes a glow::Function \p F, a jit::Graph \p subgraph to load, and a
-  /// stack of \p inputs for the subgraph to be loaded. Parameter \p settings
+  /// Takes a glow::Function \p F, a jit::Graph \p graph to load, and a
+  /// stack of \p inputs for the graph to be loaded. Parameter \p settings
   /// control the fusion details. Output parameters \p inputPlaceholders and
   /// \p outputPlaceholders are filled out. \p frozenInputIndices is an optional
   /// parameter that, if provided, will be filled with the set of stack indices
   /// that were frozen during loading.
-  PyTorchModelLoader(glow::Function &F, torch::jit::Graph &subgraph,
-                     at::ArrayRef<torch::jit::IValue> &inputs,
+  PyTorchModelLoader(glow::Function &F, const torch::jit::Graph &graph,
+                     const at::ArrayRef<torch::jit::IValue> &inputs,
                      std::vector<glow::Placeholder *> &inputPlaceholders,
                      std::vector<glow::Placeholder *> &outputPlaceholders,
                      llvm::Error &error, const PyTorchLoaderSettings &settings,
@@ -176,8 +176,8 @@ private:
 
   /// Creates and \returns a new Glow Placeholder corresponding to the given
   /// PyTorch Value \p value.
-  llvm::Expected<glow::Placeholder *> loadValue(const torch::jit::Value *value);
-
+  llvm::Expected<glow::Placeholder *>
+  loadValue(const torch::jit::Value *value, const at::TensorType &ptTensorType);
   /// Load a given PyTorch Node \p ptNode. If \p weightFreezingEnabled then
   /// load inputs that have been marked as constInputs in
   /// MappingOfMemberFunctions as Constants instead of as Placeholders. \returns


### PR DESCRIPTION
Summary:
* Use one CachingGraphRunner per glow::FusionGroup op (instead of globally)
* Use c10::TensorType shapes to cache glow functions for particular input shape

Documentation:
doxygen

Test Plan:
python setup.py test
add prints, see that things get reused