### PR TITLE
Refactor parallelization to come from NodeOpts spec

### DIFF
--- a/include/glow/Backends/BackendOptions.h
+++ b/include/glow/Backends/BackendOptions.h
@@ -17,11 +17,16 @@
 #define GLOW_BACKENDS_BACKENDOPTIONS_H
 
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringMap.h"
+
 #include <map>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace glow {
+class Function;
+class Node;
 class Storage;
 
 /// Hints provided to the Backend, the backend is not required to honor them.
@@ -34,7 +39,19 @@ struct BackendHints {
   std::vector<std::string> SRAMPrioritization;
 };
 
+/// A flexible map used for storing options for a backend. Keys are usually
+/// prefixed with a Backend's name, e.g. "Interpreter_OptionA".
 using BackendSpecificOptions = std::map<std::string, std::string>;
+
+/// A structure used for storing backend-specific information for Nodes in a
+/// Function. The outer map with Functions as a key map to another map with
+/// Nodes as a key, where all Nodes in that map are children of the original
+/// Function. The StringMap for each Node maps from an option name to a vector
+/// of values for that option.
+using BackendSpecificNodeInfo = std::unordered_map<
+    const Function *,
+    std::unordered_map<const Node *,
+                       llvm::StringMap<std::vector<std::string>>>>;
 
 /// Options relevant to Backends during compilation.
 struct BackendOptions {
@@ -50,6 +67,12 @@ struct BackendOptions {
   /// Options that are specific to a backend. Backend is responsible for
   /// parsing.
   BackendSpecificOptions backendSpecificOpts;
+
+  /// Options that are specified per-Node. Note that this structure is keyed off
+  /// of Functions and then Nodes. The Node keys for this structure are Node
+  /// pointers, so any changes of Nodes should be tracked and propagated into
+  /// new Nodes once this is set.
+  BackendSpecificNodeInfo backendSpecificNodeInfo;
 };
 
 }; // namespace glow

--- a/include/glow/Importer/ONNXModelLoader.h
+++ b/include/glow/Importer/ONNXModelLoader.h
@@ -102,10 +102,11 @@ class ONNXModelLoader
   /// If this is a custom Glow op that was exported via NodeGen automatic export
   /// logic, try to load the op. \returns Expected<true> if the op is
   /// successfully loaded. \returns Expected<false> if op type is not supported.
-  /// \returns an Error if an error occurred while trying to load.
-  Expected<bool> tryLoadGlowCustomOp(llvm::StringRef typeName,
-                                     const ONNX_NAMESPACE::NodeProto &op,
-                                     ArgumentDictionaryTy &dict);
+  /// \returns an Error if an error occurred while trying to load, or otherwise
+  /// the single Node that was created.
+  Expected<Node *> tryLoadGlowCustomOp(llvm::StringRef typeName,
+                                       const ONNX_NAMESPACE::NodeProto &op,
+                                       ArgumentDictionaryTy &dict);
 
   /// \returns True if the operator\ op is successfully folded.
   Expected<bool> foldOperator(const ONNX_NAMESPACE::NodeProto &op);
@@ -469,8 +470,13 @@ public:
                   llvm::ArrayRef<const char *> tensorNames,
                   llvm::ArrayRef<TypeRef> types, Function &F,
                   Error *errPtr = nullptr, bool zipMode = false,
+                  BackendSpecificNodeInfo *perNodeOpts = nullptr,
                   bool disableConstFoldInLoader = false,
                   const Backend *B = nullptr);
+
+private:
+  /// Per-node options that may be specified in a proto.
+  BackendSpecificNodeInfo *perNodeOpts_{nullptr};
 };
 
 } // namespace glow

--- a/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
+++ b/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
@@ -49,6 +49,8 @@ FUN_PASS(FoldTileAddIntoBatchedAdd)
 FUN_PASS(FoldElemKindConversionIntoOutputs)
 FUN_PASS(FoldElemKindConversionIntoInputs)
 FUN_PASS(FoldMatMulAddIntoFullyConnected)
