### PR TITLE
[CI fix] Fix cmake version

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -90,7 +90,7 @@ fi
 
 # Since we are using llvm-7 in these two branches, we cannot use pip install cmake
 if [ "${CIRCLE_JOB}" != "PYTORCH" ] && [ "${CIRCLE_JOB}" != "CHECK_CLANG_AND_PEP8_FORMAT" ]; then
-	sudo pip install cmake
+	sudo pip install cmake==3.17.3
 else
 	sudo apt-get install cmake
 fi


### PR DESCRIPTION
Summary:
The version of CMake installed through the pip install breaks CI, cmake version 1.8.
Fix CI by using specific version of CMake proved to be working.

Need to investigate why 1.8 failing separately.

Documentation: n/a

Test Plan:
Run on CI, all tests should be passing.

cc: @opti-mix 