### PR TITLE
[Quantization] Prefixing quantization/dequantization node names with the output node name

### DIFF
--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -421,18 +421,18 @@ protected:
   ///
   /// \pre One of t\p val's type and \p destTy must be FloatTy and
   ///      the other must be a quantized type.
-  Node *createConversion(Function &function, const Node & /* unused */,
-                         NodeValue &val, TypeRef destTy,
-                         bool /* isInput */) override {
+  Node *createConversion(Function &function, const Node &node, NodeValue &val,
+                         TypeRef destTy, bool /* isInput */) override {
     assert((&function == &function_) &&
            "Trying to add quantize/dequantize conversion to a function other "
            "than the function being quantized.");
+    std::string nodeName = node.getName();
     if (destTy->isQuantizedType()) {
-      return function.createQuantize("quantize", val, destTy);
+      return function.createQuantize(nodeName + "_quantize", val, destTy);
     }
     assert(destTy->getElementType() == ElemKind::FloatTy &&
            "Can't dequantize to any type except float.");
-    return function.createDequantize("dequantize", val);
+    return function.createDequantize(nodeName + "_dequantize", val);
   }
 
   /// All IRConstraint cases below assume that the input and output index that


### PR DESCRIPTION
Summary:
When we enable quantization for very large models (recommendation systems) with the number of nodes > 10000, GLOW throws LLVM out of memory error. This error is generated from the [uniqueName](https://github.com/pytorch/glow/blob/master/lib/Graph/Graph.cpp#L607) API because of loop constraint of 10000.

The way in which quantize and dequantize nodes are created, we get quantization nodes with names quantize/dequantize. This causes multiple nodes with the same name and uniqueName API gives LLVM out of memory error.

[Optional Fixes #issue]Prefixing quantization node name with the output node name

Test Plan:
Not adding any test case as an internal model is used for testing and cannot be shared.