### PR TITLE
Introduce autogenerated serialization to customized ONNX via NodeGen

### DIFF
--- a/docs/Serialization.md
+++ b/docs/Serialization.md
@@ -1,0 +1,62 @@
+# Serialization in Glow
+
+Glow supports multiple pathways for both exporting and loading a serialized model.
+
+## Loading
+
+Glow can load Caffe2 and ONNX protobufs, as well as TorchScript exported from a
+PyTorch model. For ONNX protobufs, Glow supports loading ops specified by the
+[ONNX spec](https://github.com/onnx/onnx/blob/master/docs/Operators.md), as well
+as custom ops that are only used by Glow (see below).
+
+## Exporting
+
+Glow supports exporting ONNX protobufs. One way this is done is by trying to
+abide by the ONNX spec for ops which can be represented in ONNX. However this
+can be problematic as not all ops may fit into ONNX. Additionally, if the
+intention is to later on reload this serialized model into Glow, then there is
+downside in moving to ONNX and back, as some information may be lost in the
+conversion from Glow -> ONNX -> Glow.
+
+As an alternative, Glow also supports exporting to custom ONNX ops, which are
+annotated with attributes to ensure that the Glow graph that is exported is the
+exact same as the one that is reloaded. See the `useGlowCustomOps_` flag in the
+`ONNXModelWriter`.
+
+### Format of custom Glow ops in ONNX
+
+Glow has unique names used for all `Nodes` in a Function, and can specify unique
+names for each `NodeValue` based on its result number. Therefore it's natural to
+use these to specify input and output names in protobuf form. This is done via
+calls to `NodeValue::generateNodeOutputName()`.
+
+Additionally, it's desirable for an exported and reimported graph to retain the
+same names for all `Nodes` and `Storage` (`Placeholders` and
+`Constants`). Keeping the same name for inputs, nodes, and initializers in ONNX
+is easily done by setting the name of the corresponding proto object. However
+for outputs, we need to retain both the name of the `SaveNode` as well as the
+name of the `Placeholder`. We use the `doc_string` of the output to retain the
+name of the `Placeholder`, and use the name of the output itself to retain the
+name of the `SaveNode`.
+
+Another note is that we use ONNX `Identity` ops to connect an output name of a
+`Node` to a `SaveNode` if it is indeed used by a `SaveNode`. This allows us to
+simplify the export process, i.e. we do not need to check the users of a `Node`
+and decide whether to overwrite its name to match the `SaveNode` name.
+
+In order to retain properties of `Storage`, the `doc_string` of inputs and
+outputs is used to save these properties. This currently includes:
+
+* `offline`: Used for static Placeholders
+* `layout`: Used for the layout of Storage
+* `trainable`: Used for the trainable property of Placeholders
+* `ElemKind`: Save the ElemKind of Storage
+* `qScale`: Scale of quantized ElemKinds
+* `qOffset`: Offset of quantized ElemKinds
+* `saveName`: Used for retaining the name of SaveNodes used by output Placeholders
+
+You can find a couple examples of some tests that were exported with the
+`useGlowCustomOps` flag mentioned above here:
+[Quantized TopK](https://github.com/pytorch/glow/tree/master/tests/models/onnxModels/glow_custom_op_topk_quantized.onnxtxt)
+and
+[ChannelwiseQuantizedConvolution](https://github.com/pytorch/glow/tree/master/tests/models/onnxModels/glow_custom_op_channelwise_quantized_group_conv.onnxtxt).

--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -41,6 +41,7 @@ public:
 
   /// \return the single output value of the node.
   NodeValue getOutput() { return getNthResult(0); }
+  const NodeValue getOutput() const { return getNthResult(0); }
 
   /// Declare the standard Node methods.
   /// @{
@@ -354,6 +355,15 @@ public:
   }
 #include "glow/AutoGenNodes.def"
 };
+
+/// Signifiers for exporting and importing properties of Nodes.
+constexpr char layoutSignifier[] = "layout";
+constexpr char staticSignifier[] = "offline";
+constexpr char trainableSignifier[] = "trainable";
+constexpr char elemKindSignifier[] = "ElemKind";
+constexpr char saveNameSignifier[] = "saveName";
+constexpr char qScaleSignifier[] = "qScale";
+constexpr char qOffsetSignifier[] = "qOffset";
 
 } // namespace glow
 

--- a/include/glow/Importer/ProtobufLoader.h
+++ b/include/glow/Importer/ProtobufLoader.h
@@ -106,6 +106,19 @@ Expected<std::vector<float>> getFloats(const AttrType *arg) {
   return dim;
 }
 
