### PR TITLE
[BackendTestUtils] Add -run-disabled-tests option to ignore blacklist

### DIFF
--- a/tests/stress/CMakeLists.txt
+++ b/tests/stress/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(SparseLengthsSumTest
 target_link_libraries(SparseLengthsSumTest
   PRIVATE
   Backends
+  BackendTestUtils
   ExecutionEngine
   gtest
   glog::glog)

--- a/tests/unittests/BackendTestUtils.cpp
+++ b/tests/unittests/BackendTestUtils.cpp
@@ -33,7 +33,7 @@
 
 namespace glow {
 
-llvm::cl::OptionCategory operatorTestCat("OperatorTest Category");
+llvm::cl::OptionCategory backendTestUtilsCat("BackendTestUtils Category");
 
 unsigned parCloneCountOpt;
 llvm::cl::opt<unsigned, /* ExternalStorage */ true> parCloneCountI(
@@ -43,7 +43,14 @@ llvm::cl::opt<unsigned, /* ExternalStorage */ true> parCloneCountI(
         "different backends. This option is not used by all unit "
         "tests; for now you must check the test to see if so."),
     llvm::cl::location(parCloneCountOpt), llvm::cl::Optional, llvm::cl::init(1),
-    llvm::cl::cat(operatorTestCat));
+    llvm::cl::cat(backendTestUtilsCat));
+
+bool runDisabledTests;
+llvm::cl::opt<bool, /* ExternalStorage */ true> runDisabledTestsI(
+    "run-disabled-tests",
+    llvm::cl::desc("If set, disabled tests will not be skipped."),
+    llvm::cl::location(runDisabledTests), llvm::cl::Optional,
+    llvm::cl::init(false), llvm::cl::cat(backendTestUtilsCat));
 
 using llvm::cast;
 

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -81,6 +81,9 @@ extern unsigned parCloneCountOpt;
 /// parameterized across many other values, e.g. those in ParameterSweepTest.
 DECLARE_STATELESS_BACKEND_TEST(BackendStatelessTest, std::tuple<std::string>);
 
+/// Whether to ignore the blacklist and run disabled tests.
+extern bool runDisabledTests;
+
 class BackendTest : public BackendStatelessTest {
 public:
   BackendTest(uint64_t deviceMemory = 0)
@@ -122,7 +125,7 @@ static const auto all_backends = ::testing::Values(
 // TODO: Replace return for GTEST_SKIP() so that skipped tests are
 // correctly reported once the macro gets available.
 #define ENABLED_BACKENDS(...)                                                  \
-  if (!isEnabledBackend({__VA_ARGS__}))                                        \
+  if (!runDisabledTests && !isEnabledBackend({__VA_ARGS__}))                   \
     GTEST_SKIP();
 
 /// Blacklist of tests for the current backend under test.
@@ -146,7 +149,8 @@ extern bool useSymmetricRowwiseQuantFC;
 
 /// Helper macro to check the current test against the blacklist.
 #define CHECK_IF_ENABLED()                                                     \
-  if (backendTestBlacklist.count(                                              \
+  if (!runDisabledTests &&                                                     \
+      backendTestBlacklist.count(                                              \
           ::testing::UnitTest::GetInstance()->current_test_info()->name()))    \
     GTEST_SKIP();
 


### PR DESCRIPTION
Make it easier to test disabled tests instead of manually changing the blacklist and recompiling.