### PR TITLE
[Quantization] Prefixing quantization node name with the output node name

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -868,6 +868,21 @@ public:
   DECLARE_BROADCAST_NODE(Add, /* NUM_INPUTS */ 2)
   DECLARE_BROADCAST_NODE(Sub, /* NUM_INPUTS */ 2)
 
+#define DECLARE_CMP_BROADCAST_NODE(NODE_NAME)                                  \
+  template <class T, class... Args>                                            \
+  typename enable_if_same_t<T, NODE_NAME##Node>::type *                        \
+  createNodeWithBroadcast(const std::string &name, int axis,                   \
+                          Args &&... inputArgs) {                              \
+    BROADCAST_FUNC_COMMON_CODE(2)                                              \
+    return create##NODE_NAME(name, inputs[0], inputs[1]);                      \
+  }
+
+  /// Template function that creates a node and normalizes its input shapes
+  /// with the use of BroadCast nodes. If axis is -1, it calculates it
+  /// automatically for multi directional broadcast.
+  DECLARE_CMP_BROADCAST_NODE(CmpLT)
+  DECLARE_CMP_BROADCAST_NODE(CmpLTE)
+
   /// Template function that creates a node and normalizes its input shapes
   /// with the use of BroadCast nodes. If axis is -1, it calculates it
   /// automatically for multi directional broadcast.
@@ -880,19 +895,9 @@ public:
                         inputs[2]);
   }
 
-  /// Template function that creates a node and normalizes its input shapes
-  /// with the use of BroadCast nodes. If axis is -1, it calculates it
-  /// automatically for multi directional broadcast.
-  template <class T, class... Args>
-  typename enable_if_same_t<T, CmpLTNode>::type *
-  createNodeWithBroadcast(const std::string &name, int axis,
-                          Args &&... inputArgs) {
-    BROADCAST_FUNC_COMMON_CODE(2)
-    return createCmpLT(name, inputs[0], inputs[1]);
-  }
-
 #undef BROADCAST_FUNC_COMMON_CODE
 #undef DECLARE_BROADCAST_NODE
+#undef DECLARE_CMP_BROADCAST_NODE
 #undef BROADCAST_FUNC_COMMON_CODE
 
   /// Create a node that produces an boolean output of the same shape as

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -2591,7 +2591,9 @@ Error ONNXModelLoader::loadCmpLTE(const ONNX_NAMESPACE::NodeProto &op,
   NodeValue RHS;
   ASSIGN_VALUE_OR_RETURN_ERR(RHS, getNodeValueByName(op.input(1)));
 
-  Node *N = G_.createCmpLTE(loadOperatorName(op), LHS, RHS);
+  int axis = -1;
+  Node *N = G_.createNodeWithBroadcast<CmpLTENode>(loadOperatorName(op), axis,
+                                                   LHS, RHS);
 
   RETURN_IF_ERR(addNodeAsOutput(op, N));
   return Error::success();

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -658,9 +658,7 @@ protected:
       auto *dequantize =
           llvm::dyn_cast<DequantizeNode>((*val.getUsers().begin()).getUser());
       TypeRef outTy = val.getType();
-      auto name =
-          NodeValue::generateNodeOutputName(dequantize->getName(), outNum);
-
+      auto name = dequantize->getResult().generateNodeOutputName();
       nodeToTQP_[name] = {outTy->getScale(), outTy->getOffset()};
     }
   } // namespace

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -421,9 +421,8 @@ protected:
   ///
   /// \pre One of t\p val's type and \p destTy must be FloatTy and
   ///      the other must be a quantized type.
