### PR TITLE
Add support for fp32 bias for FC

### DIFF
--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -2811,7 +2811,7 @@ void BoundInterpreterFunction::fwdFullyConnectedInstQuantizedImpl(
 
       // Scale the result back to the expected destination scale.
       outW.at({i, j}) = quantization::clip<AccumulatorTy, ElemTy>(
-          std::round(float(sum) * (matMulScale / outScale) + outOffset));
+          std::round(float(sum) * (matMulScale / outScale)) + outOffset);
     }
   }
 }

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -324,9 +324,10 @@ static bool verifyFullyConnected(NodeValue src, NodeValue weights,
 
   if (src.getElementType() == ElemKind::Int8QTy) {
     isValid &=
-        expectCompareTrue("Bias type should be Int8 or Int32 for FC",
+        expectCompareTrue("Bias type should be Int8, Int32 or FP32 for FC",
                           bias.getElementType() == ElemKind::Int8QTy ||
-                              bias.getElementType() == ElemKind::Int32QTy,
+                              bias.getElementType() == ElemKind::Int32QTy ||
+                              bias.getElementType() == ElemKind::FloatTy,
                           true, parent);
   }
   return isValid;


### PR DESCRIPTION
Summary: Some backend prefers to take fp32 bias directly.

Differential Revision: D20376718

