### PR TITLE
Randomize inputs and weights to GemmBench and Int8GemmBench

### DIFF
--- a/tests/benchmark/CMakeLists.txt
+++ b/tests/benchmark/CMakeLists.txt
@@ -36,7 +36,8 @@ target_link_libraries(GemmBench
                         Graph
                         GraphOptimizer
                         HostManager
-                        CPURuntimeNative)
+                        CPURuntimeNative
+                        BackendTestUtils)
 
 add_executable(Int8GemmBench
                Int8GemmBench.cpp)
@@ -47,7 +48,8 @@ target_link_libraries(Int8GemmBench
                         Graph
                         GraphOptimizer
                         HostManager
-                        CPURuntimeNative)
+                        CPURuntimeNative
+                        BackendTestUtils)
 
 add_executable(GemmParallelBench
                GemmParallelBench.cpp)

--- a/tests/benchmark/GemmBench.cpp
+++ b/tests/benchmark/GemmBench.cpp
@@ -19,6 +19,7 @@
 #include <future>
 #include <random>
 
+#include "BackendTestUtils.h"
 #include "Bench.h"
 #include "glow/ExecutionEngine/ExecutionEngine.h"
 #include "glow/Optimizer/GraphOptimizer/GraphOptimizer.h"
@@ -50,16 +51,26 @@ struct GemmParam {
 
 class GemmBench : public Benchmark {
   GemmParam param_;
-  PlaceholderBindings bindings_;
+  ExecutionContext context_;
+  PlaceholderBindings &bindings_;
   std::unique_ptr<runtime::HostManager> hostManager_;
 
 public:
-  explicit GemmBench(GemmParam param_) : param_(param_) {}
+  explicit GemmBench(GemmParam param_)
+      : param_(param_), bindings_(*context_.getPlaceholderBindings()) {}
 
   void addGemmNode(std::unique_ptr<Module> &mod, Function *fn,
                    GemmParam param) {
     auto *input = mod->createPlaceholder(param.dtype_, {param.m_, param.k_},
                                          "input", false);
+    if (param.dtype_ == ElemKind::Float16Ty) {
+      bindings_.allocate(input)->getHandle<float16>().randomize(-1.f, 1.f,
+                                                                mod->getPRNG());
+    } else {
+      assert(param.dtype_ == ElemKind::FloatTy);
+      bindings_.allocate(input)->getHandle<float>().randomize(-1.f, 1.f,
+                                                              mod->getPRNG());
+    }
     auto *output = mod->createPlaceholder(param.dtype_, {param.m_, param.n_},
                                           "output", false);
     Node *cur = input;
@@ -87,10 +98,12 @@ public:
                                     "bias" + std::to_string(layer), false);
 
       if (param.dtype_ == ElemKind::Float16Ty) {
-        bindings_.allocate(weights)->getHandle<float16_t>().clear(1.0);
+        bindings_.allocate(weights)->getHandle<float16_t>().randomize(
+            -1.f, 1.f, mod->getPRNG());
         bindings_.allocate(bias)->getHandle<float16_t>().clear(32);
       } else if (param.dtype_ == ElemKind::FloatTy) {
-        bindings_.allocate(weights)->getHandle<float>().clear(1.0);
+        bindings_.allocate(weights)->getHandle<float>().randomize(
+            -1.f, 1.f, mod->getPRNG());
         bindings_.allocate(bias)->getHandle<float>().clear(32);
       }
 
@@ -145,24 +158,8 @@ public:
   }
 
   void run() override {
-    std::vector<std::promise<void>> promises(param_.numAsyncLaunches_);
-    std::vector<std::future<void>> futures;
-
-    // Launch a number of independent requests
-    for (auto &runPromise : promises) {
-      std::unique_ptr<ExecutionContext> contextPtr(new ExecutionContext);
-      futures.push_back(runPromise.get_future());
-      hostManager_->runNetwork(
-          "singleNode", std::move(contextPtr),
-          [&runPromise](runtime::RunIdentifierTy, Error err,
-                        std::unique_ptr<ExecutionContext> /* contextPtr */) {
-            EXIT_ON_ERR(std::move(err));
-            runPromise.set_value();
-          });
-    }
-    for (auto &fut : futures) {
-      fut.wait();
-    }
+    dispatchInference("singleNode", hostManager_.get(), context_,
+                      param_.numAsyncLaunches_);
   }
 
   void teardown() override {}

--- a/tests/benchmark/Int8GemmBench.cpp
+++ b/tests/benchmark/Int8GemmBench.cpp
@@ -19,6 +19,7 @@
 #include <future>
 #include <random>
 
+#include "BackendTestUtils.h"
 #include "Bench.h"
 #include "glow/ExecutionEngine/ExecutionEngine.h"
 #include "glow/Optimizer/GraphOptimizer/GraphOptimizer.h"
@@ -49,16 +50,20 @@ struct Int8GemmParam {
 
 class Int8GemmBench : public Benchmark {
   Int8GemmParam param_;
-  PlaceholderBindings bindings_;
+  ExecutionContext context_;
+  PlaceholderBindings &bindings_;
   std::unique_ptr<runtime::HostManager> hostManager_;
 
 public:
-  explicit Int8GemmBench(Int8GemmParam param_) : param_(param_) {}
+  explicit Int8GemmBench(Int8GemmParam param_)
+      : param_(param_), bindings_(*context_.getPlaceholderBindings()) {}
 
   void addInt8GemmNode(std::unique_ptr<Module> &mod, Function *fn,
                        Int8GemmParam param) {
     auto *input = mod->createPlaceholder(ElemKind::Float16Ty,
                                          {param.m_, param.k_}, "input", false);
+    bindings_.allocate(input)->getHandle<float16>().randomize(-128.f, 127.f,
+                                                              mod->getPRNG());
     auto *output = mod->createPlaceholder(
         ElemKind::Float16Ty, {param.m_, param.n_}, "output", false);
     auto *q_input = fn->createQuantize(
@@ -85,7 +90,8 @@ public:
       bias = mod->createPlaceholder(ElemKind::Int32QTy, {param.n_}, 1.0, 0,
                                     "bias" + std::to_string(layer), false);
 
-      bindings_.allocate(weights)->getHandle<int8_t>().clear(1);
+      bindings_.allocate(weights)->getHandle<int8_t>().randomize(
+          -128, 127, mod->getPRNG());
       bindings_.allocate(bias)->getHandle<int32_t>().clear(2);
 
       Node *fc;
@@ -159,24 +165,8 @@ public:
   }
 
   void run() override {
-    std::vector<std::promise<void>> promises(param_.numAsyncLaunches_);
-    std::vector<std::future<void>> futures;
-
-    // Launch a number of independent requests
-    for (auto &runPromise : promises) {
-      std::unique_ptr<ExecutionContext> contextPtr(new ExecutionContext);
-      futures.push_back(runPromise.get_future());
-      hostManager_->runNetwork(
-          "singleNode", std::move(contextPtr),
-          [&runPromise](runtime::RunIdentifierTy, Error err,
-                        std::unique_ptr<ExecutionContext> /* contextPtr */) {
-            EXIT_ON_ERR(std::move(err));
-            runPromise.set_value();
-          });
-    }
-    for (auto &fut : futures) {
-      fut.wait();
-    }
+    dispatchInference("singleNode", hostManager_.get(), context_,
+                      param_.numAsyncLaunches_);
   }
 
   void teardown() override {}


### PR DESCRIPTION
Use PRNG-initialized inputs and weights for GemmBench and Int8GemmBench
instead of uninitialized data and all ones respectively.

Use dispatchInference() to run inferences to reduce code duplication and
to ensure that the initialized input data is used.

Summary:

Documentation:

[Optional Fixes #issue]

Test Plan:

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
