### PR TITLE
[SymbolTable] Bug fix for TensorViews with offsets

### DIFF
--- a/include/glow/IR/IRUtils.h
+++ b/include/glow/IR/IRUtils.h
@@ -17,6 +17,7 @@
 #define GLOW_IR_IRUTILS_H
 
 #include "glow/IR/IR.h"
+#include "glow/IR/Instrs.h"
 
 #include <iterator>
 
@@ -24,6 +25,9 @@ namespace glow {
 
 /// \returns true if the value \v is a tensor view.
 bool isTensorView(Value *v);
+
+/// \returns the offset for \p TVI into the underlying alloc activation.
+size_t calculateTensorViewOffset(const TensorViewInst *TVI);
 
 /// A helper class to iterate over all uses of a given Value.
 /// It also recursively iterates over uses of any tensorview

--- a/lib/LLVMIRCodeGen/AllocationsInfo.cpp
+++ b/lib/LLVMIRCodeGen/AllocationsInfo.cpp
@@ -139,24 +139,6 @@ void AllocationsInfo::allocateActivations(const IRFunction *F) {
   });
 }
 
-/// Calculate the offset for \p TVI into the underlying alloc activation.
-static size_t calculateTensorViewOffset(const TensorViewInst *TVI) {
-  // Pop tensor views off repeatedly until we reach the origin, in case there
-  // are multiple stacked together, to calculate the total offset.
-  const TensorViewInst *currTVI = TVI;
-  size_t totalOffsetLength = 0;
-  do {
-    // Get the offset into the current base Tensor in bytes. Aggregate all
-    // offsets from stacked TVIs into totalOffsetLength.
-    totalOffsetLength +=
-        getFlattenedOffset(currTVI->getSrc()->getType()->strides(),
-                           currTVI->getOffsets()) *
-        currTVI->getType()->getElementSize();
-  } while ((currTVI = dyn_cast<TensorViewInst>(currTVI->getSrc())));
-
-  return totalOffsetLength;
-}
-
 void AllocationsInfo::allocateTensorViews(const IRFunction *F) {
   for (const auto &I : F->getInstrs()) {
     if (const auto *TVI = dyn_cast<TensorViewInst>(&I)) {


### PR DESCRIPTION
Summary:
Reuse logic that was previously only used by LLVM-based backends for calculating offsets for tensorviews, as the previous logic was not correct. 

Test Plan:
This PR should fix the broken tests in https://github.com/pytorch/glow/pull/4497.

CC: @mciprian13 