### PR TITLE
Fix for windows break build. 

### DIFF
--- a/include/glow/Support/Error.h
+++ b/include/glow/Support/Error.h
@@ -379,9 +379,9 @@ class GlowError : protected detail::CheckState<detail::enableCheckingErrors> {
     return std::move(errorValue_);
   }
 
-protected:
+public:
   /// Construct a new empty Error.
-  explicit GlowError() { setErrorValue(nullptr, /*skipCheck*/ true); }
+  GlowError() { setErrorValue(nullptr, /*skipCheck*/ true); }
 
 public:
   /// Construct an Error from an ErrorValue \p errorValue.


### PR DESCRIPTION
Summary:
The VS implementation of promise was trying to access protected constructor.
Honestly not 100% why default constructor was made explicit, or protected.
Documentation:

[Optional Fixes #issue]

Test Plan:
Unit Tests
Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
