### PR TITLE
Fix TraceEvent::merge

### DIFF
--- a/include/glow/ExecutionContext/TraceEvents.h
+++ b/include/glow/ExecutionContext/TraceEvents.h
@@ -213,10 +213,11 @@ public:
   void dump(llvm::StringRef filename, const std::string &processName = "");
 
   /// Moves all TraceEvents and thread names in \p other into this context.
+  /// This will clear in the input TraceContext.
   void merge(TraceContext *other);
 
   /// Moves all TraceEvents and thread names in \p other into this context.
-  /// This version is destructive of the other TraceContext.
+  /// This will clear in the input TraceContext.
   void merge(std::unique_ptr<TraceContext> other) { merge(other.get()); }
 };
 

--- a/lib/ExecutionContext/TraceEvents.cpp
+++ b/lib/ExecutionContext/TraceEvents.cpp
@@ -167,6 +167,7 @@ void TraceContext::merge(TraceContext *other) {
   auto &newEvents = other->getTraceEvents();
   std::move(newEvents.begin(), newEvents.end(),
             std::back_inserter(getTraceEvents()));
+  newEvents.clear();
   auto &names = other->getThreadNames();
   threadNames_.insert(names.begin(), names.end());
   names.clear();

--- a/tests/unittests/TraceEventsTest.cpp
+++ b/tests/unittests/TraceEventsTest.cpp
@@ -816,4 +816,31 @@ TEST(TraceEventsTest, TraceLevels) {
   ASSERT_EQ(context.getTraceEvents().size(), 2);
 }
 
+TEST(TraceEventsTest, MergeEvents) {
+  auto tc1 = llvm::make_unique<TraceContext>(TraceLevel::STANDARD);
+  auto tc2 = llvm::make_unique<TraceContext>(TraceLevel::STANDARD);
+
+  TRACE_EVENT_BEGIN(tc1, TraceLevel::RUNTIME, "ev1");
+  TRACE_EVENT_END(tc1, TraceLevel::RUNTIME, "ev1");
+
+  ASSERT_EQ(tc1->getTraceEvents().size(), 2);
+  ASSERT_EQ(tc2->getTraceEvents().size(), 0);
+
+  tc2->merge(tc1.get());
+
+  ASSERT_EQ(tc1->getTraceEvents().size(), 0);
+  ASSERT_EQ(tc2->getTraceEvents().size(), 2);
+
+  TRACE_EVENT_BEGIN(tc1, TraceLevel::RUNTIME, "ev2");
+  TRACE_EVENT_END(tc1, TraceLevel::RUNTIME, "ev2");
+
+  ASSERT_EQ(tc1->getTraceEvents().size(), 2);
+  ASSERT_EQ(tc2->getTraceEvents().size(), 2);
+
+  tc2->merge(tc1.get());
+
+  ASSERT_EQ(tc1->getTraceEvents().size(), 0);
+  ASSERT_EQ(tc2->getTraceEvents().size(), 4);
+}
+
 INSTANTIATE_BACKEND_TEST(TraceEventsTest);


### PR DESCRIPTION
Summary: TraceEvent::merge is intended to be destructive on the input TraceEvent, but was not clearing the vector - leaving it full of blank events. This is breaking TraceEvents in the image classifier.

Documentation: NA
Test Plan: new test!