### PR TITLE
add ReluInst for backends that don't lower Relu

### DIFF
--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -1139,6 +1139,11 @@ void BoundInterpreterFunction::fwdAvgPoolGradInst(const AvgPoolGradInst *I) {
 //===----------------------------------------------------------------------===//
 //                       Activation functions
 //===----------------------------------------------------------------------===//
+
+void BoundInterpreterFunction::fwdReluInst(const ReluInst *) {
+  DCHECK(!"Found ReluInst but Relu is lowered on Interpreter");
+}
+
 template <typename ElemTy>
 void BoundInterpreterFunction::fwdSigmoidInstFloatImpl(const SigmoidInst *I) {
   staticAssertFloatingPointType(ElemTy);

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -529,6 +529,16 @@ int main(int argc, char **argv) {
   //===--------------------------------------------------------------------===//
   //                Non-linearities
   //===--------------------------------------------------------------------===//
+  BB.newInstr("Relu")
+      .addOperand("Dest", OperandKind::Out)
+      .addOperand("Src", OperandKind::In)
+      .inplaceOperand({
+          "Dest",
+          "Src",
+      })
+      .dataParallel()
+      .autoVerify(VerifyKind::SameType, {"Dest", "Src"})
+      .autoIRGen();
 
   BB.newInstr("Sigmoid")
       .addOperand("Dest", OperandKind::Out)
@@ -538,8 +548,7 @@ int main(int argc, char **argv) {
           "Src",
       })
       .dataParallel()
-      .autoVerify(VerifyKind::SameElementType, {"Dest", "Src"})
-      .autoVerify(VerifyKind::SameShape, {"Dest", "Src"})
+      .autoVerify(VerifyKind::SameType, {"Dest", "Src"})
       .autoIRGen();
 
   BB.newInstr("Tanh")
@@ -550,8 +559,7 @@ int main(int argc, char **argv) {
           "Src",
       })
       .dataParallel()
-      .autoVerify(VerifyKind::SameElementType, {"Dest", "Src"})
-      .autoVerify(VerifyKind::SameShape, {"Dest", "Src"})
+      .autoVerify(VerifyKind::SameType, {"Dest", "Src"})
       .autoIRGen();
 
   //===--------------------------------------------------------------------===//


### PR DESCRIPTION
Summary: Add an Instruction equivalent to ReluNode so it can be used in backends if they wish to disabled Relu lowering.

Documentation: NFC

Test Plan: No backends use Relu Instructions yet, so no tests.