### PR TITLE
Added calls to logPartitionInfo to partitioning when an error is encountered

### DIFF
--- a/lib/Partitioner/Partitioner.cpp
+++ b/lib/Partitioner/Partitioner.cpp
@@ -92,6 +92,8 @@ Error Partitioner::finalize(const DAGListTy &partitions,
     for (const auto &node : partitions[0].nodes) {
       Function *subF = module_->getFunction(node->name);
       if (!subF) {
+        // If we fail dump partition info for debugging.
+        logPartitionInfo(mapping);
         return MAKE_ERR(ErrorValue::ErrorCode::PARTITIONER_ERROR,
                         "Invalid function name " + node->name);
       }
@@ -284,6 +286,7 @@ Expected<DAGListTy> Partitioner::backendBasedPartition(
       }
     }
     if (nodeToBackendName.find(&N) == nodeToBackendName.end()) {
+      logPartitionInfo(mapping);
       return MAKE_ERR(ErrorValue::ErrorCode::PARTITIONER_ERROR,
                       "Node is not supported by any of the provided backends");
     }
@@ -573,6 +576,7 @@ Expected<DAGListTy> Partitioner::loadBalancedPartition(CompilationContext &cctx,
 
       // Throw error if we were not able to put this node into any partition
       if (curPartition >= numDevices) {
+        logPartitionInfo(partitionMap);
         return MAKE_ERR(ErrorValue::ErrorCode::PARTITIONER_ERROR,
                         "Load balance partition error");
       }

--- a/lib/Partitioner/PartitionerUtils.cpp
+++ b/lib/Partitioner/PartitionerUtils.cpp
@@ -521,9 +521,13 @@ void logPartitionInfo(const NodeToFunctionMap &partitions) {
               << "\t\t\t output size:\t"
               << partitions.getGraphMemInfo(subF).outMemSize << "\n"
               << "\t\t\t constant size:\t"
-              << partitions.getGraphMemInfo(subF).constMemSize << "\n"
-              << "\t\t LogicalDeviceIDs :\t"
-              << partitions.getLogicalDeviceIDList(subF)[0] << "\n";
+              << partitions.getGraphMemInfo(subF).constMemSize << "\n";
+    // This may be called before logicalDevices are assigned so check before
+    // printing.
+    if (partitions.getLogicalDeviceIDList(subF).size()) {
+      LOG(INFO) << "\t\t LogicalDeviceIDs :\t"
+                << partitions.getLogicalDeviceIDList(subF)[0] << "\n";
+    }
   }
 }
 } // namespace glow


### PR DESCRIPTION
Summary:
Added calls to logPartitionInfo to partitioning when an error is encountered to improve debugging.

Documentation:

Test Plan:
Ninja check to ensure nothing broke
Notice that PartitionerTest.memoryUsageValidation1 now prints PartitionInfo.
