### PR TITLE
Fix for Quantization for nodes that have multiple float outputs.

### DIFF
--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -658,9 +658,7 @@ protected:
       auto *dequantize =
           llvm::dyn_cast<DequantizeNode>((*val.getUsers().begin()).getUser());
       TypeRef outTy = val.getType();
-      auto name =
-          NodeValue::generateNodeOutputName(dequantize->getName(), outNum);
-
+      auto name = dequantize->getResult().generateNodeOutputName();
       nodeToTQP_[name] = {outTy->getScale(), outTy->getOffset()};
     }
   } // namespace


### PR DESCRIPTION
Summary:
This was exposed by a node that has two float outputs and it's processed before it's uses.
in postProcessing the new dequantize node is inserted in to a table with name constructed with it's name and result ID of a node being processed. So for a Node A for second output it will be: "Dequantize__##:1"

When use node is processed and canConvert is invoked when it checks input and calls quantizationParamsExist it constructs name for lookup using input node name and resNo. Which in Dequantize case will always be 0. So lookup is "Dequantize__##:0"

Documentation:

[Optional Fixes #issue]

Test Plan:
Unit tests, internal tests.

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
