### PR TITLE
Fix for sleep on windows.

### DIFF
--- a/tests/unittests/SharedMutexTest.cpp
+++ b/tests/unittests/SharedMutexTest.cpp
@@ -54,7 +54,7 @@ TEST(SharedMutex, Performance) {
   }
 
   /* sleep override */
-  sleep(1);
+  std::this_thread::sleep_for(std::chrono::seconds(1));
 
   stopThread = true;
 


### PR DESCRIPTION
Summary:
Windows doesn't have sleep, but does have Sleep which takes in millisconds vs seconds.
Documentation:

[Optional Fixes #issue]

Test Plan: UnitTests

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
