### PR TITLE
Support non-contiguous tensors

### DIFF
--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -314,7 +314,7 @@ public:
   /// unpaddedSize can be set to indicate actual size of the inputs.
   Tensor(void *data, TypeRef ty, size_t unpaddedSize = 0)
       : data_(reinterpret_cast<char *>(data)),
-        type_(*ty), isUnowned_{false}, unpaddedSize_{unpaddedSize} {
+        type_(*ty), unpaddedSize_{unpaddedSize} {
     // Mark as unowned.
     isUnowned_ = true;
     // We do want DeviceResidency however, since there is no owning Glow Tensor.

--- a/torch_glow/src/PyTorchCommon.cpp
+++ b/torch_glow/src/PyTorchCommon.cpp
@@ -208,6 +208,7 @@ at::Tensor glowTypeToEmptyPTTensor(const glow::Type &glowType) {
 }
 
 glow::Tensor ptTensorToGlowTensor(const at::Tensor &ptTensor) {
+  CHECK(ptTensor.is_contiguous());
   if (ptTensor.is_quantized()) {
     float scale = 1.0;
     int32_t offset = 0;

--- a/torch_glow/tests/nodes/mm_test.py
+++ b/torch_glow/tests/nodes/mm_test.py
@@ -15,7 +15,7 @@ class TestMm(unittest.TestCase):
             return r.mm(t)
 
         x = torch.randn(2, 3)
-        y = torch.randn(3, 4)
+        y = torch.randn(4, 3).t()
         t = torch.randn(4, 2)
 
         jitVsGlow(test_f, x, y, t, expected_fused_ops={"aten::mm"})


### PR DESCRIPTION
Summary: If a tensor is non-contiguous, make a contiguous version and save a copy.

Differential Revision: D19156522

