### PR TITLE
Add option to load network inputs from tensor blobs.

### DIFF
--- a/include/glow/Base/Image.h
+++ b/include/glow/Base/Image.h
@@ -21,6 +21,7 @@
 #endif
 
 #include "glow/Base/Tensor.h"
+#include "glow/Base/Type.h"
 
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"

--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -21,7 +21,6 @@
 #include <vector>
 
 #include "glow/Base/DeviceTensorTransferManager.h"
-#include "glow/Base/TensorSerialization.h"
 #include "glow/Base/Type.h"
 #include "glow/Support/Compiler.h"
 #include "glow/Support/Memory.h"

--- a/lib/Base/TensorSerialization.cpp
+++ b/lib/Base/TensorSerialization.cpp
@@ -15,12 +15,15 @@
  */
 
 #include "glow/Base/TensorSerialization.h"
+#include "glow/Base/Image.h"
+#include "glow/Graph/Graph.h"
 
+#include "llvm/Support/CommandLine.h"
 #include <fstream>
 
 using namespace glow;
 
-namespace {
+namespace glow {
 
 /// Helper method to dump the tensor content into a raw text file.
 template <class ElemTy>
@@ -33,6 +36,50 @@ static void dumpToRawTextFileImpl(Handle<ElemTy> handle,
     fs << handle.raw(idx) << ", ";
   }
   fs.close();
+}
+
+/// Helper method to load tensor files into the model input tensor.
+static void loadTensorFromFileWithType(Tensor &T, llvm::StringRef filename,
+                                       ImageLayout imageLayout) {
+  std::ifstream infile(filename.str().c_str());
+  CHECK(infile.is_open()) << "Error opening file '" << filename.data() << "'!";
+  std::string line;
+  ShapeVector dims;
+
+  CHECK(std::getline(infile, line)) << "Failed to read 1st line";
+  std::stringstream ss(line);
+  for (dim_t i = 0; i < 4; i++) {
+    int val;
+    CHECK(ss >> val) << "Failed to read dimension " << i;
+    dims.push_back(val);
+  }
+  T.reset(ElemKind::FloatTy, dims);
+  // Now read the tensor.
+  CHECK(std::getline(infile, line)) << "Failed to read 2nd line";
+  auto H = T.getHandle<>();
+  std::stringstream ss2(line);
+  for (dim_t i = 0, e = H.size(); i < e; i++) {
+    float val;
+    CHECK(ss2 >> val) << "Error loading file " << filename.data()
+                      << " @ element " << i;
+    H.raw(i) = val;
+  }
+  // Convert to requested layout (tensor blob is in NCHW by default).
+  if (imageLayout == ImageLayout::NHWC) {
+    Tensor transposed;
+    T.transpose(&transposed, NCHW2NHWC);
+    T = std::move(transposed);
+  }
+}
+
+/// Set default tensor loader.
+static InputTensorFileLoaderFn inputTensorFileLoader_ =
+    loadTensorFromFileWithType;
+
+} // namespace glow
+
+void glow::registerInputTensorFileLoader(InputTensorFileLoaderFn loader) {
+  inputTensorFileLoader_ = loader;
 }
 
 /// Helper method to load the tensor content from a raw text file.
@@ -66,7 +113,6 @@ static void loadFromRawTextFileImpl(Handle<ElemTy> handle,
                       << handle.actualSize() << " elements!";
   fs.close();
 }
