### PR TITLE
[PyTorch] Add test for quantized aten::relu

### DIFF
--- a/torch_glow/tests/nodes/quantized_relu_test.py
+++ b/torch_glow/tests/nodes/quantized_relu_test.py
@@ -4,16 +4,18 @@ import torch
 
 from tests.utils import jitVsGlow
 
+
 def test_quantized_relu():
     """Basic test of the PyTorch quantized::relu Node on Glow."""
 
     def test_f(a):
         q = torch.nn.quantized.Quantize(0.015, 5, torch.quint8)
         dq = torch.nn.quantized.DeQuantize()
-        return dq(torch.nn.quantized.ReLU(q(a)))
+        re = torch.nn.quantized.ReLU()
+        return dq(re(q(a)))
 
     x = torch.randn([5, 5])
 
-    jitVsGlow(test_f, x, expected_fused_ops={"quantized::add",
-                                                "aten::quantize_linear",
-                                                "aten::dequantize"})
+    jitVsGlow(test_f, x, expected_fused_ops={"aten::relu",
+                                             "aten::quantize_linear",
+                                             "aten::dequantize"})

--- a/torch_glow/tests/nodes/quantized_relu_test.py
+++ b/torch_glow/tests/nodes/quantized_relu_test.py
@@ -1,0 +1,19 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import torch
+
+from tests.utils import jitVsGlow
+
+def test_quantized_relu():
+    """Basic test of the PyTorch quantized::relu Node on Glow."""
+
+    def test_f(a):
+        q = torch.nn.quantized.Quantize(0.015, 5, torch.quint8)
+        dq = torch.nn.quantized.DeQuantize()
+        return dq(torch.nn.quantized.ReLU(q(a)))
+
+    x = torch.randn([5, 5])
+
+    jitVsGlow(test_f, x, expected_fused_ops={"quantized::add",
+                                                "aten::quantize_linear",
+                                                "aten::dequantize"})

--- a/torch_glow/tests/nodes/quantized_relu_test.py
+++ b/torch_glow/tests/nodes/quantized_relu_test.py
@@ -9,7 +9,7 @@ def test_quantized_relu():
     """Basic test of the PyTorch quantized::relu Node on Glow."""
 
     def test_f(a):
-        q = torch.nn.quantized.Quantize(0.015, 5, torch.quint8)
+        q = torch.nn.quantized.Quantize(1/128, 3, torch.quint8)
         dq = torch.nn.quantized.DeQuantize()
         re = torch.nn.quantized.ReLU()
         return dq(re(q(a)))


### PR DESCRIPTION
In PyTorch jit ir, quantized relu is same to regular aten::relu.
We only need to add related test for our quantized version of relu.