### PR TITLE
[PyTorch] Add quantized::add_relu

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -333,6 +333,10 @@ private:
   /// \return error on failure.
   Error loadQuantizedAdd(const torch::jit::Node *ptNode);
 
+  /// Load a PyTorch quantized::add_relu node.
+  /// \return error on failure.
+  Error loadQuantizedAddRelu(const torch::jit::Node *ptNode);
+
   /// Load a PyTorch glow::unpacked_quantized_conv node.
   // \return error on failure.
   Error loadQuantizedConvUnpacked(const torch::jit::Node *ptNode);

--- a/torch_glow/tests/nodes/quantized_add_relu_test.py
+++ b/torch_glow/tests/nodes/quantized_add_relu_test.py
@@ -1,0 +1,41 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import torch
+
+from tests.utils import jitVsGlow
+
+
+def test_quantized_add_relu_zerooffset():
+    """Basic test of the PyTorch quantized::add Node_relu on Glow with zero offset."""
+
+    def test_f(a, b):
+        q = torch.nn.quantized.Quantize(
+            scale=0.3, zero_point=0, dtype=torch.quint8)
+        dq = torch.nn.quantized.DeQuantize()
+        return dq(torch.ops.quantized.add_relu(q(a), q(b), scale=0.05, zero_point=0))
+
+    x = torch.tensor([1, 2, 3, 4], dtype=torch.float32)
+    y = torch.tensor([5, 6, 7, 8], dtype=torch.float32)
+
+    jitVsGlow(test_f, x, y, expected_fused_ops={"quantized::add_relu",
+                                                "aten::quantize_per_tensor",
+                                                "aten::dequantize"})
+
+
+def test_quantized_add_relu():
+    """Basic test of the PyTorch quantized::add_relu Node on Glow."""
+
+    def test_f(a, b):
+        q1 = torch.nn.quantized.Quantize(
+            scale=1.0/128, zero_point=5, dtype=torch.quint8)
+        q2 = torch.nn.quantized.Quantize(
+            scale=1.0/128, zero_point=10, dtype=torch.quint8)
+        dq = torch.nn.quantized.DeQuantize()
+        return dq(torch.ops.quantized.add_relu(q1(a), q2(b), scale=1.0/128, zero_point=3))
+
+    x = torch.randn([5, 5])
+    y = torch.randn([5, 5])
+
+    jitVsGlow(test_f, x, y, expected_fused_ops={"quantized::add_relu",
+                                                "aten::quantize_per_tensor",
+                                                "aten::dequantize"})


### PR DESCRIPTION
Since we are using this instead of quantized::add in cv model.
pytest tests/nodes/quantized_add_relu_test.py