### PR TITLE
[PyTorch] Glow fuser blacklist

### DIFF
--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -41,6 +41,10 @@ struct PyTorchLoaderSettings {
   /// Dump Glow dot graph to file after model loading is finished.
   bool dumpGlowDag = false;
 
+  /// A list of symbols for nodes that will be ignored by the Glow fuser and
+  /// thus will not be fused to Glow.
+  std::unordered_set<torch::jit::Symbol> opBlacklist;
+
   /// Name of the Glow backend to use with CachingGraphRunner's HostManager.
   std::string glowBackendName = "Interpreter";
 };

--- a/torch_glow/src/binding.cpp
+++ b/torch_glow/src/binding.cpp
@@ -61,6 +61,20 @@ PYBIND11_MODULE(_torch_glow, m) {
   m.def("disableDumpGlowDag",
         []() { getPyTorchLoaderSettings().dumpGlowDag = false; });
 
+  /// Add all of the symbols in \p blacklist to the fusion blacklist so that
+  /// nodes with these symbols will not be fused to Glow.
+  m.def("setFusionBlacklist", [](const std::vector<std::string> &blacklist) {
+    auto &bl = getPyTorchLoaderSettings().opBlacklist;
+    bl.clear();
+    for (const auto &kind : blacklist) {
+      bl.insert(torch::jit::Symbol::fromQualString(kind));
+    }
+  });
+
+  /// Clear the fusion blacklist.
+  m.def("clearFusionBlacklist",
+        []() { getPyTorchLoaderSettings().opBlacklist.clear(); });
+
   /// Binding wrapper class for TorchGlowTraining and its settings.
   py::class_<TorchGlowTrainingWrapper>(m, "TorchGlowTrainingWrapper")
       .def(py::init())

--- a/torch_glow/tests/functionality/blacklist_test.py
+++ b/torch_glow/tests/functionality/blacklist_test.py
@@ -1,0 +1,40 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import torch
+
+from tests.utils import GLOW_NODE_NAME, SUBGRAPH_ATTR
+import torch_glow
+
+
+def f(a, b):
+    return (a + b) * (a - b)
+
+
+def test_op_blacklist():
+    """Test Glow fuser blacklisting mechanism."""
+
+    torch_glow.enableFusionPass()
+    torch_glow.setFusionBlacklist(["aten::add"])
+
+    a = torch.randn(5, 5)
+    b = torch.randn(5, 5)
+
+    jit_f = torch.jit.trace(f, (a, b))
+
+    jit_f_graph = jit_f.graph_for(a, b)
+
+    fused_add = False
+    fused_sub = False
+    for node in jit_f_graph.nodes():
+        if node.kind() == GLOW_NODE_NAME:
+            glow_subgraph = node.g(SUBGRAPH_ATTR)
+            for node in glow_subgraph.nodes():
+                if node.kind() == "aten::add":
+                    fused_add = True
+                if node.kind() == "aten::sub":
+                    fused_sub = True
+
+    assert not fused_add, "Expected aten::add to be blacklisted"
+    assert fused_sub, "Expected aten::sub to not be blacklisted"
+
+    torch_glow.clearFusionBlacklist()


### PR DESCRIPTION
Summary:
Add a blacklisting functionality to Glow fuser so that it will ignore a user-specified set of node kinds.

Documentation:
doxygen

Test Plan:
added unit test