### PR TITLE
Enabling ONNXModelWriter for ResizeNearest and ResizeBilinear

### DIFF
--- a/lib/Exporter/ONNXModelWriter.cpp
+++ b/lib/Exporter/ONNXModelWriter.cpp
@@ -1652,19 +1652,52 @@ Error ONNXModelWriter::writeBucketize(const BucketizeNode *node,
 Error ONNXModelWriter::writeResizeNearest(const ResizeNearestNode *node,
                                           GraphType &graph) {
   auto *proto = graph.add_node();
-  // Add dictionary entries.
-  addValueAttribute(proto, "Scale", node->getScale());
+  // Converting arrayRef scale to a constant node
+  auto scale = node->getScale();
+  Tensor scaleTensor(ElemKind::FloatTy, {(dim_t)scale.size()});
+  auto handleScale = scaleTensor.getHandle<float>();
+  for (size_t b = 0, e = scale.size(); b < e; ++b) {
+    handleScale.raw(b) = scale[b];
+  }
 
-  return writeAllWithNode(node->getName(), node, graph, proto);
+  auto *tensorProto = addInitializer(graph);
+  tensorProto->set_name(node->getName().str() + "_scale");
+  writeTensor(scaleTensor, tensorProto, useGlowCustomOps_);
+
+  // Add dictionary entries.
+  addValueAttribute(proto, "coordinate_transformation_mode",
+                    std::string("asymmetric"));
+  addValueAttribute(proto, "mode", std::string("nearest"));
+  addValueAttribute(proto, "nearest_mode", std::string("floor"));
+
+  RETURN_IF_ERR(writeAllWithNode("Resize", node, graph, proto));
+  proto->add_input(node->getName().str() + "_scale");
+  return Error::success();
 }
 
 Error ONNXModelWriter::writeResizeBilinear(const ResizeBilinearNode *node,
                                            GraphType &graph) {
   auto *proto = graph.add_node();
-  // Add dictionary entries.
-  addValueAttribute(proto, "Scale", node->getScale());
+  // Converting arrayRef scale to a constant node
+  auto scale = node->getScale();
+  Tensor scaleTensor(ElemKind::FloatTy, {(dim_t)scale.size()});
+  auto handleScale = scaleTensor.getHandle<float>();
+  for (size_t b = 0, e = scale.size(); b < e; ++b) {
+    handleScale.raw(b) = scale[b];
+  }
 
-  return writeAllWithNode(node->getName(), node, graph, proto);
+  auto *tensorProto = addInitializer(graph);
+  tensorProto->set_name(node->getName().str() + "_scale");
+  writeTensor(scaleTensor, tensorProto, useGlowCustomOps_);
+
+  // Add dictionary entries.
+  addValueAttribute(proto, "coordinate_transformation_mode",
+                    std::string("asymmetric"));
+  addValueAttribute(proto, "mode", std::string("linear"));
+
+  RETURN_IF_ERR(writeAllWithNode("Resize", node, graph, proto));
+  proto->add_input(node->getName().str() + "_scale");
+  return Error::success();
 }
 
 Error ONNXModelWriter::writeSoftMax(const SoftMaxNode *node, GraphType &graph) {

--- a/tests/unittests/OnnxExporterTest.cpp
+++ b/tests/unittests/OnnxExporterTest.cpp
@@ -357,11 +357,9 @@ TEST(exporter, onnxModels) {
         name.find("ArgMaxNoKeepDim.onnxtxt") != std::string::npos ||
         name.find("upsampleOpset7.onnxtxt") != std::string::npos ||
         name.find("upsampleOpset9.onnxtxt") != std::string::npos ||
-        name.find("resizeNearest.onnxtxt") != std::string::npos ||
         name.find("resizeNearestV11compat.onnxtxt") != std::string::npos ||
         name.find("resizeNearestV11compat_sizes.onnxtxt") !=
             std::string::npos ||
-        name.find("resizeBilinear.onnxtxt") != std::string::npos ||
         name.find("resizeBilinearV11compat.onnxtxt") != std::string::npos ||
         name.find("resizeBilinearV11compat_sizes.onnxtxt") !=
             std::string::npos ||


### PR DESCRIPTION
Summary: Currently, OnnxModelWriter has bugs in ResizeNearest and ResizeBilinear ops. Adding the correct implementation which supports OPSET version 10 for now.

Test Plan: Enabled the corresponding test cases in ONNXExporterTest
