### PR TITLE
[WIP][LLVMIRCodeGen] Add support for error handling

### DIFF
--- a/include/glow/LLVMIRCodeGen/LLVMIRGen.h
+++ b/include/glow/LLVMIRCodeGen/LLVMIRGen.h
@@ -305,10 +305,22 @@ public:
   /// and then creates and \returns the CallInst.
   /// \param builder the IR builder to be used for creating the Call
   /// instruction. \param callee the function to be called. \param args
-  /// arguments to be passed in this call. \returns generated Call instruction
+  /// arguments to be passed in this call. If \p checked is set, this helper
+  /// emits checks for the int result of the call and returns from the caller if
+  /// it is non-zero. If callee does not return an int result, \p checked has no
+  /// effect. \returns generated Call instruction
   virtual llvm::CallInst *createCall(llvm::IRBuilder<> &builder,
                                      llvm::Function *callee,
-                                     llvm::ArrayRef<llvm::Value *> args);
+                                     llvm::ArrayRef<llvm::Value *> args,
+                                     bool checked = false);
+  /// The checked version of createCall.
+  virtual llvm::CallInst *createCheckedCall(llvm::IRBuilder<> &builder,
+                                            llvm::Function *callee,
+                                            llvm::ArrayRef<llvm::Value *> args);
+  /// The unchecked version of createCall.
+  virtual llvm::CallInst *
+  createUncheckedCall(llvm::IRBuilder<> &builder, llvm::Function *callee,
+                      llvm::ArrayRef<llvm::Value *> args);
   /// \returns a libjit API function by name.
   virtual llvm::Function *getFunction(const std::string &name);
   /// \returns a libjit API function by name and tensor element type.

--- a/lib/Backends/CPU/CPULLVMIRGen.cpp
+++ b/lib/Backends/CPU/CPULLVMIRGen.cpp
@@ -144,15 +144,15 @@ void CPULLVMIRGen::generateLLVMIRForDataParallelInstr(
                                    lhs->getType()->getOffset()};
       auto quantizedValue = quantization::quantize(V, TQP);
       auto *val = emitConst(builder, quantizedValue, lhs->getElementType());
-      auto *stackedOpCall =
-          createCall(builder, F, {loopCount, val, lhsPtr, pointerNull});
+      auto *stackedOpCall = createUncheckedCall(
+          builder, F, {loopCount, val, lhsPtr, pointerNull});
       auto *destAddr = builder.CreateGEP(builder.getInt8Ty(), destPtr,
                                          loopCount, "buffer.element.addr");
       builder.CreateStore(stackedOpCall, destAddr);
     } else {
       auto *val = emitConst(builder, V, lhs->getElementType());
-      auto *stackedOpCall =
-          createCall(builder, F, {loopCount, val, lhsPtr, pointerNull});
+      auto *stackedOpCall = createUncheckedCall(
+          builder, F, {loopCount, val, lhsPtr, pointerNull});
       auto *destAddr = builder.CreateGEP(builder.getFloatTy(), destPtr,
                                          loopCount, "buffer.element.addr");
       builder.CreateStore(stackedOpCall, destAddr);

--- a/lib/LLVMIRCodeGen/CommandLine.cpp
+++ b/lib/LLVMIRCodeGen/CommandLine.cpp
@@ -92,6 +92,11 @@ llvm::cl::opt<llvm::FloatABI::ABIType>
                                          "Hard float ABI (hardfp)")),
              llvm::cl::init(llvm::FloatABI::Default));
 
+llvm::cl::opt<bool> checkedErrors(
+    "checked-errors",
+    llvm::cl::desc("Emit code for error checking during execution"),
+    llvm::cl::init(false), llvm::cl::cat(getLLVMBackendCat()));
+
 static llvm::cl::OptionCategory bundleSaverCat("Bundle Options");
 
 llvm::cl::opt<glow::BundleApiType>

