### PR TITLE
Use Node names for vertices in dotty DAG dump

### DIFF
--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -276,14 +276,19 @@ protected:
     os << "}";
   }
 
-  void dumpNode(Node *N) {
+  void dumpNode(Node *N, bool uniqueNames) {
     if (!N) {
       return;
     }
     std::ostringstream os;
     // Print a node descriptor that looks like this:
-    // vNNNN [ shape = "record" label = "{...}" ];
-    os << uniqueVertexName(N) << "[\n";
+    if (uniqueNames) {
+      // vNNNN [ shape = "record" label = "{...}" ];
+      os << uniqueVertexName(N) << "[\n";
+    } else {
+      // <name> [ shape = "record" label = "{...}" ];
+      os << N->getName().str() << "[\n";
+    }
     os << "\tlabel = \"";
     dumpLabel(N, os);
     os << "\"\n";
@@ -381,7 +386,7 @@ class ModuleDottyPrinter : public AbstractDottyPrinter {
 public:
   void visitModule(Module *M) {
     for (auto N : M->getConstants()) {
-      dumpNode(N);
+      dumpNode(N, true);
     }
 
     for (auto F : M->getFunctions()) {
@@ -3808,16 +3813,16 @@ class FunctionDottyPrinter : public AbstractDottyPrinter {
       return;
     visitedNodes_.insert(N);
 
-    dumpNode(N);
+    dumpNode(N, false);
 
     // Print edges for the predicate field, if it's used.
     if (N->hasPredicate()) {
       auto pred = N->getPredicate();
       size_t resNo = pred.getResNo();
       std::ostringstream edge;
-      edge << uniqueVertexName(pred) << ":"
+      edge << pred.getNode()->getName().str() << ":"
            << pred.getNode()->getOutputName(resNo).str() << " -> "
-           << uniqueVertexName(N) << ":w";
+           << N->getName().str() << ":w";
       dumpEdgeStyle(N, 0, pred, edge);
       edges_.insert(edge.str());
       visitNode(pred);
@@ -3828,8 +3833,8 @@ class FunctionDottyPrinter : public AbstractDottyPrinter {
       size_t resNo = N->getNthInput(i).getResNo();
 
       std::ostringstream edge;
-      edge << uniqueVertexName(to) << ":" << to->getOutputName(resNo).str()
-           << " -> " << uniqueVertexName(N) << ":" << N->getInputName(i);
+      edge << to->getName().str() << ":" << to->getOutputName(resNo).str()
+           << " -> " << N->getName().str() << ":" << N->getInputName(i);
       dumpEdgeStyle(N, i, to, edge);
       edges_.insert(edge.str());
 


### PR DESCRIPTION
Summary: Now that all nodes in a Function, and all Storage names are unique, we can use the node name as the vertex name in the DAG output rather than a random string of numbers. This has the advantage of making the same node from different dot files use the name Vertex name, which i need for a _\~secret project\~_.

Documentation: N/A

Test Plan: ran unit tests, dumped a DAG and visualized it.
