### PR TITLE
Retain types on constant shape transforms

### DIFF
--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -514,8 +514,6 @@ struct Type final {
 
   /// Reshape existing type by taking shapes and strides of \p shapeType.
   static Type newShape(const Type &T, TypeRef shapeType) {
-    assert(T.getElementSize() == shapeType->getElementSize() &&
-           "Element size should be the same");
     Type ty;
     if (T.isQuantizedType()) {
       ty = Type(T.getElementType(), shapeType->dims(), T.getScale(),

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -2722,8 +2722,8 @@ bool TransposeConstants::run(Function *F, const CompilationContext &cctx) {
       continue;
     }
     // Create a new Constant NC to hold the transposed result.
-    auto cTy = F->getParent()->uniqueTypeWithNewShape(C->getType(),
-                                                      TN->getResult().dims());
+    auto cTy = F->getParent()->uniqueTypeWithNewShape(
+        C->getType(), TN->getResult().getType());
     auto *NC =
         F->getParent()->createConstant(cTy, C->getName(), TN->getLayout());
     // Transpose the value of C into NC.
@@ -3092,7 +3092,7 @@ bool OptimizeReshape::run(Function *F, const CompilationContext &cctx) {
           CanonicalTensorLayout::getInstance().getNthResultLayoutRequirements(
               reshapeNode, ReshapeNode::ResultIndices::ResultIdx);
       auto cTy = F->getParent()->uniqueTypeWithNewShape(
-          C->getType(), reshapeNode->getResult().dims());
+          C->getType(), reshapeNode->getResult().getType());
       auto *newC = F->getParent()->createConstant(cTy, C->getName(), layout);
       // Create an unowned view of the original tensor with the correct shape,
       // and assign it to the new Constant.


### PR DESCRIPTION
Summary: Missed in https://github.com/pytorch/glow/pull/4610 / D22408560 (https://github.com/pytorch/glow/commit/6ce616c3a26407593ffe3b11b61e2978d967aa66)

Differential Revision: D22429425

