### PR TITLE
optimize NetworkExecutionState::bind to avoid string hashing

### DIFF
--- a/include/glow/Graph/PlaceholderBindings.h
+++ b/include/glow/Graph/PlaceholderBindings.h
@@ -105,6 +105,10 @@ public:
   /// \p P must be a valid Placeholder registered in the bindings.
   void erase(Placeholder *P);
 
+  /// Removes the existing Tensor backing Placeholder \p P; Bind \p T to \P.
+  /// \p P must be a valid Placeholder registered in the bindings.
+  void update(Placeholder *P, Tensor &&T);
+
   /// \returns a copy of the PlaceholderBindings, with each placeholder mapped
   /// to a new Tensor, with their own memory.
   PlaceholderBindings clone() const;

--- a/lib/Runtime/Executor/NetworkExecutionState.cpp
+++ b/lib/Runtime/Executor/NetworkExecutionState.cpp
@@ -70,9 +70,10 @@ void NetworkExecutionState::bind(std::unique_ptr<ExecutionContext> resultCtx,
     for (auto binding : externalIntermediates_[PH]) {
       auto resultTensor = resultPHBindings->get(PH);
       if (binding->get(PH)) {
-        binding->erase(PH);
+        binding->update(PH, resultTensor->getUnowned(PH->dims()));
+      } else {
+        binding->insert(PH, resultTensor->getUnowned(PH->dims()));
       }
-      binding->insert(PH, resultTensor->getUnowned(PH->dims()));
     }
   }
 }

--- a/lib/Runtime/Executor/ThreadPoolExecutor.cpp
+++ b/lib/Runtime/Executor/ThreadPoolExecutor.cpp
@@ -110,9 +110,16 @@ void ThreadPoolExecutor::run(const DAGNode *root,
   // executed while placeholders are being propagated for the next node
   // without the callback for that node deleting the execution state.
   inflightBarrier_.increment(numChildren);
+
+  auto *traceContext = context->getTraceContext();
+
   // Get and bind state.
   auto currentState = states_[root]->getNextNetworkExecutionState();
+  TRACE_EVENT_BEGIN(traceContext, TraceLevel::RUNTIME,
+                    "bind network execution state");
   currentState->bind(std::move(context), std::move(cb), runId);
+  TRACE_EVENT_END(traceContext, TraceLevel::RUNTIME,
+                  "bind network execution state");
 
   currentState->incrementInflightNodes(numChildren);
   for (auto const &node : root->children) {


### PR DESCRIPTION
Summary:
NetworkExecutionState::bind takes around 0.5ms for a sample workload. Most cpu intensive part of this is us removing the name from the nameMap_ and then immediately add it in again. So add an update function in PlaceholderBinding so we only swap out the underlying tensor without doing anything to the nameMap.

This reduced the overhead from ~0.5ms to ~0.2ms.

Differential Revision: D20228515

