### PR TITLE
Fix CMake build for "GEMM/Add/SLS performance microbenchmarks"

### DIFF
--- a/tests/benchmark/AddBench.cpp
+++ b/tests/benchmark/AddBench.cpp
@@ -1,0 +1,158 @@
+/**
+ * Copyright (c) 2017-present, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <algorithm>
+#include <array>
+#include <cstdlib>
+#include <future>
+#include <random>
+
+#include "Bench.h"
+
+#include "glow/ExecutionEngine/ExecutionEngine.h"
+#include "glow/Optimizer/GraphOptimizer/GraphOptimizer.h"
+
+using namespace glow;
+
+/*
+ * This class implements an Add benchmark. There are a number of
+ * parallel Add nodes which are created, one per core. Then these are
+ * chained together in multiple layers.
+ */
+class AddBench : public Benchmark {
+  /// Matrices.
+  std::vector<float> a;
+  std::vector<float> b;
+  std::vector<float> c;
+
+  /// Dimensions expressed in libjit's format.
+  size_t n_;
+  size_t numLayers_;
+  PlaceholderBindings bindings_;
+  std::unique_ptr<runtime::HostManager> hostManager_;
+  size_t asyncLaunchSize_;
+  size_t numCores_;
+  const char *backendStr_;
+  const char *dtypeStr_;
+
+public:
+  AddBench(size_t n_, size_t numLayers_, size_t asyncLaunchSize_,
+           size_t numCores_, const char *backendStr_, const char *dtypeStr_)
+      : n_(n_), numLayers_(numLayers_), asyncLaunchSize_(asyncLaunchSize_),
+        numCores_(numCores_), backendStr_(backendStr_), dtypeStr_(dtypeStr_) {}
+
+  void setup() override {
+
+    // Setup host manager
+    std::vector<std::unique_ptr<runtime::DeviceConfig>> configs;
+    auto config = llvm::make_unique<runtime::DeviceConfig>(backendStr_);
+    configs.push_back(std::move(config));
+    hostManager_ = llvm::make_unique<runtime::HostManager>(std::move(configs));
+
+    a.resize(n_);
+    b.resize(n_);
+    c.resize(n_);
+
+    std::unique_ptr<Module> mod(new Module);
+    auto fn = mod->createFunction("singleNode");
+
+    ElemKind dtype = ElemKind::Float16Ty;
+    if (std::string(dtypeStr_) == "Float16") {
+      dtype = ElemKind::Float16Ty;
+    } else if (std::string(dtypeStr_) == "Float32") {
+      dtype = ElemKind::FloatTy;
+    }
+
+    std::vector<Placeholder *> A(numCores_);
+    std::vector<Placeholder *> B(numCores_);
+    std::vector<Placeholder *> output(numCores_);
+    std::vector<Node *> cur(numCores_);
+    for (size_t core = 0; core < numCores_; core++) {
+      A[core] = mod->createPlaceholder(dtype, {n_}, "A" + std::to_string(core),
+                                       false);
+      B[core] = mod->createPlaceholder(dtype, {n_}, "B" + std::to_string(core),
+                                       false);
+      output[core] = mod->createPlaceholder(
+          dtype, {n_}, "output" + std::to_string(core), false);
+      cur[core] = A[core];
+    }
+
+    std::vector<Node *> eltwise(numCores_);
+    for (size_t layer = 0; layer < numLayers_; layer++) {
+      for (size_t core = 0; core < numCores_; core++) {
+        eltwise[core] = fn->createAdd("eltwise" + std::to_string(core) + "_" +
+                                          std::to_string(layer),
+                                      cur[core], B[core]);
+        cur[core] = eltwise[core];
+      }
+    }
+    for (size_t core = 0; core < numCores_; core++) {
+      fn->createSave("save" + std::to_string(core), cur[core], output[core]);
+    }
+
+    CompilationContext ctx;
+    hostManager_->addNetwork(std::move(mod), ctx);
+  }
+
+  void run() override {
+    std::vector<std::promise<void>> promises(asyncLaunchSize_);
+    std::vector<std::future<void>> futures;
+    for (auto &runPromise : promises) {
+      std::unique_ptr<ExecutionContext> contextPtr(new ExecutionContext);
+      futures.push_back(runPromise.get_future());
+      hostManager_->runNetwork(
+          "singleNode", std::move(contextPtr),
+          [&runPromise](runtime::RunIdentifierTy, Error err,
+                        std::unique_ptr<ExecutionContext> /* contextPtr */) {
+            EXIT_ON_ERR(std::move(err));
+            runPromise.set_value();
+          });
+    }
+    for (auto &fut : futures) {
+      fut.wait();
+    }
+  }
+
+  void teardown() override {}
+
+  double gbytes() const { return 2.0 * n_ * (numLayers_ + 2) / 1e9; }
+};
+
+int main(int argc, char *argv[]) {
+  assert(argc == 8);
+  size_t n = atoi(argv[1]);
+  size_t numLayers = atoi(argv[2]);
+  size_t reps = atoi(argv[3]);
+  size_t asyncLaunches = atoi(argv[4]);
+  size_t numCores = atoi(argv[5]);
+  const char *backendStr = argv[6];
+  const char *dtypeStr = argv[7];
+  assert(reps > 0);
+
+  AddBench b(n, numLayers, asyncLaunches, numCores, backendStr, dtypeStr);
+  auto times = bench(&b, reps);
+  double min = *(std::min_element(times.begin(), times.end()));
+  size_t midElt = times.size() / 2;
+  std::nth_element(times.begin(), times.begin() + midElt, times.end());
+  double median = times[midElt];
+  double median_runtime = median / ((double)asyncLaunches);
+  double min_runtime = min / ((double)asyncLaunches);
+  printf(
+      "BenchSummary,AddBench,SW,%4zu,%4zu,%4zu,%4zu,%4zu,%s,%s,%2.6lf,%2.6lf,%"
+      "5.2lf, %5.2lf\n",
+      n, numLayers, reps, asyncLaunches, numCores, backendStr, dtypeStr,
+      median_runtime, min_runtime, b.gbytes() / median_runtime,
+      b.gbytes() / min_runtime);
+}

