### PR TITLE
[PyTorch] allow non-tensor inputs to arithmetic ops

### DIFF
--- a/torch_glow/src/PyTorchCommon.cpp
+++ b/torch_glow/src/PyTorchCommon.cpp
@@ -133,7 +133,8 @@ glow::ElemKind scalarTypeToElemKind(c10::ScalarType ty) {
   } else if (ty == at::kBool) {
     return ElemKind::BoolTy;
   } else {
-    LOG(DFATAL) << "Not supported yet.";
+    LOG(DFATAL) << "ScalarType " << static_cast<int>(ty)
+                << " not supported yet.";
     return ElemKind::Int64ITy;
   }
 }

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -248,6 +248,14 @@ private:
   bool hasGlowIValueForValue(const torch::jit::Value *value,
                              bool ignoreNones = false) const;
 
+  /// If a NodeValue is mapped to \p value then return it, otherwise look for a
+  /// float or integer IValue mapped to \p value, create a Glow Constant by
+  /// broadcasting that value to a tensor of size \p dims and return the result
+  /// of that Constant.
+  Expected<glow::NodeValue>
+  loadNodeValueOrBroadcastedConstant(const torch::jit::Value *value,
+                                     llvm::ArrayRef<size_t> dims);
+
   /// Find the Glow NodeValue that maps to a given PyTorch value \p value.
   Expected<glow::NodeValue>
   getGlowNodeValueForValue(const torch::jit::Value *value);
@@ -289,6 +297,16 @@ private:
   /// Load a PyTorch Constant node as a Glow Constant.
   /// \returns error on failure.
   Error loadConstant(const torch::jit::Node *ptNode);
+
+  /// Helper function for loading arithmetic nodes. \p name is of the name of
+  /// the node in the Glow graph, \p lhs and \p rhs are the inputs to the
+  /// arithetic node and template parameter \p GlowNode is the type of the node
+  /// that should be created in the Glow graph. \returns the output of the
+  /// loaded arithmetic node or an Error if any occurred.
+  template <typename GlowNode>
+  Expected<NodeValue> loadArithmeticNode(llvm::StringRef name,
+                                         const torch::jit::Value *lhs,
+                                         const torch::jit::Value *rhs);
 
   /// Load a PyTorch mul node.
   /// \returns error on failure.

--- a/torch_glow/tests/nodes/add_test.py
+++ b/torch_glow/tests/nodes/add_test.py
@@ -68,3 +68,25 @@ def test_add_broadcast_3():
     y = torch.randn(8, 3, 4, 2)
 
     jitVsGlow(test_f, x, y, expected_fused_ops={"aten::add"})
+
+
+def test_add_float():
+    """Test of the PyTorch aten::add Node with a float argument"""
+
+    def test_f(a):
+        return (a*a).add(3.9)
+
+    x = torch.randn(4)
+
+    jitVsGlow(test_f, x, expected_fused_ops={"aten::add"})
+
+
+def test_add_int():
+    """Test of the PyTorch aten::add Node with an int argument"""
+
+    def test_f(a):
+        return (a*a).add(20)
+
+    x = torch.randn(4)
+
+    jitVsGlow(test_f, x, expected_fused_ops={"aten::add"})

--- a/torch_glow/tests/nodes/div_test.py
+++ b/torch_glow/tests/nodes/div_test.py
@@ -55,3 +55,25 @@ def test_div_broadcast_3():
     y = torch.randn(8, 3, 4, 2)
 
     jitVsGlow(test_f, x, y, expected_fused_ops={"aten::div"})
+
+
+def test_div_float():
+    """Test of the PyTorch aten::div Node with a float argument"""
+
+    def test_f(a):
+        return (a*a).div(3.9)
+
+    x = torch.randn(4)
+
+    jitVsGlow(test_f, x, expected_fused_ops={"aten::div"})
+
+
+def test_div_int():
+    """Test of the PyTorch aten::div Node with an int argument"""
+
+    def test_f(a):
+        return (a*a).div(20)
+
+    x = torch.randn(4)
+
+    jitVsGlow(test_f, x, expected_fused_ops={"aten::div"})

--- a/torch_glow/tests/nodes/mul_test.py
+++ b/torch_glow/tests/nodes/mul_test.py
@@ -55,3 +55,25 @@ def test_mul_broadcast_3():
     y = torch.randn(8, 3, 4, 2)
 
     jitVsGlow(test_f, x, y, expected_fused_ops={"aten::mul"})
+
+
+def test_mul_float():
+    """Test of the PyTorch aten::mul Node with a float argument"""
+
+    def test_f(a):
+        return (a+a).mul(3.9)
+
+    x = torch.randn(4)
+
+    jitVsGlow(test_f, x, expected_fused_ops={"aten::mul"})
+
+
+def test_mul_int():
+    """Test of the PyTorch aten::mul Node with an int argument"""
+
+    def test_f(a):
+        return (a+a).mul(20)
+
+    x = torch.randn(4)
+
+    jitVsGlow(test_f, x, expected_fused_ops={"aten::mul"})

--- a/torch_glow/tests/nodes/sub_test.py
+++ b/torch_glow/tests/nodes/sub_test.py
@@ -55,3 +55,25 @@ def test_sub_broadcast_3():
     y = torch.randn(8, 3, 4, 2)
 
     jitVsGlow(test_f, x, y, expected_fused_ops={"aten::sub"})
+
+
+def test_sub_float():
+    """Test of the PyTorch aten::sub Node with a float argument"""
+
+    def test_f(a):
+        return (a*a).sub(3.9)
+
+    x = torch.randn(4)
+
+    jitVsGlow(test_f, x, expected_fused_ops={"aten::sub"})
+
+
+def test_sub_int():
+    """Test of the PyTorch aten::sub Node with an int argument"""
+
+    def test_f(a):
+        return (a*a).sub(20)
+
+    x = torch.randn(4)
+
+    jitVsGlow(test_f, x, expected_fused_ops={"aten::sub"})


### PR DESCRIPTION
Summary:
Allow float and int inputs to aten::add/sub/mul/div

Documentation:
doxygen

Test Plan:
added unit tests