### PR TITLE
Avoid adding Clips around transform/indexing Nodes when converting to fp16

### DIFF
--- a/include/glow/Converter/FunctionConverter.h
+++ b/include/glow/Converter/FunctionConverter.h
@@ -93,10 +93,10 @@ protected:
   virtual bool canConvert(const Node &node) const;
 
   /// Create a conversion with \p val as input and \p destTy as the destination
-  /// type in \p function. In other words, creates something like cast val to
-  /// destTy.
-  virtual Node *createConversion(Function &function, NodeValue &val,
-                                 TypeRef destTy) = 0;
+  /// type in \p function, given \p node. In other words, creates something like
+  /// cast val to destTy.
+  virtual Node *createConversion(Function &function, const Node &node,
+                                 NodeValue &val, TypeRef destTy) = 0;
 
   /// Given a \p conversion, get its output value.
   /// The default implementation returns the zero-th result.

--- a/include/glow/Converter/TypeAToTypeBFunctionConverter.h
+++ b/include/glow/Converter/TypeAToTypeBFunctionConverter.h
@@ -54,9 +54,9 @@ protected:
   /// is used.
   TypeRef getTargetTypeForInput(const Node &use, unsigned idx) const override;
 
-  /// Create a node in \p function that converts \p val to \p destTy.
-  /// \p val and \p destTy must have the same shape.
-  Node *createConversion(Function &function, NodeValue &val,
+  /// Create a node in \p function that converts \p val to \p destTy, given
+  /// context \p node. \p val and \p destTy must have the same shape.
+  Node *createConversion(Function &function, const Node &node, NodeValue &val,
                          TypeRef destTy) override;
 
   /// Check if \p node can be converted.

--- a/lib/Converter/FunctionConverter.cpp
+++ b/lib/Converter/FunctionConverter.cpp
@@ -102,7 +102,7 @@ void FunctionConverter::convertOutputs(Node &node) {
       // a save node, we actually have to convert the input.
       if (saveNode && saveNode->getOutput() == val) {
         NodeValue input = saveNode->getInput();
-        Node *conversion = createConversion(*parent, input, targetTy);
+        Node *conversion = createConversion(*parent, node, input, targetTy);
         saveNode->setNthInput(SaveNode::InputIdx,
                               getConversionOutput(*conversion));
         continue;
@@ -112,7 +112,7 @@ void FunctionConverter::convertOutputs(Node &node) {
       auto conversionValIt = functionAndValToConversion.find(functionAndVal);
       if (conversionValIt == functionAndValToConversion.end()) {
         // Create the conversion.
-        Node *conversion = createConversion(*parent, val, origTy);
+        Node *conversion = createConversion(*parent, node, val, origTy);
         // "conversion" uses val so after this call,
         // we will get a use of conversion inside conversion.
         NodeValue conversionVal = getConversionOutput(*conversion);
@@ -152,7 +152,7 @@ void FunctionConverter::convertInputs(Node &node) {
     assert(targetTy->dims() == val.getType()->dims() &&
            "Conversion does not preserve shape");
     // Create the conversion.
-    Node *conversion = createConversion(function_, val, targetTy);
+    Node *conversion = createConversion(function_, node, val, targetTy);
     node.setNthInput(idx, getConversionOutput(*conversion));
   }
 }

--- a/lib/Converter/TypeAToTypeBFunctionConverter.cpp
+++ b/lib/Converter/TypeAToTypeBFunctionConverter.cpp
@@ -52,6 +52,7 @@ TypeAToTypeBFunctionConverter::getTargetTypeForInput(const Node &use,
 }
 
 Node *TypeAToTypeBFunctionConverter::createConversion(Function &function,
+                                                      const Node &node,
                                                       NodeValue &val,
                                                       TypeRef destTy) {
   assert(((destTy->getElementType() == dstKind_ &&
@@ -60,7 +61,21 @@ Node *TypeAToTypeBFunctionConverter::createConversion(Function &function,
            val.getType()->getElementType() == dstKind_)) &&
          "Unexpected conversion type");
 
-  if (precConfig_.clipFP16) {
+  bool needClip = precConfig_.clipFP16;
+  if (needClip) {
+    switch (node.getKind()) {
+    case Kinded::Kind::ConcatNodeKind:
+    case Kinded::Kind::GatherNodeKind:
+    case Kinded::Kind::ReshapeNodeKind:
+    case Kinded::Kind::SliceNodeKind:
+    case Kinded::Kind::TransposeNodeKind:
+      needClip = false;
+      break;
+    default:
+      break;
+    }
+  }
+  if (needClip) {
     assert((destTy->getElementType() == ElemKind::Float16Ty ||
             val.getType()->getElementType() == ElemKind::Float16Ty) &&
            "Unexpected conversion type");

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -378,8 +378,8 @@ protected:
   ///
   /// \pre One of t\p val's type and \p destTy must be FloatTy and
   ///      the other must be a quantized type.
-  Node *createConversion(Function &function, NodeValue &val,
-                         TypeRef destTy) override {
+  Node *createConversion(Function &function, const Node & /* unused */,
+                         NodeValue &val, TypeRef destTy) override {
     assert((&function == &function_) &&
            "Trying to add quantize/dequantize conversion to a function other "
            "than the function being quantized.");

--- a/tests/unittests/TypeAToTypeBFunctionConverterTest.cpp
+++ b/tests/unittests/TypeAToTypeBFunctionConverterTest.cpp
@@ -1250,4 +1250,40 @@ TEST_P(AllBackends, convertOnlyUInt8FusedQTy) {
   EXPECT_TRUE(F->verify());
 }
 
+// Test that we don't insert Clips around non-numeric nodes.
+TEST_P(AllBackends, convertWithoutClipAroundNonNumericNodes) {
+  Module mod;
+  Function *F = mod.createFunction("test");
+  const size_t dims[] = {1, 5, 10, 15};
+  const size_t dimsReshape[] = {10, 10, 15};
+  Node *I0 = mod.createPlaceholder(ElemKind::FloatTy, dims, "i0", false);
+  Node *I1 = mod.createPlaceholder(ElemKind::FloatTy, dims, "i1", false);
+  Node *I2 = mod.createPlaceholder(ElemKind::Int32ITy, {2, 2, 2}, "i2", false);
+  Node *CN = F->createConcat("concat", {I0, I1}, 1);
+  Node *R = F->createReshape("reshape", CN, dimsReshape);
+  Node *S = F->createSlice("slice", R, {0, 0, 0}, {5, 5, 5});
+  Node *G = F->createGather("gather", S, I2);
+  F->createSave("ret", G);
+
+  PrecisionConfiguration precConfig;
+  precConfig.convertToFP16 = true;
+  precConfig.clipFP16 = true;
+  convertFunctionToFloat16(F, precConfig);
+
+  int numClips = 0;
+  int numConvertTos = 0;
+  for (auto &n : F->getNodes()) {
+    if (n.getKind() == Kinded::Kind::ClipNodeKind) {
+      ++numClips;
+    } else if (n.getKind() == Kinded::Kind::ConvertToNodeKind) {
+      ++numConvertTos;
+    }
+  }
+
+  EXPECT_EQ(9, numConvertTos);
+  EXPECT_EQ(0, numClips);
+
+  EXPECT_TRUE(F->verify());
+}
+
 INSTANTIATE_BACKEND_TEST(AllBackends);


### PR DESCRIPTION
Summary: Transformation/Indexing nodes don't manipulate numerics so it's not necessary to add Clip nodes around them when we converting them to fp16.

Differential Revision: D17598289

