### PR TITLE
Only parallelize RELU when its input was parallelized, and extend NNPI-specific opt pipeline

### DIFF
--- a/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
+++ b/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
@@ -55,6 +55,7 @@ FUN_PASS(RaiseClipsAboveShapeNodes)
 FUN_PASS(OptimizeQuantizeClip)
 FUN_PASS(OptimizeOutIntermediateConversions)
 FUN_PASS(OptimizeQuantFCFloatRelu)
+FUN_PASS(OptimizeConcatQuantization)
 
 // NOTE: This pass must be last; it's used to count the total number of passes.
 FUN_PASS(EmptyPass)

--- a/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
+++ b/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
@@ -54,6 +54,7 @@ FUN_PASS(EliminateConcatSlice)
 FUN_PASS(RaiseClipsAboveShapeNodes)
 FUN_PASS(OptimizeQuantizeClip)
 FUN_PASS(OptimizeOutIntermediateConversions)
+FUN_PASS(OptimizeQuantFCFloatRelu)
 
 // NOTE: This pass must be last; it's used to count the total number of passes.
 FUN_PASS(EmptyPass)

--- a/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
+++ b/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
@@ -20,6 +20,7 @@
 
 FUN_PASS(DCE)
 FUN_PASS(SinkCode)
+FUN_PASS(SinkConversions)
 FUN_PASS(MergeMatMul)
 FUN_PASS(MergePadIntoConvolution)
 FUN_PASS(MergeTransposeIntoMatMulOrFC)

