### PR TITLE
Global trace context for net_runner

### DIFF
--- a/include/glow/ExecutionContext/TraceEvents.h
+++ b/include/glow/ExecutionContext/TraceEvents.h
@@ -341,6 +341,32 @@ public:
   void end();
 };
 
+/// Optional global trace context
+class GlobalTraceContext {
+public:
+  static void activate() {
+    globalTraceContext = glow::make_unique<TraceContext>(TraceLevel::STANDARD);
+  }
+
+  static void dump() {
+    if ((bool)globalTraceContext) {
+      globalTraceContext->dump("glow-trace.json", "GlobalTraceContext");
+      globalTraceContext.reset();
+    }
+  }
+
+  static bool tryConsume(TraceContext *context) {
+    if (!(bool)globalTraceContext) {
+      return false;
+    }
+    globalTraceContext->merge(context);
+    return true;
+  }
+
+private:
+  static std::unique_ptr<TraceContext> globalTraceContext;
+};
+
 } // namespace glow
 
 #endif // GLOW_BACKENDS_TRACEEVENTS_H

--- a/lib/ExecutionContext/TraceEvents.cpp
+++ b/lib/ExecutionContext/TraceEvents.cpp
@@ -254,4 +254,7 @@ void ScopedTraceBlock::end() {
   }
   end_ = true;
 }
+
+std::unique_ptr<TraceContext> GlobalTraceContext::globalTraceContext;
+
 } // namespace glow

--- a/lib/Onnxifi/HostManagerOnnxifi.cpp
+++ b/lib/Onnxifi/HostManagerOnnxifi.cpp
@@ -170,7 +170,8 @@ onnxStatus HostManagerGraph::run(std::unique_ptr<ExecutionContext> ctx,
         if (auto *traceContext = ctx->getTraceContext()) {
           setTraceEvents(traceEvents, traceContext);
 
-          if (GlowDumpDebugTraces) {
+          if (GlowDumpDebugTraces &&
+              !GlobalTraceContext::tryConsume(traceContext)) {
             llvm::SmallString<64> path;
             auto tempFileRes =
                 llvm::sys::fs::createTemporaryFile("glow-trace", "json", path);


### PR DESCRIPTION
Summary:
Global trace context for net_runner.
The optional trace collector if activated combines all individual traces into one and dumps it's content at exit. Integrated into OnnxifyHostManager only so far. By default it is not activated, I explicitly activated it for net_runner only.

Reviewed By: yinghai

Differential Revision: D18439139

