### PR TITLE
adding PyTorchLoaderSettings member in GlowCompileSpec

### DIFF
--- a/torch_glow/src/GlowCompileSpec.h
+++ b/torch_glow/src/GlowCompileSpec.h
@@ -3,6 +3,7 @@
 #ifndef GLOW_TORCH_GLOW_SRC_GLOW_COMPILE_SPEC_H
 #define GLOW_TORCH_GLOW_SRC_GLOW_COMPILE_SPEC_H
 
+#include "PyTorchCommon.h"
 #include <ATen/core/ivalue.h>
 
 namespace glow {
@@ -28,7 +29,7 @@ public:
 
   void set(std::vector<int64_t> dims,
            c10::ScalarType type = c10::ScalarType::Float);
-  void setSameAs(const at::Tensor &t);
+  void set_same_as(const at::Tensor &t);
 
   SpecInputMetaSerializationType serializeToTuple() const;
   // Element type
@@ -45,24 +46,28 @@ class GlowCompileSpec : public torch::jit::CustomClassHolder {
 
 public:
   GlowCompileSpec() {}
-  GlowCompileSpec(const std::string &backendName,
-                  std::vector<SpecInputMeta> inputs)
-      : backendName_(backendName), inputs_(inputs) {}
+  GlowCompileSpec(std::vector<SpecInputMeta> inputs,
+                  PyTorchLoaderSettings settings)
+      : inputs_(inputs), settings_(settings) {}
   ~GlowCompileSpec() {}
 
-  const std::string &getBackend() const { return backendName_; }
-  void setBackend(const std::string &backendName) {
-    backendName_ = backendName;
-  }
   void addInputTensor(std::vector<int64_t> dims, c10::ScalarType type);
   void addInputFromTensor(at::Tensor);
   void addInput(c10::intrusive_ptr<SpecInputMeta> input);
   void addInputs(std::vector<c10::intrusive_ptr<SpecInputMeta>> inputs);
   std::vector<SpecInputMeta> inputs() const { return inputs_; }
 
+  torch::Dict<std::string, std::string> serialized_settings() const {
+    return settings_.serializeToDict();
+  }
+  PyTorchLoaderSettings settings() const { return settings_; }
+  void set_settings(c10::intrusive_ptr<PyTorchLoaderSettings> settings) {
+    settings_ = *settings;
+  }
+
 private:
-  std::string backendName_ = "";
   std::vector<SpecInputMeta> inputs_;
+  PyTorchLoaderSettings settings_;
 };
 
 } // namespace glow

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -33,7 +33,17 @@ struct InputMeta;
 /// Various settings to be used by code that loads PyTorch models. There should
 /// only be one of these and it should be obtained by calling
 /// getPyTorchLoaderSettings().