--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -1062,6 +1062,12 @@ FunctionPassPipeline NNPIBackend::getOptimizationPipeline() const {
   // Look for float Relus that we can fuse up into quantized FCs.
   pipeline.pushBack(FunctionPassID::OptimizeQuantFCFloatRelu);
 
+  // Optimize concats and quantized/dequantize patterns.
+  pipeline.pushBack(FunctionPassID::OptimizeConcatQuantization);
+
+  // Optimize quantization now that we've optimized some other quant nodes.
+  pipeline.pushBack(FunctionPassID::OptimizeQuantization);
+
   // Cleanup everything now.
   pipeline.pushBack(getDCEPassConfig());
 

--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -1068,6 +1068,12 @@ FunctionPassPipeline NNPIBackend::getOptimizationPipeline() const {
   // Optimize quantization now that we've optimized some other quant nodes.
   pipeline.pushBack(FunctionPassID::OptimizeQuantization);
 
+  // Now try to sink conversions below concats.
+  pipeline.pushBack(FunctionPassID::SinkConversions);
+
+  // Now that things have been sunk try to get rid of unnecessary concats.
+  pipeline.pushBack(FunctionPassID::OptimizeConcatNodes);
+
   // Cleanup everything now.
   pipeline.pushBack(getDCEPassConfig());
 

--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -17,6 +17,7 @@
 #include "NNPICompiledFunction.h"
 #include "NNPIDeviceManager.h"
 #include "glow/Graph/Nodes.h"
+#include "glow/Graph/Utils.h"
 #include "glow/Optimizer/GraphOptimizer/GraphOptimizer.h"
 #include "glow/Optimizer/GraphOptimizerPipeline/Pipeline.h"
 #include "glow/Optimizer/Lower/Lower.h"
@@ -507,149 +508,120 @@ static void setupBasicParallelizationConfigs(
     Function *F, llvm::DenseMap<Node *, size_t> &numChunks,
     llvm::DenseMap<Node *, ParallelTransformKind> &parOpts,
     int32_t numParallelChunks) {
-  // Find all FC layers to split
-  for (auto &node : F->getNodes()) {
-    auto *FC = llvm::dyn_cast<FullyConnectedNode>(&node);
-    if (!FC) {
-      continue;
-    }
-    size_t K = FC->getWeights().dims()[1];
-    if (K >= 512) {
-      parOpts[FC] = ParallelTransformKind::Model;
-      numChunks[FC] = numParallelChunks;
-      continue;
-    }
-    size_t M = FC->getInput().dims()[0];
-    if (M >= 256) {
-      parOpts[FC] = ParallelTransformKind::Data;
-      numChunks[FC] = numParallelChunks;
-      continue;
-    }
-  }
-
-  // Relu parallelization.
-  // If a Relu follows FC, mirror FC split so that they fuse.
-  // Otherwise, use data parallelism.
-  for (auto &node : F->getNodes()) {
-    auto *R = llvm::dyn_cast<ReluNode>(&node);
-    if (!R) {
-      continue;
+  // Process nodes PostOrder so we always process inputs before outputs of any
+  // Node, so parallelization can be based on if a parent is parallelized.
+  GraphPostOrderVisitor visitor(*F);
+  for (auto *N : visitor.getPostOrder()) {
+    // Find all FC layers to split
+    if (auto *FC = llvm::dyn_cast<FullyConnectedNode>(N)) {
+      size_t K = FC->getWeights().dims()[1];
+      if (K >= 512) {
+        parOpts[FC] = ParallelTransformKind::Model;
+        numChunks[FC] = numParallelChunks;
+        continue;
+      }
+      size_t M = FC->getInput().dims()[0];
+      if (M >= 256) {
+        parOpts[FC] = ParallelTransformKind::Data;
+        numChunks[FC] = numParallelChunks;
+        continue;
+      }
     }
 
-    // For Relus that arent preceded by FC, do data parallelism
-    Node *inputNode = R->getInput().getNode();
-    auto FC = llvm::dyn_cast<FullyConnectedNode>(inputNode);
-    if (!FC) {
-      parOpts[R] = ParallelTransformKind::Data;
-      numChunks[R] = numParallelChunks;
-      continue;
+    // Relu parallelization.
+    // If a Relu follows FC, mirror FC split so that they fuse.
+    // Otherwise, use data parallelism.
+    if (auto *R = llvm::dyn_cast<ReluNode>(N)) {
+      // For Relus that arent preceded by FC, do data parallelism if the input
+      // was parallelized.
+      Node *inputNode = R->getInput().getNode();
+      auto FC = llvm::dyn_cast<FullyConnectedNode>(inputNode);
+      if (!FC) {
+        if (numChunks.find(inputNode) != numChunks.end() &&
+            parOpts.find(inputNode) != parOpts.end()) {
+          parOpts[R] = ParallelTransformKind::Data;
+          numChunks[R] = numParallelChunks;
+        }
+        continue;
+      }
+
+      // Otherwise, mirror FC split.
+      if (R->getInput().dims().size() < 2) {
+        continue;
+      }
+      size_t K = R->getInput().dims()[1];
+      if (K >= 512) {
+        parOpts[R] = ParallelTransformKind::Model;
+        numChunks[R] = numParallelChunks;
+        continue;
+      }
+      size_t M = R->getInput().dims()[0];
+      if (M >= 256) {
+        parOpts[R] = ParallelTransformKind::Data;
+        numChunks[R] = numParallelChunks;
+        continue;
+      }
     }
 
-    // Otherwise, mirror FC split.
-    if (R->getInput().dims().size() < 2) {
-      continue;
-    }
-    size_t K = R->getInput().dims()[1];
-    if (K >= 512) {
-      parOpts[R] = ParallelTransformKind::Model;
-      numChunks[R] = numParallelChunks;
-      continue;
-    }
-    size_t M = R->getInput().dims()[0];
-    if (M >= 256) {
-      parOpts[R] = ParallelTransformKind::Data;
-      numChunks[R] = numParallelChunks;
-      continue;
-    }
-  }
-
-  // Split transpose layers in data parallel fashion
-  for (auto &node : F->getNodes()) {
-    auto *TP = llvm::dyn_cast<TransposeNode>(&node);
-    if (!TP) {
-      continue;
-    }
-    parOpts[TP] = ParallelTransformKind::Data;
-    numChunks[TP] = numParallelChunks;
-  }
-
-  // Split Quantize layers in data parallel fashion
-  for (auto &node : F->getNodes()) {
-    auto *QN = llvm::dyn_cast<QuantizeNode>(&node);
-    if (!QN) {
-      continue;
-    }
-    parOpts[QN] = ParallelTransformKind::Data;
-    numChunks[QN] = numParallelChunks;
-  }
-
-  // Split Dequantize layers in data parallel fashion
-  for (auto &node : F->getNodes()) {
-    auto *DQN = llvm::dyn_cast<DequantizeNode>(&node);
-    if (!DQN) {
-      continue;
-    }
-    parOpts[DQN] = ParallelTransformKind::Data;
-    numChunks[DQN] = numParallelChunks;
-  }
-
-  // Split BMM layers in data parallel fashion
-  for (auto &node : F->getNodes()) {
-    auto *BMM = llvm::dyn_cast<BatchMatMulNode>(&node);
-    if (!BMM) {
-      continue;
-    }
-    parOpts[BMM] = ParallelTransformKind::Data;
-    numChunks[BMM] = numParallelChunks;
-  }
-
-  // Split Tanh layers in data parallel fashion
-  for (auto &node : F->getNodes()) {
-    auto *TH = llvm::dyn_cast<TanhNode>(&node);
-    if (!TH) {
-      continue;
-    }
-    if (TH->getInput().dims().size() < 2) {
-      continue;
-    }
-    size_t N = TH->getInput().dims()[1];
-    if (N < 4096) {
-      continue;
-    }
-    parOpts[TH] = ParallelTransformKind::Data;
-    numChunks[TH] = numParallelChunks;
-  }
-
-  // Split Mul layers in data parallel fashion
-  for (auto &node : F->getNodes()) {
-    auto *M = llvm::dyn_cast<MulNode>(&node);
-    if (!M) {
-      continue;
-    }
-    if (M->getLHS().dims().size() < 2) {
-      continue;
-    }
-    size_t N = M->getLHS().dims()[1];
-    if (N < 4096) {
-      continue;
-    }
-    parOpts[M] = ParallelTransformKind::Data;
-    numChunks[M] = numParallelChunks;
-  }
-
-  // Clip parallelization.
-  // If a Clip follows a parallel op, mirror that.
-  for (auto &node : F->getNodes()) {
-    auto *C = llvm::dyn_cast<ClipNode>(&node);
-    if (!C) {
-      continue;
+    // Split transpose layers in data parallel fashion
+    if (auto *TP = llvm::dyn_cast<TransposeNode>(N)) {
+      parOpts[TP] = ParallelTransformKind::Data;
+      numChunks[TP] = numParallelChunks;
     }
 
-    Node *inputNode = C->getInput().getNode();
-    if (numChunks.find(inputNode) != numChunks.end() &&
-        parOpts.find(inputNode) != parOpts.end()) {
-      parOpts[C] = parOpts[inputNode];
-      numChunks[C] = numChunks[inputNode];
+    // Split Quantize layers in data parallel fashion
+    if (auto *QN = llvm::dyn_cast<QuantizeNode>(N)) {
+      parOpts[QN] = ParallelTransformKind::Data;
+      numChunks[QN] = numParallelChunks;
+    }
+
+    // Split Dequantize layers in data parallel fashion
+    if (auto *DQN = llvm::dyn_cast<DequantizeNode>(N)) {
+      parOpts[DQN] = ParallelTransformKind::Data;
+      numChunks[DQN] = numParallelChunks;
+    }
+
+    // Split BMM layers in data parallel fashion
+    if (auto *BMM = llvm::dyn_cast<BatchMatMulNode>(N)) {
+      parOpts[BMM] = ParallelTransformKind::Data;
+      numChunks[BMM] = numParallelChunks;
+    }
+
+    // Split Tanh layers in data parallel fashion
+    if (auto *TH = llvm::dyn_cast<TanhNode>(N)) {
+      if (TH->getInput().dims().size() < 2) {
+        continue;
+      }
+      size_t N = TH->getInput().dims()[1];
+      if (N < 4096) {
+        continue;
+      }
+      parOpts[TH] = ParallelTransformKind::Data;
+      numChunks[TH] = numParallelChunks;
+    }
+
+    // Split Mul layers in data parallel fashion
+    if (auto *M = llvm::dyn_cast<MulNode>(N)) {
+      if (M->getLHS().dims().size() < 2) {
+        continue;
+      }
+      size_t N = M->getLHS().dims()[1];
+      if (N < 4096) {
+        continue;
+      }
+      parOpts[M] = ParallelTransformKind::Data;
+      numChunks[M] = numParallelChunks;
+    }
+
+    // Clip parallelization.
+    // If a Clip follows a parallel op, mirror that.
+    if (auto *C = llvm::dyn_cast<ClipNode>(N)) {
+      Node *inputNode = C->getInput().getNode();
+      if (numChunks.find(inputNode) != numChunks.end() &&
+          parOpts.find(inputNode) != parOpts.end()) {
+        parOpts[C] = parOpts[inputNode];
+        numChunks[C] = numChunks[inputNode];
+      }
     }
   }
 }
@@ -1073,6 +1045,12 @@ FunctionPassPipeline NNPIBackend::getOptimizationPipeline() const {
 
   // Now that things have been sunk try to get rid of unnecessary concats.
   pipeline.pushBack(FunctionPassID::OptimizeConcatNodes);
+
+  // Look for float Relus that we can fuse up into quantized FCs.
+  pipeline.pushBack(FunctionPassID::OptimizeQuantFCFloatRelu);
+
+  // Optimize concats and quantized/dequantize patterns.
+  pipeline.pushBack(FunctionPassID::OptimizeConcatQuantization);
 
   // Cleanup everything now.
   pipeline.pushBack(getDCEPassConfig());

--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -1059,6 +1059,9 @@ FunctionPassPipeline NNPIBackend::getOptimizationPipeline() const {
   // Now try to eliminate any redundant Clips.
   pipeline.pushBack(FunctionPassID::OptimizeClips);
 
+  // Look for float Relus that we can fuse up into quantized FCs.
+  pipeline.pushBack(FunctionPassID::OptimizeQuantFCFloatRelu);
+
   // Cleanup everything now.
   pipeline.pushBack(getDCEPassConfig());
 

--- a/lib/Optimizer/GraphOptimizerPipeline/Pipeline.cpp
+++ b/lib/Optimizer/GraphOptimizerPipeline/Pipeline.cpp
@@ -97,6 +97,9 @@ FunctionPassPipeline glow::createDefaultGraphOptimizationPassPipeline() {
       // Optimize quantization related operators.
       {FunctionPassID::OptimizeQuantization, ConvergenceMode::UntilFixedPoint},
 
+      // Optimize patterns of concats with quantization/dequantization.
+      {FunctionPassID::OptimizeConcatQuantization},
+
       // Optimize reshapes introduced during above optimizations.
       {FunctionPassID::OptimizeReshape},
 

--- a/tests/unittests/NNPIOptPipelineTest.cpp
+++ b/tests/unittests/NNPIOptPipelineTest.cpp
@@ -158,12 +158,12 @@ TEST_F(NNPIOptPipelineTest, SplitParallelizationTestFCReluNNPI) {
       std::to_string(8);
   cloneAndCompile();
 
-  EXPECT_TRUE((F_->getNodes().size() < optimizedF_->getNodes().size()));
-  EXPECT_TRUE(countNodeKind(F_, Kinded::Kind::FullyConnectedNodeKind) == 1);
-  EXPECT_TRUE(
-      countNodeKind(optimizedF_, Kinded::Kind::FullyConnectedNodeKind) == 8);
-  EXPECT_TRUE(countNodeKind(F_, Kinded::Kind::ReluNodeKind) == 1);
-  EXPECT_TRUE(countNodeKind(optimizedF_, Kinded::Kind::ReluNodeKind) == 8);
+  EXPECT_LT(F_->getNodes().size(), optimizedF_->getNodes().size());
+  EXPECT_EQ(countNodeKind(F_, Kinded::Kind::FullyConnectedNodeKind), 1);
+  EXPECT_EQ(countNodeKind(optimizedF_, Kinded::Kind::FullyConnectedNodeKind),
+            8);
+  EXPECT_EQ(countNodeKind(F_, Kinded::Kind::ReluNodeKind), 1);
+  EXPECT_EQ(countNodeKind(optimizedF_, Kinded::Kind::ReluNodeKind), 8);
 
   SaveNode *optSave = nullptr;
   for (auto &N : optimizedF_->getNodes()) {
@@ -202,14 +202,14 @@ TEST_F(NNPIOptPipelineTest, SplitParallelizationTestFCReluClipNNPI) {
       std::to_string(8);
   cloneAndCompile();
 
-  EXPECT_TRUE((F_->getNodes().size() < optimizedF_->getNodes().size()));
-  EXPECT_TRUE(countNodeKind(F_, Kinded::Kind::FullyConnectedNodeKind) == 1);
-  EXPECT_TRUE(
-      countNodeKind(optimizedF_, Kinded::Kind::FullyConnectedNodeKind) == 8);
-  EXPECT_TRUE(countNodeKind(F_, Kinded::Kind::ReluNodeKind) == 1);
-  EXPECT_TRUE(countNodeKind(optimizedF_, Kinded::Kind::ReluNodeKind) == 8);
-  EXPECT_TRUE(countNodeKind(F_, Kinded::Kind::ClipNodeKind) == 1);
-  EXPECT_TRUE(countNodeKind(optimizedF_, Kinded::Kind::ClipNodeKind) == 8);
+  EXPECT_LT(F_->getNodes().size(), optimizedF_->getNodes().size());
+  EXPECT_EQ(countNodeKind(F_, Kinded::Kind::FullyConnectedNodeKind), 1);
+  EXPECT_EQ(countNodeKind(optimizedF_, Kinded::Kind::FullyConnectedNodeKind),
+            8);
+  EXPECT_EQ(countNodeKind(F_, Kinded::Kind::ReluNodeKind), 1);
+  EXPECT_EQ(countNodeKind(optimizedF_, Kinded::Kind::ReluNodeKind), 8);
+  EXPECT_EQ(countNodeKind(F_, Kinded::Kind::ClipNodeKind), 1);
+  EXPECT_EQ(countNodeKind(optimizedF_, Kinded::Kind::ClipNodeKind), 8);
 
   SaveNode *optSave = nullptr;
   for (auto &N : optimizedF_->getNodes()) {
@@ -246,11 +246,11 @@ TEST_F(NNPIOptPipelineTest, NoSplitTestFCReluNNPI) {
       std::to_string(1);
   cloneAndCompile();
 
-  EXPECT_TRUE(countNodeKind(F_, Kinded::Kind::FullyConnectedNodeKind) == 1);
-  EXPECT_TRUE(
-      countNodeKind(optimizedF_, Kinded::Kind::FullyConnectedNodeKind) == 1);
-  EXPECT_TRUE(countNodeKind(F_, Kinded::Kind::ReluNodeKind) == 1);
-  EXPECT_TRUE(countNodeKind(optimizedF_, Kinded::Kind::ReluNodeKind) == 1);
+  EXPECT_EQ(countNodeKind(F_, Kinded::Kind::FullyConnectedNodeKind), 1);
+  EXPECT_EQ(countNodeKind(optimizedF_, Kinded::Kind::FullyConnectedNodeKind),
+            1);
+  EXPECT_EQ(countNodeKind(F_, Kinded::Kind::ReluNodeKind), 1);
+  EXPECT_EQ(countNodeKind(optimizedF_, Kinded::Kind::ReluNodeKind), 1);
 
   SaveNode *optSave = nullptr;
   for (auto &N : optimizedF_->getNodes()) {
@@ -267,24 +267,21 @@ TEST_F(NNPIOptPipelineTest, NoSplitTestFCReluNNPI) {
 }
 
 /// Test data parallel and model parallel splitting inside
-/// of NNPIPrivateTransforms.cpp for Transpose and Relu
-TEST_F(NNPIOptPipelineTest, SplitParallelizationTestTransposeReluNNPI) {
+/// of NNPIPrivateTransforms.cpp for Transpose.
+TEST_F(NNPIOptPipelineTest, SplitParallelizationTestTransposeNNPI) {
   auto *input = mod_.createPlaceholder(ElemKind::Float16Ty, {32, 128, 128},
                                        "input", false);
 
   auto *TP = F_->createTranspose("tp", input, {0, 2, 1});
-  auto *TP_relu = F_->createRELU("relu", TP);
-  F_->createSave("ret", TP_relu);
+  F_->createSave("ret", TP);
 
   cctx_.backendOpts.backendSpecificOpts["NNPINumParallelChunks"] =
       std::to_string(3);
   cloneAndCompile();
 
-  EXPECT_TRUE((F_->getNodes().size() < optimizedF_->getNodes().size()));
-  EXPECT_TRUE(countNodeKind(F_, Kinded::Kind::TransposeNodeKind) == 1);
-  EXPECT_TRUE(countNodeKind(optimizedF_, Kinded::Kind::TransposeNodeKind) == 3);
-  EXPECT_TRUE(countNodeKind(F_, Kinded::Kind::ReluNodeKind) == 1);
-  EXPECT_TRUE(countNodeKind(optimizedF_, Kinded::Kind::ReluNodeKind) == 3);
+  EXPECT_LT(F_->getNodes().size(), optimizedF_->getNodes().size());
+  EXPECT_EQ(countNodeKind(F_, Kinded::Kind::TransposeNodeKind), 1);
+  EXPECT_EQ(countNodeKind(optimizedF_, Kinded::Kind::TransposeNodeKind), 3);
 
   SaveNode *optSave = nullptr;
   for (auto &N : optimizedF_->getNodes()) {
@@ -316,12 +313,11 @@ TEST_F(NNPIOptPipelineTest, SplitParallelizationTestBatchMatMulReluNNPI) {
       std::to_string(3);
   cloneAndCompile();
 
-  EXPECT_TRUE((F_->getNodes().size() < optimizedF_->getNodes().size()));
-  EXPECT_TRUE(countNodeKind(F_, Kinded::Kind::BatchMatMulNodeKind) == 1);
-  EXPECT_TRUE(countNodeKind(optimizedF_, Kinded::Kind::BatchMatMulNodeKind) ==
-              3);
-  EXPECT_TRUE(countNodeKind(F_, Kinded::Kind::ReluNodeKind) == 1);
-  EXPECT_TRUE(countNodeKind(optimizedF_, Kinded::Kind::ReluNodeKind) == 3);
+  EXPECT_LT(F_->getNodes().size(), optimizedF_->getNodes().size());
+  EXPECT_EQ(countNodeKind(F_, Kinded::Kind::BatchMatMulNodeKind), 1);
+  EXPECT_EQ(countNodeKind(optimizedF_, Kinded::Kind::BatchMatMulNodeKind), 3);
+  EXPECT_EQ(countNodeKind(F_, Kinded::Kind::ReluNodeKind), 1);
+  EXPECT_EQ(countNodeKind(optimizedF_, Kinded::Kind::ReluNodeKind), 3);
 
   bindings_.allocate(input1)->getHandle<float16_t>().randomize(-1.0, 1.0,
                                                                mod_.getPRNG());
@@ -346,11 +342,11 @@ TEST_F(NNPIOptPipelineTest, SplitParallelizationTestMulReluNNPI) {
       std::to_string(3);
   cloneAndCompile();
 
-  EXPECT_TRUE((F_->getNodes().size() < optimizedF_->getNodes().size()));
-  EXPECT_TRUE(countNodeKind(F_, Kinded::Kind::MulNodeKind) == 1);
-  EXPECT_TRUE(countNodeKind(optimizedF_, Kinded::Kind::MulNodeKind) == 3);
-  EXPECT_TRUE(countNodeKind(F_, Kinded::Kind::ReluNodeKind) == 1);
-  EXPECT_TRUE(countNodeKind(optimizedF_, Kinded::Kind::ReluNodeKind) == 3);
+  EXPECT_LT(F_->getNodes().size(), optimizedF_->getNodes().size());
+  EXPECT_EQ(countNodeKind(F_, Kinded::Kind::MulNodeKind), 1);
+  EXPECT_EQ(countNodeKind(optimizedF_, Kinded::Kind::MulNodeKind), 3);
+  EXPECT_EQ(countNodeKind(F_, Kinded::Kind::ReluNodeKind), 1);
+  EXPECT_EQ(countNodeKind(optimizedF_, Kinded::Kind::ReluNodeKind), 3);
 
   bindings_.allocate(input1)->getHandle<float16_t>().randomize(-1.0, 1.0,
                                                                mod_.getPRNG());
@@ -373,11 +369,11 @@ TEST_F(NNPIOptPipelineTest, SplitParallelizationTestTanhReluNNPI) {
       std::to_string(3);
   cloneAndCompile();
 
-  EXPECT_TRUE((F_->getNodes().size() < optimizedF_->getNodes().size()));
-  EXPECT_TRUE(countNodeKind(F_, Kinded::Kind::TanhNodeKind) == 1);
-  EXPECT_TRUE(countNodeKind(optimizedF_, Kinded::Kind::TanhNodeKind) == 3);
-  EXPECT_TRUE(countNodeKind(F_, Kinded::Kind::ReluNodeKind) == 1);
-  EXPECT_TRUE(countNodeKind(optimizedF_, Kinded::Kind::ReluNodeKind) == 3);
+  EXPECT_LT(F_->getNodes().size(), optimizedF_->getNodes().size());
+  EXPECT_EQ(countNodeKind(F_, Kinded::Kind::TanhNodeKind), 1);
+  EXPECT_EQ(countNodeKind(optimizedF_, Kinded::Kind::TanhNodeKind), 3);
+  EXPECT_EQ(countNodeKind(F_, Kinded::Kind::ReluNodeKind), 1);
+  EXPECT_EQ(countNodeKind(optimizedF_, Kinded::Kind::ReluNodeKind), 3);
 
   bindings_.allocate(input1)->getHandle<float16_t>().randomize(-1.0, 1.0,
                                                                mod_.getPRNG());
@@ -437,15 +433,14 @@ TEST_F(NNPIOptPipelineTestNodeOpts, ModelSplitParallelizationTestFCReluNNPI) {
   setupSplitParallelizationTestFCReluNNPI(mod_, F_, cctx_, bindings_, "Model");
   cloneAndCompile();
 
-  EXPECT_TRUE(
-      (unoptimizedF_->getNodes().size() < optimizedF_->getNodes().size()));
-  EXPECT_TRUE(
-      countNodeKind(unoptimizedF_, Kinded::Kind::FullyConnectedNodeKind) == 1);
-  EXPECT_TRUE(
-      countNodeKind(optimizedF_, Kinded::Kind::FullyConnectedNodeKind) == 8);
-  EXPECT_TRUE(countNodeKind(unoptimizedF_, Kinded::Kind::ReluNodeKind) == 1);
-  EXPECT_TRUE(countNodeKind(optimizedF_, Kinded::Kind::ReluNodeKind) == 8);
-  EXPECT_TRUE(countNodeKind(optimizedF_, Kinded::Kind::ConcatNodeKind) == 1);
+  EXPECT_LT(unoptimizedF_->getNodes().size(), optimizedF_->getNodes().size());
+  EXPECT_EQ(countNodeKind(unoptimizedF_, Kinded::Kind::FullyConnectedNodeKind),
+            1);
+  EXPECT_EQ(countNodeKind(optimizedF_, Kinded::Kind::FullyConnectedNodeKind),
+            8);
+  EXPECT_EQ(countNodeKind(unoptimizedF_, Kinded::Kind::ReluNodeKind), 1);
+  EXPECT_EQ(countNodeKind(optimizedF_, Kinded::Kind::ReluNodeKind), 8);
+  EXPECT_EQ(countNodeKind(optimizedF_, Kinded::Kind::ConcatNodeKind), 1);
 
   SaveNode *optSave = nullptr;
   for (auto &N : optimizedF_->getNodes()) {
@@ -470,15 +465,14 @@ TEST_F(NNPIOptPipelineTestNodeOpts, DataSplitParallelizationTestFCReluNNPI) {
   setupSplitParallelizationTestFCReluNNPI(mod_, F_, cctx_, bindings_, "Data");
   cloneAndCompile();
 
-  EXPECT_TRUE(
-      (unoptimizedF_->getNodes().size() < optimizedF_->getNodes().size()));
-  EXPECT_TRUE(
-      countNodeKind(unoptimizedF_, Kinded::Kind::FullyConnectedNodeKind) == 1);
-  EXPECT_TRUE(
-      countNodeKind(optimizedF_, Kinded::Kind::FullyConnectedNodeKind) == 8);
-  EXPECT_TRUE(countNodeKind(unoptimizedF_, Kinded::Kind::ReluNodeKind) == 1);
-  EXPECT_TRUE(countNodeKind(optimizedF_, Kinded::Kind::ReluNodeKind) == 8);
-  EXPECT_TRUE(countNodeKind(optimizedF_, Kinded::Kind::ConcatNodeKind) == 1);
+  EXPECT_LT(unoptimizedF_->getNodes().size(), optimizedF_->getNodes().size());
+  EXPECT_EQ(countNodeKind(unoptimizedF_, Kinded::Kind::FullyConnectedNodeKind),
+            1);
+  EXPECT_EQ(countNodeKind(optimizedF_, Kinded::Kind::FullyConnectedNodeKind),
+            8);
+  EXPECT_EQ(countNodeKind(unoptimizedF_, Kinded::Kind::ReluNodeKind), 1);
+  EXPECT_EQ(countNodeKind(optimizedF_, Kinded::Kind::ReluNodeKind), 8);
+  EXPECT_EQ(countNodeKind(optimizedF_, Kinded::Kind::ConcatNodeKind), 1);
 
   SaveNode *optSave = nullptr;
   for (auto &N : optimizedF_->getNodes()) {
@@ -496,4 +490,25 @@ TEST_F(NNPIOptPipelineTestNodeOpts, DataSplitParallelizationTestFCReluNNPI) {
   EXPECT_EQ(CN->getDim(), 0);
 
   checkNumericalEquivalence(/* allowedError */ 0.f);
+}
+
+/// Test Relu is not parallelized when following an op that was not
+/// parallelized.
+TEST_F(NNPIOptPipelineTest, NoParallelizationTestAddReluNNPI) {
+  auto *input =
+      mod_.createPlaceholder(ElemKind::Float16Ty, {32, 1024}, "input", false);
+
+  auto *AN = F_->createAdd("add", input, input);
+  auto *RN = F_->createRELU("relu", AN);
+  F_->createSave("ret", RN);
+
+  // Set 8, but Add won't be parallelized, and so Relu shouldn't be either.
+  cctx_.backendOpts.backendSpecificOpts["NNPINumParallelChunks"] =
+      std::to_string(8);
+  cloneAndCompile();
+
+  EXPECT_EQ(countNodeKind(F_, Kinded::Kind::AddNodeKind), 1);
+  EXPECT_EQ(countNodeKind(F_, Kinded::Kind::ReluNodeKind), 1);
+  EXPECT_EQ(countNodeKind(optimizedF_, Kinded::Kind::AddNodeKind), 1);
+  EXPECT_EQ(countNodeKind(optimizedF_, Kinded::Kind::ReluNodeKind), 1);
 }


### PR DESCRIPTION
Summary: RELUs were being parallelized when they shouldn't have been. Once this is fixed, add a couple more passes to the NNPI-specific opt pipeline to optimize further.

Reviewed By: mjanderson09

Differential Revision: D20862851

