### PR TITLE
Add Intel API for perf model

### DIFF
--- a/include/glow/Backend/Backend.h
+++ b/include/glow/Backend/Backend.h
@@ -210,6 +210,12 @@ public:
     return false;
   }
 
+  /// \returns an estimate of the node cost in unitless terms, or an error
+  /// if the cost of the node is unknown
+  virtual Expected<double> estimateNodeCost(const Node *node) const {
+    return MAKE_ERR("Backend does not support estimateNodeCost");
+  }
+
   /// Create device manager corresponding to the backend based on the
   /// deviceConfig.
   virtual runtime::DeviceManager *

--- a/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
+++ b/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
@@ -120,6 +120,10 @@ struct OptimizationOptions {
   /// cards using a performance model
   bool sparseNNPartitioningBalancePerfModel{false};
 
+  /// If true, SparseNN partiitoning scheme will move Layer Normalization
+  /// nodes immediately following SLS into SLS partitions
+  bool sparseNNPartitioningPairLNWithSLS{false};
+
   /// The number of cards over which to split SLS tables when using SparseNN
   /// partitioning scheme
   unsigned int sparseNNPartitioningSchemeNumCards{1};

--- a/include/glow/Partitioner/Partitioner.h
+++ b/include/glow/Partitioner/Partitioner.h
@@ -124,33 +124,6 @@ class Partitioner final : public PartitionerBase {
                      std::vector<std::unique_ptr<Backend>> &backendsHolder,
                      std::vector<Backend *> &backends);
 
-  struct SLSTableInfo {
-    Node *node;
-    uint64_t numBytesInTable;
-    unsigned int deviceId;
-    NodeValue slsClipResult;
-    uint64_t cost;
-  };
-
-  struct SLSDeviceInfo {
-    unsigned int deviceId;
-    uint64_t memAvailableInBytes;
-    size_t currentCost;
-  };
-
-  /// Helper function for SparseNN Partitioning scheme. Checks for each
-  /// kind of SLS table and appends their metadata to the vector.
-  template <typename SLSType>
-  void appendSLSTable(Node &node, std::vector<SLSTableInfo> &slsTables,
-                      bool doPerfModelBalance);
-
-  /// Helper function for SparseNN partitioning. Inserts concats into SLS
-  /// partition and corresponding slices into non-SLS partitions
-  void sparseNNInsertSplitConcat(Function *F,
-                                 std::vector<SLSDeviceInfo> slsDevices,
-                                 std::vector<SLSTableInfo> slsTables,
-                                 PartitionConfig &partitionConfig);
-
   /// Returns info for the default device of the backend. If multiple devices,
   /// returns the first one.
   const DeviceInfo &getDeviceInfoForBackend(llvm::StringRef backendName);

--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -1547,3 +1547,68 @@ double NNPIBackend::estimateEmbeddingNode(const glow::NodeInfo &NI,
 
   return estimate;
 }
+
+Expected<double> NNPIBackend::estimateNodeCost(const glow::Node *node) const {
+  double returnCost = -1.0;
+  switch (node->getKind()) {
+  case Kinded::Kind::SparseLengthsSumNodeKind: {
+    const SparseLengthsSumNode *SLS = llvm::cast<SparseLengthsSumNode>(node);
+    returnCost =
+        estimateEmbeddingNode(glow::NodeInfo(*SLS), false,
+                              SLS->getLengthsMode(), SLS->getAvgLength());
+    break;
+  }
+  case Kinded::Kind::SparseLengthsWeightedSumNodeKind: {
+    const SparseLengthsWeightedSumNode *SLWS =
+        llvm::cast<SparseLengthsWeightedSumNode>(node);
+    returnCost =
+        estimateEmbeddingNode(glow::NodeInfo(*SLWS), false,
+                              SLWS->getLengthsMode(), SLWS->getAvgLength());
+    break;
+  }
+  case Kinded::Kind::RowwiseQuantizedSparseLengthsWeightedSumNodeKind: {
+    const RowwiseQuantizedSparseLengthsWeightedSumNode *RQSLWS =
+        llvm::cast<RowwiseQuantizedSparseLengthsWeightedSumNode>(node);
+    returnCost =
+        estimateEmbeddingNode(glow::NodeInfo(*RQSLWS), false,
+                              RQSLWS->getLengthsMode(), RQSLWS->getAvgLength());
+    break;
+  }
+  case Kinded::Kind::FusedRowwiseQuantizedSparseLengthsSumNodeKind: {
+    const FusedRowwiseQuantizedSparseLengthsSumNode *FRQSLS =
+        llvm::cast<FusedRowwiseQuantizedSparseLengthsSumNode>(node);
+    returnCost =
+        estimateEmbeddingNode(glow::NodeInfo(*FRQSLS), false,
+                              FRQSLS->getLengthsMode(), FRQSLS->getAvgLength());
+    break;
+  }
+  case Kinded::Kind::FusedRowwiseQuantizedSparseLengthsWeightedSumNodeKind: {
+    const FusedRowwiseQuantizedSparseLengthsWeightedSumNode *FRQSLWS =
+        llvm::cast<FusedRowwiseQuantizedSparseLengthsWeightedSumNode>(node);
+    returnCost = estimateEmbeddingNode(glow::NodeInfo(*FRQSLWS), false,
+                                       FRQSLWS->getLengthsMode(),
+                                       FRQSLWS->getAvgLength());
+    break;
+  }
+  case Kinded::Kind::EmbeddingBagNodeKind: {
+    const EmbeddingBagNode *EB = llvm::cast<EmbeddingBagNode>(node);
+    returnCost = estimateEmbeddingNode(
+        glow::NodeInfo(*EB), false, EB->getLengthsMode(), EB->getAvgLength());
+    break;
+  }
+  case Kinded::Kind::EmbeddingBagByteRowwiseOffsetsNodeKind: {
+    const EmbeddingBagByteRowwiseOffsetsNode *EBBRO =
+        llvm::cast<EmbeddingBagByteRowwiseOffsetsNode>(node);
+    returnCost =
+        estimateEmbeddingNode(glow::NodeInfo(*EBBRO), false,
+                              EBBRO->getLengthsMode(), EBBRO->getAvgLength());
+    break;
+  }
+  default:
+    break;
+  }
+  RETURN_ERR_IF_NOT(returnCost >= 0.0,
+                    strFormat("Estimate not supported for Node kind %s",
+                              Kinded::getKindName(node->getKind())));
+  return returnCost;
+}

--- a/lib/Backends/NNPI/NNPI.h
+++ b/lib/Backends/NNPI/NNPI.h
@@ -76,13 +76,17 @@ public:
                              bool enableDRT) override;
 
   /// Estimate performance cost for a given Node \p N.
