### PR TITLE
Refactored load device config functionality 

### DIFF
--- a/include/glow/Runtime/HostManager/HostManager.h
+++ b/include/glow/Runtime/HostManager/HostManager.h
@@ -213,6 +213,14 @@ public:
 
   ~HostManager();
 };
+
+/// If the device config file specified in loadDeviceConfigsFileOpt is
+/// available, load \p configs from the file. Otherwise, create \p numDevices
+/// number of devices based on \p backendName.
+std::vector<std::unique_ptr<runtime::DeviceConfig>>
+generateDeviceConfigs(unsigned int numDevices, llvm::StringRef backendName,
+                      size_t memSize = 0);
+
 } // namespace runtime
 } // namespace glow
 #endif // GLOW_RUNTIME_HOSTMANAGERR_HOSTMANAGER_H


### PR DESCRIPTION

Summary:
Refactored load device config functionality from loader into HostManager  this way it can be used elsewhere like in Recommendation System Test.
Documentation: 

[Fixes #3556 ]

Test Plan:
./image-classifier  ../images/imagenet/*.png -m=resnet50 -model-input-name=gpu_0/data -image-mode=0to1 -use-imagenet-normalization -load-profile=resnet50.yaml -load-device-configs="cpuConfigs.yaml"

./tests/CPURecommendationSystemTest -load-device-configs="cpuConfigs.yaml"
