### PR TITLE
[OpenCL] Fix a bug when running an external model with the image-loader transposing the input to NCHW

### DIFF
--- a/lib/Backends/OpenCL/OpenCLTensorLayout.cpp
+++ b/lib/Backends/OpenCL/OpenCLTensorLayout.cpp
@@ -44,6 +44,14 @@ static std::string returnBaseReqOrNHWC(TensorLayoutDescription &baseReq,
     // These nodes accept any 4-D layout.
     return baseReq.getSerializedLayout();
   }
+  // For Placeholders and Constants that were loaded from another tool, we don't
+  // have the layout information in during load time. This makes us assume they
+  // are in Glow's Canonical NHWC format, which is not correct if we are loading
+  // an image with NCHW such as in resent loader. Weaken the verifier to avoid a
+  // runtime crash: if this is a storage location, return the baseReq.
+  if (llvm::dyn_cast<Storage>(node)) {
+    return baseReq.getSerializedLayout();
+  }
 
   return CanonicalTensorLayout::getInstance().getDefaultNDLayout(4);
 }


### PR DESCRIPTION
Summary:
See the in-source comment for workaround information, but: We have a model we load from the outside with no-way of knowing the constant/placeholder input layout, the default assumption for 4-D tensors (images) is NHWC format which is the canonical Glow format, PNG files are in NHWC format.
Our image loader, when using the `image-layout` flag, transposes the image outside the Glow graph, since there's no easy way to propagate that information, weaken the OpenCL verifier, not the canonical verifier: for placeholders and constants, assume that the loader knows what it is doing and they are in the right format.

Fixes #3815

Test Plan:
`ninja test`