### PR TITLE
ConvertTo should be a data parallel node

### DIFF
--- a/lib/Graph/TensorLayout.cpp
+++ b/lib/Graph/TensorLayout.cpp
@@ -602,11 +602,15 @@ bool TensorLayoutCommon::isSatisfiedBy(
   return true;
 }
 
-static std::string returnBaseReqOrNHWC(std::string baseReq) {
+static std::string returnBaseReqOrNHWC(std::string baseReq, const Node *node) {
   auto baseReqHelper = TensorLayoutDescription(baseReq);
   if (!baseReqHelper.isSameLayout(
           CanonicalTensorLayout::getInstance().getLayoutsForDims()[4])) {
     return baseReq;
+  }
+  if (CanonicalTensorLayout::getInstance().acceptsAnyLayout(node)) {
+    // These nodes accept any 4-D layout.
+    return baseReqHelper.getSerializedLayout();
   }
   // NHWC is the canonical default
   return CanonicalTensorLayout::getInstance().getDefaultNDLayout(4);
@@ -619,14 +623,14 @@ CanonicalTensorLayout::getNthInputLayoutRequirements(const Node *node,
   if (acceptsAnyLayout(node)) {
     return baseReq;
   }
-  return returnBaseReqOrNHWC(baseReq);
+  return returnBaseReqOrNHWC(baseReq, node);
 }
 
 std::string
 CanonicalTensorLayout::getNthResultLayoutRequirements(const Node *node,
                                                       size_t n) {
   auto baseReq = TensorLayoutCommon::getNthResultLayoutRequirements(node, n);
-  return returnBaseReqOrNHWC(baseReq);
+  return returnBaseReqOrNHWC(baseReq, node);
 }
 
 std::string CanonicalTensorLayout::getDefaultNDLayout(unsigned dims) const {

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -985,6 +985,7 @@ int main(int argc, char **argv) {
   BB.newNode("ConvertTo")
       .addInput("Input")
       .addResultFromCtorArg()
+      .dataParallel()
       .setDocstring(
           "Convert the input from its current type to the destination "
           "type. The input and output types must have the same shapes. "


### PR DESCRIPTION
Summary:

Probably an oversight - convert to should be data parallel graph node.

Test Plan:

ninja test
