### PR TITLE
add configurable alignment to MemoryAllocator

### DIFF
--- a/include/glow/CodeGen/MemoryAllocator.h
+++ b/include/glow/CodeGen/MemoryAllocator.h
@@ -23,6 +23,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include "glow/Support/Memory.h"
+
 namespace glow {
 
 /// A POD struct that represents a single half-open allocation [start .. end).
@@ -57,8 +59,9 @@ public:
   /// A reserved value to mark invalid allocation.
   static const uint64_t npos;
 
-  explicit MemoryAllocator(const std::string &name, uint64_t poolSize)
-      : name_(name), poolSize_(poolSize) {}
+  explicit MemoryAllocator(const std::string &name, uint64_t poolSize,
+                           size_t alignment = TensorAlignment)
+      : name_(name), poolSize_(poolSize), alignment_{alignment} {}
 
   void reset() {
     maxMemoryAllocated_ = 0;
@@ -123,6 +126,9 @@ public:
   /// into.
   uint64_t getMemorySize() const { return poolSize_; }
 
+  /// \returns the alignment boundary used to align segments.
+  size_t getAlignment() const { return alignment_; }
+
   /// \returns the name of the memory region.
   const std::string &getName() const { return name_; }
 
@@ -135,6 +141,8 @@ private:
   uint64_t poolSize_;
   /// This is the high water mark for the allocated memory.
   uint64_t maxMemoryAllocated_{0};
+  /// The alignment boundary for each segment allocation.
+  size_t alignment_;
   /// Maps allocated addresses to the currently associated handles.
   std::unordered_map<uint64_t, Handle> addrToHandle_;
   /// Maps handles to the allocation information about the memory block

--- a/lib/CodeGen/MemoryAllocator.cpp
+++ b/lib/CodeGen/MemoryAllocator.cpp
@@ -16,7 +16,6 @@
 
 #include "glow/CodeGen/MemoryAllocator.h"
 #include "glow/Support/Debug.h"
-#include "glow/Support/Memory.h"
 
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/Casting.h"
@@ -45,7 +44,7 @@ const uint64_t MemoryAllocator::npos = -1;
 
 uint64_t MemoryAllocator::allocate(uint64_t size, Handle handle) {
   // Always allocate buffers properly aligned to hold values of any type.
-  uint64_t segmentSize = alignedSize(size, TensorAlignment);
+  uint64_t segmentSize = alignedSize(size, alignment_);
   uint64_t prev = 0;
   for (auto it = allocations_.begin(), e = allocations_.end(); it != e; it++) {
     if (it->begin_ - prev >= segmentSize) {
@@ -74,7 +73,7 @@ void MemoryAllocator::evictFirstFit(uint64_t size,
                                     const std::set<Handle> &mustNotEvict,
                                     std::vector<Handle> &evicted) {
   // Use the first fit strategy to evict allocated blocks.
-  size = alignedSize(size, TensorAlignment);
+  size = alignedSize(size, alignment_);
   bool hasSeenNonEvicted{false};
   uint64_t startAddress = 0;
   uint64_t begin = 0;

--- a/tests/unittests/MemoryAllocatorTest.cpp
+++ b/tests/unittests/MemoryAllocatorTest.cpp
@@ -320,3 +320,25 @@ TEST(MemAlloc, testGetMemorySize) {
   MemoryAllocator MA2("test1", 102);
   EXPECT_EQ(MA2.getMemorySize(), 102);
 }
+
+TEST(MemAlloc, testAlignment) {
+  MemoryAllocator MA1("test1", 1024, 128);
+  MemoryAllocator MA2("test2", 1024, 256);
+
+  void *handle0 = reinterpret_cast<void *>(0);
+  void *handle1 = reinterpret_cast<void *>(1);
+  void *handle2 = reinterpret_cast<void *>(2);
+  void *handle3 = reinterpret_cast<void *>(3);
+
+  // Both allocators start at zero.
+  auto p0 = MA1.allocate(10, handle0);
+  auto p1 = MA2.allocate(10, handle1);
+  EXPECT_EQ(p0, 0);
+  EXPECT_EQ(p1, 0);
+
+  // Second allocation starts at the alignment boundary.
+  auto p2 = MA1.allocate(10, handle2);
+  auto p3 = MA2.allocate(10, handle3);
+  EXPECT_EQ(p2, 128);
+  EXPECT_EQ(p3, 256);
+}


### PR DESCRIPTION
Summary: The MemoryAllocator supports alignment but is hard coded in the source, this adds a constructor argument setting the alignment so we can use different alignments in different backends of the same process.

Documentation: comments only

[Optional Fixes #issue]

Test Plan: unit tests, particularly new test
