### PR TITLE
Add flag to cast fp32 to fp16

### DIFF
--- a/torch_glow/src/CachingGraphRunner.cpp
+++ b/torch_glow/src/CachingGraphRunner.cpp
@@ -68,6 +68,10 @@ CachingGraphRunner::loadImpl(torch::jit::Stack &stack) {
 
   glow::CompilationContext cctx;
 
+  if (settings_.convertToFP16) {
+    cctx.precisionConfig.convertToFP16 = true;
+  }
+
   RETURN_IF_ERR(hostManager_->addNetwork(std::move(module), cctx));
 
   perGlowGraphInfoMap_[hash] = std::move(info);
@@ -184,10 +188,15 @@ Error CachingGraphRunner::warmCache(const std::vector<InputMeta> &inputMeta) {
   return Error::success();
 }
 
+const PyTorchLoaderSettings &CachingGraphRunner::getSettings() const {
+  return settings_;
+}
+
 CachingGraphRunner::CachingGraphRunner(
     std::shared_ptr<torch::jit::Graph> graph,
-    std::shared_ptr<runtime::HostManager> hostManager)
-    : graph_(graph), hostManager_(hostManager) {}
+    std::shared_ptr<runtime::HostManager> hostManager,
+    PyTorchLoaderSettings settings)
+    : graph_(graph), hostManager_(hostManager), settings_(settings) {}
 
 CachingGraphRunner::~CachingGraphRunner() {
   // Remove Glow functions saved in HostManager when being destroyed.

--- a/torch_glow/src/CachingGraphRunner.h
+++ b/torch_glow/src/CachingGraphRunner.h
@@ -69,9 +69,14 @@ class CachingGraphRunner {
   /// Given a \p stack of inputs, computes the hash for the inputs on the stack.
   size_t computeGraphHash(const c10::ArrayRef<c10::IValue> inputs) const;
 
+  /// Store the settings that were used to create the JIT subgraph that this
+  /// CachingGraphRunner owns.
+  PyTorchLoaderSettings settings_;
+
 public:
   CachingGraphRunner(std::shared_ptr<torch::jit::Graph> graph,
-                     std::shared_ptr<runtime::HostManager> hostManager);
+                     std::shared_ptr<runtime::HostManager> hostManager,
+                     PyTorchLoaderSettings settings);
 
   ~CachingGraphRunner();
 
@@ -86,6 +91,8 @@ public:
 
   // Warm up the cache by compiling a Glow function for the inputs in \p stack.
   Error warmCache(const std::vector<InputMeta> &inputMeta);
+
+  const PyTorchLoaderSettings &getSettings() const;
 };
 
 } // namespace glow

--- a/torch_glow/src/PyTorchCommon.cpp
+++ b/torch_glow/src/PyTorchCommon.cpp
@@ -16,7 +16,6 @@
 
 #include "PyTorchCommon.h"
 
-#include "CachingGraphRunner.h"
 #include "GlowFuser.h"
 #include "PyTorchModelLoader.h"
 

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -68,6 +68,9 @@ struct PyTorchLoaderSettings {
   /// negative.
   /// NOTE: this should only be used for debugging.
   int64_t fusionEndIndex = -1;
+
+  /// Convert fp32 opts to fp16 ops during Glow compilation.
+  bool convertToFP16 = false;
 };
 
 /// Given a PyTorch ScalarType \p ty, \returns a matching Glow ElemKind.

--- a/torch_glow/src/Registration.cpp
+++ b/torch_glow/src/Registration.cpp
@@ -72,12 +72,13 @@ void registerGlowOp(const c10::Symbol &symbol) {
         // empty one.
         if (!graphRunner) {
           graphRunner = std::make_shared<CachingGraphRunner>(
-              node->g(at::attr::Subgraph), getHostManager());
+              node->g(at::attr::Subgraph), getHostManager(),
+              getPyTorchLoaderSettings());
         }
 
         return [graphRunner](torch::jit::Stack &stack) {
           Error err = Error::empty();
-          if (getPyTorchLoaderSettings().preCompilePyTorchModule) {
+          if (graphRunner->getSettings().preCompilePyTorchModule) {
             err = graphRunner->runOnly(stack);
           } else {
             err = graphRunner->run(stack);

--- a/torch_glow/src/binding.cpp
+++ b/torch_glow/src/binding.cpp
@@ -67,6 +67,14 @@ PYBIND11_MODULE(_torch_glow, m) {
   m.def("disableDumpGlowDag",
         []() { getPyTorchLoaderSettings().dumpGlowDag = false; });
 
+  /// Enable converting fp32 ops to fp16.
+  m.def("enable_convert_to_fp16",
+        []() { getPyTorchLoaderSettings().convertToFP16 = true; });
+
+  /// Disable converting fp32 ops to fp16.
+  m.def("disable_convert_to_fp16",
+        []() { getPyTorchLoaderSettings().convertToFP16 = false; });
+
   /// Add all of the symbols in \p blacklist to the fusion blacklist so that
   /// nodes with these symbols will not be fused to Glow.
   m.def("setFusionBlacklist", [](const std::vector<std::string> &blacklist) {

--- a/torch_glow/tests/unittests/PyTorchLoaderTest.cpp
+++ b/torch_glow/tests/unittests/PyTorchLoaderTest.cpp
@@ -51,7 +51,7 @@ TEST(ModelLoaderTest, Fusion) {
   EXPECT_FALSE(ERR_TO_BOOL(std::move(err)));
 }
 
-TEST(ModelLoaderTest, DISABLED_Direct) {
+TEST(ModelLoaderTest, Direct) {
   const std::string fileName{GLOW_DATA_PATH
                              "tests/models/pytorchModels/resnet18.pt"};
 


### PR DESCRIPTION
Summary:
* store settings used during fusing in `CachingGraphRunner`
* convert fp32 ops to fp16 inside of Glow if `torch_glow.enable_convert_to_fp16()` is set.

Reviewed By: yinghai

Differential Revision: D19907252

