### PR TITLE
Enable network sharing in torch_glow

### DIFF
--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -52,6 +52,7 @@ run_pytorch_tests() {
       export PATH="/tmp/sccache:$PATH"
     fi
     source /tmp/venv/bin/activate
+    pip install pytest-xdist
     python "${GLOW_SRC}/torch_glow/setup.py" test --run_cmake
     cd -
     if hash sccache 2>/dev/null; then

--- a/torch_glow/setup.cfg
+++ b/torch_glow/setup.cfg
@@ -3,4 +3,4 @@ test=pytest
 
 [tool:pytest]
 testpaths = tests
-addopts = --verbose
+addopts = --verbose --forked

--- a/torch_glow/src/Registration.h
+++ b/torch_glow/src/Registration.h
@@ -35,16 +35,22 @@ void registerGlowFusionPass(std::function<bool()> enablePassFn);
 /// registered.
 void registerGlowFusionOpAndPass(std::function<bool()> enablePassFn);
 
-/// Store a CachingGraphRunner \p graphRunner under a given \p key for later
-/// later use. This is so that a CachingGraphRunner can be preloaded for a given
-/// graph and then stored until the corresponding pt node is created for that
-/// graph.
-void setGraphRunnerForKey(const std::string &key,
-                          std::unique_ptr<CachingGraphRunner> graphRunner);
+/// Get the size of the global CachingGraphRunner map. For testing and debugging
+/// purpose only.
+size_t getGraphRunnerMapSize();
+
+/// Store a CachingGraphRunner with a constucting functor \p graphRunnerBuilder
+/// under a given \p key for later later use. This is so that a
+/// CachingGraphRunner can be preloaded for a given graph and then stored until
+/// the corresponding pt node is created for that graph.
+std::shared_ptr<CachingGraphRunner>
+setGraphRunnerForKey(const std::string &key,
+                     std::function<std::shared_ptr<CachingGraphRunner>(void)>
+                         graphRunnerBuilder);
 
 /// Get a precreated CachingGraphRunner for a given \p key. \returns nullptr if
 /// no CachingGraphRunner was registered for the given key.
-std::unique_ptr<CachingGraphRunner>
+std::shared_ptr<CachingGraphRunner>
 getGraphRunnerForKey(const std::string &key);
 } // namespace glow
 

--- a/torch_glow/tests/utils.py
+++ b/torch_glow/tests/utils.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import torch
 import torch_glow
 
+import sys
+
 GLOW_NODE_NAME = "glow::FusionGroup"
 SUBGRAPH_ATTR = "Subgraph"
 
@@ -84,9 +86,13 @@ def jitVsGlow_(f_torch, f_glow, check_trace, atol, rtol, *inputs, expected_fused
             assert isinstance(torch_res, tuple) and isinstance(glow_res, tuple)
             assert len(torch_res) == len(glow_res)
             for i in range(len(torch_res)):
+                print("torch shape: {}".format(torch_res[i].shape), file=sys.stderr)
+                print("glow shape: {}".format(glow_res[i].shape), file=sys.stderr)
                 assert torch.allclose(
                     torch_res[i], glow_res[i], atol=atol, rtol=rtol)
         else:
+            print("torch shape: {}".format(torch_res.shape), file=sys.stderr)
+            print("glow shape: {}".format(glow_res.shape), file=sys.stderr)
             is_all_close = torch.allclose(
                 torch_res, glow_res, atol=atol, rtol=rtol)
             if not is_all_close:


### PR DESCRIPTION
Summary:
We will compile and cache the glow fused graph only once, shared across all the module/function from different inference threads. We have a global singleton of CachingGraphRunner keyed on the hash of jit::Graph. For each unique jit::Graph, we have one CachingGraphRunner. Then for each shape specifalization of CachingGraphRunner, we have a unique Glow function.

Strategy on caching CachingGraphRunner:
We will first query by hashing the fused subgraph. If not found, we will query by hashing the node symbol string, which suits the AOT case. Currently, we have to leak the CachingGraphRunner as I don't have a good idea of where the glow op is going to be destroyed and what hook I can add. This is fine for the forseeable future but we probably need more application level (say, predictor) signal to help with this.

Differential Revision: D20174479

