### PR TITLE
[trivial] improve names of grad nodes

### DIFF
--- a/tools/ClassGen/NodeBuilder.cpp
+++ b/tools/ClassGen/NodeBuilder.cpp
@@ -616,7 +616,7 @@ NodeBuilder &NodeBuilder::addGradient() {
   std::stringstream ss;
   ss << "\n" + name_ + "GradNode *" + name_
      << "Node::getGrad(GraphGradMapper &builder) {\n"
-     << "  auto *x = new " + name_ + "GradNode(getName()";
+     << "  auto *x = new " + name_ + "GradNode(getName().str() + \"_grad\"";
 
   if (enum_.size()) {
     ss << ", (" << name_ << "GradNode::Mode)getMode()";


### PR DESCRIPTION
Summary: When differentiating the graph, grad nodes are created with the same name as the original node and end up with a generally unclear uniqued name (e.g. `theNode`'s grad node might be `theNode__1`). This gets worse if the original node's name was already uniqued, and the grad node is replaced during optimization - it's definitely not impossible to get a situation where `theNode__12`'s grad node is called `theNode__23` which can be pretty confusing.

Fixing this by appending "_grad" to the names of grad nodes.

Documentation: n/a

Test Plan: ran tests