### PR TITLE
Allow backends to manually set the default parallel clone count, and set to 12 for NNPI

### DIFF
--- a/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
@@ -181,3 +181,8 @@ struct EmulatorOnlyTests {
     }
   }
 } emuTests;
+
+/// Default to parallel cloning 12 times for NNPI.
+struct CloneCount {
+  CloneCount() { setParCloneCount(12); }
+} cloneCount;

--- a/tests/unittests/BackendTestUtils.cpp
+++ b/tests/unittests/BackendTestUtils.cpp
@@ -249,7 +249,7 @@ static void convertBindingsToCorrectType(PlaceholderBindings &bindings,
 static Tensor convertToFloatIfNecessary(Tensor &T) {
   const ElemKind srcK = T.getType().getElementType();
   if (srcK == ElemKind::FloatTy) {
-    return std::move(T);
+    return T.clone();
   }
   if (isQuantizedElemKind(srcK)) {
     return quantization::dequantizeTensor(T, ElemKind::FloatTy);

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -33,6 +33,9 @@ namespace glow {
 
 extern unsigned parCloneCountOpt;
 
+/// Allow backends to manually set the default parallel clone count.
+inline void setParCloneCount(unsigned c) { parCloneCountOpt = c; }
+
 // INSTANTIATE_TEST_CASE_P is deprecated in gtest v1.10.0. For now use it still
 // internally.
 #if FACEBOOK_INTERNAL


### PR DESCRIPTION
Summary:
By default let's test all 12 ICE cores if the test supports it by setting parallelCloneCount. Unit tests run pretty quickly so this doesn't cost much in runtime overhead and gets us better coverage on the NNPI HW and stack.

cl opt `-parallel-clone-count` will still work/override whatever the backend sets as its own default.

This included a fix to avoid std::moving a Tensor, which later led to a nullptr deref.

Differential Revision: D19401176

