### PR TITLE
[GraphOptz] Add helper to check whether a Node is in a Function

### DIFF
--- a/tests/unittests/GraphOptzTest.cpp
+++ b/tests/unittests/GraphOptzTest.cpp
@@ -74,6 +74,27 @@ protected:
 
 class GraphFold : public GraphOptz {};
 
+/// A helper predicate to check if the provided node has the same address as a
+/// pre-defined address provided in constructor. This is useful if you need to
+/// check that a given node is still in the graph. In general, it is not safe to
+/// use the std::find(begin_it, end_it, value) and compare the nodes by value,
+/// because the node provided as the last parameter of std::find (i.e. the value
+/// reference) may have been removed by some optimizations and cannot be
+/// dereferenced anymore. But comparing the addresses of the nodes should be
+/// fine. Thus, one can use the following form instead:
+/// std::find_if(begin_it, end_it, IsSameNodeAddress(node_address))
+struct IsSameNodeAddress {
+  const Node *nodeAddress_;
+  IsSameNodeAddress(const Node *nodeAddress) : nodeAddress_(nodeAddress) {}
+  bool operator()(const Node &n) const { return &n == nodeAddress_; }
+};
+
+/// \returns true if the Function \p F contains the Node \p N.
+static bool functionContainsNode(const Function *F, const Node *N) {
+  return std::find_if(F->getNodes().begin(), F->getNodes().end(),
+                      IsSameNodeAddress(N)) != F->getNodes().end();
+}
+
 /// Optimize the function \p F. \returns the optimized function.
 static Function *optimizeFunction(Function *F) {
   auto *G = F->clone(F->getName().str() + "_optimized");
@@ -1313,21 +1334,6 @@ TEST_F(GraphOptz, sinkTransposeBelowPad) {
   EXPECT_EQ(F_->getNodes().size(), 3);
 }
 
-/// A helper predicate to check if the provided node has the same address as a
-/// pre-defined address provided in constructor. This is useful if you need to
-/// check that a given node is still in the graph. In general, it is not safe to
-/// use the std::find(begin_it, end_it, value) and compare the nodes by value,
-/// because the node provided as the last parameter of std::find (i.e. the value
-/// reference) may have been removed by some optimizations and cannot be
-/// dereferenced anymore. But comparing the addresses of the nodes should be
-/// fine. Thus, one can use the following form instead:
-/// std::find_if(begin_it, end_it, IsSameNodeAddress(node_address))
-struct IsSameNodeAddress {
-  Node *nodeAddress_;
-  IsSameNodeAddress(Node *nodeAddress) : nodeAddress_(nodeAddress) {}
-  bool operator()(const Node &n) const { return &n == nodeAddress_; }
-};
-
 TEST_F(GraphOptz, mergeConcatNodes) {
   Node *A1 = mod_.createPlaceholder(ElemKind::FloatTy, {1, 5, 10, 15}, "input1",
                                     false);
@@ -1366,21 +1372,17 @@ TEST_F(GraphOptz, mergeConcatNodes) {
 
   // CN1 should be merged into a new CN2 and later into a new CN4 and removed by
   // the optimizations.
-  EXPECT_TRUE(std::find_if(F_->getNodes().begin(), F_->getNodes().end(),
-                           IsSameNodeAddress(CN1)) == F_->getNodes().end());
+  EXPECT_FALSE(functionContainsNode(F_, CN1));
 
   // CN2 should be merged into a new CN4 and removed by the optimizations.
-  EXPECT_TRUE(std::find_if(F_->getNodes().begin(), F_->getNodes().end(),
-                           IsSameNodeAddress(CN2)) == F_->getNodes().end());
+  EXPECT_FALSE(functionContainsNode(F_, CN2));
 
   // CN3 should not be merged into CN4 and should not be removed,
   // because CN4 and CN3 have a different dimension parameter.
-  EXPECT_TRUE(std::find_if(F_->getNodes().begin(), F_->getNodes().end(),
-                           IsSameNodeAddress(CN3)) != F_->getNodes().end());
+  EXPECT_TRUE(functionContainsNode(F_, CN3));
 
   // The CN4 concat node should be replaced by a merged concat node.
-  EXPECT_TRUE(std::find_if(F_->getNodes().begin(), F_->getNodes().end(),
-                           IsSameNodeAddress(CN4)) == F_->getNodes().end());
+  EXPECT_FALSE(functionContainsNode(F_, CN4));
 
   EXPECT_EQ(F_->getNodes().size(), 3);
 }
@@ -1410,12 +1412,10 @@ TEST_F(GraphOptz, CSE) {
   EXPECT_EQ(CN->getInputs().size(), 2);
 
   // CN1 should not be removed.
-  EXPECT_TRUE(std::find_if(F_->getNodes().begin(), F_->getNodes().end(),
-                           IsSameNodeAddress(CN1)) != F_->getNodes().end());
+  EXPECT_TRUE(functionContainsNode(F_, CN1));
 
   // CSE should replace CN2 by CN1 and remove CN2.
-  EXPECT_TRUE(std::find_if(F_->getNodes().begin(), F_->getNodes().end(),
-                           IsSameNodeAddress(CN2)) == F_->getNodes().end());
+  EXPECT_FALSE(functionContainsNode(F_, CN2));
 
   EXPECT_EQ(F_->getNodes().size(), 3);
 }
@@ -1540,10 +1540,8 @@ TEST_F(GraphOptz, ZeroArithmeticParentsMustBeSimplifiedFirst) {
 
   // Expect all muls to be optimized away, with 1 splat and 1 save left.
   EXPECT_EQ(F_->getNodes().size(), 2);
-  EXPECT_TRUE(std::find_if(F_->getNodes().begin(), F_->getNodes().end(),
-                           IsSameNodeAddress(O)) != F_->getNodes().end());
-  EXPECT_TRUE(std::find_if(F_->getNodes().begin(), F_->getNodes().end(),
-                           IsSameNodeAddress(zero)) != F_->getNodes().end());
+  EXPECT_TRUE(functionContainsNode(F_, O));
+  EXPECT_TRUE(functionContainsNode(F_, zero));
   EXPECT_EQ(O->getInput().getNode(), zero);
 }
 
@@ -1567,10 +1565,7 @@ TEST_F(GraphOptz, ArithmeticIdentitiesOne) {
   EXPECT_EQ(optimizedF_->getNodes().size(), 1);
   SaveNode *SN =
       llvm::dyn_cast<SaveNode>(optimizedF_->getNodeByName(save->getName()));
-  ASSERT_TRUE(std::find_if(optimizedF_->getNodes().begin(),
-                           optimizedF_->getNodes().end(),
-                           IsSameNodeAddress(SN)) !=
-              optimizedF_->getNodes().end());
+  ASSERT_TRUE(functionContainsNode(optimizedF_, SN));
   ASSERT_NE(SN, nullptr);
 
   // Save node should just save the input.
@@ -1698,14 +1693,11 @@ TEST_F(GraphOptz, ReshapeAfterSplat) {
   EXPECT_TRUE(SN->getResult().getType()->dims().equals(reshape));
 
   // R1 should still be in the graph.
-  EXPECT_TRUE(std::find_if(F_->getNodes().begin(), F_->getNodes().end(),
-                           IsSameNodeAddress(R1)) != F_->getNodes().end());
+  EXPECT_TRUE(functionContainsNode(F_, R1));
 
   // R3 and Z2 should not be in the graph any more.
-  EXPECT_TRUE(std::find_if(F_->getNodes().begin(), F_->getNodes().end(),
-                           IsSameNodeAddress(R3)) == F_->getNodes().end());
-  EXPECT_TRUE(std::find_if(F_->getNodes().begin(), F_->getNodes().end(),
-                           IsSameNodeAddress(Z2)) == F_->getNodes().end());
+  EXPECT_FALSE(functionContainsNode(F_, R3));
+  EXPECT_FALSE(functionContainsNode(F_, Z2));
 }
 
 /// Test the Reshape(Reshape(x)) -> Reshape(x) transformation.
@@ -1735,10 +1727,8 @@ TEST_F(GraphOptz, ReshapeReshapeOpt) {
 
   // R1 and R2 should not be in the graph any more; they were replaced by a
   // single new reshape.
-  EXPECT_TRUE(std::find_if(F_->getNodes().begin(), F_->getNodes().end(),
-                           IsSameNodeAddress(R1)) == F_->getNodes().end());
-  EXPECT_TRUE(std::find_if(F_->getNodes().begin(), F_->getNodes().end(),
-                           IsSameNodeAddress(R2)) == F_->getNodes().end());
+  EXPECT_FALSE(functionContainsNode(F_, R1));
+  EXPECT_FALSE(functionContainsNode(F_, R2));
 }
 
 TEST_F(GraphOptz, DCEPublicVars) {
@@ -2709,13 +2699,9 @@ TEST_F(GraphOptz, concatReshapes) {
   EXPECT_EQ(F_->getNodes().size(), 15);
 
   // concatNode1 should not exist any more.
-  EXPECT_TRUE(std::find_if(F_->getNodes().begin(), F_->getNodes().end(),
-                           IsSameNodeAddress(concatNode1)) ==
-              F_->getNodes().end());
+  EXPECT_FALSE(functionContainsNode(F_, concatNode1));
   // concatNode2 should still exist.
-  EXPECT_TRUE(std::find_if(F_->getNodes().begin(), F_->getNodes().end(),
-                           IsSameNodeAddress(concatNode2)) !=
-              F_->getNodes().end());
+  EXPECT_TRUE(functionContainsNode(F_, concatNode2));
 
   // The first input of addNode should be a Reshape node now, with the same
   // result shape of concatNode1.
@@ -2915,8 +2901,7 @@ TEST_F(GraphOptz, eliminateSingleConcat) {
 
   // Just the SaveNode should be left.
   EXPECT_EQ(F_->getNodes().size(), 1);
-  ASSERT_TRUE(std::find_if(F_->getNodes().begin(), F_->getNodes().end(),
-                           IsSameNodeAddress(SN)) != F_->getNodes().end());
+  ASSERT_TRUE(functionContainsNode(F_, SN));
 
   // Save node should just save the input.
   EXPECT_TRUE(SN->getInput().getNode() == input);

--- a/tests/unittests/GraphOptzTest.cpp
+++ b/tests/unittests/GraphOptzTest.cpp
@@ -36,6 +36,10 @@ protected:
     EXPECT_TRUE(F_);
     EXPECT_TRUE(optimizedF_);
 
+    // Check that the bindings are not empty. If they are, the numerical
+    // equivalence check can produce a false positive.
+    EXPECT_GT(bindings_.getDataSize(), 0);
+
     // Clone bindings to use for original and optimized functions.
     PlaceholderBindings originalBindings = bindings_.clone();
     PlaceholderBindings optimizedBindings = bindings_.clone();
@@ -2603,14 +2607,16 @@ TEST_F(GraphOptz, concatElim) {
 /// Check that we are able to eliminate concat followed by slices on axis
 /// \p dim under certain conditions.
 static void testConcatSliceElim(Module &mod, Function *F, Function *&optimizedF,
-                                size_t dim) {
+                                PlaceholderBindings &bindings, size_t dim) {
   constexpr size_t N = 5;
   std::array<NodeValue, N> inputs;
   std::vector<size_t> inShape = {10, 20};
   inShape.insert(inShape.begin() + dim, 0);
   for (size_t i = 0; i < N; i++) {
     inShape[dim] = 1 + i;
-    inputs[i] = mod.createPlaceholder(ElemKind::FloatTy, inShape, "in", true);
+    auto *P = mod.createPlaceholder(ElemKind::FloatTy, inShape, "in", true);
+    bindings.allocate(P)->getHandle().randomize(-1.0, 1.0, mod.getPRNG());
+    inputs[i] = P;
   }
   auto *CN = F->createConcat("merge", inputs, dim);
 
@@ -2638,17 +2644,17 @@ static void testConcatSliceElim(Module &mod, Function *F, Function *&optimizedF,
 }
 
 TEST_F(GraphOptz, concatSliceElimInnerDim) {
-  testConcatSliceElim(mod_, F_, optimizedF_, 0);
+  testConcatSliceElim(mod_, F_, optimizedF_, bindings_, 0);
   checkNumericalEquivalence();
 }
 
 TEST_F(GraphOptz, concatSliceElimMiddleDim) {
-  testConcatSliceElim(mod_, F_, optimizedF_, 1);
+  testConcatSliceElim(mod_, F_, optimizedF_, bindings_, 1);
   checkNumericalEquivalence();
 }
 
 TEST_F(GraphOptz, concatSliceElimOuterDim) {
-  testConcatSliceElim(mod_, F_, optimizedF_, 2);
+  testConcatSliceElim(mod_, F_, optimizedF_, bindings_, 2);
   checkNumericalEquivalence();
 }
 


### PR DESCRIPTION
**Summary**
The tests in GraphOptzTest use the helper predicate `IsSameNodeAddress` in
conjunction with `std::find_if` to check whether a `Node` is still in a
`Function` after it has been optimized. This commit introduces a helper
function `functionContainsNode` that contains this logic and replaces all of
the calls to `std::find_if` with `IsSameNodeAddress` with this new function
for improved readability. This function will also be used frequently
while adding numerical equivalence checks to more tests.

**Test Plan**
All unit tests pass.

**Stack**
This PR is stacked on top of #3811.