--- a/lib/LLVMIRCodeGen/CommandLine.h
+++ b/lib/LLVMIRCodeGen/CommandLine.h
@@ -67,6 +67,9 @@ extern llvm::cl::list<std::string> llvmCompilerOptions;
 /// Option to set float ABI. Used as -float-abi=<abi-type>.
 extern llvm::cl::opt<llvm::FloatABI::ABIType> floatABI;
 
+/// Option to enable error-checking during execution of compiled models.
+extern llvm::cl::opt<bool> checkedErrors;
+
 /// Option to specify which bundle API to use.
 extern llvm::cl::opt<glow::BundleApiType> bundleAPI;
 

--- a/lib/LLVMIRCodeGen/LLVMBackend.cpp
+++ b/lib/LLVMIRCodeGen/LLVMBackend.cpp
@@ -67,21 +67,26 @@ LLVMBackend::LLVMBackend() {}
 
 /// Emit the entry point for JIT called "jitmain".
 /// Function has the following API:
-///   void jitmain(uint8_t *baseConstantWeightVars,
-///                uint8_t *baseInOutWeightVars,
-///                uint8_t *baseActivations);
+///   ssize_t jitmain(uint8_t *baseConstantWeightVars,
+///                   uint8_t *baseInOutWeightVars,
+///                   uint8_t *baseActivations);
 void LLVMBackend::emitJitMain(LLVMIRGen &irgen) const {
   AllocationsInfo &allocationsInfo = irgen.getAllocationsInfo();
-  llvm::Type *voidTy = llvm::Type::getVoidTy(irgen.getLLVMContext());
   auto int8PtrTy = llvm::Type::getInt8PtrTy(irgen.getLLVMContext());
+  llvm::Type *retTy = llvm::Type::getIntNTy(irgen.getLLVMContext(),
+                                            irgen.getLibjitSizeTWidth());
   llvm::FunctionType *jitFuncTy =
-      llvm::FunctionType::get(voidTy, {int8PtrTy, int8PtrTy, int8PtrTy}, false);
+      llvm::FunctionType::get(retTy, {int8PtrTy, int8PtrTy, int8PtrTy}, false);
   auto *func =
       llvm::Function::Create(jitFuncTy, llvm::Function::ExternalLinkage,
                              "jitmain", &irgen.getModule());
   llvm::BasicBlock *entry_bb =
       llvm::BasicBlock::Create(irgen.getLLVMContext(), "entry", func);
   llvm::IRBuilder<> builder(entry_bb);
+  // Add a provisional terminator to make the function well-formed.
+  auto *zero = builder.getIntN(irgen.getLibjitSizeTWidth(), 0);
+  auto *ret = builder.CreateRet(zero);
+  builder.SetInsertPoint(ret);
 
   // Prepare arguments for the "main" function.
   llvm::SmallVector<llvm::Value *, 4> initFunctionCallArgs;
@@ -96,9 +101,11 @@ void LLVMBackend::emitJitMain(LLVMIRGen &irgen) const {
   // use of it.
   auto *entryF = irgen.getModule().getFunction(irgen.getMainEntryName());
   entryF->setLinkage(llvm::Function::InternalLinkage);
-  irgen.createCall(builder, entryF, initFunctionCallArgs);
+  auto *result = irgen.createCall(builder, entryF, initFunctionCallArgs);
   // Terminate the function.
-  builder.CreateRetVoid();
+  builder.CreateRet(result);
+  // Remove the provisional terminator.
+  ret->eraseFromParent();
   // Emit JIT file printer.
   irgen.generateJITFileWriter();
   // Create the debug info for the entry point function.

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -258,11 +258,12 @@ void LLVMIRGen::performCodeGen() {
   auto int8PtrTy = llvm::Type::getInt8PtrTy(getLLVMContext());
   auto dimTPtrTy = llvm::Type::getIntNPtrTy(getLLVMContext(), DIM_T_BITWIDTH);
   // The entry point has the following API:
-  // void entry(uint8_t *baseConstantWeightVars, uint8_t
+  // ssize_t entry(uint8_t *baseConstantWeightVars, uint8_t
   // *baseInoutWeightVars, uint8_t *baseActivations, dim_t *offsets);
-  llvm::Type *voidTy = llvm::Type::getVoidTy(getLLVMContext());
+  llvm::Type *retTy =
+      llvm::Type::getIntNTy(getLLVMContext(), getLibjitSizeTWidth());
   llvm::FunctionType *jitFuncTy = llvm::FunctionType::get(
-      voidTy, {int8PtrTy, int8PtrTy, int8PtrTy, dimTPtrTy}, false);
+      retTy, {int8PtrTy, int8PtrTy, int8PtrTy, dimTPtrTy}, false);
   llvmF_ = llvm::Function::Create(jitFuncTy, llvm::Function::ExternalLinkage,
                                   "main", llmodule_.get());
   emittedLLVMFunctions_.emplace_back(llvmF_);
@@ -272,7 +273,8 @@ void LLVMIRGen::performCodeGen() {
       llvm::BasicBlock::Create(getLLVMContext(), "entry", llvmF_);
   builder_ = glow::make_unique<llvm::IRBuilder<>>(entry_bb);
   // Terminate the function with a return instruction.
-  auto *ret = builder_->CreateRetVoid();
+  auto zero = builder_->getIntN(getLibjitSizeTWidth(), 0);
+  auto *ret = builder_->CreateRet(zero);
   // Emit all the code before the retrun instruction.
   builder_->SetInsertPoint(ret);
 
@@ -646,7 +648,8 @@ llvm::Function *LLVMIRGen::getLLVMFunction() { return llvmF_; }
 
 llvm::CallInst *LLVMIRGen::createCall(llvm::IRBuilder<> &builder,
                                       llvm::Function *callee,
-                                      llvm::ArrayRef<llvm::Value *> args) {
+                                      llvm::ArrayRef<llvm::Value *> args,
+                                      bool checked) {
 #ifndef NDEBUG
   llvm::FunctionType *FTy = callee->getFunctionType();
   assert((args.size() == FTy->getNumParams() ||
@@ -659,7 +662,43 @@ llvm::CallInst *LLVMIRGen::createCall(llvm::IRBuilder<> &builder,
            "Calling a function with a bad signature: argument type mismatch.");
   }
 #endif
-  return builder.CreateCall(callee, args);
+  if (!checked || !callee->getReturnType()->isIntegerTy()) {
+    return builder.CreateCall(callee, args);
+  }
+  // Check if callee returned an error, i.e. non-zero result.
+  // Emit a return with this error code in this case.
+  auto *result = builder.CreateCall(callee, args);
+  auto *zero = builder.getIntN(result->getType()->getIntegerBitWidth(), 0);
+  auto *cond = builder.CreateICmpNE(result, zero);
+  auto insertionPoint = builder.GetInsertPoint();
+  auto *currentBB = result->getParent();
+  auto *falseBB =
+      currentBB->splitBasicBlock(builder.GetInsertPoint(), "cont_bb");
+  auto *trueBB = llvm::BasicBlock::Create(getLLVMContext(), "error_bb",
+                                          result->getFunction());
+  builder.SetInsertPoint(currentBB->getTerminator());
+  builder.CreateCondBr(cond, trueBB, falseBB);
+  currentBB->getTerminator()->eraseFromParent();
+  builder.SetInsertPoint(trueBB);
+  auto *castedResult =
+      builder.CreateBitCast(result, builder.getIntNTy(getLibjitSizeTWidth()));
+  builder.CreateRet(castedResult);
+  builder.SetInsertPoint(falseBB, insertionPoint);
+  builder.SetInsertPoint(falseBB->getTerminator());
+  return result;
+}
+
+llvm::CallInst *
+LLVMIRGen::createCheckedCall(llvm::IRBuilder<> &builder, llvm::Function *callee,
+                             llvm::ArrayRef<llvm::Value *> args) {
+  return createCall(builder, callee, args, /* checked */ true);
+}
+
+llvm::CallInst *
+LLVMIRGen::createUncheckedCall(llvm::IRBuilder<> &builder,
+                               llvm::Function *callee,
+                               llvm::ArrayRef<llvm::Value *> args) {
+  return createCall(builder, callee, args, /* checked */ false);
 }
 
 std::pair<llvm::BasicBlock *, llvm::BasicBlock *>
@@ -788,7 +827,7 @@ void LLVMIRGen::emitDataParallelKernelImpl(
 
   setCurrentDebugLocation(builder, *bundle.begin());
   // Emit a call of the kernel.
-  createCall(builder, kernelFunc, buffers);
+  createUncheckedCall(builder, kernelFunc, buffers);
   // Emit debug info for the generated data-parallel kernel.
   generateFunctionDebugInfo(kernelFunc);
 }
@@ -974,15 +1013,15 @@ void LLVMIRGen::generateLLVMIRForDataParallelInstr(
       TensorQuantizationParams TQP{destTy->getScale(), destTy->getOffset()};   \
       auto quantizedValue = quantization::quantize(value, TQP);                \
       auto *val = emitConstI8(builder, quantizedValue);                        \
-      auto *stackedOpCall =                                                    \
-          createCall(builder, F, {loopCount, val, pointerNull, pointerNull});  \
+      auto *stackedOpCall = createUncheckedCall(                               \
+          builder, F, {loopCount, val, pointerNull, pointerNull});             \
       auto *destAddr = builder.CreateGEP(elementTy, destPtr, loopCount,        \
                                          "buffer.element.addr");               \
       builder.CreateStore(stackedOpCall, destAddr);                            \
     } else {                                                                   \
       auto *val = emitConst(builder, value, dest->getElementType());           \
-      auto *stackedOpCall =                                                    \
-          createCall(builder, F, {loopCount, val, pointerNull, pointerNull});  \
+      auto *stackedOpCall = createUncheckedCall(                               \
+          builder, F, {loopCount, val, pointerNull, pointerNull});             \
       auto *destAddr = builder.CreateGEP(elementTy, destPtr, loopCount,        \
                                          "buffer.element.addr");               \
       builder.CreateStore(stackedOpCall, destAddr);                            \
@@ -1038,7 +1077,7 @@ void LLVMIRGen::generateLLVMIRForDataParallelInstr(
       auto *rhsPost = emitConstI32(builder, rhsScaleParams.post);
       auto *rhsScale = emitConstI32(builder, rhsScaleParams.scale);
 
-      auto *stackedOpCall = createCall(
+      auto *stackedOpCall = createUncheckedCall(
           builder, F,
           {loopCount, condPtr, lhsPtr, rhsPtr, destOffset, lhsOffset, rhsOffset,
            lhsPre, lhsPost, lhsScale, rhsPre, rhsPost, rhsScale});
@@ -1047,7 +1086,7 @@ void LLVMIRGen::generateLLVMIRForDataParallelInstr(
       builder.CreateStore(stackedOpCall, destAddr);
     } else {
       auto *stackedOpCall =
-          createCall(builder, F, {loopCount, condPtr, lhsPtr, rhsPtr});
+          createUncheckedCall(builder, F, {loopCount, condPtr, lhsPtr, rhsPtr});
       auto *destAddr = builder.CreateGEP(builder.getFloatTy(), destPtr,
                                          loopCount, "buffer.element.addr");
       builder.CreateStore(stackedOpCall, destAddr);
@@ -1085,8 +1124,8 @@ void LLVMIRGen::generateLLVMIRForDataParallelInstr(
     auto *elementTy = getElementType(builder, dest);                           \
     auto *pointerNull =                                                        \
         llvm::ConstantPointerNull::get(elementTy->getPointerTo());             \
-    auto *stackedOpCall =                                                      \
-        createCall(builder, F, {loopCount, srcPtr, pointerNull, pointerNull}); \
+    auto *stackedOpCall = createUncheckedCall(                                 \
+        builder, F, {loopCount, srcPtr, pointerNull, pointerNull});            \
     auto *destAddr = builder.CreateGEP(builder.getFloatTy(), destPtr,          \
                                        loopCount, "buffer.element.addr");      \
     builder.CreateStore(stackedOpCall, destAddr);                              \
@@ -1107,7 +1146,7 @@ void LLVMIRGen::generateLLVMIRForDataParallelInstr(
     auto *destPtr = emitBufferAddress(builder, dest, kernel, bufferToArgNum);
     auto *srcPtr = emitBufferAddress(builder, src, kernel, bufferToArgNum);
     auto *F = getFunction("element_is_nan_kernel", src->getElementType());
-    auto *stackedOpCall = createCall(builder, F, {loopCount, srcPtr});
+    auto *stackedOpCall = createUncheckedCall(builder, F, {loopCount, srcPtr});
     auto *elementTy = getElementType(builder, dest);
     auto *destAddr =
         builder.CreateGEP(elementTy, destPtr, loopCount, "buffer.element.addr");
@@ -1126,8 +1165,8 @@ void LLVMIRGen::generateLLVMIRForDataParallelInstr(
     auto *destOffset = emitConstI32(builder, destTy->getOffset());
     auto *F = getFunction("element_quantize_kernel", dest->getElementType());
 
-    auto *stackedOpCall =
-        createCall(builder, F, {loopCount, srcPtr, destScale, destOffset});
+    auto *stackedOpCall = createUncheckedCall(
+        builder, F, {loopCount, srcPtr, destScale, destOffset});
     llvm::Value *destAddr = nullptr;
     if (dest->getElementType() == ElemKind::Int8QTy) {
       destAddr = builder.CreateGEP(builder.getInt8Ty(), destPtr, loopCount,
@@ -1154,8 +1193,8 @@ void LLVMIRGen::generateLLVMIRForDataParallelInstr(
     auto *srcOffset = emitConstI32(builder, srcTy->getOffset());
     auto *F = getFunction("element_dequantize_kernel", dest->getElementType());
 
-    auto *stackedOpCall =
-        createCall(builder, F, {loopCount, srcPtr, srcScale, srcOffset});
+    auto *stackedOpCall = createUncheckedCall(
+        builder, F, {loopCount, srcPtr, srcScale, srcOffset});
     auto *destAddr = builder.CreateGEP(builder.getFloatTy(), destPtr, loopCount,
                                        "buffer.element.addr");
     builder.CreateStore(stackedOpCall, destAddr);
@@ -1182,7 +1221,7 @@ void LLVMIRGen::generateLLVMIRForDataParallelInstr(
     auto *scale = emitConstI32(builder, rescaleParams.scale);
     auto *F = getFunction("element_rescale_kernel", dest->getElementType());
 
-    auto *stackedOpCall = createCall(
+    auto *stackedOpCall = createUncheckedCall(
         builder, F,
         {loopCount, srcPtr, destOffset, srcOffset, preShift, postShift, scale});
     auto *destAddr = builder.CreateGEP(builder.getInt8Ty(), destPtr, loopCount,
@@ -1201,8 +1240,8 @@ void LLVMIRGen::generateLLVMIRForDataParallelInstr(
     auto *elementTy = getElementType(builder, dest);
     auto *pointerNull =
         llvm::ConstantPointerNull::get(elementTy->getPointerTo());
-    auto *stackedOpCall =
-        createCall(builder, F, {loopCount, srcPtr, pointerNull, pointerNull});
+    auto *stackedOpCall = createUncheckedCall(
+        builder, F, {loopCount, srcPtr, pointerNull, pointerNull});
     auto *destAddr = builder.CreateGEP(getElementType(builder, dest), destPtr,
                                        loopCount, "buffer.element.addr");
     builder.CreateStore(stackedOpCall, destAddr);
@@ -1247,16 +1286,16 @@ void LLVMIRGen::generateLLVMIRForDataParallelInstr(
       auto *rhsPost = emitConstI32(builder, rhsScaleParams.post);              \
       auto *rhsScale = emitConstI32(builder, rhsScaleParams.scale);            \
                                                                                \
-      auto *stackedOpCall = createCall(builder, F,                             \
-                                       {loopCount, lhsPtr, rhsPtr, destOffset, \
-                                        lhsOffset, rhsOffset, lhsPre, lhsPost, \
-                                        lhsScale, rhsPre, rhsPost, rhsScale}); \
+      auto *stackedOpCall = createUncheckedCall(                               \
+          builder, F,                                                          \
+          {loopCount, lhsPtr, rhsPtr, destOffset, lhsOffset, rhsOffset,        \
+           lhsPre, lhsPost, lhsScale, rhsPre, rhsPost, rhsScale});             \
       auto *destAddr = builder.CreateGEP(builder.getInt8Ty(), destPtr,         \
                                          loopCount, "buffer.element.addr");    \
       builder.CreateStore(stackedOpCall, destAddr);                            \
     } else {                                                                   \
-      auto *stackedOpCall =                                                    \
-          createCall(builder, F, {loopCount, lhsPtr, rhsPtr, pointerNull});    \
+      auto *stackedOpCall = createUncheckedCall(                               \
+          builder, F, {loopCount, lhsPtr, rhsPtr, pointerNull});               \
       auto *destAddr = builder.CreateGEP(elementTy, destPtr, loopCount,        \
                                          "buffer.element.addr");               \
       builder.CreateStore(stackedOpCall, destAddr);                            \
@@ -1318,14 +1357,16 @@ void LLVMIRGen::generateLLVMIRForDataParallelInstr(
       auto *cmpPost = emitConstI32(builder, scaleParams.post);
       auto *cmpScale = emitConstI32(builder, scaleParams.scale);
 
-      auto *stackedOpCall = createCall(builder, F,
-                                       {loopCount, lhsPtr, rhsPtr, lhsOffset,
-                                        rhsOffset, cmpPre, cmpPost, cmpScale});
+      auto *stackedOpCall =
+          createUncheckedCall(builder, F,
+                              {loopCount, lhsPtr, rhsPtr, lhsOffset, rhsOffset,
+                               cmpPre, cmpPost, cmpScale});
       auto *destAddr = builder.CreateGEP(builder.getInt8Ty(), destPtr,
                                          loopCount, "buffer.element.addr");
       builder.CreateStore(stackedOpCall, destAddr);
     } else {
-      auto *stackedOpCall = createCall(builder, F, {loopCount, lhsPtr, rhsPtr});
+      auto *stackedOpCall =
+          createUncheckedCall(builder, F, {loopCount, lhsPtr, rhsPtr});
       auto *elementTy = getElementType(builder, dest);
       auto *destAddr = builder.CreateGEP(elementTy, destPtr, loopCount,
                                          "buffer.element.addr");
@@ -1348,7 +1389,8 @@ void LLVMIRGen::generateLLVMIRForDataParallelInstr(
     // "data-parallel" kernels in libjit.
     auto *F = getFunction("element_cmp_eq_kernel", lhs->getElementType());
     auto *elementTy = getElementType(builder, dest);
-    auto *stackedOpCall = createCall(builder, F, {loopCount, lhsPtr, rhsPtr});
+    auto *stackedOpCall =
+        createUncheckedCall(builder, F, {loopCount, lhsPtr, rhsPtr});
     auto *destAddr =
         builder.CreateGEP(elementTy, destPtr, loopCount, "buffer.element.addr");
     builder.CreateStore(stackedOpCall, destAddr);
@@ -1390,17 +1432,17 @@ void LLVMIRGen::generateLLVMIRForDataParallelInstr(
       auto *mulScale = emitConstI32(builder, scaleParams.scale);
 
       auto *stackedOpCall =
-          createCall(builder, F,
-                     {loopCount, lhsPtr, rhsPtr, destOffset, lhsOffset,
-                      rhsOffset, mulPre, mulPost, mulScale});
+          createUncheckedCall(builder, F,
+                              {loopCount, lhsPtr, rhsPtr, destOffset, lhsOffset,
+                               rhsOffset, mulPre, mulPost, mulScale});
       auto *destAddr = builder.CreateGEP(builder.getInt8Ty(), destPtr,
                                          loopCount, "buffer.element.addr");
       builder.CreateStore(stackedOpCall, destAddr);
     } else if (lhs->getType()->getElementType() == ElemKind::Int64ITy ||
                lhs->getType()->getElementType() == ElemKind::Int32ITy ||
                lhs->getType()->getElementType() == ElemKind::FloatTy) {
-      auto *stackedOpCall =
-          createCall(builder, F, {loopCount, lhsPtr, rhsPtr, pointerNull});
+      auto *stackedOpCall = createUncheckedCall(
+          builder, F, {loopCount, lhsPtr, rhsPtr, pointerNull});
       auto *destAddr = builder.CreateGEP(elementTy, destPtr, loopCount,
                                          "buffer.element.addr");
       builder.CreateStore(stackedOpCall, destAddr);
@@ -1446,16 +1488,16 @@ void LLVMIRGen::generateLLVMIRForDataParallelInstr(
       auto *divScale = emitConstI32(builder, scaleParams.scale);
 
       auto *stackedOpCall =
-          createCall(builder, F,
-                     {loopCount, lhsPtr, rhsPtr, destOffset, lhsOffset,
-                      rhsOffset, divPre, divPost, divScale});
+          createUncheckedCall(builder, F,
+                              {loopCount, lhsPtr, rhsPtr, destOffset, lhsOffset,
+                               rhsOffset, divPre, divPost, divScale});
       auto *destAddr = builder.CreateGEP(builder.getInt8Ty(), destPtr,
                                          loopCount, "buffer.element.addr");
       builder.CreateStore(stackedOpCall, destAddr);
     } else {
       auto *elementTy = getElementType(builder, dest);
-      auto *stackedOpCall =
-          createCall(builder, F, {loopCount, lhsPtr, rhsPtr, pointerNull});
+      auto *stackedOpCall = createUncheckedCall(
+          builder, F, {loopCount, lhsPtr, rhsPtr, pointerNull});
       auto *destAddr = builder.CreateGEP(elementTy, destPtr, loopCount,
                                          "buffer.element.addr");
       builder.CreateStore(stackedOpCall, destAddr);
@@ -1480,7 +1522,8 @@ void LLVMIRGen::generateLLVMIRForDataParallelInstr(
       F = getFunction("element_modulo_kernel_no_sign_follow",
                       dest->getElementType());
     }
-    auto *stackedOpCall = createCall(builder, F, {loopCount, divisor, srcPtr});
+    auto *stackedOpCall =
+        createUncheckedCall(builder, F, {loopCount, divisor, srcPtr});
     llvm::Value *destAddr = nullptr;
     if (dest->getElementType() == ElemKind::Int64ITy) {
       destAddr = builder.CreateGEP(builder.getInt64Ty(), destPtr, loopCount,


### PR DESCRIPTION
This is a feature of having LIBJIT functions to do some error handling and dropping a value of 0 (no error) vs something else to report problems. For the standard libjit math functions this is not necessarily very useful, but for custom libjit functions (e.g. DMA transfers, Remote Procedure Calls, etc) this can be extremely useful.

Use --checked-errors command-line option to enable the error handling.

Fixes #4263