### PR TITLE
(trivial) trace_parser.py utility: hide runtime events from stats by default

### DIFF
--- a/utils/trace_parser.py
+++ b/utils/trace_parser.py
@@ -74,7 +74,7 @@ class Event:
         return (self.end - self.start) - self.child_time
 
 
-def loadEvents(filename):
+def loadEvents(filename, runtimeEvents):
     """ Load the json trace file and create Events. """
     trace = None
     with open(filename) as f:
@@ -92,6 +92,8 @@ def loadEvents(filename):
                     optype = line["args"]["type"]
                 elif "kind" in line["args"]:
                     optype = line["args"]["kind"]
+            if not runtimeEvents and optype == "runtime":
+                continue
             end = 0
             if evtype == "X":
                 end = start + int(line["dur"])
@@ -169,9 +171,10 @@ def main():
                         help='filename for trace file to load')
     parser.add_argument("--layers", action='store_true')
     parser.add_argument("--kinds", action='store_true')
+    parser.add_argument("--runtime", action='store_true')
 
     args = parser.parse_args()
-    events = loadEvents(args.filename)
+    events = loadEvents(args.filename, args.runtime)
 
     # Stack events so we can determine selfTime.
     stacked = stackEvents(events)


### PR DESCRIPTION
Summary: I use the trace_parser script to get a high level view of how much change a particular optimization made. Here's a flag to remove the "runtime" events since they always dominate the trace (as they overlap the operator based events).

Documentation: nah

Test Plan:

With flag:
```
❯ python3.6 ~/work/glow/utils/trace_parser.py --kinds --runtime resnet1-ocl.json
runtime 6300 events, mean: 407.08 us, stddev: 6.21 ms, total: 2.56 s (49.75%)
conv_forward_mem 5300 events, mean: 412.16 us, stddev: 462.59 us, total: 2.18 s (42.37%)
copy 400 events, mean: 394.60 us, stddev: 355.72 us, total: 157.84 ms (3.06%)
elementmaxW 4900 events, mean: 16.65 us, stddev: 9.08 us, total: 81.59 ms (1.58%)
...
```
Without flag:
```
❯ python3.6 ~/work/glow/utils/trace_parser.py --kinds resnet1-ocl.json
conv_forward_mem 5300 events, mean: 419.14 us, stddev: 458.52 us, total: 2.22 s (84.10%)
copy 400 events, mean: 394.60 us, stddev: 355.72 us, total: 157.84 ms (5.98%)
elementmaxW 4900 events, mean: 17.90 us, stddev: 14.84 us, total: 87.70 ms (3.32%)
softmaxW 100 events, mean: 779.83 us, stddev: 54.54 us, total: 77.98 ms (2.95%)
...
```
