### PR TITLE
Record positional input/output info in onnxifi importer

### DIFF
--- a/include/glow/Importer/ONNXIFIModelLoader.h
+++ b/include/glow/Importer/ONNXIFIModelLoader.h
@@ -44,6 +44,16 @@ public:
     return core_->getOutputVarsMapping();
   }
 
+  /// \returns vector of primary input names based on their position
+  const std::vector<std::string> &getPositionalInputNames() const {
+    return core_->getPositionalInputNames();
+  }
+
+  /// \returns vector of primary output names based on their position
+  const std::vector<std::string> &getPositionalOutputNames() const {
+    return core_->getPositionalOutputNames();
+  }
+
   /// \returns a unique_ptr<ONNXIFIModelLoader> if \p onnxModel can be
   /// parsed and static weights can be loaded from the \p wightDescriptors.
   /// \returns Error otherwise. \p loadInputsAsPlaceholders is passed to

--- a/include/glow/Importer/ProtobufLoader.h
+++ b/include/glow/Importer/ProtobufLoader.h
@@ -142,6 +142,10 @@ protected:
   llvm::StringMap<Placeholder *> outputVarsByName_;
   /// A map from names of the external inputs of the network to Variables.
   llvm::StringMap<Placeholder *> inputVarsByName_;
+  /// A vector of input names ordered by their position of inference interface
+  std::vector<std::string> positionalInputNames_;
+  /// A vector of output names ordered by their position of inference interface
+  std::vector<std::string> positionalOutputNames_;
   /// Whether to try constant folding as we load each op from a protobuf.
   bool constFoldInLoader_{true};
 
