### PR TITLE
Stop OpenCL DeviceManager defaulting to CPU device

### DIFF
--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -79,10 +79,11 @@ static llvm::cl::OptionCategory OpenCLBackendCat("Glow OpenCL Backend Options");
 llvm::cl::opt<unsigned>
     clPlatformId("platform", llvm::cl::desc("OpenCL platform to be used"),
                  llvm::cl::init(0), llvm::cl::cat(OpenCLBackendCat));
-llvm::cl::opt<unsigned> clDeviceId("device",
-                                   llvm::cl::desc("OpenCL device to be used"),
-                                   llvm::cl::init(0),
-                                   llvm::cl::cat(OpenCLBackendCat));
+llvm::cl::opt<int> clDeviceId(
+    "device",
+    llvm::cl::desc(
+        "OpenCL device to be used. Default is to guess best device."),
+    llvm::cl::init(-1), llvm::cl::cat(OpenCLBackendCat));
 llvm::cl::opt<bool> clDoProfile("opencl-profile",
                                 llvm::cl::desc("Profile OpenCL kernels"),
                                 llvm::cl::init(false),

--- a/lib/Backends/OpenCL/OpenCLDeviceManager.h
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.h
@@ -176,6 +176,11 @@ public:
 
   ~OpenCLDeviceManager();
 
+  /// Enumerate OpenCL devices, if deviceId > 0 then choose that index,
+  /// otherwise guess the best available device.
+  Error findBestDevice(cl_platform_id platformId, int deviceId);
+
+  /// Initialize the DeviceManager, choosing a device and creating a CL context.
   Error init() override;
 
   /// Parse config object provided at initialization \returns Error


### PR DESCRIPTION
Summary: I noticed on my laptop that regularly the OpenCL backend was using the CPU device, because we default to the first device enumerated by `clGetDeviceIDs` and that tends to be the CPU device. This PR changes the default behaviour to choose the "best" device, which at the moment means the highest `cl_device_type` - which should mean accelerators > gpus > cpus.

This should at least speed up OCL runs considerably. I'm hoping this interacts well with pocl, but we'll find out soon.

Documentation: ?

Test Plan:

Tested using image-classifier.
before:
```
❯ time ./bin/image-classifier -m=resnet50 -backend=OpenCL -minibatch=1 -model-input-name=gpu_0/data -use-imagenet-normalization -image-mode=0to1 ../test/images/imagenet/*
Model: resnet50
Running 1 thread(s).
 File: ../tests/images/imagenet/cat_285.png     Label-K1: 281 (probability: 0.7190)
 File: ../tests/images/imagenet/dog_207.png     Label-K1: 207 (probability: 0.9446)
 File: ../tests/images/imagenet/zebra_340.png   Label-K1: 340 (probability: 0.9984)
./bin/image-classifier -m=resnet50 -backend=OpenCL -minibatch=1      32.06s user 0.69s system 777% cpu 4.214 total
```

after:
```
❯ time ./bin/image-classifier -m=resnet50 -backend=OpenCL -minibatch=1 -model-input-name=gpu_0/data -use-imagenet-normalization -image-mode=0to1 ../tests/images/imagenet/*
Model: resnet50
Running 1 thread(s).
Using OpenCL device AMD Radeon Pro 555X Compute Engine
 File: ../tests/images/imagenet/cat_285.png     Label-K1: 281 (probability: 0.7190)
 File: ../tests/images/imagenet/dog_207.png     Label-K1: 207 (probability: 0.9446)
 File: ../tests/images/imagenet/zebra_340.png   Label-K1: 340 (probability: 0.9984)
./bin/image-classifier -m=resnet50 -backend=OpenCL -minibatch=1      2.08s user 0.40s system 184% cpu 1.344 total
```

Can still specify device manually:
```
❯ time ./bin/image-classifier -m=resnet50 -backend=OpenCL -minibatch=1 -model-input-name=gpu_0/data -use-imagenet-normalization -image-mode=0to1 ../test/images/imagenet/* -device=0
Model: resnet50
Running 1 thread(s).
Using OpenCL device Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz
 File: ../tests/images/imagenet/cat_285.png     Label-K1: 281 (probability: 0.7190)
 File: ../tests/images/imagenet/dog_207.png     Label-K1: 207 (probability: 0.9446)
 File: ../tests/images/imagenet/zebra_340.png   Label-K1: 340 (probability: 0.9984)
./bin/image-classifier -m=resnet50 -backend=OpenCL -minibatch=1     -device=0  27.59s user 0.71s system 793% cpu 3.568 total
```