### PR TITLE
Add the ability to intercept the processing of instructions by the interpreter and implement custom handling

### DIFF
--- a/include/glow/Backends/Interpreter/Interpreter.h
+++ b/include/glow/Backends/Interpreter/Interpreter.h
@@ -25,7 +25,8 @@ namespace glow {
 
 /// This is the IR-interpreter. It owns the IR, and the heap, and is able to
 /// execute the instructions one at a time.
-class Interpreter final : public BackendUsingGlowIR {
+class Interpreter final : public BackendUsingGlowIR,
+                          public IRInstructionProcessingHandler {
 public:
   /// Ctor.
   Interpreter() = default;

--- a/include/glow/Backends/Interpreter/InterpreterFunction.h
+++ b/include/glow/Backends/Interpreter/InterpreterFunction.h
@@ -42,7 +42,8 @@ class Constant;
 #include "glow/AutoGenInstr.def"
 
 /// Function "compiled" for execution by the interpreter.
-class InterpreterFunction final : public CompiledFunction {
+class InterpreterFunction final : public CompiledFunction,
+                                  public IRInstructionProcessingHandler {
   /// The IR to be executed.
   std::unique_ptr<IRFunction> F_;
 
@@ -80,7 +81,7 @@ public:
 };
 
 /// An InterpreterFunction bound to a specific invocation.
-class BoundInterpreterFunction {
+class BoundInterpreterFunction : public IRInstructionProcessingHandler {
   /// Maps values to Tensors, that are owned by this class.
   std::unordered_map<const Value *, Tensor *> tensors_;
 

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -64,8 +64,11 @@ Interpreter::compileIRWithoutConstants(std::unique_ptr<IRFunction> IR) const {
   runtime::RuntimeBundle bundle = runtime::RuntimeBundle::create(
       *IR, constantWeightsAllocator, placeholderWeightsAllocator,
       activationsAllocator);
-  return glow::make_unique<InterpreterFunction>(std::move(IR),
-                                                std::move(bundle));
+  auto compiledFunction =
+      glow::make_unique<InterpreterFunction>(std::move(IR), std::move(bundle));
+  compiledFunction->setIRInstructionProcessingHandler(
+      getIRInstructionProcessingHandler());
+  return compiledFunction;
 }
 
 bool Interpreter::isOpSupported(const NodeInfo &NI) const {


### PR DESCRIPTION
This functionality is useful for testing and debugging, e.g. in the following cases:
- Changing the handling of specific instructions by the interpreter
- Performing certain actions before/after/instead of a usual instruction processing by the interpreter
- Extend the interpreter to support custom instructions without the need to change the interpreter source code