### PR TITLE
Add flags for DRT, P2P and dumpPartitions

### DIFF
--- a/lib/Onnxifi/Flags.cpp
+++ b/lib/Onnxifi/Flags.cpp
@@ -49,10 +49,13 @@ extern unsigned GlowInterpreterMemory;
 extern unsigned GlowCPUMemory;
 extern unsigned GlowHabanaMemory;
 extern unsigned GlowNNPIMemory;
+extern bool GlowEnableDRT;
+extern bool GlowEnableP2P;
 } // namespace runtime
 
 extern bool GlowDumpCompilationLog;
 extern bool GlowLogPartition;
+extern bool GlowDumpPartition;
 } // namespace glow
 
 DEFINE_int32(glow_num_devices, 1, "Number of devices for Glow backend");
@@ -365,6 +368,25 @@ DEFINE_validator(glow_nnpi_memory, [](const char *flagname, int32_t value) {
 DEFINE_bool(glow_log_partition, true, "Enable logging partition info");
 DEFINE_validator(glow_log_partition, [](const char * /*unused*/, bool value) {
   glow::GlowLogPartition = value;
+  return true;
+});
+
+DEFINE_bool(glow_enable_p2p, false, "Enable peer to peer support");
+DEFINE_validator(glow_enable_p2p, [](const char * /*unused*/, bool value) {
+  glow::runtime::GlowEnableP2P = value;
+  return true;
+});
+
+DEFINE_bool(glow_enable_drt, false, "Enable device resident tensor support");
+DEFINE_validator(glow_enable_drt, [](const char * /*unused*/, bool value) {
+  glow::runtime::GlowEnableDRT = value;
+  return true;
+});
+
+DEFINE_bool(glow_dump_partition, false,
+            "Enable dumping the graph of each partition");
+DEFINE_validator(glow_dump_partition, [](const char * /*unused*/, bool value) {
+  glow::GlowDumpPartition = value;
   return true;
 });
 

--- a/lib/Partitioner/Partitioner.cpp
+++ b/lib/Partitioner/Partitioner.cpp
@@ -28,6 +28,7 @@
 namespace glow {
 bool GlowEnableLoadBalancedPartitioning = true;
 bool GlowLogPartition = false;
+bool GlowDumpPartition = false;
 static llvm::cl::opt<bool, /* ExternalStorage */ true>
     GlowEnableLoadBalancedPartitioningOpt(
         "glow_partitioner_enable_load_balance",
@@ -45,10 +46,11 @@ static llvm::cl::opt<bool, /* ExternalStorage */ true> logPartition(
 
 /// -dump-partition - Command line option to dump the graph of each partitions
 /// by calling F->dumpDAG().
-static llvm::cl::opt<bool>
+static llvm::cl::opt<bool, /* ExternalStorage */ true>
     dumpPartition("dump-partition",
                   llvm::cl::desc("Enable dumping the graph of each partitions"),
-                  llvm::cl::init(false), llvm::cl::cat(PartitionerCat));
+                  llvm::cl::location(glow::GlowDumpPartition),
+                  llvm::cl::cat(PartitionerCat));
 
 using namespace glow;
 using llvm::isa;


### PR DESCRIPTION
Summary: For repro tool adds -enable-P2P and -enable-DRT

Differential Revision: D21190738

