### PR TITLE
Changed the default tracing level in image-classifier to NONE

### DIFF
--- a/tools/loader/ImageClassifier.cpp
+++ b/tools/loader/ImageClassifier.cpp
@@ -146,7 +146,7 @@ llvm::cl::opt<unsigned> traceLevel(
     "trace-level",
     llvm::cl::desc(
         "Set tracing level (bit-field, see TraceEvents.h for details)"),
-    llvm::cl::Optional, llvm::cl::init((unsigned)TraceLevel::STANDARD),
+    llvm::cl::Optional, llvm::cl::init((unsigned)TraceLevel::NONE),
     llvm::cl::cat(imageLoaderCat));
 
 llvm::cl::opt<unsigned>


### PR DESCRIPTION
Summary:
As in title, changed the trace-level default to NONE, tracing can be opted into.

Documentation:


Test Plan:
builds locally.
