### PR TITLE
[OnnxImporter] Add support for Logical operations And/Or/Xor/Not

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -983,6 +983,23 @@ public:
   DECLARE_BROADCAST_NODE(Add, /* NUM_INPUTS */ 2)
   DECLARE_BROADCAST_NODE(Sub, /* NUM_INPUTS */ 2)
 
+#define DECLARE_LOGICAL_BROADCAST_NODE(NODE_NAME)                              \
+  template <class T, class... Args>                                            \
+  typename enable_if_same_t<T, NODE_NAME##Node>::type *                        \
+  createNodeWithBroadcast(const std::string &name, int axis,                   \
+                          Args &&... inputArgs) {                              \
+    BROADCAST_FUNC_COMMON_CODE(2)                                              \
+    return create##NODE_NAME(name, inputs[0], inputs[1]);                      \
+  }
+
+  /// Template function that creates a node for logical operations and
+  /// normalizes its input shapes with the use of BroadCast nodes.
+  /// If axis is -1, it calculates it automatically for multi
+  /// directional broadcast.
+  DECLARE_LOGICAL_BROADCAST_NODE(And)
+  DECLARE_LOGICAL_BROADCAST_NODE(Xor)
+  DECLARE_LOGICAL_BROADCAST_NODE(Or)
+
 #define DECLARE_CMP_BROADCAST_NODE(NODE_NAME)                                  \
   template <class T, class... Args>                                            \
   typename enable_if_same_t<T, NODE_NAME##Node>::type *                        \

