### PR TITLE
Demotion: added Generic Transformation pass int64 --> int32

### DIFF
--- a/examples/bundles/bundle_with_multiple_entries/BundleSaver.cpp
+++ b/examples/bundles/bundle_with_multiple_entries/BundleSaver.cpp
@@ -35,7 +35,7 @@ int main(int argc, char **argv) {
 
   // Create a bundle with multiple entry points and save it.
   Module M;
-  constexpr size_t tensorSize = 64;
+  constexpr dim_t tensorSize = 64;
 
   Constant *addConst =
       M.createConstant(ElemKind::FloatTy, {tensorSize}, "const");

--- a/examples/cifar10.cpp
+++ b/examples/cifar10.cpp
@@ -55,7 +55,7 @@ llvm::cl::opt<ModelKind>
 /// The database contains 10000 images.
 /// Size: (1 + (32 * 32 * 3)) * 10000 = 30730000.
 const size_t cifarImageSize = 1 + (32 * 32 * 3);
-const size_t cifarNumImages = 10000;
+const dim_t cifarNumImages = 10000;
 const unsigned numLabels = 10;
 
 static Placeholder *createDefaultModel(PlaceholderBindings &bindings,

--- a/examples/training/resnet50/main.cpp
+++ b/examples/training/resnet50/main.cpp
@@ -28,12 +28,11 @@
 /// This is an example demonstrating how to load resnet50 model,
 /// randomize weights and perform training on a limited data set,
 /// and evaluate model.
-
-constexpr size_t IMAGE_COLORS = 3;
-constexpr size_t IMAGE_HEIGHT = 224;
-constexpr size_t IMAGE_WIDTH = 224;
-
 using namespace glow;
+
+constexpr dim_t IMAGE_COLORS = 3;
+constexpr dim_t IMAGE_HEIGHT = 224;
+constexpr dim_t IMAGE_WIDTH = 224;
 
 namespace {
 llvm::cl::OptionCategory category("resnet-training Options");
@@ -246,7 +245,7 @@ int main(int argc, char **argv) {
   // These tensors allocate memory for all images and labels prepared for
   // training.
   Tensor imagesT(ElemKind::FloatTy, allImagesDims);
-  Tensor labelsT(IndexElemKind, allLabelsDims);
+  Tensor labelsT(ElemKind::Int64ITy, allLabelsDims);
 
   size_t idx = 0;
   size_t orig_size = filenames.size();

--- a/include/glow/Backend/Backend.h
+++ b/include/glow/Backend/Backend.h
@@ -215,6 +215,15 @@ public:
     return llvm::StringMap<std::string>();
   };
 
+  /// \returns true if network supports Type Lowering from \p T1 to \p T2.
+  /// Populates PrecisionConfiguration with black list of operations that can't
+  /// be converted.
+  virtual bool
+  canDoIndexTypeDemotion(ElemKind fromTy, ElemKind toTy,
+                         PrecisionConfiguration &precConfig) const {
+    return false;
+  };
+
 protected:
   /// Parses the graph \F and builds a TraceInfo structure from any found
   /// TraceEventNodes.

--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -261,9 +261,6 @@ enum class ElemKind : unsigned char {
   BoolTy,
 };
 
-constexpr ElemKind IndexElemKind =
-    (sizeof(dim_t) == 4) ? ElemKind::Int32ITy : ElemKind::Int64ITy;
-
 /// \returns whether \p e is a quantized ElemKind.
 inline bool isQuantizedElemKind(ElemKind e) {
   return e == ElemKind::Int8QTy || e == ElemKind::UInt8QTy ||

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -519,11 +519,14 @@ public:
                              llvm::ArrayRef<unsigned_t> kernels,
                              llvm::ArrayRef<unsigned_t> strides,
                              llvm::ArrayRef<unsigned_t> pads,
+                             ElemKind elemTyAMT = ElemKind::Int64ITy,
                              ConvolutionLayout layout = NHWC);
 
   MaxPoolNode *createMaxPool(llvm::StringRef name, NodeValue input,
                              unsigned_t kernel, unsigned_t stride,
-                             unsigned_t pad, ConvolutionLayout layout = NHWC);
+                             unsigned_t pad,
+                             ElemKind elemTyAMT = ElemKind::Int64ITy,
+                             ConvolutionLayout layout = NHWC);
 
   AvgPoolNode *createAvgPool(llvm::StringRef name, NodeValue input,
                              llvm::ArrayRef<unsigned_t> kernels,
@@ -1200,6 +1203,9 @@ public:
                                        TypeRef outTy);
 
   TopKNode *createTopK(llvm::StringRef name, NodeValue input, unsigned_t k);
+
+  TopKNode *createTopK(llvm::StringRef name, NodeValue input, unsigned_t k,
+                       ElemKind outIndicesTyKind);
 
   /// Gathers entries of the outer-most dimension of \p data indexed by
   /// \p indices, and concatenates them. A non-zero \p batchDims specifies the

--- a/include/glow/IR/IRBuilder.h
+++ b/include/glow/IR/IRBuilder.h
@@ -52,14 +52,14 @@ public:
   /// @name High-level, operation-level IRBuilder.
   ///@{
 
-  MaxPoolWithArgmaxInst *
-  createMaxPoolWithArgmaxOp(llvm::StringRef name, Value *input,
-                            llvm::ArrayRef<unsigned_t> kernels,
-                            llvm::ArrayRef<unsigned_t> strides,
-                            llvm::ArrayRef<unsigned_t> pads, unsigned_t layout);
+  MaxPoolWithArgmaxInst *createMaxPoolWithArgmaxOp(
+      llvm::StringRef name, Value *input, llvm::ArrayRef<unsigned_t> kernels,
+      llvm::ArrayRef<unsigned_t> strides, llvm::ArrayRef<unsigned_t> pads,
+      unsigned_t layout, ElemKind argMaxIndicesTy);
 
   ArgMaxInst *createArgMaxOp(llvm::StringRef name, Value *input,
-                             unsigned_t axis, bool keepDims);
+                             unsigned_t axis, bool keepDims,
+                             ElemKind outIndicesTy);
 
   AvgPoolInst *createAvgPoolOp(Value *input, llvm::ArrayRef<unsigned_t> kernels,
                                llvm::ArrayRef<unsigned_t> strides,
@@ -78,7 +78,8 @@ public:
       llvm::StringRef name, Value *input, size_t halfWindowSize = 2,
       float alpha = 1e-4, float beta = 0.75, float k = 2.0);
 
-  TopKInst *createTopKOp(llvm::StringRef name, Value *input, size_t k);
+  TopKInst *createTopKOp(llvm::StringRef name, Value *input, size_t k,
+                         ElemKind outIndicesTy);
 
   Value *createReturnOp(Value *input);
 

--- a/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
+++ b/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
@@ -116,6 +116,10 @@ struct OptimizationOptions {
   /// The number of cores to assign to non-SLS partition when using SparseNN
   /// partitioning scheme
   unsigned int sparseNNPartitioningSchemeNumCoresOther{1};
+
+  /// If true does int64 to int32 type demotion if backend supports for specific
+  /// nodes.
+  bool enableTypeDemotion{true};
 };
 
 /// Context for compilation.

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -49,8 +49,12 @@ bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
         {ElemKind::FloatTy, ElemKind::Int32ITy, ElemKind::Int64ITy});
 
   case Kinded::Kind::AddNodeKind:
-  case Kinded::Kind::SubNodeKind:
   case Kinded::Kind::MulNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+        {ElemKind::FloatTy, ElemKind::Int8QTy, ElemKind::Int32ITy,
+         ElemKind::Int64ITy});
+
+  case Kinded::Kind::SubNodeKind:
   case Kinded::Kind::MaxNodeKind:
   case Kinded::Kind::MinNodeKind:
   case Kinded::Kind::CPUMaxSplatNodeKind:
@@ -67,13 +71,15 @@ bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
     return NI.allInputsAndOutputsHaveSameElemKind(
                {ElemKind::FloatTy, ElemKind::Int8QTy}, {},
                {MaxPoolNode::ArgmaxIdx}) &&
-           (NI.getOutElemTy(MaxPoolNode::ArgmaxIdx) == IndexElemKind);
+           (NI.getOutElemTy(MaxPoolNode::ArgmaxIdx) == ElemKind::Int64ITy ||
+            NI.getOutElemTy(MaxPoolNode::ArgmaxIdx) == ElemKind::Int32ITy);
 
   case Kinded::Kind::ArgMaxNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
                {ElemKind::FloatTy, ElemKind::Int8QTy}, {},
                {ArgMaxNode::ArgmaxIdx}) &&
-           (NI.getOutElemTy(ArgMaxNode::ArgmaxIdx) == IndexElemKind);
+           (NI.getOutElemTy(ArgMaxNode::ArgmaxIdx) == ElemKind::Int64ITy ||
+            NI.getOutElemTy(ArgMaxNode::ArgmaxIdx) == ElemKind::Int32ITy);
 
   case Kinded::Kind::SaveNodeKind:
   case Kinded::Kind::ReshapeNodeKind:
@@ -89,17 +95,17 @@ bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
   case Kinded::Kind::ConcatNodeKind:
   case Kinded::Kind::SplatNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
-        {ElemKind::FloatTy, ElemKind::Int8QTy, IndexElemKind,
-         ElemKind::Int64ITy, ElemKind::BoolTy});
-
-  case Kinded::Kind::DivNodeKind:
+        {ElemKind::FloatTy, ElemKind::Int8QTy, ElemKind::Int64ITy,
+         ElemKind::Int32ITy, ElemKind::BoolTy});
   case Kinded::Kind::SliceNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
         {ElemKind::FloatTy, ElemKind::Int8QTy, ElemKind::Int32QTy,
-         ElemKind::Int64ITy});
+         ElemKind::Int32ITy, ElemKind::Int64ITy});
   case Kinded::Kind::SpaceToDepthNodeKind:
+  case Kinded::Kind::DivNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
-        {ElemKind::FloatTy, ElemKind::Int8QTy, ElemKind::Int64ITy});
+        {ElemKind::FloatTy, ElemKind::Int8QTy, ElemKind::Int64ITy,
+         ElemKind::Int32ITy});
 
   case Kinded::Kind::TransposeNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
@@ -117,7 +123,9 @@ bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
                {ElemKind::FloatTy}, {SparseLengthsSumNode::IndicesIdx,
                                      SparseLengthsSumNode::LengthsIdx}) &&
            (NI.getInElemTy(SparseLengthsSumNode::IndicesIdx) ==
-            IndexElemKind) &&
+                ElemKind::Int64ITy ||
+            NI.getInElemTy(SparseLengthsSumNode::IndicesIdx) ==
+                ElemKind::Int32ITy) &&
            (NI.getInElemTy(SparseLengthsSumNode::LengthsIdx) ==
             ElemKind::Int32ITy);
 
@@ -127,7 +135,9 @@ bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
                {SparseLengthsWeightedSumNode::IndicesIdx,
                 SparseLengthsWeightedSumNode::LengthsIdx}) &&
            (NI.getInElemTy(SparseLengthsWeightedSumNode::IndicesIdx) ==
-            IndexElemKind) &&
+                ElemKind::Int64ITy ||
+            NI.getInElemTy(SparseLengthsWeightedSumNode::IndicesIdx) ==
+                ElemKind::Int32ITy) &&
            (NI.getInElemTy(SparseLengthsWeightedSumNode::LengthsIdx) ==
             ElemKind::Int32ITy);
 
@@ -135,8 +145,9 @@ bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
     return NI.allInputsAndOutputsHaveSameElemKind(
                {ElemKind::FloatTy},
                {EmbeddingBagNode::IndicesIdx, EmbeddingBagNode::OffsetsIdx}) &&
-           (NI.getInElemTy(EmbeddingBagNode::IndicesIdx) == IndexElemKind) &&
-           (NI.getInElemTy(EmbeddingBagNode::OffsetsIdx) == IndexElemKind);
+           (NI.getInElemTy(EmbeddingBagNode::IndicesIdx) ==
+            ElemKind::Int64ITy) &&
+           (NI.getInElemTy(EmbeddingBagNode::OffsetsIdx) == ElemKind::Int64ITy);
 
   case Kinded::Kind::SparseLengthsWeightedSumGradNodeKind:
     // GradOfInputNamedIndicesIdx and GradOfInputNamedLengthsIdx do not need to
@@ -149,7 +160,9 @@ bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
                 SparseLengthsWeightedSumGradNode::
                     GradOfInputNamedLengthsIdx}) &&
            (NI.getInElemTy(SparseLengthsWeightedSumGradNode::IndicesIdx) ==
-            IndexElemKind) &&
+                ElemKind::Int64ITy ||
+            NI.getInElemTy(SparseLengthsWeightedSumGradNode::IndicesIdx) ==
+                ElemKind::Int32ITy) &&
            (NI.getInElemTy(SparseLengthsWeightedSumGradNode::LengthsIdx) ==
             ElemKind::Int32ITy);
 
@@ -168,7 +181,10 @@ bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
             ElemKind::FloatTy) &&
            (NI.getInElemTy(
                 RowwiseQuantizedSparseLengthsWeightedSumNode::IndicesIdx) ==
-            IndexElemKind) &&
+                ElemKind::Int64ITy ||
+            NI.getInElemTy(
+                RowwiseQuantizedSparseLengthsWeightedSumNode::IndicesIdx) ==
+                ElemKind::Int32ITy) &&
            (NI.getInElemTy(
                 RowwiseQuantizedSparseLengthsWeightedSumNode::LengthsIdx) ==
             ElemKind::Int32ITy) &&
@@ -206,10 +222,15 @@ bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
                {MaxPoolGradNode::OriginalOutputForArgmaxIdx,
                 MaxPoolGradNode::GradOfOriginalOutputNamedArgmaxIdx}) &&
            (NI.getInElemTy(MaxPoolGradNode::OriginalOutputForArgmaxIdx) ==
-            IndexElemKind) &&
+                ElemKind::Int64ITy ||
+            NI.getInElemTy(MaxPoolGradNode::OriginalOutputForArgmaxIdx) ==
+                ElemKind::Int32ITy) &&
            (NI.getInElemTy(
                 MaxPoolGradNode::GradOfOriginalOutputNamedArgmaxIdx) ==
-            IndexElemKind);
+                ElemKind::Int64ITy ||
+            NI.getInElemTy(
+                MaxPoolGradNode::GradOfOriginalOutputNamedArgmaxIdx) ==
+                ElemKind::Int32ITy);
 
   case Kinded::Kind::ConvolutionNodeKind:
     if (!NI.getInTy(ConvolutionNode::InputIdx)->isQuantizedType()) {
@@ -237,20 +258,23 @@ bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
 
   case Kinded::Kind::GatherNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
-               {ElemKind::FloatTy, ElemKind::Int8QTy, ElemKind::Int64ITy},
+               {ElemKind::FloatTy, ElemKind::Int8QTy, ElemKind::Int64ITy,
+                ElemKind::Int32ITy},
                {GatherNode::IndicesIdx}) &&
            ((NI.getInElemTy(GatherNode::IndicesIdx) == ElemKind::Int32ITy) ||
-            (NI.getInElemTy(GatherNode::IndicesIdx) == IndexElemKind));
+            (NI.getInElemTy(GatherNode::IndicesIdx) == ElemKind::Int64ITy));
 
   case Kinded::Kind::GatherRangesNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
-               {ElemKind::FloatTy, ElemKind::Int8QTy, ElemKind::Int64ITy},
+               {ElemKind::FloatTy, ElemKind::Int8QTy, ElemKind::Int64ITy,
+                ElemKind::Int32ITy},
                {GatherRangesNode::RangesIdx}, {GatherRangesNode::LengthsIdx}) &&
            ((NI.getInElemTy(GatherRangesNode::RangesIdx) ==
              NI.getOutElemTy(GatherRangesNode::LengthsIdx)) &&
             ((NI.getOutElemTy(GatherRangesNode::LengthsIdx) ==
               ElemKind::Int32ITy) ||
-             (NI.getOutElemTy(GatherRangesNode::LengthsIdx) == IndexElemKind)));
+             (NI.getOutElemTy(GatherRangesNode::LengthsIdx) ==
+              ElemKind::Int64ITy)));
 
   case Kinded::Kind::ScatterDataNodeKind:
     // ScatterData ==> Copy + ScatterData. Copy supports everything
@@ -259,12 +283,14 @@ bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
     return NI.allInputsAndOutputsHaveSameElemKind(
                {ElemKind::FloatTy, ElemKind::Int8QTy},
                {ScatterDataNode::IndicesIdx}) &&
