### PR TITLE
Disable load_balanced_partitioner for en2gr partition test

### DIFF
--- a/tests/text-translator/en2gr_cpu_config_test.sh
+++ b/tests/text-translator/en2gr_cpu_config_test.sh
@@ -17,4 +17,4 @@
 set -euxo pipefail
 
 # CHECK: ich liebe Musik \.$
-$BIN/text-translator -m "${MODELS_DIR}/en2gr" -backend=CPU -cpu-memory=500000 -load-device-configs="tests/runtime_test/cpuConfigs.yaml" <<< "I love music ."
+$BIN/text-translator -m "${MODELS_DIR}/en2gr" -backend=CPU -cpu-memory=500000 -glow_partitioner_enable_load_balance=0 -load-device-configs="tests/runtime_test/cpuConfigs.yaml" <<< "I love music ."

--- a/tests/text-translator/en2gr_cpu_partition_test.sh
+++ b/tests/text-translator/en2gr_cpu_partition_test.sh
@@ -17,4 +17,4 @@
 set -euxo pipefail
 
 # CHECK: ich liebe Musik \.$
-$BIN/text-translator -m "${MODELS_DIR}/en2gr" -backend=CPU -cpu-memory=500000 -num-devices=2 <<< "I love music ."
+$BIN/text-translator -m "${MODELS_DIR}/en2gr" -backend=CPU -cpu-memory=500000 -num-devices=2 -glow_partitioner_enable_load_balance=0 <<< "I love music ."


### PR DESCRIPTION
Summary:
en2gr partition test expects specific behavior of the greedy partitioner, now that load-balanced partitioning is default it fails, this sets the test to use the greedy partitioner.
Documentation:

Test Plan:
text-translator -m eng2r -backend=CPU -cpu-memory=500000 -num-devices=2 -glow_partitioner_enable_load_balance=0 and no longer crash.
