### PR TITLE
Added freeCompilationResources method to compiledFunction

### DIFF
--- a/docs/Backends.md
+++ b/docs/Backends.md
@@ -126,7 +126,7 @@ Additionally, there are virtual functions that backends can override:
 compilation of a `Function`. Backends must implement their own derived class
 from `CompiledFunction`, which must be returned as a result of
 `Backend::compile()` or `Backend::compileWithoutConstants()` .
- `CompiledFunction` contains a single pure virtual function
+ `CompiledFunction` contains a pure virtual function
 that must be implemented: `virtual void execute();`. This function is
 responsible for copying inputs to the device from all input
 [Placeholders](https://github.com/pytorch/glow/blob/master/docs/IR.md#placeholders),
@@ -135,6 +135,8 @@ Placeholders. The `CompiledFunction` contains a [RuntimeBundle](#runtimebundle-h
 which contains the symbol information and mappings of inputs and outputs. Thus after the
 function returns, all Placeholders for the outputs of the function should have had
 their backing tensor updated.
+An optional method: `virtual void freeCompilationResources()` can be implemented to allow
+freeing resources that are no longer needed after the function has been loaded on a device.
 
 ### `RuntimeBundle` Helper Class
 

--- a/include/glow/Backend/CompiledFunction.h
+++ b/include/glow/Backend/CompiledFunction.h
@@ -59,6 +59,11 @@ public:
   /// \returns the backend name used to compile this function.
   virtual std::string getCompileBackendName() const = 0;
 
+  /// Once the compiledFunction is done being added to devices calling this
+  /// method will free any resources needed to load the network on the device
+  /// but not needed for running on the device.
+  virtual void freeCompilationResources(){};
+
 protected:
   /// Contains symbol offsets and allocation sizes.
   runtime::RuntimeBundle runtimeBundle_;

--- a/include/glow/Runtime/Provisioner/Provisioner.h
+++ b/include/glow/Runtime/Provisioner/Provisioner.h
@@ -64,8 +64,10 @@ private:
   /// List of available DeviceManagers added during initialization.
   std::vector<DeviceManager *> devices_;
 
-  /// Helper function to cleanup a failed provision call.
-  void cleanupProvision(llvm::ArrayRef<std::string> names);
+  /// Helper function to cleanup a provision call. On a success free resources
+  /// that are no longer needed by the compiledFunctions. On failure free the
+  /// compiledFunctions that were created.
+  void cleanupProvision(llvm::ArrayRef<std::string> names, bool failure = true);
 };
 } // namespace runtime
 } // namespace glow

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -124,6 +124,10 @@ OpenCLFunction::OpenCLFunction(std::unique_ptr<IRFunction> F,
   setTraceInfo(std::move(traceInfo));
 }
 
+void OpenCLFunction::freeCompilationResources() {
+  runtimeBundle_.freeConstants();
+}
+
 OpenCLFunction::~OpenCLFunction() {
   for (auto &kv : programsCache_) {
     auto prog = kv.second;

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -111,6 +111,8 @@ public:
 
   Error execute(ExecutionContext *context) override;
 
+  void freeCompilationResources() override;
+
   /// Collects constants for runtime.
   void collectConstants(const Module *module) override;
 


### PR DESCRIPTION
Summary:
Added freeCompilationResources method to compiledFunction
 and added implementation of it for OpenCLFunction. 
This method allows for freeing resources in a compiledFunction that are no longer needed after the function has been loaded on a device.
Added pass in provisioner to call new method

Documentation: Updated Backends.md to include new method.

Test Plan: ninja check
