### PR TITLE
change checkGraphCompatibility Errors to Infos

### DIFF
--- a/lib/Backends/NNPI/NNPIDeviceManager.cpp
+++ b/lib/Backends/NNPI/NNPIDeviceManager.cpp
@@ -253,7 +253,7 @@ void NNPIDeviceManager::evictNetwork(std::string functionName,
   if (evictCB) {
     evictCB(functionName, std::move(err));
   } else {
-    llvm::errs() << errorToString(std::move(err));
+    llvm::errs() << ERR_TO_STRING(std::move(err));
   }
 }
 

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -99,8 +99,10 @@ onnxStatus Backend::checkGraphCompatibility(const void *onnxModel,
   } else {
     // TODO: Use a more specific ONNXIFI error code here to denote what about
     // this operator is not supported (shape, type, etc).
-    LOG(ERROR) << "Error when loading protobuf: "
-               << ERR_TO_STRING(loaderOrErr.takeError());
+    LOG(INFO)
+        << "ONNXIFI checkGraphCompatibility incompatibility found when loading "
+           "protobuf: "
+        << ERR_TO_STRING(loaderOrErr.takeError(), /*warning*/ true);
     return ONNXIFI_STATUS_UNSUPPORTED_OPERATOR;
   }
 
@@ -117,7 +119,9 @@ onnxStatus Backend::checkGraphCompatibility(const void *onnxModel,
   // Check if the function is verified as valid for Glow/the backend -- if not
   // then conservatively early return on unsupported operator.
   if (!function->verify(glowBackend_.get())) {
-    LOG(ERROR) << "ONNXIFI: Function verification failed.";
+    LOG(INFO)
+        << "ONNXIFI checkGraphCompatibility incompatibility: Glow function "
+           "verification failed.";
     return ONNXIFI_STATUS_UNSUPPORTED_OPERATOR;
   }
 
@@ -134,7 +138,9 @@ onnxStatus Backend::checkGraphCompatibility(const void *onnxModel,
   const auto &nodes = function->getNodes();
   for (const auto &node : nodes) {
     if (!glowBackend_->acceptForExecution(node)) {
-      LOG(ERROR) << "ONNXIFI: Op rejected by backend: " << node.getDebugDesc();
+      LOG(INFO) << "ONNXIFI checkGraphCompatibility incompatibility, op "
+                   "rejected by backend: "
+                << node.getDebugDesc();
       // TODO: Use a more specific ONNXIFI error code here to denote what
       // about this operator is not supported (shape, type, etc).
       return ONNXIFI_STATUS_UNSUPPORTED_OPERATOR;

--- a/tests/unittests/ErrorTest.cpp
+++ b/tests/unittests/ErrorTest.cpp
@@ -180,3 +180,11 @@ TEST(Error, PeekExpected) {
 #endif
   ERR_TO_VOID(intOrErr.takeError());
 }
+
+TEST(Error, WarningString) {
+  const char *msg = "some message";
+  auto err = MAKE_ERR(msg);
+  auto str = ERR_TO_STRING(std::move(err), /*warning*/ true);
+  EXPECT_NE(str.find("Warning"), std::string::npos)
+      << "Expect warning to be present in message";
+}


### PR DESCRIPTION
Summary: Errors produced by Glow during ONNXIFI checkGraphCompatibility are not errors, they are indicators of incompatibility so change the log level and message to help make that more clear in logs

Reviewed By: yinghai

Differential Revision: D21193720

