### PR TITLE
[Tensor] Set unpaddedSize_ to actual bytes pointed to by data_, and fix Tensor::assign()

### DIFF
--- a/lib/Base/Tensor.cpp
+++ b/lib/Base/Tensor.cpp
@@ -634,14 +634,6 @@ Tensor Tensor::getCopyConvertedToType(ElemKind newKind) const {
   return tmp;
 }
 
-size_t Tensor::getUnpaddedSizeInBytes() const {
-  if (unpaddedSize_) {
-    return unpaddedSize_;
-  } else {
-    return type_.getSizeInBytes();
-  }
-}
-
 namespace glow {
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Tensor &t) {
   t.dump(os);

--- a/tests/unittests/TensorsTest.cpp
+++ b/tests/unittests/TensorsTest.cpp
@@ -1132,6 +1132,24 @@ TEST(Tensor, unpaddedSize) {
   auto copy = moved.getUnowned(moved.dims());
   EXPECT_EQ(copy.getUnpaddedSizeInBytes(), bytes);
   EXPECT_EQ(copy.getSizeInBytes(), paddedBytes);
+
+  // Test that a clone of a partial is still partial.
+  auto clone = moved.clone();
+  EXPECT_EQ(clone.getUnpaddedSizeInBytes(), bytes);
+  EXPECT_EQ(clone.getSizeInBytes(), paddedBytes);
+
+  // Test that assigning a Tensor to a partial is still partial.
+  Tensor assigned;
+  assigned.assign(&moved);
+  EXPECT_EQ(assigned.getUnpaddedSizeInBytes(), bytes);
+  EXPECT_EQ(assigned.getSizeInBytes(), paddedBytes);
+
+  // Check that when we reset a partial Tensor with the same Type but without
+  // specifying the reset should be partial that we do not have the same ptr, as
+  // it should have been reallocated.
+  char *oldPtr = assigned.getUnsafePtr();
+  assigned.reset(paddedType);
+  EXPECT_NE(assigned.getUnsafePtr(), oldPtr);
 }
 
 TEST(CustomAlignedTensor, sizes) {


### PR DESCRIPTION
Summary: Previously if a Tensor was not partial we left `unpaddedSize_ =  0`, representing that the actual `unpaddedSize_` was that based on the Type. This PR changes this, so that `unpaddedSize_` is equal to the actual number of allocated bytes pointed to by `data_`. 

- This includes fixing `Tensor::assign()` so that it respects unpadded size, i.e. if you clone a partial tensor the new tensor is also partial.
- Additionally includes fixing `Tensor::reset()` so that if you reset a partial tensor with a type with the same number of bytes but without specifying it should be partial, that the old buffer is not reused (this could have caused buffer overflow).

Test Plan: Updated unpaddedSize unit test with a few more checks.

Alternative fix to https://github.com/pytorch/glow/pull/3986 with a couple other fixes

CC: @jsubag 
