### PR TITLE
[OpenCL] add an option to cache programs on disk

### DIFF
--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -132,6 +132,29 @@ public:
   ManualEventMap &getManualTraceEvents() { return manualTraceEvents_; }
 
 private:
+  /// Returns the directory of cached pre-built programs for the given device.
+  /// \returns the directory as given by the user.
+  std::string deviceProgramCacheDir(cl_device_id deviceId);
+
+  /// Returns the (hashed) file name of a cached pre-built program for the
+  /// given source and set of build options.
+  /// \returns the filename (without directory).
+  std::string diskCacheProgramFileName(cl_device_id deviceId,
+                                       const std::string &source,
+                                       const std::string &options);
+
+  /// (Tries to) load a program with the given (hashed) filename
+  /// from the disk cache.
+  /// \returns pointer to the program, if found, nullptr otherwise.
+  cl_program loadProgramFromDiskCache(std::string cacheDirectory,
+                                      std::string programFileName,
+                                      cl_context ctx, cl_device_id device);
+
+  /// Save the given program to the disk cache.
+  void saveProgramToDiskCache(std::string cacheDirectory,
+                              std::string programFilename, cl_program program,
+                              cl_context ctx, cl_device_id deviceId);
+
   /// Copy the value from a device to a provided buffer.
   /// \returns number of copied bytes.
   uint64_t copyValueFromDevice(const Value *v,

--- a/lib/Backends/OpenCL/tests/OpenCLDiskCacheTest.cmake
+++ b/lib/Backends/OpenCL/tests/OpenCLDiskCacheTest.cmake
@@ -1,0 +1,25 @@
+# Smoke tests the OpenCL backend's disk based kernel program cache by
+# executing the OCLTest twice with the disk caching on.
+
+set(OPENCL_CACHE_DIR ${CMAKE_CURRENT_BINARY_DIR}/opencl-cached-binaries)
+
+file(REMOVE_RECURSE ${OPENCL_CACHE_DIR})
+
+function(RUN_OCLTEST)
+  execute_process(COMMAND "${CMAKE_CURRENT_BINARY_DIR}/tests/OCLTest" "--gtest_output=xml:OCLTestCached.xml" "--opencl-program-cache-dir=${OPENCL_CACHE_DIR}"
+    RESULT_VARIABLE CMD_RES
+    ERROR_QUIET
+    OUTPUT_QUIET)
+endfunction(RUN_OCLTEST)
+
+run_ocltest()
+if(CMD_RES)
+  message(FATAL_ERROR "Error in the OpenCL cold cache test run.")
+endif()
+
+run_ocltest()
+if(CMD_RES)
+  message(FATAL_ERROR "Error in the warm cache OpenCL test run.")
+endif()
+
+file(REMOVE_RECURSE ${OPENCL_CACHE_DIR})

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -334,10 +334,12 @@ if(GLOW_WITH_OPENCL)
                           TestMain)
   add_glow_test(OCLTest
                 ${GLOW_BINARY_DIR}/tests/OCLTest
-                    --gtest_output=xml:OCLTest.xml)
+                --gtest_output=xml:OCLTest.xml)
+
+  add_glow_test(OCLTestWithDiskCache
+                ${CMAKE_COMMAND} -P ${CMAKE_SOURCE_DIR}/lib/Backends/OpenCL/tests/OpenCLDiskCacheTest.cmake)
+
   LIST(APPEND UNOPT_TESTS ./tests/OCLTest -optimize-ir=false &&)
-
-
 
 endif()
 


### PR DESCRIPTION
Summary:

When a directory is given with -opencl-program-cache-dir, the OpenCL backend looks in it for cached OpenCL programs for the targeted device and tries to load from the found binary instead of building from the sources.

If it fails to load the binary, it assumes the file is corrupted or for a wrong device (or driver version) and rebuilds it.

When hitting the disk cache, I measured the following speedups with resnet50 (best-of-ten):

* Intel HD 620 GPU: From 7.0 s (cold cache) down to 0.3 s (hot cache).

* Intel(R) Core(TM) i7-7500U CPU @ 2.70GHz (Intel's OpenCL SDK): From 2.7 s (cold cache) down to 1.3 s (hot cache).

* pocl 1.5-pre (LLVM 9) for the same CPU: From 1.5 s (pocl's internal kcache helps) down to 1.0 (hot cache).

Test Plan:

ninja check with CPU/LLVM7, OpenCL/pocl, OpenCL/IntelCPU, OpenCL/IntelGPU
