### PR TITLE
[Quantization](trivial) Update logic for computing scale of int8/int16 bias scale

### DIFF
--- a/tests/unittests/QuantizationTest.cpp
+++ b/tests/unittests/QuantizationTest.cpp
@@ -2371,8 +2371,7 @@ static void testProfileQuantizationOfFC(bool expectLoweredFC,
     } else {
       EXPECT_EQ(quantRowwiseFC->getBias().getType()->getScale(),
                 FCBQI->Scale());
-      EXPECT_EQ(quantRowwiseFC->getBias().getType()->getOffset(),
-                FCBQI->Offset());
+      EXPECT_EQ(quantRowwiseFC->getBias().getType()->getOffset(), 0);
     }
   } else if (expectLoweredFC) {
     ASSERT_FALSE(quantFC);
@@ -2395,7 +2394,7 @@ static void testProfileQuantizationOfFC(bool expectLoweredFC,
       EXPECT_EQ(quantBA->getSlice().getType()->getOffset(), 0);
     } else {
       EXPECT_EQ(quantBA->getSlice().getType()->getScale(), FCBQI->Scale());
-      EXPECT_EQ(quantBA->getSlice().getType()->getOffset(), FCBQI->Offset());
+      EXPECT_EQ(quantBA->getSlice().getType()->getOffset(), 0);
     }
   } else {
     ASSERT_FALSE(quantRowwiseFC);
@@ -2416,7 +2415,7 @@ static void testProfileQuantizationOfFC(bool expectLoweredFC,
       EXPECT_EQ(quantFC->getBias().getType()->getOffset(), 0);
     } else {
       EXPECT_EQ(quantFC->getBias().getType()->getScale(), FCBQI->Scale());
-      EXPECT_EQ(quantFC->getBias().getType()->getOffset(), FCBQI->Offset());
+      EXPECT_EQ(quantFC->getBias().getType()->getOffset(), 0);
     }
   }
 }


### PR DESCRIPTION
**Summary**
Use the same logic for computing the scale of int8/int16 as for int32: try to force the bias_scale to product input_scale * weights_scale if no saturation occurs. This has run-time benefits since the effective scale applied at run-time (which is bias_scale / (input_scale * weights_scale)) will be 1.0 resulting in biasPre = 0, biasPost = 0, biasScale = 1.

**Documentation**
None

**Test Plan**
None