### PR TITLE
Add large model support to glow

### DIFF
--- a/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
+++ b/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
@@ -24,7 +24,8 @@
 namespace glow {
 namespace runtime {
 struct PartitionConfig;
-}
+class DeferredWeightLoader;
+} // namespace runtime
 
 /// Configuration for different precision modes.
 struct PrecisionConfiguration {
@@ -109,6 +110,10 @@ struct CompilationContext {
 
   /// How to annotate the compilation log filename.
   std::string compilationLogPrefix{"glow"};
+
+  /// Pointer to deferredWeightLoader object, this is used for large model
+  /// support.
+  runtime::DeferredWeightLoader *deferredWeightLoader{nullptr};
 
   CompilationContext(PlaceholderBindings *bindings_ = nullptr,
                      LoweredInfoMap *loweredInfoMap_ = nullptr)

--- a/include/glow/Runtime/DeferredWeightLoader.h
+++ b/include/glow/Runtime/DeferredWeightLoader.h
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_RUNTIME_DEFERREDWEIGHTLOADER_H
+#define GLOW_RUNTIME_DEFERREDWEIGHTLOADER_H
+
+#include "glog/logging.h"
+
+#include "glow/Base/Tensor.h"
+#include "glow/Support/Error.h"
+#include "glow/Support/Register.h"
+#include "glow/Support/Support.h"
+
+namespace glow {
+namespace runtime {
+
+/// A base class for deferred weight loaders. This allows for large weights to
+/// be skipped during compilation and loaded after compilation one at a time.
+class DeferredWeightLoader {
+public:
+  /// Loads the next weight, returns an Error indicating success/failure. Frees
+  /// any resources used by the current deferred weight.
+  virtual Error loadNextWeight() = 0;
+
+  /// Accepts a void * \p loaderObject with is passed in from the interface
+  /// library, e.g. deferredBlobReader in onnxifi.
+  virtual Error setSrc(void *loaderObject) = 0;
+
+  /// Gets the name of the currently loaded weight.
+  virtual std::string getName() = 0;
+
+  /// Gets the Tensor for the current weight.
+  virtual Tensor *getTensor() = 0;
+
+  virtual ~DeferredWeightLoader() = default;
+};
+
+class DeferredWeightLoaderRegistry final {
+public:
+  void registerLoader(DeferredWeightLoader *loader);
+  DeferredWeightLoader *getLoader();
+
+private:
+  DeferredWeightLoader *loader_{nullptr};
+};
+
+/// Global singleton.
+DeferredWeightLoaderRegistry *DeferredLoader();
+
+} // namespace runtime
+} // namespace glow
+
+#endif // GLOW_RUNTIME_DEFERREDWEIGHTLOADER_H

--- a/lib/Backends/CPU/tests/CPUDeferredWeightLoaderTest.cpp
+++ b/lib/Backends/CPU/tests/CPUDeferredWeightLoaderTest.cpp
@@ -18,6 +18,5 @@
 using namespace glow;
 
 std::set<std::string> glow::backendTestBlacklist = {
-    "DeviceResidentTensors/0",
-    "TransferStaticPlaceholderTest/0",
+    "staticPlaceholderInference/0",
 };

--- a/lib/Backends/Habana/tests/HabanaDeferredWeightLoaderTest.cpp
+++ b/lib/Backends/Habana/tests/HabanaDeferredWeightLoaderTest.cpp
@@ -18,6 +18,5 @@
 using namespace glow;
 
 std::set<std::string> glow::backendTestBlacklist = {
-    "DeviceResidentTensors/0",
-    "TransferStaticPlaceholderTest/0",
+    "staticPlaceholderInference/0",
 };

--- a/lib/Backends/Habana/tests/HabanaDeviceManagerTest.cpp
+++ b/lib/Backends/Habana/tests/HabanaDeviceManagerTest.cpp
@@ -19,4 +19,5 @@ using namespace glow;
 
 std::set<std::string> glow::backendTestBlacklist = {
     "DeviceResidentTensors/0",
+    "TransferStaticPlaceholderTest/0",
 };

--- a/lib/Backends/Interpreter/tests/InterpreterDeferredWeightLoaderTest.cpp
+++ b/lib/Backends/Interpreter/tests/InterpreterDeferredWeightLoaderTest.cpp
@@ -18,6 +18,5 @@
 using namespace glow;
 
 std::set<std::string> glow::backendTestBlacklist = {
-    "DeviceResidentTensors/0",
-    "TransferStaticPlaceholderTest/0",
+    "staticPlaceholderInference/0",
 };

--- a/lib/Backends/Interpreter/tests/InterpreterDeviceManagerTest.cpp
+++ b/lib/Backends/Interpreter/tests/InterpreterDeviceManagerTest.cpp
@@ -19,4 +19,5 @@ using namespace glow;
 
 std::set<std::string> glow::backendTestBlacklist = {
     "DeviceResidentTensors/0",
+    "TransferStaticPlaceholderTest/0",
 };

--- a/lib/Backends/NNPI/tests/NNPIDeferredWeightLoaderTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIDeferredWeightLoaderTest.cpp
@@ -18,6 +18,5 @@
 using namespace glow;
 
 std::set<std::string> glow::backendTestBlacklist = {
-    "DeviceResidentTensors/0",
-    "TransferStaticPlaceholderTest/0",
+    "staticPlaceholderInference/0",
 };

--- a/lib/Backends/NNPI/tests/NNPIDeviceManagerTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIDeviceManagerTest.cpp
@@ -20,4 +20,5 @@ using namespace glow;
 std::set<std::string> glow::backendTestBlacklist = {
     "MultiFunction/0",
     "DeviceResidentTensors/0",
+    "TransferStaticPlaceholderTest/0",
 };

--- a/lib/Backends/OpenCL/OpenCLDeviceManager.h
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.h
@@ -164,6 +164,10 @@ class OpenCLDeviceManager : public QueueBackedDeviceManager {
   /// The TID of the device (for TraceEvents);
   int deviceTid_{-1};
 
+  /// Map from PH to functionName for static placeholders.
+  std::unordered_map<Placeholder *, std::vector<std::string>>
+      staticPlaceholderToFunctions_;
+
 public:
   OpenCLDeviceManager(const DeviceConfig &config);
 
@@ -218,6 +222,12 @@ protected:
   void translateTraceEvents(ManualEventMap &manualTraceEvents,
                             ExecutionContext *context,
                             runtime::OpenCLDeviceBindings *devBindings);
+
+  /// Copies the contents of Tensor \p T to the device resource allocated to
+  /// Placeholder \p PH. once finished calls \p resultCB with the result of the
+  /// operation.
+  void transferStaticPlaceholderToDevice(
+      Placeholder *PH, Tensor *T, std::function<void(Error)> resultCB) override;
 };
 
 DeviceManager *createOCLDeviceManager(const DeviceConfig &config);

--- a/lib/Backends/OpenCL/OpenCLTensorLayout.cpp
+++ b/lib/Backends/OpenCL/OpenCLTensorLayout.cpp
@@ -82,9 +82,7 @@ getLayoutForTempEnumRep(size_t n, const Node *node) {
     switch (n) {
     case ConvolutionNode::InputIndices::BiasIdx:
       return &CanonicalTensorLayout::getInstance().getLayoutsForDims()[1];
-    default: {
-      return getLayoutFromEnum(CN);
-    }
+    default: { return getLayoutFromEnum(CN); }
     }
   }
   return nullptr;

--- a/lib/Backends/OpenCL/tests/OpenCLDeferredWeightLoaderTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLDeferredWeightLoaderTest.cpp
@@ -17,7 +17,4 @@
 
 using namespace glow;
 
-std::set<std::string> glow::backendTestBlacklist = {
-    "DeviceResidentTensors/0",
-    "TransferStaticPlaceholderTest/0",
-};
+std::set<std::string> glow::backendTestBlacklist = {};

--- a/lib/Graph/TensorLayout.cpp
+++ b/lib/Graph/TensorLayout.cpp
@@ -651,9 +651,7 @@ static bool acceptsAnyInputLayout(const glow::Node *node) {
   case Kinded::Kind::SGDNodeKind: {
     return true;
   }
-  default: {
-    return false;
-  }
+  default: { return false; }
   }
 }
 

--- a/lib/Onnxifi/CMakeLists.txt
+++ b/lib/Onnxifi/CMakeLists.txt
@@ -25,7 +25,8 @@ target_link_libraries(onnxifi-glow-lib
                         HostManager
                         Importer
                         GraphOptimizer
-                        Quantization)
+                        Quantization
+                        Runtime)
 
 target_link_libraries(onnxifi-glow
                       PUBLIC
@@ -37,7 +38,8 @@ target_link_libraries(onnxifi-glow
                         HostManager
                         Importer
                         GraphOptimizer
-                        Quantization)
+                        Quantization
+                        Runtime)
 
 target_compile_definitions(onnxifi-glow
                            PRIVATE

--- a/lib/Onnxifi/HostManagerOnnxifi.h
+++ b/lib/Onnxifi/HostManagerOnnxifi.h
@@ -35,7 +35,8 @@ public:
   void runNetwork(const Graph *graph, std::unique_ptr<ExecutionContext> context,
                   runtime::ResultCBTy callback, uint64_t priority = 0) override;
 
-  onnxStatus addNetwork(std::unique_ptr<Module> module);
+  onnxStatus addNetwork(std::unique_ptr<Module> module,
+                        void *deferredBlobReader);
 
   onnxStatus removeNetwork(const Graph *graph) override;
 

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -3,6 +3,7 @@ add_subdirectory(Executor)
 add_subdirectory(HostManager)
 
 add_library(Runtime
+  DeferredWeightLoader.cpp
   StatsExporter.cpp)
 target_link_libraries(Runtime
   PRIVATE

--- a/lib/Runtime/DeferredWeightLoader.cpp
+++ b/lib/Runtime/DeferredWeightLoader.cpp
@@ -13,11 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "tests/unittests/BackendTestUtils.h"
 
-using namespace glow;
+#include "glow/Runtime/DeferredWeightLoader.h"
 
-std::set<std::string> glow::backendTestBlacklist = {
-    "DeviceResidentTensors/0",
-    "TransferStaticPlaceholderTest/0",
-};
+namespace glow {
+namespace runtime {
+
+DeferredWeightLoader *DeferredWeightLoaderRegistry::getLoader() {
+  return loader_;
+}
+
+void DeferredWeightLoaderRegistry::registerLoader(
+    DeferredWeightLoader *loader) {
+  loader_ = loader;
+}
+
+DeferredWeightLoaderRegistry *DeferredLoader() {
+  static auto *deferredLoader = new DeferredWeightLoaderRegistry();
+  return deferredLoader;
+}
+} // namespace runtime
+} // namespace glow

--- a/lib/Runtime/Provisioner/CMakeLists.txt
+++ b/lib/Runtime/Provisioner/CMakeLists.txt
@@ -5,4 +5,5 @@ target_link_libraries(Provisioner
                       PRIVATE
                         Backend
                         Backends
-                        Graph)
+                        Graph
+                        Runtime)

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -334,6 +334,9 @@ if(GLOW_WITH_OPENCL)
                 ${GLOW_BINARY_DIR}/tests/OCLTest
                     --gtest_output=xml:OCLTest.xml)
   LIST(APPEND UNOPT_TESTS ./tests/OCLTest -optimize-ir=false &&)
