### PR TITLE
[GraphOptz] Add numeric equivalence test for DCE

### DIFF
--- a/include/glow/Partitioner/Partitioner.h
+++ b/include/glow/Partitioner/Partitioner.h
@@ -150,7 +150,8 @@ public:
   /// Based on \p partitionConfig passed into Partitioner, do user-defined
   /// partition.
   Expected<DAGListTy>
-  partitionFromConfig(const PartitionConfig &partitionConfig);
+  partitionFromConfig(const PartitionConfig &partitionConfig,
+                      CompilationContext &cctx);
 
   /// This partition approach is used in Glow Quantization Profiling flow. The
   /// backendBasedPartition is applied first in case there are heterogeneous

--- a/lib/Partitioner/Partitioner.cpp
+++ b/lib/Partitioner/Partitioner.cpp
@@ -768,7 +768,8 @@ Partitioner::heterogeneousPartition(CompilationContext &cctx) {
 }
 
 Expected<DAGListTy>
-Partitioner::partitionFromConfig(const PartitionConfig &partitionConfig) {
+Partitioner::partitionFromConfig(const PartitionConfig &partitionConfig,
+                                 CompilationContext &cctx) {
   DAGListTy partitions;
   // Prepare the mapping between BackendName and BackendInfo.
   std::vector<Backend *> backends;
@@ -865,7 +866,6 @@ Partitioner::partitionFromConfig(const PartitionConfig &partitionConfig) {
     std::unique_ptr<Backend> backend(
         createBackend(partitionConfig.backendNames[i]));
     if (!optimized_) {
-      CompilationContext cctx;
       RETURN_IF_ERR(::glow::optimizeFunction(func, *backend, cctx));
     }
   }
@@ -882,7 +882,7 @@ Expected<DAGListTy> Partitioner::partition(CompilationContext &cctx) {
 
   if (partitionConfig_.enabled()) {
     // Call user-defined partition flow.
-    return partitionFromConfig(partitionConfig_);
+    return partitionFromConfig(partitionConfig_, cctx);
   }
 
   if (cctx.precisionConfig.quantMode == QuantizationMode::Profile) {

--- a/tests/unittests/GraphOptzTest.cpp
+++ b/tests/unittests/GraphOptzTest.cpp
@@ -81,10 +81,13 @@ TEST_F(GraphOptz, OptimizeClipFunnel) {
 }
 
 TEST_F(GraphOptz, DCE) {
-  Node *K = mod_.createPlaceholder(ElemKind::FloatTy, {4, 320, 200, 3}, "input",
-                                   false);
+  Placeholder *input = mod_.createPlaceholder(ElemKind::FloatTy,
+                                              {4, 320, 200, 3}, "input", false);
 
-  for (int i = 0; i < 40; i++) {
+  Node *K = F_->createRELU("relu", input);
+  K = F_->createAdd("arith", K, K);
+
+  for (int i = 0; i < 39; i++) {
     K = F_->createRELU("relu", K);
     // Add a graph structure that diverges and converges, to catch algorithms
     // that perform a dump recursive scan.
@@ -95,11 +98,16 @@ TEST_F(GraphOptz, DCE) {
   EXPECT_EQ(F_->getNodes().size(), 80);
 
   // Optimize all of the dead code.
-  ::glow::optimize(F_, CompilationMode::Infer);
+  optimizedF_ = optimizeFunction(F_);
 
-  //  All of the nodes are gone.
-  EXPECT_EQ(F_->getNodes().size(), 0);
+  //  All of the nodes are gone as output not saved.
+  EXPECT_EQ(optimizedF_->getNodes().size(), 0);
   EXPECT_EQ(mod_.getConstants().size(), 0);
+
+  // Confirm numerical equivalence as well.
+  bindings_.allocate(mod_.getPlaceholders());
+  bindings_.get(input)->getHandle().randomize(-10.0, 10.0, mod_.getPRNG());
+  checkNumericalEquivalence();
 }
 
 /// Check that predicated instructions are DCE'ed like


### PR DESCRIPTION
**Summary:**
Add a numeric equivalence test to the DCE sub-test in GraphOptzTest.
The test creates a network with some dead code and then calls
optimization function that would eliminate all of the dead code.
Confirm that all nodes are removed and that there is numeric
equivalence on the original and optimized functions (networks) on
random inputs.

**Test Plan:**
```
$ ninja all && tests/GraphOptzTest --gtest_filter=GraphOptz.DCE
$ ninja test
```