+/// Load a string record vector from \p arg into a vector. \returns the vector
+/// if there is no error, or an error otherwise.
+template <typename AttrType>
+Expected<std::vector<std::string>> getStrings(const AttrType *arg) {
+  RETURN_ERR_IF_NOT(arg, "Node has no strings attribute with this name");
+  RETURN_ERR_IF_NOT(arg->strings_size() > 0, "Node has no strings values");
+  std::vector<std::string> strs;
+  for (const auto &s : arg->strings()) {
+    strs.push_back(s);
+  }
+  return strs;
+}
+
 /// Returns canonical name for a given operator: either \p name() from proto,
 /// or its type name.
 template <typename T> std::string loadOperatorName(const T &op) {
@@ -140,15 +153,18 @@ protected:
   /// Create a new constant that's initialized with \p tensor, and register it
   /// under the name \p name. If an existing Placeholder is already registered
   /// under the same name then the tensor is thrown out and no new Constant
-  /// is created.
-  Error createAndRegisterConstant(llvm::StringRef name, Tensor &&tensor);
+  /// is created. The Constant will have Layout \p layout.
+  Error createAndRegisterConstant(llvm::StringRef name, Tensor &&tensor,
+                                  const std::string &layout = ANY_LAYOUT);
 
   /// Create a new Placeholder of type \p T, and register it
   /// under the name \p name. If \p isStatic is true register the Placeholder as
-  /// a static placeholder. \returns The newly created placeholder.
-  Expected<Placeholder *> createAndRegisterPlaceholder(llvm::StringRef name,
-                                                       TypeRef T,
-                                                       bool isStatic = false);
+  /// a static placeholder. \p isTrainable and \p layout are set in the
+  /// Placeholder accoringly. \returns The newly created placeholder.
+  Expected<Placeholder *>
+  createAndRegisterPlaceholder(llvm::StringRef name, TypeRef T,
+                               bool isStatic = false, bool isTrainable = false,
+                               const std::string &layout = ANY_LAYOUT);
 
   /// \returns the NodeValue that was registered with the name \p name or
   /// a nullptr wrapped in a NodeValue if no node has been registered with this

--- a/include/glow/Support/Support.h
+++ b/include/glow/Support/Support.h
@@ -195,6 +195,11 @@ template <class T> inline constexpr unsigned convertEnumToUnsigned(T e) {
 #define LOG_CUSTOM_LOC(severity, FILE_, LINE_)                                 \
   COMPACT_GOOGLE_LOG_CUSTOM_LOC_##severity(FILE_, LINE_).stream()
 
+/// Char used for signifying the start of an attribute name to value mapping.
+constexpr char startChar = '$';
+/// Char used for separating attribute name from attribute value.
+constexpr char sepChar = ':';
+
 } // namespace glow
 
 #endif // GLOW_SUPPORT_SUPPORT_H

--- a/lib/Exporter/ONNXModelWriter.cpp
+++ b/lib/Exporter/ONNXModelWriter.cpp
@@ -18,16 +18,19 @@
 #include "glow/Graph/Utils.h"
 #include "glow/Support/ZipUtils.h"
 
+#include <float.h>
+
 #include "miniz.h"
 
 namespace glow {
 namespace {
-template <bool IsInteger, typename T> struct AttributeAssigner {
+template <bool IsInteger, bool IsEnum, typename T> struct AttributeAssigner {
   static void assign(ONNX_NAMESPACE::AttributeProto *attr, const T &container);
 };
 
 // Specialization for llvm::ArrayRef<T> container types
-template <typename T> struct AttributeAssigner<false, llvm::ArrayRef<T>> {
+template <typename T>
+struct AttributeAssigner<false, false, llvm::ArrayRef<T>> {
   static void assign(ONNX_NAMESPACE::AttributeProto *attr,
                      const llvm::ArrayRef<T> &container) {
     attr->set_type(ONNX_NAMESPACE::AttributeProto::INTS);
@@ -37,17 +40,8 @@ template <typename T> struct AttributeAssigner<false, llvm::ArrayRef<T>> {
   }
 };
 
-// Specialization for 1D, 1 element Tensor container types
-template <> struct AttributeAssigner<false, Tensor> {
-  static void assign(ONNX_NAMESPACE::AttributeProto *attr, const Tensor &T) {
-    auto *proto = attr->mutable_t();
-    ONNXModelWriter::writeTensor(T, proto);
-    attr->set_type(ONNX_NAMESPACE::AttributeProto::TENSOR);
-  }
-};
-
 // Specialization for string type
-template <> struct AttributeAssigner<false, std::string> {
+template <> struct AttributeAssigner<false, false, std::string> {
   static void assign(ONNX_NAMESPACE::AttributeProto *attr,
                      const std::string &container) {
     attr->set_type(ONNX_NAMESPACE::AttributeProto::STRING);
@@ -56,7 +50,7 @@ template <> struct AttributeAssigner<false, std::string> {
 };
 
 // Specialization for StringRef type
-template <> struct AttributeAssigner<false, llvm::StringRef> {
+template <> struct AttributeAssigner<false, false, llvm::StringRef> {
   static void assign(ONNX_NAMESPACE::AttributeProto *attr,
                      const llvm::StringRef container) {
     attr->set_type(ONNX_NAMESPACE::AttributeProto::STRING);
@@ -65,7 +59,7 @@ template <> struct AttributeAssigner<false, llvm::StringRef> {
 };
 
 // Specialization for float type
-template <> struct AttributeAssigner<false, float> {
+template <> struct AttributeAssigner<false, false, float> {
   static void assign(ONNX_NAMESPACE::AttributeProto *attr,
                      const float &container) {
     attr->set_type(ONNX_NAMESPACE::AttributeProto::FLOAT);
@@ -73,11 +67,45 @@ template <> struct AttributeAssigner<false, float> {
   }
 };
 
+// Specialization for NodeValueArrayRef.
+template <> struct AttributeAssigner<false, false, NodeValueArrayRef> {
+  static void assign(ONNX_NAMESPACE::AttributeProto *attr,
+                     const NodeValueArrayRef &container) {
+    attr->set_type(ONNX_NAMESPACE::AttributeProto::STRINGS);
+    for (size_t i = 0, e = container.size(); i < e; i++) {
+      attr->add_strings(container[i].generateNodeOutputName(
+          /* stripResNoFor0thInput */ true));
+    }
+  }
+};
+
+// Specialization for llvm::ArrayRef<float>.
+template <> struct AttributeAssigner<false, false, llvm::ArrayRef<float>> {
+  static void assign(ONNX_NAMESPACE::AttributeProto *attr,
+                     const llvm::ArrayRef<float> &container) {
+    attr->set_type(ONNX_NAMESPACE::AttributeProto::FLOATS);
+    for (auto value : container) {
+      attr->add_floats(value);
+    }
+  }
+};
+
 // Specialization for int type
-template <typename T> struct AttributeAssigner<true, T> {
+template <typename T> struct AttributeAssigner<true, false, T> {
   static void assign(ONNX_NAMESPACE::AttributeProto *attr, const T &container) {
     attr->set_type(ONNX_NAMESPACE::AttributeProto::INT);
     attr->set_i(container);
+  }
+};
+
+// Specialization for enums.
+template <typename T> struct AttributeAssigner<false, true, T> {
+  static void assign(ONNX_NAMESPACE::AttributeProto *attr, const T &container) {
+    attr->set_type(ONNX_NAMESPACE::AttributeProto::STRING);
+    std::string storage;
+    llvm::raw_string_ostream stream(storage);
+    stream << container;
+    attr->set_s(stream.str());
   }
 };
 
@@ -86,8 +114,32 @@ void addValueAttribute(ONNX_NAMESPACE::NodeProto *proto,
                        const std::string &name, const T &container) {
   auto *attr = proto->add_attribute();
   attr->set_name(name);
-  AttributeAssigner<std::numeric_limits<T>::is_integer, T>::assign(attr,
-                                                                   container);
+  AttributeAssigner<std::numeric_limits<T>::is_integer, std::is_enum<T>::value,
+                    T>::assign(attr, container);
+}
+
+/// Add the type attributes from \p NV to \p proto. This includes the ElemKind,
+/// the Shape, and scale/offset if ElemKind is quantized. Note that the result
+/// name is prefixed onto the specific attribute being appended, as some ops
+/// have multiple outputs and so this allows differentiating between them.
+void addTypeAttributes(ONNX_NAMESPACE::NodeProto *proto, NodeValue NV) {
+  const TypeRef ty = NV.getType();
+  llvm::StringRef outputName = NV.getNode()->getOutputName(NV.getResNo());
+
+  // Add ElemKind.
+  auto *elemKindAttr = proto->add_attribute();
+  elemKindAttr->set_name(outputName.str() + elemKindSignifier);
+  AttributeAssigner<false, false, llvm::StringRef>::assign(
+      elemKindAttr, ty->getElementName());
+
+  // Add Shape.
+  addValueAttribute(proto, outputName.str() + "Shape", NV.dims());
+
+  // Write out scale/offset if quantized ElemKind.
+  if (isQuantizedElemKind(ty->getElementType())) {
+    addValueAttribute(proto, outputName.str() + "QuantScale", ty->getScale());
+    addValueAttribute(proto, outputName.str() + "QuantOffset", ty->getOffset());
+  }
 }
 
 /// Helper function to recursively rewind Tile \p node.
@@ -462,6 +514,11 @@ class ReverseGraphWalker {
     for (unsigned b = 0, e = N->getNumInputs(); b < e; ++b) {
       visitRecursively(N->getNthInput(b).getNode());
     }
+
+    // Additionally visit the predicate input if it exists.
+    if (N->hasPredicate()) {
+      visitRecursively(N->getPredicate().getNode());
+    }
   }
 
 public:
@@ -469,13 +526,23 @@ public:
 
   llvm::ArrayRef<const Node *> getNodes() const { return reverseOrder_; }
 };
+
+template <typename T>
+static void addAttrToDocString(T *proto, const std::string &attrName,
+                               llvm::StringRef attrVal) {
+  *(proto->mutable_doc_string()) += std::string(1, startChar) + attrName +
+                                    std::string(1, sepChar) + attrVal.str();
+}
+
 } // namespace
 
 ONNXModelWriter::ONNXModelWriter(const std::string &modelFilename, Function &F,
                                  size_t irVersion, size_t opsetVersion,
-                                 Error *errPtr, bool textMode, bool zipMode)
+                                 Error *errPtr, bool textMode, bool zipMode,
+                                 bool useGlowCustomOps)
     : CommonOperatorWriter(modelFilename, F, errPtr),
-      opsetVersion_(opsetVersion), zipMode_(zipMode) {
+      opsetVersion_(opsetVersion), zipMode_(zipMode),
+      useGlowCustomOps_(useGlowCustomOps) {
   // If errPtr already contains an error then don't continue with constructor.
   if (errPtr && *errPtr) {
     return;
@@ -487,7 +554,8 @@ ONNXModelWriter::ONNXModelWriter(const std::string &modelFilename, Function &F,
     // Loop through all nodes, output Graph to Model protobuf.
     ONNX_NAMESPACE::ModelProto modelProto;
     modelProto.set_ir_version(irVersion);
-    modelProto.set_producer_name("ONNXModelWriter");
+    modelProto.set_producer_name(useGlowCustomOps_ ? "GlowONNXModelWriter"
+                                                   : "ONNXModelWriter");
     auto *opsetImportProto = modelProto.add_opset_import();
     opsetImportProto->set_version(opsetVersion);
     auto *graphProto = modelProto.mutable_graph();
@@ -508,11 +576,11 @@ ONNXModelWriter::ONNXModelWriter(const std::string &modelFilename, Function &F,
       const auto kind = N->getKind();
       // Handle placeholders cases.
       if (kind == Kinded::Kind::PlaceholderKind) {
-        if (hasUsesOfKind(N, Kinded::Kind::SaveNodeKind)) {
+        const auto *PH = llvm::cast<Placeholder>(N);
+        if (!isInput(PH, F)) {
           // Storage as an input to SaveNode - ignore it.
           continue;
         }
-        const auto *PH = llvm::cast<Placeholder>(N);
         // Write global input, output only tensor shape.
         auto *inputProto = graphProto->add_input();
         tensorShapeFromPlaceholder(PH, inputProto);
@@ -520,8 +588,17 @@ ONNXModelWriter::ONNXModelWriter(const std::string &modelFilename, Function &F,
         // Write global initializer, output tensor bytes.
         const auto *C = llvm::cast<Constant>(N);
         auto *tensorProto = addInitializer(*graphProto);
-        tensorProto->set_name(C->getName());
-        writeTensor(C->getPayload(), tensorProto);
+        // When using useGlowCustomOps we always use generateNodeOutputName for
+        // all inputs and outputs.
+        tensorProto->set_name(useGlowCustomOps_
+                                  ? C->getOutput().generateNodeOutputName(
+                                        /* stripResNoFor0thInput */ true)
+                                  : C->getName().str());
+        writeTensor(C->getPayload(), tensorProto, useGlowCustomOps_);
+        if (useGlowCustomOps_) {
+          // Also include the layout in the initializer to be loaded later.
+          addAttrToDocString(tensorProto, layoutSignifier, C->getLayout());
+        }
       } else if (kind == Kinded::Kind::SaveNodeKind) {
         // Save node case, find input and use its name as a global output,
         // output only shape.
@@ -529,6 +606,23 @@ ONNXModelWriter::ONNXModelWriter(const std::string &modelFilename, Function &F,
         const auto *PH = SN->getPlaceholder();
         auto *out = graphProto->add_output();
         tensorShapeFromPlaceholder(PH, out);
+
+        // Use the doc string to specify the name that should be used for the
+        // SaveNode to ensure it's kept the same between export and import.
+        addAttrToDocString(out, saveNameSignifier, SN->getName());
+
+        // If useGlowCustomOps then we need to add an Identity to map the name
+        // from generateNodeOutputName() to the name of the Placeholder.
+        if (useGlowCustomOps_) {
+          auto *proto = graphProto->add_node();
+          proto->set_op_type("Identity");
+          proto->set_name(SN->getName().data());
+          proto->add_input(SN->getInput().generateNodeOutputName(
+              /* stripResNoFor0thInput */ true));
+          proto->add_output(PH->getName().data());
+        }
+      } else if (useGlowCustomOps_) {
+        RETURN_IF_ERR(writeGlowCustomOperator(N, *graphProto));
       } else {
         RETURN_IF_ERR(writeOperator(N, *graphProto));
       }
@@ -541,19 +635,24 @@ ONNXModelWriter::ONNXModelWriter(const std::string &modelFilename, Function &F,
     for (size_t i = 0, n = nodes->size(); i < n / 2; ++i) {
       nodes->SwapElements(i, n - i - 1);
     }
-    // We need to swap back Identity node with the next non-Identity node since
-    // we append Identity node to tap out the intermediate results
-    for (int i = 0, n = nodes->size(); i < n - 1; ++i) {
-      if (nodes->Get(i).op_type() == "Identity") {
-        int k = 1;
-        while (i + k < n) {
-          if (nodes->Get(i + k).op_type() != "Identity") {
-            break;
+
+    // useGlowCustomOps uses Identities differently than the normal writer, so
+    // we do not want to do this if so.
+    if (!useGlowCustomOps_) {
+      // We need to swap back Identity node with the next non-Identity node
+      // since we append Identity node to tap out the intermediate results
+      for (int i = 0, n = nodes->size(); i < n - 1; ++i) {
+        if (nodes->Get(i).op_type() == "Identity") {
+          int k = 1;
+          while (i + k < n) {
+            if (nodes->Get(i + k).op_type() != "Identity") {
+              break;
+            }
+            ++k;
           }
-          ++k;
+          nodes->SwapElements(i, i + k);
+          i += k;
         }
-        nodes->SwapElements(i, i + k);
-        i += k;
       }
     }
 
@@ -634,7 +733,16 @@ ONNXModelWriter::convertType(const Type &glowType) {
   LOG(DFATAL) << "Cannot reach here.";
 }
 
-void ONNXModelWriter::writeTensor(const Tensor &T, TensorType *out) {
+/// Add quantization parameters to the doc_string in \p out based on \p type.
+template <typename T>
+static void addQuantParamsToDocString(T *out, const Type &type) {
+  addAttrToDocString(out, qScaleSignifier,
+                     strFormat("%.*f", DBL_DIG - 1, type.getScale()));
+  addAttrToDocString(out, qOffsetSignifier, std::to_string(type.getOffset()));
+}
+
+void ONNXModelWriter::writeTensor(const Tensor &T, TensorType *out,
+                                  bool useGlowCustomOps) {
   const auto &type = T.getType();
   out->set_data_type(convertType(type));
   const auto &dims = type.dims();
@@ -644,19 +752,41 @@ void ONNXModelWriter::writeTensor(const Tensor &T, TensorType *out) {
 
   out->set_raw_data(T.getUnsafePtr(), type.getSizeInBytes());
 
+  if (useGlowCustomOps) {
+    addAttrToDocString(out, elemKindSignifier, type.getElementName());
+  }
+
   if (type.isQuantizedType()) {
-    // Format is ElemKind:scale:offset
-    out->set_doc_string(strFormat("%s:%f:%d", type.getElementName().data(),
-                                  T.getType().getScale(),
-                                  T.getType().getOffset()));
+    // Note the use of DBL_DIG is to ensure all digits of the scale are printed.
+    if (useGlowCustomOps) {
+      addQuantParamsToDocString(out, type);
+    } else {
+      // Format is ElemKind:scale:offset.
+      out->set_doc_string(strFormat("%s:%.*f:%d", type.getElementName().data(),
+                                    DBL_DIG - 1, T.getType().getScale(),
+                                    T.getType().getOffset()));
+    }
   }
 }
 
 void ONNXModelWriter::tensorShapeFromPlaceholder(const Placeholder *PH,
                                                  ValueInfoType *valueProto) {
   tensorShapeFromInput(PH->getName(), PH->getType(), valueProto);
-  if (PH->isStatic()) {
-    valueProto->set_doc_string("offline");
+
+  if (useGlowCustomOps_) {
+    // Write out any meta information we need to for the Placeholder.
+    addAttrToDocString(valueProto, staticSignifier,
+                       std::to_string(PH->isStatic()));
+    addAttrToDocString(valueProto, trainableSignifier,
+                       std::to_string(PH->isTraining()));
+    addAttrToDocString(valueProto, layoutSignifier, PH->getLayout());
+    addAttrToDocString(valueProto, elemKindSignifier,
+                       PH->getType()->getElementName());
+
+    // Also include quantization params if necessary.
+    if (PH->getType()->isQuantizedType()) {
+      addQuantParamsToDocString(valueProto, *PH->getType());
+    }
   }
 }
 
@@ -673,15 +803,6 @@ Error ONNXModelWriter::writeAllWithNode(const std::string &opName,
 Error ONNXModelWriter::writeAll(const std::string &opName, const Node *node,
                                 GraphType &graph) {
   return writeAllWithNode(opName, node, graph, graph.add_node());
-}
-
-bool ONNXModelWriter::hasUsesOfKind(const Node *node, Kinded::Kind kind) {
-  for (const auto &use : node->getUsers()) {
-    if (use.getUser()->getKind() == kind) {
-      return true;
-    }
-  }
-  return false;
 }
 
 //===-----------------------------------------------------------------===//
@@ -974,12 +1095,12 @@ Error ONNXModelWriter::writeSlice(const SliceNode *node, GraphType &graph) {
 
     auto *tensorProto = addInitializer(graph);
     tensorProto->set_name(node->getName().str() + "_starts");
-    writeTensor(oneDimTensorStarts, tensorProto);
+    writeTensor(oneDimTensorStarts, tensorProto, useGlowCustomOps_);
     proto->add_input(node->getName().str() + "_starts");
 
     tensorProto = addInitializer(graph);
     tensorProto->set_name(node->getName().str() + "_ends");
-    writeTensor(oneDimTensorEnds, tensorProto);
+    writeTensor(oneDimTensorEnds, tensorProto, useGlowCustomOps_);
     proto->add_input(node->getName().str() + "_ends");
   } else {
     auto *attrStarts = proto->add_attribute();
@@ -1038,7 +1159,7 @@ Error ONNXModelWriter::writeTopK(const TopKNode *node, GraphType &graph) {
 
   auto *tensorProto = addInitializer(graph);
   tensorProto->set_name("k");
-  writeTensor(scalar, tensorProto);
+  writeTensor(scalar, tensorProto, useGlowCustomOps_);
 
   RETURN_IF_ERR(writeAllWithNode("TopK", node, graph, proto));
 
@@ -1058,11 +1179,11 @@ Error ONNXModelWriter::writeArgMax(const ArgMaxNode *node, GraphType &graph) {
 
   auto *tensorProto = addInitializer(graph);
   tensorProto->set_name("axis");
-  writeTensor(axis, tensorProto);
+  writeTensor(axis, tensorProto, useGlowCustomOps_);
 
   tensorProto = addInitializer(graph);
   tensorProto->set_name("keepDims");
-  writeTensor(keepDims, tensorProto);
+  writeTensor(keepDims, tensorProto, useGlowCustomOps_);
   RETURN_IF_ERR(writeAllWithNode("ArgMax", node, graph, proto));
 
   return Error::success();
@@ -1084,7 +1205,7 @@ Error ONNXModelWriter::writePRelu(const PReluNode *node, GraphType &graph) {
     Tensor scalar = {SN->getValue()};
     auto *tensorProto = addInitializer(graph);
     tensorProto->set_name(SN->getName());
-    writeTensor(scalar, tensorProto);
+    writeTensor(scalar, tensorProto, useGlowCustomOps_);
     proto->add_input(SN->getName());
     reportedNodes_.insert(SN);
   } else if (const ReshapeNode *RN = llvm::dyn_cast<ReshapeNode>(slope)) {
@@ -1425,7 +1546,7 @@ Error ONNXModelWriter::writeSplat(const SplatNode *node, GraphType &graph) {
     tensorProto->set_name(name);
   });
 
-  writeTensor(tensor, tensorProto);
+  writeTensor(tensor, tensorProto, useGlowCustomOps_);
   reportedNodes_.insert(node);
 
   return Error::success();
@@ -1642,16 +1763,9 @@ Error ONNXModelWriter::writeTile(const TileNode *node, GraphType &graph) {
   unsigned_t numDims = tile->getInput().dims().size();
 
   DCHECK(repeats.size() == numDims);
-  // Create and populate Tensor.
-  Tensor oneDimTensor(ElemKind::Int64ITy, {numDims});
-  auto handle = oneDimTensor.getHandle<int64_t>();
-
-  for (size_t b = 0, e = repeats.size(); b < e; ++b) {
-    handle.raw(b) = repeats[b];
-  }
 
   // Add Tensor type attribute.
-  addValueAttribute(indices, "value", oneDimTensor);
+  addValueAttribute(indices, "value", llvm::makeArrayRef(repeats));
   // Add indices as input to the Tile node
   proto->add_input(tile->getName().str() + "_indices");
 
@@ -1718,4 +1832,16 @@ DEF_UNSUPPORTED_NODE(BatchedPairwiseDotProductGrad)
 
 // Include backend-specific ONNX model writers.
 #include "glow/ONNXModelWriterIncludes.h"
+
+Error ONNXModelWriter::writeGlowCustomOperator(const Node *node,
+                                               GraphType &graph) {
+  switch (node->getKind()) {
+#include "glow/AutoGenNodesExport.h"
+  default:
+    return MAKE_ERR(
+        strFormat("Unhandled Node for export: %s", node->getName().data()));
+  }
+  return Error::success();
+}
+
 } // namespace glow

--- a/lib/Graph/CMakeLists.txt
+++ b/lib/Graph/CMakeLists.txt
@@ -2,19 +2,25 @@
 set(NODES_HDR ${GLOW_BINARY_DIR}/glow/AutoGenNodes.h)
 set(NODES_SRC ${GLOW_BINARY_DIR}/glow/AutoGenNodes.cpp)
 set(NODES_DEF ${GLOW_BINARY_DIR}/glow/AutoGenNodes.def)
+set(NODES_IMPORT ${GLOW_BINARY_DIR}/glow/AutoGenNodesImport.h)
+set(NODES_EXPORT ${GLOW_BINARY_DIR}/glow/AutoGenNodesExport.h)
 
 add_custom_command(OUTPUT
                    "${NODES_HDR}"
                    "${NODES_SRC}"
                    "${NODES_DEF}"
-                   COMMAND NodeGen ${NODES_HDR} ${NODES_SRC} ${NODES_DEF}
+                   "${NODES_IMPORT}"
+                   "${NODES_EXPORT}"
+                   COMMAND NodeGen ${NODES_HDR} ${NODES_SRC} ${NODES_DEF} ${NODES_IMPORT} ${NODES_EXPORT}
                    DEPENDS NodeGen
                    COMMENT "NodeGen: Generating nodes." VERBATIM)
 add_custom_target(AutoGenNode
                    DEPENDS
                      "${NODES_HDR}"
                      "${NODES_SRC}"
-                     "${NODES_DEF}")
+                     "${NODES_DEF}"
+                     "${NODES_IMPORT}"
+                     "${NODES_EXPORT}")
 add_dependencies(AutoGen AutoGenNode)
 
 add_library(Graph

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -2025,6 +2025,7 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
                               FusedActivation fusedActivation) {
   switch (fusedActivation) {
   case FusedActivation::NONE:
+    os << "NONE";
     break;
   case FusedActivation::RELU:
     os << "RELU";

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -108,6 +108,8 @@ getProtoShape(const ONNX_NAMESPACE::TensorShapeProto &shapeProto) {
   return dim;
 }
 
+/// Given some \p onnxType, sets \p elemTy to a corresponding Glow
+/// ElemKind. \returns whether an ElemKind was successfully selected.
 Error onnxTensorDataTypeToElemKind(int32_t onnxType, ElemKind *elemTy) {
   if (onnxType == ONNX_NAMESPACE::TensorProto::FLOAT) {
     *elemTy = ElemKind::FloatTy;
@@ -124,7 +126,13 @@ Error onnxTensorDataTypeToElemKind(int32_t onnxType, ElemKind *elemTy) {
   } else if (onnxType == ONNX_NAMESPACE::TensorProto::UINT8) {
     *elemTy = ElemKind::UInt8FusedQTy;
     return Error::success();
-  } else if (ONNX_NAMESPACE::TensorProto::BOOL) {
+  } else if (onnxType == ONNX_NAMESPACE::TensorProto::INT8) {
+    *elemTy = ElemKind::Int8QTy;
+    return Error::success();
+  } else if (onnxType == ONNX_NAMESPACE::TensorProto::INT16) {
+    *elemTy = ElemKind::Int16QTy;
+    return Error::success();
+  } else if (onnxType == ONNX_NAMESPACE::TensorProto::BOOL) {
     *elemTy = ElemKind::BoolTy;
     return Error::success();
   } else {
@@ -134,69 +142,288 @@ Error onnxTensorDataTypeToElemKind(int32_t onnxType, ElemKind *elemTy) {
   }
 }
 
-/// Creates tensor \p T from the input \p in. Note, there is no data associated
-/// with the Tensor. This method makes sure that the tensor is created with the
-/// proper shape and element type.
-Error setTensorType(const ONNX_NAMESPACE::TypeProto &in, Tensor *T) {
-  std::vector<dim_t> dim;
-  ASSIGN_VALUE_OR_RETURN_ERR(dim, getProtoShape(in.tensor_type().shape()));
-
-  ElemKind kind = ElemKind::FloatTy;
-  RETURN_IF_ERR(
-      onnxTensorDataTypeToElemKind(in.tensor_type().elem_type(), &kind));
-  if (kind == ElemKind::UInt8FusedQTy || kind == ElemKind::UInt4FusedFP16QTy) {
-    T->reset(kind, dim, 0.0, 0);
-  } else {
-    T->reset(kind, dim);
-  }
-  return Error::success();
+/// Convert a string to int. \returns the int or Error if problem parsing.
+Expected<int> getIntFromStr(llvm::StringRef input) {
+  const char *start = input.data();
+  char *end;
+  int val = std::strtol(start, &end, 10);
+  RETURN_ERR_IF_NOT(!(end == start || *end != '\0'),
+                    "Integer was not properly specified.");
+  return val;
 }
 
-/// Given a docstring encoding \p str of a type and its dimension \p
-/// dims, parses the string and \returns a Glow Type from it or Error if parsing
-/// failed. Expected format of str is either "ElemKind" or
-/// "ElemKind:scale:offset".
-Expected<Type> parseTypeFromDocString(const std::string &str,
-                                      llvm::ArrayRef<dim_t> dims) {
+/// Finds an attribute from the doc_string and \returns it. If it does not exist
+/// then \returns Error. The expected structure here is that each attribute
+/// starts with startChar and is separated from its value by a sepChar.
+Expected<std::string> getAttrFromDocString(const std::string &attr,
+                                           const std::string &docStr) {
+  const std::string attrAndSep = attr + sepChar;
   size_t begin = 0;
-
-  float scale = 1.0;
-  int32_t offset = 0;
-
-  // Find Elemkind string
-  size_t end = str.find(':', begin);
-
-  // If a ':' isn't found then assume the whole string is ElemKind (for
-  // backwards compatibility reasons) otherwise look for scale and offset
-  // strings.
-  std::string elemKindStr;
-  if (end == std::string::npos) {
-    elemKindStr = str.substr(0, str.size());
-  } else {
-    elemKindStr = str.substr(begin, end - begin);
-
-    // Get scale string.
-    begin = end + 1;
-    end = str.find(':', begin);
-    if (end == std::string::npos) {
-      return MAKE_ERR("scale not found");
-    }
-    std::string scaleStr = str.substr(begin, end - begin);
-
-    // Get offset string.
-    begin = end + 1;
-    end = str.size();
-    if (end - begin == 0) {
-      return MAKE_ERR("offset not found");
+  while (true) {
+    begin = docStr.find(startChar, begin);
+    if (begin == std::string::npos) {
+      return MAKE_ERR(strFormat("Didn't find PH attribute '%s'", attr.c_str()));
     }
 
-    std::string offsetStr = str.substr(begin, end - begin);
-
-    scale = std::stof(scaleStr);
-    offset = std::stoi(offsetStr);
+    // Note: +1 here and following line to account for the leading startChar.
+    if (!docStr.compare(begin + 1, attrAndSep.size(), attrAndSep)) {
+      // If we found the attribute then set begin to just after attrAndSep.
+      begin += attrAndSep.size() + 1;
+      break;
+    }
+    // Move past the current non-matching attribute to try the next attribute.
+    begin = begin + attrAndSep.size();
   }
 
-  ElemKind elemKind = Type::getElementKindFromName(elemKindStr);
+  return docStr.substr(begin, docStr.find(startChar, begin) - begin);
+}
+
+Expected<std::pair<float, int32_t>>
+getQuantParamsFromDocString(const std::string &docStr) {
+  std::string scaleStr;
+  ASSIGN_VALUE_OR_RETURN_ERR(scaleStr,
+                             getAttrFromDocString(qScaleSignifier, docStr));
+  float scale = std::strtof(scaleStr.c_str(), NULL);
+
+  std::string offsetStr;
+  ASSIGN_VALUE_OR_RETURN_ERR(offsetStr,
+                             getAttrFromDocString(qOffsetSignifier, docStr));
+  int32_t offset;
+  ASSIGN_VALUE_OR_RETURN_ERR(offset, getIntFromStr(offsetStr));
+  return std::make_pair(scale, offset);
+}
+
+/// Used for retrieving an attribute of type \p T from \p attr. Some
+/// specializations used \p loader if necessary.
+template <bool IsInteger, typename T> struct AttributeRetriever {
+  static Expected<T> get(const ONNX_NAMESPACE::AttributeProto *attr,
+                         const ProtobufLoader &loader);
+};
+
+/// Specialization for std::vector<float>.
+template <> struct AttributeRetriever<false, std::vector<float>> {
+  static Expected<std::vector<float>>
+  get(const ONNX_NAMESPACE::AttributeProto *attr,
+      const ProtobufLoader & /* unused */) {
+    return getFloats(attr);
+  }
+};
+
+/// Specialization for std::vector<NodeValue>.
+template <> struct AttributeRetriever<false, std::vector<NodeValue>> {
+  static Expected<std::vector<NodeValue>>
+  get(const ONNX_NAMESPACE::AttributeProto *attr,
+      const ProtobufLoader &loader) {
+    // Retrieve the names from the proto which map to NodeValues.
+    std::vector<std::string> strs;
+    ASSIGN_VALUE_OR_RETURN_ERR(strs, getStrings(attr));
+
+    // Get NodeValues corresponding to these names from the loader.
+    std::vector<NodeValue> NVs;
+    for (const auto &str : strs) {
+      NodeValue NV;
+      ASSIGN_VALUE_OR_RETURN_ERR(NV, loader.getNodeValueByName(str));
+      NVs.push_back(NV);
+    }
+    return NVs;
+  }
+};
+
+/// Specialization for NodeValue.
+template <> struct AttributeRetriever<false, NodeValue> {
+  static Expected<NodeValue> get(const ONNX_NAMESPACE::AttributeProto *attr,
+                                 const ProtobufLoader &loader) {
+    // Retrieve the name from the proto, which is mapped to a NodeValue.
+    std::string str;
+    ASSIGN_VALUE_OR_RETURN_ERR(str, loadStr(attr));
+
+    // Get/return the corresponding NodeValue for this name from the loader.
+    NodeValue NV;
+    ASSIGN_VALUE_OR_RETURN_ERR(NV, loader.getNodeValueByName(str));
+    return NV;
+  }
+};
+
+/// Specialization for std::vector<T>. Fall back for integer types.
+template <typename T> struct AttributeRetriever<false, std::vector<T>> {
+  static Expected<std::vector<T>>
+  get(const ONNX_NAMESPACE::AttributeProto *attr,
+      const ProtobufLoader & /* unused */) {
+    return getShape<T>(attr, /* allowEmptyShape */ true);
+  }
+};
+
+/// Specialization for integer types.
+template <typename T> struct AttributeRetriever<true, T> {
+  static Expected<T> get(const ONNX_NAMESPACE::AttributeProto *attr,
+                         const ProtobufLoader & /* unused */) {
+    return loadInt(attr);
+  }
+};
+
+/// Specialization for LengthsMode.
+template <> struct AttributeRetriever<false, LengthsMode> {
+  static Expected<LengthsMode> get(const ONNX_NAMESPACE::AttributeProto *attr,
+                                   const ProtobufLoader & /* unused */) {
+    std::string str;
+    ASSIGN_VALUE_OR_RETURN_ERR(str, loadStr(attr));
+    if (str == "AllOne") {
+      return LengthsMode::AllOne;
+    } else if (str == "Variable") {
+      return LengthsMode::Variable;
+    } else {
+      return MAKE_ERR("Invalid LengthsMode");
+    }
+  }
+};
+
+/// Specialization for FusedActivation.
+template <> struct AttributeRetriever<false, FusedActivation> {
+  static Expected<FusedActivation>
+  get(const ONNX_NAMESPACE::AttributeProto *attr,
+      const ProtobufLoader & /* unused */) {
+    std::string str;
+    ASSIGN_VALUE_OR_RETURN_ERR(str, loadStr(attr));
+    if (str == "NONE") {
+      return FusedActivation::NONE;
+    } else if (str == "RELU") {
+      return FusedActivation::RELU;
+    } else if (str == "TANH") {
+      return FusedActivation::TANH;
+    } else if (str == "SIGMOID") {
+      return FusedActivation::SIGMOID;
+    } else {
+      return MAKE_ERR("Invalid FusedActivation");
+    }
+  }
+};
+
+/// Specialization for ConvolutionLayout.
+template <> struct AttributeRetriever<false, ConvolutionLayout> {
+  static Expected<ConvolutionLayout>
+  get(const ONNX_NAMESPACE::AttributeProto *attr,
+      const ProtobufLoader & /* unused */) {
+    std::string str;
+    ASSIGN_VALUE_OR_RETURN_ERR(str, loadStr(attr));
+    if (str == "NHWC") {
+      return ConvolutionLayout::NHWC;
+    } else if (str == "NCHW") {
+      return ConvolutionLayout::NCHW;
+    } else {
+      return MAKE_ERR("Invalid ConvolutionLayout");
+    }
+  }
+};
+
+/// Specialization for PaddingMode.
+template <> struct AttributeRetriever<false, PaddingMode> {
+  static Expected<PaddingMode> get(const ONNX_NAMESPACE::AttributeProto *attr,
+                                   const ProtobufLoader & /* unused */) {
+    std::string str;
+    ASSIGN_VALUE_OR_RETURN_ERR(str, loadStr(attr));
+    if (str == "CONSTANT") {
+      return PaddingMode::CONSTANT;
+    } else if (str == "REFLECT") {
+      return PaddingMode::REFLECT;
+    } else if (str == "EDGE") {
+      return PaddingMode::EDGE;
+    } else {
+      return MAKE_ERR("Invalid PaddingMode");
+    }
+  }
+};
+
+/// Specialization for float.
+template <> struct AttributeRetriever<false, float> {
+  static Expected<float> get(const ONNX_NAMESPACE::AttributeProto *attr,
+                             const ProtobufLoader & /* unused */) {
+    return loadFloat(attr);
+  }
+};
+
+/// Specialization for std::string.
+template <> struct AttributeRetriever<false, std::string> {
+  static Expected<std::string> get(const ONNX_NAMESPACE::AttributeProto *attr,
+                                   const ProtobufLoader & /* unused */) {
+    return loadStr(attr);
+  }
+};
+
+/// Forwards to the correct AttributeRetriever specialization.
+template <typename T>
+Expected<T> loadAttribute(const ONNX_NAMESPACE::AttributeProto *attr,
+                          const ProtobufLoader &loader) {
+  RETURN_ERR_IF_NOT(attr, "No such attribute");
+  return AttributeRetriever<std::numeric_limits<T>::is_integer, T>::get(attr,
+                                                                        loader);
+}
+
+} // namespace
+
+using ArgumentDictionaryTy =
+    std::unordered_map<std::string, const ONNX_NAMESPACE::AttributeProto *>;
+
+/// Given a docstring encoding \p str of a type and its dimension \p
+/// dims, parses the string and \returns a Glow Type from it or Error if
+/// parsing failed. Expected format of str is either elemKindSignifier or
+/// "ElemKind:scale:offset".
+Expected<Type> parseTypeFromDocString(const std::string &str,
+                                      llvm::ArrayRef<dim_t> dims,
+                                      bool useGlowCustomOps) {
+  float scale = 1.0;
+  int32_t offset = 0;
+  ElemKind elemKind = ElemKind::FloatTy;
+
+  if (useGlowCustomOps) {
+    std::string elemKindStr;
+    ASSIGN_VALUE_OR_RETURN_ERR(elemKindStr,
+                               getAttrFromDocString(elemKindSignifier, str));
+    elemKind = Type::getElementKindFromName(elemKindStr);
+
+    if (isQuantizedElemKind(elemKind)) {
+      std::pair<float, int32_t> scaleOffsetPair;
+      ASSIGN_VALUE_OR_RETURN_ERR(scaleOffsetPair,
+                                 getQuantParamsFromDocString(str));
+      std::tie(scale, offset) = scaleOffsetPair;
+    }
+  } else {
+    size_t begin = 0;
+
+    // Find Elemkind string
+    size_t end = str.find(':', begin);
+
+    // If a ':' isn't found then assume the whole string is ElemKind (for
+    // backwards compatibility reasons) otherwise look for scale and offset
+    // strings.
+    std::string elemKindStr;
+    if (end == std::string::npos) {
+      elemKindStr = str.substr(0, str.size());
+    } else {
+      elemKindStr = str.substr(begin, end - begin);
+
+      // Get scale string.
+      begin = end + 1;
+      end = str.find(':', begin);
+      if (end == std::string::npos) {
+        return MAKE_ERR("scale not found");
+      }
+      std::string scaleStr = str.substr(begin, end - begin);
+
+      // Get offset string.
+      begin = end + 1;
+      end = str.size();
+      if (end - begin == 0) {
+        return MAKE_ERR("offset not found");
+      }
+
+      std::string offsetStr = str.substr(begin, end - begin);
+
+      scale = std::stof(scaleStr);
+      offset = std::stoi(offsetStr);
+    }
+
+    elemKind = Type::getElementKindFromName(elemKindStr);
+  }
 
   if (isQuantizedElemKind(elemKind)) {
     return Type(elemKind, dims, scale, offset);
@@ -204,10 +431,6 @@ Expected<Type> parseTypeFromDocString(const std::string &str,
     return Type(elemKind, dims);
   }
 }
-} // namespace
-
-using ArgumentDictionaryTy =
-    std::unordered_map<std::string, const ONNX_NAMESPACE::AttributeProto *>;
 
 /// Translates the protocol buffer node \p op into a random access map.
 static ArgumentDictionaryTy
@@ -286,7 +509,8 @@ void glow::fillPlaceholders(const std::string &fileName,
 }
 
 /// Loads tensor \p T from the input \p in.
-Error glow::loadTensor(const ONNX_NAMESPACE::TensorProto &in, Tensor *T) {
+Error glow::loadTensor(const ONNX_NAMESPACE::TensorProto &in, Tensor *T,
+                       bool useGlowCustomOps) {
   std::vector<dim_t> dim;
   for (auto d : in.dims()) {
     dim.push_back(d);
@@ -335,8 +559,8 @@ Error glow::loadTensor(const ONNX_NAMESPACE::TensorProto &in, Tensor *T) {
     }
   } else if (in.data_type() == ONNX_NAMESPACE::TensorProto::INT8) {
     Type ty;
-    ASSIGN_VALUE_OR_RETURN_ERR(ty,
-                               parseTypeFromDocString(in.doc_string(), dim));
+    ASSIGN_VALUE_OR_RETURN_ERR(
+        ty, parseTypeFromDocString(in.doc_string(), dim, useGlowCustomOps));
     T->reset(ty);
 
     if (in.has_raw_data()) {
@@ -346,11 +570,24 @@ Error glow::loadTensor(const ONNX_NAMESPACE::TensorProto &in, Tensor *T) {
       RETURN_ERR("Unsupported Tensor format.",
                  ErrorValue::ErrorCode::MODEL_LOADER_UNSUPPORTED_DATATYPE);
     }
+  } else if (in.data_type() == ONNX_NAMESPACE::TensorProto::INT16) {
+    Type ty;
+    ASSIGN_VALUE_OR_RETURN_ERR(
+        ty, parseTypeFromDocString(in.doc_string(), dim, useGlowCustomOps));
+    T->reset(ty);
+
+    if (in.has_raw_data()) {
+      std::istringstream inStream(in.raw_data(), std::stringstream::binary);
+      inStream.read(T->getUnsafePtr(), T->size() * sizeof(int16_t));
+    } else {
+      RETURN_ERR("Unsupported Tensor format.",
+                 ErrorValue::ErrorCode::MODEL_LOADER_UNSUPPORTED_DATATYPE);
+    }
   } else if (in.data_type() == ONNX_NAMESPACE::TensorProto::INT32) {
     if (in.has_doc_string()) {
       Type ty;
-      ASSIGN_VALUE_OR_RETURN_ERR(ty,
-                                 parseTypeFromDocString(in.doc_string(), dim));
+      ASSIGN_VALUE_OR_RETURN_ERR(
+          ty, parseTypeFromDocString(in.doc_string(), dim, useGlowCustomOps));
       T->reset(ty);
     } else {
       // There are few cases when we will have int32 tensors. For example, the
@@ -373,8 +610,8 @@ Error glow::loadTensor(const ONNX_NAMESPACE::TensorProto &in, Tensor *T) {
     }
   } else if (in.data_type() == ONNX_NAMESPACE::TensorProto::UINT8) {
     Type ty;
-    ASSIGN_VALUE_OR_RETURN_ERR(ty,
-                               parseTypeFromDocString(in.doc_string(), dim));
+    ASSIGN_VALUE_OR_RETURN_ERR(
+        ty, parseTypeFromDocString(in.doc_string(), dim, useGlowCustomOps));
     T->reset(ty);
 
     if (in.has_raw_data()) {
@@ -401,6 +638,46 @@ Error glow::loadTensor(const ONNX_NAMESPACE::TensorProto &in, Tensor *T) {
   return Error::success();
 }
 
+Error ONNXModelLoader::setTensorType(const ONNX_NAMESPACE::ValueInfoProto &in,
+                                     Tensor *T) {
+  auto type = in.type();
+
+  std::vector<dim_t> dim;
+  ASSIGN_VALUE_OR_RETURN_ERR(dim, getProtoShape(type.tensor_type().shape()));
+
+  ElemKind kind = ElemKind::FloatTy;
+  float scale = 1.0;
+  int32_t offset = 0;
+  if (useGlowCustomOps_) {
+    std::string elemKindStr;
+    ASSIGN_VALUE_OR_RETURN_ERR(
+        elemKindStr, getAttrFromDocString(elemKindSignifier, in.doc_string()));
+    kind = Type::getElementKindFromName(elemKindStr);
+    if (isQuantizedElemKind(kind)) {
+      std::pair<float, int32_t> scaleOffsetPair;
+      ASSIGN_VALUE_OR_RETURN_ERR(scaleOffsetPair,
+                                 getQuantParamsFromDocString(in.doc_string()));
+      std::tie(scale, offset) = scaleOffsetPair;
+    }
+  } else {
+    // Retrieve the ElemKind from the ONNX type, including considerations for
+    // whether the datatype is quantized.
+    RETURN_IF_ERR(
+        onnxTensorDataTypeToElemKind(type.tensor_type().elem_type(), &kind));
+  }
+
+  // If quantized then retrieve the scale and offset if provided (may not be for
+  // fused quantized types since they're ignored anyway).
+  if (isQuantizedElemKind(kind)) {
+    assert(useGlowCustomOps_ &&
+           "Quantized loading not fully supported without custom Glow ops.");
+    T->reset(kind, dim, scale, offset);
+  } else {
+    T->reset(kind, dim);
+  }
+  return Error::success();
+}
+
 Error ONNXModelLoader::loadInputs(ONNX_NAMESPACE::GraphProto &net,
                                   bool loadInputsAsPlaceholders) {
   for (const auto &in : net.input()) {
@@ -411,17 +688,28 @@ Error ONNXModelLoader::loadInputs(ONNX_NAMESPACE::GraphProto &net,
 
     if (loadInputsAsPlaceholders) {
       Tensor T;
-      RETURN_IF_ERR(setTensorType(in.type(), &T));
+      RETURN_IF_ERR(setTensorType(in, &T));
+
+      std::string isTrainable = "0";
+      std::string layout = ANY_LAYOUT;
+      if (useGlowCustomOps_) {
+        ASSIGN_VALUE_OR_RETURN_ERR(
+            isTrainable,
+            getAttrFromDocString(trainableSignifier, in.doc_string()));
+        ASSIGN_VALUE_OR_RETURN_ERR(
+            layout, getAttrFromDocString(layoutSignifier, in.doc_string()));
+      }
 
       Placeholder *placeholder;
       ASSIGN_VALUE_OR_RETURN_ERR(
           placeholder,
           createAndRegisterPlaceholder(in.name(), &T.getType(),
-                                       staticInputs_.count(in.name())));
+                                       staticInputs_.count(in.name()),
+                                       isTrainable != "0", layout));
       inputVarsByName_.try_emplace(in.name(), placeholder);
     } else {
       Tensor T;
-      RETURN_IF_ERR(setTensorType(in.type(), &T));
+      RETURN_IF_ERR(setTensorType(in, &T));
       RETURN_IF_ERR(createAndRegisterConstant(in.name(), std::move(T)));
     }
   }
@@ -671,13 +959,24 @@ Error ONNXModelLoader::loadConstant(const ONNX_NAMESPACE::NodeProto &op,
     return Error::success();
   }
 
-  RETURN_ERR_IF_NOT(dict.at("value")->type() ==
-                        ONNX_NAMESPACE::AttributeProto::TENSOR,
+  const auto &type = dict.at("value")->type();
+  RETURN_ERR_IF_NOT((type == ONNX_NAMESPACE::AttributeProto::TENSOR ||
+                     type == ONNX_NAMESPACE::AttributeProto::INTS),
                     "Only Tensor type constants are supported.",
                     ErrorValue::ErrorCode::MODEL_LOADER_UNSUPPORTED_DATATYPE);
 
   Tensor T;
-  RETURN_IF_ERR(loadTensor(dict.at("value")->t(), &T));
+  if (type == ONNX_NAMESPACE::AttributeProto::TENSOR) {
+    RETURN_IF_ERR(loadTensor(dict.at("value")->t(), &T, useGlowCustomOps_));
+  } else {
+    std::vector<int64_t> ints;
+    ASSIGN_VALUE_OR_RETURN_ERR(ints, getShape<int64_t>(dict["value"]));
+    T = Tensor(ElemKind::Int64ITy, {(dim_t)ints.size()});
+    auto TH = T.getHandle<int64_t>();
+    for (dim_t i = 0, e = ints.size(); i < e; ++i) {
+      TH.at({i}) = ints[i];
+    }
+  }
   RETURN_IF_ERR(createAndRegisterConstant(name, std::move(T)));
 
   return Error::success();
@@ -1646,7 +1945,7 @@ Error ONNXModelLoader::loadConstantOfShape(const ONNX_NAMESPACE::NodeProto &op,
   T.getHandle().raw(0) = 0.0;
 
   if (dict.count("value")) {
-    RETURN_IF_ERR(loadTensor(dict.at("value")->t(), &T));
+    RETURN_IF_ERR(loadTensor(dict.at("value")->t(), &T, useGlowCustomOps_));
     if (!isSplat) {
       // Validate tensor only for ConstantOfShape operator.
       RETURN_ERR_IF_NOT(T.dims().size() == 1, "Value must be a 1D vector.");
@@ -2781,9 +3080,70 @@ Error ONNXModelLoader::loadFlip(const ONNX_NAMESPACE::NodeProto &op,
   return Error::success();
 }
 
+Expected<TypeRef>
+ONNXModelLoader::loadTypeFromAttributes(llvm::StringRef name,
+                                        ArgumentDictionaryTy &dict) {
+  Module &mod = *G_.getParent();
+
+  // Load ElemKind.
+  std::string elemKindStr;
+  ASSIGN_VALUE_OR_RETURN_ERR(elemKindStr,
+                             loadStr(dict[name.str() + elemKindSignifier]));
+  const ElemKind k = Type::getElementKindFromName(elemKindStr);
+
+  // Load Shape. Note that we allow for empty shapes here because 0 dimensional
+  // shapes are allowed (representing scalars).
+  std::vector<dim_t> shape;
+  ASSIGN_VALUE_OR_RETURN_ERR(
+      shape,
+      getShape<dim_t>(dict[name.str() + "Shape"], /* allowEmptyShape */ true));
+
+  // Get scale/offset if quantized ElemKind, and create and return uniqued
+  // quantized Type.
+  if (isQuantizedElemKind(k)) {
+    float scale;
+    ASSIGN_VALUE_OR_RETURN_ERR(scale,
+                               loadFloat(dict[name.str() + "QuantScale"]));
+    int32_t offset;
+    ASSIGN_VALUE_OR_RETURN_ERR(offset,
+                               loadInt(dict[name.str() + "QuantOffset"]));
+    return mod.uniqueType(k, shape, scale, offset);
+  }
+
+  // Create and return uniqued non-quantized Type.
+  return mod.uniqueType(k, shape);
+}
+
+Expected<bool>
+ONNXModelLoader::tryLoadGlowCustomOp(llvm::StringRef typeName,
+                                     const ONNX_NAMESPACE::NodeProto &op,
+                                     ArgumentDictionaryTy &dict) {
+  const std::string &opName = loadOperatorName(op);
+
+// Try all automatically generated import cases.
+#include "glow/AutoGenNodesImport.h"
+
+  // If we get here then no case handled the op, so return false.
+  return false;
+}
+
 Error ONNXModelLoader::loadOperator(const ONNX_NAMESPACE::NodeProto &op) {
   ArgumentDictionaryTy dict = loadArgumentMap(op);
   const std::string &typeName = op.op_type();
+
+  if (useGlowCustomOps_) {
+    bool tryLoadGlowCustomOpResult;
+    ASSIGN_VALUE_OR_RETURN_ERR(tryLoadGlowCustomOpResult,
+                               tryLoadGlowCustomOp(typeName, op, dict));
+    if (tryLoadGlowCustomOpResult) {
+      return Error::success();
+    }
+
+    // Identity is the only official ONNX op used with useGlowCustomOps.
+    if (typeName != "Identity") {
+      return MAKE_ERR(strFormat("Unable to load op %s", typeName.data()));
+    }
+  }
 
   // Check if operator is supported in parent class, CommonOperatorLoader.
   bool tryLoadCommonOperatorResult;
@@ -2968,8 +3328,15 @@ Error ONNXModelLoader::loadInitializers(ONNX_NAMESPACE::GraphProto &net) {
   // Load the network initializers:
   for (const auto &in : net.initializer()) {
     Tensor T;
-    RETURN_IF_ERR(loadTensor(in, &T));
-    RETURN_IF_ERR(createAndRegisterConstant(in.name(), std::move(T)));
+    RETURN_IF_ERR(loadTensor(in, &T, useGlowCustomOps_));
+
+    std::string layout = ANY_LAYOUT;
+    if (useGlowCustomOps_) {
+      ASSIGN_VALUE_OR_RETURN_ERR(
+          layout, getAttrFromDocString(layoutSignifier, in.doc_string()));
+    }
+
+    RETURN_IF_ERR(createAndRegisterConstant(in.name(), std::move(T), layout));
   }
   return Error::success();
 }
@@ -2984,9 +3351,29 @@ Error ONNXModelLoader::setOutputNodes(ONNX_NAMESPACE::GraphProto &net) {
     NodeValue r;
     ASSIGN_VALUE_OR_RETURN_ERR(r, getNodeValueByName(outputName));
 
-    Placeholder *placeholder =
-        G_.getParent()->createPlaceholder(r.getType(), outputName, false);
-    SaveNode *SN = G_.createSave("save_" + outputName, r, placeholder);
+    const std::string &docString = net.output(i).doc_string();
+
+    Expected<std::string> saveName =
+        getAttrFromDocString(saveNameSignifier, docString);
+
+    const bool hasSpecifiedSaveName =
+        !ERR_TO_BOOL(saveName.takeError(), /* log */ false);
+    const std::string &saveNodeName =
+        hasSpecifiedSaveName ? saveName.get() : outputName;
+
+    std::string isTrainable = "0";
+    std::string layout = ANY_LAYOUT;
+    if (useGlowCustomOps_) {
+      ASSIGN_VALUE_OR_RETURN_ERR(
+          isTrainable, getAttrFromDocString(trainableSignifier, docString));
+      ASSIGN_VALUE_OR_RETURN_ERR(
+          layout, getAttrFromDocString(layoutSignifier, docString));
+    }
+
+    Placeholder *placeholder = G_.getParent()->createPlaceholder(
+        r.getType(), outputName, isTrainable != "0", layout);
+    SaveNode *SN =
+        G_.createSave(saveNodeName, r, placeholder, hasSpecifiedSaveName);
     outputVarsByName_[outputName] = SN->getPlaceholder();
   }
 
@@ -3024,7 +3411,16 @@ Error ONNXModelLoader::collectStaticInputs(ONNX_NAMESPACE::GraphProto &net) {
   for (int i = 0; i < net.input_size(); i++) {
     const ONNX_NAMESPACE::ValueInfoProto &valueInfo = net.input(i);
     const std::string &inputName = valueInfo.name();
-    if (valueInfo.has_doc_string() && valueInfo.doc_string() == "offline") {
+    if (useGlowCustomOps_) {
+      std::string isStatic;
+      ASSIGN_VALUE_OR_RETURN_ERR(
+          isStatic,
+          getAttrFromDocString(staticSignifier, valueInfo.doc_string()));
+      if (isStatic == "1") {
+        staticInputs_.emplace(inputName);
+      }
+    } else if (valueInfo.has_doc_string() &&
+               valueInfo.doc_string() == staticSignifier) {
       staticInputs_.emplace(inputName);
     }
   }
@@ -3062,7 +3458,8 @@ Error ONNXModelLoader::checkInputs(ONNX_NAMESPACE::GraphProto &net,
                           "Mismatch between input image and ONNX input shape");
       }
 
-      if (valueInfo.has_doc_string() && valueInfo.doc_string() == "offline") {
+      if (valueInfo.has_doc_string() &&
+          valueInfo.doc_string() == staticSignifier) {
         staticInputs_.emplace(inputName);
       }
     }
@@ -3074,7 +3471,8 @@ ONNXModelLoader::ONNXModelLoader(const std::string &modelDescFilename,
                                  llvm::ArrayRef<const char *> tensorNames,
                                  llvm::ArrayRef<TypeRef> types, Function &F,
                                  Error *errPtr, bool zipMode,
-                                 bool disableConstFoldInLoader)
+                                 bool disableConstFoldInLoader,
+                                 const Backend *B)
     : CommonOperatorLoader(tensorNames, types, F, errPtr) {
   // if errPtr already contains an error then don't continue with constructor
   if (errPtr && *errPtr) {
@@ -3109,6 +3507,8 @@ ONNXModelLoader::ONNXModelLoader(const std::string &modelDescFilename,
       ASSIGN_VALUE_OR_RETURN_ERR(modelDef, loadProto(modelDescFilename));
     }
 
+    useGlowCustomOps_ = modelDef.producer_name() == "GlowONNXModelWriter";
+
     RETURN_IF_ERR(setVersion(modelDef));
 
     ONNX_NAMESPACE::GraphProto graphDef = modelDef.graph();
@@ -3126,7 +3526,7 @@ ONNXModelLoader::ONNXModelLoader(const std::string &modelDescFilename,
 
     RETURN_IF_ERR(setOutputNodes(graphDef));
 
-    RETURN_ERR_IF_NOT(F.verify(), "Function verification failed.");
+    RETURN_ERR_IF_NOT(F.verify(B), "Function verification failed.");
 
     deleteUnusedConstants();
 
@@ -3158,6 +3558,8 @@ ONNXModelLoader::ONNXModelLoader(
   auto setup = [&]() -> Error {
     ONNX_NAMESPACE::ModelProto modelDef;
     ASSIGN_VALUE_OR_RETURN_ERR(modelDef, loadProto(model, modelSize));
+
+    useGlowCustomOps_ = modelDef.producer_name() == "GlowONNXModelWriter";
 
     RETURN_IF_ERR(setVersion(modelDef));
 

--- a/tests/models/onnxModels/glow_custom_op_channelwise_quantized_group_conv.onnxtxt
+++ b/tests/models/onnxModels/glow_custom_op_channelwise_quantized_group_conv.onnxtxt
@@ -1,0 +1,197 @@
+ir_version: 7
+producer_name: "GlowONNXModelWriter"
+graph {
+  node {
+    input: "input"
+    output: "qInput"
+    name: "qInput"
+    op_type: "Glow_Quantize"
+    attribute {
+      name: "ResultElemKind"
+      s: "i8"
+      type: STRING
+    }
+    attribute {
+      name: "ResultShape"
+      ints: 1
+      ints: 2
+      ints: 3
+      ints: 2
+      type: INTS
+    }
+    attribute {
+      name: "ResultQuantScale"
+      f: 1
+      type: FLOAT
+    }
+    attribute {
+      name: "ResultQuantOffset"
+      i: 0
+      type: INT
+    }
+  }
+  node {
+    input: "qInput"
+    input: "filter"
+    input: "quantized_bias"
+    input: "scales"
+    input: "offsets"
+    output: "channelwiseQuantizedConv"
+    name: "channelwiseQuantizedConv"
+    op_type: "Glow_ChannelwiseQuantizedConvolution"
+    attribute {
+      name: "ResultElemKind"
+      s: "i8"
+      type: STRING
+    }
+    attribute {
+      name: "ResultShape"
+      ints: 1
+      ints: 1
+      ints: 3
+      ints: 4
+      type: INTS
+    }
+    attribute {
+      name: "ResultQuantScale"
+      f: 1
+      type: FLOAT
+    }
+    attribute {
+      name: "ResultQuantOffset"
+      i: 0
+      type: INT
+    }
+    attribute {
+      name: "Kernels"
+      ints: 2
+      ints: 1
+      type: INTS
+    }
+    attribute {
+      name: "Strides"
+      ints: 1
+      ints: 1
+      type: INTS
+    }
+    attribute {
+      name: "Pads"
+      ints: 0
+      ints: 0
+      ints: 0
+      ints: 0
+      type: INTS
+    }
+    attribute {
+      name: "Group"
+      i: 2
+      type: INT
+    }
+  }
+  node {
+    input: "channelwiseQuantizedConv"
+    output: "dequantize"
+    name: "dequantize"
+    op_type: "Glow_Dequantize"
+    attribute {
+      name: "ResultElemKind"
+      s: "float"
+      type: STRING
+    }
+    attribute {
+      name: "ResultShape"
+      ints: 1
+      ints: 1
+      ints: 3
+      ints: 4
+      type: INTS
+    }
+  }
+  node {
+    input: "dequantize"
+    output: "save"
+    name: "save_save"
+    op_type: "Identity"
+  }
+  name: "glow"
+  initializer {
+    dims: 4
+    dims: 2
+    dims: 1
+    dims: 1
+    data_type: 3
+    name: "filter"
+    raw_data: "\001\002\001\002\001\002\001\002"
+    doc_string: "$ElemKind:i8$qScale:1.00000000000000$qOffset:0$layout:*"
+  }
+  initializer {
+    dims: 4
+    data_type: 1
+    name: "scales"
+    raw_data: "\000\000\200?\000\000\200?\000\000\200?\000\000\200?"
+    doc_string: "$ElemKind:float$layout:*"
+  }
+  initializer {
+    dims: 4
+    data_type: 6
+    name: "offsets"
+    raw_data: "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
+    doc_string: "$ElemKind:index32$layout:*"
+  }
+  initializer {
+    dims: 4
+    data_type: 6
+    name: "quantized_bias"
+    raw_data: "\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000"
+    doc_string: "$ElemKind:i32$qScale:1.00000000000000$qOffset:0$layout:*"
+  }
+  input {
+    name: "input"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+    doc_string: "$offline:0$trainable:0$layout:*$ElemKind:float"
+  }
+  output {
+    name: "save"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+    doc_string: "$offline:0$trainable:0$layout:*$ElemKind:float$saveName:save_save"
+  }
+}
+opset_import {
+  version: 9
+}

--- a/tests/models/onnxModels/glow_custom_op_topk_quantized.onnxtxt
+++ b/tests/models/onnxModels/glow_custom_op_topk_quantized.onnxtxt
@@ -1,0 +1,126 @@
+ir_version: 7
+producer_name: "GlowONNXModelWriter"
+graph {
+  node {
+    input: "input"
+    output: "TopK"
+    output: "TopK:1"
+    name: "TopK"
+    op_type: "Glow_TopK"
+    attribute {
+      name: "ValuesElemKind"
+      s: "i8"
+      type: STRING
+    }
+    attribute {
+      name: "ValuesShape"
+      ints: 3
+      ints: 1
+      ints: 3
+      type: INTS
+    }
+    attribute {
+      name: "ValuesQuantScale"
+      f: 1.2
+      type: FLOAT
+    }
+    attribute {
+      name: "ValuesQuantOffset"
+      i: 5
+      type: INT
+    }
+    attribute {
+      name: "IndicesElemKind"
+      s: "index64"
+      type: STRING
+    }
+    attribute {
+      name: "IndicesShape"
+      ints: 3
+      ints: 1
+      ints: 3
+      type: INTS
+    }
+    attribute {
+      name: "K"
+      i: 3
+      type: INT
+    }
+  }
+  node {
+    input: "TopK:1"
+    output: "save_indices"
+    name: "save_indices_save"
+    op_type: "Identity"
+  }
+  node {
+    input: "TopK"
+    output: "save_values"
+    name: "save_values_save"
+    op_type: "Identity"
+  }
+  name: "glow"
+  input {
+    name: "input"
+    type {
+      tensor_type {
+        elem_type: 3
+        shape {
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 5
+          }
+        }
+      }
+    }
+    doc_string: "$offline:0$trainable:0$layout:*$ElemKind:i8$qScale:1.20000004768372$qOffset:5"
+  }
+  output {
+    name: "save_values"
+    type {
+      tensor_type {
+        elem_type: 3
+        shape {
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+    doc_string: "$offline:0$trainable:0$layout:*$ElemKind:i8$qScale:1.20000004768372$qOffset:5$saveName:save_values_save"
+  }
+  output {
+    name: "save_indices"
+    type {
+      tensor_type {
+        elem_type: 7
+        shape {
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+    doc_string: "$offline:0$trainable:0$layout:*$ElemKind:index64$saveName:save_indices_save"
+  }
+}
+opset_import {
+  version: 9
+}

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -432,7 +432,16 @@ foreach(backend ${GLOW_BACKENDS})
   add_backend_test(TEST GradCheckTest BACKEND "${backend}" UNOPT)
   add_backend_test(TEST MLTest BACKEND "${backend}" UNOPT)
   add_backend_test(TEST OperatorGradTest BACKEND "${backend}" UNOPT)
-  add_backend_test(TEST OperatorTest BACKEND "${backend}" UNOPT)
+  add_backend_test(TEST OperatorTest BACKEND "${backend}" UNOPT PRIVATE
+                        Backend
+                        Backends
+                        Graph
+                        GraphOptimizer
+                        Importer
+                        Exporter
+                        ExecutionEngine
+                        gtest
+)
   add_backend_test(TEST NumericsTest BACKEND "${backend}" UNOPT)
   add_backend_test(TEST TensorLayoutTest BACKEND "${backend}" UNOPT)
   add_backend_test(TEST

--- a/tests/unittests/OnnxExporterTest.cpp
+++ b/tests/unittests/OnnxExporterTest.cpp
@@ -39,7 +39,7 @@ Expected<Function *>
 saveAndReloadFunction(Function *F, llvm::ArrayRef<const char *> inpuTensorNames,
                       llvm::ArrayRef<TypeRef> inputTensorTypes,
                       size_t irVer = 5, size_t opsetVer = 10,
-                      bool zipMode = false) {
+                      bool zipMode = false, bool useGlowCustomOps = false) {
   auto &mod = *F->getParent();
 
   llvm::SmallString<64> path;
@@ -55,7 +55,7 @@ saveAndReloadFunction(Function *F, llvm::ArrayRef<const char *> inpuTensorNames,
   {
     Error err = Error::empty();
     ONNXModelWriter onnxWR(outputFilename, *F, irVer, opsetVer, &err, !zipMode,
-                           zipMode);
+                           zipMode, useGlowCustomOps);
 
     if (err) {
       llvm::sys::fs::remove(outputFilename);
@@ -96,12 +96,15 @@ void testLoadAndSaveONNXModel(const std::string &name, bool zipMode) {
 
   size_t irVer = 0, opsetVer = 0;
 
+  bool useGlowCustomOps = false;
+
   // Load model from file.
   {
     Error err = Error::empty();
     ONNXModelLoader onnxLD(name, {}, {}, *F, &err);
     irVer = onnxLD.getIrVersion();
     opsetVer = onnxLD.getOpSetVersion();
+    useGlowCustomOps = onnxLD.usingGlowCustomOps();
 
     if (err) {
       llvm::errs() << "ONNXModelLoader failed to load model: " << name << "\n";
@@ -109,8 +112,9 @@ void testLoadAndSaveONNXModel(const std::string &name, bool zipMode) {
     FAIL_TEST_IF_ERR(std::move(err));
   }
 
-  FAIL_TEST_IF_ERR(
-      saveAndReloadFunction(F, {}, {}, irVer, opsetVer, zipMode).takeError());
+  FAIL_TEST_IF_ERR(saveAndReloadFunction(F, {}, {}, irVer, opsetVer, zipMode,
+                                         useGlowCustomOps)
+                       .takeError());
 }
 
 bool endsWith(const std::string &full, const std::string &ending) {

--- a/tests/unittests/OnnxExporterTest.cpp
+++ b/tests/unittests/OnnxExporterTest.cpp
@@ -33,7 +33,8 @@ namespace {
 /// Given a Function \p F and input names \p inpuTensorNames and input types \p
 /// inputTensorTypes, writes the function to file and reads it back using the
 /// ONNXModelWriter and ONNXModelReader respectively then \returns the
-/// reloaded function.
+/// reloaded function. \p useGlowCustomOps is used for determining the format
+/// for ONNXModelWriter to write with.
 Expected<Function *>
 saveAndReloadFunction(Function *F, llvm::ArrayRef<const char *> inpuTensorNames,
                       llvm::ArrayRef<TypeRef> inputTensorTypes,

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -3155,3 +3155,123 @@ TEST_F(OnnxImporterTest, importFRWQSLWS) {
   EXPECT_EQ(lengths->dims().vec(), std::vector<dim_t>({5}));
   EXPECT_EQ(lengths->getType()->getElementType(), ElemKind::Int32ITy);
 }
+
+/// Test loading a custom ONNX Glow quantized TopK.
+TEST_F(OnnxImporterTest, CustomGlowTopKQuantized) {
+  ExecutionEngine EE;
+  auto &mod = EE.getModule();
+  auto *F = mod.createFunction("main");
+  std::string netFilename(
+      GLOW_DATA_PATH
+      "tests/models/onnxModels/glow_custom_op_topk_quantized.onnxtxt");
+  Placeholder *valuesPH, *indicesPH;
+  {
+    ONNXModelLoader onnxLD(netFilename, {}, {}, *F);
+    valuesPH = EXIT_ON_ERR(onnxLD.getOutputByName("save_values"));
+    indicesPH = EXIT_ON_ERR(onnxLD.getOutputByName("save_indices"));
+  }
+
+  // Verify structure: PH -> TopK -> Save -> PH.
+  //                           \
+  //                            v
+  //                          Save -> PH
+  EXPECT_EQ(mod.getPlaceholders().size(), 3);
+  // TopK, Save nodes
+  EXPECT_EQ(F->getNodes().size(), 3);
+
+  auto *values = getSaveNodeFromDest(valuesPH);
+  ASSERT_TRUE(values);
+  EXPECT_EQ(values->getInput().getType()->getElementType(), ElemKind::Int8QTy);
+  EXPECT_EQ(values->getInput().getType()->getScale(), 1.2f);
+  EXPECT_EQ(values->getInput().getType()->getOffset(), 5);
+  EXPECT_EQ(values->getInput().dims().vec(), std::vector<dim_t>({3, 1, 3}));
+
+  auto *indices = getSaveNodeFromDest(indicesPH);
+  ASSERT_TRUE(indices);
+  EXPECT_EQ(indices->getInput().getType()->getElementType(),
+            ElemKind::Int64ITy);
+  EXPECT_EQ(indices->getInput().dims().vec(), std::vector<dim_t>({3, 1, 3}));
+
+  EXPECT_EQ(indices->getInput().getNode(), values->getInput().getNode());
+
+  auto *TKN = llvm::dyn_cast<TopKNode>(indices->getInput());
+  ASSERT_TRUE(TKN);
+  EXPECT_EQ(TKN->getK(), 3);
+
+  auto *input = llvm::dyn_cast<Placeholder>(TKN->getInput());
+  ASSERT_TRUE(input);
+  EXPECT_EQ(input->dims().vec(), std::vector<dim_t>({3, 1, 5}));
+  EXPECT_EQ(input->getType()->getElementType(), ElemKind::Int8QTy);
+  EXPECT_EQ(input->getType()->getScale(), 1.2f);
+  EXPECT_EQ(input->getType()->getOffset(), 5);
+}
+
+/// Test loading a custom ONNX Glow ChannelwiseQuantizedGroupConvolution.
+TEST_F(OnnxImporterTest, CustomGlowChannelwiseQuantizedGroupConvolution) {
+  ExecutionEngine EE;
+  auto &mod = EE.getModule();
+  auto *F = mod.createFunction("main");
+  std::string netFilename(
+      GLOW_DATA_PATH "tests/models/onnxModels/"
+                     "glow_custom_op_channelwise_quantized_group_conv.onnxtxt");
+  Placeholder *outputPH;
+  {
+    ONNXModelLoader onnxLD(netFilename, {}, {}, *F);
+    outputPH = EXIT_ON_ERR(onnxLD.getSingleOutput());
+  }
+
+  // Verify structure:
+  // {(PH -> Quantize), Constant, Constant, Constant, Constant} ->
+  // ChannelwiseQuantizedConvolution -> Save -> PH.
+  EXPECT_EQ(mod.getPlaceholders().size(), 2);
+  EXPECT_EQ(mod.getConstants().size(), 4);
+  // ChannelwiseQuantizedConvolution, Save, Quantize, Dequantize
+  EXPECT_EQ(F->getNodes().size(), 4);
+
+  auto *save = getSaveNodeFromDest(outputPH);
+  ASSERT_TRUE(save);
+
+  auto *DQN = llvm::dyn_cast<DequantizeNode>(save->getInput());
+  ASSERT_TRUE(DQN);
+  EXPECT_EQ(DQN->getInput().getType()->getElementType(), ElemKind::Int8QTy);
+  EXPECT_EQ(DQN->getInput().getType()->getScale(), 1.0f);
+  EXPECT_EQ(DQN->getInput().getType()->getOffset(), 0);
+  EXPECT_EQ(DQN->getInput().dims().vec(), std::vector<dim_t>({1, 1, 3, 4}));
+
+  auto *CN =
+      llvm::dyn_cast<ChannelwiseQuantizedConvolutionNode>(DQN->getInput());
+  ASSERT_TRUE(CN);
+  EXPECT_EQ(CN->getKernels().vec(), std::vector<unsigned_t>({2, 1}));
+  EXPECT_EQ(CN->getStrides().vec(), std::vector<unsigned_t>({1, 1}));
+  EXPECT_EQ(CN->getPads().vec(), std::vector<unsigned_t>({0, 0, 0, 0}));
+  EXPECT_EQ(CN->getGroup(), 2);
+
+  auto *QN = llvm::dyn_cast<QuantizeNode>(CN->getInput());
+  ASSERT_TRUE(QN);
+  EXPECT_EQ(QN->getResult().getType()->getElementType(), ElemKind::Int8QTy);
+  EXPECT_EQ(QN->getResult().getType()->getScale(), 1.0f);
+  EXPECT_EQ(QN->getResult().getType()->getOffset(), 0);
+  EXPECT_EQ(QN->getResult().dims().vec(), std::vector<dim_t>({1, 2, 3, 2}));
+  EXPECT_TRUE(llvm::isa<Placeholder>(QN->getInput()));
+
+  auto *filter = llvm::dyn_cast<Constant>(CN->getFilter());
+  ASSERT_TRUE(filter);
+  EXPECT_EQ(filter->getOutput().getType()->getElementType(), ElemKind::Int8QTy);
+  EXPECT_EQ(filter->getOutput().dims().vec(), std::vector<dim_t>({4, 2, 1, 1}));
+
+  auto *bias = llvm::dyn_cast<Constant>(CN->getBias());
+  ASSERT_TRUE(bias);
+  EXPECT_EQ(bias->getOutput().getType()->getElementType(), ElemKind::Int32QTy);
+  EXPECT_EQ(bias->getOutput().dims().vec(), std::vector<dim_t>({4}));
+
+  auto *scales = llvm::dyn_cast<Constant>(CN->getScales());
+  ASSERT_TRUE(scales);
+  EXPECT_EQ(scales->getOutput().getType()->getElementType(), ElemKind::FloatTy);
+  EXPECT_EQ(scales->getOutput().dims().vec(), std::vector<dim_t>({4}));
+
+  auto *offsets = llvm::dyn_cast<Constant>(CN->getOffsets());
+  ASSERT_TRUE(offsets);
+  EXPECT_EQ(offsets->getOutput().getType()->getElementType(),
+            ElemKind::Int32ITy);
+  EXPECT_EQ(offsets->getOutput().dims().vec(), std::vector<dim_t>({4}));
+}

--- a/tests/unittests/Repro.cpp
+++ b/tests/unittests/Repro.cpp
@@ -289,7 +289,11 @@ int run() {
   auto mod = glow::make_unique<Module>();
   Function *F = mod->createFunction("test");
   Error err = Error::empty();
-  { ONNXModelLoader onnxLD(modelPathOpt, {}, {}, *F, &err, /*zipMode*/ true); }
+  bool usingGlowCustomOps = false;
+  {
+    ONNXModelLoader onnxLD(modelPathOpt, {}, {}, *F, &err, /*zipMode*/ true);
+    usingGlowCustomOps = onnxLD.usingGlowCustomOps();
+  }
   CHECK(!ERR_TO_BOOL(std::move(err)))
       << "ONNXModelLoader failed to load model: " << modelPathOpt;
 
@@ -549,7 +553,7 @@ int run() {
           CHECK(tensor) << "Missing " << tp.name() << " in output placeholder";
           if (dumpOutputsOpt) {
             auto *t = outputG.add_initializer();
-            ONNXModelWriter::writeTensor(*tensor, t);
+            ONNXModelWriter::writeTensor(*tensor, t, usingGlowCustomOps);
             t->set_name(tp.name());
           }
           bool equal = tensorRef.isEqual(*tensor, thresholdOpt, true);

--- a/tools/ClassGen/NodeBuilder.cpp
+++ b/tools/ClassGen/NodeBuilder.cpp
@@ -592,8 +592,121 @@ void NodeBuilder::emitCppMethods(std::ostream &os) const {
   }
 }
 
+bool NodeBuilder::hasCtorTypeParams(llvm::StringRef res) const {
+  for (const std::string &s : ctorTypeParams_) {
+    if (s == res) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void NodeBuilder::emitImportMethods(std::ostream &os) const {
+  os << "if (typeName == \"Glow_" << name_ << "\") {\n";
+
+  // Load all the inputs.
+  for (size_t i = 0, e = nodeInputs_.size(); i < e; i++) {
+    auto &op = nodeInputs_[i];
+    os << "  NodeValue " << op << ";\n";
+    os << "  ASSIGN_VALUE_OR_RETURN_ERR(" << op
+       << ", getNodeValueByName(op.input(" << i << ")));\n\n";
+  }
+
+  // Load all the output types.
+  for (const auto &op : nodeOutputs_) {
+    if (hasCtorTypeParams(op.second)) {
+      os << "  TypeRef " << op.second << "OutTy;\n";
+      os << "  ASSIGN_VALUE_OR_RETURN_ERR(" << op.second
+         << "OutTy, loadTypeFromAttributes(\"" << op.second
+         << "\", dict));\n\n";
+    }
+  }
+
+  // Load the members.
+  for (const auto &op : members_) {
+    auto ty = getCtorArgTypename(&op.first);
+    os << "  " << ty << " " << op.second << ";\n";
+    os << "  ASSIGN_VALUE_OR_RETURN_ERR(" << op.second;
+    os << ", loadAttribute<" << ty << ">(dict.at(\"" << op.second
+       << "\"), *this));\n\n";
+  }
+
+  // We have all items needed to construct the node, so do so.
+  const auto nodeName = name_ + "Node";
+  os << "  " << nodeName << " *loadedNode = G_.addNode(new " << nodeName
+     << "(opName";
+  for (const auto &op : nodeOutputs_) {
+    if (hasCtorTypeParams(op.second)) {
+      os << ", " << op.second << "OutTy";
+    }
+  }
+  for (size_t i = 0, e = nodeInputs_.size(); i < e; i++) {
+    auto &op = nodeInputs_[i];
+    os << ", " << op;
+  }
+  for (const auto &op : members_) {
+    os << ", " << op.second;
+  }
+  os << "));\n\n";
+
+  // Now load a predicate if one exists.
+  os << "  if (dict.count(\"Predicate\")) {\n";
+  os << "    NodeValue Predicate;\n";
+  os << "    ASSIGN_VALUE_OR_RETURN_ERR(Predicate, "
+        "loadAttribute<NodeValue>(dict.at(\"Predicate\"), *this));\n";
+  os << "    loadedNode->setPredicate(Predicate);\n";
+  os << "  }\n\n";
+
+  // Add the node to the Function and return success.
+  os << "  RETURN_IF_ERR(addNodeAsOutput(op, loadedNode));\n";
+  os << "  return true;\n";
+  os << "}\n\n";
+}
+
+void NodeBuilder::emitExportMethods(std::ostream &os) const {
+  os << "case glow::Kinded::Kind::" << name_ << "NodeKind: {\n";
+  os << "  auto *N__ = llvm::cast<" << name_ << "Node>(node);\n";
+
+  // Add the node. Note that Glow custom ops are prefixed with "Glow_"
+  os << "  auto *opProto = graph.add_node();\n";
+  os << "  opProto->set_op_type(\"Glow_" << name_ << "\");\n";
+  os << "  opProto->set_name(N__->getName());\n";
+
+  // Add all of the node's inputs.
+  for (const auto &op : nodeInputs_) {
+    os << "  opProto->add_input(N__->get" << op
+       << "().generateNodeOutputName(/* stripResNoFor0thInput */ true));\n";
+  }
+
+  // Add all of the node's outputs.
+  for (const auto &op : nodeOutputs_) {
+    os << "  opProto->add_output(N__->get" << op.second
+       << "().generateNodeOutputName(/* stripResNoFor0thInput */ true));\n";
+    if (hasCtorTypeParams(op.second)) {
+      os << "  addTypeAttributes(opProto, N__->get" << op.second << "());\n";
+    }
+  }
+
+  // Add any members the node has.
+  for (const auto &op : members_) {
+    os << "  addValueAttribute(opProto, \"" << op.second << "\", N__->get"
+       << op.second << "());\n";
+  }
+
+  // Check if the node has a predicate and add it if so.
+  os << "  if (N__->hasPredicate()) {\n";
+  os << "    addValueAttribute(opProto, \"Predicate\",  "
+        "N__->getPredicate().generateNodeOutputName(/* stripResNoFor0thInput "
+        "*/ true));\n";
+  os << "  }\n";
+
+  os << "  break;\n";
+  os << "}\n\n";
+}
+
 NodeBuilder &NodeBuilder::addGradient() {
-  NodeBuilder GN(hStream, cStream, dStream, name_ + "Grad", isBackendSpecific_);
+  NodeBuilder GN(hStream, cStream, dStream, iStream, eStream, name_ + "Grad",
+                 isBackendSpecific_);
 
   // The new 'Grad' class will have all of the fields of the current class.
   GN.members_ = members_;
@@ -659,4 +772,8 @@ NodeBuilder &NodeBuilder::addGradient() {
 NodeBuilder::~NodeBuilder() {
   emitNodeClass(hStream);
   emitCppMethods(cStream);
+  if (!skipAutogenSerialization_) {
+    emitImportMethods(iStream);
+    emitExportMethods(eStream);
+  }
 }

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -19,19 +19,23 @@
 #include <iostream>
 
 int main(int argc, char **argv) {
-  if (argc != 4) {
-    std::cerr << "Usage: " << argv[0] << " output.h output.cpp output.def\n";
+  if (argc != 6) {
+    std::cerr << "Usage: " << argv[0]
+              << " output.h output.cpp output.def import.h export.h\n";
     return -1;
   }
 
   std::cout << "Writing node descriptors to:\n\t" << argv[1] << "\n\t"
-            << argv[2] << "\n\t" << argv[3] << "\n";
+            << argv[2] << "\n\t" << argv[3] << "\n\t" << argv[4] << "\n\t"
+            << argv[5] << "\n";
 
   std::ofstream hFile(argv[1]);
   std::ofstream cFile(argv[2]);
   std::ofstream dFile(argv[3]);
+  std::ofstream iFile(argv[4]);
+  std::ofstream eFile(argv[5]);
 
-  Builder BB(hFile, cFile, dFile);
+  Builder BB(hFile, cFile, dFile, iFile, eFile);
 
   //===--------------------------------------------------------------------===//
   //                    Input/Output nodes
@@ -52,6 +56,7 @@ int main(int argc, char **argv) {
       .addOverwrittenInput("Output")
       .setHasSideEffects(true)
       .dataParallel()
+      .skipAutogenSerialization()
       .setDocstring("Specifies a node whose Input will be copied to Output."
                     "This node prevents graph optimizations from eliminating "
                     "this node and all of its ancestor nodes. Generally "


### PR DESCRIPTION
Summary: This PR introduces the ability to use customized ONNX for serializing models. Exporting and importing logic is automatically generated via NodeGen. I've added `Serialization.md` to document some specifics if interested. Apologies in advance for the size of the PR -- I tried to separate out different logical chunks into different commits and sent out a bunch of PRs earlier last week to simplify it as much as possible.

In order to test this, I added automatic exporting/importing/testing to the `TearDown()` for OperatorTests. This uncovered a ton of gaps in our export/import logic for ONNX. I've included lots of fixes here.

As an example, here is what is automatically generated for exporting `BatchedReduceAddNode`:

```cpp
case glow::Kinded::Kind::BatchedReduceAddNodeKind: {
  auto *N__ = llvm::cast<BatchedReduceAddNode>(node);
  auto *opProto = graph.add_node();
  opProto->set_op_type("Glow_BatchedReduceAdd");
  opProto->set_name(N__->getName());
  opProto->add_input(
      N__->getBatch().generateNodeOutputName(/* stripResNoFor0thInput */ true));
  opProto->add_output(N__->getResult().generateNodeOutputName(
      /* stripResNoFor0thInput */ true));
  addTypeAttributes(opProto, N__->getResult());
  addValueAttribute(opProto, "Axis", N__->getAxis());
  if (N__->hasPredicate()) {
    addValueAttribute(opProto, "Predicate",
                      N__->getPredicate().generateNodeOutputName(
                          /* stripResNoFor0thInput */ true));
  }
  break;
}
```

And here is what is generated for loading `BatchedReduceAddNode`:
```cpp
if (typeName == "Glow_BatchedReduceAdd") {
  NodeValue Batch;
  ASSIGN_VALUE_OR_RETURN_ERR(Batch, getNodeValueByName(op.input(0)));

  TypeRef ResultOutTy;
  ASSIGN_VALUE_OR_RETURN_ERR(ResultOutTy,
                             loadTypeFromAttributes(0, dict));

  unsigned_t Axis;
  ASSIGN_VALUE_OR_RETURN_ERR(Axis,
                             loadAttribute<unsigned_t>(dict.at("Axis"), *this));

  BatchedReduceAddNode *loadedNode =
      G_.addNode(new BatchedReduceAddNode(opName, ResultOutTy, Batch, Axis));

  if (dict.count("Predicate")) {
    NodeValue Predicate;
    ASSIGN_VALUE_OR_RETURN_ERR(
        Predicate, loadAttribute<NodeValue>(dict.at("Predicate"), *this));
    loadedNode->setPredicate(Predicate);
  }

  RETURN_IF_ERR(addNodeAsOutput(op, loadedNode));
  return true;
}

```

Documentation: Added a doc on serialization.

Test Plan: All OperatorTests automatically export, load, check the original and reloaded graphs have the same structure, and runs the loaded graph to ensure it has bitwise identical results.
