### PR TITLE
[PyTorch]Add PyTorch Quantized Convolution (unpacked)

### DIFF
--- a/torch_glow/src/FusePrepack.cpp
+++ b/torch_glow/src/FusePrepack.cpp
@@ -28,16 +28,16 @@ namespace glow {
 void fuseConvPrepack(std::shared_ptr<torch::jit::Graph> &graph) {
   std::string convPrepackPattern = R"IR(
 graph(%input, %w, %b, %4, %5, %6, %7, %8, %9, %10, %11, %12):
-  %prepacked_weight = quantized::conv_prepacked(%w, %b, %4, %5, %6, %7)
+  %prepacked_weight = quantized::conv_prepack(%w, %b, %4, %5, %6, %7)
   %res = quantized::conv2d(%input, %prepacked_weight, %8, %9, %10, %7, %11, %12)
   return (%res))IR";
 
   std::string convFused = R"IR(
 graph(%input, %w, %b, %4, %5, %6, %7, %8, %9, %10, %11, %12):
-  %res = quantized::unpacked_conv2d(%input, %w, %b, %8, %9, %10, %7, %11, %12)
+  %res = glow::unpacked_quantized_conv2d(%input, %w, %b, %8, %9, %10, %7, %11, %12)
   return (%res))IR";
 
-  // Replace conv_prepack + conv2d to unpacked_conv2d
+  // Replace conv_prepack + conv2d to unpacked_quantized_conv2d
   torch::jit::SubgraphRewriter convToUnpackedConv;
   convToUnpackedConv.RegisterRewritePattern(convPrepackPattern, convFused);
   convToUnpackedConv.runOnGraph(graph);

--- a/torch_glow/src/PyTorchCommon.cpp
+++ b/torch_glow/src/PyTorchCommon.cpp
@@ -233,7 +233,8 @@ glow::Tensor ptTensorToGlowTensor(const at::Tensor &ptTensor) {
 
   glow::Type glowType;
   if (ptTensor.is_quantized()) {
-    glowType = glow::Type(glowElemKind, dims, ptTensor.q_scale(), ptTensor.q_zero_point());
+    glowType = glow::Type(glowElemKind, dims, ptTensor.q_scale(),
+                          ptTensor.q_zero_point());
   } else {
     glowType = glow::Type(glowElemKind, dims);
   }

--- a/torch_glow/src/PyTorchCommon.cpp
+++ b/torch_glow/src/PyTorchCommon.cpp
@@ -110,7 +110,7 @@ glow::ElemKind scalarTypeToElemKind(c10::ScalarType ty) {
   } else if (ty == at::kQInt8) {
     return ElemKind::Int8QTy;
   } else {
-    LOG(DFATAL) << ty << "Not supported yet.";
+    LOG(DFATAL) << ty << " Not supported yet.";
     return ElemKind::Int64ITy;
   }
 }

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -76,9 +76,6 @@ void registerGlowFusionPass(std::function<bool()> enablePassFn);
 /// registered.
 void registerGlowFusionOpAndPass(std::function<bool()> enablePassFn);
 
-/// Given a PyTorch TensorType \p ptType, \returns a matching Glow Type.
-glow::Type ptTypeToGlowType(const c10::TensorType &ptType);
-
 /// Given a PyTorch Tensor \p ptTensor, \returns an unowned Glow Tensor with a
 /// matching type backed by the same memory as ptTensor.
 glow::Tensor ptTensorToGlowTensor(const at::Tensor &ptTensor);

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -76,6 +76,9 @@ void registerGlowFusionPass(std::function<bool()> enablePassFn);
 /// registered.
 void registerGlowFusionOpAndPass(std::function<bool()> enablePassFn);
 
+/// Given a PyTorch TensorType \p ptType, \returns a matching Glow Type.
+glow::Type ptTypeToGlowType(const c10::TensorType &ptType);
+
 /// Given a PyTorch Tensor \p ptTensor, \returns an unowned Glow Tensor with a
 /// matching type backed by the same memory as ptTensor.
 glow::Tensor ptTensorToGlowTensor(const at::Tensor &ptTensor);

--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -1522,7 +1522,7 @@ Error PyTorchModelLoader::loadQuantizedConvUnpacked(
     bias = biasConstant->getOutput();
   }
   auto biasType =
-      F_.getParent()->uniqueType(glow::ElemKind::Int32QTy, bias.dims(), 1.0, 0);
+      F_.getParent()->uniqueType(glow::ElemKind::Int32QTy, bias.dims(), input.getType()->getScale() * weights.getType()->getScale(), 0);
   bias = F_.createQuantize("quantize_bias", bias, biasType);
 
   std::vector<glow::unsigned_t> strides;

