### PR TITLE
Add ability to set max active requests per instance of a network.

### DIFF
--- a/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
+++ b/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
@@ -158,6 +158,9 @@ struct CompilationContext {
   /// If true the HostManager will try to use all available devices on the host.
   bool saturateHost{false};
 
+  /// Number of max active requests per instance of this network.
+  unsigned maxActiveRequestsPerInstance{6};
+
   /// Used during Quantization and Profiling.
   LoweredInfoMap *loweredInfoMap{nullptr};
 

--- a/include/glow/Runtime/HostManager/HostManager.h
+++ b/include/glow/Runtime/HostManager/HostManager.h
@@ -107,7 +107,7 @@ class HostManager final {
   std::shared_timed_mutex inferQueueLock_;
 
   /// Configuration parameters for this Runtime Host.
-  const HostConfig config_{};
+  HostConfig config_{};
 
   std::unique_ptr<TraceContext> hostTraceContext_;
 

--- a/include/glow/Runtime/RuntimeTypes.h
+++ b/include/glow/Runtime/RuntimeTypes.h
@@ -105,9 +105,18 @@ struct DAGNode {
 
   /// Map of deviceID to alternating state.
   std::map<DeviceIDTy, unsigned> alternateFunction;
-  /// Count of duplications for network.
+
+  /// Count of duplications for network, this is the number of replications of
+  /// the network on a single card.
   unsigned replicationCount{1};
+
+  /// Lock to protect against race conditions when getting the next duplicated
+  /// network name.
   std::mutex nameLock;
+
+  /// Count of instances of this network created by saturateHost. This will be
+  /// copies across cards.
+  unsigned instanceCount{1};
 
   /// Backend name for this network.
   std::string backendName;
@@ -253,7 +262,7 @@ struct DeviceConfig {
 /// and Executor.
 struct HostConfig {
   /// Number of outstanding or concurrent networks before queueing.
-  size_t maxActiveRequests{12};
+  size_t maxActiveRequests{48};
   /// Number of requests to queue up before refusing further requests.
   size_t maxQueueSize{100};
   /// Number of threads to allocate to the Executor.

--- a/lib/Onnxifi/Flags.cpp
+++ b/lib/Onnxifi/Flags.cpp
@@ -46,6 +46,7 @@ extern bool GlowSparseNNPartitioningBalancePerfModel;
 extern bool GlowDumpGraph;
 extern bool GlowUseDAGOptimizer;
 extern size_t GlowMaxActiveRequests;
+extern size_t GlowMaxActiveRequestsPerInstance;
 extern size_t GlowMaxQueueSize;
 extern size_t GlowExecutorThreads;
 
@@ -268,6 +269,14 @@ DEFINE_int32(glow_max_active_requests, 48,
 DEFINE_validator(glow_max_active_requests,
                  [](const char *flagname, int32_t value) {
                    glow::onnxifi::GlowMaxActiveRequests = value;
+                   return true;
+                 });
+
+DEFINE_int32(glow_max_active_requests_per_instance, 6,
+             "Number of max active requests per instance of a network.");
+DEFINE_validator(glow_max_active_requests_per_instance,
+                 [](const char * /* unused */, int32_t value) {
+                   glow::onnxifi::GlowMaxActiveRequestsPerInstance = value;
                    return true;
                  });
 

--- a/lib/Onnxifi/HostManagerOnnxifi.cpp
+++ b/lib/Onnxifi/HostManagerOnnxifi.cpp
@@ -48,6 +48,7 @@ bool GlowUseSparseNNPartitioningScheme = false;
 bool GlowSparseNNPartitioningAddSLSConcats = false;
 bool GlowSparseNNPartitioningBalancePerfModel = false;
 size_t GlowMaxActiveRequests = 48;
+size_t GlowMaxActiveRequestsPerInstance = 6;
 size_t GlowMaxQueueSize = 100;
 size_t GlowExecutorThreads = 10;
 bool GlowSaveOnnxifiDAG = false;
@@ -151,6 +152,7 @@ onnxStatus HostManagerBackend::addNetwork(std::unique_ptr<Module> module,
   CompilationContext cctx;
   PrecisionConfiguration &precConfig = cctx.precisionConfig;
   cctx.prepartitionedConfig = PPC;
+  cctx.maxActiveRequestsPerInstance = GlowMaxActiveRequestsPerInstance;
 
   if (deferredBlobReader) {
     // Initialize loader and set field in cctx.

--- a/lib/Partitioner/Partitioner.cpp
+++ b/lib/Partitioner/Partitioner.cpp
@@ -228,6 +228,8 @@ void Partitioner::saturateHost(unsigned logicalDeviceCount,
   // Add additional logical devices to each node.
   for (auto &network : partitions) {
     for (auto &node : network.nodes) {
+      // Set instanceCount.
+      node->instanceCount = duplications;
       // Build list of new logical devices to add to node.
       std::vector<unsigned> newDevices;
       for (auto logical : node->logicalDevices) {

--- a/tests/unittests/Repro.cpp
+++ b/tests/unittests/Repro.cpp
@@ -236,6 +236,11 @@ llvm::cl::opt<unsigned> glowMaxActiveRequests(
         "Number of active requests before host manager start queuing"),
     llvm::cl::Optional, llvm::cl::init(48), llvm::cl::cat(reproTestCat));
 
+llvm::cl::opt<unsigned> glowMaxActiveRequestsPerInstance(
+    "glow_max_active_requests_per_instance",
+    llvm::cl::desc("Number of active requests per network instance."),
+    llvm::cl::Optional, llvm::cl::init(6), llvm::cl::cat(reproTestCat));
+
 llvm::cl::opt<unsigned> glowMaxQueueSize(
     "glow_max_queue_size",
     llvm::cl::desc(
@@ -440,6 +445,7 @@ int run() {
   bool usingGlowCustomOps = false;
   CompilationContext cctx;
   cctx.replicationCount = replicationCountOpt;
+  cctx.maxActiveRequestsPerInstance = glowMaxActiveRequestsPerInstance;
   runtime::PrePartitionedConfig PPC;
   cctx.prepartitionedConfig = &PPC;
   {


### PR DESCRIPTION
Summary:
This adds a new cl option to repro and netrunner --glow_max_active_requests_per_instance which defaults to 6. This also calculates a new max active requests:
max_active_requests = instance count (how many times saturateHost copied the network) * max_active_requests_per_instance

The minimum of this new value and max_active_requests is then chosen.
Example
max_active_requests = 36
max_active_requests_per_instance = 6
Number of instances = 3
Max active requests chosen by HostManager = 18

Reviewed By: yinghai

Differential Revision: D22242823

