### PR TITLE
move to_glow to py

### DIFF
--- a/torch_glow/src/binding.cpp
+++ b/torch_glow/src/binding.cpp
@@ -65,14 +65,6 @@ PYBIND11_MODULE(_torch_glow, m) {
   /// Returns a lowered module.
   (void)torchGlowBackend();
 
-  /// Wrapping registered glow_backend call
-  m.def("to_glow", [](const torch::jit::Module &orig_module,
-                      const py::dict &method_compile_spec) {
-    auto callback =
-        py::module::import("torch").attr("_C").attr("_jit_to_backend");
-    return callback("glow", orig_module, method_compile_spec);
-  });
-
   /// Enable compiling PyTorch subgraphs to Glow Functions.
   m.def("enableFusionPass",
         []() { getPyTorchLoaderSettings().fusionPassEnabled = true; });

--- a/torch_glow/tests/functionality/conv_to_glow_test.py
+++ b/torch_glow/tests/functionality/conv_to_glow_test.py
@@ -55,7 +55,7 @@ def run_to_glow(m, x):
     inputs = [sim]
     spec.addInputs(inputs)
 
-    lowered_module = torch_glow.to_glow(traced_m._c, {"forward": spec})
+    lowered_module = torch_glow.to_glow(traced_m, {"forward": spec})
     return lowered_module
 
 

--- a/torch_glow/tests/functionality/randomize_constants_test.py
+++ b/torch_glow/tests/functionality/randomize_constants_test.py
@@ -29,7 +29,7 @@ def run_model(m, input, randomize):
     sim.setSameAs(input)
     spec.addInputs([sim])
 
-    glow_m = torch_glow.to_glow(traced_m._c, {"forward": spec})
+    glow_m = torch_glow.to_glow(traced_m, {"forward": spec})
     return glow_m.forward(input)
 
 

--- a/torch_glow/torch_glow/__init__.py
+++ b/torch_glow/torch_glow/__init__.py
@@ -1,1 +1,2 @@
 from ._torch_glow import *
+from .to_glow import *

--- a/torch_glow/torch_glow/to_glow.py
+++ b/torch_glow/torch_glow/to_glow.py
@@ -1,0 +1,11 @@
+import torch
+
+__all__ = ["to_glow"]
+
+
+def to_glow(mod, method_compile_spec):
+    """to_glow is a wrapper around the torch._C._jit_to_backend which lowers the
+       the specified module `mod` to Glow using the the MethodCompileSpec
+       `method_compile_spec`. MethodCompileSpec is a dictionary from method name
+       in `mod` such as 'forward' to GlowCompileSpec for that method."""
+    return torch._C._jit_to_backend("glow", mod._c, method_compile_spec)


### PR DESCRIPTION
Summary: Move to_glow to Python instead of calling Python -> C++ -> Python -> C++

Differential Revision: D22515462

