### PR TITLE
store inputMeta for fixed compilation size in CachingGraphRunner

### DIFF
--- a/torch_glow/src/CachingGraphRunner.h
+++ b/torch_glow/src/CachingGraphRunner.h
@@ -75,6 +75,11 @@ class CachingGraphRunner {
   std::unordered_map<size_t, std::shared_ptr<PerGlowGraphInfo>>
       perGlowGraphInfoMap_;
 
+  /// In AOT flow, compile a single Glow function and use it for all input
+  /// sizes. The PyTorch tensor inputs in this case should be smaller that the
+  /// compiled inputs, and they'll be padded with zeros by Glow.
+  bool useMaxSizeCompilation_ = true;
+
   /// Indicate which type will propagate to output.
   /// It is supposely to be the correct PyTorch ScalarType
   /// in the corresponding JIT node for each output
@@ -162,8 +167,11 @@ public:
   /// perGlowGraphInfoMap_ with the hash computed using \p inputMeta. \p
   /// inputMeta is used to pass Glow shapes and types (Only tensors are valid
   /// inputs). \p settings enable different settings for each compilation.
+  /// If \p useMaxSizeCompilation , compile only a single Glow graph with an
+  /// upper-bound on the input sizes (smaller inputs will be padded by Glow.)
   Error warmCache(const std::vector<InputMeta> &inputMeta,
-                  const PyTorchLoaderSettings &settings);
+                  const PyTorchLoaderSettings &settings,
+                  bool useMaxSizeCompilation = true);
 
   const PyTorchLoaderSettings &getSettings() const;
 };

--- a/torch_glow/src/PyTorchCommon.cpp
+++ b/torch_glow/src/PyTorchCommon.cpp
@@ -440,7 +440,8 @@ void glowAOTFusion(torch::jit::Module &model, const std::string &inputMetaStr) {
 
   auto inputMeta = glow::loadInputMeta(inputMetaStr);
 
-  auto e = runner->warmCache(*inputMeta, runner->getSettings());
+  auto e = runner->warmCache(*inputMeta, runner->getSettings(),
+                             /*useMaxSizeCompilation*/ true);
   if (e) {
     // If the graph is already compiled previously, warmCache() will report
     // an error but it is fine with our execution. So here we extract the

--- a/torch_glow/src/TorchGlowBackend.cpp
+++ b/torch_glow/src/TorchGlowBackend.cpp
@@ -439,7 +439,8 @@ TorchGlowBackend::compile(c10::IValue processed,
             *c10::IValue(elem).toCustomClass<GlowCompileSpec>());
 
         // Compile
-        auto e = runner->warmCache(inputMeta, runner->getSettings());
+        auto e = runner->warmCache(inputMeta, runner->getSettings(),
+                                   /*useMaxSizeCompilation*/ false);
         CHECK(!(bool)e) << ERR_TO_STRING(std::move(e));
       }
 


### PR DESCRIPTION
Summary: adding a flag in CachingGraphRunner to use store and use fixed compilation size from input meta. This is for cases like ctr_mbl_feed where we want to pass partial tensors to Glow to be padded.

Reviewed By: jackm321

Differential Revision: D22672396

