### PR TITLE
Separate FP16 conversion for FloatTy and UInt8FusedQTy

### DIFF
--- a/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
+++ b/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
@@ -38,6 +38,9 @@ struct PrecisionConfiguration {
   /// Whether to convert the FloatTy to Float16Ty in the Function.
   bool convertToFP16{false};
 
+  /// Whether to convert UInt8FusedQTy to UInt8FusedFP16QTy in the Function.
+  bool convertFusedToFP16{false};
+
   /// Whether to clip out-of-range FP values to the min/max of fp16.
   bool clipFP16{false};
 

--- a/lib/Converter/Float16Converter.cpp
+++ b/lib/Converter/Float16Converter.cpp
@@ -66,13 +66,20 @@ convertFusedRowwiseQuantizedInputs(Function *F,
 
 void glow::convertFunctionToFloat16(Function *F,
                                     const PrecisionConfiguration &precConfig) {
+  DCHECK(precConfig.convertToFP16 || precConfig.convertFusedToFP16)
+      << "Expected to convert at least one of FloatTy or UInt8FusedQTy.";
+
   // Convert FloatTy to Float16Ty.
   TypeAToTypeBFunctionConverter converter(*F, ElemKind::FloatTy,
                                           ElemKind::Float16Ty, precConfig);
-  converter.convert();
+  if (precConfig.convertToFP16) {
+    converter.convert();
+  }
 
   // Now we want to additionally convert all nodes with inputs in UInt8FusedQTy
   // to UInt8FusedFP16QTy. This does not fit cleanly into the
   // TypeAToTypeBFunctionConverter, so write a custom pass to do so.
-  convertFusedRowwiseQuantizedInputs(F, precConfig);
+  if (precConfig.convertFusedToFP16) {
+    convertFusedRowwiseQuantizedInputs(F, precConfig);
+  }
 }

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -7364,6 +7364,7 @@ TEST_P(OperatorTest,
 
   CompilationContext cctx;
   cctx.precisionConfig.convertToFP16 = true;
+  cctx.precisionConfig.convertFusedToFP16 = true;
   EE_.compile(cctx);
   EE_.run(bindings_);
 

--- a/tests/unittests/RecommendationSystemTest.cpp
+++ b/tests/unittests/RecommendationSystemTest.cpp
@@ -703,6 +703,8 @@ protected:
   void setupPrecisionConfig() {
     if (convertToFP16) {
       precConfig_.convertToFP16 = convertToFP16;
+      // For now always convert both or neither.
+      precConfig_.convertFusedToFP16 = convertToFP16;
       // Note: always do not convert RWQ-SLWS here. The creator itself for
       // precisionForNonDataSLWS already directly created the node with the
       // correct precision.

--- a/tests/unittests/TypeAToTypeBFunctionConverterTest.cpp
+++ b/tests/unittests/TypeAToTypeBFunctionConverterTest.cpp
@@ -1044,7 +1044,10 @@ TEST_P(AllBackends, convertFRWQSLWS) {
 
   size_t origSize = F->getNodes().size();
 
-  convertFunctionToFloat16(F, PrecisionConfiguration());
+  PrecisionConfiguration precConfig;
+  precConfig.convertToFP16 = true;
+  precConfig.convertFusedToFP16 = true;
+  convertFunctionToFloat16(F, precConfig);
 
   // Should have added convert nodes for the data, weights, and results.
   EXPECT_EQ(F->getNodes().size(), origSize + 3);
@@ -1107,6 +1110,8 @@ TEST_P(AllBackends, skipConvertingFRWQSLWS) {
   size_t origSize = F->getNodes().size();
 
   PrecisionConfiguration precConfig;
+  precConfig.convertToFP16 = true;
+  precConfig.convertFusedToFP16 = true;
   precConfig.precisionModeKindSet.insert(
       Kinded::Kind::FusedRowwiseQuantizedSparseLengthsWeightedSumNodeKind);
   convertFunctionToFloat16(F, precConfig);
@@ -1122,6 +1127,119 @@ TEST_P(AllBackends, skipConvertingFRWQSLWS) {
 
   auto *origData = llvm::dyn_cast<Constant>(SLWS->getData());
   ASSERT_EQ(origData, R->getData().getNode());
+  EXPECT_EQ(origData->getOutput().getElementType(), ElemKind::UInt8FusedQTy);
+
+  auto *origWeights = llvm::dyn_cast<Constant>(SLWS->getWeights());
+  ASSERT_EQ(origWeights, weights);
+  EXPECT_EQ(origWeights->getOutput().getElementType(), ElemKind::FloatTy);
+
+  EXPECT_TRUE(F->verify());
+}
+
+/// Test conversion of only Float16Ty inputs of Node and not UInt8FusedQTy.
+TEST_P(AllBackends, convertOnlyFloat16Ty) {
+  Module mod;
+  Function *F = mod.createFunction("test");
+  Tensor data(ElemKind::FloatTy, {3, 1});
+  data.getHandle() = {
+      2.0,
+      -0.5,
+      13,
+  };
+
+  Constant *weights = mod.createConstant(ElemKind::FloatTy, {8}, "weights");
+
+  Placeholder *indices =
+      mod.createPlaceholder(ElemKind::Int64ITy, {8}, "indices",
+                            /* isTrainable */ false);
+  Placeholder *lengths =
+      mod.createPlaceholder(ElemKind::Int32ITy, {4}, "lengths",
+                            /* isTrainable */ false);
+  auto *R = F->createFusedRowwiseQuantizedSparseLengthsWeightedSum(
+      "RQSLWS", data, weights, indices, lengths, ElemKind::FloatTy);
+  SaveNode *S = F->createSave("save", R);
+
+  size_t origSize = F->getNodes().size();
+
+  PrecisionConfiguration precConfig;
+  precConfig.convertToFP16 = true;
+  precConfig.convertFusedToFP16 = false;
+  convertFunctionToFloat16(F, precConfig);
+
+  // Should have added convert nodes for the weights and results.
+  EXPECT_EQ(F->getNodes().size(), origSize + 2);
+
+  auto *convertResult = llvm::dyn_cast<ConvertToNode>(S->getInput());
+  ASSERT_NE(convertResult, nullptr);
+  EXPECT_EQ(convertResult->getResult().getElementType(), ElemKind::FloatTy);
+
+  auto *SLWS =
+      llvm::dyn_cast<FusedRowwiseQuantizedSparseLengthsWeightedSumNode>(
+          convertResult->getInput());
+  ASSERT_NE(SLWS, nullptr);
+  EXPECT_EQ(SLWS->getResult().getElementType(), ElemKind::Float16Ty);
+
+  auto *origData = llvm::dyn_cast<Constant>(SLWS->getData());
+  ASSERT_NE(origData, nullptr);
+  EXPECT_EQ(origData->getOutput().getElementType(), ElemKind::UInt8FusedQTy);
+
+  auto *convertWeights = llvm::dyn_cast<ConvertToNode>(SLWS->getWeights());
+  ASSERT_NE(convertWeights, nullptr);
+  EXPECT_EQ(convertWeights->getResult().getElementType(), ElemKind::Float16Ty);
+
+  auto *origWeights = llvm::dyn_cast<Constant>(convertWeights->getInput());
+  ASSERT_NE(origWeights, nullptr);
+  EXPECT_EQ(origWeights->getOutput().getElementType(), ElemKind::FloatTy);
+  EXPECT_EQ(weights, origWeights);
+
+  EXPECT_TRUE(F->verify());
+}
+
+/// Test conversion of only UInt8FusedQTy inputs of Node and not Float16Ty.
+TEST_P(AllBackends, convertOnlyUInt8FusedQTy) {
+  Module mod;
+  Function *F = mod.createFunction("test");
+  Tensor data(ElemKind::FloatTy, {3, 1});
+  data.getHandle() = {
+      2.0,
+      -0.5,
+      13,
+  };
+
+  Constant *weights = mod.createConstant(ElemKind::FloatTy, {8}, "weights");
+
+  Placeholder *indices =
+      mod.createPlaceholder(ElemKind::Int64ITy, {8}, "indices",
+                            /* isTrainable */ false);
+  Placeholder *lengths =
+      mod.createPlaceholder(ElemKind::Int32ITy, {4}, "lengths",
+                            /* isTrainable */ false);
+  auto *R = F->createFusedRowwiseQuantizedSparseLengthsWeightedSum(
+      "RQSLWS", data, weights, indices, lengths, ElemKind::FloatTy);
+  SaveNode *S = F->createSave("save", R);
+
+  size_t origSize = F->getNodes().size();
+
+  PrecisionConfiguration precConfig;
+  precConfig.convertToFP16 = false;
+  precConfig.convertFusedToFP16 = true;
+  convertFunctionToFloat16(F, precConfig);
+
+  // Should have added a convert nodes for the data.
+  EXPECT_EQ(F->getNodes().size(), origSize + 1);
+
+  auto *SLWS =
+      llvm::dyn_cast<FusedRowwiseQuantizedSparseLengthsWeightedSumNode>(
+          S->getInput());
+  ASSERT_EQ(SLWS, R);
+
+  auto *convertData = llvm::dyn_cast<ConvertToNode>(SLWS->getData());
+  ASSERT_NE(convertData, nullptr);
+  EXPECT_EQ(convertData->getResult().getElementType(),
+            ElemKind::UInt8FusedFP16QTy);
+
+  auto *origData = llvm::dyn_cast<Constant>(convertData->getInput());
+  ASSERT_NE(origData, nullptr);
   EXPECT_EQ(origData->getOutput().getElementType(), ElemKind::UInt8FusedQTy);
 
   auto *origWeights = llvm::dyn_cast<Constant>(SLWS->getWeights());


### PR DESCRIPTION
Summary: As above. Some backends may support mixed precision with fused scales/offsets (`UInt8FusedQTy`) and normal float tensors (`FloatTy`). Allow for specification of each separately.

Differential Revision: D17176383