-           (NI.getInElemTy(ScatterDataNode::IndicesIdx) == IndexElemKind);
+           (NI.getInElemTy(ScatterDataNode::IndicesIdx) == ElemKind::Int64ITy ||
+            NI.getInElemTy(ScatterDataNode::IndicesIdx) == ElemKind::Int32ITy);
 
   case Kinded::Kind::SelectNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
-               {ElemKind::FloatTy, ElemKind::Int8QTy}, {SelectNode::CondIdx}) &&
-           (NI.getInElemTy(SelectNode::CondIdx) == ElemKind::BoolTy);
+               {ElemKind::FloatTy, ElemKind::Int8QTy, ElemKind::Int32ITy},
+               {SelectNode::CondIdx}) &&
+           ((NI.getInElemTy(SelectNode::CondIdx) == ElemKind::BoolTy));
 
   case Kinded::Kind::CmpLTENodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
@@ -284,15 +310,17 @@ bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
            (NI.getOutElemTy(CmpLTENode::ResultIdx) == ElemKind::BoolTy);
 
   case Kinded::Kind::CmpEQNodeKind:
-    return NI.allInputsAndOutputsHaveSameElemKind({ElemKind::Int64ITy}, {},
-                                                  {CmpEQNode::ResultIdx}) &&
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::Int64ITy, ElemKind::Int32ITy}, {},
+               {CmpEQNode::ResultIdx}) &&
            (NI.getOutElemTy(CmpEQNode::ResultIdx) == ElemKind::BoolTy);
 
   case Kinded::Kind::TopKNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
                {ElemKind::FloatTy, ElemKind::Int8QTy}, {},
                {TopKNode::IndicesIdx}) &&
-           (NI.getOutElemTy(TopKNode::IndicesIdx) == IndexElemKind);
+           (NI.getOutElemTy(TopKNode::IndicesIdx) == ElemKind::Int64ITy ||
+            NI.getOutElemTy(TopKNode::IndicesIdx) == ElemKind::Int32ITy);
 
   case Kinded::Kind::QuantizeNodeKind:
     return (NI.getInElemTy(QuantizeNode::InputIdx) == ElemKind::FloatTy) &&
@@ -306,12 +334,16 @@ bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
   case Kinded::Kind::SoftMaxNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind({ElemKind::FloatTy},
                                                   {SoftMaxNode::SelectedIdx}) &&
-           (NI.getInElemTy(SoftMaxNode::SelectedIdx) == IndexElemKind);
+           (NI.getInElemTy(SoftMaxNode::SelectedIdx) == ElemKind::Int64ITy ||
+            NI.getInElemTy(SoftMaxNode::SelectedIdx) == ElemKind::Int32ITy);
 
   case Kinded::Kind::CrossEntropyLossNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
                {ElemKind::FloatTy}, {CrossEntropyLossNode::LabelsIdx}) &&
-           (NI.getInElemTy(CrossEntropyLossNode::LabelsIdx) == IndexElemKind);
+           (NI.getInElemTy(CrossEntropyLossNode::LabelsIdx) ==
+                ElemKind::Int64ITy ||
+            NI.getInElemTy(CrossEntropyLossNode::LabelsIdx) ==
+                ElemKind::Int32ITy);
 
   case Kinded::Kind::LengthsSumNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
@@ -324,9 +356,9 @@ bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
            (NI.getInElemTy(EmbeddingBagByteRowwiseOffsetsNode::WeightsIdx) ==
             ElemKind::FloatTy) &&
            (NI.getInElemTy(EmbeddingBagByteRowwiseOffsetsNode::IndicesIdx) ==
-            IndexElemKind) &&
+            ElemKind::Int64ITy) &&
            (NI.getInElemTy(EmbeddingBagByteRowwiseOffsetsNode::OffsetsIdx) ==
-            IndexElemKind) &&
+            ElemKind::Int64ITy) &&
            (NI.getOutElemTy(EmbeddingBagByteRowwiseOffsetsNode::ResultIdx) ==
             ElemKind::FloatTy);
 
@@ -336,8 +368,10 @@ bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
             ElemKind::UInt8FusedQTy) &&
            (NI.getInElemTy(FusedRowwiseQuantizedSparseLengthsWeightedSumNode::
                                WeightsIdx) == ElemKind::FloatTy) &&
-           (NI.getInElemTy(FusedRowwiseQuantizedSparseLengthsWeightedSumNode::
-                               IndicesIdx) == IndexElemKind) &&
+           ((NI.getInElemTy(FusedRowwiseQuantizedSparseLengthsWeightedSumNode::
+                                IndicesIdx) == ElemKind::Int64ITy ||
+             NI.getInElemTy(FusedRowwiseQuantizedSparseLengthsWeightedSumNode::
+                                IndicesIdx) == ElemKind::Int32ITy)) &&
            (NI.getInElemTy(FusedRowwiseQuantizedSparseLengthsWeightedSumNode::
                                LengthsIdx) == ElemKind::Int32ITy) &&
            (NI.getOutElemTy(
@@ -363,13 +397,18 @@ bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
   case Kinded::Kind::SparseToDenseNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
                {ElemKind::FloatTy}, {SparseToDenseNode::IndicesIdx}) &&
-           (NI.getInElemTy(SparseToDenseNode::IndicesIdx) == IndexElemKind);
+           (NI.getInElemTy(SparseToDenseNode::IndicesIdx) ==
+                ElemKind::Int64ITy ||
+            NI.getInElemTy(SparseToDenseNode::IndicesIdx) ==
+                ElemKind::Int32ITy);
 
   case Kinded::Kind::SoftMaxGradNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
                {ElemKind::FloatTy}, {SoftMaxGradNode::SelectedIdx},
                {SoftMaxGradNode::GradOfInputNamedSelectedIdx}) &&
-           (NI.getInElemTy(SoftMaxGradNode::SelectedIdx) == IndexElemKind);
+           (NI.getInElemTy(SoftMaxGradNode::SelectedIdx) ==
+                ElemKind::Int64ITy ||
+            NI.getInElemTy(SoftMaxGradNode::SelectedIdx) == ElemKind::Int32ITy);
 
   case Kinded::Kind::ConvolutionGradNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
@@ -381,10 +420,10 @@ bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
                {ElemKind::FloatTy}, {CrossEntropyLossGradNode::LabelsIdx},
                {CrossEntropyLossGradNode::GradOfInputNamedLabelsIdx}) &&
            (NI.getInElemTy(CrossEntropyLossGradNode::LabelsIdx) ==
-            IndexElemKind) &&
+            ElemKind::Int64ITy) &&
            (NI.getOutElemTy(
                 CrossEntropyLossGradNode::GradOfInputNamedLabelsIdx) ==
-            IndexElemKind);
+            ElemKind::Int64ITy);
 
   case Kinded::Kind::TraceEventNodeKind:
     return NI.getInElemTy(TraceEventNode::DataIdx) == ElemKind::Int64ITy;
@@ -403,10 +442,7 @@ bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
                 ElemKind::Int32ITy ||
             NI.getOutElemTy(
                 NonMaxSuppressionNode::NumberOfSelectedIndicesIdx) ==
-                ElemKind::Int64ITy) &&
-           (NI.getOutElemTy(
-                NonMaxSuppressionNode::NumberOfSelectedIndicesIdx) ==
-            NI.getOutElemTy(NonMaxSuppressionNode::IndicesIdx));
+                ElemKind::Int64ITy);
 
   case Kinded::Kind::ConvertToNodeKind:
     return ((NI.getInElemTy(ConvertToNode::InputIdx) == ElemKind::Int32ITy) &&
@@ -454,4 +490,21 @@ CPUBackend::createIRGen(const IRFunction *IR,
 llvm::StringRef CPUBackend::getLibjitBitcode() const {
   return llvm::StringRef(reinterpret_cast<const char *>(libjit_bc),
                          libjit_bc_size);
+}
+
+/// \returns true if network supports Type Lowering from \p T1 to \p T2.
+/// Populates PrecisionConfiguration with black list of operations that can't be
+/// converted.
+bool CPUBackend::canDoIndexTypeDemotion(
+    ElemKind fromTy, ElemKind toTy, PrecisionConfiguration &precConfig) const {
+  precConfig.precisionModeKindSet.insert(Kinded::Kind::EmbeddingBagNodeKind);
+  precConfig.precisionModeKindSet.insert(
+      Kinded::Kind::EmbeddingBagByteRowwiseOffsetsNodeKind);
+  precConfig.precisionModeKindSet.insert(
+      Kinded::Kind::FusedRowwiseQuantizedSparseLengthsSumNodeKind);
+  precConfig.precisionModeKindSet.insert(
+      Kinded::Kind::FusedRowwiseQuantizedSparseLengthsWeightedSumNodeKind);
+  precConfig.precisionModeKindSet.insert(
+      Kinded::Kind::SparseToDenseMaskNodeKind);
+  return fromTy == ElemKind::Int64ITy && toTy == ElemKind::Int32ITy;
 }

--- a/lib/Backends/CPU/CPUBackend.h
+++ b/lib/Backends/CPU/CPUBackend.h
@@ -56,6 +56,13 @@ public:
   createDeviceManager(const runtime::DeviceConfig &deviceConfig) override {
     return createCPUDeviceManager(deviceConfig);
   }
+
+  /// \returns true if network supports Type Lowering from \p T1 to \p T2.
+  /// Populates PrecisionConfiguration with black list of operations that can't
+  /// be converted.
+  virtual bool
+  canDoIndexTypeDemotion(ElemKind fromTy, ElemKind toTy,
+                         PrecisionConfiguration &precConfig) const override;
   /// @}
 
 public:

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -125,13 +125,13 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
     return NI.allInputsAndOutputsHaveSameElemKind(
                {ElemKind::FloatTy, ElemKind::Float16Ty, ElemKind::Int8QTy}, {},
                {MaxPoolNode::ArgmaxIdx}) &&
-           (NI.getOutElemTy(MaxPoolNode::ArgmaxIdx) == IndexElemKind);
+           (NI.getOutElemTy(MaxPoolNode::ArgmaxIdx) == ElemKind::Int64ITy);
 
   case Kinded::Kind::ArgMaxNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
                {ElemKind::FloatTy, ElemKind::Int8QTy}, {},
                {ArgMaxNode::ArgmaxIdx}) &&
-           (NI.getOutElemTy(ArgMaxNode::ArgmaxIdx) == IndexElemKind);
+           (NI.getOutElemTy(ArgMaxNode::ArgmaxIdx) == ElemKind::Int64ITy);
 
   case Kinded::Kind::PowNodeKind:
   case Kinded::Kind::LocalResponseNormalizationNodeKind:
@@ -276,7 +276,7 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
                {SparseLengthsSumNode::IndicesIdx,
                 SparseLengthsSumNode::LengthsIdx}) &&
            (NI.getInElemTy(SparseLengthsSumNode::IndicesIdx) ==
-            IndexElemKind) &&
+            ElemKind::Int64ITy) &&
            (NI.getInElemTy(SparseLengthsSumNode::LengthsIdx) ==
             ElemKind::Int32ITy);
 
@@ -286,7 +286,7 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
                {SparseLengthsWeightedSumNode::IndicesIdx,
                 SparseLengthsWeightedSumNode::LengthsIdx}) &&
            (NI.getInElemTy(SparseLengthsWeightedSumNode::IndicesIdx) ==
-            IndexElemKind) &&
+            ElemKind::Int64ITy) &&
            (NI.getInElemTy(SparseLengthsWeightedSumNode::LengthsIdx) ==
             ElemKind::Int32ITy);
 
@@ -294,8 +294,9 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
     return NI.allInputsAndOutputsHaveSameElemKind(
                {ElemKind::FloatTy, ElemKind::Float16Ty},
                {EmbeddingBagNode::IndicesIdx, EmbeddingBagNode::OffsetsIdx}) &&
-           (NI.getInElemTy(EmbeddingBagNode::IndicesIdx) == IndexElemKind) &&
-           (NI.getInElemTy(EmbeddingBagNode::OffsetsIdx) == IndexElemKind);
+           (NI.getInElemTy(EmbeddingBagNode::IndicesIdx) ==
+            ElemKind::Int64ITy) &&
+           (NI.getInElemTy(EmbeddingBagNode::OffsetsIdx) == ElemKind::Int64ITy);
 
   case Kinded::Kind::SparseLengthsWeightedSumGradNodeKind:
     // GradOfInputNamedIndicesIdx and GradOfInputNamedLengthsIdx do not need to
@@ -308,7 +309,7 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
                 SparseLengthsWeightedSumGradNode::
                     GradOfInputNamedLengthsIdx}) &&
            (NI.getInElemTy(SparseLengthsWeightedSumGradNode::IndicesIdx) ==
-            IndexElemKind) &&
+            ElemKind::Int64ITy) &&
            (NI.getInElemTy(SparseLengthsWeightedSumGradNode::LengthsIdx) ==
             ElemKind::Int32ITy);
 
