### PR TITLE
Disabel GroupwiseQuantizedConvolution/0 for OpenCL backend

### DIFF
--- a/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
@@ -278,5 +278,6 @@ std::set<std::string> glow::backendTestBlacklist = {
     "RepeatedSLSWithPartialTensors/0",
     "GatherWithInt32PartialTensors/0",
     "GatherWithInt64PartialTensors/0",
+    "GroupwiseQuantizedConvolution/0",
     "ParallelBatchMatMul_Float16/0",
 };


### PR DESCRIPTION
Summary:
Due to recent change to GroupwiseQuantizedConv (#3877), we need to change the implementation for OpenCL backend. This PR disable the test until the impl is changed since this backend isn't being actively used now.

Documentation:

[Optional Fixes #issue]

Test Plan:

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
