### PR TITLE
[unittests] Update gtest to v1.10.0 and start using GTEST_SKIP()

### DIFF
--- a/tests/stress/ParameterSweepTest.cpp
+++ b/tests/stress/ParameterSweepTest.cpp
@@ -35,7 +35,7 @@ using llvm::cast;
 
 /// This matches the signature that is used for the parameterized tests here,
 /// i.e. those passing three parameters via a single ::testing::Combine() into
-/// INSTANTIATE_TEST_CASE_P_FOR_BACKEND_COMBINED_TEST().
+/// GLOW_INSTANTIATE_TEST_SUITE_P_FOR_BACKEND_COMBINED_TEST().
 using ThreeIntTupleConfig = std::tuple<std::string, std::tuple<int, int, int>>;
 using FourIntTupleConfig =
     std::tuple<std::string, std::tuple<int, int, int, int>>;
@@ -104,7 +104,7 @@ static void testParamSweepConv(ThreeIntTupleConfig config,
 
 DECLARE_STATELESS_BACKEND_TEST(ConvSweepTest, ThreeIntTupleConfig);
 
-INSTANTIATE_TEST_CASE_P_FOR_BACKEND_COMBINED_TEST(
+GLOW_INSTANTIATE_TEST_SUITE_P_FOR_BACKEND_COMBINED_TEST(
     SweepTest, ConvSweepTest,
     ::testing::Combine(/* size */ ::testing::Values(5, 7, 15),
                        /* depth */ ::testing::Values(8, 64),
@@ -181,7 +181,7 @@ static void testParamSweepBatchMatMul(ThreeIntTupleConfig config,
 
 DECLARE_STATELESS_BACKEND_TEST(BatchMatMulSweepTest, ThreeIntTupleConfig);
 
-INSTANTIATE_TEST_CASE_P_FOR_BACKEND_COMBINED_TEST(
+GLOW_INSTANTIATE_TEST_SUITE_P_FOR_BACKEND_COMBINED_TEST(
     SweepTest, BatchMatMulSweepTest,
     ::testing::Combine(/* N */ ::testing::Values(1, 4, 16, 24),
                        /* A */ ::testing::Range(10, 16),
@@ -257,7 +257,7 @@ static void testParamSweepFC(ThreeIntTupleConfig config,
 
 DECLARE_STATELESS_BACKEND_TEST(FCSweepTest, ThreeIntTupleConfig);
 
-INSTANTIATE_TEST_CASE_P_FOR_BACKEND_COMBINED_TEST(
+GLOW_INSTANTIATE_TEST_SUITE_P_FOR_BACKEND_COMBINED_TEST(
     SweepTest, FCSweepTest,
     ::testing::Combine(
         /* A */ ::testing::Values(1, 4, 16, 64),
@@ -348,7 +348,7 @@ static void testParamSweepConcat(FourIntTupleConfig config,
 
 DECLARE_STATELESS_BACKEND_TEST(ConcatSweepTest, FourIntTupleConfig);
 
-INSTANTIATE_TEST_CASE_P_FOR_BACKEND_COMBINED_TEST(
+GLOW_INSTANTIATE_TEST_SUITE_P_FOR_BACKEND_COMBINED_TEST(
     SweepTest, ConcatSweepTest,
     ::testing::Combine(/* numInputs */ ::testing::Values(1, 2, 4, 8, 16, 32, 64,
                                                          128, 192, 256),
@@ -488,7 +488,7 @@ static void testParamSweepSLWS(ThreeIntTupleConfig config,
 
 DECLARE_STATELESS_BACKEND_TEST(SLWSSweepTest, ThreeIntTupleConfig);
 
-INSTANTIATE_TEST_CASE_P_FOR_BACKEND_COMBINED_TEST(
+GLOW_INSTANTIATE_TEST_SUITE_P_FOR_BACKEND_COMBINED_TEST(
     SweepTest, SLWSSweepTest,
     ::testing::Combine(
         /* embeddingRows */ ::testing::Values(100, 1000, 10000, 100000),

--- a/tests/stress/SparseLengthsSumTest.cpp
+++ b/tests/stress/SparseLengthsSumTest.cpp
@@ -174,7 +174,8 @@ TEST_P(SparseLengthsSum, Big) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P_FOR_BACKEND_TEST(SparseLengthsSum, SparseLengthsSum);
+GLOW_INSTANTIATE_TEST_SUITE_P_FOR_BACKEND_TEST(SparseLengthsSum,
+                                               SparseLengthsSum);
 
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -33,6 +33,14 @@ namespace glow {
 
 extern unsigned parCloneCountOpt;
 
+// INSTANTIATE_TEST_CASE_P is deprecated in gtest v1.10.0. For now use it still
+// internally.
+#if FACEBOOK_INTERNAL
+#define GLOW_INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
+#else
+#define GLOW_INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_SUITE_P
+#endif /* FACEBOOK_INTERNAL */
+
 // A test harness to enable a test case for specific backends. A test suite
 // should subclass this and instantiate it as follows:
 //
@@ -40,7 +48,7 @@ extern unsigned parCloneCountOpt;
 //   ...
 // };
 //
-// INSTANTIATE_TEST_CASE_P_FOR_BACKEND_TEST(Prefix, OperationTest);
+// GLOW_INSTANTIATE_TEST_SUITE_P_FOR_BACKEND_TEST(Prefix, OperationTest);
 //
 // A test case is defined using TEST_P(), and ENABLED_BACKENDS() can be used
 // to whitelist certain backends for the test. The absence of ENABLED_BACKENDS()
@@ -98,20 +106,20 @@ static const auto all_backends = ::testing::Values(
     "Interpreter");
 
 // Instantiate parameterized test suite with all available backends.
-#define INSTANTIATE_TEST_CASE_P_FOR_BACKEND_TEST(prefix, test_case_name)       \
-  INSTANTIATE_TEST_CASE_P(prefix, test_case_name, all_backends)
+#define GLOW_INSTANTIATE_TEST_SUITE_P_FOR_BACKEND_TEST(prefix, test_case_name) \
+  GLOW_INSTANTIATE_TEST_SUITE_P(prefix, test_case_name, all_backends)
 
 // Instantiate parameterized test suite with all available backends.
-#define INSTANTIATE_TEST_CASE_P_FOR_BACKEND_COMBINED_TEST(                     \
+#define GLOW_INSTANTIATE_TEST_SUITE_P_FOR_BACKEND_COMBINED_TEST(               \
     prefix, test_case_name, combine)                                           \
-  INSTANTIATE_TEST_CASE_P(prefix, test_case_name,                              \
-                          ::testing::Combine(all_backends, combine))
+  GLOW_INSTANTIATE_TEST_SUITE_P(prefix, test_case_name,                        \
+                                ::testing::Combine(all_backends, combine))
 
 // TODO: Replace return for GTEST_SKIP() so that skipped tests are
 // correctly reported once the macro gets available.
 #define ENABLED_BACKENDS(...)                                                  \
   if (!isEnabledBackend({__VA_ARGS__}))                                        \
-    return;
+    GTEST_SKIP();
 
 /// Blacklist of tests for the current backend under test.
 extern std::set<std::string> backendTestBlacklist;
@@ -121,7 +129,7 @@ extern std::set<std::string> backendTestBlacklist;
 
 /// Intermediate layer of macros to make expansion of defs work correctly.
 #define INSTANTIATE_TEST_INTERNAL(B, T)                                        \
-  INSTANTIATE_TEST_CASE_P(B, T, ::testing::Values(BACKEND_TO_STR(B)));
+  GLOW_INSTANTIATE_TEST_SUITE_P(B, T, ::testing::Values(BACKEND_TO_STR(B)));
 
 /// Instantate a test suite for the backend specified by GLOW_TEST_BACKEND.
 /// Usually this macro will be defined by the build system, to avoid tightly
@@ -133,7 +141,7 @@ extern std::set<std::string> backendTestBlacklist;
 #define CHECK_IF_ENABLED()                                                     \
   if (backendTestBlacklist.count(                                              \
           ::testing::UnitTest::GetInstance()->current_test_info()->name()))    \
-    return;
+    GTEST_SKIP();
 
 /// MockBackend used only for unit testing.
 class MockBackend : public Backend {

--- a/tests/unittests/GraphOptzTest.cpp
+++ b/tests/unittests/GraphOptzTest.cpp
@@ -672,7 +672,7 @@ TEST_P(GraphOptzSinkTransposeBelowParametrized,
   EXPECT_EQ(F_->getNodes().size(), 3);
 }
 
-INSTANTIATE_TEST_CASE_P(
+GLOW_INSTANTIATE_TEST_SUITE_P(
     TestSinkTranspose, GraphOptzSinkTransposeBelowParametrized,
     ::testing::Values(TestSinkTransposeNodesKind::BatchNormalization,
                       TestSinkTransposeNodesKind::Relu,

--- a/tests/unittests/QuantizationTest.cpp
+++ b/tests/unittests/QuantizationTest.cpp
@@ -2389,36 +2389,39 @@ TEST(Quantization, QuantizationZeroUsersResult) {
   EXPECT_TRUE(qTK->getValues().getType()->isQuantizedType());
 }
 
-INSTANTIATE_TEST_CASE_P(Interpreter, Quantization,
-                        ::testing::Values("Interpreter"));
+GLOW_INSTANTIATE_TEST_SUITE_P(Interpreter, Quantization,
+                              ::testing::Values("Interpreter"));
 
 #ifdef GLOW_WITH_CPU
-INSTANTIATE_TEST_CASE_P(CPU, Quantization, ::testing::Values("CPU"));
+GLOW_INSTANTIATE_TEST_SUITE_P(CPU, Quantization, ::testing::Values("CPU"));
 
-INSTANTIATE_TEST_CASE_P(
+GLOW_INSTANTIATE_TEST_SUITE_P(
     InterpAndCPUProfAndQuant, Operator,
     ::testing::Combine(::testing::Values("Interpreter", "CPU"),
                        ::testing::Values("Interpreter", "CPU")));
 
-INSTANTIATE_TEST_CASE_P(
+GLOW_INSTANTIATE_TEST_SUITE_P(
     InterpAndCPUProfAndQuant, InterpAndCPU,
     ::testing::Combine(::testing::Values("Interpreter", "CPU"),
                        ::testing::Values("Interpreter", "CPU")));
 
 #else
-INSTANTIATE_TEST_CASE_P(InterpreterProfAndQuant, Operator,
-                        ::testing::Combine(::testing::Values("Interpreter"),
-                                           ::testing::Values("Interpreter")));
+GLOW_INSTANTIATE_TEST_SUITE_P(
+    InterpreterProfAndQuant, Operator,
+    ::testing::Combine(::testing::Values("Interpreter"),
+                       ::testing::Values("Interpreter")));
 
-INSTANTIATE_TEST_CASE_P(Interpreter, InterpAndCPU,
-                        ::testing::Combine(::testing::Values("Interpreter"),
-                                           ::testing::Values("Interpreter")));
+GLOW_INSTANTIATE_TEST_SUITE_P(
+    Interpreter, InterpAndCPU,
+    ::testing::Combine(::testing::Values("Interpreter"),
+                       ::testing::Values("Interpreter")));
 #endif // GLOW_WITH_CPU
 
 #ifdef GLOW_WITH_OPENCL
-INSTANTIATE_TEST_CASE_P(InterpProfOpenCLQuant, Operator,
-                        ::testing::Combine(::testing::Values("Interpreter"),
-                                           ::testing::Values("OpenCL")));
+GLOW_INSTANTIATE_TEST_SUITE_P(
+    InterpProfOpenCLQuant, Operator,
+    ::testing::Combine(::testing::Values("Interpreter"),
+                       ::testing::Values("OpenCL")));
 #endif // GLOW_WITH_OPENCL
 
 } // namespace glow


### PR DESCRIPTION
Summary: We can start using `GTEST_SKIP()` with v1.10.0. This is much better than early returning, allowing understanding of what is being run vs. skipped.

Test Plan: Everything still passes; skipped tests are now reported as skipped.
