### PR TITLE
[LLVMIRCodeGen] Streamline handling of LLVM backend options

### DIFF
--- a/include/glow/LLVMIRCodeGen/LLVMIRGen.h
+++ b/include/glow/LLVMIRCodeGen/LLVMIRGen.h
@@ -37,6 +37,7 @@ class Constant;
 class Instruction;
 class WeightVar;
 class AllocationsInfo;
+class LLVMBackendOptions;
 
 /// Different kinds of memory areas used by the emitted LLVM function.
 /// The order is important. It should match the order of base addresses
@@ -274,13 +275,8 @@ public:
   explicit LLVMIRGen(const IRFunction *M, AllocationsInfo &allocationsInfo,
                      std::string mainEntryName, llvm::StringRef libjitBC);
 
-  /// Init the TargetMachine using a given \p target, \p arch, \p cpu, \p
-  /// targetFeatures and code model.
-  virtual void
-  initTargetMachine(llvm::StringRef target, llvm::StringRef arch,
-                    llvm::StringRef cpu,
-                    const llvm::SmallVectorImpl<std::string> &targetFeatures,
-                    llvm::CodeModel::Model CM, llvm::Reloc::Model relocModel);
+  /// Init the TargetMachine using settings provided by \p llvmBackend.
+  virtual void initTargetMachine(const LLVMBackendOptions &opts);
 
   /// Emit LLVM-IR for the instruction \p I, using the builder \p builder.
   /// Derived classes may want to override this function to implement a

--- a/lib/LLVMIRCodeGen/BundleSaver.h
+++ b/lib/LLVMIRCodeGen/BundleSaver.h
@@ -48,18 +48,8 @@ public:
     const BundleSaver *bundleSaver_;
   };
   /// Ctor.
-  explicit BundleSaver(const IRFunction *F, const LLVMBackend &llvmBackend);
   explicit BundleSaver(const LLVMBackend &llvmBackend,
                        llvm::StringRef outputDir, llvm::StringRef bundleName);
-  /// Save code bundle built for \p target, \p arch, \p cpu and \p
-  /// targetFeatures to \p outputDir under name \p bundleName. Make
-  /// \p mainEntryName the function name for the entry point of the network and
-  /// prepend all generated files with this name.
-  void save(llvm::StringRef target, llvm::StringRef arch, llvm::StringRef cpu,
-            const llvm::SmallVectorImpl<std::string> &targetFeatures,
-            llvm::StringRef outputDir, llvm::StringRef bundleName,
-            llvm::StringRef mainEntryName, llvm::CodeModel::Model codeModel,
-            llvm::Reloc::Model relocModel);
   void save(llvm::StringRef mainEntryName, const IRFunction *F);
   /// Produce a bundle.
   void produceBundle();

--- a/lib/LLVMIRCodeGen/CommandLine.cpp
+++ b/lib/LLVMIRCodeGen/CommandLine.cpp
@@ -30,6 +30,9 @@ llvm::cl::opt<std::string>
 llvm::cl::opt<std::string> llvmCPU("mcpu",
                                    llvm::cl::desc("LLVM CPU to be used"));
 
+llvm::cl::opt<std::string> llvmABI("mabi",
+                                   llvm::cl::desc("Machine ABI to be used"));
+
 llvm::cl::opt<llvm::CodeModel::Model> llvmCodeModel(
     "code-model",
     llvm::cl::desc("Specify which code model to use on the target machine"),

--- a/lib/LLVMIRCodeGen/CommandLine.h
+++ b/lib/LLVMIRCodeGen/CommandLine.h
@@ -37,6 +37,9 @@ extern llvm::cl::opt<std::string> llvmArch;
 /// CPU to be used by the LLVMBackend. Used as -mcpu=cpuA.
 extern llvm::cl::opt<std::string> llvmCPU;
 
+/// ABI to be used by the LLVMBackend. Used as -mabi=abi.
+extern llvm::cl::opt<std::string> llvmABI;
+
 /// Code model to be used by the LLVMBackend.
 extern llvm::cl::opt<llvm::CodeModel::Model> llvmCodeModel;
 

--- a/lib/LLVMIRCodeGen/LLVMBackend.cpp
+++ b/lib/LLVMIRCodeGen/LLVMBackend.cpp
@@ -49,16 +49,21 @@ void allocateJITMemory(const IRFunction *F, AllocationsInfo &allocationsInfo) {
 
 } // end namespace
 
-LLVMBackend::LLVMBackend() {
+LLVMBackendOptions::LLVMBackendOptions() {
   // Initialize using command-line options by default.
   arch_ = llvmArch;
   target_ = llvmTarget;
   cpu_ = llvmCPU;
+  abi_ = llvmABI;
+  floatABI_ = floatABI;
   codeModel_ = llvmCodeModel;
   bundleCodeModel_ = llvmBundleCodeModel;
   relocModel_ = llvmRelocModel;
   bundleAPI_ = bundleAPI;
+  targetFeatures_.append(llvmTargetFeatures.begin(), llvmTargetFeatures.end());
 }
+
+LLVMBackend::LLVMBackend() {}
 
 /// Emit the entry point for JIT called "jitmain".
 /// Function has the following API:
@@ -113,8 +118,7 @@ LLVMBackend::compileIRWithoutConstants(IRFunction *IR) const {
   std::unique_ptr<LLVMIRGen> irgen = createIRGen(IR, allocationsInfo);
   llvm::SmallVector<std::string, 8> targetFeatures(llvmTargetFeatures.begin(),
                                                    llvmTargetFeatures.end());
-  irgen->initTargetMachine(getTarget(), getArch(), getCPU(), targetFeatures,
-                           getCodeModel(), getRelocModel());
+  irgen->initTargetMachine(getOptions());
   irgen->initCodeGen();
   irgen->setIRFunction(IR);
   // Perform the address assignment for activations and WeightVars.


### PR DESCRIPTION
Summary:

Documentation:

- Add -mabi option for setting the ABI to use for a given targetTest
- Move all target-specific options from LLVMBackend into a dedicated LLVMBackendOptions class
   Use LLVMBackendOptions instead of passing a bunch of target-specific options around.

Plan:

ninja test