### PR TITLE
NNPI: get rid of string lookups in InferenceThreadEnv::execute

### DIFF
--- a/lib/Backends/NNPI/InferencePool.h
+++ b/lib/Backends/NNPI/InferencePool.h
@@ -52,8 +52,15 @@ private:
   std::vector<std::pair<std::string, NNPITensorDesc>> netInputs_;
   std::vector<std::pair<std::string, NNPITensorDesc>> netOutputs_;
 
-  /// Map from Placeholders to their backing Tensor inputs.
-  std::unordered_map<std::string, Tensor *> ioTensors_;
+  /// Vector of placeholders. The order of the placeholders match with the
+  /// netInputs_ and netOutputs_.
+  std::vector<Placeholder *> netInputPlaceholders_;
+  std::vector<Placeholder *> netOutputPlaceholders_;
+
+  /// Vector of placeholders. The order of the placeholders match with the
+  /// hostInputs_ and hostOutputs_.
+  std::vector<Placeholder *> hostInputPlaceholders_;
+  std::vector<Placeholder *> hostOutputPlaceholders_;
 
   /// Set of inputs that can be partial tensors.
   const std::unordered_set<const Placeholder *> *partialInputs_;


### PR DESCRIPTION
Summary: From profiling, building up a hash map of tensor name to tensor pointer on every inference and doing all the lookups are slowing down the inference. Replace the unordered_map with vectors of placeholder pointers that match the order of host/net input/output lists. From testing some workloads, it improves throughput by up to 5% by allowing better overlap of copy and inference on the card.

Differential Revision: D19829996

