### PR TITLE
Extend Ops for the Shape Inference Engine

### DIFF
--- a/torch_glow/src/ShapeInferenceEngine.h
+++ b/torch_glow/src/ShapeInferenceEngine.h
@@ -86,47 +86,44 @@ private:
   primConstant(const torch::jit::Node *node);
   // Shape inference for aten::add, aten::mul, aten::pow
   static Expected<std::vector<int64_t>>
-  binaryOp(const MetaStack &varibableMetas);
+  binaryOp(const MetaStack &variableMetas);
   // Shape inference for aten::mm
-  static Expected<std::vector<int64_t>> mm(const MetaStack &varibableMetas);
+  static Expected<std::vector<int64_t>> mm(const MetaStack &variableMetas);
   // Shape inference for aten::bmm
-  static Expected<std::vector<int64_t>> bmm(const MetaStack &varibableMetas);
+  static Expected<std::vector<int64_t>> bmm(const MetaStack &variableMetas);
   // Shape inference for aten::addmm
-  static Expected<std::vector<int64_t>> addmm(const MetaStack &varibableMetas);
+  static Expected<std::vector<int64_t>> addmm(const MetaStack &variableMetas);
   // Shape inference for prim::ConstantChunk
   static Expected<std::vector<std::vector<int64_t>>>
-  constantChunk(const MetaStack &varibableMetas, int64_t chunks, int64_t dim);
+  constantChunk(const MetaStack &variableMetas, int64_t chunks, int64_t dim);
   // Shape inference for prim::FusedConcat
   static Expected<std::vector<int64_t>>
-  fusedConcat(const MetaStack &varibableMetas, int64_t dim);
+  fusedConcat(const MetaStack &variableMetas, int64_t dim);
   // Shape inference for prim::ListConstruct
   static Expected<std::vector<int64_t>>
-  listConstruct(const MetaStack &varibableMetas);
+  listConstruct(const MetaStack &variableMetas);
   // Shape inference for aten::permute
-  static Expected<std::vector<int64_t>>
-  permute(const MetaStack &varibableMetas);
+  static Expected<std::vector<int64_t>> permute(const MetaStack &variableMetas);
   // Shape inference for aten::reshape
-  static Expected<std::vector<int64_t>>
-  reshape(const MetaStack &varibableMetas);
+  static Expected<std::vector<int64_t>> reshape(const MetaStack &variableMetas);
   // Shape inference for aten::slice
-  static Expected<std::vector<int64_t>> slice(const MetaStack &varibableMetas);
+  static Expected<std::vector<int64_t>> slice(const MetaStack &variableMetas);
 
   /// TODO: To be extended
   // Shape inference for aten::transpose
   static Expected<std::vector<int64_t>>
-  transpose(const MetaStack &varibableMetas);
+  transpose(const MetaStack &variableMetas);
   // Shape inference for aten::flatten
-  static Expected<std::vector<int64_t>>
-  flatten(const MetaStack &varibableMetas);
+  static Expected<std::vector<int64_t>> flatten(const MetaStack &variableMetas);
   // Shape inference for glow::fused_stack
   static Expected<std::vector<int64_t>>
-  fusedStack(const MetaStack &varibableMetas, int64_t dim);
+  fusedStack(const MetaStack &variableMetas, int64_t dim);
   // Shape inference for fb::embedding_bag_byte_rowwise_offsets
   static Expected<std::vector<int64_t>>
-  embeddingBagByteRowwiseOffsets(const MetaStack &varibableMetas);
+  embeddingBagByteRowwiseOffsets(const MetaStack &variableMetas);
   // Shape inference for aten::embedding_bag
   static Expected<std::vector<int64_t>>
-  embeddingBag(const MetaStack &varibableMetas);
+  embeddingBag(const MetaStack &variableMetas);
 };
 
 } // namespace glow

--- a/torch_glow/tests/nodes/masked_fill_test.py
+++ b/torch_glow/tests/nodes/masked_fill_test.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import unittest
+
 import torch
 from tests.utils import jitVsGlow
-import unittest
 
 
 class TestMaskedFill(unittest.TestCase):


### PR DESCRIPTION
Summary:
Add Ops: prim::ListConstruct, aten::reshape, aten::permute, aten::slice. Did some unit tests.
TODO: extend more Ops

Reviewed By: allwu

Differential Revision: D22601135

