### PR TITLE
[GraphOptz] Add verify check in TearDown

### DIFF
--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -183,6 +183,9 @@ protected:
                                              &optimizedBindings, allowedError));
   }
 
+  /// Verify the module is still valid at the end of the test.
+  virtual void TearDown() override { EXPECT_TRUE(mod_.verify()); }
+
   /// ExecutionEngine instance for running functions to check numerical
   /// equivalence.
   ExecutionEngine EE_;


### PR DESCRIPTION
Summary: Add a verification check in the TearDown for GraphOptzTests. 

- Some tests created MatMul with invalid dimensions
- One converted to an incorrect type for fused quantized kinds
- One relied on ConvertTo optimizations removing converts for quantization, but we don't use ConvertTo for quantization, so moved it to indices (`ITy`).
- TODO: Some tests still fail for padding (see https://github.com/pytorch/glow/issues/4128)

Test Plan: Tested manually. 