### PR TITLE
Added support for exporting each device's available and used memory.

### DIFF
--- a/include/glow/Runtime/HostManager/HostManager.h
+++ b/include/glow/Runtime/HostManager/HostManager.h
@@ -116,6 +116,18 @@ class HostManager final {
   /// onto the devices.
   std::unique_ptr<Provisioner> provisioner_;
 
+  /// String const for logging total device memory usage.
+  static constexpr const char *kDeviceMemoryUsed =
+      "glow.devices.used_memory.total";
+
+  /// String const for logging total available device memory.
+  static constexpr const char *kDeviceMemoryAvailable =
+      "glow.devices.available_memory.total";
+
+  /// String const for logging total maximum device memory.
+  static constexpr const char *kDeviceMemoryMax =
+      "glow.devices.maximum_memory.total";
+
   /// Helper function to handle cleanup if an error occurs during addNetwork.
   /// This must be called while holding the a lock on networkLock_.
   void cleanupAddNetwork(llvm::ArrayRef<std::string> names);
@@ -125,6 +137,9 @@ class HostManager final {
 
   /// Method to dispatch a new run to the executor.
   void dispatchNextRun();
+
+  /// Method to calculate and export aggregate memory usage counters.
+  void exportMemoryCounters();
 
 public:
   /// Default constructor.

--- a/include/glow/Runtime/RuntimeTypes.h
+++ b/include/glow/Runtime/RuntimeTypes.h
@@ -144,6 +144,8 @@ struct DeviceConfig {
   const std::string backendName;
   /// A human readable name to identify the device.
   std::string name;
+  /// A runtime assigned id for the device. This is used for stats reporting.
+  unsigned deviceID{0};
   /// Device memory size in bytes.
   uint64_t deviceMemory = 0;
   /// A map of configuration parameters.

--- a/lib/Backends/CPU/CPUDeviceManager.cpp
+++ b/lib/Backends/CPU/CPUDeviceManager.cpp
@@ -108,6 +108,9 @@ void CPUDeviceManager::addNetworkImpl(const Module *module,
 
   assert(usedMemoryBytes_ <= maxMemoryBytes_);
 
+  // Export change in memory usage.
+  exportMemoryCounters();
+
   // Fire the ready CB.
   readyCB(module, llvm::Error::success());
 }
@@ -125,6 +128,9 @@ void CPUDeviceManager::evictNetworkImpl(std::string functionName,
                                functionName.c_str())));
     return;
   }
+  // Export change in memory usage.
+  exportMemoryCounters();
+
   evictCB(functionName, llvm::Error::success());
 }
 

--- a/lib/Backends/CPU/CPUDeviceManager.h
+++ b/lib/Backends/CPU/CPUDeviceManager.h
@@ -31,13 +31,6 @@ class CPUDeviceManager : public QueueBackedDeviceManager {
   /// Compiled function list by name.
   FunctionMapTy functions_;
 
-  /// Maximum available memory on the device, for CPU devices fix to some
-  /// constant.
-  std::atomic<uint64_t> maxMemoryBytes_{0};
-
-  /// Amount of memory used by all models.
-  std::atomic<uint64_t> usedMemoryBytes_{0};
-
   /// Static memory cost of the CPU Function.
   /// This is very arbitrary for the CPU backend.
   const uint64_t functionCost_{1};
@@ -47,13 +40,14 @@ class CPUDeviceManager : public QueueBackedDeviceManager {
 
 public:
   explicit CPUDeviceManager(const DeviceConfig &config)
-      : QueueBackedDeviceManager(config),
-        maxMemoryBytes_(config_.getDeviceMemory(2000000000)) {
+      : QueueBackedDeviceManager(config) {
     Stats()->incrementCounter(kDevicesUsedCPU);
+    exportMemoryCounters();
   }
 
   ~CPUDeviceManager() override {
     Stats()->incrementCounter(kDevicesUsedCPU, -1);
+    zeroMemoryCounters();
   }
 
   /// Returns the amount of memory in bytes available on the device when no

--- a/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
@@ -106,6 +106,8 @@ void InterpreterDeviceManager::addNetworkImpl(const Module *module,
 
   assert(usedMemoryBytes_ <= maxMemoryBytes_);
 
+  // Export changes to memory use.
+  exportMemoryCounters();
   // Fire the ready CB.
   readyCB(module, llvm::Error::success());
 }
@@ -123,6 +125,7 @@ void InterpreterDeviceManager::evictNetworkImpl(std::string functionName,
                                functionName.c_str())));
     return;
   }
+  exportMemoryCounters();
   evictCB(functionName, llvm::Error::success());
 }
 

