### PR TITLE
Broadcast for masked_fill when both tensors are the same size

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -3605,10 +3605,9 @@ Error PyTorchModelLoader::loadMaskedFill(const torch::jit::Node *ptNode) {
                 inSize, maskSize));
 
   size_t maskBroadcastAxis = inSize - maskSize;
-  if (maskBroadcastAxis > 0) {
-    mask = F_.createBroadcast("broadcast", mask, in.dims(), maskBroadcastAxis)
-               ->getNthResult(0);
-  }
+  mask = F_.createBroadcast("masked_fill.broadcast", mask, in.dims(),
+                            maskBroadcastAxis)
+             ->getNthResult(0);
 
   float value;
   ASSIGN_VALUE_OR_RETURN_ERR(value, iValToDouble(getGlowIValueForValue(

--- a/torch_glow/tests/nodes/masked_fill_test.py
+++ b/torch_glow/tests/nodes/masked_fill_test.py
@@ -30,6 +30,32 @@ class TestMaskedFill(unittest.TestCase):
 
         jitVsGlow(masked_fill, x, m, expected_fused_ops={"aten::masked_fill"})
 
+    def test_masked_fill_broadcasted_unit_dim(self):
+        """Test of the PyTorch aten::masked_fill op on Glow with a
+        broadcasted mask where the mask's size contains a leading 1"""
+
+        def masked_fill(a, mask):
+            return torch.masked_fill(a + a, mask, 42.0)
+
+        x = torch.randn([4, 1, 3])
+        m = torch.tensor([[True, False, True]], dtype=torch.bool)
+
+        jitVsGlow(masked_fill, x, m, expected_fused_ops={"aten::masked_fill"})
+
+    def test_masked_fill_broadcasted_multi_dim(self):
+        """Test of the PyTorch aten::masked_fill op on Glow with a
+        broadcasted mask where the mask's size has a non 1 lead dim"""
+
+        def masked_fill(a, mask):
+            return torch.masked_fill(a + a, mask, 42.0)
+
+        x = torch.randn([2, 4, 3, 3])
+        m = torch.tensor(
+            [[[[True, False, True]]], [[[True, False, True]]]], dtype=torch.bool
+        )
+
+        jitVsGlow(masked_fill, x, m, expected_fused_ops={"aten::masked_fill"})
+
     def test_masked_fill_inplace(self):
         """Test of the PyTorch aten::masked_fill_ op on Glow"""
 


### PR DESCRIPTION
Summary: A mask with rank the as input tensor may still need to be broadcasted

Differential Revision: D22789897

