### PR TITLE
[InstrGen] Enable `isCanonical` for instructions

### DIFF
--- a/include/glow/IR/IR.h
+++ b/include/glow/IR/IR.h
@@ -177,6 +177,9 @@ public:
   /// operand \p srcIdx for writing the result of the operand at \p dstIdx.
   bool isInplaceOp(unsigned dstIdx, unsigned srcIdx) const { return false; }
 
+  /// \returns True if this instruction is not backend-specific.
+  bool isCanonical() const;
+
   /// \returns True if this instruction is data parallel.
   bool isDataParallel() const;
 

--- a/lib/IR/IR.cpp
+++ b/lib/IR/IR.cpp
@@ -358,6 +358,24 @@ Value *IRFunction::getWeightForNode(const Storage *V) const {
   return it->second;
 }
 
+bool Instruction::isCanonical() const {
+  switch (getKind()) {
+  default:
+    llvm_unreachable("Unknown value kind");
+    break;
+#define DEF_INSTR(CLASS, NAME)                                                 \
+  case Kinded::Kind::CLASS##Kind: {                                            \
+    auto *X = llvm::cast<const CLASS>(this);                                   \
+    return X->isCanonical();                                                   \
+    break;                                                                     \
+  }
+#define DEF_BACKEND_SPECIFIC_INSTR(CLASS, NAME) DEF_INSTR(CLASS, NAME)
+#define DEF_VALUE(CLASS, NAME)
+#include "glow/AutoGenInstr.def"
+  }
+  return false;
+}
+
 bool Instruction::isDataParallel() const {
   switch (getKind()) {
   default:

--- a/tools/ClassGen/InstrBuilder.cpp
+++ b/tools/ClassGen/InstrBuilder.cpp
@@ -165,6 +165,7 @@ void InstrBuilder::emitDataParallelProperty(std::ostream &os) const {
 
 void InstrBuilder::emitProperties(std::ostream &os) const {
   emitInplaceMethod(os);
+  emitCanonicalProperty(os);
   emitDataParallelProperty(os);
 }
 


### PR DESCRIPTION
Summary:
Enable `isCanonical` for instructions.

Documentation:
N/A

Test Plan:
N/A