### PR TITLE
Enable retention of original names and adds onnx load support for some unary ops

### DIFF
--- a/include/glow/IR/IR.h
+++ b/include/glow/IR/IR.h
@@ -382,7 +382,8 @@ public:
   /// \returns a unique legal name that's based on the string \p name.  Legal
   /// names are legal C identifiers in the form: "[a-zA-Z_][a-zA-Z0-9_]*".
   llvm::StringRef uniqueName(llvm::StringRef name) {
-    return Module::uniqueName(name, stringTable_, stringTable_);
+    return Module::uniqueName(name, stringTable_, stringTable_,
+                              *G_->getParent()->getOriginalNames());
   }
 
   /// Verify the correctness of the function.

--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -283,32 +283,22 @@ protected:
     return Error::success();
   }
 
-  Error loadSigmoid(const OpType &op, ArgumentDictionaryTy &dict) {
-    const std::string &opName = loadOperatorName(op);
-    NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
-    auto *S = G_->createSigmoid(opName, in);
-    RETURN_IF_ERR(addNodeAsOutput(op, S));
-    return Error::success();
+#define LOAD_UNARY_OP(OPNAME)                                                  \
+  Error load##OPNAME(const OpType &op, ArgumentDictionaryTy &dict) {           \
+    const std::string &opName = loadOperatorName(op);                          \
+    NodeValue in;                                                              \
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));           \
+    auto *T = G_->create##OPNAME(opName, in);                                  \
+    RETURN_IF_ERR(addNodeAsOutput(op, T));                                     \
+    return Error::success();                                                   \
   }
 
