### PR TITLE
repro: add a flag to keep slice and concat in fp32 when doing glow_global_fp16

### DIFF
--- a/lib/Backends/NNPI/tests/NNPIParameterSweepTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIParameterSweepTest.cpp
@@ -18,3 +18,137 @@
 using namespace glow;
 
 std::set<std::string> glow::backendTestBlacklist = {};
+struct SoftwareOnlyTests {
+  SoftwareOnlyTests() {
+    auto useNnpiThreshold = getenv("USE_NNPI_THRESHOLD");
+    if (!useNnpiThreshold || strcmp(useNnpiThreshold, "1") != 0) {
+      backendTestBlacklist = {
+          "BatchMatMulTest_Int8/39", "BatchMatMulTest_Int8/43",
+          "BatchMatMulTest_Int8/46", "BatchMatMulTest_Int8/51",
+          "BatchMatMulTest_Int8/54", "BatchMatMulTest_Int8/59",
+          "BatchMatMulTest_Int8/63", "BatchMatMulTest_Int8/67",
+          "BatchMatMulTest_Int8/71", "BatchMatMulTest_Int8/75",
+          "BatchMatMulTest_Int8/83", "BatchMatMulTest_Int8/87",
+          "BatchMatMulTest_Int8/90", "BatchMatMulTest_Int8/91",
+          "BatchMatMulTest_Int8/95", "FCTest_Int8/139",
+      };
+      for (int i = 0; i < 80; i++) {
+        backendTestBlacklist.insert("RWQSLWS_Float16_AccumFloat16/" +
+                                    std::to_string(i));
+      }
+      for (int i = 0; i < 80; i++) {
+        backendTestBlacklist.insert("FRWQSLWS_Float16_AccumFloat16/" +
+                                    std::to_string(i));
+      }
+    }
+  }
+} softwareOnlyTests;
+struct EmulatorOnlyTests {
+  EmulatorOnlyTests() {
+    auto useNnpiThreshold = getenv("USE_NNPI_THRESHOLD");
+    if (!useNnpiThreshold || strcmp(useNnpiThreshold, "1") != 0) {
+      auto useInfAPI = getenv("USE_INF_API");
+      if (useInfAPI && !strcmp(useInfAPI, "1")) {
+        backendTestBlacklist = {
+            "BatchMatMulTest_Float16/2",  "BatchMatMulTest_Float16/3",
+            "BatchMatMulTest_Float16/6",  "BatchMatMulTest_Float16/7",
+            "BatchMatMulTest_Float16/10", "BatchMatMulTest_Float16/11",
+            "BatchMatMulTest_Float16/14", "BatchMatMulTest_Float16/15",
+            "BatchMatMulTest_Float16/18", "BatchMatMulTest_Float16/19",
+            "BatchMatMulTest_Float16/21", "BatchMatMulTest_Float16/22",
+            "BatchMatMulTest_Float16/23", "BatchMatMulTest_Float16/25",
+            "BatchMatMulTest_Float16/26", "BatchMatMulTest_Float16/27",
+            "BatchMatMulTest_Float16/30", "BatchMatMulTest_Float16/31",
+            "BatchMatMulTest_Float16/33", "BatchMatMulTest_Float16/34",
+            "BatchMatMulTest_Float16/35", "BatchMatMulTest_Float16/37",
+            "BatchMatMulTest_Float16/38", "BatchMatMulTest_Float16/39",
+            "BatchMatMulTest_Float16/41", "BatchMatMulTest_Float16/42",
+            "BatchMatMulTest_Float16/43", "BatchMatMulTest_Float16/45",
+            "BatchMatMulTest_Float16/46", "BatchMatMulTest_Float16/47",
+            "BatchMatMulTest_Float16/49", "BatchMatMulTest_Float16/50",
+            "BatchMatMulTest_Float16/51", "BatchMatMulTest_Float16/54",
+            "BatchMatMulTest_Float16/55", "BatchMatMulTest_Float16/58",
+            "BatchMatMulTest_Float16/59", "BatchMatMulTest_Float16/61",
+            "BatchMatMulTest_Float16/62", "BatchMatMulTest_Float16/63",
+            "BatchMatMulTest_Float16/65", "BatchMatMulTest_Float16/66",
+            "BatchMatMulTest_Float16/67", "BatchMatMulTest_Float16/69",
+            "BatchMatMulTest_Float16/70", "BatchMatMulTest_Float16/71",
+            "BatchMatMulTest_Float16/73", "BatchMatMulTest_Float16/74",
+            "BatchMatMulTest_Float16/75", "BatchMatMulTest_Float16/78",
+            "BatchMatMulTest_Float16/79", "BatchMatMulTest_Float16/81",
+            "BatchMatMulTest_Float16/82", "BatchMatMulTest_Float16/83",
+            "BatchMatMulTest_Float16/85", "BatchMatMulTest_Float16/86",
+            "BatchMatMulTest_Float16/87", "BatchMatMulTest_Float16/89",
+            "BatchMatMulTest_Float16/90", "BatchMatMulTest_Float16/91",
+            "BatchMatMulTest_Float16/93", "BatchMatMulTest_Float16/94",
+            "BatchMatMulTest_Float16/95", "BatchMatMulTest_Int8/39",
+            "BatchMatMulTest_Int8/43",    "BatchMatMulTest_Int8/46",
+            "BatchMatMulTest_Int8/51",    "BatchMatMulTest_Int8/54",
+            "BatchMatMulTest_Int8/59",    "BatchMatMulTest_Int8/63",
+            "BatchMatMulTest_Int8/67",    "BatchMatMulTest_Int8/71",
+            "BatchMatMulTest_Int8/75",    "BatchMatMulTest_Int8/83",
+            "BatchMatMulTest_Int8/87",    "BatchMatMulTest_Int8/90",
+            "BatchMatMulTest_Int8/91",    "BatchMatMulTest_Int8/95",
+            "ConvTest_Float16/3",         "ConvTest_Float16/7",
+            "ConvTest_Float16/9",         "ConvTest_Float16/11",
+            "FCTest_Float16/14",          "FCTest_Float16/17",
+            "FCTest_Float16/18",          "FCTest_Float16/19",
+            "FCTest_Float16/21",          "FCTest_Float16/22",
+            "FCTest_Float16/23",          "FCTest_Float16/24",
+            "FCTest_Float16/26",          "FCTest_Float16/27",
+            "FCTest_Float16/28",          "FCTest_Float16/29",
+            "FCTest_Float16/30",          "FCTest_Float16/31",
+            "FCTest_Float16/32",          "FCTest_Float16/33",
+            "FCTest_Float16/34",          "FCTest_Float16/47",
+            "FCTest_Float16/48",          "FCTest_Float16/49",
+            "FCTest_Float16/51",          "FCTest_Float16/52",
+            "FCTest_Float16/53",          "FCTest_Float16/54",
+            "FCTest_Float16/55",          "FCTest_Float16/56",
+            "FCTest_Float16/57",          "FCTest_Float16/58",
+            "FCTest_Float16/59",          "FCTest_Float16/60",
+            "FCTest_Float16/61",          "FCTest_Float16/62",
+            "FCTest_Float16/63",          "FCTest_Float16/64",
+            "FCTest_Float16/65",          "FCTest_Float16/66",
+            "FCTest_Float16/67",          "FCTest_Float16/68",
+            "FCTest_Float16/69",          "FCTest_Float16/83",
+            "FCTest_Float16/84",          "FCTest_Float16/86",
+            "FCTest_Float16/87",          "FCTest_Float16/88",
+            "FCTest_Float16/89",          "FCTest_Float16/90",
+            "FCTest_Float16/91",          "FCTest_Float16/92",
+            "FCTest_Float16/93",          "FCTest_Float16/94",
+            "FCTest_Float16/95",          "FCTest_Float16/96",
+            "FCTest_Float16/97",          "FCTest_Float16/98",
+            "FCTest_Float16/99",          "FCTest_Float16/100",
+            "FCTest_Float16/101",         "FCTest_Float16/102",
+            "FCTest_Float16/103",         "FCTest_Float16/104",
+            "FCTest_Float16/116",         "FCTest_Float16/117",
+            "FCTest_Float16/118",         "FCTest_Float16/119",
+            "FCTest_Float16/121",         "FCTest_Float16/122",
+            "FCTest_Float16/123",         "FCTest_Float16/124",
+            "FCTest_Float16/125",         "FCTest_Float16/126",
+            "FCTest_Float16/127",         "FCTest_Float16/128",
+            "FCTest_Float16/129",         "FCTest_Float16/130",
+            "FCTest_Float16/131",         "FCTest_Float16/132",
+            "FCTest_Float16/133",         "FCTest_Float16/134",
+            "FCTest_Float16/135",         "FCTest_Float16/136",
+            "FCTest_Float16/137",         "FCTest_Float16/138",
+            "FCTest_Float16/139",         "FCTest_Int8/139",
+        };
+        for (int i = 0; i < 80; i++) {
+          backendTestBlacklist.insert("RWQSLWS_Float16/" + std::to_string(i));
+        }
+        for (int i = 0; i < 80; i++) {
+          backendTestBlacklist.insert("FRWQSLWS_Float16/" + std::to_string(i));
+        }
+        for (int i = 0; i < 80; i++) {
+          backendTestBlacklist.insert("RWQSLWS_Float16_AccumFloat16/" +
+                                      std::to_string(i));
+        }
+        for (int i = 0; i < 80; i++) {
+          backendTestBlacklist.insert("FRWQSLWS_Float16_AccumFloat16/" +
+                                      std::to_string(i));
+        }
+      }
+    }
+  }
+} emuTests;

