### PR TITLE
Remove nameMap_ from PlaceholderBindings

### DIFF
--- a/examples/char-rnn.cpp
+++ b/examples/char-rnn.cpp
@@ -234,8 +234,8 @@ int main(int argc, char **argv) {
   EET.compile(CompilationMode::Train);
   trainingBindings.allocate(modT.getPlaceholders());
 
-  auto *XT = modT.getPlaceholderByName("input");
-  auto *YT = modT.getPlaceholderByName("expected");
+  auto *XT = modT.getPlaceholderByNameSlow("input");
+  auto *YT = modT.getPlaceholderByNameSlow("expected");
 
   Tensor thisCharTrain(ElemKind::FloatTy, {batchSize, numSteps, 128});
   Tensor nextCharTrain(ElemKind::Int64ITy, {batchSize, numSteps});
@@ -259,7 +259,7 @@ int main(int argc, char **argv) {
     auto &mod = EEO.getModule();
     auto OF =
         createNetwork(mod, inferBindings, minibatchSize, numSteps, hiddenSize);
-    auto *X = mod.getPlaceholderByName("input");
+    auto *X = mod.getPlaceholderByNameSlow("input");
     inferBindings.allocate(mod.getPlaceholders());
     trainingBindings.copyTrainableWeightsTo(inferBindings);
 

--- a/examples/mnist.cpp
+++ b/examples/mnist.cpp
@@ -220,8 +220,8 @@ void testMNIST() {
              imageInputs, labelInputs, A, selected);
 
   trainingBindings.copyTrainableWeightsTo(inferBindings);
-  A = inferBindings.getPlaceholderByName("input");
-  E = inferBindings.getPlaceholderByName("return");
+  A = inferBindings.getPlaceholderByNameSlow("input");
+  E = inferBindings.getPlaceholderByNameSlow("return");
 
   validateModel(EEI_, inferBindings, F, minibatchSize, numIterations,
                 imageInputs, labelInputs, A, E, false /*transpose*/);

--- a/examples/resnet-runtime.cpp
+++ b/examples/resnet-runtime.cpp
@@ -101,7 +101,7 @@ void dispatchClassify(unsigned int id, HostManager *hostManager,
         EXIT_ON_ERR(std::move(err));
         auto *bindings = context->getPlaceholderBindings();
         size_t maxIdx =
-            bindings->get(bindings->getPlaceholderByName("gpu_0_softmax"))
+            bindings->get(bindings->getPlaceholderByNameSlow("gpu_0_softmax"))
                 ->getHandle()
                 .minMaxArg()
                 .second;

--- a/examples/resnet-verify.cpp
+++ b/examples/resnet-verify.cpp
@@ -67,7 +67,7 @@ public:
     auto hook = hookNode(FI, name);
     inferBindings.allocate(modI->getPlaceholders());
     for (auto PH : bindings.pairs()) {
-      auto iPH = inferBindings.getPlaceholderByName(PH.first->getName());
+      auto iPH = inferBindings.getPlaceholderByNameSlow(PH.first->getName());
       inferBindings.get(iPH)->assign(PH.second);
     }
 

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -184,7 +184,7 @@ public:
 
   /// \returns a pointer to the placeholder with the name \p name or
   /// nullptr if no placeholder has this name.
-  Placeholder *getPlaceholderByName(llvm::StringRef name) const;
+  Placeholder *getPlaceholderByNameSlow(llvm::StringRef name) const;
 
   /// @name High-level Storage builders.
   ///@{

--- a/include/glow/Graph/PlaceholderBindings.h
+++ b/include/glow/Graph/PlaceholderBindings.h
@@ -40,15 +40,9 @@ public:
   /// Maps placeholders to the tensors that back them.
   using PlaceholderMap = std::unordered_map<Placeholder *, Tensor *>;
 
-  /// Maps Placeholder names to Placeholders.
-  using PlaceholderNameMap = llvm::StringMap<Placeholder *>;
-
 private:
   /// Maps Placeholders to Tensors.
   PlaceholderMap map_;
-
-  /// Maps Placeholder names to Placeholders.
-  PlaceholderNameMap nameMap_;
 
 public:
   /// \returns true if \p A and \p B contain the same Placeholders mapped to
@@ -63,8 +57,9 @@ public:
   Tensor *get(Placeholder *P) const;
 
   /// \returns the Placeholder named \name or null of the Placeholder is not
-  /// found.
-  Placeholder *getPlaceholderByName(llvm::StringRef name) const;
+  /// found. Note that this uses a linear search path. If you want to seatch by
+  /// name more quickly, consider building a map yourself.
+  Placeholder *getPlaceholderByNameSlow(llvm::StringRef name) const;
 
   /// Inserts the Placeholder-Tensor pair.
   void insert(Placeholder *P, Tensor &&T);
@@ -135,7 +130,7 @@ public:
                       llvm::ArrayRef<Tensor *> inputs);
 
   PlaceholderBindings(PlaceholderBindings &&other)
-      : map_(std::move(other.map_)), nameMap_(std::move(other.nameMap_)) {}
+      : map_(std::move(other.map_)) {}
 
   ~PlaceholderBindings() { clear(); };
 

--- a/lib/Backend/Backend.cpp
+++ b/lib/Backend/Backend.cpp
@@ -76,7 +76,7 @@ void Backend::autoInstrument(TraceInfo &traceInfo, IRFunction *IR) const {
   // Default name for the instrumentation placeholder, will be made unique by
   // createPlaceholder.
   std::string name = F->getName().str() + "_instrumentation";
-  Placeholder *backingPH = F->getParent()->getPlaceholderByName(name);
+  Placeholder *backingPH = F->getParent()->getPlaceholderByNameSlow(name);
 
   auto &varmap = IR->getVariableMap();
   auto type = F->getParent()->uniqueType(

--- a/lib/Backends/Habana/HabanaDeviceManager.cpp
+++ b/lib/Backends/Habana/HabanaDeviceManager.cpp
@@ -398,7 +398,8 @@ void HabanaDeviceManager::runFunctionImpl(RunIdentifierTy runId,
       for (const auto &ph : function->getOutputs()) {
         auto *tensor = bindings->get(ph);
         if (!tensor) {
-          tensor = bindings->get(bindings->getPlaceholderByName(ph->getName()));
+          tensor =
+              bindings->get(bindings->getPlaceholderByNameSlow(ph->getName()));
         }
         tensors++;
 

--- a/lib/Backends/Habana/HabanaFunction.cpp
+++ b/lib/Backends/Habana/HabanaFunction.cpp
@@ -224,7 +224,7 @@ Error HabanaFunction::execute(ExecutionContext *context) {
   for (auto *P : getInputs()) {
     Tensor *T = bindings->get(P);
     if (!T) {
-      T = bindings->get(bindings->getPlaceholderByName(P->getName()));
+      T = bindings->get(bindings->getPlaceholderByNameSlow(P->getName()));
     }
     tensors++;
     RETURN_ERR_IF_NOT(T, "Failed to get input tensor.");
@@ -277,7 +277,7 @@ Error HabanaFunction::execute(ExecutionContext *context) {
   for (auto *P : getOutputs()) {
     Tensor *T = bindings->get(P);
     if (!T) {
-      T = bindings->get(bindings->getPlaceholderByName(P->getName()));
+      T = bindings->get(bindings->getPlaceholderByNameSlow(P->getName()));
     }
     RETURN_ERR_IF_NOT(T, "Failed to get output tensor.");
 

--- a/lib/Backends/NNPI/InferenceContext.cpp
+++ b/lib/Backends/NNPI/InferenceContext.cpp
@@ -343,7 +343,7 @@ void InferenceContext::execute(RunIdentifierTy runId,
       if (in->getUsage() == NNPIResource::ResourceUsage::StaticInputResource) {
         continue;
       }
-      auto *placeholder = bindings.getPlaceholderByName(in->getName());
+      auto *placeholder = bindings.getPlaceholderByNameSlow(in->getName());
       if (!placeholder) {
         netInputPlaceholders_.clear();
         LOG_AND_FAIL_EXECUTE_CALLBACK_IF_NOT(ERROR, placeholder,
@@ -356,7 +356,7 @@ void InferenceContext::execute(RunIdentifierTy runId,
   }
   if (netOutputPlaceholders_.empty()) {
     for (const auto &out : outputResources_) {
-      auto *placeholder = bindings.getPlaceholderByName(out->getName());
+      auto *placeholder = bindings.getPlaceholderByNameSlow(out->getName());
       if (!placeholder) {
         netOutputPlaceholders_.clear();
         LOG_AND_FAIL_EXECUTE_CALLBACK_IF_NOT(ERROR, placeholder,

--- a/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -113,7 +113,7 @@ void glow::updateInputPlaceholdersByName(PlaceholderBindings &bindings,
          "The number of inputs does not match the number of Placeholders");
 
   for (int i = 0, e = ph.size(); i < e; i++) {
-    Placeholder *p = mod->getPlaceholderByName(legalizeName(ph[i]));
+    Placeholder *p = mod->getPlaceholderByNameSlow(legalizeName(ph[i]));
     Tensor *t = inputs[i];
     assert(t && "Invalid tensor.");
     assert(p && "Invalid placeholder.");

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -4612,7 +4612,7 @@ NodeValue Function::getNodeValueByName(llvm::StringRef name) {
   auto nodeName = strPair.first;
   Node *node = getNodeByName(nodeName);
   node = node ? node : getParent()->getConstantByName(nodeName);
-  node = node ? node : getParent()->getPlaceholderByName(nodeName);
+  node = node ? node : getParent()->getPlaceholderByNameSlow(nodeName);
   if (!node || (node->getNumResults() == 0)) {
     return NodeValue();
   }
@@ -4659,7 +4659,7 @@ Constant *Module::getConstantByName(llvm::StringRef name) const {
   return nullptr;
 }
 
-Placeholder *Module::getPlaceholderByName(llvm::StringRef name) const {
+Placeholder *Module::getPlaceholderByNameSlow(llvm::StringRef name) const {
   for (auto *P : getPlaceholders()) {
     if (P->getName() == name) {
       return P;

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -455,7 +455,7 @@ void glow::fillPlaceholders(const ONNX_NAMESPACE::GraphProto &inputGroup,
                             bool usingGlowCustomOps) {
   for (const auto &tensorProto : inputGroup.initializer()) {
     auto *tensor =
-        bindings->get(bindings->getPlaceholderByName(tensorProto.name()));
+        bindings->get(bindings->getPlaceholderByNameSlow(tensorProto.name()));
     CHECK(tensor);
     size_t fullSize = tensor->getSizeInBytes();
     const auto fullType = tensor->getType();

--- a/lib/Runtime/Executor/ExecutionState.cpp
+++ b/lib/Runtime/Executor/ExecutionState.cpp
@@ -70,9 +70,9 @@ void ExecutionState::init() {
       const auto &symbolInfo = symbolPair.second;
 
       if (symbolInfo.symbolCategory == SymbolCategory::Placeholder) {
-        auto *PH = resultBindings->getPlaceholderByName(symbolName);
+        auto *PH = resultBindings->getPlaceholderByNameSlow(symbolName);
         if (!PH) {
-          PH = module_->getPlaceholderByName(symbolName);
+          PH = module_->getPlaceholderByNameSlow(symbolName);
           DCHECK(PH) << "Placeholder: " << symbolName
                      << " is not in the module";
           // If PH is marked static skip it.

--- a/lib/Runtime/Executor/NetworkExecutionState.cpp
+++ b/lib/Runtime/Executor/NetworkExecutionState.cpp
@@ -135,7 +135,7 @@ void NetworkExecutionState::init(
       const auto &symbolName = symbolPair.first;
       const auto &symbolInfo = symbolPair.second;
       if (symbolInfo.symbolCategory == SymbolCategory::Placeholder) {
-        auto PH = module_->getPlaceholderByName(symbolName);
+        auto PH = module_->getPlaceholderByNameSlow(symbolName);
 
         DCHECK(PH) << "Placeholder: " << symbolName << " is not in the module";
         // If PH is marked static skip it.

--- a/lib/Runtime/Provisioner/Provisioner.cpp
+++ b/lib/Runtime/Provisioner/Provisioner.cpp
@@ -561,7 +561,7 @@ Error Provisioner::provision(DAGListTy &networks, Module &module,
     // Load weights while there are weights to be loaded.
     while (weightName != "") {
       LOG(INFO) << "Loading " << weightName;
-      const auto PH = module.getPlaceholderByName(weightName);
+      const auto PH = module.getPlaceholderByNameSlow(weightName);
       if (!PH) {
         return MAKE_ERR(ErrorValue::ErrorCode::RUNTIME_ERROR,
                         llvm::formatv("Error loading deferred weight. Name: "

--- a/tests/stress/SparseLengthsSumTest.cpp
+++ b/tests/stress/SparseLengthsSumTest.cpp
@@ -144,7 +144,7 @@ TEST_P(SparseLengthsSum, Big) {
     auto *L = bindings.allocate(length);
     L->getHandle<int32_t>().randomize(0, 100, mod->getPRNG());
 
-    auto *lengthI = interpMod->getPlaceholderByName(length->getName());
+    auto *lengthI = interpMod->getPlaceholderByNameSlow(length->getName());
     auto *LI = interpBindings.allocate(lengthI);
     LI->assign(L);
   }
@@ -152,7 +152,7 @@ TEST_P(SparseLengthsSum, Big) {
     auto *W = bindings.allocate(weight);
     W->getHandle<float>().randomize(-1.0, 1.0, mod->getPRNG());
 
-    auto *weightI = interpMod->getPlaceholderByName(weight->getName());
+    auto *weightI = interpMod->getPlaceholderByNameSlow(weight->getName());
     auto *WI = interpBindings.allocate(weightI);
     WI->assign(W);
   }

--- a/tests/unittests/BackendTestUtils.cpp
+++ b/tests/unittests/BackendTestUtils.cpp
@@ -549,14 +549,15 @@ void trainConvNet(Tensor *inputs, Tensor *kernel1, Tensor *bias1,
   trainingBindings.allocate(EET.getModule().getPlaceholders());
   inferBindings.allocate(EEI.getModule().getPlaceholders());
   bindings.copyTrainableWeightsTo(trainingBindings);
-  auto *res = inferBindings.get(EEI.getModule().getPlaceholderByName("ret"));
+  auto *res =
+      inferBindings.get(EEI.getModule().getPlaceholderByNameSlow("ret"));
 
   runBatch(EET, trainingBindings, 8, sampleCounter, {var1, var2},
            {inputs, selected}, tfName);
   trainingBindings.copyTrainableWeightsTo(inferBindings);
   EEI.compile(CompilationMode::Infer);
-  var1 = inferBindings.getPlaceholderByName("var1");
-  var2 = inferBindings.getPlaceholderByName("var2");
+  var1 = inferBindings.getPlaceholderByNameSlow("var1");
+  var2 = inferBindings.getPlaceholderByNameSlow("var2");
   updateInputPlaceholders(inferBindings, {var1, var2}, {inputs, selected});
   EEI.run(inferBindings, fName);
   out->assign(res);
@@ -628,12 +629,12 @@ void trainLocalResponseNormalizationNet(Tensor *inputs, Tensor *weights,
   runBatch(EET, trainingBindings, 8, sampleCounter, {var1, var2},
            {inputs, selected}, tfName);
   trainingBindings.copyTrainableWeightsTo(bindings);
-  var1 = bindings.getPlaceholderByName("var1");
-  var2 = bindings.getPlaceholderByName("var2");
+  var1 = bindings.getPlaceholderByNameSlow("var1");
+  var2 = bindings.getPlaceholderByNameSlow("var2");
   EEI.compile(CompilationMode::Infer);
 
   runBatch(EEI, bindings, 1, sampleCounter, {var1, var2}, {inputs, selected});
-  out->assign(bindings.get(bindings.getPlaceholderByName("ret")));
+  out->assign(bindings.get(bindings.getPlaceholderByNameSlow("ret")));
 }
 
 void trainAvgPoolNet(Tensor *inputs, Tensor *weights, Tensor *bias,
@@ -682,13 +683,13 @@ void trainAvgPoolNet(Tensor *inputs, Tensor *weights, Tensor *bias,
   runBatch(EET, trainingBindings, 10, sampleCounter, {var1, var2},
            {inputs, selected}, tfName);
   trainingBindings.copyTrainableWeightsTo(bindings);
-  var1 = bindings.getPlaceholderByName("var1");
-  var2 = bindings.getPlaceholderByName("var2");
+  var1 = bindings.getPlaceholderByNameSlow("var1");
+  var2 = bindings.getPlaceholderByNameSlow("var2");
   EEI.compile(CompilationMode::Infer);
 
   updateInputPlaceholders(bindings, {var1, var2}, {inputs, selected});
   EEI.run(bindings);
-  out->assign(bindings.get(bindings.getPlaceholderByName("ret")));
+  out->assign(bindings.get(bindings.getPlaceholderByNameSlow("ret")));
 }
 
 void trainMaxPoolNet(Tensor *inputs, Tensor *weights, Tensor *bias,
@@ -734,14 +735,15 @@ void trainMaxPoolNet(Tensor *inputs, Tensor *weights, Tensor *bias,
   trainingBindings.allocate(EET.getModule().getPlaceholders());
   inferBindings.allocate(EEI.getModule().getPlaceholders());
   bindings.copyTrainableWeightsTo(trainingBindings);
-  auto *res = inferBindings.get(EEI.getModule().getPlaceholderByName("ret"));
+  auto *res =
+      inferBindings.get(EEI.getModule().getPlaceholderByNameSlow("ret"));
 
   runBatch(EET, trainingBindings, 7, sampleCounter, {var1, var2},
            {inputs, selected}, tfName);
   trainingBindings.copyTrainableWeightsTo(inferBindings);
   EEI.compile(CompilationMode::Infer);
-  var1 = inferBindings.getPlaceholderByName("var1");
-  var2 = inferBindings.getPlaceholderByName("var2");
+  var1 = inferBindings.getPlaceholderByNameSlow("var1");
+  var2 = inferBindings.getPlaceholderByNameSlow("var2");
   runBatch(EEI, inferBindings, 1, sampleCounter, {var1, var2},
            {inputs, selected}, fName);
   out->assign(res);
@@ -1012,9 +1014,10 @@ void trainSoftMaxNet(Tensor *inputs, Tensor *weights, Tensor *bias,
   EEI.compile(CompilationMode::Infer);
   inferBindings.allocate(EEI.getModule().getPlaceholders());
   trainingBindings.copyTrainableWeightsTo(inferBindings);
-  auto *res = inferBindings.get(EEI.getModule().getPlaceholderByName("ret"));
-  var1 = inferBindings.getPlaceholderByName("var1");
-  var2 = inferBindings.getPlaceholderByName("var2");
+  auto *res =
+      inferBindings.get(EEI.getModule().getPlaceholderByNameSlow("ret"));
+  var1 = inferBindings.getPlaceholderByNameSlow("var1");
+  var2 = inferBindings.getPlaceholderByNameSlow("var2");
   updateInputPlaceholders(inferBindings, {var1, var2}, {inputs, selected});
   EEI.run(inferBindings, fName);
   out->assign(res);

--- a/tests/unittests/Caffe2ImporterTest.cpp
+++ b/tests/unittests/Caffe2ImporterTest.cpp
@@ -52,7 +52,7 @@ static void testEltwiseUnaryOpFloat(std::string fileName,
   Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename,
                              {input_name.c_str()}, {&input_type}, *F);
   graphOutputVar = EXIT_ON_ERR(caffe2LD.getSingleOutput());
-  auto PH = mod.getPlaceholderByName(input_name);
+  auto PH = mod.getPlaceholderByNameSlow(input_name);
   auto *inTensor = bindings.allocate(PH);
   inTensor->getHandle().randomize(-10.0, 10.0, mod.getPRNG());
   EE.compile(CompilationMode::Infer);
@@ -1230,7 +1230,7 @@ TEST_F(Caffe2ImporterTest, importClip) {
   EXPECT_EQ(clipNode->getMax(), 60.0);
   EXPECT_EQ(clipNode->getMin(), 20.0);
   auto *inputNode = llvm::dyn_cast<Placeholder>(clipNode->getInput());
-  ASSERT_EQ(inputNode, mod.getPlaceholderByName("inputs_0"));
+  ASSERT_EQ(inputNode, mod.getPlaceholderByNameSlow("inputs_0"));
   // We have one input and one output.
   EXPECT_EQ(mod.getPlaceholders().size(), 2);
 }
@@ -1267,7 +1267,7 @@ TEST_F(Caffe2ImporterTest, importClipDefault) {
   EXPECT_EQ(clipNode->getMax(), std::numeric_limits<float>::max());
   EXPECT_EQ(clipNode->getMin(), std::numeric_limits<float>::lowest());
   auto *inputNode = llvm::dyn_cast<Placeholder>(clipNode->getInput().getNode());
-  ASSERT_EQ(inputNode, mod.getPlaceholderByName("inputs_0"));
+  ASSERT_EQ(inputNode, mod.getPlaceholderByNameSlow("inputs_0"));
   // We have one input and one output.
   EXPECT_EQ(mod.getPlaceholders().size(), 2);
 }
@@ -1310,7 +1310,7 @@ TEST_F(Caffe2ImporterTest, replaceNaN) {
   EXPECT_EQ(replaceNaNNode->getValue(), 1.0f);
   auto *inputNode =
       llvm::dyn_cast<Placeholder>(replaceNaNNode->getInput().getNode());
-  ASSERT_EQ(inputNode, mod.getPlaceholderByName("input"));
+  ASSERT_EQ(inputNode, mod.getPlaceholderByNameSlow("input"));
 
   // We have one input and one output.
   EXPECT_EQ(mod.getPlaceholders().size(), 2);
@@ -2094,7 +2094,7 @@ TEST_F(Caffe2ImporterTest, elementwiseLinear) {
   ASSERT_TRUE(bTile);
   EXPECT_EQ(bTile->getAxis(), 1);
   auto *XPH = llvm::dyn_cast<Placeholder>(mul->getRHS().getNode());
-  EXPECT_EQ(XPH, mod.getPlaceholderByName("X"));
+  EXPECT_EQ(XPH, mod.getPlaceholderByNameSlow("X"));
   auto *wTile = llvm::dyn_cast<TileNode>(mul->getLHS().getNode());
   ASSERT_TRUE(wTile);
   EXPECT_EQ(wTile->getAxis(), 1);
@@ -2103,9 +2103,9 @@ TEST_F(Caffe2ImporterTest, elementwiseLinear) {
   auto *wReshape = llvm::dyn_cast<ReshapeNode>(wTile->getInput().getNode());
   ASSERT_TRUE(wReshape);
   auto *wPH = llvm::dyn_cast<Placeholder>(wReshape->getInput().getNode());
-  EXPECT_EQ(wPH, mod.getPlaceholderByName("w"));
+  EXPECT_EQ(wPH, mod.getPlaceholderByNameSlow("w"));
   auto *bPH = llvm::dyn_cast<Placeholder>(bReshape->getInput().getNode());
-  EXPECT_EQ(bPH, mod.getPlaceholderByName("b"));
+  EXPECT_EQ(bPH, mod.getPlaceholderByNameSlow("b"));
 
   // We have three inputs and one output.
   EXPECT_EQ(mod.getPlaceholders().size(), 4);
@@ -2174,7 +2174,7 @@ TEST_F(Caffe2ImporterTest, elementwiseLinearUnspecifiedAxis) {
   ASSERT_TRUE(bTile);
   EXPECT_EQ(bTile->getAxis(), 0);
   auto *XPH = llvm::dyn_cast<Placeholder>(mul->getRHS().getNode());
-  EXPECT_EQ(XPH, mod.getPlaceholderByName("X"));
+  EXPECT_EQ(XPH, mod.getPlaceholderByNameSlow("X"));
   auto *wTile = llvm::dyn_cast<TileNode>(mul->getLHS().getNode());
   ASSERT_TRUE(wTile);
   EXPECT_EQ(wTile->getAxis(), 0);
@@ -2183,9 +2183,9 @@ TEST_F(Caffe2ImporterTest, elementwiseLinearUnspecifiedAxis) {
   auto *wReshape = llvm::dyn_cast<ReshapeNode>(wTile->getInput().getNode());
   ASSERT_TRUE(wReshape);
   auto *wPH = llvm::dyn_cast<Placeholder>(wReshape->getInput().getNode());
-  EXPECT_EQ(wPH, mod.getPlaceholderByName("w"));
+  EXPECT_EQ(wPH, mod.getPlaceholderByNameSlow("w"));
   auto *bPH = llvm::dyn_cast<Placeholder>(bReshape->getInput().getNode());
-  EXPECT_EQ(bPH, mod.getPlaceholderByName("b"));
+  EXPECT_EQ(bPH, mod.getPlaceholderByNameSlow("b"));
 
   // We have three inputs and one output.
   EXPECT_EQ(mod.getPlaceholders().size(), 4);
@@ -2254,7 +2254,7 @@ TEST_F(Caffe2ImporterTest, elementwiseImplicitBroadcast) {
   ASSERT_TRUE(bTile);
   EXPECT_EQ(bTile->getAxis(), 0);
   auto *XPH = llvm::dyn_cast<Placeholder>(mul->getLHS().getNode());
-  EXPECT_EQ(XPH, mod.getPlaceholderByName("X"));
+  EXPECT_EQ(XPH, mod.getPlaceholderByNameSlow("X"));
   auto *wTile = llvm::dyn_cast<TileNode>(mul->getRHS().getNode());
   ASSERT_TRUE(wTile);
   EXPECT_EQ(wTile->getAxis(), 0);
@@ -2263,9 +2263,9 @@ TEST_F(Caffe2ImporterTest, elementwiseImplicitBroadcast) {
   auto *wReshape = llvm::dyn_cast<ReshapeNode>(wTile->getInput().getNode());
   ASSERT_TRUE(wReshape);
   auto *wPH = llvm::dyn_cast<Placeholder>(wReshape->getInput().getNode());
-  EXPECT_EQ(wPH, mod.getPlaceholderByName("w"));
+  EXPECT_EQ(wPH, mod.getPlaceholderByNameSlow("w"));
   auto *bPH = llvm::dyn_cast<Placeholder>(bReshape->getInput().getNode());
-  EXPECT_EQ(bPH, mod.getPlaceholderByName("b"));
+  EXPECT_EQ(bPH, mod.getPlaceholderByNameSlow("b"));
 
   // We have three inputs and one output.
   EXPECT_EQ(mod.getPlaceholders().size(), 4);
@@ -2982,7 +2982,7 @@ TEST_F(Caffe2ImporterTest, importNames) {
   Tensor input(ElemKind::FloatTy, {6});
   Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename,
                              {"sigmoid_test_input"}, {&input.getType()}, *F);
-  EXPECT_TRUE(mod.getPlaceholderByName("sigmoid_test_output"));
+  EXPECT_TRUE(mod.getPlaceholderByNameSlow("sigmoid_test_output"));
   EXPECT_TRUE(F->getNodeByName("sigmoid_test_output__1"));
 }
 

--- a/tests/unittests/DeviceManagerTest.cpp
+++ b/tests/unittests/DeviceManagerTest.cpp
@@ -147,7 +147,7 @@ TEST_P(DeviceManagerTest, Basic) {
   output1.getHandle().clear(std::max(std::tanh(0.5), 0.25));
 
   updateInputPlaceholders(*context->getPlaceholderBindings(),
-                          {module->getPlaceholderByName("main_input")},
+                          {module->getPlaceholderByNameSlow("main_input")},
                           {&input1});
 
   context = runFunction("main", std::move(context));
@@ -156,7 +156,7 @@ TEST_P(DeviceManagerTest, Basic) {
   // directly.
   context->getPlaceholderBindings()->ensureOnHost();
   Tensor *result1 = context->getPlaceholderBindings()->get(
-      module->getPlaceholderByName("main_output"));
+      module->getPlaceholderByNameSlow("main_output"));
   ASSERT_TRUE(result1);
   EXPECT_TRUE(result1->isEqual(output1));
 }
@@ -228,7 +228,7 @@ TEST_P(DeviceManagerTest, PartialTensorCopy) {
   context->getPlaceholderBindings()->ensureOnHost();
 
   Tensor *result1 = context->getPlaceholderBindings()->get(
-      module->getPlaceholderByName("main_output"));
+      module->getPlaceholderByNameSlow("main_output"));
 
   ASSERT_TRUE(result1);
   EXPECT_FLOAT_EQ(result1->getHandle().at({0}), std::max(std::tanh(0.5), 0.25));
@@ -343,10 +343,10 @@ TEST_P(DeviceManagerTest, MultiRun) {
   output2.getHandle().clear(std::max(std::tanh(3.0f), 0.25f));
 
   updateInputPlaceholders(*context1->getPlaceholderBindings(),
-                          {module->getPlaceholderByName("main_input")},
+                          {module->getPlaceholderByNameSlow("main_input")},
                           {&input1});
   updateInputPlaceholders(*context2->getPlaceholderBindings(),
-                          {module->getPlaceholderByName("main_input")},
+                          {module->getPlaceholderByNameSlow("main_input")},
                           {&input2});
 
   std::promise<std::unique_ptr<ExecutionContext>> runP1, runP2;
@@ -379,9 +379,9 @@ TEST_P(DeviceManagerTest, MultiRun) {
   context2->getPlaceholderBindings()->ensureOnHost();
 
   Tensor *result1 = context1->getPlaceholderBindings()->get(
-      module->getPlaceholderByName("main_output"));
+      module->getPlaceholderByNameSlow("main_output"));
   Tensor *result2 = context2->getPlaceholderBindings()->get(
-      module->getPlaceholderByName("main_output"));
+      module->getPlaceholderByNameSlow("main_output"));
   ASSERT_TRUE(result1);
   ASSERT_TRUE(result2);
   EXPECT_TRUE(result1->isEqual(output1));
@@ -400,7 +400,7 @@ TEST_P(DeviceManagerTest, MultiFunction) {
   context1->getPlaceholderBindings()->allocate(module->getPlaceholders());
 
   Function *F = module->createFunction("func2");
-  auto *inP = module->getPlaceholderByName("func1_input");
+  auto *inP = module->getPlaceholderByNameSlow("func1_input");
   auto *outP =
       module->createPlaceholder(ElemKind::FloatTy, {1}, "func2_output", false);
   auto *p = F->createTanh("tanh2", inP);
@@ -442,10 +442,10 @@ TEST_P(DeviceManagerTest, MultiFunction) {
   output2.getHandle().clear(std::max(std::tanh(0.5f), 0.25f));
 
   updateInputPlaceholders(*context1->getPlaceholderBindings(),
-                          {module->getPlaceholderByName("func1_input")},
+                          {module->getPlaceholderByNameSlow("func1_input")},
                           {&input});
   updateInputPlaceholders(*context2->getPlaceholderBindings(),
-                          {module->getPlaceholderByName("func1_input")},
+                          {module->getPlaceholderByNameSlow("func1_input")},
                           {&input});
 
   std::promise<std::unique_ptr<ExecutionContext>> runP1, runP2;
@@ -476,9 +476,9 @@ TEST_P(DeviceManagerTest, MultiFunction) {
   context2->getPlaceholderBindings()->ensureOnHost();
 
   Tensor *result1 = context1->getPlaceholderBindings()->get(
-      module->getPlaceholderByName("func1_output"));
+      module->getPlaceholderByNameSlow("func1_output"));
   Tensor *result2 = context2->getPlaceholderBindings()->get(
-      module->getPlaceholderByName("func2_output"));
+      module->getPlaceholderByNameSlow("func2_output"));
   ASSERT_TRUE(result1);
   ASSERT_TRUE(result2);
   EXPECT_TRUE(result1->isEqual(output1));
@@ -522,14 +522,14 @@ TEST_P(DeviceManagerTest, MultiModule) {
   output.getHandle().clear(std::max(std::tanh(0.5f), 0.25f));
 
   updateInputPlaceholders(*context1->getPlaceholderBindings(),
-                          {module1->getPlaceholderByName("func1_input")},
+                          {module1->getPlaceholderByNameSlow("func1_input")},
                           {&input});
 
   std::unique_ptr<ExecutionContext> context2 =
       glow::make_unique<ExecutionContext>();
   context2->getPlaceholderBindings()->allocate(module2->getPlaceholders());
   updateInputPlaceholders(*context2->getPlaceholderBindings(),
-                          {module2->getPlaceholderByName("func2_input")},
+                          {module2->getPlaceholderByNameSlow("func2_input")},
                           {&input});
 
   std::promise<std::unique_ptr<ExecutionContext>> runP1, runP2;
@@ -560,12 +560,12 @@ TEST_P(DeviceManagerTest, MultiModule) {
   context2->getPlaceholderBindings()->ensureOnHost();
 
   Tensor *result1 = context1->getPlaceholderBindings()->get(
-      module1->getPlaceholderByName("func1_output"));
+      module1->getPlaceholderByNameSlow("func1_output"));
   ASSERT_TRUE(result1);
   EXPECT_TRUE(result1->isEqual(output));
 
   Tensor *result2 = context2->getPlaceholderBindings()->get(
-      module2->getPlaceholderByName("func2_output"));
+      module2->getPlaceholderByNameSlow("func2_output"));
   ASSERT_TRUE(result2);
   EXPECT_TRUE(result2->isEqual(output));
 }
@@ -580,7 +580,7 @@ TEST_P(DeviceManagerTest, ReuseModule) {
   context1->getPlaceholderBindings()->allocate(module->getPlaceholders());
 
   Function *F = module->createFunction("func2");
-  auto *inP = module->getPlaceholderByName("func1_input");
+  auto *inP = module->getPlaceholderByNameSlow("func1_input");
   auto *outP =
       module->createPlaceholder(ElemKind::FloatTy, {1}, "func2_output", false);
   auto *p = F->createTanh("tanh2", inP);
@@ -627,10 +627,10 @@ TEST_P(DeviceManagerTest, ReuseModule) {
   output2.getHandle().clear(std::max(std::tanh(0.5f), 0.25f));
 
   updateInputPlaceholders(*context1->getPlaceholderBindings(),
-                          {module->getPlaceholderByName("func1_input")},
+                          {module->getPlaceholderByNameSlow("func1_input")},
                           {&input});
   updateInputPlaceholders(*context2->getPlaceholderBindings(),
-                          {module->getPlaceholderByName("func1_input")},
+                          {module->getPlaceholderByNameSlow("func1_input")},
                           {&input});
 
   std::promise<std::unique_ptr<ExecutionContext>> runP1, runP2;
@@ -661,12 +661,12 @@ TEST_P(DeviceManagerTest, ReuseModule) {
   context2->getPlaceholderBindings()->ensureOnHost();
 
   Tensor *result1 = context1->getPlaceholderBindings()->get(
-      module->getPlaceholderByName("func1_output"));
+      module->getPlaceholderByNameSlow("func1_output"));
   ASSERT_TRUE(result1);
   EXPECT_TRUE(result1->isEqual(output1));
 
   Tensor *result2 = context2->getPlaceholderBindings()->get(
-      module->getPlaceholderByName("func2_output"));
+      module->getPlaceholderByNameSlow("func2_output"));
   ASSERT_TRUE(result2);
   EXPECT_TRUE(result2->isEqual(output2));
 }
@@ -812,7 +812,7 @@ TEST(DeviceManagerTest, DummyDeviceManager) {
   output1.getHandle().clear(std::max(std::tanh(0.5f), 0.25f));
 
   updateInputPlaceholders(*context1->getPlaceholderBindings(),
-                          {module->getPlaceholderByName("main_input")},
+                          {module->getPlaceholderByNameSlow("main_input")},
                           {&input1});
 
   std::promise<std::unique_ptr<ExecutionContext>> runPromise;
@@ -833,7 +833,7 @@ TEST(DeviceManagerTest, DummyDeviceManager) {
   ASSERT_TRUE(context2);
 
   Tensor *result = context2->getPlaceholderBindings()->get(
-      module->getPlaceholderByName("main_output"));
+      module->getPlaceholderByNameSlow("main_output"));
   ASSERT_TRUE(result);
   EXPECT_TRUE(result->isEqual(output1));
 
@@ -926,16 +926,16 @@ TEST_P(DeviceManagerTest, CanHandleDeviceResidentTensors) {
   output1.getHandle().clear(std::max(std::tanh(0.5), 0.25));
 
   updateInputPlaceholders(*context->getPlaceholderBindings(),
-                          {module->getPlaceholderByName("main_input")},
+                          {module->getPlaceholderByNameSlow("main_input")},
                           {&input1});
 
   mockDM.transferToDevice(*context->getPlaceholderBindings()->get(
-      module->getPlaceholderByName("main_input")));
+      module->getPlaceholderByNameSlow("main_input")));
 
   context = runFunction("main", std::move(context));
   ASSERT_TRUE(context);
   Tensor *result1 = context->getPlaceholderBindings()->get(
-      module->getPlaceholderByName("main_output"));
+      module->getPlaceholderByNameSlow("main_output"));
   ASSERT_TRUE(result1);
 }
 

--- a/tests/unittests/GradCheckTest.cpp
+++ b/tests/unittests/GradCheckTest.cpp
@@ -142,13 +142,13 @@ void performGradCheck(ExecutionEngine &EET, ExecutionEngine &EEI,
   for (auto PH : EEI.getModule().getPlaceholders()) {
     bindings.copyToTarget(PH->getName(), inferBindings);
   }
-  auto resultTensor =
-      inferBindings.get(inferBindings.getPlaceholderByName(result->getName()));
+  auto resultTensor = inferBindings.get(
+      inferBindings.getPlaceholderByNameSlow(result->getName()));
 
   auto analyticalGradsH = gradVarTensor->getHandle();
   auto inputsH = inputs->getHandle<>();
   bool allZeroGradients = true;
-  auto inferInput = inferBindings.getPlaceholderByName(inputVar->getName());
+  auto inferInput = inferBindings.getPlaceholderByNameSlow(inputVar->getName());
 
   for (size_t i = 0; i < analyticalGradsH.size(); i++) {
     auto old = inputsH.raw(i);

--- a/tests/unittests/HostManagerTest.cpp
+++ b/tests/unittests/HostManagerTest.cpp
@@ -265,7 +265,7 @@ TEST_P(HostManagerTest, runNetworkConcurrent) {
   auto *X = module->createPlaceholder(ElemKind::FloatTy, {3}, "X", false);
   auto *pow = F->createPow("Pow1", X, 2.0);
   F->createSave("save", pow);
-  auto *savePH = module->getPlaceholderByName("save");
+  auto *savePH = module->getPlaceholderByNameSlow("save");
 
   auto hostManager = createHostManager(backendName_);
   CompilationContext cctx;
@@ -307,7 +307,7 @@ TEST_P(HostManagerTest, testSaturateHost) {
   auto *X = module->createPlaceholder(ElemKind::FloatTy, {3}, "X", false);
   auto *pow = F->createPow("Pow1", X, 2.0);
   F->createSave("save", pow);
-  auto *savePH = module->getPlaceholderByName("save");
+  auto *savePH = module->getPlaceholderByNameSlow("save");
 
   std::vector<std::unique_ptr<DeviceConfig>> configs =
       generateConfigs(backendName_, 2);
@@ -820,7 +820,7 @@ TEST_P(HostManagerTest, testStaticAssignmentP2PandDRTConcurrent) {
   auto *X = module->createPlaceholder(ElemKind::FloatTy, {3}, "X", false);
   auto *pow = F->createPow("Pow1", X, 2.0);
   F->createSave("save", pow);
-  auto *savePH = module->getPlaceholderByName("save");
+  auto *savePH = module->getPlaceholderByNameSlow("save");
 
   std::vector<std::unique_ptr<DeviceConfig>> configs =
       generateConfigs(backendName_, 3);

--- a/tests/unittests/HyphenTest.cpp
+++ b/tests/unittests/HyphenTest.cpp
@@ -290,7 +290,8 @@ struct HyphenNetwork {
     dim_t numSamples = inputs.dims()[0];
     EXPECT_LE(batchSize, numSamples);
     auto resultHandle =
-        bindings_.get(bindings_.getPlaceholderByName("result"))->getHandle<>();
+        bindings_.get(bindings_.getPlaceholderByNameSlow("result"))
+            ->getHandle<>();
     unsigned errors = 0;
 
     for (dim_t bi = 0; bi < numSamples; bi += batchSize) {

--- a/tests/unittests/MLTest.cpp
+++ b/tests/unittests/MLTest.cpp
@@ -118,7 +118,7 @@ TEST_P(MLTest, trainASimpleNetwork) {
   }
   PlaceholderBindings trainingBindings;
   trainingBindings.allocate(EET_.getModule().getPlaceholders());
-  auto *resPH = EEI_.getModule().getPlaceholderByName("return");
+  auto *resPH = EEI_.getModule().getPlaceholderByNameSlow("return");
 
   // Values for the input and output variables.
   Tensor inputs(ElemKind::FloatTy, {1, 4});
@@ -138,7 +138,7 @@ TEST_P(MLTest, trainASimpleNetwork) {
   // Testing the output vector.
   PlaceholderBindings inferBindings;
   inferBindings.allocate(EEI_.getModule().getPlaceholders());
-  A = EEI_.getModule().getPlaceholderByName("A");
+  A = EEI_.getModule().getPlaceholderByNameSlow("A");
   EEI_.compile(CompilationMode::Infer);
   trainingBindings.copyTrainableWeightsTo(inferBindings);
   updateInputPlaceholders(inferBindings, {A}, {&inputs});
@@ -183,7 +183,7 @@ TEST_P(MLTest, simpleRegression) {
     O = F->createRegression("reg", O, Ex);
     F->createSave("result", O);
   }
-  auto resPH = EEI_.getModule().getPlaceholderByName("result");
+  auto resPH = EEI_.getModule().getPlaceholderByNameSlow("result");
   trainingBindings.allocate(EET_.getModule().getPlaceholders());
   inferBindings.copyTrainableWeightsTo(trainingBindings);
   inferBindings.clear();
@@ -208,7 +208,7 @@ TEST_P(MLTest, simpleRegression) {
   // Verify the result of the regression layer.
   inferBindings.allocate(EEI_.getModule().getPlaceholders());
   trainingBindings.copyTrainableWeightsTo(inferBindings);
-  A = inferBindings.getPlaceholderByName("A");
+  A = inferBindings.getPlaceholderByNameSlow("A");
   EEI_.compile(CompilationMode::Infer);
 
   // Test the output:
@@ -259,7 +259,8 @@ TEST_P(MLTest, learnXor) {
   inferBindings.clear();
   inferBindings.allocate(EEI_.getModule().getPlaceholders());
 
-  auto *res = inferBindings.get(EEI_.getModule().getPlaceholderByName("ret"));
+  auto *res =
+      inferBindings.get(EEI_.getModule().getPlaceholderByNameSlow("ret"));
 
   // Prepare the training set and the testing set.
   Tensor trainingSet(ElemKind::FloatTy, {numInputs, 2});
@@ -295,7 +296,7 @@ TEST_P(MLTest, learnXor) {
     TS.at({i, 0}) = a;
     TS.at({i, 1}) = b;
   }
-  A = inferBindings.getPlaceholderByName("A");
+  A = inferBindings.getPlaceholderByNameSlow("A");
   updateInputPlaceholders(inferBindings, {A}, {&trainingSet});
   EEI_.run(inferBindings, fname);
 
@@ -343,7 +344,8 @@ TEST_P(MLTest, learnLog) {
   inferBindings.clear();
   inferBindings.allocate(EEI_.getModule().getPlaceholders());
 
-  auto *res = inferBindings.get(EEI_.getModule().getPlaceholderByName("ret"));
+  auto *res =
+      inferBindings.get(EEI_.getModule().getPlaceholderByNameSlow("ret"));
 
   // Set the training data.
   Tensor trainingSet(ElemKind::FloatTy, {numInputs, 1});
@@ -386,7 +388,7 @@ TEST_P(MLTest, learnLog) {
     float a = EEI_.getModule().getPRNG().nextRandReal(LO_T, HI_T);
     TES.at({i, 0}) = a;
   }
-  A = inferBindings.getPlaceholderByName("A");
+  A = inferBindings.getPlaceholderByNameSlow("A");
   updateInputPlaceholders(inferBindings, {A}, {&testSet});
   EEI_.run(inferBindings, fname);
 
@@ -467,7 +469,8 @@ TEST_P(MLTest, circle) {
   inferBindings.copyTrainableWeightsTo(trainingBindings);
   inferBindings.clear();
   inferBindings.allocate(EEI_.getModule().getPlaceholders());
-  auto *res = inferBindings.get(EEI_.getModule().getPlaceholderByName("ret"));
+  auto *res =
+      inferBindings.get(EEI_.getModule().getPlaceholderByNameSlow("ret"));
 
   auto *TF = glow::differentiate(F, TC);
   auto tfName = TF->getName();
@@ -484,7 +487,7 @@ TEST_P(MLTest, circle) {
            {&coordinates, &labels}, tfName);
   trainingBindings.copyTrainableWeightsTo(inferBindings);
   EEI_.compile(CompilationMode::Infer);
-  A = inferBindings.getPlaceholderByName("A");
+  A = inferBindings.getPlaceholderByNameSlow("A");
   // Print a diagram that depicts the network decision on a grid.
   Tensor sample(ElemKind::FloatTy, {minibatchSize, 2});
   sample.zero();
@@ -581,7 +584,8 @@ TEST_P(MLTest, learnSingleValueConcat) {
   inferBindings.copyTrainableWeightsTo(trainingBindings);
   inferBindings.clear();
   inferBindings.allocate(EEI_.getModule().getPlaceholders());
-  auto *res = inferBindings.get(EEI_.getModule().getPlaceholderByName("ret"));
+  auto *res =
+      inferBindings.get(EEI_.getModule().getPlaceholderByNameSlow("ret"));
 
   Tensor inputs(ElemKind::FloatTy, {1, width});
   Tensor expected(ElemKind::FloatTy, {1, width * 2});
@@ -597,7 +601,7 @@ TEST_P(MLTest, learnSingleValueConcat) {
            {&inputs, &inputs, &expected}, tfName);
   trainingBindings.copyTrainableWeightsTo(inferBindings);
   EEI_.compile(CompilationMode::Infer);
-  A = inferBindings.getPlaceholderByName("A");
+  A = inferBindings.getPlaceholderByNameSlow("A");
   // Testing the output vector.
   updateInputPlaceholders(inferBindings, {A}, {&inputs});
   EEI_.run(inferBindings);
@@ -709,7 +713,8 @@ void testRNNCell(TCellGenerator cell) {
   inferBindings.copyTrainableWeightsTo(trainingBindings);
   inferBindings.clear();
   inferBindings.allocate(EEI.getModule().getPlaceholders());
-  auto *res = inferBindings.get(EEI.getModule().getPlaceholderByName("result"));
+  auto *res =
+      inferBindings.get(EEI.getModule().getPlaceholderByNameSlow("result"));
 
   auto *TF = glow::differentiate(F, TC);
   auto tfName = TF->getName();
@@ -732,7 +737,7 @@ void testRNNCell(TCellGenerator cell) {
   trainingBindings.copyTrainableWeightsTo(inferBindings);
   // Testing the output vector.
   EEI.compile(CompilationMode::Infer);
-  X = inferBindings.getPlaceholderByName("X");
+  X = inferBindings.getPlaceholderByNameSlow("X");
   updateInputPlaceholders(inferBindings, {X}, {&inputs});
   EEI.run(inferBindings, fname);
 
@@ -903,7 +908,7 @@ TEST_P(MLTest, classifyPlayerSport) {
            {&players, &labels}, tfName);
   trainingBindings.copyTrainableWeightsTo(inferBindings);
   EEI_.compile(CompilationMode::Infer);
-  A = inferBindings.getPlaceholderByName("A");
+  A = inferBindings.getPlaceholderByNameSlow("A");
   std::vector<std::tuple<unsigned, unsigned, Sport>> testPlayers;
   testPlayers.emplace_back(82, 240, Sport::BASKETBALL);
   testPlayers.emplace_back(86, 260, Sport::BASKETBALL);
@@ -921,8 +926,9 @@ TEST_P(MLTest, classifyPlayerSport) {
   updateInputPlaceholders(inferBindings, {A}, {&testPlayersTensor});
   EEI_.run(inferBindings, fname);
 
-  auto SMH = inferBindings.get(inferBindings.getPlaceholderByName("result"))
-                 ->getHandle<>();
+  auto SMH =
+      inferBindings.get(inferBindings.getPlaceholderByNameSlow("result"))
+          ->getHandle<>();
   for (dim_t i = 0; i < testPlayers.size(); i++) {
     const dim_t sport = static_cast<dim_t>(std::get<2>(testPlayers[i]));
     EXPECT_NEAR(SMH.at({i, sport}), 1.0, 0.1);
@@ -986,7 +992,7 @@ TEST_P(MLTest, learnSinus) {
   inferBindings.clear();
   inferBindings.allocate(EEI_.getModule().getPlaceholders());
   auto *res =
-      inferBindings.get(EEI_.getModule().getPlaceholderByName("return"));
+      inferBindings.get(EEI_.getModule().getPlaceholderByNameSlow("return"));
 
   auto *TF = glow::differentiate(F, TC);
   auto tfName = TF->getName();
@@ -1006,7 +1012,7 @@ TEST_P(MLTest, learnSinus) {
     tensorX.getHandle<>().at({i, 0}) = x;
     tensorY.getHandle<>().at({i, 0}) = y;
   }
-  inputX = inferBindings.getPlaceholderByName("input");
+  inputX = inferBindings.getPlaceholderByNameSlow("input");
   EEI_.compile(CompilationMode::Infer);
   updateInputPlaceholders(inferBindings, {inputX}, {&tensorX});
   EEI_.run(inferBindings, fname);
@@ -1055,7 +1061,8 @@ TEST_P(MLTest, nonLinearClassifier) {
   inferBindings.copyTrainableWeightsTo(trainingBindings);
   inferBindings.clear();
   inferBindings.allocate(EEI_.getModule().getPlaceholders());
-  auto *res = inferBindings.get(EEI_.getModule().getPlaceholderByName("ret"));
+  auto *res =
+      inferBindings.get(EEI_.getModule().getPlaceholderByNameSlow("ret"));
 
   auto *TF = glow::differentiate(F, TC);
   auto tfName = TF->getName();
@@ -1079,7 +1086,7 @@ TEST_P(MLTest, nonLinearClassifier) {
            {&samples, &labels}, tfName);
   trainingBindings.copyTrainableWeightsTo(inferBindings);
   EEI_.compile(CompilationMode::Infer);
-  A = inferBindings.getPlaceholderByName("A");
+  A = inferBindings.getPlaceholderByNameSlow("A");
   std::vector<std::tuple<float, float, dim_t>> tests;
   tests.emplace_back(-0.8, -0.8, 0);
   tests.emplace_back(0.8, -0.8, 1);
@@ -1160,8 +1167,8 @@ TEST_P(MLTest, convNetForImageRecognition) {
   }
 
   auto *mod = &EET_.getModule();
-  auto input = mod->getPlaceholderByName("input");
-  auto ex = mod->getPlaceholderByName("exp");
+  auto input = mod->getPlaceholderByNameSlow("input");
+  auto ex = mod->getPlaceholderByNameSlow("exp");
 
   auto *TF = glow::differentiate(mod->getFunction(fName), TC);
   auto tfName = TF->getName();
@@ -1184,7 +1191,7 @@ TEST_P(MLTest, convNetForImageRecognition) {
   cctxProf.precisionConfig.quantMode = QuantizationMode::Profile;
 
   auto F = mod->getFunction(fName);
-  input = mod->getPlaceholderByName("input");
+  input = mod->getPlaceholderByNameSlow("input");
   trainingBindings.copyTrainableWeightsTo(profileBindings);
   EEP.compile(cctxProf);
   // Since we are compiling in profiling mode the partitioner will create a new
@@ -1214,7 +1221,7 @@ TEST_P(MLTest, convNetForImageRecognition) {
 
   F = mod->getFunction("convNetForImageRecognition");
   EEI_.compile(cctxQuant);
-  input = mod->getPlaceholderByName("input");
+  input = mod->getPlaceholderByNameSlow("input");
 
   // Generate the images used for testing.
   Tensor testImages(ElemKind::FloatTy, {batchSize, 8, 8, 1});
@@ -1224,7 +1231,8 @@ TEST_P(MLTest, convNetForImageRecognition) {
 
   EEI_.run(inferBindings);
 
-  Tensor *res = inferBindings.get(EEI_.getModule().getPlaceholderByName("ret"));
+  Tensor *res =
+      inferBindings.get(EEI_.getModule().getPlaceholderByNameSlow("ret"));
   auto SMH = res->getHandle<>();
   for (dim_t i = 0; i < batchSize; i++) {
     bool isLine = testLabels.getHandle<int64_t>().at({i, 0}) == 0;
@@ -1296,8 +1304,8 @@ TEST_P(MLTest, testFindPixelRegression) {
   }
 
   auto *mod = &EET_.getModule();
-  auto input = mod->getPlaceholderByName("input");
-  auto ex = mod->getPlaceholderByName("coordinates");
+  auto input = mod->getPlaceholderByNameSlow("input");
+  auto ex = mod->getPlaceholderByNameSlow("coordinates");
 
   auto *TF = glow::differentiate(mod->getFunction(fName), TC);
   auto tfName = TF->getName();
@@ -1329,7 +1337,7 @@ TEST_P(MLTest, testFindPixelRegression) {
   CompilationContext cctxProf{&profileBindings, &loweredMapForProf};
   cctxProf.precisionConfig.quantMode = QuantizationMode::Profile;
 
-  input = mod->getPlaceholderByName("input");
+  input = mod->getPlaceholderByNameSlow("input");
   trainingBindings.copyTrainableWeightsTo(profileBindings);
   EEP.compile(cctxProf);
   // Get new function after partitioning.
@@ -1354,7 +1362,7 @@ TEST_P(MLTest, testFindPixelRegression) {
 
   F = mod->getFunction(fName);
   EEI_.compile(cctxQuant);
-  input = mod->getPlaceholderByName("input");
+  input = mod->getPlaceholderByNameSlow("input");
 
   // Generate the images used for testing.
   Tensor testImages(ElemKind::FloatTy, {batchSize, 10, 10, 1});
@@ -1366,7 +1374,8 @@ TEST_P(MLTest, testFindPixelRegression) {
   EEI_.run(inferBindings);
 
   // A handle to the projected result.
-  Tensor *res = inferBindings.get(EEI_.getModule().getPlaceholderByName("ret"));
+  Tensor *res =
+      inferBindings.get(EEI_.getModule().getPlaceholderByNameSlow("ret"));
   auto RH = res->getHandle<>();
   // A handle to the true label.
   auto LH = testLabels.getHandle<>();
@@ -1508,7 +1517,7 @@ TEST_P(MLTest, matrixRotationRecognition) {
   inferBindings.clear();
   inferBindings.allocate(EEI_.getModule().getPlaceholders());
   auto *res =
-      inferBindings.get(EEI_.getModule().getPlaceholderByName("result"));
+      inferBindings.get(EEI_.getModule().getPlaceholderByNameSlow("result"));
   auto *TF = glow::differentiate(F, TC);
   auto tfName = TF->getName();
   auto fname = F->getName();
@@ -1538,8 +1547,8 @@ TEST_P(MLTest, matrixRotationRecognition) {
   unsigned numBatches = numSamples / batchSize;
   unsigned batchStartIdx =
       EEI_.getModule().getPRNG().nextRandInt(0, numBatches - 1) * batchSize;
-  varMatricesA = inferBindings.getPlaceholderByName("matrixA");
-  varMatricesB = inferBindings.getPlaceholderByName("matrixB");
+  varMatricesA = inferBindings.getPlaceholderByNameSlow("matrixA");
+  varMatricesB = inferBindings.getPlaceholderByNameSlow("matrixB");
   auto batchMatricesA =
       matricesA.getUnowned({batchSize, 3, 3}, {batchStartIdx, 0, 0});
   auto batchMatricesB =
@@ -1618,9 +1627,11 @@ TEST_P(MLTest, learnSparseLengthsSumEmbeddings) {
   inferBindings.copyToTarget("expectedP", trainingBindings);
   inferBindings.clear();
   inferBindings.allocate(EEI_.getModule().getPlaceholders());
-  EH = trainingBindings.get(trainingBindings.getPlaceholderByName("expectedP"))
+  EH = trainingBindings
+           .get(trainingBindings.getPlaceholderByNameSlow("expectedP"))
            ->getHandle();
-  auto *res = inferBindings.get(EEI_.getModule().getPlaceholderByName("save"));
+  auto *res =
+      inferBindings.get(EEI_.getModule().getPlaceholderByNameSlow("save"));
 
   // Train the network.
   auto *TF = glow::differentiate(F, TC);
@@ -1711,9 +1722,11 @@ TEST_P(MLTest, learnSparseLengthsWeightedSumEmbeddings) {
   inferBindings.copyToTarget("expectedP", trainingBindings);
   inferBindings.clear();
   inferBindings.allocate(EEI_.getModule().getPlaceholders());
-  EH = trainingBindings.get(trainingBindings.getPlaceholderByName("expectedP"))
+  EH = trainingBindings
+           .get(trainingBindings.getPlaceholderByNameSlow("expectedP"))
            ->getHandle();
-  auto *res = inferBindings.get(EEI_.getModule().getPlaceholderByName("save"));
+  auto *res =
+      inferBindings.get(EEI_.getModule().getPlaceholderByNameSlow("save"));
 
   // Train the network.
   auto *TF = glow::differentiate(F, TC);
@@ -1804,8 +1817,10 @@ TEST_P(MLTest, learnSparseLengthsWeightedSumWeights) {
   inferBindings.copyToTarget("expectedP", trainingBindings);
   inferBindings.clear();
   inferBindings.allocate(EEI_.getModule().getPlaceholders());
-  auto *res = inferBindings.get(EEI_.getModule().getPlaceholderByName("save"));
-  EH = trainingBindings.get(trainingBindings.getPlaceholderByName("expectedP"))
+  auto *res =
+      inferBindings.get(EEI_.getModule().getPlaceholderByNameSlow("save"));
+  EH = trainingBindings
+           .get(trainingBindings.getPlaceholderByNameSlow("expectedP"))
            ->getHandle();
   // Train the network.
   auto *TF = glow::differentiate(F, TC);

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -115,7 +115,8 @@ protected:
       }
 
       // Look for an input PH by the same name as the original Function.
-      Placeholder *inputPH = loadedMod.getPlaceholderByName(p.first->getName());
+      Placeholder *inputPH =
+          loadedMod.getPlaceholderByNameSlow(p.first->getName());
       ASSERT_TRUE(inputPH);
       loadedBindings.insert(inputPH, p.second->getUnowned(inputPH->dims()));
     }
@@ -140,7 +141,7 @@ protected:
 
       // Find the result PH by the same name in the loaded Function.
       Placeholder *loadedResultPH =
-          loadedMod.getPlaceholderByName(resultPH->getName());
+          loadedMod.getPlaceholderByNameSlow(resultPH->getName());
       ASSERT_TRUE(loadedResultPH);
       const Tensor *loadedResultT = loadedBindings.get(loadedResultPH);
 

--- a/tests/unittests/PartitionerTest.cpp
+++ b/tests/unittests/PartitionerTest.cpp
@@ -223,12 +223,12 @@ static void verifyDAGSerialization(DAGListTy &dagList, Module &origMod,
   loadedEE.compile(loadedCctx);
   std::vector<Placeholder *> inPHs;
   for (const llvm::StringRef &inName : inputNames) {
-    inPHs.push_back(bindings.getPlaceholderByName(inName));
+    inPHs.push_back(bindings.getPlaceholderByNameSlow(inName));
   }
   executeDAG(loadedDAG.root.get(), loadedMod, bindings, inPHs, inputs,
              &loadedEE);
   Tensor test =
-      bindings.get(bindings.getPlaceholderByName(resultName))->clone();
+      bindings.get(bindings.getPlaceholderByNameSlow(resultName))->clone();
   EXPECT_TRUE(ref.isEqual(test, 0.0f));
 }
 
@@ -297,10 +297,11 @@ TEST_F(PartitionerTest, Basic1) {
   EER.compile(CompilationMode::Infer);
   bindings_.clear();
   bindings_.allocate(EER.getModule().getPlaceholders());
-  updateInputPlaceholders(bindings_, {bindings_.getPlaceholderByName("input")},
-                          {&in});
+  updateInputPlaceholders(bindings_,
+                          {bindings_.getPlaceholderByNameSlow("input")}, {&in});
   EER.run(bindings_);
-  Tensor ref = bindings_.get(bindings_.getPlaceholderByName("ret"))->clone();
+  Tensor ref =
+      bindings_.get(bindings_.getPlaceholderByNameSlow("ret"))->clone();
 
   std::vector<DeviceInfo> devices = {
       {3072, "Interpreter"}, {3072, "Interpreter"}, {3072, "Interpreter"}};
@@ -318,8 +319,9 @@ TEST_F(PartitionerTest, Basic1) {
   EEP.compile(cctx);
   for (auto it = dagList->begin(); it != dagList->end(); ++it) {
     executeDAG((*it).root.get(), EEP.getModule(), bindings_,
-               {bindings_.getPlaceholderByName("input")}, {&in}, &EEP);
-    Tensor test = bindings_.get(bindings_.getPlaceholderByName("ret"))->clone();
+               {bindings_.getPlaceholderByNameSlow("input")}, {&in}, &EEP);
+    Tensor test =
+        bindings_.get(bindings_.getPlaceholderByNameSlow("ret"))->clone();
     EXPECT_TRUE(ref.isEqual(test, 0.0f));
     verifyDAGSerialization(*dagList, EEP.getModule(), bindings_, {"input"},
                            "ret", devices, {&in}, ref);
@@ -384,11 +386,12 @@ TEST_F(PartitionerTest, Basic2) {
   bindings_.clear();
   bindings_.allocate(EER.getModule().getPlaceholders());
   updateInputPlaceholders(bindings_,
-                          {bindings_.getPlaceholderByName("input"),
-                           bindings_.getPlaceholderByName("input1")},
+                          {bindings_.getPlaceholderByNameSlow("input"),
+                           bindings_.getPlaceholderByNameSlow("input1")},
                           {&in, &in});
   EER.run(bindings_);
-  Tensor ref = bindings_.get(bindings_.getPlaceholderByName("ret"))->clone();
+  Tensor ref =
+      bindings_.get(bindings_.getPlaceholderByNameSlow("ret"))->clone();
 
   std::vector<DeviceInfo> devices = {{2048, "Interpreter"},
                                      {2048, "Interpreter"},
@@ -417,12 +420,13 @@ TEST_F(PartitionerTest, Basic2) {
   EEP.compile(cctx);
   for (auto it = dagList.begin(); it != dagList.end(); ++it) {
     updateInputPlaceholders(bindings_,
-                            {bindings_.getPlaceholderByName("input"),
-                             bindings_.getPlaceholderByName("input1")},
+                            {bindings_.getPlaceholderByNameSlow("input"),
+                             bindings_.getPlaceholderByNameSlow("input1")},
                             {&in, &in});
     executeDAG((*it).root.get(), EEP.getModule(), bindings_,
-               {bindings_.getPlaceholderByName("input")}, {&in}, &EEP);
-    Tensor test = bindings_.get(bindings_.getPlaceholderByName("ret"))->clone();
+               {bindings_.getPlaceholderByNameSlow("input")}, {&in}, &EEP);
+    Tensor test =
+        bindings_.get(bindings_.getPlaceholderByNameSlow("ret"))->clone();
     ASSERT_TRUE(ref.isEqual(test, 0.0f));
     verifyDAGSerialization(dagList, EEP.getModule(), bindings_,
                            {"input", "input1"}, "ret", devices, {&in, &in},
@@ -486,8 +490,8 @@ TEST_F(PartitionerTest, Error1) {
   bindings_.clear();
   bindings_.allocate(EER.getModule().getPlaceholders());
   updateInputPlaceholders(bindings_,
-                          {bindings_.getPlaceholderByName("input"),
-                           bindings_.getPlaceholderByName("input1")},
+                          {bindings_.getPlaceholderByNameSlow("input"),
+                           bindings_.getPlaceholderByNameSlow("input1")},
                           {&in, &in});
   EER.run(bindings_);
 
@@ -1566,10 +1570,11 @@ TEST_F(PartitionerTest, loadBalancedPartition) {
   EER.compile(CompilationMode::Infer);
   bindings_.clear();
   bindings_.allocate(EER.getModule().getPlaceholders());
-  updateInputPlaceholders(bindings_, {bindings_.getPlaceholderByName("input")},
-                          {&in});
+  updateInputPlaceholders(bindings_,
+                          {bindings_.getPlaceholderByNameSlow("input")}, {&in});
   EER.run(bindings_);
-  Tensor ref = bindings_.get(bindings_.getPlaceholderByName("ret"))->clone();
+  Tensor ref =
+      bindings_.get(bindings_.getPlaceholderByNameSlow("ret"))->clone();
 
   std::vector<DeviceInfo> devices = {
       {3072, "Interpreter"}, {3072, "Interpreter"}, {3072, "Interpreter"}};
@@ -1587,8 +1592,9 @@ TEST_F(PartitionerTest, loadBalancedPartition) {
   EEP.compile(cctx);
   for (auto it = dagList->begin(); it != dagList->end(); ++it) {
     executeDAG((*it).root.get(), EEP.getModule(), bindings_,
-               {bindings_.getPlaceholderByName("input")}, {&in}, &EEP);
-    Tensor test = bindings_.get(bindings_.getPlaceholderByName("ret"))->clone();
+               {bindings_.getPlaceholderByNameSlow("input")}, {&in}, &EEP);
+    Tensor test =
+        bindings_.get(bindings_.getPlaceholderByNameSlow("ret"))->clone();
     EXPECT_TRUE(ref.isEqual(test, 0.0f));
     verifyDAGSerialization(*dagList, EEP.getModule(), bindings_, {"input"},
                            "ret", devices, {&in}, ref);

--- a/tests/unittests/QuantizationTest.cpp
+++ b/tests/unittests/QuantizationTest.cpp
@@ -1187,9 +1187,9 @@ testQuantizationEnd2End(ExecutionEngine &profileEE,
 
   // STEP3 - Compare the results of the original and quantized functions.
   auto result1Handle =
-      bindings.get(bindings.getPlaceholderByName("save"))->getHandle();
+      bindings.get(bindings.getPlaceholderByNameSlow("save"))->getHandle();
   auto result2Handle =
-      bindingsBackend.get(bindingsBackend.getPlaceholderByName("save"))
+      bindingsBackend.get(bindingsBackend.getPlaceholderByNameSlow("save"))
           ->getHandle();
 
   EXPECT_EQ(result1Handle.size(), result2Handle.size());
@@ -1360,9 +1360,9 @@ TEST_P(Operator, end2endGRU) {
 
   // STEP3 - Compare the results of the original and quantized functions.
   auto result1Handle =
-      bindings.get(bindings.getPlaceholderByName("save"))->getHandle();
+      bindings.get(bindings.getPlaceholderByNameSlow("save"))->getHandle();
   auto result2Handle =
-      bindingsBackend.get(bindingsBackend.getPlaceholderByName("save"))
+      bindingsBackend.get(bindingsBackend.getPlaceholderByNameSlow("save"))
           ->getHandle();
 
   EXPECT_EQ(result1Handle.size(), result2Handle.size());

--- a/tests/unittests/RecommendationSystemTest.cpp
+++ b/tests/unittests/RecommendationSystemTest.cpp
@@ -899,7 +899,8 @@ protected:
 
     dispatchInference("main", hostManager.get(), context, concurrentReqestsOpt);
 
-    Tensor *resultTensorP = bindings.get(bindings.getPlaceholderByName("save"));
+    Tensor *resultTensorP =
+        bindings.get(bindings.getPlaceholderByNameSlow("save"));
     EXPECT_TRUE(referenceResultT.isEqual(*resultTensorP));
   }
 

--- a/tests/unittests/Repro.cpp
+++ b/tests/unittests/Repro.cpp
@@ -719,7 +719,7 @@ int run() {
           CHECK(!ERR_TO_BOOL(std::move(error)))
               << "Cannot load output ref tensor";
           const auto *tensor =
-              bindings.get(bindings.getPlaceholderByName(tp.name()));
+              bindings.get(bindings.getPlaceholderByNameSlow(tp.name()));
           CHECK(tensor) << "Missing " << tp.name() << " in output placeholder";
 
           if (cosineSimilarityStats) {

--- a/tests/unittests/ThreadPoolExecutorTest.cpp
+++ b/tests/unittests/ThreadPoolExecutorTest.cpp
@@ -468,7 +468,7 @@ public:
     }
 
     for (const auto &symbol : outputSymbols) {
-      auto *placeholder = bindings_->getPlaceholderByName(symbol);
+      auto *placeholder = bindings_->getPlaceholderByNameSlow(symbol);
       if (!placeholder) {
         assert(!"Placeholder for DAG output not found!");
       }
@@ -549,7 +549,7 @@ private:
   /// mapped for the test being created, reuse the existing value.
   void insertSymbolIntoPlaceholderBindings(llvm::StringRef name,
                                            PlaceholderBindings *bindings) {
-    auto ph = module_->getPlaceholderByName(name);
+    auto ph = module_->getPlaceholderByNameSlow(name);
 
     if (!ph) {
       // This is a new symbol. Create a Placeholder and an initialize and new

--- a/tools/Debugger/NetworkComparator.cpp
+++ b/tools/Debugger/NetworkComparator.cpp
@@ -95,7 +95,7 @@ NetworkComparatorBase::InOutTensors RecursiveLayerComparator::hookAndRun(
   // Copy the tensors from the bindings to the inference bindings
   // we feed to the Temp network.
   for (auto &PH : bindings->pairs()) {
-    auto iPH = inferBindings.getPlaceholderByName(PH.first->getName());
+    auto iPH = inferBindings.getPlaceholderByNameSlow(PH.first->getName());
     inferBindings.get(iPH)->assign(PH.second);
   }
   InOutTensors inOutTensors;
@@ -189,7 +189,7 @@ void IntermediateLayerComparator::copyInputBindingsToHookedBindings(
     PlaceholderBindings &hookedBindigs, PlaceholderBindings &inputBindings) {
   // Copy tensors from input bindings to the bindings we use for Inference.
   for (auto PH : inputBindings.pairs()) {
-    auto iPH = hookedBindigs.getPlaceholderByName(PH.first->getName());
+    auto iPH = hookedBindigs.getPlaceholderByNameSlow(PH.first->getName());
     hookedBindigs.get(iPH)->assign(PH.second);
   }
 }
@@ -259,7 +259,7 @@ void IntermediateLayerComparator::fillSingleLayerInputs(
                            << " NodeType: " << inputNode->getKindName()
                            << "\n");
       Placeholder *PH =
-          refHookedBindings_.getPlaceholderByName(hookedPlaceholderName);
+          refHookedBindings_.getPlaceholderByNameSlow(hookedPlaceholderName);
       DCHECK(PH) << "Placeholder not found in the hooked bindings";
       Tensor *payloadTensor = refHookedBindings_.get(PH);
       Placeholder *singleLayerPH = singleLayerMod.createPlaceholder(
@@ -289,7 +289,8 @@ void IntermediateLayerComparator::runAndGetoutputSingleLayer(
   singleLayerExecEng.run(singleLayerBindings);
   for (Placeholder *PH : singleLayerOutputPHs) {
     singleLayerOutputs[PH->getName()] = singleLayerBindings.get(PH);
-    Placeholder *refPH = refHookedBindings_.getPlaceholderByName(PH->getName());
+    Placeholder *refPH =
+        refHookedBindings_.getPlaceholderByNameSlow(PH->getName());
     refOutputs[PH->getName()] = refHookedBindings_.get(refPH);
   }
 }

--- a/tools/loader/TextTranslator.cpp
+++ b/tools/loader/TextTranslator.cpp
@@ -370,7 +370,8 @@ int main(int argc, char **argv) {
 
   // Get all input tensors and zero them.
   for (const auto *name : inputNames) {
-    Tensor *T = bindings.get(loader.getModule()->getPlaceholderByName(name));
+    Tensor *T =
+        bindings.get(loader.getModule()->getPlaceholderByNameSlow(name));
     DCHECK(T && "input tensor missing!");
     T->zero();
   }


### PR DESCRIPTION
Summary: Today, we always keep a nameMap_ in PlaceholderBindings, and all the operations involves insert/delete of this string map. And the purpose of nameMap_ is to speedup getPlaceholderByName, which we only use for debug purpose and some compilation pass. During inference, we don't use getPlaceholderByName at all. This diff removes nameMap_ to speedup all other operation wrt PlaceholderBindings, at the cost of a slower path for getPlaceholderByName, which seems to be justified looking at the inference profile.

Differential Revision: D21530718

