### PR TITLE
Add numerical equivalence check to GraphOptz.optimizeBatchNormAfterCo…

### DIFF
--- a/tests/unittests/GraphOptzTest.cpp
+++ b/tests/unittests/GraphOptzTest.cpp
@@ -357,11 +357,11 @@ TEST_F(GraphOptz, optimizeBatchNormAfterConvWithReshapeConst) {
 /// Check that the batch normalization optimization is
 /// not blocked by predicates and that it preserves them.
 TEST_F(GraphOptz, optimizeBatchNormAfterConvWithPred) {
-  Node *A =
+  Placeholder *A =
       mod_.createPlaceholder(ElemKind::FloatTy, {1, 10, 20, 3}, "A", false);
-  Node *pred1 =
+  Placeholder *pred1 =
       mod_.createPlaceholder(ElemKind::FloatTy, {1}, "predicate", false);
-  Node *pred2 =
+  Placeholder *pred2 =
       mod_.createPlaceholder(ElemKind::FloatTy, {1}, "predicate", false);
   Node *CV = F_->createConv(bindings_, "conv", A, 16, 5, 1, 2, 1);
   CV->setPredicate(pred1);
@@ -373,17 +373,24 @@ TEST_F(GraphOptz, optimizeBatchNormAfterConvWithPred) {
   EXPECT_EQ(F_->getNodes().size(), 3);
 
   ::glow::convertPlaceholdersToConstants(F_, bindings_, {});
-  ::glow::optimize(F_, CompilationMode::Infer);
-  EXPECT_EQ(F_->getNodes().size(), 2);
+  optimizedF_ = optimizeFunction(F_);
 
-  ASSERT_EQ(A->getNumUsers(), 1);
-  Node *newCV = A->getUsers().begin()->getUser();
+  EXPECT_EQ(optimizedF_->getNodes().size(), 2);
+
+  ASSERT_EQ(A->getNumUsers(), 2);
+  Node *newCV = A->getUsers().back().getUser();
   EXPECT_TRUE(llvm::isa<ConvolutionNode>(newCV));
   ASSERT_TRUE(newCV->hasPredicate());
   EXPECT_EQ(newCV->getPredicate().getNode(), pred2);
   ASSERT_EQ(newCV->getNumUsers(), 1);
   Node *save = newCV->getUsers().begin()->getUser();
   EXPECT_TRUE(llvm::isa<SaveNode>(save));
+
+  bindings_.allocate(mod_.getPlaceholders());
+  bindings_.get(A)->getHandle().randomize(-1.0, 1.0, mod_.getPRNG());
+  bindings_.get(pred1)->getHandle().randomize(-1.0, 1.0, mod_.getPRNG());
+  bindings_.get(pred2)->getHandle().randomize(-1.0, 1.0, mod_.getPRNG());
+  checkNumericalEquivalence();
 }
 
 /// Check CSE will not merge two nodes that have all the same inputs but


### PR DESCRIPTION
**Summary:**
Glow performs several optimizations on the graph that is passed to it as input.
GraphOptzTest has a test case named optimizeBatchNormAfterConvWithPred  which tests one such optimization. The task is to add a numerical equivalence check to this test case which checks that both the original and optimized graph return the same result for the same input.
Documentation:

**Test Plan:**
ninja all && tests/GraphOptzTest
[----------] Global test environment tear-down
[==========] 120 tests from 4 test suites ran. (823 ms total)
[  PASSED  ] 120 tests.
