### PR TITLE
[OperatorTest] Add tests for all zero lengths SLS

### DIFF
--- a/lib/Backends/CPU/tests/CPUOperatorTest.cpp
+++ b/lib/Backends/CPU/tests/CPUOperatorTest.cpp
@@ -152,4 +152,6 @@ std::set<std::string> glow::backendTestBlacklist = {
     "Tanh_Float16/0",
     "Exp_Float16/0",
     "rowwiseQuantizedSLWSTest/0",
+    "SLSAllZeroLengths_Float16/0",
+    "FusedRWQSLSAllZeroLengths_Float16/0",
 };

--- a/lib/Backends/Habana/tests/HabanaOperatorTest.cpp
+++ b/lib/Backends/Habana/tests/HabanaOperatorTest.cpp
@@ -289,4 +289,8 @@ std::set<std::string> glow::backendTestBlacklist = {
     "Int8ConvolutionDepth10/0",
     "Int8ConvolutionDepth8/0",
     "dotProduct1D_Int8/0",
+    "SLSAllZeroLengths_Float/0",
+    "SLSAllZeroLengths_Float16/0",
+    "FusedRWQSLSAllZeroLengths_Float/0",
+    "FusedRWQSLSAllZeroLengths_Float16/0",
 };

--- a/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
@@ -156,6 +156,10 @@ struct EmulatorOnlyTests {
           "TopK/0",
           "TopK1/0",
           "TransposeIntoReshapeOptim/0",
+          "FusedRWQSLSAllZeroLengths_Float/0",
+          "FusedRWQSLSAllZeroLengths_Float16/0",
+          "SLSAllZeroLengths_Float/0",
+          "SLSAllZeroLengths_Float16/0",
       });
     }
   }

--- a/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
@@ -251,4 +251,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "rowwiseQuantizedFCTest/0",
     "rowwiseQuantizedFCTestSymmetric/0",
     "rowwiseQuantizedSLWSTest/0",
+    "SLSAllZeroLengths_Float16/0",
+    "FusedRWQSLSAllZeroLengths_Float/0",
+    "FusedRWQSLSAllZeroLengths_Float16/0",
 };

--- a/tests/unittests/BackendTestUtils.cpp
+++ b/tests/unittests/BackendTestUtils.cpp
@@ -136,7 +136,9 @@ setupInterpAndBackendConfigs(
   }
 
   precConfigI.convertToFP16 = interpElemKind == ElemKind::Float16Ty;
+  precConfigI.convertFusedToFP16 = interpElemKind == ElemKind::Float16Ty;
   precConfigB.convertToFP16 = backendElemKind == ElemKind::Float16Ty;
+  precConfigB.convertFusedToFP16 = backendElemKind == ElemKind::Float16Ty;
 
   return std::make_pair(cctxI, cctxB);
 }


### PR DESCRIPTION
Summary: Add some missing tests for more corner cases for SLSs. I added Fused RWQ and non RWQ versions of the test. This included updating `compareAgainstInterprerer()` to also do fused FP16 conversion, which hadn't been used by other tests until now. Note that I blacklisted Habana for these tests for now as I haven't yet tested it there, may enable in the future.
