### PR TITLE
[FrontEnd] Update tools to work with TensorFlowLite models

### DIFF
--- a/docs/ModelTuner.md
+++ b/docs/ModelTuner.md
@@ -72,12 +72,17 @@ where:
 - `dataset-file` - The path to the dataset description file which contains on each line a data path and integer
                    label separated by space (" ") or comma (","). The integer labels start with 0 (0,1,...).
                    An example might look like this:
+                   
                    ```
                    image0.png 0 
+                   
                    image1.png 13
+                   
                    .............
+                   
                    ```
                    Another example might look like this:
+                   
                    ```
                    image0.png,0, 
                    image1.png,13,

--- a/docs/ModelTuner.md
+++ b/docs/ModelTuner.md
@@ -1,21 +1,49 @@
 ## ModelTuner
 
 This front end tool is used for tuning (calibrating) the quantization parameters of a model.
-During the quantization flow, the model is first profiled by gathering the dynamic range (min/max)
-for each tensor in the graph. Next, the quantization parameters are chosen in such a way that, for
-the given profile, no saturation occurs. Although this makes sense at first glance, there
-is actually a tradeoff when choosing the quantization parameters for a given tensor: it might be
-be beneficial overall if the quantization parameters are chosen such that to provide a smaller
-quantization step (e.g. smaller **scale** parameter) which means a better representation of most
-of the tensor values (the bulk of the histogram) at the expense of actually saturating the extreme
-values (outliers).
+During the quantization flow, the model is first **profiled** by gathering the dynamic range (min/max)
+and the histogram for each tensor in the graph. When the model is **compiled**, the quantization
+parameters are chosen in such a way that, for the given profile, no saturation occurs. Although this
+makes sense at first glance, there is actually a tradeoff when choosing the quantization parameters
+for a given tensor: it might be beneficial overall if the quantization parameters are chosen such
+that to provide a smaller quantization step (e.g. smaller **scale** parameter) which means a better
+representation of most of the tensor values (the bulk of the histogram) at the expense of actually
+saturating the extreme values (outliers).
 
-This tool is basically tuning the quantization parameters by using the following simple algorithm:
-- For each node in the graph, try different quantization parameters in the vicinity of the initially
-chosen values (right after the profiling). For example, this is done by successively dividing the
-**scale** parameter by 2 for a maximum of 3 iterations.
-- For each tested quantization parameters, keep the ones which provide the best accuracy with respect
-to a given dataset.
+The **model-tuner** front end tool is currently designed to work only with image classification models,
+that is models which are provided with an input image and which compute an output vector of scores. The
+requirements for this tool are:
+- The model was already profiled using the **image-classifier** or **model-profiler** tool such that
+a profile YAML file is available for the model. A best practice when profiling is to use a set of images
+which includes one representative image for each class.
+- A labeled tuning dataset is available which is required by the tool to optimize the accuracy. A best
+practice is to use a significant dataset which should include at least 10's (or even 100's) of images
+for each class. With more images the duration of the tuning will increase but with more images used the
+result of the tuning procedure becomes more statistically relevant.
+
+The **model-tuner** tool uses a brute force approach and has the following logic:
+- It initially computes and displays the accuracy for the floating-point model and the quantized model
+without tuning:
+  - The accuracy of the floating-point model provides an approximate upper bound for the accuracy of the quantized model.
+  - The accuracy of the quantized model provides the starting point of the accuracy before the tuning procedure.
+- Iterates over all the tensors from the graph.
+- For each tensor in the graph multiple iterations are run:
+  - For each iteration a different quantization range is tried (tested) for that tensor.
+  - For each iteration the accuracy of the quantized model is computed using the tuning dataset.
+  - From all the tested quantization ranges, the range which maximizes the accuracy is kept.
+- The expected behavior is that the accuracy of the quantized model will rise progressively because for
+each tensor the quantization parameters which maximize the accuracy are kept and used in further iterations.
+- There are situations when the tuning for a tensor stops prematurely in order to save time and speed up the tuning:
+  - If iteration N+1 obtains exactly the same accuracy as iteration N then the tuning of that tensor
+    is stopped and a message `accuracy not improved` is displayed in the console.
+  - If during subsequent iterations for the same tensor the accuracy drops with at least a given delta (default is 5%)
+    then the tuning is stopped for that tensor and a message `accuracy dropped more than "acc-drop-skip"` is displayed
+    in the console. As the message suggests the value of the delta can be chosen with the `acc-drop-skip` argument.
+  - If the tensor being tuned has all its values equal (minimum value equals the maximum value) then the
+    tuning is skipped and a message `not required` is displayed in the console.
+- At the end of the tuning procedure a tuned YAML profile file will be dumped by the tool. This new profile
+file can be used further to compile and quantize the model (e.g. using the **model-compiler** tool) and
+should provide a better numerical behavior (in terms of accuracy) than the initial non-tuned profile.
 
 ### Command line options
 
@@ -26,25 +54,37 @@ image-classifier documentation):
 the image preprocessing options (layout, channel order, normalization).
 
 ```
