### PR TITLE
Fix ConstantFolding to not fail compilation

### DIFF
--- a/include/glow/Backend/Backend.h
+++ b/include/glow/Backend/Backend.h
@@ -115,8 +115,9 @@ public:
   /// \returns whether the provided \p NI is supported by the backend.
   virtual bool isOpSupported(const NodeInfo &NI) const = 0;
 
-  /// \returns whether all nodes inside \p F are supported.
-  bool checkAllNodesSupported(const Function &F) const;
+  /// \returns whether all nodes inside \p F are supported. \p verbose
+  /// represents whether to print Nodes that are unsupported.
+  bool checkAllNodesSupported(const Function &F, bool verbose = true) const;
 
   /// \returns whether the provided \p F conforms to the backend-dependent graph
   /// constraints. Giving the backend an opportunity to check that everything
@@ -125,8 +126,9 @@ public:
   /// verifications a super-set of target independent Function::verify() by
   /// calling it in their overridden implementation. It is not a strict
   /// requirement, of course, in case they diverge / the backend has a good
-  /// reason not to call Function::verify().
-  virtual bool verify(const Function &F) const;
+  /// reason not to call Function::verify(). \p verbose represents whether to
+  /// print out nodes that are unsupported by the backend.
+  virtual bool verify(const Function &F, bool verbose = true) const;
 
   /// \returns whether the provided \p IR conforms to the backend-dependent
   /// graph constraints. Giving the backend an opportunity to check that

--- a/include/glow/Backends/Interpreter/Interpreter.h
+++ b/include/glow/Backends/Interpreter/Interpreter.h
@@ -49,7 +49,7 @@ public:
 
   bool isOpSupported(const NodeInfo &NI) const override;
 
-  bool verify(const Function &F) const override;
+  bool verify(const Function &F, bool verbose = true) const override;
   bool verify(const IRFunction &IR) const override;
 
   bool shouldLower(const Node *N) const override;

