### PR TITLE
add swish sweep test that is disabled

### DIFF
--- a/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
@@ -312,6 +312,7 @@ struct BlacklistInitializer {
              TestBlacklist::AnyDeviceAnyEngine},
             {"ChannelwiseQuantizedConv2D_Int8_BiasInt32/0",
              TestBlacklist::AnyDeviceAnyEngine},
+            {"SwishSweep_Float16", TestBlacklist::AnyDeviceAnyEngine},
         };
     TestBlacklist::prepareBlacklist(testBlacklistedSetups,
                                     backendTestBlacklist);


### PR DESCRIPTION
Summary:
add a linear sweep of swish with the ranges that cover all the
possible outputs

Differential Revision: D22086923

