### PR TITLE
Add SinkConcatBelowQuantize

### DIFF
--- a/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
+++ b/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
@@ -57,6 +57,8 @@ FUN_PASS(OptimizeQuantizeClip)
 FUN_PASS(OptimizeOutIntermediateConversions)
 FUN_PASS(OptimizeQuantFCFloatRelu)
 FUN_PASS(OptimizeConcatQuantization)
+FUN_PASS(SinkConcatBelowQuantize)
+
 
 // NOTE: This pass must be last; it's used to count the total number of passes.
 FUN_PASS(EmptyPass)


### PR DESCRIPTION
Summary: When we have a `ConcatNode` followed by a `QuantizeNode`, sink the `ConcatNode` below the `QuantizeNode`. If there are `DequantizeNode` inputs to the `ConcatNode` then we can eliminate converting between FP and back by replacing the `DequantizeNodes` with `RescaleQuantizedNodes`.

Differential Revision: D21344421

