### PR TITLE
[OperatorTest] Add check for partial tensor support to RepeatedSLSWithPartialTensors

### DIFF
--- a/include/glow/ExecutionEngine/ExecutionEngine.h
+++ b/include/glow/ExecutionEngine/ExecutionEngine.h
@@ -127,6 +127,10 @@ public:
   /// Context aware single execution of a function with the given \p
   /// name.
   void run(PlaceholderBindings &bindings, llvm::StringRef name);
+
+  /// \returns a reference to the first backend owned by the Provisioner inside
+  /// of \ref hostManager_.
+  Backend &getBackend() const;
 };
 
 //===----------------------------------------------------------------------===//

--- a/include/glow/Runtime/HostManager/HostManager.h
+++ b/include/glow/Runtime/HostManager/HostManager.h
@@ -215,6 +215,10 @@ public:
   /// Get the network DAG for \p network if it exists.
   Expected<DAG *> getNetworkDAG(llvm::StringRef network);
 
+  /// \returns a reference to the backend at index \p i owned by the
+  /// Provisioner.
+  Backend &getBackend(size_t i = 0) const;
+
   ~HostManager();
 };
 

--- a/include/glow/Runtime/Provisioner/Provisioner.h
+++ b/include/glow/Runtime/Provisioner/Provisioner.h
@@ -44,6 +44,9 @@ public:
   /// Remove stored compiledFunction.
   Error removeFunction(llvm::StringRef name);
 
+  /// \returns a reference to the backend at index \p i.
+  Backend &getBackend(size_t i = 0) const;
+
 private:
   /// Pointer to backend used for compilation. This currently gets reset per
   /// device to ensure the correct backed per device.

--- a/lib/Backends/CPU/tests/CPUOperatorTest.cpp
+++ b/lib/Backends/CPU/tests/CPUOperatorTest.cpp
@@ -158,4 +158,5 @@ std::set<std::string> glow::backendTestBlacklist = {
     "FusedRWQSLSAllZeroLengths_Float16/0",
     "SigmoidSweep_Float16/0",
     "TanHSweep_Float16/0",
+    "RepeatedSLSWithPartialTensors/0",
 };

--- a/lib/Backends/Interpreter/tests/InterpreterOperatorTest.cpp
+++ b/lib/Backends/Interpreter/tests/InterpreterOperatorTest.cpp
@@ -18,6 +18,7 @@
 using namespace glow;
 
 std::set<std::string> glow::backendTestBlacklist = {
+    "RepeatedSLSWithPartialTensors/0",
     "SigmoidSweep_Float16/0",
     "TanHSweep_Float16/0",
 };

--- a/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
@@ -68,6 +68,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "NonSquarePaddingMaxPool/0",
     "QuantizedMaxPoolWithArgmax/0",
     "QuantizedMaxPoolWithArgmaxTransposed/0",
+    "RepeatedSLSWithPartialTensors/0",
     "ResizeNearest_Float/0",
     "ResizeNearest_Float16/0",
     "ResizeNearest_Int16/0",

--- a/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
@@ -260,4 +260,5 @@ std::set<std::string> glow::backendTestBlacklist = {
     "FusedRWQSLSAllZeroLengths_Float16/0",
     "SigmoidSweep_Float16/0",
     "TanHSweep_Float16/0",
+    "RepeatedSLSWithPartialTensors/0",
 };

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -263,3 +263,7 @@ void ExecutionEngine::compile(CompilationContext &cctx) {
 
   EXIT_ON_ERR(hostManager_->addNetwork(std::move(module_), cctx));
 }
+
+Backend &ExecutionEngine::getBackend() const {
+  return hostManager_->getBackend(0);
+}

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -544,3 +544,7 @@ bool runtime::loadDeviceConfigsFromFile(
   }
   return true;
 }
+
+Backend &HostManager::getBackend(size_t i) const {
+  return provisioner_->getBackend(i);
+}

--- a/lib/Runtime/Provisioner/Provisioner.cpp
+++ b/lib/Runtime/Provisioner/Provisioner.cpp
@@ -226,6 +226,11 @@ Error Provisioner::provision(DAGListTy &networks, Module &module,
   return Error::success();
 };
 
+Backend &Provisioner::getBackend(size_t i) const {
+  assert(i < backends_.size() && "Invalid index into Backends vector");
+  return *backends_[i];
+}
+
 Error Provisioner::removeFunction(llvm::StringRef name) {
   std::lock_guard<std::mutex> functionsLock(functionsLock_);
   auto it = activeFunctions_.find(name);

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -7723,6 +7723,9 @@ TEST_P(OperatorTest, RowwiseQuantizedSparseLengthsSum_Float16_AccumFloat16) {
 TEST_P(OperatorTest, RepeatedSLSWithPartialTensors) {
   CHECK_IF_ENABLED();
 
+  // This test is only meaningful if the backend supports partial tensors.
+  ASSERT_TRUE(EE_.getBackend().supportsPartialTensors());
+
   constexpr size_t embeddingRows = 1275;
   constexpr size_t numLengths = 20;
   constexpr size_t maxIndices = 20000;


### PR DESCRIPTION
This test should only pass if the backend supports partial tensors. I needed to plumb access to the backend through the EE to do this.