### PR TITLE
Fix usage of delayAndRecordConstantModification

### DIFF
--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -5292,7 +5292,7 @@ bool Function::verify(const Backend *backend) const {
   }
   std::unordered_map<std::string, const Node *> nameToNode;
 
-  for (auto *V : getParent()->getConstants()) {
+  for (auto *V : findConstants()) {
     isValid &= insertAndReport(nameToNode, *V, *this);
     isValid &= expectCompareTrue("Constant and its payload must have same type",
                                  *V->getType(), V->getPayload().getType(), V);

--- a/lib/Optimizer/GraphOptimizer/ConstantFolding.cpp
+++ b/lib/Optimizer/GraphOptimizer/ConstantFolding.cpp
@@ -289,6 +289,9 @@ bool constantFoldNodeImpl(Backend &backend, Node *N,
   // Do not print out compilation errors encountered, as constant folding is a
   // best effort; simply silently give up and continue with compilation.
   cctx.verboseCompile = false;
+  // Signal to the graph optimizer that it should not be deleting unused
+  // Constants in the module.
+  cctx.optimizationOpts.delayAndRecordConstantModification = true;
   return evaluateConstantOperation(backend, cctx, N, constResults, record);
 }
 

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -4632,7 +4632,7 @@ bool FoldLayerNormArithmetic::run(Function *F, const CompilationContext &cctx) {
     NodeValue RHS = unwindBroadcast(N.getNthInput(ArithmeticNode::RHSIdx),
                                     LN->getResult().dims().size() -
                                         LN->getScale().dims().size());
-    if (!RHS.getNode() || !(isa<Constant>(RHS) || isa<SplatNode>(RHS))) {
+    if (!RHS.getNode()) {
       continue;
     }
 

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -386,10 +386,10 @@ Error HostManager::addNetwork(std::unique_ptr<Module> module,
 
       // Verify the Function is valid after constant folding takes place.
       Backend &B = provisioner_->getBackend(dagNode->backendName);
-      RETURN_ERR_IF_NOT(B.verify(*F, cctx.verboseCompile),
-                        "Unsupported node(s) found after optimizing Function " +
-                            F->getName().str() + " for backend " +
-                            B.getBackendName());
+      RETURN_ERR_IF_NOT(
+          B.verify(*F, cctx.verboseCompile),
+          "Unsupported node(s) found after delayed constant folding Function " +
+              F->getName().str() + " for backend " + B.getBackendName());
     }
   }
 


### PR DESCRIPTION
Summary:
- When verifying Functions, only verify the Constants they use, not all Constants in the entire Module.
- During constant folding, enable `delayAndRecordConstantModification` so that we don't run DCE during constant folding, which would delete Constants in the Module when `delayAndRecordConstantModification` is used on the base cctx (we use a new cctx for constant folding).
- Make the LayerNorm fusion kick in regardless of whether the RHS is a Constant, because we are swapping in PHs when we use `delayAndRecordConstantModification`
- Improve debug message when using `delayAndRecordConstantModification` in the host manager


Differential Revision: D22473495

