### PR TITLE
[BackendTestUtils] Fix parallel clone count for quantized tests

### DIFF
--- a/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
@@ -206,6 +206,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "BatchOneHotDataInt64/0",
     "BatchOneHotDataInt32/0",
     "BatchOneHotDataInt8/0",
+    "matmulQuantized_InterpCompareParClone/0",
     "ModuloInt64NoSignFollow/0",
     "ModuloInt64SignFollow/0",
     "ModuloInt32NoSignFollow/0",


### PR DESCRIPTION
Summary: Fix parallel cloning for quantized graphs. Previously the graph used for profiling wasn't cloned, so quantization did not find quantization parameters for the clones.

Test Plan: Added a test.
