### PR TITLE
Add separate FoldSlicesIntoConstants and EliminateConcatSlice opts

### DIFF
--- a/include/glow/Backends/BackendOptions.h
+++ b/include/glow/Backends/BackendOptions.h
@@ -17,11 +17,16 @@
 #define GLOW_BACKENDS_BACKENDOPTIONS_H
 
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringMap.h"
+
 #include <map>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace glow {
+class Function;
+class Node;
 class Storage;
 
 /// Hints provided to the Backend, the backend is not required to honor them.
@@ -34,7 +39,19 @@ struct BackendHints {
   std::vector<std::string> SRAMPrioritization;
 };
 
+/// A flexible map used for storing options for a backend. Keys are usually
+/// prefixed with a Backend's name, e.g. "Interpreter_OptionA".
 using BackendSpecificOptions = std::map<std::string, std::string>;
+
+/// A structure used for storing backend-specific information for Nodes in a
+/// Function. The outer map with Functions as a key map to another map with
+/// Nodes as a key, where all Nodes in that map are children of the original
+/// Function. The StringMap for each Node maps from an option name to a vector
+/// of values for that option.
+using BackendSpecificNodeInfo = std::unordered_map<
+    const Function *,
+    std::unordered_map<const Node *,
+                       llvm::StringMap<std::vector<std::string>>>>;
 
 /// Options relevant to Backends during compilation.
 struct BackendOptions {
@@ -50,6 +67,12 @@ struct BackendOptions {
   /// Options that are specific to a backend. Backend is responsible for
   /// parsing.
   BackendSpecificOptions backendSpecificOpts;
+
+  /// Options that are specified per-Node. Note that this structure is keyed off
+  /// of Functions and then Nodes. The Node keys for this structure are Node
+  /// pointers, so any changes of Nodes should be tracked and propagated into
+  /// new Nodes once this is set.
+  BackendSpecificNodeInfo backendSpecificNodeInfo;
 };
 
 }; // namespace glow

--- a/include/glow/Importer/ONNXModelLoader.h
+++ b/include/glow/Importer/ONNXModelLoader.h
@@ -102,10 +102,11 @@ class ONNXModelLoader
   /// If this is a custom Glow op that was exported via NodeGen automatic export
   /// logic, try to load the op. \returns Expected<true> if the op is
   /// successfully loaded. \returns Expected<false> if op type is not supported.
-  /// \returns an Error if an error occurred while trying to load.
-  Expected<bool> tryLoadGlowCustomOp(llvm::StringRef typeName,
-                                     const ONNX_NAMESPACE::NodeProto &op,
-                                     ArgumentDictionaryTy &dict);
+  /// \returns an Error if an error occurred while trying to load, or otherwise
+  /// the single Node that was created.
+  Expected<Node *> tryLoadGlowCustomOp(llvm::StringRef typeName,
+                                       const ONNX_NAMESPACE::NodeProto &op,
+                                       ArgumentDictionaryTy &dict);
 
   /// \returns True if the operator\ op is successfully folded.
   Expected<bool> foldOperator(const ONNX_NAMESPACE::NodeProto &op);
@@ -469,8 +470,13 @@ public:
                   llvm::ArrayRef<const char *> tensorNames,
                   llvm::ArrayRef<TypeRef> types, Function &F,
                   Error *errPtr = nullptr, bool zipMode = false,
+                  BackendSpecificNodeInfo *perNodeOpts = nullptr,
                   bool disableConstFoldInLoader = false,
                   const Backend *B = nullptr);
+
+private:
+  /// Per-node options that may be specified in a proto.
+  BackendSpecificNodeInfo *perNodeOpts_{nullptr};
 };
 
 } // namespace glow

--- a/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
+++ b/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
@@ -49,6 +49,8 @@ FUN_PASS(FoldTileAddIntoBatchedAdd)
 FUN_PASS(FoldElemKindConversionIntoOutputs)
 FUN_PASS(FoldElemKindConversionIntoInputs)
 FUN_PASS(FoldMatMulAddIntoFullyConnected)
+FUN_PASS(FoldSlicesIntoConstants)
+FUN_PASS(EliminateConcatSlice)
 
 // NOTE: This pass must be last; it's used to count the total number of passes.
 FUN_PASS(EmptyPass)

--- a/include/glow/Partitioner/PartitionerBase.h
+++ b/include/glow/Partitioner/PartitionerBase.h
@@ -45,9 +45,12 @@ protected:
   /// Functions representing each partition. However if \p skipCloning we skip
   /// this cloning, as it is assumed that the Functions are already partitioned
   /// correctly and so we do not need to clone their Nodes into new Functions.
+  /// \p nodeInfo represents any info mapped to Nodes, so when cloning Nodes we
+  /// need to update this map.
   DAGListTy doPartitioning(llvm::StringRef funcName,
                            std::vector<Function *> funcs, Module *module,
                            NodeToFunctionMap &mapping, bool saveDAG,
+                           BackendSpecificNodeInfo &nodeInfo,
                            bool skipCloning = false);
 };
 } // namespace glow

