### PR TITLE
[Quantization][Refactor] Make profile include only min/max

### DIFF
--- a/examples/fr2en.cpp
+++ b/examples/fr2en.cpp
@@ -160,7 +160,8 @@ struct Model {
     // Load the quantization profile and transform the graph.
     if (!loadProfileFileOpt.empty()) {
       precConfig.quantMode = QuantizationMode::Quantize;
-      precConfig.quantConfig.infos = deserializeFromYaml(loadProfileFileOpt);
+      precConfig.quantConfig.infos =
+          deserializeProfilingInfosFromYaml(loadProfileFileOpt);
       precConfig.quantConfig.assertAllNodesQuantized = true;
     }
 
@@ -403,9 +404,9 @@ void Model::translate(const std::vector<std::string> &batch) {
   }
 
   if (!dumpProfileFileOpt.empty()) {
-    std::vector<NodeQuantizationInfo> QI =
-        quantization::generateNodeQuantizationInfos(bindings, F_, loweredMap_);
-    serializeToYaml(dumpProfileFileOpt, QI);
+    std::vector<NodeProfilingInfo> PI =
+        quantization::generateNodeProfilingInfos(bindings, F_, loweredMap_);
+    serializeProfilingInfosToYaml(dumpProfileFileOpt, PI);
   }
 }
 

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -1728,10 +1728,18 @@ public:
   /// \returns the list of nodes that the Function owns.
   NodesList &getNodes() { return nodes_; }
 
+  const NodesList &getNodes() const { return nodes_; }
+
   /// \returns a node with the name \p name or nullptr if no node was found.
   Node *getNodeByName(llvm::StringRef name);
 
-  const NodesList &getNodes() const { return nodes_; }
+  /// \returns a node value using the \p name which has the same format as the
+  /// one used by the \ref NodeValue::generateNodeOutputName which is
+  /// "nodeName:outputNumber". The returned node value has a nullptr for the
+  /// node if not found in the Function or if the node has no outputs (for
+  /// example SaveNode). The searched node value can be one of a graph node,
+  /// constant or placeholder.
+  NodeValue getNodeValueByName(llvm::StringRef name);
 
   /// \returns pointer to the class member for the nodes list.
   static NodesList Function::*getNodesMemberPtr() { return &Function::nodes_; }

