### PR TITLE
Add perf comparison vs cpu to jitVsGlowCompare in CachingGraphRunner

### DIFF
--- a/torch_glow/src/CachingGraphRunner.h
+++ b/torch_glow/src/CachingGraphRunner.h
@@ -131,8 +131,8 @@ class CachingGraphRunner {
                 std::unique_ptr<ExecutionContext> &ctx);
 
   /// Run the graph_ on \p stack on using ptGraphExecutor_. This is for
-  /// debugging purposes only.
-  void runOnJit(torch::jit::Stack &stack);
+  /// debugging purposes only. \returns how long running took in usecs.
+  int64_t runOnJit(torch::jit::Stack &stack);
 
   /// Given a \p stack of inputs, computes the hash for the inputs on the stack.
   size_t computeGraphHash(const c10::ArrayRef<c10::IValue> inputs) const;

--- a/torch_glow/src/PyTorchCommon.cpp
+++ b/torch_glow/src/PyTorchCommon.cpp
@@ -49,6 +49,8 @@ DEFINE_int32(maxActiveRequests, 250,
              "Max number of active requests before HostManager starts queuing");
 DEFINE_bool(randomizeConstants, false, "See PyTorchLoaderSettings");
 DEFINE_bool(runShapeInference, false, "See PyTorchLoaderSettings");
+DEFINE_int32(fusionStartIndex, -1, "See PyTorchLoaderSettings");
+DEFINE_int32(fusionEndIndex, -1, "See PyTorchLoaderSettings");
 
 namespace glow {
 
@@ -228,6 +230,8 @@ static PyTorchLoaderSettings getInitialSettings() {
   settings.backendName = FLAGS_torch_glow_backend;
   settings.numDevices = FLAGS_torch_glow_num_devices;
   settings.runShapeInference = FLAGS_runShapeInference;
+  settings.fusionStartIndex = FLAGS_fusionStartIndex;
+  settings.fusionEndIndex = FLAGS_fusionEndIndex;
 
   if (!FLAGS_opBlacklist.empty()) {
     auto kindStrings = splitString(FLAGS_opBlacklist);


### PR DESCRIPTION
Summary:
In addition to the per-tensor correctness checks that jitVsGlowCompare prints out comparing Glow to PyTorch JIT results, also print out the run time that Glow and JIT each took for comparison of accelerator and CPU

Also add gflags for fusionStartIndex and fusionEndIndex

Differential Revision: D22788995

