### PR TITLE
Working around randomize function

### DIFF
--- a/tests/benchmark/SLSBench.cpp
+++ b/tests/benchmark/SLSBench.cpp
@@ -185,7 +185,7 @@ public:
       // Create and sort indices
       Tensor indicesReal(ElemKind::Int64ITy,
                          {param.numIndicesPerBatch * batchSize_});
-      indicesReal.getHandle<int64_t>().randomize(0, param.numTableEntries - 1,
+      indicesReal.getHandle<int64_t>().randomize(0, param.numTableEntries,
                                                  mod->getPRNG());
       // Sort each segment
       if (param.isSorted) {

--- a/tests/benchmark/SLSBench.cpp
+++ b/tests/benchmark/SLSBench.cpp
@@ -423,6 +423,7 @@ SLSParam parseArgs(int argc, char *argv[]) {
     } else if (std::string(argv[ACCUM_TYPE]) == "False") {
       param.useFP16Accumulation = false;
     } else {
+      printf("Debug - Invalid useFP16Accumulation %s %d", argv[ACCUM_TYPE], std::string(argv[ACCUM_TYPE]) == "True");
       llvm_unreachable("Invalid useFP16Accumulation");
     }
   } else {


### PR DESCRIPTION
Summary: In SLSbench.cpp, in line 188, randomize function wants the min to be strictly less than the max. We randomize from 0 to num indices-1, but in this case num indices is 1. So we're randomizing from 0 to 0. To get around this we are creating a special case in SLSBench to get around this. Randomize does [low, high) so we just remove the -1 from line 188 in SLSBench.cpp.

Differential Revision: D20522493

