### PR TITLE
[GraphOptimization] Replace Tile->Add with BatchedAdd

### DIFF
--- a/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
+++ b/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
@@ -39,7 +39,7 @@ FUN_PASS(OptimizeQuantization)
 FUN_PASS(FoldLeakyRelu)
 FUN_PASS(FoldChannelShuffle)
 FUN_PASS(ConstantFold)
-
+FUN_PASS(FoldTileAddIntoBatchedAdd)
 
 // NOTE: This pass must be last; it's used to count the total number of passes.
 FUN_PASS(EmptyPass)

--- a/lib/Optimizer/GraphOptimizerPipeline/Pipeline.cpp
+++ b/lib/Optimizer/GraphOptimizerPipeline/Pipeline.cpp
@@ -50,6 +50,9 @@ FunctionPassPipeline glow::createDefaultGraphOptimizationPassPipeline() {
       // Merge multiple matmul nodes into a single large matmul.
       {FunctionPassID::MergeMatMul},
 
+      // Fold Tile followed by Add into BatchedAdd.
+      {FunctionPassID::FoldTileAddIntoBatchedAdd},
+
       // Merge multiple batched adds into a larger batched add.
       {FunctionPassID::MergeBatchedAdd},
 


### PR DESCRIPTION
Summary:
Added compiler pass to detect and replace a Tile operation followed by an Add operation with a BatchedAdd to decrease memory footprint and memory reuse among other things.

Documentation:
See comments in the code.

[Optional Fixes #issue]
2208

Test Plan:
Added new unit test to GraphOptzTest
