### PR TITLE
[Loader] Remove assert which prevents users to load ONNX network from current directory w/o `./` prefix

### DIFF
--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -261,8 +261,7 @@ std::string Loader::getModelOptPath() {
 
   // Model path must be to one or more files. Use the path of the first file.
   size_t found = modelPathOpt[0].find_last_of("/");
-  assert(found != std::string::npos && "Expected path to proto with directory");
-  return modelPathOpt[0].substr(0, found);
+  return found == std::string::npos ? "." : modelPathOpt[0].substr(0, found);
 }
 
 llvm::StringRef Loader::getModelOptDir() {


### PR DESCRIPTION
Summary:
Currently, due to assert in Loader::getModelOptPath, one cannot use `-m=model.onnx`, but have to do `-m=./model.onnx` instead. The patch removes the assert and makes the function return "." as the directory.

Documentation: N/A

Test Plan: manually tested