### PR TITLE
[GraphOptimizer] Implement OptimizeOutIntermediateConversions

### DIFF
--- a/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
+++ b/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
@@ -53,6 +53,7 @@ FUN_PASS(FoldSlicesIntoConstants)
 FUN_PASS(EliminateConcatSlice)
 FUN_PASS(RaiseClipsAboveShapeNodes)
 FUN_PASS(OptimizeQuantizeClip)
+FUN_PASS(OptimizeOutIntermediateConversions)
 
 // NOTE: This pass must be last; it's used to count the total number of passes.
 FUN_PASS(EmptyPass)

--- a/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
+++ b/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
@@ -52,7 +52,7 @@ FUN_PASS(FoldMatMulAddIntoFullyConnected)
 FUN_PASS(FoldSlicesIntoConstants)
 FUN_PASS(EliminateConcatSlice)
 FUN_PASS(RaiseClipsAboveShapeNodes)
-FUN_PASS(OptimizeDequantizeClip)
+FUN_PASS(OptimizeQuantizeClip)
 
 // NOTE: This pass must be last; it's used to count the total number of passes.
 FUN_PASS(EmptyPass)

--- a/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
+++ b/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
@@ -52,6 +52,7 @@ FUN_PASS(FoldMatMulAddIntoFullyConnected)
 FUN_PASS(FoldSlicesIntoConstants)
 FUN_PASS(EliminateConcatSlice)
 FUN_PASS(RaiseClipsAboveShapeNodes)
+FUN_PASS(OptimizeDequantizeClip)
 
 // NOTE: This pass must be last; it's used to count the total number of passes.
 FUN_PASS(EmptyPass)

--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -1048,6 +1048,10 @@ FunctionPassPipeline NNPIBackend::getOptimizationPipeline() const {
   // occurs. Note that we do this last as it may counteract some earlier
   // optimizations that push Clips down to try to eliminate them.
   pipeline.pushBack(FunctionPassID::RaiseClipsAboveShapeNodes);
+
+  // Optimize away intermediate conversions, e.g. Quantize(ConvertTo(Node)) ->
+  // Quantize(Node).
+  pipeline.pushBack(FunctionPassID::OptimizeOutIntermediateConversions);
   pipeline.pushBack(getDCEPassConfig());
 
   return pipeline;

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -3071,6 +3071,37 @@ bool OptimizeConversions::run(Function *F, const CompilationContext &cctx) {
   return changed;
 }
 
+/// Optimize Quantize(ConvertTo(Node)) -> Quantize(Node), where Quantize is
+/// int8. This may have numerical differences but since Int8 has a small range
+/// it's likely fine. This is opt in by a backend.
+bool OptimizeOutIntermediateConversions::run(Function *F,
+                                             const CompilationContext &cctx) {
+  LOG_SCOPE(F->getLogContext(), getName());
+
+  bool changed = false;
+  for (auto &node : F->getNodes()) {
+    QuantizeNode *QN = llvm::dyn_cast<QuantizeNode>(&node);
+    if (!QN ||
+        QN->getResult().getType()->getElementType() != ElemKind::Int8QTy) {
+      continue;
+    }
+
+    ConvertToNode *CN = llvm::dyn_cast<ConvertToNode>(QN->getInput());
+    if (!CN) {
+      continue;
+    }
+
+    if (CN->getNumUsers() != 1) {
+      continue;
+    }
+
+    QN->setNthInput(QuantizeNode::InputIdx, CN->getInput());
+    changed = true;
+  }
+
+  return changed;
+}
+
 /// \returns a cloned version of node \p N, but with each of the cloned node's
 /// output types set to the corresponding type in \p types. The new node is
 /// added to Function \p F.

--- a/lib/Optimizer/GraphOptimizerPipeline/Pipeline.cpp
+++ b/lib/Optimizer/GraphOptimizerPipeline/Pipeline.cpp
@@ -103,6 +103,9 @@ FunctionPassPipeline glow::createDefaultGraphOptimizationPassPipeline() {
       // Run a round of constant folding.
       {FunctionPassID::ConstantFold},
 
+      // Optimize Clip(Dequantize) pattern to remove Clip.
+      {FunctionPassID::OptimizeDequantizeClip},
+
       // Fold Arithmetic chain w/ constants into Batch Norm, when Conv preceeds.
       {FunctionPassID::FoldArithmeticChainUnderConvIntoBN,
        ConvergenceMode::OnePass,

--- a/lib/Optimizer/GraphOptimizerPipeline/Pipeline.cpp
+++ b/lib/Optimizer/GraphOptimizerPipeline/Pipeline.cpp
@@ -103,8 +103,8 @@ FunctionPassPipeline glow::createDefaultGraphOptimizationPassPipeline() {
       // Run a round of constant folding.
       {FunctionPassID::ConstantFold},
 
-      // Optimize Clip(Dequantize) pattern to remove Clip.
-      {FunctionPassID::OptimizeDequantizeClip},
+      // Optimize combinations of Quantized Nodes and Clips.
+      {FunctionPassID::OptimizeQuantizeClip},
 
       // Fold Arithmetic chain w/ constants into Batch Norm, when Conv preceeds.
       {FunctionPassID::FoldArithmeticChainUnderConvIntoBN,


### PR DESCRIPTION
Summary: When using both FP16 and Int8 in a Function, we may encounter a pattern where a Quantize follows a ConvertTo FP16. This is unnecessary as we are narrowing the range even further when we're quantizing to Int8. Optimize this in `OptimizeOutIntermediateConversions` and make it opt in, with NNPI opting in.

Differential Revision: D20761433

