### PR TITLE
[GradCheckTest] Make pool tests test layout conversion

### DIFF
--- a/tests/unittests/GradCheckTest.cpp
+++ b/tests/unittests/GradCheckTest.cpp
@@ -580,19 +580,20 @@ TEST_P(GradCheck, gradientCheckAvgPool) {
     auto &mod = EE->getModule();
     bindings.clear();
     Function *F = mod.createFunction("main");
-    A = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim, numDim, 1}, "A",
+    A = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim, numDim, 2}, "A",
                               false);
     Exp = mod.createPlaceholder(ElemKind::FloatTy, {1, numOutputElem}, "Exp",
                                 false);
 
     Node *O = F->createAvgPool("pool", A, 3, 3, 1);
     O = F->createTanh("tanh", O);
+    O = F->createSlice("slice", O, {0, 0, 0, 0}, {1, 4, 4, 1});
     O = F->createFullyConnected(bindings, "fc", O, numOutputElem);
     O = F->createRegression("reg", O, Exp);
     result = F->createSave("ret", O);
   }
 
-  Tensor inputs(ElemKind::FloatTy, {1, numDim, numDim, 1});
+  Tensor inputs(ElemKind::FloatTy, {1, numDim, numDim, 2});
   Tensor outputs(ElemKind::FloatTy, {1, numOutputElem});
 
   auto inputsH = inputs.getHandle<>();
@@ -616,19 +617,20 @@ TEST_P(GradCheck, gradientCheckMaxPool) {
     auto &mod = EE->getModule();
     bindings.clear();
     Function *F = mod.createFunction("main");
-    A = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim, numDim, 1}, "A",
+    A = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim, numDim, 2}, "A",
                               false);
     Exp = mod.createPlaceholder(ElemKind::FloatTy, {1, numOutputElem}, "Exp",
                                 false);
 
     MaxPoolNode *P = F->createMaxPool("pool", A, 3, 3, 1);
     Node *O = F->createTanh("tanh", P->getResult());
+    O = F->createSlice("slice", O, {0, 0, 0, 0}, {1, 4, 4, 1});
     O = F->createFullyConnected(bindings, "fc", O, numOutputElem);
     O = F->createRegression("reg", O, Exp);
     result = F->createSave("ret", O);
   }
 
-  Tensor inputs(ElemKind::FloatTy, {1, numDim, numDim, 1});
+  Tensor inputs(ElemKind::FloatTy, {1, numDim, numDim, 2});
   Tensor outputs(ElemKind::FloatTy, {1, numOutputElem});
 
   auto inputsH = inputs.getHandle<>();


### PR DESCRIPTION
**Summary**
This commit modifies the max and average pool tests in `GradCheckTest` to
test layout conversion as well. At present, `NHWC `-> `NCHW` layout
conversion for these test cases ends up becoming a `Reshape`, which can be
a no-op on the device.

**Testing**
These tests are enabled for the `Interpreter`. All unit tests pass.