### PR TITLE
[OnnxModelLoader] Achieve functionality of conv1D with conv2D

### DIFF
--- a/include/glow/Importer/ONNXModelLoader.h
+++ b/include/glow/Importer/ONNXModelLoader.h
@@ -147,6 +147,20 @@ class ONNXModelLoader
   Error loadConvTranspose(const ONNX_NAMESPACE::NodeProto &op,
                           ArgumentDictionaryTy &dict);
 
+  /// Load Conv1D operator.
+  /// As per conv operation definition at
+  /// https://github.com/onnx/onnx/blob/master/docs/Operators.md#Conv ,
+  /// input is in format (NxCxD1x…xDn). If the input tensor dimension size is 3
+  /// , we have kernel size of only 1 dimension and we call such a conv
+  /// operation as conv1d.
+  /// Conv1d is implemented using Conv2d as follows:
+  ///   a) Expand the input and kernel dimension to 4 using expand operator
+  ///   b) Do the necessary tensor format conversion as required for Conv2d
+  ///   c) Then use Conv2d for execution
+  ///   d) To reduce the output tensor dimension from 4 to 3, Squeeze is used
+  Error loadConv1D(const ONNX_NAMESPACE::NodeProto &op,
+                   ArgumentDictionaryTy &dict);
+
   /// Load MaxPool or AveragePool ONNX operator. \p typeName is the name of the
   /// ONNX operator being loaded, either MaxPool or AveragePool.
   Error loadPool(const ONNX_NAMESPACE::NodeProto &op,

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -1130,9 +1130,106 @@ Error ONNXModelLoader::loadSlice(const ONNX_NAMESPACE::NodeProto &op,
   return Error::success();
 }
 
+Error ONNXModelLoader::loadConv1D(const ONNX_NAMESPACE::NodeProto &op,
+                                  ArgumentDictionaryTy &dict) {
+  const std::string &opName = loadOperatorName(op);
+  // Load the attributes
+  std::vector<glow::unsigned_t> strides(2, 1);
+
+  strides[1] = dict.count("strides") ? dict.at("strides")->ints(0) : 1;
+  strides[0] = 1;
+
+  unsigned_t group = 1;
+  if (dict.count("group")) {
+    ASSIGN_VALUE_OR_RETURN_ERR(group, loadInt(dict.at("group")));
+  }
+
+  unsigned_t dilation =
+      dict.count("dilations") ? dict.at("dilations")->ints(0) : 1;
+
+  // Load the inputs
+  NodeValue in;
+  // input == NCW ---> NCHW
+  ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
+  in = G_->createExpandDims(opName, in, 2);
+  // filtervalue == CKS ---> CKRS
+  NodeValue filterValue;
+  ASSIGN_VALUE_OR_RETURN_ERR(filterValue, getNodeValueByName(op.input(1)));
+  filterValue = G_->createExpandDims(opName, filterValue, 2);
+  // Transpose the filter to the right format. Glow expects to read the
+  // weights in the format CRSK. ONNX stores the operators as CKRS.
+  // C - output_depth, R - filter_height, S - filter_width, K - input_depth.
+  // filtervalue == CKRS ---> CRSK
+  TransposeNode *filterTransposeNode =
+      G_->createTranspose(opName, filterValue, NCHW2NHWC);
+  // The structure of the conv weights is: CRSK. We take the C, which is the
+  // number of filters. We use this value to calculate the size of the bias
+  // if it is not specified.
+  const NodeValue filterTransposedValue = filterTransposeNode->getResult();
+  dim_t depth = filterTransposedValue.dims()[0];
+
+  // Construct the Bias field.
+  Constant *bias = nullptr;
+
+  // Check if we have a serialized bias vector.
+  if (op.input_size() > 2) {
+    auto &biasTensorName = op.input(2);
+    // Load the serialized bias vector.
+    ASSIGN_VALUE_OR_RETURN_ERR(bias, getConstantByName(biasTensorName));
+  }
+
+  // If a serialized bias wasn't found then create a zero bias.
+  if (!bias) {
+    Tensor biasTensor(ElemKind::FloatTy, {depth});
+    biasTensor.zero();
+    bias = mod_.createConstant("conv.bias", std::move(biasTensor));
+  }
+
+  // ONNX passes the input as NCHW, and we expect the input to be NHWC.
+  auto *tr = G_->createTranspose(opName, in, NCHW2NHWC);
+  // Calculate the size and allocate the output buffer.
+  ShapeNHWC idim = ShapeNHWC(tr->getResult().dims());
+  llvm::SmallVector<unsigned_t, 2> idimHW(2);
+  idimHW[0] = in.dims()[2];
+  idimHW[1] = in.dims()[3];
+
+  // Pads : {pad_top, pad_left, pad_bottom, pad_right}
+  Pads pads;
+  // Get the kernel shape.
+  llvm::SmallVector<unsigned_t, 2> kernelShape(2);
+  kernelShape[0] = filterTransposedValue.dims()[1];
+  kernelShape[1] = filterTransposedValue.dims()[2];
+
+  ASSIGN_VALUE_OR_RETURN_ERR(pads, getPads(dict, kernelShape, strides, idimHW));
+  auto outSz = calculateConvPoolOutputDims(idim.h, idim.w, kernelShape, strides,
+                                           pads, dilation);
+  std::array<dim_t, 4> outDims = {{idim.n, outSz.first, outSz.second, depth}};
+  auto outTy = mod_.uniqueType(ElemKind::FloatTy, outDims);
+  auto *node = G_->createConv(opName, tr, filterTransposeNode, bias, outTy,
+                              kernelShape, strides, pads, group, dilation);
+
+  auto *N = G_->createSqueeze(opName, node, 1 /*axes*/);
+  // Transpose the output back
+  auto *RR = G_->createTranspose(opName, N, {0, 2, 1});
+  RETURN_IF_ERR(addNodeAsOutput(op, RR));
+  return Error::success();
+}
+
 Error ONNXModelLoader::loadConv(const ONNX_NAMESPACE::NodeProto &op,
                                 ArgumentDictionaryTy &dict) {
   const std::string &opName = loadOperatorName(op);
+
+  // Load the inputs
+  NodeValue in;
+  ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
+
+  if (in.dims().size() == 3) {
+    return loadConv1D(op, dict);
+  }
+
+  NodeValue filterValue;
+  ASSIGN_VALUE_OR_RETURN_ERR(filterValue, getNodeValueByName(op.input(1)));
+
   // Load the attributes
   std::vector<unsigned_t> strides(2, 1);
   if (dict.count("strides")) {
@@ -1155,12 +1252,6 @@ Error ONNXModelLoader::loadConv(const ONNX_NAMESPACE::NodeProto &op,
                       "are not supported currently. values must be same.");
     dilation = dilations[0];
   }
-
-  // Load the inputs
-  NodeValue in;
-  ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
-  NodeValue filterValue;
-  ASSIGN_VALUE_OR_RETURN_ERR(filterValue, getNodeValueByName(op.input(1)));
 
   // Transpose the filter to the right format. Glow expects to read the
   // weights in the format CRSK. ONNX stores the operators as KCRS.

--- a/tests/models/onnxModels/conv1D.onnxtxt
+++ b/tests/models/onnxModels/conv1D.onnxtxt
@@ -1,0 +1,87 @@
+ir_version: 6
+producer_name: "conv1D-onnx-example"
+graph {
+  node {
+    input: "x"
+    input: "w"
+    output: "y"
+    op_type: "Conv"
+    attribute {
+      name: "dilations"
+      ints: 1
+      type: INTS
+    }
+    attribute {
+      name: "kernel_shape"
+      ints: 1
+      type: INTS
+    }
+    attribute {
+      name: "strides"
+      ints: 1
+      type: INTS
+    }
+  }
+  name: "conv1D-node"
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 8
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "w"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 8
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 11
+}

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -622,6 +622,69 @@ TEST_F(OnnxImporterTest, importConvAutoPadSameLower) {
   convTestHelper(filename, expectedDims, expectedValues);
 }
 
+/// Import conv1D
+static void importConv1DTest(std::string &netFilename,
+                             llvm::ArrayRef<float> inputXValues,
+                             llvm::ArrayRef<dim_t> inputXShape,
+                             llvm::ArrayRef<float> inputWValues,
+                             llvm::ArrayRef<dim_t> inputWShape,
+                             llvm::ArrayRef<dim_t> outputShape,
+                             llvm::ArrayRef<float> expectedValues) {
+  float delta = 1e-07;
+  ExecutionEngine EE{};
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+  PlaceholderBindings bindings;
+  Placeholder *graphOutputVar;
+
+  Type input_type_x(ElemKind::FloatTy, inputXShape);
+  Type input_type_w(ElemKind::FloatTy, inputWShape);
+  ONNXModelLoader onnxLD(netFilename, {"x", "w"},
+                         {&input_type_x, &input_type_w}, *F);
+
+  graphOutputVar = EXIT_ON_ERR(onnxLD.getSingleOutput());
+
+  auto PHX = mod.getPlaceholderByName("x");
+  auto *inTensorX = bindings.allocate(PHX);
+  inTensorX->getHandle() = inputXValues;
+
+  auto PHW = mod.getPlaceholderByName("w");
+  auto *inTensorW = bindings.allocate(PHW);
+  inTensorW->getHandle() = inputWValues;
+
+  EE.compile(CompilationMode::Infer);
+  bindings.allocate(mod.getPlaceholders());
+  EE.run(bindings);
+
+  auto result = bindings.get(graphOutputVar)->getHandle();
+  ASSERT_TRUE(result.dims() == (llvm::ArrayRef<dim_t>)outputShape);
+  for (size_t i = 0; i < result.getType().size(); i++) {
+    EXPECT_NEAR(result.raw(i), expectedValues[i], delta);
+  }
+}
+
+/// Test Conv1D
+TEST(onnx, conv1D) {
+  std::vector<float> inputXValues = {
+      1.4206449,  -0.54408556, -1.3318906,  0.771925,   0.9450552,  0.08600737,
+      0.30009857, -0.36060193, -0.33999684, -0.9809143, -1.0172559, -0.4921318,
+      -1.0513021, 1.8671927,   -0.842103,   -0.8903683};
+  std::vector<float> inputWValues = {0.16575365, -0.42219377, 0.55620337,
+                                     -0.5700942, -1.1148645,  -0.33808824};
+  std::vector<dim_t> inputXShape = {1, 2, 8};
+  std::vector<dim_t> inputWShape = {3, 2, 1};
+  std::vector<dim_t> outputShape = {1, 3, 8};
+  std::vector<float> expectedValues = {
+      0.3790216,  0.32395172, 0.20871338,  0.33572435, 0.6004995,   -0.7740611,
+      0.40527308, 0.31613684, 0.9839977,   0.25659135, -0.16087033, 0.7099088,
+      1.1249841,  -1.0166382, 0.6469939,   0.30702582, -1.4688776,  0.9382173,
+      1.8287997,  -0.6942077, -0.69817555, -0.7271625, -0.04986412, 0.7030453};
+  std::string netFilename(GLOW_DATA_PATH
+                          "tests/models/onnxModels/conv1D.onnxtxt");
+  importConv1DTest(netFilename, inputXValues, inputXShape, inputWValues,
+                   inputWShape, outputShape, expectedValues);
+}
+
 /// Test to ensure error handling for missing bias
 /// input is handled correctly. Remaining input is
 /// still sane to make sure it only fails for the


### PR DESCRIPTION
Summary: Some of the Computer vision onnx models have Convolution operation with Input tensor dimension size of 3 (i.e., (NxCxD1)). This maps to Convolution 1D as per https://github.com/onnx/onnx/blob/master/docs/Operators.md#Conv . To achieve the functionality of Convolution 1D , Convolution 2D IR was used and corresponding changes in Onnx Model Loader where done. A test case in OnnxImporterTest is also for Convolution1D

Test Plan: Ninja Test is run