### PR TITLE
fix potential use after free / segfault in provisioner

### DIFF
--- a/lib/Runtime/Provisioner/Provisioner.cpp
+++ b/lib/Runtime/Provisioner/Provisioner.cpp
@@ -418,12 +418,17 @@ Error Provisioner::provision(DAGListTy &networks, Module &module,
         functions_.emplace(func.first, std::move(func.second));
       }
       // Check if any of the duplicated functions can also be moved.
-      for (auto func : remainingDuplications) {
+      for (auto iter = remainingDuplications.begin();
+           iter != remainingDuplications.end();) {
+        const auto &func = *iter;
         if (func.second == 0) {
           duplicatedFunctions[func.first]->freeCompilationResources();
           functions_.emplace(func.first,
                              std::move(duplicatedFunctions[func.first]));
           duplicatedFunctions.erase(func.first);
+          iter = remainingDuplications.erase(iter);
+        } else {
+          ++iter;
         }
       }
     }


### PR DESCRIPTION
Summary:
We have this map remainingDuplications which keep tracks of use count for duplicated functions. When the count reaches 0, we do some clean up. Unfortunately we never clean up remainingDuplications itself when this happens and this can lead to a segfault.

To trigger the segfault, consider a graph that's partitioned into 2 partitions (A,B). Then these partitions are further duplicated 3 times due to saturate host option. Say the mapping between between device and partition is

0: A, 1: B, 2: A, 3: B, 4: A, 5: B

After loading device 4, the duplicate count for A reaches 0 and we do some cleanup for partition A.

After loading device 5, we'll come to this clean up code again. Because the entry for A was never removed from remainingDuplicates, it still has count of 0 and we'll attempt to clean it up again, thus causing a segfault.

Differential Revision: D18950461

