### PR TITLE
Remove rescales for input and output

### DIFF
--- a/torch_glow/tests/nodes/quantized_add_test.py
+++ b/torch_glow/tests/nodes/quantized_add_test.py
@@ -59,3 +59,35 @@ class TestQuantizedAdd(unittest.TestCase):
                 "aten::dequantize",
             },
         )
+
+    def test_quantized_add_cut_q_dq(self):
+        """Basic test of the PyTorch quantized::add Node on Glow, with quantize and dequantize excluded. """
+
+        def test_f(a, b):
+            q1 = torch.nn.quantized.Quantize(
+                scale=1.0 / 128, zero_point=5, dtype=torch.quint8
+            )
+            q2 = torch.nn.quantized.Quantize(
+                scale=1.0 / 128, zero_point=10, dtype=torch.quint8
+            )
+            dq = torch.nn.quantized.DeQuantize()
+            return dq(
+                torch.ops.quantized.add(
+                    q1(a), q2(b), scale=1.0 / 128, zero_point=3)
+            )
+
+        x = torch.randn([5, 5])
+        y = torch.randn([5, 5])
+
+        jitVsGlow(
+            test_f,
+            x,
+            y,
+            expected_fused_ops={
+                "quantized::add",
+            },
+            black_list=[
+                "aten::quantize_per_tensor",
+                "aten::dequantize",
+            ]
+        )

--- a/torch_glow/tests/nodes/quantized_avgpool_test.py
+++ b/torch_glow/tests/nodes/quantized_avgpool_test.py
@@ -29,3 +29,28 @@ class TestQuantizedAvgPool(unittest.TestCase):
                 "aten::dequantize",
             },
         )
+
+    def test_quantized_avgpool_cut_q_dq(self):
+        """Basic test of the PyTorch quantized::avg_pool2d Node on Glow, with quantize and dequantize excluded. """
+
+        def test_f(a):
+            q = torch.nn.quantized.Quantize(
+                scale=1.0 / 128, zero_point=3, dtype=torch.quint8
+            )
+            dq = torch.nn.quantized.DeQuantize()
+            ap = torch.nn.AvgPool2d(3)
+            return dq(ap(q(a)))
+
+        inputs = torch.randn(1, 4, 5, 5)
+
+        jitVsGlow(
+            test_f,
+            inputs,
+            expected_fused_ops={
+                "aten::avg_pool2d",
+            },
+            black_list=[
+                "aten::quantize_per_tensor",
+                "aten::dequantize",
+            ]
+        )

--- a/torch_glow/tests/nodes/quantized_conv2d_relu_test.py
+++ b/torch_glow/tests/nodes/quantized_conv2d_relu_test.py
@@ -61,3 +61,51 @@ class TestQuantizedConv2dRelu(unittest.TestCase):
     def test_quantized_conv2d_relu_packed_nongroupwise(self):
         """PyTorch vanilla quantized::conv2d_relu Node with packed weights on Glow."""
         self._test_quantized_conv2d_relu_packed(groups=1)
+
+    def test_quantized_conv2d_relu_packed_cut_q_dq(self):
+        """Basic test of PyTorch quantized::conv2d_relu Node with packed weights on Glow, with quantize and dequantize excluded. """
+        with torch.no_grad():
+            x = torch.tensor(range(5), dtype=torch.float) / 3
+            x = torch.cat((x, x, x, x, x))
+            x = torch.cat((x, x, x))
+            x = torch.reshape(x, [1, 3, 5, 5])
+            q = torch.nn.quantized.Quantize(1, 2, torch.quint8)
+            conv = torch.nn.Conv2d(3, 3, [2, 2], groups=1)
+            relu = torch.nn.ReLU()
+            dq = torch.nn.quantized.DeQuantize()
+
+            # Due to the off-by-one error, we cannot let the weights, bias & input
+            # to be totally random.
+            conv.weight.set_(torch.arange(36, dtype=torch.float).reshape([3,
+                                                                          3, 2,
+                                                                          2])
+                             / 3)
+            conv.bias.data.fill_(2)
+
+            model = torch.nn.Sequential(
+                OrderedDict(
+                    [("quantize", q), ("conv1", conv),
+                     ("relu1", relu), ("dequantize", dq)]
+                )
+            )
+            model.eval()
+            model.qconfig = torch.quantization.get_default_qconfig("fbgemm")
+
+            # Fuse conv and relu to conv_relu
+            model = torch.quantization.fuse_modules(
+                model, [["conv1", "relu1"]])
+
+            torch.quantization.prepare(model, inplace=True)
+            torch.quantization.convert(model, inplace=True)
+
+            jitVsGlow(
+                model,
+                x,
+                expected_fused_ops={
+                    "quantized::conv2d_relu",
+                },
+                black_list=[
+                    "aten::quantize_per_tensor",
+                    "aten::dequantize",
+                ]
+            )

--- a/torch_glow/tests/nodes/quantized_maxpool_test.py
+++ b/torch_glow/tests/nodes/quantized_maxpool_test.py
@@ -29,3 +29,28 @@ class TestQuantizedMaxPool(unittest.TestCase):
                 "aten::dequantize",
             },
         )
+
+    def test_quantized_maxpool_cut_q(self):
+        """Basic test of the PyTorch quantized::max_pool2d Node on Glow, with quantize excluded. """
+
+        def test_f(a):
+            q = torch.nn.quantized.Quantize(
+                scale=1.0 / 128, zero_point=3, dtype=torch.quint8
+            )
+            dq = torch.nn.quantized.DeQuantize()
+            mp = torch.nn.MaxPool2d(3)
+            return dq(mp(q(a)))
+
+        inputs = torch.randn(1, 4, 5, 5)
+
+        jitVsGlow(
+            test_f,
+            inputs,
+            expected_fused_ops={
+                "aten::max_pool2d",
+                "aten::dequantize",
+            },
+            black_list=[
+                "aten::quantize_per_tensor",
+            ]
+        )

--- a/torch_glow/tests/nodes/quantized_relu_test.py
+++ b/torch_glow/tests/nodes/quantized_relu_test.py
@@ -29,3 +29,28 @@ class TestQuantizedRelu(unittest.TestCase):
                 "aten::dequantize",
             },
         )
+
+    def test_quantized_relu_cut_dq(self):
+        """Basic test of the PyTorch quantized::relu Node on Glow, with quantize and dequantize excluded. """
+
+        def test_f(a):
+            q = torch.nn.quantized.Quantize(
+                scale=1.0 / 128, zero_point=3, dtype=torch.quint8
+            )
+            dq = torch.nn.quantized.DeQuantize()
+            re = torch.nn.quantized.ReLU()
+            return dq(re(q(a)))
+
+        x = torch.randn([5, 5])
+
+        jitVsGlow(
+            test_f,
+            x,
+            expected_fused_ops={
+                "aten::quantize_per_tensor",
+                "aten::relu",
+            },
+            black_list=[
+                "aten::dequantize",
+            ]
+        )


### PR DESCRIPTION
Summary:
We removed most rescales between int8 and uint8.
Need to add corresponding unit tests as well for all ops related.

notice: the rescale in conv&linear 's packed weight should not be removed since they are loaded in compile time instead of run time.

Reviewed By: jackm321

Differential Revision: D20061986

