### PR TITLE
Remove SinkCode from NNPI opt pipeline

### DIFF
--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -347,6 +347,10 @@ FunctionPassPipeline NNPIBackend::getOptimizationPipeline() const {
   auto pipeline = createDefaultGraphOptimizationPassPipeline();
   pipeline.removeAllInstancesOfPass(FunctionPassID::FoldTileAddIntoBatchedAdd);
 
+  // Disable SinkCode, as NNPI does data parallel transformations and so we do
+  // not want to undo that by sinking Nodes back together.
+  pipeline.removeAllInstancesOfPass(FunctionPassID::SinkCode);
+
   return pipeline;
 }
 


### PR DESCRIPTION
Summary: The NNPI backend would like to do data parallel transformations. Our `SinkCode` optimization tends to undo some of those transformations. Disable `SinkCode` so that after NNPI does backend transformations via `NNPI::transformPostLowering()`, `SinkCode` does not undo what we did.

Differential Revision: D18351226

