### PR TITLE
Some further progress in making backends more self-contained

### DIFF
--- a/cmake/modules/GlowExternalBackends.cmake
+++ b/cmake/modules/GlowExternalBackends.cmake
@@ -120,6 +120,29 @@ FOREACH(child ${SUBDIRS})
 ENDFOREACH()
 ENDMACRO()
 
+# Macro to add backend specific ONNX model writers.
+MACRO(ExternalBackendsCollectONNXModelWriters)
+set(Exporter_Include_DIR ${GLOW_BINARY_DIR}/glow)
+getSubDirList(SUBDIRS ${GLOW_SOURCE_DIR}/externalbackends)
+FOREACH(backend ${SUBDIRS})
+  getBackendEnableVariable(backend_enable_variable ${backend})
+  # Handle the backend only when activated
+  if (${backend_enable_variable})
+    message(STATUS "Check backend ${backend} for ONNXModelWriters")
+    set(backend_ONNX_DIR "${EXTERNAL_BACKENDS_DIR}/${backend}")
+    # Check for ONNXModelWriters in the current backend subdirectory.
+    file(GLOB backend_specific_onnx_model_writers
+            RELATIVE "${backend_ONNX_DIR}"
+            "${backend_ONNX_DIR}/*ONNXModelWriter.cpp")
+    # Include these files into ONNXModelWriterIncludes.h.
+    foreach(onnx_model_writer ${backend_specific_onnx_model_writers})
+           file(APPEND "${Exporter_Include_DIR}/ONNXModelWriterIncludes.h"
+                       "#include \"${EXTERNAL_BACKENDS_DIR}/${backend}/ONNX/${onnx_model_writer}\"\n")
+    endforeach()
+  endif()
+ENDFOREACH()
+ENDMACRO()
+
 # Macro to add external backends tests.
 MACRO(ExternalBackendsTest)
 getSubDirList(SUBDIRS ${GLOW_SOURCE_DIR}/externalbackends)
@@ -136,4 +159,3 @@ FOREACH(child ${SUBDIRS})
   endif()
 ENDFOREACH()
 ENDMACRO()
-

--- a/lib/Backends/CPU/ONNX/CPUONNXModelWriter.cpp
+++ b/lib/Backends/CPU/ONNX/CPUONNXModelWriter.cpp
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Error ONNXModelWriter::writeCPUMaxSplat(const CPUMaxSplatNode *node,
+                                        GraphType &graph) {
+  auto *proto = graph.add_node();
+  // Add dictionary entries.
+  addValueAttribute(proto, "value", node->getSplatValue());
+
+  return writeAllWithNode("CPUMaxSplat", node, graph, proto);
+}
+
+Error ONNXModelWriter::writeCPUConvDKKC8(const CPUConvDKKC8Node *node,
+                                         GraphType &graph) {
+  auto *proto = graph.add_node();
+  // Add dictionary entries.
+  addValueAttribute(proto, "kernel_shape", node->getKernels());
+  addValueAttribute(proto, "strides", node->getStrides());
+  addValueAttribute(proto, "pads", node->getPads());
+  addValueAttribute(proto, "group", node->getGroup());
+
+  return writeAllWithNode("CPUConvDKKC8", node, graph, proto);
+}

--- a/lib/Backends/Habana/ONNX/HabanaONNXModelWriter.cpp
+++ b/lib/Backends/Habana/ONNX/HabanaONNXModelWriter.cpp
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Error ONNXModelWriter::writeHabanaFullyConnected(
+    glow::HabanaFullyConnectedNode const *, GraphType &graph) {
+  return MAKE_ERR("Unsupported Op for ONNX");
+}
+Error ONNXModelWriter::writeHabanaConvolution(
+    glow::HabanaConvolutionNode const *, GraphType &graph) {
+  return MAKE_ERR("Unsupported Op for ONNX");
+}
+Error ONNXModelWriter::writeHabanaConvolutionAdd(
+    glow::HabanaConvolutionAddNode const *, GraphType &graph) {
+  return MAKE_ERR("Unsupported Op for ONNX");
+}

