### PR TITLE
Add CompilationContext for manual partitioner

### DIFF
--- a/include/glow/Partitioner/Partitioner.h
+++ b/include/glow/Partitioner/Partitioner.h
@@ -150,7 +150,8 @@ public:
   /// Based on \p partitionConfig passed into Partitioner, do user-defined
   /// partition.
   Expected<DAGListTy>
-  partitionFromConfig(const PartitionConfig &partitionConfig);
+  partitionFromConfig(const PartitionConfig &partitionConfig,
+                      CompilationContext &cctx);
 
   /// This partition approach is used in Glow Quantization Profiling flow. The
   /// backendBasedPartition is applied first in case there are heterogeneous

--- a/lib/Partitioner/Partitioner.cpp
+++ b/lib/Partitioner/Partitioner.cpp
@@ -768,7 +768,8 @@ Partitioner::heterogeneousPartition(CompilationContext &cctx) {
 }
 
 Expected<DAGListTy>
-Partitioner::partitionFromConfig(const PartitionConfig &partitionConfig) {
+Partitioner::partitionFromConfig(const PartitionConfig &partitionConfig,
+                                 CompilationContext &cctx) {
   DAGListTy partitions;
   // Prepare the mapping between BackendName and BackendInfo.
   std::vector<Backend *> backends;
@@ -865,7 +866,6 @@ Partitioner::partitionFromConfig(const PartitionConfig &partitionConfig) {
     std::unique_ptr<Backend> backend(
         createBackend(partitionConfig.backendNames[i]));
     if (!optimized_) {
-      CompilationContext cctx;
       RETURN_IF_ERR(::glow::optimizeFunction(func, *backend, cctx));
     }
   }
@@ -882,7 +882,7 @@ Expected<DAGListTy> Partitioner::partition(CompilationContext &cctx) {
 
   if (partitionConfig_.enabled()) {
     // Call user-defined partition flow.
-    return partitionFromConfig(partitionConfig_);
+    return partitionFromConfig(partitionConfig_, cctx);
   }
 
   if (cctx.precisionConfig.quantMode == QuantizationMode::Profile) {


### PR DESCRIPTION
Summary: Small fix to add compilation context to the manual partitioner. For example, this allows precision options to be passed in correctly to the partitioner.

Reviewed By: gcatron

Differential Revision: D18910161

