### PR TITLE
make Interpreter claim support for ClipNode

### DIFF
--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -468,6 +468,10 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
                {TopKNode::IndicesIdx}) &&
            (NI.getOutElemTy(TopKNode::IndicesIdx) == IndexElemKind);
 
+  case Kinded::Kind::ClipNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+        {ElemKind::Float16Ty, ElemKind::Int8QTy});
+
   case Kinded::Kind::ScatterDataNodeKind:
     return (NI.getInElemTy(ScatterDataNode::IndicesIdx) == IndexElemKind) &&
            (NI.getOutElemTy(ScatterDataNode::ResultIdx) ==


### PR DESCRIPTION
Summary: The Interpreter supports ClipNode via lowering, but says that it doesn't support the op in isOpSupported. This is because isOpSupported is a bit weird. After discussing it with Jordan Fix decided not to attempt a big refactor of isOpSupported and just add in ClipNode. Not super happy about it though.

Differential Revision: D19500784

