### PR TITLE
[AOT] Legalize bundle name. Change Loader default backend to CPU.

### DIFF
--- a/include/glow/LLVMIRCodeGen/LLVMIRGen.h
+++ b/include/glow/LLVMIRCodeGen/LLVMIRGen.h
@@ -324,13 +324,13 @@ public:
   virtual AllocationsInfo &getAllocationsInfo() { return allocationsInfo_; }
   /// \returns the name of the bundle, to be used for filename when saving.
   llvm::StringRef getBundleName() const;
-  /// Set the name of the bundle.
+  /// Set the name of the bundle (name is automatically legalized).
   void setBundleName(const std::string &name);
   /// \returns the name of the main entry point.
   /// When JITting, it will be "main". In case of bundling it will be the name
   /// of the bundle.
   std::string getMainEntryName() const;
-  /// Set the name of the main entry point.
+  /// Set the name of the main entry point (name is automatically legalized).
   void setMainEntryName(std::string name);
   /// Creates an LLVM module, the entry function, etc.
   virtual void initCodeGen();

--- a/lib/LLVMIRCodeGen/BundleSaver.h
+++ b/lib/LLVMIRCodeGen/BundleSaver.h
@@ -82,10 +82,6 @@ private:
   AllocationsInfo allocationsInfo_;
   /// The LLVM IR code generator.
   std::unique_ptr<LLVMIRGen> irgen_;
-  /// The output directory to be used.
-  std::string outputDir_;
-  /// The name of the bundle to be saved.
-  std::string bundleName_;
   /// Information about IR functions inside this bundle.
   std::vector<SavedIRFunction> savedIRFunctions_;
   /// Bundle API to use.

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -92,8 +92,10 @@ static unsigned getPointerNumBits(const llvm::TargetMachine &TM) {
 
 LLVMIRGen::LLVMIRGen(const IRFunction *F, AllocationsInfo &allocationsInfo,
                      std::string mainEntryName, llvm::StringRef libjitBC)
-    : F_(F), allocationsInfo_(allocationsInfo), mainEntryName_(mainEntryName),
-      libjitBC_(libjitBC) {}
+    : F_(F), allocationsInfo_(allocationsInfo), libjitBC_(libjitBC) {
+  // Legalize main entry name.
+  setMainEntryName(mainEntryName);
+}
 
 /// Mutex to protect LLVM's TargetRegistry.
 static std::mutex initTargetMutex;
@@ -134,13 +136,15 @@ void LLVMIRGen::initTargetMachine(const LLVMBackendOptions &opts) {
 
 llvm::StringRef LLVMIRGen::getBundleName() const { return bundleName_; }
 
-void LLVMIRGen::setBundleName(const std::string &name) { bundleName_ = name; }
-
-std::string LLVMIRGen::getMainEntryName() const {
-  return mainEntryName_.empty() ? "main" : mainEntryName_;
+void LLVMIRGen::setBundleName(const std::string &name) {
+  bundleName_ = name.empty() ? "bundle" : legalizeName(name);
 }
 
-void LLVMIRGen::setMainEntryName(std::string name) { mainEntryName_ = name; }
+std::string LLVMIRGen::getMainEntryName() const { return mainEntryName_; }
+
+void LLVMIRGen::setMainEntryName(std::string name) {
+  mainEntryName_ = name.empty() ? "main" : legalizeName(name);
+}
 
 /// Load base addresses of different memory areas so that they can be easily
 /// reused during codegen.

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -400,6 +400,11 @@ static bool commandLineIsInvalid() {
                   end = llvm::sys::path::rend(modelPathOpt[0]);
              it != end; ++it) {
           networkName = *it;
+          // Strip extension (if any).
+          size_t lastDotPos = networkName.find_last_of(".");
+          if (lastDotPos != std::string::npos) {
+            networkName = networkName.substr(0, lastDotPos);
+          }
           // Empty names are replaced by '.' (see Path.h in LLVM).
           if (!networkName.empty() && networkName != ".") {
             break;
@@ -494,6 +499,10 @@ void Loader::compile(CompilationContext &cctx) {
   auto module = M_.get();
 
   if (emittingBundle()) {
+    // Create bundle directory if not exists.
+    if (!llvm::sys::fs::is_directory(emitBundle)) {
+      llvm::sys::fs::create_directory(emitBundle);
+    }
     // Emit IR for the graph, compile it and save as a bundle.
     auto error = ::glow::optimizeFunction(F_, *backend_, cctx);
     EXIT_ON_ERR(std::move(error));


### PR DESCRIPTION
**Summary**

Duplicates #3726 (mostly) but I need this landed kind of ASAP.
- Legalize bundle name.
- Legalize bundle main entry point.
- Removed **bundleName** and **outputDir** attributes from the BundleSaver class since they are redundant (duplicate the attributes of the LLVMIRGen class) and create even more confusion in the context of legalization.
- When building bundle, create directory if does not exist.
- Remove ".onnx" extension when building bundles for ONNX models without the "network-name" parameter. Otherwise the bundle artifacts will be named like this: **model.onnx.o** , **model.onnx.h** etc (and the inference function itself will be named **model_onnx**) which is kind of ugly IMHO.
- Change Loader default backend to CPU: currently the default backend is Interpreter so when building bundles without the "backend" parameter (which is not mandatory), the build crashes since the Interpreter cannot save a bundle.

**Documentation**
None

**Test Plan**
None
