### PR TITLE
Add Backend option to Backend creation

### DIFF
--- a/include/glow/Backend/Backend.h
+++ b/include/glow/Backend/Backend.h
@@ -203,8 +203,10 @@ protected:
   void autoInstrument(TraceInfo &traceInfo, IRFunction *IR) const;
 };
 
-/// Create a backend based on the registered backend name \p backendName.
-Backend *createBackend(llvm::StringRef backendName);
+/// Create a backend based on the registered backend name \p backendName with \p
+/// backendOptions.
+Backend *createBackend(llvm::StringRef backendName,
+                       const BackendOptions &backendOptions = {});
 
 // Backends that use Glow low-level IR should inherit from this class. It allows
 // for unit tests to create low-level IR to compile and run.
@@ -218,14 +220,17 @@ public:
 
 /// Perform Backend Factory registration.
 #define REGISTER_GLOW_BACKEND_FACTORY(FactoryName, BackendClass)               \
-  class FactoryName : public BaseFactory<std::string, Backend> {               \
+  class FactoryName                                                            \
+      : public BaseFactory<std::string, Backend, BackendOptions> {             \
   public:                                                                      \
-    Backend *create() override { return new BackendClass(); }                  \
+    Backend *create(const BackendOptions &backendOptions) override {           \
+      return new BackendClass(backendOptions);                                 \
+    }                                                                          \
     std::string getRegistrationKey() const override {                          \
       return BackendClass::getName();                                          \
     }                                                                          \
   };                                                                           \
-  static RegisterFactory<std::string, FactoryName, Backend>                    \
+  static RegisterFactory<std::string, FactoryName, Backend, BackendOptions>    \
       FactoryName##_REGISTERED;
 
 /// The backend name used in Glow quantization profiling.

--- a/include/glow/Backends/DeviceManager.h
+++ b/include/glow/Backends/DeviceManager.h
@@ -89,7 +89,9 @@ public:
   virtual ~DeviceManager() = default;
 
   /// Create a device manager based on the device config \p config.
-  static DeviceManager *createDeviceManager(const DeviceConfig &config);
+  static DeviceManager *
+  createDeviceManager(const DeviceConfig &config,
+                      const BackendOptions &backendOptions = {});
 
   /// Query the system for the number of devices of a specified kind.
   static unsigned numDevices(llvm::StringRef backendName);

--- a/include/glow/Backends/Interpreter/Interpreter.h
+++ b/include/glow/Backends/Interpreter/Interpreter.h
@@ -29,6 +29,7 @@ class Interpreter final : public BackendUsingGlowIR {
 public:
   /// Ctor.
   Interpreter() = default;
+  Interpreter(const BackendOptions &) : Interpreter() {}
 
   /// @name Backend methods.
   /// This is the implementation of the Backend interface.

--- a/lib/Backends/Backends.cpp
+++ b/lib/Backends/Backends.cpp
@@ -18,13 +18,15 @@
 
 namespace glow {
 
-Backend *createBackend(llvm::StringRef backendName) {
-  auto *backend = FactoryRegistry<std::string, Backend>::get(backendName);
+Backend *createBackend(llvm::StringRef backendName,
+                       const BackendOptions &backendOptions) {
+  auto *backend = FactoryRegistry<std::string, Backend, BackendOptions>::get(
+      backendName, backendOptions);
 
   if (backend == nullptr) {
     LOG(INFO) << "List of all registered backends:";
     for (const auto &factory :
-         FactoryRegistry<std::string, Backend>::factories()) {
+         FactoryRegistry<std::string, Backend, BackendOptions>::factories()) {
       LOG(INFO) << factory.first;
     }
   }

--- a/lib/Backends/CPU/CPUBackend.h
+++ b/lib/Backends/CPU/CPUBackend.h
@@ -32,6 +32,7 @@ class NodeInfo;
 class CPUBackend : public LLVMBackend {
 public:
   CPUBackend() = default;
+  CPUBackend(const BackendOptions &) : CPUBackend(){};
 
   /// @name Backend methods.
   /// This is the implementation of the Backend interface.

--- a/lib/Backends/DeviceManagers.cpp
+++ b/lib/Backends/DeviceManagers.cpp
@@ -33,16 +33,19 @@ using namespace glow::runtime;
 namespace glow {
 namespace runtime {
 
-DeviceManager *DeviceManager::createDeviceManager(const DeviceConfig &config) {
+DeviceManager *
+DeviceManager::createDeviceManager(const DeviceConfig &config,
+                                   const BackendOptions &backendOptions) {
   std::unique_ptr<Backend> backend(
-      FactoryRegistry<std::string, Backend>::get(config.backendName));
+      FactoryRegistry<std::string, Backend, BackendOptions>::get(
+          config.backendName, backendOptions));
 
   if (backend == nullptr) {
     LOG(ERROR) << "There is no registered backend by name: "
                << config.backendName;
     LOG(ERROR) << "List of all registered backends: ";
     for (const auto &factory :
-         FactoryRegistry<std::string, Backend>::factories()) {
+         FactoryRegistry<std::string, Backend, BackendOptions>::factories()) {
       LOG(ERROR) << factory.first;
     }
 

--- a/lib/Backends/Habana/Habana.h
+++ b/lib/Backends/Habana/Habana.h
@@ -33,6 +33,7 @@ class HabanaBackend final : public Backend {
 public:
   /// Constructor.
   HabanaBackend() = default;
+  HabanaBackend(const BackendOptions &) : HabanaBackend(){};
 
   /// @name Backend methods.
   /// This is the implementation of the Backend interface.

--- a/lib/Backends/NNPI/CMakeLists.txt
+++ b/lib/Backends/NNPI/CMakeLists.txt
@@ -127,6 +127,7 @@ target_link_libraries(NNPI
                       CodeGen
                       IR
                       Support
+                      GraphOptimizer
                       ${NNPI_TRANSFORMER_LIB}
                       ${NNPI_INFERENCE_LIB}
                       ${NNPI_MG_LIB}

--- a/lib/Backends/NNPI/NNPI.h
+++ b/lib/Backends/NNPI/NNPI.h
@@ -25,7 +25,8 @@ namespace glow {
 class NNPIBackend final : public Backend {
 public:
   /// Ctor.
-  explicit NNPIBackend() = default;
+  NNPIBackend() = default;
+  NNPIBackend(const BackendOptions &) : NNPIBackend(){};
 
   /// @name Backend methods.
   /// This is the implementation of the Backend interface.

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -190,6 +190,7 @@ class OCLBackend final : public BackendUsingGlowIR {
 public:
   /// Ctor.
   OCLBackend() = default;
+  OCLBackend(const BackendOptions &) : OCLBackend(){};
 
   /// @name Backend methods.
   /// This is the implementation of the Backend interface.


### PR DESCRIPTION
Summary: 
Add am option to pass  backend options on backend creation to allow multiple backend instances with different configurations.
