### PR TITLE
Dump glow function right after ONNXIFI

### DIFF
--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -16,7 +16,6 @@
 #include "NNPI.h"
 #include "NNPICompiledFunction.h"
 #include "NNPIDeviceManager.h"
-#include "glow/Exporter/ONNXModelWriter.h"
 #include "glow/Graph/Nodes.h"
 #include "glow/Optimizer/GraphOptimizerPipeline/Pipeline.h"
 
@@ -26,7 +25,6 @@ namespace glow {
 namespace onnxifi {
 
 bool GlowDumpGraph = false;
-bool GlowSaveModel = false;
 
 } // namespace onnxifi
 } // namespace glow
@@ -314,17 +312,6 @@ NNPIBackend::compile(Function *F, const BackendOptions &opts) const {
     std::string fname = "Graph_" + F->getName().str() + ".dot";
     LOG(INFO) << "Dumping net to " << fname;
     F->dumpDAG(fname);
-  }
-  if (glow::onnxifi::GlowSaveModel) {
-    std::string fname = F->getName().str() + ".zip";
-    LOG(INFO) << "Saving model to " << fname;
-    Error err = Error::empty();
-    constexpr size_t kIrVer = 7, kOpsetVer = 10;
-    { ONNXModelWriter onnxWR(fname, *F, kIrVer, kOpsetVer, &err, false, true); }
-    if (ERR_TO_BOOL(std::move(err))) {
-      llvm::errs() << "ONNXModelWriter failed to write model: " << fname
-                   << ".\n";
-    }
   }
   std::unique_ptr<NNPICompiledFunction> compiledFunc =
       llvm::make_unique<NNPICompiledFunction>(F);

--- a/lib/Exporter/ONNXModelWriter.cpp
+++ b/lib/Exporter/ONNXModelWriter.cpp
@@ -1613,4 +1613,19 @@ Error ONNXModelWriter::writeNNPICustomDSP(glow::NNPICustomDSPNode const *,
 }
 #endif // GLOW_WITH_NNPI
 
+#ifdef GLOW_WITH_HABANA
+Error ONNXModelWriter::writeHabanaFullyConnected(
+    glow::HabanaFullyConnectedNode const *, GraphType &graph) {
+  return MAKE_ERR("Unsupported Op for ONNX");
+}
+Error ONNXModelWriter::writeHabanaConvolution(
+    glow::HabanaConvolutionNode const *, GraphType &graph) {
+  return MAKE_ERR("Unsupported Op for ONNX");
+}
+Error ONNXModelWriter::writeHabanaConvolutionAdd(
+    glow::HabanaConvolutionAddNode const *, GraphType &graph) {
+  return MAKE_ERR("Unsupported Op for ONNX");
+}
+#endif // GLOW_WITH_HABANA
+
 } // namespace glow

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -15,6 +15,7 @@
  */
 #include "Base.h"
 
+#include "glow/Exporter/ONNXModelWriter.h"
 #include "glow/Importer/ONNXIFIModelLoader.h"
 #include "glow/Optimizer/GraphOptimizer/FunctionPasses.h"
 #include "glow/Optimizer/GraphOptimizer/GraphOptimizer.h"
@@ -24,11 +25,24 @@
 
 namespace glow {
 namespace onnxifi {
+bool GlowSaveOnnxifiModel = false;
+
 extern bool GlowDumpDebugTraces;
 
 namespace {
 const char *compatibilityFunctionName = "check";
 } // namespace
+
+void saveOnnxifiModel(Function *F) {
+  std::string fname = F->getName().str() + ".zip";
+  LOG(INFO) << "Saving model to " << fname;
+  Error err = Error::empty();
+  constexpr size_t kIrVer = 7, kOpsetVer = 10;
+  { ONNXModelWriter onnxWR(fname, *F, kIrVer, kOpsetVer, &err, false, true); }
+  if (ERR_TO_BOOL(std::move(err))) {
+    LOG(ERROR) << "ONNXModelWriter failed to write model: " << fname;
+  }
+}
 
 onnxStatus Backend::checkGraphCompatibility(const void *onnxModel,
                                             size_t onnxModelSize) {

--- a/lib/Onnxifi/Base.h
+++ b/lib/Onnxifi/Base.h
@@ -162,6 +162,9 @@ protected:
 
 typedef Graph *GraphPtr;
 
+/// Save the Function from ONNXIFI to a file
+void saveOnnxifiModel(Function *F);
+
 } // namespace onnxifi
 } // namespace glow
 

--- a/lib/Onnxifi/CMakeLists.txt
+++ b/lib/Onnxifi/CMakeLists.txt
@@ -20,6 +20,7 @@ target_link_libraries(onnxifi-glow-lib
                         Backends
                         ExecutionContext
                         ExecutionEngine
+                        Exporter
                         Graph
                         HostManager
                         Importer
@@ -31,6 +32,7 @@ target_link_libraries(onnxifi-glow
                         Backends
                         ExecutionContext
                         ExecutionEngine
+                        Exporter
                         Graph
                         HostManager
                         Importer

--- a/lib/Onnxifi/HostManagerOnnxifi.cpp
+++ b/lib/Onnxifi/HostManagerOnnxifi.cpp
@@ -22,6 +22,8 @@
 namespace glow {
 namespace onnxifi {
 
+extern bool GlowSaveOnnxifiModel;
+;
 int32_t GlowNumDevices = 0;
 bool GlowDumpDebugTraces = false;
 bool GlowSaturateHost = false;
@@ -132,6 +134,10 @@ HostManagerGraph::initGraph(const void *onnxModel, size_t onnxModelSize,
   // Make sure the pool is ready to go.
   for (auto &obj : onnxInputToPlaceholder_) {
     tensorPool_.reserve(obj.second->getType(), 10);
+  }
+
+  if (GlowSaveOnnxifiModel) {
+    saveOnnxifiModel(function);
   }
 
   return static_cast<HostManagerBackend *>(backendPtr_)

--- a/lib/Onnxifi/InlineOnnxifi.cpp
+++ b/lib/Onnxifi/InlineOnnxifi.cpp
@@ -26,6 +26,8 @@
 namespace glow {
 namespace onnxifi {
 
+extern bool GlowSaveOnnxifiModel;
+
 namespace {
 std::string getProfileFile(llvm::StringRef hash) {
   return strFormat("/tmp/glow-profile-%s.yaml", hash.str().c_str());
@@ -54,6 +56,9 @@ InlineGraph::initGraph(const void *onnxModel, size_t onnxModelSize,
 
   onnxInputToPlaceholder_ = loader->getInputVarsMapping();
   onnxOutputToPlaceholder_ = loader->getOutputVarsMapping();
+  if (GlowSaveOnnxifiModel) {
+    saveOnnxifiModel(function_);
+  }
 
   computeModelHash(onnxModel, onnxModelSize, modelHash_);
   optimize(function_, CompilationMode::Infer);


### PR DESCRIPTION
Summary: Dumping right before lowering to backend makes the repro a bit harder since it will go through optimization again. So we move the dumping to right after onnxifi.

Differential Revision: D18070674

