### PR TITLE
[torch_glow] Add ability to pass backend specific options

### DIFF
--- a/include/glow/Backends/Interpreter/Interpreter.h
+++ b/include/glow/Backends/Interpreter/Interpreter.h
@@ -58,6 +58,8 @@ public:
 
   bool shouldLower(const Node *N) const override;
 
+  void parseBackendSpecificOptions(const BackendOptions &opts) const;
+
   /// @}
   //
   /// \returns the size of metrics collected for a single TraceEvent.

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -25,12 +25,21 @@
 #include "glow/IR/Instrs.h"
 #include "glow/Optimizer/IROptimizer/IROptimizer.h"
 
+namespace glow {
+namespace runtime {
+extern unsigned GlowInterpreterMemory;
+}
+} // namespace glow
 using namespace glow;
 
 Expected<std::unique_ptr<CompiledFunction>>
 Interpreter::compile(Function *F, const BackendOptions &opts) const {
   TraceInfo traceInfo = buildManualTraceInfo(F);
   auto IR = generateAndOptimizeIR(F, *this, shouldShareBuffers());
+
+  if (!opts.backendSpecificOpts.empty()) {
+    parseBackendSpecificOptions(opts);
+  }
 
   if (opts.autoInstrument) {
     autoInstrument(traceInfo, IR.get());
@@ -690,5 +699,17 @@ bool Interpreter::shouldLower(const Node *N) const {
     return false;
   default:
     return true;
+  }
+}
+
+void Interpreter::parseBackendSpecificOptions(
+    const BackendOptions &opts) const {
+  auto interpreterMaxMemOpt =
+      opts.backendSpecificOpts.find("interpreter-memory");
+  if (interpreterMaxMemOpt != opts.backendSpecificOpts.end()) {
+    glow::runtime::GlowInterpreterMemory =
+        std::stoi(interpreterMaxMemOpt->second);
+    llvm::outs() << "Interpreter memory set to "
+                 << glow::runtime::GlowInterpreterMemory << "\n";
   }
 }

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -151,14 +151,31 @@ Error HostManager::addNetwork(std::unique_ptr<Module> module,
       names.push_back(name);
     }
   }
-  // Load backend-specific options if specified.
+
+  // Issue a warning when loading backend specific options from the command line
+  // and the compile context also contains backend specific options.
+
   if (!loadBackendSpecificOptionsOpt.empty()) {
     if (cctx.backendOpts.backendSpecificOpts.size() != 0) {
       VLOG_EVERY_N(1, 1000) << "Warning: backendSpecificOpts is set via the "
                                "HostManager, ignoring previously set options.";
     }
+  }
+
+  // Load backend specific options when requested by command line or context.
+
+  if (!loadBackendSpecificOptionsOpt.empty()) {
     cctx.backendOpts.backendSpecificOpts =
         deserializeStrStrMapFromYaml(loadBackendSpecificOptionsOpt);
+  } else {
+    auto ctxLoadBackendSpecificOpt =
+        cctx.backendOpts.backendSpecificOpts.find("loadBackendSpecificOptions");
+
+    if (ctxLoadBackendSpecificOpt !=
+        cctx.backendOpts.backendSpecificOpts.end()) {
+      cctx.backendOpts.backendSpecificOpts =
+          deserializeStrStrMapFromYaml(ctxLoadBackendSpecificOpt->second);
+    }
   }
 
   std::vector<DeviceInfo> deviceInfo;

--- a/torch_glow/src/CachingGraphRunner.cpp
+++ b/torch_glow/src/CachingGraphRunner.cpp
@@ -127,6 +127,16 @@ CachingGraphRunner::loadImpl(torch::jit::Stack &stack,
   }
 
   TRACE_EVENT_BEGIN(traceContext, TraceLevel::RUNTIME, "addNetwork");
+  // If --load-backend-specific-opts was passed from python, add it to the
+  // compile context so the host manager knows to load backend options from
+  // yaml.
+
+  if (!settings_.backendOptionsFile.empty()) {
+    std::pair<std::string, std::string> loadBackendSpecificOpts(
+        "loadBackendSpecificOptions", settings_.backendOptionsFile);
+    cctx.backendOpts.backendSpecificOpts.insert(loadBackendSpecificOpts);
+  }
+
   RETURN_IF_ERR(hostManager_->addNetwork(std::move(module), cctx));
   TRACE_EVENT_END(traceContext, TraceLevel::RUNTIME, "addNetwork");
 

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -80,6 +80,9 @@ struct PyTorchLoaderSettings {
 
   /// Number of traces per json trace file dump.
   size_t numTracesPerDump = 1;
+
+  /// Name of a YAML file containing backend specific options.
+  std::string backendOptionsFile;
 };
 
 /// Given a PyTorch ScalarType \p ty, \returns a matching Glow ElemKind.

--- a/torch_glow/src/binding.cpp
+++ b/torch_glow/src/binding.cpp
@@ -144,6 +144,11 @@ PYBIND11_MODULE(_torch_glow, m) {
   /// HostManager.
   m.def("getGlowBackendNumDevices", []() { return getBackendNumDevices(); });
 
+  /// Inform host manager to load backend specific options from YAML file.
+  m.def("loadBackendSpecificOptions", [](const std::string &yamlFile) {
+    getPyTorchLoaderSettings().backendOptionsFile = yamlFile;
+  });
+
   /// Calls all of the fusion passes that get run before the PyTorchModelLoader
   /// run.
   /// NOTE: This is only exposed for testing.

--- a/torch_glow/tests/functionality/load_backend_specific_options_test.py
+++ b/torch_glow/tests/functionality/load_backend_specific_options_test.py
@@ -1,0 +1,29 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import torch
+import torch_glow
+
+import tempfile
+import unittest
+
+
+class TestLoadBackendSpecificOptions(unittest.TestCase):
+
+    def test_backend_specific_options(self):
+        """Test loading backend specific options from YAML file."""
+        def test_f(a, b):
+            return a.add(b)
+
+        x = torch.randn(4)
+        y = torch.randn(4)
+
+        # Create YAML file with backend options
+        with tempfile.NamedTemporaryFile() as options_fd:
+            options_fd.write(b'interpreter-memory: 4194304\n')
+            options_fd.flush()
+
+            # Run Glow
+            torch_glow.loadBackendSpecificOptions(options_fd.name)
+            torch_glow.enableFusionPass()
+            glow_trace = torch.jit.trace(test_f, (x, y), check_trace=False)
+            glow_trace(x, y)


### PR DESCRIPTION
Add ability to pass backend specific options to backends from torch_glow

Summary:

Host manager already provides the --load-backend-specific-options command
line option which loads a YAML file containing backend options. When using
torch_glow, it is currently not possible ot pass this option.

This change adds torch_glow.loadBackendSpecificOptions() which takes the name
of a YAML file. CachingGraphRunner will pass the name of the YAML file to the
host manager via cctx.backendOpts.backendSpecificOpts and host manager will
load the options into the context which is already passed to backends.

Fixes:  #4140
