### PR TITLE
Refactored image classifier so that common parts can be used by other apps

### DIFF
--- a/tools/loader/CMakeLists.txt
+++ b/tools/loader/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_executable(image-classifier
   Loader.cpp
-  ImageClassifier.cpp)
+  ImageClassifier.cpp
+  ExecutorCore.cpp
+  ExecutorCoreHelperFunctions.cpp)
 
 target_link_libraries(image-classifier
                       PRIVATE

--- a/tools/loader/ExecutorCore.h
+++ b/tools/loader/ExecutorCore.h
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef GLOW_TOOLS_LOADER_EXECUTOR_CORE_H
+#define GLOW_TOOLS_LOADER_EXECUTOR_CORE_H
+
+#include "Loader.h"
+#include "glow/Graph/Nodes.h"
+
+namespace glow {
+class PostProcessOutputDataExtension {
+public:
+  /// Called once per mini-batch after network is executed to post process
+  /// output(s).
+  virtual int
+  processOutputs(const llvm::StringMap<Placeholder *> &PHM,
+                 PlaceholderBindings &bindings,
+                 llvm::ArrayRef<std::string> inputImageBatchFilenames) = 0;
+  virtual ~PostProcessOutputDataExtension(){};
+};
+
+class PreProcessInputDataExtension {
+public:
+  /// Called once per batch after images are loaded in to Tensor.
+  virtual void processInputTensor(Tensor &inputImageData, size_t startId,
+                                  size_t endId, size_t batchSz) = 0;
+  virtual ~PreProcessInputDataExtension(){};
+};
+
+class Executor final {
+public:
+  Executor(std::string appName) : appName_(appName){};
+  Executor() = delete;
+  Executor(const Executor &) = delete;
+  Executor &operator=(const Executor &) = delete;
+  /// Registers a Loader Extension that will be invoked after model is
+  /// loaded. If multiple extensions are registered they will be executed in
+  /// order they were registered.
+  void registerLoaderExtension(
+      std::function<std::unique_ptr<LoaderExtension>()> func);
+  /// Registers an extension that will be invoked on Tensor containing current
+  /// batch of input data. If multiple extensions are registered they will be
+  /// executed in order they were registered.
+  /// A new instance of the extension will be created for each thread.
+  void registerInputDataPreProcessingExtension(
+      std::function<std::unique_ptr<PreProcessInputDataExtension>()> func);
+  /// Registers extension that will be invoked for each execution of the
+  /// network. If multiple extensions are registered they will be executed in
+  /// order they were registered.
+  /// A new instance of the extension will be created for each thread.
+  void registerPostProcessOutputExtension(
+      std::function<std::unique_ptr<PostProcessOutputDataExtension>()> func);
+  /// This will parse command line, load, build and execute a network.
+  /// Returns /p 0 if no errors occured, others none zero value.
+  int executeNetwork(int argc, char **argv);
+
+private:
+  /// Iterates over lambda expressions and registers them with each instance of
+  /// a loader in main dispatch loop.
+  void addLoaderExtensions(Loader &ld);
+
+private:
+  std::vector<std::function<std::unique_ptr<PreProcessInputDataExtension>()>>
+      ppInputDataExtensions_;
+  std::vector<std::function<std::unique_ptr<PostProcessOutputDataExtension>()>>
+      ppOutputDataExtensions_;
+  std::vector<std::function<std::unique_ptr<LoaderExtension>()>>
+      loaderextensions_;
+  std::string appName_;
+};
+
+} // namespace glow
+#endif // GLOW_TOOLS_LOADER_EXECUTOR_CORE_H

--- a/tools/loader/ExecutorCoreHelperFunctions.cpp
+++ b/tools/loader/ExecutorCoreHelperFunctions.cpp
@@ -1,0 +1,410 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/Base/Image.h"
+#include "glow/Converter/TypeAToTypeBFunctionConverter.h"
+#include "glow/Graph/Nodes.h"
+#include "glow/Importer/Caffe2ModelLoader.h"
+#include "glow/Importer/ONNXModelLoader.h"
+
+#include "llvm/ADT/StringSwitch.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/Format.h"
+#include "llvm/Support/Timer.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <atomic>
+#include <cfloat>
+#include <fstream>
+#include <future>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <sstream>
+#include <thread>
+
+#include "ExecutorCoreHelperFunctions.h"
+
+using namespace glow;
+
+/// Image loader options.
+llvm::cl::OptionCategory executorCat("Executor Options");
+llvm::cl::list<std::string> inputImageFilenames(
+    llvm::cl::Positional,
+    llvm::cl::desc("<input files> (note: specifying '-' enables streaming "
+                   "mode, where the model is compiled once and then can be run "
+                   "many times with new input filenames passed via stdin)"),
+    llvm::cl::ZeroOrMore);
+
+llvm::cl::opt<std::string> inputImageListFile(
+    "input-image-list-file",
+    llvm::cl::desc(
+        "Name of the file containing list of images (one image per line)"),
+    llvm::cl::value_desc("string_name"), llvm::cl::Optional,
+    llvm::cl::cat(executorCat));
+
+llvm::cl::opt<unsigned> miniBatch(
+    "minibatch",
+    llvm::cl::desc(
+        "Size of mini-batches. Split the input image list into a set of "
+        "mini-batches. The input model is compiled for an input tensor batch "
+        "size equal to the specified mini-batch size and mini-batches of "
+        "images are inferred separately. The number of input images must be a "
+        "multiple of the mini-batch size. By default, splitting the input "
+        "image list into mini-batches is deactivated."),
+    llvm::cl::Optional, llvm::cl::init(0), llvm::cl::cat(executorCat));
+
+llvm::cl::opt<unsigned> miniBatchThreads(
+    "minibatch-threads",
+    llvm::cl::desc(
+        "Max number of threads used to process mini-batches. If "
+        "minibatch-threads is greater than 1, and we are working in minibatch "
+        "mode, then several worker threads are created to process the "
+        "minibatches. Then the minibatches are distributed between these "
+        "threads, and each thread processes its set of minibatches "
+        "independently."
+        " By default, the number of threads is 1, and no parallelization is "
+        "happening. These are things to be aware of:\n"
+        "\t- The actual number of worker threads can be less than specified by "
+        "this option (for example, if specified number of threads is greater "
+        "than number of minibatches to process). Their number may also be "
+        "forced to 1 in some cases (see below);\n"
+        "\t- Currently, dumping profile and emitting bundle force "
+        "single-threaded mode;\n"
+        "\t- If a model has operations that make reduction across images in "
+        "the batch, it is a user's responsibility to make sure that this model "
+        "is  not processed in multi-threaded mode. Otherwise, the correctness "
+        "of  results is not guaranteed."),
+    llvm::cl::Optional, llvm::cl::init(1), llvm::cl::cat(executorCat));
+
+llvm::cl::opt<unsigned> poolSize(
+    "pool-size",
+    llvm::cl::desc("Size of context pool for the benchmark; default:10"),
+    llvm::cl::Optional, llvm::cl::init(10), llvm::cl::cat(executorCat));
+
+llvm::cl::opt<std::string> modelInputName(
+    "model-input-name",
+    llvm::cl::desc("The name of the variable for the model's input image."),
+    llvm::cl::value_desc("string_name"), llvm::cl::Required,
+    llvm::cl::cat(executorCat));
+
+llvm::cl::opt<bool> convertInAndOutToFp16(
+    "convert-inout-to-fp16",
+    llvm::cl::desc(
+        "Convert the input and output tensors of the network to fp16"),
+    llvm::cl::cat(executorCat));
+
+llvm::cl::opt<std::string> tracePath("trace-path",
+                                     llvm::cl::desc("Write trace logs to disk"),
+                                     llvm::cl::init(""),
+                                     llvm::cl::cat(executorCat));
+
+llvm::cl::opt<bool>
+    autoInstrument("auto-instrument",
+                   llvm::cl::desc("Add instrumentation for operator tracing"),
+                   llvm::cl::Optional, llvm::cl::init(false),
+                   llvm::cl::cat(executorCat));
+
+llvm::cl::opt<unsigned> traceLevel(
+    "trace-level",
+    llvm::cl::desc(
+        "Set tracing level (bit-field, see TraceEvents.h for details)"),
+    llvm::cl::Optional, llvm::cl::init((unsigned)TraceLevel::NONE),
+    llvm::cl::cat(executorCat));
+
+llvm::cl::opt<unsigned> warmup(
+    "warmup", llvm::cl::desc("How many passes to do to warm everything up"),
+    llvm::cl::init(0), llvm::cl::value_desc("W"), llvm::cl::cat(executorCat));
+
+llvm::cl::opt<unsigned> excludedFirstWarmupRuns(
+    "excluded-first-warmup-runs",
+    llvm::cl::desc("Exclude the time of the given number of first warmup runs "
+                   "from the total time"),
+    llvm::cl::Optional, llvm::cl::init(0), llvm::cl::cat(executorCat));
+
+/// Read all images from \p inputImageListFile in to \p inputImageFilenames.
+void parseInputImageList(const std::string &inputImageListFile) {
+  std::ifstream inFile;
+  inFile.open(inputImageListFile);
+  if (!inFile.good()) {
+    llvm::outs() << "Could not open input-image-list-file: "
+                 << inputImageListFile << ", exiting.\n";
+    std::exit(1);
+  }
+
+  while (!inFile.eof()) {
+    std::string img;
+    getline(inFile, img);
+    if (!img.empty()) {
+      inputImageFilenames.push_back(img);
+    }
+  }
+  inFile.close();
+}
+
+/// Write a prompt to stdout asking for filenames for classification. Read in
+/// those filenames and add them to \p filenames. \p filenames is cleared before
+/// adding the new set of filenames from stdin. \returns false if the passed in
+/// line was empty.
+bool getNextImageFilenames(std::vector<std::string> *filenames) {
+  // Clear out old filenames before adding new ones.
+  filenames->clear();
+
+  llvm::outs() << "Enter image filenames to classify: ";
+
+  // Add in each filename to the vector.
+  std::string filenamesRaw;
+  getline(std::cin, filenamesRaw);
+  std::istringstream iss(filenamesRaw);
+  std::string filename;
+  while (iss >> filename) {
+    filenames->push_back(filename);
+  }
+
+  return !filenames->empty();
+}
+
+/// Generate in \p imageList the list of filenames corresponding to the next
+/// mini-batch of size \p miniBatchSize extracted from \p totalImageList at
+/// index \p minibatchIndex. /returns true if the index is valid, false
+/// otherwise. In case the function returns true, \p minibatchIndex is
+/// incremented by \p miniBatchSize. Stop upon reaching \p miniBatchLimit.
+bool getNextMiniBatch(std::vector<std::string> &imageList,
+                      std::vector<std::string> &totalImageList,
+                      size_t &miniBatchIndex, size_t miniBatchSize,
+                      size_t miniBatchLimit) {
+  if (miniBatchIndex >= miniBatchLimit) {
+    return false;
+  }
+  imageList.clear();
+  size_t endIndex = miniBatchIndex + miniBatchSize;
+  for (size_t index = miniBatchIndex; index < endIndex; index++) {
+    imageList.push_back(totalImageList[index]);
+  }
+  miniBatchIndex += miniBatchSize;
+  return true;
+}
+
+/// Creates and \returns the ProtobufLoader given \p loader and the
+/// \p inputImageType. Note that this must come after loading images for
+/// inference so that \p inputImageType is known.
+static std::unique_ptr<ProtobufLoader>
+createProtobufLoader(Loader &loader, TypeRef inputImageType) {
+  // The image name that the model expects must be passed on the command line.
+  const char *inputName = modelInputName.c_str();
+
+  // Create the model based on the input model format.
+  std::unique_ptr<ProtobufLoader> LD;
+  bool c2Model = !loader.getCaffe2NetDescFilename().empty();
+  if (c2Model) {
+    LD.reset(new Caffe2ModelLoader(
+        loader.getCaffe2NetDescFilename(), loader.getCaffe2NetWeightFilename(),
+        {inputName}, {inputImageType}, *loader.getFunction()));
+  } else {
+    LD.reset(new ONNXModelLoader(loader.getOnnxModelFilename(), {inputName},
+                                 {inputImageType}, *loader.getFunction()));
+  }
+
+  return LD;
+}
+
+/// Populates a map from the ProtobufLoader.
+static void populateOutMap(std::unique_ptr<ProtobufLoader> &LD,
+                           llvm::StringMap<Placeholder *> &OutMap) {
+  auto &ldOutMap = LD->getOutputVarsMapping();
+  for (auto &entry : ldOutMap) {
+    OutMap[entry.getKey()] = entry.second;
+  }
+}
+
+/// Given \p loader, the \p bindings, and \p inputImageType, build the graph
+/// from the provided protobuf file found via \p loader. Then compiles and
+/// \returns a pair of pointers to the input Placeholder and output Nodes Map.
+std::pair<Placeholder *, llvm::StringMap<Placeholder *>>
+buildAndCompileAndGetInAndOutPair(Loader &loader, PlaceholderBindings &bindings,
+                                  TypeRef inputImageType) {
+  auto LD = createProtobufLoader(loader, inputImageType);
+  llvm::StringMap<Placeholder *> outMap;
+  populateOutMap(LD, outMap);
+  loader.postModelLoad(bindings, *LD.get(), outMap, inputImageType->dims()[0]);
+
+  // Allocate tensors to back all inputs and outputs.
+  bindings.allocate(loader.getModule()->getPlaceholders());
+
+  // Convert the placeholders for now. The backing Tensor's data will be
+  // converted later.
+  if (convertInAndOutToFp16) {
+    PrecisionConfiguration precConfig;
+    TypeAToTypeBFunctionConverter converter(*loader.getFunction(),
+                                            ElemKind::FloatTy,
+                                            ElemKind::Float16Ty, precConfig);
+    for (auto *placeholder : loader.getModule()->getPlaceholders()) {
+      converter.convertPlaceholder(*placeholder, &bindings);
+    }
+  }
+
+  // Compile the model, and perform quantization/emit a bundle/dump debug info
+  // if requested from command line.
+  CompilationContext cctx = loader.getCompilationContext();
+  cctx.bindings = &bindings;
+  cctx.backendOpts.autoInstrument = autoInstrument;
+  loader.compile(cctx);
+
+  // The image name that the model expects must be passed on the command line.
+  const char *inputName = modelInputName.c_str();
+  Placeholder *inputImagePH =
+      llvm::cast<Placeholder>(EXIT_ON_ERR(LD->getNodeValueByName(inputName)));
+
+  return std::make_pair(inputImagePH, outMap);
+}
+
+/// Setup the pool of contexts needed for a benchmark run.
+std::vector<std::unique_ptr<ExecutionContext>>
+setupContextPool(const std::vector<Placeholder *> outputPHV,
+                 Placeholder *inputImagePH, glow::Tensor &inputImageData) {
+  std::vector<std::unique_ptr<ExecutionContext>> contexts;
+  // Size of the pool, the smaller of poolSize or the actual number of
+  // requests.
+  unsigned iterations =
+      miniBatch ? std::min(int(poolSize), int(iterationsOpt / miniBatch)) : 1;
+  // Setup pool of inference requests to be run.
+  for (unsigned i = 0; i < iterations; i++) {
+    auto newContext = glow::make_unique<ExecutionContext>();
+    newContext->setTraceContext(glow::make_unique<TraceContext>(traceLevel));
+    auto ph = newContext->getPlaceholderBindings();
+    ph->insert(inputImagePH, Tensor(inputImageData.getType()));
+    for (auto *outputPH : outputPHV) {
+      ph->allocate(outputPH);
+    }
+    contexts.push_back(std::move(newContext));
+  }
+  return contexts;
+}
+
+std::mutex eventLock;
+std::unique_ptr<TraceContext> traceContext;
+
+/// Run inference request on HostManager. This method builds a runNetwork
+/// request for the \p hostManager, this is a recursive call, in the callback
+/// provided to the HostManager this function can call itself if the desired
+/// number of warmups and requests has not yet been dispatched.
+static void runInference(runtime::HostManager *hostManager, std::string name,
+                         std::unique_ptr<ExecutionContext> batch,
+                         std::promise<void> &runPromise,
+                         std::atomic<unsigned> &inflight,
+                         std::atomic<int> &dispatched, unsigned warmUp,
+                         llvm::Timer *restRunsTimer = nullptr,
+                         llvm::Timer *firstRunsTimer = nullptr,
+                         double *bestRunTime = nullptr) {
+  static std::atomic<unsigned> firstRunsDone(0);
+  auto start = TraceEvent::now();
+  if (firstRunsTimer != nullptr && !firstRunsTimer->isRunning() &&
+      firstRunsDone < excludedFirstWarmupRuns) {
+    firstRunsTimer->startTimer();
+  } else if (restRunsTimer != nullptr &&
+             firstRunsDone >= excludedFirstWarmupRuns &&
+             !restRunsTimer->hasTriggered()) {
+    restRunsTimer->startTimer();
+  }
+
+  llvm::Timer *bestRunTimer = nullptr;
+  if (bestRunTime != nullptr) {
+    bestRunTimer = new llvm::Timer("Best Run", "Best Inference Run");
+    bestRunTimer->startTimer();
+  }
+
+  hostManager->runNetwork(
+      name, std::move(batch),
+      [&runPromise, &inflight, &dispatched, hostManager, name, warmUp,
+       restRunsTimer, firstRunsTimer, bestRunTime, bestRunTimer,
+       start](runtime::RunIdentifierTy, Error err,
+              std::unique_ptr<ExecutionContext> contextPtr) {
+        EXIT_ON_ERR(std::move(err));
+        if (!tracePath.empty()) {
+          if (!warmUp) {
+            std::lock_guard<std::mutex> l(eventLock);
+            // Temporary (AIBench relies on inference_e2e metric)
+            // Later we switch AIBench to the metric from
+            // HostManager::dispatchNextRun()
+            traceContext->logCompleteTraceEvent("inference_e2e",
+                                                TraceLevel::RUNTIME, start);
+            // Merge this run's TraceEvents into the global
+            // TraceContext.
+            traceContext->merge(contextPtr->getTraceContext());
+          } else {
+            contextPtr->getTraceContext()->getTraceEvents().clear();
+          }
+        }
+        firstRunsDone++;
+        if (firstRunsTimer != nullptr && firstRunsTimer->isRunning() &&
+            firstRunsDone == excludedFirstWarmupRuns) {
+          firstRunsTimer->stopTimer();
+        }
+        if (bestRunTime != nullptr) {
+          bestRunTimer->stopTimer();
+          double wallTime = bestRunTimer->getTotalTime().getWallTime();
+          if (wallTime < *bestRunTime)
+            *bestRunTime = wallTime;
+          bestRunTimer->clear();
+          delete bestRunTimer;
+        }
+
+        // Kick off another run.
+        if (dispatched.fetch_sub(1) > 0) {
+          inflight++;
+          runInference(hostManager, name, std::move(contextPtr), runPromise,
+                       inflight, dispatched, warmUp > 0 ? warmUp - 1 : 0,
+                       restRunsTimer, firstRunsTimer, bestRunTime);
+        } else if (restRunsTimer != nullptr) {
+          restRunsTimer->stopTimer();
+        }
+
+        if (--inflight == 0) {
+          runPromise.set_value();
+        }
+      });
+}
+
+/// Run the requested number of benchmark requests \p requestCount prepended by
+/// \p warmUp cycles
+/// through the HostManager from the \p loader using the provided context pool
+/// \p contexts and wait for all runs to complete.
+void runBenchmark(std::string name, Loader &loader,
+                  std::vector<std::unique_ptr<ExecutionContext>> contexts,
+                  unsigned requestCount, unsigned warmUp,
+                  llvm::Timer *restRunsTimer = nullptr,
+                  llvm::Timer *firstRunsTimer = nullptr,
+                  double *bestRunTime = nullptr) {
+  runtime::HostManager *hostManager = loader.getHostManager();
+  std::atomic<unsigned> inflight(0);
+  std::atomic<int> dispatched(requestCount + warmUp * contexts.size());
+  std::promise<void> runPromise;
+  auto fut = runPromise.get_future();
+
+  // Kick off initial pool of requests.
+  for (size_t i = 0, e = contexts.size(); i < e; i++) {
+    auto batch = std::move(contexts[i]);
+    inflight++;
+    dispatched--;
+    runInference(hostManager, name, std::move(batch), runPromise, inflight,
+                 dispatched, warmUp, restRunsTimer, firstRunsTimer,
+                 bestRunTime);
+  }
+
+  // Wait for all to finish.
+  fut.wait();
+}

--- a/tools/loader/ExecutorCoreHelperFunctions.h
+++ b/tools/loader/ExecutorCoreHelperFunctions.h
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef GLOW_TOOLS_LOADER_EXECUTOR_CORE_HELPER_FUNCTIONS_H
+#define GLOW_TOOLS_LOADER_EXECUTOR_CORE_HELPER_FUNCTIONS_H
+
+#include "Loader.h"
+#include "glow/Graph/Nodes.h"
+#include "llvm/ADT/StringMap.h"
+
+extern llvm::cl::opt<std::string> inputImageListFile;
+extern llvm::cl::list<std::string> inputImageFilenames;
+extern llvm::cl::opt<unsigned> excludedFirstWarmupRuns;
+extern llvm::cl::opt<unsigned> warmup;
+extern llvm::cl::opt<std::string> tracePath;
+extern llvm::cl::opt<bool> convertInAndOutToFp16;
+extern llvm::cl::opt<unsigned> miniBatch;
+extern llvm::cl::opt<unsigned> miniBatchThreads;
+
+extern std::unique_ptr<glow::TraceContext> traceContext;
+
+/// Read all images from \p inputImageListFile in to \p inputImageFilenames.
+void parseInputImageList(const std::string &inputImageListFile);
+
+/// Write a prompt to stdout asking for filenames for classification. Read in
+/// those filenames and add them to \p filenames. \p filenames is cleared before
+/// adding the new set of filenames from stdin. \returns false if the passed in
+/// line was empty.
+bool getNextImageFilenames(std::vector<std::string> *filenames);
+
+/// Generate in \p imageList the list of filenames corresponding to the next
+/// mini-batch of size \p miniBatchSize extracted from \p totalImageList at
+/// index \p minibatchIndex. /returns true if the index is valid, false
+/// otherwise. In case the function returns true, \p minibatchIndex is
+/// incremented by \p miniBatchSize. Stop upon reaching \p miniBatchLimit.
+bool getNextMiniBatch(std::vector<std::string> &imageList,
+                      std::vector<std::string> &totalImageList,
+                      size_t &miniBatchIndex, size_t miniBatchSize,
+                      size_t miniBatchLimit);
+
+/// Given \p loader, the \p bindings, and \p inputImageType, build the graph
+/// from the provided protobuf file found via \p loader. Then compiles and
+/// \returns a pair of pointers to the input Placeholder and output Nodes Map.
+std::pair<glow::Placeholder *, llvm::StringMap<glow::Placeholder *>>
+buildAndCompileAndGetInAndOutPair(glow::Loader &loader,
+                                  glow::PlaceholderBindings &bindings,
+                                  glow::TypeRef inputImageType);
+
+/// Setup the pool of contexts needed for a benchmark run.
+std::vector<std::unique_ptr<glow::ExecutionContext>>
+setupContextPool(const std::vector<glow::Placeholder *> outputPHV,
+                 glow::Placeholder *inputImagePH, glow::Tensor &inputImageData);
+
+/// Run the requested number of benchmark requests \p requestCount prepended by
+/// \p warmUp cycles
+/// through the HostManager from the \p loader using the provided context pool
+/// \p contexts and wait for all runs to complete.
+void runBenchmark(std::string name, glow::Loader &loader,
+                  std::vector<std::unique_ptr<glow::ExecutionContext>> contexts,
+                  unsigned requestCount, unsigned warmUp,
+                  llvm::Timer *restRunsTimer, llvm::Timer *firstRunsTimer,
+                  double *bestRunTime);
+#endif // GLOW_TOOLS_LOADER_EXECUTOR_CORE_HELPER_FUNCTIONS_H

--- a/tools/loader/ImageClassifier.cpp
+++ b/tools/loader/ImageClassifier.cpp
@@ -39,249 +39,40 @@
 #include <sstream>
 #include <thread>
 
+#include "ExecutorCore.h"
+#include "ExecutorCoreHelperFunctions.h"
+
 using namespace glow;
 
 namespace {
 
 /// Image loader options.
-llvm::cl::OptionCategory imageLoaderCat("Image Loader Options");
-llvm::cl::list<std::string> inputImageFilenames(
-    llvm::cl::Positional,
-    llvm::cl::desc("<input files> (note: specifying '-' enables streaming "
-                   "mode, where the model is compiled once and then can be run "
-                   "many times with new input filenames passed via stdin)"),
-    llvm::cl::ZeroOrMore);
-
-llvm::cl::opt<std::string> inputImageListFile(
-    "input-image-list-file",
-    llvm::cl::desc(
-        "Name of the file containing list of images (one image per line)"),
-    llvm::cl::value_desc("string_name"), llvm::cl::Optional,
-    llvm::cl::cat(imageLoaderCat));
-
-llvm::cl::opt<unsigned> miniBatch(
-    "minibatch",
-    llvm::cl::desc(
-        "Size of mini-batches. Split the input image list into a set of "
-        "mini-batches. The input model is compiled for an input tensor batch "
-        "size equal to the specified mini-batch size and mini-batches of "
-        "images are inferred separately. The number of input images must be a "
-        "multiple of the mini-batch size. By default, splitting the input "
-        "image list into mini-batches is deactivated."),
-    llvm::cl::Optional, llvm::cl::init(0), llvm::cl::cat(imageLoaderCat));
-
-llvm::cl::opt<unsigned> miniBatchThreads(
-    "minibatch-threads",
-    llvm::cl::desc(
-        "Max number of threads used to process mini-batches. If "
-        "minibatch-threads is greater than 1, and we are working in minibatch "
-        "mode, then several worker threads are created to process the "
-        "minibatches. Then the minibatches are distributed between these "
-        "threads, and each thread processes its set of minibatches "
-        "independently."
-        " By default, the number of threads is 1, and no parallelization is "
-        "happening. These are things to be aware of:\n"
-        "\t- The actual number of worker threads can be less than specified by "
-        "this option (for example, if specified number of threads is greater "
-        "than number of minibatches to process). Their number may also be "
-        "forced to 1 in some cases (see below);\n"
-        "\t- Currently, dumping profile and emitting bundle force "
-        "single-threaded mode;\n"
-        "\t- If a model has operations that make reduction across images in "
-        "the batch, it is a user's responsibility to make sure that this model "
-        "is  not processed in multi-threaded mode. Otherwise, the correctness "
-        "of  results is not guaranteed."),
-    llvm::cl::Optional, llvm::cl::init(1), llvm::cl::cat(imageLoaderCat));
+llvm::cl::OptionCategory imageClassifierCat("Image Loader Options");
 
 llvm::cl::opt<unsigned> labelOffset(
     "label-offset",
     llvm::cl::desc("Label offset for TF ONNX models with 1001 classes"),
-    llvm::cl::Optional, llvm::cl::init(0), llvm::cl::cat(imageLoaderCat));
+    llvm::cl::Optional, llvm::cl::init(0), llvm::cl::cat(imageClassifierCat));
 
-llvm::cl::opt<unsigned> poolSize(
-    "pool-size",
-    llvm::cl::desc("Size of context pool for the benchmark; default:10"),
-    llvm::cl::Optional, llvm::cl::init(10), llvm::cl::cat(imageLoaderCat));
-
-llvm::cl::opt<bool> computeSoftmax(
-    "compute-softmax", llvm::cl::desc("Compute softmax of the network output"),
-    llvm::cl::Optional, llvm::cl::init(false), llvm::cl::cat(imageLoaderCat));
+llvm::cl::opt<bool>
+    computeSoftmax("compute-softmax",
+                   llvm::cl::desc("Compute softmax of the network output"),
+                   llvm::cl::Optional, llvm::cl::init(false),
+                   llvm::cl::cat(imageClassifierCat));
 
 llvm::cl::opt<unsigned>
     topKCount("topk",
               llvm::cl::desc("Number of highest likelihood labels to print and "
                              "match the correspondent expected-lables"),
               llvm::cl::Optional, llvm::cl::init(1),
-              llvm::cl::cat(imageLoaderCat));
-
-llvm::cl::opt<std::string> modelInputName(
-    "model-input-name",
-    llvm::cl::desc("The name of the variable for the model's input image."),
-    llvm::cl::value_desc("string_name"), llvm::cl::Required,
-    llvm::cl::cat(imageLoaderCat));
-
-llvm::cl::opt<bool> convertInAndOutToFp16(
-    "convert-inout-to-fp16",
-    llvm::cl::desc(
-        "Convert the input and output tensors of the network to fp16"),
-    llvm::cl::cat(imageLoaderCat));
+              llvm::cl::cat(imageClassifierCat));
 
 llvm::cl::list<unsigned> expectedMatchingLabels(
     "expected-labels",
     llvm::cl::desc("The comma delimited list of the matching lables"),
     llvm::cl::value_desc("int"), llvm::cl::ZeroOrMore, llvm::cl::CommaSeparated,
-    llvm::cl::cat(imageLoaderCat));
-
-llvm::cl::opt<std::string> tracePath("trace-path",
-                                     llvm::cl::desc("Write trace logs to disk"),
-                                     llvm::cl::init(""),
-                                     llvm::cl::cat(imageLoaderCat));
-
-llvm::cl::opt<bool>
-    autoInstrument("auto-instrument",
-                   llvm::cl::desc("Add instrumentation for operator tracing"),
-                   llvm::cl::Optional, llvm::cl::init(false),
-                   llvm::cl::cat(imageLoaderCat));
-
-llvm::cl::opt<unsigned> traceLevel(
-    "trace-level",
-    llvm::cl::desc(
-        "Set tracing level (bit-field, see TraceEvents.h for details)"),
-    llvm::cl::Optional, llvm::cl::init((unsigned)TraceLevel::NONE),
-    llvm::cl::cat(imageLoaderCat));
-
-llvm::cl::opt<unsigned>
-    warmup("warmup",
-           llvm::cl::desc("How many passes to do to warm everything up"),
-           llvm::cl::init(0), llvm::cl::value_desc("W"),
-           llvm::cl::cat(imageLoaderCat));
-
-llvm::cl::opt<unsigned> excludedFirstWarmupRuns(
-    "excluded-first-warmup-runs",
-    llvm::cl::desc("Exclude the time of the given number of first warmup runs "
-                   "from the total time"),
-    llvm::cl::Optional, llvm::cl::init(0), llvm::cl::cat(imageLoaderCat));
-
-std::mutex eventLock;
-std::unique_ptr<TraceContext> traceContext;
-
+    llvm::cl::cat(imageClassifierCat));
 } // unnamed namespace
