### PR TITLE
Added an info log for number of partitions created

### DIFF
--- a/lib/Partitioner/Partitioner.cpp
+++ b/lib/Partitioner/Partitioner.cpp
@@ -79,10 +79,11 @@ Error Partitioner::finalize(const DAGListTy &partitions,
   // needs the backend specific verifier. Tensor layouts, for example, might
   // have gone from canonical form to backend specific form.
 
+  LOG(INFO) << "The number of partitions is : "
+            << module_->getFunctions().size() << "\n";
+
   if (logPartition) {
-    LOG(INFO) << "The number of partitions is : "
-              << module_->getFunctions().size()
-              << ", and the DAG is dumped into DAG.dot file.\n";
+    LOG(INFO) << "Dumping partitioning DAG to DAG.dot file.\n";
     dumpDAG("DAG.dot", partitions);
     logPartitionInfo(mapping);
   }


### PR DESCRIPTION
Summary:
Add an always print info statement for number of partitions.
Documentation:


Test Plan:
run tests and notice that partition count is now printed.
