### PR TITLE
Support import of HalfToFloat

### DIFF
--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -1141,6 +1141,16 @@ Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     return Error::success();
   }
 
+  if (typeName == "HalfToFloat") {
+    NodeValue in;
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
+    auto fp16InputType =
+        G_.getParent()->uniqueType(ElemKind::Float16Ty, in.getType()->dims());
+    auto *R = G_.createConvertTo("ConvertInput", in, fp16InputType);
+    RETURN_IF_ERR(addNodeAsOutput(op, R));
+    return Error::success();
+  }
+
   if (typeName == "ScatterAssign") {
     NodeValue data;
     ASSIGN_VALUE_OR_RETURN_ERR(data, getNodeValueByName(op.input(0)));

--- a/tests/models/caffe2Models/halftofloat_op_net.pbtxt
+++ b/tests/models/caffe2Models/halftofloat_op_net.pbtxt
@@ -1,0 +1,9 @@
+name: "alias"
+op {
+  input: "X"
+  output: "Y"
+  name: ""
+  type: "HalfToFloat"
+}
+external_input: "X"
+external_output: "Y"

--- a/tests/unittests/Caffe2ImporterTest.cpp
+++ b/tests/unittests/Caffe2ImporterTest.cpp
@@ -1797,6 +1797,43 @@ TEST(caffe2, tensorFillsTest) {
   }
 }
 
+TEST(caffe2, HalfToFloat) {
+  ExecutionEngine EE{};
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+
+  llvm::StringRef NetDescFilename(
+      GLOW_DATA_PATH "tests/models/caffe2Models/halftofloat_op_net.pbtxt");
+  std::string NetWeightFilename(
+      GLOW_DATA_PATH "tests/models/caffe2Models/empty_init_net.pbtxt");
+
+  Placeholder *output;
+  PlaceholderBindings bindings;
+
+  Tensor input(ElemKind::FloatTy, {1, 2, 3, 4});
+
+  // Destroy the loader after the graph is loaded since the following execution
+  // will not depend on anything from the loader.
+  {
+    // Loaded protos must have at least one external output, so load an unused
+    // output and type to satisfy it. It is named unused_output in
+    // empty_predict_net.pbtxt.
+    Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"X"},
+                               {&input.getType()}, *F);
+    output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
+  }
+
+  ASSERT_TRUE(output);
+
+  // Graph has 2 nodes: Save and ConvertTo
+  EXPECT_EQ(F->getNodes().size(), 2);
+
+  // Input to save node is ConvertToNode.
+  auto *saveNode = getSaveNodeFromDest(output);
+  auto *N = llvm::dyn_cast<ConvertToNode>(saveNode->getInput());
+  EXPECT_TRUE(N);
+}
+
 TEST(caffe2, Alias) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();


### PR DESCRIPTION
Summary: Import HalfToFloat as Glow ConvertTo. We might need a pass into Glow to cancel out ConvertAtoB - ConvertBtoA

Differential Revision: D19293024

