### PR TITLE
Add getters and setters for scale/offset from fused RWQ tensors

### DIFF
--- a/include/glow/Quantization/Base/Base.h
+++ b/include/glow/Quantization/Base/Base.h
@@ -365,9 +365,6 @@ void tensorFusedRowwiseQuantization(const Tensor &input, Tensor &output) {
         "for 4-bits quantization.");
   }
 
-  const size_t outWidth = output.dims()[1];
-  char *dataBasePtr = output.getUnsafePtr();
-
   auto srcH = input.getHandle<float>();
   auto destH = output.getHandle<uint8_t>();
   for (size_t i = 0, e = input.dims()[0]; i < e; i++) {
@@ -422,12 +419,7 @@ void tensorFusedRowwiseQuantization(const Tensor &input, Tensor &output) {
     }
 
     // Now set the scale/offset at the end of each row.
-    T finalScale = static_cast<T>(scale);
-    T finalOffset = static_cast<T>(offset);
-    char *currRowScaleOffsetPtr =
-        dataBasePtr + (i + 1) * outWidth - 2 * sizeof(T);
-    memcpy(currRowScaleOffsetPtr, &finalScale, sizeof(T));
-    memcpy(currRowScaleOffsetPtr + sizeof(T), &finalOffset, sizeof(T));
+    destH.setFusedScaleOffsetInRow<T>(i, scale, offset);
   }
 }
 } // namespace quantization

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -3283,15 +3283,8 @@ void BoundInterpreterFunction::
       const float weight = static_cast<float>(WH.raw(curIdx));
       const size_t rowIdx = IH.raw(curIdx++);
       size_t offsetIn = rowIdx * inLineSize;
