### PR TITLE
[NNPI] Propagate/setup CompilationHints

### DIFF
--- a/lib/Backends/NNPI/NNPI.h
+++ b/lib/Backends/NNPI/NNPI.h
@@ -79,5 +79,11 @@ private:
   static NNPIAdapterContainer adapter_;
 };
 
+/// These are used for parsing backend-specific node options.
+constexpr char numParallelChunksKey[] = "NNPI_numParallelChunks";
+constexpr char parallelTransformKindKey[] = "NNPI_parallelTransformKind";
+constexpr char extraEdgesKey[] = "NNPI_extraEdges";
+constexpr char coreAssignmentsKey[] = "NNPI_coreAssignments";
+
 } // namespace glow
 #endif // GLOW_NNPI_BACKEND_H

--- a/lib/Backends/NNPI/NNPICompiledFunction.h
+++ b/lib/Backends/NNPI/NNPICompiledFunction.h
@@ -93,6 +93,12 @@ private:
 
   Error updateCompilationConfigFromOptions(
       NNPICompilationOptions &compilationOptions);
+
+  /// Setup compilation hints for \p F given \p backendSpecificNodeInfo.
+  /// \returns an error if some validation issue is found given expected format.
+  Error
+  setupCompilationHints(const Function *F,
+                        const BackendSpecificNodeInfo &backendSpecificNodeInfo);
   ///@}
 };
 } // end namespace glow


### PR DESCRIPTION
Summary: Now that we have backend-specific per-node options setup, we can propagate them into NNPI CompilationHints.

Differential Revision: D20754375

