### PR TITLE
[Examples] Fix MaxPool layer connections in cifar10 example

### DIFF
--- a/examples/cifar10.cpp
+++ b/examples/cifar10.cpp
@@ -65,15 +65,16 @@ static Placeholder *createDefaultModel(PlaceholderBindings &bindings,
   auto *RL0 = F->createRELU("relu", CV0);
   auto *MP0 = F->createMaxPool("pool", RL0, 2, 2, 0);
 
-  auto *CV1 = F->createConv(bindings, "conv", MP0, 20, 5, 1, 2, 1);
+  auto *CV1 = F->createConv(bindings, "conv", MP0->getResult(), 20, 5, 1, 2, 1);
   auto *RL1 = F->createRELU("relu", CV1);
   auto *MP1 = F->createMaxPool("pool", RL1, 2, 2, 0);
 
-  auto *CV2 = F->createConv(bindings, "conv", MP1, 20, 5, 1, 2, 1);
+  auto *CV2 = F->createConv(bindings, "conv", MP1->getResult(), 20, 5, 1, 2, 1);
   auto *RL2 = F->createRELU("relu", CV2);
   auto *MP2 = F->createMaxPool("pool", RL2, 2, 2, 0);
 
-  auto *FCL1 = F->createFullyConnected(bindings, "fc", MP2, numLabels);
+  auto *FCL1 =
+      F->createFullyConnected(bindings, "fc", MP2->getResult(), numLabels);
   auto *SM = F->createSoftMax("softmax", FCL1, expected);
   auto *save = F->createSave("ret", SM);
   return save->getPlaceholder();


### PR DESCRIPTION
Summary:

Due to some change in the MaxPool API, connections in the graph need to be made via getResult; the cifar10 example was not updated to fix this problem and caused a runtime error when using the default graph.

Fixes: 

https://github.com/pytorch/glow/issues/4158

