### PR TITLE
[DRT] add method for updating a device Tensor without copying it to host

### DIFF
--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -747,6 +747,10 @@ public:
   /// associated device memory.
   void ensureOnHost();
 
+  /// Updates contents of a device resident Tensor with the data from \p t
+  /// without copying its contents to host.
+  void copyRawToDevice(const Tensor *t);
+
   /// \returns the pointer to the device manager where the tensor resides.
   DeviceTensorTransferManager *getDeviceManager() const {
     assert(deviceResidency_ != nullptr && "DeviceResidencyInfo must exist");

--- a/lib/Base/Tensor.cpp
+++ b/lib/Base/Tensor.cpp
@@ -676,4 +676,13 @@ void Tensor::ensureOnHost() {
   assert(!isDeviceResident());
 }
 
+void Tensor::copyRawToDevice(const Tensor *t) {
+  assert(isDeviceResident());
+  void *locationContext = deviceResidency_->locationContext_;
+  DeviceTensorTransferManager *DM = deviceResidency_->deviceManager_;
+  clearDeviceResidency();
+  copyRawFrom(t);
+  DM->transferToDevice(*this, locationContext);
+}
+
 } // namespace glow


### PR DESCRIPTION
Summary: Adds a new method to Tensor: `copyRawToDevice` which is an equivalent to `copyRawFrom` when the target is device resident. This is particularly useful for Inputs which are write only on the device.

Documentation: N/A

Test Plan: new test in DeviceManagerTests, since you need a DeviceManager to make a Tensor device Resident.
