### PR TITLE
refactor glow Compilation Log options

### DIFF
--- a/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
+++ b/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
@@ -90,6 +90,9 @@ struct CompilationContext {
   /// Configuration for different precision modes.
   PrecisionConfiguration precisionConfig;
 
+  /// How to annotate the compilation log filename.
+  std::string compilationLogPrefix{"glow"};
+
   CompilationContext(PlaceholderBindings *bindings_ = nullptr,
                      LoweredInfoMap *loweredInfoMap_ = nullptr)
       : bindings(bindings_), loweredInfoMap(loweredInfoMap_) {}

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -437,7 +437,6 @@ Function::~Function() {
     auto cur = it++;
     eraseNode(&*cur);
   }
-  logCtx_->dumpLog(getName());
 }
 
 TypeRef Module::uniqueType(ElemKind elemTy, llvm::ArrayRef<size_t> dims) {

--- a/lib/Graph/Log.cpp
+++ b/lib/Graph/Log.cpp
@@ -28,9 +28,11 @@ namespace glow {
 /// Log version number.
 static constexpr auto logVersionNo_ = "v1.0.0";
 
-static llvm::cl::opt<std::string>
-    dumpCompilationLogOpt("compilation-log", llvm::cl::init(""),
-                          llvm::cl::desc("Dump Compilation Log"));
+bool GlowDumpCompilationLog = false;
+static llvm::cl::opt<bool, true>
+    enableCompilationLogOpt("compilation-log",
+                            llvm::cl::desc("Dump Compilation Log"),
+                            llvm::cl::location(GlowDumpCompilationLog));
 
 static llvm::cl::opt<bool> verboseCompilationLogOpt(
     "verbose-compilation", llvm::cl::init(false),
@@ -221,14 +223,13 @@ void LogContext::popLogScope() {
   currentScope_ = currentScope_->parent;
 }
 
-void LogContext::dumpLog(llvm::StringRef) {
-  if (dumpCompilationLogOpt == "") {
+void LogContext::dumpLog(llvm::StringRef compileLogFilename) {
+  if (!GlowDumpCompilationLog) {
     return;
   }
-  std::string compileLogFilename = dumpCompilationLogOpt;
 
-  llvm::outs() << "Writing compilation log file for Module to: "
-               << compileLogFilename << '\n';
+  llvm::outs() << "Writing compilation log file to: " << compileLogFilename
+               << '\n';
   std::error_code EC;
   llvm::raw_fd_ostream myfile(compileLogFilename, EC);
   myfile << llvm::formatv("{ \"log\":\"Glow Compilation Log\", "
@@ -247,7 +248,7 @@ void LogContext::dumpLog(llvm::StringRef) {
 
 /// Logs the node creation with a list of input nodes.
 void LogContext::logNodeCreation(const Node &newNode, bool logIntoModule) {
-  if (dumpCompilationLogOpt == "") {
+  if (!GlowDumpCompilationLog) {
     return;
   }
 
@@ -261,7 +262,7 @@ void LogContext::logNodeCreation(const Node &newNode, bool logIntoModule) {
 
 /// Logs the node deletion.
 void LogContext::logNodeDeletion(const Node &deletedNode, bool logIntoModule) {
-  if (dumpCompilationLogOpt == "") {
+  if (!GlowDumpCompilationLog) {
     return;
   }
 
@@ -277,7 +278,7 @@ void LogContext::logNodeDeletion(const Node &deletedNode, bool logIntoModule) {
 void LogContext::logNodeInputChange(const Node &user,
                                     const NodeValue &prevOprVal,
                                     const NodeValue &newOprVal) {
-  if (dumpCompilationLogOpt == "") {
+  if (!GlowDumpCompilationLog) {
     return;
   }
 

--- a/lib/Onnxifi/HostManagerOnnxifi.cpp
+++ b/lib/Onnxifi/HostManagerOnnxifi.cpp
@@ -20,6 +20,7 @@
 #include "llvm/Support/FileSystem.h"
 
 namespace glow {
+extern bool GlowDumpCompilationLog;
 namespace onnxifi {
 
 extern bool GlowSaveOnnxifiModel;
@@ -89,6 +90,9 @@ onnxStatus HostManagerBackend::addNetwork(std::unique_ptr<Module> module) {
   if (GlowClipFP16) {
     precConfig.clipFP16 = GlowClipFP16;
     LOG(INFO) << "Clipping to fp16 enabled";
+  }
+  if (GlowDumpCompilationLog) {
+    cctx.compilationLogPrefix = "glow-onnxifi";
   }
 
   auto err =


### PR DESCRIPTION
Summary: Refactor how the glow compilation log is produced, writing a set of files to /tmp based on filename (similar to how trace dumping works in Onnxifi).

Differential Revision: D18239159

