### PR TITLE
Add simple ShapeInferenceEngine into CachingGraphRunner

### DIFF
--- a/torch_glow/src/CMakeLists.txt
+++ b/torch_glow/src/CMakeLists.txt
@@ -11,6 +11,16 @@ message(STATUS "Using pytorch dir ${PYTORCH_DIR}")
 
 link_directories(${PYTORCH_DIR}/lib)
 
+add_library(PyTorchShapeInference
+                     ShapeInferenceEngine.cpp)
+target_compile_options(PyTorchShapeInference
+                      PRIVATE
+                        -frtti -fexceptions -DC10_USE_GLOG)
+target_link_libraries(PyTorchShapeInference
+                      PRIVATE
+                        torch_cpu
+                        c10)
+
 add_library(PyTorchModelLoader
                      CachingGraphRunner.cpp
                      CustomPyTorchOpLoader.cpp
@@ -40,7 +50,8 @@ target_link_libraries(PyTorchModelLoader
                         Importer
                         GraphOptimizer
                         Quantization
-                        Runtime)
+                        Runtime
+                        PyTorchShapeInference)
 
 add_library(PyTorchFileLoader
                      PyTorchFileLoader.cpp)
@@ -64,6 +75,9 @@ target_link_libraries(_torch_glow
                         Backends
                         pybind11
                         torch_python)
+
+target_include_directories(PyTorchShapeInference PUBLIC
+                            ${PYTORCH_DIR}/include)
 
 target_include_directories(PyTorchModelLoader PUBLIC
                             ${PYTORCH_DIR}/include)

--- a/torch_glow/src/PyTorchCommon.cpp
+++ b/torch_glow/src/PyTorchCommon.cpp
@@ -43,6 +43,7 @@ DEFINE_bool(writeToOnnx, false, "See PyTorchLoaderSettings");
 DEFINE_int32(maxActiveRequests, 250,
              "Max number of active requests before HostManager starts queuing");
 DEFINE_bool(randomizeConstants, false, "See PyTorchLoaderSettings");
