### PR TITLE
Enabling ONNXModelWriter for ResizeNearest and ResizeBilinear 

### DIFF
--- a/tests/unittests/OnnxExporterTest.cpp
+++ b/tests/unittests/OnnxExporterTest.cpp
@@ -357,11 +357,9 @@ TEST(exporter, onnxModels) {
         name.find("ArgMaxNoKeepDim.onnxtxt") != std::string::npos ||
         name.find("upsampleOpset7.onnxtxt") != std::string::npos ||
         name.find("upsampleOpset9.onnxtxt") != std::string::npos ||
-        name.find("resizeNearest.onnxtxt") != std::string::npos ||
         name.find("resizeNearestV11compat.onnxtxt") != std::string::npos ||
         name.find("resizeNearestV11compat_sizes.onnxtxt") !=
             std::string::npos ||
-        name.find("resizeBilinear.onnxtxt") != std::string::npos ||
         name.find("resizeBilinearV11compat.onnxtxt") != std::string::npos ||
         name.find("resizeBilinearV11compat_sizes.onnxtxt") !=
             std::string::npos ||
@@ -383,6 +381,7 @@ TEST(exporter, onnxModels) {
         name.find("simpleConvTransposeAutoPadSameUpper.onnxtxt") !=
             std::string::npos ||
         name.find("convTransposeAsymmetric.onnxtxt") != std::string::npos ||
+        name.find("convTransposeGroup.onnxtxt") != std::string::npos ||
         name.find("NonZero.onnxtxt") != std::string::npos ||
         name.find("simpleConvTransposePads.onnxtxt") != std::string::npos ||
         name.find("simpleConvTransposeAutoPadValid.onnxtxt") !=


### PR DESCRIPTION
Summary: Currently, OnnxModelWriter has bugs in ResizeNearest and ResizeBilinear ops. Adding the correct implementation which supports OPSET version 10 for now.  

Test Plan: Enabled the corresponding test cases in ONNXExporterTest
