### PR TITLE
Fixing Stats Exporter memory leak

### DIFF
--- a/include/glow/Runtime/HostManager/HostManager.h
+++ b/include/glow/Runtime/HostManager/HostManager.h
@@ -15,12 +15,14 @@
  */
 #ifndef GLOW_RUNTIME_HOSTMANAGERR_HOSTMANAGER_H
 #define GLOW_RUNTIME_HOSTMANAGERR_HOSTMANAGER_H
+
 #include "glow/Backend/Backend.h"
 #include "glow/Backends/DeviceManager.h"
 #include "glow/Graph/Graph.h"
 #include "glow/Runtime/Executor/Executor.h"
 #include "glow/Runtime/Provisioner/Provisioner.h"
 #include "glow/Runtime/RuntimeTypes.h"
+#include "glow/Runtime/StatsExporter.h"
 
 #include <atomic>
 #include <map>
@@ -141,14 +143,17 @@ class HostManager final {
   /// Method to calculate and export aggregate memory usage counters.
   void exportMemoryCounters();
 
-  /// Execution stats update
-  static void updateExecutionStats(uint64_t startTime,
-                                   std::unique_ptr<ExecutionContext> &context);
+  /// Execution stats update.
+  void updateExecutionStats(uint64_t startTime,
+                            std::unique_ptr<ExecutionContext> &context);
+
+  /// Keeps the stats exporter registry object alive till destructor.
+  std::shared_ptr<StatsExporterRegistry> statsExporterRegistry_;
+
+  /// Default constructor.
+  HostManager();
 
 public:
-  /// Default constructor.
-  HostManager() = default;
-
   /// Constructor that takes configuration options.
   HostManager(const HostConfig &hostConfig);
 

--- a/include/glow/Runtime/StatsExporter.h
+++ b/include/glow/Runtime/StatsExporter.h
@@ -27,7 +27,7 @@ namespace glow {
 class StatsExporter {
 public:
   /// Dtor.
-  virtual ~StatsExporter() {}
+  virtual ~StatsExporter() = default;
 
   /// Add value to a time series.  May be called concurrently.
   virtual void addTimeSeriesValue(llvm::StringRef key, double value) = 0;
@@ -54,13 +54,16 @@ public:
   /// Register a StatsExporter.
   void registerStatsExporter(StatsExporter *exporter);
 
+  /// Revoke a StatsExporter.
+  void revokeStatsExporter(StatsExporter *exporter);
+
+  /// Static singleton StatsExporter.
+  static std::shared_ptr<StatsExporterRegistry> Stats();
+
 private:
   /// Registered StatsExporters.
   std::vector<StatsExporter *> exporters_;
 };
-
-/// Global singleton StatsExporter.
-StatsExporterRegistry *Stats();
 
 } // namespace glow
 

--- a/lib/Backend/CMakeLists.txt
+++ b/lib/Backend/CMakeLists.txt
@@ -10,4 +10,5 @@ target_link_libraries(Backend
                         CodeGen
                         Graph
                         IR
-                        GraphOptimizerPipeline)
+                        GraphOptimizerPipeline
+                        Runtime)

