### PR TITLE
Make generic FusedActivation pass

### DIFF
--- a/include/glow/Backend/Backend.h
+++ b/include/glow/Backend/Backend.h
@@ -161,6 +161,11 @@ public:
   /// for multiple requests.
   virtual bool supportsStaticPlaceholders() const { return false; }
 
+  /// \returns whether the backend supports fusing \p activation into \p parent.
+  virtual bool supportsFusedActivation(Node *parent, Node *activation) const {
+    return false;
+  }
+
   /// \returns true if Backend generated Instruction for Node \p N,
   /// using IRGenVisitor \p irgen.
   virtual bool generateInst(Node *N, IRGenVisitor &irgen) const {

--- a/include/glow/Optimizer/GraphOptimizer/GraphOptimizer.h
+++ b/include/glow/Optimizer/GraphOptimizer/GraphOptimizer.h
@@ -36,8 +36,7 @@ void optimize(Function *F, CompilationMode mode);
 void optimize(Function *F, CompilationContext &cctx, const Backend &B);
 
 /// Fold nodes that were expressed lowered in the input model.
-void fold(Function *F, CompilationContext &cctx);
-void fold(Function *F, CompilationMode mode);
+void fold(Function *F, CompilationContext &cctx, const Backend *B = nullptr);
 
 /// Lower the high-level neural network nodes found in \p F into low-level
 /// linear algebra operators. If \p B is not a nullptr then it can prevent

--- a/tools/ClassGen/NodeBuilder.cpp
+++ b/tools/ClassGen/NodeBuilder.cpp
@@ -58,6 +58,15 @@ NodeBuilder &NodeBuilder::addMember(MemberType type, const std::string &name,
   return addMember(*typeInfo, name, addSetter);
 }
 
+NodeBuilder &NodeBuilder::addFusedActivation() {
+  return addMember(MEMBER_TYPE_INFO(glow::FusedActivation), "FusedActivation",
+                   /* addSetter */ true)
+      .addExtraMethod(
+          "bool hasFusedActivation() const;",
+          "bool ConvolutionNode::hasFusedActivation() const { return "
+          "getFusedActivation() != FusedActivation::NONE; }");
+}
+
 void NodeBuilder::emitMemberForwardDecls(std::ostream &os) const {
   for (const auto &mem : members_) {
     const std::string &forwardDecl = (mem.first).forwardDecl;

--- a/tools/ClassGen/NodeBuilder.h
+++ b/tools/ClassGen/NodeBuilder.h
@@ -179,6 +179,10 @@ public:
   /// the same name.
   NodeBuilder &addGradient();
 
+  /// Helper to add a FusedActivation Member to this node, along with getters
+  /// and setters.
+  NodeBuilder &addFusedActivation();
+
   ~NodeBuilder();
 
 private:

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -86,11 +86,7 @@ int main(int argc, char **argv) {
       .addMember(MemberType::Unsigned, "Group")
       .addMember(MemberType::Unsigned, "Dilation")
       .addMember(MEMBER_TYPE_INFO(glow::ConvolutionLayout), "Layout")
-      .addMember(MEMBER_TYPE_INFO(glow::FusedActivation), "FusedActivation")
-      .addExtraMethod(
-          "bool hasFusedActivation() const;",
-          "bool ConvolutionNode::hasFusedActivation() const { return "
-          "getFusedActivation() != FusedActivation::NONE; }")
+      .addFusedActivation()
       .addResultFromCtorArg()
       .addGradient()
       .setDocstring(


### PR DESCRIPTION
Summary: Add `Backend::supportsFusedActivation()` which is queried to see if the backend supports fusing a Node with some activation. If so it performs that fusion.

Differential Revision: D18838714