+
+
+
 endif()
 
 add_executable(OnnxImporterTest
@@ -387,6 +390,14 @@ foreach(backend ${GLOW_BACKENDS})
                    Partitioner
                    HostManager)
   add_backend_test(TEST TraceEventsTest BACKEND "${backend}" UNOPT)
+  add_backend_test(TEST
+                   DeferredWeightLoaderTest
+                   BACKEND
+                   "${backend}"
+                   UNOPT
+                   PRIVATE
+                   HostManager
+                   Runtime)
   add_backend_test(TEST TypeAToTypeBFunctionConverterTest BACKEND "${backend}")
 endforeach()
 

--- a/tests/unittests/DeferredWeightLoaderTest.cpp
+++ b/tests/unittests/DeferredWeightLoaderTest.cpp
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/Runtime/DeferredWeightLoader.h"
+#include "BackendTestUtils.h"
+#include "glow/ExecutionContext/ExecutionContext.h"
+#include "glow/ExecutionEngine/ExecutionEngine.h"
+
+#include "gtest/gtest.h"
+
+using namespace glow;
+using namespace glow::runtime;
+
+class TestDeferredWeightLoader : public DeferredWeightLoader {
+public:
+  Error loadNextWeight() override {
+    position_++;
+    return Error::success();
+  }
+  Error setSrc(void *loaderObject) override { return Error::success(); }
+  void addWeight(Tensor *weight) { weights_.push_back(weight); }
+  void addName(std::string name) { names_.push_back(name); }
+
+  std::string getName() override {
+    for (auto na : names_) {
+    }
+    if (position_ >= names_.size()) {
+      return "";
+    }
+    return names_[position_];
+  }
+
+  Tensor *getTensor() override {
+    if (position_ >= weights_.size()) {
+      return nullptr;
+    }
+    return weights_[position_];
+  }
+
+private:
+  std::vector<Tensor *> weights_{};
+  std::vector<std::string> names_{};
+  int position_{-1};
+};
+
+class DeferredWeightLoaderTest : public ::testing::TestWithParam<std::string> {
+};
+
+std::unique_ptr<HostManager>
+createHostManager(llvm::StringRef backendName,
+                  HostConfig hostConfig = HostConfig()) {
+  std::vector<std::unique_ptr<DeviceConfig>> configs;
+  auto deviceConfig = glow::make_unique<DeviceConfig>(backendName);
+  configs.push_back(std::move(deviceConfig));
+  std::unique_ptr<HostManager> hostManager =
+      glow::make_unique<HostManager>(std::move(configs), hostConfig);
+  return hostManager;
+}
+
+TEST_P(DeferredWeightLoaderTest, staticPlaceholderInference) {
+  CHECK_IF_ENABLED();
+  auto hostmanager = createHostManager(GetParam());
+  ExecutionEngine EE{GetParam()};
+  auto &module = EE.getModule();
+  auto F = module.createFunction("main");
+  auto *X = module.createPlaceholder(ElemKind::FloatTy, {1}, "X", false);
+
+  auto *Y = module.createPlaceholder(ElemKind::FloatTy, {1}, "Y", false);
+  auto *Z = module.createPlaceholder(ElemKind::FloatTy, {1}, "Z", false);
+  auto *output =
+      module.createPlaceholder(ElemKind::FloatTy, {1}, "output", false);
+  // Set X and Y as static.
+  X->setStatic(true);
+  Y->setStatic(true);
+  auto pow1 = F->createPow("pow", X, Y);
+  auto pow2 = F->createPow("pow2", Z, pow1);
+  F->createSave("save", pow2, output);
+  std::vector<Tensor> staticInputs;
+  auto xTensor = Tensor(X->getType());
+  auto yTensor = Tensor(Y->getType());
+  auto zTensor = Tensor(Z->getType());
+  xTensor.getHandle().clear(2.0);
+  yTensor.getHandle().clear(3.0);
+  zTensor.getHandle().clear(2.0);
+
+  TestDeferredWeightLoader loader;
+  loader.addWeight(&xTensor);
+  loader.addWeight(&yTensor);
+  loader.addName("X");
+  loader.addName("Y");
+  DeferredLoader()->registerLoader(&loader);
+
+  CompilationContext cctx;
+  cctx.deferredWeightLoader = &loader;
+  EE.compile(cctx);
+  PlaceholderBindings pBindings;
+  pBindings.allocate(Z);
+  pBindings.allocate(output);
+  updateInputPlaceholders(pBindings, {Z}, {&zTensor});
+  EE.run(pBindings);
+  auto resHandle = pBindings.get(output)->getHandle();
+  EXPECT_NEAR(resHandle.at({0}), 256.0, 1E-5);
+}
+INSTANTIATE_BACKEND_TEST(DeferredWeightLoaderTest);


### PR DESCRIPTION
Hindsight being 20/20 there may have been a more incremental path here...

Summary:
Added new deferredWeightLoader that can be used to load large weight after compilation
Updated Provisioner to support new use case
Added Support for static placeholders to OpenCL device manager.
Added new test to deviceManagerTest for staticPlaceholder
Added new StaticPlaceholderTest

Documentation:

Test Plan: ninja check to make sure I didn't break anything and added StaticPlaceholderTest to test end2 end flow and a DeviceManager test for DM level test.
