### PR TITLE
[Grad] Add support for differentiating TileNode

### DIFF
--- a/lib/Backends/OpenCL/tests/OpenCLGradCheckTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLGradCheckTest.cpp
@@ -21,4 +21,5 @@ std::set<std::string> glow::backendTestBlacklist = {
     "gradientCheckAvgPool/0",
     "gradientCheckAdaptiveAvgPool/0",
     "gradientCheckCrossEntropyLoss/0",
+    "gradientCheckTile/0",
 };

--- a/lib/Graph/Grad.cpp
+++ b/lib/Graph/Grad.cpp
@@ -144,6 +144,38 @@ Function *glow::differentiate(Function *F, const TrainingConfig &conf,
       continue;
     }
 
+    if (N->getKind() == Kind::TileNodeKind) {
+      TileNode *TN = cast<TileNode>(N);
+      NodeValue outputG = map.getGradient(TN->getResult());
+
+      // To compute the gradient with respect to the input of the TileNode, all
+      // of the slices in outputG corresponding to the tiled slices in the
+      // forward pass need to be added together. This is achieved by reshaping
+      // outputG to replace the tiling axis with {numTiles, tileDim}, and then
+      // performing a BatchedReduceAdd on the axis with numTiles elements. For
+      // example, if the tile creates a {n,x,h,w} output with a {n,c,h,w}
+      // input where x = c * numTiles, then the {n,x,h,w} gradient with respect
+      // to the output is reshaped to {n, numTiles, c, h, w} so that
+      // BatchedReduceAddNode eliminates the numTiles axis and produces a
+      // {n,c,h,w} output.
+      auto *TNInputType = TN->getInput().getType();
+      std::vector<size_t> BRAInputDims{TNInputType->dims()};
+      BRAInputDims.insert(BRAInputDims.begin() + TN->getAxis(), TN->getCount());
+      auto *BRAInputType =
+          F->getParent()->uniqueTypeWithNewShape(TNInputType, BRAInputDims);
+
+      auto *RN = new ReshapeNode(TN->getName().str() + ".grad.reshape",
+                                 BRAInputType, outputG, BRAInputType->dims());
+      auto *BRA =
+          new BatchedReduceAddNode(TN->getName().str() + ".grad.bra",
+                                   TN->getInput().getType(), RN, TN->getAxis());
+
+      toAppend.push_back(RN);
+      toAppend.push_back(BRA);
+      map.addGradient(TN->getInput(), BRA);
+      continue;
+    }
+
     if (N->getKind() == Kind::ConvertToNodeKind) {
       auto *RN = cast<ConvertToNode>(N);
       NodeValue outputG = map.getGradient(RN->getResult());

--- a/tests/unittests/GraphGradTest.cpp
+++ b/tests/unittests/GraphGradTest.cpp
@@ -232,6 +232,23 @@ TEST(GraphAutoGrad, checkMatMulGradTest) {
   EE.compile(CompilationMode::Train);
 }
 
+// Check that we can differentiate functions that use Tile.
+TEST(GraphAutoGrad, checkTileGradTest) {
+  ExecutionEngine EE;
+  TrainingConfig TC;
+
+  auto &Mod = EE.getModule();
+  Function *F = Mod.createFunction("main");
+
+  auto *A = Mod.createPlaceholder(ElemKind::FloatTy, {10, 10}, "A", false);
+  auto *Tile = F->createTile("tile", A, /*tiles=*/5, /*axis=*/1);
+
+  F->createSave("save", Tile);
+
+  glow::differentiate(F, TC);
+  EE.compile(CompilationMode::Train);
+}
+
 /// Check that we can differentiate functions that use BatchedReduceAddNode.
 TEST(GraphAutoGrad, checkBatchedReduceAddGradTest) {
   ExecutionEngine EE;


### PR DESCRIPTION
**Summary**
This commit adds support for differentiating `TileNodes`. The gradient
with respect to the input of the `TileNode` is the sum of the slices of
the gradient with respect to the output of the `TileNode` that correspond
to the slices that were repeated and concatenated during the forward
pass of `TileNode`. This operation is performed by using a `ReshapeNode` to
modify the dimensions of the gradient with respect to the `TileNode` output
such that the tiling axis is replaced with `{numTiles, tileDim}` and then
adding all of the slices with a `BatchedReduceAdd` node on the axis
corresponding to `numTiles`.

**Testing**
This commit adds unit tests to `GraphGradTest` and `GradCheckTest` for
`TileNode`. The latter checks that the gradient is correct when tiling on
a nontrivial axis (i.e. not the first). All unit tests pass.