### PR TITLE
dump graph before compiling

### DIFF
--- a/lib/Onnxifi/HostManagerOnnxifi.cpp
+++ b/lib/Onnxifi/HostManagerOnnxifi.cpp
@@ -27,6 +27,7 @@ bool GlowDumpDebugTraces = false;
 bool GlowSaturateHost = false;
 bool GlowFP16 = false;
 bool GlowClipFP16 = false;
+bool GlowDumpGraph = false;
 
 static llvm::cl::opt<int32_t, true>
     GlowNumDevicesOpt("glow-num-devices",


### PR DESCRIPTION
Summary:
buck test //glow/fb/test:test_numerics_xxx -- limits

dot 1.dot -T png -o 1.png

Reviewed By: rdzhabarov

Differential Revision: D16978685

