### PR TITLE
Support padded tensor in torch-glow

### DIFF
--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -3706,6 +3706,11 @@ void BoundInterpreterFunction::fwdEmbeddingBagInstFloatImpl(
     } else {
       end = OFFH.raw(i + 1);
     }
+    if (start == end) {
+      continue;
+    } else if (start > end) {
+      break;
+    }
     for (dim_t j = start; j < end; j++) {
       ElemTy weight = WH.raw(curIdx);
       dim_t offsetIn = IH.raw(curIdx++) * lineSize;
@@ -3983,6 +3988,12 @@ void BoundInterpreterFunction::fwdEmbeddingBagByteRowwiseOffsetsImpl(
     } else {
       end = OFFH.raw(i + 1);
     }
+    if (start == end) {
+      continue;
+    } else if (start > end) {
+      break;
+    }
+
     for (dim_t j = start; j < end; j++) {
       const float weight = static_cast<float>(WH.raw(j));
       const dim_t rowIdx = IH.raw(j);

--- a/torch_glow/src/Registration.h
+++ b/torch_glow/src/Registration.h
@@ -52,6 +52,10 @@ setGraphRunnerForKey(const std::string &key,
 /// no CachingGraphRunner was registered for the given key.
 std::shared_ptr<CachingGraphRunner>
 getGraphRunnerForKey(const std::string &key);
+
+/// Remove an existing CachingGraphRunner for a given \p key. \returns false if
+/// no CachingGraphRunner was registered for the given key, true otherwise.
+bool removeGraphRunnerForKey(const std::string &key);
 } // namespace glow
 
 #endif // GLOW_TORCH_GLOW_SRC_REGISTRATION_H

--- a/torch_glow/tests/nodes/embedding_bag_test.py
+++ b/torch_glow/tests/nodes/embedding_bag_test.py
@@ -13,12 +13,13 @@ class TestEmbeddingBag(unittest.TestCase):
             weight = torch.FloatTensor([[1, 2.3, 3], [4, 5.1, 6.3]])
             embedding_sum = torch.nn.EmbeddingBag.from_pretrained(
                 weight, mode="sum")
-            a = embedding_sum(input, offsets)
-            b = embedding_sum(input, offsets, per_sample_weights)
+            # in jit mode we need to discard the end offset
+            a = embedding_sum(input, offsets[:-1])
+            b = embedding_sum(input, offsets[:-1], per_sample_weights)
             return a, b
 
         input = torch.LongTensor([1, 0, 0, 1, 1])
-        offsets = torch.LongTensor([0, 1])
+        offsets = torch.LongTensor([0, 1, 5])  # final item is endOffset
         per_sample_weights = torch.FloatTensor([1, 2, 3, 4, 5])
 
         jitVsGlow(


### PR DESCRIPTION
Summary:
Add support for padded tensor in CachingGraphRunner, by passing an unowned tensor with actual size during inferencing. Also added check for cases where input tensor is larger than placeholder.

This Diff also involves the current modifications:
- Update PyTorchModelLoader with ```hasEndOffset = true```
- Update Unit tests to depend on NNPI backend
- Update CachingGraphRunner with handler to the backend
- Add an API to delete existing graph runner in Registration

Issues:
- Current implementation means the unit test "TestPartialTensor" will always fail because in zero-padding we cannot figure out the correct dims for torch.mean()
- zero-length tensors are not tested in unit cases, however it is tested in the ctr_mbl_feed model.

Differential Revision: D20826123

