### PR TITLE
Module compilation support

### DIFF
--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -20,9 +20,13 @@
 #include "glow/Base/Tensor.h"
 #include "glow/Base/Type.h"
 
+#include "glow/Runtime/HostManager/HostManager.h"
+
 #include <torch/csrc/jit/ir.h>
 
 namespace glow {
+
+extern bool GlowCompilePyTorchModule;
 /// Various settings to be used by code that loads PyTorch models. There should
 /// only be one of these and it should be obtained by calling
 /// getPyTorchLoaderSettings().
@@ -38,9 +42,18 @@ struct PyTorchLoaderSettings {
   std::string glowBackendName = "Interpreter";
 };
 
+/// Given a PyTorch ScalarType \p ty, \returns a matching Glow ElemKind.
+ElemKind scalarTypeToElemKind(c10::ScalarType ty);
+
+/// Given a c10 typekind \p ty, \returns a matching Glow ElemKind.
+ElemKind typeKindToElemKind(c10::TypeKind ty);
+
 /// \returns the PyTorchLoaderSettings singleton to be used throughout Glow's
 /// PyTorch model loading code.
 PyTorchLoaderSettings &getPyTorchLoaderSettings();
+
+/// \returns the HostManager singleton used to run all PyTorch graphs in Glow.
+runtime::HostManager *getHostManager();
 
 /// \returns the PyTorch symbol to be used for the PyTorch node which represents
 /// the subgraph that Glow will compile and run.
@@ -51,7 +64,7 @@ void glowCustomFuse(std::shared_ptr<torch::jit::Graph> &graph,
                     at::Symbol fuseSymbol);
 
 /// Register the glow::FusionGroup operator.
-void registerGlowOp();
+void registerGlowOp(const c10::Symbol &symbol);
 
 /// Register the pass that fuses parts of the graph into a glow::FusionGroup. \p
 /// enablePassFn is used to enable/disable the glow fusion pass once it's

--- a/torch_glow/src/PyTorchFileLoader.cpp
+++ b/torch_glow/src/PyTorchFileLoader.cpp
@@ -68,7 +68,7 @@ Error loadJitGraphToGlowFunction(
 
   // Load JIT Graph into Glow Function.
   RETURN_IF_ERR(PyTorchModelLoader::loadJITGraph(
-      f, graph, inputs, inputPlaceholders, outputPlaceholders, settings));
+      f, graph, inputPlaceholders, outputPlaceholders, settings, inputs, {}));
 
   // Remove from stack input parameters.
   torch::jit::drop(stack, numInputs);

--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "PyTorchModelLoader.h"
+#include "PyTorchCommon.h"
 
 #include "glow/Support/Error.h"
 #include "glow/Support/Support.h"
