### PR TITLE
[Partitioner] Small fix: use move constructor (GCC 5.5 build error fix)

### DIFF
--- a/lib/Partitioner/Partitioner.cpp
+++ b/lib/Partitioner/Partitioner.cpp
@@ -1401,7 +1401,7 @@ Expected<DAGListTy> Partitioner::partitionSparseNN(CompilationContext &cctx) {
     saturateHost(cctx.optimizationOpts.sparseNNPartitioningSchemeNumCards,
                  partitions);
   }
-  return partitions;
+  return std::move(partitions);
 }
 
 Expected<DAGListTy> Partitioner::partition(CompilationContext &cctx) {


### PR DESCRIPTION
Summary:
Use move instead of copy constructor in Partitioner.
Not sure why clang compiles this, but `unique_ptr` doesn't have copy constructor, thus `DAG` default copy constructor is deleted as well.

Documentation:
N/A

Test Plan:
N/A