--- a/lib/Backends/NNPI/ONNX/NNPIONNXModelWriter.cpp
+++ b/lib/Backends/NNPI/ONNX/NNPIONNXModelWriter.cpp
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Error ONNXModelWriter::writeNNPICustomDSP(glow::NNPICustomDSPNode const *,
+                                          GraphType &graph) {
+  return MAKE_ERR("Unsupported Op for ONNX");
+}

--- a/lib/Backends/OpenCL/ONNX/OpenCLONNXModelWriter.cpp
+++ b/lib/Backends/OpenCL/ONNX/OpenCLONNXModelWriter.cpp
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+Error ONNXModelWriter::writeOCLBatchedReduceAdd(
+    const OCLBatchedReduceAddNode *node, GraphType &graph) {
+  auto *proto = graph.add_node();
+  // Add dictionary entries.
+  addValueAttribute(proto, "axis", node->getAxis());
+  addValueAttribute(proto, "source_axis", node->getAxisSrcSliceSize());
+
+  return writeAllWithNode("OCLBatchedReduceAdd", node, graph, proto);
+}

--- a/lib/Exporter/CMakeLists.txt
+++ b/lib/Exporter/CMakeLists.txt
@@ -17,3 +17,27 @@ target_link_libraries(Exporter
                         LLVMSupport
                         Support)
 target_link_libraries(Exporter PUBLIC onnx_proto ${PROTOBUF_LIBRARY})
+
+# Include custom ONNX model writers from enabled backends.
+set(Exporter_Include_DIR ${GLOW_BINARY_DIR}/glow)
+include_directories(${Exporter_Include_DIR})
+
+file(REMOVE "${Exporter_Include_DIR}/ONNXModelWriterIncludes.h")
+
+# External backends
+ExternalBackendsCollectONNXModelWriters()
+
+# Iterate over all enabled backends.
+foreach(backend ${GLOW_BACKENDS})
+    message(STATUS "Check backend ${backend} for ONNXModelWriters")
+    set(backend_ONNX_DIR "${GLOW_BACKENDS_DIR}/${backend}/ONNX")
+    # Check for ONNXModelWriters in the current backend subdirectory.
+    file(GLOB backend_specific_onnx_model_writers
+            RELATIVE "${backend_ONNX_DIR}"
+            "${backend_ONNX_DIR}/*ONNXModelWriter.cpp")
+    # Include these files into ONNXModelWriterIncludes.h.
+    foreach(onnx_model_writer ${backend_specific_onnx_model_writers})
+           file(APPEND "${Exporter_Include_DIR}/ONNXModelWriterIncludes.h"
+                       "#include \"lib/Backends/${backend}/ONNX/${onnx_model_writer}\"\n")
+    endforeach()
+endforeach()

--- a/lib/Exporter/ONNXModelWriter.cpp
+++ b/lib/Exporter/ONNXModelWriter.cpp
@@ -1640,65 +1640,6 @@ DEF_UNSUPPORTED_NODE(SigmoidCrossEntropyWithLogits)
 DEF_UNSUPPORTED_NODE(LocalResponseNormalizationGrad)
 DEF_UNSUPPORTED_NODE(AdaptiveAvgPoolGrad)
 
