### PR TITLE
[ClassGen] add support for fixed IRGen

### DIFF
--- a/tools/ClassGen/InstrBuilder.cpp
+++ b/tools/ClassGen/InstrBuilder.cpp
@@ -338,6 +338,11 @@ void InstrBuilder::addGradientInstr(
 }
 
 void InstrBuilder::emitAutoIRGen(std::ostream &os) const {
+  if (!IRGenBody.empty()) {
+    os << IRGenBody << "\n";
+    return;
+  }
+
   if (autoIRGenNodeName.empty()) {
     return;
   }

--- a/tools/ClassGen/InstrBuilder.h
+++ b/tools/ClassGen/InstrBuilder.h
@@ -83,6 +83,8 @@ class InstrBuilder {
   /// If autoIRGen is used on this Instr, this is the name of the Node that
   /// generates to this Instr. If left empty then autoIRGen is not used.
   std::string autoIRGenNodeName;
+  /// Fixed IRGen for this Instr.
+  std::string IRGenBody;
 
   /// Header file stream.
   std::ofstream &headerStream;
@@ -194,6 +196,14 @@ public:
   /// name (if empty, defaults to same name as Instr).
   InstrBuilder &autoIRGen(const std::string &name = "") {
     autoIRGenNodeName = (name.empty() ? name_ : name);
+    return *this;
+  }
+
+  /// Adds a fixed string to be used for IRGen, similar to those in
+  /// lib/IR/IRGen.cpp. This is mostly useful for backend specific nodes which
+  /// can't use that method.
+  InstrBuilder &addIRGen(const std::string &body) {
+    IRGenBody = std::move(body);
     return *this;
   }
 


### PR DESCRIPTION
Summary: Adds a method to the InstrBuilder which allows specifying a fixed string to be used for IRGen. We usually specify IRGen manually in lib/IR/IRGen.cpp, but this doesn't work for Backend Specific Operators (now: BSOs). So far all BSOs have used autoIRGen, but I'd like to add one that doesn't. Does nothing if not set and don't think it's worth modifying an existing operator as a test.

Documentation: N/A

Test Plan: build only