### PR TITLE
[Graph] Fix build break caused by adding BatchedPairwiseDotProduct

### DIFF
--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -2562,8 +2562,8 @@ BatchedPairwiseDotProductNode *
 Function::createBatchedPairwiseDotProduct(llvm::StringRef name,
                                           llvm::ArrayRef<NodeValue> inputs) {
   assert(!inputs.empty());
-  size_t batchCount = inputs[0].getType()->dims()[0];
-  size_t numPairs = inputs.size() * (inputs.size() - 1) / 2;
+  dim_t batchCount = inputs[0].getType()->dims()[0];
+  dim_t numPairs = inputs.size() * (inputs.size() - 1) / 2;
   auto *outTy = getParent()->uniqueTypeWithNewShape(inputs[0].getType(),
                                                     {batchCount, numPairs});
 


### PR DESCRIPTION
**Summary**
This commit fixes a build break with GCC caused by the addition of the
`BatchedPairwiseDotProduct` operator. Dimensions extracted from an input type
were stored in variables of type `size_t` instead of `dim_t` and then
used in a brace-delimited literal for the dimensions of a new `Type`.
This commit fixes this issue by declaring these variables with `auto` instead.

**Test Plan**
Continuous integration.