### PR TITLE
[InstrGen] Add Src input to AvgPoolGradInst

### DIFF
--- a/lib/IR/IRGen.cpp
+++ b/lib/IR/IRGen.cpp
@@ -189,14 +189,16 @@ void IRGenVisitor::post(Node *parent, Node *N) {
   case glow::Kinded::Kind::AvgPoolGradNodeKind: {
     auto *PG = cast<AvgPoolGradNode>(N);
 
+    auto poolIn = PG->getInput();
     auto poolOut = PG->getOriginalOutputForResult();
+    auto *inW = valueForNode(poolIn);
     auto *outW = valueForNode(poolOut);
     auto *outG = valueForNode(PG->getGradOfOriginalOutputNamedResult());
 
     auto *inG = builder_.createAllocActivationInst("pool.outG",
                                                    PG->getInput().getType());
 
-    builder_.createAvgPoolGradInst(N->getName(), outW, outG, inG,
+    builder_.createAvgPoolGradInst(N->getName(), outW, inW, outG, inG,
                                    PG->getKernels(), PG->getStrides(),
                                    PG->getPads(), PG->getLayout());
     registerIR(PG->getGradOfInputNamedInput(), inG);

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -153,7 +153,7 @@ int main(int argc, char **argv) {
       .addMember(MemberType::Unsigned, "Layout")
       .autoIRGen()
       .autoVerify(VerifyKind::SameElementType, {"Dest", "Src"})
-      .addGradientInstr({"Dest"}, {"Dest", "Src"});
+      .addGradientInstr({"Dest", "Src"}, {"Dest", "Src"});
 
   BB.newInstr("ArgMax")
       .addOperand("Argmax", OperandKind::Out)


### PR DESCRIPTION
**Summary**
This commit adds an input to `AvgPoolGradInst` for the `Src` operand of the
corresponding `AvgPoolInst` because some backends might require this.

**Testing**
All unit tests pass.