--- a/tests/unittests/Repro.cpp
+++ b/tests/unittests/Repro.cpp
@@ -102,6 +102,13 @@ llvm::cl::opt<bool>
                   llvm::cl::desc("Enable fp16 lowering for all ops on the net"),
                   llvm::cl::Optional, llvm::cl::init(true),
                   llvm::cl::cat(reproTestCat));
+
+llvm::cl::opt<bool> sliceConcatFp32Opt(
+    "glow_slice_concat_fp32",
+    llvm::cl::desc("Don't convert slice and concat ops's precision when "
+                   "--glow_global_fp16 is used."),
+    llvm::cl::Optional, llvm::cl::init(false), llvm::cl::cat(reproTestCat));
+
 llvm::cl::opt<bool> dumpOutputsOpt("dump_outputs",
                                    llvm::cl::desc("Dump output tensors"),
                                    llvm::cl::Optional, llvm::cl::init(true),
@@ -209,6 +216,10 @@ int run() {
   PrecisionConfiguration precConfig;
   if (globalFp16Opt) {
     precConfig.convertToFP16 = globalFp16Opt;
+    if (sliceConcatFp32Opt) {
+      precConfig.precisionModeKindSet.insert(Kinded::Kind::SliceNodeKind);
+      precConfig.precisionModeKindSet.insert(Kinded::Kind::ConcatNodeKind);
+    }
     llvm::outs() << "Conversion to fp16 enabled\n";
   }
   if (fuseScaleOffsetFp16Opt) {


### PR DESCRIPTION
Summary: This is a temporary flag that demonstrate a workaround for a known bug in one of the backends. This will be removed once the underlying bug is resolved.

Reviewed By: yinghai

Differential Revision: D19559354

