### PR TITLE
32b dim_t fixes + a new builder for 32b dim t

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -141,6 +141,9 @@ elif [[ "$CIRCLE_JOB" == "PYTORCH" ]]; then
 elif [[ "$CIRCLE_JOB" == "OPENCL" ]]; then
     install_pocl
     CMAKE_ARGS+=("-DGLOW_WITH_OPENCL=ON")
+elif [[ "$CIRCLE_JOB" == "32B_DIM_T" ]]; then
+    install_pocl
+    CMAKE_ARGS+=("-DTENSOR_DIMS_32_BITS=ON -DGLOW_WITH_OPENCL=ON")
 else
     CMAKE_ARGS+=("-DCMAKE_BUILD_TYPE=Debug")
     if [[ "${CIRCLE_JOB}" == "SHARED" ]]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,10 @@ jobs:
     environment:
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:283"
     <<: *linux_default
+  32B_DIM_T:
+    environment:
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:283"
+    <<: *linux_default
   RELEASE_WITH_EXPENSIVE_TESTS:
     environment:
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:283"
@@ -114,6 +118,7 @@ workflows:
       - ASAN
       - TSAN
       - SHARED
+      - 32B_DIM_T
       - RELEASE_WITH_EXPENSIVE_TESTS
       - COVERAGE
       - PYTORCH

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -79,6 +79,9 @@ case ${CIRCLE_JOB} in
     SHARED)
         # No tests with shared libs; it's similar to DEBUG.
         ;;
+    32B_DIM_T)
+        # No tests with 32b dim_t; it's similar to DEBUG.
+        ;;
     RELEASE_WITH_EXPENSIVE_TESTS)
         run_unit_tests check_expensive
         run_and_check_lenet_mnist_bundle

