### PR TITLE
Glow: use a list instead of a vector to store trace events

### DIFF
--- a/include/glow/ExecutionContext/TraceEvents.h
+++ b/include/glow/ExecutionContext/TraceEvents.h
@@ -20,6 +20,7 @@
 #include "glow/Support/ThreadPool.h"
 #include "llvm/ADT/DenseMap.h"
 
+#include <list>
 #include <map>
 #include <mutex>
 #include <vector>
@@ -94,7 +95,7 @@ struct TraceEvent {
         id(d), level(l), args(a) {}
 
   static void
-  dumpTraceEvents(std::vector<TraceEvent> &events, llvm::StringRef filename,
+  dumpTraceEvents(std::list<TraceEvent> &events, llvm::StringRef filename,
                   const std::string &processName = "",
                   const std::map<int, std::string> &threadNames = {});
 
@@ -160,7 +161,7 @@ struct TraceInfo {
 /// partitioned CompiledFunctions).
 class TraceContext {
   /// The list of materialized Events filled out with timestamp and metadata.
-  std::vector<TraceEvent> traceEvents_;
+  std::list<TraceEvent> traceEvents_;
 
   /// Human readable name mapping for trace Threads.
   std::map<int, std::string> threadNames_;
@@ -175,10 +176,7 @@ public:
   TraceContext(int level) : traceLevel_(level) {}
 
   /// \returns TraceEvents for the last run.
-  std::vector<TraceEvent> &getTraceEvents() { return traceEvents_; }
-
-  /// \returns TraceEvents for the last run.
-  llvm::ArrayRef<TraceEvent> getTraceEvents() const { return traceEvents_; }
+  std::list<TraceEvent> &getTraceEvents() { return traceEvents_; }
 
   /// \returns the level of verbosity allowed for TraceEvents.
   int getTraceLevel() { return traceLevel_; }

--- a/lib/ExecutionContext/TraceEvents.cpp
+++ b/lib/ExecutionContext/TraceEvents.cpp
@@ -35,25 +35,13 @@ void writeMetadataHelper(llvm::raw_fd_ostream &file, llvm::StringRef type,
 }
 
 void TraceEvent::dumpTraceEvents(
-    std::vector<TraceEvent> &events, llvm::StringRef filename,
+    std::list<TraceEvent> &events, llvm::StringRef filename,
     const std::string &processName,
     const std::map<int, std::string> &threadNames) {
   llvm::errs() << "dumping " << events.size() << " trace events to "
                << filename.str() << ".\n";
 
-  // Chrome trace UI has a bug with complete events which are ordered later in
-  // the json than an event they completely enclose, so sort the list of events
-  // by start time and duration.
-  std::stable_sort(events.begin(), events.end(),
-                   [](const TraceEvent &a, const TraceEvent &b) {
-                     if (a.timestamp == b.timestamp) {
-                       return a.duration > b.duration;
-                     }
-                     return a.timestamp < b.timestamp;
-                   });
-
   auto process = processName.empty() ? "glow" : processName;
-
   std::error_code EC;
   llvm::raw_fd_ostream file(filename, EC);
 


### PR DESCRIPTION
Summary:
We merge trace events together when we run with --glow_dump_debug_traces. When merging many events together, the reallocation of the vector when it grows can eventually take many milliseconds and this happens during us calling merge() under a lock. This can then create a stall in the application.

Change the underlying datastructure from a vector to a list to avoid this issue. We don't really need the random access.

Also fixed a memory leak when dumping the traces to file.

Finally, removed the sorting of the events to work around a chrome bug. From my latest testing, the traces seemed to render fine without it.

Reviewed By: yinghai

Differential Revision: D20194932

