### PR TITLE
[ClassGen] Automatic scratch allocation for Instructions

### DIFF
--- a/include/glow/Base/Traits.h
+++ b/include/glow/Base/Traits.h
@@ -63,6 +63,8 @@ public:
 
   TypeRef getType() const { return Ty_; }
 
+  void setType(TypeRef Ty) { Ty_ = Ty; }
+
   llvm::ArrayRef<dim_t> dims() const { return Ty_->dims(); }
 
   size_t size() const { return Ty_->size(); }

--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -343,10 +343,13 @@ static int value_index_sort(const void *va, const void *vb) {
 /// size is the size of the input, and \p n is the size of the last dimension of
 /// the input.
 template <typename T, typename TI>
-static void libjit_topk(T *values, TI *indices, const T *input, TI *scratch,
+static void libjit_topk(T *values, TI *indices, const T *input, void *scratch,
                         dim_t k, dim_t n, dim_t size) {
   dim_t in = 0;
   dim_t out = 0;
+
+  // Initialize scratch with 0.
+  memset(scratch, 0, 2 * n * sizeof(TI));
 
   value_index<T, TI> *buffer = (value_index<T, TI> *)scratch;
 
@@ -2567,22 +2570,22 @@ void libjit_softmax_grad_f_i32(float *inG, float *outW,
 }
 
 void libjit_topk_f_u(float *values, size_t *indices, const float *input,
-                     size_t *scratch, dim_t k, dim_t n, dim_t size) {
+                     void *scratch, dim_t k, dim_t n, dim_t size) {
   libjit_topk(values, indices, input, scratch, k, n, size);
 }
 
 void libjit_topk_f_i32(float *values, int32_t *indices, const float *input,
-                       int32_t *scratch, dim_t k, dim_t n, dim_t size) {
+                       void *scratch, dim_t k, dim_t n, dim_t size) {
   libjit_topk(values, indices, input, scratch, k, n, size);
 }
 
 void libjit_topk_i8_u(int8_t *values, size_t *indices, const int8_t *input,
-                      size_t *scratch, dim_t k, dim_t n, dim_t size) {
+                      void *scratch, dim_t k, dim_t n, dim_t size) {
   libjit_topk(values, indices, input, scratch, k, n, size);
 }
 
 void libjit_topk_i8_i32(int8_t *values, int32_t *indices, const int8_t *input,
-                        int32_t *scratch, dim_t k, dim_t n, dim_t size) {
+                        void *scratch, dim_t k, dim_t n, dim_t size) {
   libjit_topk(values, indices, input, scratch, k, n, size);
 }
 

--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -3145,7 +3145,7 @@ void libjit_fft_real_f(float *output, float *input, const float *twiddleFactors,
 /// FFT LUTs \p twiddleFactors and \p bitReverseIndices are computed at
 /// compile-time. More details in Graph.h about the AudioSpectrogram node.
 void libjit_audio_spectrogram_f(
-    float *spectrogram, const float *input, const float *window,
+    void *scratch, float *spectrogram, const float *input, const float *window,
     const float *twiddleFactors, const int32_t *bitReverseIndices,
     const float *complexToRealWeights, const dim_t *spectrogramDims,
     const dim_t inputLength, const dim_t windowSize, const dim_t windowStride,
@@ -3155,9 +3155,9 @@ void libjit_audio_spectrogram_f(
   dim_t specLen = spectrogramDims[1];
   dim_t fftLen = (specLen - 1) * 2;
 
-  // Temporary buffers.
-  float winOut[fftLen];
-  float fftOut[fftLen + 2];
+  // Scratch buffers.
+  float *winOut = (float *)scratch;
+  float *fftOut = winOut + fftLen;
   memset(winOut, 0, fftLen * sizeof(float));
 
   // Compute the spectrogram.
@@ -3190,14 +3190,13 @@ void libjit_audio_spectrogram_f(
 /// \p spectrogram power. The lookup tables \p melWeights, \p melRanges
 /// and \p dctMat are computed at compile-time. More details in Graph.h
 /// about the MFCC node.
-void libjit_mfcc_f(float *coefficients, const float *spectrogram,
+void libjit_mfcc_f(void *scratch, float *coefficients, const float *spectrogram,
                    const float *melWeights, const int32_t *melRanges,
                    const float *dctMat, const dim_t *coefficientsDims,
                    const dim_t *spectrogramDims, const dim_t filterBankCount) {
 
-  // Allocate intermediate buffer on the stack.
-  // The size is expected to be relatively small.
-  float melBuff[filterBankCount];
+  // Scratch buffer.
+  float *melBuff = (float *)scratch;
 
   // Perform MFCC for all the windows.
   dim_t winNum = spectrogramDims[0];

--- a/lib/Backends/CPU/libjit/libjit.cpp
+++ b/lib/Backends/CPU/libjit/libjit.cpp
@@ -3145,10 +3145,11 @@ void libjit_fft_real_f(float *output, float *input, const float *twiddleFactors,
 /// FFT LUTs \p twiddleFactors and \p bitReverseIndices are computed at
 /// compile-time. More details in Graph.h about the AudioSpectrogram node.
 void libjit_audio_spectrogram_f(
-    void *scratch, float *spectrogram, const float *input, const float *window,
-    const float *twiddleFactors, const int32_t *bitReverseIndices,
-    const float *complexToRealWeights, const dim_t *spectrogramDims,
-    const dim_t inputLength, const dim_t windowSize, const dim_t windowStride,
+    void *winOutScratch, void *fftOutScratch, float *spectrogram,
+    const float *input, const float *window, const float *twiddleFactors,
+    const int32_t *bitReverseIndices, const float *complexToRealWeights,
+    const dim_t *spectrogramDims, const dim_t inputLength,
+    const dim_t windowSize, const dim_t windowStride,
     const bool magnitudeSquared) {
 
   dim_t winNum = spectrogramDims[0];
@@ -3156,8 +3157,8 @@ void libjit_audio_spectrogram_f(
   dim_t fftLen = (specLen - 1) * 2;
 
   // Scratch buffers.
-  float *winOut = (float *)scratch;
-  float *fftOut = winOut + fftLen;
+  float *winOut = (float *)winOutScratch;
+  float *fftOut = (float *)fftOutScratch;
   memset(winOut, 0, fftLen * sizeof(float));
 
   // Compute the spectrogram.

--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -1642,7 +1642,8 @@ Error OpenCLFunction::execute(ExecutionContext *context) {
       copyValueFromDevice(srcDev, clBindings, srcT.getUnsafePtr());
       clFinish(commands);
 
-      if (isQuantized) {
+      if (srcDev->getType()->isQuantizedType() ||
+          destDev->getType()->isQuantizedType()) {
         topK<int8_t>(destT, indT, srcT, k);
       } else {
         topK<float>(destT, indT, srcT, k);

--- a/lib/IR/IRBuilder.cpp
+++ b/lib/IR/IRBuilder.cpp
@@ -194,14 +194,10 @@ TopKInst *IRBuilder::createTopKOp(llvm::StringRef name, Value *input, size_t k,
   outDims.back() = k;
   auto outTy = F_->getGraph()->getParent()->uniqueTypeWithNewShape(
       input->getType(), outDims);
-  // Allocate enough scratch space to hold N values and N indices.
-  auto *scratch = createAllocActivationInst(name.str() + ".scratch",
-                                            outIndicesTy, {inDims.back() * 2});
-  createSplatInst(name.str() + ".zero.scratch", scratch, 0);
   auto *values = createAllocActivationInst(name.str() + ".values", outTy);
   auto *indices =
       createAllocActivationInst(name.str() + ".indices", outIndicesTy, outDims);
-  return createTopKInst(name.str(), values, indices, input, scratch, k);
+  return createTopKInst(name.str(), values, indices, input, k);
 }
 
 Value *IRBuilder::createReturnOp(Value *input) {

--- a/lib/IR/Instrs.cpp
+++ b/lib/IR/Instrs.cpp
@@ -126,10 +126,16 @@ void ReluGradInst::verify() const {
 //===----------------------------------------------------------------------===//
 //                       Instruction scratch requirements
 //===----------------------------------------------------------------------===//
-dim_t AudioSpectrogramInst::getScratchSize() const {
+dim_t AudioSpectrogramInst::getWinOutScratchSize() const {
   dim_t spectrogramLen = getSpectrogram()->dims()[1];
   dim_t fftLen = (spectrogramLen - 1) * 2;
-  return (2 * fftLen + 2) * sizeof(float);
+  return fftLen * sizeof(float);
+}
+
+dim_t AudioSpectrogramInst::getFftOutScratchSize() const {
+  dim_t spectrogramLen = getSpectrogram()->dims()[1];
+  dim_t fftLen = (spectrogramLen - 1) * 2;
+  return (fftLen + 2) * sizeof(float);
 }
 
 dim_t MFCCInst::getScratchSize() const {

--- a/lib/IR/Instrs.cpp
+++ b/lib/IR/Instrs.cpp
@@ -126,6 +126,13 @@ void ReluGradInst::verify() const {
 //===----------------------------------------------------------------------===//
 //                       Instruction scratch requirements
 //===----------------------------------------------------------------------===//
+dim_t TopKInst::getScratchSize() const {
+  // Allocate enough scratch space to hold N values and N indices.
+  dim_t N = getInput()->dims().back();
+  dim_t elemSize = getIndices()->getType()->getElementSize();
+  return (2 * N * elemSize);
+}
+
 dim_t AudioSpectrogramInst::getWinOutScratchSize() const {
   dim_t spectrogramLen = getSpectrogram()->dims()[1];
   dim_t fftLen = (spectrogramLen - 1) * 2;

--- a/lib/IR/Instrs.cpp
+++ b/lib/IR/Instrs.cpp
@@ -122,3 +122,16 @@ void ReluGradInst::verify() const {
   verifyRelu(getSrcGrad()->getType(), getDest()->getType());
   verifyRelu(getSrcGrad()->getType(), getDestGrad()->getType());
 }
+
+//===----------------------------------------------------------------------===//
+//                       Instruction scratch requirements
+//===----------------------------------------------------------------------===//
+dim_t AudioSpectrogramInst::getScratchSize() const {
+  dim_t spectrogramLen = getSpectrogram()->dims()[1];
+  dim_t fftLen = (spectrogramLen - 1) * 2;
+  return (2 * fftLen + 2) * sizeof(float);
+}
+
+dim_t MFCCInst::getScratchSize() const {
+  return getFilterBankCount() * sizeof(float);
+}

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -2924,7 +2924,8 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
 
   case Kinded::Kind::AudioSpectrogramInstKind: {
     auto *ASI = llvm::cast<AudioSpectrogramInst>(I);
-    auto scratch = ASI->getScratch();
+    auto winOutScratch = ASI->getWinOutScratch();
+    auto fftOutScratch = ASI->getFftOutScratch();
     auto spectrogram = ASI->getSpectrogram();
     auto input = ASI->getInput();
     auto window = ASI->getWindow();
@@ -2935,7 +2936,8 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     int64_t windowStride = ASI->getWindowStride();
     bool magnitudeSquared = ASI->getMagnitudeSquared();
 
-    auto *scratchPtr = emitValueAddress(builder, scratch);
+    auto *winOutScratchPtr = emitValueAddress(builder, winOutScratch);
+    auto *fftOutScratchPtr = emitValueAddress(builder, fftOutScratch);
     auto *spectrogramPtr = emitValueAddress(builder, spectrogram);
     auto *inputPtr = emitValueAddress(builder, input);
     auto *windowPtr = emitValueAddress(builder, window);
@@ -2951,8 +2953,8 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
 
     auto *F = getFunction("audio_spectrogram", spectrogram->getElementType());
     createCall(builder, F,
-               {scratchPtr, spectrogramPtr, inputPtr, windowPtr,
-                twiddleFactorsPtr, bitReverseIndicesPtr,
+               {winOutScratchPtr, fftOutScratchPtr, spectrogramPtr, inputPtr,
+                windowPtr, twiddleFactorsPtr, bitReverseIndicesPtr,
                 complexToRealWeightsPtr, spectrogramDimVal, inputLengthVal,
                 windowSizeVal, windowStrideVal, magnitudeSquaredVal});
     break;

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -2924,6 +2924,7 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
 
   case Kinded::Kind::AudioSpectrogramInstKind: {
     auto *ASI = llvm::cast<AudioSpectrogramInst>(I);
+    auto scratch = ASI->getScratch();
     auto spectrogram = ASI->getSpectrogram();
     auto input = ASI->getInput();
     auto window = ASI->getWindow();
@@ -2934,6 +2935,7 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     int64_t windowStride = ASI->getWindowStride();
     bool magnitudeSquared = ASI->getMagnitudeSquared();
 
+    auto *scratchPtr = emitValueAddress(builder, scratch);
     auto *spectrogramPtr = emitValueAddress(builder, spectrogram);
     auto *inputPtr = emitValueAddress(builder, input);
     auto *windowPtr = emitValueAddress(builder, window);
@@ -2949,15 +2951,16 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
 
     auto *F = getFunction("audio_spectrogram", spectrogram->getElementType());
     createCall(builder, F,
-               {spectrogramPtr, inputPtr, windowPtr, twiddleFactorsPtr,
-                bitReverseIndicesPtr, complexToRealWeightsPtr,
-                spectrogramDimVal, inputLengthVal, windowSizeVal,
-                windowStrideVal, magnitudeSquaredVal});
+               {scratchPtr, spectrogramPtr, inputPtr, windowPtr,
+                twiddleFactorsPtr, bitReverseIndicesPtr,
+                complexToRealWeightsPtr, spectrogramDimVal, inputLengthVal,
+                windowSizeVal, windowStrideVal, magnitudeSquaredVal});
     break;
   }
 
   case Kinded::Kind::MFCCInstKind: {
     auto *MFCCI = llvm::cast<MFCCInst>(I);
+    auto scratch = MFCCI->getScratch();
     auto coefficients = MFCCI->getCoefficients();
     auto spectrogram = MFCCI->getSpectrogram();
     auto melWeights = MFCCI->getMelWeights();
@@ -2965,6 +2968,7 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     auto dctMat = MFCCI->getDctMat();
     int64_t filterBankCount = MFCCI->getFilterBankCount();
 
+    auto *scratchPtr = emitValueAddress(builder, scratch);
     auto *coefficientsPtr = emitValueAddress(builder, coefficients);
     auto *spectrogramPtr = emitValueAddress(builder, spectrogram);
     auto *melWeightsPtr = emitValueAddress(builder, melWeights);
@@ -2976,8 +2980,8 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
 
     auto *F = getFunction("mfcc", coefficients->getElementType());
     createCall(builder, F,
-               {coefficientsPtr, spectrogramPtr, melWeightsPtr, melRangesPtr,
-                dctMatPtr, coefficientsDimVal, spectrogramDimVal,
+               {scratchPtr, coefficientsPtr, spectrogramPtr, melWeightsPtr,
+                melRangesPtr, dctMatPtr, coefficientsDimVal, spectrogramDimVal,
                 filterBankCountVal});
     break;
   }

--- a/tests/unittests/BasicIRTest.cpp
+++ b/tests/unittests/BasicIRTest.cpp
@@ -369,3 +369,19 @@ TEST(IR, getOperandName) {
     EXPECT_EQ(pool->getOperandName(1), "Src");
   }
 }
+
+/// Check that Scratch is allocated properly for instructions.
+TEST(IR, scratchAllocation) {
+  Module mod;
+  Function *F = mod.createFunction("main");
+  IRFunction M(F);
+  {
+    IRBuilder bb(&M);
+    auto *input = bb.createWeightVar(ElemKind::FloatTy, {10});
+    TopKInst *topk = bb.createTopKOp("topk", input, 3, ElemKind::Int64ITy);
+    // Verify scratch is allocated and has correct size.
+    auto *scratch = topk->getScratch();
+    EXPECT_TRUE(isa<AllocActivationInst>(scratch));
+    EXPECT_EQ(scratch->getType()->size(), topk->getScratchSize());
+  }
+}

--- a/tools/ClassGen/InstrBuilder.h
+++ b/tools/ClassGen/InstrBuilder.h
@@ -33,6 +33,7 @@ enum class OperandKind : unsigned char {
   In,
   Out,
   InOut,
+  Scratch,
 };
 
 enum class VerifyKind : unsigned char {
@@ -51,12 +52,14 @@ inline OperandKind negateOperandKind(OperandKind CC) {
     return OperandKind::In;
   case OperandKind::InOut:
     return OperandKind::InOut;
+  case OperandKind::Scratch:
+    return OperandKind::Scratch;
   }
   llvm_unreachable("Invalid operand kind.");
 }
 
 inline const char *getOperandKindStr(OperandKind CC) {
-  const char *names[] = {"In", "Out", "InOut", nullptr};
+  const char *names[] = {"In", "Out", "InOut", "Out", nullptr};
   return names[(int)CC];
 }
 
@@ -102,9 +105,6 @@ class InstrBuilder {
 
   /// Specifies if this Instr is data parallel.
   bool isDataParallel_{false};
-
-  /// Specifies if this Instr requires scratch allocation.
-  bool requiresScratch_{false};
 
   /// \returns the index of the operand with the name \p name. Aborts if no such
   /// name.
@@ -216,13 +216,6 @@ public:
 
   InstrBuilder &dataParallel() {
     isDataParallel_ = true;
-    return *this;
-  }
-
-  /// Add a scratch allocation mechanism for this instruction.
-  InstrBuilder &addScratch() {
-    operands_.push_back({"Scratch", OperandKind::Out});
-    requiresScratch_ = true;
     return *this;
   }
 

--- a/tools/ClassGen/InstrBuilder.h
+++ b/tools/ClassGen/InstrBuilder.h
@@ -33,6 +33,20 @@ enum class OperandKind : unsigned char {
   In,
   Out,
   InOut,
+  /// The 'Scratch' operand kind is similar to the 'Out' operand kind with the
+  /// following distinctions:
+  /// - is is intended to be used as a temporary memory buffer for Instructions
+  ///   to write some temporary data before writing the final results using
+  ///   their 'Out' operands.
+  /// - it is NOT intended to be consumed by other Instructions and hence it is
+  ///   deallocated immediately after the Instruction execution.
+  /// - it is only exposed in the Instruction constructor and NOT in the IR
+  ///   builder method 'createXInst'. The intention is to have the IR builder
+  ///   method manage the scratch allocation/deallocation automatically.
+  /// - when defining a 'Scratch' operand named 'X', the instruction builder
+  ///   automatically declares and uses a method 'getXSize()' as part of the
+  ///   respective instruction which must be implemented by the developer in
+  ///   order for the scratch size requirements (in bytes) to be provided.
   Scratch,
 };
 

--- a/tools/ClassGen/InstrBuilder.h
+++ b/tools/ClassGen/InstrBuilder.h
@@ -100,7 +100,11 @@ class InstrBuilder {
   /// Specifies if this Instr is backend specific.
   bool isBackendSpecific_{false};
 
+  /// Specifies if this Instr is data parallel.
   bool isDataParallel_{false};
+
+  /// Specifies if this Instr requires scratch allocation.
+  bool requiresScratch_{false};
 
   /// \returns the index of the operand with the name \p name. Aborts if no such
   /// name.
@@ -212,6 +216,13 @@ public:
 
   InstrBuilder &dataParallel() {
     isDataParallel_ = true;
+    return *this;
+  }
+
+  /// Add a scratch allocation mechanism for this instruction.
+  InstrBuilder &addScratch() {
+    operands_.push_back({"Scratch", OperandKind::Out});
+    requiresScratch_ = true;
     return *this;
   }
 

--- a/tools/ClassGen/InstrBuilder.h
+++ b/tools/ClassGen/InstrBuilder.h
@@ -35,7 +35,7 @@ enum class OperandKind : unsigned char {
   InOut,
   /// The 'Scratch' operand kind is similar to the 'Out' operand kind with the
   /// following distinctions:
-  /// - is is intended to be used as a temporary memory buffer for Instructions
+  /// - is intended to be used as a temporary memory buffer for Instructions
   ///   to write some temporary data before writing the final results using
   ///   their 'Out' operands.
   /// - it is NOT intended to be consumed by other Instructions and hence it is

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -851,10 +851,11 @@ int main(int argc, char **argv) {
       .addOperand("TwiddleFactors", OperandKind::In)
       .addOperand("BitReverseIndices", OperandKind::In)
       .addOperand("ComplexToRealWeights", OperandKind::In)
+      .addOperand("WinOutScratch", OperandKind::Scratch)
+      .addOperand("FftOutScratch", OperandKind::Scratch)
       .addMember(MemberType::Int64, "WindowSize")
       .addMember(MemberType::Int64, "WindowStride")
       .addMember(MemberType::Boolean, "MagnitudeSquared")
-      .addScratch()
       .autoVerify(VerifyKind::SameElementType,
                   {"Spectrogram", "Input", "Window", "TwiddleFactors",
                    "ComplexToRealWeights", "ElemKind::FloatTy"})
@@ -868,12 +869,12 @@ int main(int argc, char **argv) {
       .addOperand("MelWeights", OperandKind::In)
       .addOperand("MelRanges", OperandKind::In)
       .addOperand("DctMat", OperandKind::In)
+      .addOperand("Scratch", OperandKind::Scratch)
       .addMember(MemberType::Float, "SampleRate")
       .addMember(MemberType::Float, "LowerFrequency")
       .addMember(MemberType::Float, "UpperFrequency")
       .addMember(MemberType::Int64, "FilterBankCount")
       .addMember(MemberType::Int64, "NumCoefficients")
-      .addScratch()
       .autoVerify(VerifyKind::SameElementType,
                   {"Coefficients", "Spectrogram", "MelWeights", "DctMat",
                    "ElemKind::FloatTy"})

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -825,7 +825,7 @@ int main(int argc, char **argv) {
       .addOperand("Values", OperandKind::Out)
       .addOperand("Indices", OperandKind::Out)
       .addOperand("Input", OperandKind::In)
-      .addOperand("Scratch", OperandKind::InOut)
+      .addOperand("Scratch", OperandKind::Scratch)
       .addMember(MemberType::Unsigned, "K")
       .autoVerify(VerifyKind::SameElementType, {"Values", "Input"})
       .autoVerify(VerifyKind::SameShape, {"Values", "Indices"});

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -49,7 +49,10 @@ int main(int argc, char **argv) {
 
   BB.newInstr("AllocActivation")
       .addMember(MemberType::TypeRef, "Ty")
-      .setType("Ty");
+      .setType("Ty")
+      .addExtraMethod(
+          "void setTy(TypeRef Ty);",
+          "void AllocActivationInst::setTy(TypeRef Ty) { Ty_ = Ty; }");
 
   BB.newInstr("TensorView")
       .addOperand("Src", OperandKind::In)
@@ -851,6 +854,7 @@ int main(int argc, char **argv) {
       .addMember(MemberType::Int64, "WindowSize")
       .addMember(MemberType::Int64, "WindowStride")
       .addMember(MemberType::Boolean, "MagnitudeSquared")
+      .addScratch()
       .autoVerify(VerifyKind::SameElementType,
                   {"Spectrogram", "Input", "Window", "TwiddleFactors",
                    "ComplexToRealWeights", "ElemKind::FloatTy"})
@@ -869,6 +873,7 @@ int main(int argc, char **argv) {
       .addMember(MemberType::Float, "UpperFrequency")
       .addMember(MemberType::Int64, "FilterBankCount")
       .addMember(MemberType::Int64, "NumCoefficients")
+      .addScratch()
       .autoVerify(VerifyKind::SameElementType,
                   {"Coefficients", "Spectrogram", "MelWeights", "DctMat",
                    "ElemKind::FloatTy"})


### PR DESCRIPTION
**Summary**
Add mechanism in ClassGen for automatic scratch allocation for Instructions.
This mechanism in enabled in InstrGen by using the method `.addScratch()` which:
- defines a new instruction operand `Scratch` for the Instruction
- declares a `getScratchSize()` method for the instruction which must be implemented by the Instruction creator
- performs in the function `create<InstructionName>()` the scratch allocation automatically based on the value returned by the function `getScratchSize()`

**Test Plan**
Identified a couple of LIBJIT implementations which previously used some scratch data allocated on the stack: **AudioSpectrogram** and **MFCC** Instructions.
Replaced the implementation to use scratch allocated with the new mechanism.

