### PR TITLE
Add preventConstantModification option, swapping in PHs for Constants for compilation

### DIFF
--- a/include/glow/Exporter/ONNXModelWriter.h
+++ b/include/glow/Exporter/ONNXModelWriter.h
@@ -19,6 +19,7 @@
 
 #include "glow/Exporter/CommonOperatorWriter.h"
 #include "glow/Graph/Graph.h"
+#include "glow/Optimizer/GraphOptimizer/GraphOptimizer.h"
 #include "glow/Runtime/RuntimeTypes.h"
 
 #include "onnx/onnx_pb.h"
@@ -52,6 +53,10 @@ class ONNXModelWriter : public CommonOperatorWriter<ONNX_TRAITS> {
   ONNX_NAMESPACE::ModelProto modelProto_;
   // GraphProto that we are writing to.
   ONNX_TRAITS::GraphProto *graphProto_;
+  // Root GraphProto that we are writing to. Equal to \ref graphProto_ unless
+  // when writing a constant folding subgraph, when graphProto_ is temporarily
+  // changed.
+  ONNX_TRAITS::GraphProto *graphProtoRoot_;
   /// Current IR version of ONNX.
   const size_t irVersion_;
   /// Current version of ONNX standard.
@@ -68,11 +73,16 @@ class ONNXModelWriter : public CommonOperatorWriter<ONNX_TRAITS> {
   const bool useGlowCustomOps_;
   /// Whether we are writing a DAG.
   const bool dagMode_;
+  /// A map containing a record of what constant folding took place, to record
+  /// in serialized DAGs.
+  const ConstantFoldingRecordMap &constFoldRecord_;
   /// A dedicated list of initializers in case the tensors get too big and don't
   /// fit into the model.
   std::list<TensorType> initializers_;
   /// Holds all Functions from a DAG that are being written when in dagMode_.
   llvm::SmallSet<Function *, 6> functionsFromDAG_;
+  /// Holds all constant folding Functions that have been processed.
+  llvm::SmallSet<Function *, 6> processedConstFoldFunctions_;
   /// Writes tensor shape from placeholder \p PH into protpbuf \p valueProto.
   void tensorShapeFromPlaceholder(const Placeholder *PH,
                                   ValueInfoType *valueProto);
@@ -104,6 +114,15 @@ class ONNXModelWriter : public CommonOperatorWriter<ONNX_TRAITS> {
   /// Write the current Function \ref F_ to \ref graphProto_. \returns if there
   /// was an issue during iteration or writing.
   Error writeFunction();
+
+  /// Given a Constant \p C that was previously created during Constant folding,
+  /// Serializes the constant folding Function saved by \p SN, where the
+  /// Function is the parent of \p SN. The function is written to an attribute
+  /// in a Glow__ConstFoldSubgraph NodeProto. \returns if an Error occurs.
+  Error writeConstantFoldingSubgraph(const Constant *C, SaveNode *SN);
+
+  /// \returns whether currently writing a constant folding subgraph.
+  bool isWritingConstFoldSubgraph();
 
   /// Finalize the written function and write it out to \p filename. \returns if
   /// there is an error encountered.
@@ -144,11 +163,15 @@ public:
   /// to abide by the official ONNX ops. If \p includeConstantData then data for
   /// Constants will be serialized in the written model, otherwise it will be
   /// skipped (but initializers will still exist, they will just have no data).
+  /// \p constFoldRecord contains any records of constant folding that should be
+  /// included in the serialized model.
   ONNXModelWriter(const std::string &modelFilename, Function &F,
                   size_t irVersion, size_t opsetVersion,
                   Error *errPtr = nullptr, bool textMode = false,
                   bool zipMode = false, bool useGlowCustomOps = false,
-                  bool includeConstantData = true);
+                  bool includeConstantData = true,
+                  const ConstantFoldingRecordMap &constFoldRecord =
+                      ConstantFoldingRecordMap());
 
   /// Creates an ONNX model writer to serialize \p dagList into file
 
@@ -162,11 +185,15 @@ public:
   /// TensorProto file along with the model file and package them into a zip
   /// file. If \p includeConstantData then data for Constants will be serialized
   /// in the written model, otherwise it will be skipped (but initializers will
-  /// still exist, they will just have no data).
+  /// still exist, they will just have no data). \p constFoldRecord contains any
+  /// records of constant folding that should be included in the serialized
+  /// model.
   ONNXModelWriter(const std::string &modelFilename, runtime::DAGListTy &dagList,
                   size_t irVersion, size_t opsetVersion,
                   Error *errPtr = nullptr, bool textMode = false,
-                  bool zipMode = false, bool includeConstantData = true);
+                  bool zipMode = false, bool includeConstantData = true,
+                  const ConstantFoldingRecordMap &constFoldRecord =
+                      ConstantFoldingRecordMap());
 
 private:
   /// \returns error for the unexpected node kind.

--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -364,6 +364,7 @@ constexpr char saveNameSignifier[] = "saveName";
 constexpr char qScaleSignifier[] = "qScale";
 constexpr char qOffsetSignifier[] = "qOffset";
 constexpr char shapeSignifier[] = "shape";
+constexpr char constFoldSubgraphNodeName[] = "Glow__ConstFoldSubgraph";
 
 /// \returns the string ID for a type attribute property for a specific \p ioNum
 /// and \p signifier and whether \p isInput. E.g. to retrieve result number 0's

--- a/include/glow/Importer/ONNXModelLoader.h
+++ b/include/glow/Importer/ONNXModelLoader.h
@@ -123,6 +123,9 @@ class ONNXModelLoader
   /// A set of inputs which will be static placeholders.
   std::unordered_set<std::string> staticInputs_;
 
+  /// A set of Functions used for ConstantFolding to be deleted after loading.
+  std::unordered_set<Function *> constFoldFuns_;
+
   /// Load ONNX NonZero Operator.
   /// Glow's requirement for static shapes results in required Constant
   /// input. Thus, the operator will be folded in the Importer.
@@ -383,9 +386,11 @@ class ONNXModelLoader
                  ArgumentDictionaryTy &dict);
 
 protected:
