### PR TITLE
Remove unnecessary ensureOnHost

### DIFF
--- a/lib/Backends/NNPI/NNPIDeviceManager.cpp
+++ b/lib/Backends/NNPI/NNPIDeviceManager.cpp
@@ -247,9 +247,6 @@ NNPIDeviceManager::runFunction(std::string functionName,
                                runtime::ResultCBTy resultCB) {
   RunIdentifierTy runId = runIdentifier_++;
 
-  /// NNPI DeviceManager doesn't support Device Resident Tensors.
-  ctx->getPlaceholderBindings()->ensureOnHost();
-
   // Get thread env.
   auto infEnv = inferenceEnvs_.find(functionName);
   if (infEnv == inferenceEnvs_.end()) {


### PR DESCRIPTION
Summary: It seems only useful for GPU case which we don't plan to support.

Differential Revision: D22104139

