### PR TITLE
PassManager improvements

### DIFF
--- a/docs/Backends.md
+++ b/docs/Backends.md
@@ -120,7 +120,7 @@ Additionally, there are several virtual functions that backends can override:
   - Allow the backend to perform custom lowering from Node to Instruction IR.
     Returns true if lowering is performed, false otherwise.
 
-- `virtual FunctionPassPipeline getOptimizationPipeline() const;`
+- `virtual std::unique_ptr<FunctionPassPipeline> getOptimizationPipeline() const;`
 
   - Allows the backend to customize the graph optimizations that are performed
     when compiling a Function. Backend returns the

--- a/include/glow/Backend/Backend.h
+++ b/include/glow/Backend/Backend.h
@@ -170,9 +170,10 @@ public:
   virtual bool shouldShareBuffers() const { return true; }
 
   /// Modify the \p optimizationOpts however desired.
-  virtual FunctionPassPipeline getOptimizationPipeline() const;
+  virtual std::unique_ptr<FunctionPassPipeline> getOptimizationPipeline() const;
   /// Modify the \p optimizationOpts however desired.
-  virtual IRFunctionPassPipeline getIROptimizationPipeline() const;
+  virtual std::unique_ptr<IRFunctionPassPipeline>
+  getIROptimizationPipeline() const;
 
   /// \returns true if the Backend supports partial, unpadded tensors for
   /// inputs that can have variable size (e.g., embedding indices).

