### PR TITLE
Modified RecommendationSystemTest to use HostManager directly. 

### DIFF
--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -310,7 +310,14 @@ foreach(backend ${GLOW_BACKENDS})
   add_backend_test(TEST MLTest BACKEND "${backend}" UNOPT)
   add_backend_test(TEST OperatorGradTest BACKEND "${backend}" UNOPT)
   add_backend_test(TEST OperatorTest BACKEND "${backend}" UNOPT)
-  add_backend_test(TEST RecommendationSystemTest BACKEND "${backend}" EXPENSIVE PRIVATE Partitioner)
+  add_backend_test(TEST
+                   RecommendationSystemTest
+                   BACKEND
+                   "${backend}"
+                   EXPENSIVE
+                   PRIVATE
+                   Partitioner
+                   HostManager)
   add_backend_test(TEST TraceEventsTest BACKEND "${backend}" UNOPT)
   add_backend_test(TEST TypeAToTypeBFunctionConverterTest BACKEND "${backend}")
 endforeach()


### PR DESCRIPTION
Summary:
Modified RecommendationSystemTest to use HostManager directly. 
This allows for testing concurrency and heterogeneous partitioning.
Added a second request to test concurrent requests.
Documentation:

Fixes #3521 

Test Plan: Verify RecommendationSystemTest still builds and runs successfully.