### PR TITLE
Move useSymmetricRowwiseQuantFC to be backend-parameterized

### DIFF
--- a/lib/Backends/CPU/tests/CPURecommendationSystemTest.cpp
+++ b/lib/Backends/CPU/tests/CPURecommendationSystemTest.cpp
@@ -31,3 +31,5 @@ std::set<std::string> glow::backendTestBlacklist = {
     "RecSys_Partitioned_RWQuantizedFP16_SLWS_FP16/0",
     "RecSys_Partitioned_RWQuantizedFP16AccumFP16_SLWS_FP16/0",
 };
+
+bool glow::useSymmetricRowwiseQuantFC = false;

--- a/lib/Backends/Habana/tests/HabanaRecommendationSystemTest.cpp
+++ b/lib/Backends/Habana/tests/HabanaRecommendationSystemTest.cpp
@@ -34,3 +34,5 @@ std::set<std::string> glow::backendTestBlacklist = {
     "RecSys_Partitioned_RWQuantizedFP16AccumFP16_SLWS_FP16/0",
     "RecSys_FP32_Gather_Weights/0",
 };
+
+bool glow::useSymmetricRowwiseQuantFC = false;

--- a/lib/Backends/Interpreter/tests/InterpreterRecommendationSystemTest.cpp
+++ b/lib/Backends/Interpreter/tests/InterpreterRecommendationSystemTest.cpp
@@ -18,3 +18,5 @@
 using namespace glow;
 
 std::set<std::string> glow::backendTestBlacklist = {};
+
+bool glow::useSymmetricRowwiseQuantFC = false;

--- a/lib/Backends/OpenCL/tests/OpenCLRecommendationSystemTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLRecommendationSystemTest.cpp
@@ -38,3 +38,5 @@ std::set<std::string> glow::backendTestBlacklist = {
     "RecSys_Partitioned_RWQuantized_SLWS_FC_FP16/0",
     "RecSys_RWQuantized_SLWS_FC_FP16/0",
 };
+
+bool glow::useSymmetricRowwiseQuantFC = false;

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -124,6 +124,9 @@ static const auto all_backends = ::testing::Values(
 /// Blacklist of tests for the current backend under test.
 extern std::set<std::string> backendTestBlacklist;
 
+/// Bool for whether to use symmetric quantization for rowwise-quantized FCs.
+extern bool useSymmetricRowwiseQuantFC;
+
 /// Stringify a macro def.
 #define BACKEND_TO_STR(X) #X
 

--- a/tests/unittests/RecommendationSystemTest.cpp
+++ b/tests/unittests/RecommendationSystemTest.cpp
@@ -116,12 +116,6 @@ llvm::cl::opt<unsigned> numDevicesOpt(
     "num-devices", llvm::cl::desc("Number of devices to use for partitioning."),
     llvm::cl::Optional, llvm::cl::init(6), llvm::cl::cat(recSysTestCat));
 
-llvm::cl::opt<bool> useSymmetricRowwiseQuantFCOpt(
-    "use-symmetric-rowwise-quant-fc",
-    llvm::cl::desc(
-        "Whether to use Symmetric quantization with FCs. Default is false."),
-    llvm::cl::Optional, llvm::cl::init(false), llvm::cl::cat(recSysTestCat));
-
 llvm::cl::opt<std::string> traceDir(
     "trace-dir",
     llvm::cl::desc("Directory used to store Glow trace events files. If not "
@@ -505,7 +499,7 @@ protected:
         mod, internalTypeF, {inputDim, firstIntDim}, "initial_weight");
 
     // Output is size {MB, intermediatDim}
-    quantization::Schema rowwiseQuantSchema = useSymmetricRowwiseQuantFCOpt
+    quantization::Schema rowwiseQuantSchema = useSymmetricRowwiseQuantFC
                                                   ? quantization::Symmetric
                                                   : quantization::Asymmetric;
     Node *initial_layer = F_->createRowwiseQuantizedFullyConnected(

--- a/tests/unittests/RecommendationSystemTest.cpp
+++ b/tests/unittests/RecommendationSystemTest.cpp
@@ -855,7 +855,7 @@ protected:
 
     assert(resultTensor && "Must run and set resultTensor before comparing "
                            "against the intepreter.");
-    EXPECT_TRUE(resultIT->isEqual(*resultTensor));
+    EXPECT_TRUE(resultIT->isEqual(*resultTensor, 0.005));
   }
 
   /// Create partitions to run and compare results.


### PR DESCRIPTION
Summary: Instead of having the flag for symmetric rowwise-quantized FCs as an llvm flag, make built in/parameterized for each backend.

Reviewed By: arunm-git

Differential Revision: D17785576

