### PR TITLE
Fix missing std::move to Partitioner::partitionSparseNN return object.

### DIFF
--- a/lib/Partitioner/Partitioner.cpp
+++ b/lib/Partitioner/Partitioner.cpp
@@ -1401,7 +1401,7 @@ Expected<DAGListTy> Partitioner::partitionSparseNN(CompilationContext &cctx) {
     saturateHost(cctx.optimizationOpts.sparseNNPartitioningSchemeNumCards,
                  partitions);
   }
-  return partitions;
+  return std::move(partitions);
 }
 
 Expected<DAGListTy> Partitioner::partition(CompilationContext &cctx) {


### PR DESCRIPTION
Summary:
Fix missing std::move to the partitions returned object in Partitioner::partitionSparseNN that causes compilation to break when compiling with GCC 7.3.1 (and older versions). 
