### PR TITLE
Implementation of NMS ONNX and TF V4.

### DIFF
--- a/include/glow/Backends/Interpreter/InterpreterFunction.h
+++ b/include/glow/Backends/Interpreter/InterpreterFunction.h
@@ -325,6 +325,9 @@ private:
   void fwdFusedRowwiseQuantizedSparseLengthsWeightedSumImpl(
       const FusedRowwiseQuantizedSparseLengthsWeightedSumInst *I);
 
+  template <typename T>
+  void fwdNonMaxSuppressionInstImpl(glow::NonMaxSuppressionInst const *I);
+
   template <typename T, typename AccumT>
   void fwdEmbeddingBagByteRowwiseOffsetsImpl(
       const EmbeddingBagByteRowwiseOffsetsInst *I);

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -1493,6 +1493,90 @@ public:
                                    llvm::StringRef eventType, Node *data,
                                    unsigned index);
 
+  /// Creates NMSv4 node that does NMS for one class.
+  /// Inputs
+  /// - \p boxes Tensor with box coordinates.
+  /// - \p scores Tensor with scores per box.
+  /// - \p centerPointBox Indicates format of the box per ONNX spec.
+  /// - \p iouThreshold Threshold for box overlap.
+  /// - \p scoreThreshold Threshold for box scores.
+  NonMaxSuppressionNode *
+  createNonMaxSuppressionV4(llvm::StringRef name, NodeValue boxes,
+                            NodeValue scores, int64_t centerPointBox,
+                            int64_t maxOutputBoxesPerClass, float iouThreshold,
+                            float scoreThreshold);
+
+  /// Creates NMSv4 node that does NMS for one class.
+  /// Inputs
+  /// - \p boxes Tensor with box coordinates.
+  /// - \p scores Tensor with scores per box.
+  /// - \p centerPointBox Indicates format of the box per ONNX spec.
+  /// - \p iouThreshold Threshold for box overlap.
+  /// - \p scoreThreshold Threshold for box scores.
+  /// - \p ElemKind Output ElemKind.
+  NonMaxSuppressionNode *
+  createNonMaxSuppressionV4(llvm::StringRef name, NodeValue boxes,
+                            NodeValue scores, int64_t centerPointBox,
+                            int64_t maxOutputBoxesPerClass, float iouThreshold,
+                            float scoreThreshold, ElemKind elTy);
+
+  /// Creates NMSv4 node that does NMS for one class.
+  /// Inputs
+  /// - \p boxes Tensor with box coordinates.
+  /// - \p scores Tensor with scores per box.
+  /// - \p centerPointBox Indicates format of the box per ONNX spec.
+  /// - \p iouThreshold Threshold for box overlap.
+  /// - \p scoreThreshold Threshold for box scores.
+  /// - \p indicesTy Type of indices output.
+  /// - \p numberOfSelectedIndicesTy \p Type of second output for number of
+  /// boxes detected.
+  NonMaxSuppressionNode *
+  createNonMaxSuppressionV4(llvm::StringRef name, NodeValue boxes,
+                            NodeValue scores, int64_t centerPointBox,
+                            int64_t maxOutputBoxesPerClass, float iouThreshold,
+                            float scoreThreshold, TypeRef indicesTy,
+                            TypeRef numberOfSelectedIndicesTy);
+
+  /// Performs class wise NMS based on ONNX specification, with padding and ONNX
+  /// layout output.
+  /// Inputs
+  /// - \p boxes Tensor with box coordinates.
+  /// - \p scores Tensor with scores per box.
+  /// - \p centerPointBox Indicates format of the box per ONNX spec.
+  /// - \p iouThreshold Threshold for box overlap.
+  /// - \p scoreThreshold Threshold for box scores.
+  NonMaxSuppressionNode *
+  createNonMaxSuppressionONNX(llvm::StringRef name, NodeValue boxes,
+                              NodeValue scores, int64_t centerPointBox,
+                              int64_t maxOutputBoxesPerClass,
+                              float iouThreshold, float scoreThreshold);
+
+  /// Performs class wise NMS based on ONNX specification, with padding and ONNX
+  /// layout output.
+  /// Inputs
+  /// - \p boxes Tensor with box coordinates.
+  /// - \p scores Tensor with scores per box.
+  /// - \p centerPointBox Indicates format of the box per ONNX spec.
+  /// - \p iouThreshold Threshold for box overlap.
+  /// - \p scoreThreshold Threshold for box scores.
+  NonMaxSuppressionNode *createNonMaxSuppressionONNX(
+      llvm::StringRef name, NodeValue boxes, NodeValue scores,
+      int64_t centerPointBox, int64_t maxOutputBoxesPerClass,
+      float iouThreshold, float scoreThreshold, ElemKind elTy);
+
+  /// Performs class wise NMS based on ONNX specification, with padding and ONNX
+  /// layout output.
+  /// Inputs
+  /// - \p boxes Tensor with box coordinates.
+  /// - \p scores Tensor with scores per box.
+  /// - \p centerPointBox Indicates format of the box per ONNX spec.
+  /// - \p iouThreshold Threshold for box overlap.
+  /// - \p scoreThreshold Threshold for box scores.
+  NonMaxSuppressionNode *createNonMaxSuppressionONNX(
+      llvm::StringRef name, NodeValue boxes, NodeValue scores,
+      int64_t centerPointBox, int64_t maxOutputBoxesPerClass,
+      float iouThreshold, float scoreThreshold, TypeRef indicesTy);
+
   /// Erase the node \p N from the Function.
   void eraseNode(Node *N);
 

--- a/include/glow/Importer/ONNXModelLoader.h
+++ b/include/glow/Importer/ONNXModelLoader.h
@@ -248,6 +248,11 @@ class ONNXModelLoader
   Error loadSplat(const ONNX_NAMESPACE::NodeProto &op,
                   const ArgumentDictionaryTy &dict);
 
+  /// Load NonMaxSuppression ONNX and TF NMSv4 operator.
+  /// The \p isV4 indicates whether this is ONNX or custom NMSv4 operator.
+  Error loadNonMaxSuppression(const ONNX_NAMESPACE::NodeProto &op,
+                              const ArgumentDictionaryTy &dict, bool isV4);
+
   /// Load Glow InsertTensor operator.
   Error loadInsertTensor(const ONNX_NAMESPACE::NodeProto &op,
                          const ArgumentDictionaryTy &dict);

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -385,6 +385,25 @@ bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
   case Kinded::Kind::TraceEventNodeKind:
     return NI.getInElemTy(TraceEventNode::DataIdx) == ElemKind::Int64ITy;
 
