### PR TITLE
Fix broken .clang-tidy file

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,30 +1,29 @@
 ---
-# NOTE: there must be no spaces before the '-', so put the comma first.
-Checks: '
-  *
-  ,clang-diagnostic-*
-  ,modernize-*
-  ,clang-analyzer-*
-  ,-clang-analyzer-alpha*
-  ,-readability-named-parameter
-  ,-misc-unused-parameters
-  ,-google-runtime-references
-  ,-google-build-using-namespace
-  ,-cppcoreguidelines-pro-type-union-access
-  ,-google-readability-casting
-  ,-readability-implicit-bool-cast
-  ,-google-readability-todo
-  ,-readability-braces-around-statements
-  ,-google-readability-braces-around-statements
-  ,-performance-unnecessary-value-param
-  ,-misc-unused-using-decls
-  ,-modernize-pass-by-value
-  ,-modernize-raw-string-literal
-  ,-readability-else-after-return
-  ,-readability-implicit-bool-conversion
-  ,-cppcoreguidelines-pro-type-member-init
-  ,-hicpp-member-init
-  ,-cppcoreguidelines-pro-bounds-array-to-pointer-decay
+# NOTE: there must be no spaces before the '-', so put the comma last.
+Checks: '*,
+clang-diagnostic-*,
+modernize-*,
+clang-analyzer-*,
+-clang-analyzer-alpha*,
+-readability-named-parameter,
+-misc-unused-parameters,
+-google-runtime-references,
+-google-build-using-namespace,
+-cppcoreguidelines-pro-type-union-access,
+-google-readability-casting,
+-readability-implicit-bool-cast,
+-google-readability-todo,
+-readability-braces-around-statements,
+-google-readability-braces-around-statements,
+-performance-unnecessary-value-param,
+-misc-unused-using-decls,
+-modernize-pass-by-value,
+-modernize-raw-string-literal,
+-readability-else-after-return,
+-readability-implicit-bool-conversion,
+-cppcoreguidelines-pro-type-member-init,
+-hicpp-member-init,
+-cppcoreguidelines-pro-bounds-array-to-pointer-decay
   '
 WarningsAsErrors: ''
 HeaderFilterRegex: 'include/glow'


### PR DESCRIPTION
Summary:
The syntax in `.clang-tidy` does not have the desired effect.  Fixed formatting so that rules in the config are observed.

Differential Revision: D18092684

