### PR TITLE
[GraphOptzTest.cpp] added a numerical equivalence check to ZeroArithmetic test

### DIFF
--- a/tests/unittests/GraphOptzTest.cpp
+++ b/tests/unittests/GraphOptzTest.cpp
@@ -1304,6 +1304,13 @@ TEST_F(GraphOptz, ZeroArithmetic) {
   EXPECT_EQ(F_->getNodes().size(), 1);
 
   EXPECT_EQ(O->getInput().getNode(), input);
+
+  optimizedF_ = optimizeFunction(F_);
+
+  bindings_.allocate(mod_.getPlaceholders());
+  bindings_.get(input)->getHandle().randomize(-1.0, 1.0, mod_.getPRNG());
+
+  checkNumericalEquivalence();
 }
 
 /// A test that verifies that arithmetic simplification works correctly when


### PR DESCRIPTION
Summary:
Used checkNumericalEquivalence helper function to add a numerical equivalence check in the ZeroArithmetic test case.

Documentation:
N/A

Test Plan:
./tests/GraphOptzTest 

[==========] Running 104 tests from 4 test cases.
[----------] Global test environment set-up.
[----------] 89 tests from GraphOptz
[ RUN      ] GraphOptz.OptimizeClipFunnel
[       OK ] GraphOptz.OptimizeClipFunnel (1 ms)
[ RUN      ] GraphOptz.DCE
[       OK ] GraphOptz.DCE (2 ms)
[ RUN      ] GraphOptz.DCEwithPredicate
[       OK ] GraphOptz.DCEwithPredicate (2 ms)
[ RUN      ] GraphOptz.liveCodeNotEliminated
[       OK ] GraphOptz.liveCodeNotEliminated (3 ms)
[ RUN      ] GraphOptz.optimizeBatchNormAfterConv
[       OK ] GraphOptz.optimizeBatchNormAfterConv (2 ms)
[ RUN      ] GraphOptz.optimizeBatchNormAfterConvMultiple
[       OK ] GraphOptz.optimizeBatchNormAfterConvMultiple (2 ms)
[ RUN      ] GraphOptz.optimizeBatchNormAfterConvFP16
[       OK ] GraphOptz.optimizeBatchNormAfterConvFP16 (2 ms)
[ RUN      ] GraphOptz.optimizeBatchNormAfterConvWithTransposedWeights
[       OK ] GraphOptz.optimizeBatchNormAfterConvWithTransposedWeights (2 ms)
[ RUN      ] GraphOptz.optimizeBatchNormAfterConvWithReshapeConst
[       OK ] GraphOptz.optimizeBatchNormAfterConvWithReshapeConst (1 ms)
[ RUN      ] GraphOptz.optimizeBatchNormAfterConvWithPred
[       OK ] GraphOptz.optimizeBatchNormAfterConvWithPred (2 ms)
[ RUN      ] GraphOptz.cseRespectsPredicates
[       OK ] GraphOptz.cseRespectsPredicates (1 ms)
[ RUN      ] GraphOptz.optimizeBatchNormAfterConvButConvReused
[       OK ] GraphOptz.optimizeBatchNormAfterConvButConvReused (1 ms)
[ RUN      ] GraphOptz.optimizeBatchNormAfterConvButVarReused
[       OK ] GraphOptz.optimizeBatchNormAfterConvButVarReused (1 ms)
[ RUN      ] GraphOptz.transposeConstant
[       OK ] GraphOptz.transposeConstant (1 ms)
[ RUN      ] GraphOptz.transposeConstantWithPredicate
[       OK ] GraphOptz.transposeConstantWithPredicate (1 ms)
[ RUN      ] GraphOptz.BatchNormAfterConvNotOptimizeForTrain
[       OK ] GraphOptz.BatchNormAfterConvNotOptimizeForTrain (1 ms)
[ RUN      ] GraphOptz.batchNormAfterConvNotOptimizeWhenMoreThanOneUseOfConv
[       OK ] GraphOptz.batchNormAfterConvNotOptimizeWhenMoreThanOneUseOfConv (1 ms)
[ RUN      ] GraphOptz.sinkTransposeBelowRescale
[       OK ] GraphOptz.sinkTransposeBelowRescale (1 ms)
[ RUN      ] GraphOptz.cancelTwoTransposes
[       OK ] GraphOptz.cancelTwoTransposes (6 ms)
[ RUN      ] GraphOptz.cancelTwoTransposesWithPredicate
[       OK ] GraphOptz.cancelTwoTransposesWithPredicate (1 ms)
[ RUN      ] GraphOptz.removeIdentityTranspose
[       OK ] GraphOptz.removeIdentityTranspose (0 ms)
[ RUN      ] GraphOptz.removeIdentityTransposeWithPredicate
[       OK ] GraphOptz.removeIdentityTransposeWithPredicate (1 ms)
[ RUN      ] GraphOptz.mergeNonInverseTransposes
[       OK ] GraphOptz.mergeNonInverseTransposes (0 ms)
[ RUN      ] GraphOptz.sinkTransposeBelowArithmeticNodes
[       OK ] GraphOptz.sinkTransposeBelowArithmeticNodes (1 ms)
[ RUN      ] GraphOptz.sinkTransposeBelowArithmeticNodesWithPredicate
[       OK ] GraphOptz.sinkTransposeBelowArithmeticNodesWithPredicate (0 ms)
[ RUN      ] GraphOptz.sinkReluBelowConcatNodes
[       OK ] GraphOptz.sinkReluBelowConcatNodes (1 ms)
[ RUN      ] GraphOptz.sinkReluBelowConcatNodesWithPredicate
[       OK ] GraphOptz.sinkReluBelowConcatNodesWithPredicate (0 ms)
[ RUN      ] GraphOptz.sinkTransposeBelowConcatNodes
[       OK ] GraphOptz.sinkTransposeBelowConcatNodes (1 ms)
[ RUN      ] GraphOptz.sinkTransposeBelowConcatWithPredicate
[       OK ] GraphOptz.sinkTransposeBelowConcatWithPredicate (1 ms)
[ RUN      ] GraphOptz.sinkTransposeBelowPad
[       OK ] GraphOptz.sinkTransposeBelowPad (0 ms)
[ RUN      ] GraphOptz.mergeConcatNodes
[       OK ] GraphOptz.mergeConcatNodes (1 ms)
[ RUN      ] GraphOptz.CSE
[       OK ] GraphOptz.CSE (0 ms)
[ RUN      ] GraphOptz.SliceOfSplatNode
[       OK ] GraphOptz.SliceOfSplatNode (1 ms)
[ RUN      ] GraphOptz.ZeroArithmetic
[       OK ] GraphOptz.ZeroArithmetic (0 ms)
[ RUN      ] GraphOptz.ZeroArithmeticParentsMustBeSimplifiedFirst
[       OK ] GraphOptz.ZeroArithmeticParentsMustBeSimplifiedFirst (1 ms)
[ RUN      ] GraphOptz.ArithmeticIdentitiesOne
[       OK ] GraphOptz.ArithmeticIdentitiesOne (0 ms)
[ RUN      ] GraphOptz.ReshapeNoop
[       OK ] GraphOptz.ReshapeNoop (1 ms)
[ RUN      ] GraphOptz.ReshapeAfterSplat
[       OK ] GraphOptz.ReshapeAfterSplat (0 ms)
[ RUN      ] GraphOptz.ReshapeReshapeOpt
[       OK ] GraphOptz.ReshapeReshapeOpt (1 ms)
[ RUN      ] GraphOptz.DCEPublicVars
[       OK ] GraphOptz.DCEPublicVars (0 ms)
[ RUN      ] GraphOptz.foldQuantizeIntoVar
[       OK ] GraphOptz.foldQuantizeIntoVar (1 ms)
[ RUN      ] GraphOptz.foldQuantizeIntoVarMultipleUsages
[       OK ] GraphOptz.foldQuantizeIntoVarMultipleUsages (0 ms)
[ RUN      ] GraphOptz.foldQuantizeIntoSplat
[       OK ] GraphOptz.foldQuantizeIntoSplat (1 ms)
[ RUN      ] GraphOptz.foldDequantizeIntoSplat
[       OK ] GraphOptz.foldDequantizeIntoSplat (0 ms)
[ RUN      ] GraphOptz.foldQuantizeIntoSplatMultipleUsers
[       OK ] GraphOptz.foldQuantizeIntoSplatMultipleUsers (1 ms)
[ RUN      ] GraphOptz.removeUnnecessaryRescale
[       OK ] GraphOptz.removeUnnecessaryRescale (0 ms)
[ RUN      ] GraphOptz.mergeRescaleIntoDequantize
[       OK ] GraphOptz.mergeRescaleIntoDequantize (1 ms)
[ RUN      ] GraphOptz.quantizeToRescale
[       OK ] GraphOptz.quantizeToRescale (0 ms)
[ RUN      ] GraphOptz.MaxOfQuantizedSplat
[       OK ] GraphOptz.MaxOfQuantizedSplat (0 ms)
[ RUN      ] GraphOptz.FuseRescaleIntoArithmetic
[       OK ] GraphOptz.FuseRescaleIntoArithmetic (1 ms)
[ RUN      ] GraphOptz.FuseRescaleUpIntoMatMul
[       OK ] GraphOptz.FuseRescaleUpIntoMatMul (1 ms)
[ RUN      ] GraphOptz.FuseRescaleUpIntoSparseLengthsWeightedSum
[       OK ] GraphOptz.FuseRescaleUpIntoSparseLengthsWeightedSum (0 ms)
[ RUN      ] GraphOptz.fuseRescaleIntoConv
[       OK ] GraphOptz.fuseRescaleIntoConv (1 ms)
[ RUN      ] GraphOptz.fusePadIntoConv
[       OK ] GraphOptz.fusePadIntoConv (1 ms)
[ RUN      ] GraphOptz.fusePadIntoConvNeg1
[       OK ] GraphOptz.fusePadIntoConvNeg1 (0 ms)
[ RUN      ] GraphOptz.fusePadIntoConvNeg2
[       OK ] GraphOptz.fusePadIntoConvNeg2 (1 ms)
[ RUN      ] GraphOptz.MultipleUsersRescaleCombineNoOpt
[       OK ] GraphOptz.MultipleUsersRescaleCombineNoOpt (0 ms)
[ RUN      ] GraphOptz.FuseRescaleIntoMatMul
[       OK ] GraphOptz.FuseRescaleIntoMatMul (1 ms)
[ RUN      ] GraphOptz.sinkRescaledQuantizedNode
[       OK ] GraphOptz.sinkRescaledQuantizedNode (1 ms)
[ RUN      ] GraphOptz.mergeRescaleWithArithmeticNode
[       OK ] GraphOptz.mergeRescaleWithArithmeticNode (0 ms)
[ RUN      ] GraphOptz.mergeRescaleWithRelu
[       OK ] GraphOptz.mergeRescaleWithRelu (1 ms)
[ RUN      ] GraphOptz.mergeMatMulNodes
[       OK ] GraphOptz.mergeMatMulNodes (1 ms)
[ RUN      ] GraphOptz.mergeBANodes
[       OK ] GraphOptz.mergeBANodes (1 ms)
[ RUN      ] GraphOptz.eliminateNoopTile
[       OK ] GraphOptz.eliminateNoopTile (4 ms)
[ RUN      ] GraphOptz.FoldTileAddIntoBatchedAdd
[       OK ] GraphOptz.FoldTileAddIntoBatchedAdd (1 ms)
[ RUN      ] GraphOptz.concatElim
[       OK ] GraphOptz.concatElim (1 ms)
[ RUN      ] GraphOptz.concatReshapes
[       OK ] GraphOptz.concatReshapes (1 ms)
[ RUN      ] GraphOptz.VarsCSE
[       OK ] GraphOptz.VarsCSE (0 ms)
[ RUN      ] GraphOptz.VarsCSENaN
[       OK ] GraphOptz.VarsCSENaN (1 ms)
[ RUN      ] GraphOptz.simplifyArithmeticMultipleUsers
[       OK ] GraphOptz.simplifyArithmeticMultipleUsers (0 ms)
[ RUN      ] GraphOptz.eliminateSingleConcat
[       OK ] GraphOptz.eliminateSingleConcat (1 ms)
[ RUN      ] GraphOptz.ReshapeConstantOneUse
[       OK ] GraphOptz.ReshapeConstantOneUse (0 ms)
[ RUN      ] GraphOptz.transposeIntoReshapeOptim
[       OK ] GraphOptz.transposeIntoReshapeOptim (1 ms)
[ RUN      ] GraphOptz.mergeTransposeIntoMatMul
[       OK ] GraphOptz.mergeTransposeIntoMatMul (0 ms)
[ RUN      ] GraphOptz.mergeTransposeIntoFC
[       OK ] GraphOptz.mergeTransposeIntoFC (1 ms)
[ RUN      ] GraphOptz.ConvertPlaceholdersToConstants
[       OK ] GraphOptz.ConvertPlaceholdersToConstants (0 ms)
[ RUN      ] GraphOptz.optimizeConversion_i8_i32_i16
[       OK ] GraphOptz.optimizeConversion_i8_i32_i16 (1 ms)
[ RUN      ] GraphOptz.optimizeSameTypeConversions
[       OK ] GraphOptz.optimizeSameTypeConversions (0 ms)
[ RUN      ] GraphOptz.optimizeConvertingBetweenFused
[       OK ] GraphOptz.optimizeConvertingBetweenFused (1 ms)
[ RUN      ] GraphOptz.dceBeforeOptimizeTranpose
[       OK ] GraphOptz.dceBeforeOptimizeTranpose (0 ms)
[ RUN      ] GraphOptz.sinkTransposeBelowChannelShuffleNodesAndEliminate
[       OK ] GraphOptz.sinkTransposeBelowChannelShuffleNodesAndEliminate (1 ms)
[ RUN      ] GraphOptz.QuantizedFC
[       OK ] GraphOptz.QuantizedFC (0 ms)
[ RUN      ] GraphOptz.convertReduceMean2AvgPool
[       OK ] GraphOptz.convertReduceMean2AvgPool (1 ms)
[ RUN      ] GraphOptz.convertBroadcastedBatchMatMulToMatMul
[       OK ] GraphOptz.convertBroadcastedBatchMatMulToMatMul (0 ms)
[ RUN      ] GraphOptz.dceQuantization
[       OK ] GraphOptz.dceQuantization (1 ms)
[ RUN      ] GraphOptz.nopRelu
[       OK ] GraphOptz.nopRelu (0 ms)
[ RUN      ] GraphOptz.constantFoldSingleNode
[       OK ] GraphOptz.constantFoldSingleNode (2 ms)
[ RUN      ] GraphOptz.constantFoldWholeFunction
[       OK ] GraphOptz.constantFoldWholeFunction (3 ms)
[ RUN      ] GraphOptz.SplitFCIntoMultipleOps
[       OK ] GraphOptz.SplitFCIntoMultipleOps (1 ms)
[----------] 89 tests from GraphOptz (80 ms total)

