### PR TITLE
[TensorLayout] Add setAlignment helper method to TensorLayoutDescription

### DIFF
--- a/include/glow/Graph/TensorLayout.h
+++ b/include/glow/Graph/TensorLayout.h
@@ -80,6 +80,9 @@ public:
   size_t getAlignment(size_t n) const;
   /// \returns the alignment by parsing dimension string \p s.
   size_t getAlignment(const std::string &s) const;
+  /// sets the alignment of dimension \p n to the value \p align. \returns the
+  /// new layout serialization for the current dimension.
+  llvm::StringRef setAlignment(size_t n, size_t align);
   /// \returns true if both tensor layouts are the same.
   bool isSameLayout(const TensorLayoutDescription &rhs) const;
   /// \returns description of the dimension \p n.

--- a/include/glow/Graph/TensorLayout.h
+++ b/include/glow/Graph/TensorLayout.h
@@ -83,6 +83,12 @@ public:
   /// sets the alignment of dimension \p n to the value \p align. \returns the
   /// new layout serialization for the current dimension.
   llvm::StringRef setAlignment(size_t n, size_t align);
+  /// \returns the value of the attribute \p name of a dimension \p n.
+  std::string getAttribute(size_t n, llvm::StringRef name) const;
+  /// sets the value of attribute \p name to the value \p value. \returns the
+  /// new layout serialization for the current dimension.
+  llvm::StringRef setAttribute(size_t n, llvm::StringRef name,
+                               llvm::StringRef value);
   /// \returns true if both tensor layouts are the same.
   bool isSameLayout(const TensorLayoutDescription &rhs) const;
   /// \returns description of the dimension \p n.
@@ -108,6 +114,13 @@ private:
 
   /// parse helper: get the official extensions information.
   void parseOfficialExtensions(llvm::StringRef &text, unsigned idx);
+
+  /// Modifies \p dimStr to remove an extension starting with the prefix \p
+  /// name.
+  void removeAttribute(const std::string &name, std::string &dimStr);
+
+  /// Rebuilds serializedLayout_ from scratch.
+  void reconstructSerialized();
 };
 
 /// Interface for finding out layout requirements.

--- a/lib/Graph/TensorLayout.cpp
+++ b/lib/Graph/TensorLayout.cpp
@@ -219,33 +219,65 @@ size_t TensorLayoutDescription::getAlignment(const std::string &s) const {
   return ret;
 }
 
