### PR TITLE
[PyTorch Lower prim::GetAttr to Glow

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -764,8 +764,15 @@ PyTorchModelLoader::getSymbolsMapping() {
 
 // static
 bool PyTorchModelLoader::isNodeSupported(const torch::jit::Node *ptNode) {
+  const auto kind = ptNode->kind();
+
+  // Special case for prim::GetAttr, it's loaded separately from other ops.
+  if (kind == torch::jit::prim::GetAttr) {
+    return true;
+  }
+
   const auto &mapping = getSymbolsMapping();
-  return mapping.count(ptNode->kind()) != 0;
+  return mapping.count(kind) != 0;
 }
 
 Error PyTorchModelLoader::freezeWeights(const torch::jit::Node *ptNode) {
@@ -827,14 +834,27 @@ Error PyTorchModelLoader::freezeWeights(const torch::jit::Node *ptNode) {
   return Error::success();
 }
 
-Error PyTorchModelLoader::loadNode(const torch::jit::Node *node) {
+Error PyTorchModelLoader::loadNodes(const torch::jit::Graph &graph) {
   const auto &mapping = getSymbolsMapping();
-  auto it = mapping.find(node->kind());
 
-  RETURN_ERR_IF_NOT(it != mapping.end(),
-                    glow::strFormat("Node kind %s is not supported by Glow",
-                                    node->kind().toDisplayString()));
-  return (this->*it->second.loadFn)(node);
+  // Nodes are topologically sorted.
+  for (const auto &node : graph.nodes()) {
+    const auto kind = node->kind();
+
+    // prim::GetAttr is loaded separately.
+    if (kind == torch::jit::prim::GetAttr) {
+      continue;
+    }
+
+    auto it = mapping.find(kind);
+
+    RETURN_ERR_IF_NOT(it != mapping.end(),
+                      glow::strFormat("Node kind %s is not supported by Glow",
+                                      node->kind().toDisplayString()));
+    RETURN_IF_ERR((this->*it->second.loadFn)(node));
+  }
+
+  return Error::success();
 }
 
 Error PyTorchModelLoader::addValueMapping(const torch::jit::Value *value,
@@ -2396,6 +2416,82 @@ Error PyTorchModelLoader::loadConstant(const torch::jit::Node *ptNode) {
   return Error::success();
 }
 
+Error PyTorchModelLoader::loadAttributes(
+    const torch::jit::Graph &graph,
+    const at::ArrayRef<torch::jit::IValue> inputs) {
+
+  // Map from the Value in the Graph of an ivalue::Object to the Object and a
+  // string representing it's place in the module hierarchy.
+  std::unordered_map<const torch::jit::Value *,
+                     std::pair<const c10::ivalue::Object *, std::string>>
+      objectTree;
+
+  // Load graph inputs that are Objects.
+  auto graphInputValues = graph.inputs();
+  for (size_t i = 0; i < inputs.size(); ++i) {
+    const auto &input = inputs[i];
+    if (!input.isObject()) {
+      continue;
+    }
+
+    const auto &object = input.toObjectRef();
+
+    objectTree[graphInputValues[i]] =
+        std::make_pair(&object, object.type()->str().c_str());
+  }
+
+  // Load prim::GetAttr nodes.
+  for (const auto &node : graph.nodes()) {
+    if (node->kind() != torch::jit::prim::GetAttr) {
+      continue;
+    }
+
+    RETURN_IF_ERR(
+        checkInputAndOutputSizes(node->inputs(), 1, node->outputs(), 1));
+
+    const auto *inputValue = node->input();
+    const auto *outputValue = node->output();
+
+    RETURN_ERR_IF_NOT(objectTree.count(inputValue),
+                      "Missing input for prim::getAttr");
+
+    const auto &parent = objectTree.at(inputValue);
+    const auto *parentObject = parent.first;
+
+    const auto attrName = node->s(torch::jit::attr::name);
+    const auto ival = parentObject->getAttr(attrName);
+
+    // Concatenation of names of Objects and fields referenced in the Module
+    // tree.
+    const auto &nameHierarchy = parent.second;
+    const auto newNameHierarchy =
+        strFormat("%s_%s", nameHierarchy.c_str(), attrName.c_str());
+
+    if (ival.isObject()) {
+      objectTree[outputValue] =
+          std::make_pair(&ival.toObjectRef(), newNameHierarchy);
+      continue;
+    } else if (ival.isTensor()) {
+      const auto &ptTensor = ival.toTensor();
+      auto glowTensor = ptTensorToGlowTensor(ptTensor);
+
+      glow::Constant *glowConstant = F_.getParent()->createConstant(
+          newNameHierarchy, std::move(glowTensor));
+
+      if (copyTensorMemory_) {
+        glowConstant->ensureIsOwned();
+      }
+      RETURN_IF_ERR(addValueMapping(outputValue, glowConstant->getOutput()));
+    } else {
+      GlowIValue glowIVal;
+      RETURN_IF_ERR(glowIVal.fromIValue(ival));
+      RETURN_IF_ERR(addValueMapping(outputValue, std::move(glowIVal)));
+    }
+  }
+
+  return Error::success();
+}
+
 /*static*/
 Error PyTorchModelLoader::loadJITGraph(
     glow::Function &F, const torch::jit::Graph &graph,
@@ -2439,7 +2535,6 @@ PyTorchModelLoader::PyTorchModelLoader(
         if (inputValue->type()->kind() == c10::TypeKind::TensorType) {
           glow::Type t(scalarTypeToElemKind(inputMeta[i].type),
                        inputMeta[i].dims);
-          // ASSIGN_VALUE_OR_RETURN_ERR(t, glowIVal.toTensor());
           ph = F_.getParent()->createPlaceholder(&t, "input",
                                                  /*isTrainable*/ false);
         } else {
@@ -2452,12 +2547,15 @@ PyTorchModelLoader::PyTorchModelLoader(
         inputPlaceholdersReverseIndex_[ph] = i;
       } else {
         const c10::IValue inputIValue = inputs.at(i);
+        // Objects will be used to load model parameters.
+        if (inputIValue.isObject()) {
+          continue;
+        }
         GlowIValue glowIVal;
         RETURN_IF_ERR(glowIVal.fromIValue(inputIValue));
         if (glowIVal.isTensor()) {
           glow::Tensor *t;
           ASSIGN_VALUE_OR_RETURN_ERR(t, glowIVal.toTensor());
-          // ASSIGN_VALUE_OR_RETURN_ERR(t, glowIVal.toTensor());
           ph = F_.getParent()->createPlaceholder(&t->getType(), "input",
                                                  /*isTrainable*/ false);
           RETURN_IF_ERR(addValueMapping(inputValue, ph->getOutput()));
@@ -2469,19 +2567,9 @@ PyTorchModelLoader::PyTorchModelLoader(
       }
     }
 
-    // If weight freezing is enabled then freeze all weights. This is done
-    // before any nodes are loaded so all nodes see either frozen or unfrozen
-    // view of inputs in case any input is shared.
-    if (settings.weightFreezingEnabled) {
-      for (const auto &node : graph.nodes()) {
-        RETURN_IF_ERR(freezeWeights(node));
-      }
-    }
+    RETURN_IF_ERR(loadAttributes(graph, inputs));
 
-    // Nodes are topologically sorted.
-    for (const auto &node : graph.nodes()) {
-      RETURN_IF_ERR(loadNode(node));
-    }
+    RETURN_IF_ERR(loadNodes(graph));
 
     // Create Glow Placeholders for outputs.
     for (const torch::jit::Value *output : graph.outputs()) {
@@ -2566,10 +2654,7 @@ PyTorchModelLoader::PyTorchModelLoader(
           addValueMapping(graphInputValues[graphIdx], C->getOutput()));
     }
 
-    // Nodes are topologically sorted. Don't do any weight freezing first.
-    for (const auto &node : graph.nodes()) {
-      RETURN_IF_ERR(loadNode(node));
-    }
+    RETURN_IF_ERR(loadNodes(graph));
 
     // Create Glow Placeholders for outputs.
     for (const torch::jit::Value *output : graph.outputs()) {

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -269,9 +269,18 @@ private:
   /// Constants.
   Error freezeWeights(const torch::jit::Node *ptNode);
 
-  /// Load a given PyTorch Node \p ptNode. \returns
-  /// error on failure.
-  Error loadNode(const torch::jit::Node *ptNode);
+  /// Load all PyTorch prim::GetAttr nodes in \p graph. This method uses the
+  /// PyTorch Module hierarchy to map Values for all outputs of prim::GetAttr
+  /// nodes. If the output type of a prim::GetAttr is a tensor, this will load
+  /// it as a Glow constant, if it's an ivalue::Object it is ignored, and if
+  /// it's any other kind of IValue, it is loaded as a GlowIvalue for use during
+  /// the rest of model loading. \returns error on failure.
+  Error loadAttributes(const torch::jit::Graph &graph,
+                       const at::ArrayRef<torch::jit::IValue> inputs);
+
+  /// Load each PyTorch Node in the Graph \p graph.
+  /// \returns error on failure.
+  Error loadNodes(const torch::jit::Graph &graph);
 
   /// Load a PyTorch Constant node as a Glow Constant.
   /// \returns error on failure.

--- a/torch_glow/tests/nodes/getattr_test.py
+++ b/torch_glow/tests/nodes/getattr_test.py
@@ -1,0 +1,38 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import torch
+from tests.utils import GLOW_NODE_NAME, SUBGRAPH_ATTR
+import torch_glow
+
+
+def test_getattr():
+    """Test fusion of the PyTorch prim::GetAttr Node into the Glow subgraph."""
+    with torch.no_grad():
+        class Model(torch.nn.Module):
+            def __init__(self):
+                super(Model, self).__init__()
+                self.linear = torch.nn.Linear(2, 1)
+
+            def forward(self, x):
+                return self.linear(x)
+
+        x = torch.tensor([2., 3.])
+
+        torch_glow.enableFusionPass()
+
+        m = Model()
+        jit_m = torch.jit.trace(m, x)
+        jit_m_graph = jit_m.graph_for(x)
+
+        # Ensure all prim::GetAttrs were fused and none were left out
+        found_getattrs = False
+        for node in jit_m_graph.nodes():
+            kind = node.kind()
+            assert kind != "prim::GetAttr", "Expected all prim::GetAttrsGlow to be in Glow subgraph"
+            if kind == GLOW_NODE_NAME:
+                glow_subgraph = node.g(SUBGRAPH_ATTR)
+                for node in glow_subgraph.nodes():
+                    if node.kind() == "prim::GetAttr":
+                        found_getattrs = True
+
+        assert found_getattrs, "Expected to find prim::GetAttrs in the Glow subgraph"


### PR DESCRIPTION
Summary:
Instead of bringing Module attributes like parameters into the Glow subgraph as inputs, pull the self class in as an input and then get the attributes from the Module hierarchy below that.

There are some follow ups to this that will be needed
* Change the Glow custom fuser to only fuse prim::GetAttrs that produce values consumed by Glow Subgraph
* Add checks to other node loaders to ensure that values that should come from attributes (like Conv weights for example) actually do
* Remove the other PyTorchModelLoader constructor used for onnxifi training and use this instead (and get is_parameter from the corresponding Module slot) for training use case

Documentation:
Doxygen

Test Plan:
Unit test
