### PR TITLE
remove shared_ptr from Tensor DeviceResidencyInfo

### DIFF
--- a/lib/Base/Tensor.cpp
+++ b/lib/Base/Tensor.cpp
@@ -656,15 +656,22 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Tensor *t) {
 
 void Tensor::moveToDevice(DeviceTensorTransferManager *deviceManager,
                           void *locationContext) {
-  residencyInfoP_->deviceManager_ = deviceManager;
-  residencyInfoP_->locationContext_ = locationContext;
-  residencyInfoP_->tensorResidency_ =
+  if (deviceResidency_ == nullptr) {
+    deviceResidency_ = new DeviceResidencyInfo();
+  }
+  deviceResidency_->deviceManager_ = deviceManager;
+  deviceResidency_->locationContext_ = locationContext;
+  deviceResidency_->tensorResidency_ =
       DeviceResidencyInfo::TensorResidency::Device;
 }
 
 void Tensor::ensureOnHost() {
-  if (residencyInfoP_->isDeviceResident()) {
-    residencyInfoP_->deviceManager_->transferFromDevice(*this);
+  if (deviceResidency_ == nullptr) {
+    // already on host.
+    return;
+  }
+  if (deviceResidency_->isDeviceResident()) {
+    deviceResidency_->deviceManager_->transferFromDevice(*this);
   }
   assert(!isDeviceResident());
 }

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -208,6 +208,8 @@ onnxStatus Graph::setIOAndRun(uint32_t inputsCount,
                     << inOnnxTensor.name;
         return ONNXIFI_STATUS_INTERNAL_ERROR;
       }
+      // We want fresh DeviceResidencyInfo for this fresh Tensor.
+      inputTensor->resetDeviceInfo();
       // Copy the input from onnxTensorDescriptor unless it has a NULL buffer
       // pointer (which is a valid case if the tensor is empty).
       if (inOnnxBuffer) {


### PR DESCRIPTION
In the Tensor, we store the DeviceResidencyInfo in a shared pointer to easily manage lifetime based on all unowned tensors that refer to the same buffer on device. The shared_ptr overhead is significant in situations when we create a lot of unowned tensors. Instead, we can handle DeviceResidencyInfo the same way we treat the data buffer in Tensor: unownedTensors keep raw pointers, and the master Tensor manages creation and destruction. This has been safe for buffers and so should be safe for DRI.

Test plan: unit tests generally & on a device that supports resident Tensors.

Differential Revision: D18814052

