### PR TITLE
Fix build for GCC 5.4 - template definition in a different namespace

### DIFF
--- a/lib/Optimizer/GraphOptimizer/FunctionPassManager.cpp
+++ b/lib/Optimizer/GraphOptimizer/FunctionPassManager.cpp
@@ -19,7 +19,7 @@
 
 #include <glog/logging.h>
 
-using namespace glow;
+namespace glow {
 
 /// The purpose of ThePassManager alias is to make the code of this pass manager
 /// look as similar to other pass managers as possible. Often the changes in one
@@ -41,7 +41,7 @@ void ThePassManager::dumpIR(IRContainer *C, llvm::raw_ostream &os,
 }
 
 std::unique_ptr<ThePassManager::IRPassTy>
-glow::createFunctionPass(ThePassManager::PassIDTy passID) {
+createFunctionPass(ThePassManager::PassIDTy passID) {
   switch (passID) {
 #define FUN_PASS(PASS_NAME)                                                    \
   case (ThePassManager::PassIDTy::PASS_NAME):                                  \
@@ -75,7 +75,8 @@ bool ThePassManager::runPassHook(const PassConfigBase &passConfig, PassBase &P,
                                           cctx);
 }
 
-bool glow::runDCEPass(ThePassManager::IRContainerTy *F,
-                      CompilationContext &cctx) {
+bool runDCEPass(ThePassManager::IRContainerTy *F, CompilationContext &cctx) {
   return FunctionPassManager("DCE_FPM", {getDCEPassConfig()}).run(F, cctx);
 }
+
+} // namespace glow

--- a/lib/Optimizer/GraphOptimizerPipeline/FunctionPassPipeline.cpp
+++ b/lib/Optimizer/GraphOptimizerPipeline/FunctionPassPipeline.cpp
@@ -18,9 +18,9 @@
 #include "glow/Optimizer/GraphOptimizer/FunctionPassManager.h"
 #include "glow/Optimizer/GraphOptimizer/GraphOptimizer.h"
 
-using namespace glow;
+namespace glow {
 
-FunctionPassPipeline glow::createDefaultGraphOptimizationPassPipeline() {
+FunctionPassPipeline createDefaultGraphOptimizationPassPipeline() {
   return {
       // Sink transpose operations in an attempt to cancel them out.
       // Perform code sinking until a fixed-point is reached.
@@ -131,7 +131,7 @@ FunctionPassPipeline glow::createDefaultGraphOptimizationPassPipeline() {
   };
 }
 
-FunctionPassPipeline glow::createFP16GraphOptimizationPassPipeline() {
+FunctionPassPipeline createFP16GraphOptimizationPassPipeline() {
   return {
       // Optimize away intermediate type conversions.
       {FunctionPassID::OptimizeConversions},
@@ -141,7 +141,7 @@ FunctionPassPipeline glow::createFP16GraphOptimizationPassPipeline() {
   };
 }
 
-FunctionPassPipeline glow::createDefaultFoldPassPipeline() {
+FunctionPassPipeline createDefaultFoldPassPipeline() {
   return {
       // Get Reshape nodes merged into constants to simplify folding.
       {FunctionPassID::OptimizeReshape},
@@ -160,14 +160,14 @@ FunctionPassPipeline glow::createDefaultFoldPassPipeline() {
   };
 }
 
-FunctionPassConfig glow::getDCEPassConfig() {
+FunctionPassConfig getDCEPassConfig() {
   return {FunctionPassID::DCE,
           ConvergenceMode::OnePass,
           {CompilationMode::Infer, CompilationMode::Train},
           DCERequiredMode::None};
 }
 
-llvm::StringRef glow::getNameOfPass(FunctionPassID passID) {
+llvm::StringRef getNameOfPass(FunctionPassID passID) {
   switch (passID) {
 #define FUN_PASS(PASS_NAME)                                                    \
   case FunctionPassID::PASS_NAME:                                              \
@@ -193,3 +193,5 @@ void FunctionPassConfig::dump(llvm::raw_ostream &os) const {
   }
   os << "\n";
 }
+
+} // namespace glow

--- a/lib/Optimizer/IROptimizer/IRFunctionPassManager.cpp
+++ b/lib/Optimizer/IROptimizer/IRFunctionPassManager.cpp
@@ -19,7 +19,7 @@
 
 #include <glog/logging.h>
 
-using namespace glow;
+namespace glow {
 
 /// The purpose of ThePassManager alias is to make the code of this pass manager
 /// look as similar to other pass managers as possible. Often the changes in one
@@ -41,7 +41,7 @@ void ThePassManager::dumpIR(IRContainer *C, llvm::raw_ostream &os,
 }
 
 std::unique_ptr<ThePassManager::IRPassTy>
-glow::createFunctionPass(ThePassManager::PassIDTy passID) {
+createFunctionPass(ThePassManager::PassIDTy passID) {
   switch (passID) {
 #define IR_FUN_PASS(PASS_NAME)                                                 \
   case (ThePassManager::PassIDTy::PASS_NAME):                                  \
@@ -64,3 +64,5 @@ bool ThePassManager::runPassHook(const PassConfigBase &passConfig, PassBase &P,
   return static_cast<IRPassTy *>(&P)->run(static_cast<IRContainerTy *>(C),
                                           cctx);
 }
+
+} // namespace glow

--- a/lib/Optimizer/IROptimizerPipeline/IRFunctionPassPipeline.cpp
+++ b/lib/Optimizer/IROptimizerPipeline/IRFunctionPassPipeline.cpp
@@ -20,8 +20,6 @@
 
 #include "llvm/Support/CommandLine.h"
 
-using namespace glow;
-
 namespace {
 static llvm::cl::opt<bool>
     instrumentDebug("instrument-debug",
@@ -36,7 +34,9 @@ static llvm::cl::opt<bool> dumpIR("dump-ir",
                                   llvm::cl::desc("Prints IR to stdout"));
 } // namespace
 
-IRFunctionPassPipeline glow::createDefaultIRFunctionOptimizationPipeline() {
+namespace glow {
+
+IRFunctionPassPipeline createDefaultIRFunctionOptimizationPipeline() {
   if (!optimizeIR) {
     return {};
   }
@@ -70,7 +70,7 @@ IRFunctionPassPipeline glow::createDefaultIRFunctionOptimizationPipeline() {
   return pipeline;
 }
 
-llvm::StringRef glow::getNameOfPass(IRFunctionPassID passID) {
+llvm::StringRef getNameOfPass(IRFunctionPassID passID) {
   switch (passID) {
 #define IR_FUN_PASS(PASS_NAME)                                                 \
   case IRFunctionPassID::PASS_NAME:                                            \
@@ -83,3 +83,5 @@ llvm::StringRef glow::getNameOfPass(IRFunctionPassID passID) {
 template <> void IRFunctionPassConfig::dump(llvm::raw_ostream &os) const {
   PassConfigBase::dump(os, getNameOfPass(getPassID()));
 }
+
+} // namespace glow


### PR DESCRIPTION
Summary:
This fixes compilation for GCC 5.4.
The issue is with template definition in a different namespace than the one it was declared in.
See: http://www.cplusplus.com/forum/general/211640/#msg990839