### PR TITLE
[LLVMIRCodeGen] Minor improvements to make backends more configurable

### DIFF
--- a/include/glow/LLVMIRCodeGen/LLVMBackend.h
+++ b/include/glow/LLVMIRCodeGen/LLVMBackend.h
@@ -20,6 +20,7 @@
 #include "glow/Backend/CompiledFunction.h"
 #include "glow/Base/Tensor.h"
 #include "glow/LLVMIRCodeGen/GlowJIT.h"
+#include "glow/LLVMIRCodeGen/LLVMIRGen.h"
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/IR/IRBuilder.h"
@@ -43,6 +44,8 @@ class LLVMBackend : public BackendUsingGlowIR {
   llvm::CodeModel::Model bundleCodeModel_;
   /// Relocation model used by this backend.
   llvm::Reloc::Model relocModel_;
+  /// Bundle API to use.
+  BundleApiType bundleAPI_;
 
 public:
   LLVMBackend();
@@ -70,6 +73,10 @@ public:
   void setBundleCodeModel(llvm::CodeModel::Model codeModel) {
     bundleCodeModel_ = codeModel;
   }
+  /// \returns bundle API used by this backend for bundles.
+  BundleApiType getBundleAPI() const { return bundleAPI_; }
+  /// Sets bundle API used by this backend for bundles.
+  void setBundleAPI(BundleApiType api) { bundleAPI_ = api; }
   /// \returns relocation model used by this backend.
   llvm::Reloc::Model getRelocModel() const { return relocModel_; }
   /// Sets relocation model used by this backend.

--- a/include/glow/LLVMIRCodeGen/LLVMIRGen.h
+++ b/include/glow/LLVMIRCodeGen/LLVMIRGen.h
@@ -370,6 +370,12 @@ public:
   /// \returns true if a global symbol \p GV needs to be preserved in the module
   /// and not interalized during optimizations.
   virtual bool preserveSymbol(const llvm::GlobalValue &GV);
+  /// \returns inlining mode to be used for a function \p F.
+  virtual llvm::Attribute::AttrKind
+  getInlinineAttr(const llvm::Function *F) const;
+  /// Update inline attributes of functions in the module \p M using a
+  /// backend-specific logic.
+  virtual void updateInlineAttributes(llvm::Module *M);
   /// \returns true if an instruction \p I can be part of a data parallel
   /// kernel. This gives backends a possibility to provide a custom logic to
   /// decide on a per-instruction basis what can be part of data parallel

--- a/include/glow/LLVMIRCodeGen/LLVMIRGen.h
+++ b/include/glow/LLVMIRCodeGen/LLVMIRGen.h
@@ -76,6 +76,26 @@ struct DebugInfo {
       baseAddressesVariables_;
 };
 
+/// Different kinds of bundle APIs.
+enum BundleApiType {
+  /// Dynamic bundle API with the following features:
+  /// - the weights are exported in a binary file which are assumed
+  ///   to be loaded dynamically at run-time.
+  /// - the memory layout information (bundle configuration) is only
+  ///   available at run-time and therefore allows ONLY dynamic memory
+  ///   allocaton.
+  Dynamic,
+  /// Static bundle API (default) with the following features:
+  /// - the weights are exported in a binary file but and also in a
+  ///   text file (C array format) suitable to include at compile-time.
+  /// - the memory layout information (bundle configuration) is available
+  ///   at compile-time through macros printed in the header file and thus
+  ///   allows also static memory allocation.
+  /// - this API is suitable for low end devices with no file system or OS
+  ///   (bare-metal).
+  Static,
+};
+
 /// This is a class containing a common logic for the generation of the LLVM IR
 /// from an IRFunction. The primary clients of this class are JITs and bundlers.
 class LLVMIRGen {

--- a/lib/LLVMIRCodeGen/BundleSaver.h
+++ b/lib/LLVMIRCodeGen/BundleSaver.h
@@ -98,6 +98,8 @@ private:
   std::string bundleName_;
   /// Information about IR functions inside this bundle.
   std::vector<SavedIRFunction> savedIRFunctions_;
+  /// Bundle API to use.
+  BundleApiType bundleAPI_;
   /// Indicates if this bundle was saved already.
   bool isSaved_{false};
 };

--- a/lib/LLVMIRCodeGen/CommandLine.cpp
+++ b/lib/LLVMIRCodeGen/CommandLine.cpp
@@ -88,3 +88,15 @@ llvm::cl::opt<llvm::FloatABI::ABIType>
                               clEnumValN(llvm::FloatABI::Hard, "hard",
                                          "Hard float ABI (hardfp)")),
              llvm::cl::init(llvm::FloatABI::Default));
+
+static llvm::cl::OptionCategory bundleSaverCat("Bundle Options");
+
+llvm::cl::opt<glow::BundleApiType>
+    bundleAPI("bundle-api", llvm::cl::desc("Specify which bundle API to use."),
+              llvm::cl::Optional,
+              llvm::cl::values(clEnumValN(glow::BundleApiType::Dynamic,
+                                          "dynamic", "Dynamic API"),
+                               clEnumValN(glow::BundleApiType::Static, "static",
+                                          "Static API")),
+              llvm::cl::init(glow::BundleApiType::Static),
+              llvm::cl::cat(bundleSaverCat));

--- a/lib/LLVMIRCodeGen/CommandLine.h
+++ b/lib/LLVMIRCodeGen/CommandLine.h
@@ -17,6 +17,7 @@
 #ifndef GLOW_LLVMIRCODEGEN_COMMANDLINE_H
 #define GLOW_LLVMIRCODEGEN_COMMANDLINE_H
 
+#include "glow/LLVMIRCodeGen/LLVMIRGen.h"
 #include "llvm/Support/CodeGen.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Target/TargetOptions.h"
@@ -62,5 +63,8 @@ extern llvm::cl::list<std::string> llvmCompilerOptions;
 
 /// Option to set float ABI. Used as -float-abi=<abi-type>.
 extern llvm::cl::opt<llvm::FloatABI::ABIType> floatABI;
+
+/// Option to specify which bundle API to use.
+extern llvm::cl::opt<glow::BundleApiType> bundleAPI;
 
 #endif // GLOW_LLVMIRCODEGEN_COMMANDLINE_H

--- a/lib/LLVMIRCodeGen/LLVMBackend.cpp
+++ b/lib/LLVMIRCodeGen/LLVMBackend.cpp
@@ -57,6 +57,7 @@ LLVMBackend::LLVMBackend() {
   codeModel_ = llvmCodeModel;
   bundleCodeModel_ = llvmBundleCodeModel;
   relocModel_ = llvmRelocModel;
+  bundleAPI_ = bundleAPI;
 }
 
 /// Emit the entry point for JIT called "jitmain".


### PR DESCRIPTION
Summary:

-  Allow backends to set/override the bundle API type

- Allow backends to override the logic for setting inline attributes on LLVM-functions
