### PR TITLE
[GraphOptz] Sink Transpose below Dequantize

### DIFF
--- a/lib/Backends/Habana/tests/HabanaOperatorTest.cpp
+++ b/lib/Backends/Habana/tests/HabanaOperatorTest.cpp
@@ -245,7 +245,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "NonSquarePaddingMaxPool/0",
     "NonSquareStrideAveragePool/0",
     "NonSquareStrideConvolution/0",
-    "OperatorStatelessTest.QuantizedTranspose/0"
+    "QuantizedTranspose/0",
     "ParallelBatchMatMul_Float16/0",
     "ParallelBatchMatMul_Int8/0",
     "pow/0",

--- a/lib/Backends/Habana/tests/HabanaOperatorTest.cpp
+++ b/lib/Backends/Habana/tests/HabanaOperatorTest.cpp
@@ -245,6 +245,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "NonSquarePaddingMaxPool/0",
     "NonSquareStrideAveragePool/0",
     "NonSquareStrideConvolution/0",
+    "OperatorStatelessTest.QuantizedTranspose/0"
     "ParallelBatchMatMul_Float16/0",
     "ParallelBatchMatMul_Int8/0",
     "pow/0",

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -605,6 +605,22 @@ bool SinkCode::run(Function *F, const CompilationContext &cctx) {
       changed = true;
     }
 
+    // Sink TransposeNode below DequantizedNode.
+    // If it doesn't work out it will be re-sinked later.
+    if (auto *D = dyn_cast<DequantizeNode>(node)) {
+      auto *TR = dyn_cast<TransposeNode>(D->getInput());
+      if (!TR) {
+        continue;
+      }
+
+      auto newDType = F->getParent()->uniqueTypeWithNewShape(
+          D->getResult().getType(), TR->getInput().dims());
+      auto *newD = F->createDequantize(D->getName(), TR->getInput(), newDType);
+      auto *newTR = F->createTranspose(TR->getName(), newD, TR->getShuffle());
+      D->getResult().replaceAllUsesOfWith(newTR);
+      changed = true;
+    }
+
     // Sink Transpose below RescaleQuantized.
     // Potentially exposes opportunity to be combined up with Convolution.
     // If it doesn't work out it will be re-sinked later.


### PR DESCRIPTION
Summary: Transpose node can be safely sinked below Dequantize
Closes: #3966

Testing: New unit test, ninja test