### PR TITLE
[Quantization] Options to quantize input/output placeholders.

### DIFF
--- a/docs/AOT.md
+++ b/docs/AOT.md
@@ -324,11 +324,12 @@ image-classifier 0_1009.png ... -image-mode=0to1 -model=lenet_mnist -model-input
 model-compiler -backend=CPU -model=lenet_mnist -emit-bundle=build -model-input=data,float,[1,1,28,28] -load-profile=profile.yml
 ```
 
-It is important to note that currently the quantization of a model is performed
+It is important to note that by default the quantization of a model is performed
 only for the intermediate nodes of the graph, without affecting the data types of
 the model inputs and outputs. In the examples above, the data type for the model input
 (image tensor) and the model output remains **float** even though the intermediate
-operators and tensors use **int8** data type.
+operators and tensors use **int8** data type. If you want to convert also the model
+input and output placeholders you can use the option `convert-placeholders`.
 
 When compiling a quantized bundle you can choose to disable the quantization of some
 of the graph operators which might be more susceptible to quantization by using

--- a/lib/LLVMIRCodeGen/BundleSaver.cpp
+++ b/lib/LLVMIRCodeGen/BundleSaver.cpp
@@ -284,31 +284,21 @@ void BundleSaver::saveHeader(llvm::StringRef headerFileName) {
   auto placeholders = findPlaceholders();
   for (auto &v : placeholders) {
     auto *w = cast<WeightVar>(getWeightForNode(v));
-    // Get placeholder shape as string.
-    std::string shapeStr = "[";
-    auto dims = w->getType()->dims();
-    for (size_t idx = 0; idx < dims.size(); idx++) {
-      if (idx < dims.size() - 1) {
-        shapeStr += strFormat("%" PRIuDIM ", ", dims[idx]);
-      } else {
-        shapeStr += strFormat("%" PRIuDIM "]", dims[idx]);
-      }
-    }
     // Get placeholder properties.
     auto name = w->getName();
-    auto typeName = w->getType()->getElementName();
-    auto sizeElem = w->getType()->size();
-    auto sizeByte = w->getType()->getSizeInBytes();
+    auto type = w->getType();
+    auto typeName = type->toString();
+    auto sizeElem = type->size();
+    auto sizeByte = type->getSizeInBytes();
     auto offset = allocationsInfo_.allocatedAddress_[w];
     modelInfo += strFormat("//\n"
                            "//   Name: \"%s\"\n"
                            "//   Type: %s\n"
-                           "//   Shape: %s\n"
                            "//   Size: %" PRIuDIM " (elements)\n"
                            "//   Size: %zu (bytes)\n"
                            "//   Offset: %lu (bytes)\n",
-                           name.data(), typeName.data(), shapeStr.c_str(),
-                           sizeElem, sizeByte, (unsigned long)offset);
+                           name.data(), typeName.c_str(), sizeElem, sizeByte,
+                           (unsigned long)offset);
   }
   // Print constants (optional).
   if (bundleAPIVerbose) {
@@ -317,31 +307,21 @@ void BundleSaver::saveHeader(llvm::StringRef headerFileName) {
     auto constantWeights = findConstantWeights();
     for (auto &weightInfo : constantWeights) {
       auto *w = weightInfo.first;
-      // Get constant shape as string.
-      std::string shapeStr = "[";
-      auto dims = w->getType()->dims();
-      for (size_t idx = 0; idx < dims.size(); idx++) {
-        if (idx < dims.size() - 1) {
-          shapeStr += strFormat("%" PRIuDIM ", ", dims[idx]);
-        } else {
-          shapeStr += strFormat("%" PRIuDIM "]", dims[idx]);
-        }
-      }
       // Get constant properties.
       auto name = w->getName();
-      auto typeName = w->getType()->getElementName();
-      auto sizeElem = w->getType()->size();
-      auto sizeByte = w->getType()->getSizeInBytes();
+      auto type = w->getType();
+      auto typeName = type->toString();
+      auto sizeElem = type->size();
+      auto sizeByte = type->getSizeInBytes();
       auto offset = allocationsInfo_.allocatedAddress_[w];
       modelInfo += strFormat("//\n"
                              "//   Name: \"%s\"\n"
                              "//   Type: %s\n"
-                             "//   Shape: %s\n"
                              "//   Size: %" PRIuDIM " (elements)\n"
                              "//   Size: %zu (bytes)\n"
                              "//   Offset: %lu (bytes)\n",
-                             name.data(), typeName.data(), shapeStr.c_str(),
-                             sizeElem, sizeByte, (unsigned long)offset);
+                             name.data(), typeName.c_str(), sizeElem, sizeByte,
+                             (unsigned long)offset);
     }
   }
   modelInfo += "//";

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -546,7 +546,14 @@ CompilationContext Loader::getCompilationContext(QuantizationMode mode) {
     LOG(FATAL) << "Quantization mode not supported";
   }
 
-  // Optimization options.
+  // When converting the model placeholders, if the placeholders are already
+  // allocated, we should also convert the backing tensors. Since this procedure
+  // is not yet in place, we only convert when emitting a bundle.
+  if (convertPlaceholdersOpt && !emittingBundle()) {
+    llvm::errs() << "The flag 'convert-placeholders' can only be used when "
+                    "emitting a bundle!\n";
+    std::exit(1);
+  }
   cctx.optimizationOpts.foldElemKindConversionIntoIO = convertPlaceholdersOpt;
 
   return cctx;

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -203,6 +203,12 @@ llvm::cl::opt<bool>
                   llvm::cl::desc("Run all floating-point computation in fp16."),
                   llvm::cl::init(false), llvm::cl::cat(loaderCat));
 
+llvm::cl::opt<bool> convertPlaceholdersOpt(
+    "convert-placeholders",
+    llvm::cl::desc("Convert model placeholders by merging ConvertTo, Quantize "
+                   "and Dequantize nodes into the model inputs and outputs."),
+    llvm::cl::init(false), llvm::cl::cat(loaderCat));
+
 /// Emit a bundle into the specified output directory.
 llvm::cl::opt<std::string>
     emitBundle("emit-bundle",
@@ -539,6 +545,9 @@ CompilationContext Loader::getCompilationContext(QuantizationMode mode) {
   } else {
     LOG(FATAL) << "Quantization mode not supported";
   }
+
+  // Optimization options.
+  cctx.optimizationOpts.foldElemKindConversionIntoIO = convertPlaceholdersOpt;
 
   return cctx;
 }


### PR DESCRIPTION
**Summary**
- Add options to quantize separately the input/output placeholders. Sometimes we don`t want to quantize all the placeholders (e.g. when the model ends with a Softmax which does not have a quantized implementation). Having separate options for inputs/ouputs adds extra flexibility.
- I needed to add in the **generateQuantizationInfos** the missing TQP for the output placeholders which do not have profiling information (the output nodes are not profiled). Without this the quantization of the output placeholders will not work because the TQP will not be found.
- Replaced in the bundle header generation the manual shape string derivation with **type.toString()** which already includes the shape and additionally for the quantized types the scales and offsets.

**Documentation**
Document parameters in AOT.md.

**Test Plan**
Unit test in QuantizationTest.

**Question**
Should I provide in the **quantizeFunction** also the **PlaceholderBindings** so that during the placeholder quantization, the backing tensors (if allocated) are also quantized? 
