### PR TITLE
Limit operator kind instrumentation test to CPU and Interpreter only

### DIFF
--- a/tests/unittests/TraceEventsTest.cpp
+++ b/tests/unittests/TraceEventsTest.cpp
@@ -143,6 +143,11 @@ public:
       const std::vector<TraceEvent> &traceEvents,
       const std::vector<std::pair<std::string, std::string>> &expected) {
 
+    const auto &backend = GetParam();
+    if (backend != "Interpreter" && backend != "CPU") {
+      return;
+    }
+
     auto map_element = [](const std::map<std::string, std::string> &m,
                           const std::string &k) {
       return m.find(k) == m.end() ? std::string() : m.find(k)->second;


### PR DESCRIPTION
Summary: Limit operator kind instrumentation test to CPU and Interpreter only

Differential Revision: D17751622

