### PR TITLE
Add support for cloning IR functions and IR instructions

### DIFF
--- a/include/glow/IR/IR.h
+++ b/include/glow/IR/IR.h
@@ -169,6 +169,10 @@ public:
     }
   }
 
+  /// Clone the current instruction.
+  /// \returns a cloned instruction.
+  Instruction *clone() const;
+
   /// \returns True if this instruction may reuse the memory buffer read by
   /// operand \p srcIdx for writing the result of the operand at \p dstIdx.
   bool isInplaceOp(unsigned dstIdx, unsigned srcIdx) const { return false; }

--- a/include/glow/IR/IR.h
+++ b/include/glow/IR/IR.h
@@ -292,6 +292,28 @@ public:
   /// again for another round of code generation.
   void clear();
 
+  /// Clone the current IR function into a new function with the name \p newName
+  /// in the same module. If \p map is non-null then the procedure records the
+  /// mapping between the old node to the new node in \p map. If \p currToNewMap
+  /// is non-null it is used as the initial state of the currToNew map inside
+  /// the cloner.
+  /// \returns a new function that is a copy of the current function.
+  IRFunction *
+  clone(llvm::StringRef newName,
+        llvm::DenseMap<const Value *, Value *> *map = nullptr,
+        llvm::DenseMap<const Value *, Value *> *currToNewMap = nullptr);
+
+  /// Clone the current function into a user-provided function \p newF. The
+  /// function \p newF is not automatically added to a module by the clone call.
+  /// If \p map is non-null then the procedure records the mapping between the
+  /// old node to the new node in \p map. If \p currToNewMap is non-null it is
+  /// used as the initial state of the currToNew map inside the cloner. \returns
+  /// a user-provided function \p newF that now contains a clone of the current
+  /// function.
+  IRFunction *
+  clone(IRFunction *newF, llvm::DenseMap<const Value *, Value *> *map = nullptr,
+        llvm::DenseMap<const Value *, Value *> *currToNewMap = nullptr) const;
+
   /// \returns a reference to the high-level graph.
   Function *getGraph() { return G_; }
 
@@ -332,6 +354,9 @@ public:
 
   /// \returns the variable map.
   VariableMap &getVariableMap() { return variableMap_; }
+
+  /// \returns the variable map.
+  const VariableMap &getVariableMap() const { return variableMap_; }
 
   /// Returns a list of constants associated with function.
   std::vector<const Constant *> findConstants() const;

--- a/lib/IR/IR.cpp
+++ b/lib/IR/IR.cpp
@@ -609,6 +609,61 @@ std::string IRFunction::toString() const {
   return os.str();
 }
 
+IRFunction *
+IRFunction::clone(llvm::StringRef newName,
+                  llvm::DenseMap<const Value *, Value *> *map,
+                  llvm::DenseMap<const Value *, Value *> *currToNewMap) {
+  // Create a new function.
+  auto *newF = new IRFunction(getGraph());
+  newF->setName(newName);
+  return clone(newF, map, currToNewMap);
+}
+
+IRFunction *
+IRFunction::clone(IRFunction *newF, llvm::DenseMap<const Value *, Value *> *map,
+                  llvm::DenseMap<const Value *, Value *> *currToNewMap) const {
+
+  llvm::DenseMap<const Value *, Value *> currToNew;
+  // Initialize the map from a user-provided map.
+  if (currToNewMap) {
+    currToNew.insert(currToNewMap->begin(), currToNewMap->end());
+  }
+  // Clone weights.
+  for (auto &w : getWeights()) {
+    auto cloneWeight =
+        new WeightVar(w->getName(), w->getType(), w->getMutability());
+    newF->getWeights().emplace_back(cloneWeight);
+    currToNew[w] = cloneWeight;
+  }
+  // Clone the variable map.
+  for (auto &v : getVariableMap()) {
+    assert(v.second && "The value should have been cloned already");
+    newF->getVariableMap()[v.first] = currToNew[v.second];
+  }
+  // Clone instructions.
+  for (const auto &I : getInstrs()) {
+    auto *cloneI = I.clone();
+    currToNew[&I] = cloneI;
+    // Remap all operands.
+    for (unsigned idx = 0, e = cloneI->getNumOperands(); idx < e; ++idx) {
+      cloneI->setOperand(idx, currToNew[cloneI->getOperand(idx).first]);
+    }
+    newF->insertInstruction(cloneI);
+  }
+  // Record the node mapping into the external map.
+  if (map) {
+    assert(map->empty() && "The external map must be empty");
+    for (auto it : currToNew) {
+      map->insert(it);
+    }
+  }
+  assert(newF->getInstrs().size() == getInstrs().size() && "Invalid func size");
+  assert(newF->getWeights().size() == getWeights().size() &&
+         "Invalid func size");
+  newF->verify();
+  return newF;
+}
+
 //===----------------------------------------------------------------------===//
 // InstructionTraits<Instruction> Implementation
 //===----------------------------------------------------------------------===//

