### PR TITLE
[Importer] Add logic for wrapping negative axes.

### DIFF
--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -392,7 +392,8 @@ protected:
     // softmax function. This is similar to a bitcast operation.
     int axis = 1;
     if (dict.count("axis")) {
-      ASSIGN_VALUE_OR_RETURN_ERR(axis, loadInt(dict["axis"]));
+      ASSIGN_VALUE_OR_RETURN_ERR(axis,
+                                 loadAxis<int>(dict["axis"], in.dims().size()));
     }
 
     auto *FN = G_->createFlatten("reshapeInput", in, axis);
@@ -604,7 +605,8 @@ protected:
     ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
     size_t axis = 0;
     if (dict.count("axis")) {
-      ASSIGN_VALUE_OR_RETURN_ERR(axis, loadInt(dict["axis"]));
+      ASSIGN_VALUE_OR_RETURN_ERR(
+          axis, loadAxis<size_t>(dict["axis"], in.dims().size()));
     }
 
     std::vector<dim_t> split;
@@ -722,7 +724,8 @@ protected:
     ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
     int axis = 1;
     if (dict.count("axis")) {
-      ASSIGN_VALUE_OR_RETURN_ERR(axis, loadInt(dict["axis"]));
+      ASSIGN_VALUE_OR_RETURN_ERR(axis,
+                                 loadAxis<int>(dict["axis"], in.dims().size()));
     }
     auto *node = G_->createFlatten(opName, in, axis);
     RETURN_IF_ERR(addNodeAsOutput(op, node));
@@ -779,13 +782,11 @@ protected:
       ASSIGN_VALUE_OR_RETURN_ERR(k, loadInt(dict["k"]));
     }
 
-    int axis = -1;
-    if (dict.count("axis")) {
-      ASSIGN_VALUE_OR_RETURN_ERR(axis, loadInt(dict["axis"]));
-    }
     int lastDim = in.dims().size() - 1;
