### PR TITLE
[NodeBuilder][trivial] Allow for multiple VectorNodeValue members

### DIFF
--- a/tools/ClassGen/NodeBuilder.cpp
+++ b/tools/ClassGen/NodeBuilder.cpp
@@ -323,10 +323,12 @@ void NodeBuilder::emitPrettyPrinter(std::ostream &os) const {
     }
 
     // Make sure that inputs are properly indexed.
+    os << "  {\n";
     os << "  unsigned mIndex = 0;\n";
     os << "  for (const auto &II : get" << mem.second << "()) {\n"
        << "    db.addParam(\"" << mem.second
        << "\"+std::to_string(mIndex++), *II.getType());\n"
+       << "  }\n"
        << "  }\n";
   }
 


### PR DESCRIPTION
Summary: `mIndex` is declared in the local scope and so it causes compilation issues if there are multiple `VectorNodeValue` for a node. Fix by putting in a nested scope.

Test Plan: Tested locally with a private backend.
