### PR TITLE
Device Resident Tensors - API & Framework

### DIFF
--- a/include/glow/Backends/DeviceManager.h
+++ b/include/glow/Backends/DeviceManager.h
@@ -17,6 +17,7 @@
 #define GLOW_BACKENDS_DEVICEMANAGER_H
 
 #include "glow/Backend/CompiledFunction.h"
+#include "glow/Base/DeviceTensorTransferManager.h"
 #include "glow/ExecutionContext/ExecutionContext.h"
 #include "glow/Graph/Graph.h"
 #include "glow/Runtime/RuntimeTypes.h"
@@ -42,7 +43,7 @@ using ReadyCBTy = std::function<void(const Module *, Error)>;
 using FunctionMapTy = std::map<std::string, CompiledFunction *>;
 
 /// Interface managing a specific instance of a device.
-class DeviceManager {
+class DeviceManager : public DeviceTensorTransferManager {
 protected:
   /// Configuration object for the device.
   DeviceConfig config_;
@@ -152,6 +153,33 @@ public:
   /// \returns the DeviceInfo for this device containing peak limits for
   /// compute and bandwidths (used in partitioning).
   virtual DeviceInfo getDeviceInfo() const { return DeviceInfo(); }
+
+  /// Copies the contents of \p tensor from the host to the \p location
+  /// address on this device. Updates the tensor residency info.
+  virtual void transferToDevice(Tensor &tensor, void *locationContext,
+                                std::function<void(Error)> resultCB =
+                                    [](Error) {}) {
+    DCHECK("Not Implemented");
+    resultCB(MAKE_ERR(ErrorValue::ErrorCode::DEVICE_FEATURE_NOT_SUPPORTED,
+                      "Direct transfer not supported on this device"));
+  }
+
+  /// Copies the device buffer associated with \p tensor to the host.
+  /// The tensor must be resident on this device. If \p release is true,
+  /// frees the device memory. Updates the tensor residency info.
+  virtual void transferFromDevice(Tensor &tensor, bool release = true,
+                                  std::function<void(Error)> resultCB =
+                                      [](Error) {}) {
+    DCHECK("Not Implemented");
+    resultCB(MAKE_ERR(ErrorValue::ErrorCode::DEVICE_FEATURE_NOT_SUPPORTED,
+                      "Direct transfer not supported on this device"));
+  }
+
+  /// Releases the device buffer associated with \p tensor.
+  virtual bool releaseDeviceTensor(void *locationContext) {
+    DCHECK("Not Implemented");
+    return false;
+  }
 };
 
 } // namespace runtime

--- a/include/glow/Base/DeviceTensorTransferManager.h
+++ b/include/glow/Base/DeviceTensorTransferManager.h
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_BASE_DEVICETENSORTRANSFERMANAGER_H
+#define GLOW_BASE_DEVICETENSORTRANSFERMANAGER_H
+
+#include "glow/Base/Tensor.h"
+#include "glow/Support/Error.h"
+
+#include <functional>
+
+namespace glow {
+
+class Tensor;
+
+class DeviceTensorTransferManager {
+public:
+  virtual ~DeviceTensorTransferManager() {}
+  /// Copies the contents of \p tensor from the host to the \p location address
+  /// on this device. Updates the tensor residency info.
+  virtual void transferToDevice(Tensor &tensor, void *locationContext = nullptr,
+                                std::function<void(Error)> resultCB =
+                                    [](Error) {}) = 0;
+
+  /// Copies the device buffer associated with \p tensor to the host.
+  /// The tensor must be resident on this device. If \p release is true, frees
+  /// the device memory. Updates the tensor residency info.
+  virtual void transferFromDevice(Tensor &tensor, bool release = true,
+                                  std::function<void(Error)> resultCB =
+                                      [](Error) {}) = 0;
+
+  /// Releases the device buffer associated with \p tensor.
+  virtual bool releaseDeviceTensor(void *locationContext) = 0;
+};
+
+} // namespace glow
+
+#endif // GLOW_BASE_DEVICETENSORTRANSFERMANAGER_H