--- a/include/glow/Importer/ProtobufLoader.h
+++ b/include/glow/Importer/ProtobufLoader.h
@@ -222,12 +222,11 @@ Error constantFoldInLoader(Function *F, LoaderType &tmpLoader,
                            LoaderType *loader, const OpType &op) {
   PlaceholderBindings bindings;
   std::vector<Tensor *> outTensors;
-  Module *mod = F->getParent();
 
   // Register the constant inputs to the current op with the constant folding
   // loader.
   for (unsigned i = 0; i < (dim_t)op.input_size(); i++) {
-    Constant *tmpConst = mod->getConstantByName(op.input(i));
+    Constant *tmpConst = loader->getConstantByNameOrNull(op.input(i));
     RETURN_ERR_IF_NOT(tmpConst, "No constant found");
     tmpLoader.nodeValueByName_[op.input(i)] = tmpConst->getOutput();
   }

--- a/include/glow/Importer/ProtobufLoader.h
+++ b/include/glow/Importer/ProtobufLoader.h
@@ -253,6 +253,9 @@ Error constantFoldInLoader(Function *F, LoaderType &tmpLoader,
   cctx.compMode = CompilationMode::Infer;
   cctx.optimizationOpts.enableConstantFolding = false;
   cctx.backendOpts.collectConstants = true;
+  // Do not print out compilation errors encountered, as constant folding is a
+  // best effort; simply silently give up and continue with compilation.
+  cctx.verboseCompile = false;
   RETURN_IF_ERR(executeConstantFunction(*backend, *F, bindings, cctx));
 
   // Using the graph output, place constant nodes in the original graph.

--- a/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
+++ b/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
@@ -153,6 +153,10 @@ struct CompilationContext {
   /// support.
   runtime::DeferredWeightLoader *deferredWeightLoader{nullptr};
 
+  // Whether to print out issues/logging during compilation. Used for example to
+  // disable printing issues encountered during ConstantFolding.
+  bool verboseCompile{true};
+
   CompilationContext(PlaceholderBindings *bindings_ = nullptr,
                      LoweredInfoMap *loweredInfoMap_ = nullptr)
       : bindings(bindings_), loweredInfoMap(loweredInfoMap_) {}

--- a/lib/Backend/Backend.cpp
+++ b/lib/Backend/Backend.cpp
@@ -159,21 +159,23 @@ void Backend::autoInstrument(TraceInfo &traceInfo, IRFunction *IR) const {
   IR->pushInstr(new TraceEventInst("end_trace", backingWeight, index));
 }
 
-bool Backend::checkAllNodesSupported(const Function &F) const {
+bool Backend::checkAllNodesSupported(const Function &F, bool verbose) const {
   bool allSupported = true;
   for (const Node &N : F.getNodes()) {
     if (!isOpSupported(N)) {
       allSupported = false;
-      report("Unsupported node found while compiling Function " +
-             F.getName().str() + " for backend " + getBackendName() + ": " +
-             N.getDebugDesc());
+      if (verbose) {
+        report("Unsupported node found while compiling Function " +
+               F.getName().str() + " for backend " + getBackendName() + ": " +
+               N.getDebugDesc());
+      }
     }
   }
   return allSupported;
 }
 
-bool Backend::verify(const Function &F) const {
-  return F.verify(this) && checkAllNodesSupported(F);
+bool Backend::verify(const Function &F, bool verbose) const {
+  return F.verify(this) && checkAllNodesSupported(F, verbose);
 }
 
 bool Backend::verify(const IRFunction &IR) const {

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -598,11 +598,11 @@ static bool checkLayoutForNode(const Node &N) {
   return true;
 }
 
-bool Interpreter::verify(const Function &F) const {
+bool Interpreter::verify(const Function &F, bool verbose) const {
   if (!F.verify(this)) {
     return false;
   }
-  if (!checkAllNodesSupported(F)) {
+  if (!checkAllNodesSupported(F, verbose)) {
     return false;
   }
   for (const Node &N : F.getNodes()) {

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -1870,11 +1870,11 @@ template <class T> static bool checkSquare(const T &I) {
   return true;
 }
 
-bool OCLBackend::verify(const Function &F) const {
+bool OCLBackend::verify(const Function &F, bool verbose) const {
   if (!F.verify(this)) {
     return false;
   }
-  if (!checkAllNodesSupported(F)) {
+  if (!checkAllNodesSupported(F, verbose)) {
     return false;
   }
   for (const Node &N : F.getNodes()) {

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -234,7 +234,7 @@ public:
 
   bool isOpSupported(const NodeInfo &NI) const override;
 
-  bool verify(const Function &F) const override;
+  bool verify(const Function &F, bool verbose = true) const override;
   bool verify(const IRFunction &IR) const override;
 
   TensorLayoutCommon &getTensorLayoutRequirements() const override;

--- a/lib/Importer/ProtobufLoader.cpp
+++ b/lib/Importer/ProtobufLoader.cpp
@@ -26,7 +26,7 @@ static llvm::cl::opt<bool> isConstFoldLoaderOps(
     "const-fold-ops",
     llvm::cl::desc(
         "Performs constant folding on ONNX and Caffe Operators while loading."),
-    llvm::cl::init(false), llvm::cl::cat(loaderOptCat));
+    llvm::cl::init(true), llvm::cl::cat(loaderOptCat));
 
 bool isArrayConstant(llvm::ArrayRef<size_t> a) {
   for (size_t i = 1; i < a.size(); i++)

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -3472,7 +3472,7 @@ Error glow::optimizeFunction(Function *F, const Backend &B,
     // Cleanup from lowering via DCE.
     runDCEPass(F, cctx);
 
-    if (!B.verify(*F)) {
+    if (!B.verify(*F, cctx.verboseCompile)) {
       return MAKE_ERR(
           ErrorValue::ErrorCode::COMPILE_UNSUPPORTED_NODE_AFTER_OPTIMIZE,
           "Unsupported node(s) found after only-lowering path for Function " +
@@ -3534,7 +3534,7 @@ Error glow::optimizeFunction(Function *F, const Backend &B,
   // We already started using backend specific verification when the function
   // state became lowered. Do one more verification pass to make sure everything
   // is in order and to bail if it is not.
-  if (!B.verify(*F)) {
+  if (!B.verify(*F, cctx.verboseCompile)) {
     return MAKE_ERR(
         ErrorValue::ErrorCode::COMPILE_UNSUPPORTED_NODE_AFTER_OPTIMIZE,
         "Unsupported node(s) found after optimizing Function " +

--- a/tests/unittests/Caffe2ImporterTest.cpp
+++ b/tests/unittests/Caffe2ImporterTest.cpp
@@ -1387,6 +1387,7 @@ TEST(caffe2, LengthsToRanges) {
 
   // Destroy the loader after the graph is loaded
   {
+    setConstantFoldLoaderOpsFlag(false);
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {}, {}, *F);
     output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
   }

--- a/tests/unittests/Caffe2ImporterTest.cpp
+++ b/tests/unittests/Caffe2ImporterTest.cpp
@@ -23,6 +23,15 @@
 #define GLOW_DATA_PATH
 #endif
 
+class Caffe2ImporterTest : public ::testing::Test {
+protected:
+  // By default constant folding at load time is enabled in general, but we do
+  // many tests here loading Constants, so keep it false during these tests by
+  // default.
+  void SetUp() override { glow::setConstantFoldLoaderOpsFlag(false); }
+  void TearDown() override { glow::setConstantFoldLoaderOpsFlag(true); }
+};
+
 using namespace glow;
 /// Test loading of Elementwise Unary Ops floating point.
 static void testEltwiseUnaryOpFloat(std::string fileName,
@@ -57,7 +66,7 @@ static void testEltwiseUnaryOpFloat(std::string fileName,
   }
 }
 
-TEST(caffe2, importExp) {
+TEST_F(Caffe2ImporterTest, importExp) {
   testEltwiseUnaryOpFloat("exp_op_net.pbtxt", {1, 2, 4, 3}, "data", 0.002,
                           [](float a) { return std::exp(a); });
 }
@@ -65,7 +74,7 @@ TEST(caffe2, importExp) {
 /// Test loading conv op from a Caffe2 model.
 /// The input is N*C*H*W (1*1*3*3), the kernel is 2,
 /// stride is 1, pad is 1, group is 1.
-TEST(caffe2, importConv) {
+TEST_F(Caffe2ImporterTest, importConv) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -107,7 +116,7 @@ TEST(caffe2, importConv) {
 /// Test loading ConvRelu op from a Caffe2 model.
 /// The input is N*C*H*W (1*1*3*3), the kernel is 2,
 /// stride is 1, pad is 1, group is 1.
-TEST(caffe2, importConvRelu) {
+TEST_F(Caffe2ImporterTest, importConvRelu) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -166,7 +175,7 @@ TEST(caffe2, importConvRelu) {
 /// Test loading conv op from a Caffe2 model.
 /// The input is N*H*W*C (1*3*3*1), the kernel is 2,
 /// stride is 1, pad is 1, group is 1.
-TEST(caffe2, convNHWC) {
+TEST_F(Caffe2ImporterTest, convNHWC) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -205,7 +214,7 @@ TEST(caffe2, convNHWC) {
 /// Test loading ChannelwiseQuantizedConvolutionNode op from a Caffe2 model.
 /// The input is N*H*W*C (1*1*1*4), the kernel is 1,
 /// stride is 1, pad is 1, group is 2.
-TEST(caffe2, convGroupQuantized) {
+TEST_F(Caffe2ImporterTest, convGroupQuantized) {
   // TODO Due to https://github.com/pytorch/glow/pull/3877
   // the API of channelwise quantized conv has been changed
   // this test is skipped for now and should be enbaled once
@@ -298,7 +307,7 @@ TEST(caffe2, convGroupQuantized) {
 }
 
 /// Test loading MaxPool with NHWC order input.
-TEST(caffe2, maxPoolNHWC) {
+TEST_F(Caffe2ImporterTest, maxPoolNHWC) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -336,7 +345,7 @@ TEST(caffe2, maxPoolNHWC) {
 }
 
 /// Test that loading MaxPool with legacy padding terminates early.
-TEST(caffe2, maxPoolLegacyPadding) {
+TEST_F(Caffe2ImporterTest, maxPoolLegacyPadding) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -361,7 +370,7 @@ TEST(caffe2, maxPoolLegacyPadding) {
 }
 
 /// Test loading MaxPool with default NCHW order input.
-TEST(caffe2, maxPool) {
+TEST_F(Caffe2ImporterTest, maxPool) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -405,7 +414,7 @@ TEST(caffe2, maxPool) {
 }
 
 /// Test loading AvgPool with NHWC order input.
-TEST(caffe2, avgPoolNHWC) {
+TEST_F(Caffe2ImporterTest, avgPoolNHWC) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -443,7 +452,7 @@ TEST(caffe2, avgPoolNHWC) {
 }
 
 /// Test loading AveragePool with default NCHW order input.
-TEST(caffe2, avgPool) {
+TEST_F(Caffe2ImporterTest, avgPool) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -496,7 +505,7 @@ TEST(caffe2, avgPool) {
 ///
 /// To fill the gap between the two, glow issues a reshape
 /// right after its concat.
-TEST(caffe2, concatAddAxis) {
+TEST_F(Caffe2ImporterTest, concatAddAxis) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -574,7 +583,7 @@ TEST(caffe2, concatAddAxis) {
 }
 
 /// Test loading a regular concat node.
-TEST(caffe2, concat) {
+TEST_F(Caffe2ImporterTest, concat) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -652,7 +661,7 @@ TEST(caffe2, concat) {
 }
 
 /// Test loading a batched matmul with transpose on RHS.
-TEST(caffe2, batchedMatmulRHS) {
+TEST_F(Caffe2ImporterTest, batchedMatmulRHS) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -707,7 +716,7 @@ TEST(caffe2, batchedMatmulRHS) {
 }
 
 /// Test loading a parallel batched matmul.
-TEST(caffe2, parallelBatchedMatmulRHS) {
+TEST_F(Caffe2ImporterTest, parallelBatchedMatmulRHS) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -756,7 +765,7 @@ TEST(caffe2, parallelBatchedMatmulRHS) {
 }
 
 /// Test loading a FC node : I * transpose(W) + B.
-TEST(caffe2, FC) {
+TEST_F(Caffe2ImporterTest, FC) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -830,7 +839,7 @@ TEST(caffe2, FC) {
 
 /// Test loading a FC node : I * transpose(W) + B, where I is need to be
 /// flatten.
-TEST(caffe2, FCWithFlatten) {
+TEST_F(Caffe2ImporterTest, FCWithFlatten) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -877,7 +886,7 @@ TEST(caffe2, FCWithFlatten) {
 }
 
 /// Test loading a FCTransposed node: I * W + B
-TEST(caffe2, FCTransposed) {
+TEST_F(Caffe2ImporterTest, FCTransposed) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -951,7 +960,7 @@ TEST(caffe2, FCTransposed) {
 }
 
 /// Test loading a FCTransposed node: I * W + B, where I is need to be flatten.
-TEST(caffe2, FCTransposedWithFlatten) {
+TEST_F(Caffe2ImporterTest, FCTransposedWithFlatten) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -1001,7 +1010,7 @@ TEST(caffe2, FCTransposedWithFlatten) {
 
 /// Test loading bucketize op from a Caffe2 model.
 /// Test with arg boundaries = [0.1, 2.5]
-TEST(caffe2, importBucketize) {
+TEST_F(Caffe2ImporterTest, importBucketize) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -1039,7 +1048,7 @@ TEST(caffe2, importBucketize) {
 
 /// Test loading ResizeNearest op from a Caffe2 model.
 /// Test with NHWC order, 2.0 height scale and 1.5 width scale
-TEST(caffe2, importResizeNearest) {
+TEST_F(Caffe2ImporterTest, importResizeNearest) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -1077,7 +1086,7 @@ TEST(caffe2, importResizeNearest) {
 
 /// Test loading clip op from a Caffe2 model.
 /// Test with arg min = 20.0 max = 60.0
-TEST(caffe2, importClip) {
+TEST_F(Caffe2ImporterTest, importClip) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -1115,7 +1124,7 @@ TEST(caffe2, importClip) {
 /// Test loading clip op from a Caffe2 model with default arg values:
 /// min = std::numeric_limits<float>::lowest()
 /// max = std::numeric_limits<float>::max()
-TEST(caffe2, importClipDefault) {
+TEST_F(Caffe2ImporterTest, importClipDefault) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -1150,7 +1159,7 @@ TEST(caffe2, importClipDefault) {
 }
 
 /// Test loading a ReplaceNaN operator.
-TEST(caffe2, replaceNaN) {
+TEST_F(Caffe2ImporterTest, replaceNaN) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -1194,7 +1203,7 @@ TEST(caffe2, replaceNaN) {
 }
 
 /// Test loading a DotProduct operator with 1D inputs.
-TEST(caffe2, dotProduct1D) {
+TEST_F(Caffe2ImporterTest, dotProduct1D) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -1236,7 +1245,7 @@ TEST(caffe2, dotProduct1D) {
 }
 
 // Test loading a DotProduct operator with 2D inputs.
-TEST(caffe2, dotProduct2D) {
+TEST_F(Caffe2ImporterTest, dotProduct2D) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -1283,7 +1292,7 @@ TEST(caffe2, dotProduct2D) {
 }
 
 // Test loading a BatchBoxCox operator.
-TEST(caffe2, batchBoxCox) {
+TEST_F(Caffe2ImporterTest, batchBoxCox) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -1332,7 +1341,7 @@ TEST(caffe2, batchBoxCox) {
 }
 
 // Test loading a EQ operator with 1D inputs.
-TEST(caffe2, EQ1D) {
+TEST_F(Caffe2ImporterTest, EQ1D) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -1372,7 +1381,7 @@ TEST(caffe2, EQ1D) {
 }
 
 // Test loading a LengthsToRanges operator.
-TEST(caffe2, LengthsToRanges) {
+TEST_F(Caffe2ImporterTest, LengthsToRanges) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -1387,7 +1396,6 @@ TEST(caffe2, LengthsToRanges) {
 
   // Destroy the loader after the graph is loaded
   {
-    setConstantFoldLoaderOpsFlag(false);
     Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {}, {}, *F);
     output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
   }
@@ -1407,7 +1415,7 @@ TEST(caffe2, LengthsToRanges) {
 }
 
 // Test loading Logit operator from a Caffe2 model.
-TEST(caffe2, Logit) {
+TEST_F(Caffe2ImporterTest, Logit) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -1444,7 +1452,7 @@ TEST(caffe2, Logit) {
 }
 
 // Test loading a SparseToDense operator.
-TEST(caffe2, sparseToDense) {
+TEST_F(Caffe2ImporterTest, sparseToDense) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -1496,7 +1504,7 @@ TEST(caffe2, sparseToDense) {
   EXPECT_EQ(mod.getPlaceholders().size(), 4);
 }
 
-TEST(caffe2, SparseToDenseMask) {
+TEST_F(Caffe2ImporterTest, SparseToDenseMask) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -1549,7 +1557,7 @@ TEST(caffe2, SparseToDenseMask) {
 }
 
 /// Test loading NCHW2NHWC op.
-TEST(caffe2, testNCHW2NHWC) {
+TEST_F(Caffe2ImporterTest, testNCHW2NHWC) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -1593,7 +1601,7 @@ TEST(caffe2, testNCHW2NHWC) {
 }
 
 /// Test loading a LengthsSum operator.
-TEST(caffe2, lengthsSum) {
+TEST_F(Caffe2ImporterTest, lengthsSum) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -1638,7 +1646,7 @@ TEST(caffe2, lengthsSum) {
 }
 
 /// Test loading a GatherRanges op.
-TEST(caffe2, gatherRanges) {
+TEST_F(Caffe2ImporterTest, gatherRanges) {
   ExecutionEngine EE;
   auto &mod = EE.getModule();
   auto *F = mod.createFunction("main");
@@ -1671,7 +1679,7 @@ TEST(caffe2, gatherRanges) {
 }
 
 /// Test loading Gather ops with constant folding from an Caffe2 model.
-TEST(caffe2, gatherConstantFoldingAndReshape) {
+TEST_F(Caffe2ImporterTest, gatherConstantFoldingAndReshape) {
   // This test verifies that Gather gets constant-folded, so that the argument
   // of the reshape becomes constant.
   ExecutionEngine EE;
@@ -1685,6 +1693,8 @@ TEST(caffe2, gatherConstantFoldingAndReshape) {
   auto *F = mod.createFunction("main");
   Placeholder *output;
   Tensor data(ElemKind::FloatTy, {1, 2, 4, 3});
+  // This test is testing constant folding during loading, so enable it
+  // explicitly.
   setConstantFoldLoaderOpsFlag(true);
   {
     Caffe2ModelLoader caffe2LD(netDescFilename, netWeightFilename, {"data"},
@@ -1692,7 +1702,6 @@ TEST(caffe2, gatherConstantFoldingAndReshape) {
     output = EXIT_ON_ERR(caffe2LD.getOutputByName("result"));
     bindings.allocate(mod.getPlaceholders());
   }
-  setConstantFoldLoaderOpsFlag(false);
   EE.compile(CompilationMode::Infer);
   EE.run(bindings);
 
@@ -1701,7 +1710,7 @@ TEST(caffe2, gatherConstantFoldingAndReshape) {
   EXPECT_TRUE(result.dims().vec() == expectedDims);
 }
 /// Test loading a LengthsRangeFill op.
-TEST(caffe2, LengthsRangeFill) {
+TEST_F(Caffe2ImporterTest, LengthsRangeFill) {
   ExecutionEngine EE;
   auto &mod = EE.getModule();
   auto *F = mod.createFunction("main");
@@ -1734,7 +1743,7 @@ TEST(caffe2, LengthsRangeFill) {
 }
 
 /// Verify that different fill types are loaded with the correct types.
-TEST(caffe2, tensorFillsTest) {
+TEST_F(Caffe2ImporterTest, tensorFillsTest) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -1798,7 +1807,7 @@ TEST(caffe2, tensorFillsTest) {
   }
 }
 
-TEST(caffe2, HalfToFloat) {
+TEST_F(Caffe2ImporterTest, HalfToFloat) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -1836,7 +1845,7 @@ TEST(caffe2, HalfToFloat) {
   EXPECT_EQ(N->getResult().getElementType(), ElemKind::FloatTy);
 }
 
-TEST(caffe2, Alias) {
+TEST_F(Caffe2ImporterTest, Alias) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -1872,7 +1881,7 @@ TEST(caffe2, Alias) {
   EXPECT_TRUE(N);
 }
 
-TEST(caffe2, Modulo) {
+TEST_F(Caffe2ImporterTest, Modulo) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -1913,7 +1922,7 @@ TEST(caffe2, Modulo) {
 }
 
 /// Test loading an ElementwiseLinear operator.
-TEST(caffe2, elementwiseLinear) {
+TEST_F(Caffe2ImporterTest, elementwiseLinear) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -1989,7 +1998,7 @@ TEST(caffe2, elementwiseLinear) {
 }
 
 /// Test loading an ElementwiseLinear operator with no axis specified.
-TEST(caffe2, elementwiseLinearUnspecifiedAxis) {
+TEST_F(Caffe2ImporterTest, elementwiseLinearUnspecifiedAxis) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -2079,7 +2088,7 @@ TEST(caffe2, elementwiseLinearUnspecifiedAxis) {
 ///    INDICES = [1, 0, 2, 0, 1, 2, 2, 0]
 ///    LENGTHS = [3, 0, 3, 2]
 ///    OUTPUT =  [[0.5, 0, 0, 25]]
-TEST(caffe2, SparseLengthsWeightedSum8BitsRowwise) {
+TEST_F(Caffe2ImporterTest, SparseLengthsWeightedSum8BitsRowwise) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -2186,7 +2195,7 @@ TEST(caffe2, SparseLengthsWeightedSum8BitsRowwise) {
 ///        [1.0, 1.2],
 ///        [3.0, 3.6],
 ///    ]
-TEST(caffe2, SparseLengthsSum8BitsRowwise) {
+TEST_F(Caffe2ImporterTest, SparseLengthsSum8BitsRowwise) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -2275,7 +2284,7 @@ TEST(caffe2, SparseLengthsSum8BitsRowwise) {
 ///    INDICES = [1, 0, 2, 0, 1, 2, 2, 0]
 ///    LENGTHS = [3, 0, 3, 2]
 ///    OUTPUT =  [[0.5, 0, 0, 25]]
-TEST(caffe2, SparseLengthsWeightedSumFused8BitRowwise) {
+TEST_F(Caffe2ImporterTest, SparseLengthsWeightedSumFused8BitRowwise) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -2380,7 +2389,7 @@ TEST(caffe2, SparseLengthsWeightedSumFused8BitRowwise) {
 ///        [1.0, 1.2],
 ///        [3.0, 3.6],
 ///    ]
-TEST(caffe2, SparseLengthsSumFused8BitRowwise) {
+TEST_F(Caffe2ImporterTest, SparseLengthsSumFused8BitRowwise) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -2458,7 +2467,7 @@ TEST(caffe2, SparseLengthsSumFused8BitRowwise) {
 }
 
 /// Test loading SparseLengthsSumFused4BitRowwise.
-TEST(caffe2, SparseLengthsSumFused4BitRowwise) {
+TEST_F(Caffe2ImporterTest, SparseLengthsSumFused4BitRowwise) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -2527,7 +2536,7 @@ TEST(caffe2, SparseLengthsSumFused4BitRowwise) {
 }
 
 /// Load big enough model and validate node order.
-TEST(caffe2, validateNodeOrder) {
+TEST_F(Caffe2ImporterTest, validateNodeOrder) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -2565,7 +2574,7 @@ TEST(caffe2, validateNodeOrder) {
       [](const Node &a, const Node &b) { return a.getName() < b.getName(); }));
 }
 
-TEST(caffe2, importInt8ConvRelu) {
+TEST_F(Caffe2ImporterTest, importInt8ConvRelu) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -2610,7 +2619,7 @@ TEST(caffe2, importInt8ConvRelu) {
   EE.compile(CompilationMode::Infer);
 }
 
-TEST(caffe2, importInt8SumRelu) {
+TEST_F(Caffe2ImporterTest, importInt8SumRelu) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -2653,7 +2662,7 @@ TEST(caffe2, importInt8SumRelu) {
   EE.compile(CompilationMode::Infer);
 }
 
-TEST(caffe2, importNames) {
+TEST_F(Caffe2ImporterTest, importNames) {
   std::string NetDescFilename(GLOW_DATA_PATH
                               "tests/models/caffe2Models/sigmoid.pbtxt");
   std::string NetWeightFilename(
@@ -2668,7 +2677,7 @@ TEST(caffe2, importNames) {
   EXPECT_TRUE(F->getNodeByName("sigmoid_test_output__1"));
 }
 
-TEST(caffe2, importSqr) {
+TEST_F(Caffe2ImporterTest, importSqr) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");

--- a/tests/unittests/OnnxExporterTest.cpp
+++ b/tests/unittests/OnnxExporterTest.cpp
@@ -156,6 +156,9 @@ TEST(exporter, onnxModels) {
       setOnnxDefineSymbol({"ONNXUndefinedSymbol,1"});
     }
 
+    // Disable constant folding for these tests.
+    setConstantFoldLoaderOpsFlag(false);
+
     testLoadAndSaveONNXModel(dirIt->path(), /* zipMode */ true);
     testLoadAndSaveONNXModel(dirIt->path(), /* zipMode */ false);
 

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -31,6 +31,15 @@ using namespace glow;
 #include <fstream>
 using namespace std;
 
+class OnnxImporterTest : public ::testing::Test {
+protected:
+  // By default constant folding at load time is enabled in general, but we do
+  // many tests here loading Constants, so keep it false during these tests by
+  // default.
+  void SetUp() override { glow::setConstantFoldLoaderOpsFlag(false); }
+  void TearDown() override { glow::setConstantFoldLoaderOpsFlag(true); }
+};
+
 /// Loads onnxtxt model file \p filename and \returns ModelProto object.
 Expected<ONNX_NAMESPACE::ModelProto> loadProto(const std::string &filename) {
   std::ifstream ff(filename, std::ios::in | std::ios::binary);
@@ -253,7 +262,7 @@ importArithMultiBroadcastTest(std::string fileName,
 }
 
 /// Test loading LeakyRelu op from an ONNX model.
-TEST(onnx, leakyRelu) {
+TEST_F(OnnxImporterTest, leakyRelu) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -281,7 +290,7 @@ TEST(onnx, leakyRelu) {
 }
 
 /// Test Loading LeakyRelu op from an ONNX model with default alpha.
-TEST(onnx, leakyReluDefault) {
+TEST_F(OnnxImporterTest, leakyReluDefault) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -308,80 +317,80 @@ TEST(onnx, leakyReluDefault) {
   EXPECT_FLOAT_EQ(splatN->getValue(), 0.01);
 }
 
-TEST(onnx, importAddMultiBroadcastOp7) {
+TEST_F(OnnxImporterTest, importAddMultiBroadcastOp7) {
   importArithMultiBroadcastTest<AddNode>(
       "addMultiBroadcastOp7.onnxtxt", {1, 3, 1, 2}, true, 1, 2,
       [](float a, float b) { return a + b; });
 }
 
-TEST(onnx, importAddUniBroadcastOp6NoAxis) {
+TEST_F(OnnxImporterTest, importAddUniBroadcastOp6NoAxis) {
   importArithMultiBroadcastTest<AddNode>(
       "addUniBroadcastOp6NoAxis.onnxtxt", {1, 3, 4, 2}, false, 0, 2,
       [](float a, float b) { return a + b; });
 }
 
-TEST(onnx, importAddUniBroadcastOp6Axis) {
+TEST_F(OnnxImporterTest, importAddUniBroadcastOp6Axis) {
   importArithMultiBroadcastTest<AddNode>(
       "addUniBroadcastOp6Axis.onnxtxt", {1, 3, 4, 2}, false, 0, 2,
       [](float a, float b) { return a + b; });
 }
 
-TEST(onnx, importSubMultiBroadcastOp7) {
+TEST_F(OnnxImporterTest, importSubMultiBroadcastOp7) {
   importArithMultiBroadcastTest<SubNode>(
       "subMultiBroadcastOp7.onnxtxt", {1, 3, 1, 2}, true, 1, 2,
       [](float a, float b) { return a - b; });
 }
 
-TEST(onnx, importSubUniBroadcastOp6NoAxis) {
+TEST_F(OnnxImporterTest, importSubUniBroadcastOp6NoAxis) {
   importArithMultiBroadcastTest<SubNode>(
       "subUniBroadcastOp6NoAxis.onnxtxt", {1, 3, 4, 2}, false, 0, 2,
       [](float a, float b) { return a - b; });
 }
 
-TEST(onnx, importSubUniBroadcastOp6Axis) {
+TEST_F(OnnxImporterTest, importSubUniBroadcastOp6Axis) {
   importArithMultiBroadcastTest<SubNode>(
       "subUniBroadcastOp6Axis.onnxtxt", {1, 3, 4, 2}, false, 0, 2,
       [](float a, float b) { return a - b; });
 }
 
-TEST(onnx, importMulMultiBroadcastOp7) {
+TEST_F(OnnxImporterTest, importMulMultiBroadcastOp7) {
   importArithMultiBroadcastTest<MulNode>(
       "mulMultiBroadcastOp7.onnxtxt", {1, 3, 1, 2}, true, 1, 2,
       [](float a, float b) { return a * b; });
 }
 
-TEST(onnx, importMulUniBroadcastOp6NoAxis) {
+TEST_F(OnnxImporterTest, importMulUniBroadcastOp6NoAxis) {
   importArithMultiBroadcastTest<MulNode>(
       "mulUniBroadcastOp6NoAxis.onnxtxt", {1, 3, 4, 2}, false, 0, 2,
       [](float a, float b) { return a * b; });
 }
 
-TEST(onnx, importMulUniBroadcastOp6Axis) {
+TEST_F(OnnxImporterTest, importMulUniBroadcastOp6Axis) {
   importArithMultiBroadcastTest<MulNode>(
       "mulUniBroadcastOp6Axis.onnxtxt", {1, 3, 4, 2}, false, 0, 2,
       [](float a, float b) { return a * b; });
 }
 
-TEST(onnx, importDivMultiBroadcastOp7) {
+TEST_F(OnnxImporterTest, importDivMultiBroadcastOp7) {
   importArithMultiBroadcastTest<DivNode>(
       "divMultiBroadcastOp7.onnxtxt", {1, 3, 1, 2}, true, 1, 2,
       [](float a, float b) { return a / b; });
 }
 
-TEST(onnx, importDivUniBroadcastOp6NoAxis) {
+TEST_F(OnnxImporterTest, importDivUniBroadcastOp6NoAxis) {
   importArithMultiBroadcastTest<DivNode>(
       "divUniBroadcastOp6NoAxis.onnxtxt", {1, 3, 4, 2}, false, 0, 2,
       [](float a, float b) { return a / b; });
 }
 
-TEST(onnx, importDivUniBroadcastOp6Axis) {
+TEST_F(OnnxImporterTest, importDivUniBroadcastOp6Axis) {
   importArithMultiBroadcastTest<DivNode>(
       "divUniBroadcastOp6Axis.onnxtxt", {1, 3, 4, 2}, false, 0, 2,
       [](float a, float b) { return a / b; });
 }
 
 /// This tests reproduces issue #2135.
-TEST(onnx, importUniBroadcastMultiOutput) {
+TEST_F(OnnxImporterTest, importUniBroadcastMultiOutput) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -423,7 +432,7 @@ static void testEltwiseUnaryOpFloat(std::string fileName,
   }
 }
 
-TEST(onnx, importExp) {
+TEST_F(OnnxImporterTest, importExp) {
   testEltwiseUnaryOpFloat("exp.onnxtxt", {1, 2, 4, 3}, "data", 0.002,
                           [](float a) { return std::exp(a); });
 }
@@ -471,7 +480,7 @@ static void testImportPRelu(std::string filename,
                                           {bindings.get(graphOutputVar)}));
 }
 
-TEST(onnx, importPreluSlopeHasSameShape) {
+TEST_F(OnnxImporterTest, importPreluSlopeHasSameShape) {
   // The expected slope values correspond to the pre-broadcast
   // initializer values in the model file.
   std::vector<float> expectedSlope = {1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0,
@@ -480,7 +489,7 @@ TEST(onnx, importPreluSlopeHasSameShape) {
                   expectedSlope);
 }
 
-TEST(onnx, importPReluBroadcastSlope) {
+TEST_F(OnnxImporterTest, importPReluBroadcastSlope) {
   // The expected slope values correspond to the pre-broadcast
   // initializer values in the model file.
   std::vector<float> expectedSlope = {1.0, 1.0, 1.0, 1.0, 2.0, 2.0, 2.0, 2.0,
@@ -489,7 +498,7 @@ TEST(onnx, importPReluBroadcastSlope) {
 }
 
 /// Expects failure to load PRelu in case of invalid slope shape.
-TEST(onnx, importPReluInvalidBroadcastSlope) {
+TEST_F(OnnxImporterTest, importPReluInvalidBroadcastSlope) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -575,7 +584,7 @@ static void convTestHelper(std::string &filename,
 /// Test loading conv op from a ONNX model.
 /// The input is N*C*H*W (1*1*3*3), the kernels is {2, 2},
 /// strides is {1, 1}, pads is {1, 1, 1, 1}, group is 1.
-TEST(onnx, importConv) {
+TEST_F(OnnxImporterTest, importConv) {
   std::string filename("simpleConv.onnxtxt");
   std::vector<dim_t> expectedDims = {1, 1, 4, 4};
   std::vector<float> expectedValues = {2,  3,  5,  4,  5, 10, 14, 9,
@@ -586,7 +595,7 @@ TEST(onnx, importConv) {
 /// Test loading conv op from a ONNX model.
 /// The input is N*C*H*W (1*1*3*3), the kernels is {2, 2},
 /// strides is {1, 1}, auto_pad VALID (i.e. no padding), group is 1.
-TEST(onnx, importConvAutoPadValid) {
+TEST_F(OnnxImporterTest, importConvAutoPadValid) {
   std::string filename("simpleConvAutoPadValid.onnxtxt");
   std::vector<dim_t> expectedDims = {1, 1, 2, 2};
   std::vector<float> expectedValues = {10, 14, 22, 26};
@@ -596,7 +605,7 @@ TEST(onnx, importConvAutoPadValid) {
 /// Test loading conv op from a ONNX model.
 /// The input is N*C*H*W (1*1*3*3), the kernels is {2, 2},
 /// strides is {1, 1}, auto_pad SAME_UPPER, group is 1.
-TEST(onnx, importConvAutoPadSameUpper) {
+TEST_F(OnnxImporterTest, importConvAutoPadSameUpper) {
   std::string filename("simpleConvAutoPadSameUpper.onnxtxt");
   std::vector<dim_t> expectedDims = {1, 1, 3, 3};
   std::vector<float> expectedValues = {10, 14, 9, 22, 26, 15, 15, 17, 10};
@@ -606,7 +615,7 @@ TEST(onnx, importConvAutoPadSameUpper) {
 /// Test loading conv op from a ONNX model.
 /// The input is N*C*H*W (1*1*3*3), the kernels is {2, 2},
 /// strides is {1, 1}, auto_pad SAME_LOWER, group is 1.
-TEST(onnx, importConvAutoPadSameLower) {
+TEST_F(OnnxImporterTest, importConvAutoPadSameLower) {
   std::string filename("simpleConvAutoPadSameLower.onnxtxt");
   std::vector<dim_t> expectedDims = {1, 1, 3, 3};
   std::vector<float> expectedValues = {2, 3, 5, 5, 10, 14, 11, 22, 26};
@@ -617,7 +626,7 @@ TEST(onnx, importConvAutoPadSameLower) {
 /// input is handled correctly. Remaining input is
 /// still sane to make sure it only fails for the
 /// intended case.
-TEST(onnx, importConvBiasFail) {
+TEST_F(OnnxImporterTest, importConvBiasFail) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -699,7 +708,7 @@ static void averagePoolTestHelper(std::string &filename,
 /// Test loading AveragePool op from a ONNX model.
 /// The input is N*C*H*W (1*1*3*3), the kernels is {2, 2},
 /// strides is {1, 1}, pads is auto_pad VALID (no padding), group is 1.
-TEST(onnx, importAveragePool2DAutoPadValid) {
+TEST_F(OnnxImporterTest, importAveragePool2DAutoPadValid) {
   std::string filename("averagePool2DAutoPadValid.onnxtxt");
   std::vector<dim_t> expectedDims = {1, 1, 2, 2};
   std::vector<float> expectedValues = {2, 3, 5, 6};
@@ -709,7 +718,7 @@ TEST(onnx, importAveragePool2DAutoPadValid) {
 /// Test loading AveragePool op from a ONNX model.
 /// The input is N*C*H*W (1*1*3*3), the kernels is {2, 2},
 /// strides is {1, 1}, pads is auto_pad SAME_UPPER, group is 1.
-TEST(onnx, importAveragePool2DAutoPadSameUpper) {
+TEST_F(OnnxImporterTest, importAveragePool2DAutoPadSameUpper) {
   std::string filename("averagePool2DAutoPadSameUpper.onnxtxt");
   std::vector<dim_t> expectedDims = {1, 1, 3, 3};
   std::vector<float> expectedValues = {2, 3, 1.75, 5, 6, 3.25, 3.25, 3.75, 2};
@@ -719,14 +728,14 @@ TEST(onnx, importAveragePool2DAutoPadSameUpper) {
 /// Test loading AveragePool op from a ONNX model.
 /// The input is N*C*H*W (1*1*3*3), the kernels is {2, 2},
 /// strides is {1, 1}, pads is auto_pad SAME_LOWER, group is 1.
-TEST(onnx, importAveragePool2DAutoPadSameLower) {
+TEST_F(OnnxImporterTest, importAveragePool2DAutoPadSameLower) {
   std::string filename("averagePool2DAutoPadSameLower.onnxtxt");
   std::vector<dim_t> expectedDims = {1, 1, 3, 3};
   std::vector<float> expectedValues = {0, 0.25, 0.75, 0.75, 2, 3, 2.25, 5, 6};
   averagePoolTestHelper(filename, expectedDims, expectedValues);
 }
 
-TEST(onnx, importAveragePool3D) {
+TEST_F(OnnxImporterTest, importAveragePool3D) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -745,7 +754,7 @@ TEST(onnx, importAveragePool3D) {
 
 /// Test loading ReduceMean op from a ONNX model.
 /// Input shape is 4D, one dimension is reduced, and output shape is 3D.
-TEST(onnx, reduceMean4Dto3D) {
+TEST_F(OnnxImporterTest, reduceMean4Dto3D) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -787,7 +796,7 @@ TEST(onnx, reduceMean4Dto3D) {
 
 /// Test loading ReduceMean op from a ONNX model.
 /// Input shape is 4D, one dimension is reduced, and output shape stays 4D.
-TEST(onnx, reduceMean4Dto4D) {
+TEST_F(OnnxImporterTest, reduceMean4Dto4D) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -831,7 +840,7 @@ TEST(onnx, reduceMean4Dto4D) {
 
 /// Test loading ReduceSum op from a ONNX model.
 /// Input shape is 4D, one dimension is reduced, and output shape is 4D.
-TEST(onnx, reduceSum4D) {
+TEST_F(OnnxImporterTest, reduceSum4D) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -872,7 +881,7 @@ TEST(onnx, reduceSum4D) {
 /// Test loading ReduceMean op from a ONNX model.
 /// Input shape is 4D, two dimensions are reduced, targeting ReduceMean
 /// optimization using AvgPool. Output shape is 4D.
-TEST(onnx, reduceMean2AvgPoolKeepDims) {
+TEST_F(OnnxImporterTest, reduceMean2AvgPoolKeepDims) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -919,7 +928,7 @@ TEST(onnx, reduceMean2AvgPoolKeepDims) {
 /// Test loading ReduceMean op from a ONNX model.
 /// Input shape is 4D, two dimensions are reduced, targeting ReduceMean
 /// optimization using AvgPool. Output shape is 2D.
-TEST(onnx, reduceMean2AvgPoolNoKeepDims) {
+TEST_F(OnnxImporterTest, reduceMean2AvgPoolNoKeepDims) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -967,7 +976,7 @@ TEST(onnx, reduceMean2AvgPoolNoKeepDims) {
 
 /// Test loading ReduceMin op from a ONNX model.
 /// Input shape is 4D, two dimensions are reduced,Output shape is 4D.
-TEST(onnx, reduceMinKeepDims) {
+TEST_F(OnnxImporterTest, reduceMinKeepDims) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -1006,7 +1015,7 @@ TEST(onnx, reduceMinKeepDims) {
 /// Test loading ReduceMean op from a ONNX model.
 /// Input shape is 4D, two dimensions are reduced, targeting ReduceMean
 /// optimization using AvgPool. Output shape is 2D.
-TEST(onnx, reduceMinNoKeepDims) {
+TEST_F(OnnxImporterTest, reduceMinNoKeepDims) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -1049,7 +1058,7 @@ TEST(onnx, reduceMinNoKeepDims) {
 
 /// Test loading ReduceMin op from a ONNX model.
 /// Input shape is 4D, two dimensions are reduced,Output shape is 4D.
-TEST(onnx, reduceMinKeepDimsDefaultAxis) {
+TEST_F(OnnxImporterTest, reduceMinKeepDimsDefaultAxis) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -1086,7 +1095,7 @@ TEST(onnx, reduceMinKeepDimsDefaultAxis) {
 }
 
 /// Test loading SpaceToDepth op from an ONNX model.
-TEST(onnx, spaceToDepth) {
+TEST_F(OnnxImporterTest, spaceToDepth) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -1117,7 +1126,7 @@ TEST(onnx, spaceToDepth) {
 
 /// Test loading clip op from an ONNX model.
 /// Test with arg min = 20.0 max = 60.0
-TEST(onnx, importClip) {
+TEST_F(OnnxImporterTest, importClip) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -1157,7 +1166,7 @@ TEST(onnx, importClip) {
 }
 
 /// Test loading BatchMatMul op from an ONNX model.
-TEST(onnx, importBatchMatMul) {
+TEST_F(OnnxImporterTest, importBatchMatMul) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -1226,7 +1235,7 @@ TEST(onnx, importBatchMatMul) {
 }
 
 /// Test loading BatchBoxCox op from an ONNX model.
-TEST(onnx, importBatchBoxCox) {
+TEST_F(OnnxImporterTest, importBatchBoxCox) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -1307,7 +1316,7 @@ TEST(onnx, importBatchBoxCox) {
 }
 
 /// Test loading DotProduct op from an ONNX model.
-TEST(onnx, importDotProduct) {
+TEST_F(OnnxImporterTest, importDotProduct) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -1337,7 +1346,7 @@ TEST(onnx, importDotProduct) {
 }
 
 /// Test loading Sum with more than 2 inputs
-TEST(onnx, importSumN) {
+TEST_F(OnnxImporterTest, importSumN) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -1399,7 +1408,7 @@ TEST(onnx, importSumN) {
 }
 
 /// Test loading Sum with one input and one output
-TEST(onnx, importSum1) {
+TEST_F(OnnxImporterTest, importSum1) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -1444,7 +1453,7 @@ TEST(onnx, importSum1) {
 }
 
 /// Test loading LengthsToRanges from an ONNX model.
-TEST(onnx, importLengthsToRanges) {
+TEST_F(OnnxImporterTest, importLengthsToRanges) {
   ExecutionEngine EE;
   auto &mod = EE.getModule();
   auto *F = mod.createFunction("main");
@@ -1467,7 +1476,7 @@ TEST(onnx, importLengthsToRanges) {
 
 /// Test loading ReplaceNaN op from an ONNX model.
 /// Test with arg value = 1.0.
-TEST(onnx, importReplaceNaN) {
+TEST_F(OnnxImporterTest, importReplaceNaN) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -1501,7 +1510,7 @@ TEST(onnx, importReplaceNaN) {
 }
 
 /// Test loading SparseToDense op from an ONNX model.
-TEST(onnx, importSparseToDense) {
+TEST_F(OnnxImporterTest, importSparseToDense) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -1546,7 +1555,7 @@ TEST(onnx, importSparseToDense) {
 }
 
 /// Test loading SparseLengthsSum from an ONNX model.
-TEST(onnx, importSparseLengthsSum) {
+TEST_F(OnnxImporterTest, importSparseLengthsSum) {
   ExecutionEngine EE;
   auto &mod = EE.getModule();
   auto *F = mod.createFunction("main");
@@ -1575,7 +1584,7 @@ TEST(onnx, importSparseLengthsSum) {
 }
 
 /// Test loading LengthsSum from an ONNX model.
-TEST(onnx, importLengthsSum) {
+TEST_F(OnnxImporterTest, importLengthsSum) {
   ExecutionEngine EE;
   auto &mod = EE.getModule();
   auto *F = mod.createFunction("main");
@@ -1625,7 +1634,7 @@ TEST(onnx, importCumSum) {
 }
 
 /// Test loading a FCTransposed node: I * W + B, where I is need to be flatten.
-TEST(onnx, FCTransposedWithFlatten) {
+TEST_F(OnnxImporterTest, FCTransposedWithFlatten) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -1654,7 +1663,7 @@ TEST(onnx, FCTransposedWithFlatten) {
 }
 
 /// Test loading Constant from an ONNX model.
-TEST(onnx, constant) {
+TEST_F(OnnxImporterTest, constant) {
   ExecutionEngine EE;
   auto &mod = EE.getModule();
   auto *F = mod.createFunction("main");
@@ -1713,28 +1722,28 @@ static void testConstantOfShapeFailure(std::string fileName) {
   ASSERT_DEATH(ONNXModelLoader(netFilename, {}, {}, *F), "losses");
 }
 
-TEST(onnx, importConstantOfShapeFloat) {
+TEST_F(OnnxImporterTest, importConstantOfShapeFloat) {
   testConstantOfShape<float>("constantOfShape.onnxtxt", 1.0F);
 }
 
-TEST(onnx, importConstantOfShapeInt32) {
+TEST_F(OnnxImporterTest, importConstantOfShapeInt32) {
   testConstantOfShape<int32_t>("constantOfShapeInt32.onnxtxt", 65535);
 }
 
-TEST(onnx, importConstantOfShapeInt64) {
+TEST_F(OnnxImporterTest, importConstantOfShapeInt64) {
   testConstantOfShape<int64_t>("constantOfShapeInt64.onnxtxt", 16777216LL);
 }
 
-TEST(onnx, importConstantOfShapeInt64LossFailure) {
+TEST_F(OnnxImporterTest, importConstantOfShapeInt64LossFailure) {
   testConstantOfShapeFailure<int64_t>("constantOfShapeInt64Fail.onnxtxt");
 }
 
-TEST(onnx, importConstantOfShapeInt32LossFailure) {
+TEST_F(OnnxImporterTest, importConstantOfShapeInt32LossFailure) {
   testConstantOfShapeFailure<int32_t>("constantOfShapeInt32Fail.onnxtxt");
 }
 
 /// Test loading ExpandDims from an ONNX model.
-TEST(onnx, expandDims) {
+TEST_F(OnnxImporterTest, expandDims) {
   ExecutionEngine EE;
   auto &mod = EE.getModule();
   auto *F = mod.createFunction("main");
@@ -1757,7 +1766,7 @@ TEST(onnx, expandDims) {
 }
 
 /// Test loading Gather from an ONNX model.
-TEST(onnx, gather) {
+TEST_F(OnnxImporterTest, gather) {
   ExecutionEngine EE;
   auto &mod = EE.getModule();
   std::string netFilename(GLOW_DATA_PATH
@@ -1783,7 +1792,7 @@ TEST(onnx, gather) {
 }
 
 /// Test loading GatherRanges from an ONNX model.
-TEST(onnx, gatherRanges) {
+TEST_F(OnnxImporterTest, gatherRanges) {
   ExecutionEngine EE;
   auto &mod = EE.getModule();
   std::string netFilename(GLOW_DATA_PATH
@@ -1811,7 +1820,7 @@ TEST(onnx, gatherRanges) {
 }
 
 /// Test loading Gather ops with constant folding from an ONNX model.
-TEST(onnx, gatherOpConstantFoldingAndReshape) {
+TEST_F(OnnxImporterTest, gatherOpConstantFoldingAndReshape) {
   // This test verifies that Gather gets constant-folded, so that the argument
   // of the reshape becomes constant.
   ExecutionEngine EE;
@@ -1897,38 +1906,38 @@ static void importSliceTest(std::string fileName, const char *inputName,
                                           {bindings.get(graphOutputVar)}));
 }
 
-TEST(onnx, importSliceDynamicNoAxes) {
+TEST_F(OnnxImporterTest, importSliceDynamicNoAxes) {
   importSliceTest("sliceDynamic.onnxtxt", "data", {2, 3, 3, 3} /* input */,
                   {0, 1, 1, 1} /* starts */, /* ends: {2, 2, 3, 3} */
                   {2, 1, 2, 2} /* output */);
 }
 
-TEST(onnx, importSliceAxesFull) {
+TEST_F(OnnxImporterTest, importSliceAxesFull) {
   importSliceTest("sliceAxesFull.onnxtxt", "data", {2, 3, 3, 3} /* input */,
                   {0, 1, 1, 2} /* starts */, /* ends: {1, 2, 3, 3} */
                   {1, 1, 2, 1} /* output */);
 }
 
-TEST(onnx, importSliceAxesAnyOrder) {
+TEST_F(OnnxImporterTest, importSliceAxesAnyOrder) {
   importSliceTest("sliceAxesAnyOrder.onnxtxt", "data", {2, 3, 3, 3} /* input */,
                   {1, 2, 0, 2} /* starts */, /* ends: {2, 3, 1, 3} */
                   {1, 1, 1, 1} /* output */);
 }
 
-TEST(onnx, importSliceAxesOverwrite) {
+TEST_F(OnnxImporterTest, importSliceAxesOverwrite) {
   importSliceTest("sliceAxesOverwrite.onnxtxt", "data",
                   {2, 3, 3, 3} /* input */,
                   {0, 1, 1, 2} /* starts */, /* ends: {1, 2, 3, 3} */
                   {1, 1, 2, 1} /* output */);
 }
 
-TEST(onnx, importSliceAxesPartial) {
+TEST_F(OnnxImporterTest, importSliceAxesPartial) {
   importSliceTest("sliceAxesPartial.onnxtxt", "data", {2, 3, 3, 3} /* input */,
                   {0, 1, 1, 0} /* starts */, /* ends: {2, 2, 3, 3} */
                   {2, 1, 2, 3} /* output */);
 }
 
-TEST(onnx, importSliceNoAxes) {
+TEST_F(OnnxImporterTest, importSliceNoAxes) {
   importSliceTest("sliceNoAxes.onnxtxt", "data", {2, 3, 3, 3} /* input */,
                   {0, 1, 1, 1} /* starts */, /* ends: {2, 2, 3, 3} */
                   {2, 1, 2, 2} /* output */);
@@ -1969,21 +1978,21 @@ static void importCast(llvm::StringRef fileName, llvm::StringRef inputName,
   ASSERT_EQ(castNode->getResult().getType()->getElementType(), outputKind);
 }
 
-TEST(onnx, importCastToFloat) {
+TEST_F(OnnxImporterTest, importCastToFloat) {
   importCast("castToFloat.onnxtxt", "data", {1, 2, 2, 2}, ElemKind::FloatTy);
 }
-TEST(onnx, importCastToFloat16) {
+TEST_F(OnnxImporterTest, importCastToFloat16) {
   importCast("castToFloat16.onnxtxt", "data", {1, 2, 2, 2},
              ElemKind::Float16Ty);
 }
-TEST(onnx, importCastToInt32) {
+TEST_F(OnnxImporterTest, importCastToInt32) {
   importCast("castToInt32.onnxtxt", "data", {1, 2, 2, 2}, ElemKind::Int32ITy);
 }
-TEST(onnx, importCastToInt64) {
+TEST_F(OnnxImporterTest, importCastToInt64) {
   importCast("castToInt64.onnxtxt", "data", {1, 2, 2, 2}, ElemKind::Int64ITy);
 }
 
-TEST(onnx, cast_32_64) {
+TEST_F(OnnxImporterTest, cast_32_64) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -2111,19 +2120,19 @@ static void importPad(std::string fileName, const char *inputName,
   }
 }
 
-TEST(onnx, importPadDefault) {
+TEST_F(OnnxImporterTest, importPadDefault) {
   importPad("padDefault.onnxtxt", "data", {4, 6, 5, 7} /* input */,
             {1, 2, -2, 0} /* starts */, {0, -2, 1, 2} /* ends */,
             PaddingMode::CONSTANT, 0.f, false);
 }
 
-TEST(onnx, importPadConstant) {
+TEST_F(OnnxImporterTest, importPadConstant) {
   importPad("padConstant.onnxtxt", "data", {4, 6, 5, 7} /* input */,
             {1, 2, -2, 0} /* starts */, {0, -2, 1, 2} /* ends */,
             PaddingMode::CONSTANT, 2.55f, false);
 }
 
-TEST(onnx, importPadReflect) {
+TEST_F(OnnxImporterTest, importPadReflect) {
   // Note: PaddingMode::REFLECT is not yet supported, so we assert death when
   // loading the model.
   importPad("padReflect.onnxtxt", "data", {4, 6, 5, 7} /* input */,
@@ -2132,7 +2141,7 @@ TEST(onnx, importPadReflect) {
             /* expectLoadError */ true);
 }
 
-TEST(onnx, importPadEdge) {
+TEST_F(OnnxImporterTest, importPadEdge) {
   // Note: PaddingMode::EDGE is not yet supported, so we assert death when
   // loading the model.
   importPad("padEdge.onnxtxt", "data", {4, 6, 5, 7} /* input */,
@@ -2141,7 +2150,7 @@ TEST(onnx, importPadEdge) {
             /* expectLoadError */ true);
 }
 
-TEST(onnx, importPadConstantPositive) {
+TEST_F(OnnxImporterTest, importPadConstantPositive) {
   importPad("padConstantPositive.onnxtxt", "data", {4, 6, 5, 7} /* input */,
             {1, 2, 3, 4} /* starts */, {0, 3, 1, 2} /* ends */,
             PaddingMode::CONSTANT, 2.55f, true);
@@ -2151,7 +2160,7 @@ TEST(onnx, importPadConstantPositive) {
 /// the model. Glow supports only the first mandatory output, but declaring
 /// optional outputs while not using them in the model should not make the
 /// import fail.
-TEST(onnx, batchNormPR2304) {
+TEST_F(OnnxImporterTest, batchNormPR2304) {
   ExecutionEngine EE;
   auto &mod = EE.getModule();
   std::string netFilename(GLOW_DATA_PATH
@@ -2175,7 +2184,7 @@ TEST(onnx, batchNormPR2304) {
 }
 
 /// Test constructor for auto loading inputs case.
-TEST(onnx, autoLoadInputs) {
+TEST_F(OnnxImporterTest, autoLoadInputs) {
   ExecutionEngine EE;
   auto &mod = EE.getModule();
   std::string netFilename(GLOW_DATA_PATH
@@ -2189,7 +2198,7 @@ TEST(onnx, autoLoadInputs) {
   EXPECT_TRUE(inputTensor.getType().isEqual(inputs[inputName]->getType()));
 }
 
-TEST(onnx, shape) {
+TEST_F(OnnxImporterTest, shape) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -2227,7 +2236,7 @@ TEST(onnx, shape) {
                                           {bindings.get(output)}));
 }
 
-TEST(onnx, tile) {
+TEST_F(OnnxImporterTest, tile) {
   ExecutionEngine EE;
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -2266,7 +2275,7 @@ TEST(onnx, tile) {
   }
 }
 
-TEST(onnx, topK) {
+TEST_F(OnnxImporterTest, topK) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -2317,7 +2326,7 @@ TEST(onnx, topK) {
       checkConstFoldedOutput(netFilename, {"scores"}, {&x}, {outputT, indexT}));
 }
 
-TEST(onnx, argMaxKeepDim) {
+TEST_F(OnnxImporterTest, argMaxKeepDim) {
   ExecutionEngine EE;
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -2344,7 +2353,7 @@ TEST(onnx, argMaxKeepDim) {
   EXPECT_TRUE(argmax.dims().vec() == expectedDims);
 }
 
-TEST(onnx, argMaxNoKeepDim) {
+TEST_F(OnnxImporterTest, argMaxNoKeepDim) {
   ExecutionEngine EE;
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -2371,7 +2380,7 @@ TEST(onnx, argMaxNoKeepDim) {
   EXPECT_TRUE(argmax.dims().vec() == expectedDims);
 }
 
-TEST(onnx, argMaxDefault) {
+TEST_F(OnnxImporterTest, argMaxDefault) {
   ExecutionEngine EE;
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -2398,7 +2407,7 @@ TEST(onnx, argMaxDefault) {
   EXPECT_TRUE(argmax.dims().vec() == expectedDims);
 }
 
-TEST(onnx, importMaxPoolWithArgmax) {
+TEST_F(OnnxImporterTest, importMaxPoolWithArgmax) {
   ExecutionEngine EE;
   auto &mod = EE.getModule();
   std::string netFilename(GLOW_DATA_PATH
@@ -2480,7 +2489,7 @@ TEST(onnx, importMaxPoolWithArgmax) {
   }
 }
 
-TEST(onnx, importWhere) {
+TEST_F(OnnxImporterTest, importWhere) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -2514,7 +2523,7 @@ TEST(onnx, importWhere) {
   EXPECT_EQ(WHR->getResult().dims()[2], 4);
 }
 
-TEST(onnx, importLess) {
+TEST_F(OnnxImporterTest, importLess) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
   Function *F = mod.createFunction("main");
@@ -2545,7 +2554,7 @@ TEST(onnx, importLess) {
   EXPECT_EQ(CMPLT->getResult().dims()[2], 1);
 }
 
-TEST(onnx, importDimParamExplicit) {
+TEST_F(OnnxImporterTest, importDimParamExplicit) {
   ExecutionEngine EE;
   auto &mod = EE.getModule();
   std::string netFilename(GLOW_DATA_PATH
@@ -2573,7 +2582,7 @@ TEST(onnx, importDimParamExplicit) {
   EXPECT_EQ(outputPH->dims()[1], 2);
 }
 
-TEST(onnx, importDimParamImplicit) {
+TEST_F(OnnxImporterTest, importDimParamImplicit) {
   ExecutionEngine EE;
   auto &mod = EE.getModule();
   std::string netFilename(GLOW_DATA_PATH
@@ -2634,23 +2643,23 @@ static void importRNN(std::string fileName) {
   }
 }
 
-TEST(onnx, importRNNForward) {
+TEST_F(OnnxImporterTest, importRNNForward) {
   importRNN(GLOW_DATA_PATH "tests/models/onnxModels/rnnForward.onnxtxt");
 }
 
-TEST(onnx, importRNNReverse) {
+TEST_F(OnnxImporterTest, importRNNReverse) {
   importRNN(GLOW_DATA_PATH "tests/models/onnxModels/rnnReverse.onnxtxt");
 }
 
-TEST(onnx, importRNNBidirectional) {
+TEST_F(OnnxImporterTest, importRNNBidirectional) {
   importRNN(GLOW_DATA_PATH "tests/models/onnxModels/rnnBidirectional.onnxtxt");
 }
 
-TEST(onnx, importRNNForwardNoBias) {
+TEST_F(OnnxImporterTest, importRNNForwardNoBias) {
   importRNN(GLOW_DATA_PATH "tests/models/onnxModels/rnnForwardNoBias.onnxtxt");
 }
 
-TEST(onnx, importRNNForwardNoState) {
+TEST_F(OnnxImporterTest, importRNNForwardNoState) {
   importRNN(GLOW_DATA_PATH "tests/models/onnxModels/rnnForwardNoState.onnxtxt");
 }
 
@@ -2689,27 +2698,27 @@ static void importGRU(std::string fileName) {
   }
 }
 
-TEST(onnx, importGRUForward) {
+TEST_F(OnnxImporterTest, importGRUForward) {
   importGRU(GLOW_DATA_PATH "tests/models/onnxModels/gruForward.onnxtxt");
 }
 
-TEST(onnx, importGRUReverse) {
+TEST_F(OnnxImporterTest, importGRUReverse) {
   importGRU(GLOW_DATA_PATH "tests/models/onnxModels/gruReverse.onnxtxt");
 }
 
-TEST(onnx, importGRUBidirectional) {
+TEST_F(OnnxImporterTest, importGRUBidirectional) {
   importGRU(GLOW_DATA_PATH "tests/models/onnxModels/gruBidirectional.onnxtxt");
 }
 
-TEST(onnx, importGRUForwardNoBias) {
+TEST_F(OnnxImporterTest, importGRUForwardNoBias) {
   importGRU(GLOW_DATA_PATH "tests/models/onnxModels/gruForwardNoBias.onnxtxt");
 }
 
-TEST(onnx, importGRUForwardNoState) {
+TEST_F(OnnxImporterTest, importGRUForwardNoState) {
   importGRU(GLOW_DATA_PATH "tests/models/onnxModels/gruForwardNoState.onnxtxt");
 }
 
-TEST(onnx, importGRUForwardLinearBeforeReset) {
+TEST_F(OnnxImporterTest, importGRUForwardLinearBeforeReset) {
   importGRU(GLOW_DATA_PATH
             "tests/models/onnxModels/gruForwardLinearBeforeReset.onnxtxt");
 }
@@ -2754,35 +2763,35 @@ static void importLSTM(std::string fileName) {
   }
 }
 
-TEST(onnx, importLSTMForward) {
+TEST_F(OnnxImporterTest, importLSTMForward) {
   importLSTM(GLOW_DATA_PATH "tests/models/onnxModels/lstmForward.onnxtxt");
 }
 
-TEST(onnx, importLSTMReverse) {
+TEST_F(OnnxImporterTest, importLSTMReverse) {
   importLSTM(GLOW_DATA_PATH "tests/models/onnxModels/lstmReverse.onnxtxt");
 }
 
-TEST(onnx, importLSTMBidirectional) {
+TEST_F(OnnxImporterTest, importLSTMBidirectional) {
   importLSTM(GLOW_DATA_PATH
              "tests/models/onnxModels/lstmBidirectional.onnxtxt");
 }
 
-TEST(onnx, importLSTMForwardNoBias) {
+TEST_F(OnnxImporterTest, importLSTMForwardNoBias) {
   importLSTM(GLOW_DATA_PATH
              "tests/models/onnxModels/lstmForwardNoBias.onnxtxt");
 }
 
-TEST(onnx, importLSTMForwardNoState) {
+TEST_F(OnnxImporterTest, importLSTMForwardNoState) {
   importLSTM(GLOW_DATA_PATH
              "tests/models/onnxModels/lstmForwardNoState.onnxtxt");
 }
 
-TEST(onnx, importLSTMForwardWithPeephole) {
+TEST_F(OnnxImporterTest, importLSTMForwardWithPeephole) {
   importLSTM(GLOW_DATA_PATH
              "tests/models/onnxModels/lstmForwardWithPeephole.onnxtxt");
 }
 
-TEST(onnx, importLSTMForwardInputForget) {
+TEST_F(OnnxImporterTest, importLSTMForwardInputForget) {
   importLSTM(GLOW_DATA_PATH
              "tests/models/onnxModels/lstmForwardInputForget.onnxtxt");
 }
@@ -2813,10 +2822,10 @@ static void importFlip(std::string fileName) {
   }
 }
 
-TEST(onnx, importFlipWithAxis) {
+TEST_F(OnnxImporterTest, importFlipWithAxis) {
   importFlip(GLOW_DATA_PATH "tests/models/onnxModels/flipWithAxis.onnxtxt");
 }
 
-TEST(onnx, importFlipNoAxis) {
+TEST_F(OnnxImporterTest, importFlipNoAxis) {
   importFlip(GLOW_DATA_PATH "tests/models/onnxModels/flipNoAxis.onnxtxt");
 }

--- a/tools/loader/TextTranslator.cpp
+++ b/tools/loader/TextTranslator.cpp
@@ -361,7 +361,6 @@ int main(int argc, char **argv) {
       &encoderInputs.getType(), &attnWeights.getType(),
       &prevHyposIndices.getType(), &prevScores.getType(), &prevToken.getType()};
 
-  setConstantFoldLoaderOpsFlag(false);
   Caffe2ModelLoader LD(loader.getCaffe2NetDescFilename(),
                        loader.getCaffe2NetWeightFilename(), inputNames,
                        inputTensors, *loader.getFunction());

--- a/tools/loader/TextTranslator.cpp
+++ b/tools/loader/TextTranslator.cpp
@@ -361,6 +361,7 @@ int main(int argc, char **argv) {
       &encoderInputs.getType(), &attnWeights.getType(),
       &prevHyposIndices.getType(), &prevScores.getType(), &prevToken.getType()};
 
+  setConstantFoldLoaderOpsFlag(false);
   Caffe2ModelLoader LD(loader.getCaffe2NetDescFilename(),
                        loader.getCaffe2NetWeightFilename(), inputNames,
                        inputTensors, *loader.getFunction());


### PR DESCRIPTION
Summary:
Fixes https://github.com/pytorch/glow/issues/4030. Comes with additional fixes on top of https://github.com/pytorch/glow/pull/4027.

Includes a new verboseCompile bool in the CompilationContext and set it to false for constant folding (true by default) so if there are constant folding errors we don't spam the log.

CC: @mciprian13 @tlepley-cadence

Differential Revision: D19543559

