### PR TITLE
[OpenCL] do not always write the program to disk cache

### DIFF
--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -308,6 +308,7 @@ OpenCLFunction::createProgram(const std::string &source,
   }
 
   const bool useDiskCache = deviceProgramCacheDir(deviceId) != "";
+  bool loadedFromCache = false;
 
   std::string cacheDir;
   std::string programFileName;
@@ -317,6 +318,7 @@ OpenCLFunction::createProgram(const std::string &source,
         diskCacheProgramFileName(deviceId, source, combinedOptions);
     program =
         loadProgramFromDiskCache(cacheDir, programFileName, ctx, deviceId);
+    loadedFromCache = program != nullptr;
   }
 
   if (program == nullptr) {
@@ -333,7 +335,7 @@ OpenCLFunction::createProgram(const std::string &source,
   }
   CHECK_EQ(err, CL_SUCCESS) << "clBuildProgram Failed.";
 
-  if (useDiskCache) {
+  if (useDiskCache && !loadedFromCache) {
     saveProgramToDiskCache(cacheDir, programFileName, program, ctx, deviceId);
   }
 


### PR DESCRIPTION
If the program was loaded from the cache, writing it again after build is just extra overhead.

Test Plan:

Tested with pocl and Intel's (GPU) OpenCL.
