### PR TITLE
Adds allocateDeviceIOBuffer to the deviceManager 

### DIFF
--- a/include/glow/Backends/DeviceManager.h
+++ b/include/glow/Backends/DeviceManager.h
@@ -102,6 +102,13 @@ public:
   /// Initialize the device.
   virtual Error init() { return Error::success(); }
 
+  /// \returns a pointer to a buffer of size \p size allocated on the host, that
+  /// satistfies any requirements for pinning/alignment for transferring to/from
+  /// the device.
+  virtual void *allocateDeviceIOBuffer(dim_t size) {
+    return alignedAlloc(size, TensorAlignment);
+  };
+
   /// Load the provided module into the device, readyCB will be called when
   /// ready to use.
   /// \p functions contains the list of functions to load, keyed by their name


### PR DESCRIPTION
Summary:
This adds a new api method to the Backend, allocateDeviceIOBuffer. This is used to allow a backend to allocate a buffer that satisfies any requirements needed for the buffer to be used for transfer to/from the device.
Documentation:

Test Plan:

