### PR TITLE
Remove the Shape::fromXYZ methods

### DIFF
--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -71,25 +71,7 @@ struct ShapeNHWC {
     c = shape[3];
   }
 
-  static ShapeNHWC fromXYZ(llvm::ArrayRef<size_t> shape) {
-    assert(shape.size() == 3 && "Invalid 3d shape");
-    return ShapeNHWC(shape[0], shape[1], shape[2], 1);
-  }
-
-  static ShapeNHWC fromXY(llvm::ArrayRef<size_t> shape) {
-    assert(shape.size() == 2 && "Invalid 2d shape");
-    return ShapeNHWC(shape[0], shape[1], 1, 1);
-  }
-
-  static ShapeNHWC fromX(llvm::ArrayRef<size_t> shape) {
-    assert(shape.size() == 1 && "Invalid 1d shape");
-    return ShapeNHWC(shape[0], 1, 1, 1);
-  }
-
-  static ShapeNHWC empty() { return ShapeNHWC(0, 0, 0, 0); }
-
-  explicit ShapeNHWC(size_t samples, size_t height, size_t width,
-                     size_t channels)
+  ShapeNHWC(size_t samples, size_t height, size_t width, size_t channels)
       : n(samples), h(height), w(width), c(channels) {}
 
   bool equals(const ShapeNHWC &other) const {
@@ -113,10 +95,8 @@ struct ShapeNHWDC {
     c = shape[4];
   }
 
-  static ShapeNHWDC empty() { return ShapeNHWDC(0, 0, 0, 0, 0); }
-
-  explicit ShapeNHWDC(size_t samples, size_t height, size_t width, size_t depth,
-                      size_t channels)
+  ShapeNHWDC(size_t samples, size_t height, size_t width, size_t depth,
+             size_t channels)
       : n(samples), h(height), w(width), d(depth), c(channels) {}
 
   bool equals(const ShapeNHWDC &other) const {
@@ -139,20 +119,7 @@ struct ShapeNCHW {
     w = shape[3];
   }
 
-  static ShapeNCHW fromXYZ(llvm::ArrayRef<size_t> shape) {
-    assert(shape.size() == 3 && "Invalid 3d shape");
-    return ShapeNCHW(shape[0], 1, shape[1], shape[2]);
-  }
-
-  static ShapeNCHW fromXY(llvm::ArrayRef<size_t> shape) {
-    assert(shape.size() == 2 && "Invalid 2d shape");
-    return ShapeNCHW(shape[0], 1, shape[1], 1);
-  }
-
-  static ShapeNCHW empty() { return ShapeNCHW(0, 0, 0, 0); }
-
-  explicit ShapeNCHW(size_t samples, size_t channels, size_t height,
-                     size_t width)
+  ShapeNCHW(size_t samples, size_t channels, size_t height, size_t width)
       : n(samples), c(channels), h(height), w(width) {}
 
   bool equals(const ShapeNCHW &other) const {

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -578,6 +578,13 @@ static void topK(Tensor &outW, Tensor &indW, Tensor &inW, size_t k) {
   }
 }
 
+static ShapeNHWC shapeFromDims(llvm::ArrayRef<size_t> arr) {
+  assert(arr.size() <= 4);
+  llvm::SmallVector<size_t, 4> ones(4, 1);
+  std::copy(arr.begin(), arr.end(), ones.begin());
+  return ShapeNHWC(llvm::ArrayRef<size_t>(ones));
+};
+
 Error OpenCLFunction::execute(ExecutionContext *context) {
   auto clBindings = static_cast<runtime::OpenCLDeviceBindings *>(
       context->getDeviceBindings());
@@ -785,30 +792,11 @@ Error OpenCLFunction::execute(ExecutionContext *context) {
 
       // Currently support tensors up to 4 dimensions.
       // TODO: Handle other dimensions.
-      const size_t numDimensions = ET->getDest()->getType()->dims().size();
-      ShapeNHWC odim = ShapeNHWC::empty();
-      ShapeNHWC idim = ShapeNHWC::empty();
-      ShapeNHWC offset = ShapeNHWC::empty();
+      assert(ET->getDest()->getType()->dims().size() <= 4);
 
-      if (numDimensions == 1) {
-        odim = ShapeNHWC::fromX(ET->getDest()->getType()->dims());
-        idim = ShapeNHWC::fromX(ET->getSrc()->getType()->dims());
-        offset = ShapeNHWC::fromXY(ET->getOffsets());
-      } else if (numDimensions == 2) {
-        odim = ShapeNHWC::fromXY(ET->getDest()->getType()->dims());
-        idim = ShapeNHWC::fromXY(ET->getSrc()->getType()->dims());
-        offset = ShapeNHWC::fromXY(ET->getOffsets());
-      } else if (numDimensions == 3) {
-        odim = ShapeNHWC::fromXYZ(ET->getDest()->getType()->dims());
-        idim = ShapeNHWC::fromXYZ(ET->getSrc()->getType()->dims());
-        offset = ShapeNHWC::fromXYZ(ET->getOffsets());
-      } else if (numDimensions == 4) {
-        odim = ShapeNHWC(ET->getDest()->getType()->dims());
-        idim = ShapeNHWC(ET->getSrc()->getType()->dims());
-        offset = ShapeNHWC(ET->getOffsets());
-      } else {
-        llvm_unreachable("Unsupported tensor dimension");
-      }
+      ShapeNHWC odim = shapeFromDims(ET->getDest()->getType()->dims());
+      ShapeNHWC idim = shapeFromDims(ET->getSrc()->getType()->dims());
+      ShapeNHWC offset = shapeFromDims(ET->getOffsets());
 
       setKernelArg(kernel, numArgs + 1, odim);
       setKernelArg(kernel, numArgs + 2, idim);
@@ -825,29 +813,11 @@ Error OpenCLFunction::execute(ExecutionContext *context) {
 
       // Currently support tensors of up to 4 dimensions.
       // TODO: Handle other dimensions.
-      const size_t numDimensions = IT->getDest()->getType()->dims().size();
-      ShapeNHWC odim = ShapeNHWC::empty();
-      ShapeNHWC idim = ShapeNHWC::empty();
-      ShapeNHWC offset = ShapeNHWC::empty();
-      if (numDimensions == 1) {
-        odim = ShapeNHWC::fromX(IT->getDest()->getType()->dims());
-        idim = ShapeNHWC::fromX(IT->getSrc()->getType()->dims());
-        offset = ShapeNHWC::fromX(IT->getOffsets());
-      } else if (numDimensions == 2) {
-        odim = ShapeNHWC::fromXY(IT->getDest()->getType()->dims());
-        idim = ShapeNHWC::fromXY(IT->getSrc()->getType()->dims());
-        offset = ShapeNHWC::fromXY(IT->getOffsets());
-      } else if (numDimensions == 3) {
-        odim = ShapeNHWC::fromXYZ(IT->getDest()->getType()->dims());
-        idim = ShapeNHWC::fromXYZ(IT->getSrc()->getType()->dims());
-        offset = ShapeNHWC::fromXYZ(IT->getOffsets());
-      } else if (numDimensions == 4) {
-        odim = ShapeNHWC(IT->getDest()->getType()->dims());
-        idim = ShapeNHWC(IT->getSrc()->getType()->dims());
-        offset = ShapeNHWC(IT->getOffsets());
-      } else {
-        llvm_unreachable("Unsupported tensor dimension");
-      }
+      assert(IT->getDest()->getType()->dims().size() <= 4);
+
+      ShapeNHWC odim = shapeFromDims(IT->getDest()->getType()->dims());
+      ShapeNHWC idim = shapeFromDims(IT->getSrc()->getType()->dims());
+      ShapeNHWC offset = shapeFromDims(IT->getOffsets());
 
       setKernelArg(kernel, numArgs + 1, odim);
       setKernelArg(kernel, numArgs + 2, idim);
@@ -860,8 +830,9 @@ Error OpenCLFunction::execute(ExecutionContext *context) {
     }
 
     if (auto *BMM = dyn_cast<MatMulInst>(&I)) {
-// Size of the tile to be used for matrix multiplication.
-#define TILE_DIM ((size_t)8)
+      // Size of the tile to be used for matrix multiplication.
+      constexpr size_t TILE_DIM = 8;
+
       // Determine max work groups sizes.
       size_t WIS[3];
       cl_int err = clGetDeviceInfo(deviceId, CL_DEVICE_MAX_WORK_ITEM_SIZES,
@@ -877,9 +848,9 @@ Error OpenCLFunction::execute(ExecutionContext *context) {
       setKernelArg(kernel, 0, deviceBuffer);
       auto numArgs = setKernelArgsForBuffers(kernel, I, 1, runtimeBundle_);
 
-      auto ddim = ShapeNHWC::fromXY(BMM->getDest()->getType()->dims());
-      auto ldim = ShapeNHWC::fromXY(BMM->getLHS()->getType()->dims());
-      auto rdim = ShapeNHWC::fromXY(BMM->getRHS()->getType()->dims());
+      ShapeNHWC ddim = shapeFromDims(BMM->getDest()->getType()->dims());
+      ShapeNHWC ldim = shapeFromDims(BMM->getLHS()->getType()->dims());
+      ShapeNHWC rdim = shapeFromDims(BMM->getRHS()->getType()->dims());
 
       setKernelArg(kernel, numArgs + 1, ddim);
       setKernelArg(kernel, numArgs + 2, ldim);
@@ -907,7 +878,6 @@ Error OpenCLFunction::execute(ExecutionContext *context) {
         enqueueKernel(I.getName(), commands, kernel, deviceId,
                       {ddim.n, ddim.h, ddim.w}, kernelLaunches);
       }
-#undef TILE_DIM
       continue;
     }
 


### PR DESCRIPTION
Summary: We only use these in the OpenCL backend, and a more concise helper can be added there.

Test Plan: OpenCL tests
