### PR TITLE
[torch_glow] Minor change to allow backend selection for pytests

### DIFF
--- a/torch_glow/tests/conftest.py
+++ b/torch_glow/tests/conftest.py
@@ -1,0 +1,14 @@
+# contents of conftest.py
+import pytest
+import torch
+import torch_glow
+
+
+def pytest_addoption(parser):
+    parser.addoption("--backend", action="store", default=None)
+
+    
+def pytest_sessionstart(session):
+    backend = session.config.getoption("--backend")
+    if backend:
+        torch_glow.setGlowBackend(backend)

--- a/torch_glow/tests/conftest.py
+++ b/torch_glow/tests/conftest.py
@@ -7,7 +7,7 @@ import torch_glow
 def pytest_addoption(parser):
     parser.addoption("--backend", action="store", default=None)
 
-    
+
 def pytest_sessionstart(session):
     backend = session.config.getoption("--backend")
     if backend:


### PR DESCRIPTION

Summary:

    [torch_glow] Minor change to allow backend selection for pytests
    
    Add torch_glow/tests/conftest.py which enables a --backend option
    when running pytest. E.g. - pytest ./tests --backend CPU
    
    Add --backend option to torch_glow/examples/resnet_example.py to
    select the glow backend.
    
    If no --backend option is passed setGlowBackend() is not called
    thus maintaining the current behavior of letting glow select the
    default backend.


Documentation:

    N/A

Test Plan:

    Tested resnet_example.py with:
    
        $ python ./resnet_example.py --image 1_cat_285.png
        $ python ./resnet_example.py --image 1_cat_285.png --backend Interpreter
        $ python ./resnet_example.py --image 1_cat_285.png --backend CPU
        $ python ./resnet_example.py --image 1_cat_285.png --backend bogus
    
    Tested pytests with:
    
        $ pytest ./tests
        $ pytest --backend Interpreter ./tests
        $ pytest --backend CPU ./tests
        $ pytest --backend bogus ./tests