-  /// Load the network operators from the GraphProto.
+  /// Loads operators from \p net. If \p loadingConstFoldSubgraph then the
+  /// current Function \ref G_ is assumed to be the one to load into.
   /// \returns Error if network cannot be loaded.
-  Error loadNetwork(ONNX_NAMESPACE::GraphProto &net);
+  Error loadNetwork(ONNX_NAMESPACE::GraphProto &net,
+                    bool loadingConstFoldSubgraph);
 
   /// Set the output nodes of the network \p net. Initializes the map from the
   /// names of the outputs to the save nodes that save each output.
@@ -402,6 +407,19 @@ protected:
 
   /// Load the network initializers from the GraphProto.
   Error loadInitializers(ONNX_NAMESPACE::GraphProto &net);
+
+  /// Given some initializer \p in, check if it has some constant folding node
+  /// associated with it in \p net. If so, deserializes the Function if not
+  /// already done, performs the constant folding, and \returns the Constant
+  /// created as a result to be used for this initializer.
+  Expected<Constant *>
+  replaySerializedConstFold(const ONNX_NAMESPACE::TensorProto &in,
+                            ONNX_NAMESPACE::GraphProto &net);
+
+  /// Given some \p outputName that maps to a NodeValue that we want to constant
+  /// fold, run it and assign the resulting Constant \p initializerName.
+  Expected<Constant *> runDeserializedConstFold(llvm::StringRef initializerName,
+                                                llvm::StringRef outputName);
 
   /// Load the inputs from the GraphProto. If \p loadInputsAsPlaceholdersForOnnx
   /// is true then this will load each graph input as a placeholder otherwise it
@@ -474,6 +492,9 @@ protected:
   Error setupPartitions(ONNX_NAMESPACE::ModelProto &modelDef,
                         runtime::PrePartitionedConfig &PPC,
                         llvm::StringRef rootName, int numPartitions);
