### PR TITLE
Updated the Partitioner to pick the max available mem size rather than the first.

### DIFF
--- a/lib/Partitioner/Partitioner.cpp
+++ b/lib/Partitioner/Partitioner.cpp
@@ -390,6 +390,9 @@ void Partitioner::genBackendMap(
       backends.push_back(backendMap[backendName].backend);
     } else {
       backendMap[backendName].num += 1;
+      // Since we are currently assuming one value it should be the max.
+      backendMap[backendName].memSize = std::max(
+          backendMap[backendName].memSize, deviceInfo_[i].availableMemory);
     }
   }
 }


### PR DESCRIPTION


Summary:
The partitioner assumes the same value for available memory for all devices. It is currently getting the first value which is likely to be the lowest. This changes it to grab the max.

Documentation:

Test Plan:
ninja test

