### PR TITLE
[torch_glow] Add support for negative dimensions in PyTorchLoader

### DIFF
--- a/torch_glow/tests/nodes/cat_test.py
+++ b/torch_glow/tests/nodes/cat_test.py
@@ -19,3 +19,30 @@ class TestCat(unittest.TestCase):
         y = torch.randn(2, 3, 4)
 
         jitVsGlow(test_f, x, y, expected_fused_ops={"prim::FusedConcat"})
+
+    def test_cat_neg_dim(self):
+        """Test negative dimension index for the PyTorch cat Node on Glow."""
+
+        def test_f(a, b):
+            c = torch.cat((a, b), -3)
+            d = torch.cat((c, c), -2)
+            return torch.cat((d, d), -1)
+
+        x = torch.randn(2, 3, 4)
+        y = torch.randn(2, 3, 4)
+
+        jitVsGlow(test_f, x, y, expected_fused_ops={"prim::FusedConcat"})
+
+    def test_cat_oob_neg_dim(self):
+        """Test out of bounds negative dimension index for the PyTorch cat Node on Glow."""
+
+        def test_f(a, b):
+            c = torch.cat((a, b), -4)
+            d = torch.cat((c, c), -2)
+            return torch.cat((d, d), -1)
+
+        x = torch.randn(2, 3, 4)
+        y = torch.randn(2, 3, 4)
+
+        with self.assertRaises(IndexError):
+            jitVsGlow(test_f, x, y, expected_fused_ops={"prim::FusedConcat"})

--- a/torch_glow/tests/nodes/size_test.py
+++ b/torch_glow/tests/nodes/size_test.py
@@ -19,3 +19,25 @@ class TestSize(unittest.TestCase):
         x = torch.zeros([4], dtype=torch.int32)
 
         jitVsGlow(test_f, x, expected_fused_ops={"aten::size"})
+
+    @unittest.skip(reason="not ready")
+    def test_size_neg_dim(self):
+        """Test negative dimension index for the PyTorch aten::size Node on Glow."""
+
+        def test_f(a):
+            return a.size(-1)
+
+        x = torch.randn(2, 3, 4, dtype=torch.float32)
+
+        jitVsGlow(test_f, x, expected_fused_ops={"aten::size"})
+
+    def test_size_oob_neg_dim(self):
+        """Test out of bounds negative dimension index for the PyTorch aten::size Node on Glow."""
+
+        def test_f(a):
+            return a.size(-4)
+
+        x = torch.randn(2, 3, 4, dtype=torch.float32)
+
+        with self.assertRaises(IndexError):
+            jitVsGlow(test_f, x, expected_fused_ops={"aten::size"})

--- a/torch_glow/tests/nodes/softmax_test.py
+++ b/torch_glow/tests/nodes/softmax_test.py
@@ -15,3 +15,23 @@ class TestSoftmax(unittest.TestCase):
 
         inputs = torch.randn(2, 3)
         jitVsGlow(softmax_basic, inputs, expected_fused_ops={"aten::softmax"})
+
+    def test_softmax_neg_dim(self):
+        """Test negative dimension index for the PyTorch SoftMax Node on Glow."""
+        def softmax_neg_dim(inputs):
+            # Note: dims in the range [-size, -2] cause an assert from flattenCdr() as currently implemented
+            return F.softmax(inputs, dim=-1)
+
+        inputs = torch.randn(2, 3)
+        jitVsGlow(softmax_neg_dim, inputs,
+                  expected_fused_ops={"aten::softmax"})
+
+    def test_softmax_oob_neg_dim(self):
+        """Test out of bounds negative dimension index for the PyTorch SoftMax Node on Glow."""
+        def test_f(inputs):
+            with self.assertRaises(IndexError):
+                return F.softmax(inputs, dim=-3)
+
+        inputs = torch.randn(2, 3)
+        with self.assertRaises(RuntimeError):
+            jitVsGlow(test_f, inputs, expected_fused_ops={"aten::softmax"})


### PR DESCRIPTION
Add support for negative dimension indices.
    
Summary:
    
Add support for negative dimension indices for loadSize(), loadFusedConcat(), loadSoftmax() and loadTranspose(). When a dimension is negative, PyTorchModelLoader will convert the index to a positive index and check that it is in the valid range.
    
These changes enable running the huggingface/transformers Bert, Albert and Distilbert models.

Fixes:  #4150

TestPlan:

Added negative dimension tests to cat_test.py, transpose_test.py, size_test.py and softmax_test.py

