### PR TITLE
Make forcing FP16 accumulation for SLS true by default

### DIFF
--- a/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
+++ b/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
@@ -59,7 +59,7 @@ struct PrecisionConfiguration {
   bool clipFP16SkipInputs{false};
 
   /// Whether to force FP16 accumulation for the SLS family of ops.
-  bool forceFP16AccumSLS{false};
+  bool forceFP16AccumSLS{true};
 
   /// Used during Quantization and convertToFP16 to keep the original precision
   /// of specific node kinds (i.e. quantization/FP16 conversion would be skipped

--- a/tests/unittests/Repro.cpp
+++ b/tests/unittests/Repro.cpp
@@ -94,7 +94,8 @@ llvm::cl::opt<bool>
 llvm::cl::opt<bool>
     forceFP16AccumSLSOpt("glow_global_force_sls_fp16_accum",
                          llvm::cl::desc("Force FP16 accumulation for SLS ops"),
-                         llvm::cl::Optional, llvm::cl::cat(reproTestCat));
+                         llvm::cl::Optional, llvm::cl::init(true),
+                         llvm::cl::cat(reproTestCat));
 
 llvm::cl::opt<bool> enablePartialTensor("glow_enable_partial_tensor",
                                         llvm::cl::desc("Enable partial tensor"),


### PR DESCRIPTION
Summary: Default to FP16 accumulation. This is generally the expectation, so this helps avoid confusion and requiring extra flags.

Differential Revision: D19396588

