### PR TITLE
Blacklist the failing test in NNPI.

### DIFF
--- a/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
@@ -205,6 +205,9 @@ struct BlacklistInitializer {
             {"FusedRowwiseQuantizedSparseLengthsWeightedSum_ConvertedFloat16_"
              "NoFusedConvert_FP32Accum/0",
              TestBlacklist::AnyDeviceHWEngine},
+            {"FusedRowwiseQuantizedSparseLengthsSum_Fused4Bit_Float16_"
+             "AccumFloat16/0",
+             TestBlacklist::AnyDeviceHWEngine},
             {"to_back2/0", TestBlacklist::AnyDeviceHWEngine},
             {"GroupDilatedConvolution/0", TestBlacklist::AnyDeviceHWEngine},
             {"less_int32Cases/0", TestBlacklist::AnyDeviceHWEngine},


### PR DESCRIPTION
Summary:
The blacklisted NNPI Operator test failed due to D21061244. This diff is to
blacklist the failing test for the NNPI backend. More context in the comments section of D21061244.

Reviewed By: jfix71

Differential Revision: D21174549

