### PR TITLE
Increase allowedError for Interpreter comparison

### DIFF
--- a/tests/unittests/RecommendationSystemTest.cpp
+++ b/tests/unittests/RecommendationSystemTest.cpp
@@ -855,7 +855,7 @@ protected:
 
     assert(resultTensor && "Must run and set resultTensor before comparing "
                            "against the intepreter.");
-    EXPECT_TRUE(resultIT->isEqual(*resultTensor));
+    EXPECT_TRUE(resultIT->isEqual(*resultTensor, 0.005));
   }
 
   /// Create partitions to run and compare results.


### PR DESCRIPTION
Summary: Instead of requiring the backend and Interpreter to be within the default `allowedError == 0.0001`, relax this to `0.005`.

Differential Revision: D17777645

