### PR TITLE
[GraphOptimizer]Bug fix for Conversion Optimizations in the case of constant input

### DIFF
--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -2838,7 +2838,9 @@ bool OptimizeConversions::run(Function *F, const CompilationContext &cctx) {
       if (auto *BN = llvm::dyn_cast<Constant>(CN->getInput())) {
         auto newConst =
             convertConstant(*F->getParent(), *BN, CN->getResult().getType());
-        LOG_ASSERT(newConst) << "Constant conversion failed.";
+        if (newConst == NodeValue()) {
+          continue;
+        }
         CN->getResult().replaceAllUsesOfWith(newConst, F);
         changed = true;
         continue;

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -658,9 +658,7 @@ protected:
       auto *dequantize =
           llvm::dyn_cast<DequantizeNode>((*val.getUsers().begin()).getUser());
       TypeRef outTy = val.getType();
-      auto name =
-          NodeValue::generateNodeOutputName(dequantize->getName(), outNum);
-
+      auto name = dequantize->getResult().generateNodeOutputName();
       nodeToTQP_[name] = {outTy->getScale(), outTy->getOffset()};
     }
   } // namespace


### PR DESCRIPTION
Due to optimize conversions, Conversion from Int32 to Int64 throws an error in the case of Constant Input. convertConstant API gives NodeValue default value in this case and it replaces the current node with empty NodeValue. This is an addition just like in OptimizeQuantization API. 

I have not added any test case as it is a bug fix. Please add constant folding tests for the Cast Operator too. 