### PR TITLE
Add super allowlist tooling for torch_glow

### DIFF
--- a/torch_glow/src/GlowFuser.cpp
+++ b/torch_glow/src/GlowFuser.cpp
@@ -277,6 +277,12 @@ void glowCustomFuseImpl(std::shared_ptr<torch::jit::Graph> graph,
 
   size_t i = 0;
   for (const torch::jit::Node *node : graph->nodes()) {
+    // if a node is in super allowlist, it is always allowed
+    if (settings.opOverrideAllowlist.count(node->kind())) {
+      i++;
+      continue;
+    }
+
     if (settings.fusionStartIndex >= 0 && i < settings.fusionStartIndex) {
       blacklistedNodes[node] = NodeBlacklistReason::Index;
     }

--- a/torch_glow/src/PyTorchCommon.cpp
+++ b/torch_glow/src/PyTorchCommon.cpp
@@ -43,6 +43,7 @@ DEFINE_bool(saturateHost, false, "See PyTorchLoaderSettings");
 DEFINE_bool(convertToFP16, false, "See PyTorchLoaderSettings");
 DEFINE_bool(convertFusedToFP16, false, "See PyTorchLoaderSettings");
 DEFINE_string(opBlacklist, "", "See PyTorchLoaderSettings");
+DEFINE_string(opOverrideAllowlist, "", "See PyTorchLoaderSettings");
 DEFINE_int32(replicationCount, 1, "Number of replications on each device");
 DEFINE_bool(writeToOnnx, false, "See PyTorchLoaderSettings");
 DEFINE_int32(maxActiveRequests, 250,
@@ -237,6 +238,14 @@ static PyTorchLoaderSettings getInitialSettings() {
     auto kindStrings = splitString(FLAGS_opBlacklist);
     for (const auto &kindString : kindStrings) {
       settings.opBlacklist.insert(
+          torch::jit::Symbol::fromQualString(kindString));
+    }
+  }
+
+  if (!FLAGS_opOverrideAllowlist.empty()) {
+    auto kindStrings = splitString(FLAGS_opOverrideAllowlist);
+    for (const auto &kindString : kindStrings) {
+      settings.opOverrideAllowlist.insert(
           torch::jit::Symbol::fromQualString(kindString));
     }
   }

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -54,6 +54,11 @@ struct PyTorchLoaderSettings {
   /// thus will not be fused to Glow.
   std::unordered_set<torch::jit::Symbol> opBlacklist;
 
+  /// A list of symbols for nodes that will always be fused by Glow fuser when
+  /// it is supported. This list overwrite all other blacklisting/indexing, and
+  /// can only be canceled by min/max fusion group size.
+  std::unordered_set<torch::jit::Symbol> opOverrideAllowlist;
+
   /// The minimum size of a glow fusion groups in terms of number of PyTorch
   /// nodes. 0 indicates no minimum size.
   size_t minFusionGroupSize = 0;

--- a/torch_glow/src/binding.cpp
+++ b/torch_glow/src/binding.cpp
@@ -180,10 +180,26 @@ PYBIND11_MODULE(_torch_glow, m) {
       bl.insert(torch::jit::Symbol::fromQualString(kind));
     }
   });
+  /// Add all of the symbols in \p allowlist to the fusion allowlist so that
+  /// nodes with these symbols will always be fused to Glow.
+  /// Noticing this is a super allowlist which overwrites blacklist and fusion
+  /// index.
+  m.def("setFusionOverrideAllowlist",
+        [](const std::vector<std::string> &superAllowlist) {
+          auto &al = getPyTorchLoaderSettings().opOverrideAllowlist;
+          al.clear();
+          for (const auto &kind : superAllowlist) {
+            al.insert(torch::jit::Symbol::fromQualString(kind));
+          }
+        });
 
   /// Clear the fusion blacklist.
   m.def("clearFusionBlacklist",
         []() { getPyTorchLoaderSettings().opBlacklist.clear(); });
+
+  /// Clear the fusion allow.
+  m.def("clearFusionOverrideAllowlist",
+        []() { getPyTorchLoaderSettings().opOverrideAllowlist.clear(); });
 
   /// Set the index (inclusive) of the first node in the graph to fuse.
   m.def("setFusionStartIndex", [](int64_t startIndex) {

--- a/torch_glow/tests/functionality/allowlist_test.py
+++ b/torch_glow/tests/functionality/allowlist_test.py
@@ -1,0 +1,89 @@
+# isort:skip_file
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import torch_glow
+import torch
+
+from tests.utils import GLOW_NODE_NAME, SUBGRAPH_ATTR
+import unittest
+
+
+class TestAllowList(unittest.TestCase):
+    def test_op_blacklist_allowlist(self):
+        """Test Glow fuser allowlist overwrites blacklist mechanism."""
+
+        def f(a, b):
+            return (a + b) * (a - b)
+
+        torch_glow.enableFusionPass()
+        torch_glow.setFusionBlacklist(["aten::add", "aten::sub"])
+        torch_glow.setFusionOverrideAllowlist(["aten::sub"])
+
+        a = torch.randn(5, 5)
+        b = torch.randn(5, 5)
+
+        jit_f = torch.jit.trace(f, (a, b))
+
+        jit_f_graph = jit_f.graph_for(a, b)
+
+        fused_add = False
+        fused_sub = False
+        for node in jit_f_graph.nodes():
+            if node.kind() == GLOW_NODE_NAME:
+                glow_subgraph = node.g(SUBGRAPH_ATTR)
+                for node in glow_subgraph.nodes():
+                    if node.kind() == "aten::add":
+                        fused_add = True
+                    if node.kind() == "aten::sub":
+                        fused_sub = True
+
+        assert not fused_add, "Expected aten::add to be blacklisted"
+        assert fused_sub, "Expected aten::sub to not be blacklisted"
+
+        torch_glow.clearFusionBlacklist()
+        torch_glow.clearFusionOverrideAllowlist()
+
+    def test_op_index_blacklist_allowlist(self):
+        """Test Glow fuser allowlist overwrites index blacklisting mechanism."""
+
+        def f(a, b):
+            x1 = a * b
+            x2 = x1 * b
+            x3 = x2 * a
+            x4 = x3 / b
+            x5 = x4 / a
+            x6 = x5 / b
+            x7 = x6 * a
+            x8 = x7 * b
+            return x8
+
+        torch_glow.enableFusionPass()
+        # Only one div is allowed by index
+        torch_glow.setFusionStartIndex(5)
+        torch_glow.setFusionEndIndex(6)
+        # But all divs are allowed by allowlist
+        torch_glow.setFusionOverrideAllowlist(["aten::div"])
+
+        a = torch.randn(5, 5)
+        b = torch.randn(5, 5)
+
+        jit_f = torch.jit.trace(f, (a, b))
+
+        jit_f_graph = jit_f.graph_for(a, b)
+
+        torch_glow.clearFusionIndices()
+        torch_glow.clearFusionOverrideAllowlist()
+
+        fused_muls = 0
+        fused_divs = 0
+        for node in jit_f_graph.nodes():
+            if node.kind() == GLOW_NODE_NAME:
+                glow_subgraph = node.g(SUBGRAPH_ATTR)
+                for node in glow_subgraph.nodes():
+                    if node.kind() == "aten::mul":
+                        fused_muls += 1
+                    if node.kind() == "aten::div":
+                        fused_divs += 1
+
+        assert fused_muls == 0, "Expected no aten::muls to be fused"
+        assert fused_divs == 3, "Expected all 3 aten::divs to be fused"


### PR DESCRIPTION
Summary:
Add super allowlist in torch_glow,
which overwrites blacklist and fusion index, makes ops in the list always be fused, unless the fused fusion group is too big/small which hits min/maxFusionGroupSize.

Differential Revision: D22835011

