### PR TITLE
[PyTorch] Add rowwise quantized linear support

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -528,6 +528,15 @@ public:
 
   /// Create a row-wise quantized fully connected node. This node is only used
   /// in quantization. Args \p input and \p B are quantized in regular way, \p W
+  /// is the constant weights and is row-wise quantized using the given \p
+  /// scales and \p offsets. The output is quantized in the regular way, and its
+  /// type \p outTy is a quantized type.
+  RowwiseQuantizedFullyConnectedNode *createRowwiseQuantizedFullyConnected(
+      llvm::StringRef name, NodeValue input, Constant *W, Constant *scales,
+      Constant *offsets, NodeValue B, TypeRef outTy);
+
+  /// Create a row-wise quantized fully connected node. This node is only used
+  /// in quantization. Args \p input and \p B are quantized in regular way, \p W
   /// is the constant weights and will be row-wise quantized during node
   /// creation time. The output is quantized in the regular way, and its type
   /// \p outTy is a quantized type. if \p transposeWeight is true, \p W need to

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -863,6 +863,16 @@ FullyConnectedNode *Function::createFullyConnected(llvm::StringRef name,
 RowwiseQuantizedFullyConnectedNode *
 Function::createRowwiseQuantizedFullyConnected(llvm::StringRef name,
                                                NodeValue input, Constant *W,
+                                               Constant *scales,
+                                               Constant *offsets, NodeValue B,
+                                               TypeRef outTy) {
+  return addNode(new RowwiseQuantizedFullyConnectedNode(name, outTy, input, W,
+                                                        scales, offsets, B));
+}
+
+RowwiseQuantizedFullyConnectedNode *
+Function::createRowwiseQuantizedFullyConnected(llvm::StringRef name,
+                                               NodeValue input, Constant *W,
                                                NodeValue B, TypeRef outTy,
                                                quantization::Schema schema,
                                                bool transposeWeight) {


### PR DESCRIPTION
Summary:
Add support for rowwise quantized linear in pytorch-glow
Documentation:

[Optional Fixes #issue]

Test Plan:
pytest torch_glow/tests/nodes/quantized_linear_test.py::test_quantized_linear_packed_rowwise

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