-llvm::StringRef TensorLayoutDescription::setAlignment(size_t n, size_t align) {
-  assert(n < numDims_ && "Wrong dimension number");
-  std::string alignPrefix = "a=";
-  auto &dimStr = dims_[n];
-  // If we have a current alignment value - remove it.
-  size_t pos = dimStr.find(alignPrefix);
-  if (pos != std::string::npos) {
-    size_t posEnd = pos;
-    pos = pos - 1;
-    assert(dimStr[pos] == '[' && "Expected start of align extension.");
-    while (dimStr[posEnd] != ']') {
-      ++posEnd;
-      assert(posEnd < dimStr.size() && "Expected to find closing bracket.");
-    }
-    dimStr = dimStr.substr(0, pos) + dimStr.substr(posEnd + 1);
+/// \returns the position of ']' for extension at \p pos.
+static size_t getEndOFExtension(llvm::StringRef dimStr, size_t pos) {
+  size_t posEnd = pos;
+  pos = pos - 1;
+  assert(dimStr[pos] == '[' && "Expected start of align extension.");
+  while (dimStr[posEnd] != ']') {
+    ++posEnd;
+    assert(posEnd < dimStr.size() && "Expected to find closing bracket.");
   }
-  // Add new alignment information to dim:
-  dimStr.append("[");
-  dimStr.append(alignPrefix);
-  dimStr.append(std::to_string(align));
-  dimStr.append("]");
-  // Reconstruct serializedLayout_:
+  return posEnd;
+}
+
+void TensorLayoutDescription::removeAttribute(const std::string &name,
+                                              std::string &dimStr) {
+  size_t pos = dimStr.find(name);
+  if (pos != std::string::npos) {
+    size_t posEnd = getEndOFExtension(dimStr, pos);
+    dimStr = dimStr.substr(0, pos - 1) + dimStr.substr(posEnd + 1);
+  }
+}
+
+void TensorLayoutDescription::reconstructSerialized() {
   serializedLayout_ = "";
   for (size_t i = 0; i < numDims_; ++i) {
     serializedLayout_.append(dims_[i]);
   }
+}
+
+llvm::StringRef TensorLayoutDescription::setAlignment(size_t n, size_t align) {
+  assert(n < numDims_ && "Wrong dimension number");
+  return setAttribute(n, "a=", std::to_string(align));
+}
+
+llvm::StringRef TensorLayoutDescription::setAttribute(size_t n,
+                                                      llvm::StringRef name,
+                                                      llvm::StringRef value) {
+  assert(n < numDims_ && "Wrong dimension number");
+  auto &dimStr = dims_[n];
+  // If we have a current name - remove it.
+  removeAttribute(name, dimStr);
+  // Add new name information to dim:
+  dimStr.append("[");
+  dimStr.append(name);
+  dimStr.append(value);
+  dimStr.append("]");
+  reconstructSerialized();
   return dimStr;
+}
+
+std::string TensorLayoutDescription::getAttribute(size_t n,
+                                                  llvm::StringRef name) const {
+  assert(n < numDims_ && "Wrong dimension number");
+  size_t pos = dims_[n].find(name);
+  if (pos == std::string::npos) {
+    return "";
+  }
+  size_t posEnd = getEndOFExtension(dims_[n], pos);
+  auto nameSZ = name.size();
+  return dims_[n].substr(pos + nameSZ, posEnd - nameSZ - pos);
 }
 
 llvm::ArrayRef<std::string> TensorLayoutDescription::getDims() const {

--- a/lib/Graph/TensorLayout.cpp
+++ b/lib/Graph/TensorLayout.cpp
@@ -219,6 +219,35 @@ size_t TensorLayoutDescription::getAlignment(const std::string &s) const {
   return ret;
 }
 
+llvm::StringRef TensorLayoutDescription::setAlignment(size_t n, size_t align) {
+  assert(n < numDims_ && "Wrong dimension number");
+  std::string alignPrefix = "a=";
+  auto &dimStr = dims_[n];
+  // If we have a current alignment value - remove it.
+  size_t pos = dimStr.find(alignPrefix);
+  if (pos != std::string::npos) {
+    size_t posEnd = pos;
+    pos = pos - 1;
+    assert(dimStr[pos] == '[' && "Expected start of align extension.");
+    while (dimStr[posEnd] != ']') {
+      ++posEnd;
+      assert(posEnd < dimStr.size() && "Expected to find closing bracket.");
+    }
+    dimStr = dimStr.substr(0, pos) + dimStr.substr(posEnd + 1);
+  }
+  // Add new alignment information to dim:
+  dimStr.append("[");
+  dimStr.append(alignPrefix);
+  dimStr.append(std::to_string(align));
+  dimStr.append("]");
+  // Reconstruct serializedLayout_:
+  serializedLayout_ = "";
+  for (size_t i = 0; i < numDims_; ++i) {
+    serializedLayout_.append(dims_[i]);
+  }
+  return dimStr;
+}
+
 llvm::ArrayRef<std::string> TensorLayoutDescription::getDims() const {
   return llvm::makeArrayRef(dims_, numDims_);
 }

--- a/tests/unittests/TensorLayoutTest.cpp
+++ b/tests/unittests/TensorLayoutTest.cpp
@@ -159,4 +159,18 @@ TEST_P(TensorLayoutTest, parseTestStar) {
   EXPECT_EQ(custom.getAlignment(3), 64);
 }
 
+// Check TensorLayoutDescription's setting of alignment.
+TEST_P(TensorLayoutTest, setAlignment) {
+  CHECK_IF_ENABLED();
+
+  TensorLayoutDescription before("N[a=16][answer:42]HW[answer:42]C");
+  EXPECT_FALSE(before.isAnyLayout());
+  auto modN = before.setAlignment(0, 32);
+  EXPECT_EQ(modN, "N[answer:42][a=32]");
+  auto addToW = before.setAlignment(2, 64);
+  EXPECT_EQ(addToW, "W[answer:42][a=64]");
+  auto newSerial = before.getSerializedLayout();
+  EXPECT_EQ(newSerial, "N[answer:42][a=32]HW[answer:42][a=64]C");
+}
+
 INSTANTIATE_BACKEND_TEST(TensorLayoutTest);

--- a/tests/unittests/TensorLayoutTest.cpp
+++ b/tests/unittests/TensorLayoutTest.cpp
@@ -173,4 +173,30 @@ TEST_P(TensorLayoutTest, setAlignment) {
   EXPECT_EQ(newSerial, "N[answer:42][a=32]HW[answer:42][a=64]C");
 }
 
+// Check TensorLayoutDescription's attribute getter.
+TEST_P(TensorLayoutTest, getAttribute) {
+  CHECK_IF_ENABLED();
+
+  TensorLayoutDescription layout("N[a=16][answer:q=42]HWC");
+  EXPECT_FALSE(layout.isAnyLayout());
+  auto notFound = layout.getAttribute(0, "question");
+  EXPECT_EQ(notFound, "");
+  auto alignStr = layout.getAttribute(0, "a=");
+  EXPECT_EQ(alignStr, "16");
+  auto customAttr = layout.getAttribute(0, "answer:q=");
+  EXPECT_EQ(customAttr, "42");
+}
+
+// Check TensorLayoutDescription's attribute setter.
+TEST_P(TensorLayoutTest, setAttribute) {
+  CHECK_IF_ENABLED();
+
+  TensorLayoutDescription layout("N[a=16][answer:q=42]HWC");
+  EXPECT_FALSE(layout.isAnyLayout());
+  auto customAttr = layout.setAttribute(0, "answer:q=", "h2g2");
+  EXPECT_EQ(customAttr, "N[a=16][answer:q=h2g2]");
+  auto customAttrNew = layout.setAttribute(2, "answer:q=", "42");
+  EXPECT_EQ(customAttrNew, "W[answer:q=42]");
+}
+
 INSTANTIATE_BACKEND_TEST(TensorLayoutTest);


### PR DESCRIPTION
The optional `TensorLayoutDescription` helper class only supported a getter method for the official alignment extension. This PR adds a setter method for alignment + test case for it.

Test Plan:
`ninja test`
