### PR TITLE
Improve PassManager debug by adding iteration count.

### DIFF
--- a/include/glow/PassManager/PassManager.h
+++ b/include/glow/PassManager/PassManager.h
@@ -66,6 +66,11 @@ struct PassManagerOptions {
 /// all pass managers, but provides a number of hooks that can be overridden by
 /// concrete pass manager to customize the behavior.
 class PassManagerBase : public Named {
+
+private:
+  /// The index of pass iteration
+  int iterationCount = 0;
+
 protected:
   /// The index of the current pass being executed in the pipeline.
   size_t passIdx_ = 0;
@@ -149,6 +154,12 @@ public:
   virtual std::atomic<unsigned> &globalPassCounter() = 0;
   /// Get the global pass counter associated with the pass manager.
   virtual const std::atomic<unsigned> &globalPassCounter() const = 0;
+
+  /// increase the index and return the current index
+  int globalInterationCounter(){
+    iterationCount++;
+    return iterationCount;
+  }
 };
 
 template <typename IRPassTy, typename PassIDTy>

--- a/include/glow/PassManager/PassManager.h
+++ b/include/glow/PassManager/PassManager.h
@@ -69,7 +69,7 @@ class PassManagerBase : public Named {
 
 private:
   /// The index of pass iteration
-  int iterationCount = 0;
+  int iterationCount_ = 0;
 
 protected:
   /// The index of the current pass being executed in the pipeline.
@@ -155,11 +155,6 @@ public:
   /// Get the global pass counter associated with the pass manager.
   virtual const std::atomic<unsigned> &globalPassCounter() const = 0;
 
-  /// increase the index and return the current index
-  int globalInterationCounter(){
-    iterationCount++;
-    return iterationCount;
-  }
 };
 
 template <typename IRPassTy, typename PassIDTy>

--- a/include/glow/PassManager/PassManager.h
+++ b/include/glow/PassManager/PassManager.h
@@ -154,7 +154,6 @@ public:
   virtual std::atomic<unsigned> &globalPassCounter() = 0;
   /// Get the global pass counter associated with the pass manager.
   virtual const std::atomic<unsigned> &globalPassCounter() const = 0;
-
 };
 
 template <typename IRPassTy, typename PassIDTy>

--- a/lib/PassManager/PassManager.cpp
+++ b/lib/PassManager/PassManager.cpp
@@ -166,7 +166,8 @@ void PassManagerBase::runPrePassHook(IRContainer *C,
                  << "\n";
     dumpIR(C, glow::outs(),
            C->getName().str() + "_PrePass_" + P.getName().str() + "_n" +
-               std::to_string(globalPassCounter()) + "_"+std::to_string(iterationCount_++)+ ".dot");
+               std::to_string(globalPassCounter()) + "_" +
+               std::to_string(iterationCount_++) + ".dot");
   }
 }
 
@@ -180,7 +181,8 @@ void PassManagerBase::runPostPassHook(IRContainer *C,
                  << "\n";
     dumpIR(C, glow::outs(),
            C->getName().str() + "_PostPass_" + P.getName().str() + "_n" +
-               std::to_string(globalPassCounter()) + "_"+std::to_string(iterationCount_++)+ ".dot");
+               std::to_string(globalPassCounter()) + "_" +
+               std::to_string(iterationCount_++) + ".dot");
   }
 }
 

--- a/lib/PassManager/PassManager.cpp
+++ b/lib/PassManager/PassManager.cpp
@@ -166,7 +166,7 @@ void PassManagerBase::runPrePassHook(IRContainer *C,
                  << "\n";
     dumpIR(C, glow::outs(),
            C->getName().str() + "_PrePass_" + P.getName().str() + "_n" +
-               std::to_string(globalPassCounter()) + "_"+std::to_string(globalInterationCounter())+ ".dot");
+               std::to_string(globalPassCounter()) + "_"+std::to_string(iterationCount_++)+ ".dot");
   }
 }
 
@@ -180,7 +180,7 @@ void PassManagerBase::runPostPassHook(IRContainer *C,
                  << "\n";
     dumpIR(C, glow::outs(),
            C->getName().str() + "_PostPass_" + P.getName().str() + "_n" +
-               std::to_string(globalPassCounter()) + "_"+std::to_string(globalInterationCounter())+ ".dot");
+               std::to_string(globalPassCounter()) + "_"+std::to_string(iterationCount_++)+ ".dot");
   }
 }
 

