### PR TITLE
Handroll make_unique impl for future-compat with LLVM

### DIFF
--- a/docs/Tracing.md
+++ b/docs/Tracing.md
@@ -111,7 +111,7 @@ Then, to examine the events emitted for a particular run create a TraceContext w
 
 ```
 ExecutionContext ctx;
-ctx.setTraceContext(llvm::make_unique<TraceContext>(TraceLevel::STANDARD));
+ctx.setTraceContext(glow::make_unique<TraceContext>(TraceLevel::STANDARD));
 
 // Run the compiled Function as usual
 executionEngine.run(ctx);

--- a/examples/resnet-runtime.cpp
+++ b/examples/resnet-runtime.cpp
@@ -132,17 +132,17 @@ int main(int argc, char **argv) {
 
   std::vector<std::unique_ptr<DeviceConfig>> configs;
   for (unsigned int i = 0; i < numDevices; ++i) {
-    auto config = llvm::make_unique<DeviceConfig>(backend);
+    auto config = glow::make_unique<DeviceConfig>(backend);
     configs.push_back(std::move(config));
   }
 
   std::unique_ptr<HostManager> hostManager =
-      llvm::make_unique<HostManager>(std::move(configs));
+      glow::make_unique<HostManager>(std::move(configs));
 
   // If tracing is enabled, create a TraceContext to merge each runs events
   // into.
   if (!tracePath.empty()) {
-    traceContext = llvm::make_unique<TraceContext>(TraceLevel::STANDARD);
+    traceContext = glow::make_unique<TraceContext>(TraceLevel::STANDARD);
   }
 
   // Load model, create a context, and add to HostManager.
@@ -152,7 +152,7 @@ int main(int argc, char **argv) {
   Placeholder *input;
   PlaceholderList phList;
 
-  std::unique_ptr<Module> module = llvm::make_unique<Module>();
+  std::unique_ptr<Module> module = glow::make_unique<Module>();
   TypeRef inputType = module->uniqueType(ElemKind::FloatTy, inputShape);
   input = loadResnet50Model(inputType, module.get(), 0);
   phList = module->getPlaceholders();
@@ -194,9 +194,9 @@ int main(int argc, char **argv) {
         path, ImageNormalizationMode::k0to1, ImageChannelOrder::BGR,
         ImageLayout::NCHW, imagenetNormMean, imagenetNormStd);
     std::unique_ptr<ExecutionContext> context =
-        llvm::make_unique<ExecutionContext>();
+        glow::make_unique<ExecutionContext>();
     context->setTraceContext(
-        llvm::make_unique<TraceContext>(TraceLevel::STANDARD));
+        glow::make_unique<TraceContext>(TraceLevel::STANDARD));
 
     context->getPlaceholderBindings()->allocate(phList);
     Tensor batch = image.getUnowned(inputShape);

--- a/examples/tracing-compare.cpp
+++ b/examples/tracing-compare.cpp
@@ -146,9 +146,9 @@ int main(int argc, char **argv) {
       supportedBackends.size());
 
   for (unsigned i = 0, e = supportedBackends.size(); i < e; ++i) {
-    auto context = llvm::make_unique<ExecutionContext>();
+    auto context = glow::make_unique<ExecutionContext>();
     context->setTraceContext(
-        llvm::make_unique<TraceContext>(TraceLevel::STANDARD));
+        glow::make_unique<TraceContext>(TraceLevel::STANDARD));
     context->getPlaceholderBindings()->allocate(module.getPlaceholders());
     updateInputPlaceholders(*(context->getPlaceholderBindings()), {input},
                             {&batch});

--- a/include/glow/ExecutionContext/ExecutionContext.h
+++ b/include/glow/ExecutionContext/ExecutionContext.h
@@ -18,6 +18,7 @@
 
 #include "glow/ExecutionContext/TraceEvents.h"
 #include "glow/Graph/PlaceholderBindings.h"
+#include "glow/Support/Memory.h"
 
 #include "llvm/ADT/STLExtras.h"
 
@@ -33,7 +34,7 @@ public:
   virtual ~DeviceBindings() {}
 
   virtual std::unique_ptr<DeviceBindings> clone() {
-    return llvm::make_unique<DeviceBindings>(backend_);
+    return glow::make_unique<DeviceBindings>(backend_);
   }
 };
 
@@ -51,7 +52,7 @@ class ExecutionContext {
 
 public:
   ExecutionContext()
-      : placeholderBindings_(llvm::make_unique<PlaceholderBindings>()) {}
+      : placeholderBindings_(glow::make_unique<PlaceholderBindings>()) {}
 
   ExecutionContext(std::unique_ptr<PlaceholderBindings> bindings)
       : placeholderBindings_(std::move(bindings)) {}
@@ -108,10 +109,10 @@ public:
   ExecutionContext clone() {
     if (deviceBindings_) {
       return ExecutionContext(
-          llvm::make_unique<PlaceholderBindings>(placeholderBindings_->clone()),
+          glow::make_unique<PlaceholderBindings>(placeholderBindings_->clone()),
           deviceBindings_->clone());
     } else {
-      return ExecutionContext(llvm::make_unique<PlaceholderBindings>(
+      return ExecutionContext(glow::make_unique<PlaceholderBindings>(
           placeholderBindings_->clone()));
     }
   }

--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -78,7 +78,7 @@ class CommonOperatorLoader : public ProtobufLoader {
     }
 
     LoadWeightResult result;
-    result.t = llvm::make_unique<Tensor>();
+    result.t = glow::make_unique<Tensor>();
 
     std::vector<size_t> dims;
     for (unsigned i = 0; i < in.dimensions; ++i) {
@@ -138,8 +138,8 @@ class CommonOperatorLoader : public ProtobufLoader {
     } else {
       Type scalesTy(ElemKind::FloatTy, llvm::makeArrayRef({qparams}));
       Type offsetsTy(ElemKind::Int32ITy, llvm::makeArrayRef({qparams}));
-      result.scales = llvm::make_unique<Tensor>((void *)in.scales, &scalesTy);
-      result.offsets = llvm::make_unique<Tensor>((void *)in.biases, &offsetsTy);
+      result.scales = glow::make_unique<Tensor>((void *)in.scales, &scalesTy);
+      result.offsets = glow::make_unique<Tensor>((void *)in.biases, &offsetsTy);
     }
 
     if (in.dataType == ONNXIFI_DATATYPE_UINT8) {

--- a/include/glow/Support/Memory.h
+++ b/include/glow/Support/Memory.h
@@ -21,6 +21,7 @@
 #include <glog/logging.h>
 
 #include <cstdlib>
+#include <memory>
 
 namespace glow {
 
@@ -47,6 +48,41 @@ inline size_t alignedSize(size_t size, size_t alignment) {
   size_t mod = size % alignment;
   return mod ? size + alignment - mod : size;
 }
+
+// Implement make_unique according to N3656.
+
+/// \brief Constructs a `new T()` with the given args and returns a
+///        `unique_ptr<T>` which owns the object.
+///
+/// Example:
+///
+///     auto p = make_unique<int>();
+///     auto p = make_unique<std::tuple<int, int>>(0, 1);
+template <class T, class... Args>
+typename std::enable_if<!std::is_array<T>::value, std::unique_ptr<T>>::type
+make_unique(Args &&... args) {
+  return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+
+/// \brief Constructs a `new T[n]` with the given args and returns a
+///        `unique_ptr<T[]>` which owns the object.
+///
+/// \param n size of the new array.
+///
+/// Example:
+///
+///     auto p = make_unique<int[]>(2); // value-initializes the array with 0's.
+template <class T>
+typename std::enable_if<std::is_array<T>::value && std::extent<T>::value == 0,
+                        std::unique_ptr<T>>::type
+make_unique(size_t n) {
+  return std::unique_ptr<T>(new typename std::remove_extent<T>::type[n]());
+}
+
+/// This function isn't used and is only here to provide better compile errors.
+template <class T, class... Args>
+typename std::enable_if<std::extent<T>::value != 0>::type
+make_unique(Args &&...) = delete;
 
 } // end namespace glow
 

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -374,7 +374,7 @@ bool CPUBackend::shouldLower(const Node *N) const {
 std::unique_ptr<CompiledFunction> CPUBackend::createCompiledFunction(
     std::unique_ptr<llvm::orc::GlowJIT> JIT,
     runtime::RuntimeBundle &&runtimeBundle) const {
-  return llvm::make_unique<CPUFunction>(std::move(JIT),
+  return glow::make_unique<CPUFunction>(std::move(JIT),
                                         std::move(runtimeBundle));
 }
 

--- a/lib/Backends/DeviceManagers.cpp
+++ b/lib/Backends/DeviceManagers.cpp
@@ -106,7 +106,7 @@ DeviceManager::generateDeviceConfigs(llvm::StringRef backendName) {
   std::vector<std::unique_ptr<runtime::DeviceConfig>> configs;
   auto deviceCount = numDevices(backendName);
   for (int i = 0; i < deviceCount; i++) {
-    configs.push_back(llvm::make_unique<runtime::DeviceConfig>(backendName));
+    configs.push_back(glow::make_unique<runtime::DeviceConfig>(backendName));
   }
   return configs;
 }

--- a/lib/Backends/Habana/HabanaDeviceManager.cpp
+++ b/lib/Backends/Habana/HabanaDeviceManager.cpp
@@ -105,8 +105,8 @@ Error HabanaDeviceManager::init() {
   RETURN_IF_ERR(updateMemoryUsage());
 
   // Create thread pools for running functions and waiting on function results.
-  runPool_ = llvm::make_unique<ThreadPool>(numRunners_);
-  waitPool_ = llvm::make_unique<ThreadPool>(numWaiters_);
+  runPool_ = glow::make_unique<ThreadPool>(numRunners_);
+  waitPool_ = glow::make_unique<ThreadPool>(numWaiters_);
 
   if (!runPool_ || !waitPool_) {
     RETURN_ERR("Failed to create HabanaDeviceManager thread pools");
@@ -184,7 +184,7 @@ void HabanaDeviceManager::addNetwork(const Module *module,
     std::tie(std::ignore, inserted) = functions_.insert(std::make_pair(
         func.first,
         HabanaFunctionMeta{topologyId, habanaFunction,
-                           llvm::make_unique<HabanaIOBufferPool>(
+                           glow::make_unique<HabanaIOBufferPool>(
                                deviceId_, habanaFunction->getInputs(),
                                habanaFunction->getOutputs())}));
 
@@ -334,7 +334,7 @@ void HabanaDeviceManager::runFunctionImpl(RunIdentifierTy runId,
 
   // Execute the function.
   auto deviceBindings =
-      llvm::make_unique<HabanaBindings>(deviceId_, topologyId);
+      glow::make_unique<HabanaBindings>(deviceId_, topologyId);
   deviceBindings->setIOBuffer(ioBufferPool->get());
   ctx->setDeviceBindings(std::move(deviceBindings));
 

--- a/lib/Backends/Habana/HabanaFunction.cpp
+++ b/lib/Backends/Habana/HabanaFunction.cpp
@@ -66,7 +66,7 @@ HabanaIOBufferPool::HabanaIOBufferPool(uint32_t deviceId,
   uint8_t *copyOffset = buffer_;
   for (unsigned i = 0; i < numBuffers_; ++i) {
     ioBuffers_.push(
-        llvm::make_unique<HabanaIOBuffer>(deviceId_, copyOffset, offsets_));
+        glow::make_unique<HabanaIOBuffer>(deviceId_, copyOffset, offsets_));
     copyOffset += perBufferSize_;
   }
 }
@@ -214,10 +214,10 @@ static Error dumpTopologyInfo(uint32_t deviceId, uint64_t topologyId) {
                             numOfIntermediates));
 
   using TensorNames = char[ENQUEUE_TENSOR_NAME_MAX_SIZE];
-  auto inputTensorNames = llvm::make_unique<TensorNames[]>(numOfInputs);
-  auto outputTensorNames = llvm::make_unique<TensorNames[]>(numOfOutputs);
+  auto inputTensorNames = glow::make_unique<TensorNames[]>(numOfInputs);
+  auto outputTensorNames = glow::make_unique<TensorNames[]>(numOfOutputs);
   auto intermediateTensorNames =
-      llvm::make_unique<TensorNames[]>(numOfIntermediates);
+      glow::make_unique<TensorNames[]>(numOfIntermediates);
 
   chk(synGetTensorsName(deviceId, topologyId, inputTensorNames.get(),
                         numOfInputs, outputTensorNames.get(), numOfOutputs,

--- a/lib/Backends/Habana/HabanaFunction.h
+++ b/lib/Backends/Habana/HabanaFunction.h
@@ -164,7 +164,7 @@ public:
   virtual ~HabanaBindings() {}
 
   std::unique_ptr<DeviceBindings> clone() override {
-    return llvm::make_unique<HabanaBindings>(deviceId_, topologyId_);
+    return glow::make_unique<HabanaBindings>(deviceId_, topologyId_);
   }
 
   uint32_t getDeviceId() const { return deviceId_; }

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -64,7 +64,7 @@ Interpreter::compileIRWithoutConstants(std::unique_ptr<IRFunction> IR) const {
   runtime::RuntimeBundle bundle = runtime::RuntimeBundle::create(
       *IR, constantWeightsAllocator, placeholderWeightsAllocator,
       activationsAllocator);
-  return llvm::make_unique<InterpreterFunction>(std::move(IR),
+  return glow::make_unique<InterpreterFunction>(std::move(IR),
                                                 std::move(bundle));
 }
 

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -1754,7 +1754,7 @@ OCLBackend::compileIR(std::unique_ptr<IRFunction> IR) const {
   runtime::RuntimeBundle bundle =
       runtime::RuntimeBundle::create(*IR, allocator);
   std::unique_ptr<CompiledFunction> function =
-      llvm::make_unique<OpenCLFunction>(std::move(IR), std::move(bundle),
+      glow::make_unique<OpenCLFunction>(std::move(IR), std::move(bundle),
                                         std::move(traceInfo));
   auto OCLFunction = static_cast<OpenCLFunction *>(function.get());
   OCLFunction->collectConstants(module);
@@ -1780,7 +1780,7 @@ OCLBackend::compile(Function *F, const BackendOptions &opts) const {
   }
 
   std::unique_ptr<CompiledFunction> compiledFunc =
-      llvm::make_unique<OpenCLFunction>(std::move(IR), std::move(bundle),
+      glow::make_unique<OpenCLFunction>(std::move(IR), std::move(bundle),
                                         std::move(traceInfo));
 
   return Expected<std::unique_ptr<CompiledFunction>>(std::move(compiledFunc));

--- a/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
@@ -448,7 +448,7 @@ void OpenCLDeviceManager::runFunctionImpl(
   // Create and set deviceBindings for call. This contains all the state needed
   // for the function to run on a device.
   auto program = programs_[function];
-  auto clBindings = llvm::make_unique<runtime::OpenCLDeviceBindings>(
+  auto clBindings = glow::make_unique<runtime::OpenCLDeviceBindings>(
       buffers_[function]->getBuffer(), queue.backingQueue, deviceId_, context_,
       program);
 

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -45,12 +45,12 @@ void ExecutionEngine::setBackendName(llvm::StringRef backend) {
   }
 
   std::vector<std::unique_ptr<runtime::DeviceConfig>> configs;
-  auto config = llvm::make_unique<runtime::DeviceConfig>(backend);
+  auto config = glow::make_unique<runtime::DeviceConfig>(backend);
   if (deviceMemory_) {
     config->setDeviceMemory(deviceMemory_);
   }
   configs.push_back(std::move(config));
-  hostManager_ = llvm::make_unique<runtime::HostManager>(std::move(configs));
+  hostManager_ = glow::make_unique<runtime::HostManager>(std::move(configs));
 }
 
 llvm::StringRef ExecutionEngine::getBackendName() const { return backendName_; }

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -83,7 +83,7 @@ createAndSetTensorType(const caffe2::TensorProto &in) {
   }
 
   LoadWeightResult result;
-  result.t = llvm::make_unique<Tensor>();
+  result.t = glow::make_unique<Tensor>();
 
   if (in.data_type() == caffe2::TensorProto::FLOAT) {
     result.t->reset(ElemKind::FloatTy, dim);
@@ -130,7 +130,7 @@ createAndSetTensorType(const caffe2::QTensorProto &in) {
                     "Found a different number of biases and scales");
 
   LoadWeightResult result;
-  result.t = llvm::make_unique<Tensor>();
+  result.t = glow::make_unique<Tensor>();
 
   float scale = 1.0;
   int32_t offset = 0;
@@ -143,9 +143,9 @@ createAndSetTensorType(const caffe2::QTensorProto &in) {
     scale = in.scales(0);
     offset = in.biases(0);
   } else {
-    result.scales = llvm::make_unique<Tensor>(ElemKind::FloatTy,
+    result.scales = glow::make_unique<Tensor>(ElemKind::FloatTy,
                                               llvm::makeArrayRef({qparams}));
-    result.offsets = llvm::make_unique<Tensor>(ElemKind::Int32ITy,
+    result.offsets = glow::make_unique<Tensor>(ElemKind::Int32ITy,
                                                llvm::makeArrayRef({qparams}));
 
     auto scalesH = result.scales->getHandle<float>();

--- a/lib/LLVMIRCodeGen/DebugInfo.cpp
+++ b/lib/LLVMIRCodeGen/DebugInfo.cpp
@@ -257,7 +257,7 @@ void LLVMIRGen::initDebugInfo() {
   initBaseAddressesOfMemoryAreas(dbgInfo_, *builder_, getModule());
 
   // Construct the DIBuilder.
-  DIBuilder_ = llvm::make_unique<llvm::DIBuilder>(getModule());
+  DIBuilder_ = glow::make_unique<llvm::DIBuilder>(getModule());
 
   // Create a textual representation of the IR for the main function.
   // First store the textual IR into a string.

--- a/lib/LLVMIRCodeGen/LLVMBackend.cpp
+++ b/lib/LLVMIRCodeGen/LLVMBackend.cpp
@@ -121,7 +121,7 @@ LLVMBackend::compileIRWithoutConstants(IRFunction *IR) const {
   // Emit the code for the body of the entry function.
   irgen->performCodeGen();
   // Hand over the module to JIT for the machine code generation.
-  auto JIT = llvm::make_unique<llvm::orc::GlowJIT>(irgen->getTargetMachine());
+  auto JIT = glow::make_unique<llvm::orc::GlowJIT>(irgen->getTargetMachine());
   JIT->addModule(irgen->borrowModule());
   // Build runtimeBundle object containing offsets and allocation sizes.
   MemoryAllocator constantAllocator("ConstantWeights", 0);

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -214,7 +214,7 @@ void LLVMIRGen::initCodeGen() {
 
   // Setup the entry basic block and initialize the IR builder.
   llvm::BasicBlock *entry_bb = llvm::BasicBlock::Create(ctx_, "entry", func);
-  builder_ = llvm::make_unique<llvm::IRBuilder<>>(entry_bb);
+  builder_ = glow::make_unique<llvm::IRBuilder<>>(entry_bb);
 
   // Initialize the debug information emission.
   initDebugInfo();

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -125,11 +125,11 @@ onnxStatus Graph::setIOAndRun(uint32_t inputsCount,
                               const onnxTensorDescriptorV1 *outputDescriptors,
                               EventPtr outputEvent,
                               onnxTraceEventList *traceEvents) {
-  auto ctx = llvm::make_unique<ExecutionContext>();
+  auto ctx = glow::make_unique<ExecutionContext>();
 
   TraceContext *traceContext = nullptr;
   if (traceEvents || GlowDumpDebugTraces) {
-    ctx->setTraceContext(llvm::make_unique<TraceContext>(TraceLevel::STANDARD));
+    ctx->setTraceContext(glow::make_unique<TraceContext>(TraceLevel::STANDARD));
     traceContext = ctx->getTraceContext();
     traceContext->setThreadName("Onnxifi");
   }

--- a/lib/Onnxifi/HostManagerOnnxifi.cpp
+++ b/lib/Onnxifi/HostManagerOnnxifi.cpp
@@ -50,12 +50,12 @@ HostManagerBackend::createHostManager(llvm::StringRef backendName) {
   // discovered devices.
   if (GlowNumDevices) {
     for (int i = 0; i < GlowNumDevices; i++) {
-      configs.push_back(llvm::make_unique<runtime::DeviceConfig>(backendName));
+      configs.push_back(glow::make_unique<runtime::DeviceConfig>(backendName));
     }
   } else {
     configs = runtime::DeviceManager::generateDeviceConfigs(backendName);
   }
-  return llvm::make_unique<runtime::HostManager>(std::move(configs));
+  return glow::make_unique<runtime::HostManager>(std::move(configs));
 }
 
 void HostManagerBackend::runNetwork(const Graph *graph,
@@ -110,7 +110,7 @@ HostManagerGraph::initGraph(const void *onnxModel, size_t onnxModelSize,
 
   netName_ = strFormat("onnxifi_function_%lu", makeUniqueGraphId());
 
-  std::unique_ptr<Module> module = llvm::make_unique<Module>();
+  std::unique_ptr<Module> module = glow::make_unique<Module>();
   Function *function = module->createFunction(netName_);
 
   // TODO: make better error reporting.

--- a/lib/Optimizer/GraphOptimizer/PassManager.cpp
+++ b/lib/Optimizer/GraphOptimizer/PassManager.cpp
@@ -176,7 +176,7 @@ FunctionPassManager::createFunctionPass(FunctionPassID passID) {
   switch (passID) {
 #define FUN_PASS(PASS_NAME)                                                    \
   case (FunctionPassID::PASS_NAME):                                            \
-    return llvm::make_unique<PASS_NAME>();
+    return glow::make_unique<PASS_NAME>();
 #include "glow/Optimizer/GraphOptimizer/FunctionPasses.def"
   }
   LOG(DFATAL) << "Cannot reach here.";

--- a/lib/Optimizer/IROptimizer/IROptimizer.cpp
+++ b/lib/Optimizer/IROptimizer/IROptimizer.cpp
@@ -1650,7 +1650,7 @@ void performPeepholeOptimizations(IRFunction &M) {
 std::unique_ptr<IRFunction>
 glow::generateAndOptimizeIR(Function *F, const Backend &B,
                             bool shouldShareBuffers) {
-  auto IR = llvm::make_unique<IRFunction>(F);
+  auto IR = glow::make_unique<IRFunction>(F);
   IR->generateIR(B);
   ::glow::optimize(*IR, shouldShareBuffers);
   if (!B.verify(*IR)) {

--- a/lib/Partitioner/Partitioner.cpp
+++ b/lib/Partitioner/Partitioner.cpp
@@ -405,11 +405,11 @@ Expected<DAGListTy> Partitioner::createDAGWithoutPartition(
       auto backend = backendMap[backendName].backend;
       RETURN_IF_ERR(::glow::optimizeFunction(F, *backend, cctx));
     }
-    std::unique_ptr<DAGNode> DAG0 = llvm::make_unique<DAGNode>();
+    std::unique_ptr<DAGNode> DAG0 = glow::make_unique<DAGNode>();
     DAG0->logicalDevices = {0};
     DAG0->name = F->getName();
     DAG0->module = module_;
-    std::unique_ptr<DAGNode> DAG1 = llvm::make_unique<DAGNode>();
+    std::unique_ptr<DAGNode> DAG1 = glow::make_unique<DAGNode>();
     DAG1->logicalDevices = {0};
     DAG1->name = F->getName();
     DAG1->backendName = backendName;

--- a/lib/Partitioner/PartitionerBase.cpp
+++ b/lib/Partitioner/PartitionerBase.cpp
@@ -31,7 +31,7 @@ DAGListTy PartitionerBase::doPartitioning(llvm::StringRef funcName,
                                           bool saveDAG) {
   DAGListTy partitions;
   // Add a dummy node to make sure that a DAG has a single entrance.
-  DAGNodePtr DAGRoot = llvm::make_unique<DAGNode>();
+  DAGNodePtr DAGRoot = glow::make_unique<DAGNode>();
   DAGNodePtrVec nodes;
   DAGRoot->logicalDevices = {0};
   DAGRoot->name = funcName;
@@ -56,7 +56,7 @@ DAGListTy PartitionerBase::doPartitioning(llvm::StringRef funcName,
   llvm::DenseMap<Function *, DAGNode *> funcDAG;
   for (auto *subF : mapping.getPartitions()) {
     if (funcDAG.find(subF) == funcDAG.end()) {
-      std::unique_ptr<DAGNode> subDAG = llvm::make_unique<DAGNode>();
+      std::unique_ptr<DAGNode> subDAG = glow::make_unique<DAGNode>();
       subDAG->name = subF->getName();
       subDAG->logicalDevices = mapping.getLogicalDeviceIDList(subF);
       subDAG->backendName = mapping.getPartitionBackendName(subF);
@@ -99,7 +99,7 @@ DAGListTy PartitionerBase::doPartitioning(llvm::StringRef funcName,
         // Check if a DAGNode for subF's parent is created or not. If not,
         // create one.
         if (funcDAG.find(inputF) == funcDAG.end()) {
-          std::unique_ptr<DAGNode> subDAG = llvm::make_unique<DAGNode>();
+          std::unique_ptr<DAGNode> subDAG = glow::make_unique<DAGNode>();
           subDAG->name = inputF->getName();
           subDAG->logicalDevices = mapping.getLogicalDeviceIDList(inputF);
           subDAG->backendName = mapping.getPartitionBackendName(inputF);

--- a/lib/Runtime/Executor/ExecutionState.cpp
+++ b/lib/Runtime/Executor/ExecutionState.cpp
@@ -49,11 +49,11 @@ void ExecutionState::init() {
     nodeParentsDone_[node] = 0;
 
     // Make an (empty) input context for the node.
-    auto nodeInputCtx = llvm::make_unique<ExecutionContext>();
+    auto nodeInputCtx = glow::make_unique<ExecutionContext>();
 
     if (resultTraceContext) {
       nodeInputCtx->setTraceContext(
-          llvm::make_unique<TraceContext>(resultTraceContext->getTraceLevel()));
+          glow::make_unique<TraceContext>(resultTraceContext->getTraceLevel()));
     }
 
     auto nodeInputPhBindings = nodeInputCtx->getPlaceholderBindings();

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -196,7 +196,7 @@ Error HostManager::addNetwork(std::unique_ptr<Module> module,
     size_t devicesNum = devices_.size();
     for (size_t i = 0; i < devicesNum; i++) {
       auto name = devices_[i]->getDeviceConfig().name;
-      auto config = llvm::make_unique<DeviceConfig>(profilingBackend, name);
+      auto config = glow::make_unique<DeviceConfig>(profilingBackend, name);
       devices_[i] = std::unique_ptr<DeviceManager>(
           DeviceManager::createDeviceManager(*config));
       RETURN_IF_ERR(devices_[i]->init());
@@ -267,7 +267,7 @@ Error HostManager::removeNetwork(llvm::StringRef networkName) {
       devices_[device]->evictNetwork(
           node->name,
           [&removeNetwork, &removeErr](std::string name, Error err) {
-            removeErr = llvm::make_unique<Error>(std::move(err));
+            removeErr = glow::make_unique<Error>(std::move(err));
             removeNetwork.set_value();
           });
       done.get();
@@ -317,7 +317,7 @@ Error HostManager::runNetworkBlocking(llvm::StringRef networkName,
                                       PlaceholderBindings &bindings) {
   std::unique_ptr<PlaceholderBindings> phBindings(&bindings);
   std::unique_ptr<ExecutionContext> context =
-      llvm::make_unique<ExecutionContext>(std::move(phBindings));
+      glow::make_unique<ExecutionContext>(std::move(phBindings));
   std::promise<void> runPromise;
   auto fut = runPromise.get_future();
   std::unique_ptr<Error> runErr;
@@ -331,7 +331,7 @@ Error HostManager::runNetworkBlocking(llvm::StringRef networkName,
             contextPtr->movePlaceholderBindings();
         phBind.release();
 
-        runErr = llvm::make_unique<Error>(std::move(err));
+        runErr = glow::make_unique<Error>(std::move(err));
         runPromise.set_value();
       });
 
@@ -348,7 +348,7 @@ Error HostManager::runNetworkBlocking(
       networkName, std::move(context),
       [&runPromise, &runErr](runtime::RunIdentifierTy, Error err,
                              std::unique_ptr<ExecutionContext> contextPtr) {
-        runErr = llvm::make_unique<Error>(std::move(err));
+        runErr = glow::make_unique<Error>(std::move(err));
         runPromise.set_value();
       });
 

--- a/lib/Runtime/Provisioner/Provisioner.cpp
+++ b/lib/Runtime/Provisioner/Provisioner.cpp
@@ -142,7 +142,7 @@ Error Provisioner::provision(DAGListTy &networks, Module &module,
             }
             auto compiled = std::move(*compiledOrErr);
             node->runtimeBundle =
-                llvm::make_unique<RuntimeBundle>(compiled->getRuntimeBundle());
+                glow::make_unique<RuntimeBundle>(compiled->getRuntimeBundle());
 
             compiledFunctions.emplace(node->name, std::move(compiled));
             break;
@@ -205,7 +205,7 @@ Error Provisioner::provision(DAGListTy &networks, Module &module,
         devices_[deviceID]->addNetwork(
             &module, functionMaps[logicalID],
             [&addErr, &addPromise](const Module *, Error err) {
-              addErr = llvm::make_unique<Error>(std::move(err));
+              addErr = glow::make_unique<Error>(std::move(err));
               addPromise.set_value();
             });
         ready.wait();

--- a/tests/benchmark/RuntimeBench.cpp
+++ b/tests/benchmark/RuntimeBench.cpp
@@ -215,7 +215,7 @@ public:
 protected:
   std::unique_ptr<Backend> &getBackend() { return backend_; }
   void setUpBackend(benchmark::State &state) {
-    backend_ = llvm::make_unique<BackendTy>();
+    backend_ = glow::make_unique<BackendTy>();
   }
   virtual void tearDownBackend(benchmark::State &state) {}
 
@@ -235,9 +235,9 @@ protected:
 
     // Allocate all Placeholders in mod_ and move the bindings into an
     // ExecutionContext object.
-    auto bindings = llvm::make_unique<PlaceholderBindings>();
+    auto bindings = glow::make_unique<PlaceholderBindings>();
     bindings->allocate(mod_->getPlaceholders());
-    ctx_ = llvm::make_unique<ExecutionContext>(std::move(bindings));
+    ctx_ = glow::make_unique<ExecutionContext>(std::move(bindings));
   }
   virtual void tearDownExecutionContext(benchmark::State &state) {}
 
@@ -292,11 +292,11 @@ protected:
     std::vector<std::unique_ptr<DeviceConfig>> configs;
     for (unsigned i = 0; i < numDeviceManagers_; ++i) {
       configs.emplace_back(
-          llvm::make_unique<DeviceConfig>(backend->getBackendName()));
+          glow::make_unique<DeviceConfig>(backend->getBackendName()));
     }
 
     // Create and initialize the HostManager instance.
-    hostManager_ = llvm::make_unique<HostManager>(std::move(configs));
+    hostManager_ = glow::make_unique<HostManager>(std::move(configs));
 
     // Remember the names of all functions in the module before passing
     // ownership to the HostManager.
@@ -533,7 +533,7 @@ protected:
 //----------------------------- Single Node --------------------------------//
 /// Create a module consisting of a single FC operator.
 std::unique_ptr<Module> createSingleNodeModule() {
-  auto mod = llvm::make_unique<Module>();
+  auto mod = glow::make_unique<Module>();
   auto fn = mod->createFunction("singleNode");
   PlaceholderBindings bindings;
 
@@ -564,21 +564,21 @@ std::unique_ptr<DAG> createSingleNodeDAG(
   // The DAG should have one root node and one actual node corresponding to the
   // CompiledFunction obtained by compiling the singular function in the Module
   // created by createSingleNodeModule.
-  auto root = llvm::make_unique<DAGNode>();
-  auto singleNode = llvm::make_unique<DAGNode>();
+  auto root = glow::make_unique<DAGNode>();
+  auto singleNode = glow::make_unique<DAGNode>();
 
   root->children.emplace_back(singleNode.get());
 
   singleNode->parents.emplace_back(root.get());
   singleNode->deviceIDs = {0};
   singleNode->name = "singleNode";
-  singleNode->runtimeBundle = llvm::make_unique<RuntimeBundle>(
+  singleNode->runtimeBundle = glow::make_unique<RuntimeBundle>(
       compiledFunctions["singleNode"]->getRuntimeBundle());
 
   std::vector<std::unique_ptr<DAGNode>> nodes;
   nodes.emplace_back(std::move(singleNode));
 
-  auto dag = llvm::make_unique<DAG>();
+  auto dag = glow::make_unique<DAG>();
   dag->root = std::move(root);
   dag->nodes = std::move(nodes);
 

--- a/tests/unittests/BackendCorrectnessTest.cpp
+++ b/tests/unittests/BackendCorrectnessTest.cpp
@@ -207,11 +207,11 @@ TEST_P(BackendCorrectnessTest, dataParallelStackingTest) {
   // buffer that is already used by other instructions in the stacked kernel.
   Module mod;
   Function *F = mod.createFunction("DataParallelStacking");
-  auto M = llvm::make_unique<IRFunction>(F);
+  auto M = glow::make_unique<IRFunction>(F);
 
   auto *var =
       mod.createPlaceholder(glow::ElemKind::FloatTy, {2}, "output", false);
-  auto ctx = llvm::make_unique<ExecutionContext>();
+  auto ctx = glow::make_unique<ExecutionContext>();
   auto *outputTensor = ctx->getPlaceholderBindings()->allocate(var);
   {
     // Scope the IRBuilder so the active allocations are properly deallocated at

--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -292,7 +292,7 @@ TEST_P(BackendExecTest, simpleInference) {
 TEST_P(BackendExecTest, debugPrint) {
   Tensor input{0.0, 1.0, 2.0, 3.0};
   auto &mod = EE_.getModule();
-  auto ctx = llvm::make_unique<ExecutionContext>();
+  auto ctx = glow::make_unique<ExecutionContext>();
   Function *F = mod.createFunction("main");
   auto *IV = mod.createPlaceholder(input.getElementType(), input.dims(),
                                    "input", false);
@@ -303,7 +303,7 @@ TEST_P(BackendExecTest, debugPrint) {
 
   std::unique_ptr<BackendUsingGlowIR> backend(
       static_cast<BackendUsingGlowIR *>(createBackend(GetParam())));
-  auto IR = llvm::make_unique<IRFunction>(F);
+  auto IR = glow::make_unique<IRFunction>(F);
   IR->generateIR(*backend.get());
   IRBuilder(IR.get()).createDebugPrintInst("print", *IR->getWeights().begin());
 
@@ -312,7 +312,7 @@ TEST_P(BackendExecTest, debugPrint) {
   // Since we are compiling IR by hand we cannot go through the normal EE route.
   // Create and initialize the device.
   auto config =
-      llvm::make_unique<runtime::DeviceConfig>(backend->getBackendName());
+      glow::make_unique<runtime::DeviceConfig>(backend->getBackendName());
   std::unique_ptr<runtime::DeviceManager> device(
       runtime::DeviceManager::createDeviceManager(*config));
   EXIT_ON_ERR(device->init());

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -151,7 +151,7 @@ class MockBackend : public Backend {
 
   Expected<std::unique_ptr<CompiledFunction>>
   compile(Function *F, const BackendOptions &) const override {
-    return llvm::make_unique<MockFunction>(runtime::RuntimeBundle::create(*F));
+    return glow::make_unique<MockFunction>(runtime::RuntimeBundle::create(*F));
   }
 
   bool isOpSupported(const NodeInfo &NI) const override { return false; }
@@ -183,7 +183,7 @@ class MockBackendCustomIRGen : public Backend {
 
   Expected<std::unique_ptr<CompiledFunction>>
   compile(Function *F, const BackendOptions &) const override {
-    return llvm::make_unique<MockFunction>(runtime::RuntimeBundle::create(*F));
+    return glow::make_unique<MockFunction>(runtime::RuntimeBundle::create(*F));
   }
 
   bool isOpSupported(const NodeInfo &NI) const override { return false; }

--- a/tests/unittests/DeviceManagerTest.cpp
+++ b/tests/unittests/DeviceManagerTest.cpp
@@ -48,7 +48,7 @@ public:
 };
 
 std::unique_ptr<Module> makeBasicModule(std::string functionName = "main") {
-  std::unique_ptr<Module> module = llvm::make_unique<Module>();
+  std::unique_ptr<Module> module = glow::make_unique<Module>();
 
   Function *F = module->createFunction(functionName);
   auto *input = module->createPlaceholder(ElemKind::FloatTy, {1},
@@ -116,7 +116,7 @@ TEST_P(DeviceManagerTest, Basic) {
   EXPECT_EQ(future.get(), module.get());
 
   std::unique_ptr<ExecutionContext> context =
-      llvm::make_unique<ExecutionContext>();
+      glow::make_unique<ExecutionContext>();
   context->getPlaceholderBindings()->allocate(module->getPlaceholders());
 
   Tensor input1(ElemKind::FloatTy, {1});
@@ -155,7 +155,7 @@ TEST_P(DeviceManagerTest, PartialTensorCopy) {
   if (backendName == "Habana") {
     return;
   }
-  std::unique_ptr<Module> module = llvm::make_unique<Module>();
+  std::unique_ptr<Module> module = glow::make_unique<Module>();
 
   // Create function of batch size 2.
   Function *F = module->createFunction("main");
@@ -183,7 +183,7 @@ TEST_P(DeviceManagerTest, PartialTensorCopy) {
   EXPECT_EQ(future.get(), module.get());
 
   std::unique_ptr<ExecutionContext> context =
-      llvm::make_unique<ExecutionContext>();
+      glow::make_unique<ExecutionContext>();
   context->getPlaceholderBindings()->allocate(output);
 
   Tensor input1(ElemKind::FloatTy, {1});
@@ -234,9 +234,9 @@ TEST_P(DeviceManagerTest, MultiRun) {
   EXPECT_EQ(future.get(), module.get());
 
   std::unique_ptr<ExecutionContext> context1 =
-      llvm::make_unique<ExecutionContext>();
+      glow::make_unique<ExecutionContext>();
   std::unique_ptr<ExecutionContext> context2 =
-      llvm::make_unique<ExecutionContext>();
+      glow::make_unique<ExecutionContext>();
   context1->getPlaceholderBindings()->allocate(module->getPlaceholders());
   context2->getPlaceholderBindings()->allocate(module->getPlaceholders());
 
@@ -298,9 +298,9 @@ TEST_P(DeviceManagerTest, MultiFunction) {
   auto module = makeBasicModule("func1");
 
   std::unique_ptr<ExecutionContext> context1 =
-      llvm::make_unique<ExecutionContext>();
+      glow::make_unique<ExecutionContext>();
   std::unique_ptr<ExecutionContext> context2 =
-      llvm::make_unique<ExecutionContext>();
+      glow::make_unique<ExecutionContext>();
   context1->getPlaceholderBindings()->allocate(module->getPlaceholders());
 
   Function *F = module->createFunction("func2");
@@ -416,7 +416,7 @@ TEST_P(DeviceManagerTest, MultiModule) {
   EXPECT_EQ(future.get(), module2.get());
 
   std::unique_ptr<ExecutionContext> context1 =
-      llvm::make_unique<ExecutionContext>();
+      glow::make_unique<ExecutionContext>();
   context1->getPlaceholderBindings()->allocate(module1->getPlaceholders());
   Tensor input(ElemKind::FloatTy, {1});
   input.getHandle().clear(0.5f);
@@ -428,7 +428,7 @@ TEST_P(DeviceManagerTest, MultiModule) {
                           {&input});
 
   std::unique_ptr<ExecutionContext> context2 =
-      llvm::make_unique<ExecutionContext>();
+      glow::make_unique<ExecutionContext>();
   context2->getPlaceholderBindings()->allocate(module2->getPlaceholders());
   updateInputPlaceholders(*context2->getPlaceholderBindings(),
                           {module2->getPlaceholderByName("func2_input")},
@@ -474,9 +474,9 @@ TEST_P(DeviceManagerTest, ReuseModule) {
   auto module = makeBasicModule("func1");
 
   std::unique_ptr<ExecutionContext> context1 =
-      llvm::make_unique<ExecutionContext>();
+      glow::make_unique<ExecutionContext>();
   std::unique_ptr<ExecutionContext> context2 =
-      llvm::make_unique<ExecutionContext>();
+      glow::make_unique<ExecutionContext>();
   context1->getPlaceholderBindings()->allocate(module->getPlaceholders());
 
   Function *F = module->createFunction("func2");
@@ -699,7 +699,7 @@ TEST(DeviceManagerTest, DummyDeviceManager) {
   EXPECT_EQ(future.get(), module.get());
 
   std::unique_ptr<ExecutionContext> context1 =
-      llvm::make_unique<ExecutionContext>();
+      glow::make_unique<ExecutionContext>();
   context1->getPlaceholderBindings()->allocate(module->getPlaceholders());
 
   Tensor input1(ElemKind::FloatTy, {1});

--- a/tests/unittests/HabanaGlowTest.cpp
+++ b/tests/unittests/HabanaGlowTest.cpp
@@ -1563,7 +1563,7 @@ TEST_F(HabanaBackendTest, SingleFunctionMultiThreadMultiDevice) {
         // in runFunction (hopefully).
         for (unsigned j = 0, e = iterationsPerThread; j < e; ++j) {
           // Set inputs.
-          auto iBindings = llvm::make_unique<PlaceholderBindings>();
+          auto iBindings = glow::make_unique<PlaceholderBindings>();
           auto inputHandle = iBindings->allocate(inputP)->getHandle();
           inputHandle.clear(1);
 
@@ -1576,7 +1576,7 @@ TEST_F(HabanaBackendTest, SingleFunctionMultiThreadMultiDevice) {
           outputHandle.clear(32);
 
           inputExecutionContexts.emplace_back(
-              llvm::make_unique<ExecutionContext>(std::move(iBindings)));
+              glow::make_unique<ExecutionContext>(std::move(iBindings)));
           outputBindings.emplace_back(std::move(oBindings));
         }
 

--- a/tests/unittests/HostManagerTest.cpp
+++ b/tests/unittests/HostManagerTest.cpp
@@ -29,7 +29,7 @@ using DAGNodePairTy = std::pair<std::vector<std::unique_ptr<DAGNode>>,
 
 class HostManagerTest : public ::testing::Test {};
 std::unique_ptr<Module> setupModule(unsigned functionCount) {
-  std::unique_ptr<Module> module = llvm::make_unique<Module>();
+  std::unique_ptr<Module> module = glow::make_unique<Module>();
   for (unsigned int i = 0; i < functionCount; i++) {
     Function *F = module->createFunction("function" + std::to_string(i));
     auto *X = module->createPlaceholder(ElemKind::FloatTy, {3},
@@ -44,15 +44,15 @@ std::unique_ptr<HostManager>
 createHostManager(llvm::StringRef backendName,
                   HostConfig hostConfig = HostConfig()) {
   std::vector<std::unique_ptr<DeviceConfig>> configs;
-  auto deviceConfig = llvm::make_unique<DeviceConfig>(backendName);
+  auto deviceConfig = glow::make_unique<DeviceConfig>(backendName);
   configs.push_back(std::move(deviceConfig));
   std::unique_ptr<HostManager> hostManager =
-      llvm::make_unique<HostManager>(std::move(configs), hostConfig);
+      glow::make_unique<HostManager>(std::move(configs), hostConfig);
   return hostManager;
 }
 
 Error addNetwork(HostManager *manager, std::string name) {
-  std::unique_ptr<Module> module = llvm::make_unique<Module>();
+  std::unique_ptr<Module> module = glow::make_unique<Module>();
   Function *F = module->createFunction(name);
   auto *X =
       module->createPlaceholder(ElemKind::FloatTy, {3}, "X_" + name, false);
@@ -83,9 +83,9 @@ TEST_F(HostManagerTest, addNetwork) {
 }
 
 TEST_F(HostManagerTest, runNetwork) {
-  std::unique_ptr<Module> module = llvm::make_unique<Module>();
+  std::unique_ptr<Module> module = glow::make_unique<Module>();
   std::unique_ptr<ExecutionContext> context =
-      llvm::make_unique<ExecutionContext>();
+      glow::make_unique<ExecutionContext>();
 
   Function *F = module->createFunction("main");
   auto *X = module->createPlaceholder(ElemKind::FloatTy, {3}, "X", false);
@@ -113,7 +113,7 @@ TEST_F(HostManagerTest, runNetwork) {
                             EXPECT_NEAR(HX.at({1}), 4, 1E-5);
                             EXPECT_NEAR(HX.at({2}), 9, 1E-5);
                             context = std::move(context_);
-                            runErr = llvm::make_unique<Error>(std::move(err));
+                            runErr = glow::make_unique<Error>(std::move(err));
                             runNetwork.set_value();
                           });
 
@@ -133,7 +133,7 @@ TEST_F(HostManagerTest, runNetwork) {
                             EXPECT_NEAR(HX.at({0}), 1, 1E-5);
                             EXPECT_NEAR(HX.at({1}), 4, 1E-5);
                             EXPECT_NEAR(HX.at({2}), 9, 1E-5);
-                            runErr = llvm::make_unique<Error>(std::move(err));
+                            runErr = glow::make_unique<Error>(std::move(err));
                             newRun.set_value();
                           });
 
@@ -191,8 +191,8 @@ TEST_F(HostManagerTest, ConfigureHostManager) {
 
   EXPECT_FALSE(ERR_TO_BOOL(addNetwork(hostManager.get(), "main")));
 
-  auto context = llvm::make_unique<ExecutionContext>();
-  auto context2 = llvm::make_unique<ExecutionContext>();
+  auto context = glow::make_unique<ExecutionContext>();
+  auto context2 = glow::make_unique<ExecutionContext>();
 
   std::unique_ptr<Error> runErr;
 
@@ -210,7 +210,7 @@ TEST_F(HostManagerTest, ConfigureHostManager) {
       "main", std::move(context2),
       [&runErr](RunIdentifierTy runID, Error err,
                 std::unique_ptr<ExecutionContext> context_) {
-        runErr = llvm::make_unique<Error>(std::move(err));
+        runErr = glow::make_unique<Error>(std::move(err));
       });
   guard.unlock();
   // Don't need a future, error CB called inline.
@@ -227,10 +227,10 @@ TEST_F(HostManagerTest, QueueTest) {
 
   EXPECT_FALSE(ERR_TO_BOOL(addNetwork(hostManager.get(), "main")));
 
-  auto context = llvm::make_unique<ExecutionContext>();
-  auto context2 = llvm::make_unique<ExecutionContext>();
-  auto context3 = llvm::make_unique<ExecutionContext>();
-  auto context4 = llvm::make_unique<ExecutionContext>();
+  auto context = glow::make_unique<ExecutionContext>();
+  auto context2 = glow::make_unique<ExecutionContext>();
+  auto context3 = glow::make_unique<ExecutionContext>();
+  auto context4 = glow::make_unique<ExecutionContext>();
   std::promise<unsigned> run1p, run2p, run3p, dispatched;
   auto dispatchDone = dispatched.get_future();
   auto run1f = run1p.get_future();

--- a/tests/unittests/PartitionerTest.cpp
+++ b/tests/unittests/PartitionerTest.cpp
@@ -488,7 +488,7 @@ public:
 
   Expected<std::unique_ptr<CompiledFunction>>
   compile(Function *F, const BackendOptions &opts) const override {
-    return llvm::make_unique<MockFunction>(backendName,
+    return glow::make_unique<MockFunction>(backendName,
                                            runtime::RuntimeBundle::create(*F));
   }
 

--- a/tests/unittests/ProvisionerTest.cpp
+++ b/tests/unittests/ProvisionerTest.cpp
@@ -25,7 +25,7 @@ using namespace glow::runtime;
 class ProvisionerTest : public ::testing::Test {};
 
 std::unique_ptr<Module> setupModule(unsigned functionCount) {
-  auto mod = llvm::make_unique<Module>();
+  auto mod = glow::make_unique<Module>();
   for (unsigned int i = 0; i < functionCount; i++) {
     auto *F = mod->createFunction("function" + std::to_string(i));
     auto *X = mod->createPlaceholder(ElemKind::FloatTy, {16, 1024}, "X", false);
@@ -44,8 +44,8 @@ DAGListTy setupDAG(unsigned rootCount, unsigned childCount) {
   unsigned currentFunction = 0;
   for (unsigned int root = 0; root < rootCount; root++) {
     DAGNodePtrVec nodes;
-    auto rootNode = llvm::make_unique<DAGNode>();
-    auto firstNode = llvm::make_unique<DAGNode>();
+    auto rootNode = glow::make_unique<DAGNode>();
+    auto firstNode = glow::make_unique<DAGNode>();
     rootNode->name = "root" + std::to_string(root);
     rootNode->children.push_back(firstNode.get());
     firstNode->name = "function" + std::to_string(currentFunction);
@@ -53,7 +53,7 @@ DAGListTy setupDAG(unsigned rootCount, unsigned childCount) {
     firstNode->backendName = "CPU";
     currentFunction++;
     for (unsigned int child = 0; child < childCount; child++) {
-      auto newChild = llvm::make_unique<DAGNode>();
+      auto newChild = glow::make_unique<DAGNode>();
       newChild->name = "function" + std::to_string(currentFunction);
       newChild->logicalDevices = {0};
       newChild->backendName = "CPU";

--- a/tests/unittests/RecommendationSystemTest.cpp
+++ b/tests/unittests/RecommendationSystemTest.cpp
@@ -174,8 +174,8 @@ static void dispatchInference(HostManager *hostManager,
     // Clone the placeholder bindings into a new executionContext.
     for (unsigned i = 0, max = concurrentReqestsOpt - 1; i < max; i++) {
       std::unique_ptr<ExecutionContext> newContext =
-          llvm::make_unique<ExecutionContext>(
-              llvm::make_unique<PlaceholderBindings>(
+          glow::make_unique<ExecutionContext>(
+              glow::make_unique<PlaceholderBindings>(
                   context.getPlaceholderBindings()->clone()));
       contexts.push_back(std::move(newContext));
     }
@@ -210,7 +210,7 @@ generateDeviceConfigs(llvm::StringRef backendName, unsigned numDevices,
                       size_t memorySize) {
   std::vector<std::unique_ptr<runtime::DeviceConfig>> configs;
   for (unsigned i = 0; i < numDevices; i++) {
-    auto deviceConfig = llvm::make_unique<DeviceConfig>(backendName);
+    auto deviceConfig = glow::make_unique<DeviceConfig>(backendName);
     deviceConfig->setDeviceMemory(memorySize);
     configs.push_back(std::move(deviceConfig));
   }
@@ -365,7 +365,7 @@ protected:
     // Create TraceContext if trace file path is provided.
     if (!traceDir.empty()) {
       context_.setTraceContext(
-          llvm::make_unique<TraceContext>(TraceEvent::TraceLevel::STANDARD));
+          glow::make_unique<TraceContext>(TraceEvent::TraceLevel::STANDARD));
     }
 
     // If device memory capacity is unset via command line, use 8MB by default.

--- a/tests/unittests/StatsExporterTest.cpp
+++ b/tests/unittests/StatsExporterTest.cpp
@@ -102,11 +102,11 @@ TEST(StatsExporter, HostManager) {
   EXPECT_EQ(MockStats.counters.count("glow.devices.available_memory.total"), 0);
   EXPECT_EQ(MockStats.counters.count("glow.devices.maximum_memory.total"), 0);
   {
-    auto deviceConfig = llvm::make_unique<DeviceConfig>("Interpreter");
+    auto deviceConfig = glow::make_unique<DeviceConfig>("Interpreter");
     std::vector<std::unique_ptr<DeviceConfig>> configs;
     configs.push_back(std::move(deviceConfig));
     std::unique_ptr<HostManager> HM =
-        llvm::make_unique<HostManager>(std::move(configs), HostConfig());
+        glow::make_unique<HostManager>(std::move(configs), HostConfig());
     EXPECT_EQ(MockStats.counters["glow.devices.used_memory.total"], 0);
     EXPECT_EQ(MockStats.counters["glow.devices.available_memory.total"],
               2000000000);
@@ -114,7 +114,7 @@ TEST(StatsExporter, HostManager) {
               2000000000);
 
     // Add a network so the memory used value is non-zero.
-    std::unique_ptr<Module> module = llvm::make_unique<Module>();
+    std::unique_ptr<Module> module = glow::make_unique<Module>();
     Function *F = module->createFunction("main");
     auto *X = module->createConstant(ElemKind::FloatTy, {1024, 1024}, "X");
     auto *pow = F->createPow("Pow", X, 2.0);

--- a/tests/unittests/ThreadPoolTest.cpp
+++ b/tests/unittests/ThreadPoolTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "glow/Support/ThreadPool.h"
+#include "glow/Support/Memory.h"
 #include "gtest/gtest.h"
 
 #include "llvm/ADT/STLExtras.h"
@@ -55,7 +56,7 @@ TEST(ThreadPool, BasicTest) {
 TEST(ThreadPool, moveCaptureTest) {
   ThreadPool tp(1);
 
-  std::unique_ptr<int> input = llvm::make_unique<int>(42);
+  std::unique_ptr<int> input = glow::make_unique<int>(42);
   int output = 0;
   auto func = [input = std::move(input), &output]() { output = (*input) * 2; };
 

--- a/tests/unittests/TraceEventsTest.cpp
+++ b/tests/unittests/TraceEventsTest.cpp
@@ -123,7 +123,7 @@ TEST_P(TraceEventsTest, manualEvents) {
   CHECK_IF_ENABLED();
   ExecutionContext context;
   context.setTraceContext(
-      llvm::make_unique<TraceContext>(TraceLevel::OPERATOR));
+      glow::make_unique<TraceContext>(TraceLevel::OPERATOR));
 
   size_t numEvents = 4;
   auto *eventData = createEventPlaceholder(numEvents);
@@ -173,7 +173,7 @@ TEST_P(TraceEventsTest, incompleteCoverage) {
   CHECK_IF_ENABLED();
   ExecutionContext context;
   context.setTraceContext(
-      llvm::make_unique<TraceContext>(TraceLevel::OPERATOR));
+      glow::make_unique<TraceContext>(TraceLevel::OPERATOR));
 
   size_t numEvents = 2;
   auto *eventData = createEventPlaceholder(numEvents);
@@ -218,7 +218,7 @@ TEST_P(TraceEventsTest, internalGap) {
   CHECK_IF_ENABLED();
   ExecutionContext context;
   context.setTraceContext(
-      llvm::make_unique<TraceContext>(TraceLevel::OPERATOR));
+      glow::make_unique<TraceContext>(TraceLevel::OPERATOR));
 
   size_t numEvents = 2;
   auto *eventData = createEventPlaceholder(numEvents);
@@ -263,7 +263,7 @@ TEST_P(TraceEventsTest, automaticInstrumentation) {
   CHECK_IF_ENABLED();
   ExecutionContext context;
   context.setTraceContext(
-      llvm::make_unique<TraceContext>(TraceLevel::OPERATOR));
+      glow::make_unique<TraceContext>(TraceLevel::OPERATOR));
 
   auto n = part_one(F, context);
   n = part_two(F, context, n);
@@ -290,7 +290,7 @@ TEST_P(TraceEventsTest, manualAndAutomatic) {
   CHECK_IF_ENABLED();
   ExecutionContext context;
   context.setTraceContext(
-      llvm::make_unique<TraceContext>(TraceLevel::OPERATOR));
+      glow::make_unique<TraceContext>(TraceLevel::OPERATOR));
 
   size_t numEvents = 4;
   auto *eventData = createEventPlaceholder(numEvents);
@@ -338,7 +338,7 @@ TEST_P(TraceEventsTest, twoCompiles) {
   CHECK_IF_ENABLED();
   ExecutionContext context;
   context.setTraceContext(
-      llvm::make_unique<TraceContext>(TraceLevel::OPERATOR));
+      glow::make_unique<TraceContext>(TraceLevel::OPERATOR));
 
   size_t numEvents = 4;
   auto *eventData = createEventPlaceholder(numEvents);
@@ -353,7 +353,7 @@ TEST_P(TraceEventsTest, twoCompiles) {
 
   ExecutionContext context2{context.clone()};
   context2.setTraceContext(
-      llvm::make_unique<TraceContext>(TraceLevel::OPERATOR));
+      glow::make_unique<TraceContext>(TraceLevel::OPERATOR));
 
   context.getPlaceholderBindings()->allocate(EE_.getModule().getPlaceholders());
 
@@ -366,7 +366,7 @@ TEST_P(TraceEventsTest, twoCompiles) {
 
   std::string name = F->getName();
   auto config =
-      llvm::make_unique<runtime::DeviceConfig>(backend->getBackendName());
+      glow::make_unique<runtime::DeviceConfig>(backend->getBackendName());
   std::unique_ptr<runtime::DeviceManager> device(
       runtime::DeviceManager::createDeviceManager(*config));
   EXIT_ON_ERR(device->init());
@@ -413,7 +413,7 @@ TEST_P(TraceEventsTest, onlyTraceEvents) {
   CHECK_IF_ENABLED();
   ExecutionContext context;
   context.setTraceContext(
-      llvm::make_unique<TraceContext>(TraceLevel::OPERATOR));
+      glow::make_unique<TraceContext>(TraceLevel::OPERATOR));
 
   size_t numEvents = 16;
   auto *eventData = createEventPlaceholder(numEvents);
@@ -454,7 +454,7 @@ TEST_P(TraceEventsTest, multipleBackingTensors) {
   CHECK_IF_ENABLED();
   ExecutionContext context;
   context.setTraceContext(
-      llvm::make_unique<TraceContext>(TraceLevel::OPERATOR));
+      glow::make_unique<TraceContext>(TraceLevel::OPERATOR));
 
   size_t numEvents = 6;
   auto *eventData1 = createEventPlaceholder(3);
@@ -514,7 +514,7 @@ TEST_P(TraceEventsTest, multipleRunsAreDistinct) {
   CHECK_IF_ENABLED();
   ExecutionContext context;
   context.setTraceContext(
-      llvm::make_unique<TraceContext>(TraceLevel::OPERATOR));
+      glow::make_unique<TraceContext>(TraceLevel::OPERATOR));
 
   size_t numEvents = 4;
   auto *eventData = createEventPlaceholder(numEvents);
@@ -542,7 +542,7 @@ TEST_P(TraceEventsTest, multipleRunsAreDistinct) {
 
   ExecutionContext context2{context.clone()};
   context2.setTraceContext(
-      llvm::make_unique<TraceContext>(TraceLevel::OPERATOR));
+      glow::make_unique<TraceContext>(TraceLevel::OPERATOR));
 
   // run twice
   EE_.run(context);
@@ -566,7 +566,7 @@ TEST_P(TraceEventsTest, deviceManagerEvents) {
   CHECK_IF_ENABLED();
   ExecutionContext context;
   context.setTraceContext(
-      llvm::make_unique<TraceContext>(TraceLevel::STANDARD));
+      glow::make_unique<TraceContext>(TraceLevel::STANDARD));
 
   auto n = part_one(F, context);
   n = part_two(F, context, n);
@@ -595,7 +595,7 @@ TEST(TraceEventsTest, nestedScopedEvents) {
   CHECK_IF_ENABLED();
   ExecutionContext context;
   context.setTraceContext(
-      llvm::make_unique<TraceContext>(TraceLevel::STANDARD));
+      glow::make_unique<TraceContext>(TraceLevel::STANDARD));
 
   TraceContext *tc = context.getTraceContext();
 
@@ -635,7 +635,7 @@ TEST(TraceEventsTest, nestedScopedEventsMacro) {
   CHECK_IF_ENABLED();
   ExecutionContext context;
   context.setTraceContext(
-      llvm::make_unique<TraceContext>(TraceLevel::STANDARD));
+      glow::make_unique<TraceContext>(TraceLevel::STANDARD));
 
   TraceContext *tc = context.getTraceContext();
 
@@ -676,7 +676,7 @@ TEST(TraceEventsTest, nestedScopedEventsTerm) {
   CHECK_IF_ENABLED();
   ExecutionContext context;
   context.setTraceContext(
-      llvm::make_unique<TraceContext>(TraceLevel::STANDARD));
+      glow::make_unique<TraceContext>(TraceLevel::STANDARD));
 
   TraceContext *tc = context.getTraceContext();
 

--- a/tools/loader/ImageClassifier.cpp
+++ b/tools/loader/ImageClassifier.cpp
@@ -494,9 +494,9 @@ setupContextPool(Placeholder *outputPH, Placeholder *inputImagePH,
       miniBatch ? std::min(int(poolSize), int(iterationsOpt / miniBatch)) : 1;
   // Setup pool of inference requests to be run.
   for (unsigned i = 0; i < iterations; i++) {
-    auto newContext = llvm::make_unique<ExecutionContext>();
+    auto newContext = glow::make_unique<ExecutionContext>();
     newContext->setTraceContext(
-        llvm::make_unique<TraceContext>(TraceLevel::STANDARD));
+        glow::make_unique<TraceContext>(TraceLevel::STANDARD));
     auto ph = newContext->getPlaceholderBindings();
     ph->insert(inputImagePH, Tensor(inputImageData.getType()));
     ph->allocate(outputPH);
@@ -546,7 +546,7 @@ int main(int argc, char **argv) {
   // If tracing is enabled, create a TraceContext to merge each runs events
   // into.
   if (!tracePath.empty()) {
-    traceContext = llvm::make_unique<TraceContext>(TraceLevel::STANDARD);
+    traceContext = glow::make_unique<TraceContext>(TraceLevel::STANDARD);
     if (!iterationsOpt) {
       iterationsOpt = 1;
     }

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -342,7 +342,7 @@ generateDeviceConfigs(std::string &loadDeviceConfigsFile,
     // If there is no device config file, use numDevices to generate the
     // configs.
     for (unsigned int i = 0; i < numDevices; ++i) {
-      auto config = llvm::make_unique<runtime::DeviceConfig>(backendName);
+      auto config = glow::make_unique<runtime::DeviceConfig>(backendName);
       configs.push_back(std::move(config));
     }
   } else {
@@ -353,7 +353,7 @@ generateDeviceConfigs(std::string &loadDeviceConfigsFile,
       auto backendName = lists[i].backendName_;
       auto name = lists[i].name_;
       auto parameters = getBackendParams(lists[i].parameters_.str);
-      auto config = llvm::make_unique<runtime::DeviceConfig>(backendName, name,
+      auto config = glow::make_unique<runtime::DeviceConfig>(backendName, name,
                                                              parameters);
       configs.push_back(std::move(config));
     }
@@ -495,7 +495,7 @@ Loader::Loader() {
       generateDeviceConfigs(loadDeviceConfigsFileOpt, numDevices,
                             ExecutionBackend);
 
-  hostManager_ = llvm::make_unique<runtime::HostManager>(std::move(configs));
+  hostManager_ = glow::make_unique<runtime::HostManager>(std::move(configs));
   backend_ = createBackend(ExecutionBackend);
   F_ = M_->createFunction(modelPathOpt[0]);
   functionName_ = modelPathOpt[0];

--- a/torch_glow/src/CachingGraphRunner.cpp
+++ b/torch_glow/src/CachingGraphRunner.cpp
@@ -63,10 +63,10 @@ CachingGraphRunner::loadImpl(torch::jit::Stack &stack) {
     return it->second.get();
   }
 
-  auto info = llvm::make_unique<PerGlowGraphInfo>();
+  auto info = glow::make_unique<PerGlowGraphInfo>();
   info->functionName = strFormat("PTFunction%lu", hash);
 
-  std::unique_ptr<Module> module = llvm::make_unique<Module>();
+  std::unique_ptr<Module> module = glow::make_unique<Module>();
   Function *f = module->createFunction(info->functionName);
 
   RETURN_IF_ERR(PyTorchModelLoader::loadJITGraph(
@@ -88,7 +88,7 @@ Error CachingGraphRunner::runImpl(const PerGlowGraphInfo &info,
 
   const auto inputs = torch::jit::last(stack, numInputs);
 
-  std::unique_ptr<ExecutionContext> ctx = llvm::make_unique<ExecutionContext>();
+  std::unique_ptr<ExecutionContext> ctx = glow::make_unique<ExecutionContext>();
   auto *bindings = ctx->getPlaceholderBindings();
 
   for (size_t i = 0; i < numInputs; ++i) {

--- a/torch_glow/src/PyTorchCommon.cpp
+++ b/torch_glow/src/PyTorchCommon.cpp
@@ -34,11 +34,11 @@ std::unique_ptr<runtime::HostManager> buildHostManager() {
 
   std::vector<std::unique_ptr<runtime::DeviceConfig>> deviceConfigs;
   for (int i = 0; i < numGlowDevices; i++) {
-    deviceConfigs.push_back(llvm::make_unique<runtime::DeviceConfig>(
+    deviceConfigs.push_back(glow::make_unique<runtime::DeviceConfig>(
         getPyTorchLoaderSettings().glowBackendName));
   }
 
-  return llvm::make_unique<runtime::HostManager>(std::move(deviceConfigs));
+  return glow::make_unique<runtime::HostManager>(std::move(deviceConfigs));
 }
 
 /// \returns the HostManager singleton used to run all PyTorch graphs in Glow.

--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -2102,7 +2102,7 @@ ValueMapping::ValueMapping(NodeValue nodeValue, bool wasFrozen) {
 
 ValueMapping::ValueMapping(GlowIValue glowIValue) {
   mappingType_ = ValueMappingType::IValue;
-  glowIValue_ = llvm::make_unique<GlowIValue>(std::move(glowIValue));
+  glowIValue_ = glow::make_unique<GlowIValue>(std::move(glowIValue));
 }
 
 Expected<NodeValue> ValueMapping::getMappedNodeValue() {


### PR DESCRIPTION
Summary: Newer versions of LLVM (10+) will use C++14, eliding the need for make_unique.
This diff removes it entirely: https://reviews.llvm.org/D66259

Documentation: Updated docs/Tracing.md and all examples + core code with `llvm::make_unique`.

Test Plan: Build and run all tests
