### PR TITLE
Add Backend::saveFunctions to store multiple Glow functions into a single bundle

### DIFF
--- a/examples/bundles/CMakeLists.txt
+++ b/examples/bundles/CMakeLists.txt
@@ -1,4 +1,5 @@
 if (GLOW_WITH_BUNDLES)
   add_subdirectory(lenet_mnist)
   add_subdirectory(resnet50)
+  add_subdirectory(bundle_with_multiple_entries)
 endif()

--- a/examples/bundles/bundle_with_multiple_entries/BundleSaver.cpp
+++ b/examples/bundles/bundle_with_multiple_entries/BundleSaver.cpp
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/Backend/Backend.h"
+#include "glow/Graph/Graph.h"
+#include "glow/Graph/Hook.h"
+#include "glow/Graph/Node.h"
+#include "glow/Graph/Nodes.h"
+#include "glow/Graph/Utils.h"
+#include "llvm/Support/CommandLine.h"
+
+using namespace glow;
+
+/// Emit a bundle into the specified output directory.
+llvm::cl::opt<std::string>
+    emitBundle("emit-bundle",
+               llvm::cl::desc("Output directory for the bundle serialization"),
+               llvm::cl::init("."));
+
+int main(int argc, char **argv) {
+  llvm::cl::ParseCommandLineOptions(argc, argv, "Bundle Saver\n");
+
+  // Create a bundle with multiple entry points and save it.
+  Module M;
+  constexpr size_t tensorSize = 64;
+
+  Constant *addConst =
+      M.createConstant(ElemKind::FloatTy, {tensorSize}, "const");
+  addConst->getHandle().clear(10.0f);
+  // Create a simple graph.
+  Function *F1 = M.createFunction("F1");
+  auto *inputPH1 =
+      M.createPlaceholder(ElemKind::FloatTy, {tensorSize}, "input1", false);
+  auto *addConst1 = M.createConstant(ElemKind::FloatTy, {tensorSize}, "const1");
+  addConst1->getHandle().clear(20.0f);
+  Node *addNode11 = F1->createAdd("add", inputPH1, addConst);
+  Node *addNode12 = F1->createAdd("add", addNode11, addConst1);
+  auto *save1 = F1->createSave("output1", addNode12);
+
+  // Create a simple graph.
+  Function *F2 = M.createFunction("F2");
+  auto *inputPH2 =
+      M.createPlaceholder(ElemKind::FloatTy, {tensorSize}, "input2", false);
+  auto *addConst2 = M.createConstant(ElemKind::FloatTy, {tensorSize}, "const2");
+  addConst2->getHandle().clear(30.0f);
+  Node *addNode21 = F2->createAdd("add", inputPH2, addConst);
+  Node *addNode22 = F2->createSub("add", addNode21, addConst2);
+  auto *save2 = F2->createSave("output2", addNode22);
+
+  // Save a bundle with multiple functions.
+  llvm::StringRef outputDir = emitBundle;
+  llvm::StringRef bundleName = "testBundle";
+  std::unique_ptr<Backend> cpuBackend(
+      reinterpret_cast<Backend *>(createBackend("CPU")));
+  std::vector<BundleEntry> bundleEntries;
+  bundleEntries.emplace_back(BundleEntry{"testMainEntry1", F1});
+  bundleEntries.emplace_back(BundleEntry{"testMainEntry2", F2});
+  cpuBackend->saveFunctions(bundleEntries, outputDir, bundleName);
+
+  // Check that each entry point produces correct results.
+  std::unique_ptr<Backend> backend(
+      reinterpret_cast<Backend *>(createBackend("Interpreter")));
+  ExecutionContext ctx1;
+  ctx1.getPlaceholderBindings()->allocate(inputPH1);
+  ctx1.getPlaceholderBindings()->allocate(save1->getPlaceholder());
+  ctx1.getPlaceholderBindings()->get(inputPH1)->getHandle().clear(1.0);
+  EXIT_ON_ERR(EXIT_ON_ERR(backend->compile(F1))->execute(&ctx1));
+  Tensor expected1(ElemKind::FloatTy, {tensorSize});
+  expected1.getHandle().clear(31.0f);
+  DCHECK(ctx1.getPlaceholderBindings()
+             ->get(save1->getPlaceholder())
+             ->isEqual(expected1))
+      << "Wrong output1";
+
+  ExecutionContext ctx2;
+  ctx2.getPlaceholderBindings()->allocate(inputPH2);
+  ctx2.getPlaceholderBindings()->allocate(save2->getPlaceholder());
+  ctx2.getPlaceholderBindings()->get(inputPH2)->getHandle().clear(1.0);
+  EXIT_ON_ERR(EXIT_ON_ERR(backend->compile(F2))->execute(&ctx2));
+  Tensor expected2(ElemKind::FloatTy, {tensorSize});
+  expected2.getHandle().clear(-19.0f);
+  DCHECK(ctx2.getPlaceholderBindings()
+             ->get(save2->getPlaceholder())
+             ->isEqual(expected2))
+      << "Wrong output2";
+  return 0;
+}

