### PR TITLE
Move FoldTileAddIntoBatchedAdd out of the default pipeline and into Backend::getOptimizationPipeline()

### DIFF
--- a/include/glow/Optimizer/GraphOptimizerPipeline/Pipeline.h
+++ b/include/glow/Optimizer/GraphOptimizerPipeline/Pipeline.h
@@ -127,6 +127,9 @@ public:
   /// Push a new \p FPC to the end of the pipeline.
   void pushBack(FunctionPassConfig FPC) { push_back(FPC); }
 
+  /// Push a new \p FPC to the start of the pipeline.
+  void pushFront(FunctionPassConfig FPC) { insert(begin(), FPC); }
+
   /// Removes all instances of a pass with ID \p FPID.
   void removeAllInstancesOfPass(FunctionPassID FPID);
 

--- a/lib/Backend/Backend.cpp
+++ b/lib/Backend/Backend.cpp
@@ -180,5 +180,10 @@ bool Backend::verify(const IRFunction &IR) const {
 }
 
 FunctionPassPipeline Backend::getOptimizationPipeline() const {
-  return createDefaultGraphOptimizationPassPipeline();
+  auto p = createDefaultGraphOptimizationPassPipeline();
+  // Fold Tile followed by Add into BatchedAdd. Currently this is not part of
+  // the default pipeline to avoid issues with some backends. If backends do not
+  // want this opt then they should override getOptimizationPipeline().
+  p.pushFront({FunctionPassID::FoldTileAddIntoBatchedAdd});
+  return p;
 };

--- a/lib/Optimizer/GraphOptimizerPipeline/Pipeline.cpp
+++ b/lib/Optimizer/GraphOptimizerPipeline/Pipeline.cpp
@@ -54,9 +54,6 @@ FunctionPassPipeline glow::createDefaultGraphOptimizationPassPipeline() {
       // Merge multiple matmul nodes into a single large matmul.
       {FunctionPassID::MergeMatMul},
 
-      // Fold Tile followed by Add into BatchedAdd.
-      {FunctionPassID::FoldTileAddIntoBatchedAdd},
-
       // Merge multiple batched adds into a larger batched add.
       {FunctionPassID::MergeBatchedAdd},
 


### PR DESCRIPTION
Summary: We need to disable FoldTileAddIntoBatchedAdd from backend-independent optimizations, as it is currently causing an issue for a private backend. Add it to `Backend::getOptimizationPipeline()` so it will be added by default to backend-specific optimizations, and then backends can opt out if they want.

Differential Revision: D17638252

