### PR TITLE
Only change torch_glow signal handlers for python

### DIFF
--- a/torch_glow/src/PyTorchCommon.cpp
+++ b/torch_glow/src/PyTorchCommon.cpp
@@ -354,4 +354,17 @@ glow::Tensor ptTensorToGlowTensor(const at::Tensor &ptTensor) {
   }
 }
 
+static bool &_signalHandlerOverridesEnabled() {
+  static bool enabled = false;
+  return enabled;
+}
+
+void enableSignalHandlerOverrides(bool enable) {
+  _signalHandlerOverridesEnabled() = enable;
+}
+
+bool signalHandlerOverridesEnabled() {
+  return _signalHandlerOverridesEnabled();
+}
+
 } // namespace glow

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -148,6 +148,15 @@ glow::Tensor ptTensorToGlowTensor(const at::Tensor &ptTensor);
 /// matching type.
 at::Tensor glowTypeToEmptyPTTensor(const glow::Type &glowType);
 
+/// Enable overriding signal handlers while exeucting torch_glow code. This
+/// should only be used in Python to enable easier debugging and not in
+/// production C++ multithreaded environments. \p enable is used to enable or
+/// disable overriding if set to false.
+void enableSignalHandlerOverrides(bool enable = true);
+
+/// \returns whether or not signal handler overriding is enabled.
+bool signalHandlerOverridesEnabled();
+
 } // namespace glow
 
 #endif // GLOW_TORCH_GLOW_SRC_COMMON_H

--- a/torch_glow/src/binding.cpp
+++ b/torch_glow/src/binding.cpp
@@ -42,6 +42,11 @@ PYBIND11_MODULE(_torch_glow, m) {
   registerGlowFusionOpAndPass(
       []() { return getPyTorchLoaderSettings().fusionPassEnabled; });
 
+  /// Enable overriding signal handlers for torch_glow to make interruping long
+  /// running processes possible. This should only be used when running
+  /// torch_glow with Python.
+  enableSignalHandlerOverrides();
+
   /// Enable compiling PyTorch subgraphs to Glow Functions.
   m.def("enableFusionPass",
         []() { getPyTorchLoaderSettings().fusionPassEnabled = true; });


### PR DESCRIPTION
Summary: Only enable signal handler override in torch_glow for Python. The mechanism for this is if binding.cpp since that is what binds torch_glow C++ functions for use in Python. Removed all non-python references to binding.cpp

Reviewed By: yinghai

Differential Revision: D21374377