+  case Kinded::Kind::NonMaxSuppressionNodeKind:
+    return NI.getInElemTy(NonMaxSuppressionNode::BoxesIdx) ==
+               ElemKind::FloatTy &&
+           NI.getInElemTy(NonMaxSuppressionNode::ScoresIdx) ==
+               ElemKind::FloatTy &&
+           (NI.getOutElemTy(NonMaxSuppressionNode::IndicesIdx) ==
+                ElemKind::Int32ITy ||
+            NI.getOutElemTy(NonMaxSuppressionNode::IndicesIdx) ==
+                ElemKind::Int64ITy) &&
+           (NI.getOutElemTy(
+                NonMaxSuppressionNode::NumberOfSelectedIndicesIdx) ==
+                ElemKind::Int32ITy ||
+            NI.getOutElemTy(
+                NonMaxSuppressionNode::NumberOfSelectedIndicesIdx) ==
+                ElemKind::Int64ITy) &&
+           (NI.getOutElemTy(
+                NonMaxSuppressionNode::NumberOfSelectedIndicesIdx) ==
+            NI.getOutElemTy(NonMaxSuppressionNode::IndicesIdx));
+
   case Kinded::Kind::ConvertToNodeKind:
     return ((NI.getInElemTy(ConvertToNode::InputIdx) == ElemKind::Int32ITy) &&
             (NI.getOutElemTy(ConvertToNode::ResultIdx) == ElemKind::FloatTy)) ||

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -535,6 +535,25 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
     // These work regardless of the underlying type.
     return true;
 
+  case Kinded::Kind::NonMaxSuppressionNodeKind:
+    return NI.getInElemTy(NonMaxSuppressionNode::BoxesIdx) ==
+               ElemKind::FloatTy &&
+           NI.getInElemTy(NonMaxSuppressionNode::ScoresIdx) ==
+               ElemKind::FloatTy &&
+           (NI.getOutElemTy(NonMaxSuppressionNode::IndicesIdx) ==
+                ElemKind::Int32ITy ||
+            NI.getOutElemTy(NonMaxSuppressionNode::IndicesIdx) ==
+                ElemKind::Int64ITy) &&
+           (NI.getOutElemTy(
+                NonMaxSuppressionNode::NumberOfSelectedIndicesIdx) ==
+                ElemKind::Int32ITy ||
+            NI.getOutElemTy(
+                NonMaxSuppressionNode::NumberOfSelectedIndicesIdx) ==
+                ElemKind::Int64ITy) &&
+           (NI.getOutElemTy(
+                NonMaxSuppressionNode::NumberOfSelectedIndicesIdx) ==
+            NI.getOutElemTy(NonMaxSuppressionNode::IndicesIdx));
+
   case Kinded::Kind::SoftMaxGradNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
                {ElemKind::FloatTy}, {SoftMaxGradNode::SelectedIdx},

--- a/lib/Exporter/ONNXModelWriter.cpp
+++ b/lib/Exporter/ONNXModelWriter.cpp
@@ -1426,6 +1426,7 @@ DEF_ALL_WRITER_NODE(RowwiseQuantizedSparseLengthsWeightedSum)
 DEF_ALL_WRITER_NODE(FusedRowwiseQuantizedSparseLengthsSum)
 DEF_ALL_WRITER_NODE(EmbeddingBagByteRowwiseOffsets)
 DEF_ALL_WRITER_NODE(FusedRowwiseQuantizedSparseLengthsWeightedSum)
