### PR TITLE
[PyTorch] Add quantized packing weights support for fc & conv

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -135,7 +135,7 @@ elif [[ "$CIRCLE_JOB" == "PYTORCH" ]]; then
     git clone https://github.com/pytorch/pytorch.git --recursive --depth 1
     cd pytorch
     pip install -r requirements.txt
-    BUILD_BINARY=OFF BUILD_TEST=0 BUILD_CAFFE2_OPS=0 python setup.py install
+    BUILD_BINARY=OFF BUILD_TEST=0 BUILD_CAFFE2_OPS=0 USE_FBGEMM=ON python setup.py install
     cd ${GLOW_DIR}
     cd build
 elif [[ "$CIRCLE_JOB" == "OPENCL" ]]; then

--- a/torch_glow/src/GlowIValue.h
+++ b/torch_glow/src/GlowIValue.h
@@ -41,6 +41,7 @@ public:
     DoubleList,
     BoolList,
     Tuple,
+    PTTensor,
   };
 
 private:
@@ -56,6 +57,7 @@ private:
     std::vector<double> *asDoubleList;
     std::vector<bool> *asBoolList;
     std::vector<GlowIValue> *asTuple;
+    at::Tensor *asPTTensor;
   };
 
   Tag tag_ = Tag::None;
@@ -96,6 +98,7 @@ public:
   bool isDoubleList() const;
   bool isBoolList() const;
   bool isTuple() const;
+  bool isPTTensor() const;
 
   /// \returns Payload a glow Tensor or error if the tag is not Tensor.
   Expected<Tensor *> toTensor();
@@ -138,11 +141,22 @@ public:
   /// \returns Payload a vector of GlowIValues or error if the tag is not Tuple.
   Expected<const std::vector<GlowIValue> *> toTuple() const;
 
+  /// \returns Payload a PyTorch Tensor* or error if the tag is not a PyTorch
+  /// Tensor.
+  Expected<at::Tensor *> toPTTensor();
+
+  /// \returns Payload a const Pytorch Tensor* or error if the tag is not
+  /// Tensor.
+  Expected<const at::Tensor *> toPTTensor() const;
+
   /// Set the tag to None.
   void fromNone();
 
   /// Set the tag to Tensor.
   void fromTensor(Tensor tensor);
+
+  /// Set the tag to PyTorch Tensor.
+  void fromPTTensor(at::Tensor tensor);
 
   /// Set the tag to Double.
   void fromDouble(double d);

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -26,6 +26,11 @@
 
 namespace glow {
 
+/// For Glow: -128 <= orig_fp32/scale_1 + offset_1 <= 127
+/// For PyTorch: 0 <= orig_fp32/scale_2 + offset_2 <= 255
+/// Therefore, we can make scale_1 == scale_2, and offset_1 = offset2 - 128
+const int32_t OFFSETSHIFT = 128;
+
 extern bool GlowCompilePyTorchModule;
 /// Various settings to be used by code that loads PyTorch models. There should
 /// only be one of these and it should be obtained by calling
@@ -87,6 +92,11 @@ glow::Tensor ptTensorToGlowTensor(const at::Tensor &ptTensor);
 /// Given a Glow Type \p glowType, \returns an empty PyTorch Tensor with a
 /// matching type.
 at::Tensor glowTypeToEmptyPTTensor(const glow::Type &glowType);
+
+/// Given a Glow Tensor \p glowTensor, \returns a PyTorch Tensor with the same
+/// type, shape and content.
+at::Tensor glowTensorToPTTensor(const glow::Tensor &glowTensor,
+                                const at::ScalarType &torch_type);
 
 } // namespace glow
 

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -279,6 +279,12 @@ private:
   /// Rescale a int8 NodeValue \p input to the equivalent uint8 NodeValue.
   glow::NodeValue rescaleIntToUint(glow::NodeValue input);
 
+  /// Load a quantized conv node from ptNode to qconv.
+  /// a wrapper function of loadQuantizedConv and loadQuantizedConvRelu.
+  /// Returns error on failure.
+  Expected<NodeValue> loadQuantizedConvImpl(const torch::jit::Node *ptNode,
+                                            const bool isRelu);
+
   /// For each Placeholder input to \p ptNode, if this input has been marked
   /// as being an input that should be frozen in MappingOfMemberFunctions,
   /// create a glow Constant for that Placeholder with the iValue from the stack
@@ -399,11 +405,23 @@ private:
   /// \return error on failure.
   Error loadQuantizedAddRelu(const torch::jit::Node *ptNode);
 
-  /// Load a PyTorch glow::unpacked_quantized_conv node.
+  /// Load a glow::unpacked_quantized_conv node.
   // \return error on failure.
   Error loadQuantizedConvUnpacked(const torch::jit::Node *ptNode);
 
+  /// Load a PyTorch quantized::conv2d node.
+  // \return error on failure.
+  Error loadQuantizedConv(const torch::jit::Node *ptNode);
+
+  /// Load a PyTorch quantized::conv2d_relu node.
+  // \return error on failure.
+  Error loadQuantizedConvRelu(const torch::jit::Node *ptNode);
+
   /// Load a glow::unpacked_quantized_linear node.
+  /// \return error on failure.
+  Error loadQuantizedLinearUnpacked(const torch::jit::Node *ptNode);
+
+  /// Load a PyTorch quantized::linear node.
   /// \return error on failure.
   Error loadQuantizedLinear(const torch::jit::Node *ptNode);
 

