### PR TITLE
EndOffset Support for debugging EmbeddingBag-like ops

### DIFF
--- a/torch_glow/src/GlowFuser.cpp
+++ b/torch_glow/src/GlowFuser.cpp
@@ -263,9 +263,45 @@ void verifyFusions(const std::shared_ptr<torch::jit::Graph> graph,
   }
 }
 
+void setIncludeLastOffsets(std::shared_ptr<torch::jit::Graph> graph) {
+  c10::IValue ivalTrue(true);
+  torch::jit::Value *constantTrue = graph->insertConstant(ivalTrue);
+  for (auto *node : graph->nodes()) {
+    if (node->kind() == at::Symbol::fromQualString("aten::embedding_bag") ||
+        node->kind() == at::Symbol::fromQualString(
+                            "fb::embedding_bag_byte_rowwise_offsets") ||
+        node->kind() == at::Symbol::fromQualString(
+                            "fb::embedding_bag_4bit_rowwise_offsets") ||
+        node->kind() == at::Symbol::fromQualString(
+                            "quantized::embedding_bag_byte_rowwise_offsets") ||
+        node->kind() == at::Symbol::fromQualString(
+                            "quantized::embedding_bag_4bit_rowwise_offsets")) {
+
+      // locate constant for include_last_offset
+      int positionIndex = node->inputs().size() - 1;
+      const auto val = node->input(positionIndex);
+      assert(torch::jit::toIValue(val).has_value());
+      const auto ivalIncludeLastOffset = *torch::jit::toIValue(val);
+
+      assert(ivalIncludeLastOffset.isBool());
+      if (!ivalIncludeLastOffset.toBool()) {
+        node->replaceInput(positionIndex, constantTrue);
+        LOG_FIRST_N(WARNING, 1)
+            << "Set include_last_offset to True for "
+            << node->kind().toQualString() << " and all other occurrences";
+      }
+    }
+  }
+}
+
 void glowCustomFuseImpl(std::shared_ptr<torch::jit::Graph> graph,
                         at::Symbol kind, const PyTorchLoaderSettings &settings,
                         IsSupportFunc fn) {
+  // Set include_last_offset all embedding_bag-like operators to be compatible
+  if (settings.setIncludeLastOffsets) {
+    setIncludeLastOffsets(graph);
+  }
+
   // Reason for node being blacklisted.
   enum class NodeBlacklistReason {
     Kind,
@@ -306,12 +342,12 @@ void glowCustomFuseImpl(std::shared_ptr<torch::jit::Graph> graph,
     if (blacklist.count(ptNode)) {
       switch (blacklist.at(ptNode)) {
       case NodeBlacklistReason::Kind:
-        LOG(INFO) << "Skipping " << ptNode->kind().toQualString()
-                  << " op because its kind is blacklisted";
+        VLOG(1) << "Skipping " << ptNode->kind().toQualString()
+                << " op because its kind is blacklisted";
         break;
       case NodeBlacklistReason::Index:
-        LOG(INFO) << "Skipping " << ptNode->kind().toQualString()
-                  << " op because it's outside of the fusion range";
+        VLOG(1) << "Skipping " << ptNode->kind().toQualString()
+                << " op because it's outside of the fusion range";
         break;
       }
       return false;

--- a/torch_glow/src/PyTorchCommon.cpp
+++ b/torch_glow/src/PyTorchCommon.cpp
@@ -52,6 +52,7 @@ DEFINE_bool(randomizeConstants, false, "See PyTorchLoaderSettings");
 DEFINE_bool(runShapeInference, false, "See PyTorchLoaderSettings");
 DEFINE_int32(fusionStartIndex, -1, "See PyTorchLoaderSettings");
 DEFINE_int32(fusionEndIndex, -1, "See PyTorchLoaderSettings");
+DEFINE_bool(setIncludeLastOffsets, true, "See PyTorchLoaderSettings");
 
 namespace glow {
 
@@ -230,6 +231,9 @@ void PyTorchLoaderSettings::initSettings() {
   backendName = FLAGS_torch_glow_backend;
   numDevices = FLAGS_torch_glow_num_devices;
   runShapeInference = FLAGS_runShapeInference;
+  fusionStartIndex = FLAGS_fusionStartIndex;
+  fusionEndIndex = FLAGS_fusionEndIndex;
+  setIncludeLastOffsets = FLAGS_setIncludeLastOffsets;
 
   if (!FLAGS_opBlacklist.empty()) {
     auto kindStrings = splitString(FLAGS_opBlacklist);
@@ -604,7 +608,7 @@ void glowAOTFusion(torch::jit::Module &model, const std::string &inputMetaStr) {
     // If the graph is already compiled previously, warmCache() will report
     // an error but it is fine with our execution. So here we extract the
     // error only.
-    ERR_TO_STRING(std::move(e));
+    LOG(ERROR) << ERR_TO_STRING(std::move(e));
   }
 }
 

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -154,6 +154,11 @@ public:
   /// Run Fusion flow within to_glow compile function
   /// TODO: move to GlowCompileSpec
   bool enableDebugFuser = false;
+
+  /// Whether to enforce module conversion to set include_last_offset for all
+  /// embedding-bag-like operators. This is default to true since it is
+  /// currently a requirement if we want to support partial inputs
+  bool setIncludeLastOffsets = true;
 };
 
 /// Given a PyTorch ScalarType \p ty, \returns a matching Glow ElemKind.


### PR DESCRIPTION
Summary: Force set ```include_end_offset``` to true in torchscript to ensure consistency between pytorch and glow execution. This is needed when we need to blacklist embedding bag ops such as ```aten::embedding_bag```. The conversion is performed by default, but can be turned off using ```setIncludeLastOffsets```. We also read the value for ```include_end_offset``` in PyTorchModelLoader with an additional assertion check.

Differential Revision: D22870420

