### PR TITLE
Control Relocation Model from LLVM Backend

### DIFF
--- a/include/glow/LLVMIRCodeGen/LLVMBackend.h
+++ b/include/glow/LLVMIRCodeGen/LLVMBackend.h
@@ -39,6 +39,8 @@ class LLVMBackend : public BackendUsingGlowIR {
   std::string cpu_;
   /// Code model used by this backend.
   llvm::CodeModel::Model codeModel_;
+  /// Relocation model used by this backend.
+  llvm::Reloc::Model relocModel_;
 
 public:
   LLVMBackend();
@@ -59,6 +61,12 @@ public:
   /// Sets code model used by this backend.
   void setCodeModel(llvm::CodeModel::Model codeModel) {
     codeModel_ = codeModel;
+  }
+  /// \returns relocation model used by this backend.
+  llvm::Reloc::Model getRelocModel() const { return relocModel_; }
+  // Sets Relocation Model used by this backend
+  void setRelocModel(llvm::Reloc::Model relocModel) {
+    relocModel_ = relocModel;
   }
   /// @name Backend methods.
   /// This is the implementation of the Backend interface.

--- a/include/glow/LLVMIRCodeGen/LLVMIRGen.h
+++ b/include/glow/LLVMIRCodeGen/LLVMIRGen.h
@@ -254,7 +254,7 @@ public:
   initTargetMachine(llvm::StringRef target, llvm::StringRef arch,
                     llvm::StringRef cpu,
                     const llvm::SmallVectorImpl<std::string> &targetFeatures,
-                    llvm::CodeModel::Model CM);
+                    llvm::CodeModel::Model CM, llvm::Reloc::Model relocModel);
 
   /// Emit LLVM-IR for the instruction \p I, using the builder \p builder.
   /// Derived classes may want to override this function to implement a

--- a/lib/LLVMIRCodeGen/BundleSaver.cpp
+++ b/lib/LLVMIRCodeGen/BundleSaver.cpp
@@ -287,10 +287,12 @@ void BundleSaver::save(llvm::StringRef target, llvm::StringRef arch,
                        llvm::StringRef cpu,
                        const llvm::SmallVectorImpl<std::string> &targetFeatures,
                        llvm::StringRef outputDir, llvm::StringRef bundleName,
-                       llvm::StringRef mainEnryName) {
+                       llvm::StringRef mainEnryName,
+                       llvm::CodeModel::Model codeModel,
+                       llvm::Reloc::Model relocModel) {
   // Object files generation works properly only in small mode.
-  irgen_->initTargetMachine(target, arch, cpu, targetFeatures,
-                            llvm::CodeModel::Model::Small);
+  irgen_->initTargetMachine(target, arch, cpu, targetFeatures, codeModel,
+                            relocModel);
   irgen_->setOutputDir(outputDir);
   irgen_->setBundleName(bundleName);
   irgen_->setMainEntryName(mainEnryName);

--- a/lib/LLVMIRCodeGen/BundleSaver.h
+++ b/lib/LLVMIRCodeGen/BundleSaver.h
@@ -55,7 +55,8 @@ public:
   void save(llvm::StringRef target, llvm::StringRef arch, llvm::StringRef cpu,
             const llvm::SmallVectorImpl<std::string> &targetFeatures,
             llvm::StringRef outputDir, llvm::StringRef bundleName,
-            llvm::StringRef mainEntryName);
+            llvm::StringRef mainEntryName, llvm::CodeModel::Model codeModel,
+            llvm::Reloc::Model relocModel);
 };
 
 } // namespace glow

--- a/lib/LLVMIRCodeGen/LLVMBackend.cpp
+++ b/lib/LLVMIRCodeGen/LLVMBackend.cpp
@@ -55,6 +55,7 @@ LLVMBackend::LLVMBackend() {
   target_ = llvmTarget;
   cpu_ = llvmCPU;
   codeModel_ = llvm::CodeModel::Model::Large;
+  relocModel_ = llvm::Reloc::Model::Static;
 }
 
 /// Emit the entry point for JIT called "jitmain".
@@ -111,7 +112,7 @@ LLVMBackend::compileIRWithoutConstants(IRFunction *IR) const {
   llvm::SmallVector<std::string, 8> targetFeatures(llvmTargetFeatures.begin(),
                                                    llvmTargetFeatures.end());
   irgen->initTargetMachine(getTarget(), getArch(), getCPU(), targetFeatures,
-                           getCodeModel());
+                           getCodeModel(), getRelocModel());
   irgen->initCodeGen();
   // Perform the address assignment for activations and WeightVars.
 
@@ -160,5 +161,5 @@ void LLVMBackend::save(Function *F, llvm::StringRef outputDir,
   auto IR = generateAndOptimizeIR(F, *this, shouldShareBuffers());
   BundleSaver(IR.get(), *this)
       .save(getTarget(), getArch(), getCPU(), targetFeatures, outputDir,
-            bundleName, mainEntryName);
+            bundleName, mainEntryName, getCodeModel(), getRelocModel());
 }

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -54,15 +54,6 @@ llvm::cl::opt<bool>
     emitDebugInfo("g", llvm::cl::desc("Emit debug information for debuggers"),
                   llvm::cl::init(false), llvm::cl::cat(getLLVMBackendCat()));
 
-llvm::cl::opt<llvm::Reloc::Model> relocModel(
-    "relocation-model",
-    llvm::cl::desc(
-        "Specify which relocation model to use on the target machine"),
-    llvm::cl::values(
-        clEnumValN(llvm::Reloc::Static, "static", "Non-relocatable code"),
-        clEnumValN(llvm::Reloc::PIC_, "pic", "Position independent code")),
-    llvm::cl::init(llvm::Reloc::Static), llvm::cl::cat(getLLVMBackendCat()));
-
 /// Limitation of number of arguments for `emitDataParallelKernel`.
 constexpr static size_t kArgLimit = 64;
 
@@ -106,7 +97,7 @@ LLVMIRGen::LLVMIRGen(const IRFunction *F, AllocationsInfo &allocationsInfo,
 void LLVMIRGen::initTargetMachine(
     llvm::StringRef target, llvm::StringRef arch, llvm::StringRef cpu,
     const llvm::SmallVectorImpl<std::string> &targetFeatures,
-    llvm::CodeModel::Model codeModel) {
+    llvm::CodeModel::Model codeModel, llvm::Reloc::Model relocModel) {
   llvm::InitializeAllTargets();
   llvm::InitializeAllTargetMCs();
   llvm::InitializeAllAsmPrinters();


### PR DESCRIPTION
  Make the Relocation Model determined by the Backend instead of
  an option. Also, fix a bug in BendleSaver where the code model
  was always set to small instead of using what the backend uses.

  Fixes #3608

Summary:

Documentation:

[Optional Fixes #issue]

Test Plan:
 ninja test
Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
