### PR TITLE
[Hotfix] Add a CONFIG_HAVE_KERNEL_TIMESPEC option to avoid an invalid …

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,7 +198,11 @@ else()
 
   # Remove Glow-specific CMAKE_CXX_FLAGS to build folly.
   set(SAVE_CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
-  set(CMAKE_CXX_FLAGS "")
+  if (CONFIG_HAVE_KERNEL_TIMESPEC)
+    set(CMAKE_CXX_FLAGS "-DCONFIG_HAVE_KERNEL_TIMESPEC")
+  else()
+    set(CMAKE_CXX_FLAGS "")
+  endif()
   set(SAVE_CMAKE_CXX_STANDARD "${CMAKE_CXX_STANDARD}")
   unset(CMAKE_CXX_STANDARD)
   add_subdirectory("${GLOW_THIRDPARTY_DIR}/folly" EXCLUDE_FROM_ALL)


### PR DESCRIPTION
Summary:
Add a CMake option that allows developers to compile Glow under Fedora 31 (and maybe some other distrib like Redhat?)

Documentation: N/A

Fixes #4200

Test Plan: Could build locally master with this cmake option activated.

.
