### PR TITLE
Fix memory leak

### DIFF
--- a/lib/Backends/NNPI/InferencePool.cpp
+++ b/lib/Backends/NNPI/InferencePool.cpp
@@ -636,7 +636,7 @@ bool InferenceThreadEnv::init(
     }
 
     // Create command list.
-    NNPICommandHandle *commands = new NNPICommandHandle[numCommands_];
+    NNPICommandHandle commands[numCommands_];
     LOG_AND_RETURN_IF_NOT(ERROR, commands,
                           "Failed to allocate command handle array", false);
     uint32_t cmdIdx = 0;


### PR DESCRIPTION
Summary: commands array is never deleted. Changing it to local variable.

Differential Revision: D19204847