-#ifdef GLOW_WITH_CPU
-
-Error ONNXModelWriter::writeCPUMaxSplat(const CPUMaxSplatNode *node,
-                                        GraphType &graph) {
-  auto *proto = graph.add_node();
-  // Add dictionary entries.
-  addValueAttribute(proto, "value", node->getSplatValue());
-
-  return writeAllWithNode("CPUMaxSplat", node, graph, proto);
-}
-
-Error ONNXModelWriter::writeCPUConvDKKC8(const CPUConvDKKC8Node *node,
-                                         GraphType &graph) {
-  auto *proto = graph.add_node();
-  // Add dictionary entries.
-  addValueAttribute(proto, "kernel_shape", node->getKernels());
-  addValueAttribute(proto, "strides", node->getStrides());
-  addValueAttribute(proto, "pads", node->getPads());
-  addValueAttribute(proto, "group", node->getGroup());
-
-  return writeAllWithNode("CPUConvDKKC8", node, graph, proto);
-}
-
-#endif // GLOW_WITH_CPU
-
-#ifdef GLOW_WITH_OPENCL
-
-Error ONNXModelWriter::writeOCLBatchedReduceAdd(
-    const OCLBatchedReduceAddNode *node, GraphType &graph) {
-  auto *proto = graph.add_node();
-  // Add dictionary entries.
-  addValueAttribute(proto, "axis", node->getAxis());
-  addValueAttribute(proto, "source_axis", node->getAxisSrcSliceSize());
-
-  return writeAllWithNode("OCLBatchedReduceAdd", node, graph, proto);
-}
-
-#endif // GLOW_WITH_OPENCL
-
-#ifdef GLOW_WITH_NNPI
-Error ONNXModelWriter::writeNNPICustomDSP(glow::NNPICustomDSPNode const *,
-                                          GraphType &graph) {
-  return MAKE_ERR("Unsupported Op for ONNX");
-}
-#endif // GLOW_WITH_NNPI
-
-#ifdef GLOW_WITH_HABANA
-Error ONNXModelWriter::writeHabanaFullyConnected(
-    glow::HabanaFullyConnectedNode const *, GraphType &graph) {
-  return MAKE_ERR("Unsupported Op for ONNX");
-}
-Error ONNXModelWriter::writeHabanaConvolution(
-    glow::HabanaConvolutionNode const *, GraphType &graph) {
-  return MAKE_ERR("Unsupported Op for ONNX");
-}
-Error ONNXModelWriter::writeHabanaConvolutionAdd(
-    glow::HabanaConvolutionAddNode const *, GraphType &graph) {
-  return MAKE_ERR("Unsupported Op for ONNX");
-}
-#endif // GLOW_WITH_HABANA
-
+// Include backend-specific ONNX model writers.
+#include "glow/ONNXModelWriterIncludes.h"
 } // namespace glow

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -67,11 +67,6 @@ extern unsigned parCloneCountOpt;
     bool isEnabledBackend(const std::set<std::string> &enabledBackends) {      \
       return enabledBackends.find(getBackendName()) != enabledBackends.end();  \
     }                                                                          \
