### PR TITLE
Add new circleCI job named FEATURE_COMPILATION

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -160,6 +160,8 @@ elif [[ "$CIRCLE_JOB" == "PYTORCH" ]]; then
 elif [[ "$CIRCLE_JOB" == "OPENCL" ]]; then
     install_pocl
     CMAKE_ARGS+=("-DGLOW_WITH_OPENCL=ON")
+elif [[ "$CIRCLE_JOB" == "FEATURE_COMPILATION" ]]; then
+    CMAKE_ARGS+=("-DGLOW_USE_PNG_IF_REQUIRED=OFF")
 elif [[ "$CIRCLE_JOB" == "32B_DIM_T" ]]; then
     install_pocl
     CMAKE_ARGS+=("-DTENSOR_DIMS_32_BITS=ON -DGLOW_WITH_OPENCL=ON")

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,10 @@ jobs:
     environment:
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:283"
     <<: *linux_default
+  FEATURE_COMPILATION:
+    environment:
+      DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:283"
+    <<: *linux_default
   OPENCL:
     environment:
       DOCKER_IMAGE: "308535385114.dkr.ecr.us-east-1.amazonaws.com/caffe2/py2-clang8-ubuntu16.04:283"
@@ -102,6 +106,7 @@ workflows:
   build:
     jobs:
       - DEBUG
+      - FEATURE_COMPILATION
       - OPENCL
       - ASAN
       - 32B_DIM_T

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -70,7 +70,8 @@ case ${CIRCLE_JOB} in
         run_unit_tests check
         ;;
     FEATURE_COMPILATION)
-        run_unit_tests check
+        # FEATURE_COMPILATION is a compilation only CI job, thus tests
+        # are not requited.
         ;;
     DEBUG)
         run_unit_tests check

--- a/.circleci/test.sh
+++ b/.circleci/test.sh
@@ -69,6 +69,9 @@ case ${CIRCLE_JOB} in
     OPENCL)
         run_unit_tests check
         ;;
+    FEATURE_COMPILATION)
+        run_unit_tests check
+        ;;
     DEBUG)
         run_unit_tests check
         run_unit_tests test_unopt


### PR DESCRIPTION
This PR is extension of PR https://github.com/pytorch/glow/pull/4589 where we had planned to add a circleCI Job to make sure that compilation issues are caught upfront. 

This can be used to make sure that compilation of different features made available by glow can be tested. Currently have added cmake flag DGLOW_USE_PNG_IF_REQUIRED=OFF.