### PR TITLE
Add virtual toJSON() to allow a backend to dump structured info about the result of compilation

### DIFF
--- a/include/glow/Backend/CompiledFunction.h
+++ b/include/glow/Backend/CompiledFunction.h
@@ -64,6 +64,10 @@ public:
   /// but not needed for running on the device.
   virtual void freeCompilationResources(){};
 
+  /// \returns a JSON representation of the result of compilation. Structure of
+  /// the JSON is dependent on the backend.
+  virtual const std::string toJSON() const { return ""; }
+
 protected:
   /// Contains symbol offsets and allocation sizes.
   runtime::RuntimeBundle runtimeBundle_;


### PR DESCRIPTION
Summary: Enable extracting compilation result out of a CompiledFunction in JSON format.

Reviewed By: mjanderson09

Differential Revision: D21825542

