### PR TITLE
Tell the different flavors of int8 types during ONNX export

### DIFF
--- a/lib/Exporter/ONNXModelWriter.cpp
+++ b/lib/Exporter/ONNXModelWriter.cpp
@@ -597,6 +597,10 @@ void ONNXModelWriter::writeTensor(const Tensor &T, TensorType *out) {
   }
 
   out->set_raw_data(T.getUnsafePtr(), type.getSizeInBytes());
+
+  if (type.isQuantizedType()) {
+    out->set_doc_string(type.getElementName());
+  }
 }
 
 void ONNXModelWriter::tensorShapeFromPlaceholder(const Placeholder *PH,


### PR DESCRIPTION
Summary: Previously we don't tell the difference between different int8 types (https://fburl.com/diffusion/uaz122mz). This will confuse the importer.

Differential Revision: D18093484

