### PR TITLE
Add numerical equivalence check to GraphOptz.nopRelu test case.

### DIFF
--- a/tests/unittests/GraphOptzTest.cpp
+++ b/tests/unittests/GraphOptzTest.cpp
@@ -3007,9 +3007,14 @@ TEST_F(GraphOptz, nopRelu) {
   auto *relu = F_->createRELU("relu", in);
   F_->createSave("save", relu);
 
-  ::glow::optimize(F_, CompilationMode::Infer);
+  optimizedF_ = optimizeFunction(F_);
 
-  EXPECT_EQ(F_->getNodes().size(), 1);
+  EXPECT_EQ(optimizedF_->getNodes().size(), 1);
+
+  bindings_.allocate(mod_.getPlaceholders());
+  bindings_.get(in)->getHandle<int8_t>().randomize(-4, 4, mod_.getPRNG());
+
+  checkNumericalEquivalence();
 }
 
 template <typename ElemTy>


### PR DESCRIPTION
Summary:
Added a numerical equivalence check to this test case which checks that both the original and optimized graph return the same result for the same input. 

Fixes T54749244

Test Plan:

=> ctest -R GraphOptz
Test project /Users/lofe/git/glow/build_Debug
    Start 8: GraphOptzTest
1/1 Test #8: GraphOptzTest ....................   Passed    0.09 sec

100% tests passed, 0 tests failed out of 1

Total Test time (real) =   0.10 sec