### PR TITLE
[GraphOpt] Add generalized Noop elimination pass

### DIFF
--- a/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
+++ b/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
@@ -38,8 +38,7 @@ FUN_PASS(CSE)
 FUN_PASS(OptimizeSplat)
 FUN_PASS(OptimizeTransposeIntoReshape)
 FUN_PASS(OptimizeReshape)
-FUN_PASS(EliminateNoopTile)
-FUN_PASS(EliminateNoopSlice)
+FUN_PASS(EliminateNoop)
 FUN_PASS(OptimizeClips)
 FUN_PASS(OptimizeConversions)
 FUN_PASS(OptimizeQuantization)
@@ -60,8 +59,6 @@ FUN_PASS(OptimizeQuantFCFloatRelu)
 FUN_PASS(OptimizeConcatQuantization)
 FUN_PASS(SinkConcatBelowQuantize)
 FUN_PASS(FoldLayerNormArithmetic)
-FUN_PASS(OptimizeSelect)
-
 
 // NOTE: This pass must be last; it's used to count the total number of passes.
 FUN_PASS(EmptyPass)

--- a/include/glow/Support/Support.h
+++ b/include/glow/Support/Support.h
@@ -276,6 +276,12 @@ public:
   };
 };
 
+/// Helper function to return true if every element in array \p a is \p x.
+template <typename ElemTy>
+static bool isUniformArray(llvm::ArrayRef<ElemTy> a, ElemTy x) {
+  return std::all_of(a.begin(), a.end(), [x](ElemTy e) { return e == x; });
+}
+
 } // namespace glow
 
 #endif // GLOW_SUPPORT_SUPPORT_H

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -2999,41 +2999,70 @@ bool OptimizeTransposeIntoReshape::run(Function *F,
   return changed;
 }
 
