### PR TITLE
[PyTorch]New ptTensorToGlowTensor

### DIFF
--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -76,9 +76,6 @@ void registerGlowFusionPass(std::function<bool()> enablePassFn);
 /// registered.
 void registerGlowFusionOpAndPass(std::function<bool()> enablePassFn);
 
-/// Given a PyTorch TensorType \p ptType, \returns a matching Glow Type.
-glow::Type ptTypeToGlowType(const c10::TensorType &ptType);
-
 /// Given a PyTorch Tensor \p ptTensor, \returns an unowned Glow Tensor with a
 /// matching type backed by the same memory as ptTensor.
 glow::Tensor ptTensorToGlowTensor(const at::Tensor &ptTensor);


### PR DESCRIPTION
Now we accept a quantized tensor as fused node input.
test is in test_quantized_conv2d_nonfunctional, however it is now not enbaled since it could be very flaky because of accuracy.