### PR TITLE
Support loading previously serialized DAG

### DIFF
--- a/include/glow/Runtime/RuntimeTypes.h
+++ b/include/glow/Runtime/RuntimeTypes.h
@@ -87,6 +87,9 @@ struct DeviceRuntimeInfo {
 
 /// Individual Node in the DAG for a given network. This contains all the
 /// information needed to run the sub-network at inference time.
+/// NOTE: When adding members to this struct, if it's a compile-time member that
+/// needs to be remembered when serializing the model, metadata-prop
+/// serialization logic must be updated in ONNXModelImporter/ONNXModelWriter.
 struct DAGNode {
   /// The children of this node, these are nodes that depend on the current
   /// node.
@@ -308,6 +311,18 @@ struct PrePartitionedConfig {
   std::vector<BackendSpecificOptions> backendSpecificOpts;
   /// Number of times to replicate each partition.
   std::vector<unsigned> replicationCounts;
+
+  /// Resizes/reserves for all vectors in the struct to \p size. Resize is used
+  /// for those vectors which need to have their parameter constructed.
+  void resizeAndReserve(size_t size) {
+    funcs.reserve(size);
+    partitionNames.reserve(size);
+    logicalIDs.resize(size);
+    backendNames.reserve(size);
+    backendHints.reserve(size);
+    backendSpecificOpts.resize(size);
+    replicationCounts.reserve(size);
+  }
 };
 
 /// A struct containing a mapping of ExecutionContext to a loaded network on a

--- a/include/glow/Runtime/RuntimeTypes.h
+++ b/include/glow/Runtime/RuntimeTypes.h
@@ -296,10 +296,18 @@ struct PrePartitionedConfig {
   std::string funcName;
   /// Functions from the module which are partitioned.
   std::vector<Function *> funcs;
+  /// Names assigned to each partition.
+  std::vector<std::string> partitionNames;
   /// The logical IDs to assign to the partitions.
-  std::vector<std::unordered_set<unsigned>> logicalIDs;
-  /// Backend-specific options for each Partition.
+  std::vector<std::vector<DeviceIDTy>> logicalIDs;
+  /// Backends that are used for each partition.
+  std::vector<std::string> backendNames;
+  /// BackendHints for each partition.
+  std::vector<BackendHints> backendHints;
+  /// Backend-specific options for each partition.
   std::vector<BackendSpecificOptions> backendSpecificOpts;
+  /// Number of times to replicate each partition.
+  std::vector<unsigned> replicationCounts;
 };
 
 /// A struct containing a mapping of ExecutionContext to a loaded network on a

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -2095,7 +2095,7 @@ Error Caffe2ModelLoader::initWithModule(caffe2::NetDef &networkDef,
   // partition_info then we create a single Function to load into. Otherwise
   // we create multiple Functions and switch between them as we load each
   // operator.
-  std::unordered_map<Function *, std::unordered_set<unsigned>> funToIDs;
+  std::unordered_map<Function *, std::vector<runtime::DeviceIDTy>> funToIDs;
   std::unordered_map<Function *, BackendSpecificOptions> funToOpts;
   if (networkDef.partition_info_size() == 0) {
     G_ = mod_.createFunction(funNamePrefix);
@@ -2106,7 +2106,7 @@ Error Caffe2ModelLoader::initWithModule(caffe2::NetDef &networkDef,
       Function *PF = mod_.createFunction(funName);
       partNameToFun_[pName] = PF;
       for (auto id : networkDef.partition_info(i).device_id()) {
-        funToIDs[PF].insert(id);
+        funToIDs[PF].push_back(id);
       }
 
       // Now set up device options for this partition.

--- a/lib/Runtime/Provisioner/Provisioner.cpp
+++ b/lib/Runtime/Provisioner/Provisioner.cpp
@@ -368,14 +368,6 @@ Error Provisioner::provision(DAGListTy &networks, Module &module,
                               deviceBackendName);
         }
 
-        if (cctx.dumpFinalGraph) {
-          auto fname =
-              strFormat("final_graph_%s_%s.dot", deviceBackendName.c_str(),
-                        function->getName().str().c_str());
-          LOG(INFO) << "Dumping final graph to " << fname;
-          function->dumpDAG(fname);
-        }
-
         std::unordered_map<std::string, std::unique_ptr<glow::CompiledFunction>>
             compiledReplications;
         // Before we compile clone the function so we can replicate it on the
@@ -397,6 +389,16 @@ Error Provisioner::provision(DAGListTy &networks, Module &module,
 
         auto compiledOrErr =
             backends_[deviceBackendName]->compile(function, options);
+
+        // Note: This needs to come after compile above because compile may
+        // modify the Function as well.
+        if (cctx.dumpFinalGraph) {
+          auto fname =
+              strFormat("final_graph_%s_%s.dot", deviceBackendName.c_str(),
+                        function->getName().str().c_str());
+          LOG(INFO) << "Dumping final graph to " << fname;
+          function->dumpDAG(fname);
+        }
 
         if (GlowDumpCompilationLog) {
           llvm::SmallString<64> path;

--- a/tests/models/onnxModels/glow_custom_dag_multi_op.onnxtxt
+++ b/tests/models/onnxModels/glow_custom_dag_multi_op.onnxtxt
@@ -1,0 +1,437 @@
+ir_version: 7
+producer_name: "GlowONNXModelWriter"
+graph {
+  node {
+    input: "mm0_in"
+    input: "mm1_in"
+    output: "mm_out"
+    name: "mm_out"
+    op_type: "Glow_MatMul"
+    attribute {
+      name: "i0_elemKind"
+      s: "float"
+      type: STRING
+    }
+    attribute {
+      name: "i0_shape"
+      ints: 10
+      ints: 10
+      type: INTS
+    }
+    attribute {
+      name: "i1_elemKind"
+      s: "float"
+      type: STRING
+    }
+    attribute {
+      name: "i1_shape"
+      ints: 10
+      ints: 10
+      type: INTS
+    }
+    attribute {
+      name: "o0_elemKind"
+      s: "float"
+      type: STRING
+    }
+    attribute {
+      name: "o0_shape"
+      ints: 10
+      ints: 10
+      type: INTS
+    }
+    attribute {
+      name: "partitionName"
+      s: "main_p1"
+      type: STRING
+    }
+  }
+  node {
+    input: "mm_out"
+    output: "tmp_mm_out"
+    name: "tmp_mm_out_save"
+    op_type: "Identity"
+    attribute {
+      name: "isIntermediateOutputForDAG"
+      i: 1
+      type: INT
+    }
+    attribute {
+      name: "partitionName"
+      s: "main_p1"
+      type: STRING
+    }
+  }
+  node {
+    input: "tmp_mm_out"
+    input: "add_in"
+    output: "add_out"
+    name: "add_out"
+    op_type: "Glow_Add"
+    attribute {
+      name: "NodeOpt_NNPI_numParallelChunks"
+      strings: "2"
+      type: STRINGS
+    }
+    attribute {
+      name: "NodeOpt_NNPI_parallelTransformKind"
+      strings: "Data"
+      type: STRINGS
+    }
+    attribute {
+      name: "i0_elemKind"
+      s: "float"
+      type: STRING
+    }
+    attribute {
+      name: "i0_shape"
+      ints: 10
+      ints: 10
+      type: INTS
+    }
+    attribute {
+      name: "i1_elemKind"
+      s: "float"
+      type: STRING
+    }
+    attribute {
+      name: "i1_shape"
+      ints: 10
+      ints: 10
+      type: INTS
+    }
+    attribute {
+      name: "o0_elemKind"
+      s: "float"
+      type: STRING
+    }
+    attribute {
+      name: "o0_shape"
+      ints: 10
+      ints: 10
+      type: INTS
+    }
+    attribute {
+      name: "partitionName"
+      s: "main_p2"
+      type: STRING
+    }
+  }
+  node {
+    input: "add_out"
+    output: "tmp_add_out"
+    name: "tmp_add_out_save"
+    op_type: "Identity"
+    attribute {
+      name: "isIntermediateOutputForDAG"
+      i: 1
+      type: INT
+    }
+    attribute {
+      name: "partitionName"
+      s: "main_p2"
+      type: STRING
+    }
+  }
+  node {
+    input: "mm0_in"
+    input: "tmp_mm_out"
+    output: "mul_out"
+    name: "mul_out"
+    op_type: "Glow_Mul"
+    attribute {
+      name: "i0_elemKind"
+      s: "float"
+      type: STRING
+    }
+    attribute {
+      name: "i0_shape"
+      ints: 10
+      ints: 10
+      type: INTS
+    }
+    attribute {
+      name: "i1_elemKind"
+      s: "float"
+      type: STRING
+    }
+    attribute {
+      name: "i1_shape"
+      ints: 10
+      ints: 10
+      type: INTS
+    }
+    attribute {
+      name: "o0_elemKind"
+      s: "float"
+      type: STRING
+    }
+    attribute {
+      name: "o0_shape"
+      ints: 10
+      ints: 10
+      type: INTS
+    }
+    attribute {
+      name: "partitionName"
+      s: "main_p0"
+      type: STRING
+    }
+  }
+  node {
+    input: "mul_out"
+    input: "tmp_add_out"
+    output: "res__1"
+    name: "res__1"
+    op_type: "Glow_Sub"
+    attribute {
+      name: "i0_elemKind"
+      s: "float"
+      type: STRING
+    }
+    attribute {
+      name: "i0_shape"
+      ints: 10
+      ints: 10
+      type: INTS
+    }
+    attribute {
+      name: "i1_elemKind"
+      s: "float"
+      type: STRING
+    }
+    attribute {
+      name: "i1_shape"
+      ints: 10
+      ints: 10
+      type: INTS
+    }
+    attribute {
+      name: "o0_elemKind"
+      s: "float"
+      type: STRING
+    }
+    attribute {
+      name: "o0_shape"
+      ints: 10
+      ints: 10
+      type: INTS
+    }
+    attribute {
+      name: "partitionName"
+      s: "main_p0"
+      type: STRING
+    }
+  }
+  node {
+    input: "res__1"
+    output: "res"
+    name: "res_save"
+    op_type: "Identity"
+    attribute {
+      name: "partitionName"
+      s: "main_p0"
+      type: STRING
+    }
+  }
+  name: "glow"
+  input {
+    name: "mm0_in"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 10
+          }
+          dim {
+            dim_value: 10
+          }
+        }
+      }
+    }
+    doc_string: "$offline:0$trainable:0$layout:*$elemKind:float"
+  }
+  input {
+    name: "add_in"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 10
+          }
+          dim {
+            dim_value: 10
+          }
+        }
+      }
+    }
+    doc_string: "$offline:0$trainable:0$layout:*$elemKind:float"
+  }
+  input {
+    name: "mm1_in"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 10
+          }
+          dim {
+            dim_value: 10
+          }
+        }
+      }
+    }
+    doc_string: "$offline:0$trainable:0$layout:*$elemKind:float"
+  }
+  output {
+    name: "res"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 10
+          }
+          dim {
+            dim_value: 10
+          }
+        }
+      }
+    }
+    doc_string: "$offline:0$trainable:0$layout:*$elemKind:float$saveName:res_save"
+  }
+}
+opset_import {
+  version: 9
+}
+metadata_props {
+  key: "numPartitions"
+  value: "3"
+}
+metadata_props {
+  key: "partition_0_name"
+  value: "main_p0"
+}
+metadata_props {
+  key: "partition_0_numLogicalDevices"
+  value: "1"
+}
+metadata_props {
+  key: "partition_0_logicalDevice_0"
+  value: "2"
+}
+metadata_props {
+  key: "partition_0_backendName"
+  value: "Interpreter"
+}
+metadata_props {
+  key: "partition_0_size"
+  value: "1600"
+}
+metadata_props {
+  key: "partition_0_BackendHint_executionUnits"
+  value: "0"
+}
+metadata_props {
+  key: "partition_0_numBackendSpecificOpts"
+  value: "0"
+}
+metadata_props {
+  key: "partition_0_replicationCount"
+  value: "1"
+}
+metadata_props {
+  key: "partition_1_name"
+  value: "main_p2"
+}
+metadata_props {
+  key: "partition_1_numLogicalDevices"
+  value: "1"
+}
+metadata_props {
+  key: "partition_1_logicalDevice_0"
+  value: "2"
+}
+metadata_props {
+  key: "partition_1_backendName"
+  value: "Interpreter"
+}
+metadata_props {
+  key: "partition_1_size"
+  value: "1200"
+}
+metadata_props {
+  key: "partition_1_BackendHint_executionUnits"
+  value: "0"
+}
+metadata_props {
+  key: "partition_1_numBackendSpecificOpts"
+  value: "3"
+}
+metadata_props {
+  key: "partition_1_backendSpecificOpts_key_0"
+  value: "BackendA_opt1"
+}
+metadata_props {
+  key: "partition_1_backendSpecificOpts_val_0"
+  value: "val1"
+}
+metadata_props {
+  key: "partition_1_backendSpecificOpts_key_1"
+  value: "BackendA_opt2"
+}
+metadata_props {
+  key: "partition_1_backendSpecificOpts_val_1"
+  value: "val2"
+}
+metadata_props {
+  key: "partition_1_backendSpecificOpts_key_2"
+  value: "BackendB_opt3"
+}
+metadata_props {
+  key: "partition_1_backendSpecificOpts_val_2"
+  value: "val3"
+}
+metadata_props {
+  key: "partition_1_replicationCount"
+  value: "1"
+}
+metadata_props {
+  key: "partition_2_name"
+  value: "main_p1"
+}
+metadata_props {
+  key: "partition_2_numLogicalDevices"
+  value: "2"
+}
+metadata_props {
+  key: "partition_2_logicalDevice_0"
+  value: "1"
+}
+metadata_props {
+  key: "partition_2_logicalDevice_1"
+  value: "0"
+}
+metadata_props {
+  key: "partition_2_backendName"
+  value: "Interpreter"
+}
+metadata_props {
+  key: "partition_2_size"
+  value: "1200"
+}
+metadata_props {
+  key: "partition_2_BackendHint_executionUnits"
+  value: "0"
+}
+metadata_props {
+  key: "partition_2_numBackendSpecificOpts"
+  value: "0"
+}
+metadata_props {
+  key: "partition_2_replicationCount"
+  value: "1"
+}

