### PR TITLE
[IR][Optimization] Generalize optimization of Insert/Extract to TensorView.

### DIFF
--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -1046,51 +1046,14 @@ inline size_t getFlattenedOffset(llvm::ArrayRef<dim_t> strides,
 }
 
 /// Helper function which \returns true if a slice with the shape \p sliceShape
-/// references fully a tensor with the shape \p tensorShape. This happens when
-/// the shapes are the same.
-inline bool isSliceFull(llvm::ArrayRef<dim_t> sliceShape,
-                        llvm::ArrayRef<dim_t> tensorShape) {
-  assert(sliceShape.size() == tensorShape.size() &&
-         "Array length mismatch for slice/tensor sizes!");
-  for (size_t dim = 0, dimEnd = sliceShape.size(); dim < dimEnd; ++dim) {
-    if (sliceShape[dim] != tensorShape[dim]) {
-      return false;
-    }
-  }
-  return true;
-}
-
-/// Helper function which \returns true if a slice with the shape \p sliceShape
 /// referenced from a larger tensor with the shape \p tensorShape is contiguous
 /// in memory (assuming the tensor it is referenced from is contiguous). This
 /// happens when the slice dimensions:
 /// - Start with singleton dimensions (dimensions equal to 1).
 /// - Continue with a partially extracted dimension (one maximum).
 /// - End with fully extracted dimensions.
-inline bool isSliceContiguous(llvm::ArrayRef<dim_t> sliceShape,
-                              llvm::ArrayRef<dim_t> tensorShape) {
-  assert(sliceShape.size() == tensorShape.size() &&
-         "Array length mismatch for slice/tensor sizes!");
-  // Search first non-singleton slice dimension. If all the dimensions are
-  // singleton then by convention the first non-singleton dimension is the
-  // slice size.
-  size_t firstNonSingleDim = sliceShape.size();
-  for (size_t dim = 0, dimEnd = sliceShape.size(); dim < dimEnd; ++dim) {
-    if (sliceShape[dim] != 1) {
-      firstNonSingleDim = dim;
-      break;
-    }
-  }
-  // First non-singleton slice dimension can be partially or fully extracted.
-  // The following dimensions must be fully extracted.
-  for (size_t dim = firstNonSingleDim + 1, dimEnd = sliceShape.size();
-       dim < dimEnd; ++dim) {
-    if (sliceShape[dim] != tensorShape[dim]) {
-      return false;
-    }
-  }
-  return true;
-}
+bool isSliceContiguous(llvm::ArrayRef<dim_t> sliceShape,
+                       llvm::ArrayRef<dim_t> tensorShape);
 
 /// A class that provides indexed access to a tensor. This class has value
 /// semantics and it's copied around. One of the reasons for making this class

--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -1045,6 +1045,53 @@ inline size_t getFlattenedOffset(llvm::ArrayRef<dim_t> strides,
   return index;
 }
 