-  Node *createConversion(Function &function, const Node &node,
-                         NodeValue &val, TypeRef destTy,
-                         bool /* isInput */) override {
+  Node *createConversion(Function &function, const Node &node, NodeValue &val,
+                         TypeRef destTy, bool /* isInput */) override {
     assert((&function == &function_) &&
            "Trying to add quantize/dequantize conversion to a function other "
            "than the function being quantized.");

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -421,18 +421,19 @@ protected:
   ///
   /// \pre One of t\p val's type and \p destTy must be FloatTy and
   ///      the other must be a quantized type.
-  Node *createConversion(Function &function, const Node & /* unused */,
+  Node *createConversion(Function &function, const Node &node,
                          NodeValue &val, TypeRef destTy,
                          bool /* isInput */) override {
     assert((&function == &function_) &&
            "Trying to add quantize/dequantize conversion to a function other "
            "than the function being quantized.");
+    std::string nodeName = node.getName();
     if (destTy->isQuantizedType()) {
-      return function.createQuantize("quantize", val, destTy);
+      return function.createQuantize(nodeName + "_quantize", val, destTy);
     }
     assert(destTy->getElementType() == ElemKind::FloatTy &&
            "Can't dequantize to any type except float.");
-    return function.createDequantize("dequantize", val);
+    return function.createDequantize(nodeName + "_dequantize", val);
   }
 
   /// All IRConstraint cases below assume that the input and output index that

--- a/tests/models/onnxModels/CmpLTE.onnxtxt
+++ b/tests/models/onnxModels/CmpLTE.onnxtxt
@@ -1,0 +1,90 @@
+ir_version: 5
+domain: "onnx"
+# ONNX TensorProto.DataType:
+#    UNDEFINED = 0;
+#    FLOAT = 1;
+#    UINT8 = 2;
+#    INT8 = 3;
+#    UINT16 = 4;
+#    INT16 = 5;
+#    INT32 = 6;
+#    INT64 = 7;
+#    STRING = 8;
+#    BOOL = 9;
+#    FLOAT16 = 10;
+#    DOUBLE = 11;
+#    UINT32 = 12;
+#    UINT64 = 13;
+#    COMPLEX64 = 14;
+#    COMPLEX128 = 15;
+graph {
+  input {
+    name: "X"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+         dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "Y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+         dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+   node {
+       input: "X"
+       input: "Y"
+       output: "Out"
+       name: "LTENode"
+       op_type: "CmpLTE"
+       domain: ""
+   }
+
+output {
+    name: "Out"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 10
+}

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -2732,6 +2732,37 @@ TEST_F(OnnxImporterTest, importLess) {
   EXPECT_EQ(CMPLT->getResult().dims()[2], 1);
 }
 
+TEST(onnx, importLessEqual) {
+  ExecutionEngine EE{};
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+
+  std::string netFilename(GLOW_DATA_PATH
+                          "tests/models/onnxModels/CmpLTE.onnxtxt");
+
+  Placeholder *out = nullptr;
+  {
+    Tensor X(ElemKind::FloatTy, {1, 4, 1});
+    Tensor Y(ElemKind::FloatTy, {4, 1, 1});
+    X.zero();
+    Y.zero();
+
+    ONNXModelLoader onnxLD(netFilename, {"X", "Y"},
+                           {&X.getType(), &Y.getType()}, *F);
+    out = EXIT_ON_ERR(onnxLD.getOutputByName("Out"));
+  }
+
+  auto *save = getSaveNodeFromDest(out);
+
+  CmpLTENode *CMPLTE = llvm::dyn_cast<CmpLTENode>(save->getInput().getNode());
+
+  ASSERT_TRUE(CMPLTE);
+  ASSERT_EQ(CMPLTE->getResult().dims().size(), 3);
+  EXPECT_EQ(CMPLTE->getResult().dims()[0], 4);
+  EXPECT_EQ(CMPLTE->getResult().dims()[1], 4);
+  EXPECT_EQ(CMPLTE->getResult().dims()[2], 1);
+}
+
 /// Test loading NMS using initializer nodes op from an ONNX model.
 TEST_F(OnnxImporterTest, importNMSInitializer) {
   ExecutionEngine EE{};


### PR DESCRIPTION
Summary:
When we enable quantization for very large models (recommendation systems) with the number of nodes > 10000, GLOW throws LLVM out of memory error. This error is generated from the [uniqueName](https://github.com/pytorch/glow/blob/master/lib/Graph/Graph.cpp#L607) API because of loop constraint of 10000. 
The way in which quantize and dequantize nodes are created, we get quantization nodes with names quantize/dequantize. This causes multiple nodes with the same name and uniqueName API gives LLVM out of memory error. 

[Optional Fixes #issue]
Prefixing quantization node name with the output node name

Test Plan:
An internal model is used for testing and cannot be shared. 
