### PR TITLE
repro: end trace scope

### DIFF
--- a/tests/unittests/Repro.cpp
+++ b/tests/unittests/Repro.cpp
@@ -670,6 +670,8 @@ int run() {
       std::promise<void> promise;
       auto future = promise.get_future();
 
+      TRACE_EVENT_SCOPE_END();
+
       hostManager->runNetwork(
           "test", std::move(ctx),
           [&promise, index = ioIndex,


### PR DESCRIPTION
Summary: We forgot to end the trace scope in repro tool. This could lead to a use after free bug if --skip_correctness_check is used.

Differential Revision: D21729208

