### PR TITLE
Ignore strides for Type::isEqual() with allowDifferentShape, and test ConcatSplit elimination for middle and outer dims

### DIFF
--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -468,12 +468,12 @@ struct Type final {
           return false;
         }
       }
-    }
 
-    // Strides must be the same.
-    for (size_t i = 0; i < numSizes_; i++) {
-      if (strides_[i] != other.strides_[i]) {
-        return false;
+      // Strides must be the same.
+      for (size_t i = 0; i < numSizes_; i++) {
+        if (strides_[i] != other.strides_[i]) {
+          return false;
+        }
       }
     }
 

--- a/tests/unittests/TensorsTest.cpp
+++ b/tests/unittests/TensorsTest.cpp
@@ -853,6 +853,57 @@ TEST(Type, compare) {
   EXPECT_FALSE(T1.isEqual(T4));
 }
 
+TEST(Type, isEqual) {
+  {
+    Type T1(ElemKind::FloatTy, {1, 2, 3});
+    Type T2(ElemKind::Int64ITy, {1, 2, 3});
+    EXPECT_FALSE(T1.isEqual(T2));
+    EXPECT_FALSE(T2.isEqual(T1));
+  }
+  {
+    Type T1(ElemKind::FloatTy, {1, 2, 3});
+    Type T2(ElemKind::FloatTy, {1, 2});
+    EXPECT_FALSE(T1.isEqual(T2));
+    EXPECT_FALSE(T2.isEqual(T1));
+  }
+  {
+    Type T1(ElemKind::FloatTy, {1, 2, 3});
+    Type T2(ElemKind::FloatTy, {1, 2, 4});
+    EXPECT_FALSE(T1.isEqual(T2));
+    EXPECT_FALSE(T2.isEqual(T1));
+  }
+  {
+    Type T1(ElemKind::FloatTy, {1, 2, 3});
+    Type T2(ElemKind::FloatTy, {1, 2, 4});
+    EXPECT_TRUE(T1.isEqual(T2, /* allowDifferentShape */ true));
+    EXPECT_TRUE(T2.isEqual(T1, /* allowDifferentShape */ true));
+  }
+  {
+    Type T1(ElemKind::FloatTy, {1, 2, 3});
+    Type T2(ElemKind::FloatTy, {4, 2, 3});
+    EXPECT_TRUE(T1.isEqual(T2, /* allowDifferentShape */ true));
+    EXPECT_TRUE(T2.isEqual(T1, /* allowDifferentShape */ true));
+  }
+  {
+    Type T1(ElemKind::Int8QTy, {1, 2, 3}, 0, 0);
+    Type T2(ElemKind::Int8QTy, {1, 2, 3}, 1, 0);
+    EXPECT_FALSE(T1.isEqual(T2));
+    EXPECT_FALSE(T2.isEqual(T1));
+  }
+  {
+    Type T1(ElemKind::Int8QTy, {1, 2, 3}, 1, 4);
+    Type T2(ElemKind::Int8QTy, {1, 2, 3}, 1, 4);
+    EXPECT_TRUE(T1.isEqual(T2));
+    EXPECT_TRUE(T2.isEqual(T1));
+  }
+  {
+    Type T1(ElemKind::FloatTy, {1, 2, 3});
+    Type T2(ElemKind::FloatTy, {1, 2, 3});
+    EXPECT_TRUE(T1.isEqual(T2));
+    EXPECT_TRUE(T2.isEqual(T1));
+  }
+}
+
 TEST(Tensor, insertSlice) {
   Tensor big(ElemKind::FloatTy, {3, 4});
   Tensor small({1.0f, 2.0f, 3.0f, 4.0f});


### PR DESCRIPTION
Summary: See title. Once ignoring strides, ConcatSplit works correctly for all dims to concat/split on.

Test Plan: Added new TensorsTest and GraphOptzTest
