### PR TITLE
[JIT] Attempt to handle static C++ objects construction/destruction

### DIFF
--- a/lib/LLVMIRCodeGen/Pipeline.cpp
+++ b/lib/LLVMIRCodeGen/Pipeline.cpp
@@ -130,6 +130,13 @@ void LLVMIRGen::optimizeLLVMModule(llvm::Module *M, llvm::TargetMachine &TM) {
     }
 
     FF.removeFnAttr(llvm::Attribute::AttrKind::NoInline);
+
+    // LinkOnce linkage seems to cause problems to OrcJIT on some OS platforms.
+    // In particular, ORCJit doesn't like linkonce_odr linkage which is used for
+    // almost all templatized C++ functions in the LLVM module.
+    if (!FF.isDeclaration() && FF.isLinkOnceLinkage(FF.getLinkage())) {
+      FF.setLinkage(llvm::GlobalValue::LinkageTypes::InternalLinkage);
+    }
   }
 
   // Perform specialization of functions for constant arguments before anything

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -550,3 +550,38 @@ add_glow_test(ErrorTest ${GLOW_BINARY_DIR}/tests/ErrorTest --gtest_output=xml:Er
 LIST(APPEND UNOPT_TESTS true)
 add_custom_target(test_unopt ${UNOPT_TESTS}
                   WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+
+# JIT tests
+if("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+    set(CLANG_BIN ${CMAKE_CXX_COMPILER})
+else()
+    find_program(CLANG_BIN clang++)
+endif()
+if(NOT CLANG_BIN)
+    message(SEND_ERROR "unable to find clang, cannot build the CPU runtime")
+endif()
+set (TEST_LIBJIT "test_libjit")
+add_custom_command(
+    OUTPUT ${GLOW_BINARY_DIR}/tests/${TEST_LIBJIT}.bc
+    COMMAND ${CLANG_BIN} -emit-llvm -c -o ${GLOW_BINARY_DIR}/tests/${TEST_LIBJIT}.bc ${TEST_LIBJIT}.cpp
+    DEPENDS ${TEST_LIBJIT}.cpp
+    WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}")
+file(MAKE_DIRECTORY ${GLOW_BINARY_DIR}/glow/CPU)
+add_custom_command(
+    OUTPUT ${GLOW_BINARY_DIR}/glow/CPU/${TEST_LIBJIT}_bc.inc
+    COMMAND include-bin "${GLOW_BINARY_DIR}/tests/${TEST_LIBJIT}.bc" "${GLOW_BINARY_DIR}/glow/CPU/${TEST_LIBJIT}_bc.inc"
+    DEPENDS ${GLOW_BINARY_DIR}/tests/${TEST_LIBJIT}.bc
+    WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}")
+add_executable(CPUJITTest
+    CPUJITTest.cpp ${GLOW_BINARY_DIR}/glow/CPU/${TEST_LIBJIT}_bc.inc)
+target_link_libraries(CPUJITTest
+    PRIVATE
+    Backends
+    ExecutionEngine
+    Graph
+    Support
+    gtest
+    TestMain)
+add_custom_target(CPUJITTest_libjit SOURCES ${TEST_LIBJIT}.cpp)
+add_glow_test(CPUJITTest ${GLOW_BINARY_DIR}/tests/CPUJITTest --gtest_output=xml:CPUJITTest.xml)
+

--- a/tests/unittests/CPUJITTest.cpp
+++ b/tests/unittests/CPUJITTest.cpp
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/Backend/Backend.h"
+#include "glow/ExecutionEngine/ExecutionEngine.h"
+#include "glow/Graph/Graph.h"
+#include "glow/Graph/Hook.h"
+#include "glow/Graph/Node.h"
+#include "glow/Graph/Nodes.h"
+#include "glow/Graph/Utils.h"
+
+#include "../../lib/Backends/CPU/CPUBackend.h"
+#include "../../lib/Backends/CPU/CPULLVMIRGen.h"
+#include "glow/IR/Instrs.h"
+
+#include "gtest/gtest.h"
+
+using namespace glow;
+
+//==============================================================
+// Test main classes
+//==============================================================
+
+/// We compile the standard library (libjit) to LLVM bitcode, and then convert
+/// that binary data to an include file using an external utility (include-bin).
+/// The resulting file is included here to compile the bitcode image into our
+/// library.
+static const unsigned char libjit_bc[] = {
+#include "glow/CPU/test_libjit_bc.inc"
+};
+static const size_t libjit_bc_size = sizeof(libjit_bc);
+
+class MockLLVMIRGen : public CPULLVMIRGen {
+
+  // JIT test specific codegen method.
+  bool generateJITTESTIRForInstr(llvm::IRBuilder<> &builder,
+                                 const glow::Instruction *I) {
+    if (I->getKind() == Kinded::Kind::ElementLogInstKind) {
+      auto *AN = llvm::cast<ElementLogInst>(I);
+      auto *src = AN->getSrc();
+      auto *dest = AN->getDest();
+      auto *srcPtr = emitValueAddress(builder, src);
+      auto *destPtr = emitValueAddress(builder, dest);
+      auto *F = getFunction("JITTestDispatch");
+      createCall(builder, F, {srcPtr, destPtr});
+      return true;
+    }
+
+    return false;
+  }
+
+  virtual void generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
+                                      const glow::Instruction *I) override {
+    // Try to generate test version of instruction.
+    if (generateJITTESTIRForInstr(builder, I)) {
+      return;
+    }
+
+    // Fall back to LLVMIRGen.
+    LLVMIRGen::generateLLVMIRForInstr(builder, I);
+  }
+
+  bool
+  canBePartOfDataParallelKernel(const glow::Instruction *I) const override {
+    return false;
+  }
+
+public:
+  MockLLVMIRGen(const IRFunction *F, AllocationsInfo &allocationsInfo,
+                std::string mainEntryName, llvm::StringRef libjitBC)
+      : CPULLVMIRGen(F, allocationsInfo, mainEntryName, libjitBC) {}
+};
+
+class MockCPUBackend : public CPUBackend {
+  virtual std::unique_ptr<LLVMIRGen>
+  createIRGen(const IRFunction *IR,
+              AllocationsInfo &allocationsInfo) const override {
+    MockLLVMIRGen *irgen =
+        new MockLLVMIRGen(IR, allocationsInfo, "", getLibjitBitcode());
+    return std::unique_ptr<MockLLVMIRGen>(irgen);
+  }
+  virtual std::string getBackendName() const override {
+    return "MockCPUBackend";
+  }
+
+public:
+  virtual llvm::StringRef getLibjitBitcode() const override {
+    return llvm::StringRef(reinterpret_cast<const char *>(libjit_bc),
+                           libjit_bc_size);
+  }
+  static std::string getName() { return "MockCPUBackend"; }
+};
+
+REGISTER_GLOW_BACKEND_FACTORY(MockCPUFactory, MockCPUBackend);
+
+//==============================================================
+// Actual tests
+//
+// For JIT tests, we take the following approach:
+// - override the code generation for a particular node (log)
+// - the log input value determines the index of libjit function
+//   that must be called
+// - in case there are later change in the Glow that may result
+//   in a IR/code generation change, we check that the expected
+//   JIT function was called by checking that the log output
+//   value is JIT_MAGIC_VALUE + <log input>
+//==============================================================
+
+#define JIT_MAGIC_VALUE 555
+
+// Test 0: test that the libjit code can use global C++ objects.
+TEST(CPUJITTest, testCppConstructors) {
+  glow::ExecutionEngine EE("MockCPUBackend");
+  Module &M = EE.getModule();
+  Function *F = M.createFunction("F");
+
+  // Create a simple graph.
+  auto *inputPH = M.createPlaceholder(ElemKind::FloatTy, {1}, "input", false);
+  Node *addNode = F->createLog("testCppConstructors", inputPH);
+  auto *saveNode = F->createSave("output", addNode);
+
+  PlaceholderBindings bindings;
+  auto *inputT = bindings.allocate(inputPH);
+  inputT->getHandle().clear(0);
+  Tensor expectedT(inputT->getType());
+  expectedT.getHandle().clear(JIT_MAGIC_VALUE + 0);
+  auto *outputT = bindings.allocate(saveNode->getPlaceholder());
+  EE.compile(CompilationMode::Infer);
+  EE.run(bindings);
+  EXPECT_TRUE(outputT->isEqual(expectedT));
+}

--- a/tests/unittests/test_libjit.cpp
+++ b/tests/unittests/test_libjit.cpp
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <map>
+
+/// The following variable needs to be defined in libjit, because codegen looks
+/// for it to determine the size of size_t on the target.
+size_t libjit_sizeTVar;
+
+/// Simply write a global map to validate that static C++ constructors are
+/// correctly called.
+extern std::map<float, float> GlobalMap;
+std::map<float, float> GlobalMap;
+void libjit_WriteGlobalMap() { GlobalMap[1.0] = 1.2f; }
+
+extern "C" {
+
+#define JIT_MAGIC_VALUE 555
+
+// JIT test dispatch function.
+__attribute__((noinline)) void libjit_JITTestDispatch(float *src, float *dest) {
+  if (*src == 0.f) {
+    libjit_WriteGlobalMap();
+  } else {
+    // No test for this index. This should be an error.
+    *dest = 0;
+  }
+
+  *dest = JIT_MAGIC_VALUE + *src;
+}
+}


### PR DESCRIPTION
Summary: (very) experimental code to solve the handling of static C++ objects in libjit.

Fixes #3839 

@opti-mix 