### PR TITLE
[Graph] Add a new method to NodeBuilder to support many results

### DIFF
--- a/tools/ClassGen/NodeBuilder.cpp
+++ b/tools/ClassGen/NodeBuilder.cpp
@@ -559,6 +559,10 @@ void NodeBuilder::emitNodeClass(std::ostream &os) const {
      << "  Node* clone() const;\n"
      << "  bool verify() const;\n";
 
+  if (hasExtraResults_) {
+    os << "  void addExtraResult(TypeRef T) { addResult(T); }\n";
+  }
+
   if (!enum_.empty()) {
     os << "  const char *getModeStr() const { return getModeStr(mode_); }\n"
        << "  static const char *getModeStr(Mode m);\n";

--- a/tools/ClassGen/NodeBuilder.h
+++ b/tools/ClassGen/NodeBuilder.h
@@ -68,6 +68,8 @@ class NodeBuilder {
   bool isBackendSpecific_{false};
   /// Specifies if this Node is data parallel.
   bool isDataParallel_{false};
+  /// Specifies if this Node can have extra results.
+  bool hasExtraResults_{false};
 
 public:
   NodeBuilder(std::ofstream &H, std::ofstream &C, std::ofstream &D,
@@ -169,6 +171,11 @@ public:
 
   NodeBuilder &dataParallel() {
     isDataParallel_ = true;
+    return *this;
+  }
+
+  NodeBuilder &hasExtraResults() {
+    hasExtraResults_ = true;
     return *this;
   }
 


### PR DESCRIPTION
**Summary**
This commit adds a `hasExtraResults()` member to NodeBuilder that exposes `Node::addResult`
as a public member. This can be useful for creating nodes with an arbitrary number of outputs.

**Test Plan**
Used `hasExtraResults()` on existing node, examined generated files:
```
class SparseLengthsSumNode final : public Node {
...
  void addExtraResult(TypeRef T) { addResult(T); }
```
