### PR TITLE
Two minor changes for enabling the initial LLVM 9 support

### DIFF
--- a/include/glow/Backends/LayoutConverter.h
+++ b/include/glow/Backends/LayoutConverter.h
@@ -23,7 +23,7 @@ namespace glow {
 
 /// Convert regular convolution nodes (that use NHWC) into a backend-specific
 /// convolution nodes using NCHW.
-Node *convertConvToNCHWConv(ConvolutionNode *CN, Function *F) {
+inline Node *convertConvToNCHWConv(ConvolutionNode *CN, Function *F) {
   // Convert filter and input from NHWC (Glow's default) into NCHW.
   auto *NI = F->createTranspose("conv.input", CN->getInput(), NHWC2NCHW);
   auto *NF = F->createTranspose("conv.filter", CN->getFilter(), NHWC2NCHW);
@@ -44,7 +44,7 @@ Node *convertConvToNCHWConv(ConvolutionNode *CN, Function *F) {
 
 /// Convert regular pool nodes (that use NHWC) into backend-specific nodes using
 /// NCHW.
-Node *convertMaxPoolToNCHWPool(MaxPoolNode *PN, Function *F) {
+inline Node *convertMaxPoolToNCHWPool(MaxPoolNode *PN, Function *F) {
   // Convert input from NHWC (Glow's default) into NCHW.
   auto *NI = F->createTranspose("maxpool.input", PN->getInput(), NHWC2NCHW);
 
@@ -63,7 +63,7 @@ Node *convertMaxPoolToNCHWPool(MaxPoolNode *PN, Function *F) {
   return NR;
 }
 
-Node *convertAvgPoolToNCHWPool(AvgPoolNode *PN, Function *F) {
+inline Node *convertAvgPoolToNCHWPool(AvgPoolNode *PN, Function *F) {
   // Convert input from NHWC (Glow's default) into NCHW.
   auto *NI = F->createTranspose("maxpool.input", PN->getInput(), NHWC2NCHW);
 

--- a/include/glow/LLVMIRCodeGen/LLVMBackend.h
+++ b/include/glow/LLVMIRCodeGen/LLVMBackend.h
@@ -37,6 +37,8 @@ class LLVMBackend : public BackendUsingGlowIR {
   std::string arch_;
   /// Cpu used by this backend.
   std::string cpu_;
+  /// Code model used by this backend.
+  llvm::CodeModel::Model codeModel_;
 
 public:
   LLVMBackend();
@@ -52,6 +54,12 @@ public:
   llvm::StringRef getCPU() const { return cpu_; }
   /// Sets cpu used by this backend.
   void setCPU(llvm::StringRef cpu) { cpu_ = cpu; }
+  /// \returns code model used by this backend.
+  llvm::CodeModel::Model getCodeModel() const { return codeModel_; }
+  /// Sets code model used by this backend.
+  void setCodeModel(llvm::CodeModel::Model codeModel) {
+    codeModel_ = codeModel;
+  }
   /// @name Backend methods.
   /// This is the implementation of the Backend interface.
   ///@{

--- a/lib/LLVMIRCodeGen/LLVMBackend.cpp
+++ b/lib/LLVMIRCodeGen/LLVMBackend.cpp
@@ -54,6 +54,7 @@ LLVMBackend::LLVMBackend() {
   arch_ = llvmArch;
   target_ = llvmTarget;
   cpu_ = llvmCPU;
+  codeModel_ = llvm::CodeModel::Model::Large;
 }
 
 /// Emit the entry point for JIT called "jitmain".
@@ -110,7 +111,7 @@ LLVMBackend::compileIRWithoutConstants(IRFunction *IR) const {
   llvm::SmallVector<std::string, 8> targetFeatures(llvmTargetFeatures.begin(),
                                                    llvmTargetFeatures.end());
   irgen->initTargetMachine(getTarget(), getArch(), getCPU(), targetFeatures,
-                           llvm::CodeModel::Model::Large);
+                           getCodeModel());
   irgen->initCodeGen();
   // Perform the address assignment for activations and WeightVars.
 


### PR DESCRIPTION
Summary:

This PR fixes a couple of issues were discovered while trying to build Glow with the recently released LLVM 9.0.

- Declares conversion methods as inline to avoid "duplicate symbol definition" linker errors
- Let backends set their code models
  Switching to LLVM 9 resulted in the code model related failures of some LLVMBackend-based backends when a hard-coded code model is used. These new APIs allow backends set a proper code model.

There are still some issues related to LLVM 9, which are not fixed by this PR. In particular, LLVM's ORC JIT APIs were changed once again. Glow's LLVM JIT related code compiles, but it uses deprecated ORCv1 APIs, which results in compiler warnings. I filed #3551 to track this issue.

Test Plan:

ninja test
