### PR TITLE
Do not parallelize Concat in basic parallelization

### DIFF
--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -676,19 +676,6 @@ static void setupBasicParallelizationConfigs(
       continue;
     }
 
-    // Split Concat layers.
-    if (auto *CN = llvm::dyn_cast<ConcatNode>(node)) {
-      if (CN->getDim() == 0) {
-        parOpts[CN] = ParallelTransformKind::Data;
-      } else if (CN->getDim() == 1) {
-        parOpts[CN] = ParallelTransformKind::Model;
-      } else {
-        continue;
-      }
-      numChunks[CN] = numParallelChunks;
-      continue;
-    }
-
     // Split LayerNorm layers in data parallel fashion
     if (auto *LN = llvm::dyn_cast<LayerNormalizationNode>(node)) {
       if (LN->getInput().dims().size() < 2) {


### PR DESCRIPTION
Summary: This was not correctly specified. Remove for now.

Reviewed By: mjanderson09

Differential Revision: D22702336

