### PR TITLE
Adding max group size

### DIFF
--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -61,6 +61,11 @@ struct PyTorchLoaderSettings {
   /// nodes. 0 indicates no minimum size.
   size_t minFusionGroupSize = 0;
 
+  /// The maximum total number of nodes which are allowed to merge when
+  /// fusing groups. The resulting group may be larger than this limit
+  /// however as additional nodes may be inserted during the merge.
+  size_t maxFusionMergeSize = 0;
+
   /// Index (inclusive) of the first node in the JIT graph to fuse. Ignored if
   /// negative.
   /// NOTE: this should only be used for debugging.

--- a/torch_glow/src/binding.cpp
+++ b/torch_glow/src/binding.cpp
@@ -195,6 +195,10 @@ PYBIND11_MODULE(_torch_glow, m) {
   m.def("setMinFusionGroupSize",
         [](size_t k) { getPyTorchLoaderSettings().minFusionGroupSize = k; });
 
+  /// Set the maximum fusion merge size
+  m.def("setMaxFusionMergeSize",
+        [](size_t k) { getPyTorchLoaderSettings().maxFusionMergeSize = k; });
+
   /// Call the Glow fuser and accept all node kinds but don't actually run the
   /// PyTorchModelLoader.
   /// NOTE: This is only exposed for testing.

--- a/torch_glow/tests/functionality/max_fusion_merge_size_test.py
+++ b/torch_glow/tests/functionality/max_fusion_merge_size_test.py
@@ -1,0 +1,73 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import torch
+
+from tests.utils import GLOW_NODE_NAME, SUBGRAPH_ATTR
+import torch_glow
+import unittest
+
+
+class TestMaxFusionMergeSize(unittest.TestCase):
+    def test_max_fusion_merge_size(self):
+        """Test Glow fuser maximum fusion merge size mechanism."""
+
+        def f(a):
+            return (a * a * a * a * a * a)
+
+        torch_glow.disableFusionPass()
+
+        # Set maximum fusion merge size to 3 nodes so that the
+        # graph will not fit into 1 node
+        torch_glow.setMaxFusionMergeSize(3)
+
+        a = torch.randn(5, 5)
+
+        jit_f = torch.jit.trace(f, (a))
+        jit_f_graph = jit_f.graph_for(a)
+
+        #print("before: ", jit_f_graph)
+
+        torch_glow.glowCustomFuseDebug_(jit_f_graph)
+
+        #print("after: ", jit_f_graph)
+
+        fusion_nodes = 0
+        for node in jit_f_graph.nodes():
+            if node.kind() == GLOW_NODE_NAME:
+                fusion_nodes += 1
+
+        assert fusion_nodes > 1, "Expected more than one fusion group to be created"
+
+        torch_glow.setMaxFusionMergeSize(0)
+
+    def test_max_fusion_merge_size_zero(self):
+        """Test Glow fuser maximum fusion merge size mechanism set to zero."""
+
+        def f(a):
+            return (a * a * a * a * a * a)
+
+        torch_glow.disableFusionPass()
+
+        # Set maximum fusion merge size to 0 so that there is
+        # no limit to fusion
+        torch_glow.setMaxFusionMergeSize(0)
+
+        a = torch.randn(5, 5)
+
+        jit_f = torch.jit.trace(f, (a))
+        jit_f_graph = jit_f.graph_for(a)
+
+        #print("before: ", jit_f_graph)
+
+        torch_glow.glowCustomFuseDebug_(jit_f_graph)
+
+        #print("after: ", jit_f_graph)
+
+        fusion_nodes = 0
+        for node in jit_f_graph.nodes():
+            if node.kind() == GLOW_NODE_NAME:
+                fusion_nodes += 1
+
+        assert fusion_nodes == 1, "Expected just one fusion group to be created"
+
+        torch_glow.setMaxFusionMergeSize(0)


### PR DESCRIPTION
Summary: Stop the graph merging after a certain size threshold is reached, specified by maxFusionMergeSize. Useful for correctness debugging

Differential Revision: D21285423

