### PR TITLE
Fix TraceEvent::dumpTraceEvents

### DIFF
--- a/lib/ExecutionContext/TraceEvents.cpp
+++ b/lib/ExecutionContext/TraceEvents.cpp
@@ -70,7 +70,11 @@ void TraceEvent::dumpTraceEvents(
     writeMetadataHelper(file, "thread_name", nameMap.first, nameMap.second);
   }
 
+  bool first{true};
   for (const auto &event : events) {
+    file << (first ? "" : ",\n");
+    first = false;
+
     file << "{\"name\": \"" << event.name;
     file << "\", \"cat\": \"glow\",";
     file << "\"ph\": \"" << event.type;
@@ -84,18 +88,18 @@ void TraceEvent::dumpTraceEvents(
 
     if (!event.args.empty()) {
       file << ", \"args\": {";
-      bool first{true};
+      bool firstArg{true};
       for (auto &pair : event.args) {
         // Start with a comma unless it's the first item in the list.
-        file << (first ? "" : ", ");
-        first = false;
+        file << (firstArg ? "" : ", ");
+        firstArg = false;
         file << "\"" << pair.first << "\" : \"" << pair.second << "\"";
       }
       file << "}";
     }
-    file << "},\n";
+    file << "}";
   }
-  // Skip the ending bracket since that is allowed.
+  file << "\n]";
   file.close();
 }
 


### PR DESCRIPTION
Summary: When dumping TraceEvents to json, we take some shortcuts because the chromium tracing page allows it. Really we should suck it up and produce correct json, so now we do.

Documentation: N/A

Test Plan: ran resnet-runtime:

Before:
```
❯ ./bin/resnet-runtime -trace-path=trace.json --auto-instrument
❯ python3 -m json.tool < trace.json
Expecting value: line 759 column 1 (char 110955)
```
After:
```
❯ ./bin/resnet-runtime -trace-path=trace.json --auto-instrument
❯ python3 -m json.tool < trace.json
[
    {
        "cat": "__metadata",
        "ph": "M",
        "ts": 0,
        "pid": 0,
        "tid": 0,
        "name": "process_name",
        "args": {
            "name": "resnet-runtime"
        }
    },
    ...
```