-    if (axis == -1) {
-      axis = lastDim;
+    int axis = lastDim;
+    if (dict.count("axis")) {
+      ASSIGN_VALUE_OR_RETURN_ERR(axis,
+                                 loadAxis<int>(dict["axis"], in.dims().size()));
     }
 
     RETURN_ERR_IF_NOT(axis == lastDim,
@@ -804,7 +805,8 @@ protected:
 
     std::vector<unsigned_t> shapeAxes = {};
     if (dict.count("axes")) {
-      ASSIGN_VALUE_OR_RETURN_ERR(shapeAxes, getShape<unsigned_t>(dict["axes"]));
+      ASSIGN_VALUE_OR_RETURN_ERR(
+          shapeAxes, loadAxes<unsigned_t>(dict["axes"], in.dims().size()));
     } else {
       shapeAxes.resize(in.dims().size());
       std::iota(shapeAxes.begin(), shapeAxes.end(), 0);
@@ -1082,7 +1084,8 @@ protected:
 
     if (dict.count("axis")) {
       int axis;
-      ASSIGN_VALUE_OR_RETURN_ERR(axis, loadInt(dict.find("axis")->second));
+      ASSIGN_VALUE_OR_RETURN_ERR(
+          axis, loadAxis<int>(dict.find("axis")->second, data.dims().size()));
       if (axis != 0 && axis != 1) {
         RETURN_ERR("Axis must be 0 or 1.");
       }

--- a/include/glow/Importer/ProtobufLoader.h
+++ b/include/glow/Importer/ProtobufLoader.h
@@ -142,8 +142,8 @@ Expected<int> getPositiveAxis(int axis, int rank);
 
 /// Reads a single axis parameter which is wrapped if negative using \p rank
 /// based on the logic of \ref getPositiveAxis.
-template <typename ElemTy, typename T> static
-Expected<ElemTy> loadAxis(const T *arg, int rank) {
+template <typename ElemTy, typename T>
+static Expected<ElemTy> loadAxis(const T *arg, int rank) {
   int axis;
   ASSIGN_VALUE_OR_RETURN_ERR(axis, loadInt(arg));
   ASSIGN_VALUE_OR_RETURN_ERR(axis, getPositiveAxis(axis, rank));
@@ -152,12 +152,12 @@ Expected<ElemTy> loadAxis(const T *arg, int rank) {
 
 /// Reads multiple axes as an array which are wrapped if negative using \p rank
 /// based on the logic of \ref getPositiveAxis.
-template <typename ElemTy, typename T> static
-Expected<std::vector<ElemTy>> loadAxes(const T *arg, int rank) {
+template <typename ElemTy, typename T>
+static Expected<std::vector<ElemTy>> loadAxes(const T *arg, int rank) {
   std::vector<int> axes;
   ASSIGN_VALUE_OR_RETURN_ERR(axes, getShape<int>(arg));
   std::vector<ElemTy> axesPos;
-  for (const int &axis: axes) {
+  for (const int &axis : axes) {
     int axisPos;
     ASSIGN_VALUE_OR_RETURN_ERR(axisPos, getPositiveAxis(axis, rank));
     axesPos.push_back(static_cast<ElemTy>(axisPos));

--- a/include/glow/Importer/ProtobufLoader.h
+++ b/include/glow/Importer/ProtobufLoader.h
@@ -131,6 +131,40 @@ template <typename T> std::string loadOperatorName(const T &op) {
   return op.op_type();
 }
 
+/// \returns the positive value (modulo) of \p axis given the \p rank (number
+/// of dimensions) of the tensor it refers to. The proto format allows negative
+/// axis in which case the axis is used for counting dimensions from the back.
+/// Since Glow cannot use a negative axis we use this converter utility. For
+/// example an axis value of -1 for a tensor with 3 dimensions (rank 3) is
+/// converted to 2. A good definition of the axis value requires to be in the
+/// range [rank, rank-1].
+Expected<int> getPositiveAxis(int axis, int rank);
+
+/// Reads a single axis parameter which is wrapped if negative using \p rank
+/// based on the logic of \ref getPositiveAxis.
+template <typename ElemTy, typename T> static
+Expected<ElemTy> loadAxis(const T *arg, int rank) {
+  int axis;
+  ASSIGN_VALUE_OR_RETURN_ERR(axis, loadInt(arg));
+  ASSIGN_VALUE_OR_RETURN_ERR(axis, getPositiveAxis(axis, rank));
+  return static_cast<ElemTy>(axis);
+}
+
+/// Reads multiple axes as an array which are wrapped if negative using \p rank
+/// based on the logic of \ref getPositiveAxis.
+template <typename ElemTy, typename T> static
+Expected<std::vector<ElemTy>> loadAxes(const T *arg, int rank) {
+  std::vector<int> axes;
+  ASSIGN_VALUE_OR_RETURN_ERR(axes, getShape<int>(arg));
+  std::vector<ElemTy> axesPos;
+  for (const int &axis: axes) {
+    int axisPos;
+    ASSIGN_VALUE_OR_RETURN_ERR(axisPos, getPositiveAxis(axis, rank));
+    axesPos.push_back(static_cast<ElemTy>(axisPos));
+  }
+  return axesPos;
+}
+
 /// Loads model: graph and weights.
 class ProtobufLoader {
 protected:

--- a/include/glow/Importer/ProtobufLoader.h
+++ b/include/glow/Importer/ProtobufLoader.h
@@ -157,7 +157,7 @@ static Expected<std::vector<ElemTy>> loadAxes(const T *arg, int rank) {
   std::vector<int> axes;
   ASSIGN_VALUE_OR_RETURN_ERR(axes, getShape<int>(arg));
   std::vector<ElemTy> axesPos;
-  for (const int &axis : axes) {
+  for (int axis : axes) {
     int axisPos;
     ASSIGN_VALUE_OR_RETURN_ERR(axisPos, getPositiveAxis(axis, rank));
     axesPos.push_back(static_cast<ElemTy>(axisPos));

--- a/lib/Importer/ProtobufLoader.cpp
+++ b/lib/Importer/ProtobufLoader.cpp
@@ -35,6 +35,16 @@ bool isArrayConstant(llvm::ArrayRef<size_t> a) {
   return true;
 }
 
+Expected<int> getPositiveAxis(int axis, int rank) {
+  RETURN_ERR_IF_NOT(-rank <= axis, "Axis parameter invalid!");
+  RETURN_ERR_IF_NOT(axis < rank, "Axis parameter invalid!");
+  int axisPos = axis % rank;
+  if (axisPos < 0) {
+    axisPos += rank;
+  }
+  return axisPos;
+}
+
 void setConstantFoldLoaderOpsFlag(bool flag) { isConstFoldLoaderOps = flag; }
 
 bool getConstantFoldLoaderOpsFlag() { return isConstFoldLoaderOps; }

--- a/lib/Importer/ProtobufLoader.cpp
+++ b/lib/Importer/ProtobufLoader.cpp
@@ -36,13 +36,11 @@ bool isArrayConstant(llvm::ArrayRef<size_t> a) {
 }
 
 Expected<int> getPositiveAxis(int axis, int rank) {
-  RETURN_ERR_IF_NOT(-rank <= axis, "Axis parameter invalid!");
-  RETURN_ERR_IF_NOT(axis < rank, "Axis parameter invalid!");
-  int axisPos = axis % rank;
-  if (axisPos < 0) {
-    axisPos += rank;
-  }
-  return axisPos;
+  RETURN_ERR_IF_NOT(
+      (-rank <= axis) && (axis < rank),
+      strFormat("Axis value %d is invalid! Should be in the range [%d, %d]!",
+                axis, -rank, rank - 1));
+  return (axis < 0) ? axis + rank : axis;
 }
 
 void setConstantFoldLoaderOpsFlag(bool flag) { isConstFoldLoaderOps = flag; }

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -232,6 +232,23 @@ static void importReduceL2Test(const std::string &netFilename,
   }
 }
 
+/// Test the utility function which wraps a negative axis.
+TEST_F(OnnxImporterTest, getPositiveAxis) {
+  int axisPos;
+  ASSIGN_VALUE_OR_FAIL_TEST(axisPos, getPositiveAxis(-3, 3));
+  EXPECT_EQ(axisPos, 0);
+  ASSIGN_VALUE_OR_FAIL_TEST(axisPos, getPositiveAxis(-2, 3));
+  EXPECT_EQ(axisPos, 1);
+  ASSIGN_VALUE_OR_FAIL_TEST(axisPos, getPositiveAxis(-1, 3));
+  EXPECT_EQ(axisPos, 2);
+  ASSIGN_VALUE_OR_FAIL_TEST(axisPos, getPositiveAxis(0, 3));
+  EXPECT_EQ(axisPos, 0);
+  ASSIGN_VALUE_OR_FAIL_TEST(axisPos, getPositiveAxis(1, 3));
+  EXPECT_EQ(axisPos, 1);
+  ASSIGN_VALUE_OR_FAIL_TEST(axisPos, getPositiveAxis(2, 3));
+  EXPECT_EQ(axisPos, 2);
+}
+
 /// Test loading reduceL2 op from an ONNX model
 /// with axes = [].
 TEST_F(OnnxImporterTest, reduceL2NoAxis) {


### PR DESCRIPTION
**Summary**
Add logic for wrapping negative axes for some operators (e.g. Softmax, Slice, Concat, Squeeze, etc) since the proto format allows it but Glow does not handle properly negative axes.

**Fixes**
#4004

**Test Plan**
Current tests are passing.
Added unit test for the utility function.

