### PR TITLE
Add ability to skip stripping the Module

### DIFF
--- a/include/glow/ExecutionEngine/ExecutionEngine.h
+++ b/include/glow/ExecutionEngine/ExecutionEngine.h
@@ -63,6 +63,10 @@ class ExecutionEngine final {
   /// the run.
   bool ensureOutputsOnHost_{true};
 
+  /// Whether to override the cctx's skipModuleStrip setting and skip stripping
+  /// the module. Used for testing purposes.
+  bool skipModuleStrip_{false};
+
   /// Single execution of the given function, \p name with the given context
   /// \bindings.
   void runInternal(ExecutionContext &context, llvm::StringRef name);
@@ -142,6 +146,9 @@ public:
   /// \returns the single Function contained in this Module.
   /// \pre Must be a single Function in the Module.
   Function *getSingleFunctionFromModule() const;
+
+  /// Setter for \ref skipModuleStrip_ to \p b.
+  void setSkipModuleStrip(bool b) { skipModuleStrip_ = b; }
 };
 
 //===----------------------------------------------------------------------===//

--- a/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
+++ b/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
@@ -160,6 +160,9 @@ struct CompilationContext {
   /// Call dumpDag on each Function passed to the backend for compilation.
   bool dumpFinalGraph = false;
 
+  /// Whether to skip stripping the module.
+  bool skipModuleStrip{false};
+
   CompilationContext(PlaceholderBindings *bindings_ = nullptr,
                      LoweredInfoMap *loweredInfoMap_ = nullptr)
       : bindings(bindings_), loweredInfoMap(loweredInfoMap_) {}

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -262,11 +262,18 @@ void glow::evalBatch(
 void ExecutionEngine::compile(CompilationMode mode) {
   CompilationContext cctx;
   cctx.compMode = mode;
+  if (skipModuleStrip_) {
+    cctx.skipModuleStrip = true;
+  }
   compile(cctx);
 }
 
 void ExecutionEngine::compile(CompilationContext &cctx) {
   assert(module_.get() && "Compile has already been called.");
+
+  if (skipModuleStrip_) {
+    cctx.skipModuleStrip = true;
+  }
 
   for (auto &function : module_->getFunctions()) {
     compiledFunctions_.insert(function->getName());

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -231,7 +231,9 @@ Error HostManager::addNetwork(std::unique_ptr<Module> module,
   // Clear constants contents from the module then put it in a
   // shared_ptr to be shared between all of the networks created from each
   // function in the module.
-  module->strip();
+  if (!cctx.skipModuleStrip) {
+    module->strip();
+  }
   auto sharedModule = std::shared_ptr<Module>(std::move(module));
   {
     std::unique_lock<std::shared_timed_mutex> networkLock(networkLock_);

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -37,6 +37,11 @@ class OperatorStatelessTest : public BackendStatelessTest {};
 class OperatorTest : public BackendTest {
 protected:
   PlaceholderBindings bindings_;
+  virtual void SetUp() override {
+    // Skip stripping the module so that we can inspect Constants after
+    // compilation.
+    EE_.setSkipModuleStrip(true);
+  }
 };
 
 /// Helper to create a Placeholder; if \p T is quantized, then it will include a


### PR DESCRIPTION
This is used in a future PR for testing exporting and importing in OperatorTest. For now just disable module stripping in OperatorTests.