### PR TITLE
glow: name threads

### DIFF
--- a/include/glow/Runtime/Executor/ThreadPoolExecutor.h
+++ b/include/glow/Runtime/Executor/ThreadPoolExecutor.h
@@ -61,7 +61,8 @@ class ThreadPoolExecutor final : public Executor {
 public:
   /// Constructor.
   explicit ThreadPoolExecutor(const DeviceManagerMapTy &deviceManagers,
-                              unsigned numWorkers = kNumWorkers);
+                              unsigned numWorkers = kNumWorkers,
+                              const std::string &name = "");
 
   /// Setup context pool for new network.
   void createPool(const DAGNode *root, unsigned poolSize) override;

--- a/include/glow/Support/ThreadPool.h
+++ b/include/glow/Support/ThreadPool.h
@@ -64,7 +64,7 @@ shared_function<std::decay_t<F>> make_shared_function(F &&f) {
 class ThreadExecutor final {
 public:
   /// Constructor. Initializes one thread backed by the workQueue_.
-  ThreadExecutor();
+  explicit ThreadExecutor(const std::string &name = "");
 
   /// Destructor. Signals the thread to stop and waits for exit.
   ~ThreadExecutor();
@@ -120,7 +120,7 @@ class ThreadPool final {
 public:
   /// Constructor. Initializes a thread pool with \p numWorkers
   /// threads and has them all run ThreadPool::threadPoolWorkerMain.
-  ThreadPool(unsigned numWorkers = kNumWorkers);
+  ThreadPool(unsigned numWorkers = kNumWorkers, const std::string &name = "");
 
   /// Destructor. Signals to all threads to stop and waits for all of them
   /// to exit.

--- a/lib/Backends/NNPI/InferencePool.cpp
+++ b/lib/Backends/NNPI/InferencePool.cpp
@@ -56,7 +56,7 @@ Error InferencePoolEnv::init(unsigned numWorkers, NNPIAdapter adapter,
     return MAKE_ERR("InferencePool already initialized!");
   }
   numWorkers_ = numWorkers;
-  workersPool_ = glow::make_unique<ThreadPool>(numWorkers_);
+  workersPool_ = glow::make_unique<ThreadPool>(numWorkers_, "NNPI-worker");
   deviceTracing_ = deviceTracing;
 
   inferenceContexts_.resize(numWorkers_);

--- a/lib/Runtime/Executor/ThreadPoolExecutor.cpp
+++ b/lib/Runtime/Executor/ThreadPoolExecutor.cpp
@@ -60,8 +60,9 @@ void InflightBarrier::wait() {
 }
 
 ThreadPoolExecutor::ThreadPoolExecutor(const DeviceManagerMapTy &deviceManagers,
-                                       unsigned numWorkers)
-    : threadPool_(numWorkers), deviceManagers_(deviceManagers) {}
+                                       unsigned numWorkers,
+                                       const std::string &name)
+    : threadPool_(numWorkers, name), deviceManagers_(deviceManagers) {}
 
 void ThreadPoolExecutor::shutdown() {
   // Prevent more requests from being processed.

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -101,7 +101,8 @@ Error HostManager::init(std::vector<std::unique_ptr<DeviceConfig>> configs) {
     deviceCount++;
   }
   provisioner_.reset(new Provisioner(devices_));
-  executor_.reset(new ThreadPoolExecutor(devices_, config_.executorThreads));
+  executor_.reset(
+      new ThreadPoolExecutor(devices_, config_.executorThreads, "HostManager"));
   exportMemoryCounters();
   return Error::success();
 }

--- a/lib/Support/CMakeLists.txt
+++ b/lib/Support/CMakeLists.txt
@@ -9,6 +9,8 @@ target_link_libraries(Support
                       PUBLIC
                         LLVMSupport
                         Miniz
-                        glog::glog)
+                        glog::glog
+                        folly_jemalloc
+                        )
 
 add_subdirectory(TensorPool)


### PR DESCRIPTION
Summary: Name all the threads glow's thread pool starts. This makes debugging or looking at perf profiles much easier.

Reviewed By: jfix71

Differential Revision: D19867718

