### PR TITLE
[GraphOptz] Stop collapsing Dequantize(Quantize)

### DIFF
--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -2802,12 +2802,6 @@ bool OptimizeQuantization::run(Function *F, const CompilationContext &cctx) {
     }
 
     if (auto *DQ = dyn_cast<DequantizeNode>(node)) {
-      if (auto *Q = dyn_cast<QuantizeNode>(DQ->getInput())) {
-        // Dequantize(Quantize(X)) -> X
-        changed = true;
-        DQ->getResult().replaceAllUsesOfWith(Q->getInput());
-        continue;
-      }
       // Fold the rescale into the following Dequantize.
       // Dequantize(rescale) -> Dequantize()
       if (auto *RS = dyn_cast<RescaleQuantizedNode>(DQ->getInput())) {


### PR DESCRIPTION
Summary: Implementation optimizes Dequantize(Quantize(X)) -> X. This drops the rescaling aspect of Quantize.
Combination should be pretty rare and does not deserve introduction of new node type,
unless non-quantized rescaling can be useful by itself

Testing: New test fails without change, all tests succeed with it.