### PR TITLE
fix registerDummyOperator

### DIFF
--- a/torch_glow/src/FuseKnownPatterns.cpp
+++ b/torch_glow/src/FuseKnownPatterns.cpp
@@ -35,9 +35,11 @@ void registerDummyOperator(const char *opName) {
   torch::jit::RegisterOperators op({torch::jit::Operator(
       at::Symbol::fromQualString(opName),
       [](const torch::jit::Node *node) -> torch::jit::Operation {
-        LOG(FATAL) << "Operator \"" << (*node)
-                   << "\" has no implementation and is meant only as a "
-                      "placeholder while fusing ops to run with Glow";
+        return [node](torch::jit::Stack *stack) {
+          LOG(FATAL) << "Operator \"" << (*node)
+                     << "\" has no implementation and is meant only as a "
+                        "placeholder while fusing ops to run with Glow";
+        };
       },
       at::AliasAnalysisKind::PURE_FUNCTION)});
 }


### PR DESCRIPTION
Summary: The returned Operation should fatal when run since it's not implemented but instead registerDummyOperator was fataling when creting the Operation.

Differential Revision: D22908135

