### PR TITLE
Add more meta info for custom exporting

### DIFF
--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -366,10 +366,12 @@ constexpr char qScaleSignifier[] = "qScale";
 constexpr char qOffsetSignifier[] = "qOffset";
 constexpr char shapeSignifier[] = "shape";
 
-/// \returns the string ID for a type attribute property for a specific \p resNo
-/// and \p signifier, e.g. to retrieve result number 0's shape.
-inline std::string getTypeAttrID(unsigned resNo, const std::string &signifier) {
-  return "o" + std::to_string(resNo) + "_" + signifier;
+/// \returns the string ID for a type attribute property for a specific \p ioNum
+/// and \p signifier and whether \p isInput. E.g. to retrieve result number 0's
+/// shape, you'd pass `(0, "shape", false)`.
+inline std::string getTypeAttrID(unsigned ioNum, const std::string &signifier,
+                                 bool isInput = false) {
+  return (isInput ? "i" : "o") + std::to_string(ioNum) + "_" + signifier;
 }
 
 } // namespace glow

--- a/tools/ClassGen/NodeBuilder.cpp
+++ b/tools/ClassGen/NodeBuilder.cpp
@@ -677,15 +677,21 @@ void NodeBuilder::emitExportMethods(std::ostream &os) const {
   for (const auto &op : nodeInputs_) {
     os << "  opProto->add_input(N__->get" << op
        << "().generateNodeOutputName(/* stripResNoFor0thInput */ true));\n";
+    // Note: Add each input's type attributes so that other tools have easy
+    // visibility into types. This info may go ignored by the importer.
+    os << "  addTypeAttributes(opProto, N__, " << name_ << "Node::" << op
+       << "Idx, /* isInput */ true);\n";
   }
 
   // Add all of the node's outputs.
   for (const auto &op : nodeOutputs_) {
     os << "  opProto->add_output(N__->get" << op.second
        << "().generateNodeOutputName(/* stripResNoFor0thInput */ true));\n";
-    if (hasCtorTypeParams(op.second)) {
-      os << "  addTypeAttributes(opProto, N__->get" << op.second << "());\n";
-    }
+    // Note: export the type attributes even if not needed by the importer, so
+    // that other tools have easy visibility into types. This info may go
+    // ignored by the importer.
+    os << "  addTypeAttributes(opProto, N__, " << name_ << "Node::" << op.second
+       << "Idx, /* isInput */ false);\n";
   }
 
   // Add any members the node has.


### PR DESCRIPTION
Summary:
During exporting:
- Add type attributes for inputs, prefixed with `i#_`
- Always dump shape info for outputs even if not needed by the importer

Differential Revision: D20313228

