### PR TITLE
Fix StringRef issue in ExecutionEngine

### DIFF
--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -53,10 +53,10 @@ void ExecutionEngine::setBackendName(llvm::StringRef backend) {
     // and that it matches the expected backend name.
     CHECK_EQ(configs.size(), 1)
         << "Expected a single device for the ExecutionEngine";
-    CHECK(backend.str() == configs[0]->backendName)
+    CHECK(backendName_ == configs[0]->backendName)
         << "Expected backend name to match the ExecutionEngine";
   } else {
-    auto config = glow::make_unique<runtime::DeviceConfig>(backend);
+    auto config = glow::make_unique<runtime::DeviceConfig>(backendName_);
     if (deviceMemory_) {
       config->setDeviceMemory(deviceMemory_);
     }


### PR DESCRIPTION
ExecutionEngine::setBackendName() is getting a llvm::StringRef as input. in some cases, the reference is invalid after calling hostManager_.reset(), and when trying to use it in the next few lines you'll get an unexpected behavior (probably failing on line 56 check).
suggesting to use the member string that gets updated in the beginning of the function instead of using the input itself.

Summary:

Documentation:

[Optional Fixes #issue]

Test Plan:

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
