### PR TITLE
Pass more device data to backend's post lowering graph transformation

### DIFF
--- a/include/glow/Backend/Backend.h
+++ b/include/glow/Backend/Backend.h
@@ -44,6 +44,7 @@ struct BundleEntry {
 namespace runtime {
 
 class DeviceManager;
+struct DeviceInfo;
 struct DeviceConfig;
 
 } // namespace runtime
@@ -102,11 +103,12 @@ public:
 
   /// Used by the compiler during graph optimization and before code generation,
   /// giving the backend an opportunity to transform the graph before IRGen. The
-  /// backend may insert backend-specific nodes. The backend is responsible for
-  /// cleaning up after itself.
+  /// backend may insert backend and device-specific nodes. The backend is
+  /// responsible for cleaning up after itself.
   /// \returns True if the graph was modified.
-  virtual bool transformPostLowering(Function *F,
-                                     CompilationContext &cctx) const {
+  virtual bool transformPostLowering(
+      Function *F, CompilationContext &cctx,
+      const glow::runtime::DeviceInfo *devInfo = nullptr) const {
     return false;
   }
 

--- a/include/glow/Optimizer/GraphOptimizer/GraphOptimizer.h
+++ b/include/glow/Optimizer/GraphOptimizer/GraphOptimizer.h
@@ -30,6 +30,10 @@ class Module;
 class PlaceholderBindings;
 class Placeholder;
 
+namespace runtime {
+struct DeviceInfo;
+}
+
 /// Perform optimizations on the graph representation.
 void optimize(Function *F, CompilationContext &cctx);
 void optimize(Function *F, CompilationMode mode);
@@ -62,7 +66,8 @@ void profileQuantization(PlaceholderBindings &bindings, Function *F);
 /// Optimize the Function \p F given compilation options \p cctx for Backend \B.
 /// \returns success if all nodes in the final resulting optimized Function are
 /// supported by \p B; if not, this represents a compiler error.
-Error optimizeFunction(Function *F, const Backend &B, CompilationContext &cctx);
+Error optimizeFunction(Function *F, const Backend &B, CompilationContext &cctx,
+                       const glow::runtime::DeviceInfo *devInfo = nullptr);
 
 /// Optimize the Function \p F given compilation options \p cctx performing
 /// backend-independent optimizations that can be done before lowering.

--- a/include/glow/Partitioner/Partitioner.h
+++ b/include/glow/Partitioner/Partitioner.h
@@ -144,6 +144,10 @@ class Partitioner final : public PartitionerBase {
   template <typename SLSType>
   void appendSLSTable(Node &node, std::vector<SLSTableInfo> &slsTables);
 
+  /// Returns info for the default device of the backend. If multiple devices,
+  /// returns the first one.
+  const DeviceInfo &getDeviceInfoForBackend(llvm::StringRef backendName);
+
 public:
   /// \p parent is the module which contains the functions need to be divided.
   /// Here we assume that all the functions in one module belong to a same

--- a/include/glow/Runtime/RuntimeTypes.h
+++ b/include/glow/Runtime/RuntimeTypes.h
@@ -48,7 +48,7 @@ using ResultCBTy = std::function<void(runtime::RunIdentifierTy, Error,
 /// Data structure that contains device constraint information for each device.
 /// Used to communicate memory constraints and later costs to the Partitioner.
 struct DeviceInfo {
-  /// Available memory on device in bytes.
+  /// Available global memory on device in bytes.
   uint64_t availableMemory;
   /// Backend Type.
   std::string backendName;
@@ -62,6 +62,9 @@ struct DeviceInfo {
   std::string supportedNodes;
   /// Available SRAM capacity in bytes.
   uint64_t sramCapacity;
+  /// Available (software controlled) local/scratchpad/onchip memory on the
+  /// device in bytes.
+  uint64_t availableLocalMemory;
   /// Peak compute on device in ops/second. Assumes all ops are in int8.
   /// TODO: distinguish between data types with different peak flops.
   float peakCompute;

--- a/lib/Backends/CPU/CPUBackend.h
+++ b/lib/Backends/CPU/CPUBackend.h
@@ -41,8 +41,9 @@ public:
   std::string getBackendName() const override { return getName(); }
   static std::string getName() { return "CPU"; }
 
-  bool transformPostLowering(Function *F,
-                             CompilationContext &cctx) const override;
+  bool transformPostLowering(
+      Function *F, CompilationContext &cctx,
+      const glow::runtime::DeviceInfo *devInfo = nullptr) const override;
 
   bool isOpSupported(const NodeInfo &NI) const override;
 

--- a/lib/Backends/CPU/Transforms.cpp
+++ b/lib/Backends/CPU/Transforms.cpp
@@ -119,8 +119,9 @@ static Node *optimizeCPUMaxSplat(MaxNode *MN, Function *F) {
       new CPUMaxSplatNode(MN->getName(), input, splat->getValue()));
 }
 
-bool CPUBackend::transformPostLowering(Function *F,
-                                       CompilationContext &) const {
+bool CPUBackend::transformPostLowering(
+    Function *F, CompilationContext &,
+    const glow::runtime::DeviceInfo *) const {
   LOG_SCOPE(F->getLogContext(), "CPUBackend::transformPostLowering")
 
   bool changed = false;

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -205,8 +205,9 @@ public:
   Expected<std::unique_ptr<CompiledFunction>>
   compile(Function *F, const BackendOptions &opts) const override;
 
-  bool transformPostLowering(Function *F,
-                             CompilationContext &cctx) const override;
+  bool transformPostLowering(
+      Function *F, CompilationContext &cctx,
+      const glow::runtime::DeviceInfo *devInfo) const override;
 
   bool isOpSupported(const NodeInfo &NI) const override;
 

--- a/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
@@ -238,6 +238,23 @@ Error OpenCLDeviceManager::init() {
     maxMemoryBytes_ = mem_size;
   }
 
+  localMemSize_ = 0;
+  cl_device_local_mem_type localMemType;
+  err = clGetDeviceInfo(deviceId_, CL_DEVICE_LOCAL_MEM_TYPE,
+                        sizeof(localMemType), &localMemType, NULL);
+  if (err != CL_SUCCESS) {
+    RETURN_ERR("Error getting device local memory type.");
+  }
+  if (localMemType == CL_LOCAL) {
+    cl_ulong localMemSize;
+    err = clGetDeviceInfo(deviceId_, CL_DEVICE_LOCAL_MEM_SIZE,
+                          sizeof(localMemSize), &localMemSize, NULL);
+    if (err != CL_SUCCESS) {
+      RETURN_ERR("Error getting device local memory type.");
+    }
+    localMemSize_ = localMemSize;
+  }
+
   commandQueuePool_.setContext(context_);
   commandQueuePool_.setDevice(deviceId_);
 
@@ -781,4 +798,10 @@ void OpenCLDeviceManager::runFunctionImpl(
 
   // Fire the resultCB.
   resultCB(id, std::move(executeErr), std::move(context));
+}
+
+DeviceInfo OpenCLDeviceManager::getDeviceInfo() const {
+  DeviceInfo info;
+  info.availableLocalMemory = localMemSize_;
+  return info;
 }

--- a/lib/Backends/OpenCL/OpenCLDeviceManager.h
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.h
@@ -151,6 +151,9 @@ class OpenCLDeviceManager : public QueueBackedDeviceManager {
   /// Device name.
   std::string name_;
 
+  /// Size of static local memory in the device.
+  cl_ulong localMemSize_;
+
   /// Command queue pool.
   OpenCLCommandQueuePool commandQueuePool_;
 
@@ -189,6 +192,8 @@ public:
   /// device. This is not a promise as memory cost could vary due to alignment,
   /// etc.
   bool isMemoryAvailable(uint64_t estimate) const override;
+
+  DeviceInfo getDeviceInfo() const override;
 
 protected:
   /// Adds functions to the device. Calls to this are serialized so concurrency

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -1291,7 +1291,7 @@ static bool verifyFusedRowwiseQuantizedSparseLengthsSum(
   // For EmbeddingBagByteRowwiseOffsets lengths are really offsets and should be
   // Int64ITy.
   if (isEmbeddingBagByteRowwiseOffsets) {
-    isValid &= checkType(lengths, ElemKind::Int64ITy, parent);
+    isValid &= checkType(lengths, IndexElemKind, parent);
   } else {
     isValid &= checkType(lengths, ElemKind::Int32ITy, parent);
   }

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -32,6 +32,7 @@
 #include "glow/Optimizer/Lower/Lower.h"
 #include "glow/Quantization/Base/Base.h"
 #include "glow/Quantization/Quantization.h"
+#include "glow/Runtime/RuntimeTypes.h"
 
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/CommandLine.h"
@@ -3445,7 +3446,8 @@ Error glow::optimizeFunctionBeforeLowering(Function *F,
 // NOTE: When updating this function, please also update the documentation in
 // docs/GraphOptimizationPipeline.md
 Error glow::optimizeFunction(Function *F, const Backend &B,
-                             CompilationContext &cctx) {
+                             CompilationContext &cctx,
+                             const glow::runtime::DeviceInfo *devInfo) {
   LOG_SCOPE(F->getLogContext(), "glow::optimizeFunction")
 
   // If requested only lower the Function and early return.
@@ -3506,7 +3508,7 @@ Error glow::optimizeFunction(Function *F, const Backend &B,
   }
 
   // Allow the backend to transform the graph after lowering.
-  if (B.transformPostLowering(F, cctx)) {
+  if (B.transformPostLowering(F, cctx, devInfo)) {
     // If the backend made changes, optimize the graph again. Perform only
     // passes that the Backend has requested so we do not interfere with the
     // backend's transformations.

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -7756,14 +7756,13 @@ createAndInitRWQSLWSAllSame(glow::PlaceholderBindings &bindings,
       0.2244578,  0.44881952, 0.42696562, 0.33007848, 0.4511249,  0.11568925,
       0.02629679, 0.33864713, 0.42614424};
 
-  Placeholder *indices =
-      mod.createPlaceholder(ElemKind::Int64ITy, {21}, "indices",
-                            /* isTrainable */ false);
+  Placeholder *indices = mod.createPlaceholder(IndexElemKind, {21}, "indices",
+                                               /* isTrainable */ false);
   Placeholder *lengths =
       mod.createPlaceholder(ElemKind::Int32ITy, {2}, "lengths",
                             /* isTrainable */ false);
 
-  bindings.allocate(indices)->getHandle<int64_t>() = {
+  bindings.allocate(indices)->getHandle<sdim_t>() = {
       11, 8, 19, 8, 4, 11, 4, 19, 6, 18, 2, 6, 15, 5, 14, 14, 15, 13, 4, 6, 5,
   };
   bindings.allocate(lengths)->getHandle<int32_t>() = {15, 6};

--- a/tests/unittests/PartitionerTest.cpp
+++ b/tests/unittests/PartitionerTest.cpp
@@ -541,7 +541,7 @@ static void createSimpleSparseNNModule(Module &mod) {
   for (int table = 0; table < 5; table++) {
     Tensor data(ElemKind::FloatTy, {tableEntries, tableWidth});
     auto indices = mod.createPlaceholder(
-        ElemKind::Int64ITy, {numIndices * batchSize}, "indices", false);
+        IndexElemKind, {numIndices * batchSize}, "indices", false);
     auto weights = mod.createPlaceholder(
         ElemKind::FloatTy, {numIndices * batchSize}, "weights", false);
     auto lengths = mod.createPlaceholder(ElemKind::Int32ITy, {batchSize},

--- a/utils/scripts/gen_onnx_gru_model.py
+++ b/utils/scripts/gen_onnx_gru_model.py
@@ -190,7 +190,9 @@ def gen_gru_onnx_test_model(model_path, seq_length, batch_size, hidden_size, inp
             dir_idx)
 
         def f(x): return (1 / (1 + np.exp(-x)))
+
         def g(x): return np.tanh(x)
+
         def mm(x, w): return np.matmul(x, w.transpose())
         Ht = np.reshape(initial_h[dir_idx, :, :], [batch_size, hidden_size])
 

--- a/utils/scripts/gen_onnx_rnn_model.py
+++ b/utils/scripts/gen_onnx_rnn_model.py
@@ -173,6 +173,7 @@ def gen_rnn_onnx_test_model(model_path, seq_length, batch_size, hidden_size, inp
         Wi, Ri, bWi, bRi = get_weights(dir_idx)
 
         def f(x): return np.tanh(x)
+
         def mm(x, w): return np.matmul(x, w.transpose())
         Ht = np.reshape(initial_h[dir_idx, :, :], [batch_size, hidden_size])
 


### PR DESCRIPTION
Summary:

Pass more device data to backend's post lowering graph transformation

First use case is the OpenCL backend of which actual device properties
can vary greatly. In the first use case, we check if there is actual
explicit scratchpad memory in the device which impacts the optimal
choice of kernels; if there is none, using the OpenCL "local" mem
as a temporary storage is often just an extra copy that should be
avoided if possible.

This gives around 80x speedup with pocl 1.5-pre (i7-7500U, pthread, LLVM 8)
and around 3x speedup with Intel OpenCL SDK for the same CPU. This is
measured with squeezenet (-time switch, wall clock time).

Test Plan:

Tested with clang8 build, g++ builds, 32b and 64b dim_t, OpenCL (pocl and Intel SDK).

For reference, the OpenCL squeezenet wall clock -time for this laptop's CPU+GPU:
```With the patch
--------------

* Intel GPU (HD620) (has local mem)

   ---User Time---   --System Time--   --User+System--   ---Wall Time---  --- Name ---
   5.3613 (100.0%)   0.0156 (100.0%)   5.3770 (100.0%)   5.3932 (100.0%)  Infer
   5.3613 (100.0%)   0.0156 (100.0%)   5.3770 (100.0%)   5.3932 (100.0%)  Total
   
* Intel CPU (i7-7500U)

   ---User Time---   --System Time--   --User+System--   ---Wall Time---  --- Name ---
   1.2382 (100.0%)   0.0277 (100.0%)   1.2658 (100.0%)   0.5523 (100.0%)  Infer
   1.2382 (100.0%)   0.0277 (100.0%)   1.2658 (100.0%)   0.5523 (100.0%)  Total

* pocl 1.5-pre (i7-7500U, LLVM 8.0, pthread)

   ---User Time---   --System Time--   --User+System--   ---Wall Time---  --- Name ---
   0.5970 (100.0%)   0.0032 (100.0%)   0.6002 (100.0%)   0.1540 (100.0%)  Infer
   0.5970 (100.0%)   0.0032 (100.0%)   0.6002 (100.0%)   0.1540 (100.0%)  Total

   
Without the patch
-----------------

* Intel GPU (HD620) (has local mem)

No significant difference (as expected).

* Intel CPU (i7-7500U)

   ---User Time---   --System Time--   --User+System--   ---Wall Time---  --- Name ---
   2.0702 (100.0%)   0.0273 (100.0%)   2.0974 (100.0%)   1.5960 (100.0%)  Infer
   2.0702 (100.0%)   0.0273 (100.0%)   2.0974 (100.0%)   1.5960 (100.0%)  Total

* pocl 1.5-pre (i7-7500U, LLVM 8.0, pthread)

   ---User Time---   --System Time--   --User+System--   ---Wall Time---  --- Name ---
  12.0850 (100.0%)   0.2214 (100.0%)  12.3064 (100.0%)  12.6355 (100.0%)  Infer
  12.0850 (100.0%)   0.2214 (100.0%)  12.3064 (100.0%)  12.6355 (100.0%)  Total

```