@@ -323,16 +324,16 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
             ElemKind::UInt8QTy) &&
            (NI.getInElemTy(
                 RowwiseQuantizedSparseLengthsWeightedSumNode::IndicesIdx) ==
-            IndexElemKind) &&
+            ElemKind::Int64ITy) &&
            (NI.getInElemTy(
                 RowwiseQuantizedSparseLengthsWeightedSumNode::LengthsIdx) ==
             ElemKind::Int32ITy);
 
   case Kinded::Kind::EmbeddingBagByteRowwiseOffsetsNodeKind: {
     if (NI.getInElemTy(EmbeddingBagByteRowwiseOffsetsNode::IndicesIdx) !=
-            IndexElemKind ||
+            ElemKind::Int64ITy ||
         NI.getInElemTy(EmbeddingBagByteRowwiseOffsetsNode::OffsetsIdx) !=
-            IndexElemKind) {
+            ElemKind::Int64ITy) {
       return false;
     }
 
@@ -356,7 +357,7 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
   case Kinded::Kind::FusedRowwiseQuantizedSparseLengthsWeightedSumNodeKind: {
     if (NI.getInElemTy(
             FusedRowwiseQuantizedSparseLengthsWeightedSumNode::IndicesIdx) !=
-            IndexElemKind ||
+            ElemKind::Int64ITy ||
         NI.getInElemTy(
             FusedRowwiseQuantizedSparseLengthsWeightedSumNode::LengthsIdx) !=
             ElemKind::Int32ITy) {
@@ -425,10 +426,10 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
                {MaxPoolGradNode::OriginalOutputForArgmaxIdx,
                 MaxPoolGradNode::GradOfOriginalOutputNamedArgmaxIdx}) &&
            (NI.getInElemTy(MaxPoolGradNode::OriginalOutputForArgmaxIdx) ==
-            IndexElemKind) &&
+            ElemKind::Int64ITy) &&
            (NI.getInElemTy(
                 MaxPoolGradNode::GradOfOriginalOutputNamedArgmaxIdx) ==
-            IndexElemKind);
+            ElemKind::Int64ITy);
 
   case Kinded::Kind::QuantizeNodeKind:
     return ((NI.getInElemTy(QuantizeNode::InputIdx) == ElemKind::FloatTy) ||
@@ -474,10 +475,12 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
     return NI.allInputsAndOutputsHaveSameElemKind(
                {ElemKind::FloatTy, ElemKind::Float16Ty, ElemKind::Int8QTy}, {},
                {TopKNode::IndicesIdx}) &&
-           (NI.getOutElemTy(TopKNode::IndicesIdx) == IndexElemKind);
+           ((NI.getOutElemTy(TopKNode::IndicesIdx) == ElemKind::Int64ITy) ||
+            (NI.getOutElemTy(TopKNode::IndicesIdx) == ElemKind::Int32ITy));
 
   case Kinded::Kind::ScatterDataNodeKind:
-    return (NI.getInElemTy(ScatterDataNode::IndicesIdx) == IndexElemKind) &&
+    return (NI.getInElemTy(ScatterDataNode::IndicesIdx) ==
+            ElemKind::Int64ITy) &&
            (NI.getOutElemTy(ScatterDataNode::ResultIdx) ==
             NI.getInElemTy(ScatterDataNode::DataIdx)) &&
            (NI.getOutElemTy(ScatterDataNode::ResultIdx) ==
@@ -503,7 +506,8 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
     return NI.allInputsAndOutputsHaveSameElemKind(
                {ElemKind::FloatTy, ElemKind::Float16Ty},
                {CrossEntropyLossNode::LabelsIdx}) &&
-           (NI.getInElemTy(CrossEntropyLossNode::LabelsIdx) == IndexElemKind);
+           (NI.getInElemTy(CrossEntropyLossNode::LabelsIdx) ==
+            ElemKind::Int64ITy);
 
   case Kinded::Kind::CumSumNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
@@ -520,11 +524,12 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
     return NI.allInputsAndOutputsHaveSameElemKind(
                {ElemKind::FloatTy, ElemKind::Float16Ty},
                {SparseToDenseNode::IndicesIdx}) &&
-           (NI.getInElemTy(SparseToDenseNode::IndicesIdx) == IndexElemKind);
+           (NI.getInElemTy(SparseToDenseNode::IndicesIdx) ==
+            ElemKind::Int64ITy);
 
   case Kinded::Kind::SparseToDenseMaskNodeKind:
     return (NI.getInElemTy(SparseToDenseMaskNode::IndicesIdx) ==
-            IndexElemKind) &&
+            ElemKind::Int64ITy) &&
            (NI.getInElemTy(SparseToDenseMaskNode::LengthsIdx) ==
             ElemKind::Int32ITy) &&
            (NI.getInElemTy(SparseToDenseMaskNode::ValuesIdx) ==
@@ -565,7 +570,7 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
     return NI.allInputsAndOutputsHaveSameElemKind(
                {ElemKind::FloatTy}, {SoftMaxGradNode::SelectedIdx},
                {SoftMaxGradNode::GradOfInputNamedSelectedIdx}) &&
-           (NI.getInElemTy(SoftMaxGradNode::SelectedIdx) == IndexElemKind);
+           (NI.getInElemTy(SoftMaxGradNode::SelectedIdx) == ElemKind::Int64ITy);
 
   case Kinded::Kind::ConvolutionGradNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
@@ -577,10 +582,10 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
                {ElemKind::FloatTy}, {CrossEntropyLossGradNode::LabelsIdx},
                {CrossEntropyLossGradNode::GradOfInputNamedLabelsIdx}) &&
            (NI.getInElemTy(CrossEntropyLossGradNode::LabelsIdx) ==
-            IndexElemKind) &&
+            ElemKind::Int64ITy) &&
            (NI.getOutElemTy(
                 CrossEntropyLossGradNode::GradOfInputNamedLabelsIdx) ==
-            IndexElemKind);
+            ElemKind::Int64ITy);
 
   case Kinded::Kind::BatchedPairwiseDotProductNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind({ElemKind::FloatTy});

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -704,7 +704,7 @@ void OpenCLFunction::executeNCHWConvolution(
 template <typename T>
 static void topK(Tensor &outW, Tensor &indW, Tensor &inW, size_t k) {
   auto values = outW.getHandle<T>();
-  auto indices = indW.getHandle<sdim_t>();
+  auto indices = indW.getHandle<int64_t>();
   auto in = inW.getHandle<T>();
   size_t n = in.dims().back();
 
@@ -1757,7 +1757,7 @@ bool OCLBackend::isOpSupported(const NodeInfo &NI) const {
   case Kinded::Kind::SplatNodeKind:
   case Kinded::Kind::TransposeNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
-        {ElemKind::FloatTy, ElemKind::Int8QTy, IndexElemKind});
+        {ElemKind::FloatTy, ElemKind::Int8QTy, ElemKind::Int64ITy});
 
   case Kinded::Kind::PowNodeKind:
   case Kinded::Kind::LocalResponseNormalizationNodeKind:
@@ -1785,7 +1785,7 @@ bool OCLBackend::isOpSupported(const NodeInfo &NI) const {
     return NI.allInputsAndOutputsHaveSameElemKind(
                {ElemKind::FloatTy, ElemKind::Int8QTy}, {},
                {MaxPoolNode::ArgmaxIdx}) &&
-           (NI.getOutElemTy(MaxPoolNode::ArgmaxIdx) == IndexElemKind);
+           (NI.getOutElemTy(MaxPoolNode::ArgmaxIdx) == ElemKind::Int64ITy);
 
   case Kinded::Kind::ConvolutionNodeKind:
     if (!NI.getInTy(ConvolutionNode::InputIdx)->isQuantizedType()) {
@@ -1799,7 +1799,7 @@ bool OCLBackend::isOpSupported(const NodeInfo &NI) const {
     return NI.allInputsAndOutputsHaveSameElemKind(
                {ElemKind::FloatTy, ElemKind::Int8QTy}, {},
                {TopKNode::IndicesIdx}) &&
-           (NI.getOutElemTy(TopKNode::IndicesIdx) == IndexElemKind);
+           (NI.getOutElemTy(TopKNode::IndicesIdx) == ElemKind::Int64ITy);
 
   case Kinded::Kind::BatchedAddNodeKind:
     if (!NI.getInTy(BatchedAddNode::BatchIdx)->isQuantizedType()) {
@@ -1813,12 +1813,12 @@ bool OCLBackend::isOpSupported(const NodeInfo &NI) const {
   case Kinded::Kind::GatherNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind({ElemKind::FloatTy},
                                                   {GatherNode::IndicesIdx}) &&
-           (NI.getInElemTy(GatherNode::IndicesIdx) == IndexElemKind);
+           (NI.getInElemTy(GatherNode::IndicesIdx) == ElemKind::Int64ITy);
 
   case Kinded::Kind::ScatterDataNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
                {ElemKind::FloatTy}, {ScatterDataNode::IndicesIdx}) &&
-           (NI.getInElemTy(ScatterDataNode::IndicesIdx) == IndexElemKind);
+           (NI.getInElemTy(ScatterDataNode::IndicesIdx) == ElemKind::Int64ITy);
 
   case Kinded::Kind::SparseLengthsWeightedSumNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
@@ -1826,7 +1826,7 @@ bool OCLBackend::isOpSupported(const NodeInfo &NI) const {
                {SparseLengthsWeightedSumNode::IndicesIdx,
                 SparseLengthsWeightedSumNode::LengthsIdx}) &&
            (NI.getInElemTy(SparseLengthsWeightedSumNode::IndicesIdx) ==
-            IndexElemKind) &&
+            ElemKind::Int64ITy) &&
            (NI.getInElemTy(SparseLengthsWeightedSumNode::LengthsIdx) ==
             ElemKind::Int32ITy);
 
@@ -1836,10 +1836,10 @@ bool OCLBackend::isOpSupported(const NodeInfo &NI) const {
                {MaxPoolGradNode::OriginalOutputForArgmaxIdx,
                 MaxPoolGradNode::GradOfOriginalOutputNamedArgmaxIdx}) &&
            (NI.getInElemTy(MaxPoolGradNode::OriginalOutputForArgmaxIdx) ==
-            IndexElemKind) &&
+            ElemKind::Int64ITy) &&
            (NI.getInElemTy(
                 MaxPoolGradNode::GradOfOriginalOutputNamedArgmaxIdx) ==
-            IndexElemKind);
+            ElemKind::Int64ITy);
 
   case Kinded::Kind::SparseLengthsWeightedSumGradNodeKind:
     // GradOfInputNamedIndicesIdx and GradOfInputNamedLengthsIdx do not need to
@@ -1852,7 +1852,7 @@ bool OCLBackend::isOpSupported(const NodeInfo &NI) const {
                 SparseLengthsWeightedSumGradNode::
                     GradOfInputNamedLengthsIdx}) &&
            (NI.getInElemTy(SparseLengthsWeightedSumGradNode::IndicesIdx) ==
-            IndexElemKind) &&
+            ElemKind::Int64ITy) &&
            (NI.getInElemTy(SparseLengthsWeightedSumGradNode::LengthsIdx) ==
             ElemKind::Int32ITy);
 
