### PR TITLE
Reduce the cost of NetworkExecutionState::bind

### DIFF
--- a/include/glow/Graph/PlaceholderBindings.h
+++ b/include/glow/Graph/PlaceholderBindings.h
@@ -40,6 +40,7 @@ class PlaceholderBindings final {
 public:
   /// Maps placeholders to the tensors that back them.
   using PlaceholderMap = std::unordered_map<Placeholder *, Tensor *>;
+  using PlaceholderMapIterator = PlaceholderMap::iterator;
 
 private:
   /// Maps Placeholders to Tensors.
@@ -66,7 +67,7 @@ public:
   void insert(Placeholder *P, Tensor &&T);
 
   /// Inserts the Placeholder-Tensor pair. This takes ownership of the Tensor.
-  void insert(Placeholder *P, Tensor *T);
+  PlaceholderMapIterator insert(Placeholder *P, Tensor *T);
 
   /// Copy values from this PlaceholderBindings to another, \p dst, by \p name.
   /// This is useful when trained weights need to be transferred between
@@ -104,10 +105,6 @@ public:
   /// Removes the existing Tensor backing Placeholder \p P; Bind \p T to \P.
   /// \p P must be a valid Placeholder registered in the bindings.
   void update(Placeholder *P, Tensor &&T);
-
-  /// Check if Placeholder \p P already exists. If yes, bind \p T to \p P.
-  /// Otherwise, insert \p P to the map.
-  void insertOrUpdate(Placeholder *P, Tensor &&T);
 
   /// \returns a copy of the PlaceholderBindings, with each placeholder mapped
   /// to a new Tensor, with their own memory.

--- a/include/glow/Runtime/Executor/NetworkExecutionState.h
+++ b/include/glow/Runtime/Executor/NetworkExecutionState.h
@@ -140,8 +140,9 @@ private:
 
   /// Map of intermediate placeholder bindings that need to be pointed at
   /// resultCtx tensors.
-  std::unordered_map<Placeholder *, std::vector<PlaceholderBindings *>>
-      externalIntermediates_;
+  std::unordered_map<Placeholder *,
+                     std::vector<PlaceholderBindings::PlaceholderMap::iterator>>
+      externalPlaceholders_;
   /// Input contexts for all of the nodes. These are gradually
   /// populated as a node's parents finish.
   std::unordered_map<const DAGNode *, std::unique_ptr<ExecutionContext>>

--- a/tests/unittests/Repro.cpp
+++ b/tests/unittests/Repro.cpp
@@ -664,7 +664,7 @@ int run() {
       for (auto &binding : inputBindings[ioIndex].pairs()) {
         auto PH = binding.first;
         auto resultTensor = binding.second;
-        bindings.insertOrUpdate(PH, resultTensor->getUnowned());
+        bindings.update(PH, resultTensor->getUnowned());
       }
 
       std::promise<void> promise;


### PR DESCRIPTION
Summary:
This diff remove one level of hashmap loojup in `NetworkExecutionState::bind`. What `bind` does is to bind the external input placeholders to the input placeholders of each partition nodes. Key observation is that we will insert this placeholder to the placeholderbinding of the partition nodes, and we don't delete any of these bindings during the run. So once we keep hold of the iterator of the external input binding, it will be valid throughout the life time of NetworkExecutionState. Hence, during binding, we can save one lookup to match the input placeholder pointer but just go directly to update the backing tensor.

TODO:
- Cleanup the PlaceholderBindins and TensorPook to use Tensor instead of Tensor* as value.
- Save the outer layer of lookup by using a vector for external input binding.
- Find a way to tell intermediate placeholders from external placeholders for DAG node.

Differential Revision: D21634676

