### PR TITLE
[ONNXModeLoader] Skip empty inputs for applicability check for const folding in loader

### DIFF
--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -2486,6 +2486,13 @@ ONNXModelLoader::foldOperator(const ONNX_NAMESPACE::NodeProto &op) {
   llvm::SmallVector<NodeValue, 4> inputs;
   inputs.reserve(numInputs);
   for (unsigned i = 0; i < numInputs; i++) {
+    // If the name of the input is empty then consider it to be unspecified,
+    // which is valid for optional inputs, so simply skip. If it is necessary
+    // for loading the op, then when we later try to load the proper error will
+    // be propagated upward.
+    if (op.input(i).empty()) {
+      continue;
+    }
     NodeValue in;
     ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(i)));
     inputs.push_back(in);
@@ -4066,9 +4073,10 @@ Error ONNXModelLoader::loadNetwork(ONNX_NAMESPACE::GraphProto &net) {
       auto tryFold = foldOperator(op);
       if (!tryFold) {
         // Error during constant folding; load the op normally below.
-        const std::string errStr = ERR_TO_STRING(tryFold.takeError());
-        LOG(INFO) << "Error while trying to ConstantFold "
-                  << loadOperatorName(op) << ": " << errStr;
+        const std::string errStr =
+            ERR_TO_STRING(tryFold.takeError(), /* warning */ true);
+        VLOG(1) << "Issue while trying to ConstantFold " << loadOperatorName(op)
+                << ": " << errStr;
       } else if (tryFold.get()) {
         // Folded successfully, so skip loading the op below.
         continue;


### PR DESCRIPTION
Summary: This was causing an error message to be printed unnecessarily. E.g. if an op has optional inputs specified as `input: ""` (which is allowed, and means the input is not there), then an error would be printed because we were searching for a NodeValue by name `""`.

Fixes https://github.com/pytorch/glow/issues/4492

Test Plan: Tested locally with the model in https://github.com/pytorch/glow/issues/4492. This isn't easy to verify directly with a unit test, as compilation is successful regardless, because constant folding is best-effort.

CC: @mciprian13 