### PR TITLE
Quantization support along with broadcasting in ElementwiseAdd

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -968,6 +968,21 @@ public:
   DECLARE_BROADCAST_NODE(Add, /* NUM_INPUTS */ 2)
   DECLARE_BROADCAST_NODE(Sub, /* NUM_INPUTS */ 2)
 
+#define DECLARE_BROADCAST_NODE_WITH_OUT_TYPE(NODE_NAME, NUM_INPUTS,            \
+                                             OUTTYPEREF)                       \
+  template <class T, class... Args>                                            \
+  typename enable_if_same_t<T, NODE_NAME##Node>::type *                        \
+  createNodeWithBroadcastOutTy(const std::string &name, int axis,              \
+                               TypeRef OUTTYPEREF, Args &&... inputArgs) {     \
+    BROADCAST_FUNC_COMMON_CODE(NUM_INPUTS)                                     \
+    return create##NODE_NAME(name, OUTTYPEREF, inputs[0], inputs[1]);          \
+  }
+
+  DECLARE_BROADCAST_NODE_WITH_OUT_TYPE(Mul, /* NUM_INPUTS */ 2, outTy)
+  DECLARE_BROADCAST_NODE_WITH_OUT_TYPE(Div, /* NUM_INPUTS */ 2, outTy)
+  DECLARE_BROADCAST_NODE_WITH_OUT_TYPE(Add, /* NUM_INPUTS */ 2, outTy)
+  DECLARE_BROADCAST_NODE_WITH_OUT_TYPE(Sub, /* NUM_INPUTS */ 2, outTy)
+
 #define DECLARE_CMP_BROADCAST_NODE(NODE_NAME)                                  \
   template <class T, class... Args>                                            \
   typename enable_if_same_t<T, NODE_NAME##Node>::type *                        \
@@ -1000,6 +1015,7 @@ public:
 
 #undef BROADCAST_FUNC_COMMON_CODE
 #undef DECLARE_BROADCAST_NODE
+#undef DECLARE_BROADCAST_NODE_WITH_OUT_TYPE
 #undef DECLARE_CMP_BROADCAST_NODE
 #undef BROADCAST_FUNC_COMMON_CODE
 

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -7229,6 +7229,58 @@ TEST_P(OperatorTest, Relu_Int8) {
   }
 }
 
+// Test for elementwise add with quantization and broadcast
+TEST_P(OperatorTest, IntAddBroadcast) {
+  CHECK_IF_ENABLED();
+
+  const float in1scale = 0.1;
+  const float in2scale = 0.2;
+  const float addScale = 2.0;
+  const int32_t in1Offset = 5;
+  const int32_t in2Offset = 10;
+  const int32_t addOffset = 15;
+  const dim_t N = 2;
+  const dim_t C = 3;
+  const dim_t H = 4;
+  const dim_t W = 5;
+
+  auto in1Ty =
+      mod_.uniqueType(ElemKind::Int8QTy, {N, C, H, W}, in1scale, in1Offset);
+  auto in2Ty = mod_.uniqueType(ElemKind::Int8QTy, {W}, in2scale, in2Offset);
+  auto outTy =
+      mod_.uniqueType(ElemKind::Int8QTy, {N, C, H, W}, addScale, addOffset);
+
+  auto *in1 = mod_.createPlaceholder(in1Ty, "in1", false);
+  auto *in2 = mod_.createPlaceholder(in2Ty, "in2", false);
+
+  bindings_.allocate(in1)->getHandle<int8_t>().randomize(-10, 10,
+                                                         mod_.getPRNG());
+  bindings_.allocate(in2)->getHandle<int8_t>().randomize(-10, 10,
+                                                         mod_.getPRNG());
+  constexpr int axis = -1;
+  auto *addbroadcast = F_->createNodeWithBroadcastOutTy<AddNode>(
+      "addbroadcast", axis, outTy, in1, in2);
+
+  auto *save = F_->createSave("save", addbroadcast);
+  bindings_.allocate(mod_.getPlaceholders());
+
+  auto Qin1H = bindings_.get(in1)->getHandle<int8_t>();
+  auto Qin2H = bindings_.get(in2)->getHandle<int8_t>();
+
+  EE_.compile(CompilationMode::Infer);
+  EE_.run(bindings_);
+
+  auto result = bindings_.get(save->getPlaceholder())->getHandle<int8_t>();
+
+  for (dim_t i = 0; i < result.size(); i++) {
+    float a = in1Ty->getScale() * (Qin1H.raw(i) - in1Ty->getOffset());
+    float b =
+        in2Ty->getScale() * (Qin2H.raw(i % in2Ty->size()) - in2Ty->getOffset());
+    float add = a + b / outTy->getScale() + outTy->getOffset();
+    EXPECT_NEAR(std::round(add), result.raw(i), 1.0);
+  }
+}
+
 /// Test Clip with Int8QTy.
 TEST_P(OperatorTest, Clip_Int8) {
   CHECK_IF_ENABLED();


### PR DESCRIPTION
Summary:
Currently, Elementwise operators do not support quantization parameters (scale, offset) along with broadcasting support. Added an API in Graph creation so that Quantization parameters for output can also be passed to the operator. 
Test Plan:
Added test case in Operator Test
Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
