### PR TITLE
[GraphOptz] Add lowering logic for 1x1 Conv to FullyConnected.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,10 @@ execute_process(COMMAND
   ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
 add_definitions("-DGIT_DATE=\"${GIT_DATE}\"")
 
+# Compile definition for Glow build date in Y-M-D format.
+string(TIMESTAMP GLOW_BUILD_DATE "%Y-%m-%d")
+add_definitions("-DGLOW_BUILD_DATE=\"${GLOW_BUILD_DATE}\"")
+
 if(GLOW_USE_PNG_IF_REQUIRED)
   find_package(PNG)
   if(PNG_FOUND)

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -1992,6 +1992,11 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Function &F);
 
 llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Function *F);
 
+/// \returns whether the Convolution node \p node is equivalent with a
+/// FullyConnected node. This happens for a 2D NHWC Convolution with 1x1 filter
+/// with strides 1, pads 0, group 1 and dilations 1.
+bool isConvolutionSameAsFullyConnected(const ConvolutionNode *node);
+
 } // namespace glow
 
 #endif // GLOW_GRAPH_GRAPH_H

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -5320,7 +5320,8 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Function *F) {
 
 bool isConvolutionSameAsFullyConnected(const ConvolutionNode *node) {
   bool isConv2D = (node->getInput().getType()->dims().size() == 4);
-  if (!(isConv2D && node->getLayout() == ConvolutionLayout::NHWC)) {
+  if (!(isConv2D && node->getLayout() == ConvolutionLayout::NHWC &&
+        !node->hasFusedActivation())) {
     return false;
   }
   auto filterDims = ShapeNHWC(node->getFilter().getType()->dims());

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -5317,4 +5317,27 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Function *F) {
   F->dump(os);
   return os;
 }
+
+bool isConvolutionSameAsFullyConnected(const ConvolutionNode *node) {
+  bool isConv2D = (node->getInput().getType()->dims().size() == 4);
+  if (!(isConv2D && node->getLayout() == ConvolutionLayout::NHWC)) {
+    return false;
+  }
+  auto filterDims = ShapeNHWC(node->getFilter().getType()->dims());
+  ShapeHW kernels = ShapeHW(node->getKernels());
+  ShapeHW strides = ShapeHW(node->getStrides());
+  PaddingTLBR pads = PaddingTLBR(node->getPads());
+  auto group = node->getGroup();
+  auto dilation = node->getDilation();
+
+  bool isSame = (filterDims.h == 1) && (filterDims.w == 1);
+  isSame &= (kernels.height == 1) && (kernels.width == 1);
+  isSame &= (strides.height == 1) && (strides.width == 1);
+  isSame &= (pads.top == 0) && (pads.left == 0) && (pads.bottom == 0) &&
+            (pads.right == 0);
+  isSame &= (group == 1);
+  isSame &= (dilation == 1);
+  return isSame;
+}
+
 } // namespace glow

--- a/lib/LLVMIRCodeGen/BundleSaver.cpp
+++ b/lib/LLVMIRCodeGen/BundleSaver.cpp
@@ -91,7 +91,9 @@ static void printHeader(llvm::StringRef headerFileName,
   CHECK(!EC) << "Could not open header file!";
   std::string header;
   header += "// Bundle API auto-generated header file. Do not edit!\n";
+#ifdef GLOW_BUILD_DATE
   header += "// Glow Tools version: " + std::string(GLOW_BUILD_DATE) + "\n";
+#endif
   headerFile << strFormat(headerFileTemplate, header.c_str(),
                           bundleName.upper().data(), bundleName.upper().data(),
                           commonDefines.data(), modelInfo.data(),

--- a/lib/LLVMIRCodeGen/BundleSaver.cpp
+++ b/lib/LLVMIRCodeGen/BundleSaver.cpp
@@ -45,8 +45,7 @@ using llvm::isa;
 
 /// Header file string template.
 static const char *headerFileTemplate =
-    R"RAW(// Bundle API header file
-// Auto-generated file. Do not edit!
+    R"RAW(%s
 #ifndef _GLOW_BUNDLE_%s_H
 #define _GLOW_BUNDLE_%s_H
 
@@ -90,10 +89,13 @@ static void printHeader(llvm::StringRef headerFileName,
   llvm::raw_fd_ostream headerFile(headerFileName, EC,
                                   llvm::sys::fs::OpenFlags::F_Text);
   CHECK(!EC) << "Could not open header file!";
-  headerFile << strFormat(headerFileTemplate, bundleName.upper().data(),
-                          bundleName.upper().data(), commonDefines.data(),
-                          modelInfo.data(), modelApi.data(),
-                          headerExtra.data());
+  std::string header;
+  header += "// Bundle API auto-generated header file. Do not edit!\n";
+  header += "// Glow Tools version: " + std::string(GLOW_BUILD_DATE) + "\n";
+  headerFile << strFormat(headerFileTemplate, header.c_str(),
+                          bundleName.upper().data(), bundleName.upper().data(),
+                          commonDefines.data(), modelInfo.data(),
+                          modelApi.data(), headerExtra.data());
   headerFile.close();
 }
 

--- a/lib/Optimizer/Lower/Lower.cpp
+++ b/lib/Optimizer/Lower/Lower.cpp
@@ -823,19 +823,18 @@ static void lowerConvolutionToFullyConnected(Function *F,
   // Reshape input to 2D.
   auto inpDims = ShapeNHWC(input.getType()->dims());
   std::vector<dim_t> inpDimsFC = {inpDims.n * inpDims.h * inpDims.w, inpDims.c};
-  input =
-      F->createReshape(CN.getName().str() + ".ReshapeInput", input, inpDimsFC);
+  input = F->createReshape(DECORATE_NODE_NAME(CN, "ReshapeInput"), input,
+                           inpDimsFC);
 
   // Reshape filter to 2D and Transpose.
   auto filterDims = ShapeNHWC(filter.getType()->dims());
   std::vector<dim_t> weightsDimsFC = {filterDims.n, filterDims.c};
-  NodeValue weights = F->createReshape(CN.getName().str() + ".ReshapeWeights",
+  NodeValue weights = F->createReshape(DECORATE_NODE_NAME(CN, "ReshapeWeights"),
                                        filter, weightsDimsFC);
-  weights = F->createTranspose(CN.getName().str() + ".TransposeWeights",
+  weights = F->createTranspose(DECORATE_NODE_NAME(CN, "TransposeWeights"),
                                weights, {1, 0});
 
   // Create FullyConnected node with same output type but 2D shape.
-  // The 4D convolution input will be flattened along the channel dimension.
   auto outDims = ShapeNHWC(output.getType()->dims());
   std::vector<dim_t> outDimsFC = {outDims.n * outDims.h * outDims.w, outDims.c};
   auto outTyFC =
@@ -844,7 +843,7 @@ static void lowerConvolutionToFullyConnected(Function *F,
       CN.getName().str(), input, weights, bias, outTyFC, ShapeNHWC::DimC);
 
   // Reshape the 2D output back to its original shape.
-  outputFC = F->createReshape(CN.getName().str() + ".ReshapeOutput", outputFC,
+  outputFC = F->createReshape(DECORATE_NODE_NAME(CN, "ReshapeOutput"), outputFC,
                               output.getType()->dims());
   replaceAllUsesOfWith(cctx.loweredInfoMap, output, outputFC);
 }

--- a/lib/Optimizer/Lower/Lower.cpp
+++ b/lib/Optimizer/Lower/Lower.cpp
@@ -809,6 +809,46 @@ static void lowerBatchNormalizationGradNode(Function *F,
                        zeroSplat);
 }
 
+static void lowerConvolutionToFullyConnected(Function *F,
+                                             CompilationContext &cctx,
+                                             const ConvolutionNode &CN) {
+
+  LOG_SCOPE(F->getLogContext(), "lowerConvolutionToFullyConnected");
+
+  NodeValue output = CN.getResult();
+  NodeValue input = CN.getInput();
+  NodeValue filter = CN.getFilter();
+  NodeValue bias = CN.getBias();
+
+  // Reshape input to 2D.
+  auto inpDims = ShapeNHWC(input.getType()->dims());
+  std::vector<dim_t> inpDimsFC = {inpDims.n * inpDims.h * inpDims.w, inpDims.c};
+  input =
+      F->createReshape(CN.getName().str() + ".ReshapeInput", input, inpDimsFC);
+
+  // Reshape filter to 2D and Transpose.
+  auto filterDims = ShapeNHWC(filter.getType()->dims());
+  std::vector<dim_t> weightsDimsFC = {filterDims.n, filterDims.c};
+  NodeValue weights = F->createReshape(CN.getName().str() + ".ReshapeWeights",
+                                       filter, weightsDimsFC);
+  weights = F->createTranspose(CN.getName().str() + ".TransposeWeights",
+                               weights, {1, 0});
+
+  // Create FullyConnected node with same output type but 2D shape.
+  // The 4D convolution input will be flattened along the channel dimension.
+  auto outDims = ShapeNHWC(output.getType()->dims());
+  std::vector<dim_t> outDimsFC = {outDims.n * outDims.h * outDims.w, outDims.c};
+  auto outTyFC =
+      F->getParent()->uniqueTypeWithNewShape(output.getType(), outDimsFC);
+  NodeValue outputFC = F->createFullyConnected(
+      CN.getName().str(), input, weights, bias, outTyFC, ShapeNHWC::DimC);
+
+  // Reshape the 2D output back to its original shape.
+  outputFC = F->createReshape(CN.getName().str() + ".ReshapeOutput", outputFC,
+                              output.getType()->dims());
+  replaceAllUsesOfWith(cctx.loweredInfoMap, output, outputFC);
+}
+
 static void lowerGroupConvolutionNode(Function *F, CompilationContext &cctx,
                                       const ConvolutionNode &BNG) {
   // When Group parameter is more than 1, ConvolutionNode can be represented as
@@ -1418,6 +1458,10 @@ bool glow::lowerNode(Function *F, Node *node, CompilationContext &cctx) {
     ConvolutionNode *CN = cast<ConvolutionNode>(node);
     if (CN->getGroup() > 1 && CN->hasFusedActivation()) {
       lowerGroupConvolutionNode(F, cctx, *CN);
+      return true;
+    }
+    if (isConvolutionSameAsFullyConnected(CN)) {
+      lowerConvolutionToFullyConnected(F, cctx, *CN);
       return true;
     }
   }

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -501,6 +501,9 @@ static bool commandLineIsInvalid() {
 }
 
 void glow::parseCommandLine(int argc, char **argv) {
+  llvm::cl::SetVersionPrinter([](llvm::raw_ostream &os) {
+    os << "Glow Tools version: " << GLOW_BUILD_DATE << "\n";
+  });
   llvm::sys::PrintStackTraceOnErrorSignal(argv[0]);
   llvm::cl::ParseCommandLineOptions(
       argc, argv,


### PR DESCRIPTION
**Summary**
- Add lowering logic for 1x1 2D Convolution to FullyConnected. The reason behind this is described here: #4463
- Updated the `-version` CLI argument for the Glow tools to print the Glow build date used for tracking the build version. Also printed the version in the AOT auto-generated header file.

**Fixes**
#4463

**Test Plan**
Unit tests in GraphOptz for lowering.
Manually tested using the CPU backend that for a MobileNet v1 1.0 224 (which is full of 1x1 convolutions) the numerical results do not change after lowering all the 1x1 convolutions to FC.