### PR TITLE
Interpreter send-recv experiment == Not to land ==

### DIFF
--- a/include/glow/Backends/DeviceManager.h
+++ b/include/glow/Backends/DeviceManager.h
@@ -155,6 +155,20 @@ public:
   /// \returns the DeviceInfo for this device containing peak limits for
   /// compute and bandwidths (used in partitioning).
   virtual DeviceInfo getDeviceInfo() const { return DeviceInfo(); }
+
+  virtual bool isPeerToPeerSupported() { return false; }
+
+  virtual llvm::Error setupRemotePeerToPeer(int64_t channelId,
+                                            DeviceManager *remote) {
+    return MAKE_ERR(GlowErr::ErrorCode::RUNTIME_ERROR,
+                    "Backend does not support peer-to-peer communication.");
+  }
+
+  virtual llvm::Error getRemotePeerToPeerAddress(int64_t channelId,
+                                                 Placeholder *remoteAddress) {
+    return MAKE_ERR(GlowErr::ErrorCode::RUNTIME_ERROR,
+                    "Backend does not support peer-to-peer communication.");
+  }
 };
 
 } // namespace runtime

--- a/include/glow/Backends/DeviceManager.h
+++ b/include/glow/Backends/DeviceManager.h
@@ -164,8 +164,8 @@ public:
                     "Backend does not support peer-to-peer communication.");
   }
 
-  virtual llvm::Error getRemotePeerToPeerAddress(int64_t channelId,
-                                                 Placeholder *remoteAddress) {
+  virtual llvm::Expected<int64_t>
+  getRemotePeerToPeerAddress(int64_t channelId, PlaceholderBindings *bindings) {
     return MAKE_ERR(GlowErr::ErrorCode::RUNTIME_ERROR,
                     "Backend does not support peer-to-peer communication.");
   }

--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -504,6 +504,8 @@ public:
       return isEqualImpl<uint8_t>(other, allowedError, verbose);
     case ElemKind::BoolTy:
       return isEqualImpl<bool>(other, allowedError, verbose);
+    case ElemKind::AddressTy:
+      return isEqualImpl<int64_t>(other, allowedError, verbose);
     }
 
     // This is to make compiler happy. It can never reach this point as switch

--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -506,6 +506,8 @@ public:
       return isEqualImpl<bool>(other, allowedError, verbose);
     case ElemKind::AddressTy:
       return isEqualImpl<int64_t>(other, allowedError, verbose);
+    case ElemKind::UIntPtrTy:
+      return isEqualImpl<uintptr_t>(other, allowedError, verbose);
     }
 
     // This is to make compiler happy. It can never reach this point as switch

--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -292,6 +292,8 @@ enum class ElemKind : unsigned char {
   BoolTy,
   // Address type (int64_t or uint64_t?)
   AddressTy,
+  // Unsigned integer type capable of holding a pointer (uintptr_t)
+  UIntPtrTy,
 };
 
 /// \returns whether \p e is a quantized ElemKind.
@@ -552,6 +554,8 @@ struct Type final {
       return std::is_same<ElemTy, bool>::value;
     case ElemKind::AddressTy:
       return std::is_same<ElemTy, int64_t>::value;
+    case ElemKind::UIntPtrTy:
+      return std::is_same<ElemTy, uintptr_t>::value;
     }
     LOG(FATAL) << "Invalid type: " << getElementName(Ty).str();
   }
@@ -612,6 +616,8 @@ struct Type final {
       return sizeof(bool);
     case ElemKind::AddressTy:
       return sizeof(int64_t);
+    case ElemKind::UIntPtrTy:
+      return sizeof(uintptr_t);
     }
     LOG(FATAL) << "Invalid type: " << getElementName(Ty).str();
   }

--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -290,6 +290,8 @@ enum class ElemKind : unsigned char {
   UInt4FusedFP16QTy,
   // Bool type (bool)
   BoolTy,
+  // Address type (int64_t or uint64_t?)
+  AddressTy,
 };
 
 /// \returns whether \p e is a quantized ElemKind.
@@ -548,6 +550,8 @@ struct Type final {
       return std::is_same<ElemTy, uint8_t>::value;
     case ElemKind::BoolTy:
       return std::is_same<ElemTy, bool>::value;
+    case ElemKind::AddressTy:
+      return std::is_same<ElemTy, int64_t>::value;
     }
     LOG(FATAL) << "Invalid type: " << getElementName(Ty).str();
   }
@@ -606,6 +610,8 @@ struct Type final {
       return sizeof(uint8_t);
     case ElemKind::BoolTy:
       return sizeof(bool);
+    case ElemKind::AddressTy:
+      return sizeof(int64_t);
     }
     LOG(FATAL) << "Invalid type: " << getElementName(Ty).str();
   }

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -1253,6 +1253,16 @@ public:
                   const llvm::ArrayRef<NodeValue> inputs, unsigned batchSize,
                   unsigned hiddenSize, unsigned outputSize,
                   std::vector<NodeValue> &outputs);
+
+  RecvReadyNode *createRecvReady(llvm::StringRef name, unsigned_t channelId,
+                                 TypeRef remoteTensorTypeDescriptor);
+
+  SendNode *createSend(llvm::StringRef name, NodeValue input,
+                       NodeValue remoteAddress, unsigned_t channelId,
+                       TypeRef remoteTensorTypeDescriptor);
+
+  RecvNode *createRecv(llvm::StringRef name, NodeValue localAddress,
+                       unsigned_t channelId, TypeRef tensorTypeDescriptor);
   /// @}
 
   /// Create a TraceEvent in the runtime profile, which triggers collection of

