### PR TITLE
Add OptimizeQuantFCFloatRelu

### DIFF
--- a/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
+++ b/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
@@ -54,6 +54,7 @@ FUN_PASS(EliminateConcatSlice)
 FUN_PASS(RaiseClipsAboveShapeNodes)
 FUN_PASS(OptimizeQuantizeClip)
 FUN_PASS(OptimizeOutIntermediateConversions)
+FUN_PASS(OptimizeQuantFCFloatRelu)
 
 // NOTE: This pass must be last; it's used to count the total number of passes.
 FUN_PASS(EmptyPass)

--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -1059,6 +1059,9 @@ FunctionPassPipeline NNPIBackend::getOptimizationPipeline() const {
   // Now try to eliminate any redundant Clips.
   pipeline.pushBack(FunctionPassID::OptimizeClips);
 
+  // Look for float Relus that we can fuse up into quantized FCs.
+  pipeline.pushBack(FunctionPassID::OptimizeQuantFCFloatRelu);
+
   // Cleanup everything now.
   pipeline.pushBack(getDCEPassConfig());
 


### PR DESCRIPTION
Summary:
Look for an FP relu following a quantized FC, or an FP relu following a concat of multiple quantized FCs, and move the relu up to right after the FC for good fusion.

Note that this changes the numerics of the Function if fusion does occur by the backend, as the FC's output range has changed. Hence I for now made it opt in by backends (NNPI uses it currently) --- I could set the opt to instead be enabled when `enableQuantParamChanges`, as it may make more sense to enable it on a per-model basis.

Technically I think this should be more accurate, but it will differ from reference implementations. This is as jackm321 found for Convs.

Differential Revision: D20831489

