### PR TITLE
Move Expected IValue helper methods to common

### DIFF
--- a/torch_glow/src/GlowIValue.cpp
+++ b/torch_glow/src/GlowIValue.cpp
@@ -452,4 +452,72 @@ size_t GlowIValueMapHash::operator()(const GlowIValue &ival) const {
   return 0;
 }
 
+/// Unwrap a Expected<GlowIValue *> \p expectedIVal and call toDouble,
+/// propogate any Errors.
+Expected<double> iValToDouble(Expected<GlowIValue *> expectedIVal) {
+  if (expectedIVal) {
+    return (*expectedIVal)->toDouble();
+  } else {
+    return expectedIVal.takeError();
+  }
+}
+
+/// Unwrap a Expected<GlowIValue *> \p expectedIVal and call toInt,
+/// propogate any Errors.
+Expected<int64_t> iValToInt(Expected<GlowIValue *> expectedIVal) {
+  if (expectedIVal) {
+    return (*expectedIVal)->toInt();
+  } else {
+    return expectedIVal.takeError();
+  }
+}
+
+/// Unwrap a Expected<GlowIValue *> \p expectedIVal and call toBool,
+/// propogate any Errors.
+Expected<bool> iValToBool(Expected<GlowIValue *> expectedIVal) {
+  if (expectedIVal) {
+    return (*expectedIVal)->toBool();
+  } else {
+    return expectedIVal.takeError();
+  }
+}
+
+/// Unwrap a Expected<GlowIValue *> \p expectedIVal and call toIntList,
+/// propogate any Errors.
+Expected<std::vector<int64_t> *>
+iValToIntList(Expected<GlowIValue *> expectedIVal) {
+  if (expectedIVal) {
+    return (*expectedIVal)->toIntList();
+  } else {
+    return expectedIVal.takeError();
+  }
+}
+
+/// Unwrap a Expected<GlowIValue *> \p expectedIVal and call toPTTensor,
+/// propogate any Errors.
+Expected<at::Tensor *> iValToPTTensor(Expected<GlowIValue *> expectedIVal) {
+  if (expectedIVal) {
+    return (*expectedIVal)->toPTTensor();
+  } else {
+    return expectedIVal.takeError();
+  }
+}
+
+Expected<GlowIValueMap *>
+iValToGenericMap(Expected<GlowIValue *> expectedIVal) {
+  if (expectedIVal) {
+    return (*expectedIVal)->toGenericMap();
+  } else {
+    return expectedIVal.takeError();
+  }
+}
+
+Expected<std::string *> iValToString(Expected<GlowIValue *> expectedIVal) {
+  if (expectedIVal) {
+    return (*expectedIVal)->toString();
+  } else {
+    return expectedIVal.takeError();
+  }
+}
+
 } // namespace glow

--- a/torch_glow/src/GlowIValue.h
+++ b/torch_glow/src/GlowIValue.h
@@ -236,6 +236,35 @@ public:
   Error fromIValue(const at::IValue &ival);
 };
 
+/// Unwrap a Expected<GlowIValue *> \p expectedIVal and call toDouble,
+/// propogate any Errors.
+Expected<double> iValToDouble(Expected<GlowIValue *> expectedIVal);
+
+/// Unwrap a Expected<GlowIValue *> \p expectedIVal and call toInt,
+/// propogate any Errors.
+Expected<int64_t> iValToInt(Expected<GlowIValue *> expectedIVal);
+
+/// Unwrap a Expected<GlowIValue *> \p expectedIVal and call toBool,
+/// propogate any Errors.
+Expected<bool> iValToBool(Expected<GlowIValue *> expectedIVal);
+
+/// Unwrap a Expected<GlowIValue *> \p expectedIVal and call toIntList,
+/// propogate any Errors.
+Expected<std::vector<int64_t> *>
+iValToIntList(Expected<GlowIValue *> expectedIVal);
+
+/// Unwrap a Expected<GlowIValue *> \p expectedIVal and call toPTTensor,
+/// propogate any Errors.
+Expected<at::Tensor *> iValToPTTensor(Expected<GlowIValue *> expectedIVal);
+
+/// Unwrap a Expected<GlowIValue *> \p expectedIVal and call toGenericMap,
+/// propogate any Errors.
+Expected<GlowIValueMap *> iValToGenericMap(Expected<GlowIValue *> expectedIVal);
+
+/// Unwrap a Expected<GlowIValue *> \p expectedIVal and call toString,
+/// propogate any Errors.
+Expected<std::string *> iValToString(Expected<GlowIValue *> expectedIVal);
+
 } // namespace glow
 
 #endif // GLOW_TORCH_GLOW_SRC_GLOWIVALUE_H

--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -176,57 +176,6 @@ contractIntIValIfNeeded(Expected<GlowIValue *> expectedGlowIVal) {
   }
 }
 
-/// Unwrap a Expected<GlowIValue *> \p expectedIVal and call toDouble,
-/// propogate any Errors.
-Expected<double> iValToDouble(Expected<GlowIValue *> expectedIVal) {
-  if (expectedIVal) {
-    return (*expectedIVal)->toDouble();
-  } else {
-    return expectedIVal.takeError();
-  }
-}
-
-/// Unwrap a Expected<GlowIValue *> \p expectedIVal and call toInt,
-/// propogate any Errors.
-Expected<int64_t> iValToInt(Expected<GlowIValue *> expectedIVal) {
-  if (expectedIVal) {
-    return (*expectedIVal)->toInt();
-  } else {
-    return expectedIVal.takeError();
-  }
-}
-
-/// Unwrap a Expected<GlowIValue *> \p expectedIVal and call toBool,
-/// propogate any Errors.
-Expected<bool> iValToBool(Expected<GlowIValue *> expectedIVal) {
-  if (expectedIVal) {
-    return (*expectedIVal)->toBool();
-  } else {
-    return expectedIVal.takeError();
-  }
-}
-
-/// Unwrap a Expected<GlowIValue *> \p expectedIVal and call toIntList,
-/// propogate any Errors.
-Expected<std::vector<int64_t> *>
-iValToIntList(Expected<GlowIValue *> expectedIVal) {
-  if (expectedIVal) {
-    return (*expectedIVal)->toIntList();
-  } else {
-    return expectedIVal.takeError();
-  }
-}
-
-/// Unwrap a Expected<GlowIValue *> \p expectedIVal and call toPTTensor,
-/// propogate any Errors.
-Expected<at::Tensor *> iValToPTTensor(Expected<GlowIValue *> expectedIVal) {
-  if (expectedIVal) {
-    return (*expectedIVal)->toPTTensor();
-  } else {
-    return expectedIVal.takeError();
-  }
-}
-
 /// Given a vector \p original containing elements of some type, \returns a
 /// vector of each element cast to another type T.
 template <typename T, typename OriginalT>
@@ -968,6 +917,7 @@ bool PyTorchModelLoader::isNodeSupported(const torch::jit::Node *ptNode) {
   }
 
   const auto &mapping = getSymbolsMapping();
+
   return mapping.count(kind) != 0;
 }
 


### PR DESCRIPTION
Summary:
Move methods used to deal with Expected IVavlues in the
PyTorchModelLoader to Common so that they can be used in other code as well

Reviewed By: yinghai

Differential Revision: D20068995

