### PR TITLE
 NMS V4 to ONNX NMS optimizaion.

### DIFF
--- a/include/glow/Graph/Node.h
+++ b/include/glow/Graph/Node.h
@@ -50,7 +50,11 @@ class Node : public Named,
 
 protected:
   /// The output types for the results of the node.
+#if defined(_DEBUG) && defined(WIN32)
+  std::vector<TypeRef> types_;
+#else
   llvm::SmallVector<TypeRef, 6> types_;
+#endif
   /// A nullable reference to some tensor value that may predicate the execution
   /// of the current node.
   NodeHandle predicate_;

--- a/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
+++ b/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
@@ -61,6 +61,7 @@ FUN_PASS(OptimizeConcatQuantization)
 FUN_PASS(SinkConcatBelowQuantize)
 FUN_PASS(FoldLayerNormArithmetic)
 FUN_PASS(OptimizeSelect)
+FUN_PASS(PostProcessingNMS)
 
 
 // NOTE: This pass must be last; it's used to count the total number of passes.

--- a/lib/Optimizer/GraphOptimizerPipeline/FunctionPassPipeline.cpp
+++ b/lib/Optimizer/GraphOptimizerPipeline/FunctionPassPipeline.cpp
@@ -173,6 +173,10 @@ createDefaultGraphOptimizationPassPipeline() {
 
       // Optimize select operations.
       {FunctionPassID::OptimizeSelect},
+
+      // Optimize post processing graph.
+      {FunctionPassID::PostProcessingNMS},
+
       // Perform a round of Dead Code Elimination to cleanup the final pass.
       getDCEPassConfig(),
   };


### PR DESCRIPTION
Summary:
Optimization for some flavors of SSD converted from TF. There is a family of SSD networks that use different core networks, but have the same post processing.

Network use NMS V4 which can only handle 1 class. Which results in 80 NMS nodes, with all the corresponding sub graphs to split the data then filter results and concat everything together. It also uses TopK to pack all results together.
Optimization Isolates NMS V4 subgraph and replaces with ONNX NMS and appropriate subgraph. Due to being able to handle multiple classes in ONNX NMS the first TopK also becomes redundant.

Optimization finds NMS nodes and isolates the divergence and convergence points and replaces it with a new much smaller sub graph that uses ONNX NMS.

Using utility functions in Utils.h created by @ksaurabh-cadence 
Documentation:
Before optimization:
![SSD_TF_graph](https://user-images.githubusercontent.com/43973793/81863589-5376ad00-9520-11ea-9dfb-b0599d885a79.jpg)

After optimization:
![SSD_TF_graph_to_onnx_nms](https://user-images.githubusercontent.com/43973793/81863593-54a7da00-9520-11ea-9230-948008643f77.jpg)
[Optional Fixes #issue]

Test Plan:
Unit Tests, TF SSD networks.
Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
