### PR TITLE
Extend Supported Operator "aten::t" in Shape Inference

### DIFF
--- a/torch_glow/src/ShapeInferenceEngine.h
+++ b/torch_glow/src/ShapeInferenceEngine.h
@@ -97,6 +97,8 @@ private:
   static Expected<std::vector<int64_t>> bmm(const MetaStack &variableMetas);
   // Shape inference for aten::addmm
   static Expected<std::vector<int64_t>> addmm(const MetaStack &variableMetas);
+  // Shape inference for aten::t
+  static Expected<std::vector<int64_t>> t(const MetaStack &variableMetas);
   // Shape inference for prim::ConstantChunk
   static Expected<std::vector<std::vector<int64_t>>>
   constantChunk(const MetaStack &variableMetas, int64_t chunks, int64_t dim);


### PR DESCRIPTION
Summary: Add aten::t in shape inference; Add unit tests accordingly;

Reviewed By: movefast1990

Differential Revision: D22675906

