### PR TITLE
[ExecutorCore/Loader]Add support for a few flags for testing purposes

### DIFF
--- a/tools/loader/ExecutorCoreHelperFunctions.h
+++ b/tools/loader/ExecutorCoreHelperFunctions.h
@@ -19,7 +19,9 @@
 
 #include "Loader.h"
 #include "glow/Graph/Nodes.h"
+
 #include "llvm/ADT/StringMap.h"
+#include "llvm/Support/Timer.h"
 
 extern llvm::cl::opt<std::string> inputImageListFile;
 extern llvm::cl::list<std::string> inputImageFilenames;
@@ -29,6 +31,8 @@ extern llvm::cl::opt<std::string> tracePath;
 extern llvm::cl::opt<bool> convertInAndOutToFp16;
 extern llvm::cl::opt<unsigned> miniBatch;
 extern llvm::cl::opt<unsigned> miniBatchThreads;
+extern llvm::cl::opt<bool> preloadAllImages;
+extern llvm::cl::opt<unsigned> repeatSingleBatchCount;
 
 extern std::unique_ptr<glow::TraceContext> traceContext;
 
@@ -57,7 +61,7 @@ bool getNextMiniBatch(std::vector<std::string> &imageList,
 std::pair<glow::Placeholder *, llvm::StringMap<glow::Placeholder *>>
 buildAndCompileAndGetInAndOutPair(glow::Loader &loader,
                                   glow::PlaceholderBindings &bindings,
-                                  glow::TypeRef inputImageType);
+                                  const glow::Type &inputImageType);
 
 /// Setup the pool of contexts needed for a benchmark run.
 std::vector<std::unique_ptr<glow::ExecutionContext>>

--- a/tools/loader/Loader.h
+++ b/tools/loader/Loader.h
@@ -28,6 +28,12 @@
 /// Options.
 extern llvm::cl::OptionCategory loaderCat;
 
+/// Number of devices to use.
+extern llvm::cl::opt<unsigned> numDevices;
+
+/// Whether to run all inputs on all numDevices. Used for testing.
+extern llvm::cl::opt<bool> runAllInputsOnAllDevices;
+
 /// Timer option used to indicate if inferences should be timed -time.
 extern llvm::cl::opt<bool> timeOpt;
 /// Iterations used to indicate the number of iterations to run an inferece
@@ -187,8 +193,10 @@ public:
   /// include quantization profile guided information.
   void generateAndSerializeProfilingInfos(PlaceholderBindings &bindings);
 
-  /// Create the Loader driver object.
-  Loader();
+  /// Create the Loader driver object. If \p configDeviceIDs is empty then \ref
+  /// numDevices DeviceConfigs are created for each device, otherwise
+  /// configDeviceIDs is used to create DeviceConfigs with specified IDs.
+  Loader(llvm::ArrayRef<size_t> configDeviceIDs = {});
 };
 
 } // namespace glow


### PR DESCRIPTION
Summary:
Enable faster testing:
- `-preload-all-images`: Preloads all images before any threads begin. Throughput is often limited by loading+preprocessing images, so do it before all threads begin and then share the images across threads. Only really useful if used with the next cmd:
- `-run-all-inputs-on-all-devices`: Runs all pre-loaded inputs on all devices to enable testing all devices in parallel
- `-repeat-single-batch-count`: Instead of loading many batches over and over again, or preloading all in the beginning, just load the first batch and reuse it the specified number of times. Also useful when combined with `-run-all-inputs-on-all-devices`.

Differential Revision: D20962433

