### PR TITLE
[PyTorch] update Glow fuser

### DIFF
--- a/torch_glow/src/GlowFuser.h
+++ b/torch_glow/src/GlowFuser.h
@@ -25,9 +25,14 @@ namespace glow {
 /// this function.
 void glowCustomFuse(std::shared_ptr<torch::jit::Graph> graph, at::Symbol kind);
 
-/// Fuse nodes in \p graph that are supported by glow into a subgraph in a glow
-/// fusion group node.
+/// Fuse nodes in \p graph that are supported by glow into a subgraph in Glow
+/// fusion group nodes.
 void glowCustomFuse(std::shared_ptr<torch::jit::Graph> graph);
+
+/// Fuse nodes in \p graph that have a kind in \p acceptableKinds into a
+/// subgraph in Glow fusion group nodes.
+void glowCustomFuseDebug(std::shared_ptr<torch::jit::Graph> graph,
+                         std::vector<std::string> acceptableKinds);
 } // namespace glow
 
 #endif // GLOW_TORCH_GLOW_SRC_GLOW_FUSER_H

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -44,6 +44,10 @@ struct PyTorchLoaderSettings {
   /// A list of symbols for nodes that will be ignored by the Glow fuser and
   /// thus will not be fused to Glow.
   std::unordered_set<torch::jit::Symbol> opBlacklist;
+
+  /// The minimum size of a glow fusion groups in terms of number of PyTorch
+  /// nodes. 0 indicates no minimum size.
+  size_t minFusionGroupSize = 0;
 };
 
 /// Given a PyTorch ScalarType \p ty, \returns a matching Glow ElemKind.

--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -1014,8 +1014,9 @@ PyTorchModelLoader::getGlowNodeValueForValue(const torch::jit::Value *value) {
   }
   auto &mappingValue = it->second;
   if (mappingValue.getMappingType() == ValueMappingType::IValue) {
-    RETURN_ERR(glow::strFormat("Did not find a NodeValue mapping for Value %s",
-                               value->debugNameBase().c_str()));
+    RETURN_ERR(glow::strFormat(
+        "Found a GlowIValue instead of a NodeValue for this Value: %s",
+        value->debugNameBase().c_str()));
   }
 
   return mappingValue.getMappedNodeValue();
@@ -1030,8 +1031,9 @@ PyTorchModelLoader::getGlowIValueForValue(const torch::jit::Value *value) {
   }
   auto &mappingValue = it->second;
   if (mappingValue.getMappingType() != ValueMappingType::IValue) {
-    RETURN_ERR(glow::strFormat("Did not find a IValue mapping for Value %s",
-                               value->debugNameBase().c_str()));
+    RETURN_ERR(glow::strFormat(
+        "Found a NodeValue instead of a GlowIValue for this Value: %s",
+        value->debugNameBase().c_str()));
   }
   return mappingValue.getMappedGlowIValue();
 }
@@ -2971,6 +2973,11 @@ PyTorchModelLoader::PyTorchModelLoader(
   };
 
   error = loadFn();
+
+  if (error) {
+    DLOG(ERROR) << "Encountered error while loading graph:" << std::endl
+                << graph << std::endl;
+  }
 }
 
 /*static*/

--- a/torch_glow/src/binding.cpp
+++ b/torch_glow/src/binding.cpp
@@ -17,6 +17,7 @@
 #include <pybind11/pybind11.h>
 
 #include "FuseKnownPatterns.h"
+#include "GlowFuser.h"
 #include "PyTorchCommon.h"
 #include "Registration.h"
 #include "TorchGlowTraining.h"
