### PR TITLE
Expose glow_log_parition as a gflag

### DIFF
--- a/lib/Partitioner/Partitioner.cpp
+++ b/lib/Partitioner/Partitioner.cpp
@@ -27,6 +27,7 @@
 #include <fstream>
 namespace glow {
 bool GlowEnableLoadBalancedPartitioning = false;
+bool GlowLogPartition = false;
 static llvm::cl::opt<bool, /* ExternalStorage */ true>
     GlowEnableLoadBalancedPartitioningOpt(
         "glow_partitioner_enable_load_balance",
@@ -38,10 +39,9 @@ static llvm::cl::opt<bool, /* ExternalStorage */ true>
 
 /// -log-partition - Command line option to dump Partitioner logs.
 static llvm::cl::OptionCategory PartitionerCat("Glow Partitioner Options");
-static llvm::cl::opt<bool>
-    logPartition("log-partition",
-                 llvm::cl::desc("Enable logging partition info"),
-                 llvm::cl::init(false), llvm::cl::cat(PartitionerCat));
+static llvm::cl::opt<bool, /* ExternalStorage */ true> logPartition(
+    "log-partition", llvm::cl::desc("Enable logging partition info"),
+    llvm::cl::location(glow::GlowLogPartition), llvm::cl::cat(PartitionerCat));
 
 /// -dump-partition - Command line option to dump the graph of each partitions
 /// by calling F->dumpDAG().


### PR DESCRIPTION
Summary: This is useful for some basic sanity check when we have multiple partitions for one network.

Differential Revision: D19868436

