### PR TITLE
[Partitioner] Add dump/log info for non-partiton function.

### DIFF
--- a/include/glow/Partitioner/Partitioner.h
+++ b/include/glow/Partitioner/Partitioner.h
@@ -78,9 +78,11 @@ class Partitioner final : public PartitionerBase {
   /// Initialization. Called in class constructor.
   void init();
 
-  /// Verify the generated functions in module, and dump partition logs from \p
-  /// partitions and \p mapping.
-  void finalize(const DAGListTy &partitions, const NodeToFunctionMap &mapping);
+  /// Verify the generated functions in module, and \returns error if any
+  /// function is invalid. Dump partition logs from \p partitions and \p
+  /// mapping.
+  llvm::Error finalize(const DAGListTy &partitions,
+                       const NodeToFunctionMap &mapping);
 
   /// After getting the initial partitions, adjust the partitions to minimize
   /// communication and computation cost.

--- a/lib/Partitioner/PartitionerBase.cpp
+++ b/lib/Partitioner/PartitionerBase.cpp
@@ -207,6 +207,12 @@ void PartitionerBase::dumpDAG(llvm::StringRef dotFilename,
     auto *node = nodes[i];
     for (size_t j = 0; j < node->children.size(); j++) {
       auto child = node->children[j];
+      if (node->name.compare(child->name) == 0) {
+        // If a network is too small to be partitioned, the dummy node's name
+        // and its child (i.e. the original network) share the same name. The
+        // edge will create loop. So in this case, this edge just be ignored.
+        continue;
+      }
       myfile << "\"" << escapeDottyString(node->name) << "\""
              << " -> "
              << "\"" << escapeDottyString(child->name) << "\""


### PR DESCRIPTION
Summary:
As @hyuen noticed, if there is no actual partition (i.e. the network is too small and `Partitioner::createDAGWithoutPartition` is called, the log info won't be dumped even the llvm option is enabled. So this PR adds the missing part. 

Documentation:

[Optional Fixes #issue]

Test Plan:
ninja test, ./tests/images/run.sh, manually checked the dumped DAG.dot.

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
