### PR TITLE
Relax single-use constant restrictions

### DIFF
--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -1791,8 +1791,7 @@ bool TransposeConstants::run(Function *F, const CompilationContext &cctx) {
       continue;
     }
     auto *C = dyn_cast<Constant>(TN->getInput());
-    // C must have a single use.
-    if (!C || !C->hasOneUse()) {
+    if (!C) {
       continue;
     }
     // Create a new Constant NC to hold the transposed result.
@@ -2123,10 +2122,7 @@ bool OptimizeReshape::run(Function *F, const CompilationContext &cctx) {
       continue;
     }
     // Reshape(Constant) -> Constant'.
-    // Only do this if the Constant has a single use, as otherwise we would
-    // duplicate the Constant and increase the memory footprint.
-    auto *C = dyn_cast<Constant>(inputNode);
-    if (C && C->hasOneUse()) {
+    if (auto *C = dyn_cast<Constant>(inputNode)) {
       // Create a new Constant with the type of the reshape.
       auto *newC = F->getParent()->createConstant(
           reshapeNode->getResult().getType(), C->getName());

--- a/tests/unittests/GraphOptzTest.cpp
+++ b/tests/unittests/GraphOptzTest.cpp
@@ -282,9 +282,8 @@ TEST_F(GraphOptz, optimizeBatchNormAfterConvFP16) {
 
   EXPECT_EQ(F_->getNodes().size(), 3);
 
-  optimizedF_ = F_->clone(F_->getName().str() + "_optimized");
   ::glow::convertPlaceholdersToConstants(F_, bindings_, {});
-  ::glow::convertPlaceholdersToConstants(optimizedF_, bindings_, {});
+  optimizedF_ = F_->clone(F_->getName().str() + "_optimized");
   ::glow::optimize(optimizedF_, CompilationMode::Infer);
 
   EXPECT_EQ(optimizedF_->getNodes().size(), 2);
@@ -332,9 +331,8 @@ TEST_F(GraphOptz, optimizeBatchNormAfterConvWithTransposedWeights) {
   EXPECT_EQ(F_->getNodes().size(), 4);
   EXPECT_EQ(countNodeKind(F_, Kinded::Kind::BatchNormalizationNodeKind), 1);
 
-  optimizedF_ = F_->clone(F_->getName().str() + "_optimized");
   ::glow::convertPlaceholdersToConstants(F_, bindings_, {input});
-  ::glow::convertPlaceholdersToConstants(optimizedF_, bindings_, {input});
+  optimizedF_ = F_->clone(F_->getName().str() + "_optimized");
   ::glow::optimize(optimizedF_, CompilationMode::Infer);
 
   EXPECT_EQ(optimizedF_->getNodes().size(), 2);
@@ -370,10 +368,10 @@ TEST_F(GraphOptz, optimizeBatchNormAfterConvWithReshapeConst) {
   EXPECT_EQ(F_->getNodes().size(), 4);
   EXPECT_EQ(countNodeKind(F_, Kinded::Kind::BatchNormalizationNodeKind), 1);
 
-  optimizedF_ = F_->clone(F_->getName().str() + "_optimized");
   ::glow::convertPlaceholdersToConstants(F_, bindings_, {input});
-  ::glow::convertPlaceholdersToConstants(optimizedF_, bindings_, {input});
+  optimizedF_ = F_->clone(F_->getName().str() + "_optimized");
   ::glow::optimize(optimizedF_, CompilationMode::Infer);
+
   EXPECT_EQ(optimizedF_->getNodes().size(), 2);
   EXPECT_EQ(
       countNodeKind(optimizedF_, Kinded::Kind::BatchNormalizationNodeKind), 0);


### PR DESCRIPTION
Summary: In a few places we check that a constant must have one use before performing some optimization on it.  This means that we get unintuitive results if we try to clone a function and optimize the clone, because some optimizations won't kick in.  I think the intent is to avoid increasing the model's memory footprint, but it seems like a heavy hammer to never allow.

Test Plan: Modifications to some existing GraphOptzTests.  I noticed this behavior when reviewing #3731 and wanted to get to the bottom of it.
