### PR TITLE
[Quantization] 4bit-quantization algorithm

### DIFF
--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -500,6 +500,8 @@ public:
       return isEqualImpl<uint8_t>(other, allowedError, verbose);
     case ElemKind::UInt8FusedFP16QTy:
       return isEqualImpl<uint8_t>(other, allowedError, verbose);
+    case ElemKind::UInt4FusedFP16QTy:
+      return isEqualImpl<uint8_t>(other, allowedError, verbose);
     case ElemKind::BoolTy:
       return isEqualImpl<bool>(other, allowedError, verbose);
     }

--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -285,6 +285,9 @@ enum class ElemKind : unsigned char {
   UInt8FusedQTy,
   // 8-bit quantized type with fused FP16 scale/offset (uint8_t)
   UInt8FusedFP16QTy,
+  // 4-bit quantized type with fused FP16 scale/offset (uint8_t, each byte
+  // represents 2 4-bit quantized data)
+  UInt4FusedFP16QTy,
   // Bool type (bool)
   BoolTy,
 };
@@ -293,12 +296,14 @@ enum class ElemKind : unsigned char {
 inline bool isQuantizedElemKind(ElemKind e) {
   return e == ElemKind::Int8QTy || e == ElemKind::UInt8QTy ||
          e == ElemKind::Int16QTy || e == ElemKind::Int32QTy ||
-         e == ElemKind::UInt8FusedQTy || e == ElemKind::UInt8FusedFP16QTy;
+         e == ElemKind::UInt8FusedQTy || e == ElemKind::UInt8FusedFP16QTy ||
+         e == ElemKind::UInt4FusedFP16QTy;
 }
 
 /// \returns whether \p e is a fused quantized ElemKind.
 inline bool isFusedQuantizedElemKind(ElemKind e) {
-  return e == ElemKind::UInt8FusedQTy || e == ElemKind::UInt8FusedFP16QTy;
+  return e == ElemKind::UInt8FusedQTy || e == ElemKind::UInt8FusedFP16QTy ||
+         e == ElemKind::UInt4FusedFP16QTy;
 }
 
 /// A class that represents a type of a tensor.
@@ -539,6 +544,8 @@ struct Type final {
       return std::is_same<ElemTy, uint8_t>::value;
     case ElemKind::UInt8FusedFP16QTy:
       return std::is_same<ElemTy, uint8_t>::value;
+    case ElemKind::UInt4FusedFP16QTy:
+      return std::is_same<ElemTy, uint8_t>::value;
     case ElemKind::BoolTy:
       return std::is_same<ElemTy, bool>::value;
     }
@@ -594,6 +601,8 @@ struct Type final {
     case ElemKind::UInt8FusedQTy:
       return sizeof(uint8_t);
     case ElemKind::UInt8FusedFP16QTy:
+      return sizeof(uint8_t);
+    case ElemKind::UInt4FusedFP16QTy:
       return sizeof(uint8_t);
     case ElemKind::BoolTy:
       return sizeof(bool);

--- a/include/glow/Quantization/Base/Base.h
+++ b/include/glow/Quantization/Base/Base.h
@@ -186,6 +186,15 @@ inline DestTy quantizeWithFloatOffset(float input, float scale, float offset) {
   return static_cast<DestTy>(d);
 }
 
+/// Converts floating point value \p input to 4-bit quantization based on the
+/// quantization parameters \p scale and \p offset.
+inline uint8_t quantize4BitsWithFloatOffset(float input, float scale,
+                                            float offset) {
+  uint8_t d =
+      std::max(0, std::min(static_cast<int>((input - offset) / scale), 15));
+  return d;
+}
+
 /// Converts a quantized value (type eTy) to floating point based on the
 /// quantization parameters \p scale and \p offset. If the input type is int8_t,
 /// then an offset of 128 is added to convert to uint8_t.
@@ -198,6 +207,18 @@ inline float dequantizeWithFloatOffset(eTy input, float scale, float offset) {
   return (d * scale) + offset;
 }
 
+/// Converts a 4-bit quantized value, which is stored in \p input (MSB if \p
+/// isMSB is true, otherwise LSB), to floating point based on the quantization
+/// parameters \p scale and \p offset.
+inline float dequantize4BitWithFloatOffset(uint8_t input, float scale,
+                                           float offset, bool isMSB) {
+  if (isMSB) {
+    input >>= 4;
+  }
+  input &= 0x0f;
+  return (input * scale) + offset;
+}
+
 /// Converts a floating point \p tensor to quantized tensor based on the
 /// quantization parameters \p TQP and \p Ty.
 Tensor quantizeTensor(const Tensor &tensor, const TensorQuantizationParams &TQP,
@@ -206,6 +227,10 @@ Tensor quantizeTensor(const Tensor &tensor, const TensorQuantizationParams &TQP,
 /// Converts quantized tensor \p tensor to floating point tensor of type \p Ty
 /// floatKind.
 Tensor dequantizeTensor(const Tensor &tensor, ElemKind floatKind);
+
+/// Dequantize 4-bit fused quantized tensor \p input. \returns the float type
+/// output.
+Tensor tensor4BitsFusedRowwiseDequantization(const Tensor &input);
 
 /// Convert the floating point quantization parameters \p scale and \p offset
 /// into the integer sequence of:
@@ -293,21 +318,52 @@ void tensorRowwiseQuantization(const Tensor &input, Tensor &output,
 }
 
 /// Fused-rowwise quantize the tensor \p input. Scales and offsets are generated
-/// from each row of \p input. \p output is tensor of the same shape as input
-/// but with extra columns for storing fused scales. Template parameter \p T
-/// represents the datatype used for storing the scale and offset in the row.
+/// from each row of \p input. This function supports 8-bits quantization (i.e.
+/// each quantized data uses 8 bits) and 4-bits quantization(i.e. each quantized
+/// data uses 4 bits).
+/// For 8-bits quantization, \p output is tensor of the same shape as input but
+/// with extra columns for storing fused scales. Template parameter \p T
+/// represents the datatype used for storing the scale and offset in the row
+/// |   .... int8 data ...    |   scale   |  offset   |
+/// |num_of_input_columns * 1B| sizeof(T) | sizeof(T) |
+/// For 4-bits quantization, in \p output, 1 byte will contain 2 quantized data.
+/// Template parameter \p T here must be float16_t.
+/// |   .... int4 data ...       | scale | offset |
+/// |num_of_input_columns * 0.5B |  2B   |   2B   |
 /// \pre input.dims().size() == 2
 /// \pre output.dims().size() == 2
+/// For 8-bits quantization:
 /// \pre input.dims()[1] + 2 * sizeof(T) == output.dims()[1]
+/// For 4-bits quantization:
+/// \pre input.dims()[1] % 2 == 0
+/// \pre input.dims()[1] / 2 + 2 * sizeof(T) == output.dims()[1]
 template <typename T>
 void tensorFusedRowwiseQuantization(const Tensor &input, Tensor &output) {
   // We are fusing the scale and offset onto the end of each row. Thus input and
   // output must both be 2 dimensional, with output having 2*sizeof(T) extra
   // columns for the scale and offset.
+  auto outputType = output.getElementType();
   assert(input.dims().size() == 2 && output.dims().size() == 2 &&
          "Input and output must be 2 dimensional.");
-  assert(input.dims()[1] + 2 * sizeof(T) == output.dims()[1] &&
-         "Output must have 2*sizeof(T) more columns than input.");
+  if (outputType == ElemKind::UInt8FusedFP16QTy ||
+      outputType == ElemKind::UInt8FusedQTy) {
+    assert(input.dims()[1] + 2 * sizeof(T) == output.dims()[1] &&
+           "Output must have 2*sizeof(T) more columns than input for 8-bits "
+           "quantization.");
+  } else if (outputType == ElemKind::UInt4FusedFP16QTy) {
+    constexpr bool scaleIsFP16 = std::is_same<float16_t, T>::value;
+    (void)scaleIsFP16;
+    assert(scaleIsFP16 && "Only float16_t scale and offset are supported "
+                          "in 4-bit fused quantization");
+    assert(
+        input.dims()[1] % 2 == 0 &&
+        "4-bits fused quantization only works for the number of input column "
+        "a multiple of 2");
+    assert(
+        input.dims()[1] / 2 + 2 * sizeof(T) == output.dims()[1] &&
+        "Output must have 2*sizeof(T) more columns than half of input columns "
+        "for 4-bits quantization.");
+  }
 
   const size_t outWidth = output.dims()[1];
   char *dataBasePtr = output.getUnsafePtr();
@@ -324,17 +380,45 @@ void tensorFusedRowwiseQuantization(const Tensor &input, Tensor &output) {
     min = std::min(min, 0.0f);
     max = std::max(max, 0.0f);
 
+    float range;
+    switch (outputType) {
+    case ElemKind::UInt8FusedQTy:
+    case ElemKind::UInt8FusedFP16QTy:
+      range = 255.0;
+      break;
+    case ElemKind::UInt4FusedFP16QTy:
+      range = 15.0;
+      break;
+    default:
+      llvm_unreachable("Not yet supported");
+    }
+
     // This matches the Caffe2 implementation for FloatToRowwiseQuantized8BitsOp
     // found in operators/lengths_reducer_rowwise_8bit_ops.h.
     constexpr float kEqualityThreshold = 1e-10f;
     const float scale = ((max - min) < kEqualityThreshold)
                             ? 1.0
-                            : ((double)max - (double)min) / 255.0;
+                            : ((double)max - (double)min) / range;
     const float offset = min;
 
     for (size_t j = 0, f = input.dims()[1]; j < f; j++) {
-      destH.at({i, j}) = quantization::quantizeWithFloatOffset<uint8_t>(
-          srcH.at({i, j}), scale, offset);
+      if (outputType == ElemKind::UInt8FusedFP16QTy ||
+          outputType == ElemKind::UInt8FusedQTy) {
+        destH.at({i, j}) = quantization::quantizeWithFloatOffset<uint8_t>(
+            srcH.at({i, j}), scale, offset);
+      } else if (outputType == ElemKind::UInt4FusedFP16QTy) {
+        uint8_t quantized = quantization::quantize4BitsWithFloatOffset(
+            srcH.at({i, j}), scale, offset);
+        if (j % 2 == 0) {
+          // Even columns use LSB 4-bit.
+          destH.at({i, j / 2}) = quantized;
+        } else {
+          // Odd columns use MSB 4-bit.
+          destH.at({i, j / 2}) |= quantized << 4;
+        }
+      } else {
+        llvm_unreachable("Not yet supported");
+      }
     }
 
     // Now set the scale/offset at the end of each row.
@@ -346,7 +430,6 @@ void tensorFusedRowwiseQuantization(const Tensor &input, Tensor &output) {
     memcpy(currRowScaleOffsetPtr + sizeof(T), &finalOffset, sizeof(T));
   }
 }
-
 } // namespace quantization
 } // namespace glow
 

--- a/lib/Base/Tensor.cpp
+++ b/lib/Base/Tensor.cpp
@@ -295,6 +295,8 @@ void glow::dumpAsciiImpl(const Tensor *T, llvm::raw_ostream &os) {
     return dumpAsciiGenericImpl(T->getHandle<uint8_t>(), os);
   case ElemKind::UInt8FusedFP16QTy:
     return dumpAsciiGenericImpl(T->getHandle<uint8_t>(), os);
+  case ElemKind::UInt4FusedFP16QTy:
+    return dumpAsciiGenericImpl(T->getHandle<uint8_t>(), os);
   case ElemKind::BoolTy:
     return dumpAsciiGenericImpl(T->getHandle<bool>(), os);
   }
@@ -324,6 +326,8 @@ void glow::dumpImpl(const Tensor *T, llvm::raw_ostream &os,
   case ElemKind::UInt8FusedQTy:
     return dumpGenericImpl(T->getHandle<uint8_t>(), os, maxNumElem);
   case ElemKind::UInt8FusedFP16QTy:
+    return dumpGenericImpl(T->getHandle<uint8_t>(), os, maxNumElem);
+  case ElemKind::UInt4FusedFP16QTy:
     return dumpGenericImpl(T->getHandle<uint8_t>(), os, maxNumElem);
   case ElemKind::BoolTy:
     return dumpGenericImpl(T->getHandle<bool>(), os, maxNumElem);
@@ -448,6 +452,9 @@ void glow::genericTranspose(const Tensor *src, Tensor *dest,
   case ElemKind::UInt8FusedFP16QTy: {
     llvm_unreachable("Transposing UInt8FusedFP16QTy is unsupported.");
   }
+  case ElemKind::UInt4FusedFP16QTy: {
+    llvm_unreachable("Transposing UInt4FusedFP16QTy is unsupported.");
+  }
   case ElemKind::BoolTy: {
     auto srcH = src->getHandle<bool>();
     auto destH = dest->getHandle<bool>();
@@ -524,6 +531,7 @@ void Tensor::init(InitKind init, float val, PseudoRNG &PRNG) {
   }
       FUSED_CASE(UInt8FusedQTy, float);
       FUSED_CASE(UInt8FusedFP16QTy, float16_t);
+      FUSED_CASE(UInt4FusedFP16QTy, float16_t);
 #undef FUSED_CASE
 
     case ElemKind::BoolTy: {

--- a/lib/Exporter/ONNXModelWriter.cpp
+++ b/lib/Exporter/ONNXModelWriter.cpp
@@ -400,6 +400,7 @@ ONNXModelWriter::convertType(const Type &glowType) {
     return TensorType::INT8;
   case ElemKind::UInt8FusedQTy:
   case ElemKind::UInt8FusedFP16QTy:
+  case ElemKind::UInt4FusedFP16QTy:
   case ElemKind::UInt8QTy:
     return TensorType::UINT8;
   case ElemKind::Int16QTy:

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -245,6 +245,8 @@ llvm::Type *LLVMIRGen::getElementType(llvm::IRBuilder<> &builder,
     return builder.getInt8Ty();
   case ElemKind::UInt8FusedFP16QTy:
     return builder.getInt8Ty();
+  case ElemKind::UInt4FusedFP16QTy:
+    return builder.getInt8Ty();
   case ElemKind::BoolTy:
     static_assert(sizeof(bool) == sizeof(int8_t),
                   "Bool is expected to be the same size as int8.");
@@ -343,6 +345,9 @@ llvm::Value *LLVMIRGen::emitValueAddress(llvm::IRBuilder<> &builder,
     T = llvm::Type::getInt8PtrTy(ctx_);
     break;
   case ElemKind::UInt8FusedFP16QTy:
+    T = llvm::Type::getInt8PtrTy(ctx_);
+    break;
+  case ElemKind::UInt4FusedFP16QTy:
     T = llvm::Type::getInt8PtrTy(ctx_);
     break;
   case ElemKind::BoolTy:
@@ -502,6 +507,8 @@ llvm::Value *LLVMIRGen::emitConst(llvm::IRBuilder<> &builder, float val,
   case ElemKind::UInt8FusedQTy:
     return builder.getInt8(static_cast<int8_t>(val));
   case ElemKind::UInt8FusedFP16QTy:
+    return builder.getInt8(static_cast<int8_t>(val));
+  case ElemKind::UInt4FusedFP16QTy:
     return builder.getInt8(static_cast<int8_t>(val));
   case ElemKind::BoolTy:
     return builder.getInt8(static_cast<int8_t>(val));

--- a/lib/Quantization/Base/Base.cpp
+++ b/lib/Quantization/Base/Base.cpp
@@ -114,6 +114,36 @@ Tensor dequantizeTensor(const Tensor &tensor, ElemKind floatKind) {
   return tmp;
 }
 
+Tensor tensor4BitsFusedRowwiseDequantization(const Tensor &input) {
+  assert(input.dims().size() == 2 && "Input must be 2 dimensional.");
+  // The output tensor should have the same raw as input tensor. Since the
+  // quantized tensor is in the following format: | 4bit quantized data |
+  // float16_t scale | float16_t offset| The columns of dequantized float data
+  // should be (input.dims()[1] - 2*sizeof(float16_t)) * 2.
+  Tensor output(
+      ElemKind::FloatTy,
+      {input.dims()[0], (input.dims()[1] - 2 * sizeof(float16_t)) * 2});
+  auto srcH = input.getHandle<uint8_t>();
+  auto destH = output.getHandle<float>();
+  for (size_t i = 0; i < input.dims()[0]; i++) {
+    const char *currRowScaleOffsetPtr = input.getUnsafePtr() +
+                                        (i + 1) * input.dims()[1] -
+                                        2 * sizeof(float16_t);
+    float16_t scale;
+    float16_t offset;
+    memcpy(&scale, currRowScaleOffsetPtr, sizeof(float16_t));
+    memcpy(&offset, currRowScaleOffsetPtr + sizeof(float16_t),
+           sizeof(float16_t));
+    for (size_t j = 0; j < output.dims()[1]; j++) {
+      bool isMSB = (j % 2 == 1);
+      destH.at({i, j}) = dequantize4BitWithFloatOffset(
+          srcH.at({i, j / 2}), static_cast<float>(scale),
+          static_cast<float>(offset), isMSB);
+    }
+  }
+  return output;
+}
+
 QuantizationTransform32To8 quantizeScaleOffset32To8(float scale,
                                                     int32_t offset) {
   // In this function we compute an efficient way to convert signed 32-bit

--- a/tests/unittests/QuantizationTest.cpp
+++ b/tests/unittests/QuantizationTest.cpp
@@ -239,6 +239,32 @@ TEST(Quantization, quantizeTensorSymmetricUInt32) {
                               quantization::Schema::SymmetricWithUnsigned);
 }
 
+/// Test 4-bit fused rowwise quantization.
+TEST(Quantization, fused4BitsRowwiseQuantizeTensor) {
+  // Create an FP32 tensor with 12 elements and initialize it with numbers from
+  // -3 to 3.
+  Tensor inputFP32(ElemKind::FloatTy, {2, 6});
+  Tensor dequantized(ElemKind::FloatTy, {2, 6});
+  Tensor quantized(ElemKind::UInt4FusedFP16QTy, {2, 7}, /* dummy scale */ 1.0,
+                   /* dummy offset */ 0);
+  Handle<float> inputH = inputFP32.getHandle<float>();
+  for (size_t i = 0; i < 2; i++) {
+    for (size_t j = 0; j < 6; j++) {
+      inputH.at({i, j}) = (i + j) * 1.0f - 3;
+    }
+  }
+
+  quantization::tensorFusedRowwiseQuantization<float16_t>(inputFP32, quantized);
+  dequantized = quantization::tensor4BitsFusedRowwiseDequantization(quantized);
+
+  Handle<float> dequantizedH = dequantized.getHandle<float>();
+  for (size_t i = 0; i < 2; i++) {
+    for (size_t j = 0; j < 6; j++) {
+      EXPECT_NEAR(inputH.at({i, j}), dequantizedH.at({i, j}), 0.02f);
+    }
+  }
+}
+
 /// Helper for quantizing a simple Conv with precision \p quantizationPrecision.
 static void quantizeSimpleConvGraph(ElemKind quantizationPrecision) {
   ExecutionEngine EE{};

--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -311,6 +311,7 @@ c10::ScalarType PyTorchModelLoader::convertGlowType(glow::TypeRef ty) {
     return at::kBool;
   case ElemKind::UInt8FusedQTy:
   case ElemKind::UInt8FusedFP16QTy:
+  case ElemKind::UInt4FusedFP16QTy:
   case ElemKind::Int8QTy:
   case ElemKind::UInt8QTy:
   case ElemKind::Int16QTy:


### PR DESCRIPTION
Summary:
This PR is the first part of 4-bit fused quantization support(#3463). It implemented functions to quantize/dequantize a tensor. 
Since so far, in most of cases, Glow loads pre-quantized model and run. For 4-bit quantization, we just use the row-wise quantization and simply use min/max to get the scale and offset. If in the future, we need to use Glow to generate quantized model and find the unaccepted accuracy drop issue, we could improve the quantization approach. 

Documentation:
Will update Quantization.md once everything is ready.
[Optional Fixes #issue]

Test Plan:
ninja test, added unnitest.

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
