### PR TITLE
Add BatchedMatMulInst for backends that don't want to lower

### DIFF
--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -2597,6 +2597,11 @@ void BoundInterpreterFunction::fwdMatMulInst(const glow::MatMulInst *I) {
                             I->getLHS()->getElementType(), I);
 }
 
+void BoundInterpreterFunction::fwdBatchMatMulInst(
+    const glow::BatchMatMulInst *I) {
+  DCHECK(!"Found BatchMatMulInst but BatchMatMul is lowered on Interpreter");
+}
+
 //===----------------------------------------------------------------------===//
 //                       Row-wise quantized FC
 //===----------------------------------------------------------------------===//

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -240,6 +240,16 @@ int main(int argc, char **argv) {
       .autoIRGen()
       .autoVerify(VerifyKind::SameElementType, {"Dest", "LHS", "RHS"});
 
+  /// Performs batch matrix multiplication between the LHS and RHS. The operands
+  /// are a stack of two dimensional matrices. Example: (N, A, Z) x (N, Z, B) =>
+  /// (N, A, B).
+  BB.newInstr("BatchMatMul")
+      .addOperand("Dest", OperandKind::Out)
+      .addOperand("LHS", OperandKind::In)
+      .addOperand("RHS", OperandKind::In)
+      .autoIRGen()
+      .autoVerify(VerifyKind::SameElementType, {"Dest", "LHS", "RHS"});
+
   /// Accumulates all of the layers in the batch along the Axis dimension and
   /// produce a tensor that has the same dimensions as the input tensor without
   /// the Axis dimension.


### PR DESCRIPTION
Summary: We generally lower BatchMatMulNode to a series of Reshape + MatMul + Concat, so we don't have an instruction for it. Adding one for a backend that doesn't benefit from that lowering.

Documentation: comments

Test Plan: ninja check (no backend uses this instruction)