### PR TITLE
Added new interface for cacheable Placeholders

### DIFF
--- a/include/glow/Backend/Backend.h
+++ b/include/glow/Backend/Backend.h
@@ -136,6 +136,11 @@ public:
   /// inputs that can have variable size (e.g., embedding indices).
   virtual bool supportsPartialTensors() const { return false; }
 
+  /// \returns true if the Backend supports static Placeholders. This means
+  /// an input can be treated as a placeholder that can be reused on the device
+  /// for multiple requests.
+  virtual bool supportsStaticPlaceholders() const { return false; }
+
   /// \returns true if Backend generated Instruction for Node \p N,
   /// using IRGenVisitor \p irgen.
   virtual bool generateInst(Node *N, IRGenVisitor &irgen) const {

--- a/include/glow/Backends/DeviceManager.h
+++ b/include/glow/Backends/DeviceManager.h
@@ -120,6 +120,16 @@ public:
               std::unique_ptr<ExecutionContext> context,
               runtime::ResultCBTy resultCB) = 0;
 
+  /// Copies the contents of Tensor \p T to the device resource allocated to
+  /// Placeholder \p PH. once finished calls \p resultCB with the result of the
+  /// operation.
+  virtual void
+  transferStaticPlaceholderToDevice(Placeholder *PH, Tensor *T,
+                                    std::function<void(Error)> resultCB) {
+    resultCB(MAKE_ERR(ErrorValue::ErrorCode::RUNTIME_ERROR,
+                      "Unsupported feature, cannot copy Placeholder."));
+  };
+
   /// Stops execution and shuts down the Device.
   virtual Error stop(bool block = true) { return Error::success(); };
 

--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -143,6 +143,10 @@ class Placeholder : public Storage {
   /// Specifies if associated Tensors should be zeroed when allocated.
   bool allocZero_{false};
 
+  /// Specifies if this is a static placeholder, this means it is set once
+  /// before the first network run and will be reused by following runs.
+  bool isStatic_{false};
+
 public:
   /// Create a new placeholder.
   Placeholder(llvm::StringRef name, TypeRef Ty, bool isTrainable)
@@ -157,6 +161,12 @@ public:
 
   /// \returns True if associated Tensors should be zeroed when allocated.
   bool allocZero() const { return allocZero_; }
+
+  /// Update the isStatic_ field.
+  void setStatic(bool isStatic) { isStatic_ = isStatic; }
+
+  /// Get the status of the isStatic_ flag.
+  bool isStatic() const { return isStatic_; }
 
   /// Sets whether or not associated Tensors should be zeroed.
   void setAllocZero(bool on = true) { allocZero_ = on; }


### PR DESCRIPTION
Summary:
This adds the notion of a cacheable Placeholder. This type of placeholder is used for values that do can be constant across more than one inference request. This is also useful for loading large constants after compilation by treating them as cacheable placeholders.
This is just the interface, implementations will follow.

Documentation:

Test Plan:

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