--- a/torch_glow/tests/nodes/quantized_conv2d_relu_test.py
+++ b/torch_glow/tests/nodes/quantized_conv2d_relu_test.py
@@ -1,0 +1,44 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import torch
+
+from tests.utils import jitVsGlow
+import pytest
+
+from collections import OrderedDict
+
+
+def test_quantized_conv2d_relu_packed_groupwise():
+    """Basic test of PyTorch quantized::conv2d_relu Node with packed weights on Glow."""
+
+    x = torch.tensor(range(5), dtype=torch.float) * 1.5
+    x = torch.cat((x, x, x, x, x))
+    x = torch.cat((x, x, x))
+    x = torch.reshape(x, [1, 3, 5, 5])
+    q = torch.nn.quantized.Quantize(0.2, 2, torch.quint8)
+    conv = torch.nn.Conv2d(3, 3, [2, 2], groups=3)
+    relu = torch.nn.ReLU()
+    dq = torch.nn.quantized.DeQuantize()
+
+    # Due to the off-by-one error, we cannot let the weights, bias & input
+    # to be totally random.
+    conv.weight.data.fill_(1.5)
+    conv.bias.data.fill_(2.5)
+
+    model = torch.nn.Sequential(OrderedDict([
+        ('quantize', q),
+        ('conv1', conv),
+        ('relu1', relu),
+        ('deuantize', dq)]))
+    model.eval()
+    model.qconfig = torch.quantization.get_default_qconfig('fbgemm')
+
+    # Fuse conv and relu to conv_relu
+    model = torch.quantization.fuse_modules(model, [['conv1', 'relu1']])
+
+    torch.quantization.prepare(model, inplace=True)
+    torch.quantization.convert(model, inplace=True)
+
+    jitVsGlow(model, x, expected_fused_ops={"aten::quantize_per_tensor",
+                                            "quantized::conv2d_relu",
+                                            "aten::dequantize"})

--- a/torch_glow/tests/nodes/quantized_conv2d_test.py
+++ b/torch_glow/tests/nodes/quantized_conv2d_test.py
@@ -6,8 +6,8 @@ from tests.utils import jitVsGlow
 import pytest
 
 
-def test_quantized_conv2d():
-    """Basic test of the PyTorch quantized onv2d Node on Glow."""
+def test_quantized_conv2d_unpacked():
+    """Basic test of the PyTorch quantize::conv2d Node with unpacked weights on Glow."""
 
     def test_f(a, w, b):
         qu = torch.nn.quantized.Quantize(1/16, 0, torch.quint8)
@@ -36,6 +36,34 @@ def test_quantized_conv2d():
     jitVsGlow(test_f, x, w, b_zero, expected_fused_ops={"aten::quantize_per_tensor",
                                                         "glow::unpacked_quantized_conv2d",
                                                         "aten::dequantize"})
+
+
+def test_quantized_conv2d_packed_groupwise():
+    """Basic test of PyTorch quantize::conv2d Node with packed weights on Glow."""
+
+    x = torch.tensor(range(5), dtype=torch.float)
+    x = torch.cat((x, x, x, x, x))
+    x = torch.cat((x, x, x))
+    x = torch.reshape(x, [1, 3, 5, 5])
+    q = torch.nn.quantized.Quantize(0.1, 2, torch.quint8)
+    conv = torch.nn.Conv2d(3, 3, [2, 2], groups=3)
+    dq = torch.nn.quantized.DeQuantize()
+
+    # Due to the off-by-one error, we cannot let the weights, bias & input
+    # to be totally random.
+    conv.weight.data.fill_(2.0)
+    conv.bias.data.fill_(1.0)
+
+    model = torch.nn.Sequential(q, conv, dq)
+    model.eval()
+    model.qconfig = torch.quantization.get_default_qconfig('fbgemm')
+
+    torch.quantization.prepare(model, inplace=True)
+    torch.quantization.convert(model, inplace=True)
+
+    jitVsGlow(model, x, expected_fused_ops={"aten::quantize_per_tensor",
+                                            "quantized::conv2d",
+                                            "aten::dequantize"})
 
 
 @pytest.mark.skip(reason="accuracy between glow & pytorch")

--- a/torch_glow/tests/nodes/quantized_linear_test.py
+++ b/torch_glow/tests/nodes/quantized_linear_test.py
@@ -5,6 +5,31 @@ import torch
 from tests.utils import jitVsGlow
 
 
+def test_quantized_linear_packed():
+    """Basic test of the PyTorch quantized::linear Node on Glow."""
+
+    q = torch.nn.quantized.Quantize(scale=1/25, zero_point=17,
+                                    dtype=torch.quint8)
+    dq = torch.nn.quantized.DeQuantize()
+    linear = torch.nn.Linear(5, 5)
+
+    linear.weight.data.fill_(1.2)
+    linear.bias.data.fill_(3.0)
+
+    model = torch.nn.Sequential(q, linear, dq)
+    model.qconfig = torch.quantization.get_default_qconfig('fbgemm')
+    torch.quantization.prepare(model, inplace=True)
+    torch.quantization.convert(model, inplace=True)
+
+    x = torch.tensor(range(5), dtype=torch.float)
+    x = torch.cat((x, x, x, x, x))
+    x = torch.reshape(x, [5, 5])
+
+    jitVsGlow(model, x, expected_fused_ops={"aten::quantize_per_tensor",
+                                            "quantized::linear",
+                                            "aten::dequantize"})
+
+
 def test_quantized_linear_random_input():
     """Basic test of the PyTorch quantized::linear Node on Glow."""
 


### PR DESCRIPTION
This pr added quantized conv, quantized conv_relu and quantized linear supported with packed weights & bias.
Also, conv & conv_relu has groupwise supported.
Unit test:

unit test 
quantized_conv2d_test.py 
quantized_conv2d_relu_test.py 
quantized_linear_test.py