--- a/lib/Backends/CPU/CPUDeviceManager.h
+++ b/lib/Backends/CPU/CPUDeviceManager.h
@@ -37,12 +37,12 @@ class CPUDeviceManager : public QueueBackedDeviceManager {
 public:
   explicit CPUDeviceManager(const DeviceConfig &config)
       : QueueBackedDeviceManager(config) {
-    Stats()->incrementCounter(kDevicesUsedCPU);
+    statsExporterRegistry_->incrementCounter(kDevicesUsedCPU);
     exportMemoryCounters();
   }
 
   ~CPUDeviceManager() override {
-    Stats()->incrementCounter(kDevicesUsedCPU, -1);
+    statsExporterRegistry_->incrementCounter(kDevicesUsedCPU, -1);
     zeroMemoryCounters();
   }
 
@@ -50,7 +50,7 @@ public:
   /// models are loaded.
   uint64_t getMaximumMemory() const override;
 
-  /// Returns the amount of memory in bytes currently availbe on the device.
+  /// Returns the amount of memory in bytes currently availbe on the device.4
   uint64_t getAvailableMemory() const override;
 
   /// Returns true if a function requiring the \p estimate size will fit on the

--- a/lib/Backends/Habana/HabanaDeviceManager.cpp
+++ b/lib/Backends/Habana/HabanaDeviceManager.cpp
@@ -63,7 +63,7 @@ HabanaDeviceManager::~HabanaDeviceManager() {
   }
   std::lock_guard<std::mutex> lock(synapseMtx_);
   numActiveDevices_--;
-  Stats()->incrementCounter(kDevicesUsedHabana, -1);
+  statsExporterRegistry_->incrementCounter(kDevicesUsedHabana, -1);
 
   // Explicitly clear this map to force synFree of the managed IOBuffers to
   // happen now, before we synReleaseDevice.  Otherwise synReleaseDevice will
@@ -99,7 +99,7 @@ Error HabanaDeviceManager::init() {
   }
 
   numActiveDevices_++;
-  Stats()->incrementCounter(kDevicesUsedHabana);
+  statsExporterRegistry_->incrementCounter(kDevicesUsedHabana);
 
   // Fetch initial memory information.
   RETURN_IF_ERR(updateMemoryUsage());

--- a/lib/Backends/Interpreter/InterpreterDeviceManager.h
+++ b/lib/Backends/Interpreter/InterpreterDeviceManager.h
@@ -40,12 +40,12 @@ class InterpreterDeviceManager : public QueueBackedDeviceManager {
 public:
   explicit InterpreterDeviceManager(const DeviceConfig &config)
       : QueueBackedDeviceManager(config) {
-    Stats()->incrementCounter(kDevicesUsedInterpreter);
+    statsExporterRegistry_->incrementCounter(kDevicesUsedInterpreter);
     exportMemoryCounters();
   }
 
   ~InterpreterDeviceManager() override {
-    Stats()->incrementCounter(kDevicesUsedInterpreter, -1);
+    statsExporterRegistry_->incrementCounter(kDevicesUsedInterpreter, -1);
     zeroMemoryCounters();
   }
 

--- a/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
@@ -241,7 +241,7 @@ Error OpenCLDeviceManager::init() {
   commandQueuePool_.setContext(context_);
   commandQueuePool_.setDevice(deviceId_);
 
-  Stats()->incrementCounter(kDevicesUsedOpenCL);
+  statsExporterRegistry_->incrementCounter(kDevicesUsedOpenCL);
   exportMemoryCounters();
 
   threads::getThreadId();
@@ -259,7 +259,7 @@ Error OpenCLDeviceManager::init() {
 OpenCLDeviceManager::~OpenCLDeviceManager() {
   clReleaseContext(context_);
   buffers_.clear();
-  Stats()->incrementCounter(kDevicesUsedOpenCL, -1);
+  statsExporterRegistry_->incrementCounter(kDevicesUsedOpenCL, -1);
   zeroMemoryCounters();
 }
 

--- a/lib/Runtime/StatsExporter.cpp
+++ b/lib/Runtime/StatsExporter.cpp
@@ -24,6 +24,11 @@ void StatsExporterRegistry::registerStatsExporter(StatsExporter *exporter) {
   exporters_.push_back(exporter);
 }
 
+void StatsExporterRegistry::revokeStatsExporter(StatsExporter *exporter) {
+  exporters_.erase(std::remove(exporters_.begin(), exporters_.end(), exporter),
+                   exporters_.end());
+}
+
 void StatsExporterRegistry::addTimeSeriesValue(llvm::StringRef key,
                                                double value) {
   for (auto const &exporter : exporters_) {
@@ -44,8 +49,8 @@ void StatsExporterRegistry::incrementCounter(llvm::StringRef key,
   }
 }
 
-StatsExporterRegistry *Stats() {
-  static auto *stats = new StatsExporterRegistry();
+std::shared_ptr<StatsExporterRegistry> StatsExporterRegistry::Stats() {
+  static auto stats = std::make_shared<StatsExporterRegistry>();
   return stats;
 }
 

--- a/tests/unittests/StatsExporterTest.cpp
+++ b/tests/unittests/StatsExporterTest.cpp
@@ -25,10 +25,16 @@
 using namespace glow;
 
 class MockStatsExporter : public StatsExporter {
-public:
-  MockStatsExporter() { Stats()->registerStatsExporter(this); }
+  std::shared_ptr<StatsExporterRegistry> statsExporterRegistry_;
 
-  ~MockStatsExporter() override {}
+public:
+  MockStatsExporter() : statsExporterRegistry_(StatsExporterRegistry::Stats()) {
+    statsExporterRegistry_->registerStatsExporter(this);
+  }
+
+  ~MockStatsExporter() override {
+    statsExporterRegistry_->revokeStatsExporter(this);
+  }
 
   void addTimeSeriesValue(llvm::StringRef key, double value) override {
     timeSeries[key].push_back(value);


### PR DESCRIPTION
Summary: Modifying stats exporter code to prevent memory leak and add more flexibility for FB stats exporter.

Differential Revision: D18895398