--- a/include/glow/ExecutionEngine/ExecutionEngine.h
+++ b/include/glow/ExecutionEngine/ExecutionEngine.h
@@ -59,6 +59,10 @@ class ExecutionEngine final {
   /// Glow functions compiled for this ExecutionEngine's backend.
   std::set<std::string> compiledFunctions_;
 
+  /// Whether to move all Device Resident Tensors on to the host at the end of
+  /// the run.
+  bool ensureOutputsOnHost_{true};
+
   /// Single execution of the given function, \p name with the given context
   /// \bindings.
   void runInternal(ExecutionContext &context, llvm::StringRef name);
@@ -84,6 +88,9 @@ public:
     deviceMemory_ = mem;
     setBackendName(backendName_);
   }
+
+  // Set whether or not to ensure outputs are in host memory.
+  void ensureOutputsOnHost(bool should) { ensureOutputsOnHost_ = should; }
 
   /// Get the name of the current backend in use.
   llvm::StringRef getBackendName() const;

--- a/include/glow/Graph/PlaceholderBindings.h
+++ b/include/glow/Graph/PlaceholderBindings.h
@@ -114,6 +114,13 @@ public:
   /// PlaceholderBindings.
   uint64_t getDataSize() const;
 
+  /// Copies all Device Resident Tensors back to the host.
+  void ensureOnHost() {
+    for (auto &ph : pairs()) {
+      ph.second->ensureOnHost();
+    }
+  }
+
   PlaceholderBindings() = default;
 
   /// Construct the PlaceholderBindings with an initial mapping between \p

--- a/include/glow/Support/Error.h
+++ b/include/glow/Support/Error.h
@@ -262,6 +262,8 @@ public:
     RUNTIME_DEVICE_NOT_FOUND,
     // Runtime error, network busy to perform any operation on it.
     RUNTIME_NET_BUSY,
+    // Device error, not supported.
+    DEVICE_FEATURE_NOT_SUPPORTED,
     // Compilation error; node unsupported after optimizations.
     COMPILE_UNSUPPORTED_NODE_AFTER_OPTIMIZE,
     // Compilation error; Compilation context not correctly setup.

--- a/lib/Backends/CPU/tests/CPUDeviceManagerTest.cpp
+++ b/lib/Backends/CPU/tests/CPUDeviceManagerTest.cpp
@@ -17,4 +17,6 @@
 
 using namespace glow;
 
-std::set<std::string> glow::backendTestBlacklist = {};
+std::set<std::string> glow::backendTestBlacklist = {
+    "DeviceResidentTensors/0",
+};