--- a/tests/benchmark/Bench.h
+++ b/tests/benchmark/Bench.h
@@ -19,6 +19,8 @@
 #include <algorithm>
 #include <chrono>
 #include <limits>
+#include <tuple>
+#include <vector>
 
 namespace glow {
 
@@ -31,19 +33,19 @@ public:
   virtual void teardown() = 0;
 };
 
-/// Run a benchmark \p reps times and report the best execution time.
-double bench(Benchmark *b, size_t reps) {
-  double best = std::numeric_limits<double>::max();
+/// Run a benchmark \p reps times and return the execution times
+std::vector<double> bench(Benchmark *b, size_t reps) {
+  std::vector<double> times(reps);
   b->setup();
   for (size_t i = 0; i < reps; i++) {
     auto start = std::chrono::high_resolution_clock::now();
     b->run();
     auto end = std::chrono::high_resolution_clock::now();
     auto duration = std::chrono::duration<double>(end - start).count();
-    best = std::min(best, duration);
+    times[i] = duration;
   }
   b->teardown();
-  return best;
+  return times;
 }
 
 } // namespace glow

--- a/tests/benchmark/CMakeLists.txt
+++ b/tests/benchmark/CMakeLists.txt
@@ -1,14 +1,38 @@
 if(GLOW_WITH_CPU AND NOT MSVC)
