### PR TITLE
Add FoldLayerNormArithmetic

### DIFF
--- a/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
+++ b/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
@@ -59,6 +59,7 @@ FUN_PASS(OptimizeOutIntermediateConversions)
 FUN_PASS(OptimizeQuantFCFloatRelu)
 FUN_PASS(OptimizeConcatQuantization)
 FUN_PASS(SinkConcatBelowQuantize)
+FUN_PASS(FoldLayerNormArithmetic)
 
 
 // NOTE: This pass must be last; it's used to count the total number of passes.

--- a/lib/Optimizer/GraphOptimizerPipeline/FunctionPassPipeline.cpp
+++ b/lib/Optimizer/GraphOptimizerPipeline/FunctionPassPipeline.cpp
@@ -71,6 +71,12 @@ createDefaultGraphOptimizationPassPipeline() {
       // enables further optimizations.
       {FunctionPassID::OptimizeTransposeIntoReshape},
 
+      // Optimize arithmetic nodes based on algebraic identities.
+      {FunctionPassID::OptimizeArithmeticNodes},
+
+      // Fold some Arithmetic ops following a LayerNorm into LayerNorm.
+      {FunctionPassID::FoldLayerNormArithmetic},
+
       // Reshapes and transposes can prevent other optimizations from
       // triggering,
       // so try to optimize them out first.

--- a/tests/unittests/Repro.cpp
+++ b/tests/unittests/Repro.cpp
@@ -441,7 +441,9 @@ int run() {
   {
     ONNXModelLoader onnxLD(modelPathOpt, {}, {}, *mod, "test", &PPC, &err,
                            onnxLoaderZipMode,
-                           &cctx.backendOpts.backendSpecificNodeInfo);
+                           &cctx.backendOpts.backendSpecificNodeInfo,
+                           /* loadIntoExistingModule */ false,
+                           /* disableConstFoldInLoader */ true);
     usingGlowCustomOps = onnxLD.usingGlowCustomOps();
   }
   CHECK(!ERR_TO_BOOL(std::move(err)))


### PR DESCRIPTION
Summary:
Enable folding some arithmetic ops following LayerNorm into the LayerNorm's scale/bias.

Also disabled constant folding at proto-load time in Repro, as this should not be necessary and may cause issues for optimizations.

Differential Revision: D22220634

