### PR TITLE
Remove basename from ImageClassifier

### DIFF
--- a/tools/loader/ImageClassifier.cpp
+++ b/tools/loader/ImageClassifier.cpp
@@ -732,7 +732,7 @@ int main(int argc, char **argv) {
   }
 
   if (!tracePath.empty()) {
-    traceContext->dump(tracePath, basename(argv[0]));
+    traceContext->dump(tracePath, "ImageClassifier");
   }
 
   return numErrors;


### PR DESCRIPTION
Summary:
ImageClassifier not compiling on mac with this.

Documentation:
n/a

Test Plan:
`ninja all`
