### PR TITLE
[Tracing] Add thread names for Interpreter, CPU and OCL

### DIFF
--- a/include/glow/ExecutionContext/TraceEvents.h
+++ b/include/glow/ExecutionContext/TraceEvents.h
@@ -94,9 +94,6 @@ struct TraceEvent {
   /// Return the current time in microseconds in the timestamp domain.
   static uint64_t now();
 
-  /// Returns a unique id associated with the current thread.
-  static size_t getThreadId();
-
   /// Returns a string representation of the provided \p level.
   static llvm::StringRef traceLevelToString(TraceLevel level);
 };
@@ -210,7 +207,7 @@ public:
   void setThreadName(int tid, llvm::StringRef name);
 
   /// Sets the human readable \p name for the current thread (by
-  /// TraceEvent::getThreadId()).
+  /// threads::getThreadId()).
   void setThreadName(llvm::StringRef name);
 
   /// \returns the list of human readable thread names.

--- a/include/glow/Runtime/Executor/ThreadPoolExecutor.h
+++ b/include/glow/Runtime/Executor/ThreadPoolExecutor.h
@@ -60,8 +60,7 @@ class ThreadPoolExecutor final : public Executor {
 public:
   /// Constructor.
   explicit ThreadPoolExecutor(const DeviceManagerMapTy &deviceManagers,
-                              unsigned numWorkers = kNumWorkers)
-      : threadPool_(numWorkers), deviceManagers_(deviceManagers) {}
+                              unsigned numWorkers = kNumWorkers);
 
   /// See Executor::run. A particular invocation is specified completely by
   /// the triple (roots, bindings, runId).

--- a/include/glow/Support/ThreadPool.h
+++ b/include/glow/Support/ThreadPool.h
@@ -22,10 +22,20 @@
 #include <future>
 #include <mutex>
 #include <queue>
+#include <set>
 #include <thread>
 #include <vector>
 
 namespace glow {
+
+namespace threads {
+/// Returns a unique id associated with the current thread.
+size_t getThreadId();
+
+/// Returns a unique id associated with a new virtual thread (i.e. a device
+/// tid).
+size_t createThreadId();
+} // namespace threads
 
 #ifdef WIN32
 /// A copyable wrapper for a lambda function that has non-copyable objects in
@@ -160,6 +170,8 @@ public:
     return promise->get_future();
   }
 
+  const std::set<size_t> &getThreadIds() { return threadIds_; }
+
 private:
   /// The default number of workers in the thread pool (overridable).
   constexpr static unsigned kNumWorkers = 10;
@@ -171,6 +183,9 @@ private:
 
   /// Round robin index for the next work thread.
   std::atomic<size_t> nextWorker_{0};
+
+  /// Thread Ids and associated names owned by this ThreadPool.
+  std::set<size_t> threadIds_;
 };
 } // namespace glow
 

--- a/lib/Backends/CPU/CPUDeviceManager.cpp
+++ b/lib/Backends/CPU/CPUDeviceManager.cpp
@@ -150,6 +150,9 @@ void CPUDeviceManager::runFunctionImpl(
 
   TRACE_EVENT_SCOPE_NAMED(context->getTraceContext(), TraceLevel::RUNTIME,
                           "DeviceManager::run", dmRun);
+  if (context->getTraceContext()) {
+    context->getTraceContext()->setThreadName("CPU DeviceManager");
+  }
   auto funcIt = functions_.find(function);
   if (funcIt == functions_.end()) {
     dmRun.addArg("reason", "function not found");

--- a/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.cpp
@@ -146,6 +146,9 @@ void InterpreterDeviceManager::runFunctionImpl(
 
   TRACE_EVENT_SCOPE_NAMED(context->getTraceContext(), TraceLevel::RUNTIME,
                           "DeviceManager::run", dmRun);
+  if (context->getTraceContext()) {
+    context->getTraceContext()->setThreadName("Interpreter");
+  }
   auto funcIt = functions_.find(function);
   if (funcIt == functions_.end()) {
     dmRun.addArg("reason", "function not found");

--- a/lib/Backends/Interpreter/InterpreterFunction.cpp
+++ b/lib/Backends/Interpreter/InterpreterFunction.cpp
@@ -19,6 +19,7 @@
 #include "glow/IR/IR.h"
 #include "glow/IR/IRUtils.h"
 #include "glow/IR/Instrs.h"
+#include "glow/Support/ThreadPool.h"
 
 #include "llvm/Support/Casting.h"
 
@@ -74,7 +75,7 @@ void InterpreterFunction::translateTraceEvents(
 
   PlaceholderBindings *bindings = context->getPlaceholderBindings();
 
-  int tid = TraceEvent::getThreadId();
+  int tid = threads::getThreadId();
   auto &traceEvents = traceContext->getTraceEvents();
   for (auto &backing : traceInfo.events) {
     Tensor *backingTensor = bindings->get(backing.first);

--- a/lib/Backends/OpenCL/OpenCLDeviceManager.h
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.h
@@ -161,6 +161,9 @@ class OpenCLDeviceManager : public QueueBackedDeviceManager {
   /// Returns a command queue.
   void returnRunCommandQueue(OpenCLCommandQueue &queue);
 
+  /// The TID of the device (for TraceEvents);
+  int deviceTid_{-1};
+
 public:
   OpenCLDeviceManager(const DeviceConfig &config);
 

--- a/lib/LLVMIRCodeGen/LLVMCompiledFunction.cpp
+++ b/lib/LLVMIRCodeGen/LLVMCompiledFunction.cpp
@@ -18,6 +18,7 @@
 #include "glow/Graph/PlaceholderBindings.h"
 #include "glow/Support/Compiler.h"
 #include "glow/Support/Memory.h"
+#include "glow/Support/ThreadPool.h"
 
 using namespace glow;
 
@@ -160,7 +161,7 @@ void LLVMCompiledFunction::translateTraceEvents(
 
   PlaceholderBindings *bindings = context->getPlaceholderBindings();
 
-  int tid = TraceEvent::getThreadId();
+  int tid = threads::getThreadId();
   for (auto &backing : traceInfo.events) {
     Tensor *backingTensor = bindings->get(backing.first);
     DCHECK(backingTensor) << "Could not get backing tensor for Placeholder: "

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -405,6 +405,9 @@ HostManager::runNetwork(llvm::StringRef networkName,
 
   TRACE_EVENT_SCOPE(context->getTraceContext(), TraceLevel::RUNTIME,
                     "HostManager::runNetwork");
+  if (context->getTraceContext()) {
+    context->getTraceContext()->setThreadName("Caller");
+  }
   auto currentRun = totalRequestCount_++;
 
   NetworkData *network = nullptr;


### PR DESCRIPTION
Summary: Adding thread names to glow Traces for the third time, hopefully this time it sticks. I've also modified the OpenCL DeviceManager so events that are generated on the device us a different thread than those on the host, which I think is easier to read.

Traces look like this (from image-classifier):
![image](https://user-images.githubusercontent.com/701287/67132692-67db0d00-f1be-11e9-8539-6032317dca53.png)
![image](https://user-images.githubusercontent.com/701287/67132801-d3bd7580-f1be-11e9-9f3a-3b424acc6541.png)

With multiple devices they look like this (from resnet-runtime):
![image](https://user-images.githubusercontent.com/701287/67132878-25660000-f1bf-11e9-9d74-e82e1071e52d.png)

Documentation: N/A

Test Plan: unit tests, image-classifier & resnet-runtime