### PR TITLE
[unittests] Add NumericsTest and placeholder for NNPI numerics tests

### DIFF
--- a/lib/Backends/NNPI/tests/NNPINumericsTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPINumericsTest.cpp
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "tests/unittests/BackendTestUtils.h"
+
+using namespace glow;
+
+std::set<std::string> glow::backendTestBlacklist = {};
+
+// NOTE: Specify numerics tests specific to NNPI in this file.

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -154,6 +154,11 @@ extern bool useSymmetricRowwiseQuantFC;
           ::testing::UnitTest::GetInstance()->current_test_info()->name()))    \
     GTEST_SKIP();
 
+class NumericsTest : public BackendTest {
+protected:
+  PlaceholderBindings bindings_;
+};
+
 class GraphOptz : public ::testing::Test {
 public:
   GraphOptz(llvm::StringRef backendName = "Interpreter")

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -384,6 +384,7 @@ foreach(backend ${GLOW_BACKENDS})
   add_backend_test(TEST MLTest BACKEND "${backend}" UNOPT)
   add_backend_test(TEST OperatorGradTest BACKEND "${backend}" UNOPT)
   add_backend_test(TEST OperatorTest BACKEND "${backend}" UNOPT)
+  add_backend_test(TEST NumericsTest BACKEND "${backend}" UNOPT)
   add_backend_test(TEST TensorLayoutTest BACKEND "${backend}" UNOPT)
   add_backend_test(TEST
                    RecommendationSystemTest

--- a/tests/unittests/NumericsTest.cpp
+++ b/tests/unittests/NumericsTest.cpp
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "BackendTestUtils.h"
+
+using namespace glow;
+
+INSTANTIATE_BACKEND_TEST(NumericsTest);
+
+// NOTE: Specify generic numerics tests below that should be supported by all
+// backends (and blacklisted explicitly if not supported).


### PR DESCRIPTION
Summary: Separate our numerics-specific tests from OperatorTests. Also allow for tests specific to NNPI to be specified in `NNPINumericsTest.cpp`, while generic numerics tests that all backends should pass can go in `NumericsTest.cpp`.

No tests have been added yet, but they can follow the pattern below, and used exactly as how OperatorTests are used:

```
TEST_P(NumericsTest, ExampleTest) {
  EXPECT_TRUE(true);
}
```