### PR TITLE
[WIP] Support for ONNX Upsample and ONNX Resize(mode=nearest) v10.

### DIFF
--- a/include/glow/Importer/ONNXModelLoader.h
+++ b/include/glow/Importer/ONNXModelLoader.h
@@ -279,6 +279,14 @@ class ONNXModelLoader
   Error loadFlip(const ONNX_NAMESPACE::NodeProto &op,
                  const ArgumentDictionaryTy &dict);
 
+  /// Load Upsample Glow Operator.
+  Error loadUpsample(const ONNX_NAMESPACE::NodeProto &op,
+                     const ArgumentDictionaryTy &dict);
+
+  /// Load Resize Glow Operator.
+  Error loadResize(const ONNX_NAMESPACE::NodeProto &op,
+                   const ArgumentDictionaryTy &dict);
+
 protected:
   /// Load the network operators from the GraphProto.
   /// \returns Error if network cannot be loaded.

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -413,6 +413,10 @@ bool CPUBackend::isOpSupported(const NodeInfo &NI) const {
            ((NI.getInElemTy(ConvertToNode::InputIdx) == ElemKind::Int32ITy) &&
             (NI.getOutElemTy(ConvertToNode::ResultIdx) == ElemKind::Int64ITy));
 
+  case Kinded::Kind::ResizeNearestNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+        {ElemKind::FloatTy, ElemKind::Int8QTy, ElemKind::Int32QTy});
+
   default:
     return false;
   }

--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -1110,6 +1110,26 @@ libjit_nms_generic(T *indices, T *numDetected, const float *boxTensor,
     }
   }
 }
+
+template <typename T>
+static void libjit_resize_nearest_generic(const T *inW, T *outW,
+                                          const dim_t *inWdims,
+                                          const dim_t *outWdims, float scaleH,
+                                          float scaleW) {
+  for (dim_t ob = 0; ob < outWdims[0]; ++ob) {
+    for (dim_t oh = 0; oh < outWdims[1]; ++oh) {
+      auto ic = std::min(dim_t(oh / scaleH), inWdims[1] - 1);
+      for (dim_t ow = 0; ow < outWdims[2]; ++ow) {
+        auto iw = std::min(dim_t(ow / scaleW), inWdims[2] - 1);
+        for (dim_t oc = 0; oc < outWdims[3]; ++oc) {
+          outW[libjit_getXYZW(outWdims, ob, oh, ow, oc)] =
+              inW[libjit_getXYZW(inWdims, ob, ic, iw, oc)];
+        }
+      }
+    }
+  }
+}
+
 } // namespace
 
 extern "C" {
@@ -2509,4 +2529,29 @@ libjit_nms_i32(int32_t *indices, int32_t *numDetected, const float *boxTensor,
                      centerPointBox, maxOutputBoxesPerClass, iouThreshold,
                      scoreThreshold, isV4);
 }
+
+void libjit_resize_nearest_i8(const int8_t *inW, int8_t *outW,
+                              const dim_t *inWdims, const dim_t *outWdims,
+                              float scaleH, float scaleW) {
+  libjit_resize_nearest_generic(inW, outW, inWdims, outWdims, scaleH, scaleW);
+}
+
+void libjit_resize_nearest_i16(const int16_t *inW, int16_t *outW,
+                               const dim_t *inWdims, const dim_t *outWdims,
+                               float scaleH, float scaleW) {
+  libjit_resize_nearest_generic(inW, outW, inWdims, outWdims, scaleH, scaleW);
+}
+
+void libjit_resize_nearest_i32(const int32_t *inW, int32_t *outW,
+                               const dim_t *inWdims, const dim_t *outWdims,
+                               float scaleH, float scaleW) {
+  libjit_resize_nearest_generic(inW, outW, inWdims, outWdims, scaleH, scaleW);
+}
+
+void libjit_resize_nearest_f(const float *inW, float *outW,
+                             const dim_t *inWdims, const dim_t *outWdims,
+                             float scaleH, float scaleW) {
+  libjit_resize_nearest_generic(inW, outW, inWdims, outWdims, scaleH, scaleW);
+}
+
 } // extern "C"

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -1679,7 +1679,7 @@ bool ResizeNearestNode::verify() const {
   isValid &= expectCompareTrue("Batch size must be the same", inputDims[0],
                                outputDims[0], this);
   isValid &= expectCompareTrue("Depth must be the same", inputDims[3],
-                               outputDims[0], this);
+                               outputDims[3], this);
   isValid &= expectCompareTrue(
       "Unexpected output height",
       dim_t(std::floor(inputDims[1] * getHeightScale())), outputDims[1], this);

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -2775,6 +2775,25 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     break;
   }
 
