### PR TITLE
Enable 4bit RWQ SLS

### DIFF
--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -243,7 +243,8 @@ bool NNPIBackend::isOpSupported(const NodeInfo &NI) const {
     auto resultK =
         NI.getOutElemTy(FusedRowwiseQuantizedSparseLengthsSumNode::ResultIdx);
     return (dataK == ElemKind::UInt8FusedQTy ||
-            dataK == ElemKind::UInt8FusedFP16QTy) &&
+            dataK == ElemKind::UInt8FusedFP16QTy ||
+            dataK == ElemKind::UInt4FusedFP16QTy) &&
            (resultK == ElemKind::FloatTy || resultK == ElemKind::Float16Ty) &&
            (indicesK == ElemKind::Int64ITy) && (lengthsK == ElemKind::Int32ITy);
   }

--- a/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
@@ -157,9 +157,6 @@ struct EmulatorOnlyTests {
           "Exp/0",
           "FloatArgMaxKeepDim/0",
           "FloatArgMaxNoKeepDim/0",
-          "FusedRowwiseQuantizedSLWSTwoColumn_Fused4Bit_Float16_AccumFloat16/0",
-          "FusedRowwiseQuantizedSparseLengthsSum_Fused4Bit_Float16_"
-          "AccumFloat16/0",
           "FusedRowwiseQuantizedSparseLengthsWeightedSum_ConvertedFloat16_"
           "back_",
           "FusedRowwiseQuantizedSparseLengthsWeightedSum_ConvertedFloat16_"


### PR DESCRIPTION
Summary: Not sure why these weren't enabled for the 0.4.2.5 release.

Differential Revision: D19397626

