### PR TITLE
More improvement to glow traces

### DIFF
--- a/lib/ExecutionContext/TraceEvents.cpp
+++ b/lib/ExecutionContext/TraceEvents.cpp
@@ -58,9 +58,11 @@ void TraceEvent::dumpTraceEvents(
 
   /// And thread name metadata.
   for (const auto &nameMap : threadNames) {
+    // Put thread name ahead of thread ID so chrome will group thread with the
+    // same prefix together.
     writeMetadataHelper(
         file, "thread_name", nameMap.first,
-        llvm::formatv("{0}: {1}", nameMap.first, nameMap.second).str());
+        llvm::formatv("{1}: {0}", nameMap.first, nameMap.second).str());
   }
 
   bool first{true};

--- a/lib/Onnxifi/HostManagerOnnxifi.cpp
+++ b/lib/Onnxifi/HostManagerOnnxifi.cpp
@@ -270,9 +270,12 @@ void dumpTraces(TraceContext *traceContext) {
 onnxStatus HostManagerGraph::run(std::unique_ptr<ExecutionContext> ctx,
                                  EventPtr outputEvent,
                                  onnxTraceEventList *traceEvents) {
+  auto threadId = threads::getThreadId();
+  auto startTime = TraceEvent::now();
+
   backendPtr_->runNetwork(
       this, std::move(ctx),
-      [outputEvent, traceEvents,
+      [outputEvent, traceEvents, threadId, startTime,
        this](runtime::RunIdentifierTy runId, Error err,
              std::unique_ptr<ExecutionContext> ctx) mutable {
         TRACE_EVENT_SCOPE(ctx->getTraceContext(), TraceLevel::RUNTIME,
@@ -290,6 +293,15 @@ onnxStatus HostManagerGraph::run(std::unique_ptr<ExecutionContext> ctx,
 
         auto *traceContext = ctx->getTraceContext();
         if (traceContext) {
+          // We want to log the async start event with the original caller's
+          // threadId. This way, chrome UI will put the async event next to the
+          // caller thread.
+          traceContext->logTraceEvent("glow e2e", TraceLevel::RUNTIME,
+                                      TraceEvent::AsyncBeginType, startTime, {},
+                                      threadId, runId);
+          traceContext->logTraceEvent(
+              "glow e2e", TraceLevel::RUNTIME, TraceEvent::AsyncEndType,
+              TraceEvent::now(), {}, threads::getThreadId(), runId);
           setTraceEvents(traceEvents, traceContext);
         }
 


### PR DESCRIPTION
Summary:
- Set the thread names to 'name - tid' instead of 'tid - name'. This helps chrome to group related threads together.
- Instrument the queuing time in between device manager thread finished with inference and host manager thread handling the result.
- Moved the e2e trace to be associated with the caller. Now it measures the total time from caller calling into run() and getting the result.

Reviewed By: yinghai

Differential Revision: D20199213