--- a/examples/bundles/bundle_with_multiple_entries/CMakeLists.txt
+++ b/examples/bundles/bundle_with_multiple_entries/CMakeLists.txt
@@ -1,0 +1,44 @@
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${GLOW_BINARY_DIR}/bundles)
+
+# Output directories for regular and quantized outputs.
+set(BUNDLE_OUTPUT_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/bundle_with_multiple_entries)
+
+add_custom_target(BundleWithMultipleEntriesDir ALL
+  COMMAND ${CMAKE_COMMAND} -E make_directory ${BUNDLE_OUTPUT_DIRECTORY}
+)
+
+# Final Executables.
+# =================
+# Regular.
+add_executable(bundle_with_multiple_entries $<TARGET_OBJECTS:bundle_with_multiple_entriesMain>)
+set_target_properties(bundle_with_multiple_entries PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${BUNDLE_OUTPUT_DIRECTORY})
+target_link_libraries(bundle_with_multiple_entries ${BUNDLE_OUTPUT_DIRECTORY}/testBundle.o png)
+add_dependencies(bundle_with_multiple_entries bundle_with_multiple_entriesMain bundle_with_multiple_entriesNet)
+
+add_executable(bundle_with_multiple_entriesBundleSaver BundleSaver.cpp)
+set_target_properties(bundle_with_multiple_entriesBundleSaver PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${BUNDLE_OUTPUT_DIRECTORY})
+target_link_libraries(bundle_with_multiple_entriesBundleSaver
+                        PRIVATE
+                          Backends
+                          Graph
+                          Support)
+# Glow Bundles.
+# ============
+# Regular Bundle.
+add_custom_command(
+  OUTPUT
+    ${BUNDLE_OUTPUT_DIRECTORY}/testBundle.o
+  COMMAND
+    ${BUNDLE_OUTPUT_DIRECTORY}/bundle_with_multiple_entriesBundleSaver -emit-bundle ${BUNDLE_OUTPUT_DIRECTORY} -bundle-api=dynamic -g
+  DEPENDS
+    bundle_with_multiple_entriesBundleSaver BundleWithMultipleEntriesDir
+)
+add_custom_target(bundle_with_multiple_entriesNet DEPENDS ${BUNDLE_OUTPUT_DIRECTORY}/testBundle.o)
+
+# Other.
+# =====
+# Driver program with main function for regular bundle.
+add_library(bundle_with_multiple_entriesMain OBJECT main.cpp)
+target_compile_options(bundle_with_multiple_entriesMain PRIVATE -std=c++11 -g)
+target_include_directories(bundle_with_multiple_entriesMain PUBLIC ${BUNDLE_OUTPUT_DIRECTORY})
+add_dependencies(bundle_with_multiple_entriesMain bundle_with_multiple_entriesNet)

