### PR TITLE
blacklist SigmoidSweep in all backends

### DIFF
--- a/lib/Backends/CPU/tests/CPUOperatorTest.cpp
+++ b/lib/Backends/CPU/tests/CPUOperatorTest.cpp
@@ -154,4 +154,5 @@ std::set<std::string> glow::backendTestBlacklist = {
     "rowwiseQuantizedSLWSTest/0",
     "SLSAllZeroLengths_Float16/0",
     "FusedRWQSLSAllZeroLengths_Float16/0",
+    "SigmoidSweep/0",
 };

--- a/lib/Backends/Habana/tests/HabanaOperatorTest.cpp
+++ b/lib/Backends/Habana/tests/HabanaOperatorTest.cpp
@@ -256,6 +256,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "Select/0",
     "SigmoidCrossEntropyWithLogits/0",
     "Sigmoid_Float16/0",
+    "SigmoidSweep/0",
     "simpleCmpSelectPredication/0",
     "sliceConcatVectors_Float16/0",
     "sliceConcatVectors_Int64/0",

--- a/lib/Backends/Interpreter/tests/InterpreterOperatorTest.cpp
+++ b/lib/Backends/Interpreter/tests/InterpreterOperatorTest.cpp
@@ -17,4 +17,6 @@
 
 using namespace glow;
 
-std::set<std::string> glow::backendTestBlacklist = {};
+std::set<std::string> glow::backendTestBlacklist = {
+    "SigmoidSweep/0",
+};

--- a/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
@@ -254,4 +254,5 @@ std::set<std::string> glow::backendTestBlacklist = {
     "SLSAllZeroLengths_Float16/0",
     "FusedRWQSLSAllZeroLengths_Float/0",
     "FusedRWQSLSAllZeroLengths_Float16/0",
+    "SigmoidSweep/0",
 };


### PR DESCRIPTION
Summary: blacklist SigmoidSweep in all backends

Differential Revision: D18048775

