### PR TITLE
[Grad] Add support for differentiating BatchMatMul

### DIFF
--- a/lib/Graph/Grad.cpp
+++ b/lib/Graph/Grad.cpp
@@ -300,6 +300,32 @@ Function *glow::differentiate(Function *F, const TrainingConfig &conf,
       continue;
     }
 
+    if (N->getKind() == Kind::BatchMatMulNodeKind) {
+      BatchMatMulNode *BMMN = cast<BatchMatMulNode>(N);
+      // Get gradient.
+      NodeValue OutputG = map.getGradient(BMMN->getResult());
+
+      // The implementation below is a batched version of the gradient
+      // computation for MatMul.
+      NodeValue InputLHS = BMMN->getLHS();
+      NodeValue InputRHS = BMMN->getRHS();
+      auto *LT = G->createTranspose("lhs.T", InputLHS, {0, 2, 1});
+      auto *RT = G->createTranspose("rhs.T", InputRHS, {0, 2, 1});
+
+      // Grad for LHS = outputG x transpose(RHS).
+      auto *GradLHS = new BatchMatMulNode(BMMN->getInputName(0),
+                                          InputLHS.getType(), OutputG, RT);
+      // Grad for RHS = transpose(LHS) x outputG.
+      auto *GradRHS = new BatchMatMulNode(BMMN->getInputName(1),
+                                          InputRHS.getType(), LT, OutputG);
+
+      toAppend.push_back(GradLHS);
+      map.addGradient(InputLHS, GradLHS);
+      toAppend.push_back(GradRHS);
+      map.addGradient(InputRHS, GradRHS);
+      continue;
+    }
+
     if (N->getKind() == Kind::BatchedReduceAddNodeKind) {
       BatchedReduceAddNode *BRA = cast<BatchedReduceAddNode>(N);
       // Get gradient.

--- a/tests/unittests/GraphGradTest.cpp
+++ b/tests/unittests/GraphGradTest.cpp
@@ -232,6 +232,26 @@ TEST(GraphAutoGrad, checkMatMulGradTest) {
   EE.compile(CompilationMode::Train);
 }
 
+/// Check that we can differentiate functions that use BatchMatMul.
+TEST(GraphAutoGrad, checkBatchMatMulGradTest) {
+  ExecutionEngine EE;
+  TrainingConfig TC;
+
+  auto &Mod = EE.getModule();
+  Function *F = Mod.createFunction("main");
+
+  auto *A = Mod.createPlaceholder(ElemKind::FloatTy, {5, 20, 13}, "A",
+                                  /*isTrainable=*/false);
+  auto *B = Mod.createPlaceholder(ElemKind::FloatTy, {13, 30}, "B",
+                                  /*isTrainable=*/false);
+  auto *BatchMatMul = F->createBatchMatMul("batchMatMul", A, B);
+
+  F->createSave("save", BatchMatMul);
+
+  glow::differentiate(F, TC);
+  EE.compile(CompilationMode::Train);
+}
+
 // Check that we can differentiate functions that use Tile.
 TEST(GraphAutoGrad, checkTileGradTest) {
   ExecutionEngine EE;


### PR DESCRIPTION
**Summary**
This commit adds support for differentiating `BatchMatMul` nodes.
Recall that the gradients with respect to both inputs of a `MatMul` node are computed
using `MatMul` nodes with the gradient with respect to the output of the
original `MatMul` and transposed versions of either input. Similarly, the
gradients with respect to both inputs of `BatchMatMul` node are computed
using `BatchMatMul` nodes with the (batched) gradient with respect to the
output of the original `BatchedMatMul` and transposed versions of either
input.

**Testing**
This commit adds tests to `GradCheckTest` and `GraphGradTest` for
`BatchMatMulNode`. All tests pass.

**Dependencies**
This PR is stacked on top of #3527.