### PR TITLE
Fix broken DeviceManagerTest test cases

### DIFF
--- a/tests/unittests/DeviceManagerTest.cpp
+++ b/tests/unittests/DeviceManagerTest.cpp
@@ -476,7 +476,7 @@ TEST_P(DeviceManagerTest, MultiModule) {
   ASSERT_TRUE(context1);
   ASSERT_TRUE(context2);
   EXPECT_NE(context1, context2);
-  context2->getPlaceholderBindings()->ensureOnHost();
+  context1->getPlaceholderBindings()->ensureOnHost();
   context2->getPlaceholderBindings()->ensureOnHost();
 
   Tensor *result1 = context1->getPlaceholderBindings()->get(
@@ -577,6 +577,8 @@ TEST_P(DeviceManagerTest, ReuseModule) {
   ASSERT_TRUE(context1);
   ASSERT_TRUE(context2);
   EXPECT_NE(context1, context2);
+  context1->getPlaceholderBindings()->ensureOnHost();
+  context2->getPlaceholderBindings()->ensureOnHost();
 
   Tensor *result1 = context1->getPlaceholderBindings()->get(
       module->getPlaceholderByName("func1_output"));
@@ -851,7 +853,6 @@ TEST_P(DeviceManagerTest, CanHandleDeviceResidentTensors) {
   Tensor *result1 = context->getPlaceholderBindings()->get(
       module->getPlaceholderByName("main_output"));
   ASSERT_TRUE(result1);
-  EXPECT_TRUE(result1->isEqual(output1));
 }
 
 INSTANTIATE_BACKEND_TEST(DeviceManagerTest);


### PR DESCRIPTION
Summary:
This commit fixes some broken DeviceManagerTest test cases. In the case of the
ReuseModule and MultiModule tests, the tests did not call `ensureOnHost` before
checking the contents of output Tensors. In the case of the
CanHandleDeviceResidentTensors test, the runFunction implementation of the
DeviceManager subclass used in the test is a no-op, so the output Tensor of the
Function used for the test is not set at all. Thus, there is no reason to
expect it to be equal to a Tensor produced by applying a host-side
implementation of the Function to the same input.

Differential Revision: D18689157

