### PR TITLE
better error message between C2 and glow

### DIFF
--- a/lib/Onnxifi/Base.h
+++ b/lib/Onnxifi/Base.h
@@ -95,10 +95,15 @@ public:
   /// Check if event was signalled.
   bool isSignalled() { return fired_; }
 
+  const std::string &getMessage() const { return message_; }
+
+  void setMessage(const std::string &message) { message_ = message; }
+
 private:
   std::atomic<bool> fired_;
   std::mutex mutex_;
   std::condition_variable cond_;
+  std::string message_;
   /// Used to hold an onnxStatus that will be passed for the signaller of the
   /// event to a waiter. Should only be accessed while holding mutex_.
   onnxStatus status_ = ONNXIFI_STATUS_SUCCESS;

--- a/lib/Onnxifi/HostManagerOnnxifi.cpp
+++ b/lib/Onnxifi/HostManagerOnnxifi.cpp
@@ -366,22 +366,22 @@ onnxStatus HostManagerGraph::run(std::unique_ptr<ExecutionContext> ctx,
              std::unique_ptr<ExecutionContext> ctx) mutable {
         TRACE_EVENT_SCOPE(ctx->getTraceContext(), TraceLevel::RUNTIME,
                           "Onnxifi::callback");
-        // If an Error occurred then log it in ERR_TO_BOOL and signal the output
-        // event.
-        if (ERR_TO_BOOL(std::move(err))) {
+
+        if (err) {
+          outputEvent->setMessage(ERR_TO_STRING(std::move(err)));
           outputEvent->signal(ONNXIFI_STATUS_INTERNAL_ERROR);
           return;
         }
 
-        // End the current trace event before we convert TraceEvents to the ONNX
-        // format.
+        // End the current trace event before we convert TraceEvents to the
+        // ONNX format.
         TRACE_EVENT_SCOPE_END();
 
         auto *traceContext = ctx->getTraceContext();
         if (traceContext) {
           // We want to log the async start event with the original caller's
-          // threadId. This way, chrome UI will put the async event next to the
-          // caller thread.
+          // threadId. This way, chrome UI will put the async event next to
+          // the caller thread.
           traceContext->logTraceEvent("glow e2e", TraceLevel::RUNTIME,
                                       TraceEvent::BeginType, startTime,
                                       attributes, threadId, runId);


### PR DESCRIPTION
Summary:
Previously in the glow onnxifi path, when an error is encountered, we log it to stderr then just return ONNXIFI_STATUS_INTERNAL_ERROR to C2. C2 then does CAFFE2_ENFORCE_EQUAL(return_code, ONNXIFI_STATUS_SUCCESS). The error message that eventually went to the user is something like

   [enforce fail at onnxifi_op.cc:545] eventStatus == ONNXIFI_STATUS_SUCCESS. 1030 vs 0

This diff adds plumbing to get human readable error message out of glow into C2.

Differential Revision: D22416857

