### PR TITLE
[LIBJIT][Do not commit][Debate] Remove heap usage in LIBJIT

### DIFF
--- a/lib/Backends/CPU/libjit/libjit_defs.h
+++ b/lib/Backends/CPU/libjit/libjit_defs.h
@@ -125,13 +125,13 @@ inline int32_t libjit_scale_i32i8(int32_t input, int32_t pre, int32_t post,
   return ((((input >> pre) * scale) + rtn) >> post) + offset;
 }
 
-#ifdef _WIN32
-#define libjit_aligned_malloc(p, a, s)                                         \
-  (((*(p)) = _aligned_malloc((s), (a))), *(p) ? 0 : errno)
-#define libjit_aligned_free(p) _aligned_free(p)
-#else
-#define libjit_aligned_malloc(p, a, s) posix_memalign(p, a, s)
-#define libjit_aligned_free(p) free(p)
-#endif
+//#ifdef _WIN32
+//#define libjit_aligned_malloc(p, a, s)                                         \
+//  (((*(p)) = _aligned_malloc((s), (a))), *(p) ? 0 : errno)
+//#define libjit_aligned_free(p) _aligned_free(p)
+//#else
+//#define libjit_aligned_malloc(p, a, s) posix_memalign(p, a, s)
+//#define libjit_aligned_free(p) free(p)
+//#endif
 
 #endif // GLOW_BACKENDS_CPU_LIBJIT_LIBJIT_DEFS_H

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -1415,9 +1415,11 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     auto *dest = MM->getDest();
     auto *lhs = MM->getLHS();
     auto *rhs = MM->getRHS();
+    auto *scratch = MM->getScratch();
     auto *destPtr = emitValueAddress(builder, dest);
     auto *lhsPtr = emitValueAddress(builder, lhs);
     auto *rhsPtr = emitValueAddress(builder, rhs);
+    auto *scratchPtr = emitValueAddress(builder, scratch);
 
     auto *destDims = emitValueDims(builder, dest);
     auto *lhsDims = emitValueDims(builder, lhs);
@@ -1446,7 +1448,7 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
                   destOffset, lhsOffset, rhsOffset, outPre, outPost, outScale});
     } else {
       createCall(builder, F,
-                 {destPtr, lhsPtr, rhsPtr, destDims, lhsDims, rhsDims});
+                 {destPtr, lhsPtr, rhsPtr, destDims, lhsDims, rhsDims, scratchPtr});
     }
     break;
   }

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -237,7 +237,7 @@ int main(int argc, char **argv) {
       .addOperand("Dest", OperandKind::Out)
       .addOperand("LHS", OperandKind::In)
       .addOperand("RHS", OperandKind::In)
-      .autoIRGen()
+      .addOperand("Scratch", OperandKind::Out)
       .autoVerify(VerifyKind::SameElementType, {"Dest", "LHS", "RHS"});
 
   /// Accumulates all of the layers in the batch along the Axis dimension and


### PR DESCRIPTION
**Summary**

This PR should not be landed but it should initiate a discussion (a more elaborate solution). The problem is this:
- currently in LIBJIT the kernel **libjit_matmul_f()** uses dynamically memory allocation via the **libjit_aligned_malloc()** which for a Linux host maps to the **posix_memalign()** function

Allowing kernels in LIBJIT to dynamically allocate memory has a couple of problems when considering cross-compiling bundles **(AOT),** especially for MCU targets:
- The bundle would have **posix_memalign()** as an undefined symbol which will not be resolved by target toolchains
- Although the application code could define the function **posix_memalign()** with a custom implementation such that the bundle will work, allowing LIBJIT code to use in an uncontrolled manner dynamic memory allocation raises some issues, especially for low-end/embedded devices like MCUs, where the heap is commonly pre-configured (before run-time) to a fixed and relatively limited size. Using heap in an unpredictable manner calls for unwanted situations: debugging and figuring out that heap size was exceeded, reconfigure the linker to increase the heap size (by how much? we can`t set a size too big because we starve the rest of the RAM ... etc).

The great/elegant thing for the Glow bundles is (or should be) that, apart from the stack usage (which should be decent given a serial sequence of function calls), the memory usage is completely transparent. Without even running the bundle I can known right after I compile the bundle:
- the EXACT data memory requirement by inspecting the auto-generated header file
- the program memory requirement (or approximately) by looking at the size of the bundle object: this is commonly not significant but it is great that Glow has such a small program memory footprint given the AOT approach (since it contains only the necessary kernel code and not all the kernel code like the Tensor Flow Lite run-time does for example -> one of the reasons I love Glow)

This PR contains an example of how we can avoid using heap for the mentioned LIBJIT kernel (just an example, code is very dirty) by providing the required scratch size through the kernel interface, scratch size which becomes an operand of the Glow IR Instruction and allocated through "createAllocActivation" (I noticed that the **TopK** node does this similarly).

Also this has been a recurrent issue when specializing some LIBJIT kernels to some optimized ARM libraries: some kernels (mostly the big operators: Convolution, FullyConnected) required scratch so I provided in the ways described here. This means an elegant solution for this would benefit developers in general. 

As a conclusion, heap usage in LIBJIT should be discouraged.
Pros:
- more transparency & predictability for memory usage (essential for memory constrained devices)

Cons:
- slightly harder to implement than a simple **malloc**
- scratch size requirement is defined in a separate place in the code than the kernel implementation


**Side notes**:
- I am not familiar with the matmul implementation but I am not sure the allocated size is correct. Should not be like this:
   libjit_aligned_malloc((void **)&packedB, 64, kc * nc * **sizeof(float)**);
- Are there testcases for MatMul with big sizes such that the code branch with dynamic memory allocation ("packed") is tested?
- I think semantically the correct operand type for scratch would be **OperandKind::OutIn** (which I don`t think is currently defined in Glow IR)
- Maybe we can define a "Scratch" operand by default for all the instructions (through ClassGen) and make the kernel somehow specify the exact size ...

What do you think?