-
-/// Write a prompt to stdout asking for filenames for classification. Read in
-/// those filenames and add them to \p filenames. \p filenames is cleared before
-/// adding the new set of filenames from stdin. \returns false if the passed in
-/// line was empty.
-static bool getNextImageFilenames(std::vector<std::string> *filenames) {
-  // Clear out old filenames before adding new ones.
-  filenames->clear();
-
-  llvm::outs() << "Enter image filenames to classify: ";
-
-  // Add in each filename to the vector.
-  std::string filenamesRaw;
-  getline(std::cin, filenamesRaw);
-  std::istringstream iss(filenamesRaw);
-  std::string filename;
-  while (iss >> filename) {
-    filenames->push_back(filename);
-  }
-
-  return !filenames->empty();
-}
-
-/// Generate in \p imageList the list of filenames corresponding to the next
-/// mini-batch of size \p miniBatchSize extracted from \p totalImageList at
-/// index \p minibatchIndex. /returns true if the index is valid, false
-/// otherwise. In case the function returns true, \p minibatchIndex is
-/// incremented by \p miniBatchSize. Stop upon reaching \p miniBatchLimit.
-static bool getNextMiniBatch(std::vector<std::string> &imageList,
-                             std::vector<std::string> &totalImageList,
-                             size_t &miniBatchIndex, size_t miniBatchSize,
-                             size_t miniBatchLimit) {
-  if (miniBatchIndex >= miniBatchLimit) {
-    return false;
-  }
-  imageList.clear();
-  size_t endIndex = miniBatchIndex + miniBatchSize;
-  for (size_t index = miniBatchIndex; index < endIndex; index++) {
-    imageList.push_back(totalImageList[index]);
-  }
-  miniBatchIndex += miniBatchSize;
-  return true;
-}
-
-/// Creates and \returns the ProtobufLoader given \p loader and the
-/// \p inputImageType. Note that this must come after loading images for
-/// inference so that \p inputImageType is known.
-static std::unique_ptr<ProtobufLoader>
-createProtobufLoader(Loader &loader, TypeRef inputImageType) {
-  // The image name that the model expects must be passed on the command line.
-  const char *inputName = modelInputName.c_str();
-
-  // Create the model based on the input model format.
-  std::unique_ptr<ProtobufLoader> LD;
-  bool c2Model = !loader.getCaffe2NetDescFilename().empty();
-  if (c2Model) {
-    LD.reset(new Caffe2ModelLoader(
-        loader.getCaffe2NetDescFilename(), loader.getCaffe2NetWeightFilename(),
-        {inputName}, {inputImageType}, *loader.getFunction()));
-  } else {
-    LD.reset(new ONNXModelLoader(loader.getOnnxModelFilename(), {inputName},
-                                 {inputImageType}, *loader.getFunction()));
-  }
-
-  return LD;
-}
-
-/// Given \p loader, the \p bindings, and \p inputImageType, build the graph
-/// from the provided protobuf file found via \p loader. Then compiles and
-/// \returns a pair of pointers to the input Placeholder and output Placeholder
-/// for the Softmax.
-static std::pair<Placeholder *, Placeholder *>
-buildAndCompileAndGetInAndOutPair(Loader &loader, PlaceholderBindings &bindings,
-                                  TypeRef inputImageType) {
-  auto LD = createProtobufLoader(loader, inputImageType);
-  loader.postModelLoad(bindings, *LD.get(), inputImageType->dims()[0]);
-
-  // Allocate tensors to back all inputs and outputs.
-  bindings.allocate(loader.getModule()->getPlaceholders());
-
-  // Convert the placeholders for now. The backing Tensor's data will be
-  // converted later.
-  if (convertInAndOutToFp16) {
-    PrecisionConfiguration precConfig;
-    TypeAToTypeBFunctionConverter converter(*loader.getFunction(),
-                                            ElemKind::FloatTy,
-                                            ElemKind::Float16Ty, precConfig);
-    for (auto *placeholder : loader.getModule()->getPlaceholders()) {
-      converter.convertPlaceholder(*placeholder, &bindings);
-    }
-  }
-
-  // Compile the model, and perform quantization/emit a bundle/dump debug info
-  // if requested from command line.
-  CompilationContext cctx = loader.getCompilationContext();
-  cctx.bindings = &bindings;
-  cctx.backendOpts.autoInstrument = autoInstrument;
-  loader.compile(cctx);
-
-  // The image name that the model expects must be passed on the command line.
-  const char *inputName = modelInputName.c_str();
-  Placeholder *inputImagePH =
-      llvm::cast<Placeholder>(EXIT_ON_ERR(LD->getNodeValueByName(inputName)));
-
-  // When profiling the graph do not return the output placeholder. This allows
-  // profiling SSD models which have two output placeholders (scores and boxes).
-  if (profilingGraph()) {
-    return std::make_pair(inputImagePH, nullptr);
-  }
-
-  // Get the Tensor from the Placeholder that the final expected Softmax writes
-  // into at the end of image inference.
-  Placeholder *SMPH = EXIT_ON_ERR(LD->getSingleOutput());
-
-  return std::make_pair(inputImagePH, SMPH);
-}
 
 /// A pair representing a float and the index where the float was found.
 using FloatIndexPair = std::pair<float, size_t>;
