### PR TITLE
Preliminary implementation for standalone Glow trainer

### DIFF
--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -72,6 +72,9 @@ glow::Tensor ptTensorToGlowTensor(const at::Tensor &ptTensor);
 /// matching type.
 at::Tensor glowTypeToEmptyPTTensor(const glow::Type &glowType);
 
+/// Fuse known sets of operators into compact ones.
+void FuseKnownPatterns(std::shared_ptr<torch::jit::Graph> &graph);
+
 } // namespace glow
 
 #endif // GLOW_TORCH_GLOW_SRC_COMMON_H


### PR DESCRIPTION
Summary:
Standalone Glow trainer can be run from command line against different backends.
It will run training algorithms for a simple MNIST model or more complex models like ResNet.

Reviewed By: jackm321

Differential Revision: D17413773

