### PR TITLE
Don't print too much log

### DIFF
--- a/lib/Backends/NNPI/NNPIDeviceManager.cpp
+++ b/lib/Backends/NNPI/NNPIDeviceManager.cpp
@@ -88,7 +88,7 @@ public:
             std::string reason;
             getline(inFile, reason);
             inFile.close();
-            LOG(INFO) << "Device " << i << ": " << reason;
+            VLOG(1) << "Device " << i << ": " << reason;
             if (reason.find("None") == std::string::npos) {
               LOG(FATAL) << "Broken device " << i << ": " << reason;
             }


### PR DESCRIPTION
Summary: Printing device status periodically doesn't add much info.

Differential Revision: D22335488

