### PR TITLE
Eliminate direct references to backend-specific code in DeviceManagerTest

### DIFF
--- a/lib/Backends/Habana/tests/HabanaDeviceManagerTest.cpp
+++ b/lib/Backends/Habana/tests/HabanaDeviceManagerTest.cpp
@@ -20,4 +20,5 @@ using namespace glow;
 std::set<std::string> glow::backendTestBlacklist = {
     "DeviceResidentTensors/0",
     "TransferStaticPlaceholderTest/0",
+    "AvailableMemoryTest/0",
 };

--- a/lib/Backends/Interpreter/tests/InterpreterDeviceManagerTest.cpp
+++ b/lib/Backends/Interpreter/tests/InterpreterDeviceManagerTest.cpp
@@ -20,4 +20,5 @@ using namespace glow;
 std::set<std::string> glow::backendTestBlacklist = {
     "DeviceResidentTensors/0",
     "TransferStaticPlaceholderTest/0",
+    "AvailableMemoryTest/0",
 };

--- a/lib/Backends/NNPI/tests/NNPIDeviceManagerTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIDeviceManagerTest.cpp
@@ -25,6 +25,7 @@ struct BlacklistInitializer {
         {
             {"MultiFunction/0", TestBlacklist::AnyDeviceAnyEngine},
             {"DeviceResidentTensors/0", TestBlacklist::AnyDeviceAnyEngine},
+            {"AvailableMemory/0", TestBlacklist::AnyDeviceAnyEngine},
             {"TransferStaticPlaceholderTest/0",
              TestBlacklist::AnyDeviceSWEngine},
             {"CanHandleDeviceResidentTensors/0",

--- a/lib/Backends/OpenCL/tests/OpenCLDeviceManagerTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLDeviceManagerTest.cpp
@@ -19,4 +19,5 @@ using namespace glow;
 
 std::set<std::string> glow::backendTestBlacklist = {
     "DeviceResidentTensors/0",
+    "AvailableMemory/0",
 };


### PR DESCRIPTION
Summary:
Attempting to decouple some of our tests from backend code by relying
on registry-based constructors.

Differential Revision: D19900226

