### PR TITLE
Add Quantize and convertToFP16 support to large model loading

### DIFF
--- a/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
+++ b/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
@@ -78,6 +78,11 @@ struct OptimizationOptions {
   /// Quantize, Dequantize nodes).. Note that this must be accompanied by
   /// modifying the Tensors backing Placeholders at runtime.
   bool foldElemKindConversionIntoIO{false};
+
+  /// If true this will fold convertTo and Quantize nodes into only static
+  /// placeholders. The conversion of the Tensors will be handled by the
+  /// provisioner.
+  bool foldStaticPlaceholderConversions{false};
 };
 
 /// Context for compilation.

--- a/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
+++ b/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
@@ -43,7 +43,8 @@ FUN_PASS(FoldLeakyRelu)
 FUN_PASS(FoldChannelShuffle)
 FUN_PASS(ConstantFold)
 FUN_PASS(FoldTileAddIntoBatchedAdd)
-FUN_PASS(FoldElemKindConversionIntoIO)
+FUN_PASS(FoldElemKindConversionIntoOutputs)
+FUN_PASS(FoldElemKindConversionIntoInputs)
 
 // NOTE: This pass must be last; it's used to count the total number of passes.
 FUN_PASS(EmptyPass)

--- a/lib/Backends/CPU/tests/CPUDeferredWeightLoaderTest.cpp
+++ b/lib/Backends/CPU/tests/CPUDeferredWeightLoaderTest.cpp
@@ -19,4 +19,5 @@ using namespace glow;
 
 std::set<std::string> glow::backendTestBlacklist = {
     "staticPlaceholderInference/0",
+    "FP16StaticPlaceholderInference/0",
 };

--- a/lib/Backends/NNPI/tests/NNPIDeferredWeightLoaderTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIDeferredWeightLoaderTest.cpp
@@ -19,4 +19,5 @@ using namespace glow;
 
 std::set<std::string> glow::backendTestBlacklist = {
     "staticPlaceholderInference/0",
+    "FP16StaticPlaceholderInference/0",
 };

--- a/lib/Backends/OpenCL/tests/OpenCLDeferredWeightLoaderTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLDeferredWeightLoaderTest.cpp
@@ -17,4 +17,6 @@
 
 using namespace glow;
 
-std::set<std::string> glow::backendTestBlacklist = {};
+std::set<std::string> glow::backendTestBlacklist = {
+    "FP16StaticPlaceholderInference/0",
+};

--- a/lib/Onnxifi/HostManagerOnnxifi.cpp
+++ b/lib/Onnxifi/HostManagerOnnxifi.cpp
@@ -90,6 +90,9 @@ onnxStatus HostManagerBackend::addNetwork(std::unique_ptr<Module> module,
     }
     loader->setSrc(deferredBlobReader);
     cctx.deferredWeightLoader = loader;
