### PR TITLE
Add HostManager dependence to BackendTestUtils

### DIFF
--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -16,6 +16,7 @@ target_link_libraries(BackendTestUtils
                         ExecutionEngine
                         Graph
                         GraphOptimizer
+                        HostManager
                         Quantization
                         QuantizationBase
                         LLVMSupport


### PR DESCRIPTION
This dep was missing, which caused the shared-libs build to break on macOS.  (I don't know why our Linux CI shared build doesn't always catch these 🤷‍♂ ).
