### PR TITLE
[CommonModelLoader] Remove gather axis constraint

### DIFF
--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -1092,10 +1092,6 @@ protected:
       int axis;
       ASSIGN_VALUE_OR_RETURN_ERR(
           axis, loadAxis<int>(dict.find("axis")->second, data.dims().size()));
-      if (axis != 0 && axis != 1) {
-        RETURN_ERR("Axis must be 0 or 1.");
-      }
-
       batchDims = axis;
     }
 


### PR DESCRIPTION
Summary: Gather ops work for any axis value. The axis constraint that has been put in place in loadGatherOps is unnecessary and blocks the support for other axis value. 

Test Plan: Ninja test