--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -134,6 +134,15 @@ class Placeholder : public Storage {
   /// Specifies if associated Tensors should be zeroed when allocated.
   bool allocZero_{false};
 
+  // Specifies the policy about loading the associated Tensor to the device,
+  // and reading it from the device:
+  // 0 - Input - always load, read on demand (i.e. for debug)
+  // 1 - Intermediate - do not load, read on demand
+  // 2 - IntermediateWithInit - load at init only, read on demand
+  // 3 - Output - do not load, always read
+  // 4 - InOut - always load, always read
+  int ioPolicy_{0};
+
 public:
   /// Create a new placeholder.
   Placeholder(llvm::StringRef name, TypeRef Ty, bool isTrainable)
@@ -148,6 +157,9 @@ public:
 
   /// \returns True if associated Tensors should be zeroed when allocated.
   bool allocZero() const { return allocZero_; }
+
+  int getIoPolicy() { return ioPolicy_; }
+  void setIoPolicy(int p) { ioPolicy_ = p; }
 
   /// Sets whether or not associated Tensors should be zeroed.
   void setAllocZero(bool on = true) { allocZero_ = on; }

--- a/include/glow/LLVMIRCodeGen/LLVMCompiledFunction.h
+++ b/include/glow/LLVMIRCodeGen/LLVMCompiledFunction.h
@@ -20,8 +20,25 @@
 
 #include "glow/Backend/BackendUtils.h"
 #include "glow/Backend/CompiledFunction.h"
+#include "glow/ExecutionContext/ExecutionContext.h"
 
 namespace glow {
+
+/// CPUDeviceBindings inherits from DeviceBindings, it contains per run
+/// device specific information used to run a compiled function on a specific
+/// device.
+struct CPUDeviceBindings : DeviceBindings {
+  CPUDeviceBindings(uint8_t *activationsBuffer, uint8_t *weightsBuffer)
+      : DeviceBindings("CPU"), deviceActivationsBuffer{activationsBuffer},
+        deviceWeightsBuffer{weightsBuffer} {}
+
+  ~CPUDeviceBindings() {}
+
+  /// TODO: determine if these are owned pointers! ==> should be freed in DTOR
+  uint8_t *deviceActivationsBuffer;
+  uint8_t *deviceWeightsBuffer;
+};
+
 /// A Glow IR function compiled using LLVM.
 class LLVMCompiledFunction : public CompiledFunction {
 public:

--- a/lib/Backends/CPU/CPUDeviceManager.h
+++ b/lib/Backends/CPU/CPUDeviceManager.h
@@ -24,6 +24,33 @@
 namespace glow {
 namespace runtime {
 
+/// A class that contains an openCL device buffer. It frees the buffer when it
+/// is destroyed.
+class CPUBuffer {
+  /// The OpenCL buffer being stored.
+  uint8_t* activationsBuffer_;
+  uint8_t* weightsBuffer_;
+  /// Size of the buffer in bytes.
+  const size_t activationsSize_{0};
+  const size_t weightsSize_{0};
+
+public:
+  ~CPUBuffer();
+
+  CPUBuffer(uint8_t *activationsBuffer, size_t activationsSize,
+            uint8_t *weightsBuffer, size_t weightsSize)
+      : activationsBuffer_(activationsBuffer), weightsBuffer_(weightsBuffer),
+        activationsSize_(activationsSize), weightsSize_(weightsSize) {}
+
+  /// Returns the stored buffer.
+  uint8_t *getActivationsBuffer() { return activationsBuffer_; }
+  uint8_t *getWeightsBuffer() { return weightsBuffer_; }
+
+  /// Get size of buffer in bytes.
+  size_t getActivationsSize() { return activationsSize_; }
+  size_t getWeightsSize() { return weightsSize_; }
+};
+
 /// A class controlling a single CPU thread of execution driving the JIT
 /// backend. Many CPUFunctions may be added, but only one inference is executed
 /// at a time.
@@ -34,6 +61,9 @@ class CPUDeviceManager : public QueueBackedDeviceManager {
   /// Static memory cost of the CPU Function.
   /// This is very arbitrary for the CPU backend.
   const uint64_t functionCost_{1};
+
+  /// A map from function name to its memory buffer
+  std::map<std::string, std::unique_ptr<CPUBuffer>> buffers_;
 
   /// String constant for logging number of in-use devices.
   static constexpr const char *kDevicesUsedCPU = "glow.devices_used.cpu";

--- a/lib/Backends/CPU/CPUDeviceManager.h
+++ b/lib/Backends/CPU/CPUDeviceManager.h
@@ -42,6 +42,8 @@ public:
       : activationsBuffer_(activationsBuffer), weightsBuffer_(weightsBuffer),
         activationsSize_(activationsSize), weightsSize_(weightsSize) {}
 
+  CPUBuffer* getBuffer() { return this; }
+
   /// Returns the stored buffer.
   uint8_t *getActivationsBuffer() { return activationsBuffer_; }
   uint8_t *getWeightsBuffer() { return weightsBuffer_; }
@@ -95,6 +97,11 @@ public:
   /// Returns the DeviceInfo for this device containing peak limits for
   /// compute and bandwidths (used in partitioning).
   DeviceInfo getDeviceInfo() const override;
+
+  bool isPeerToPeerSupported() override;
+  llvm::Expected<int64_t>
+  getRemotePeerToPeerAddress(int64_t channelId,
+                             PlaceholderBindings *bindings) override;
 
 protected:
   void addNetworkImpl(const Module *module, FunctionMapTy functions,

--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -1969,6 +1969,11 @@ void libjit_write_timestamp(uint64_t *tensor, size_t offset) {
   memcpy(tensor + offset, &ts, sizeof(uint64_t));
 }
 
+void libjit_send(int64_t *dest, int64_t *src, size_t numBytes) {
+  uint8_t* destAddress = reinterpret_cast<uint8_t*>(*dest);
+  memcpy(destAddress, src, numBytes);
+}
+
 /// Update min/max values \p compInfo and histogram \p existingHistogram with
 /// data collected from tensor \p inputTensor.
 /// Note: code ported from Profile.cpp: generateTensorHistogram

--- a/lib/Backends/Interpreter/CMakeLists.txt
+++ b/lib/Backends/Interpreter/CMakeLists.txt
@@ -3,7 +3,8 @@ add_library(Interpreter
               InterpreterFunction.cpp
               InterpreterNodes.cpp
               InterpreterDeviceManager.cpp
-              InterpreterFactory.cpp)
+              InterpreterFactory.cpp
+              InterpreterDeviceMemoryHelper.cpp)
 target_link_libraries(Interpreter
                       PRIVATE
                         Backend

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -462,6 +462,10 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
            (NI.getOutElemTy(
                 CrossEntropyLossGradNode::GradOfInputNamedLabelsIdx) ==
             ElemKind::Int64ITy);
+  case Kinded::Kind::RecvReadyNodeKind:
+  case Kinded::Kind::SendNodeKind:
+  case Kinded::Kind::RecvNodeKind:
+    return true;
 
   default:
     return false;

--- a/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
@@ -148,6 +148,8 @@ void InterpreterDeviceManager::runFunctionImpl(
   }
 
   CompiledFunction *func = funcIt->second;
+  auto ifunc = static_cast<InterpreterFunction *>(func);
+  ifunc->setMemoryHelper(memoryHelperPtr_);
 
   // Run that function.
   auto executeErr = func->execute(context.get());
@@ -157,6 +159,21 @@ void InterpreterDeviceManager::runFunctionImpl(
 
   // Fire the resultCB.
   resultCB(id, std::move(executeErr), std::move(context));
+}
+
+bool InterpreterDeviceManager::isPeerToPeerSupported() { return true; }
+
+llvm::Error
+InterpreterDeviceManager::setupRemotePeerToPeer(int64_t channelId,
+                                                DeviceManager *remote) {
+  auto idm = static_cast<InterpreterDeviceManager *>(remote);
+  memoryHelperPtr_->addRemoteReceiver(channelId, idm->memoryHelperPtr_.get());
+  return llvm::Error::success();
+}
+
+llvm::Error InterpreterDeviceManager::getRemotePeerToPeerAddress(
+    int64_t channelId, Placeholder *remoteAddress) {
+  return llvm::Error::success();
 }
 
 } // namespace runtime

--- a/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
@@ -171,10 +171,6 @@ InterpreterDeviceManager::setupRemotePeerToPeer(int64_t channelId,
   return llvm::Error::success();
 }
 
-llvm::Error InterpreterDeviceManager::getRemotePeerToPeerAddress(
-    int64_t channelId, Placeholder *remoteAddress) {
-  return llvm::Error::success();
-}
 
 } // namespace runtime
 } // namespace glow

--- a/lib/Backends/Interpreter/InterpreterDeviceManager.h
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.h
@@ -87,8 +87,6 @@ protected:
   bool isPeerToPeerSupported() override;
   llvm::Error setupRemotePeerToPeer(int64_t channelId,
                                     DeviceManager *remote) override;
-  llvm::Error getRemotePeerToPeerAddress(int64_t channelId,
-                                         Placeholder *remoteAddress) override;
 };
 
 DeviceManager *createInterpreterDeviceManager(const DeviceConfig &config);

--- a/lib/Backends/Interpreter/InterpreterDeviceMemoryHelper.cpp
+++ b/lib/Backends/Interpreter/InterpreterDeviceMemoryHelper.cpp
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "InterpreterDeviceMemoryHelper.h"
+
+using namespace glow;
+
+InterpreterDeviceMemoryHelper::InterpreterDeviceMemoryHelper() {}
+
+InterpreterDeviceMemoryHelper::~InterpreterDeviceMemoryHelper() {
+  for (const auto &pair : tensors_) {
+    delete pair.second;
+  }
+  tensors_.clear();
+}
+
+void InterpreterDeviceMemoryHelper::allocateTensor(channel_id_type channelId,
+                                                   TypeRef tensorType) {
+  std::lock_guard<std::mutex> tGuard(tensorsGuard_);
+  std::lock_guard<std::mutex> sGuard(transferStatusGuard_);
+  assert(tensors_.find(channelId) == tensors_.end() &&
+         "Tensor already allocated for channel ID");
+  tensors_.insert(std::make_pair(channelId, new Tensor(tensorType)));
+  transferStatus_.insert(std::make_pair(channelId, false));
+}
+
+Tensor *
+InterpreterDeviceMemoryHelper::getLocalTensor(channel_id_type channelId) {
+  std::lock_guard<std::mutex> tGuard(tensorsGuard_);
+  auto it = tensors_.find(channelId);
+  assert(it != tensors_.end() && "Unknown channel ID");
+  return it->second;
+}
+
+Tensor *
+InterpreterDeviceMemoryHelper::getRemoteTensor(channel_id_type channelId) {
+  std::lock_guard<std::mutex> rGuard(remotesGuard_);
+  auto it = remoteReceiverDevices_.find(channelId);
+  assert(it != remoteReceiverDevices_.end() && "Unknown remote channel ID");
+  return it->second->getLocalTensor(channelId);
+}
+
+bool InterpreterDeviceMemoryHelper::getLocalStatus(channel_id_type channelId) {
+  const auto st = transferStatus_.find(channelId);
+  assert(st != transferStatus_.end() && "Unknown channel ID");
+  return st->second;
+}
+
+void InterpreterDeviceMemoryHelper::addRemoteReceiver(
+    channel_id_type channelId, InterpreterDeviceMemoryHelper *receiver) {
+  std::lock_guard<std::mutex> rGuard(remotesGuard_);
+  remoteReceiverDevices_.insert(std::make_pair(channelId, receiver));
+}
+
+void InterpreterDeviceMemoryHelper::sendTensor(channel_id_type channelId,
+                                               Tensor *message) {
+  // copy data
+  Tensor *dest = getRemoteTensor(channelId);
+  dest->copyRawFrom(message);
+  // set transfer status
+  std::lock_guard<std::mutex> rGuard(remotesGuard_);
+  auto it = remoteReceiverDevices_.find(channelId);
+  assert(it != remoteReceiverDevices_.end() && "Unknown remote channel ID");
+  it->second->transferCompleted(channelId);
+}
+
+void InterpreterDeviceMemoryHelper::transferCompleted(
+    channel_id_type channelId) {
+  std::lock_guard<std::mutex> sGuard(transferStatusGuard_);
+  auto st = transferStatus_.find(channelId);
+  assert(st != transferStatus_.end() && "Unknown channel ID");
+  st->second = true;
+}

--- a/lib/Backends/Interpreter/InterpreterDeviceMemoryHelper.h
+++ b/lib/Backends/Interpreter/InterpreterDeviceMemoryHelper.h
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_BACKENDS_INTERPRETER_INTERPRETERDEVICEMEMORYHELPER_H
+#define GLOW_BACKENDS_INTERPRETER_INTERPRETERDEVICEMEMORYHELPER_H
+
+#include "glow/Base/Tensor.h"
+#include <mutex>
+#include <unordered_map>
+
+namespace glow {
+
+typedef int64_t channel_id_type;
+
+class InterpreterDeviceMemoryHelper final {
+
+public:
+  explicit InterpreterDeviceMemoryHelper();
+  ~InterpreterDeviceMemoryHelper();
+
+  /// Allocates tensor memory on local device
+  void allocateTensor(channel_id_type channelId, TypeRef tensorType);
+  /// Add remote receiver device mapped to the given channelId
+  void addRemoteReceiver(channel_id_type channelId,
+                         InterpreterDeviceMemoryHelper *receiver);
+  /// Sends tensor data to the remote receiver device corresponding to channelId
+  void sendTensor(channel_id_type channelId, Tensor *message);
+  /// Returns local tensor backing
+  Tensor *getLocalTensor(channel_id_type channelId);
+  /// Returns true if the tensor was received
+  bool getLocalStatus(channel_id_type channelId);
+
+private:
+  Tensor *getRemoteTensor(channel_id_type channelId);
+  void transferCompleted(channel_id_type channelId);
+
+  std::unordered_map<channel_id_type, Tensor *> tensors_; // received tensors
+  std::mutex tensorsGuard_;
+  std::unordered_map<channel_id_type, InterpreterDeviceMemoryHelper *>
+      remoteReceiverDevices_; // devices to send tensors to
+  std::mutex remotesGuard_;
+  std::unordered_map<channel_id_type, bool> transferStatus_;
+  std::mutex transferStatusGuard_;
+};
+
+} // namespace glow
+#endif // GLOW_BACKENDS_INTERPRETER_INTERPRETERDEVICEMEMORYHELPER_H

--- a/lib/Backends/Interpreter/InterpreterFunction.cpp
+++ b/lib/Backends/Interpreter/InterpreterFunction.cpp
@@ -51,6 +51,7 @@ void InterpreterFunction::collectConstants(const Module *module) {
 
 llvm::Error InterpreterFunction::execute(ExecutionContext *context) {
   BoundInterpreterFunction boundFunc(constants_);
+  boundFunc.setMemoryHelper(memoryHelperPtr_);
   auto res = boundFunc.execute(F_.get(), context);
   {
     TRACE_EVENT_SCOPE(context, TraceLevel::RUNTIME, "processInstrumentation");

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -16,6 +16,7 @@
 #ifndef GLOW_BACKENDS_INTERPRETER_INTERPRETERFUNCTION_H
 #define GLOW_BACKENDS_INTERPRETER_INTERPRETERFUNCTION_H
 
+#include "InterpreterDeviceMemoryHelper.h"
 #include "glow/Backend/Backend.h"
 #include "glow/Backend/BackendUtils.h"
 #include "glow/Backend/CompiledFunction.h"
@@ -49,6 +50,9 @@ class InterpreterFunction final : public CompiledFunction {
   /// Maps Value.name to tensors for constants.
   std::unordered_map<std::string, Tensor *> constants_;
 
+  // std::shared_ptr<std::unordered_map<int64_t, Tensor *>> memoryHelperPtr_;
+  std::shared_ptr<InterpreterDeviceMemoryHelper> memoryHelperPtr_;
+
 public:
   InterpreterFunction(std::unique_ptr<IRFunction> F,
                       runtime::RuntimeBundle &&bundle);
@@ -72,6 +76,10 @@ public:
   virtual std::string getCompileBackendName() const override {
     return "Interpreter";
   }
+
+  void setMemoryHelper(std::shared_ptr<InterpreterDeviceMemoryHelper> mhp) {
+    memoryHelperPtr_ = std::move(mhp);
+  }
   ///@}
 };
 
@@ -86,6 +94,10 @@ class BoundInterpreterFunction {
   /// A reference to the constant map from the owning InterpreterFunction.
   const std::unordered_map<std::string, Tensor *> &constants_;
 
+  // std::shared_ptr<std::unordered_map<int64_t, Tensor *>> memoryHelperPtr_
+  std::shared_ptr<InterpreterDeviceMemoryHelper> memoryHelperPtr_;
+  ;
+
 public:
   explicit BoundInterpreterFunction(
       const std::unordered_map<std::string, Tensor *> &constants)
@@ -94,6 +106,10 @@ public:
   ~BoundInterpreterFunction();
 
   llvm::Error execute(IRFunction *F, ExecutionContext *context);
+
+  void setMemoryHelper(std::shared_ptr<InterpreterDeviceMemoryHelper> mhp) {
+    memoryHelperPtr_ = std::move(mhp);
+  }
 
 private:
   /// \returns a pointer to the tensor that is saved under \p v.

--- a/lib/Base/Tensor.cpp
+++ b/lib/Base/Tensor.cpp
@@ -301,6 +301,8 @@ void glow::dumpAsciiImpl(const Tensor *T, llvm::raw_ostream &os) {
     return dumpAsciiGenericImpl(T->getHandle<bool>(), os);
   case ElemKind::AddressTy:
     return dumpAsciiGenericImpl(T->getHandle<int64_t>(), os);
+  case ElemKind::UIntPtrTy:
+    return dumpAsciiGenericImpl(T->getHandle<uintptr_t>(), os);
   }
 }
 
@@ -335,6 +337,8 @@ void glow::dumpImpl(const Tensor *T, llvm::raw_ostream &os,
     return dumpGenericImpl(T->getHandle<bool>(), os, maxNumElem);
   case ElemKind::AddressTy:
     return dumpGenericImpl(T->getHandle<int64_t>(), os, maxNumElem);
+  case ElemKind::UIntPtrTy:
+    return dumpGenericImpl(T->getHandle<uintptr_t>(), os, maxNumElem);
   }
 }
 
@@ -471,6 +475,12 @@ void glow::genericTranspose(const Tensor *src, Tensor *dest,
     transposeSelectImpl(srcH, destH, shuffle);
     return;
   }
+  case ElemKind::UIntPtrTy: {
+    auto srcH = src->getHandle<uintptr_t>();
+    auto destH = dest->getHandle<uintptr_t>();
+    transposeSelectImpl(srcH, destH, shuffle);
+    return;
+  }
   }
 }
 
@@ -546,6 +556,10 @@ void Tensor::init(InitKind init, float val, PseudoRNG &PRNG) {
 
     case ElemKind::BoolTy: {
       getHandle<bool>().clear(val);
+      break;
+    }
+    case ElemKind::UIntPtrTy: {
+      getHandle<uintptr_t>().clear(val);
       break;
     }
     }

--- a/lib/Base/Tensor.cpp
+++ b/lib/Base/Tensor.cpp
@@ -299,6 +299,8 @@ void glow::dumpAsciiImpl(const Tensor *T, llvm::raw_ostream &os) {
     return dumpAsciiGenericImpl(T->getHandle<uint8_t>(), os);
   case ElemKind::BoolTy:
     return dumpAsciiGenericImpl(T->getHandle<bool>(), os);
+  case ElemKind::AddressTy:
+    return dumpAsciiGenericImpl(T->getHandle<int64_t>(), os);
   }
 }
 
@@ -331,6 +333,8 @@ void glow::dumpImpl(const Tensor *T, llvm::raw_ostream &os,
     return dumpGenericImpl(T->getHandle<uint8_t>(), os, maxNumElem);
   case ElemKind::BoolTy:
     return dumpGenericImpl(T->getHandle<bool>(), os, maxNumElem);
+  case ElemKind::AddressTy:
+    return dumpGenericImpl(T->getHandle<int64_t>(), os, maxNumElem);
   }
 }
 
@@ -458,6 +462,12 @@ void glow::genericTranspose(const Tensor *src, Tensor *dest,
   case ElemKind::BoolTy: {
     auto srcH = src->getHandle<bool>();
     auto destH = dest->getHandle<bool>();
+    transposeSelectImpl(srcH, destH, shuffle);
+    return;
+  }
+  case ElemKind::AddressTy: {
+    auto srcH = src->getHandle<int64_t>();
+    auto destH = dest->getHandle<int64_t>();
     transposeSelectImpl(srcH, destH, shuffle);
     return;
   }

--- a/lib/Exporter/ONNXModelWriter.cpp
+++ b/lib/Exporter/ONNXModelWriter.cpp
@@ -1140,6 +1140,9 @@ DEF_ALL_WRITER_NODE(RowwiseQuantizedFullyConnected)
 DEF_ALL_WRITER_NODE(RowwiseQuantizedSparseLengthsWeightedSum)
 DEF_ALL_WRITER_NODE(FusedRowwiseQuantizedSparseLengthsSum)
 DEF_ALL_WRITER_NODE(FusedRowwiseQuantizedSparseLengthsWeightedSum)
+DEF_ALL_WRITER_NODE(RecvReady)
+DEF_ALL_WRITER_NODE(Send)
+DEF_ALL_WRITER_NODE(Recv)
 
 llvm::Error ONNXModelWriter::writeConvertTo(const ConvertToNode *node,
                                             GraphType &graph) {

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -2760,6 +2760,29 @@ void Function::createLSTM(PlaceholderBindings &bindings,
   }
 };
 
+RecvReadyNode *Function::createRecvReady(llvm::StringRef name,
+                                         unsigned_t channelId,
+                                         TypeRef remoteTensorTypeDescriptor) {
+  auto outTy = getParent()->uniqueType(ElemKind::AddressTy, {1});
+  return addNode(
+      new RecvReadyNode(name, outTy, channelId, remoteTensorTypeDescriptor));
+}
+
+SendNode *Function::createSend(llvm::StringRef name, NodeValue input,
+                               NodeValue remoteAddress, unsigned_t channelId,
+                               TypeRef remoteTensorTypeDescriptor) {
+  auto outTy = getParent()->uniqueType(*(input.getType()));
+  return addNode(new SendNode(name, outTy, input, remoteAddress, channelId,
+                              remoteTensorTypeDescriptor));
+}
+
+RecvNode *Function::createRecv(llvm::StringRef name, NodeValue localAddress,
+                               unsigned_t channelId,
+                               TypeRef tensorTypeDescriptor) {
+  return addNode(new RecvNode(name, tensorTypeDescriptor, localAddress,
+                              channelId, tensorTypeDescriptor));
+}
+
 TraceEventNode *Function::createTraceEvent(llvm::StringRef eventName,
                                            llvm::StringRef eventType,
                                            Node *data, unsigned index) {

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -1728,6 +1728,12 @@ bool BatchBoxCoxNode::verify() const {
 
 bool ModuloNode::verify() const { return getDivisor() >= 1; }
 
+bool RecvReadyNode::verify() const { return true; }
+
+bool SendNode::verify() const { return true; }
+
+bool RecvNode::verify() const { return true; }
+
 //===----------------------------------------------------------------------===//
 //                     Node hashing support
 //===----------------------------------------------------------------------===//

--- a/lib/LLVMIRCodeGen/LLVMCompiledFunction.cpp
+++ b/lib/LLVMIRCodeGen/LLVMCompiledFunction.cpp
@@ -44,7 +44,10 @@ void LLVMCompiledFunction::loadPlaceholders(
     auto addr = symbolInfo.offset;
     auto numBytes = PH.second->getUnpaddedSizeInBytes();
     // copy PH to allocated memory.
-    memcpy(baseMutableWeightVarsAddress + addr, payload, numBytes);
+    if (PH.first->getIoPolicy() == 0 || PH.first->getIoPolicy() == 2 ||
+        PH.first->getIoPolicy() == 4) {
+      memcpy(baseMutableWeightVarsAddress + addr, payload, numBytes);
+    }
   }
 }
 

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -251,7 +251,12 @@ llvm::Type *LLVMIRGen::getElementType(llvm::IRBuilder<> &builder,
     static_assert(sizeof(bool) == sizeof(int8_t),
                   "Bool is expected to be the same size as int8.");
     return builder.getInt8Ty();
+  case ElemKind::UIntPtrTy:
+    static_assert(sizeof(uintptr_t) == sizeof(int64_t),
+                  "uintptr_t is expected to be the same size as int64.");
+    return builder.getInt64Ty();
   }
+
   return nullptr;
 }
 
@@ -512,6 +517,8 @@ llvm::Value *LLVMIRGen::emitConst(llvm::IRBuilder<> &builder, float val,
     return builder.getInt8(static_cast<int8_t>(val));
   case ElemKind::BoolTy:
     return builder.getInt8(static_cast<int8_t>(val));
+  case ElemKind::UIntPtrTy:
+    llvm_unreachable("Not implemented");
   }
   llvm_unreachable("Unknown element type");
 }

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -411,6 +411,20 @@ target_link_libraries(PartitionerTest
                         TestMain)
 add_glow_test(PartitionerTest ${GLOW_BINARY_DIR}/tests/PartitionerTest --gtest_output=xml:PartitionerTest.xml)
 
+add_executable(PeerToPeerTest
+        PeerToPeerTest.cpp)
+target_link_libraries(PeerToPeerTest
+                      PRIVATE
+                        BackendTestUtils
+                        Graph
+                        IR
+                        ExecutionEngine
+                        Quantization
+                        GraphOptimizer
+                        gtest
+                        TestMain)
+add_glow_test(PeerToPeerTest ${GLOW_BINARY_DIR}/tests/PeerToPeerTest --gtest_output=xml:PeerToPeerTest.xml)
+
 add_executable(RecommendationSystemTest
                RecommendationSystemTest.cpp)
 target_link_libraries(RecommendationSystemTest

--- a/tests/unittests/PeerToPeerTest.cpp
+++ b/tests/unittests/PeerToPeerTest.cpp
@@ -1,0 +1,222 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/Backends/DeviceManager.h"
+#include "glow/ExecutionEngine/ExecutionEngine.h"
+#include "glow/Optimizer/GraphOptimizer/GraphOptimizer.h"
+#include "glow/Runtime/RuntimeTypes.h"
+#include "llvm/ADT/StringRef.h"
+#include "gtest/gtest.h"
+#include <future>
+
+using namespace glow;
+using namespace glow::runtime;
+
+class PeerToPeerTest : public ::testing::TestWithParam<llvm::StringRef> {
+public:
+  void SetUp() override { backendName = GetParam(); }
+
+  std::string backendName;
+};
+
+INSTANTIATE_TEST_CASE_P(Interpreter, PeerToPeerTest,
+                        ::testing::Values("Interpreter"));
+
+std::unique_ptr<Module> createSenderModule(int64_t channel_id) {
+  std::unique_ptr<Module> mod = llvm::make_unique<Module>();
+  auto *F = mod->createFunction("send_func");
+  auto *inputPH =
+      mod->createPlaceholder(ElemKind::FloatTy, {1}, "send_input", false);
+  auto *P = F->createPow("pow", inputPH, 2);
+  TypeRef inputType = mod->uniqueType(ElemKind::FloatTy, {1});
+  auto *remoteAddress =
+      mod->createPlaceholder(ElemKind::AddressTy, {1}, "remoteAddress", false);
+  auto *Send = F->createSend("send", P, remoteAddress, channel_id, inputType);
+  F->createSave("send_save", Send);
+  return mod;
+}
+
+std::unique_ptr<Module> createReceiverModule(int64_t channel_id) {
+  std::unique_ptr<Module> mod = llvm::make_unique<Module>();
+  auto *F0 = mod->createFunction("recv_ready_func");
+  TypeRef inputType = mod->uniqueType(ElemKind::FloatTy, {1});
+  auto *RR = F0->createRecvReady("recv_ready", channel_id, inputType);
+  F0->createSave("recv_ready_save", RR);
+
+  auto *F1 = mod->createFunction("recv_func");
+  auto *R = F1->createRecv("recv", RR, channel_id, inputType);
+  F1->createSave("recv_save", R);
+  return mod;
+}
+
+FunctionMapTy
+compileFunctions(llvm::StringRef backendName, Module *mod,
+                 std::vector<std::unique_ptr<CompiledFunction>> &backing) {
+  FunctionMapTy results;
+  auto *backend = createBackend(backendName);
+  CompilationContext cctx;
+  cctx.compMode = CompilationMode::Infer;
+  cctx.optimizationOpts.enableConstantFolding = false;
+  for (auto *F : mod->getFunctions()) {
+    // EXIT_ON_ERR(::glow::optimizeFunction(F, *backend, cctx));
+    auto f = EXIT_ON_ERR(backend->compile(F, cctx.backendOpts));
+    backing.push_back(std::move(f));
+    results.emplace(F->getName(), backing.back().get());
+  }
+
+  delete backend;
+  return results;
+}
+
+template <typename ResultType>
+std::pair<std::promise<ResultType>, std::future<ResultType>> getFutureHelper() {
+  std::promise<ResultType> promise;
+  auto future = promise.get_future();
+  return std::make_pair(std::move(promise), std::move(future));
+}
+
+template <typename ResultType>
+void callbackHelper(std::promise<ResultType> &promise, ResultType res,
+                    llvm::Error err) {
+  promise.set_value(!errToBool(std::move(err)) ? std::move(res) : ResultType());
+}
+
+TEST_P(PeerToPeerTest, SendRecvSimple) {
+  auto sender = std::unique_ptr<DeviceManager>(
+      DeviceManager::createDeviceManager(DeviceConfig(backendName)));
+  auto receiver = std::unique_ptr<DeviceManager>(
+      DeviceManager::createDeviceManager(DeviceConfig(backendName)));
+  ASSERT_FALSE(errToBool(sender->init()));
+  ASSERT_FALSE(errToBool(receiver->init()));
+
+  int64_t channelId = 8;
+  auto sender_mod = createSenderModule(channelId);
+  auto receiver_mod = createReceiverModule(channelId);
+
+  // compile functions
+  std::vector<std::unique_ptr<CompiledFunction>> receiverBacking;
+  FunctionMapTy receiverFunctions =
+      compileFunctions(backendName, receiver_mod.get(), receiverBacking);
+  EXPECT_EQ(receiverBacking.size(), 2);
+
+  std::vector<std::unique_ptr<CompiledFunction>> senderBacking;
+  FunctionMapTy senderFunctions =
+      compileFunctions(backendName, sender_mod.get(), senderBacking);
+  EXPECT_EQ(senderBacking.size(), 1);
+
+  // setup device-memory helper according to channel IDs
+  EXIT_ON_ERR(sender->setupRemotePeerToPeer(channelId, receiver.get()));
+
+  // add networks
+  std::promise<const Module *> recv_promise;
+  std::future<const Module *> recv_future;
+  std::tie(recv_promise, recv_future) = getFutureHelper<const Module *>();
+
+  receiver->addNetwork(receiver_mod.get(), std::move(receiverFunctions),
+                       [&recv_promise](const Module *module, llvm::Error err) {
+                         callbackHelper(recv_promise, module, std::move(err));
+                       });
+
+  recv_future.wait_for(std::chrono::seconds(2));
+  EXPECT_EQ(recv_future.get(), receiver_mod.get());
+
+  std::promise<const Module *> send_promise;
+  std::future<const Module *> send_future;
+  std::tie(send_promise, send_future) = getFutureHelper<const Module *>();
+
+  sender->addNetwork(sender_mod.get(), std::move(senderFunctions),
+                     [&send_promise](const Module *module, llvm::Error err) {
+                       callbackHelper(send_promise, module, std::move(err));
+                     });
+
+  send_future.wait_for(std::chrono::seconds(2));
+  EXPECT_EQ(send_future.get(), sender_mod.get());
+
+  std::unique_ptr<ExecutionContext> sendContext =
+      llvm::make_unique<ExecutionContext>();
+  sendContext->getPlaceholderBindings()->allocate(
+      sender_mod->getPlaceholders());
+
+  std::unique_ptr<ExecutionContext> recvContext =
+      llvm::make_unique<ExecutionContext>();
+  recvContext->getPlaceholderBindings()->allocate(
+      receiver_mod->getPlaceholders());
+
+  Tensor send_input(ElemKind::FloatTy, {1});
+  Tensor send_output_ref(ElemKind::FloatTy, {1});
+  send_input.getHandle().clear(2.0f);
+  send_output_ref.getHandle().clear(2.0f * 2.0f);
+
+  updateInputPlaceholders(*sendContext->getPlaceholderBindings(),
+                          {sender_mod->getPlaceholderByName("send_input")},
+                          {&send_input});
+
+  // Run RecvReady func
+  std::promise<std::unique_ptr<ExecutionContext>> runPromise;
+  std::future<std::unique_ptr<ExecutionContext>> runFuture;
+
+  std::tie(runPromise, runFuture) =
+      getFutureHelper<std::unique_ptr<ExecutionContext>>();
+  receiver->runFunction(
+      "recv_ready_func", std::move(recvContext),
+      [&runPromise](RunIdentifierTy, llvm::Error err,
+                    std::unique_ptr<ExecutionContext> context) {
+        callbackHelper(runPromise, std::move(context), std::move(err));
+      });
+
+  runFuture.wait_for(std::chrono::seconds(2));
+  recvContext = runFuture.get();
+  ASSERT_TRUE(recvContext);
+
+  // Run Send func
+  std::promise<std::unique_ptr<ExecutionContext>> runPromise1;
+  std::future<std::unique_ptr<ExecutionContext>> runFuture1;
+
+  std::tie(runPromise1, runFuture1) =
+      getFutureHelper<std::unique_ptr<ExecutionContext>>();
+  sender->runFunction(
+      "send_func", std::move(sendContext),
+      [&runPromise1](RunIdentifierTy, llvm::Error err,
+                     std::unique_ptr<ExecutionContext> context) {
+        callbackHelper(runPromise1, std::move(context), std::move(err));
+      });
+
+  runFuture1.wait_for(std::chrono::seconds(2));
+  sendContext = runFuture1.get();
+  ASSERT_TRUE(sendContext);
+
+  // Run Recv func
+  std::promise<std::unique_ptr<ExecutionContext>> runPromise2;
+  std::future<std::unique_ptr<ExecutionContext>> runFuture2;
+
+  std::tie(runPromise2, runFuture2) =
+      getFutureHelper<std::unique_ptr<ExecutionContext>>();
+  receiver->runFunction(
+      "recv_func", std::move(recvContext),
+      [&runPromise2](RunIdentifierTy, llvm::Error err,
+                     std::unique_ptr<ExecutionContext> context) {
+        callbackHelper(runPromise2, std::move(context), std::move(err));
+      });
+
+  runFuture2.wait_for(std::chrono::seconds(2));
+  recvContext = runFuture2.get();
+  ASSERT_TRUE(recvContext);
+
+  Tensor *result = recvContext->getPlaceholderBindings()->get(
+      receiver_mod->getPlaceholderByName("recv_save"));
+  ASSERT_TRUE(result);
+  EXPECT_TRUE(result->isEqual(send_output_ref));
+}

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -718,6 +718,34 @@ int main(int argc, char **argv) {
       .autoIRGen();
 
   //===--------------------------------------------------------------------===//
+  //                   Peer-To-Peer
+  //===--------------------------------------------------------------------===//
+
+  BB.newInstr("RecvReady")
+      .addOperand("RemoteAddress", OperandKind::Out)
+      .addMember(MemberType::Unsigned, "ChannelId")
+      .addMember(MemberType::TypeRef, "RemoteTensorTypeDescriptor")
+      .autoVerify(VerifyKind::NoVerify)
+      .autoIRGen();
+
+  BB.newInstr("Send")
+      .addOperand("Result", OperandKind::Out)
+      .addOperand("Input", OperandKind::In)
+      .addOperand("RemoteAddress", OperandKind::In)
+      .addMember(MemberType::Unsigned, "ChannelId")
+      .addMember(MemberType::TypeRef, "RemoteTensorTypeDescriptor")
+      .autoVerify(VerifyKind::NoVerify)
+      .autoIRGen();
+
+  BB.newInstr("Recv")
+      .addOperand("Result", OperandKind::Out)
+      .addOperand("LocalAddress", OperandKind::In)
+      .addMember(MemberType::Unsigned, "ChannelId")
+      .addMember(MemberType::TypeRef, "TensorTypeDescriptor")
+      .autoVerify(VerifyKind::NoVerify)
+      .autoIRGen();
+
+  //===--------------------------------------------------------------------===//
   //                Backend-Specific Instructions
   //===--------------------------------------------------------------------===//
 

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -892,6 +892,39 @@ int main(int argc, char **argv) {
           "and Rescale nodes.");
 
   //===--------------------------------------------------------------------===//
+  //                Peer-To-Peer
+  //===--------------------------------------------------------------------===//
+
+  BB.newNode("RecvReady")
+      .addMember(MemberType::Unsigned, "ChannelId")
+      .addMember(MemberType::TypeRef, "RemoteTensorTypeDescriptor")
+      .addResultFromCtorArg("RemoteAddress")
+      .setHasSideEffects(true)
+      .setDocstring(
+          "Asignes device memory address for a following send operation "
+          "according to RemoteTensorTypeDescriptor.");
+
+  BB.newNode("Send")
+      .addInput("Input")
+      .addInput("RemoteAddress")
+      .addMember(MemberType::Unsigned, "ChannelId")
+      .addMember(MemberType::TypeRef, "RemoteTensorTypeDescriptor")
+      .addResultFromCtorArg()
+      .setHasSideEffects(true)
+      .setDocstring("Sends the input tensor to the provided remote-address "
+                    "according to RemoteTensorTypeDescriptor.");
+
+  BB.newNode("Recv")
+      .addInput("LocalAddress")
+      .addMember(MemberType::Unsigned, "ChannelId")
+      .addMember(MemberType::TypeRef, "TensorTypeDescriptor")
+      .addResultFromCtorArg()
+      .setHasSideEffects(true)
+      .setDocstring(
+          "Receives a transferred tensor to in the provided local address "
+          "according to TensorTypeDescriptor.");
+
+  //===--------------------------------------------------------------------===//
   //                Backend-Specific Nodes
   //===--------------------------------------------------------------------===//
 


### PR DESCRIPTION
===== NOT Intended To Land =====
Summary:
This experiment aims for finding a good representation for P2P primitives in Glow graph, suitable for P2P implementations in accelerator backends.
Here, I cheated my way in the interpreter backend to identify some of the issues need solving.
"Cheated", because of passing a pointer to the helper class instance which serves as a mapping between the sender and receiver (which made what was supposed to be the only API method "getRemotePeerToPeerAddress" redundant).

Possible lessons/conclusions:
* For a backend with MPI-like interface (i.e. send takes "rank" and "message" as args) we may use Glow nodes "Send" and "Recv" based on a channel-ID input (can be mapped to "rank") and the tensor-to-send ("message"). We may want to use different node types for these and direct-writes.
(This implementation misses the point because it mixes MPI-like helper with "direct-write" like nodes descriptions)

* In order to perform direct writes, "Send" should get a physical address in a remote device as an input (acquired using "RecvReady" executed on the remote device).

* The remote address may be represented as just another input placeholder in bindings. In this case, the Runtime is responsible to schedule and fully-run "RecvReady" before calling the function with the corresponding "Send". 

I will probably abandon this interpreter implementation and continue to develop this on the CPU backend.
I'd love to get your feedback and thoughts.
