### PR TITLE
Fix NetworkExecutionStatePool available state tracking.

### DIFF
--- a/lib/Runtime/Executor/NetworkExecutionState.cpp
+++ b/lib/Runtime/Executor/NetworkExecutionState.cpp
@@ -19,6 +19,14 @@
 using namespace glow;
 using namespace glow::runtime;
 
+void NetworkExecutionStatePool::addNewState(
+    std::unique_ptr<NetworkExecutionState> state) {
+
+  std::lock_guard<std::mutex> lock(stateLock_);
+  availableStates_.push_back(state.get());
+  states_.push_back(std::move(state));
+}
+
 NetworkExecutionState::NetworkExecutionState(const DAGNode *root)
     : inflightNodes_(0), module_(root->module), root_(root) {}
 

--- a/lib/Runtime/Executor/ThreadPoolExecutor.cpp
+++ b/lib/Runtime/Executor/ThreadPoolExecutor.cpp
@@ -214,8 +214,15 @@ void ThreadPoolExecutor::handleDeviceManagerResult(
     // will transfer. //executionState->transferOutputs();
     ResultCBTy cb = executionState->getCallback();
     DCHECK(cb != nullptr);
-    cb(executionState->getRunId(), executionState->getErrorContainer().get(),
-       executionState->getUniqueResultContextPtr());
+
+    // Get what we need from the executionState and return it to the pool.
+    auto runId = executionState->getRunId();
+    auto err = executionState->getErrorContainer().get();
+    auto resultCtx = executionState->getUniqueResultContextPtr();
+    states_[executionState->getRoot()]->returnNetworkExecutionState(
+        executionState);
+
+    cb(runId, std::move(err), std::move(resultCtx));
   }
 
   // Decrement the inflight barrier for the executor keeping track of all


### PR DESCRIPTION
Summary:
Changed getNextNetworkExecutionState to use a deque to track available states instead of round robin.
Documentation:

Test Plan:
ninja check