@@ -1895,7 +1895,7 @@ bool OCLBackend::isOpSupported(const NodeInfo &NI) const {
     return NI.allInputsAndOutputsHaveSameElemKind(
                {ElemKind::FloatTy}, {SoftMaxGradNode::SelectedIdx},
                {SoftMaxGradNode::GradOfInputNamedSelectedIdx}) &&
-           (NI.getInElemTy(SoftMaxGradNode::SelectedIdx) == IndexElemKind);
+           (NI.getInElemTy(SoftMaxGradNode::SelectedIdx) == ElemKind::Int64ITy);
 
   case Kinded::Kind::SaveNodeKind:
   case Kinded::Kind::ReshapeNodeKind:

--- a/lib/Backends/OpenCL/kernels.cl
+++ b/lib/Backends/OpenCL/kernels.cl
@@ -23,6 +23,19 @@ typedef int cl_int32_t;
 typedef char cl_int8_t;
 typedef unsigned char cl_uint8_t;
 
+/// Define a type cl_host_size_t exactly matching the type size_t used on the
+/// host size. This is required to e.g. properly pass struct parameters of
+/// types like ShapeNHWC, ShapeNCHW, etc. The definitions of these types on the
+/// host side use size_t for their members and they should be defined on the
+/// OpenCL's side using integer types of the same width.
+#if SIZEOF_HOST_SIZE_T == 8
+typedef cl_uint64_t cl_host_size_t;
+#elif SIZEOF_HOST_SIZE_T == 4
+typedef cl_uint32_t cl_host_size_t;
+#else
+#error "Unsupported size of size_t on the host side"
+#endif
+
 /// The types of elements should be always matching the definitions of
 /// ShapeNHWC in Type.h
 typedef struct {
@@ -1013,7 +1026,8 @@ __kernel void softmaxW(__global void *mem, cl_uint32_t dest, cl_uint32_t src,
 }
 
 __kernel void softmaxgradK(__global float *inG, __global float *outW,
-                           __global dim_t *selectedW, cl_uint32_t sliceSize) {
+                           __global cl_uint64_t *selectedW,
+                           cl_uint32_t sliceSize) {
   size_t i = get_global_id(0);
   for (size_t j = 0; j < sliceSize; j++) {
     float delta = (selectedW[i] == j);
@@ -1314,9 +1328,10 @@ DEFINE_OPENCL_MAXPOOL_KERNEL(oclmaxpool_i8, char)
 #undef DEFINE_OPENCL_BINARY_DATA_PARALLEL_KERNEL
 
 __kernel void maxpoolwithargmaxK(__global float *dest, __global float *src,
-                                 __global dim_t *argmax, cl_uint32_t kernelSize,
-                                 cl_uint32_t stride, PaddingTLBR pads,
-                                 ShapeNHWC odim, ShapeNHWC idim) {
+                                 __global cl_uint64_t *argmax,
+                                 cl_uint32_t kernelSize, cl_uint32_t stride,
+                                 PaddingTLBR pads, ShapeNHWC odim,
+                                 ShapeNHWC idim) {
   size_t ax = get_global_id(0);
   size_t ay = get_global_id(1);
   size_t d = get_global_id(2);
@@ -1330,7 +1345,7 @@ __kernel void maxpoolwithargmaxK(__global float *dest, __global float *src,
   for (size_t n = 0; n < idim.n; n++) {
     float maxVal = 0;
     bool first = true;
-    dim_t argmaxNHWC = 0;
+    cl_uint64_t argmaxNHWC = 0;
 
     // For each element in the convolution-filter:
     for (size_t fx = 0; fx < kernelSize; fx++) {
@@ -1369,10 +1384,13 @@ __kernel void maxpoolwithargmaxW(__global void *mem, cl_uint32_t dest,
                      pads, odim, idim);
 }
 
-__kernel void maxpoolwithargmaxgradK(
-    __global float *dest, __global dim_t *argmax, __global float *destGrad,
-    __global float *srcGrad, cl_uint32_t kernelSize, cl_uint32_t stride,
-    PaddingTLBR pads, ShapeNHWC srcGradDim, ShapeNHWC destGradDim) {
+__kernel void maxpoolwithargmaxgradK(__global float *dest,
+                                     __global cl_uint64_t *argmax,
+                                     __global float *destGrad,
+                                     __global float *srcGrad,
+                                     cl_uint32_t kernelSize, cl_uint32_t stride,
+                                     PaddingTLBR pads, ShapeNHWC srcGradDim,
+                                     ShapeNHWC destGradDim) {
   size_t n = get_global_id(0);
 
   // NHWC format is assumed
@@ -1653,11 +1671,11 @@ void memcpy_float(__global float *dest, const __global float *src, int len) {
 }
 
 __kernel void gatherK(__global float *dest, __global const float *src,
-                      __global dim_t *indices, cl_uint32_t numIndices,
+                      __global cl_uint64_t *indices, cl_uint32_t numIndices,
                       cl_uint32_t sliceSize, cl_uint32_t numSamples,
                       cl_uint32_t destSampleSize, cl_uint32_t srcSampleSize) {
   int idx = get_global_id(0);
-  dim_t slice = indices[idx];
+  cl_uint64_t slice = indices[idx];
   // For each sample in our batch:
   for (size_t sample = 0; sample < numSamples; sample++) {
     size_t srcSampleStart = sample * srcSampleSize;
@@ -1675,11 +1693,11 @@ __kernel void gatherW(__global void *mem, cl_uint32_t dest, cl_uint32_t src,
           numSamples, destSampleSize, srcSampleSize);
 }
 
-__kernel void scatterdataK(__global float *data, __global dim_t *indices,
+__kernel void scatterdataK(__global float *data, __global cl_uint64_t *indices,
                            __global const float *slices,
                            cl_uint32_t sliceSize) {
   int idx = get_global_id(0);
-  dim_t destDataIdx = indices[idx];
+  cl_uint64_t destDataIdx = indices[idx];
   memcpy_float(data + destDataIdx * sliceSize, slices + idx * sliceSize,
                sliceSize);
 }
@@ -1690,10 +1708,12 @@ __kernel void scatterdataW(__global void *mem, cl_uint32_t data,
   scatterdataK(&mem[data], &mem[indices], &mem[slices], sliceSize);
 }
 
-__kernel void
-sparselengthsweightedsumK(__global float *dest, __global float *data,
-                          __global float *weights, __global dim_t *indices,
-                          __global cl_int32_t *lengths, cl_uint32_t sliceSize) {
+__kernel void sparselengthsweightedsumK(__global float *dest,
+                                        __global float *data,
+                                        __global float *weights,
+                                        __global cl_uint64_t *indices,
+                                        __global cl_int32_t *lengths,
+                                        cl_uint32_t sliceSize) {
   // Get the global ID. This corresponds to the segment that this kernel will
   // compute, and therefore also the index into the output buffer at which this
   // kernel will write its output.
@@ -1713,7 +1733,7 @@ sparselengthsweightedsumK(__global float *dest, __global float *data,
     // Read the weight.
     float weight = weights[curIdx];
     // Read the data index.
-    dim_t dataIdx = indices[curIdx];
+    cl_uint64_t dataIdx = indices[curIdx];
 
     // Read an entire slice of data at index dataIdx, multiply it by the weight
     // and store it into dest at index idx (same as the segment number).
@@ -1738,8 +1758,8 @@ __kernel void sparselengthsweightedsumW(__global void *mem, cl_uint32_t dest,
 __kernel void sparselengthsweightedsumgradK(
     __global float *destGrad, __global float *dataGrad,
     __global float *weightsGrad, __global float *data, __global float *weights,
-    __global dim_t *indices, __global cl_int32_t *lengths, cl_uint32_t segments,
-    cl_uint32_t sliceSize) {
+    __global cl_uint64_t *indices, __global cl_int32_t *lengths,
+    cl_uint32_t segments, cl_uint32_t sliceSize) {
 
   // For each segment:
   for (cl_uint32_t i = 0, curIdx = 0; i < segments; ++i) {
@@ -1749,7 +1769,7 @@ __kernel void sparselengthsweightedsumgradK(
       // Get the weight for the current index.
       float weight = weights[curIdx];
       // Get the index into dataGrad corresponding to the current index.
-      dim_t dataGradIdx = indices[curIdx];
+      cl_uint64_t dataGradIdx = indices[curIdx];
 
       // Read an entire slice of destGrad at index i (same as the segment
       // number), multiply it by the weight (that helped produce the

--- a/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
@@ -330,4 +330,8 @@ std::set<std::string> glow::backendTestBlacklist = {
     "FusedRowwiseQuantizedSLWSLengthsLow_Float16_AccumFloat16/0",
     "FusedRowwiseQuantizedSLWSLengthsLow_Fused4Bit_Float16_AccumFloat16/0",
     "SLWSLengthsLow_Float16_AccumFloat/0",
-};
+    "TopK1int32/0",
+    "mul_int32/0",
+    "mul_int64/0",
+    "add_int32/0",
+    "add_int64/0"};

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -850,6 +850,7 @@ MaxPoolNode *Function::createMaxPool(llvm::StringRef name, NodeValue input,
                                      llvm::ArrayRef<unsigned_t> kernels,
                                      llvm::ArrayRef<unsigned_t> strides,
                                      llvm::ArrayRef<unsigned_t> pads,
+                                     ElemKind elemTyAMT,
                                      ConvolutionLayout layout) {
   ShapeNHWC idim = ShapeNHWC(input.dims());
   checkKernelSize(idim, kernels, pads);
@@ -859,7 +860,7 @@ MaxPoolNode *Function::createMaxPool(llvm::StringRef name, NodeValue input,
   auto OT = getParent()->uniqueTypeWithNewShape(
       input.getType(), {idim.n, outSz.first, outSz.second, idim.c});
   auto AMT = getParent()->uniqueType(
-      IndexElemKind, {idim.n, outSz.first, outSz.second, idim.c});
+      elemTyAMT, {idim.n, outSz.first, outSz.second, idim.c});
 
   return addNode(
       new MaxPoolNode(name, OT, AMT, input, kernels, strides, pads, layout));
@@ -867,11 +868,12 @@ MaxPoolNode *Function::createMaxPool(llvm::StringRef name, NodeValue input,
 
 MaxPoolNode *Function::createMaxPool(llvm::StringRef name, NodeValue input,
                                      unsigned_t kernel, unsigned_t stride,
-                                     unsigned_t pad, ConvolutionLayout layout) {
+                                     unsigned_t pad, ElemKind elemTyAMT,
+                                     ConvolutionLayout layout) {
   llvm::SmallVector<unsigned_t, 4> pads = {pad, pad, pad, pad};
   llvm::SmallVector<unsigned_t, 2> strides = {stride, stride};
   llvm::SmallVector<unsigned_t, 2> kernels = {kernel, kernel};
-  return createMaxPool(name, input, kernels, strides, pads, layout);
+  return createMaxPool(name, input, kernels, strides, pads, elemTyAMT, layout);
 }
 
 AvgPoolNode *Function::createAvgPool(llvm::StringRef name, NodeValue input,
@@ -2096,7 +2098,7 @@ QuantizationProfileNode *
 Function::createQuantizationProfile(PlaceholderBindings &bindings,
                                     llvm::StringRef name, NodeValue input) {
   // TODO: this size is going to be refined. Just a placeholder now.
-  const size_t numberOfBuckets = 2000U;
+  const dim_t numberOfBuckets = 2000U;
   auto *histogram = getParent()->createPlaceholder(
       ElemKind::FloatTy, {numberOfBuckets}, "histogram_" + name.str(), false);
   bindings.allocate(histogram)->zero();
@@ -2187,7 +2189,7 @@ IntLookupTableNode *Function::createIntSigmoid(llvm::StringRef name,
 }
 
 TopKNode *Function::createTopK(llvm::StringRef name, NodeValue input,
-                               unsigned_t k) {
+                               unsigned_t k, ElemKind outIndicesTyKind) {
   auto inDims = input.dims();
   assert(inDims.size() > 0);
   assert(k <= inDims.back());
@@ -2195,7 +2197,12 @@ TopKNode *Function::createTopK(llvm::StringRef name, NodeValue input,
   outDims.back() = k;
   auto OT = getParent()->uniqueTypeWithNewShape(input.getType(), outDims);
   return addNode(new TopKNode(
-      name, OT, getParent()->uniqueType(IndexElemKind, outDims), input, k));
+      name, OT, getParent()->uniqueType(outIndicesTyKind, outDims), input, k));
+}
+
+TopKNode *Function::createTopK(llvm::StringRef name, NodeValue input,
+                               unsigned_t k) {
+  return createTopK(name, input, k, ElemKind::Int64ITy);
 }
 
 ArgMaxNode *Function::createArgMax(llvm::StringRef name, NodeValue input,
@@ -2209,7 +2216,7 @@ ArgMaxNode *Function::createArgMax(llvm::StringRef name, NodeValue input,
       newDims.push_back(i == axis ? 1 : inDims[i]);
     }
   }
-  auto TR = getParent()->uniqueType(IndexElemKind, newDims);
+  auto TR = getParent()->uniqueType(ElemKind::Int64ITy, newDims);
   return addNode(new ArgMaxNode(name, TR, input, axis, keepDims));
 }
 

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -467,7 +467,8 @@ static bool verifyRegression(NodeValue src, NodeValue dest,
 static bool verifySparseLengthsSum(NodeValue dest, NodeValue data,
                                    NodeValue indices, NodeValue lengths) {
   bool isValid = checkType(dest, data.getElementType(), dest.getNode());
-  isValid &= checkType(indices, IndexElemKind, dest.getNode());
+  isValid &= checkType(indices, {ElemKind::Int64ITy, ElemKind::Int32ITy},
+                       dest.getNode());
   isValid &= checkType(lengths, ElemKind::Int32ITy, dest.getNode());
   isValid &=
       expectCompareTrue("Indices must be a 1D vector", indices.dims().size(),
@@ -483,7 +484,8 @@ static bool verifySparseLengthsWeightedSum(NodeValue dest, NodeValue data,
                                            NodeValue lengths) {
   bool isValid = checkType(dest, data.getElementType(), dest.getNode());
   isValid &= checkType(weights, data.getElementType(), dest.getNode());
-  isValid &= checkType(indices, IndexElemKind, dest.getNode());
+  isValid &= checkType(indices, {ElemKind::Int64ITy, ElemKind::Int32ITy},
+                       dest.getNode());
   isValid &= checkType(lengths, ElemKind::Int32ITy, dest.getNode());
   isValid &=
       expectCompareTrue("Indices must be a 1D vector", indices.dims().size(),
@@ -506,8 +508,8 @@ static bool verifyEmbeddingBag(NodeValue dest, NodeValue data,
                                NodeValue offsets) {
   bool isValid = checkType(dest, data.getElementType(), dest.getNode());
   isValid &= checkType(weights, data.getElementType(), dest.getNode());
-  isValid &= checkType(indices, IndexElemKind, dest.getNode());
-  isValid &= checkType(offsets, IndexElemKind, dest.getNode());
+  isValid &= checkType(indices, ElemKind::Int64ITy, dest.getNode());
+  isValid &= checkType(offsets, ElemKind::Int64ITy, dest.getNode());
   isValid &=
       expectCompareTrue("Indices must be a 1D vector", indices.dims().size(),
                         size_t(1), dest.getNode());
@@ -1377,11 +1379,11 @@ static bool verifyFusedRowwiseQuantizedSparseLengthsSum(
         "Only use FP16 accumulation with FP16 version of RWQ-SLWS.",
         result.getType()->getElementType(), ElemKind::Float16Ty, parent);
   }
-  isValid &= checkType(indices, IndexElemKind, parent);
+  isValid &= checkType(indices, ElemKind::Int64ITy, parent);
   // For EmbeddingBagByteRowwiseOffsets lengths are really offsets and should be
   // Int64ITy.
   if (isEmbeddingBagByteRowwiseOffsets) {
-    isValid &= checkType(lengths, IndexElemKind, parent);
+    isValid &= checkType(lengths, ElemKind::Int64ITy, parent);
   } else {
     isValid &= checkType(lengths, ElemKind::Int32ITy, parent);
   }
@@ -1467,7 +1469,8 @@ bool LengthsRangeFillNode::verify() const {
 
 bool SparseToDenseNode::verify() const {
   bool isValid = checkType(getResult(), getValues().getElementType(), this);
-  isValid &= checkType(getIndices(), IndexElemKind, this);
+  isValid &=
+      checkType(getIndices(), {ElemKind::Int64ITy, ElemKind::Int32ITy}, this);
   isValid &= expectCompareTrue("Indices must be a 1D vector",
                                getIndices().dims().size(), size_t(1), this);
   isValid &=
@@ -1479,7 +1482,7 @@ bool SparseToDenseNode::verify() const {
 bool SparseToDenseMaskNode::verify() const {
   bool isValid = checkType(getResult(), getValues().getElementType(), this);
   isValid &= checkType(getResult(), getDefaultValue().getElementType(), this);
-  isValid &= checkType(getIndices(), IndexElemKind, this);
+  isValid &= checkType(getIndices(), ElemKind::Int64ITy, this);
   isValid &= checkType(getLengths(), ElemKind::Int32ITy, this);
   isValid &= expectCompareTrue("Indices must be a 1D vector",
                                getIndices().dims().size(), size_t(1), this);
@@ -1568,8 +1571,9 @@ bool ArgMaxNode::verify() const {
   bool isValid = true;
 
   // Check input type.
-  isValid &=
-      checkType(getArgmax(), llvm::ArrayRef<ElemKind>({IndexElemKind}), this);
+  isValid &= checkType(
+      getArgmax(),
+      llvm::ArrayRef<ElemKind>({ElemKind::Int64ITy, ElemKind::Int32ITy}), this);
 
   isValid &= expectCompareTrue("Input must be a 4D tensor",
                                getInput().dims().size(), size_t(4), this);

--- a/lib/IR/IRGen.cpp
+++ b/lib/IR/IRGen.cpp
@@ -153,9 +153,10 @@ void IRGenVisitor::post(Node *parent, Node *N) {
   case glow::Kinded::Kind::MaxPoolNodeKind: {
     auto *P = cast<MaxPoolNode>(N);
     auto *in = valueForNode(P->getInput());
+    auto argMax = P->getArgmax();
     auto *V = builder_.createMaxPoolWithArgmaxOp(
         N->getName(), in, P->getKernels(), P->getStrides(), P->getPads(),
-        P->getLayout());
+        P->getLayout(), argMax.getElementType());
     Value *dest = V->getDest();
     Value *argmax = V->getArgmax();
     nodeToInstr_[N] = V;
@@ -167,7 +168,8 @@ void IRGenVisitor::post(Node *parent, Node *N) {
     auto *P = cast<ArgMaxNode>(N);
     auto *in = valueForNode(P->getInput());
     auto *V = builder_.createArgMaxOp(N->getName(), in, P->getAxis(),
-                                      P->getKeepDims());
+                                      P->getKeepDims(),
+                                      P->getArgmax().getElementType());
     registerIR(P->getArgmax(), V->getArgmax());
     break;
   }
@@ -414,7 +416,8 @@ void IRGenVisitor::post(Node *parent, Node *N) {
     auto *TKN = cast<TopKNode>(N);
     auto *inputTensor = valueForNode(TKN->getInput());
     auto k = TKN->getK();
-    auto *V = builder_.createTopKOp(N->getName(), inputTensor, k);
+    auto *V = builder_.createTopKOp(N->getName(), inputTensor, k,
+                                    TKN->getIndices().getElementType());
     registerIR(TKN->getValues(), V->getValues());
     registerIR(TKN->getIndices(), V->getIndices());
     break;

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -18,6 +18,7 @@
 
 #include "glow/Backend/Backend.h"
 #include "glow/Converter/Float16Converter.h"
+#include "glow/Converter/TypeAToTypeBFunctionConverter.h"
 #include "glow/Graph/Graph.h"
 #include "glow/Graph/Log.h"
 #include "glow/Graph/Node.h"
@@ -2680,6 +2681,13 @@ static NodeValue convertConstant(Module &mod, Constant &constant,
           tensorToBeModified, params, dstTy->getElementType());
       return constantToBeModified.getOutput();
     }
+    case ElemKind::Int32ITy: {
+      // Plain conversion: {FloatTy} -> {Int32ITy}.
+      Constant &constantToBeModified = modifyConstantTyAndGet();
+      constantToBeModified.getPayloadMutable().convertToType(
+          dstTy->getElementType());
+      return constantToBeModified.getOutput();
+    }
     default:
       // Quantization: {FloatTy, Float16Ty} -> Int[16|32]QTy.
       // Plain conversion: {FloatTy, Float16Ty} -> Int64ITy.
@@ -2695,7 +2703,27 @@ static NodeValue convertConstant(Module &mod, Constant &constant,
         tensor.getCopyConvertedToType(dstTy->getElementType());
     return NC->getOutput();
   }
+  case ElemKind::Int64ITy:
+  case ElemKind::Int32ITy:
+    switch (dstTy->getElementType()) {
+    case ElemKind::Int32ITy:
+    case ElemKind::Int64ITy: {
+      // Plain conversion: {Int64ITy, Int32ITy} -> {Int64ITy, Int32ITy}.
+      Constant &constantToBeModified = modifyConstantTyAndGet();
+      constantToBeModified.getPayloadMutable().convertToType(
+          dstTy->getElementType());
+      return constantToBeModified.getOutput();
+    }
+    case ElemKind::FloatTy: {
+      Constant &constantToBeModified = modifyConstantTyAndGet();
+      constantToBeModified.getPayloadMutable().convertToType(
+          dstTy->getElementType());
+      return constantToBeModified.getOutput();
+    }
 
+    default:
+      return NodeValue();
+    }
   default:
     // For now we don't see other quantize, dequantize, or rescale nodes
     // directly attached to constants.
@@ -2810,6 +2838,7 @@ bool OptimizeConversions::run(Function *F, const CompilationContext &cctx) {
       if (auto *BN = llvm::dyn_cast<Constant>(CN->getInput())) {
         auto newConst =
             convertConstant(*F->getParent(), *BN, CN->getResult().getType());
+        LOG_ASSERT(newConst) << "Constant conversion failed.";
         CN->getResult().replaceAllUsesOfWith(newConst, F);
         changed = true;
         continue;
@@ -2878,6 +2907,18 @@ FUNCTION_ENABLE_IF_TEMPLATE(Max)
 FUNCTION_ENABLE_IF_TEMPLATE(MatMul)
 *createNode(Function &F, Args... args) { return F.createMatMul(args...); }
 
+FUNCTION_ENABLE_IF_TEMPLATE(AvgPool) *
+    createNewPool(Function &F, T *PN, RescaleQuantizedNode *rescale) {
+  return createNode<T>(F, PN->getName(), rescale->getInput(), PN->getKernels(),
+                       PN->getStrides(), PN->getPads());
+}
+FUNCTION_ENABLE_IF_TEMPLATE(MaxPool) *
+    createNewPool(Function &F, T *PN, RescaleQuantizedNode *rescale) {
+  return createNode<T>(F, PN->getName(), rescale->getInput(), PN->getKernels(),
+                       PN->getStrides(), PN->getPads(),
+                       PN->getArgmax().getElementType());
+}
+
 /// Sink Rescale down with Pooling node.
 /// PoolingNode(Rescale(X)) -> Rescale(PoolingNode(X)).
 /// Apply this transformation for AvgPool and MaxPool.
@@ -2888,8 +2929,7 @@ static bool sinkDownRescaleToPoolingNode(Function &F, T *PN) {
   bool changed = false;
 
   if (auto *rescale = dyn_cast<RescaleQuantizedNode>(PN->getInput())) {
-    T *newPN = createNode<T>(F, PN->getName(), rescale->getInput(),
-                             PN->getKernels(), PN->getStrides(), PN->getPads());
+    T *newPN = createNewPool(F, PN, rescale);
     auto rescaleOutTy = F.getParent()->uniqueTypeWithNewShape(
         rescale->getResult().getType(), PN->getResult().getType());
     auto *newRescale = F.createRescaleQuantized(
@@ -3737,6 +3777,34 @@ static void setFP16AccumSLS(Function *F,
   } while (nodeIt != stopIt);
 }
 
+/// This funciton uses TypeAToTypeBFunctionConverter to do a whole graph
+/// demotion of Index type from INT64 to INT32.
+static void transformIndexTypeDemotion(const Backend &B, Function *F,
+                                       CompilationContext &cctx) {
+
+  // Does a coarse  check to make sure none of the indices potentially can
+  // overflow 32 bit. For now we just give up on the whole optimization, since
+  // this is probably a corner case.
+  for (auto &n : F->getNodes()) {
+    for (int i = 0, nOutputs = n.getNumResults(); i < nOutputs; ++i) {
+      if (n.getNthResult(i).getType()->actualSize() >=
+          std::numeric_limits<int32_t>::max()) {
+        return;
+      }
+    }
+  }
+
+  PrecisionConfiguration precConfig;
+  if (B.canDoIndexTypeDemotion(ElemKind::Int64ITy, ElemKind::Int32ITy,
+                               precConfig) &&
+      cctx.optimizationOpts.enableTypeDemotion) {
+    precConfig.precisionModeKindSet.insert(Kinded::Kind::TraceEventNodeKind);
+    TypeAToTypeBFunctionConverter converter(*F, ElemKind::Int64ITy,
+                                            ElemKind::Int32ITy, precConfig);
+    converter.convert();
+  }
+}
+
 void glow::transformForPrecisionMode(const Backend &B, Function *F,
                                      CompilationContext &cctx) {
   LOG_SCOPE(F->getLogContext(), "transformForPrecisionMode")
@@ -3845,6 +3913,9 @@ Error glow::optimizeFunction(Function *F, const Backend &B,
     // Lower based on the backend's preferences.
     ::glow::lower(F, cctx, &B);
   }
+
+  // Transforms the graph by demoting i64 to i32.
+  transformIndexTypeDemotion(B, F, cctx);
 
   // Transform given precision mode; may quantize, convert to fp16, or
   // instrument with profiling nodes. This must be done after lowering.

--- a/tests/benchmark/BERTProxyLayerBench.cpp
+++ b/tests/benchmark/BERTProxyLayerBench.cpp
@@ -179,7 +179,7 @@ public:
         (float)(1.0 / std::sqrt(((double)hiddenSize_) / ((double)numHeads_)));
 
     // Softmax expected output. Not needed for inference
-    Tensor expected_Tensor(IndexElemKind, {maxSequenceLength_ * batchSize_, 1});
+    Tensor expected_Tensor(ElemKind::Int64ITy, {maxSequenceLength_ * batchSize_, 1});
     Constant *expected = mod->createConstant("expected", expected_Tensor);
 
     // Weights/bias constants for FC1

--- a/tests/stress/ParameterSweepTest.cpp
+++ b/tests/stress/ParameterSweepTest.cpp
@@ -411,9 +411,9 @@ createAndInitSLWSNet(glow::PlaceholderBindings &bindings,
 
   // Initialize indices to size of sum of lengths. Randomly set them to point
   // somewhere inside the embedding.
-  auto *indices =
-      mod.createPlaceholder(IndexElemKind, {sumOfLengths}, "indices", false);
-  bindings.allocate(indices)->getHandle<sdim_t>().randomize(
+  auto *indices = mod.createPlaceholder(ElemKind::Int64ITy, {sumOfLengths},
+                                        "indices", false);
+  bindings.allocate(indices)->getHandle<int64_t>().randomize(
       0, embeddingRows - 1, mod.getPRNG());
 
   // Xavier initialize the weights with the correct data type.

--- a/tests/unittests/BackendCorrectnessTest.cpp
+++ b/tests/unittests/BackendCorrectnessTest.cpp
@@ -98,13 +98,13 @@ TEST_P(BackendCorrectnessTest, convGradTest) {
   Tensor bias1(ElemKind::FloatTy, {3});
   Tensor kernel2(ElemKind::FloatTy, {2, 2, 2, 1});
   Tensor bias2(ElemKind::FloatTy, {2});
-  Tensor selected(IndexElemKind, {9, 1});
+  Tensor selected(ElemKind::Int64ITy, {9, 1});
   inputs.getHandle().initXavier(1, PRNG);
   kernel1.getHandle().randomize(-1.0, 1.4, PRNG);
   bias1.getHandle().randomize(-0.2, 0.5, PRNG);
   kernel2.getHandle().randomize(-1.8, 2.3, PRNG);
   bias2.getHandle().randomize(-0.5, 1.0, PRNG);
-  auto selectedH = selected.getHandle<sdim_t>();
+  auto selectedH = selected.getHandle<int64_t>();
   for (size_t i = 0; i < 9; i++) {
     selectedH.raw(i) = PRNG.nextRandInt(0, 29);
   }
@@ -143,11 +143,11 @@ TEST_P(BackendCorrectnessTest, localResponseNormalizationGradTest) {
   Tensor inputs(ElemKind::FloatTy, {5, 4, 7, 3});
   Tensor weights(ElemKind::FloatTy, {84, 180});
   Tensor bias(ElemKind::FloatTy, {180});
-  Tensor selected(IndexElemKind, {5, 1});
+  Tensor selected(ElemKind::Int64ITy, {5, 1});
   inputs.getHandle().initXavier(1, PRNG);
   weights.getHandle().randomize(-2.0, 3.0, PRNG);
   bias.getHandle().randomize(-1.0, 1.3, PRNG);
-  auto selectedH = selected.getHandle<sdim_t>();
+  auto selectedH = selected.getHandle<int64_t>();
   for (size_t i = 0; i < 5; i++) {
     selectedH.raw(i) = PRNG.nextRandInt(0, 179);
   }
@@ -270,11 +270,11 @@ TEST_P(BackendCorrectnessTest, AvgPoolGradTest) {
   Tensor inputs(ElemKind::FloatTy, {5, 7, 6, 3});
   Tensor weights(ElemKind::FloatTy, {126, 72});
   Tensor bias(ElemKind::FloatTy, {72});
-  Tensor selected(IndexElemKind, {5, 1});
+  Tensor selected(ElemKind::Int64ITy, {5, 1});
   inputs.getHandle().initXavier(1, PRNG);
   weights.getHandle().randomize(-0.3, 0.6, PRNG);
   bias.getHandle().randomize(-0.2, 0.1, PRNG);
-  auto selectedH = selected.getHandle<sdim_t>();
+  auto selectedH = selected.getHandle<int64_t>();
   for (size_t i = 0; i < 5; i++) {
     selectedH.raw(i) = PRNG.nextRandInt(0, 17);
   }
@@ -299,11 +299,11 @@ TEST_P(BackendCorrectnessTest, MaxPoolGradTest) {
   Tensor inputs(ElemKind::FloatTy, {4, 8, 7, 2});
   Tensor weights(ElemKind::FloatTy, {112, 84});
   Tensor bias(ElemKind::FloatTy, {84});
-  Tensor selected(IndexElemKind, {4, 1});
+  Tensor selected(ElemKind::Int64ITy, {4, 1});
   inputs.getHandle().initXavier(1, PRNG);
   weights.getHandle().randomize(-0.1, 0.7, PRNG);
   bias.getHandle().randomize(-0.3, 0.1, PRNG);
-  auto selectedH = selected.getHandle<sdim_t>();
+  auto selectedH = selected.getHandle<int64_t>();
   for (size_t i = 0; i < 4; i++) {
     selectedH.raw(i) = PRNG.nextRandInt(0, 31);
   }
@@ -325,14 +325,14 @@ TEST_P(BackendCorrectnessTest, MaxPoolGradTest) {
 TEST_P(BackendCorrectnessTest, intLookupTable) {
   CHECK_IF_ENABLED();
   PseudoRNG PRNG;
-  constexpr size_t inputSize = 100;
+  constexpr dim_t inputSize = 100;
   Tensor inputs(ElemKind::Int8QTy, {inputSize}, 0.8, 4);
   inputs.getHandle<int8_t>().randomize(-128, 127, PRNG);
   Tensor out1, out2;
 
   // Mapping i -> i.
   std::vector<int8_t> initValues(256);
-  for (size_t i = 0; i < 256; ++i) {
+  for (dim_t i = 0; i < 256; ++i) {
     initValues[i] = i - 128;
   }
 
@@ -422,11 +422,11 @@ TEST_P(BackendCorrectnessTest, softmaxGradTest) {
   Tensor inputs(ElemKind::FloatTy, shape);
   Tensor weights(ElemKind::FloatTy, {23, 23});
   Tensor bias(ElemKind::FloatTy, {23});
-  Tensor selected(IndexElemKind, {8, 1});
+  Tensor selected(ElemKind::Int64ITy, {8, 1});
   inputs.getHandle().initXavier(1, PRNG);
   weights.getHandle().randomize(0.0, 0.5, PRNG);
   bias.getHandle().randomize(-0.2, 0.0, PRNG);
-  auto selectedH = selected.getHandle<sdim_t>();
+  auto selectedH = selected.getHandle<int64_t>();
   for (size_t i = 0; i < 8; i++) {
     selectedH.raw(i) = PRNG.nextRandInt(0, 22);
   }

--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -295,7 +295,7 @@ TEST(RuntimeBundle, BundleSymbolInfo) {
   auto *input =
       mod.createPlaceholder(ElemKind::FloatTy, {1, 10, 10, 3}, "in", false);
 
-  auto *ex = mod.createConstant(IndexElemKind, {1, 1}, "exp");
+  auto *ex = mod.createConstant(ElemKind::Int64ITy, {1, 1}, "exp");
 
   auto *FC = F->createFullyConnected(bindings, "FC", input, 30);
   auto *RL = F->createRELU("RL2", FC);
@@ -429,7 +429,7 @@ TEST_P(BackendExecTest, simpleInference) {
   auto *input =
       mod.createPlaceholder(ElemKind::FloatTy, {1, 32, 32, 3}, "input", false);
 
-  auto *ex = mod.createPlaceholder(IndexElemKind, {1, 1}, "exp", false);
+  auto *ex = mod.createPlaceholder(ElemKind::Int64ITy, {1, 1}, "exp", false);
 
   auto *CV0 = F->createConv(bindings, "conv1", input, 16, 5, 1, 2, 1);
   auto *RL0 = F->createRELU("relu1", CV0);
@@ -675,7 +675,7 @@ TEST_P(BackendExecTest, compileThenAddNetwork) {
   auto *input =
       mod.createPlaceholder(ElemKind::FloatTy, {1, 10, 10, 3}, "in", false);
 
-  auto *ex = mod.createPlaceholder(IndexElemKind, {1, 1}, "exp", false);
+  auto *ex = mod.createPlaceholder(ElemKind::Int64ITy, {1, 1}, "exp", false);
 
   auto *FC = F->createFullyConnected(bindings1, "FC", input, 30);
   auto *RL = F->createRELU("RL2", FC);
@@ -690,7 +690,7 @@ TEST_P(BackendExecTest, compileThenAddNetwork) {
   auto *input2 =
       mod.createPlaceholder(ElemKind::FloatTy, {1, 10, 10, 3}, "in", false);
 
-  auto *ex2 = mod.createPlaceholder(IndexElemKind, {1, 1}, "exp", false);
+  auto *ex2 = mod.createPlaceholder(ElemKind::Int64ITy, {1, 1}, "exp", false);
   auto *FC2 = F2->createFullyConnected(bindings2, "FC", input2, 30);
 
   // FC2 now has random weights we replace with FC1's weights so the output is

--- a/tests/unittests/BackendTestUtils.cpp
+++ b/tests/unittests/BackendTestUtils.cpp
@@ -1106,7 +1106,7 @@ void inferMixedNet(Tensor *inputs, Tensor *out, llvm::StringRef kind) {
   Function *F = mod.createFunction("main");
   auto *var = createPlaceholder(mod, bindings, inputs, "var", "NCHW");
   auto *selected =
-      mod.createPlaceholder(IndexElemKind, {2, 1}, "selected", false);
+      mod.createPlaceholder(ElemKind::Int64ITy, {2, 1}, "selected", false);
 
   auto *tr = F->createTranspose("tr", var, NCHW2NHWC);
   auto *fc = F->createFullyConnected(bindings, "fc", tr, 16);

--- a/tests/unittests/BasicIRTest.cpp
+++ b/tests/unittests/BasicIRTest.cpp
@@ -309,7 +309,7 @@ TEST(IR, InstUniqueNames) {
     EXPECT_TRUE(it.second);
 
     MaxPoolWithArgmaxInst *MP1 = builder.createMaxPoolWithArgmaxOp(
-        name, V1, {2, 2}, {1, 1}, {0, 2, 1, 3}, NHWC);
+        name, V1, {2, 2}, {1, 1}, {0, 2, 1, 3}, NHWC, ElemKind::Int64ITy);
     it = nameSet.insert(MP1->getName());
     EXPECT_TRUE(it.second);
 
@@ -328,7 +328,7 @@ TEST(IR, InstUniqueNames) {
 
     // IRBuilder::createTopKOp() creates alloc activation insts internally, so
     // we dealloc them here to keep the instruction list well-formed.
-    TopKInst *TK = builder.createTopKOp(name, V2, 2);
+    TopKInst *TK = builder.createTopKOp(name, V2, 2, ElemKind::Int64ITy);
     it = nameSet.insert(TK->getName());
     EXPECT_TRUE(it.second);
 

--- a/tests/unittests/Caffe2ImporterTest.cpp
+++ b/tests/unittests/Caffe2ImporterTest.cpp
@@ -1327,7 +1327,7 @@ TEST_F(Caffe2ImporterTest, dotProduct1D) {
   Placeholder *output;
 
   // Input tensors.
-  constexpr std::size_t kDataSize = 10;
+  constexpr dim_t kDataSize = 10;
   auto type = mod.uniqueType(ElemKind::FloatTy, {kDataSize});
 
   // Destroy the loader after the graph is loaded to ensure the function F
@@ -1369,8 +1369,8 @@ TEST_F(Caffe2ImporterTest, dotProduct2D) {
   Placeholder *output;
 
   // Input tensors.
-  constexpr std::size_t kRows = 10;
-  constexpr std::size_t kCols = 20;
+  constexpr dim_t kRows = 10;
+  constexpr dim_t kCols = 20;
   auto type = mod.uniqueType(ElemKind::FloatTy, {kRows, kCols});
 
   // Destroy the loader after the graph is loaded to ensure the function F
@@ -1418,8 +1418,8 @@ TEST_F(Caffe2ImporterTest, batchBoxCox) {
   Placeholder *output;
 
   // Input tensors.
-  const size_t kRows = 10;
-  const size_t kCols = 5;
+  const dim_t kRows = 10;
+  const dim_t kCols = 5;
   Tensor data(ElemKind::FloatTy, {kRows, kCols});
   Tensor lambda1(ElemKind::FloatTy, {kCols});
   Tensor lambda2(ElemKind::FloatTy, {kCols});
@@ -1466,7 +1466,7 @@ TEST_F(Caffe2ImporterTest, EQ1D) {
   PlaceholderBindings bindings;
 
   // Input tensors.
-  const size_t kDataSize = 10;
+  const dim_t kDataSize = 10;
   Tensor X(ElemKind::FloatTy, {kDataSize});
   Tensor Y(ElemKind::FloatTy, {kDataSize});
 
@@ -1539,7 +1539,7 @@ TEST_F(Caffe2ImporterTest, Logit) {
   Placeholder *output;
 
   // Input tensors.
-  const std::size_t kDataSize = 10;
+  const dim_t kDataSize = 10;
   Tensor X(ElemKind::FloatTy, {kDataSize});
 
   // Destroy the loader after the graph is loaded
@@ -1577,11 +1577,11 @@ TEST_F(Caffe2ImporterTest, sparseToDense) {
   PlaceholderBindings bindings;
 
   // Create inputs.
-  constexpr size_t kNumIndices = 5;
-  constexpr size_t kMaxIndex = 20;
-  constexpr size_t kRows = 10;
-  constexpr size_t kCols = 5;
-  Tensor indices(IndexElemKind, {kNumIndices});
+  constexpr dim_t kNumIndices = 5;
+  constexpr dim_t kMaxIndex = 20;
+  constexpr dim_t kRows = 10;
+  constexpr dim_t kCols = 5;
+  Tensor indices(ElemKind::Int64ITy, {kNumIndices});
   Tensor values(ElemKind::FloatTy, {kNumIndices, kRows, kCols});
   Tensor dataToInferDim(ElemKind::FloatTy, {kMaxIndex, kRows, kCols});
 
@@ -1629,7 +1629,7 @@ TEST_F(Caffe2ImporterTest, SparseToDenseMask) {
   Placeholder *output;
   PlaceholderBindings bindings;
 
-  Tensor indices(IndexElemKind, {4});
+  Tensor indices(ElemKind::Int64ITy, {4});
   Tensor values(ElemKind::FloatTy, {4, 10, 20, 30});
   Tensor defaultValue(ElemKind::FloatTy, {10, 20, 30});
 
@@ -2216,7 +2216,7 @@ TEST_F(Caffe2ImporterTest, SparseLengthsWeightedSum8BitsRowwise) {
   Placeholder *output, *indices, *lengths;
   PlaceholderBindings bindings;
 
-  TypeRef indicesType = F->getParent()->uniqueType(IndexElemKind, {8});
+  TypeRef indicesType = F->getParent()->uniqueType(ElemKind::Int64ITy, {8});
   TypeRef lengthsType = F->getParent()->uniqueType(ElemKind::Int32ITy, {4});
 
   // Destroy the loader after the graph is loaded since the following execution
@@ -2236,7 +2236,7 @@ TEST_F(Caffe2ImporterTest, SparseLengthsWeightedSum8BitsRowwise) {
   ASSERT_TRUE(indices);
   ASSERT_TRUE(lengths);
 
-  bindings.allocate(indices)->getHandle<sdim_t>() = {
+  bindings.allocate(indices)->getHandle<int64_t>() = {
       1, 0, 2, 0, 1, 2, 2, 0,
   };
   bindings.allocate(lengths)->getHandle<int32_t>() = {
@@ -2321,7 +2321,7 @@ TEST_F(Caffe2ImporterTest, SparseLengthsSum8BitsRowwise) {
   Placeholder *output, *indices, *lengths;
   PlaceholderBindings bindings;
 
-  TypeRef indicesType = F->getParent()->uniqueType(IndexElemKind, {8});
+  TypeRef indicesType = F->getParent()->uniqueType(ElemKind::Int64ITy, {8});
   TypeRef lengthsType = F->getParent()->uniqueType(ElemKind::Int32ITy, {5});
 
   // Destroy the loader after the graph is loaded since the following execution
@@ -2341,7 +2341,7 @@ TEST_F(Caffe2ImporterTest, SparseLengthsSum8BitsRowwise) {
   ASSERT_TRUE(indices);
   ASSERT_TRUE(lengths);
 
-  bindings.allocate(indices)->getHandle<sdim_t>() = {
+  bindings.allocate(indices)->getHandle<int64_t>() = {
       2, 0, 1, 2, 0, 0, 0, 0,
   };
   bindings.allocate(lengths)->getHandle<int32_t>() = {
@@ -2412,7 +2412,7 @@ TEST_F(Caffe2ImporterTest, SparseLengthsWeightedSumFused8BitRowwise) {
   Placeholder *output, *indices, *lengths;
   PlaceholderBindings bindings;
 
-  TypeRef indicesType = F->getParent()->uniqueType(IndexElemKind, {8});
+  TypeRef indicesType = F->getParent()->uniqueType(ElemKind::Int64ITy, {8});
   TypeRef lengthsType = F->getParent()->uniqueType(ElemKind::Int32ITy, {4});
 
   // Destroy the loader after the graph is loaded since the following execution
@@ -2432,7 +2432,7 @@ TEST_F(Caffe2ImporterTest, SparseLengthsWeightedSumFused8BitRowwise) {
   ASSERT_TRUE(indices);
   ASSERT_TRUE(lengths);
 
-  bindings.allocate(indices)->getHandle<sdim_t>() = {
+  bindings.allocate(indices)->getHandle<int64_t>() = {
       1, 0, 2, 0, 1, 2, 2, 0,
   };
   bindings.allocate(lengths)->getHandle<int32_t>() = {
@@ -2517,7 +2517,7 @@ TEST_F(Caffe2ImporterTest, SparseLengthsSumFused8BitRowwise) {
   Placeholder *output, *indices, *lengths;
   PlaceholderBindings bindings;
 
-  TypeRef indicesType = F->getParent()->uniqueType(IndexElemKind, {8});
+  TypeRef indicesType = F->getParent()->uniqueType(ElemKind::Int64ITy, {8});
   TypeRef lengthsType = F->getParent()->uniqueType(ElemKind::Int32ITy, {5});
 
   // Destroy the loader after the graph is loaded since the following execution
@@ -2537,7 +2537,7 @@ TEST_F(Caffe2ImporterTest, SparseLengthsSumFused8BitRowwise) {
   ASSERT_TRUE(indices);
   ASSERT_TRUE(lengths);
 
-  bindings.allocate(indices)->getHandle<sdim_t>() = {
+  bindings.allocate(indices)->getHandle<int64_t>() = {
       2, 0, 1, 2, 0, 0, 0, 0,
   };
   bindings.allocate(lengths)->getHandle<int32_t>() = {
@@ -2613,7 +2613,7 @@ TEST_F(Caffe2ImporterTest, SparseLengthsSumFused8BitRowwiseAllLengthsOne) {
   Placeholder *output, *indices, *lengths;
   PlaceholderBindings bindings;
 
-  TypeRef indicesType = F->getParent()->uniqueType(IndexElemKind, {5});
+  TypeRef indicesType = F->getParent()->uniqueType(ElemKind::Int64ITy, {5});
   TypeRef lengthsType = F->getParent()->uniqueType(ElemKind::Int32ITy, {5});
 
   // Destroy the loader after the graph is loaded since the following execution
@@ -2633,7 +2633,7 @@ TEST_F(Caffe2ImporterTest, SparseLengthsSumFused8BitRowwiseAllLengthsOne) {
   ASSERT_TRUE(indices);
   ASSERT_TRUE(lengths);
 
-  bindings.allocate(indices)->getHandle<sdim_t>() = {
+  bindings.allocate(indices)->getHandle<int64_t>() = {
       2, 0, 1, 2, 0,
   };
   bindings.allocate(lengths)->getHandle<int32_t>() = {
@@ -2710,7 +2710,7 @@ TEST_F(Caffe2ImporterTest, SparseLengthsSumFused8BitRowwiseLengthsLow) {
   Placeholder *output, *indices, *lengths;
   PlaceholderBindings bindings;
 
-  TypeRef indicesType = F->getParent()->uniqueType(IndexElemKind, {5});
+  TypeRef indicesType = F->getParent()->uniqueType(ElemKind::Int64ITy, {5});
   TypeRef lengthsType = F->getParent()->uniqueType(ElemKind::Int32ITy, {5});
 
   // Destroy the loader after the graph is loaded since the following execution
@@ -2730,7 +2730,7 @@ TEST_F(Caffe2ImporterTest, SparseLengthsSumFused8BitRowwiseLengthsLow) {
   ASSERT_TRUE(indices);
   ASSERT_TRUE(lengths);
 
-  bindings.allocate(indices)->getHandle<sdim_t>() = {
+  bindings.allocate(indices)->getHandle<int64_t>() = {
       2, 0, 1, 2, 0,
   };
   bindings.allocate(lengths)->getHandle<int32_t>() = {2, 0, 0, 3, 0};
@@ -2785,7 +2785,7 @@ TEST_F(Caffe2ImporterTest, SparseLengthsSumFused4BitRowwise) {
   Placeholder *output, *indices, *lengths;
   PlaceholderBindings bindings;
 
-  TypeRef indicesType = F->getParent()->uniqueType(IndexElemKind, {8});
+  TypeRef indicesType = F->getParent()->uniqueType(ElemKind::Int64ITy, {8});
   TypeRef lengthsType = F->getParent()->uniqueType(ElemKind::Int32ITy, {5});
 
   // Destroy the loader after the graph is loaded since the following execution
@@ -2850,8 +2850,8 @@ TEST_F(Caffe2ImporterTest, validateNodeOrder) {
   PlaceholderBindings bindings;
 
   // Input tensors.
-  const size_t kRows = 10;
-  const size_t kCols = 5;
+  const dim_t kRows = 10;
+  const dim_t kCols = 5;
   Tensor data(ElemKind::FloatTy, {kRows, kCols});
   Tensor lambda1(ElemKind::FloatTy, {kCols});
   Tensor lambda2(ElemKind::FloatTy, {kCols});

--- a/tests/unittests/GraphGradTest.cpp
+++ b/tests/unittests/GraphGradTest.cpp
@@ -56,7 +56,7 @@ TEST(GraphAutoGrad, autoGrad) {
   auto *FCL1 = F->createFullyConnected(bindings, "fc3", MP1->getResult(), 10);
   auto *RL2 = F->createRELU("relu3", FCL1);
   auto *selected =
-      mod.createPlaceholder(IndexElemKind, {10, 1}, "selected", false);
+      mod.createPlaceholder(ElemKind::Int64ITy, {10, 1}, "selected", false);
 
   auto *SM = F->createSoftMax("sm", RL2, selected);
 
@@ -86,7 +86,7 @@ TEST(GraphAutoGrad, checkLRNGen) {
   auto *FCL1 = F->createFullyConnected(bindings, "fc3", CV0, 10);
   auto *RL2 = F->createRELU("relu3", FCL1);
   auto *selected =
-      mod.createPlaceholder(IndexElemKind, {10, 1}, "selected", false);
+      mod.createPlaceholder(ElemKind::Int64ITy, {10, 1}, "selected", false);
 
   auto *SM = F->createSoftMax("sm", RL2, selected);
 
@@ -301,12 +301,13 @@ TEST(GraphAutoGrad, checkGatherGrad1DIndexTest) {
   Function *F = Mod.createFunction("main");
 
   auto *Data = Mod.createPlaceholder(ElemKind::FloatTy, {3, 4}, "Data", false);
-  auto *Indices = Mod.createPlaceholder(IndexElemKind, {2}, "Indices", false);
+  auto *Indices =
+      Mod.createPlaceholder(ElemKind::Int64ITy, {2}, "Indices", false);
 
   auto HandleData = Bindings.allocate(Data)->getHandle<float>();
   HandleData.randomize(-3.0, 3.0, Mod.getPRNG());
 
-  Bindings.allocate(Indices)->getHandle<sdim_t>() = {0, 2};
+  Bindings.allocate(Indices)->getHandle<int64_t>() = {0, 2};
 
   auto *G = F->createGather("gather", Data, Indices, 0 /*batchDims*/);
   auto *R = F->createSave("save", G);
@@ -326,12 +327,12 @@ TEST(GraphAutoGrad, checkGatherGrad2DIndexTest) {
 
   auto *Data = Mod.createPlaceholder(ElemKind::FloatTy, {8, 4}, "Data", false);
   auto *Indices =
-      Mod.createPlaceholder(IndexElemKind, {2, 2}, "Indices", false);
+      Mod.createPlaceholder(ElemKind::Int64ITy, {2, 2}, "Indices", false);
 
   auto HandleData = Bindings.allocate(Data)->getHandle<float>();
   HandleData.randomize(-3.0, 3.0, Mod.getPRNG());
 
-  Bindings.allocate(Indices)->getHandle<sdim_t>() = {0, 2, 1, 3};
+  Bindings.allocate(Indices)->getHandle<int64_t>() = {0, 2, 1, 3};
 
   auto *G = F->createGather("gather", Data, Indices, 0 /*batchDims*/);
   auto *R = F->createSave("save", G);
@@ -351,12 +352,12 @@ TEST(GraphAutoGrad, checkGatherGrad3DIndexTest) {
 
   auto *Data = Mod.createPlaceholder(ElemKind::FloatTy, {8, 4}, "Data", false);
   auto *Indices =
-      Mod.createPlaceholder(IndexElemKind, {2, 2, 2}, "Indices", false);
+      Mod.createPlaceholder(ElemKind::Int64ITy, {2, 2, 2}, "Indices", false);
 
   auto HandleData = Bindings.allocate(Data)->getHandle<float>();
   HandleData.randomize(-3.0, 3.0, Mod.getPRNG());
 
-  Bindings.allocate(Indices)->getHandle<sdim_t>() = {0, 2, 1, 3, 4, 5, 7, 6};
+  Bindings.allocate(Indices)->getHandle<int64_t>() = {0, 2, 1, 3, 4, 5, 7, 6};
 
   auto *G = F->createGather("gather", Data, Indices, 0 /*batchDims*/);
   auto *R = F->createSave("save", G);

--- a/tests/unittests/GraphTest.cpp
+++ b/tests/unittests/GraphTest.cpp
@@ -510,7 +510,7 @@ TEST(Graph, quantizeGather) {
   auto *F = mod.createFunction("main");
   auto *input =
       mod.createPlaceholder(ElemKind::Int8QTy, {2, 2}, 0.4, 2, "input", true);
-  auto *indices = mod.createPlaceholder(IndexElemKind, {1}, "index", true);
+  auto *indices = mod.createPlaceholder(ElemKind::Int64ITy, {1}, "index", true);
   auto *gather = F->createGather("gather", input, indices);
   PlaceholderBindings bindings;
   F->createSave("ret", gather);
@@ -768,7 +768,7 @@ TEST(Graph, nodesWithPredicates) {
   PlaceholderBindings bindings;
   auto *input =
       mod.createPlaceholder(ElemKind::FloatTy, {1, 32, 32, 3}, "input", true);
-  auto *ex = mod.createPlaceholder(IndexElemKind, {1, 1}, "exp", true);
+  auto *ex = mod.createPlaceholder(ElemKind::Int64ITy, {1, 1}, "exp", true);
   auto *pred =
       mod.createPlaceholder(ElemKind::Int64ITy, {1}, "predicate", false);
   bindings.allocate(input);
@@ -1295,7 +1295,7 @@ TEST(Graph, setType) {
       M.createPlaceholder(ElemKind::FloatTy, inputDims, "input", true);
   TopKNode *topK = F->createTopK("add", input, 5);
   TypeRef origTopKRes0 = M.uniqueType(ElemKind::FloatTy, top5Dims);
-  TypeRef origTopKRes1 = M.uniqueType(IndexElemKind, top5Dims);
+  TypeRef origTopKRes1 = M.uniqueType(ElemKind::Int64ITy, top5Dims);
 
   EXPECT_EQ(topK->getType(TopKNode::ValuesIdx), origTopKRes0);
   EXPECT_EQ(topK->getType(TopKNode::IndicesIdx), origTopKRes1);
@@ -1885,7 +1885,7 @@ trainable : 1
   llvm::raw_string_ostream osF1(storageF1);
   F2->dump(osF1);
   std::string mesF = F2->toString();
-  std::string expectMesF = DIM_T_BITWIDTH == 64 ? R"(Graph structure F2:
+  std::string expectMesF = R"(Graph structure F2:
 TopK
 name : topk
 Input : float<10 x 10>
@@ -1893,15 +1893,6 @@ K : 3
 users : 0
 Values : float<10 x 3>
 Indices : index64<10 x 3>
-)"
-                                                : R"(Graph structure F2:
-TopK
-name : topk
-Input : float<10 x 10>
-K : 3
-users : 0
-Values : float<10 x 3>
-Indices : index32<10 x 3>
 )";
   EXPECT_EQ(mesF, expectMesF);
   EXPECT_EQ(mesF, osF1.str());

--- a/tests/unittests/HyphenTest.cpp
+++ b/tests/unittests/HyphenTest.cpp
@@ -265,7 +265,7 @@ struct HyphenNetwork {
   HyphenNetwork(Module &mod, TrainingConfig &conf)
       : input_(mod.createPlaceholder(ElemKind::FloatTy, {conf.batchSize, 6, 27},
                                      "input", false)),
-        expected_(mod.createPlaceholder(IndexElemKind, {conf.batchSize, 1},
+        expected_(mod.createPlaceholder(ElemKind::Int64ITy, {conf.batchSize, 1},
                                         "expected", false)),
         infer_(mod.createFunction("infer")), result_(nullptr), train_(nullptr) {
     bindings_.allocate(input_);
@@ -330,7 +330,7 @@ TEST(HyphenTest, network) {
   }
 
   // This depends on the training data, of course.
-  const size_t numSamples = 566;
+  const dim_t numSamples = 566;
   ASSERT_EQ(hyphens.size(), numSamples);
   ASSERT_EQ(words.size(), numSamples);
 
@@ -345,10 +345,10 @@ TEST(HyphenTest, network) {
 
   // Convert words and hyphens to a tensor representation.
   Tensor inputs(ElemKind::FloatTy, {numSamples, 6, 27});
-  Tensor expected(IndexElemKind, {numSamples, 1});
+  Tensor expected(ElemKind::Int64ITy, {numSamples, 1});
   inputs.zero();
   auto inputHandle = inputs.getHandle<float>();
-  auto expectedHandle = expected.getHandle<sdim_t>();
+  auto expectedHandle = expected.getHandle<int64_t>();
   for (dim_t i = 0; i != numSamples; i++) {
     mapLetterWindow(words[i], i, inputHandle);
     expectedHandle.at({i, 0}) = hyphens[i];

--- a/tests/unittests/LoaderTest.cpp
+++ b/tests/unittests/LoaderTest.cpp
@@ -38,7 +38,7 @@ protected:
 using namespace glow;
 
 namespace {
-const size_t BATCH_SIZE = 8;
+const dim_t BATCH_SIZE = 8;
 const size_t MINI_BATCH_SIZE = 2;
 } // namespace
 

--- a/tests/unittests/MLTest.cpp
+++ b/tests/unittests/MLTest.cpp
@@ -164,7 +164,7 @@ TEST_P(MLTest, simpleRegression) {
   // Testing the regression layer. This test takes the first element from the
   // input vector, adds one to it and places the result in the second element of
   // the output vector.
-  const size_t numInputs = 4;
+  const dim_t numInputs = 4;
 
   // Learning a single input vector.
   TC.learningRate = 0.05;
@@ -405,7 +405,7 @@ unsigned numSamples = 230;
 /// L0, and the rest of the dots, away from the axis are L1.
 void generateCircleData(Tensor &coordinates, Tensor &labels, PseudoRNG &PRNG) {
   auto C = coordinates.getHandle<>();
-  auto L = labels.getHandle<sdim_t>();
+  auto L = labels.getHandle<int64_t>();
 
   for (dim_t i = 0; i < numSamples / 2; i++) {
     float r = PRNG.nextRand() * 0.4;
@@ -454,7 +454,8 @@ TEST_P(MLTest, circle) {
     F = mod.createFunction("circle");
     A = mod.createPlaceholder(ElemKind::FloatTy, {minibatchSize, 2}, "A",
                               false);
-    S = mod.createPlaceholder(IndexElemKind, {minibatchSize, 1}, "S", false);
+    S = mod.createPlaceholder(ElemKind::Int64ITy, {minibatchSize, 1}, "S",
+                              false);
 
     auto *FCL0 = F->createFullyConnected(inferBindings, "fc1", A, 8);
     auto *T0 = F->createTanh("tanh1", FCL0);
@@ -475,7 +476,7 @@ TEST_P(MLTest, circle) {
   trainingBindings.allocate(EET_.getModule().getPlaceholders());
 
   Tensor coordinates(ElemKind::FloatTy, {numSamples, 2});
-  Tensor labels(IndexElemKind, {numSamples, 1});
+  Tensor labels(ElemKind::Int64ITy, {numSamples, 1});
   generateCircleData(coordinates, labels, EET_.getModule().getPRNG());
 
   // Training:
@@ -827,7 +828,7 @@ enum class Sport : size_t { BASKETBALL = 0, SOCCER = 1 };
 void generatePlayerData(Tensor &players, Tensor &labels,
                         unsigned numTrainPlayers, PseudoRNG &PRNG) {
   auto P = players.getHandle<>();
-  auto L = labels.getHandle<sdim_t>();
+  auto L = labels.getHandle<int64_t>();
 
   // Auto generate height/weights for basketball players.
   for (dim_t i = 0; i < numTrainPlayers / 2; i++) {
@@ -875,7 +876,8 @@ TEST_P(MLTest, classifyPlayerSport) {
 
     A = mod.createPlaceholder(ElemKind::FloatTy, {numTrainPlayers, numFeatures},
                               "A", false);
-    S = mod.createPlaceholder(IndexElemKind, {numTrainPlayers, 1}, "S", false);
+    S = mod.createPlaceholder(ElemKind::Int64ITy, {numTrainPlayers, 1}, "S",
+                              false);
 
     auto *FC = F->createFullyConnected(inferBindings, "fc", A, numClasses);
     auto *SM = F->createSoftMax("softmax", FC, S);
@@ -892,7 +894,7 @@ TEST_P(MLTest, classifyPlayerSport) {
   EET_.compile(CompilationMode::Train);
 
   Tensor players(ElemKind::FloatTy, {numTrainPlayers, numFeatures});
-  Tensor labels(IndexElemKind, {numTrainPlayers, 1});
+  Tensor labels(ElemKind::Int64ITy, {numTrainPlayers, 1});
   generatePlayerData(players, labels, numTrainPlayers,
                      EET_.getModule().getPRNG());
 
@@ -1039,7 +1041,7 @@ TEST_P(MLTest, nonLinearClassifier) {
     F = mod.createFunction("nonLinearClassifier");
 
     A = mod.createPlaceholder(ElemKind::FloatTy, {batchSize, 2}, "A", false);
-    S = mod.createPlaceholder(IndexElemKind, {batchSize, 1}, "S", false);
+    S = mod.createPlaceholder(ElemKind::Int64ITy, {batchSize, 1}, "S", false);
 
     auto *FCL0 = F->createFullyConnected(inferBindings, "fc1", A, 8);
     auto *T0 = F->createTanh("tanh1", FCL0);
@@ -1062,7 +1064,7 @@ TEST_P(MLTest, nonLinearClassifier) {
   trainingBindings.allocate(EET_.getModule().getPlaceholders());
 
   Tensor samples(ElemKind::FloatTy, {numSamples, 2});
-  Tensor labels(IndexElemKind, {numSamples, 1});
+  Tensor labels(ElemKind::Int64ITy, {numSamples, 1});
 
   for (dim_t i = 0; i < numSamples; i++) {
     float x = EET_.getModule().getPRNG().nextRand();
@@ -1070,7 +1072,7 @@ TEST_P(MLTest, nonLinearClassifier) {
     dim_t label = (x < 0.0) ^ (y < 0.0);
     samples.getHandle<>().at({i, 0}) = x;
     samples.getHandle<>().at({i, 1}) = y;
-    labels.getHandle<sdim_t>().at({i, 0}) = label;
+    labels.getHandle<int64_t>().at({i, 0}) = label;
   }
 
   runBatch(EET_, trainingBindings, 500, sampleCounter, {A, S},
@@ -1097,7 +1099,7 @@ TEST_P(MLTest, nonLinearClassifier) {
 /// Generate images in two classes.
 /// A "line" is labeled as 0 and a "cross" is labeled as 1.
 static void generateImageData(Tensor &images, Tensor &labels, PseudoRNG &PRNG) {
-  auto L = labels.getHandle<sdim_t>();
+  auto L = labels.getHandle<int64_t>();
   auto image = images.getHandle<>();
   unsigned numSamples = images.dims()[0];
   images.zero();
@@ -1147,7 +1149,7 @@ TEST_P(MLTest, convNetForImageRecognition) {
         ElemKind::FloatTy, {batchSize, 8, 8, 1}, "input", false);
 
     Placeholder *ex =
-        mod.createPlaceholder(IndexElemKind, {batchSize, 1}, "exp", false);
+        mod.createPlaceholder(ElemKind::Int64ITy, {batchSize, 1}, "exp", false);
 
     auto *CV = F->createConv(inferBindings, "conv", input, 1, 3, 1, 0, 1);
     auto *TANH = F->createTanh("tanh", CV);
@@ -1168,7 +1170,7 @@ TEST_P(MLTest, convNetForImageRecognition) {
   inferBindings.copyTrainableWeightsTo(trainingBindings);
 
   Tensor images(ElemKind::FloatTy, {numSamples, 8, 8, 1});
-  Tensor labels(IndexElemKind, {numSamples, 1});
+  Tensor labels(ElemKind::Int64ITy, {numSamples, 1});
   generateImageData(images, labels, mod->getPRNG());
 
   // Training:
@@ -1216,7 +1218,7 @@ TEST_P(MLTest, convNetForImageRecognition) {
 
   // Generate the images used for testing.
   Tensor testImages(ElemKind::FloatTy, {batchSize, 8, 8, 1});
-  Tensor testLabels(IndexElemKind, {batchSize, 1});
+  Tensor testLabels(ElemKind::Int64ITy, {batchSize, 1});
   generateImageData(testImages, testLabels, mod->getPRNG());
   updateInputPlaceholders(inferBindings, {input}, {&testImages});
 
@@ -1225,7 +1227,7 @@ TEST_P(MLTest, convNetForImageRecognition) {
   Tensor *res = inferBindings.get(EEI_.getModule().getPlaceholderByName("ret"));
   auto SMH = res->getHandle<>();
   for (dim_t i = 0; i < batchSize; i++) {
-    bool isLine = testLabels.getHandle<sdim_t>().at({i, 0}) == 0;
+    bool isLine = testLabels.getHandle<int64_t>().at({i, 0}) == 0;
     auto lineWeight = SMH.at({i, 0});
     auto crossWeight = SMH.at({i, 1});
     EXPECT_TRUE((isLine && lineWeight > crossWeight) ||
@@ -1420,7 +1422,7 @@ static void generateMatrixRotationRecognitionData(Tensor &matricesA,
          "Size of the tensors is incompatible");
   auto handleMatricesA = matricesA.getHandle<float>();
   auto handleMatricesB = matricesB.getHandle<float>();
-  auto handleExpected = expected.getHandle<sdim_t>();
+  auto handleExpected = expected.getHandle<int64_t>();
 
   handleMatricesA.randomize<int>(0, 1, PRNG);
   handleMatricesB.randomize<int>(0, 1, PRNG);
@@ -1476,7 +1478,7 @@ TEST_P(MLTest, matrixRotationRecognition) {
         ElemKind::FloatTy, {TC.batchSize, 3, 3}, "matrixA", false);
     varMatricesB = mod.createPlaceholder(
         ElemKind::FloatTy, {TC.batchSize, 3, 3}, "matrixB", false);
-    varExpected = mod.createPlaceholder(IndexElemKind, {TC.batchSize, 1},
+    varExpected = mod.createPlaceholder(ElemKind::Int64ITy, {TC.batchSize, 1},
                                         "expected", false);
 
     // Simply concatenating the matrices first would probability be as effective
@@ -1511,7 +1513,7 @@ TEST_P(MLTest, matrixRotationRecognition) {
   const unsigned numSamples = 50;
   Tensor matricesA(ElemKind::FloatTy, {numSamples, 3, 3});
   Tensor matricesB(ElemKind::FloatTy, {numSamples, 3, 3});
-  Tensor expected(IndexElemKind, {numSamples, 1});
+  Tensor expected(ElemKind::Int64ITy, {numSamples, 1});
   generateMatrixRotationRecognitionData(matricesA, matricesB, expected,
                                         EET_.getModule().getPRNG());
 
@@ -1548,7 +1550,7 @@ TEST_P(MLTest, matrixRotationRecognition) {
     // Note that the two softmax outputs always sum to 1, so we only look at
     // one. Index one is true if there is a rotation.
     float value = RHtrain.at({i, 1});
-    bool hasRotation = expected.getHandle<sdim_t>().at({batchStartIdx + i, 0});
+    bool hasRotation = expected.getHandle<int64_t>().at({batchStartIdx + i, 0});
     if ((value > 0.5) != hasRotation) {
       ++errors;
     }
@@ -1663,7 +1665,7 @@ TEST_P(MLTest, learnSparseLengthsWeightedSumEmbeddings) {
     F = mod.createFunction("SparseLengthsWeightedSum");
     dataP = mod.createPlaceholder(ElemKind::FloatTy, {10}, "dataP",
                                   /*isTrainable=*/true);
-    indicesP = mod.createPlaceholder(IndexElemKind, {10}, "indicesP",
+    indicesP = mod.createPlaceholder(ElemKind::Int64ITy, {10}, "indicesP",
                                      /*isTrainable=*/false);
     weightsP = mod.createPlaceholder(ElemKind::FloatTy, {10}, "weightsP",
                                      /*isTrainable=*/false);
@@ -1682,8 +1684,8 @@ TEST_P(MLTest, learnSparseLengthsWeightedSumEmbeddings) {
   DH.randomize(-5.0, 5.0, PRNG);
 
   // Allocate and set indices such that input embeddings are reversed.
-  inferBindings.allocate(indicesP)->getHandle<sdim_t>() = {9, 8, 7, 6, 5,
-                                                           4, 3, 2, 1, 0};
+  inferBindings.allocate(indicesP)->getHandle<int64_t>() = {9, 8, 7, 6, 5,
+                                                            4, 3, 2, 1, 0};
   // Allocate and set weights.
   inferBindings.allocate(weightsP)->getHandle() = {
       0.75, 0.25, 0.75, 0.25, 0.75, 0.25, 0.75, 0.25, 0.75, 0.25};
@@ -1757,7 +1759,7 @@ TEST_P(MLTest, learnSparseLengthsWeightedSumWeights) {
     F = mod.createFunction("SparseLengthsWeightedSum");
     dataP = mod.createPlaceholder(ElemKind::FloatTy, {10}, "dataP",
                                   /*isTrainable=*/false);
-    indicesP = mod.createPlaceholder(IndexElemKind, {10}, "indicesP",
+    indicesP = mod.createPlaceholder(ElemKind::Int64ITy, {10}, "indicesP",
                                      /*isTrainable=*/false);
     weightsP = mod.createPlaceholder(ElemKind::FloatTy, {10}, "weightsP",
                                      /*isTrainable=*/true);
@@ -1775,8 +1777,8 @@ TEST_P(MLTest, learnSparseLengthsWeightedSumWeights) {
   inferBindings.allocate(dataP)->getHandle() = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 
   // Allocate and set indices such that input embeddings are reversed.
-  inferBindings.allocate(indicesP)->getHandle<sdim_t>() = {9, 8, 7, 6, 5,
-                                                           4, 3, 2, 1, 0};
+  inferBindings.allocate(indicesP)->getHandle<int64_t>() = {9, 8, 7, 6, 5,
+                                                            4, 3, 2, 1, 0};
   // Allocate and randomly initialize weights.
   auto WH = inferBindings.allocate(weightsP)->getHandle();
   WH.randomize(-1.0, 1.0, PRNG);

--- a/tests/unittests/OCLTest.cpp
+++ b/tests/unittests/OCLTest.cpp
@@ -78,7 +78,7 @@ TEST(OpenCLCorrectnessTest, softmaxGradTest) {
   Tensor inputs(ElemKind::FloatTy, shape);
   Tensor weights(ElemKind::FloatTy, {23, 23});
   Tensor bias(ElemKind::FloatTy, {23});
-  Tensor selected(IndexElemKind, {8, 1});
+  Tensor selected(ElemKind::Int64ITy, {8, 1});
   inputs.getHandle().initXavier(1, PRNG);
   weights.getHandle().randomize(0.0, 0.5, PRNG);
   bias.getHandle().randomize(-0.2, 0.0, PRNG);

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -1426,8 +1426,8 @@ TEST_F(OnnxImporterTest, importBatchBoxCox) {
   Placeholder *output;
 
   // Make input tensors.
-  const size_t kRows = 3;
-  const size_t kCols = 3;
+  const dim_t kRows = 3;
+  const dim_t kCols = 3;
   Tensor data(ElemKind::FloatTy, {kRows, kCols});
   Tensor lambda1(ElemKind::FloatTy, {kCols});
   Tensor lambda2(ElemKind::FloatTy, {kCols});
@@ -1705,7 +1705,7 @@ TEST_F(OnnxImporterTest, importSparseToDense) {
   constexpr dim_t kMaxIndex = 20;
   constexpr dim_t kRows = 10;
   constexpr dim_t kCols = 5;
-  Tensor indices(IndexElemKind, {kNumIndices});
+  Tensor indices(ElemKind::Int64ITy, {kNumIndices});
   Tensor values(ElemKind::FloatTy, {kNumIndices, kRows, kCols});
   Tensor dataToInferDim(ElemKind::FloatTy, {kMaxIndex, kRows, kCols});
 
@@ -1743,7 +1743,7 @@ TEST_F(OnnxImporterTest, importSparseLengthsSum) {
   Placeholder *output;
   {
     Tensor data(ElemKind::FloatTy, {2, 1});
-    Tensor indices(IndexElemKind, {2});
+    Tensor indices(ElemKind::Int64ITy, {2});
     Tensor lengths(ElemKind::Int32ITy, {2});
     ONNXModelLoader onnxLD(
         netFilename, {"data", "indices", "lengths"},
@@ -2482,12 +2482,12 @@ TEST_F(OnnxImporterTest, topK) {
   EE.run(bindings);
 
   auto outputH = outputT->getHandle();
-  auto indexH = indexT->getHandle<sdim_t>();
+  auto indexH = indexT->getHandle<int64_t>();
   std::vector<dim_t> expectedDims = {1, 3, 2};
   std::vector<float> expectedValues = {
       4., 3., 8., 7., 12, 11.,
   };
-  std::vector<dim_t> expectedIndices = {3, 2, 0, 1, 1, 0};
+  std::vector<int64_t> expectedIndices = {3, 2, 0, 1, 1, 0};
 
   EXPECT_TRUE(outputH.dims().vec() == expectedDims);
   for (size_t i = 0; i < expectedValues.size(); i++) {
@@ -2650,7 +2650,7 @@ TEST_F(OnnxImporterTest, importMaxPoolWithArgmax) {
   EE.run(bindings);
 
   auto result = bindings.get(resultPH)->getHandle();
-  auto indices = bindings.get(indicesPH)->getHandle<sdim_t>();
+  auto indices = bindings.get(indicesPH)->getHandle<int64_t>();
   std::vector<dim_t> expectedDims = {1, 3, 2, 2};
 
   EXPECT_TRUE(result.dims().vec() == expectedDims);
@@ -2658,8 +2658,8 @@ TEST_F(OnnxImporterTest, importMaxPoolWithArgmax) {
 
   std::vector<float> expectedResult = {58.0, 46.0, 33.0, 57.0, 55.0, 31.0,
                                        54.0, 53.0, 40.0, 52.0, 51.0, 38.0};
-  std::vector<sdim_t> expectedIndices = {15, 18, 36, 30, 13, 19,
-                                         28, 43, 14, 11, 26, 44};
+  std::vector<int64_t> expectedIndices = {15, 18, 36, 30, 13, 19,
+                                          28, 43, 14, 11, 26, 44};
 
   for (size_t i = 0; i < expectedResult.size(); i++) {
     EXPECT_EQ(result.raw(i), expectedResult[i]);
@@ -3121,7 +3121,7 @@ TEST_F(OnnxImporterTest, importFRWQSLWS) {
   Placeholder *output;
   {
     Tensor weights(ElemKind::FloatTy, {8});
-    Tensor indices(IndexElemKind, {8});
+    Tensor indices(ElemKind::Int64ITy, {8});
     Tensor lengths(ElemKind::Int32ITy, {5});
     ONNXModelLoader onnxLD(
         netFilename, {"weights", "indices", "lengths"},

--- a/tests/unittests/PartitionerTest.cpp
+++ b/tests/unittests/PartitionerTest.cpp
@@ -548,7 +548,7 @@ static void createSimpleSparseNNModule(Module &mod, bool shareSplatWeights) {
   for (int table = 0; table < 5; table++) {
     Tensor data(ElemKind::FloatTy, {tableEntries, tableWidth});
     auto *indices = mod.createPlaceholder(
-        IndexElemKind, {numIndices * batchSize}, "indices", false);
+        ElemKind::Int64ITy, {numIndices * batchSize}, "indices", false);
     if (!shareSplatWeights) {
       weights = mod.createPlaceholder(ElemKind::FloatTy,
                                       {numIndices * batchSize}, "w", false)
@@ -869,7 +869,7 @@ TEST_F(PartitionerTest, graphMemInfoCalculation1) {
   auto *inp2 =
       mod_.createPlaceholder(ElemKind::FloatTy, {2, 1, 3}, "input", false);
   auto *indices =
-      mod_.createPlaceholder(IndexElemKind, {4, 1, 2}, "indices", false);
+      mod_.createPlaceholder(ElemKind::Int64ITy, {4, 1, 2}, "indices", false);
 
   auto *R1 = F_->createTopK("TopK1", inp1, 2);
   auto *R2 = F_->createTopK("TopK2", inp2, 2);

--- a/tests/unittests/QuantizationTest.cpp
+++ b/tests/unittests/QuantizationTest.cpp
@@ -747,7 +747,8 @@ TEST(Quantization, enableRowwiseQuantizedSLWS) {
   auto *data = mod.createPlaceholder(ElemKind::FloatTy, {3, 1}, "data", false);
   auto *weights =
       mod.createPlaceholder(ElemKind::FloatTy, {8}, "weights", false);
-  auto *indices = mod.createPlaceholder(IndexElemKind, {8}, "indices", false);
+  auto *indices =
+      mod.createPlaceholder(ElemKind::Int64ITy, {8}, "indices", false);
   auto *lengths =
       mod.createPlaceholder(ElemKind::Int32ITy, {4}, "lengths", false);
 
@@ -1081,7 +1082,7 @@ TEST_P(Operator, end2endInt8) {
 
 /// Fills the tensor \p H with some stable random integers with the seed \p seed
 /// and the range [0, scale).
-static void fillStableRandomIndex(Handle<sdim_t> H, size_t seed,
+static void fillStableRandomIndex(Handle<int64_t> H, size_t seed,
                                   size_t scale = 10) {
   for (size_t i = 0, e = H.size(); i < e; i++) {
     H.raw(i) = int(i * 1921 + seed) % scale;
@@ -1106,8 +1107,8 @@ static Function *createGRUForQuantization(Module *M,
   fillStableRandomData(bindings.allocate(emb)->getHandle(), 4565, 1);
 
   auto *input = F->getParent()->createPlaceholder(
-      IndexElemKind, {batchSize, sequenceSize}, "input", false);
-  fillStableRandomIndex(bindings.allocate(input)->getHandle<sdim_t>(), 7227,
+      ElemKind::Int64ITy, {batchSize, sequenceSize}, "input", false);
+  fillStableRandomIndex(bindings.allocate(input)->getHandle<int64_t>(), 7227,
                         10);
 
   auto *hiddenInit = F->getParent()->createPlaceholder(
@@ -1532,7 +1533,7 @@ TEST(Quantization, quantizeSoftmaxAndLRN) {
   auto *input =
       mod.createPlaceholder(ElemKind::FloatTy, {1, 10}, "input", true);
   auto *selected =
-      mod.createPlaceholder(IndexElemKind, {1, 10}, "selected", true);
+      mod.createPlaceholder(ElemKind::Int64ITy, {1, 10}, "selected", true);
   auto *LRN =
       F->createLocalResponseNormalization("LRN", input, 2, 1.0, 0.0001, 0.75);
   auto *SM = F->createSoftMax("softmax", LRN, selected);

--- a/tests/unittests/TensorsTest.cpp
+++ b/tests/unittests/TensorsTest.cpp
@@ -920,7 +920,7 @@ TEST(Tensor, insertSlice) {
 /// row's offset.
 template <typename ScaleOffsetT>
 static void testInitZeroFused(ElemKind fusedKind, float allowedError) {
-  constexpr size_t numTotalColumns = 2 + 2 * sizeof(ScaleOffsetT);
+  constexpr dim_t numTotalColumns = 2 + 2 * sizeof(ScaleOffsetT);
   Tensor T(fusedKind, {10, numTotalColumns}, 0.0, 0);
   auto TH = T.getHandle<uint8_t>();
   auto *TData = reinterpret_cast<uint8_t *>(T.getUnsafePtr());

--- a/tests/unittests/TraceEventsTest.cpp
+++ b/tests/unittests/TraceEventsTest.cpp
@@ -76,8 +76,8 @@ public:
   }
 
   Node *part_four(Function *F, ExecutionContext &context, NodeValue last) {
-    auto *ex =
-        F->getParent()->createPlaceholder(IndexElemKind, {1, 1}, "exp", false);
+    auto *ex = F->getParent()->createPlaceholder(ElemKind::Int64ITy, {1, 1},
+                                                 "exp", false);
     auto *FCL1 = F->createFullyConnected(*context.getPlaceholderBindings(),
                                          "fc", last, 10);
     auto *RL3 = F->createRELU("relu4", FCL1);

--- a/tests/unittests/TypeAToTypeBFunctionConverterTest.cpp
+++ b/tests/unittests/TypeAToTypeBFunctionConverterTest.cpp
@@ -519,7 +519,7 @@ TEST(TypeAToTypeBFunctionConverter, int64IConversionFloatToFloat16) {
   auto *output =
       mod.createPlaceholder(ElemKind::FloatTy, {20, 3}, "Output", false);
   auto *outputIdx =
-      mod.createPlaceholder(IndexElemKind, {20, 3}, "Output", false);
+      mod.createPlaceholder(ElemKind::Int64ITy, {20, 3}, "Output", false);
 
   auto *topK = F->createTopK("topK", input, 3);
   auto *result = F->createSave("save", topK->getValues(), output);
@@ -551,7 +551,8 @@ TEST(TypeAToTypeBFunctionConverter, int64IConversionFloatToFloat16) {
   ASSERT_NE(convertedTopK, nullptr);
   EXPECT_EQ(convertedTopK->getElementType(TopKNode::ValuesIdx),
             ElemKind::Float16Ty);
-  EXPECT_EQ(convertedTopK->getElementType(TopKNode::IndicesIdx), IndexElemKind);
+  EXPECT_EQ(convertedTopK->getElementType(TopKNode::IndicesIdx),
+            ElemKind::Int64ITy);
   // Check that the input of TopK is a convertTo node from float to
   // Float16Ty.
   auto *convertedTopKInput =
@@ -577,7 +578,7 @@ TEST(TypeAToTypeBFunctionConverter, int64IConversionFloatToFloat16) {
   EXPECT_EQ(resultIndices->getOutput(), outputIdx->getOutput());
   EXPECT_EQ(resultIndices->getInput(),
             convertedTopK->getNthResult(TopKNode::IndicesIdx));
-  EXPECT_EQ(resultIndices->getInput().getElementType(), IndexElemKind);
+  EXPECT_EQ(resultIndices->getInput().getElementType(), ElemKind::Int64ITy);
 }
 
 /// Check that the conversion optimization can get rid of conversion of
@@ -1028,8 +1029,9 @@ static void testConvertFRWQSLWS(bool forceFP16AccumSLS) {
 
   Constant *weights = mod.createConstant(ElemKind::FloatTy, {8}, "weights");
 
-  Placeholder *indices = mod.createPlaceholder(IndexElemKind, {8}, "indices",
-                                               /* isTrainable */ false);
+  Placeholder *indices =
+      mod.createPlaceholder(ElemKind::Int64ITy, {8}, "indices",
+                            /* isTrainable */ false);
   Placeholder *lengths =
       mod.createPlaceholder(ElemKind::Int32ITy, {4}, "lengths",
                             /* isTrainable */ false);
@@ -1095,8 +1097,9 @@ TEST(TypeAToTypeBFunctionConverter, skipConvertingFRWQSLWS) {
 
   Constant *weights = mod.createConstant(ElemKind::FloatTy, {8}, "weights");
 
-  Placeholder *indices = mod.createPlaceholder(IndexElemKind, {8}, "indices",
-                                               /* isTrainable */ false);
+  Placeholder *indices =
+      mod.createPlaceholder(ElemKind::Int64ITy, {8}, "indices",
+                            /* isTrainable */ false);
   Placeholder *lengths =
       mod.createPlaceholder(ElemKind::Int32ITy, {4}, "lengths",
                             /* isTrainable */ false);
@@ -1146,8 +1149,9 @@ TEST(TypeAToTypeBFunctionConverter, convertOnlyFloat16Ty) {
 
   Constant *weights = mod.createConstant(ElemKind::FloatTy, {8}, "weights");
 
-  Placeholder *indices = mod.createPlaceholder(IndexElemKind, {8}, "indices",
-                                               /* isTrainable */ false);
+  Placeholder *indices =
+      mod.createPlaceholder(ElemKind::Int64ITy, {8}, "indices",
+                            /* isTrainable */ false);
   Placeholder *lengths =
       mod.createPlaceholder(ElemKind::Int32ITy, {4}, "lengths",
                             /* isTrainable */ false);
@@ -1204,8 +1208,9 @@ TEST(TypeAToTypeBFunctionConverter, convertOnlyUInt8FusedQTy) {
 
   Constant *weights = mod.createConstant(ElemKind::FloatTy, {8}, "weights");
 
-  Placeholder *indices = mod.createPlaceholder(IndexElemKind, {8}, "indices",
-                                               /* isTrainable */ false);
+  Placeholder *indices =
+      mod.createPlaceholder(ElemKind::Int64ITy, {8}, "indices",
+                            /* isTrainable */ false);
   Placeholder *lengths =
       mod.createPlaceholder(ElemKind::Int32ITy, {4}, "lengths",
                             /* isTrainable */ false);

--- a/tools/ClassGen/InstrBuilder.cpp
+++ b/tools/ClassGen/InstrBuilder.cpp
@@ -206,8 +206,7 @@ void InstrBuilder::emitCloner(std::ostream &os) const {
 
 std::string getOpElementType(const std::string &name) {
   const std::string elemKindPrefix = "ElemKind::";
-  if (name == "IndexElemKind" ||
-      name.substr(0, elemKindPrefix.size()) == elemKindPrefix) {
+  if (name.substr(0, elemKindPrefix.size()) == elemKindPrefix) {
     return name;
   }
   return "get" + name + "()->getElementType()";

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -320,7 +320,6 @@ int main(int argc, char **argv) {
       .addMember(MEMBER_TYPE_INFO(glow::LengthsMode), "LengthsMode")
       .autoIRGen()
       .autoVerify(VerifyKind::SameElementType, {"Dest", "Data"})
-      .autoVerify(VerifyKind::SameElementType, {"Indices", "IndexElemKind"})
       .autoVerify(VerifyKind::SameElementType,
                   {"Lengths", "ElemKind::Int32ITy"})
       .addGradientInstr({"Data", "Indices", "Lengths"}, {"Dest", "Data"});
@@ -334,7 +333,6 @@ int main(int argc, char **argv) {
       .addMember(MEMBER_TYPE_INFO(glow::LengthsMode), "LengthsMode")
       .autoIRGen()
       .autoVerify(VerifyKind::SameElementType, {"Dest", "Data", "Weights"})
-      .autoVerify(VerifyKind::SameElementType, {"Indices", "IndexElemKind"})
       .autoVerify(VerifyKind::SameElementType,
                   {"Lengths", "ElemKind::Int32ITy"})
       .autoVerify(VerifyKind::SameShape, {"Weights", "Indices"})
@@ -351,8 +349,10 @@ int main(int argc, char **argv) {
       .addMember(MEMBER_TYPE_INFO(glow::LengthsMode), "LengthsMode")
       .autoIRGen()
       .autoVerify(VerifyKind::SameElementType, {"Dest", "Data", "Weights"})
-      .autoVerify(VerifyKind::SameElementType, {"Indices", "IndexElemKind"})
-      .autoVerify(VerifyKind::SameElementType, {"Offsets", "IndexElemKind"})
+      .autoVerify(VerifyKind::SameElementType,
+                  {"Indices", "ElemKind::Int64ITy"})
+      .autoVerify(VerifyKind::SameElementType,
+                  {"Offsets", "ElemKind::Int64ITy"})
       .autoVerify(VerifyKind::SameShape, {"Weights", "Indices"});
 
   BB.newInstr("RowwiseQuantizedSparseLengthsWeightedSum")
@@ -367,7 +367,6 @@ int main(int argc, char **argv) {
       .addMember(MEMBER_TYPE_INFO(glow::LengthsMode), "LengthsMode")
       .autoIRGen()
       .autoVerify(VerifyKind::SameElementType, {"Data", "ElemKind::UInt8QTy"})
-      .autoVerify(VerifyKind::SameElementType, {"Indices", "IndexElemKind"})
       .autoVerify(VerifyKind::SameElementType,
                   {"Lengths", "ElemKind::Int32ITy"})
       .autoVerify(VerifyKind::SameShape, {"Weights", "Indices"});
@@ -381,7 +380,6 @@ int main(int argc, char **argv) {
       .addMember(MemberType::Boolean, "UseFP16Accumulation")
       .addMember(MEMBER_TYPE_INFO(glow::LengthsMode), "LengthsMode")
       .autoIRGen()
-      .autoVerify(VerifyKind::SameElementType, {"Indices", "IndexElemKind"})
       .autoVerify(VerifyKind::SameElementType,
                   {"Lengths", "ElemKind::Int32ITy"})
       .autoVerify(VerifyKind::SameShape, {"Weights", "Indices"});
@@ -396,8 +394,10 @@ int main(int argc, char **argv) {
       .addMember(MemberType::Boolean, "HasEndOffset")
       .addMember(MEMBER_TYPE_INFO(glow::LengthsMode), "LengthsMode")
       .autoIRGen()
-      .autoVerify(VerifyKind::SameElementType, {"Indices", "IndexElemKind"})
-      .autoVerify(VerifyKind::SameElementType, {"Offsets", "IndexElemKind"})
+      .autoVerify(VerifyKind::SameElementType,
+                  {"Indices", "ElemKind::Int64ITy"})
+      .autoVerify(VerifyKind::SameElementType,
+                  {"Offsets", "ElemKind::Int64ITy"})
       .autoVerify(VerifyKind::SameShape, {"Weights", "Indices"});
 
   BB.newInstr("LengthsToRanges")
@@ -433,7 +433,8 @@ int main(int argc, char **argv) {
       .addMember(MemberType::VectorDimT, "Mask")
       .autoVerify(VerifyKind::SameElementType,
                   {"Dest", "Values", "DefaultValue"})
-      .autoVerify(VerifyKind::SameElementType, {"Indices", "IndexElemKind"})
+      .autoVerify(VerifyKind::SameElementType,
+                  {"Indices", "ElemKind::Int64ITy"})
       .autoVerify(VerifyKind::SameElementType,
                   {"Lengths", "ElemKind::Int32ITy"})
       .autoIRGen();
@@ -700,7 +701,7 @@ int main(int argc, char **argv) {
       .addOperand("Indices", OperandKind::In)
       .addOperand("Slices", OperandKind::In)
       .addMember(MemberType::Boolean, "Cumulative")
-      .autoVerify(VerifyKind::SameElementType, {"Indices", "IndexElemKind"});
+      .autoVerify(VerifyKind::NoVerify);
 
   BB.newInstr("BatchOneHot")
       .addOperand("Dest", OperandKind::Out)


### PR DESCRIPTION
Summary: Refactored index demotion from automatic during project creation to compile time pass.
Related to: github.com/pytorch/glow/issues/4071

Documentation:

[Optional Fixes #issue]

Test Plan: Unit tests

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
