### PR TITLE
[DeviceResidentTensors] Implementing device resident tensors in OpenCL

### DIFF
--- a/include/glow/Backends/DeviceManager.h
+++ b/include/glow/Backends/DeviceManager.h
@@ -152,6 +152,27 @@ public:
   /// \returns the DeviceInfo for this device containing peak limits for
   /// compute and bandwidths (used in partitioning).
   virtual DeviceInfo getDeviceInfo() const { return DeviceInfo(); }
+
+  /// Copies the contents of \p tensor from the host to the \p location address
+  /// on this device. Updates the tensor residency info.
+  virtual bool transferToDevice(Tensor &tensor, void *location) {
+    DCHECK("Not Implemented");
+    return false;
+  }
+
+  /// Copies the device buffer associated with \p tensor to the host.
+  /// The tensor must be resident on this device. If \p release is true, frees
+  /// the device memory. Updates the tensor residency info.
+  virtual bool transferFromDevice(Tensor &tensor, bool release = true) {
+    DCHECK("Not Implemented");
+    return false;
+  }
+
+  /// Releases the device buffer associated with \p tensor.
+  virtual bool releaseDeviceTensor(Tensor &tensor) {
+    DCHECK("Not Implemented");
+    return false;
+  }
 };
 
 } // namespace runtime

--- a/include/glow/Backends/DeviceManager.h
+++ b/include/glow/Backends/DeviceManager.h
@@ -17,6 +17,7 @@
 #define GLOW_BACKENDS_DEVICEMANAGER_H
 
 #include "glow/Backend/CompiledFunction.h"
+#include "glow/Base/DeviceTensorTransferManager.h"
 #include "glow/ExecutionContext/ExecutionContext.h"
 #include "glow/Graph/Graph.h"
 #include "glow/Runtime/RuntimeTypes.h"
@@ -42,7 +43,7 @@ using ReadyCBTy = std::function<void(const Module *, Error)>;
 using FunctionMapTy = std::map<std::string, CompiledFunction *>;
 
 /// Interface managing a specific instance of a device.
