### PR TITLE
[NFC] Move NodeQuantizationInfo::generateNodeOutputName() to NodeValue, and add a member method for getting it

### DIFF
--- a/include/glow/Graph/NodeValue.h
+++ b/include/glow/Graph/NodeValue.h
@@ -16,6 +16,7 @@
 #ifndef GLOW_GRAPH_NODEVALUE_H
 #define GLOW_GRAPH_NODEVALUE_H
 
+#include "glow/Base/Traits.h"
 #include "glow/Base/Type.h"
 
 namespace glow {
@@ -114,7 +115,40 @@ public:
   /// Get the list of users of this NodeValue.
   llvm::iterator_range<NodeValueIterator> getUsers();
   llvm::iterator_range<NodeValueConstIterator> getUsers() const;
+
+  /// Get the full node output name based on the node name and output number.
+  /// The following format is used: nodename:outputNumber
+  static std::string generateNodeOutputName(const std::string &nodeName,
+                                            unsigned outputNumber = 0) {
+    return nodeName + ":" + std::to_string(outputNumber);
+  }
+
+  std::string generateNodeOutputName() const;
 };
+
+/// Struct containing the output name string and node kind for use in the
+/// LoweredInfoMap for keeping track of lowered node info.
+struct NodeNameAndKind : public Named, public Kinded {
+public:
+  NodeNameAndKind(llvm::StringRef name, size_t resNo, Kinded::Kind k)
+      : Named(NodeValue::generateNodeOutputName(name, resNo)), Kinded(k) {}
+};
+
+/// Overload < operator for NodeNameAndKind to allow for usage with std::set.
+inline bool operator<(const NodeNameAndKind &x, const NodeNameAndKind &y) {
+  return x.getName() < y.getName();
+}
+
+/// Overload == operator for NodeNameAndKind to allow for usage with std::set.
+inline bool operator==(const NodeNameAndKind &x, const NodeNameAndKind &y) {
+  return x.getName() == y.getName();
+}
+
+/// Used to keep track of the origin of lowered Nodes via output names as
+/// determined by NodeValue::generateNodeOutputName(). For example if some
+/// NodeValue X is lowered from some NodeValue Y, then the output name of X is a
+/// key which maps to a set of names which contains the output name of Y.
+using LoweredInfoMap = llvm::StringMap<std::set<NodeNameAndKind>>;
 
 /// A handle type for a NodeValue. This type should be used only by the
 /// class members of Node classes when they need to refer to other nodes!

--- a/include/glow/Quantization/Base/Base.h
+++ b/include/glow/Quantization/Base/Base.h
@@ -72,39 +72,7 @@ struct NodeQuantizationInfo {
 
   float Scale() const { return tensorQuantizationParams_.scale; }
   int32_t Offset() const { return tensorQuantizationParams_.offset; }
-
-  /// Get the full node output name based on the node name and output number.
-  /// The following format is used: nodename:outputNumber
-  static std::string generateNodeOutputName(const std::string &nodeName,
-                                            unsigned outputNumber = 0) {
-    return nodeName + ":" + std::to_string(outputNumber);
-  }
 };
