### PR TITLE
Fix bug in non-groupwise ConvRelu conversion

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -1333,7 +1333,7 @@ PyTorchModelLoader::loadQuantizedConvImpl(const torch::jit::Node *ptNode,
   } else {
     auto qconv = F_.createConv("qconv", input, weight, bias, outTy, kernels,
                                strides, pads, groups, dilation);
-    glow::NodeValue output_not_transposed = qconv->getResult();
+    output_not_transposed = qconv->getResult();
   }
   if (isRelu) {
     glow::ReluNode *qrelu = F_.createRELU("qconv_relu", output_not_transposed);

--- a/torch_glow/tests/nodes/quantized_conv2d_relu_test.py
+++ b/torch_glow/tests/nodes/quantized_conv2d_relu_test.py
@@ -3,42 +3,57 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import torch
 
 from tests.utils import jitVsGlow
-import pytest
-
 from collections import OrderedDict
+import unittest
 
 
-def test_quantized_conv2d_relu_packed_groupwise():
-    """Basic test of PyTorch quantized::conv2d_relu Node with packed weights on Glow."""
+class TestQuantizedConv2dRelu(unittest.TestCase):
+    def _test_quantized_conv2d_relu_packed(self, groups):
+        """Basic test of PyTorch quantized::conv2d_relu Node with packed weights on Glow."""
 
-    x = torch.tensor(range(5), dtype=torch.float) * 1.5
-    x = torch.cat((x, x, x, x, x))
-    x = torch.cat((x, x, x))
-    x = torch.reshape(x, [1, 3, 5, 5])
-    q = torch.nn.quantized.Quantize(0.2, 2, torch.quint8)
-    conv = torch.nn.Conv2d(3, 3, [2, 2], groups=3)
-    relu = torch.nn.ReLU()
-    dq = torch.nn.quantized.DeQuantize()
+        x = torch.tensor(range(5), dtype=torch.float) * 1.5
+        x = torch.cat((x, x, x, x, x))
+        x = torch.cat((x, x, x))
+        x = torch.reshape(x, [1, 3, 5, 5])
+        q = torch.nn.quantized.Quantize(0.2, 2, torch.quint8)
+        conv = torch.nn.Conv2d(3, 3, [2, 2], groups=groups)
+        relu = torch.nn.ReLU()
+        dq = torch.nn.quantized.DeQuantize()
 
-    # Due to the off-by-one error, we cannot let the weights, bias & input
-    # to be totally random.
-    conv.weight.data.fill_(1.5)
-    conv.bias.data.fill_(2.5)
+        # Due to the off-by-one error, we cannot let the weights, bias & input
+        # to be totally random.
+        conv.weight.data.fill_(1.5)
+        conv.bias.data.fill_(2.5)
 
-    model = torch.nn.Sequential(OrderedDict([
-        ('quantize', q),
-        ('conv1', conv),
-        ('relu1', relu),
-        ('deuantize', dq)]))
-    model.eval()
-    model.qconfig = torch.quantization.get_default_qconfig('fbgemm')
+        model = torch.nn.Sequential(
+            OrderedDict(
+                [("quantize", q), ("conv1", conv),
+                 ("relu1", relu), ("dequantize", dq)]
+            )
+        )
+        model.eval()
+        model.qconfig = torch.quantization.get_default_qconfig("fbgemm")
 
-    # Fuse conv and relu to conv_relu
-    model = torch.quantization.fuse_modules(model, [['conv1', 'relu1']])
+        # Fuse conv and relu to conv_relu
+        model = torch.quantization.fuse_modules(model, [["conv1", "relu1"]])
 
-    torch.quantization.prepare(model, inplace=True)
-    torch.quantization.convert(model, inplace=True)
+        torch.quantization.prepare(model, inplace=True)
+        torch.quantization.convert(model, inplace=True)
 
-    jitVsGlow(model, x, expected_fused_ops={"aten::quantize_per_tensor",
-                                            "quantized::conv2d_relu",
-                                            "aten::dequantize"})
+        jitVsGlow(
+            model,
+            x,
+            expected_fused_ops={
+                "aten::quantize_per_tensor",
+                "quantized::conv2d_relu",
+                "aten::dequantize",
+            },
+        )
+
+    def test_quantized_conv2d_relu_packed_groupwise(self):
+        """PyTorch groupwise quantized::conv2d_relu Node with packed weights on Glow."""
+        self._test_quantized_conv2d_relu_packed(groups=3)
+
+    def test_quantized_conv2d_relu_packed_nongroupwise(self):
+        """PyTorch vanilla quantized::conv2d_relu Node with packed weights on Glow."""
+        self._test_quantized_conv2d_relu_packed(groups=1)


### PR DESCRIPTION
Summary: Simple shadow variable bug which will result in a coredump when handling vanilla ConvRelu.

Differential Revision: D18876557

