### PR TITLE
Add channelwise/rowwise scales to randomization blacklist and better ranges for fp tensors

### DIFF
--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -1367,7 +1367,7 @@ public:
   template <typename T = ElemTy>
   typename std::enable_if<std::is_floating_point<T>::value>::type
   randomize(float low, float high, PseudoRNG &PRNG) {
-    assert(low < high && "invalid range");
+    assert(low <= high && "invalid range");
     std::uniform_real_distribution<ElemTy> dist(low, high);
     for (auto &elem : *this) {
       elem = dist(PRNG);
@@ -1379,7 +1379,7 @@ public:
   template <typename T = ElemTy>
   typename std::enable_if<std::is_integral<T>::value>::type
   randomize(int low, int high, PseudoRNG &PRNG) {
-    assert(low < high && "invalid range");
+    assert(low <= high && "invalid range");
     assert(low >= std::numeric_limits<ElemTy>::lowest() &&
            high <= std::numeric_limits<ElemTy>::max() &&
            "Cannot initialize outside range of representable values.");
@@ -1416,7 +1416,7 @@ public:
   typename std::enable_if<!std::is_floating_point<T>::value &&
                           !std::is_integral<T>::value>::type
   randomize(float low, float high, PseudoRNG &PRNG) {
-    assert(low < high && "invalid range");
+    assert(low <= high && "invalid range");
     std::uniform_real_distribution<float> dist(low, high);
     for (auto &elem : *this) {
       elem = dist(PRNG);

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -4960,45 +4960,54 @@ void Function::randomizeConstants(
     auto &payload = c->getPayloadMutable();
 
     switch (c->getElementType()) {
-    case ElemKind::FloatTy:
-      payload.getHandle<float>().randomize(std::numeric_limits<float>::lowest(),
-                                           std::numeric_limits<float>::max(),
-                                           getPRNG());
+    case ElemKind::FloatTy: {
+      auto H = payload.getHandle<float>();
+      auto minMaxArg = H.minMaxArg();
+      H.randomize(H.raw(minMaxArg.first), H.raw(minMaxArg.second), getPRNG());
       break;
-    case ElemKind::Float16Ty:
-      payload.getHandle<float16_t>().randomize(-65504.0f, 65504.0f, getPRNG());
+    }
+    case ElemKind::Float16Ty: {
+      auto H = payload.getHandle<float16_t>();
+      auto minMaxArg = H.minMaxArg();
+      H.randomize(H.raw(minMaxArg.first), H.raw(minMaxArg.second), getPRNG());
       break;
-    case ElemKind::Int8QTy:
-      payload.getHandle<int8_t>().randomize(
-          std::numeric_limits<int8_t>::lowest(),
-          std::numeric_limits<int8_t>::max(), getPRNG());
+    }
+    case ElemKind::Int8QTy: {
+      auto H = payload.getHandle<int8_t>();
+      auto minMaxArg = H.minMaxArg();
+      H.randomize(H.raw(minMaxArg.first), H.raw(minMaxArg.second), getPRNG());
       break;
-    case ElemKind::UInt8QTy:
-      payload.getHandle<uint8_t>().randomize(
-          std::numeric_limits<uint8_t>::lowest(),
-          std::numeric_limits<uint8_t>::max(), getPRNG());
+    }
+    case ElemKind::UInt8QTy: {
+      auto H = payload.getHandle<uint8_t>();
+      auto minMaxArg = H.minMaxArg();
+      H.randomize(H.raw(minMaxArg.first), H.raw(minMaxArg.second), getPRNG());
       break;
-    case ElemKind::Int16QTy:
-      payload.getHandle<int16_t>().randomize(
-          std::numeric_limits<int16_t>::lowest(),
-          std::numeric_limits<int16_t>::max(), getPRNG());
+    }
+    case ElemKind::Int16QTy: {
+      auto H = payload.getHandle<int16_t>();
+      auto minMaxArg = H.minMaxArg();
+      H.randomize(H.raw(minMaxArg.first), H.raw(minMaxArg.second), getPRNG());
       break;
-    case ElemKind::Int32QTy:
-      payload.getHandle<int32_t>().randomize(
-          std::numeric_limits<int32_t>::lowest(),
-          std::numeric_limits<int32_t>::max(), getPRNG());
+    }
+    case ElemKind::Int32QTy: {
+      auto H = payload.getHandle<int32_t>();
+      auto minMaxArg = H.minMaxArg();
+      H.randomize(H.raw(minMaxArg.first), H.raw(minMaxArg.second), getPRNG());
       break;
-    case ElemKind::Int32ITy:
-      payload.getHandle<int32_t>().randomize(
-          std::numeric_limits<int32_t>::lowest(),
-          std::numeric_limits<int32_t>::max(), getPRNG());
+    }
+    case ElemKind::Int32ITy: {
+      auto H = payload.getHandle<int32_t>();
+      auto minMaxArg = H.minMaxArg();
+      H.randomize(H.raw(minMaxArg.first), H.raw(minMaxArg.second), getPRNG());
       break;
-    case ElemKind::Int64ITy:
-      // Use int32_t due to randomize() range
-      payload.getHandle<int32_t>().randomize(
-          std::numeric_limits<int32_t>::lowest(),
-          std::numeric_limits<int32_t>::max(), getPRNG());
+    }
+    case ElemKind::Int64ITy: {
+      auto H = payload.getHandle<int64_t>();
+      auto minMaxArg = H.minMaxArg();
+      H.randomize(H.raw(minMaxArg.first), H.raw(minMaxArg.second), getPRNG());
       break;
+    }
     case ElemKind::UInt8FusedQTy:
       payload.getHandle<uint8_t>().randomize(
           std::numeric_limits<uint8_t>::lowest(),

--- a/tests/unittests/GraphTest.cpp
+++ b/tests/unittests/GraphTest.cpp
@@ -2107,40 +2107,41 @@ TEST(Graph, testRandomizeConstants) {
 
   // Create tensors to be used in Constants
   Tensor floatT(ElemKind::FloatTy, {10});
-  floatT = {3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0};
+  floatT = {0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0};
 
   Tensor halfT(ElemKind::Float16Ty, {10});
-  halfT = {3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0, 3.0};
+  halfT = {0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0};
 
   Tensor int8QT(ElemKind::Int8QTy, {10}, 1.0, 0);
-  int8QT = {3, 3, 3, 3, 3, 3, 3, 3, 3, 3};
+  int8QT = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
   Tensor uint8QT(ElemKind::UInt8QTy, {10}, 1.0, 0);
-  uint8QT = {3, 3, 3, 3, 3, 3, 3, 3, 3, 3};
+  uint8QT = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
   Tensor int16QT(ElemKind::Int16QTy, {10}, 1.0, 0);
-  int16QT = {3, 3, 3, 3, 3, 3, 3, 3, 3, 3};
+  int16QT = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
   Tensor int32QT(ElemKind::Int32QTy, {10}, 1.0, 0);
-  int32QT = {3, 3, 3, 3, 3, 3, 3, 3, 3, 3};
+  int32QT = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
   Tensor int32IT(ElemKind::Int32ITy, {10});
-  int32IT = {3, 3, 3, 3, 3, 3, 3, 3, 3, 3};
+  int32IT = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
   Tensor int64IT(ElemKind::Int64ITy, {10});
-  int64IT = {3, 3, 3, 3, 3, 3, 3, 3, 3, 3};
+  int64IT = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
   Tensor uint8FusedQT(ElemKind::UInt8FusedQTy, {10}, 1.0, 0);
-  uint8FusedQT = {3, 3, 3, 3, 3, 3, 3, 3, 3, 3};
+  uint8FusedQT = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
   Tensor uint8FusedFP16QT(ElemKind::UInt8FusedFP16QTy, {10}, 1.0, 0);
-  uint8FusedFP16QT = {3, 3, 3, 3, 3, 3, 3, 3, 3, 3};
+  uint8FusedFP16QT = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
   Tensor uint4FusedFP16QT(ElemKind::UInt4FusedFP16QTy, {10}, 1.0, 0);
-  uint4FusedFP16QT = {3, 3, 3, 3, 3, 3, 3, 3, 3, 3};
+  uint4FusedFP16QT = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
   Tensor boolT(ElemKind::BoolTy, {10});
-  boolT = {true, true, true, true, true, true, true, true, true, true, true};
+  boolT = {false, true, false, true, false, true,
+           false, true, false, true, false};
 
   // Create Constants and use them in F
   auto *floatC = MD.createConstant("floatC", floatT);

--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -4037,15 +4037,18 @@ PyTorchModelLoader::PyTorchModelLoader(
       outputCorrectType.push_back(outputScalarType);
     }
 
-    // When randomizing constants in graphs, don't randomize offsets for
+    // When randomizing constants in graphs, don't randomize scales/offsets for
     // rowwise/channelwise ops.
     static std::map<Kinded::Kind, std::set<unsigned>>
         randomizeConstantsIgnoreSet = {
             {Kinded::Kind::ChannelwiseQuantizedConvolutionNodeKind,
              {ChannelwiseQuantizedConvolutionNode::InputIndices::
-                  FilterOffsetsIdx}},
+                  FilterOffsetsIdx,
+              ChannelwiseQuantizedConvolutionNode::InputIndices::
+                  FilterScalesIdx}},
             {Kinded::Kind::RowwiseQuantizedFullyConnectedNodeKind,
-             {RowwiseQuantizedFullyConnectedNode::InputIndices::OffsetsIdx}},
+             {RowwiseQuantizedFullyConnectedNode::InputIndices::OffsetsIdx,
+              RowwiseQuantizedFullyConnectedNode::InputIndices::ScalesIdx}},
         };
 
     if (settings.randomizeConstants) {


### PR DESCRIPTION
Summary:
* Randomize within existing min/max range for fp16 and fp32 tensors
* Don't randomize scale tensors for rowwise/channelwise ops
* Add image size flags for cv_model_eval.py

Reviewed By: jfix71

Differential Revision: D22473098

