### PR TITLE
Put back torch_glow CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,10 +93,10 @@ jobs:
     environment:
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:283"
     <<: *linux_default
-  # PYTORCH:
-  #   environment:
-  #     DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py3.6-clang7-ubuntu16.04:287"
-  #   <<: *linux_default
+  PYTORCH:
+    environment:
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py3.6-clang7-ubuntu16.04:287"
+    <<: *linux_default
   CHECK_CLANG_AND_PEP8_FORMAT:
     environment:
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang6.0-ubuntu16.04:230"
@@ -111,5 +111,5 @@ workflows:
       - TSAN
       - 32B_DIM_T
       - RELEASE_WITH_EXPENSIVE_TESTS
-      # - PYTORCH
+      - PYTORCH
       - CHECK_CLANG_AND_PEP8_FORMAT

--- a/torch_glow/src/binding.cpp
+++ b/torch_glow/src/binding.cpp
@@ -24,7 +24,6 @@
 #include <pybind11/pybind11.h>
 /// Required include files for a proper binding TorchGlowTrainingWrapper class.
 #include <pybind11/stl.h>
-#include <torch/csrc/utils/pybind.h>
 
 #include "glow/Graph/Graph.h"
 


### PR DESCRIPTION
Summary:
Fixing the undefined symbol issue by avoiding including `autograd/python_variable.h` transitively, where it declares an `extern PyObject *THPVariableClass;` which is dangling. 

Documentation:

[Optional Fixes #issue]

Test Plan:

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