-  Error loadTanh(const OpType &op, ArgumentDictionaryTy &dict) {
-    const std::string &opName = loadOperatorName(op);
-    NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
-    auto *T = G_->createTanh(opName, in);
-    RETURN_IF_ERR(addNodeAsOutput(op, T));
-    return Error::success();
-  }
-
-  Error loadExp(const OpType &op, ArgumentDictionaryTy &dict) {
-    const std::string &opName = loadOperatorName(op);
-    NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
-    auto *E = G_->createExp(opName, in);
-    RETURN_IF_ERR(addNodeAsOutput(op, E));
-    return Error::success();
-  }
+  LOAD_UNARY_OP(Sigmoid)
+  LOAD_UNARY_OP(Tanh)
+  LOAD_UNARY_OP(Exp)
+  LOAD_UNARY_OP(Neg)
+  LOAD_UNARY_OP(Floor)
+  LOAD_UNARY_OP(Ceil)
 
   Error loadShape(const OpType &op, ArgumentDictionaryTy &dict) {
     NodeValue in;
@@ -1187,6 +1177,18 @@ protected:
     }
     if (typeName == "Exp") {
       RETURN_IF_ERR(loadExp(op, dict));
+      return true;
+    }
+    if (typeName == "Neg") {
+      RETURN_IF_ERR(loadNeg(op, dict));
+      return true;
+    }
+    if (typeName == "Ceil") {
+      RETURN_IF_ERR(loadCeil(op, dict));
+      return true;
+    }
+    if (typeName == "Floor") {
+      RETURN_IF_ERR(loadFloor(op, dict));
       return true;
     }
     if (typeName == "Shape") {

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -694,6 +694,7 @@ Error Caffe2ModelLoader::loadConvTranspose(const caffe2::OperatorDef &op,
 Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
   ArgumentDictionaryTy dict = loadArgumentMap(op);
   const std::string &typeName = op.type();
+  mod_.registerOriginalName(op.name());
 
   // Check if operator is supported in parent class, CommonOperatorLoader.
   bool loadCommonOperatorSuccess;

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -3882,6 +3882,7 @@ static Error loadPerNodeOptions(const Node *loadedNode,
 Error ONNXModelLoader::loadOperator(const ONNX_NAMESPACE::NodeProto &op) {
   ArgumentDictionaryTy dict = loadArgumentMap(op);
   const std::string &typeName = op.op_type();
+  mod_.registerOriginalName(op.name());
 
   if (useGlowCustomOps_) {
     Node *loadedNode;

--- a/lib/Importer/TFLiteModelLoader.cpp
+++ b/lib/Importer/TFLiteModelLoader.cpp
@@ -765,6 +765,7 @@ Error TFLiteModelLoader::loadOperators() {
     ASSIGN_VALUE_OR_RETURN_ERR(opInfo.version, getOperatorVersion(op));
     opInfo.index = opIdx;
     // Load operator.
+    mod_.registerOriginalName(opInfo.name);
     RETURN_IF_ERR(loadOperator(op, opInfo));
   }
   return Error::success();

--- a/tests/models/onnxModels/ceil.onnxtxt
+++ b/tests/models/onnxModels/ceil.onnxtxt
@@ -1,0 +1,58 @@
+ir_version: 5
+producer_name: "onnx-example"
+graph {
+  node {
+    input: "data"
+    output: "result"
+    op_type: "Ceil"
+  }
+ name: "test-Ceil"
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "result"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 6
+}
+

--- a/tests/models/onnxModels/floor.onnxtxt
+++ b/tests/models/onnxModels/floor.onnxtxt
@@ -1,0 +1,58 @@
+ir_version: 5
+producer_name: "onnx-example"
+graph {
+  node {
+    input: "data"
+    output: "result"
+    op_type: "Floor"
+  }
+ name: "test-Floor"
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "result"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 6
+}
+

--- a/tests/models/onnxModels/legalizeNames.onnxtxt
+++ b/tests/models/onnxModels/legalizeNames.onnxtxt
@@ -1,0 +1,109 @@
+ir_version: 5
+producer_name: "onnx-example"
+graph {
+  name: "test-names"
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  node {
+    input: "data"
+    output: "clip"
+    name: "a"
+    op_type: "Clip"
+    attribute {
+      name: "min"
+      f: 20.0
+      type: FLOAT
+    }
+    attribute {
+      name: "max"
+      f: 60.0
+      type: FLOAT
+    }
+  }
+  node {
+    input: "clip"
+    name: "a__b"
+    output: "neg"
+    op_type: "Neg"
+  }
+  node {
+    input: "neg"
+    name: "a__1_"
+    output: "ceil"
+    op_type: "Ceil"
+  }
+  node {
+    input: "ceil"
+    name: "a__2"
+    output: "exp"
+    op_type: "Exp"
+  }
+  node {
+    input: "exp"
+    name: "a__3__3"
+    output: "floor"
+    op_type: "Floor"
+  }
+  node {
+    input: "floor"
+    output: "result"
+    name: "a__1"
+    op_type: "Clip"
+    attribute {
+      name: "min"
+      f: 20.0
+      type: FLOAT
+    }
+    attribute {
+      name: "max"
+      f: 60.0
+      type: FLOAT
+    }
+  }  
+  output {
+    name: "result"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 10
+}
+

--- a/tests/models/onnxModels/neg.onnxtxt
+++ b/tests/models/onnxModels/neg.onnxtxt
@@ -1,0 +1,58 @@
+ir_version: 5
+producer_name: "onnx-example"
+graph {
+  node {
+    input: "data"
+    output: "result"
+    op_type: "Neg"
+  }
+ name: "test-Neg"
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "result"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 6
+}
+

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -688,6 +688,21 @@ TEST_F(OnnxImporterTest, importExp) {
                           [](float a) { return std::exp(a); });
 }
 
+TEST(onnx, importNeg) {
+  testEltwiseUnaryOpFloat("neg.onnxtxt", {1, 2, 4, 3}, "data", 0.000,
+                          [](float a) { return -a; });
+}
+
+TEST(onnx, importCeil) {
+  testEltwiseUnaryOpFloat("ceil.onnxtxt", {1, 2, 4, 3}, "data", 0.000,
+                          [](float a) { return std::ceil(a); });
+}
+
+TEST(onnx, importFloor) {
+  testEltwiseUnaryOpFloat("floor.onnxtxt", {1, 2, 4, 3}, "data", 0.000,
+                          [](float a) { return std::floor(a); });
+}
+
 static void testImportPRelu(std::string filename,
                             llvm::ArrayRef<dim_t> inputShape,
                             std::vector<float> expectedSlope) {


### PR DESCRIPTION
Summary: 
Adds onnx load support for some ops and addresses issue https://github.com/pytorch/glow/issues/4600

Documentation:
1.  Added onnx load support/tests for ceil/floor/neg.
2.  Modify op-names at load time to prevent loss of original names later on.
3.  Test for retention of original names.

[Optional Fixes #issue]

Test Plan:

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