--- a/lib/Backends/Interpreter/InterpreterDeviceManager.h
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.h
@@ -29,13 +29,6 @@ class InterpreterDeviceManager : public QueueBackedDeviceManager {
   /// Compiled function list by name.
   FunctionMapTy functions_;
 
-  /// Maximum available memory on the device, for local devices fix to some
-  /// constant.
-  std::atomic<uint64_t> maxMemoryBytes_{0};
-
-  /// Amount of memory used by all models.
-  std::atomic<uint64_t> usedMemoryBytes_{0};
-
   /// Static memory cost of the InterpreterFunction.
   /// This is very arbitrary for the Interpreter backend.
   const uint64_t functionCost_{1};
@@ -46,13 +39,14 @@ class InterpreterDeviceManager : public QueueBackedDeviceManager {
 
 public:
   explicit InterpreterDeviceManager(const DeviceConfig &config)
-      : QueueBackedDeviceManager(config),
-        maxMemoryBytes_(config_.getDeviceMemory(2000000000)) {
+      : QueueBackedDeviceManager(config) {
     Stats()->incrementCounter(kDevicesUsedInterpreter);
+    exportMemoryCounters();
   }
 
   ~InterpreterDeviceManager() override {
     Stats()->incrementCounter(kDevicesUsedInterpreter, -1);
+    zeroMemoryCounters();
   }
 
   /// Returns the amount of memory in bytes available on the device when no

--- a/lib/Backends/OpenCL/OpenCLDeviceManager.h
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.h
@@ -133,12 +133,6 @@ class OpenCLDeviceManager : public QueueBackedDeviceManager {
   /// Map of function name to cl_program.
   std::unordered_map<std::string, cl_program> programs_;
 
-  /// Maximum available memory on the device.
-  std::atomic<uint64_t> maxMemoryBytes_{0};
-
-  /// Amount of memory used by all models.
-  std::atomic<uint64_t> usedMemoryBytes_{0};
-
   /// CL compute device id.
   cl_device_id deviceId_;
   /// CL compute context.

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -465,6 +465,7 @@ target_link_libraries(StatsExporterTest
                       PRIVATE
                         Backends
                         Runtime
+                        HostManager
                         gtest
                         TestMain
                         glog::glog)

--- a/tests/unittests/StatsExporterTest.cpp
+++ b/tests/unittests/StatsExporterTest.cpp
@@ -16,6 +16,7 @@
 
 #include "glow/Runtime/StatsExporter.h"
 #include "glow/Backends/DeviceManager.h"
+#include "glow/Runtime/HostManager/HostManager.h"
 
 #include <gtest/gtest.h>
 
@@ -81,10 +82,51 @@ TEST(StatsExporter, TimeSeries) {
 TEST(StatsExporter, Device) {
   using namespace glow::runtime;
   EXPECT_EQ(MockStats.counters.count("glow.devices_used.interpreter"), 0);
+  EXPECT_EQ(MockStats.counters.count("glow.device.used_memory.device0"), 0);
+  EXPECT_EQ(MockStats.counters.count("glow.device.available_memory.device0"),
+            0);
   {
     std::unique_ptr<DeviceManager> DM(
         DeviceManager::createDeviceManager(DeviceConfig("Interpreter")));
     EXPECT_EQ(MockStats.counters["glow.devices_used.interpreter"], 1);
+    EXPECT_EQ(MockStats.counters["glow.device.used_memory.device0"], 0);
+    EXPECT_EQ(MockStats.counters["glow.device.available_memory.device0"],
+              2000000000);
+  }
+  EXPECT_EQ(MockStats.counters["glow.devices_used.interpreter"], 0);
+}
+
+TEST(StatsExporter, HostManager) {
+  using namespace glow::runtime;
+  EXPECT_EQ(MockStats.counters.count("glow.devices.used_memory.total"), 0);
+  EXPECT_EQ(MockStats.counters.count("glow.devices.available_memory.total"), 0);
+  EXPECT_EQ(MockStats.counters.count("glow.devices.maximum_memory.total"), 0);
+  {
+    auto deviceConfig = llvm::make_unique<DeviceConfig>("Interpreter");
+    std::vector<std::unique_ptr<DeviceConfig>> configs;
+    configs.push_back(std::move(deviceConfig));
+    std::unique_ptr<HostManager> HM =
+        llvm::make_unique<HostManager>(std::move(configs), HostConfig());
+    EXPECT_EQ(MockStats.counters["glow.devices.used_memory.total"], 0);
+    EXPECT_EQ(MockStats.counters["glow.devices.available_memory.total"],
+              2000000000);
+    EXPECT_EQ(MockStats.counters["glow.devices.maximum_memory.total"],
+              2000000000);
+
+    // Add a network so the memory used value is non-zero.
+    std::unique_ptr<Module> module = llvm::make_unique<Module>();
+    Function *F = module->createFunction("main");
+    auto *X = module->createConstant(ElemKind::FloatTy, {1024, 1024}, "X");
+    auto *pow = F->createPow("Pow", X, 2.0);
+    F->createSave("save", pow);
+
+    CompilationContext cctx;
+    EXIT_ON_ERR(HM->addNetwork(std::move(module), cctx));
+    // Currently the interpreter DM treats all added networks as size 1 byte so
+    // expect to see 1 byte used.
+    EXPECT_EQ(MockStats.counters["glow.devices.used_memory.total"], 1);
+    EXPECT_EQ(MockStats.counters["glow.devices.available_memory.total"],
+              1999999999);
   }
   EXPECT_EQ(MockStats.counters["glow.devices_used.interpreter"], 0);
 }


### PR DESCRIPTION
Summary: This PR adds used and available memory reporting to Interpreter, CPU, and OpenCL deviceManagers. 

Documentation:

Test Plan: Added check for memory counters to StatsExporterTest. 