### PR TITLE
Use GlowCompileSpec to pass compilation parameters in to_glow

### DIFF
--- a/torch_glow/src/CMakeLists.txt
+++ b/torch_glow/src/CMakeLists.txt
@@ -20,7 +20,8 @@ add_library(PyTorchModelLoader
                      PyTorchCommon.cpp
                      Registration.cpp
                      PyTorchModelLoader.cpp
-                     TorchGlowBackend.cpp)
+                     TorchGlowBackend.cpp
+                     GlowCompileSpec.cpp)
 target_compile_options(PyTorchModelLoader
                       PRIVATE
                         -frtti -fexceptions -DC10_USE_GLOG)

--- a/torch_glow/src/GlowCompileSpec.cpp
+++ b/torch_glow/src/GlowCompileSpec.cpp
@@ -1,0 +1,121 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include "GlowCompileSpec.h"
+#include <ATen/core/ivalue.h>
+#include <torch/custom_class.h>
+
+namespace glow {
+
+// tuple<tensor_element_type, tensor_dims>
+using SpecInputMetaSerializationType =
+    std::tuple<std::string, std::vector<int64_t>>;
+
+static c10::ScalarType scalarTypeFromString(const std::string &str) {
+  if (str == "float") {
+    return c10::ScalarType::Float;
+  } else {
+    throw std::invalid_argument("Invalid SpecInputMeta type");
+  }
+}
+
+SpecInputMeta::SpecInputMeta(const SpecInputMeta &other) {
+  type_ = other.type_;
+  dims_ = other.dims_;
+}
+
+SpecInputMeta::SpecInputMeta(const std::string &typeStr,
+                             std::vector<int64_t> dims) {
+  type_ = scalarTypeFromString(typeStr);
+  dims_ = dims;
+}
+
+SpecInputMeta::SpecInputMeta(const SpecInputMetaSerializationType &state) {
+  std::string typeStr;
+  std::tie(typeStr, dims_) = state;
+  type_ = scalarTypeFromString(typeStr);
+}
+
+void SpecInputMeta::setSpec(const std::string &typeStr,
+                            std::vector<int64_t> dims) {
+  type_ = scalarTypeFromString(typeStr);
+  dims_ = dims;
+}
+
+void SpecInputMeta::setSpecFromTensor(const at::Tensor &t) {
+  type_ = t.scalar_type();
+  std::copy(t.sizes().begin(), t.sizes().end(), std::back_inserter(dims_));
+}
+
+SpecInputMetaSerializationType SpecInputMeta::serializeToTuple() const {
+  return make_tuple(c10::toString(type_), dims_);
+}
+
+void GlowCompileSpec::addInputTensor(const std::string &type,
+                                     std::vector<int64_t> dims) {
+  inputs_.emplace_back(SpecInputMeta(type, std::move(dims)));
+}
+
+void GlowCompileSpec::addInput(c10::intrusive_ptr<SpecInputMeta> input) {
+  inputs_.emplace_back(std::move(*input));
+}
+
+void GlowCompileSpec::addInputs(
+    std::vector<c10::intrusive_ptr<SpecInputMeta>> inputs) {
+  for (auto m : inputs) {
+    inputs_.emplace_back(std::move(*m));
+  }
+}
+
+void registerGlowCompileSpecCustomClass() {
+
+  static auto spec_input_meta_registry =
+      torch::class_<SpecInputMeta>("glow", "SpecInputMeta")
+          .def(torch::init())
+          .def("setSpec", &SpecInputMeta::setSpec)
+          .def("setSpecFromTensor", &SpecInputMeta::setSpecFromTensor)
+          .def_pickle(
+              [](const c10::intrusive_ptr<SpecInputMeta> &sim)
+                  -> SpecInputMetaSerializationType { // __getstate__
+                return sim->serializeToTuple();
+              },
+              [](SpecInputMetaSerializationType state)
+                  -> c10::intrusive_ptr<SpecInputMeta> { // __setstate__
+                return c10::make_intrusive<SpecInputMeta>(state);
+              });
+
+  using GcsSerializationType =
+      std::tuple<std::string, std::vector<SpecInputMetaSerializationType>>;
+  static auto glow_compile_spec_registry =
+      torch::class_<GlowCompileSpec>("glow", "GlowCompileSpec")
+          .def(torch::init())
+          .def("setBackend", &GlowCompileSpec::setBackend)
+          .def("addInputTensor", &GlowCompileSpec::addInputTensor)
+          .def("addInput", &GlowCompileSpec::addInput)
+          .def("addInputs", &GlowCompileSpec::addInputs)
+          .def_pickle(
+              [](const c10::intrusive_ptr<GlowCompileSpec> &gcs)
+                  -> GcsSerializationType { // __getstate__
+                std::string backend = gcs->getBackend();
+                std::vector<SpecInputMetaSerializationType> inputs;
+                for (const auto &meta : gcs->inputs()) {
+                  inputs.emplace_back(meta.serializeToTuple());
+                }
+                return std::make_tuple(backend, inputs);
+              },
+              [](GcsSerializationType state)
+                  -> c10::intrusive_ptr<GlowCompileSpec> { // __setstate__
+                std::string backend;
+                std::vector<SpecInputMetaSerializationType> inputs;
+                std::tie(backend, inputs) = state;
+                std::vector<SpecInputMeta> glowInputs;
+                for (auto inputState : inputs) {
+                  glowInputs.emplace_back(SpecInputMeta(inputState));
+                }
+                return c10::make_intrusive<GlowCompileSpec>(
+                    GlowCompileSpec(backend, glowInputs));
+              }
+
+          );
+}
+
+} // namespace glow

