### PR TITLE
Add error handling to benchmark tests

### DIFF
--- a/tests/benchmark/AddBench.cpp
+++ b/tests/benchmark/AddBench.cpp
@@ -100,7 +100,7 @@ public:
     }
 
     CompilationContext ctx;
-    hostManager_->addNetwork(std::move(mod), ctx);
+    EXIT_ON_ERR(hostManager_->addNetwork(std::move(mod), ctx));
   }
 
   void run() override {

--- a/tests/benchmark/BatchGemmBench.cpp
+++ b/tests/benchmark/BatchGemmBench.cpp
@@ -144,7 +144,7 @@ public:
     }
 
     CompilationContext ctx;
-    hostManager_->addNetwork(std::move(mod), ctx);
+    EXIT_ON_ERR(hostManager_->addNetwork(std::move(mod), ctx));
   }
 
   void run() override {

--- a/tests/benchmark/GemmBench.cpp
+++ b/tests/benchmark/GemmBench.cpp
@@ -96,7 +96,7 @@ public:
     executeVerticalFCWeightsSplit(fn, numSplits_, n_);
 
     CompilationContext ctx;
-    hostManager_->addNetwork(std::move(mod), ctx);
+    EXIT_ON_ERR(hostManager_->addNetwork(std::move(mod), ctx));
   }
 
   void run() override {

--- a/tests/benchmark/GemmParallelBench.cpp
+++ b/tests/benchmark/GemmParallelBench.cpp
@@ -122,7 +122,7 @@ public:
                                              });
     }
     CompilationContext ctx;
-    hostManager_->addNetwork(std::move(mod), ctx);
+    EXIT_ON_ERR(hostManager_->addNetwork(std::move(mod), ctx));
   }
 
   void run() override {

--- a/tests/benchmark/SLSBench.cpp
+++ b/tests/benchmark/SLSBench.cpp
@@ -150,7 +150,7 @@ public:
     } // For each slsNodeId
 
     CompilationContext ctx;
-    hostManager_->addNetwork(std::move(mod), ctx);
+    EXIT_ON_ERR(hostManager_->addNetwork(std::move(mod), ctx));
   }
 
   void run() override {

--- a/tests/benchmark/TransposeBench.cpp
+++ b/tests/benchmark/TransposeBench.cpp
@@ -130,7 +130,7 @@ public:
     }
 
     CompilationContext ctx;
-    hostManager_->addNetwork(std::move(mod), ctx);
+    EXIT_ON_ERR(hostManager_->addNetwork(std::move(mod), ctx));
   }
 
   void run() override {


### PR DESCRIPTION
Summary: The benchmark tests don't check a potential error return during execution.
This asserts in debug on unchecked error object

