### PR TITLE
glow: change dump debug traces to merge traces together before dumping

### DIFF
--- a/lib/Onnxifi/HostManagerOnnxifi.h
+++ b/lib/Onnxifi/HostManagerOnnxifi.h
@@ -80,6 +80,9 @@ public:
 
 private:
   std::string netName_;
+  std::mutex tracesMutex_;
+  std::unique_ptr<TraceContext> mergedTraceContext_;
+  int numTracesToDump_{0};
 };
 
 } // namespace onnxifi


### PR DESCRIPTION
Summary: We have this --glow_dump_debug_traces flag that dumps the glow traces to file. The old behavior is that we dump each trace as individual files on disk. It's more useful to have them merged together so one can observe if any expected overlap is happening or if there is runtime overhead in between request dispatches.

Reviewed By: jfix71

Differential Revision: D19785966

