### PR TITLE
[Graph] Make Module::addConstant private and delete Module::addPlaceholder

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -75,6 +75,9 @@ class Module final {
   /// Module log context that stores all logs related to this module.
   ModuleLogContext moduleLogCtx_;
 
+  /// Inserts the constant \p V to the list of constants.
+  Constant *addConstant(Constant *V);
+
 public:
   Module() = default;
 
@@ -84,12 +87,6 @@ public:
   /// names are legal C identifiers in the form: "[a-zA-Z_][a-zA-Z0-9_]*".
   static llvm::StringRef uniqueName(llvm::StringRef name,
                                     llvm::StringSet<> &stringTable);
-
-  /// Inserts the constant \p V to the list of constants.
-  Constant *addConstant(Constant *V);
-
-  /// Inserts the placeholder node \p ph to the list of variables.
-  Placeholder *addPlaceholder(Placeholder *ph);
 
   /// Return a pointer to a uniqued type \p T.
   TypeRef uniqueType(const Type &T);

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -497,7 +497,11 @@ static ShapeVector getNewShapeWithoutAxes(llvm::ArrayRef<size_t> dims,
 Placeholder *Module::createPlaceholder(TypeRef T, llvm::StringRef name,
                                        bool isTrainable) {
   auto FT = uniqueType(*T);
-  return addPlaceholder(new Placeholder(name, FT, isTrainable));
+  auto *ph = new Placeholder(name, FT, isTrainable);
+  ph->setName(uniqueName(ph->getName(), uniqueVariableNames_));
+  placeholders_.push_back(ph);
+  logStorageCreation(functions_, ph);
+  return ph;
 }
 
 Placeholder *Module::createPlaceholder(ElemKind T, llvm::ArrayRef<size_t> dims,
@@ -572,13 +576,6 @@ Constant *Module::addConstant(Constant *V) {
   constants_.push_back(V);
   logStorageCreation(functions_, V);
   return V;
-}
-
-Placeholder *Module::addPlaceholder(Placeholder *ph) {
-  ph->setName(uniqueName(ph->getName(), uniqueVariableNames_));
-  placeholders_.push_back(ph);
-  logStorageCreation(functions_, ph);
-  return ph;
 }
 
 /// Check if the 'pads' array has the right size.

--- a/tests/unittests/GraphTest.cpp
+++ b/tests/unittests/GraphTest.cpp
@@ -895,9 +895,6 @@ TEST(Graph, parentLink) {
   // Even when we create them from a module...
   Constant *V2 = mod.createConstant(V->getType(), "V2");
   EXPECT_EQ(V2->getParent(), nullptr);
-  // Or add them to a module.
-  mod.addConstant(V);
-  EXPECT_EQ(V->getParent(), nullptr);
 
   Function *F = mod.createFunction("main");
 
@@ -927,6 +924,35 @@ TEST(Graph, parentLink) {
   // cleaned at the end of the test.
   F->addNode(clonedAddNode);
   EXPECT_EQ(clonedAddNode->getParent(), F);
+
+  delete V;
+}
+
+/// Check that verification can detect that Storage nodes are being used by
+/// Functions in a Module that doesn't own the Storage nodes.
+TEST(Graph, moduleLink) {
+  ExecutionEngine EEA, EEB;
+
+  auto &modA = EEA.getModule();
+  auto &modB = EEB.getModule();
+
+  auto *FA = modA.createFunction("FA");
+  auto *FB = modB.createFunction("FB");
+
+  auto *C = modA.createConstant(ElemKind::FloatTy, {1}, "C");
+  auto *P = modA.createPlaceholder(ElemKind::FloatTy, {1}, "P", false);
+
+  auto *AA = FA->createAdd("AA", C, P);
+  FA->createSave("SA", AA);
+
+  // These nodes use Storage nodes that reside in modA
+  auto *AB = FB->createAdd("AB", C, P);
+  FB->createSave("SB", AB);
+
+  EXPECT_TRUE(modA.verify());
+  EXPECT_FALSE(
+      modB.verify()); // Module::verify calls Function::verify on all functions
+                      // within the module, so this should fail
 }
 
 /// Check that Cmp nodes are created with proper output types.


### PR DESCRIPTION
**Summary**
`Storage` nodes (i.e. `Constants` and `Placeholders`) are supposed to be owned
by a `Module`. Accordingly, the preferred methods of creation for these
objects are `Module::createConstant` and `Module::createPlaceholder`.
Exposing public `addConstant` and `addPlaceholder` methods makes it possible
to create a `Storage` node and add it to multiple `Modules`. These methods
are not used frequently, so this commit makes one of them them private
and deletes the other in order to preclude this issue.

**Testing**
This commit adds a new unit test to `GraphTest` to make sure that
`Module::verify()` can catch the case in which a `Storage` node is owned by
one `Module` but used by a `Function` in another `Module`.

**Fixes**
This PR fixes #3428.