### PR TITLE
[easy] Rename GroupwiseQuantizedConvolution OperatorTest

### DIFF
--- a/lib/Backends/Habana/tests/HabanaOperatorTest.cpp
+++ b/lib/Backends/Habana/tests/HabanaOperatorTest.cpp
@@ -202,7 +202,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "GroupConv3D/0",
     "GroupConvolution/0",
     "GroupDilatedConvolution/0",
-    "GroupwiseQuantizedConvolution/0",
+    "ChannelwiseQuantizedGroupConvolution/0",
     "insertTensorTest/0",
     "Int16ConvolutionDepth10/0",
     "Int16ConvolutionDepth8/0",

--- a/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
@@ -50,7 +50,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "FusedRowwiseQuantizedSparseLengthsWeightedSum_ConvertedFloat16_"
     "NoFusedConvert/0",
     "GroupConv3D/0",
-    "GroupwiseQuantizedConvolution/0",
+    "ChannelwiseQuantizedGroupConvolution/0",
     "insertTensorTest/0",
     "Int16ConvolutionDepth10/0",
     "Int16ConvolutionDepth8/0",

--- a/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
@@ -288,7 +288,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "RepeatedSLSWithPartialTensors/0",
     "GatherWithInt32PartialTensors/0",
     "GatherWithInt64PartialTensors/0",
-    "GroupwiseQuantizedConvolution/0",
+    "ChannelwiseQuantizedGroupConvolution/0",
     "ParallelBatchMatMul_Float16/0",
     "RWQSLWSAllSame_Float16_AccumFP16/0",
     "RWQSLWSAllSame_Float16_AccumFP32/0",

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -5398,9 +5398,9 @@ TEST_P(OperatorTest, GroupConvolution) {
   EXPECT_FLOAT_EQ(result.at({0, 1, 0, 5}), (13 + 14 + 15 + 16) * 100000);
 }
 
-/// Test the functionality of groupwise quantized convolution expressed using
+/// Test the functionality of channelwise quantized group convolution using
 /// ChannelwiseQuantizedConvNode.
-TEST_P(OperatorTest, GroupwiseQuantizedConvolution) {
+TEST_P(OperatorTest, ChannelwiseQuantizedGroupConvolution) {
   CHECK_IF_ENABLED();
 
   constexpr size_t groups = 2;


### PR DESCRIPTION
Summary:
Rename OperatorTest GroupwiseQuantizedConvolution to ChannelwiseQuantizedGroupConvolution

Documentation:

[Optional Fixes #issue]

Test Plan:

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