--- a/examples/bundles/bundle_with_multiple_entries/main.cpp
+++ b/examples/bundles/bundle_with_multiple_entries/main.cpp
@@ -1,0 +1,177 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <assert.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <string>
+#include <vector>
+
+#include "testBundle.h"
+
+//===----------------------------------------------------------------------===//
+//                 Wrapper code for executing a bundle
+//===----------------------------------------------------------------------===//
+/// Find in the bundle's symbol table a weight variable whose name starts with
+/// \p name.
+const SymbolTableEntry *getWeightVar(const BundleConfig &config,
+                                     const char *name) {
+  for (unsigned i = 0, e = config.numSymbols; i < e; ++i) {
+    if (!strncmp(config.symbolTable[i].name, name, strlen(name))) {
+      return &config.symbolTable[i];
+    }
+  }
+  return nullptr;
+}
+
+/// Find in the bundle's symbol table a mutable weight variable whose name
+/// starts with \p name.
+const SymbolTableEntry &getMutableWeightVar(const BundleConfig &config,
+                                            const char *name) {
+  const SymbolTableEntry *mutableWeightVar = getWeightVar(config, name);
+  if (!mutableWeightVar) {
+    printf("Expected to find variable '%s'\n", name);
+  }
+  assert(mutableWeightVar && "Expected to find a mutable weight variable");
+  assert(mutableWeightVar->kind != 0 &&
+         "Weight variable is expected to be mutable");
+  return *mutableWeightVar;
+}
+
+/// Allocate an aligned block of memory.
+void *alignedAlloc(const BundleConfig &config, size_t size) {
+  void *ptr;
+  // Properly align the memory region.
+  int res = posix_memalign(&ptr, config.alignment, size);
+  assert(res == 0 && "posix_memalign failed");
+  assert((size_t)ptr % config.alignment == 0 && "Wrong alignment");
+  memset(ptr, 0, size);
+  (void)res;
+  return ptr;
+}
+
+/// Initialize the constant weights memory block by loading the weights from the
+/// weights file.
+static uint8_t *initConstantWeights(const char *weightsFileName,
+                                    const BundleConfig &config) {
+  // Load weights.
+  FILE *weightsFile = fopen(weightsFileName, "rb");
+  if (!weightsFile) {
+    fprintf(stderr, "Could not open the weights file: %s\n", weightsFileName);
+    exit(1);
+  }
+  fseek(weightsFile, 0, SEEK_END);
+  size_t fileSize = ftell(weightsFile);
+  fseek(weightsFile, 0, SEEK_SET);
+  uint8_t *baseConstantWeightVarsAddr =
+      static_cast<uint8_t *>(alignedAlloc(config, fileSize));
+  printf("Allocated weights of size: %lu\n", fileSize);
+  printf("Expected weights of size: %" PRIu64 "\n",
+         config.constantWeightVarsMemSize);
+  assert(fileSize == config.constantWeightVarsMemSize &&
+         "Wrong weights file size");
+  int result = fread(baseConstantWeightVarsAddr, fileSize, 1, weightsFile);
+  if (result != 1) {
+    perror("Could not read the weights file");
+  } else {
+    printf("Loaded weights of size: %lu from the file %s\n", fileSize,
+           weightsFileName);
+  }
+  fclose(weightsFile);
+  float *dataPtr = (float *)baseConstantWeightVarsAddr;
+  printf("Constants:");
+  for (size_t idx = 0, e = fileSize / sizeof(float); idx < e; ++idx) {
+    if (idx % 8 == 0) {
+      printf("\n");
+      printf("offset %4ld: ", idx * sizeof(float));
+    }
+    printf(" %f", dataPtr[idx]);
+  }
+  printf("\n");
+  return baseConstantWeightVarsAddr;
+}
+
+static uint8_t *allocateMutableWeightVars(const BundleConfig &config) {
+  auto *weights = static_cast<uint8_t *>(
+      alignedAlloc(config, config.mutableWeightVarsMemSize));
+  printf("Allocated mutable weight variables of size: %" PRIu64 "\n",
+         config.mutableWeightVarsMemSize);
+  return weights;
+}
+
+/// Dump the result of the inference by looking at the results vector and
+/// finding the index of the max element.
+static void dumpInferenceResult(const BundleConfig &config,
+                                uint8_t *mutableWeightVars, const char *name) {
+  const SymbolTableEntry &outputWeight = getMutableWeightVar(config, name);
+  float *outputWeightPtr =
+      reinterpret_cast<float *>(mutableWeightVars + outputWeight.offset);
+  printf("Output weight %s:", name);
+  for (size_t idx = 0, e = outputWeight.size; idx < e; ++idx) {
+    printf(" %f", outputWeightPtr[idx]);
+  }
+  printf("\n");
+}
+
+static uint8_t *initMutableWeightVars(const BundleConfig &config,
+                                      const char *name) {
+  uint8_t *mutableWeightVarsAddr = allocateMutableWeightVars(config);
+  const SymbolTableEntry &inputVar = getMutableWeightVar(config, name);
+
+  float *inputVar1Ptr =
+      reinterpret_cast<float *>(mutableWeightVarsAddr + inputVar.offset);
+  for (size_t idx = 0, e = inputVar.size; idx < e; ++idx) {
+    inputVar1Ptr[idx] = 1.0f;
+  }
+  return mutableWeightVarsAddr;
+}
+
+static uint8_t *initActivations(const BundleConfig &config) {
+  return static_cast<uint8_t *>(
+      alignedAlloc(config, config.activationsMemSize));
+}
+
+/// Invoke \p bundleEntry with the input \p inputName and output \p outputName.
+void testBundleEntry(const char *outputName, const char *inputName,
+                     void (*bundleEntry)(uint8_t *constantWeight,
+                                         uint8_t *mutableWeight,
+                                         uint8_t *activations)) {
+  // Allocate and initialize constant and mutable weights.
+  uint8_t *constantWeightVarsAddr =
+      initConstantWeights("testBundle.weights.bin", testBundle_config);
+  uint8_t *mutableWeightVarsAddr =
+      initMutableWeightVars(testBundle_config, inputName);
+  uint8_t *activationsAddr = initActivations(testBundle_config);
+
+  // Perform the computation.
+  bundleEntry(constantWeightVarsAddr, mutableWeightVarsAddr, activationsAddr);
+
+  // Report the results.
+  dumpInferenceResult(testBundle_config, mutableWeightVarsAddr, outputName);
+
+  // Free all resources.
+  free(activationsAddr);
+  free(constantWeightVarsAddr);
+  free(mutableWeightVarsAddr);
+}
+
+int main(int argc, char **argv) {
+  // Invoke all entry points of the bundle.
+  testBundleEntry("output1", "input1", testMainEntry1);
+  testBundleEntry("output2", "input2", testMainEntry2);
+}

