### PR TITLE
Start/stop device tracing interface.

### DIFF
--- a/include/glow/Backends/DeviceManager.h
+++ b/include/glow/Backends/DeviceManager.h
@@ -229,6 +229,15 @@ public:
     DCHECK("Not Implemented");
     return false;
   }
+
+  /// Starts device tracing \returns Error if fails.
+  virtual Error startDeviceTrace(TraceContext *traceContext) {
+    return Error::success();
+  }
+  /// Stops device tracing \returns Error if fails.
+  virtual Error stopDeviceTrace(TraceContext *traceContext) {
+    return Error::success();
+  }
 };
 
 } // namespace runtime

--- a/include/glow/Runtime/HostManager/HostManager.h
+++ b/include/glow/Runtime/HostManager/HostManager.h
@@ -105,6 +105,8 @@ class HostManager final {
   /// Configuration parameters for this Runtime Host.
   const HostConfig config_{};
 
+  std::unique_ptr<TraceContext> hostTraceContext_;
+
   /// A map from a networkName to a network, which is represented by struct DAG.
   std::unordered_map<std::string, NetworkData> networks_;
 
@@ -228,6 +230,22 @@ public:
 
   /// Get the network DAG for \p network if it exists.
   Expected<DAG *> getNetworkDAG(llvm::StringRef network);
+
+  /// \returns a non-owning pointer to the TraceContext.
+  TraceContext *getTraceContext() { return hostTraceContext_.get(); }
+
+  /// Sets the TraceContext and \returns the existing value.
+  std::unique_ptr<TraceContext>
+  setTraceContext(std::unique_ptr<TraceContext> traceContext) {
+    std::swap(hostTraceContext_, traceContext);
+    return traceContext;
+  }
+
+  /// Triggers start tracing of all active devices \returns Error if fails.
+  Error startDeviceTrace();
+
+  /// Triggers stop tracing of all active devices \returns Error if fails.
+  Error stopDeviceTrace();
 
   /// \returns a reference to the backend with name \p backendName owned by the
   /// Provisioner.

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -84,6 +84,26 @@ Expected<DAG *> HostManager::getNetworkDAG(llvm::StringRef network) {
   return &it->second.dag;
 }
 
+Error HostManager::startDeviceTrace() {
+  for (auto &dev : devices_) {
+    Error err = dev.second->startDeviceTrace(hostTraceContext_.get());
+    if (err) {
+      return err;
+    }
+  }
+  return Error::success();
+}
+
+Error HostManager::stopDeviceTrace() {
+  for (auto &dev : devices_) {
+    Error err = dev.second->stopDeviceTrace(hostTraceContext_.get());
+    if (err) {
+      return err;
+    }
+  }
+  return Error::success();
+}
+
 Error HostManager::init(std::vector<std::unique_ptr<DeviceConfig>> configs) {
   DeviceIDTy deviceCount = 0;
 


### PR DESCRIPTION
Summary:
Define an interface to start/stop device tracing.
Using this interface we will be able to capture device traces for end 2 end glow application execution when only one device tracing context is allowed.
Tracing context is owned by the HostManager and can be merge into a global trace context when the execution ends.
For an example of how to use, see the tools/loader/ImageClassifier.cpp suggested changes.

