### PR TITLE
Add support for exporting DAG

### DIFF
--- a/include/glow/Exporter/ONNXModelWriter.h
+++ b/include/glow/Exporter/ONNXModelWriter.h
@@ -19,6 +19,7 @@
 
 #include "glow/Exporter/CommonOperatorWriter.h"
 #include "glow/Graph/Graph.h"
+#include "glow/Runtime/RuntimeTypes.h"
 
 #include "onnx/onnx_pb.h"
 
@@ -63,9 +64,13 @@ class ONNXModelWriter : public CommonOperatorWriter<ONNX_TRAITS> {
   const bool textMode_;
   /// Whether to use custom ONNX ops.
   const bool useGlowCustomOps_;
+  /// Whether we are writing a DAG.
+  const bool dagMode_;
   /// A dedicated list of initializers in case the tensors get too big and don't
   /// fit into the model.
   std::list<TensorType> initializers_;
+  /// Holds all Functions from a DAG that are being written when in dagMode_.
+  llvm::SmallSet<Function *, 6> functionsFromDAG_;
   /// Writes tensor shape from placeholder \p PH into protpbuf \p valueProto.
   void tensorShapeFromPlaceholder(const Placeholder *PH,
                                   ValueInfoType *valueProto);
@@ -102,6 +107,18 @@ class ONNXModelWriter : public CommonOperatorWriter<ONNX_TRAITS> {
   /// there is an error encountered.
   Error finalizeAndWriteProto(llvm::StringRef filename);
 
+  /// Adds a metadata prop with \p key and \p val to \ref modelProto_.
+  void addMetadataProp(const std::string &key, const std::string &val);
+
+  /// Write out the Functions and metadata for all DAGNodes in \p postOrder
+  /// given parent \p mod.
+  Error writePartitionAndMetadataProps(
+      Module &mod, llvm::ArrayRef<const runtime::DAGNode *> postOrder);
+
+  /// \returns whether \p PH is an intermediate PH for the DAG being written
+  /// (i.e. both input and an output for Functions in \ref functionsFromDAG_).
+  bool isIntermediatePHForDAG(const Placeholder *PH);
+
 public:
   /// Converts \p glowType to \p protoType.
   static typename TensorType::DataType convertType(const Type &glowType);
@@ -124,6 +141,22 @@ public:
                   size_t irVersion, size_t opsetVersion,
                   Error *errPtr = nullptr, bool textMode = false,
                   bool zipMode = false, bool useGlowCustomOps = false);
+
+  /// Creates an ONNX model writer to serialize \p dagList into file
+
+  /// \p modelFilename, writing \p irVersion and \p opsetVersion. Each partition
+  /// from \p dagList will be annotated with the name of the partition to the
+  /// op. This exporter requires using \ref useGlowCustomOps_ and sets it true
+  /// as such. If \p errPtr is not null then if an error occurs it will get
+  /// assigned there otherwise if an error occurs it will abort. It also
+  /// supports serialization with text format or binary format depending on
+  /// \p textMode. If \p zipMode is true, it will save weights into individual
+  /// TensorProto file along with the model file and package them into a zip
+  /// file.
+  ONNXModelWriter(const std::string &modelFilename, runtime::DAGListTy &dagList,
+                  size_t irVersion, size_t opsetVersion,
+                  Error *errPtr = nullptr, bool textMode = false,
+                  bool zipMode = false);
 
 private:
   /// \returns error for the unexpected node kind.

--- a/include/glow/Exporter/ONNXModelWriter.h
+++ b/include/glow/Exporter/ONNXModelWriter.h
@@ -47,14 +47,22 @@ class ONNXModelWriter : public CommonOperatorWriter<ONNX_TRAITS> {
   using AttrType = ONNX_NAMESPACE::AttributeProto;
   using ValueInfoType = ONNX_NAMESPACE::ValueInfoProto;
 
+  // ModelProto that we are writing to.
+  ONNX_NAMESPACE::ModelProto modelProto_;
+  // GraphProto that we are writing to.
+  ONNX_TRAITS::GraphProto *graphProto_;
+  /// Current IR version of ONNX.
+  const size_t irVersion_;
   /// Current version of ONNX standard.
-  size_t opsetVersion_;
+  const size_t opsetVersion_;
   /// Keeps the track of already visited or processed nodes.
   ReportedNodes reportedNodes_;
   /// Whether we use zip mode or not
-  bool zipMode_;
+  const bool zipMode_;
+  /// Whether we use text mode or not
+  const bool textMode_;
   /// Whether to use custom ONNX ops.
-  bool useGlowCustomOps_;
+  const bool useGlowCustomOps_;
   /// A dedicated list of initializers in case the tensors get too big and don't
   /// fit into the model.
   std::list<TensorType> initializers_;
@@ -82,6 +90,17 @@ class ONNXModelWriter : public CommonOperatorWriter<ONNX_TRAITS> {
   /// Write \p node to \p graph using custom Glow Nodes, exported via
   /// auto-generated export logic in NodeGen.
   Error writeGlowCustomOperator(const Node *node, GraphType &graph);
+
+  /// Setup a new proto \ref modelProto_ and \ref graphProto_.
+  void setupNewProto();
+
+  /// Write the current Function \ref F_ to \ref graphProto_. \returns if there
+  /// was an issue during iteration or writing.
+  Error writeFunction();
+
+  /// Finalize the written function and write it out to \p filename. \returns if
+  /// there is an error encountered.
+  Error finalizeAndWriteProto(llvm::StringRef filename);
 
 public:
   /// Converts \p glowType to \p protoType.

--- a/include/glow/Exporter/ProtobufWriter.h
+++ b/include/glow/Exporter/ProtobufWriter.h
@@ -28,7 +28,7 @@ namespace glow {
 class ProtobufWriter {
 protected:
   /// The graph that we are constructing.
-  Function &G_;
+  Function *F_;
   /// Output file stream.
   std::ofstream ff_;
 
@@ -40,7 +40,7 @@ public:
   /// \p modelFilename using graph and constants from \p F.
   /// If \p errPtr is not null then if an error occurs it will get assigned
   /// there otherwise if an error occurs it will abort.
-  ProtobufWriter(const std::string &modelFilename, Function &F,
+  ProtobufWriter(const std::string &modelFilename, Function *F,
                  Error *errPtr = nullptr);
 };
 

--- a/include/glow/Runtime/RuntimeTypes.h
+++ b/include/glow/Runtime/RuntimeTypes.h
@@ -313,6 +313,32 @@ struct ContextBinding {
   std::string networkName;
 };
 
+/// Signifiers for exporting and importing properties of Nodes.
+inline std::string getPartitionIdPrefix(int idx) {
+  return std::string("partition_") + std::to_string(idx) + "_";
+}
+
+constexpr char numLogicalDevicesSignifier[] = "numLogicalDevices";
+inline std::string getLogicalDeviceSignfier(int idx) {
+  return std::string("logicalDevice_") + std::to_string(idx);
+}
+
+constexpr char nameSignifier[] = "name";
+constexpr char backendNameSignifier[] = "backendName";
+constexpr char executionUnitsSignifier[] = "BackendHint_executionUnits";
+constexpr char sizeSignifier[] = "size";
+
+constexpr char numBackendSpecificOptsSignifier[] = "numBackendSpecificOpts";
+inline std::string getBackendSpecificOptKeySignifier(int idx) {
+  return std::string("backendSpecificOpts_key_") + std::to_string(idx);
+}
+inline std::string getBackendSpecificOptValSignifier(int idx) {
+  return std::string("backendSpecificOpts_val_") + std::to_string(idx);
+}
+
+constexpr char replicationCountSignifier[] = "replicationCount";
+constexpr char Signifier[] = "";
+
 } // namespace runtime
 } // namespace glow
 #endif // GLOW_RUNTIME_RUNTIMETYPES_H

--- a/lib/Exporter/ProtobufWriter.cpp
+++ b/lib/Exporter/ProtobufWriter.cpp
@@ -20,9 +20,9 @@
 
 namespace glow {
 
-ProtobufWriter::ProtobufWriter(const std::string &modelFilename, Function &F,
+ProtobufWriter::ProtobufWriter(const std::string &modelFilename, Function *F,
                                Error *errPtr)
-    : G_(F) {
+    : F_(F) {
   // Verify that the version of the library that we linked against is
   // compatible with the version of the headers we compiled against.
   GOOGLE_PROTOBUF_VERIFY_VERSION;

--- a/tools/ClassGen/NodeBuilder.cpp
+++ b/tools/ClassGen/NodeBuilder.cpp
@@ -669,7 +669,7 @@ void NodeBuilder::emitExportMethods(std::ostream &os) const {
   os << "  auto *N__ = llvm::cast<" << name_ << "Node>(node);\n";
 
   // Add the node. Note that Glow custom ops are prefixed with "Glow_"
-  os << "  auto *opProto = graph.add_node();\n";
+  os << "  opProto = graph.add_node();\n";
   os << "  opProto->set_op_type(\"Glow_" << name_ << "\");\n";
   os << "  opProto->set_name(N__->getName());\n";
 


### PR DESCRIPTION
Summary: Add a new API for ONNXModelWriter to write a DAG. This follows somewhat in the C2 pre-partitioned flow, adding a `partitionName` to each Node. All partition info is saved using metadata props, including things that need to be reloaded into the DAG such as `logicalDevices`, `backendName`, `replicationCount`, etc.

Differential Revision: D21013535

