### PR TITLE
Fix the verifier for ReluInst

### DIFF
--- a/lib/IR/Instrs.cpp
+++ b/lib/IR/Instrs.cpp
@@ -101,3 +101,24 @@ void ExtractTensorInst::verify() const {
       "ExtractTensor offsets should have the same number of dims as Src type "
       "shape");
 }
+
+static void verifyRelu(TypeRef srcTy, TypeRef destTy) {
+  if (srcTy->isQuantizedType()) {
+    assert(srcTy->isQuantizedType() == destTy->isQuantizedType() &&
+           "Mismatching isQuantized");
+    assert(srcTy->dims() == destTy->dims() && "Mismatching dimensions");
+    assert(srcTy->getElementType() == destTy->getElementType() &&
+           "Mismatching element type");
+    return;
+  }
+  assert(destTy->isEqual(*srcTy) && "Mismatching types");
+}
+
+void ReluInst::verify() const {
+  verifyRelu(getSrc()->getType(), getDest()->getType());
+}
+
+void ReluGradInst::verify() const {
+  verifyRelu(getSrcGrad()->getType(), getDest()->getType());
+  verifyRelu(getSrcGrad()->getType(), getDestGrad()->getType());
+}

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -618,7 +618,6 @@ int main(int argc, char **argv) {
           "Src",
       })
       .dataParallel()
-      .autoVerify(VerifyKind::SameType, {"Dest", "Src"})
       .autoIRGen()
       .addGradientInstr({"Dest"}, {"Dest", "Src"});
 


### PR DESCRIPTION
The verifier was too strict. Now we check exactly the same conditions that we use for verifying ReluNode.