### PR TITLE
Add option to serialize DAG after optimizations and partitioning

### DIFF
--- a/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
+++ b/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
@@ -195,6 +195,9 @@ struct CompilationContext {
   /// user-defined partitioning.
   unsigned replicationCount{1};
 
+  /// Whether to serialize the DAG that has been optimized and partitioned.
+  bool serializeCompiledDAG{false};
+
   CompilationContext(PlaceholderBindings *bindings_ = nullptr,
                      LoweredInfoMap *loweredInfoMap_ = nullptr)
       : bindings(bindings_), loweredInfoMap(loweredInfoMap_) {}

--- a/lib/Onnxifi/Flags.cpp
+++ b/lib/Onnxifi/Flags.cpp
@@ -1,3 +1,19 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <gflags/gflags.h>
 
 namespace glow {
@@ -19,6 +35,7 @@ extern bool GlowClipFP16;
 extern bool GlowClipFP16SkipInputs;
 extern bool GlowSaturateHost;
 extern bool GlowSaveOnnxifiModel;
+extern bool GlowSaveOnnxifiDAG;
 extern bool GlowSaveOnnxifiIO;
 extern bool GlowEnablePartialTensors;
 extern bool GlowUseCustomOpsForExport;
@@ -196,6 +213,14 @@ DEFINE_bool(glow_saturate_host, false,
             "Try to use all available devices on the host");
 DEFINE_validator(glow_saturate_host, [](const char *flagname, bool value) {
   glow::onnxifi::GlowSaturateHost = value;
+  return true;
+});
+
+DEFINE_bool(
+    glow_save_onnxifi_dag, false,
+    "Whether to serialize the DAG that has been optimized and partitioned.");
+DEFINE_validator(glow_save_onnxifi_dag, [](const char *flagname, bool value) {
+  glow::onnxifi::GlowSaveOnnxifiDAG = value;
   return true;
 });
 

--- a/lib/Onnxifi/HostManagerOnnxifi.cpp
+++ b/lib/Onnxifi/HostManagerOnnxifi.cpp
@@ -47,6 +47,7 @@ bool GlowSparseNNPartitioningAddSLSConcats = false;
 size_t GlowMaxActiveRequests = 48;
 size_t GlowMaxQueueSize = 100;
 size_t GlowExecutorThreads = 10;
+bool GlowSaveOnnxifiDAG = false;
 
 static llvm::cl::opt<int32_t, true>
     GlowNumDevicesOpt("glow-num-devices",
@@ -215,6 +216,10 @@ onnxStatus HostManagerBackend::addNetwork(std::unique_ptr<Module> module,
   }
   if (GlowDumpGraph) {
     cctx.dumpFinalGraph = true;
+  }
+  if (GlowSaveOnnxifiDAG) {
+    LOG(INFO) << "Serializing DAG after optimization and partitioning.";
+    cctx.serializeCompiledDAG = true;
   }
   cctx.saturateHost = GlowSaturateHost;
 

--- a/lib/Runtime/HostManager/CMakeLists.txt
+++ b/lib/Runtime/HostManager/CMakeLists.txt
@@ -6,6 +6,7 @@ target_link_libraries(HostManager
                         Backends
                         Base
                         Executor
+                        Exporter
                         Graph
                         GraphOptimizer
                         Partitioner

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -16,6 +16,7 @@
 
 #include "glow/Runtime/HostManager/HostManager.h"
 #include "glow/Backends/DeviceManager.h"
+#include "glow/Exporter/ONNXModelWriter.h"
 #include "glow/Graph/PlaceholderBindings.h"
 #include "glow/Optimizer/GraphOptimizer/GraphOptimizer.h"
 #include "glow/Partitioner/Partitioner.h"
@@ -25,6 +26,7 @@
 #include "glow/Support/Support.h"
 
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/FormatVariadic.h"
 
 #include <glog/logging.h>
@@ -235,6 +237,19 @@ Error HostManager::addNetwork(std::unique_ptr<Module> module,
     std::unique_lock<std::shared_timed_mutex> networkLock(networkLock_);
     cleanupAddNetwork(names);
     return result.takeError();
+  }
+
+  // If requested, serialize the resulting DAG that was just optimized and
+  // partitioned.
+  if (cctx.serializeCompiledDAG) {
+    std::string loc = nodeList.begin()->root->name + ".zip";
+    LOG(INFO) << "Serializing DAG to " << loc;
+    {
+      Error writeErr = Error::empty();
+      ONNXModelWriter onnxWR(loc, nodeList, 7, 9, &writeErr,
+                             /* textMode */ false, /* zipMode */ true);
+      RETURN_IF_ERR(writeErr);
+    }
   }
 
   if (cctx.precisionConfig.quantMode == QuantizationMode::Profile) {


### PR DESCRIPTION
Summary: This can be used along with Repro. Flag is added `--glow_save_onnxifi_dag` which is similar to/used just like `glow_save_onnxifi_model`.

Differential Revision: D21036914