@@ -402,7 +193,9 @@ static int processAndPrintResultsImpl(Tensor *SMT,
   int retVal = 0;
   for (unsigned i = 0; i < imageList.size(); i++) {
     const auto &fileName = imageList[i];
-    llvm::outs() << " File: " << fileName;
+    if (topKCount) {
+      llvm::outs() << " File: " << fileName;
+    }
 
     // batchSize is the first dimension, so update it to get the next slice.
     sliceOffset[0] = i;
@@ -413,22 +206,45 @@ static int processAndPrintResultsImpl(Tensor *SMT,
       applySoftmax(SH);
     }
 
-    auto topKPairs = getTopKPairs(SH);
-    printTopKPairs(topKPairs);
-    if (!expectedMatchingLabels.empty()) {
-      retVal +=
-          checkExpectedLabel(topKPairs, fileName, expectedMatchingLabels[i]);
+    if (topKCount) {
+      auto topKPairs = getTopKPairs(SH);
+      printTopKPairs(topKPairs);
+      if (!expectedMatchingLabels.empty()) {
+        retVal +=
+            checkExpectedLabel(topKPairs, fileName, expectedMatchingLabels[i]);
+      }
     }
   }
 
   return retVal;
 }
 
-/// Given the output Softmax Tensor \p SMT and \p functionName, switch between
-/// the correct element type to print the results of inference as contained in
-/// \p SMT, \returns the number of found mismatches.
-static int processAndPrintResults(Tensor *SMT,
-                                  llvm::ArrayRef<std::string> imageList) {
+class ImageClassifierProcessResult : public PostProcessOutputDataExtension {
+public:
+  int processOutputs(
+      const llvm::StringMap<Placeholder *> &PHM, PlaceholderBindings &bindings,
+      llvm::ArrayRef<std::string> inputImageBatchFilenames) override;
+};
+
+/// Given the output PlaceHolder StringMap \p PHM, of size 1, from SoftMax and
+/// \p functionName, switch between the correct element type to print the
+/// results of inference as contained in \p PHM, \returns the number of found
+/// mismatches.
+int ImageClassifierProcessResult::processOutputs(
+    const llvm::StringMap<Placeholder *> &PHM, PlaceholderBindings &bindings,
+    llvm::ArrayRef<std::string> imageList) {
+
+  if (profilingGraph()) {
+    LOG(INFO) << "Graph profiling is ON. Processing of output is disabled.";
+    return 0;
+  }
+
+  if (PHM.size() > 1) {
+    LOG(FATAL) << "Network has more then one output. Process results not "
+                  "run for ImageClassifier.";
+  }
+
+  auto *SMT = bindings.get(PHM.begin()->second);
   switch (SMT->getElementType()) {
   case ElemKind::FloatTy:
     return processAndPrintResultsImpl<float>(SMT, imageList);
@@ -437,195 +253,10 @@ static int processAndPrintResults(Tensor *SMT,
   default:
     llvm_unreachable("Type not supported");
   }
-}
-
-/// Read all images from \p inputImageListFile in to \p inputImageFilenames.
-static void parseInputImageList(const std::string &inputImageListFile) {
-  std::ifstream inFile;
-  inFile.open(inputImageListFile);
-  if (!inFile.good()) {
-    llvm::outs() << "Could not open input-image-list-file: "
-                 << inputImageListFile << ", exiting.\n";
-    std::exit(1);
-  }
-
-  while (!inFile.eof()) {
-    std::string img;
-    getline(inFile, img);
-    if (!img.empty()) {
-      inputImageFilenames.push_back(img);
-    }
-  }
-  inFile.close();
-}
-
-/// Run inference request on HostManager. This method builds a runNetwork
-/// request for the \p hostManager, this is a recursive call, in the callback
-/// provided to the HostManager this function can call itself if the desired
-/// number of warmups and requests has not yet been dispatched.
-static void runInference(runtime::HostManager *hostManager, std::string name,
-                         std::unique_ptr<ExecutionContext> batch,
-                         std::promise<void> &runPromise,
-                         std::atomic<unsigned> &inflight,
-                         std::atomic<int> &dispatched, unsigned warmUp,
-                         llvm::Timer *restRunsTimer = nullptr,
-                         llvm::Timer *firstRunsTimer = nullptr,
-                         double *bestRunTime = nullptr) {
-  static std::atomic<unsigned> firstRunsDone(0);
-  auto start = TraceEvent::now();
-  if (firstRunsTimer != nullptr && !firstRunsTimer->isRunning() &&
-      firstRunsDone < excludedFirstWarmupRuns) {
-    firstRunsTimer->startTimer();
-  } else if (restRunsTimer != nullptr &&
-             firstRunsDone >= excludedFirstWarmupRuns &&
-             !restRunsTimer->hasTriggered()) {
-    restRunsTimer->startTimer();
-  }
-
-  llvm::Timer *bestRunTimer = nullptr;
-  if (bestRunTime != nullptr) {
-    bestRunTimer = new llvm::Timer("Best Run", "Best Inference Run");
-    bestRunTimer->startTimer();
-  }
-
-  hostManager->runNetwork(
-      name, std::move(batch),
-      [&runPromise, &inflight, &dispatched, hostManager, name, warmUp,
-       restRunsTimer, firstRunsTimer, bestRunTime, bestRunTimer,
-       start](runtime::RunIdentifierTy, Error err,
-              std::unique_ptr<ExecutionContext> contextPtr) {
-        EXIT_ON_ERR(std::move(err));
-        if (!tracePath.empty()) {
-          if (!warmUp) {
-            std::lock_guard<std::mutex> l(eventLock);
-            // Temporary (AIBench relies on inference_e2e metric)
-            // Later we switch AIBench to the metric from
-            // HostManager::dispatchNextRun()
-            traceContext->logCompleteTraceEvent("inference_e2e",
-                                                TraceLevel::RUNTIME, start);
-            // Merge this run's TraceEvents into the global
-            // TraceContext.
-            traceContext->merge(contextPtr->getTraceContext());
-          } else {
-            contextPtr->getTraceContext()->getTraceEvents().clear();
-          }
-        }
-        firstRunsDone++;
-        if (firstRunsTimer != nullptr && firstRunsTimer->isRunning() &&
-            firstRunsDone == excludedFirstWarmupRuns) {
-          firstRunsTimer->stopTimer();
-        }
-        if (bestRunTime != nullptr) {
-          bestRunTimer->stopTimer();
-          double wallTime = bestRunTimer->getTotalTime().getWallTime();
-          if (wallTime < *bestRunTime)
-            *bestRunTime = wallTime;
-          bestRunTimer->clear();
-          delete bestRunTimer;
-        }
-
-        // Kick off another run.
-        if (dispatched.fetch_sub(1) > 0) {
-          inflight++;
-          runInference(hostManager, name, std::move(contextPtr), runPromise,
-                       inflight, dispatched, warmUp > 0 ? warmUp - 1 : 0,
-                       restRunsTimer, firstRunsTimer, bestRunTime);
-        } else if (restRunsTimer != nullptr) {
-          restRunsTimer->stopTimer();
-        }
-
-        if (--inflight == 0) {
-          runPromise.set_value();
-        }
-      });
-}
-
-/// Run the requested number of benchmark requests \p requestCount prepended by
-/// \p warmUp cycles
-// through the HostManager from the \p loader using the provided context pool \p
-// contexts
-/// and wait for all runs to complete.
-static void
-runBenchmark(std::string name, Loader &loader,
-             std::vector<std::unique_ptr<ExecutionContext>> contexts,
-             unsigned requestCount, unsigned warmUp,
-             llvm::Timer *restRunsTimer = nullptr,
-             llvm::Timer *firstRunsTimer = nullptr,
-             double *bestRunTime = nullptr) {
-  runtime::HostManager *hostManager = loader.getHostManager();
-  std::atomic<unsigned> inflight(0);
-  std::atomic<int> dispatched(requestCount + warmUp * contexts.size());
-  std::promise<void> runPromise;
-  auto fut = runPromise.get_future();
-
-  // Kick off initial pool of requests.
-  for (size_t i = 0, e = contexts.size(); i < e; i++) {
-    auto batch = std::move(contexts[i]);
-    inflight++;
-    dispatched--;
-    runInference(hostManager, name, std::move(batch), runPromise, inflight,
-                 dispatched, warmUp, restRunsTimer, firstRunsTimer,
-                 bestRunTime);
-  }
-
-  // Wait for all to finish.
-  fut.wait();
-}
-
-/// Setup the pool of contexts needed for a benchmark run.
-static std::vector<std::unique_ptr<ExecutionContext>>
-setupContextPool(Placeholder *outputPH, Placeholder *inputImagePH,
-                 glow::Tensor &inputImageData) {
-  std::vector<std::unique_ptr<ExecutionContext>> contexts;
-  // Size of the pool, the smaller of poolSize or the actual number of
-  // requests.
-  unsigned iterations =
-      miniBatch ? std::min(int(poolSize), int(iterationsOpt / miniBatch)) : 1;
-  // Setup pool of inference requests to be run.
-  for (unsigned i = 0; i < iterations; i++) {
-    auto newContext = glow::make_unique<ExecutionContext>();
-    newContext->setTraceContext(glow::make_unique<TraceContext>(traceLevel));
-    auto ph = newContext->getPlaceholderBindings();
-    ph->insert(inputImagePH, Tensor(inputImageData.getType()));
-    ph->allocate(outputPH);
-    contexts.push_back(std::move(newContext));
-  }
-  return contexts;
-}
-
-/// This function is a placeholder for registering Loader extensions to the
-/// loader. A loader extension in an instance of a loader extension class that
-/// must derive from class LoaderExtension. Any number of loader extensions
-/// can be registered to the Loader.
-static void registerLoaderExtensions(Loader &loader) {
-  // Example :
-  // class myLoaderExtension : public LoaderExtension {
-  //    // implement pure virtuel methods of class LoaderExtension.
-  // };
-  // loader.registerExtension(
-  //   std::unique_ptr<LoaderExtension>(new myLoaderExtension()));
-  (void)loader;
+  return 0;
 }
 
 int main(int argc, char **argv) {
-  // Verify/initialize command line parameters, and then loader initializes
-  // the ExecutionEngine and Function.
-  parseCommandLine(argc, argv);
-
-  if (inputImageListFile.empty() && inputImageFilenames.size() == 0) {
-    llvm::errs() << "Args: Either positional inputImageFilenames or "
-                    "-inputImageListFile "
-                    "must be used to specify input images.\n";
-    std::exit(1);
-  }
-
-  if (!inputImageListFile.empty()) {
-    CHECK_EQ(inputImageFilenames.size(), 0)
-        << "When using -input-image-list-file all Input images must be "
-           "specified "
-           "using -input-image-list-file option.";
-    parseInputImageList(inputImageListFile);
-  }
 
   if (!expectedMatchingLabels.empty()) {
     // The number of category indices must match the number of files.
@@ -638,266 +269,12 @@ int main(int argc, char **argv) {
     }
   }
 
-  if (excludedFirstWarmupRuns && excludedFirstWarmupRuns >= warmup) {
-    llvm::errs() << "Excluding all warmup runs does not make sense\n";
-    return 1;
-  }
-  // Stream input mode.
-  const bool streamInputFilenamesMode =
-      inputImageFilenames.size() == 1 && inputImageFilenames.front() == "-";
-
-  CHECK(!(streamInputFilenamesMode && emittingBundle()))
-      << "Cannot emit a bundle and also stream inputs.";
-
-  // If tracing is enabled, create a TraceContext to merge each runs events
-  // into.
-  if (!tracePath.empty()) {
-    traceContext = glow::make_unique<TraceContext>(TraceLevel::STANDARD);
-  }
-
-  // Mini-batch mode.
-  const bool miniBatchMode = miniBatch > 0;
-  CHECK(((!miniBatchMode) || (!streamInputFilenamesMode)))
-      << "The minibatch option is not compatible with the stream input "
-         "image mode.";
-  CHECK(((!miniBatchMode) || (inputImageFilenames.size() % miniBatch == 0)))
-      << "The number of input images must be a multiple of the mini-batch.";
-
-  CHECK(((!iterationsOpt) || (!miniBatchMode) ||
-         (iterationsOpt % miniBatch == 0)))
-      << "Benchmark count must be a multiple of the mini-batch.";
-
-  // Print out the inferred image classification.
-  llvm::outs() << "Model: " << Loader::getModelOptPath() << "\n";
-  std::mutex ioMu;
-  int numErrors = 0;
-
-  // Process a set of minibatches with indices [startIndex, endIndex).
-  auto processImageRange = [&](size_t startIndex, size_t endIndex) {
-    std::unique_ptr<ExecutionContext> exContext =
-        glow::make_unique<ExecutionContext>();
-    PlaceholderBindings &bindings = *exContext->getPlaceholderBindings();
-    if (traceContext) {
-      exContext->setTraceContext(
-          glow::make_unique<TraceContext>(TraceLevel::STANDARD));
-    }
-    Loader loader;
-
-    // Register Loader extensions.
-    registerLoaderExtensions(loader);
-
-    // Used to make sure we only compile once, and run only once if not
-    // streaming.
-    bool isFirstRun = true;
-
-    // These will be set during the first run.
-    Placeholder *inputImagePH = nullptr;
-    Placeholder *outputPH = nullptr;
-
-    size_t miniBatchIndex = startIndex;
-    Tensor inputImageData;
-    std::vector<std::string> inputImageBatchFilenames;
-    if ((!miniBatchMode) && (!streamInputFilenamesMode)) {
-      inputImageBatchFilenames = inputImageFilenames;
-    }
-    if (!tracePath.empty()) {
-      loader.getHostManager()->setTraceContext(
-          glow::make_unique<TraceContext>(traceLevel));
-      Error err = loader.getHostManager()->startDeviceTrace();
-      if (err) {
-        llvm::outs() << "Failed to start device trace.";
-      } else {
-        llvm::outs() << "Device trace started.";
-      }
-    }
-    while ((streamInputFilenamesMode &&
-            getNextImageFilenames(&inputImageBatchFilenames)) ||
-           (miniBatchMode &&
-            getNextMiniBatch(inputImageBatchFilenames, inputImageFilenames,
-                             miniBatchIndex, miniBatch, endIndex)) ||
-           isFirstRun) {
-      // Load and process the image data into the inputImageData Tensor.
-      loadImagesAndPreprocess(inputImageBatchFilenames, &inputImageData,
-                              imageNormMode, imageChannelOrder, imageLayout);
-
-      // It we are benchmarking reset the image data to the batch size we need.
-      if (iterationsOpt) {
-        ShapeVector imageSize(inputImageData.getType().dims().begin(),
-                              inputImageData.getType().dims().end());
-        if (miniBatch) {
-          imageSize[0] = miniBatch;
-        } else {
-          imageSize[0] = iterationsOpt;
-        }
-        // Resize the Tensor to the appropriate size.
-        inputImageData.reset(ElemKind::FloatTy, imageSize);
-      }
-      // If this is the first run, then we need to build and compile the model.
-      if (isFirstRun) {
-        isFirstRun = false;
-
-        // Build and compile the graph, and then get back the input Placeholder
-        // and output Placeholder.
-        std::pair<Placeholder *, Placeholder *> inputOutputPair =
-            buildAndCompileAndGetInAndOutPair(loader, bindings,
-                                              &inputImageData.getType());
-
-        // If in bundle mode, the bundle has been saved by the above call, so we
-        // can safely return.
-        if (emittingBundle()) {
-          return;
-        }
-
-        inputImagePH = inputOutputPair.first;
-        outputPH = inputOutputPair.second;
-      }
-      CHECK(inputImagePH) << "Input must be valid.";
-      CHECK(inputImagePH->dims() == inputImageData.dims())
-          << "New input shape does not match the compiled function: "
-          << inputImagePH->dims() << " vs " << inputImageData.dims();
-
-      // Validate the out placeholder when doing inference (and not profiling).
-      if (!profilingGraph()) {
-        CHECK(outputPH) << "Output must be valid.";
-      }
-
-      // Convert the raw input to fp16. This must be done every time we get new
-      // image data.
-      if (convertInAndOutToFp16) {
-        inputImageData.convertToType(ElemKind::Float16Ty);
-      }
-
-      // If we are benchmarking we are done with the while loop.
-      if (iterationsOpt) {
-        break;
-      }
-
-      // Minibatch inference initialization of loader extensions
-      loader.inferInitMiniBatch(bindings, miniBatchIndex - miniBatch,
-                                miniBatch);
-
-      // About to run inference, so update the input image Placeholder's backing
-      // Tensor with inputImageData.
-      updateInputPlaceholders(bindings, {inputImagePH}, {&inputImageData});
-
-      // Perform the inference execution, updating SMT.
-      auto batchSize = inputImageData.dims()[0];
-      loader.runInference(exContext.get(), batchSize);
-      if (traceContext) {
-        traceContext->merge(exContext->getTraceContext());
-      }
-
-      // Print the top-k results from the output Softmax tensor. Do this only
-      // when doing inference (and not profiling).
-      if (!profilingGraph()) {
-        std::lock_guard<std::mutex> lock(ioMu);
-        numErrors += processAndPrintResults(bindings.get(outputPH),
-                                            inputImageBatchFilenames);
-      }
-
-      // Minibatch inference initialization of loader extensions
-      loader.inferEndMiniBatch(bindings, miniBatchIndex - miniBatch, miniBatch);
-    }
-
-    if (iterationsOpt) {
-      // Image tensors loaded up to be run at once for benchmark mode.
-      std::vector<std::unique_ptr<ExecutionContext>> contexts =
-          setupContextPool(outputPH, inputImagePH, inputImageData);
-
-      std::string name = loader.getFunctionName();
-      std::unique_ptr<llvm::Timer> restRunsTimer = nullptr;
-      std::unique_ptr<llvm::Timer> firstRunsTimer = nullptr;
-      std::unique_ptr<double> bestRunTime = nullptr;
-      if (timeOpt) {
-        if (excludedFirstWarmupRuns) {
-          firstRunsTimer.reset(
-              new llvm::Timer("First Runs", "First inference runs"));
-          restRunsTimer.reset(
-              new llvm::Timer("Rest Inferences", "Rest of the inference runs"));
-        } else {
-          restRunsTimer.reset(
-              new llvm::Timer("Inferences", "All inference runs"));
-        }
-        bestRunTime.reset(new double);
-        *bestRunTime = DBL_MAX;
-      }
-      unsigned requestCount = miniBatch ? iterationsOpt / miniBatch : 1;
-
-      runBenchmark(name, loader, std::move(contexts), requestCount, warmup,
-                   restRunsTimer.get(), firstRunsTimer.get(),
-                   bestRunTime.get());
-      if (timeOpt) {
-        double wallTime = restRunsTimer->getTotalTime().getWallTime();
-        llvm::outs() << llvm::formatv(
-            "Average wall time per item (s): {0:f4}\n",
-            wallTime / (iterationsOpt + warmup - excludedFirstWarmupRuns));
-        llvm::outs() << llvm::formatv(
-            "            Best wall time (s): {0:f4}\n", *bestRunTime);
-      }
-    }
-
-    // If profiling, generate and serialize the quantization infos now that we
-    // have run inference one or more times to gather the profile.
-    if (profilingGraph()) {
-      loader.generateAndSerializeQuantizationInfos(bindings);
-    }
-    if (!tracePath.empty()) {
-      Error err = loader.getHostManager()->stopDeviceTrace();
-      if (err) {
-        llvm::outs() << "Failed to stop device trace:";
-      } else {
-        traceContext->merge(loader.getHostManager()->getTraceContext());
-      }
-    }
+  glow::Executor core("ImageClassifier");
+  auto printResultCreator =
+      []() -> std::unique_ptr<PostProcessOutputDataExtension> {
+    return std::make_unique<ImageClassifierProcessResult>();
   };
-
-  // We will force single-threaded execution if:
-  // - Minibatch mode is disabled;
-  // - We are going to emit bundle and do not do inference;
-  // - We are collecting inference profile.
-  // Otherwise, there can be several minibatches of equal size.
-  const bool multiThreadingAllowed =
-      miniBatchMode && !emittingBundle() && !profilingGraph();
-  const size_t numBatches =
-      miniBatchMode ? inputImageFilenames.size() / miniBatch : 1u;
-  const size_t numThreads = multiThreadingAllowed
-                                ? std::min(size_t(miniBatchThreads), numBatches)
-                                : 1u;
-  if (miniBatchThreads > 1 && !multiThreadingAllowed) {
-    llvm::outs() << "WARNING: multi-threaded execution is not possible. Make "
-                    "sure that minibatch size is specified and you are not "
-                    "trying to dump profile or emit bundle.\n";
-  }
-
-  llvm::outs() << "Running " << numThreads << " thread(s).\n";
-  std::vector<std::thread> threads(numThreads);
-  const size_t miniBatchesPerThread =
-      (numBatches + numThreads - 1) / numThreads;
-  for (size_t i = 0; i < numThreads; i++) {
-    size_t startIndex, endIndex;
-    if (numThreads > 1) {
-      startIndex = i * miniBatchesPerThread * miniBatch;
-      endIndex = std::min((i + 1) * miniBatchesPerThread * miniBatch,
-                          inputImageFilenames.size());
-    } else {
-      startIndex = 0;
-      endIndex = inputImageFilenames.size();
-    }
-    auto worker = [&processImageRange, startIndex, endIndex]() {
-      processImageRange(startIndex, endIndex);
-    };
-    threads.push_back(std::thread(worker));
-  }
-
-  for (auto &t : threads) {
-    if (t.joinable()) {
-      t.join();
-    }
-  }
-
-  if (!tracePath.empty()) {
-    traceContext->dump(tracePath, "ImageClassifier");
-  }
-
+  core.registerPostProcessOutputExtension(printResultCreator);
+  int numErrors = core.executeNetwork(argc, argv);
   return numErrors;
 }

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -688,9 +688,11 @@ Loader &Loader::registerExtension(std::unique_ptr<LoaderExtension> extension) {
 
 void Loader::postModelLoad(PlaceholderBindings &bindings,
                            ProtobufLoader &protoLoader,
+                           llvm::StringMap<Placeholder *> &placeholderMap,
                            size_t compilationBatchSize) {
   for (auto &&ext : loaderExtensionList_) {
-    ext->postModelLoad(*this, bindings, protoLoader, compilationBatchSize);
+    ext->postModelLoad(*this, bindings, protoLoader, placeholderMap,
+                       compilationBatchSize);
   }
 }
 

--- a/tools/loader/Loader.h
+++ b/tools/loader/Loader.h
@@ -57,6 +57,7 @@ class LoaderExtension {
 public:
   /// Called once after ONNX or Caffe2 model loading.
   virtual void postModelLoad(Loader &, PlaceholderBindings &, ProtobufLoader &,
+                             llvm::StringMap<Placeholder *> &,
                              size_t compilationBatchSize) = 0;
   /// Called once at the beginning of the mini-batch inference.
   virtual void inferInitMiniBatch(Loader &, PlaceholderBindings &,
@@ -171,6 +172,7 @@ public:
   Loader &registerExtension(std::unique_ptr<LoaderExtension> ext);
   /// Called once after ONNX or Caffe2 model loading.
   void postModelLoad(PlaceholderBindings &bindings, ProtobufLoader &protoLoader,
+                     llvm::StringMap<Placeholder *> &,
                      size_t compilationBatchSize);
   /// Called at the beginning of each mini-batch inference.
   void inferInitMiniBatch(PlaceholderBindings &bindings, size_t minibatchIndex,


### PR DESCRIPTION
Summary:
This stems from: https://github.com/pytorch/glow/issues/4020

The main idea is to refactor image-classifier in to app specific part and common part that can be used by other apps.

Most of the changes are just mechanical movement of common helper functions in to ExecutorCoreHelperFunctions.cpp

A new class was introduced in ExecutorCore.h that encapsulates core of building and running networks with extensions mechanism introduced that is similar to Loader one.

Another change was to modify buildAndCompileAndGetInAndOutPair to return a map of placeholders instead of just one. This is to enable networks with multiple outputs. For example ObjectDetection networks.

Documentation:
In the Issue link.
[Optional Fixes #issue]

Test Plan:
Unit tests, image classification networks.
Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
