### PR TITLE
[BundleSaver](trivial) Minimize header file content.

### DIFF
--- a/lib/LLVMIRCodeGen/BundleSaver.cpp
+++ b/lib/LLVMIRCodeGen/BundleSaver.cpp
@@ -284,9 +284,10 @@ void BundleSaver::saveHeader(llvm::StringRef headerFileName) {
 
   // Format model description.
   std::string modelInfo = strFormat("// Model name: \"%s\"\n"
-                                    "// Total data size: %lu (bytes)\n"
-                                    "// Placeholders:\n",
+                                    "// Total data size: %lu (bytes)\n",
                                     bundleName.data(), totMemSize);
+  // Print placeholders (mandatory).
+  modelInfo += "// Placeholders:\n";
   auto placeholders = findPlaceholders();
   for (auto &v : placeholders) {
     auto *w = cast<WeightVar>(getWeightForNode(v));
@@ -316,34 +317,38 @@ void BundleSaver::saveHeader(llvm::StringRef headerFileName) {
                            name.data(), typeName.data(), shapeStr.c_str(),
                            sizeElem, sizeByte, (unsigned long)offset);
   }
-  auto constantWeights = findConstantWeights();
-  for (auto &weightInfo : constantWeights) {
-    auto *w = weightInfo.first;
-    // Get placeholder shape as string.
-    std::string shapeStr = "[";
-    auto dims = w->getType()->dims();
-    for (size_t idx = 0; idx < dims.size(); idx++) {
-      if (idx < dims.size() - 1) {
-        shapeStr += strFormat("%lu, ", dims[idx]);
-      } else {
-        shapeStr += strFormat("%lu]", dims[idx]);
+  // Print constants (optional).
+  if (bundleAPIVerbose_) {
+    modelInfo += "// Constants:\n";
+    auto constantWeights = findConstantWeights();
+    for (auto &weightInfo : constantWeights) {
+      auto *w = weightInfo.first;
+      // Get constant shape as string.
+      std::string shapeStr = "[";
+      auto dims = w->getType()->dims();
+      for (size_t idx = 0; idx < dims.size(); idx++) {
+        if (idx < dims.size() - 1) {
+          shapeStr += strFormat("%lu, ", dims[idx]);
+        } else {
+          shapeStr += strFormat("%lu]", dims[idx]);
+        }
       }
+      // Get constant properties.
+      auto name = w->getName();
+      auto typeName = w->getType()->getElementName();
+      auto sizeElem = w->getType()->size();
+      auto sizeByte = w->getType()->getSizeInBytes();
+      auto offset = allocationsInfo_.allocatedAddress_[w];
+      modelInfo += strFormat("//\n"
+                             "//   Name: \"%s\"\n"
+                             "//   Type: %s\n"
+                             "//   Shape: %s\n"
+                             "//   Size: %zu (elements)\n"
+                             "//   Size: %zu (bytes)\n"
+                             "//   Offset: %lu (bytes)\n",
+                             name.data(), typeName.data(), shapeStr.c_str(),
+                             sizeElem, sizeByte, (unsigned long)offset);
     }
-    // Get placeholder properties.
-    auto name = w->getName();
-    auto typeName = w->getType()->getElementName();
-    auto sizeElem = w->getType()->size();
-    auto sizeByte = w->getType()->getSizeInBytes();
-    auto offset = allocationsInfo_.allocatedAddress_[w];
-    modelInfo += strFormat("//\n"
-                           "//   Name: \"%s\"\n"
-                           "//   Type: %s\n"
-                           "//   Shape: %s\n"
-                           "//   Size: %zu (elements)\n"
-                           "//   Size: %zu (bytes)\n"
-                           "//   Offset: %lu (bytes)\n",
-                           name.data(), typeName.data(), shapeStr.c_str(),
-                           sizeElem, sizeByte, (unsigned long)offset);
   }
   modelInfo += "//";
 

--- a/lib/LLVMIRCodeGen/BundleSaver.cpp
+++ b/lib/LLVMIRCodeGen/BundleSaver.cpp
@@ -43,6 +43,15 @@ using llvm::cast;
 using llvm::dyn_cast;
 using llvm::isa;
 
+namespace {
+llvm::cl::OptionCategory bundleSaverCat("Bundle Options");
+
+llvm::cl::opt<bool> bundleAPIVerboseOpt(
+    "bundle-api-verbose",
+    llvm::cl::desc("Print more details in the bundle API header file"),
+    llvm::cl::init(false), llvm::cl::cat(bundleSaverCat));
+} // namespace
+
 /// Header file string template.
 static const char *headerFileTemplate =
     R"RAW(// Bundle API header file
@@ -318,8 +327,9 @@ void BundleSaver::saveHeader(llvm::StringRef headerFileName) {
                            sizeElem, sizeByte, (unsigned long)offset);
   }
   // Print constants (optional).
-  if (bundleAPIVerbose_) {
-    modelInfo += "// Constants:\n";
+  if (bundleAPIVerboseOpt) {
+    modelInfo += "//\n"
+                 "// Constants:\n";
     auto constantWeights = findConstantWeights();
     for (auto &weightInfo : constantWeights) {
       auto *w = weightInfo.first;

--- a/lib/LLVMIRCodeGen/BundleSaver.cpp
+++ b/lib/LLVMIRCodeGen/BundleSaver.cpp
@@ -43,15 +43,6 @@ using llvm::cast;
 using llvm::dyn_cast;
 using llvm::isa;
 
-namespace {
-llvm::cl::OptionCategory bundleSaverCat("Bundle Options");
-
-llvm::cl::opt<bool> bundleAPIVerboseOpt(
-    "bundle-api-verbose",
-    llvm::cl::desc("Print more details in the bundle API header file"),
-    llvm::cl::init(false), llvm::cl::cat(bundleSaverCat));
-} // namespace
-
 /// Header file string template.
 static const char *headerFileTemplate =
     R"RAW(// Bundle API header file
@@ -327,7 +318,7 @@ void BundleSaver::saveHeader(llvm::StringRef headerFileName) {
                            sizeElem, sizeByte, (unsigned long)offset);
   }
   // Print constants (optional).
-  if (bundleAPIVerboseOpt) {
+  if (bundleAPIVerbose) {
     modelInfo += "//\n"
                  "// Constants:\n";
     auto constantWeights = findConstantWeights();

--- a/lib/LLVMIRCodeGen/BundleSaver.h
+++ b/lib/LLVMIRCodeGen/BundleSaver.h
@@ -100,6 +100,8 @@ private:
   std::vector<SavedIRFunction> savedIRFunctions_;
   /// Bundle API to use.
   BundleApiType bundleAPI_;
+  /// Bundle API verbose mode.
+  bool bundleAPIVerbose_{false};
   /// Indicates if this bundle was saved already.
   bool isSaved_{false};
 };

--- a/lib/LLVMIRCodeGen/BundleSaver.h
+++ b/lib/LLVMIRCodeGen/BundleSaver.h
@@ -100,8 +100,6 @@ private:
   std::vector<SavedIRFunction> savedIRFunctions_;
   /// Bundle API to use.
   BundleApiType bundleAPI_;
-  /// Bundle API verbose mode.
-  bool bundleAPIVerbose_{false};
   /// Indicates if this bundle was saved already.
   bool isSaved_{false};
 };

--- a/lib/LLVMIRCodeGen/CommandLine.cpp
+++ b/lib/LLVMIRCodeGen/CommandLine.cpp
@@ -100,3 +100,8 @@ llvm::cl::opt<glow::BundleApiType>
                                           "Static API")),
               llvm::cl::init(glow::BundleApiType::Static),
               llvm::cl::cat(bundleSaverCat));
+
+llvm::cl::opt<bool> bundleAPIVerbose(
+    "bundle-api-verbose",
+    llvm::cl::desc("Print more details in the bundle API header file"),
+    llvm::cl::init(false), llvm::cl::cat(bundleSaverCat));

--- a/lib/LLVMIRCodeGen/CommandLine.h
+++ b/lib/LLVMIRCodeGen/CommandLine.h
@@ -67,4 +67,7 @@ extern llvm::cl::opt<llvm::FloatABI::ABIType> floatABI;
 /// Option to specify which bundle API to use.
 extern llvm::cl::opt<glow::BundleApiType> bundleAPI;
 
+/// Option to print more details in the bundle API.
+extern llvm::cl::opt<bool> bundleAPIVerbose;
+
 #endif // GLOW_LLVMIRCODEGEN_COMMANDLINE_H


### PR DESCRIPTION
**Summary**
In one of the latest commits the BundleSaver prints in the auto-generated header file also the model constants. For large models the generated API header file becomes more of a log file and less of a clean API. For example:
[bundle.txt](https://github.com/pytorch/glow/files/3898153/bundle.txt)
This feature (verbosity) should be made optional since a clean approach should mandate that the API includes only what`s necessary and sufficient (in this case placeholder information).

Documentation
None

[Optional Fixes #issue]

Test Plan
None