+DEFINE_bool(runShapeInference, false, "See PyTorchLoaderSettings");
 
 namespace glow {
 
@@ -219,6 +220,7 @@ static PyTorchLoaderSettings getInitialSettings() {
   settings.randomizeConstants = FLAGS_randomizeConstants;
   settings.backendName = FLAGS_torch_glow_backend;
   settings.numDevices = FLAGS_torch_glow_num_devices;
+  settings.runShapeInference = FLAGS_runShapeInference;
 
   if (!FLAGS_opBlacklist.empty()) {
     auto kindStrings = splitString(FLAGS_opBlacklist);

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -116,6 +116,9 @@ struct PyTorchLoaderSettings {
 
   /// Number of Glow devices to use.
   int32_t numDevices = -1;
+
+  // Whether to run shape inference of meta input
+  bool runShapeInference = false;
 };
 
 /// Given a PyTorch ScalarType \p ty, \returns a matching Glow ElemKind.

--- a/torch_glow/src/ShapeInferenceEngine.cpp
+++ b/torch_glow/src/ShapeInferenceEngine.cpp
@@ -1,0 +1,262 @@
+// Copyright 2004-present Facebook. All Rights Reserved.
+
+#include <iostream>
+#include <string>
+#include <torch/script.h>
+#include <unordered_set>
+#include <vector>
+
+#include "ShapeInferenceEngine.h"
+
+#include "glow/Support/Error.h"
+#include "glow/Support/Support.h"
+
+namespace glow {
+
+ShapeInferenceEngine::ShapeInferenceEngine(
+    const torch::jit::Graph &graph, const at::ArrayRef<at::IValue> &inputs)
+    : graph_(graph), inputs_(inputs){};
+
+void ShapeInferenceEngine::getNodeInputShape(const torch::jit::Node *node,
+                                             ShapeStack &inputShapes) {
+  for (auto input : node->inputs()) {
+    auto it = shapeMap_.find(input);
+    CHECK(it != shapeMap_.end());
+    inputShapes.emplace_back(shapeMap_[input]);
+  }
+}
+
+/// This function could only cover the operation which produces one output
+/// case.
+/// TODO: Since a node may have multiple outputs, this func will support
+/// multiple outputs later
+std::vector<int64_t> &
+ShapeInferenceEngine::getNodeOutputShape(const torch::jit::Node *node) {
+  return shapeMap_[node->output()];
+}
+
+ShapeStack ShapeInferenceEngine::getGraphOutputShape() {
+  return outputShapeMeta_;
+}
+
+Error ShapeInferenceEngine::shapeOnNode(const torch::jit::Node *node) {
+
+  /// Get op symbol
+  const auto kind = node->kind();
+
+  /// Get shapes of inputs from shape mapping
+  ShapeStack inputShapes;
+
+  /// Get shapes of outputs from shape mapping
+  /// Right now, all of the supported ops have single output. Multiple outputs
+  /// cases will be covered later. The \p output_shape is for single output
+  /// scenario. The \p output_shapes is for multiple output scenario.
+  /// TODO: Cover more ops which will generate multiple outputs
+  std::vector<int64_t> outputShape;
+  ShapeStack outputShapes;
+
+  getNodeInputShape(node, inputShapes);
+
+  // Get output shape
+  switch (kind) {
+  case c10::prim::Constant: {
+    ASSIGN_VALUE_OR_RETURN_ERR(outputShape, primConstant(node));
+    break;
+  }
+  case c10::aten::sub:
+  case c10::aten::add: {
+    ASSIGN_VALUE_OR_RETURN_ERR(outputShape, add(inputShapes));
+    break;
+  }
+  case c10::aten::mm: {
+    ASSIGN_VALUE_OR_RETURN_ERR(outputShape, mm(inputShapes));
+    break;
+  }
+  case c10::aten::bmm: {
+    ASSIGN_VALUE_OR_RETURN_ERR(outputShape, bmm(inputShapes));
+    break;
+  }
+  default: { return MAKE_ERR("Node is not supported"); }
+  }
+
+  // Put output shape into map
+  if (node->outputs().size() == 1) {
+    shapeMap_[node->output()] = outputShape;
+  } else {
+    for (int i = 0; i < outputShapes.size(); i++) {
+      shapeMap_[node->output(i)] = outputShapes[i];
+    }
+  }
+  return Error::success();
+}
+
+Error ShapeInferenceEngine::run() {
+
+  if (inputs_.size() != graph_.inputs().size()) {
+    return MAKE_ERR(
+        "Number of inputs mismatch between Graph and actual inputs");
+  }
+
+  /// Put graph input into shape mapping
+  getGraphIntputShape();
+
+  for (auto *node : graph_.nodes()) {
+    RETURN_IF_ERR(shapeOnNode(node));
+  }
+
+  /// Extract output from shape mapping
+  generateGraphOutputShape();
+  return Error::success();
+}
+
+void ShapeInferenceEngine::printShapeMap() {
+  for (auto elem : shapeMap_) {
+    std::cout << elem.first << " ";
+    for (auto value : elem.second) {
+      std::cout << value << " ";
+    }
+    std::cout << std::endl;
+  }
+}
+
+void ShapeInferenceEngine::getGraphIntputShape() {
+  for (auto i = 0; i < inputs_.size(); i++) {
+    auto gInName = graph_.inputs()[i];
+    shapeMap_[gInName] = {};
+
+    auto input = inputs_[i];
+    if (input.isTensor()) {
+      auto ptTensor = input.toTensor();
+      for (auto s : ptTensor.sizes()) {
+        shapeMap_[gInName].emplace_back(s);
+      }
+    } else if (input.isBool() || input.isInt()) {
+      shapeMap_[gInName] = {1};
+    } else if (input.isIntList()) {
+      auto ptIntList = input.toIntVector();
+      shapeMap_[gInName] = {static_cast<long>(ptIntList.size()), 1};
+    }
+  }
+}
+
+void ShapeInferenceEngine::generateGraphOutputShape() {
+  for (auto output : graph_.outputs()) {
+    auto it = shapeMap_.find(output);
+    CHECK(it != shapeMap_.end());
+    outputShapeMeta_.emplace_back(it->second);
+  }
+}
+
+/// The \p prim::Constant may have multiple types of output, eg.
+/// int = prim::Constant[value=0]()
+/// Float(1:1) = prim::Constant[value={0}]()
+/// bool = prim::Constant[value=0]()
+/// None = prim::Constant()
+/// Tensor = prim::Constant[value= <Tensor>]()
+/// TODO: Cover Tensor case.
+Expected<std::vector<int64_t>>
+ShapeInferenceEngine::primConstant(const torch::jit::Node *node) {
+
+  if (node->inputs().size() != 0) {
+    return MAKE_ERR("Expect zero input of prim::Constant Op.");
+  }
+  std::vector<int64_t> shape;
+  at::TypePtr type = node->output()->type();
+
+  if (type->isSubtypeOf(at::NumberType::get()) ||
+      type->isSubtypeOf(at::BoolType::get())) {
+    shape = {1};
+  } else if (type->isSubtypeOf(at::NoneType::get())) {
+    shape = {0};
+  }
+  return shape;
+}
+
+Expected<std::vector<int64_t>>
+ShapeInferenceEngine::add(const ShapeStack &shapeMeta) {
+
+  if (shapeMeta.size() != 2 && shapeMeta.size() != 3) {
+    return MAKE_ERR("Expected two or three inputs shapes of this operation.");
+  }
+
+  std::vector<int64_t> t0 = shapeMeta[0];
+  std::vector<int64_t> t1 = shapeMeta[1];
+
+  auto d0 = t0.size();
+  auto d1 = t1.size();
+  size_t dim = std::max(d0, d1);
+  std::vector<int64_t> shape(dim);
+
+  for (auto i = 0; i < dim; i++) {
+    auto j = -1 - i;
+    if (i >= d0 || t0[d0 + j] == 1) {
+      shape[dim + j] = t1[d1 + j];
+    } else if (i >= d1 || t1[d1 + j] == 1) {
+      shape[dim + j] = t0[d0 + j];
+    } else {
+      if (t1[d1 + j] != t0[d0 + j]) {
+        return MAKE_ERR(
+            strFormat("The size of tensor a (%zu) must match the size of "
+                      "tensor b (%zu)at non-singleton dimension 1.",
+                      t0[d0 + j], t1[d1 + j]));
+      }
+
+      shape[dim + j] = t1[d1 + j];
+    }
+  }
+  return shape;
+}
+
+Expected<std::vector<int64_t>>
+ShapeInferenceEngine::mm(const ShapeStack &shapeMeta) {
+
+  if (shapeMeta.size() != 2) {
+    return MAKE_ERR("Expected two inputs shapes of this operation.");
+  }
+
+  std::vector<int64_t> t0 = shapeMeta[0];
+  std::vector<int64_t> t1 = shapeMeta[1];
+
+  if (!(t1.size() == 2 && t0.size() == 2)) {
+    return MAKE_ERR("Expected 2-dimensional tensor.");
+  }
+
+  if (t0[1] != t1[0]) {
+    return MAKE_ERR(
+        strFormat("The size of tensor a (%zu) at dimension 1 must match the "
+                  "size of tensor b (%zu) at dimension 0.",
+                  t0[1], t1[0]));
+  }
+
+  std::vector<int64_t> shape = {t0[0], t1[1]};
+  return shape;
+}
+
+Expected<std::vector<int64_t>>
+ShapeInferenceEngine::bmm(const ShapeStack &shapeMeta) {
+
+  if (shapeMeta.size() != 2) {
+    return MAKE_ERR("Expected two inputs shapes of this operation.");
+  }
+
+  std::vector<int64_t> t0 = shapeMeta[0];
+  std::vector<int64_t> t1 = shapeMeta[1];
+
+  if (!(t0.size() == 3 && t1.size() == 3)) {
+    return MAKE_ERR("Expected 3-dimensional tensor.");
+  }
+
+  if (t0[0] != t1[0]) {
+    return MAKE_ERR("Expected tensors to have same size at dimension 0");
+  }
+
+  if (t0[2] != t1[1]) {
+    return MAKE_ERR(strFormat("The size of tensor a (%zu) at dimension 2 must"
+                              "match the size of tensor b (%zu) at dimension 1",
+                              t0[2], t1[1]));
+  }
+  std::vector<int64_t> shape = {t0[0], t0[1], t1[2]};
+  return shape;
+}
+
+} // namespace glow

--- a/torch_glow/src/ShapeInferenceEngine.h
+++ b/torch_glow/src/ShapeInferenceEngine.h
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef GLOW_TORCH_GLOW_SRC_SHAPEINFERENCEENGINE_H
+#define GLOW_TORCH_GLOW_SRC_SHAPEINFERENCEENGINE_H
+
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "glow/Support/Error.h"
+
+/// Given actual inputs and the glow graph, this class is responsible for
+/// slicing the upperbounded outputs from Glow back to the actual output size
+/// expected by PyTorch.
+namespace glow {
+
+using ShapeStack = std::vector<std::vector<int64_t>>;
+
+class ShapeInferenceEngine {
+public:
+  ShapeInferenceEngine(const torch::jit::Graph &graph,
+                       const at::ArrayRef<torch::jit::IValue> &inputs);
+
+  /// Get shapes of outputs of the given graph.
+  ShapeStack getGraphOutputShape();
+
+  /// This run the shape inference engine for the given \p graph and \p inputs.
+  /// \returns error of failure.
+  Error run();
+
+private:
+  /// Graph that needs to be run shape inference.
+  const torch::jit::Graph &graph_;
+
+  /// Actual inputs of the given \p graph.
+  const at::ArrayRef<torch::jit::IValue> &inputs_;
+
+  /// This is a mapping which uses torch::jit::Value as a key, Shape as a
+  /// value. It is used for tracking the shape of each input or output in a
+  /// graph.
+  std::unordered_map<const torch::jit::Value *, std::vector<int64_t>> shapeMap_;
+
+  /// Store shapes of all the outputs in a graph.
+  ShapeStack outputShapeMeta_;
+
+  /// Print shapeMap_.
+  void printShapeMap();
+
+  /// Put shape info of actual graph inputs into \p shapeMap_.
+  void getGraphIntputShape();
+
+  /// Extract shape info of graph outputs from \p shapeMap_.
+  void generateGraphOutputShape();
+
+  /// Extract shape info of node inputs from \p shapeMap_.
+  void getNodeInputShape(const torch::jit::Node *node, ShapeStack &inputShape);
+
+  // This function could only cover the operation which produces one output
+  // case.
+  // TODO: Since a node may have multiple outputs, this func will support
+  // multiple outputs in the next diff
+  std::vector<int64_t> &getNodeOutputShape(const torch::jit::Node *node);
+
+  /// Infer shapes of node outputs
+  Error shapeOnNode(const torch::jit::Node *node);
+
+  // TODO: Support more Ops
+  // Shape inference for prim::Constant
+  static Expected<std::vector<int64_t>>
+  primConstant(const torch::jit::Node *node);
+  // Shape inference for aten::add
+  static Expected<std::vector<int64_t>> add(const ShapeStack &shapeMeta);
+  // Shape inference for aten::mm
+  static Expected<std::vector<int64_t>> mm(const ShapeStack &shapeMeta);
+  // Shape inference for aten::bmm
+  static Expected<std::vector<int64_t>> bmm(const ShapeStack &shapeMeta);
+};
+
+} // namespace glow
+
+#endif // GLOW_TORCH_GLOW_SRC_SHAPEINFERENCEENGINE_H

--- a/torch_glow/src/binding.cpp
+++ b/torch_glow/src/binding.cpp
@@ -166,6 +166,14 @@ PYBIND11_MODULE(_torch_glow, m) {
   m.def("disable_saturate_host",
         []() { getPyTorchLoaderSettings().saturateHost = false; });
 
+  /// Enable shape inference engine.
+  m.def("enable_shape_inference_engine",
+        []() { getPyTorchLoaderSettings().runShapeInference = true; });
+
+  /// Disable shape inference engine.
+  m.def("disable_shape_inference_engine",
+        []() { getPyTorchLoaderSettings().runShapeInference = false; });
+
   /// Add all of the symbols in \p blacklist to the fusion blacklist so that
   /// nodes with these symbols will not be fused to Glow.
   m.def("setFusionBlacklist", [](const std::vector<std::string> &blacklist) {


### PR DESCRIPTION
Summary:
This diff added a ShapeInferenceEngine into CachingGraphRunner. The ShapeInferenceEngine will generate appropriate outputs shape according to inputs and slice the output of glow into outputs with corresponding shape, then push back into the stack. Right now, it only supports limited ops.

TODO:
1. Expand the coverage of Ops. At least covers the Ops in the CtrMblFeedTest models.
2. The runtime shape inference has high requirement for efficiency. Add hashing may speedup the shape inference.
3. The ShapeInferenceEngine can also be used in Pytorch for generate output with MetaTensors. We could consider how to migrate with MetaTensor later.

Reviewed By: qizzzh

Differential Revision: D22248847

