### PR TITLE
OneErrOnly contents should initialize to empty

### DIFF
--- a/include/glow/Support/Error.h
+++ b/include/glow/Support/Error.h
@@ -795,7 +795,7 @@ void errorToVoid(const char *fileName, size_t lineNumber, GlowError error,
 /// added when the class already holds an Error, it will discard the new Error
 /// in favor of the original one. All methods in OneErrOnly are thread-safe.
 class OneErrOnly {
-  Error err_ = Error::success();
+  Error err_ = Error::empty();
   std::mutex m_;
 
 public:

--- a/tests/unittests/ErrorTest.cpp
+++ b/tests/unittests/ErrorTest.cpp
@@ -143,6 +143,9 @@ TEST(Error, EmptyErrors) {
   EXPECT_TRUE(ERR_TO_BOOL(std::move(err)));
 }
 
+// Creating an unused OneErrOnly should be safe.
+TEST(Error, UntouchedOneErrOnly) { OneErrOnly foo; }
+
 TEST(Error, ExpectedConversion) {
   auto foo = []() -> Expected<int32_t> { return 42; };
 


### PR DESCRIPTION
Summary: as title

Reviewed By: gcatron

Differential Revision: D19916465

