### PR TITLE
Create network debugger tool

### DIFF
--- a/docs/Network-Debugger.md
+++ b/docs/Network-Debugger.md
@@ -1,0 +1,118 @@
+## Overview of Network Debugger tool and classes
+
+### Introduction
+
+This document describes the motivation behind the Network Debugger tool and
+how it can be used.
+
+Network Debugger was created to provide a way to find an exact broken layer
+when running a network on a backend. This is useful when
+developing a new backend or compiling a new network that was never compiled before
+on a particular backend.
+
+### Usage:
+  * Logic for detection of a broken layer is factored into Comparator classes (see section below) which allows for different usage modes:
+
+  * Use the network debugger tool:
+    * This tool loads a model from a protobuf file, runs conversions  to fp16, if needed, and optimizations
+      on the network then passes it to the comparator class to find a broken layer:
+      ```
+      Module mod;
+       // Load Module to mod.
+       IntermediateLayerComparator netCompare(mod, "Interpreter", testBackend,numericCmpThreshold);
+      netCompare.verify();
+      ```
+      A sample run line for the tool:
+      ```
+      bin/network-debugger --model onnxifi_function_0.zip --inputs input_0.onnx -glow_global_fp16    -backend=Interpreter
+      ```
+      ```
+      --model specifies the protobuf file for the network.
+      --input is a sample input ot the network in ONNX format.
+      ```
+    * Output.
+      * The tool will print out what layer being verified; when it
+        starts and when it finishes verifying the layer:
+
+    ```
+    [NetworkComparator.cpp:137] Verifying layer: layer_1	Type: SparseLengthsSum
+    [NetworkComparator.cpp:151] DONE Verifying layer: layer_1
+
+    [NetworkComparator.cpp:137] Verifying layer: layer_2	Type: Add
+    [NetworkComparator.cpp:151] DONE Verifying layer: layer_2
+    ```
+      * If the layer is detected to generates the wrong result the tool will print the following:
+    ```
+    [NetworkComparator.cpp:137] Verifying layer: layer_1	Type: SparseLengthsSum
+                                Error at output index 4, got 0.779 expected 0.564
+                                Results differ
+                                dumping tensors.
+    [NetworkComparator.cpp:151] DONE Verifying layer: layer_1
+
+    ```
+       To help the user later reproduce the failure, the input and output tensors
+       of the failing layer are dumped out to separate files. The name of the dumped file
+       is "Input_#InputName_#LayerName". For example, a SparseLengthsSum
+       node  has inputs called "Data", "Indices" and "Lengths", if the layer is called
+       "layer_1" like in the above example the dumped files will be called:
+
+       ```
+       intput_Data_layer_1
+       intput_Indices_layer_1
+       intput_Lengths_layer_1
+       ```
+
+       The tool will also dump a reference output that is provided by the reference backend:
+       If the output is called "Result" like in SparseLengthsSum the dumped file:
+       ```
+       ref_Result_layer1
+       ```
+       The user can later create a test case and feed these inputs to the test and compare the results against the reference.
+
+  * Using the classes standalone fashion
+
+    Instead of using the network-debugger tool the user can instantiate an object of the comparator while working on
+    their application and just pass the module. The sample
+    code above shows an example of that.
+
+### How broken layers are found
+
+The core logic for finding a broken layer is provided in the classes in `lib/Graph/NetworkComparator.cpp`. The comparator class receives a module and a test backend,
+the provided module gets compiled and run on a reference backend (Interpreter) and compares the results to these of running on the provided test backend. 
+
+ These classes provide different modes of operation:
+
+#### `IntermediateLayerComparator`
+* This class first tests layer all at once to find suspicious
+layers that are different between the reference and test backend runs. It works as follows:
+   1) Instrument the input network with Save nodes to capture the results at run time.
+   2) Compile and run the instrumented network on the reference backend and the test backend.
+   3) Compare the intermediate results from between the reference backend and the test backend. If no errors are found the comparator just returns success.
+   4) If errors were detected; Start a single layer test debug.
+      1) For every node in the network, create a new network that only has that one node.
+      2) For the inputs of the network, feed in placeholders resulting from the reference run. This will guarantee errors that might be caused by previous layers don't propagate to the layer being tested and allows detection of only the broken layers.
+      3) Compare the output of the one layer network with the outputs from the reference backend run. If the results don't match the mark the layer as broken.
+
+#### `RecursiveLayerComparator`
+  * This class tests layers by creating a subnet of the original
+    graph for every layer instead of instrumenting all the layers
+    at once.
+    It works as follows:
+    *  **For every layer in the network**:
+    1) Visit the inputs of the layer recursively until reaching the input
+   placeholders; add the visited notes to create a subnet.
+    1) Add Save node(s) to the layer output(s).
+    2) Run the network on the the test backend and reference backend.
+    3) If the results differ mark the layer as broken.
+
+  * This tester is slower than the Intermediate tester. However, it
+     has a smaller memory footprint since it doesn't need to save
+    intermediate results of all layers.
+
+
+#### Future work
+  * Add binary logging of tensors, e.g ONNX. This is best
+    added to the ```Tensor::dump() ``` method overrides and called later in  ```NetworkComparatorBase::dumpTensors()```. If we add that the user can later
+    use ``` glow::loadTensor()``` to load it in their test case.
+  * Make testing more autonomous; instead of just dumping tensors for errant layer
+   provide a way to dump the network (made of one layer) to a file to later be loaded and tested.

--- a/examples/resnet-verify.cpp
+++ b/examples/resnet-verify.cpp
@@ -64,7 +64,7 @@ public:
     Caffe2ModelLoader loader(
         "resnet50/predict_net.pb", "resnet50/init_net.pb", {inputName},
         {mod->uniqueType(ElemKind::FloatTy, {1, 3, 224, 224})}, *FI);