--- a/lib/Optimizer/GraphOptimizerPipeline/Pipeline.cpp
+++ b/lib/Optimizer/GraphOptimizerPipeline/Pipeline.cpp
@@ -76,6 +76,9 @@ FunctionPassPipeline glow::createDefaultGraphOptimizationPassPipeline() {
       // Optimize Concat nodes.
       {FunctionPassID::OptimizeConcatNodes},
 
+      // Eliminate Concat-Slice patterns which are unnecessary.
+      {FunctionPassID::EliminateConcatSlice},
+
       // Optimize arithmetic nodes based on algebraic identities.
       {FunctionPassID::OptimizeArithmeticNodes},
 

--- a/tests/models/onnxModels/glow_custom_op_node_opts.onnxtxt
+++ b/tests/models/onnxModels/glow_custom_op_node_opts.onnxtxt
@@ -1,0 +1,122 @@
+ir_version: 7
+producer_name: "GlowONNXModelWriter"
+graph {
+  node {
+    input: "lhs"
+    input: "rhs"
+    output: "MM"
+    name: "MM"
+    op_type: "Glow_MatMul"
+    attribute {
+      name: "i0_elemKind"
+      s: "float"
+      type: STRING
+    }
+    attribute {
+      name: "i0_shape"
+      ints: 3
+      ints: 2
+      type: INTS
+    }
+    attribute {
+      name: "i1_elemKind"
+      s: "float"
+      type: STRING
+    }
+    attribute {
+      name: "i1_shape"
+      ints: 2
+      ints: 1
+      type: INTS
+    }
+    attribute {
+      name: "o0_elemKind"
+      s: "float"
+      type: STRING
+    }
+    attribute {
+      name: "o0_shape"
+      ints: 3
+      ints: 1
+      type: INTS
+    }
+    attribute {
+      name: "NodeOpt_BackendA_Option1"
+      strings: "1"
+      strings: "2"
+      type: STRINGS
+    }
+    attribute {
+      name: "NodeOpt_BackendA_Option2"
+      strings: "3"
+      type: STRINGS
+    }
+    attribute {
+      name: "NodeOpt_BackendB_Option3"
+      strings: "4"
+      strings: "5"
+      type: STRINGS
+    }
+  }
+  node {
+    input: "MM"
+    output: "save"
+    name: "save_save"
+    op_type: "Identity"
+  }
+  name: "glow"
+  input {
+    name: "lhs"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+    doc_string: "$offline:0$trainable:0$layout:*$elemKind:float"
+  }
+  input {
+    name: "rhs"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+    doc_string: "$offline:0$trainable:0$layout:*$elemKind:float"
+  }
+  output {
+    name: "save"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+    doc_string: "$offline:0$trainable:0$layout:*$elemKind:float$saveName:save_save"
+  }
+}
+opset_import {
+  version: 9
+}

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -85,9 +85,10 @@ protected:
       // Note: We disable constant folding here because we only need it to
       // calculate shapes that are the result of constant compute in the proto,
       // but this won't be the case when using useGlowCustomOps exporting.
-      ONNXModelLoader onnxLD(
-          pathToModel, {}, {}, *loadedF, &err, /* zipMode */ false,
-          /* disableConstFoldInLoader */ true, &loadedEE.getBackend());
+      ONNXModelLoader onnxLD(pathToModel, {}, {}, *loadedF, &err,
+                             /* zipMode */ false, /* perNodeOpts */ nullptr,
+                             /* disableConstFoldInLoader */ true,
+                             &loadedEE.getBackend());
       if (ERR_TO_BOOL(std::move(err))) {
         llvm::sys::fs::remove(pathToModel);
         FAIL() << "Error loading exported model";

--- a/tests/unittests/Repro.cpp
+++ b/tests/unittests/Repro.cpp
@@ -417,8 +417,10 @@ int run() {
   Function *F = mod->createFunction("test");
   Error err = Error::empty();
   bool usingGlowCustomOps = false;
+  CompilationContext cctx;
   {
-    ONNXModelLoader onnxLD(modelPathOpt, {}, {}, *F, &err, onnxLoaderZipMode);
+    ONNXModelLoader onnxLD(modelPathOpt, {}, {}, *F, &err, onnxLoaderZipMode,
+                           &cctx.backendOpts.backendSpecificNodeInfo);
     usingGlowCustomOps = onnxLD.usingGlowCustomOps();
   }
   CHECK(!ERR_TO_BOOL(std::move(err)))
@@ -430,7 +432,6 @@ int run() {
   }
 
   // Build host manager and compile the module.
-  CompilationContext cctx;
   PrecisionConfiguration &precConfig = cctx.precisionConfig;
   if (globalFp16Opt) {
     precConfig.convertToFP16 = globalFp16Opt;

--- a/tools/ClassGen/NodeBuilder.cpp
+++ b/tools/ClassGen/NodeBuilder.cpp
@@ -658,9 +658,9 @@ void NodeBuilder::emitImportMethods(std::ostream &os) const {
   os << "    loadedNode->setPredicate(Predicate);\n";
   os << "  }\n\n";
 
-  // Add the node to the Function and return success.
+  // Add the node to the Function and return it.
   os << "  RETURN_IF_ERR(addNodeAsOutput(op, loadedNode));\n";
-  os << "  return true;\n";
+  os << "  return loadedNode;\n";
   os << "}\n\n";
 }
 


### PR DESCRIPTION
Summary:
- `EliminateConcatSlice`: This is already implemented but was part of `OptimizeConcatNodes`. Instead move it to a separate pass to call separately.
- `FoldSlicesIntoConstants`: This already happens during the `ConstantFold` pass, but add an extra separate lightweight pass that can be called separately. This is not added to the default graph opt pipeline as it's already covered. Used later in stack.

Differential Revision: D20681574

