### PR TITLE
[GraphOptimizer] Change pipeline so we only run the backend's preferred optimizations at the end of the pipeline

### DIFF
--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -3211,13 +3211,14 @@ Error glow::optimizeFunction(Function *F, const Backend &B,
   // need to be lowered, e.g., Clip.
   ::glow::lower(F, cctx, &B);
 
-  // Optimize the graph again, but given the backend's preferred pipeline.
-  ::glow::optimize(F, cctx, B);
+  // Optimize the graph again now that we have a lowered representation.
+  ::glow::optimize(F, cctx);
 
   // Allow the backend to transform the graph after lowering.
   if (B.transformPostLowering(F, cctx)) {
-    // Optimize the graph again after the backend transformation.
-    // In particular, DCE is very likely to be useful.
+    // If the backend made changes, optimize the graph again. Perform only
+    // passes that the Backend has requested so we do not interfere with the
+    // backend's transformations.
     ::glow::optimize(F, cctx, B);
   }
 


### PR DESCRIPTION
Summary: Prior to this PR, we ran the backend's preferred pipeline before and after backend transformation (via `Backend::transformPostLowering()`). However the backend's preferred pipeline may be pretty minimal. Let's use our default pipeline after the final round of lowering instead.

Test Plan: All tests still pass.
