### PR TITLE
Fix crash with --instrument-debug

### DIFF
--- a/lib/Optimizer/IROptimizer/IROptimizer.cpp
+++ b/lib/Optimizer/IROptimizer/IROptimizer.cpp
@@ -1538,7 +1538,11 @@ static void performDebugInstrumentation(IRFunction &M) {
         name += ".";
         name += I->getKindName();
         auto *dumpInstr = new DebugPrintInst(name, Op.first);
-        M.insertInstruction(&*next, dumpInstr);
+        if (next == e) {
+          M.insertInstruction(dumpInstr);
+        } else {
+          M.insertInstruction(&*next, dumpInstr);
+        }
       }
     }
     it = next;


### PR DESCRIPTION
Summary:
Currently calls `IRFunction::insertInstruction` with `InstListTy::end` iterator and crashes

Documentation:
n/a

Test Plan:
`ninja all`
`./tests/InterpreterOperatorTest --instrument-debug`
no crash