### PR TITLE
(trivial) fix hang in ImageClassifier when -input-image-list-file doesn't exist

### DIFF
--- a/tools/loader/ImageClassifier.cpp
+++ b/tools/loader/ImageClassifier.cpp
@@ -428,6 +428,12 @@ static int processAndPrintResults(Tensor *SMT,
 static void parseInputImageList(const std::string &inputImageListFile) {
   std::ifstream inFile;
   inFile.open(inputImageListFile);
+  if (!inFile.good()) {
+    llvm::outs() << "Could not open input-image-list-file: "
+                 << inputImageListFile << ", exiting.\n";
+    std::exit(1);
+  }
+
   while (!inFile.eof()) {
     std::string img;
     getline(inFile, img);


### PR DESCRIPTION
Summary: When using the ImageClassifier with -input-image-list-file mode, if the file doesn't exist the process hangs waiting for a non existent file to be EOF. Add in a guard before the loop.

Documentation: N/A

Test Plan:

before:
```
~/work/glow/build_Release master*
❯ ./bin/image-classifier --input-image-list-file=asdasd -model=resnet50 -model-input-name=gpu_0/data

^C
```

after:
```
~/work/glow/build_Release master* 6s
❯ ./bin/image-classifier --input-image-list-file=asdasd -model=resnet50 -model-input-name=gpu_0/data
Could not open input-image-list-file: asdasd, exiting.

~/work/glow/build_Release master*
❯ ls -1d tests/images/imagenet/* > imagefile.txt

~/work/glow/build_Release master*
❯ ./bin/image-classifier --input-image-list-file=imagefile.txt -model=resnet50 -model-input-name=gpu_0/data
Model: resnet50
Running 1 thread(s).
 File: tests/images/imagenet/cat_285.png        Label-K1: 783 (probability: 1.0000)
 File: tests/images/imagenet/dog_207.png        Label-K1: 818 (probability: 0.6797)
 File: tests/images/imagenet/zebra_340.png      Label-K1: 818 (probability: 0.5439)
```