--- a/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
+++ b/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
@@ -152,7 +152,7 @@ struct CompilationContext {
 
   /// Select whether in Training or Inference mode.
   enum class CompilationMode {
-    Train, /// Compile the graph in preperation for training.
+    Train, /// Compile the graph in preparation for training.
     Infer, /// Compile the graph for inference. Notice that this operation
            /// changes the graph in a way that is not reversible.
     NumCompilationModes, /// Used to count the number of CompilationModes.

--- a/include/glow/Optimizer/GraphOptimizer/FunctionPass.h
+++ b/include/glow/Optimizer/GraphOptimizer/FunctionPass.h
@@ -38,15 +38,22 @@ class FunctionPassConfig : public PassConfig<FunctionPassID> {
   DCERequiredMode dceMode_{DCERequiredMode::BeforePass};
 
 public:
+  /// Constructor.
   FunctionPassConfig(FunctionPassID ID,
                      ConvergenceMode convergenceMode = ConvergenceMode::OnePass,
                      const std::set<CompilationMode> &enabledCompModes =
                          {CompilationMode::Infer, CompilationMode::Train},
                      DCERequiredMode dceMode = DCERequiredMode::BeforePass)
-      : PassConfig(ID, convergenceMode), dceMode_(dceMode) {}
+      : PassConfig(ID, convergenceMode, enabledCompModes), dceMode_(dceMode) {}
+  /// Constructor.
+  FunctionPassConfig(FunctionPassID ID, ConvergenceMode convergenceMode,
+                     unsigned enabledCompModes, DCERequiredMode dceMode)
+      : PassConfig(ID, convergenceMode, enabledCompModes), dceMode_(dceMode) {}
   /// \returns the DCERequiredMode of this config.
   DCERequiredMode getDCERequiredMode() const { return dceMode_; }
-  void dump(llvm::raw_ostream &os) const;
+  void dump(llvm::raw_ostream &os, llvm::StringRef passName) const override;
+  llvm::StringRef getNameOfPass() const override;
+  bool equals(const PassConfigBase &other) const override;
 };
 
 /// Class used for all passes over Functions. All passes over Functions should

--- a/include/glow/Optimizer/GraphOptimizer/FunctionPassPipeline.h
+++ b/include/glow/Optimizer/GraphOptimizer/FunctionPassPipeline.h
@@ -33,17 +33,15 @@ enum class FunctionPassID {
 /// IR passes pipeline.
 using FunctionPassPipeline = PassPipeline<FunctionPass>;
 
-/// \returns the name of a Pass given its \p passID.
-llvm::StringRef getNameOfPass(FunctionPassID passID);
-
 /// \returns the default, target-independent graph optimization pipeline
-FunctionPassPipeline createDefaultGraphOptimizationPassPipeline();
+std::unique_ptr<FunctionPassPipeline>
+createDefaultGraphOptimizationPassPipeline();
 
 /// \returns the fp16 specific optimization pipeline
-FunctionPassPipeline createFP16GraphOptimizationPassPipeline();
+std::unique_ptr<FunctionPassPipeline> createFP16GraphOptimizationPassPipeline();
 
 /// \returns the default fold pipeline.
-FunctionPassPipeline createDefaultFoldPassPipeline();
+std::unique_ptr<FunctionPassPipeline> createDefaultFoldPassPipeline();
 
 /// \returns a FunctionPassConfig for performing DCE.
 FunctionPassConfig getDCEPassConfig();

--- a/include/glow/Optimizer/IROptimizer/IRFunctionPass.h
+++ b/include/glow/Optimizer/IROptimizer/IRFunctionPass.h
@@ -24,8 +24,12 @@ namespace glow {
 class IRFunction;
 enum class IRFunctionPassID;
 
-// template <typename X, typename Y> class IRFunctionPass;
-using IRFunctionPassConfig = PassConfig<IRFunctionPassID>;
+class IRFunctionPassConfig : public PassConfig<IRFunctionPassID> {
+public:
+  using PassConfig::PassConfig;
+  llvm::StringRef getNameOfPass() const override;
+  void dump(llvm::raw_ostream &os) const override;
+};
 
 /// Pass over low-level IR-level functions.
 using IRFunctionPass = Pass<IRFunction, IRFunctionPassConfig>;

--- a/include/glow/Optimizer/IROptimizer/IRFunctionPassPipeline.h
+++ b/include/glow/Optimizer/IROptimizer/IRFunctionPassPipeline.h
@@ -32,7 +32,8 @@ enum class IRFunctionPassID {
 using IRFunctionPassPipeline = PassPipeline<IRFunctionPass>;
 
 /// \returns the default, target-independent IR optimization pipeline.
-IRFunctionPassPipeline createDefaultIRFunctionOptimizationPipeline();
+std::unique_ptr<IRFunctionPassPipeline>
+createDefaultIRFunctionOptimizationPipeline();
 
 /// \returns the name of a Pass given its \p passID.
 llvm::StringRef getNameOfPass(IRFunctionPassID passID);

--- a/include/glow/PassManager/PassConfigUtils.h
+++ b/include/glow/PassManager/PassConfigUtils.h
@@ -1,0 +1,90 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_PASSMANAGER_PASSCONFIGTUILS_H
+#define GLOW_PASSMANAGER_PASSCONFIGTUILS_H
+
+#include "llvm/Support/YAMLParser.h"
+#include "llvm/Support/YAMLTraits.h"
+
+LLVM_YAML_STRONG_TYPEDEF(unsigned, CompilationModes)
+
+namespace llvm {
+namespace yaml {
+template <> struct ScalarEnumerationTraits<glow::ConvergenceMode> {
+  static void enumeration(IO &io, glow::ConvergenceMode &mode) {
+    io.enumCase(mode, "one_pass", glow::ConvergenceMode::OnePass);
+    io.enumCase(mode, "until_fixed_point",
+                glow::ConvergenceMode::UntilFixedPoint);
+  }
+};
+
+template <> struct ScalarEnumerationTraits<glow::DCERequiredMode> {
+  static void enumeration(IO &io, glow::DCERequiredMode &mode) {
+    io.enumCase(mode, "none", glow::DCERequiredMode::None);
+    io.enumCase(mode, "before_pass", glow::DCERequiredMode::BeforePass);
+  }
+};
+
+template <> struct ScalarBitSetTraits<CompilationModes> {
+  static void bitset(IO &io, CompilationModes &value) {
+    io.bitSetCase(value, "infer",
+                  1 << convertEnumToUnsigned(glow::CompilationMode::Infer));
+    io.bitSetCase(value, "train",
+                  1 << convertEnumToUnsigned(glow::CompilationMode::Train));
+  }
+};
+
+template <typename Helper> struct SequenceTraits<std::vector<Helper>> {
+  static size_t size(IO &io, std::vector<Helper> &configs) {
+    return configs.size();
+  }
+
+  static Helper &element(IO &io, std::vector<Helper> &configs, size_t index) {
+    if (index >= configs.size()) {
+      configs.resize(index + 1);
+    }
+    return configs[index];
+  }
+};
+} // namespace yaml
+} // namespace llvm
+
+template <typename T> static T deserializeFromYaml(llvm::StringRef fileName) {
+  T result;
+  llvm::outs() << fileName << "\n";
+  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> text =
+      llvm::MemoryBuffer::getFileAsStream(fileName);
+  assert(!text.getError() && "Unable to open file");
+
+  std::unique_ptr<llvm::MemoryBuffer> buffer = std::move(*text);
+  llvm::yaml::Input yin(buffer->getBuffer());
+  yin >> result;
+
+  assert(!yin.error() && "Error reading yaml file");
+
+  return result;
+}
+
+template <typename T>
+static void serializeToYaml(llvm::StringRef fileName, T &value) {
+  std::error_code EC;
+  llvm::raw_fd_ostream os(fileName, EC);
+  CHECK(!EC) << "Could not open output file";
+  llvm::yaml::Output yout(os);
+  yout << value;
+}
+
+#endif // GLOW_PASSMANAGER_PASSCONFIGTUILS_H

--- a/include/glow/PassManager/Pipeline.h
+++ b/include/glow/PassManager/Pipeline.h
@@ -20,28 +20,49 @@
 #include "glow/Optimizer/GraphOptimizer/CompilationContext.h"
 #include "glow/Support/Support.h"
 
-#include <bitset>
 #include <iterator>
 
 namespace glow {
+
+/// Base class for all pass pipelines providing some common functionality.
+class PassPipelineBase {
+protected:
+  /// \returns pass config at index \p i.
+  virtual const PassConfigBase &elementAt(size_t i) const = 0;
+
+public:
+  /// Constructor.
+  PassPipelineBase() = default;
+
+  /// Destructor.
+  virtual ~PassPipelineBase() = default;
+
+  /// Dump a textual representation of the pipeline to \p os.
+  virtual void dump(llvm::raw_ostream &os = llvm::outs()) const;
+
+  /// \returns size of pipeline.
+  virtual size_t size() const = 0;
+};
 
 /// Implementation of a pipeline for executing a series of passes. Each pass
 /// should be of type \p PASS or a type derived from it.
 template <typename PASS>
 class PassPipeline
-    : private llvm::SmallVector<typename PASS::IRPassConfigTy, 64> {
+    : public PassPipelineBase,
+      private llvm::SmallVector<typename PASS::IRPassConfigTy, 16> {
 public:
   using IRPassConfigTy = typename PASS::IRPassConfigTy;
   using PassIDTy = typename IRPassConfigTy::PassIDTy;
+  using Base = llvm::SmallVector<IRPassConfigTy, 16>;
+  using iterator = typename Base::iterator;
+  using const_iterator = typename Base::const_iterator;
 
 private:
-  using ParentImpl = llvm::SmallVectorImpl<IRPassConfigTy>;
-
   /// Removes the first instance of a pass with ID \p passID. \returns whether
   /// an instance of the pass was successfully found and removed.
   bool removeFirstInstanceOfPass(PassIDTy passID) {
     for (auto it = begin(); it != end(); it++) {
-      if (it->getPassID() == passID) {
+      if (static_cast<PassIDTy>(it->getID()) == passID) {
         this->erase(it);
         return true;
       }
@@ -49,34 +70,53 @@ private:
     return false;
   }
 
+  const PassConfigBase &elementAt(size_t i) const override { return at(i); }
+
 public:
-  using Base = llvm::SmallVector<IRPassConfigTy, 64>;
-  using iterator = typename Base::iterator;
-  using const_iterator = typename Base::const_iterator;
+  /// Constructor.
   PassPipeline() = default;
 
-  /// Constructs a FunctionPassPipeline from an initializer_list \p IL.
-  PassPipeline(std::initializer_list<IRPassConfigTy> IL) { this->assign(IL); }
+  /// Constructor for a PassPipeline from an initializer_list \p configs.
+  PassPipeline(std::initializer_list<IRPassConfigTy> configs) {
+    pushBack(configs);
+  }
+
+  /// \returns size of pipeline.
+  size_t size() const override { return Base::size(); }
 
   /// Forward iterator creation methods.
   ///@{
-  iterator begin() { return ParentImpl::begin(); }
-  const_iterator begin() const { return ParentImpl::begin(); }
+  iterator begin() { return Base::begin(); }
+  const_iterator begin() const { return Base::begin(); }
   iterator end() { return begin() + size(); }
   const_iterator end() const { return begin() + size(); }
   /// @}
 
-  /// Forward to parent size() method. \returns size of pipeline.
-  size_t size() const { return ParentImpl::size(); }
-
   /// Helper to get the IRPassConfig at index \p i in the pipeline.
-  const IRPassConfigTy &at(size_t i) const { return begin()[i]; }
+  const IRPassConfigTy &at(size_t i) const {
+    const PassConfigBase &config = begin()[i];
+    return *static_cast<const IRPassConfigTy *>(&config);
+  }
 
   /// Push a new \p IRPC to the end of the pipeline.
-  void pushBack(IRPassConfigTy IRPC) { ParentImpl::push_back(IRPC); }
+  void pushBack(const IRPassConfigTy &IRPC) { Base::push_back(IRPC); }
+
+  /// Push \p configs to the end of the pipeline.
+  void pushBack(const std::initializer_list<IRPassConfigTy> &configs) {
+    for (auto &config : configs) {
+      pushBack(config);
+    }
+  }
+
+  /// Push \p configs to the end of the pipeline.
+  void pushBack(llvm::ArrayRef<IRPassConfigTy> configs) {
+    for (auto &config : configs) {
+      pushBack(config);
+    }
+  }
 
   /// Push a new \p IRPC to the start of the pipeline.
-  void pushFront(IRPassConfigTy IRPC) { ParentImpl::insert(begin(), IRPC); }
+  void pushFront(const IRPassConfigTy &IRPC) { Base::insert(begin(), IRPC); }
 
   /// Removes all instances of a pass with ID \p passID.
   void removeAllInstancesOfPass(PassIDTy passID) {
@@ -84,15 +124,22 @@ public:
     }
   }
 
-  /// Dump a textual representation of the pipeline to \p os.
-  void dump(llvm::raw_ostream &os = llvm::outs()) const {
-    os << "Pipeline contains:\n";
-    for (size_t i = 0, e = this->size(); i < e; i++) {
-      const auto &passConfig = (*this)[i];
-      os << "FunctionPassIdx " << i << ": {\n";
-      passConfig.dump(os);
-      os << "}\n";
+  /// Initialize the pipeline from a file with a name \p pipelineDefFilename.
+  virtual void initFromFile(llvm::StringRef pipelineDefFilename);
+
+  /// Dump pipeline definition into a file with a name \p pipelineDefFilename.
+  virtual void dumpToFile(llvm::StringRef pipelineDefFilename);
+
+  bool equals(const PassPipeline &other) const {
+    if (size() != other.size()) {
+      return false;
     }
+    for (unsigned idx = 0, e = size(); idx < e; ++idx) {
+      if (!at(idx).equals(other.at(idx))) {
+        return false;
+      }
+    }
+    return true;
   }
 };
 

--- a/lib/Backend/Backend.cpp
+++ b/lib/Backend/Backend.cpp
@@ -187,16 +187,17 @@ TensorLayoutCommon &Backend::getTensorLayoutRequirements() const {
   return CanonicalTensorLayout::getInstance();
 }
 
-FunctionPassPipeline Backend::getOptimizationPipeline() const {
-  auto p = createDefaultGraphOptimizationPassPipeline();
+std::unique_ptr<FunctionPassPipeline> Backend::getOptimizationPipeline() const {
+  auto pipeline = createDefaultGraphOptimizationPassPipeline();
   // Fold Tile followed by Add into BatchedAdd. Currently this is not part of
   // the default pipeline to avoid issues with some backends. If backends do not
   // want this opt then they should override getOptimizationPipeline().
-  p.pushFront({FunctionPassID::FoldTileAddIntoBatchedAdd});
-  return p;
+  pipeline->pushFront({FunctionPassID::FoldTileAddIntoBatchedAdd});
+  return pipeline;
 }
 
-IRFunctionPassPipeline Backend::getIROptimizationPipeline() const {
+std::unique_ptr<IRFunctionPassPipeline>
+Backend::getIROptimizationPipeline() const {
   auto pipeline = createDefaultIRFunctionOptimizationPipeline();
   return pipeline;
 }

--- a/lib/Backends/NNPI/NNPI.h
+++ b/lib/Backends/NNPI/NNPI.h
@@ -46,7 +46,8 @@ public:
   bool shouldShareBuffers() const override { return false; }
   bool supportsPartialTensors() const override { return true; }
   bool supportsStaticPlaceholders() const override { return true; }
-  FunctionPassPipeline getOptimizationPipeline() const override;
+  std::unique_ptr<FunctionPassPipeline>
+  getOptimizationPipeline() const override;
 
   runtime::DeviceManager *
   createDeviceManager(const runtime::DeviceConfig &deviceConfig) override;

--- a/lib/Optimizer/GraphOptimizer/FunctionPassManager.cpp
+++ b/lib/Optimizer/GraphOptimizer/FunctionPassManager.cpp
@@ -76,7 +76,11 @@ bool ThePassManager::runPassHook(const PassConfigBase &passConfig, PassBase &P,
 }
 
 bool runDCEPass(ThePassManager::IRContainerTy *F, CompilationContext &cctx) {
-  return FunctionPassManager("DCE_FPM", {getDCEPassConfig()}).run(F, cctx);
+  auto pipeline = glow::make_unique<FunctionPassPipeline>();
+  pipeline->pushBack(getDCEPassConfig());
+  return FunctionPassManager("DCE_FPM", std::move(pipeline)).run(F, cctx);
 }
+
+void test() { FunctionPassManager FPM("name", "pipeline.def"); }
 
 } // namespace glow

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -4562,13 +4562,15 @@ Error glow::optimizeFunction(Function *F, const Backend &B,
   // inputs, and outputs (Placeholders and SaveNodes).
   if (cctx.optimizationOpts.foldStaticPlaceholderConversions ||
       cctx.optimizationOpts.foldElemKindConversionIntoIO) {
-    FunctionPassPipeline pipeline{
-        FunctionPassID::FoldElemKindConversionIntoInputs};
+    std::unique_ptr<FunctionPassPipeline> pipeline =
+        glow::make_unique<FunctionPassPipeline>();
+    pipeline->pushBack({FunctionPassID::FoldElemKindConversionIntoInputs});
 
     if (cctx.optimizationOpts.foldElemKindConversionIntoIO) {
-      pipeline.pushBack({FunctionPassID::FoldElemKindConversionIntoOutputs});
+      pipeline->pushBack({FunctionPassID::FoldElemKindConversionIntoOutputs});
     }
-    FunctionPassManager FPM("FoldElemKindConversionIntoIO", pipeline);
+    FunctionPassManager FPM("FoldElemKindConversionIntoIO",
+                            std::move(pipeline));
     if (FPM.run(F, cctx)) {
       ::glow::optimize(F, cctx);
     }

--- a/lib/Optimizer/IROptimizerPipeline/IRFunctionPassPipeline.cpp
+++ b/lib/Optimizer/IROptimizerPipeline/IRFunctionPassPipeline.cpp
@@ -17,8 +17,13 @@
 
 #include "glow/Optimizer/IROptimizer/IRFunctionPassManager.h"
 #include "glow/Optimizer/IROptimizer/IROptimizer.h"
+#include "glow/PassManager/PassConfigUtils.h"
 
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/YAMLParser.h"
+#include "llvm/Support/YAMLTraits.h"
+
+#include <fstream>
 
 namespace {
 static llvm::cl::opt<bool>
@@ -35,12 +40,57 @@ static llvm::cl::opt<bool> dumpIR("dump-ir",
 } // namespace
 
 namespace glow {
-
-IRFunctionPassPipeline createDefaultIRFunctionOptimizationPipeline() {
-  if (!optimizeIR) {
-    return {};
+llvm::StringRef getNameOfPass(IRFunctionPassID passID) {
+  switch (passID) {
+#define IR_FUN_PASS(PASS_NAME)                                                 \
+  case IRFunctionPassID::PASS_NAME:                                            \
+    return #PASS_NAME;
+#include "glow/Optimizer/IROptimizer/IRPasses.def"
   }
-  IRFunctionPassPipeline pipeline = {
+  llvm_unreachable("Unexpected pass.");
+}
+
+llvm::StringRef IRFunctionPassConfig::getNameOfPass() const {
+  return glow::getNameOfPass(getPassID());
+}
+} // namespace glow
+
+namespace {
+/// A helper class to represent a IRFunctionPassConfig in a way which can be
+/// easily handled by YAML functions.
+struct IRPassConfigHelper {
+  std::string passName;
+  glow::ConvergenceMode convergenceMode;
+  CompilationModes enabledCompilationModes;
+  IRPassConfigHelper(const glow::IRFunctionPassConfig &config)
+      : passName(config.getNameOfPass()),
+        convergenceMode(config.getConvergenceMode()),
+        enabledCompilationModes(config.getEnabledCompilationModes()) {}
+  IRPassConfigHelper() = default;
+};
+} // namespace
+
+namespace llvm {
+namespace yaml {
+/// Define the YAML mapping for IRPassConfigHelper.
+template <> struct MappingTraits<IRPassConfigHelper> {
+  static void mapping(IO &io, IRPassConfigHelper &config) {
+    io.mapRequired("passName", config.passName);
+    io.mapRequired("convergenceMode", config.convergenceMode);
+    io.mapRequired("enabledCompilaitonModes", config.enabledCompilationModes);
+  }
+};
+} // namespace yaml
+} // namespace llvm
+
+namespace glow {
+
+std::unique_ptr<IRFunctionPassPipeline>
+createDefaultIRFunctionOptimizationPipeline() {
+  if (!optimizeIR) {
+    return glow::make_unique<IRFunctionPassPipeline>();
+  }
+  std::initializer_list<IRFunctionPassConfig> configs{
       {IRFunctionPassID::PeepholeOptimizations},
       // Dead store elimination.
       {IRFunctionPassID::DSE},
@@ -57,31 +107,58 @@ IRFunctionPassPipeline createDefaultIRFunctionOptimizationPipeline() {
       {IRFunctionPassID::DeleteDeadAllocs},
       {IRFunctionPassID::MakeWeightsConst},
   };
+
+  auto pipeline = glow::make_unique<IRFunctionPassPipeline>(configs);
+
   if (instrumentDebug) {
     // Run debug instrumentation only if necessary.
-    pipeline.pushBack({IRFunctionPassID::DebugInstrument});
+    pipeline->pushBack(IRFunctionPassID::DebugInstrument);
   }
   // Always run a verifier at the end.
-  pipeline.pushBack({IRFunctionPassID::IRVerify});
+  pipeline->pushBack(IRFunctionPassID::IRVerify);
   // If requested, dump IR to stdout for debugging.
   if (dumpIR) {
-    pipeline.pushBack({IRFunctionPassID::IRDumper});
+    pipeline->pushBack(IRFunctionPassID::IRDumper);
   }
   return pipeline;
 }
 
-llvm::StringRef getNameOfPass(IRFunctionPassID passID) {
-  switch (passID) {
-#define IR_FUN_PASS(PASS_NAME)                                                 \
-  case IRFunctionPassID::PASS_NAME:                                            \
-    return #PASS_NAME;
+#define IR_FUN_PASS(PASS_NAME) {#PASS_NAME, IRFunctionPassID::PASS_NAME},
+
+static llvm::StringMap<IRFunctionPassID> passNameToID{
 #include "glow/Optimizer/IROptimizer/IRPasses.def"
-  }
-  llvm_unreachable("Unexpected pass.");
+};
+
+static IRFunctionPassID getPassID(llvm::StringRef name) {
+  CHECK_GT(passNameToID.count(name), 0) << "Unknown pass name: " << name.str();
+  return passNameToID.lookup(name);
 }
 
-template <> void IRFunctionPassConfig::dump(llvm::raw_ostream &os) const {
-  PassConfigBase::dump(os, getNameOfPass(getPassID()));
+template <>
+void IRFunctionPassPipeline::initFromFile(llvm::StringRef pipelineDefFilename) {
+  clear();
+  auto configs =
+      deserializeFromYaml<std::vector<IRPassConfigHelper>>(pipelineDefFilename);
+  for (auto &config : configs) {
+    IRFunctionPassConfig irFunctionPassConfig(getPassID(config.passName),
+                                              config.convergenceMode,
+                                              config.enabledCompilationModes);
+    pushBack(irFunctionPassConfig);
+  }
+}
+
+template <>
+void IRFunctionPassPipeline::dumpToFile(llvm::StringRef pipelineDefFilename) {
+  std::vector<IRPassConfigHelper> configs;
+  for (unsigned idx = 0, e = size(); idx < e; ++idx) {
+    const auto &config = at(idx);
+    configs.emplace_back(IRPassConfigHelper(config));
+  }
+  serializeToYaml(pipelineDefFilename, configs);
+}
+
+void IRFunctionPassConfig::dump(llvm::raw_ostream &os) const {
+  PassConfigBase::dump(os, glow::getNameOfPass(getPassID()));
 }
 
 } // namespace glow

--- a/lib/PassManager/CMakeLists.txt
+++ b/lib/PassManager/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(PassManager
               PassConfig.cpp
-              PassManager.cpp)
+              PassManager.cpp
+              PassPipeline.cpp)
 
 target_link_libraries(PassManager
                       PRIVATE

--- a/lib/PassManager/PassConfig.cpp
+++ b/lib/PassManager/PassConfig.cpp
@@ -42,6 +42,10 @@ void PassConfigBase::dump(llvm::raw_ostream &os,
     os << "[Train]";
   }
   os << "},\n";
+}
 
-  os << "\n";
+bool PassConfigBase::equals(const PassConfigBase &other) const {
+  return convergenceMode_ == other.convergenceMode_ &&
+         enabledCompModes_ == other.enabledCompModes_ &&
+         passID_ == other.passID_;
 }

--- a/lib/PassManager/PassPipeline.cpp
+++ b/lib/PassManager/PassPipeline.cpp
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "glow/PassManager/Pipeline.h"
+
+using namespace glow;
+
+void PassPipelineBase::dump(llvm::raw_ostream &os) const {
+  os << "Pipeline contains:\n";
+  for (size_t i = 0, e = size(); i < e; i++) {
+    const auto &passConfig = elementAt(i);
+    os << "FunctionPassIdx " << i << ": {\n";
+    auto passName = passConfig.getNameOfPass();
+    passConfig.dump(os, passName);
+    os << "}\n";
+  }
+}

--- a/tests/unittests/IROptTest.cpp
+++ b/tests/unittests/IROptTest.cpp
@@ -929,25 +929,3 @@ code {
   osIRF2 << M;
   EXPECT_EQ(mesI, osIRF2.str());
 }
-
-TEST(Optimizer, IRFunctionPassPipeline) {
-  Module mod;
-  Function *F = mod.createFunction("inoutCopy");
-  IRFunction M(F);
-  IRBuilder bb(&M);
-
-  // Create a WeightVar for TensorViews to use as their source operand.
-  auto *A = bb.createWeightVar(glow::ElemKind::FloatTy, {4, 2}, "A",
-                               WeightVar::MutabilityKind::Mutable);
-
-  // Create a view into A.
-  bb.createTensorViewInst(
-      "view1", A, mod.uniqueType(Type(glow::ElemKind::FloatTy, {1, 2, 1})),
-      {0, 0});
-
-  IRFunctionPassPipeline irFunctionPassPipeline;
-  irFunctionPassPipeline.pushFront({IRFunctionPassID::DSE});
-  IRFunctionPassManager IRFPM("opt", irFunctionPassPipeline);
-  IRFPM.run(&M, CompilationContext());
-  ASSERT_TRUE(M.verify());
-}

--- a/tests/unittests/PassManagerTest.cpp
+++ b/tests/unittests/PassManagerTest.cpp
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "BackendTestUtils.h"
+#include "glow/Graph/Graph.h"
+#include "glow/IR/IR.h"
+#include "glow/IR/IRBuilder.h"
+#include "glow/IR/IRUtils.h"
+#include "glow/IR/Instrs.h"
+#include "glow/Optimizer/GraphOptimizer/FunctionPassManager.h"
+#include "glow/Optimizer/IROptimizer/IRFunctionPassManager.h"
+#include "glow/Optimizer/IROptimizer/IROptimizer.h"
+
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/FileSystem.h"
+
+#include "gtest/gtest.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <string>
+
+using namespace glow;
+using llvm::cast;
+using llvm::dyn_cast;
+using llvm::isa;
+
+/// Test the ability to construct IRFunctionPassPipelines.
+TEST(Optimizer, IRFunctionPassPipeline) {
+  Module mod;
+  Function *F = mod.createFunction("IRPassManagerTest");
+  IRFunction M(F);
+  IRBuilder bb(&M);
+
+  // Create a WeightVar for TensorViews to use as their source operand.
+  auto *A = bb.createWeightVar(glow::ElemKind::FloatTy, {4, 2}, "A",
+                               WeightVar::MutabilityKind::Mutable);
+
+  // Create a view into A.
+  bb.createTensorViewInst(
+      "view1", A, mod.uniqueType(Type(glow::ElemKind::FloatTy, {1, 2, 1})),
+      {0, 0});
+
+  IRFunctionPassManager IRFPM("opt",
+                              glow::make_unique<IRFunctionPassPipeline>(
+                                  std::initializer_list<IRFunctionPassConfig>(
+                                      {{IRFunctionPassID::DSE}})));
+  IRFPM.run(&M, CompilationContext());
+  ASSERT_TRUE(M.verify());
+}
+
+/// Test the ability to construct FunctionPassPipelines.
+TEST(Optimizer, FunctionPassPipeline) {
+  Module mod;
+  Function *F = mod.createFunction("PassManagerTest");
+
+  FunctionPassManager FPM("opt", glow::make_unique<FunctionPassPipeline>(
+                                     std::initializer_list<FunctionPassConfig>(
+                                         {{FunctionPassID::CSE}})));
+  FPM.run(F, CompilationContext());
+  ASSERT_TRUE(F->verify());
+}
+
+/// Test that IRFunctionPassPipeline can be stored into files and can be read
+/// from files.
+TEST(Optimizer, IRFunctionPassPipelineFromFile) {
+  llvm::SmallString<64> path;
+  auto tempFileRes = llvm::sys::fs::createTemporaryFile(
+      "ir_function_pass_pipeline", "def", path);
+  EXPECT_EQ(tempFileRes.value(), 0);
+
+  IRFunctionPassPipeline origPipeline{
+      {IRFunctionPassID::DSE, ConvergenceMode::OnePass,
+       std::set{CompilationMode::Train}},
+
+      {IRFunctionPassID::OptimizeInserts, ConvergenceMode::UntilFixedPoint,
+       std::set{CompilationMode::Infer}},
+
+      {IRFunctionPassID::OptimizeExtracts, ConvergenceMode::OnePass,
+       std::set{CompilationMode::Infer, CompilationMode::Train}}};
+
+  /// Store the pipeline into a file.
+  origPipeline.dumpToFile(path);
+
+  /// Constuct a pipeline by reading its definition from a file.
+  IRFunctionPassManager IRFPM("irfpm", path);
+
+  /// Pipeline read from the file should be equivalent to the original pipeline.
+  EXPECT_TRUE(origPipeline.equals(IRFPM.getPipeline()));
+}
+
+/// Test that FunctionPassPipeline can be stored into files and can be read
+/// from files.
+TEST(Optimizer, FunctionPassPipelineFromFile) {
+  llvm::SmallString<64> path;
+  auto tempFileRes =
+      llvm::sys::fs::createTemporaryFile("function_pass_pipeline", "def", path);
+  EXPECT_EQ(tempFileRes.value(), 0);
+
+  FunctionPassPipeline origPipeline{
+      {FunctionPassID::CSE, ConvergenceMode::OnePass,
+       std::set{CompilationMode::Infer}, DCERequiredMode::BeforePass},
+
+      {FunctionPassID::SinkCode, ConvergenceMode::UntilFixedPoint,
+       std::set{CompilationMode::Infer, CompilationMode::Train},
+       DCERequiredMode::BeforePass},
+
+      {FunctionPassID::OptimizeReshape, ConvergenceMode::OnePass,
+       std::set{CompilationMode::Infer}, DCERequiredMode::None}};
+
+  /// Store the pipeline into a file.
+  origPipeline.dumpToFile(path);
+
+  /// Constuct a pipeline by reading its definition from a file.
+  FunctionPassManager FPM("fpm", path);
+
+  /// Pipeline read from the file should be equivalent to the original pipeline.
+  EXPECT_TRUE(origPipeline.equals(FPM.getPipeline()));
+}


### PR DESCRIPTION
Summary:
A number of improvements for the PassManager:
- Do not pass and copy pass configs and pass pipelines by value. Use unique_ptrs instead.
- Add support for reading pipeline definitions from YAML files and add tests for this functionality.

Reviewed By: jfix71

Differential Revision: D21218423

