### PR TITLE
Allow for zero-sized partial inputs

### DIFF
--- a/lib/Backends/NNPI/NNPIResource.cpp
+++ b/lib/Backends/NNPI/NNPIResource.cpp
@@ -382,7 +382,8 @@ bool NNPIResource::updateHostResourceFromTensor(Tensor *t, bool partialTensor) {
     default:
       LOG(ERROR) << "Invalid avxType=" << deviceOptions_->avxType;
     }
-  } else { // Copy
+  } else if (unpaddedSize) { // Only copy if there is data. Required because
+                             // tensorData cannot be null for memcpy.
     memcpy(hostPtr_, tensorData, unpaddedSize);
   }
 

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -277,8 +277,7 @@ onnxStatus Graph::adjustInputs(uint32_t inputsCount,
       ctx->getPlaceholderBindings()->insert(
           inPhPtr, Tensor(inOnnxBuffer, inPhPtr->getType()));
     } else if (GlowEnablePartialTensors &&
-               backendPtr_->getBackend().supportsPartialTensors() &&
-               inOnnxBuffer && inOnnxTensorSize > 0) {
+               backendPtr_->getBackend().supportsPartialTensors()) {
       // We have a partial input buffer.  Create a padded unowned tensor that
       // remembers the actual size of the input.
       ctx->getPlaceholderBindings()->insert(


### PR DESCRIPTION
Summary:
Previously the backend was not given an opportunity to simply skip copying zero-sized partial inputs -- in Onnxifi we always created a Tensor backing the Placeholder with all zeros.

Now that we can support partial zero-sized Tensors, allow for them to propagate into the backend for the backend to make this decision.

Note that Onnxifi was intelligently keeping around a single large zero Tensor which it reused for all such inputs that were smaller than that max size. So we may lose some perf here because the backend now need to create zeroed out allocations for all zero tensors if it's not a partial we can skip copying (i.e. not an Indices/Weights input for SLWS). We could do something similar in the backend to avoid these allocations.

Reviewed By: yinghai

Differential Revision: D21145596

