### PR TITLE
Fix initializatin order issue by avoiding calling glog before main

### DIFF
--- a/lib/Backends/NNPI/NNPIOptions.cpp
+++ b/lib/Backends/NNPI/NNPIOptions.cpp
@@ -20,6 +20,7 @@
 #include <cstdio>
 #include <fstream>
 #include <glog/logging.h>
+#include <iostream>
 #include <sstream>
 
 using namespace glow;
@@ -102,7 +103,7 @@ unsigned NNPIOptions::getFirstDeviceSteppingVersion() {
   constexpr char stepLoc[] = "/sys/class/nnpi/nnpi0/card_stepping";
   inFile.open(stepLoc);
   if (!inFile.good() || inFile.eof()) {
-    LOG(INFO) << "Could not find device stepping at " << stepLoc;
+    std::cerr << "Could not find device stepping at " << stepLoc << std::endl;
     return 0;
   }
 


### PR DESCRIPTION
Summary: `NNPIOptions::getFirstDeviceSteppingVersion()` is called before `main()` and hence if we cannot find `/sys/class/nnpi/nnpi0/card_stepping`, for example, if we are running the program on a machine without card (with just emulator), it's possible that we hit the reporting path and call logging. Previously we are calling glog where some internal flags are not allocated yet, therefore causing coredump. Fix is calling plain std::cerr instead.

Differential Revision: D22750397

