### PR TITLE
Using Tensor instead of Tensor* in TensorMap

### DIFF
--- a/examples/resnet-verify.cpp
+++ b/examples/resnet-verify.cpp
@@ -66,9 +66,9 @@ public:
         {mod->uniqueType(ElemKind::FloatTy, {1, 3, 224, 224})}, *FI);
     auto hook = hookNode(FI, name);
     inferBindings.allocate(modI->getPlaceholders());
-    for (auto PH : bindings.pairs()) {
+    for (const auto &PH : bindings.pairs()) {
       auto iPH = inferBindings.getPlaceholderByNameSlow(PH.first->getName());
-      inferBindings.get(iPH)->assign(PH.second);
+      inferBindings.get(iPH)->assign(&PH.second);
     }
 
     std::list<Tensor *> outs;

--- a/include/glow/Graph/PlaceholderBindings.h
+++ b/include/glow/Graph/PlaceholderBindings.h
@@ -39,7 +39,7 @@ class Placeholder;
 class PlaceholderBindings final {
 public:
   /// Maps placeholders to the tensors that back them.
-  using PlaceholderMap = std::unordered_map<Placeholder *, Tensor *>;
+  using PlaceholderMap = std::unordered_map<Placeholder *, Tensor>;
   using PlaceholderMapIterator = PlaceholderMap::iterator;
 
 private:
@@ -56,18 +56,16 @@ public:
 
   /// \returns the tensor that corresponds to Placeholder \p P or Null if the
   /// tensor is not found.
-  Tensor *get(Placeholder *P) const;
+  Tensor *get(Placeholder *P);
+  const Tensor *get(Placeholder *P) const;
 
   /// \returns the Placeholder named \name or null of the Placeholder is not
   /// found. Note that this uses a linear search path. If you want to seatch by
   /// name more quickly, consider building a map yourself.
   Placeholder *getPlaceholderByNameSlow(llvm::StringRef name) const;
 
-  /// Inserts the Placeholder-Tensor pair.
-  void insert(Placeholder *P, Tensor &&T);
-
   /// Inserts the Placeholder-Tensor pair. This takes ownership of the Tensor.
-  PlaceholderMapIterator insert(Placeholder *P, Tensor *T);
+  PlaceholderMapIterator insert(Placeholder *P, Tensor &&T);
 
   /// Copy values from this PlaceholderBindings to another, \p dst, by \p name.
   /// This is useful when trained weights need to be transferred between
@@ -117,6 +115,7 @@ public:
   PlaceholderBindings clone(const PlaceholderList &newPHs) const;
 
   /// \returns the mapping between placeholder to tensors.
+  PlaceholderMap &pairs() { return map_; }
   const PlaceholderMap &pairs() const { return map_; }
 
   /// \returns the size in bytes of allocated Tensors owned by
@@ -125,8 +124,8 @@ public:
 
   /// Copies all Device Resident Tensors back to the host.
   void ensureOnHost() {
-    for (auto &ph : pairs()) {
-      ph.second->ensureOnHost();
+    for (auto &ph : map_) {
+      ph.second.ensureOnHost();
     }
   }
 

--- a/include/glow/Support/TensorPool.h
+++ b/include/glow/Support/TensorPool.h
@@ -17,6 +17,7 @@
 #define GLOW_TENSORPOOL_H
 
 #include "glow/Base/Tensor.h"
+#include "llvm/ADT/Optional.h"
 
 #include <atomic>
 #include <iostream>
@@ -36,7 +37,7 @@ private:
     bool operator()(const Type &a, const Type &b) const { return a.isEqual(b); }
   };
   /// A stack of available Tensors per Type.
-  std::unordered_map<Type, std::vector<Tensor *>, TypeHash, TypeEquals> pools_;
+  std::unordered_map<Type, std::vector<Tensor>, TypeHash, TypeEquals> pools_;
 
   /// Mutex around pools_;
   std::mutex lock_;
@@ -73,11 +74,11 @@ public:
   /// previously been added by initialize. If the pool is empty this will
   /// allocate a new Tensor unless preventAllocs was set true at construction
   /// time.
-  Tensor *get(TypeRef ty);
+  llvm::Optional<Tensor> get(TypeRef ty);
 
   /// Return a Tensor \p t to the pool. This Tensor must have been previously
   /// allocated by this TensorPool.
-  void reclaim(Tensor *t);
+  void reclaim(Tensor &&t);
 
   /// Add \p count elements of the provided type \p ty to the pool.
   void reserve(TypeRef ty, size_t count);

--- a/lib/Backends/Interpreter/InterpreterFunction.cpp
+++ b/lib/Backends/Interpreter/InterpreterFunction.cpp
@@ -206,7 +206,7 @@ Error BoundInterpreterFunction::execute(IRFunction *F,
     // Find all virtually padded tensors so they can be replaced.
     std::vector<Placeholder *> virtualPadded;
     for (auto &ph : context->getPlaceholderBindings()->pairs()) {
-      if (ph.second->getUnpaddedSizeInBytes() < ph.second->getSizeInBytes()) {
+      if (ph.second.getUnpaddedSizeInBytes() < ph.second.getSizeInBytes()) {
         virtualPadded.push_back(ph.first);
       }
     }
@@ -227,7 +227,7 @@ Error BoundInterpreterFunction::execute(IRFunction *F,
         continue;
       }
 
-      externalTensors_[w] = ph.second;
+      externalTensors_[w] = &ph.second;
     }
   }
 

--- a/lib/Backends/NNPI/InferenceContext.cpp
+++ b/lib/Backends/NNPI/InferenceContext.cpp
@@ -370,7 +370,7 @@ void InferenceContext::execute(RunIdentifierTy runId,
   std::unordered_set<Tensor *> partialTensorInputs;
   for (auto &pht : bindings.pairs()) {
     if (partialInputs_->count(pht.first)) {
-      partialTensorInputs.insert(pht.second);
+      partialTensorInputs.insert(&pht.second);
     }
   }
 

--- a/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
+++ b/lib/Backends/OpenCL/OpenCLDeviceManager.cpp
@@ -567,7 +567,7 @@ void OpenCLDeviceManager::copyInputsToDevice(
       (context->getTraceContext()->getTraceLevel() & TraceLevel::COPY);
 
   auto &symbolTable = runtimeBundle.getSymbolTable();
-  for (auto PH : context->getPlaceholderBindings()->pairs()) {
+  for (auto &PH : context->getPlaceholderBindings()->pairs()) {
     auto it = symbolTable.find(PH.first->getName());
     if (it == symbolTable.end()) {
       continue;
@@ -578,9 +578,9 @@ void OpenCLDeviceManager::copyInputsToDevice(
     }
     auto symbolInfo = it->second;
     auto addr = symbolInfo.offset;
-    auto numBytes = PH.second->getUnpaddedSizeInBytes();
+    auto numBytes = PH.second.getUnpaddedSizeInBytes();
     // Issue a non-blocking command to copy the buffer to the device.
-    auto buf = PH.second->getUnsafePtr();
+    auto buf = PH.second.getUnsafePtr();
     cl_event event{nullptr};
 
     cl_int err = clEnqueueWriteBuffer(
@@ -611,16 +611,16 @@ void OpenCLDeviceManager::copyOutputsFromDevice(
       (context->getTraceContext()->getTraceLevel() & TraceLevel::COPY);
 
   auto &symbolTable = runtimeBundle.getSymbolTable();
-  for (auto PH : context->getPlaceholderBindings()->pairs()) {
+  for (auto &PH : context->getPlaceholderBindings()->pairs()) {
     auto it = symbolTable.find(PH.first->getName());
     if (it == symbolTable.end()) {
       continue;
     }
     auto symbolInfo = it->second;
     auto addr = symbolInfo.offset;
-    auto numBytes = PH.second->getUnpaddedSizeInBytes();
+    auto numBytes = PH.second.getUnpaddedSizeInBytes();
     // Issue a non-blocking command to copy the buffer to the device.
-    auto buf = PH.second->getUnsafePtr();
+    auto buf = PH.second.getUnsafePtr();
     cl_event event{nullptr};
 
     cl_int err = clEnqueueReadBuffer(

--- a/lib/LLVMIRCodeGen/LLVMCompiledFunction.cpp
+++ b/lib/LLVMIRCodeGen/LLVMCompiledFunction.cpp
@@ -38,16 +38,16 @@ void LLVMCompiledFunction::loadPlaceholders(
 
   // Copy Placeholders into allocated memory.
   auto &symbolTable = runtimeBundle_.getSymbolTable();
-  for (auto PH : bindings->pairs()) {
+  for (auto &PH : bindings->pairs()) {
     auto it = symbolTable.find(PH.first->getName());
     if (it == symbolTable.end()) {
       continue;
     }
-    assert(!PH.second->isDeviceResident());
+    assert(!PH.second.isDeviceResident());
     auto symbolInfo = it->second;
-    auto payload = PH.second->getUnsafePtr();
+    auto payload = PH.second.getUnsafePtr();
     auto addr = symbolInfo.offset;
-    auto numBytes = PH.second->getUnpaddedSizeInBytes();
+    auto numBytes = PH.second.getUnpaddedSizeInBytes();
     // copy PH to allocated memory.
     memcpy(baseMutableWeightVarsAddress + addr, payload, numBytes);
   }
@@ -57,15 +57,15 @@ void LLVMCompiledFunction::updatePlaceholders(
     PlaceholderBindings *bindings, uint8_t *baseMutableWeightVarsAddress) {
   // Copy placeholders from device back into bindings.
   auto &symbolTable = runtimeBundle_.getSymbolTable();
-  for (auto PH : bindings->pairs()) {
+  for (auto &PH : bindings->pairs()) {
     auto it = symbolTable.find(PH.first->getName());
     if (it == symbolTable.end()) {
       continue;
     }
     auto symbolInfo = it->second;
     auto payload = baseMutableWeightVarsAddress + symbolInfo.offset;
-    auto numBytes = PH.second->getUnpaddedSizeInBytes();
-    auto addr = PH.second->getUnsafePtr();
+    auto numBytes = PH.second.getUnpaddedSizeInBytes();
+    auto addr = PH.second.getUnsafePtr();
     // copy PH from allocated memory.
     memcpy(addr, payload, numBytes);
   }

--- a/lib/Runtime/Executor/ExecutionState.cpp
+++ b/lib/Runtime/Executor/ExecutionState.cpp
@@ -81,8 +81,9 @@ void ExecutionState::init() {
           }
           // allocate into the resultBindings because they have the longest
           // lifetime.
-          resultBindings->insert(PH,
-                                 intermediateTensorPool_.get(PH->getType()));
+          auto opt = intermediateTensorPool_.get(PH->getType());
+          DCHECK(opt.hasValue());
+          resultBindings->insert(PH, std::move(opt.getValue()));
           intermediatePlaceholders_.push_back(PH);
         }
         // Check that provided context does not contain a static PH.

--- a/lib/Support/TensorPool/TensorPool.cpp
+++ b/lib/Support/TensorPool/TensorPool.cpp
@@ -18,7 +18,7 @@
 
 namespace glow {
 
-Tensor *TensorPool::get(TypeRef ty) {
+llvm::Optional<Tensor> TensorPool::get(TypeRef ty) {
   stats_.totalGets++;
 
   std::unique_lock<std::mutex> l(lock_);
@@ -27,16 +27,16 @@ Tensor *TensorPool::get(TypeRef ty) {
 
   if (it == pools_.end()) {
     if (preventInlineAllocs_) {
-      return nullptr;
+      return llvm::Optional<Tensor>();
     }
 
     stats_.totalTypes++;
-    it = pools_.emplace(*ty, std::vector<Tensor *>()).first;
+    it = pools_.emplace(*ty, std::vector<Tensor>()).first;
   }
 
   if (it->second.empty()) {
     if (preventInlineAllocs_) {
-      return nullptr;
+      return llvm::Optional<Tensor>();
     }
 
     // Don't need to alloc under the lock.
@@ -44,31 +44,31 @@ Tensor *TensorPool::get(TypeRef ty) {
     stats_.totalAllocs++;
     stats_.inlineAllocs++;
     // Don't add it to the queue because it's being claimed now.
-    return new Tensor(ty, this);
+    return Tensor(ty, this);
   }
 
   auto &queue = it->second;
-  Tensor *t = std::move(queue.back());
+  Tensor t = std::move(queue.back());
   queue.pop_back();
   stats_.currentBuffers--;
   return t;
 }
 
-void TensorPool::reclaim(Tensor *t) {
+void TensorPool::reclaim(Tensor &&t) {
   std::lock_guard<std::mutex> l(lock_);
-  auto it = pools_.find(t->getType());
+  auto it = pools_.find(t.getType());
   assert(it != pools_.end() && "Type has not been initialized");
   stats_.totalReclaims++;
   stats_.currentBuffers++;
-  it->second.push_back(t);
+  it->second.emplace_back(std::move(t));
 }
 
 void TensorPool::reserve(TypeRef ty, size_t count) {
-  std::vector<Tensor *> temp;
+  std::vector<Tensor> temp;
   temp.reserve(count);
   for (unsigned i = 0; i < count; ++i) {
     stats_.totalAllocs++;
-    temp.push_back(new Tensor(ty, this));
+    temp.emplace_back(ty, this);
   }
 
   {
@@ -78,7 +78,7 @@ void TensorPool::reserve(TypeRef ty, size_t count) {
       stats_.totalTypes++;
     }
 
-    std::vector<Tensor *> &queue = pools_[*ty];
+    std::vector<Tensor> &queue = pools_[*ty];
     std::move(temp.begin(), temp.end(), std::back_inserter(queue));
     stats_.currentBuffers += count;
   }
@@ -88,10 +88,7 @@ void TensorPool::clear() {
   std::lock_guard<std::mutex> l(lock_);
   for (auto &p : pools_) {
     stats_.currentBuffers -= p.second.size();
-    for (auto *t : p.second) {
-      delete t;
-      stats_.totalFrees++;
-    }
+    stats_.totalFrees += p.second.size();
     p.second.clear();
   }
   assert(stats_.currentBuffers == 0);

--- a/tests/unittests/DeviceManagerTest.cpp
+++ b/tests/unittests/DeviceManagerTest.cpp
@@ -200,14 +200,14 @@ TEST_P(DeviceManagerTest, PartialTensorCopy) {
 
   Tensor input1(ElemKind::FloatTy, {1});
   auto size = input->getType()->getSizeInBytes() / 2;
-  Tensor *virtualPaddedInput =
-      new Tensor(input1.getUnsafePtr(), input->getType(), size);
+  Tensor virtualPaddedInput(input1.getUnsafePtr(), input->getType(), size);
 
   Tensor output1(ElemKind::FloatTy, {1});
   input1.getHandle().clear(0.5);
   output1.getHandle().clear(std::max(std::tanh(0.5), 0.25));
 
-  context->getPlaceholderBindings()->insert(input, virtualPaddedInput);
+  context->getPlaceholderBindings()->insert(input,
+                                            std::move(virtualPaddedInput));
   std::promise<std::unique_ptr<ExecutionContext>> runPromise;
   std::future<std::unique_ptr<ExecutionContext>> runFuture;
 

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -119,7 +119,7 @@ protected:
       Placeholder *inputPH =
           loadedMod.getPlaceholderByNameSlow(p.first->getName());
       ASSERT_TRUE(inputPH);
-      loadedBindings.insert(inputPH, p.second->getUnowned(inputPH->dims()));
+      loadedBindings.insert(inputPH, p.second.getUnowned(inputPH->dims()));
     }
 
     // Allocate all other PHs/tensors that need it (i.e. result PHs/tensors).
@@ -138,7 +138,7 @@ protected:
       if (!isOutput(resultPH, *F_)) {
         continue;
       }
-      const Tensor *resultT = p.second;
+      const Tensor &resultT = p.second;
 
       // Find the result PH by the same name in the loaded Function.
       Placeholder *loadedResultPH =
@@ -146,7 +146,7 @@ protected:
       ASSERT_TRUE(loadedResultPH);
       const Tensor *loadedResultT = loadedBindings.get(loadedResultPH);
 
-      EXPECT_TRUE(resultT->isBitwiseEqual(*loadedResultT, /* verbose */ true));
+      EXPECT_TRUE(resultT.isBitwiseEqual(*loadedResultT, /* verbose */ true));
     }
 
     llvm::sys::fs::remove(pathToModel);

--- a/tests/unittests/RecommendationSystemTest.cpp
+++ b/tests/unittests/RecommendationSystemTest.cpp
@@ -893,7 +893,7 @@ protected:
     bindings.clear();
     bindings.allocate(rawModule->getPlaceholders());
     bindingsP.allocate(rawModule->getPlaceholders());
-    for (auto PH : bindingsP.pairs()) {
+    for (const auto &PH : bindingsP.pairs()) {
       bindingsP.copyToTarget(PH.first->getName(), bindings);
     }
 

--- a/tests/unittests/Repro.cpp
+++ b/tests/unittests/Repro.cpp
@@ -639,10 +639,9 @@ int run() {
     results.emplace_back(InferenceResult());
     auto &result = results.back();
 
-    threadPool.add([&inputBindings, &nonStaticPlaceholderList, ioIndex,
-                    &mergedTraceContext, &hostManager, &result, &cv, &mutex,
-                    numTotalInferences, &numFinishedInferences,
-                    runAccuracyChecks]() {
+    threadPool.add([&inputBindings, ioIndex, &mergedTraceContext, &hostManager,
+                    &result, &cv, &mutex, numTotalInferences,
+                    &numFinishedInferences, runAccuracyChecks]() {
       // Setup the inputs.
       auto ctx = glow::make_unique<ExecutionContext>();
 
@@ -659,12 +658,10 @@ int run() {
       // Set up input
       auto &bindings = *ctx->getPlaceholderBindings();
       bindings.clear();
-      bindings.allocate(nonStaticPlaceholderList);
 
-      for (auto &binding : inputBindings[ioIndex].pairs()) {
-        auto PH = binding.first;
-        auto resultTensor = binding.second;
-        bindings.update(PH, resultTensor->getUnowned());
+      for (const auto &binding : inputBindings[ioIndex].pairs()) {
+        auto *PH = binding.first;
+        bindings.insert(PH, binding.second.getUnowned());
       }
 
       std::promise<void> promise;

--- a/tests/unittests/ThreadPoolExecutorTest.cpp
+++ b/tests/unittests/ThreadPoolExecutorTest.cpp
@@ -89,7 +89,7 @@ public:
           equalInputs = false;
           break;
         }
-        equalInputs &= p.second->isEqual(*CT, 0.0001, true);
+        equalInputs &= p.second.isEqual(*CT, 0.0001, true);
       }
 
       if (equalInputs) {
@@ -99,9 +99,10 @@ public:
         runId = registeredResult->runId;
         successResult = registeredResult->success;
 
-        for (auto p : registeredResult->resultContext->getPlaceholderBindings()
-                          ->pairs()) {
-          context->getPlaceholderBindings()->get(p.first)->assign(p.second);
+        for (const auto &p :
+             registeredResult->resultContext->getPlaceholderBindings()
+                 ->pairs()) {
+          context->getPlaceholderBindings()->get(p.first)->assign(&p.second);
         }
       }
     }

--- a/tools/Debugger/NetworkComparator.cpp
+++ b/tools/Debugger/NetworkComparator.cpp
@@ -96,7 +96,7 @@ NetworkComparatorBase::InOutTensors RecursiveLayerComparator::hookAndRun(
   // we feed to the Temp network.
   for (auto &PH : bindings->pairs()) {
     auto iPH = inferBindings.getPlaceholderByNameSlow(PH.first->getName());
-    inferBindings.get(iPH)->assign(PH.second);
+    inferBindings.get(iPH)->assign(&PH.second);
   }
   InOutTensors inOutTensors;
   for (const auto &P : hook.outputs) {
@@ -188,9 +188,9 @@ void IntermediateLayerComparator::hookNodesInPlace(
 void IntermediateLayerComparator::copyInputBindingsToHookedBindings(
     PlaceholderBindings &hookedBindigs, PlaceholderBindings &inputBindings) {
   // Copy tensors from input bindings to the bindings we use for Inference.
-  for (auto PH : inputBindings.pairs()) {
+  for (auto &PH : inputBindings.pairs()) {
     auto iPH = hookedBindigs.getPlaceholderByNameSlow(PH.first->getName());
-    hookedBindigs.get(iPH)->assign(PH.second);
+    hookedBindigs.get(iPH)->assign(&PH.second);
   }
 }
 


### PR DESCRIPTION
Summary:
In TensorPool and PlaceholderBinding, we used to have a map which has value of Tensor*, which works but is not ideal because:
1. Using Tensor* needs explicit `delete` which isn't very appealing.
2. Sometimes, when input is Tensor&&, we need to create a new Tensor just to create Tenor*.

Proposed change here just use Tensor and rely on move constructor to maintain the ownership. It seems cleaner this way.

Differential Revision: D21636297

