### PR TITLE
Move the NNPI device checker out

### DIFF
--- a/include/glow/Runtime/DeviceHealthMonitor.h
+++ b/include/glow/Runtime/DeviceHealthMonitor.h
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef GLOW_RUNTIME_HEALTHMONITOR_H
+#define GLOW_RUNTIME_HEALTHMONITOR_H
+
+#include <memory>
+#include <vector>
+
+namespace glow {
+
+/// Interface for exporting runtime statistics.  The base implementation
+/// delegates to any subclass registered via `registerStatsExporter`.
+class DeviceHealthMonitor {
+public:
+  /// Dtor.
+  virtual ~DeviceHealthMonitor() = default;
+
+  /// Start monitoring the device health
+  virtual void start() = 0;
+};
+
+/// Registry of StatsExporters.
+class DeviceHealthMonitorRegistry final {
+public:
+  /// Start all the device health monitors
+  void start() {
+    for (auto *monitor : monitors_) {
+      monitor->start();
+    }
+  }
+
+  /// Register a DeviceHealthMonitor.
+  void registerDeviceHealthMonitor(DeviceHealthMonitor *monitor);
+
+  /// Revoke a DeviceHealthMonitor.
+  void revokeDeviceHealthMonitor(DeviceHealthMonitor *exporter);
+
+  /// Static singleton DeviceHealthMonitor.
+  static std::shared_ptr<DeviceHealthMonitorRegistry> Monitors();
+
+private:
+  /// Registered StatsExporters.
+  std::vector<DeviceHealthMonitor *> monitors_;
+};
+
+} // namespace glow
+
+#endif // GLOW_RUNTIME_HEALTHMONITOR_H

--- a/lib/Onnxifi/Flags.cpp
+++ b/lib/Onnxifi/Flags.cpp
@@ -72,8 +72,6 @@ extern unsigned GlowHabanaMemory;
 #ifdef GLOW_WITH_NNPI
 extern unsigned GlowNNPIMemory;
 extern unsigned GlowNNPITimeout;
-extern unsigned GlowNNPIDeviceCheckPeriodSec;
-extern bool GlowNNPIDeviceCheck;
 #endif
 extern bool GlowEnableDRT;
 extern bool GlowEnableP2P;
@@ -451,21 +449,6 @@ DEFINE_validator(glow_nnpi_timeout_ms,
                    return true;
                  });
 
-DEFINE_bool(glow_nnpi_device_check, false,
-            "Whether to check NNPI device health or not");
-DEFINE_validator(glow_nnpi_device_check,
-                 [](const char * /*unused*/, bool value) {
-                   glow::runtime::GlowNNPIDeviceCheck = value;
-                   return true;
-                 });
-
-DEFINE_int32(glow_nnpi_device_check_period_s, 30,
-             "Period for NNPI device health check in seconds. Default to 32s.");
-DEFINE_validator(glow_nnpi_device_check_period_s,
-                 [](const char *flagname, int32_t value) {
-                   glow::runtime::GlowNNPIDeviceCheckPeriodSec = value;
-                   return true;
-                 });
 #endif
 
 DEFINE_bool(glow_log_partition, true, "Enable logging partition info");

--- a/lib/Runtime/CMakeLists.txt
+++ b/lib/Runtime/CMakeLists.txt
@@ -3,6 +3,7 @@ add_subdirectory(Executor)
 add_subdirectory(HostManager)
 
 add_library(Runtime
+  DeviceHealthMonitor.cpp
   DeferredWeightLoader.cpp
   StatsExporter.cpp)
 target_link_libraries(Runtime

--- a/lib/Runtime/DeviceHealthMonitor.cpp
+++ b/lib/Runtime/DeviceHealthMonitor.cpp
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/Runtime/DeviceHealthMonitor.h"
+
+#include <algorithm>
+
+namespace glow {
+
+void DeviceHealthMonitorRegistry::registerDeviceHealthMonitor(
+    DeviceHealthMonitor *m) {
+  monitors_.push_back(m);
+}
+
+void DeviceHealthMonitorRegistry::revokeDeviceHealthMonitor(
+    DeviceHealthMonitor *m) {
+  monitors_.erase(std::remove(monitors_.begin(), monitors_.end(), m),
+                  monitors_.end());
+}
+
+std::shared_ptr<DeviceHealthMonitorRegistry>
+DeviceHealthMonitorRegistry::Monitors() {
+  static auto monitors = std::make_shared<DeviceHealthMonitorRegistry>();
+  return monitors;
+}
+
+} // namespace glow

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -20,6 +20,7 @@
 #include "glow/Graph/PlaceholderBindings.h"
 #include "glow/Optimizer/GraphOptimizer/GraphOptimizer.h"
 #include "glow/Partitioner/Partitioner.h"
+#include "glow/Runtime/DeviceHealthMonitor.h"
 #include "glow/Runtime/Executor/ThreadPoolExecutor.h"
 #include "glow/Runtime/Provisioner/Provisioner.h"
 #include "glow/Runtime/RequestData.h"
@@ -145,6 +146,14 @@ Error HostManager::stopDeviceTrace() {
 }
 
 Error HostManager::init(std::vector<std::unique_ptr<DeviceConfig>> configs) {
+  static std::once_flag monitorFlag;
+  std::call_once(monitorFlag, []() {
+    auto monitors = DeviceHealthMonitorRegistry::Monitors();
+    if (monitors) {
+      monitors->start();
+    }
+  });
+
   DeviceIDTy deviceCount = 0;
 
   for (auto &config : configs) {


### PR DESCRIPTION
Summary:
Move the NNPI device checker out of NNPIDeviceManager and use registry so that
- We can provide a generic interface for device monitoring
- We can register any monitor that can 1) use lower level NNPI api. 2) use FB specific facility

Differential Revision: D22376097

