### PR TITLE
Fix some race conditions in glow tracing

### DIFF
--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -371,6 +371,11 @@ onnxStatus Graph::setIOAndRun(uint32_t inputsCount,
   if (ctx->getTraceContext()) {
     ctx->getTraceContext()->setThreadName("Caller");
   }
+
+  // End trace scope before calling into run. run() can trigger the completion
+  // callback which deallocates ctx and traceContext. So it will no longer be
+  // safe to access the trace context after calling into run().
+  TRACE_EVENT_SCOPE_END();
   auto ret = run(std::move(ctx), outputEvent, traceEvents);
   if (GlowSaveOnnxifiIO) {
     // We need to wait for the execution to finish in order to extract output

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -504,6 +504,7 @@ HostManager::runNetwork(llvm::StringRef networkName,
   // If we haven't reached maxActiveRequests kick off next request.
   size_t activeRequestCount = activeRequestCount_++;
   if (activeRequestCount < config_.maxActiveRequests) {
+    TRACE_EVENT_SCOPE_END();
     dispatchNextRun();
     return currentRun;
   }

--- a/lib/Runtime/Provisioner/Provisioner.cpp
+++ b/lib/Runtime/Provisioner/Provisioner.cpp
@@ -454,13 +454,15 @@ Error Provisioner::provision(DAGListTy &networks, Module &module,
   if (cctx.deferredWeightLoader) {
     LOG(INFO) << "Loading deferred weights";
 
+    auto startTime = std::chrono::steady_clock::now();
     auto loader = cctx.deferredWeightLoader;
     // Load the first weight.
     RETURN_IF_ERR(loader->loadNextWeight());
     std::string weightName = loader->getName();
     // Load weights while there are weights to be loaded.
     while (weightName != "") {
-      auto PH = module.getPlaceholderByName(weightName);
+      VLOG(1) << "Loading " << weightName;
+      const auto PH = module.getPlaceholderByName(weightName);
       if (!PH) {
         return MAKE_ERR(ErrorValue::ErrorCode::RUNTIME_ERROR,
                         llvm::formatv("Error loading deferred weight. Name: "
@@ -485,19 +487,17 @@ Error Provisioner::provision(DAGListTy &networks, Module &module,
           weight->convertToType(newK);
         }
       }
-
       // Transfer weight to all devices needed.
       for (const auto &device : placeholderToDeviceManager[PH]) {
-        std::promise<void> transferPromise;
-        Error transferError = Error::empty();
+        std::promise<Error> transferPromise;
         auto done = transferPromise.get_future();
         devices_[device]->transferStaticPlaceholderToDevice(
-            PH, weight, [&transferPromise, &transferError](Error err) {
-              transferError = std::move(err);
-              transferPromise.set_value();
+            PH, weight, [&transferPromise](Error err) {
+              transferPromise.set_value(std::move(err));
             });
-        RETURN_IF_ERR(transferError);
+        RETURN_IF_ERR(done.get());
       }
+
       RETURN_IF_ERR(loader->loadNextWeight());
       weightName = loader->getName();
       // Remove PH from map, this way we can know that we've added all static
@@ -508,6 +508,11 @@ Error Provisioner::provision(DAGListTy &networks, Module &module,
       return MAKE_ERR(ErrorValue::ErrorCode::RUNTIME_ERROR,
                       "Error not all static placeholders were initialized.");
     }
+
+    std::chrono::duration<double> duration =
+        std::chrono::steady_clock::now() - startTime;
+    LOG(INFO) << "Done loading deferred weights in " << duration.count()
+              << " seconds";
   }
 
   cleanupProvision(localActiveNames, {}, false);


### PR DESCRIPTION
Summary:
In glow, we have this pattern where we use TRACE_EVENT_SCOPE to clock the runtime of a function. This can be a problem when the code inside the scope can then pass the execution context to a different thread which can trigger the finish callback before the current thread finishes execution. So by the time we go out of the scope to add tracing information, the execution context and trace context are already gone. This really only happens under high load situation.

Fix this by finishing the scope before calling another function that can invoke the callback.

Also fix another instance where we can potentially access trace context under a race condition around determining if any node is inflight.

Differential Revision: D20566594