-  /// Returns a unitless value to be used when comparing to other estimates
+  /// \returns a unitless value to be used when comparing to other estimates.
   /// or -1 if no estimate could be generated.
   /// SparseLength and EmbeddingBag type nodes are supported.
   double
   estimateEmbeddingNode(const glow::NodeInfo &NI, bool fp32Accumulation = false,
                         glow::LengthsMode lengthsMode = LengthsMode::Variable,
                         float averageLength = NAN) const;
+
+  /// \returns a unitless value to be used when comparing Nodes or
+  /// error if no estimate can be generated.
+  Expected<double> estimateNodeCost(const glow::Node *node) const override;
   /// @}
 
 private:

--- a/lib/Onnxifi/Flags.cpp
+++ b/lib/Onnxifi/Flags.cpp
@@ -43,6 +43,7 @@ extern bool GlowUseCustomOpsForExport;
 extern bool GlowUseSparseNNPartitioningScheme;
 extern bool GlowSparseNNPartitioningAddSLSConcats;
 extern bool GlowSparseNNPartitioningBalancePerfModel;
+extern bool GlowSparseNNPartitioningPairLNWithSLS;
 extern bool GlowDumpGraph;
 extern bool GlowUseDAGOptimizer;
 extern std::string GlowDAGOptimizerPlacementTaggingAlgorithm;
