### PR TITLE
[CPU][Interpreter] Modify CPU and Interpreter DeviceManagers to use constant weight size for function cost

### DIFF
--- a/lib/Backends/CPU/CPUDeviceManager.h
+++ b/lib/Backends/CPU/CPUDeviceManager.h
@@ -31,10 +31,6 @@ class CPUDeviceManager : public QueueBackedDeviceManager {
   /// Compiled function list by name.
   FunctionMapTy functions_;
 
-  /// Static memory cost of the CPU Function.
-  /// This is very arbitrary for the CPU backend.
-  const uint64_t functionCost_{1};
-
   /// String constant for logging number of in-use devices.
   static constexpr const char *kDevicesUsedCPU = "glow.devices_used.cpu";
 

--- a/lib/Backends/Interpreter/InterpreterDeviceManager.h
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.h
@@ -29,10 +29,6 @@ class InterpreterDeviceManager : public QueueBackedDeviceManager {
   /// Compiled function list by name.
   FunctionMapTy functions_;
 
-  /// Static memory cost of the InterpreterFunction.
-  /// This is very arbitrary for the Interpreter backend.
-  const uint64_t functionCost_{1};
-
   /// String constant for logging number of in-use devices.
   static constexpr const char *kDevicesUsedInterpreter =
       "glow.devices_used.interpreter";

--- a/tests/unittests/StatsExporterTest.cpp
+++ b/tests/unittests/StatsExporterTest.cpp
@@ -120,13 +120,16 @@ TEST(StatsExporter, HostManager) {
     auto *pow = F->createPow("Pow", X, 2.0);
     F->createSave("save", pow);
 
+    const int64_t functionCost = X->getType()->getSizeInBytes();
+
     CompilationContext cctx;
     EXIT_ON_ERR(HM->addNetwork(std::move(module), cctx));
     // Currently the interpreter DM treats all added networks as size 1 byte so
     // expect to see 1 byte used.
-    EXPECT_EQ(MockStats.counters["glow.devices.used_memory.total"], 1);
+    EXPECT_EQ(MockStats.counters["glow.devices.used_memory.total"],
+              functionCost);
     EXPECT_EQ(MockStats.counters["glow.devices.available_memory.total"],
-              1999999999);
+              2000000000 - functionCost);
   }
   EXPECT_EQ(MockStats.counters["glow.devices_used.interpreter"], 0);
 }


### PR DESCRIPTION
**Description**
This commit modifies the CPU and Interpreter `DeviceManagers` to use the
total constant weight size of a function as its cost instead of a
hardcoded value of 1. `DeviceManagerTest` has been modified
accordingly.

**Testing**
All unit tests pass including `DeviceManagerTest`.

**Issues**
This PR fixes #3472.