### PR TITLE
[Quantization] Round instead of floor for quantizing with float offset

### DIFF
--- a/include/glow/Quantization/Base/Base.h
+++ b/include/glow/Quantization/Base/Base.h
@@ -194,7 +194,7 @@ inline float dequantize(eTy input, const TensorQuantizationParams &TQP) {
 /// then an offset of 128 is substracted to convert to int8_t.
 template <class DestTy>
 inline DestTy quantizeWithFloatOffset(float input, float scale, float offset) {
-  uint8_t d = static_cast<uint8_t>((input - offset) / scale);
+  uint8_t d = static_cast<uint8_t>(std::round((input - offset) / scale));
   if (std::is_same<int8_t, DestTy>::value) {
     d -= 128;
   }
@@ -205,8 +205,8 @@ inline DestTy quantizeWithFloatOffset(float input, float scale, float offset) {
 /// quantization parameters \p scale and \p offset.
 inline uint8_t quantize4BitsWithFloatOffset(float input, float scale,
                                             float offset) {
-  uint8_t d =
-      std::max(0, std::min(static_cast<int>((input - offset) / scale), 15));
+  uint8_t d = std::max(
+      0, std::min(static_cast<int>(std::round((input - offset) / scale)), 15));
   return d;
 }
 

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -7524,8 +7524,8 @@ static void testRowwiseQuantizedSparseLengthsWeightedSum(
 /// Test RWQ-SLWS with Float Weights, Scales, Offsets, and Output.
 TEST_P(OperatorTest, RowwiseQuantizedSparseLengthsWeightedSum_Float) {
   CHECK_IF_ENABLED();
-  testRowwiseQuantizedSparseLengthsWeightedSum<float>(bindings_, mod_, F_, EE_,
-                                                      ElemKind::FloatTy, 0.01);
+  testRowwiseQuantizedSparseLengthsWeightedSum<float>(
+      bindings_, mod_, F_, EE_, ElemKind::FloatTy, 0.0001);
 }
 
 /// Test RWQ-SLWS with Float16 Weights, Scales, Offsets, and Output. Uses Float
@@ -7534,7 +7534,7 @@ TEST_P(OperatorTest,
        RowwiseQuantizedSparseLengthsWeightedSum_Float16_AccumFloat) {
   CHECK_IF_ENABLED();
   testRowwiseQuantizedSparseLengthsWeightedSum<float16_t>(
-      bindings_, mod_, F_, EE_, ElemKind::Float16Ty, 0.02,
+      bindings_, mod_, F_, EE_, ElemKind::Float16Ty, 0.0001,
       /* useFP16Accumulation */ false);
 }
 
@@ -7544,7 +7544,7 @@ TEST_P(OperatorTest,
        RowwiseQuantizedSparseLengthsWeightedSum_Float16_AccumFloat16) {
   CHECK_IF_ENABLED();
   testRowwiseQuantizedSparseLengthsWeightedSum<float16_t>(
-      bindings_, mod_, F_, EE_, ElemKind::Float16Ty, 0.02,
+      bindings_, mod_, F_, EE_, ElemKind::Float16Ty, 0.0001,
       /* useFP16Accumulation */ true);
 }
 
@@ -7609,7 +7609,7 @@ static void testRowwiseQuantizedSparseLengthsSum(
 TEST_P(OperatorTest, RowwiseQuantizedSparseLengthsSum_Float) {
   CHECK_IF_ENABLED();
   testRowwiseQuantizedSparseLengthsSum<float>(bindings_, mod_, F_, EE_,
-                                              ElemKind::FloatTy, 0.025);
+                                              ElemKind::FloatTy, 0.015);
 }
 
 /// Test RWQ-SLS with Float16 Weights, Scales, Offsets, and Output. Uses
@@ -7617,7 +7617,7 @@ TEST_P(OperatorTest, RowwiseQuantizedSparseLengthsSum_Float) {
 TEST_P(OperatorTest, RowwiseQuantizedSparseLengthsSum_Float16_AccumFloat) {
   CHECK_IF_ENABLED();
   testRowwiseQuantizedSparseLengthsSum<float16_t>(
-      bindings_, mod_, F_, EE_, ElemKind::Float16Ty, 0.025,
+      bindings_, mod_, F_, EE_, ElemKind::Float16Ty, 0.02,
       /* useFP16Accumulation */ false);
 }
 
@@ -7626,7 +7626,7 @@ TEST_P(OperatorTest, RowwiseQuantizedSparseLengthsSum_Float16_AccumFloat) {
 TEST_P(OperatorTest, RowwiseQuantizedSparseLengthsSum_Float16_AccumFloat16) {
   CHECK_IF_ENABLED();
   testRowwiseQuantizedSparseLengthsSum<float16_t>(
-      bindings_, mod_, F_, EE_, ElemKind::Float16Ty, 0.025,
+      bindings_, mod_, F_, EE_, ElemKind::Float16Ty, 0.02,
       /* useFP16Accumulation */ true);
 }
 
@@ -7751,7 +7751,7 @@ static void testFusedRowwiseQuantizedSparseLengthsWeightedSum(
 TEST_P(OperatorTest, FusedRowwiseQuantizedSparseLengthsWeightedSum_Float) {
   CHECK_IF_ENABLED();
   testFusedRowwiseQuantizedSparseLengthsWeightedSum<float>(
-      bindings_, mod_, F_, EE_, ElemKind::FloatTy, 0.01);
+      bindings_, mod_, F_, EE_, ElemKind::FloatTy, 0.0001);
 }
 
 /// Test Fused-RWQ-SLWS in Float16. Uses Float accumulation.
@@ -7759,7 +7759,7 @@ TEST_P(OperatorTest,
        FusedRowwiseQuantizedSparseLengthsWeightedSum_Float16_AccumFloat) {
   CHECK_IF_ENABLED();
   testFusedRowwiseQuantizedSparseLengthsWeightedSum<float16_t>(
-      bindings_, mod_, F_, EE_, ElemKind::Float16Ty, 0.02,
+      bindings_, mod_, F_, EE_, ElemKind::Float16Ty, 0.0001,
       /* useFP16Accumulation */ false);
 }
 
@@ -7768,7 +7768,7 @@ TEST_P(OperatorTest,
        FusedRowwiseQuantizedSparseLengthsWeightedSum_Float16_AccumFloat16) {
   CHECK_IF_ENABLED();
   testFusedRowwiseQuantizedSparseLengthsWeightedSum<float16_t>(
-      bindings_, mod_, F_, EE_, ElemKind::Float16Ty, 0.02,
+      bindings_, mod_, F_, EE_, ElemKind::Float16Ty, 0.0001,
       /* useFP16Accumulation */ true);
 }
 
@@ -7974,14 +7974,14 @@ static void testFusedRowwiseQuantizedSparseLengthsSum(
 TEST_P(OperatorTest, FusedRowwiseQuantizedSparseLengthsSum_Float) {
   CHECK_IF_ENABLED();
   testFusedRowwiseQuantizedSparseLengthsSum<float>(bindings_, mod_, F_, EE_,
-                                                   ElemKind::FloatTy, 0.025);
+                                                   ElemKind::FloatTy, 0.015);
 }
 
 /// Test Fused-RWQ-SLS in Float16. Uses Float accumulation.
 TEST_P(OperatorTest, FusedRowwiseQuantizedSparseLengthsSum_Float16_AccumFloat) {
   CHECK_IF_ENABLED();
   testFusedRowwiseQuantizedSparseLengthsSum<float16_t>(
-      bindings_, mod_, F_, EE_, ElemKind::Float16Ty, 0.025,
+      bindings_, mod_, F_, EE_, ElemKind::Float16Ty, 0.02,
       /* useFP16Accumulation */ false);
 }
 
@@ -7990,7 +7990,7 @@ TEST_P(OperatorTest,
        FusedRowwiseQuantizedSparseLengthsSum_Float16_AccumFloat16) {
   CHECK_IF_ENABLED();
   testFusedRowwiseQuantizedSparseLengthsSum<float16_t>(
-      bindings_, mod_, F_, EE_, ElemKind::Float16Ty, 0.025,
+      bindings_, mod_, F_, EE_, ElemKind::Float16Ty, 0.02,
       /* useFP16Accumulation */ true);
 }
 

--- a/tests/unittests/RecommendationSystemTest.cpp
+++ b/tests/unittests/RecommendationSystemTest.cpp
@@ -808,7 +808,7 @@ protected:
 
     assert(resultTensor && "Must run and set resultTensor before comparing "
                            "against the intepreter.");
-    EXPECT_TRUE(resultIT->isEqual(*resultTensor, 0.005));
+    EXPECT_TRUE(resultIT->isEqual(*resultTensor, 0.004));
   }
 
   /// Create partitions to run and compare results.


### PR DESCRIPTION
Previously we were not rounding when quantizing when using float offset. This meant if we had e.g. some value quantized to 4.9 before converting to int, we would quantize it to 4 instead of 5. Updating this allows us to get better accuracy and improve error bounds on tests using it.