### PR TITLE
[OnnxModelLoader] Adding Support of Floor Onnx Operator

### DIFF
--- a/include/glow/Importer/ONNXModelLoader.h
+++ b/include/glow/Importer/ONNXModelLoader.h
@@ -132,6 +132,10 @@ class ONNXModelLoader
   Error loadNonZero(const ONNX_NAMESPACE::NodeProto &op,
                     const ArgumentDictionaryTy &dict);
 
+  /// Load ONNX Floor operator.
+  Error loadFloor(const ONNX_NAMESPACE::NodeProto &op,
+                  const ArgumentDictionaryTy &dict);
+
   /// Load Constant ONNX operator.
   Error loadConstant(const ONNX_NAMESPACE::NodeProto &op,
                      ArgumentDictionaryTy &dict);

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -3799,6 +3799,16 @@ Error ONNXModelLoader::loadMFCC(const ONNX_NAMESPACE::NodeProto &op,
   return Error::success();
 }
 
+Error ONNXModelLoader::loadFloor(const ONNX_NAMESPACE::NodeProto &op,
+                                 const ArgumentDictionaryTy &dict) {
+  const std::string &opName = loadOperatorName(op);
+  NodeValue in;
+  ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
+  Node *node = G_->createFloor(opName, in);
+  RETURN_IF_ERR(addNodeAsOutput(op, node));
+  return Error::success();
+}
+
 Expected<TypeRef>
 ONNXModelLoader::loadTypeFromAttributes(unsigned resNo,
                                         ArgumentDictionaryTy &dict) {
@@ -4090,6 +4100,9 @@ Error ONNXModelLoader::loadOperator(const ONNX_NAMESPACE::NodeProto &op) {
   }
   if (typeName == "MFCC") {
     return loadMFCC(op, dict);
+  }
+  if (typeName == "Floor") {
+    return loadFloor(op, dict);
   }
   if (typeName == "Identity") {
     return loadIdentity(op, dict);

--- a/tests/models/onnxModels/floor.onnxtxt
+++ b/tests/models/onnxModels/floor.onnxtxt
@@ -1,0 +1,58 @@
+ir_version: 7
+producer_name: "floor-onnx-example"
+graph {
+  node {
+    input: "input"
+    output: "Y"
+    op_type: "Floor"
+  }
+  name: "floor-node"
+  input {
+    name: "input"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 5
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "Y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 5
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 13
+}

--- a/tests/unittests/OnnxExporterTest.cpp
+++ b/tests/unittests/OnnxExporterTest.cpp
@@ -350,6 +350,7 @@ TEST(exporter, onnxModels) {
         name.find("castToInt64.onnxtxt") != std::string::npos ||
         name.find("castToInt32.onnxtxt") != std::string::npos ||
         name.find("simpleConvBiasFail.onnxtxt") != std::string::npos ||
+        name.find("floor.onnxtxt") != std::string::npos ||
         name.find("Where.onnxtxt") != std::string::npos ||
         name.find("constantOfShapeInt64Fail.onnxtxt") != std::string::npos ||
         name.find("ArgMaxDefault.onnxtxt") != std::string::npos ||

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -688,6 +688,11 @@ TEST_F(OnnxImporterTest, importExp) {
                           [](float a) { return std::exp(a); });
 }
 
+TEST_F(OnnxImporterTest, importFloor) {
+  testEltwiseUnaryOpFloat("floor.onnxtxt", {1, 3, 4, 5}, "input", 0.002,
+                          [](float a) { return std::floor(a); });
+}
+
 static void testImportPRelu(std::string filename,
                             llvm::ArrayRef<dim_t> inputShape,
                             std::vector<float> expectedSlope) {


### PR DESCRIPTION
Summary: Many computer vision models when represented in onnx use floor operator, thus support of this operator is essential.

Test Plan: Ninja test was done. Additional test cases were added for floor operator functionality check.