--- a/tests/unittests/CMakeLists.txt
+++ b/tests/unittests/CMakeLists.txt
@@ -482,8 +482,10 @@ target_link_libraries(PartitionerTest
                         Backend
                         Backends
                         ExecutionEngine
+                        Exporter
                         Graph
                         GraphOptimizer
+                        Importer
                         IR
                         Partitioner
                         gtest

--- a/tests/unittests/Caffe2ImporterTest.cpp
+++ b/tests/unittests/Caffe2ImporterTest.cpp
@@ -3009,6 +3009,12 @@ TEST_F(Caffe2ImporterTest, importSqr) {
   EE.compile(CompilationMode::Infer);
 }
 
+/// \returns whether \p val is found in \p vec.
+static bool vecContainsVal(const std::vector<runtime::DeviceIDTy> &vec,
+                           runtime::DeviceIDTy val) {
+  return std::find(vec.begin(), vec.end(), val) != vec.end();
+}
+
 /// Verify that different fill types are loaded with the correct types into
 /// their respective partitions specified in the C2 proto.
 TEST_F(Caffe2ImporterTest, PrePartitionedTensorFillsTest) {
@@ -3057,18 +3063,18 @@ TEST_F(Caffe2ImporterTest, PrePartitionedTensorFillsTest) {
     if (F->getName() == "main_p0") {
       P0 = F;
       ASSERT_EQ(PPC.logicalIDs[i].size(), 2);
-      EXPECT_TRUE(PPC.logicalIDs[i].count(0));
-      EXPECT_TRUE(PPC.logicalIDs[i].count(2));
+      EXPECT_TRUE(vecContainsVal(PPC.logicalIDs[i], 0));
+      EXPECT_TRUE(vecContainsVal(PPC.logicalIDs[i], 2));
     } else if (F->getName() == "main_p1") {
       P1 = F;
       ASSERT_EQ(PPC.logicalIDs[i].size(), 1);
-      EXPECT_TRUE(PPC.logicalIDs[i].count(1));
+      EXPECT_TRUE(vecContainsVal(PPC.logicalIDs[i], 1));
     } else if (F->getName() == "main_p2") {
       P2 = F;
     } else {
       FAIL() << "Unknown Function found.";
       ASSERT_EQ(PPC.logicalIDs[i].size(), 1);
-      EXPECT_TRUE(PPC.logicalIDs[i].count(2));
+      EXPECT_TRUE(vecContainsVal(PPC.logicalIDs[i], 2));
     }
 
     // Check that the function was also found in the module.
@@ -3193,18 +3199,18 @@ TEST_F(Caffe2ImporterTest, PrePartitionedMultiOpTest) {
       if (F->getName() == "main_p0") {
         P0 = F;
         ASSERT_EQ(PPC.logicalIDs[i].size(), 1);
-        EXPECT_TRUE(PPC.logicalIDs[i].count(2));
+        EXPECT_TRUE(vecContainsVal(PPC.logicalIDs[i], 2));
         EXPECT_EQ(PPC.backendSpecificOpts[i].size(), 0);
       } else if (F->getName() == "main_p1") {
         P1 = F;
         ASSERT_EQ(PPC.logicalIDs[i].size(), 2);
-        EXPECT_TRUE(PPC.logicalIDs[i].count(0));
-        EXPECT_TRUE(PPC.logicalIDs[i].count(1));
+        EXPECT_TRUE(vecContainsVal(PPC.logicalIDs[i], 0));
+        EXPECT_TRUE(vecContainsVal(PPC.logicalIDs[i], 1));
         EXPECT_EQ(PPC.backendSpecificOpts[i].size(), 0);
       } else if (F->getName() == "main_p2") {
         P2 = F;
         ASSERT_EQ(PPC.logicalIDs[i].size(), 1);
-        EXPECT_TRUE(PPC.logicalIDs[i].count(2));
+        EXPECT_TRUE(vecContainsVal(PPC.logicalIDs[i], 2));
         EXPECT_EQ(PPC.backendSpecificOpts[i].size(), 3);
         ASSERT_TRUE(PPC.backendSpecificOpts[i].count("BackendA_opt1"));
         EXPECT_EQ(PPC.backendSpecificOpts[i].at("BackendA_opt1"), "val1");

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -3837,3 +3837,197 @@ TEST_F(OnnxImporterTest, CustomGlowWithNodeOpts) {
   EXPECT_EQ(itOpt3->second[0], "4");
   EXPECT_EQ(itOpt3->second[1], "5");
 }
+
+static bool vecContainsVal(const std::vector<runtime::DeviceIDTy> &vec,
+                           runtime::DeviceIDTy val) {
+  return std::find(vec.begin(), vec.end(), val) != vec.end();
+}
+
+/// Test loading a custom ONNX Glow net that has been already partitioned,
+/// turned into a DAG, and then exported.
+TEST_F(OnnxImporterTest, CustomGlowDAGMultiOp) {
+  ExecutionEngine EE("Interpreter", /* deviceMemory (16GB) */ 0x400000000,
+                     /* ignoreUserDeviceConfig */ false, /* numDevices */ 3);
+  auto &mod = EE.getModule();
+  std::string netFilename(
+      GLOW_DATA_PATH
+      "tests/models/onnxModels/glow_custom_dag_multi_op.onnxtxt");
+
+  Placeholder *outputPH;
+  Tensor *resultPartitionedT;
+  PlaceholderBindings bindingsU;
+  PlaceholderBindings bindingsP;
+
+  runtime::PrePartitionedConfig PPC;
+  Tensor mmIn0T(ElemKind::FloatTy, {10, 10});
+  Tensor mmIn1T(ElemKind::FloatTy, {10, 10});
+  Tensor addInT(ElemKind::FloatTy, {10, 10});
+  mmIn0T.getHandle().randomize(-3.0, 3.0, mod.getPRNG());
+  mmIn1T.getHandle().randomize(-3.0, 3.0, mod.getPRNG());
+  addInT.getHandle().randomize(-3.0, 3.0, mod.getPRNG());
+  Placeholder *mmIn0P = nullptr, *mmIn1P = nullptr, *addInP = nullptr;
+  {
+    ONNXModelLoader onnxLD(netFilename, {}, {}, mod, "main", &PPC,
+                           /* errPtr */ nullptr, /* zipMode */ false);
+    outputPH = EXIT_ON_ERR(onnxLD.getSingleOutput());
+    NodeValue mmIn0NV;
+    ASSIGN_VALUE_OR_FAIL_TEST(mmIn0NV, onnxLD.getNodeValueByName("mm0_in"));
+    mmIn0P = llvm::dyn_cast<Placeholder>(mmIn0NV);
+    NodeValue mmIn1NV;
+    ASSIGN_VALUE_OR_FAIL_TEST(mmIn1NV, onnxLD.getNodeValueByName("mm1_in"));
+    mmIn1P = llvm::dyn_cast<Placeholder>(mmIn1NV);
+    NodeValue addInNV;
+    ASSIGN_VALUE_OR_FAIL_TEST(addInNV, onnxLD.getNodeValueByName("add_in"));
+    addInP = llvm::dyn_cast<Placeholder>(addInNV);
+  }
+
+  {
+    ASSERT_TRUE(mmIn0P);
+    ASSERT_TRUE(mmIn1P);
+    ASSERT_TRUE(addInP);
+
+    ASSERT_EQ(mod.getFunctions().size(), 3);
+    Function *P0 = nullptr, *P1 = nullptr, *P2 = nullptr;
+    for (size_t i = 0, e = PPC.funcs.size(); i < e; i++) {
+      // Find the expected Function, and check that the logical device IDs were
+      // correctly loaded.
+      Function *F = PPC.funcs[i];
+      if (F->getName() == "main_p0") {
+        P0 = F;
+        ASSERT_EQ(PPC.logicalIDs[i].size(), 1);
+        EXPECT_TRUE(vecContainsVal(PPC.logicalIDs[i], 2));
+        EXPECT_EQ(PPC.backendSpecificOpts[i].size(), 0);
+      } else if (F->getName() == "main_p1") {
+        P1 = F;
+        ASSERT_EQ(PPC.logicalIDs[i].size(), 2);
+        EXPECT_TRUE(vecContainsVal(PPC.logicalIDs[i], 0));
+        EXPECT_TRUE(vecContainsVal(PPC.logicalIDs[i], 1));
+        EXPECT_EQ(PPC.backendSpecificOpts[i].size(), 0);
+      } else if (F->getName() == "main_p2") {
+        P2 = F;
+        ASSERT_EQ(PPC.logicalIDs[i].size(), 1);
+        EXPECT_TRUE(vecContainsVal(PPC.logicalIDs[i], 2));
+        EXPECT_EQ(PPC.backendSpecificOpts[i].size(), 3);
+        ASSERT_TRUE(PPC.backendSpecificOpts[i].count("BackendA_opt1"));
+        EXPECT_EQ(PPC.backendSpecificOpts[i].at("BackendA_opt1"), "val1");
+        ASSERT_TRUE(PPC.backendSpecificOpts[i].count("BackendA_opt2"));
+        EXPECT_EQ(PPC.backendSpecificOpts[i].at("BackendA_opt2"), "val2");
+        ASSERT_TRUE(PPC.backendSpecificOpts[i].count("BackendB_opt3"));
+        EXPECT_EQ(PPC.backendSpecificOpts[i].at("BackendB_opt3"), "val3");
+      } else {
+        FAIL() << "Unknown Function found.";
+      }
+
+      // Check that the function was also found in the module.
+      auto &modFuns = mod.getFunctions();
+      ASSERT_NE(std::find(modFuns.begin(), modFuns.end(), F), modFuns.end());
+    }
+    ASSERT_TRUE(P0);
+    ASSERT_TRUE(P1);
+    ASSERT_TRUE(P2);
+
+    // Verify P0:
+    auto *finalSave = getSaveNodeFromDest(outputPH);
+    ASSERT_TRUE(finalSave);
+    EXPECT_EQ(finalSave->getParent(), P0);
+    SubNode *sub = llvm::dyn_cast<SubNode>(finalSave->getInput());
+    ASSERT_TRUE(sub);
+    Placeholder *intermedAddOut = llvm::dyn_cast<Placeholder>(sub->getRHS());
+    ASSERT_TRUE(intermedAddOut);
+    MulNode *mul = llvm::dyn_cast<MulNode>(sub->getLHS());
+    ASSERT_TRUE(mul);
+    Placeholder *intermedMMOut = llvm::dyn_cast<Placeholder>(mul->getRHS());
+    ASSERT_TRUE(intermedMMOut);
+    Placeholder *mmIn0 = llvm::dyn_cast<Placeholder>(mul->getLHS());
+    ASSERT_TRUE(mmIn0);
+
+    // Verify P2:
+    Node *userFromP2 = nullptr;
+    for (auto &U : intermedAddOut->getUsers()) {
+      if (U.getUser()->getParent() == P2) {
+        ASSERT_FALSE(userFromP2);
+        userFromP2 = U.getUser();
+      }
+    }
+    ASSERT_TRUE(userFromP2);
+    SaveNode *saveIntermedP2Out = llvm::dyn_cast<SaveNode>(userFromP2);
+    ASSERT_TRUE(saveIntermedP2Out);
+    AddNode *add = llvm::dyn_cast<AddNode>(saveIntermedP2Out->getInput());
+    ASSERT_TRUE(add);
+    Placeholder *addIn = llvm::dyn_cast<Placeholder>(add->getRHS());
+    ASSERT_TRUE(addIn);
+    EXPECT_EQ(add->getLHS().getNode(), intermedMMOut);
+
+    // Verify P1:
+    Node *userFromP1 = nullptr;
+    for (auto &U : intermedMMOut->getUsers()) {
+      if (U.getUser()->getParent() == P1) {
+        ASSERT_FALSE(userFromP1);
+        userFromP1 = U.getUser();
+      }
+    }
+    ASSERT_TRUE(userFromP1);
+    SaveNode *saveIntermedP1Out = llvm::dyn_cast<SaveNode>(userFromP1);
+    ASSERT_TRUE(saveIntermedP1Out);
+    MatMulNode *matMul =
+        llvm::dyn_cast<MatMulNode>(saveIntermedP1Out->getInput());
+    ASSERT_TRUE(matMul);
+    EXPECT_EQ(matMul->getLHS().getNode(), mmIn0);
+    Placeholder *matMulIn = llvm::dyn_cast<Placeholder>(matMul->getRHS());
+    ASSERT_TRUE(matMulIn);
+
+    // Now that we've verifed the shape of the Module, run it and keep around
+    // the pointer to the result.
+    CompilationContext cctx;
+    cctx.prepartitionedConfig = &PPC;
+    EE.compile(cctx);
+    bindingsP.insert(mmIn0P, mmIn0T.getUnowned());
+    bindingsP.insert(mmIn1P, mmIn1T.getUnowned());
+    bindingsP.insert(addInP, addInT.getUnowned());
+    bindingsP.allocate(mod.getPlaceholders());
+    EE.run(bindingsP);
+
+    resultPartitionedT = bindingsP.get(outputPH);
+  }
+
+  // Now that we have the model result from pre-partitioned execution, execute
+  // the model ignoring the pre-partitioning and bitwise compare results.
+  EE.setBackendName(EE.getBackendName());
+
+  Module &modU = EE.getModule();
+  {
+    Function *F = modU.createFunction("main");
+    ONNXModelLoader onnxLD(netFilename, {}, {}, *F);
+    outputPH = EXIT_ON_ERR(onnxLD.getSingleOutput());
+    NodeValue mmIn0NV;
+    ASSIGN_VALUE_OR_FAIL_TEST(mmIn0NV, onnxLD.getNodeValueByName("mm0_in"));
+    mmIn0P = llvm::dyn_cast<Placeholder>(mmIn0NV);
+    NodeValue mmIn1NV;
+    ASSIGN_VALUE_OR_FAIL_TEST(mmIn1NV, onnxLD.getNodeValueByName("mm1_in"));
+    mmIn1P = llvm::dyn_cast<Placeholder>(mmIn1NV);
+    NodeValue addInNV;
+    ASSIGN_VALUE_OR_FAIL_TEST(addInNV, onnxLD.getNodeValueByName("add_in"));
+    addInP = llvm::dyn_cast<Placeholder>(addInNV);
+  }
+
+  Tensor *resultUnpartitonedT;
+
+  {
+    ASSERT_TRUE(mmIn0P);
+    ASSERT_TRUE(mmIn1P);
+    ASSERT_TRUE(addInP);
+    ASSERT_EQ(modU.getFunctions().size(), 1);
+
+    EE.compile(CompilationMode::Infer);
+    bindingsU.insert(mmIn0P, mmIn0T.getUnowned());
+    bindingsU.insert(mmIn1P, mmIn1T.getUnowned());
+    bindingsU.insert(addInP, addInT.getUnowned());
+    bindingsU.allocate(modU.getPlaceholders());
+    EE.run(bindingsU);
+
+    resultUnpartitonedT = bindingsU.get(outputPH);
+  }
+
+  EXPECT_TRUE(resultPartitionedT->isBitwiseEqual(*resultUnpartitonedT,
+                                                 /* verbose */ true));
+}

--- a/tests/unittests/PartitionerTest.cpp
+++ b/tests/unittests/PartitionerTest.cpp
@@ -1460,9 +1460,10 @@ TEST_F(PartitionerTest, PrePartitionedTest) {
   PPC.funcs.push_back(F1);
   PPC.funcs.push_back(F2);
   PPC.logicalIDs.resize(3);
-  PPC.logicalIDs[0].insert(0);
-  PPC.logicalIDs[1].insert(1);
-  PPC.logicalIDs[2].insert({1, 2});
+  PPC.logicalIDs[0].push_back(0);
+  PPC.logicalIDs[1].push_back(1);
+  PPC.logicalIDs[2].push_back(1);
+  PPC.logicalIDs[2].push_back(2);
   PPC.backendSpecificOpts.emplace_back(
       BackendSpecificOptions{{"opt0", "val0"}, {"opt1", "val1"}});
   PPC.backendSpecificOpts.emplace_back(

--- a/tests/unittests/Repro.cpp
+++ b/tests/unittests/Repro.cpp
@@ -420,12 +420,14 @@ int run() {
 
   // Build the execution engine and deserialize the Function.
   auto mod = glow::make_unique<Module>();
-  Function *F = mod->createFunction("test");
   Error err = Error::empty();
   bool usingGlowCustomOps = false;
   CompilationContext cctx;
+  runtime::PrePartitionedConfig PPC;
+  cctx.prepartitionedConfig = &PPC;
   {
-    ONNXModelLoader onnxLD(modelPathOpt, {}, {}, *F, &err, onnxLoaderZipMode,
+    ONNXModelLoader onnxLD(modelPathOpt, {}, {}, *mod, "test", &PPC, &err,
+                           onnxLoaderZipMode,
                            &cctx.backendOpts.backendSpecificNodeInfo);
     usingGlowCustomOps = onnxLD.usingGlowCustomOps();
   }
@@ -433,8 +435,8 @@ int run() {
       << "ONNXModelLoader failed to load model: " << modelPathOpt;
   llvm::outs() << "End onnx model load\n";
 
-  if (glowDumpGraphAfterLoadOpt) {
-    F->dumpDAG("dag.dot");
+  for (Function *F : mod->getFunctions()) {
+    F->dumpDAG(F->getName().str() + ".dot");
   }
 
   // Build host manager and compile the module.


### PR DESCRIPTION
Summary: Support loading serialized DAGs. This is similar to the C2 loader for pre-partitioned models, but it includes more info for the DAG to reload. This DAG info is saved as a `metadata_prop`.

Differential Revision: D21036912

