### PR TITLE
[NNPI] Disable AllOne specialization for SLS by default

### DIFF
--- a/lib/Backends/NNPI/Importer.cpp
+++ b/lib/Backends/NNPI/Importer.cpp
@@ -26,7 +26,23 @@
 #include <fstream>
 #include <limits>
 
+#include "llvm/Support/CommandLine.h"
+
 using namespace glow;
+
+namespace glow {
+llvm::cl::OptionCategory optionsForNNPIImporter("NNPI Importer Options");
+
+bool GlowNNPISpecializeAllOneSLS = false;
+static llvm::cl::opt<bool, /* ExternalStorage */ true>
+    GlowNNPISpecializeAllOneSLSOpt(
+        "glow_nnpi_specialize_all_one_sls",
+        llvm::cl::desc(
+            "Whether to import SLS ops with AllOne attribute to NNPI."),
+        llvm::cl::location(GlowNNPISpecializeAllOneSLS), llvm::cl::Optional,
+        llvm::cl::init(false), llvm::cl::cat(optionsForNNPIImporter));
+
+} // namespace glow
 
 const std::string NNPIImporter::internalName_("_NNPI_");
 
@@ -43,6 +59,9 @@ static std::string nodeValueName(const glow::NodeValue &nv) {
 static inline NNPIErrorCode
 convertLengthsModeToLengthType(glow::LengthsMode mode,
                                NNPI_LENGTH_TYPE &lengthType) {
+  if (!GlowNNPISpecializeAllOneSLS) {
+    mode = LengthsMode::Variable;
+  }
   switch (mode) {
   case LengthsMode::Variable:
     lengthType = NNPI_LENGTH_VARIABLE;

--- a/lib/Onnxifi/Flags.cpp
+++ b/lib/Onnxifi/Flags.cpp
@@ -62,6 +62,7 @@ extern int32_t GlowNNPINumParallelChunks;
 extern bool GlowEnableLoadBalancedPartitioning;
 extern bool GlowNNPILowerAllBatchMatMul;
 extern bool GlowNNPIAcceptUnarySLS;
+extern bool GlowNNPISpecializeAllOneSLS;
 
 namespace runtime {
 extern unsigned GlowInterpreterMemory;
@@ -334,6 +335,14 @@ DEFINE_bool(glow_dump_nnpi_compiler_data, false,
 DEFINE_validator(glow_dump_nnpi_compiler_data,
                  [](const char * /* unused */, bool value) {
                    glow::onnxifi::GlowDumpNNPICompilerData = value;
+                   return true;
+                 });
+
+DEFINE_bool(glow_nnpi_specialize_all_one_sls, false,
+            "Whether to import SLS ops with AllOne attribute to NNPI.");
+DEFINE_validator(glow_nnpi_specialize_all_one_sls,
+                 [](const char * /*unused*/, bool value) {
+                   glow::GlowNNPISpecializeAllOneSLS = value;
                    return true;
                  });
 

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -11435,13 +11435,13 @@ static void testSLWSLengthsMode(glow::PlaceholderBindings &bindings,
   if (fusedData) {
     SLWS = F->createFusedRowwiseQuantizedSparseLengthsWeightedSum(
         "RQSLWS", data, weights, indices, lengths, dataDTy, useFP16Accumulation,
-        LengthsMode::AllOne);
+        lengthsMode);
   } else {
     Placeholder *dataP = mod.createPlaceholder(&data.getType(), "data",
                                                /* isTrainable */ false);
     bindings.insert(dataP, std::move(data));
     SLWS = F->createSparseLengthsWeightedSum("SLWS", dataP, weights, indices,
-                                             lengths, LengthsMode::AllOne);
+                                             lengths, lengthsMode);
   }
   SaveNode *S = F->createSave("save", SLWS);
   bindings.allocate(S->getPlaceholder());


### PR DESCRIPTION
Summary: Specialized AllOne kernels appears to be buggy. Disable for now. Can use `--glow_nnpi_specialize_all_one_sls=true` to re-enable

Reviewed By: yinghai

Differential Revision: D21834343

