### PR TITLE
Add ignoredConstants to randomizeConstants

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -2005,8 +2005,10 @@ public:
 
   /// Randomize all of the Constants in the function. If a Constant with users
   /// in this Function also has users in other Functions then this will result
-  /// in a FATAL.
-  void randomizeConstants();
+  /// in a FATAL. \p ignoredConstants is a map Kinds of nodes to the input
+  /// indices for that node that should be ignored (not randomized).
+  void randomizeConstants(
+      const std::map<Kinded::Kind, std::set<unsigned>> &ignoredConstants = {});
 };
 
 struct TrainingConfig;

--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -4037,8 +4037,19 @@ PyTorchModelLoader::PyTorchModelLoader(
       outputCorrectType.push_back(outputScalarType);
     }
 
+    // When randomizing constants in graphs, don't randomize offsets for
+    // rowwise/channelwise ops.
+    static std::map<Kinded::Kind, std::set<unsigned>>
+        randomizeConstantsIgnoreSet = {
+            {Kinded::Kind::ChannelwiseQuantizedConvolutionNodeKind,
+             {ChannelwiseQuantizedConvolutionNode::InputIndices::
+                  FilterOffsetsIdx}},
+            {Kinded::Kind::RowwiseQuantizedFullyConnectedNodeKind,
+             {RowwiseQuantizedFullyConnectedNode::InputIndices::OffsetsIdx}},
+        };
+
     if (settings.randomizeConstants) {
-      F_.randomizeConstants();
+      F_.randomizeConstants(randomizeConstantsIgnoreSet);
     }
 
     if (settings.dumpGlowDag) {


### PR DESCRIPTION
Summary: Add the ability to _not_ randomize some selected node inputs during graph randomization

Reviewed By: jfix71

Differential Revision: D22303974

