### PR TITLE
glow: add some logging to provisioner

### DIFF
--- a/lib/Onnxifi/Flags.cpp
+++ b/lib/Onnxifi/Flags.cpp
@@ -362,7 +362,7 @@ DEFINE_validator(glow_nnpi_memory, [](const char *flagname, int32_t value) {
 });
 #endif
 
-DEFINE_bool(glow_log_partition, false, "Enable logging partition info");
+DEFINE_bool(glow_log_partition, true, "Enable logging partition info");
 DEFINE_validator(glow_log_partition, [](const char * /*unused*/, bool value) {
   glow::GlowLogPartition = value;
   return true;

--- a/lib/Partitioner/Partitioner.cpp
+++ b/lib/Partitioner/Partitioner.cpp
@@ -79,11 +79,10 @@ Error Partitioner::finalize(const DAGListTy &partitions,
   // needs the backend specific verifier. Tensor layouts, for example, might
   // have gone from canonical form to backend specific form.
 
-  LOG(INFO) << "The number of partitions is : "
-            << module_->getFunctions().size() << "\n";
-
   if (logPartition) {
-    LOG(INFO) << "Dumping partitioning DAG to DAG.dot file.\n";
+    LOG(INFO) << "The number of partitions is : "
+              << module_->getFunctions().size();
+    LOG(INFO) << "Dumping partitioning DAG to DAG.dot file.";
     dumpDAG("DAG.dot", partitions);
     logPartitionInfo(mapping);
   }


### PR DESCRIPTION
Summary:
- Add more logging about defer weights loading.
- Changed the default value for log partition in flags.cpp
- Fixed a bug where we were not actually waiting for callback from transferStaticPlaceholderToDevice() before checking the error code.

Differential Revision: D21140508

