### PR TITLE
Add network_execution_e2e event trace output and report execution time and

### DIFF
--- a/include/glow/Runtime/HostManager/HostManager.h
+++ b/include/glow/Runtime/HostManager/HostManager.h
@@ -141,6 +141,10 @@ class HostManager final {
   /// Method to calculate and export aggregate memory usage counters.
   void exportMemoryCounters();
 
+  /// Execution stats update
+  static void updateExecutionStats(uint64_t startTime,
+                                   std::unique_ptr<ExecutionContext> &context);
+
 public:
   /// Default constructor.
   HostManager() = default;

--- a/lib/ExecutionContext/TraceEvents.cpp
+++ b/lib/ExecutionContext/TraceEvents.cpp
@@ -91,6 +91,10 @@ void TraceEvent::dumpTraceEvents(
       file << ", \"dur\": " << event.duration;
     }
 
+    if (event.id != -1) {
+      file << ", \"id\": \"" << event.id << "\"";
+    }
+
     if (!event.args.empty()) {
       file << ", \"args\": {";
       bool firstArg{true};
@@ -137,35 +141,53 @@ llvm::StringRef TraceEvent::traceLevelToString(TraceLevel level) {
 
 void TraceContext::logTraceEvent(
     llvm::StringRef name, TraceLevel level, char type,
-    std::map<std::string, std::string> additionalAttributes) {
+    std::map<std::string, std::string> additionalAttributes, size_t tid,
+    int id) {
   logTraceEvent(name, level, type, TraceEvent::now(),
-                std::move(additionalAttributes));
+                std::move(additionalAttributes), tid, id);
 }
 
 void TraceContext::logTraceEvent(
     llvm::StringRef name, TraceLevel level, char type, uint64_t timestamp,
-    std::map<std::string, std::string> additionalAttributes) {
+    std::map<std::string, std::string> additionalAttributes, size_t tid,
+    int id) {
   if (!shouldLog(level)) {
     return;
   }
 
-  TraceEvent ev(name, level, timestamp, type, threads::getThreadId(),
-                std::move(additionalAttributes));
+  TraceEvent ev(name, level, timestamp, type, tid,
+                std::move(additionalAttributes), id);
   {
     std::lock_guard<std::mutex> l(lock_);
     traceEvents_.push_back(std::move(ev));
   }
 }
 
+void TraceContext::logTraceEvent(TraceEvent &&ev) {
+  if (!shouldLog(ev.level)) {
+    return;
+  }
+  std::lock_guard<std::mutex> l(lock_);
+  traceEvents_.push_back(std::move(ev));
+}
+
 void TraceContext::logCompleteTraceEvent(
     llvm::StringRef name, TraceLevel level, uint64_t startTimestamp,
     std::map<std::string, std::string> additionalAttributes) {
+  this->logCompleteTraceEvent(name, level, startTimestamp,
+                              std::move(additionalAttributes),
+                              threads::getThreadId());
+}
+
+void TraceContext::logCompleteTraceEvent(
+    llvm::StringRef name, TraceLevel level, uint64_t startTimestamp,
+    std::map<std::string, std::string> additionalAttributes, size_t tid) {
   if (!shouldLog(level)) {
     return;
   }
 
   TraceEvent ev(name, level, startTimestamp, TraceEvent::now() - startTimestamp,
-                threads::getThreadId(), std::move(additionalAttributes));
+                tid, std::move(additionalAttributes));
   {
     std::lock_guard<std::mutex> l(lock_);
     traceEvents_.push_back(std::move(ev));
@@ -173,6 +195,7 @@ void TraceContext::logCompleteTraceEvent(
 }
 
 void TraceContext::setThreadName(int tid, llvm::StringRef name) {
+  std::lock_guard<std::mutex> l(lock_);
   threadNames_[tid] = name;
 }
 

--- a/lib/Support/ThreadPool.cpp
+++ b/lib/Support/ThreadPool.cpp
@@ -20,12 +20,14 @@ namespace glow {
 namespace threads {
 
 static std::atomic<std::size_t> thread_idx{0};
+
 size_t getThreadId() {
   thread_local std::size_t id = thread_idx++;
   return id;
 }
 
 size_t createThreadId() { return thread_idx++; }
+
 } // namespace threads
 
 ThreadExecutor::ThreadExecutor()


### PR DESCRIPTION
Summary:
Add network_execution_e2e event trace output and report execution time and
throughput to StatsExporter

Differential Revision: D18090219

