### PR TITLE
Updated cleanupProvision to evict partitions for an unsuccessful provisioning.

### DIFF
--- a/include/glow/Runtime/Provisioner/Provisioner.h
+++ b/include/glow/Runtime/Provisioner/Provisioner.h
@@ -44,6 +44,9 @@ public:
   /// Remove stored compiledFunction.
   Error removeFunction(llvm::StringRef name);
 
+  /// Evict function from device.
+  Error evictFunction(llvm::StringRef name, DeviceIDTy device);
+
   /// \returns a reference to the backend with name \p backendName.
   Backend &getBackend(llvm::StringRef backendName) const;
 
@@ -66,9 +69,13 @@ private:
   /// List of available DeviceManagers added during initialization.
   std::vector<DeviceManager *> devices_;
 
-  /// Helper function to cleanup a provision call. On failure free the
-  /// compiledFunctions that were created.
-  void cleanupProvision(llvm::ArrayRef<std::string> names, bool failure = true);
+  /// Helper function to cleanup a provision call. On \p failure free the
+  /// compiledFunctions that were created, \p names , and remove networks
+  /// already added to devices, \p currentNetworkResidency .
+  void cleanupProvision(llvm::ArrayRef<std::string> names,
+                        std::map<DeviceIDTy, std::vector<std::string>> const
+                            &currentNetworkResidency,
+                        bool failure = true);
 
   /// Helper function to parse the DAG and generate logicalDevices.
   std::map<DeviceIDTy, std::vector<DAGNode *>>

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -274,17 +274,8 @@ Error HostManager::removeNetwork(llvm::StringRef networkName) {
   auto &nodes = networkIterator->second.dag.nodes;
   for (auto &node : nodes) {
     for (auto device : node->deviceIDs) {
-      std::promise<void> removeNetwork;
-      auto done = removeNetwork.get_future();
-      std::unique_ptr<Error> removeErr;
-      devices_[device]->evictNetwork(
-          node->name,
-          [&removeNetwork, &removeErr](std::string name, Error err) {
-            removeErr = glow::make_unique<Error>(std::move(err));
-            removeNetwork.set_value();
-          });
-      done.get();
-      err.set(std::move(*DCHECK_NOTNULL(removeErr.get())));
+      Error evictErr = provisioner_->evictFunction(node->name, device);
+      err.set(std::move(evictErr));
     }
     // Also remove compiledFunction from Provisioner.
     err.set(provisioner_->removeFunction(node->name));

--- a/lib/Runtime/Provisioner/Provisioner.cpp
+++ b/lib/Runtime/Provisioner/Provisioner.cpp
@@ -277,7 +277,7 @@ Error Provisioner::provision(DAGListTy &networks, Module &module,
   if (!deviceAssignments) {
     // If and error occured, clean up provisioning state and return
     // the error.
-    cleanupProvision(localActiveNames);
+    cleanupProvision(localActiveNames, {});
     return deviceAssignments.takeError();
   }
   auto assignments = std::move(*deviceAssignments);
@@ -323,6 +323,7 @@ Error Provisioner::provision(DAGListTy &networks, Module &module,
   // device are compiled and then added to their assigned device. If a function
   // is in multiple logical devices it is stored so that it only needs to be
   // compiled once.
+  std::map<DeviceIDTy, std::vector<std::string>> addedNetworks;
   for (auto &assignment : assignments) {
     auto logicalDevice = assignment.first;
     auto physicalDevice = assignment.second;
@@ -372,7 +373,7 @@ Error Provisioner::provision(DAGListTy &networks, Module &module,
         if (!compiledOrErr) {
           // If and error occured, clean up provisioning state and return
           // the error.
-          cleanupProvision(localActiveNames);
+          cleanupProvision(localActiveNames, {});
           return compiledOrErr.takeError();
         }
         auto compiled = std::move(*compiledOrErr);
@@ -404,9 +405,15 @@ Error Provisioner::provision(DAGListTy &networks, Module &module,
     ready.wait();
     DCHECK_NOTNULL(addErr.get());
     if (*addErr.get()) {
-      cleanupProvision(localActiveNames);
+      cleanupProvision(localActiveNames, addedNetworks);
       return std::move(*addErr.get());
     }
+    // Add networks successfully loaded on device to addedNetworks, this way if
+    // we fail later we can evict them.
+    for (auto &node : logicalDevices[logicalDevice]) {
+      addedNetworks[physicalDevice].push_back(node->name);
+    }
+
     // Free up memory no longer needed by the compiledFunction.
     for (auto &func : compiledFunctions) {
       func.second->freeCompilationResources();
@@ -446,12 +453,11 @@ Error Provisioner::provision(DAGListTy &networks, Module &module,
     while (weightName != "") {
       auto PH = module.getPlaceholderByName(weightName);
       if (!PH) {
-        return MAKE_ERR(
-            ErrorValue::ErrorCode::RUNTIME_ERROR,
-            llvm::formatv(
-                "Error loading deferred weight. Name: {0} not found in module.",
-                weightName)
-                .str());
+        return MAKE_ERR(ErrorValue::ErrorCode::RUNTIME_ERROR,
+                        llvm::formatv("Error loading deferred weight. Name: "
+                                      "{0} not found in module.",
+                                      weightName)
+                            .str());
       }
       // Convert the weight if needed.
       auto newTy = PH->getType();
@@ -495,7 +501,7 @@ Error Provisioner::provision(DAGListTy &networks, Module &module,
     }
   }
 
-  cleanupProvision(localActiveNames, false);
+  cleanupProvision(localActiveNames, {}, false);
   return Error::success();
 };
 
@@ -520,14 +526,39 @@ Error Provisioner::removeFunction(llvm::StringRef name) {
   return Error::success();
 }
 
-void Provisioner::cleanupProvision(llvm::ArrayRef<std::string> names,
-                                   bool failure) {
+Error Provisioner::evictFunction(llvm::StringRef name, DeviceIDTy device) {
+  std::promise<Error> evictPromise;
+  auto done = evictPromise.get_future();
+  std::unique_ptr<Error> evictErr;
+  devices_[device]->evictNetwork(name, [&evictPromise](std::string, Error err) {
+    evictPromise.set_value(std::move(err));
+  });
+  Error err = done.get();
+  return err;
+}
+
+void Provisioner::cleanupProvision(
+    llvm::ArrayRef<std::string> names,
+    std::map<DeviceIDTy, std::vector<std::string>> const
+        &currentNetworkResidency,
+    bool failure) {
   std::lock_guard<std::mutex> functionLock(functionsLock_);
   for (auto &name : names) {
     activeFunctions_.erase(name);
     if (failure) {
       // Remove any functions added before the failure.
       functions_.erase(name);
+    }
+  }
+  if (failure) {
+    // Remove any partitions added to devices.
+    for (auto &device : currentNetworkResidency) {
+      for (auto &network : device.second) {
+        Error evictErr = evictFunction(network, device.first);
+        if (evictErr) {
+          LOG(ERROR) << "Unable to evict network: " << network << "\n";
+        }
+      }
     }
   }
 }

--- a/tests/unittests/ProvisionerTest.cpp
+++ b/tests/unittests/ProvisionerTest.cpp
@@ -103,3 +103,24 @@ TEST_F(ProvisionerTest, provisionDagFail) {
   // Expect that there was an Error when provisioning
   EXPECT_TRUE(ERR_TO_BOOL(std::move(err)));
 }
+
+TEST_F(ProvisionerTest, provisionFailCleanup) {
+  // We want this provisioning to fail after adding the first partition
+  // successfully. This is to test that cleanup properly evicts networks.
+  DeviceConfig configBig("CPU");
+  DeviceConfig configSmall("CPU");
+  configSmall.setDeviceMemory(1);
+  std::unique_ptr<DeviceManager> deviceBig(new CPUDeviceManager(configBig));
+  std::unique_ptr<DeviceManager> deviceSmall(new CPUDeviceManager(configSmall));
+  DeviceManagerMapTy devices;
+  devices.emplace(0, std::move(deviceBig));
+  devices.emplace(1, std::move(deviceSmall));
+
+  auto mod = setupModule(2);
+  auto networks = setupDAG(2, 0);
+  CompilationContext cctx;
+  Provisioner provisioner(devices);
+  auto err = provisioner.provision(networks, *mod.get(), cctx);
+  // Expect that there was an Error when provisioning
+  EXPECT_TRUE(ERR_TO_BOOL(std::move(err)));
+}


### PR DESCRIPTION


Summary:
Currently if the provisioner fails while loading a network part way through any partitions loaded are left on device. This PR adds the cleanup logic to properly evict the partial load. Also added a unit test to exercise the code flow.

Documentation:

Test Plan:
Added new unit test.
