### PR TITLE
Add file printer for JIT backend use.

### DIFF
--- a/include/glow/LLVMIRCodeGen/JITFilePrinter.h
+++ b/include/glow/LLVMIRCodeGen/JITFilePrinter.h
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file contains the print functionality the JIT code can use. The backend
+// can call function to emit a global var that points to the host side struct
+// containing fopen/fprintf/fclose pointers, JIT code can call instead of it's
+// own fopen/fprintf/fclose.
+
+#include <condition_variable>
+#include <cstdarg>
+#include <unordered_map>
+
+/// Structure implements file I/O related functions. Currently,
+/// it just maps C-lib fopen/fprintf/fclose onto it's members.
+struct JITFileWriterIF {
+  FILE *(*fopen)(const char *, const char *);
+  int (*fprintf)(FILE *, const char *, ...);
+  int (*fclose)(FILE *);
+};
+
+struct JITFileWriter {
+  JITFileWriterIF IF;
+  /// Open a file. Operation, arguments and return value match standard fopen
+  /// function.
+  static FILE *JITfopen(const char *, const char *);
+  /// Writes the C string pointed by format to the stream. Operation, arguments
+  /// and return value match standard fprintf function.
+  static int JITfprintf(FILE *, const char *, ...);
+  /// Close a file. Operation, arguments and return value match standard fclose
+  /// function.
+  static int JITfclose(FILE *);
+  JITFileWriter() {
+    IF.fopen = &JITfopen;
+    IF.fprintf = &JITfprintf;
+    IF.fclose = &JITfclose;
+  }
+  std::unordered_map<std::string, bool> fileLock_;
+  std::unordered_map<FILE *, std::string> fileMap_;
+  std::condition_variable readyCV;
+  std::mutex mtx_;
+};

--- a/include/glow/LLVMIRCodeGen/LLVMIRGen.h
+++ b/include/glow/LLVMIRCodeGen/LLVMIRGen.h
@@ -371,6 +371,8 @@ public:
   /// Generates LLVM IR that materializes the string literal \p str.
   virtual llvm::Value *emitStringConst(llvm::IRBuilder<> &builder,
                                        llvm::StringRef str);
+  /// Emit symbols to JIT to allow it to use host side file printing.
+  void generateJITFileWriter();
   /// Register \p val as an argument that should not be specialized.
   virtual void markArgAsUnspecialized(llvm::Value *val);
   /// \returns bit-width of the target size_t.

--- a/lib/Backends/CPU/CMakeLists.txt
+++ b/lib/Backends/CPU/CMakeLists.txt
@@ -24,6 +24,7 @@ if(NOT EXISTS ${LLVM_LINK_BIN} AND NOT MSVC)
 endif()
 
 set(CPURunttimeCompilationOptions
+      -I ${CMAKE_CURRENT_SOURCE_DIR}/../../../../glow/include
       -std=c++14
       -ffast-math
       -fno-finite-math-only

--- a/lib/LLVMIRCodeGen/CMakeLists.txt
+++ b/lib/LLVMIRCodeGen/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(LLVMIRCodeGen
             CommandLine.cpp
             LLVMCompiledFunction.cpp
             DebugInfo.cpp
+            JITFilePrinter.cpp
             FunctionSpecializer.cpp
             GlowJIT.cpp
             Pipeline.cpp

--- a/lib/LLVMIRCodeGen/JITFilePrinter.cpp
+++ b/lib/LLVMIRCodeGen/JITFilePrinter.cpp
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This file contains the print functionality the JIT code can use. The backend
+// can call function to emit a global var that points to the host side struct
+// containing fopen/fprintf/fclose pointers, JIT code can call instead of it's
+// own fopen/fprintf/fclose.
+
+#include "glow/LLVMIRCodeGen/JITFilePrinter.h"
+#include "glow/LLVMIRCodeGen/LLVMIRGen.h"
+
+#include "llvm/Support/DynamicLibrary.h"
+
+using namespace glow;
+
+#if defined _MSC_VER
+#define EXTERN __declspec(dllexport)
+#else
+#define EXTERN
+#endif
+
+static JITFileWriter jitfileWriter;
+
+int JITFileWriter::JITfprintf(FILE *f, const char *format, ...) {
+  va_list argptr;
+  va_start(argptr, format);
+  return vfprintf(f, format, argptr);
+}
+
+FILE *JITFileWriter::JITfopen(const char *path, const char *mode) {
+  // File access is locked using per file name lock. This lock is a simple
+  // bool variable with it's access guarded by mutex.
+  std::unique_lock<std::mutex> lck(jitfileWriter.mtx_);
+  jitfileWriter.readyCV.wait(
+      lck, [&path] { return !jitfileWriter.fileLock_[std::string(path)]; });
+  jitfileWriter.fileLock_[std::string(path)] = true;
+  FILE *f = fopen(path, mode);
+  jitfileWriter.fileMap_[f] = std::string(path);
+  return f;
+}
+
+int JITFileWriter::JITfclose(FILE *f) {
+  std::lock_guard<std::mutex> lck(jitfileWriter.mtx_);
+  if (!jitfileWriter.fileMap_.count(f)) {
+    return -1;
+  }
+  std::string &file = jitfileWriter.fileMap_[f];
+  int ret = fclose(f);
+  jitfileWriter.fileMap_.erase(f);
+  jitfileWriter.fileLock_[file] = false;
+  jitfileWriter.readyCV.notify_all();
+  return ret;
+}
+
+/// Expose host side file printer for JIT code to use.
+/// The function simply exposes the writer object as a global symbol
+/// that will be avaiable for JIT to use.
+void LLVMIRGen::generateJITFileWriter() {
+  llvm::sys::DynamicLibrary::AddSymbol("_jitFileWriter", &jitfileWriter);
+}

--- a/lib/LLVMIRCodeGen/LLVMBackend.cpp
+++ b/lib/LLVMIRCodeGen/LLVMBackend.cpp
@@ -99,6 +99,8 @@ void LLVMBackend::emitJitMain(LLVMIRGen &irgen) const {
   irgen.createCall(builder, entryF, initFunctionCallArgs);
   // Terminate the function.
   builder.CreateRetVoid();
+  // Emit JIT file printer.
+  irgen.generateJITFileWriter();
   // Create the debug info for the entry point function.
   irgen.generateFunctionDebugInfo(func);
 }


### PR DESCRIPTION
Introduce host based file printer for backend JIT use.
It allows for concurrent writes to the same files and also avoids running into problems on windows with NTDLL failing on fprintf from JIT code.

Related to #4392, #3845 

Use like this in libjit.cpp for example:
```
#include <glow/LLVMIRCodeGen/JITFilePrinter.h>
extern "C" {
extern JITFileWriterIF _jitFileWriter;
}
```
Actual calls:
`_jitFileWriter.fopen();`

Testing: #4392 needs to provide testing, this MR will include replace libjit.cpp I/O calls, and the tests should pass.
