### PR TITLE
refactor Compilation Log generation and usability

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -73,7 +73,7 @@ class Module final {
   PseudoRNG PRNG_;
 
   /// Module log context that stores all logs related to this module.
-  ModuleLogContext moduleLogCtx_;
+  LogContext moduleLogCtx_{nullptr};
 
   /// Inserts the constant \p V to the list of constants.
   Constant *addConstant(Constant *V);
@@ -221,7 +221,7 @@ public:
   uint64_t getConstantsSize();
 
   /// \Returns the module log context.
-  ModuleLogContext &getModuleLogContext() { return moduleLogCtx_; };
+  LogContext *getModuleLogContext() { return &moduleLogCtx_; };
 
   // Don't copy or move this class around.
   // The destructor will wipe the functions leaving
@@ -256,9 +256,8 @@ class Function final : public Named {
 public:
   Function(Module *parent, llvm::StringRef Name = {})
       : Named(Name), parent_(parent), state_(FunctionState::FuncCreated) {
-    logCtx_ = std::make_shared<LogContext>();
-    logCtx_->setParent(this);
-    logCtx_->loadModuleLogContext();
+    logCtx_ = std::make_shared<LogContext>(parent);
+    logCtx_->pushEvent(parent->getModuleLogContext()->getClonedScope());
   }
 
   ~Function();

--- a/lib/Graph/Grad.cpp
+++ b/lib/Graph/Grad.cpp
@@ -267,7 +267,11 @@ Function *glow::differentiate(Function *F, const TrainingConfig &conf,
 
       // Replace the BN's mean and variance with the new mean and variance
       // calculated from MVN.
+      BN->getParent()->getLogContext()->logNodeInputChange(
+          *BN, BN->getNthInput(BatchNormalizationNode::MeanIdx), mean);
       BN->setNthInput(BatchNormalizationNode::MeanIdx, mean);
+      BN->getParent()->getLogContext()->logNodeInputChange(
+          *BN, BN->getNthInput(BatchNormalizationNode::VarIdx), var);
       BN->setNthInput(BatchNormalizationNode::VarIdx, var);
 
       toAppend.push_back(BN->getGrad(map));

--- a/lib/Graph/Log.cpp
+++ b/lib/Graph/Log.cpp
@@ -28,145 +28,248 @@ namespace glow {
 /// Log version number.
 static constexpr auto logVersionNo_ = "v1.0.0";
 
-static llvm::cl::opt<bool>
-    dumpCompilationLogOpt("dump-compilation-log", llvm::cl::init(false),
-                          llvm::cl::desc("Dump compilation log"));
+static llvm::cl::opt<std::string>
+    dumpCompilationLogOpt("compilation-log", llvm::cl::init(""),
+                          llvm::cl::desc("Dump Compilation Log"));
 
-void ModuleLogContext::addModuleLogContent(llvm::StringRef logContent) {
-  moduleLogContents_.push_back(logContent);
-}
+static llvm::cl::opt<bool> verboseCompilationLogOpt(
+    "verbose-compilation", llvm::cl::init(false),
+    llvm::cl::desc("Log empty passes to Compilation Log"));
 
-void LogContext::addLogMetaData() {
-  addLogContent("<!-- Log Version: ");
-  addLogContent(logVersionNo_);
-  addLogContent(" -->\n");
-#ifdef GIT_SHA1
-  addLogContent("<!-- Log commit sha1: ");
-  addLogContent(GIT_SHA1);
-  addLogContent(" -->\n");
-#endif
-#ifdef GIT_DATE
-  addLogContent("<!-- Log commit date: ");
-  addLogContent(GIT_DATE);
-  addLogContent(" -->\n");
-#endif
-  addLogContent("\n");
-}
+bool LogEvent::dump(llvm::raw_fd_ostream &ostream) {
+  ostream << llvm::formatv("{ \"name\":\"{0}\",", name);
 
-LogContext::LogContext() { addLogMetaData(); }
-
-void LogContext::loadModuleLogContext() {
-  if (!parent_ || !dumpCompilationLogOpt) {
-    return;
+  if (!children.empty()) {
+    ostream << llvm::format(", \"children\":\n");
+    dumpChildren(ostream);
   }
 
-  // Add the logs of module constants/placeholders into the log context of this
-  // function. Such that the Log Context has the information of any
-  // constants/placeholders created in previous functions.
-  for (const auto &s :
-       parent_->getParent()->getModuleLogContext().getModuleLog()) {
-    addLogContent(s);
-  }
-  addLogContent(llvm::formatv("----------- Enter function: {0} ----------\n",
-                              parent_->getName())
-                    .str());
+  ostream << std::string("}");
+  return true;
 }
 
-void LogContext::addLogContent(llvm::StringRef logContent) {
-  logContents_.push_back(logContent);
+bool LogEvent::dumpChildren(llvm::raw_fd_ostream &ostream) {
+  ostream << std::string("[");
+  bool first = true;
+  for (auto *c : children) {
+    DCHECK(c);
+    if (c->silent()) {
+      continue;
+    }
+
+    if (first) {
+      first = false;
+    } else {
+      ostream << std::string(",\n");
+    }
+
+    c->dump(ostream);
+  }
+  ostream << std::string("]");
+  return true;
 }
+
+LogEvent *LogEvent::clone() {
+  LogEvent *copy = new LogEvent(name);
+  copy->parent = parent;
+  for (auto *c : children) {
+    copy->children.push_back(c->clone());
+  }
+  return copy;
+}
+
+bool LogScope::dump(llvm::raw_fd_ostream &ostream) {
+  if (silent()) {
+    return false;
+  }
+
+  ostream << llvm::formatv("{\"{0}\":", name);
+  dumpChildren(ostream);
+  ostream << std::string("}");
+  return true;
+}
+
+bool LogScope::silent() {
+  if (children.empty()) {
+    return true;
+  }
+
+  for (auto &c : children) {
+    if (!c->silent()) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+LogEvent *LogScope::clone() {
+  LogEvent *copy = new LogScope(name);
+  copy->parent = parent;
+  for (auto *c : children) {
+    copy->children.push_back(c->clone());
+  }
+  return copy;
+}
+
+LogCreate::LogCreate(const Node *node) : LogEvent(node->getName()) {
+  kindName = node->getKindName();
+
+  inputs.resize(node->getNumInputs());
+  for (size_t idx = 0; idx < node->getNumInputs(); idx++) {
+    auto &nv = node->getNthInput(idx);
+    inputs[idx] =
+        llvm::formatv("\"{0}:{1}\"", nv.getNode()->getName(), nv.getResNo());
+  }
+}
+
+LogCreate::LogCreate(llvm::StringRef n, llvm::StringRef k,
+                     std::vector<std::string> &i)
+    : LogEvent(n), kindName(k) {
+  std::copy(i.begin(), i.end(), inputs.begin());
+}
+
+bool LogCreate::dump(llvm::raw_fd_ostream &ostream) {
+  ostream << llvm::formatv(
+      "{\"create\":\"{0}\", \"kind\":\"{1}\", \"inputs\": [", name, kindName);
+
+  if (!inputs.empty()) {
+    ostream << "\n" + llvm::join(inputs.begin(), inputs.end(), ",\n");
+  }
+
+  ostream << std::string("]}");
+  return true;
+}
+
+LogEvent *LogCreate::clone() {
+  LogEvent *copy = new LogCreate(name, kindName, inputs);
+  copy->parent = parent;
+  for (auto *c : children) {
+    copy->children.push_back(c->clone());
+  }
+  return copy;
+}
+
+LogDelete::LogDelete(const Node *node) : LogEvent(node->getName()) {
+  kindName = node->getKindName();
+}
+
+LogDelete::LogDelete(llvm::StringRef n, llvm::StringRef k)
+    : LogEvent(n), kindName(k) {}
+
+bool LogDelete::dump(llvm::raw_fd_ostream &ostream) {
+  ostream << llvm::formatv("{\"delete\":\"{0}\", \"kind\":\"{1}\"}", name,
+                           kindName);
+  return true;
+}
+
+LogEvent *LogDelete::clone() {
+  LogEvent *copy = new LogDelete(name, kindName);
+  copy->parent = parent;
+  for (auto *c : children) {
+    copy->children.push_back(c->clone());
+  }
+  return copy;
+}
+
+LogInputChange::LogInputChange(const Node *user, const NodeValue &before,
+                               const NodeValue &after)
+    : LogEvent(user->getName()) {
+  kindName = user->getKindName();
+  beforeName =
+      llvm::formatv("{0}:{1}", before.getNode()->getName(), before.getResNo());
+  afterName = "NONE";
+  if (after.getNode()) {
+    afterName =
+        llvm::formatv("{0}:{1}", after.getNode()->getName(), after.getResNo());
+  }
+}
+
+LogInputChange::LogInputChange(llvm::StringRef n, llvm::StringRef k,
+                               llvm::StringRef b, llvm::StringRef a)
+    : LogEvent(n), kindName(k), beforeName(b), afterName(a) {}
+
+bool LogInputChange::dump(llvm::raw_fd_ostream &ostream) {
+  ostream << llvm::formatv("{\"input_change\":\"{0}\", \"kind\":\"{1}\", "
+                           "\"before\":\"{2}\", \"after\":\"{3}\"}",
+                           name, kindName, beforeName, afterName);
+  return true;
+}
+
+LogEvent *LogInputChange::clone() {
+  LogEvent *copy = new LogInputChange(name, kindName, beforeName, afterName);
+  copy->parent = parent;
+  for (auto *c : children) {
+    copy->children.push_back(c->clone());
+  }
+  return copy;
+}
+
+LogContext::LogContext(Module *parent)
+    : currentScope_(&topScope_), parent_(parent) {}
+
+void LogContext::pushEvent(LogEvent *ev) { currentScope_->pushEvent(ev); }
 
 void LogContext::pushLogScope(llvm::StringRef scopeName) {
-  logScopes_.push_back(scopeName);
-  currentFullScope_ += "->";
-  currentFullScope_ += scopeName;
+  LogScope *scope = new LogScope(scopeName);
+  currentScope_->pushEvent(scope);
+  currentScope_ = currentScope_->children.back();
 }
 
 void LogContext::popLogScope() {
-  if (logScopes_.size() > 0) {
-    currentFullScope_ = currentFullScope_.substr(
-        0, currentFullScope_.size() - logScopes_.back().size() - 2);
-    logScopes_.pop_back();
-  }
+  DCHECK(currentScope_->parent);
+  currentScope_ = currentScope_->parent;
 }
 
-void LogContext::dumpLog(llvm::StringRef funcName) {
-  if (!dumpCompilationLogOpt) {
+void LogContext::dumpLog(llvm::StringRef) {
+  if (dumpCompilationLogOpt == "") {
     return;
   }
-  std::string compileLogFilename = funcName;
-  compileLogFilename.append("_compile.log");
+  std::string compileLogFilename = dumpCompilationLogOpt;
 
   llvm::outs() << "Writing compilation log file for Module to: "
                << compileLogFilename << '\n';
   std::error_code EC;
   llvm::raw_fd_ostream myfile(compileLogFilename, EC);
-  for (const auto &s : logContents_) {
-    myfile << s;
-  }
+  myfile << llvm::formatv("{ \"log\":\"Glow Compilation Log\", "
+                          "\"version\":\"{0}\", ",
+                          logVersionNo_);
+#ifdef GIT_SHA1
+  myfile << llvm::formatv("\"commitHash\":\"{0}\", ", GIT_SHA1);
+#endif
+#ifdef GIT_DATE
+  myfile << llvm::formatv("\"commitDate\":\"{0}\", ", GIT_DATE);
+#endif
+  myfile << std::string("\"passes\":");
+  topScope_.dumpChildren(myfile);
+  myfile << std::string("}\n");
 }
 
 /// Logs the node creation with a list of input nodes.
 void LogContext::logNodeCreation(const Node &newNode, bool logIntoModule) {
-  if (!dumpCompilationLogOpt) {
+  if (dumpCompilationLogOpt == "") {
     return;
   }
-  std::vector<NodeValue> inputs;
-  for (size_t idx = 0; idx < newNode.getNumInputs(); idx++) {
-    inputs.push_back(newNode.getNthInput(idx));
-  }
 
-  std::string contentStr =
-      llvm::formatv(" --- CREATE { (Kind: {0}, Name: {1}) <== ",
-                    newNode.getKindName(), newNode.getName())
-          .str();
-  for (auto &n : inputs) {
-    contentStr += llvm::formatv(" (Kind: {0}, Name: {1}, ResNo: {2}) ",
-                                n.getNode()->getKindName(),
-                                n.getNode()->getName(), n.getResNo())
-                      .str();
-  }
-  contentStr += " }\n";
-
-  // Use scope as "Module" when writting into Module logs.
+  LogEvent *ev = new LogCreate(&newNode);
   if (logIntoModule) {
-    if (parent_) {
-      std::string scopeName = "[FULL SCOPE: Module ]";
-      parent_->getParent()->getModuleLogContext().addModuleLogContent(
-          scopeName + contentStr);
-    }
-
+    parent_->getModuleLogContext()->pushEvent(ev);
   } else {
-    std::string scopeName =
-        llvm::formatv("[FULL SCOPE: {0}]", getFullScopeName()).str();
-    addLogContent(scopeName + contentStr);
+    currentScope_->pushEvent(ev);
   }
 }
 
 /// Logs the node deletion.
 void LogContext::logNodeDeletion(const Node &deletedNode, bool logIntoModule) {
-  if (!dumpCompilationLogOpt) {
+  if (dumpCompilationLogOpt == "") {
     return;
   }
 
-  std::string contentStr =
-      llvm::formatv(" --- DELETE ( (Kind: {0}, "
-                    "Name: {1}) }\n",
-                    deletedNode.getKindName(), deletedNode.getName())
-          .str();
-
-  // Use scope as "Module" when writting into Module logs.
+  LogEvent *ev = new LogDelete(&deletedNode);
   if (logIntoModule) {
-    if (parent_) {
-      std::string scopeName = "[FULL SCOPE: Module ]";
-      parent_->getParent()->getModuleLogContext().addModuleLogContent(
-          scopeName + contentStr);
-    }
-
+    parent_->getModuleLogContext()->pushEvent(ev);
   } else {
-    std::string scopeName =
-        llvm::formatv("[FULL SCOPE: {0} ]", getFullScopeName()).str();
-    addLogContent(scopeName + contentStr);
+    currentScope_->pushEvent(ev);
   }
 }
 
@@ -174,49 +277,23 @@ void LogContext::logNodeDeletion(const Node &deletedNode, bool logIntoModule) {
 void LogContext::logNodeInputChange(const Node &user,
                                     const NodeValue &prevOprVal,
                                     const NodeValue &newOprVal) {
-  if (!dumpCompilationLogOpt) {
+  if (dumpCompilationLogOpt == "") {
     return;
   }
-  addLogContent(
-      llvm::formatv(
-          "[FULL SCOPE: {0} ] --- NODE_INPUT_CHANGE { User(Kind: {1}, "
-          "Name: {2}) :: ",
-          getFullScopeName(), user.getKindName(), user.getName())
-          .str());
 
-  // prevOpr.getNode()should never be null.
-  addLogContent(
-      llvm::formatv("PrevOprValue(Kind: {0}, Name: {1}, ResNo: {2}) -> ",
-                    prevOprVal.getNode()->getKindName(),
-                    prevOprVal.getNode()->getName(), prevOprVal.getResNo())
-          .str());
-
-  if (newOprVal.getNode()) {
-    addLogContent(
-        llvm::formatv("NewOprValue(Kind: {0}, Name: {1}, ResNo: {2}) }\n",
-                      newOprVal.getNode()->getKindName(),
-                      newOprVal.getNode()->getName(), newOprVal.getResNo())
-            .str());
-  } else {
-    addLogContent("NewOprValue(null) }\n");
-  }
+  LogEvent *ev = new LogInputChange(&user, prevOprVal, newOprVal);
+  currentScope_->pushEvent(ev);
 }
+
+LogEvent *LogContext::getClonedScope() { return topScope_.clone(); }
 
 ScopedLogBlock::ScopedLogBlock(std::shared_ptr<LogContext> ctx,
                                llvm::StringRef name)
     : ctx_(ctx), name_(name) {
   ctx_->pushLogScope(name_);
-  ctx_->addLogContent("============= ENTER SCOPE: ");
-  ctx_->addLogContent(ctx_->getFullScopeName());
-  ctx_->addLogContent(" ================================\n");
 };
 
-ScopedLogBlock::~ScopedLogBlock() {
-  ctx_->addLogContent("============= EXIT SCOPE: ");
-  ctx_->addLogContent(ctx_->getFullScopeName());
-  ctx_->addLogContent(" ================================\n");
-  end();
-};
+ScopedLogBlock::~ScopedLogBlock() { end(); };
 
 void ScopedLogBlock::end() {
   if (!end_) {

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -1243,9 +1243,13 @@ bool normalizeWeights(Module *M, ConvolutionNode &CV,
 
   // Set the new filter and bias on CV if necessary.
   if (filterC != CV.getFilter().getNode()) {
+    CV.getParent()->getLogContext()->logNodeInputChange(
+        CV, CV.getNthInput(ConvolutionNode::FilterIdx), filterC);
     CV.setNthInput(ConvolutionNode::FilterIdx, filterC);
   }
   if (cbiasC != CV.getBias().getNode()) {
+    CV.getParent()->getLogContext()->logNodeInputChange(
+        CV, CV.getNthInput(ConvolutionNode::BiasIdx), cbiasC);
     CV.setNthInput(ConvolutionNode::BiasIdx, cbiasC);
   }
 

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -507,6 +507,8 @@ protected:
                           outputTy->getScale(), outputTy->getOffset());        \
       auto *rescale = function_.createRescaleQuantized(                        \
           input.getNode()->getName(), input, argOutTy);                        \
+      function_.getLogContext()->logNodeInputChange(*N, N->getNthInput(idx),   \
+                                                    rescale);                  \
       N->setNthInput(idx++, rescale);                                          \
     }                                                                          \
     break;                                                                     \
@@ -548,6 +550,10 @@ protected:
       auto *rescale =
           function_.createRescaleQuantized(node.getName(), val, outTy);
       quantizedNode = rescale;
+
+      function_.getLogContext()->logNodeInputChange(
+          *dequantize, dequantize->getNthInput(DequantizeNode::InputIdx),
+          rescale);
       dequantize->setNthInput(DequantizeNode::InputIdx, rescale);
       break;
     }
@@ -612,7 +618,7 @@ protected:
           dequantize->getName(), outNum)] = {outTy->getScale(),
                                              outTy->getOffset()};
     }
-  }
+  } // namespace
 
   void convertTensor(Tensor &tensor, TypeRef destTy) override {
     assert(tensor.getElementType() == ElemKind::FloatTy &&
@@ -834,7 +840,7 @@ public:
     cleanUp();
     assert(function_.verify() && "Conversion led to invalid function");
   }
-};
+}; // namespace
 
 } // namespace
 


### PR DESCRIPTION
Summary: The Compilation Log option is very useful, but has a few rough edges. This PR attempts to improve usability by changing the log format.

The biggest change is switching the log itself to use JSON, it now looks like this (I did run the output through a json pretty printer):

![image](https://user-images.githubusercontent.com/701287/66879951-a8ecda80-ef8e-11e9-9e09-15eed33f6b1e.png)

I find this more readable personally, and it lets us remove all the regexs from the log_parser tool.

A few other QOL changes:

* Changed the command line option to `--compilation-log=filename` rather than a fixed filename based on Function name. This overwrites so currently will only log the last Function compiled in the process.
* By default, empty compilation stages are not logged, making it easier to see what was done. The `--verbose-compilation` flag  disables this and logs all compilation/optimization passes.
* Fixed a bunch of places where a Node's input was changed and we didn't log it, which broke all the log-based tooling.
* Simplified the log parser a bit.

Documentation: I still havent uploaded Compilation Log docs yet, so nothing to update.

Test Plan: ran tests & image-classifier, dumped log of compiling resnet and used the tools.

E.g.  here's the base of Resnet before and after lowering:
before:
![image](https://user-images.githubusercontent.com/701287/66880194-cb332800-ef8f-11e9-9b89-e16283f058db.png)

after:
![image](https://user-images.githubusercontent.com/701287/66880178-b8b8ee80-ef8f-11e9-96f1-d5b05dc0ee02.png)
