### PR TITLE
Add RaiseClipsAboveShapeNodes and use for NNPI

### DIFF
--- a/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
+++ b/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
@@ -51,6 +51,7 @@ FUN_PASS(FoldElemKindConversionIntoInputs)
 FUN_PASS(FoldMatMulAddIntoFullyConnected)
 FUN_PASS(FoldSlicesIntoConstants)
 FUN_PASS(EliminateConcatSlice)
+FUN_PASS(RaiseClipsAboveShapeNodes)
 
 // NOTE: This pass must be last; it's used to count the total number of passes.
 FUN_PASS(EmptyPass)

--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -1044,6 +1044,12 @@ FunctionPassPipeline NNPIBackend::getOptimizationPipeline() const {
   // not want to undo that by sinking Nodes back together.
   pipeline.removeAllInstancesOfPass(FunctionPassID::SinkCode);
 
+  // Raise Clips above Shape Nodes (e.g. Reshape) to try to ensure fusion
+  // occurs. Note that we do this last as it may counteract some earlier
+  // optimizations that push Clips down to try to eliminate them.
+  pipeline.pushBack(FunctionPassID::RaiseClipsAboveShapeNodes);
+  pipeline.pushBack(getDCEPassConfig());
+
   return pipeline;
 }
 


### PR DESCRIPTION
Summary: To try to ensure that Clip ops are next to compute ops and so fusion occurs nicely, add a pass that raises Clips above shape ops such as Reshape, Transpose, and Slice. This should be one of the last passes that occurs, as other passes prior will try to sink Clips in order to eliminate unnecessary/redundant ones.

Differential Revision: D20757184

