### PR TITLE
Run scripted conv3d model with fp32 bias in glow interpreter

### DIFF
--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -244,7 +244,7 @@ bool NNPIBackend::isOpSupported(const NodeInfo &NI) const {
     }
     return NI.allInputsAndOutputsHaveSameElemKind(
                {ElemKind::Int8QTy}, {FullyConnectedNode::BiasIdx}) &&
-           (NI.getInElemTy(FullyConnectedNode::BiasIdx) == ElemKind::Int32QTy);
+           (NI.getInElemTy(FullyConnectedNode::BiasIdx) == ElemKind::Int32QTy || NI.getInElemTy(FullyConnectedNode::BiasIdx) == ElemKind::FloatTy);
 
   case Kinded::Kind::MaxPoolNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(


### PR DESCRIPTION
Summary: Add bias quantization in createConv3d op

Differential Revision: D21173237

