### PR TITLE
Added NNPI device checker and fatal the program when card hang is detected

### DIFF
--- a/lib/Backends/NNPI/NNPIDeviceManager.cpp
+++ b/lib/Backends/NNPI/NNPIDeviceManager.cpp
@@ -28,14 +28,20 @@
 #include "llvm/Support/FormatVariadic.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include "folly/experimental/FunctionScheduler.h"
+
 #include "DebugMacros.h"
 #include "glow/Support/Error.h"
+
+#include <fstream>
 
 namespace glow {
 namespace runtime {
 
 unsigned GlowNNPIMemory = 0;
 unsigned GlowNNPITimeout = 0;
+unsigned GlowNNPIDeviceCheckPeriodSec = 30;
+bool GlowNNPIDeviceCheck = false;
 
 static llvm::cl::opt<unsigned, /* ExternalStorage */ true>
     GlowNNPIMemoryOpt("glow-nnpi-memory",
@@ -47,9 +53,70 @@ static llvm::cl::opt<unsigned, /* ExternalStorage */ true> GlowNNPITimeoutOpt(
     llvm::cl::desc("Timeout threshold for inferecnce in microseconds. "
                    "Default 0 means infinity"),
     llvm::cl::location(GlowNNPITimeout));
+static llvm::cl::opt<unsigned, /* ExternalStorage */ true>
+    GlowNNPIDeviceCheckPeriodSecOpt(
+        "glow-nnpi-device-check-period",
+        llvm::cl::desc(
+            "Period for NNPI device health check in seconds. Default to 32s."),
+        llvm::cl::location(GlowNNPIDeviceCheckPeriodSec));
+static llvm::cl::opt<bool, /* ExternalStorage */ true> GlowNNPIDeviceCheckOpt(
+    "glow-nnpi-device-check",
+    llvm::cl::desc(
+        "Whether to check NNPI device health or not. Default to false."),
+    llvm::cl::location(GlowNNPIDeviceCheck));
+
+namespace {
+class NNPIDeviceChecker {
+private:
+  folly::FunctionScheduler fs_;
+
+public:
+  NNPIDeviceChecker() {
+    LOG(INFO) << "Starting NNPI Device Checker...";
+    fs_.addFunction(
+        []() {
+          for (int i = 0; i < 6; ++i) {
+            std::ifstream inFile;
+            std::string bootFailReason = "/sys/class/nnpi/nnpi" +
+                                         std::to_string(i) +
+                                         +"/boot_fail_reason";
+            inFile.open(bootFailReason);
+            if (!inFile.good() || inFile.eof()) {
+              continue;
+            }
+
+            std::string reason;
+            getline(inFile, reason);
+            inFile.close();
+            LOG(INFO) << "Device " << i << ": " << reason;
+            if (reason.find("None") == std::string::npos) {
+              LOG(FATAL) << "Broken device " << i << ": " << reason;
+            }
+          }
+        },
+        std::chrono::seconds(GlowNNPIDeviceCheckPeriodSecOpt), "card");
+    fs_.start();
+  }
+
+  ~NNPIDeviceChecker() {
+    LOG(INFO) << "Shutting down NNPI Device Checker...";
+    fs_.shutdown();
+  }
+};
+
+std::once_flag deviceCheckFlag;
+} // namespace
+
+static void initNNPIDeviceChecker() {
+  static std::shared_ptr<NNPIDeviceChecker> c =
+      std::make_shared<NNPIDeviceChecker>();
+}
 
 DeviceManager *createNNPIDeviceManager(const DeviceConfig &config,
                                        NNPIAdapterContainer *adapter) {
+  if (GlowNNPIDeviceCheckOpt) {
+    std::call_once(deviceCheckFlag, []() { initNNPIDeviceChecker(); });
+  }
   std::shared_ptr<NNPIDeviceOptions> deviceOptions =
       std::make_shared<NNPIDeviceOptions>(config.parameters);
   if (deviceOptions->inferOnDevice &&

--- a/lib/Onnxifi/Flags.cpp
+++ b/lib/Onnxifi/Flags.cpp
@@ -72,6 +72,8 @@ extern unsigned GlowHabanaMemory;
 #ifdef GLOW_WITH_NNPI
 extern unsigned GlowNNPIMemory;
 extern unsigned GlowNNPITimeout;
+extern unsigned GlowNNPIDeviceCheckPeriodSec;
+extern bool GlowNNPIDeviceCheck;
 #endif
 extern bool GlowEnableDRT;
 extern bool GlowEnableP2P;
@@ -433,10 +435,27 @@ DEFINE_validator(glow_nnpi_memory, [](const char *flagname, int32_t value) {
 DEFINE_int32(glow_nnpi_timeout_ms, 0,
              "Timeout threshold for inferecnce in milliseconds. Default 0 "
              "means infinity");
-DEFINE_validator(glow_nnpi_timeout_ms, [](const char *flagname, int32_t value) {
-  glow::runtime::GlowNNPITimeout = value * 1000;
-  return true;
-});
+DEFINE_validator(glow_nnpi_timeout_ms,
+                 [](const char * /*unused*/, int32_t value) {
+                   glow::runtime::GlowNNPITimeout = value * 1000;
+                   return true;
+                 });
+
+DEFINE_bool(glow_nnpi_device_check, false,
+            "Whether to check NNPI device health or not");
+DEFINE_validator(glow_nnpi_device_check,
+                 [](const char * /*unused*/, bool value) {
+                   glow::runtime::GlowNNPIDeviceCheck = value;
+                   return true;
+                 });
+
+DEFINE_int32(glow_nnpi_device_check_period_s, 30,
+             "Period for NNPI device health check in seconds. Default to 32s.");
+DEFINE_validator(glow_nnpi_device_check_period_s,
+                 [](const char *flagname, int32_t value) {
+                   glow::runtime::GlowNNPIDeviceCheckPeriodSec = value;
+                   return true;
+                 });
 #endif
 
 DEFINE_bool(glow_log_partition, true, "Enable logging partition info");


### PR DESCRIPTION
Summary:
Preliminary impl. Might be too radical. And need tuning of params.

Together with `--glow_nnpi_timeout_ms=5000`, it should be able to resolve
- sporadic card hang
- sporadic unresponsed inference

Reviewed By: benjibc

Differential Revision: D22183576

