### PR TITLE
Remove unused Functions; Fix device indexing

### DIFF
--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -2059,6 +2059,11 @@ Error Caffe2ModelLoader::initWithModule(caffe2::NetDef &networkDef,
     PPC->logicalIDs.reserve(partNameToFun_.size());
     for (auto &SF : partNameToFun_) {
       Function *F = SF.getValue();
+      // Remove unused Functions from the module and skip them.
+      if (F->getNodes().size() == 0) {
+        mod_.eraseFunction(SF.getValue());
+        continue;
+      }
       // This is to ensure that the same processing done with
       // the same network, even if order of operators is different.
       F->orderNodes();

--- a/lib/Partitioner/Partitioner.cpp
+++ b/lib/Partitioner/Partitioner.cpp
@@ -905,6 +905,10 @@ Partitioner::partitionFromConfig(const PartitionConfig &partitionConfig,
 
 Expected<DAGListTy>
 Partitioner::setupPrepartitionedModule(const PrePartitionedConfig &config) {
+  RETURN_ERR_IF_NOT(
+      !multiBackendNames_,
+      "Do not support multiple backend kinds in prepartitioned flow.");
+
   // Prepare the mapping between BackendName and BackendInfo.
   std::vector<Backend *> backends;
   genBackendMap(backendMap_, backendHolder_, backends);
@@ -914,7 +918,7 @@ Partitioner::setupPrepartitionedModule(const PrePartitionedConfig &config) {
   NodeToFunctionMap partitionMap;
   // Create partitions based on the given number and names.
   for (size_t i = 0, e = funcs.size(); i < e; i++) {
-    partitionMap.createPartition(funcs[i], deviceInfo_[i].backendName);
+    partitionMap.createPartition(funcs[i], deviceInfo_[0].backendName);
   }
 
   // Map the nodes the the partitions.

--- a/tests/models/caffe2Models/pre_partitioned_multi_op_predict_net.pbtxt
+++ b/tests/models/caffe2Models/pre_partitioned_multi_op_predict_net.pbtxt
@@ -77,3 +77,7 @@ partition_info {
   name: "p2"
   device_id: 2
 }
+partition_info {
+  name: "unused_p3"
+  device_id: 2
+}


### PR DESCRIPTION
Summary:
- Prepartitioned models may add `partition_info` that goes unused by an ops, so remove those Functions that are unused
- Add a check for all backends being the same, and then always use the first device's name

Differential Revision: D20504678

