### PR TITLE
NNPI: set better thread names for glow tracing

### DIFF
--- a/include/glow/ExecutionContext/TraceEvents.h
+++ b/include/glow/ExecutionContext/TraceEvents.h
@@ -20,6 +20,7 @@
 #include "glow/Support/ThreadPool.h"
 #include "llvm/ADT/DenseMap.h"
 
+#include <list>
 #include <map>
 #include <mutex>
 #include <vector>
@@ -94,7 +95,7 @@ struct TraceEvent {
         id(d), level(l), args(a) {}
 
   static void
-  dumpTraceEvents(std::vector<TraceEvent> &events, llvm::StringRef filename,
+  dumpTraceEvents(std::list<TraceEvent> &events, llvm::StringRef filename,
                   const std::string &processName = "",
                   const std::map<int, std::string> &threadNames = {});
 
@@ -160,7 +161,7 @@ struct TraceInfo {
 /// partitioned CompiledFunctions).
 class TraceContext {
   /// The list of materialized Events filled out with timestamp and metadata.
-  std::vector<TraceEvent> traceEvents_;
+  std::list<TraceEvent> traceEvents_;
 
   /// Human readable name mapping for trace Threads.
   std::map<int, std::string> threadNames_;
@@ -175,10 +176,7 @@ public:
   TraceContext(int level) : traceLevel_(level) {}
 
   /// \returns TraceEvents for the last run.
-  std::vector<TraceEvent> &getTraceEvents() { return traceEvents_; }
-
-  /// \returns TraceEvents for the last run.
-  llvm::ArrayRef<TraceEvent> getTraceEvents() const { return traceEvents_; }
+  std::list<TraceEvent> &getTraceEvents() { return traceEvents_; }
 
   /// \returns the level of verbosity allowed for TraceEvents.
   int getTraceLevel() { return traceLevel_; }

--- a/lib/Backends/NNPI/InferenceContext.cpp
+++ b/lib/Backends/NNPI/InferenceContext.cpp
@@ -52,13 +52,16 @@ bool InferenceContext::init(
     const std::unordered_set<const Placeholder *> &staticInputs,
     std::shared_ptr<NNPIDeviceTracing> deviceTracing,
     StaticPlaceholderMap *staticPlaceholderMap,
-    const NNPIDeviceOptions *deviceOptions) {
+    const NNPIDeviceOptions *deviceOptions, const std::string &functionName,
+    unsigned deviceId) {
   deviceOptions_ = deviceOptions;
   nnpiNetwork_ = network;
   device_ = device;
   compilationConfig_ = config;
   partialInputs_ = &partialInputs;
   deviceTracing_ = deviceTracing;
+  functionName_ = functionName;
+  deviceId_ = deviceId;
 
   LOG_AND_RETURN_IF(ERROR, staticPlaceholderMap == nullptr,
                     "InferenceContext Init was called with an invalid "
@@ -258,7 +261,9 @@ void InferenceContext::execute(RunIdentifierTy runId,
   TRACE_EVENT_SCOPE(ctx->getTraceContext(), TraceLevel::REQUEST,
                     TRACING_BACKEND_EXECUTE);
   if (ctx->getTraceContext()) {
-    ctx->getTraceContext()->setThreadName("InferenceContext");
+      ctx->getTraceContext()->setThreadName(
+          llvm::formatv("Inf ctx - device: {0}: {1}", deviceId_, functionName_)
+              .str());
   }
 
   // Pre inference input preparation.

--- a/lib/Backends/NNPI/InferenceContext.h
+++ b/lib/Backends/NNPI/InferenceContext.h
@@ -64,6 +64,12 @@ private:
   std::vector<Placeholder *> netInputPlaceholders_;
   std::vector<Placeholder *> netOutputPlaceholders_;
 
+  // Name for the function that we are executing.
+  std::string functionName_;
+
+  // Logical device ID this context maps to.
+  unsigned deviceId_;
+
 public:
   InferenceContext();
   ~InferenceContext();
@@ -79,7 +85,8 @@ public:
       const std::unordered_set<const Placeholder *> &staticInputs,
       std::shared_ptr<NNPIDeviceTracing> deviceTracing,
       StaticPlaceholderMap *staticPlaceholderMap,
-      const NNPIDeviceOptions *deviceOptions);
+      const NNPIDeviceOptions *deviceOptions, const std::string &functionName,
+      unsigned deviceId);
 };
 
 } // namespace runtime

--- a/lib/Backends/NNPI/InferencePool.cpp
+++ b/lib/Backends/NNPI/InferencePool.cpp
@@ -50,7 +50,10 @@ Error InferencePoolEnv::init(unsigned numWorkers, NNPIAdapter adapter,
                              std::shared_ptr<NNPIDeviceTracing> deviceTracing,
                              CompiledFunction *compiledFunction,
                              StaticPlaceholderMap *staticPlaceholderMap,
-                             const NNPIDeviceOptions *deviceOptions) {
+                             const NNPIDeviceOptions *deviceOptions,
+                             const std::string &functionName,
+                             unsigned deviceId) {
+
   deviceOptions_ = deviceOptions;
   if (workersPool_) {
     return MAKE_ERR("InferencePool already initialized!");
@@ -111,12 +114,12 @@ Error InferencePoolEnv::init(unsigned numWorkers, NNPIAdapter adapter,
   }
 
   for (auto &infCtx : inferenceContexts_) {
-    auto success = infCtx.init(nnpiFunction->getCompiledNetworkHandle(),
-                               nnpiFunction->getCompilationConfig(),
-                               hostNetwork_, deviceNetwork_, adapter, device,
-                               nnpiFunction->getPartialInputs(),
-                               nnpiFunction->getStaticInputs(), deviceTracing_,
-                               staticPlaceholderMap, deviceOptions);
+    auto success = infCtx.init(
+        nnpiFunction->getCompiledNetworkHandle(),
+        nnpiFunction->getCompilationConfig(), hostNetwork_, deviceNetwork_,
+        adapter, device, nnpiFunction->getPartialInputs(),
+        nnpiFunction->getStaticInputs(), deviceTracing_, staticPlaceholderMap,
+        deviceOptions, functionName, deviceId);
     if (!success) {
       return MAKE_ERR("Failed to initialize inferece context");
     }

--- a/lib/Backends/NNPI/InferencePool.h
+++ b/lib/Backends/NNPI/InferencePool.h
@@ -49,7 +49,8 @@ public:
              std::shared_ptr<NNPIDeviceTracing> deviceTracing,
              CompiledFunction *compiledFunction,
              StaticPlaceholderMap *staticPlaceholderMap,
-             const NNPIDeviceOptions *deviceOptions);
+             const NNPIDeviceOptions *deviceOptions,
+             const std::string &functionName, unsigned deviceId);
   void stop(bool block);
   void execute(RunIdentifierTy runId, std::unique_ptr<ExecutionContext> ctx,
                runtime::ResultCBTy resultCB);

--- a/lib/Backends/NNPI/NNPIDeviceManager.cpp
+++ b/lib/Backends/NNPI/NNPIDeviceManager.cpp
@@ -196,7 +196,7 @@ void NNPIDeviceManager::addNetwork(const Module *module,
     usedMemoryBytes_ += functionCost_; // TODO:: static moduleSize.
     auto err = inferenceEnvs_[func.first].init(
         numWorkersPerFunction_, adapter_, device_, deviceTracing_, func.second,
-        &staticPlaceholders_, &deviceOptions_);
+        &staticPlaceholders_, &deviceOptions_, func.first, deviceId_);
     if (err) {
       functions_.erase(func.first);
       lock.unlock();

--- a/lib/ExecutionContext/TraceEvents.cpp
+++ b/lib/ExecutionContext/TraceEvents.cpp
@@ -35,25 +35,13 @@ void writeMetadataHelper(llvm::raw_fd_ostream &file, llvm::StringRef type,
 }
 
 void TraceEvent::dumpTraceEvents(
-    std::vector<TraceEvent> &events, llvm::StringRef filename,
+    std::list<TraceEvent> &events, llvm::StringRef filename,
     const std::string &processName,
     const std::map<int, std::string> &threadNames) {
   llvm::errs() << "dumping " << events.size() << " trace events to "
                << filename.str() << ".\n";
 
-  // Chrome trace UI has a bug with complete events which are ordered later in
-  // the json than an event they completely enclose, so sort the list of events
-  // by start time and duration.
-  std::stable_sort(events.begin(), events.end(),
-                   [](const TraceEvent &a, const TraceEvent &b) {
-                     if (a.timestamp == b.timestamp) {
-                       return a.duration > b.duration;
-                     }
-                     return a.timestamp < b.timestamp;
-                   });
-
   auto process = processName.empty() ? "glow" : processName;
-
   std::error_code EC;
   llvm::raw_fd_ostream file(filename, EC);
 


### PR DESCRIPTION
Summary:
NNPI worker threads just set their thread names to be "InferenceContext". This is problematic when we are looking at traces with multiple devices with multiple functions on each: you can't tell which is which.

Fix this by putting the function name and device id in the thread name. Now traces are easier to understand.

Reviewed By: yinghai

Differential Revision: D20196265

