### PR TITLE
fix concurrency issue in InferencePool

### DIFF
--- a/lib/Backends/NNPI/InferencePool.h
+++ b/lib/Backends/NNPI/InferencePool.h
@@ -100,9 +100,10 @@ public:
 
 class InferencePoolEnv {
   unsigned numWorkers_;
-  std::atomic<unsigned> workerIndex_;
   std::unique_ptr<ThreadPool> workersPool_;
   std::vector<InferenceThreadEnv> threadEnvs_;
+  std::vector<InferenceThreadEnv *> threadEnvsFree_;
+  std::mutex threadEnvsFreeLock_;
   NNPIHostNetwork hostNetwork_;
   NNPIDeviceNetwork deviceNetwork_;
   std::shared_ptr<NNPIDeviceTracing> deviceTracing_;


### PR DESCRIPTION
Summary:
In https://github.com/pytorch/glow/commit/3397db6a19cd3c56cd659d97c83362e1ff8098b0 we fixed a hot lock issue in host manager that's hurting throughput. It made it so that we can call into device manager concurrently instead of sequentially behind a single mutex.

This exposes a problem in InferencePool however. InferencePoolEnv::execute() isn't totally correct. We use an atomic to determine which InferenceEnv a given thread can use. But when this function can be called concurrently, instead of strictly 0,1,0,1... order for env, we can have two worker threads working on env 0 at the same time. This causes race condition and failing inferences.

This is a potential fix. There is probably a better way to do this. This is just to show the problem.

Differential Revision: D19637849

