### PR TITLE
[Quantization] Check for profile before trying to open it

### DIFF
--- a/include/glow/Quantization/Serialization.h
+++ b/include/glow/Quantization/Serialization.h
@@ -31,7 +31,7 @@ void serializeProfilingInfosToYaml(
 
 /// Deserialize from the file named \p fileName the hash \p graphPreLowerHash
 /// of the graph pre lowering and the profiling information \p profilingInfos.
-void deserializeProfilingInfosFromYaml(
+bool deserializeProfilingInfosFromYaml(
     llvm::StringRef fileName, llvm::hash_code &graphPreLowerHash,
     std::vector<NodeProfilingInfo> &profilingInfos);
 

--- a/lib/Onnxifi/InlineOnnxifi.cpp
+++ b/lib/Onnxifi/InlineOnnxifi.cpp
@@ -83,9 +83,12 @@ InlineGraph::initGraph(const void *onnxModel, size_t onnxModelSize,
 
   // If quantizing, load quantization infos and setup the schema.
   if (quantizationMode_ == QuantizationMode::Quantize) {
-    deserializeProfilingInfosFromYaml(getProfileFile(modelHash_),
-                                      precConfig.quantConfig.graphPreLowerHash,
-                                      precConfig.quantConfig.infos);
+    auto fileExists = deserializeProfilingInfosFromYaml(
+        getProfileFile(modelHash_), precConfig.quantConfig.graphPreLowerHash,
+        precConfig.quantConfig.infos);
+    if (!fileExists) {
+      return ONNXIFI_STATUS_UNIDENTIFIED_NAME;
+    }
     precConfig.quantConfig.schema = quantization::Schema::Symmetric;
   }
 

--- a/lib/Quantization/Serialization.cpp
+++ b/lib/Quantization/Serialization.cpp
@@ -117,9 +117,13 @@ void serializeProfilingInfosToYaml(
   yout << profilingInfos;
 }
 
-void deserializeProfilingInfosFromYaml(
+bool deserializeProfilingInfosFromYaml(
     llvm::StringRef fileName, llvm::hash_code &graphPreLowerHash,
     std::vector<NodeProfilingInfo> &profilingInfos) {
+
+  if (!llvm::sys::fs::exists(fileName)) {
+    return false;
+  }
 
   // Open YAML input stream.
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> text =
@@ -139,6 +143,7 @@ void deserializeProfilingInfosFromYaml(
   // Read profiling info.
   yin >> profilingInfos;
   CHECK(!yin.error()) << "Error reading YAML file '" << fileName.str() << "'!";
+  return true;
 }
 
 } // namespace glow

--- a/tests/unittests/QuantizationTest.cpp
+++ b/tests/unittests/QuantizationTest.cpp
@@ -142,10 +142,21 @@ void testProfilingInfosSerialization(std::vector<NodeProfilingInfo> &expected) {
   serializeProfilingInfosToYaml(filePath, hash, expected);
   std::vector<NodeProfilingInfo> deserialized;
   llvm::hash_code hashDeserialized;
-  deserializeProfilingInfosFromYaml(filePath, hashDeserialized, deserialized);
+  auto fileExists = deserializeProfilingInfosFromYaml(
+      filePath, hashDeserialized, deserialized);
   llvm::sys::fs::remove(filePath);
+  EXPECT_TRUE(fileExists);
   EXPECT_EQ(static_cast<size_t>(hash), static_cast<size_t>(hashDeserialized));
   EXPECT_EQ(expected, deserialized);
+}
+
+TEST(Quantization, DeserializeNonExistingFile) {
+  std::string fakeFilePath = "/fake";
+  std::vector<NodeProfilingInfo> deserialized;
+  llvm::hash_code hashDeserialized;
+  auto fileExists = deserializeProfilingInfosFromYaml(
+      fakeFilePath, hashDeserialized, deserialized);
+  EXPECT_FALSE(fileExists);
 }
 
 TEST(Quantization, ProfilingSerialize) {


### PR DESCRIPTION
Summary: `deserializeProfilingInfosFromYaml` will return a `bool` indicating whether the profile file exists. `initGraph` will return `ONNXIFI_STATUS_UNIDENTIFIED_NAME` if file does not exist.

Fixes #2586

Test Plan:
1. Add a unit test to `Quantization` called `DeserializeNonExistingFile`. The name of the non-existent file is `/fake`. The function should return `false` when trying to deserialize. 
2. `testProfilingInfosSerialization` has an additional check to make sure the file being deserialized always exists. 

cc @jackm321 