-model-tuner -model=<model-path> <image-options> <quantization-options> -dataset-path=<dataset-folder>
+model-tuner -backend=CPU -model=<model-path> <image-options> <quantization-options> -dataset-path=<dataset-folder>
 -dataset-file=<dataset-file> -load-profile=<input-profile> -dump-tuned-profile=<tuned-profile>
 ```
 
 where:
-- *dataset-path* - the folder where the dataset files are located. The assumption is that all the dataset files
-                    are located in the same directory.
-- *dataset-file* - the path to the dataset description file which contains on each line a data path and integer
+- `-backend=CPU` - This option specifies the backend used to run the model in order to compute the accuracy.
+                   It is recommended to use the CPU backend which runs faster than other backends.
+- `<image-options>` - The options used to pre-process the images before running the inference. These options
+                      should be the same as the options used to obtain the initial profile (for example when
+                      using the **image-classifier** tool).
+- `<quantization-options>` - The quantization options used to quantize the model. These quantization options
+                             should match the desired quantization parameters used when the model is finally
+                             compiled/quantized (for example when using the **model-compiler** tool).
+- `dataset-path` - The folder where the dataset files are located. The assumption is that all the dataset files
+                   are located in the same directory.
+- `dataset-file` - The path to the dataset description file which contains on each line a data path and integer
                    label separated by space (" ") or comma (","). The integer labels start with 0 (0,1,...).
                    An example might look like this:
-                     image0.png 0 
-                     image1.png 13
-                     .............
+                   ```
+                   image0.png 0 
+                   image1.png 13
+                   .............
+                   ```
                    Another example might look like this:
-                     image0.png,0, 
-                     image1.png,13,
-                     ..............
-- *load-profile* - the path of the input profile which is loaded and tuned.
-- *dump-tuned-profile* - the path where the tuned profile is written.
+                   ```
+                   image0.png,0, 
+                   image1.png,13,
+                   ..............
+                   ```
+- `load-profile` - The path of the input profile obtained initially which is loaded and tuned.
+- `dump-tuned-profile` - The path where the tuned profile is dumped.
 
 More information can be acquired by typing the following command:
 ```
@@ -54,62 +94,58 @@ model-tuner -help
 ### Extra command line options
 
 There are a couple of extra command line parameters which can be used to tweak the algorithm behavior:
+- *max-iter-per-node* - The maximum number of tuning iterations per node/tensor (default is 3).
+- *acc-drop-skip* - The accuracy drop for which the tuning of any node/tensor is skipped. The default value is 0.05 (5%).
 - *target-accuracy* - The tuning procedure is stopped when the accuracy has reached or surpassed the given
                       value. A float value between 0.0 and 1.0 is expected. If not specified, the tuning will
                       run until completion.
-- *max-iter-per-node* - The maximum number of tuning iterations per node (default is 3).
-- *acc-drop-skip* - The accuracy drop for which the tuning of any node is skipped. The default value is 0.05 (5%).
 
 ### Command line output
 
