### PR TITLE
[OpenCL] Refactor buffer copies into DeviceManager

### DIFF
--- a/include/glow/ExecutionContext/TraceEvents.h
+++ b/include/glow/ExecutionContext/TraceEvents.h
@@ -169,6 +169,7 @@ class TraceContext {
 
 public:
   TraceContext(TraceLevel level) : traceLevel_(level) {}
+  TraceContext(int level) : traceLevel_((TraceLevel)level) {}
 
   /// \returns TraceEvents for the last run.
   std::vector<TraceEvent> &getTraceEvents() { return traceEvents_; }

--- a/lib/Backends/OpenCL/OpenCLDeviceManager.h
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.h
@@ -17,6 +17,7 @@
 #define GLOW_BACKENDS_OPENCL_OPENCLDEVICEMANAGER_H
 
 #include "glow/Backends/QueueBackedDeviceManager.h"
+#include "lib/Backends/OpenCL/OpenCL.h"
 
 #include <atomic>
 
@@ -198,6 +199,22 @@ protected:
   void runFunctionImpl(runtime::RunIdentifierTy id, std::string functionName,
                        std::unique_ptr<ExecutionContext> context,
                        ResultCBTy cb) override;
+
+  /// Load inputs from \p context onto the device.
+  void copyInputsToDevice(const RuntimeBundle &runtimeBundle,
+                          ExecutionContext *context,
+                          runtime::OpenCLDeviceBindings *devBindings);
+
+  /// Copy back results from the device to the host.
+  void copyOutputsFromDevice(const RuntimeBundle &runtimeBundle,
+                             ExecutionContext *context,
+                             runtime::OpenCLDeviceBindings *devBindings);
+
+  /// Get profiling information for each kernelLaunch. This must happen after
+  /// copyOutputsFromDevice.
+  void translateTraceEvents(ManualEventMap &manualTraceEvents,
+                            ExecutionContext *context,
+                            runtime::OpenCLDeviceBindings *devBindings);
 };
 
 DeviceManager *createOCLDeviceManager(const DeviceConfig &config);

--- a/tests/unittests/TraceEventsTest.cpp
+++ b/tests/unittests/TraceEventsTest.cpp
@@ -207,7 +207,6 @@ TEST_P(TraceEventsTest, manualEvents) {
   EE_.run(context);
 
   auto &traceEvents = context.getTraceContext()->getTraceEvents();
-
   ASSERT_EQ(traceEvents.size(), numEvents);
   checkEventMetadata(traceEvents, {{"first half", 'B'},
                                    {"first half", 'E'},
@@ -627,8 +626,8 @@ TEST_P(TraceEventsTest, multipleRunsAreDistinct) {
 TEST_P(TraceEventsTest, deviceManagerEvents) {
   CHECK_IF_ENABLED();
   ExecutionContext context;
-  context.setTraceContext(
-      llvm::make_unique<TraceContext>(TraceLevel::STANDARD));
+  context.setTraceContext(llvm::make_unique<TraceContext>(
+      TraceLevel::RUNTIME | TraceLevel::OPERATOR));
 
   auto n = part_one(F, context);
   n = part_two(F, context, n);
@@ -656,8 +655,8 @@ TEST_P(TraceEventsTest, deviceManagerEvents) {
 TEST(TraceEventsTest, nestedScopedEvents) {
   CHECK_IF_ENABLED();
   ExecutionContext context;
-  context.setTraceContext(
-      llvm::make_unique<TraceContext>(TraceLevel::STANDARD));
+  context.setTraceContext(llvm::make_unique<TraceContext>(
+      TraceLevel::RUNTIME | TraceLevel::OPERATOR));
 
   TraceContext *tc = context.getTraceContext();
 
@@ -696,8 +695,8 @@ TEST(TraceEventsTest, nestedScopedEvents) {
 TEST(TraceEventsTest, nestedScopedEventsMacro) {
   CHECK_IF_ENABLED();
   ExecutionContext context;
-  context.setTraceContext(
-      llvm::make_unique<TraceContext>(TraceLevel::STANDARD));
+  context.setTraceContext(llvm::make_unique<TraceContext>(
+      TraceLevel::RUNTIME | TraceLevel::OPERATOR));
 
   TraceContext *tc = context.getTraceContext();
 
@@ -737,8 +736,8 @@ TEST(TraceEventsTest, nestedScopedEventsMacro) {
 TEST(TraceEventsTest, nestedScopedEventsTerm) {
   CHECK_IF_ENABLED();
   ExecutionContext context;
-  context.setTraceContext(
-      llvm::make_unique<TraceContext>(TraceLevel::STANDARD));
+  context.setTraceContext(llvm::make_unique<TraceContext>(
+      TraceLevel::RUNTIME | TraceLevel::OPERATOR));
 
   TraceContext *tc = context.getTraceContext();
 
@@ -811,8 +810,10 @@ TEST(TraceEventsTest, TraceLevels) {
 }
 
 TEST(TraceEventsTest, MergeEvents) {
-  auto tc1 = llvm::make_unique<TraceContext>(TraceLevel::STANDARD);
-  auto tc2 = llvm::make_unique<TraceContext>(TraceLevel::STANDARD);
+  auto tc1 = llvm::make_unique<TraceContext>(TraceLevel::RUNTIME |
+                                             TraceLevel::OPERATOR);
+  auto tc2 = llvm::make_unique<TraceContext>(TraceLevel::RUNTIME |
+                                             TraceLevel::OPERATOR);
 
   TRACE_EVENT_BEGIN(tc1, TraceLevel::RUNTIME, "ev1");
   TRACE_EVENT_END(tc1, TraceLevel::RUNTIME, "ev1");


### PR DESCRIPTION
Summary: As a preparation for supporting device resident Tensors, move Tensor copies out of the OCLCompiledFunction and into the DeviceManager. Mostly this is just a move of the relevant code into the new class, but I had to move the KernelLaunches to the OCLDeviceBindings.

Fixed a few small TraceEventTest issues as well.

Documentation: NFC

Test Plan: ran tests, image-classifier, and resnet-runtime with OCL