### PR TITLE
[fr2en] Restore ptr to function after compilation

### DIFF
--- a/examples/fr2en.cpp
+++ b/examples/fr2en.cpp
@@ -165,6 +165,10 @@ struct Model {
     }
 
     EE_.compile(cctx);
+
+    // After compilation, the original function may be removed/replaced. Need to
+    // update F_.
+    F_ = EE_.getModule().getFunctions().front();
   }
 
 private:


### PR DESCRIPTION
Similar to in the Loader, we need to restore the pointer to the function after compilation.

Not sure how this snuck by. I thought we had fr2en on CI but I guess not?

Fixes https://github.com/pytorch/glow/issues/3708