### PR TITLE
[WIP][PyTorch] Compute output shapes for a given FunctionSchema and inputs for LazyTensor

### DIFF
--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -45,6 +45,9 @@ struct PyTorchLoaderSettings {
 /// Given a PyTorch ScalarType \p ty, \returns a matching Glow ElemKind.
 ElemKind scalarTypeToElemKind(c10::ScalarType ty);
 
+/// Given a Glow ElemKind \p ty, \returns a matching PyTorch ScalarType.
+c10::ScalarType elemKindToScalarType(glow::ElemKind ty);
+
 /// Given a c10 typekind \p ty, \returns a matching Glow ElemKind.
 ElemKind typeKindToElemKind(c10::TypeKind ty);
 

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -182,6 +182,13 @@ public:
                const at::ArrayRef<torch::jit::IValue> inputs,
                const std::vector<InputMeta> &inputMeta);
 
+  /// Given a FunctionSchema \p schema and IValues \p inputs, \returns
+  /// InputMetas describing the output shapes expected if a JIT node with the
+  /// given schema and inputs were to be lowered to Glow.
+  static Expected<InputMeta>
+  computeOutputShapes(const c10::FunctionSchema &schema,
+                      const std::vector<c10::IValue> &inputs);
+
   /// Takes a glow::Function \p F, a jit::Graph \p subgraph to load, \p inputs
   /// as graph external inputs, and \parameters as known tensors. Output
   /// parameters \p inputPlaceholders and \p outputPlaceholders are filled out.


### PR DESCRIPTION
Summary:
Compute output shapes for a given FunctionSchema and some inputs.
This is just a quick draft that makes a jit graph and creates a node from the FunctionSchema, probably we'll want to abstract PyTorchModelLoader a bit to avoid this.

Documentation:
comments

Test Plan: