### PR TITLE
Allow for folding of ElemKind conversion into IO where applicable for better bounds checking/testing

### DIFF
--- a/include/glow/ExecutionEngine/ExecutionEngine.h
+++ b/include/glow/ExecutionEngine/ExecutionEngine.h
@@ -98,7 +98,7 @@ public:
   /// \returns the internal graph. Note: After compilation the contents of the
   /// module will have been altered and raw pointers to elements of the graph
   /// may no longer be valid.
-  Module &getModule() { return *rawModule_; }
+  Module &getModule() const { return *rawModule_; }
 
   /// Clears the ExecutionEngine and all CompiledFunctions.
   void clear();
@@ -138,6 +138,10 @@ public:
   /// \returns a reference to the backend with name \p backendName owned by the
   /// Provisioner inside of \ref hostManager_.
   Backend &getBackend(llvm::StringRef backendName) const;
+
+  /// \returns the single Function contained in this Module.
+  /// \pre Must be a single Function in the Module.
+  Function *getSingleFunctionFromModule() const;
 };
 
 //===----------------------------------------------------------------------===//

--- a/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
+++ b/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
@@ -70,6 +70,13 @@ struct OptimizationOptions {
 
   /// If true, perform compile-time computation of constant operations.
   bool enableConstantFolding{true};
+
+  /// If true, this will merge ConvertTo and Quantize nodes into inputs and
+  /// outputs of the Function. This means modifying the types of Placeholders
+  /// and SaveNodes if they have a corresponding ElemKind conversion (ConvertTo,
+  /// Quantize, Dequantize nodes).. Note that this must be accompanied by
+  /// modifying the Tensors backing Placeholders at runtime.
+  bool foldElemKindConversionIntoIO{false};
 };
 
 /// Context for compilation.

--- a/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
+++ b/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
@@ -43,6 +43,7 @@ FUN_PASS(FoldLeakyRelu)
 FUN_PASS(FoldChannelShuffle)
 FUN_PASS(ConstantFold)
 FUN_PASS(FoldTileAddIntoBatchedAdd)
+FUN_PASS(FoldElemKindConversionIntoIO)
 
 // NOTE: This pass must be last; it's used to count the total number of passes.
 FUN_PASS(EmptyPass)

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -67,6 +67,12 @@ void ExecutionEngine::setBackendName(llvm::StringRef backend) {
 
 llvm::StringRef ExecutionEngine::getBackendName() const { return backendName_; }
 
+Function *ExecutionEngine::getSingleFunctionFromModule() const {
+  auto &fList = getModule().getFunctions();
+  assert(fList.size() == 1 && "More than one Function in Module.");
+  return *fList.begin();
+}
+
 ExecutionEngine::~ExecutionEngine() { clear(); }
 
 void ExecutionEngine::clear() {

--- a/tests/unittests/BackendCorrectnessTest.cpp
+++ b/tests/unittests/BackendCorrectnessTest.cpp
@@ -466,7 +466,7 @@ TEST_P(BackendCorrectnessTest, basicFCNet) {
 TEST_P(BackendCorrectnessTest, basicFCNetQuantized) {
   CHECK_IF_ENABLED();
   compareAgainstInterpreter(GetParam(), createAndInitBasicFCNet,
-                            ElemKind::Int8QTy, ElemKind::Int8QTy, 0.0001f,
+                            ElemKind::Int8QTy, ElemKind::Int8QTy, 0.f,
                             parCloneCountOpt);
 }
 


### PR DESCRIPTION
Summary: This PR introduces a `FoldElemKindConversionIntoIO` pass which looks for single-use Placeholders that have ConvertTo/Quantize/Dequantize right after/before them and folds them into the Placeholder (and SaveNode if an output). It then adds usage of this pass to `compareAgainstInterpreter()` tests. By doing this we allow the backend to more directly test the operator in its desired precision instead of also allowing the results of the test to be impacted by the specific logic used for type conversion (see bottom for before/after Functions).

This is opt-in, and at least initially meant for better bounds testing on tests which use `compareAgainstInterpreter()`. This is a dangerous pass, as it requires converting the associated Tensors for these Placeholders in PlaceholderBindings, and correctly getting handles to these Tensors based on these types. I've made this opt-in based on the optimization options in the compilation context.

Test Plan: All tests still pass. I modified the one test (BackendCorrectnessTest's `basicFCNetQuantized`) which currently does Int8 to Int8 comparison to expect bitwise accuracy.

Related to https://github.com/pytorch/glow/pull/3710

Before:
<img width="399" alt="before" src="https://user-images.githubusercontent.com/1198212/69445162-a8baca00-0d06-11ea-9082-30616feae3f4.png">

After:
<img width="510" alt="after" src="https://user-images.githubusercontent.com/1198212/69445173-ad7f7e00-0d06-11ea-88df-62c3635622ee.png">
