### PR TITLE
use legacy executor for glow [WIP]

### DIFF
--- a/torch_glow/src/PyTorchCommon.cpp
+++ b/torch_glow/src/PyTorchCommon.cpp
@@ -23,12 +23,25 @@
 #include <torch/csrc/jit/operator_options.h>
 #include <torch/csrc/jit/pass_manager.h>
 #include <torch/csrc/jit/passes/subgraph_rewrite.h>
+#include <torch/csrc/jit/graph_executor.h>
 
 namespace glow {
+
 
 bool GlowCompilePyTorchModule = false;
 
 namespace {
+
+static int setGraphExecutorToLegacy() {
+  // use legacy GraphExecutor for Glow
+  torch::jit::getExecutorMode() = false;
+  torch::jit::getProfilingMode() = false;
+  return 0;
+
+}
+
+static const int USE_LEGACY_GE = setGraphExecutorToLegacy();
+
 /// GlowBackendState stores the currently active Glow HostManager that will
 /// be used to run the subgraphs lowered to Glow. It also contains information
 /// about the number and type of backend devices owned by the HostManager.

--- a/torch_glow/src/PyTorchCommon.cpp
+++ b/torch_glow/src/PyTorchCommon.cpp
@@ -20,13 +20,12 @@
 #include "GlowFuser.h"
 #include "PyTorchModelLoader.h"
 
+#include <torch/csrc/jit/graph_executor.h>
 #include <torch/csrc/jit/operator_options.h>
 #include <torch/csrc/jit/pass_manager.h>
 #include <torch/csrc/jit/passes/subgraph_rewrite.h>
-#include <torch/csrc/jit/graph_executor.h>
 
 namespace glow {
-
 
 bool GlowCompilePyTorchModule = false;
 
@@ -37,7 +36,6 @@ static int setGraphExecutorToLegacy() {
   torch::jit::getExecutorMode() = false;
   torch::jit::getProfilingMode() = false;
   return 0;
-
 }
 
 static const int USE_LEGACY_GE = setGraphExecutorToLegacy();


### PR DESCRIPTION
Summary:

Forces Glow to use the legacy GraphExecutor as pytorch jit is enabling to the new infrastructure by default.

Documentation:

https://github.com/pytorch/pytorch/pull/29230

Test Plan:

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