-} // namespace
 
 void glow::dumpToRawBinaryFile(Tensor &tensor, llvm::StringRef filename) {
   std::ofstream fs;
@@ -161,5 +207,67 @@ void glow::loadFromRawTextFile(Tensor &tensor, llvm::StringRef filename) {
   default:
     llvm_unreachable(
         "Tensor type not supported for loading from raw text file!");
+  }
+}
+
+void glow::loadInputImageFromFileWithType(
+    const llvm::ArrayRef<std::string> &filenames, Tensor *inputData,
+    ImageLayout imageLayout) {
+  DCHECK(!filenames.empty())
+      << "There must be at least one filename in filenames.";
+  assert((dim_t)filenames.size() == filenames.size());
+  dim_t numImages = filenames.size();
+
+  CHECK(inputTensorFileLoader_) << "tensor loader not assigned!";
+
+  // Read each tensor file into a vector of tensors.
+  std::vector<Tensor> data(numImages);
+  dim_t batchSize = 0;
+  for (dim_t n = 0; n < numImages; n++) {
+    inputTensorFileLoader_(data[n], filenames[n], imageLayout);
+    auto dims0 = data[0].dims();
+    auto dims = data[n].dims();
+    CHECK_EQ(dims0[1], dims[1]) << "Non batch dimensions must match";
+    CHECK_EQ(dims0[2], dims[2]) << "Non batch dimensions must match";
+    CHECK_EQ(dims0[3], dims[3]) << "Non batch dimensions must match";
+    batchSize += data[n].dims()[0];
+  }
+
+  // Input tensor size is known now.
+  inputData->reset(ElemKind::FloatTy, {batchSize, data[0].dims()[1],
+                                       data[0].dims()[2], data[0].dims()[3]});
+  auto IIDH = inputData->getHandle<>();
+  // Insert each loaded file (in data[] tensors) as the input tensor slices.
+  for (dim_t n = 0, e = data.size(); n < e; n++) {
+    Handle<float> H = data[n].getHandle<>();
+    IIDH.insertTensors(H, {n, 0, 0, 0});
+  }
+}
+
+/// Helper function for loadInputTensorFromFileWithType, to produce blob files.
+void glow::dumpInputTensorToFileWithType(
+    const llvm::ArrayRef<std::string> &filenames, const Tensor &T,
+    ImageLayout imageLayout) {
+  CHECK_EQ(filenames.size(), 1) << "Dumping support single file only";
+  const std::string &filename = filenames[0];
+  Tensor localTensor = T.clone();
+  // Convert to requested layout (tensor blob is in NCHW by default).
+  if (imageLayout == ImageLayout::NHWC) {
+    Tensor transposed;
+    localTensor.transpose(&transposed, NHWC2NCHW);
+    localTensor = std::move(transposed);
+  }
+  std::ofstream outfile(filename.c_str());
+  CHECK(outfile.is_open()) << "Error opening file '" << filename << "'!";
+  // write dimensions to 1st line.
+  for (dim_t i = 0; i < 4; i++) {
+    CHECK(outfile << localTensor.dims()[i] << " ")
+        << "Failed to write dimension " << i;
+  }
+  outfile << "\n";
+  // write tensor to 2nd line.
+  auto H = localTensor.getHandle<float>();
+  for (auto e : H) {
+    outfile << e << " ";
   }
 }

--- a/tests/unittests/TensorsTest.cpp
+++ b/tests/unittests/TensorsTest.cpp
@@ -16,6 +16,7 @@
 
 #include "glow/Base/Tensor.h"
 #include "glow/Base/TensorSerialization.h"
+#include "glow/Graph/Graph.h"
 #include "glow/Quantization/Base/Base.h"
 
 #include "llvm/Support/FileSystem.h"
@@ -1356,6 +1357,78 @@ TEST(Tensor, accessToRawTextFile) {
   for (size_t rcnt = 0; rcnt < tensorTest.actualSize(); rcnt++) {
     EXPECT_FLOAT_EQ(handleTest.raw(rcnt), handleRef.raw(rcnt));
   }
+}
+
+/// Testing loading of input tensors from a file.
+static void tensorInputWriterLoader(ImageLayout outImageLayout,
+                                    ImageLayout inImageLayout) {
+  Tensor tensorRef(Type{ElemKind::FloatTy, {1, 2, 4, 3}});
+  tensorRef.getHandle<>() = {0.75f,  0.23f,  0.76f,  0.99f,  1.00f, -0.78f,
+                             0.23f,  -0.97f, -0.37f, 0.00f,  0.25f, 0.13f,
+                             0.66f,  0.69f,  2.00f,  -0.18f, 0.43f, -0.92f,
+                             -0.33f, 0.01f,  0.21f,  0.11f,  0.13f, 0.87f};
+  llvm::SmallString<64> path;
+  auto tempFileRes = llvm::sys::fs::createTemporaryFile("tensor", ".txt", path);
+  if (tempFileRes.value() != 0) {
+    FAIL() << "Failed to create temp file to write into.";
+  }
+  dumpInputTensorToFileWithType({path.str()}, tensorRef, outImageLayout);
+  //
+  Tensor tensorTest;
+  loadInputImageFromFileWithType({path.str()}, &tensorTest, inImageLayout);
+
+  if (outImageLayout == ImageLayout::NHWC) {
+    Tensor transposed;
+    tensorRef.transpose(&transposed, NHWC2NCHW);
+    tensorRef = std::move(transposed);
+  }
+
+  if (inImageLayout == ImageLayout::NHWC) {
+    Tensor transposed;
+    tensorTest.transpose(&transposed, NHWC2NCHW);
+    tensorTest = std::move(transposed);
+  }
+
+  auto handleRef = tensorRef.getHandle<>();
+  auto handleTest = tensorTest.getHandle<>();
+  EXPECT_EQ(handleRef.size(), handleTest.size());
+  EXPECT_EQ(tensorRef.dims(), tensorTest.dims());
+  for (size_t rcnt = 0, e = tensorTest.actualSize(); rcnt < e; rcnt++) {
+    EXPECT_FLOAT_EQ(handleTest.raw(rcnt), handleRef.raw(rcnt));
+  }
+}
+
+TEST(Tensor, tensorInputWriterLoaderNCHW) {
+  tensorInputWriterLoader(ImageLayout::NCHW, ImageLayout::NCHW);
+}
+
+TEST(Tensor, tensorInputWriterLoaderNCHW_NHWC) {
+  tensorInputWriterLoader(ImageLayout::NCHW, ImageLayout::NHWC);
+}
+
+TEST(Tensor, tensorInputWriterLoaderNHWC_NCHW) {
+  tensorInputWriterLoader(ImageLayout::NHWC, ImageLayout::NCHW);
+}
+
+TEST(Tensor, tensorInputWriterLoaderNHWC) {
+  tensorInputWriterLoader(ImageLayout::NHWC, ImageLayout::NHWC);
+}
+
+// Test custom input tensor loader
+TEST(Tensor, tensorCustomInputLoader) {
+  bool entered = false;
+  auto loader = [&entered](Tensor &T, llvm::StringRef filename,
+                           ImageLayout imageLayout) {
+    EXPECT_EQ(imageLayout, ImageLayout::NHWC);
+    EXPECT_EQ(filename, "input.tensor");
+    T.reset(ElemKind::FloatTy, {1, 2, 3, 4});
+    entered = true;
+  };
+  Tensor testT(Type{ElemKind::Int32ITy, {4, 4, 4, 4}});
+  registerInputTensorFileLoader(loader);
+  loadInputImageFromFileWithType({"input.tensor"}, &testT, ImageLayout::NHWC);
+  EXPECT_EQ(entered, true);
+  EXPECT_EQ(testT.dims(), llvm::ArrayRef<dim_t>({1, 2, 3, 4}));
 }
 
 // Check that write/read of tensors data from/to raw-binary files is

