### PR TITLE
Add numerical equivalence check to GraphOptz.optimizeBatchNormAfterCo…

### DIFF
--- a/tests/unittests/GraphOptzTest.cpp
+++ b/tests/unittests/GraphOptzTest.cpp
@@ -337,8 +337,8 @@ TEST_F(GraphOptz, optimizeBatchNormAfterConvWithTransposedWeights) {
   ::glow::convertPlaceholdersToConstants(optimizedF_, bindings_, {input});
   ::glow::optimize(optimizedF_, CompilationMode::Infer);
   EXPECT_EQ(optimizedF_->getNodes().size(), 2);
-   EXPECT_EQ(
-       countNodeKind(optimizedF_, Kinded::Kind::BatchNormalizationNodeKind), 0);
+  EXPECT_EQ(
+      countNodeKind(optimizedF_, Kinded::Kind::BatchNormalizationNodeKind), 0);
 
   bindings_.allocate(input)->getHandle().randomize(-1.0, 1.0, mod_.getPRNG());
   checkNumericalEquivalence();

--- a/tests/unittests/GraphOptzTest.cpp
+++ b/tests/unittests/GraphOptzTest.cpp
@@ -328,12 +328,20 @@ TEST_F(GraphOptz, optimizeBatchNormAfterConvWithTransposedWeights) {
   // Initialize to ensure that constant tensors are not optimized out.
   bindings_.allocate(filter)->getHandle().randomize(-1.0, 1.0, mod_.getPRNG());
   bindings_.allocate(bias)->getHandle().randomize(-1.0, 1.0, mod_.getPRNG());
-  ::glow::convertPlaceholdersToConstants(F_, bindings_, {input});
-
+  
   EXPECT_EQ(F_->getNodes().size(), 4);
-  ::glow::optimize(F_, CompilationMode::Infer);
-  EXPECT_EQ(F_->getNodes().size(), 2);
-  EXPECT_EQ(countNodeKind(F_, Kinded::Kind::BatchNormalizationNodeKind), 0);
+  EXPECT_EQ(countNodeKind(F_, Kinded::Kind::BatchNormalizationNodeKind), 1);
+
+  optimizedF_ = F_->clone(F_->getName().str() + "_optimized");
+  ::glow::convertPlaceholdersToConstants(F_, bindings_, {input});
+  ::glow::convertPlaceholdersToConstants(optimizedF_, bindings_, {input});
+  ::glow::optimize(optimizedF_, CompilationMode::Infer);
+  EXPECT_EQ(optimizedF_->getNodes().size(), 2);
+   EXPECT_EQ(
+       countNodeKind(optimizedF_, Kinded::Kind::BatchNormalizationNodeKind), 0);
+
+  bindings_.allocate(input)->getHandle().randomize(-1.0, 1.0, mod_.getPRNG());
+  checkNumericalEquivalence();
 }
 
 /// Check that reshape constant folding is done before BatchNorm optimization,

--- a/tests/unittests/GraphOptzTest.cpp
+++ b/tests/unittests/GraphOptzTest.cpp
@@ -328,7 +328,7 @@ TEST_F(GraphOptz, optimizeBatchNormAfterConvWithTransposedWeights) {
   // Initialize to ensure that constant tensors are not optimized out.
   bindings_.allocate(filter)->getHandle().randomize(-1.0, 1.0, mod_.getPRNG());
   bindings_.allocate(bias)->getHandle().randomize(-1.0, 1.0, mod_.getPRNG());
-  
+
   EXPECT_EQ(F_->getNodes().size(), 4);
   EXPECT_EQ(countNodeKind(F_, Kinded::Kind::BatchNormalizationNodeKind), 1);
 
@@ -336,6 +336,7 @@ TEST_F(GraphOptz, optimizeBatchNormAfterConvWithTransposedWeights) {
   ::glow::convertPlaceholdersToConstants(F_, bindings_, {input});
   ::glow::convertPlaceholdersToConstants(optimizedF_, bindings_, {input});
   ::glow::optimize(optimizedF_, CompilationMode::Infer);
+
   EXPECT_EQ(optimizedF_->getNodes().size(), 2);
   EXPECT_EQ(
       countNodeKind(optimizedF_, Kinded::Kind::BatchNormalizationNodeKind), 0);


### PR DESCRIPTION
…nvWithTransposedWeights

Summary:
Add numerical equivalence check to GraphOptz.optimizeBatchNormAfterConvWithTransposedWeights

Test Plan: ninja test: 100% tests passed, 0 tests failed out of 49