### PR TITLE
Remove embedding save nodes in RecommendationSystemTest

### DIFF
--- a/tests/unittests/RecommendationSystemTest.cpp
+++ b/tests/unittests/RecommendationSystemTest.cpp
@@ -541,7 +541,6 @@ protected:
               "convert_" + embeddings[i].getNode()->getName().str(),
               embeddings[i], ElemKind::FloatTy);
         }
-        F_->createSave("save_embedding", embeddings[i]);
       } else {
         Constant *data =
             createRandomizedConstant(mod, internalTypeF, {embSizes[i], embDim},


### PR DESCRIPTION
Summary: Removing extra save nodes created for SLWS nodes for debugging.
