### PR TITLE
glow: add another unittest for back to back inference with slws ops

### DIFF
--- a/lib/Backends/CPU/tests/CPUOperatorTest.cpp
+++ b/lib/Backends/CPU/tests/CPUOperatorTest.cpp
@@ -96,6 +96,8 @@ std::set<std::string> glow::backendTestBlacklist = {
     "FusedRowwiseQuantizedSparseLengthsWeightedSum_ConvertedFloat16/0",
     "FusedRowwiseQuantizedSparseLengthsWeightedSum_ConvertedFloat16_back_to_"
     "back/0",
+    "FusedRowwiseQuantizedSparseLengthsWeightedSum_ConvertedFloat16_back_to_"
+    "back2/0",
     "FusedRowwiseQuantizedSparseLengthsSum_Float16_AccumFloat/0",
     "FusedRowwiseQuantizedSparseLengthsSum_Float16_AccumFloat16/0",
     "SparseToDenseMask1/0",

--- a/lib/Backends/Habana/tests/HabanaOperatorTest.cpp
+++ b/lib/Backends/Habana/tests/HabanaOperatorTest.cpp
@@ -152,6 +152,8 @@ std::set<std::string> glow::backendTestBlacklist = {
     "FusedRowwiseQuantizedSparseLengthsWeightedSum_ConvertedFloat16/0",
     "FusedRowwiseQuantizedSparseLengthsWeightedSum_ConvertedFloat16_back_to_"
     "back/0",
+    "FusedRowwiseQuantizedSparseLengthsWeightedSum_ConvertedFloat16_back_to_"
+    "back2/0",
     "FusedRowwiseQuantizedSparseLengthsWeightedSum_Float16_AccumFloat/0",
     "FusedRowwiseQuantizedSparseLengthsWeightedSum_Float16_AccumFloat16/0",
     "FusedRWQSLSAllZeroLengths_Float/0",

--- a/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
@@ -143,6 +143,8 @@ struct EmulatorOnlyTests {
           "Exp/0",
           "FloatArgMaxKeepDim/0",
           "FloatArgMaxNoKeepDim/0",
+          "FusedRowwiseQuantizedSparseLengthsWeightedSum_ConvertedFloat16_back_"
+          "to_back2/0",
           "GroupDilatedConvolution/0",
           "less_int32Cases/0",
           "less_int64Cases/0",

--- a/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
@@ -176,6 +176,8 @@ std::set<std::string> glow::backendTestBlacklist = {
     "FusedRowwiseQuantizedSparseLengthsWeightedSum_ConvertedFloat16/0",
     "FusedRowwiseQuantizedSparseLengthsWeightedSum_ConvertedFloat16_back_to_"
     "back/0",
+    "FusedRowwiseQuantizedSparseLengthsWeightedSum_ConvertedFloat16_back_to_"
+    "back2/0",
     "FusedRowwiseQuantizedSparseLengthsSum_Float/0",
     "FusedRowwiseQuantizedSparseLengthsSum_Float16_AccumFloat/0",
     "FusedRowwiseQuantizedSparseLengthsSum_Float16_AccumFloat16/0",


### PR DESCRIPTION
Summary: This is a repro for a bug in NNPI backend.

Reviewed By: jfix71

Differential Revision: D18265809

