### PR TITLE
Fix concat+slice optimizations

### DIFF
--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -2217,10 +2217,19 @@ static NodeValue simplifyConcatNode(Function *F, ConcatNode *CN) {
     // Check if the slices span the input value.
     bool found = findSlicesThatSpanInput(slices, CN->getDim(), order);
     if (found && order.size() == slices.size()) {
+      // Check that the ordered Slices that span the input are in order.
+      bool ordered = true;
+      for (size_t i = 0, e = slices.size(); i < e; i++) {
+        if (order[i] != slices[i]) {
+          ordered = false;
+          break;
+        }
+      }
+
       auto orig = order[0]->getInput();
       // The original value that we extract from must be of the same shape as
       // the concat.
-      if (CN->getResult().getType() == orig.getType()) {
+      if (ordered && CN->getResult().getType() == orig.getType()) {
         return orig;
       }
     }

--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -156,12 +156,15 @@ public:
 protected:
   void checkNumericalEquivalence(float allowedError = 0.0001) {
     // Check that the function and its optimized complement exist.
-    EXPECT_TRUE(F_);
-    EXPECT_TRUE(optimizedF_);
+    ASSERT_TRUE(F_);
+    ASSERT_TRUE(optimizedF_);
 
     // Check that the bindings are not empty. If they are, the numerical
     // equivalence check can produce a false positive.
     EXPECT_GT(bindings_.getDataSize(), 0);
+
+    // Allocate any leftover PHs; these are usually for SaveNodes.
+    bindings_.allocate(mod_.getPlaceholders());
 
     // Clone bindings to use for original and optimized functions.
     PlaceholderBindings originalBindings = bindings_.clone();


### PR DESCRIPTION
Summary: The optimization for eliminating Concat(Slice, ..., Slice) when all the Slices span the input was too aggressive. If the Slices were not in order into the Concat then the opt was still kicking in. I added a check for this.

Differential Revision: D21299036

