### PR TITLE
HostManager needs to depend on Runtime for Stats

### DIFF
--- a/lib/Runtime/HostManager/CMakeLists.txt
+++ b/lib/Runtime/HostManager/CMakeLists.txt
@@ -5,8 +5,9 @@ target_link_libraries(HostManager
                       PRIVATE
                         Backends
                         Base
+                        Executor
                         Graph
                         GraphOptimizer
                         Partitioner
                         Provisioner
-                        Executor)
+                        Runtime)


### PR DESCRIPTION
Summary: I don't know why this doesn't show up in CI, but we have a user report of a build failure, and it seems legit: https://discuss.pytorch.org/t/undefined-reference-to-glow-stats/56065/2
