### PR TITLE
[PyTorch]Fix PYTORCH CI break

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -366,7 +366,7 @@ struct QuantizedAddInputs {
   };
 };
 
-/// Indexes of aten::quantize_linear inputs.
+/// Indexes of aten::quantize_per_tensor inputs.
 struct QuantizeInputs {
   enum {
     input = 0,
@@ -470,7 +470,7 @@ PyTorchModelLoader::getSymbolsMapping() {
        {{"quantized::add"},
         &PyTorchModelLoader::loadQuantizedAdd,
         {QuantizedAddInputs::scale, QuantizedAddInputs::offset}},
-       {{"aten::quantize_linear"},
+       {{"aten::quantize_per_tensor"},
         &PyTorchModelLoader::loadQuantize,
         {QuantizeInputs::scale, QuantizeInputs::offset, QuantizeInputs::dtype}},
        {{"aten::dequantize"}, &PyTorchModelLoader::loadDequantize, {}},

--- a/torch_glow/tests/nodes/quantized_add_test.py
+++ b/torch_glow/tests/nodes/quantized_add_test.py
@@ -17,7 +17,7 @@ def test_quantized_add_zerooffset():
     y = torch.tensor([5, 6, 7, 8], dtype=torch.float32)
 
     jitVsGlow(test_f, x, y, expected_fused_ops={"quantized::add",
-                                                "aten::quantize_linear",
+                                                "aten::quantize_per_tensor",
                                                 "aten::dequantize"})
 
 
@@ -34,5 +34,5 @@ def test_quantized_add():
     y = torch.randn([5, 5])
 
     jitVsGlow(test_f, x, y, expected_fused_ops={"quantized::add",
-                                                "aten::quantize_linear",
+                                                "aten::quantize_per_tensor",
                                                 "aten::dequantize"})

--- a/torch_glow/tests/nodes/quantized_relu_test.py
+++ b/torch_glow/tests/nodes/quantized_relu_test.py
@@ -17,5 +17,5 @@ def test_quantized_relu():
     x = torch.randn([5, 5])
 
     jitVsGlow(test_f, x, expected_fused_ops={"aten::relu",
-                                             "aten::quantize_linear",
+                                             "aten::quantize_per_tensor",
                                              "aten::dequantize"})


### PR DESCRIPTION
Last week we have some API update in pytorch quantization jit ir, which caused our CI down.
This pr fixed this problem, and all tests should be passed.