-
-/// Struct containing the output name string and node kind for use in the
-/// LoweredInfoMap for keeping track of lowered node info.
-struct NodeNameAndKind : public Named, public Kinded {
-public:
-  NodeNameAndKind(llvm::StringRef name, size_t resNo, Kinded::Kind k)
-      : Named(NodeQuantizationInfo::generateNodeOutputName(name, resNo)),
-        Kinded(k) {}
-};
-
-/// Overload < operator for NodeNameAndKind to allow for usage with std::set.
-inline bool operator<(const NodeNameAndKind &x, const NodeNameAndKind &y) {
-  return x.getName() < y.getName();
-}
-
-/// Overload == operator for NodeNameAndKind to allow for usage with std::set.
-inline bool operator==(const NodeNameAndKind &x, const NodeNameAndKind &y) {
-  return x.getName() == y.getName();
-}
-
-/// Used to keep track of the origin of lowered Nodes via output names as
-/// determined by NodeQuantizationInfo::generateNodeOutputName(). For example if
-/// some NodeValue X is lowered from some NodeValue Y, then the output name of X
-/// is a key which maps to a set of names which contains the output name of Y.
-using LoweredInfoMap = llvm::StringMap<std::set<NodeNameAndKind>>;
 
 namespace quantization {
 

--- a/lib/Graph/NodeValue.cpp
+++ b/lib/Graph/NodeValue.cpp
@@ -113,6 +113,10 @@ ElemKind NodeValue::getElementType() const {
 
 llvm::ArrayRef<dim_t> NodeValue::dims() const { return getType()->dims(); }
 
+std::string NodeValue::generateNodeOutputName() const {
+  return generateNodeOutputName(node_->getName(), resNo_);
+}
+
 NodeHandle::NodeHandle(Node *parent, Node *N) : NodeValue(N), parent_(parent) {
   setOperand(N, 0);
 }

--- a/lib/Optimizer/Lower/Lower.cpp
+++ b/lib/Optimizer/Lower/Lower.cpp
@@ -48,9 +48,7 @@ static void replaceAllUsesOfWith(LoweredInfoMap *loweredMap, NodeValue oldNV,
     return;
   }
 
-  std::string newOutputName = NodeQuantizationInfo::generateNodeOutputName(
-      newNV.getNode()->getName(), newNV.getResNo());
-  (*loweredMap)[newOutputName].insert(
+  (*loweredMap)[newNV.generateNodeOutputName()].insert(
       NodeNameAndKind(oldNV.getNode()->getName(), oldNV.getResNo(),
                       oldNV.getNode()->getKind()));
 }

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -146,8 +146,7 @@ static bool isBAFromLoweredFC(const BatchedAddNode *baN,
                               const LoweredInfoMap &loweredMap) {
   // Look for the set of NodeNameAndKinds corresponding to the
   // BatchedAdd. If one exists, this means it was lowered.
-  auto it = loweredMap.find(NodeQuantizationInfo::generateNodeOutputName(
-      baN->getName(), BatchedAddNode::ResultIdx));
+  auto it = loweredMap.find(baN->getResult().generateNodeOutputName());
   if (it == loweredMap.end()) {
     return false;
   }
@@ -175,10 +174,7 @@ protected:
   /// of \p out to match some IR constraints, but the final type still
   /// needs to be known to insert rescale nodes.
   TypeRef getTargetTypeForOutputImpl(const NodeValue &out) const {
-    const std::string nodeOutputName =
-        NodeQuantizationInfo::generateNodeOutputName(out.getNode()->getName(),
-                                                     out.getResNo());
-    auto outTQPIt = nodeToTQP_.find(nodeOutputName);
+    auto outTQPIt = nodeToTQP_.find(out.generateNodeOutputName());
     assert(outTQPIt != nodeToTQP_.end() &&
            "Missing quantization params for a node");
 
@@ -208,9 +204,7 @@ protected:
       return val.getType();
     }
 
-    std::string nodeOutputName = NodeQuantizationInfo::generateNodeOutputName(
-        val.getNode()->getName(), val.getResNo());
-    auto valTQPIt = nodeToTQP_.find(nodeOutputName);
+    auto valTQPIt = nodeToTQP_.find(val.generateNodeOutputName());
     assert(valTQPIt != nodeToTQP_.end() &&
            "Missing quantization params for a node");
 
@@ -414,9 +408,7 @@ protected:
   /// Helper that \returns whether quantization parameters exist
   /// in \ref nodeToTQP_ given the name and result number of \p val.
   bool quantizationParamsExist(const NodeValue &val) const {
-    std::string nodeOutputName = NodeQuantizationInfo::generateNodeOutputName(
-        val.getNode()->getName(), val.getResNo());
-    auto valTQPIt = nodeToTQP_.find(nodeOutputName);
+    auto valTQPIt = nodeToTQP_.find(val.generateNodeOutputName());
     return valTQPIt != nodeToTQP_.end();
   }
 
@@ -666,8 +658,8 @@ protected:
       auto *dequantize =
           llvm::dyn_cast<DequantizeNode>((*val.getUsers().begin()).getUser());
       TypeRef outTy = val.getType();
-      auto name = NodeQuantizationInfo::generateNodeOutputName(
-          dequantize->getName(), outNum);
+      auto name =
+          NodeValue::generateNodeOutputName(dequantize->getName(), outNum);
 
       nodeToTQP_[name] = {outTy->getScale(), outTy->getOffset()};
     }
@@ -929,7 +921,7 @@ generateNodeQuantizationInfos(PlaceholderBindings &bindings, const Function *F,
       float min = CI.raw(0);
       float max = CI.raw(1);
 
-      std::string fullOutputName = NodeQuantizationInfo::generateNodeOutputName(
+      std::string fullOutputName = NodeValue::generateNodeOutputName(
           QPN->getProfiledNodeName(), QPN->getProfiledOutputNumber());
 
       ElemKind qPrec = quantizationPrecision;


### PR DESCRIPTION
This is cleaner. And I am going to use it outside of quantization in future PRs.