### PR TITLE
small glow perf improvements

### DIFF
--- a/torch_glow/src/CachingGraphRunner.cpp
+++ b/torch_glow/src/CachingGraphRunner.cpp
@@ -459,8 +459,7 @@ Error CachingGraphRunner::runImpl(const PerGlowGraphInfo &info,
       }
     }
 
-    auto var = torch::autograd::make_variable(ptTensor);
-    stack.push_back(at::IValue(var));
+    stack.push_back(at::IValue(std::move(ptTensor)));
   }
 
   if (settings_.writeToOnnx) {


### PR DESCRIPTION
Summary:
* don't call `autograd::make_variable` for torch_glow outputs, no need
* don't compute names for trace events in executeDAGNode when tracing is not enabled

Reviewed By: yinghai

Differential Revision: D22134301

