### PR TITLE
glow runtime: dynamically schedule request to device manager based on load instead of round robin

### DIFF
--- a/lib/Partitioner/PartitionerBase.cpp
+++ b/lib/Partitioner/PartitionerBase.cpp
@@ -36,7 +36,6 @@ DAGListTy PartitionerBase::doPartitioning(llvm::StringRef funcName,
   DAGRoot->logicalDevices = {0};
   DAGRoot->name = funcName;
   DAGRoot->module = module;
-  DAGRoot->deviceIDs = {0};
   DAGNode *root = DAGRoot.get();
 
   llvm::DenseMap<Node *, Node *> currToNew;

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -288,8 +288,8 @@ Error HostManager::removeNetwork(llvm::StringRef networkName) {
   // Free the pool of executionStates.
   executor_->freePool(networkIterator->second.dag.root.get());
   for (auto &node : nodes) {
-    for (auto device : node->deviceIDs) {
-      Error evictErr = provisioner_->evictFunction(node->name, device);
+    for (auto device : node->deviceRuntimeInfos) {
+      Error evictErr = provisioner_->evictFunction(node->name, device.first);
       err.set(std::move(evictErr));
     }
     // Also remove compiledFunction from Provisioner.

--- a/lib/Runtime/Provisioner/Provisioner.cpp
+++ b/lib/Runtime/Provisioner/Provisioner.cpp
@@ -212,7 +212,7 @@ Provisioner::generateDeviceAssignments(
   // Update nodes in logicalDevices with their assignments.
   for (auto &assignment : deviceAssignment) {
     for (auto &node : logicalDevices[assignment.first]) {
-      node->deviceIDs.push_back(assignment.second);
+      node->deviceRuntimeInfos[assignment.second] = DeviceRuntimeInfo();
     }
   }
   return deviceAssignment;

--- a/tests/benchmark/RuntimeBench.cpp
+++ b/tests/benchmark/RuntimeBench.cpp
@@ -570,7 +570,7 @@ std::unique_ptr<DAG> createSingleNodeDAG(
   root->children.emplace_back(singleNode.get());
 
   singleNode->parents.emplace_back(root.get());
-  singleNode->deviceIDs = {0};
+  singleNode->deviceRuntimeInfos[0] = DeviceRuntimeInfo();
   singleNode->name = "singleNode";
   singleNode->runtimeBundle = glow::make_unique<RuntimeBundle>(
       compiledFunctions["singleNode"]->getRuntimeBundle());

--- a/tests/unittests/ThreadPoolExecutorTest.cpp
+++ b/tests/unittests/ThreadPoolExecutorTest.cpp
@@ -413,7 +413,7 @@ public:
 
     // Set the name, device ID, and RuntimeBundle of the new node.
     newNode->name = name;
-    newNode->deviceIDs = {deviceId};
+    newNode->deviceRuntimeInfos[deviceId] = DeviceRuntimeInfo();
 
     newNode->runtimeBundle = glow::make_unique<RuntimeBundle>(
         symbolTable, /*constWeight=*/0, /*mutableWeight=*/0,


### PR DESCRIPTION
Summary:
Previously glow uses round robin to determine which device should handle the next request. This is suboptimal if different devices can process requests at different rate. Say a system has two devices and it needs to process 10k inferences. In the round robin strategy, the overall throughput of the system is limited by the time it takes for the slower device to process 5k inferences.

Instead of robin, we can dynamically pick the device that has the least load. During a tie, we'll pick the device that's least most recently used.

Reviewed By: yinghai

Differential Revision: D20200631