+/// Helper function which \returns true if a slice with the shape \p sliceShape
+/// references fully a tensor with the shape \p tensorShape. This happens when
+/// the shapes are the same.
+inline bool isSliceFull(llvm::ArrayRef<dim_t> sliceShape,
+                        llvm::ArrayRef<dim_t> tensorShape) {
+  assert(sliceShape.size() == tensorShape.size() &&
+         "Array length mismatch for slice/tensor sizes!");
+  for (size_t dim = 0, dimEnd = sliceShape.size(); dim < dimEnd; ++dim) {
+    if (sliceShape[dim] != tensorShape[dim]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/// Helper function which \returns true if a slice with the shape \p sliceShape
+/// referenced from a larger tensor with the shape \p tensorShape is contiguous
+/// in memory (assuming the tensor it is referenced from is contiguous). This
+/// happens when the slice dimensions:
+/// - Start with singleton dimensions (dimensions equal to 1).
+/// - Continue with a partially extracted dimension (one maximum).
+/// - End with fully extracted dimensions.
+inline bool isSliceContiguous(llvm::ArrayRef<dim_t> sliceShape,
+                              llvm::ArrayRef<dim_t> tensorShape) {
+  assert(sliceShape.size() == tensorShape.size() &&
+         "Array length mismatch for slice/tensor sizes!");
+  // Search first non-singleton slice dimension. If all the dimensions are
+  // singleton then by convention the first non-singleton dimension is the
+  // slice size.
+  size_t firstNonSingleDim = sliceShape.size();
+  for (size_t dim = 0, dimEnd = sliceShape.size(); dim < dimEnd; ++dim) {
+    if (sliceShape[dim] != 1) {
+      firstNonSingleDim = dim;
+      break;
+    }
+  }
+  // First non-singleton slice dimension can be partially or fully extracted.
+  // The following dimensions must be fully extracted.
+  for (size_t dim = firstNonSingleDim + 1, dimEnd = sliceShape.size();
+       dim < dimEnd; ++dim) {
+    if (sliceShape[dim] != tensorShape[dim]) {
+      return false;
+    }
+  }
+  return true;
+}
+
 /// A class that provides indexed access to a tensor. This class has value
 /// semantics and it's copied around. One of the reasons for making this class
 /// value semantics is to allow efficient index calculation that the compiler

--- a/lib/Optimizer/IROptimizer/IROptimizer.cpp
+++ b/lib/Optimizer/IROptimizer/IROptimizer.cpp
@@ -1308,29 +1308,31 @@ static bool eliminateDeadStores(IRFunction &M) {
   return changed;
 }
 
-/// \returns true if the first dimension in \p offsets has a non-zero value.
-static bool isOnlyOffsetInFirstDim(llvm::ArrayRef<dim_t> offsets) {
-  if (offsets.size() > 1) {
-    for (size_t i = 1; i < offsets.size(); ++i) {
-      if (offsets[i] != 0) {
-        return false;
-      }
+/// \returns true if a slice with the shape \p sliceShape extracted from a
+/// tensor with the shape \p tensorShape is contiguous in memory. This happens
+/// when the slice dimensions:
+/// - Start with singleton dimensions (dimensions equal to 1).
+/// - Follow with a partially extracted dimension (one maximum).
+/// - Follow with fully extracted dimensions.
+static bool isSliceMemoryContiguous(llvm::ArrayRef<dim_t> sliceShape,
+                                    llvm::ArrayRef<dim_t> tensorShape) {
+  assert(sliceShape.size() == tensorShape.size() &&
+         "Array length mismatch for slice/tensor sizes!");
+  // Search first non-singleton slice dimension. If all the dimensions are
+  // singleton then by convention the first non-singleton dimension is the
+  // slice size.
+  size_t firstNonSingleDim = sliceShape.size();
+  for (size_t dim = 0; dim < sliceShape.size(); ++dim) {
+    if (sliceShape[dim] != 1) {
+      firstNonSingleDim = dim;
+      break;
     }
   }
-  return true;
-}
-
-/// \returns true if the dimensions of \p sourceDims, other than the first
-/// dimension, all equal the dimensions in \p destDims.
-static bool allButFirstDimsEqual(llvm::ArrayRef<dim_t> sourceDims,
-                                 llvm::ArrayRef<dim_t> destDims) {
-  assert(sourceDims.size() == destDims.size() &&
-         "Source and dest dims must have same number of dims.");
-  if (sourceDims.size() > 1) {
-    for (size_t i = 1; i < sourceDims.size(); ++i) {
-      if (sourceDims[i] != destDims[i]) {
-        return false;
-      }
+  // First non-singleton slice dimension can be partially or fully extracted.
+  // The following dimensions must be fully extracted.
+  for (size_t dim = firstNonSingleDim + 1; dim < sliceShape.size(); ++dim) {
+    if (sliceShape[dim] != tensorShape[dim]) {
+      return false;
     }
   }
   return true;
@@ -1363,10 +1365,9 @@ bool optimizeInserts(IRFunction &M) {
       continue;
     }
 
-    // TVI with offsets currently only works for this optimization if the insert
-    // is only into the first dimension. This is because the tensor memory must
-    // be contiguous.
-    if (!isOnlyOffsetInFirstDim(ITI->getOffsets())) {
+    // TVI is used only when inserting a slice which is contiguous in memory.
+    if (!isSliceMemoryContiguous(ITI->getSrc()->dims(),
+                                 ITI->getDest()->dims())) {
       continue;
     }
 
@@ -1385,14 +1386,6 @@ bool optimizeInserts(IRFunction &M) {
       continue;
     }
 
-    // Make sure that all but the first dimension of the inserttensor's source
-    // and dest are equal. This means that the writes to the destination of the
-    // insert are contiguous.
-    auto *insertDest = ITI->getDest();
-    if (!allButFirstDimsEqual(insertSourceAAI->dims(), insertDest->dims())) {
-      continue;
-    }
-
     // Find the original writer into insertSourceAAI.
     Instruction *origWriter = nullptr;
     for (const auto &U : ValueUses(insertSourceAAI)) {
@@ -1407,6 +1400,7 @@ bool optimizeInserts(IRFunction &M) {
 
     // Create a new TensorView of the original dest of the InsertTensor,
     // with the same offset as the InsertTensor.
+    auto *insertDest = ITI->getDest();
     auto *TVI =
         B.createTensorViewInst((ITI->getName() + ".tv.dest").str(), insertDest,
                                insertSourceAAI->getType(), ITI->getOffsets());
@@ -1449,10 +1443,9 @@ bool optimizeExtracts(IRFunction &M) {
       continue;
     }
 
-    // TVI with offsets currently only works for this optimization if the
-    // extract is only into the first dimension. This is because the tensor
-    // memory must be contiguous.
-    if (!isOnlyOffsetInFirstDim(ETI->getOffsets())) {
+    // TVI is used only when extracting a slice which is contiguous in memory.
+    if (!isSliceMemoryContiguous(ETI->getDest()->dims(),
+                                 ETI->getSrc()->dims())) {
       continue;
     }
 
@@ -1469,12 +1462,6 @@ bool optimizeExtracts(IRFunction &M) {
     // pattern usually seen via IRGen'd SliceNodes.
     auto *extractDestAAI = dyn_cast<AllocActivationInst>(ETI->getDest());
     if (!extractDestAAI) {
-      continue;
-    }
-
-    // Make sure that all but the first dimension of the extract's source and
-    // dest are equal. This means that the accesses are contiguous.
-    if (!allButFirstDimsEqual(extractSrc->dims(), extractDestAAI->dims())) {
       continue;
     }
 

--- a/tests/unittests/IROptTest.cpp
+++ b/tests/unittests/IROptTest.cpp
@@ -262,37 +262,191 @@ TEST(Optimizer, copyPropagationTranspose) {
       }));
 }
 
-/// Simple test where a single insert is replaced by a tensor view with offsets.
-TEST(Optimizer, insertOptimizer) {
+/// Test the isSliceContiguous utility function.
+TEST(Optimizer, isSliceContiguous) {
+  EXPECT_EQ(isSliceContiguous({1, 1, 1}, {3, 3, 3}), true);
+  EXPECT_EQ(isSliceContiguous({1, 1, 2}, {3, 3, 3}), true);
+  EXPECT_EQ(isSliceContiguous({1, 1, 3}, {3, 3, 3}), true);
+  EXPECT_EQ(isSliceContiguous({1, 2, 1}, {3, 3, 3}), false);
+  EXPECT_EQ(isSliceContiguous({1, 2, 2}, {3, 3, 3}), false);
+  EXPECT_EQ(isSliceContiguous({1, 2, 3}, {3, 3, 3}), true);
+  EXPECT_EQ(isSliceContiguous({1, 3, 1}, {3, 3, 3}), false);
+  EXPECT_EQ(isSliceContiguous({1, 3, 2}, {3, 3, 3}), false);
+  EXPECT_EQ(isSliceContiguous({1, 3, 3}, {3, 3, 3}), true);
+  EXPECT_EQ(isSliceContiguous({2, 1, 1}, {3, 3, 3}), false);
+  EXPECT_EQ(isSliceContiguous({2, 1, 2}, {3, 3, 3}), false);
+  EXPECT_EQ(isSliceContiguous({2, 1, 3}, {3, 3, 3}), false);
+  EXPECT_EQ(isSliceContiguous({2, 2, 1}, {3, 3, 3}), false);
+  EXPECT_EQ(isSliceContiguous({2, 2, 2}, {3, 3, 3}), false);
+  EXPECT_EQ(isSliceContiguous({2, 2, 3}, {3, 3, 3}), false);
+  EXPECT_EQ(isSliceContiguous({2, 3, 1}, {3, 3, 3}), false);
+  EXPECT_EQ(isSliceContiguous({2, 3, 2}, {3, 3, 3}), false);
+  EXPECT_EQ(isSliceContiguous({2, 3, 3}, {3, 3, 3}), true);
+  EXPECT_EQ(isSliceContiguous({3, 1, 1}, {3, 3, 3}), false);
+  EXPECT_EQ(isSliceContiguous({3, 1, 2}, {3, 3, 3}), false);
+  EXPECT_EQ(isSliceContiguous({3, 1, 3}, {3, 3, 3}), false);
+  EXPECT_EQ(isSliceContiguous({3, 2, 1}, {3, 3, 3}), false);
+  EXPECT_EQ(isSliceContiguous({3, 2, 2}, {3, 3, 3}), false);
+  EXPECT_EQ(isSliceContiguous({3, 2, 3}, {3, 3, 3}), false);
+  EXPECT_EQ(isSliceContiguous({3, 3, 1}, {3, 3, 3}), false);
+  EXPECT_EQ(isSliceContiguous({3, 3, 2}, {3, 3, 3}), false);
+  EXPECT_EQ(isSliceContiguous({3, 3, 3}, {3, 3, 3}), true);
+}
+
+/// Utility function for testing the optimization of an InsertTensorInstruction
+/// to a TensorViewInstruction when the inserted tensor (slice) is contiguous.
+static void testInsertOptimizer(llvm::ArrayRef<dim_t> srcShape,
+                                llvm::ArrayRef<dim_t> destShape,
+                                llvm::ArrayRef<dim_t> offsets) {
   Module mod;
   Function *F = mod.createFunction("InsertOptimizer");
   IRFunction M(F);
   IRBuilder bb(&M);
 
-  auto *output =
-      bb.createWeightVar(glow::ElemKind::FloatTy, {4, 4, 5}, "output",
-                         WeightVar::MutabilityKind::Mutable);
-
-  auto *allocSrc = bb.createAllocActivationInst(
-      "allocSrc", glow::ElemKind::FloatTy, {3, 4, 5});
-
-  bb.createSplatInst("splatSrc", allocSrc, 1.0);
-  bb.createSplatInst("splatDest", output, 2.0);
-
-  bb.createInsertTensorInst("insert", output, allocSrc, {1, 0, 0}, 1, 0);
-
-  bb.createDeallocActivationInst("deallocSrc", allocSrc);
+  auto *dest = bb.createWeightVar(glow::ElemKind::FloatTy, destShape, "dest",
+                                  WeightVar::MutabilityKind::Mutable);
+  auto *srcAlloc = bb.createAllocActivationInst(
+      "srcAlloc", glow::ElemKind::FloatTy, srcShape);
+  bb.createSplatInst("srcSplat", srcAlloc, 1.0);
+  bb.createSplatInst("destSplat", dest, 2.0);
+  bb.createInsertTensorInst("insert", dest, srcAlloc, offsets, 1, 0);
+  bb.createDeallocActivationInst("deallocSrc", srcAlloc);
 
   optimize(M, MockBackend().shouldShareBuffers());
 
-  // After optimization, should be left with two splats and a tensorview; the
-  // insert, alloc, and dealloc should be gone.
   auto &instrs = M.getInstrs();
-  EXPECT_EQ(instrs.size(), 3);
-  EXPECT_TRUE(std::all_of(
-      instrs.begin(), instrs.end(), [](const Instruction &I) -> bool {
-        return isa<SplatInst>(&I) || isa<TensorViewInst>(&I);
-      }));
+  if (isSliceFull(srcShape, destShape)) {
+    // If the slice was fully inserted then we should be left with only the
+    // the source Splat.
+    EXPECT_EQ(instrs.size(), 1);
+    EXPECT_EQ(instrs.begin()->getName().str(), std::string("srcSplat"));
+  } else if (isSliceContiguous(srcShape, destShape)) {
+    // If the slice is contiguous then we should be left with 2 Splats and a
+    // TensorView. The Insert, Alloc and Dealloc should be gone.
+    EXPECT_EQ(instrs.size(), 3);
+    EXPECT_TRUE(std::all_of(
+        instrs.begin(), instrs.end(), [](const Instruction &I) -> bool {
+          return isa<SplatInst>(&I) || isa<TensorViewInst>(&I);
+        }));
+  } else {
+    // If the slice is not contiguous, we should be left with the original
+    // instructions: Alloc, 2 Splats, Insert, Dealloc.
+    EXPECT_EQ(instrs.size(), 5);
+  }
+}
+
+/// Simple test where a single Insert is replaced by a TensorView with offsets.
+TEST(Optimizer, insertOptimizer) {
+  testInsertOptimizer({1, 1, 1}, {3, 3, 3}, {0, 0, 0});
+  testInsertOptimizer({1, 1, 2}, {3, 3, 3}, {1, 1, 1});
+  testInsertOptimizer({1, 1, 3}, {3, 3, 3}, {2, 2, 0});
+  testInsertOptimizer({1, 2, 1}, {3, 3, 3}, {0, 0, 1});
+  testInsertOptimizer({1, 2, 2}, {3, 3, 3}, {1, 1, 0});
+  testInsertOptimizer({1, 2, 3}, {3, 3, 3}, {2, 0, 0});
+  testInsertOptimizer({1, 3, 1}, {3, 3, 3}, {0, 0, 0});
+  testInsertOptimizer({1, 3, 2}, {3, 3, 3}, {1, 0, 1});
+  testInsertOptimizer({1, 3, 3}, {3, 3, 3}, {2, 0, 0});
+  testInsertOptimizer({2, 1, 1}, {3, 3, 3}, {0, 0, 1});
+  testInsertOptimizer({2, 1, 2}, {3, 3, 3}, {1, 1, 0});
+  testInsertOptimizer({2, 1, 3}, {3, 3, 3}, {0, 2, 0});
+  testInsertOptimizer({2, 2, 1}, {3, 3, 3}, {1, 0, 0});
+  testInsertOptimizer({2, 2, 2}, {3, 3, 3}, {0, 1, 1});
+  testInsertOptimizer({2, 2, 3}, {3, 3, 3}, {1, 0, 0});
+  testInsertOptimizer({2, 3, 1}, {3, 3, 3}, {0, 0, 1});
+  testInsertOptimizer({2, 3, 2}, {3, 3, 3}, {1, 0, 0});
+  testInsertOptimizer({2, 3, 3}, {3, 3, 3}, {0, 0, 0});
+  testInsertOptimizer({3, 1, 1}, {3, 3, 3}, {0, 0, 0});
+  testInsertOptimizer({3, 1, 2}, {3, 3, 3}, {0, 1, 1});
+  testInsertOptimizer({3, 1, 3}, {3, 3, 3}, {0, 2, 0});
+  testInsertOptimizer({3, 2, 1}, {3, 3, 3}, {0, 0, 1});
+  testInsertOptimizer({3, 2, 2}, {3, 3, 3}, {0, 1, 0});
+  testInsertOptimizer({3, 2, 3}, {3, 3, 3}, {0, 0, 0});
+  testInsertOptimizer({3, 3, 1}, {3, 3, 3}, {0, 0, 0});
+  testInsertOptimizer({3, 3, 2}, {3, 3, 3}, {0, 0, 1});
+  testInsertOptimizer({3, 3, 3}, {3, 3, 3}, {0, 0, 0});
+}
+
+/// Utility function for testing the optimization of an ExtractTensorInstruction
+/// to a TensorViewInstruction when the inserted tensor (slice) is contiguous.
+static void testExtractOptimizer(llvm::ArrayRef<dim_t> destShape,
+                                 llvm::ArrayRef<dim_t> srcShape,
+                                 llvm::ArrayRef<dim_t> offsets) {
+  Module mod;
+  Function *F = mod.createFunction("ExtractOptimizer");
+  IRFunction M(F);
+  IRBuilder bb(&M);
+
+  auto *src = bb.createWeightVar(glow::ElemKind::FloatTy, srcShape, "src",
+                                 WeightVar::MutabilityKind::Mutable);
+  auto *dest = bb.createWeightVar(glow::ElemKind::FloatTy, destShape, "dest",
+                                  WeightVar::MutabilityKind::Mutable);
+  bb.createSplatInst("srcSplat", src, 1.0);
+  auto *destAlloc =
+      bb.createAllocActivationInst("dest", glow::ElemKind::FloatTy, destShape);
+  bb.createExtractTensorInst("extract", destAlloc, src, offsets);
+  bb.createCopyInst("save", dest, destAlloc);
+  bb.createDeallocActivationInst("deallocDest", destAlloc);
+
+  optimize(M, MockBackend().shouldShareBuffers());
+
+  auto &instrs = M.getInstrs();
+  if (isSliceFull(destShape, srcShape)) {
+    // If the slice was fully extracted then we should be left with a Splat
+    // and a Copy. The Alloc, Extract and Dealloc should be gone.
+    EXPECT_EQ(instrs.size(), 2);
+    EXPECT_TRUE(std::all_of(instrs.begin(), instrs.end(),
+                            [](const Instruction &I) -> bool {
+                              return isa<SplatInst>(&I) || isa<CopyInst>(&I);
+                            }));
+  } else if (isSliceContiguous(destShape, srcShape)) {
+    // If the extracted slice is contiguous then we should be left with a Splat,
+    // a TensorView and a Copy. The Extract, Alloc and Dealloc should be gone.
+    EXPECT_EQ(instrs.size(), 3);
+    EXPECT_TRUE(std::all_of(
+        instrs.begin(), instrs.end(), [](const Instruction &I) -> bool {
+          return isa<SplatInst>(&I) || isa<TensorViewInst>(&I) ||
+                 isa<CopyInst>(&I);
+        }));
+  } else {
+    // If the slice is not contiguous, we should be left with a Splat and an
+    // Extract. The Alloc, Copy and Dealloc should be gone.
+    EXPECT_EQ(instrs.size(), 2);
+    EXPECT_TRUE(std::all_of(
+        instrs.begin(), instrs.end(), [](const Instruction &I) -> bool {
+          return isa<SplatInst>(&I) || isa<ExtractTensorInst>(&I);
+        }));
+  }
+}
+
+/// Simple test where a single Extract is replaced by a TensorView with offsets.
+TEST(Optimizer, extractOptimizer) {
+  testExtractOptimizer({1, 1, 1}, {3, 3, 3}, {0, 0, 0});
+  testExtractOptimizer({1, 1, 2}, {3, 3, 3}, {1, 1, 1});
+  testExtractOptimizer({1, 1, 3}, {3, 3, 3}, {2, 2, 0});
+  testExtractOptimizer({1, 2, 1}, {3, 3, 3}, {0, 0, 1});
+  testExtractOptimizer({1, 2, 2}, {3, 3, 3}, {1, 1, 0});
+  testExtractOptimizer({1, 2, 3}, {3, 3, 3}, {2, 0, 0});
+  testExtractOptimizer({1, 3, 1}, {3, 3, 3}, {0, 0, 0});
+  testExtractOptimizer({1, 3, 2}, {3, 3, 3}, {1, 0, 1});
+  testExtractOptimizer({1, 3, 3}, {3, 3, 3}, {2, 0, 0});
+  testExtractOptimizer({2, 1, 1}, {3, 3, 3}, {0, 0, 1});
+  testExtractOptimizer({2, 1, 2}, {3, 3, 3}, {1, 1, 0});
+  testExtractOptimizer({2, 1, 3}, {3, 3, 3}, {0, 2, 0});
+  testExtractOptimizer({2, 2, 1}, {3, 3, 3}, {1, 0, 0});
+  testExtractOptimizer({2, 2, 2}, {3, 3, 3}, {0, 1, 1});
+  testExtractOptimizer({2, 2, 3}, {3, 3, 3}, {1, 0, 0});
+  testExtractOptimizer({2, 3, 1}, {3, 3, 3}, {0, 0, 1});
+  testExtractOptimizer({2, 3, 2}, {3, 3, 3}, {1, 0, 0});
+  testExtractOptimizer({2, 3, 3}, {3, 3, 3}, {0, 0, 0});
+  testExtractOptimizer({3, 1, 1}, {3, 3, 3}, {0, 0, 0});
+  testExtractOptimizer({3, 1, 2}, {3, 3, 3}, {0, 1, 1});
+  testExtractOptimizer({3, 1, 3}, {3, 3, 3}, {0, 2, 0});
+  testExtractOptimizer({3, 2, 1}, {3, 3, 3}, {0, 0, 1});
+  testExtractOptimizer({3, 2, 2}, {3, 3, 3}, {0, 1, 0});
+  testExtractOptimizer({3, 2, 3}, {3, 3, 3}, {0, 0, 0});
+  testExtractOptimizer({3, 3, 1}, {3, 3, 3}, {0, 0, 0});
+  testExtractOptimizer({3, 3, 2}, {3, 3, 3}, {0, 0, 1});
+  testExtractOptimizer({3, 3, 3}, {3, 3, 3}, {0, 0, 0});
 }
 
 /// This is representative of what a ConcatNode is IRGen'd into: src1 and src2

--- a/tests/unittests/IROptTest.cpp
+++ b/tests/unittests/IROptTest.cpp
@@ -315,7 +315,7 @@ static void testInsertOptimizer(llvm::ArrayRef<dim_t> srcShape,
   optimize(M, MockBackend().shouldShareBuffers());
 
   auto &instrs = M.getInstrs();
-  if (isSliceFull(srcShape, destShape)) {
+  if (srcShape == destShape) {
     // If the slice was fully inserted then we should be left with only the
     // the source Splat.
     EXPECT_EQ(instrs.size(), 1);
@@ -390,7 +390,7 @@ static void testExtractOptimizer(llvm::ArrayRef<dim_t> destShape,
   optimize(M, MockBackend().shouldShareBuffers());
 
   auto &instrs = M.getInstrs();
-  if (isSliceFull(destShape, srcShape)) {
+  if (destShape == srcShape) {
     // If the slice was fully extracted then we should be left with a Splat
     // and a Copy. The Alloc, Extract and Dealloc should be gone.
     EXPECT_EQ(instrs.size(), 2);


### PR DESCRIPTION
**Summary**
Make the IR optimization of specializing the Insert/Extract instructions to TensorView more generic.
Added a more generic utility function called `isSliceMemoryContiguous`.

**Test Plan**
Some problems arise in some existing unit tests involving the Slice operator for the OpenCL backend which do not work after this optimization. Same unit tests work for the other backends so there is something wrong with the OpenCL implementation.
Will add more specialized unit tests after the OpenCL problem is solved.
