### PR TITLE
Do insert or update with one lookup

### DIFF
--- a/include/glow/Graph/PlaceholderBindings.h
+++ b/include/glow/Graph/PlaceholderBindings.h
@@ -104,6 +104,10 @@ public:
   /// \p P must be a valid Placeholder registered in the bindings.
   void update(Placeholder *P, Tensor &&T);
 
+  /// Check if Placeholder \p P already exists. If yes, bind \p T to \p P.
+  /// Otherwise, insert \p P to the map.
+  void insertOrUpdate(Placeholder *P, Tensor &&T);
+
   /// \returns a copy of the PlaceholderBindings, with each placeholder mapped
   /// to a new Tensor, with their own memory.
   PlaceholderBindings clone() const;

--- a/lib/Runtime/Executor/NetworkExecutionState.cpp
+++ b/lib/Runtime/Executor/NetworkExecutionState.cpp
@@ -70,12 +70,8 @@ void NetworkExecutionState::bind(std::unique_ptr<ExecutionContext> resultCtx,
   for (auto &pair : resultPHBindings->pairs()) {
     auto PH = pair.first;
     auto resultTensor = pair.second;
-    for (auto binding : externalIntermediates_[PH]) {
-      if (binding->get(PH)) {
-        binding->update(PH, resultTensor->getUnowned());
-      } else {
-        binding->insert(PH, resultTensor->getUnowned());
-      }
+    for (auto &binding : externalIntermediates_[PH]) {
+      binding->insertOrUpdate(PH, resultTensor->getUnowned());
     }
   }
 }


### PR DESCRIPTION
Summary: We do 2-3 hash map lookup when we try to insert/update the backing tensor of a placeholder. Hashing is expensive. This diff make it with 1-lookup. I really think we can get rid of the hashmap look up altogether (or just do it once for all inferences)  and just use array indexing. But this may involve more effort.

Reviewed By: jfix71

Differential Revision: D21537587

