### PR TITLE
[NFC] Fix -Wmissing-braces warnings

### DIFF
--- a/examples/tracing-compare.cpp
+++ b/examples/tracing-compare.cpp
@@ -32,9 +32,9 @@ using namespace glow;
 using namespace glow::runtime;
 
 #if (GLOW_WITH_OPENCL)
-std::array<std::string, 3> supportedBackends{"CPU", "Interpreter", "OpenCL"};
+std::array<std::string, 3> supportedBackends{{"CPU", "Interpreter", "OpenCL"}};
 #else
-std::array<std::string, 2> supportedBackends{"CPU", "Interpreter"};
+std::array<std::string, 2> supportedBackends{{"CPU", "Interpreter"}};
 #endif
 
 namespace {

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -1074,13 +1074,13 @@ Error OpenCLFunction::execute(ExecutionContext *context) {
 
         setKernelArg(kernel, numArgs + 4, odim);
         setKernelArg(kernel, numArgs + 5, idim);
-        global = {odim.h, odim.w, odim.c};
+        global = {{odim.h, odim.w, odim.c}};
       } else {
         ShapeNHWC odim(PM->getDest()->getType()->dims());
         ShapeNHWC idim(PM->getSrc()->getType()->dims());
         setKernelArg(kernel, numArgs + 4, odim);
         setKernelArg(kernel, numArgs + 5, idim);
-        global = {odim.h, odim.w, odim.c};
+        global = {{odim.h, odim.w, odim.c}};
       }
 
       enqueueKernel(I.getName(), commands, kernel, deviceId, global,
@@ -1157,13 +1157,13 @@ Error OpenCLFunction::execute(ExecutionContext *context) {
 
         setKernelArg(kernel, numArgs + 4, odim);
         setKernelArg(kernel, numArgs + 5, idim);
-        global = {odim.h, odim.w, odim.c};
+        global = {{odim.h, odim.w, odim.c}};
       } else {
         ShapeNHWC odim(PA->getDest()->getType()->dims());
         ShapeNHWC idim(PA->getSrc()->getType()->dims());
         setKernelArg(kernel, numArgs + 4, odim);
         setKernelArg(kernel, numArgs + 5, idim);
-        global = {odim.h, odim.w, odim.c};
+        global = {{odim.h, odim.w, odim.c}};
       }
 
       if (isNCHW && isQuantized) {

--- a/tests/stress/SparseLengthsSumTest.cpp
+++ b/tests/stress/SparseLengthsSumTest.cpp
@@ -34,10 +34,10 @@ TEST_P(SparseLengthsSum, Big) {
   F_ = mod->createFunction("main");
   auto *interpMod = &interp.getModule();
   auto *G = interp.getModule().createFunction("main");
-  std::array<size_t, 13> dataRows = {
+  std::array<size_t, 13> dataRows = {{
       5000000, 5000000, 6000000, 8000000, 8000000, 8000000, 3000000,
       3000000, 1000000, 5000000, 8000000, 5000000, 1000000,
-  };
+  }};
 
   std::vector<Constant *> data;
   std::vector<Constant *> dataI;

--- a/tests/unittests/TraceEventsTest.cpp
+++ b/tests/unittests/TraceEventsTest.cpp
@@ -724,9 +724,9 @@ TEST(TraceEventsTest, nestedScopedEventsTerm) {
 
 TEST(TraceEventsTest, TraceLevels) {
   CHECK_IF_ENABLED();
-  std::array<TraceLevel, 4> levels = {TraceLevel::NONE, TraceLevel::REQUEST,
-                                      TraceLevel::RUNTIME,
-                                      TraceLevel::OPERATOR};
+  std::array<TraceLevel, 4> levels = {{TraceLevel::NONE, TraceLevel::REQUEST,
+                                       TraceLevel::RUNTIME,
+                                       TraceLevel::OPERATOR}};
   for (auto L : levels) {
     TraceContext context(L);
     for (auto evl : levels) {


### PR DESCRIPTION
**Summary**
This commit fixes a handful of compiler warnings flagged by the
`-Wmissing-braces` option.

**Testing**
After applying this commit, these warnings no longer appear after
executing `ninja all`.