### PR TITLE
[partitioner] Add logging for single partition

### DIFF
--- a/include/glow/Partitioner/PartitionerUtils.h
+++ b/include/glow/Partitioner/PartitionerUtils.h
@@ -54,6 +54,9 @@ GraphMemInfo updateGraphMemInfoByAddingNode(const NodesSet &currNodes,
 /// Return the memory usage of a given nodes set.
 GraphMemInfo getGraphMemInfo(const NodesSet &nodes);
 
+/// Return the memory usage of \p func function.
+GraphMemInfo getFunctionMemory(Function *func);
+
 /// Parse a node name string (e.g. "Div,Add") \p names, \returns a set of
 /// NodeKinds corresponding to the names in the string.
 std::set<Kinded::Kind> generateNodeKindsSet(llvm::StringRef names);

--- a/lib/Partitioner/Partitioner.cpp
+++ b/lib/Partitioner/Partitioner.cpp
@@ -427,10 +427,10 @@ Expected<DAGListTy> Partitioner::createDAGWithoutPartition(
     GraphMemInfo graphMem;
     graphMem.constMemSize = func->getParent()->getConstantsSize();
 
-    // walk thru all the nodes to compute input and output mem size
+    // Walk thru all the nodes to compute input and output mem size.
     for (auto &node : func->getNodes()) {
-      // if input to a node is a storage node but not constant then
-      // accummulate it as placeholder size
+      // If input to a node is a storage node but not constant then
+      // accummulate it as placeholder size.
       for (size_t i = 0, e = node.getNumInputs(); i < e; i++) {
         if (auto *in = llvm::dyn_cast<Storage>(node.getNthInput(i).getNode())) {
           if (in->getKind() != Kinded::Kind::ConstantKind) {
@@ -439,17 +439,18 @@ Expected<DAGListTy> Partitioner::createDAGWithoutPartition(
         }
       }
 
-      // if a node is SaveNode then accumulate size
+      // If a node is SaveNode then accumulate size for output memory.
       if (auto *SN = llvm::dyn_cast<SaveNode>(&node)) {
         Storage *out = llvm::dyn_cast<Storage>(SN->getPlaceholder());
         graphMem.outMemSize += out->getType()->getSizeInBytes();
       }
     }
-    // output memory got double counted as input as it is storage node
+    // Output memory got double counted as input as it is storage node
+    // so subtract from the input memory size.
     graphMem.inMemSize -= graphMem.outMemSize;
 
     mapping.setGraphMemInfo(func, graphMem);
-    // use the same hard-coded logical device ID as used for the DAG itself
+    // Use the same hard-coded logical device ID as used for the DAG itself.
     mapping.appendLogicalDeviceID(func, logDevice);
   }
 

--- a/lib/Partitioner/PartitionerUtils.cpp
+++ b/lib/Partitioner/PartitionerUtils.cpp
@@ -493,6 +493,31 @@ GraphMemInfo getGraphMemInfo(const NodesSet &nodes) {
   return ret;
 }
 
+GraphMemInfo getFunctionMemory(Function *func) {
+  GraphMemInfo graphMem;
+
+  for (auto cons : func->findConstants()) {
+      graphMem.constMemSize += cons->getType()->getSizeInBytes();
+    }
+
+    // Walk thru all the Placeholders in the function to accumulate input and
+    // output mem size.
+    for (auto &place : func->findPlaceholders()) {
+      graphMem.inMemSize += place->getType()->getSizeInBytes();
+    }
+
+    for (auto &node : func->getNodes()) {
+      // If a node is SaveNode then accumulate size for output memory.
+      if (auto *SN = llvm::dyn_cast<SaveNode>(&node)) {
+        graphMem.outMemSize += SN->getOutput().getType()->getSizeInBytes();
+      }
+    }
+    // Output memory got double counted as inputs during Placeholder list scan
+    // so subtract from the input memory size.
+    graphMem.inMemSize -= graphMem.outMemSize;
+    return graphMem;
+}
+
 std::set<Kinded::Kind> generateNodeKindsSet(llvm::StringRef names) {
   std::set<Kinded::Kind> nodeKindsSet;
   llvm::StringRef::size_type pos = names.find(',');

--- a/tests/unittests/PartitionerTest.cpp
+++ b/tests/unittests/PartitionerTest.cpp
@@ -863,6 +863,94 @@ TEST_F(PartitionerTest, graphMemInfoCalculation2) {
   EXPECT_EQ(res2, GraphMemInfo(96, 32, 544));
 }
 
+/// Check the function getFunctionMemory in PartitionerUtils.cpp to compute
+/// memory consumption of a simple function with same inputs used for multiple
+/// nodes.
+TEST_F(PartitionerTest, funcMemInfoCalculation1) {
+  auto *input1 =
+      mod_.createPlaceholder(ElemKind::FloatTy, {16}, "input1", false);
+  auto *input2 =
+      mod_.createPlaceholder(ElemKind::FloatTy, {16}, "input2", false);
+  auto *input3 =
+      mod_.createPlaceholder(ElemKind::FloatTy, {16}, "input3", false);
+  auto *sub = F_->createSub("sub", input1, input2);
+  auto *mul = F_->createMul("mul", input1, input2);
+  auto *sum = F_->createAdd("add", sub, mul);
+  auto *sub2 = F_->createSub("sub1", sum, input3);
+  auto *save = F_->createSave("ret", sub2);
+  (void)save;
+
+  GraphMemInfo info = getFunctionMemory(F_);
+  // 3x input Tensors of 16 fp32 each and 1x output of 16 fp32 values.
+  GraphMemInfo res(192, 64, 0);
+  EXPECT_EQ(res, info);
+}
+
+/// Check the function getFunctionMemory in PartitionerUtils.cpp to compute
+/// memory consumption of a function with constants.
+TEST_F(PartitionerTest, funcMemInfoCalculation2) {
+  auto *input =
+      mod_.createPlaceholder(ElemKind::FloatTy, {1, 16}, "input", false);
+
+  // Left branch.
+  auto *w2 = mod_.createConstant(ElemKind::FloatTy, {16, 16}, "w2");
+  auto *b2 = mod_.createConstant(ElemKind::FloatTy, {16}, "b2");
+  auto *L = F_->createFullyConnected("left_fc1", input, w2, b2);
+  auto *L1 = F_->createSigmoid("left_sigmoid1", L);
+  auto *w3 = mod_.createConstant(ElemKind::FloatTy, {16, 8}, "w3");
+  auto *b3 = mod_.createConstant(ElemKind::FloatTy, {8}, "b3");
+  auto *L2 = F_->createFullyConnected("left_fc2", L1, w3, b3);
+  auto *L3 = F_->createSigmoid("left_sigmoid2", L2);
+
+  // Right branch.
+  auto *R = F_->createFullyConnected("right_fc1", input, w2, b2);
+  auto *R1 = F_->createSigmoid("right_sigmoid1", R);
+  auto *w5 = mod_.createConstant(ElemKind::FloatTy, {16, 8}, "w5");
+  auto *b5 = mod_.createConstant(ElemKind::FloatTy, {8}, "b5");
+  auto *R2 = F_->createFullyConnected("right_fc2", R1, w5, b5);
+  auto *R3 = F_->createSigmoid("right_sigmoid2", R2);
+
+  // Join branches.
+  auto *mul = F_->createMul("mul", L3, R3);
+  auto *save = F_->createSave("ret", mul);
+  (void)save;
+
+  GraphMemInfo info = getFunctionMemory(F_);
+  // single input tensor (1*16) fp32
+  // single output tensor (1*8) fp32
+  // constants fp32 (16*16 + 16 + 16*8 + 8 + 16*8 + 8)
+  GraphMemInfo res(64, 32, 2176);
+  EXPECT_EQ(res, info);
+}
+
+/// Check the function getFunctionMemory in PartitionerUtils.cpp to compute
+/// memory consumption of a function with same inputs used for multiple
+/// nodes.
+TEST_F(PartitionerTest, funcMemInfoCalculation3) {
+  auto *input1 =
+      mod_.createPlaceholder(ElemKind::FloatTy, {2, 10}, "input1", false);
+  auto *input2 =
+      mod_.createPlaceholder(ElemKind::FloatTy, {10, 16}, "input2", false);
+  auto *input3 =
+      mod_.createPlaceholder(ElemKind::FloatTy, {16, 20}, "input3", false);
+  auto *input4 =
+      mod_.createPlaceholder(ElemKind::FloatTy, {20, 1}, "input4", false);
+  auto *input5 =
+      mod_.createPlaceholder(ElemKind::FloatTy, {1, 50}, "input5", false);
+  auto *mul0 = F_->createMatMul("mul0", input1, input2);
+  auto *mul1 = F_->createMatMul("mul1", mul0, input3);
+  auto *mul2 = F_->createMatMul("mul2", mul1, input4);
+  auto *mul3 = F_->createMatMul("mul3", mul2, input5);
+  auto *save = F_->createSave("ret", mul3);
+  (void)save;
+
+  GraphMemInfo info = getFunctionMemory(F_);
+  // input consists of 5 input tensors (2*10 + 10*16 + 16*20 + 20*1 + 1*50 = 570) fp32
+  // output is tensor of 2*50 = 100 fp32
+  GraphMemInfo res(2280, 400, 0);
+  EXPECT_EQ(res, info);
+}
+
 /// This one test the memoryUsageValidation in Partitioner : the memory usage
 /// of one single node is larger than the given device memory.
 TEST_F(PartitionerTest, memoryUsageValidation1) {


### PR DESCRIPTION
**Summary:**
Partition Info was logged only when more than one partitions were created.
Added code to log key partition info for a single partition case as well.

**Test Plan:**
Ran image_classifier on few different models (resnet50, vgg19, inception_v1)
with enough Interpreter backend memory to use a single partition and then
with less memory and multiple devices to create partitions. Compared the
size of input memory, output memory and constants as well as the logical
device ID.

**Testing:**
```
$ ninja all && ninja test
$ ./bin/image-classifier tests/images/imagenet/zebra_340.png -expected-labels=340 -use-imagenet-normalization -image-mode=0to1 -m=resnet50 -model-input-name=gpu_0/data  --log-partition --interpreter-memory=400000
$ ./bin/image-classifier tests/images/imagenet/zebra_340.png -expected-labels=340 -use-imagenet-normalization -image-mode=0to1 -m=resnet50 -model-input-name=gpu_0/data  --log-partition --num-devices=4 --interpreter-memory=40000
```

