### PR TITLE
Initial step of exporting a glow Function before lowering

### DIFF
--- a/lib/Exporter/ONNXModelWriter.cpp
+++ b/lib/Exporter/ONNXModelWriter.cpp
@@ -1564,10 +1564,9 @@ Error ONNXModelWriter::writeOCLBatchedReduceAdd(
 
 #ifdef GLOW_WITH_NNPI
 Error ONNXModelWriter::writeNNPICustomDSP(glow::NNPICustomDSPNode const *,
-                                          glow_onnx::GraphProto &graph) {
+                                          GraphType &graph) {
   return MAKE_ERR("Unsupported Op for ONNX");
 }
-
 #endif // GLOW_WITH_NNPI
 
 } // namespace glow


### PR DESCRIPTION
Summary:
Steps for a repro procedure for vendors
- Export Glow Function right before lowering
  - Export the net structure  <- this diff)
  - Export the weights and pack them together as a zip
- A `repro` binary to read in the zip file and execute the vendor backend
- Some randomization at net_runner.

Problem now, the ONNXWriter will mutate the input Function! This is not desirable. For the short term we need to clone a function. But exporter mutating a Function is a bit weird. Jordan, Roman

Differential Revision: D17897889

