### PR TITLE
Disable GroupwiseQuantizedConv for OpenCL

### DIFF
--- a/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
@@ -276,4 +276,5 @@ std::set<std::string> glow::backendTestBlacklist = {
     "RepeatedSLSWithPartialTensors/0",
     "GatherWithInt32PartialTensors/0",
     "GatherWithInt64PartialTensors/0",
+    "GroupwiseQuantizedConvolution/0",
 };

--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -2645,7 +2645,8 @@ Error PyTorchModelLoader::loadMean(const torch::jit::Node *ptNode) {
     }
   }
 
-  if (hasGlowIValueForValue(inputs[MeanInputs::keepdims])) {
+  if (inputs.size() > 2 &&
+      hasGlowIValueForValue(inputs[MeanInputs::keepdims])) {
     bool keepdims;
     ASSIGN_VALUE_OR_RETURN_ERR(keepdims, iValToBool(getGlowIValueForValue(
                                              inputs[MeanInputs::keepdims])));

--- a/torch_glow/tests/nodes/adaptive_avg_pool2d_test.py
+++ b/torch_glow/tests/nodes/adaptive_avg_pool2d_test.py
@@ -4,36 +4,36 @@ import torch
 import torch.nn.functional as F
 
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_adaptive_avg_pool2d_basic():
-    """Basic test of PyTorch adaptive_avg_pool2d Node."""
+class TestAdaptiveAvgPool2d(unittest.TestCase):
+    def test_adaptive_avg_pool2d_basic(self):
+        """Basic test of PyTorch adaptive_avg_pool2d Node."""
 
-    def test_f(inputs):
-        return F.adaptive_avg_pool2d(inputs, (5, 5))
+        def test_f(inputs):
+            return F.adaptive_avg_pool2d(inputs, (5, 5))
 
-    inputs = torch.randn(3, 6, 14, 14)
+        inputs = torch.randn(3, 6, 14, 14)
 
-    jitVsGlow(test_f, inputs, expected_fused_ops={"aten::adaptive_avg_pool2d"})
+        jitVsGlow(test_f, inputs, expected_fused_ops={"aten::adaptive_avg_pool2d"})
 
+    def test_adaptive_avg_pool2d_nonsquare_inputs(self):
+        """Test of PyTorch adaptive_avg_pool2d Node with non-square inputs."""
 
-def test_adaptive_avg_pool2d_nonsquare_inputs():
-    """Test of PyTorch adaptive_avg_pool2d Node with non-square inputs."""
+        def test_f(inputs):
+            return F.adaptive_avg_pool2d(inputs, (3, 3))
 
-    def test_f(inputs):
-        return F.adaptive_avg_pool2d(inputs, (3, 3))
+        inputs = torch.randn(3, 6, 13, 14)
 
-    inputs = torch.randn(3, 6, 13, 14)
+        jitVsGlow(test_f, inputs, expected_fused_ops={"aten::adaptive_avg_pool2d"})
 
-    jitVsGlow(test_f, inputs, expected_fused_ops={"aten::adaptive_avg_pool2d"})
+    def test_adaptive_avg_pool2d_nonsquare_outputs(self):
+        """Test of PyTorch adaptive_avg_pool2d Node with non-square outputs."""
 
+        def test_f(inputs):
+            return F.adaptive_avg_pool2d(inputs, (5, 3))
 
-def test_adaptive_avg_pool2d_nonsquare_outputs():
-    """Test of PyTorch adaptive_avg_pool2d Node with non-square outputs."""
+        inputs = torch.randn(3, 6, 14, 14)
 
-    def test_f(inputs):
-        return F.adaptive_avg_pool2d(inputs, (5, 3))
-
-    inputs = torch.randn(3, 6, 14, 14)
-
-    jitVsGlow(test_f, inputs, expected_fused_ops={"aten::adaptive_avg_pool2d"})
+        jitVsGlow(test_f, inputs, expected_fused_ops={"aten::adaptive_avg_pool2d"})

--- a/torch_glow/tests/nodes/add_test.py
+++ b/torch_glow/tests/nodes/add_test.py
@@ -3,90 +3,86 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import torch
 
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_add_basic():
-    """Basic test of the PyTorch add Node on Glow."""
+class TestAdd(unittest.TestCase):
+    def test_add_basic(self):
+        """Basic test of the PyTorch add Node on Glow."""
 
-    def test_f(a, b):
-        c = a.add(b)
-        return c.add(c)
+        def test_f(a, b):
+            c = a.add(b)
+            return c.add(c)
 
-    x = torch.randn(4)
-    y = torch.randn(4)
+        x = torch.randn(4)
+        y = torch.randn(4)
 
-    jitVsGlow(test_f, x, y, expected_fused_ops={"aten::add"})
+        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::add"})
 
+    def test_add_inplace(self):
+        """Test of the PyTorch add_ Node on Glow."""
 
-def test_add_inplace():
-    """Test of the PyTorch add_ Node on Glow."""
+        def test_f(a, b):
+            c = a.add_(b)
+            return c.add_(c)
 
-    def test_f(a, b):
-        c = a.add_(b)
-        return c.add_(c)
+        x = torch.randn(4)
+        y = torch.randn(4)
 
-    x = torch.randn(4)
-    y = torch.randn(4)
+        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::add_"})
 
-    jitVsGlow(test_f, x, y, expected_fused_ops={"aten::add_"})
+    def test_add_broadcast_1(self):
+        """Test of the PyTorch add Node on Glow with broadcasting."""
 
+        def test_f(a, b):
+            c = a.add(b)
+            return c.add(c)
 
-def test_add_broadcast_1():
-    """Test of the PyTorch add Node on Glow with broadcasting."""
+        x = torch.randn(8, 3, 4, 2)
+        y = torch.randn(4, 2)
 
-    def test_f(a, b):
-        c = a.add(b)
-        return c.add(c)
+        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::add"})
 
-    x = torch.randn(8, 3, 4, 2)
-    y = torch.randn(4, 2)
+    def test_add_broadcast_2(self):
+        """Test of the PyTorch add Node on Glow with broadcasting."""
 
-    jitVsGlow(test_f, x, y, expected_fused_ops={"aten::add"})
+        def test_f(a, b):
+            c = a.add(b)
+            return c.add(c)
 
+        x = torch.randn(8, 3, 4, 2)
+        y = torch.randn(1, 2)
 
-def test_add_broadcast_2():
-    """Test of the PyTorch add Node on Glow with broadcasting."""
+        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::add"})
 
-    def test_f(a, b):
-        c = a.add(b)
-        return c.add(c)
+    def test_add_broadcast_3(self):
+        """Test of the PyTorch add Node on Glow with broadcasting."""
 
-    x = torch.randn(8, 3, 4, 2)
-    y = torch.randn(1, 2)
+        def test_f(a, b):
+            c = a.add(b)
+            return c.add(c)
 
-    jitVsGlow(test_f, x, y, expected_fused_ops={"aten::add"})
+        x = torch.randn(4, 2)
+        y = torch.randn(8, 3, 4, 2)
 
+        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::add"})
 
-def test_add_broadcast_3():
-    """Test of the PyTorch add Node on Glow with broadcasting."""
+    def test_add_float(self):
+        """Test of the PyTorch aten::add Node with a float argument"""
 
-    def test_f(a, b):
-        c = a.add(b)
-        return c.add(c)
+        def test_f(a):
+            return (a * a).add(3.9)
 
-    x = torch.randn(4, 2)
-    y = torch.randn(8, 3, 4, 2)
+        x = torch.randn(4)
 
-    jitVsGlow(test_f, x, y, expected_fused_ops={"aten::add"})
+        jitVsGlow(test_f, x, expected_fused_ops={"aten::add"})
 
+    def test_add_int(self):
+        """Test of the PyTorch aten::add Node with an int argument"""
 
-def test_add_float():
-    """Test of the PyTorch aten::add Node with a float argument"""
+        def test_f(a):
+            return (a * a).add(20)
 
-    def test_f(a):
-        return (a*a).add(3.9)
+        x = torch.randn(4)
 
-    x = torch.randn(4)
-
-    jitVsGlow(test_f, x, expected_fused_ops={"aten::add"})
-
-
-def test_add_int():
-    """Test of the PyTorch aten::add Node with an int argument"""
-
-    def test_f(a):
-        return (a*a).add(20)
-
-    x = torch.randn(4)
-
-    jitVsGlow(test_f, x, expected_fused_ops={"aten::add"})
+        jitVsGlow(test_f, x, expected_fused_ops={"aten::add"})

--- a/torch_glow/tests/nodes/addmm_test.py
+++ b/torch_glow/tests/nodes/addmm_test.py
@@ -3,42 +3,42 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import torch
 
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_addmm_basic():
-    """Basic test of the PyTorch addmm Node on Glow."""
+class TestAddMM(unittest.TestCase):
+    def test_addmm_basic(self):
+        """Basic test of the PyTorch addmm Node on Glow."""
 
-    def test_f(a, b, c):
-        return (a+a).addmm(b, c)
+        def test_f(a, b, c):
+            return (a + a).addmm(b, c)
 
-    x = torch.randn(6, 4)
-    y = torch.randn(6, 10)
-    z = torch.randn(10, 4)
+        x = torch.randn(6, 4)
+        y = torch.randn(6, 10)
+        z = torch.randn(10, 4)
 
-    jitVsGlow(test_f, x, y, z, expected_fused_ops={"aten::add", "aten::mm"})
+        jitVsGlow(test_f, x, y, z, expected_fused_ops={"aten::add", "aten::mm"})
 
+    def test_addmm_broadcast(self):
+        """Test of the PyTorch addmm with broadcasting add on Glow."""
 
-def test_addmm_broadcast():
-    """Test of the PyTorch addmm with broadcasting add on Glow."""
+        def test_f(a, b, c):
+            return (a + a).addmm(b, c)
 
-    def test_f(a, b, c):
-        return (a+a).addmm(b, c)
+        x = torch.randn(4)
+        y = torch.randn(6, 10)
+        z = torch.randn(10, 4)
 
-    x = torch.randn(4)
-    y = torch.randn(6, 10)
-    z = torch.randn(10, 4)
+        jitVsGlow(test_f, x, y, z, expected_fused_ops={"aten::add", "aten::mm"})
 
-    jitVsGlow(test_f, x, y, z, expected_fused_ops={"aten::add", "aten::mm"})
+    def test_addmm_broadcast_with_alpha_and_beta(self):
+        """Test of the PyTorch addmm with broadcasting add on Glow."""
 
+        def test_f(a, b, c):
+            return (a + a).addmm(b, c, alpha=2.0, beta=3.0)
 
-def test_addmm_broadcast_with_alpha_and_beta():
-    """Test of the PyTorch addmm with broadcasting add on Glow."""
+        x = torch.randn(4)
+        y = torch.randn(6, 10)
+        z = torch.randn(10, 4)
 
-    def test_f(a, b, c):
-        return (a+a).addmm(b, c, alpha=2.0, beta=3.0)
-
-    x = torch.randn(4)
-    y = torch.randn(6, 10)
-    z = torch.randn(10, 4)
-
-    jitVsGlow(test_f, x, y, z, expected_fused_ops={"aten::addmm"})
+        jitVsGlow(test_f, x, y, z, expected_fused_ops={"aten::addmm"})

--- a/torch_glow/tests/nodes/avgpool2d_test.py
+++ b/torch_glow/tests/nodes/avgpool2d_test.py
@@ -4,23 +4,26 @@ import torch
 import torch.nn.functional as F
 
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_avg_pool2d_basic():
-    """Basic test of the PyTorch avg_pool2d Node on Glow."""
-    def test_f(inputs):
-        return F.avg_pool2d(inputs, 3)
+class TestAvgPool2d(unittest.TestCase):
+    def test_avg_pool2d_basic(self):
+        """Basic test of the PyTorch avg_pool2d Node on Glow."""
 
-    inputs = torch.randn(1, 4, 5, 5)
+        def test_f(inputs):
+            return F.avg_pool2d(inputs, 3)
 
-    jitVsGlow(test_f, inputs, expected_fused_ops={"aten::avg_pool2d"})
+        inputs = torch.randn(1, 4, 5, 5)
 
+        jitVsGlow(test_f, inputs, expected_fused_ops={"aten::avg_pool2d"})
 
-def test_avg_pool2d_with_args():
-    """Test of the PyTorch avg_pool2d Node with arguments on Glow."""
-    def test_f(inputs):
-        return F.avg_pool2d(inputs, padding=3, kernel_size=7)
+    def test_avg_pool2d_with_args(self):
+        """Test of the PyTorch avg_pool2d Node with arguments on Glow."""
 
-    inputs = torch.randn(1, 4, 10, 10)
+        def test_f(inputs):
+            return F.avg_pool2d(inputs, padding=3, kernel_size=7)
 
-    jitVsGlow(test_f, inputs, expected_fused_ops={"aten::avg_pool2d"})
+        inputs = torch.randn(1, 4, 10, 10)
+
+        jitVsGlow(test_f, inputs, expected_fused_ops={"aten::avg_pool2d"})

--- a/torch_glow/tests/nodes/batchnorm_test.py
+++ b/torch_glow/tests/nodes/batchnorm_test.py
@@ -4,40 +4,48 @@ import torch
 import torch.nn.functional as F
 
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_batchnorm_basic():
-    """Basic test of the PyTorch batchnorm Node on Glow."""
+class TestBatchNorm(unittest.TestCase):
+    def test_batchnorm_basic(self):
+        """Basic test of the PyTorch batchnorm Node on Glow."""
 
-    def test_f(inputs, running_mean, running_var):
-        return F.batch_norm(inputs, running_mean, running_var)
+        def test_f(inputs, running_mean, running_var):
+            return F.batch_norm(inputs, running_mean, running_var)
 
-    inputs = torch.randn(1, 4, 5, 5)
-    running_mean = torch.rand(4)
-    running_var = torch.rand(4)
+        inputs = torch.randn(1, 4, 5, 5)
+        running_mean = torch.rand(4)
+        running_var = torch.rand(4)
 
-    jitVsGlow(test_f, inputs, running_mean, running_var,
-              expected_fused_ops={"aten::batch_norm"})
+        jitVsGlow(
+            test_f,
+            inputs,
+            running_mean,
+            running_var,
+            expected_fused_ops={"aten::batch_norm"},
+        )
 
+    def test_batchnorm_with_weights(self):
+        """Test of the PyTorch batchnorm Node with weights and biases on Glow."""
 
-def test_batchnorm_with_weights():
-    """Test of the PyTorch batchnorm Node with weights and biases on Glow."""
+        def test_f(inputs, weight, bias, running_mean, running_var):
+            return F.batch_norm(
+                inputs, running_mean, running_var, weight=weight, bias=bias
+            )
 
-    def test_f(
-            inputs, weight, bias, running_mean, running_var):
-        return F.batch_norm(inputs, running_mean,
-                            running_var, weight=weight, bias=bias)
+        inputs = torch.randn(1, 4, 5, 5)
+        weight = torch.rand(4)
+        bias = torch.rand(4)
+        running_mean = torch.rand(4)
+        running_var = torch.rand(4)
 
-    inputs = torch.randn(1, 4, 5, 5)
-    weight = torch.rand(4)
-    bias = torch.rand(4)
-    running_mean = torch.rand(4)
-    running_var = torch.rand(4)
-
-    jitVsGlow(
-        test_f,
-        inputs,
-        weight,
-        bias,
-        running_mean,
-        running_var, expected_fused_ops={"aten::batch_norm"})
+        jitVsGlow(
+            test_f,
+            inputs,
+            weight,
+            bias,
+            running_mean,
+            running_var,
+            expected_fused_ops={"aten::batch_norm"},
+        )

--- a/torch_glow/tests/nodes/bmm_test.py
+++ b/torch_glow/tests/nodes/bmm_test.py
@@ -3,15 +3,17 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import torch
 
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_bmm():
-    """Basic test of the PyTorch bmm Node on Glow."""
+class TestBmm(unittest.TestCase):
+    def test_bmm(self):
+        """Basic test of the PyTorch bmm Node on Glow."""
 
-    def test_f(a, b):
-        return (a + a).bmm(b)
+        def test_f(a, b):
+            return (a + a).bmm(b)
 
-    x = torch.randn(6, 4, 10)
-    y = torch.randn(6, 10, 2)
+        x = torch.randn(6, 4, 10)
+        y = torch.randn(6, 10, 2)
 
-    jitVsGlow(test_f, x, y, expected_fused_ops={"aten::bmm"})
+        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::bmm"})

--- a/torch_glow/tests/nodes/cat_test.py
+++ b/torch_glow/tests/nodes/cat_test.py
@@ -3,17 +3,19 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import torch
 
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_cat_basic():
-    """Basic test of the PyTorch cat Node on Glow."""
+class TestCat(unittest.TestCase):
+    def test_cat_basic(self):
+        """Basic test of the PyTorch cat Node on Glow."""
 
-    def test_f(a, b):
-        c = torch.cat((a, b), 0)
-        d = torch.cat((c, c), 1)
-        return torch.cat((d, d), 2)
+        def test_f(a, b):
+            c = torch.cat((a, b), 0)
+            d = torch.cat((c, c), 1)
+            return torch.cat((d, d), 2)
 
-    x = torch.randn(2, 3, 4)
-    y = torch.randn(2, 3, 4)
+        x = torch.randn(2, 3, 4)
+        y = torch.randn(2, 3, 4)
 
-    jitVsGlow(test_f, x, y, expected_fused_ops={"prim::FusedConcat"})
+        jitVsGlow(test_f, x, y, expected_fused_ops={"prim::FusedConcat"})

--- a/torch_glow/tests/nodes/clamp_test.py
+++ b/torch_glow/tests/nodes/clamp_test.py
@@ -3,12 +3,14 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import torch
 
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_clamp():
-    """Test of the PyTorch clamp Node on Glow."""
+class TestClamp(unittest.TestCase):
+    def test_clamp(self):
+        """Test of the PyTorch clamp Node on Glow."""
 
-    def test_f(x):
-        return torch.clamp(x, 0.0, 6.0)
+        def test_f(x):
+            return torch.clamp(x, 0.0, 6.0)
 
-    jitVsGlow(test_f, torch.randn(7), expected_fused_ops={"aten::clamp"})
+        jitVsGlow(test_f, torch.randn(7), expected_fused_ops={"aten::clamp"})

--- a/torch_glow/tests/nodes/constant_chunk_test.py
+++ b/torch_glow/tests/nodes/constant_chunk_test.py
@@ -2,27 +2,26 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import torch
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_constant_chunk_basic():
-    """Test of prim::ConstantChunk node on glow"""
+class TestConstantChunk(unittest.TestCase):
+    def test_constant_chunk_basic(self):
+        """Test of prim::ConstantChunk node on glow"""
 
-    def test_f(x):
-        return torch.chunk(x + x, 3, 1)  # shapes: [(10,4), (10,4), (10,3)]
+        def test_f(x):
+            return torch.chunk(x + x, 3, 1)  # shapes: [(10,4), (10,4), (10,3)]
 
-    x = torch.rand((10, 11))
+        x = torch.rand((10, 11))
 
-    jitVsGlow(test_f, x,
-              expected_fused_ops={"prim::ConstantChunk"})
+        jitVsGlow(test_f, x, expected_fused_ops={"prim::ConstantChunk"})
 
+    def test_constant_chunk_negative_indices(self):
+        """Test of prim::ConstantChunk node on glow"""
 
-def test_constant_chunk_negative_indices():
-    """Test of prim::ConstantChunk node on glow"""
+        def test_f(x):
+            return torch.chunk(x + x, 3, -2)  # shapes: [(4,11), (4,11), (2,11)]
 
-    def test_f(x):
-        return torch.chunk(x + x, 3, -2)  # shapes: [(4,11), (4,11), (2,11)]
+        x = torch.rand((10, 11))
 
-    x = torch.rand((10, 11))
-
-    jitVsGlow(test_f, x,
-              expected_fused_ops={"prim::ConstantChunk"})
+        jitVsGlow(test_f, x, expected_fused_ops={"prim::ConstantChunk"})

--- a/torch_glow/tests/nodes/conv2d_test.py
+++ b/torch_glow/tests/nodes/conv2d_test.py
@@ -5,75 +5,74 @@ import torch.nn.functional as F
 from collections import namedtuple
 
 from tests.utils import jitVsGlow
-import pytest
+import unittest
 
 
-def test_conv2d_basic():
-    """Basic test of the PyTorch conv2d Node on Glow."""
-
-    def test_f(inputs, filters):
-        conv = F.conv2d(inputs, filters, padding=1)
-        return F.relu(conv)
-
-    inputs = torch.randn(1, 4, 5, 5)
-    filters = torch.randn(8, 4, 3, 3)
-
-    jitVsGlow(test_f, inputs, filters,
-              expected_fused_ops={"aten::_convolution"})
-
-
-def test_conv2d_with_bias():
-    """Test of the PyTorch conv2d Node with a provided bias tensor."""
-
-    def test_f(inputs, filters, bias):
-        conv = F.conv2d(inputs, filters, bias)
-        return F.relu(conv)
-
-    inputs = torch.randn(1, 4, 5, 5)
-    filters = torch.randn(8, 4, 3, 3)
-    bias = torch.randn(8)
-
-    jitVsGlow(test_f, inputs, filters, bias,
-              expected_fused_ops={"aten::_convolution"})
-
-
-@pytest.mark.skip(reason="not ready")
-def test_conv2d_param_sweep():
-    """
-    Test of the PyTorch conv2d Node sweeping through various parameters of the
-    Node to test that they work correctly.
-    """
-
-    hwOpts = [3, 4]
-    padOpts = [0, 1]
-    groupsOpts = [1, 2]
-    dilationOpts = [1, 2]
-    strideOpts = [1, 2]
-
-    Setting = namedtuple("Setting", ["h", "w", "p", "g", "d", "s"])
-
-    settings = [
-        Setting(h=h, w=w, p=p, g=g, d=d, s=s)
-        for h in hwOpts
-        for w in hwOpts
-        for p in padOpts
-        for g in groupsOpts
-        for d in dilationOpts
-        for s in strideOpts
-    ]
-
-    for setting in settings:
+class TestConv2d(unittest.TestCase):
+    def test_conv2d_basic(self):
+        """Basic test of the PyTorch conv2d Node on Glow."""
 
         def test_f(inputs, filters):
-            conv = F.conv2d(
-                inputs,
-                filters,
-                padding=setting.p,
-                groups=setting.g)
+            conv = F.conv2d(inputs, filters, padding=1)
             return F.relu(conv)
 
-        inputs = torch.randn(2, 4, setting.h, setting.w)
-        filters = torch.randn(8, 4 / setting.g, 3, 3)
+        inputs = torch.randn(1, 4, 5, 5)
+        filters = torch.randn(8, 4, 3, 3)
 
         jitVsGlow(test_f, inputs, filters,
                   expected_fused_ops={"aten::_convolution"})
+
+    def test_conv2d_with_bias(self):
+        """Test of the PyTorch conv2d Node with a provided bias tensor."""
+
+        def test_f(inputs, filters, bias):
+            conv = F.conv2d(inputs, filters, bias)
+            return F.relu(conv)
+
+        inputs = torch.randn(1, 4, 5, 5)
+        filters = torch.randn(8, 4, 3, 3)
+        bias = torch.randn(8)
+
+        jitVsGlow(test_f, inputs, filters, bias,
+                  expected_fused_ops={"aten::_convolution"})
+
+    @unittest.skip(reason="not ready")
+    def test_conv2d_param_sweep(self):
+        """
+        Test of the PyTorch conv2d Node sweeping through various parameters of the
+        Node to test that they work correctly.
+        """
+
+        hwOpts = [3, 4]
+        padOpts = [0, 1]
+        groupsOpts = [1, 2]
+        dilationOpts = [1, 2]
+        strideOpts = [1, 2]
+
+        Setting = namedtuple("Setting", ["h", "w", "p", "g", "d", "s"])
+
+        settings = [
+            Setting(h=h, w=w, p=p, g=g, d=d, s=s)
+            for h in hwOpts
+            for w in hwOpts
+            for p in padOpts
+            for g in groupsOpts
+            for d in dilationOpts
+            for s in strideOpts
+        ]
+
+        for setting in settings:
+
+            def test_f(inputs, filters):
+                conv = F.conv2d(
+                    inputs,
+                    filters,
+                    padding=setting.p,
+                    groups=setting.g)
+                return F.relu(conv)
+
+            inputs = torch.randn(2, 4, setting.h, setting.w)
+            filters = torch.randn(8, 4 / setting.g, 3, 3)
+
+            jitVsGlow(test_f, inputs, filters,
+                      expected_fused_ops={"aten::_convolution"})

--- a/torch_glow/tests/nodes/div_test.py
+++ b/torch_glow/tests/nodes/div_test.py
@@ -3,77 +3,74 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import torch
 
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_div_basic():
-    """Basic test of the PyTorch div Node on Glow."""
+class TestDiv(unittest.TestCase):
+    def test_div_basic(self):
+        """Basic test of the PyTorch div Node on Glow."""
 
-    def test_f(a, b):
-        c = a.div(b)
-        return c.div(c)
+        def test_f(a, b):
+            c = a.div(b)
+            return c.div(c)
 
-    x = torch.randn(4)
-    y = torch.randn(4)
+        x = torch.randn(4)
+        y = torch.randn(4)
 
-    jitVsGlow(test_f, x, y, expected_fused_ops={"aten::div"})
+        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::div"})
 
+    def test_div_broadcast_1(self):
+        """Test of the PyTorch div Node on Glow with broadcasting."""
 
-def test_div_broadcast_1():
-    """Test of the PyTorch div Node on Glow with broadcasting."""
+        def test_f(a, b):
+            c = a.div(b)
+            return c.div(c)
 
-    def test_f(a, b):
-        c = a.div(b)
-        return c.div(c)
+        x = torch.randn(8, 3, 4, 2)
+        y = torch.randn(4, 2)
 
-    x = torch.randn(8, 3, 4, 2)
-    y = torch.randn(4, 2)
+        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::div"})
 
-    jitVsGlow(test_f, x, y, expected_fused_ops={"aten::div"})
+    def test_div_broadcast_2(self):
+        """Test of the PyTorch div Node on Glow with broadcasting."""
 
+        def test_f(a, b):
+            c = a.div(b)
+            return c.div(c)
 
-def test_div_broadcast_2():
-    """Test of the PyTorch div Node on Glow with broadcasting."""
+        x = torch.randn(8, 3, 4, 2)
+        y = torch.randn(1, 2)
 
-    def test_f(a, b):
-        c = a.div(b)
-        return c.div(c)
+        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::div"})
 
-    x = torch.randn(8, 3, 4, 2)
-    y = torch.randn(1, 2)
+    def test_div_broadcast_3(self):
+        """Test of the PyTorch div Node on Glow with broadcasting."""
 
-    jitVsGlow(test_f, x, y, expected_fused_ops={"aten::div"})
+        def test_f(a, b):
+            c = a.div(b)
+            return c.div(c)
 
+        x = torch.randn(4, 2)
+        y = torch.randn(8, 3, 4, 2)
 
-def test_div_broadcast_3():
-    """Test of the PyTorch div Node on Glow with broadcasting."""
+        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::div"})
 
-    def test_f(a, b):
-        c = a.div(b)
-        return c.div(c)
+    def test_div_float(self):
+        """Test of the PyTorch aten::div Node with a float argument"""
 
-    x = torch.randn(4, 2)
-    y = torch.randn(8, 3, 4, 2)
+        def test_f(a):
+            return (a * a).div(3.9)
 
-    jitVsGlow(test_f, x, y, expected_fused_ops={"aten::div"})
+        x = torch.randn(4)
 
+        jitVsGlow(test_f, x, expected_fused_ops={"aten::div"})
 
-def test_div_float():
-    """Test of the PyTorch aten::div Node with a float argument"""
+    def test_div_int(self):
+        """Test of the PyTorch aten::div Node with an int argument"""
 
-    def test_f(a):
-        return (a*a).div(3.9)
+        def test_f(a):
+            return (a * a).div(20)
 
-    x = torch.randn(4)
+        x = torch.randn(4)
 
-    jitVsGlow(test_f, x, expected_fused_ops={"aten::div"})
-
-
-def test_div_int():
-    """Test of the PyTorch aten::div Node with an int argument"""
-
-    def test_f(a):
-        return (a*a).div(20)
-
-    x = torch.randn(4)
-
-    jitVsGlow(test_f, x, expected_fused_ops={"aten::div"})
+        jitVsGlow(test_f, x, expected_fused_ops={"aten::div"})

--- a/torch_glow/tests/nodes/dropout_test.py
+++ b/torch_glow/tests/nodes/dropout_test.py
@@ -4,25 +4,26 @@ import torch
 import torch.nn.functional as F
 
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_dropout():
-    """Basic test of the PyTorch aten::dropout Node on Glow."""
+class TestDropout(unittest.TestCase):
+    def test_dropout(self):
+        """Basic test of the PyTorch aten::dropout Node on Glow."""
 
-    def test_f(a):
-        return F.dropout(a + a, p=0.5, training=False)
+        def test_f(a):
+            return F.dropout(a + a, p=0.5, training=False)
 
-    x = torch.randn(6, 4, 10)
+        x = torch.randn(6, 4, 10)
 
-    jitVsGlow(test_f, x, expected_fused_ops={"aten::dropout"})
+        jitVsGlow(test_f, x, expected_fused_ops={"aten::dropout"})
 
+    def test_dropout_inplace(self):
+        """Basic test of the PyTorch aten::dropout_ Node on Glow."""
 
-def test_dropout_inplace():
-    """Basic test of the PyTorch aten::dropout_ Node on Glow."""
+        def test_f(a):
+            return F.dropout(a + a, p=0.5, training=False, inplace=True)
 
-    def test_f(a):
-        return F.dropout(a + a, p=0.5, training=False, inplace=True)
+        x = torch.randn(6, 4, 10)
 
-    x = torch.randn(6, 4, 10)
-
-    jitVsGlow(test_f, x, expected_fused_ops={"aten::dropout_"})
+        jitVsGlow(test_f, x, expected_fused_ops={"aten::dropout_"})

--- a/torch_glow/tests/nodes/embedding_bag_test.py
+++ b/torch_glow/tests/nodes/embedding_bag_test.py
@@ -2,22 +2,28 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import torch
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_embedding_bag_basic():
-    """Test of aten::embedding_bag node on glow"""
+class TestEmbeddingBag(unittest.TestCase):
+    def test_embedding_bag_basic(self):
+        """Test of aten::embedding_bag node on glow"""
 
-    def embedding_bag_basic(input, offsets, per_sample_weights):
-        weight = torch.FloatTensor([[1, 2.3, 3], [4, 5.1, 6.3]])
-        embedding_sum = torch.nn.EmbeddingBag.from_pretrained(
-            weight, mode='sum')
-        a = embedding_sum(input, offsets)
-        b = embedding_sum(input, offsets, per_sample_weights)
-        return a, b
+        def embedding_bag_basic(input, offsets, per_sample_weights):
+            weight = torch.FloatTensor([[1, 2.3, 3], [4, 5.1, 6.3]])
+            embedding_sum = torch.nn.EmbeddingBag.from_pretrained(weight, mode="sum")
+            a = embedding_sum(input, offsets)
+            b = embedding_sum(input, offsets, per_sample_weights)
+            return a, b
 
-    input = torch.LongTensor([1, 0, 0, 1, 1])
-    offsets = torch.LongTensor([0, 1])
-    per_sample_weights = torch.FloatTensor([1, 2, 3, 4, 5])
+        input = torch.LongTensor([1, 0, 0, 1, 1])
+        offsets = torch.LongTensor([0, 1])
+        per_sample_weights = torch.FloatTensor([1, 2, 3, 4, 5])
 
-    jitVsGlow(embedding_bag_basic, input, offsets, per_sample_weights,
-              expected_fused_ops={"aten::embedding_bag"})
+        jitVsGlow(
+            embedding_bag_basic,
+            input,
+            offsets,
+            per_sample_weights,
+            expected_fused_ops={"aten::embedding_bag"},
+        )

--- a/torch_glow/tests/nodes/exp_test.py
+++ b/torch_glow/tests/nodes/exp_test.py
@@ -3,15 +3,17 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import torch
 
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_exp_basic():
-    """Test of the PyTorch exp Node on Glow."""
+class TestExp(unittest.TestCase):
+    def test_exp_basic(self):
+        """Test of the PyTorch exp Node on Glow."""
 
-    def test_f(a):
-        b = torch.exp(a)
-        return torch.exp(b)
+        def test_f(a):
+            b = torch.exp(a)
+            return torch.exp(b)
 
-    x = torch.randn(4)
+        x = torch.randn(4)
 
-    jitVsGlow(test_f, x, expected_fused_ops={"aten::exp"})
+        jitVsGlow(test_f, x, expected_fused_ops={"aten::exp"})

--- a/torch_glow/tests/nodes/flatten_test.py
+++ b/torch_glow/tests/nodes/flatten_test.py
@@ -2,14 +2,16 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import torch
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_flatten_basic():
-    """Test of the PyTorch flatten Node on Glow."""
+class TestFaltten(unittest.TestCase):
+    def test_flatten_basic(self):
+        """Test of the PyTorch flatten Node on Glow."""
 
-    def flatten_basic(a):
-        return torch.flatten(a, 1)
+        def flatten_basic(a):
+            return torch.flatten(a, 1)
 
-    x = torch.randn(2, 2, 2)
+        x = torch.randn(2, 2, 2)
 
-    jitVsGlow(flatten_basic, x, expected_fused_ops={"aten::flatten"})
+        jitVsGlow(flatten_basic, x, expected_fused_ops={"aten::flatten"})

--- a/torch_glow/tests/nodes/gelu_test.py
+++ b/torch_glow/tests/nodes/gelu_test.py
@@ -4,15 +4,22 @@ import torch
 import torch.nn.functional as F
 
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_gelu_basic():
-    """Basic test of the PyTorch gelu Node on Glow."""
+class TestGelu(unittest.TestCase):
+    def test_gelu_basic(self):
+        """Basic test of the PyTorch gelu Node on Glow."""
 
-    def test_f(a):
-        return F.gelu(a + a)
+        def test_f(a):
+            return F.gelu(a + a)
 
-    for i in range(100):
-        x = torch.randn(10)
-        jitVsGlow(test_f, x, check_trace=False, atol=1e-3,
-                  expected_fused_ops={"aten::gelu"})
+        for i in range(100):
+            x = torch.randn(10)
+            jitVsGlow(
+                test_f,
+                x,
+                check_trace=False,
+                atol=1e-3,
+                expected_fused_ops={"aten::gelu"},
+            )

--- a/torch_glow/tests/nodes/getattr_test.py
+++ b/torch_glow/tests/nodes/getattr_test.py
@@ -3,36 +3,43 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import torch
 from tests.utils import GLOW_NODE_NAME, SUBGRAPH_ATTR
 import torch_glow
+import unittest
 
 
-def test_getattr():
-    """Test fusion of the PyTorch prim::GetAttr Node into the Glow subgraph."""
-    with torch.no_grad():
-        class Model(torch.nn.Module):
-            def __init__(self):
-                super(Model, self).__init__()
-                self.linear = torch.nn.Linear(2, 1)
+class TestGetAttr(unittest.TestCase):
+    def test_getattr(self):
+        """Test fusion of the PyTorch prim::GetAttr Node into the Glow subgraph."""
+        with torch.no_grad():
 
-            def forward(self, x):
-                return self.linear(x)
+            class Model(torch.nn.Module):
+                def __init__(self):
+                    super(Model, self).__init__()
+                    self.linear = torch.nn.Linear(2, 1)
 
-        x = torch.tensor([2., 3.])
+                def forward(self, x):
+                    return self.linear(x)
 
-        torch_glow.enableFusionPass()
+            x = torch.tensor([2.0, 3.0])
 
-        m = Model()
-        jit_m = torch.jit.trace(m, x)
-        jit_m_graph = jit_m.graph_for(x)
+            torch_glow.enableFusionPass()
 
-        # Ensure all prim::GetAttrs were fused and none were left out
-        found_getattrs = False
-        for node in jit_m_graph.nodes():
-            kind = node.kind()
-            assert kind != "prim::GetAttr", "Expected all prim::GetAttrsGlow to be in Glow subgraph"
-            if kind == GLOW_NODE_NAME:
-                glow_subgraph = node.g(SUBGRAPH_ATTR)
-                for node in glow_subgraph.nodes():
-                    if node.kind() == "prim::GetAttr":
-                        found_getattrs = True
+            m = Model()
+            jit_m = torch.jit.trace(m, x)
+            jit_m_graph = jit_m.graph_for(x)
 
-        assert found_getattrs, "Expected to find prim::GetAttrs in the Glow subgraph"
+            # Ensure all prim::GetAttrs were fused and none were left out
+            found_getattrs = False
+            for node in jit_m_graph.nodes():
+                kind = node.kind()
+                assert (
+                    kind != "prim::GetAttr"
+                ), "Expected all prim::GetAttrsGlow to be in Glow subgraph"
+                if kind == GLOW_NODE_NAME:
+                    glow_subgraph = node.g(SUBGRAPH_ATTR)
+                    for node in glow_subgraph.nodes():
+                        if node.kind() == "prim::GetAttr":
+                            found_getattrs = True
+
+            assert (
+                found_getattrs
+            ), "Expected to find prim::GetAttrs in the Glow subgraph"

--- a/torch_glow/tests/nodes/layernorm_test.py
+++ b/torch_glow/tests/nodes/layernorm_test.py
@@ -4,28 +4,28 @@ import torch
 import torch.nn.functional as F
 
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_layernorm_basic():
-    """Basic test of the PyTorch layernorm Node on Glow."""
+class TestLayerNorm(unittest.TestCase):
+    def test_layernorm_basic(self):
+        """Basic test of the PyTorch layernorm Node on Glow."""
 
-    def test_f(inputs, weight, bias):
-        return F.layer_norm(inputs, [5], weight, bias)
+        def test_f(inputs, weight, bias):
+            return F.layer_norm(inputs, [5], weight, bias)
 
-    inputs = torch.randn(1, 4, 5, 5)
-    weight = torch.randn(5)
-    bias = torch.randn(5)
+        inputs = torch.randn(1, 4, 5, 5)
+        weight = torch.randn(5)
+        bias = torch.randn(5)
 
-    jitVsGlow(test_f, inputs, weight, bias,
-              expected_fused_ops={"aten::layer_norm"})
+        jitVsGlow(test_f, inputs, weight, bias, expected_fused_ops={"aten::layer_norm"})
 
+    def test_layernorm_no_bias(self):
+        """Test of the PyTorch aten::layer_norm without weights and bias."""
 
-def test_layernorm_no_bias():
-    """Test of the PyTorch aten::layer_norm without weights and bias."""
+        def test_f(inputs):
+            return F.layer_norm(inputs, [5, 5])
 
-    def test_f(inputs):
-        return F.layer_norm(inputs, [5, 5])
+        inputs = torch.randn(1, 4, 5, 5)
 
-    inputs = torch.randn(1, 4, 5, 5)
-
-    jitVsGlow(test_f, inputs, expected_fused_ops={"aten::layer_norm"})
+        jitVsGlow(test_f, inputs, expected_fused_ops={"aten::layer_norm"})

--- a/torch_glow/tests/nodes/linear_test.py
+++ b/torch_glow/tests/nodes/linear_test.py
@@ -4,55 +4,55 @@ import torch
 import torch.nn.functional as F
 
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_linear_basic():
-    """Basic test of the PyTorch aten::linear op on Glow."""
+class TestLinear(unittest.TestCase):
+    def test_linear_basic(self):
+        """Basic test of the PyTorch aten::linear op on Glow."""
 
-    def test_f(input, weight, bias=None):
-        return F.linear((input+input), weight, bias)
+        def test_f(input, weight, bias=None):
+            return F.linear((input + input), weight, bias)
 
-    n = 5
-    in_features = 4
-    out_features = 3
+        n = 5
+        in_features = 4
+        out_features = 3
 
-    input = torch.randn(n, in_features)
-    weight = torch.randn(out_features, in_features)
+        input = torch.randn(n, in_features)
+        weight = torch.randn(out_features, in_features)
 
-    # expected_fused_ops has is empty because linear gets lowered to other ops
-    jitVsGlow(test_f, input, weight, expected_fused_ops={})
+        # expected_fused_ops has is empty because linear gets lowered to other ops
+        jitVsGlow(test_f, input, weight, expected_fused_ops={})
 
+    def test_linear_bias(self):
+        """Test of the PyTorch aten::linear op on Glow."""
 
-def test_linear_bias():
-    """Test of the PyTorch aten::linear op on Glow."""
+        def test_f(input, weight, bias=None):
+            return F.linear((input + input), weight, bias)
 
-    def test_f(input, weight, bias=None):
-        return F.linear((input+input), weight, bias)
+        n = 5
+        in_features = 4
+        out_features = 3
 
-    n = 5
-    in_features = 4
-    out_features = 3
+        input = torch.randn(n, in_features)
+        weight = torch.randn(out_features, in_features)
+        bias = torch.randn(out_features)
 
-    input = torch.randn(n, in_features)
-    weight = torch.randn(out_features, in_features)
-    bias = torch.randn(out_features)
+        # expected_fused_ops has is empty because linear gets lowered to other ops
+        jitVsGlow(test_f, input, weight, bias, expected_fused_ops={})
 
-    # expected_fused_ops has is empty because linear gets lowered to other ops
-    jitVsGlow(test_f, input, weight, bias, expected_fused_ops={})
+    def test_linear_broadcast(self):
+        """Test of the PyTorch aten::linear op with broadcasting on Glow."""
 
+        def test_f(input, weight, bias=None):
+            return F.linear((input + input), weight, bias)
 
-def test_linear_broadcast():
-    """Test of the PyTorch aten::linear op with broadcasting on Glow."""
+        n = 5
+        in_features = 4
+        out_features = 3
 
-    def test_f(input, weight, bias=None):
-        return F.linear((input+input), weight, bias)
+        input = torch.randn(n, 9, 7, in_features)
+        weight = torch.randn(out_features, in_features)
 
-    n = 5
-    in_features = 4
-    out_features = 3
-
-    input = torch.randn(n, 9, 7, in_features)
-    weight = torch.randn(out_features, in_features)
-
-    # expected_fused_ops has is empty because linear gets lowered to other ops
-    jitVsGlow(test_f, input, weight, expected_fused_ops={})
+        # expected_fused_ops has is empty because linear gets lowered to other ops
+        jitVsGlow(test_f, input, weight, expected_fused_ops={})

--- a/torch_glow/tests/nodes/matmul_test.py
+++ b/torch_glow/tests/nodes/matmul_test.py
@@ -4,124 +4,119 @@ import torch
 import random
 
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_matmul_1d_1d():
-    """Test of aten::matmul with two 1d inputs Glow."""
+class TestMatMul(unittest.TestCase):
+    def test_matmul_1d_1d(self):
+        """Test of aten::matmul with two 1d inputs Glow."""
 
-    def test_f(a, b):
-        return a.matmul(b+b)
+        def test_f(a, b):
+            return a.matmul(b + b)
 
-    x = torch.randn(4)
-    y = torch.randn(4)
+        x = torch.randn(4)
+        y = torch.randn(4)
 
-    jitVsGlow(test_f, x, y, expected_fused_ops={"aten::matmul"})
+        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::matmul"})
 
+    def test_matmul_2d_1d(self):
+        """Test of aten::matmul with 2d and 1d inputs Glow."""
 
-def test_matmul_2d_1d():
-    """Test of aten::matmul with 2d and 1d inputs Glow."""
+        def test_f(a, b):
+            return a.matmul(b + b)
 
-    def test_f(a, b):
-        return a.matmul(b+b)
+        x = torch.randn(9, 4)
+        y = torch.randn(4)
 
-    x = torch.randn(9, 4)
-    y = torch.randn(4)
+        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::matmul"})
 
-    jitVsGlow(test_f, x, y, expected_fused_ops={"aten::matmul"})
+    def test_matmul_3d_1d(self):
+        """Test of aten::matmul with 2d and 1d inputs Glow."""
 
+        def test_f(a, b):
+            return a.matmul(b + b)
 
-def test_matmul_3d_1d():
-    """Test of aten::matmul with 2d and 1d inputs Glow."""
+        x = torch.randn(6, 9, 4)
+        y = torch.randn(4)
 
-    def test_f(a, b):
-        return a.matmul(b+b)
+        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::matmul"})
 
-    x = torch.randn(6, 9, 4)
-    y = torch.randn(4)
+    def test_matmul_4d_1d(self):
+        """Test of aten::matmul with 2d and 1d inputs Glow."""
 
-    jitVsGlow(test_f, x, y, expected_fused_ops={"aten::matmul"})
+        def test_f(a, b):
+            return a.matmul(b + b)
 
+        x = torch.randn(2, 6, 9, 4)
+        y = torch.randn(4)
 
-def test_matmul_4d_1d():
-    """Test of aten::matmul with 2d and 1d inputs Glow."""
+        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::matmul"})
 
-    def test_f(a, b):
-        return a.matmul(b+b)
+    def test_matmul_1d_2d(self):
+        """Test of aten::matmul with 1d and 2d inputs Glow."""
 
-    x = torch.randn(2, 6, 9, 4)
-    y = torch.randn(4)
+        def test_f(a, b):
+            return a.matmul(b + b)
 
-    jitVsGlow(test_f, x, y, expected_fused_ops={"aten::matmul"})
+        x = torch.randn(4)
+        y = torch.randn(4, 9)
 
+        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::matmul"})
 
-def test_matmul_1d_2d():
-    """Test of aten::matmul with 1d and 2d inputs Glow."""
+    def test_matmul_1d_3d(self):
+        """Test of aten::matmul with 1d and 2d inputs Glow."""
 
-    def test_f(a, b):
-        return a.matmul(b+b)
+        def test_f(a, b):
+            return a.matmul(b + b)
 
-    x = torch.randn(4)
-    y = torch.randn(4, 9)
+        x = torch.randn(4)
+        y = torch.randn(3, 4, 9)
 
-    jitVsGlow(test_f, x, y, expected_fused_ops={"aten::matmul"})
+        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::matmul"})
 
+    def test_matmul_1d_4d(self):
+        """Test of aten::matmul with 1d and 2d inputs Glow."""
 
-def test_matmul_1d_3d():
-    """Test of aten::matmul with 1d and 2d inputs Glow."""
+        def test_f(a, b):
+            return a.matmul(b + b)
 
-    def test_f(a, b):
-        return a.matmul(b+b)
+        x = torch.randn(4)
+        y = torch.randn(5, 3, 4, 9)
 
-    x = torch.randn(4)
-    y = torch.randn(3, 4, 9)
+        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::matmul"})
 
-    jitVsGlow(test_f, x, y, expected_fused_ops={"aten::matmul"})
+    def test_matmul_nd_nd(self):
+        """Test of aten::matmul with >2d and >2d inputs Glow."""
 
+        def test_f(a, b):
+            return a.matmul(b + b)
 
-def test_matmul_1d_4d():
-    """Test of aten::matmul with 1d and 2d inputs Glow."""
+        def do_test(lhsDims, rhsDims):
+            lhs = torch.randn(lhsDims)
+            rhs = torch.randn(rhsDims)
 
-    def test_f(a, b):
-        return a.matmul(b+b)
+            jitVsGlow(test_f, lhs, rhs, expected_fused_ops={"aten::matmul"})
 
-    x = torch.randn(4)
-    y = torch.randn(5, 3, 4, 9)
+        def randomDimsOfRank(rank):
+            dims = []
+            for i in range(rank):
+                dim = random.randint(2, 9)
+                dims.append(dim)
+            return dims
 
-    jitVsGlow(test_f, x, y, expected_fused_ops={"aten::matmul"})
+        # Dimensions of base tensors that lhs and rhs will be built from
+        lhsBase = [3, 4]
+        rhsBase = [4, 2]
 
+        for additional_dims in range(3):
+            extension = randomDimsOfRank(additional_dims)
 
-def test_matmul_nd_nd():
-    """Test of aten::matmul with >2d and >2d inputs Glow."""
+            do_test(extension + lhsBase, rhsBase)
+            do_test([1] + extension + lhsBase, rhsBase)
+            do_test(extension + [1] + lhsBase, rhsBase)
 
-    def test_f(a, b):
-        return a.matmul(b+b)
+            do_test(lhsBase, extension + rhsBase)
+            do_test(lhsBase, [1] + extension + rhsBase)
+            do_test(lhsBase, extension + [1] + rhsBase)
 
-    def do_test(lhsDims, rhsDims):
-        lhs = torch.randn(lhsDims)
-        rhs = torch.randn(rhsDims)
-
-        jitVsGlow(test_f, lhs, rhs, expected_fused_ops={"aten::matmul"})
-
-    def randomDimsOfRank(rank):
-        dims = []
-        for i in range(rank):
-            dim = random.randint(2, 9)
-            dims.append(dim)
-        return dims
-
-    # Dimensions of base tensors that lhs and rhs will be built from
-    lhsBase = [3, 4]
-    rhsBase = [4, 2]
-
-    for additional_dims in range(3):
-        extension = randomDimsOfRank(additional_dims)
-
-        do_test(extension+lhsBase, rhsBase)
-        do_test([1]+extension+lhsBase, rhsBase)
-        do_test(extension+[1]+lhsBase, rhsBase)
-
-        do_test(lhsBase, extension+rhsBase)
-        do_test(lhsBase, [1]+extension+rhsBase)
-        do_test(lhsBase, extension+[1]+rhsBase)
-
-        do_test(extension+lhsBase, extension+rhsBase)
+            do_test(extension + lhsBase, extension + rhsBase)

--- a/torch_glow/tests/nodes/max_test.py
+++ b/torch_glow/tests/nodes/max_test.py
@@ -2,16 +2,18 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import torch
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_elementwise_max():
-    """Test of the PyTorch max Node on Glow."""
+class TestMax(unittest.TestCase):
+    def test_elementwise_max(self):
+        """Test of the PyTorch max Node on Glow."""
 
-    def test_f(a, b):
-        c = torch.max(a, b)
-        return torch.max(c, c)
+        def test_f(a, b):
+            c = torch.max(a, b)
+            return torch.max(c, c)
 
-    x = torch.randn(4)
-    y = torch.randn(4)
+        x = torch.randn(4)
+        y = torch.randn(4)
 
-    jitVsGlow(test_f, x, y, expected_fused_ops={"aten::max"})
+        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::max"})

--- a/torch_glow/tests/nodes/maxpool2d_test.py
+++ b/torch_glow/tests/nodes/maxpool2d_test.py
@@ -4,27 +4,26 @@ import torch
 import torch.nn.functional as F
 
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_max_pool2d_basic():
-    """Basic test of the PyTorch max_pool2d Node on Glow."""
+class TestMaxPool2d(unittest.TestCase):
+    def test_max_pool2d_basic(self):
+        """Basic test of the PyTorch max_pool2d Node on Glow."""
 
-    def test_f(inputs):
-        return F.max_pool2d(inputs, 3)
+        def test_f(inputs):
+            return F.max_pool2d(inputs, 3)
 
-    inputs = torch.randn(1, 4, 5, 5)
+        inputs = torch.randn(1, 4, 5, 5)
 
-    jitVsGlow(test_f, inputs,
-              expected_fused_ops={"aten::max_pool2d"})
+        jitVsGlow(test_f, inputs, expected_fused_ops={"aten::max_pool2d"})
 
+    def test_max_pool2d_with_args(self):
+        """Test of the PyTorch max_pool2d Node with arguments on Glow."""
 
-def test_max_pool2d_with_args():
-    """Test of the PyTorch max_pool2d Node with arguments on Glow."""
+        def test_f(inputs):
+            return F.max_pool2d(inputs, padding=3, kernel_size=7)
 
-    def test_f(inputs):
-        return F.max_pool2d(inputs, padding=3, kernel_size=7)
+        inputs = torch.randn(1, 4, 10, 10)
 
-    inputs = torch.randn(1, 4, 10, 10)
-
-    jitVsGlow(test_f, inputs,
-              expected_fused_ops={"aten::max_pool2d"})
+        jitVsGlow(test_f, inputs, expected_fused_ops={"aten::max_pool2d"})

--- a/torch_glow/tests/nodes/mean_test.py
+++ b/torch_glow/tests/nodes/mean_test.py
@@ -3,24 +3,26 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import torch
 
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_basic():
-    """Test of the PyTorch mean Node on Glow."""
+class TestMean(unittest.TestCase):
+    def test_basic(self):
+        """Test of the PyTorch mean Node on Glow."""
 
-    def test_f(a, b):
-        return torch.mean(a + b)
+        def test_f(a, b):
+            return torch.mean(a + b)
 
-    jitVsGlow(test_f, torch.randn(7), torch.randn(
-        7), expected_fused_ops={"aten::mean"})
+        jitVsGlow(
+            test_f, torch.randn(7), torch.randn(7), expected_fused_ops={"aten::mean"}
+        )
 
+    def test_with_dims(self):
+        """Test of the PyTorch mean node with dims on Glow. """
 
-def test_with_dims():
-    """Test of the PyTorch mean node with dims on Glow. """
+        def test_f(a, b):
+            return torch.mean(a + b, (1, 2))
 
-    def test_f(a, b):
-        return torch.mean(a + b, (1, 2))
-
-    x = torch.randn([1, 2, 3, 4])
-    y = torch.randn([1, 2, 3, 4])
-    jitVsGlow(test_f, x, y, expected_fused_ops={"aten::mean"})
+        x = torch.randn([1, 2, 3, 4])
+        y = torch.randn([1, 2, 3, 4])
+        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::mean"})

--- a/torch_glow/tests/nodes/min_test.py
+++ b/torch_glow/tests/nodes/min_test.py
@@ -3,13 +3,16 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import torch
 
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_elementwise_min():
-    """Test of the PyTorch min Node on Glow."""
+class TestMin(unittest.TestCase):
+    def test_elementwise_min(self):
+        """Test of the PyTorch min Node on Glow."""
 
-    def test_f(a, b):
-        return torch.min(a + a, b + b)
+        def test_f(a, b):
+            return torch.min(a + a, b + b)
 
-    jitVsGlow(test_f, torch.randn(7), torch.randn(
-        7), expected_fused_ops={"aten::min"})
+        jitVsGlow(
+            test_f, torch.randn(7), torch.randn(7), expected_fused_ops={"aten::min"}
+        )

--- a/torch_glow/tests/nodes/mm_test.py
+++ b/torch_glow/tests/nodes/mm_test.py
@@ -3,17 +3,19 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import torch
 
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_mm_basic():
-    """Test of the PyTorch mm Node on Glow."""
+class TestMm(unittest.TestCase):
+    def test_mm_basic(self):
+        """Test of the PyTorch mm Node on Glow."""
 
-    def test_f(a, b, t):
-        r = torch.mm(a, b)
-        return r.mm(t)
+        def test_f(a, b, t):
+            r = torch.mm(a, b)
+            return r.mm(t)
 
-    x = torch.randn(2, 3)
-    y = torch.randn(3, 4)
-    t = torch.randn(4, 2)
+        x = torch.randn(2, 3)
+        y = torch.randn(3, 4)
+        t = torch.randn(4, 2)
 
-    jitVsGlow(test_f, x, y, t, expected_fused_ops={"aten::mm"})
+        jitVsGlow(test_f, x, y, t, expected_fused_ops={"aten::mm"})

--- a/torch_glow/tests/nodes/mul_test.py
+++ b/torch_glow/tests/nodes/mul_test.py
@@ -3,77 +3,74 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import torch
 
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_mul_basic():
-    """Basic test of the PyTorch mul Node on Glow."""
+class TestMul(unittest.TestCase):
+    def test_mul_basic(self):
+        """Basic test of the PyTorch mul Node on Glow."""
 
-    def test_f(a, b):
-        c = a.mul(b)
-        return c.mul(c)
+        def test_f(a, b):
+            c = a.mul(b)
+            return c.mul(c)
 
-    x = torch.randn(4)
-    y = torch.randn(4)
+        x = torch.randn(4)
+        y = torch.randn(4)
 
-    jitVsGlow(test_f, x, y, expected_fused_ops={"aten::mul"})
+        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::mul"})
 
+    def test_mul_broadcast_1(self):
+        """Test of the PyTorch mul Node on Glow with broadcasting."""
 
-def test_mul_broadcast_1():
-    """Test of the PyTorch mul Node on Glow with broadcasting."""
+        def test_f(a, b):
+            c = a.mul(b)
+            return c.mul(c)
 
-    def test_f(a, b):
-        c = a.mul(b)
-        return c.mul(c)
+        x = torch.randn(8, 3, 4, 2)
+        y = torch.randn(4, 2)
 
-    x = torch.randn(8, 3, 4, 2)
-    y = torch.randn(4, 2)
+        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::mul"})
 
-    jitVsGlow(test_f, x, y, expected_fused_ops={"aten::mul"})
+    def test_mul_broadcast_2(self):
+        """Test of the PyTorch mul Node on Glow with broadcasting."""
 
+        def test_f(a, b):
+            c = a.mul(b)
+            return c.mul(c)
 
-def test_mul_broadcast_2():
-    """Test of the PyTorch mul Node on Glow with broadcasting."""
+        x = torch.randn(8, 3, 4, 2)
+        y = torch.randn(1, 2)
 
-    def test_f(a, b):
-        c = a.mul(b)
-        return c.mul(c)
+        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::mul"})
 
-    x = torch.randn(8, 3, 4, 2)
-    y = torch.randn(1, 2)
+    def test_mul_broadcast_3(self):
+        """Test of the PyTorch mul Node on Glow with broadcasting."""
 
-    jitVsGlow(test_f, x, y, expected_fused_ops={"aten::mul"})
+        def test_f(a, b):
+            c = a.mul(b)
+            return c.mul(c)
 
+        x = torch.randn(4, 2)
+        y = torch.randn(8, 3, 4, 2)
 
-def test_mul_broadcast_3():
-    """Test of the PyTorch mul Node on Glow with broadcasting."""
+        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::mul"})
 
-    def test_f(a, b):
-        c = a.mul(b)
-        return c.mul(c)
+    def test_mul_float(self):
+        """Test of the PyTorch aten::mul Node with a float argument"""
 
-    x = torch.randn(4, 2)
-    y = torch.randn(8, 3, 4, 2)
+        def test_f(a):
+            return (a + a).mul(3.9)
 
-    jitVsGlow(test_f, x, y, expected_fused_ops={"aten::mul"})
+        x = torch.randn(4)
 
+        jitVsGlow(test_f, x, expected_fused_ops={"aten::mul"})
 
-def test_mul_float():
-    """Test of the PyTorch aten::mul Node with a float argument"""
+    def test_mul_int(self):
+        """Test of the PyTorch aten::mul Node with an int argument"""
 
-    def test_f(a):
-        return (a+a).mul(3.9)
+        def test_f(a):
+            return (a + a).mul(20)
 
-    x = torch.randn(4)
+        x = torch.randn(4)
 
-    jitVsGlow(test_f, x, expected_fused_ops={"aten::mul"})
-
-
-def test_mul_int():
-    """Test of the PyTorch aten::mul Node with an int argument"""
-
-    def test_f(a):
-        return (a+a).mul(20)
-
-    x = torch.randn(4)
-
-    jitVsGlow(test_f, x, expected_fused_ops={"aten::mul"})
+        jitVsGlow(test_f, x, expected_fused_ops={"aten::mul"})

--- a/torch_glow/tests/nodes/permute_test.py
+++ b/torch_glow/tests/nodes/permute_test.py
@@ -3,15 +3,17 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import torch
 
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_permute():
-    """Basic test of the PyTorch aten::permute node on Glow."""
+class TestPermute(unittest.TestCase):
+    def test_permute(self):
+        """Basic test of the PyTorch aten::permute node on Glow."""
 
-    def test_f(a):
-        b = a.permute(0, 2, 1)
-        return b
+        def test_f(a):
+            b = a.permute(0, 2, 1)
+            return b
 
-    x = torch.randn(2, 3, 4)
+        x = torch.randn(2, 3, 4)
 
-    jitVsGlow(test_f, x, expected_fused_ops={"aten::permute"})
+        jitVsGlow(test_f, x, expected_fused_ops={"aten::permute"})

--- a/torch_glow/tests/nodes/pow_test.py
+++ b/torch_glow/tests/nodes/pow_test.py
@@ -2,15 +2,17 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import torch
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_pow_basic():
-    """Test of the PyTorch pow Node on Glow."""
+class TestPow(unittest.TestCase):
+    def test_pow_basic(self):
+        """Test of the PyTorch pow Node on Glow."""
 
-    def pow_basic(a):
-        b = torch.pow(a, 2.3)
-        return torch.pow(b, 3.4)
+        def pow_basic(a):
+            b = torch.pow(a, 2.3)
+            return torch.pow(b, 3.4)
 
-    x = torch.rand(4) + 5
+        x = torch.rand(4) + 5
 
-    jitVsGlow(pow_basic, x, expected_fused_ops={"aten::pow"})
+        jitVsGlow(pow_basic, x, expected_fused_ops={"aten::pow"})

--- a/torch_glow/tests/nodes/prelu_test.py
+++ b/torch_glow/tests/nodes/prelu_test.py
@@ -4,15 +4,17 @@ import torch
 import torch.nn.functional as F
 
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_prelu_basic():
-    """Basic test of the PyTorch prelu Node on Glow."""
+class TestPrelu(unittest.TestCase):
+    def test_prelu_basic(self):
+        """Basic test of the PyTorch prelu Node on Glow."""
 
-    def prelu_basic(inputs, weight):
-        return F.prelu(inputs+inputs, weight)
+        def prelu_basic(inputs, weight):
+            return F.prelu(inputs + inputs, weight)
 
-    inputs = torch.randn(1, 4, 5, 5)
-    weight = torch.tensor([0.25])
+        inputs = torch.randn(1, 4, 5, 5)
+        weight = torch.tensor([0.25])
 
-    jitVsGlow(prelu_basic, inputs, weight, expected_fused_ops={"aten::prelu"})
+        jitVsGlow(prelu_basic, inputs, weight, expected_fused_ops={"aten::prelu"})

--- a/torch_glow/tests/nodes/quantized_add_relu_test.py
+++ b/torch_glow/tests/nodes/quantized_add_relu_test.py
@@ -3,39 +3,61 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import torch
 
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_quantized_add_relu_zerooffset():
-    """Basic test of the PyTorch quantized::add Node_relu on Glow with zero offset."""
+class TestQuantizedAddRelu(unittest.TestCase):
+    def test_quantized_add_relu_zerooffset(self):
+        """Basic test of the PyTorch quantized::add Node_relu on Glow with zero offset."""
 
-    def test_f(a, b):
-        q = torch.nn.quantized.Quantize(
-            scale=0.3, zero_point=0, dtype=torch.quint8)
-        dq = torch.nn.quantized.DeQuantize()
-        return dq(torch.ops.quantized.add_relu(q(a), q(b), scale=0.05, zero_point=0))
+        def test_f(a, b):
+            q = torch.nn.quantized.Quantize(scale=0.3, zero_point=0, dtype=torch.quint8)
+            dq = torch.nn.quantized.DeQuantize()
+            return dq(
+                torch.ops.quantized.add_relu(q(a), q(b), scale=0.05, zero_point=0)
+            )
 
-    x = torch.tensor([1, 2, 3, 4], dtype=torch.float32)
-    y = torch.tensor([5, 6, 7, 8], dtype=torch.float32)
+        x = torch.tensor([1, 2, 3, 4], dtype=torch.float32)
+        y = torch.tensor([5, 6, 7, 8], dtype=torch.float32)
 
-    jitVsGlow(test_f, x, y, expected_fused_ops={"quantized::add_relu",
-                                                "aten::quantize_per_tensor",
-                                                "aten::dequantize"})
+        jitVsGlow(
+            test_f,
+            x,
+            y,
+            expected_fused_ops={
+                "quantized::add_relu",
+                "aten::quantize_per_tensor",
+                "aten::dequantize",
+            },
+        )
 
+    def test_quantized_add_relu(self):
+        """Basic test of the PyTorch quantized::add_relu Node on Glow."""
 
-def test_quantized_add_relu():
-    """Basic test of the PyTorch quantized::add_relu Node on Glow."""
+        def test_f(a, b):
+            q1 = torch.nn.quantized.Quantize(
+                scale=1.0 / 128, zero_point=5, dtype=torch.quint8
+            )
+            q2 = torch.nn.quantized.Quantize(
+                scale=1.0 / 128, zero_point=10, dtype=torch.quint8
+            )
+            dq = torch.nn.quantized.DeQuantize()
+            return dq(
+                torch.ops.quantized.add_relu(
+                    q1(a), q2(b), scale=1.0 / 128, zero_point=3
+                )
+            )
 
-    def test_f(a, b):
-        q1 = torch.nn.quantized.Quantize(
-            scale=1.0/128, zero_point=5, dtype=torch.quint8)
-        q2 = torch.nn.quantized.Quantize(
-            scale=1.0/128, zero_point=10, dtype=torch.quint8)
-        dq = torch.nn.quantized.DeQuantize()
-        return dq(torch.ops.quantized.add_relu(q1(a), q2(b), scale=1.0/128, zero_point=3))
+        x = torch.randn([5, 5])
+        y = torch.randn([5, 5])
 
-    x = torch.randn([5, 5])
-    y = torch.randn([5, 5])
-
-    jitVsGlow(test_f, x, y, expected_fused_ops={"quantized::add_relu",
-                                                "aten::quantize_per_tensor",
-                                                "aten::dequantize"})
+        jitVsGlow(
+            test_f,
+            x,
+            y,
+            expected_fused_ops={
+                "quantized::add_relu",
+                "aten::quantize_per_tensor",
+                "aten::dequantize",
+            },
+        )

--- a/torch_glow/tests/nodes/quantized_add_test.py
+++ b/torch_glow/tests/nodes/quantized_add_test.py
@@ -3,39 +3,57 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import torch
 
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_quantized_add_zerooffset():
-    """Basic test of the PyTorch quantized::add Node on Glow with zero offset."""
+class TestQuantizedAdd(unittest.TestCase):
+    def test_quantized_add_zerooffset(self):
+        """Basic test of the PyTorch quantized::add Node on Glow with zero offset."""
 
-    def test_f(a, b):
-        q = torch.nn.quantized.Quantize(
-            scale=0.3, zero_point=0, dtype=torch.quint8)
-        dq = torch.nn.quantized.DeQuantize()
-        return dq(torch.ops.quantized.add(q(a), q(b), scale=0.05, zero_point=0))
+        def test_f(a, b):
+            q = torch.nn.quantized.Quantize(scale=0.3, zero_point=0, dtype=torch.quint8)
+            dq = torch.nn.quantized.DeQuantize()
+            return dq(torch.ops.quantized.add(q(a), q(b), scale=0.05, zero_point=0))
 
-    x = torch.tensor([1, 2, 3, 4], dtype=torch.float32)
-    y = torch.tensor([5, 6, 7, 8], dtype=torch.float32)
+        x = torch.tensor([1, 2, 3, 4], dtype=torch.float32)
+        y = torch.tensor([5, 6, 7, 8], dtype=torch.float32)
 
-    jitVsGlow(test_f, x, y, expected_fused_ops={"quantized::add",
-                                                "aten::quantize_per_tensor",
-                                                "aten::dequantize"})
+        jitVsGlow(
+            test_f,
+            x,
+            y,
+            expected_fused_ops={
+                "quantized::add",
+                "aten::quantize_per_tensor",
+                "aten::dequantize",
+            },
+        )
 
+    def test_quantized_add(self):
+        """Basic test of the PyTorch quantized::add Node on Glow."""
 
-def test_quantized_add():
-    """Basic test of the PyTorch quantized::add Node on Glow."""
+        def test_f(a, b):
+            q1 = torch.nn.quantized.Quantize(
+                scale=1.0 / 128, zero_point=5, dtype=torch.quint8
+            )
+            q2 = torch.nn.quantized.Quantize(
+                scale=1.0 / 128, zero_point=10, dtype=torch.quint8
+            )
+            dq = torch.nn.quantized.DeQuantize()
+            return dq(
+                torch.ops.quantized.add(q1(a), q2(b), scale=1.0 / 128, zero_point=3)
+            )
 
-    def test_f(a, b):
-        q1 = torch.nn.quantized.Quantize(
-            scale=1.0/128, zero_point=5, dtype=torch.quint8)
-        q2 = torch.nn.quantized.Quantize(
-            scale=1.0/128, zero_point=10, dtype=torch.quint8)
-        dq = torch.nn.quantized.DeQuantize()
-        return dq(torch.ops.quantized.add(q1(a), q2(b), scale=1.0/128, zero_point=3))
+        x = torch.randn([5, 5])
+        y = torch.randn([5, 5])
 
-    x = torch.randn([5, 5])
-    y = torch.randn([5, 5])
-
-    jitVsGlow(test_f, x, y, expected_fused_ops={"quantized::add",
-                                                "aten::quantize_per_tensor",
-                                                "aten::dequantize"})
+        jitVsGlow(
+            test_f,
+            x,
+            y,
+            expected_fused_ops={
+                "quantized::add",
+                "aten::quantize_per_tensor",
+                "aten::dequantize",
+            },
+        )

--- a/torch_glow/tests/nodes/quantized_avgpool_test.py
+++ b/torch_glow/tests/nodes/quantized_avgpool_test.py
@@ -3,20 +3,29 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import torch
 
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_quantized_avgpool():
-    """Basic test of the PyTorch quantized::avg_pool2d Node on Glow."""
+class TestQuantizedAvgPool(unittest.TestCase):
+    def test_quantized_avgpool(self):
+        """Basic test of the PyTorch quantized::avg_pool2d Node on Glow."""
 
-    def test_f(a):
-        q = torch.nn.quantized.Quantize(
-            scale=1.0/128, zero_point=3, dtype=torch.quint8)
-        dq = torch.nn.quantized.DeQuantize()
-        ap = torch.nn.AvgPool2d(3)
-        return dq(ap(q(a)))
+        def test_f(a):
+            q = torch.nn.quantized.Quantize(
+                scale=1.0 / 128, zero_point=3, dtype=torch.quint8
+            )
+            dq = torch.nn.quantized.DeQuantize()
+            ap = torch.nn.AvgPool2d(3)
+            return dq(ap(q(a)))
 
-    inputs = torch.randn(1, 4, 5, 5)
+        inputs = torch.randn(1, 4, 5, 5)
 
-    jitVsGlow(test_f, inputs, expected_fused_ops={"aten::avg_pool2d",
-                                                  "aten::quantize_per_tensor",
-                                                  "aten::dequantize"})
+        jitVsGlow(
+            test_f,
+            inputs,
+            expected_fused_ops={
+                "aten::avg_pool2d",
+                "aten::quantize_per_tensor",
+                "aten::dequantize",
+            },
+        )

--- a/torch_glow/tests/nodes/quantized_conv2d_test.py
+++ b/torch_glow/tests/nodes/quantized_conv2d_test.py
@@ -3,82 +3,109 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import torch
 
 from tests.utils import jitVsGlow
-import pytest
+import unittest
 
 
-def test_quantized_conv2d_unpacked():
-    """Basic test of the PyTorch quantize::conv2d Node with unpacked weights on Glow."""
+class TestQuantizedConv2d(unittest.TestCase):
+    def test_quantized_conv2d_unpacked(self):
+        """Basic test of the PyTorch quantize::conv2d Node with unpacked weights on Glow."""
 
-    def test_f(a, w, b):
-        qu = torch.nn.quantized.Quantize(1/16, 0, torch.quint8)
-        qi = torch.nn.quantized.Quantize(1/16, 0, torch.qint8)
+        def test_f(a, w, b):
+            qu = torch.nn.quantized.Quantize(1 / 16, 0, torch.quint8)
+            qi = torch.nn.quantized.Quantize(1 / 16, 0, torch.qint8)
+            dq = torch.nn.quantized.DeQuantize()
+            conv = torch.nn.quantized.functional.conv2d
+            return dq(conv(qu(a), qi(w), b))
+
+        # TODO
+        # Due to the quantization error between
+        # PyTorch and Glow, we would like to use some
+        # determined test data instead of random ones
+        # x = torch.randn([3, 3, 3, 3])
+        # w = torch.randn([3, 3, 3, 3])
+        # b = torch.randn([3])
+
+        x = torch.tensor([[[[5.0, 6.0], [7.0, 8.0]]]])
+        w = torch.tensor([[[[1.0, 2.0], [3.0, 4.0]]]])
+        b_zero = torch.zeros(1)
+        b = torch.randn(1)
+
+        jitVsGlow(
+            test_f,
+            x,
+            w,
+            b,
+            expected_fused_ops={
+                "aten::quantize_per_tensor",
+                "glow::unpacked_quantized_conv2d",
+                "aten::dequantize",
+            },
+        )
+
+        jitVsGlow(
+            test_f,
+            x,
+            w,
+            b_zero,
+            expected_fused_ops={
+                "aten::quantize_per_tensor",
+                "glow::unpacked_quantized_conv2d",
+                "aten::dequantize",
+            },
+        )
+
+    def test_quantized_conv2d_packed_groupwise(self):
+        """Basic test of PyTorch quantize::conv2d Node with packed weights on Glow."""
+
+        x = torch.tensor(range(5), dtype=torch.float)
+        x = torch.cat((x, x, x, x, x))
+        x = torch.cat((x, x, x))
+        x = torch.reshape(x, [1, 3, 5, 5])
+        q = torch.nn.quantized.Quantize(0.1, 2, torch.quint8)
+        conv = torch.nn.Conv2d(3, 3, [2, 2], groups=3)
         dq = torch.nn.quantized.DeQuantize()
-        conv = torch.nn.quantized.functional.conv2d
-        return dq(conv(qu(a), qi(w), b))
 
-    # TODO
-    # Due to the quantization error between
-    # PyTorch and Glow, we would like to use some
-    # determined test data instead of random ones
-    # x = torch.randn([3, 3, 3, 3])
-    # w = torch.randn([3, 3, 3, 3])
-    # b = torch.randn([3])
+        # Due to the off-by-one error, we cannot let the weights, bias & input
+        # to be totally random.
+        conv.weight.data.fill_(2.0)
+        conv.bias.data.fill_(1.0)
 
-    x = torch.tensor([[[[5., 6.], [7., 8.]]]])
-    w = torch.tensor([[[[1., 2.], [3., 4.]]]])
-    b_zero = torch.zeros(1)
-    b = torch.randn(1)
+        model = torch.nn.Sequential(q, conv, dq)
+        model.eval()
+        model.qconfig = torch.quantization.get_default_qconfig("fbgemm")
 
-    jitVsGlow(test_f, x, w, b, expected_fused_ops={"aten::quantize_per_tensor",
-                                                   "glow::unpacked_quantized_conv2d",
-                                                   "aten::dequantize"})
+        torch.quantization.prepare(model, inplace=True)
+        torch.quantization.convert(model, inplace=True)
 
-    jitVsGlow(test_f, x, w, b_zero, expected_fused_ops={"aten::quantize_per_tensor",
-                                                        "glow::unpacked_quantized_conv2d",
-                                                        "aten::dequantize"})
+        jitVsGlow(
+            model,
+            x,
+            expected_fused_ops={
+                "aten::quantize_per_tensor",
+                "quantized::conv2d",
+                "aten::dequantize",
+            },
+        )
 
+    @unittest.skip(reason="accuracy between glow & pytorch")
+    def test_quantized_conv2d_nonfunctional(self):
+        """Basic test of the PyTorch quantized conv2d Node with external quantized
+        input on Glow."""
 
-def test_quantized_conv2d_packed_groupwise():
-    """Basic test of PyTorch quantize::conv2d Node with packed weights on Glow."""
+        def test_f(a):
+            q = torch.nn.quantized.Quantize(1 / 16, 0, torch.quint8)
+            dq = torch.nn.quantized.DeQuantize()
+            conv = torch.nn.quantized.Conv2d(1, 1, [2, 2])
+            return dq(conv(q(a)))
 
-    x = torch.tensor(range(5), dtype=torch.float)
-    x = torch.cat((x, x, x, x, x))
-    x = torch.cat((x, x, x))
-    x = torch.reshape(x, [1, 3, 5, 5])
-    q = torch.nn.quantized.Quantize(0.1, 2, torch.quint8)
-    conv = torch.nn.Conv2d(3, 3, [2, 2], groups=3)
-    dq = torch.nn.quantized.DeQuantize()
+        x = torch.tensor([[[[5.0, 6.0], [7.0, 8.0]]]])
 
-    # Due to the off-by-one error, we cannot let the weights, bias & input
-    # to be totally random.
-    conv.weight.data.fill_(2.0)
-    conv.bias.data.fill_(1.0)
-
-    model = torch.nn.Sequential(q, conv, dq)
-    model.eval()
-    model.qconfig = torch.quantization.get_default_qconfig('fbgemm')
-
-    torch.quantization.prepare(model, inplace=True)
-    torch.quantization.convert(model, inplace=True)
-
-    jitVsGlow(model, x, expected_fused_ops={"aten::quantize_per_tensor",
-                                            "quantized::conv2d",
-                                            "aten::dequantize"})
-
-
-@pytest.mark.skip(reason="accuracy between glow & pytorch")
-def test_quantized_conv2d_nonfunctional():
-    """Basic test of the PyTorch quantized conv2d Node with external quantized
-    input on Glow."""
-
-    def test_f(a):
-        q = torch.nn.quantized.Quantize(1/16, 0, torch.quint8)
-        dq = torch.nn.quantized.DeQuantize()
-        conv = torch.nn.quantized.Conv2d(1, 1, [2, 2])
-        return dq(conv(q(a)))
-
-    x = torch.tensor([[[[5., 6.], [7., 8.]]]])
-
-    jitVsGlow(test_f, x, expected_fused_ops={"aten::quantize_per_tensor",
-                                             "glow::unpacked_quantized_conv2d",
-                                             "aten::dequantize"})
+        jitVsGlow(
+            test_f,
+            x,
+            expected_fused_ops={
+                "aten::quantize_per_tensor",
+                "glow::unpacked_quantized_conv2d",
+                "aten::dequantize",
+            },
+        )

--- a/torch_glow/tests/nodes/quantized_linear_test.py
+++ b/torch_glow/tests/nodes/quantized_linear_test.py
@@ -3,55 +3,71 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import torch
 
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_quantized_linear_packed():
-    """Basic test of the PyTorch quantized::linear Node on Glow."""
+class TestQuantizedLinear(unittest.TestCase):
+    def test_quantized_linear_packed(self):
+        """Basic test of the PyTorch quantized::linear Node on Glow."""
 
-    q = torch.nn.quantized.Quantize(scale=1/25, zero_point=17,
-                                    dtype=torch.quint8)
-    dq = torch.nn.quantized.DeQuantize()
-    linear = torch.nn.Linear(5, 5)
-
-    linear.weight.data.fill_(1.2)
-    linear.bias.data.fill_(3.0)
-
-    model = torch.nn.Sequential(q, linear, dq)
-    model.qconfig = torch.quantization.get_default_qconfig('fbgemm')
-    torch.quantization.prepare(model, inplace=True)
-    torch.quantization.convert(model, inplace=True)
-
-    x = torch.tensor(range(5), dtype=torch.float)
-    x = torch.cat((x, x, x, x, x))
-    x = torch.reshape(x, [5, 5])
-
-    jitVsGlow(model, x, expected_fused_ops={"aten::quantize_per_tensor",
-                                            "quantized::linear",
-                                            "aten::dequantize"})
-
-
-def test_quantized_linear_random_input():
-    """Basic test of the PyTorch quantized::linear Node on Glow."""
-
-    def test_f(inputs, weights, bias=None):
-        q_int = torch.nn.quantized.Quantize(
-            scale=1/13, zero_point=0, dtype=torch.qint8)
-        q_uint = torch.nn.quantized.Quantize(
-            scale=1/13, zero_point=10, dtype=torch.quint8)
-
+        q = torch.nn.quantized.Quantize(scale=1 / 25, zero_point=17, dtype=torch.quint8)
         dq = torch.nn.quantized.DeQuantize()
+        linear = torch.nn.Linear(5, 5)
 
-        q_inputs = q_uint(inputs)
-        q_weights = q_int(weights)
+        linear.weight.data.fill_(1.2)
+        linear.bias.data.fill_(3.0)
 
-        return dq(torch.nn.quantized.functional.linear(q_inputs, q_weights, bias))
+        model = torch.nn.Sequential(q, linear, dq)
+        model.qconfig = torch.quantization.get_default_qconfig("fbgemm")
+        torch.quantization.prepare(model, inplace=True)
+        torch.quantization.convert(model, inplace=True)
 
-    for _ in range(100):
-        inputs = torch.randn(7, 7)
-        weights = torch.randn(7, 7)
+        x = torch.tensor(range(5), dtype=torch.float)
+        x = torch.cat((x, x, x, x, x))
+        x = torch.reshape(x, [5, 5])
 
-        bias = torch.tensor([1, 1, 1, 1, 1, 1, 1], dtype=torch.float) * 0.1
+        jitVsGlow(
+            model,
+            x,
+            expected_fused_ops={
+                "aten::quantize_per_tensor",
+                "quantized::linear",
+                "aten::dequantize",
+            },
+        )
 
-        jitVsGlow(test_f, inputs, weights, bias, expected_fused_ops={
-            "glow::unpacked_quantized_linear", "aten::quantize_per_tensor",
-            "aten::dequantize"})
+    def test_quantized_linear_random_input(self):
+        """Basic test of the PyTorch quantized::linear Node on Glow."""
+
+        def test_f(inputs, weights, bias=None):
+            q_int = torch.nn.quantized.Quantize(
+                scale=1 / 13, zero_point=0, dtype=torch.qint8
+            )
+            q_uint = torch.nn.quantized.Quantize(
+                scale=1 / 13, zero_point=10, dtype=torch.quint8
+            )
+
+            dq = torch.nn.quantized.DeQuantize()
+
+            q_inputs = q_uint(inputs)
+            q_weights = q_int(weights)
+
+            return dq(torch.nn.quantized.functional.linear(q_inputs, q_weights, bias))
+
+        for _ in range(100):
+            inputs = torch.randn(7, 7)
+            weights = torch.randn(7, 7)
+
+            bias = torch.tensor([1, 1, 1, 1, 1, 1, 1], dtype=torch.float) * 0.1
+
+            jitVsGlow(
+                test_f,
+                inputs,
+                weights,
+                bias,
+                expected_fused_ops={
+                    "glow::unpacked_quantized_linear",
+                    "aten::quantize_per_tensor",
+                    "aten::dequantize",
+                },
+            )

--- a/torch_glow/tests/nodes/quantized_maxpool_test.py
+++ b/torch_glow/tests/nodes/quantized_maxpool_test.py
@@ -3,20 +3,29 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import torch
 
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_quantized_maxpool():
-    """Basic test of the PyTorch quantized::max_pool2d Node on Glow."""
+class TestQuantizedMaxPool(unittest.TestCase):
+    def test_quantized_maxpool(self):
+        """Basic test of the PyTorch quantized::max_pool2d Node on Glow."""
 
-    def test_f(a):
-        q = torch.nn.quantized.Quantize(
-            scale=1.0/128, zero_point=3, dtype=torch.quint8)
-        dq = torch.nn.quantized.DeQuantize()
-        mp = torch.nn.MaxPool2d(3)
-        return dq(mp(q(a)))
+        def test_f(a):
+            q = torch.nn.quantized.Quantize(
+                scale=1.0 / 128, zero_point=3, dtype=torch.quint8
+            )
+            dq = torch.nn.quantized.DeQuantize()
+            mp = torch.nn.MaxPool2d(3)
+            return dq(mp(q(a)))
 
-    inputs = torch.randn(1, 4, 5, 5)
+        inputs = torch.randn(1, 4, 5, 5)
 
-    jitVsGlow(test_f, inputs, expected_fused_ops={"aten::max_pool2d",
-                                                  "aten::quantize_per_tensor",
-                                                  "aten::dequantize"})
+        jitVsGlow(
+            test_f,
+            inputs,
+            expected_fused_ops={
+                "aten::max_pool2d",
+                "aten::quantize_per_tensor",
+                "aten::dequantize",
+            },
+        )

--- a/torch_glow/tests/nodes/quantized_relu_test.py
+++ b/torch_glow/tests/nodes/quantized_relu_test.py
@@ -3,20 +3,29 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import torch
 
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_quantized_relu():
-    """Basic test of the PyTorch quantized::relu Node on Glow."""
+class TestQuantizedRelu(unittest.TestCase):
+    def test_quantized_relu(self):
+        """Basic test of the PyTorch quantized::relu Node on Glow."""
 
-    def test_f(a):
-        q = torch.nn.quantized.Quantize(
-            scale=1.0/128, zero_point=3, dtype=torch.quint8)
-        dq = torch.nn.quantized.DeQuantize()
-        re = torch.nn.quantized.ReLU()
-        return dq(re(q(a)))
+        def test_f(a):
+            q = torch.nn.quantized.Quantize(
+                scale=1.0 / 128, zero_point=3, dtype=torch.quint8
+            )
+            dq = torch.nn.quantized.DeQuantize()
+            re = torch.nn.quantized.ReLU()
+            return dq(re(q(a)))
 
-    x = torch.randn([5, 5])
+        x = torch.randn([5, 5])
 
-    jitVsGlow(test_f, x, expected_fused_ops={"aten::relu",
-                                             "aten::quantize_per_tensor",
-                                             "aten::dequantize"})
+        jitVsGlow(
+            test_f,
+            x,
+            expected_fused_ops={
+                "aten::relu",
+                "aten::quantize_per_tensor",
+                "aten::dequantize",
+            },
+        )

--- a/torch_glow/tests/nodes/reciprocal_test.py
+++ b/torch_glow/tests/nodes/reciprocal_test.py
@@ -2,26 +2,27 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import torch
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_reciprocal():
-    """Test of the PyTorch reciprocal Node on Glow."""
+class TestReciprocal(unittest.TestCase):
+    def test_reciprocal(self):
+        """Test of the PyTorch reciprocal Node on Glow."""
 
-    def test_f(a):
-        return torch.reciprocal(a + a)
+        def test_f(a):
+            return torch.reciprocal(a + a)
 
-    x = torch.randn(4)
+        x = torch.randn(4)
 
-    jitVsGlow(test_f, x, expected_fused_ops={"aten::reciprocal"})
+        jitVsGlow(test_f, x, expected_fused_ops={"aten::reciprocal"})
 
+    def test_inplace_reciprocal(self):
+        """Test of the PyTorch inplace reciprocal Node on Glow."""
 
-def test_inplace_reciprocal():
-    """Test of the PyTorch inplace reciprocal Node on Glow."""
+        def test_f(a):
+            b = a + a
+            return b.reciprocal_()
 
-    def test_f(a):
-        b = a + a
-        return b.reciprocal_()
+        x = torch.randn(4)
 
-    x = torch.randn(4)
-
-    jitVsGlow(test_f, x, expected_fused_ops={"aten::reciprocal_"})
+        jitVsGlow(test_f, x, expected_fused_ops={"aten::reciprocal_"})

--- a/torch_glow/tests/nodes/relu_test.py
+++ b/torch_glow/tests/nodes/relu_test.py
@@ -4,31 +4,32 @@ import torch
 import torch.nn.functional as F
 
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_relu_basic():
-    """Basic test of the PyTorch relu Node on Glow."""
+class TestRelu(unittest.TestCase):
+    def test_relu_basic(self):
+        """Basic test of the PyTorch relu Node on Glow."""
 
-    def test_f(a):
-        b = F.relu(a)
-        return F.relu(b)
+        def test_f(a):
+            b = F.relu(a)
+            return F.relu(b)
 
-    x = torch.randn(4)
-    # make sure we have at least one negative
-    x[0] = -2.0
+        x = torch.randn(4)
+        # make sure we have at least one negative
+        x[0] = -2.0
 
-    jitVsGlow(test_f, x, expected_fused_ops={"aten::relu"})
+        jitVsGlow(test_f, x, expected_fused_ops={"aten::relu"})
 
+    def test_relu_inplace(self):
+        """Test of the PyTorch relu_ Node on Glow."""
 
-def test_relu_inplace():
-    """Test of the PyTorch relu_ Node on Glow."""
+        def test_f(a):
+            b = F.relu(a, inplace=True)
+            return F.relu(b, inplace=True)
 
-    def test_f(a):
-        b = F.relu(a, inplace=True)
-        return F.relu(b, inplace=True)
+        x = torch.randn(4)
+        # make sure we have at least one negative
+        x[0] = -2.0
 
-    x = torch.randn(4)
-    # make sure we have at least one negative
-    x[0] = -2.0
-
-    jitVsGlow(test_f, x, expected_fused_ops={"aten::relu_"})
+        jitVsGlow(test_f, x, expected_fused_ops={"aten::relu_"})

--- a/torch_glow/tests/nodes/reshape_test.py
+++ b/torch_glow/tests/nodes/reshape_test.py
@@ -2,15 +2,17 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import torch
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_reshape():
-    """Test of the PyTorch reshape Node on Glow."""
+class TestReshape(unittest.TestCase):
+    def test_reshape(self):
+        """Test of the PyTorch reshape Node on Glow."""
 
-    def test_f(a):
-        b = a + a
-        return b.reshape([2, -1])
+        def test_f(a):
+            b = a + a
+            return b.reshape([2, -1])
 
-    x = torch.rand(2, 3, 4)
+        x = torch.rand(2, 3, 4)
 
-    jitVsGlow(test_f, x, expected_fused_ops={"aten::reshape"})
+        jitVsGlow(test_f, x, expected_fused_ops={"aten::reshape"})

--- a/torch_glow/tests/nodes/sigmoid_test.py
+++ b/torch_glow/tests/nodes/sigmoid_test.py
@@ -4,25 +4,28 @@ import torch
 import torch_glow
 
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_sigmoid_basic():
-    """Basic test of the PyTorch sigmoid Node on Glow"""
-    def sigmoid_basic(a):
-        c = a + a
-        return c.sigmoid()
+class TestSigmoid(unittest.TestCase):
+    def test_sigmoid_basic(self):
+        """Basic test of the PyTorch sigmoid Node on Glow"""
 
-    x = torch.randn(6)
+        def sigmoid_basic(a):
+            c = a + a
+            return c.sigmoid()
 
-    jitVsGlow(sigmoid_basic, x, expected_fused_ops={"aten::sigmoid"})
+        x = torch.randn(6)
 
+        jitVsGlow(sigmoid_basic, x, expected_fused_ops={"aten::sigmoid"})
 
-def test_sigmoid_inplace():
-    """Test of the inplace PyTorch sigmoid Node on Glow"""
-    def sigmoid_inplace(a):
-        c = a + a
-        return c.sigmoid_()
+    def test_sigmoid_inplace(self):
+        """Test of the inplace PyTorch sigmoid Node on Glow"""
 
-    x = torch.randn(6)
+        def sigmoid_inplace(a):
+            c = a + a
+            return c.sigmoid_()
 
-    jitVsGlow(sigmoid_inplace, x, expected_fused_ops={"aten::sigmoid_"})
+        x = torch.randn(6)
+
+        jitVsGlow(sigmoid_inplace, x, expected_fused_ops={"aten::sigmoid_"})

--- a/torch_glow/tests/nodes/size_test.py
+++ b/torch_glow/tests/nodes/size_test.py
@@ -3,18 +3,19 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import torch
 
 from tests.utils import jitVsGlow
-import pytest
+import unittest
 
 
-# Need to be able to export lists from Glow fused nodes
-@pytest.mark.skip(reason="not ready")
-def test_size_basic():
-    """Test of the PyTorch aten::size Node on Glow."""
+class TestSize(unittest.TestCase):
+    # Need to be able to export lists from Glow fused nodes
+    @unittest.skip(reason="not ready")
+    def test_size_basic(self):
+        """Test of the PyTorch aten::size Node on Glow."""
 
-    def test_f(a):
-        b = a + a.size(0)
-        return b
+        def test_f(a):
+            b = a + a.size(0)
+            return b
 
-    x = torch.zeros([4], dtype=torch.int32)
+        x = torch.zeros([4], dtype=torch.int32)
 
-    jitVsGlow(test_f, x, expected_fused_ops={"aten::size"})
+        jitVsGlow(test_f, x, expected_fused_ops={"aten::size"})

--- a/torch_glow/tests/nodes/slice_test.py
+++ b/torch_glow/tests/nodes/slice_test.py
@@ -2,15 +2,17 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import torch
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_slice_basic():
-    """Test of the PyTorch slice Node on Glow."""
+class TestSlice(unittest.TestCase):
+    def test_slice_basic(self):
+        """Test of the PyTorch slice Node on Glow."""
 
-    def slice_basic(a):
-        b = (a+a)[1:]
-        return b[0][1:]
+        def slice_basic(a):
+            b = (a + a)[1:]
+            return b[0][1:]
 
-    x = torch.rand((2, 3))
+        x = torch.rand((2, 3))
 
-    jitVsGlow(slice_basic, x, expected_fused_ops={"aten::slice"})
+        jitVsGlow(slice_basic, x, expected_fused_ops={"aten::slice"})

--- a/torch_glow/tests/nodes/softmax_test.py
+++ b/torch_glow/tests/nodes/softmax_test.py
@@ -1,13 +1,17 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import torch
 import torch.nn.functional as F
 
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_softmax_basic():
-    """Basic test of the PyTorch SoftMax Node on Glow."""
-    def softmax_basic(inputs):
-        return F.softmax(inputs, dim=1)
+class TestSoftmax(unittest.TestCase):
+    def test_softmax_basic(self):
+        """Basic test of the PyTorch SoftMax Node on Glow."""
+        def softmax_basic(inputs):
+            return F.softmax(inputs, dim=1)
 
-    inputs = torch.randn(2, 3)
-    jitVsGlow(softmax_basic, inputs, expected_fused_ops={"aten::softmax"})
+        inputs = torch.randn(2, 3)
+        jitVsGlow(softmax_basic, inputs, expected_fused_ops={"aten::softmax"})

--- a/torch_glow/tests/nodes/sqrt_test.py
+++ b/torch_glow/tests/nodes/sqrt_test.py
@@ -2,29 +2,30 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import torch
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_sqrt_basic():
-    """Test of the PyTorch sqrt Node on Glow."""
+class TestSqrt(unittest.TestCase):
+    def test_sqrt_basic(self):
+        """Test of the PyTorch sqrt Node on Glow."""
 
-    def test_f(a):
-        b = torch.sqrt(a)
-        return torch.sqrt(b)
+        def test_f(a):
+            b = torch.sqrt(a)
+            return torch.sqrt(b)
 
-    # Make sure the input is positive and not super close to zero.
-    x = torch.rand(4) + 5
+        # Make sure the input is positive and not super close to zero.
+        x = torch.rand(4) + 5
 
-    jitVsGlow(test_f, x, expected_fused_ops={"aten::sqrt"})
+        jitVsGlow(test_f, x, expected_fused_ops={"aten::sqrt"})
 
+    def test_sqrt_inplace(self):
+        """Test of the PyTorch inplace sqrt Node on Glow."""
 
-def test_sqrt_inplace():
-    """Test of the PyTorch inplace sqrt Node on Glow."""
+        def test_f(a):
+            b = a.sqrt_()
+            return b.sqrt_()
 
-    def test_f(a):
-        b = a.sqrt_()
-        return b.sqrt_()
+        # Make sure the input is positive and not super close to zero.
+        x = torch.rand(4) + 5
 
-    # Make sure the input is positive and not super close to zero.
-    x = torch.rand(4) + 5
-
-    jitVsGlow(test_f, x, expected_fused_ops={"aten::sqrt_"})
+        jitVsGlow(test_f, x, expected_fused_ops={"aten::sqrt_"})

--- a/torch_glow/tests/nodes/stack_test.py
+++ b/torch_glow/tests/nodes/stack_test.py
@@ -3,17 +3,19 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import torch
 
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_stack_basic():
-    """Basic test of the PyTorch aten::stack Node on Glow."""
+class TestStack(unittest.TestCase):
+    def test_stack_basic(self):
+        """Basic test of the PyTorch aten::stack Node on Glow."""
 
-    def test_f(a, b):
-        c = torch.stack((a, b), 0)
-        d = torch.stack((c, c), 1)
-        return torch.stack((d, d), 2)
+        def test_f(a, b):
+            c = torch.stack((a, b), 0)
+            d = torch.stack((c, c), 1)
+            return torch.stack((d, d), 2)
 
-    x = torch.randn(2, 3, 4)
-    y = torch.randn(2, 3, 4)
+        x = torch.randn(2, 3, 4)
+        y = torch.randn(2, 3, 4)
 
-    jitVsGlow(test_f, x, y, expected_fused_ops={"glow::fused_stack"})
+        jitVsGlow(test_f, x, y, expected_fused_ops={"glow::fused_stack"})

--- a/torch_glow/tests/nodes/sub_test.py
+++ b/torch_glow/tests/nodes/sub_test.py
@@ -3,77 +3,74 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import torch
 
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_sub_basic():
-    """Basic test of the PyTorch sub Node on Glow."""
+class TestSub(unittest.TestCase):
+    def test_sub_basic(self):
+        """Basic test of the PyTorch sub Node on Glow."""
 
-    def test_f(a, b):
-        c = a.sub(b)
-        return c.sub(c)
+        def test_f(a, b):
+            c = a.sub(b)
+            return c.sub(c)
 
-    x = torch.randn(4)
-    y = torch.randn(4)
+        x = torch.randn(4)
+        y = torch.randn(4)
 
-    jitVsGlow(test_f, x, y, expected_fused_ops={"aten::sub"})
+        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::sub"})
 
+    def test_sub_broadcast_1(self):
+        """Test of the PyTorch sub Node on Glow with broadcasting."""
 
-def test_sub_broadcast_1():
-    """Test of the PyTorch sub Node on Glow with broadcasting."""
+        def test_f(a, b):
+            c = a.sub(b)
+            return c.sub(c)
 
-    def test_f(a, b):
-        c = a.sub(b)
-        return c.sub(c)
+        x = torch.randn(8, 3, 4, 2)
+        y = torch.randn(4, 2)
 
-    x = torch.randn(8, 3, 4, 2)
-    y = torch.randn(4, 2)
+        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::sub"})
 
-    jitVsGlow(test_f, x, y, expected_fused_ops={"aten::sub"})
+    def test_sub_broadcast_2(self):
+        """Test of the PyTorch sub Node on Glow with broadcasting."""
 
+        def test_f(a, b):
+            c = a.sub(b)
+            return c.sub(c)
 
-def test_sub_broadcast_2():
-    """Test of the PyTorch sub Node on Glow with broadcasting."""
+        x = torch.randn(8, 3, 4, 2)
+        y = torch.randn(1, 2)
 
-    def test_f(a, b):
-        c = a.sub(b)
-        return c.sub(c)
+        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::sub"})
 
-    x = torch.randn(8, 3, 4, 2)
-    y = torch.randn(1, 2)
+    def test_sub_broadcast_3(self):
+        """Test of the PyTorch sub Node on Glow with broadcasting."""
 
-    jitVsGlow(test_f, x, y, expected_fused_ops={"aten::sub"})
+        def test_f(a, b):
+            c = a.sub(b)
+            return c.sub(c)
 
+        x = torch.randn(4, 2)
+        y = torch.randn(8, 3, 4, 2)
 
-def test_sub_broadcast_3():
-    """Test of the PyTorch sub Node on Glow with broadcasting."""
+        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::sub"})
 
-    def test_f(a, b):
-        c = a.sub(b)
-        return c.sub(c)
+    def test_sub_float(self):
+        """Test of the PyTorch aten::sub Node with a float argument"""
 
-    x = torch.randn(4, 2)
-    y = torch.randn(8, 3, 4, 2)
+        def test_f(a):
+            return (a * a).sub(3.9)
 
-    jitVsGlow(test_f, x, y, expected_fused_ops={"aten::sub"})
+        x = torch.randn(4)
 
+        jitVsGlow(test_f, x, expected_fused_ops={"aten::sub"})
 
-def test_sub_float():
-    """Test of the PyTorch aten::sub Node with a float argument"""
+    def test_sub_int(self):
+        """Test of the PyTorch aten::sub Node with an int argument"""
 
-    def test_f(a):
-        return (a*a).sub(3.9)
+        def test_f(a):
+            return (a * a).sub(20)
 
-    x = torch.randn(4)
+        x = torch.randn(4)
 
-    jitVsGlow(test_f, x, expected_fused_ops={"aten::sub"})
-
-
-def test_sub_int():
-    """Test of the PyTorch aten::sub Node with an int argument"""
-
-    def test_f(a):
-        return (a*a).sub(20)
-
-    x = torch.randn(4)
-
-    jitVsGlow(test_f, x, expected_fused_ops={"aten::sub"})
+        jitVsGlow(test_f, x, expected_fused_ops={"aten::sub"})

--- a/torch_glow/tests/nodes/tanh_test.py
+++ b/torch_glow/tests/nodes/tanh_test.py
@@ -3,25 +3,26 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import torch
 
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_tanh():
-    """Basic test of the PyTorch aten::tanh Node on Glow."""
+class TestTanh(unittest.TestCase):
+    def test_tanh(self):
+        """Basic test of the PyTorch aten::tanh Node on Glow."""
 
-    def test_f(a):
-        return (a + a).tanh()
+        def test_f(a):
+            return (a + a).tanh()
 
-    x = torch.randn(4)
+        x = torch.randn(4)
 
-    jitVsGlow(test_f, x, expected_fused_ops={"aten::tanh"})
+        jitVsGlow(test_f, x, expected_fused_ops={"aten::tanh"})
 
+    def test_tanh_inplace(self):
+        """Basic test of the PyTorch aten::tanh_ Node on Glow."""
 
-def test_tanh_inplace():
-    """Basic test of the PyTorch aten::tanh_ Node on Glow."""
+        def test_f(a):
+            return (a + a).tanh_()
 
-    def test_f(a):
-        return (a + a).tanh_()
+        x = torch.randn(4)
 
-    x = torch.randn(4)
-
-    jitVsGlow(test_f, x, expected_fused_ops={"aten::tanh_"})
+        jitVsGlow(test_f, x, expected_fused_ops={"aten::tanh_"})

--- a/torch_glow/tests/nodes/topk_test.py
+++ b/torch_glow/tests/nodes/topk_test.py
@@ -3,15 +3,17 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import torch
 
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_topk_basic():
-    """Test of the PyTorch TopK Node on Glow."""
+class TestTopk(unittest.TestCase):
+    def test_topk_basic(self):
+        """Test of the PyTorch TopK Node on Glow."""
 
-    def test_topk(x):
-        x+x
-        return torch.topk(x, 3)
+        def test_topk(x):
+            x + x
+            return torch.topk(x, 3)
 
-    x = torch.arange(1., 6.)
+        x = torch.arange(1.0, 6.0)
 
-    jitVsGlow(test_topk, x, expected_fused_ops={"aten::topk"})
+        jitVsGlow(test_topk, x, expected_fused_ops={"aten::topk"})

--- a/torch_glow/tests/nodes/transpose_test.py
+++ b/torch_glow/tests/nodes/transpose_test.py
@@ -3,63 +3,61 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import torch
 
 from tests.utils import jitVsGlow
+import unittest
 
 
-def test_t_2d():
-    """Test of PyTorch aten::t on Glow with 2d inputs."""
+class TestTranspose(unittest.TestCase):
+    def test_t_2d(self):
+        """Test of PyTorch aten::t on Glow with 2d inputs."""
 
-    def test_f(a):
-        b = a + a
-        return b.t()
+        def test_f(a):
+            b = a + a
+            return b.t()
 
-    x = torch.randn(7, 4)
+        x = torch.randn(7, 4)
 
-    jitVsGlow(test_f, x, expected_fused_ops={"aten::t"})
+        jitVsGlow(test_f, x, expected_fused_ops={"aten::t"})
 
+    def test_t_1d(self):
+        """Test of PyTorch aten::t on Glow with 1d inputs."""
 
-def test_t_1d():
-    """Test of PyTorch aten::t on Glow with 1d inputs."""
+        def test_f(a):
+            b = a + a
+            return b.t()
 
-    def test_f(a):
-        b = a + a
-        return b.t()
+        x = torch.randn(7)
 
-    x = torch.randn(7)
+        jitVsGlow(test_f, x, expected_fused_ops={"aten::t"})
 
-    jitVsGlow(test_f, x, expected_fused_ops={"aten::t"})
+    def test_t_inplace(self):
+        """Test of PyTorch aten::t_ (in place t) on Glow."""
 
+        def test_f(a):
+            b = a + a
+            return b.t_()
 
-def test_t_inplace():
-    """Test of PyTorch aten::t_ (in place t) on Glow."""
+        x = torch.randn(7, 4)
 
-    def test_f(a):
-        b = a + a
-        return b.t_()
+        jitVsGlow(test_f, x, expected_fused_ops={"aten::t_"})
 
-    x = torch.randn(7, 4)
+    def test_transpose(self):
+        """Test of PyTorch aten::transpose on Glow."""
 
-    jitVsGlow(test_f, x, expected_fused_ops={"aten::t_"})
+        def test_f(a):
+            b = a + a
+            return b.transpose(1, 2)
 
+        x = torch.randn(2, 3, 4)
 
-def test_transpose():
-    """Test of PyTorch aten::transpose on Glow."""
+        jitVsGlow(test_f, x, expected_fused_ops={"aten::transpose"})
 
-    def test_f(a):
-        b = a + a
-        return b.transpose(1, 2)
+    def test_transpose_inplace(self):
+        """Test of PyTorch aten::transpose on Glow."""
 
-    x = torch.randn(2, 3, 4)
+        def test_f(a):
+            b = a + a
+            return b.transpose_(1, 2)
 
-    jitVsGlow(test_f, x, expected_fused_ops={"aten::transpose"})
+        x = torch.randn(2, 3, 4)
 
-
-def test_transpose_inplace():
-    """Test of PyTorch aten::transpose on Glow."""
-
-    def test_f(a):
-        b = a + a
-        return b.transpose_(1, 2)
-
-    x = torch.randn(2, 3, 4)
-
-    jitVsGlow(test_f, x, expected_fused_ops={"aten::transpose_"})
+        jitVsGlow(test_f, x, expected_fused_ops={"aten::transpose_"})


### PR DESCRIPTION
Summary:
Due to recent change to GroupwiseQuantizedConv (https://github.com/pytorch/glow/pull/3877), we need to change the implementation for OpenCL backend. This PR disable the test until the impl is changed since this backend isn't being actively used now. 

Documentation:

[Optional Fixes #issue]

Test Plan:

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
