### PR TITLE
refactoring CPU device memory allocation out from function execution

### DIFF
--- a/include/glow/LLVMIRCodeGen/LLVMCompiledFunction.h
+++ b/include/glow/LLVMIRCodeGen/LLVMCompiledFunction.h
@@ -20,8 +20,25 @@
 
 #include "glow/Backend/BackendUtils.h"
 #include "glow/Backend/CompiledFunction.h"
+#include "glow/ExecutionContext/ExecutionContext.h"
 
 namespace glow {
+
+/// CPUDeviceBindings inherits from DeviceBindings, it contains per run
+/// device specific information used to run a compiled function on a specific
+/// device.
+struct CPUDeviceBindings : DeviceBindings {
+  CPUDeviceBindings(uint8_t *activationsBuffer, uint8_t *weightsBuffer)
+      : DeviceBindings("CPU"), deviceActivationsBuffer{activationsBuffer},
+        deviceWeightsBuffer{weightsBuffer} {}
+
+  ~CPUDeviceBindings() {}
+
+  /// Non-owning pointers. Memory is owned by the device manager.
+  uint8_t *deviceActivationsBuffer;
+  uint8_t *deviceWeightsBuffer;
+};
+
 /// A Glow IR function compiled using LLVM.
 class LLVMCompiledFunction : public CompiledFunction {
 public:

--- a/include/glow/LLVMIRCodeGen/LLVMCompiledFunction.h
+++ b/include/glow/LLVMIRCodeGen/LLVMCompiledFunction.h
@@ -24,16 +24,21 @@
 
 namespace glow {
 
-/// CPUDeviceBindings inherits from DeviceBindings, it contains per run
+/// LLVMDeviceBindings inherits from DeviceBindings, it contains per run
 /// device specific information used to run a compiled function on a specific
 /// device.
-struct CPUDeviceBindings : DeviceBindings {
-  CPUDeviceBindings(uint8_t *activationsBuffer, uint8_t *weightsBuffer)
-      : DeviceBindings("CPU"), deviceActivationsBuffer{activationsBuffer},
+class LLVMDeviceBindings : public DeviceBindings {
+public:
+  LLVMDeviceBindings(std::string backend, uint8_t *activationsBuffer,
+                     uint8_t *weightsBuffer)
+      : DeviceBindings(backend), deviceActivationsBuffer{activationsBuffer},
         deviceWeightsBuffer{weightsBuffer} {}
 
-  ~CPUDeviceBindings() {}
+  ~LLVMDeviceBindings() {}
 
+  friend class LLVMCompiledFunction;
+
+protected:
   /// Non-owning pointers. Memory is owned by the device manager.
   uint8_t *deviceActivationsBuffer;
   uint8_t *deviceWeightsBuffer;

--- a/lib/Backends/CPU/CPUDeviceManager.cpp
+++ b/lib/Backends/CPU/CPUDeviceManager.cpp
@@ -42,9 +42,10 @@ DeviceManager *createCPUDeviceManager(const DeviceConfig &config) {
 
 CPUBuffer::CPUBuffer(size_t activationsSize, size_t activations_alignment,
                      size_t weightsSize, size_t weights_alignment) {
-  activationsBuffer_ =
-      (uint8_t *)alignedAlloc(activationsSize, activations_alignment);
-  weightsBuffer_ = (uint8_t *)alignedAlloc(weightsSize, weights_alignment);
+  activationsBuffer_ = static_cast<uint8_t *>(
+      alignedAlloc(activationsSize, activations_alignment));
+  weightsBuffer_ =
+      static_cast<uint8_t *>(alignedAlloc(weightsSize, weights_alignment));
 }
 
 CPUBuffer::~CPUBuffer() {
@@ -182,11 +183,11 @@ void CPUDeviceManager::runFunctionImpl(
 
   CompiledFunction *func = funcIt->second;
 
-  auto cpuBindings = llvm::make_unique<CPUDeviceBindings>(
+  auto deviceBindings = llvm::make_unique<CPUDeviceBindings>(
       buffers_[function]->getActivationsBuffer(),
       buffers_[function]->getWeightsBuffer());
 
-  context->setDeviceBindings(std::move(cpuBindings));
+  context->setDeviceBindings(std::move(deviceBindings));
 
   // Run that function.
   auto executeErr = func->execute(context.get());

--- a/lib/Backends/CPU/CPUDeviceManager.h
+++ b/lib/Backends/CPU/CPUDeviceManager.h
@@ -24,12 +24,40 @@
 namespace glow {
 namespace runtime {
 
+/// A class that contains a CPU device buffer. It frees the buffer when it
+/// is destroyed.
+class CPUBuffer {
+  /// The OpenCL buffer being stored.
+  uint8_t *activationsBuffer_;
+  uint8_t *weightsBuffer_;
+  /// Size of the buffer in bytes.
+  const size_t activationsSize_{0};
+  const size_t weightsSize_{0};
+
+public:
+  CPUBuffer(size_t activationsSize, size_t activations_alignment,
+            size_t weightsSize, size_t weights_alignment);
+
+  ~CPUBuffer();
+
+  /// Returns the stored buffer.
+  uint8_t *getActivationsBuffer() { return activationsBuffer_; }
+  uint8_t *getWeightsBuffer() { return weightsBuffer_; }
+
+  /// Get size of buffer in bytes.
+  size_t getActivationsSize() { return activationsSize_; }
+  size_t getWeightsSize() { return weightsSize_; }
+};
+
 /// A class controlling a single CPU thread of execution driving the JIT
 /// backend. Many CPUFunctions may be added, but only one inference is executed
 /// at a time.
 class CPUDeviceManager : public QueueBackedDeviceManager {
   /// Compiled function list by name.
   FunctionMapTy functions_;
+
+  /// A map from function name to its memory buffer
+  std::map<std::string, std::unique_ptr<CPUBuffer>> buffers_;
 
   /// String constant for logging number of in-use devices.
   static constexpr const char *kDevicesUsedCPU = "glow.devices_used.cpu";

--- a/lib/Backends/CPU/CPUDeviceManager.h
+++ b/lib/Backends/CPU/CPUDeviceManager.h
@@ -27,7 +27,7 @@ namespace runtime {
 /// A class that contains a CPU device buffer. It frees the buffer when it
 /// is destroyed.
 class CPUBuffer {
-  /// The OpenCL buffer being stored.
+  /// The buffers being stored.
   uint8_t *activationsBuffer_;
   uint8_t *weightsBuffer_;
   /// Size of the buffer in bytes.

--- a/lib/Backends/CPU/CPUFunction.cpp
+++ b/lib/Backends/CPU/CPUFunction.cpp
@@ -21,6 +21,12 @@
 
 using namespace glow;
 
+CPUDeviceBindings::CPUDeviceBindings(uint8_t *activationsBuffer,
+                                     uint8_t *weightsBuffer)
+    : LLVMDeviceBindings("CPU", activationsBuffer, weightsBuffer) {}
+
+CPUDeviceBindings::~CPUDeviceBindings() {}
+
 CPUFunction::CPUFunction(std::unique_ptr<llvm::orc::GlowJIT> JIT,
                          runtime::RuntimeBundle &&runtimeBundle)
     : LLVMCompiledFunction(std::move(JIT), std::move(runtimeBundle)) {}

--- a/lib/Backends/CPU/CPUFunction.h
+++ b/lib/Backends/CPU/CPUFunction.h
@@ -24,6 +24,14 @@
 #include "glow/Backend/CompiledFunction.h"
 
 namespace glow {
+
+class CPUDeviceBindings final : public LLVMDeviceBindings {
+public:
+  CPUDeviceBindings(uint8_t *activationsBuffer, uint8_t *weightsBuffer);
+
+  ~CPUDeviceBindings();
+};
+
 /// A Glow IR function compiled for the CPU using LLVM.
 class CPUFunction final : public LLVMCompiledFunction {
 public:

--- a/lib/Backends/Interpreter/tests/InterpreterBackendCorrectnessTest.cpp
+++ b/lib/Backends/Interpreter/tests/InterpreterBackendCorrectnessTest.cpp
@@ -17,4 +17,5 @@
 
 using namespace glow;
 
-std::set<std::string> glow::backendTestBlacklist = {};
+std::set<std::string> glow::backendTestBlacklist = {
+    "dataParallelStackingTest/0"};

--- a/lib/LLVMIRCodeGen/LLVMCompiledFunction.cpp
+++ b/lib/LLVMIRCodeGen/LLVMCompiledFunction.cpp
@@ -67,11 +67,11 @@ void LLVMCompiledFunction::updatePlaceholders(
 }
 
 Error LLVMCompiledFunction::execute(ExecutionContext *context) {
-  auto cpuBindings =
-      static_cast<CPUDeviceBindings *>(context->getDeviceBindings());
+  auto deviceBindings =
+      static_cast<LLVMDeviceBindings *>(context->getDeviceBindings());
   uint8_t *deviceActivationsBufferBaseAddress =
-      cpuBindings->deviceActivationsBuffer;
-  uint8_t *deviceWeightsBufferBaseAddress = cpuBindings->deviceWeightsBuffer;
+      deviceBindings->deviceActivationsBuffer;
+  uint8_t *deviceWeightsBufferBaseAddress = deviceBindings->deviceWeightsBuffer;
 
   uint8_t *baseActivationsAddress{nullptr};
 

--- a/lib/LLVMIRCodeGen/LLVMCompiledFunction.cpp
+++ b/lib/LLVMIRCodeGen/LLVMCompiledFunction.cpp
@@ -67,6 +67,12 @@ void LLVMCompiledFunction::updatePlaceholders(
 }
 
 Error LLVMCompiledFunction::execute(ExecutionContext *context) {
+  auto cpuBindings =
+      static_cast<CPUDeviceBindings *>(context->getDeviceBindings());
+  uint8_t *deviceActivationsBufferBaseAddress =
+      cpuBindings->deviceActivationsBuffer;
+  uint8_t *deviceWeightsBufferBaseAddress = cpuBindings->deviceWeightsBuffer;
+
   uint8_t *baseActivationsAddress{nullptr};
 
   /// Base address for Mutable weights memory block, Inputs and Outputs.
@@ -75,13 +81,11 @@ Error LLVMCompiledFunction::execute(ExecutionContext *context) {
   {
     TRACE_EVENT_SCOPE(context, TraceLevel::RUNTIME, "allocBuffers");
     if (runtimeBundle_.getActivationsSize() != 0) {
-      baseActivationsAddress = (uint8_t *)alignedAlloc(
-          runtimeBundle_.getActivationsSize(), TensorAlignment);
+      baseActivationsAddress = deviceActivationsBufferBaseAddress;
     }
 
     if (runtimeBundle_.getMutableWeightSize() != 0) {
-      baseMutableWeightVarsAddress = (uint8_t *)alignedAlloc(
-          runtimeBundle_.getMutableWeightSize(), TensorAlignment);
+      baseMutableWeightVarsAddress = deviceWeightsBufferBaseAddress;
     }
   }
 
@@ -129,12 +133,6 @@ Error LLVMCompiledFunction::execute(ExecutionContext *context) {
     TRACE_EVENT_SCOPE(context, TraceLevel::RUNTIME, "updatePlaceholders");
     updatePlaceholders(context->getPlaceholderBindings(),
                        baseMutableWeightVarsAddress);
-  }
-
-  {
-    TRACE_EVENT_SCOPE(context, TraceLevel::RUNTIME, "freeBuffers");
-    alignedFree(baseMutableWeightVarsAddress);
-    alignedFree(baseActivationsAddress);
   }
 
   {

--- a/tests/unittests/BackendCorrectnessTest.cpp
+++ b/tests/unittests/BackendCorrectnessTest.cpp
@@ -197,6 +197,14 @@ public:
   }
 };
 
+class MockCPUDeviceBindings final : public LLVMDeviceBindings {
+public:
+  MockCPUDeviceBindings(uint8_t *activationsBuffer, uint8_t *weightsBuffer)
+      : LLVMDeviceBindings("CPU", activationsBuffer, weightsBuffer) {}
+
+  ~MockCPUDeviceBindings() {}
+};
+
 TEST_P(BackendCorrectnessTest, dataParallelStackingTest) {
   CHECK_IF_ENABLED();
   // Create an activation of size 3 and create two overlapping tensorviews of
@@ -265,9 +273,9 @@ TEST_P(BackendCorrectnessTest, dataParallelStackingTest) {
       (uint8_t *)alignedAlloc(bundle.getActivationsSize(), TensorAlignment);
   uint8_t *weightsBuffer =
       (uint8_t *)alignedAlloc(bundle.getMutableWeightSize(), TensorAlignment);
-  auto cpuBindings =
-      llvm::make_unique<CPUDeviceBindings>(activationsBuffer, weightsBuffer);
-  ctx->setDeviceBindings(std::move(cpuBindings));
+  auto deviceBindings = llvm::make_unique<MockCPUDeviceBindings>(
+      activationsBuffer, weightsBuffer);
+  ctx->setDeviceBindings(std::move(deviceBindings));
 
   ASSERT_FALSE(ERR_TO_BOOL(function->execute(ctx.get())));
   alignedFree(activationsBuffer);

--- a/tests/unittests/BackendCorrectnessTest.cpp
+++ b/tests/unittests/BackendCorrectnessTest.cpp
@@ -22,6 +22,7 @@
 #include "glow/IR/IR.h"
 #include "glow/IR/IRBuilder.h"
 #include "glow/IR/Instrs.h"
+#include "glow/LLVMIRCodeGen/LLVMCompiledFunction.h"
 #include "glow/Support/Random.h"
 
 #include "gtest/gtest.h"
@@ -258,7 +259,20 @@ TEST_P(BackendCorrectnessTest, dataParallelStackingTest) {
 
   MockCPUBackend backend;
   auto function = backend.compileIR(std::move(M));
+
+  auto &bundle = function->getRuntimeBundle();
+  uint8_t *activationsBuffer =
+      (uint8_t *)alignedAlloc(bundle.getActivationsSize(), TensorAlignment);
+  uint8_t *weightsBuffer =
+      (uint8_t *)alignedAlloc(bundle.getMutableWeightSize(), TensorAlignment);
+  auto cpuBindings =
+      llvm::make_unique<CPUDeviceBindings>(activationsBuffer, weightsBuffer);
+  ctx->setDeviceBindings(std::move(cpuBindings));
+
   ASSERT_FALSE(ERR_TO_BOOL(function->execute(ctx.get())));
+  alignedFree(activationsBuffer);
+  alignedFree(weightsBuffer);
+
   auto H = outputTensor->getHandle();
   EXPECT_EQ(H.at(0), 3);
   EXPECT_EQ(H.at(1), 4);


### PR DESCRIPTION
Summary:

LLVMCompiledFunction::execute(...) allocates (and then frees) memory for activations and weights on each call.
This PR refactors the allocation part to CPUDeviceManager::addNetwork(..).
CPUBuffer is the struct owning the device memory. A different CPUBuffer is created for each function.
CPUBindings are used to pass the memory addresses to the compiled function.

This is all very similar to the OpenCL implementation, with some major distinctions:
LLVM is not a backend itself. CPU is the backend and CPUFunction is derived from LLVMCompiledFunction. This creates a small linkage mess.
I'd love to get feedback about how it may constructed better.

This is the CPU backend, so the change is not very impactful. It's a helper feature from experiments on training and P2P, enabling not to update (copy) output/intermediate placeholders on each iteration and handle special specific cases of input placeholders. 
Addressing issue #3436 .

This also improves the situation a bit for training which calls runBatch(...) with a large number of iterations.
For example, on resnet50 training using CIFAR10, it saves ~5% time on each epoch:
before:
   ---User Time---   --System Time--   --User+System--   ---Wall Time---  --- Name ---
  216.9277 (100.0%)  12.8826 (100.0%)  229.8103 (100.0%)  229.9044 (100.0%)  Training
after:
   ---User Time---   --System Time--   --User+System--   ---Wall Time---  --- Name ---
  209.2006 (100.0%)   2.2592 (100.0%)  211.4598 (100.0%)  211.4995 (100.0%)  Training

Test Plan:
ninja test
