### PR TITLE
(trivial) add const to some PlaceholderBindings params

### DIFF
--- a/include/glow/Graph/PlaceholderBindings.h
+++ b/include/glow/Graph/PlaceholderBindings.h
@@ -85,12 +85,12 @@ public:
   /// Allocates zero-initialized backing tensors to all placeholders in \p lst
   /// that are not currently allocated in the bindings.
   /// \returns the number of tensors that were allocated.
-  unsigned allocate(std::list<Placeholder *> &lst);
+  unsigned allocate(const std::list<Placeholder *> &lst);
 
   /// \returns the first placeholder in \p list that is not allocated by this
   /// bindings. This method returns null if all placeholders in the list are
   /// allocated.
-  Placeholder *getFirstUnallocated(std::list<Placeholder *> &lst) const;
+  Placeholder *getFirstUnallocated(const std::list<Placeholder *> &lst) const;
 
   /// \returns True if \p P is a registered Placeholder.
   size_t count(Placeholder *P) const;

--- a/lib/Graph/PlaceholderBindings.cpp
+++ b/lib/Graph/PlaceholderBindings.cpp
@@ -179,7 +179,7 @@ Tensor *PlaceholderBindings::allocate(Placeholder *P) {
   return T;
 }
 
-unsigned PlaceholderBindings::allocate(std::list<Placeholder *> &lst) {
+unsigned PlaceholderBindings::allocate(const std::list<Placeholder *> &lst) {
   unsigned allocated = 0;
   // For each placeholder in the list:
   for (Placeholder *P : lst) {
@@ -195,8 +195,8 @@ unsigned PlaceholderBindings::allocate(std::list<Placeholder *> &lst) {
   return allocated;
 }
 
-Placeholder *
-PlaceholderBindings::getFirstUnallocated(std::list<Placeholder *> &lst) const {
+Placeholder *PlaceholderBindings::getFirstUnallocated(
+    const std::list<Placeholder *> &lst) const {
   // For each placeholder in the list:
   for (Placeholder *P : lst) {
     // If we found an unallocated placeholder then return it.


### PR DESCRIPTION
Summary: For the methods of PlaceholderBindings that take a list, we don't ever modify the params and they can be const. Most usefully this lets you call `allocate(module->getPlaceholders())` if the module is const.

Documentation: n/a

Test Plan: build & ran tests