--- a/tests/models/onnxModels/logicalAnd.onnxtxt
+++ b/tests/models/onnxModels/logicalAnd.onnxtxt
@@ -1,0 +1,82 @@
+ir_version: 7
+producer_name: "Logical_And_Example"
+graph {
+  node {
+    input: "LHS"
+    input: "RHS"
+    output: "Out"
+    name: "LogicalAnd"
+    op_type: "And"
+  }
+  name: "And operation"
+  input {
+    name: "LHS"
+    type {
+      tensor_type {
+        elem_type: 9
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "RHS"
+    type {
+      tensor_type {
+        elem_type: 9
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "Out"
+    type {
+      tensor_type {
+        elem_type: 9
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 7
+}

--- a/tests/models/onnxModels/logicalAndBcast.onnxtxt
+++ b/tests/models/onnxModels/logicalAndBcast.onnxtxt
@@ -1,0 +1,76 @@
+ir_version: 7
+producer_name: "Logical_Broadcast_And_Example"
+graph {
+  node {
+    input: "LHS"
+    input: "RHS"
+    output: "Out"
+    name: "LogicalBroadCastAnd"
+    op_type: "And"
+  }
+  name: "Broadcast And operation"
+  input {
+    name: "LHS"
+    type {
+      tensor_type {
+        elem_type: 9
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "RHS"
+    type {
+      tensor_type {
+        elem_type: 9
+        shape {
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "Out"
+    type {
+      tensor_type {
+        elem_type: 9
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 7
+}

--- a/tests/models/onnxModels/logicalNot.onnxtxt
+++ b/tests/models/onnxModels/logicalNot.onnxtxt
@@ -1,0 +1,59 @@
+ir_version: 7
+producer_name: "Not_Example"
+graph {
+  node {
+    input: "X"
+    output: "Y"
+    name: "NotOp"
+    op_type: "Not"
+  }
+  name: "Not operation"
+  input {
+    name: "X"
+    type {
+      tensor_type {
+        elem_type: 9
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "Y"
+    type {
+      tensor_type {
+        elem_type: 9
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 1
+}

--- a/tests/models/onnxModels/logicalOr.onnxtxt
+++ b/tests/models/onnxModels/logicalOr.onnxtxt
@@ -1,0 +1,82 @@
+ir_version: 7
+producer_name: "Logical_Or_Example"
+graph {
+  node {
+    input: "LHS"
+    input: "RHS"
+    output: "Out"
+    name: "LogicalOr"
+    op_type: "Or"
+  }
+  name: "Or operation"
+  input {
+    name: "LHS"
+    type {
+      tensor_type {
+        elem_type: 9
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "RHS"
+    type {
+      tensor_type {
+        elem_type: 9
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "Out"
+    type {
+      tensor_type {
+        elem_type: 9
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 7
+}

--- a/tests/models/onnxModels/logicalOrBcast.onnxtxt
+++ b/tests/models/onnxModels/logicalOrBcast.onnxtxt
@@ -1,0 +1,76 @@
+ir_version: 7
+producer_name: "Logical_Broadcast_Or_Example"
+graph {
+  node {
+    input: "LHS"
+    input: "RHS"
+    output: "Out"
+    name: "LogicalBroadCastOr"
+    op_type: "Or"
+  }
+  name: "Broadcast Or operation"
+  input {
+    name: "LHS"
+    type {
+      tensor_type {
+        elem_type: 9
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "RHS"
+    type {
+      tensor_type {
+        elem_type: 9
+        shape {
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "Out"
+    type {
+      tensor_type {
+        elem_type: 9
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 7
+}

--- a/tests/models/onnxModels/logicalXor.onnxtxt
+++ b/tests/models/onnxModels/logicalXor.onnxtxt
@@ -1,0 +1,82 @@
+ir_version: 7
+producer_name: "Logical_Xor_Example"
+graph {
+  node {
+    input: "LHS"
+    input: "RHS"
+    output: "Out"
+    name: "LogicalXor"
+    op_type: "Xor"
+  }
+  name: "Xor operation"
+  input {
+    name: "LHS"
+    type {
+      tensor_type {
+        elem_type: 9
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "RHS"
+    type {
+      tensor_type {
+        elem_type: 9
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "Out"
+    type {
+      tensor_type {
+        elem_type: 9
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 7
+}

--- a/tests/models/onnxModels/logicalXorBcast.onnxtxt
+++ b/tests/models/onnxModels/logicalXorBcast.onnxtxt
@@ -1,0 +1,76 @@
+ir_version: 7
+producer_name: "Logical_Broadcast_Xor_Example"
+graph {
+  node {
+    input: "LHS"
+    input: "RHS"
+    output: "Out"
+    name: "LogicalBroadCastXor"
+    op_type: "Xor"
+  }
+  name: "Broadcast Xor operation"
+  input {
+    name: "LHS"
+    type {
+      tensor_type {
+        elem_type: 9
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "RHS"
+    type {
+      tensor_type {
+        elem_type: 9
+        shape {
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "Out"
+    type {
+      tensor_type {
+        elem_type: 9
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 7
+}

--- a/tests/unittests/OnnxExporterTest.cpp
+++ b/tests/unittests/OnnxExporterTest.cpp
@@ -384,6 +384,14 @@ TEST(exporter, onnxModels) {
             std::string::npos ||
         name.find("convTransposeAsymmetric.onnxtxt") != std::string::npos ||
         name.find("NonZero.onnxtxt") != std::string::npos ||
+        name.find("logicalAnd.onnxtxt") != std::string::npos ||
+        name.find("logicalAndBcast.onnxtxt") != std::string::npos ||
+        name.find("logicalOrBcast.onnxtxt") != std::string::npos ||
+        name.find("logicalOr.onnxtxt") != std::string::npos ||
+        name.find("logicalXorBcast.onnxtxt") != std::string::npos ||
+        name.find("logicalXor.onnxtxt") != std::string::npos ||
+        name.find("logicalNot.onnxtxt") != std::string::npos ||
+
         name.find("simpleConvTransposePads.onnxtxt") != std::string::npos ||
         name.find("simpleConvTransposeAutoPadValid.onnxtxt") !=
             std::string::npos ||


### PR DESCRIPTION
Summary: [OnnxImporter] Add support for logical operations in onnx model importer
                                          (AND / OR/ XOR / NOT)

Test Plan:  Added Tests for each operation

