### PR TITLE
[RecSys][trivial] Reduce default batch size to make test run faster

### DIFF
--- a/tests/unittests/RecommendationSystemTest.cpp
+++ b/tests/unittests/RecommendationSystemTest.cpp
@@ -34,7 +34,7 @@ namespace {
 llvm::cl::OptionCategory recSysTestCat("RecSys Category");
 
 llvm::cl::opt<unsigned> miniBatchOpt("mini-batch", llvm::cl::desc("Minibatch."),
-                                     llvm::cl::Optional, llvm::cl::init(16),
+                                     llvm::cl::Optional, llvm::cl::init(8),
                                      llvm::cl::cat(recSysTestCat));
 
 llvm::cl::opt<unsigned> embeddingDimOpt("embedding-dim",


### PR DESCRIPTION
The default configuration here takes a long time to run. Let's make this test run for a shorter amount of time. I don't think we lose much signal by doing so. It's command line tunable, so if someone wants to try out a different configuration they can do so there (e.g. `--mini-batch=16`).