### PR TITLE
Update loadStandardLibary() to report error from llvm::SMDiagnostic

### DIFF
--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -175,12 +175,19 @@ loadStandardLibrary(llvm::LLVMContext *ctx, llvm::StringRef filename,
   llvm::SMDiagnostic error;
 
   // Parse the compiled-in image of libjit and return the resulting Module.
-  return llvm::parseIR(
+  // checking for and reporting errors from parseIR.
+
+  auto mod = llvm::parseIR(
       llvm::MemoryBufferRef(
           llvm::StringRef(reinterpret_cast<const char *>(libjitBC.data()),
                           libjitBC.size()),
           "libjit.bc"),
       error, *ctx);
+
+  if (!mod) {
+    error.print("LLVMIRGen", llvm::errs());
+  }
+  return mod;
 }
 
 /// Register a diagnostics handler that prevents the compiler from printing to


### PR DESCRIPTION
Summary:

Update loadStandardLibary() to report the error from
llvm::SMDiagnostic which is more informative that the generic 'Unable
to load the JIT library' error that is reported upon return from
loadStandardLibrary(). Specifically, we ran into an issue with
mismatched LLVM versions on a system containing more than a single
version of LLVM. Providing the message from SMDiagnostic explicitly
identified that problem.

Documentation:

None

Test Plan:

"make test" passes
