### PR TITLE
[Onnxifi] Better error message

### DIFF
--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -158,13 +158,13 @@ onnxStatus Graph::setIOAndRun(uint32_t inputsCount,
 
     if (inOnnxTensorSize > inPhPtr->getType()->size()) {
       std::stringstream ss;
-      for (const auto i : inOnnxTensorDims) {
-        ss << i << ", ";
+      for (const auto j : inOnnxTensorDims) {
+        ss << j << ", ";
       }
       ss << " vs ";
       auto sizes = inPhPtr->getType()->dims();
-      for (const auto i : sizes) {
-        ss << i << ", ";
+      for (const auto j : sizes) {
+        ss << j << ", ";
       }
       LOG(ERROR) << "Input tensor is too large: " << inOnnxTensorSize << " vs "
                  << inPhPtr->getType()->size() << ": " << inOnnxTensor.name

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -157,8 +157,18 @@ onnxStatus Graph::setIOAndRun(uint32_t inputsCount,
     }
 
     if (inOnnxTensorSize > inPhPtr->getType()->size()) {
+      std::stringstream ss;
+      for (const auto i : inOnnxTensorDims) {
+        ss << i << ", ";
+      }
+      ss << " vs ";
+      auto sizes = inPhPtr->getType()->dims();
+      for (const auto i : sizes) {
+        ss << i << ", ";
+      }
       LOG(ERROR) << "Input tensor is too large: " << inOnnxTensorSize << " vs "
-                 << inPhPtr->getType()->size() << ": " << inOnnxTensor.name;
+                 << inPhPtr->getType()->size() << ": " << inOnnxTensor.name
+                 << ", shape: " << ss.str();
       return ONNXIFI_STATUS_INVALID_SHAPE;
     }
 


### PR DESCRIPTION
Summary:
Give better error message when input tensor is larger than the compiled spec. Adding shape will help on which dimension we got wrong. 

Documentation:

[Optional Fixes #issue]

Test Plan:

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