+  case Kinded::Kind::ResizeNearestInstKind: {
+    auto *N = llvm::cast<ResizeNearestInst>(I);
+    auto *src = N->getSrc();
+    auto *dst = N->getDest();
+
+    auto *srcVal = emitValueAddress(builder, src);
+    auto *dstVal = emitValueAddress(builder, dst);
+    auto *srcDimsVal = emitValueDims(builder, src);
+    auto *dstDimsVal = emitValueDims(builder, dst);
+
+    auto *hScaleVal = emitConstF32(builder, N->getHeightScale());
+    auto *wScaleVal = emitConstF32(builder, N->getWidthScale());
+
+    auto *F = getFunction("resize_nearest", src->getElementType());
+    createCall(builder, F,
+               {srcVal, dstVal, srcDimsVal, dstDimsVal, hScaleVal, wScaleVal});
+    break;
+  }
+
   default:
     std::string sBuf;
     llvm::raw_string_ostream s(sBuf);

--- a/tests/models/onnxModels/resizeNearest.onnxtxt
+++ b/tests/models/onnxModels/resizeNearest.onnxtxt
@@ -1,0 +1,73 @@
+ir_version: 3
+producer_name: "backend-test"
+graph {
+  node {
+    input: "in"
+    input: "const"
+    output: "out"
+    name: "resizeNearest"
+    op_type: "Resize"
+    attribute {
+      name: "mode"
+      s: "nearest"
+      type: STRING
+    }
+  }
+  name: "test-model"
+  initializer {
+    dims: 4
+    data_type: 1
+    float_data: 1.0
+    float_data: 1.0
+    float_data: 2.0
+    float_data: 2.0
+   name: "const"
+  }
+  input {
+    name: "in"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+         dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "out"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+         dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 10
+}

--- a/tests/models/onnxModels/upsample.onnxtxt
+++ b/tests/models/onnxModels/upsample.onnxtxt
@@ -1,0 +1,73 @@
+ir_version: 3
+producer_name: "backend-test"
+graph {
+  node {
+    input: "in"
+    input: "const"
+    output: "out"
+    name: "upsample"
+    op_type: "Upsample"
+    attribute {
+      name: "mode"
+      s: "nearest"
+      type: STRING
+    }
+  }
+  name: "test-model"
+  initializer {
+    dims: 4
+    data_type: 1
+    float_data: 1.0
+    float_data: 1.0
+    float_data: 2.0
+    float_data: 2.0
+   name: "const"
+  }
+  input {
+    name: "in"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+         dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "out"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+         dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 9
+}

--- a/tests/unittests/OnnxExporterTest.cpp
+++ b/tests/unittests/OnnxExporterTest.cpp
@@ -153,7 +153,9 @@ TEST(exporter, onnxModels) {
         name.find("NonMaxSuppressionSSD_ONNX.onnxtxt") != std::string::npos ||
         name.find("NonMaxSuppression.onnxtxt") != std::string::npos ||
         name.find("NonMaxSuppressionSSD.onnxtxt") != std::string::npos ||
-        name.find("Less.onnxtxt") != std::string::npos) {
+        name.find("Less.onnxtxt") != std::string::npos ||
+        name.find("upsample.onnxtxt") != std::string::npos ||
+        name.find("resizeNearest.onnxtxt") != std::string::npos) {
       // Ignore invalid ONNX files and graphs without nodes.
       llvm::outs() << "Ignore invalid input files: " << name << "\n";
       continue;

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -1347,7 +1347,7 @@ static void testResizeNearest(glow::PlaceholderBindings &bindings,
 
 /// Verify that the ResizeNearest operator works correctly for Float.
 TEST_P(OperatorTest, ResizeNearest_Float) {
-  CHECK_IF_ENABLED();
+  ENABLED_BACKENDS("Interpreter", "CPU");
   testResizeNearest<float>(bindings_, mod_, F_, EE_, ElemKind::FloatTy);
 }
 
@@ -1359,7 +1359,7 @@ TEST_P(OperatorTest, ResizeNearest_Float16) {
 
 /// Verify that the ResizeNearest operator works correctly for Int8Q.
 TEST_P(OperatorTest, ResizeNearest_Int8) {
-  CHECK_IF_ENABLED();
+  ENABLED_BACKENDS("Interpreter", "CPU");
   testResizeNearest<int8_t>(bindings_, mod_, F_, EE_, ElemKind::Int8QTy);
 }
 
@@ -1371,7 +1371,7 @@ TEST_P(OperatorTest, ResizeNearest_Int16) {
 
 /// Verify that the ResizeNearest operator works correctly for Int32Q.
 TEST_P(OperatorTest, ResizeNearest_Int32) {
-  CHECK_IF_ENABLED();
+  ENABLED_BACKENDS("Interpreter", "CPU");
   testResizeNearest<int32_t>(bindings_, mod_, F_, EE_, ElemKind::Int32QTy);
 }
 


### PR DESCRIPTION
Summary:
Upsample from ONNX v9 (later deprecated ) and Resize (mode=nearest) are used in many segmentation and detection networks.

Documentation:
https://github.com/onnx/onnx/blob/master/docs/Operators.md#Upsample
https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Resize-10

Fixes #4108 

This further extends work in #2421. We aimed to support ONNX Resize (mode=nearest)  v10  operator only.  Later on we plan to add  ONNX Resize (mode=bilinear) v10.  Apart from those we don't have other immediate needs. E.g. all the complex stuff from Resize v11 is not on our radar.

