### PR TITLE
fix tests/Repro assertion failure due to wrong Error returned

### DIFF
--- a/tests/unittests/Repro.cpp
+++ b/tests/unittests/Repro.cpp
@@ -187,7 +187,7 @@ void parseCommandLine(int argc, char **argv) {
 }
 
 struct InferenceResult {
-  Error error = Error::success();
+  Error error = Error::empty();
   std::unique_ptr<ExecutionContext> ctx;
   int index = 0;
 };


### PR DESCRIPTION
Fix assertion failure caused by https://github.com/pytorch/glow/pull/4014 (wrongly return "Error:success" which should be "Error:empty()").