### PR TITLE
Compile PyTorch model ahead of time

### DIFF
--- a/torch_glow/src/CachingGraphRunner.h
+++ b/torch_glow/src/CachingGraphRunner.h
@@ -81,6 +81,9 @@ public:
   /// it as a Glow Function and compiles. \returns error of failure.
   Error run(torch::jit::Stack &stack);
 
+  /// The Glow Function should've already been created. Returns an error if not.
+  Error runOnly(torch::jit::Stack &stack);
+
   // Warm up the cache by compiling a Glow function for the inputs in \p stack.
   Error warmCache(const std::vector<InputMeta> &inputMeta);
 };

--- a/torch_glow/src/PyTorchCommon.cpp
+++ b/torch_glow/src/PyTorchCommon.cpp
@@ -27,8 +27,6 @@
 
 namespace glow {
 
-bool GlowCompilePyTorchModule = false;
-
 namespace {
 
 static int setGraphExecutorToLegacy() {

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -31,11 +31,16 @@ namespace glow {
 /// Therefore, we can make scale_1 == scale_2, and offset_1 = offset2 - 128
 const int32_t OFFSETSHIFT = 128;
 
-extern bool GlowCompilePyTorchModule;
 /// Various settings to be used by code that loads PyTorch models. There should
 /// only be one of these and it should be obtained by calling
 /// getPyTorchLoaderSettings().
 struct PyTorchLoaderSettings {
+  /// This should be used with CachingGraphRunner::warmCache. When this flag is
+  /// enabled, it assumes the glow graph is compiled ahead of time instead of
+  /// at PyTorch JIT runtime. And the registered glow operator will run
+  /// the precompiled results directly.
+  bool preCompilePyTorchModule = false;
+
   /// Whether or not run the custom pass that fuses jit nodes into a glow node.
   bool fusionPassEnabled = false;
 

--- a/torch_glow/src/Registration.cpp
+++ b/torch_glow/src/Registration.cpp
@@ -76,7 +76,12 @@ void registerGlowOp(const c10::Symbol &symbol) {
         }
 
         return [graphRunner](torch::jit::Stack &stack) {
-          Error err = graphRunner->run(stack);
+          Error err = Error::empty();
+          if (getPyTorchLoaderSettings().preCompilePyTorchModule) {
+            err = graphRunner->runOnly(stack);
+          } else {
+            err = graphRunner->run(stack);
+          }
 
           if (static_cast<bool>(err)) {
             // PyTorch framework expects an exception been thrown here.


### PR DESCRIPTION
Summary:
This is required to support dynamic shape models running on certain devices.
The logic is mostly the same as #3611. The original code was refactored due to
incomplete support for Object inputs. Now with frozen modules, glow fusion node
will almost always contain tensor only inputs. And InputMeta should cover them
all.

Differential Revision: D19038389

