### PR TITLE
Add numerical equivalence check to GraphOptzTest.BatchNormAfterConvNotOptimizeForTrain

### DIFF
--- a/tests/unittests/GraphOptzTest.cpp
+++ b/tests/unittests/GraphOptzTest.cpp
@@ -717,7 +717,7 @@ TEST_F(GraphOptz, transposeConstantWithPredicate) {
 }
 
 TEST_F(GraphOptz, BatchNormAfterConvNotOptimizeForTrain) {
-  Node *A =
+  Placeholder *A =
       mod_.createPlaceholder(ElemKind::FloatTy, {1, 10, 20, 3}, "A", false);
   Node *CV = F_->createConv(bindings_, "conv", A, 16, 5, 1, 2, 1);
   Node *BN =
@@ -726,10 +726,11 @@ TEST_F(GraphOptz, BatchNormAfterConvNotOptimizeForTrain) {
 
   EXPECT_EQ(F_->getNodes().size(), 3);
 
-  ::glow::optimize(F_, CompilationMode::Train);
-  EXPECT_EQ(F_->getNodes().size(), 3);
+  optimizedF_ = F_->clone(F_->getName().str() + "_optimized");
+  ::glow::optimize(optimizedF_, CompilationMode::Train);
+  EXPECT_EQ(optimizedF_->getNodes().size(), 3);
 
-  ASSERT_EQ(A->getNumUsers(), 1);
+  ASSERT_EQ(A->getNumUsers(), 2);
   Node *curCV = A->getUsers().begin()->getUser();
   EXPECT_EQ(curCV, CV);
   ASSERT_EQ(curCV->getNumUsers(), 1);
@@ -738,6 +739,10 @@ TEST_F(GraphOptz, BatchNormAfterConvNotOptimizeForTrain) {
   ASSERT_EQ(curBN->getNumUsers(), 1);
   Node *save = curBN->getUsers().begin()->getUser();
   EXPECT_TRUE(llvm::isa<SaveNode>(save));
+
+  bindings_.allocate(mod_.getPlaceholders());
+  bindings_.get(A)->getHandle().randomize(-1.0, 1.0, mod_.getPRNG());
+  checkNumericalEquivalence();
 }
 
 TEST_F(GraphOptz, batchNormAfterConvNotOptimizeWhenMoreThanOneUseOfConv) {


### PR DESCRIPTION
Summary:
Add a numeric equivalence test to the `batchNormAfterConvNotOptimizeForTrain` subtest in `GraphOptzTest`.  The original test ensures there are no structural changes to the graph when `BatchNormalization` nodes are optimized/compiled in training mode; this addition confirms that there is *numeric* equivalence on the original and optimized graphs.

Test Plan:
`ninja all && test/GraphOptzTest`
```
[----------] Global test environment tear-down
[==========] 128 tests from 4 test suites ran. (977 ms total)
[  PASSED  ] 128 tests.
```