### PR TITLE
Remove useless name check for inputs

### DIFF
--- a/lib/Backends/NNPI/NNPIDeviceManager.cpp
+++ b/lib/Backends/NNPI/NNPIDeviceManager.cpp
@@ -247,9 +247,6 @@ NNPIDeviceManager::runFunction(std::string functionName,
                                runtime::ResultCBTy resultCB) {
   RunIdentifierTy runId = runIdentifier_++;
 
-  /// NNPI DeviceManager doesn't support Device Resident Tensors.
-  ctx->getPlaceholderBindings()->ensureOnHost();
-
   // Get thread env.
   auto infEnv = inferenceEnvs_.find(functionName);
   if (infEnv == inferenceEnvs_.end()) {

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -231,8 +231,7 @@ onnxStatus Graph::adjustInputs(uint32_t inputsCount,
     auto *inOnnxBuffer = reinterpret_cast<void *>(inOnnxTensor.buffer);
     Placeholder *inPhPtr;
 
-    if (onnxInputNames_.size() == inputsCount &&
-        onnxInputNames_[i] == inOnnxTensor.name) {
+    if (onnxInputNames_.size() == inputsCount) {
       inPhPtr = onnxInputPlaceholders_[i];
     } else {
       auto inPhIt = onnxInputToPlaceholder_.find(inOnnxTensor.name);


### PR DESCRIPTION
Summary: `onnxInputNames_` originated from positional name binding. This is inherited from C2, where in C2 inputs are bound by position. So it's useless to check the name here as like as `onnxInputNames_` is filled. If should save cycles on string comparison.

Differential Revision: D22104338

