### PR TITLE
Add missing accumulator type parameter propagation for SLWS

### DIFF
--- a/lib/Optimizer/GraphOptimizer/Lower.cpp
+++ b/lib/Optimizer/GraphOptimizer/Lower.cpp
@@ -1016,7 +1016,7 @@ static void lowerFusedRowwiseQuantizedSparseLengthsSumNode(
   auto *ones = F->createSplat(FRQSLSN.getName().str() + ".ones", ty, 1.0);
   auto *FRQSLWSN = F->createFusedRowwiseQuantizedSparseLengthsWeightedSum(
       FRQSLSN.getName().str(), FRQSLSN.getData(), ones, FRQSLSN.getIndices(),
-      FRQSLSN.getLengths());
+      FRQSLSN.getLengths(), FRQSLSN.getUseFP16Accumulation());
 
   replaceAllUsesOfWith(cctx.loweredInfoMap, FRQSLSN.getResult(), FRQSLWSN);
 }


### PR DESCRIPTION
Summary:
Fixed a missing layer parameter propagation for SLWS accumulation type during lowering.
