### PR TITLE
[Dump DAG](trivial) Use the exact CLI file name for single function.

### DIFF
--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -516,8 +516,9 @@ void Loader::compile(CompilationContext &cctx) {
     for (auto function : module->getFunctions()) {
       std::string filename =
           function->getFilename() + "_" + dumpGraphDAGFileOpt;
-      if (module->getFunctions().size() == 1)
+      if (module->getFunctions().size() == 1) {
         filename = dumpGraphDAGFileOpt;
+      }
       function->dumpDAG(filename.c_str());
     }
   }

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -516,6 +516,8 @@ void Loader::compile(CompilationContext &cctx) {
     for (auto function : module->getFunctions()) {
       std::string filename =
           function->getFilename() + "_" + dumpGraphDAGFileOpt;
+      if (module->getFunctions().size() == 1)
+        filename = dumpGraphDAGFileOpt;
       function->dumpDAG(filename.c_str());
     }
   }


### PR DESCRIPTION
**Summary**
When the module has a single function, even if the CLI parameter is given as (for example) 

> -dump-graph-DAG=graph.dot

the generated file name is "_graph.dot" which is not clean (pre-pending the function name makes sense when multiple functions are in the module).

Documentation/test:
Not required.