--- a/tools/loader/ExecutorCoreHelperFunctions.cpp
+++ b/tools/loader/ExecutorCoreHelperFunctions.cpp
@@ -57,6 +57,13 @@ llvm::cl::opt<std::string> inputImageListFile(
     llvm::cl::value_desc("string_name"), llvm::cl::Optional,
     llvm::cl::cat(executorCat));
 
+llvm::cl::opt<std::string> inputTensorListFile(
+    "input-tensor-list-file",
+    llvm::cl::desc(
+        "Name of the file containing list of tensors (one tensor per line)"),
+    llvm::cl::value_desc("string_name"), llvm::cl::Optional,
+    llvm::cl::cat(executorCat));
+
 llvm::cl::opt<unsigned> miniBatch(
     "minibatch",
     llvm::cl::desc(
@@ -151,12 +158,12 @@ llvm::cl::opt<unsigned> repeatSingleBatchCount(
     llvm::cl::init(0), llvm::cl::cat(executorCat));
 
 /// Read all images from \p inputImageListFile in to \p inputImageFilenames.
-void parseInputImageList(const std::string &inputImageListFile) {
+void parseInputList(const std::string &inputListFile) {
   std::ifstream inFile;
-  inFile.open(inputImageListFile);
+  inFile.open(inputListFile);
   if (!inFile.good()) {
-    llvm::outs() << "Could not open input-image-list-file: "
-                 << inputImageListFile << ", exiting.\n";
+    llvm::outs() << "Could not open input-image-list-file: " << inputListFile
+                 << ", exiting.\n";
     std::exit(1);
   }
 

--- a/tools/loader/ExecutorCoreHelperFunctions.h
+++ b/tools/loader/ExecutorCoreHelperFunctions.h
@@ -24,6 +24,7 @@
 #include "llvm/Support/Timer.h"
 
 extern llvm::cl::opt<std::string> inputImageListFile;
+extern llvm::cl::opt<std::string> inputTensorListFile;
 extern llvm::cl::list<std::string> inputImageFilenames;
 extern llvm::cl::opt<unsigned> excludedFirstWarmupRuns;
 extern llvm::cl::opt<unsigned> warmup;
@@ -37,7 +38,7 @@ extern llvm::cl::opt<unsigned> repeatSingleBatchCount;
 extern std::unique_ptr<glow::TraceContext> traceContext;
 
 /// Read all images from \p inputImageListFile in to \p inputImageFilenames.
-void parseInputImageList(const std::string &inputImageListFile);
+void parseInputList(const std::string &inputImageListFile);
 
 /// Write a prompt to stdout asking for filenames for classification. Read in
 /// those filenames and add them to \p filenames. \p filenames is cleared before

--- a/tools/loader/ModelProfiler.cpp
+++ b/tools/loader/ModelProfiler.cpp
@@ -16,7 +16,7 @@
 
 #include "Loader.h"
 #include "LoaderUtils.h"
-
+#include "glow/Base/TensorSerialization.h"
 #include "llvm/Support/CommandLine.h"
 
 using namespace glow;


### PR DESCRIPTION
Add option `-input-tensor-list-file `which allows passing the list of tensor blobs that are to be loaded into network inputs. This is very similar to `-input-image-list-file`.

Also allows for registering a custom tensor loader in case e.g. backend wants to use it's own tensor blob format. The default used loader blob format is described in `TensorSerialization.h `

All the loaded blobs are concatenated along the batch dimensions.

Fixes #4371 

Added new tests to TensorsTests.cpp