-When running this tool the console output will might look like this:
+When running this tool the console output might look like this:
 
 ```
 Computing initial accuracy ... 
-Initial accuracy: 81.0180 %
-Number of nodes: 277
-Target accuracy: 100.0000 %
+Initial accuracy: 75.3333 % (FLOAT)
+Initial accuracy: 74.3333 % (QUANTIZED)
+Target  accuracy: 80.0000 % (QUANTIZED)
+Number of tensors: 35
 
-[1/277] Tuning node "broadcast_B_tile0_save__1:0"
-  [1/3] Testing scale = 0.00195
-  Accuracy = 81.0180 %
-  Tunning stopped for this node (no effect)
-Best accuracy : 81.0180 %
-Iteration time: 34 seconds
-Remaining time: 2 hours 36 minutes
+[1/35] Tuning quantization for tensor "Conv_0__1:0"
+  [1/3] Testing range = [-0.5000, 0.5000]
+  Accuracy = 75.3333 %
+  [2/3] Testing range = [-0.2500, 0.2500]
+  Accuracy = 66.6667 %
+  Tuning stopped for this tensor: accuracy dropped more than "acc-drop-skip"
+Best accuracy : 75.3333 %
+Iteration time: 5 seconds
+Remaining time: 0 hours 2 minutes
 
-[2/277] Tuning node "W52__1:0"
-  [1/3] Testing scale = 0.06250
-  Accuracy = 81.4422 %
-  [2/3] Testing scale = 0.03125
-  Accuracy = 79.0032 %
-  [3/3] Testing scale = 0.01562
-  Accuracy = 67.1262 %
-Best accuracy : 81.4422 %
-Iteration time: 68 seconds
-Remaining time: 5 hours 11 minutes
+[2/35] Tuning quantization for tensor "Conv_0__2:0"
+  [1/3] Testing range = [-4.0598, 4.0598]
+  Accuracy = 75.3333 %
+  Tuning stopped for this tensor: accuracy not improved
+Best accuracy : 75.3333 %
+Iteration time: 3 seconds
+Remaining time: 0 hours 1 minutes
 
 ..................................
 ..................................
 
-[277/277] Tuning node "W42__1:0"
-  [1/3] Testing scale = 0.01562
-  Accuracy = 90.2439 %
-  Tunning stopped for this node
-Best accuracy : 97.9852 %
-Iteration time: 66 seconds
+[35/35] Tuning quantization for tensor "zero__3:0"
+  Tuning skipped for this tensor: not required
+Best accuracy : 75.6667 %
+Iteration time: 3 seconds
 Remaining time: 0 hours 0 minutes
 
 
-Final accuracy: 97.9852 %
+Final accuracy: 75.6667 % (QUANTIZED)
 
-Total time: 5 hours 6 minutes
+Total time: 0 hours 2 minutes
 ```
 
 Notes:
 - The quantization tuning procedure is a long procedure: the order of magnitude of the time
-required to run is similar to training. For example, the model used for tuning in the above example
-is a medium size model (e.g. similar to a Mobile Net with a scale factor of 0.5). For this reason
-the tool also prints an estimated remaining time for running the tuning (the estimation gets
-better after calibrating more nodes).
-- When the estimated time for the tuning is too much, one might use a smaller tuning dataset.
+required to run is similar to training. For this reason the tool also prints an estimated
+remaining time for running the tuning (the estimation gets better after calibrating more nodes).
+- When the estimated time for the tuning is too high, one might use a smaller tuning dataset.

--- a/docs/ModelTuner.md
+++ b/docs/ModelTuner.md
@@ -84,7 +84,7 @@ where:
                    ..............
                    ```
 - `load-profile` - The path of the input profile obtained initially which is loaded and tuned.
-- `dump-tuned-profile` - The path where the tuned profile is dumped.
+- `dump-tuned-profile` - The path where the final tuned profile is dumped.
 
 More information can be acquired by typing the following command:
 ```

--- a/docs/ModelTuner.md
+++ b/docs/ModelTuner.md
@@ -94,9 +94,9 @@ model-tuner -help
 ### Extra command line options
 
 There are a couple of extra command line parameters which can be used to tweak the algorithm behavior:
-- *max-iter-per-node* - The maximum number of tuning iterations per node/tensor (default is 3).
-- *acc-drop-skip* - The accuracy drop for which the tuning of any node/tensor is skipped. The default value is 0.05 (5%).
-- *target-accuracy* - The tuning procedure is stopped when the accuracy has reached or surpassed the given
+- `max-iter-per-node` - The maximum number of tuning iterations per node/tensor (default is 3).
+- `acc-drop-skip` - The accuracy drop for which the tuning of any node/tensor is skipped. The default value is 0.05 (5%).
+- `target-accuracy` - The tuning procedure is stopped when the accuracy has reached or surpassed the given
                       value. A float value between 0.0 and 1.0 is expected. If not specified, the tuning will
                       run until completion.
 

