### PR TITLE
Added check to llvm::expected address before overwriting it.

### DIFF
--- a/lib/LLVMIRCodeGen/LLVMCompiledFunction.cpp
+++ b/lib/LLVMIRCodeGen/LLVMCompiledFunction.cpp
@@ -100,8 +100,10 @@ llvm::Error LLVMCompiledFunction::execute(ExecutionContext *context) {
     auto sym = JIT_->findSymbol("jitmain");
 
     DCHECK(sym) << "Unable to JIT the code!";
-
-    address = sym.getAddress();
+    // We know address is success since we just made it. Mark it as checked.
+    if (address) {
+      address = sym.getAddress();
+    }
   }
   using JitFuncType =
       void (*)(uint8_t * constantWeightVars, uint8_t * mutableWeightVars,


### PR DESCRIPTION
Summary:
This PR adds a check to the llvm::Expected address in llvmCompiledFunction. 

Documentation:

Fixes #3504 
Test Plan: ninja check. 

