### PR TITLE
Lift error processing to glow runtime

### DIFF
--- a/include/glow/Support/Error.h
+++ b/include/glow/Support/Error.h
@@ -253,7 +253,7 @@ class GlowErrorValue final {
 public:
   /// An enumeration of error codes representing various possible errors that
   /// could occur.
-  /// NOTE: when updating this enum, also update ErrorCodeToString function
+  /// NOTE: when updating this enum, also update errorCodeToString function
   /// below.
   enum class ErrorCode {
     // An unknown error ocurred. This is the default value.
@@ -282,6 +282,8 @@ public:
     RUNTIME_REQUEST_REFUSED,
     // Runtime error, device wasn't found.
     RUNTIME_DEVICE_NOT_FOUND,
+    // Non-recoverable device error
+    RUNTIME_DEVICE_NONRECOVERABLE,
     // Runtime error, network busy to perform any operation on it.
     RUNTIME_NET_BUSY,
     // Device error, not supported.
@@ -329,6 +331,11 @@ public:
   /// "Warning", this is useful for when Errors are used in non-exceptional
   /// conditions.
   std::string logToString(bool warning = false) const;
+
+  /// Return the error code.
+  bool isFatalError() const {
+    return ec_ == ErrorCode::RUNTIME_DEVICE_NONRECOVERABLE;
+  }
 
   GlowErrorValue(std::string message, ErrorCode ec)
       : message_(message), ec_(ec) {}

--- a/lib/Backends/NNPI/DebugMacros.h
+++ b/lib/Backends/NNPI/DebugMacros.h
@@ -210,6 +210,18 @@ GetNNPIInferenceErrorDesc(NNPIInferenceErrorCode err) {
     }                                                                          \
   }
 
+#define FATAL_CALLBACK_IF_NOT(exp, msg, runId, ctx, callback)                  \
+  {                                                                            \
+    bool exp_res = (exp);                                                      \
+    if (!exp_res) {                                                            \
+      callback(                                                                \
+          runId,                                                               \
+          MAKE_ERR(ErrorValue::ErrorCode::RUNTIME_DEVICE_NONRECOVERABLE, msg), \
+          std::move(ctx));                                                     \
+      return;                                                                  \
+    }                                                                          \
+  }
+
 #define LOG_AND_FAIL_EXECUTE_CALLBACK_IF_NOT(loglevel, exp, msg, runId, ctx,   \
                                              callback)                         \
   {                                                                            \

--- a/lib/Runtime/Executor/ThreadPoolExecutor.cpp
+++ b/lib/Runtime/Executor/ThreadPoolExecutor.cpp
@@ -251,6 +251,10 @@ void ThreadPoolExecutor::handleDeviceManagerResult(
         executeDAGNode(executionState, child);
       }
     }
+  } else if (err && err.peekErrorValue() &&
+             err.peekErrorValue()->isFatalError()) {
+    LOG(FATAL) << "Non-recoverable device error: "
+               << err.peekErrorValue()->logToString();
   }
   // Return intermediateContext to executionState.
   executionState->returnUniqueNodeContextPtr(node, std::move(ctx));

--- a/lib/Support/Error.cpp
+++ b/lib/Support/Error.cpp
@@ -85,6 +85,8 @@ std::string GlowErrorValue::errorCodeToString(const ErrorCode &ec) {
     return "RUNTIME_REQUEST_REFUSED";
   case ErrorCode::RUNTIME_DEVICE_NOT_FOUND:
     return "RUNTIME_DEVICE_NOT_FOUND";
+  case ErrorCode::RUNTIME_DEVICE_NONRECOVERABLE:
+    return "RUNTIME_DEVICE_NONRECOVERABLE";
   case ErrorCode::RUNTIME_NET_BUSY:
     return "RUNTIME_NET_BUSY";
   case ErrorCode::DEVICE_FEATURE_NOT_SUPPORTED:


### PR DESCRIPTION
Summary: Move the error checking and fataling logic from backend to runtime, which is logically more clear. And it gives us a chance to report this error to other framework before fataling the process.

Differential Revision: D22605943

