### PR TITLE
Move concat optimization after arithmetic optimization pass.

### DIFF
--- a/lib/Optimizer/GraphOptimizerPipeline/FunctionPassPipeline.cpp
+++ b/lib/Optimizer/GraphOptimizerPipeline/FunctionPassPipeline.cpp
@@ -115,17 +115,17 @@ createDefaultGraphOptimizationPassPipeline() {
       // Perform Common Subexpression Elimination.
       {FunctionPassID::CSE},
 
-      // Optimize Concat nodes.
-      {FunctionPassID::OptimizeConcatNodes},
-
-      // Eliminate Concat-Slice patterns which are unnecessary.
-      {FunctionPassID::EliminateConcatSlice},
-
       // Optimize arithmetic nodes based on algebraic identities.
       {FunctionPassID::OptimizeArithmeticNodes},
 
       // Optimize Splat nodes.
       {FunctionPassID::OptimizeSplat},
+
+      // Optimize Concat nodes.
+      {FunctionPassID::OptimizeConcatNodes},
+
+      // Eliminate Concat-Slice patterns which are unnecessary.
+      {FunctionPassID::EliminateConcatSlice},
 
       // Merge Transpose into MatMul/FC.
       {FunctionPassID::MergeTransposeIntoMatMulOrFC},


### PR DESCRIPTION
Summary:
Move concat optimization after arithmetic optimization pass. This is helpful when redundant arithmetic ops block the concat optimization.

Documentation:

[Optional Fixes #issue]

Test Plan:
Test added in GraphOptzTest.cpp

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
