### PR TITLE
[Caffe2ModelLoader] Add support for loading Sqr

### DIFF
--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -1223,6 +1223,14 @@ llvm::Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     return llvm::Error::success();
   }
 
+  if (typeName == "Sqr") {
+    NodeValue in;
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
+    auto *pow = G_.createPow(opName, in, /* exp */ 2);
+    RETURN_IF_ERR(addNodeAsOutput(op, pow));
+    return llvm::Error::success();
+  }
+
   if (typeName == "SparseLengthsWeightedSum8BitsRowwise" ||
       typeName == "SparseLengthsSum8BitsRowwise" ||
       typeName == "SparseLengthsWeightedSumFused8BitRowwise" ||

--- a/tests/models/caffe2Models/sqr_predict_net.pbtxt
+++ b/tests/models/caffe2Models/sqr_predict_net.pbtxt
@@ -1,0 +1,9 @@
+name: "square"
+op {
+  input: "input"
+  output: "result"
+  name: ""
+  type: "Sqr"
+}
+external_input: "inputs"
+external_output: "result"


### PR DESCRIPTION
Summary: Simply implemented via a PowNode.

Test Plan: Added Caffe2ImporterTest.