--- a/include/glow/Backend/Backend.h
+++ b/include/glow/Backend/Backend.h
@@ -33,6 +33,14 @@ class IRGenVisitor;
 class FunctionPassPipeline;
 class TensorLayoutCommon;
 
+/// Information about an entry point of a saved bundle.
+struct BundleEntry {
+  /// Name of the bundle entry point for the function to be saved.
+  std::string name;
+  /// Function to be saved.
+  Function *func;
+};
+
 namespace runtime {
 
 class DeviceManager;
@@ -83,6 +91,12 @@ public:
   virtual void save(Function *F, llvm::StringRef outputDir,
                     llvm::StringRef bundleName,
                     llvm::StringRef mainEntryName) const {
+    LOG(FATAL) << "Saving a bundle is not supported by the backend";
+  }
+
+  virtual void saveFunctions(llvm::ArrayRef<BundleEntry> entries,
+                             llvm::StringRef outputDir,
+                             llvm::StringRef bundleName) const {
     LOG(FATAL) << "Saving a bundle is not supported by the backend";
   }
 

--- a/include/glow/LLVMIRCodeGen/LLVMBackend.h
+++ b/include/glow/LLVMIRCodeGen/LLVMBackend.h
@@ -26,7 +26,7 @@
 
 namespace glow {
 
-struct AllocationsInfo;
+class AllocationsInfo;
 class PlaceholderBindings;
 class LLVMIRGen;
 

--- a/include/glow/LLVMIRCodeGen/LLVMBackend.h
+++ b/include/glow/LLVMIRCodeGen/LLVMBackend.h
@@ -93,6 +93,10 @@ public:
   virtual void save(Function *F, llvm::StringRef outputDir,
                     llvm::StringRef bundleName,
                     llvm::StringRef mainEntryName) const override;
+
+  virtual void saveFunctions(llvm::ArrayRef<BundleEntry> entries,
+                             llvm::StringRef outputDir,
+                             llvm::StringRef bundleName) const override;
   /// @}
 
   /// \returns the size of metrics collected for a single TraceEvent.

--- a/include/glow/LLVMIRCodeGen/LLVMIRGen.h
+++ b/include/glow/LLVMIRCodeGen/LLVMIRGen.h
@@ -36,7 +36,7 @@ class Tensor;
 class Constant;
 class Instruction;
 class WeightVar;
-struct AllocationsInfo;
+class AllocationsInfo;
 
 /// Different kinds of memory areas used by the emitted LLVM function.
 /// The order is important. It should match the order of base addresses

--- a/include/glow/LLVMIRCodeGen/LLVMIRGen.h
+++ b/include/glow/LLVMIRCodeGen/LLVMIRGen.h
@@ -97,6 +97,10 @@ protected:
 
   /// The IR to generate code for.
   const IRFunction *F_;
+  /// LLVM IR function corresponding to F_.
+  llvm::Function *llvmF_;
+  /// Set of emitted LLVM functions for IR functions.
+  llvm::SmallVector<llvm::Function *, 4> emittedLLVMFunctions_;
   /// The LLVM context.
   llvm::LLVMContext ctx_;
   /// The LLVM IR module.
@@ -279,6 +283,8 @@ public:
   /// \returns a libjit API function by name and tensor element type.
   virtual llvm::Function *getFunction(const std::string &name,
                                       glow::ElemKind elemTy);
+  /// \returns current LLVM function.
+  virtual llvm::Function *getLLVMFunction();
   /// Optimize the function \p F and the module that owns it. Use the target
   /// information from the \p TM target machine.
   virtual void optimizeLLVMModule(llvm::Module *M, llvm::TargetMachine &TM);
@@ -300,6 +306,8 @@ public:
   virtual void initCodeGen();
   /// Emits the code of the entry function, performs optimizations, etc.
   virtual void performCodeGen();
+  /// Finish the LLVM IR code generation.
+  virtual void finishCodeGen();
   /// \returns the current builder.
   llvm::IRBuilder<> &getBuilder() { return *builder_; }
   /// \returns the target machine description.
@@ -313,6 +321,8 @@ public:
   llvm::Module &getModule() const { return *llmodule_; }
   /// \returns the IR function.
   const IRFunction *getIRFunction() { return F_; }
+  /// Set IRFunction to be processed next.
+  void setIRFunction(const IRFunction *F) { F_ = F; }
   /// Set output directory for bundles, debug info files, etc.
   void setOutputDir(llvm::StringRef outputDir) { outputDir_ = outputDir; }
   /// Get output directory for bundles, debug info files, etc.

--- a/include/glow/LLVMIRCodeGen/LLVMIRGen.h
+++ b/include/glow/LLVMIRCodeGen/LLVMIRGen.h
@@ -211,8 +211,10 @@ protected:
   llvm::DIType *getDebugType(llvm::IRBuilder<> &builder, llvm::Type *ty);
   /// Init the generation of debug information.
   virtual void initDebugInfo();
-  /// Generate debug information.
-  virtual void generateDebugInfo();
+  /// Generate debug information for the current function.
+  virtual void generateFunctionDebugInfo();
+  /// Generate debug information for the whole module.
+  virtual void generateModuleDebugInfo();
   /// Set the debug location for the \p builder, so that it corresponds to the
   /// instruction \p I in the textual representation of the Glow IR.
   void setCurrentDebugLocation(llvm::IRBuilder<> &builder,

--- a/lib/LLVMIRCodeGen/BundleSaver.h
+++ b/lib/LLVMIRCodeGen/BundleSaver.h
@@ -25,31 +25,32 @@ namespace glow {
 class LLVMBackend;
 
 class BundleSaver final {
-  /// The IR to be compiled.
-  const IRFunction *F_;
-  /// Information about allocations.
-  AllocationsInfo allocationsInfo_;
-  /// The LLVM IR code generator.
-  std::unique_ptr<LLVMIRGen> irgen_;
-
-  /// Perform memory allocation for a bundle.
-  void performBundleMemoryAllocation();
-  /// Save weights for the bundle.
-  void saveWeights(llvm::StringRef weightsFileName);
-  /// Save header file for the bundle.
-  void saveHeader(llvm::StringRef headerFileName);
-  /// Produce a bundle.
-  void produceBundle(llvm::StringRef outputDir);
-  /// Emit config for a bundle.
-  void emitBundleConfig();
-  /// Emit the symbol table for a bundle.
-  void emitSymbolTable();
-  /// Emit the entry function for the bundle.
-  void emitBundleEntryFunction();
-
 public:
+  /// Information about a saved IR function.
+  struct SavedIRFunction {
+    /// Entry name for the IR function.
+    std::string entryName;
+    /// Saved IRFunction.
+    const IRFunction *savedF;
+  };
+  /// WeightInfo represents a constant weight and a constant it is produced
+  /// from.
+  using WeightInfo = std::pair<const WeightVar *, const Constant *>;
+  /// Comparator for WeightInfo objects, sorting them by their allocated
+  /// address.
+  class WeightAddrComparator {
+  public:
+    WeightAddrComparator(const BundleSaver &bundleSaver)
+        : bundleSaver_(bundleSaver) {}
+    bool operator()(const WeightInfo &LHS, const WeightInfo &RHS) const;
+
+  private:
+    const BundleSaver &bundleSaver_;
+  };
   /// Ctor.
   explicit BundleSaver(const IRFunction *F, const LLVMBackend &llvmBackend);
+  explicit BundleSaver(const LLVMBackend &llvmBackend,
+                       llvm::StringRef outputDir, llvm::StringRef bundleName);
   /// Save code bundle built for \p target, \p arch, \p cpu and \p
   /// targetFeatures to \p outputDir under name \p bundleName. Make
   /// \p mainEntryName the function name for the entry point of the network and
@@ -59,6 +60,46 @@ public:
             llvm::StringRef outputDir, llvm::StringRef bundleName,
             llvm::StringRef mainEntryName, llvm::CodeModel::Model codeModel,
             llvm::Reloc::Model relocModel);
+  void save(llvm::StringRef mainEntryName, const IRFunction *F);
+  /// Produce a bundle.
+  void produceBundle();
+
+private:
+  /// Perform memory allocation for a bundle.
+  void performBundleMemoryAllocation();
+  /// Save weights for the bundle.
+  void saveWeights(llvm::StringRef weightsFileName);
+  /// Save header file for the bundle.
+  void saveHeader(llvm::StringRef headerFileName);
+  /// Emit config for a bundle.
+  void emitBundleConfig();
+  /// Emit the symbol table for a bundle.
+  void emitSymbolTable();
+  /// Emit the entry function for the bundle.
+  void emitBundleEntryFunction();
+  /// Set current IRFunction.
+  void setIRFunction(llvm::StringRef mainEntryName, const IRFunction *F);
+  /// Returns a set of placeholders associated with IR functions inside this
+  /// bundle.
+  std::set<const Placeholder *> findPlaceholders() const;
+  /// Returns a set of constant weights associated with IR functions inside this
+  /// bundle.
+  std::set<WeightInfo, WeightAddrComparator> findConstantWeights() const;
+  /// \returns the weight that the variable \p v is lowered into in one of the
+  /// IR functions inside this bundle, or null if the variable is unknown.
+  Value *getWeightForNode(const Storage *V) const;
+  /// Information about allocations.
+  AllocationsInfo allocationsInfo_;
+  /// The LLVM IR code generator.
+  std::unique_ptr<LLVMIRGen> irgen_;
+  /// The output directory to be used.
+  std::string outputDir_;
+  /// The name of the bundle to be saved.
+  std::string bundleName_;
+  /// Information about IR functions inside this bundle.
+  std::vector<SavedIRFunction> savedIRFunctions_;
+  /// Indicates if this bundle was saved already.
+  bool isSaved_{false};
 };
 
 } // namespace glow

--- a/lib/LLVMIRCodeGen/LLVMBackend.cpp
+++ b/lib/LLVMIRCodeGen/LLVMBackend.cpp
@@ -115,13 +115,14 @@ LLVMBackend::compileIRWithoutConstants(IRFunction *IR) const {
   irgen->initTargetMachine(getTarget(), getArch(), getCPU(), targetFeatures,
                            getCodeModel(), getRelocModel());
   irgen->initCodeGen();
+  irgen->setIRFunction(IR);
   // Perform the address assignment for activations and WeightVars.
-
   allocateJITMemory(IR, irgen->getAllocationsInfo());
-  // Create the jitmain function to be invoked by JIT.
-  emitJitMain(*irgen);
   // Emit the code for the body of the entry function.
   irgen->performCodeGen();
+  // Create the jitmain function to be invoked by JIT.
+  emitJitMain(*irgen);
+  irgen->finishCodeGen();
   // Hand over the module to JIT for the machine code generation.
   auto JIT = glow::make_unique<llvm::orc::GlowJIT>(irgen->getTargetMachine());
   JIT->addModule(irgen->borrowModule());

--- a/lib/LLVMIRCodeGen/LLVMBackend.cpp
+++ b/lib/LLVMIRCodeGen/LLVMBackend.cpp
@@ -161,7 +161,20 @@ void LLVMBackend::save(Function *F, llvm::StringRef outputDir,
   llvm::SmallVector<std::string, 8> targetFeatures(llvmTargetFeatures.begin(),
                                                    llvmTargetFeatures.end());
   auto IR = generateAndOptimizeIR(F, *this, shouldShareBuffers());
-  BundleSaver(IR.get(), *this)
-      .save(getTarget(), getArch(), getCPU(), targetFeatures, outputDir,
-            bundleName, mainEntryName, getBundleCodeModel(), getRelocModel());
+  BundleSaver bundleSaver(*this, outputDir, bundleName);
+  bundleSaver.save(mainEntryName, IR.get());
+  bundleSaver.produceBundle();
+}
+
+void LLVMBackend::saveFunctions(llvm::ArrayRef<BundleEntry> entries,
+                                llvm::StringRef outputDir,
+                                llvm::StringRef bundleName) const {
+  BundleSaver bundleSaver(*this, outputDir, bundleName);
+  std::vector<std::unique_ptr<glow::IRFunction>> irFunctions;
+  for (auto &entry : entries) {
+    auto IR = generateAndOptimizeIR(entry.func, *this, shouldShareBuffers());
+    bundleSaver.save(entry.name, IR.get());
+    irFunctions.emplace_back(std::move(IR));
+  }
+  bundleSaver.produceBundle();
 }

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -258,6 +258,7 @@ void LLVMIRGen::performCodeGen() {
   builder_->SetInsertPoint(ret);
 
   instrNumbering_.reset(new InstructionNumbering(*F_));
+  generateFunctionDebugInfo();
   loadBaseAddresses(*builder_);
   generateLLVMIRForModule(*builder_);
 }
@@ -283,7 +284,7 @@ void LLVMIRGen::finishCodeGen() {
   optimizeLLVMModule(&getModule(), getTargetMachine());
 
   // Generate debug information.
-  generateDebugInfo();
+  generateModuleDebugInfo();
 
   if (dumpIR) {
     llvm::outs() << "LLVM module after optimizations:\n";

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -180,7 +180,6 @@ static void registerEmptyDiagHandler(llvm::LLVMContext &ctx) {
 }
 
 void LLVMIRGen::initCodeGen() {
-  instrNumbering_.reset(new InstructionNumbering(*F_));
   // Load the jit library as a new module.
   llmodule_ = loadStandardLibrary(&getLLVMContext(), "libjit.bc", libjitBC_);
   CHECK(llmodule_.get()) << "Unable to load the JIT library.";
@@ -194,28 +193,6 @@ void LLVMIRGen::initCodeGen() {
 
   // Assign the target information to the module.
   llmodule_->setDataLayout(getTargetMachine().createDataLayout());
-
-  // Create the entry function into the LLVM module.
-  auto int8PtrTy = llvm::Type::getInt8PtrTy(getLLVMContext());
-  auto sizeTPtrTy =
-      llvm::Type::getIntNPtrTy(getLLVMContext(), getLibjitSizeTWidth());
-  // The entry point has the following API:
-  // void entry(uint8_t *baseConstantWeightVars, uint8_t
-  // *baseInoutWeightVars, uint8_t *baseActivations, size_t *offsets);
-  llvm::Type *voidTy = llvm::Type::getVoidTy(getLLVMContext());
-  llvm::FunctionType *jitFuncTy = llvm::FunctionType::get(
-      voidTy, {int8PtrTy, int8PtrTy, int8PtrTy, sizeTPtrTy}, false);
-  auto *func = llvm::Function::Create(
-      jitFuncTy, llvm::Function::ExternalLinkage, "main", llmodule_.get());
-
-  // Setup the entry basic block and initialize the IR builder.
-  llvm::BasicBlock *entry_bb =
-      llvm::BasicBlock::Create(getLLVMContext(), "entry", func);
-  builder_ = glow::make_unique<llvm::IRBuilder<>>(entry_bb);
-  // Terminate the function with a return instruction.
-  auto *ret = builder_->CreateRetVoid();
-  // Emit all the code before the retrun instruction.
-  builder_->SetInsertPoint(ret);
 
   // Initialize the debug information emission.
   initDebugInfo();
@@ -257,15 +234,39 @@ llvm::Type *LLVMIRGen::getElementType(llvm::IRBuilder<> &builder,
 }
 
 void LLVMIRGen::performCodeGen() {
+  // Create the entry function into the LLVM module.
+  auto int8PtrTy = llvm::Type::getInt8PtrTy(getLLVMContext());
+  auto sizeTPtrTy =
+      llvm::Type::getIntNPtrTy(getLLVMContext(), getLibjitSizeTWidth());
+  // The entry point has the following API:
+  // void entry(uint8_t *baseConstantWeightVars, uint8_t
+  // *baseInoutWeightVars, uint8_t *baseActivations, size_t *offsets);
+  llvm::Type *voidTy = llvm::Type::getVoidTy(getLLVMContext());
+  llvm::FunctionType *jitFuncTy = llvm::FunctionType::get(
+      voidTy, {int8PtrTy, int8PtrTy, int8PtrTy, sizeTPtrTy}, false);
+  llvmF_ = llvm::Function::Create(jitFuncTy, llvm::Function::ExternalLinkage,
+                                  "main", llmodule_.get());
+  emittedLLVMFunctions_.emplace_back(llvmF_);
+
+  // Setup the entry basic block and initialize the IR builder.
+  llvm::BasicBlock *entry_bb =
+      llvm::BasicBlock::Create(getLLVMContext(), "entry", llvmF_);
+  builder_ = glow::make_unique<llvm::IRBuilder<>>(entry_bb);
+  // Terminate the function with a return instruction.
+  auto *ret = builder_->CreateRetVoid();
+  // Emit all the code before the retrun instruction.
+  builder_->SetInsertPoint(ret);
+
+  instrNumbering_.reset(new InstructionNumbering(*F_));
   loadBaseAddresses(*builder_);
-
   generateLLVMIRForModule(*builder_);
+}
 
+void LLVMIRGen::finishCodeGen() {
   if (dumpIR) {
     llvm::outs() << "LLVM module before optimizations:\n";
     llmodule_->print(llvm::outs(), nullptr);
   }
-
   // Perform verification if no debug info is being emitted.
   // Otherwise, the verification is performed later by
   // generateDebugInfo, once the debug info emission is finalized.
@@ -383,14 +384,18 @@ llvm::Value *LLVMIRGen::emitValueAddress(llvm::IRBuilder<> &builder,
 llvm::Value *
 LLVMIRGen::emitConstOffsetsArray(llvm::IRBuilder<> &builder,
                                  const AllocationsInfo &allocationsInfo) {
+  constexpr const char *offsetsArrayName = "offsetsArray";
   auto sizeTType = builder.getIntNTy(getLibjitSizeTWidth());
   std::vector<llvm::Constant *> elems(allocationsInfo.valueNumbers_.size());
+  size_t maxOffset = 0;
   for (auto &I : allocationsInfo.valueNumbers_) {
     auto *V = I.first;
     auto offset = I.second.second;
     elems[offset] = llvm::ConstantInt::get(
         sizeTType, allocationsInfo.allocatedAddress_.lookup(V));
+    maxOffset = std::max(maxOffset, offset);
   }
+  elems.resize(maxOffset + 1);
   auto *arr = llvm::ConstantArray::get(
       llvm::ArrayType::get(sizeTType, elems.size()), elems);
   // Ensure that the same casted global variable is used for the equivalent
@@ -398,14 +403,24 @@ LLVMIRGen::emitConstOffsetsArray(llvm::IRBuilder<> &builder,
   // LLVM does not do it automatically for this code pattern involving global
   // variables. It also reduces the number of variables.
   auto &constArrayVar = constArrayPtrs_[arr];
-  if (constArrayVar && constArrayVar->getType() == sizeTType->getPointerTo())
+  auto oldG =
+      getModule().getGlobalVariable(offsetsArrayName, /* allowInternal */ true);
+  if (constArrayVar && constArrayVar->getType() == sizeTType->getPointerTo()) {
     return constArrayVar;
-
+  }
+  if (oldG) {
+    oldG->setName("offsetsArrayOld");
+  }
   auto *M = builder.GetInsertBlock()->getModule();
-
   auto *G = new llvm::GlobalVariable(*M, arr->getType(), true,
-                                     llvm::GlobalValue::InternalLinkage, arr);
+                                     llvm::GlobalValue::InternalLinkage, arr,
+                                     offsetsArrayName);
   constArrayVar = builder.CreateBitCast(G, sizeTType->getPointerTo());
+  if (oldG) {
+    // Replace the old offsetsArray by the new one and remove the old.
+    oldG->replaceAllUsesWith(G);
+    oldG->eraseFromParent();
+  }
   return constArrayVar;
 }
 
@@ -558,6 +573,8 @@ llvm::Function *LLVMIRGen::getFunction(const std::string &name,
   }
 }
 
+llvm::Function *LLVMIRGen::getLLVMFunction() { return llvmF_; }
+
 llvm::CallInst *LLVMIRGen::createCall(llvm::IRBuilder<> &builder,
                                       llvm::Function *callee,
                                       llvm::ArrayRef<llvm::Value *> args) {
@@ -700,8 +717,11 @@ void LLVMIRGen::emitDataParallelKernelImpl(
   // Add a return.
   kernelBuilder.CreateRetVoid();
 
+  setCurrentDebugLocation(builder, *bundle.begin());
   // Emit a call of the kernel.
   createCall(builder, kernelFunc, buffers);
+  // Emit debug info for the generated data-parallel kernel.
+  generateFunctionDebugInfo(kernelFunc);
 }
 
 /// Emit the function that implements a data-parallel kernel and calls it.

--- a/lib/LLVMIRCodeGen/Pipeline.cpp
+++ b/lib/LLVMIRCodeGen/Pipeline.cpp
@@ -135,7 +135,7 @@ void LLVMIRGen::optimizeLLVMModule(llvm::Module *M, llvm::TargetMachine &TM) {
   // and it is always invoked from either the "jitmain" function or the AOT
   // entry point. To enable better LLVM optimizations "main" should always be
   // inlined.
-  M->getFunction("main")->addFnAttr(llvm::Attribute::AttrKind::AlwaysInline);
+  getLLVMFunction()->addFnAttr(llvm::Attribute::AttrKind::AlwaysInline);
 
   llvm::legacy::FunctionPassManager FPM(M);
   llvm::legacy::PassManager PM;


### PR DESCRIPTION
Summary: Extend LLVMBackend and BundleSaver to support saving multiple Glow functions into a single bundle.

Detailed changes are:
- [LLVMIRCodeGen] Preserve the state in AllocationsInfo to enable allocation of multiple functions using the same AllocationsInfo object

- [LLVMIRCodeGen] Split finishCodeGen from performCodeGen to support compilation of multiple Glow IR functions into a single LLVM module

- [LLVMIRCodeGen] Extend FunctionSpecializer to support LLVM modules with multiple main entry points

- [LLVMIRCodeGen] Fix debug info emission for multiple functions inside the same bundle

- Add an example of an AOT bundle with multiple entry points

Fixes #3228

Test Plan:
ninja test

