### PR TITLE
Let repro dump its outputs

### DIFF
--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -28,7 +28,8 @@ target_link_libraries(Repro
                       PRIVATE
                         BackendTestUtils
                         HostManager
-                        Importer)
+                        Importer
+                        Exporter)
 
 # Test executables, sorted alphabetically.
 


### PR DESCRIPTION
Summary: There is certain requirement that we dump repro output in one backend and use it as a reference for another backend.

Differential Revision: D18939895

