### PR TITLE
Add loading support in Glow for 4BitEmbeddingBag

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -347,6 +347,17 @@ private:
   // \returns error on failure.
   Error loadEmbeddingBagByteRowwiseOffsets(const torch::jit::Node *ptNode);
 
+  // Load a PyTorch fb::embedding_bag_4bit_rowwise_offsets.
+  // \returns error on failure.
+  Error loadEmbeddingBag4BitRowwiseOffsets(const torch::jit::Node *ptNode);
+
+  // Helper function that implements the loading logic for
+  // fb::embedding_bag_4bit_rowwise_offsets and
+  // fb::embedding_bag_byte_rowwise_offsets.
+  // \returns error on failure.
+  Error loadEmbeddingBagByteRowwiseOffsetsHelper(const torch::jit::Node *ptNode,
+                                                 bool is4Bit = false);
+
   /// Load all PyTorch prim::GetAttr nodes in \p graph. This method uses the
   /// PyTorch Module hierarchy to map Values for all outputs of prim::GetAttr
   /// nodes. If the output type of a prim::GetAttr is a tensor, this will load


### PR DESCRIPTION
Summary:
This diff adds a loader for ```fb::embedding_bag_4bit_rowwise_offsets``` op.

The loader shares the implementation underneath with the ```embedding_bag_byte_rowwise_offsets``` op.

The 4bit-embedding-bag implementation between PyTorch and Glow differs in the way that PyTorch returns Float32 and Glow returns Float16. So, in the unit-test we are upcasting the Glow Float16 to Float32 to make the unit-test pass. In the shorter term, glow/C2 folks will be changing the PyTorch implementation to return Float16 by default.

Differential Revision: D20957178