[----------] 1 test from GraphOptzTest
[ RUN      ] GraphOptzTest.SliceOfSplatNodeChain
[       OK ] GraphOptzTest.SliceOfSplatNodeChain (0 ms)
[----------] 1 test from GraphOptzTest (0 ms total)

[----------] 4 tests from GraphFold
[ RUN      ] GraphFold.foldLeakyReluFromSplat
[       OK ] GraphFold.foldLeakyReluFromSplat (0 ms)
[ RUN      ] GraphFold.foldLeakyReluFromConst
[       OK ] GraphFold.foldLeakyReluFromConst (1 ms)
[ RUN      ] GraphFold.foldChannelShuffle
[       OK ] GraphFold.foldChannelShuffle (0 ms)
[ RUN      ] GraphFold.NoFoldChannelShuffle
[       OK ] GraphFold.NoFoldChannelShuffle (0 ms)
[----------] 4 tests from GraphFold (1 ms total)

[----------] 10 tests from TestSinkTranspose/GraphOptzSinkTransposeBelowParametrized
[ RUN      ] TestSinkTranspose/GraphOptzSinkTransposeBelowParametrized.TestSinkTransposeForDifferentCases/0
[       OK ] TestSinkTranspose/GraphOptzSinkTransposeBelowParametrized.TestSinkTransposeForDifferentCases/0 (1 ms)
[ RUN      ] TestSinkTranspose/GraphOptzSinkTransposeBelowParametrized.TestSinkTransposeForDifferentCases/1
[       OK ] TestSinkTranspose/GraphOptzSinkTransposeBelowParametrized.TestSinkTransposeForDifferentCases/1 (0 ms)
[ RUN      ] TestSinkTranspose/GraphOptzSinkTransposeBelowParametrized.TestSinkTransposeForDifferentCases/2
[       OK ] TestSinkTranspose/GraphOptzSinkTransposeBelowParametrized.TestSinkTransposeForDifferentCases/2 (1 ms)
[ RUN      ] TestSinkTranspose/GraphOptzSinkTransposeBelowParametrized.TestSinkTransposeForDifferentCases/3
[       OK ] TestSinkTranspose/GraphOptzSinkTransposeBelowParametrized.TestSinkTransposeForDifferentCases/3 (0 ms)
[ RUN      ] TestSinkTranspose/GraphOptzSinkTransposeBelowParametrized.TestSinkTransposeForDifferentCases/4
[       OK ] TestSinkTranspose/GraphOptzSinkTransposeBelowParametrized.TestSinkTransposeForDifferentCases/4 (1 ms)
[ RUN      ] TestSinkTranspose/GraphOptzSinkTransposeBelowParametrized.TestSinkTransposeWithPredicateForDifferentCases/0
[       OK ] TestSinkTranspose/GraphOptzSinkTransposeBelowParametrized.TestSinkTransposeWithPredicateForDifferentCases/0 (0 ms)
[ RUN      ] TestSinkTranspose/GraphOptzSinkTransposeBelowParametrized.TestSinkTransposeWithPredicateForDifferentCases/1
[       OK ] TestSinkTranspose/GraphOptzSinkTransposeBelowParametrized.TestSinkTransposeWithPredicateForDifferentCases/1 (1 ms)
[ RUN      ] TestSinkTranspose/GraphOptzSinkTransposeBelowParametrized.TestSinkTransposeWithPredicateForDifferentCases/2
[       OK ] TestSinkTranspose/GraphOptzSinkTransposeBelowParametrized.TestSinkTransposeWithPredicateForDifferentCases/2 (0 ms)
[ RUN      ] TestSinkTranspose/GraphOptzSinkTransposeBelowParametrized.TestSinkTransposeWithPredicateForDifferentCases/3
[       OK ] TestSinkTranspose/GraphOptzSinkTransposeBelowParametrized.TestSinkTransposeWithPredicateForDifferentCases/3 (1 ms)
[ RUN      ] TestSinkTranspose/GraphOptzSinkTransposeBelowParametrized.TestSinkTransposeWithPredicateForDifferentCases/4
[       OK ] TestSinkTranspose/GraphOptzSinkTransposeBelowParametrized.TestSinkTransposeWithPredicateForDifferentCases/4 (0 ms)
[----------] 10 tests from TestSinkTranspose/GraphOptzSinkTransposeBelowParametrized (5 ms total)

[----------] Global test environment tear-down
[==========] 104 tests from 4 test cases ran. (86 ms total)
[  PASSED  ] 104 tests.
