### PR TITLE
[Clang Formatting] Fixing Clang format.

### DIFF
--- a/include/glow/Backends/DeviceManager.h
+++ b/include/glow/Backends/DeviceManager.h
@@ -119,9 +119,9 @@ public:
   /// Remove (and delete) the provided function, freeing
   /// up space on the device. \p evictCB will be called when the operation
   /// is completed or attempted and failed.
-  virtual void evictNetwork(std::string functionName,
-                            EvictFunctionCBTy evictCB = [](std::string, Error) {
-                            }) = 0;
+  virtual void evictNetwork(
+      std::string functionName,
+      EvictFunctionCBTy evictCB = [](std::string, Error) {}) = 0;
 
   /// Execute the named Function in an already provided network on the device.
   /// functionName must match the name of a function already added.

--- a/lib/Backends/OpenCL/OpenCLTensorLayout.cpp
+++ b/lib/Backends/OpenCL/OpenCLTensorLayout.cpp
@@ -90,7 +90,9 @@ getLayoutForTempEnumRep(size_t n, const Node *node) {
     switch (n) {
     case ConvolutionNode::InputIndices::BiasIdx:
       return &CanonicalTensorLayout::getInstance().getLayoutsForDims()[1];
-    default: { return getLayoutFromEnum(CN); }
+    default: {
+      return getLayoutFromEnum(CN);
+    }
     }
   }
   return nullptr;

--- a/lib/Graph/TensorLayout.cpp
+++ b/lib/Graph/TensorLayout.cpp
@@ -656,7 +656,9 @@ static bool acceptsAnyInputLayout(const glow::Node *node) {
   case Kinded::Kind::SGDNodeKind: {
     return true;
   }
-  default: { return false; }
+  default: {
+    return false;
+  }
   }
 }
 

--- a/lib/LLVMIRCodeGen/GlowJIT.cpp
+++ b/lib/LLVMIRCodeGen/GlowJIT.cpp
@@ -169,19 +169,21 @@ GlowJIT::GlowJIT(llvm::TargetMachine &TM)
           },
           [](Error Err) { cantFail(std::move(Err), "lookupFlags failed"); })),
 #if LLVM_VERSION_MAJOR == 7 || FACEBOOK_INTERNAL
-      objectLayer_(ES_,
-                   [this](llvm::orc::VModuleKey) {
-                     return RTDyldObjectLinkingLayer::Resources{
-                         std::make_shared<SectionMemoryManager>(), resolver_};
-                   },
-                   NotifyLoadedFunctor(this)),
+      objectLayer_(
+          ES_,
+          [this](llvm::orc::VModuleKey) {
+            return RTDyldObjectLinkingLayer::Resources{
+                std::make_shared<SectionMemoryManager>(), resolver_};
+          },
+          NotifyLoadedFunctor(this)),
 #else
-      objectLayer_(ES_,
-                   [this](llvm::orc::VModuleKey) {
-                     return LegacyRTDyldObjectLinkingLayer::Resources{
-                         std::make_shared<SectionMemoryManager>(), resolver_};
-                   },
-                   NotifyLoadedFunctor(this)),
+      objectLayer_(
+          ES_,
+          [this](llvm::orc::VModuleKey) {
+            return LegacyRTDyldObjectLinkingLayer::Resources{
+                std::make_shared<SectionMemoryManager>(), resolver_};
+          },
+          NotifyLoadedFunctor(this)),
 #endif
 #endif
       compileLayer_(objectLayer_, SimpleCompiler(TM_)) {

--- a/tests/unittests/DeviceManagerTest.cpp
+++ b/tests/unittests/DeviceManagerTest.cpp
@@ -869,9 +869,9 @@ public:
   void addNetwork(const Module *module, FunctionMapTy functions,
                   ReadyCBTy readyCB) override {}
 
-  void evictNetwork(std::string functionName,
-                    EvictFunctionCBTy evictCB = [](std::string, Error) {
-                    }) override {}
+  void evictNetwork(
+      std::string functionName,
+      EvictFunctionCBTy evictCB = [](std::string, Error) {}) override {}
 
   runtime::RunIdentifierTy
   runFunction(std::string functionName,
@@ -886,9 +886,9 @@ public:
 
   bool isMemoryAvailable(uint64_t estimate) const override { return 0; }
 
-  void transferToDevice(Tensor &tensor, void *locationContext = nullptr,
-                        std::function<void(Error)> resultCB = [](Error) {
-                        }) override {
+  void transferToDevice(
+      Tensor &tensor, void *locationContext = nullptr,
+      std::function<void(Error)> resultCB = [](Error) {}) override {
     if (locationContext == nullptr) {
       locationContext = malloc(tensor.getSizeInBytes());
     }
@@ -896,9 +896,9 @@ public:
     tensor.moveToDevice(this, locationContext);
   }
 
-  void transferFromDevice(Tensor &tensor, bool release = true,
-                          std::function<void(Error)> resultCB = [](Error) {
-                          }) override {
+  void transferFromDevice(
+      Tensor &tensor, bool release = true,
+      std::function<void(Error)> resultCB = [](Error) {}) override {
     memcpy(tensor.getUnsafePtr(), tensor.getLocationContext(),
            tensor.getSizeInBytes());
     free(tensor.getLocationContext());


### PR DESCRIPTION
Clang-format-8 corrects clang formatting of below files
                   include/glow/Backends/DeviceManager.h
                   lib/Backends/OpenCL/OpenCLTensorLayout.cpp
                   lib/Graph/TensorLayout.cpp
                   lib/LLVMIRCodeGen/GlowJIT.cpp
                   tests/unittests/DeviceManagerTest.cpp

Test Plan: Ninja test is done