### PR TITLE
[OnnxModelLoader] Achieving functionality of Maxpool1D with Maxpool2D

### DIFF
--- a/tests/models/onnxModels/maxPool1D.onnxtxt
+++ b/tests/models/onnxModels/maxPool1D.onnxtxt
@@ -1,0 +1,67 @@
+ir_version: 6
+producer_name: "maxpool1D-onnx-example"
+graph {
+  node {
+    input: "x"
+    output: "y"
+    op_type: "MaxPool"
+    attribute {
+      name: "auto_pad"
+      s: "SAME_UPPER"
+      type: STRING
+    }
+    attribute {
+      name: "kernel_shape"
+      ints: 5
+      type: INTS
+    }
+    attribute {
+      name: "strides"
+      ints: 5
+      type: INTS
+    }
+  }
+  name: "maxPool-node"
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 7
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 11
+}

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -263,10 +263,10 @@ importArithMultiBroadcastTest(std::string fileName,
 
 /// Import maxPool1D
 static void importMaxPool1DTest(std::string &netFilename,
-                                std::vector<float> inputValues,
-                                std::vector<dim_t> inputShape,
-                                std::vector<dim_t> outputShape,
-                                std::vector<float> expectedValues) {
+                                llvm::ArrayRef<float> inputValues,
+                                llvm::ArrayRef<dim_t> inputShape,
+                                llvm::ArrayRef<dim_t> outputShape,
+                                llvm::ArrayRef<float> expectedValues) {
   float delta = 1e-08;
   ExecutionEngine EE{};
   auto &mod = EE.getModule();
@@ -274,8 +274,6 @@ static void importMaxPool1DTest(std::string &netFilename,
   PlaceholderBindings bindings;
   Placeholder *graphOutputVar;
 
-  // Load the .onnxtxt model
-  // ONNXModelLoader onnxLD(netFilename, {"x"}, {&x.getType()}, *F);
   Type input_type(ElemKind::FloatTy, inputShape);
   ONNXModelLoader onnxLD(netFilename, {"x"}, {&input_type}, *F);
 

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -261,6 +261,63 @@ importArithMultiBroadcastTest(std::string fileName,
                                           {bindings.get(graphOutputVar)}));
 }
 
+/// Import maxPool1D
+static void importMaxPool1DTest(std::string &netFilename,
+                                std::vector<float> inputValues,
+                                std::vector<dim_t> inputShape,
+                                std::vector<dim_t> outputShape,
+                                std::vector<float> expectedValues) {
+  float delta = 1e-08;
+  ExecutionEngine EE{};
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+  PlaceholderBindings bindings;
+  Placeholder *graphOutputVar;
+
+  // Load the .onnxtxt model
+  // ONNXModelLoader onnxLD(netFilename, {"x"}, {&x.getType()}, *F);
+  Type input_type(ElemKind::FloatTy, inputShape);
+  ONNXModelLoader onnxLD(netFilename, {"x"}, {&input_type}, *F);
+
+  graphOutputVar = EXIT_ON_ERR(onnxLD.getSingleOutput());
+
+  auto PH = mod.getPlaceholderByName("x");
+  auto *inTensor = bindings.allocate(PH);
+  inTensor->getHandle() = inputValues;
+
+  EE.compile(CompilationMode::Infer);
+  bindings.allocate(mod.getPlaceholders());
+  EE.run(bindings);
+
+  auto result = bindings.get(graphOutputVar)->getHandle();
+  ASSERT_TRUE(result.dims() == (llvm::ArrayRef<dim_t>)outputShape);
+  for (size_t i = 0; i < result.getType().size(); i++) {
+    EXPECT_NEAR(result.raw(i), expectedValues[i], delta);
+  }
+}
+
+/// Test loading maxPool1D op from an ONNX model
+/// with different ouput shape.
+TEST(onnx, maxPool1D) {
+  std::vector<float> inputValues = {
+      1.4206449,  0.54408556, 1.3318906,  0.771925,   0.9450552,
+      0.08600737, 0.30009857, 1.4206449,  0.54408556, 1.3318906,
+      0.771925,   0.9450552,  0.08600737, 0.30009857};
+
+  std::vector<dim_t> inputShape = {1, 2, 7};
+  std::vector<dim_t> outputShape = {1, 2, 2};
+  std::vector<float> expectedValues = {
+      1.4206449,
+      0.9450552,
+      1.4206449,
+      0.9450552,
+  };
+  std::string netFilename(GLOW_DATA_PATH
+                          "tests/models/onnxModels/maxPool1D.onnxtxt");
+  importMaxPool1DTest(netFilename, inputValues, inputShape, outputShape,
+                      expectedValues);
+}
+
 /// Test loading LeakyRelu op from an ONNX model.
 TEST_F(OnnxImporterTest, leakyRelu) {
   ExecutionEngine EE{};


### PR DESCRIPTION
Some of the Computer vision onnx models have Maxpool operation with Input tensor dimension size of 3 (i.e., (NxCxD1)). This maps to Maxpool 1D as per https://github.com/onnx/onnx/blob/master/docs/Operators.md#MaxPool . To achieve the functionality of Maxpool 1D, Maxpool 2D IR was used and corresponding changes in Onnx Model Loader where done. A test case in OnnxImporterTest is also for Maxpool1D

Test Plan: Ninja Test is run