### PR TITLE
fix image classifier when tracing batches

### DIFF
--- a/tools/loader/Loader.h
+++ b/tools/loader/Loader.h
@@ -110,6 +110,11 @@ public:
   /// tensors include quantization profile guided information.
   void runInference(PlaceholderBindings &bindings, size_t batchSize = 1);
 
+  /// Runs inference, \p context binds both Tensors to Placeholders and
+  /// potentially holds a TraceContext. This method allows obtaining TraceEvents
+  /// from the run.
+  void runInference(ExecutionContext *context, size_t batchSize = 1);
+
   /// Generates and serializes the quantization infos after gathering a profile
   /// by running inference one or more times. \p bindings
   /// binds specific placeholders to concrete tensors. The concrete tensors


### PR DESCRIPTION
Summary: The image-classifier has multiple paths to running the inference, and TraceEvents only worked in one of them (single image no batch). This fixes the other path to supply and merge a TraceContext so we can trace many runs.

![image](https://user-images.githubusercontent.com/701287/66227258-adadb680-e691-11e9-85ee-1497e92fb163.png)

This is a bit hacky, we should not have multiple paths in image-classifier but that's a bigger task (i'm looking at it). Would like to land this to unblock in the short term.

Documentation: NFC

Test Plan: unit tests && tests/images/run.sh