### PR TITLE
Allow for removing a pass from an optimization pipeline

### DIFF
--- a/include/glow/Optimizer/GraphOptimizerPipeline/Pipeline.h
+++ b/include/glow/Optimizer/GraphOptimizerPipeline/Pipeline.h
@@ -98,6 +98,10 @@ class FunctionPassPipeline : private llvm::SmallVector<FunctionPassConfig, 64> {
 private:
   using ParentImpl = llvm::SmallVectorImpl<FunctionPassConfig>;
 
+  /// Removes the first instance of a pass with ID \p FPID. \returns whether an
+  /// instance of the pass was successfully found and removed.
+  bool removeFirstInstanceOfPass(FunctionPassID FPID);
+
 public:
   FunctionPassPipeline() = default;
 
@@ -122,6 +126,9 @@ public:
 
   /// Push a new \p FPC to the end of the pipeline.
   void pushBack(FunctionPassConfig FPC) { push_back(FPC); }
+
+  /// Removes all instances of a pass with ID \p FPID.
+  void removeAllInstancesOfPass(FunctionPassID FPID);
 
   /// Dump a textual representation of the pipeline to \p os.
   void dump(llvm::raw_ostream &os = llvm::outs()) const;

--- a/lib/Optimizer/GraphOptimizerPipeline/Pipeline.cpp
+++ b/lib/Optimizer/GraphOptimizerPipeline/Pipeline.cpp
@@ -197,3 +197,18 @@ void FunctionPassPipeline::dump(llvm::raw_ostream &os) const {
     os << "}\n";
   }
 }
+
+bool FunctionPassPipeline::removeFirstInstanceOfPass(FunctionPassID FPID) {
+  for (auto it = begin(); it != end(); it++) {
+    if (it->getFunctionPassID() == FPID) {
+      erase(it);
+      return true;
+    }
+  }
+  return false;
+}
+
+void FunctionPassPipeline::removeAllInstancesOfPass(FunctionPassID FPID) {
+  while (removeFirstInstanceOfPass(FPID)) {
+  }
+}


### PR DESCRIPTION
Summary: This may be necessary if a backend wants to opt out of an optimization. This is cleaner than requiring the backend to recreate the default optimization pipeline manually without specific optimizations.

Differential Revision: D17620020

