### PR TITLE
Enable blacklist for stress tests

### DIFF
--- a/lib/Backends/NNPI/tests/NNPIParameterSweepTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIParameterSweepTest.cpp
@@ -18,3 +18,114 @@
 using namespace glow;
 
 std::set<std::string> glow::backendTestBlacklist = {};
+
+struct BlacklistInitializer {
+  BlacklistInitializer() {
+    backendTestBlacklist = {
+        "BatchMatMulTest_Int8/39", "BatchMatMulTest_Int8/43",
+        "BatchMatMulTest_Int8/46", "BatchMatMulTest_Int8/51",
+        "BatchMatMulTest_Int8/54", "BatchMatMulTest_Int8/59",
+        "BatchMatMulTest_Int8/63", "BatchMatMulTest_Int8/67",
+        "BatchMatMulTest_Int8/71", "BatchMatMulTest_Int8/75",
+        "BatchMatMulTest_Int8/83", "BatchMatMulTest_Int8/87",
+        "BatchMatMulTest_Int8/90", "BatchMatMulTest_Int8/91",
+        "BatchMatMulTest_Int8/95", "FCTest_Int8/139",
+    };
+
+    for (int i = 0; i < 80; i++) {
+      backendTestBlacklist.insert("RWQSLWS_Float16_AccumFloat16/" +
+                                  std::to_string(i));
+    }
+    for (int i = 0; i < 80; i++) {
+      backendTestBlacklist.insert("FRWQSLWS_Float16_AccumFloat16/" +
+                                  std::to_string(i));
+    }
+
+    std::set<std::string> emuOnlyTests = {
+        "BatchMatMulTest_Float16/2",  "BatchMatMulTest_Float16/3",
+        "BatchMatMulTest_Float16/6",  "BatchMatMulTest_Float16/7",
+        "BatchMatMulTest_Float16/10", "BatchMatMulTest_Float16/11",
+        "BatchMatMulTest_Float16/14", "BatchMatMulTest_Float16/15",
+        "BatchMatMulTest_Float16/18", "BatchMatMulTest_Float16/19",
+        "BatchMatMulTest_Float16/21", "BatchMatMulTest_Float16/22",
+        "BatchMatMulTest_Float16/23", "BatchMatMulTest_Float16/25",
+        "BatchMatMulTest_Float16/26", "BatchMatMulTest_Float16/27",
+        "BatchMatMulTest_Float16/30", "BatchMatMulTest_Float16/31",
+        "BatchMatMulTest_Float16/33", "BatchMatMulTest_Float16/34",
+        "BatchMatMulTest_Float16/35", "BatchMatMulTest_Float16/37",
+        "BatchMatMulTest_Float16/38", "BatchMatMulTest_Float16/39",
+        "BatchMatMulTest_Float16/41", "BatchMatMulTest_Float16/42",
+        "BatchMatMulTest_Float16/43", "BatchMatMulTest_Float16/45",
+        "BatchMatMulTest_Float16/46", "BatchMatMulTest_Float16/47",
+        "BatchMatMulTest_Float16/49", "BatchMatMulTest_Float16/50",
+        "BatchMatMulTest_Float16/51", "BatchMatMulTest_Float16/54",
+        "BatchMatMulTest_Float16/55", "BatchMatMulTest_Float16/58",
+        "BatchMatMulTest_Float16/59", "BatchMatMulTest_Float16/61",
+        "BatchMatMulTest_Float16/62", "BatchMatMulTest_Float16/63",
+        "BatchMatMulTest_Float16/65", "BatchMatMulTest_Float16/66",
+        "BatchMatMulTest_Float16/67", "BatchMatMulTest_Float16/69",
+        "BatchMatMulTest_Float16/70", "BatchMatMulTest_Float16/71",
+        "BatchMatMulTest_Float16/73", "BatchMatMulTest_Float16/74",
+        "BatchMatMulTest_Float16/75", "BatchMatMulTest_Float16/78",
+        "BatchMatMulTest_Float16/79", "BatchMatMulTest_Float16/81",
+        "BatchMatMulTest_Float16/82", "BatchMatMulTest_Float16/83",
+        "BatchMatMulTest_Float16/85", "BatchMatMulTest_Float16/86",
+        "BatchMatMulTest_Float16/87", "BatchMatMulTest_Float16/89",
+        "BatchMatMulTest_Float16/90", "BatchMatMulTest_Float16/91",
+        "BatchMatMulTest_Float16/93", "BatchMatMulTest_Float16/94",
+        "BatchMatMulTest_Float16/95", "ConvTest_Float16/3",
+        "ConvTest_Float16/7",         "ConvTest_Float16/9",
+        "ConvTest_Float16/11",        "FCTest_Float16/14",
+        "FCTest_Float16/17",          "FCTest_Float16/18",
+        "FCTest_Float16/19",          "FCTest_Float16/21",
+        "FCTest_Float16/22",          "FCTest_Float16/23",
+        "FCTest_Float16/24",          "FCTest_Float16/26",
+        "FCTest_Float16/27",          "FCTest_Float16/28",
+        "FCTest_Float16/29",          "FCTest_Float16/30",
+        "FCTest_Float16/31",          "FCTest_Float16/32",
+        "FCTest_Float16/33",          "FCTest_Float16/34",
+        "FCTest_Float16/47",          "FCTest_Float16/48",
+        "FCTest_Float16/49",          "FCTest_Float16/51",
+        "FCTest_Float16/52",          "FCTest_Float16/53",
+        "FCTest_Float16/54",          "FCTest_Float16/55",
+        "FCTest_Float16/56",          "FCTest_Float16/57",
+        "FCTest_Float16/58",          "FCTest_Float16/59",
+        "FCTest_Float16/60",          "FCTest_Float16/61",
+        "FCTest_Float16/62",          "FCTest_Float16/63",
+        "FCTest_Float16/64",          "FCTest_Float16/65",
+        "FCTest_Float16/66",          "FCTest_Float16/67",
+        "FCTest_Float16/68",          "FCTest_Float16/69",
+        "FCTest_Float16/83",          "FCTest_Float16/84",
+        "FCTest_Float16/86",          "FCTest_Float16/87",
+        "FCTest_Float16/88",          "FCTest_Float16/89",
+        "FCTest_Float16/90",          "FCTest_Float16/91",
+        "FCTest_Float16/92",          "FCTest_Float16/93",
+        "FCTest_Float16/94",          "FCTest_Float16/95",
+        "FCTest_Float16/96",          "FCTest_Float16/97",
+        "FCTest_Float16/98",          "FCTest_Float16/99",
+        "FCTest_Float16/100",         "FCTest_Float16/101",
+        "FCTest_Float16/102",         "FCTest_Float16/103",
+        "FCTest_Float16/104",         "FCTest_Float16/116",
+        "FCTest_Float16/117",         "FCTest_Float16/118",
+        "FCTest_Float16/119",         "FCTest_Float16/121",
+        "FCTest_Float16/122",         "FCTest_Float16/123",
+        "FCTest_Float16/124",         "FCTest_Float16/125",
+        "FCTest_Float16/126",         "FCTest_Float16/127",
+        "FCTest_Float16/128",         "FCTest_Float16/129",
+        "FCTest_Float16/130",         "FCTest_Float16/131",
+        "FCTest_Float16/132",         "FCTest_Float16/133",
+        "FCTest_Float16/134",         "FCTest_Float16/135",
+        "FCTest_Float16/136",         "FCTest_Float16/137",
+        "FCTest_Float16/138",         "FCTest_Float16/139",
+    };
+
+    // If USE_INF_API is set, we are running on real hardware, and need
+    // to blacklist additional testcases.
+    auto useInfAPI = getenv("USE_INF_API");
+    if (useInfAPI && !strcmp(useInfAPI, "1")) {
+      for (auto testname : emuOnlyTests) {
+        backendTestBlacklist.insert(testname);
+      }
+    }
+  }
+} blacklistInitializer;

