### PR TITLE
[Operator] Add dilation support to ConvTranspose operator

### DIFF
--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -244,13 +244,10 @@ inline std::pair<dim_t, dim_t> calculateConvTransposeOutputDims(
   ShapeHW kdim(kernels);
   ShapeHW sdim(strides);
 
-  assert((dilation == 1) &&
-         "ConvTranspose output calculation doesn't support dilation");
-
-  size_t outsx = (sx - 1) * sdim.height + (kdim.height - 1) * (dilation - 1) -
-                 pdim.top - pdim.bottom + kdim.height;
-  size_t outsy = (sy - 1) * sdim.width + (kdim.width - 1) * (dilation - 1) -
-                 pdim.left - pdim.right + kdim.width;
+  size_t outsx = (sx - 1) * sdim.height + (kdim.height - 1) * dilation + 1 -
+                 pdim.top - pdim.bottom;
+  size_t outsy = (sy - 1) * sdim.width + (kdim.width - 1) * dilation + 1 -
+                 pdim.left - pdim.right;
 
   return {outsx, outsy};
 }

--- a/lib/Backends/CPU/libjit/libjit_conv.cpp
+++ b/lib/Backends/CPU/libjit/libjit_conv.cpp
@@ -579,8 +579,8 @@ void libjit_conv_transpose_f(float *outW, const float *inW,
 
             for (dim_t kx = 0; kx < kernel_h; kx++) {
               for (dim_t ky = 0; ky < kernel_w; ky++) {
-                ssize_t ax = x + kx;
-                ssize_t ay = y + ky;
+                ssize_t ax = x + kx * dilation;
+                ssize_t ay = y + ky * dilation;
 
                 if (ax < 0 || ay < 0 || ax >= (ssize_t)outWdims[1] ||
                     ay >= (ssize_t)outWdims[2]) {

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -368,7 +368,6 @@ void BoundInterpreterFunction::fwdConvTransposeInstFloatImpl(
 
   assert(idim.c % group == 0 && "Input channels must be divisible by group.");
   assert(odim.c % group == 0 && "Output channels must be divisible by group.");
-  assert(dilation == 1 && "Dilation must be 1.");
   assert(group == 1 && "Group must be 1.");
 
   dim_t inCperG = idim.c / group;

--- a/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
@@ -327,6 +327,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "sanityConvTranspose2OutCh/0",
     "sanityConvTranspose1OutCh/0",
     "sanityConvTransposeStrided/0",
+    "sanityConvTransposeDilated/0",
     "sanityConvTransposePads/0",
     "convTransposeCompareSimpleK8S1P0I3/0",
     "convTransposeCompareSimpleK6S1P1I4/0",

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -892,13 +892,13 @@ Expected<Pads> getPads(ArgumentDictionaryTy &dict,
 /// \p idim: input sizes (HW)
 static Expected<Pads> getConvTransposePadsfromOutput(
     ArgumentDictionaryTy &dict, llvm::ArrayRef<unsigned_t> kdim,
-    llvm::ArrayRef<unsigned_t> sdim, llvm::ArrayRef<unsigned_t> idim,
-    llvm::ArrayRef<unsigned_t> odim) {
+    llvm::ArrayRef<unsigned_t> sdim, unsigned_t dilation,
+    llvm::ArrayRef<unsigned_t> idim, llvm::ArrayRef<unsigned_t> odim) {
 
   llvm::SmallVector<unsigned_t, 2> pdim(2); // Total Paddding, HW.
   for (size_t i = 0, e = pdim.size(); i < e; i++) {
     pdim[i] = sdim[i] * (idim[i] - 1) /* + output_padding[0]*/ +
-              ((kdim[i] - 1) /* * dilations[i]*/ + 1) - odim[i];
+              ((kdim[i] - 1) * dilation + 1) - odim[i];
   }
 
   unsigned_t top, left, bottom, right;
@@ -1338,8 +1338,17 @@ Error ONNXModelLoader::loadConvTranspose(const ONNX_NAMESPACE::NodeProto &op,
   }
 
   unsigned_t dilation = 1;
-  if (dict.count("dilation")) {
-    ASSIGN_VALUE_OR_RETURN_ERR(dilation, loadInt(dict.at("dilation")));
+  if (dict.count("dilations")) {
+    std::vector<unsigned_t> dilations;
+    ASSIGN_VALUE_OR_RETURN_ERR(dilations,
+                               getShape<unsigned_t>(dict["dilations"]));
+    RETURN_ERR_IF_NOT(dilations.size() == 2,
+                      "ConvTranspose: dilations must be specified for 2 axes.");
+    RETURN_ERR_IF_NOT(
+        dilations[1] == dilations[0],
+        "ConvTranspose: different dilation values along different axes "
+        "are not supported currently. values must be same.");
+    dilation = dilations[0];
   }
 
   // Load the inputs
@@ -1418,8 +1427,8 @@ Error ONNXModelLoader::loadConvTranspose(const ONNX_NAMESPACE::NodeProto &op,
     ASSIGN_VALUE_OR_RETURN_ERR(outShape,
                                getShape<unsigned_t>(dict["output_shape"]));
     ASSIGN_VALUE_OR_RETURN_ERR(
-        pads, getConvTransposePadsfromOutput(dict, kernels, strides, idimHW,
-                                             outShape));
+        pads, getConvTransposePadsfromOutput(dict, kernels, strides, dilation,
+                                             idimHW, outShape));
     outSz = {outShape[0], outShape[1]};
 
     std::pair<dim_t, dim_t> outSzTest = calculateConvTransposeOutputDims(

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -1958,7 +1958,6 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     auto *filterPtr = emitValueAddress(builder, filter);
     auto *biasPtr = emitValueAddress(builder, bias);
 
-    assert(CI->getDilation() == 1 && "Dilation != 1 is not supported.");
     assert(CI->getGroup() == 1 && "Group != 1 is not supported.");
 
     auto *destDims = emitValueDims(builder, dest);

--- a/tests/models/onnxModels/simpleConvTransposeOutShapeDilation.onnxtxt
+++ b/tests/models/onnxModels/simpleConvTransposeOutShapeDilation.onnxtxt
@@ -1,0 +1,130 @@
+ir_version: 6
+producer_name: "onnx-convtranspose"
+graph {
+  node {
+    input: "data"
+    input: "W"
+    input: "B"
+    output: "y"
+    op_type: "ConvTranspose"
+    attribute {
+      name: "dilations"
+      ints: 2
+      ints: 2
+      type: INTS
+    }
+    attribute {
+      name: "output_shape"
+      ints: 6
+      ints: 6
+      type: INTS
+    }
+  }
+  name: "test-convtranspose"
+  initializer {
+    dims: 1
+    dims: 1
+    dims: 3
+    dims: 3
+    data_type: 1
+    float_data: 2.0
+    float_data: 3.0
+    float_data: 4.0
+    float_data: 5.0
+    float_data: 6.0
+    float_data: 7.0
+    float_data: 8.0
+    float_data: 9.0
+    float_data: 10.0
+    name: "W"
+  }
+  initializer {
+    dims: 1
+    data_type: 1
+    float_data: 0.0
+    name: "B"
+  }
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "W"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "B"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 6
+          }
+          dim {
+            dim_value: 6
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 4
+}

--- a/tests/unittests/OnnxExporterTest.cpp
+++ b/tests/unittests/OnnxExporterTest.cpp
@@ -189,6 +189,8 @@ TEST(exporter, onnxModels) {
         name.find("Less.onnxtxt") != std::string::npos ||
         name.find("simpleConvTranspose.onnxtxt") != std::string::npos ||
         name.find("simpleConvTransposeOutShape.onnxtxt") != std::string::npos ||
+        name.find("simpleConvTransposeOutShapeDilation.onnxtxt") !=
+            std::string::npos ||
         name.find("simpleConvTransposePads.onnxtxt") != std::string::npos ||
         name.find("simpleConvTransposeAutoPadValid.onnxtxt") !=
             std::string::npos ||

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -790,6 +790,19 @@ TEST(onnx, importConvTransposeOutputShape) {
   convTransposeTestHelper(filename, expectedDims, expectedValues);
 }
 
+/// Test loading conv op from a ONNX model.
+/// The input is N*C*H*W (1*1*2*2), the kernels is {3, 3},
+/// strides is {1, 1}, dilations is {2, 2},
+/// auto_pad is not set, group is 1.
+TEST(onnx, importConvTransposeOutputShapeDilation) {
+  std::string filename("simpleConvTransposeOutShapeDilation.onnxtxt");
+  std::vector<dim_t> expectedDims = {1, 1, 6, 6};
+  std::vector<float> expectedValues = {
+      4,  6,  6,  9,  8,  12, 8,  10, 12, 15, 16, 20, 10, 15, 12, 18, 14, 21,
+      20, 25, 24, 30, 28, 35, 16, 24, 18, 27, 20, 30, 32, 40, 36, 45, 40, 50};
+  convTransposeTestHelper(filename, expectedDims, expectedValues);
+}
+
 /// Helper method to run the AveragePool operator test cases.
 /// \p filename contains the model .onnxtxt.
 /// \p expectedDims: output Tensor dimensions.

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -6351,6 +6351,82 @@ TEST_P(OperatorTest, sanityConvTransposeStrided) {
   EXPECT_FLOAT_EQ(result.at({0, 4, 4, 0}), 50);
 }
 
+/// ConvTranspose with easy to calculate output values. 2x2 input, 1-ch input,
+/// 1-ch output.
+TEST_P(OperatorTest, sanityConvTransposeDilated) {
+  CHECK_IF_ENABLED()
+
+  auto *input =
+      mod_.createPlaceholder(ElemKind::FloatTy, {1, 2, 2, 1}, "input", false);
+  bindings_.allocate(input)->getHandle() = {2., 3., 4., 5.};
+
+  auto *filter =
+      mod_.createPlaceholder(ElemKind::FloatTy, {1, 3, 3, 1}, "filter", false);
+  bindings_.allocate(filter)->getHandle() = {2., 3., 4., 5., 6.,
+                                             7., 8., 9., 10.};
+
+  auto *bias = mod_.createPlaceholder(ElemKind::FloatTy, {1}, "bias", false);
+  bindings_.allocate(bias)->zero();
+
+  std::pair<dim_t, dim_t> outWH =
+      calculateConvTransposeOutputDims(2, 2, {3, 3}, {1, 1}, {0, 0, 0, 0}, 2);
+  auto outTy =
+      mod_.uniqueType(ElemKind::FloatTy, {1, outWH.first, outWH.second, 1});
+
+  ConvTransposeNode *CN =
+      F_->createConvTranspose("ConvTranspose", input, filter, bias, outTy,
+                              {3, 3}, {1, 1}, {0, 0, 0, 0}, 1, 2);
+
+  SaveNode *S = F_->createSave("save", CN);
+  bindings_.allocate(S->getPlaceholder());
+
+  ::glow::convertPlaceholdersToConstants(F_, bindings_,
+                                         {input, S->getPlaceholder()});
+  EE_.compile(CompilationMode::Infer);
+  EE_.run(bindings_);
+
+  auto result = bindings_.get(S->getPlaceholder())->getHandle();
+  std::vector<dim_t> expectedDims = {1, 6, 6, 1};
+
+  ASSERT_TRUE(result.dims().vec() == expectedDims);
+  EXPECT_FLOAT_EQ(result.at({0, 0, 0, 0}), 4);
+  EXPECT_FLOAT_EQ(result.at({0, 0, 1, 0}), 6);
+  EXPECT_FLOAT_EQ(result.at({0, 0, 2, 0}), 6);
+  EXPECT_FLOAT_EQ(result.at({0, 0, 3, 0}), 9);
+  EXPECT_FLOAT_EQ(result.at({0, 0, 4, 0}), 8);
+  EXPECT_FLOAT_EQ(result.at({0, 0, 5, 0}), 12);
+  EXPECT_FLOAT_EQ(result.at({0, 1, 0, 0}), 8);
+  EXPECT_FLOAT_EQ(result.at({0, 1, 1, 0}), 10);
+  EXPECT_FLOAT_EQ(result.at({0, 1, 2, 0}), 12);
+  EXPECT_FLOAT_EQ(result.at({0, 1, 3, 0}), 15);
+  EXPECT_FLOAT_EQ(result.at({0, 1, 4, 0}), 16);
+  EXPECT_FLOAT_EQ(result.at({0, 1, 5, 0}), 20);
+  EXPECT_FLOAT_EQ(result.at({0, 2, 0, 0}), 10);
+  EXPECT_FLOAT_EQ(result.at({0, 2, 1, 0}), 15);
+  EXPECT_FLOAT_EQ(result.at({0, 2, 2, 0}), 12);
+  EXPECT_FLOAT_EQ(result.at({0, 2, 3, 0}), 18);
+  EXPECT_FLOAT_EQ(result.at({0, 2, 4, 0}), 14);
+  EXPECT_FLOAT_EQ(result.at({0, 2, 5, 0}), 21);
+  EXPECT_FLOAT_EQ(result.at({0, 3, 0, 0}), 20);
+  EXPECT_FLOAT_EQ(result.at({0, 3, 1, 0}), 25);
+  EXPECT_FLOAT_EQ(result.at({0, 3, 2, 0}), 24);
+  EXPECT_FLOAT_EQ(result.at({0, 3, 3, 0}), 30);
+  EXPECT_FLOAT_EQ(result.at({0, 3, 4, 0}), 28);
+  EXPECT_FLOAT_EQ(result.at({0, 3, 5, 0}), 35);
+  EXPECT_FLOAT_EQ(result.at({0, 4, 0, 0}), 16);
+  EXPECT_FLOAT_EQ(result.at({0, 4, 1, 0}), 24);
+  EXPECT_FLOAT_EQ(result.at({0, 4, 2, 0}), 18);
+  EXPECT_FLOAT_EQ(result.at({0, 4, 3, 0}), 27);
+  EXPECT_FLOAT_EQ(result.at({0, 4, 4, 0}), 20);
+  EXPECT_FLOAT_EQ(result.at({0, 4, 5, 0}), 30);
+  EXPECT_FLOAT_EQ(result.at({0, 5, 0, 0}), 32);
+  EXPECT_FLOAT_EQ(result.at({0, 5, 1, 0}), 40);
+  EXPECT_FLOAT_EQ(result.at({0, 5, 2, 0}), 36);
+  EXPECT_FLOAT_EQ(result.at({0, 5, 3, 0}), 45);
+  EXPECT_FLOAT_EQ(result.at({0, 5, 4, 0}), 40);
+  EXPECT_FLOAT_EQ(result.at({0, 5, 5, 0}), 50);
+}
+
 /// ConvTranspose with easy to calculate output values. 2x2 input, 3-ch input,
 /// 1-ch output.
 TEST_P(OperatorTest, sanityConvTransposePads) {


### PR DESCRIPTION
 - Disable dilation == 1 checks
 - Add dilation support in CPU implementation
 - Add dilation unittest in OnnxImporterTest and OperatorTest

Summary:

Dilation support was already added to ConvTranspose Interpreter implementation in #3464  but it was disabled. 
This PR enables dilation support by removing the `dilation==1` checks. 
This also adds dilation support to the CPU backend implementation.

Documentation:

[Optional Fixes #issue]

Test Plan:

Added one unittest case each to OnnxImporterTest and OperatorTest.

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
