### PR TITLE
Trace Collection for AOT Compilation in CachingGraphRunner

### DIFF
--- a/torch_glow/src/CachingGraphRunner.h
+++ b/torch_glow/src/CachingGraphRunner.h
@@ -77,6 +77,9 @@ class CachingGraphRunner {
   /// The number of runs traced
   size_t numTraces_{0};
 
+  /// The number of trace dumps already generated
+  size_t numTraceDumps_{0};
+
   /// TraceContext used to aggregate traces from runs before dumping them
   /// in groups to file.
   std::unique_ptr<TraceContext> mergedTraceContext_;


### PR DESCRIPTION
Summary:
Adding tracing support for the AOT path in CachingGraphRunner, with some minor refractoring on the trace collection to make the aggregate and dump logic simpler.
Added a final dump in CachingGraphRunner destructor to make sure we collect everything, and added the option of setting numTracesPerDump to 0 to dump only once for the lifetime of a graph runner.

Differential Revision: D22001276

