### PR TITLE
aggregate the latency counters traced into requestContext

### DIFF
--- a/include/glow/ExecutionContext/TraceEvents.h
+++ b/include/glow/ExecutionContext/TraceEvents.h
@@ -177,6 +177,7 @@ public:
 
   /// \returns TraceEvents for the last run.
   std::list<TraceEvent> &getTraceEvents() { return traceEvents_; }
+  std::list<TraceEvent> getTraceEventsCopy();
 
   /// \returns the level of verbosity allowed for TraceEvents.
   int getTraceLevel() { return traceLevel_; }

--- a/include/glow/Runtime/RequestData.h
+++ b/include/glow/Runtime/RequestData.h
@@ -24,6 +24,7 @@ namespace runtime {
 class RequestData : public folly::RequestData {
 public:
   int64_t appLevelRequestId{0};
+  folly::Synchronized<std::vector<std::pair<std::string, int64_t>>> counters_;
 
   static RequestData *get() {
     auto data = dynamic_cast<RequestData *>(

--- a/lib/ExecutionContext/TraceEvents.cpp
+++ b/lib/ExecutionContext/TraceEvents.cpp
@@ -189,6 +189,11 @@ void TraceContext::setThreadName(int tid, llvm::StringRef name) {
   threadNames_[tid] = name;
 }
 
+std::list<TraceEvent> TraceContext::getTraceEventsCopy() {
+  std::lock_guard<std::mutex> l(lock_);
+  return traceEvents_;
+}
+
 void TraceContext::setThreadName(llvm::StringRef name) {
   setThreadName(threads::getThreadId(), name);
 }


### PR DESCRIPTION
Summary:
We already collect a lot of latency counters in the existing glow trace, it
would be better if we can aggregate it and visualize it through collecting it
in RequestContext

Differential Revision: D21515856

