### PR TITLE
Add device pinning to executionContexts to enable P2P/DRT

### DIFF
--- a/include/glow/Backend/Backend.h
+++ b/include/glow/Backend/Backend.h
@@ -48,7 +48,7 @@ struct DeviceInfo;
 struct DeviceConfig;
 struct ContextBinding;
 
-struct DAG;
+struct DAGNode;
 
 } // namespace runtime
 
@@ -199,11 +199,12 @@ public:
   createDeviceManager(const runtime::DeviceConfig &deviceConfig);
 
   /// Walks the provided /p bindings and does any setup needed for copying data
-  /// to/from host or peers. Also has access to /p network, which contains
-  /// partition dependency and symbol information. Any state information should
-  /// be stored in the ExecutionContext or DeviceManager.
+  /// to/from host or peers. Also has access to /p root the root node of the
+  /// graph, which contains partition dependency and symbol information. Any
+  /// state information should be stored in the ExecutionContext or
+  /// DeviceManager.
   virtual Error bindContexts(llvm::ArrayRef<runtime::ContextBinding> bindings,
-                             const std::vector<runtime::DAG> &network) {
+                             const runtime::DAGNode *root) {
     return Error::success();
   }
 

--- a/include/glow/ExecutionContext/ExecutionContext.h
+++ b/include/glow/ExecutionContext/ExecutionContext.h
@@ -48,6 +48,11 @@ public:
 class ExecutionContext {
   std::unique_ptr<PlaceholderBindings> placeholderBindings_;
   std::unique_ptr<DeviceBindings> deviceBindings_;
+
+  /// Pointer to DeviceManager this context is bound to, use for P2P/DRT
+  /// enablement. Unused otherwise.
+  runtime::DeviceManager *boundDeviceManager_{nullptr};
+
   std::unique_ptr<TraceContext> traceContext_;
 
   /// Trace Events recorded during this run.
@@ -85,6 +90,19 @@ public:
   /// \returns a const non-owning pointer to the DeviceBindings.
   const DeviceBindings *getDeviceBindings() const {
     return deviceBindings_.get();
+  }
+
+  /// \returns a non-owning pointer the the deviceManager this context is bound
+  /// to.
+  runtime::DeviceManager *getBoundDeviceManager() {
+    return boundDeviceManager_;
+  }
+
+  /// Sets which device this context is bound to. NOTE this should not be
+  /// changed once set.
+  void setBoundDeviceManager(runtime::DeviceManager *device) {
+    DCHECK(boundDeviceManager_ == nullptr);
+    boundDeviceManager_ = device;
   }
 
   /// Sets the DeviceBindings and \returns the existing value.

--- a/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
+++ b/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
@@ -171,6 +171,9 @@ struct CompilationContext {
   /// Whether to skip stripping the module.
   bool skipModuleStrip{false};
 
+  /// Whether to enable P2P and DRT at runtime.
+  bool enableStaticAssignment{false};
+
   CompilationContext(PlaceholderBindings *bindings_ = nullptr,
                      LoweredInfoMap *loweredInfoMap_ = nullptr)
       : bindings(bindings_), loweredInfoMap(loweredInfoMap_) {}

--- a/include/glow/Runtime/Executor/Executor.h
+++ b/include/glow/Runtime/Executor/Executor.h
@@ -48,7 +48,8 @@ public:
   virtual void shutdown() = 0;
 
   /// Setup context pool for new network.
-  virtual void createPool(const DAGNode *root, unsigned poolSize) = 0;
+  virtual void createPool(const DAGNode *root, unsigned poolSize,
+                          bool assignStatic = false) = 0;
 
   /// Free the context pool for given network.
   virtual void freePool(const DAGNode *root) = 0;

--- a/include/glow/Runtime/Executor/NetworkExecutionState.h
+++ b/include/glow/Runtime/Executor/NetworkExecutionState.h
@@ -37,8 +37,12 @@ public:
   /// Destructor.
   ~NetworkExecutionState();
 
-  /// Does the BFS traversal and initializes the NetworkExecutionState.
-  void init(const DeviceManagerMapTy &devices);
+  /// Does the BFS traversal and initializes the NetworkExecutionState. Takes in
+  /// a map of all deviceManagers \p devices , and \p staticAssignment , a map
+  /// between each node an a deviceManager. If this is an empty map no
+  /// assignment is made.
+  void init(const DeviceManagerMapTy &devices,
+            std::unordered_map<DAGNode *, DeviceIDTy> &staticAssignment);
 
   /// Binds the state to a new run. This moves the result ctx and cb to be owned
   /// by the networkExecutionState for the duration of the run.

--- a/include/glow/Runtime/Executor/ThreadPoolExecutor.h
+++ b/include/glow/Runtime/Executor/ThreadPoolExecutor.h
@@ -65,7 +65,8 @@ public:
                               const std::string &name = "");
 
   /// Setup context pool for new network.
-  void createPool(const DAGNode *root, unsigned poolSize) override;
+  void createPool(const DAGNode *root, unsigned poolSize,
+                  bool assignStatic = false) override;
 
   /// Free the context pool for specified network.
   void freePool(const DAGNode *root) override;

--- a/lib/Runtime/Executor/CMakeLists.txt
+++ b/lib/Runtime/Executor/CMakeLists.txt
@@ -4,5 +4,7 @@ add_library(Executor
 
 target_link_libraries(Executor
                       PRIVATE
+                        Backend
+                        Backends
                         ExecutionContext
                         Graph)

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -255,7 +255,8 @@ Error HostManager::addNetwork(std::unique_ptr<Module> module,
     for (auto &node : nodeList) {
       // Note: currently getNextNetworkExecutionState assumes that pool size is
       // >= currentInFlight requests, so we set pool size to maxActiveRequests.
-      executor_->createPool(node.root.get(), config_.maxActiveRequests);
+      executor_->createPool(node.root.get(), config_.maxActiveRequests,
+                            cctx.enableStaticAssignment);
     }
   }
   // Clear constants contents from the module then put it in a

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -114,6 +114,7 @@ add_executable(ThreadPoolExecutorTest
         ThreadPoolExecutorTest.cpp)
 target_link_libraries(ThreadPoolExecutorTest
         PRIVATE
+        Backend
         Backends
         Executor
         Graph

--- a/tests/unittests/HostManagerTest.cpp
+++ b/tests/unittests/HostManagerTest.cpp
@@ -327,3 +327,150 @@ TEST_F(HostManagerTest, QueueTest) {
   EXPECT_GT(res3, res1);
   EXPECT_GT(res2, res3);
 }
+
+// This test creates a network that is split into two partitions. P0,P1. P0 is
+// loaded on one device, P1 is loaded on two devices. This test then enables
+// static assignment which allows for P2P testing. We then run the network twice
+// to test the alternating static assignments.
+TEST_F(HostManagerTest, testStaticAssignment) {
+  std::unique_ptr<Module> module = glow::make_unique<Module>();
+  std::unique_ptr<ExecutionContext> context =
+      glow::make_unique<ExecutionContext>();
+
+  Function *F = module->createFunction("main");
+  auto *X = module->createPlaceholder(ElemKind::FloatTy, {3}, "X", false);
+  auto *XTensor = context->getPlaceholderBindings()->allocate(X);
+  XTensor->getHandle() = {1., 2., 3.};
+  auto *pow = F->createPow("Pow1", X, 2.0);
+  auto *save = F->createSave("save", pow);
+  auto *saveTensor =
+      context->getPlaceholderBindings()->allocate(save->getPlaceholder());
+
+  std::vector<std::unique_ptr<DeviceConfig>> configs;
+  auto deviceConfig = glow::make_unique<DeviceConfig>("CPU");
+  auto deviceConfig2 = glow::make_unique<DeviceConfig>("CPU");
+  auto deviceConfig3 = glow::make_unique<DeviceConfig>("CPU");
+  configs.push_back(std::move(deviceConfig));
+  configs.push_back(std::move(deviceConfig2));
+  configs.push_back(std::move(deviceConfig3));
+  std::unique_ptr<HostManager> hostManager =
+      glow::make_unique<HostManager>(std::move(configs), HostConfig());
+  CompilationContext cctx;
+  cctx.enableStaticAssignment = true;
+
+  // Setup forced partitioning.
+  PartitionConfig partitionConfig;
+  partitionConfig.funcName = "main";
+  partitionConfig.numOfPartitions = 2;
+  partitionConfig.backendNames = {"CPU", "CPU"};
+  partitionConfig.partitionNames = {"p0", "p1"};
+  partitionConfig.nodeToPartition = {{"Pow1", 0}, {"save", 1}};
+  partitionConfig.logicalIDs = {{0}, {1, 2}};
+  cctx.partitionConfig = &partitionConfig;
+
+  ASSERT_FALSE(ERR_TO_BOOL(hostManager->addNetwork(std::move(module), cctx)));
+
+  std::promise<void> runNetwork;
+  auto ready = runNetwork.get_future();
+
+  std::unique_ptr<Error> runErr;
+  hostManager->runNetwork("main", std::move(context),
+                          [&runNetwork, &saveTensor, &context, &runErr](
+                              RunIdentifierTy runID, Error err,
+                              std::unique_ptr<ExecutionContext> context_) {
+                            auto HX = saveTensor->getHandle();
+                            EXPECT_NEAR(HX.at({0}), 1, 1E-5);
+                            EXPECT_NEAR(HX.at({1}), 4, 1E-5);
+                            EXPECT_NEAR(HX.at({2}), 9, 1E-5);
+                            context = std::move(context_);
+                            runErr = glow::make_unique<Error>(std::move(err));
+                            runNetwork.set_value();
+                          });
+
+  ready.wait();
+  EXPECT_FALSE(ERR_TO_BOOL(std::move(*DCHECK_NOTNULL(runErr.get()))));
+
+  // reset runErr
+  runErr = nullptr;
+
+  std::promise<void> newRun;
+  ready = newRun.get_future();
+  hostManager->runNetwork("main", std::move(context),
+                          [&newRun, &saveTensor, &runErr](
+                              RunIdentifierTy runID, Error err,
+                              std::unique_ptr<ExecutionContext> context_) {
+                            auto HX = saveTensor->getHandle();
+                            EXPECT_NEAR(HX.at({0}), 1, 1E-5);
+                            EXPECT_NEAR(HX.at({1}), 4, 1E-5);
+                            EXPECT_NEAR(HX.at({2}), 9, 1E-5);
+                            runErr = glow::make_unique<Error>(std::move(err));
+                            newRun.set_value();
+                          });
+
+  ready.wait();
+  EXPECT_FALSE(ERR_TO_BOOL(std::move(*DCHECK_NOTNULL(runErr.get()))));
+}
+
+// This test creates a network that is split into two partitions. P0,P1. P0 is
+// loaded on one device, P1 is loaded on two devices. This test then enables
+// static assignment which allows for P2P testing. We then run the network
+// multiple requests concurrently.
+TEST_F(HostManagerTest, testStaticAssignmentConcurrent) {
+  std::unique_ptr<Module> module = glow::make_unique<Module>();
+
+  Function *F = module->createFunction("main");
+  auto *X = module->createPlaceholder(ElemKind::FloatTy, {3}, "X", false);
+  auto *pow = F->createPow("Pow1", X, 2.0);
+  F->createSave("save", pow);
+  auto *savePH = module->getPlaceholderByName("save");
+
+  std::vector<std::unique_ptr<DeviceConfig>> configs;
+  auto deviceConfig = glow::make_unique<DeviceConfig>("CPU");
+  auto deviceConfig2 = glow::make_unique<DeviceConfig>("CPU");
+  auto deviceConfig3 = glow::make_unique<DeviceConfig>("CPU");
+  configs.push_back(std::move(deviceConfig));
+  configs.push_back(std::move(deviceConfig2));
+  configs.push_back(std::move(deviceConfig3));
+  std::unique_ptr<HostManager> hostManager =
+      glow::make_unique<HostManager>(std::move(configs), HostConfig());
+  CompilationContext cctx;
+  cctx.enableStaticAssignment = true;
+
+  // Setup forced partitioning.
+  PartitionConfig partitionConfig;
+  partitionConfig.funcName = "main";
+  partitionConfig.numOfPartitions = 2;
+  partitionConfig.backendNames = {"CPU", "CPU"};
+  partitionConfig.partitionNames = {"p0", "p1"};
+  partitionConfig.nodeToPartition = {{"Pow1", 0}, {"save", 1}};
+  partitionConfig.logicalIDs = {{0}, {1, 2}};
+  cctx.partitionConfig = &partitionConfig;
+
+  ASSERT_FALSE(ERR_TO_BOOL(hostManager->addNetwork(std::move(module), cctx)));
+
+  std::vector<std::future<void>> ready;
+  for (int i = 0; i < 50; i++) {
+    auto runNetwork = std::make_shared<std::promise<void>>();
+    ready.push_back(runNetwork->get_future());
+    std::unique_ptr<ExecutionContext> context =
+        glow::make_unique<ExecutionContext>();
+    auto *XTensor = context->getPlaceholderBindings()->allocate(X);
+    XTensor->getHandle() = {1., 2., 3.};
+    auto *saveTensor = context->getPlaceholderBindings()->allocate(savePH);
+    hostManager->runNetwork(
+        "main", std::move(context),
+        [runNetwork, saveTensor](RunIdentifierTy runID, Error err,
+                                 std::unique_ptr<ExecutionContext> context_) {
+          auto HX = saveTensor->getHandle();
+          EXPECT_NEAR(HX.at({0}), 1, 1E-5);
+          EXPECT_NEAR(HX.at({1}), 4, 1E-5);
+          EXPECT_NEAR(HX.at({2}), 9, 1E-5);
+          EXPECT_FALSE(std::move(err));
+          runNetwork->set_value();
+        });
+  }
+
+  for (auto &r : ready) {
+    r.wait();
+  }
+}


### PR DESCRIPTION
Summary:
This PR adds the ability to pin an executionContext to a specific deviceManager. This allows it to be used to store additional DRT info for copy reduction and P2P.
To test this feature there is a new flag in compilationContext: enableStaticAssignment. This should work for all backends, but will allow devices that support DRT and P2P to enable those features.

Documentation:

Test Plan:
Added a new unittest to Hostmanager test.
