### PR TITLE
Updated tensor.assign to only copy unpadded size in the case of an unpadded tensor. (Quick Fix for Repro)

### DIFF
--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -631,7 +631,8 @@ public:
     assert(!isDeviceResident() && "Tensor must reside on host to access data.");
     assert(this != t && "Copying to self");
     reset(t);
-    size_t bufferSize = type_.getSizeInBytes();
+    size_t bufferSize = t->getUnpaddedSizeInBytes();
+    this->unpaddedSize_ = bufferSize;
     std::copy(&t->getData()[0], &t->getData()[bufferSize], getData());
   }
 


### PR DESCRIPTION

Summary:
This fixes an issue with the Repro tool where only the first Tensor has it's unpaddedSize set.
This is a quick fix and won't be landed, a more proper fix to Tensor will follow.
Documentation:


Test Plan:
ninja check
