### PR TITLE
Add correct type propagating in quantized nodes

### DIFF
--- a/torch_glow/src/CachingGraphRunner.h
+++ b/torch_glow/src/CachingGraphRunner.h
@@ -53,6 +53,13 @@ class CachingGraphRunner {
   std::unordered_map<size_t, std::shared_ptr<PerGlowGraphInfo>>
       perGlowGraphInfoMap_;
 
+  /// Indicate which type will propagate to output.
+  /// It is supposely to be the correct PyTorch ScalarType
+  /// in the corresponding JIT node for each output
+  /// placeholder from Glow graph.
+  /// Use for quantization int8/uint8 rescale.
+  std::vector<c10::ScalarType> outputCorrectType_;
+
   /// Given a PyTorch input stack \p stack, this generates a hash from the
   /// values on the stack and checks to see if a matching function was loaded
   /// previously. If a matching function was loaded previously then its cached

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -79,6 +79,9 @@ struct PyTorchLoaderSettings {
 /// Given a PyTorch ScalarType \p ty, \returns a matching Glow ElemKind.
 ElemKind scalarTypeToElemKind(c10::ScalarType ty);
 
+// Given a Glow ElemKind \p ty, \returns a matching PyTorch ScalarType.
+c10::ScalarType elemKindToScalarType(glow::ElemKind ty);
+
 /// Given a c10 typekind \p ty, \returns a matching Glow ElemKind.
 ElemKind typeKindToElemKind(c10::TypeKind ty);
 

--- a/torch_glow/src/PyTorchFileLoader.cpp
+++ b/torch_glow/src/PyTorchFileLoader.cpp
@@ -73,9 +73,14 @@ Error loadJitGraphToGlowFunction(
   const auto numInputs = graphInputs.size();
   auto inputs = torch::jit::last(stack, numInputs);
 
+  // FileLoader not yet support quantized inputs/outputs.
+  // These is just dummy type vectors for API.
+  std::vector<c10::ScalarType> dummyOutputType;
+
   // Load JIT Graph into Glow Function.
   RETURN_IF_ERR(PyTorchModelLoader::loadJITGraph(
-      f, graph, inputPlaceholders, outputPlaceholders, settings, inputs, {}));
+      f, graph, inputPlaceholders, outputPlaceholders, dummyOutputType,
+      settings, inputs, {}));
 
   // Remove from stack input parameters.
   torch::jit::drop(stack, numInputs);

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -51,6 +51,10 @@ class ValueMapping {
   /// Tag of which member is valid. Only one member is valid at a time.
   ValueMappingType mappingType_;
 
+  // The original data type of this jit value in PyTorch.
+  // Useful when we quantize an uint8 PyTorch tensor to int8 in Glow.
+  c10::ScalarType correctType_;
+
   /// Members that store either a NodeValue or a pointer to a GlowIValue
   /// depending on what the PyTorch Value being mapped is.
   NodeValue nodeValue_;
@@ -59,6 +63,13 @@ class ValueMapping {
 public:
   /// \returns the ValueMappingType representing the type that is mapped.
   ValueMappingType getMappingType() const;
+
+  /// \return the correctType_ representing the original PyTorch data type.
+  c10::ScalarType getCorrectType() const;
+
+  /// Set the correctType_ to be \p dtype.
+  /// \returns error on failure.
+  void setCorrectType(c10::ScalarType dtype);
 
   /// Create a ValueMapping from a NodeValue \p nodeValue. \p wasFrozen should
   /// be set to true if this NodeValue comes from weight freezing.
@@ -180,6 +191,7 @@ public:
   loadJITGraph(glow::Function &F, const torch::jit::Graph &graph,
                std::vector<glow::Placeholder *> &inputPlaceholders,
                std::vector<glow::Placeholder *> &outputPlaceholders,
+               std::vector<c10::ScalarType> &outputCorrectType,
                const PyTorchLoaderSettings &settings,
                const at::ArrayRef<torch::jit::IValue> inputs,
                const std::vector<InputMeta> &inputMeta);
@@ -205,6 +217,7 @@ private:
   PyTorchModelLoader(glow::Function &F, const torch::jit::Graph &graph,
                      std::vector<glow::Placeholder *> &inputPlaceholders,
                      std::vector<glow::Placeholder *> &outputPlaceholders,
+                     std::vector<c10::ScalarType> &outputCorrectType,
                      Error &error, const PyTorchLoaderSettings &settings,
                      std::set<size_t> *frozenInputIndices,
                      const at::ArrayRef<torch::jit::IValue> inputs,
@@ -238,12 +251,33 @@ public:
   Error addValueMapping(const torch::jit::Value *value,
                         glow::NodeValue nodeValue, bool wasFrozen = false);
 
+  /// Add a new mapping from the PyTorch Value \p value and its original type in
+  /// PyTorch \p correctType to the Glow NodeValue \p nodeValue. Set \p
+  /// wasFrozen to true if this comes from a from a frozen input. \returns error
+  /// on failure.
+  Error addValueMapping(const torch::jit::Value *value,
+                        glow::NodeValue nodeValue, c10::ScalarType correctType,
+                        bool wasFrozen = false);
+
   /// Add a new mapping from the PyTorch Value \p value to the GlowIValue
   /// \p glowIValue. Set \p wasFrozen to true if this comes from a from a frozen
   /// input.
   /// \returns error on failure.
   Error addValueMapping(const torch::jit::Value *value,
                         glow::GlowIValue glowIValue, bool wasFrozen = false);
+
+  /// Add a new mapping from the PyTorch Value \p value and its original type in
+  /// PyTorch \p correctType to the Glow IValue \p nodeValue. Set \p wasFrozen
+  /// to true if this comes from a from a frozen input.
+  /// \returns error on failure.
+  Error addValueMapping(const torch::jit::Value *value,
+                        glow::GlowIValue glowIValue,
+                        c10::ScalarType correctType, bool wasFrozen = false);
+
+  /// Get the correctType of \p src from valueMap_, and save it to \p dest.
+  /// \returns error on failure.
+  Error getCorrectTypeMapping(c10::ScalarType &dest,
+                              const torch::jit::Value *src);
 
   /// Remove any ValueMapping associated with \p value.
   void removeValueMapping(const torch::jit::Value *value);


### PR DESCRIPTION
Summary:
This diff add "correct type" propagating in all quantization supported nodes.
this propagating process make sure we can always have the original pytorch type in glow backend, in case we are trying to recover it (like rescale quantized tensor).

Differential Revision: D20062483

