### PR TITLE
Require ElemKind for Function::createDequantize()

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -1301,8 +1301,9 @@ public:
 
   /// Create dequantization node which transforms quantized tensor to a
   /// floating point one with given Scale and Offset. Scale and Offset params
-  /// are part of the \p input.
-  DequantizeNode *createDequantize(llvm::StringRef name, NodeValue input);
+  /// are part of the \p input. Result dequantization kind is \p k.
+  DequantizeNode *createDequantize(llvm::StringRef name, NodeValue input,
+                                   ElemKind k);
 
   /// Create dequantization node which transforms quantized tensor to a
   /// floating point type \p outTy one with given Scale and Offset. Scale and

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -2332,11 +2332,11 @@ QuantizeNode *Function::createQuantize(llvm::StringRef name, NodeValue input,
 }
 
 DequantizeNode *Function::createDequantize(llvm::StringRef name,
-                                           NodeValue input) {
+                                           NodeValue input, ElemKind k) {
   assert(input.getType()->isQuantizedType() &&
          "Input must be a quantized type");
-  TypeRef outTy =
-      getParent()->uniqueType(Type(ElemKind::FloatTy, input.dims()));
+  assert(isFloatElemKind(k) && "Result must be float type.");
+  TypeRef outTy = getParent()->uniqueType(Type(k, input.dims()));
   return createDequantize(name, input, outTy);
 }
 

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -794,7 +794,7 @@ Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
   if (typeName == "Int8Dequantize") {
     NodeValue in;
     ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
-    auto *node = G_->createDequantize(opName, in);
+    auto *node = G_->createDequantize(opName, in, ElemKind::FloatTy);
     RETURN_IF_ERR(addNodeAsOutput(op, node));
     return Error::success();
   }

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -2971,7 +2971,7 @@ Error ONNXModelLoader::loadDequantize(const ONNX_NAMESPACE::NodeProto &op,
   NodeValue in;
   ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
 
-  Node *N = G_->createDequantize(loadOperatorName(op), in);
+  Node *N = G_->createDequantize(loadOperatorName(op), in, ElemKind::FloatTy);
 
   RETURN_IF_ERR(addNodeAsOutput(op, N));
   return Error::success();

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -3728,7 +3728,8 @@ bool OptimizeQuantization::run(Function *F, const CompilationContext &cctx) {
       // Dequantize(rescale) -> Dequantize()
       if (auto *RS = dyn_cast<RescaleQuantizedNode>(DQ->getInput())) {
         changed = true;
-        auto *newRS = F->createDequantize(DQ->getName(), RS->getInput());
+        auto *newRS = F->createDequantize(DQ->getName(), RS->getInput(),
+                                          DQ->getResult().getType());
         DQ->getResult().replaceAllUsesOfWith(newRS);
 
         // We may be able to optimize this rescale node. Remember to visit

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -370,7 +370,8 @@ bool SinkConversions::run(Function *F, const CompilationContext &cctx) {
       }
 
       DequantizeNode *newDequantize =
-          F->createDequantize(CN->getName().str() + "_dequantize", newCN);
+          F->createDequantize(CN->getName().str() + "_dequantize", newCN,
+                              CN->getResult().getType());
 
       CN->getResult().replaceAllUsesOfWith(newDequantize->getResult());
       changed = true;

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -429,9 +429,7 @@ protected:
     if (destTy->isQuantizedType()) {
       return function.createQuantize(nodeName + "_quantize", val, destTy);
     }
-    assert(destTy->getElementType() == ElemKind::FloatTy &&
-           "Can't dequantize to any type except float.");
-    return function.createDequantize(nodeName + "_dequantize", val);
+    return function.createDequantize(nodeName + "_dequantize", val, destTy);
   }
 
   /// All IRConstraint cases below assume that the input and output index that

--- a/tests/unittests/GraphOptzTest.cpp
+++ b/tests/unittests/GraphOptzTest.cpp
@@ -4509,7 +4509,10 @@ TEST_F(GraphOptz, SinkDequantizeBelowConcatTest) {
                                                 scale, offset, "input", false);
     bindings_.allocate(input)->getHandle<int8_t>().randomize(-100, 100,
                                                              mod_.getPRNG());
-    DequantizeNode *dequantize = F_->createDequantize("dequantize", input);
+    const TypeRef DQTy =
+        mod_.uniqueType(ElemKind::Float16Ty, input->getOutput().dims());
+    DequantizeNode *dequantize =
+        F_->createDequantize("dequantize", input, DQTy);
     inputs[i] = dequantize->getResult();
   }
   ConcatNode *concat = F_->createConcat("concat", inputs, 0);

--- a/tests/unittests/GraphTest.cpp
+++ b/tests/unittests/GraphTest.cpp
@@ -595,7 +595,7 @@ TEST(Graph, quantizeDequantizeNodes) {
       F->getParent()->uniqueType(ElemKind::Int8QTy, {1, 3}, 1.4, 3);
   auto *A = F->createRescaleQuantized("rescale", Q, transform);
 
-  auto *D = F->createDequantize("dequantize", A);
+  auto *D = F->createDequantize("dequantize", A, ElemKind::FloatTy);
   PlaceholderBindings bindings;
   F->createSave("ret", D);
   EE.compile(CompilationMode::Infer);

--- a/tests/unittests/HabanaGlowTest.cpp
+++ b/tests/unittests/HabanaGlowTest.cpp
@@ -780,7 +780,7 @@ TEST_F(HabanaBackendTest, QuantizedFC) {
   auto *fc = F_->createFullyConnected(
       "fc", qInput, qWeights, qBias,
       mod_.uniqueType(ElemKind::Int8QTy, {2, 32}, 1.0, 0));
-  auto *dq = F_->createDequantize("dq", fc);
+  auto *dq = F_->createDequantize("dq", fc, ElemKind::FloatTy);
   F_->createSave("save", dq, output);
 
   ctx_.allocate(input)->getHandle<float>().clear(1);
@@ -815,7 +815,7 @@ TEST_F(HabanaBackendTest, QuantizedNonZeroOffset) {
 
   auto *matmulq = F_->createSub("sub.q", resTy, lhsq, rhsq);
 
-  auto *rq = F_->createDequantize("dequant", matmulq);
+  auto *rq = F_->createDequantize("dequant", matmulq, ElemKind::FloatTy);
 
   auto *result = F_->createSave("save", rq);
   ctx_.allocate(result->getPlaceholder());

--- a/tests/unittests/QuantizationTest.cpp
+++ b/tests/unittests/QuantizationTest.cpp
@@ -426,7 +426,8 @@ void quantizeScalarTest(float val, ElemKind qTy, quantization::Schema schema) {
   auto *input = mod.createPlaceholder(ElemKind::FloatTy, {1}, "val", false);
   auto inputQTy = mod.uniqueType(qTy, {1}, TQP.scale, TQP.offset);
   QuantizeNode *quant = F->createQuantize("quant", input, inputQTy);
-  DequantizeNode *dequant = F->createDequantize("dequant", quant);
+  DequantizeNode *dequant =
+      F->createDequantize("dequant", quant, ElemKind::FloatTy);
   SaveNode *save = F->createSave("save", dequant);
 
   // Allocate placeholders, set input, run, get output
@@ -1385,7 +1386,7 @@ TEST(Quantization, rescaleSameType) {
 
   auto *Q = F->createRescaleQuantized(
       "rescale", input, mod.uniqueType(ElemKind::Int8QTy, {1, 1}, 0.5, 11));
-  auto *D = F->createDequantize("dequantize", Q);
+  auto *D = F->createDequantize("dequantize", Q, ElemKind::FloatTy);
   auto *save = F->createSave("ret", D);
   auto *result = bindings.allocate(save->getPlaceholder());
 
@@ -1413,7 +1414,7 @@ TEST(Quantization, optimizeRescaleQuantize) {
       "quant", input, mod.uniqueType(ElemKind::Int8QTy, {1, 1}, 0.25, 4));
   auto *RS = F->createRescaleQuantized(
       "rescale", Q, mod.uniqueType(ElemKind::Int8QTy, {1, 1}, 0.5, 11));
-  auto *D = F->createDequantize("dequantize", RS);
+  auto *D = F->createDequantize("dequantize", RS, ElemKind::FloatTy);
   auto *save = F->createSave("ret", D);
   auto *result = bindings.allocate(save->getPlaceholder());
 
@@ -1576,7 +1577,7 @@ TEST(Quantization, reluCanUseSymmetricSchema) {
                         mod.uniqueType(ElemKind::Int8QTy, {10},
                                        inputParams.scale, inputParams.offset));
   ReluNode *RN = F->createRELU("relu", QN, reluTy);
-  DequantizeNode *DN = F->createDequantize("dequantize", RN);
+  DequantizeNode *DN = F->createDequantize("dequantize", RN, ElemKind::FloatTy);
   SaveNode *SN = F->createSave("save", DN);
   auto *res = bindings.allocate(SN->getPlaceholder());
 

--- a/tests/unittests/RecommendationSystemTest.cpp
+++ b/tests/unittests/RecommendationSystemTest.cpp
@@ -504,7 +504,7 @@ protected:
         /* transposeWeight */ true);
 
     auto *RN = F_->createRELU("relu", end_layer);
-    auto *DQN = F_->createDequantize("mlp_dequant", RN);
+    auto *DQN = F_->createDequantize("mlp_dequant", RN, ElemKind::FloatTy);
 
     return DQN->getResult();
   }

--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -985,7 +985,7 @@ PyTorchModelLoader::getGlowIValueForValue(const torch::jit::Value *value) {
 glow::NodeValue PyTorchModelLoader::rescaleUIntToInt(glow::NodeValue input) {
   auto *inputTy = input.getType();
   if (inputTy->getElementType() == ElemKind::UInt8QTy) {
-    auto dqInput = F_.createDequantize("dequantize", input);
+    auto dqInput = F_.createDequantize("dequantize", input, ElemKind::FloatTy);
     auto *outputTy = F_.getParent()->uniqueType(
         ElemKind::Int8QTy, inputTy->dims(), inputTy->getScale(),
         inputTy->getOffset() - OFFSETSHIFT);
@@ -999,7 +999,7 @@ glow::NodeValue PyTorchModelLoader::rescaleUIntToInt(glow::NodeValue input) {
 glow::NodeValue PyTorchModelLoader::rescaleIntToUint(glow::NodeValue input) {
   auto *inputTy = input.getType();
   if (inputTy->getElementType() == ElemKind::Int8QTy) {
-    auto dqInput = F_.createDequantize("dequantize", input);
+    auto dqInput = F_.createDequantize("dequantize", input, ElemKind::FloatTy);
     auto *outputTy = F_.getParent()->uniqueType(
         ElemKind::UInt8QTy, inputTy->dims(), inputTy->getScale(),
         inputTy->getOffset() + OFFSETSHIFT);
@@ -2419,7 +2419,8 @@ Error PyTorchModelLoader::loadDequantize(const torch::jit::Node *ptNode) {
   glow::NodeValue input;
   ASSIGN_VALUE_OR_RETURN_ERR(input, getGlowNodeValueForValue(inputs[0]));
 
-  glow::DequantizeNode *dn = F_.createDequantize("dequantize", input);
+  glow::DequantizeNode *dn =
+      F_.createDequantize("dequantize", input, ElemKind::FloatTy);
 
   c10::ScalarType dtype;
   RETURN_IF_ERR(getCorrectTypeMapping(dtype, inputs[0]));


### PR DESCRIPTION
Summary: This API was leading to subtle bugs. Require that the ElemKind to dequantize to is specified.

Differential Revision: D21148678