--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -30,6 +30,7 @@ namespace {
 /// In Glow, the activations are quantized to int_8. Therefore, for the offset
 /// read from quantized pytorch model, we need to subtract 128(i.e. INT8_MIN) to
 /// make the activations becomes int8_t.
+
 /// For Glow: -128 <= orig_fp32/scale_1 + offset_1 <= 127
 /// For PyTorch: 0 <= orig_fp32/scale_2 + offset_2 <= 255
 /// Therefore, we can make scale_1 == scale_2, and offset_1 = offset2 - 128
@@ -1574,7 +1575,7 @@ Error PyTorchModelLoader::loadQuantizedConvUnpacked(
   glow::TransposeNode *output = F_.createTranspose(
       "qconv_output_transposed", qconv->getResult(), NHWC2NCHW);
 
-  return addValueMapping(outputs[0], output->getResult());
+  return addValueMapping(outputs[0], rescaleIntToUint(output->getResult()));
 }
 
 Error PyTorchModelLoader::loadMaxPool2d(const torch::jit::Node *ptNode) {

--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -615,7 +615,8 @@ PyTorchModelLoader::getSymbolsMapping() {
         }},
        {{"aten::quantize_per_tensor"},
         &PyTorchModelLoader::loadQuantize,
-        {QuantizeInputs::scale, QuantizeInputs::zero_point, QuantizeInputs::dtype}},
+        {QuantizeInputs::scale, QuantizeInputs::zero_point,
+         QuantizeInputs::dtype}},
        {{"aten::dequantize"}, &PyTorchModelLoader::loadDequantize, {}},
        {{"aten::size"}, &PyTorchModelLoader::loadSize, {SizeInputs::dim}},
        // TODO: use -1 to freeze all inputs
