### PR TITLE
[ONNXModelLoader] Add support for ONNX ScatterND Operator.

### DIFF
--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -4033,7 +4033,7 @@ Error ONNXModelLoader::loadOperator(const ONNX_NAMESPACE::NodeProto &op) {
   if (typeName == "CumSum") {
     return loadCumSum(op, dict);
   }
-  if (typeName == "ScatterAssign") {
+  if ((typeName == "ScatterAssign") || (typeName == "ScatterND")) {
     return loadScatterAssign(op, dict);
   }
   if (typeName == "IntLookupTable") {

--- a/tests/models/onnxModels/mscatterND.onnxtxt
+++ b/tests/models/onnxModels/mscatterND.onnxtxt
@@ -1,0 +1,90 @@
+ir_version: 7
+producer_name: "scatterND-onnx-example"
+graph {
+  node {
+    input: "data"
+    input: "indices"
+    input: "updates"
+    output: "Y"
+    op_type: "ScatterND"
+  }
+  name: "scatterND-node"
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "indices"
+    type {
+      tensor_type {
+        elem_type: 7
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "updates"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "Y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 13
+}
+

--- a/tests/models/onnxModels/scatterND.onnxtxt
+++ b/tests/models/onnxModels/scatterND.onnxtxt
@@ -1,0 +1,72 @@
+ir_version: 7
+producer_name: "scatterND-onnx-example"
+graph {
+  node {
+    input: "data"
+    input: "indices"
+    input: "updates"
+    output: "Y"
+    op_type: "ScatterND"
+  }
+  name: "scatterND-node"
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 8
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "indices"
+    type {
+      tensor_type {
+        elem_type: 7
+        shape {
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "updates"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "Y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 8
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 13
+}
+

--- a/tests/unittests/OnnxExporterTest.cpp
+++ b/tests/unittests/OnnxExporterTest.cpp
@@ -370,6 +370,8 @@ TEST(exporter, onnxModels) {
         name.find("NonMaxSuppression.onnxtxt") != std::string::npos ||
         name.find("NonMaxSuppressionSSD.onnxtxt") != std::string::npos ||
         name.find("Less.onnxtxt") != std::string::npos ||
+        name.find("scatterND.onnxtxt") != std::string::npos ||
+        name.find("mscatterND.onnxtxt") != std::string::npos ||
         name.find("simpleConvTranspose.onnxtxt") != std::string::npos ||
         name.find("simpleConvTransposeOutShape.onnxtxt") != std::string::npos ||
         name.find("simpleConvTransposeOutShapeDilation.onnxtxt") !=


### PR DESCRIPTION
Summary: This change maps ONNX node ScatterND to the exising
implementation of ScatterData, which has the same implementation.
ScatterND was added to ONNX operators after ScatterData was
already implemented.

Whole discussion on how to support scatterND style Op when
scatterND was not in ONNX Operators list here:
https://github.com/pytorch/glow/issues/3153

ScatterND like implementation done in glow here:
https://github.com/pytorch/glow/pull/3210/
(before scatterND was added to ONNX)


Documentation: No updates

[Optional Fixes #issue] None

Test Plan: Tested Ninja test, OnnxImporterTest
