### PR TITLE
[OpenCL] Use channel as grid dimension for LRN

### DIFF
--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -1159,7 +1159,7 @@ Error OpenCLFunction::execute(ExecutionContext *context) {
       setKernelArg(kernel, ++numArgs, LRN->getAlpha() / windowSize);
 
       enqueueKernel(I.getName(), commands, kernel, deviceId,
-                    {dim.n, dim.h, dim.w}, kernelLaunches);
+                    {dim.h, dim.w, dim.c}, kernelLaunches);
       continue;
     }
 

--- a/lib/Backends/OpenCL/kernels.cl
+++ b/lib/Backends/OpenCL/kernels.cl
@@ -932,11 +932,13 @@ __kernel void localresponsenormalizationW(__global void *mem, unsigned dest,
   global float *outW = (global float *)&mem[dest];
   global float *inW = (global float *)&mem[src];
   global float *scaleCache = (global float *)&mem[scaleC];
-  unsigned n = get_global_id(0);
-  unsigned h = get_global_id(1);
-  unsigned w = get_global_id(2);
-  // For every channel:
-  for (unsigned c = 0; c < dim.c; c++) {
+
+  unsigned h = get_global_id(0);
+  unsigned w = get_global_id(1);
+  unsigned c = get_global_id(2);
+
+  // For each input in the batch:
+  for (unsigned n = 0; n < dim.n; n++) {
     float squareSum = 0.0;
     for (unsigned i = (c >= halfWindowSize ? c - halfWindowSize : 0);
          i <= min(c + halfWindowSize, (unsigned)dim.c - 1); i++) {


### PR DESCRIPTION
Use channel as grid dimension for local response normalization kernel instead of batch so more work is done by the kernel (this assumes that the batch count is usually a small number).

This gives about 5% speedup on inception v1 for Intel HD620 GPU.
