### PR TITLE
[OpenCL] speed up local size search

### DIFF
--- a/lib/Backends/Interpreter/tests/InterpreterBackendCorrectnessTest.cpp
+++ b/lib/Backends/Interpreter/tests/InterpreterBackendCorrectnessTest.cpp
@@ -17,4 +17,7 @@
 
 using namespace glow;
 
-std::set<std::string> glow::backendTestBlacklist = {};
+std::set<std::string> glow::backendTestBlacklist = {
+    // Interpreter does not support kernel stacking yet.
+    "dataParallelStackingTest/0",
+};

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -308,15 +308,15 @@ static void getMaxLocalWorkgroupSize(cl_kernel kernel, cl_device_id device,
   // constraints:
   size_t totalWorkPrevDims = 1;
   for (int i = 0, e = global.size(); i < e; i++) {
-    local[i] = L;
+    local[i] = std::min(L, WIS[i]);
+    local[i] = std::min(local[i], WGS / totalWorkPrevDims);
 
-    while (global[i] % local[i] || L % local[i] || local[i] > WIS[i] ||
-           local[i] * totalWorkPrevDims > WGS) {
+    while (global[i] % local[i] || L % local[i]) {
       local[i]--;
     }
 
     // Remember how much work we are doing in this dimension. Use it to make
-    // sure that the next dimenstions don't exceed the total allowed workgroup
+    // sure that the next dimensions don't exceed the total allowed workgroup
     // size.
     totalWorkPrevDims *= local[i];
   }

--- a/lib/Backends/OpenCL/tests/OpenCLBackendCorrectnessTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLBackendCorrectnessTest.cpp
@@ -18,6 +18,8 @@
 using namespace glow;
 
 std::set<std::string> glow::backendTestBlacklist = {
+    // Requires the CPU target due to the use of MockCPUBackend.
+    "dataParallelStackingTest/0",
     "localResponseNormalizationTest/0",
     "localResponseNormalizationGradTest/0",
     "AvgPoolGradTest/0",

--- a/tests/unittests/BackendCorrectnessTest.cpp
+++ b/tests/unittests/BackendCorrectnessTest.cpp
@@ -64,7 +64,7 @@ TEST_P(BackendCorrectnessTest, extract3Dtest) {
   Tensor out1;
   Tensor out2;
 
-  inferExtract3D(&inputs, &out1, "CPU");
+  inferExtract3D(&inputs, &out1, backendName_);
   inferExtract3D(&inputs, &out2, "Interpreter");
 
   EXPECT_TRUE(out1.isEqual(out2));
@@ -373,7 +373,8 @@ TEST_P(BackendCorrectnessTest, nonSquarePaddingConvTest) {
   CHECK_IF_ENABLED();
   Tensor out1;
   Tensor out2;
-  inferNonSquarePaddingConv(&out1, "CPU");
+
+  inferNonSquarePaddingConv(&out1, backendName_);
   inferNonSquarePaddingConv(&out2, "Interpreter");
 
   EXPECT_TRUE(out1.isEqual(out2));
@@ -382,9 +383,11 @@ TEST_P(BackendCorrectnessTest, nonSquarePaddingConvTest) {
 /// This non-square kernel test targets the DKKC8 optimization.
 TEST_P(BackendCorrectnessTest, nonSquareKernelConvTest) {
   CHECK_IF_ENABLED();
+
   Tensor out1;
   Tensor out2;
-  inferNonSquareKernelConv(&out1, "CPU");
+
+  inferNonSquareKernelConv(&out1, backendName_);
   inferNonSquareKernelConv(&out2, "Interpreter");
 
   EXPECT_TRUE(out1.isEqual(out2));
@@ -395,7 +398,7 @@ TEST_P(BackendCorrectnessTest, nonSquareStrideConvTest) {
   CHECK_IF_ENABLED();
   Tensor out1;
   Tensor out2;
-  inferNonSquareStrideConv(&out1, "CPU");
+  inferNonSquareStrideConv(&out1, backendName_);
   inferNonSquareStrideConv(&out2, "Interpreter");
 
   EXPECT_TRUE(out1.isEqual(out2));
@@ -406,7 +409,7 @@ TEST_P(BackendCorrectnessTest, convDKKC8Test) {
   CHECK_IF_ENABLED();
   Tensor out1;
   Tensor out2;
-  inferConvDKKC8(&out1, "CPU");
+  inferConvDKKC8(&out1, backendName_);
   inferConvDKKC8(&out2, "Interpreter");
   EXPECT_TRUE(out1.isEqual(out2));
 }

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -335,7 +335,12 @@ target_link_libraries(PartitionerTest
                         Partitioner
                         gtest
                         TestMain)
-add_glow_test(PartitionerTest ${GLOW_BINARY_DIR}/tests/PartitionerTest --gtest_output=xml:PartitionerTest.xml)
+
+# There are multiple test cases in PartitionerTest that work only with CPU
+# backend built-in.
+if(GLOW_WITH_CPU)
+  add_glow_test(PartitionerTest ${GLOW_BINARY_DIR}/tests/PartitionerTest --gtest_output=xml:PartitionerTest.xml)
+endif()
 
 if(GLOW_WITH_CPU)
   add_executable(ProvisionerTest


### PR DESCRIPTION
Summary:

Speed up the local size search. The starting point can be rather large especially for CPU devices, and decrementing it one unit at a time can take quite a long time.

Test Plan:

Passes ninja check for x86_64 pocl-hsa OpenCL target. I needed the 2nd patch in the PR since I had an OpenCL-only Glow build.