### PR TITLE
fix "invalid llvm.linker.options" for Windows build

### DIFF
--- a/lib/Backends/CPU/CMakeLists.txt
+++ b/lib/Backends/CPU/CMakeLists.txt
@@ -30,6 +30,7 @@ set(CPURunttimeCompilationOptions
       -I${CMAKE_SOURCE_DIR}/include
       -emit-llvm
       -O0
+      -fno-autolink
 
       # When building for a custom target, use this as an example of how to
       # set up cross-compilation correctly. Then, when building bundles,


### PR DESCRIPTION

Summary:

The operators implemented as part of the libjit are compiled to LLVMIR as part of the GLOW library build and kept as LLVMIR.

While compiling and optimizing a model (using GLOW model-compiler for ahead-of-time model build), the libjit LLVMIR is further used to generate code for the needed operators and for the required targets.
For the Windows build, the libjit compile (to LLVMIR) is not target specific, but since the Windows clang is used, a specific Windows metadata is implicitly added in the "llvm.linker.options":
	- #pragma detect_mismatch is implicitly added to assure linked objects compatibility (mostly related to the versions of the tools and ABI that is used for the object file)

When the target of the built model is the host (Windows), the metadata added in the "llvm.linker.options" is correctly consumed by "TargetLoweringObjectFileCOFF::::emitModuleMetadata()".
When the target of the built model is an ELF format oriented target, another consumer for the "llvm.linker.options" metadata is used - "TargetLoweringObjectFileELF::emitModuleMetadata()".
But since the metadata is produced for Windows it is not compatible with the ELF format consumer.

To avoid these in-compatibilities, the libjit should be compiled to LLVMIR without generating the "#pragma detect_mismatch" metadata in the "llvm.linker.options".
An llvm / clang option that can be used for this purpose is "-fno-autolink" and should be used for all libjit files.

Modifying the libjit building CMakeLists with this option should solve model compile errors for different ELF format based targets (ARM for instance):
	"invalid llvm.linker.options"

Documentation:

[Optional Fixes #issue]

Test Plan:

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
