### PR TITLE
[LayoutConverter] Modify convertMaxPoolToNCHWPool to return argmax too

### DIFF
--- a/lib/Backends/OpenCL/Transforms.cpp
+++ b/lib/Backends/OpenCL/Transforms.cpp
@@ -65,8 +65,8 @@ bool OCLBackend::transformPostLowering(Function *F,
         continue;
       }
 
-      auto *NR = convertMaxPoolToNCHWPool(PMN, F);
-      PMN->getResult().replaceAllUsesOfWith(NR);
+      auto results = convertMaxPoolToNCHWPool(PMN, F);
+      PMN->getResult().replaceAllUsesOfWith(results.first);
       changed = true;
       continue;
     }


### PR DESCRIPTION
**Summary**
`MaxPoolNode` has two outputs, `Result` and `Argmax`. The current
implementation of `convertMaxPoolToNCHWPool` returns one `Node`
corresponding to Result, but does not return any node corresponding to
`Argmax`. This commit fixes that by modifying the return type to
`std::pair<Node*, Node*>` and by returning both the `Result` and `Argmax` of
the new `MaxPoolNode` created inside the function (transposed back to the
original NHWC layout).

**Testing**
All unit tests pass.