### PR TITLE
Add option to IR optimize() to inhibit instrumentation

### DIFF
--- a/include/glow/Optimizer/IROptimizer/IROptimizer.h
+++ b/include/glow/Optimizer/IROptimizer/IROptimizer.h
@@ -25,7 +25,8 @@ class Function;
 class Backend;
 
 /// Perform optimizations on the IR representation.
-void optimize(IRFunction &M, bool shouldShareBuffers);
+void optimize(IRFunction &M, bool shouldShareBuffers,
+              bool instrumentDebug = true);
 
 /// Helper to generate and optimize IR from given Function \p F. \p
 /// shouldShareBuffers signifies whether to use the share buffers optimization.

--- a/lib/Optimizer/IROptimizer/IROptimizer.cpp
+++ b/lib/Optimizer/IROptimizer/IROptimizer.cpp
@@ -1663,7 +1663,8 @@ glow::generateAndOptimizeIR(Function *F, const Backend &B,
 }
 
 /// Perform optimizations on the IR representation.
-void glow::optimize(IRFunction &M, bool shouldShareBuffers) {
+void glow::optimize(IRFunction &M, bool shouldShareBuffers,
+                    bool instrumentDebug) {
   M.verify();
   if (!optimizeIR) {
     return;
@@ -1697,7 +1698,9 @@ void glow::optimize(IRFunction &M, bool shouldShareBuffers) {
   makeWeightsConst(M);
 
   // Perform a debug instrumentation if required.
-  performDebugInstrumentation(M);
+  // Check parameter to avoid instrumenting multiple times.
+  if (instrumentDebug)
+    performDebugInstrumentation(M);
 
   M.verify();
 


### PR DESCRIPTION
Summary:
This is needed to avoid instrumenting the code multiple times if the
optimize() function is called from a backend.
