### PR TITLE
Synchronize target registration

### DIFF
--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -94,7 +94,13 @@ LLVMIRGen::LLVMIRGen(const IRFunction *F, AllocationsInfo &allocationsInfo,
     : F_(F), allocationsInfo_(allocationsInfo), mainEntryName_(mainEntryName),
       libjitBC_(libjitBC) {}
 
+/// Mutex to protect LLVM's TargetRegistry.
+static std::mutex initTargetMutex;
+
 void LLVMIRGen::initTargetMachine(const LLVMBackendOptions &opts) {
+  // LLVM's TargetRegistry is not thread safe so we add a critical section.
+  std::lock_guard<std::mutex> g(initTargetMutex);
+
   llvm::InitializeAllTargets();
   llvm::InitializeAllTargetMCs();
   llvm::InitializeAllAsmPrinters();


### PR DESCRIPTION
Summary:
Under load Glow sometimes deadlocks in
`TargetRegistry::RegisterTarget`, and from comments in LLVM it seems that this
method is inherently thread-unsafe:
https://github.com/llvm/llvm-project/blob/master/llvm/lib/Support/TargetRegistry.cpp#L17.
Adding a mutex protects initialization when performing multithreaded
compilation.

Differential Revision: D18767758

