### PR TITLE
Adding cacheable networkExecutionState to Executor

### DIFF
--- a/include/glow/ExecutionContext/ExecutionContext.h
+++ b/include/glow/ExecutionContext/ExecutionContext.h
@@ -22,6 +22,9 @@
 #include "llvm/ADT/STLExtras.h"
 
 namespace glow {
+namespace runtime {
+class DeviceManager;
+}
 
 /// Sub-classed per backend, this holds Device specific per-function information
 /// if that is necessary on that particular backend.

--- a/include/glow/Runtime/Executor/Executor.h
+++ b/include/glow/Runtime/Executor/Executor.h
@@ -46,6 +46,12 @@ public:
   /// Shutdown the Executor. Should block until all active requests are complete
   /// and prevent new requests from being initiated.
   virtual void shutdown() = 0;
+
+  /// Setup context pool for new network.
+  virtual void createPool(const DAGNode *root, unsigned poolSize) = 0;
+
+  /// Free the context pool for given network.
+  virtual void freePool(const DAGNode *root) = 0;
 };
 
 } // namespace runtime

--- a/include/glow/Runtime/Executor/NetworkExecutionState.h
+++ b/include/glow/Runtime/Executor/NetworkExecutionState.h
@@ -1,0 +1,158 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_RUNTIME_EXECUTOR_NETWORKEXECUTIONSTATE_H
+#define GLOW_RUNTIME_EXECUTOR_NETWORKEXECUTIONSTATE_H
+
+#include "glow/Runtime/RuntimeTypes.h"
+#include "glow/Support/TensorPool.h"
+#include "glow/Support/ThreadPool.h"
+
+#include <mutex>
+
+namespace glow {
+namespace runtime {
+
+/// This class keeps track of the state of execution for a run (identified
+/// by the runId).
+class NetworkExecutionState final {
+public:
+  /// Constructor.
+  explicit NetworkExecutionState(const DAGNode *root);
+
+  /// Destructor.
+  ~NetworkExecutionState();
+
+  /// Does the BFS traversal and initializes the NetworkExecutionState.
+  void init(const DeviceManagerMapTy &devices);
+
+  /// Binds the state to a new run. This moves the result ctx and cb to be owned
+  /// by the networkExecutionState for the duration of the run.
+  void bind(std::unique_ptr<ExecutionContext> resultCtx, ResultCBTy cb,
+            RunIdentifierTy runId);
+
+  /// \returns a unique pointer to an input bindings for \p node. This should
+  /// not be called at the same time as insertIntoNodeCtx().
+  std::unique_ptr<ExecutionContext>
+  getUniqueNodeContextPtr(const DAGNode *node);
+
+  /// Returns the intermediateContext back to the networkExecutionState after
+  /// completion so it can be re-used.
+  void returnUniqueNodeContextPtr(const DAGNode *node,
+                                  std::unique_ptr<ExecutionContext> ctx);
+
+  /// Increment the count of inflight nodes by \p increment (default is 1).
+  void incrementInflightNodes(unsigned increment = 1);
+
+  /// Decrement the count of inflight nodes by the \p decrement (default is 1).
+  /// \returns true if there are no nodes inflight after the decrement
+  /// operation.
+  bool decrementInflightNodes(unsigned decrement = 1);
+
+  /// Increment the count of completed parent nodes for \p node. \returns
+  /// true if all parents are done after the increment operation, false
+  /// otherwise.
+  bool incrementNodeParentsDone(const DAGNode *node, unsigned increment = 1);
+
+  /// Move all events from the provided vector into the top level resultContxt.
+  void insertIntoTraceContext(TraceContext *runCtx);
+
+  /// \returns a unique pointer to the result bindings. This should not be
+  /// called at the same time as getRawResultPlaceholderBindingsPtr() or
+  /// insertIntoResultCtx().
+  std::unique_ptr<ExecutionContext> getUniqueResultContextPtr();
+
+  /// \returns a raw pointer to the result bindings. This should be not called
+  /// at the same time as getUniqueResultPlaceholderBindingsPtr().
+  ExecutionContext *getRawResultContextPtr() const;
+
+  /// \returns the callback for this execution.
+  ResultCBTy getCallback() { return cb_; }
+
+  /// \returns the OneErrOnly Error container for the execution.
+  OneErrOnly &getErrorContainer() { return errContainer_; }
+
+  /// \returns the run ID for the execution.
+  RunIdentifierTy getRunId() const { return runId_; }
+
+  /// Whether or not this node has been initialized.
+  bool initialized_{false};
+
+private:
+  /// The run identifier for this execution of a DAG.
+  RunIdentifierTy runId_;
+
+  /// The callback that should be called when execution is done.
+  ResultCBTy cb_;
+
+  /// The ExecutionContext object containing the results of the execution
+  /// (i.e. the outputs of the DAGNodes that have no children).
+  std::unique_ptr<ExecutionContext> resultCtx_;
+
+  /// Counters for how many of each nodes parents are done. These are needed
+  /// in order to determine when a node is ready to be executed.
+  std::unordered_map<const DAGNode *, std::atomic<unsigned>> nodeParentsDone_;
+
+  /// Count of current inflight nodes.
+  std::atomic<unsigned> inflightNodes_;
+
+  /// Value that is used to track if an Error was received.
+  OneErrOnly errContainer_;
+
+  /// Module for the network. This contains the PHs used by the functions in
+  /// this network.
+  Module *module_{nullptr};
+
+  /// Root node of the DAG for this run.
+  const DAGNode *root_;
+
+  /// Map of all buffers allocated for intermediate contexts.
+  std::unordered_map<Placeholder *, void *> buffers_;
+
+  /// Map from buffer to device that allocated it, used at destruction to
+  /// free buffers.
+  std::unordered_map<void *, DeviceManager *> deviceAllocations_;
+
+  /// Map of intermediate placeholder bindings that need to be pointed at
+  /// resultCtx tensors.
+  std::unordered_map<Placeholder *, std::vector<PlaceholderBindings *>>
+      externalIntermediates_;
+  /// Input contexts for all of the nodes. These are gradually
+  /// populated as a node's parents finish.
+  std::unordered_map<const DAGNode *, std::unique_ptr<ExecutionContext>>
+      intermediateContexts_;
+};
+
+class NetworkExecutionStatePool {
+public:
+  NetworkExecutionState *getNextNetworkExecutionState() {
+    // Note: this assumes pool size is maxActiveRequests, otherwise it's
+    // possible to wrap around on a state currently in use.
+    unsigned current = currentState_.fetch_add(1);
+    return states_[current % states_.size()].get();
+  }
+  void addNewState(std::unique_ptr<NetworkExecutionState> state) {
+    states_.push_back(std::move(state));
+  }
+
+private:
+  std::vector<std::unique_ptr<NetworkExecutionState>> states_;
+  std::atomic<unsigned> currentState_;
+};
+
+} // namespace runtime
+} // namespace glow
+
+#endif // GLOW_RUNTIME_EXECUTOR_NetworkEXECUTIONSTATE_H

