### PR TITLE
Modifying BatchGemm and TransposeBench to split batch at top level

### DIFF
--- a/tests/benchmark/AddBench.cpp
+++ b/tests/benchmark/AddBench.cpp
@@ -32,10 +32,6 @@ using namespace glow;
  * chained together in multiple layers.
  */
 class AddBench : public Benchmark {
-  /// Matrices.
-  std::vector<float> a;
-  std::vector<float> b;
-  std::vector<float> c;
 
   /// Dimensions expressed in libjit's format.
   size_t n_;
@@ -72,10 +68,6 @@ public:
     auto config = llvm::make_unique<runtime::DeviceConfig>(backendStr_);
     configs.push_back(std::move(config));
     hostManager_ = llvm::make_unique<runtime::HostManager>(std::move(configs));
-
-    a.resize(n_);
-    b.resize(n_);
-    c.resize(n_);
 
     std::unique_ptr<Module> mod(new Module);
     auto fn = mod->createFunction("singleNode");

--- a/tests/benchmark/BatchGemmBench.cpp
+++ b/tests/benchmark/BatchGemmBench.cpp
@@ -39,16 +39,18 @@ class BatchGemmBench : public Benchmark {
   std::unique_ptr<runtime::HostManager> hostManager_;
   std::vector<std::unique_ptr<ExecutionContext>> contexts_;
   size_t asyncLaunchSize_;
+  size_t numCores_;
   const char *backendStr_;
   ElemKind dtype_;
   size_t elementSize_;
 
 public:
   BatchGemmBench(size_t batchSize_, size_t m_, size_t n_, size_t numLayers_,
-                 size_t asyncLaunchSize_, const char *backendStr_,
-                 const char *dtypeStr_)
+                 size_t asyncLaunchSize_, size_t numCores_,
+                 const char *backendStr_, const char *dtypeStr_)
       : batchSize_(batchSize_), m_(m_), n_(n_), numLayers_(numLayers_),
-        asyncLaunchSize_(asyncLaunchSize_), backendStr_(backendStr_) {
+        asyncLaunchSize_(asyncLaunchSize_), numCores_(numCores_),
+        backendStr_(backendStr_) {
 
     dtype_ = ElemKind::Float16Ty;
     elementSize_ = 2;
@@ -78,51 +80,67 @@ public:
     std::unique_ptr<Module> mod(new Module);
     auto fn = mod->createFunction("singleNode");
 
-    Placeholder *A;
-    Placeholder *B;
-    SaveNode *S;
+    std::vector<Placeholder *> A(numCores_);
+    std::vector<Placeholder *> B(numCores_);
+    std::vector<SaveNode *> S(numCores_);
 
-    A = mod->createPlaceholder(dtype_, {batchSize_, m_, m_}, "A", false);
-    B = mod->createPlaceholder(dtype_, {batchSize_, m_, n_}, "B", false);
+    // Calculate the batch size per core
+    auto batchSizePerCore = getBatchSizePerCore(batchSize_, numCores_);
+
+    for (size_t core = 0; core < numCores_; core++) {
+      if (batchSizePerCore[core] == 0)
+        continue;
+      A[core] = mod->createPlaceholder(dtype_, {batchSizePerCore[core], m_, m_},
+                                       "A" + std::to_string(core), false);
+      B[core] = mod->createPlaceholder(dtype_, {batchSizePerCore[core], m_, n_},
+                                       "B" + std::to_string(core), false);
+    }
 
     // for each context, add input bindings
-    for (int i = 0; i < asyncLaunchSize_; i++) {
-      if (dtype_ == ElemKind::FloatTy) {
-        contexts_[i]
-            ->getPlaceholderBindings()
-            ->allocate(A)
-            ->getHandle<float>()
-            .randomize(0.0f, 1.0f, mod->getPRNG());
-        contexts_[i]
-            ->getPlaceholderBindings()
-            ->allocate(B)
-            ->getHandle<float>()
-            .randomize(0.0f, 1.0f, mod->getPRNG());
-      } else if (dtype_ == ElemKind::Float16Ty) {
-        contexts_[i]
-            ->getPlaceholderBindings()
-            ->allocate(A)
-            ->getHandle<float16_t>()
-            .randomize(0.0f, 1.0f, mod->getPRNG());
-        contexts_[i]
-            ->getPlaceholderBindings()
-            ->allocate(B)
-            ->getHandle<float16_t>()
-            .randomize(0.0f, 1.0f, mod->getPRNG());
+    for (size_t core = 0; core < numCores_; core++) {
+      if (batchSizePerCore[core] == 0)
+        continue;
+      for (int i = 0; i < asyncLaunchSize_; i++) {
+        if (dtype_ == ElemKind::FloatTy) {
+          contexts_[i]
+              ->getPlaceholderBindings()
+              ->allocate(A[core])
+              ->getHandle<float>()
+              .randomize(0.0f, 1.0f, mod->getPRNG());
+          contexts_[i]
+              ->getPlaceholderBindings()
+              ->allocate(B[core])
+              ->getHandle<float>()
+              .randomize(0.0f, 1.0f, mod->getPRNG());
+        } else if (dtype_ == ElemKind::Float16Ty) {
+          contexts_[i]
+              ->getPlaceholderBindings()
+              ->allocate(A[core])
+              ->getHandle<float16_t>()
+              .randomize(0.0f, 1.0f, mod->getPRNG());
+          contexts_[i]
+              ->getPlaceholderBindings()
+              ->allocate(B[core])
+              ->getHandle<float16_t>()
+              .randomize(0.0f, 1.0f, mod->getPRNG());
+        }
       }
-    }
 
-    Node *cur = B;
-    for (size_t layer = 0; layer < numLayers_; layer++) {
-      auto *bmm = fn->createBatchMatMul("batchmatmul", A, cur);
-      cur = bmm;
-    }
+      Node *cur = B[core];
+      for (size_t layer = 0; layer < numLayers_; layer++) {
+        auto *bmm = fn->createBatchMatMul(
+            "batchmatmul" + std::to_string(layer) + "_" + std::to_string(core),
+            A[core], cur);
+        cur = bmm;
+      }
 
-    S = fn->createSave("save", cur);
+      S[core] = fn->createSave("save" + std::to_string(core), cur);
 
-    // for each context, add output bindings
-    for (int i = 0; i < asyncLaunchSize_; i++) {
-      contexts_[i]->getPlaceholderBindings()->allocate(S->getPlaceholder());
+      // for each context, add output bindings
+      for (int i = 0; i < asyncLaunchSize_; i++) {
+        contexts_[i]->getPlaceholderBindings()->allocate(
+            S[core]->getPlaceholder());
+      }
     }
 
     CompilationContext ctx;
@@ -167,26 +185,28 @@ public:
 };
 
 int main(int argc, char *argv[]) {
-  assert(argc == 9);
+  assert(argc == 10);
   size_t batchSize = atoi(argv[1]);
   size_t m = atoi(argv[2]);
   size_t n = atoi(argv[3]);
   size_t numLayers = atoi(argv[4]);
   size_t numReps = atoi(argv[5]);
   size_t numAsyncLaunches = atoi(argv[6]);
-  const char *backendStr = argv[7];
-  const char *dtypeStr = argv[8];
+  size_t numCores = atoi(argv[7]);
+  const char *backendStr = argv[8];
+  const char *dtypeStr = argv[9];
   assert(numReps > 0);
 
-  BatchGemmBench b(batchSize, m, n, numLayers, numAsyncLaunches, backendStr,
-                   dtypeStr);
+  BatchGemmBench b(batchSize, m, n, numLayers, numAsyncLaunches, numCores,
+                   backendStr, dtypeStr);
 
   auto times = bench(&b, numReps);
   for (auto t : times) {
-    printf(
-        "BenchResult,BatchGemmBench,SW,%zu,%zu,%zu,%zu,%zu,%zu,%s,%s,%f,%f\n",
-        batchSize, m, n, numLayers, numReps, numAsyncLaunches, backendStr,
-        dtypeStr, t / numAsyncLaunches, b.gflops() * numAsyncLaunches / t);
+    printf("BenchResult,BatchGemmBench,SW,%zu,%zu,%zu,%zu,%zu,%zu,%zu,%s,%s,%f,"
+           "%f\n",
+           batchSize, m, n, numLayers, numReps, numAsyncLaunches, numCores,
+           backendStr, dtypeStr, t / numAsyncLaunches,
+           b.gflops() * numAsyncLaunches / t);
   }
   double min = *(std::min_element(times.begin(), times.end()));
   size_t midElt = times.size() / 2;
@@ -194,10 +214,10 @@ int main(int argc, char *argv[]) {
   double median = times[midElt];
   double median_runtime = median / ((double)numAsyncLaunches);
   double min_runtime = min / ((double)numAsyncLaunches);
-  printf(
-      "BenchSummary,BatchGemmBench,SW,%zu,%zu,%zu,%zu,%zu,%zu,%s,%s,%f,%f,%f,%"
-      "f\n",
-      batchSize, m, n, numLayers, numReps, numAsyncLaunches, backendStr,
-      dtypeStr, median_runtime, min_runtime, b.gflops() / median_runtime,
-      b.gflops() / min_runtime);
+  printf("BenchSummary,BatchGemmBench,SW,%zu,%zu,%zu,%zu,%zu,%zu,%zu,%s,%s,%f,%"
+         "f,%f,%"
+         "f\n",
+         batchSize, m, n, numLayers, numReps, numAsyncLaunches, numCores,
+         backendStr, dtypeStr, median_runtime, min_runtime,
+         b.gflops() / median_runtime, b.gflops() / min_runtime);
 }

--- a/tests/benchmark/Bench.h
+++ b/tests/benchmark/Bench.h
@@ -48,6 +48,21 @@ std::vector<double> bench(Benchmark *b, size_t reps) {
   return times;
 }
 
+std::vector<size_t> getBatchSizePerCore(size_t batchSize, size_t numCores) {
+  std::vector<size_t> batchSizePerCore(numCores);
+  for (size_t core = 0; core < numCores; core++) {
+    size_t perCore = (batchSize + numCores - 1) / numCores;
+    size_t startIdx = core * perCore;
+    size_t endIdx = (core + 1) * perCore;
+    if (startIdx > batchSize)
+      startIdx = batchSize;
+    if (endIdx > batchSize)
+      endIdx = batchSize;
+    batchSizePerCore[core] = (endIdx - startIdx);
+  }
+  return batchSizePerCore;
+}
+
 } // namespace glow
 
 #endif // GLOW_TESTS_BENCHMARK_H

--- a/tests/benchmark/SLSBench.cpp
+++ b/tests/benchmark/SLSBench.cpp
@@ -91,7 +91,7 @@ public:
 
     for (int slsNodeId = 0; slsNodeId < numSLSNodes_; slsNodeId++) {
       Tensor data(ElemKind::FloatTy, {numTableEntries_, numElementsPerRow_});
-      data.getHandle().randomize(0.0f, 1.0f, mod->getPRNG());
+      data.getHandle().clear(1.0f);
 
       weights[slsNodeId] =
           mod->createPlaceholder(dtype_, {numIndicesPerBatch_ * batchSize_},


### PR DESCRIPTION
Summary:
(1) Removed a few unnecessary lines from AddBench
(2) Modified BatchGemmBench and TransposeBench to take a "numCores" argument and split the batch inside of the benchmark
(3) Changed SLS table setting to "1.0f" instead of random number generation to make the test run faster.

Differential Revision: D18274156

