### PR TITLE
Update swish operator unit test threshold (0.002->0.006)

### DIFF
--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -9987,7 +9987,7 @@ static void testSwish(glow::PlaceholderBindings &bindings, glow::Module &mod,
   for (dim_t i = 0; i < size; i++) {
     float x = (float)inH.at({i});
     float val = x / (1 + std::exp(-x));
-    EXPECT_NEAR(RH.at({i}), val, 0.002);
+    EXPECT_NEAR(RH.at({i}), val, 0.006);
   }
 }
 


### PR DESCRIPTION
Summary:
Update the Swish operator unit test threshold from 0.002 to 0.006.