### PR TITLE
[ONNXModelLoader] Update Onnx Matmul Operator to support inputs of dimension 3

### DIFF
--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -1191,8 +1191,14 @@ Error ONNXModelLoader::loadMatMul(const ONNX_NAMESPACE::NodeProto &op,
   NodeValue RHS;
   ASSIGN_VALUE_OR_RETURN_ERR(RHS, getNodeValueByName(op.input(1)));
 
-  Node *node = G_.createMatMul(opName, LHS, RHS);
-  RETURN_IF_ERR(addNodeAsOutput(op, node));
+  /// For dimension size equal to 3 use batchedMatMul
+  if (LHS.dims().size() == 3) {
+    Node *node = G_.createBatchMatMul(opName, LHS, RHS);
+    RETURN_IF_ERR(addNodeAsOutput(op, node));
+  } else {
+    Node *node = G_.createMatMul(opName, LHS, RHS);
+    RETURN_IF_ERR(addNodeAsOutput(op, node));
+  }
   return Error::success();
 }
 

--- a/tests/models/onnxModels/matmul.onnxtxt
+++ b/tests/models/onnxModels/matmul.onnxtxt
@@ -1,0 +1,73 @@
+ir_version: 3
+producer_name: "onnx-test"
+graph {
+  node {
+    input: "inputs_0"
+    input: "inputs_1"
+    output: "output"
+    name: ""
+    op_type: "MatMul"
+  }
+  input {
+    name: "inputs_0"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 20
+          }
+          dim {
+            dim_value: 40
+          }
+          dim {
+            dim_value: 7
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "inputs_1"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 20
+          }
+          dim {
+            dim_value: 7
+          }
+          dim {
+            dim_value: 40
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "output"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 20
+          }
+          dim {
+            dim_value: 7
+          }
+          dim {
+            dim_value: 7
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 7
+}
+


### PR DESCRIPTION
Some of the recommendation systems when represented in onnx format have matmul operator whose inputs are of dimension size 3. Currently OnnxModelLoader does not support this requirement. loadMatmul API has been updated such that when dimension size is 3 then use BatchMatmulNode. 

Test Plan: A sample .onnxtxt has been added along with a test case in OnnxImporterTest