-      // Get the scale and offset from the row; go to the current row and offset
-      // into it up until the last 2*sizeof(T) bytes. Use memcpy to get the
-      // values out to avoid alignment issues.
-      const char *currRowScaleOffsetPtr =
-          data->getUnsafePtr() + offsetIn + inLineSize - 2 * sizeof(T);
-      T scale;
-      T offset;
-      memcpy(&scale, currRowScaleOffsetPtr, sizeof(T));
-      memcpy(&offset, currRowScaleOffsetPtr + sizeof(T), sizeof(T));
+      T scale, offset;
+      std::tie(scale, offset) = DH.getFusedScaleOffsetFromRow<T>(rowIdx);
       for (size_t k = 0; k < outLineSize; k++) {
         float d = quantization::dequantizeWithFloatOffset(
             DH.raw(offsetIn++), static_cast<float>(scale),

--- a/lib/Base/Tensor.cpp
+++ b/lib/Base/Tensor.cpp
@@ -599,28 +599,15 @@ Tensor Tensor::getCopyConvertedToType(ElemKind newKind) const {
              {dims()[0], dims()[1] - 2 * (sizeof(float) - sizeof(float16_t))},
              1.0, 0);
 
-  const size_t srcWidth = dims()[1];
   const size_t dstWidth = tmp.dims()[1];
-  auto *srcData = reinterpret_cast<uint8_t *>(getUnsafePtr());
-  auto *dstData = reinterpret_cast<uint8_t *>(tmp.getUnsafePtr());
   auto srcH = getHandle<uint8_t>();
   auto dstH = tmp.getHandle<uint8_t>();
   for (size_t i = 0, e = dims()[0]; i < e; i++) {
-    // Get the src's scale/offset for the row.
-    uint8_t *srcScaleOffsetPtr =
-        &srcData[(i + 1) * srcWidth] - 2 * sizeof(float);
-    float srcScale, srcOffset;
-    memcpy(&srcScale, srcScaleOffsetPtr, sizeof(float));
-    memcpy(&srcOffset, srcScaleOffsetPtr + sizeof(float), sizeof(float));
-
-    // Convert scale/offset to FP16 and copy only those to dst.
-    float16_t dstScale = static_cast<float16_t>(srcScale);
-    float16_t dstOffset = static_cast<float16_t>(srcOffset);
-    uint8_t *dstScaleOffsetPtr =
-        &dstData[(i + 1) * dstWidth] - 2 * sizeof(float16_t);
-    memcpy(dstScaleOffsetPtr, &dstScale, sizeof(float16_t));
-    memcpy(dstScaleOffsetPtr + sizeof(float16_t), &dstOffset,
-           sizeof(float16_t));
+    // Copy the scale/offset from src to dst.
+    float scale, offset;
+    std::tie(scale, offset) = srcH.getFusedScaleOffsetFromRow<float>(i);
+    dstH.setFusedScaleOffsetInRow<float16_t>(i, static_cast<float16_t>(scale),
+                                             static_cast<float16_t>(offset));
 
     // Copy over the row's uint8 data from src to dst; scales and offsets were
     // already copied over above.

--- a/lib/Quantization/Base/Base.cpp
+++ b/lib/Quantization/Base/Base.cpp
@@ -126,14 +126,8 @@ Tensor tensor4BitsFusedRowwiseDequantization(const Tensor &input) {
   auto srcH = input.getHandle<uint8_t>();
   auto destH = output.getHandle<float>();
   for (size_t i = 0; i < input.dims()[0]; i++) {
-    const char *currRowScaleOffsetPtr = input.getUnsafePtr() +
-                                        (i + 1) * input.dims()[1] -
-                                        2 * sizeof(float16_t);
-    float16_t scale;
-    float16_t offset;
-    memcpy(&scale, currRowScaleOffsetPtr, sizeof(float16_t));
-    memcpy(&offset, currRowScaleOffsetPtr + sizeof(float16_t),
-           sizeof(float16_t));
+    float16_t scale, offset;
+    std::tie(scale, offset) = srcH.getFusedScaleOffsetFromRow<float16_t>(i);
     for (size_t j = 0; j < output.dims()[1]; j++) {
       bool isMSB = (j % 2 == 1);
       destH.at({i, j}) = dequantize4BitWithFloatOffset(

--- a/tests/unittests/TensorsTest.cpp
+++ b/tests/unittests/TensorsTest.cpp
@@ -994,8 +994,39 @@ TEST(Tensor, randomizeFused_Float) {
 }
 
 /// Test randomizing a Fused tensor with Float16 scale/offsets.
-TEST(Tensor, randomizeFused_Foat16) {
+TEST(Tensor, randomizeFused_Float16) {
   testRandomizeFused(ElemKind::UInt8FusedFP16QTy);
+}
+
+/// Check that getting and setting fused tensors works correctly.
+template <typename ScaleOffsetT>
+static void testGetSetFusedScaleOffset(ElemKind fusedKind) {
+  Tensor T(fusedKind, {10, 10}, 1.0, 0);
+  auto TH = T.getHandle<uint8_t>();
+  for (size_t i = 0; i < 10; i++) {
+    TH.setFusedScaleOffsetInRow<ScaleOffsetT>(i, i, i);
+  }
+  for (size_t i = 0; i < 10; i++) {
+    ScaleOffsetT scale, offset;
+    std::tie(scale, offset) = TH.getFusedScaleOffsetFromRow<ScaleOffsetT>(i);
+    EXPECT_EQ(scale, (ScaleOffsetT)i);
+    EXPECT_EQ(offset, (ScaleOffsetT)i);
+  }
+}
+
+/// Test getting and setting fused scales and offsets from UInt8FusedQTy.
+TEST(Tensor, GetFusedScaleOffset_UInt8FusedQTy) {
+  testGetSetFusedScaleOffset<float>(ElemKind::UInt8FusedQTy);
+}
+
+/// Test getting and setting fused scales and offsets from UInt8FusedFP16QTy.
+TEST(Tensor, GetFusedScaleOffset_UInt8FusedFP16QTy) {
+  testGetSetFusedScaleOffset<float16_t>(ElemKind::UInt8FusedFP16QTy);
+}
+
+/// Test getting and setting fused scales and offsets from UInt4FusedFP16QTy.
+TEST(Tensor, GetFusedScaleOffset_UInt4FusedFP16QTy) {
+  testGetSetFusedScaleOffset<float16_t>(ElemKind::UInt4FusedFP16QTy);
 }
 
 /// Check if dump functions work for Tensor


### PR DESCRIPTION
Summary: Make using fused tensors easier by adding a helper to Tensor to retrieve scale and offset from a specific row.

Test Plan: Added test. All other unit tests still pass.
