### PR TITLE
Add ability to record what Constant Folding occurs, and support (de)serializing

### DIFF
--- a/include/glow/Exporter/ONNXModelWriter.h
+++ b/include/glow/Exporter/ONNXModelWriter.h
@@ -19,6 +19,7 @@
 
 #include "glow/Exporter/CommonOperatorWriter.h"
 #include "glow/Graph/Graph.h"
+#include "glow/Optimizer/GraphOptimizer/GraphOptimizer.h"
 #include "glow/Runtime/RuntimeTypes.h"
 
 #include "onnx/onnx_pb.h"
@@ -52,6 +53,10 @@ class ONNXModelWriter : public CommonOperatorWriter<ONNX_TRAITS> {
   ONNX_NAMESPACE::ModelProto modelProto_;
   // GraphProto that we are writing to.
   ONNX_TRAITS::GraphProto *graphProto_;
+  // Root GraphProto that we are writing to. Equal to \ref graphProto_ unless
+  // when writing a constant folding subgraph, when graphProto_ is temporarily
+  // changed.
+  ONNX_TRAITS::GraphProto *graphProtoRoot_;
   /// Current IR version of ONNX.
   const size_t irVersion_;
   /// Current version of ONNX standard.
@@ -68,11 +73,16 @@ class ONNXModelWriter : public CommonOperatorWriter<ONNX_TRAITS> {
   const bool useGlowCustomOps_;
   /// Whether we are writing a DAG.
   const bool dagMode_;
+  /// A map containing a record of what constant folding took place, to record
+  /// in serialized DAGs.
+  const ConstantFoldingRecordMap &constFoldRecord_;
   /// A dedicated list of initializers in case the tensors get too big and don't
   /// fit into the model.
   std::list<TensorType> initializers_;
   /// Holds all Functions from a DAG that are being written when in dagMode_.
   llvm::SmallSet<Function *, 6> functionsFromDAG_;
+  /// Holds all constant folding Functions that have been processed.
+  llvm::SmallSet<Function *, 6> processedConstFoldFunctions_;
   /// Writes tensor shape from placeholder \p PH into protpbuf \p valueProto.
   void tensorShapeFromPlaceholder(const Placeholder *PH,
                                   ValueInfoType *valueProto);
@@ -104,6 +114,15 @@ class ONNXModelWriter : public CommonOperatorWriter<ONNX_TRAITS> {
   /// Write the current Function \ref F_ to \ref graphProto_. \returns if there
   /// was an issue during iteration or writing.
   Error writeFunction();
+
+  /// Given a Constant \p C that was previously created during Constant folding,
+  /// Serializes the constant folding Function saved by \p SN, where the
+  /// Function is the parent of \p SN. The function is written to an attribute
+  /// in a Glow__ConstFoldSubgraph NodeProto. \returns if an Error occurs.
+  Error writeConstantFoldingSubgraph(const Constant *C, SaveNode *SN);
+
+  /// \returns whether currently writing a constant folding subgraph.
+  bool isWritingConstFoldSubgraph();
 
   /// Finalize the written function and write it out to \p filename. \returns if
   /// there is an error encountered.
@@ -144,11 +163,15 @@ public:
   /// to abide by the official ONNX ops. If \p includeConstantData then data for
   /// Constants will be serialized in the written model, otherwise it will be
   /// skipped (but initializers will still exist, they will just have no data).
+  /// \p constFoldRecord contains any records of constant folding that should be
+  /// included in the serialized model.
   ONNXModelWriter(const std::string &modelFilename, Function &F,
                   size_t irVersion, size_t opsetVersion,
                   Error *errPtr = nullptr, bool textMode = false,
                   bool zipMode = false, bool useGlowCustomOps = false,
-                  bool includeConstantData = true);
+                  bool includeConstantData = true,
+                  const ConstantFoldingRecordMap &constFoldRecord =
+                      ConstantFoldingRecordMap());
 
   /// Creates an ONNX model writer to serialize \p dagList into file
 
@@ -162,11 +185,15 @@ public:
   /// TensorProto file along with the model file and package them into a zip
   /// file. If \p includeConstantData then data for Constants will be serialized
   /// in the written model, otherwise it will be skipped (but initializers will
-  /// still exist, they will just have no data).
+  /// still exist, they will just have no data). \p constFoldRecord contains any
+  /// records of constant folding that should be included in the serialized
+  /// model.
   ONNXModelWriter(const std::string &modelFilename, runtime::DAGListTy &dagList,
                   size_t irVersion, size_t opsetVersion,
                   Error *errPtr = nullptr, bool textMode = false,
-                  bool zipMode = false, bool includeConstantData = true);
+                  bool zipMode = false, bool includeConstantData = true,
+                  const ConstantFoldingRecordMap &constFoldRecord =
+                      ConstantFoldingRecordMap());
 
 private:
   /// \returns error for the unexpected node kind.

--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -364,6 +364,7 @@ constexpr char saveNameSignifier[] = "saveName";
 constexpr char qScaleSignifier[] = "qScale";
 constexpr char qOffsetSignifier[] = "qOffset";
 constexpr char shapeSignifier[] = "shape";
+constexpr char constFoldSubgraphNodeName[] = "Glow__ConstFoldSubgraph";
 
 /// \returns the string ID for a type attribute property for a specific \p ioNum
 /// and \p signifier and whether \p isInput. E.g. to retrieve result number 0's

--- a/include/glow/Importer/ONNXModelLoader.h
+++ b/include/glow/Importer/ONNXModelLoader.h
@@ -123,6 +123,9 @@ class ONNXModelLoader
   /// A set of inputs which will be static placeholders.
   std::unordered_set<std::string> staticInputs_;
 
+  /// A set of Functions used for ConstantFolding to be deleted after loading.
+  std::unordered_set<Function *> constFoldFuns_;
+
   /// Load ONNX NonZero Operator.
   /// Glow's requirement for static shapes results in required Constant
   /// input. Thus, the operator will be folded in the Importer.
@@ -383,9 +386,11 @@ class ONNXModelLoader
                  ArgumentDictionaryTy &dict);
 
 protected:
