### PR TITLE
Update BindContext to use EnableP2P/DRT flags 

### DIFF
--- a/include/glow/Runtime/Executor/NetworkExecutionState.h
+++ b/include/glow/Runtime/Executor/NetworkExecutionState.h
@@ -30,7 +30,8 @@ namespace runtime {
 class NetworkExecutionState final {
 public:
   /// Constructor.
-  explicit NetworkExecutionState(const DAGNode *root);
+  explicit NetworkExecutionState(const DAGNode *root, bool enableDRT,
+                                 bool enableP2P);
 
   const DAGNode *getRoot() { return root_; }
 
@@ -102,6 +103,12 @@ private:
 
   /// The callback that should be called when execution is done.
   ResultCBTy cb_;
+
+  /// Whether Device Resident Tensors optimization is enabled for the state.
+  bool enableDRT_;
+
+  /// Whether Peer to Peer optimization is enabled for the state.
+  bool enableP2P_;
 
   /// The ExecutionContext object containing the results of the execution
   /// (i.e. the outputs of the DAGNodes that have no children).

--- a/lib/Runtime/Executor/NetworkExecutionState.cpp
+++ b/lib/Runtime/Executor/NetworkExecutionState.cpp
@@ -27,8 +27,10 @@ void NetworkExecutionStatePool::addNewState(
   states_.push_back(std::move(state));
 }
 
-NetworkExecutionState::NetworkExecutionState(const DAGNode *root)
-    : inflightNodes_(0), module_(root->module), root_(root) {}
+NetworkExecutionState::NetworkExecutionState(const DAGNode *root,
+                                             bool enableDRT, bool enableP2P)
+    : enableDRT_(enableDRT), enableP2P_(enableP2P), inflightNodes_(0),
+      module_(root->module), root_(root) {}
 
 NetworkExecutionState::~NetworkExecutionState() {
   // Free all allocated buffers.
@@ -175,8 +177,8 @@ void NetworkExecutionState::init(
     // once we are done with it.
     std::unique_ptr<Backend> newBackend(createBackend(backendName));
 
-    EXIT_ON_ERR(newBackend->bindContexts(contexts, root_, /*enableP2P*/ true,
-                                         /*enableDRT*/ true));
+    EXIT_ON_ERR(
+        newBackend->bindContexts(contexts, root_, enableP2P_, enableDRT_));
   }
   initialized_ = true;
 }

--- a/lib/Runtime/Executor/ThreadPoolExecutor.cpp
+++ b/lib/Runtime/Executor/ThreadPoolExecutor.cpp
@@ -324,7 +324,8 @@ void ThreadPoolExecutor::createPool(const DAGNode *root, unsigned poolSize,
   std::unique_ptr<NetworkExecutionStatePool> pool =
       glow::make_unique<NetworkExecutionStatePool>();
   for (unsigned i = 0; i < poolSize; i++) {
-    auto newState = glow::make_unique<NetworkExecutionState>(root);
+    auto newState =
+        glow::make_unique<NetworkExecutionState>(root, enableDRT, enableP2P);
     // If assignStatic, calculate the device assignments for this
     // executionState. For now we are assigning a round robin pattern per node.
     if (enableDRT || enableP2P) {


### PR DESCRIPTION
Summary:
Update the BindContexts call in NetworkExecutionState to pass in the values for enableDRT/enableP2P flags instead of being hard coded.
Documentation:

Test Plan:
ninja check
