### PR TITLE
[TensorLayout] Add BatchedReduceAddNode to operator list which accept any layout

### DIFF
--- a/lib/Graph/TensorLayout.cpp
+++ b/lib/Graph/TensorLayout.cpp
@@ -654,6 +654,7 @@ static bool acceptsAnyInputLayout(const glow::Node *node) {
   case Kinded::Kind::ConcatNodeKind:
   case Kinded::Kind::BatchedReduceMeanNodeKind:
   case Kinded::Kind::BatchedAddNodeKind:
+  case Kinded::Kind::BatchedReduceAddNodeKind:
   case Kinded::Kind::BatchedReduceMinNodeKind:
   case Kinded::Kind::BatchNormalizationNodeKind:
   case Kinded::Kind::BatchNormalizationGradNodeKind:


### PR DESCRIPTION
Summary: When  BatchedReduceAdd Operator is followed by Transpose Operator (Tranpose ->  BatchedReduceAdd) and Transpose operator has layout change like NHWC2NCHW, then Tile Node tensor layout verification fails since it is not part of list of operators which can accept any layout.

In this commit we are adding BatchedReduceAdd Operator as a part of operator list which can accept any layout

Test Plan: Ninja Test is run
