### PR TITLE
Fix bug in TransposeBench

### DIFF
--- a/tests/benchmark/TransposeBench.cpp
+++ b/tests/benchmark/TransposeBench.cpp
@@ -90,6 +90,8 @@ public:
     }
 
     for (size_t core = 0; core < numCores_; core++) {
+      if (batchSizePerCore[core] == 0)
+        continue;
       // for each context, add input bindings
       for (int i = 0; i < asyncLaunchSize_; i++) {
         if (dtype_ == ElemKind::FloatTy) {


### PR DESCRIPTION
Summary: Should not create ops when size of batch is zero.

Differential Revision: D18279021

