### PR TITLE
Move quantized embedding ops to OSS.

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -713,8 +713,8 @@ struct EmbeddingBagInputs {
   };
 };
 
-/// Indexes used for fb::embedding_bag_byte_rowwise_offsets and
-/// fb::embedding_bag_4bit_rowwise_offsets inputs.
+/// Indexes used for quantized::embedding_bag_byte_rowwise_offsets and
+/// quantized::embedding_bag_4bit_rowwise_offsets inputs.
 struct EmbeddingBagByteRowwiseOffsetsInputs {
   enum {
     weight,
@@ -805,9 +805,9 @@ PyTorchModelLoader::buildSymbolsMapping() {
       {{"aten::topk"}, &PyTorchModelLoader::loadTopK},
       {{"prim::ConstantChunk"}, &PyTorchModelLoader::loadConstantChunk},
       {{"aten::embedding_bag"}, &PyTorchModelLoader::loadEmbeddingBag},
-      {{"fb::embedding_bag_byte_rowwise_offsets"},
+      {{"quantized::embedding_bag_byte_rowwise_offsets"},
        &PyTorchModelLoader::loadEmbeddingBagByteRowwiseOffsets},
-      {{"fb::embedding_bag_4bit_rowwise_offsets"},
+      {{"quantized::embedding_bag_4bit_rowwise_offsets"},
        &PyTorchModelLoader::loadEmbeddingBag4BitRowwiseOffsets},
   });
 


### PR DESCRIPTION
Summary: Move quantized embedding ops to OSS. This is the first step in supporting Graph Mode Quantization for EmbeddingBag. The next step would be to look into packing for embeddings as well as graph code rewrite to support post training dynamic quantization.

Differential Revision: D21949828

