### PR TITLE
Add ability to load pre-partitioned C2 models

### DIFF
--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -347,6 +347,9 @@ public:
   /// scaled/offsets will not be modified.
   void init(InitKind init, float val, PseudoRNG &PRNG);
 
+  /// \returns an unowned tensor with the exact same dimensions as this.
+  Tensor getUnowned() const { return getUnowned(dims()); }
+
   /// \returns unowned tensor using the same data buffer as the current tensor
   /// but having different dimensions \p dims. \p offsets represents an optional
   /// offset into the tensor representing the location of the first element to

--- a/include/glow/ExecutionEngine/ExecutionEngine.h
+++ b/include/glow/ExecutionEngine/ExecutionEngine.h
@@ -67,6 +67,10 @@ class ExecutionEngine final {
   /// the module. Used for testing purposes.
   bool skipModuleStrip_{false};
 
+  /// Whether to allow multiple functions when running. This is usually due to
+  /// running a pre-partitioned model.
+  bool allowMultiFunction_{false};
+
   /// Single execution of the given function, \p name with the given context
   /// \bindings.
   void runInternal(ExecutionContext &context, llvm::StringRef name);
@@ -74,17 +78,18 @@ class ExecutionEngine final {
 public:
   /// Constructor for an ExecutionEngine with \p backend and memory \p
   /// deviceMemory in bytes. If \p ignoreUserDeviceConfig then user device
-  /// configs will be ignored.
+  /// configs will be ignored. \p numDevices controls how many devices to create
+  /// for the EE.
   ExecutionEngine(llvm::StringRef backend = "Interpreter",
                   uint64_t deviceMemory = 0,
-                  bool ignoreUserDeviceConfig = false);
+                  bool ignoreUserDeviceConfig = false, unsigned numDevices = 1);
 
   ~ExecutionEngine();
 
   /// Set the code generator to \p backend. New code will be generated
   /// using this backend. This clears all previously loaded functions and resets
-  /// the Module.
-  void setBackendName(llvm::StringRef backend);
+  /// the Module. \p numDevices controls how many devices to create for the EE.
+  void setBackendName(llvm::StringRef backend, size_t numDevices = 1);
 
   /// Set the device memory to \p mem. This will reset the existing device,
   /// clearing all existing functions and resetting the module.

--- a/include/glow/Importer/Caffe2ModelLoader.h
+++ b/include/glow/Importer/Caffe2ModelLoader.h
@@ -134,6 +134,24 @@ public:
                     llvm::ArrayRef<TypeRef> types, Function &F,
                     Error *errPtr = nullptr);
 
+  /// Loads the caffe2 model that's represented by a network description file,
+  /// serialized in \p netDescFilename, and weights file, serialized in
+  /// \p netWeightFilename, and populates the network in \p mod.
+  /// Any Functions created in \p mod will have name (or prefixed name for
+  /// pre-partitioned protos) \p funNamePrefix.  \p PPC is used to store the
+  /// pre-partitioned config for the model if relevant.
+  /// The list \p types and \p names are used to initialized the inputs and
+  /// outputs with specific names and types.
+  /// If \p errPtr is not null then if an error occurs it will get assigned
+  /// there otherwise if an error occurs it will abort.
+  Caffe2ModelLoader(const std::string &netDescFilename,
+                    const std::string &netWeightFilename,
+                    llvm::ArrayRef<const char *> names,
+                    llvm::ArrayRef<TypeRef> types, Module &mod,
+                    llvm::StringRef funNamePrefix,
+                    runtime::PrePartitionedConfig *PPC = nullptr,
+                    Error *errPtr = nullptr);
+
   /// Creates a Caffe2 model loader to build \p F.
   /// If \p errPtr is not null then if an error occurs it will get assigned
   /// there otherwise if an error occurs it will abort.

--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -194,6 +194,10 @@ protected:
                        llvm::ArrayRef<TypeRef> types, Function *F)
       : ProtobufLoader(names, types, F) {}
 
+  CommonOperatorLoader(llvm::ArrayRef<const char *> names,
+                       llvm::ArrayRef<TypeRef> types, Module &mod)
+      : ProtobufLoader(names, types, mod) {}
+
   using ArgumentDictionaryTy =
       std::unordered_map<std::string, const AttrType *>;
 
@@ -372,8 +376,8 @@ protected:
     RETURN_ERR_IF_NOT(in.dims().size() >= 2, "SoftMax input dims must be >= 2");
 
     // Create a constant to store labels to be used in SoftMaxGradNode.
-    auto selected = G_->getParent()->createConstant(
-        ElemKind::Int64ITy, {in.dims()[0], 1}, "selected");
+    auto selected =
+        mod_.createConstant(ElemKind::Int64ITy, {in.dims()[0], 1}, "selected");
 
     // ONNX allows shapes like <N x 10 x 1 x 1 >. Flatten the inputs to the
     // softmax function. This is similar to a bitcast operation.
@@ -990,8 +994,8 @@ protected:
     } else {
       // If Lengths input is not present, create scalar containing number of
       // index-value pairs.
-      auto *lengthsConstant = G_->getParent()->createConstant(
-          ElemKind::Int32ITy, {}, "lengthsConstant");
+      auto *lengthsConstant =
+          mod_.createConstant(ElemKind::Int32ITy, {}, "lengthsConstant");
       lengthsConstant->getPayloadMutable().template getHandle<int32_t>().raw(
           0) = indices.dims()[0];
       lengths = lengthsConstant->getOutput();

--- a/lib/Graph/PlaceholderBindings.cpp
+++ b/lib/Graph/PlaceholderBindings.cpp
@@ -241,7 +241,7 @@ PlaceholderBindings::PlaceholderBindings(
     auto *orig = inputs[i];
     /// Create a reference to the original tensor and hand it to the
     /// PlaceholderBindings.
-    Tensor ptrT = orig->getUnowned(orig->dims());
+    Tensor ptrT = orig->getUnowned();
     insert(placeholders[i], std::move(ptrT));
   }
 }

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -18,6 +18,7 @@
 #include "glow/Base/Tensor.h"
 #include "glow/Graph/Graph.h"
 #include "glow/Graph/Nodes.h"
+#include "glow/Runtime/RuntimeTypes.h"
 #include "glow/Support/Error.h"
 
 #include "llvm/Support/Casting.h"
