### PR TITLE
Add enableQuantParamChanges flag and use accordingly

### DIFF
--- a/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
+++ b/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
@@ -125,6 +125,9 @@ struct OptimizationOptions {
   /// If true does int64 to int32 type demotion if backend supports for specific
   /// nodes.
   bool enableTypeDemotion{true};
+
+  /// If true, optimizations are allowed to change quantization scale/offset.
+  bool enableQuantParamChanges{false};
 };
 
 /// Context for compilation.

--- a/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
+++ b/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
@@ -53,6 +53,7 @@ FUN_PASS(FoldSlicesIntoConstants)
 FUN_PASS(EliminateConcatSlice)
 FUN_PASS(RaiseClipsAboveShapeNodes)
 FUN_PASS(OptimizeQuantizeClip)
+FUN_PASS(OptimizeOutIntermediateConversions)
 
 // NOTE: This pass must be last; it's used to count the total number of passes.
 FUN_PASS(EmptyPass)

--- a/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
+++ b/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
@@ -52,7 +52,7 @@ FUN_PASS(FoldMatMulAddIntoFullyConnected)
 FUN_PASS(FoldSlicesIntoConstants)
 FUN_PASS(EliminateConcatSlice)
 FUN_PASS(RaiseClipsAboveShapeNodes)
-FUN_PASS(OptimizeDequantizeClip)
+FUN_PASS(OptimizeQuantizeClip)
 
 // NOTE: This pass must be last; it's used to count the total number of passes.
 FUN_PASS(EmptyPass)

--- a/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
+++ b/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
@@ -52,6 +52,7 @@ FUN_PASS(FoldMatMulAddIntoFullyConnected)
 FUN_PASS(FoldSlicesIntoConstants)
 FUN_PASS(EliminateConcatSlice)
 FUN_PASS(RaiseClipsAboveShapeNodes)
+FUN_PASS(OptimizeDequantizeClip)
 
 // NOTE: This pass must be last; it's used to count the total number of passes.
 FUN_PASS(EmptyPass)

--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -1049,6 +1049,10 @@ FunctionPassPipeline NNPIBackend::getOptimizationPipeline() const {
   // optimizations that push Clips down to try to eliminate them.
   pipeline.pushBack(FunctionPassID::RaiseClipsAboveShapeNodes);
 
+  // Optimize away intermediate conversions, e.g. Quantize(ConvertTo(Node)) ->
+  // Quantize(Node).
+  pipeline.pushBack(FunctionPassID::OptimizeOutIntermediateConversions);
+
   // Now that we've raised clips up try to optimize quantize-clip combos again.
   pipeline.pushBack(FunctionPassID::OptimizeQuantizeClip);
 

--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -1048,6 +1048,11 @@ FunctionPassPipeline NNPIBackend::getOptimizationPipeline() const {
   // occurs. Note that we do this last as it may counteract some earlier
   // optimizations that push Clips down to try to eliminate them.
   pipeline.pushBack(FunctionPassID::RaiseClipsAboveShapeNodes);
+
+  // Now that we've raised clips up try to optimize quantize-clip combos again.
+  pipeline.pushBack(FunctionPassID::OptimizeQuantizeClip);
+
+  // Cleanup everything now.
   pipeline.pushBack(getDCEPassConfig());
 
   return pipeline;

--- a/lib/Optimizer/GraphOptimizerPipeline/Pipeline.cpp
+++ b/lib/Optimizer/GraphOptimizerPipeline/Pipeline.cpp
@@ -103,6 +103,9 @@ FunctionPassPipeline glow::createDefaultGraphOptimizationPassPipeline() {
       // Run a round of constant folding.
       {FunctionPassID::ConstantFold},
 
+      // Optimize Clip(Dequantize) pattern to remove Clip.
+      {FunctionPassID::OptimizeDequantizeClip},
+
       // Fold Arithmetic chain w/ constants into Batch Norm, when Conv preceeds.
       {FunctionPassID::FoldArithmeticChainUnderConvIntoBN,
        ConvergenceMode::OnePass,

--- a/lib/Optimizer/GraphOptimizerPipeline/Pipeline.cpp
+++ b/lib/Optimizer/GraphOptimizerPipeline/Pipeline.cpp
@@ -103,8 +103,8 @@ FunctionPassPipeline glow::createDefaultGraphOptimizationPassPipeline() {
       // Run a round of constant folding.
       {FunctionPassID::ConstantFold},
 
-      // Optimize Clip(Dequantize) pattern to remove Clip.
-      {FunctionPassID::OptimizeDequantizeClip},
+      // Optimize combinations of Quantized Nodes and Clips.
+      {FunctionPassID::OptimizeQuantizeClip},
 
       // Fold Arithmetic chain w/ constants into Batch Norm, when Conv preceeds.
       {FunctionPassID::FoldArithmeticChainUnderConvIntoBN,


### PR DESCRIPTION
Summary: Instead of blindly changing quantization parameters in graph optimizations, make it opt-in based on setting `cctx.optimizationOpts.enableQuantParamChanges = true` (defaults to false).

Differential Revision: D20790667

