### PR TITLE
[GraphOptimizer] Fix ConstantFolding pass to handle nodes which are lowered in Interpreter backend.

### DIFF
--- a/lib/Optimizer/GraphOptimizer/ConstantFolding.cpp
+++ b/lib/Optimizer/GraphOptimizer/ConstantFolding.cpp
@@ -296,12 +296,6 @@ bool glow::ConstantFold::run(Function *F, const CompilationContext &cctx) {
       continue;
     }
 
-    // Don't try to constant fold Nodes that are not supported by the
-    // Interpreter. These are usually backend-specific.
-    if (!backend->isOpSupported(*N)) {
-      continue;
-    }
-
     // Skip nodes that are not constant operations.
     if (!isConstantOperation(N, *backend)) {
       continue;


### PR DESCRIPTION
Summary:
Fix ConstantFolding pass to handle nodes which are lowered in Interpreter backend. The issue pop ups when target backend has different lowering ruls from Interpreter backend.
Note that the correct check is already done in `isConstantOperation`, so `isOpSupported` check can simply be removed.

Documentation:
N/A

Test Plan:
Added GraphOptz unit test.