+DEF_ALL_WRITER_NODE(NonMaxSuppression)
 
 Error ONNXModelWriter::writeClip(const ClipNode *node, GraphType &graph) {
   auto *proto = graph.add_node();

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -2118,6 +2118,86 @@ Error ONNXModelLoader::loadFullyConnected(const ONNX_NAMESPACE::NodeProto &op,
   return Error::success();
 }
 
+Error ONNXModelLoader::loadNonMaxSuppression(
+    const ONNX_NAMESPACE::NodeProto &op, const ArgumentDictionaryTy &dict,
+    bool isV4) {
+  NodeValue boxesNV;
+  ASSIGN_VALUE_OR_RETURN_ERR(boxesNV, getNodeValueByName(op.input(0)));
+  NodeValue scoresNV;
+  ASSIGN_VALUE_OR_RETURN_ERR(scoresNV, getNodeValueByName(op.input(1)));
+  Constant *maxOutputBoxesPerClassC = getConstantByNameOrNull(op.input(2));
+  Constant *iouThresholdC = getConstantByNameOrNull(op.input(3));
+  Constant *scoreThresholdC = getConstantByNameOrNull(op.input(4));
+
+  // Defaults to 0 which is the same representation as TF.
+  unsigned centerPointBox = 0;
+  if (dict.count("center_point_box")) {
+    ASSIGN_VALUE_OR_RETURN_ERR(centerPointBox,
+                               loadInt(dict.at("center_point_box")));
+  }
+
+  int32_t padToMaxOutputSize = 0;
+  if (isV4) {
+    if (dict.count("pad_to_max_output_size")) {
+      ASSIGN_VALUE_OR_RETURN_ERR(padToMaxOutputSize,
+                                 loadInt(dict.at("pad_to_max_output_size")));
+    }
+
+    // Does it make sense within GLOW context to have no padding? Since Size has
+    // to be compile time constant.
+    RETURN_ERR_IF_NOT(padToMaxOutputSize == 1,
+                      "NonMaxSuppressionV4 does not support non-padding mode.");
+  }
+
+  unsigned maxOutputBoxesPerClass = 0;
+  float iouThreshold = 0.0f;
+  float scoreThreshold = 0.0f;
+
+  if (maxOutputBoxesPerClassC) {
+    if (maxOutputBoxesPerClassC->getPayload().getElementType() ==
+        ElemKind::Int64ITy) {
+      maxOutputBoxesPerClass =
+          maxOutputBoxesPerClassC->getPayload().getHandle<int64_t>().raw(0);
+    } else if (maxOutputBoxesPerClassC->getPayload().getElementType() ==
+               ElemKind::Int32ITy) {
+      maxOutputBoxesPerClass =
+          maxOutputBoxesPerClassC->getPayload().getHandle<int32_t>().raw(0);
+    } else {
+      RETURN_ERR("Unsupported type for maxoutputboxesperclass.");
+    }
+  } else {
+    RETURN_ERR("NMS: maxOutputBoxesPerClass is not a contant tensor.");
+  }
+
+  if (iouThresholdC) {
+    iouThreshold = iouThresholdC->getPayload().getHandle<float>().raw(0);
+  } else {
+    RETURN_ERR("NMS: iouThreshold is not a contant tensor.");
+  }
+
+  if (scoreThresholdC) {
+    scoreThreshold = scoreThresholdC->getPayload().getHandle<float>().raw(0);
+  } else {
+    RETURN_ERR("NMS: scoreThrehold is not a contant tensor.");
+  }
+
+  // Create Node.
+  std::string opName = loadOperatorName(op);
+  Node *N = nullptr;
+
+  if (isV4) {
+    N = G_.createNonMaxSuppressionV4(opName, boxesNV, scoresNV, centerPointBox,
+                                     maxOutputBoxesPerClass, iouThreshold,
+                                     scoreThreshold);
+  } else {
+    N = G_.createNonMaxSuppressionONNX(opName, boxesNV, scoresNV,
+                                       centerPointBox, maxOutputBoxesPerClass,
+                                       iouThreshold, scoreThreshold);
+  }
+  RETURN_IF_ERR(addNodeAsOutput(op, N));
+  return Error::success();
+}
+
 Error ONNXModelLoader::loadSplat(const ONNX_NAMESPACE::NodeProto &op,
                                  const ArgumentDictionaryTy &dict) {
   return loadConstantOfShape(op, dict, true /* isSplat */);
@@ -2352,6 +2432,12 @@ Error ONNXModelLoader::loadOperator(const ONNX_NAMESPACE::NodeProto &op) {
   }
   if (typeName == "ArgMax") {
     return loadArgMax(op, dict);
+  }
+  if (typeName == "NonMaxSuppressionV4") {
+    return loadNonMaxSuppression(op, dict, true);
+  }
+  if (typeName == "NonMaxSuppression") {
+    return loadNonMaxSuppression(op, dict, false);
   }
   if (typeName == "AdaptiveAvgPool") {
     return loadAdaptiveAvgPool(op, dict);

--- a/tests/models/onnxModels/NonMaxSuppression.onnxtxt
+++ b/tests/models/onnxModels/NonMaxSuppression.onnxtxt
@@ -1,0 +1,118 @@
+ir_version: 5
+domain: "onnx"
+# ONNX TensorProto.DataType:
+#    UNDEFINED = 0;
+#    FLOAT = 1;
+#    UINT8 = 2;
+#    INT8 = 3;
+#    UINT16 = 4;
+#    INT16 = 5;
+#    INT32 = 6;
+#    INT64 = 7;
+#    STRING = 8;
+#    BOOL = 9;
+#    FLOAT16 = 10;
+#    DOUBLE = 11;
+#    UINT32 = 12;
+#    UINT64 = 13;
+#    COMPLEX64 = 14;
+#    COMPLEX128 = 15;
+graph {
+   initializer {
+       data_type: 7
+       name: "max_output_size"
+       raw_data: "\003\000\000\000\000\000\000\000"
+   }
+   initializer {
+       data_type: 1
+       name: "iou_threshold"
+       raw_data: "\000\000\000?"
+   }
+   initializer {
+       data_type: 1
+       name: "layer.score_threshold"
+       raw_data: "\232\231\031?"
+   }
+   input {
+    name: "boxes"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 8
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "scores"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 8
+          }
+        }
+      }
+    }
+  }
+   node {
+       input: "boxes"
+       input: "scores"
+       input: "max_output_size"
+       input: "iou_threshold"
+       input: "layer.score_threshold"
+       output: "indices"
+       output: "numSelected"
+       name: "NonMaxSuppressionV4"
+       op_type: "NonMaxSuppressionV4"
+       attribute {
+        name: "pad_to_max_output_size"
+        i: 1
+        type: INT
+      }
+       domain: "ai.onnx.converters.tensorflow"
+   }
+
+output {
+    name: "indices"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 8
+          }
+        }
+      }
+    }
+  }
+output {
+    name: "numSelected"
+    type {
+      tensor_type {
+        elem_type: 6
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 10
+}

--- a/tests/models/onnxModels/NonMaxSuppressionSSD.onnxtxt
+++ b/tests/models/onnxModels/NonMaxSuppressionSSD.onnxtxt
@@ -1,0 +1,156 @@
+ir_version: 4
+producer_name: "pytorch"
+producer_version: "1.1"
+# ONNX TensorProto.DataType:
+#    UNDEFINED = 0;
+#    FLOAT = 1;
+#    UINT8 = 2;
+#    INT8 = 3;
+#    UINT16 = 4;
+#    INT16 = 5;
+#    INT32 = 6;
+#    INT64 = 7;
+#    STRING = 8;
+#    BOOL = 9;
+#    FLOAT16 = 10;
+#    DOUBLE = 11;
+#    UINT32 = 12;
+#    UINT64 = 13;
+#    COMPLEX64 = 14;
+#    COMPLEX128 = 15;
+graph {
+   # max_output_boxes_per_class
+node {
+    output: "Constant_677"
+    name: "Constant_677"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 7
+        raw_data: "\003\000\000\000\000\000\000\000"
+      }
+      type: TENSOR
+    }
+  }
+
+  # iou_threshold
+  node {
+    output: "Constant_680"
+    name: "Constant_680"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 1
+        raw_data: "\001\000\000?"
+      }
+      type: TENSOR
+    }
+  }
+
+  # score_threshold
+  node {
+    output: "Constant_682"
+    name: "Constant_682"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 1
+        raw_data: "\315\314L="
+      }
+      type: TENSOR
+    }
+  }
+
+   input {
+    name: "boxes"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 8
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "scores"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 8
+          }
+        }
+      }
+    }
+  }
+node {
+    input: "boxes"
+    input: "scores"
+    input: "Constant_677" # max_output_boxes_per_class
+    input: "Constant_680" # iou_threshold
+    input: "Constant_682" # score_threshold
+    output: "indices"
+    output: "numSelected"
+    name: "NonMaxSuppression_683"
+    op_type: "NonMaxSuppressionV4"
+    attribute {
+        name: "center_point_box"
+        i: 1
+        type: INT
+    }
+    attribute {
+      name: "pad_to_max_output_size"
+      i: 1
+      type: INT
+    }
+}
+ output {
+    name: "indices"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 8
+          }
+        }
+      }
+    }
+  }
+
+ output {
+    name: "numSelected"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 10
+}

--- a/tests/models/onnxModels/NonMaxSuppressionSSD_ONNX.onnxtxt
+++ b/tests/models/onnxModels/NonMaxSuppressionSSD_ONNX.onnxtxt
@@ -1,0 +1,142 @@
+ir_version: 4
+producer_name: "pytorch"
+producer_version: "1.1"
+# ONNX TensorProto.DataType:
+#    UNDEFINED = 0;
+#    FLOAT = 1;
+#    UINT8 = 2;
+#    INT8 = 3;
+#    UINT16 = 4;
+#    INT16 = 5;
+#    INT32 = 6;
+#    INT64 = 7;
+#    STRING = 8;
+#    BOOL = 9;
+#    FLOAT16 = 10;
+#    DOUBLE = 11;
+#    UINT32 = 12;
+#    UINT64 = 13;
+#    COMPLEX64 = 14;
+#    COMPLEX128 = 15;
+graph {
+   # max_output_boxes_per_class
+node {
+    output: "Constant_677"
+    name: "Constant_677"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 7
+        raw_data: "\003\000\000\000\000\000\000\000"
+      }
+      type: TENSOR
+    }
+  }
+
+  # iou_threshold
+  node {
+    output: "Constant_680"
+    name: "Constant_680"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 1
+        raw_data: "\001\000\000?"
+      }
+      type: TENSOR
+    }
+  }
+
+  # score_threshold
+  node {
+    output: "Constant_682"
+    name: "Constant_682"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 1
+        raw_data: "\315\314L="
+      }
+      type: TENSOR
+    }
+  }
+
+   input {
+    name: "boxes"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 8
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "scores"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 8
+          }
+        }
+      }
+    }
+  }
+node {
+    input: "boxes"
+    input: "scores"
+    input: "Constant_677" # max_output_boxes_per_class
+    input: "Constant_680" # iou_threshold
+    input: "Constant_682" # score_threshold
+    output: "indices"
+    name: "NonMaxSuppression_683"
+    op_type: "NonMaxSuppression"
+    attribute {
+        name: "center_point_box"
+        i: 1
+        type: INT
+    }
+}
+ output {
+    name: "indices"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 8
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 10
+}

