### PR TITLE
Add an opt-in backend option to delay the actual quantization of constant 

### DIFF
--- a/include/glow/Backend/Backend.h
+++ b/include/glow/Backend/Backend.h
@@ -116,6 +116,10 @@ public:
     return false;
   }
 
+  /// \returns true if Constants must be actually quantized before
+  /// Post-Lowering, false if it must be done after post-lowering.
+  virtual bool shouldPreQuantizeConstants() const { return true; }
+
   /// \returns whether the provided \p NI is supported by the backend.
   virtual bool isOpSupported(const NodeInfo &NI) const = 0;
 

--- a/include/glow/Optimizer/GraphOptimizer/GraphOptimizer.h
+++ b/include/glow/Optimizer/GraphOptimizer/GraphOptimizer.h
@@ -42,6 +42,9 @@ void optimize(Function *F, CompilationContext &cctx, const Backend &B);
 /// Fold nodes that were expressed lowered in the input model.
 void fold(Function *F, CompilationContext &cctx, const Backend *B = nullptr);
 
+/// Performs the actual constant quantization in function \p F.
+void convertQuantizedConstants(Function *F, CompilationContext &cctx);
+
 /// Lower the high-level neural network nodes found in \p F into low-level
 /// linear algebra operators. If \p B is not a nullptr then it can prevent
 /// lowering of a node via \ref Backend::shouldLower(); otherwise everything

--- a/lib/Optimizer/GraphOptimizer/ConstantFolding.cpp
+++ b/lib/Optimizer/GraphOptimizer/ConstantFolding.cpp
@@ -47,6 +47,11 @@ bool isConstantOperation(const Node *N, const Backend &backend) {
   if (N->hasSideEffects()) {
     return false;
   }
+  // Quantize nodes are not handled by ConstantFolding but by a specific
+  // quantization specific optimization.
+  if (isa<QuantizeNode>(N)) {
+    return false;
+  }
   // Constant and splat nodes are trivially constant operations.
   if (isa<Constant>(N) || isa<SplatNode>(N)) {
     return true;

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -205,6 +205,7 @@ protected:
 
 /// MockBackend used only for unit testing.
 class MockBackend : public Backend {
+public:
   class MockFunction : public CompiledFunction {
   public:
     MockFunction(runtime::RuntimeBundle &&bundle)
@@ -212,10 +213,10 @@ class MockBackend : public Backend {
 
     Error execute(ExecutionContext *) override { return Error::success(); }
 
-    std::string getCompileBackendName() const override { return "Interpreter"; }
+    std::string getCompileBackendName() const override { return "MockBackend"; }
   };
 
-  std::string getBackendName() const override { return "Interpreter"; }
+  std::string getBackendName() const override { return "MockBackend"; }
 
   Expected<std::unique_ptr<CompiledFunction>>
   compile(Function *F, const BackendOptions &) const override {

--- a/tests/unittests/QuantizationTest.cpp
+++ b/tests/unittests/QuantizationTest.cpp
@@ -1964,6 +1964,8 @@ TEST(Quantization, quantizeFunctionConvertConstant) {
   quantization::quantizeFunction(F, quantConfig, *backend);
 
   optimize(F, CompilationMode::Infer);
+  CompilationContext cctx;
+  convertQuantizedConstants(F, cctx);
 
   {
     // Verify that the output variable is not quantized, and that it has a


### PR DESCRIPTION
**Summary**: Add an opt-in backend option to delay the actual quantization of constant tensors after post-lowering. For us, letting the backend handle itself some aspects of the quantization is fundamental. For doing this in a lossless manner, we need to delay the actual quantization of constant (Quantize(Constant) -> Constant)

**Documentation**: N/A

**Fixes** #2165 #2481

**Test Plan**: Added a mock backend tests to check at what time the actual constant quantization is done, depending on the backend option. Changed existing related tests to reflect the code change. 


