### PR TITLE
Fix null context bug in HostManager

### DIFF
--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -463,9 +463,6 @@ HostManager::runNetwork(llvm::StringRef networkName,
           std::move(context));
       return currentRun;
     }
-    // Setup the request
-    InferRequest queuedRequest(networkName, std::move(context), callback,
-                               priority, currentRun);
     // Put the request in the queue.
     {
       std::shared_lock<std::shared_timed_mutex> lock(inferQueueLock_);
@@ -485,6 +482,9 @@ HostManager::runNetwork(llvm::StringRef networkName,
         return currentRun;
       }
     }
+    // Setup the request
+    InferRequest queuedRequest(networkName, std::move(context), callback,
+                               priority, currentRun);
     {
       std::unique_lock<std::shared_timed_mutex> lock(inferQueueLock_);
       inferQueue_.push(std::move(queuedRequest));


### PR DESCRIPTION
Summary: Previously, if we ever enter the `RUNTIME_REQUEST_REFUSED`, we return a context which is just moved out when we construct the `InferRequest`. Referencing to that context in the callback will thus cause segfault. It's fixed by deferring the construction of `InferRequest`.

Differential Revision: D20244238

