### PR TITLE
ConvTranspose Bug in verification function

### DIFF
--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -395,7 +395,6 @@ void BoundInterpreterFunction::fwdConvTransposeInstFloatImpl(
 
   assert(idim.c % group == 0 && "Input channels must be divisible by group.");
   assert(odim.c % group == 0 && "Output channels must be divisible by group.");
-  assert(group == 1 && "Group must be 1.");
 
   dim_t inCperG = idim.c / group;
   dim_t outCperG = odim.c / group;

--- a/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
@@ -268,6 +268,7 @@ struct BlacklistInitializer {
             {"TopK1/0", TestBlacklist::AnyDeviceHWEngine},
             {"TopK1int32/0", TestBlacklist::AnyDeviceAnyEngine},
             {"ConvTransposedAsymmetric/0", TestBlacklist::AnyDeviceAnyEngine},
+            {"ConvTransposedGroup/0", TestBlacklist::AnyDeviceAnyEngine},
             {"sanityConvTranspose/0", TestBlacklist::AnyDeviceAnyEngine},
             {"convTransposeCompareSimpleK8S1P0I3/0",
              TestBlacklist::AnyDeviceAnyEngine},

--- a/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
@@ -388,6 +388,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "RWQSLWSAllSame_Float16_AccumFP32/0",
     "sanityConvTranspose/0",
     "ConvTransposedAsymmetric/0",
+    "ConvTransposedGroup/0",
     "convTransposeCompareSimpleK8S1P0I3/0",
     "convTransposeCompareSimpleK6S1P1I4/0",
     "convTransposeConvolutionCompareSimpleK5S1P2I3/0",

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -719,11 +719,10 @@ static void assertConvTransposeDims(NodeValue input, NodeValue filter,
   ShapeNHWC filterDims(filter.dims());
   (void)filterDims;
 
-  assert(filterDims.n % group == 0 && filterDims.h == kdim.height &&
-         filterDims.w == kdim.width && filterDims.c == idim.c / group &&
-         "Invalid filter dims");
+  assert(filterDims.h == kdim.height && filterDims.w == kdim.width &&
+         filterDims.c == idim.c && "Invalid filter dims");
 
-  assert(bias.getType()->size() == filterDims.n && "Invalid bias size");
+  assert(bias.getType()->size() == filterDims.n * group && "Invalid bias size");
 }
 
 /// Check that the dimensions that are passed in when the convolution is

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -299,8 +299,8 @@ static bool verifyConvTranspose(NodeValue src, NodeValue dest, NodeValue filter,
   isValid &= expectCompareTrue("Invalid output dimension CT", odim.c % group,
                                dim_t(0), parent);
 
-  const dim_t filterDims[] = {odim.c, kdim.height, kdim.width,
-                              idim.c / (dim_t)group};
+  const dim_t filterDims[] = {odim.c / (dim_t)group, kdim.height, kdim.width,
+                              idim.c};
   isValid &=
       expectCompareTrue("Invalid filter dimensions", filter.getType()->dims(),
                         llvm::makeArrayRef(filterDims), parent);

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -1591,7 +1591,7 @@ Error ONNXModelLoader::loadConvTranspose(const ONNX_NAMESPACE::NodeProto &op,
   // number of filters. We use this value to calculate the size of the bias
   // if it is not specified.
   const NodeValue filterTransposedValue = filterTransposeNode->getResult();
-  dim_t depth = filterTransposedValue.dims()[0];
+  dim_t depth = filterTransposedValue.dims()[0] * group;
 
   // Get the kernel shape from the input.
   llvm::SmallVector<unsigned_t, 2> kernels(2);

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -2141,8 +2141,6 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     auto *filterPtr = emitValueAddress(builder, filter);
     auto *biasPtr = emitValueAddress(builder, bias);
 
-    assert(CI->getGroup() == 1 && "Group != 1 is not supported.");
-
     auto *destDims = emitValueDims(builder, dest);
     auto *srcDims = emitValueDims(builder, src);
     auto *filterDims = emitValueDims(builder, filter);

--- a/tests/models/onnxModels/convTransposeGroup.onnxtxt
+++ b/tests/models/onnxModels/convTransposeGroup.onnxtxt
@@ -1,0 +1,111 @@
+ir_version: 3
+producer_name: "onnx-deconv-group"
+graph {
+  node {
+    input: "X"
+    input: "W"
+    output: "Y"
+    op_type: "ConvTranspose"
+    attribute {
+      name: "pads"
+      ints: 0
+      ints: 0
+      ints: 0
+      ints: 0
+      type: INTS
+    }
+    attribute {
+      name: "dilations"
+      ints: 1
+      ints: 1
+      type: INTS
+    }
+    attribute {
+      name: "strides"
+      ints: 2
+      ints: 2
+      type: INTS
+    }
+    attribute {
+      name: "kernel_shape"
+      ints: 2
+      ints: 2
+      type: INTS
+    }
+    attribute {
+      name: "group"
+      i: 2
+      type: INT
+    }
+  }
+  name: "deconv-model"
+  input {
+    name: "X"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "W"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "Y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 6
+          }
+          dim {
+            dim_value: 6
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 10
+}

--- a/tests/unittests/OnnxExporterTest.cpp
+++ b/tests/unittests/OnnxExporterTest.cpp
@@ -391,6 +391,7 @@ TEST(exporter, onnxModels) {
             std::string::npos ||
         name.find("simpleConvTransposeAutoPadSameLower.onnxtxt") !=
             std::string::npos ||
+        name.find("convTransposeGroup.onnxtxt") != std::string::npos ||
         name.find("simpleConvTransposeAutoPadSameUpper.onnxtxt") !=
             std::string::npos) {
       // Ignore invalid ONNX files and graphs without nodes.

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -1149,6 +1149,54 @@ TEST(onnx, importDeconvAsymmetric) {
   }
 }
 
+// ConvTranspose test with Group>1
+TEST(onnx, importDeconvGrouped) {
+
+  ExecutionEngine EE{};
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+
+  std::string NetFilename = std::string(
+      GLOW_DATA_PATH "tests/models/onnxModels/convTransposeGroup.onnxtxt");
+
+  PlaceholderBindings bindings;
+  Placeholder *output;
+  {
+    Tensor input(ElemKind::FloatTy, {1, 2, 3, 3});
+    for (dim_t i = 0; i < 2 * 3 * 3; i++) {
+      input.getHandle().raw(i) = i;
+    }
+    Tensor filter(ElemKind::FloatTy, {2, 1, 2, 2});
+    for (dim_t i = 0; i < 2 * 2 * 2; i++) {
+      filter.getHandle().raw(i) = i * 2;
+    }
+    ONNXModelLoader onnxLD(NetFilename, {"X", "W"},
+                           {&input.getType(), &filter.getType()}, *F);
+    output = EXIT_ON_ERR(onnxLD.getSingleOutput());
+    bindings.allocate(mod.getPlaceholders());
+    updateInputPlaceholdersByName(bindings, &mod, {"X", "W"},
+                                  {&input, &filter});
+  }
+  auto *res = bindings.get(output);
+  EE.compile(CompilationMode::Infer);
+  EE.run(bindings);
+
+  auto result = res->getHandle();
+
+  EXPECT_TRUE(result.dims() == llvm::ArrayRef<dim_t>({1, 2, 6, 6}));
+
+  std::vector<float> expected = {
+      0,   0,   0,   2,   0,   4,   0,   0,   4,   6,   8,   12,  0,   6,   0,
+      8,   0,   10,  12,  18,  16,  24,  20,  30,  0,   12,  0,   14,  0,   16,
+      24,  36,  28,  42,  32,  48,  72,  90,  80,  100, 88,  110, 108, 126, 120,
+      140, 132, 154, 96,  120, 104, 130, 112, 140, 144, 168, 156, 182, 168, 196,
+      120, 150, 128, 160, 136, 170, 180, 210, 192, 224, 204, 238};
+
+  for (dim_t i = 0, e = expected.size(); i < e; i++) {
+    EXPECT_FLOAT_EQ(result.raw(i), expected[i]);
+  }
+}
+
 /// Helper method to run the AveragePool operator test cases.
 /// \p filename contains the model .onnxtxt.
 /// \p expectedDims: output Tensor dimensions.

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -7837,6 +7837,58 @@ TEST_P(OperatorTest, ConvTransposedAsymmetric) {
   }
 }
 
+/// ConvTranspose test with Group>1
+TEST_P(OperatorTest, ConvTransposedGroup) {
+
+  CHECK_IF_ENABLED();
+
+  float biasVal[2] = {0, 0};
+  auto bias = mod_.createPlaceholder(ElemKind::FloatTy, {2}, "bias", false);
+  bindings_.allocate(bias)->getHandle() = biasVal;
+
+  auto *input =
+      mod_.createPlaceholder(ElemKind::FloatTy, {1, 3, 3, 2}, "input", false);
+  bindings_.allocate(input)->getHandle() = {0., 9.,  1., 10., 2., 11.,
+                                            3., 12., 4., 13., 5., 14.,
+                                            6., 15., 7., 16., 8., 17.};
+
+  auto filter =
+      mod_.createPlaceholder(ElemKind::FloatTy, {1, 2, 2, 2}, "filter", false);
+  bindings_.allocate(filter)->getHandle() = {
+      0., 8., 2., 10., 4., 12., 6., 14,
+  };
+
+  std::pair<dim_t, dim_t> outWH =
+      calculateConvTransposeOutputDims(3, 3, {2, 2}, {2, 2}, {0, 0, 0, 0});
+  auto outTy =
+      mod_.uniqueType(ElemKind::FloatTy, {1, outWH.first, outWH.second, 2});
+
+  ConvTransposeNode *CN =
+      F_->createConvTranspose("ConvTranspose", input, filter, bias, outTy,
+                              {2, 2}, {2, 2}, {0, 0, 0, 0}, 2, 1);
+
+  SaveNode *S = F_->createSave("save", CN);
+  bindings_.allocate(S->getPlaceholder());
+
+  ::glow::convertPlaceholdersToConstants(F_, bindings_,
+                                         {input, S->getPlaceholder()});
+  EE_.compile(CompilationMode::Infer);
+  EE_.run(bindings_);
+  auto result = bindings_.get(S->getPlaceholder())->getHandle();
+  std::vector<dim_t> expectedDims = {1, 6, 6, 2};
+  ASSERT_TRUE(result.dims().vec() == expectedDims);
+  std::vector<float> expected = {
+      0,   72,  0,   90,  0,   80,  2,   100, 0,   88,  4,   110, 0,   108, 0,
+      126, 4,   120, 6,   140, 8,   132, 12,  154, 0,   96,  6,   120, 0,   104,
+      8,   130, 0,   112, 10,  140, 12,  144, 18,  168, 16,  156, 24,  182, 20,
+      168, 30,  196, 0,   120, 12,  150, 0,   128, 14,  160, 0,   136, 16,  170,
+      24,  180, 36,  210, 28,  192, 42,  224, 32,  204, 48,  238};
+
+  for (dim_t i = 0; i < result.size(); i++) {
+    EXPECT_FLOAT_EQ(result.raw(i), expected[i]);
+  }
+}
+
 /// Compare ConvTranspose with equivalent Convolution, no strides.
 /// TODO - need version with Strides (dilate input).
 template <unsigned_t kernel, unsigned_t stride, unsigned_t pad, unsigned_t idim>


### PR DESCRIPTION
Summary: ConvTranspose operator has wrong asserts for filter and bias in verification functions. This error is observed in Group>1 case only. According to ONNX documentation in ConvTranspose, filters are expected to be in [C, M/group, H, W] but the verification functions are copied from Convolution verification which has [M, C/group, H, W]. 

In ONNXModelLoader, currently, output channel dimensions used is "M/group" which should be "M". Same thing also goes for bias, 

Test Plan:
Added test case in ONNXImporterTest with grouped deconvolution. 