--- a/include/glow/Quantization/Quantization.h
+++ b/include/glow/Quantization/Quantization.h
@@ -53,7 +53,7 @@ generateNodeProfilingInfos(PlaceholderBindings &bindings, const Function *F,
 /// is the lowering map obtained during the quantization phase and is used
 /// to find lowering patterns for the bias operands.
 std::vector<NodeQuantizationInfo> generateNodeQuantizationInfos(
-    const std::vector<NodeProfilingInfo> &profilingInfos, Function *F,
+    llvm::ArrayRef<NodeProfilingInfo> profilingInfos, Function *F,
     const LoweredInfoMap &loweredMap = {}, Schema schema = Schema::Asymmetric,
     ElemKind quantizationPrecision = ElemKind::Int8QTy,
     ElemKind quantizationPrecisionBias = ElemKind::Int32QTy);

--- a/include/glow/Quantization/Quantization.h
+++ b/include/glow/Quantization/Quantization.h
@@ -30,16 +30,30 @@ class Backend;
 
 namespace quantization {
 
-/// Generate NodeQuantizationInfo for all required nodes from function \p F
-/// using the method specified by \p schema and target quantization precision \p
-/// quantizationPrecision. Profiling values will be written into context \p
-/// bindings. \p loweredMap maps from the NodeOutputName of a NodeValue which
-/// was lowered to a vector of the original NodeOutputNames which it replaced;
-/// this map is used to generate infos for the original unlowered NodeValues
-/// which no longer exist in \p F. The quantization precision for the bias of
-/// Convolution and FullyConnected is given by \p quantizationPrecisionBias.
+/// Generate NodeProfilingInfo for all the required nodes from function \p F
+/// using the profiling information stored in \p bindings obtained after
+/// running the network in profiling mode. During the profiling phase all the
+/// nodes are lowered. The map \p loweredMap maps the vector of NodeOutputNames
+/// obtained after lowering a NodeValue to the NodeOutputName of the lowered
+/// NodeValue. This map is used to replicate the profiling information for the
+/// unlowered NodeValues such that during the actual quantization, depending
+/// on the backend decision to lower some nodes or not, a profile will be found
+/// for any NodeValue.
+std::vector<NodeProfilingInfo>
+generateNodeProfilingInfos(PlaceholderBindings &bindings, const Function *F,
+                           const LoweredInfoMap &loweredMap = {});
+
+/// Generate NodeQuantizationInfo for all the required nodes from function \p F
+/// using the profiling information stored in \p profilingInfos obtained with
+/// the function \ref generateNodeProfilingInfos. The quantization schema is
+/// specified by \p schema and the target precision for quantization is given
+/// by \p quantizationPrecision for all the operands except the bias operands
+/// (used in nodes like Convolution and FullyConnected) for which the target
+/// precision is given by \p quantizationPrecisionBias. The map \p loweredMap
+/// is the lowering map obtained during the quantization phase and is used
+/// to find lowering patterns for the bias operands.
 std::vector<NodeQuantizationInfo> generateNodeQuantizationInfos(
-    PlaceholderBindings &bindings, const Function *F,
+    const std::vector<NodeProfilingInfo> &profilingInfos, Function *F,
     const LoweredInfoMap &loweredMap = {}, Schema schema = Schema::Asymmetric,
     ElemKind quantizationPrecision = ElemKind::Int8QTy,
     ElemKind quantizationPrecisionBias = ElemKind::Int32QTy);

--- a/include/glow/Quantization/Serialization.h
+++ b/include/glow/Quantization/Serialization.h
@@ -23,12 +23,22 @@
 
 namespace glow {
 
+/// Serialize \p profilingInfos into the file named \p fileName.
+void serializeProfilingInfosToYaml(
+    llvm::StringRef fileName, llvm::ArrayRef<NodeProfilingInfo> profilingInfos);
+
+/// Deserialize profiling infos from the file \p fileName.
+std::vector<NodeProfilingInfo>
+deserializeProfilingInfosFromYaml(llvm::StringRef fileName);
+
 /// Serialize \p quantizationInfos into the file named \p fileName.
-void serializeToYaml(llvm::StringRef fileName,
-                     llvm::ArrayRef<NodeQuantizationInfo> quantizationInfos);
+void serializeQuantizationInfosToYaml(
+    llvm::StringRef fileName,
+    llvm::ArrayRef<NodeQuantizationInfo> quantizationInfos);
 
 /// Deserialize quantization infos from the file \p fileName.
-std::vector<NodeQuantizationInfo> deserializeFromYaml(llvm::StringRef fileName);
+std::vector<NodeQuantizationInfo>
+deserializeQuantizationInfosFromYaml(llvm::StringRef fileName);
 
 } // namespace glow
 

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -4264,7 +4264,7 @@ NodeValue Function::getNodeValueByName(llvm::StringRef name) {
   if (node->getNumResults() == 1) {
     return NodeValue(node);
   } else {
-    unsigned resNo;
+    unsigned resNo = 0;
     assert(!strPair.second.getAsInteger(0, resNo) &&
            "Invalid node value name!");
     return NodeValue(node, resNo);

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -4265,8 +4265,7 @@ NodeValue Function::getNodeValueByName(llvm::StringRef name) {
     return NodeValue(node);
   } else {
     unsigned resNo = 0;
-    bool status = strPair.second.getAsInteger(0, resNo);
-    assert(!status && "Invalid node value name!");
+    CHECK(!strPair.second.getAsInteger(0, resNo)) << "Invalid node value name!";
     return NodeValue(node, resNo);
   }
 }

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -4250,6 +4250,27 @@ Node *Function::getNodeByName(llvm::StringRef name) {
   return nullptr;
 }
 
+NodeValue Function::getNodeValueByName(llvm::StringRef name) {
+  auto strPair = name.split(':');
+  // Search node, constant or placeholder.
+  auto nodeName = strPair.first;
+  Node *node = getNodeByName(nodeName);
+  node = node ? node : getParent()->getConstantByName(nodeName);
+  node = node ? node : getParent()->getPlaceholderByName(nodeName);
+  if (!node || (node->getNumResults() == 0)) {
+    return NodeValue();
+  }
+  // Get result number.
+  if (node->getNumResults() == 1) {
+    return NodeValue(node);
+  } else {
+    unsigned resNo;
+    assert(!strPair.second.getAsInteger(0, resNo) &&
+           "Invalid node value name!");
+    return NodeValue(node, resNo);
+  }
+}
+
 void Module::eraseConstant(ConstList::iterator I) {
   if (I == constants_.end())
     return;

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -4265,8 +4265,8 @@ NodeValue Function::getNodeValueByName(llvm::StringRef name) {
     return NodeValue(node);
   } else {
     unsigned resNo = 0;
-    assert(!strPair.second.getAsInteger(0, resNo) &&
-           "Invalid node value name!");
+    bool status = strPair.second.getAsInteger(0, resNo);
+    assert(!status && "Invalid node value name!");
     return NodeValue(node, resNo);
   }
 }

--- a/lib/Onnxifi/InlineOnnxifi.cpp
+++ b/lib/Onnxifi/InlineOnnxifi.cpp
@@ -72,7 +72,7 @@ InlineGraph::initGraph(const void *onnxModel, size_t onnxModelSize,
   // If quantizing, load quantization infos and setup the schema.
   if (quantizationMode_ == QuantizationMode::Quantize) {
     precConfig.quantConfig.infos =
-        deserializeFromYaml(getProfileFile(modelHash_));
+        deserializeProfilingInfosFromYaml(getProfileFile(modelHash_));
     precConfig.quantConfig.schema = quantization::Schema::Symmetric;
   }
 
@@ -87,12 +87,10 @@ onnxStatus InlineGraph::run(std::unique_ptr<ExecutionContext> ctx,
   executionEngine_.run(*ctx);
 
   // Dump profile if requested.
-  // TODO: enable configuration of quantization schema
   if (quantizationMode_ == QuantizationMode::Profile) {
-    auto QI = quantization::generateNodeQuantizationInfos(
-        *(ctx->getPlaceholderBindings()), function_, loweredMap_,
-        quantization::Schema::Symmetric, ElemKind::Int8QTy);
-    serializeToYaml(getProfileFile(modelHash_), QI);
+    auto PI = quantization::generateNodeProfilingInfos(
+        *(ctx->getPlaceholderBindings()), function_, loweredMap_);
+    serializeProfilingInfosToYaml(getProfileFile(modelHash_), PI);
   }
 
   if (auto *traceContext = ctx->getTraceContext()) {

--- a/lib/Quantization/Base/Base.cpp
+++ b/lib/Quantization/Base/Base.cpp
@@ -337,8 +337,11 @@ void validateQuantizationParams(TensorQuantizationParams qParams, Schema schema,
   }
 }
 
-TensorQuantizationParams chooseQuantizationParams(float min, float max,
-                                                  Schema schema, ElemKind qTy) {
+TensorQuantizationParams
+chooseQuantizationParams(TensorProfilingParams profParams, Schema schema,
+                         ElemKind qTy) {
+  float min = profParams.min;
+  float max = profParams.max;
   assert(min <= max && "min must not be bigger than max");
 
   // Get the quantized range.

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -709,7 +709,7 @@ public:
   /// true then if the backend does not support a node as quantized for the
   /// given \p quantizationPrecision then the program will exit with an error.
   FunctionQuantizer(Function &F, const Backend &B, quantization::Schema schema,
-                    const std::vector<NodeProfilingInfo> &profilingInfos,
+                    llvm::ArrayRef<NodeProfilingInfo> profilingInfos,
                     ElemKind quantizationPrecision,
                     const KindSet &doNotQuantizeKinds,
                     const LoweredInfoMap &loweredMap,
@@ -949,10 +949,11 @@ generateNodeProfilingInfos(PlaceholderBindings &bindings, const Function *F,
   return profilingInfos;
 }
 
-std::vector<NodeQuantizationInfo> generateNodeQuantizationInfos(
-    const std::vector<NodeProfilingInfo> &profilingInfos, Function *F,
-    const LoweredInfoMap &loweredMap, Schema schema,
-    ElemKind quantizationPrecision, ElemKind quantizationPrecisionBias) {
+std::vector<NodeQuantizationInfo>
+generateNodeQuantizationInfos(llvm::ArrayRef<NodeProfilingInfo> profilingInfos,
+                              Function *F, const LoweredInfoMap &loweredMap,
+                              Schema schema, ElemKind quantizationPrecision,
+                              ElemKind quantizationPrecisionBias) {
   std::vector<NodeQuantizationInfo> quantizationInfos;
   for (const auto &profilingInfo : profilingInfos) {
     // Get node value from node output name.

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -74,7 +74,7 @@ static Node *replaceQuantizedTanhWithLookupTable(Function &F,
   // The output quantization parameters are chosen to represent the floating
   // point range of [-1.0, 1.0].
   auto inputQuantizationParams =
-      glow::quantization::chooseQuantizationParams(-3.0, 3.0);
+      glow::quantization::chooseQuantizationParams({-3.0, 3.0});
   auto tanhInTy = F.getParent()->uniqueType(
       ElemKind::Int8QTy, TN.getResult().dims(), inputQuantizationParams.scale,
       inputQuantizationParams.offset);
@@ -85,7 +85,7 @@ static Node *replaceQuantizedTanhWithLookupTable(Function &F,
 
   // Make sure output is clipped in [-1.0, 1.0] floating point range.
   auto outputQuantizationParams =
-      glow::quantization::chooseQuantizationParams(-1.0, 1.0);
+      glow::quantization::chooseQuantizationParams({-1.0, 1.0});
   auto resultOutTy = F.getParent()->uniqueType(
       ElemKind::Int8QTy, rescaleInputNode->getResult().dims(),
       outputQuantizationParams.scale, outputQuantizationParams.offset);
@@ -113,7 +113,7 @@ static Node *replaceQuantizedSigmoidWithLookupTable(Function &F,
   // 0.997527 at -6.0 and 6.0 correspondingly. The output quantization
   // parameters are chosen to represent the floating point range of [0, 1.0].
   auto inputQuantizationParams =
-      glow::quantization::chooseQuantizationParams(-6.0, 6.0);
+      glow::quantization::chooseQuantizationParams({-6.0, 6.0});
   auto sigmoidInTy = F.getParent()->uniqueType(
       ElemKind::Int8QTy, SN.getResult().dims(), inputQuantizationParams.scale,
       inputQuantizationParams.offset);
@@ -124,7 +124,7 @@ static Node *replaceQuantizedSigmoidWithLookupTable(Function &F,
 
   // Make sure output is clipped in [0.0, 1.0] floating point range.
   auto outputQuantizationParams =
-      glow::quantization::chooseQuantizationParams(0.0, 1.0);
+      glow::quantization::chooseQuantizationParams({0.0, 1.0});
   auto resultOutTy = F.getParent()->uniqueType(
       ElemKind::Int8QTy, rescaleInputNode->getResult().dims(),
       outputQuantizationParams.scale, outputQuantizationParams.offset);
@@ -268,7 +268,6 @@ protected:
       return getBiasType(
           getTargetTypeForInput(use, ConvTransposeNode::InputIdx),
           getTargetTypeForInput(use, ConvTransposeNode::FilterIdx));
-
     } else if (use.getKind() == glow::Kinded::Kind::FullyConnectedNodeKind &&
                idx == FullyConnectedNode::BiasIdx) {
       // Get the input and weights types. This ensures the types will be
@@ -702,15 +701,15 @@ private:
   const ElemKind quantizationPrecisionBias_;
 
 public:
-  /// Creates a function quantizer for \p F using the quantization
-  /// parameters defined by \p quantizationInfos and target quantization
+  /// Creates a function quantizer for \p F using the profiling
+  /// parameters defined by \p profilingInfos and target quantization
   /// precision defined by \p quantizationPrecision.
   /// \p B and \p doNotQuantizeKinds are used to check which nodes shouldn't be
   /// converted. \p assertAllNodesQuantized is used as a debugging tool; if
   /// true then if the backend does not support a node as quantized for the
   /// given \p quantizationPrecision then the program will exit with an error.
   FunctionQuantizer(Function &F, const Backend &B, quantization::Schema schema,
-                    llvm::ArrayRef<NodeQuantizationInfo> quantizationInfos,
+                    const std::vector<NodeProfilingInfo> &profilingInfos,
                     ElemKind quantizationPrecision,
                     const KindSet &doNotQuantizeKinds,
                     const LoweredInfoMap &loweredMap,
@@ -721,11 +720,18 @@ public:
         doNotQuantizeKinds_(doNotQuantizeKinds), loweredMap_(loweredMap),
         assertAllNodesQuantized_(assertAllNodesQuantized),
         quantizationPrecisionBias_(quantizationPrecisionBias) {
+
+    // Compute the TensorQuantizationParams using the profiling infos.
+    auto quantizationInfos = generateNodeQuantizationInfos(
+        profilingInfos, &F, loweredMap, schema, quantizationPrecision,
+        quantizationPrecisionBias);
+
     // Build a mapping between node name and TensorQuantizatonParams.
     for (const auto &quantizationInfo : quantizationInfos) {
       nodeToTQP_.emplace(quantizationInfo.nodeOutputName_,
                          quantizationInfo.tensorQuantizationParams_);
     }
+
     // Use for debug purposes.
     lastMorphedNodeWithTypeChanges = nullptr;
     (void)assertAllNodesQuantized_;
@@ -879,12 +885,12 @@ namespace quantization {
 /// Helper which, given the output name \p currName of some node, looks for
 /// corresponding names in \p loweredMap which represent any names that this
 /// node was lowered from. If any are found then they are inserted into \p
-/// quantizationInfos along with \p TQP.
+/// profilingInfos along with \p TPP.
 static void
 findAndInsertLoweredInfos(llvm::StringRef currName,
                           const LoweredInfoMap &loweredMap,
-                          std::vector<NodeQuantizationInfo> &quantizationInfos,
-                          const TensorQuantizationParams &TQP) {
+                          std::vector<NodeProfilingInfo> &profilingInfos,
+                          const TensorProfilingParams &TPP) {
   auto currSetIt = loweredMap.find(currName);
   if (currSetIt == loweredMap.end()) {
     return;
@@ -894,27 +900,26 @@ findAndInsertLoweredInfos(llvm::StringRef currName,
   // names that were originally lowered into currName.
   auto &currSet = currSetIt->getValue();
 
-  // For each of the names (currOrigName), insert them into quantizationInfos,
+  // For each of the names (currOrigName), insert them into profilingInfos,
   // and then recursively find and insert other names in case currOrigName was
   // also lowered from a previous node.
   for (auto i = currSet.begin(), e = currSet.end(); i != e; ++i) {
     llvm::StringRef currOrigName = i->getName();
-    quantizationInfos.emplace_back(currOrigName, TQP);
-    findAndInsertLoweredInfos(currOrigName, loweredMap, quantizationInfos, TQP);
+    profilingInfos.emplace_back(currOrigName, TPP);
+    findAndInsertLoweredInfos(currOrigName, loweredMap, profilingInfos, TPP);
   }
 }
 
-std::vector<NodeQuantizationInfo>
-generateNodeQuantizationInfos(PlaceholderBindings &bindings, const Function *F,
-                              const LoweredInfoMap &loweredMap, Schema schema,
-                              ElemKind quantizationPrecision,
-                              ElemKind quantizationPrecisionBias) {
-  std::vector<NodeQuantizationInfo> quantizationInfos;
-
+std::vector<NodeProfilingInfo>
+generateNodeProfilingInfos(PlaceholderBindings &bindings, const Function *F,
+                           const LoweredInfoMap &loweredMap) {
+  std::vector<NodeProfilingInfo> profilingInfos;
   for (auto &node : F->getNodes()) {
     auto *QPN = llvm::dyn_cast<QuantizationProfileNode>(&node);
-
     if (QPN) {
+
+      // Extract the profiling information from the placeholders after running
+      // the network in profiling mode.
       auto CI = bindings.get(QPN->getComputationInfoPlaceholder())
                     ->getHandle<float>();
       auto histogram =
@@ -922,65 +927,94 @@ generateNodeQuantizationInfos(PlaceholderBindings &bindings, const Function *F,
       float min = CI.raw(0);
       float max = CI.raw(1);
 
+      // Generate a name to be used as profiling information identifier.
       std::string fullOutputName = NodeValue::generateNodeOutputName(
           QPN->getProfiledNodeName(), QPN->getProfiledOutputNumber());
 
-      ElemKind qPrec = quantizationPrecision;
-
-      // During profiling, for a given node, the TQP params must be computed
-      // according to the target precision used during actual quantization.
-      // The code below reflects the same logic as the one used in the function
-      // FunctionQuantizer::getTargetTypeForInput for specializing the bias
-      // quantization precision.
-      // TODO: For better clarity and to remove logic duplication this code
-      // should be coupled tighter with the logic used in FunctionQuantizer.
-      NodeValue profNode = QPN->getInput();
-      for (const auto &use : profNode.getUsers()) {
-        const auto *user = use.getUser();
-        if ((user->getKind() == glow::Kinded::Kind::ConvolutionNodeKind) &&
-            (user->getNthInput(ConvolutionNode::BiasIdx) == profNode)) {
-          // Found bias for ConvolutionNode.
-          qPrec = quantizationPrecisionBias;
-          continue;
-        }
-        if ((user->getKind() == glow::Kinded::Kind::Convolution3DNodeKind) &&
-            (user->getNthInput(Convolution3DNode::BiasIdx) == profNode)) {
-          // Found bias for Convolution3DNode.
-          qPrec = quantizationPrecisionBias;
-          continue;
-        }
-        if ((user->getKind() == glow::Kinded::Kind::FullyConnectedNodeKind) &&
-            (user->getNthInput(FullyConnectedNode::BiasIdx) == profNode)) {
-          // Found bias for FullyConnectedNode.
-          qPrec = quantizationPrecisionBias;
-          continue;
-        }
-        if ((user->getKind() == glow::Kinded::Kind::BatchedAddNodeKind) &&
-            (user->getNthInput(BatchedAddNode::SliceIdx) == profNode)) {
-          // Find out if this BatchAddNode was lowered from FullyConnectedNode.
-          const auto *baN = llvm::cast<BatchedAddNode>(user);
-          if (isBAFromLoweredFC(baN, loweredMap)) {
-            // Found bias for lowered FullyConnectedNode.
-            qPrec = quantizationPrecisionBias;
-            continue;
-          }
-        }
-      }
-
-      // TODO: Ideally tensor quantization params should be calculated
+      // TODO: Ideally tensor quantization parameters should be calculated
       // based on the histogram distribution. Use simplistic approach for now.
       (void)histogram;
-      TensorQuantizationParams TQP =
-          chooseQuantizationParams(min, max, schema, qPrec);
-
-      quantizationInfos.emplace_back(fullOutputName, TQP);
+      TensorProfilingParams TPP;
+      TPP.min = min;
+      TPP.max = max;
+      profilingInfos.emplace_back(fullOutputName, TPP);
 
       // If the NodeValue represented by fullOutputName was created via lowering
-      // another original NodeValue, then generate node quantization info for
-      // the original NodeValue using the same quantization parameters.
-      findAndInsertLoweredInfos(fullOutputName, loweredMap, quantizationInfos,
-                                TQP);
+      // of another original NodeValue, then generate node profiling info for
+      // the original NodeValue using the same profiling parameters.
+      findAndInsertLoweredInfos(fullOutputName, loweredMap, profilingInfos,
+                                TPP);
     }
+  }
+  return profilingInfos;
+}
+
+std::vector<NodeQuantizationInfo> generateNodeQuantizationInfos(
+    const std::vector<NodeProfilingInfo> &profilingInfos, Function *F,
+    const LoweredInfoMap &loweredMap, Schema schema,
+    ElemKind quantizationPrecision, ElemKind quantizationPrecisionBias) {
+  std::vector<NodeQuantizationInfo> quantizationInfos;
+  for (const auto &profilingInfo : profilingInfos) {
+    // Get node value from node output name.
+    std::string nodeOutputName = profilingInfo.nodeOutputName_;
+    NodeValue nodeOutput = F->getNodeValueByName(nodeOutputName);
+
+    // Skip if the node is not part of the graph.
+    if (!nodeOutput.getNode()) {
+      continue;
+    }
+
+    // Default target precision.
+    ElemKind qPrec = quantizationPrecision;
+
+    // The TensorQuantizationParams must be computed using the target
+    // precision used during the actual quantization. The code below
+    // reflects the same logic as the one used in the function
+    // FunctionQuantizer::getTargetTypeForInput for specializing the bias
+    // quantization precision.
+    for (const auto &use : nodeOutput.getUsers()) {
+      const auto *user = use.getUser();
+      if ((user->getKind() == glow::Kinded::Kind::ConvolutionNodeKind) &&
+          (user->getNthInput(ConvolutionNode::BiasIdx) == nodeOutput)) {
+        // Found bias for ConvolutionNode.
+        qPrec = quantizationPrecisionBias;
+        continue;
+      }
+      if ((user->getKind() == glow::Kinded::Kind::Convolution3DNodeKind) &&
+          (user->getNthInput(Convolution3DNode::BiasIdx) == nodeOutput)) {
+        // Found bias for Convolution3DNode.
+        qPrec = quantizationPrecisionBias;
+        continue;
+      }
+      if ((user->getKind() == glow::Kinded::Kind::ConvTransposeNodeKind) &&
+          (user->getNthInput(ConvTransposeNode::BiasIdx) == nodeOutput)) {
+        // Found bias for ConvTranspose.
+        qPrec = quantizationPrecisionBias;
+        continue;
+      }
+      if ((user->getKind() == glow::Kinded::Kind::FullyConnectedNodeKind) &&
+          (user->getNthInput(FullyConnectedNode::BiasIdx) == nodeOutput)) {
+        // Found bias for FullyConnectedNode.
+        qPrec = quantizationPrecisionBias;
+        continue;
+      }
+      if ((user->getKind() == glow::Kinded::Kind::BatchedAddNodeKind) &&
+          (user->getNthInput(BatchedAddNode::SliceIdx) == nodeOutput)) {
+        // Find out if this BatchAddNode was lowered from FullyConnectedNode.
+        const auto *baN = llvm::cast<BatchedAddNode>(user);
+        if (isBAFromLoweredFC(baN, loweredMap)) {
+          // Found bias for lowered FullyConnectedNode.
+          qPrec = quantizationPrecisionBias;
+          continue;
+        }
+      }
+    }
+
+    // Compute the TensorQuantizationParams using the profiling information
+    // and the target precision.
+    TensorProfilingParams TPP = profilingInfo.tensorProfilingParams_;
+    TensorQuantizationParams TQP = chooseQuantizationParams(TPP, schema, qPrec);
+    quantizationInfos.emplace_back(nodeOutputName, TQP);
   }
 
   return quantizationInfos;

--- a/tests/unittests/MLTest.cpp
+++ b/tests/unittests/MLTest.cpp
@@ -1204,7 +1204,7 @@ TEST_P(MLTest, convNetForImageRecognition) {
   CompilationContext cctxQuant{&inferBindings, &loweredMapForQuant};
   PrecisionConfiguration &precConfig = cctxQuant.precisionConfig;
   cctxQuant.precisionConfig.quantMode = QuantizationMode::Quantize;
-  precConfig.quantConfig.infos = quantization::generateNodeQuantizationInfos(
+  precConfig.quantConfig.infos = quantization::generateNodeProfilingInfos(
       profileBindings, F, loweredMapForProf);
   precConfig.quantConfig.assertAllNodesQuantized = true;
 
@@ -1344,8 +1344,8 @@ TEST_P(MLTest, testFindPixelRegression) {
   cctxQuant.precisionConfig.quantMode = QuantizationMode::Quantize;
   cctxQuant.loweredInfoMap = &loweredMapForQuant;
   cctxQuant.precisionConfig.quantConfig.infos =
-      quantization::generateNodeQuantizationInfos(profileBindings, F,
-                                                  loweredMapForProf);
+      quantization::generateNodeProfilingInfos(profileBindings, F,
+                                               loweredMapForProf);
   cctxQuant.precisionConfig.quantConfig.assertAllNodesQuantized = true;
 
   F = mod->getFunction(fName);

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -4082,7 +4082,7 @@ TEST_P(OperatorTest, ScatterDataQuantized) {
   bindings_.allocate(indices)->getHandle<int64_t>() = {1, 3};
   bindings_.allocate(slices)->getHandle() = {-3, -4, -7, -8};
 
-  auto qParams = glow::quantization::chooseQuantizationParams(-11, 11);
+  auto qParams = glow::quantization::chooseQuantizationParams({-11, 11});
   auto dataTy =
       mod_.uniqueType(ElemKind::Int8QTy, {5, 2}, qParams.scale, qParams.offset);
   auto slicesTy =
@@ -4235,7 +4235,7 @@ TEST_P(OperatorTest, ScatterAddQuantized) {
   bindings_.allocate(indices)->getHandle<int64_t>() = {1, 3};
   bindings_.allocate(slices)->getHandle() = {3, -8, -7, 8};
 
-  auto qParams = glow::quantization::chooseQuantizationParams(-11, 11);
+  auto qParams = glow::quantization::chooseQuantizationParams({-11, 11});
   auto dataTy =
       mod_.uniqueType(ElemKind::Int8QTy, {5, 2}, qParams.scale, qParams.offset);
   auto slicesTy =
@@ -5685,7 +5685,8 @@ TEST_P(OperatorTest, QuantizedTile) {
   auto *V = mod_.createPlaceholder(ElemKind::FloatTy, {4, 5}, "V", false);
   bindings_.allocate(V);
 
-  auto quantizationParams = glow::quantization::chooseQuantizationParams(0, 20);
+  auto quantizationParams =
+      glow::quantization::chooseQuantizationParams({0, 20});
   auto quantizeTy =
       mod_.uniqueType(ElemKind::Int8QTy, {4, 5}, quantizationParams.scale,
                       quantizationParams.offset);
@@ -7831,13 +7832,13 @@ static void Conv3DQuantizedTest(glow::PlaceholderBindings &bindings,
 
   // Quantized types.
   auto inputTQP = quantization::chooseQuantizationParams(
-      -1.0, 1.0, quantization::Schema::Asymmetric, elemKind);
+      {-1.0, 1.0}, quantization::Schema::Asymmetric, elemKind);
   auto filterTQP = quantization::chooseQuantizationParams(
-      -1.0, 1.0, quantization::Schema::Asymmetric, elemKind);
+      {-1.0, 1.0}, quantization::Schema::Asymmetric, elemKind);
   auto biasTQP = quantization::chooseQuantizationParams(
-      -1.0, 1.0, quantization::Schema::Asymmetric, biaselemKind);
+      {-1.0, 1.0}, quantization::Schema::Asymmetric, biaselemKind);
   auto outputTQP = quantization::chooseQuantizationParams(
-      -4.0, 4.0, quantization::Schema::Asymmetric, elemKind);
+      {-4.0, 4.0}, quantization::Schema::Asymmetric, elemKind);
 
   // Create quantized network.
   auto inputQTy = mod.uniqueType(elemKind, {1, 4, 4, 4, 1}, inputTQP.scale,

--- a/tools/loader/ExecutorCore.cpp
+++ b/tools/loader/ExecutorCore.cpp
@@ -384,10 +384,10 @@ int Executor::executeNetwork(int argc, char **argv) {
       }
     }
 
-    // If profiling, generate and serialize the quantization infos now that we
+    // If profiling, generate and serialize the profiling infos now that we
     // have run inference one or more times to gather the profile.
     if (profilingGraph()) {
-      loader.generateAndSerializeQuantizationInfos(bindings);
+      loader.generateAndSerializeProfilingInfos(bindings);
     }
     if (!tracePath.empty()) {
       Error err = loader.getHostManager()->stopDeviceTrace();

--- a/tools/loader/Loader.h
+++ b/tools/loader/Loader.h
@@ -181,11 +181,11 @@ public:
   void inferEndMiniBatch(PlaceholderBindings &, size_t minibatchIndex,
                          size_t minibatchSize);
 
-  /// Generates and serializes the quantization infos after gathering a profile
+  /// Generates and serializes the profiling infos after gathering a profile
   /// by running inference one or more times. \p bindings
   /// binds specific placeholders to concrete tensors. The concrete tensors
   /// include quantization profile guided information.
-  void generateAndSerializeQuantizationInfos(PlaceholderBindings &bindings);
+  void generateAndSerializeProfilingInfos(PlaceholderBindings &bindings);
 
   /// Create the Loader driver object.
   Loader();

--- a/tools/loader/ModelProfiler.cpp
+++ b/tools/loader/ModelProfiler.cpp
@@ -267,7 +267,7 @@ int main(int argc, char **argv) {
   }
 
   // Dump the final profile.
-  loader.generateAndSerializeQuantizationInfos(bindings);
+  loader.generateAndSerializeProfilingInfos(bindings);
 
   return 0;
 }

--- a/tools/loader/ModelRunner.cpp
+++ b/tools/loader/ModelRunner.cpp
@@ -79,10 +79,10 @@ int main(int argc, char **argv) {
       LOG(FATAL) << "Unexpected output type";
     }
 
-    // If profiling, generate and serialize the quantization infos now that we
+    // If profiling, generate and serialize the profiling infos now that we
     // have run inference to gather the profile.
     if (profilingGraph()) {
-      loader.generateAndSerializeQuantizationInfos(bindings);
+      loader.generateAndSerializeProfilingInfos(bindings);
     }
   }
 

--- a/tools/loader/ModelTuner.cpp
+++ b/tools/loader/ModelTuner.cpp
@@ -271,8 +271,8 @@ int main(int argc, char **argv) {
 
     // Tune the quantization for this node.
     auto nodeName = pInfosTune[nodeQIdx].nodeOutputName_.data();
-    llvm::outs() << strFormat("[%d/%d] Tuning node value \"%s\"\n", nodeQIdx + 1,
-                              nodeQNum, nodeName);
+    llvm::outs() << strFormat("[%d/%d] Tuning node value \"%s\"\n",
+                              nodeQIdx + 1, nodeQNum, nodeName);
     accVal = tuneQuantizationForNode(pInfosTune, datasetTune, nodeQIdx, accVal);
 
     // Display estimated remaining time and stats.

--- a/tools/loader/ModelTuner.cpp
+++ b/tools/loader/ModelTuner.cpp
@@ -109,9 +109,9 @@ static std::pair<unsigned, float> getOutputClass(Tensor *T) {
   return std::make_pair(maxIdx, maxVal);
 }
 
-/// Function to quantize the model with the given quantization infos and
+/// Function to quantize the model with the given profiling infos and
 /// compute the accuracy on the given data set.
-float quantizeAndGetAccuracy(std::vector<NodeQuantizationInfo> &qInfos,
+float quantizeAndGetAccuracy(std::vector<NodeProfilingInfo> &pInfos,
                              LabeledDataSet &dataset) {
 
   // Initialize the loader object.
@@ -133,8 +133,8 @@ float quantizeAndGetAccuracy(std::vector<NodeQuantizationInfo> &qInfos,
       loader.getCompilationContext(QuantizationMode::Quantize);
   cctx.bindings = &bindings;
 
-  // Force the given quantization infos.
-  cctx.precisionConfig.quantConfig.infos = qInfos;
+  // Force the given profiling infos.
+  cctx.precisionConfig.quantConfig.infos = pInfos;
 
   // Compile the function.
   loader.compile(cctx);
@@ -163,7 +163,7 @@ float quantizeAndGetAccuracy(std::vector<NodeQuantizationInfo> &qInfos,
 }
 
 /// Function to tune a given node for the given function with the given dataset.
-float tuneQuantizationForNode(std::vector<NodeQuantizationInfo> &qInfos,
+float tuneQuantizationForNode(std::vector<NodeProfilingInfo> &pInfos,
                               LabeledDataSet &dataset, unsigned qIdx,
                               float bestAcc) {
 
@@ -171,8 +171,8 @@ float tuneQuantizationForNode(std::vector<NodeQuantizationInfo> &qInfos,
   unsigned maxIterPerNode = maxIterPerNodeOpt;
   float accDropSkip = accDropSkipOpt;
 
-  // Backup quantization parameters for this node.
-  auto bestTQP = qInfos[qIdx].tensorQuantizationParams_;
+  // Backup profiling parameters for this node.
+  auto bestTPP = pInfos[qIdx].tensorProfilingParams_;
 
   // Get quantization configuration.
   auto quantConfig = Loader::getQuantizationConfiguration();
@@ -180,35 +180,40 @@ float tuneQuantizationForNode(std::vector<NodeQuantizationInfo> &qInfos,
   // Run the tune iterations for this node.
   for (unsigned iterIdx = 0; iterIdx < maxIterPerNode; ++iterIdx) {
 
-    // Test the scale by repeatedly dividing by 2.
-    float testScale = qInfos[qIdx].tensorQuantizationParams_.scale / 2;
-    qInfos[qIdx].tensorQuantizationParams_.scale = testScale;
-    llvm::outs() << strFormat("  [%d/%d] Testing scale = %.5f\n", iterIdx + 1,
-                              maxIterPerNode, testScale);
+    // Only symmetrical schema are supported. For asymmetrical schema
+    // we need to shrink the range around the average.
+    CHECK(quantConfig.schema == quantization::Symmetric ||
+          quantConfig.schema == quantization::SymmetricWithPower2Scale)
+        << "Only Symmetric and SymmetricWithPower2Scale schema are supported!";
 
-    // Validate that for SymmetricWithPower2Scale schema the scale
-    // is a power of 2 after manipulation.
-    if (quantConfig.schema == quantization::SymmetricWithPower2Scale) {
-      assert(
-          quantization::isFloatPowerOf2(testScale) &&
-          "SymmetricWithPower2Scale quantization scale should be a power of 2");
-    }
+    // Get current range with symmetrization.
+    float rangeAbsMin = std::abs(pInfos[qIdx].tensorProfilingParams_.min);
+    float rangeAbsMax = std::abs(pInfos[qIdx].tensorProfilingParams_.max);
+    float rangeAbs = rangeAbsMax > rangeAbsMin ? rangeAbsMax : rangeAbsMin;
+
+    // Test the quantization range by repeatedly shrinking with a factor of 2.
+    float testMin = -rangeAbs / 2.0f;
+    float testMax = +rangeAbs / 2.0f;
+    pInfos[qIdx].tensorProfilingParams_.min = testMin;
+    pInfos[qIdx].tensorProfilingParams_.max = testMax;
+    llvm::outs() << strFormat("  [%d/%d] Testing range = [%.4f, %.4f]\n",
+                              iterIdx + 1, maxIterPerNode, testMin, testMax);
 
     // Quantize model and compute accuracy for current params.
-    float currAcc = quantizeAndGetAccuracy(qInfos, dataset);
+    float currAcc = quantizeAndGetAccuracy(pInfos, dataset);
     llvm::outs() << strFormat("  Accuracy = %.4f %%\n", currAcc * 100);
 
-    // If we obtain EXACTLY the same accuracy then the quantization parameters
+    // If we obtain EXACTLY the same accuracy then the profiling parameters
     // of this node have no side effects (most probably are not used).
     if (currAcc == bestAcc) {
-      llvm::outs() << "  Tunning stopped for this node (no effect)\n";
+      llvm::outs() << "  Tunning stopped for this node value (no effect)\n";
       break;
     }
 
-    // If current accuracy is better then save the quantization parameters.
+    // If current accuracy is better then save the profiling parameters.
     if (currAcc > bestAcc) {
       bestAcc = currAcc;
-      bestTQP = qInfos[qIdx].tensorQuantizationParams_;
+      bestTPP = pInfos[qIdx].tensorProfilingParams_;
     }
 
     // If the current accuracy drops below the best accuracy with a given delta
@@ -220,8 +225,8 @@ float tuneQuantizationForNode(std::vector<NodeQuantizationInfo> &qInfos,
     }
   }
 
-  // Save best quantization parameters for this node.
-  qInfos[qIdx].tensorQuantizationParams_ = bestTQP;
+  // Save best profiling parameters for this node.
+  pInfos[qIdx].tensorProfilingParams_ = bestTPP;
   llvm::outs() << strFormat("Best accuracy : %.4f %%\n", bestAcc * 100);
   return bestAcc;
 }
@@ -232,12 +237,12 @@ int main(int argc, char **argv) {
   // the loader object.
   parseCommandLine(argc, argv);
 
-  // Get the input quantization profile used for tuning.
+  // Get the input profile used for tuning.
   auto quantConfig = Loader::getQuantizationConfiguration();
   CHECK(quantConfig.infos.size())
       << "Input profile not found. Use the -load-profile option!";
-  auto qInfosTune = quantConfig.infos;
-  int nodeQNum = qInfosTune.size();
+  auto pInfosTune = quantConfig.infos;
+  int nodeQNum = pInfosTune.size();
 
   // Read tuning dataset.
   LabeledDataSet datasetTune =
@@ -248,7 +253,7 @@ int main(int argc, char **argv) {
 
   // Compute initial accuracy.
   llvm::outs() << strFormat("\nComputing initial accuracy ... \n");
-  float accVal = quantizeAndGetAccuracy(qInfosTune, datasetTune);
+  float accVal = quantizeAndGetAccuracy(pInfosTune, datasetTune);
   llvm::outs() << strFormat("Initial accuracy: %.4f %%\n", accVal * 100);
   llvm::outs() << strFormat("Number of nodes: %d\n", nodeQNum);
   llvm::outs() << strFormat("Target accuracy: %.4f %%\n\n",
@@ -265,10 +270,10 @@ int main(int argc, char **argv) {
     }
 
     // Tune the quantization for this node.
-    auto nodeName = qInfosTune[nodeQIdx].nodeOutputName_.data();
-    llvm::outs() << strFormat("[%d/%d] Tuning node \"%s\"\n", nodeQIdx + 1,
+    auto nodeName = pInfosTune[nodeQIdx].nodeOutputName_.data();
+    llvm::outs() << strFormat("[%d/%d] Tuning node value \"%s\"\n", nodeQIdx + 1,
                               nodeQNum, nodeName);
-    accVal = tuneQuantizationForNode(qInfosTune, datasetTune, nodeQIdx, accVal);
+    accVal = tuneQuantizationForNode(pInfosTune, datasetTune, nodeQIdx, accVal);
 
     // Display estimated remaining time and stats.
     unsigned iterSec = getDurationSec(startTime) / (nodeQIdx + 1);
@@ -290,7 +295,7 @@ int main(int argc, char **argv) {
                             totMin);
 
   // Serialize the tuned output profile.
-  serializeToYaml(dumpTunedProfileFileOpt, qInfosTune);
+  serializeProfilingInfosToYaml(dumpTunedProfileFileOpt, pInfosTune);
 
   return 0;
 }

--- a/tools/loader/TextTranslator.cpp
+++ b/tools/loader/TextTranslator.cpp
@@ -416,10 +416,10 @@ int main(int argc, char **argv) {
     }
   }
 
-  // If profiling, generate and serialize the quantization infos now that we
+  // If profiling, generate and serialize the profiling infos now that we
   // have run inference to gather the profile.
   if (profilingGraph()) {
-    loader.generateAndSerializeQuantizationInfos(bindings);
+    loader.generateAndSerializeProfilingInfos(bindings);
   }
 
   return incorrectTranslationCount;

--- a/tools/loader/XModelBuilder.cpp
+++ b/tools/loader/XModelBuilder.cpp
@@ -344,7 +344,7 @@ int main(int argc, char **argv) {
 
   // Are we profiling? If so, spit out the profile.
   if (profilingGraph()) {
-    loader.generateAndSerializeQuantizationInfos(ioBindings);
+    loader.generateAndSerializeProfilingInfos(ioBindings);
   }
 
   return 0;

--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -1494,7 +1494,8 @@ Error PyTorchModelLoader::loadQuantizedLinear(const torch::jit::Node *ptNode) {
   const auto biasMinMaxIdx = biasHandle.minMaxArg();
 
   const auto biasQParams = chooseQuantizationParams(
-      biasHandle.raw(biasMinMaxIdx.first), biasHandle.raw(biasMinMaxIdx.second),
+      {biasHandle.raw(biasMinMaxIdx.first),
+       biasHandle.raw(biasMinMaxIdx.second)},
       glow::quantization::Schema::Asymmetric, glow::ElemKind::Int32QTy);
 
   auto bias = biasConstant->getOutput();
@@ -1613,7 +1614,8 @@ Error PyTorchModelLoader::loadQuantizedLinearUnpacked(
   const auto biasMinMaxIdx = biasHandle.minMaxArg();
 
   const auto biasQParams = chooseQuantizationParams(
-      biasHandle.raw(biasMinMaxIdx.first), biasHandle.raw(biasMinMaxIdx.second),
+      {biasHandle.raw(biasMinMaxIdx.first),
+       biasHandle.raw(biasMinMaxIdx.second)},
       glow::quantization::Schema::Asymmetric, glow::ElemKind::Int32QTy);
 
   const auto biasType =


### PR DESCRIPTION
**Summary**

Until this point the profile generated after the profiling phase included the quantization parameters **scale** and **offset** which were computed for a given quantization configuration (schema, precision, precisionBias). This approach was extremely error prone (multiple times I had this problem) because in order for the flow to be consistent, same configuration had to be provided during the profiling (e.g. while using image-classifier or model-profiler) versus during the quantization (e.g. while using the model-compiler).

With this PR the profile includes only the profiling specific information (**min** and **max**) while the actual quantization parameters are computed during the quantization phase. This has the following benefits:
- the profiling phase becomes totally independent on the quantization configuration (schema, precision, precisionBias) thus making the usage of the front-end tools less error prone (for model-profiler or image-classifier no quantization parameters are required)
- the information in the **profile.yml** is much more readable in terms of the tensor dynamic range (which I think was the purpose of using the YAML format in the first place) because just having the **scale** and **offset** was not indicative on the tensor dynamic range because:
  - the information itself was not sufficient without the data precision (given offset & scale mean totally different things for int8 vs int32)
  - some information was lost because for (e.g.) Symmetric quantization schema the information about the original (min,max) pair was lost due to symmetrization
- the profiling information is closer to where the actual quantization is performed, allowing more elaborate and precise quantization schemes (joint operand quantization, etc)

The functionality of serializing the tensor quantization parameters (scale & offset) is still there and we might use it for debugging (although the scales and offset are readable in the dumped graph).

**Fixes**
#2600
#2599 (No longer required)

**Documentation**
Updated AOT.md.

**Test Plan**
The quantization unit tests are passing.
Added new unit test for the new **getNodeValueByName()** utility function.
I manually tested the LeNet MNIST model and verified the results of the quantized bundle are exactly the same (bit exact) before and after this change. This is possible because the serialization of the min/max preserves the floating-point bit-exactness (just as it did for the floating-point scale).

**Next**
We should also include in the profile the histogram (which is already computed) and use some smarter quantization (outlier removal, KL divergence minimization, etc).
