### PR TITLE
Move NoLower tests to their own harness

### DIFF
--- a/tests/unittests/BackendTestUtils.h
+++ b/tests/unittests/BackendTestUtils.h
@@ -154,7 +154,7 @@ public:
   }
 
 protected:
-  void checkNumericalEquivalence(float allowedError = 0.0001) {
+  virtual void checkNumericalEquivalence(float allowedError = 0.0001) {
     // Check that the function and its optimized complement exist.
     ASSERT_TRUE(F_);
     ASSERT_TRUE(optimizedF_);


### PR DESCRIPTION
Summary:
Add a harness that only tests that when we rely on the optimization pipeline to do lowering based on precision that the resulting ops are using the precision we expect. Using the current `NNPIOptPipelineTest` harness causes an issue -- the unoptimized `F_` will not be converted to FP16 because it's added to `onlyLowerFuns`, but then it may not be supported as non-FP16.

Note that this test is not intended to run, just to compile to examine the output Function, and thus \ref checkNumericalEquivalence() will fail if called.

Differential Revision: D22849766

