### PR TITLE
[RFC] Added new bindContexts method to backend

### DIFF
--- a/include/glow/Backend/Backend.h
+++ b/include/glow/Backend/Backend.h
@@ -46,6 +46,9 @@ namespace runtime {
 class DeviceManager;
 struct DeviceInfo;
 struct DeviceConfig;
+struct ContextBinding;
+
+struct DAG;
 
 } // namespace runtime
 
@@ -182,6 +185,15 @@ public:
   /// deviceConfig.
   virtual runtime::DeviceManager *
   createDeviceManager(const runtime::DeviceConfig &deviceConfig);
+
+  /// Walks the provided /p bindings and does any setup needed for copying data
+  /// to/from host or peers. Also has access to /p network, which contains
+  /// partition dependency and symbol information. Any state information should
+  /// be stored in the ExecutionContext or DeviceManager.
+  virtual Error bindContexts(llvm::ArrayRef<runtime::ContextBinding> bindings,
+                             const std::vector<runtime::DAG> &network) {
+    return Error::success();
+  }
 
   /// \returns the supported options for compiled functions (name=>description).
   virtual llvm::StringMap<std::string>

--- a/include/glow/Runtime/RuntimeTypes.h
+++ b/include/glow/Runtime/RuntimeTypes.h
@@ -215,6 +215,17 @@ struct PartitionConfig {
   bool enabled() { return numOfPartitions > 0; }
 };
 
+/// A struct containing a mapping of ExecutionContext to a loaded network on a
+/// device.
+struct ContextBinding {
+  /// The context used for execution of the specified network.
+  ExecutionContext *context;
+  /// The device the network will be run on with this context.
+  DeviceManager *device;
+  /// The name of the network.
+  std::string networkName;
+};
+
 } // namespace runtime
 } // namespace glow
 #endif // GLOW_RUNTIME_RUNTIMETYPES_H


### PR DESCRIPTION
Summary:
This is a proposal for a new bindContexts method to be on the backend. 
This method is a setup method that is meant to be called after the provisioner completes. 
Once called the backend is responsible for performing any setup needed for data transfer, this includes creating any copy commands or allocation of transfer space.
Any state generated from this method should either be stored in the DeviceManager or ExecutionContext. 
Once called the deviceManagers should be ready to execute the network with the bound contexts.
In the future this will enable backends to create P2P connection between devices and enable command chaining where execution can continue from one device to the next automatically. 



Documentation:


Test Plan: verify it builds
