### PR TITLE
Back out "Zero-arithmetic and identity-arithmetic optimizations with uniform constant."

### DIFF
--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -248,19 +248,14 @@ static bool isIdentityShuffle(llvm::ArrayRef<unsigned> shuffle) {
 /// \returns True if the node \p N always evaluates to \p val.
 bool isSplatOfVal(Node *N, float val) {
   SplatNode *Z = dyn_cast<SplatNode>(N);
-  if (Z) {
-    return (Z->getValue() == val);
+  if (!Z) {
+    return false;
   }
-  Constant *C = dyn_cast<Constant>(N);
-  if (C) {
-    float fval;
-    return isUniformConstant<float>(*C, fval) && (fval == val);
-  }
-  return false;
+  return (Z->getValue() == val);
 }
 
 /// \returns True if the node returns a constant value.
-bool isConstant(Node *N) { return isa<SplatNode>(N) || isa<Constant>(N); }
+bool isConstant(Node *N) { return isa<SplatNode>(N); }
 
 /// \returns the new simplified NodeValue or the original node's first result.
 static NodeValue simplifyNode(Node *node, Function *F) {

--- a/tests/unittests/QuantizationTest.cpp
+++ b/tests/unittests/QuantizationTest.cpp
@@ -2295,13 +2295,13 @@ TEST(Quantization, quantizeGraphPartiallyMultipleKinds) {
     ASSERT_TRUE(AN);
     EXPECT_TRUE(!TN->getResult().getType()->isQuantizedType());
 
-    // Verify that the RHS input to the AddNode is an unquantized variable.
-    auto varANRHS = llvm::dyn_cast<Constant>(AN->getRHS());
-    ASSERT_TRUE(varANRHS);
-    EXPECT_TRUE(!varANRHS->getType()->isQuantizedType());
+    // Verify that the LHS input to the AddNode is an unquantized variable.
+    auto varANLHS = llvm::dyn_cast<Constant>(AN->getLHS());
+    ASSERT_TRUE(varANLHS);
+    EXPECT_TRUE(!varANLHS->getType()->isQuantizedType());
 
-    // Verify that the LHS input to the AddNode is a dequantize node.
-    auto *DN = llvm::dyn_cast<DequantizeNode>(AN->getLHS());
+    // Verify that the RHS input to the AddNode is a dequantize node.
+    auto *DN = llvm::dyn_cast<DequantizeNode>(AN->getRHS());
     ASSERT_TRUE(DN);
 
     // Verify that the matmul is quantized.

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -28,6 +28,8 @@ DECLARE_bool(dumpFinalGlowGraph);
 
 namespace glow {
 
+struct InputMeta;
+
 /// Various settings to be used by code that loads PyTorch models. There should
 /// only be one of these and it should be obtained by calling
 /// getPyTorchLoaderSettings().
@@ -148,8 +150,9 @@ std::shared_ptr<runtime::HostManager>
 getHostManager(const std::string &backendName, int32_t numDevices = -1);
 
 /// \returns the PyTorch symbol to be used for the PyTorch node which represents
-/// the subgraph that Glow will compile and run.
-const c10::Symbol &getGlowSymbol();
+/// the subgraph that Glow will compile and run. \p g is the PyTorch graph to
+/// lower, and if specified, will be used to generate unique symbol
+c10::Symbol getGlowSymbol(std::shared_ptr<torch::jit::Graph> g = nullptr);
 
 /// Given a PyTorch TensorType \p ptType, \returns a matching Glow Type.
 glow::Type ptTypeToGlowType(const c10::TensorType &ptType);
@@ -166,6 +169,15 @@ glow::Tensor ptTensorToGlowTensor(const at::Tensor &ptTensor);
 /// Given a Glow Type \p glowType, \returns an empty PyTorch Tensor with a
 /// matching type.
 at::Tensor glowTypeToEmptyPTTensor(const glow::Type &glowType);
+
+/// Load the \p InputMeta data contains Glow fusion node's input size and type
+/// info from \p raw_data stored in string format.
+std::shared_ptr<std::vector<glow::InputMeta>>
+loadInputMeta(const std::string &raw_data);
+
+/// Lower a pytorch \p module to glow before execution. \p inputMetaStr is the
+/// raw string containing the meta data of the glow fuser node input.
+void glowAOTFusion(torch::jit::Module &module, const std::string &inputMetaStr);
 
 /// Enable overriding signal handlers while exeucting torch_glow code. This
 /// should only be used in Python to enable easier debugging and not in


### PR DESCRIPTION
Summary: Revert because this diff causes accuracy drop when using fp16 conversion.

Differential Revision: D22436714

