### PR TITLE
32b dim_t fixes

### DIFF
--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -1291,7 +1291,7 @@ static bool verifyFusedRowwiseQuantizedSparseLengthsSum(
   // For EmbeddingBagByteRowwiseOffsets lengths are really offsets and should be
   // Int64ITy.
   if (isEmbeddingBagByteRowwiseOffsets) {
-    isValid &= checkType(lengths, ElemKind::Int64ITy, parent);
+    isValid &= checkType(lengths, IndexElemKind, parent);
   } else {
     isValid &= checkType(lengths, ElemKind::Int32ITy, parent);
   }

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -7866,14 +7866,13 @@ createAndInitRWQSLWSAllSame(glow::PlaceholderBindings &bindings,
       0.2244578,  0.44881952, 0.42696562, 0.33007848, 0.4511249,  0.11568925,
       0.02629679, 0.33864713, 0.42614424};
 
-  Placeholder *indices =
-      mod.createPlaceholder(ElemKind::Int64ITy, {21}, "indices",
-                            /* isTrainable */ false);
+  Placeholder *indices = mod.createPlaceholder(IndexElemKind, {21}, "indices",
+                                               /* isTrainable */ false);
   Placeholder *lengths =
       mod.createPlaceholder(ElemKind::Int32ITy, {2}, "lengths",
                             /* isTrainable */ false);
 
-  bindings.allocate(indices)->getHandle<int64_t>() = {
+  bindings.allocate(indices)->getHandle<sdim_t>() = {
       11, 8, 19, 8, 4, 11, 4, 19, 6, 18, 2, 6, 15, 5, 14, 14, 15, 13, 4, 6, 5,
   };
   bindings.allocate(lengths)->getHandle<int32_t>() = {15, 6};

--- a/tests/unittests/PartitionerTest.cpp
+++ b/tests/unittests/PartitionerTest.cpp
@@ -541,7 +541,7 @@ static void createSimpleSparseNNModule(Module &mod) {
   for (int table = 0; table < 5; table++) {
     Tensor data(ElemKind::FloatTy, {tableEntries, tableWidth});
     auto indices = mod.createPlaceholder(
-        ElemKind::Int64ITy, {numIndices * batchSize}, "indices", false);
+        IndexElemKind, {numIndices * batchSize}, "indices", false);
     auto weights = mod.createPlaceholder(
         ElemKind::FloatTy, {numIndices * batchSize}, "weights", false);
     auto lengths = mod.createPlaceholder(ElemKind::Int32ITy, {batchSize},

--- a/utils/scripts/gen_onnx_gru_model.py
+++ b/utils/scripts/gen_onnx_gru_model.py
@@ -190,7 +190,9 @@ def gen_gru_onnx_test_model(model_path, seq_length, batch_size, hidden_size, inp
             dir_idx)
 
         def f(x): return (1 / (1 + np.exp(-x)))
+
         def g(x): return np.tanh(x)
+
         def mm(x, w): return np.matmul(x, w.transpose())
         Ht = np.reshape(initial_h[dir_idx, :, :], [batch_size, hidden_size])
 

--- a/utils/scripts/gen_onnx_rnn_model.py
+++ b/utils/scripts/gen_onnx_rnn_model.py
@@ -173,6 +173,7 @@ def gen_rnn_onnx_test_model(model_path, seq_length, batch_size, hidden_size, inp
         Wi, Ri, bWi, bRi = get_weights(dir_idx)
 
         def f(x): return np.tanh(x)
+
         def mm(x, w): return np.matmul(x, w.transpose())
         Ht = np.reshape(initial_h[dir_idx, :, :], [batch_size, hidden_size])
 


### PR DESCRIPTION
These are needed to fix tests with 32b dim_t. 

Also sneak in a fix for some whitespaces of a .py script the "format.sh fix" keeps modifying (at least with clang-format-7).

Test Plan:

32b and 64b dim_t via pocl CPU driver (LLVM 8).
