### PR TITLE
Add LayerNorm unit tests, and add NNPI unlowered support

### DIFF
--- a/lib/Backends/CPU/tests/CPUOperatorTest.cpp
+++ b/lib/Backends/CPU/tests/CPUOperatorTest.cpp
@@ -201,4 +201,6 @@ std::set<std::string> glow::backendTestBlacklist = {
     "FusedRowwiseQuantizedSLWSAllLengthsOne_Float16_AccumFloat/0",
     "FusedRowwiseQuantizedSLWSAllLengthsOne_Float16_AccumFloat16/0",
     "FusedRowwiseQuantizedSLWSAllLengthsOne_Fused4Bit_Float16_AccumFloat16/0",
+    "LayerNorm_Float16/0",
+    "LayerNorm_Int8/0",
 };

--- a/lib/Backends/Interpreter/tests/InterpreterOperatorTest.cpp
+++ b/lib/Backends/Interpreter/tests/InterpreterOperatorTest.cpp
@@ -20,6 +20,7 @@ using namespace glow;
 std::set<std::string> glow::backendTestBlacklist = {
     "GatherWithInt32PartialTensors/0",
     "GatherWithInt64PartialTensors/0",
+    "LayerNorm_Int8/0",
     "RepeatedSLSWithPartialTensors/0",
     "SigmoidSweep_Float16/0",
     "TanHSweep_Float16/0",

--- a/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
@@ -97,6 +97,7 @@ struct BlacklistInitializer {
             {"CumSum_Reverse/0", TestBlacklist::AnyDeviceAnyEngine},
             {"CumSum_ExclusiveReverse/0", TestBlacklist::AnyDeviceAnyEngine},
             {"CumSum_WithZeroes/0", TestBlacklist::AnyDeviceAnyEngine},
+            {"LayerNorm_Float/0", TestBlacklist::AnyDeviceHWEngine},
             {"LengthsSum/0", TestBlacklist::AnyDeviceAnyEngine},
             {"LengthsToRanges/0", TestBlacklist::AnyDeviceAnyEngine},
             {"ModuloInt32NoSignFollow/0", TestBlacklist::AnyDeviceAnyEngine},

--- a/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
@@ -341,4 +341,6 @@ std::set<std::string> glow::backendTestBlacklist = {
     "mul_int64/0",
     "add_int32/0",
     "add_int64/0",
+    "LayerNorm_Float16/0",
+    "LayerNorm_Int8/0",
 };

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -1102,15 +1102,14 @@ bool LayerNormalizationNode::verify() const {
   auto scale = getScale();
   auto bias = getBias();
 
-  bool isValid = true;
+  // Check all inputs/outputs have same ElemKind.
+  bool isValid = checkType(src, dest.getElementType(), this);
+  isValid &= checkType(src, scale.getElementType(), this);
+  isValid &= checkType(src, bias.getElementType(), this);
 
-  // Check inputs and outputs match.
-  isValid &= checkSameType(src, dest, this);
-
-  // Check that the types of scale and bias match and that they have the same
-  // ElemKind as input.
-  isValid &= checkTypeIgnoreShape(scale, src, this);
-  isValid &= checkSameType(scale, bias, this);
+  // Check inputs/outputs and scale/bias match shapes.
+  isValid &= checkSameShape(src, dest, this);
+  isValid &= checkSameShape(scale, bias, this);
 
   // Check that the dims of scale and bias match the end of src.
   auto srcDims = src.getType()->dims();

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -12509,5 +12509,58 @@ TEST_P(OperatorTest, add_float) {
   }
 }
 
+static FunctionTensorPair
+createAndInitLayerNormTest(glow::PlaceholderBindings &bindings,
+                           glow::ExecutionEngine &EE) {
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+
+  auto *input =
+      mod.createPlaceholder(ElemKind::FloatTy, {1, 4, 5, 5}, "in", false);
+
+  Tensor scaleT(ElemKind::FloatTy, {5, 5});
+  scaleT.getHandle().randomize(0.0f, 1.0f, mod.getPRNG());
+  Constant *scaleC = mod.createConstant("scale", std::move(scaleT));
+  Tensor biasT(ElemKind::FloatTy, {5, 5});
+  biasT.getHandle().randomize(0.0f, 1.0f, mod.getPRNG());
+  Constant *biasC = mod.createConstant("bias", std::move(biasT));
+
+  LayerNormalizationNode *LNN =
+      F->createLayerNormalization("LN", input, scaleC, biasC, 1e-5);
+
+  bindings.allocate(input)->getHandle().randomize(0.0f, 1.0f, mod.getPRNG());
+
+  auto *res = F->createSave("save", LNN);
+  ::glow::convertPlaceholdersToConstants(F, bindings,
+                                         {input, res->getPlaceholder()});
+  auto *resultTensor = bindings.allocate(res->getPlaceholder());
+
+  return std::make_pair(F, resultTensor);
+}
+
+/// Test LayerNorm with FloatTy.
+TEST_P(OperatorStatelessTest, LayerNorm_Float) {
+  CHECK_IF_ENABLED();
+  compareAgainstInterpreter(getBackendName(), createAndInitLayerNormTest,
+                            ElemKind::FloatTy, ElemKind::FloatTy, 0.0001f,
+                            parCloneCountOpt);
+}
+
+/// Test LayerNorm with Float16Ty.
+TEST_P(OperatorStatelessTest, LayerNorm_Float16) {
+  CHECK_IF_ENABLED();
+  compareAgainstInterpreter(getBackendName(), createAndInitLayerNormTest,
+                            ElemKind::FloatTy, ElemKind::Float16Ty, 0.005f,
+                            parCloneCountOpt);
+}
+
+/// Test LayerNorm with Int8Ty.
+TEST_P(OperatorStatelessTest, LayerNorm_Int8) {
+  CHECK_IF_ENABLED();
+  compareAgainstInterpreter(getBackendName(), createAndInitLayerNormTest,
+                            ElemKind::FloatTy, ElemKind::Int8QTy, 0.04f,
+                            parCloneCountOpt);
+}
+
 INSTANTIATE_BACKEND_TEST(OperatorStatelessTest);
 INSTANTIATE_BACKEND_TEST(OperatorTest);


### PR DESCRIPTION
Summary:
- LayerNorm unit tests did not exist before, so add them
- NNPI can support LayerNorm unlowered, so prevent lowering and add Import case

Differential Revision: D20552297

