### PR TITLE
Change DeviceManager::numDevices() to make backends more self-contained

### DIFF
--- a/include/glow/Backend/Backend.h
+++ b/include/glow/Backend/Backend.h
@@ -226,6 +226,9 @@ public:
     std::string getRegistrationKey() const override {                          \
       return BackendClass::getName();                                          \
     }                                                                          \
+    unsigned numDevices() const override {                                     \
+      return BackendClass::numDevices();                                       \
+    }                                                                          \
   };                                                                           \
   static RegisterFactory<std::string, FactoryName, Backend>                    \
       FactoryName##_REGISTERED;

--- a/include/glow/Backends/Interpreter/Interpreter.h
+++ b/include/glow/Backends/Interpreter/Interpreter.h
@@ -37,6 +37,7 @@ public:
 
   std::string getBackendName() const override { return getName(); }
   static std::string getName() { return "Interpreter"; }
+  static unsigned numDevices() { return std::thread::hardware_concurrency(); }
 
   std::unique_ptr<CompiledFunction>
   compileIR(std::unique_ptr<IRFunction> IR) const override;

--- a/include/glow/Support/Register.h
+++ b/include/glow/Support/Register.h
@@ -32,6 +32,8 @@ public:
   virtual Base *create() = 0;
   /// Key used for a registered factory.
   virtual Key getRegistrationKey() const = 0;
+  /// Number of devices available for the registered factory.
+  virtual unsigned numDevices() const = 0;
 };
 
 /// General registry for implementation factories.

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -409,6 +409,10 @@ bool CPUBackend::shouldLower(const Node *N) const {
   }
 }
 