--- a/torch_glow/src/GlowCompileSpec.h
+++ b/torch_glow/src/GlowCompileSpec.h
@@ -1,0 +1,68 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#ifndef GLOW_TORCH_GLOW_SRC_GLOW_COMPILE_SPEC_H
+#define GLOW_TORCH_GLOW_SRC_GLOW_COMPILE_SPEC_H
+
+#include <ATen/core/ivalue.h>
+
+namespace glow {
+
+/// Register GlowCompileSpec and related classes as PyTorch custom classes
+void registerGlowCompileSpecCustomClass();
+
+/// Specifications for Glow graph input (Tensor meta)
+class SpecInputMeta : public torch::jit::CustomClassHolder {
+  /// tuple<type, dims>
+  using SpecInputMetaSerializationType =
+      std::tuple<std::string, std::vector<int64_t>>;
+
+public:
+  // Constructors
+  SpecInputMeta() = default;
+  SpecInputMeta(const SpecInputMeta &other);
+  SpecInputMeta(const std::string &typeStr, std::vector<int64_t> dims);
+  SpecInputMeta(const SpecInputMetaSerializationType &state);
+
+  SpecInputMeta &operator=(const SpecInputMeta &other) = default;
+
+  void setSpec(const std::string &typeStr, std::vector<int64_t> dims);
+  void setSpecFromTensor(const at::Tensor &t);
+
+  SpecInputMetaSerializationType serializeToTuple() const;
+  // Element type
+  c10::ScalarType type() const { return type_; }
+  // Tensor dimensions
+  const std::vector<int64_t> &dims() const { return dims_; }
+
+private:
+  c10::ScalarType type_;
+  std::vector<int64_t> dims_;
+};
+
+class GlowCompileSpec : public torch::jit::CustomClassHolder {
+
+public:
+  GlowCompileSpec() {}
+  GlowCompileSpec(const std::string &backendName,
+                  std::vector<SpecInputMeta> inputs)
+      : backendName_(backendName), inputs_(inputs) {}
+  ~GlowCompileSpec() {}
+
+  const std::string &getBackend() const { return backendName_; }
+  void setBackend(const std::string &backendName) {
+    backendName_ = backendName;
+  }
+  void addInputTensor(const std::string &type, std::vector<int64_t> dims);
+  void addInputFromTensor(at::Tensor);
+  void addInput(c10::intrusive_ptr<SpecInputMeta> input);
+  void addInputs(std::vector<c10::intrusive_ptr<SpecInputMeta>> inputs);
+  std::vector<SpecInputMeta> inputs() const { return inputs_; }
+
+private:
+  std::string backendName_ = "";
+  std::vector<SpecInputMeta> inputs_;
+};
+
+} // namespace glow
+
+#endif // GLOW_TORCH_GLOW_SRC_GLOW_COMPILE_SPEC_H

--- a/torch_glow/src/binding.cpp
+++ b/torch_glow/src/binding.cpp
@@ -17,6 +17,7 @@
 #include <pybind11/pybind11.h>
 
 #include "FuseKnownPatterns.h"
+#include "GlowCompileSpec.h"
 #include "GlowFuser.h"
 #include "PyTorchCommon.h"
 #include "Registration.h"
@@ -51,6 +52,9 @@ PYBIND11_MODULE(_torch_glow, m) {
   /// fusionPassEnabled is set in PyTorchLoaderSettings.
   registerGlowFusionOpAndPass(
       []() { return getPyTorchLoaderSettings().fusionPassEnabled; });
+
+  /// Register GlowCompileSpec as PyTorch custom class
+  registerGlowCompileSpecCustomClass();
 
   /// Enable overriding signal handlers for torch_glow to make interruping long
   /// running processes possible. This should only be used when running

--- a/torch_glow/tests/functionality/glow_compile_spec_test.py
+++ b/torch_glow/tests/functionality/glow_compile_spec_test.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import torch_glow
+import torch
+import unittest
+
+
+class TestGlowCompileSpec(unittest.TestCase):
+    def test_glow_compile_spec(self):
+        """Create glow compile spec."""
+
+        dims = [2, 2]
+        gcs = torch.classes.glow.GlowCompileSpec()
+        gcs.setBackend("Interpreter")
+        gcs.addInputTensor("float", dims)
+
+        sim = torch.classes.glow.SpecInputMeta()
+        sim.setSpec("float", dims)
+        gcs.addInput(sim)
+        inputs = [sim, sim]
+        gcs.addInputs(inputs)
+
+        t = torch.tensor(dims)
+        sim.setSpecFromTensor(t)


### PR DESCRIPTION
Summary: Adding custom class GlowCompileSpec to pass compilation / lowering parameters for to_glow

Differential Revision: D21968514

