### PR TITLE
[PyTorch] Import quantized linear

### DIFF
--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -343,11 +343,13 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
     return ((NI.getInElemTy(QuantizeNode::InputIdx) == ElemKind::FloatTy) ||
             (NI.getInElemTy(QuantizeNode::InputIdx) == ElemKind::Float16Ty)) &&
            ((NI.getOutElemTy(QuantizeNode::ResultIdx) == ElemKind::Int8QTy) ||
+            (NI.getOutElemTy(QuantizeNode::ResultIdx) == ElemKind::UInt8QTy) ||
             (NI.getOutElemTy(QuantizeNode::ResultIdx) == ElemKind::Int16QTy) ||
             (NI.getOutElemTy(QuantizeNode::ResultIdx) == ElemKind::Int32QTy));
 
   case Kinded::Kind::DequantizeNodeKind:
     return ((NI.getInElemTy(DequantizeNode::InputIdx) == ElemKind::Int8QTy) ||
+            (NI.getInElemTy(DequantizeNode::InputIdx) == ElemKind::UInt8QTy) ||
             (NI.getInElemTy(DequantizeNode::InputIdx) == ElemKind::Int16QTy) ||
             (NI.getInElemTy(DequantizeNode::InputIdx) == ElemKind::Int32QTy)) &&
            ((NI.getOutElemTy(DequantizeNode::ResultIdx) == ElemKind::FloatTy) ||

--- a/torch_glow/src/FusePrepack.h
+++ b/torch_glow/src/FusePrepack.h
@@ -20,8 +20,13 @@
 #include <torch/csrc/jit/ir.h>
 
 namespace glow {
-/// Performs specific fusion for Linear operator.
-void FuseConvPrepack(std::shared_ptr<torch::jit::Graph> &graph);
+/// Fuse weight packing operation into quantized convolution op thus skipping
+/// weight packing.
+void fuseConvPrepack(std::shared_ptr<torch::jit::Graph> &graph);
+
+/// Fuse weight packing operation into quantized linear op thus skipping
+/// weight packing.
+void fuseLinearPrepack(std::shared_ptr<torch::jit::Graph> &graph);
 } // namespace glow
 
 #endif // GLOW_TORCH_GLOW_SRC_FUSE_PREPACK_H

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -88,7 +88,7 @@ glow::Tensor ptTensorToGlowTensor(const at::Tensor &ptTensor);
 at::Tensor glowTypeToEmptyPTTensor(const glow::Type &glowType);
 
 /// Fuse known sets of operators into compact ones.
-void FuseKnownPatterns(std::shared_ptr<torch::jit::Graph> &graph);
+void fuseKnownPatterns(std::shared_ptr<torch::jit::Graph> &graph);
 
 } // namespace glow
 

--- a/torch_glow/src/PyTorchFileLoader.cpp
+++ b/torch_glow/src/PyTorchFileLoader.cpp
@@ -192,7 +192,7 @@ Error PyTorchFileLoader::parsePyTorchGraphForOnnxTraining(
   // std::pair<std::shared_ptr<Graph>, std::vector<at::Tensor>>
   auto graphAndTensors = method._lowered_graph();
 
-  FuseKnownPatterns(graphAndTensors.first);
+  fuseKnownPatterns(graphAndTensors.first);
 
   // Parse JIT Graph and load into Glow Function.
   return PyTorchModelLoader::loadJITGraphForOnnxTraining(

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -319,6 +319,10 @@ private:
   /// \return error on failure.
   Error loadQuantizedAdd(const torch::jit::Node *ptNode);
 
+  /// Load a glow::unpacked_quantized_linear node.
+  /// \return error on failure.
+  Error loadQuantizedLinear(const torch::jit::Node *ptNode);
+
   /// Load a PyTorch quantize_linear node.
   /// \returns error on failure.
   Error loadQuantize(const torch::jit::Node *ptNode);
@@ -394,6 +398,12 @@ private:
   /// Load a PyTorch aten::matmul node.
   /// \returns error on failure.
   Error loadMatMul(const torch::jit::Node *ptNode);
+
+  /// Rescale a uint8 NodeValue \p input to the equivalent int8 NodeValue.
+  glow::NodeValue rescaleUIntToInt(glow::NodeValue input);
+
+  /// Rescale a int8 NodeValue \p input to the equivalent uint8 NodeValue.
+  glow::NodeValue rescaleIntToUint(glow::NodeValue input);
 };
 
 } // namespace glow

--- a/torch_glow/tests/nodes/quantized_linear_test.py
+++ b/torch_glow/tests/nodes/quantized_linear_test.py
@@ -1,0 +1,30 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import torch
+
+from tests.utils import jitVsGlow
+
+
+def test_quantized_linear():
+    """Basic test of the PyTorch quantized::linear Node on Glow."""
+
+    def test_f(inputs, weights, bias=None):
+        q_int = torch.nn.quantized.Quantize(
+            scale=2.0, zero_point=0, dtype=torch.qint8)
+        q_uint = torch.nn.quantized.Quantize(
+            scale=1.5, zero_point=120, dtype=torch.quint8)
+
+        dq = torch.nn.quantized.DeQuantize()
+
+        q_inputs = q_uint(inputs)
+        q_weights = q_int(weights)
+
+        return dq(torch.nn.quantized.functional.linear(q_inputs, q_weights, bias))
+
+    inputs = torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+    weights = torch.tensor([[2.0, 4.0], [3.0, 1.0], [6.0, 1.0]])
+    bias = torch.tensor([5.0, 3.0, 2.0])
+
+    jitVsGlow(test_f, inputs, weights, bias, expected_fused_ops={
+              "glow::unpacked_quantized_linear", "aten::quantize_per_tensor",
+              "aten::dequantize"})

--- a/torch_glow/tests/utils.py
+++ b/torch_glow/tests/utils.py
@@ -83,4 +83,8 @@ def jitVsGlow_(f_torch, f_glow, *inputs, expected_fused_ops=None,
             for i in range(len(torch_res)):
                 assert torch.allclose(torch_res[i], glow_res[i], atol=01e-6)
         else:
-            torch.allclose(torch_res, glow_res, atol=01e-6)
+            is_all_close = torch.allclose(torch_res, glow_res, atol=01e-6)
+            if not is_all_close:
+                print("torch_res\n", torch_res)
+                print("glow_res\n", glow_res)
+            assert is_all_close


### PR DESCRIPTION
Summary:
* Enable aten::quantize_linear loader to load as uint8 or int8
* Keep all values between nodes in the correct quantization scheme 
* Import quantized linear operator.
* Create dummy nodes for glow-specific fusion passes to use to eliminate packed intermediate values.

Documentation:
doxygen

Test Plan:
added unit test