### PR TITLE
Move final graph dumping to provisioner

### DIFF
--- a/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
+++ b/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
@@ -153,9 +153,12 @@ struct CompilationContext {
   /// support.
   runtime::DeferredWeightLoader *deferredWeightLoader{nullptr};
 
-  // Whether to print out issues/logging during compilation. Used for example to
-  // disable printing issues encountered during ConstantFolding.
+  /// Whether to print out issues/logging during compilation. Used for example
+  /// to disable printing issues encountered during ConstantFolding.
   bool verboseCompile{true};
+
+  /// Call dumpDag on each Function passed to the backend for compilation.
+  bool dumpFinalGraph = false;
 
   CompilationContext(PlaceholderBindings *bindings_ = nullptr,
                      LoweredInfoMap *loweredInfoMap_ = nullptr)

--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -69,7 +69,6 @@ static llvm::cl::opt<bool, /* ExternalStorage */ true>
         llvm::cl::location(GlowUsePerPartitionIcetConfig), llvm::cl::Optional,
         llvm::cl::init(false), llvm::cl::cat(optionsForNNPI));
 
-bool GlowDumpGraph = false;
 bool GlowDisableNNPITransforms = false;
 bool GlowDisableNNPIPrivateTransforms = false;
 int32_t GlowNNPINumParallelChunks = 1;
@@ -462,11 +461,6 @@ NNPIBackend::createDeviceManager(const runtime::DeviceConfig &deviceConfig) {
 
 Expected<std::unique_ptr<CompiledFunction>>
 NNPIBackend::compile(Function *F, const BackendOptions &opts) const {
-  if (glow::onnxifi::GlowDumpGraph) {
-    std::string fname = "Graph_" + F->getName().str() + ".dot";
-    LOG(INFO) << "Dumping net to " << fname;
-    F->dumpDAG(fname);
-  }
   std::unique_ptr<NNPICompiledFunction> compiledFunc =
       glow::make_unique<NNPICompiledFunction>(F);
   auto compileHasError = compiledFunc->compile(F, opts);

--- a/lib/Onnxifi/HostManagerOnnxifi.cpp
+++ b/lib/Onnxifi/HostManagerOnnxifi.cpp
@@ -25,7 +25,7 @@ extern bool GlowDumpCompilationLog;
 namespace onnxifi {
 
 extern bool GlowSaveOnnxifiModel;
-;
+
 int32_t GlowNumDevices = 0;
 int32_t GlowSparseNNPartitioningSchemeNumCards = 1;
 int64_t GlowSparseNNPartitioningSchemeSLSTableKBytesPerCard = 0;
@@ -37,6 +37,7 @@ bool GlowSaturateHost = false;
 bool GlowFP16 = false;
 bool GlowFP16Placeholders = true;
 bool GlowFP16Constants = true;
+bool GlowDumpGraph = false;
 bool GlowFusedScaleOffsetFP16 = false;
 bool GlowForceSLSAccumFP16 = false;
 bool GlowClipFP16 = false;
@@ -190,6 +191,9 @@ onnxStatus HostManagerBackend::addNetwork(std::unique_ptr<Module> module,
         GlowSparseNNPartitioningSchemeNumCoresSLS;
     cctx.optimizationOpts.sparseNNPartitioningSchemeNumCoresOther =
         GlowSparseNNPartitioningSchemeNumCoresOther;
+  }
+  if (GlowDumpGraph) {
+    cctx.dumpFinalGraph = true;
   }
 
   auto err =

--- a/lib/Runtime/Provisioner/Provisioner.cpp
+++ b/lib/Runtime/Provisioner/Provisioner.cpp
@@ -349,6 +349,14 @@ Error Provisioner::provision(DAGListTy &networks, Module &module,
                               deviceBackendName);
         }
 
+        if (cctx.dumpFinalGraph) {
+          auto fname =
+              strFormat("final_graph_%s_%s.dot", deviceBackendName.c_str(),
+                        function->getName().str().c_str());
+          LOG(INFO) << "Dumping final graph to " << fname;
+          function->dumpDAG(fname);
+        }
+
         auto compiledOrErr =
             backends_[deviceBackendName]->compile(function, options);
 

--- a/torch_glow/src/CachingGraphRunner.cpp
+++ b/torch_glow/src/CachingGraphRunner.cpp
@@ -72,6 +72,10 @@ CachingGraphRunner::loadImpl(torch::jit::Stack &stack) {
     cctx.precisionConfig.convertToFP16 = true;
   }
 
+  if (settings_.dumpFinalGlowGraph) {
+    cctx.dumpFinalGraph = true;
+  }
+
   RETURN_IF_ERR(hostManager_->addNetwork(std::move(module), cctx));
 
   perGlowGraphInfoMap_[hash] = std::move(info);

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -71,6 +71,9 @@ struct PyTorchLoaderSettings {
 
   /// Convert fp32 opts to fp16 ops during Glow compilation.
   bool convertToFP16 = false;
+
+  /// Dump Glow dot graph to file after Glow compilation is finished.
+  bool dumpFinalGlowGraph = false;
 };
 
 /// Given a PyTorch ScalarType \p ty, \returns a matching Glow ElemKind.

--- a/torch_glow/src/binding.cpp
+++ b/torch_glow/src/binding.cpp
@@ -75,6 +75,14 @@ PYBIND11_MODULE(_torch_glow, m) {
   m.def("disable_convert_to_fp16",
         []() { getPyTorchLoaderSettings().convertToFP16 = false; });
 
+  /// Enable dumping the final Glow dag after compilation.
+  m.def("enable_dump_final_glow_graph",
+        []() { getPyTorchLoaderSettings().dumpFinalGlowGraph = true; });
+
+  /// Disable dumping the final Glow dag after compilation.
+  m.def("disable_dump_final_glow_graph",
+        []() { getPyTorchLoaderSettings().dumpFinalGlowGraph = false; });
+
   /// Add all of the symbols in \p blacklist to the fusion blacklist so that
   /// nodes with these symbols will not be fused to Glow.
   m.def("setFusionBlacklist", [](const std::vector<std::string> &blacklist) {


### PR DESCRIPTION
Summary:
* Move function to dump final graph out of the NNPI backend and into provisioner.
* Update Onnxifi and Repro to match this
* Create a flag in torch_glow to dump the final graph

Reviewed By: gcatron, yinghai

Differential Revision: D19915274

