### PR TITLE
pass multiple specs for method

### DIFF
--- a/torch_glow/src/CachingGraphRunner.cpp
+++ b/torch_glow/src/CachingGraphRunner.cpp
@@ -26,6 +26,45 @@
 #include "ShapeInferenceEngine.h"
 
 namespace glow {
+
+namespace {
+
+// Hashing a stack of tensors using their types.
+size_t hashTensorStack(const torch::jit::Stack &stack, size_t numInputs,
+                       const CachingGraphRunner *const runnerPtr) {
+  const auto inputs = torch::jit::last(stack, numInputs);
+  // Start off hash with pointer to this CachingGraphRunner to avoid collisions
+  // with Glow functions created by other CachingGraphRunners.
+  size_t hash = reinterpret_cast<size_t>(runnerPtr);
+  for (auto &input : inputs) {
+    CHECK(input.isTensor()) << "Found non-tensor input. Glow AOT compiled "
+                               "graph accepts tensor inputs only.";
+    // hash on input Tensor type
+    const auto ptTensorType = c10::TensorType::create(input.toTensor());
+    size_t tensorHash = std::hash<c10::TensorType>()(*ptTensorType);
+    hash = torch::hash_combine(hash, tensorHash);
+  }
+  return hash;
+}
+
+// Use inputMeta to create a fake stack of empty tensors. Helper function to
+// enable calling hashTensorStack from warmCache.
+torch::jit::Stack
+createFakeStackFromInputMeta(const std::vector<InputMeta> &inputMeta) {
+  torch::jit::Stack stack;
+  for (auto &meta : inputMeta) {
+    std::vector<int64_t> dims;
+    dims.reserve(meta.dims.size());
+    for (auto d : meta.dims) {
+      dims.push_back(d);
+    }
+    stack.push_back(
+        c10::IValue(at::empty(dims, at::TensorOptions().dtype(meta.type))));
+  }
+  return stack;
+}
+} // namespace
+
 // TODO: this should also return the list of TensorTypes used to compute the
 // hash to check for equality. Will make a nicer wrapper for this in the future.
 size_t CachingGraphRunner::computeGraphHash(
@@ -111,21 +150,13 @@ CachingGraphRunner::loadImpl(torch::jit::Stack &stack,
 
   // If we already have a Glow function compiled for this graph with and the
   // given inputs then use that.
-  {
-    std::shared_lock<std::shared_timed_mutex> rlock(graphInfoMapMutex);
-    auto it = perGlowGraphInfoMap_.find(hash);
-    if (it != perGlowGraphInfoMap_.end()) {
-      return it->second;
-    }
-  }
-
   std::unique_lock<std::shared_timed_mutex> wlock(graphInfoMapMutex);
   auto it = perGlowGraphInfoMap_.find(hash);
   if (it != perGlowGraphInfoMap_.end()) {
     return it->second;
   }
-  auto info = std::make_shared<PerGlowGraphInfo>();
-  info->functionName = strFormat("pt_function_%lu", hash);
+  auto info = std::make_shared<PerGlowGraphInfo>(
+      strFormat("pt_function_%lu", hash), getSettings());
 
   std::unique_ptr<Module> module = glow::make_unique<Module>();
   Function *f = module->createFunction(info->functionName);
@@ -551,16 +582,13 @@ Error CachingGraphRunner::run(torch::jit::Stack &stack) {
 }
 
 Error CachingGraphRunner::runOnly(torch::jit::Stack &stack) {
-  std::shared_ptr<PerGlowGraphInfo> info;
-  {
-    std::shared_lock<std::shared_timed_mutex> rlock(graphInfoMapMutex);
-    if (perGlowGraphInfoMap_.size() != 1) {
-      return MAKE_ERR(strFormat(
-          "There should be one and only one compiled graph, but got %lu",
-          perGlowGraphInfoMap_.size()));
-    }
-    info = perGlowGraphInfoMap_.at(0);
+  size_t hash = hashTensorStack(stack, graph_->inputs().size(), this);
+  std::unique_lock<std::shared_timed_mutex> wlock(graphInfoMapMutex);
+  auto it = perGlowGraphInfoMap_.find(hash);
+  if (it == perGlowGraphInfoMap_.end()) {
+    return MAKE_ERR(strFormat("No compiled graph found for hash: %lu", hash));
   }
+  std::shared_ptr<PerGlowGraphInfo> info = it->second;
 
   std::unique_ptr<ExecutionContext> ctx = glow::make_unique<ExecutionContext>();
   TraceContext *traceContext = nullptr;
@@ -581,7 +609,8 @@ Error CachingGraphRunner::runOnly(torch::jit::Stack &stack) {
   return err;
 }
 
-Error CachingGraphRunner::warmCache(const std::vector<InputMeta> &inputMeta) {
+Error CachingGraphRunner::warmCache(const std::vector<InputMeta> &inputMeta,
+                                    const PyTorchLoaderSettings &settings) {
   if (!hostManager_) {
     return MAKE_ERR("Host manager is null!");
   }
@@ -591,7 +620,7 @@ Error CachingGraphRunner::warmCache(const std::vector<InputMeta> &inputMeta) {
   }
 
   std::unique_ptr<TraceContext> traceContext;
-  if (getSettings().enableGlowTracing) {
+  if (settings.enableGlowTracing) {
     traceContext = std::make_unique<TraceContext>(TraceLevel::STANDARD);
     traceContext->setThreadName("torch_glow");
   }
@@ -600,22 +629,30 @@ Error CachingGraphRunner::warmCache(const std::vector<InputMeta> &inputMeta) {
 
   // If this setting is missing we will not use pre compiled model at runtime,
   // which will cause unexpected behaviors.
-  if (!settings_.preCompilePyTorchModule) {
+  if (!settings.preCompilePyTorchModule) {
     return MAKE_ERR(
         "Calling AOT compilation when preCompilePyTorchModule is not set");
   }
 
-  std::unique_lock<std::shared_timed_mutex> wlock(graphInfoMapMutex);
-  if (perGlowGraphInfoMap_.size() != 0) {
-    return MAKE_ERR(strFormat("There is already a compiled graph!"));
+  // hash should be unique in the following mappings:
+  // 1) perGlowGraphInfoMap_ - a specifc instance of a runner corresponds to
+  //    a single graph (i.e. Glow fusion group) that may have multiple
+  //    Glow functions to serve different input shapes.
+  // 2) HostManager mapping a functionName to a Glow function.
+  // The input-based hash is combined with the pointer to this runner to
+  // produce a unique mapping for HostManager.
+  torch::jit::Stack fakeStack = createFakeStackFromInputMeta(inputMeta);
+  size_t hash = hashTensorStack(fakeStack, inputMeta.size(), this);
+  {
+    std::unique_lock<std::shared_timed_mutex> wlock(graphInfoMapMutex);
+    if (perGlowGraphInfoMap_.find(hash) != perGlowGraphInfoMap_.end()) {
+      return MAKE_ERR(
+          strFormat("There is already a compiled graph for hash: %lu", hash));
+    }
   }
 
-  auto info = std::make_shared<PerGlowGraphInfo>();
-
-  // Using the pointer to current graph runner should be enough to ensure
-  // one-to-one mapping from compiled graph to the network in host managers.
-  size_t hash = reinterpret_cast<size_t>(this);
-  info->functionName = strFormat("pt_function_%lu", hash);
+  auto info = std::make_shared<PerGlowGraphInfo>(
+      strFormat("pt_function_%lu", hash), settings);
 
   std::unique_ptr<Module> glowModule = std::make_unique<Module>();
   Function *f = glowModule->createFunction(info->functionName);
@@ -623,7 +660,7 @@ Error CachingGraphRunner::warmCache(const std::vector<InputMeta> &inputMeta) {
   TRACE_EVENT_BEGIN(traceContext.get(), TraceLevel::RUNTIME, "loadJITGraph");
   RETURN_IF_ERR(PyTorchModelLoader::loadJITGraph(
       *f, *graph_, info->inputPlaceholders, info->outputPlaceholders,
-      outputCorrectType_, getPyTorchLoaderSettings(), {}, inputMeta));
+      outputCorrectType_, info->settings, {}, inputMeta));
   TRACE_EVENT_END(traceContext.get(), TraceLevel::RUNTIME, "loadJITGraph");
 
   // Obtain maxSeqLength from inputMeta
@@ -643,17 +680,17 @@ Error CachingGraphRunner::warmCache(const std::vector<InputMeta> &inputMeta) {
 
   glow::CompilationContext cctx;
 
-  cctx.precisionConfig.convertToFP16 = settings_.convertToFP16;
-  cctx.precisionConfig.convertFusedToFP16 = settings_.convertFusedToFP16;
-  cctx.dumpFinalGraph = settings_.dumpFinalGlowGraph;
-  cctx.saturateHost = settings_.saturateHost;
+  cctx.precisionConfig.convertToFP16 = settings.convertToFP16;
+  cctx.precisionConfig.convertFusedToFP16 = settings.convertFusedToFP16;
+  cctx.dumpFinalGraph = settings.dumpFinalGlowGraph;
+  cctx.saturateHost = settings.saturateHost;
 
   TRACE_EVENT_BEGIN(traceContext.get(), TraceLevel::RUNTIME, "addNetwork");
   RETURN_IF_ERR(hostManager_->addNetwork(std::move(glowModule), cctx));
   TRACE_EVENT_END(traceContext.get(), TraceLevel::RUNTIME, "addNetwork");
 
   // There should be only one element in the map when model is precompiled.
-  perGlowGraphInfoMap_[0] = info;
+  perGlowGraphInfoMap_.emplace(hash, info);
 
   TRACE_EVENT_END(traceContext.get(), TraceLevel::RUNTIME,
                   "torch_glow::warmCache");

--- a/torch_glow/src/CachingGraphRunner.h
+++ b/torch_glow/src/CachingGraphRunner.h
@@ -35,12 +35,23 @@ class CachingGraphRunner {
   /// Information that is stored per-Glow graph for running it using
   /// HostManager.
   struct PerGlowGraphInfo {
+
+    PerGlowGraphInfo() = delete;
+    PerGlowGraphInfo(const std::string func, const PyTorchLoaderSettings &set)
+        : functionName(func), settings(set) {}
+
+    PerGlowGraphInfo(const PerGlowGraphInfo &) = delete;
+    PerGlowGraphInfo &operator=(const PerGlowGraphInfo &) = delete;
+
     /// Input and output placeholders to the Glow function.
     std::vector<glow::Placeholder *> inputPlaceholders;
     std::vector<glow::Placeholder *> outputPlaceholders;
 
     /// Name of the Glow function maintained by HostManager for this subgraph.
     std::string functionName;
+
+    /// PyTorchLoaderSettings used to compile this function
+    PyTorchLoaderSettings settings;
   };
 
   /// The PyTorch JIT Graph that this CachingGraphRunner caches Glow functions
@@ -147,8 +158,12 @@ public:
   /// The Glow Function should've already been created. Returns an error if not.
   Error runOnly(torch::jit::Stack &stack);
 
-  // Warm up the cache by compiling a Glow function for the inputs in \p stack.
-  Error warmCache(const std::vector<InputMeta> &inputMeta);
+  /// Warm up the cache by compiling a Glow function and storing its info in
+  /// perGlowGraphInfoMap_ with the hash computed using \p inputMeta. \p
+  /// inputMeta is used to pass Glow shapes and types (Only tensors are valid
+  /// inputs). \p settings enable different settings for each compilation.
+  Error warmCache(const std::vector<InputMeta> &inputMeta,
+                  const PyTorchLoaderSettings &settings);
 
   const PyTorchLoaderSettings &getSettings() const;
 };

--- a/torch_glow/src/PyTorchCommon.cpp
+++ b/torch_glow/src/PyTorchCommon.cpp
@@ -440,7 +440,7 @@ void glowAOTFusion(torch::jit::Module &model, const std::string &inputMetaStr) {
 
   auto inputMeta = glow::loadInputMeta(inputMetaStr);
 
-  auto e = runner->warmCache(*inputMeta);
+  auto e = runner->warmCache(*inputMeta, runner->getSettings());
   if (e) {
     // If the graph is already compiled previously, warmCache() will report
     // an error but it is fine with our execution. So here we extract the

--- a/torch_glow/src/TorchGlowBackend.cpp
+++ b/torch_glow/src/TorchGlowBackend.cpp
@@ -425,18 +425,23 @@ TorchGlowBackend::compile(c10::IValue processed,
           << "Could not find corresponding method_compile_spec for method: "
           << method.name();
       c10::IValue methodSpec = spec->value();
-      c10::intrusive_ptr<GlowCompileSpec> gcs;
+      c10::impl::GenericList gcs(c10::AnyType::get());
       try {
-        gcs = methodSpec.toCustomClass<GlowCompileSpec>();
+        gcs = methodSpec.toList();
       } catch (const std::exception &e) {
         throw std::invalid_argument(
             "method_compile_spec does not match GlowCompileSpec type.");
       }
-      std::vector<glow::InputMeta> inputMeta = parseMethodCompileSpec(*gcs);
 
-      // Compile
-      auto e = runner->warmCache(inputMeta);
-      CHECK(!(bool)e) << ERR_TO_STRING(std::move(e));
+      // iterate list elements: get settings for each elem and compile
+      for (const auto &elem : gcs) {
+        std::vector<glow::InputMeta> inputMeta = parseMethodCompileSpec(
+            *c10::IValue(elem).toCustomClass<GlowCompileSpec>());
+
+        // Compile
+        auto e = runner->warmCache(inputMeta, runner->getSettings());
+        CHECK(!(bool)e) << ERR_TO_STRING(std::move(e));
+      }
 
       // Bakcend is created on each to_backend call --> use simple consecutive
       // keys for methods.

--- a/torch_glow/torch_glow/to_glow.py
+++ b/torch_glow/torch_glow/to_glow.py
@@ -23,9 +23,14 @@ def to_glow(model, method_compile_spec):
         A copy of the model that has been lowered to Glow and will run on
         Glow backend devices
     """
-
-    if not isinstance(method_compile_spec, collections.Mapping):
+    if isinstance(method_compile_spec, collections.Mapping):
+        for k, v in method_compile_spec.items():
+            if not isinstance(v, list):
+                method_compile_spec[k] = [v]
+    elif isinstance(method_compile_spec, list):
         method_compile_spec = {"forward", method_compile_spec}
+    else:
+        method_compile_spec = {"forward", [method_compile_spec]}
 
     return torch._C._jit_to_backend("glow", model._c, method_compile_spec)
 


### PR DESCRIPTION
Summary:
Adding support in multiple specs per functions - allowing a function to compile AOT with multiple <input_meta, settings> pairs.
In CachingGraphRunner AOT path warmCache and runOnly are adjusted to hanlde multiple compilations per graph (hashing on input tensor types).
In to_glow, adding support for passing a list of GlowCompileSpec.

PyTorchLoaderSettings are now stored in PerGlowGraphInfo.

Differential Revision: D22600035