--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -806,13 +806,13 @@ static void libjit_space_to_depth_generic(const T *inPtr, T *outPtr,
 template <typename DstType, typename SrcType>
 static void
 libjit_copy_kernel_with_conversion(DstType *dstPtr, const SrcType *srcPtr,
-                                   const size_t *dims, size_t numDims) {
-  size_t dimSize = 1;
-  for (size_t i = 0; i < numDims; ++i) {
+                                   const dim_t *dims, dim_t numDims) {
+  dim_t dimSize = 1;
+  for (dim_t i = 0; i < numDims; ++i) {
     dimSize *= dims[i];
   }
 
-  for (size_t i = 0; i < dimSize; ++i) {
+  for (dim_t i = 0; i < dimSize; ++i) {
     dstPtr[i] = DstType(srcPtr[i]);
   }
 }
@@ -823,12 +823,12 @@ template <typename T>
 static void libjit_reducemin(T *dest, const T *batch, size_t destSize,
                              const dim_t *destDims, const dim_t *batchDims,
                              T init) {
-  for (size_t i = 0; i < destSize; i++) {
+  for (dim_t i = 0; i < destSize; i++) {
     dest[i] = init;
   }
 
   unsigned int axis[6];
-  for (size_t i = 0; i < 6; i++) {
+  for (dim_t i = 0; i < 6; i++) {
     axis[i] = (destDims[i] > 1);
   }
 
@@ -2072,19 +2072,19 @@ void libjit_write_timestamp(uint64_t *tensor, dim_t offset) {
 
 /// Copies a kernel with type conversion
 void libjit_convertTo_f_i32(float *dstPtr, const int32_t *srcPtr,
-                            const size_t *dims, size_t numDims) {
+                            const dim_t *dims, dim_t numDims) {
   libjit_copy_kernel_with_conversion<float, int32_t>(dstPtr, srcPtr, dims,
                                                      numDims);
 }
 
 void libjit_convertTo_i32_u(int32_t *dstPtr, const int64_t *srcPtr,
-                            const size_t *dims, size_t numDims) {
+                            const dim_t *dims, dim_t numDims) {
   libjit_copy_kernel_with_conversion<int32_t, int64_t>(dstPtr, srcPtr, dims,
                                                        numDims);
 }
 
 void libjit_convertTo_u_i32(int64_t *dstPtr, const int32_t *srcPtr,
-                            const size_t *dims, size_t numDims) {
+                            const dim_t *dims, dim_t numDims) {
   libjit_copy_kernel_with_conversion<int64_t, int32_t>(dstPtr, srcPtr, dims,
                                                        numDims);
 }

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -590,9 +590,9 @@ static void topK(Tensor &outW, Tensor &indW, Tensor &inW, size_t k) {
 
 static ShapeNHWC shapeFromDims(llvm::ArrayRef<dim_t> arr) {
   assert(arr.size() <= 4);
-  llvm::SmallVector<size_t, 4> ones(4, 1);
+  llvm::SmallVector<dim_t, 4> ones(4, 1);
   std::copy(arr.begin(), arr.end(), ones.begin());
-  return ShapeNHWC(llvm::ArrayRef<size_t>(ones));
+  return ShapeNHWC(llvm::ArrayRef<dim_t>(ones));
 };
 
 Error OpenCLFunction::execute(ExecutionContext *context) {

--- a/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
@@ -650,7 +650,7 @@ void OpenCLDeviceManager::translateTraceEvents(
         // Convert into usec and move into steady_clock domain.
         auto timestamp = (timeEnd / 1000) + tsOffset;
 
-        handle.at({ev->startIndex, 0}) = timestamp;
+        handle.at({(dim_t)ev->startIndex, 0}) = timestamp;
         traceEvents.push_back({ev->name,
                                TraceLevel::DEBUG,
                                timestamp,

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1827,8 +1827,8 @@ static Constant *quantizeDataForFusedRowwiseQuantizedSparseLengthsWeightedSum(
   }
   case ElemKind::UInt8FusedFP16QTy: {
     Constant *rwqData = F->getParent()->createConstant(
-        precision, {fDims.first, fDims.second + 2 * sizeof(float16_t)}, 0.0, 0,
-        "data");
+        precision, {fDims.first, fDims.second + 2 * (dim_t)sizeof(float16_t)},
+        0.0, 0, "data");
     quantization::tensorFusedRowwiseQuantization<float16_t>(
         fData, rwqData->getPayloadMutable());
     return rwqData;
@@ -1837,7 +1837,7 @@ static Constant *quantizeDataForFusedRowwiseQuantizedSparseLengthsWeightedSum(
     // We pack 4-bit values into bytes, so given the input size in float we
     // divide by two and take the ceiling to make sure we have enough space for
     // all elements.
-    const size_t outerDim =
+    const dim_t outerDim =
         std::ceil(((float)fDims.second) / 2) + 2 * sizeof(float16_t);
     Constant *rwqData = F->getParent()->createConstant(
         precision, {fDims.first, outerDim}, 0.0, 0, "data");
@@ -2944,12 +2944,12 @@ void Function::createONNXLSTM(llvm::StringRef namePrefix, NodeValue X,
   const std::string &opName = namePrefix.str();
 
   // Get all size parameters.
-  size_t numDirections = (direction == LstmDirection::Bidirectional) ? 2 : 1;
+  dim_t numDirections = (direction == LstmDirection::Bidirectional) ? 2 : 1;
   assert(X.dims().size() == 3 &&
          "ONNX LSTM input 'X' should have 3 dimensions!");
-  size_t seqLength = X.dims()[0];
-  size_t batchSize = X.dims()[1];
-  size_t inputSize = X.dims()[2];
+  dim_t seqLength = X.dims()[0];
+  dim_t batchSize = X.dims()[1];
+  dim_t inputSize = X.dims()[2];
 
   // Validate W size.
   assert(W.dims().size() == 3 &&
@@ -3005,7 +3005,7 @@ void Function::createONNXLSTM(llvm::StringRef namePrefix, NodeValue X,
 
   // Create X slices.
   std::vector<Node *> Xslices;
-  for (size_t t = 0; t < seqLength; t++) {
+  for (dim_t t = 0; t < seqLength; t++) {
     auto XsliceName = opName + ".X" + std::to_string(t) + ".slice";
     Node *Xt = createSlice(XsliceName, X, LSTM_X_SLICE_RANGE(t));
     auto XreshapeName = opName + ".X" + std::to_string(t) + ".reshape";
@@ -3021,7 +3021,7 @@ void Function::createONNXLSTM(llvm::StringRef namePrefix, NodeValue X,
     std::string prefix = opName + ((numDirections > 1) ? dirLabel : "");
 
     // Slice index used for creating weights slices.
-    size_t sliceIdx0 = 0;
+    dim_t sliceIdx0 = 0;
     if (direction == LstmDirection::Bidirectional) {
       sliceIdx0 = forward ? 0 : 1;
     }

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -1118,7 +1118,7 @@ Error ONNXModelLoader::loadConstantOfShape(const ONNX_NAMESPACE::NodeProto &op,
     auto TH = in->getPayload().getHandle<int64_t>();
     auto begin = &TH.raw(0);
     auto end = begin + TH.actualSize();
-    ShapeVector outputDims = {(const dim_t *)begin, (const dim_t *)end};
+    ShapeVector outputDims(begin, end);
 
     ty = G_.getParent()->uniqueType(T.getType().getElementType(), outputDims);
     switch (T.getType().getElementType()) {
@@ -1257,7 +1257,7 @@ Error ONNXModelLoader::loadLSTM(const ONNX_NAMESPACE::NodeProto &op,
                  ErrorValue::ErrorCode::MODEL_LOADER_UNSUPPORTED_ATTRIBUTE);
     }
   }
-  size_t numDirections =
+  dim_t numDirections =
       (direction == Function::LstmDirection::Bidirectional) ? 2 : 1;
 
   // Activation alpha not supported (Optional)(Default:activation dependent).
@@ -1318,7 +1318,7 @@ Error ONNXModelLoader::loadLSTM(const ONNX_NAMESPACE::NodeProto &op,
                     "ONNX LSTM 'clip' attribute not supported!");
 
   // Get hidden size (Required).
-  size_t hiddenSize;
+  dim_t hiddenSize;
   RETURN_ERR_IF_NOT(dict.count("hidden_size"),
                     "ONNX LSTM 'hidden_size' attribute is required!");
   ASSIGN_VALUE_OR_RETURN_ERR(hiddenSize, loadInt(dict.at("hidden_size")));
@@ -1395,7 +1395,7 @@ Error ONNXModelLoader::loadLSTM(const ONNX_NAMESPACE::NodeProto &op,
   // Derived parameters.
   RETURN_ERR_IF_NOT(X.dims().size() == 3,
                     "ONNX LSTM input 'X' should have 3 dimensions!");
-  size_t batchSize = X.dims()[1];
+  dim_t batchSize = X.dims()[1];
 
   // Create Y_h (hidden state) output placeholder.
   Placeholder *Y_h_ph;

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -2693,7 +2693,7 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     auto *inputVal = emitValueAddress(builder, input);
     auto *outptVal = emitValueAddress(builder, output);
     auto *dimsVal = emitValueDims(builder, output);
-    auto *dimSizeVal = emitConstSizeT(builder, output->dims().size());
+    auto *dimSizeVal = emitConstDimT(builder, output->dims().size());
 
     auto *F = getFunction("convertTo",
                           {output->getElementType(), input->getElementType()});

--- a/lib/Optimizer/GraphOptimizer/Lower.cpp
+++ b/lib/Optimizer/GraphOptimizer/Lower.cpp
@@ -438,9 +438,9 @@ static void lowerLayerNormalizationNode(Function *F, CompilationContext &cctx,
   auto nodeName = LN.getName();
 
   // input shape -> {M, N} where N is the size of each layer to be normalized.
-  size_t N = std::accumulate(gamma.dims().begin(), gamma.dims().end(), 1,
-                             std::multiplies<size_t>());
-  size_t M = in.getType()->size() / N;
+  dim_t N = std::accumulate(gamma.dims().begin(), gamma.dims().end(), 1,
+                            std::multiplies<size_t>());
+  dim_t M = in.getType()->size() / N;
   in = F->createReshape(nodeName, in, {M, N})->getResult();
 
   // Compute mean and standard deviation for each layer using the formula from

--- a/tests/benchmark/BERTProxyLayerBench.cpp
+++ b/tests/benchmark/BERTProxyLayerBench.cpp
@@ -161,7 +161,7 @@ public:
         (float)(1.0 / std::sqrt(((double)hiddenSize_) / ((double)numHeads_)));
 
     // Softmax expected output. Not needed for inference
-    Tensor expected_Tensor(ElemKind::Int64ITy,
+    Tensor expected_Tensor(IndexElemKind,
                            {maxSequenceLength_ * batchSize_, 1});
     Constant *expected = mod->createConstant("expected", expected_Tensor);
 
@@ -192,7 +192,7 @@ public:
     // rowSizePerCore is the number of tokens assigned to each
     // core (each data-parallel chunk)
     auto rowSizePerCore = batchSizePerCore;
-    for (size_t i = 0; i < batchSizePerCore.size(); i++) {
+    for (dim_t i = 0; i < batchSizePerCore.size(); i++) {
       rowSizePerCore[i] = batchSizePerCore[i] * maxSequenceLength_;
     }
 

--- a/tests/models/onnxModels/dim32/sparseToDense.onnxtxt
+++ b/tests/models/onnxModels/dim32/sparseToDense.onnxtxt
@@ -1,0 +1,85 @@
+ir_version: 3
+producer_name: "backend-test"
+graph {
+  node {
+    input: "indices"
+    input: "values"
+    input: "dataToInferDim"
+    output: "y"
+    op_type: "SparseToDense"
+  }
+  name: "test_SparseToDense"
+  input {
+    name: "indices"
+    type {
+      tensor_type {
+        elem_type: 6
+        shape {
+          dim {
+            dim_value: 5
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "values"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 5
+          }
+          dim {
+            dim_value: 10
+          }
+          dim {
+            dim_value: 5
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "dataToInferDim"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 20 
+          }
+          dim {
+            dim_value: 10
+          }
+          dim {
+            dim_value: 5
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 20 
+          }
+          dim {
+            dim_value: 10
+          }
+          dim {
+            dim_value: 5
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 9
+}

--- a/tests/unittests/RecommendationSystemTest.cpp
+++ b/tests/unittests/RecommendationSystemTest.cpp
@@ -668,7 +668,7 @@ protected:
     auto *reshapeDot = F->createReshape(
         "reshapeDot", dot,
         {bottomMLP.dims()[0],
-         (dim_t)embeddings.size() * embeddings.size()}); // {MB, n^2}
+         (dim_t)(embeddings.size() * embeddings.size())}); // {MB, n^2}
     NodeValue interact = F->createConcat("interact", {reshapeDot, bottomMLP},
                                          1); // {MB, n^2 + embDim}
 

--- a/utils/scripts/gen_onnx_lstm_model.py
+++ b/utils/scripts/gen_onnx_lstm_model.py
@@ -212,8 +212,11 @@ def gen_lstm_onnx_test_model(model_path, seq_length, batch_size, hidden_size, in
             dir_idx)
 
         def f(x): return (1 / (1 + np.exp(-x)))
+
         def g(x): return np.tanh(x)
+
         def h(x): return np.tanh(x)
+
         def mm(x, w): return np.matmul(x, w.transpose())
         Ht = np.reshape(initial_h[dir_idx, :, :], [batch_size, hidden_size])
         Ct = np.reshape(initial_c[dir_idx, :, :], [batch_size, hidden_size])


### PR DESCRIPTION
Summary:

There were a few remaining 32b dim_t issues in recent code. E.g. one case of wrong vector initialization in the onnximporter/exporter.

Also adds a new circleci test for 32B_DIM_T that also builds the OpenCL backend to catch most of the size_t/64b assumed index code additions first hand. 

Test Plan:

Tested with LLVM7 64b/32b and pocl 64b/32b.
