### PR TITLE
Add method to list supported options for device managers and compilation functions.

### DIFF
--- a/include/glow/Backend/Backend.h
+++ b/include/glow/Backend/Backend.h
@@ -174,6 +174,18 @@ public:
   virtual runtime::DeviceManager *
   createDeviceManager(const runtime::DeviceConfig &deviceConfig);
 
+  /// \returns the supported options for compiled functions (name=>description).
+  virtual llvm::StringMap<std::string>
+  getSupportedCompiledFunctionOptions() const {
+    return llvm::StringMap<std::string>();
+  };
+
+  /// \returns the supported options for device managers (name=>description).
+  virtual llvm::StringMap<std::string>
+  getSupportedDeviceManagerOptions() const {
+    return llvm::StringMap<std::string>();
+  };
+
 protected:
   /// Parses the graph \F and builds a TraceInfo structure from any found
   /// TraceEventNodes.


### PR DESCRIPTION
Summary:
Added new methods in the Backend to expose the supported options for device manages and compiled functions.
Compiled function options can be specified in BackendOptions::backendSpecificOpts (in Backed::compile).
Device manager options can be specified in DeviceConfig::parameters (in Backed::createDeviceManager).