### PR TITLE
[OpenCL] Add src operand to maxpoolgrad kernel

### DIFF
--- a/lib/Backends/OpenCL/kernels.cl
+++ b/lib/Backends/OpenCL/kernels.cl
@@ -1322,11 +1322,13 @@ __kernel void maxpoolwithargmaxgradK(__global float *dest,
 }
 
 __kernel void maxpoolwithargmaxgradW(__global void *mem, cl_uint32_t dest,
-                                     cl_uint32_t argmax, cl_uint32_t destGrad,
-                                     cl_uint32_t srcGrad,
+                                     cl_uint32_t src, cl_uint32_t argmax,
+                                     cl_uint32_t destGrad, cl_uint32_t srcGrad,
                                      cl_uint32_t kernelSize, cl_uint32_t stride,
                                      PaddingTLBR pads, ShapeNHWC srcGradDim,
                                      ShapeNHWC destDim) {
+  // src operand is present on the instruction but not needed by the OpenCL
+  // kernel.
   maxpoolwithargmaxgradK(&mem[dest], &mem[argmax], &mem[destGrad],
                          &mem[srcGrad], kernelSize, stride, pads, srcGradDim,
                          destDim);


### PR DESCRIPTION
**Summary**
This commit adds a src operand to the OpenCL maxpoolgrad kernel. This
operand was added to the `MaxPoolWithArgmaxGradInst` class in an earlier
commit, but was not added to the corresponding OpenCL kernel. This
broke the code in the OpenCL backend that sets kernel arguments using
operands from the corresponding instruction because it sets them in the order
of that they are declared in the instruction class.

**Testing**
All unit tests pass.