### PR TITLE
[ClassGen] Generate isCanonical method.

### DIFF
--- a/include/glow/Graph/Node.h
+++ b/include/glow/Graph/Node.h
@@ -98,6 +98,7 @@ public:
   llvm::StringRef getOutputName(unsigned idx) const;
   bool hasSideEffects() const;
   bool isArithmetic() const;
+  bool isCanonical() const;
   bool isDataParallel() const;
 
   /// \returns true if this input is being overwritten by the node.

--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -52,6 +52,7 @@ public:
   NodeValue getNthInput(unsigned idx);
   llvm::StringRef getOutputName(unsigned idx) const;
   bool hasSideEffects() const;
+  bool isCanonical() const { return true; }
   bool isDataParallel() const { return false; }
   Node *clone() const;
   /// @}

--- a/lib/Graph/Node.cpp
+++ b/lib/Graph/Node.cpp
@@ -209,6 +209,17 @@ bool Node::hasSideEffects() const {
   }
 }
 
+bool Node::isCanonical() const {
+  switch (getKind()) {
+#define DEF_NODE(CLASS, NAME)                                                  \
+  case glow::Kinded::Kind::CLASS##Kind:                                        \
+    return static_cast<const CLASS *>(this)->isCanonical();
+#include "glow/AutoGenNodes.def"
+  default:
+    llvm_unreachable("Unhandled node");
+  }
+}
+
 bool Node::isDataParallel() const {
   switch (getKind()) {
 #define DEF_NODE(CLASS, NAME)                                                  \

--- a/lib/Optimizer/GraphOptimizer/ConstantFolding.cpp
+++ b/lib/Optimizer/GraphOptimizer/ConstantFolding.cpp
@@ -50,6 +50,11 @@ bool isConstantOperation(const Node *N, const Backend &backend) {
   if (isa<Constant>(N) || isa<SplatNode>(N)) {
     return true;
   }
+  // If the node is backend specific, we cannot safely do constant folding using
+  // the interpreter.
+  if (!N->isCanonical()) {
+    return false;
+  }
   // If the operation is not supported by the backend, it cannot be computed at
   // compile-time.
   if (!backend.shouldLower(N) && !backend.isOpSupported(NodeInfo(*N))) {

--- a/tools/ClassGen/InstrBuilder.cpp
+++ b/tools/ClassGen/InstrBuilder.cpp
@@ -115,6 +115,11 @@ void InstrBuilder::emitInplaceMethod(std::ostream &os) const {
   os << "    return false;\n  }\n";
 }
 
+void InstrBuilder::emitCanonicalProperty(std::ostream &os) const {
+  os << "\n  bool isCanonical() const {\n";
+  os << "    return " << (isBackendSpecific_ ? "false" : "true") << ";\n  }\n";
+}
+
 void InstrBuilder::emitDataParallelProperty(std::ostream &os) const {
   os << "\n  bool isDataParallel() const {\n";
   os << "    return " << (isDataParallel_ ? "true" : "false") << ";\n  }\n";

--- a/tools/ClassGen/InstrBuilder.h
+++ b/tools/ClassGen/InstrBuilder.h
@@ -230,6 +230,9 @@ private:
   /// Emits the method that calculates the inplace property.
   void emitInplaceMethod(std::ostream &os) const;
 
+  /// Emits the property that returns true if the instruction is canonical.
+  void emitCanonicalProperty(std::ostream &os) const;
+
   /// Emits the property that returns true if the instruction is data parallel.
   void emitDataParallelProperty(std::ostream &os) const;
 

--- a/tools/ClassGen/NodeBuilder.cpp
+++ b/tools/ClassGen/NodeBuilder.cpp
@@ -550,6 +550,7 @@ void NodeBuilder::emitNodeClass(std::ostream &os) const {
      << "  void setNthInput(unsigned idx, NodeValue val);\n"
      << "  llvm::StringRef getOutputName(unsigned idx) const;\n"
      << "  bool hasSideEffects() const { return " << hasSideEffects_ << "; }\n"
+     << "  bool isCanonical() const { return " << !isBackendSpecific_ << "; }\n"
      << "  bool isDataParallel() const { return " << isDataParallel_ << "; }\n"
      << "  std::string getDebugDesc() const;\n"
      << "  bool isEqual(const " << name_ << "Node &other) const;\n"


### PR DESCRIPTION
Summary:

It lets us figure out if a node is backend specific or not. This is needed to fix a bug in constant folding wherein we try to run a backend specific node on the interpreter backend.

NOTE: As is already described in the documentations folder, when creating backend specific nodes you need to use BB.newBackendSpecificNode instead of newNode() method. calling newNode for the creation of backend specific nodes is deprecated and will be disallowed in the future.