### PR TITLE
Fix ONNX Importer/Exporter for ConvertTo

### DIFF
--- a/lib/Exporter/ONNXModelWriter.cpp
+++ b/lib/Exporter/ONNXModelWriter.cpp
@@ -1437,8 +1437,16 @@ Error ONNXModelWriter::writeClip(const ClipNode *node, GraphType &graph) {
 Error ONNXModelWriter::writeConvertTo(const ConvertToNode *node,
                                       GraphType &graph) {
   auto *proto = graph.add_node();
+
   // Add dictionary entries.
-  addValueAttribute(proto, "shape", node->getResult().dims());
+  TensorType ttype;
+  for (auto d : node->getResult().dims()) {
+    ttype.add_dims(d);
+  }
+  ttype.set_data_type(convertType(*node->getResult().getType()));
+  auto *attr = proto->add_attribute();
+  attr->set_name("shape");
+  attr->mutable_t()->CopyFrom(ttype);
 
   return writeAllWithNode("ConvertTo", node, graph, proto);
 }

--- a/tests/models/onnxModels/fp16FullyConnected.onnxtxt
+++ b/tests/models/onnxModels/fp16FullyConnected.onnxtxt
@@ -1,0 +1,102 @@
+ir_version: 7
+producer_name: "ONNXModelWriter"
+graph {
+  node {
+    input: "X__0"
+    output: "X__1"
+    name: "N__0"
+    op_type: "ConvertTo"
+    attribute {
+      name: "shape"
+      t {
+        dims: 7
+        data_type: 1
+      }
+    }
+  }
+  node {
+    input: "X__2"
+    output: "X__3"
+    name: "N__1"
+    op_type: "ConvertTo"
+    attribute {
+      name: "shape"
+      t {
+        dims: 10
+        dims: 1
+        data_type: 10
+      }
+    }
+  }
+  node {
+    input: "X__3"
+    input: "X__4"
+    input: "X__1"
+    output: "X__5"
+    name: "N__2"
+    op_type: "FullyConnected"
+  }
+  node {
+    input: "X__5"
+    output: "X__6"
+    name: "N__3"
+    op_type: "ConvertTo"
+    attribute {
+      name: "shape"
+      t {
+        dims: 10
+        dims: 7
+        data_type: 1
+      }
+    }
+  }
+  name: "glow"
+  initializer {
+    dims: 7
+    data_type: 1
+    name: "X__0"
+    raw_data: "\023\347\313\275K;\031;\360\314i\275%\201=\275i\341\035:\372\207\003\276\253J\000\275"
+  }
+  initializer {
+    dims: 1
+    dims: 7
+    data_type: 10
+    name: "X__4"
+    raw_data: "\257;\2537W$\2713\210:\2523\240:"
+  }
+  input {
+    name: "X__2"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 10
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "X__6"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 7
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 9
+}


### PR DESCRIPTION
Summary: `ConvertTo` for ONNX Importer/Exporter was broken as it didn't convey the convert to type. Fix this. With this, we should be able to support Repro with fp16 FC stuff.

Differential Revision: D19506315