-    auto hook = hookOutput(FI, name);
+    auto hook = hookNode(FI, name);
     inferBindings.allocate(modI->getPlaceholders());
     for (auto PH : bindings.pairs()) {
       auto iPH = inferBindings.getPlaceholderByName(PH.first->getName());

--- a/include/glow/Graph/Hook.h
+++ b/include/glow/Graph/Hook.h
@@ -26,15 +26,33 @@ class Node;
 class Placeholder;
 class SaveNode;
 
+/// This struct is used to keep information returned from
+/// hooking a function.
 struct HookedFunction {
+  /// Saves the function hookNode() creates and inserts hooks in.
   Function *function;
-  std::list<SaveNode *> saves;
+  /// List of Save nodes hookNode() inserts at the outputs of the layer.
+  std::list<SaveNode *> outputSaves;
+  /// List of the Placeholders associated with Save nodes in outputSaves.
   std::list<Placeholder *> outputs;
+  /// List of Save nodes hookNode() inserts at the input of the layer.
+  std::list<SaveNode *> inputSaves;
+  /// List of the Placeholders associated with Save nodes in inputSaves.
+  std::list<Placeholder *> inputs;
 };
 
-HookedFunction hookOutput(Function *F, Node *node);
+/// Given a function \p F and a node \p node it creates a function
+/// in the same module and populates it with a recursive clone of
+/// the node \p node then inserts Save nodes at the output of to capture it.
+/// If \p hookInputs is set it also inserts Save nodes to capture the inputs.
+/// \returns the list of inserted nodes and associated placeholder in
+/// \p HookedFunction object.
+HookedFunction hookNode(Function *F, Node *node, bool hookInputs = false);
 
-HookedFunction hookOutput(Function *F, llvm::StringRef nodeName);
+/// Given a function \p F and a layer name \p nodeName it finds the
+/// corresponding nodes in the function \p F then calls above override.
+HookedFunction hookNode(Function *F, llvm::StringRef nodeName,
+                        bool hookInputs = false);
 
 } // namespace glow
 

--- a/include/glow/Importer/ONNXModelLoader.h
+++ b/include/glow/Importer/ONNXModelLoader.h
@@ -44,14 +44,23 @@ namespace glow {
 /// Loads tensor \p T from the input \p in.
 Error loadTensor(const ONNX_NAMESPACE::TensorProto &in, Tensor *T);
 
-/// Parse as input file name \p fileName which is an ONNX file
+/// Parses as input file name \p fileName which is an ONNX file
 /// and \returns a parsed GraphProto.
-::ONNX_NAMESPACE::GraphProto parseOnnxFile(const std::string &fileName);
+ONNX_NAMESPACE::GraphProto parseOnnxFile(const std::string &fileName);
 
-/// Taken an ONNX file in \p fileName reads it and loads the tensors
-/// in \p bindings.
+/// Takes an ONNX file in \p fileName reads it and loads the tensors
+/// in \p bindings. If the tensors loaded from the underlying file
+/// Are smaller than what the placeholder for that tensor expects it gets
+/// Padded with 0 if \p partialTensorPayloads is nullptr other wise
+/// \p partialTensorPayloads holds the data for full tensors.
 void fillPlaceholders(const std::string &fileName,
-                      PlaceholderBindings *bindings);
+                      PlaceholderBindings *bindings,
+                      std::vector<Tensor> *partialTensorPayloads = nullptr);
+
+/// Override that takes \p parsedFile as a parsed file instead of file name.
+void fillPlaceholders(const ONNX_NAMESPACE::GraphProto &parsedFile,
+                      PlaceholderBindings *bindings,
+                      std::vector<Tensor> *partialTensorPayloads = nullptr);
 
 /// Define undefined symbols to \p str loaded from an ONNX proto. See
 /// onnxDefineSymbolOpt in ONNXModelLoader.cpp.

--- a/include/glow/Importer/ONNXModelLoader.h
+++ b/include/glow/Importer/ONNXModelLoader.h
@@ -25,6 +25,9 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 
+#include "google/protobuf/io/coded_stream.h"
+#include "google/protobuf/io/zero_copy_stream_impl.h"
+#include <fstream>
 #include <string>
 #include <unordered_set>
 