-add_executable(GemmBench
-               GemmBench.cpp)
-target_link_libraries(GemmBench
+add_executable(AddBench
+               AddBench.cpp)
+target_link_libraries(AddBench
                       PRIVATE
+                        ExecutionEngine
+                        Graph
+                        HostManager
                         CPURuntimeNative)
 
 add_executable(ConvBench
                ConvBench.cpp)
 target_link_libraries(ConvBench
                       PRIVATE
+                        ExecutionEngine
+                        CPURuntimeNative)
+
+add_executable(GemmBench
+               GemmBench.cpp)
+target_link_libraries(GemmBench
+                      PRIVATE
+                        ExecutionEngine
+                        Graph
+                        GraphOptimizer
+                        HostManager
+                        CPURuntimeNative)
+
+add_executable(GemmParallelBench
+               GemmParallelBench.cpp)
+target_link_libraries(GemmParallelBench
+                      PRIVATE
+                        ExecutionEngine
+                        Graph
+                        GraphOptimizer
+                        HostManager
                         CPURuntimeNative)
 
 add_executable(RuntimeBench

--- a/tests/benchmark/ConvBench.cpp
+++ b/tests/benchmark/ConvBench.cpp
@@ -139,7 +139,8 @@ int main() {
                   continue;
                 ConvBench b(inputBatch, inputEdgeSize, inputChannels,
                             filterMultiplier, kernelSize, stride, pad, group);
-                auto time = bench(&b, reps);
+                auto times = bench(&b, reps);
+                double time = *(std::min_element(times.begin(), times.end()));
                 printf("%zu, %zu, %zu, %zu, %zu, %zu, %zu, %zu, %f\n",
                        inputBatch, inputEdgeSize, inputChannels,
                        filterMultiplier, kernelSize, stride, pad, group, time);

--- a/tests/benchmark/GemmParallelBench.cpp
+++ b/tests/benchmark/GemmParallelBench.cpp
@@ -18,20 +18,21 @@
 #include <future>
 #include <random>
 
+#include "Bench.h"
+
 #include "glow/ExecutionEngine/ExecutionEngine.h"
 #include "glow/Optimizer/GraphOptimizer/GraphOptimizer.h"
-#include "Bench.h"
 
 using namespace glow;
 
 /*
- * Benchmark an (m x k) * (k x n) = (m x n) matrix multiplication.
+ * Benchmark a number of (m x n) * (n x n) matrix multiplications.
  * There are a number of parallel FC nodes which are created, one per core.
- * Each core handles n/num_cores columns of the weight matrix. Then these are
+ * Each core handles one weight matrix. Then these are
  * chained together in multiple layers. After each layer, output tensor
- * is concatenated into one tensor for consumption in the next layer.
+ * is passed to the next layer.
  */
-class GemmBench : public Benchmark {
+class GemmParallelBench : public Benchmark {
   /// Matrices.
   std::vector<float> a;
   std::vector<float> b;
@@ -49,10 +50,10 @@ class GemmBench : public Benchmark {
   const char *dtypeStr_;
 
 public:
-  GemmBench(size_t m, size_t n, size_t k, size_t numLayers_,
-            size_t asyncLaunchSize_, size_t numCores_, const char *backendStr_,
-            const char *dtypeStr_)
-      : aDims{m, k}, cDims{m, n}, numLayers_(numLayers_),
+  GemmParallelBench(size_t m, size_t n, size_t numLayers_,
+                    size_t asyncLaunchSize_, size_t numCores_,
+                    const char *backendStr_, const char *dtypeStr_)
+      : aDims{m, n}, cDims{m, n}, numLayers_(numLayers_),
         asyncLaunchSize_(asyncLaunchSize_), numCores_(numCores_),
         backendStr_(backendStr_), dtypeStr_(dtypeStr_) {}
 
@@ -60,9 +61,9 @@ public:
 
     // Setup host manager
     std::vector<std::unique_ptr<runtime::DeviceConfig>> configs;
-    configs.push_back(llvm::make_unique<runtime::DeviceConfig>(backendStr_));
+    auto config = llvm::make_unique<runtime::DeviceConfig>(backendStr_);
+    configs.push_back(std::move(config));
     hostManager_ = llvm::make_unique<runtime::HostManager>(std::move(configs));
-
     size_t m = cDims[0];
     size_t n = cDims[1];
     size_t k = aDims[1];
@@ -70,8 +71,6 @@ public:
     b.resize(k * n);
     c.resize(m * n);
 
-    std::unique_ptr<Module> mod(new Module);
-    auto fn = mod->createFunction("singleNode");
     ElemKind dtype = ElemKind::Float16Ty;
     if (std::string(dtypeStr_) == "Float16") {
       dtype = ElemKind::Float16Ty;
@@ -79,37 +78,49 @@ public:
       dtype = ElemKind::FloatTy;
     }
 
-    auto *input = mod->createPlaceholder(dtype, {m, k}, "input", false);
-    auto *output = mod->createPlaceholder(dtype, {m, n}, "output", false);
-    Node *cur = input;
+    std::unique_ptr<Module> mod(new Module);
+    auto fn = mod->createFunction("singleNode");
+
+    std::vector<Node *> cur(numCores_);
     std::vector<Placeholder *> weights(numCores_);
     std::vector<Placeholder *> bias(numCores_);
     std::vector<Node *> fc(numCores_);
-    Node *concat;
+    std::vector<Placeholder *> input(numCores_);
+    std::vector<Placeholder *> output(numCores_);
+
+    for (size_t core = 0; core < numCores_; core++) {
+      input[core] = mod->createPlaceholder(
+          dtype, {m, k}, "input" + std::to_string(core), false);
+      output[core] = mod->createPlaceholder(
+          dtype, {m, n}, "output" + std::to_string(core), false);
+      cur[core] = input[core];
+    }
+
     for (size_t layer = 0; layer < numLayers_; layer++) {
       for (size_t core = 0; core < numCores_; core++) {
         weights[core] = mod->createPlaceholder(
-            dtype, {k, n / numCores_}, "weights" + std::to_string(core), false);
+            dtype, {k, n}, "weights" + std::to_string(core), false);
         bias[core] = mod->createPlaceholder(
-            dtype, {n / numCores_}, "bias" + std::to_string(core), false);
+            dtype, {n}, "bias" + std::to_string(core), false);
         bindings_.allocate(weights[core])->getHandle<float16_t>().clear(0);
         bindings_.allocate(bias[core])->getHandle<float16_t>().clear(32);
-        fc[core] = fn->createFullyConnected("fc" + std::to_string(core) + "_" +
-                                                std::to_string(layer),
-                                            cur, weights[core], bias[core]);
+        fc[core] = fn->createFullyConnected(
+            "fc" + std::to_string(core) + "_" + std::to_string(layer),
+            cur[core], weights[core], bias[core]);
+        cur[core] = fc[core];
       }
-
-      std::vector<NodeValue> fcNv;
-      for (auto _fc : fc) {
-        fcNv.push_back(_fc);
-      }
-      concat = fn->createConcat("concat_" + std::to_string(layer), fcNv, 1);
-      cur = concat;
     }
-    fn->createSave("save1", cur, output);
+    for (int core = 0; core < numCores_; core++) {
+      fn->createSave("save" + std::to_string(core), cur[core], output[core]);
+    }
 
-    ::glow::convertPlaceholdersToConstants(fn, bindings_, {input, output});
-
+    for (int core = 0; core < numCores_; core++) {
+      ::glow::convertPlaceholdersToConstants(fn, bindings_,
+                                             {
+                                                 input[core],
+                                                 output[core],
+                                             });
+    }
     CompilationContext ctx;
     hostManager_->addNetwork(std::move(mod), ctx);
   }
@@ -136,23 +147,23 @@ public:
   void teardown() override {}
 
   double gflops() const {
-    return 2.0 * cDims[0] * cDims[1] * aDims[1] * numLayers_ / 1e9;
+    return 2.0 * cDims[0] * cDims[1] * aDims[1] * numLayers_ * numCores_ / 1e9;
   }
 };
 
 int main(int argc, char *argv[]) {
-  assert(argc == 10);
+  assert(argc == 9);
   size_t m = atoi(argv[1]);
   size_t n = atoi(argv[2]);
-  size_t k = atoi(argv[3]);
-  size_t numLayers = atoi(argv[4]);
-  size_t reps = atoi(argv[5]);
-  size_t asyncLaunches = atoi(argv[6]);
-  size_t numCores = atoi(argv[7]);
-  const char *backendStr = argv[8];
-  const char *dtypeStr = argv[9];
-  GemmBench b(m, n, k, numLayers, asyncLaunches, numCores, backendStr,
-              dtypeStr);
+  size_t numLayers = atoi(argv[3]);
+  size_t reps = atoi(argv[4]);
+  size_t asyncLaunches = atoi(argv[5]);
+  size_t numCores = atoi(argv[6]);
+  const char *backendStr = argv[7];
+  const char *dtypeStr = argv[8];
+
+  GemmParallelBench b(m, n, numLayers, asyncLaunches, numCores, backendStr,
+                      dtypeStr);
   auto times = bench(&b, reps);
   double min = *(std::min_element(times.begin(), times.end()));
   size_t midElt = times.size() / 2;
@@ -161,9 +172,9 @@ int main(int argc, char *argv[]) {
   double median_runtime = median / ((double)asyncLaunches);
   double min_runtime = min / ((double)asyncLaunches);
   printf(
-      "BenchSummary,GemmBench,SW,%4zu,%4zu,%4zu,%4zu,%4zu,%4zu,%4zu,%s,%s,%2."
-      "6lf,%2.6lf,%5.2lf, %5.2lf\n",
-      m, n, k, numLayers, reps, asyncLaunches, numCores, backendStr, dtypeStr,
+      "BenchSummary,GemmParallelBench,SW,%4zu,%4zu,%4zu,%4zu,%4zu,%4zu,%s,%s,%"
+      "2.6lf,%2.6lf,%5.2lf, %5.2lf\n",
+      m, n, numLayers, reps, asyncLaunches, numCores, backendStr, dtypeStr,
       median_runtime, min_runtime, b.gflops() / median_runtime,
       b.gflops() / min_runtime);
 }


### PR DESCRIPTION
Summary: A few fixes were needed here:
- Use relative include for Bench.h
- Depend on ExecutionEngine (and some other things) in benchmarks/CMakeLists.txt
- Fix compiler warnings (unused member bDims)