### PR TITLE
[FR2EN] Fix potential illegal access when printing the result

### DIFF
--- a/examples/fr2en.cpp
+++ b/examples/fr2en.cpp
@@ -388,7 +388,10 @@ void Model::translate(const std::vector<std::string> &batch) {
 
       if (i)
         std::cout << ' ';
-      std::cout << en_.index2word_[wordIdx];
+      if (en_.index2word_.size() > (wordIdx))
+        std::cout << en_.index2word_[wordIdx];
+      else
+        std::cout << "[" << wordIdx << "]";
     }
     std::cout << "\n\n";
   }


### PR DESCRIPTION
Summary: When the output is printed the words indices weren't checked before accessing the dictionary.

Documentation:

