### PR TITLE
Add helper for getting an unowned copy of the current Tensor with same shape

### DIFF
--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -347,6 +347,9 @@ public:
   /// scaled/offsets will not be modified.
   void init(InitKind init, float val, PseudoRNG &PRNG);
 
+  /// \returns an unowned tensor with the exact same dimensions as this.
+  Tensor getUnowned() const { return getUnowned(dims()); }
+
   /// \returns unowned tensor using the same data buffer as the current tensor
   /// but having different dimensions \p dims. \p offsets represents an optional
   /// offset into the tensor representing the location of the first element to

--- a/lib/Graph/PlaceholderBindings.cpp
+++ b/lib/Graph/PlaceholderBindings.cpp
@@ -241,7 +241,7 @@ PlaceholderBindings::PlaceholderBindings(
     auto *orig = inputs[i];
     /// Create a reference to the original tensor and hand it to the
     /// PlaceholderBindings.
-    Tensor ptrT = orig->getUnowned(orig->dims());
+    Tensor ptrT = orig->getUnowned();
     insert(placeholders[i], std::move(ptrT));
   }
 }

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -1744,12 +1744,12 @@ bool FoldBatchNormalizationWithArithmeticChain::run(
 
     auto *newScaleC =
         F->getParent()->createConstant(scaleC->getType(), scaleC->getName());
-    Tensor scaleT = scaleC->getPayload().getUnowned(scaleC->dims());
+    Tensor scaleT = scaleC->getPayload().getUnowned();
     newScaleC->assign(&scaleT);
 
     auto *newBiasC =
         F->getParent()->createConstant(biasC->getType(), biasC->getName());
-    Tensor biasT = biasC->getPayload().getUnowned(biasC->dims());
+    Tensor biasT = biasC->getPayload().getUnowned();
     newBiasC->assign(&biasT);
 
     // Collect the chain and compute the new scale and bias.

--- a/lib/Runtime/Executor/NetworkExecutionState.cpp
+++ b/lib/Runtime/Executor/NetworkExecutionState.cpp
@@ -70,9 +70,9 @@ void NetworkExecutionState::bind(std::unique_ptr<ExecutionContext> resultCtx,
     for (auto binding : externalIntermediates_[PH]) {
       auto resultTensor = resultPHBindings->get(PH);
       if (binding->get(PH)) {
-        binding->update(PH, resultTensor->getUnowned(PH->dims()));
+        binding->update(PH, resultTensor->getUnowned());
       } else {
-        binding->insert(PH, resultTensor->getUnowned(PH->dims()));
+        binding->insert(PH, resultTensor->getUnowned());
       }
     }
   }

--- a/tests/unittests/TensorsTest.cpp
+++ b/tests/unittests/TensorsTest.cpp
@@ -1130,7 +1130,7 @@ TEST(Tensor, unpaddedSize) {
   EXPECT_EQ(moved.getSizeInBytes(), paddedBytes);
 
   // Test getting an unowned tensor from a padded tensor.
-  auto copy = moved.getUnowned(moved.dims());
+  auto copy = moved.getUnowned();
   EXPECT_EQ(copy.getUnpaddedSizeInBytes(), bytes);
   EXPECT_EQ(copy.getSizeInBytes(), paddedBytes);
 


### PR DESCRIPTION
Summary: We have this pattern in some places. Add a helper for it. I'm sure there are other places this pattern is used, but I found these easily.

Differential Revision: D20454075

