### PR TITLE
Update CommonOperatorLoader to support offline weights 

### DIFF
--- a/include/glow/Importer/ProtobufLoader.h
+++ b/include/glow/Importer/ProtobufLoader.h
@@ -132,9 +132,11 @@ protected:
   Error createAndRegisterConstant(llvm::StringRef name, Tensor &&tensor);
 
   /// Create a new Placeholder of type \p T, and register it
-  /// under the name \p name. \returns The newly created placeholder.
+  /// under the name \p name. If \p isStatic is true register the Placeholder as
+  /// a static placeholder. \returns The newly created placeholder.
   Expected<Placeholder *> createAndRegisterPlaceholder(llvm::StringRef name,
-                                                       TypeRef T);
+                                                       TypeRef T,
+                                                       bool isStatic = false);
 
   /// \returns the NodeValue that was registered with the name \p name or
   /// a nullptr wrapped in a NodeValue if no node has been registered with this

--- a/lib/Importer/ProtobufLoader.cpp
+++ b/lib/Importer/ProtobufLoader.cpp
@@ -151,11 +151,13 @@ void ProtobufLoader::deleteUnusedConstants() {
 }
 
 Expected<Placeholder *>
-ProtobufLoader::createAndRegisterPlaceholder(llvm::StringRef name, TypeRef T) {
+ProtobufLoader::createAndRegisterPlaceholder(llvm::StringRef name, TypeRef T,
+                                             bool isStatic) {
   RETURN_ERR_IF_NOT(
       !hasNodeByName(name),
       llvm::Twine("Creating an already existing node ", name).str());
   Placeholder *node = G_.getParent()->createPlaceholder(T, name, false);
+  node->setStatic(isStatic);
   nodeValueByName_[name] = node->getOutput();
   return node;
 }


### PR DESCRIPTION
Summary:
Add support for offline weights in CommonOperatorLoader, it now creates a static placeholder for each offline weight.
Documentation:

Test Plan: ninja check