### PR TITLE
Add path for only lowering a Function during optimizations, and use during GraphOptzTest numerical correctness

### DIFF
--- a/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
+++ b/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
@@ -61,6 +61,10 @@ using QuantizationMode = PrecisionConfiguration::QuantizationMode;
 
 /// Options relevant to optimizations during compilation.
 struct OptimizationOptions {
+  /// Only lower, i.e. skip optimizations and precision transformations. Used
+  /// for testing.
+  bool onlyLower{false};
+
   /// If true, perform compile-time computation of constant operations.
   bool enableConstantFolding{true};
 };

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -3159,6 +3159,11 @@ Error glow::optimizeFunctionBeforeLowering(Function *F,
                                            CompilationContext &cctx) {
   LOG_SCOPE(F->getLogContext(), "glow::optimizeFunctionBeforeLowering")
 
+  // If we only want to lower the Function, do nothing here.
+  if (cctx.optimizationOpts.onlyLower) {
+    return Error::success();
+  }
+
   // Verify the function pre-optimization/lowering.
   assert(F->verify() && "Function must be valid");
 
@@ -3183,6 +3188,21 @@ Error glow::optimizeFunctionBeforeLowering(Function *F,
 Error glow::optimizeFunction(Function *F, const Backend &B,
                              CompilationContext &cctx) {
   LOG_SCOPE(F->getLogContext(), "glow::optimizeFunction")
+
+  // If requested only lower the Function and early return.
+  if (cctx.optimizationOpts.onlyLower) {
+    ::glow::lower(F, cctx, &B);
+    // Cleanup from lowering via DCE.
+    runDCEPass(F, cctx);
+
+    if (!B.verify(*F)) {
+      return MAKE_ERR(
+          ErrorValue::ErrorCode::COMPILE_UNSUPPORTED_NODE_AFTER_OPTIMIZE,
+          "Unsupported node(s) found after only-lowering path for Function " +
+              F->getName().str() + " for backend " + B.getBackendName());
+    }
+    return Error::success();
+  }
 
   RETURN_IF_ERR(optimizeFunctionBeforeLowering(F, cctx));
   // Lower the graph into a sequence of low-level linear algebra operations.


### PR DESCRIPTION
Summary: For the numerical correctness checks for GraphOptzTest, we compile both optimized and unoptimized Function. This meant that the unoptimized Function was actually being optimized still, meaning the numerical test was not really doing much. I've added an optimization option to only lower so we can still run the Function but skip all optimizations (either the Function has already been optimized, or we don't want it to be optimized).

Test Plan: All tests still pass.