### PR TITLE
Start using quantized embedding ops from OSS.

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -713,8 +713,8 @@ struct EmbeddingBagInputs {
   };
 };
 
-/// Indexes used for fb::embedding_bag_byte_rowwise_offsets and
-/// fb::embedding_bag_4bit_rowwise_offsets inputs.
+/// Indexes used for quantized::embedding_bag_byte_rowwise_offsets and
+/// quantized::embedding_bag_4bit_rowwise_offsets inputs.
 struct EmbeddingBagByteRowwiseOffsetsInputs {
   enum {
     weight,
@@ -808,9 +808,9 @@ PyTorchModelLoader::buildSymbolsMapping() {
       {{"aten::topk"}, &PyTorchModelLoader::loadTopK},
       {{"prim::ConstantChunk"}, &PyTorchModelLoader::loadConstantChunk},
       {{"aten::embedding_bag"}, &PyTorchModelLoader::loadEmbeddingBag},
-      {{"fb::embedding_bag_byte_rowwise_offsets"},
+      {{"quantized::embedding_bag_byte_rowwise_offsets"},
        &PyTorchModelLoader::loadEmbeddingBagByteRowwiseOffsets},
-      {{"fb::embedding_bag_4bit_rowwise_offsets"},
+      {{"quantized::embedding_bag_4bit_rowwise_offsets"},
        &PyTorchModelLoader::loadEmbeddingBag4BitRowwiseOffsets},
   });
 


### PR DESCRIPTION
Summary: From this diff, we switch from using our internal ```torch.ops.*fb*.embedding_bag*``` operators to ```torch.ops.*quantized*.embedding_bag*``` OSS operators.

Differential Revision: D22087096

