### PR TITLE
use ScalarType instead of string, mimic torch.tensor interface

### DIFF
--- a/torch_glow/src/GlowCompileSpec.h
+++ b/torch_glow/src/GlowCompileSpec.h
@@ -14,19 +14,21 @@ void registerGlowCompileSpecCustomClass();
 class SpecInputMeta : public torch::jit::CustomClassHolder {
   /// tuple<type, dims>
   using SpecInputMetaSerializationType =
-      std::tuple<std::string, std::vector<int64_t>>;
+      std::tuple<c10::ScalarType, std::vector<int64_t>>;
 
 public:
   // Constructors
   SpecInputMeta() = default;
   SpecInputMeta(const SpecInputMeta &other);
-  SpecInputMeta(const std::string &typeStr, std::vector<int64_t> dims);
+  SpecInputMeta(std::vector<int64_t> dims, c10::ScalarType type)
+      : type_(type), dims_(dims) {}
   SpecInputMeta(const SpecInputMetaSerializationType &state);
 
   SpecInputMeta &operator=(const SpecInputMeta &other) = default;
 
-  void setSpec(const std::string &typeStr, std::vector<int64_t> dims);
-  void setSpecFromTensor(const at::Tensor &t);
+  void set(std::vector<int64_t> dims,
+           c10::ScalarType type = c10::ScalarType::Float);
+  void setSameAs(const at::Tensor &t);
 
   SpecInputMetaSerializationType serializeToTuple() const;
   // Element type
@@ -52,7 +54,7 @@ public:
   void setBackend(const std::string &backendName) {
     backendName_ = backendName;
   }
-  void addInputTensor(const std::string &type, std::vector<int64_t> dims);
+  void addInputTensor(std::vector<int64_t> dims, c10::ScalarType type);
   void addInputFromTensor(at::Tensor);
   void addInput(c10::intrusive_ptr<SpecInputMeta> input);
   void addInputs(std::vector<c10::intrusive_ptr<SpecInputMeta>> inputs);

--- a/torch_glow/tests/functionality/glow_compile_spec_test.py
+++ b/torch_glow/tests/functionality/glow_compile_spec_test.py
@@ -7,18 +7,20 @@ import unittest
 
 class TestGlowCompileSpec(unittest.TestCase):
     def test_glow_compile_spec(self):
-        """Create glow compile spec."""
+        """Test glow compile spec basics."""
 
         dims = [2, 2]
         gcs = torch.classes.glow.GlowCompileSpec()
         gcs.setBackend("Interpreter")
-        gcs.addInputTensor("float", dims)
 
+        # Test SpecInputMeta setters
         sim = torch.classes.glow.SpecInputMeta()
-        sim.setSpec("float", dims)
+        sim.set(dims, torch.float32)
+        t = torch.tensor(dims)
+        sim.setSameAs(t)
+
+        # Test adding input methods
+        gcs.addInputTensor(dims, torch.float32)
         gcs.addInput(sim)
         inputs = [sim, sim]
         gcs.addInputs(inputs)
-
-        t = torch.tensor(dims)
-        sim.setSpecFromTensor(t)


### PR DESCRIPTION
Summary: Modify specInputMeta ctor and setter interfaces to receive ScalarType instead of a string.

Reviewed By: jackm321

Differential Revision: D22047153

