### PR TITLE
Keep Swish unlowered, and correctly lower SLS based on ElemKind

### DIFF
--- a/lib/Backends/NNPI/NNPI.h
+++ b/lib/Backends/NNPI/NNPI.h
@@ -52,6 +52,11 @@ public:
   transformPostOptPipeline(Function *F,
                            CompilationContext &cctx) const override;
 
+  /// Helper to lower nodes which need further lowering. This is useful for when
+  /// we need to lower Nodes based on precision, as we do lowering pre-precision
+  /// transformation. \returns whether \p F was modified.
+  bool lowerRequiredNodes(Function *F, CompilationContext &cctx) const;
+
   runtime::DeviceManager *
   createDeviceManager(const runtime::DeviceConfig &deviceConfig) override;
 

--- a/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
@@ -197,6 +197,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "FP16BatchAdd/0",
     "Sigmoid_Float16/0",
     "Swish_Float16/0",
+    "Swish_Int8/0",
     "IntLookupTable/0",
     "testBatchAdd_Float16/0",
     "CumSum_Float/0",


### PR DESCRIPTION
Summary:
- Do not lower Swish and add an Int8 test for it
- Move lowering logic for Swish and SLS to `NNPI::lowerRequiredNodes()`

Reviewed By: hyuen

Differential Revision: D22567238

