### PR TITLE
Create torchifi lib

### DIFF
--- a/torch_glow/src/PyTorchCommon.cpp
+++ b/torch_glow/src/PyTorchCommon.cpp
@@ -138,18 +138,18 @@ void registerGlowOp() {
       options)});
 }
 
-void registerGlowFusionPass() {
-  torch::jit::RegisterPass pass([](std::shared_ptr<torch::jit::Graph> &g) {
-    if (getPyTorchLoaderSettings().fusionPassEnabled) {
+void registerGlowFusionPass(std::function<bool()> enablePassFn) {
+  torch::jit::RegisterPass pass([enablePassFn = std::move(enablePassFn)](
+                                    std::shared_ptr<torch::jit::Graph> &g) {
+    if (enablePassFn()) {
       glow::glowCustomFuse(g, getGlowSymbol());
     }
   });
 }
 
-void registerGlowFusionOpAndPass(bool enableFusionPass) {
+void registerGlowFusionOpAndPass(std::function<bool()> enablePassFn) {
   registerGlowOp();
-  registerGlowFusionPass();
-  getPyTorchLoaderSettings().fusionPassEnabled = enableFusionPass;
+  registerGlowFusionPass(std::move(enablePassFn));
 }
 
 glow::Type ptTypeToGlowType(const c10::TensorType &ptType) {

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -53,13 +53,15 @@ void glowCustomFuse(std::shared_ptr<torch::jit::Graph> &graph,
 /// Register the glow::FusionGroup operator.
 void registerGlowOp();
 
-/// Register the pass that fuses parts of the graph into a glow::FusionGroup.
-void registerGlowFusionPass();
+/// Register the pass that fuses parts of the graph into a glow::FusionGroup. \p
+/// enablePassFn is used to enable/disable the glow fusion pass once it's
+/// registered.
+void registerGlowFusionPass(std::function<bool()> enablePassFn);
 
 /// Convenience method to register the glow fusion op and pass. \p
-/// enableFusionPass can be used to enable the glow fusion pass once it's
+/// enablePassFn is used to enable/disable the glow fusion pass once it's
 /// registered.
-void registerGlowFusionOpAndPass(bool enableFusionPass = false);
+void registerGlowFusionOpAndPass(std::function<bool()> enablePassFn);
 
 /// Given a PyTorch TensorType \p ptType, \returns a matching Glow Type.
 glow::Type ptTypeToGlowType(const c10::TensorType &ptType);

--- a/torch_glow/src/binding.cpp
+++ b/torch_glow/src/binding.cpp
@@ -32,7 +32,10 @@ using namespace glow;
 
 /// The torch_glow pybind11 module.
 PYBIND11_MODULE(_torch_glow, m) {
-  registerGlowFusionOpAndPass();
+  /// Register Glow op and FusionPass, enable the fusion pass if
+  /// fusionPassEnabled is set in PyTorchLoaderSettings.
+  registerGlowFusionOpAndPass(
+      []() { return getPyTorchLoaderSettings().fusionPassEnabled; });
 
   /// Enable compiling PyTorch subgraphs to Glow Functions.
   m.def("enableFusionPass",


### PR DESCRIPTION
Summary: Create a "torchifi" lib that can be used to register a PyTorch fusion pass with a specific glow backend so that users of torch-glow don't need to depend directly on Glow and can use multiple different Glow backends with their service.

Differential Revision: D17347725

