### PR TITLE
Make Floating-Point Matmul Reference Use 32b for Scalar Product

### DIFF
--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -2613,7 +2613,7 @@ void BoundInterpreterFunction::fwdMatMulInstFloatImpl(const MatMulInst *I) {
       // Perform DOT on the row an column.
       float sum = 0;
       for (dim_t i = 0; i < lhsDim[1]; i++) {
-        sum += float(lhs.at({x, i}) * rhs.at({i, y}));
+        sum += float(lhs.at({x, i})) * float(rhs.at({i, y}));
       }
       dest.at({x, y}) = ElemTy(sum);
     }


### PR DESCRIPTION
Summary: This commit makes it so that the scalar multiplication (in a row-column dot product) performed during a forward floating-point MatMul instruction in the Interpreter first (i) converts each scalar value to 32 bits; and *then* (ii) performs the scalar multiplication; rather than first performing the multiplication and *then* converting to 32 bits only for the accumulation.

Documentation:
Fixes #4008 .  The reasons for this change are to (i) make the floating-point Matmul implementation in the Interpreter consistent with the floating-point FC implementation in the Interpreter; and to (ii) shore up reference calculations for float16.

Test Plan:
This is more of a philosophical change.  The usual tests would apply.
```
ninja test
```