+FUN_PASS(FoldSlicesIntoConstants)
+FUN_PASS(EliminateConcatSlice)
 
 // NOTE: This pass must be last; it's used to count the total number of passes.
 FUN_PASS(EmptyPass)

--- a/include/glow/Optimizer/GraphOptimizer/GraphOptimizer.h
+++ b/include/glow/Optimizer/GraphOptimizer/GraphOptimizer.h
@@ -116,11 +116,13 @@ enum class ParallelTransformKind { None, Data, Model };
 /// Perform data or model parallel transformation of supported Nodes in \p F.
 /// \p numOfChunksMap maps Nodes to how many chunks they should be split into;
 /// if not listed this falls back to \p numOfChunks. \p parOpts represents what
-/// kind of parallelism to use.
-bool parallelizeOps(
-    Function *F, const llvm::DenseMap<Node *, size_t> &numOfChunksMap,
-    const llvm::DenseMap<Node *, ParallelTransformKind> &parOpts,
-    size_t numOfChunks);
+/// kind of parallelism to use. \returns an expected map from Nodes from \p F to
+/// the ConcatNode that they were replaced with.
+Expected<std::unordered_map<Node *, ConcatNode *>>
+parallelizeOps(Function *F,
+               const llvm::DenseMap<Node *, size_t> &numOfChunksMap,
+               const llvm::DenseMap<Node *, ParallelTransformKind> &parOpts,
+               size_t numOfChunks = 1);
 
 } // namespace glow
 

--- a/include/glow/Partitioner/PartitionerBase.h
+++ b/include/glow/Partitioner/PartitionerBase.h
@@ -45,9 +45,12 @@ protected:
   /// Functions representing each partition. However if \p skipCloning we skip
   /// this cloning, as it is assumed that the Functions are already partitioned
   /// correctly and so we do not need to clone their Nodes into new Functions.
+  /// \p nodeInfo represents any info mapped to Nodes, so when cloning Nodes we
+  /// need to update this map.
   DAGListTy doPartitioning(llvm::StringRef funcName,
                            std::vector<Function *> funcs, Module *module,
                            NodeToFunctionMap &mapping, bool saveDAG,
+                           BackendSpecificNodeInfo &nodeInfo,
                            bool skipCloning = false);
 };
 } // namespace glow

--- a/include/glow/Support/Support.h
+++ b/include/glow/Support/Support.h
@@ -16,6 +16,8 @@
 #ifndef GLOW_SUPPORT_SUPPORT_H
 #define GLOW_SUPPORT_SUPPORT_H
 
+#include "glow/Support/Error.h"
+
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -199,6 +201,9 @@ template <class T> inline constexpr unsigned convertEnumToUnsigned(T e) {
 constexpr char startChar = '$';
 /// Char used for separating attribute name from attribute value.
 constexpr char sepChar = ':';
+
+/// Convert a string to int. \returns the int or Error if problem parsing.
+Expected<int> getIntFromStr(llvm::StringRef input);
 
 } // namespace glow
 

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -142,16 +142,6 @@ Error onnxTensorDataTypeToElemKind(int32_t onnxType, ElemKind *elemTy) {
   }
 }
 