+
+  /// Deletes the Functions in \ref constFoldFuns_ from \ref mod_.
+  void deleteConstFoldFunctions();
 
 public:
   /// \returns ONNX model ir_version;

--- a/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
+++ b/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
@@ -89,6 +89,12 @@ struct OptimizationOptions {
   /// If true, perform compile-time computation of constant operations.
   bool enableConstantFolding{true};
 
+  /// If true, before any Function optimization, all the Constants will be
+  /// temporarily replaced by Placeholders, preventing the Constants from being
+  /// modified. The original Constants will be put back in place automatically
+  /// afterward, and then Constant Folding will be run.
+  bool preventConstantModification{false};
+
   /// If true, this will merge ConvertTo and Quantize nodes into inputs and
   /// outputs of the Function. This means modifying the types of Placeholders
   /// and SaveNodes if they have a corresponding ElemKind conversion (ConvertTo,
@@ -237,6 +243,16 @@ struct CompilationContext {
     case QuantizationMode::None:
       break;
     }
+
+    RETURN_ERR_IF_NOT(!(optimizationOpts.foldElemKindConversionIntoIO &&
+                        optimizationOpts.preventConstantModification),
+                      "Cannot currently perform elem kind merging into PHs "
+                      "when also preventing constant modification.");
+
+    RETURN_ERR_IF_NOT(!(serializeCompiledDAG &&
+                        !optimizationOpts.preventConstantModification),
+                      "When serializing the compiled DAG, must also enable "
+                      "preventConstantModification.");
 
     return Error::success();
   }

--- a/include/glow/Support/Support.h
+++ b/include/glow/Support/Support.h
@@ -240,7 +240,9 @@ void vectorReorder(std::vector<T> &v, std::vector<size_t> const &order) {
 class ScopeGuard {
   /// Function to call when the destructor is called.
   std::function<void()> endFun_;
-  /// Whether the guard has been dismissed..
+
+protected:
+  /// Whether the guard has been dismissed.
   bool dismissed_{false};
 
 public:

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -507,8 +507,13 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
         return false;
       }
     };
-    return isConversionSupportedFor(NI.getInElemTy(ConvertToNode::InputIdx)) &&
-           isConversionSupportedFor(NI.getOutElemTy(ConvertToNode::ResultIdx));
+    return (isConversionSupportedFor(NI.getInElemTy(ConvertToNode::InputIdx)) &&
+            isConversionSupportedFor(
+                NI.getOutElemTy(ConvertToNode::ResultIdx))) ||
+           (NI.getInElemTy(ConvertToNode::InputIdx) ==
+                ElemKind::UInt8FusedQTy &&
+            NI.getOutElemTy(ConvertToNode::ResultIdx) ==
+                ElemKind::UInt8FusedFP16QTy);
   }
 
   case Kinded::Kind::TopKNodeKind:

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -4519,6 +4519,12 @@ void BoundInterpreterFunction::fwdConvertToInst(const glow::ConvertToInst *I) {
   CONVERT(int64_t, float16_t, ElemKind::Int64ITy, ElemKind::Float16Ty)
   CONVERT(int64_t, int32_t, ElemKind::Int64ITy, ElemKind::Int32ITy)
 #undef CONVERT
+
+  if (srcElType == ElemKind::UInt8FusedQTy &&
+      destElType == ElemKind::UInt8FusedFP16QTy) {
+    dest->convertToType(ElemKind::UInt8FusedFP16QTy);
+    return;
+  }
   llvm_unreachable("Type not supported");
 }
 

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -69,6 +69,35 @@ static bool shouldDeleteNode(Node *N) {
   return true;
 }
 
