### PR TITLE
Only build network-debugger if GLOW_BUILD_TESTS is ON

### DIFF
--- a/tools/Debugger/CMakeLists.txt
+++ b/tools/Debugger/CMakeLists.txt
@@ -1,3 +1,4 @@
+if (GLOW_BUILD_TESTS)
 add_executable(network-debugger
                network-debugger.cpp
                NetworkComparator.cpp)
@@ -5,8 +6,7 @@ add_executable(network-debugger
 target_link_libraries(network-debugger
                       PRIVATE
                         BackendTestUtils
-                        HostManager
                         Importer
                         HostManager
-                        ExecutionEngine
-                        Exporter)
+                        ExecutionEngine)
+endif()


### PR DESCRIPTION
  Remove unneeded dependencies network-debugger had.
  No longer needs Exporter to build.

Summary:

Documentation:
  None needed.

This fixes #4135

Test Plan:
  Built with  -DGLOW_BUILD_TESTS=OFF

