### PR TITLE
Add RWQSLWSAllSame_Float16 test

### DIFF
--- a/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
+++ b/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
@@ -58,6 +58,9 @@ struct PrecisionConfiguration {
   /// If clipFP16, whether to skip clipping inputs of Nodes.
   bool clipFP16SkipInputs{false};
 
+  /// Whether to force FP16 accumulation for the SLS family of ops.
+  bool forceFP16AccumSLS{false};
+
   /// Used during Quantization and convertToFP16 to keep the original precision
   /// of specific node kinds (i.e. quantization/FP16 conversion would be skipped
   /// for any node kinds found here). Used during profiling to prevent nodes

--- a/include/glow/Optimizer/GraphOptimizer/GraphOptimizer.h
+++ b/include/glow/Optimizer/GraphOptimizer/GraphOptimizer.h
@@ -70,6 +70,13 @@ Error optimizeFunction(Function *F, const Backend &B, CompilationContext &cctx);
 /// compiler error.
 Error optimizeFunctionBeforeLowering(Function *F, CompilationContext &cctx);
 
+/// Helper function that may transform \p F given preferences of \p cctx and
+/// \p B. The specific transformations are done based on the
+/// PrecisionConfiguration found in \p cctx. This could include quantization,
+/// profiling, and FP16 conversion.
+void transformForPrecisionMode(const Backend &B, Function *F,
+                               CompilationContext &cctx);
+
 /// Perform a compile-time constant folding of the node \p N.
 /// \returns list of constants which are the result of the constant-folding.
 /// These constants correspond to results of the node. If no constant folding

--- a/lib/Backends/CPU/tests/CPUOperatorTest.cpp
+++ b/lib/Backends/CPU/tests/CPUOperatorTest.cpp
@@ -166,6 +166,8 @@ std::set<std::string> glow::backendTestBlacklist = {
     "rowwiseQuantizedSLWSTest/0",
     "SLSAllZeroLengths_Float16/0",
     "FusedRWQSLSAllZeroLengths_Float16/0",
+    "RWQSLWSAllSame_Float16_AccumFP16/0",
+    "RWQSLWSAllSame_Float16_AccumFP32/0",
     "SigmoidSweep_Float16/0",
     "TanHSweep_Float16/0",
     "RepeatedSLSWithPartialTensors/0",

--- a/lib/Backends/CPU/tests/CPUOperatorTest.cpp
+++ b/lib/Backends/CPU/tests/CPUOperatorTest.cpp
@@ -108,6 +108,8 @@ std::set<std::string> glow::backendTestBlacklist = {
     "FusedRowwiseQuantizedSparseLengthsWeightedSum_ConvertedFloat16/0",
     "FusedRowwiseQuantizedSparseLengthsWeightedSum_ConvertedFloat16_"
     "NoFusedConvert/0",
+    "FusedRowwiseQuantizedSparseLengthsWeightedSum_ConvertedFloat16_"
+    "NoFusedConvert_FP32Accum/0",
     "SLWSTwoColumn_Float16_AccumFloat/0",
     "SparseToDenseMask1/0",
     "SparseToDenseMask2/0",

--- a/lib/Backends/Habana/tests/HabanaOperatorTest.cpp
+++ b/lib/Backends/Habana/tests/HabanaOperatorTest.cpp
@@ -164,6 +164,8 @@ std::set<std::string> glow::backendTestBlacklist = {
     "back2/0",
     "FusedRowwiseQuantizedSparseLengthsWeightedSum_ConvertedFloat16_"
     "NoFusedConvert/0",
+    "FusedRowwiseQuantizedSparseLengthsWeightedSum_ConvertedFloat16_"
+    "NoFusedConvert_FP32Accum/0",
     "FusedRowwiseQuantizedSparseLengthsWeightedSum_Float16_AccumFloat/0",
     "FusedRowwiseQuantizedSparseLengthsWeightedSum_Float16_AccumFloat16/0",
     "EmbeddingBagByteRowwiseOffsets_ConvertedFloat16/0",

--- a/lib/Backends/Habana/tests/HabanaOperatorTest.cpp
+++ b/lib/Backends/Habana/tests/HabanaOperatorTest.cpp
@@ -269,6 +269,8 @@ std::set<std::string> glow::backendTestBlacklist = {
     "RowwiseQuantizedSparseLengthsWeightedSum_Float/0",
     "RowwiseQuantizedSparseLengthsWeightedSum_Float16_AccumFloat/0",
     "RowwiseQuantizedSparseLengthsWeightedSum_Float16_AccumFloat16/0",
+    "RWQSLWSAllSame_Float16_AccumFP16/0",
+    "RWQSLWSAllSame_Float16_AccumFP32/0",
     "ScatterAddNDimensionalDuplicatingIndices/0",
     "ScatterAddNDimensionalSimple/0",
     "ScatterAddQuantized/0",

--- a/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
@@ -77,6 +77,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "ResizeNearest_Int8/0",
     "rowwiseQuantizedFCTest_Int8_BiasInt32/0",
     "rowwiseQuantizedFCTest_Int8_BiasInt8/0",
+    "RWQSLWSAllSame_Float16_AccumFP32/0",
     "ScatterAddNDimensionalDuplicatingIndices/0",
     "ScatterAddNDimensionalSimple/0",
     "ScatterAddQuantized/0",

--- a/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
@@ -47,6 +47,8 @@ std::set<std::string> glow::backendTestBlacklist = {
     "FullyConnected_Int16_BiasInt16/0",
     "FullyConnected_Int16_BiasInt32/0",
     "FullyConnected_Int8_BiasInt8/0",
+    "FusedRowwiseQuantizedSparseLengthsWeightedSum_ConvertedFloat16_"
+    "NoFusedConvert/0",
     "GroupConv3D/0",
     "GroupwiseQuantizedConvolution/0",
     "insertTensorTest/0",
@@ -152,7 +154,7 @@ struct EmulatorOnlyTests {
           "FusedRowwiseQuantizedSparseLengthsWeightedSum_ConvertedFloat16_"
           "back_",
           "FusedRowwiseQuantizedSparseLengthsWeightedSum_ConvertedFloat16_"
-          "NoFusedConvert/0",
+          "NoFusedConvert_FP32Accum/0",
           "to_back2/0",
           "GroupDilatedConvolution/0",
           "less_int32Cases/0",

--- a/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
@@ -192,6 +192,8 @@ std::set<std::string> glow::backendTestBlacklist = {
     "FusedRowwiseQuantizedSLWSTwoColumn_Fused4Bit_Float16_AccumFloat16/0",
     "FusedRowwiseQuantizedSparseLengthsWeightedSum_ConvertedFloat16_"
     "NoFusedConvert/0",
+    "FusedRowwiseQuantizedSparseLengthsWeightedSum_ConvertedFloat16_"
+    "NoFusedConvert_FP32Accum/0",
     "SLWSTwoColumn_Float16_AccumFloat/0",
     "SLSWithZeroLengths/0",
     "SparseToDense/0",

--- a/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
@@ -282,4 +282,6 @@ std::set<std::string> glow::backendTestBlacklist = {
     "GatherWithInt64PartialTensors/0",
     "GroupwiseQuantizedConvolution/0",
     "ParallelBatchMatMul_Float16/0",
+    "RWQSLWSAllSame_Float16_AccumFP16/0",
+    "RWQSLWSAllSame_Float16_AccumFP32/0",
 };

--- a/lib/Onnxifi/HostManagerOnnxifi.cpp
+++ b/lib/Onnxifi/HostManagerOnnxifi.cpp
@@ -35,6 +35,7 @@ bool GlowDumpDebugTraces = false;
 bool GlowSaturateHost = false;
 bool GlowFP16 = false;
 bool GlowFusedScaleOffsetFP16 = false;
+bool GlowForceSLSAccumFP16 = false;
 bool GlowClipFP16 = false;
 bool GlowUseSparseNNPartitioningScheme = false;
 
@@ -120,6 +121,10 @@ onnxStatus HostManagerBackend::addNetwork(std::unique_ptr<Module> module,
   if (GlowClipFP16) {
     precConfig.clipFP16 = GlowClipFP16;
     LOG(INFO) << "Clipping to fp16 enabled";
+  }
+  if (GlowForceSLSAccumFP16) {
+    precConfig.forceFP16AccumSLS = GlowForceSLSAccumFP16;
+    LOG(INFO) << "Forcing all SLS/SLWS ops to use FP16 accumulation enabled";
   }
   if (GlowDumpCompilationLog) {
     cctx.compilationLogPrefix = "glow-onnxifi";

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -317,14 +317,15 @@ using CreateAndInitFunction =
 /// use, if applicable. \p parallelCount represents the number of times to clone
 /// the Function inside itself, so that testing can be done on architectures
 /// that have parallel compute engines. The bias is quantized using the
-/// precision \p biasElemKind.
+/// precision \p biasElemKind. \p forceFP16AccumSLS is propagated into the
+/// precision config for compilation.
 void compareAgainstInterpreter(
     llvm::StringRef backendName, CreateAndInitFunction createAndInitFunction,
     ElemKind interpElemKind, ElemKind backendElemKind,
     float allowedError = 0.0001, unsigned parallelCount = 1,
     bool convertToRowwiseQuantization = false,
     quantization::Schema schema = quantization::Schema::Asymmetric,
-    ElemKind biasElemKind = ElemKind::Int32QTy);
+    ElemKind biasElemKind = ElemKind::Int32QTy, bool forceFP16AccumSLS = false);
 
 /// Given some \p FTP representing a Function with a single SaveNode and its
 /// Tensor output, duplicate the Nodes in the Function and their Placeholder

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -312,17 +312,17 @@ using CreateAndInitFunction =
 /// be gathered on the Interpreter, and then that profile will be used to
 /// quantize one or both. Otherwise if either is Float16Ty then the respective
 /// Function it will be converted using the Converter. If
-/// \p enableRowwiseQuantization then rowwise quantization will be used for
-/// nodes that support it. \p schema represents the quantization schema to use,
-/// if applicable. \p parallelCount represents the number of times to clone the
-/// Function inside itself, so that testing can be done on architectures that
-/// have parallel compute engines. The bias is quantized using the precision
-/// \p biasElemKind.
+/// \p convertToRowwiseQuantization then nodes supporting rowwise quantization
+/// will converted to use it. \p schema represents the quantization schema to
+/// use, if applicable. \p parallelCount represents the number of times to clone
+/// the Function inside itself, so that testing can be done on architectures
+/// that have parallel compute engines. The bias is quantized using the
+/// precision \p biasElemKind.
 void compareAgainstInterpreter(
     llvm::StringRef backendName, CreateAndInitFunction createAndInitFunction,
     ElemKind interpElemKind, ElemKind backendElemKind,
     float allowedError = 0.0001, unsigned parallelCount = 1,
-    bool enableRowwiseQuantization = false,
+    bool convertToRowwiseQuantization = false,
     quantization::Schema schema = quantization::Schema::Asymmetric,
     ElemKind biasElemKind = ElemKind::Int32QTy);
 

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -3860,8 +3860,8 @@ TEST_P(OperatorStatelessTest, ConvolutionDepth10_Int8_BiasInt8) {
   compareAgainstInterpreter(
       getBackendName(), createAndInitConvDepthTest<10>, ElemKind::FloatTy,
       ElemKind::Int8QTy, 0.03f, parCloneCountOpt,
-      /* enableRowwiseQuantization */ false, quantization::Schema::Asymmetric,
-      ElemKind::Int8QTy);
+      /* convertToRowwiseQuantization */ false,
+      quantization::Schema::Asymmetric, ElemKind::Int8QTy);
 }
 
 TEST_P(OperatorStatelessTest, ConvolutionDepth10_Int8_BiasInt32) {
@@ -3869,8 +3869,8 @@ TEST_P(OperatorStatelessTest, ConvolutionDepth10_Int8_BiasInt32) {
   compareAgainstInterpreter(
       getBackendName(), createAndInitConvDepthTest<10>, ElemKind::FloatTy,
       ElemKind::Int8QTy, 0.03f, parCloneCountOpt,
-      /* enableRowwiseQuantization */ false, quantization::Schema::Asymmetric,
-      ElemKind::Int32QTy);
+      /* convertToRowwiseQuantization */ false,
+      quantization::Schema::Asymmetric, ElemKind::Int32QTy);
 }
 
 TEST_P(OperatorStatelessTest, ConvolutionDepth10_Int16_BiasInt16) {
@@ -3878,8 +3878,8 @@ TEST_P(OperatorStatelessTest, ConvolutionDepth10_Int16_BiasInt16) {
   compareAgainstInterpreter(
       getBackendName(), createAndInitConvDepthTest<10>, ElemKind::FloatTy,
       ElemKind::Int16QTy, 0.0003f, parCloneCountOpt,
-      /* enableRowwiseQuantization */ false, quantization::Schema::Asymmetric,
-      ElemKind::Int16QTy);
+      /* convertToRowwiseQuantization */ false,
+      quantization::Schema::Asymmetric, ElemKind::Int16QTy);
 }
 
 TEST_P(OperatorStatelessTest, ConvolutionDepth10_Int16_BiasInt32) {
@@ -3887,8 +3887,8 @@ TEST_P(OperatorStatelessTest, ConvolutionDepth10_Int16_BiasInt32) {
   compareAgainstInterpreter(
       getBackendName(), createAndInitConvDepthTest<10>, ElemKind::FloatTy,
       ElemKind::Int16QTy, 0.0003f, parCloneCountOpt,
-      /* enableRowwiseQuantization */ false, quantization::Schema::Asymmetric,
-      ElemKind::Int32QTy);
+      /* convertToRowwiseQuantization */ false,
+      quantization::Schema::Asymmetric, ElemKind::Int32QTy);
 }
 
 static FunctionTensorPair
@@ -3996,8 +3996,8 @@ TEST_P(OperatorStatelessTest, FullyConnected_Int8_BiasInt8) {
   compareAgainstInterpreter(
       getBackendName(), createAndInitBasicFCTest, ElemKind::FloatTy,
       ElemKind::Int8QTy, 0.05f, parCloneCountOpt,
-      /* enableRowwiseQuantization */ false, quantization::Schema::Asymmetric,
-      ElemKind::Int8QTy);
+      /* convertToRowwiseQuantization */ false,
+      quantization::Schema::Asymmetric, ElemKind::Int8QTy);
 }
 
 /// Test Int8 FullyConnected with Int32 bias.
@@ -4006,8 +4006,8 @@ TEST_P(OperatorStatelessTest, FullyConnected_Int8_BiasInt32) {
   compareAgainstInterpreter(
       getBackendName(), createAndInitBasicFCTest, ElemKind::FloatTy,
       ElemKind::Int8QTy, 0.05f, parCloneCountOpt,
-      /* enableRowwiseQuantization */ false, quantization::Schema::Asymmetric,
-      ElemKind::Int32QTy);
+      /* convertToRowwiseQuantization */ false,
+      quantization::Schema::Asymmetric, ElemKind::Int32QTy);
 }
 
 /// Test Int16 FullyConnected with Int16 bias.
@@ -4016,8 +4016,8 @@ TEST_P(OperatorStatelessTest, FullyConnected_Int16_BiasInt16) {
   compareAgainstInterpreter(
       getBackendName(), createAndInitBasicFCTest, ElemKind::FloatTy,
       ElemKind::Int16QTy, 0.0005f, parCloneCountOpt,
-      /* enableRowwiseQuantization */ false, quantization::Schema::Asymmetric,
-      ElemKind::Int16QTy);
+      /* convertToRowwiseQuantization */ false,
+      quantization::Schema::Asymmetric, ElemKind::Int16QTy);
 }
 
 /// Test Int16 FullyConnected with Int32 bias.
@@ -4026,8 +4026,8 @@ TEST_P(OperatorStatelessTest, FullyConnected_Int16_BiasInt32) {
   compareAgainstInterpreter(
       getBackendName(), createAndInitBasicFCTest, ElemKind::FloatTy,
       ElemKind::Int16QTy, 0.0005f, parCloneCountOpt,
-      /* enableRowwiseQuantization */ false, quantization::Schema::Asymmetric,
-      ElemKind::Int32QTy);
+      /* convertToRowwiseQuantization */ false,
+      quantization::Schema::Asymmetric, ElemKind::Int32QTy);
 }
 
 TEST_P(OperatorTest, EntropyLossTest) {
@@ -8033,8 +8033,8 @@ TEST_P(OperatorTest,
 
 static void testRowwiseQuantizedSparseLengthsSum_ConvertedFloat16(
     glow::PlaceholderBindings &bindings, glow::Module &mod, glow::Function *F,
-    glow::ExecutionEngine &EE, float allowedError,
-    bool convertFusedToFP16 = true) {
+    glow::ExecutionEngine &EE, float allowedError, bool convertFusedToFP16,
+    bool useFP16AccumSLS) {
   CHECK_IF_ENABLED();
   /*
     DATA  =   [[2.0, -0.5, 13]]
@@ -8079,6 +8079,7 @@ static void testRowwiseQuantizedSparseLengthsSum_ConvertedFloat16(
   CompilationContext cctx;
   cctx.precisionConfig.convertToFP16 = true;
   cctx.precisionConfig.convertFusedToFP16 = convertFusedToFP16;
+  cctx.precisionConfig.forceFP16AccumSLS = useFP16AccumSLS;
   EE.compile(cctx);
   EE.run(bindings);
 
@@ -8102,7 +8103,16 @@ TEST_P(
   CHECK_IF_ENABLED();
   return testRowwiseQuantizedSparseLengthsSum_ConvertedFloat16(
       bindings_, mod_, F_, EE_, 0.02,
-      /* convertFusedToFP16*/ false);
+      /* convertFusedToFP16*/ false, /* useFP16AccumSLS */ true);
+}
+
+TEST_P(
+    OperatorTest,
+    FusedRowwiseQuantizedSparseLengthsWeightedSum_ConvertedFloat16_NoFusedConvert_FP32Accum) {
+  CHECK_IF_ENABLED();
+  return testRowwiseQuantizedSparseLengthsSum_ConvertedFloat16(
+      bindings_, mod_, F_, EE_, 0.02,
+      /* convertFusedToFP16*/ false, /* useFP16AccumSLS */ false);
 }
 
 TEST_P(OperatorTest,
@@ -8110,7 +8120,7 @@ TEST_P(OperatorTest,
   CHECK_IF_ENABLED();
   return testRowwiseQuantizedSparseLengthsSum_ConvertedFloat16(
       bindings_, mod_, F_, EE_, 0.02,
-      /* convertFusedToFP16*/ true);
+      /* convertFusedToFP16*/ true, /* useFP16AccumSLS */ true);
 }
 
 TEST_P(
@@ -8567,11 +8577,11 @@ TEST_P(OperatorTest, SLSWithZeroLengths) {
 }
 
 /// Helper to create an SLS test with all zero lengths, with and without fused
-/// rowwise quantization based on \p useRowwiseQuantization.
+/// rowwise quantization based on \p convertToRowwiseQuantization.
 static FunctionTensorPair
 createAndInitZeroLengthsSLSTest(glow::PlaceholderBindings &bindings,
                                 glow::ExecutionEngine &EE,
-                                bool useRowwiseQuantization) {
+                                bool convertToRowwiseQuantization) {
   auto &mod = EE.getModule();
   auto *F = mod.createFunction("main");
   constexpr dim_t embedWidth = 1000;
@@ -8590,7 +8600,7 @@ createAndInitZeroLengthsSLSTest(glow::PlaceholderBindings &bindings,
   LH.clear(0);
 
   Node *R = nullptr;
-  if (useRowwiseQuantization) {
+  if (convertToRowwiseQuantization) {
     R = F->createFusedRowwiseQuantizedSparseLengthsWeightedSum(
         "RQSLWS", data, weights, indices, lengths);
   } else {
@@ -8612,7 +8622,7 @@ TEST_P(OperatorTest, FusedRWQSLSAllZeroLengths_Float) {
   compareAgainstInterpreter(
       getBackendName(),
       std::bind(createAndInitZeroLengthsSLSTest, std::placeholders::_1,
-                std::placeholders::_2, /* useRowwiseQuantization */ true),
+                std::placeholders::_2, /* convertToRowwiseQuantization */ true),
       ElemKind::FloatTy, ElemKind::FloatTy);
 }
 
@@ -8623,7 +8633,7 @@ TEST_P(OperatorTest, FusedRWQSLSAllZeroLengths_Float16) {
   compareAgainstInterpreter(
       getBackendName(),
       std::bind(createAndInitZeroLengthsSLSTest, std::placeholders::_1,
-                std::placeholders::_2, /* useRowwiseQuantization */ true),
+                std::placeholders::_2, /* convertToRowwiseQuantization */ true),
 
       ElemKind::Float16Ty, ElemKind::Float16Ty);
 }
@@ -8632,23 +8642,25 @@ TEST_P(OperatorTest, FusedRWQSLSAllZeroLengths_Float16) {
 TEST_P(OperatorTest, SLSAllZeroLengths_Float) {
   CHECK_IF_ENABLED();
 
-  compareAgainstInterpreter(
-      getBackendName(),
-      std::bind(createAndInitZeroLengthsSLSTest, std::placeholders::_1,
-                std::placeholders::_2, /* useRowwiseQuantization */ false),
-      ElemKind::FloatTy, ElemKind::FloatTy);
+  compareAgainstInterpreter(getBackendName(),
+                            std::bind(createAndInitZeroLengthsSLSTest,
+                                      std::placeholders::_1,
+                                      std::placeholders::_2,
+                                      /* convertToRowwiseQuantization */ false),
+                            ElemKind::FloatTy, ElemKind::FloatTy);
 }
 
 /// Test SLS when all "lengths" inputs are zero in Float16Ty.
 TEST_P(OperatorTest, SLSAllZeroLengths_Float16) {
   CHECK_IF_ENABLED();
 
-  compareAgainstInterpreter(
-      getBackendName(),
-      std::bind(createAndInitZeroLengthsSLSTest, std::placeholders::_1,
-                std::placeholders::_2, /* useRowwiseQuantization */ false),
+  compareAgainstInterpreter(getBackendName(),
+                            std::bind(createAndInitZeroLengthsSLSTest,
+                                      std::placeholders::_1,
+                                      std::placeholders::_2,
+                                      /* convertToRowwiseQuantization */ false),
 
-      ElemKind::Float16Ty, ElemKind::Float16Ty);
+                            ElemKind::Float16Ty, ElemKind::Float16Ty);
 }
 
 TEST_P(OperatorTest, SparseToDense) {
@@ -9283,7 +9295,7 @@ TEST_P(OperatorStatelessTest, rowwiseQuantizedFCTest_Int8_BiasInt8) {
   compareAgainstInterpreter(
       getBackendName(), createAndInitBasicRowwiseFCTest, ElemKind::FloatTy,
       ElemKind::Int8QTy, 0.06f, parCloneCountOpt,
-      /* enableRowwiseQuantization */ true, quantization::Schema::Asymmetric,
+      /* convertToRowwiseQuantization */ true, quantization::Schema::Asymmetric,
       ElemKind::Int8QTy);
 }
 
@@ -9293,7 +9305,7 @@ TEST_P(OperatorStatelessTest, rowwiseQuantizedFCTest_Int8_BiasInt32) {
   compareAgainstInterpreter(
       getBackendName(), createAndInitBasicRowwiseFCTest, ElemKind::FloatTy,
       ElemKind::Int8QTy, 0.06f, parCloneCountOpt,
-      /* enableRowwiseQuantization */ true, quantization::Schema::Asymmetric,
+      /* convertToRowwiseQuantization */ true, quantization::Schema::Asymmetric,
       ElemKind::Int32QTy);
 }
 
@@ -9303,7 +9315,7 @@ TEST_P(OperatorStatelessTest, rowwiseQuantizedFCTestSymmetric) {
   compareAgainstInterpreter(
       getBackendName(), createAndInitBasicRowwiseFCTest, ElemKind::FloatTy,
       ElemKind::Int8QTy, 0.07f, parCloneCountOpt,
-      /* enableRowwiseQuantization */ true, quantization::Schema::Symmetric);
+      /* convertToRowwiseQuantization */ true, quantization::Schema::Symmetric);
 }
 
 static FunctionTensorPair
@@ -9360,7 +9372,7 @@ TEST_P(OperatorStatelessTest, rowwiseQuantizedSLWSTest) {
   compareAgainstInterpreter(getBackendName(), createAndInitBasicSLWSTest,
                             ElemKind::FloatTy, ElemKind::Int8QTy, 0.01f,
                             parCloneCountOpt,
-                            /* enableRowwiseQuantization */ true);
+                            /* convertToRowwiseQuantization */ true);
 }
 
 static SaveNode *setupBucketNode(Function *F, PlaceholderBindings &bindings,


### PR DESCRIPTION
Summary: Updated `compareAgainstInterpreter()` to by default use FP16 accumulation for supporting this test.

Differential Revision: D18800305

