### PR TITLE
Disable AvgPool3D operator test in OpenCL backend

### DIFF
--- a/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
@@ -157,6 +157,8 @@ std::set<std::string> glow::backendTestBlacklist = {
     "GroupConv3D/0",
     "NonCubicPaddingConv3D/0",
     "FP16AvgPool/0",
+    "Int8AvgPool3D/0",
+    "FP16AvgPool3D/0",
     "AdaptiveAvgPool/0",
     "FP16AdaptiveAvgPool/0",
     "Int8AdaptiveAvgPool/0",


### PR DESCRIPTION
Summary: Disable AvgPool3D operator test in OpenCL backend

Differential Revision: D22100994