-struct PyTorchLoaderSettings {
+struct PyTorchLoaderSettings : public torch::jit::CustomClassHolder {
+public:
+  PyTorchLoaderSettings();
+  PyTorchLoaderSettings(torch::Dict<std::string, std::string> dict);
+  ~PyTorchLoaderSettings() {}
+
+  void initSettings();
+  std::string toString() const;
+
+  torch::Dict<std::string, std::string> serializeToDict() const;
+
   /// This should be used with CachingGraphRunner::warmCache. When this flag is
   /// enabled, it assumes the glow graph is compiled ahead of time instead of
   /// at PyTorch JIT runtime. And the registered glow operator will run
@@ -80,9 +90,13 @@ struct PyTorchLoaderSettings {
 
   /// Convert fp32 opts to fp16 ops during Glow compilation.
   bool convertToFP16 = false;
+  bool get_convert_to_fp16() { return convertToFP16; }
+  void set_convert_to_fp16(bool val) { convertToFP16 = val; }
 
   /// Convert fp32 fused opts to fp16 ops during Glow compilation.
   bool convertFusedToFP16 = false;
+  bool get_convert_fused_to_fp16() { return convertFusedToFP16; }
+  void set_convert_fused_to_fp16(bool val) { convertFusedToFP16 = val; }
 
   /// Dump Glow dot graph to file after Glow compilation is finished.
   bool dumpFinalGlowGraph = false;
@@ -95,6 +109,10 @@ struct PyTorchLoaderSettings {
 
   /// Replication count of a graph on a device.
   size_t replicationCount = 1;
+  int64_t get_replication_count() {
+    return static_cast<int64_t>(replicationCount);
+  }
+  void set_replication_count(int64_t val) { replicationCount = val; }
 
   /// Backend-specific options to be put into the CompilationContext and passed
   /// to the Glow backend.
@@ -113,13 +131,19 @@ struct PyTorchLoaderSettings {
   /// Whether not to set the saturateHost flag (use all available device) when
   /// adding networks to HostManager.
   bool saturateHost = false;
+  bool get_saturate_host() { return saturateHost; }
+  void set_saturate_host(bool val) { saturateHost = val; }
 
   /// If true then randomize the Constants in the Function loaded by
   /// PyTorchModelLoader.
   bool randomizeConstants = false;
+  bool get_randomize_constants() { return randomizeConstants; }
+  void set_randomize_constants(bool val) { randomizeConstants = val; }
 
   /// Name of the Glow backend to use.
   std::string backendName = "Interpreter";
+  std::string get_backend_name() { return backendName; }
+  void set_backend_name(std::string name) { backendName = name; }
 
   /// Number of Glow devices to use.
   int32_t numDevices = -1;

--- a/torch_glow/tests/functionality/conv_to_glow_test.py
+++ b/torch_glow/tests/functionality/conv_to_glow_test.py
@@ -2,6 +2,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import torch_glow
+from torch_glow import InputMeta, CompilationOptions, GlowCompileSpec
 import torch
 import unittest
 
@@ -49,12 +50,13 @@ def run_to_glow(m, x):
     """Trace the model m with input x and call to_glow"""
     traced_m = torch.jit.trace(m, (x))
 
-    spec = torch.classes.glow.GlowCompileSpec()
-    spec.setBackend("Interpreter")
-    sim = torch.classes.glow.SpecInputMeta()
-    sim.set(x.size(), torch.float32)
-    inputs = [sim]
-    spec.addInputs(inputs)
+    input_meta = InputMeta()
+    input_meta.set(x.size(), torch.float32)
+    inputs = [input_meta]
+    options = CompilationOptions()
+    options.backend = "Interpreter"
+    spec = GlowCompileSpec()
+    spec.set(inputs, options)
 
     lowered_module = torch_glow.to_glow(traced_m, {"forward": spec})
     return lowered_module

--- a/torch_glow/tests/functionality/glow_compile_spec_test.py
+++ b/torch_glow/tests/functionality/glow_compile_spec_test.py
@@ -1,7 +1,7 @@
 # isort:skip_file
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import torch_glow
+from torch_glow import InputMeta, CompilationOptions, GlowCompileSpec
 import torch
 import unittest
 
@@ -11,17 +11,11 @@ class TestGlowCompileSpec(unittest.TestCase):
         """Test glow compile spec basics."""
 
         dims = [2, 2]
-        gcs = torch.classes.glow.GlowCompileSpec()
-        gcs.setBackend("Interpreter")
+        input_meta = InputMeta()
+        input_meta.set(dims, torch.float32)
+        inputs = [input_meta, input_meta]
 
-        # Test SpecInputMeta setters
-        sim = torch.classes.glow.SpecInputMeta()
-        sim.set(dims, torch.float32)
-        t = torch.tensor(dims)
-        sim.setSameAs(t)
-
-        # Test adding input methods
-        gcs.addInputTensor(dims, torch.float32)
-        gcs.addInput(sim)
-        inputs = [sim, sim]
-        gcs.addInputs(inputs)
+        options = CompilationOptions()
+        options.backend = "Interpreter"
+        spec = GlowCompileSpec()
+        spec.set(inputs, options)

--- a/torch_glow/tests/functionality/randomize_constants_test.py
+++ b/torch_glow/tests/functionality/randomize_constants_test.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch_glow
+from torch_glow import InputMeta, CompilationOptions, GlowCompileSpec
 import torch
 
 
@@ -17,19 +18,17 @@ class Model(torch.nn.Module):
 
 
 def run_model(m, input, randomize):
-    if randomize:
-        torch_glow.enable_randomize_constants()
-    else:
-        torch_glow.disable_randomize_constants()
-
     torch_glow.disableFusionPass()
     traced_m = torch.jit.trace(m, input)
 
-    spec = torch.classes.glow.GlowCompileSpec()
-    spec.setBackend("Interpreter")
-    sim = torch.classes.glow.SpecInputMeta()
-    sim.setSameAs(input)
-    spec.addInputs([sim])
+    input_meta = InputMeta()
+    input_meta.set_same_as(input)
+    inputs = [input_meta]
+    options = CompilationOptions()
+    options.backend = "Interpreter"
+    options.randomize_constants = randomize
+    spec = GlowCompileSpec()
+    spec.set(inputs, options)
 
     glow_m = torch_glow.to_glow(traced_m, {"forward": spec})
     return glow_m.forward(input)

--- a/torch_glow/tests/functionality/to_glow_selective_test.py
+++ b/torch_glow/tests/functionality/to_glow_selective_test.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch_glow
+from torch_glow import InputMeta, CompilationOptions, GlowCompileSpec
 import torch
 
 
@@ -75,11 +76,14 @@ class TestSelectiveToGlow(unittest.TestCase):
         b = torch.zeros(4) + 7
         torch_res = model(a, b)
 
-        spec = torch.classes.glow.GlowCompileSpec()
-        spec.setBackend("Interpreter")
-        sim = torch.classes.glow.SpecInputMeta()
-        sim.setSameAs(a)
-        spec.addInputs([sim, sim])
+        input_meta = InputMeta()
+        input_meta.set_same_as(a)
+        inputs = [input_meta, input_meta]
+
+        options = CompilationOptions()
+        options.backend = "Interpreter"
+        spec = GlowCompileSpec()
+        spec.set(inputs, options)
 
         glow_mod = torch_glow.to_glow_selective(
             model, {"foo.bar": (spec, (a, b)), "qux": (spec, (a, b))}

--- a/torch_glow/tests/unittests/PyTorchLoaderTest.cpp
+++ b/torch_glow/tests/unittests/PyTorchLoaderTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "PyTorchCommon.h"
 #include "PyTorchFileLoader.h"
 #include "PyTorchModelLoader.h"
 #include "glow/Support/Error.h"
@@ -68,4 +69,19 @@ TEST(ModelLoaderTest, Direct) {
       fileName, vec, *F, inputPlaceholders, outputPlaceholders);
 
   EXPECT_FALSE(ERR_TO_BOOL(std::move(err)));
+}
+
+TEST(PyTorchLoaderSettings, Settings) {
+  torch::Dict<std::string, std::string> dict;
+  dict.insert("convertToFP16", "True");
+
+  std::string opts = "k1,v1,k2,v2,k3,v3";
+  dict.insert("backendSpecificOpts", opts);
+
+  glow::PyTorchLoaderSettings settings(dict);
+  EXPECT_TRUE(settings.convertToFP16);
+  EXPECT_TRUE(settings.backendSpecificOpts.size() == 3);
+
+  torch::Dict<std::string, std::string> ser = settings.serializeToDict();
+  EXPECT_TRUE(ser.at("convertToFP16") == "true");
 }

--- a/torch_glow/torch_glow/to_glow.py
+++ b/torch_glow/torch_glow/to_glow.py
@@ -4,7 +4,105 @@ import copy
 import torch
 
 
-__all__ = ["to_glow", "to_glow_selective"]
+__all__ = [
+    "to_glow",
+    "to_glow_selective",
+    "GlowCompileSpec",
+    "InputMeta",
+    "CompilationOptions",
+]
+
+
+"""
+    InputMeta  C++ custom class that defines metadata of input tensors to
+    the module being passed in to_glow. This metadata is composed of
+    dimensions and type.
+    Usage:
+    input_meta = InputMeta()
+    input_meta.set(dims, torch.float32)
+    inputs = [input_meta, input_meta]
+"""
+InputMeta = torch.classes.glow.SpecInputMeta
+
+
+class CompilationOptions:
+    r"""
+    CompilationOptions is a wrapper around a corresponding C++ custom class.
+    It enables to get and set compilation options available in Glow.
+    Usage:
+    options = GlowOptions()
+    options.backend = "Interpreter"
+    """
+
+    def __init__(self):
+        self.options = torch.classes.glow.PyTorchLoaderSettings()
+
+    @property
+    def backend(self):
+        return self.options.get_backend_name()
+
+    @backend.setter
+    def backend(self, value):
+        self.options.set_backend_name(value)
+
+    @property
+    def convert_to_fp16(self):
+        return self.options.get_convert_to_fp16()
+
+    @convert_to_fp16.setter
+    def convert_to_fp16(self, value):
+        self.options.set_convert_to_fp16(value)
+
+    @property
+    def convert_fused_to_fp16(self):
+        return self.options.get_convert_fused_to_fp16()
+
+    @convert_fused_to_fp16.setter
+    def convert_fused_to_fp16(self, value):
+        self.options.set_convert_fused_to_fp16(value)
+
+    @property
+    def saturate_host(self):
+        return self.options.get_saturate_host()
+
+    @saturate_host.setter
+    def saturate_host(self, value):
+        self.options.set_saturate_host(value)
+
+    @property
+    def randomize_constants(self):
+        return self.options.get_randomize_constants()
+
+    @randomize_constants.setter
+    def randomize_constants(self, value):
+        self.options.set_randomize_constants(value)
+
+    @property
+    def replication_count(self):
+        return self.options.get_replication_count()
+
+    @replication_count.setter
+    def replication_count(self, value):
+        self.options.set_replication_count(value)
+
+
+class GlowCompileSpec:
+    r"""
+    GlowCompileSpec is a wrapper around a corresponding C++ custom class.
+    The spec contains metadata for the module's input tensor[s] and optional
+    compilation options.
+    Usage:
+    spec = GlowCompileSpec()
+    spec.set(inputs, options)
+    """
+
+    def __init__(self):
+        self.spec = torch.classes.glow.GlowCompileSpec()
+
+    def set(self, input_meta, options=None):
+        self.spec.addInputs(input_meta)
+        if options is not None:
+            self.spec.set_settings(options.options)
 
 
 def to_glow(model, method_compile_spec):
@@ -28,11 +126,12 @@ def to_glow(model, method_compile_spec):
     if isinstance(method_compile_spec, collections.Mapping):
         for k, v in method_compile_spec.items():
             if not isinstance(v, list):
-                method_compile_spec[k] = [v]
+                method_compile_spec[k] = [v.spec]
     elif isinstance(method_compile_spec, list):
+        method_compile_spec = [wrapper.spec for wrapper in method_compile_spec]
         method_compile_spec = {"forward", method_compile_spec}
     else:
-        method_compile_spec = {"forward", [method_compile_spec]}
+        method_compile_spec = {"forward", [method_compile_spec.spec]}
 
     return torch._C._jit_to_backend("glow", model._c, method_compile_spec)
 


### PR DESCRIPTION
Summary:
Enabling compilation settings via to_glow:
* Adding PyTorchLoaderSettings member in GlowCompileSpec
* PyTorchLoaderSettings changed to custom_class, [de]serializtion to torch::Dict
* Defining a wrapper class in to_glow python library, to enable property interface
* Binding useful settings : backend_name, convert_to_fp16, saturate_host, replication_count

Reviewed By: jackm321

Differential Revision: D22699345

