### PR TITLE
Support loading a DAG back into a Module that already exists

### DIFF
--- a/include/glow/Exporter/ONNXModelWriter.h
+++ b/include/glow/Exporter/ONNXModelWriter.h
@@ -62,6 +62,8 @@ class ONNXModelWriter : public CommonOperatorWriter<ONNX_TRAITS> {
   const bool zipMode_;
   /// Whether we use text mode or not
   const bool textMode_;
+  /// Whether to include Constant (initializer) data in the exported proto.
+  const bool includeConstantData_;
   /// Whether to use custom ONNX ops.
   const bool useGlowCustomOps_;
   /// Whether we are writing a DAG.
@@ -124,8 +126,11 @@ public:
   static typename TensorType::DataType convertType(const Type &glowType);
   /// Writes Glow tensor \p T to proto output \p out. Depending on
   /// \p useGlowCustomOps meta info will be annotated differently.
+  /// If \p includeData then the data from \p T will be included; otherwise only
+  /// the type info and name will be.
   static void writeTensor(const Tensor &T, TensorType *out,
-                          bool useGlowCustomOps = false);
+                          bool useGlowCustomOps = false,
+                          bool includeData = true);
 
   /// Creates an ONNX model writer to serialize \p F graph into file
   /// \p modelFilename, writing \p irVersion and \p opsetVersion.
@@ -152,11 +157,13 @@ public:
   /// supports serialization with text format or binary format depending on
   /// \p textMode. If \p zipMode is true, it will save weights into individual
   /// TensorProto file along with the model file and package them into a zip
-  /// file.
+  /// file. If \p includeConstantData then data for Constants will be serialized
+  /// in the written model, otherwise it will be skipped (but initializers will
+  /// still exist, they will just have no data).
   ONNXModelWriter(const std::string &modelFilename, runtime::DAGListTy &dagList,
                   size_t irVersion, size_t opsetVersion,
                   Error *errPtr = nullptr, bool textMode = false,
-                  bool zipMode = false);
+                  bool zipMode = false, bool includeConstantData = true);
 
 private:
   /// \returns error for the unexpected node kind.

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -159,6 +159,9 @@ public:
 
   const FunctionList &getFunctions() const { return functions_; }
 
+  /// Clears out all Functions from \ref functions_.
+  void clearFunctions();
+
   /// \returns the list of types that the Module owns.
   const TypesList &getTypes() const { return types_; }
 
@@ -322,6 +325,9 @@ public:
   }
 
   ~Function();
+
+  /// Clear out \ref nodes_ and \ref uniqueNodeNames_.
+  void clear();
 
   /// Sets the state of the function.
   void setState(FunctionState state) { state_ = state; }

--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -744,8 +744,14 @@ protected:
 
       if (intermediate) {
         const std::string &opName = loadOperatorName(op);
-        Placeholder *PH = mod_.createPlaceholder(in.getType(), op.output(0),
-                                                 /* isTrainable */ false);
+        Placeholder *PH = nullptr;
+        if (loadIntoExistingModule_) {
+          PH = mod_.getPlaceholderByNameSlow(op.output(0));
+          RETURN_ERR_IF_NOT(PH, "Did not find intermediate PH" + op.output(0));
+        } else {
+          PH = mod_.createPlaceholder(in.getType(), op.output(0),
+                                      /* isTrainable */ false);
+        }
         G_->createSave(opName, in, PH, /* skipSuffix */ true);
         intermediatePHsByName_[op.output(0)] = PH;
         in = PH->getOutput();

--- a/include/glow/Importer/ONNXModelLoader.h
+++ b/include/glow/Importer/ONNXModelLoader.h
@@ -455,10 +455,11 @@ protected:
   friend Error constantFoldInLoader(Function *F, LoaderType &tmpLoader,
                                     LoaderType *loader, const OpType &op);
 
-  /// Creates tensor \p T from the input \p in. Note, there is no data
-  /// associated with the Tensor. This method makes sure that the tensor is
-  /// created with the proper shape and element type.
-  Error setTensorType(const ONNX_NAMESPACE::ValueInfoProto &in, Tensor *T);
+  /// \returns a Type with the proper shape and element type given \p in.
+  Expected<Type> getTensorType(const ONNX_NAMESPACE::ValueInfoProto &in);
+
+  /// \returns a Type with the proper shape and element type given \p in.
+  Expected<Type> getTensorType(const ONNX_NAMESPACE::TensorProto &in);
 
   /// Load a model \p modelDef given \p tensorNames, \p types, \p B, and
   /// \p loadInputsAsPlaceholdersForOnnx.
@@ -520,7 +521,9 @@ public:
   /// there otherwise if an error occurs it will abort.
   /// If \p disableConstFoldInLoader then constant folding will be disabled
   /// during loading. \p B will be used during function verification after
-  /// loading.
+  /// loading. If \p loadIntoExistingModule then all Functions and Storage is
+  /// expected to already exist, so they will be searched for according to the
+  /// proto being loaded instead of created as usual.
   ONNXModelLoader(const std::string &modelDescFilename,
                   llvm::ArrayRef<const char *> tensorNames,
                   llvm::ArrayRef<TypeRef> types, Module &mod,
@@ -528,6 +531,7 @@ public:
                   runtime::PrePartitionedConfig *PPC = nullptr,
                   Error *errPtr = nullptr, bool zipMode = false,
                   BackendSpecificNodeInfo *perNodeOpts = nullptr,
+                  bool loadIntoExistingModule = false,
                   bool disableConstFoldInLoader = false,
                   const Backend *B = nullptr);
 

--- a/include/glow/Importer/ProtobufLoader.h
+++ b/include/glow/Importer/ProtobufLoader.h
@@ -155,6 +155,10 @@ protected:
   std::vector<std::string> positionalOutputNames_;
   /// Whether to try constant folding as we load each op from a protobuf.
   bool constFoldInLoader_{true};
+  /// Whether to load the proto into the existing module. All Functions and
+  /// Storage should already exist for the proto; the Functions should be empty
+  /// and will be filled with Nodes from the proto connected to Storage.
+  bool loadIntoExistingModule_{false};
 
   // Delete all Constants that have no users. This is useful because some
   // Constants may have been copied and modified during loading instead of used
@@ -233,10 +237,12 @@ public:
   /// \p mod. The list \p types and \p names are used to initialize the inputs
   /// of the model with specific names and types. If \p errPtr is not null then
   /// if an error occurs it will get assigned there otherwise if an error
-  /// occurs it will abort.
+  /// occurs it will abort. If \p loadIntoExistingModule then all Functions and
+  /// Storage is expected to already exist, so they will be searched for
+  /// according to the proto being loaded instead of created as usual.
   ProtobufLoader(llvm::ArrayRef<const char *> tensorNames,
                  llvm::ArrayRef<TypeRef> types, Module &mod,
-                 Error *errPtr = nullptr);
+                 Error *errPtr = nullptr, bool loadIntoExistingModule = false);
 
   ProtobufLoader(const ProtobufLoader &other) = delete;
   ProtobufLoader &operator=(const ProtobufLoader &) = delete;