-bool EliminateNoopTile::run(Function *F, const CompilationContext &cctx) {
-  LOG_SCOPE(F->getLogContext(), getName());
-  bool changed = false;
-
-  for (auto &node : F->getNodes()) {
-    if (auto *tileNode = dyn_cast<TileNode>(&node)) {
-      // If the TileNode tiles only once, eliminate it.
-      if (tileNode->getCount() == 1) {
-        tileNode->getResult().replaceAllUsesOfWith(tileNode->getInput());
-        changed = true;
-      }
-    }
+/// Gets Constant or returns nullptr if input is not Constant.
+/// Skips QuantizeNode if present.
+static Constant *getConstant(const NodeValue &NV) {
+  Node *N = NV.getNode();
+  if (isa<QuantizeNode>(N)) {
+    N = N->getNthInput(QuantizeNode::InputIdx);
   }
-
-  return changed;
+  return dyn_cast<Constant>(N);
 }
 
-/// Eliminate noop Slice(Node) -> Node.
-bool EliminateNoopSlice::run(Function *F, const CompilationContext &cctx) {
+/// Eliminate nodes which don't do anything useful.
+bool EliminateNoop::run(Function *F, const CompilationContext &cctx) {
   LOG_SCOPE(F->getLogContext(), getName());
   bool changed = false;
 
+  auto isNoop = [](const Node &node, NodeValue &input,
+                   NodeValue &output) -> bool {
+    // Auto-select input/output, if there is just one. For other cases it
+    // will be handled on per-operator basis below.
+    if (node.getNumInputs() == 1) {
+      input = node.getNthInput(0);
+    }
+    if (node.getNumResults() == 1) {
+      output = node.getNthResult(0);
+    }
+
+    // For some nodes it's enough just to compare input and output types to
+    // determine if they are noop.
+    if (isa<PadNode>(&node) || isa<SliceNode>(&node) || isa<TileNode>(&node)) {
+      return input.getType() == output.getType();
+    }
+
+    // Operator-specific analysis.
+    if (auto *APN = dyn_cast<AvgPoolNode>(&node)) {
+      input = APN->getInput();
+      return isUniformArray(APN->getKernels(), 1u) &&
+             isUniformArray(APN->getStrides(), 1u) &&
+             isUniformArray(APN->getPads(), 0u);
+    } else if (auto *MPN = dyn_cast<MaxPoolNode>(&node)) {
+      input = MPN->getInput();
+      output = MPN->getResult();
+      return isUniformArray(MPN->getKernels(), 1u) &&
+             isUniformArray(MPN->getStrides(), 1u) &&
+             isUniformArray(MPN->getPads(), 0u);
+    } else if (auto *SN = dyn_cast<SelectNode>(&node)) {
+      auto *cond = getConstant(SN->getCond());
+      bool val = false;
+      if (cond && isUniformConstant<bool>(*cond, val)) {
+        input = val ? SN->getLHS() : SN->getRHS();
+        return true;
+      }
+    }
+
+    return false;
+  };
+
   for (auto &node : F->getNodes()) {
-    SliceNode *sliceNode = dyn_cast<SliceNode>(&node);
-    if (!sliceNode) {
-      continue;
+    NodeValue input, output;
+    if (isNoop(node, input, output)) {
+      assert(input != NodeValue() && output != NodeValue() &&
+             "Sanity check that input and output are set");
+      output.replaceAllUsesOfWith(input);
+      changed = true;
     }
-
-    // If input and result have different types then this is not a noop.
-    if (sliceNode->getInput().getType() != sliceNode->getResult().getType()) {
-      continue;
-    }
-
-    sliceNode->getResult().replaceAllUsesOfWith(sliceNode->getInput());
-    changed = true;
   }
 
   return changed;
@@ -4804,41 +4833,6 @@ static void setFP16AccumSLS(Function *F,
       continue;
     }
   } while (nodeIt != stopIt);
-}
-
-/// Gets Constant or returns nullptr if input is not Constant.
-/// Skips QuantizeNode if present.
-static Constant *getConstant(const NodeValue &NV) {
-  Node *N = NV.getNode();
-  if (isa<QuantizeNode>(N)) {
-    N = N->getNthInput(QuantizeNode::InputIdx);
-  }
-  return dyn_cast<Constant>(N);
-}
-
-/// Simple optimization if select cond is constant and uniform, just pick
-/// appropriate input.
-bool OptimizeSelect::run(Function *F, const CompilationContext &cctx) {
-  bool changed = false;
-  for (auto &n : F->getNodes()) {
-    auto *selectN = llvm::dyn_cast<SelectNode>(&n);
-    if (!selectN) {
-      continue;
-    }
-
-    auto *constCond = getConstant(selectN->getCond());
-    bool val = false;
-    if (!constCond || !isUniformConstant<bool>(*constCond, val)) {
-      continue;
-    }
-    changed = true;
-    if (val) {
-      selectN->getResult().replaceAllUsesOfWith(selectN->getLHS());
-    } else {
-      selectN->getResult().replaceAllUsesOfWith(selectN->getRHS());
-    }
-  }
-  return changed;
 }
 
 /// This funciton uses TypeAToTypeBFunctionConverter to do a whole graph

--- a/tests/unittests/GraphOptzTest.cpp
+++ b/tests/unittests/GraphOptzTest.cpp
@@ -3027,45 +3027,44 @@ TEST_F(GraphOptz, mergeBANodes) {
   EXPECT_EQ(countNodeKind(F_, Kinded::Kind::BatchedAddNodeKind), 1);
 }
 
-/// Check that TileNodes that tile something only once are eliminated.
-TEST_F(GraphOptz, eliminateNoopTile) {
-  auto *A = mod_.createPlaceholder(ElemKind::FloatTy, {3, 1, 2}, "A",
-                                   /*isTrainable=*/false);
-  auto *tile = F_->createTile("tile", A, /*tiles=*/1,
-                              /*axis=*/1);
-  auto *relu = F_->createRELU("relu", tile);
-  F_->createSave("save", relu);
+/// Check that EliminateNoop optimization pass removes nodes which don't do
+/// anything useful.
+TEST_F(GraphOptz, eliminateNoop) {
+  std::vector<dim_t> shape = {1, 2, 2, 3};
+  Placeholder *input1 = mod_.createPlaceholder(ElemKind::Int8QTy, shape, 0.004,
+                                               0, "input", false);
+  Placeholder *input2 = mod_.createPlaceholder(ElemKind::Int8QTy, shape, 0.004,
+                                               0, "input", false);
+  auto *cond = mod_.createConstant(ElemKind::BoolTy, shape, "input1");
+  cond->getHandle<bool>() = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1};
 
-  EXPECT_EQ(countNodeKind(F_, Kinded::Kind::TileNodeKind), 1);
+  auto *select = F_->createSelect("select", cond, input1, input2);
+  auto *slice = F_->createSlice("slice", select, {0, 0, 0, 0}, shape);
+  auto *tile = F_->createTile("tile", slice, 1, 1);
+  auto *pad = F_->createPad("pad", tile, tile->getResult().getType(), 0,
+                            {0, 0, 0, 0, 0, 0, 0, 0}, 0);
+  auto *avgPool = F_->createAvgPool("avgpool", pad, 1, 1, 0);
+  auto *maxPool = F_->createMaxPool("maxpool", avgPool, 1, 1, 0);
 
-  optimizedF_ = optimizeFunction(F_);
+  F_->createSave("save", maxPool->getResult());
 
-  // Check that the Tile node is eliminated.
-  EXPECT_EQ(countNodeKind(optimizedF_, Kinded::Kind::TileNodeKind), 0);
-
-  bindings_.allocate(mod_.getPlaceholders());
-  bindings_.get(A)->getHandle().randomize(-1.0, 1.0, mod_.getPRNG());
-
-  checkNumericalEquivalence();
-}
-
-/// Check that noop SliceNodes are correctly eliminated.
-TEST_F(GraphOptz, eliminateNoopSlice) {
-  Placeholder *input = mod_.createPlaceholder(
-      ElemKind::Int8QTy, {2, 32}, 0.004, 0, "input", /* isTrainable */ false);
-  auto *slice = F_->createSlice("tile", input, {0, 0}, {2, 32});
-  F_->createSave("save", slice);
-
+  EXPECT_EQ(countNodeKind(F_, Kinded::Kind::SelectNodeKind), 1);
   EXPECT_EQ(countNodeKind(F_, Kinded::Kind::SliceNodeKind), 1);
+  EXPECT_EQ(countNodeKind(F_, Kinded::Kind::TileNodeKind), 1);
+  EXPECT_EQ(countNodeKind(F_, Kinded::Kind::PadNodeKind), 1);
+  EXPECT_EQ(countNodeKind(F_, Kinded::Kind::AvgPoolNodeKind), 1);
+  EXPECT_EQ(countNodeKind(F_, Kinded::Kind::MaxPoolNodeKind), 1);
 
   optimizedF_ = optimizeFunction(F_);
 
-  // Check that the Slice node is eliminated.
-  EXPECT_EQ(countNodeKind(optimizedF_, Kinded::Kind::SliceNodeKind), 0);
+  // Check that all nodes except for Save are eliminated.
+  EXPECT_EQ(optimizedF_->getNodes().size(), 1);
 
   bindings_.allocate(mod_.getPlaceholders());
-  bindings_.get(input)->getHandle<int8_t>().randomize(-1.0, 1.0,
-                                                      mod_.getPRNG());
+  bindings_.get(input1)->getHandle<int8_t>().randomize(-1.0, 1.0,
+                                                       mod_.getPRNG());
+  bindings_.get(input2)->getHandle<int8_t>().randomize(-1.0, 1.0,
+                                                       mod_.getPRNG());
 
   checkNumericalEquivalence();
 }
@@ -5612,25 +5611,6 @@ TEST_F(GraphOptz, foldMulAddIntoLayerNormNoBatch) {
   // Now compile/run/compare F_ and optimizedF_.
   bindings_.allocate(input)->getHandle().randomize(0.0f, 1.0f, mod_.getPRNG());
   checkNumericalEquivalence(1e-6);
-}
-
-/// Tests select optimization with uniform constant condition.
-TEST_F(GraphOptz, SelectConstCondOptimization) {
-  llvm::SmallVector<dim_t, 4> dims = {1, 1, 4, 2};
-  auto *condConst =
-      mod_.createConstant(ElemKind::BoolTy, dims, "condition_const");
-  condConst->getHandle<bool>().clear(true);
-  auto *RHS =
-      mod_.createPlaceholder(ElemKind::FloatTy, dims, "rhs_input", false);
-  auto *LHS =
-      mod_.createPlaceholder(ElemKind::FloatTy, dims, "lhs_input", false);
-
-  auto *select = F_->createSelect("select", condConst, LHS, RHS);
-  auto *save = F_->createSave("save", select);
-  ::glow::optimize(F_, CompilationMode::Infer);
-  auto saveInput = save->getInput();
-  EXPECT_FALSE(llvm::isa<SelectNode>(saveInput));
-  EXPECT_TRUE((*saveInput).getHash() == LHS->getHash());
 }
 
 TEST_F(GraphOptz, transposeQuantizeConstantWithAlignment) {


### PR DESCRIPTION
Summary:
Add a generic optimization pass which eliminates noop nodes to avoid proliferation of trivial passes like EliminateNoopTile/EliminateNoopSlice/OptimizeSelect.

Documentation:
N/A

Test Plan:
Added GraphOptz unit tests.
