### PR TITLE
re-enable the Sigmoid NNPI test

### DIFF
--- a/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
@@ -84,7 +84,6 @@ std::set<std::string> glow::backendTestBlacklist = {
     "ScatterDataNDimensional/0",
     "ScatterDataNDimensionalSimple/0",
     "ScatterDataQuantized/0",
-    "SigmoidSweep_Float16/0",
     "sliceReshape_Int32/0",
     "sliceVectors_Int32/0",
     "spaceToDepth_block2_Float/0",


### PR DESCRIPTION
Summary: re-enable the Sigmoid Sweep in NNPI with updated thresholds such that it will pass

Differential Revision: D18303428

