### PR TITLE
Add SLWS in the interpreter for fp16

### DIFF
--- a/lib/Backends/CPU/tests/CPUOperatorTest.cpp
+++ b/lib/Backends/CPU/tests/CPUOperatorTest.cpp
@@ -105,6 +105,9 @@ std::set<std::string> glow::backendTestBlacklist = {
     "FusedRowwiseQuantizedSLWSTwoColumn_Float16_AccumFloat/0",
     "FusedRowwiseQuantizedSLWSTwoColumn_Float16_AccumFloat16/0",
     "FusedRowwiseQuantizedSLWSTwoColumn_Fused4Bit_Float16_AccumFloat16/0",
+    "FusedRowwiseQuantizedSparseLengthsWeightedSum_ConvertedFloat16/0",
+    "FusedRowwiseQuantizedSparseLengthsWeightedSum_ConvertedFloat16_"
+    "NoFusedConvert/0",
     "SLWSTwoColumn_Float16_AccumFloat/0",
     "SparseToDenseMask1/0",
     "SparseToDenseMask2/0",

--- a/lib/Backends/Habana/tests/HabanaOperatorTest.cpp
+++ b/lib/Backends/Habana/tests/HabanaOperatorTest.cpp
@@ -162,6 +162,8 @@ std::set<std::string> glow::backendTestBlacklist = {
     "back/0",
     "FusedRowwiseQuantizedSparseLengthsWeightedSum_ConvertedFloat16_back_to_"
     "back2/0",
+    "FusedRowwiseQuantizedSparseLengthsWeightedSum_ConvertedFloat16_"
+    "NoFusedConvert/0",
     "FusedRowwiseQuantizedSparseLengthsWeightedSum_Float16_AccumFloat/0",
     "FusedRowwiseQuantizedSparseLengthsWeightedSum_Float16_AccumFloat16/0",
     "EmbeddingBagByteRowwiseOffsets_ConvertedFloat16/0",

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -365,11 +365,21 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
                   FusedRowwiseQuantizedSparseLengthsWeightedSumNode::
                       ResultIdx) == ElemKind::Float16Ty);
     case ElemKind::UInt8FusedQTy:
-      return (NI.getInElemTy(FusedRowwiseQuantizedSparseLengthsWeightedSumNode::
-                                 WeightsIdx) == ElemKind::FloatTy) &&
-             (NI.getOutElemTy(
-                  FusedRowwiseQuantizedSparseLengthsWeightedSumNode::
-                      ResultIdx) == ElemKind::FloatTy);
+      if ((NI.getInElemTy(
+               FusedRowwiseQuantizedSparseLengthsWeightedSumNode::WeightsIdx) ==
+           ElemKind::FloatTy) &&
+          (NI.getOutElemTy(
+               FusedRowwiseQuantizedSparseLengthsWeightedSumNode::ResultIdx) ==
+           ElemKind::FloatTy)) {
+        return true;
+      }
+      return (
+          (NI.getInElemTy(
+               FusedRowwiseQuantizedSparseLengthsWeightedSumNode::WeightsIdx) ==
+           ElemKind::Float16Ty) &&
+          (NI.getOutElemTy(
+               FusedRowwiseQuantizedSparseLengthsWeightedSumNode::ResultIdx) ==
+           ElemKind::Float16Ty));
     default:
       return false;
     }

--- a/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
@@ -151,6 +151,8 @@ struct EmulatorOnlyTests {
           "AccumFloat16/0",
           "FusedRowwiseQuantizedSparseLengthsWeightedSum_ConvertedFloat16_"
           "back_",
+          "FusedRowwiseQuantizedSparseLengthsWeightedSum_ConvertedFloat16_"
+          "NoFusedConvert/0",
           "to_back2/0",
           "GroupDilatedConvolution/0",
           "less_int32Cases/0",

--- a/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
@@ -190,6 +190,8 @@ std::set<std::string> glow::backendTestBlacklist = {
     "FusedRowwiseQuantizedSLWSTwoColumn_Float16_AccumFloat/0",
     "FusedRowwiseQuantizedSLWSTwoColumn_Float16_AccumFloat16/0",
     "FusedRowwiseQuantizedSLWSTwoColumn_Fused4Bit_Float16_AccumFloat16/0",
+    "FusedRowwiseQuantizedSparseLengthsWeightedSum_ConvertedFloat16_"
+    "NoFusedConvert/0",
     "SLWSTwoColumn_Float16_AccumFloat/0",
     "SLSWithZeroLengths/0",
     "SparseToDense/0",


### PR DESCRIPTION
  * Update the Interpreter to support RWQ-SLWS with data input
    of UInt8FusedQTy with the output tensor if type fp16. It
    will support a node that looks like:
      name : RQSLWS
      Data : ui8fused[S:0.0000 O:0][0.000,0.000]<3 x 9>
      Weights : float16<8>
      Indices : index64<8>
      Lengths : index32<4>
      UseFP16Accumulation : 0

  * Update the interpreter to decouple the output tensor type from
    the type for the fused Scale and Offset. The type of scale and
    offset for a fused quantized type should depend on the input.

Summary:

Documentation:

[Optional Fixes #issue]

Test Plan:
  Added a new test
  ninja test passes


