### PR TITLE
Plumb pre-partitioned model loading into ONNXIFI

### DIFF
--- a/include/glow/Importer/ONNXIFIModelLoader.h
+++ b/include/glow/Importer/ONNXIFIModelLoader.h
@@ -55,17 +55,23 @@ public:
   }
 
   /// \returns a unique_ptr<ONNXIFIModelLoader> if \p onnxModel can be
-  /// parsed and static weights can be loaded from the \p wightDescriptors.
+  /// parsed and static weights can be loaded from the \p weightDescriptors.
   /// \returns Error otherwise. \p loadInputsAsPlaceholders is passed to
   /// loadInputs to determine whether graph inputs are loaded as Placeholders or
   /// Tensors. Loading inputs as Tensors is useful for when weights are not
   /// provided such as when the graph being loaded is actually a small patch of
   /// a larger graph because the graph inputs in this case may represent
   /// internal values for the larger graph. \p constFoldInLoader is used to
-  /// determine whether to try constant folding at load time.
+  /// determine whether to try constant folding at load time. \p mod will be
+  /// filled wth one or more Functions built. If the model is pre-partitioned,
+  /// then \p PPC will be filled with relevant configuration for partitioning,
+  /// and all Functions created will be named with prefix /p netName. Otherwise
+  /// \p PPC is ignored, and \p netName is used as the name of the single
+  /// Function that is created inside \p mod.
   static Expected<std::unique_ptr<ONNXIFIModelLoader>>
   parse(const void *onnxModel, uint32_t onnxModelSize, uint32_t weightsCount,
-        const onnxTensorDescriptorV1 *weightDescriptors, Function &F,
+        const onnxTensorDescriptorV1 *weightDescriptors, Module &mod,
+        llvm::StringRef netName, runtime::PrePartitionedConfig *PPC,
         bool loadInputsAsPlaceholders = true, bool use_onnx = true,
         bool constFoldInLoader = true);
 };

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -54,8 +54,6 @@ onnxStatus Backend::checkGraphCompatibility(const void *onnxModel,
                                             size_t onnxModelSize) {
   Module module;
 
-  auto function = module.createFunction(compatibilityFunctionName);
-
   std::unique_ptr<ONNXIFIModelLoader> loader;
   // Note: Because we are not loading inputs as Placeholders, we need to
   // explicitly not do constant folding in the loader. This is because the
@@ -64,11 +62,11 @@ onnxStatus Backend::checkGraphCompatibility(const void *onnxModel,
   // Constants, such as a Convolution's weights. In the future we should clean
   // this up so that we load Constants and Placeholders based on the actual
   // eventual input graph.
-  auto loaderOrErr =
-      ONNXIFIModelLoader::parse(onnxModel, onnxModelSize, 0 /*weightCount*/,
-                                nullptr /*weightDescriptors*/, *function,
-                                false /*loadInputsAsPlaceholders*/,
-                                getUseOnnx(), /*constFoldInLoader*/ false);
+  auto loaderOrErr = ONNXIFIModelLoader::parse(
+      onnxModel, onnxModelSize, 0 /*weightCount*/,
+      nullptr /*weightDescriptors*/, module, compatibilityFunctionName,
+      /* PPC */ nullptr, false /*loadInputsAsPlaceholders*/, getUseOnnx(),
+      /*constFoldInLoader*/ false);
   if (loaderOrErr) {
     loader = std::move(*loaderOrErr);
   } else {
@@ -82,6 +80,12 @@ onnxStatus Backend::checkGraphCompatibility(const void *onnxModel,
   if (!glowBackend_) {
     return ONNXIFI_STATUS_INTERNAL_ERROR;
   }
+
+  if (module.getFunctions().size() != 1) {
+    LOG(ERROR) << "Should have exactly one Function in compatibiliity mode.";
+    return ONNXIFI_STATUS_INTERNAL_ERROR;
+  }
+  Function *function = *module.getFunctions().begin();
 
   CompilationContext cctx;
   cctx.compMode = CompilationMode::Infer;

--- a/lib/Onnxifi/HostManagerOnnxifi.h
+++ b/lib/Onnxifi/HostManagerOnnxifi.h
@@ -36,7 +36,8 @@ public:
                   runtime::ResultCBTy callback, uint64_t priority = 0) override;
 
   onnxStatus addNetwork(std::unique_ptr<Module> module,
-                        void *deferredBlobReader);
+                        void *deferredBlobReader,
+                        runtime::PrePartitionedConfig *PPC);
 
   onnxStatus removeNetwork(const Graph *graph) override;
 

--- a/lib/Onnxifi/InlineOnnxifi.cpp
+++ b/lib/Onnxifi/InlineOnnxifi.cpp
@@ -48,12 +48,17 @@ InlineGraph::initGraph(const void *onnxModel, size_t onnxModelSize,
                        uint32_t weightCount,
                        const onnxTensorDescriptorV1 *weightDescriptors,
                        uint32_t maxSeqLength, void * /*unused */) {
-  function_ = executionEngine_.getModule().createFunction("function");
-
+  Module &mod = executionEngine_.getModule();
+  // Note: Pass in a nullptr for PPC here because we do not currently support
+  // pre-partitioned models here.
   std::unique_ptr<ONNXIFIModelLoader> loader =
       EXIT_ON_ERR(ONNXIFIModelLoader::parse(
-          onnxModel, onnxModelSize, weightCount, weightDescriptors, *function_,
-          true /*loadInputsAsPlaceholders*/, backendPtr_->getUseOnnx()));
+          onnxModel, onnxModelSize, weightCount, weightDescriptors, mod,
+          "function", /* PPC */ nullptr, true /*loadInputsAsPlaceholders*/,
+          backendPtr_->getUseOnnx()));
+
+  CHECK_EQ(mod.getFunctions().size(), 1) << "Should have exactly one Function.";
+  function_ = *mod.getFunctions().begin();
 
   bindPlaceholders(*loader);
   if (GlowSaveOnnxifiModel) {

--- a/lib/Partitioner/Partitioner.cpp
+++ b/lib/Partitioner/Partitioner.cpp
@@ -1260,7 +1260,8 @@ Expected<DAGListTy> Partitioner::partitionSparseNN(CompilationContext &cctx) {
 }
 
 Expected<DAGListTy> Partitioner::partition(CompilationContext &cctx) {
-  if (cctx.prepartitionedConfig) {
+  if (cctx.prepartitionedConfig &&
+      cctx.prepartitionedConfig->funcs.size() != 0) {
     return setupPrepartitionedModule(*cctx.prepartitionedConfig);
   }
 


### PR DESCRIPTION
Summary: Note that there is some weirdness here for exporting a pre-partitioned model -- right now it will export each partition separately as a different zip. We probably want to export this based on the Module instead, annotating the ops in the ONNX model with the partitions similar to what we do with the C2 protos. Can be done in a followup diff.

Reviewed By: yinghai

Differential Revision: D20437866