@@ -1932,30 +1933,33 @@ Error PyTorchModelLoader::loadConstant(const torch::jit::Node *ptNode) {
 /*static*/
 Error PyTorchModelLoader::loadJITGraph(
     glow::Function &F, const torch::jit::Graph &graph,
-    const at::ArrayRef<torch::jit::IValue> inputs,
     std::vector<glow::Placeholder *> &inputPlaceholders,
     std::vector<glow::Placeholder *> &outputPlaceholders,
-    const PyTorchLoaderSettings &settings) {
+    const PyTorchLoaderSettings &settings,
+    const at::ArrayRef<torch::jit::IValue> inputs,
+    const std::vector<InputMeta> &inputMeta) {
   Error error = Error::empty();
-  PyTorchModelLoader loader(F, graph, inputs, inputPlaceholders,
-                            outputPlaceholders, error, settings,
-                            /*frozenInputIndices*/ nullptr);
+  PyTorchModelLoader loader(F, graph, inputPlaceholders, outputPlaceholders,
+                            error, settings,
+                            /*frozenInputIndices*/ nullptr, inputs, inputMeta);
   return error;
 }
 
 PyTorchModelLoader::PyTorchModelLoader(
     glow::Function &F, const torch::jit::Graph &graph,
-    const at::ArrayRef<torch::jit::IValue> inputs,
     std::vector<glow::Placeholder *> &inputPlaceholders,
     std::vector<glow::Placeholder *> &outputPlaceholders, Error &error,
-    const PyTorchLoaderSettings &settings, std::set<size_t> *frozenInputIndices)
+    const PyTorchLoaderSettings &settings, std::set<size_t> *frozenInputIndices,
+    const at::ArrayRef<torch::jit::IValue> inputs,
+    const std::vector<InputMeta> &inputMeta)
     : F_(F), inputs_(inputs), frozenInputIndices_(frozenInputIndices),
       copyTensorMemory_(false) {
   auto loadFn = [&]() -> Error {
     auto graphInputValues = graph.inputs();
 
     RETURN_ERR_IF_NOT(
-        inputs.size() == graphInputValues.size(),
+        inputs.size() == graphInputValues.size() ||
+            inputMeta.size() == graphInputValues.size(),
         glow::strFormat("Number of Graph inputs %lu must match the "
                         "number of provided inputs %lu.",
                         graphInputValues.size(), inputs.size()));
@@ -1963,19 +1967,39 @@ PyTorchModelLoader::PyTorchModelLoader(
     // Create Glow Placeholders for inputs.
     for (size_t i = 0; i < graphInputValues.size(); ++i) {
       const torch::jit::Value *inputValue = graphInputValues[i];
-      const c10::IValue inputIValue = inputs.at(i);
-      GlowIValue glowIVal;
-      RETURN_IF_ERR(glowIVal.fromIValue(inputIValue));
-      if (glowIVal.isTensor()) {
-        glow::Tensor *t;
-        ASSIGN_VALUE_OR_RETURN_ERR(t, glowIVal.toTensor());
-        glow::Placeholder *ph = F_.getParent()->createPlaceholder(
-            &t->getType(), "input", /*isTrainable*/ false);
+      glow::Placeholder *ph;
+
+      if (!inputMeta.empty()) {
+        if (inputValue->type()->kind() == c10::TypeKind::TensorType) {
+          glow::Type t(scalarTypeToElemKind(inputMeta[i].type),
+                       inputMeta[i].dims);
+          // ASSIGN_VALUE_OR_RETURN_ERR(t, glowIVal.toTensor());
+          ph = F_.getParent()->createPlaceholder(&t, "input",
+                                                 /*isTrainable*/ false);
+        } else {
+          // Here we assume it's scalar type
+          glow::Type t(typeKindToElemKind(inputValue->type()->kind()), {});
+          ph = F_.getParent()->createPlaceholder(&t, "input", false);
+        }
         RETURN_IF_ERR(addValueMapping(inputValue, ph->getOutput()));
         inputPlaceholders.push_back(ph);
         inputPlaceholdersReverseIndex_[ph] = i;
       } else {
-        RETURN_IF_ERR(addValueMapping(inputValue, std::move(glowIVal)));
+        const c10::IValue inputIValue = inputs.at(i);
+        GlowIValue glowIVal;
+        RETURN_IF_ERR(glowIVal.fromIValue(inputIValue));
+        if (glowIVal.isTensor()) {
+          glow::Tensor *t;
+          ASSIGN_VALUE_OR_RETURN_ERR(t, glowIVal.toTensor());
+          // ASSIGN_VALUE_OR_RETURN_ERR(t, glowIVal.toTensor());
+          ph = F_.getParent()->createPlaceholder(&t->getType(), "input",
+                                                 /*isTrainable*/ false);
+          RETURN_IF_ERR(addValueMapping(inputValue, ph->getOutput()));
+          inputPlaceholders.push_back(ph);
+          inputPlaceholdersReverseIndex_[ph] = i;
+        } else {
+          RETURN_IF_ERR(addValueMapping(inputValue, std::move(glowIVal)));
+        }
       }
     }
 
@@ -2017,17 +2041,17 @@ Error PyTorchModelLoader::loadJITGraphForOnnxTraining(
     std::vector<glow::Placeholder *> &inputPlaceholders,
     std::vector<glow::Placeholder *> &outputPlaceholders) {
   Error error = Error::empty();
-  PyTorchModelLoader loader(F, graph, inputs, parameters, inputPlaceholders,
-                            outputPlaceholders, error);
+  PyTorchModelLoader loader(F, graph, parameters, inputPlaceholders,
+                            outputPlaceholders, error, inputs);
   return error;
 }
 
 PyTorchModelLoader::PyTorchModelLoader(
     glow::Function &F, const torch::jit::Graph &graph,
-    const at::ArrayRef<torch::jit::IValue> inputs,
     const std::vector<at::Tensor> &parameters,
     std::vector<glow::Placeholder *> &inputPlaceholders,
-    std::vector<glow::Placeholder *> &outputPlaceholders, Error &error)
+    std::vector<glow::Placeholder *> &outputPlaceholders, Error &error,
+    const at::ArrayRef<torch::jit::IValue> inputs)
     : F_(F), inputs_(inputs), copyTensorMemory_(true) {
 
   auto setup = [&]() -> Error {


### PR DESCRIPTION
Summary:
There are a couple motivations for this change. For some models, e.g. sparseNN, input Tensor shapes are not deterministic and may vary at runtime. To reduce the overhead we want to run compile glow graph using max shapes, e.g. shapes got when using max_batch_size. This compilation is better done ahead of time using external shape and type information instead of depending on JIT stack values.

Also as we are adding profiling to models, users may decide to put computation heavy part into submodules. Therefore add the ability to compile a submodule. Currently we impose a few constraints, e.g. one method per module, and assumes the fusion node is at the top level. These constraints can be relaxed if needed.

The behavior is controlled by a flag - GlowCompilePyTorchModule. Backward compatibility is maintained as we may still need just in time compilation in some cases.

CachingGraphRunner can works as a singleton now.

Differential Revision: D17779645

