### PR TITLE
Added deferred loading support to interpreter backend

### DIFF
--- a/lib/Backends/Interpreter/InterpreterDeviceManager.h
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.h
@@ -29,6 +29,10 @@ class InterpreterDeviceManager : public QueueBackedDeviceManager {
   /// Compiled function list by name.
   FunctionMapTy functions_;
 
+  /// Map from PH to functionName for static placeholders.
+  std::unordered_map<Placeholder *, std::vector<std::string>>
+      staticPlaceholderToFunctions_;
+
   /// String constant for logging number of in-use devices.
   static constexpr const char *kDevicesUsedInterpreter =
       "glow.devices_used.interpreter";
@@ -60,6 +64,12 @@ public:
   /// Returns the DeviceInfo for this device containing peak limits for
   /// compute and bandwidths (used in partitioning).
   DeviceInfo getDeviceInfo() const override;
+
+  /// Copies the contents of Tensor \p T to the device resource allocated to
+  /// Placeholder \p PH. once finished calls \p resultCB with the result of the
+  /// operation.
+  void transferStaticPlaceholderToDevice(
+      Placeholder *PH, Tensor *T, std::function<void(Error)> resultCB) override;
 
 protected:
   void addNetworkImpl(const Module *module, FunctionMapTy functions,

--- a/lib/Backends/Interpreter/InterpreterFunction.cpp
+++ b/lib/Backends/Interpreter/InterpreterFunction.cpp
@@ -50,6 +50,12 @@ void InterpreterFunction::collectConstants(const Module *module) {
   }
 }
 
+void InterpreterFunction::addConstant(std::string name, Tensor *T) {
+  Tensor *newTensor = new Tensor;
+  newTensor->assign(T);
+  constants_[name] = newTensor;
+}
+
 Error InterpreterFunction::execute(ExecutionContext *context) {
   BoundInterpreterFunction boundFunc(constants_);
   auto res = boundFunc.execute(F_.get(), context);

--- a/lib/Backends/Interpreter/InterpreterFunction.h
+++ b/lib/Backends/Interpreter/InterpreterFunction.h
@@ -62,6 +62,10 @@ public:
   /// Collects constants for runtime.
   void collectConstants(const Module *module) override;
 
+  /// Add a constant to the function, this is used for loading static
+  /// placeholders.
+  void addConstant(std::string name, Tensor *T);
+
   /// Get reference to IR function.
   IRFunction *getIR() { return F_.get(); }
 

--- a/lib/Backends/Interpreter/tests/InterpreterDeferredWeightLoaderTest.cpp
+++ b/lib/Backends/Interpreter/tests/InterpreterDeferredWeightLoaderTest.cpp
@@ -17,6 +17,4 @@
 
 using namespace glow;
 
-std::set<std::string> glow::backendTestBlacklist = {
-    "staticPlaceholderInference/0",
-};
+std::set<std::string> glow::backendTestBlacklist = {};


### PR DESCRIPTION
Summary:
This adds the plumbing for the interpreter device manager to support deferred loading of static placeholders.

Documentation:

Test Plan: enabled deferredWeightLoaderTest for interpreter backend.