### PR TITLE
Add an option to allow timeout on NNPI inference

### DIFF
--- a/lib/Backends/NNPI/InferenceContext.cpp
+++ b/lib/Backends/NNPI/InferenceContext.cpp
@@ -425,8 +425,8 @@ void InferenceContext::execute(RunIdentifierTy runId,
     // Wait on completion and error handling.
     uint32_t numErrors(0);
     // First wait for the command list to complete.
-    NNPIInferenceErrorCode res =
-        nnpiCommandListWait(commandList_, UINT32_MAX, NULL, 0, &numErrors);
+    NNPIInferenceErrorCode res = nnpiCommandListWait(
+        commandList_, deviceOptions_->inferTimeout, NULL, 0, &numErrors);
     uint64_t completeTime = TraceEvent::now();
     // Set batchDeviceTimestamps.
     auto requestData = ::glow::runtime::RequestData::get();

--- a/lib/Backends/NNPI/NNPIDeviceManager.cpp
+++ b/lib/Backends/NNPI/NNPIDeviceManager.cpp
@@ -35,12 +35,18 @@ namespace glow {
 namespace runtime {
 
 unsigned GlowNNPIMemory = 0;
+unsigned GlowNNPITimeout = 0;
 
 static llvm::cl::opt<unsigned, /* ExternalStorage */ true>
     GlowNNPIMemoryOpt("glow-nnpi-memory",
                       llvm::cl::desc("Override the amount of DRAM to allocate "
                                      "per NNPI device, in kilobytes"),
                       llvm::cl::location(GlowNNPIMemory));
+static llvm::cl::opt<unsigned, /* ExternalStorage */ true> GlowNNPITimeoutOpt(
+    "glow-nnpi-timeout",
+    llvm::cl::desc("Timeout threshold for inferecnce in microseconds. "
+                   "Default 0 means infinity"),
+    llvm::cl::location(GlowNNPITimeout));
 
 DeviceManager *createNNPIDeviceManager(const DeviceConfig &config,
                                        NNPIAdapterContainer *adapter) {
@@ -50,6 +56,9 @@ DeviceManager *createNNPIDeviceManager(const DeviceConfig &config,
       adapter->getHandle() == NNPI_INVALID_NNPIHANDLE) {
     LOG(ERROR) << "Adapter allocation failed";
     return nullptr;
+  }
+  if (GlowNNPITimeoutOpt != 0) {
+    deviceOptions->inferTimeout = GlowNNPITimeout;
   }
   return new NNPIDeviceManager(config, deviceOptions, adapter);
 }

--- a/lib/Backends/NNPI/NNPIOptions.h
+++ b/lib/Backends/NNPI/NNPIOptions.h
@@ -431,6 +431,9 @@ public:
                       "Disable IO buffers allocation by the NNPI stack.",
                       "NNPI_DISABLE_IOBUFFER", "1");
 
+  /// Inference timeout threshold. Default UINT32_MAX means infinity.
+  unsigned inferTimeout{UINT32_MAX};
+
   NNPIDeviceOptions(const llvm::StringMap<std::string> &parameters) {
     INIT_NNPI_OPTIONS(useIceT, parameters);
     INIT_NNPI_OPTIONS(inferOnDevice, parameters);

--- a/lib/Onnxifi/Flags.cpp
+++ b/lib/Onnxifi/Flags.cpp
@@ -49,8 +49,8 @@ extern size_t GlowMaxActiveRequests;
 extern size_t GlowMaxQueueSize;
 extern size_t GlowExecutorThreads;
 
-#ifdef GLOW_WITH_NNPI
 // Defined in glow/lib/Backends/NNPI/NNPI.cpp
+#ifdef GLOW_WITH_NNPI
 extern bool GlowDumpNNPICompilerData;
 extern bool GlowUsePerPartitionIcetConfig;
 extern bool GlowDisableNNPITransforms;
@@ -69,7 +69,10 @@ namespace runtime {
 extern unsigned GlowInterpreterMemory;
 extern unsigned GlowCPUMemory;
 extern unsigned GlowHabanaMemory;
+#ifdef GLOW_WITH_NNPI
 extern unsigned GlowNNPIMemory;
+extern unsigned GlowNNPITimeout;
+#endif
 extern bool GlowEnableDRT;
 extern bool GlowEnableP2P;
 } // namespace runtime
@@ -424,6 +427,14 @@ DEFINE_int32(glow_nnpi_memory, 16 << 20,
              "Amount of DRAM to allocate per NNPI device in KiB");
 DEFINE_validator(glow_nnpi_memory, [](const char *flagname, int32_t value) {
   glow::runtime::GlowNNPIMemory = value;
+  return true;
+});
+
+DEFINE_int32(glow_nnpi_timeout_ms, 0,
+             "Timeout threshold for inferecnce in milliseconds. Default 0 "
+             "means infinity");
+DEFINE_validator(glow_nnpi_timeout_ms, [](const char *flagname, int32_t value) {
+  glow::runtime::GlowNNPITimeout = value * 1000;
   return true;
 });
 #endif


### PR DESCRIPTION
Summary: For various reasons, a specific NNPI inference can stuck. In these cases, we don't want to block the NNPI worker thread and application level thread forever. Timing out and bailing out is an option. This diff adds this option.

Reviewed By: tracelogfb, gcatron

Differential Revision: D22133381

