### PR TITLE
Fix bug in OCL trace when autoInstrument is off

### DIFF
--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -500,7 +500,8 @@ void OpenCLFunction::enqueueKernel(llvm::StringRef name,
                                &global[0], &local[0], 0, nullptr,
                                profile ? &event : nullptr);
   CHECK_EQ(err, CL_SUCCESS) << "Error in clEnqueueNDRangeKernel.";
-  kernelLaunches.push_back(KernelLaunch(kernel, name, kernelType, event));
+  kernelLaunches.push_back(
+      KernelLaunch(kernel, name, kernelType, profile ? event : nullptr));
 }
 
 void OpenCLFunction::executeNCHWConvolution(

--- a/lib/Backends/OpenCL/OpenCLDeviceManager.h
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.h
@@ -215,12 +215,14 @@ protected:
   /// Load inputs from \p context onto the device.
   void copyInputsToDevice(const RuntimeBundle &runtimeBundle,
                           ExecutionContext *context,
-                          runtime::OpenCLDeviceBindings *devBindings);
+                          runtime::OpenCLDeviceBindings *devBindings,
+                          bool traceEnabled);
 
   /// Copy back results from the device to the host.
   void copyOutputsFromDevice(const RuntimeBundle &runtimeBundle,
                              ExecutionContext *context,
-                             runtime::OpenCLDeviceBindings *devBindings);
+                             runtime::OpenCLDeviceBindings *devBindings,
+                             bool traceEnabled);
 
   /// Get profiling information for each kernelLaunch. This must happen after
   /// copyOutputsFromDevice.


### PR DESCRIPTION
Summary: Fix a bug where we were still recording timestamps for DMA on the OpenCL backend when profiling was disabled, which doesn't work. This meant our trace was corrupted with uninitialized timestamps and was not useful. Simple fix is to disable DMA timestamps when we're not instrumenting operators.

Documentation: N/A

Test Plan:

Tested with image-classifier with this invocation:
```
 ./bin/image-classifier -m=resnet50 -backend=OpenCL -minibatch=1 -model-input-name=gpu_0/data -use-imagenet-normalization -image-mode=0to1 --trace-path=trace.json ../tests/images/imagenet/* -device=2
```

before:
![image](https://user-images.githubusercontent.com/701287/72823479-a56d8d00-3c28-11ea-8f9a-1afd693d041d.png)
(note the timeframe is 475k years)

after:
![image](https://user-images.githubusercontent.com/701287/72823605-d51c9500-3c28-11ea-8fef-9e836783fe1e.png)

auto-instrument still works fine:
![image](https://user-images.githubusercontent.com/701287/72823338-66d7d280-3c28-11ea-8eac-be97c21e7b17.png)


Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
