### PR TITLE
Disable Reshape-BN sinking when necessary

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -1873,11 +1873,15 @@ public:
 
   /// Dump a textual representation of the Function to std::string. If
   /// \p skipUsersForStorage then user counts for Storage will not be dumped.
-  std::string toString(bool skipUsersForStorage = false) const;
+  /// If \p skipName then the name of the Function will not be dumped.
+  std::string toString(bool skipUsersForStorage = false,
+                       bool skipName = false) const;
 
   /// Dump a textual representation of the Function into default output stream.
   /// If \p skipUsersForStorage then user counts for Storage will not be dumped.
-  void dump(llvm::raw_ostream &os, bool skipUsersForStorage = false) const;
+  /// If \p skipName then the name of the Function will not be dumped.
+  void dump(llvm::raw_ostream &os, bool skipUsersForStorage = false,
+            bool skipName = false) const;
 
   /// Dump a dotty graph that depicts the function into a file.
   /// \returns full path to the file.

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -4491,15 +4491,20 @@ void Function::dump() const {
   }
 }
 
-std::string Function::toString(bool skipUsersForStorage) const {
+std::string Function::toString(bool skipUsersForStorage, bool skipName) const {
   std::string storage;
   llvm::raw_string_ostream os(storage);
-  dump(os, skipUsersForStorage);
+  dump(os, skipUsersForStorage, skipName);
   return os.str();
 }
 
-void Function::dump(llvm::raw_ostream &os, bool skipUsersForStorage) const {
-  os << "Graph structure " << getName() << ":\n";
+void Function::dump(llvm::raw_ostream &os, bool skipUsersForStorage,
+                    bool skipName) const {
+  os << "Graph structure";
+  if (!skipName) {
+    os << " " << getName();
+  }
+  os << ":\n";
   std::set<const Node *, SortNamed> sorted;
   for (const Node &n : nodes_) {
     sorted.insert(&n);

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -379,6 +379,11 @@ static bool verifyBatchNormalization(NodeValue src, NodeValue dest,
   const Node *parent = dest.getNode();
   bool isValid = checkSameType(dest, src, parent);
 
+  isValid &= expectCompareTrue(
+      "Require some spatial dimensions in addition to batch and channel",
+      src.dims().size(), (size_t)2, parent,
+      CompareOperatorGreaterThan<size_t>());
+
   // Figure out how many channels are in the tensor.
   dim_t channels = src.dims()[channel];
 

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -461,6 +461,12 @@ bool SinkCode::run(Function *F, const CompilationContext &cctx) {
         auto outDims = RS->getResult().dims();
         unsigned_t newChannelIdx;
 
+        // Skip sinking if the input was less than 3 dimensions, because we need
+        // spatial dimensions in addition to batch and channel.
+        if (RS->getInput().dims().size() < 3) {
+          continue;
+        }
+
         // Reshape should not change the BatchNorm ChannelIdx dimensions.
         // Only NH[W]C and NCH[W] are allowed.
         if (BN->getChannelIdx() == outDims.size() - 1) {


### PR DESCRIPTION
Summary: This sinking was taking place even when the Reshape input only was 2D. Disable it in this case. Also added better Node verification for BN.

Reviewed By: hl475

Differential Revision: D21529041