--- a/tests/stress/CMakeLists.txt
+++ b/tests/stress/CMakeLists.txt
@@ -1,24 +1,8 @@
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${GLOW_BINARY_DIR}/tests/stress/)
 
-add_executable(SparseLengthsSumTest
-  SparseLengthsSumTest.cpp)
-target_link_libraries(SparseLengthsSumTest
-  PRIVATE
-  Backends
-  BackendTestUtils
-  ExecutionEngine
-  gtest
-  glog::glog)
-
-add_executable(ParameterSweepTest
-               ParameterSweepTest.cpp)
-target_link_libraries(ParameterSweepTest
-                      PRIVATE
-                        Backends
-                        BackendTestUtils
-                        ExecutionEngine
-                        glog::glog
-                        gtest
-                        Graph
-                        GraphOptimizer
-                        Support)
+# Loop through all backends present in lib/Backends (see FindBackends.cmake)
+# and instantiate a backend-parameterized test for each of them.
+foreach(backend ${GLOW_BACKENDS})
+  add_backend_test(TEST ParameterSweepTest BACKEND "${backend}" UNOPT)
+  add_backend_test(TEST SparseLengthsSumTest BACKEND "${backend}" UNOPT)
+endforeach()

--- a/tests/stress/ParameterSweepTest.cpp
+++ b/tests/stress/ParameterSweepTest.cpp
@@ -112,19 +112,19 @@ GLOW_INSTANTIATE_TEST_SUITE_P_FOR_BACKEND_COMBINED_TEST(
 
 /// Compare backend against the interpreter in Float.
 TEST_P(ConvSweepTest, ConvTest_Float) {
-  ENABLED_BACKENDS(CPU, OpenCL, NNPI);
+  CHECK_IF_ENABLED();
   testParamSweepConv(GetParam(), ElemKind::FloatTy, ElemKind::FloatTy, 0.0001f);
 }
 
 /// Compare backend against the interpreter in Int8.
 TEST_P(ConvSweepTest, ConvTest_Int8) {
-  ENABLED_BACKENDS(Interpreter, CPU, OpenCL, NNPI);
+  CHECK_IF_ENABLED();
   testParamSweepConv(GetParam(), ElemKind::FloatTy, ElemKind::Int8QTy, 0.045f);
 }
 
 /// Compare backend against the interpreter in FP16.
 TEST_P(ConvSweepTest, ConvTest_Float16) {
-  ENABLED_BACKENDS(Interpreter, NNPI);
+  CHECK_IF_ENABLED();
   testParamSweepConv(GetParam(), ElemKind::FloatTy, ElemKind::Float16Ty,
                      0.005f);
 }
@@ -189,21 +189,21 @@ GLOW_INSTANTIATE_TEST_SUITE_P_FOR_BACKEND_COMBINED_TEST(
 
 /// Compare backend against the interpreter in Float.
 TEST_P(BatchMatMulSweepTest, BatchMatMulTest_Float) {
-  ENABLED_BACKENDS(CPU, OpenCL, NNPI);
+  CHECK_IF_ENABLED();
   testParamSweepBatchMatMul(GetParam(), ElemKind::FloatTy, ElemKind::FloatTy,
                             0.0001f);
 }
 
 /// Compare backend against the interpreter in Int8.
 TEST_P(BatchMatMulSweepTest, BatchMatMulTest_Int8) {
-  ENABLED_BACKENDS(Interpreter, CPU, OpenCL, NNPI);
+  CHECK_IF_ENABLED();
   testParamSweepBatchMatMul(GetParam(), ElemKind::FloatTy, ElemKind::Int8QTy,
                             0.06f);
 }
 
 /// Compare backend against the interpreter in FP16.
 TEST_P(BatchMatMulSweepTest, BatchMatMulTest_Float16) {
-  ENABLED_BACKENDS(Interpreter, NNPI);
+  CHECK_IF_ENABLED();
   testParamSweepBatchMatMul(GetParam(), ElemKind::FloatTy, ElemKind::Float16Ty,
                             0.005f);
 }
@@ -266,19 +266,19 @@ GLOW_INSTANTIATE_TEST_SUITE_P_FOR_BACKEND_COMBINED_TEST(
 
 /// Compare backend against the interpreter in Float.
 TEST_P(FCSweepTest, FCTest_Float) {
-  ENABLED_BACKENDS(CPU, OpenCL, NNPI);
+  CHECK_IF_ENABLED();
   testParamSweepFC(GetParam(), ElemKind::FloatTy, ElemKind::FloatTy, 0.0001f);
 }
 
 /// Compare backend against the interpreter in Int8.
 TEST_P(FCSweepTest, FCTest_Int8) {
-  ENABLED_BACKENDS(Interpreter, CPU, OpenCL, NNPI);
+  CHECK_IF_ENABLED();
   testParamSweepFC(GetParam(), ElemKind::FloatTy, ElemKind::Int8QTy, 0.065f);
 }
 
 /// Compare backend against the interpreter in FP16.
 TEST_P(FCSweepTest, FCTest_Float16) {
-  ENABLED_BACKENDS(Interpreter, NNPI);
+  CHECK_IF_ENABLED();
   testParamSweepFC(GetParam(), ElemKind::FloatTy, ElemKind::Float16Ty, 0.005f);
 }
 
@@ -358,7 +358,7 @@ GLOW_INSTANTIATE_TEST_SUITE_P_FOR_BACKEND_COMBINED_TEST(
 
 /// Compare backend against the interpreter in Float.
 TEST_P(ConcatSweepTest, ConcatTest_Float) {
-  ENABLED_BACKENDS(CPU, OpenCL, NNPI);
+  CHECK_IF_ENABLED();
   testParamSweepConcat(GetParam(), ElemKind::FloatTy, ElemKind::FloatTy, 0.0f);
 }
 
@@ -367,7 +367,7 @@ TEST_P(ConcatSweepTest, ConcatTest_Float) {
 /// quantize/dequantize the input/result anyway, so the comparison wouldn't be
 /// purely on data movement.
 TEST_P(ConcatSweepTest, ConcatTest_Int8) {
-  ENABLED_BACKENDS(Interpreter, CPU, OpenCL, NNPI);
+  CHECK_IF_ENABLED();
   testParamSweepConcat(GetParam(), ElemKind::FloatTy, ElemKind::Int8QTy,
                        0.002f);
 }
@@ -377,7 +377,7 @@ TEST_P(ConcatSweepTest, ConcatTest_Int8) {
 /// down/up convert the input/result anyway, so the comparison wouldn't be
 /// purely on data movement.
 TEST_P(ConcatSweepTest, ConcatTest_Float16) {
-  ENABLED_BACKENDS(Interpreter, NNPI);
+  CHECK_IF_ENABLED();
   testParamSweepConcat(GetParam(), ElemKind::FloatTy, ElemKind::Float16Ty,
                        0.0001f);
 }
@@ -500,7 +500,7 @@ GLOW_INSTANTIATE_TEST_SUITE_P_FOR_BACKEND_COMBINED_TEST(
 
 /// Compare backend against the interpreter.
 TEST_P(SLWSSweepTest, SLWS_Float) {
-  ENABLED_BACKENDS(CPU, NNPI);
+  CHECK_IF_ENABLED();
   testParamSweepSLWS(GetParam(), ElemKind::FloatTy, ElemKind::FloatTy,
                      0.000001f,
                      /* rowwiseQuantize */ false,
@@ -510,7 +510,7 @@ TEST_P(SLWSSweepTest, SLWS_Float) {
 
 /// Compare backend against the interpreter in Float.
 TEST_P(SLWSSweepTest, RWQSLWS_Float) {
-  ENABLED_BACKENDS(CPU, NNPI);
+  CHECK_IF_ENABLED();
   testParamSweepSLWS(GetParam(), ElemKind::FloatTy, ElemKind::FloatTy,
                      0.000001f,
                      /* rowwiseQuantize */ true,
@@ -520,7 +520,7 @@ TEST_P(SLWSSweepTest, RWQSLWS_Float) {
 
 /// Compare backend against the interpreter in Float.
 TEST_P(SLWSSweepTest, FRWQSLWS_Float) {
-  ENABLED_BACKENDS(CPU, NNPI);
+  CHECK_IF_ENABLED();
   testParamSweepSLWS(GetParam(), ElemKind::FloatTy, ElemKind::FloatTy,
                      0.000001f,
                      /* rowwiseQuantize */ true,
@@ -532,7 +532,7 @@ TEST_P(SLWSSweepTest, FRWQSLWS_Float) {
 TEST_P(SLWSSweepTest, RWQSLWS_Float16) {
   // Note: not currently enabled for any open-source backends, as only the
   // Interpreter supports this.
-  ENABLED_BACKENDS(NNPI);
+  CHECK_IF_ENABLED();
   testParamSweepSLWS(GetParam(), ElemKind::FloatTy, ElemKind::FloatTy,
                      0.000001f,
                      /* rowwiseQuantize */ true,
@@ -544,7 +544,7 @@ TEST_P(SLWSSweepTest, RWQSLWS_Float16) {
 TEST_P(SLWSSweepTest, FRWQSLWS_Float16) {
   // Note: not currently enabled for any open-source backends, as only the
   // Interpreter supports this.
-  ENABLED_BACKENDS(NNPI);
+  CHECK_IF_ENABLED();
   testParamSweepSLWS(GetParam(), ElemKind::FloatTy, ElemKind::FloatTy,
                      0.000001f,
                      /* rowwiseQuantize */ true,
@@ -556,7 +556,7 @@ TEST_P(SLWSSweepTest, FRWQSLWS_Float16) {
 TEST_P(SLWSSweepTest, RWQSLWS_Float16_AccumFloat16) {
   // Note: not currently enabled for any open-source backends, as only the
   // Interpreter supports this.
-  ENABLED_BACKENDS(NNPI);
+  CHECK_IF_ENABLED();
   testParamSweepSLWS(GetParam(), ElemKind::FloatTy, ElemKind::FloatTy,
                      0.000001f,
                      /* rowwiseQuantize */ true,
@@ -568,7 +568,7 @@ TEST_P(SLWSSweepTest, RWQSLWS_Float16_AccumFloat16) {
 TEST_P(SLWSSweepTest, FRWQSLWS_Float16_AccumFloat16) {
   // Note: not currently enabled for any open-source backends, as only the
   // Interpreter supports this.
-  ENABLED_BACKENDS(NNPI);
+  CHECK_IF_ENABLED();
   testParamSweepSLWS(GetParam(), ElemKind::FloatTy, ElemKind::FloatTy,
                      0.000001f,
                      /* rowwiseQuantize */ true,

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -97,6 +97,14 @@ protected:
   Function *F_;
 };
 
+/// Stringify a macro def.
+#define BACKEND_TO_STR(X) #X
+
+#ifdef GLOW_TEST_BACKEND
+  #define STRINGIZE(X) BACKEND_TO_STR(X)
+  static const auto all_backends =
+    ::testing::Values(STRINGIZE(GLOW_TEST_BACKEND));
+#else
 static const auto all_backends = ::testing::Values(
 #ifdef GLOW_WITH_NNPI
     "NNPI",
@@ -111,6 +119,7 @@ static const auto all_backends = ::testing::Values(
     "Habana",
 #endif // GLOW_WITH_HABANA
     "Interpreter");
+#endif
 
 // Instantiate parameterized test suite with all available backends.
 #define GLOW_INSTANTIATE_TEST_SUITE_P_FOR_BACKEND_TEST(prefix, test_case_name) \
@@ -133,9 +142,6 @@ extern std::set<std::string> backendTestBlacklist;
 
 /// Bool for whether to use symmetric quantization for rowwise-quantized FCs.
 extern bool useSymmetricRowwiseQuantFC;
-
-/// Stringify a macro def.
-#define BACKEND_TO_STR(X) #X
 
 /// Intermediate layer of macros to make expansion of defs work correctly.
 #define INSTANTIATE_TEST_INTERNAL(B, T)                                        \


### PR DESCRIPTION
Summary:
Enables stress tests(ParameterSweep and SparseLengthsSumTest) to run with blacklist


Documentation:

[Optional Fixes #issue]

Test Plan:

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