--- a/lib/IR/IR.cpp
+++ b/lib/IR/IR.cpp
@@ -359,6 +359,24 @@ bool Instruction::isDataParallel() const {
   return false;
 }
 
+Instruction *Instruction::clone() const {
+  switch (getKind()) {
+  default:
+    llvm_unreachable("Unknown value kind");
+    break;
+#define DEF_INSTR(CLASS, NAME)                                                 \
+  case Kinded::Kind::CLASS##Kind: {                                            \
+    auto *X = llvm::cast<const CLASS>(this);                                   \
+    return X->clone();                                                         \
+    break;                                                                     \
+  }
+#define DEF_BACKEND_SPECIFIC_INSTR(CLASS, NAME) DEF_INSTR(CLASS, NAME)
+#define DEF_VALUE(CLASS, NAME)
+#include "glow/AutoGenInstr.def"
+  }
+  return nullptr;
+}
+
 //===----------------------------------------------------------------------===//
 //                    Instruction numbering
 //===----------------------------------------------------------------------===//

--- a/tools/ClassGen/InstrBuilder.cpp
+++ b/tools/ClassGen/InstrBuilder.cpp
@@ -188,6 +188,22 @@ void InstrBuilder::emitPrettyPrinter(std::ostream &os) const {
   os << "}\n";
 }
 
+void InstrBuilder::emitCloner(std::ostream &os) const {
+  os << "\nInstruction* " << name_ << "Inst::clone() const {\n";
+
+  os << "  return new " << name_ << "Inst(getName()";
+
+  for (const auto &op : operands_) {
+    os << ", get" << op.first << "()";
+  }
+
+  for (const auto &mem : members_) {
+    os << ", get" << mem.second << "()";
+  }
+
+  os << ");\n}\n";
+}
+
 std::string getOpElementType(const std::string &name) {
   const std::string elemKindPrefix = "ElemKind::";
   if (name == "IndexElemKind" ||
@@ -213,6 +229,7 @@ void InstrBuilder::emitClass(std::ostream &os) const {
     os << "  " << m.first << "\n";
   }
 
+  os << "\n  Instruction* clone() const;\n";
   os << "\n  void dump(llvm::raw_ostream &os) const;\n";
 
   // If there is no auto-verification then we assume verification is manually
@@ -280,7 +297,7 @@ void InstrBuilder::emitClass(std::ostream &os) const {
 
 void InstrBuilder::emitCppMethods(std::ostream &os) const {
   emitPrettyPrinter(os);
-
+  emitCloner(os);
   // Emit the "extra" method bodies.
   for (const auto &m : extraMethods_) {
     os << "  " << m.second << "\n";

--- a/tools/ClassGen/InstrBuilder.h
+++ b/tools/ClassGen/InstrBuilder.h
@@ -256,6 +256,9 @@ private:
   /// Emit the class definition.
   void emitClass(std::ostream &os) const;
 
+  /// Emit the clone() method.
+  void emitCloner(std::ostream &os) const;
+
   /// Emit the methods that go into the CPP file and implement the methods that
   /// were declared in the header file.
   void emitCppMethods(std::ostream &os) const;


### PR DESCRIPTION
Follow the example of the functionality available for the graph-level cloning:
- Introduce a clone method in the Instruction class and auto-generate the implementations of cloning functions by means of InstrGen.
- Add support for cloning IRFunctions