### PR TITLE
Add Backend::transformPostOptPipeline()

### DIFF
--- a/include/glow/Backend/Backend.h
+++ b/include/glow/Backend/Backend.h
@@ -197,6 +197,19 @@ public:
 
   virtual size_t getTraceEventDataSize() const { return 0; }
 
+  /// Called outside/after the end of the optimization pipeline and before code
+  /// generation, giving the backend another opportunity to transform the graph
+  /// before IRGen. The backend may insert backend and device-specific
+  /// nodes. This is generally used to process backend-specific node info, as we
+  /// skip the optimization pipeline in such cases in order to preserve the Node
+  /// -> NodeInfo mapping. This is only called if not using the DAG optimizer.
+  /// The backend is responsible for cleaning up after itself. \returns an
+  /// Expected True if the graph was modified.
+  virtual Expected<bool>
+  transformPostOptPipeline(Function *F, CompilationContext &cctx) const {
+    return false;
+  }
+
   /// Create device manager corresponding to the backend based on the
   /// deviceConfig.
   virtual runtime::DeviceManager *

--- a/lib/Backends/NNPI/NNPI.h
+++ b/lib/Backends/NNPI/NNPI.h
@@ -48,6 +48,9 @@ public:
   bool supportsStaticPlaceholders() const override { return true; }
   std::unique_ptr<FunctionPassPipeline>
   getOptimizationPipeline() const override;
+  Expected<bool>
+  transformPostOptPipeline(Function *F,
+                           CompilationContext &cctx) const override;
 
   runtime::DeviceManager *
   createDeviceManager(const runtime::DeviceConfig &deviceConfig) override;

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -64,7 +64,8 @@ std::string GlowAvailableDevices = "";
 #if FACEBOOK_INTERNAL
 Error optimizeDAG(DAGListTy &nodeList, const Provisioner &provisioner,
                   Module &mod, const std::vector<DeviceInfo> &devices,
-                  CompilationContext &cctx);
+                  CompilationContext &cctx,
+                  ConstantFoldingRecordMap &constFoldRecord);
 #endif /* FACEBOOK_INTERNAL */
 
 /// The device configs file used for Runtime.
@@ -392,17 +393,38 @@ Error HostManager::addNetwork(std::unique_ptr<Module> module,
     }
   }
 
-#if FACEBOOK_INTERNAL
   if (cctx.callDAGOptimizer) {
+#if FACEBOOK_INTERNAL
     auto optDagErr =
-        optimizeDAG(nodeList, *provisioner_, *module, deviceInfo, cctx);
+        optimizeDAG(nodeList, *provisioner_, *module, deviceInfo, cctx, record);
     if (optDagErr) {
       std::unique_lock<std::shared_timed_mutex> networkLock(networkLock_);
       cleanupAddNetwork(names);
       return optDagErr;
     }
-  }
 #endif /* FACEBOOK_INTERNAL */
+  } else {
+    // If not using the DAG optimizer, iterate over the DAGs and call
+    // transformPostOptPipeline() on the Functions.
+    for (const auto &dag : nodeList) {
+      for (auto &dagNode : dag.nodes) {
+        Function *F = module->getFunction(dagNode->name);
+        if (cctx.optimizationOpts.onlyLowerFuns.count(F)) {
+          continue;
+        }
+        RETURN_ERR_IF_NOT(
+            F, strFormat("Function %s not found", dagNode->name.data()));
+
+        Backend &B = provisioner_->getBackend(dagNode->backendName);
+        RETURN_IF_EXPECTED_IS_ERR(B.transformPostOptPipeline(F, cctx));
+
+        RETURN_ERR_IF_NOT(
+            B.verify(*F, cctx.verboseCompile),
+            "Unsupported node(s) found after transformPostOptPipeline() " +
+                F->getName().str() + " for backend " + B.getBackendName());
+      }
+    }
+  }
 
   // If requested, serialize the resulting DAG that was just optimized and
   // partitioned.


### PR DESCRIPTION
Summary:
This is called outside/after the end of the optimization pipeline and before code generation, giving the backend another opportunity to transform the graph before IRGen. This is generally used to process backend-specific node info, as we skip the optimization pipeline in such cases in order to preserve the Node-> NodeInfo mapping.

For NNPI, refactor parallelization to always occur in this function. This makes sure we do parallelization in the same place whether it's through flags or through backend-specific node info. Better to also not transform the graph once we get into `NNPI::compile()`

Reviewed By: mjanderson09

Differential Revision: D22462288

