### PR TITLE
Changes to accommodate GLOW build using LLVM 10.0

### DIFF
--- a/include/glow/Graph/NodeValue.h
+++ b/include/glow/Graph/NodeValue.h
@@ -18,6 +18,7 @@
 
 #include "glow/Base/Traits.h"
 #include "glow/Base/Type.h"
+#include "llvm/ADT/StringMap.h"
 
 namespace glow {
 

--- a/lib/LLVMIRCodeGen/BundleSaver.cpp
+++ b/lib/LLVMIRCodeGen/BundleSaver.cpp
@@ -513,9 +513,7 @@ void BundleSaver::produceBundle() {
         PM, outputFile, nullptr,
         llvm::TargetMachine::CodeGenFileType::CGFT_ObjectFile);
 #else
-    TM.addPassesToEmitFile(
-        PM, outputFile, nullptr,
-        llvm::CGFT_ObjectFile);
+    TM.addPassesToEmitFile(PM, outputFile, nullptr, llvm::CGFT_ObjectFile);
 #endif
 
     PM.run(M);

--- a/lib/LLVMIRCodeGen/BundleSaver.cpp
+++ b/lib/LLVMIRCodeGen/BundleSaver.cpp
@@ -508,10 +508,14 @@ void BundleSaver::produceBundle() {
 #if FACEBOOK_INTERNAL && LLVM_VERSION_MAJOR < 8
     TM.addPassesToEmitFile(
         PM, outputFile, llvm::TargetMachine::CodeGenFileType::CGFT_ObjectFile);
-#else
+#elif LLVM_VERSION_MAJOR < 10
     TM.addPassesToEmitFile(
         PM, outputFile, nullptr,
         llvm::TargetMachine::CodeGenFileType::CGFT_ObjectFile);
+#else
+    TM.addPassesToEmitFile(
+        PM, outputFile, nullptr,
+        llvm::CGFT_ObjectFile);
 #endif
 
     PM.run(M);

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -326,9 +326,8 @@ void LLVMIRGen::finishCodeGen() {
         PM, asmStream, nullptr,
         llvm::TargetMachine::CodeGenFileType::CGFT_AssemblyFile);
 #else
-    getTargetMachine().addPassesToEmitFile(
-        PM, asmStream, nullptr,
-        llvm::CGFT_AssemblyFile);
+    getTargetMachine().addPassesToEmitFile(PM, asmStream, nullptr,
+                                           llvm::CGFT_AssemblyFile);
 #endif
 
     PM.run(*llmodule_);

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -321,10 +321,14 @@ void LLVMIRGen::finishCodeGen() {
 #if FACEBOOK_INTERNAL && LLVM_VERSION_MAJOR < 8
     getTargetMachine().addPassesToEmitFile(
         PM, asmStream, llvm::TargetMachine::CodeGenFileType::CGFT_AssemblyFile);
-#else
+#elif LLVM_VERSION_MAJOR < 10
     getTargetMachine().addPassesToEmitFile(
         PM, asmStream, nullptr,
         llvm::TargetMachine::CodeGenFileType::CGFT_AssemblyFile);
+#else
+    getTargetMachine().addPassesToEmitFile(
+        PM, asmStream, nullptr,
+        llvm::CGFT_AssemblyFile);
 #endif
 
     PM.run(*llmodule_);

--- a/lib/Support/Debug.cpp
+++ b/lib/Support/Debug.cpp
@@ -41,9 +41,11 @@ namespace glow {
 /// Exported boolean set by -debug-glow option.
 bool DebugFlag = false;
 
+#ifndef NDEBUG
 bool isCurrentDebugType(const char *type) {
   return std::find(DebugGlowOnly.begin(), DebugGlowOnly.end(), type) !=
          DebugGlowOnly.end();
 }
+#endif
 
 } // namespace glow


### PR DESCRIPTION
Summary:
Changes to accommodate GLOW build using LLVM 10.0

Documentation:

[Optional Fixes #issue]

Test Plan:

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