--- a/lib/Backends/Habana/HabanaDeviceManager.cpp
+++ b/lib/Backends/Habana/HabanaDeviceManager.cpp
@@ -284,6 +284,10 @@ void HabanaDeviceManager::runFunctionImpl(RunIdentifierTy runId,
 
   TRACE_EVENT_SCOPE_NAMED(ctx->getTraceContext(), TraceLevel::RUNTIME,
                           "HabanaDM::runnerThread", trEvent);
+
+  /// Habana DeviceManager doesn't support Device Resident Tensors.
+  ctx->getPlaceholderBindings()->ensureOnHost();
+
   if (ctx->getTraceContext()) {
     ctx->getTraceContext()->setThreadName(
         llvm::formatv("Habana {0} (enqueue)", deviceId_).str());

--- a/lib/Backends/Habana/tests/HabanaDeviceManagerTest.cpp
+++ b/lib/Backends/Habana/tests/HabanaDeviceManagerTest.cpp
@@ -17,4 +17,6 @@
 
 using namespace glow;
 
-std::set<std::string> glow::backendTestBlacklist = {};
+std::set<std::string> glow::backendTestBlacklist = {
+    "DeviceResidentTensors/0",
+};

--- a/lib/Backends/Interpreter/InterpreterFunction.cpp
+++ b/lib/Backends/Interpreter/InterpreterFunction.cpp
@@ -192,6 +192,8 @@ Error BoundInterpreterFunction::execute(IRFunction *F,
                                         ExecutionContext *context) {
   {
     TRACE_EVENT_SCOPE(context, TraceLevel::RUNTIME, "registerTensors");
+    // Make sure all referenced tensors are on the host.
+    context->getPlaceholderBindings()->ensureOnHost();
 
     // Find all virtually padded tensors so they can be replaced.
     std::vector<Placeholder *> virtualPadded;

--- a/lib/Backends/Interpreter/tests/InterpreterDeviceManagerTest.cpp
+++ b/lib/Backends/Interpreter/tests/InterpreterDeviceManagerTest.cpp
@@ -17,4 +17,6 @@
 
 using namespace glow;
 
-std::set<std::string> glow::backendTestBlacklist = {};
+std::set<std::string> glow::backendTestBlacklist = {
+    "DeviceResidentTensors/0",
+};

--- a/lib/Backends/NNPI/NNPIDeviceManager.cpp
+++ b/lib/Backends/NNPI/NNPIDeviceManager.cpp
@@ -193,6 +193,9 @@ NNPIDeviceManager::runFunction(std::string functionName,
                                runtime::ResultCBTy resultCB) {
   RunIdentifierTy runId = runIdentifier_++;
 
+  /// NNPI DeviceManager doesn't support Device Resident Tensors.
+  ctx->getPlaceholderBindings()->ensureOnHost();
+
   // Get thread env.
   auto infEnv = inferenceEnvs_.find(functionName);
   if (infEnv == inferenceEnvs_.end()) {

--- a/lib/Backends/NNPI/tests/NNPIDeviceManagerTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIDeviceManagerTest.cpp
@@ -19,4 +19,5 @@ using namespace glow;
 
 std::set<std::string> glow::backendTestBlacklist = {
     "MultiFunction/0",
+    "DeviceResidentTensors/0",
 };

--- a/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
@@ -430,6 +430,7 @@ void OpenCLDeviceManager::copyInputsToDevice(
     runtime::OpenCLDeviceBindings *devBindings) {
   TRACE_EVENT_SCOPE(context->getTraceContext(), TraceLevel::RUNTIME,
                     "copyInputsToDevice");
+
   bool profilingEnabled =
       context->getTraceContext() &&
       (context->getTraceContext()->getTraceLevel() & TraceLevel::COPY);
@@ -459,6 +460,7 @@ void OpenCLDeviceManager::copyInputsToDevice(
       devBindings->kernelLaunches.emplace_back(name, "copy", event);
     }
   }
+
   // Do it!
   clFinish(devBindings->commandQueue);
 }
@@ -468,9 +470,11 @@ void OpenCLDeviceManager::copyOutputsFromDevice(
     runtime::OpenCLDeviceBindings *devBindings) {
   TRACE_EVENT_SCOPE(context->getTraceContext(), TraceLevel::RUNTIME,
                     "copyOutputsFromDevice");
+
   bool profilingEnabled =
       context->getTraceContext() &&
       (context->getTraceContext()->getTraceLevel() & TraceLevel::COPY);
+
   auto &symbolTable = runtimeBundle.getSymbolTable();
   for (auto PH : context->getPlaceholderBindings()->pairs()) {
     auto it = symbolTable.find(PH.first->getName());
@@ -496,6 +500,7 @@ void OpenCLDeviceManager::copyOutputsFromDevice(
       devBindings->kernelLaunches.emplace_back(name, "copy", event);
     }
   }
+
   // Do it!
   clFinish(devBindings->commandQueue);
 }
@@ -630,9 +635,11 @@ void OpenCLDeviceManager::runFunctionImpl(
     RunIdentifierTy id, std::string function,
     std::unique_ptr<ExecutionContext> context, ResultCBTy resultCB) {
   DCHECK(resultCB != nullptr);
-
   TRACE_EVENT_SCOPE_NAMED(context->getTraceContext(), TraceLevel::RUNTIME,
                           "DeviceManager::run", dmRun);
+  /// OpenCL DeviceManager doesn't support Device Resident Tensors.
+  context->getPlaceholderBindings()->ensureOnHost();
+
   auto funcIt = functions_.find(function);
   if (funcIt == functions_.end()) {
     dmRun.addArg("reason", "function not found");

--- a/lib/Backends/OpenCL/tests/OpenCLDeviceManagerTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLDeviceManagerTest.cpp
@@ -17,4 +17,6 @@
 
 using namespace glow;
 
-std::set<std::string> glow::backendTestBlacklist = {};
+std::set<std::string> glow::backendTestBlacklist = {
+    "DeviceResidentTensors/0",
+};

--- a/lib/Base/Tensor.cpp
+++ b/lib/Base/Tensor.cpp
@@ -473,6 +473,7 @@ ShapeVector glow::expandDimsToMax(llvm::ArrayRef<size_t> currDims) {
 }
 
 void Tensor::init(InitKind init, float val, PseudoRNG &PRNG) {
+  assert(!isDeviceResident() && "Tensor must reside on host to access data.");
   switch (init) {
   case InitKind::Zero:
     zero();
@@ -562,10 +563,12 @@ void Tensor::init(InitKind init, float val, PseudoRNG &PRNG) {
 }
 
 void Tensor::convertToType(ElemKind newTy) {
+  assert(!isDeviceResident() && "Tensor must reside on host to access data.");
   *this = this->getCopyConvertedToType(newTy);
 }
 
 Tensor Tensor::getCopyConvertedToType(ElemKind newKind) const {
+  assert(!isDeviceResident() && "Tensor must reside on host to access data.");
   const ElemKind origKind = getElementType();
   DCHECK((origKind == ElemKind::FloatTy && newKind == ElemKind::Float16Ty) ||
          (origKind == ElemKind::Float16Ty && newKind == ElemKind::FloatTy) ||
@@ -636,6 +639,21 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Tensor *t) {
   assert(t != nullptr && "Null Pointer.");
   t->dump(os);
   return os;
+}
+
+void Tensor::moveToDevice(DeviceTensorTransferManager *deviceManager,
+                          void *locationContext) {
+  residencyInfoP_->deviceManager_ = deviceManager;
+  residencyInfoP_->locationContext_ = locationContext;
+  residencyInfoP_->tensorResidency_ =
+      DeviceResidencyInfo::TensorResidency::Device;
+}
+
+void Tensor::ensureOnHost() {
+  if (residencyInfoP_->isDeviceResident()) {
+    residencyInfoP_->deviceManager_->transferFromDevice(*this);
+  }
+  assert(!isDeviceResident());
 }
 
 } // namespace glow

--- a/lib/LLVMIRCodeGen/LLVMCompiledFunction.cpp
+++ b/lib/LLVMIRCodeGen/LLVMCompiledFunction.cpp
@@ -33,6 +33,9 @@ void LLVMCompiledFunction::collectConstants(const Module *module) {
 
 void LLVMCompiledFunction::loadPlaceholders(
     PlaceholderBindings *bindings, uint8_t *baseMutableWeightVarsAddress) {
+  // Make sure our inputs are on the host.
+  bindings->ensureOnHost();
+
   // Copy Placeholders into allocated memory.
   auto &symbolTable = runtimeBundle_.getSymbolTable();
   for (auto PH : bindings->pairs()) {
@@ -40,6 +43,7 @@ void LLVMCompiledFunction::loadPlaceholders(
     if (it == symbolTable.end()) {
       continue;
     }
+    assert(!PH.second->isDeviceResident());
     auto symbolInfo = it->second;
     auto payload = PH.second->getUnsafePtr();
     auto addr = symbolInfo.offset;

--- a/lib/Support/Error.cpp
+++ b/lib/Support/Error.cpp
@@ -87,6 +87,8 @@ std::string GlowErrorValue::errorCodeToString(const ErrorCode &ec) {
     return "RUNTIME_DEVICE_NOT_FOUND";
   case ErrorCode::RUNTIME_NET_BUSY:
     return "RUNTIME_NET_BUSY";
+  case ErrorCode::DEVICE_FEATURE_NOT_SUPPORTED:
+    return "DEVICE_FEATURE_NOT_SUPPORTED";
   case ErrorCode::COMPILE_UNSUPPORTED_NODE_AFTER_OPTIMIZE:
     return "COMPILE_UNSUPPORTED_NODE_AFTER_OPTIMIZE";
   case ErrorCode::COMPILE_CONTEXT_MALFORMED:

--- a/tests/unittests/BackendTestUtils.cpp
+++ b/tests/unittests/BackendTestUtils.cpp
@@ -211,6 +211,10 @@ void dispatchInference(const std::string &fname,
   for (auto &future : futures) {
     future.wait();
   }
+
+  for (auto &c : contexts) {
+    c->getPlaceholderBindings()->ensureOnHost();
+  }
   // Release the original context passed in by reference so we don't free it.
   contexts[0].release();
 }

--- a/tests/unittests/DeviceManagerTest.cpp
+++ b/tests/unittests/DeviceManagerTest.cpp
@@ -32,11 +32,26 @@
 using namespace glow;
 using namespace glow::runtime;
 
+template <typename ResultType>
+std::pair<std::promise<ResultType>, std::future<ResultType>> getFutureHelper() {
+  std::promise<ResultType> promise;
+  auto future = promise.get_future();
+  return std::make_pair(std::move(promise), std::move(future));
+}
+
+template <typename ResultType>
+void callbackHelper(std::promise<ResultType> &promise, ResultType res,
+                    Error err) {
+  promise.set_value(!ERR_TO_BOOL(std::move(err)) ? std::move(res)
+                                                 : ResultType());
+}
+
 class DeviceManagerTest : public ::testing::TestWithParam<std::string> {
 public:
   void SetUp() override {
     backendName = GetParam();
-    device.reset(DeviceManager::createDeviceManager(DeviceConfig(backendName)));
+    DeviceConfig config(backendName);
+    device.reset(DeviceManager::createDeviceManager(config));
     ASSERT_TRUE(device.get());
     ASSERT_FALSE(ERR_TO_BOOL(device->init()));
   }
@@ -45,6 +60,40 @@ public:
 
   std::string backendName;
   std::unique_ptr<DeviceManager> device{nullptr};
+
+  void addToDevice(Module *module, FunctionMapTy functions) {
+
+    std::promise<const Module *> promise;
+    std::future<const Module *> future;
+    std::tie(promise, future) = getFutureHelper<const Module *>();
+
+    device->addNetwork(module, std::move(functions),
+                       [&promise](const Module *module, Error err) {
+                         callbackHelper(promise, module, std::move(err));
+                       });
+
+    future.wait_for(std::chrono::seconds(2));
+    EXPECT_EQ(future.get(), module);
+  }
+
+  std::unique_ptr<ExecutionContext>
+  runFunction(std::string name, std::unique_ptr<ExecutionContext> context) {
+    std::promise<std::unique_ptr<ExecutionContext>> runPromise;
+    std::future<std::unique_ptr<ExecutionContext>> runFuture;
+
+    std::tie(runPromise, runFuture) =
+        getFutureHelper<std::unique_ptr<ExecutionContext>>();
+    device->runFunction(
+        name, std::move(context),
+        [&runPromise](RunIdentifierTy, Error err,
+                      std::unique_ptr<ExecutionContext> context) {
+          callbackHelper(runPromise, std::move(context), std::move(err));
+        });
+
+    runFuture.wait_for(std::chrono::seconds(2));
+    context = runFuture.get();
+    return context;
+  }
 };
 
 std::unique_ptr<Module> makeBasicModule(std::string functionName = "main") {
@@ -83,41 +132,17 @@ compileFunctions(llvm::StringRef backendName, Module *module,
   return results;
 }
 
-template <typename ResultType>
-std::pair<std::promise<ResultType>, std::future<ResultType>> getFutureHelper() {
-  std::promise<ResultType> promise;
-  auto future = promise.get_future();
-  return std::make_pair(std::move(promise), std::move(future));
-}
-
-template <typename ResultType>
-void callbackHelper(std::promise<ResultType> &promise, ResultType res,
-                    Error err) {
-  promise.set_value(!ERR_TO_BOOL(std::move(err)) ? std::move(res)
-                                                 : ResultType());
-}
-
 TEST_P(DeviceManagerTest, Basic) {
   auto module = makeBasicModule();
   std::vector<std::unique_ptr<CompiledFunction>> backing;
   FunctionMapTy functions =
       compileFunctions(backendName, module.get(), backing);
 
-  std::promise<const Module *> promise;
-  std::future<const Module *> future;
-  std::tie(promise, future) = getFutureHelper<const Module *>();
-
-  device->addNetwork(module.get(), std::move(functions),
-                     [&promise](const Module *module, Error err) {
-                       callbackHelper(promise, module, std::move(err));
-                     });
-
-  future.wait_for(std::chrono::seconds(2));
-  EXPECT_EQ(future.get(), module.get());
-
   std::unique_ptr<ExecutionContext> context =
       glow::make_unique<ExecutionContext>();
   context->getPlaceholderBindings()->allocate(module->getPlaceholders());
+
+  addToDevice(module.get(), std::move(functions));
 
   Tensor input1(ElemKind::FloatTy, {1});
   Tensor output1(ElemKind::FloatTy, {1});
@@ -128,21 +153,11 @@ TEST_P(DeviceManagerTest, Basic) {
                           {module->getPlaceholderByName("main_input")},
                           {&input1});
 
-  std::promise<std::unique_ptr<ExecutionContext>> runPromise;
-  std::future<std::unique_ptr<ExecutionContext>> runFuture;
-
-  std::tie(runPromise, runFuture) =
-      getFutureHelper<std::unique_ptr<ExecutionContext>>();
-  device->runFunction("main", std::move(context),
-                      [&runPromise](RunIdentifierTy, Error err,
-                                    std::unique_ptr<ExecutionContext> context) {
-                        callbackHelper(runPromise, std::move(context),
-                                       std::move(err));
-                      });
-
-  runFuture.wait_for(std::chrono::seconds(2));
-  context = runFuture.get();
+  context = runFunction("main", std::move(context));
   ASSERT_TRUE(context);
+  // We must ensure results are on host since we're using DeviceManager
+  // directly.
+  context->getPlaceholderBindings()->ensureOnHost();
   Tensor *result1 = context->getPlaceholderBindings()->get(
       module->getPlaceholderByName("main_output"));
   ASSERT_TRUE(result1);
@@ -211,8 +226,13 @@ TEST_P(DeviceManagerTest, PartialTensorCopy) {
   runFuture.wait_for(std::chrono::seconds(2));
   context = runFuture.get();
   ASSERT_TRUE(context);
+  // We must ensure results are on host since we're using DeviceManager
+  // directly.
+  context->getPlaceholderBindings()->ensureOnHost();
+
   Tensor *result1 = context->getPlaceholderBindings()->get(
       module->getPlaceholderByName("main_output"));
+
   ASSERT_TRUE(result1);
   EXPECT_FLOAT_EQ(result1->getHandle().at({0}), std::max(std::tanh(0.5), 0.25));
 }
@@ -223,15 +243,7 @@ TEST_P(DeviceManagerTest, MultiRun) {
   FunctionMapTy functions =
       compileFunctions(backendName, module.get(), backing);
 
-  std::promise<const Module *> promise;
-  std::future<const Module *> future;
-  std::tie(promise, future) = getFutureHelper<const Module *>();
-  device->addNetwork(module.get(), std::move(functions),
-                     [&promise](const Module *module, Error err) {
-                       callbackHelper(promise, module, std::move(err));
-                     });
-  future.wait_for(std::chrono::seconds(2));
-  EXPECT_EQ(future.get(), module.get());
+  addToDevice(module.get(), std::move(functions));
 
   std::unique_ptr<ExecutionContext> context1 =
       glow::make_unique<ExecutionContext>();
@@ -281,6 +293,10 @@ TEST_P(DeviceManagerTest, MultiRun) {
   ASSERT_TRUE(context1);
   ASSERT_TRUE(context2);
   EXPECT_NE(context1, context2);
+  // We must ensure results are on host since we're using DeviceManager
+  // directly.
+  context1->getPlaceholderBindings()->ensureOnHost();
+  context2->getPlaceholderBindings()->ensureOnHost();
 
   Tensor *result1 = context1->getPlaceholderBindings()->get(
       module->getPlaceholderByName("main_output"));
@@ -376,6 +392,8 @@ TEST_P(DeviceManagerTest, MultiFunction) {
   ASSERT_TRUE(context1);
   ASSERT_TRUE(context2);
   EXPECT_NE(context1, context2);
+  context1->getPlaceholderBindings()->ensureOnHost();
+  context2->getPlaceholderBindings()->ensureOnHost();
 
   Tensor *result1 = context1->getPlaceholderBindings()->get(
       module->getPlaceholderByName("func1_output"));
@@ -458,6 +476,8 @@ TEST_P(DeviceManagerTest, MultiModule) {
   ASSERT_TRUE(context1);
   ASSERT_TRUE(context2);
   EXPECT_NE(context1, context2);
+  context2->getPlaceholderBindings()->ensureOnHost();
+  context2->getPlaceholderBindings()->ensureOnHost();
 
   Tensor *result1 = context1->getPlaceholderBindings()->get(
       module1->getPlaceholderByName("func1_output"));
@@ -737,5 +757,101 @@ TEST(DeviceManagerTest, DummyDeviceManager) {
 }
 
 #endif // GLOW_WITH_CPU
+
+/// Check that the device can move data to and from the host.
+/// Disable if your device does not support Device Resident Tensors.
+TEST_P(DeviceManagerTest, DeviceResidentTensors) {
+  CHECK_IF_ENABLED();
+  Tensor T = {1.2f, 12.1f, 51.0f, 1515.2f};
+  Tensor R = {1.2f, 12.1f, 51.0f, 1515.2f};
+
+  ASSERT_FALSE(T.isDeviceResident());
+
+  device->transferToDevice(T, nullptr);
+
+  ASSERT_TRUE(T.isDeviceResident());
+
+  device->transferFromDevice(T);
+
+  ASSERT_FALSE(T.isDeviceResident());
+
+  ASSERT_TRUE(T.isEqual(R));
+}
+
+/// A mock DeviceManager for use in Device Resident Tensor tests.
+class MockDM : public DeviceManager {
+public:
+  MockDM() : DeviceManager(DeviceConfig("MockDM")) {}
+  void addNetwork(const Module *module, FunctionMapTy functions,
+                  ReadyCBTy readyCB) override {}
+
+  void evictNetwork(std::string functionName,
+                    EvictFunctionCBTy evictCB = [](std::string, Error) {
+                    }) override {}
+
+  runtime::RunIdentifierTy
+  runFunction(std::string functionName,
+              std::unique_ptr<ExecutionContext> context,
+              runtime::ResultCBTy resultCB) override {
+    return 0;
+  }
+
+  uint64_t getMaximumMemory() const override { return 0; }
+
+  uint64_t getAvailableMemory() const override { return 0; }
+
+  bool isMemoryAvailable(uint64_t estimate) const override { return 0; }
+
+  void transferToDevice(Tensor &tensor, void *locationContext = nullptr,
+                        std::function<void(Error)> resultCB = [](Error) {
+                        }) override {
+    if (locationContext == nullptr) {
+      locationContext = this;
+    }
+    tensor.moveToDevice(this, locationContext);
+  }
+
+  void transferFromDevice(Tensor &tensor, bool release = true,
+                          std::function<void(Error)> resultCB = [](Error) {
+                          }) override {
+    tensor.clearDeviceResidency();
+  }
+
+  bool releaseDeviceTensor(void *locationContext) override { return true; }
+};
+
+TEST_P(DeviceManagerTest, CanHandleDeviceResidentTensors) {
+  MockDM mockDM;
+
+  auto module = makeBasicModule();
+  std::vector<std::unique_ptr<CompiledFunction>> backing;
+  FunctionMapTy functions =
+      compileFunctions(backendName, module.get(), backing);
+
+  addToDevice(module.get(), std::move(functions));
+
+  std::unique_ptr<ExecutionContext> context =
+      glow::make_unique<ExecutionContext>();
+  context->getPlaceholderBindings()->allocate(module->getPlaceholders());
+
+  Tensor input1(ElemKind::FloatTy, {1});
+  Tensor output1(ElemKind::FloatTy, {1});
+  input1.getHandle().clear(0.5);
+  output1.getHandle().clear(std::max(std::tanh(0.5), 0.25));
+
+  updateInputPlaceholders(*context->getPlaceholderBindings(),
+                          {module->getPlaceholderByName("main_input")},
+                          {&input1});
+
+  mockDM.transferToDevice(*context->getPlaceholderBindings()->get(
+      module->getPlaceholderByName("main_input")));
+
+  context = runFunction("main", std::move(context));
+  ASSERT_TRUE(context);
+  Tensor *result1 = context->getPlaceholderBindings()->get(
+      module->getPlaceholderByName("main_output"));
+  ASSERT_TRUE(result1);
+  EXPECT_TRUE(result1->isEqual(output1));
+}
 
 INSTANTIATE_BACKEND_TEST(DeviceManagerTest);


### PR DESCRIPTION
Summary: Taking over #3671, but spinning out the API and Glow-core level changes associated with the DRT plan in #3629. This does not implement DRT support on any device.

Documentation: See #3629.

Test Plan: Ran tests, added two simple new sanity checks to DeviceManagerTest. The first `DeviceResidentTensors` should run only for backends that support resident tensors (none currently). The second `CanHandleDeviceResidentTensors` should run on all devices.