### PR TITLE
Add an option to set output trace file path.

### DIFF
--- a/tests/unittests/Repro.cpp
+++ b/tests/unittests/Repro.cpp
@@ -190,6 +190,12 @@ llvm::cl::opt<bool> glowDumpTrace("glow_dump_debug_traces",
                                   llvm::cl::Optional, llvm::cl::init(false),
                                   llvm::cl::cat(reproTestCat));
 
+llvm::cl::opt<std::string>
+    glowDumpTraceFile("glow_dump_debug_traces_file",
+                      llvm::cl::desc("Dump glow trace file"),
+                      llvm::cl::Optional, llvm::cl::init(std::string("")),
+                      llvm::cl::cat(reproTestCat));
+
 void parseCommandLine(int argc, char **argv) {
   llvm::sys::PrintStackTraceOnErrorSignal(argv[0]);
   llvm::cl::ParseCommandLineOptions(
@@ -564,13 +570,19 @@ int run() {
 
   if (glowDumpTrace) {
     llvm::SmallString<64> path;
-    auto tempFileRes =
-        llvm::sys::fs::createTemporaryFile("glow-trace", "json", path);
-    if (tempFileRes.value() != 0) {
-      LOG(ERROR) << "Failed to create temp file for Glow trace events: "
-                 << tempFileRes;
+    if (glowDumpTraceFile.empty()) {
+      auto tempFileRes =
+          llvm::sys::fs::createTemporaryFile("glow-trace", "json", path);
+      if (tempFileRes.value() != 0) {
+        LOG(ERROR) << "Failed to create temp file for Glow trace events: "
+                   << tempFileRes;
+      } else {
+        LOG(INFO) << "Trace path=" << path.c_str();
+        mergedTraceContext.dump(path);
+      }
     } else {
-      mergedTraceContext.dump(path);
+      LOG(INFO) << "Trace path=" << path.c_str();
+      mergedTraceContext.dump(glowDumpTraceFile);
     }
   }
 


### PR DESCRIPTION
Summary: Add an option in the Repro tool to predefine the output trace file. 