### PR TITLE
Minor fixes for windows unit tests.

### DIFF
--- a/lib/Quantization/Base/Calibration.cpp
+++ b/lib/Quantization/Base/Calibration.cpp
@@ -37,7 +37,7 @@ static void conditionHistogram(float *hist, const size_t length,
   }
 
   // Get information about the zero values within the histogram.
-  int isZero[length];
+  std::vector<int> isZero(length);
   size_t numZeros = 0;
   for (size_t idx = 0, e = length; idx < e; idx++) {
     isZero[idx] = static_cast<int>(hist[idx] == 0.f);

--- a/tests/unittests/CPUJITTest.cpp
+++ b/tests/unittests/CPUJITTest.cpp
@@ -120,7 +120,7 @@ REGISTER_GLOW_BACKEND_FACTORY(MockCPUFactory, MockCPUBackend);
 //==============================================================
 
 #define JIT_MAGIC_VALUE 555
-
+#ifndef WIN32
 // Test 0: test that the libjit code can use global C++ objects.
 TEST(CPUJITTest, testCppConstructors) {
   glow::ExecutionEngine EE("MockCPUBackend");
@@ -142,3 +142,4 @@ TEST(CPUJITTest, testCppConstructors) {
   EE.run(bindings);
   EXPECT_TRUE(outputT->isEqual(expectedT));
 }
+#endif // ! WIN32

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -1227,7 +1227,7 @@ createAndInitBasicMFCCTest(glow::PlaceholderBindings &bindings,
 
 TEST_MFCC(1, 17, 5e-5)
 TEST_MFCC(1, 33, 5e-5)
-TEST_MFCC(1, 65, 1e-5)
+TEST_MFCC(1, 65, 2e-5)
 TEST_MFCC(1, 129, 1e-5)
 TEST_MFCC(2, 257, 1e-5)
 TEST_MFCC(3, 513, 1e-5)


### PR DESCRIPTION
Summary:
Disabling CPUJITTest for windows. @tlepley approach still doesn't work with VisualStudio.
Raising allowable error for MFCC when comparing interpreter and CPU backends.
@mciprian13 as we discussed in your other MR.
Documentation:

[Optional Fixes #issue]

Test Plan:
Unit Tests.
Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
