### PR TITLE
Allow for Tensors with dimensions/sizes of 0

### DIFF
--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -664,6 +664,10 @@ struct Type final {
   size_t getSizeInBytes() const {
     size_t s = getElementSize();
     for (unsigned char i = 0; i < numSizes_; i++) {
+      // If any dimensions are 0 then the entire size is 0, so early return.
+      if (sizes_[i] == 0) {
+        return 0;
+      }
       s = std::max<dim_t>(s,
                           size_t(sizes_[i]) * getElementSize() * strides_[i]);
     }
@@ -793,7 +797,6 @@ private:
       }
       // All the strides (except for last one) depend on the previous dimension.
       strides_[i] = alignedSize(dims[i + 1] * strides_[i + 1], alignment);
-      assert(dims[i] > 0 && "Do not allow a dimension of zero.");
       sizes_[i] = dims[i];
     }
   }
@@ -802,7 +805,6 @@ private:
     assert(dims.size() <= max_tensor_dimensions && "Too many dimensions.");
     // Update the tensor sizes.
     for (size_t i = 0, e = dims.size(); i < e; i++) {
-      assert(dims[i] > 0 && "Do not allow a dimension of zero.");
       sizes_[i] = dims[i];
     }
     numSizes_ = dims.size();

--- a/lib/Base/Tensor.cpp
+++ b/lib/Base/Tensor.cpp
@@ -93,6 +93,12 @@ static void dumpGenericImpl(Handle<ElemTy> handle, llvm::raw_ostream &os,
   dumpShape(shape, os);
   os << "\n";
 
+  // Check for tensor of size 0.
+  if (handle.getUnpaddedSizeInBytes() == 0) {
+    os << "[ tensor has no elements ]\n";
+    return;
+  }
+
   ElemTy mx = handle.raw(0);
   ElemTy mn = handle.raw(0);
 

--- a/tests/unittests/TensorsTest.cpp
+++ b/tests/unittests/TensorsTest.cpp
@@ -55,6 +55,42 @@ TEST(Tensor, init) {
   H.dump();
 }
 
+/// Test that Tensors with zero-dimensions work as expected.
+TEST(Tensor, zeroDimTensors) {
+  Tensor T0(ElemKind::FloatTy, {0});
+  Tensor T1(ElemKind::FloatTy, {0, 100});
+  Tensor T2(ElemKind::FloatTy, {100, 0});
+
+  EXPECT_EQ(T0.getUnpaddedSizeInBytes(), 0);
+  EXPECT_EQ(T1.getUnpaddedSizeInBytes(), 0);
+  EXPECT_EQ(T2.getUnpaddedSizeInBytes(), 0);
+  EXPECT_EQ(T0.getSizeInBytes(), 0);
+  EXPECT_EQ(T1.getSizeInBytes(), 0);
+  EXPECT_EQ(T2.getSizeInBytes(), 0);
+  EXPECT_EQ(T0.size(), 0);
+  EXPECT_EQ(T1.size(), 0);
+  EXPECT_EQ(T2.size(), 0);
+
+  // Nothing is allocated for these tensors.
+  EXPECT_EQ(T0.getUnsafePtr(), nullptr);
+  EXPECT_EQ(T1.getUnsafePtr(), nullptr);
+  EXPECT_EQ(T2.getUnsafePtr(), nullptr);
+
+  T0.getHandle<>().dump();
+  T1.getHandle<>().dump();
+  T2.getHandle<>().dump();
+
+  // Now test getting unowned views of partial tensors that are zero sized.
+  Tensor T4(ElemKind::FloatTy, {10, 0, 10});
+  Type ty(ElemKind::FloatTy, {10, 5, 10});
+  Tensor T5(T4.getUnsafePtr(), &ty, T4.getSizeInBytes());
+  EXPECT_EQ(T4.getUnsafePtr(), T5.getUnsafePtr());
+  EXPECT_EQ(T5.getUnpaddedSizeInBytes(), 0);
+  EXPECT_EQ(T5.getSizeInBytes(), ty.getSizeInBytes());
+  EXPECT_EQ(T5.size(), ty.size());
+  T5.getHandle<>().dump();
+}
+
 TEST(Tensor, getSliceSize) {
   // Test the Type::getSliceSize() function.
 


### PR DESCRIPTION
Summary: Make it valid for there to be Tensors with some dimension of 0. These Tensors should always have size 0. I left their backing allocation to be nullptr, and added missing asserts for checking that the input index for any Handle is within the range of the size.

Reviewed By: yinghai

Differential Revision: D21121854

