### PR TITLE
[GraphOptimizer] Add opt for eliminating concat->slices

### DIFF
--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -441,8 +441,9 @@ struct Type final {
     return std::make_pair(lowFloat, highFloat);
   }
 
-  /// \returns true if \p other is the same type.
-  bool isEqual(const Type &other) const {
+  /// \returns true if \p other is the same type. If \p allowDifferentShape then
+  /// shapes will not be considered as part of the equal comparison.
+  bool isEqual(const Type &other, bool allowDifferentShape = false) const {
     // Element type must be the same.
     if (elementType_ != other.elementType_) {
       return false;
@@ -452,9 +453,11 @@ struct Type final {
       return false;
     }
     // Sizes must be the same.
-    for (size_t i = 0; i < numSizes_; i++) {
-      if (sizes_[i] != other.sizes_[i]) {
-        return false;
+    if (!allowDifferentShape) {
+      for (size_t i = 0; i < numSizes_; i++) {
+        if (sizes_[i] != other.sizes_[i]) {
+          return false;
+        }
       }
     }
 


### PR DESCRIPTION
Skip unnecessary patterns where we see a concat followed by slices of its output, where we can eliminate both concat and slices. For example the following graph:

<img width="1226" alt="Screen Shot 2019-10-26 at 12 22 26 AM" src="https://user-images.githubusercontent.com/1198212/67615893-bbcd8f00-f786-11e9-8921-0fbb91eed09c.png">

Is transformed into:

<img width="1226" alt="Screen Shot 2019-10-26 at 12 23 17 AM" src="https://user-images.githubusercontent.com/1198212/67615900-d142b900-f786-11e9-8b95-5d91578013c8.png">
