### PR TITLE
remove unnecessary header - unbreak torch_glow build

### DIFF
--- a/torch_glow/src/CMakeLists.txt
+++ b/torch_glow/src/CMakeLists.txt
@@ -61,7 +61,8 @@ target_link_libraries(_torch_glow
                         PyTorchModelLoader
                         TorchGlowTraining
                         Backends
-                        pybind11)
+                        pybind11
+                        torch_python)
 
 target_include_directories(PyTorchModelLoader PUBLIC
                             ${PYTORCH_DIR}/include)

--- a/torch_glow/src/TorchGlowBackend.h
+++ b/torch_glow/src/TorchGlowBackend.h
@@ -3,7 +3,6 @@
 #define GLOW_TORCH_GLOW_BACKEND_H
 
 #include "CachingGraphRunner.h"
-#include <torch/csrc/jit/api/module.h>
 #include <torch/csrc/jit/backends/backend_interface.h>
 
 namespace glow {


### PR DESCRIPTION
Summary: Removing this header which causes torch_glow CI to break

Differential Revision: D21643530

