### PR TITLE
[PyTorch] Update test all close tol to 1e-2

### DIFF
--- a/torch_glow/tests/nodes/quantized_add_test.py
+++ b/torch_glow/tests/nodes/quantized_add_test.py
@@ -25,10 +25,10 @@ def test_quantized_add():
     """Basic test of the PyTorch quantized::add Node on Glow."""
 
     def test_f(a, b):
-        q1 = torch.nn.quantized.Quantize(0.015, 5, torch.quint8)
-        q2 = torch.nn.quantized.Quantize(0.012, 10, torch.quint8)
+        q1 = torch.nn.quantized.Quantize(1/128, 5, torch.quint8)
+        q2 = torch.nn.quantized.Quantize(1/128, 10, torch.quint8)
         dq = torch.nn.quantized.DeQuantize()
-        return dq(torch.ops.quantized.add(q1(a), q2(b), scale=0.008, zero_point=3))
+        return dq(torch.ops.quantized.add(q1(a), q2(b), scale=1/128, zero_point=3))
 
     x = torch.randn([5, 5])
     y = torch.randn([5, 5])

--- a/torch_glow/tests/utils.py
+++ b/torch_glow/tests/utils.py
@@ -75,4 +75,4 @@ def jitVsGlow_(f_torch, f_glow, *inputs, expected_fused_ops=None,
         # i.e using torch.randn, scale should be set between 1/128 and 1/256,
         # to make sure the result does not mismatch.
         for i in range(len(torch_res)):
-            assert torch.allclose(torch_res[i], glow_res[i], atol=01e-5)
+            assert torch.allclose(torch_res[i], glow_res[i], atol=01e-6)

--- a/torch_glow/tests/utils.py
+++ b/torch_glow/tests/utils.py
@@ -71,5 +71,8 @@ def jitVsGlow_(f_torch, f_glow, *inputs, expected_fused_ops=None,
         assert accept_all_ops or len(expected_fused_ops) == len(expected_fused_ops_seen), \
             "Expected all of expected_fused_ops to be in the graph"
         assert len(torch_res) == len(glow_res)
+        # When testing quantized operators and generating data between [0, 1]
+        # i.e using torch.randn, scale should be set between 1/128 and 1/256,
+        # to make sure the result does not mismatch.
         for i in range(len(torch_res)):
             assert torch.allclose(torch_res[i], glow_res[i], atol=01e-5)

--- a/torch_glow/tests/utils.py
+++ b/torch_glow/tests/utils.py
@@ -72,4 +72,4 @@ def jitVsGlow_(f_torch, f_glow, *inputs, expected_fused_ops=None,
             "Expected all of expected_fused_ops to be in the graph"
         assert len(torch_res) == len(glow_res)
         for i in range(len(torch_res)):
-            assert torch.allclose(torch_res[i], glow_res[i], atol=01e-6)
+            assert torch.allclose(torch_res[i], glow_res[i], atol=01e-2)

--- a/torch_glow/tests/utils.py
+++ b/torch_glow/tests/utils.py
@@ -72,4 +72,4 @@ def jitVsGlow_(f_torch, f_glow, *inputs, expected_fused_ops=None,
             "Expected all of expected_fused_ops to be in the graph"
         assert len(torch_res) == len(glow_res)
         for i in range(len(torch_res)):
-            assert torch.allclose(torch_res[i], glow_res[i], atol=01e-2)
+            assert torch.allclose(torch_res[i], glow_res[i], atol=01e-5)


### PR DESCRIPTION
As we implementing quantization, the result mismatch becomes common and tolerable. 
Therefore we would like to update our tol to 1e-2, to make sure all our tests not flaky.