### PR TITLE
Make GraphOptzTest tests use optimizeFunction helper

### DIFF
--- a/tests/unittests/GraphOptzTest.cpp
+++ b/tests/unittests/GraphOptzTest.cpp
@@ -239,8 +239,7 @@ TEST_F(GraphOptz, optimizeBatchNormAfterConvFP16) {
   EXPECT_EQ(F_->getNodes().size(), 3);
 
   ::glow::convertPlaceholdersToConstants(F_, bindings_, {});
-  optimizedF_ = F_->clone(F_->getName().str() + "_optimized");
-  ::glow::optimize(optimizedF_, CompilationMode::Infer);
+  optimizedF_ = optimizeFunction(F_);
 
   EXPECT_EQ(optimizedF_->getNodes().size(), 2);
 
@@ -288,8 +287,7 @@ TEST_F(GraphOptz, optimizeBatchNormAfterConvWithTransposedWeights) {
   EXPECT_EQ(countNodeKind(F_, Kinded::Kind::BatchNormalizationNodeKind), 1);
 
   ::glow::convertPlaceholdersToConstants(F_, bindings_, {input});
-  optimizedF_ = F_->clone(F_->getName().str() + "_optimized");
-  ::glow::optimize(optimizedF_, CompilationMode::Infer);
+  optimizedF_ = optimizeFunction(F_);
 
   EXPECT_EQ(optimizedF_->getNodes().size(), 2);
   EXPECT_EQ(
@@ -325,8 +323,7 @@ TEST_F(GraphOptz, optimizeBatchNormAfterConvWithReshapeConst) {
   EXPECT_EQ(countNodeKind(F_, Kinded::Kind::BatchNormalizationNodeKind), 1);
 
   ::glow::convertPlaceholdersToConstants(F_, bindings_, {input});
-  optimizedF_ = F_->clone(F_->getName().str() + "_optimized");
-  ::glow::optimize(optimizedF_, CompilationMode::Infer);
+  optimizedF_ = optimizeFunction(F_);
 
   EXPECT_EQ(optimizedF_->getNodes().size(), 2);
   EXPECT_EQ(


### PR DESCRIPTION
Summary: Tests that rely on testing optimizedF_ for numerical equivalence with F_ refactored to use  optimizeFunction helper

Test Plan: ninja all && ctest -R GraphOptzTest