### PR TITLE
Fix duplicated converter insertion when importing ChannelwiseQuantizedConvolutionNode

### DIFF
--- a/lib/Backends/NNPI/Importer.cpp
+++ b/lib/Backends/NNPI/Importer.cpp
@@ -1474,23 +1474,29 @@ public:
     std::string convertInputName = NNPIImporter::internalName_ +
                                    glowRowwiseFC->getName().begin() +
                                    "_convert_input";
-    LOG_NNPI_IF_ERROR_RETURN_VALUE(
-        nnpiNetworkAddConvertOp(
-            importer.getNetwork(), convertInputName.c_str(),
-            nodeValueName(glowRowwiseFC->getInput()).c_str(),
-            symlowpInputName.c_str()),
-        "Failed to add layer");
+    std::string convertInputInputName =
+        nodeValueName(glowRowwiseFC->getInput());
+    if (!importer.hasChannelWiseConverter(convertInputInputName)) {
+      LOG_NNPI_IF_ERROR_RETURN_VALUE(
+          nnpiNetworkAddConvertOp(
+              importer.getNetwork(), convertInputName.c_str(),
+              convertInputInputName.c_str(), symlowpInputName.c_str()),
+          "Failed to add layer");
+      importer.addChannelWiseConverter(convertInputInputName);
+    }
 
     // Add convert op from Symlowp output to Gemmlowp.
     std::string convertOutputName = NNPIImporter::internalName_ +
                                     glowRowwiseFC->getName().begin() +
                                     "_convert_output";
+    std::string convertOutputOutputName =
+        nodeValueName(glowRowwiseFC->getResult());
     LOG_NNPI_IF_ERROR_RETURN_VALUE(
         nnpiNetworkAddConvertOp(
             importer.getNetwork(), convertOutputName.c_str(),
-            symlowpOutputName.c_str(),
-            nodeValueName(glowRowwiseFC->getResult()).c_str()),
+            symlowpOutputName.c_str(), convertOutputOutputName.c_str()),
         "Failed to add layer");
+    importer.addChannelWiseConverter(convertOutputOutputName);
 
     // Create the weights with no offset tensor.
     // Assert weights & biases have no offset or all zeroes.
@@ -1635,23 +1641,29 @@ public:
     std::string convertInputName =
         NNPIImporter::internalName_ +
         glowChannelwiseQuantizedConv->getName().begin() + "_convert_input";
-    LOG_NNPI_IF_ERROR_RETURN_VALUE(
-        nnpiNetworkAddConvertOp(
-            importer.getNetwork(), convertInputName.c_str(),
-            nodeValueName(glowChannelwiseQuantizedConv->getInput()).c_str(),
-            symlowpInputName.c_str()),
-        "Failed to add layer");
+    std::string convertInputInputName =
+        nodeValueName(glowChannelwiseQuantizedConv->getInput());
+    if (!importer.hasChannelWiseConverter(convertInputInputName)) {
+      LOG_NNPI_IF_ERROR_RETURN_VALUE(
+          nnpiNetworkAddConvertOp(
+              importer.getNetwork(), convertInputName.c_str(),
+              convertInputInputName.c_str(), symlowpInputName.c_str()),
+          "Failed to add layer");
+      importer.addChannelWiseConverter(convertInputInputName);
+    }
 
     // Add convert op from Symlowp output to Gemmlowp.
     std::string convertOutputName =
         NNPIImporter::internalName_ +
         glowChannelwiseQuantizedConv->getName().begin() + "_convert_output";
+    std::string convertOutputOutputName =
+        nodeValueName(glowChannelwiseQuantizedConv->getResult());
     LOG_NNPI_IF_ERROR_RETURN_VALUE(
         nnpiNetworkAddConvertOp(
             importer.getNetwork(), convertOutputName.c_str(),
-            symlowpOutputName.c_str(),
-            nodeValueName(glowChannelwiseQuantizedConv->getResult()).c_str()),
+            symlowpOutputName.c_str(), convertOutputOutputName.c_str()),
         "Failed to add layer");
+    importer.addChannelWiseConverter(convertOutputOutputName);
 
     // Create the weights with no offset tensor.
     // Assert weights & biases have no offset or all zeroes.

--- a/lib/Backends/NNPI/Importer.h
+++ b/lib/Backends/NNPI/Importer.h
@@ -96,6 +96,16 @@ public:
   /// Internal name header used for variables.
   static const std::string internalName_;
 
+  /// Check whether a variable name is in the channelwiseConverters_ set.
+  bool hasChannelWiseConverter(const std::string &s) const {
+    return channelwiseConverters_.count(s);
+  }
+
+  /// Add a new (gemmlowp) variable name to the channelwiseConverters_ set.
+  void addChannelWiseConverter(const std::string &s) {
+    channelwiseConverters_.emplace(s);
+  }
+
 private:
   /// Map of named external tensors (inputs, outputs, weights, etc...).
   std::unordered_map<std::string, const Tensor *> constants_;
@@ -117,6 +127,14 @@ private:
       nodeImporters_;
   /// NNPI Device configuration.
   const NNPICompilationOptions &compileOptions_;
+
+  /// This set records all the gemmlowp variables that we created for
+  /// channelwise FC/Conv operator inputs/ouputs. When an variable name appears
+  /// in this set, it means that a (gemmlowp -> symlowp) converter has already
+  /// created. Querying of this can help us create duplicated converters when 1.
+  /// an input is feeding into more than one channelwise ops. 2. an output of
+  /// one channelwise op is consumed by another channelwise op.
+  std::unordered_set<std::string> channelwiseConverters_;
 };
 
 /// Interface class for all node specific importers.


### PR DESCRIPTION
Summary:
When we import ChannelwiseQuantizedConvolutionNode, we will create a chain like this
input -> [Convert] -> input_symlowp -> [Conv] -> output_symlowp -> [Convert] -> output

This doesn't work well when
- An input is fed into two ChannelwiseQuantizedConvolutionNode, where we will create `ChannelwiseQuantizedConvolutionNode` twice
- An output of ChannelwiseQuantizedConvolutionNode is fed into another ChannelwiseQuantizedConvolutionNode. output_symlowp of the first conv will be of the same name as input_symlowp of the second Conv hence we have a multi-producer race.

Solution here is basically remember the gemmlowp tensors so that we can avoid duplicated conversion.

Differential Revision: D20812887

