### PR TITLE
Refactored Provisioner to reduce complexity and memory consumption

### DIFF
--- a/include/glow/Runtime/RuntimeTypes.h
+++ b/include/glow/Runtime/RuntimeTypes.h
@@ -99,6 +99,8 @@ struct DAGNode {
   /// Runtime bundle containing all the symbol information for this network at
   /// runtime.
   std::unique_ptr<RuntimeBundle> runtimeBundle;
+  /// Size of constants and placeholders used by the function.
+  uint64_t size{0};
 
   /// Backend Hints object, this is populated by the Partitioner and is used
   /// to communicated hints to the compiler, like SRAM pinning and resource

--- a/lib/Partitioner/PartitionerBase.cpp
+++ b/lib/Partitioner/PartitionerBase.cpp
@@ -60,6 +60,7 @@ DAGListTy PartitionerBase::doPartitioning(llvm::StringRef funcName,
       subDAG->name = subF->getName();
       subDAG->logicalDevices = mapping.getLogicalDeviceIDList(subF);
       subDAG->backendName = mapping.getPartitionBackendName(subF);
+      subDAG->size = mapping.getGraphMemInfo(subF).getTotalMemSize();
       funcDAG[subF] = subDAG.get();
       nodes.push_back(std::move(subDAG));
     }
@@ -103,6 +104,7 @@ DAGListTy PartitionerBase::doPartitioning(llvm::StringRef funcName,
           subDAG->name = inputF->getName();
           subDAG->logicalDevices = mapping.getLogicalDeviceIDList(inputF);
           subDAG->backendName = mapping.getPartitionBackendName(inputF);
+          subDAG->size = mapping.getGraphMemInfo(inputF).getTotalMemSize();
           funcDAG[inputF] = subDAG.get();
           nodes.push_back(std::move(subDAG));
         }


### PR DESCRIPTION
Summary:
Refactored the provisioner, it now compiles and loads functions one logicalDevice at a time. This will decrease memory overhead. Also tried to split out different phases of provisioning into their own functions so it would be easier to reason over. 

Documentation:

Test Plan: ninja check