@@ -1445,8 +1446,9 @@ Error PyTorchModelLoader::loadQuantize(const torch::jit::Node *ptNode) {
 
   // zero_point
   int32_t outOffset;
-  ASSIGN_VALUE_OR_RETURN_ERR(outOffset, iValToInt(getGlowIValueForValue(
-                                            inputs[QuantizeInputs::zero_point])));
+  ASSIGN_VALUE_OR_RETURN_ERR(
+      outOffset,
+      iValToInt(getGlowIValueForValue(inputs[QuantizeInputs::zero_point])));
 
   // dtype, we only support quantize to int8 for now
   int32_t outDtype;

--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -1521,8 +1521,9 @@ Error PyTorchModelLoader::loadQuantizedConvUnpacked(
         F_.getParent()->createConstant("qconv_bias", std::move(biasT));
     bias = biasConstant->getOutput();
   }
-  auto biasType =
-      F_.getParent()->uniqueType(glow::ElemKind::Int32QTy, bias.dims(), input.getType()->getScale() * weights.getType()->getScale(), 0);
+  auto biasType = F_.getParent()->uniqueType(
+      glow::ElemKind::Int32QTy, bias.dims(),
+      input.getType()->getScale() * weights.getType()->getScale(), 0);
   bias = F_.createQuantize("quantize_bias", bias, biasType);
 
   std::vector<glow::unsigned_t> strides;

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -315,15 +315,19 @@ private:
   /// \returns error on failure.
   Error loadBatchNorm(const torch::jit::Node *ptNode);
 
-  /// Load a PyTorch quantization::add node.
+  /// Load a PyTorch quantized::add node.
   /// \return error on failure.
   Error loadQuantizedAdd(const torch::jit::Node *ptNode);
+
+  /// Load a PyTorch glow::unpacked_quantized_conv node.
+  // \return error on failure.
+  Error loadQuantizedConvUnpacked(const torch::jit::Node *ptNode);
 
   /// Load a glow::unpacked_quantized_linear node.
   /// \return error on failure.
   Error loadQuantizedLinear(const torch::jit::Node *ptNode);
 
-  /// Load a PyTorch quantize_linear node.
+  /// Load a PyTorch quantize_per_tensor node.
   /// \returns error on failure.
   Error loadQuantize(const torch::jit::Node *ptNode);
 

--- a/torch_glow/tests/nodes/quantized_conv2d_test.py
+++ b/torch_glow/tests/nodes/quantized_conv2d_test.py
@@ -1,0 +1,32 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import torch
+
+from tests.utils import jitVsGlow
+
+
+def test_quantized_conv2d():
+    """Basic test of the PyTorch quantized::relu Node on Glow."""
+
+    def test_f(a, w, b):
+        qu = torch.nn.quantized.Quantize(1/16, 0, torch.quint8)
+        qi = torch.nn.quantized.Quantize(1/16, 0, torch.qint8)
+        dq = torch.nn.quantized.DeQuantize()
+        conv = torch.nn.quantized.functional.conv2d
+        return dq(conv(qu(a), qi(w), b))
+
+    # TODO
+    # Due to the quantization error between
+    # PyTorch and Glow, we would like to use some
+    # determined test data instead of random ones
+    # x = torch.randn([3, 3, 3, 3])
+    # w = torch.randn([3, 3, 3, 3])
+    # b = torch.randn([3])
+
+    x = torch.tensor([[[[5., 6.], [7., 8.]]]])
+    w = torch.tensor([[[[1., 2.], [3., 4.]]]])
+    b = torch.zeros(1)
+
+    jitVsGlow(test_f, x, w, b, expected_fused_ops={"aten::quantize_per_tensor",
+                                                   "glow::unpacked_quantized_conv2d",
+                                                   "aten::dequantize"})

--- a/torch_glow/tests/nodes/quantized_conv2d_test.py
+++ b/torch_glow/tests/nodes/quantized_conv2d_test.py
@@ -25,8 +25,13 @@ def test_quantized_conv2d():
 
     x = torch.tensor([[[[5., 6.], [7., 8.]]]])
     w = torch.tensor([[[[1., 2.], [3., 4.]]]])
-    b = torch.zeros(1)
+    b_zero = torch.zeros(1)
+    b = torch.randn(1)
 
     jitVsGlow(test_f, x, w, b, expected_fused_ops={"aten::quantize_per_tensor",
+                                                   "glow::unpacked_quantized_conv2d",
+                                                   "aten::dequantize"})
+
+    jitVsGlow(test_f, x, w, b_zero, expected_fused_ops={"aten::quantize_per_tensor",
                                                    "glow::unpacked_quantized_conv2d",
                                                    "aten::dequantize"})

--- a/torch_glow/tests/nodes/quantized_conv2d_test.py
+++ b/torch_glow/tests/nodes/quantized_conv2d_test.py
@@ -5,6 +5,7 @@ import torch
 from tests.utils import jitVsGlow
 import pytest
 
+
 def test_quantized_conv2d():
     """Basic test of the PyTorch quantized::relu Node on Glow."""
 
@@ -33,8 +34,9 @@ def test_quantized_conv2d():
                                                    "aten::dequantize"})
 
     jitVsGlow(test_f, x, w, b_zero, expected_fused_ops={"aten::quantize_per_tensor",
-                                                   "glow::unpacked_quantized_conv2d",
-                                                   "aten::dequantize"})
+                                                        "glow::unpacked_quantized_conv2d",
+                                                        "aten::dequantize"})
+
 
 @pytest.mark.skip(reason="accuracy between glow&ytorch")
 def test_quantized_conv2d_nonfunctional():
@@ -49,5 +51,5 @@ def test_quantized_conv2d_nonfunctional():
     x = torch.tensor([[[[5., 6.], [7., 8.]]]])
 
     jitVsGlow(test_f, x, expected_fused_ops={"aten::quantize_per_tensor",
-                                                   "glow::unpacked_quantized_conv2d",
-                                                   "aten::dequantize"})
+                                             "glow::unpacked_quantized_conv2d",
+                                             "aten::dequantize"})

--- a/torch_glow/tests/nodes/quantized_conv2d_test.py
+++ b/torch_glow/tests/nodes/quantized_conv2d_test.py
@@ -7,7 +7,7 @@ import pytest
 
 
 def test_quantized_conv2d():
-    """Basic test of the PyTorch quantized::relu Node on Glow."""
+    """Basic test of the PyTorch quantized onv2d Node on Glow."""
 
     def test_f(a, w, b):
         qu = torch.nn.quantized.Quantize(1/16, 0, torch.quint8)
@@ -40,7 +40,8 @@ def test_quantized_conv2d():
 
 @pytest.mark.skip(reason="accuracy between glow&ytorch")
 def test_quantized_conv2d_nonfunctional():
-    """Basic test of the PyTorch quantized::relu Node on Glow."""
+    """Basic test of the PyTorch quantized conv2d Node with external quantized
+    input on Glow."""
 
     def test_f(a):
         q = torch.nn.quantized.Quantize(1/16, 0, torch.quint8)


### PR DESCRIPTION
This pr is supposed to add support for pytorch quantized conv with unpakced weight&bias inputs.
With this solving packed w&b should also be easy.

This pr is still WIP and not runable so please dont review it in detail, but feel free to leave comments about the main idea.