### PR TITLE
[CI] Not to use pip to install cmake in PYTORCH and CHECK_FORMAT branch.

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -72,7 +72,7 @@ sudo apt-get update
 sudo apt-get install cmake
 
 # Install ninja, (newest version of) autopep8 through pip
-sudo pip install ninja cmake autopep8
+sudo pip install ninja autopep8
 hash cmake ninja
 
 # Build glow

--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -70,6 +70,15 @@ fi
 # Install scikit-build for cmake
 sudo pip install scikit-build
 
+# Install cmake 3.8.1
+sudo apt-get install build-essential
+wget http://www.cmake.org/files/v3.12/cmake-3.12.1-Linux-x86_64.tar.gz
+tar xf cmake-3.12.1-Linux-x86_64.tar.gz
+cd cmake-3.12.1-Linux-x86_64
+./configure
+make
+cd ..
+
 # Install ninja, (newest version of) autopep8 through pip
 sudo pip install ninja autopep8 cmake
 hash cmake ninja

--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -80,7 +80,7 @@ make
 cd ..
 
 # Install ninja, (newest version of) autopep8 through pip
-sudo pip install ninja autopep8 cmake
+sudo pip install ninja autopep8
 hash cmake ninja
 
 # Build glow

--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -67,7 +67,11 @@ else
     sudo apt-get install -y libpng-dev libgoogle-glog-dev
 fi
 
-# Install ninja, (newest version of) cmake and autopep8 through pip
+# Install cmake through apt-get
+sudo apt-get update
+sudo apt-get install cmake
+
+# Install ninja, (newest version of) autopep8 through pip
 sudo pip install ninja cmake autopep8
 hash cmake ninja
 

--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -67,12 +67,11 @@ else
     sudo apt-get install -y libpng-dev libgoogle-glog-dev
 fi
 
-# Install cmake through apt-get
-sudo apt-get update
-sudo apt-get install cmake
+# Install scikit-build for cmake
+sudo pip install scikit-build
 
 # Install ninja, (newest version of) autopep8 through pip
-sudo pip install ninja autopep8
+sudo pip install ninja autopep8 cmake
 hash cmake ninja
 
 # Build glow

--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -67,22 +67,12 @@ else
     sudo apt-get install -y libpng-dev libgoogle-glog-dev
 fi
 
-# Install scikit-build for cmake
-#sudo pip install scikit-build
-
-if [[ "${CIRCLE_JOB}" == "PYTORCH" ]]; then
+# Since we are using llvm-7 in these two branches, we cannot use pip install cmake
+if [[ "${CIRCLE_JOB}" == "PYTORCH" ] || [ "$CIRCLE_JOB" == "CHECK_CLANG_AND_PEP8_FORMAT" ]]; then
 	sudo apt-get install cmake
 else
     sudo pip install cmake
 fi
-# Install cmake 3.8.1
-#sudo apt-get install build-essential
-#wget http://www.cmake.org/files/v3.8/cmake-3.8.1.tar.gz
-#tar xf cmake-3.8.1.tar.gz
-#cd cmake-3.8.1
-#./configure
-#make
-#cd ..
 
 # Install ninja, (newest version of) autopep8 through pip
 sudo pip install ninja autopep8

--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -68,10 +68,10 @@ else
 fi
 
 # Since we are using llvm-7 in these two branches, we cannot use pip install cmake
-if [[ "${CIRCLE_JOB}" == "PYTORCH" ] || [ "$CIRCLE_JOB" == "CHECK_CLANG_AND_PEP8_FORMAT" ]]; then
-	sudo apt-get install cmake
+if [ "${CIRCLE_JOB}" != "PYTORCH" ] && [ "${CIRCLE_JOB}" != "CHECK_CLANG_AND_PEP8_FORMAT" ]; then
+	sudo pip install cmake
 else
-    sudo pip install cmake
+	sudo apt-get install cmake
 fi
 
 # Install ninja, (newest version of) autopep8 through pip

--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -68,16 +68,18 @@ else
 fi
 
 # Install scikit-build for cmake
-sudo pip install scikit-build
+#sudo pip install scikit-build
+
+sudo apt-get install cmake
 
 # Install cmake 3.8.1
-sudo apt-get install build-essential
-wget http://www.cmake.org/files/v3.8/cmake-3.8.1.tar.gz
-tar xf cmake-3.8.1.tar.gz
-cd cmake-3.8.1
-./configure
-make
-cd ..
+#sudo apt-get install build-essential
+#wget http://www.cmake.org/files/v3.8/cmake-3.8.1.tar.gz
+#tar xf cmake-3.8.1.tar.gz
+#cd cmake-3.8.1
+#./configure
+#make
+#cd ..
 
 # Install ninja, (newest version of) autopep8 through pip
 sudo pip install ninja autopep8

--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -72,9 +72,9 @@ sudo pip install scikit-build
 
 # Install cmake 3.8.1
 sudo apt-get install build-essential
-wget http://www.cmake.org/files/v3.12/cmake-3.12.1.tar.gz
-tar xf cmake-3.12.1.tar.gz
-cd cmake-3.12.1
+wget http://www.cmake.org/files/v3.8/cmake-3.8.1.tar.gz
+tar xf cmake-3.8.1.tar.gz
+cd cmake-3.8.1
 ./configure
 make
 cd ..

--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -72,9 +72,9 @@ sudo pip install scikit-build
 
 # Install cmake 3.8.1
 sudo apt-get install build-essential
-wget http://www.cmake.org/files/v3.12/cmake-3.12.1-Linux-x86_64.tar.gz
-tar xf cmake-3.12.1-Linux-x86_64.tar.gz
-cd cmake-3.12.1-Linux-x86_64
+wget http://www.cmake.org/files/v3.12/cmake-3.12.1.tar.gz
+tar xf cmake-3.12.1.tar.gz
+cd cmake-3.12.1
 ./configure
 make
 cd ..

--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -70,8 +70,11 @@ fi
 # Install scikit-build for cmake
 #sudo pip install scikit-build
 
-sudo apt-get install cmake
-
+if [[ "${CIRCLE_JOB}" == "PYTORCH" ]]; then
+	sudo apt-get install cmake
+else
+    sudo pip install cmake
+fi
 # Install cmake 3.8.1
 #sudo apt-get install build-essential
 #wget http://www.cmake.org/files/v3.8/cmake-3.8.1.tar.gz


### PR DESCRIPTION
Currently CI is down because of we are using pip install cmake which may cause some problem.
In this diff we will try to solve this problem by using apt-get or conda.

Since PYTORCH branch uses an older version of llvm, pip install cmake does not work for that. Therefore switch to use apt-get for that branch.