### PR TITLE
Load quantized conv3d in PytorchModelLoader

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -478,6 +478,24 @@ public:
       llvm::ArrayRef<unsigned_t> kernels, llvm::ArrayRef<unsigned_t> strides,
       llvm::ArrayRef<unsigned_t> pads, unsigned_t group);
 
+  /// Creates a ChannelwiseQuantizedConvolutionNode with the given \p name
+  /// which convolves the 5D \p input with \p filter and \p bias. \p scales and
+  /// \p offsets provide individual quantization parameters for each filter
+  /// group in \p filter. \p kernels defines the size of the temporal_frame,
+  /// height and width dimensions of the filters. \p strides defines the number
+  /// of steps to take in the input for each output cell. \p pads defines how
+  /// many zero padding cells should be added to the input during convolution.
+  /// \p group defines the number of groups the input and output channels should
+  /// be divided into and convolved separately. If bias is FloatTy then it will
+  /// be quantized to Int32QTy automatically. NOTE:
+  /// ChannelwiseQuantizedConvolutionNode does not yet have an implementation
+  /// so attempting to run a graph containing this node fails.
+  ChannelwiseQuantizedConvolutionNode *createChannelwiseQuantizedConv3D(
+      llvm::StringRef name, NodeValue input, NodeValue filter, NodeValue bias,
+      NodeValue scales, NodeValue offsets, TypeRef outTy,
+      llvm::ArrayRef<unsigned_t> kernels, llvm::ArrayRef<unsigned_t> strides,
+      llvm::ArrayRef<unsigned_t> pads, unsigned_t group);
+
   /// Creates a ConvTransposeNode with the given \p name which does transposed
   /// convolution of the 4D \p input with \p filter and \bias. \p kernels define
   /// the size of the height and width dimensions of the filters. \p strides

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -802,12 +802,26 @@ static bool channelwiseQuantizeFloatBias(
   auto biasQuantizedC = F->getParent()->createConstant(
       biasC->getName(), std::move(biasQuantizedT));
 
-  auto newChannelwiseConv = F->createChannelwiseQuantizedConv(
-      channelwiseConv.getName(), channelwiseConv.getInput(),
-      channelwiseConv.getFilter(), biasQuantizedC, channelwiseConv.getScales(),
-      channelwiseConv.getOffsets(), channelwiseConv.getResult().getType(),
-      channelwiseConv.getKernels(), channelwiseConv.getStrides(),
-      channelwiseConv.getPads(), channelwiseConv.getGroup());
+  bool isConv3d = (channelwiseConv.getInput().getType()->dims().size() == 5);
+  glow::ChannelwiseQuantizedConvolutionNode *newChannelwiseConv;
+  if (isConv3d) {
+    newChannelwiseConv = F->createChannelwiseQuantizedConv3D(
+        channelwiseConv.getName(), channelwiseConv.getInput(),
+        channelwiseConv.getFilter(), biasQuantizedC,
+        channelwiseConv.getScales(), channelwiseConv.getOffsets(),
+        channelwiseConv.getResult().getType(), channelwiseConv.getKernels(),
+        channelwiseConv.getStrides(), channelwiseConv.getPads(),
+        channelwiseConv.getGroup());
+
+  } else {
+    newChannelwiseConv = F->createChannelwiseQuantizedConv(
+        channelwiseConv.getName(), channelwiseConv.getInput(),
+        channelwiseConv.getFilter(), biasQuantizedC,
+        channelwiseConv.getScales(), channelwiseConv.getOffsets(),
+        channelwiseConv.getResult().getType(), channelwiseConv.getKernels(),
+        channelwiseConv.getStrides(), channelwiseConv.getPads(),
+        channelwiseConv.getGroup());
+  }
 
   channelwiseConv.getResult().replaceAllUsesOfWith(newChannelwiseConv);
   return true;

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -761,19 +761,6 @@ void BoundInterpreterFunction::fwdChannelwiseQuantizedConvolutionInst(
   llvm::ArrayRef<unsigned_t> pads = I->getPads();
   llvm::ArrayRef<unsigned_t> strides = I->getStrides();
   dim_t group = I->getGroup();
-
-  ShapeNHWC odim(outW.dims());
-  ShapeNHWC idim(inW.dims());
-  ShapeHW kdim(kernelSizes);
-  ShapeHW sdim(strides);
-
-  assert(idim.c % group == 0 && "Input channels must be divisible by group.");
-  assert(odim.c % group == 0 && "Output channels must be divisible by group.");
-  dim_t inCperG = idim.c / group;
-  dim_t outCperG = odim.c / group;
-
-  PaddingTLBR pdim(pads);
-
   auto &inTy = inW.getType();
   auto &outTy = outW.getType();
 
@@ -783,62 +770,158 @@ void BoundInterpreterFunction::fwdChannelwiseQuantizedConvolutionInst(
   int32_t inOffset = inTy.getOffset();
   int32_t outOffset = outTy.getOffset();
 
-  // For each input in the batch:
-  for (dim_t n = 0; n < idim.n; n++) {
-    // For each group of input channels:
-    for (dim_t g = 0; g < group; g++) {
+  bool isConv3d = (inW.dims().size() == 5);
+  if (isConv3d) {
+    ShapeNTHWC odim(outW.dims());
+    ShapeNTHWC idim(inW.dims());
+    ShapeTHW kdim(kernelSizes);
+    ShapeTHW sdim(strides);
 
-      // For each output channel in the group:
-      for (dim_t d = g * outCperG; d < (g + 1) * outCperG; d++) {
+    assert(idim.c % group == 0 && "Input channels must be divisible by group.");
+    assert(odim.c % group == 0 &&
+           "Output channels must be divisible by group.");
+    dim_t inCperG = idim.c / group;
+    dim_t outCperG = odim.c / group;
 
-        // get channelwise qparams params
-        int32_t filterOffset = offsetsW.at(d);
-        float filterScale = scalesW.at(d);
-        float matMulScale = inScale * filterScale;
-        // For each convolution 'jump' in the input tensor:
-        sdim_t x = -sdim_t(pdim.top);
-        for (dim_t ax = 0; ax < odim.h; x += sdim.height, ax++) {
-          sdim_t y = -sdim_t(pdim.left);
-          for (dim_t ay = 0; ay < odim.w; y += sdim.width, ay++) {
+    PaddingNFTBLR pdim(pads);
 
-            // For each element in the convolution-filter:
-            AccumulatorTy sum = 0;
-            for (dim_t fx = 0; fx < kdim.height; fx++) {
-              for (dim_t fy = 0; fy < kdim.width; fy++) {
-                sdim_t ox = x + fx;
-                sdim_t oy = y + fy;
+    // For each input in the batch:
+    for (dim_t n = 0; n < idim.n; n++) {
+      // For each group of input channels:
+      for (dim_t g = 0; g < group; g++) {
 
-                // Ignore index access below zero (this is due to padding).
-                if (ox < 0 || oy < 0 || ox >= ssize_t(idim.h) ||
-                    oy >= sdim_t(idim.w)) {
-                  continue;
+        // For each output channel in the group:
+        for (dim_t d = g * outCperG; d < (g + 1) * outCperG; d++) {
+
+          // get channelwise qparams params
+          int32_t filterOffset = offsetsW.at(d);
+          float filterScale = scalesW.at(d);
+          float matMulScale = inScale * filterScale;
+          // For each convolution 'jump' in the input tensor:
+          sdim_t t = -sdim_t(pdim.near);
+          for (dim_t at = 0; at < odim.t; t += sdim.temporal_frames, at++) {
+            sdim_t x = -sdim_t(pdim.top);
+            for (dim_t ax = 0; ax < odim.h; x += sdim.height, ax++) {
+              sdim_t y = -sdim_t(pdim.left);
+              for (dim_t ay = 0; ay < odim.w; y += sdim.width, ay++) {
+
+                // For each element in the convolution-filter:
+                AccumulatorTy sum = 0;
+                for (dim_t ft = 0; ft < kdim.temporal_frames; ft++) {
+                  for (dim_t fx = 0; fx < kdim.height; fx++) {
+                    for (dim_t fy = 0; fy < kdim.width; fy++) {
+                      sdim_t ot = t + ft;
+                      sdim_t ox = x + fx;
+                      sdim_t oy = y + fy;
+
+                      // Ignore index access below zero (this is due to
+                      // padding).
+                      if (ot < 0 || ox < 0 || oy < 0 || ot >= ssize_t(idim.t) ||
+                          ox >= ssize_t(idim.h) || oy >= sdim_t(idim.w)) {
+                        continue;
+                      }
+                      for (dim_t fd = 0; fd < inCperG; fd++) {
+
+                        AccumulatorTy F = filterW.at({d, ft, fx, fy, fd});
+                        AccumulatorTy I = inW.at({n, (dim_t)ot, (dim_t)ox,
+                                                  (dim_t)oy, g * inCperG + fd});
+                        // We represent the element multiplication with offset
+                        // as (value - offset).
+                        sum += (F - filterOffset) * (I - inOffset);
+                      }
+                    }
+                  }
                 }
-                for (dim_t fd = 0; fd < inCperG; fd++) {
 
-                  AccumulatorTy F = filterW.at({d, fx, fy, fd});
-                  AccumulatorTy I =
-                      inW.at({n, (dim_t)ox, (dim_t)oy, g * inCperG + fd});
-                  // We represent the element multiplication with offset as
-                  // (value - offset).
-                  sum += (F - filterOffset) * (I - inOffset);
+                // Add the channelwise quantized bias.
+                // NOTE: The bias of ChannelwiseQuantizedConvolution should be
+                // quantized such that each element is scaled to match the
+                // matMulScale (biasScale_i = scales_i * inScale).
+                sum += biasW.at({d});
+
+                // Scale the result back to the expected destination scale.
+                outW.at({n, at, ax, ay, d}) =
+                    quantization::clip<AccumulatorTy, int8_t>(std::round(
+                        float(sum) * (matMulScale / outScale) + outOffset));
+              } // W
+            }   // H
+          }     // T
+        }       // C
+      }         // G
+    }           // N
+  } else {
+
+    ShapeNHWC odim(outW.dims());
+    ShapeNHWC idim(inW.dims());
+    ShapeHW kdim(kernelSizes);
+    ShapeHW sdim(strides);
+
+    assert(idim.c % group == 0 && "Input channels must be divisible by group.");
+    assert(odim.c % group == 0 &&
+           "Output channels must be divisible by group.");
+    dim_t inCperG = idim.c / group;
+    dim_t outCperG = odim.c / group;
+
+    PaddingTLBR pdim(pads);
+
+    // For each input in the batch:
+    for (dim_t n = 0; n < idim.n; n++) {
+      // For each group of input channels:
+      for (dim_t g = 0; g < group; g++) {
+
+        // For each output channel in the group:
+        for (dim_t d = g * outCperG; d < (g + 1) * outCperG; d++) {
+
+          // get channelwise qparams params
+          int32_t filterOffset = offsetsW.at(d);
+          float filterScale = scalesW.at(d);
+          float matMulScale = inScale * filterScale;
+          // For each convolution 'jump' in the input tensor:
+          sdim_t x = -sdim_t(pdim.top);
+          for (dim_t ax = 0; ax < odim.h; x += sdim.height, ax++) {
+            sdim_t y = -sdim_t(pdim.left);
+            for (dim_t ay = 0; ay < odim.w; y += sdim.width, ay++) {
+
+              // For each element in the convolution-filter:
+              AccumulatorTy sum = 0;
+              for (dim_t fx = 0; fx < kdim.height; fx++) {
+                for (dim_t fy = 0; fy < kdim.width; fy++) {
+                  sdim_t ox = x + fx;
+                  sdim_t oy = y + fy;
+
+                  // Ignore index access below zero (this is due to padding).
+                  if (ox < 0 || oy < 0 || ox >= ssize_t(idim.h) ||
+                      oy >= sdim_t(idim.w)) {
+                    continue;
+                  }
+                  for (dim_t fd = 0; fd < inCperG; fd++) {
+
+                    AccumulatorTy F = filterW.at({d, fx, fy, fd});
+                    AccumulatorTy I =
+                        inW.at({n, (dim_t)ox, (dim_t)oy, g * inCperG + fd});
+                    // We represent the element multiplication with offset as
+                    // (value - offset).
+                    sum += (F - filterOffset) * (I - inOffset);
+                  }
                 }
               }
-            }
 
-            // Add the channelwise quantized bias.
-            // NOTE: The bias of ChannelwiseQuantizedConvolution should be
-            // quantized such that each element is scaled to match the
-            // matMulScale (biasScale_i = scales_i * inScale).
-            sum += biasW.at({d});
+              // Add the channelwise quantized bias.
+              // NOTE: The bias of ChannelwiseQuantizedConvolution should be
+              // quantized such that each element is scaled to match the
+              // matMulScale (biasScale_i = scales_i * inScale).
+              sum += biasW.at({d});
 
-            // Scale the result back to the expected destination scale.
-            outW.at({n, ax, ay, d}) = quantization::clip<AccumulatorTy, int8_t>(
-                std::round(float(sum) * (matMulScale / outScale) + outOffset));
-          } // W
-        }   // H
-      }     // C
-    }       // G
-  }         // N
+              // Scale the result back to the expected destination scale.
+              outW.at({n, ax, ay, d}) =
+                  quantization::clip<AccumulatorTy, int8_t>(std::round(
+                      float(sum) * (matMulScale / outScale) + outOffset));
+            } // W
+          }   // H
+        }     // C
+      }       // G
+    }         // N
+  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -2621,6 +2621,41 @@ ChannelwiseQuantizedConvolutionNode *Function::createChannelwiseQuantizedConv(
       group));
 }
 
+ChannelwiseQuantizedConvolutionNode *Function::createChannelwiseQuantizedConv3D(
+    llvm::StringRef name, NodeValue input, NodeValue filter, NodeValue bias,
+    NodeValue scales, NodeValue offsets, TypeRef outTy,
+    llvm::ArrayRef<unsigned_t> kernels, llvm::ArrayRef<unsigned_t> strides,
+    llvm::ArrayRef<unsigned_t> pads, unsigned_t group) {
+  assertConv3DDims(input, filter, bias, kernels, strides, pads, group);
+  auto OT = getParent()->uniqueType(*outTy);
+  auto biasElemKind = bias.getElementType();
+
+  if (biasElemKind != ElemKind::Int32QTy && biasElemKind != ElemKind::FloatTy) {
+    LOG(DFATAL)
+        << "Unsupported element type for ChannelwiseQuantizedConvolution bias: "
+        << Type::getElementName(biasElemKind).str();
+  }
+
+  DCHECK(dyn_cast<Constant>(bias.getNode()))
+      << "bias input to ChannelwiseQuantizedConvolutionNode must be a Constant";
+
+  DCHECK(dyn_cast<Constant>(filter.getNode()))
+      << "filter input to ChannelwiseQuantizedConvolutionNode must be a "
+         "Constant";
+
+  DCHECK(dyn_cast<Constant>(scales.getNode()))
+      << "scales input to ChannelwiseQuantizedConvolutionNode must a Constant "
+         "in order to quantize the bias";
+
+  DCHECK(dyn_cast<Constant>(offsets.getNode()))
+      << "offsets input to ChannelwiseQuantizedConvolutionNode must be a"
+         "Constant";
+
+  return addNode(new ChannelwiseQuantizedConvolutionNode(
+      name, OT, input, filter, bias, scales, offsets, kernels, strides, pads,
+      group));
+}
+
 ConvTransposeNode *Function::createConvTranspose(
     PlaceholderBindings &bindings, llvm::StringRef name, NodeValue input,
     dim_t outChannels, llvm::ArrayRef<unsigned_t> kernels,

--- a/torch_glow/tests/nodes/quantized_conv3d_relu_test.py
+++ b/torch_glow/tests/nodes/quantized_conv3d_relu_test.py
@@ -1,0 +1,115 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+from collections import OrderedDict
+
+import torch
+from tests.utils import jitVsGlow
+
+
+class TestQuantizedConv3dRelu(unittest.TestCase):
+    def _test_quantized_conv3d_relu_packed(self, groups):
+        """Basic test of PyTorch quantized::conv3d_relu Node with packed weights on Glow."""
+        with torch.no_grad():
+            x = torch.tensor(range(5), dtype=torch.float)
+            x = torch.cat((x, x, x, x, x))
+            x = torch.cat((x, x, x))
+            x = torch.cat((x, x, x))
+            x = torch.reshape(x, [1, 3, 3, 5, 5])
+            q = torch.nn.quantized.Quantize(1, 2, torch.quint8)
+            conv = torch.nn.Conv3d(3, 3, kernel_size=3, stride=(2, 2, 2), groups=groups)
+            relu = torch.nn.ReLU()
+            dq = torch.nn.quantized.DeQuantize()
+
+            # Due to the off-by-one error, we cannot let the weights, bias & input
+            # to be totally random.
+            conv.weight.set_(
+                torch.arange(72 / groups, dtype=torch.float).reshape(
+                    [3, 3 // groups, 2, 2, 2]
+                )
+                / 3
+            )
+            conv.bias.data.fill_(2)
+
+            model = torch.nn.Sequential(
+                OrderedDict(
+                    [
+                        ("quantize", q),
+                        ("conv1", conv),
+                        ("relu1", relu),
+                        ("dequantize", dq),
+                    ]
+                )
+            )
+            model.eval()
+            model.qconfig = torch.quantization.get_default_qconfig("fbgemm")
+
+            # Fuse conv and relu to conv_relu
+            model = torch.quantization.fuse_modules(model, [["conv1", "relu1"]])
+
+            torch.quantization.prepare(model, inplace=True)
+            torch.quantization.convert(model, inplace=True)
+
+            jitVsGlow(
+                model,
+                x,
+                expected_fused_ops={
+                    "aten::quantize_per_tensor",
+                    "quantized::conv3d_relu",
+                    "aten::dequantize",
+                },
+            )
+
+    def test_quantized_conv3d_relu_packed_groupwise(self):
+        """PyTorch groupwise quantized::conv3d_relu Node with packed weights on Glow."""
+        self._test_quantized_conv3d_relu_packed(groups=3)
+
+    def test_quantized_conv3d_relu_packed_nongroupwise(self):
+        """PyTorch vanilla quantized::conv3d_relu Node with packed weights on Glow."""
+        self._test_quantized_conv3d_relu_packed(groups=1)
+
+    def test_quantized_conv3d_relu_packed_cut_q_dq(self):
+        """Basic test of PyTorch quantized::conv3d_relu Node with packed weights on Glow, with quantize and dequantize excluded. """
+        with torch.no_grad():
+            x = torch.tensor(range(5), dtype=torch.float)
+            x = torch.cat((x, x, x, x, x))
+            x = torch.cat((x, x, x))
+            x = torch.cat((x, x, x))
+            x = torch.reshape(x, [1, 3, 3, 5, 5])
+            q = torch.nn.quantized.Quantize(1, 2, torch.quint8)
+            conv = torch.nn.Conv3d(3, 3, kernel_size=3, stride=(2, 2, 2), groups=1)
+            relu = torch.nn.ReLU()
+            dq = torch.nn.quantized.DeQuantize()
+
+            # Due to the off-by-one error, we cannot let the weights, bias & input
+            # to be totally random.
+            conv.weight.set_(
+                torch.arange(72, dtype=torch.float).reshape([3, 3, 2, 2, 2]) / 3
+            )
+            conv.bias.data.fill_(2)
+
+            model = torch.nn.Sequential(
+                OrderedDict(
+                    [
+                        ("quantize", q),
+                        ("conv1", conv),
+                        ("relu1", relu),
+                        ("dequantize", dq),
+                    ]
+                )
+            )
+            model.eval()
+            model.qconfig = torch.quantization.get_default_qconfig("fbgemm")
+
+            # Fuse conv and relu to conv_relu
+            model = torch.quantization.fuse_modules(model, [["conv1", "relu1"]])
+
+            torch.quantization.prepare(model, inplace=True)
+            torch.quantization.convert(model, inplace=True)
+
+            jitVsGlow(
+                model,
+                x,
+                expected_fused_ops={"quantized::conv3d_relu"},
+                black_list=["aten::quantize_per_tensor", "aten::dequantize"],
+            )

--- a/torch_glow/tests/nodes/quantized_conv3d_test.py
+++ b/torch_glow/tests/nodes/quantized_conv3d_test.py
@@ -1,0 +1,155 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+
+import torch
+from tests.utils import jitVsGlow
+
+import logging
+
+logger = logging.getLogger("quantized conv3d test")
+logger.setLevel(logging.INFO)
+
+
+class TestQuantizedConv3d(unittest.TestCase):
+    def test_quantized_conv3d_unpacked(self):
+        """Basic test of the PyTorch quantize::conv3d Node with unpacked weights on Glow."""
+
+        def test_f(a, w, b):
+            qu = torch.nn.quantized.Quantize(1 / 16, 0, torch.quint8)
+            qi = torch.nn.quantized.Quantize(1 / 16, 0, torch.qint8)
+            dq = torch.nn.quantized.DeQuantize()
+            conv = torch.nn.quantized.functional.conv3d
+            return dq(conv(qu(a), qi(w), b))
+
+        # TODO
+        # Due to the quantization error between
+        # PyTorch and Glow, we would like to use some
+        # determined test data instead of random ones
+        # x = torch.randn([3, 3, 3, 3])
+        # w = torch.randn([3, 3, 3, 3])
+        # b = torch.randn([3])
+
+        x = torch.tensor([[[[[5.0, 6.0], [7.0, 8.0]]]]])
+        w = torch.tensor([[[[[2.0]]]]])
+        b_zero = torch.zeros(1)
+        b = torch.randn(1)
+
+        jitVsGlow(
+            test_f,
+            x,
+            w,
+            b,
+            expected_fused_ops={
+                "aten::quantize_per_tensor",
+                "glow::unpacked_quantized_conv3d",
+                "aten::dequantize",
+            },
+        )
+
+        jitVsGlow(
+            test_f,
+            x,
+            w,
+            b_zero,
+            expected_fused_ops={
+                "aten::quantize_per_tensor",
+                "glow::unpacked_quantized_conv3d",
+                "aten::dequantize",
+            },
+        )
+
+    def test_quantized_conv3d_packed_groupwise(self):
+        """Basic test of PyTorch quantize::conv3d Node with packed weights on Glow."""
+
+        x = torch.tensor(range(5), dtype=torch.float)
+        x = torch.cat((x, x, x, x, x))
+        x = torch.cat((x, x, x))
+        x = torch.cat((x, x, x))
+        x = torch.reshape(x, [1, 3, 3, 5, 5])
+        q = torch.nn.quantized.Quantize(0.1, 2, torch.quint8)
+        conv = torch.nn.Conv3d(3, 3, kernel_size=1, stride=(1, 1, 1), groups=3)
+        dq = torch.nn.quantized.DeQuantize()
+
+        # Due to the off-by-one error, we cannot let the weights, bias & input
+        # to be totally random.
+        conv.weight.data.fill_(2.0)
+        conv.bias.data.fill_(1.0)
+
+        model = torch.nn.Sequential(q, conv, dq)
+        model.eval()
+        model.qconfig = torch.quantization.get_default_qconfig("fbgemm")
+
+        torch.quantization.prepare(model, inplace=True)
+        torch.quantization.convert(model, inplace=True)
+
+        jitVsGlow(
+            model,
+            x,
+            expected_fused_ops={
+                "aten::quantize_per_tensor",
+                "quantized::conv3d",
+                "aten::dequantize",
+            },
+        )
+
+    def test_quantized_conv3d_packed_cut_q_dq(self):
+        """Basic test of PyTorch quantize::conv3d Node with packed weights on Glow, with quantize and dequantize excluded."""
+
+        x = torch.tensor(range(5), dtype=torch.float)
+        x = torch.cat((x, x, x, x, x))
+        x = torch.cat((x, x, x))
+        x = torch.cat((x, x, x))
+        x = torch.reshape(x, [1, 3, 3, 5, 5])
+        q = torch.nn.quantized.Quantize(0.1, 2, torch.quint8)
+        conv = torch.nn.Conv3d(3, 3, kernel_size=1, stride=(1, 1, 1), groups=3)
+        dq = torch.nn.quantized.DeQuantize()
+
+        # Due to the off-by-one error, we cannot let the weights, bias & input
+        # to be totally random.
+        conv.weight.data.fill_(2.0)
+        conv.bias.data.fill_(1.0)
+
+        model = torch.nn.Sequential(q, conv, dq)
+        model.eval()
+        model.qconfig = torch.quantization.get_default_qconfig("fbgemm")
+
+        torch.quantization.prepare(model, inplace=True)
+        torch.quantization.convert(model, inplace=True)
+
+        jitVsGlow(
+            model,
+            x,
+            expected_fused_ops={"quantized::conv3d"},
+            black_list=["aten::quantize_per_tensor", "aten::dequantize"],
+        )
+
+    def test_quantized_conv3d_packed_channelwise(self):
+        """Basic test of PyTorch quantize::conv3d Node with packed channelwise weights on Glow."""
+
+        with torch.no_grad():
+            x = torch.randn([1, 4, 4, 4, 4])
+
+            conv = torch.nn.Conv3d(4, 2, 2, (2, 2, 2), groups=1)
+            conv.weight.random_(-1, 1)
+            conv.bias.data.random_(-1, 1)
+
+            model = torch.quantization.QuantWrapper(conv)
+            model.qconfig = torch.quantization.get_default_qconfig("fbgemm")
+
+            torch.quantization.prepare(model, inplace=True)
+            # Calibration
+            model.forward(x)
+            torch.quantization.convert(model, inplace=True)
+
+            # TODO: acuracy needs to be investigated. Average acuracy is decent
+            # but some elements have errors (possibly from rounding differences)
+            jitVsGlow(
+                model,
+                x,
+                expected_fused_ops={
+                    "aten::quantize_per_tensor",
+                    "quantized::conv3d",
+                    "aten::dequantize",
+                },
+            )


### PR DESCRIPTION
Summary:
Add quantized conv3d support in glow

Depends on the following PR to fuse conv3d, batchnorm3d, and relu. https://github.com/pytorch/pytorch/pull/33540

Reviewed By: jackm321

Differential Revision: D20524122

