### PR TITLE
Fix an LLVM issue in BundleSaver reported by LLVM debug builds

### DIFF
--- a/lib/LLVMIRCodeGen/BundleSaver.h
+++ b/lib/LLVMIRCodeGen/BundleSaver.h
@@ -31,7 +31,9 @@ public:
     /// Entry name for the IR function.
     std::string entryName;
     /// Saved IRFunction.
-    const IRFunction *savedF;
+    const IRFunction *savedF{nullptr};
+    /// LLVM IR function created for this IR function.
+    llvm::Function *llvmF{nullptr};
   };
   /// WeightInfo represents a constant weight and a constant it is produced
   /// from.
@@ -65,8 +67,8 @@ private:
   void emitBundleConfig();
   /// Emit the symbol table for a bundle.
   void emitSymbolTable();
-  /// Emit the entry function for the bundle.
-  void emitBundleEntryFunction();
+  /// Emit the entry function for the saved function \p savedF.
+  void emitBundleEntryFunction(SavedIRFunction &savedF);
   /// Set current IRFunction.
   void setIRFunction(llvm::StringRef mainEntryName, const IRFunction *F);
   /// Returns a set of placeholders associated with IR functions inside this

--- a/tests/unittests/BundleSaverTest.cpp
+++ b/tests/unittests/BundleSaverTest.cpp
@@ -59,10 +59,10 @@ TEST(BundleSaver, testSaveMultipleFunctions) {
   // Create a simple graph.
   Function *F2 = M.createFunction("F2");
   Node *inputPH2 = M.createPlaceholder(ElemKind::FloatTy, {1}, "input2", false);
-  Node *addConst2 = M.createConstant(ElemKind::FloatTy, {1}, "const2");
-  Node *addNode21 = F2->createAdd("add", inputPH2, addConst);
-  Node *addNode22 = F2->createAdd("add", addNode21, addConst2);
-  F2->createSave("output", addNode22);
+  Node *subConst2 = M.createConstant(ElemKind::FloatTy, {1}, "const2");
+  Node *subNode21 = F2->createSub("sub", inputPH2, addConst);
+  Node *subNode22 = F2->createSub("sub", subNode21, subConst2);
+  F2->createSave("output", subNode22);
 
   // Save a bundle with multiple functions.
   llvm::StringRef outputDir = ".";


### PR DESCRIPTION
There was a problem with a specific replaceAllUsesWith, as it used a different type for the replacement. This is solved now by emitting all entry functions at once at the very end of the bundle emission process.

Fixes #4214
