### PR TITLE
Support for ONNX NonZero. Constant input only.

### DIFF
--- a/include/glow/Importer/ONNXModelLoader.h
+++ b/include/glow/Importer/ONNXModelLoader.h
@@ -123,6 +123,12 @@ class ONNXModelLoader
   /// A set of inputs which will be static placeholders.
   std::unordered_set<std::string> staticInputs_;
 
+  /// Load ONNX NonZero Operator.
+  /// Glow's requirement for static shapes results in required Constant
+  /// input. Thus, the operator will be folded in the Importer.
+  Error loadNonZero(const ONNX_NAMESPACE::NodeProto &op,
+                    const ArgumentDictionaryTy &dict);
+
   /// Load Constant ONNX operator.
   Error loadConstant(const ONNX_NAMESPACE::NodeProto &op,
                      ArgumentDictionaryTy &dict);

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -2901,6 +2901,80 @@ Error ONNXModelLoader::loadSelect(const ONNX_NAMESPACE::NodeProto &op,
   return Error::success();
 }
 
+Error ONNXModelLoader::loadNonZero(const ONNX_NAMESPACE::NodeProto &op,
+                                   const ArgumentDictionaryTy &dict) {
+  NodeValue input;
+  ASSIGN_VALUE_OR_RETURN_ERR(input, getNodeValueByName(op.input(0)));
+
+  Constant *C = getConstantByNameOrNull(op.input(0));
+  RETURN_ERR_IF_NOT(C, "Only constant shape is supported!");
+
+  // output tensor.
+  Tensor outT;
+
+  // Fold NonZero operator.
+  auto foldNonZero = [&C, &outT](auto dummy) -> Error {
+    auto inH = C->getPayload().getHandle<decltype(dummy)>();
+    auto dims = C->dims();
+
+    // First pass over the input is used to find the number of non-zero elements
+    // so we can create output tensor that will be filled in the 2nd pass.
+    dim_t nonZeroCnt = 0;
+    for (dim_t idx = 0, e = inH.size(); idx < e; idx++) {
+      nonZeroCnt += (inH.raw(idx) != 0) ? 1 : 0;
+    }
+
+    // No need to support zero Tensor (empty output); we support constant input
+    // only and such input likely means it's an invalid model or the part of
+    // graph can be removed.
+    RETURN_ERR_IF_NOT(nonZeroCnt > 0,
+                      "Non-Zero input with all zeroes is not supported.");
+
+    // Create output tensor. First dimension is the rank of input tensor, second
+    // dimension is the number of non-zero elements.
+    outT.reset(ElemKind::Int64ITy, {(dim_t)dims.size(), nonZeroCnt});
+
+    // Strides for each dimensions, needed to calculate NonZero output.
+    std::vector<dim_t> strides;
+    strides.reserve(dims.size());
+    strides[dims.size() - 1] = 1;
+    if (dims.size() > 1) {
+      for (int i = dims.size() - 2; i >= 0; i--) {
+        strides[i] = dims[i + 1] * strides[i + 1];
+      }
+    }
+
+    // Second pass over the input is used to fill the output tensor. For each
+    // non-zero element we fill all the dimensions, at position determined
+    // by the non-zero element's index when zero elements are ignored.
+    auto outH = outT.getHandle<int64_t>();
+    for (dim_t idx = 0, pos = 0, e = inH.size(); idx < e; idx++) {
+      if (inH.raw(idx) != 0) {
+        for (dim_t dim = 0; dim < dims.size(); dim++) {
+          outH.at({dim, pos}) = (idx / strides[dim]) % dims[dim];
+        }
+        pos++;
+      }
+    }
+    return Error::success();
+  };
+
+  std::string err;
+  if (C->getElementType() == ElemKind::FloatTy) {
+    RETURN_IF_ERR(foldNonZero((float)0));
+  } else if (C->getElementType() == ElemKind::Int64ITy) {
+    RETURN_IF_ERR(foldNonZero((int64_t)0));
+  } else if (C->getElementType() == ElemKind::Int32ITy) {
+    RETURN_IF_ERR(foldNonZero((int32_t)0));
+  } else {
+    RETURN_ERR("Unsupported input type for NonZero operator.");
+  }
+
+  Constant *outC = G_->getParent()->createConstant("nonZero", std::move(outT));
+  RETURN_IF_ERR(addNodeAsOutput(op, outC));
+  return Error::success();
+}
+
 Error ONNXModelLoader::loadQuantize(const ONNX_NAMESPACE::NodeProto &op,
                                     ArgumentDictionaryTy &dict) {
   NodeValue in;
@@ -3739,6 +3813,9 @@ Error ONNXModelLoader::loadOperator(const ONNX_NAMESPACE::NodeProto &op) {
   }
   if (typeName == "Upsample") {
     return loadUpsample(op, dict);
+  }
+  if (typeName == "NonZero") {
+    return loadNonZero(op, dict);
   }
 
   RETURN_ERR("Failed to load operator " + typeName + " .",

--- a/tests/models/onnxModels/NonZero.onnxtxt
+++ b/tests/models/onnxModels/NonZero.onnxtxt
@@ -1,0 +1,94 @@
+ir_version: 3
+producer_name: "backend-test"
+graph {
+  name: "test-model"
+  ###
+  ### INT32 INPUT MODEL:
+  ###
+  node {
+    input: "const_i32"
+    output: "out_i32"
+    name: "NonZero"
+    op_type: "NonZero"
+  }
+  initializer {
+    dims: 4
+    dims: 2
+    dims: 3
+    dims: 1
+    dims: 2
+    data_type: 6
+    name: "const_i32"
+    int32_data : [1,2,0,4,5,0,1,0,3,0,5,0,-2,0,3,0,5,0,-1,2,0,4,5,0]
+    int32_data : [4,2,0,2,5,0,1,0,7,-4,0,0,-2,0,3,-4,5,0,-1,2,0,4,-1,0]
+  }
+  output {
+    name: "out_i32"
+    type {
+      tensor_type {
+        elem_type: 7
+        shape {
+         dim {dim_value: 5}
+         dim {dim_value: 29}
+        }
+      }
+    }
+  }
+  ###
+  ### FLOAT INPUT MODEL:
+  ###
+  node {
+    input: "const_f"
+    output: "out_f"
+    name: "NonZeroNode"
+    op_type: "NonZero"
+  }
+  initializer {
+    dims: 24
+    data_type: 1
+    name: "const_f"
+    float_data : [1,2,0,4,5,0,1,0,3,0,5,0,-2,0,3,0,5,0,-1,2,0,4,5,0]
+  }
+  output {
+    name: "out_f"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+         dim {dim_value: 1}
+         dim {dim_value: 14}
+        }
+      }
+    }
+  }
+  ###
+  ### INT64 INPUT MODEL:
+  ###
+  node {
+    input: "const_i64"
+    output: "out_i64"
+    name: "NonZeroNode"
+    op_type: "NonZero"
+  }
+  initializer {
+    dims: 24
+    data_type: 7
+    name: "const_i64"
+    int64_data : [1,2,0,4,5,0,1,0,3,0,5,0,-2,0,3,0,5,0,-1,2,0,4,5,0]
+  }
+  output {
+    name: "out_i64"
+    type {
+      tensor_type {
+        elem_type: 7
+        shape {
+         dim {dim_value: 1}
+         dim {dim_value: 14}
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 10
+}

--- a/tests/unittests/OnnxExporterTest.cpp
+++ b/tests/unittests/OnnxExporterTest.cpp
@@ -193,6 +193,7 @@ TEST(exporter, onnxModels) {
         name.find("simpleConvTransposeOutShape.onnxtxt") != std::string::npos ||
         name.find("simpleConvTransposeOutShapeDilation.onnxtxt") !=
             std::string::npos ||
+        name.find("NonZero.onnxtxt") != std::string::npos ||
         name.find("simpleConvTransposePads.onnxtxt") != std::string::npos ||
         name.find("simpleConvTransposeAutoPadValid.onnxtxt") !=
             std::string::npos ||


### PR DESCRIPTION
Implement ONNX NonZero support when input is constant, by folding in Importer.

Fixes #4407 

Test Plan:
Onnx importer tests added.
