### PR TITLE
[resnet-runtime] Print the correct device type

### DIFF
--- a/examples/resnet-runtime.cpp
+++ b/examples/resnet-runtime.cpp
@@ -122,12 +122,13 @@ void dispatchClassify(unsigned int id, HostManager *hostManager,
   LOG(INFO) << "Started run ID: " << runid;
 }
 
-/// Run ResNet concurrently on the number CPU Devices provided by the user.
+/// Run ResNet concurrently on the number of devices provided by the user.
 int main(int argc, char **argv) {
   llvm::cl::ParseCommandLineOptions(
-      argc, argv, "Run ResNet concurrently on a fixed number of CPU devices");
+      argc, argv, "Run ResNet concurrently on a fixed number of devices");
 
-  LOG(INFO) << "Initializing " << numDevices << " CPU Devices on HostManager.";
+  LOG(INFO) << "Initializing " << numDevices << " " << backend
+            << " devices on HostManager.";
 
   std::vector<std::unique_ptr<DeviceConfig>> configs;
   for (unsigned int i = 0; i < numDevices; ++i) {


### PR DESCRIPTION
**Description**
This commit modifies `resnet-runtime` to print the correct device type in
its log messages. It currently prints `CPU` regardless of which backend
is specified on the command line.

**Testing**
Ran the executable on the Interpreter and CPU and observed the log
messages:
```
$ ../build_DEBUG/bin/resnet-runtime ../glow/tests/images/imagenet/ -backend=Interpreter
WARNING: Logging before InitGoogleLogging() is written to STDERR
I0830 07:35:04.535593 318879168 resnet-runtime.cpp:130] Initializing 5 Interpreter devices on HostManager.
I0830 07:35:04.536674 318879168 resnet-runtime.cpp:78] Loading resnet50 model.

$ ../build_DEBUG/bin/resnet-runtime ../glow/tests/images/imagenet/ -backend=CPU
WARNING: Logging before InitGoogleLogging() is written to STDERR
I0830 07:35:14.114750 161125824 resnet-runtime.cpp:130] Initializing 5 CPU devices on HostManager.
I0830 07:35:14.115845 161125824 resnet-runtime.cpp:78] Loading resnet50 model.
```

**Fixes**
This PR fixes #3471.