### PR TITLE
Ignore rest of outputs of LayerNorm when lowering to Glow

### DIFF
--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -511,6 +511,26 @@ protected:
 
     bool broadcast;
     ASSIGN_VALUE_OR_RETURN_ERR(broadcast, getBroadcast(dict));
+    // Check implicit broadcast
+    if (!broadcast && in0.dims().size() != in1.dims().size()) {
+      bool validBroadcast = true;
+      auto dimsA = in0.dims();
+      auto dimsB = in1.dims();
+      for (int i = dimsA.size() - 1, j = dimsB.size() - 1; i >= 0 && j >= 0;) {
+        auto a = dimsA[i];
+        auto b = dimsB[j];
+        if (!(a == b || a == 1 || b == 1)) {
+          validBroadcast = false;
+          break;
+        }
+        --i;
+        --j;
+      }
+      if (!validBroadcast) {
+        LOG(WARNING) << "Invalid broadcast rule for inputs of " << opName;
+      }
+      broadcast = validBroadcast;
+    }
 
     int axis = -1;
 

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -580,10 +580,10 @@ Error Caffe2ModelLoader::loadLayerNorm(const caffe2::OperatorDef &op,
   LayerNormalizationNode *node =
       G_->createLayerNormalization(opName, in, weight, bias, eps);
 
-  RETURN_ERR_IF_NOT(op.output_size() == 1,
-                    "Supporting only one output from LayerNorm");
+  // We only support one output for LayoutNorm. Ignoring the
+  // rest of the outputs.
+  RETURN_IF_ERR(addNodeAsOutput(op, node, /* numOutputs */ 1));
 
-  RETURN_IF_ERR(addNodeAsOutput(op, node));
   return Error::success();
 }
 

--- a/tests/models/caffe2Models/elementwise_linear_broadcast_net.pbtxt
+++ b/tests/models/caffe2Models/elementwise_linear_broadcast_net.pbtxt
@@ -1,0 +1,35 @@
+name: "elementwise_linear"
+op {
+  input: "X"
+  input: "w"
+  output: "i0"
+  name: ""
+  type: "Mul"
+  arg {
+    name: "axis"
+    i: 1
+  }
+  arg {
+    name: "broadcast"
+    i: 0
+  }
+}
+op {
+  input: "i0"
+  input: "b"
+  output: "el_result"
+  name: ""
+  type: "Add"
+  arg {
+    name: "axis"
+    i: 1
+  }
+  arg {
+    name: "broadcast"
+    i: 0
+  }
+}
+external_input: "X"
+external_input: "w"
+external_input: "b"
+external_output: "el_result"


### PR DESCRIPTION
Summary:
- Ignore rest of outputs of layoutNorm
- Support implicit broadcast when loading basic binary ops from Glow.

Differential Revision: D20627768

