### PR TITLE
Fix the issue where we don't propagate onnxifi run errors

### DIFF
--- a/lib/Onnxifi/onnxifiGlow.cpp
+++ b/lib/Onnxifi/onnxifiGlow.cpp
@@ -320,9 +320,7 @@ GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxWaitEvent)(onnxEvent event) {
     return ONNXIFI_STATUS_INVALID_EVENT;
   }
 
-  glowEvent->wait();
-
-  return ONNXIFI_STATUS_SUCCESS;
+  return glowEvent->wait();
 }
 
 /// Wait until an ONNXIFI \p event is signalled or until \p timeoutMs


### PR DESCRIPTION
Summary: Previously we blindly return success when wait for the signal.

Differential Revision: D18392957