--- a/docs/ModelTuner.md
+++ b/docs/ModelTuner.md
@@ -71,23 +71,19 @@ where:
                    are located in the same directory.
 - `dataset-file` - The path to the dataset description file which contains on each line a data path and integer
                    label separated by space (" ") or comma (","). The integer labels start with 0 (0,1,...).
-                   An example might look like this:
-                   
-                   ```
-                   image0.png 0 
-                   
-                   image1.png 13
-                   
-                   .............
-                   
-                   ```
-                   Another example might look like this:
-                   
-                   ```
-                   image0.png,0, 
-                   image1.png,13,
-                   ..............
-                   ```
+  An example might look like this:
+  ```
+  image0.png 0 
+  image1.png 13
+  .............
+  ```
+  Another example might look like this:
+  
+  ```
+  image0.png,0, 
+  image1.png,13,
+  ..............
+  ```
 - `load-profile` - The path of the input profile obtained initially which is loaded and tuned.
 - `dump-tuned-profile` - The path where the final tuned profile is dumped.
 

--- a/include/glow/Importer/TFLiteModelLoader.h
+++ b/include/glow/Importer/TFLiteModelLoader.h
@@ -46,6 +46,12 @@ class TFLiteModelLoader {
   /// The Glow module containing the function(s) we are constructing.
   Module &mod_;
 
+  /// A map from names of the model inputs to placeholders.
+  llvm::StringMap<Placeholder *> inputPlaceholderByName_;
+
+  /// A map from names of the model outputs to placeholders.
+  llvm::StringMap<Placeholder *> outputPlaceholderByName_;
+
   /// Vector with node values ordered by their corresponding tensor positions
   /// in the original model. This vector contains only the node values (tensors)
   /// registered in the original model since only those are needed for chaining
@@ -275,6 +281,16 @@ public:
 
   /// \returns the TensorFlowLite model description.
   std::string getModelDescription() const { return modelDescription_; };
+
+  /// \returns a map between the model input names and the input placeholders.
+  const llvm::StringMap<Placeholder *> &getInputPlaceholderMap() const {
+    return inputPlaceholderByName_;
+  }
+
+  /// \returns a map between the model output names and the output placeholders.
+  const llvm::StringMap<Placeholder *> &getOutputPlaceholderMap() const {
+    return outputPlaceholderByName_;
+  }
 
   /// Loads the TensorFlowLite model from the file \p modelFilename into the
   /// function \p F.

--- a/include/glow/Quantization/Base/Base.h
+++ b/include/glow/Quantization/Base/Base.h
@@ -208,6 +208,9 @@ struct QuantizationConfiguration {
   QuantizationConfiguration(llvm::ArrayRef<NodeProfilingInfo> i) : infos(i) {}
 };
 
+/// \returns the tensor average value based on the profiling info \p profParams.
+float getTensorAverageValue(const TensorProfilingParams &profParams);
+
 /// \returns the value \p in as clipped to the range of \p DestTy.
 template <class SrcTy, class DestTy> DestTy clip(SrcTy in) {
   static_assert(sizeof(SrcTy) >= sizeof(DestTy), "Invalid types");

--- a/lib/Quantization/Base/Base.cpp
+++ b/lib/Quantization/Base/Base.cpp
@@ -24,6 +24,23 @@
 namespace glow {
 namespace quantization {
 
+float getTensorAverageValue(const TensorProfilingParams &profParams) {
+  size_t numBins = profParams.histogram.size();
+  assert(numBins > 0 && "Histogram is empty!");
+  float histDelta = (profParams.max - profParams.min) / (float)(numBins);
+  float histOff = profParams.min + histDelta / 2.0;
+  float histAvg = 0.0;
+  float histSum = 0.0;
+  for (size_t idx = 0; idx < numBins; ++idx) {
+    float histBinCenter = histOff + histDelta * (float)idx;
+    float histBinCount = profParams.histogram[idx];
+    histAvg += histBinCenter * histBinCount;
+    histSum += histBinCount;
+  }
+  histAvg /= histSum;
+  return histAvg;
+}
+
 template <class eTy = int8_t>
 static void quantizeTensorUtil(Tensor *dest, const Tensor &src) {
   auto destH = dest->getHandle<eTy>();

--- a/lib/Quantization/Quantization.cpp
+++ b/lib/Quantization/Quantization.cpp
@@ -438,6 +438,7 @@ protected:
   CASE_SINGLE_MATCHING_INOUT_TYPE(LocalResponseNormalization, Input, Result):  \
   CASE_SINGLE_MATCHING_INOUT_TYPE(Slice, Input, Result):                       \
   CASE_SINGLE_MATCHING_INOUT_TYPE(Reshape, Input, Result):                     \
+  CASE_SINGLE_MATCHING_INOUT_TYPE(Transpose, Input, Result):                   \
   CASE_SINGLE_MATCHING_INOUT_TYPE(TopK, Input, Values):                        \
   CASE_SINGLE_MATCHING_INOUT_TYPE(Gather, Data, Result):                       \
   CASE_SINGLE_MATCHING_INOUT_TYPE(MaxPool, Input, Result)

--- a/tests/unittests/QuantizationTest.cpp
+++ b/tests/unittests/QuantizationTest.cpp
@@ -215,6 +215,33 @@ TEST(Quantization, QuantizationSerializeEmpty) {
 }
 #endif
 
+TEST(Quantization, tensorAverageValue) {
+  {
+    float min = -10.0;
+    float max = 10.0;
+    std::vector<float> hist = {64, 64};
+    TensorProfilingParams profParams(min, max, hist);
+    float avgVal = quantization::getTensorAverageValue(profParams);
+    EXPECT_FLOAT_EQ(avgVal, 0.0);
+  }
+  {
+    float min = -10.0;
+    float max = 10.0;
+    std::vector<float> hist = {0, 64};
+    TensorProfilingParams profParams(min, max, hist);
+    float avgVal = quantization::getTensorAverageValue(profParams);
+    EXPECT_FLOAT_EQ(avgVal, 5.0);
+  }
+  {
+    float min = 0.0;
+    float max = 10.0;
+    std::vector<float> hist = {64, 0};
+    TensorProfilingParams profParams(min, max, hist);
+    float avgVal = quantization::getTensorAverageValue(profParams);
+    EXPECT_FLOAT_EQ(avgVal, 2.5);
+  }
+}
+
 template <typename From, typename To> static To clip(From in) {
   static_assert(sizeof(From) >= sizeof(To),
                 "Clip should reduce the variable size");

--- a/tools/loader/ExecutorCoreHelperFunctions.h
+++ b/tools/loader/ExecutorCoreHelperFunctions.h
@@ -27,7 +27,6 @@ extern llvm::cl::opt<std::string> inputImageListFile;
 extern llvm::cl::opt<std::string> inputTensorListFile;
 extern llvm::cl::list<std::string> inputImageFilenames;
 extern llvm::cl::opt<unsigned> excludedFirstWarmupRuns;
-extern llvm::cl::opt<std::string> modelInputName;
 extern llvm::cl::opt<unsigned> warmup;
 extern llvm::cl::opt<std::string> tracePath;
 extern llvm::cl::opt<bool> convertInAndOutToFp16;

--- a/tools/loader/Loader.h
+++ b/tools/loader/Loader.h
@@ -104,6 +104,10 @@ class Loader {
   LoweredInfoMap loweredMap_;
   /// List of Loader owned extension objects.
   std::vector<std::unique_ptr<LoaderExtension>> loaderExtensionList_;
+  /// A map from the original names of the model inputs to placeholders.
+  llvm::StringMap<Placeholder *> inputPlaceholderByName_;
+  /// A map from the original names of the model outputs to placeholders.
+  llvm::StringMap<Placeholder *> outputPlaceholderByName_;
 
 public:
   /// Getter for the hostManager, this can be useful for calling into the
@@ -149,7 +153,17 @@ public:
 
   /// Load a Caffe2 or ONNX model into this Loader object according to the
   /// Loader command line options.
-  std::unique_ptr<ProtobufLoader> loadModel();
+  void loadModel();
+
+  /// \returns a map between the model input names and the input placeholders.
+  const llvm::StringMap<Placeholder *> &getInputPlaceholderMap() const {
+    return inputPlaceholderByName_;
+  }
+
+  /// \returns a map between the model output names and the output placeholders.
+  const llvm::StringMap<Placeholder *> &getOutputPlaceholderMap() const {
+    return outputPlaceholderByName_;
+  }
 
   /// Get the compilation options (context) for a given quantization \p mode.
   /// The options are initialized by the Loader command line arguments.

--- a/tools/loader/Loader.h
+++ b/tools/loader/Loader.h
@@ -61,9 +61,8 @@ class ProtobufLoader;
 
 class LoaderExtension {
 public:
-  /// Called once after ONNX or Caffe2 model loading.
-  virtual void postModelLoad(Loader &, PlaceholderBindings &, ProtobufLoader &,
-                             llvm::StringMap<Placeholder *> &,
+  /// Called once after model loading.
+  virtual void postModelLoad(Loader &, PlaceholderBindings &,
                              TypeRef inputImageType) = 0;
   /// Called once at the beginning of the mini-batch inference.
   virtual void inferInitMiniBatch(Loader &, PlaceholderBindings &,
@@ -151,16 +150,21 @@ public:
   /// Loader.
   static quantization::QuantizationConfiguration getQuantizationConfiguration();
 
-  /// Load a Caffe2 or ONNX model into this Loader object according to the
-  /// Loader command line options.
-  void loadModel();
+  /// Load a Caffe2, ONNX or TensorFlowLite model into this Loader object based
+  /// on the Loader command line options. If \p inputType is optionally given
+  /// then the model input is forced to have the given input type regardless of
+  /// the actual command line options (this requires for the model to have only
+  /// one input).
+  void loadModel(TypeRef inputType = nullptr);
 
   /// \returns a map between the model input names and the input placeholders.
+  /// The placeholder map is available once \ref loadModel() is called.
   const llvm::StringMap<Placeholder *> &getInputPlaceholderMap() const {
     return inputPlaceholderByName_;
   }
 
   /// \returns a map between the model output names and the output placeholders.
+  /// The placeholder map is available once \ref loadModel() is called.
   const llvm::StringMap<Placeholder *> &getOutputPlaceholderMap() const {
     return outputPlaceholderByName_;
   }
@@ -195,9 +199,8 @@ public:
 
   /// Register a loader extension.
   Loader &registerExtension(std::unique_ptr<LoaderExtension> ext);
-  /// Called once after ONNX or Caffe2 model loading.
-  void postModelLoad(PlaceholderBindings &bindings, ProtobufLoader &protoLoader,
-                     llvm::StringMap<Placeholder *> &, TypeRef inputImageType);
+  /// Called once after model loading.
+  void postModelLoad(PlaceholderBindings &bindings, TypeRef inputImageType);
   /// Called at the beginning of each mini-batch inference.
   void inferInitMiniBatch(PlaceholderBindings &bindings, size_t minibatchIndex,
                           size_t minibatchSize);

--- a/tools/loader/ModelProfiler.cpp
+++ b/tools/loader/ModelProfiler.cpp
@@ -213,11 +213,11 @@ int main(int argc, char **argv) {
   Loader loader;
 
   // Load the model.
-  auto protobufLoader = loader.loadModel();
+  loader.loadModel();
 
   // Get the model input placeholders in the same order as the input dataset
   // options.
-  auto inputVarsMapping = protobufLoader->getInputVarsMapping();
+  auto inputVarsMapping = loader.getInputPlaceholderMap();
   auto modelNumInputs = inputVarsMapping.size();
   checkCond(modelNumInputs == numInputDatasets,
             "Not all the model inputs where provided with the 'input-dataset' "


### PR DESCRIPTION
**Summary**
- Make the TFLiteModelLoader export the input/output placeholder map in the Loader class
- Update `model-tuner`, `model-profiler`, `image-classifier` to work with TensorFlowLite models
- Remove from Loader any reference to ProtobufLoader class to discourage its use since the TFLiteModelLoader is not derived from it.
- Upgrades to the `model-tuner` tool to work with asymmetric quantization and update documentation
- Fix in Quantization.cpp for the Transpose node to enforce same in/out quantization parameters
