### PR TITLE
[docs] Update README with folly dependencies for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,8 @@ following command should install the required dependencies:
   sudo apt-get install clang clang-8 cmake graphviz libpng-dev \
       libprotobuf-dev llvm-8 llvm-8-dev ninja-build protobuf-compiler wget \
       opencl-headers libgoogle-glog-dev libboost-all-dev \
-      libdouble-conversion-dev libevent-dev libssl-dev
+      libdouble-conversion-dev libevent-dev libssl-dev libgflags-dev \
+      libjemalloc-dev libpthread-stubs0-dev
   ```
 
 [Note: Ubuntu 16.04 and 18.04 ship with llvm-6 and need to be upgraded before building Glow. Building Glow on Ubuntu 16.04 with llvm-7 fails because llvm-7 xenial distribution uses an older c++ ABI, however building Glow on Ubuntu 18.04 with llvm-7 has been tested and is successful]

--- a/README.md
+++ b/README.md
@@ -144,8 +144,10 @@ following command should install the required dependencies:
   ```bash
   sudo apt-get install clang clang-8 cmake graphviz libpng-dev \
       libprotobuf-dev llvm-8 llvm-8-dev ninja-build protobuf-compiler wget \
-      opencl-headers libgoogle-glog-dev
+      opencl-headers libgoogle-glog-dev libboost-all-dev \
+      libdouble-conversion-dev libevent-dev libssl-dev
   ```
+
 [Note: Ubuntu 16.04 and 18.04 ship with llvm-6 and need to be upgraded before building Glow. Building Glow on Ubuntu 16.04 with llvm-7 fails because llvm-7 xenial distribution uses an older c++ ABI, however building Glow on Ubuntu 18.04 with llvm-7 has been tested and is successful]
 
 It may be desirable to use `update-alternatives` to manage the version of


### PR DESCRIPTION
Summary:
These dependencies were added in #4051 and are required to build the project (they were added as dependencies in the macOS section of the README and have been added to the CircleCI build script). I have checked that amending the command now allows me to build the project again.

Test Plan:
I have run the above command in a Docker Ubuntu 18.04 container and confirmed that I am now able to build the project. 
