### PR TITLE
[Tracing] add category to trace files & a TraceLevel for copies

### DIFF
--- a/lib/Backends/Interpreter/InterpreterFunction.cpp
+++ b/lib/Backends/Interpreter/InterpreterFunction.cpp
@@ -92,16 +92,24 @@ void InterpreterFunction::translateTraceEvents(
                backingTensor->getUnsafePtr() +
                    (event.endIndex * traceInfo.dataSize),
                traceInfo.dataSize);
-        traceEvents.push_back(
-            {event.name, start, end - start, tid, {{"kind", event.kind}}});
+        traceEvents.push_back({event.name,
+                               TraceLevel::OPERATOR,
+                               start,
+                               end - start,
+                               tid,
+                               {{"kind", event.kind}}});
       } else {
         uint64_t ts{0};
         memcpy(&ts,
                backingTensor->getUnsafePtr() +
                    (event.startIndex * traceInfo.dataSize),
                traceInfo.dataSize);
-        traceEvents.push_back(
-            {event.name, ts, event.type, tid, {{"kind", event.kind}}});
+        traceEvents.push_back({event.name,
+                               TraceLevel::OPERATOR,
+                               ts,
+                               event.type,
+                               tid,
+                               {{"kind", event.kind}}});
       }
     }
   }

--- a/lib/LLVMIRCodeGen/LLVMCompiledFunction.cpp
+++ b/lib/LLVMIRCodeGen/LLVMCompiledFunction.cpp
@@ -179,16 +179,24 @@ void LLVMCompiledFunction::translateTraceEvents(
                backingTensor->getUnsafePtr() +
                    (event.endIndex * traceInfo.dataSize),
                traceInfo.dataSize);
-        traceEvents.push_back(
-            {event.name, start, end - start, tid, {{"kind", event.kind}}});
+        traceEvents.push_back({event.name,
+                               TraceLevel::OPERATOR,
+                               start,
+                               end - start,
+                               tid,
+                               {{"kind", event.kind}}});
       } else {
         uint64_t ts{0};
         memcpy(&ts,
                backingTensor->getUnsafePtr() +
                    (event.startIndex * traceInfo.dataSize),
                traceInfo.dataSize);
-        traceEvents.push_back(
-            {event.name, ts, event.type, tid, {{"kind", event.kind}}});
+        traceEvents.push_back({event.name,
+                               TraceLevel::OPERATOR,
+                               ts,
+                               event.type,
+                               tid,
+                               {{"kind", event.kind}}});
       }
     }
   }

--- a/tests/unittests/TraceEventsTest.cpp
+++ b/tests/unittests/TraceEventsTest.cpp
@@ -786,8 +786,8 @@ TEST(TraceEventsTest, nestedScopedEventsTerm) {
 
 TEST(TraceEventsTest, TraceLevels) {
   CHECK_IF_ENABLED();
-  std::array<TraceLevel, 4> levels = {{TraceLevel::NONE, TraceLevel::REQUEST,
-                                       TraceLevel::RUNTIME,
+  std::array<TraceLevel, 5> levels = {{TraceLevel::NONE, TraceLevel::REQUEST,
+                                       TraceLevel::RUNTIME, TraceLevel::COPY,
                                        TraceLevel::OPERATOR}};
   for (auto L : levels) {
     TraceContext context(L);
@@ -807,7 +807,7 @@ TEST(TraceEventsTest, TraceLevels) {
   for (auto evl : levels) {
     context.logTraceEvent("event", evl);
   }
-  ASSERT_EQ(context.getTraceEvents().size(), 2);
+  ASSERT_EQ(context.getTraceEvents().size(), 4);
 }
 
 TEST(TraceEventsTest, MergeEvents) {


### PR DESCRIPTION
Summary: Two small improvements to the tracing output:
* Fill out the "cat" field of TraceEvents with the TraceLevel an event is logged at (e.g. OPERATOR, RUNTIME) rather than hardcode "glow", this means we can more easily tell which part of glow an event comes from.
* Add a new TraceLevel for memory copies, DMAs, etc. I've added input/output events for OpenCL and used this new TraceLevel.

Documentation: N/A

Test Plan: unit tests + run image classifier for Interpreter, CPU and OCL and inspect output.