### PR TITLE
[LLVMIRCodeGen] Minor improvements

### DIFF
--- a/include/glow/LLVMIRCodeGen/LLVMIRGen.h
+++ b/include/glow/LLVMIRCodeGen/LLVMIRGen.h
@@ -85,7 +85,7 @@ protected:
   /// \param builder IRBuilder to be used for the LLVM IR code emission.
   /// \param bundle set of instructions to be emitted as a data-parallel kernel.
   /// \param argType types of arguments for the data-parallel kernel.
-  /// \bufferToArgNum mapping from a buffer to its argument number in the
+  /// \param bufferToArgNum mapping from a buffer to its argument number in the
   /// data-parallel kernel.
   /// \param buffers buffers used by the data-parallel kernel.
   virtual void

--- a/include/glow/LLVMIRCodeGen/LLVMIRGen.h
+++ b/include/glow/LLVMIRCodeGen/LLVMIRGen.h
@@ -281,7 +281,7 @@ public:
                                       glow::ElemKind elemTy);
   /// Optimize the function \p F and the module that owns it. Use the target
   /// information from the \p TM target machine.
-  virtual void optimizeLLVMModule(llvm::Function *F, llvm::TargetMachine &TM);
+  virtual void optimizeLLVMModule(llvm::Module *M, llvm::TargetMachine &TM);
   /// Performs specialization of operations based on constant parameters.
   virtual void performSpecialization();
   /// \returns allocations info.

--- a/lib/LLVMIRCodeGen/DebugInfo.cpp
+++ b/lib/LLVMIRCodeGen/DebugInfo.cpp
@@ -42,7 +42,8 @@ void LLVMIRGen::setCurrentDebugLocation(llvm::IRBuilder<> &builder,
     return;
   auto instrNum = instrNumbering_->getInstrNumber(I);
   auto DILoc = llvm::DILocation::get(
-      ctx_, dbgInfo_.mainFileFirstInstrLineNo_ + instrNum, 0, dbgInfo_.mainF_);
+      getLLVMContext(), dbgInfo_.mainFileFirstInstrLineNo_ + instrNum, 0,
+      dbgInfo_.mainF_);
   llvm::DebugLoc loc(DILoc);
   builder.SetCurrentDebugLocation(loc);
 }
@@ -130,7 +131,8 @@ void LLVMIRGen::generateFunctionDebugInfo(llvm::Function *F) {
     for (auto &I : BB) {
       if (I.getDebugLoc())
         continue;
-      I.setDebugLoc(llvm::DebugLoc(llvm::DILocation::get(ctx_, 0, 0, scope)));
+      I.setDebugLoc(
+          llvm::DebugLoc(llvm::DILocation::get(getLLVMContext(), 0, 0, scope)));
     }
   }
 }
