### PR TITLE
Add option to dump input/output across ONNXIFI layer

### DIFF
--- a/lib/Onnxifi/Base.h
+++ b/lib/Onnxifi/Base.h
@@ -158,6 +158,10 @@ protected:
 
   /// An object pool for tensors, to share allocations.
   TensorPool tensorPool_;
+
+private:
+  /// inference dump counter
+  std::atomic<size_t> ioDumpCounter_{0};
 };
 
 typedef Graph *GraphPtr;


### PR DESCRIPTION
Summary: This diff provides a unified place to dump input/output into glow so that we can pair it with model dumping to reproduce results.

Differential Revision: D18081703

