### PR TITLE
[LLVMIRCodeGen] Add command-line options to provide a code model to be used for JIT and bundles and a relocation model

### DIFF
--- a/include/glow/LLVMIRCodeGen/LLVMBackend.h
+++ b/include/glow/LLVMIRCodeGen/LLVMBackend.h
@@ -39,6 +39,8 @@ class LLVMBackend : public BackendUsingGlowIR {
   std::string cpu_;
   /// Code model used by this backend.
   llvm::CodeModel::Model codeModel_;
+  /// Code model used by this backend for bundles.
+  llvm::CodeModel::Model bundleCodeModel_;
   /// Relocation model used by this backend.
   llvm::Reloc::Model relocModel_;
 
@@ -62,9 +64,15 @@ public:
   void setCodeModel(llvm::CodeModel::Model codeModel) {
     codeModel_ = codeModel;
   }
+  /// \returns code model used by this backend for bundles.
+  llvm::CodeModel::Model getBundleCodeModel() const { return bundleCodeModel_; }
+  /// Sets code model used by this backend for bundles.
+  void setBundleCodeModel(llvm::CodeModel::Model codeModel) {
+    bundleCodeModel_ = codeModel;
+  }
   /// \returns relocation model used by this backend.
   llvm::Reloc::Model getRelocModel() const { return relocModel_; }
-  // Sets Relocation Model used by this backend
+  /// Sets relocation model used by this backend.
   void setRelocModel(llvm::Reloc::Model relocModel) {
     relocModel_ = relocModel;
   }

--- a/lib/LLVMIRCodeGen/CommandLine.cpp
+++ b/lib/LLVMIRCodeGen/CommandLine.cpp
@@ -30,6 +30,37 @@ llvm::cl::opt<std::string>
 llvm::cl::opt<std::string> llvmCPU("mcpu",
                                    llvm::cl::desc("LLVM CPU to be used"));
 
+llvm::cl::opt<llvm::CodeModel::Model> llvmCodeModel(
+    "code-model",
+    llvm::cl::desc("Specify which code model to use on the target machine"),
+    llvm::cl::values(
+        clEnumValN(llvm::CodeModel::Model::Small, "small", "Small code model"),
+        clEnumValN(llvm::CodeModel::Model::Medium, "medium",
+                   "Medium code model"),
+        clEnumValN(llvm::CodeModel::Model::Large, "large", "Large code model")),
+    llvm::cl::init(llvm::CodeModel::Model::Large),
+    llvm::cl::cat(getLLVMBackendCat()));
+
+llvm::cl::opt<llvm::CodeModel::Model> llvmBundleCodeModel(
+    "bundle-code-model",
+    llvm::cl::desc("Specify which code model to use for a bundle"),
+    llvm::cl::values(
+        clEnumValN(llvm::CodeModel::Model::Small, "small", "Small code model"),
+        clEnumValN(llvm::CodeModel::Model::Medium, "medium",
+                   "Medium code model"),
+        clEnumValN(llvm::CodeModel::Model::Large, "large", "Large code model")),
+    llvm::cl::init(llvm::CodeModel::Model::Small),
+    llvm::cl::cat(getLLVMBackendCat()));
+
+llvm::cl::opt<llvm::Reloc::Model> llvmRelocModel(
+    "relocation-model",
+    llvm::cl::desc(
+        "Specify which relocation model to use on the target machine"),
+    llvm::cl::values(
+        clEnumValN(llvm::Reloc::Static, "static", "Non-relocatable code"),
+        clEnumValN(llvm::Reloc::PIC_, "pic", "Position independent code")),
+    llvm::cl::init(llvm::Reloc::Static), llvm::cl::cat(getLLVMBackendCat()));
+
 llvm::cl::list<std::string>
     llvmTargetFeatures("target-feature",
                        llvm::cl::desc("LLVM target/CPU features to be used"),

--- a/lib/LLVMIRCodeGen/CommandLine.h
+++ b/lib/LLVMIRCodeGen/CommandLine.h
@@ -17,6 +17,7 @@
 #ifndef GLOW_LLVMIRCODEGEN_COMMANDLINE_H
 #define GLOW_LLVMIRCODEGEN_COMMANDLINE_H
 
+#include "llvm/Support/CodeGen.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Target/TargetOptions.h"
 
@@ -34,6 +35,15 @@ extern llvm::cl::opt<std::string> llvmArch;
 
 /// CPU to be used by the LLVMBackend. Used as -mcpu=cpuA.
 extern llvm::cl::opt<std::string> llvmCPU;
+
+/// Code model to be used by the LLVMBackend.
+extern llvm::cl::opt<llvm::CodeModel::Model> llvmCodeModel;
+
+/// Code model to be used by the LLVMBackend to produce bundles.
+extern llvm::cl::opt<llvm::CodeModel::Model> llvmBundleCodeModel;
+
+/// Relocation model to be used by the LLVMBackend.
+extern llvm::cl::opt<llvm::Reloc::Model> llvmRelocModel;
 
 /// Target and CPU features to be used by the LLVMBackend. The features should
 /// be comma-separated and prefixed with +.

--- a/lib/LLVMIRCodeGen/LLVMBackend.cpp
+++ b/lib/LLVMIRCodeGen/LLVMBackend.cpp
@@ -54,8 +54,9 @@ LLVMBackend::LLVMBackend() {
   arch_ = llvmArch;
   target_ = llvmTarget;
   cpu_ = llvmCPU;
-  codeModel_ = llvm::CodeModel::Model::Large;
-  relocModel_ = llvm::Reloc::Model::Static;
+  codeModel_ = llvmCodeModel;
+  bundleCodeModel_ = llvmBundleCodeModel;
+  relocModel_ = llvmRelocModel;
 }
 
 /// Emit the entry point for JIT called "jitmain".
@@ -161,5 +162,5 @@ void LLVMBackend::save(Function *F, llvm::StringRef outputDir,
   auto IR = generateAndOptimizeIR(F, *this, shouldShareBuffers());
   BundleSaver(IR.get(), *this)
       .save(getTarget(), getArch(), getCPU(), targetFeatures, outputDir,
-            bundleName, mainEntryName, getCodeModel(), getRelocModel());
+            bundleName, mainEntryName, getBundleCodeModel(), getRelocModel());
 }


### PR DESCRIPTION
Summary:

LLVM-based backends can still override these settings and initialize them differently e.g. in their constructors.

This also fixes a bug related to bundles generation on x86_64 which was introduced during recent re-factorings. Small code model should be used for bundles, but the large one for JIT.

Test Plan:
ninja test
manually running produced example bundles when building with `-DGLOW_WITH_BUNDLES=ON`