--- a/tests/unittests/OnnxExporterTest.cpp
+++ b/tests/unittests/OnnxExporterTest.cpp
@@ -117,6 +117,9 @@ TEST(exporter, onnxModels) {
         name.find("ArgMaxDefault.onnxtxt") != std::string::npos ||
         name.find("ArgMaxKeepDim.onnxtxt") != std::string::npos ||
         name.find("ArgMaxNoKeepDim.onnxtxt") != std::string::npos ||
+        name.find("NonMaxSuppressionSSD_ONNX.onnxtxt") != std::string::npos ||
+        name.find("NonMaxSuppression.onnxtxt") != std::string::npos ||
+        name.find("NonMaxSuppressionSSD.onnxtxt") != std::string::npos ||
         name.find("Less.onnxtxt") != std::string::npos) {
       // Ignore invalid ONNX files and graphs without nodes.
       llvm::outs() << "Ignore invalid input files: " << name << "\n";

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -2545,6 +2545,101 @@ TEST(onnx, importLess) {
   EXPECT_EQ(CMPLT->getResult().dims()[2], 1);
 }
 
+/// Test loading NMS using initializer nodes op from an ONNX model.
+TEST(onnx, importNMSInitializer) {
+  ExecutionEngine EE{};
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+
+  std::string netFilename(GLOW_DATA_PATH
+                          "tests/models/onnxModels/NonMaxSuppression.onnxtxt");
+
+  PlaceholderBindings bindings;
+  Placeholder *output;
+  {
+    Tensor boxes(ElemKind::FloatTy, {8, 4});
+    boxes.zero();
+
+    Tensor scores(ElemKind::FloatTy, {8});
+    scores.zero();
+
+    ONNXModelLoader onnxLD(netFilename, {"boxes", "scores"},
+                           {&boxes.getType(), &scores.getType()}, *F);
+    output = EXIT_ON_ERR(onnxLD.getOutputByName("indices"));
+  }
+
+  auto *save = getSaveNodeFromDest(output);
+  NonMaxSuppressionNode *NMS =
+      llvm::dyn_cast<NonMaxSuppressionNode>(save->getInput().getNode());
+  ASSERT_TRUE(NMS);
+  EXPECT_EQ(NMS->dims(0)[0], 3);
+  EXPECT_EQ(NMS->getCenterPointBox(), 0);
+}
+
+/// Test loading NMS using Constant Tensors op from an ONNX model.
+TEST(onnx, importNMSConstTensor) {
+  ExecutionEngine EE{};
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+
+  std::string netFilename(
+      GLOW_DATA_PATH "tests/models/onnxModels/NonMaxSuppressionSSD.onnxtxt");
+
+  PlaceholderBindings bindings;
+  Placeholder *output;
+  {
+    Tensor boxes(ElemKind::FloatTy, {8, 4});
+    boxes.zero();
+
+    Tensor scores(ElemKind::FloatTy, {8});
+    scores.zero();
+
+    ONNXModelLoader onnxLD(netFilename, {"boxes", "scores"},
+                           {&boxes.getType(), &scores.getType()}, *F);
+    output = EXIT_ON_ERR(onnxLD.getOutputByName("indices"));
+  }
+
+  auto *save = getSaveNodeFromDest(output);
+  NonMaxSuppressionNode *NMS =
+      llvm::dyn_cast<NonMaxSuppressionNode>(save->getInput().getNode());
+  ASSERT_TRUE(NMS);
+  EXPECT_EQ(NMS->dims(0)[0], 3);
+  EXPECT_EQ(NMS->getCenterPointBox(), 1);
+}
+
+/// Test loading ONNX NMS using Constant Tensors op from an ONNX model.
+TEST(onnx, importNMSONNXConstTensor) {
+  ExecutionEngine EE{};
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+
+  std::string netFilename(
+      GLOW_DATA_PATH
+      "tests/models/onnxModels/NonMaxSuppressionSSD_ONNX.onnxtxt");
+
+  PlaceholderBindings bindings;
+  Placeholder *output;
+  {
+    Tensor boxes(ElemKind::FloatTy, {1, 8, 4});
+    boxes.zero();
+
+    Tensor scores(ElemKind::FloatTy, {1, 1, 8});
+    scores.zero();
+
+    ONNXModelLoader onnxLD(netFilename, {"boxes", "scores"},
+                           {&boxes.getType(), &scores.getType()}, *F);
+    output = EXIT_ON_ERR(onnxLD.getOutputByName("indices"));
+  }
+
+  auto *save = getSaveNodeFromDest(output);
+  NonMaxSuppressionNode *NMS =
+      llvm::dyn_cast<NonMaxSuppressionNode>(save->getInput().getNode());
+  ASSERT_TRUE(NMS);
+  EXPECT_EQ(NMS->dims(0)[0], 3);
+  EXPECT_EQ(NMS->dims(0)[1], 3);
+  EXPECT_EQ(NMS->getCenterPointBox(), 1);
+}
+
 TEST(onnx, importDimParamExplicit) {
   ExecutionEngine EE;
   auto &mod = EE.getModule();

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -616,6 +616,411 @@ TEST_P(OperatorTest, where_element_wise_float) {
   }
 }
 
+struct NMSMetaData {
+  int centerPoint{0};
+  size_t maxOutputPerClass{0};
+  float iouThreshold{0.0};
+  float scoreThreshold{0.0};
+};
+
+struct SelectedBox {
+  int batchIndex{0};
+  int classIndex{0};
+  int boxIndex{0};
+};
+
+struct Box {
+  float x;
+  float y;
+  float h;
+  float w;
+};
+
+template <typename DataType, typename outType = int64_t>
+static Handle<outType> testNonMaxSuppression(
+    glow::PlaceholderBindings &bindings, glow::Module &mod, glow::Function *F,
+    glow::ExecutionEngine &EE, ElemKind DTy, llvm::ArrayRef<dim_t> boxesDims,
+    llvm::ArrayRef<dim_t> scoresDims, llvm::ArrayRef<DataType> boxesData,
+    llvm::ArrayRef<DataType> classes, llvm::ArrayRef<SelectedBox> refResults,
+    llvm::ArrayRef<int32_t> refNumSelected, const NMSMetaData &metaData,
+    bool isV4) {
+
+  // NHW
+  auto *boxes = createPlaceholderConditionallyQuantized(mod, DTy, boxesDims,
+                                                        "boxes", false);
+
+  auto *scores = createPlaceholderConditionallyQuantized(mod, DTy, scoresDims,
+                                                         "scores", false);
+
+  NonMaxSuppressionNode *nms = nullptr;
+
+  if (isV4) {
+    nms = F->createNonMaxSuppressionV4(
+        "NMS", boxes, scores, metaData.centerPoint, metaData.maxOutputPerClass,
+        metaData.iouThreshold, metaData.scoreThreshold);
+  } else {
+    nms = F->createNonMaxSuppressionONNX(
+        "NMS", boxes, scores, metaData.centerPoint, metaData.maxOutputPerClass,
+        metaData.iouThreshold, metaData.scoreThreshold);
+  }
+
+  auto *saveIndices = F->createSave("save", nms->getIndices());
+  auto *saveNumSelected =
+      F->createSave("numSelected", nms->getNumberOfSelectedIndices());
+  auto *result = bindings.allocate(saveIndices->getPlaceholder());
+  auto *result2 = bindings.allocate(saveNumSelected->getPlaceholder());
+
+  bindings.allocate(boxes)->getHandle<DataType>() = boxesData;
+  bindings.allocate(scores)->getHandle<DataType>() = classes;
+
+  CompilationContext cctx;
+  cctx.compMode = CompilationMode::Infer;
+  EE.compile(cctx);
+  EE.run(bindings);
+
+  Handle<outType> result2H = result2->getHandle<outType>();
+  for (dim_t i = 0; i < (dim_t)refNumSelected.size(); ++i) {
+    EXPECT_EQ(result2H.at({i}), refNumSelected[i]);
+  }
+
+  Handle<outType> resultH = result->getHandle<outType>();
+
+  if (isV4) {
+    for (dim_t i = 0; i < (dim_t)metaData.maxOutputPerClass; ++i) {
+      EXPECT_EQ(refResults[i].boxIndex, resultH.at({i}));
+    }
+  } else {
+    for (dim_t i = 0; i < (dim_t)metaData.maxOutputPerClass; ++i) {
+      EXPECT_EQ(refResults[i].batchIndex, resultH.at({i, (dim_t)0}));
+      EXPECT_EQ(refResults[i].classIndex, resultH.at({i, (dim_t)1}));
+      EXPECT_EQ(refResults[i].boxIndex, resultH.at({i, (dim_t)2}));
+    }
+  }
+
+  return resultH;
+}
+
+template <typename DataType, typename outType = int64_t>
+static Handle<float> testNonMaxSuppressionWithGather(
+    glow::PlaceholderBindings &bindings, glow::Module &mod, glow::Function *F,
+    glow::ExecutionEngine &EE, ElemKind DTy, llvm::ArrayRef<dim_t> boxesDims,
+    llvm::ArrayRef<dim_t> scoresDims, llvm::ArrayRef<dim_t> boxIndicesDim,
+    llvm::ArrayRef<DataType> boxesData, llvm::ArrayRef<DataType> classes,
+    llvm::ArrayRef<int32_t> boxIndicesData, llvm::ArrayRef<Box> refBoxResults,
+    llvm::ArrayRef<int32_t> refNumSelected, const NMSMetaData &metaData,
+    bool isV4) {
+  // NHW
+  auto *boxes = createPlaceholderConditionallyQuantized(mod, DTy, boxesDims,
+                                                        "boxes", false);
+
+  auto *scores = createPlaceholderConditionallyQuantized(mod, DTy, scoresDims,
+                                                         "scores", false);
+
+  auto *boxIndices = createPlaceholderConditionallyQuantized(
+      mod, ElemKind::Int32ITy, boxIndicesDim, "boxIndices", false);
+
+  NonMaxSuppressionNode *nms = nullptr;
+
+  unsigned axis = 1;
+  if (isV4) {
+    nms = F->createNonMaxSuppressionV4(
+        "NMS", boxes, scores, metaData.centerPoint, metaData.maxOutputPerClass,
+        metaData.iouThreshold, metaData.scoreThreshold);
+    axis = 0;
+  } else {
+
+    nms = F->createNonMaxSuppressionONNX(
+        "NMS", boxes, scores, metaData.centerPoint, metaData.maxOutputPerClass,
+        metaData.iouThreshold, metaData.scoreThreshold);
+  }
+
+  // extract all the box indices
+  auto *gthI =
+      F->createGather("gatherBoxIndices", nms->getIndices(), boxIndices, axis);
+  auto *gthB = F->createGather("gatherClassIndices", boxes, gthI, axis);
+  Node *fltn2 = nullptr;
+
+  if (isV4) {
+    fltn2 = gthB;
+  } else {
+    fltn2 = F->createFlatten("flatten", gthB, 2);
+  }
+
+  auto *saveBoxes = F->createSave("saveBoxes", fltn2);
+  auto saveNumSelected =
+      F->createSave("numSelected", nms->getNumberOfSelectedIndices());
+
+  auto *result = bindings.allocate(saveBoxes->getPlaceholder());
+  auto *result2 = bindings.allocate(saveNumSelected->getPlaceholder());
+
+  bindings.allocate(boxes)->getHandle<DataType>() = boxesData;
+  bindings.allocate(scores)->getHandle<DataType>() = classes;
+  bindings.allocate(boxIndices)->getHandle<int32_t>() = boxIndicesData;
+
+  CompilationContext cctx;
+  cctx.compMode = CompilationMode::Infer;
+  EE.compile(cctx);
+  EE.run(bindings);
+
+  Handle<outType> result2H = result2->getHandle<outType>();
+  for (dim_t i = 0; i < (dim_t)refNumSelected.size(); ++i) {
+    EXPECT_EQ(result2H.at({i}), refNumSelected[i]);
+  }
+
+  Handle<float> resultH = result->getHandle<float>();
+
+  for (dim_t i = 0; i < (dim_t)refBoxResults.size(); ++i) {
+    EXPECT_EQ(refBoxResults[i].x, resultH.at({i, (dim_t)0}));
+    EXPECT_EQ(refBoxResults[i].y, resultH.at({i, (dim_t)1}));
+    EXPECT_EQ(refBoxResults[i].h, resultH.at({i, (dim_t)2}));
+    EXPECT_EQ(refBoxResults[i].w, resultH.at({i, (dim_t)3}));
+  }
+
+  return resultH;
+}
+
+TEST_P(OperatorTest, nms_center_point_box_with_gather_float) {
+  ENABLED_BACKENDS(Interpreter, CPU);
+  llvm::SmallVector<dim_t, 3> boxesDims = {1, 6, 4};
+  llvm::SmallVector<dim_t, 3> scoresDims = {1, 1, 6};
+  llvm::SmallVector<dim_t, 1> boxIndexesDms = {1};
+
+  llvm::SmallVector<float, 24> boxes = {
+      0.5, 0.5,  1.0, 1.0, 0.5, 0.6,  1.0, 1.0, 0.5, 0.4,   1.0, 1.0,
+      0.5, 10.5, 1.0, 1.0, 0.5, 10.6, 1.0, 1.0, 0.5, 100.5, 1.0, 1.0};
+
+  llvm::SmallVector<float, 6> classes = {0.9, 0.75, 0.6, 0.95, 0.5, 0.3};
+  llvm::SmallVector<int32_t, 1> boxIndices = {2};
+  llvm::SmallVector<Box, 3> refResults = {
+      {0.5, 10.5, 1.0, 1.0}, {0.5, 0.5, 1.0, 1.0}, {0.5, 0.5, 1.0, 1.0}};
+  NMSMetaData metaData = {1, 3, 0.5, 0.4};
+  llvm::SmallVector<int32_t, 1> refNumSelected = {2};
+
+  testNonMaxSuppressionWithGather<float>(
+      bindings_, mod_, F_, EE_, ElemKind::FloatTy, boxesDims, scoresDims,
+      boxIndexesDms, boxes, classes, boxIndices, refResults, refNumSelected,
+      metaData, false);
+}
+
+TEST_P(OperatorTest, nms_v4_center_point_box_with_gather_float) {
+  ENABLED_BACKENDS(Interpreter, CPU);
+  llvm::SmallVector<dim_t, 3> boxesDims = {6, 4};
+  llvm::SmallVector<dim_t, 1> scoresDims = {6};
+  llvm::SmallVector<dim_t, 1> boxIndexesDims = {3};
+
+  llvm::SmallVector<float, 24> boxes = {
+      0.5, 0.5,  1.0, 1.0, 0.5, 0.6,  1.0, 1.0, 0.5, 0.4,   1.0, 1.0,
+      0.5, 10.5, 1.0, 1.0, 0.5, 10.6, 1.0, 1.0, 0.5, 100.5, 1.0, 1.0};
+
+  llvm::SmallVector<float, 6> classes = {0.9, 0.75, 0.6, 0.95, 0.5, 0.3};
+  llvm::SmallVector<int32_t, 3> boxIndices = {0, 1, 2};
+  llvm::SmallVector<Box, 3> refResults = {
+      {0.5, 10.5, 1.0, 1.0}, {0.5, 0.5, 1.0, 1.0}, {0.5, 0.5, 1.0, 1.0}};
+  NMSMetaData metaData = {1, 3, 0.5, 0.4};
+  llvm::SmallVector<int32_t, 1> refNumSelected{2};
+
+  testNonMaxSuppressionWithGather<float>(
+      bindings_, mod_, F_, EE_, ElemKind::FloatTy, boxesDims, scoresDims,
+      boxIndexesDims, boxes, classes, boxIndices, refResults, refNumSelected,
+      metaData, true);
+}
+
+TEST_P(OperatorTest, nms_center_point_box_float) {
+  ENABLED_BACKENDS(Interpreter, CPU);
+  llvm::SmallVector<dim_t, 3> boxesDims = {1, 6, 4};
+  llvm::SmallVector<dim_t, 3> scoresDims = {1, 1, 6};
+  llvm::SmallVector<float, 24> boxes = {
+      0.5, 0.5,  1.0, 1.0, 0.5, 0.6,  1.0, 1.0, 0.5, 0.4,   1.0, 1.0,
+      0.5, 10.5, 1.0, 1.0, 0.5, 10.6, 1.0, 1.0, 0.5, 100.5, 1.0, 1.0};
+  llvm::SmallVector<float, 6> classes = {0.9, 0.75, 0.6, 0.95, 0.5, 0.3};
+  llvm::SmallVector<SelectedBox, 3> refResults = {
+      {0, 0, 3}, {0, 0, 0}, {0, 0, 5}};
+  NMSMetaData metaData = {1, 3, 0.5, 0.0};
+  llvm::SmallVector<int32_t, 1> refNumSelected{3};
+
+  testNonMaxSuppression<float>(bindings_, mod_, F_, EE_, ElemKind::FloatTy,
+                               boxesDims, scoresDims, boxes, classes,
+                               refResults, refNumSelected, metaData, false);
+}
+
+TEST_P(OperatorTest, nms_v4_center_point_box_float) {
+  ENABLED_BACKENDS(Interpreter, CPU);
+  llvm::SmallVector<dim_t, 3> boxesDims = {6, 4};
+  llvm::SmallVector<dim_t, 1> scoresDims = {6};
+  llvm::SmallVector<float, 24> boxes = {
+      0.5, 0.5,  1.0, 1.0, 0.5, 0.6,  1.0, 1.0, 0.5, 0.4,   1.0, 1.0,
+      0.5, 10.5, 1.0, 1.0, 0.5, 10.6, 1.0, 1.0, 0.5, 100.5, 1.0, 1.0};
+  llvm::SmallVector<float, 6> classes = {0.9, 0.75, 0.6, 0.95, 0.5, 0.3};
+  llvm::SmallVector<SelectedBox, 3> refResults = {
+      {0, 0, 3}, {0, 0, 0}, {0, 0, 5}};
+  NMSMetaData metaData = {1, 3, 0.5, 0.0};
+  llvm::SmallVector<int32_t, 1> refNumSelected{3};
+
+  testNonMaxSuppression<float>(bindings_, mod_, F_, EE_, ElemKind::FloatTy,
+                               boxesDims, scoresDims, boxes, classes,
+                               refResults, refNumSelected, metaData, true);
+}
+
+TEST_P(OperatorTest, nms_flipped_coordinates_float) {
+  ENABLED_BACKENDS(Interpreter, CPU);
+  llvm::SmallVector<dim_t, 3> boxesDims = {1, 6, 4};
+  llvm::SmallVector<dim_t, 3> scoresDims = {1, 1, 6};
+  llvm::SmallVector<float, 24> boxes = {
+      1.0, 1.0,  0.0, 0.0,  0.0, 0.1,  1.0, 1.1,  0.0, 0.9,   1.0, -0.1,
+      0.0, 10.0, 1.0, 11.0, 1.0, 10.1, 0.0, 11.1, 1.0, 101.0, 0.0, 100.0};
+  llvm::SmallVector<float, 6> classes = {0.9, 0.75, 0.6, 0.95, 0.5, 0.3};
+  llvm::SmallVector<SelectedBox, 3> refResults = {
+      {0, 0, 3}, {0, 0, 0}, {0, 0, 5}};
+  NMSMetaData metaData = {0, 3, 0.5, 0.0};
+  llvm::SmallVector<int32_t, 1> refNumSelected{3};
+
+  testNonMaxSuppression<float>(bindings_, mod_, F_, EE_, ElemKind::FloatTy,
+                               boxesDims, scoresDims, boxes, classes,
+                               refResults, refNumSelected, metaData, false);
+}
+
+TEST_P(OperatorTest, nms_identical_boxes_float) {
+  ENABLED_BACKENDS(Interpreter, CPU);
+  llvm::SmallVector<dim_t, 3> boxesDims = {1, 10, 4};
+  llvm::SmallVector<dim_t, 3> scoresDims = {1, 1, 10};
+  llvm::SmallVector<float, 40> boxes = {
+      0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0,
+      1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0,
+      0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0};
+  llvm::SmallVector<float, 10> classes = {0.9, 0.9, 0.9, 0.9, 0.9,
+                                          0.9, 0.9, 0.9, 0.9, 0.9};
+  llvm::SmallVector<SelectedBox, 3> refResults = {{0, 0, 0}};
+  NMSMetaData metaData = {0, 1, 0.5, 0.0};
+  llvm::SmallVector<int32_t, 1> refNumSelected{1};
+
+  testNonMaxSuppression<float>(bindings_, mod_, F_, EE_, ElemKind::FloatTy,
+                               boxesDims, scoresDims, boxes, classes,
+                               refResults, refNumSelected, metaData, false);
+}
+
+TEST_P(OperatorTest, nms_limit_output_size_float) {
+  ENABLED_BACKENDS(Interpreter, CPU);
+  llvm::SmallVector<dim_t, 3> boxesDims = {1, 6, 4};
+  llvm::SmallVector<dim_t, 3> scoresDims = {1, 1, 6};
+  llvm::SmallVector<float, 24> boxes = {
+      0.0, 0.0,  1.0, 1.0,  0.0, 0.1,  1.0, 1.1,  0.0, -0.1,  1.0, 0.9,
+      0.0, 10.0, 1.0, 11.0, 0.0, 10.1, 1.0, 11.1, 0.0, 100.0, 1.0, 101.0};
+  llvm::SmallVector<float, 6> classes = {0.9, 0.75, 0.6, 0.95, 0.5, 0.3};
+  llvm::SmallVector<SelectedBox, 2> refResults = {{0, 0, 3}, {0, 0, 0}};
+  NMSMetaData metaData = {0, 2, 0.5, 0.0};
+  llvm::SmallVector<int32_t, 1> refNumSelected{2};
+
+  testNonMaxSuppression<float>(bindings_, mod_, F_, EE_, ElemKind::FloatTy,
+                               boxesDims, scoresDims, boxes, classes,
+                               refResults, refNumSelected, metaData, false);
+}
+
+TEST_P(OperatorTest, nms_single_box_float) {
+  ENABLED_BACKENDS(Interpreter, CPU);
+  llvm::SmallVector<dim_t, 3> boxesDims = {1, 1, 4};
+  llvm::SmallVector<dim_t, 3> scoresDims = {1, 1, 1};
+  llvm::SmallVector<float, 4> boxes = {0.0, 0.0, 1.0, 1.0};
+  llvm::SmallVector<float, 1> classes = {0.9};
+  llvm::SmallVector<SelectedBox, 1> refResults = {
+      {0, 0, 0}, {0, 0, 0}, {0, 0, 0}};
+  NMSMetaData metaData = {0, 3, 0.5, 0.0};
+  llvm::SmallVector<int32_t, 1> refNumSelected{1};
+
+  testNonMaxSuppression<float>(bindings_, mod_, F_, EE_, ElemKind::FloatTy,
+                               boxesDims, scoresDims, boxes, classes,
+                               refResults, refNumSelected, metaData, false);
+}
+
+TEST_P(OperatorTest, nms_by_iou_float) {
+  ENABLED_BACKENDS(Interpreter, CPU);
+  llvm::SmallVector<dim_t, 3> boxesDims = {1, 6, 4};
+  llvm::SmallVector<dim_t, 3> scoresDims = {1, 1, 6};
+  llvm::SmallVector<float, 24> boxes = {
+      0.0, 0.0,  1.0, 1.0,  0.0, 0.1,  1.0, 1.1,  0.0, -0.1,  1.0, 0.9,
+      0.0, 10.0, 1.0, 11.0, 0.0, 10.1, 1.0, 11.1, 0.0, 100.0, 1.0, 101.0};
+  llvm::SmallVector<float, 6> classes = {0.9, 0.75, 0.6, 0.95, 0.5, 0.3};
+  llvm::SmallVector<SelectedBox, 2> refResults = {
+      {0, 0, 3}, {0, 0, 0}, {0, 0, 5}};
+  NMSMetaData metaData = {0, 3, 0.5, 0.0};
+  llvm::SmallVector<int32_t, 1> refNumSelected{3};
+
+  testNonMaxSuppression<float>(bindings_, mod_, F_, EE_, ElemKind::FloatTy,
+                               boxesDims, scoresDims, boxes, classes,
+                               refResults, refNumSelected, metaData, false);
+}
+
+TEST_P(OperatorTest, nms_by_iou_and_scores_float) {
+  ENABLED_BACKENDS(Interpreter, CPU);
+  llvm::SmallVector<dim_t, 3> boxesDims = {1, 6, 4};
+  llvm::SmallVector<dim_t, 3> scoresDims = {1, 1, 6};
+  llvm::SmallVector<float, 24> boxes = {
+      0.0, 0.0,  1.0, 1.0,  0.0, 0.1,  1.0, 1.1,  0.0, -0.1,  1.0, 0.9,
+      0.0, 10.0, 1.0, 11.0, 0.0, 10.1, 1.0, 11.1, 0.0, 100.0, 1.0, 101.0};
+  llvm::SmallVector<float, 6> classes = {0.9, 0.75, 0.6, 0.95, 0.5, 0.3};
+  llvm::SmallVector<SelectedBox, 2> refResults = {{0, 0, 3}, {0, 0, 0}};
+  NMSMetaData metaData = {0, 2, 0.5, 0.4};
+  llvm::SmallVector<int32_t, 1> refNumSelected{2};
+
+  testNonMaxSuppression<float>(bindings_, mod_, F_, EE_, ElemKind::FloatTy,
+                               boxesDims, scoresDims, boxes, classes,
+                               refResults, refNumSelected, metaData, false);
+}
+
+TEST_P(OperatorTest, nms_two_batches_float) {
+  ENABLED_BACKENDS(Interpreter, CPU);
+  llvm::SmallVector<dim_t, 3> boxesDims = {2, 6, 4};
+  llvm::SmallVector<dim_t, 3> scoresDims = {2, 1, 6};
+  llvm::SmallVector<float, 48> boxes = {
+      0.0, 0.0,  1.0, 1.0,  0.0, 0.1,  1.0, 1.1,  0.0, -0.1,  1.0, 0.9,
+      0.0, 10.0, 1.0, 11.0, 0.0, 10.1, 1.0, 11.1, 0.0, 100.0, 1.0, 101.0,
+      0.0, 0.0,  1.0, 1.0,  0.0, 0.1,  1.0, 1.1,  0.0, -0.1,  1.0, 0.9,
+      0.0, 10.0, 1.0, 11.0, 0.0, 10.1, 1.0, 11.1, 0.0, 100.0, 1.0, 101.0};
+  llvm::SmallVector<float, 12> classes = {0.9, 0.75, 0.6, 0.95, 0.5, 0.3,
+                                          0.9, 0.75, 0.6, 0.95, 0.5, 0.3};
+  llvm::SmallVector<SelectedBox, 4> refResults = {
+      {0, 0, 3}, {0, 0, 0}, {1, 0, 3}, {1, 0, 0}};
+  NMSMetaData metaData = {0, 2, 0.5, 0.0};
+  llvm::SmallVector<int32_t, 2> refNumSelected{2, 2};
+
+  testNonMaxSuppression<float>(bindings_, mod_, F_, EE_, ElemKind::FloatTy,
+                               boxesDims, scoresDims, boxes, classes,
+                               refResults, refNumSelected, metaData, false);
+}
+
+TEST_P(OperatorTest, nms_two_classes_float) {
+  ENABLED_BACKENDS(Interpreter, CPU);
+  llvm::SmallVector<dim_t, 3> boxesDims = {1, 6, 4};
+  llvm::SmallVector<dim_t, 3> scoresDims = {1, 2, 6};
+  llvm::SmallVector<float, 24> boxes = {
+      0.0, 0.0,  1.0, 1.0,  0.0, 0.1,  1.0, 1.1,  0.0, -0.1,  1.0, 0.9,
+      0.0, 10.0, 1.0, 11.0, 0.0, 10.1, 1.0, 11.1, 0.0, 100.0, 1.0, 101.0};
+  llvm::SmallVector<float, 12> classes = {0.9, 0.75, 0.6, 0.95, 0.5, 0.3,
+                                          0.9, 0.75, 0.6, 0.95, 0.5, 0.3};
+  llvm::SmallVector<SelectedBox, 4> refResults = {
+      {0, 0, 3}, {0, 0, 0}, {0, 1, 3}, {0, 1, 0}};
+  NMSMetaData metaData = {0, 2, 0.5, 0.4};
+  llvm::SmallVector<int32_t, 1> refNumSelected{4};
+
+  testNonMaxSuppression<float>(bindings_, mod_, F_, EE_, ElemKind::FloatTy,
+                               boxesDims, scoresDims, boxes, classes,
+                               refResults, refNumSelected, metaData, false);
+}
+
+TEST_P(OperatorTest, nms_two_boxes_float) {
+  ENABLED_BACKENDS(Interpreter, CPU);
+  llvm::SmallVector<dim_t, 3> boxesDims = {1, 2, 4};
+  llvm::SmallVector<dim_t, 3> scoresDims = {1, 1, 2};
+  llvm::SmallVector<float, 4> boxes = {0.0, 0.0, 1.0, 1.0, 0.1, 0.1, 0.9, 0.9};
+  llvm::SmallVector<float, 2> classes = {0.8, 0.9};
+  llvm::SmallVector<SelectedBox, 1> refResults = {{0, 0, 1}};
+  NMSMetaData metaData = {0, 1, 0.5, 0.0};
+  llvm::SmallVector<int32_t, 1> refNumSelected{1};
+
+  testNonMaxSuppression<float>(bindings_, mod_, F_, EE_, ElemKind::FloatTy,
+                               boxesDims, scoresDims, boxes, classes,
+                               refResults, refNumSelected, metaData, false);
+}
+
 // Helper to test SpaceToDepth using \p DTy.
 template <typename DataType>
 static void testSpaceToDepthBlock3(glow::PlaceholderBindings &bindings,

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -794,6 +794,25 @@ int main(int argc, char **argv) {
       .autoIRGen();
 
   //===--------------------------------------------------------------------===//
+  //                Post Processing
+  //===--------------------------------------------------------------------===//
+
+  BB.newInstr("NonMaxSuppression")
+      .addOperand("Indices", OperandKind::Out)
+      .addOperand("NumberOfSelectedIndices", OperandKind::Out)
+      .addOperand("Boxes", OperandKind::In)
+      .addOperand("Scores", OperandKind::In)
+      .addMember(MemberType::Int64, "CenterPointBox")
+      .addMember(MemberType::Int64, "MaxOutputBoxesPerClass")
+      .addMember(MemberType::Float, "IouThreshold")
+      .addMember(MemberType::Float, "ScoreThreshold")
+      .addMember(MemberType::Boolean, "IsTFVersion4")
+      .autoVerify(VerifyKind::SameElementType, {"Boxes", "Scores"})
+      .autoVerify(VerifyKind::SameElementType,
+                  {"Indices", "NumberOfSelectedIndices"})
+      .autoIRGen();
+
+  //===--------------------------------------------------------------------===//
   //                Backend-Specific Instructions
   //===--------------------------------------------------------------------===//
 

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -993,6 +993,25 @@ int main(int argc, char **argv) {
           "and Rescale nodes.");
 
   //===--------------------------------------------------------------------===//
+  //                Post Processing
+  //===--------------------------------------------------------------------===//
+
+  BB.newNode("NonMaxSuppression")
+      .addInput("Boxes")
+      .addInput("Scores")
+      .addMember(MemberType::Unsigned, "CenterPointBox")
+      .addMember(MemberType::Unsigned, "MaxOutputBoxesPerClass")
+      .addMember(MemberType::Float, "IouThreshold")
+      .addMember(MemberType::Float, "ScoreThreshold")
+      .addMember(MemberType::Boolean, "IsTFVersion4")
+      .addResultFromCtorArg("Indices")
+      .addResultFromCtorArg("NumberOfSelectedIndices")
+      .setDocstring("This is a mix of ONNX and TF NMSv4. It supports multiple "
+                    "classes and does per class NMS. It also supports TF NMS "
+                    "V4 by outputting indices and scalar tensor with number of "
+                    "valid indices. It pads the rest with global MIN box.");
+
+  //===--------------------------------------------------------------------===//
   //                Backend-Specific Nodes
   //===--------------------------------------------------------------------===//
 


### PR DESCRIPTION
Summary:
This is somewhat of a messy, and probably controversial node.
It is needed for Object Detection post processing.
The core algorithm is basically ONNX runtime one. That being said there are some caveats. 
First one.
The TF models use NMSv4. Unlike ONNX spec definition it
1) Works only on 1 class.
2) Has second output of number of indices detected.

So this implementation tries to combine them.

Second caveat is that second output is being broadcasted internally within NMS node. This eliminates explicit broadcast node in the graph. 

Documentation:
https://github.com/onnx/onnx/blob/master/docs/Operators.md#NonMaxSuppression
https://www.tensorflow.org/api_docs/cc/class/tensorflow/ops/non-max-suppression-v4

[Optional Fixes #issue]

Test Plan:
External: Unit Tests
Internal: ONNX SSD, TF converted Mobilenet V2 SSD, DarkNet converted Yolo V2.

Related to https://github.com/pytorch/glow/issues/3944