--- a/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
+++ b/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
@@ -195,6 +195,9 @@ struct CompilationContext {
   /// user-defined partitioning.
   unsigned replicationCount{1};
 
+  /// Whether to serialize the DAG that has been optimized and partitioned.
+  bool serializeCompiledDAG{false};
+
   CompilationContext(PlaceholderBindings *bindings_ = nullptr,
                      LoweredInfoMap *loweredInfoMap_ = nullptr)
       : bindings(bindings_), loweredInfoMap(loweredInfoMap_) {}

--- a/include/glow/Runtime/RuntimeTypes.h
+++ b/include/glow/Runtime/RuntimeTypes.h
@@ -299,8 +299,6 @@ struct PrePartitionedConfig {
   std::string funcName;
   /// Functions from the module which are partitioned.
   std::vector<Function *> funcs;
-  /// Names assigned to each partition.
-  std::vector<std::string> partitionNames;
   /// The logical IDs to assign to the partitions.
   std::vector<std::vector<DeviceIDTy>> logicalIDs;
   /// Backends that are used for each partition.
@@ -316,7 +314,6 @@ struct PrePartitionedConfig {
   /// for those vectors which need to have their parameter constructed.
   void resizeAndReserve(size_t size) {
     funcs.reserve(size);
-    partitionNames.reserve(size);
     logicalIDs.resize(size);
     backendNames.reserve(size);
     backendHints.reserve(size);

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -148,6 +148,17 @@ Function::broadcastInputs(int axis, const llvm::ArrayRef<NodeValue> inputs) {
 
 bool Module::hasFunction(llvm::StringRef name) { return getFunction(name); }
 
+void Module::clearFunctions() {
+  for (auto *F : functions_) {
+    F->clear();
+  }
+}
+
+void Function::clear() {
+  nodes_.clear();
+  uniqueNodeNames_.clear();
+}
+
 Function *Module::getFunction(llvm::StringRef name) {
   for (auto *F : functions_) {
     if (F->getName() == name) {

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -2154,6 +2154,10 @@ Error Caffe2ModelLoader::initWithModule(caffe2::NetDef &networkDef,
       PPC->funcs.push_back(F);
       PPC->logicalIDs.emplace_back(funToIDs[F]);
       PPC->backendSpecificOpts.emplace_back(funToOpts[F]);
+      // Replication counts not currently loaded through C2, so default to 1.
+      PPC->replicationCounts.emplace_back(1);
+      // Backend hints not currently loaded through C2, so use default.
+      PPC->backendHints.emplace_back();
       RETURN_ERR_IF_NOT(F->verify(), "Function verification failed.");
     }
   }

--- a/lib/Importer/ProtobufLoader.cpp
+++ b/lib/Importer/ProtobufLoader.cpp
@@ -239,8 +239,8 @@ bool ProtobufLoader::hasNodeByName(llvm::StringRef name) const {
 
 ProtobufLoader::ProtobufLoader(llvm::ArrayRef<const char *> tensorNames,
                                llvm::ArrayRef<TypeRef> types, Module &mod,
-                               Error *errPtr)
-    : G_(nullptr), mod_(mod) {
+                               Error *errPtr, bool loadIntoExistingModule)
+    : G_(nullptr), mod_(mod), loadIntoExistingModule_(loadIntoExistingModule) {
   setupLoader(tensorNames, types, errPtr);
 }
 

--- a/lib/Onnxifi/Flags.cpp
+++ b/lib/Onnxifi/Flags.cpp
@@ -1,3 +1,19 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include <gflags/gflags.h>
 
 namespace glow {
@@ -19,6 +35,7 @@ extern bool GlowClipFP16;
 extern bool GlowClipFP16SkipInputs;
 extern bool GlowSaturateHost;
 extern bool GlowSaveOnnxifiModel;
+extern bool GlowSaveOnnxifiDAG;
 extern bool GlowSaveOnnxifiIO;
 extern bool GlowEnablePartialTensors;
 extern bool GlowUseCustomOpsForExport;
@@ -199,6 +216,14 @@ DEFINE_bool(glow_saturate_host, false,
             "Try to use all available devices on the host");
 DEFINE_validator(glow_saturate_host, [](const char *flagname, bool value) {
   glow::onnxifi::GlowSaturateHost = value;
+  return true;
+});
+
+DEFINE_bool(
+    glow_save_onnxifi_dag, false,
+    "Whether to serialize the DAG that has been optimized and partitioned.");
+DEFINE_validator(glow_save_onnxifi_dag, [](const char *flagname, bool value) {
+  glow::onnxifi::GlowSaveOnnxifiDAG = value;
   return true;
 });
 

--- a/lib/Onnxifi/HostManagerOnnxifi.cpp
+++ b/lib/Onnxifi/HostManagerOnnxifi.cpp
@@ -48,6 +48,7 @@ bool GlowSparseNNPartitioningAddSLSConcats = false;
 size_t GlowMaxActiveRequests = 48;
 size_t GlowMaxQueueSize = 100;
 size_t GlowExecutorThreads = 10;
+bool GlowSaveOnnxifiDAG = false;
 
 static llvm::cl::opt<int32_t, true>
     GlowNumDevicesOpt("glow-num-devices",
@@ -216,6 +217,10 @@ onnxStatus HostManagerBackend::addNetwork(std::unique_ptr<Module> module,
   }
   if (GlowDumpGraph) {
     cctx.dumpFinalGraph = true;
+  }
+  if (GlowSaveOnnxifiDAG) {
+    LOG(INFO) << "Serializing DAG after optimization and partitioning.";
+    cctx.serializeCompiledDAG = true;
   }
   cctx.saturateHost = GlowSaturateHost;
 

--- a/lib/Runtime/HostManager/CMakeLists.txt
+++ b/lib/Runtime/HostManager/CMakeLists.txt
@@ -6,6 +6,8 @@ target_link_libraries(HostManager
                         Backends
                         Base
                         Executor
+                        Exporter
+                        Importer
                         Graph
                         GraphOptimizer
                         Partitioner

--- a/tests/unittests/GraphTest.cpp
+++ b/tests/unittests/GraphTest.cpp
@@ -94,6 +94,36 @@ TEST(Graph, clear) {
   EXPECT_EQ(M.getFunctions().size(), 0);
 }
 
+/// Check that the clear method works as expected.
+TEST(Graph, clearFunctions) {
+  Module M;
+
+  // Check that the module is initially empty.
+  EXPECT_EQ(M.getConstants().size(), 0);
+  EXPECT_EQ(M.getPlaceholders().size(), 0);
+  EXPECT_EQ(M.getFunctions().size(), 0);
+
+  // Create a few things.
+  Function *F = M.createFunction("main");
+  auto *PH = M.createPlaceholder(ElemKind::FloatTy, {1}, "placeholder", true);
+  auto *C = M.createConstant(ElemKind::FloatTy, {1}, "var");
+  auto *AN = F->createAdd("add", PH, C);
+  F->createSave("save", AN);
+
+  EXPECT_EQ(M.getConstants().size(), 1);
+  EXPECT_EQ(M.getPlaceholders().size(), 2); // Input PH and PH for Save
+  EXPECT_EQ(M.getFunctions().size(), 1);
+  EXPECT_EQ(F->getNodes().size(), 2); // Add, Save
+
+  M.clearFunctions();
+  EXPECT_EQ(M.getConstants().size(), 1);
+  EXPECT_EQ(M.getPlaceholders().size(), 2);
+  ASSERT_EQ(M.getFunctions().size(), 1);
+  // Same Function ptr should exist, just nothing left in them.
+  EXPECT_EQ(*M.getFunctions().begin(), F);
+  EXPECT_EQ(F->getNodes().size(), 0);
+}
+
 /// Test the graph nodes names and utilities.
 TEST(Graph, testGraphNames) {
   Module MD;


### PR DESCRIPTION
Summary: Allow for reusing a module when loading a proto. We write out a proto without any Constant data initializers, and then load it back into the Module it was exported from. This allows for e.g. exporting a DAG, tweaking the model proto, and then loading it back in without needing to copy data into new Constants, recreate Placeholders, etc. since they're still there.

Differential Revision: D21171718