--- a/lib/Runtime/Executor/CMakeLists.txt
+++ b/lib/Runtime/Executor/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(Executor
-              ExecutionState.cpp
+              NetworkExecutionState.cpp
               ThreadPoolExecutor.cpp)
 
 target_link_libraries(Executor

--- a/lib/Runtime/Executor/NetworkExecutionState.cpp
+++ b/lib/Runtime/Executor/NetworkExecutionState.cpp
@@ -1,0 +1,228 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "glow/Runtime/Executor/NetworkExecutionState.h"
+#include "glow/Backends/DeviceManager.h"
+
+using namespace glow;
+using namespace glow::runtime;
+
+NetworkExecutionState::NetworkExecutionState(const DAGNode *root)
+    : inflightNodes_(0), module_(root->module), root_(root) {}
+
+NetworkExecutionState::~NetworkExecutionState() {
+  // Free all allocated buffers.
+  for (auto &allocation : deviceAllocations_) {
+    allocation.second->freeAllocatedDeviceIOBuffer(allocation.first);
+  }
+}
+
+void NetworkExecutionState::bind(std::unique_ptr<ExecutionContext> resultCtx,
+                                 ResultCBTy cb, RunIdentifierTy runId) {
+  resultCtx_ = std::move(resultCtx);
+  cb_ = std::move(cb);
+  runId_ = runId;
+  // Reset execution state, inflight nodes, parents done, etc.
+  for (auto &count : nodeParentsDone_) {
+    count.second = 0;
+  }
+  inflightNodes_ = 0;
+  // Setup tracing if desired.
+  auto resultTraceContext = resultCtx_->getTraceContext();
+  if (resultTraceContext) {
+    for (auto &context : intermediateContexts_) {
+      context.second->setTraceContext(
+          glow::make_unique<TraceContext>(resultTraceContext->getTraceLevel()));
+    }
+  } else {
+    // Clear any trace context from a previous run.
+    for (auto &context : intermediateContexts_) {
+      context.second->setTraceContext(nullptr);
+    }
+  }
+  // Move inputs into tensors backing intermediate contexts.
+  // Instead we point the tensors to the provided buffers to avoid copy in and
+  // out. Once we have pinned allocations we will need to transfer.
+  // For now point input and output tensors to buffers used in resultCtx.
+  auto resultPHBindings = resultCtx_->getPlaceholderBindings();
+  for (auto &pair : resultPHBindings->pairs()) {
+    auto PH = pair.first;
+    for (auto binding : externalIntermediates_[PH]) {
+      auto resultTensor = resultPHBindings->get(PH);
+      if (binding->get(PH)) {
+        binding->erase(PH);
+      }
+      binding->insert(PH, resultTensor->getUnowned(PH->dims()));
+    }
+  }
+}
+
+void NetworkExecutionState::init(const DeviceManagerMapTy &devices) {
+  // Create a queue for the breadth-first traversal through the graph.
+  std::queue<DAGNode *> bfsQueue;
+  // Marking the default err as checked so we don't get an unchecked error in
+  // destructor if we never use this state.
+  errContainer_.containsErr();
+
+  // Place the root nodes in the queue.
+  for (auto &node : root_->children) {
+    bfsQueue.push(node);
+    // Make a counter for the number of node parents done. This also is used for
+    // tracking if we've added the node already.
+    nodeParentsDone_[node] = 0;
+  }
+
+  // Breadth-first search.
+  while (!bfsQueue.empty()) {
+    // Get the next node in the BFS queue.
+    DAGNode *node = bfsQueue.front();
+    bfsQueue.pop();
+
+    // Push all unvisited children onto the BFS queue.
+    for (const auto &child : node->children) {
+      // Use nodeParentsDone_ as a set of nodes that have been visited already
+      // to avoid visiting a node more than once.
+      if (!nodeParentsDone_.count(child)) {
+        nodeParentsDone_[child] = 0;
+        bfsQueue.push(child);
+      }
+    }
+
+    // Make an (empty) context for the node.
+    auto intermediateContext = glow::make_unique<ExecutionContext>();
+    // Get a device to do allocation we can use the first device since the
+    // allocation is not device specific.
+    auto &device = devices.begin()->second;
+
+    auto intermediatePHBindings = intermediateContext->getPlaceholderBindings();
+
+    // Get the symbol table for the node.
+    const SymbolTableTy &symbolTable = node->runtimeBundle->getSymbolTable();
+
+    // Add inputs/outputs to the context. Skip any marked as static.
+    for (const auto &symbolPair : symbolTable) {
+      const auto &symbolName = symbolPair.first;
+      const auto &symbolInfo = symbolPair.second;
+      if (symbolInfo.symbolCategory == SymbolCategory::Placeholder) {
+        auto PH = module_->getPlaceholderByName(symbolName);
+
+        DCHECK(PH) << "Placeholder: " << symbolName << " is not in the module";
+        // If PH is marked static skip it.
+        if (PH->isStatic()) {
+          continue;
+        }
+        // If we haven't allocated a buffer for this PH yet do so, otherwise
+        // reuse the allocation.
+        auto bufferIt = buffers_.find(PH);
+        if (bufferIt == buffers_.end()) {
+
+          buffers_[PH] =
+              device->allocateDeviceIOBuffer(PH->getType()->getSizeInBytes());
+        }
+        auto buffer = buffers_[PH];
+        Tensor *backingTensor = new Tensor(buffer, PH->getType());
+        intermediatePHBindings->insert(PH, backingTensor);
+        externalIntermediates_[PH].push_back(intermediatePHBindings);
+      }
+    }
+
+    // Insert the prepared ExecutionContext into the input contexts map.
+    intermediateContexts_.emplace(node, std::move(intermediateContext));
+  }
+  initialized_ = true;
+}
+
+std::unique_ptr<ExecutionContext>
+NetworkExecutionState::getUniqueNodeContextPtr(const DAGNode *node) {
+  // The input PlaceholderBindings for the node should have been created in
+  // the constructor.
+  auto ctxIt = intermediateContexts_.find(node);
+
+  DCHECK(ctxIt != intermediateContexts_.end())
+      << "Input bindings not found but should exist!";
+
+  return std::move(ctxIt->second);
+}
+
+void NetworkExecutionState::returnUniqueNodeContextPtr(
+    const DAGNode *node, std::unique_ptr<ExecutionContext> ctx) {
+  intermediateContexts_[node] = std::move(ctx);
+}
+
+void NetworkExecutionState::incrementInflightNodes(unsigned increment) {
+  inflightNodes_ += increment;
+}
+
+bool NetworkExecutionState::decrementInflightNodes(unsigned decrement) {
+  // fetch_sub must be used here so that the function returns true to only one
+  // caller.
+  unsigned previousValue = inflightNodes_.fetch_sub(decrement);
+
+  // The decrement should never be more than the value of the counter at the
+  // time of decrement.
+  DCHECK_GE(previousValue, decrement)
+      << "More decrements than increments to inflight nodes!";
+
+  // Return true when the counter hits zero.
+  return (previousValue == decrement);
+}
+
+bool NetworkExecutionState::incrementNodeParentsDone(const DAGNode *node,
+                                                     unsigned increment) {
+  // Get the parents done counter for the node. It should have
+  // been created in the constructor.
+  auto it = nodeParentsDone_.find(node);
+
+  DCHECK(it != nodeParentsDone_.end())
+      << "Node parents done counter should exist but not found!";
+
+  // fetch_add must be used here so that the function returns true to only
+  // one caller.
+  unsigned numParents = (node->parents).size();
+  unsigned previousValue = (it->second).fetch_add(increment);
+  unsigned newValue = previousValue + increment;
+
+  // The new value of the counter cannot exceed the number of parents that
+  // the node has.
+  DCHECK_LE(newValue, numParents)
+      << "Node parents done counter incremented beyond limit!";
+
+  // Return true only when the counter hits the total numer of parents.
+  return (newValue == numParents);
+}
+
+void NetworkExecutionState::insertIntoTraceContext(TraceContext *runCtx) {
+  if (!resultCtx_->getTraceContext()) {
+    return;
+  }
+
+  resultCtx_->getTraceContext()->merge(runCtx);
+}
+
+std::unique_ptr<ExecutionContext>
+NetworkExecutionState::getUniqueResultContextPtr() {
+  // The result PlaceholderBindings should have been been created in the
+  // constructor.
+  DCHECK_NOTNULL(resultCtx_.get());
+  return std::move(resultCtx_);
+}
+
+ExecutionContext *NetworkExecutionState::getRawResultContextPtr() const {
+  // The result PlaceholderBindings should have been been created in the
+  // constructor and should not yet have been moved out if this function is
+  // being called.
+  DCHECK_NOTNULL(resultCtx_.get());
+  return resultCtx_.get();
+}

--- a/tests/unittests/ThreadPoolExecutorTest.cpp
+++ b/tests/unittests/ThreadPoolExecutorTest.cpp
@@ -221,6 +221,8 @@ public:
         outputContext_(std::move(outputContext)), runId_(runId),
         expectSuccess_(expectSuccess), testRun_(false) {
     root_->module = module_.get();
+    // Create context pool.
+    executor_->createPool(root_.get(), 1000);
   }
 
   /// Run the test.
@@ -600,7 +602,7 @@ private:
 class ThreadPoolExecutorTest : public ::testing::Test {
 protected:
   ThreadPoolExecutorTest()
-      : executor_(std::make_shared<ThreadPoolExecutor>((deviceManagerMap_))),
+      : executor_(std::make_shared<ThreadPoolExecutor>(deviceManagerMap_)),
         testBuilder_(executor_, deviceManagerMap_) {}
   ~ThreadPoolExecutorTest() = default;
 
@@ -696,7 +698,7 @@ TEST_F(ThreadPoolExecutorTest, ConcurrentSingleNode) {
   constexpr RunIdentifierTy baseTestRunId = 10;
   constexpr DeviceIDTy testDeviceId = 111;
   constexpr unsigned deviceManagerThreads = 3;
-  unsigned numConcurrentRuns = 1000;
+  unsigned numConcurrentRuns = 100;
 
   // Make a TestDeviceManager and insert into the DeviceManagerMap map (which
   // the ThreadPoolExecutor has a reference to) and the TestDeviceManager map
@@ -993,7 +995,7 @@ TEST_F(ThreadPoolExecutorTest, ConcurrentMultiNode) {
   constexpr RunIdentifierTy baseTestRunId = 10;
   constexpr DeviceIDTy testDeviceId = 111;
   constexpr unsigned deviceManagerThreads = 3;
-  unsigned numConcurrentRuns = 1000;
+  unsigned numConcurrentRuns = 100;
 
   // Make a TestDeviceManager and insert it into the DeviceManagerMap map
   // (which the ThreadPoolExecutor has a reference to) and the TestDeviceManager


### PR DESCRIPTION

Summary:
This adds a NetworkExecutionState class to the executor, it is similar to the ExecutionState object except that it is initialized once and re-used for multiple executions.
This will reduce the overhead in the Executor and allows for further optimizations such as pinned memory in contexts, and P2P support. 
Documentation:

Test Plan:
Ensure unit tests pass
