### PR TITLE
fix some Instruction names in IRGen

### DIFF
--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -147,7 +147,7 @@ TEST(RuntimeBundle, BundleSymbolInfo) {
             glow::runtime::SymbolCategory::Activation);
   // Check that tensor views have the same label as their parent symbol. In this
   // case same as "input".
-  EXPECT_EQ(table.find("tensorview_reshape_in")->second.symbolCategory,
+  EXPECT_EQ(table.find("FC_reshape2D_tensorview")->second.symbolCategory,
             glow::runtime::SymbolCategory::PlaceholderTensorView);
 
   // Check that placeholders and constants input/output flags are correctly set.
@@ -165,8 +165,8 @@ TEST(RuntimeBundle, BundleSymbolInfo) {
   EXPECT_EQ(table.find("FC_res")->second.input, false);
   EXPECT_EQ(table.find("FC_res")->second.output, false);
   // Check that tensor views are labelled correctly.
-  EXPECT_EQ(table.find("tensorview_reshape_in")->second.input, false);
-  EXPECT_EQ(table.find("tensorview_reshape_in")->second.output, false);
+  EXPECT_EQ(table.find("FC_reshape2D_tensorview")->second.input, false);
+  EXPECT_EQ(table.find("FC_reshape2D_tensorview")->second.output, false);
 }
 
 // Test if the placeholders are allocated contiguously as


### PR DESCRIPTION
Summary: A bunch of hand rolled IRGen uses static names for Instructions rather than propagating the Node name, fix this by apply the Node name decoration helper we use in Lower and GraphOptimizer stages.

Documentation: NFC, we don't rely on Instruction names anywhere I know of.

Test Plan: ran tests