### PR TITLE
Do not overwrite the DeviceConfig deviceID

### DIFF
--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -108,7 +108,6 @@ Error HostManager::init(std::vector<std::unique_ptr<DeviceConfig>> configs) {
   DeviceIDTy deviceCount = 0;
 
   for (auto &config : configs) {
-    config->deviceID = deviceCount;
     if (!config->hasName()) {
       config->name = "config" + std::to_string(deviceCount);
     }


### PR DESCRIPTION
Summary: This should not be set here, it's set higher up in the stack.

Differential Revision: D20973117