@@ -107,6 +108,23 @@ PYBIND11_MODULE(_torch_glow, m) {
   /// Calls the fuseBranchedLinearPattern pass.
   /// NOTE: This is only exposed for testing.
   m.def("fuseBranchedLinearPattern_", glow::detail::fuseBranchedLinearPattern);
+
+  /// Set the minimum fusion group size.
+  m.def("setMinFusionGroupSize",
+        [](size_t k) { getPyTorchLoaderSettings().minFusionGroupSize = k; });
+
+  /// Call the Glow fuser and accept all node kinds but don't actually run the
+  /// PyTorchModelLoader.
+  /// NOTE: This is only exposed for testing.
+  m.def("glowCustomFuseDebug_", [](std::shared_ptr<torch::jit::Graph> graph) {
+    return glowCustomFuse(graph);
+  });
+
+  /// NOTE: This is only exposed for testing.
+  m.def("glowCustomFuseDebug_", [](std::shared_ptr<torch::jit::Graph> graph,
+                                   std::vector<std::string> &acceptableKinds) {
+    return glowCustomFuseDebug(graph, acceptableKinds);
+  });
 
   /// Binding wrapper class for TorchGlowTraining and its settings.
   py::class_<TorchGlowTrainingWrapper>(m, "TorchGlowTrainingWrapper")

--- a/torch_glow/tests/functionality/fuse_necessary_getattrs_only.py
+++ b/torch_glow/tests/functionality/fuse_necessary_getattrs_only.py
@@ -1,0 +1,57 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import torch
+
+from tests.utils import GLOW_NODE_NAME
+import torch_glow
+
+
+class LinearModel(torch.nn.Module):
+    def __init__(self):
+        super(LinearModel, self).__init__()
+        self.linear1 = torch.nn.Linear(5, 3)
+        self.linear2 = torch.nn.Linear(3, 1)
+
+    def forward(self, x):
+        return self.linear2(self.linear1(x))
+
+
+class ConvModel(torch.nn.Module):
+    def __init__(self):
+        super(ConvModel, self).__init__()
+        self.conv1 = torch.nn.Conv2d(3, 3, 1)
+        self.conv2 = torch.nn.Conv2d(3, 3, 1)
+        self.linear = torch.nn.Linear(5, 5)
+
+    def forward(self, x):
+        return self.linear(self.conv2(self.conv1(x)))
+
+
+class Model(torch.nn.Module):
+    def __init__(self):
+        super(Model, self).__init__()
+        self.conv = ConvModel()
+        self.linear = LinearModel()
+
+    def forward(self, x):
+        return self.linear(self.conv(x))
+
+
+def test_fuse_necessary_getattrs_only():
+    m = Model()
+    x = torch.randn(1, 3, 5, 5)
+
+    torch_glow.disableFusionPass()
+
+    jit_m = torch.jit.trace(m, x)
+    jit_m_graph = jit_m.graph_for(x)
+
+    print(jit_m_graph)
+
+    # don't fuse aten::_convolutions
+    torch_glow.glowCustomFuseDebug_(
+        jit_m_graph, ["prim::Constant", "prim::GetAttr", "aten::t", "aten::matmul", "aten::add_"])
+
+    print(jit_m_graph)
+
+    return m(x)

--- a/torch_glow/tests/functionality/min_graph_size_test.py
+++ b/torch_glow/tests/functionality/min_graph_size_test.py
@@ -1,0 +1,50 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import torch
+
+from tests.utils import GLOW_NODE_NAME, SUBGRAPH_ATTR
+import torch_glow
+
+
+def f(a, b, c):
+    return (a * a * a * a) / (b * b * b) / (c * c * c * c * c)
+
+
+def test_min_graph_size():
+    """Test Glow fuser minimum fusion group size mechanism."""
+
+    torch_glow.disableFusionPass()
+
+    # Disable aten::div so that each group of aten::mul nodes will be forced
+    # into separate subgraphs
+    torch_glow.setFusionBlacklist(["aten::div"])
+
+    # Set minimum fusion group size to 3 nodes so that the smallest group which
+    # contains only 2 nodes will not be created
+    torch_glow.setMinFusionGroupSize(3)
+
+    a = torch.randn(5, 5)
+    b = torch.randn(5, 5)
+    c = torch.randn(5, 5)
+
+    jit_f = torch.jit.trace(f, (a, b, c))
+    jit_f_graph = jit_f.graph_for(a, b, c)
+
+    # print("before: ", jit_f_graph)
+
+    torch_glow.glowCustomFuseDebug_(jit_f_graph)
+
+    # print("after: ", jit_f_graph)
+
+    fusion_nodes = 0
+    for node in jit_f_graph.nodes():
+        if node.kind() == GLOW_NODE_NAME:
+            fusion_nodes += 1
+
+    assert fusion_nodes == 2, "Expected smallest fusion group to not be created"
+
+    torch_glow.clearFusionBlacklist()
+    torch_glow.setMinFusionGroupSize(0)
+
+
+test_min_graph_size()

--- a/torch_glow/tests/functionality/only_tensor_outputs_test.py
+++ b/torch_glow/tests/functionality/only_tensor_outputs_test.py
@@ -1,0 +1,42 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import torch
+
+from tests.utils import GLOW_NODE_NAME
+import torch_glow
+
+
+def f(a, b):
+    x = (a+b).size(0)
+    c = a.reshape(x, -1)
+    return a+c
+
+
+def test_only_tensor_outputs():
+    """Test that Glow fuser only produces tensor outputs."""
+
+    torch_glow.disableFusionPass()
+
+    a = torch.randn(5, 5)
+    b = torch.randn(5, 5)
+
+    jit_f = torch.jit.trace(f, (a, b))
+    jit_f_graph = jit_f.graph_for(a, b)
+
+    # By creating a graph with an aten::size (supported) feeding into an
+    # unsupported op (prim::ListConstruct), we see that even if an op is
+    # supported, if it produces a non-tensor output to the fusion group it
+    # would not be fused.
+    torch_glow.glowCustomFuseDebug_(
+        jit_f_graph, ["prim::Constant", "aten::add", "aten::size", "aten::reshape"])
+
+    fusion_nodes = 0
+    aten_sizes = 0
+    for node in jit_f_graph.nodes():
+        if node.kind() == GLOW_NODE_NAME:
+            fusion_nodes += 1
+        if node.kind() == "aten::size":
+            aten_sizes += 1
+
+    assert fusion_nodes == 2, "Expected two fusion nodes to be split up with aten::size between them"
+    assert aten_sizes == 1, "Expected aten::size not to be fused"

--- a/torch_glow/tests/nodes/slice_test.py
+++ b/torch_glow/tests/nodes/slice_test.py
@@ -8,7 +8,7 @@ def test_slice_basic():
     """Test of the PyTorch slice Node on Glow."""
 
     def slice_basic(a):
-        b = a[1:]
+        b = (a+a)[1:]
         return b[0][1:]
 
     x = torch.rand((2, 3))


### PR DESCRIPTION
Summary:
* Add support for minimum fusion group size
* Only fuse nodes with non-tensor outputs if those outputs are only consumed by nodes that have already been fused
* Only fuse getattrs that have uses within the fusion group
* Add a verifier step after fusion to ensure that fusion requirements are met
* Added a debugging mechanism to call fuser on graphs directly from Python

Documentation:
doxygen

Test Plan:
Added unit tests
try fusion on resnet and bert