### PR TITLE
Adding correctness checking to CachingGraphRunner

### DIFF
--- a/torch_glow/src/PyTorchCommon.cpp
+++ b/torch_glow/src/PyTorchCommon.cpp
@@ -30,6 +30,7 @@ DEFINE_int32(torch_glow_num_devices, 1, "Number of devices for Glow backend");
 DEFINE_int32(torch_glow_min_fusion_group_size, 1,
              "Number of devices for Glow backend");
 DEFINE_bool(dumpGlowDag, false, "See PyTorchLoaderSettings");
+DEFINE_bool(jitVsGlowCompare, false, "Enable per-group error check");
 DEFINE_bool(dumpFinalGlowGraph, false, "See PyTorchLoaderSettings");
 DEFINE_bool(enableGlowTracing, false, "See PyTorchLoaderSettings");
 DEFINE_int32(numTracesPerDump, 1, "See PyTorchLoaderSettings");
@@ -205,6 +206,7 @@ static PyTorchLoaderSettings getInitialSettings() {
   PyTorchLoaderSettings settings;
   settings.minFusionGroupSize = FLAGS_torch_glow_min_fusion_group_size;
   settings.dumpGlowDag = FLAGS_dumpGlowDag;
+  settings.jitVsGlowCompare = FLAGS_jitVsGlowCompare;
   settings.dumpFinalGlowGraph = FLAGS_dumpFinalGlowGraph;
   settings.enableGlowTracing = FLAGS_enableGlowTracing;
   settings.numTracesPerDump = FLAGS_numTracesPerDump;

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -61,6 +61,11 @@ struct PyTorchLoaderSettings {
   /// nodes. 0 indicates no minimum size.
   size_t minFusionGroupSize = 0;
 
+  /// The maximum total number of nodes which are allowed to merge when
+  /// fusing groups. The resulting group may be larger than this limit
+  /// however as additional nodes may be inserted during the merge.
+  size_t maxFusionMergeSize = 0;
+
   /// Index (inclusive) of the first node in the JIT graph to fuse. Ignored if
   /// negative.
   /// NOTE: this should only be used for debugging.

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -102,6 +102,9 @@ struct PyTorchLoaderSettings {
   /// and from the function to file as ONNX graphs.
   bool writeToOnnx = false;
 
+  /// Whether or not to do a numerical comparions of Glow and jit outputs
+  bool jitVsGlowCompare = false;
+
   /// Name of a YAML file containing backend specific options.
   std::string backendOptionsFile;
 

--- a/torch_glow/src/binding.cpp
+++ b/torch_glow/src/binding.cpp
@@ -116,6 +116,14 @@ PYBIND11_MODULE(_torch_glow, m) {
   m.def("disable_write_to_onnx",
         []() { getPyTorchLoaderSettings().writeToOnnx = false; });
 
+  /// Enable check Glow vs jit correctness.
+  m.def("enable_jit_vs_glow_compare",
+        []() { getPyTorchLoaderSettings().jitVsGlowCompare = true; });
+
+  /// Disable check Glow vs jit correctness.
+  m.def("disable_jit_vs_glow_compare",
+        []() { getPyTorchLoaderSettings().jitVsGlowCompare = false; });
+
   /// Enable saturateHost mode in Glow runtime.
   m.def("enable_saturate_host",
         []() { getPyTorchLoaderSettings().saturateHost = true; });

--- a/torch_glow/src/binding.cpp
+++ b/torch_glow/src/binding.cpp
@@ -195,6 +195,10 @@ PYBIND11_MODULE(_torch_glow, m) {
   m.def("setMinFusionGroupSize",
         [](size_t k) { getPyTorchLoaderSettings().minFusionGroupSize = k; });
 
+  /// Set the maximum fusion merge size
+  m.def("setMaxFusionMergeSize",
+        [](size_t k) { getPyTorchLoaderSettings().maxFusionMergeSize = k; });
+
   /// Call the Glow fuser and accept all node kinds but don't actually run the
   /// PyTorchModelLoader.
   /// NOTE: This is only exposed for testing.

--- a/torch_glow/tests/functionality/jit_vs_glow_path_test.py
+++ b/torch_glow/tests/functionality/jit_vs_glow_path_test.py
@@ -1,0 +1,60 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+
+import torch
+import torch.nn.functional as F
+import torch_glow
+from tests.utils import jitVsGlow
+
+
+class TestJITVsGlowPath(unittest.TestCase):
+    def test_jit_vs_glow_path(self):
+        """Basic test of the JIT vs. Glow logging feature."""
+
+        torch_glow.enable_jit_vs_glow_compare()
+
+        def test_f(input, weight, bias=None):
+            return F.linear((input + input), weight, bias)
+
+        n = 5
+        in_features = 4
+        out_features = 3
+
+        input = torch.randn(n, in_features)
+        weight = torch.randn(out_features, in_features)
+
+        jitVsGlow(
+            test_f,
+            input,
+            weight,
+            expected_fused_ops={"aten::add", "aten::t", "aten::matmul"},
+        )
+
+    def test_jit_vs_glow_int_path(self):
+        """Test JIT vs. Glow logging with int type """
+
+        torch_glow.enable_jit_vs_glow_compare()
+
+        def test_f(a, b):
+            c = a + b
+            return c
+
+        a = torch.randn(5, 6).to(dtype=torch.int32)
+        b = torch.randn(5, 6).to(dtype=torch.int32)
+
+        jitVsGlow(test_f, a, b, expected_fused_ops={"aten::add"})
+
+    def test_jit_vs_glow_inplace(self):
+        """Test JIT vs. Glow logging with in-place op"""
+
+        torch_glow.enable_jit_vs_glow_compare()
+
+        def test_f(a, b):
+            a += b
+            return a
+
+        a = torch.randn(5, 6)
+        b = torch.randn(5, 6)
+
+        jitVsGlow(test_f, a, b, expected_fused_ops={"aten::add_"})

--- a/torch_glow/tests/functionality/max_fusion_merge_size_test.py
+++ b/torch_glow/tests/functionality/max_fusion_merge_size_test.py
@@ -1,0 +1,73 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import torch
+
+from tests.utils import GLOW_NODE_NAME, SUBGRAPH_ATTR
+import torch_glow
+import unittest
+
+
+class TestMaxFusionMergeSize(unittest.TestCase):
+    def test_max_fusion_merge_size(self):
+        """Test Glow fuser maximum fusion merge size mechanism."""
+
+        def f(a):
+            return (a * a * a * a * a * a)
+
+        torch_glow.disableFusionPass()
+
+        # Set maximum fusion merge size to 3 nodes so that the
+        # graph will not fit into 1 node
+        torch_glow.setMaxFusionMergeSize(3)
+
+        a = torch.randn(5, 5)
+
+        jit_f = torch.jit.trace(f, (a))
+        jit_f_graph = jit_f.graph_for(a)
+
+        #print("before: ", jit_f_graph)
+
+        torch_glow.glowCustomFuseDebug_(jit_f_graph)
+
+        #print("after: ", jit_f_graph)
+
+        fusion_nodes = 0
+        for node in jit_f_graph.nodes():
+            if node.kind() == GLOW_NODE_NAME:
+                fusion_nodes += 1
+
+        assert fusion_nodes > 1, "Expected more than one fusion group to be created"
+
+        torch_glow.setMaxFusionMergeSize(0)
+
+    def test_max_fusion_merge_size_zero(self):
+        """Test Glow fuser maximum fusion merge size mechanism set to zero."""
+
+        def f(a):
+            return (a * a * a * a * a * a)
+
+        torch_glow.disableFusionPass()
+
+        # Set maximum fusion merge size to 0 so that there is
+        # no limit to fusion
+        torch_glow.setMaxFusionMergeSize(0)
+
+        a = torch.randn(5, 5)
+
+        jit_f = torch.jit.trace(f, (a))
+        jit_f_graph = jit_f.graph_for(a)
+
+        #print("before: ", jit_f_graph)
+
+        torch_glow.glowCustomFuseDebug_(jit_f_graph)
+
+        #print("after: ", jit_f_graph)
+
+        fusion_nodes = 0
+        for node in jit_f_graph.nodes():
+            if node.kind() == GLOW_NODE_NAME:
+                fusion_nodes += 1
+
+        assert fusion_nodes == 1, "Expected just one fusion group to be created"
+
+        torch_glow.setMaxFusionMergeSize(0)


### PR DESCRIPTION
Summary:
Add flag to enable JIT vs. Glow comparison.
Also changed the stack copy to use deep instead of shallow copy.

Differential Revision: D21285371