-    const std::string Interpreter = "Interpreter";                             \
-    const std::string CPU = "CPU";                                             \
-    const std::string OpenCL = "OpenCL";                                       \
-    const std::string Habana = "Habana";                                       \
-    const std::string NNPI = "NNPI";                                           \
                                                                                \
   public:                                                                      \
     std::string getBackendName() { return std::get<0>(GetParam()); }           \

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -3113,21 +3113,21 @@ static void testFlip(glow::PlaceholderBindings &bindings, glow::Module &mod,
 
 /// Test Flip 1D with Int8.
 TEST_P(OperatorTest, Flip1D_Int8) {
-  ENABLED_BACKENDS(Interpreter, CPU);
+  ENABLED_BACKENDS("Interpreter", "CPU");
   testFlip<int8_t>(bindings_, mod_, F_, EE_, {1, 2, 3, 4}, {4, 3, 2, 1}, {4}, 0,
                    ElemKind::Int8QTy);
 }
 
 /// Test Flip 1D with Int32.
 TEST_P(OperatorTest, Flip1D_Int32) {
-  ENABLED_BACKENDS(Interpreter, CPU);
+  ENABLED_BACKENDS("Interpreter", "CPU");
   testFlip<int32_t>(bindings_, mod_, F_, EE_, {1, 2, 3, 4}, {4, 3, 2, 1}, {4},
                     0, ElemKind::Int32QTy);
 }
 
 /// Test Flip 1D with Int64.
 TEST_P(OperatorTest, Flip1D_Int64) {
-  ENABLED_BACKENDS(Interpreter, CPU);
+  ENABLED_BACKENDS("Interpreter", "CPU");
   testFlip<int64_t>(bindings_, mod_, F_, EE_, {1, 2, 3, 4}, {4, 3, 2, 1}, {4},
                     0, ElemKind::Int64ITy);
 }
@@ -3235,116 +3235,116 @@ TEST_P(OperatorTest, Flip1D_Int64) {
 
 /// Test Flip 1D with Float.
 TEST_P(OperatorTest, Flip1D_Axis0_Float) {
-  ENABLED_BACKENDS(Interpreter, CPU);
+  ENABLED_BACKENDS("Interpreter", "CPU");
   testFlip<float>(bindings_, mod_, F_, EE_, {1, 2}, {2, 1}, {2}, 0);
 }
 
 /// Test Flip 2D with Float.
 TEST_P(OperatorTest, Flip2D_Axis0_Float) {
-  ENABLED_BACKENDS(Interpreter, CPU);
+  ENABLED_BACKENDS("Interpreter", "CPU");
   testFlip<float>(bindings_, mod_, F_, EE_, {1, 2, 3, 4}, {3, 4, 1, 2}, {2, 2},
                   0);
 }
 TEST_P(OperatorTest, Flip2D_Axis1_Float) {
-  ENABLED_BACKENDS(Interpreter, CPU);
+  ENABLED_BACKENDS("Interpreter", "CPU");
   testFlip<float>(bindings_, mod_, F_, EE_, {1, 2, 3, 4}, {2, 1, 4, 3}, {2, 2},
                   1);
 }
 
 /// Test Flip 3D with Float.
 TEST_P(OperatorTest, Flip3D_Axis0_Float) {
-  ENABLED_BACKENDS(Interpreter, CPU);
+  ENABLED_BACKENDS("Interpreter", "CPU");
   testFlip<float>(bindings_, mod_, F_, EE_, FLIP_3D_INPUT, FLIP_3D_AXIS0,
                   {2, 2, 2}, 0);
 }
 TEST_P(OperatorTest, Flip3D_Axis1_Float) {
-  ENABLED_BACKENDS(Interpreter, CPU);
+  ENABLED_BACKENDS("Interpreter", "CPU");
   testFlip<float>(bindings_, mod_, F_, EE_, FLIP_3D_INPUT, FLIP_3D_AXIS1,
                   {2, 2, 2}, 1);
 }
 TEST_P(OperatorTest, Flip3D_Axis2_Float) {
-  ENABLED_BACKENDS(Interpreter, CPU);
+  ENABLED_BACKENDS("Interpreter", "CPU");
   testFlip<float>(bindings_, mod_, F_, EE_, FLIP_3D_INPUT, FLIP_3D_AXIS2,
                   {2, 2, 2}, 2);
 }
 
 /// Test Flip 4D with Float.
 TEST_P(OperatorTest, Flip4D_Axis0_Float) {
-  ENABLED_BACKENDS(Interpreter, CPU);
+  ENABLED_BACKENDS("Interpreter", "CPU");
   testFlip<float>(bindings_, mod_, F_, EE_, FLIP_4D_INPUT, FLIP_4D_AXIS0,
                   {2, 2, 2, 2}, 0);
 }
 TEST_P(OperatorTest, Flip4D_Axis1_Float) {
-  ENABLED_BACKENDS(Interpreter, CPU);
+  ENABLED_BACKENDS("Interpreter", "CPU");
   testFlip<float>(bindings_, mod_, F_, EE_, FLIP_4D_INPUT, FLIP_4D_AXIS1,
                   {2, 2, 2, 2}, 1);
 }
 TEST_P(OperatorTest, Flip4D_Axis2_Float) {
-  ENABLED_BACKENDS(Interpreter, CPU);
+  ENABLED_BACKENDS("Interpreter", "CPU");
   testFlip<float>(bindings_, mod_, F_, EE_, FLIP_4D_INPUT, FLIP_4D_AXIS2,
                   {2, 2, 2, 2}, 2);
 }
 TEST_P(OperatorTest, Flip4D_Axis3_Float) {
-  ENABLED_BACKENDS(Interpreter, CPU);
+  ENABLED_BACKENDS("Interpreter", "CPU");
   testFlip<float>(bindings_, mod_, F_, EE_, FLIP_4D_INPUT, FLIP_4D_AXIS3,
                   {2, 2, 2, 2}, 3);
 }
 
 /// Test Flip 5D with Float.
 TEST_P(OperatorTest, Flip5D_Axis0_Float) {
-  ENABLED_BACKENDS(Interpreter, CPU);
+  ENABLED_BACKENDS("Interpreter", "CPU");
   testFlip<float>(bindings_, mod_, F_, EE_, FLIP_5D_INPUT, FLIP_5D_AXIS0,
                   {2, 2, 2, 2, 2}, 0);
 }
 TEST_P(OperatorTest, Flip5D_Axis1_Float) {
-  ENABLED_BACKENDS(Interpreter, CPU);
+  ENABLED_BACKENDS("Interpreter", "CPU");
   testFlip<float>(bindings_, mod_, F_, EE_, FLIP_5D_INPUT, FLIP_5D_AXIS1,
                   {2, 2, 2, 2, 2}, 1);
 }
 TEST_P(OperatorTest, Flip5D_Axis2_Float) {
-  ENABLED_BACKENDS(Interpreter, CPU);
+  ENABLED_BACKENDS("Interpreter", "CPU");
   testFlip<float>(bindings_, mod_, F_, EE_, FLIP_5D_INPUT, FLIP_5D_AXIS2,
                   {2, 2, 2, 2, 2}, 2);
 }
 TEST_P(OperatorTest, Flip5D_Axis3_Float) {
-  ENABLED_BACKENDS(Interpreter, CPU);
+  ENABLED_BACKENDS("Interpreter", "CPU");
   testFlip<float>(bindings_, mod_, F_, EE_, FLIP_5D_INPUT, FLIP_5D_AXIS3,
                   {2, 2, 2, 2, 2}, 3);
 }
 TEST_P(OperatorTest, Flip5D_Axis4_Float) {
-  ENABLED_BACKENDS(Interpreter, CPU);
+  ENABLED_BACKENDS("Interpreter", "CPU");
   testFlip<float>(bindings_, mod_, F_, EE_, FLIP_5D_INPUT, FLIP_5D_AXIS4,
                   {2, 2, 2, 2, 2}, 4);
 }
 
 /// Test Flip 6D with Float.
 TEST_P(OperatorTest, Flip6D_Axis0_Float) {
-  ENABLED_BACKENDS(Interpreter, CPU);
+  ENABLED_BACKENDS("Interpreter", "CPU");
   testFlip<float>(bindings_, mod_, F_, EE_, FLIP_6D_INPUT, FLIP_6D_AXIS0,
                   {2, 2, 2, 2, 2, 2}, 0);
 }
 TEST_P(OperatorTest, Flip6D_Axis1_Float) {
-  ENABLED_BACKENDS(Interpreter, CPU);
+  ENABLED_BACKENDS("Interpreter", "CPU");
   testFlip<float>(bindings_, mod_, F_, EE_, FLIP_6D_INPUT, FLIP_6D_AXIS1,
                   {2, 2, 2, 2, 2, 2}, 1);
 }
 TEST_P(OperatorTest, Flip6D_Axis2_Float) {
-  ENABLED_BACKENDS(Interpreter, CPU);
+  ENABLED_BACKENDS("Interpreter", "CPU");
   testFlip<float>(bindings_, mod_, F_, EE_, FLIP_6D_INPUT, FLIP_6D_AXIS2,
                   {2, 2, 2, 2, 2, 2}, 2);
 }
 TEST_P(OperatorTest, Flip6D_Axis3_Float) {
-  ENABLED_BACKENDS(Interpreter, CPU);
+  ENABLED_BACKENDS("Interpreter", "CPU");
   testFlip<float>(bindings_, mod_, F_, EE_, FLIP_6D_INPUT, FLIP_6D_AXIS3,
                   {2, 2, 2, 2, 2, 2}, 3);
 }
 TEST_P(OperatorTest, Flip6D_Axis4_Float) {
-  ENABLED_BACKENDS(Interpreter, CPU);
+  ENABLED_BACKENDS("Interpreter", "CPU");
   testFlip<float>(bindings_, mod_, F_, EE_, FLIP_6D_INPUT, FLIP_6D_AXIS4,
                   {2, 2, 2, 2, 2, 2}, 4);
 }
 TEST_P(OperatorTest, Flip6D_Axis5_Float) {
-  ENABLED_BACKENDS(Interpreter, CPU);
+  ENABLED_BACKENDS("Interpreter", "CPU");
   testFlip<float>(bindings_, mod_, F_, EE_, FLIP_6D_INPUT, FLIP_6D_AXIS5,
                   {2, 2, 2, 2, 2, 2}, 5);
 }
@@ -4149,7 +4149,7 @@ TEST_P(OperatorStatelessTest, FP16ConvolutionDepth8) {
 }
 
 TEST_P(OperatorStatelessTest, ConvolutionDepth10_Int8_BiasInt8) {
-  ENABLED_BACKENDS(Interpreter, CPU);
+  ENABLED_BACKENDS("Interpreter", "CPU");
   compareAgainstInterpreter(
       getBackendName(), createAndInitConvDepthTest<10>, ElemKind::FloatTy,
       ElemKind::Int8QTy, 0.03f, parCloneCountOpt,
@@ -4158,7 +4158,7 @@ TEST_P(OperatorStatelessTest, ConvolutionDepth10_Int8_BiasInt8) {
 }
 
 TEST_P(OperatorStatelessTest, ConvolutionDepth10_Int8_BiasInt32) {
-  ENABLED_BACKENDS(Interpreter, CPU);
+  ENABLED_BACKENDS("Interpreter", "CPU");
   compareAgainstInterpreter(
       getBackendName(), createAndInitConvDepthTest<10>, ElemKind::FloatTy,
       ElemKind::Int8QTy, 0.03f, parCloneCountOpt,
@@ -4167,7 +4167,7 @@ TEST_P(OperatorStatelessTest, ConvolutionDepth10_Int8_BiasInt32) {
 }
 
 TEST_P(OperatorStatelessTest, ConvolutionDepth10_Int16_BiasInt16) {
-  ENABLED_BACKENDS(Interpreter);
+  ENABLED_BACKENDS("Interpreter");
   compareAgainstInterpreter(
       getBackendName(), createAndInitConvDepthTest<10>, ElemKind::FloatTy,
       ElemKind::Int16QTy, 0.0003f, parCloneCountOpt,
@@ -4176,7 +4176,7 @@ TEST_P(OperatorStatelessTest, ConvolutionDepth10_Int16_BiasInt16) {
 }
 
 TEST_P(OperatorStatelessTest, ConvolutionDepth10_Int16_BiasInt32) {
-  ENABLED_BACKENDS(Interpreter);
+  ENABLED_BACKENDS("Interpreter");
   compareAgainstInterpreter(
       getBackendName(), createAndInitConvDepthTest<10>, ElemKind::FloatTy,
       ElemKind::Int16QTy, 0.0003f, parCloneCountOpt,
@@ -4285,7 +4285,7 @@ TEST_P(OperatorStatelessTest, FC_Float16) {
 
 /// Test Int8 FullyConnected with Int8 bias.
 TEST_P(OperatorStatelessTest, FullyConnected_Int8_BiasInt8) {
-  ENABLED_BACKENDS(Interpreter, CPU);
+  ENABLED_BACKENDS("Interpreter", "CPU");
   compareAgainstInterpreter(
       getBackendName(), createAndInitBasicFCTest, ElemKind::FloatTy,
       ElemKind::Int8QTy, 0.05f, parCloneCountOpt,
@@ -4295,7 +4295,7 @@ TEST_P(OperatorStatelessTest, FullyConnected_Int8_BiasInt8) {
 
 /// Test Int8 FullyConnected with Int32 bias.
 TEST_P(OperatorStatelessTest, FullyConnected_Int8_BiasInt32) {
-  ENABLED_BACKENDS(Interpreter, CPU);
+  ENABLED_BACKENDS("Interpreter", "CPU");
   compareAgainstInterpreter(
       getBackendName(), createAndInitBasicFCTest, ElemKind::FloatTy,
       ElemKind::Int8QTy, 0.05f, parCloneCountOpt,
@@ -4305,7 +4305,7 @@ TEST_P(OperatorStatelessTest, FullyConnected_Int8_BiasInt32) {
 
 /// Test Int16 FullyConnected with Int16 bias.
 TEST_P(OperatorStatelessTest, FullyConnected_Int16_BiasInt16) {
-  ENABLED_BACKENDS(Interpreter);
+  ENABLED_BACKENDS("Interpreter");
   compareAgainstInterpreter(
       getBackendName(), createAndInitBasicFCTest, ElemKind::FloatTy,
       ElemKind::Int16QTy, 0.0005f, parCloneCountOpt,
@@ -4315,7 +4315,7 @@ TEST_P(OperatorStatelessTest, FullyConnected_Int16_BiasInt16) {
 
 /// Test Int16 FullyConnected with Int32 bias.
 TEST_P(OperatorStatelessTest, FullyConnected_Int16_BiasInt32) {
-  ENABLED_BACKENDS(Interpreter);
+  ENABLED_BACKENDS("Interpreter");
   compareAgainstInterpreter(
       getBackendName(), createAndInitBasicFCTest, ElemKind::FloatTy,
       ElemKind::Int16QTy, 0.0005f, parCloneCountOpt,
@@ -6955,28 +6955,28 @@ static void Conv3DQuantizedTest(glow::PlaceholderBindings &bindings,
 
 /// Test Int8 Conv3D with Int8 bias.
 TEST_P(OperatorTest, Conv3DQuantizedTest_Int8_BiasInt8) {
-  ENABLED_BACKENDS(Interpreter);
+  ENABLED_BACKENDS("Interpreter");
   Conv3DQuantizedTest(bindings_, mod_, F_, EE_, ElemKind::Int8QTy,
                       ElemKind::Int8QTy);
 }
 
 /// Test Int8 Conv3D with Int32 bias.
 TEST_P(OperatorTest, Conv3DQuantizedTest_Int8_BiasInt32) {
-  ENABLED_BACKENDS(Interpreter);
+  ENABLED_BACKENDS("Interpreter");
   Conv3DQuantizedTest(bindings_, mod_, F_, EE_, ElemKind::Int8QTy,
                       ElemKind::Int32QTy);
 }
 
 /// Test Int16 Conv3D with Int16 bias.
 TEST_P(OperatorTest, Conv3DQuantizedTest_Int16_BiasInt16) {
-  ENABLED_BACKENDS(Interpreter);
+  ENABLED_BACKENDS("Interpreter");
   Conv3DQuantizedTest(bindings_, mod_, F_, EE_, ElemKind::Int16QTy,
                       ElemKind::Int16QTy);
 }
 
 /// Test Int16 Conv3D with Int32 bias.
 TEST_P(OperatorTest, Conv3DQuantizedTest_Int16_BiasInt32) {
-  ENABLED_BACKENDS(Interpreter);
+  ENABLED_BACKENDS("Interpreter");
   Conv3DQuantizedTest(bindings_, mod_, F_, EE_, ElemKind::Int16QTy,
                       ElemKind::Int32QTy);
 }
@@ -9907,7 +9907,7 @@ createAndInitBasicRowwiseFCTest(glow::PlaceholderBindings &bindings,
 
 /// Test Int8 RowwiseQuantizedFullyConnected Node with Int8 bias.
 TEST_P(OperatorStatelessTest, rowwiseQuantizedFCTest_Int8_BiasInt8) {
-  ENABLED_BACKENDS(Interpreter, CPU);
+  ENABLED_BACKENDS("Interpreter", "CPU");
   compareAgainstInterpreter(
       getBackendName(), createAndInitBasicRowwiseFCTest, ElemKind::FloatTy,
       ElemKind::Int8QTy, 0.06f, parCloneCountOpt,
@@ -9917,7 +9917,7 @@ TEST_P(OperatorStatelessTest, rowwiseQuantizedFCTest_Int8_BiasInt8) {
 
 /// Test Int8 RowwiseQuantizedFullyConnected Node with Int32 bias.
 TEST_P(OperatorStatelessTest, rowwiseQuantizedFCTest_Int8_BiasInt32) {
-  ENABLED_BACKENDS(Interpreter, CPU);
+  ENABLED_BACKENDS("Interpreter", "CPU");
   compareAgainstInterpreter(
       getBackendName(), createAndInitBasicRowwiseFCTest, ElemKind::FloatTy,
       ElemKind::Int8QTy, 0.06f, parCloneCountOpt,


### PR DESCRIPTION
This PR provides some partial fixs for https://github.com/pytorch/glow/issues/3785

- Avoids explicit enumeration of all backend names in BackendTestUtils.h
- Moves backend-specific ONNX model writers into the sub-directories containing backend sources
   Yet another place in glow/master that had to know about all existing backends is removed.