@@ -333,7 +334,7 @@ Error Caffe2ModelLoader::loadConv(const caffe2::OperatorDef &op,
   // Caffe2 "Conv" op always stores the weight as CKRS.
   Tensor wT;
   w->getPayload().transpose(&wT, NCHW2NHWC);
-  w = G_->getParent()->createConstant(w->getName(), std::move(wT), "NHWC");
+  w = mod_.createConstant(w->getName(), std::move(wT), "NHWC");
 
   // The structure of the conv weights is: CRSK. We take the C, which is the
   // number of filters. We use this value to calculate the size of the bias
@@ -366,10 +367,10 @@ Error Caffe2ModelLoader::loadConv(const caffe2::OperatorDef &op,
   if (!bias) {
     Tensor b(ElemKind::FloatTy, {depth});
     b.zero();
-    bias = G_->getParent()->createConstant("conv.bias", std::move(b));
+    bias = mod_.createConstant("conv.bias", std::move(b));
   }
 
-  TypeRef outTy = G_->getParent()->uniqueType(ElemKind::FloatTy, outDims);
+  TypeRef outTy = mod_.uniqueType(ElemKind::FloatTy, outDims);
 
   Node *node = G_->createConv(opName, finalIn, w, bias, outTy, kernels, strides,
                               pads, group, dilation);
@@ -434,7 +435,7 @@ Error Caffe2ModelLoader::loadConvQuantized(const caffe2::OperatorDef &op,
   if (order != "NHWC") {
     Tensor wT;
     w->getPayload().transpose(&wT, NCHW2NHWC);
-    w = G_->getParent()->createConstant(w->getName(), std::move(wT), "NHWC");
+    w = mod_.createConstant(w->getName(), std::move(wT), "NHWC");
   }
 
   // The structure of the conv weights is: CRSK. We take the C, which is the
@@ -475,7 +476,7 @@ Error Caffe2ModelLoader::loadConvQuantized(const caffe2::OperatorDef &op,
   if (!bias) {
     Tensor b(ElemKind::Int32QTy, {depth}, 1.0, 0);
     b.zero();
-    bias = G_->getParent()->createConstant("conv.bias", std::move(b));
+    bias = mod_.createConstant("conv.bias", std::move(b));
   }
 
   RETURN_ERR_IF_NOT(bias->getPayload().size() == depth,
@@ -486,8 +487,8 @@ Error Caffe2ModelLoader::loadConvQuantized(const caffe2::OperatorDef &op,
   ASSIGN_VALUE_OR_RETURN_ERR(scale, loadFloat(dict["Y_scale"]));
   int32_t offset;
   ASSIGN_VALUE_OR_RETURN_ERR(offset, loadInt(dict["Y_zero_point"]));
-  outTy = G_->getParent()->uniqueType(ElemKind::Int8QTy, outDims, scale,
-                                      offset - OFFSETSHIFT);
+  outTy =
+      mod_.uniqueType(ElemKind::Int8QTy, outDims, scale, offset - OFFSETSHIFT);
 
   Node *node;
 
@@ -516,7 +517,7 @@ Error Caffe2ModelLoader::loadConvQuantized(const caffe2::OperatorDef &op,
       Tensor quantizedBiasTensor =
           quantization::quantizeTensor(biasTensor, tqp, ElemKind::Int32QTy);
 
-      bias = G_->getParent()->createConstant("conv.bias", quantizedBiasTensor);
+      bias = mod_.createConstant("conv.bias", quantizedBiasTensor);
     }
 
     node = G_->createConv(opName, finalIn, w, bias, outTy, kernels, strides,
@@ -552,13 +553,13 @@ Expected<bool> Caffe2ModelLoader::foldOperator(const caffe2::OperatorDef &op) {
 
   // Create a temporary lightweight loader to construct function representing
   // current Op, and then constant fold the function using Interp backend.
-  Function *tmpF = G_->getParent()->createFunction("eval_const_fold__");
+  Function *tmpF = mod_.createFunction("eval_const_fold__");
   Caffe2ModelLoader tmpLoader(*tmpF, nullptr);
   bool foldStatus =
       !ERR_TO_BOOL(constantFoldInLoader<Caffe2ModelLoader, caffe2::OperatorDef>(
                        tmpF, tmpLoader, this, op),
                    /* log */ false);
-  G_->getParent()->eraseFunction(tmpF);
+  mod_.eraseFunction(tmpF);
   return foldStatus;
 }
 
@@ -598,7 +599,7 @@ Error Caffe2ModelLoader::loadConvTranspose(const caffe2::OperatorDef &op,
   // Caffe2 "ConvTranspose" op always stores the weight as KCRS.
   Tensor wT;
   weight->getPayload().transpose(&wT, CNHW2NHWC);
-  weight = G_->getParent()->createConstant(weight->getName(), std::move(wT));
+  weight = mod_.createConstant(weight->getName(), std::move(wT));
 
   // The structure of the conv weights is: CRSK. We take the C, which is the
   // number of filters. We use this value to calculate the size of the bias
@@ -631,10 +632,10 @@ Error Caffe2ModelLoader::loadConvTranspose(const caffe2::OperatorDef &op,
   if (!bias) {
     Tensor b(ElemKind::FloatTy, {depth});
     b.zero();
-    bias = G_->getParent()->createConstant("conv.bias", std::move(b));
+    bias = mod_.createConstant("conv.bias", std::move(b));
   }
 
-  TypeRef outTy = G_->getParent()->uniqueType(ElemKind::FloatTy, outDims);
+  TypeRef outTy = mod_.uniqueType(ElemKind::FloatTy, outDims);
 
   Node *node = G_->createConvTranspose(opName, finalIn, weight, bias, outTy,
                                        kernels, strides, pads, group, dilation);
@@ -688,8 +689,8 @@ Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     ASSIGN_VALUE_OR_RETURN_ERR(yScale, loadFloat(dict["Y_scale"]));
     int yZeroPoint;
     ASSIGN_VALUE_OR_RETURN_ERR(yZeroPoint, loadInt(dict["Y_zero_point"]));
-    auto outTy = G_->getParent()->uniqueType(ElemKind::Int8QTy, outDims, yScale,
-                                             yZeroPoint - OFFSETSHIFT);
+    auto outTy = mod_.uniqueType(ElemKind::Int8QTy, outDims, yScale,
+                                 yZeroPoint - OFFSETSHIFT);
     auto *add = G_->createAdd(opName + ".sum", outTy, in0, in1);
     auto *relu = G_->createRELU(opName + ".relu", add);
     RETURN_IF_ERR(addNodeAsOutput(op, relu));
@@ -709,8 +710,8 @@ Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     ASSIGN_VALUE_OR_RETURN_ERR(yScale, loadFloat(dict["Y_scale"]));
     int yZeroPoint;
     ASSIGN_VALUE_OR_RETURN_ERR(yZeroPoint, loadInt(dict["Y_zero_point"]));
-    auto outTy = G_->getParent()->uniqueType(ElemKind::Int8QTy, outDims, yScale,
-                                             yZeroPoint - OFFSETSHIFT);
+    auto outTy = mod_.uniqueType(ElemKind::Int8QTy, outDims, yScale,
+                                 yZeroPoint - OFFSETSHIFT);
     auto *relu = G_->createRELU(opName, in, outTy);
     RETURN_IF_ERR(addNodeAsOutput(op, relu));
     return Error::success();
@@ -728,8 +729,8 @@ Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     ASSIGN_VALUE_OR_RETURN_ERR(yScale, loadFloat(dict["Y_scale"]));
     int yZeroPoint;
     ASSIGN_VALUE_OR_RETURN_ERR(yZeroPoint, loadInt(dict["Y_zero_point"]));
-    auto outTy = G_->getParent()->uniqueType(ElemKind::Int8QTy, outDims, yScale,
-                                             yZeroPoint - OFFSETSHIFT);
+    auto outTy = mod_.uniqueType(ElemKind::Int8QTy, outDims, yScale,
+                                 yZeroPoint - OFFSETSHIFT);
     Node *N = G_->createQuantize(opName, in, outTy);
     RETURN_IF_ERR(addNodeAsOutput(op, N));
     return Error::success();
@@ -812,8 +813,8 @@ Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
         ASSIGN_VALUE_OR_RETURN_ERR(yScale, loadFloat(dict["Y_scale"]));
         int yZeroPoint;
         ASSIGN_VALUE_OR_RETURN_ERR(yZeroPoint, loadInt(dict["Y_zero_point"]));
-        auto outTy = G_->getParent()->uniqueType(
-            ElemKind::Int8QTy, outDims, yScale, yZeroPoint - OFFSETSHIFT);
+        auto outTy = mod_.uniqueType(ElemKind::Int8QTy, outDims, yScale,
+                                     yZeroPoint - OFFSETSHIFT);
         node =
             G_->createAvgPool(opName, finalIn, outTy, kernels, strides, pads);
       }
@@ -998,13 +999,13 @@ Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
                   W->getType()->getScale(), W->getType()->getOffset());
       }
       tmp.copyRawFrom(&W->getPayload());
-      W = G_->getParent()->createConstant(W->getName(), tmp);
+      W = mod_.createConstant(W->getName(), tmp);
     }
 
     if (typeName == "FC" || typeName == "Int8FC" || typeName == "FbFCPacked") {
       Tensor tmp;
       W->getPayloadMutable().transpose(&tmp, {1, 0});
-      W = G_->getParent()->createConstant(W->getName(), tmp);
+      W = mod_.createConstant(W->getName(), tmp);
     }
 
     Constant *B;
@@ -1021,24 +1022,24 @@ Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
       ASSIGN_VALUE_OR_RETURN_ERR(yScale, loadFloat(dict["Y_scale"]));
       int yZeroPoint;
       ASSIGN_VALUE_OR_RETURN_ERR(yZeroPoint, loadInt(dict["Y_zero_point"]));
-      auto outTy = G_->getParent()->uniqueType(
+      auto outTy = mod_.uniqueType(
           ElemKind::Int8QTy, {in.getType()->dims()[0], B->getType()->dims()[0]},
           yScale, yZeroPoint - OFFSETSHIFT);
       node = G_->createFullyConnected(opName, in, W, B, outTy, axis);
     } else if (typeName == "FbFCPacked") {
-      auto fp16InputType = G_->getParent()->uniqueType(ElemKind::Float16Ty,
-                                                       in.getType()->dims());
+      auto fp16InputType =
+          mod_.uniqueType(ElemKind::Float16Ty, in.getType()->dims());
       in = G_->createConvertTo("ConvertInput", in, fp16InputType);
 
-      auto fp16BiasType = G_->getParent()->uniqueType(ElemKind::Float16Ty,
-                                                      B->getType()->dims());
+      auto fp16BiasType =
+          mod_.uniqueType(ElemKind::Float16Ty, B->getType()->dims());
       auto *fp16Bias = G_->createConvertTo("ConvertBias", B, fp16BiasType);
-      TypeRef OT = G_->getParent()->uniqueType(
-          ElemKind::Float16Ty, {in.dims()[0], B->getType()->dims()[0]});
+      TypeRef OT = mod_.uniqueType(ElemKind::Float16Ty,
+                                   {in.dims()[0], B->getType()->dims()[0]});
 
       auto fc = G_->createFullyConnected(opName, in, W, fp16Bias, OT, axis);
-      auto outputType = G_->getParent()->uniqueType(ElemKind::FloatTy,
-                                                    fc->getResult().dims());
+      auto outputType =
+          mod_.uniqueType(ElemKind::FloatTy, fc->getResult().dims());
       node = G_->createConvertTo("ConvertOutput", fc, outputType);
     } else {
       node = G_->createFullyConnected(opName, in, W, B, axis);
@@ -1176,10 +1177,14 @@ Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
       typeName == "Copy" || typeName == "EnsureCPUOutput" ||
       typeName == "EnsureDense") {
     // Glow does not support any of these ops now, so implement them as
-    // no-ops.
+    // no-ops. Note: Implement this as a no-op reshape because these ops may
+    // have partition information, and we need a node to maintain the parent
+    // Function partition it specified. This reshape will get eliminated later
+    // on during graph optimizations.
     NodeValue in;
     ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
-    RETURN_IF_ERR(addNodeAsOutput(op, in));
+    ReshapeNode *RN = G_->createReshape(in.getNode()->getName(), in, in.dims());
+    RETURN_IF_ERR(addNodeAsOutput(op, RN));
     return Error::success();
   }
 
@@ -1251,7 +1256,7 @@ Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     NodeValue in;
     ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
     auto convertedType =
-        G_->getParent()->uniqueType(ElemKind::FloatTy, in.getType()->dims());
+        mod_.uniqueType(ElemKind::FloatTy, in.getType()->dims());
     auto *R = G_->createConvertTo("ConvertInput", in, convertedType);
     RETURN_IF_ERR(addNodeAsOutput(op, R));
     return Error::success();
@@ -1401,9 +1406,9 @@ Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
                           "Data must be UInt8QTy.");
         // Use dummy 0.0/0 as scale/offset, since the actual scales/offsets
         // are fused inline with the data.
-        TypeRef fusedTy = G_->getParent()->uniqueType(
-            is4Bit ? ElemKind::UInt4FusedFP16QTy : ElemKind::UInt8FusedQTy,
-            dataS->dims(), 0.0, 0);
+        TypeRef fusedTy = mod_.uniqueType(is4Bit ? ElemKind::UInt4FusedFP16QTy
+                                                 : ElemKind::UInt8FusedQTy,
+                                          dataS->dims(), 0.0, 0);
         dataS->setType(Storage::OutputIdx, fusedTy);
         // If the node is a Constant set the payload type as well.
         if (auto dataConstant = llvm::dyn_cast<Constant>(data)) {
@@ -1442,10 +1447,10 @@ Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
                         "Second dim of scale_bias has to be equal to 2.");
 
       // Now strip out the scales and biases into their own tensors.
-      Constant *dataScales = G_->getParent()->createConstant(
-          ElemKind::FloatTy, {numRows}, "dataScales");
-      Constant *dataOffsets = G_->getParent()->createConstant(
-          ElemKind::FloatTy, {numRows}, "dataOffsets");
+      Constant *dataScales =
+          mod_.createConstant(ElemKind::FloatTy, {numRows}, "dataScales");
+      Constant *dataOffsets =
+          mod_.createConstant(ElemKind::FloatTy, {numRows}, "dataOffsets");
 
       auto dataScalesH = dataScales->getHandle<float>();
       auto dataOffsetsH = dataOffsets->getHandle<float>();
@@ -1593,12 +1598,25 @@ Error Caffe2ModelLoader::loadNetwork(caffe2::NetDef &net) {
   // Make a claim on the unique name of all output Placeholders.
   for (int i = 0; i < net.external_output_size(); i++) {
     auto &outputName = net.external_output(i);
-    G_->getParent()->registerStorageName(legalizeName(outputName));
+    mod_.registerStorageName(legalizeName(outputName));
   }
 
   /// Load the network operators:
   for (int i = 0; i < net.op_size(); i++) {
     auto &op = net.op(i);
+
+    // Set up current partition to load into if relevant.
+    if (partNameToFun_.size()) {
+      auto &pName = op.device_option().node_name();
+      auto it = partNameToFun_.find(pName);
+      RETURN_ERR_IF_NOT(
+          it != partNameToFun_.end(),
+          strFormat("Did not find partition with name %s", pName.c_str()));
+      G_ = it->second;
+    } else {
+      assert(G_ && "G_ should be non-null when not loading partitions.");
+    }
+
     if (constFoldInLoader_) {
       auto tryFold = foldOperator(op);
       if (!tryFold) {
@@ -1620,15 +1638,24 @@ Error Caffe2ModelLoader::loadNetwork(caffe2::NetDef &net) {
   for (int i = 0; i < net.external_output_size(); i++) {
     auto &outputName = net.external_output(i);
     NodeValue r;
-    ASSIGN_VALUE_OR_RETURN_ERR(r, getNodeValueByName(outputName));
+    // We want to create the save node in the same Function as the original
+    // NodeValue. Thus here we ignore the source function when getting the NV,
+    // which avoids copying the NV to whatever G_ currently is via an
+    // intermediate Placeholder.
+    ASSIGN_VALUE_OR_RETURN_ERR(
+        r, getNodeValueByName(outputName, /* ignoreSrcFun */ true));
 
-    PlaceholderList &PHList = G_->getParent()->getPlaceholders();
+    PlaceholderList &PHList = mod_.getPlaceholders();
     // Create a Placeholder with the previously claimed name.
-    auto *PH = new Placeholder(legalizeName(outputName),
-                               G_->getParent()->uniqueType(*r.getType()), false,
-                               ANY_LAYOUT);
+    auto *PH =
+        new Placeholder(legalizeName(outputName), mod_.uniqueType(*r.getType()),
+                        false, ANY_LAYOUT);
     PHList.push_back(PH);
-    auto *SN = G_->createSave("save_" + outputName, r, PH);
+    // If r is storage then just use the current last Function to save, since
+    // we're just saving directly from a Storage node anyway.
+    Function *F = llvm::isa<Storage>(r) ? G_ : r.getNode()->getParent();
+    assert(F && "F must be valid here.");
+    auto *SN = F->createSave(outputName, r, PH);
     outputVarsByName_[outputName] = SN->getPlaceholder();
   }
   return Error::success();
@@ -1934,7 +1961,7 @@ Error Caffe2ModelLoader::loadWeight(const caffe2::OperatorDef &op) {
 
     // Uniformly generate random numbers in [tensorMin; tensorMax).
     for (auto &elem : TH) {
-      elem = G_->getParent()->getPRNG().nextRandReal(tensorMin, tensorMax);
+      elem = mod_.getPRNG().nextRandReal(tensorMin, tensorMax);
     }
 
     RETURN_IF_ERR(createAndRegisterConstant(name, std::move(T)));
@@ -1986,6 +2013,83 @@ Caffe2ModelLoader::Caffe2ModelLoader(const std::string &netDescFilename,
     // the same network, even if order of operators is different.
     F.orderNodes();
     RETURN_ERR_IF_NOT(F.verify(), "Function verification failed.");
+
+    deleteUnusedConstants();
+
+    return Error::success();
+  };
+
+  if (errPtr) {
+    *errPtr = setup();
+  } else {
+    EXIT_ON_ERR(setup());
+  }
+}
+
+Caffe2ModelLoader::Caffe2ModelLoader(const std::string &netDescFilename,
+                                     const std::string &netWeightFilename,
+                                     llvm::ArrayRef<const char *> names,
+                                     llvm::ArrayRef<TypeRef> types, Module &mod,
+                                     llvm::StringRef funNamePrefix,
+                                     runtime::PrePartitionedConfig *PPC,
+                                     Error *errPtr)
+    : CommonOperatorLoader(names, types, mod, errPtr) {
+  // if errPtr already contains an error then don't continue with constructor
+  if (errPtr && *errPtr) {
+    return;
+  }
+
+  // Lambda to setup the Caffe2ModelLoader and return any Errors that
+  // were raised.
+  auto setup = [&]() -> Error {
+    // The caffe2 network descriptor that we are deserializing.
+    caffe2::NetDef networkDef;
+    ASSIGN_VALUE_OR_RETURN_ERR(networkDef, loadProtoFile(netDescFilename));
+
+    // The caffe2 weights that we are deserializing.
+    caffe2::NetDef weightsDef;
+    ASSIGN_VALUE_OR_RETURN_ERR(weightsDef, loadProtoFile(netWeightFilename));
+
+    // Look for any partitions that will be needed. If there is no
+    // partition_info then we create a single Function to load into. Otherwise
+    // we create multiple Functions and switch between them as we load each
+    // operator.
+    std::unordered_map<Function *, std::unordered_set<unsigned>> funToIDs;
+    if (networkDef.partition_info_size() == 0) {
+      mod_.createFunction(funNamePrefix);
+    } else {
+      for (int i = 0; i < networkDef.partition_info_size(); i++) {
+        const std::string &pName = networkDef.partition_info(i).name();
+        const std::string funName = funNamePrefix.str() + "_" + pName;
+        Function *PF = mod_.createFunction(funName);
+        partNameToFun_[pName] = PF;
+        for (auto i : networkDef.partition_info(i).device_id()) {
+          funToIDs[PF].insert(i);
+        }
+      }
+    }
+
+    RETURN_IF_ERR(loadWeightsFromNet(weightsDef));
+    RETURN_IF_ERR(loadNetwork(networkDef));
+
+    // Now setup the pre-partitioned config if relevant.
+    if (partNameToFun_.size()) {
+      RETURN_ERR_IF_NOT(
+          PPC, "Partitioned model but no config to store meta information in.");
+      PPC->funcName = funNamePrefix.str();
+
+      PPC->funcs.reserve(partNameToFun_.size());
+      PPC->logicalIDs.reserve(partNameToFun_.size());
+      for (auto &SF : partNameToFun_) {
+        Function *F = SF.getValue();
+        // This is to ensure that the same processing done with
+        // the same network, even if order of operators is different.
+        F->orderNodes();
+        PPC->funcs.push_back(F);
+        PPC->logicalIDs.push_back(funToIDs[F]);
+        RETURN_ERR_IF_NOT(F->verify(), "Function verification failed.");
+      }
+    }
 
     deleteUnusedConstants();
 

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -1744,12 +1744,12 @@ bool FoldBatchNormalizationWithArithmeticChain::run(
 
     auto *newScaleC =
         F->getParent()->createConstant(scaleC->getType(), scaleC->getName());
-    Tensor scaleT = scaleC->getPayload().getUnowned(scaleC->dims());
+    Tensor scaleT = scaleC->getPayload().getUnowned();
     newScaleC->assign(&scaleT);
 
     auto *newBiasC =
         F->getParent()->createConstant(biasC->getType(), biasC->getName());
-    Tensor biasT = biasC->getPayload().getUnowned(biasC->dims());
+    Tensor biasT = biasC->getPayload().getUnowned();
     newBiasC->assign(&biasT);
 
     // Collect the chain and compute the new scale and bias.

--- a/lib/Runtime/Executor/NetworkExecutionState.cpp
+++ b/lib/Runtime/Executor/NetworkExecutionState.cpp
@@ -70,9 +70,9 @@ void NetworkExecutionState::bind(std::unique_ptr<ExecutionContext> resultCtx,
     for (auto binding : externalIntermediates_[PH]) {
       auto resultTensor = resultPHBindings->get(PH);
       if (binding->get(PH)) {
-        binding->update(PH, resultTensor->getUnowned(PH->dims()));
+        binding->update(PH, resultTensor->getUnowned());
       } else {
-        binding->insert(PH, resultTensor->getUnowned(PH->dims()));
+        binding->insert(PH, resultTensor->getUnowned());
       }
     }
   }

--- a/tests/models/caffe2Models/pre_partitioned_fill_test_predict_net.pbtxt
+++ b/tests/models/caffe2Models/pre_partitioned_fill_test_predict_net.pbtxt
@@ -1,0 +1,62 @@
+name: "prepartitioned_fill_test_dummy_net"
+op {
+  input: "tensor_fill_float"
+  output: "tensor_fill_float_copy"
+  name: ""
+  type: "Copy"
+  device_option {
+    node_name: "p0"
+  }
+}
+op {
+  input: "tensor_int_fill"
+  input: "tensor_int_fill"
+  output: "tensor_int_fill_copy"
+  name: ""
+  type: "Copy"
+  device_option {
+    node_name: "p1"
+  }
+}
+op {
+  input: "tensor_int64_fill"
+  input: "tensor_int64_fill"
+  output: "tensor_int64_fill_copy"
+  name: ""
+  type: "Copy"
+  device_option {
+    node_name: "p2"
+  }
+}
+op {
+  input: "tensor_string_to_uint8_fill"
+  input: "tensor_string_to_uint8_fill"
+  output: "tensor_string_to_uint8_fill_copy"
+  name: ""
+  type: "Copy"
+  device_option {
+    node_name: "p0"
+  }
+}
+external_input: "tensor_fill_float"
+external_input: "tensor_int_fill"
+external_input: "tensor_int64_fill"
+external_input: "tensor_string_to_uint8_fill"
+external_output: "tensor_fill_float_copy"
+external_output: "tensor_int_fill_copy"
+external_output: "tensor_int64_fill_copy"
+external_output: "tensor_string_to_uint8_fill_copy"
+
+partition_info {
+  name: "p0"
+  device_id: 0
+  device_id: 2
+}
+partition_info {
+  name: "p1"
+  device_id: 1
+}
+partition_info {
+  name: "p2"
+  device_id: 2
+}

--- a/tests/models/caffe2Models/pre_partitioned_multi_op_predict_net.pbtxt
+++ b/tests/models/caffe2Models/pre_partitioned_multi_op_predict_net.pbtxt
@@ -1,0 +1,79 @@
+name: "prepartitioned_multioip_test"
+op {
+  input: "mm0_in"
+  input: "mm1_in"
+  output: "mm_out"
+  name: ""
+  type: "MatMul"
+  arg {
+    name: "trans_a"
+    i: 0
+  }
+  arg {
+    name: "trans_b"
+    i: 0
+  }
+  device_option {
+    node_name: "p1"
+  }
+}
+op {
+  input: "mm_out"
+  input: "add_in"
+  output: "add_out"
+  name: ""
+  type: "Add"
+  arg {
+    name: "broadcast"
+    i: 0
+  }
+  device_option {
+    node_name: "p2"
+  }
+}
+op {
+  input: "mm0_in"
+  input: "mm_out"
+  output: "mul_out"
+  name: ""
+  type: "Mul"
+  arg {
+    name: "broadcast"
+    i: 0
+  }
+  device_option {
+    node_name: "p0"
+  }
+}
+op {
+  input: "mul_out"
+  input: "add_out"
+  output: "res"
+  name: ""
+  type: "Sub"
+  arg {
+    name: "broadcast"
+    i: 0
+  }
+  device_option {
+    node_name: "p0"
+  }
+}
+external_input: "mm0_in"
+external_input: "mm1_in"
+external_input: "add_in"
+external_output: "res"
+
+partition_info {
+  name: "p0"
+  device_id: 2
+}
+partition_info {
+  name: "p1"
+  device_id: 0
+  device_id: 1
+}
+partition_info {
+  name: "p2"
+  device_id: 2
+}

--- a/tests/unittests/TensorsTest.cpp
+++ b/tests/unittests/TensorsTest.cpp
@@ -1130,7 +1130,7 @@ TEST(Tensor, unpaddedSize) {
   EXPECT_EQ(moved.getSizeInBytes(), paddedBytes);
 
   // Test getting an unowned tensor from a padded tensor.
-  auto copy = moved.getUnowned(moved.dims());
+  auto copy = moved.getUnowned();
   EXPECT_EQ(copy.getUnpaddedSizeInBytes(), bytes);
   EXPECT_EQ(copy.getSizeInBytes(), paddedBytes);
 


### PR DESCRIPTION
Summary:
This diff adds a new way of loading C2 protos where we will switch between different Functions to load into on every new op that is loaded.

To cleanly add this functionality I extended `getNodeValueFromName()` to check if the current Function being loaded into and the NodeValue being retrieved are from different Functions. If so then the method will add a SaveNode+Placeholder (if they don't already exist) to link the NodeValue to to the new op being constructed.

I also needed to add new functionality/plumbing in the EE, e.g. to allow for multiple Functions to exist in an EE and to only add the name from the `PrePartitionedConfig` to the EE to execute later.

Differential Revision: D20434014

