### PR TITLE
repro tool: install signal handler to print stacktrace when it crashes

### DIFF
--- a/tests/unittests/Repro.cpp
+++ b/tests/unittests/Repro.cpp
@@ -29,6 +29,7 @@
 
 #include "google/protobuf/io/coded_stream.h"
 #include "google/protobuf/io/zero_copy_stream_impl.h"
+#include <glog/logging.h>
 
 #include <fstream>
 #include <string>
@@ -729,6 +730,8 @@ int run() {
 } // namespace
 
 int main(int argc, char **argv) {
+  google::InitGoogleLogging(argv[0]);
+  google::InstallFailureSignalHandler();
   parseCommandLine(argc, argv);
   return run();
 }


### PR DESCRIPTION
Summary: We don't have the glog failure handler in the repro tool. When it crashes or aborts, it doesn't print a human readable stack which makes debugging very frustrating.

Differential Revision: D20254987

