### PR TITLE
fix lowering 1x1 conv to FC on NNPI

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -2099,7 +2099,8 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Function *F);
 /// \returns whether the Convolution node \p node is equivalent with a
 /// FullyConnected node. This happens for a 2D NHWC Convolution with 1x1 filter
 /// with strides 1, pads 0, group 1 and dilations 1.
-bool isConvolutionSameAsFullyConnected(const ConvolutionNode *node);
+bool isConvolutionSameAsFullyConnected(const ConvolutionNode *node,
+                                       bool enfoceInput1x1 = false);
 
 /// \returns whether the Gemm node \p node is equivalent with a FullyConnected
 /// node. This happens when alpha and beta are 1.0 and the C operand is 1D.

--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -513,7 +513,8 @@ bool NNPIBackend::isOpSupported(const NodeInfo &NI) const {
 bool NNPIBackend::shouldLower(const Node *N) const {
   switch (N->getKind()) {
   case Kinded::Kind::ConvolutionNodeKind:
-    return isConvolutionSameAsFullyConnected(llvm::cast<ConvolutionNode>(N));
+    return isConvolutionSameAsFullyConnected(llvm::cast<ConvolutionNode>(N),
+                                             /* enforceInput1x1*/ true);
   case Kinded::Kind::ClipNodeKind:
   case Kinded::Kind::FullyConnectedNodeKind:
   case Kinded::Kind::ConcatNodeKind:

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -5573,7 +5573,8 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Function *F) {
   return os;
 }
 
-bool isConvolutionSameAsFullyConnected(const ConvolutionNode *node) {
+bool isConvolutionSameAsFullyConnected(const ConvolutionNode *node,
+                                       bool enforceInput1x1) {
   bool isConv2D = (node->getInput().getType()->dims().size() == 4);
   if (!(isConv2D && node->getLayout() == ConvolutionLayout::NHWC &&
         !node->hasFusedActivation())) {
@@ -5593,6 +5594,10 @@ bool isConvolutionSameAsFullyConnected(const ConvolutionNode *node) {
             (pads.right == 0);
   isSame &= (group == 1);
   isSame &= (dilation == 1);
+  if (enforceInput1x1) {
+    auto inputDims = ShapeNHWC(node->getInput().getType()->dims());
+    isSame &= (inputDims.h == 1) && (inputDims.w == 1);
+  }
   return isSame;
 }
 


### PR DESCRIPTION
Summary: Lowering conv2d with h,w other than 1,1 causes performance degradation on NNPI. Adding option to enforce input <n,h,w,c> to <?,1,1,?>.

Reviewed By: zrphercule

Differential Revision: D22561425

