### PR TITLE
Improved dynamic registration/unregistration of backends

### DIFF
--- a/include/glow/Backend/Backend.h
+++ b/include/glow/Backend/Backend.h
@@ -247,6 +247,27 @@ public:
   static RegisterFactory<std::string, FactoryName, Backend>                    \
       FactoryName##_REGISTERED;
 
+/// Perform dynamic Backend Factory registration. Register the backend factory
+/// under the provided \p Name and use \p CreateFn expression to create new
+/// instances of the backends.
+#define REGISTER_DYNAMIC_GLOW_BACKEND_FACTORY(FactoryName, BackendClass, Name, \
+                                              CreateFn)                        \
+  class FactoryName : public BaseFactory<std::string, Backend> {               \
+  public:                                                                      \
+    FactoryName() : registrationKey_(Name) {}                                  \
+    Backend *create() override { return CreateFn; }                            \
+    std::string getRegistrationKey() const override {                          \
+      return registrationKey_;                                                 \
+    }                                                                          \
+    unsigned numDevices() const override {                                     \
+      return BackendClass::numDevices();                                       \
+    }                                                                          \
+                                                                               \
+  private:                                                                     \
+    std::string registrationKey_;                                              \
+  };                                                                           \
+  RegisterFactory<std::string, FactoryName, Backend> FactoryName##_REGISTERED;
+
 /// \returns the set of names for all available, registered backends.
 std::vector<std::string> getAvailableBackends();
 

--- a/include/glow/Backend/Backend.h
+++ b/include/glow/Backend/Backend.h
@@ -53,8 +53,9 @@ struct DAG;
 } // namespace runtime
 
 // This is the interface that glow backends need to implement.
-class Backend {
+class Backend : public Named {
 public:
+  Backend() : Named("") {}
   /// Dtor.
   virtual ~Backend() = default;
 

--- a/include/glow/Backends/Interpreter/Interpreter.h
+++ b/include/glow/Backends/Interpreter/Interpreter.h
@@ -35,7 +35,9 @@ public:
   ///@{
   ~Interpreter() override = default;
 
-  std::string getBackendName() const override { return getName(); }
+  std::string getBackendName() const override {
+    return Named::getName().empty() ? getName() : Named::getName().str();
+  }
   static std::string getName() { return "Interpreter"; }
   static unsigned numDevices() { return std::thread::hardware_concurrency(); }
 

--- a/lib/Backends/CPU/CPUBackend.h
+++ b/lib/Backends/CPU/CPUBackend.h
@@ -38,7 +38,9 @@ public:
   ///@{
   virtual ~CPUBackend() override = default;
 
-  std::string getBackendName() const override { return getName(); }
+  std::string getBackendName() const override {
+    return Named::getName().empty() ? getName() : Named::getName().str();
+  }
   static std::string getName() { return "CPU"; }
   static unsigned numDevices();
 

--- a/lib/Backends/OpenCL/OpenCL.h
+++ b/lib/Backends/OpenCL/OpenCL.h
@@ -219,7 +219,9 @@ public:
   ///@{
   ~OCLBackend() override = default;
 
-  std::string getBackendName() const override { return getName(); }
+  std::string getBackendName() const override {
+    return Named::getName().empty() ? getName() : Named::getName().str();
+  }
   static std::string getName() { return "OpenCL"; }
   static unsigned numDevices() { return 1; }
 


### PR DESCRIPTION
- Add a more dynamic way to register new backends and backend factories

   The name of the backend being registered is not hard-coded and can be provided as a parameter. The expression to generate new instances of the backend can also be dynamic.

- Unregister backend factories once they are being destructed

  This is useful e.g. for testing. You can define new backends inside your test and they will be automatically unregistered once the test (or the scope where they are declared) are finished.

- Allow instances of backends to have names 

   This is useful if you want to register multiple instances of the same backend as different backend factories with different names. getBackendName would still report the usual backend name as before unless you explicitly call setName for a backend instance.

- Add a test for dynamic backend factories registration