@@ -327,9 +329,9 @@ void LLVMIRGen::emitDebugGlobalVariableForValue(const Value *val) {
   auto dbgElemTy = getDebugType(*builder_, getElementType(*builder_, val));
   llvm::SmallVector<llvm::Metadata *, 8> subranges;
   for (auto dim : dims) {
-    subranges.push_back(llvm::DISubrange::get(ctx_, dim));
+    subranges.push_back(llvm::DISubrange::get(getLLVMContext(), dim));
   }
-  auto subscripts = llvm::MDTuple::get(ctx_, subranges);
+  auto subscripts = llvm::MDTuple::get(getLLVMContext(), subranges);
   auto dbgArrayTy = DIBuilder_->createArrayType(
       ty->getSizeInBytes() * 8, sizeof(float), dbgElemTy, subscripts);
 
@@ -416,7 +418,8 @@ void LLVMIRGen::generateDebugInfo() {
         if (I.getDebugLoc() &&
             I.getDebugLoc()->getScope()->getName() != F.getName())
           continue;
-        I.setDebugLoc(llvm::DebugLoc(llvm::DILocation::get(ctx_, 0, 0, scope)));
+        I.setDebugLoc(llvm::DebugLoc(
+            llvm::DILocation::get(getLLVMContext(), 0, 0, scope)));
       }
     }
   }

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -284,8 +284,6 @@ void LLVMIRGen::performCodeGen() {
   // Generate debug information.
   generateDebugInfo();
 
-  // And pass the ownership to the JIT.
-
   if (dumpIR) {
     llvm::outs() << "LLVM module after optimizations:\n";
     llmodule_->print(llvm::outs(), nullptr);
@@ -736,7 +734,7 @@ void LLVMIRGen::emitDataParallelKernel(
     // If adding the buffers of current instruction might make the total number
     // of unique buffer exceed `kArgLimit`, we need to emit the kernel and start
     // over. Note the "might" as this method is pessimistic, because number of
-    // buffers from current instructure might not be unique. Trade-off here is
+    // buffers from current instruction might not be unique. Trade-off here is
     // that the algorithm is cleaner and in practice, if we over-estimate the
     // argument size by several, it does not matter too much.
     if (argTypes.size() + I->getOperands().size() > kArgLimit) {

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -212,6 +212,10 @@ void LLVMIRGen::initCodeGen() {
   llvm::BasicBlock *entry_bb =
       llvm::BasicBlock::Create(getLLVMContext(), "entry", func);
   builder_ = llvm::make_unique<llvm::IRBuilder<>>(entry_bb);
+  // Terminate the function with a return instruction.
+  auto *ret = builder_->CreateRetVoid();
+  // Emit all the code before the retrun instruction.
+  builder_->SetInsertPoint(ret);
 
   // Initialize the debug information emission.
   initDebugInfo();
@@ -253,13 +257,9 @@ llvm::Type *LLVMIRGen::getElementType(llvm::IRBuilder<> &builder,
 }
 
 void LLVMIRGen::performCodeGen() {
-  auto *func = builder_->GetInsertBlock()->getParent();
   loadBaseAddresses(*builder_);
 
   generateLLVMIRForModule(*builder_);
-
-  // Terminate the function.
-  builder_->CreateRetVoid();
 
   if (dumpIR) {
     llvm::outs() << "LLVM module before optimizations:\n";

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -279,7 +279,7 @@ void LLVMIRGen::performCodeGen() {
   }
 
   // Optimize the module.
-  optimizeLLVMModule(func, getTargetMachine());
+  optimizeLLVMModule(&getModule(), getTargetMachine());
 
   // Generate debug information.
   generateDebugInfo();

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -182,7 +182,7 @@ static void registerEmptyDiagHandler(llvm::LLVMContext &ctx) {
 void LLVMIRGen::initCodeGen() {
   instrNumbering_.reset(new InstructionNumbering(*F_));
   // Load the jit library as a new module.
-  llmodule_ = loadStandardLibrary(&ctx_, "libjit.bc", libjitBC_);
+  llmodule_ = loadStandardLibrary(&getLLVMContext(), "libjit.bc", libjitBC_);
   CHECK(llmodule_.get()) << "Unable to load the JIT library.";
 
   // By default, LLVM would emit some diagnostics, remarks, etc. It is fine for
@@ -190,25 +190,27 @@ void LLVMIRGen::initCodeGen() {
   // providing a dummy diagnostics handler, that does not emit anything.
   // In particular, this allows us to get rid of the annoying "cannot vectorize"
   // warnings.
-  registerEmptyDiagHandler(ctx_);
+  registerEmptyDiagHandler(getLLVMContext());
 
   // Assign the target information to the module.
   llmodule_->setDataLayout(getTargetMachine().createDataLayout());
 
   // Create the entry function into the LLVM module.
-  auto int8PtrTy = llvm::Type::getInt8PtrTy(ctx_);
-  auto sizeTPtrTy = llvm::Type::getIntNPtrTy(ctx_, getLibjitSizeTWidth());
+  auto int8PtrTy = llvm::Type::getInt8PtrTy(getLLVMContext());
+  auto sizeTPtrTy =
+      llvm::Type::getIntNPtrTy(getLLVMContext(), getLibjitSizeTWidth());
   // The entry point has the following API:
   // void entry(uint8_t *baseConstantWeightVars, uint8_t
   // *baseInoutWeightVars, uint8_t *baseActivations, size_t *offsets);
-  llvm::Type *voidTy = llvm::Type::getVoidTy(ctx_);
+  llvm::Type *voidTy = llvm::Type::getVoidTy(getLLVMContext());
   llvm::FunctionType *jitFuncTy = llvm::FunctionType::get(
       voidTy, {int8PtrTy, int8PtrTy, int8PtrTy, sizeTPtrTy}, false);
   auto *func = llvm::Function::Create(
       jitFuncTy, llvm::Function::ExternalLinkage, "main", llmodule_.get());
 
   // Setup the entry basic block and initialize the IR builder.
-  llvm::BasicBlock *entry_bb = llvm::BasicBlock::Create(ctx_, "entry", func);
+  llvm::BasicBlock *entry_bb =
+      llvm::BasicBlock::Create(getLLVMContext(), "entry", func);
   builder_ = llvm::make_unique<llvm::IRBuilder<>>(entry_bb);
 
   // Initialize the debug information emission.
@@ -316,37 +318,37 @@ llvm::Value *LLVMIRGen::emitValueAddress(llvm::IRBuilder<> &builder,
 
   switch (val->getElementType()) {
   case ElemKind::FloatTy:
-    T = llvm::Type::getFloatPtrTy(ctx_);
+    T = llvm::Type::getFloatPtrTy(getLLVMContext());
     break;
   case ElemKind::Int8QTy:
-    T = llvm::Type::getInt8PtrTy(ctx_);
+    T = llvm::Type::getInt8PtrTy(getLLVMContext());
     break;
   case ElemKind::UInt8QTy:
-    T = llvm::Type::getInt8PtrTy(ctx_);
+    T = llvm::Type::getInt8PtrTy(getLLVMContext());
     break;
   case ElemKind::Int16QTy:
-    T = llvm::Type::getInt16PtrTy(ctx_);
+    T = llvm::Type::getInt16PtrTy(getLLVMContext());
     break;
   case ElemKind::Int32QTy:
-    T = llvm::Type::getInt32PtrTy(ctx_);
+    T = llvm::Type::getInt32PtrTy(getLLVMContext());
     break;
   case ElemKind::Int64ITy:
-    T = llvm::Type::getInt64PtrTy(ctx_);
+    T = llvm::Type::getInt64PtrTy(getLLVMContext());
     break;
   case ElemKind::Int32ITy:
-    T = llvm::Type::getInt32PtrTy(ctx_);
+    T = llvm::Type::getInt32PtrTy(getLLVMContext());
     break;
   case ElemKind::UInt8FusedQTy:
-    T = llvm::Type::getInt8PtrTy(ctx_);
+    T = llvm::Type::getInt8PtrTy(getLLVMContext());
     break;
   case ElemKind::UInt8FusedFP16QTy:
-    T = llvm::Type::getInt8PtrTy(ctx_);
+    T = llvm::Type::getInt8PtrTy(getLLVMContext());
     break;
   case ElemKind::UInt4FusedFP16QTy:
-    T = llvm::Type::getInt8PtrTy(ctx_);
+    T = llvm::Type::getInt8PtrTy(getLLVMContext());
     break;
   case ElemKind::BoolTy:
-    T = llvm::Type::getInt8PtrTy(ctx_);
+    T = llvm::Type::getInt8PtrTy(getLLVMContext());
     break;
   default:
     LOG(FATAL) << "Unsupported element type: "
@@ -461,7 +463,7 @@ llvm::Value *LLVMIRGen::emitValueSize(llvm::IRBuilder<> &builder,
 }
 
 llvm::Value *LLVMIRGen::emitConstF32(llvm::IRBuilder<> &builder, float val) {
-  return llvm::ConstantFP::get(llvm::Type::getFloatTy(ctx_), val);
+  return llvm::ConstantFP::get(llvm::Type::getFloatTy(getLLVMContext()), val);
 }
 
 llvm::Value *LLVMIRGen::emitConstI32(llvm::IRBuilder<> &builder, int32_t val) {
@@ -484,7 +486,7 @@ llvm::Value *LLVMIRGen::emitConst(llvm::IRBuilder<> &builder, float val,
                                   glow::ElemKind kind) {
   switch (kind) {
   case ElemKind::FloatTy:
-    return llvm::ConstantFP::get(llvm::Type::getFloatTy(ctx_), val);
+    return llvm::ConstantFP::get(llvm::Type::getFloatTy(getLLVMContext()), val);
   case ElemKind::Float16Ty:
     llvm_unreachable("Not implemented");
   case ElemKind::Int64ITy:
@@ -514,7 +516,7 @@ llvm::Value *LLVMIRGen::emitConst(llvm::IRBuilder<> &builder, float val,
 llvm::Value *LLVMIRGen::emitStringConst(llvm::IRBuilder<> &builder,
                                         llvm::StringRef str) {
   llvm::Constant *constStrArray =
-      llvm::ConstantDataArray::getString(ctx_, str, true);
+      llvm::ConstantDataArray::getString(getLLVMContext(), str, true);
   llvm::GlobalVariable *gvarStr = new llvm::GlobalVariable(
       *llmodule_, constStrArray->getType(), true,
       llvm::GlobalValue::PrivateLinkage, constStrArray, ".str");
@@ -659,7 +661,7 @@ void LLVMIRGen::emitDataParallelKernelImpl(
     return;
   }
   // Create stacked kernel function type.
-  llvm::Type *voidTy = llvm::Type::getVoidTy(ctx_);
+  llvm::Type *voidTy = llvm::Type::getVoidTy(getLLVMContext());
   llvm::FunctionType *kernelFuncTy =
       llvm::FunctionType::get(voidTy, argTypes, false);
   auto *kernelFunc =
@@ -673,13 +675,13 @@ void LLVMIRGen::emitDataParallelKernelImpl(
 
   // Create the entry BB.
   llvm::BasicBlock *entryBB =
-      llvm::BasicBlock::Create(ctx_, "entry", kernelFunc);
+      llvm::BasicBlock::Create(getLLVMContext(), "entry", kernelFunc);
   llvm::IRBuilder<> kernelBuilder(entryBB);
   // Number of tensor elements.
   auto *numElements =
       emitValueSize(kernelBuilder, bundle[0]->getOperand(0).first);
   // Create a loop inside the stacked kernel function being generated.
-  auto loopBBs = createLoop(kernelBuilder, ctx_, numElements);
+  auto loopBBs = createLoop(kernelBuilder, getLLVMContext(), numElements);
 
   // Get the index parameter of the loop.
   // This is the PHI node of the BB.

--- a/lib/LLVMIRCodeGen/Pipeline.cpp
+++ b/lib/LLVMIRCodeGen/Pipeline.cpp
@@ -63,9 +63,7 @@ bool LLVMIRGen::preserveSymbol(const llvm::GlobalValue &GV) {
   return true;
 }
 
-void LLVMIRGen::optimizeLLVMModule(llvm::Function *F, llvm::TargetMachine &TM) {
-  auto *M = F->getParent();
-
+void LLVMIRGen::optimizeLLVMModule(llvm::Module *M, llvm::TargetMachine &TM) {
   // Make all of the definitions from libjit and unnamed symbols internal and
   // optimizable. Everything else should be preserved as is.
   auto preserveSymbolCallback = [&](const llvm::GlobalValue &GV) -> bool {


### PR DESCRIPTION
A bunch of very small improvements. Almost NFC.

- Use the getLLVMContext getter instead of explicit ctx_ to hide implementation details
- Fix the parameter type of optimizeLLVMModule

  As the name of the method implies, it operates on modules. Thus it should take an LLVM module as a parameter.
- [LLVMIRCodeGen] Add a ret instruction when creating a new LLVM function to ensure that the new LLVM function is well-formed at any time

  Until now "ret" was inserted at the very end of the code emission which kept this function non well-formed for this whole time.
- Fix spelling & comments