### PR TITLE
Fixes for windows

### DIFF
--- a/include/glow/Support/Error.h
+++ b/include/glow/Support/Error.h
@@ -294,7 +294,7 @@ public:
     }
     os << "\nError return stack:\n";
     for (const auto &p : stack_) {
-      os << p.first << ":" << p.second << "\n";
+      os << p.first.c_str() << ":" << p.second << "\n";
     }
   }
 

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -30,6 +30,9 @@
 #include "llvm/Support/Format.h"
 #include "llvm/Support/raw_ostream.h"
 
+#ifdef WIN32
+#include <corecrt_math_defines.h>
+#endif
 #include <fstream>
 #include <unordered_set>
 

--- a/lib/LLVMIRCodeGen/BundleSaver.cpp
+++ b/lib/LLVMIRCodeGen/BundleSaver.cpp
@@ -220,16 +220,16 @@ void BundleSaver::setIRFunction(llvm::StringRef mainEntryName,
 bool BundleSaver::WeightAddrComparator::
 operator()(const WeightInfo &LHS, const WeightInfo &RHS) const {
   auto lhsAddr =
-      bundleSaver_.allocationsInfo_.allocatedAddress_.lookup(LHS.first);
+      bundleSaver_->allocationsInfo_.allocatedAddress_.lookup(LHS.first);
   auto rhsAddr =
-      bundleSaver_.allocationsInfo_.allocatedAddress_.lookup(RHS.first);
+      bundleSaver_->allocationsInfo_.allocatedAddress_.lookup(RHS.first);
   return lhsAddr < rhsAddr;
 }
 
 std::set<BundleSaver::WeightInfo, BundleSaver::WeightAddrComparator>
 BundleSaver::findConstantWeights() const {
   std::set<BundleSaver::WeightInfo, BundleSaver::WeightAddrComparator>
-      constants(WeightAddrComparator(*this));
+      constants(WeightAddrComparator(*const_cast<BundleSaver *>(this)));
   for (auto &savedIRFunction : savedIRFunctions_) {
     for (auto *c : savedIRFunction.savedF->findConstants()) {
       auto *w = cast<WeightVar>(savedIRFunction.savedF->getWeightForNode(c));

--- a/lib/LLVMIRCodeGen/BundleSaver.h
+++ b/lib/LLVMIRCodeGen/BundleSaver.h
@@ -40,12 +40,12 @@ public:
   /// address.
   class WeightAddrComparator {
   public:
-    WeightAddrComparator(const BundleSaver &bundleSaver)
-        : bundleSaver_(bundleSaver) {}
+    WeightAddrComparator(BundleSaver &bundleSaver)
+        : bundleSaver_(&bundleSaver) {}
     bool operator()(const WeightInfo &LHS, const WeightInfo &RHS) const;
 
   private:
-    const BundleSaver &bundleSaver_;
+    const BundleSaver *bundleSaver_;
   };
   /// Ctor.
   explicit BundleSaver(const IRFunction *F, const LLVMBackend &llvmBackend);


### PR DESCRIPTION
Summary:
Error.h -- VS wasn't able to resolve overloaded operator.
Graph.cpp -- Added header so that VS can find M_2_SQRTPI.
BundeSaver -- Build issue with VS 2017 deleting auto generated = operator because of by pass reference member. The use of = operator comes from Tree implementation used by set. So then there is a build error from VS saying deleted function is being referenced. Not sure if there is a better way to fix this. Thoughts?

Documentation:

[Optional Fixes #issue]

Test Plan: Unit Tests

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
