### PR TITLE
Remove unnecessary min/max shift in tensorFusedRowwiseQuantization.

### DIFF
--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -9718,7 +9718,7 @@ TEST_P(OperatorStatelessTest, RWQSLWSAllSame_Float16_AccumFP16) {
   CHECK_IF_ENABLED();
   compareAgainstInterpreter(
       getBackendName(), createAndInitRWQSLWSAllSame, ElemKind::Float16Ty,
-      ElemKind::Float16Ty, 1e-6, parCloneCountOpt,
+      ElemKind::Float16Ty, 0.0005, parCloneCountOpt,
       /* convertToRowwiseQuantization */ false,
       /*schema */ quantization::Schema::Asymmetric,
       /* biasElemKind */ ElemKind::Int32QTy, /* forceFP16AccumSLS */ true);


### PR DESCRIPTION
Summary:
Caffe2 implementation (https://fburl.com/c9l1sffg) of `tensorFusedRowwiseQuantization`
doesn't shift update min/max wrt to 0.

This diff removes the un-necessary shift and add unit-tests to ensure complementary behavior between `tensorFusedRowwiseQuantization` and `tensor4BitsFusedRowwiseDequantization`.

Reviewed By: jfix71, qizzzh

Differential Revision: D21061244

