### PR TITLE
Add new HostManagerRegistry and interface to support multi-tenancy

### DIFF
--- a/include/glow/Runtime/HostManager/HostManager.h
+++ b/include/glow/Runtime/HostManager/HostManager.h
@@ -197,6 +197,11 @@ public:
   /// Update the list of available devices.
   void setAvailableDevices(const std::vector<DeviceIDTy> &devices);
 
+  /// For a given \p network returns all partitions of that network and the
+  /// devices each partition is assigned to.
+  std::unordered_map<std::string, std::vector<DeviceIDTy>>
+  getDevicePartitionMapping(llvm::StringRef network);
+
   /// Returns true if \p networkName is already added to the host.
   bool networkAdded(llvm::StringRef networkName);
 
@@ -283,6 +288,19 @@ generateDeviceConfigs(unsigned int numDevices, llvm::StringRef backendName,
 bool loadDeviceConfigsFromFile(
     std::vector<std::unique_ptr<runtime::DeviceConfig>> &configs,
     size_t memSize);
+
+/// Registry singleton for aquiring a HostManager.
+class HostManagerRegistry final {
+public:
+  void registerHostManager(HostManager *hostManager);
+  HostManager *getHostManager();
+
+private:
+  HostManager *hostManager_{nullptr};
+};
+
+/// Global singleton.
+std::shared_ptr<HostManagerRegistry> ManagerRegistry();
 
 } // namespace runtime
 } // namespace glow

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -180,6 +180,11 @@ Error HostManager::init(std::vector<std::unique_ptr<DeviceConfig>> configs) {
                                                    devices.end());
     setAvailableDevices(convertedDevs);
   }
+  // If no HostManager is registered yet, register this one.
+  if (!ManagerRegistry()->getHostManager()) {
+    ManagerRegistry()->registerHostManager(this);
+  }
+
   return Error::success();
 }
 
@@ -455,6 +460,23 @@ Error HostManager::addNetwork(std::unique_ptr<Module> module,
     cleanupAddNetwork(names);
   }
   return Error::success();
+}
+
+std::unordered_map<std::string, std::vector<DeviceIDTy>>
+HostManager::getDevicePartitionMapping(llvm::StringRef network) {
+  std::unordered_map<std::string, std::vector<DeviceIDTy>> mapping;
+  auto it = networks_.find(network);
+  if (it != networks_.end()) {
+    auto &nodeList = it->second.dag.nodes;
+    for (auto &node : nodeList) {
+      std::vector<DeviceIDTy> devices;
+      for (auto &dev : node->deviceRuntimeInfos) {
+        devices.push_back(dev.first);
+      }
+      mapping[node->name] = devices;
+    }
+  }
+  return mapping;
 }
 
 Error HostManager::removeNetwork(llvm::StringRef networkName) {
@@ -797,4 +819,15 @@ Backend &HostManager::getBackend(llvm::StringRef backendName) const {
 
 Expected<Backend *> HostManager::getBackend() const {
   return provisioner_->getBackend();
+}
+
+HostManager *HostManagerRegistry::getHostManager() { return hostManager_; }
+
+void HostManagerRegistry::registerHostManager(HostManager *hostManager) {
+  hostManager_ = hostManager;
+}
+
+std::shared_ptr<HostManagerRegistry> glow::runtime::ManagerRegistry() {
+  static auto hostManager = std::make_shared<HostManagerRegistry>();
+  return hostManager;
 }


### PR DESCRIPTION
Summary:
This adds a new hostManager interface which allows for accessing the HostManager to query network assignments and set available devices for network loading.
The registry provides a method to register a HM and get a registered HM. During initialization a HM will register itself if no HM has been registered yet.

Reviewed By: yinghai

Differential Revision: D22405909

