### PR TITLE
Add Function::randomizeConstants

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -2002,6 +2002,11 @@ public:
 
   /// \returns pointer to the class member for the nodes list.
   static NodesList Function::*getNodesMemberPtr() { return &Function::nodes_; }
+
+  /// Randomize all of the Constants in the function. If a Constant with users
+  /// in this Function also has users in other Functions then this will result
+  /// in a FATAL.
+  void randomizeConstants();
 };
 
 struct TrainingConfig;

--- a/tests/unittests/GraphTest.cpp
+++ b/tests/unittests/GraphTest.cpp
@@ -2099,3 +2099,102 @@ Function : F
   osM2 << MD;
   EXPECT_EQ(mesM, osM2.str());
 }
+
+// Test that randomizing Constants in a Function works.
+TEST(Graph, testRandomizeConstants) {
+  Module MD;
+  Function *F = MD.createFunction("F");
+
+  // Create tensors to be used in Constants
+  Tensor floatT(ElemKind::FloatTy, {10});
+  floatT = {3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0};
+
+  Tensor halfT(ElemKind::Float16Ty, {10});
+  halfT = {3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0};
+
+  Tensor int8QT(ElemKind::Int8QTy, {10}, 1.0, 0);
+  int8QT = {3, 3, 3, 3, 3, 3, 3, 3, 3, 3};
+
+  Tensor uint8QT(ElemKind::UInt8QTy, {10}, 1.0, 0);
+  uint8QT = {3, 3, 3, 3, 3, 3, 3, 3, 3, 3};
+
+  Tensor int16QT(ElemKind::Int16QTy, {10}, 1.0, 0);
+  int16QT = {3, 3, 3, 3, 3, 3, 3, 3, 3, 3};
+
+  Tensor int32QT(ElemKind::Int32QTy, {10}, 1.0, 0);
+  int32QT = {3, 3, 3, 3, 3, 3, 3, 3, 3, 3};
+
+  Tensor int32IT(ElemKind::Int32ITy, {10});
+  int32IT = {3, 3, 3, 3, 3, 3, 3, 3, 3, 3};
+
+  Tensor int64IT(ElemKind::Int64ITy, {10});
+  int64IT = {3, 3, 3, 3, 3, 3, 3, 3, 3, 3};
+
+  Tensor uint8FusedQT(ElemKind::UInt8FusedQTy, {10}, 1.0, 0);
+  uint8FusedQT = {3, 3, 3, 3, 3, 3, 3, 3, 3, 3};
+
+  Tensor uint8FusedFP16QT(ElemKind::UInt8FusedFP16QTy, {10}, 1.0, 0);
+  uint8FusedFP16QT = {3, 3, 3, 3, 3, 3, 3, 3, 3, 3};
+
+  Tensor uint4FusedFP16QT(ElemKind::UInt4FusedFP16QTy, {10}, 1.0, 0);
+  uint4FusedFP16QT = {3, 3, 3, 3, 3, 3, 3, 3, 3, 3};
+
+  Tensor boolT(ElemKind::BoolTy, {10});
+  boolT = {true, true, true, true, true, true, true, true, true, true, true};
+
+  // Create Constants and use them in F
+  auto *floatC = MD.createConstant("floatC", floatT);
+  F->createAdd("add", floatC, floatC);
+
+  auto *halfC = MD.createConstant("halfC", halfT);
+  F->createAdd("add", halfC, halfC);
+
+  auto *int8QC = MD.createConstant("int8QC", int8QT);
+  F->createAdd("add", int8QC, int8QC);
+
+  auto *uint8QC = MD.createConstant("uint8QC", uint8QT);
+  F->createAdd("add", uint8QC, uint8QC);
+
+  auto *int16QC = MD.createConstant("int16QC", int16QT);
+  F->createAdd("add", int16QC, int16QC);
+
+  auto *int32QC = MD.createConstant("int32QC", int32QT);
+  F->createAdd("add", int32QC, int32QC);
+
+  auto *int32IC = MD.createConstant("int32IC", int32IT);
+  F->createAdd("add", int32IC, int32IC);
+
+  auto *int64IC = MD.createConstant("int64IC", int64IT);
+  F->createAdd("add", int64IC, int64IC);
+
+  auto *uint8FusedQC = MD.createConstant("uint8FusedQC", uint8FusedQT);
+  F->createAdd("add", uint8FusedQC, uint8FusedQC);
+
+  auto *uint8FusedFP16QC =
+      MD.createConstant("uint8FusedFP16QC", uint8FusedFP16QT);
+  F->createAdd("add", uint8FusedFP16QC, uint8FusedFP16QC);
+
+  auto *uint4FusedFP16QC =
+      MD.createConstant("uint4FusedFP16QC", uint4FusedFP16QT);
+  F->createAdd("add", uint4FusedFP16QC, uint4FusedFP16QC);
+
+  auto *boolC = MD.createConstant("boolC", boolT);
+  F->createAdd("add", boolC, boolC);
+
+  // Randomize Constants in F
+  F->randomizeConstants();
+
+  // Check that no Constant is the same as what it started as
+  EXPECT_FALSE(floatT.isEqual(floatC->getPayload()));
+  EXPECT_FALSE(halfT.isEqual(halfC->getPayload()));
+  EXPECT_FALSE(int8QT.isEqual(int8QC->getPayload()));
+  EXPECT_FALSE(uint8QT.isEqual(uint8QC->getPayload()));
+  EXPECT_FALSE(int16QT.isEqual(int16QC->getPayload()));
+  EXPECT_FALSE(int32QT.isEqual(int32QC->getPayload()));
+  EXPECT_FALSE(int32IT.isEqual(int32IC->getPayload()));
+  EXPECT_FALSE(int64IT.isEqual(int64IC->getPayload()));
+  EXPECT_FALSE(uint8FusedQT.isEqual(uint8FusedQC->getPayload()));
+  EXPECT_FALSE(uint8FusedFP16QT.isEqual(uint8FusedFP16QC->getPayload()));
+  EXPECT_FALSE(uint4FusedFP16QT.isEqual(uint4FusedFP16QC->getPayload()));
+  EXPECT_FALSE(boolT.isEqual(boolC->getPayload()));
+}

