### PR TITLE
[TensorLayout] Add SliceNode to the operator list which can accept any Layout

### DIFF
--- a/lib/Graph/TensorLayout.cpp
+++ b/lib/Graph/TensorLayout.cpp
@@ -662,6 +662,7 @@ static bool acceptsAnyInputLayout(const glow::Node *node) {
   case Kinded::Kind::MeanVarNormalizationNodeKind:
   case Kinded::Kind::MatMulNodeKind:
   case Kinded::Kind::FlipNodeKind:
+  case Kinded::Kind::SliceNodeKind:
   case Kinded::Kind::SGDNodeKind: {
     return true;
   }


### PR DESCRIPTION
When Slice Operator is followed by Transpose Operator (Tranpose -> Slice) and Transpose operator has layout change like NHWC2NCHW, then Slice Node tensor layout verification fails since it is not part of list of operators which can accept any layout.

In this commit we are adding Slice Operator as a part of operator list which can accept any layout

Test Plan: Ninja Test is run