### PR TITLE
[NNPICompiledFunction] Add mutex around compilation

### DIFF
--- a/lib/Backends/NNPI/NNPICompiledFunction.cpp
+++ b/lib/Backends/NNPI/NNPICompiledFunction.cpp
@@ -247,40 +247,46 @@ Error NNPICompiledFunction::compile(Function *F, const BackendOptions &opts) {
     LOG_IF_NOT_RETURN_LLVMERROR(
         compilationFileName_.length() < NNPI_MAX_STRING_LEN, "Bad filename");
 
-    if (compilationFileName_.empty()) // Compile to memory.
     {
-      NNPIStream outFileStream;
-      outFileStream.userData = &compiledStream_;
-      outFileStream.readCallback = NULL;
-      outFileStream.seekCallback = NULL;
-      outFileStream.writeCallback = [](const void *ptr, uint64_t size,
-                                       uint64_t count,
-                                       void *userData) -> uint64_t {
-        DBG_MEM_USAGE("NNPICompiledFunction before appending: "
-                      << ((size * count) / 1024));
-        BlockStream *ss = reinterpret_cast<BlockStream *>(userData);
-        size_t wSize = ss->write(static_cast<const char *>(ptr), size * count);
-        if (wSize < size * count) {
-          return 0;
-        } else {
-          DBG_MEM_USAGE("NNPICompiledFunction stream appended: "
-                        << ((size * count) / 1024) << " KB current size: "
-                        << ss->getSize() / 1024 << " KB ");
-          return size * count;
-        }
-      };
-      DBG_MEM_USAGE("NNPICompiledFunction call get compile <<");
-      LOG_NNPI_IF_ERROR_RETURN_LLVMERROR(
-          nnpiNetworkCompileToStream(network_, &config_, &outFileStream, NULL),
-          "Failed NNPI Compile");
+      static std::mutex compileMutex;
+      std::lock_guard<std::mutex> guard(compileMutex);
+      if (compilationFileName_.empty()) // Compile to memory.
+      {
+        NNPIStream outFileStream;
+        outFileStream.userData = &compiledStream_;
+        outFileStream.readCallback = NULL;
+        outFileStream.seekCallback = NULL;
+        outFileStream.writeCallback = [](const void *ptr, uint64_t size,
+                                         uint64_t count,
+                                         void *userData) -> uint64_t {
+          DBG_MEM_USAGE("NNPICompiledFunction before appending: "
+                        << ((size * count) / 1024));
+          BlockStream *ss = reinterpret_cast<BlockStream *>(userData);
+          size_t wSize =
+              ss->write(static_cast<const char *>(ptr), size * count);
+          if (wSize < size * count) {
+            return 0;
+          } else {
+            DBG_MEM_USAGE("NNPICompiledFunction stream appended: "
+                          << ((size * count) / 1024) << " KB current size: "
+                          << ss->getSize() / 1024 << " KB ");
+            return size * count;
+          }
+        };
+        DBG_MEM_USAGE("NNPICompiledFunction call get compile <<");
+        LOG_NNPI_IF_ERROR_RETURN_LLVMERROR(
+            nnpiNetworkCompileToStream(network_, &config_, &outFileStream,
+                                       NULL),
+            "Failed NNPI Compile");
 
-      DBG_MEM_USAGE("NNPICompiledFunction done compile <<");
-    } else // Compile to file.
-    {
-      LOG_NNPI_IF_ERROR_RETURN_LLVMERROR(
-          nnpiNetworkCompileToFile(network_, &config_,
-                                   compilationFileName_.c_str(), NULL),
-          "Failed NNPI Compile");
+        DBG_MEM_USAGE("NNPICompiledFunction done compile <<");
+      } else // Compile to file.
+      {
+        LOG_NNPI_IF_ERROR_RETURN_LLVMERROR(
+            nnpiNetworkCompileToFile(network_, &config_,
+                                     compilationFileName_.c_str(), NULL),
+            "Failed NNPI Compile");
+      }
     }
     if (compilationOptions_.inferOnDevice) {
       DBG_MEM_USAGE("NNPICompiledFunction destroy network");


### PR DESCRIPTION
Summary: It appears compilation isn't thread safe currently. Add a mutex for now to prevent errors.

Differential Revision: D20960680

