### PR TITLE
Optimize zero length input

### DIFF
--- a/lib/Onnxifi/Base.h
+++ b/lib/Onnxifi/Base.h
@@ -132,6 +132,7 @@ public:
   virtual onnxStatus initGraph(const void *onnxModel, size_t onnxModelSize,
                                uint32_t weightCount,
                                const onnxTensorDescriptorV1 *weightDescriptors,
+                               uint32_t maxSeqLength,
                                void *deferedBlobReader) = 0;
 
   virtual onnxStatus run(std::unique_ptr<ExecutionContext> ctx,
@@ -160,6 +161,12 @@ protected:
 
   /// An object pool for tensors, to share allocations.
   TensorPool tensorPool_;
+
+  /// An anchor tensor specialized for zero length indices
+  Tensor zeroLengthSequence_;
+
+  /// Set the zero length tensor
+  void setZeroLengthSequence(dim_t maxSeqLength);
 
 private:
   /// inference dump counter

--- a/lib/Onnxifi/HostManagerOnnxifi.cpp
+++ b/lib/Onnxifi/HostManagerOnnxifi.cpp
@@ -162,9 +162,11 @@ onnxStatus HostManagerBackend::removeNetwork(const Graph *graph) {
   return ONNXIFI_STATUS_SUCCESS;
 }
 
-onnxStatus HostManagerGraph::initGraph(
-    const void *onnxModel, size_t onnxModelSize, uint32_t weightCount,
-    const onnxTensorDescriptorV1 *weightDescriptors, void *deferedBlobReader) {
+onnxStatus
+HostManagerGraph::initGraph(const void *onnxModel, size_t onnxModelSize,
+                            uint32_t weightCount,
+                            const onnxTensorDescriptorV1 *weightDescriptors,
+                            uint32_t maxSeqLength, void *deferedBlobReader) {
 
   netName_ = strFormat("onnxifi_function_%lu", makeUniqueGraphId());
 
@@ -180,6 +182,7 @@ onnxStatus HostManagerGraph::initGraph(
   onnxInputToPlaceholder_ = loader->getInputVarsMapping();
   onnxOutputToPlaceholder_ = loader->getOutputVarsMapping();
 
+  setZeroLengthSequence(maxSeqLength);
   // Make sure the pool is ready to go.
   for (auto &obj : onnxInputToPlaceholder_) {
     tensorPool_.reserve(obj.second->getType(), 10);

--- a/lib/Onnxifi/HostManagerOnnxifi.h
+++ b/lib/Onnxifi/HostManagerOnnxifi.h
@@ -64,6 +64,7 @@ public:
   onnxStatus initGraph(const void *onnxModel, size_t onnxModelSize,
                        uint32_t weightCount,
                        const onnxTensorDescriptorV1 *weightDescriptors,
+                       uint32_t maxSeqLengths,
                        void *deferedBlobReader) override;
 
   /// Async run HostManagerGraph with the given ExecutionContext \p ctx then

--- a/lib/Onnxifi/InlineOnnxifi.cpp
+++ b/lib/Onnxifi/InlineOnnxifi.cpp
@@ -43,9 +43,11 @@ void computeModelHash(const void *onnxModel, size_t onnxModelSize,
 }
 } // namespace
 
-onnxStatus InlineGraph::initGraph(
-    const void *onnxModel, size_t onnxModelSize, uint32_t weightCount,
-    const onnxTensorDescriptorV1 *weightDescriptors, void *deferedBlobReader) {
+onnxStatus
+InlineGraph::initGraph(const void *onnxModel, size_t onnxModelSize,
+                       uint32_t weightCount,
+                       const onnxTensorDescriptorV1 *weightDescriptors,
+                       uint32_t maxSeqLength, void * /*unused */) {
   function_ = executionEngine_.getModule().createFunction("function");
 
   std::unique_ptr<ONNXIFIModelLoader> loader =
@@ -59,6 +61,7 @@ onnxStatus InlineGraph::initGraph(
     saveOnnxifiModel(function_);
   }
 
+  setZeroLengthSequence(maxSeqLength);
   computeModelHash(onnxModel, onnxModelSize, modelHash_);
   optimize(function_, CompilationMode::Infer);
 

--- a/lib/Onnxifi/InlineOnnxifi.h
+++ b/lib/Onnxifi/InlineOnnxifi.h
@@ -36,7 +36,7 @@ public:
   onnxStatus initGraph(const void *onnxModel, size_t onnxModelSize,
                        uint32_t weightCount,
                        const onnxTensorDescriptorV1 *weightDescriptors,
-                       void *deferedBlobReader) override;
+                       uint32_t maxSeqLength, void *deferedBlobReader) override;
 
   onnxStatus run(std::unique_ptr<ExecutionContext> ctx, EventPtr outputEvent,
                  onnxTraceEventList *traceEvents) override;

--- a/lib/Onnxifi/onnxifiGlow.cpp
+++ b/lib/Onnxifi/onnxifiGlow.cpp
@@ -400,7 +400,7 @@ GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxInitGraph)(
     onnxBackend backend, const uint64_t *auxPropertiesList,
     size_t onnxModelSize, const void *onnxModel, uint32_t weightsCount,
     const onnxTensorDescriptorV1 *weightDescriptors, onnxGraph *graph,
-    void *deferredBlobReader) {
+    uint32_t maxSeqLength, void *deferredBlobReader) {
   if (!onnxModel || (!weightDescriptors && weightsCount) || !graph) {
     return ONNXIFI_STATUS_INVALID_POINTER;
   }
@@ -425,8 +425,9 @@ GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxInitGraph)(
   }
 
   auto *glowGraph = manager.createGraph(glowBackend, quantizationMode);
-  auto ret = glowGraph->initGraph(onnxModel, onnxModelSize, weightsCount,
-                                  weightDescriptors, deferredBlobReader);
+  auto ret =
+      glowGraph->initGraph(onnxModel, onnxModelSize, weightsCount,
+                           weightDescriptors, maxSeqLength, deferredBlobReader);
   if (ret != ONNXIFI_STATUS_SUCCESS) {
     manager.release(glowGraph);
     return ret;


### PR DESCRIPTION
Summary: Zero length input is something we hit fairly frequently in practice. Previous handling of global TensorPool involves two locks per input (acquire and reclaim). Here we use a specialized anchor tensor to host zero length input. Note that it is only padded to max sequence length. If necessary, an easy extension can be added to pad to max `InputPlaceholder.getType().size()`.

Differential Revision: D19192467