--- a/lib/PassManager/PassManager.cpp
+++ b/lib/PassManager/PassManager.cpp
@@ -166,7 +166,7 @@ void PassManagerBase::runPrePassHook(IRContainer *C,
                  << "\n";
     dumpIR(C, glow::outs(),
            C->getName().str() + "_PrePass_" + P.getName().str() + "_n" +
-               std::to_string(globalPassCounter()) + ".dot");
+               std::to_string(globalPassCounter()) + "_"+std::to_string(globalInterationCounter())+ ".dot");
   }
 }
 
@@ -180,7 +180,7 @@ void PassManagerBase::runPostPassHook(IRContainer *C,
                  << "\n";
     dumpIR(C, glow::outs(),
            C->getName().str() + "_PostPass_" + P.getName().str() + "_n" +
-               std::to_string(globalPassCounter()) + ".dot");
+               std::to_string(globalPassCounter()) + "_"+std::to_string(globalInterationCounter())+ ".dot");
   }
 }
 


### PR DESCRIPTION
Summary:

PassManager supports debug option as below:
-dump-graph-before-all-passes
-dump-graph-after-all-passes

However, the problem when I use this option is that before and after dot files are the same.
For example, `OptimizeBatchNorm` could be running in several times because `ConvergenceMode` is `UntilFixedPoint`. 
As shown in the below log, the last `OptimizeBatchNorm` overwrites the existing dot file. 

The previous dot file(`/onnx_models/conv_batchnorm.onnx_PrePass_OptimizeBatchNorm_n196589877.dot`) was lost by replacing new one (Two file names are exactly same). Therefore, we apparently did not track graph changes with this debug option.

```bash
I0618 14:43:20.249387 34099200 PassManager.cpp:119] Starting Pass #196589877: OptimizeBatchNorm on Function: "/Users/jeminlee/development/onnx_models/conv_batchnorm.onnx"
Writing dotty graph for Function to: /Users/jeminlee/development/onnx_models/conv_batchnorm.onnx_PrePass_OptimizeBatchNorm_n196589877.dot
I0618 14:43:37.811813 34099200 PassManager.cpp:119] Starting Pass #196589877: DCE on Function: "/Users/jeminlee/development/onnx_models/conv_batchnorm.onnx"
graph before pass DCE
Writing dotty graph for Function to: /Users/jeminlee/development/onnx_models/conv_batchnorm.onnx_PrePass_DCE_n196589877.dot
I0618 14:48:44.973562 34099200 PassManager.cpp:142] Finished Pass #196589877: DCE on Function: "/Users/jeminlee/development/onnx_models/conv_batchnorm.onnx"
graph after pass DCE
Writing dotty graph for Function to: /Users/jeminlee/development/onnx_models/conv_batchnorm.onnx_PostPass_DCE_n196589877.dot
I0618 14:54:05.711381 34099200 PassManager.cpp:142] Finished Pass #196589877: OptimizeBatchNorm on Function: "/Users/jeminlee/development/onnx_models/conv_batchnorm.onnx"
graph after pass OptimizeBatchNorm
Writing dotty graph for Function to: /Users/jeminlee/development/onnx_models/conv_batchnorm.onnx_PostPass_OptimizeBatchNorm_n196589877.dot
I0618 14:56:10.317090 34099200 PassManager.cpp:119] Starting Pass #196589877: OptimizeBatchNorm on Function: "/Users/jeminlee/development/onnx_models/conv_batchnorm.onnx"
graph before pass OptimizeBatchNorm
Writing dotty graph for Function to: /Users/jeminlee/development/onnx_models/conv_batchnorm.onnx_PrePass_OptimizeBatchNorm_n196589877.dot
I0618 14:56:13.148741 34099200 PassManager.cpp:119] Starting Pass #196589877: DCE on Function: "/Users/jeminlee/development/onnx_models/conv_batchnorm.onnx"
graph before pass DCE
Writing dotty graph for Function to: /Users/jeminlee/development/onnx_models/conv_batchnorm.onnx_PrePass_DCE_n196589877.dot
I0618 15:23:37.501085 34099200 PassManager.cpp:142] Finished Pass #196589877: DCE on Function: "/Users/jeminlee/development/onnx_models/conv_batchnorm.onnx"
graph after pass DCE
Writing dotty graph for Function to: /Users/jeminlee/development/onnx_models/conv_batchnorm.onnx_PostPass_DCE_n196589877.dot
I0618 15:25:06.449208 34099200 PassManager.cpp:142] Finished Pass #196589877: OptimizeBatchNorm on Function: "/Users/jeminlee/development/onnx_models/conv_batchnorm.onnx"
graph after pass OptimizeBatchNorm
Writing dotty graph for Function to: /Users/jeminlee/development/onnx_models/conv_batchnorm.onnx_PostPass_OptimizeBatchNorm_n196589877.dot
```

To fix this problem, `NewCounter` is added.

Documentation:

[Optional Fixes #issue]

Test Plan:

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
