### PR TITLE
Add Glow standard command-line options to benchmarks

### DIFF
--- a/tests/benchmark/AddBench.cpp
+++ b/tests/benchmark/AddBench.cpp
@@ -143,6 +143,9 @@ int main(int argc, char *argv[]) {
   printf("Usage: AddBench n(Int) numLayers(Int) numReps(Int) "
          "numAsyncLaunches(Int) numAddChains(Int) backendStr(String) "
          "dtypeStr(\"Float16\"|\"Float32\") dev_id(Int)\n");
+  printf("Standard Glow command-line options may be passed via the GLOW_OPTS "
+         "environment variable\n");
+  llvm::cl::ParseEnvironmentOptions(argv[0], "GLOW_OPTS", "");
   assert(argc == 8 || argc == 9);
   size_t n = atoi(argv[1]);
   size_t numLayers = atoi(argv[2]);

--- a/tests/benchmark/BERTProxyLayerBench.cpp
+++ b/tests/benchmark/BERTProxyLayerBench.cpp
@@ -179,7 +179,8 @@ public:
         (float)(1.0 / std::sqrt(((double)hiddenSize_) / ((double)numHeads_)));
 
     // Softmax expected output. Not needed for inference
-    Tensor expected_Tensor(ElemKind::Int64ITy, {maxSequenceLength_ * batchSize_, 1});
+    Tensor expected_Tensor(ElemKind::Int64ITy,
+                           {maxSequenceLength_ * batchSize_, 1});
     Constant *expected = mod->createConstant("expected", expected_Tensor);
 
     // Weights/bias constants for FC1
@@ -423,6 +424,9 @@ int main(int argc, char *argv[]) {
       "Usage: BERTLayerBench maxSequenceLength batchSize hiddenSize numHeads "
       "numCores "
       "numReps numAsyncLaunches backendStr dtypeStr useInt8FCs\n");
+  printf("Standard Glow command-line options may be passed via the GLOW_OPTS "
+         "environment variable\n");
+  llvm::cl::ParseEnvironmentOptions(argv[0], "GLOW_OPTS", "");
   assert(argc == 11);
   size_t maxSequenceLength = atoi(argv[1]);
   size_t batchSize = atoi(argv[2]);

--- a/tests/benchmark/BatchGemmBench.cpp
+++ b/tests/benchmark/BatchGemmBench.cpp
@@ -199,6 +199,9 @@ int main(int argc, char *argv[]) {
   printf("Usage: BatchGemmBench batchSize(Int) m(Int) n(Int) numLayers(Int) "
          "numReps(Int) numAsyncLaunches(Int) numBatchGEMMChains(Int) "
          "backendStr(String) dtypeStr(\"Float16\"|\"Float32\") dev_id(Int)\n");
+  printf("Standard Glow command-line options may be passed via the GLOW_OPTS "
+         "environment variable\n");
+  llvm::cl::ParseEnvironmentOptions(argv[0], "GLOW_OPTS", "");
 
   assert(argc == 10 || argc == 11);
   size_t batchSize = atoi(argv[1]);

--- a/tests/benchmark/ConcatBench.cpp
+++ b/tests/benchmark/ConcatBench.cpp
@@ -158,6 +158,9 @@ int main(int argc, char *argv[]) {
          "numLayers(Int) numReps(Int) "
          "numAsyncLaunches(Int) backendStr(String) "
          "dtypeStr(\"Float16\"|\"Float32\") dev_id(Int)\n");
+  printf("Standard Glow command-line options may be passed via the GLOW_OPTS "
+         "environment variable\n");
+  llvm::cl::ParseEnvironmentOptions(argv[0], "GLOW_OPTS", "");
   assert(argc == 9 || argc == 10);
   size_t m = atoi(argv[1]);
   size_t n = atoi(argv[2]);

--- a/tests/benchmark/GemmBench.cpp
+++ b/tests/benchmark/GemmBench.cpp
@@ -218,6 +218,9 @@ int main(int argc, char *argv[]) {
   printf("Usage: GemmBench m(Int) n(Int) k(Int) numLayers(Int) numReps(Int) "
          "numAsyncLaunches(Int) numSplits(Int) backendStr(String) "
          "dtypeStr(\"Float16\"|\"Float32\") dev_id(Int)\n");
+  printf("Standard Glow command-line options may be passed via the GLOW_OPTS "
+         "environment variable\n");
+  llvm::cl::ParseEnvironmentOptions(argv[0], "GLOW_OPTS", "");
 
   std::vector<GemmParam> params;
   std::string runHeader;

--- a/tests/benchmark/GemmParallelBench.cpp
+++ b/tests/benchmark/GemmParallelBench.cpp
@@ -152,6 +152,7 @@ public:
 };
 
 int main(int argc, char *argv[]) {
+  llvm::cl::ParseEnvironmentOptions(argv[0], "GLOW_OPTS", "");
   assert(argc == 9);
   size_t m = atoi(argv[1]);
   size_t n = atoi(argv[2]);

--- a/tests/benchmark/Int8Conv2dParallelBench.cpp
+++ b/tests/benchmark/Int8Conv2dParallelBench.cpp
@@ -232,6 +232,9 @@ int main(int argc, char *argv[]) {
       "Usage: Int8Conv2dParallelBench numLayers(Int) "
       "numReps(Int) "
       "numAsyncLaunches(Int) numCores(Int) backendStr(String) dev_id(Int)\n");
+  printf("Standard Glow command-line options may be passed via the GLOW_OPTS "
+         "environment variable\n");
+  llvm::cl::ParseEnvironmentOptions(argv[0], "GLOW_OPTS", "");
   assert(argc == 6 || argc == 7);
   if (argc > 6) {
     dev_id = argv[6];

--- a/tests/benchmark/Int8Conv3dParallelBench.cpp
+++ b/tests/benchmark/Int8Conv3dParallelBench.cpp
@@ -267,6 +267,9 @@ int main(int argc, char *argv[]) {
       "Usage: Int8Conv3dParallelBench numLayers(Int) "
       "numReps(Int) "
       "numAsyncLaunches(Int) numCores(Int) backendStr(String) dev_id(Int)\n");
+  printf("Standard Glow command-line options may be passed via the GLOW_OPTS "
+         "environment variable\n");
+  llvm::cl::ParseEnvironmentOptions(argv[0], "GLOW_OPTS", "");
   assert(argc == 6 || argc == 7);
   if (argc > 6) {
     dev_id = argv[6];

--- a/tests/benchmark/Int8GemmBench.cpp
+++ b/tests/benchmark/Int8GemmBench.cpp
@@ -224,6 +224,9 @@ int main(int argc, char *argv[]) {
   printf("Usage: GemmBench m(Int) n(Int) k(Int) numLayers(Int) numReps(Int) "
          "numAsyncLaunches(Int) numSplits(Int) backendStr(String) "
          "dev_id(Int)\n");
+  printf("Standard Glow command-line options may be passed via the GLOW_OPTS "
+         "environment variable\n");
+  llvm::cl::ParseEnvironmentOptions(argv[0], "GLOW_OPTS", "");
 
   std::vector<Int8GemmParam> params;
   std::string runHeader;

--- a/tests/benchmark/Int8GemmParallelBench.cpp
+++ b/tests/benchmark/Int8GemmParallelBench.cpp
@@ -173,6 +173,9 @@ int main(int argc, char *argv[]) {
   printf(
       "Usage: Int8GemmParallelBench m(Int) n(Int) numLayers(Int) numReps(Int) "
       "numAsyncLaunches(Int) numCores(Int) backendStr(String) dev_id(Int)\n");
+  printf("Standard Glow command-line options may be passed via the GLOW_OPTS "
+         "environment variable\n");
+  llvm::cl::ParseEnvironmentOptions(argv[0], "GLOW_OPTS", "");
   assert(argc == 8 || argc == 9);
   if (argc > 8) {
     dev_id = argv[8];

--- a/tests/benchmark/SLSBench.cpp
+++ b/tests/benchmark/SLSBench.cpp
@@ -459,6 +459,9 @@ int main(int argc, char *argv[]) {
          "useFP16AccumulationStr(\"True\"|\"False\") \n"
          "Optional: dev_id(Int)\n");
   printf("\n");
+  printf("Standard Glow command-line options may be passed via the GLOW_OPTS "
+         "environment variable\n");
+  llvm::cl::ParseEnvironmentOptions(argv[0], "GLOW_OPTS", "");
 
   std::vector<SLSParam> params;
   std::string runHeader;

--- a/tests/benchmark/TransposeBench.cpp
+++ b/tests/benchmark/TransposeBench.cpp
@@ -187,6 +187,9 @@ int main(int argc, char *argv[]) {
   printf("Usage: TransposeBench batchSize(Int) n(Int) numLayers(Int) "
          "numReps(Int) numAsyncLaunches(Int) numTransposeChains(Int) "
          "backendStr(String) dtypeStr(\"Float16\"|\"Float32\") dev_id(Int)\n");
+  printf("Standard Glow command-line options may be passed via the GLOW_OPTS "
+         "environment variable\n");
+  llvm::cl::ParseEnvironmentOptions(argv[0], "GLOW_OPTS", "");
   assert(argc == 9 || argc == 10);
   size_t batchSize = atoi(argv[1]);
   size_t n = atoi(argv[2]);


### PR DESCRIPTION
Enable passing Glow standard command-line options for benchmarks via the
GLOW_OPTS environment variable

Summary:

Documentation:

[Optional Fixes #issue]

Test Plan:

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
