### PR TITLE
Fix build error with DGLOW_WITH_BUNDLES=ON flag (#4333)

### DIFF
--- a/examples/bundles/lenet_mnist/main.cpp
+++ b/examples/bundles/lenet_mnist/main.cpp
@@ -19,6 +19,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <cstring>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Summary:
  The build with the bundles flag on had been failing on fresh Ubuntu 18.04 docker install. The fix was to include `<cstring>`. The details on the error and set up are in #4333.

Issues:
  * Fixes #4333

Test Plan:

```
ninja test

100% tests passed, 0 tests failed out of 55

Label Time Summary:
EXPENSIVE    =  55.89 sec*proc (2 tests)
STRESS       = 864.19 sec*proc (1 test)

Total Test time (real) = 1050.63 sec

```
