### PR TITLE
Refactor GraphOptzTest harness and other related APIs

### DIFF
--- a/include/glow/Graph/PlaceholderBindings.h
+++ b/include/glow/Graph/PlaceholderBindings.h
@@ -52,9 +52,11 @@ private:
 
 public:
   /// \returns true if \p A and \p B contain the same Placeholders mapped to
-  /// equivalent Tensors.
+  /// equivalent Tensors. \p allowedError is used when comparing each
+  /// Placeholder's backing payload data.
   static bool compare(const PlaceholderBindings *A,
-                      const PlaceholderBindings *B);
+                      const PlaceholderBindings *B,
+                      float allowedError = 0.0001);
 
   /// \returns the tensor that corresponds to Placeholder \p P or Null if the
   /// tensor is not found.

--- a/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
+++ b/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
@@ -66,7 +66,7 @@ using QuantizationMode = PrecisionConfiguration::QuantizationMode;
 struct OptimizationOptions {
   /// Only lower, i.e. skip optimizations and precision transformations. Used
   /// for testing.
-  bool onlyLower{false};
+  llvm::SmallSet<Function *, 1> onlyLowerFuns;
 
   /// If true, perform compile-time computation of constant operations.
   bool enableConstantFolding{true};

--- a/lib/Graph/PlaceholderBindings.cpp
+++ b/lib/Graph/PlaceholderBindings.cpp
@@ -24,7 +24,8 @@
 using namespace glow;
 
 bool PlaceholderBindings::compare(const PlaceholderBindings *A,
-                                  const PlaceholderBindings *B) {
+                                  const PlaceholderBindings *B,
+                                  float allowedError) {
   // Trivial cases.
   if (!A && !B) {
     return true;
@@ -51,8 +52,8 @@ bool PlaceholderBindings::compare(const PlaceholderBindings *A,
         B->get(B->getPlaceholderByName(placeholder->getName()));
 
     if (!tensorA || !tensorB ||
-        !tensorA->isEqual(*tensorB, /* allowedError */ 0.0001,
-                          /* verbose */ false)) {
+        !tensorA->isEqual(*tensorB, allowedError,
+                          /* verbose */ true)) {
       return false;
     }
   }

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -3304,7 +3304,7 @@ Error glow::optimizeFunctionBeforeLowering(Function *F,
   LOG_SCOPE(F->getLogContext(), "glow::optimizeFunctionBeforeLowering")
 
   // If we only want to lower the Function, do nothing here.
-  if (cctx.optimizationOpts.onlyLower) {
+  if (cctx.optimizationOpts.onlyLowerFuns.count(F)) {
     return Error::success();
   }
 
@@ -3334,7 +3334,7 @@ Error glow::optimizeFunction(Function *F, const Backend &B,
   LOG_SCOPE(F->getLogContext(), "glow::optimizeFunction")
 
   // If requested only lower the Function and early return.
-  if (cctx.optimizationOpts.onlyLower) {
+  if (cctx.optimizationOpts.onlyLowerFuns.count(F)) {
     ::glow::lower(F, cctx, &B);
     // Cleanup from lowering via DCE.
     runDCEPass(F, cctx);

--- a/tests/unittests/GraphOptzTest.cpp
+++ b/tests/unittests/GraphOptzTest.cpp
@@ -26,48 +26,6 @@
 
 using namespace glow;
 
-class GraphOptz : public ::testing::Test {
-public:
-  GraphOptz() : mod_(EE_.getModule()) { F_ = mod_.createFunction("main"); }
-
-protected:
-  void checkNumericalEquivalence() {
-    // Check that the function and its optimized complement exist.
-    EXPECT_TRUE(F_);
-    EXPECT_TRUE(optimizedF_);
-
-    // Clone bindings to use for original and optimized functions.
-    PlaceholderBindings originalBindings = bindings_.clone();
-    PlaceholderBindings optimizedBindings = bindings_.clone();
-
-    // Compile and run functions. Only lower Functions; we do not want to
-    // optimize the unoptimized Function, and the optimized Function has, well,
-    // already been optimized.
-    cctx_.optimizationOpts.onlyLower = true;
-    EE_.compile(cctx_);
-    EE_.run(originalBindings, F_->getName());
-    EE_.run(optimizedBindings, optimizedF_->getName());
-
-    // Compare outputs.
-    EXPECT_TRUE(
-        PlaceholderBindings::compare(&originalBindings, &optimizedBindings));
-  }
-
-  /// ExecutionEngine instance for running functions to check numerical
-  /// equivalence.
-  ExecutionEngine EE_;
-  /// A reference to the Module inside EE_.
-  Module &mod_;
-  /// The original Function for the test case.
-  Function *F_{nullptr};
-  /// The optimized Function for the test case.
-  Function *optimizedF_{nullptr};
-  /// The bindings used to check numerical equivalence for the test case.
-  PlaceholderBindings bindings_;
-  /// CompilationContext used for all Functions in \ref mod_.
-  CompilationContext cctx_;
-};
-
 class GraphFold : public GraphOptz {};
 
 /// Optimize the function \p F. \returns the optimized function.


### PR DESCRIPTION
Summary:
- Moved GraphOptzTest harness to BackendTestUtils header for subclassing/use by other tests
- Add `backendName` to GraphOptzTest constructor so it can be subclassed by other backends
- Add in option for `allowedError` to `checkNumericalEquivalence()` and `PlaceholderBindings::compare()`
- Add `alreadyCompiled_` so that we can skip compilation if it has already happened

Differential Revision: D18623320

