### PR TITLE
Parsing PyTorch model and loading into Glow directly.

### DIFF
--- a/torch_glow/setup.py
+++ b/torch_glow/setup.py
@@ -33,6 +33,9 @@ print("torch location:", os.path.dirname(os.path.realpath(torch.__file__)))
 FILE_DIR = os.path.realpath(os.path.dirname(__file__))
 # Find the top directory with root Makefile, i.e. glow
 TOP_DIR = os.path.realpath(os.path.dirname(FILE_DIR))
+
+os.environ['TOP_DIR'] = TOP_DIR
+
 # Make build directory a subdirectory of FILE_DIR, i.e.
 # glow/build.
 CMAKE_BUILD_DIR = os.path.join(TOP_DIR, 'build')
@@ -63,10 +66,10 @@ parser.add_argument(
     default=False,
     help="Run cmake")
 parser.add_argument(
-    "--debug",
+    "--release",
     action='store_true',
     default=False,
-    help="Compile with debug on")
+    help="Compile with release on")
 parser.add_argument(
     "--cmake_prefix_path",
     type=str,
@@ -125,7 +128,7 @@ class cmake_build(setuptools.Command):
                 '-DBUILD_SHARED_LIBS=OFF',
                 '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON',
                 '-DCMAKE_BUILD_TYPE={}'.format(
-                    'Debug' if args.debug else 'Release'),
+                    'Release' if args.release else 'Debug'),
                 '-DPYTHON_EXECUTABLE={}'.format(sys.executable),
                 # PyTorch cmake args
                 '-DPYTORCH_DIR={}'.format(

--- a/torch_glow/src/PyTorchFileLoader.cpp
+++ b/torch_glow/src/PyTorchFileLoader.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "PyTorchFileLoader.h"
+#include "FuseLinear.h"
 #include "PyTorchModelLoader.h"
 #include "glow/Support/Error.h"
 #include "glow/Support/Support.h"
@@ -96,7 +97,7 @@ loadJitGraphToGlowFunction(torch::jit::Stack &stack, torch::jit::Graph &graph,
 /// Glow function is set.
 llvm::Error
 evaluateModuleGraph(std::shared_ptr<torch::jit::script::Module> &module,
-                    std::vector<torch::jit::IValue> &inputs) {
+                    const std::vector<torch::jit::IValue> &inputs) {
   try {
     module->forward(inputs);
   } catch (const std::exception &x) {
@@ -131,7 +132,8 @@ struct RegisterCustomFusionPass {
 
     torch::jit::RegisterPass pass([&](std::shared_ptr<torch::jit::Graph> &g) {
       // Trigger custom fusion pass only if local thread Glow Function is set.
-      if (localFusionInfo.function) {
+      if (localFusionInfo.settings &&
+          localFusionInfo.settings->fusionPassEnabled) {
         glowCustomFuse(g, getFusionSymbol());
       }
     });
@@ -155,12 +157,15 @@ llvm::Error PyTorchFileLoader::loadPyTorchModel(
 
 /*static*/
 llvm::Error PyTorchFileLoader::loadPyTorchGraph(
-    const std::string &fileName, std::vector<torch::jit::IValue> &inputs,
+    const std::string &fileName, const std::vector<torch::jit::IValue> &inputs,
     glow::Function &F, std::vector<glow::Placeholder *> &inputPlaceholders,
-    std::vector<glow::Placeholder *> &outputPlaceholders,
-    const PyTorchLoaderSettings &settings, bool sanityCheck) {
+    std::vector<glow::Placeholder *> &outputPlaceholders, bool sanityCheck) {
   // Register custom pass once.
   static RegisterCustomFusionPass fuser;
+
+  PyTorchLoaderSettings settings;
+  settings.fusionPassEnabled = true;
+  settings.weightFreezingEnabled = false;
 
   // Convert PyTorch model into JIT Module.
   std::shared_ptr<torch::jit::script::Module> module;
@@ -177,6 +182,27 @@ llvm::Error PyTorchFileLoader::loadPyTorchGraph(
   RETURN_IF_ERR(err);
 
   return sanityCheck ? performSanityCheck() : llvm::Error::success();
+}
+
+/*static*/
+llvm::Error PyTorchFileLoader::parsePyTorchGraph(
+    const std::string &fileName, const std::vector<torch::jit::IValue> &inputs,
+    glow::Function &F, std::vector<glow::Placeholder *> &inputPlaceholders,
+    std::vector<glow::Placeholder *> &outputPlaceholders) {
+
+  // Convert PyTorch model into JIT Module.
+  std::shared_ptr<torch::jit::script::Module> module;
+  RETURN_IF_ERR(PyTorchFileLoader::loadPyTorchModel(fileName, module));
+
+  auto method = module->get_method("forward");
+  auto graphAndTensors = method._lowered_graph();
+
+  FuseLinear(graphAndTensors.first);
+
+  // Parse JIT Graph and load into Glow Function.
+  return PyTorchModelLoader::parseJITGraph(
+      F, *graphAndTensors.first, inputs, graphAndTensors.second,
+      inputPlaceholders, outputPlaceholders);
 }
 
 // Sanity check, after "fusionSymbol" node, not other nodes should exist.

--- a/torch_glow/src/PyTorchFileLoader.h
+++ b/torch_glow/src/PyTorchFileLoader.h
@@ -37,19 +37,32 @@ public:
   loadPyTorchModel(const std::string &fileName,
                    std::shared_ptr<torch::jit::script::Module> &module);
 
-  /// Takes a model file \p fileName, loads optimized graph into Glow Function
-  /// \p F and input \p inputPlaceholders, output \p outputPlaceholders
-  /// placeholders, \returns error if any. Parameter \p settings
-  /// control the fusion details. Optionally method performs a sanity check if
-  /// \p sanityCheck is set.
+  /// Takes a model file \p fileName, loads optimized graph and a
+  /// stack of \p inputs into Glow Function \p F and fills out input \p
+  /// inputPlaceholders, output \p outputPlaceholders placeholders, \returns
+  /// error if any. Optionally method performs a sanity check if \p sanityCheck
+  /// is set.
   /// Method is thread safe, internally it uses local thread structures for
   /// executing custom fusion pass, registered globally. No other passes or
   /// other treads calling this method will be affected.
-  static llvm::Error loadPyTorchGraph(
-      const std::string &fileName, std::vector<torch::jit::IValue> &inputs,
-      glow::Function &F, std::vector<glow::Placeholder *> &inputPlaceholders,
-      std::vector<glow::Placeholder *> &outputPlaceholders,
-      const PyTorchLoaderSettings &settings, bool sanityCheck = true);
+  static llvm::Error
+  loadPyTorchGraph(const std::string &fileName,
+                   const std::vector<torch::jit::IValue> &inputs,
+                   glow::Function &F,
+                   std::vector<glow::Placeholder *> &inputPlaceholders,
+                   std::vector<glow::Placeholder *> &outputPlaceholders,
+                   bool sanityCheck = true);
+
+  /// Takes a model file \p fileName, loads optimized graph and a
+  /// stack of \p inputs into Glow Function \p F and fills out input \p
+  /// inputPlaceholders, output \p outputPlaceholders placeholders, \returns
+  /// error if any. Method is thread safe.
+  static llvm::Error
+  parsePyTorchGraph(const std::string &fileName,
+                    const std::vector<torch::jit::IValue> &inputs,
+                    glow::Function &F,
+                    std::vector<glow::Placeholder *> &inputPlaceholders,
+                    std::vector<glow::Placeholder *> &outputPlaceholders);
 };
 
 } // namespace glow

--- a/torch_glow/src/binding.cpp
+++ b/torch_glow/src/binding.cpp
@@ -56,7 +56,6 @@ PYBIND11_MODULE(_torch_glow, m) {
       .def("init", &TorchGlowTrainingWrapper::init)
       .def("train", &TorchGlowTrainingWrapper::train)
       .def("save", &TorchGlowTrainingWrapper::save)
-      .def("settings", &TorchGlowTrainingWrapper::setPyTorchLoaderSettings)
       .def("parameters", &TorchGlowTrainingWrapper::setONNXWriterParameters)
       .def("config", &TorchGlowTrainingWrapper::setTrainingConfig);
 }

--- a/torch_glow/src/training/TorchGlowTraining.cpp
+++ b/torch_glow/src/training/TorchGlowTraining.cpp
@@ -36,7 +36,7 @@ bool isValidSamplesForSingleInput(const Tensor &input, const Tensor &samples) {
 /// Checks if \p samples Tensor contains multiple training examples with the
 /// correct shape, matching \p input.
 bool isValidSamplesForSliceInput(const Tensor &input, const Tensor &samples) {
-  return input.dims().size() > 1 &&
+  return input.dims().size() > 1 && samples.dims().size() > 1 &&
          input.dims().slice(1) == samples.dims().slice(1) &&
          input.getElementType() == samples.getElementType();
 }
@@ -59,7 +59,6 @@ llvm::Error TorchGlowTraining::init(llvm::StringRef modelFile,
                                     std::vector<torch::jit::IValue> &inputs,
                                     llvm::StringRef backend,
                                     const ONNXWriterParameters &parameters,
-                                    const PyTorchLoaderSettings &settings,
                                     const TrainingConfig &config,
                                     RandomizeWeights mode) {
   // Clean up all previous allocations, if any.
@@ -71,34 +70,12 @@ llvm::Error TorchGlowTraining::init(llvm::StringRef modelFile,
   // Execution lambda helps to use compact Glow RETURN_* macros inside, and
   // have possibility to clean-up resources before leaving the function scope.
   auto setup = [&]() -> llvm::Error {
-    // Don't make constants from placeholders, it will crash training.
-    RETURN_ERR_IF_NOT(
-        !settings.weightFreezingEnabled,
-        "Cannot initialize training with weightFreezingEnabled set to true.");
     // Detect the proper loader.
     if (modelFile.endswith_lower(".pt")) {
-      RETURN_IF_ERR(PyTorchFileLoader::loadPyTorchGraph(
-          modelFile.str(), inputs, *F_, inputPHs_, outputPHs_, settings, true));
+      RETURN_IF_ERR(PyTorchFileLoader::parsePyTorchGraph(
+          modelFile.str(), inputs, *F_, inputPHs_, outputPHs_));
       if (mode == RandomizeWeights::AUTO) {
         mode = RandomizeWeights::YES;
-      }
-      // After fusion and replacing all inputs, weights, biases, etc. with
-      // placeholders, we lost the track of input placeholders. Let's find them.
-      // Get graph root node with all inputs.
-      inputPHs_.clear();
-      const auto &nodes = F_->getNodes();
-      const auto &root = *nodes.begin();
-      const unsigned n = root.getNumInputs();
-      RETURN_ERR_IF_NOT(
-          inputs.size() == n,
-          glow::strFormat("expected %lu inputs, got %u", inputs.size(), n));
-
-      for (unsigned b = 0; b < n; ++b) {
-        auto input = root.getNthInput(b);
-        Placeholder *PH = llvm::dyn_cast<Placeholder>(input.getNode());
-        RETURN_ERR_IF_NOT(PH,
-                          "Expected placeholder as input for the first node.");
-        inputPHs_.push_back(PH);
       }
     } else if (modelFile.endswith_lower(".onnx")) {
       llvm::Error err = llvm::Error::success();
@@ -166,7 +143,6 @@ llvm::Error TorchGlowTraining::train(const Tensor &samples,
   RETURN_ERR_IF_NOT(TF_, "Class instance, wasn't properly initialized.");
   auto *input = bindings_.get(inputPHs_[0]);
   auto *label = bindings_.get(selectedPH_);
-  auto TFName = TF_->getName();
 
   // Sanity check.
   const bool isSlice = isValidSamplesForSliceInput(*input, samples) &&
@@ -174,9 +150,17 @@ llvm::Error TorchGlowTraining::train(const Tensor &samples,
 
   if (!isSlice && (!isValidSamplesForSingleInput(*input, samples) ||
                    !isValidSamplesForSingleInput(*label, labels))) {
-    RETURN_ERR("Invalid samples/labels dimensions.");
+    std::string O;
+    llvm::raw_string_ostream sink(O);
+    sink << "input: " << input->getType() << ", samples: " << samples.getType()
+         << ", label: " << label->getType() << ", labels: " << labels.getType();
+
+    RETURN_ERR("Invalid samples/labels dimensions: " + sink.str());
   }
 
+#ifdef NDEBUG
+  /// Enable only in release mode.
+  auto TFName = TF_->getName();
   size_t numEpochs = samples.dims()[0] / input->dims()[0];
   for (size_t e = 0; e < numEpochs; ++e) {
     isSlice ? input->copyConsecutiveSlices(&samples, e)
@@ -185,7 +169,7 @@ llvm::Error TorchGlowTraining::train(const Tensor &samples,
             : label->copySlice(&labels, e);
     engine_.run(bindings_, TFName);
   }
-
+#endif
   return llvm::Error::success();
 }
 
@@ -196,7 +180,7 @@ llvm::Error TorchGlowTraining::save(llvm::StringRef snapshotFile) {
   const bool textMode = snapshotFile.endswith_lower(".onnxtxt");
 
   // Move placeholder tensors into constants.
-  llvm::ArrayRef<Placeholder *> phs = {inputPHs_[0], outputPHs_[0]};
+  std::vector<Placeholder *> phs = {inputPHs_[0], outputPHs_[0]};
   std::list<std::pair<Placeholder *, Constant *>> cache;
   // Move placeholder tensors into constants.
   for (auto &PH : F_->findPlaceholders()) {
@@ -238,7 +222,7 @@ bool TorchGlowTrainingWrapper::init(const std::string &modelPath,
   std::vector<torch::jit::IValue> ptInputs = {ptTensors.begin(),
                                               ptTensors.end()};
   return !errToBool(trainer_.init(
-      modelPath, ptInputs, backend, parameters_, settings_, config_,
+      modelPath, ptInputs, backend, parameters_, config_,
       randomizeWeights ? TorchGlowTraining::RandomizeWeights::YES
                        : TorchGlowTraining::RandomizeWeights::NO));
 }
@@ -246,14 +230,14 @@ bool TorchGlowTrainingWrapper::init(const std::string &modelPath,
 bool TorchGlowTrainingWrapper::train(const at::Tensor &ptSamples,
                                      const at::Tensor &ptLabels) {
   llvm::Expected<glow::Tensor> glowSamples =
-      PyTorchModelLoader::ptTensorToGlowTensor(ptSamples);
+      PyTorchModelLoader::ptTensorToGlowTensor(ptSamples, /*copy*/ false);
   if (!glowSamples) {
     errToBool(takeErr(std::move(glowSamples)));
     return false;
   }
 
   llvm::Expected<glow::Tensor> glowLabels =
-      PyTorchModelLoader::ptTensorToGlowTensor(ptLabels);
+      PyTorchModelLoader::ptTensorToGlowTensor(ptLabels, /*copy*/ false);
   if (!glowLabels) {
     errToBool(takeErr(std::move(glowLabels)));
     return false;
@@ -264,14 +248,6 @@ bool TorchGlowTrainingWrapper::train(const at::Tensor &ptSamples,
 
 bool TorchGlowTrainingWrapper::save(const std::string &snapshotFile) {
   return !errToBool(trainer_.save(snapshotFile));
-}
-
-/// Helper functions for assigning settings/parameters/configs.
-/// Sets PyTorchLoaderSettings
-void TorchGlowTrainingWrapper::setPyTorchLoaderSettings(
-    bool enableFusionPass, bool enableWeightFreezing) {
-  settings_.fusionPassEnabled = enableFusionPass;
-  settings_.weightFreezingEnabled = enableWeightFreezing;
 }
 
 /// Sets ONNXWriterParameters

--- a/torch_glow/src/training/TorchGlowTraining.h
+++ b/torch_glow/src/training/TorchGlowTraining.h
@@ -68,15 +68,15 @@ public:
   /// once init() -> repeatedly train() -> repeatedly save().
 
   /// Initializes internal Glow objects from \p modelFile file, uses provided
-  /// \p backend name, ONNX exporter \p parameters, \p inputs, \p settings,
-  /// and training configuration \p config for training algorithm, randomizes
-  /// weights according to the provided \p mode.
+  /// \p backend name, ONNX exporter \p parameters, \p inputs, \p config,
+  /// randomizes weights according to the provided \p mode.
   /// \returns error on failure.
-  llvm::Error
-  init(llvm::StringRef modelFile, std::vector<torch::jit::IValue> &inputs,
-       llvm::StringRef backend, const ONNXWriterParameters &parameters,
-       const PyTorchLoaderSettings &settings, const TrainingConfig &config,
-       RandomizeWeights mode = RandomizeWeights::AUTO);
+  llvm::Error init(llvm::StringRef modelFile,
+                   std::vector<torch::jit::IValue> &inputs,
+                   llvm::StringRef backend,
+                   const ONNXWriterParameters &parameters,
+                   const TrainingConfig &config,
+                   RandomizeWeights mode = RandomizeWeights::AUTO);
 
   /// Trains the loaded model from the provided \p samples and \p labels.
   /// Samples and labels must have the compatible dimensions and types.
@@ -100,7 +100,6 @@ class TorchGlowTrainingWrapper {
   TorchGlowTraining trainer_;
   // Required settings/parameters/configs.
   TorchGlowTraining::ONNXWriterParameters parameters_;
-  PyTorchLoaderSettings settings_;
   TrainingConfig config_;
 
 public:
@@ -118,11 +117,6 @@ public:
   /// Saves Glow model into \p snapshotFile using ONNX format
   /// \returns false on a failure.
   bool save(const std::string &snapshotFile);
-
-  /// Helper functions for assigning settings/parameters/configs.
-  /// Sets PyTorchLoaderSettings.
-  void setPyTorchLoaderSettings(bool enableFusionPass,
-                                bool enableWeightFreezing);
 
   /// Sets ONNXWriterParameters.
   void setONNXWriterParameters(size_t irVersion, size_t opsetVersion);

--- a/torch_glow/tests/training/init_test.py
+++ b/torch_glow/tests/training/init_test.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import torch
 import torch_glow
+import os
 
 
 def test_init():
@@ -10,13 +11,14 @@ def test_init():
     trainer = torch_glow.TorchGlowTrainingWrapper()
 
     # test settings
-    trainer.settings(True, True)
     trainer.parameters(3, 10)
     trainer.config(0.1, 0.2, 0.3, 0.4, 64)
 
-    x = torch.randn(3, 224, 244)
+    x = torch.randn(1, 3, 224, 244)
+    y = torch.randint(0, 1, (1, 1000))
 
-    trainer.train(x, x)
-    #  TODO assert trainer.init(
-    #  "../../../tests/models/pytorchModels/resnet18.pt",
-    #  [x], "Interpreter", True)
+    assert trainer.init(
+        os.environ['TOP_DIR'] + "/tests/models/pytorchModels/resnet18.pt",
+        [x], "Interpreter", True)
+
+    assert trainer.train(x, y)

--- a/torch_glow/tests/unittests/PyTorchLoaderTest.cpp
+++ b/torch_glow/tests/unittests/PyTorchLoaderTest.cpp
@@ -44,10 +44,28 @@ TEST(ModelLoaderTest, Fusion) {
 
   std::vector<glow::Placeholder *> inputPlaceholders;
   std::vector<glow::Placeholder *> outputPlaceholders;
-  glow::PyTorchLoaderSettings settings;
 
   llvm::Error err = glow::PyTorchFileLoader::loadPyTorchGraph(
-      fileName, vec, *F, inputPlaceholders, outputPlaceholders, settings);
+      fileName, vec, *F, inputPlaceholders, outputPlaceholders);
+
+  EXPECT_FALSE(glow::errToBool(std::move(err)));
+}
+
+TEST(ModelLoaderTest, Direct) {
+  const std::string fileName{GLOW_DATA_PATH
+                             "tests/models/pytorchModels/resnet18.pt"};
+
+  glow::Module mod;
+  auto *F = mod.createFunction("GlowFunction");
+  std::vector<torch::jit::IValue> vec;
+  auto emptyTensor = at::empty({1, 3, 224, 224});
+  vec.push_back(torch::autograd::make_variable(emptyTensor));
+
+  std::vector<glow::Placeholder *> inputPlaceholders;
+  std::vector<glow::Placeholder *> outputPlaceholders;
+
+  llvm::Error err = glow::PyTorchFileLoader::parsePyTorchGraph(
+      fileName, vec, *F, inputPlaceholders, outputPlaceholders);
 
   EXPECT_FALSE(glow::errToBool(std::move(err)));
 }

--- a/torch_glow/tests/unittests/TorchGlowTrainingTest.cpp
+++ b/torch_glow/tests/unittests/TorchGlowTrainingTest.cpp
@@ -23,7 +23,7 @@
 
 using namespace glow;
 
-TEST(TorchGlowTraining, DISABLED_Test) {
+TEST(TorchGlowTraining, Test) {
   const std::string fileName{GLOW_DATA_PATH
                              "tests/models/pytorchModels/resnet18.pt"};
   TorchGlowTraining trainer;
@@ -31,8 +31,6 @@ TEST(TorchGlowTraining, DISABLED_Test) {
   auto emptyTensor = at::empty({1, 3, 224, 224});
   vec.push_back(torch::autograd::make_variable(emptyTensor));
   TorchGlowTraining::ONNXWriterParameters parameters;
-  PyTorchLoaderSettings settings;
-  settings.weightFreezingEnabled = false;
   TrainingConfig config;
   config.learningRate = 0.01;
   config.momentum = 0.9;
@@ -40,8 +38,8 @@ TEST(TorchGlowTraining, DISABLED_Test) {
   config.batchSize = 1;
 
   // TODO (after full fusion is available)
-  if (errToBool(trainer.init(fileName, vec, "Interpreter", parameters, settings,
-                             config))) {
+  if (errToBool(
+          trainer.init(fileName, vec, "Interpreter", parameters, config))) {
     return;
   }
 


### PR DESCRIPTION
Summary:
Use JIT Module API to get lowered graph and load it directly into Glow without registered Fusion passes.
Documentation:

[Optional Fixes #issue]

Test Plan:

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