@@ -215,6 +219,16 @@ public:
   /// \returns mapping between external names and actual Glow input nodes.
   const llvm::StringMap<Placeholder *> &getInputVarsMapping() const {
     return inputVarsByName_;
+  }
+
+  /// \returns vector of primary input names based on their position
+  const std::vector<std::string> &getPositionalInputNames() const {
+    return positionalInputNames_;
+  }
+
+  /// \returns vector of primary output names based on their position
+  const std::vector<std::string> &getPositionalOutputNames() const {
+    return positionalOutputNames_;
   }
 
   /// \returns the single final output of the network. The function assumes

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -2021,6 +2021,20 @@ Caffe2ModelLoader::Caffe2ModelLoader(
 
     RETURN_IF_ERR(loadInputs(networkDef, loadInputsAsPlaceholders));
 
+    // Identify primary input sequence
+    std::unordered_set<std::string> weights;
+    for (uint32_t i = 0; i < weightsCount; ++i) {
+      weights.emplace(weightDescriptors[i].name);
+    }
+    for (const auto &input : networkDef.external_input()) {
+      if (!weights.count(input)) {
+        positionalInputNames_.emplace_back(input);
+      }
+    }
+    for (const auto &output : networkDef.external_output()) {
+      positionalOutputNames_.emplace_back(output);
+    }
+
     // TODO: in Caffe2ModelLoader, setOutputNodes is actually inside
     // loadNetwork, maybe we should make it a separate function?
     RETURN_IF_ERR(loadNetwork(networkDef));

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -153,6 +153,35 @@ void Graph::setZeroLengthSequence(dim_t maxSeqLength) {
   zeroLengthSequence_.zero();
 }
 
+void Graph::bindPlaceholders(const ONNXIFIModelLoader &loader) {
+  onnxInputToPlaceholder_ = loader.getInputVarsMapping();
+  onnxOutputToPlaceholder_ = loader.getOutputVarsMapping();
+  onnxInputNames_ = loader.getPositionalInputNames();
+  onnxInputPlaceholders_.reserve(onnxInputNames_.size());
+  for (const auto &i : onnxInputNames_) {
+    const auto it = onnxInputToPlaceholder_.find(i);
+    if (it == onnxInputToPlaceholder_.end()) {
+      break;
+    }
+    onnxInputPlaceholders_.push_back(it->second);
+  }
+  if (onnxInputPlaceholders_.size() != onnxInputToPlaceholder_.size()) {
+    onnxInputPlaceholders_.clear();
+  }
+  onnxOutputNames_ = loader.getPositionalOutputNames();
+  onnxOutputPlaceholders_.reserve(onnxOutputNames_.size());
+  for (const auto &i : onnxOutputNames_) {
+    const auto it = onnxOutputToPlaceholder_.find(i);
+    if (it == onnxOutputToPlaceholder_.end()) {
+      break;
+    }
+    onnxOutputPlaceholders_.push_back(it->second);
+  }
+  if (onnxOutputPlaceholders_.size() != onnxOutputToPlaceholder_.size()) {
+    onnxOutputPlaceholders_.clear();
+  }
+}
+
 onnxStatus Graph::adjustInputs(uint32_t inputsCount,
                                const onnxTensorDescriptorV1 *inputDescriptors,
                                ExecutionContext *ctx) {

--- a/lib/Onnxifi/Base.h
+++ b/lib/Onnxifi/Base.h
@@ -159,6 +159,22 @@ protected:
   /// placeholder for output.
   llvm::StringMap<Placeholder *> onnxOutputToPlaceholder_;
 
+  /// A list of input names ordered by their position in ONNXIFI input
+  /// descriptor array.
+  std::vector<std::string> onnxInputNames_;
+
+  /// A list of input placeholders ordered by their position in ONNXIFI input
+  /// descriptor array.
+  std::vector<Placeholder *> onnxInputPlaceholders_;
+
+  /// A list of output names ordered by their position in ONNXIFI output
+  /// descriptor array.
+  std::vector<std::string> onnxOutputNames_;
+
+  /// A list of output placeholders ordered by their position in ONNXIFI output
+  /// descriptor array.
+  std::vector<Placeholder *> onnxOutputPlaceholders_;
+
   /// An object pool for tensors, to share allocations.
   TensorPool tensorPool_;
 
@@ -167,6 +183,9 @@ protected:
 
   /// Set the zero length tensor
   void setZeroLengthSequence(dim_t maxSeqLength);
+
+  /// Bind input/output placeholders
+  void bindPlaceholders(const ONNXIFIModelLoader &loader);
 
 private:
   /// inference dump counter

--- a/lib/Onnxifi/HostManagerOnnxifi.cpp
+++ b/lib/Onnxifi/HostManagerOnnxifi.cpp
@@ -244,9 +244,7 @@ HostManagerGraph::initGraph(const void *onnxModel, size_t onnxModelSize,
           onnxModel, onnxModelSize, weightCount, weightDescriptors, *function,
           true /*loadInputsAsPlaceholders*/, backendPtr_->getUseOnnx()));
 
-  onnxInputToPlaceholder_ = loader->getInputVarsMapping();
-  onnxOutputToPlaceholder_ = loader->getOutputVarsMapping();
-
+  bindPlaceholders(*loader);
   setZeroLengthSequence(maxSeqLength);
   // Make sure the pool is ready to go.
   for (auto &obj : onnxInputToPlaceholder_) {

--- a/lib/Onnxifi/InlineOnnxifi.cpp
+++ b/lib/Onnxifi/InlineOnnxifi.cpp
@@ -55,8 +55,7 @@ InlineGraph::initGraph(const void *onnxModel, size_t onnxModelSize,
           onnxModel, onnxModelSize, weightCount, weightDescriptors, *function_,
           true /*loadInputsAsPlaceholders*/, backendPtr_->getUseOnnx()));
 
-  onnxInputToPlaceholder_ = loader->getInputVarsMapping();
-  onnxOutputToPlaceholder_ = loader->getOutputVarsMapping();
+  bindPlaceholders(*loader);
   if (GlowSaveOnnxifiModel) {
     saveOnnxifiModel(function_);
   }


### PR DESCRIPTION
Summary: Add bookkeeper during ONNXIFI load time to record the positional input/output names and placeholder array so that later we can bind them by position instead of doing string hashing every inference time. This diff only prepares the information. We will hook up the per inference binding once the Cached ExecutionContext is in place.

Differential Revision: D19966535

