### PR TITLE
[ONNXModelWriter] Add VectorNodeValue type attributes for autogen export

### DIFF
--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -370,10 +370,13 @@ constexpr char shapeSignifier[] = "shape";
 
 /// \returns the string ID for a type attribute property for a specific \p ioNum
 /// and \p signifier and whether \p isInput. E.g. to retrieve result number 0's
-/// shape, you'd pass `(0, "shape", false)`.
+/// shape, you'd pass `(0, "shape", false)`. \p addPrefix is an additional
+/// prefix to include at the front of the returned ID.
 inline std::string getTypeAttrID(unsigned ioNum, const std::string &signifier,
-                                 bool isInput = false) {
-  return (isInput ? "i" : "o") + std::to_string(ioNum) + "_" + signifier;
+                                 bool isInput = false,
+                                 const std::string &addPrefix = "") {
+  return addPrefix + (isInput ? "i" : "o") + std::to_string(ioNum) + "_" +
+         signifier;
 }
 
 } // namespace glow

--- a/tools/ClassGen/NodeBuilder.cpp
+++ b/tools/ClassGen/NodeBuilder.cpp
@@ -698,6 +698,15 @@ void NodeBuilder::emitExportMethods(std::ostream &os) const {
   for (const auto &op : members_) {
     os << "  addValueAttribute(opProto, \"" << op.second << "\", N__->get"
        << op.second << "());\n";
+
+    // If the member is a VectorNodeValue then also add the types of the NVs.
+    if (op.first.type == MemberType::VectorNodeValue) {
+      os << "  for (unsigned i = 0, e = N__->get" << op.second
+         << "().size(); i < e; i++) {\n";
+      os << "    addTypeAttributes(opProto, N__->get" << op.second
+         << "()[i], i, /* isInput */ true, \"" << op.second << "_\");\n";
+      os << "  }\n";
+    }
   }
 
   // Check if the node has a predicate and add it if so.


### PR DESCRIPTION
Summary: Previously this was not included, meaning ops such as Concat did not have input type info readily available.

Test Plan: Verified by looking at serialized output. E.g. for a Concat this is what is now dumped alongside the Inputs:

```
...
    attribute {
      name: "Inputs"
      strings: "V1"
      strings: "V2"
      strings: "V3"
      type: STRINGS
    }
    attribute {
      name: "Inputs_i0_elemKind"
      s: "index32"
      type: STRING
    }
    attribute {
      name: "Inputs_i0_shape"
      ints: 10
      type: INTS
    }
...
```