### PR TITLE
Fix various bugs in ONNX Exporter

### DIFF
--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -296,6 +296,16 @@ protected:
     return Error::success();
   }
 
+  /// Loads Sqr operator, given its protobuf representation and parsed args.
+  Error loadSqr(const OpType &op, ArgumentDictionaryTy &dict) {
+    const std::string &opName = loadOperatorName(op);
+    NodeValue in;
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
+    auto *R = G_.createPow(opName, in, 2.0f);
+    RETURN_IF_ERR(addNodeAsOutput(op, R));
+    return Error::success();
+  }
+
   /// Loads Reciprocal operator, given its protobuf representation and parsed
   /// args.
   Error loadReciprocal(const OpType &op, ArgumentDictionaryTy &dict) {
@@ -1059,6 +1069,10 @@ protected:
     }
     if (typeName == "Sqrt") {
       RETURN_IF_ERR(loadSqrt(op, dict));
+      return true;
+    }
+    if (typeName == "Sqr") {
+      RETURN_IF_ERR(loadSqr(op, dict));
       return true;
     }
     if (typeName == "Reciprocal") {

--- a/include/glow/Importer/ONNXModelLoader.h
+++ b/include/glow/Importer/ONNXModelLoader.h
@@ -207,6 +207,11 @@ class ONNXModelLoader
   Error loadFusedRowwiseQuantizedSparseLengthsWeightedSum(
       const ONNX_NAMESPACE::NodeProto &op, const ArgumentDictionaryTy &dict);
 
+  /// Load Glow FusedRowwiseQuantizedSparseLengthsSum operator.
+  Error
+  loadFusedRowwiseQuantizedSparseLengthsSum(const ONNX_NAMESPACE::NodeProto &op,
+                                            const ArgumentDictionaryTy &dict);
+
   /// Load Glow RowwiseQuantizedFullyConnected operator.
   Error loadRowwiseQuantizedFullyConnected(const ONNX_NAMESPACE::NodeProto &op,
                                            const ArgumentDictionaryTy &dict);

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -1222,14 +1222,6 @@ Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     return Error::success();
   }
 
-  if (typeName == "Sqr") {
-    NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
-    auto *pow = G_.createPow(opName, in, /* exp */ 2);
-    RETURN_IF_ERR(addNodeAsOutput(op, pow));
-    return Error::success();
-  }
-
   if (typeName == "SparseLengthsWeightedSum8BitsRowwise" ||
       typeName == "SparseLengthsSum8BitsRowwise" ||
       typeName == "SparseLengthsWeightedSumFused8BitRowwise" ||

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -38,7 +38,7 @@ void saveOnnxifiModel(Function *F) {
   std::string fname = F->getName().str() + ".zip";
   LOG(INFO) << "Saving model to " << fname;
   Error err = Error::empty();
-  constexpr size_t kIrVer = 7, kOpsetVer = 10;
+  constexpr size_t kIrVer = 7, kOpsetVer = 9;
   { ONNXModelWriter onnxWR(fname, *F, kIrVer, kOpsetVer, &err, false, true); }
   if (ERR_TO_BOOL(std::move(err))) {
     LOG(ERROR) << "ONNXModelWriter failed to write model: " << fname;


### PR DESCRIPTION
Summary:
- Support load of `Sqr` op in ONNX
- Support loading of `FusedRowwiseQuantizedSparseLengthsSum` node
- Fix `BatchMatMul` export when inputs are 3D
- Fix `ReduceSum` and `ReduceMean` to explicitly add keepdims=0 because default is 1
- Fix end indices of `Slice` during exporting
- Export `FullyConnected` properly

Differential Revision: D18102563