+ConstantModificationPreventer::ConstantModificationPreventer(Module &mod)
+    : ScopeGuard([&]() {
+        // Ensure we cleanup Placeholder-Constant swap if necessary.
+        auto &PHs = mod_.getPlaceholders();
+        for (auto &pair : tmpPHToConstMap_) {
+          Placeholder *tmpPH = pair.first;
+          Constant *C = pair.second;
+          tmpPH->getOutput().replaceAllUsesOfWith(C->getOutput());
+          mod_.erasePlaceholder(std::find(PHs.begin(), PHs.end(), tmpPH));
+        }
+      }),
+      mod_(mod) {
+  // By default dismiss until explicitly activated.
+  dismissed_ = true;
+}
+
+void ConstantModificationPreventer::activate() {
+  dismissed_ = false;
+  // Prevent Constant modification by temporarily replacing them with PHs.
+  for (Constant *C : mod_.getConstants()) {
+    Placeholder *tmpPH = mod_.createPlaceholder(
+        C->getType(), C->getName().str() + "_SWAP_CONST_FOLD",
+        /* isTrainable */ false, C->getLayout());
+    tmpPH->setStatic(true);
+    tmpPHToConstMap_[tmpPH] = C;
+    C->getOutput().replaceAllUsesOfWith(tmpPH->getOutput());
+  }
+}
+
 /// Helper that \returns whether all sibling Functions of \p F (other Functions
 /// inside its Module) are Loaded.
 static bool shouldDeleteConstants(Function *F) {
@@ -168,6 +197,12 @@ bool DCE::run(Function *F, const CompilationContext &cctx) {
     if (!changedLocally) {
       break;
     }
+  }
+
+  // Don't remove unused Constants since many may be temporarily unused during
+  // optimizations.
+  if (cctx.optimizationOpts.preventConstantModification) {
+    return changed;
   }
 
   if (!shouldDeleteConstants(F)) {
@@ -4804,8 +4839,11 @@ Error glow::optimizeFunction(Function *F, const Backend &B,
 
   // We already started using backend specific verification when the function
   // state became lowered. Do one more verification pass to make sure everything
-  // is in order and to bail if it is not.
-  if (!B.verify(*F, cctx.verboseCompile)) {
+  // is in order and to bail if it is not. Only do so if we are allowing
+  // constant modification, as otherwise we may have prevent a backend from
+  // supporting some Nodes. Expect the caller to verify later on in such cases.
+  if (!cctx.optimizationOpts.preventConstantModification &&
+      !B.verify(*F, cctx.verboseCompile)) {
     return MAKE_ERR(
         ErrorValue::ErrorCode::COMPILE_UNSUPPORTED_NODE_AFTER_OPTIMIZE,
         "Unsupported node(s) found after optimizing Function " +

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -192,6 +192,14 @@ Error HostManager::addNetwork(std::unique_ptr<Module> module,
     }
   });
 
+  /// If specified in the cctx, this will prevent Constants from being modified
+  /// until the current scope ends or the preventer is dismissed. Does so by
+  /// swapping in temporary Placeholders instead of Constants.
+  ConstantModificationPreventer constModPreventer(*module);
+  if (cctx.optimizationOpts.preventConstantModification) {
+    constModPreventer.activate();
+  }
+
   std::vector<std::string> names;
   {
     std::unique_lock<std::shared_timed_mutex> networkLock(networkLock_);
@@ -282,31 +290,6 @@ Error HostManager::addNetwork(std::unique_ptr<Module> module,
     return result.takeError();
   }
 
-  // If requested, serialize the resulting DAG that was just optimized and
-  // partitioned.
-  if (cctx.serializeCompiledDAG) {
-    std::string loc = nodeList.begin()->root->name + ".zip";
-    LOG(INFO) << "Serializing DAG to " << loc;
-    {
-      Error writeErr = Error::empty();
-      ONNXModelWriter onnxWR(loc, nodeList, 7, 9, &writeErr,
-                             /* textMode */ false, /* zipMode */ true);
-      RETURN_IF_ERR(writeErr);
-    }
-  }
-
-#if FACEBOOK_INTERNAL
-  if (cctx.callDAGOptimizer) {
-    auto optDagErr =
-        optimizeDAG(nodeList, *provisioner_, *module, deviceInfo, cctx);
-    if (optDagErr) {
-      std::unique_lock<std::shared_timed_mutex> networkLock(networkLock_);
-      cleanupAddNetwork(names);
-      return optDagErr;
-    }
-  }
-#endif /* FACEBOOK_INTERNAL */
-
   if (cctx.precisionConfig.quantMode == QuantizationMode::Profile) {
     // Since for profiling the provisioner will be reset, we only allow one
     // network in one HM.
@@ -328,6 +311,63 @@ Error HostManager::addNetwork(std::unique_ptr<Module> module,
     provisioner_.reset(new Provisioner(devices_));
     executor_.reset(new ThreadPoolExecutor(devices_, config_.executorThreads));
   }
+
+  // If we prevented constant modification then run constant folding with
+  // recording now. Record so that if we are going to serialize we can embed the
+  // constant folding subgraphs in the Glow ONNX model.
+  ConstantFoldingRecordMap record;
+  if (cctx.optimizationOpts.preventConstantModification) {
+    constModPreventer.deactivateAndCleanup();
+
+    RETURN_ERR_IF_NOT(nodeList.size() == 1, "Expect only one DAG.");
+    const auto &dag = *nodeList.begin();
+    for (auto &dagNode : dag.nodes) {
+      Function *F = module->getFunction(dagNode->name);
+      RETURN_ERR_IF_NOT(
+          F, strFormat("Function %s not found", dagNode->name.data()));
+
+      ConstantFoldingRecordMap currRecord = constantFoldAndRecord(F, cctx);
+      record.insert(currRecord.begin(), currRecord.end());
+      runDCEPass(F, cctx);
+
+      // Verify the Function is valid after constant folding takes place.
+      Backend &B = provisioner_->getBackend(dagNode->backendName);
+      RETURN_ERR_IF_NOT(B.verify(*F, cctx.verboseCompile),
+                        "Unsupported node(s) found after optimizing Function " +
+                            F->getName().str() + " for backend " +
+                            B.getBackendName());
+    }
+  }
+
+#if FACEBOOK_INTERNAL
+  if (cctx.callDAGOptimizer) {
+    auto optDagErr =
+        optimizeDAG(nodeList, *provisioner_, *module, deviceInfo, cctx);
+    if (optDagErr) {
+      std::unique_lock<std::shared_timed_mutex> networkLock(networkLock_);
+      cleanupAddNetwork(names);
+      return optDagErr;
+    }
+  }
+#endif /* FACEBOOK_INTERNAL */
+
+  // If requested, serialize the resulting DAG that was just optimized and
+  // partitioned.
+  if (cctx.serializeCompiledDAG) {
+    std::string loc = nodeList.begin()->root->name + ".onnx";
+    LOG(INFO) << "Serializing DAG to " << loc;
+    {
+      Error writeErr = Error::empty();
+      ONNXModelWriter onnxWR(loc, nodeList, 7, 9, &writeErr,
+                             /* textMode */ false, /* zipMode */ false,
+                             /* includeConstantData */ false, record);
+      RETURN_IF_ERR(writeErr);
+    }
+  }
+
+  // Now that we've serialized the model if requested, cleanup the temporary
+  // Functions and PHs used for constant folding.
+  cleanupConstantFolding(*module, record);
 
   auto err = provisioner_->provision(nodeList, *module, cctx);
   if (err) {


### PR DESCRIPTION
Summary:
To ensure that all Constant modification is prevented and only occurs during Constant Folding recording, add a `preventConstantModification` option. This swaps in temporary Placeholders for Constants inside the `HostManager::addNetwork()` call to prevent any modification from occurring. It swaps them back once it's safe to do so.

Implemented this via `ConstantModificationPreventer`, a subclass of `ScopeGuard` which will swap in the temp Placeholders and undo it when we leave the scope.

During testing encountered a couple issues that are fixed:
- ConstantFolding does not apply for Quantize nodes by default, so enabled quantize constant folding when we're doing Constant Folding recording.
- Added support in the Interpreter for folding `ConvertTo` into a `Constant` when converting from `UInt8FusedQTy` to `UInt8FusedFP16QTy`

Differential Revision: D21545357

