### PR TITLE
Reintroduce HabanaConvolution because of weird filter layout

### DIFF
--- a/lib/Backends/Habana/Habana.cpp
+++ b/lib/Backends/Habana/Habana.cpp
@@ -749,15 +749,12 @@ HabanaBackend::compile(Function *F, const BackendOptions &opts) const {
       multiInputs.emplace_back(std::move(inputs));
       break;
     }
-    case Kinded::Kind::ConvolutionNodeKind: {
-      auto *NI = llvm::cast<ConvolutionNode>(&I);
+    case Kinded::Kind::HabanaConvolutionNodeKind: {
+      auto *NI = llvm::cast<HabanaConvolutionNode>(&I);
 
-      bool doRelu = (NI->getFusedActivation() == FusedActivation::RELU);
-      DCHECK(NI->getFusedActivation() == FusedActivation::NONE || doRelu);
-
-      std::unique_ptr<synConvolutionParams> params =
-          makeSynConvolutionParams(NI->getKernels(), NI->getStrides(),
-                                   NI->getPads(), NI->getGroup(), doRelu);
+      std::unique_ptr<synConvolutionParams> params = makeSynConvolutionParams(
+          NI->getKernels(), NI->getStrides(), NI->getPads(), NI->getGroup(),
+          NI->getDoRelu());
 
       chk(synSpatialConvolution(tensors[NI->getInput()].get(),
                                 tensors[NI->getFilter()].get(),
@@ -1095,6 +1092,7 @@ bool HabanaBackend::isOpSupported(const NodeInfo &NI) const {
     case Kinded::Kind::ConvolutionNodeKind:
     case Kinded::Kind::DivNodeKind:
     case Kinded::Kind::FullyConnectedNodeKind:
+    case Kinded::Kind::HabanaConvolutionNodeKind:
     case Kinded::Kind::HabanaConvolutionAddNodeKind:
     case Kinded::Kind::HabanaFullyConnectedNodeKind:
     case Kinded::Kind::MatMulNodeKind:
@@ -1266,7 +1264,7 @@ bool separateSlice(Function *F, SliceNode &slice) {
 }
 
 /// Fuse conv followed by relu into a single FusedConvRelu node.
-bool fuseConvRelu(Function *F, ConvolutionNode &conv, ReluNode &relu) {
+bool fuseConvRelu(Function *F, HabanaConvolutionNode &conv, ReluNode &relu) {
   // Convolution should have only a single use.
   if (!conv.getResult().hasOneUse()) {
     return false;
@@ -1274,11 +1272,10 @@ bool fuseConvRelu(Function *F, ConvolutionNode &conv, ReluNode &relu) {
 
   auto fusedOpName =
       conv.getName().str() + "." + relu.getName().str() + ".fused";
-  auto *fusedNode = new ConvolutionNode(
+  auto *fusedNode = new HabanaConvolutionNode(
       fusedOpName, relu.getResult().getType(), conv.getInput(),
       conv.getFilter(), conv.getBias(), conv.getKernels(), conv.getStrides(),
-      conv.getPads(), conv.getGroup(), conv.getDilation(), conv.getLayout(),
-      FusedActivation::RELU);
+      conv.getPads(), conv.getGroup(), /*doRelu=*/true);
   F->addNode(fusedNode);
 
   relu.getResult().replaceAllUsesOfWith(fusedNode);
@@ -1309,21 +1306,19 @@ bool fuseConvAdd(Function *F, AddNode &add) {
   //           ^     -->    Node --> HabanaConvolutionAdd
   //           |
   // Node ------
-  auto *lhs = llvm::dyn_cast<ConvolutionNode>(add.getLHS());
-  auto *rhs = llvm::dyn_cast<ConvolutionNode>(add.getRHS());
+  auto *lhs = llvm::dyn_cast<HabanaConvolutionNode>(add.getLHS());
+  auto *rhs = llvm::dyn_cast<HabanaConvolutionNode>(add.getRHS());
 
   // Pick the Conv with only a single use (the Add) to fuse because
   // there is no output of the fused node that can provide only the
   // convolution output to other users.
-  ConvolutionNode *singleUseConv;
+  HabanaConvolutionNode *singleUseConv;
   NodeValue otherNode;
 
-  if (lhs && lhs->getResult().hasOneUse() &&
-      lhs->getFusedActivation() == FusedActivation::NONE) {
+  if (lhs && lhs->getResult().hasOneUse()) {
     singleUseConv = lhs;
     otherNode = add.getRHS();
-  } else if (rhs && rhs->getResult().hasOneUse() &&
-             rhs->getFusedActivation() == FusedActivation::NONE) {
+  } else if (rhs && rhs->getResult().hasOneUse()) {
     singleUseConv = rhs;
     otherNode = add.getLHS();
   } else {
@@ -1443,8 +1438,8 @@ bool HabanaBackend::transformPostLowering(Function *F,
 
     // Fuse Convolution followed by relu.
     if (auto *relu = llvm::dyn_cast<ReluNode>(&node)) {
-      if (auto *conv =
-              llvm::dyn_cast<ConvolutionNode>(relu->getInput().getNode())) {
+      if (auto *conv = llvm::dyn_cast<HabanaConvolutionNode>(
+              relu->getInput().getNode())) {
         changed |= fuseConvRelu(F, *conv, *relu);
         continue;
       } else if (auto *convAdd = llvm::dyn_cast<HabanaConvolutionAddNode>(
@@ -1480,19 +1475,16 @@ bool HabanaBackend::transformPostLowering(Function *F,
       }
     }
 
-    // Transpose filter into order expected by Habana backend (HWCN)
+    // Replace Conv with HabanaConv for better control over code generation.
     if (auto *conv = llvm::dyn_cast<ConvolutionNode>(&node)) {
-      if (conv->hasFusedActivation()) {
-        continue;
-      }
+      // Transpose filter into order expected by Habana backend (HWCN)
       auto *TF =
           F->createTranspose((conv->getName()).str() + ".filter.transpose",
                              conv->getFilter(), {1, 2, 3, 0});
-      auto *NC = F->addNode(new ConvolutionNode(
+      auto *NC = F->addNode(new HabanaConvolutionNode(
           conv->getName(), conv->getResult().getType(), conv->getInput(), TF,
           conv->getBias(), conv->getKernels(), conv->getStrides(),
-          conv->getPads(), conv->getGroup(), conv->getDilation(),
-          conv->getLayout(), conv->getFusedActivation()));
+          conv->getPads(), conv->getGroup(), /*doRelu=*/false));
       conv->getResult().replaceAllUsesOfWith(NC);
       changed = true;
       continue;

--- a/lib/Partitioner/PartitionerUtils.cpp
+++ b/lib/Partitioner/PartitionerUtils.cpp
@@ -346,6 +346,25 @@ float getNodeComputeTime(const Node *node, const BackendInfo &backendInfo) {
     totalOps *= (inputChannels * 1.0 / nGroups);
     break;
   }
+#ifdef GLOW_WITH_HABANA
+  case Kinded::Kind::HabanaConvolutionNodeKind: {
+    auto *CN = llvm::dyn_cast<HabanaConvolutionNode>(node);
+    auto resultDims = CN->getResult().dims();
+    // Get the product of batch, output height, output dims, output channels
+    totalOps = resultDims[0];
+    for (size_t i = 1, e = resultDims.size(); i < e; i++) {
+      totalOps *= resultDims[i];
+    }
+    // Multiply in kernel height, kernel width
+    auto kernelDims = CN->getKernels();
+    totalOps *= kernelDims[0] * kernelDims[1];
+    // Multiply in input channels/groups
+    auto inputChannels = CN->getInput().dims()[1];
+    auto nGroups = CN->getGroup();
+    totalOps *= (inputChannels * 1.0 / nGroups);
+    break;
+  }
+#endif
   default:
     break;
   }

--- a/tests/unittests/HabanaGlowTest.cpp
+++ b/tests/unittests/HabanaGlowTest.cpp
@@ -149,13 +149,13 @@ TEST_F(HabanaBackendTest, FuseConvRelu) {
   //   Placeholder ------
   //       |            |
   //       v            v
-  //     Conv         Conv
+  //   HabanaConv       Conv
   //       |            |
   //       v            v
   //     Save         Relu
 
   // Check that HabanaConv feeds into the Save.
-  auto *HCA = llvm::dyn_cast<ConvolutionNode>(SN->getInput());
+  auto *HCA = llvm::dyn_cast<HabanaConvolutionNode>(SN->getInput());
   ASSERT_TRUE(HCA);
 
   // Check that the inputs to the HabanaConvAdd are the same as the Conv
@@ -167,8 +167,8 @@ TEST_F(HabanaBackendTest, FuseConvRelu) {
   EXPECT_EQ(HCA->getPads(), CVN->getPads());
   EXPECT_EQ(HCA->getGroup(), CVN->getGroup());
 
-  // Check that the Relu is fused into the Conv.
-  EXPECT_EQ(HCA->getFusedActivation(), FusedActivation::RELU);
+  // Check that the doRelu parameter of the HabanaConvAdd is true.
+  EXPECT_TRUE(HCA->getDoRelu());
 
   // Dead code elimination.
   ::glow::optimize(F_, CompilationMode::Infer);
@@ -177,7 +177,7 @@ TEST_F(HabanaBackendTest, FuseConvRelu) {
   //   Placeholder
   //       |
   //       v
-  //     Conv
+  //   HabanaConv
   //       |
   //       v
   //     Save
@@ -401,6 +401,21 @@ TEST_F(HabanaBackendTest, ConvertFC) {
   backend.transformPostLowering(F_, cctx);
   ASSERT_TRUE(save);
   ASSERT_TRUE(llvm::isa<HabanaFullyConnectedNode>(save->getInput()));
+}
+
+TEST_F(HabanaBackendTest, ConvertConv) {
+  HabanaBackend backend;
+
+  Placeholder *input =
+      mod_.createPlaceholder(ElemKind::FloatTy, {1, 10, 20, 3}, "input", false);
+  ConvolutionNode *conv = F_->createConv(ctx_, "conv", input, 3, 5, 1, 2, 1);
+  SaveNode *save = F_->createSave("save", conv);
+
+  CompilationContext cctx;
+  bool changed = backend.transformPostLowering(F_, cctx);
+  EXPECT_TRUE(changed);
+  ASSERT_TRUE(save);
+  ASSERT_TRUE(llvm::isa<HabanaConvolutionNode>(save->getInput()));
 }
 
 template <ElemKind kind, typename ElemTy>

--- a/tools/ClassGen/Backends/Habana/HabanaSpecificNodes.h
+++ b/tools/ClassGen/Backends/Habana/HabanaSpecificNodes.h
@@ -26,6 +26,21 @@ BB.newNode("HabanaFullyConnected")
     .setDocstring(
         "This is a Habana-specific FC that combines weights and bias.");
 
+BB.newNode("HabanaConvolution")
+    .addInput("Input")
+    .addInput("Filter")
+    .addInput("Bias")
+    .addMember(MemberType::VectorUnsigned, "Kernels")
+    .addMember(MemberType::VectorUnsigned, "Strides")
+    .addMember(MemberType::VectorUnsigned, "Pads")
+    .addMember(MemberType::Unsigned, "Group")
+    .addMember(MemberType::Boolean, "DoRelu")
+    .addResultFromCtorArg()
+    .setDocstring("This is a Habana-specific convolution node that is "
+                  "identical to the normal ConvolutionNode. That node "
+                  "and convolution + relu are replaced with this one "
+                  "for backend-specific code generation");
+
 BB.newNode("HabanaConvolutionAdd")
     .addInput("Addend")
     .addInput("Input")

--- a/tools/ClassGen/Backends/Habana/HabanaSpecificNodesVerification.h
+++ b/tools/ClassGen/Backends/Habana/HabanaSpecificNodesVerification.h
@@ -76,6 +76,11 @@ static bool verifyConvolution(NodeValue src, NodeValue dest, NodeValue filter,
 
 bool HabanaFullyConnectedNode::verify() const { return true; }
 
+bool HabanaConvolutionNode::verify() const {
+  return verifyConvolution(getInput(), getResult(), getFilter(), getBias(),
+                           Kernels_, Strides_, Pads_, Group_);
+}
+
 bool HabanaConvolutionAddNode::verify() const {
   bool isValid =
       verifyConvolution(getInput(), getResult(), getFilter(), getBias(),


### PR DESCRIPTION
Summary:
Even though we've introduced a clean mechanism for controlling the
input layout of convolutions (NHWC vs NCHW), we didn't account for a
potentially different *filter* layout.  It looks like Habana follows
[TensorFlow's
convention](https://www.tensorflow.org/api_docs/python/tf/nn/convolution) for
filter shape, which is (H, W, input_channels, output_channels), rather than
Glow's (OC, H, W, IC) or Caffe2's (OC, IC, H, W).

Without a way to express the differing filter layout, there's no way to check if the existing convolution needs to be transformed.  In the existing implementation, this manifests as the transformPostLowering step creating Transposes in an endless loop.

Since we don't have a great mechanism for configuring the filter layout, I'm
simply reverting to the Habana-specific convolution implementation, and feeling
a bit sad.

Differential Revision: D17311487

