### PR TITLE
Change HostManagerTest to run against all backends

### DIFF
--- a/lib/Backends/CPU/tests/CPUHostManagerTest.cpp
+++ b/lib/Backends/CPU/tests/CPUHostManagerTest.cpp
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "tests/unittests/BackendTestUtils.h"
+
+using namespace glow;
+
+std::set<std::string> glow::backendTestBlacklist = {};

--- a/lib/Backends/Habana/tests/HabanaHostManagerTest.cpp
+++ b/lib/Backends/Habana/tests/HabanaHostManagerTest.cpp
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "tests/unittests/BackendTestUtils.h"
+
+using namespace glow;
+
+std::set<std::string> glow::backendTestBlacklist = {};

--- a/lib/Backends/Interpreter/tests/InterpreterHostManagerTest.cpp
+++ b/lib/Backends/Interpreter/tests/InterpreterHostManagerTest.cpp
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "tests/unittests/BackendTestUtils.h"
+
+using namespace glow;
+
+std::set<std::string> glow::backendTestBlacklist = {};

--- a/lib/Backends/NNPI/tests/NNPIHostManagerTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIHostManagerTest.cpp
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "tests/unittests/BackendTestUtils.h"
+
+using namespace glow;
+
+std::set<std::string> glow::backendTestBlacklist = {};

--- a/lib/Backends/OpenCL/tests/OpenCLHostManagerTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLHostManagerTest.cpp
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "tests/unittests/BackendTestUtils.h"
+
+using namespace glow;
+
+std::set<std::string> glow::backendTestBlacklist = {};

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -257,25 +257,6 @@ if(GLOW_WITH_HABANA)
 endif()
 
 if(GLOW_WITH_CPU)
