### PR TITLE
Add OptimizeDequantizeClip

### DIFF
--- a/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
+++ b/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
@@ -52,6 +52,7 @@ FUN_PASS(FoldMatMulAddIntoFullyConnected)
 FUN_PASS(FoldSlicesIntoConstants)
 FUN_PASS(EliminateConcatSlice)
 FUN_PASS(RaiseClipsAboveShapeNodes)
+FUN_PASS(OptimizeDequantizeClip)
 
 // NOTE: This pass must be last; it's used to count the total number of passes.
 FUN_PASS(EmptyPass)

--- a/lib/Optimizer/GraphOptimizerPipeline/Pipeline.cpp
+++ b/lib/Optimizer/GraphOptimizerPipeline/Pipeline.cpp
@@ -103,6 +103,9 @@ FunctionPassPipeline glow::createDefaultGraphOptimizationPassPipeline() {
       // Run a round of constant folding.
       {FunctionPassID::ConstantFold},
 
+      // Optimize Clip(Dequantize) pattern to remove Clip.
+      {FunctionPassID::OptimizeDequantizeClip},
+
       // Fold Arithmetic chain w/ constants into Batch Norm, when Conv preceeds.
       {FunctionPassID::FoldArithmeticChainUnderConvIntoBN,
        ConvergenceMode::OnePass,


### PR DESCRIPTION
Summary: When using both FP16 and Int8 in a Function, we may encounter a pattern where a Clip follows Dequantize. This is unnecessary as both restrict the range of results, so we can eliminate the Clip and merge its min/max into the quantized range of the op being dequantized.

Differential Revision: D20758587

