### PR TITLE
[GraphOptimizer] Do transformPostLowering in a loop

### DIFF
--- a/lib/Backends/OpenCL/Transforms.cpp
+++ b/lib/Backends/OpenCL/Transforms.cpp
@@ -65,6 +65,14 @@ bool OCLBackend::transformPostLowering(Function *F,
         continue;
       }
 
+      // We need to replace both of the MaxPool results with their NCHW
+      // counterpart in order to get rid of the old node. There appears to be a
+      // bug in the implementation of the result(1) portion of the optimized
+      // kernel, if getArgmax got users - bail.
+      if (PMN->getArgmax().getNumUsers() > 0) {
+        continue;
+      }
+
       auto results = convertMaxPoolToNCHWPool(PMN, F);
       PMN->getResult().replaceAllUsesOfWith(results.first);
       changed = true;

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -3385,7 +3385,7 @@ Error glow::optimizeFunction(Function *F, const Backend &B,
   }
 
   // Allow the backend to transform the graph after lowering.
-  if (B.transformPostLowering(F, cctx)) {
+  while (B.transformPostLowering(F, cctx)) {
     // If the backend made changes, optimize the graph again. Perform only
     // passes that the Backend has requested so we do not interfere with the
     // backend's transformations.


### PR DESCRIPTION
Summary:

Iterate to a fixed point instead of doing the post-lowering once. anywhere we iterate to a fixed point we need to dce in between passes or else we keep optimizing dead code.