-class DeviceManager {
+class DeviceManager : public DeviceTensorTransferManager {
 protected:
   /// Configuration object for the device.
   DeviceConfig config_;
@@ -153,23 +154,23 @@ public:
   /// compute and bandwidths (used in partitioning).
   virtual DeviceInfo getDeviceInfo() const { return DeviceInfo(); }
 
-  /// Copies the contents of \p tensor from the host to the \p location address
-  /// on this device. Updates the tensor residency info.
-  virtual bool transferToDevice(Tensor &tensor, void *location) {
+  /// Copies the contents of \p tensor from the host to the \p location
+  /// address on this device. Updates the tensor residency info.
+  virtual bool transferToDevice(Tensor &tensor, void *locationContext) {
     DCHECK("Not Implemented");
     return false;
   }
 
   /// Copies the device buffer associated with \p tensor to the host.
-  /// The tensor must be resident on this device. If \p release is true, frees
-  /// the device memory. Updates the tensor residency info.
+  /// The tensor must be resident on this device. If \p release is true,
+  /// frees the device memory. Updates the tensor residency info.
   virtual bool transferFromDevice(Tensor &tensor, bool release = true) {
     DCHECK("Not Implemented");
     return false;
   }
 
   /// Releases the device buffer associated with \p tensor.
-  virtual bool releaseDeviceTensor(Tensor &tensor) {
+  virtual bool releaseDeviceTensor(void *locationContext) {
     DCHECK("Not Implemented");
     return false;
   }

--- a/include/glow/Base/DeviceTensorTransferManager.h
+++ b/include/glow/Base/DeviceTensorTransferManager.h
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_BASE_DEVICETENSORTRANSFERMANAGER_H
+#define GLOW_BASE_DEVICETENSORTRANSFERMANAGER_H
+
+#include "glow/Base/Tensor.h"
+
+namespace glow {
+
+class Tensor;
+
+class DeviceTensorTransferManager {
+public:
+  virtual ~DeviceTensorTransferManager() {}
+  /// Copies the contents of \p tensor from the host to the \p location address
+  /// on this device. Updates the tensor residency info.
+  virtual bool transferToDevice(Tensor &tensor, void *locationContext) = 0;
+
+  /// Copies the device buffer associated with \p tensor to the host.
+  /// The tensor must be resident on this device. If \p release is true, frees
+  /// the device memory. Updates the tensor residency info.
+  virtual bool transferFromDevice(Tensor &tensor, bool release = true) = 0;
+
+  /// Releases the device buffer associated with \p tensor.
+  virtual bool releaseDeviceTensor(void *locationContext) = 0;
+};
+
+} // namespace glow
+
+#endif // GLOW_BASE_DEVICETENSORTRANSFERMANAGER_H

--- a/include/glow/Runtime/HostManager/HostManager.h
+++ b/include/glow/Runtime/HostManager/HostManager.h
@@ -215,6 +215,8 @@ public:
   /// Get the network DAG for \p network if it exists.
   Expected<DAG *> getNetworkDAG(llvm::StringRef network);
 
+  void ensureOutputsAvailable(ExecutionContext &context);
+
   ~HostManager();
 };
 

--- a/include/glow/Runtime/RuntimeTypes.h
+++ b/include/glow/Runtime/RuntimeTypes.h
@@ -150,6 +150,9 @@ struct DeviceConfig {
   uint64_t deviceMemory = 0;
   /// A map of configuration parameters.
   llvm::StringMap<std::string> parameters{};
+  /// True to always copy output device tensors to host at the end of a function
+  /// run.
+  bool copyDeviceTensorsToHost{false};
 
   DeviceConfig(llvm::StringRef backendName) : backendName(backendName) {}
   DeviceConfig(llvm::StringRef backendName, llvm::StringRef name)

--- a/lib/Base/Tensor.cpp
+++ b/lib/Base/Tensor.cpp
@@ -473,6 +473,7 @@ ShapeVector glow::expandDimsToMax(llvm::ArrayRef<size_t> currDims) {
 }
 
 void Tensor::init(InitKind init, float val, PseudoRNG &PRNG) {
+  assert(!isDeviceResident() && "Tensor must reside on host to access data.");
   switch (init) {
   case InitKind::Zero:
     zero();
@@ -562,10 +563,12 @@ void Tensor::init(InitKind init, float val, PseudoRNG &PRNG) {
 }
 
 void Tensor::convertToType(ElemKind newTy) {
+  assert(!isDeviceResident() && "Tensor must reside on host to access data.");
   *this = this->getCopyConvertedToType(newTy);
 }
 
 Tensor Tensor::getCopyConvertedToType(ElemKind newKind) const {
+  assert(!isDeviceResident() && "Tensor must reside on host to access data.");
   const ElemKind origKind = getElementType();
   DCHECK((origKind == ElemKind::FloatTy && newKind == ElemKind::Float16Ty) ||
          (origKind == ElemKind::Float16Ty && newKind == ElemKind::FloatTy) ||

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -114,20 +114,23 @@ void glow::updateInputPlaceholdersByName(PlaceholderBindings &bindings,
 void ExecutionEngine::runInternal(ExecutionContext &context,
                                   llvm::StringRef name) {
   std::unique_ptr<ExecutionContext> contextPtr(&context);
+  std::unique_ptr<ExecutionContext> contextOut;
   std::promise<void> runPromise;
   auto fut = runPromise.get_future();
   Error runErr = Error::empty();
-  hostManager_->runNetwork(
-      name, std::move(contextPtr),
-      [&runPromise, &runErr](runtime::RunIdentifierTy, Error err,
-                             std::unique_ptr<ExecutionContext> contextPtr) {
-        // Don't delete context.
-        contextPtr.release();
-        runErr = std::move(err);
-        runPromise.set_value();
-      });
+  hostManager_->runNetwork(name, std::move(contextPtr),
+                           [&runPromise, &runErr, &contextOut](
+                               runtime::RunIdentifierTy, Error err,
+                               std::unique_ptr<ExecutionContext> contextPtr) {
+                             contextOut = std::move(contextPtr);
+                             runErr = std::move(err);
+                             runPromise.set_value();
+                           });
 
   fut.wait();
+  hostManager_->ensureOutputsAvailable(*contextOut.get());
+  // Don't delete context.
+  contextOut.release();
   EXIT_ON_ERR(std::move(runErr));
 }
 

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -480,6 +480,15 @@ void HostManager::updateExecutionStats(
                                 1000000 / duration);
 }
 
+void HostManager::ensureOutputsAvailable(ExecutionContext &context) {
+  for (auto &PH : context.getPlaceholderBindings()->pairs()) {
+    if (PH.second->isDeviceResident()) {
+      DCHECK_NOTNULL(PH.second->getDeviceManager());
+      PH.second->getDeviceManager()->transferFromDevice(*PH.second);
+    }
+  }
+}
+
 /// Helper to get the parameters in DeviceConfig from \p str. The \p str has
 /// multiple lines, and each line with this format : "str1" : "str2".
 static llvm::StringMap<std::string> getBackendParams(std::string &str) {

--- a/tests/unittests/BackendTestUtils.cpp
+++ b/tests/unittests/BackendTestUtils.cpp
@@ -200,6 +200,9 @@ void dispatchInference(const std::string &fname,
   for (auto &future : futures) {
     future.wait();
   }
+  for (unsigned i = 0; i < concurrentRequestsOpt; i++) {
+    hostManager->ensureOutputsAvailable(*contexts[i].get());
+  }
   // Release the original context passed in by reference so we don't free it.
   contexts[0].release();
 }

--- a/tests/unittests/DeviceManagerTest.cpp
+++ b/tests/unittests/DeviceManagerTest.cpp
@@ -36,7 +36,9 @@ class DeviceManagerTest : public ::testing::TestWithParam<std::string> {
 public:
   void SetUp() override {
     backendName = GetParam();
-    device.reset(DeviceManager::createDeviceManager(DeviceConfig(backendName)));
+    DeviceConfig config(backendName);
+    config.copyDeviceTensorsToHost = true;
+    device.reset(DeviceManager::createDeviceManager(config));
     ASSERT_TRUE(device.get());
     ASSERT_FALSE(ERR_TO_BOOL(device->init()));
   }

--- a/tests/unittests/TraceEventsTest.cpp
+++ b/tests/unittests/TraceEventsTest.cpp
@@ -428,6 +428,7 @@ TEST_P(TraceEventsTest, twoCompiles) {
   std::string name = F->getName();
   auto config =
       llvm::make_unique<runtime::DeviceConfig>(backend->getBackendName());
+  config->copyDeviceTensorsToHost = true;
   std::unique_ptr<runtime::DeviceManager> device(
       runtime::DeviceManager::createDeviceManager(*config));
   EXIT_ON_ERR(device->init());


### PR DESCRIPTION
Summary:
Device resident tensors API implementation with OpenCL backend.

* DeviceResidencyInfo - the class which stores residency info. 
  Tensor holds a shared_ptr to a default DRI object in order to be able to share the pointer on tensor "getUnowned" calls before any device transfers take place. Calls to "clone" produce an independent copy with a different DRI object. 

* DeviceTensorTransferManager - an interface of the transfer operations related to DRT. 

* Tensor: asserts were added on accessing host tensor data to ensure host manipulations and device residency are mutually exclusive.

* Functionality: OpenCL backend now supports DRT and leaves tensors on the device by default. This requires the user to transfer tensors to host to access data.
  - HostManager - implements the method "ensureOutputsAvailable()". Calling this after runNetworks ensures all tensors are on host.
  - Execution Engine - calling EE::run() uses hostManager and calls ensureOutputsAvailable().
  - DeviceManager based testing - "copyDeviceTensorsToHost" field was added to DeviceConfig to enable runFunction to transfer all tensors to host when complete. 

* OpenCL: in order to do device transfers a base address (cl_mem) and an offset are required. Both were wrapped in a struct OpenCLDeviceTransferContext. 
This should be eliminated if/when we change openCL compiled function to direct pointer calls (instead of base+offset pointer arithmetic, see below).    

Previous notes on openCL function:
OpenCL compiled function and kernels rely on pointer arithmetic in the contiguous memory section (defined by the runtime bundle). This doesn't fit with dynamic memory allocation for device tensor buffers. (Ongoing discussion with @nickgg ) This may be addressed multiple ways, for example:
    - Modify openCL function and kernels to support absolute addresses (instead of base+offset scheme). This enables dynamic memory allocation and also different memory management schemes (allocating per-tensor ahead-of time).
    - Blocking the entire contiguous memory section until all tensors are released (while doing the required ref-counting) 

Currently solved by "buffering" : copy to a separate device buffer when the function completes and free the function buffer.


Test Plan:
ninja test
