### PR TITLE
[Graph] Only tile RHS of a BatchMatMul if LHS batch size is > 1

### DIFF
--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1440,7 +1440,7 @@ BatchMatMulNode *Function::createBatchMatMul(llvm::StringRef name,
     RHS = createExpandDims(name.str() + ".reshapeRHS", RHS, {0});
   }
   // If necessary, Tile the RHS input so it matches the numBatches of LHS.
-  if (RHS.dims()[0] == 1) {
+  if (RHS.dims()[0] == 1 && LHS.dims()[0] != 1) {
     RHS = createTile(name.str() + ".tileRHS", RHS, LHS.dims()[0], /*axis */ 0);
   }
 


### PR DESCRIPTION
**Summary**
This commit modifies `Function::createBatchMatMul` to insert a `Tile`
operation to make the first dimension (the batch dimension) of the RHS
operand equal to that of the LHS operand only if the latter is greater
than 1. If it is equal to 1, the `Tile` is not needed.

Test Plan:
This commit adds a new unit test for `BatchMatMul` in which the batch
dimension of the LHS operand is 1. All unit tests pass.