@@ -225,6 +226,15 @@ DEFINE_validator(glow_sparsenn_partitioning_balance_perf_model,
                  [](const char * /* flagname */, bool value) {
                    glow::onnxifi::GlowSparseNNPartitioningBalancePerfModel =
                        value;
+                   return true;
+                 });
+
+DEFINE_bool(glow_sparsenn_partitioning_pair_ln_with_sls, false,
+            "Put layer normalization nodes immediately following SLS into SLS "
+            "Partitions");
+DEFINE_validator(glow_sparsenn_partitioning_pair_ln_with_sls,
+                 [](const char * /* flagname */, bool value) {
+                   glow::onnxifi::GlowSparseNNPartitioningPairLNWithSLS = value;
                    return true;
                  });
 

--- a/lib/Onnxifi/HostManagerOnnxifi.cpp
+++ b/lib/Onnxifi/HostManagerOnnxifi.cpp
@@ -50,6 +50,7 @@ bool GlowClipFP16SkipInputs = true;
 bool GlowUseSparseNNPartitioningScheme = false;
 bool GlowSparseNNPartitioningAddSLSConcats = false;
 bool GlowSparseNNPartitioningBalancePerfModel = false;
+bool GlowSparseNNPartitioningPairLNWithSLS = false;
 size_t GlowMaxActiveRequests = 48;
 size_t GlowMaxActiveRequestsPerInstance = 48;
 size_t GlowMaxQueueSize = 100;
@@ -113,6 +114,12 @@ static llvm::cl::opt<bool, true> GlowSparseNNPartitioningBalancePerfModelOpt(
     "glow_sparsenn_partitioning_balance_perf_model",
     llvm::cl::desc("Balance SLS tables across cards using a perf model"),
     llvm::cl::location(GlowSparseNNPartitioningBalancePerfModel));