-  add_executable(HostManagerTest
-          HostManagerTest.cpp)
-  target_link_libraries(HostManagerTest
-          PRIVATE
-          Backends
-          HostManager
-          ExecutionEngine
-          Executor
-          Graph
-          IR
-          Partitioner
-          Provisioner
-          gtest
-          TestMain)
-
-  add_glow_test(HostManagerTest
-                ${GLOW_BINARY_DIR}/tests/HostManagerTest
-                    --gtest_output=xml:ProvisionerTest.xml)
-
   add_executable(HyphenTest
                  HyphenTest.cpp)
   target_link_libraries(HyphenTest
@@ -431,6 +412,17 @@ foreach(backend ${GLOW_BACKENDS})
   add_backend_test(TEST BackendTest BACKEND "${backend}" UNOPT PRIVATE Backend HostManager)
   add_backend_test(TEST DeviceManagerTest BACKEND "${backend}")
   add_backend_test(TEST GradCheckTest BACKEND "${backend}" UNOPT)
+  add_backend_test(TEST HostManagerTest BACKEND "${backend}" UNOPT PRIVATE
+                        Backends
+                        HostManager
+                        ExecutionEngine
+                        Executor
+                        Graph
+                        IR
+                        Partitioner
+                        Provisioner
+                        gtest                        
+)
   add_backend_test(TEST MLTest BACKEND "${backend}" UNOPT)
   add_backend_test(TEST OperatorGradTest BACKEND "${backend}" UNOPT)
   add_backend_test(TEST OperatorTest BACKEND "${backend}" UNOPT PRIVATE

--- a/tests/unittests/HostManagerTest.cpp
+++ b/tests/unittests/HostManagerTest.cpp
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "BackendTestUtils.h"
 
-#include "glow/Runtime/HostManager/HostManager.h"
 #include "glow/ExecutionContext/ExecutionContext.h"
+#include "glow/Runtime/HostManager/HostManager.h"
 
 #include "gtest/gtest.h"
 
@@ -27,7 +28,12 @@ using namespace glow::runtime;
 using DAGNodePairTy = std::pair<std::vector<std::unique_ptr<DAGNode>>,
                                 std::vector<std::unique_ptr<DAGNode>>>;
 
-class HostManagerTest : public ::testing::Test {};
+class HostManagerTest : public ::testing::TestWithParam<std::string> {
+public:
+  void SetUp() { backendName_ = GetParam(); }
+  std::string backendName_;
+};
+
 std::unique_ptr<Module> setupModule(unsigned functionCount) {
   std::unique_ptr<Module> module = glow::make_unique<Module>();
   for (unsigned int i = 0; i < functionCount; i++) {
@@ -73,16 +79,16 @@ void addAndRemoveNetwork(HostManager *manager, unsigned int functionNumber) {
   ERR_TO_BOOL(manager->removeNetwork(name));
 }
 
-TEST_F(HostManagerTest, newHostManager) { createHostManager("CPU"); }
+TEST_P(HostManagerTest, newHostManager) { createHostManager(backendName_); }
 
-TEST_F(HostManagerTest, addNetwork) {
+TEST_P(HostManagerTest, addNetwork) {
   auto module = setupModule(6);
-  auto hostManager = createHostManager("CPU");
+  auto hostManager = createHostManager(backendName_);
   CompilationContext cctx;
   ASSERT_FALSE(ERR_TO_BOOL(hostManager->addNetwork(std::move(module), cctx)));
 }
 
-TEST_F(HostManagerTest, queueOverflow) {
+TEST_P(HostManagerTest, queueOverflow) {
   std::unique_ptr<Module> module = glow::make_unique<Module>();
 
   Function *F = module->createFunction("main");
@@ -103,7 +109,7 @@ TEST_F(HostManagerTest, queueOverflow) {
   HostConfig hostConfig;
   hostConfig.maxQueueSize = 1;
   hostConfig.maxActiveRequests = 1;
-  auto hostManager = createHostManager("CPU", hostConfig);
+  auto hostManager = createHostManager(backendName_, hostConfig);
   CompilationContext cctx;
   ASSERT_FALSE(ERR_TO_BOOL(hostManager->addNetwork(std::move(module), cctx)));
 
@@ -132,7 +138,7 @@ TEST_F(HostManagerTest, queueOverflow) {
   }
 }
 
-TEST_F(HostManagerTest, runNetwork) {
+TEST_P(HostManagerTest, runNetwork) {
   std::unique_ptr<Module> module = glow::make_unique<Module>();
   std::unique_ptr<ExecutionContext> context =
       glow::make_unique<ExecutionContext>();
@@ -146,7 +152,7 @@ TEST_F(HostManagerTest, runNetwork) {
   auto *saveTensor =
       context->getPlaceholderBindings()->allocate(save->getPlaceholder());
 
-  auto hostManager = createHostManager("CPU");
+  auto hostManager = createHostManager(backendName_);
   CompilationContext cctx;
   ASSERT_FALSE(ERR_TO_BOOL(hostManager->addNetwork(std::move(module), cctx)));
 
@@ -193,10 +199,10 @@ TEST_F(HostManagerTest, runNetwork) {
 
 /// Test that HostManager properly handles concurrent add/remove requests with
 /// unique network names.
-TEST_F(HostManagerTest, ConcurrentAddRemoveUnique) {
+TEST_P(HostManagerTest, ConcurrentAddRemoveUnique) {
   constexpr auto numThreads = 6;
   constexpr auto numItersPerThread = 20;
-  auto hostManager = createHostManager("CPU");
+  auto hostManager = createHostManager(backendName_);
   std::atomic<unsigned> counter{0};
   std::vector<std::thread> threads;
   for (auto i = 0; i < numThreads; ++i) {
@@ -214,10 +220,10 @@ TEST_F(HostManagerTest, ConcurrentAddRemoveUnique) {
 
 /// Test that HostManager properly handles concurrent add/remove requests with a
 /// duplicate network name.
-TEST_F(HostManagerTest, ConcurrentAddRemoveDuplicate) {
+TEST_P(HostManagerTest, ConcurrentAddRemoveDuplicate) {
   constexpr auto numThreads = 6;
   constexpr auto numItersPerThread = 20;
-  auto hostManager = createHostManager("CPU");
+  auto hostManager = createHostManager(backendName_);
   std::vector<std::thread> threads;
   for (auto i = 0; i < numThreads; ++i) {
     threads.emplace_back([&]() {
@@ -233,7 +239,7 @@ TEST_F(HostManagerTest, ConcurrentAddRemoveDuplicate) {
 }
 
 /// Run several requests concurrently.
-TEST_F(HostManagerTest, runNetworkConcurrent) {
+TEST_P(HostManagerTest, runNetworkConcurrent) {
   std::unique_ptr<Module> module = glow::make_unique<Module>();
 
   Function *F = module->createFunction("main");
@@ -242,7 +248,7 @@ TEST_F(HostManagerTest, runNetworkConcurrent) {
   F->createSave("save", pow);
   auto *savePH = module->getPlaceholderByName("save");
 
-  auto hostManager = createHostManager("CPU");
+  auto hostManager = createHostManager(backendName_);
   CompilationContext cctx;
 
   ASSERT_FALSE(ERR_TO_BOOL(hostManager->addNetwork(std::move(module), cctx)));
@@ -275,7 +281,7 @@ TEST_F(HostManagerTest, runNetworkConcurrent) {
 }
 
 /// Test that the HostManager respects it's configuration parameters.
-TEST_F(HostManagerTest, ConfigureHostManager) {
+TEST_P(HostManagerTest, ConfigureHostManager) {
   HostConfig config;
   config.maxActiveRequests = 1;
   config.maxQueueSize = 0;
@@ -310,7 +316,7 @@ TEST_F(HostManagerTest, ConfigureHostManager) {
 }
 
 /// Test that the HostManager properly enqueues requests.
-TEST_F(HostManagerTest, QueueTest) {
+TEST_P(HostManagerTest, QueueTest) {
   HostConfig config;
   // Setup the hostmanager to allow 1 active and 2 queued requests for a total
   // of 3 requests in the system.
@@ -374,7 +380,7 @@ TEST_F(HostManagerTest, QueueTest) {
 // loaded on one device, P1 is loaded on two devices. This test then enables
 // static assignment which allows for P2P testing. We then run the network twice
 // to test the alternating static assignments.
-TEST_F(HostManagerTest, testStaticAssignment) {
+TEST_P(HostManagerTest, testStaticAssignment) {
   std::unique_ptr<Module> module = glow::make_unique<Module>();
   std::unique_ptr<ExecutionContext> context =
       glow::make_unique<ExecutionContext>();
@@ -389,9 +395,9 @@ TEST_F(HostManagerTest, testStaticAssignment) {
       context->getPlaceholderBindings()->allocate(save->getPlaceholder());
 
   std::vector<std::unique_ptr<DeviceConfig>> configs;
-  auto deviceConfig = glow::make_unique<DeviceConfig>("CPU");
-  auto deviceConfig2 = glow::make_unique<DeviceConfig>("CPU");
-  auto deviceConfig3 = glow::make_unique<DeviceConfig>("CPU");
+  auto deviceConfig = glow::make_unique<DeviceConfig>(backendName_);
+  auto deviceConfig2 = glow::make_unique<DeviceConfig>(backendName_);
+  auto deviceConfig3 = glow::make_unique<DeviceConfig>(backendName_);
   configs.push_back(std::move(deviceConfig));
   configs.push_back(std::move(deviceConfig2));
   configs.push_back(std::move(deviceConfig3));
@@ -404,7 +410,7 @@ TEST_F(HostManagerTest, testStaticAssignment) {
   PartitionConfig partitionConfig;
   partitionConfig.funcName = "main";
   partitionConfig.numOfPartitions = 2;
-  partitionConfig.backendNames = {"CPU", "CPU"};
+  partitionConfig.backendNames = {backendName_, backendName_};
   partitionConfig.partitionNames = {"p0", "p1"};
   partitionConfig.nodeToPartition = {{"Pow1", 0}, {"save", 1}};
   partitionConfig.logicalIDs = {{0}, {1, 2}};
@@ -457,7 +463,7 @@ TEST_F(HostManagerTest, testStaticAssignment) {
 // loaded on one device, P1 is loaded on two devices. This test then enables
 // static assignment which allows for P2P testing. We then run the network
 // multiple requests concurrently.
-TEST_F(HostManagerTest, testStaticAssignmentConcurrent) {
+TEST_P(HostManagerTest, testStaticAssignmentConcurrent) {
   std::unique_ptr<Module> module = glow::make_unique<Module>();
 
   Function *F = module->createFunction("main");
@@ -467,9 +473,9 @@ TEST_F(HostManagerTest, testStaticAssignmentConcurrent) {
   auto *savePH = module->getPlaceholderByName("save");
 
   std::vector<std::unique_ptr<DeviceConfig>> configs;
-  auto deviceConfig = glow::make_unique<DeviceConfig>("CPU");
-  auto deviceConfig2 = glow::make_unique<DeviceConfig>("CPU");
-  auto deviceConfig3 = glow::make_unique<DeviceConfig>("CPU");
+  auto deviceConfig = glow::make_unique<DeviceConfig>(backendName_);
+  auto deviceConfig2 = glow::make_unique<DeviceConfig>(backendName_);
+  auto deviceConfig3 = glow::make_unique<DeviceConfig>(backendName_);
   configs.push_back(std::move(deviceConfig));
   configs.push_back(std::move(deviceConfig2));
   configs.push_back(std::move(deviceConfig3));
@@ -482,7 +488,7 @@ TEST_F(HostManagerTest, testStaticAssignmentConcurrent) {
   PartitionConfig partitionConfig;
   partitionConfig.funcName = "main";
   partitionConfig.numOfPartitions = 2;
-  partitionConfig.backendNames = {"CPU", "CPU"};
+  partitionConfig.backendNames = {backendName_, backendName_};
   partitionConfig.partitionNames = {"p0", "p1"};
   partitionConfig.nodeToPartition = {{"Pow1", 0}, {"save", 1}};
   partitionConfig.logicalIDs = {{0}, {1, 2}};
@@ -516,3 +522,5 @@ TEST_F(HostManagerTest, testStaticAssignmentConcurrent) {
     r.wait();
   }
 }
+
+INSTANTIATE_BACKEND_TEST(HostManagerTest);


### PR DESCRIPTION
Summary:
This PR changes HostManagerTest from being hardcoded to CPU to a proper backend test for each backend.
Documentation:

Test Plan:
verify test builds and runs with the new backends.
