### PR TITLE
[OpenCL] fixes to the disk caching support

### DIFF
--- a/lib/Backends/OpenCL/tests/OpenCLDiskCacheTest.cmake
+++ b/lib/Backends/OpenCL/tests/OpenCLDiskCacheTest.cmake
@@ -6,20 +6,18 @@ set(OPENCL_CACHE_DIR ${CMAKE_CURRENT_BINARY_DIR}/opencl-cached-binaries)
 file(REMOVE_RECURSE ${OPENCL_CACHE_DIR})
 
 function(RUN_OCLTEST)
-  execute_process(COMMAND "${CMAKE_CURRENT_BINARY_DIR}/tests/OCLTest" "--gtest_output=xml:OCLTestCached.xml" "--opencl-program-cache-dir=${OPENCL_CACHE_DIR}"
-    RESULT_VARIABLE CMD_RES
-    ERROR_QUIET
-    OUTPUT_QUIET)
+  execute_process(COMMAND "${GLOW_BINARY_DIR}/tests/OpenCLBackendCorrectnessTest" "--gtest_output=xml:OpenCLBackendCorrectnessTestCached.xml" "--opencl-program-cache-dir=${OPENCL_CACHE_DIR}")
+  set(RES ${CMD_RES} PARENT_SCOPE)
 endfunction(RUN_OCLTEST)
 
 run_ocltest()
-if(CMD_RES)
-  message(FATAL_ERROR "Error in the OpenCL cold cache test run.")
+if(RES)
+  message(FATAL_ERROR "Error in the OpenCL cold cache test run: ${RES}")
 endif()
 
 run_ocltest()
-if(CMD_RES)
-  message(FATAL_ERROR "Error in the warm cache OpenCL test run.")
+if(RES)
+  message(FATAL_ERROR "Error in the warm cache OpenCL test run: ${RES}")
 endif()
 
 file(REMOVE_RECURSE ${OPENCL_CACHE_DIR})

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -336,8 +336,8 @@ if(GLOW_WITH_OPENCL)
                 ${GLOW_BINARY_DIR}/tests/OCLTest
                 --gtest_output=xml:OCLTest.xml)
 
-  add_glow_test(OCLTestWithDiskCache
-                ${CMAKE_COMMAND} -P ${CMAKE_SOURCE_DIR}/lib/Backends/OpenCL/tests/OpenCLDiskCacheTest.cmake)
+  add_glow_test(OpenCLBackendTestWithDiskCache
+                ${CMAKE_COMMAND} "-DGLOW_BINARY_DIR=${GLOW_BINARY_DIR}" "-P" "${CMAKE_SOURCE_DIR}/lib/Backends/OpenCL/tests/OpenCLDiskCacheTest.cmake")
 
   LIST(APPEND UNOPT_TESTS ./tests/OCLTest -optimize-ir=false &&)
 


### PR DESCRIPTION
* Use size_t for the binary size parameter.
* Fix incorrect reference to the unique_ptr object.
* Fix the flaky test.