### PR TITLE
Allow EE to use user-specified device config

### DIFF
--- a/include/glow/ExecutionEngine/ExecutionEngine.h
+++ b/include/glow/ExecutionEngine/ExecutionEngine.h
@@ -50,6 +50,9 @@ class ExecutionEngine final {
   /// Size of device memory in bytes, if 0 device default is used.
   uint64_t deviceMemory_{0};
 
+  /// Whether to ignore the user-specified DeviceConfig.
+  bool ignoreUserDeviceConfig_{false};
+
   /// The HostManager for executing the compiled functions.
   std::unique_ptr<runtime::HostManager> hostManager_;
 
@@ -62,9 +65,11 @@ class ExecutionEngine final {
 
 public:
   /// Constructor for an ExecutionEngine with \p backend and memory \p
-  /// deviceMemory in bytes.
+  /// deviceMemory in bytes. If \p ignoreUserDeviceConfig then user device
+  /// configs will be ignored.
   ExecutionEngine(llvm::StringRef backend = "Interpreter",
-                  uint64_t deviceMemory = 0);
+                  uint64_t deviceMemory = 0,
+                  bool ignoreUserDeviceConfig = false);
 
   ~ExecutionEngine();
 

--- a/include/glow/Runtime/HostManager/HostManager.h
+++ b/include/glow/Runtime/HostManager/HostManager.h
@@ -221,6 +221,14 @@ std::vector<std::unique_ptr<runtime::DeviceConfig>>
 generateDeviceConfigs(unsigned int numDevices, llvm::StringRef backendName,
                       size_t memSize = 0);
 
+/// Attempts to load user-specified DeviceConfigs file
+/// \ref loadDeviceConfigsFileOpt. If the path exists then \p configs will be
+/// loaded with DeviceConfigs given that file and \p memSize, and the function
+/// \returns true. Otherwise \returns false with \p configs untouched.
+bool loadDeviceConfigsFromFile(
+    std::vector<std::unique_ptr<runtime::DeviceConfig>> &configs,
+    size_t memSize);
+
 } // namespace runtime
 } // namespace glow
 #endif // GLOW_RUNTIME_HOSTMANAGERR_HOSTMANAGER_H

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -27,8 +27,10 @@
 
 using namespace glow;
 
-ExecutionEngine::ExecutionEngine(llvm::StringRef backend, uint64_t deviceMemory)
-    : deviceMemory_(deviceMemory) {
+ExecutionEngine::ExecutionEngine(llvm::StringRef backend, uint64_t deviceMemory,
+                                 bool ignoreUserDeviceConfig)
+    : deviceMemory_(deviceMemory),
+      ignoreUserDeviceConfig_(ignoreUserDeviceConfig) {
   setBackendName(backend);
 }
 
@@ -45,11 +47,21 @@ void ExecutionEngine::setBackendName(llvm::StringRef backend) {
   }
 
   std::vector<std::unique_ptr<runtime::DeviceConfig>> configs;
-  auto config = llvm::make_unique<runtime::DeviceConfig>(backend);
-  if (deviceMemory_) {
-    config->setDeviceMemory(deviceMemory_);
+  if (!ignoreUserDeviceConfig_ &&
+      loadDeviceConfigsFromFile(configs, deviceMemory_)) {
+    // Loaded from file, so verify that there is just a single device configured
+    // and that it matches the expected backend name.
+    CHECK_EQ(configs.size(), 1)
+        << "Expected a single device for the ExecutionEngine";
+    CHECK(backend.str() == configs[0]->backendName)
+        << "Expected backend name to match the ExecutionEngine";
+  } else {
+    auto config = llvm::make_unique<runtime::DeviceConfig>(backend);
+    if (deviceMemory_) {
+      config->setDeviceMemory(deviceMemory_);
+    }
+    configs.push_back(std::move(config));
   }
-  configs.push_back(std::move(config));
   hostManager_ = llvm::make_unique<runtime::HostManager>(std::move(configs));
 }
 

--- a/tests/unittests/BackendTestUtils.cpp
+++ b/tests/unittests/BackendTestUtils.cpp
@@ -80,7 +80,9 @@ profileAndGetNodeQuantizationInfo(CreateAndInitFunction createAndInitFunction,
                                   quantization::Schema schema) {
   LoweredInfoMap loweredMapForProf;
   PlaceholderBindings pBindings;
-  ExecutionEngine PEE{"Interpreter"};
+  // Note: deviceMemory = 0 is a signal to use the defaultMemory.
+  ExecutionEngine PEE{"Interpreter", /* deviceMemory */ 0,
+                      /* ignoreUserDeviceConfig */ true};
   createAndInitFunction(pBindings, PEE);
   CompilationContext cctx{&pBindings, &loweredMapForProf};
   cctx.precisionConfig.quantMode = QuantizationMode::Profile;
@@ -146,7 +148,9 @@ void compareAgainstInterpreter(llvm::StringRef backendName,
                                ElemKind backendElemKind, float allowedError,
                                unsigned count, bool enableRowwiseQuantization,
                                quantization::Schema schema) {
-  ExecutionEngine IEE{"Interpreter"};
+  // Note: deviceMemory = 0 is a signal to use the defaultMemory.
+  ExecutionEngine IEE{"Interpreter", /* deviceMemory */ 0,
+                      /* ignoreUserDeviceConfig */ true};
   ExecutionEngine BEE{backendName};
   PlaceholderBindings iBindings, bBindings;
 


### PR DESCRIPTION
Summary: Allow for the EE to use the `-load-device-configs` option. This required a little bit of refactoring. Additionally because there are some tests that use a second EE for comparing against the Interpreter, added a flag to the EE constructor to ignore the loaded config.

Differential Revision: D17847703