-/// Convert a string to int. \returns the int or Error if problem parsing.
-Expected<int> getIntFromStr(llvm::StringRef input) {
-  const char *start = input.data();
-  char *end;
-  int val = std::strtol(start, &end, 10);
-  RETURN_ERR_IF_NOT(!(end == start || *end != '\0'),
-                    "Integer was not properly specified.");
-  return val;
-}
-
 /// Finds an attribute from the doc_string and \returns it. If it does not exist
 /// then \returns Error. The expected structure here is that each attribute
 /// starts with startChar and is separated from its value by a sepChar.

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -4194,17 +4194,23 @@ bool glow::executeVerticalFCWeightsSplit(Function *F, unsigned numOfChunks,
 /// \p splitDim represents what dimension to split for each of the inputs to
 /// \p curNode. \p resultDim is the dimension on which we are splitting and then
 /// concatenating the results. \p resultIdx represents the result index from
-/// \p curNode that is being split and later concatenated.
-static void parallelizeAndReplaceNode(Function *F, Node *curNode,
-                                      dim_t numOfChunksNode,
-                                      dim_t inputBatchIdx, dim_t resultIdx,
-                                      llvm::ArrayRef<int> splitDims,
-                                      size_t resultDim) {
+/// \p curNode that is being split and later concatenated. \returns an Expected
+/// of the ConcatNode that is created and replaces \p curNode, or otherwise an
+/// Error if parallelization had some issue.
+static Expected<ConcatNode *>
+parallelizeAndReplaceNode(Function *F, Node *curNode, dim_t numOfChunksNode,
+                          dim_t inputBatchIdx, dim_t resultIdx,
+                          llvm::ArrayRef<int> splitDims, size_t resultDim) {
   const int inputIdx = splitDims[inputBatchIdx];
   CHECK_GE(inputIdx, 0) << "Input batch idx must be split";
   const dim_t batchSize = curNode->getNthInput(inputBatchIdx).dims()[inputIdx];
   const dim_t elemPerChunk = batchSize / numOfChunksNode;
   const dim_t remain = batchSize % numOfChunksNode;
+
+  RETURN_ERR_IF_NOT(
+      batchSize >= numOfChunksNode,
+      "Invalid parallelization; batchSize " + std::to_string(batchSize) +
+          "must be >= numOfChunksNode " + std::to_string(numOfChunksNode));
 
   std::vector<NodeValue> newNodes(numOfChunksNode);
   for (dim_t i = 0; i < numOfChunksNode; ++i) {
@@ -4267,20 +4273,23 @@ static void parallelizeAndReplaceNode(Function *F, Node *curNode,
   auto *concat = F->createConcat("concat." + curNode->getName().str(), newNodes,
                                  resultDim);
   curNode->getNthResult(resultIdx).replaceAllUsesOfWith(concat);
+  return concat;
 }
 
-bool glow::parallelizeOps(
+Expected<std::unordered_map<Node *, ConcatNode *>> glow::parallelizeOps(
     Function *F, const llvm::DenseMap<Node *, size_t> &numOfChunksMap,
     const llvm::DenseMap<Node *, ParallelTransformKind> &parOpts,
     size_t numOfChunks) {
   // Since we will be transforming the original list of nodes, reverse iterate.
   auto &nodes = F->getNodes();
   size_t numProcessedNodes = 0;
+  std::unordered_map<Node *, ConcatNode *> replacedMap;
   for (auto it = nodes.rbegin(), e = nodes.rend(); it != e; it++) {
     Node *curNode = &*it;
+    size_t curNumOfChunks = numOfChunks;
     auto numOfChunksIt = numOfChunksMap.find(curNode);
     if (numOfChunksIt != numOfChunksMap.end()) {
-      numOfChunks = numOfChunksIt->second;
+      curNumOfChunks = numOfChunksIt->second;
     }
 
     ParallelTransformKind parTransformMode = ParallelTransformKind::None;
@@ -4293,6 +4302,8 @@ bool glow::parallelizeOps(
     VLOG(1) << "Attempting to Parallelizing Node: " << curNode->getName().str()
             << "\n";
 
+    ConcatNode *CN = nullptr;
+
     // Use this vector to communicate what dims to split to
     // parallelizeAndReplaceNode(). -1 represents not splitting at all.
     llvm::SmallVector<int, 3> splitDims(curNode->getNumInputs(), -1);
@@ -4301,85 +4312,102 @@ bool glow::parallelizeOps(
       switch (curNode->getKind()) {
       case Kinded::Kind::FullyConnectedNodeKind: {
         splitDims[FullyConnectedNode::InputIdx] = 0;
-        parallelizeAndReplaceNode(F, curNode, numOfChunks,
-                                  FullyConnectedNode::InputIdx,
-                                  FullyConnectedNode::ResultIdx, splitDims, 0);
+        ASSIGN_VALUE_OR_RETURN_ERR(
+            CN, parallelizeAndReplaceNode(
+                    F, curNode, curNumOfChunks, FullyConnectedNode::InputIdx,
+                    FullyConnectedNode::ResultIdx, splitDims, 0));
         break;
       }
       case Kinded::Kind::AddNodeKind: {
         splitDims[AddNode::LHSIdx] = 0;
         splitDims[AddNode::RHSIdx] = 0;
-        parallelizeAndReplaceNode(F, curNode, numOfChunks, AddNode::LHSIdx,
-                                  AddNode::ResultIdx, splitDims, 0);
+        ASSIGN_VALUE_OR_RETURN_ERR(
+            CN, parallelizeAndReplaceNode(F, curNode, curNumOfChunks,
+                                          AddNode::LHSIdx, AddNode::ResultIdx,
+                                          splitDims, 0));
         break;
       }
       case Kinded::Kind::BatchMatMulNodeKind: {
         splitDims[BatchMatMulNode::LHSIdx] = 0;
         splitDims[BatchMatMulNode::RHSIdx] = 0;
-        parallelizeAndReplaceNode(F, curNode, numOfChunks,
-                                  BatchMatMulNode::LHSIdx,
-                                  BatchMatMulNode::ResultIdx, splitDims, 0);
+        ASSIGN_VALUE_OR_RETURN_ERR(
+            CN, parallelizeAndReplaceNode(
+                    F, curNode, curNumOfChunks, BatchMatMulNode::LHSIdx,
+                    BatchMatMulNode::ResultIdx, splitDims, 0));
         break;
       }
       case Kinded::Kind::MulNodeKind: {
         splitDims[AddNode::LHSIdx] = 0;
         splitDims[AddNode::RHSIdx] = 0;
-        parallelizeAndReplaceNode(F, curNode, numOfChunks, MulNode::LHSIdx,
-                                  MulNode::ResultIdx, splitDims, 0);
+        ASSIGN_VALUE_OR_RETURN_ERR(
+            CN, parallelizeAndReplaceNode(F, curNode, curNumOfChunks,
+                                          MulNode::LHSIdx, MulNode::ResultIdx,
+                                          splitDims, 0));
         break;
       }
       case Kinded::Kind::SigmoidNodeKind: {
         splitDims[SigmoidNode::InputIdx] = 0;
-        parallelizeAndReplaceNode(F, curNode, numOfChunks,
-                                  SigmoidNode::InputIdx, SigmoidNode::ResultIdx,
-                                  splitDims, 0);
+        ASSIGN_VALUE_OR_RETURN_ERR(
+            CN, parallelizeAndReplaceNode(
+                    F, curNode, curNumOfChunks, SigmoidNode::InputIdx,
+                    SigmoidNode::ResultIdx, splitDims, 0));
         break;
       }
       case Kinded::Kind::TanhNodeKind: {
         splitDims[TanhNode::InputIdx] = 0;
-        parallelizeAndReplaceNode(F, curNode, numOfChunks, TanhNode::InputIdx,
-                                  TanhNode::ResultIdx, splitDims, 0);
+        ASSIGN_VALUE_OR_RETURN_ERR(
+            CN, parallelizeAndReplaceNode(F, curNode, curNumOfChunks,
+                                          TanhNode::InputIdx,
+                                          TanhNode::ResultIdx, splitDims, 0));
         break;
       }
       case Kinded::Kind::TransposeNodeKind: {
         splitDims[TransposeNode::InputIdx] = 0;
         unsigned_t resultDim = cast<TransposeNode>(curNode)->getShuffle()[0];
-        parallelizeAndReplaceNode(
-            F, curNode, numOfChunks, TransposeNode::InputIdx,
-            TransposeNode::ResultIdx, splitDims, resultDim);
+        ASSIGN_VALUE_OR_RETURN_ERR(
+            CN, parallelizeAndReplaceNode(
+                    F, curNode, curNumOfChunks, TransposeNode::InputIdx,
+                    TransposeNode::ResultIdx, splitDims, resultDim));
         break;
       }
       case Kinded::Kind::ReluNodeKind: {
         splitDims[ReluNode::InputIdx] = 0;
-        parallelizeAndReplaceNode(F, curNode, numOfChunks, ReluNode::InputIdx,
-                                  ReluNode::ResultIdx, splitDims, 0);
+        ASSIGN_VALUE_OR_RETURN_ERR(
+            CN, parallelizeAndReplaceNode(F, curNode, curNumOfChunks,
+                                          ReluNode::InputIdx,
+                                          ReluNode::ResultIdx, splitDims, 0));
         break;
       }
       case Kinded::Kind::ClipNodeKind: {
         splitDims[ClipNode::InputIdx] = 0;
-        parallelizeAndReplaceNode(F, curNode, numOfChunks, ClipNode::InputIdx,
-                                  ClipNode::ResultIdx, splitDims, 0);
+        ASSIGN_VALUE_OR_RETURN_ERR(
+            CN, parallelizeAndReplaceNode(F, curNode, curNumOfChunks,
+                                          ClipNode::InputIdx,
+                                          ClipNode::ResultIdx, splitDims, 0));
         break;
       }
       case Kinded::Kind::QuantizeNodeKind: {
         splitDims[QuantizeNode::InputIdx] = 0;
-        parallelizeAndReplaceNode(F, curNode, numOfChunks,
-                                  QuantizeNode::InputIdx,
-                                  QuantizeNode::ResultIdx, splitDims, 0);
+        ASSIGN_VALUE_OR_RETURN_ERR(
+            CN, parallelizeAndReplaceNode(
+                    F, curNode, curNumOfChunks, QuantizeNode::InputIdx,
+                    QuantizeNode::ResultIdx, splitDims, 0));
         break;
       }
       case Kinded::Kind::DequantizeNodeKind: {
         splitDims[DequantizeNode::InputIdx] = 0;
-        parallelizeAndReplaceNode(F, curNode, numOfChunks,
-                                  DequantizeNode::InputIdx,
-                                  DequantizeNode::ResultIdx, splitDims, 0);
+        ASSIGN_VALUE_OR_RETURN_ERR(
+            CN, parallelizeAndReplaceNode(
+                    F, curNode, curNumOfChunks, DequantizeNode::InputIdx,
+                    DequantizeNode::ResultIdx, splitDims, 0));
         break;
       }
       case Kinded::Kind::ConvertToNodeKind: {
         splitDims[ConvertToNode::InputIdx] = 0;
-        parallelizeAndReplaceNode(F, curNode, numOfChunks,
-                                  ConvertToNode::InputIdx,
-                                  ConvertToNode::ResultIdx, splitDims, 0);
+        ASSIGN_VALUE_OR_RETURN_ERR(
+            CN, parallelizeAndReplaceNode(
+                    F, curNode, curNumOfChunks, ConvertToNode::InputIdx,
+                    ConvertToNode::ResultIdx, splitDims, 0));
         break;
       }
       default:
@@ -4396,9 +4424,10 @@ bool glow::parallelizeOps(
       case Kinded::Kind::FullyConnectedNodeKind: {
         splitDims[FullyConnectedNode::WeightsIdx] = 1;
         splitDims[FullyConnectedNode::BiasIdx] = 0;
-        parallelizeAndReplaceNode(F, curNode, numOfChunks,
-                                  FullyConnectedNode::WeightsIdx,
-                                  FullyConnectedNode::ResultIdx, splitDims, 1);
+        ASSIGN_VALUE_OR_RETURN_ERR(
+            CN, parallelizeAndReplaceNode(
+                    F, curNode, curNumOfChunks, FullyConnectedNode::WeightsIdx,
+                    FullyConnectedNode::ResultIdx, splitDims, 1));
         break;
       }
       case Kinded::Kind::ReluNodeKind: {
@@ -4406,8 +4435,10 @@ bool glow::parallelizeOps(
           break;
         }
         splitDims[ReluNode::InputIdx] = 1;
-        parallelizeAndReplaceNode(F, curNode, numOfChunks, ReluNode::InputIdx,
-                                  ReluNode::ResultIdx, splitDims, 1);
+        ASSIGN_VALUE_OR_RETURN_ERR(
+            CN, parallelizeAndReplaceNode(F, curNode, curNumOfChunks,
+                                          ReluNode::InputIdx,
+                                          ReluNode::ResultIdx, splitDims, 1));
         break;
       }
       case Kinded::Kind::ClipNodeKind: {
@@ -4415,8 +4446,10 @@ bool glow::parallelizeOps(
           break;
         }
         splitDims[ClipNode::InputIdx] = 1;
-        parallelizeAndReplaceNode(F, curNode, numOfChunks, ClipNode::InputIdx,
-                                  ClipNode::ResultIdx, splitDims, 1);
+        ASSIGN_VALUE_OR_RETURN_ERR(
+            CN, parallelizeAndReplaceNode(F, curNode, curNumOfChunks,
+                                          ClipNode::InputIdx,
+                                          ClipNode::ResultIdx, splitDims, 1));
         break;
       }
       default:
@@ -4431,15 +4464,18 @@ bool glow::parallelizeOps(
     case ParallelTransformKind::None:
       break;
     }
+
+    if (CN) {
+      replacedMap[curNode] = CN;
+    }
   }
 
   // Because we transformed Node types unsafely, make sure all types of the
   // Function still are valid.
-  bool ret = F->verify();
-  DCHECK(ret) << "Verification issue post parallelization";
+  RETURN_ERR_IF_NOT(F->verify(), "Verification issue post parallelization");
 
-  const bool allProcessed = numProcessedNodes == parOpts.size();
-  DCHECK(allProcessed) << "Not all Nodes specified in parOpts were processed.";
+  RETURN_ERR_IF_NOT(numProcessedNodes == parOpts.size(),
+                    "Not all Nodes specified in parOpts were processed.");
 
-  return ret && allProcessed;
+  return replacedMap;
 }

--- a/lib/Optimizer/GraphOptimizerPipeline/Pipeline.cpp
+++ b/lib/Optimizer/GraphOptimizerPipeline/Pipeline.cpp
@@ -76,6 +76,9 @@ FunctionPassPipeline glow::createDefaultGraphOptimizationPassPipeline() {
       // Optimize Concat nodes.
       {FunctionPassID::OptimizeConcatNodes},
 
+      // Eliminate Concat-Slice patterns which are unnecessary.
+      {FunctionPassID::EliminateConcatSlice},
+
       // Optimize arithmetic nodes based on algebraic identities.
       {FunctionPassID::OptimizeArithmeticNodes},
 

--- a/lib/Runtime/Provisioner/Provisioner.cpp
+++ b/lib/Runtime/Provisioner/Provisioner.cpp
@@ -355,6 +355,9 @@ Error Provisioner::provision(DAGListTy &networks, Module &module,
                               deviceBackendName);
         }
 
+        auto compiledOrErr =
+            backends_[deviceBackendName]->compile(function, options);
+
         if (cctx.dumpFinalGraph) {
           auto fname =
               strFormat("final_graph_%s_%s.dot", deviceBackendName.c_str(),
@@ -362,9 +365,6 @@ Error Provisioner::provision(DAGListTy &networks, Module &module,
           LOG(INFO) << "Dumping final graph to " << fname;
           function->dumpDAG(fname);
         }
-
-        auto compiledOrErr =
-            backends_[deviceBackendName]->compile(function, options);
 
         if (GlowDumpCompilationLog) {
           llvm::SmallString<64> path;

--- a/lib/Support/Support.cpp
+++ b/lib/Support/Support.cpp
@@ -191,4 +191,13 @@ deserializeStrStrMapFromYaml(llvm::StringRef fileName) {
   return deserializeFromYaml<std::map<std::string, std::string>>(fileName);
 }
 
+Expected<int> getIntFromStr(llvm::StringRef input) {
+  const char *start = input.data();
+  char *end;
+  int val = std::strtol(start, &end, 10);
+  RETURN_ERR_IF_NOT(!(end == start || *end != '\0'),
+                    "Integer was not properly specified.");
+  return val;
+}
+
 } // namespace glow

--- a/tests/models/onnxModels/glow_custom_op_node_opts.onnxtxt
+++ b/tests/models/onnxModels/glow_custom_op_node_opts.onnxtxt
@@ -1,0 +1,122 @@
+ir_version: 7
+producer_name: "GlowONNXModelWriter"
+graph {
+  node {
+    input: "lhs"
+    input: "rhs"
+    output: "MM"
+    name: "MM"
+    op_type: "Glow_MatMul"
+    attribute {
+      name: "i0_elemKind"
+      s: "float"
+      type: STRING
+    }
+    attribute {
+      name: "i0_shape"
+      ints: 3
+      ints: 2
+      type: INTS
+    }
+    attribute {
+      name: "i1_elemKind"
+      s: "float"
+      type: STRING
+    }
+    attribute {
+      name: "i1_shape"
+      ints: 2
+      ints: 1
+      type: INTS
+    }
+    attribute {
+      name: "o0_elemKind"
+      s: "float"
+      type: STRING
+    }
+    attribute {
+      name: "o0_shape"
+      ints: 3
+      ints: 1
+      type: INTS
+    }
+    attribute {
+      name: "NodeOpt_BackendA_Option1"
+      strings: "1"
+      strings: "2"
+      type: STRINGS
+    }
+    attribute {
+      name: "NodeOpt_BackendA_Option2"
+      strings: "3"
+      type: STRINGS
+    }
+    attribute {
+      name: "NodeOpt_BackendB_Option3"
+      strings: "4"
+      strings: "5"
+      type: STRINGS
+    }
+  }
+  node {
+    input: "MM"
+    output: "save"
+    name: "save_save"
+    op_type: "Identity"
+  }
+  name: "glow"
+  input {
+    name: "lhs"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+    doc_string: "$offline:0$trainable:0$layout:*$elemKind:float"
+  }
+  input {
+    name: "rhs"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+    doc_string: "$offline:0$trainable:0$layout:*$elemKind:float"
+  }
+  output {
+    name: "save"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+    doc_string: "$offline:0$trainable:0$layout:*$elemKind:float$saveName:save_save"
+  }
+}
+opset_import {
+  version: 9
+}

--- a/tests/unittests/GraphOptzTest.cpp
+++ b/tests/unittests/GraphOptzTest.cpp
@@ -3848,7 +3848,10 @@ TEST_F(GraphOptz, ParallelizeGraph_FC_ModelParallel) {
   parOpts[relu1] = ParallelTransformKind::Model;
   parOpts[fc2] = ParallelTransformKind::Model;
   parOpts[relu2] = ParallelTransformKind::Model;
-  EXPECT_TRUE(::glow::parallelizeOps(F_, numChunks, parOpts, 12));
+  std::unordered_map<Node *, ConcatNode *> replacedMap;
+  ASSIGN_VALUE_OR_FAIL_TEST(replacedMap,
+                            ::glow::parallelizeOps(F_, numChunks, parOpts));
+  EXPECT_EQ(replacedMap.size(), parOpts.size());
 
   runDCEPass(F_, cctx_);
 
@@ -3884,8 +3887,11 @@ TEST_F(GraphOptz, ParallelizeGraph_Add) {
   llvm::DenseMap<Node *, ParallelTransformKind> parOpts;
   parOpts[add1] = ParallelTransformKind::Data;
 
-  EXPECT_TRUE(::glow::parallelizeOps(F_, llvm::DenseMap<Node *, size_t>(),
-                                     parOpts, 12));
+  std::unordered_map<Node *, ConcatNode *> replacedMap;
+  ASSIGN_VALUE_OR_FAIL_TEST(
+      replacedMap, ::glow::parallelizeOps(F_, llvm::DenseMap<Node *, size_t>(),
+                                          parOpts, 12));
+  EXPECT_EQ(replacedMap.size(), parOpts.size());
   runDCEPass(F_, cctx_);
 
   // We now have 12 Adds from add1, as well as the original add2 which is
@@ -3923,7 +3929,10 @@ TEST_F(GraphOptz, ParallelizeGraph_Transpose) {
   llvm::DenseMap<Node *, ParallelTransformKind> parOpts;
   numChunks[trans1] = 2;
   parOpts[trans1] = ParallelTransformKind::Data;
-  EXPECT_TRUE(::glow::parallelizeOps(F_, numChunks, parOpts, 12));
+  std::unordered_map<Node *, ConcatNode *> replacedMap;
+  ASSIGN_VALUE_OR_FAIL_TEST(replacedMap,
+                            ::glow::parallelizeOps(F_, numChunks, parOpts));
+  EXPECT_EQ(replacedMap.size(), parOpts.size());
 
   runDCEPass(F_, cctx_);
 

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -85,9 +85,10 @@ protected:
       // Note: We disable constant folding here because we only need it to
       // calculate shapes that are the result of constant compute in the proto,
       // but this won't be the case when using useGlowCustomOps exporting.
-      ONNXModelLoader onnxLD(
-          pathToModel, {}, {}, *loadedF, &err, /* zipMode */ false,
-          /* disableConstFoldInLoader */ true, &loadedEE.getBackend());
+      ONNXModelLoader onnxLD(pathToModel, {}, {}, *loadedF, &err,
+                             /* zipMode */ false, /* perNodeOpts */ nullptr,
+                             /* disableConstFoldInLoader */ true,
+                             &loadedEE.getBackend());
       if (ERR_TO_BOOL(std::move(err))) {
         llvm::sys::fs::remove(pathToModel);
         FAIL() << "Error loading exported model";

--- a/tests/unittests/Repro.cpp
+++ b/tests/unittests/Repro.cpp
@@ -417,8 +417,10 @@ int run() {
   Function *F = mod->createFunction("test");
   Error err = Error::empty();
   bool usingGlowCustomOps = false;
+  CompilationContext cctx;
   {
-    ONNXModelLoader onnxLD(modelPathOpt, {}, {}, *F, &err, onnxLoaderZipMode);
+    ONNXModelLoader onnxLD(modelPathOpt, {}, {}, *F, &err, onnxLoaderZipMode,
+                           &cctx.backendOpts.backendSpecificNodeInfo);
     usingGlowCustomOps = onnxLD.usingGlowCustomOps();
   }
   CHECK(!ERR_TO_BOOL(std::move(err)))
@@ -430,7 +432,6 @@ int run() {
   }
 
   // Build host manager and compile the module.
-  CompilationContext cctx;
   PrecisionConfiguration &precConfig = cctx.precisionConfig;
   if (globalFp16Opt) {
     precConfig.convertToFP16 = globalFp16Opt;

--- a/tools/ClassGen/NodeBuilder.cpp
+++ b/tools/ClassGen/NodeBuilder.cpp
@@ -658,9 +658,9 @@ void NodeBuilder::emitImportMethods(std::ostream &os) const {
   os << "    loadedNode->setPredicate(Predicate);\n";
   os << "  }\n\n";
 
-  // Add the node to the Function and return success.
+  // Add the node to the Function and return it.
   os << "  RETURN_IF_ERR(addNodeAsOutput(op, loadedNode));\n";
-  os << "  return true;\n";
+  os << "  return loadedNode;\n";
   os << "}\n\n";
 }
 


### PR DESCRIPTION
Summary:
Allow for specification of parallelization from a custom Glow ONNX serialized model that has been annotated with extra info.

This includes separating `EliminateConcatSlice` into its own optimization that can be called by itself after we do the `parallelizeFunction()` call.

Differential Revision: D20642516

