### PR TITLE
Sink Reshape below BatchNorm.

### DIFF
--- a/tests/unittests/QuantizationTest.cpp
+++ b/tests/unittests/QuantizationTest.cpp
@@ -743,6 +743,8 @@ TEST(Quantization, enableRowwiseQuantizedFullyConnectedSymmetric) {
   auto *FC = F->createFullyConnected(bindings, "FC", input, 100);
   auto *res = F->createSave("save", FC);
   bindings.allocate(res->getPlaceholder());
+  bindings.allocate(input);
+  bindings.get(input)->getHandle().randomize(-1.0, 6.0, mod.getPRNG());
 
   ::glow::convertPlaceholdersToConstants(F, bindings,
                                          {input, res->getPlaceholder()});


### PR DESCRIPTION
[graph optimization] Sink reshape below BatchNorm 

Summary: 
Sinking reshape below BatchNorm enables merge of Conv and BatchNorm.
Sink is performed only under certain conditions:
 - Reshape does not alter number of Channels and Batches
 - ChannelIdx of BatchNorm is indexing to 'C' in NH[W]C or NCH[W]

Change-Id: I380a12203d214ca3d1c03aa8ecbb2dd840a71ce8


Documentation:

[Optional Fixes #issue]

Test Plan: Added a unittest.

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
