### PR TITLE
Skip backend correctness checking during optimizeFunction call

### DIFF
--- a/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
+++ b/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
@@ -116,6 +116,11 @@ struct OptimizationOptions {
   /// Folding will be run.
   bool delayAndRecordConstantModification{false};
 
+  /// If true, then there will be no error checking for backend support during
+  /// the optimization pipeline. Expected that the caller will check if desired
+  /// later on.
+  bool skipBackendSupportCheck{false};
+
   /// If true, this will merge ConvertTo and Quantize nodes into inputs and
   /// outputs of the Function. This means modifying the types of Placeholders
   /// and SaveNodes if they have a corresponding ElemKind conversion (ConvertTo,

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -126,8 +126,10 @@ onnxStatus Backend::checkGraphCompatibility(const void *onnxModel,
   }
 
   // Perform the normal optimization pipeline, returning an internal error if we
-  // encounter an issue during optimization.
+  // encounter an issue during optimization. Skip backend support checking
+  // because we check it next below via acceptForExecution().
   CompilationContext cctx;
+  cctx.optimizationOpts.skipBackendSupportCheck = true;
   auto optErr = glow::optimizeFunction(function, *glowBackend_, cctx);
   if (optErr) {
     LOG(ERROR) << "Error during glow::optimizeFunction():\n" +

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -5086,11 +5086,18 @@ Error glow::optimizeFunction(Function *F, const Backend &B,
 
   // We already started using backend specific verification when the function
   // state became lowered. Do one more verification pass to make sure everything
-  // is in order and to bail if it is not. Only do so if we are allowing
-  // constant modification, as otherwise we may have prevent a backend from
-  // supporting some Nodes. Expect the caller to verify later on in such cases.
-  if (!cctx.optimizationOpts.delayAndRecordConstantModification &&
-      !B.verify(*F, cctx.verboseCompile)) {
+  // is in order and to bail if it is not.
+  if (cctx.optimizationOpts.delayAndRecordConstantModification ||
+      cctx.optimizationOpts.skipBackendSupportCheck) {
+    // Only do verification without checking backend's support if requested, or
+    // if we are disallowing constant modification (as otherwise we may have
+    // prevent a backend from supporting some Nodes). Expect the caller to
+    // verify that Nodes are supported later on in such cases.
+    RETURN_ERR_IF_NOT(F->verify(&B),
+                      "Verification after optimization failed for Function " +
+                          F->getName().str() + " and Backend " +
+                          B.getBackendName());
+  } else if (!B.verify(*F, cctx.verboseCompile)) {
     return MAKE_ERR(
         ErrorValue::ErrorCode::COMPILE_UNSUPPORTED_NODE_AFTER_OPTIMIZE,
         "Unsupported node(s) found after optimizing Function " +


### PR DESCRIPTION
Summary: The way this was before, if a backend didn't support a node then it would return an internal error due to an error inside the optimization pipeline. Instead, add a flag to only do Function verification instead. Then we check ourselves via `acceptForExecution()`

Reviewed By: yinghai

Differential Revision: D22676766