+    // Signal that we want to fold convertTo and Quantize into static
+    // Placeholders.
+    cctx.optimizationOpts.foldStaticPlaceholderConversions = true;
   }
 
   if (GlowFP16) {

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -3142,21 +3142,21 @@ bool FoldTileAddIntoBatchedAdd::run(Function *F,
   return changed;
 }
 
-/// Fold ElemKind conversion nodes (ConvertTo, Quantize, Dequantize) into
-/// single-user Placeholders and SaveNodes. Note that this changes the semantics
+/// Fold ElemKind conversion nodes (ConvertTo, Quantize) into
+/// single-user Placeholders. Note that this changes the semantics
 /// of the IO of the Function and so must be done carefully, i.e. should always
 /// be opt-in and done alongside conversion of corresponding Tensors in
-/// PlaceholderBindings.
-bool FoldElemKindConversionIntoIO::run(Function *F,
-                                       const CompilationContext &cctx) {
+/// PlaceholderBindings. If
+/// cctx.optimizationOpts.foldStaticPlaceholderConversions is set this will
+/// only change Placeholders marked as static.
+bool FoldElemKindConversionIntoInputs::run(Function *F,
+                                           const CompilationContext &cctx) {
   LOG_SCOPE(F->getLogContext(), getName());
 
-  std::unordered_set<SaveNode *> deadSaves;
-
   bool changed = false;
-  // Since we will be adding in new SaveNodes, reverse iterate to be safe.
   auto &nodes = F->getNodes();
-  for (auto it = nodes.rbegin(), e = nodes.rend(); it != e; it++) {
+
+  for (auto it = nodes.begin(), e = nodes.end(); it != e; it++) {
     Node *N = &*it;
     // Handle conversion of inputs (conversion of Placeholders):
     ConvertToNode *CTN = llvm::dyn_cast<ConvertToNode>(N);
@@ -3165,6 +3165,12 @@ bool FoldElemKindConversionIntoIO::run(Function *F,
       NodeValue in = CTN ? CTN->getInput() : QN->getInput();
       Placeholder *P = llvm::dyn_cast<Placeholder>(in);
       if (!P || P->getUsers().size() != 1) {
+        continue;
+      }
+      // If foldElemKindConversionIntoIO is not set and this is not a static
+      // placeholder then skip.
+      if (!cctx.optimizationOpts.foldElemKindConversionIntoIO &&
+          !P->isStatic()) {
         continue;
       }
 
@@ -3181,6 +3187,25 @@ bool FoldElemKindConversionIntoIO::run(Function *F,
       changed = true;
       continue;
     }
+  }
+  return changed;
+}
+
+/// Fold ElemKind conversion nodes (ConvertTo, Dequantize) into SaveNodes. Note
+/// that this changes the semantics of the IO of the Function and so must be
+/// done carefully, i.e. should always be opt-in and done alongside conversion
+/// of corresponding Tensors in PlaceholderBindings.
+bool FoldElemKindConversionIntoOutputs::run(Function *F,
+                                            const CompilationContext &cctx) {
+  LOG_SCOPE(F->getLogContext(), getName());
+
+  std::unordered_set<SaveNode *> deadSaves;
+
+  bool changed = false;
+  // Since we will be adding in new SaveNodes, reverse iterate to be safe.
+  auto &nodes = F->getNodes();
+  for (auto it = nodes.rbegin(), e = nodes.rend(); it != e; it++) {
+    Node *N = &*it;
 
     // Handle conversion of outputs (SaveNodes + Placeholders):
     if (SaveNode *SN = llvm::dyn_cast<SaveNode>(N)) {
@@ -3374,11 +3399,17 @@ Error glow::optimizeFunction(Function *F, const Backend &B,
   // Optimize the graph again now that we have a lowered representation.
   ::glow::optimize(F, cctx);
 
-  // If requested, fold ElemKind conversion Nodes into inputs and outputs
-  // (Placeholders and SaveNodes).
-  if (cctx.optimizationOpts.foldElemKindConversionIntoIO) {
-    FunctionPassManager FPM("FoldElemKindConversionIntoIO",
-                            {FunctionPassID::FoldElemKindConversionIntoIO});
+  // If requested fold ElemKind conversion Nodes into static Placeholders,
+  // inputs, and outputs (Placeholders and SaveNodes).
+  if (cctx.optimizationOpts.foldStaticPlaceholderConversions ||
+      cctx.optimizationOpts.foldElemKindConversionIntoIO) {
+    FunctionPassPipeline pipeline{
+        FunctionPassID::FoldElemKindConversionIntoInputs};
+
+    if (cctx.optimizationOpts.foldElemKindConversionIntoIO) {
+      pipeline.pushBack({FunctionPassID::FoldElemKindConversionIntoOutputs});
+    }
+    FunctionPassManager FPM("FoldElemKindConversionIntoIO", pipeline);
     if (FPM.run(F, cctx)) {
       ::glow::optimize(F, cctx);
     }


### PR DESCRIPTION


Summary:
This adds support for loading deferred weights when they need to be quantized or converted to FP16. 
This PR splits foldElemKindConversionIntoIO into Input and Output and modified Input pass to support selectively folding static placeholders only and updated the Provisioner to check if a conversion is needed before transferring the weight to the device.

Documentation:

Test Plan: added new FP16StaticPlaceholderInference test to test conversion flow.