### PR TITLE
Preserve Placeholders count and names for Module

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -115,6 +115,11 @@ public:
     usedStorageNames_.insert(name);
   }
 
+  /// \returns whether there's a Storage node already registered with \p name.
+  bool hasStorageName(llvm::StringRef name) {
+    return usedStorageNames_.count(name);
+  }
+
   /// Return a pointer to a uniqued type \p T.
   TypeRef uniqueType(const Type &T);
 

--- a/include/glow/Support/Support.h
+++ b/include/glow/Support/Support.h
@@ -236,6 +236,29 @@ void vectorReorder(std::vector<T> &v, std::vector<size_t> const &order) {
   }
 }
 
+/// Simple scope guard implementation.
+class ScopeGuard {
+  /// Function to call when the destructor is called.
+  std::function<void()> endFun_;
+  /// Whether the guard is enabled.
+  bool enabled_{true};
+
+public:
+  /// Ctor that takes the function to call in destructor.
+  ScopeGuard(std::function<void()> &&fun)
+      : endFun_(std::move(fun)), enabled_(true) {}
+
+  // Dtor that calls \ref endFun_ if \ref enabled_.
+  ~ScopeGuard() {
+    if (enabled_) {
+      endFun_();
+    }
+  }
+
+  /// Disables the guard.
+  void disable() { enabled_ = false; }
+};
+
 } // namespace glow
 
 #endif // GLOW_SUPPORT_SUPPORT_H

--- a/lib/Importer/ProtobufLoader.cpp
+++ b/lib/Importer/ProtobufLoader.cpp
@@ -223,6 +223,10 @@ ProtobufLoader::createAndRegisterPlaceholder(llvm::StringRef name, TypeRef T,
   RETURN_ERR_IF_NOT(
       !hasNodeByName(name),
       llvm::Twine("Creating an already existing node ", name).str());
+  RETURN_ERR_IF_NOT(!mod_.hasStorageName(name),
+                    strFormat("A Placeholder was already registered by name %s",
+                              name.data()));
+
   Placeholder *node = mod_.createPlaceholder(T, name, isTrainable, layout);
   node->setStatic(isStatic);
   nodeValueByName_[name] = node->getOutput();

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -2325,6 +2325,7 @@ TEST_F(OnnxImporterTest, gatherOpConstantFoldingAndReshape) {
   {
     ONNXModelLoader onnxLD(netFilename, {"input"}, {&data.getType()}, *F);
     output = EXIT_ON_ERR(onnxLD.getSingleOutput());
+    EXPECT_EQ(mod.getPlaceholders().size(), 2);
     bindings.allocate(mod.getPlaceholders());
   }
   EE.compile(CompilationMode::Infer);

--- a/tests/unittests/SupportTest.cpp
+++ b/tests/unittests/SupportTest.cpp
@@ -93,3 +93,12 @@ TEST(Support, loadStrStrMapYamlFile) {
   EXPECT_EQ(map["backendOption1"], "foo");
   EXPECT_EQ(map["backendOption2"], "bar");
 }
+
+TEST(Support, ScopeGuard) {
+  int val = 1;
+  {
+    ScopeGuard guard([&]() { val++; });
+    EXPECT_EQ(val, 1);
+  }
+  EXPECT_EQ(val, 2);
+}


### PR DESCRIPTION
Summary:
Constant folding in the loader was creating Placeholders without erasing them from the Module when finished with them. These Placeholders were orphaned and never used again. Now we delete them from the module. Also added check to make sure Placeholders created during loading a proto get the name in the module that they expect.

Fixes https://github.com/pytorch/glow/issues/4456

Differential Revision: D21521508

