### PR TITLE
Add support for importing LayerNorm

### DIFF
--- a/include/glow/Importer/Caffe2ModelLoader.h
+++ b/include/glow/Importer/Caffe2ModelLoader.h
@@ -74,6 +74,10 @@ class Caffe2ModelLoader
   Error loadConvQuantized(const caffe2::OperatorDef &op,
                           ArgumentDictionaryTy &dict);
 
+  /// Load LayerNorm Caffe2 operator \p op given \p dict.
+  Error loadLayerNorm(const caffe2::OperatorDef &op,
+                      ArgumentDictionaryTy &dict);
+
   /// Reads a network (weights or structure) from the serialized protocol
   /// buffer file.
   Expected<caffe2::NetDef> loadProtoFile(const std::string &filename);

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -536,6 +536,54 @@ Error Caffe2ModelLoader::loadConvQuantized(const caffe2::OperatorDef &op,
   return Error::success();
 }
 
+Error Caffe2ModelLoader::loadLayerNorm(const caffe2::OperatorDef &op,
+                                       ArgumentDictionaryTy &dict) {
+  const std::string &opName = loadOperatorName(op);
+
+  NodeValue in;
+  ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
+
+  unsigned_t axis = 1; // Caffe2 default.
+  if (dict.count("axis")) {
+    ASSIGN_VALUE_OR_RETURN_ERR(axis, loadInt(dict["axis"]));
+  }
+
+  RETURN_ERR_IF_NOT(axis < in.dims().size(), "axis must fit inside input dims");
+
+  // Feature shape is based on the input dims, from the axis to the end.
+  ShapeVector featDims;
+  for (dim_t i = axis, e = in.dims().size(); i < e; ++i) {
+    featDims.push_back(in.dims()[i]);
+  }
+  TypeRef featTy = mod_.uniqueTypeWithNewShape(in.getType(), featDims);
+
+  NodeValue weight, bias;
+  if (op.input_size() > 1) {
+    RETURN_ERR_IF_NOT(op.input_size() == 3, "Must have both weight and bias");
+
+    ASSIGN_VALUE_OR_RETURN_ERR(weight, getNodeValueByName(op.input(1)));
+    RETURN_ERR_IF_NOT(weight.getType() == featTy, "Invalid weight shape");
+
+    ASSIGN_VALUE_OR_RETURN_ERR(bias, getNodeValueByName(op.input(2)));
+    RETURN_ERR_IF_NOT(bias.getType() == featTy, "Invalid bias shape");
+  } else {
+    // Caffe2 default to use weight 1 and bias 0.
+    weight = G_->createSplat(opName + "_weight_ones", featTy, 1.0)->getResult();
+    bias = G_->createSplat(opName + "_bias_zeros", featTy, 0.0)->getResult();
+  }
+
+  float eps = 0.001; // Caffe2 default.
+  if (dict.count("epsilon")) {
+    ASSIGN_VALUE_OR_RETURN_ERR(eps, loadFloat(dict["epsilon"]));
+  }
+
+  LayerNormalizationNode *node =
+      G_->createLayerNormalization(opName, in, weight, bias, eps);
+
+  RETURN_IF_ERR(addNodeAsOutput(op, node));
+  return Error::success();
+}
+
 Expected<bool> Caffe2ModelLoader::foldOperator(const caffe2::OperatorDef &op) {
   const unsigned numInputs = op.input_size();
   const std::string &typeName = op.type();
@@ -671,6 +719,10 @@ Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
 
   if (typeName == "Int8Conv" || typeName == "Int8ConvRelu") {
     return loadConvQuantized(op, dict);
+  }
+
+  if (typeName == "LayerNorm") {
+    return loadLayerNorm(op, dict);
   }
 
   if (typeName == "Int8SumRelu") {

--- a/tests/models/caffe2Models/layernorm_pred_net.pbtxt
+++ b/tests/models/caffe2Models/layernorm_pred_net.pbtxt
@@ -1,0 +1,17 @@
+name: "layer_norm"
+op {
+  input: "input"
+  output: "result"
+  name: ""
+  type: "LayerNorm"
+  arg {
+    name: "axis"
+    i: 2
+  }
+  arg {
+    name: "epsilon"
+    f: 0.05
+  }
+}
+external_input: "input"
+external_output: "result"

--- a/tests/models/caffe2Models/layernorm_weight_bias_init_net.pbtxt
+++ b/tests/models/caffe2Models/layernorm_weight_bias_init_net.pbtxt
@@ -1,0 +1,49 @@
+name: "init"
+op {
+  output: "weight"
+  type: "GivenTensorFill"
+  arg {
+    name: "shape"
+    ints: 4
+    ints: 3
+  }
+  arg {
+    name: "values"
+    floats: 1.0
+    floats: 2.0
+    floats: 3.0
+    floats: 4.0
+    floats: 5.0
+    floats: 6.0
+    floats: 7.0
+    floats: 8.0
+    floats: 9.0
+    floats: 10.0
+    floats: 11.0
+    floats: 12.0
+  }
+}
+op {
+  output: "bias"
+  type: "GivenTensorFill"
+  arg {
+    name: "shape"
+    ints: 4
+    ints: 3
+  }
+  arg {
+    name: "values"
+    floats: -1.0
+    floats: -2.0
+    floats: -3.0
+    floats: -4.0
+    floats: -5.0
+    floats: -6.0
+    floats: -7.0
+    floats: -8.0
+    floats: -9.0
+    floats: -10.0
+    floats: -11.0
+    floats: -12.0
+  }
+}

--- a/tests/models/caffe2Models/layernorm_weight_bias_pred_net.pbtxt
+++ b/tests/models/caffe2Models/layernorm_weight_bias_pred_net.pbtxt
@@ -1,0 +1,11 @@
+name: "layer_norm"
+op {
+  input: "input"
+  input: "weight"
+  input: "bias"
+  output: "result"
+  name: ""
+  type: "LayerNorm"
+}
+external_input: "input"
+external_output: "result"

--- a/tests/unittests/Caffe2ImporterTest.cpp
+++ b/tests/unittests/Caffe2ImporterTest.cpp
@@ -3239,3 +3239,118 @@ TEST_F(Caffe2ImporterTest, PrePartitionedMultiOpTest) {
   EXPECT_TRUE(resultPartitionedT->isBitwiseEqual(*resultUnpartitonedT,
                                                  /* verbose */ true));
 }
+
+/// Test importing a Caffe2 LayerNorm without weights and bias provided but with
+/// epsilon or axis.
+TEST_F(Caffe2ImporterTest, importLayerNormNoWeightBias) {
+  ExecutionEngine EE{};
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+
+  std::string NetDescFilename(
+      GLOW_DATA_PATH "tests/models/caffe2Models/layernorm_pred_net.pbtxt");
+  std::string NetWeightFilename(
+      GLOW_DATA_PATH "tests/models/caffe2Models/empty_init_net.pbtxt");
+
+  Placeholder *output;
+  PlaceholderBindings bindings;
+
+  const ShapeVector inShape({4, 2, 5, 5});
+
+  // Destroy the loader after the graph is loaded since the following execution
+  // will not depend on anything from the loader.
+  {
+    Tensor data(ElemKind::FloatTy, inShape);
+    data.getHandle().randomize(-3.0, 3.0, mod.getPRNG());
+    Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"input"},
+                               {&data.getType()}, *F);
+    output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
+
+    bindings.allocate(mod.getPlaceholders());
+    updateInputPlaceholdersByName(bindings, &mod, {"input"}, {&data});
+  }
+
+  // High level check on the content of the graph. We should have
+  // {Placeholder, Splat, Splat} => LayerNorm => Save
+  EXPECT_EQ(F->getNodes().size(), 4);
+  SaveNode *save = getSaveNodeFromDest(output);
+
+  auto *LN = llvm::dyn_cast<LayerNormalizationNode>(save->getInput().getNode());
+  ASSERT_TRUE(LN);
+  EXPECT_EQ(LN->getEpsilon(), 0.05f);
+  EXPECT_TRUE(LN->getInput().dims().equals(inShape));
+  EXPECT_TRUE(LN->getResult().dims().equals(inShape));
+
+  auto *scale = llvm::dyn_cast<SplatNode>(LN->getScale().getNode());
+  ASSERT_TRUE(scale);
+  EXPECT_EQ(scale->getValue(), 1.0f);
+
+  auto *bias = llvm::dyn_cast<SplatNode>(LN->getBias().getNode());
+  ASSERT_TRUE(bias);
+  EXPECT_EQ(bias->getValue(), 0.0f);
+
+  // Axis is 2, so check shape with second and third dims of inShape.
+  EXPECT_TRUE(scale->getResult().dims().equals({inShape[2], inShape[3]}));
+  EXPECT_TRUE(bias->getResult().dims().equals({inShape[2], inShape[3]}));
+
+  EE.compile(CompilationMode::Infer);
+  EE.run(bindings);
+}
+
+/// Test importing a Caffe2 LayerNorm with weights and bias provided but no
+/// epsilon or axis.
+TEST_F(Caffe2ImporterTest, importLayerNormWithWeightBias) {
+  ExecutionEngine EE{};
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+
+  std::string NetDescFilename(
+      GLOW_DATA_PATH
+      "tests/models/caffe2Models/layernorm_weight_bias_pred_net.pbtxt");
+  std::string NetWeightFilename(
+      GLOW_DATA_PATH
+      "tests/models/caffe2Models/layernorm_weight_bias_init_net.pbtxt");
+
+  Placeholder *output;
+  PlaceholderBindings bindings;
+
+  const ShapeVector inShape({5, 4, 3});
+
+  // Destroy the loader after the graph is loaded since the following execution
+  // will not depend on anything from the loader.
+  {
+    Tensor data(ElemKind::FloatTy, inShape);
+    data.getHandle().randomize(-3.0, 3.0, mod.getPRNG());
+    Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"input"},
+                               {&data.getType()}, *F);
+    output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
+
+    bindings.allocate(mod.getPlaceholders());
+    updateInputPlaceholdersByName(bindings, &mod, {"input"}, {&data});
+  }
+
+  // High level check on the content of the graph. We should have
+  // {Placeholder, Constant, Constant} => LayerNorm => Save
+  EXPECT_EQ(F->getNodes().size(), 2);
+  SaveNode *save = getSaveNodeFromDest(output);
+
+  auto *LN = llvm::dyn_cast<LayerNormalizationNode>(save->getInput().getNode());
+  ASSERT_TRUE(LN);
+  EXPECT_EQ(LN->getEpsilon(), 0.001f); // Caffe2 default.
+  EXPECT_TRUE(LN->getInput().dims().equals(inShape));
+  EXPECT_TRUE(LN->getResult().dims().equals(inShape));
+
+  auto *scale = llvm::dyn_cast<Constant>(LN->getScale().getNode());
+  ASSERT_TRUE(scale);
+
+  auto *bias = llvm::dyn_cast<Constant>(LN->getBias().getNode());
+  ASSERT_TRUE(bias);
+
+  // Default axis is 1 and it was unspecified in the input proto, so check shape
+  // with first and second dims of inShape.
+  EXPECT_TRUE(scale->getOutput().dims().equals({inShape[1], inShape[2]}));
+  EXPECT_TRUE(bias->getOutput().dims().equals({inShape[1], inShape[2]}));
+
+  EE.compile(CompilationMode::Infer);
+  EE.run(bindings);
+}


### PR DESCRIPTION
Summary: Add support for loading LayerNorm from Caffe2. Supports with and without optional weights/bias/epsilon/axis.

Differential Revision: D20568265

