### PR TITLE
[LLVM] Add command line option for ABI type

### DIFF
--- a/lib/LLVMIRCodeGen/CommandLine.cpp
+++ b/lib/LLVMIRCodeGen/CommandLine.cpp
@@ -18,20 +18,25 @@
 
 llvm::cl::OptionCategory &getLLVMBackendCat() {
   static llvm::cl::OptionCategory cpuBackendCat("Glow CPU Backend Options");
-
   return cpuBackendCat;
 }
 
 llvm::cl::opt<std::string> llvmTarget("target",
                                       llvm::cl::desc("LLVM target to be used"));
+
 llvm::cl::opt<std::string>
     llvmArch("march", llvm::cl::desc("LLVM architecture to be used"));
+
 llvm::cl::opt<std::string> llvmCPU("mcpu",
                                    llvm::cl::desc("LLVM CPU to be used"));
+
 llvm::cl::list<std::string>
     llvmTargetFeatures("target-feature",
                        llvm::cl::desc("LLVM target/CPU features to be used"),
                        llvm::cl::CommaSeparated, llvm::cl::ZeroOrMore);
+
+llvm::cl::alias llvmMAttr("mattr", llvm::cl::desc("Alias for -target-feature"),
+                          llvm::cl::aliasopt(llvmTargetFeatures));
 
 llvm::cl::opt<std::string>
     llvmCompiler("llvm-compiler",
@@ -42,3 +47,13 @@ llvm::cl::list<std::string> llvmCompilerOptions(
     "llvm-compiler-opt",
     llvm::cl::desc("Options to pass to the external LLVM compiler"),
     llvm::cl::ZeroOrMore);
+
+llvm::cl::opt<llvm::FloatABI::ABIType>
+    floatABI("float-abi", llvm::cl::desc("Option to set float ABI type"),
+             llvm::cl::values(clEnumValN(llvm::FloatABI::Default, "default",
+                                         "Default float ABI type"),
+                              clEnumValN(llvm::FloatABI::Soft, "soft",
+                                         "Soft float ABI (softfp)"),
+                              clEnumValN(llvm::FloatABI::Hard, "hard",
+                                         "Hard float ABI (hardfp)")),
+             llvm::cl::init(llvm::FloatABI::Default));

--- a/lib/LLVMIRCodeGen/CommandLine.h
+++ b/lib/LLVMIRCodeGen/CommandLine.h
@@ -18,6 +18,7 @@
 #define GLOW_LLVMIRCODEGEN_COMMANDLINE_H
 
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Target/TargetOptions.h"
 
 llvm::cl::OptionCategory &getLLVMBackendCat();
 
@@ -27,18 +28,29 @@ llvm::cl::OptionCategory &getLLVMBackendCat();
 
 /// Target to be used by the LLVMBackend. Used as -target=targetA.
 extern llvm::cl::opt<std::string> llvmTarget;
+
 /// Architecture to be used by the LLVMBackend. Used as -march=archA.
 extern llvm::cl::opt<std::string> llvmArch;
+
 /// CPU to be used by the LLVMBackend. Used as -mcpu=cpuA.
 extern llvm::cl::opt<std::string> llvmCPU;
+
 /// Target and CPU features to be used by the LLVMBackend. The features should
 /// be comma-separated and prefixed with +.
 /// Used as  -target-feature=+featureA,+featureB.
 extern llvm::cl::list<std::string> llvmTargetFeatures;
-//// External LLVM compiler (e.g. llc) to use for compiling LLVM bitcode into
+
+/// Alias for the LLVM Machine attributes.
+extern llvm::cl::alias llvmMAttr;
+
+/// External LLVM compiler (e.g. llc) to use for compiling LLVM bitcode into
 /// machine code.
 extern llvm::cl::opt<std::string> llvmCompiler;
+
 /// Set of options to pass to the external LLVM compiler.
 extern llvm::cl::list<std::string> llvmCompilerOptions;
+
+/// Option to set float ABI. Used as -float-abi=<abi-type>.
+extern llvm::cl::opt<llvm::FloatABI::ABIType> floatABI;
 
 #endif // GLOW_LLVMIRCODEGEN_COMMANDLINE_H

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -66,8 +66,8 @@ llvm::cl::opt<llvm::Reloc::Model> relocModel(
 /// Limitation of number of arguments for `emitDataParallelKernel`.
 constexpr static size_t kArgLimit = 64;
 
-/// Generate the LLVM MAttr list of attributes.
-static llvm::SmallVector<std::string, 0> getMachineAttributes() {
+/// Generate the LLVM machine attribute list for the host.
+static llvm::SmallVector<std::string, 0> getHostMachineAttributes() {
   llvm::SmallVector<std::string, 0> result;
   llvm::StringMap<bool> hostFeatures;
   if (llvm::sys::getHostCPUFeatures(hostFeatures)) {
@@ -111,18 +111,22 @@ void LLVMIRGen::initTargetMachine(
   llvm::InitializeAllTargetMCs();
   llvm::InitializeAllAsmPrinters();
   llvm::InitializeAllAsmParsers();
+  llvm::TargetOptions targetOpts;
+  targetOpts.FloatABIType = floatABI;
 
   if (target.empty()) {
     TM_.reset(llvm::EngineBuilder()
                   .setCodeModel(codeModel)
                   .setRelocationModel(relocModel)
+                  .setTargetOptions(targetOpts)
                   .selectTarget(llvm::Triple(), arch, getHostCpuName(),
-                                getMachineAttributes()));
+                                getHostMachineAttributes()));
   } else {
     TM_.reset(
         llvm::EngineBuilder()
             .setCodeModel(codeModel)
             .setRelocationModel(relocModel)
+            .setTargetOptions(targetOpts)
             .selectTarget(llvm::Triple(target), arch, cpu, targetFeatures));
   }
   assert(TM_ && "Could not initialize the target machine");


### PR DESCRIPTION
**Summary**
Add command line option for ABI type (soft/hard/default): useful to force the generated bundle to have a specific ABI such that it links properly with some MCU toolchains.
Add "-mattr" alias for "-target-feature" LLVM option (common usage from clang).