+unsigned CPUBackend::numDevices() {
+  return std::thread::hardware_concurrency();
+}
+
 std::unique_ptr<CompiledFunction> CPUBackend::createCompiledFunction(
     std::unique_ptr<llvm::orc::GlowJIT> JIT,
     runtime::RuntimeBundle &&runtimeBundle) const {

--- a/lib/Backends/CPU/CPUBackend.h
+++ b/lib/Backends/CPU/CPUBackend.h
@@ -40,6 +40,7 @@ public:
 
   std::string getBackendName() const override { return getName(); }
   static std::string getName() { return "CPU"; }
+  static unsigned numDevices();
 
   bool transformPostLowering(
       Function *F, CompilationContext &cctx,

--- a/lib/Backends/DeviceManagers.cpp
+++ b/lib/Backends/DeviceManagers.cpp
@@ -21,7 +21,6 @@
 #include "llvm/Support/Casting.h"
 #include "llvm/Support/raw_ostream.h"
 
-#include <fstream>
 #include <string>
 #include <thread>
 
@@ -46,7 +45,7 @@ DeviceManager *DeviceManager::createDeviceManager(const DeviceConfig &config) {
       LOG(ERROR) << factory.first;
     }
 
-    // As a fallback to make developing new Backends easier we'll create a
+    // As a fallback to make developing new backends easier we'll create a
     // DummyDeviceManager here, but this is not threadsafe and very simplistic.
     // Strongly recommended that you create a DeviceManager customized for your
     // device.
@@ -57,72 +56,14 @@ DeviceManager *DeviceManager::createDeviceManager(const DeviceConfig &config) {
   return backend->createDeviceManager(config);
 }
 
-#if defined(GLOW_WITH_CPU)
-unsigned numCPUDevices() { return std::thread::hardware_concurrency(); }
-#else
-unsigned numCPUDevices() { return 0; }
-#endif
-
-#if defined(GLOW_WITH_NNPI)
-unsigned numNNPIDevices() {
-  // TODO: unify with numHabanaDevices. copy-pasta with a different device name
-  std::ifstream devices("/proc/bus/pci/devices");
-  std::string device;
-  unsigned count = 0;
-  while (std::getline(devices, device)) {
-    if (device.find("sph_pcie") != std::string::npos) {
-      count++;
-    }
-  }
-  if (count > 0) {
-    return count;
-  }
-  // Todo
-  return 1; // Fall back to emulator since GLOW_NNPI is set. This feels hacky.
-}
-#else
-unsigned numNNPIDevices() { return 0; }
-#endif
-
-#if defined(GLOW_WITH_HABANA)
-unsigned numHabanaDevices() {
-  std::ifstream devices("/proc/bus/pci/devices");
-  std::string device;
-  unsigned count = 0;
-  while (std::getline(devices, device)) {
-    if (device.find("habanalabs") != std::string::npos) {
-      count++;
-    }
-  }
-  return count;
-}
-#else
-unsigned numHabanaDevices() { return 0; }
-#endif
-
-#if defined(GLOW_WITH_OPENCL)
-unsigned numOpenCLDevices() { return 1; }
-#else
-unsigned numOpenCLDevices() { return 0; }
-#endif
-
 unsigned DeviceManager::numDevices(llvm::StringRef backendName) {
-  if (backendName == "Interpreter") {
-    return std::thread::hardware_concurrency();
+  const auto &factories = FactoryRegistry<std::string, Backend>::factories();
+  auto it = factories.find(backendName);
+  if (it == factories.end()) {
+    return 0;
+  } else {
+    return it->second->numDevices();
   }
-  if (backendName == "CPU") {
-    return numCPUDevices();
-  }
-  if (backendName == "Habana") {
-    return numHabanaDevices();
-  }
-  if (backendName == "OpenCL") {
-    return numOpenCLDevices();
-  }
-  if (backendName == "NNPI") {
-    return numNNPIDevices();
-  }
-  return 0;
 }
 
 std::vector<std::unique_ptr<runtime::DeviceConfig>>

--- a/lib/Backends/Habana/Habana.cpp
+++ b/lib/Backends/Habana/Habana.cpp
@@ -27,6 +27,7 @@
 #include "llvm/Support/FormatVariadic.h"
 
 #include <chrono>
+#include <fstream>
 #include <glog/logging.h>
 #include <unordered_map>
 
@@ -1510,4 +1511,16 @@ bool HabanaBackend::isVersionBiggerEqualTo(std::string versionToCompare) {
     }
   }
   return false;
+}
+
+unsigned HabanaBackend::numDevices() {
+  std::ifstream devices("/proc/bus/pci/devices");
+  std::string device;
+  unsigned count = 0;
+  while (std::getline(devices, device)) {
+    if (device.find("habanalabs") != std::string::npos) {
+      count++;
+    }
+  }
+  return count;
 }

--- a/lib/Backends/Habana/Habana.h
+++ b/lib/Backends/Habana/Habana.h
@@ -41,6 +41,7 @@ public:
 
   std::string getBackendName() const override { return getName(); }
   static std::string getName() { return "Habana"; }
+  static unsigned numDevices();
 
   Expected<std::unique_ptr<CompiledFunction>>
   compile(Function *F, const BackendOptions &opts) const override;

--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -21,6 +21,8 @@
 #include "glow/Optimizer/Lower/Lower.h"
 #include "llvm/Support/CommandLine.h"
 
+#include <fstream>
+
 using namespace glow;
 
 namespace glow {
@@ -67,6 +69,24 @@ int32_t GlowNNPINumParallelChunks = 1;
 } // namespace glow
 
 NNPIBackendOptions NNPIBackend::backendOptions_;
+
+unsigned NNPIBackend::numDevices() {
+  // TODO: unify with numHabanaDevices. copy-paste with a different device
+  // name.
+  std::ifstream devices("/proc/bus/pci/devices");
+  std::string device;
+  unsigned count = 0;
+  while (std::getline(devices, device)) {
+    if (device.find("sph_pcie") != std::string::npos) {
+      count++;
+    }
+  }
+  if (count > 0) {
+    return count;
+  }
+  // TODO: Fall back to emulator since GLOW_NNPI is set. This feels hacky.
+  return 1;
+}
 
 bool NNPIBackend::isOpSupported(const NodeInfo &NI) const {
   switch (NI.getKind()) {

--- a/lib/Backends/NNPI/NNPI.h
+++ b/lib/Backends/NNPI/NNPI.h
@@ -34,6 +34,7 @@ public:
 
   std::string getBackendName() const override { return getName(); }
   static std::string getName() { return "NNPI"; }
+  static unsigned numDevices();
 
   Expected<std::unique_ptr<CompiledFunction>>
   compile(Function *F, const BackendOptions &opts) const override;

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -221,6 +221,7 @@ public:
 
   std::string getBackendName() const override { return getName(); }
   static std::string getName() { return "OpenCL"; }
+  static unsigned numDevices() { return 1; }
 
   std::unique_ptr<CompiledFunction>
   compileIR(std::unique_ptr<IRFunction> IR) const override;


### PR DESCRIPTION
Summary:

- Introduce a virtual method `numDevices()` in every Backend Factory
  class that must be implemented by every new backend. This method
  must return the number of devices of the specified kind.
- Move the implementation of each individual kind of `numDevices()` from
  the `DeviceManager` class to each individual backend class.
- Modify the `numDevices()` method in `DeviceManager` to return values
  based on all the backends already registered.

Documentation:

[Fixes part 1 of #3785 ]

Test Plan: ninja test
