### PR TITLE
Fix bug in convertToFloatIfNecessary

### DIFF
--- a/tests/unittests/BackendTestUtils.cpp
+++ b/tests/unittests/BackendTestUtils.cpp
@@ -249,7 +249,7 @@ static void convertBindingsToCorrectType(PlaceholderBindings &bindings,
 static Tensor convertToFloatIfNecessary(Tensor &T) {
   const ElemKind srcK = T.getType().getElementType();
   if (srcK == ElemKind::FloatTy) {
-    return std::move(T);
+    return T.clone();
   }
   if (isQuantizedElemKind(srcK)) {
     return quantization::dequantizeTensor(T, ElemKind::FloatTy);


### PR DESCRIPTION
Summary: This is causing some segfaults when running with `-parallel-clone-count > 1`.

Differential Revision: D19645740