--- a/torch_glow/src/PyTorchCommon.cpp
+++ b/torch_glow/src/PyTorchCommon.cpp
@@ -42,6 +42,7 @@ DEFINE_int32(replicationCount, 1, "Number of replications on each device");
 DEFINE_bool(writeToOnnx, false, "See PyTorchLoaderSettings");
 DEFINE_int32(maxActiveRequests, 250,
              "Max number of active requests before HostManager starts queuing");
+DEFINE_bool(randomizeConstants, false, "See PyTorchLoaderSettings");
 
 namespace glow {
 
@@ -221,6 +222,7 @@ static PyTorchLoaderSettings getInitialSettings() {
   settings.convertFusedToFP16 = FLAGS_convertFusedToFP16;
   settings.replicationCount = FLAGS_replicationCount;
   settings.writeToOnnx = FLAGS_writeToOnnx;
+  settings.randomizeConstants = FLAGS_randomizeConstants;
 
   if (!FLAGS_opBlacklist.empty()) {
     auto kindStrings = splitString(FLAGS_opBlacklist);

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -106,6 +106,10 @@ struct PyTorchLoaderSettings {
   /// Whether not to set the saturateHost flag (use all available device) when
   /// adding networks to HostManager.
   bool saturateHost = false;
+
+  /// If true then randomize the Constants in the Function loaded by
+  /// PyTorchModelLoader.
+  bool randomizeConstants = false;
 };
 
 /// Given a PyTorch ScalarType \p ty, \returns a matching Glow ElemKind.

--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -4033,6 +4033,10 @@ PyTorchModelLoader::PyTorchModelLoader(
       outputCorrectType.push_back(outputScalarType);
     }
 
+    if (settings.randomizeConstants) {
+      F_.randomizeConstants();
+    }
+
     if (settings.dumpGlowDag) {
       F_.dumpDAG(strFormat("%s.dot", F_.getName().data()));
     }

--- a/torch_glow/src/binding.cpp
+++ b/torch_glow/src/binding.cpp
@@ -142,6 +142,14 @@ PYBIND11_MODULE(_torch_glow, m) {
   m.def("disable_write_to_onnx",
         []() { getPyTorchLoaderSettings().writeToOnnx = false; });
 
+  /// Enable randomizing Constants in loaded Functions.
+  m.def("enable_randomize_constants",
+        []() { getPyTorchLoaderSettings().randomizeConstants = true; });
+
+  /// Disable randomizing Constants in loaded Functions.
+  m.def("disable_randomize_constants",
+        []() { getPyTorchLoaderSettings().randomizeConstants = false; });
+
   /// Enable check Glow vs jit correctness.
   m.def("enable_jit_vs_glow_compare",
         []() { getPyTorchLoaderSettings().jitVsGlowCompare = true; });

--- a/torch_glow/tests/functionality/randomize_constants_test.py
+++ b/torch_glow/tests/functionality/randomize_constants_test.py
@@ -1,0 +1,50 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import torch_glow
+import torch
+import unittest
+
+
+class Model(torch.nn.Module):
+    def __init__(self):
+        super(Model, self).__init__()
+        self.linear = torch.nn.Linear(5, 5)
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+def run_model(m, input, randomize):
+    if randomize:
+        torch_glow.enable_randomize_constants()
+    else:
+        torch_glow.disable_randomize_constants()
+
+    torch_glow.disableFusionPass()
+    traced_m = torch.jit.trace(m, input)
+
+    spec = torch.classes.glow.GlowCompileSpec()
+    spec.setBackend("Interpreter")
+    sim = torch.classes.glow.SpecInputMeta()
+    sim.setSameAs(input)
+    spec.addInputs([sim])
+
+    glow_m = torch_glow.to_glow(traced_m._c, {"forward": spec})
+    return glow_m.forward(input)
+
+
+class TestRandomizeWeights(unittest.TestCase):
+    def test_randomize_weights(self):
+        m = Model()
+        input = torch.randn(5)
+        normal1 = run_model(m, input, False)
+        normal2 = run_model(m, input, False)
+        rand1 = run_model(m, input, True)
+        rand2 = run_model(m, input, True)
+
+        assert(torch.allclose(normal1, normal2))
+        assert(not torch.allclose(normal1, rand1))
+        assert(not torch.allclose(normal1, rand2))
+        assert(not torch.allclose(normal2, rand1))
+        assert(not torch.allclose(normal2, rand2))
+        assert(not torch.allclose(rand1, rand2))


### PR DESCRIPTION
Summary:
* Add `Function::randomizeConstants()` to randomize all Constants in glow Function
* Enable randomizing all of the constants in a Function loaded from PyTorch with `torch_glow.enable_randomize_constants()`

Differential Revision: D22266130

