### PR TITLE
[TensorLayout] Add InsertTensorNode to operator list which accept any layout

### DIFF
--- a/lib/Graph/TensorLayout.cpp
+++ b/lib/Graph/TensorLayout.cpp
@@ -665,6 +665,7 @@ static bool acceptsAnyInputLayout(const glow::Node *node) {
   case Kinded::Kind::FlipNodeKind:
   case Kinded::Kind::SliceNodeKind:
   case Kinded::Kind::TileNodeKind:
+  case Kinded::Kind::InsertTensorNodeKind:
   case Kinded::Kind::SGDNodeKind: {
     return true;
   }


### PR DESCRIPTION
Summary: When InsertTensorNode Operator is followed by Transpose Operator (Tranpose ->  InsertTensor) and Transpose operator has layout change like NHWC2NCHW, then InsertTensor Node tensor layout verification fails since it is not part of list of operators which can accept any layout.

Test Plan: Ninja Test is run