@@ -40,6 +43,15 @@ namespace glow {
 
 /// Loads tensor \p T from the input \p in.
 Error loadTensor(const ONNX_NAMESPACE::TensorProto &in, Tensor *T);
+
+/// Parse as input file name \p fileName which is an ONNX file
+/// and \returns a parsed GraphProto.
+::ONNX_NAMESPACE::GraphProto parseOnnxFile(const std::string &fileName);
+
+/// Taken an ONNX file in \p fileName reads it and loads the tensors
+/// in \p bindings.
+void fillPlaceholders(const std::string &fileName,
+                      PlaceholderBindings *bindings);
 
 /// Define undefined symbols to \p str loaded from an ONNX proto. See
 /// onnxDefineSymbolOpt in ONNXModelLoader.cpp.

--- a/tests/unittests/GraphTest.cpp
+++ b/tests/unittests/GraphTest.cpp
@@ -1544,11 +1544,11 @@ TEST(Graph, hookTest) {
   EXPECT_EQ(mod.getPlaceholders().size(), 2);
 
   // Hook the first relu and verify that the hooked graph looks right.
-  auto hooked = glow::hookOutput(F, relu1);
+  auto hooked = glow::hookNode(F, relu1);
   auto const &nodes = hooked.function->getNodes();
   ASSERT_EQ(mod.getPlaceholders().size(), 3);
   ASSERT_EQ(nodes.size(), 2);
-  auto const *hookSave = *hooked.saves.begin();
+  auto const *hookSave = *hooked.outputSaves.begin();
   ASSERT_TRUE(hookSave);
   auto *inp = llvm::dyn_cast<ReluNode>(hookSave->getInput());
   ASSERT_TRUE(inp);

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(Debugger)
 add_subdirectory(ClassGen)
 add_subdirectory(IncludeBin)
 if(PNG_FOUND)

--- a/tools/Debugger/CMakeLists.txt
+++ b/tools/Debugger/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_executable(network-debugger
+               network-debugger.cpp
+               NetworkComparator.cpp)
+
+target_link_libraries(network-debugger
+                      PRIVATE
+                        BackendTestUtils
+                        HostManager
+                        Importer
+                        HostManager
+                        ExecutionEngine
+                        Exporter)
+

--- a/tools/Debugger/NetworkComparator.cpp
+++ b/tools/Debugger/NetworkComparator.cpp
@@ -1,0 +1,362 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "NetworkComparator.h"
+
+#include "glow/Graph/Graph.h"
+#include "glow/Graph/Node.h"
+
+#include "glow/ExecutionEngine/ExecutionEngine.h"
+#include "glow/Graph/Hook.h"
+#include "glow/Graph/Utils.h"
+#include "glow/Support/Debug.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/Support/FormatVariadic.h"
+
+#define DEBUG_TYPE "verifier"
+
+using namespace glow;
+
+void NetworkComparatorBase::dumpTensors(
+    std::unordered_map<std::string, Tensor *> tensors,
+    const std::string &layerName, const std::string &prefix) {
+  // TODO: Need to add different flavours of dumping.
+  auto it = tensors.begin();
+  while (it != tensors.end()) {
+    std::error_code EC;
+    DCHECK(it->second) << "Tensor is Null\n";
+    llvm::raw_fd_ostream fs(prefix + "_" + it->first + "_" + layerName, EC);
+    it->second->dump(fs, std::numeric_limits<unsigned>::max());
+    fs.close();
+    it++;
+  }
+}
+bool NetworkComparatorBase::checkTensors(
+    std::unordered_map<std::string, Tensor *> &refOuts,
+    std::unordered_map<std::string, Tensor *> &checkOuts) {
+  if (refOuts.size() != checkOuts.size()) {
+    LOG(ERROR) << "Backends produced different number of results\n";
+    return false;
+  }
+  auto itRef = refOuts.begin();
+  auto itCheck = checkOuts.begin();
+  auto endRef = refOuts.end();
+  auto endCheck = checkOuts.end();
+  while (itRef != endRef && itCheck != endCheck) {
+    if (!itRef->second->isEqual(*(itCheck->second), numericCmpThreshold_,
+                                /* verbose */ true)) {
+      LOG(INFO) << "Error: " << itRef->first << "\n";
+      return false;
+    }
+    itRef++;
+    itCheck++;
+  }
+  return true;
+}
+
+NetworkComparatorBase::NetworkComparatorBase(
+    Module &mod, const std::string &referenceBackend,
+    const std::string &testBackend, float numericCmpThreshold,
+    bool dumpTensorsForBadLayer)
+    : numericCmpThreshold_(numericCmpThreshold), inputModule_(&mod),
+      dumpTensorsForBadLayer_(dumpTensorsForBadLayer) {
+  DCHECK(mod.getFunctions().size() == 1)
+      << "Module must have exactly one functions";
+  EERefNet_.setBackendName(referenceBackend);
+  mod.clone(&EERefNet_.getModule());
+  EETestNet_.setBackendName(testBackend);
+  mod.clone(&EETestNet_.getModule());
+}
+
+NetworkComparatorBase::InOutTensors RecursiveLayerComparator::hookAndRun(
+    llvm::StringRef layerName, PlaceholderBindings *bindings, bool isRef) {
+  ExecutionEngine execEngine;
+  execEngine.setBackendName(isRef ? EERefNet_.getBackendName()
+                                  : EETestNet_.getBackendName());
+  inputModule_->clone(&execEngine.getModule());
+  HookedFunction hook = hookNode(execEngine.getSingleFunctionFromModule(),
+                                 layerName, /* hookInputs */ true);
+  PlaceholderBindings &inferBindings =
+      isRef ? inferBindingsRef_ : inferBindingsCheck_;
+  inferBindings.allocate(execEngine.getModule().getPlaceholders());
+  // Copy the tensors from the bindings to the inference bindings
+  // we feed to the Temp network.
+  for (auto &PH : bindings->pairs()) {
+    auto iPH = inferBindings.getPlaceholderByName(PH.first->getName());
+    inferBindings.get(iPH)->assign(PH.second);
+  }
+  InOutTensors inOutTensors;
+  for (const auto &P : hook.outputs) {
+    Tensor *t = inferBindings.get(P);
+    std::string str = P->getName();
+    DCHECK(t) << "Placeholder not " << str << " found in the bindings\n";
+    inOutTensors.outputs[str] = t;
+  }
+  for (const auto &P : hook.inputs) {
+    Tensor *t = inferBindings.get(P);
+    std::string str = P->getName();
+    DCHECK(t) << "Placeholder " << str << " not found in the bindings\n";
+    inOutTensors.inputs[str] = t;
+  }
+  auto fName = hook.function->getName();
+  execEngine.compile(CompilationMode::Infer);
+  execEngine.run(inferBindings, fName);
+  return inOutTensors;
+}
+
+bool RecursiveLayerComparator::verify(PlaceholderBindings *bindings) {
+  bool allPassed = true;
+  // Sort the nodes in topological order to test nodes in that order.
+  // Tensors flow through the network in topological order, testing the layers
+  // in that order will allow us to see how errors propagate.
+  GraphPostOrderVisitor visitor(*EERefNet_.getSingleFunctionFromModule());
+  llvm::ArrayRef<Node *> order = visitor.getPostOrder();
+  for (auto const *nodePtr : order) {
+    auto &node = *nodePtr;
+    DCHECK(nodePtr) << "Node is empty!";
+    if (llvm::isa<SaveNode>(&node) || llvm::isa<Constant>(&node) ||
+        llvm::isa<Placeholder>(&node)) {
+      continue;
+    }
+    llvm::StringRef layerName = node.getName();
+    llvm::StringRef kName = node.getKindName();
+    LOG(INFO) << "Verifying layer: " << layerName.data()
+              << "\tType: " << kName.data() << "\n";
+    auto refOuts = hookAndRun(layerName, bindings, /*isRef*/ true);
+    auto checkOuts = hookAndRun(layerName, bindings, /*isRef*/ false);
+    if (!checkTensors(refOuts.outputs, checkOuts.outputs)) {
+      LOG(ERROR) << "\tResults differ\n";
+      LOG(ERROR) << "\tDumping tensors\n";
+      dumpTensors(refOuts.outputs, layerName.data(), "ref_output");
+      dumpTensors(refOuts.inputs, layerName.data(), "input");
+      brokenLayers_.push_back(layerName);
+      allPassed = false;
+    }
+    inferBindingsCheck_.clear();
+    inferBindingsRef_.clear();
+    LOG(INFO) << "DONE Verifying layer: " << layerName.data() << "\n";
+  }
+  return allPassed;
+}
+RecursiveLayerComparator::RecursiveLayerComparator(
+    Module &mod, const std::string &referenceBackend,
+    const std::string &testBackend, float numericCmpThreshold,
+    bool dumpTensorsForBadLayer)
+    : NetworkComparatorBase(mod, referenceBackend, testBackend,
+                            numericCmpThreshold, dumpTensorsForBadLayer) {}
+
+void IntermediateLayerComparator::hookSingleNodeInPlace(
+    Node &node, std::list<SaveNode *> &saveNodes,
+    std::list<Placeholder *> &hookPlaceholders) {
+  std::string layerName = node.getName();
+  for (unsigned i = 0; i < node.getNumResults(); ++i) {
+    std::string saveName = node.getOutputName(i);
+    saveName += "_" + layerName + "_hook";
+    SaveNode *save =
+        node.getParent()->createSave(saveName, node.getNthResult(i));
+    saveNodes.emplace_back(save);
+    hookPlaceholders.emplace_back(save->getPlaceholder());
+  }
+}
+void IntermediateLayerComparator::hookNodesInPlace(
+    Function *func, std::list<SaveNode *> &saveNodes,
+    std::list<Placeholder *> &hookPlaceholders) {
+  DEBUG_GLOW(LOG(INFO) << "Before hooking the function: " << func->dumpDAG());
+  for (Node &node : func->getNodes()) {
+    if (llvm::isa<SaveNode>(&node) || llvm::isa<Constant>(&node) ||
+        llvm::isa<Placeholder>(&node)) {
+      continue;
+    }
+    hookSingleNodeInPlace(node, saveNodes, hookPlaceholders);
+  }
+  DEBUG_GLOW(LOG(INFO) << "After hooking the function: " << func->dumpDAG());
+}
+
+void IntermediateLayerComparator::copyInputBindingsToHookedBindings(
+    PlaceholderBindings &hookedBindigs, PlaceholderBindings &inputBindings) {
+  // Copy tensors from input bindings to the bindings we use for Inference.
+  for (auto PH : inputBindings.pairs()) {
+    auto iPH = hookedBindigs.getPlaceholderByName(PH.first->getName());
+    hookedBindigs.get(iPH)->assign(PH.second);
+  }
+}
+
+void IntermediateLayerComparator::getIntermediateResults(
+    ExecutionEngine &networkExecEngine, PlaceholderBindings *inputBindings,
+    PlaceholderBindings &hookedBindigs) {
+  std::list<SaveNode *> saveNodes;
+  std::list<Placeholder *> hookPlaceholders;
+  Function *func = networkExecEngine.getSingleFunctionFromModule();
+  std::string newName = func->getName();
+  Function *hookedFunction = func->clone(newName + "_hooked");
+  // Instrument all the nodes in hookedFunction by inserts Save nodes.
+  hookNodesInPlace(hookedFunction, saveNodes, hookPlaceholders);
+  hookedBindigs.allocate(networkExecEngine.getModule().getPlaceholders());
+  // Copy values from inputBindings to the allocated hookedBindigs.
+  copyInputBindingsToHookedBindings(hookedBindigs, *inputBindings);
+  networkExecEngine.compile(CompilationMode::Infer);
+  networkExecEngine.run(hookedBindigs, hookedFunction->getName());
+  DEBUG_GLOW(LOG(INFO) << "Network has " << hookPlaceholders.size()
+                       << " hooks inserted and " << hookedBindigs.pairs().size()
+                       << " total bindings");
+  DEBUG_GLOW(LOG(INFO) << "Network after running and compiling the function: "
+                       << hookedFunction->dumpDAG());
+  hookedFunction->getParent()->eraseFunction(hookedFunction);
+}
+
+void IntermediateLayerComparator::fillSingleLayerInputs(
+    const Node &originalNode, Node *singleLayerNode, Module &singleLayerMod,
+    std::unordered_map<std::string, Tensor *> &singleLayerInputMap,
+    PlaceholderBindings &singleLayerBindings) {
+  // Copy the types used in the node to the singleLayerModule.
+  for (unsigned idx = 0, e = singleLayerNode->getNumResults(); idx < e; ++idx) {
+    singleLayerNode->setType(
+        idx, singleLayerMod.uniqueType(*singleLayerNode->getType(idx)));
+  }
+
+  for (size_t idx = 0; idx < originalNode.getNumInputs(); idx++) {
+    size_t resNo = originalNode.getNthInput(idx).getResNo();
+    Node *inputNode = originalNode.getNthInput(idx).getNode();
+    std::string hookedPlaceholderName = inputNode->getName();
+    Node *inputToFeed = nullptr;
+    DCHECK(!llvm::isa<SaveNode>(inputNode))
+        << "SaveNode as an input was not hooked!";
+    if (llvm::isa<Constant>(inputNode)) {
+      // Constants live in the module, getting them from the reloaded
+      // module. They get deleted after running.
+      DEBUG_GLOW(LOG(INFO) << "\t\tInput name: " << hookedPlaceholderName
+                           << " NodeType: " << inputNode->getKindName()
+                           << "\n");
+      Constant *constNode =
+          inputModule_->getConstantByName(hookedPlaceholderName);
+      DCHECK(constNode) << "Constant not found\n";
+      Tensor &payLoad = constNode->getPayloadMutable();
+      inputToFeed = singleLayerMod.createConstant(constNode->getName(), payLoad,
+                                                  constNode->getLayout());
+      singleLayerInputMap[originalNode.getInputName(idx)] = &payLoad;
+    } else {
+      if (!llvm::isa<Placeholder>(inputNode)) {
+        // If the input is placeholder the name stays the
+        // same since these don't get hooked.
+        std::string outputName = inputNode->getOutputName(resNo);
+        hookedPlaceholderName =
+            outputName + "_" + hookedPlaceholderName + "_hook";
+      }
+      DEBUG_GLOW(LOG(INFO) << "\t\tInput name: " << hookedPlaceholderName
+                           << " NodeType: " << inputNode->getKindName()
+                           << "\n");
+      Placeholder *PH =
+          refHookedBindings_.getPlaceholderByName(hookedPlaceholderName);
+      DCHECK(PH) << "Placeholder not found in the hooked bindings";
+      Tensor *payloadTensor = refHookedBindings_.get(PH);
+      Placeholder *singleLayerPH = singleLayerMod.createPlaceholder(
+          PH->getType(), PH->getName(), PH->isTraining(), PH->getLayout());
+      singleLayerBindings.allocate(singleLayerPH);
+      singleLayerBindings.get(singleLayerPH)->assign(payloadTensor);
+      inputToFeed = singleLayerPH;
+      singleLayerInputMap[originalNode.getInputName(idx)] = payloadTensor;
+    }
+    singleLayerNode->setNthInput(idx, inputToFeed);
+  }
+}
+
+void IntermediateLayerComparator::runAndGetoutputSingleLayer(
+    ExecutionEngine &singleLayerExecEng,
+    PlaceholderBindings &singleLayerBindings, Node *singleLayerNode,
+    std::unordered_map<std::string, Tensor *> &singleLayerOutputs,
+    std::unordered_map<std::string, Tensor *> &refOutputs) {
+  std::list<SaveNode *> singleLayerSaveNodes;
+  std::list<Placeholder *> singleLayerOutputPHs;
+  hookSingleNodeInPlace(*singleLayerNode, singleLayerSaveNodes,
+                        singleLayerOutputPHs);
+  singleLayerBindings.allocate(singleLayerOutputPHs);
+  DEBUG_GLOW(LOG(INFO) << "\t\tSingle layer network"
+                       << singleLayerNode->getParent()->dumpDAG());
+  singleLayerExecEng.compile(CompilationMode::Infer);
+  singleLayerExecEng.run(singleLayerBindings);
+  for (Placeholder *PH : singleLayerOutputPHs) {
+    singleLayerOutputs[PH->getName()] = singleLayerBindings.get(PH);
+    Placeholder *refPH = refHookedBindings_.getPlaceholderByName(PH->getName());
+    refOutputs[PH->getName()] = refHookedBindings_.get(refPH);
+  }
+}
+
+bool IntermediateLayerComparator::testSingleLayer(const Node *node) {
+  bool pass = true;
+  std::unordered_map<std::string, Tensor *> singleLayerInputMap;
+  ExecutionEngine singleLayerExecEng(EETestNet_.getBackendName());
+  PlaceholderBindings singleLayerBindings;
+  Module &singleLayerMod = singleLayerExecEng.getModule();
+  Function *singleLayerFunc = singleLayerMod.createFunction(node->getName());
+  Node *singleLayerNode = node->clone();
+  llvm::StringRef layerName = node->getName();
+  llvm::StringRef kindName = node->getKindName();
+  LOG(INFO) << "Verifying layer: " << layerName.data()
+            << "\tType: " << kindName.data() << "\n";
+  singleLayerFunc->addNode(singleLayerNode);
+  // 1) Dynamically build a net made out of one layer and feed the
+  // placeholders in.
+  fillSingleLayerInputs(*node, singleLayerNode, singleLayerMod,
+                        singleLayerInputMap, singleLayerBindings);
+  // 2) Run the network and get outputs.
+  std::unordered_map<std::string, Tensor *> singleLayerOutputs;
+  std::unordered_map<std::string, Tensor *> refOutputs;
+  runAndGetoutputSingleLayer(singleLayerExecEng, singleLayerBindings,
+                             singleLayerNode, singleLayerOutputs, refOutputs);
+  if (!checkTensors(refOutputs, singleLayerOutputs)) {
+    LOG(ERROR) << "\tResults differ\n";
+    LOG(ERROR) << "\tDumping tensors\n";
+    dumpTensors(refOutputs, layerName, "ref_output");
+    dumpTensors(singleLayerInputMap, layerName, "input");
+    brokenLayers_.push_back(layerName);
+    pass = false;
+  }
+  LOG(INFO) << "DONE Verifying layer: " << layerName.data() << "\n";
+  return pass;
+}
+
+bool IntermediateLayerComparator::verify(PlaceholderBindings *bindings) {
+  bool allPassed = true;
+  // Instrument all the layers with Save nodes.
+  getIntermediateResults(EERefNet_, bindings, refHookedBindings_);
+  getIntermediateResults(EETestNet_, bindings, testHookedBindings_);
+  if (refHookedBindings_.compare(&refHookedBindings_, &testHookedBindings_,
+                                 numericCmpThreshold_)) {
+    LOG(INFO) << "All intermediate results match.";
+    return true;
+  }
+  // Sort the nodes in topological order to test nodes in that order.
+  // Tensors flow through the network in topological order, testing the layers
+  // in that order will allow us to see how errors propagate.
+  Function *func = *inputModule_->getFunctions().begin();
+  GraphPostOrderVisitor visitor(*func);
+  llvm::ArrayRef<Node *> order = visitor.getPostOrder();
+  for (auto const *nodePtr : order) {
+    if (llvm::isa<SaveNode>(nodePtr) || llvm::isa<Constant>(nodePtr) ||
+        llvm::isa<Placeholder>(nodePtr)) {
+      continue;
+    }
+    allPassed &= testSingleLayer(nodePtr);
+  }
+  return allPassed;
+}
+
+IntermediateLayerComparator::IntermediateLayerComparator(
+    Module &mod, const std::string &referenceBackend,
+    const std::string &testBackend, float numericCmpThreshold,
+    bool dumpTensorsForBadLayer)
+    : NetworkComparatorBase(mod, referenceBackend, testBackend,
+                            numericCmpThreshold, dumpTensorsForBadLayer) {}

--- a/tools/Debugger/NetworkComparator.h
+++ b/tools/Debugger/NetworkComparator.h
@@ -1,0 +1,195 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_GRAPH_NETWORKCOMPARATOR_H
+#define GLOW_GRAPH_NETWORKCOMPARATOR_H
+
+#include "glow/ExecutionEngine/ExecutionEngine.h"
+#include "glow/Graph/Graph.h"
+#include "glow/Graph/PlaceholderBindings.h"
+#include "llvm/ADT/StringRef.h"
+#include <list>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace glow {
+
+class Function;
+class Node;
+class Placeholder;
+class SaveNode;
+class Tensor;
+class Module;
+
+/// Base class for building a comparator that takes an input network \p
+/// inputModule_ and run it on two backends; a test backend and a reference
+/// backend and saves the list of layers that generate wrong results on the test
+/// net in \p brokenLayers_ . This class has a pure virtual function (verify)
+/// that must be implemented by a subclass.
+class NetworkComparatorBase {
+public:
+  /// Struct to save the list of input and output tensors of a node\layer.
+  struct InOutTensors {
+    std::unordered_map<std::string, Tensor *> inputs;
+    std::unordered_map<std::string, Tensor *> outputs;
+  };
+
+protected:
+  /// Execution Engine to run the Network tested on the reference backend.
+  ExecutionEngine EERefNet_;
+  /// Execution Engine to run the Network tested on the test backend.
+  ExecutionEngine EETestNet_;
+  /// Stores layer names found to be broken on the test backend.
+  std::vector<std::string> brokenLayers_;
+  /// Threshold of numerical comparison for tensors.
+  float numericCmpThreshold_;
+  /// Pointer to the module being tested.
+  Module *inputModule_;
+
+  /// Dump input\output tensors of a bad layer.
+  bool dumpTensorsForBadLayer_;
+  /// Prints out the input or output \p tensors associated with a \p layerName
+  /// the output file is a concatenation of the \p prefix and the \p layerName.
+  virtual void dumpTensors(std::unordered_map<std::string, Tensor *> tensors,
+                           const std::string &layerName,
+                           const std::string &prefix);
+  /// Compares tensors in \p refOuts with tensors in \p checkOuts using the
+  /// isEqual Tensor method.
+  bool checkTensors(std::unordered_map<std::string, Tensor *> &refOuts,
+                    std::unordered_map<std::string, Tensor *> &checkOuts);
+
+public:
+  /// Constructor for the base class tester that tests the network passed in
+  /// \p mod on the \p testBackend using the \p referenceBackend as a reference
+  /// backend. \p numericCmpThreshold is accepted error threshold.
+  /// Inputs\outputs of a detected bad layer are dumped if \p
+  /// dumpTensorsForBadLayer is set.
+  NetworkComparatorBase(Module &mod, const std::string &referenceBackend,
+                        const std::string &testBackend,
+                        float numericCmpThreshold, bool dumpTensorsForBadLayer);
+  virtual ~NetworkComparatorBase() {}
+  /// Test the network with the inputs passed in \p bindings. The function
+  /// is pure virtual to be implemented by the underlying strategy in sub
+  /// classes. \returns True if all checks passed.
+  virtual bool verify(PlaceholderBindings *bindings) = 0;
+};
+
+/// A comparator class that tests layers by creating a subnet of the original
+/// graph for every layer. The subnets are created by recursively visiting the
+/// inputs of the layer. The results or running the subnet are compared between
+/// the test and reference backend. The subnet might have more than one broken
+/// layer.
+class RecursiveLayerComparator : public NetworkComparatorBase {
+private:
+  PlaceholderBindings inferBindingsRef_;
+  PlaceholderBindings inferBindingsCheck_;
+  /// Takes a \p layerName, creates a subnet comprised of all the predecessor
+  /// nodes till the inputs. The outputs of this layer are saved in the
+  /// inferenceBindingsRef if \p isRef is true and in inferenceBindingsCheck if
+  /// false. The inputs are passed in \p bindings. The run saves the inputs to
+  /// the layer \p layerName.
+  NetworkComparatorBase::InOutTensors hookAndRun(llvm::StringRef layerName,
+                                                 PlaceholderBindings *bindings,
+                                                 bool isRef);
+
+public:
+  /// Constructor for the RecursiveLayerComparator tester that tests the network
+  /// passed in \p mod on the \p testBackend using the \p referenceBackend as a
+  /// reference backend. \p numericCmpThreshold_. Inputs\outputs of
+  /// a detected bad layer are dumped if \p dumpTensorsForBadLayer is set.
+  RecursiveLayerComparator(Module &mod, const std::string &referenceBackend,
+                           const std::string &testBackend,
+                           float numericCmpThreshold_,
+                           bool dumpTensorsForBadLayer);
+  /// Takes the \p bindings as an input. For every layer in the Network creates
+  /// a subnet comprised of all the predecessor nodes till the placeholders.
+  /// This subnet is compiled and run on the reference and on the test backend
+  /// and results are compared.
+  bool verify(PlaceholderBindings *bindings);
+};
+
+/// A comparator class that first tests layer all at once to find suspicious
+/// layers that are different between the reference and test backends runs. Then
+/// all the layers are tested one layer at a time to find out which
+/// of them are actually producing wrong results on their own and not as a
+/// result of errors in any previous layers.
+class IntermediateLayerComparator : public NetworkComparatorBase {
+private:
+  /// Save results (including intermediates) for running the network on the
+  /// reference backend.
+  PlaceholderBindings refHookedBindings_;
+  /// Save results (including intermediates) for running the network on the test
+  /// backend.
+  PlaceholderBindings testHookedBindings_;
+  /// Inserts Save Nodes for the outputs of \p node and saves them in \p
+  /// saveNodes and the placeholders in \p hookPlaceholders.
+  void hookSingleNodeInPlace(Node &node, std::list<SaveNode *> &saveNodes,
+                             std::list<Placeholder *> &hookPlaceholders);
+  /// Hook outputs of all the layers in \p func and saves the pointers to
+  /// the inserted Save nodes and corresponding placeholders in \p saveNodes
+  /// and \p hookPlaceholders.
+  void hookNodesInPlace(Function *func, std::list<SaveNode *> &saveNodes,
+                        std::list<Placeholder *> &hookPlaceholders);
+  /// Populate tensors in \p  hookedBindigs with values from inputBindings.
+  void copyInputBindingsToHookedBindings(PlaceholderBindings &hookedBindigs,
+                                         PlaceholderBindings &inputBindings);
+  /// Uses the \p networkExecEngine to get all the intermediate results of
+  /// running the network and save the results in \p hookedBindigs. Uses \p
+  /// inputBindings for inputs for the run.
+  void getIntermediateResults(ExecutionEngine &networkExecEngine,
+                              PlaceholderBindings *inputBindings,
+                              PlaceholderBindings &hookedBindigs);
+  /// Takes \p originalNode , that represents the layer being tested,
+  /// and fills in the inputs of \p singleLayerNode with placeholders from
+  /// running the hooked network on a ref backend or constants
+  /// from the original module. Saves the inputs in \p singleLayerInputMap and
+  /// the placeholders in \p singleLayerBindings.
+  void fillSingleLayerInputs(
+      const Node &originalNode, Node *singleLayerNode, Module &singleLayerMod,
+      std::unordered_map<std::string, Tensor *> &singleLayerInputMap,
+      PlaceholderBindings &singleLayerBindings);
+  /// Runs the network made of a single layer \p singleLayerNode that is getting
+  /// tested. The outputs are saved in \p singleLayerOutputs and bindings in \p
+  /// singleLayerBindings \p refOutputs are populated fron the reference
+  /// bindings run.
+  void runAndGetoutputSingleLayer(
+      ExecutionEngine &singleLayerExecEng,
+      PlaceholderBindings &singleLayerBindings, Node *singleLayerNode,
+      std::unordered_map<std::string, Tensor *> &singleLayerOutputs,
+      std::unordered_map<std::string, Tensor *> &refOutputs);
+  /// Tests a single layer node passed in \p node.
+  bool testSingleLayer(const Node *node);
+
+public:
+  /// Constructor for the IntermediateLayerComparator tester that tests the
+  /// network passed in \p mod on the \p testBackend using the \p
+  /// referenceBackend as a reference backend. \p numericCmpThreshold_.
+  /// Inputs\outputs of a detected bad layer are dumped if \p
+  /// dumpTensorsForBadLayer is set.
+  IntermediateLayerComparator(Module &mod, const std::string &referenceBackend,
+                              const std::string &testBackend,
+                              float numericCmpThreshold,
+                              bool IntermediateLayerComparator);
+  /// Takes the \p bindings as an input. For every layer in the Network creates
+  /// a subnet comprised of all the predecessor nodes till the placeholders.
+  /// This subnet is compiled and run on the reference and on the test backend
+  /// and results are compared.
+  virtual bool verify(PlaceholderBindings *bindings) override;
+};
+
+} // namespace glow
+
+#endif // GLOW_GRAPH_NETWORKCOMPARATOR_H

--- a/tools/Debugger/network-debugger.cpp
+++ b/tools/Debugger/network-debugger.cpp
@@ -1,0 +1,178 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ *  This is a debugging tool that can be used to detect errors in a test
+ * backend. it works by loading a model from a protobuf file, compile this model
+ * on two backends; a reference backend (Interpreter) and a a test backend. It
+ * compares the results from running these networks on a layer by layer fashion
+ * to detect which layer generated wrong results.
+ *
+ *  Sample run line:
+ *  ./network-debuger --model function_0.zip --inputs input_0.onnx -backend=CPU
+ *
+ *  The tool will print to screen when a faulty layer is detected. Input and
+ * output tensors for the layers will be printed from the reference network to
+ * disk.
+ *
+ */
+
+#include "glow/ExecutionEngine/ExecutionEngine.h"
+#include "glow/Exporter/ONNXModelWriter.h"
+#include "glow/Importer/ONNXModelLoader.h"
+#include "glow/Support/Debug.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Signals.h"
+
+#include "NetworkComparator.h"
+#include "glow/Converter/Float16Converter.h"
+
+#include <string>
+
+using namespace glow;
+
+namespace {
+llvm::cl::OptionCategory debuggerTestCat("Debugger Category");
+
+llvm::cl::opt<std::string> modelPathOpt("model", llvm::cl::desc("Input models"),
+                                        llvm::cl::value_desc("modelPath"),
+                                        llvm::cl::Required,
+                                        llvm::cl::cat(debuggerTestCat));
+llvm::cl::list<std::string> inputsOpt("inputs", llvm::cl::desc("Inputs"),
+                                      llvm::cl::value_desc("Inputs"),
+                                      llvm::cl::Required, llvm::cl::OneOrMore,
+                                      llvm::cl::cat(debuggerTestCat));
+llvm::cl::opt<std::string>
+    testBackend("backend",
+                llvm::cl::desc("Backend to use, e.g. Interpreter, CPU, NNPI:"),
+                llvm::cl::init("Interpreter"), llvm::cl::cat(debuggerTestCat));
+
+llvm::cl::opt<std::string> comparatorType(
+    "comparator",
+    llvm::cl::desc("The type of comparator to use, Recursive or Intermediate"),
+    llvm::cl::init("Intermediate"), llvm::cl::cat(debuggerTestCat));
+
+llvm::cl::opt<float> numericCmpThreshold(
+    "threshold", llvm::cl::desc("Threshold for tensor numeric comparison"),
+    llvm::cl::Optional, llvm::cl::init(1e-5), llvm::cl::cat(debuggerTestCat));
+
+llvm::cl::opt<bool> dumpTensors(
+    "dump_tensors",
+    llvm::cl::desc("Dump input(s)\\output(s) of an errant layer to files."),
+    llvm::cl::Optional, llvm::cl::init(false), llvm::cl::cat(debuggerTestCat));
+
+llvm::cl::opt<bool>
+    globalFp16Opt("glow_global_fp16",
+                  llvm::cl::desc("Enable fp16 lowering for all ops on the net"),
+                  llvm::cl::Optional, llvm::cl::cat(debuggerTestCat));
+
+llvm::cl::opt<bool> fuseScaleOffsetFp16Opt(
+    "glow_global_fused_scale_offset_fp16",
+    llvm::cl::desc(
+        "Enable fp16 lowering for all op inputs using fused scale/offset"),
+    llvm::cl::Optional, llvm::cl::cat(debuggerTestCat));
+
+llvm::cl::opt<bool>
+    ClipFp16Opt("glow_clip_fp16",
+                llvm::cl::desc("Force glow to clip fp16 values to min/max"),
+                llvm::cl::Optional, llvm::cl::cat(debuggerTestCat));
+
+llvm::cl::opt<bool>
+    forceFP16AccumSLSOpt("glow_global_force_sls_fp16_accum",
+                         llvm::cl::desc("Force FP16 accumulation for SLS ops"),
+                         llvm::cl::Optional, llvm::cl::cat(debuggerTestCat));
+
+#define DEBUG_TYPE "verifier"
+
+void parseCommandLine(int argc, char **argv) {
+  llvm::sys::PrintStackTraceOnErrorSignal(argv[0]);
+  llvm::cl::ParseCommandLineOptions(
+      argc, argv,
+      " Network Debugger tool, part of the Glow compiler\n\n"
+      "Glow is a compiler for neural network accelerators.\n");
+}
+
+// Utility functions:
+void convertNetwork(Function *F) {
+  CompilationContext cctx;
+  PrecisionConfiguration precConfig;
+  if (globalFp16Opt) {
+    precConfig.convertToFP16 = globalFp16Opt;
+  }
+  if (fuseScaleOffsetFp16Opt) {
+    precConfig.convertFusedToFP16 = fuseScaleOffsetFp16Opt;
+  }
+  if (ClipFp16Opt) {
+    precConfig.clipFP16 = ClipFp16Opt;
+  }
+  if (forceFP16AccumSLSOpt) {
+    precConfig.forceFP16AccumSLS = true;
+  }
+  // Convert Network to fp16.
+  if (globalFp16Opt || fuseScaleOffsetFp16Opt || ClipFp16Opt ||
+      forceFP16AccumSLSOpt)
+    glow::convertFunctionToFloat16(F, precConfig);
+
+  // Optimize network after conversion to remove unneeded converts.
+  glow::optimize(F, CompilationMode::Infer);
+}
+void loadModelIntoFunc(Function *F) {
+  Error err = Error::empty();
+  { ONNXModelLoader onnxLD(modelPathOpt, {}, {}, *F, &err, /*zipMode*/ true); }
+  CHECK(!ERR_TO_BOOL(std::move(err)))
+      << "ONNXModelLoader failed to load model: " << modelPathOpt;
+  convertNetwork(F);
+}
+
+bool run() {
+  LOG(INFO) << "Comparing the " << testBackend
+            << " backend against the Interpreter "
+               "(reference backend)";
+  Module mod;
+  bool allPass = true;
+  loadModelIntoFunc(mod.createFunction("test"));
+  // Create a Comparator based on the type.
+  // NetworkComparatorBase *netCompare;
+  std::unique_ptr<NetworkComparatorBase> netCompare;
+  if (comparatorType == "comparatorType") {
+    netCompare.reset(new IntermediateLayerComparator(
+        mod, "Interpreter", testBackend, numericCmpThreshold, dumpTensors));
+  } else {
+    netCompare.reset(new RecursiveLayerComparator(
+        mod, "Interpreter", testBackend, numericCmpThreshold, dumpTensors));
+  }
+  PlaceholderBindings inputBindings;
+  inputBindings.allocate(mod.getPlaceholders());
+  for (size_t idx = 0; idx != inputsOpt.size(); idx++) {
+    fillPlaceholders(inputsOpt[idx], &inputBindings);
+    // Test the network with these inputs
+    allPass &= netCompare->verify(&inputBindings);
+    inputBindings.clear();
+  }
+  return allPass;
+}
+} // namespace
+
+int main(int argc, char **argv) {
+  parseCommandLine(argc, argv);
+  if (run()) {
+    LOG(INFO) << "All layers match with no errors\n";
+    return 0;
+  } else {
+    LOG(ERROR) << "Errors found!";
+    return -1;
+  }
+}


### PR DESCRIPTION
This PR introduces a tool called networkDebugger, this tool allows us
to compare runs of the network, layer by layer, on a reference backend
and a test backend.

The tool itself is an example of how to use the underlying functionality
implemented in Network Comparator and it could be used in any other
fashion.

Documentation:
 Added an md file to describe the work.
 Partially addresses #3845

Test Plan:
  ran the tool to detect errors on an internal network with a new backend.