-  /// Load the network operators from the GraphProto.
+  /// Loads operators from \p net. If \p loadingConstFoldSubgraph then the
+  /// current Function \ref G_ is assumed to be the one to load into.
   /// \returns Error if network cannot be loaded.
-  Error loadNetwork(ONNX_NAMESPACE::GraphProto &net);
+  Error loadNetwork(ONNX_NAMESPACE::GraphProto &net,
+                    bool loadingConstFoldSubgraph);
 
   /// Set the output nodes of the network \p net. Initializes the map from the
   /// names of the outputs to the save nodes that save each output.
@@ -402,6 +407,19 @@ protected:
 
   /// Load the network initializers from the GraphProto.
   Error loadInitializers(ONNX_NAMESPACE::GraphProto &net);
+
+  /// Given some initializer \p in, check if it has some constant folding node
+  /// associated with it in \p net. If so, deserializes the Function if not
+  /// already done, performs the constant folding, and \returns the Constant
+  /// created as a result to be used for this initializer.
+  Expected<Constant *>
+  replaySerializedConstFold(const ONNX_NAMESPACE::TensorProto &in,
+                            ONNX_NAMESPACE::GraphProto &net);
+
+  /// Given some \p outputName that maps to a NodeValue that we want to constant
+  /// fold, run it and assign the resulting Constant \p initializerName.
+  Expected<Constant *> runDeserializedConstFold(llvm::StringRef initializerName,
+                                                llvm::StringRef outputName);
 
   /// Load the inputs from the GraphProto. If \p loadInputsAsPlaceholdersForOnnx
   /// is true then this will load each graph input as a placeholder otherwise it
@@ -474,6 +492,9 @@ protected:
   Error setupPartitions(ONNX_NAMESPACE::ModelProto &modelDef,
                         runtime::PrePartitionedConfig &PPC,
                         llvm::StringRef rootName, int numPartitions);
+
+  /// Deletes the Functions in \ref constFoldFuns_ from \ref mod_.
+  void deleteConstFoldFunctions();
 
 public:
   /// \returns ONNX model ir_version;


### PR DESCRIPTION
Summary: 
- Add the ability to record what constant folding occurs via subgraphs -- a map from Constants created to the SaveNode that created it from the constant folding function it came from
- Add serializing this subgraph to custom Glow ONNX
- Add deserializing this subgraph we serialized

Test plan:
- Added a few unit tests to consider different cases to GraphOptzTest for the const fold recording pass.
- Added a few more similar tests to OnnxExporterTest that serialize/deserialize and run to make sure results are bitwise equal

Differential Revision: D21569329