+
+static llvm::cl::opt<bool, true> GlowSparseNNPartitioningPairLNWithSLSOpt(
+    "glow_sparsenn_partitioning_pair_ln_with_sls",
+    llvm::cl::desc("Place layer normalization nodes immediately following SLS "
+                   "into SLS partition"),
+    llvm::cl::location(GlowSparseNNPartitioningPairLNWithSLS));
 
 std::unique_ptr<runtime::HostManager>
 HostManagerBackend::createHostManager(llvm::StringRef backendName) {
@@ -221,6 +228,8 @@ onnxStatus HostManagerBackend::addNetwork(std::unique_ptr<Module> module,
         GlowSparseNNPartitioningAddSLSConcats;
     cctx.optimizationOpts.sparseNNPartitioningBalancePerfModel =
         GlowSparseNNPartitioningBalancePerfModel;
+    cctx.optimizationOpts.sparseNNPartitioningPairLNWithSLS =
+        GlowSparseNNPartitioningPairLNWithSLS;
     cctx.optimizationOpts.sparseNNPartitioningSchemeNumCards =
         GlowSparseNNPartitioningSchemeNumCards;
     cctx.optimizationOpts.sparseNNPartitioningSchemeSLSTableKBytesPerCard =

--- a/tests/unittests/PartitionerTest.cpp
+++ b/tests/unittests/PartitionerTest.cpp
@@ -675,6 +675,10 @@ public:
     return false;
   }
 
+  Expected<double> estimateNodeCost(const Node * /*node */) const override {
+    return 2.0;
+  }
+
   runtime::DeviceManager *
   createDeviceManager(const runtime::DeviceConfig &deviceConfig) override {
     return nullptr;

--- a/tests/unittests/PartitionerTest.cpp
+++ b/tests/unittests/PartitionerTest.cpp
@@ -707,7 +707,8 @@ static void createSimpleModule(Module &mod) {
   (void)save;
 }
 
-static void createSimpleSparseNNModule(Module &mod, bool shareSplatWeights) {
+static void createSimpleSparseNNModule(Module &mod, bool shareSplatWeights,
+                                       bool addClipAndLayerNorm) {
   mod.clear();
   auto *F = mod.createFunction("test");
 
@@ -739,10 +740,31 @@ static void createSimpleSparseNNModule(Module &mod, bool shareSplatWeights) {
     auto *lengths = mod.createPlaceholder(ElemKind::Int32ITy, {batchSize},
                                           "lengths", false);
     float avgLength = (table % 2) ? 12.0f : 10.0f;
-    auto *output = F->createFusedRowwiseQuantizedSparseLengthsWeightedSum(
+    auto *slsOutput = F->createFusedRowwiseQuantizedSparseLengthsWeightedSum(
         "SLS", data, weights, indices, lengths, ElemKind::UInt8FusedQTy, false,
         /* lengthsMode */ LengthsMode::Variable, /* avgLength */ avgLength);
-    slsOutputs.push_back(output);
+
+    if (addClipAndLayerNorm) {
+      /* Clip */
+      auto *clipped = F->createClip("SLS_clipped", slsOutput, 0.0f, 70.0f);
+
+      /* Layer Norm*/
+      Tensor scaleT(ElemKind::FloatTy, {thisTableWidth});
+      scaleT.getHandle().randomize(0.0f, 1.0f, mod.getPRNG());
+      Constant *scaleC = mod.createConstant("LN_scale", std::move(scaleT));
+      Tensor biasT(ElemKind::FloatTy, {thisTableWidth});
+      biasT.getHandle().randomize(0.0f, 1.0f, mod.getPRNG());
+      Constant *biasC = mod.createConstant("LN_bias", std::move(biasT));
+      auto *layerNormed =
+          F->createLayerNormalization("LN", clipped, scaleC, biasC, 1e-5);
+
+      /* Clip */
+      auto *layerNormedClipped =
+          F->createClip("LN_clipped", layerNormed, 0.0f, 70.0f);
+      slsOutputs.push_back(layerNormedClipped);
+    } else {
+      slsOutputs.push_back(slsOutput);
+    }
   }
 
   // Create Concat
@@ -779,7 +801,9 @@ static bool findNodeInFunction(const Function *func,
 /// unnittests. The network used for check is generated from function static
 /// void createSimpleSparseNNModule(Module &mod).
 static void sparseNNPartitionValidation(const DAGListTy &dagList, Module &mod,
-                                        bool shareSplatWeights) {
+                                        bool shareSplatWeights,
+                                        bool addClipAndLayerNorm,
+                                        bool pairLNWithSLS) {
   int numOfCPUBackends = 0;
   int numOfSLSNodes = 0;
   int numOfFCNodes = 0;
@@ -802,10 +826,20 @@ static void sparseNNPartitionValidation(const DAGListTy &dagList, Module &mod,
               }
             }
           }
+          if (addClipAndLayerNorm && pairLNWithSLS) {
+            EXPECT_TRUE(findNodeInFunction(
+                func, Kinded::Kind::LayerNormalizationNodeKind));
+            EXPECT_TRUE(findNodeInFunction(func, Kinded::Kind::ClipNodeKind));
+          }
         } else if (findNodeInFunction(func,
                                       Kinded::Kind::FullyConnectedNodeKind)) {
           numOfFCNodes++;
           EXPECT_EQ(node->logicalDevices.size(), 3);
+          if (addClipAndLayerNorm && !pairLNWithSLS) {
+            EXPECT_TRUE(findNodeInFunction(
+                func, Kinded::Kind::LayerNormalizationNodeKind));
+            EXPECT_TRUE(findNodeInFunction(func, Kinded::Kind::ClipNodeKind));
+          }
         }
       }
     }
@@ -818,8 +852,10 @@ static void sparseNNPartitionValidation(const DAGListTy &dagList, Module &mod,
 
 static void testSimpleSparseNNPartitioning(Module &mod, bool shareSplatWeights,
                                            bool concatSLSOutputs,
-                                           bool balancePerfModel) {
-  createSimpleSparseNNModule(mod, shareSplatWeights);
+                                           bool balancePerfModel,
+                                           bool addClipAndLayerNorm,
+                                           bool pairLNWithSLS) {
+  createSimpleSparseNNModule(mod, shareSplatWeights, addClipAndLayerNorm);
   BackendWithoutSub backend1, backend2, backend3;
   std::vector<Backend *> backends;
   backends.emplace_back(&backend1);
@@ -834,12 +870,14 @@ static void testSimpleSparseNNPartitioning(Module &mod, bool shareSplatWeights,
   cctx.optimizationOpts.sparseNNPartitioningSchemeSLSTableKBytesPerCard = 200;
   cctx.optimizationOpts.sparseNNPartitioningAddSLSConcats = concatSLSOutputs;
   cctx.optimizationOpts.sparseNNPartitioningBalancePerfModel = balancePerfModel;
+  cctx.optimizationOpts.sparseNNPartitioningPairLNWithSLS = pairLNWithSLS;
   auto dagList = partitioner.partition(cctx);
   ASSERT_TRUE((bool)dagList);
   EXPECT_EQ(mod.getFunctions().size(), 4);
   EXPECT_EQ(dagList->size(), 1);
   ASSERT_TRUE(checkSaveNode(mod));
-  sparseNNPartitionValidation(dagList.get(), mod, shareSplatWeights);
+  sparseNNPartitionValidation(dagList.get(), mod, shareSplatWeights,
+                              addClipAndLayerNorm, pairLNWithSLS);
   mod.clear();
 }
 
@@ -847,13 +885,44 @@ static void testSimpleSparseNNPartitioning(Module &mod, bool shareSplatWeights,
 TEST_F(PartitionerTest, SimpleSparseNNPartitioning) {
   testSimpleSparseNNPartitioning(mod_, /*shareSplatWeights*/ false,
                                  /*concatSLSOutputs*/ false,
-                                 /*balancePerfModel*/ false);
+                                 /*balancePerfModel*/ false,
+                                 /*addClipAndLayerNorm*/ false,
+                                 /*pairLNWithSLS*/ false);
+}
+
+/// Test that this flag is a NOP when LN doesn't exist
+TEST_F(PartitionerTest, SimpleSparseNNPartitioningPairLNNOP) {
+  testSimpleSparseNNPartitioning(mod_, /*shareSplatWeights*/ false,
+                                 /*concatSLSOutputs*/ false,
+                                 /*balancePerfModel*/ false,
+                                 /*addClipAndLayerNorm*/ false,
+                                 /*pairLNWithSLS*/ true);
+}
+
+/// Test using user-defined backends for SparseNN partition.
+TEST_F(PartitionerTest, SimpleSparseNNPartitioningClipAndLayerNormInNonSLS) {
+  testSimpleSparseNNPartitioning(mod_, /*shareSplatWeights*/ false,
+                                 /*concatSLSOutputs*/ false,
+                                 /*balancePerfModel*/ false,
+                                 /*addClipAndLayerNorm*/ true,
+                                 /*pairLNWithSLS*/ false);
+}
+
+/// Test using user-defined backends for SparseNN partition.
+TEST_F(PartitionerTest, SimpleSparseNNPartitioningClipAndLayerNormInSLS) {
+  testSimpleSparseNNPartitioning(mod_, /*shareSplatWeights*/ false,
+                                 /*concatSLSOutputs*/ false,
+                                 /*balancePerfModel*/ false,
+                                 /*addClipAndLayerNorm*/ true,
+                                 /*pairLNWithSLS*/ true);
 }
 
 TEST_F(PartitionerTest, SimpleSparseNNPartitioning_ConcatSLSOutputs) {
   testSimpleSparseNNPartitioning(mod_, /*shareSplatWeights*/ false,
                                  /*concatSLSOutputs*/ true,
-                                 /*balancePerfModel*/ false);
+                                 /*balancePerfModel*/ false,
+                                 /*addClipAndLayerNorm*/ true,
+                                 /*pairLNWithSLS*/ false);
 }
 
 /// Test using user-defined backends for SparseNN partition when weights are
@@ -861,14 +930,18 @@ TEST_F(PartitionerTest, SimpleSparseNNPartitioning_ConcatSLSOutputs) {
 TEST_F(PartitionerTest, SimpleSparseNNPartitioning_SharedWeights) {
   testSimpleSparseNNPartitioning(mod_, /*shareSplatWeights*/ true,
                                  /*concatSLSOutputs*/ false,
-                                 /*balancePerfModel*/ false);
+                                 /*balancePerfModel*/ false,
+                                 /*addClipAndLayerNorm*/ true,
+                                 /*pairLNWithSLS*/ false);
 }
 
 /// Test using user-defined backends for SparseNN partition.
 TEST_F(PartitionerTest, SimpleSparseNNPartitioningBalancePerfModel) {
   testSimpleSparseNNPartitioning(mod_, /*shareSplatWeights*/ false,
                                  /*concatSLSOutputs*/ false,
-                                 /*balancePerfModel*/ true);
+                                 /*balancePerfModel*/ true,
+                                 /*addClipAndLayerNorm*/ true,
+                                 /*pairLNWithSLS*/ false);
 }
 
 /// To check if the generated DAG is correct for the Heterogeneous Partiton

--- a/tests/unittests/Repro.cpp
+++ b/tests/unittests/Repro.cpp
@@ -184,6 +184,12 @@ llvm::cl::opt<bool> sparseNNPartitioningBalancePerfModel(
     llvm::cl::desc("Balance SLS tables across cards using a perf model"),
     llvm::cl::Optional, llvm::cl::init(false), llvm::cl::cat(reproTestCat));
 
+llvm::cl::opt<bool> sparseNNPartitioningPairLNWithSLS(
+    "glow_sparsenn_partitioning_pair_ln_with_sls",
+    llvm::cl::desc("Place layer normalization nodes immediately following SLS "
+                   "into SLS partitions"),
+    llvm::cl::Optional, llvm::cl::init(false), llvm::cl::cat(reproTestCat));
+
 llvm::cl::opt<int32_t> sparseNNPartitioningSchemeNumCards(
     "glow_snn_partitioning_num_cards",
     llvm::cl::desc("Num cards used in SparseNN partitioning scheme"),
@@ -536,6 +542,8 @@ int run() {
         sparseNNPartitioningAddSLSConcats;
     cctx.optimizationOpts.sparseNNPartitioningBalancePerfModel =
         sparseNNPartitioningBalancePerfModel;
+    cctx.optimizationOpts.sparseNNPartitioningPairLNWithSLS =
+        sparseNNPartitioningPairLNWithSLS;
     cctx.optimizationOpts.sparseNNPartitioningSchemeNumCards =
         sparseNNPartitioningSchemeNumCards;
     cctx.optimizationOpts.sparseNNPartitioningSchemeSLSTableKBytesPerCard =


### PR DESCRIPTION
Summary:
Modify --glow_sparsenn_partitioning_balance_perf_model behavior to call Intel's API for perf model.

In doing so, added:
virtual Expected<double> estimateNodeCost(const Node *node) const
to Backend.h and override it for NNPI.

Differential Revision: D22399481

