### PR TITLE
Add fp16 flags to the repro

### DIFF
--- a/tests/unittests/Repro.cpp
+++ b/tests/unittests/Repro.cpp
@@ -60,6 +60,22 @@ llvm::cl::opt<float> thresholdOpt(
     "threshold", llvm::cl::desc("theshold for tensor numeric comparison"),
     llvm::cl::Optional, llvm::cl::init(1e-5), llvm::cl::cat(reproTestCat));
 
+llvm::cl::opt<bool>
+    globalFp16Opt("glow_global_fp16",
+                  llvm::cl::desc("Enable fp16 lowering for all ops on the net"),
+                  llvm::cl::Optional, llvm::cl::cat(reproTestCat));
+
+llvm::cl::opt<bool> fuseScaleOffsetFp16Opt(
+    "glow_global_fused_scale_offset_fp16",
+    llvm::cl::desc(
+        "Enable fp16 lowering for all op inputs using fused scale/offset"),
+    llvm::cl::Optional, llvm::cl::cat(reproTestCat));
+
+llvm::cl::opt<bool>
+    ClipFp16Opt("glow_clip_fp16",
+                llvm::cl::desc("Force glow to clip fp16 values to min/max"),
+                llvm::cl::Optional, llvm::cl::cat(reproTestCat));
+
 void parseCommandLine(int argc, char **argv) {
   llvm::sys::PrintStackTraceOnErrorSignal(argv[0]);
   llvm::cl::ParseCommandLineOptions(
@@ -102,6 +118,18 @@ void run() {
   // Build host manager and compile the module.
   // TODO: fix MAX_MEMORY
   PrecisionConfiguration precConfig;
+  if (globalFp16Opt) {
+    precConfig.convertToFP16 = globalFp16Opt;
+    llvm::outs() << "Conversion to fp16 enabled\n";
+  }
+  if (fuseScaleOffsetFp16Opt) {
+    precConfig.convertFusedToFP16 = fuseScaleOffsetFp16Opt;
+    llvm::outs() << "Conversion of fused scales/offsets to fp16 enabled\n";
+  }
+  if (ClipFp16Opt) {
+    precConfig.clipFP16 = ClipFp16Opt;
+    llvm::outs() << "Clipping to fp16 enabled\n";
+  }
   auto configs =
       runtime::generateDeviceConfigs(1, ExecutionBackend, MAX_MEMORY);
   auto hostManager =


### PR DESCRIPTION
Summary: Ported `--glow_global_fp16`, `--glow_global_fused_scale_offset_fp16`, `--glow_clip_fp16` to the repro binary.

Differential Revision: D18131165

