### PR TITLE
Test the AOT Model with Shape Inference. Add Hash funcion to Shape Inference.

### DIFF
--- a/torch_glow/src/CachingGraphRunner.h
+++ b/torch_glow/src/CachingGraphRunner.h
@@ -75,6 +75,12 @@ class CachingGraphRunner {
   std::unordered_map<size_t, std::shared_ptr<PerGlowGraphInfo>>
       perGlowGraphInfoMap_;
 
+  /// Here we assume this is only one corresponding Glow function.
+  /// Mapping from hash of PyTorch inputs to PerGlowGraphShape for the Glow
+  /// function that will run inputs matching that hash.
+  std::unordered_map<size_t, std::vector<std::vector<int64_t>>>
+      perGlowGraphShapeMap_;
+
   /// In AOT flow, compile a single Glow function and use it for all input
   /// sizes. The PyTorch tensor inputs in this case should be smaller that the
   /// compiled inputs, and they'll be padded with zeros by Glow.
@@ -123,6 +129,16 @@ class CachingGraphRunner {
   Expected<std::shared_ptr<PerGlowGraphInfo>>
   loadImpl(torch::jit::Stack &stack, TraceContext *traceContext);
 
+  /// Given a PyTorch inputs \p inputs, this generates a hash from the input
+  /// shape and checks to see if the graph output shape with the given input
+  /// was loaded previously. If was loaded previously then its output shape
+  /// info is returned immediately. Otherwise this will run the shape inference
+  /// engine, push the generated the output shape into \p perGlowGraphShapeMap_,
+  /// and then \returns the output shape pointer.
+  Expected<std::vector<std::vector<int64_t>> *>
+  loadShape(const c10::ArrayRef<c10::IValue> &inputs,
+            TraceContext *traceContext);
+
   /// Given a PerGlowGraphInfo \p info for a subgraph that was previously
   /// loaded, this runs the Glow function that corresponds to that
   /// PerGlowGraphInfo in the shape of the inputs with the given \p stack with
@@ -136,6 +152,10 @@ class CachingGraphRunner {
 
   /// Given a \p stack of inputs, computes the hash for the inputs on the stack.
   size_t computeGraphHash(const c10::ArrayRef<c10::IValue> inputs) const;
+
+  /// Given a \p stack of inputs, computes the hash using the inputs shape on
+  /// the stack.
+  size_t hashTensorShape(const c10::ArrayRef<c10::IValue> &inputs) const;
 
   /// Store the settings that were used to create the JIT subgraph that this
   /// CachingGraphRunner owns.

--- a/torch_glow/src/ShapeInferenceEngine.cpp
+++ b/torch_glow/src/ShapeInferenceEngine.cpp
@@ -27,8 +27,14 @@ void ShapeInferenceEngine::getNodeInputShape(const torch::jit::Node *node,
   }
 }
 
-std::vector<std::vector<int64_t>> &ShapeInferenceEngine::getGraphOutputShape() {
+const std::vector<std::vector<int64_t>> &
+ShapeInferenceEngine::getGraphOutputShape() {
   return outputShape_;
+}
+
+const std::unordered_map<const torch::jit::Value *, VariableMeta> &
+ShapeInferenceEngine::getVariableMap() {
+  return shapeMap_;
 }
 
 Error ShapeInferenceEngine::shapeOnNode(const torch::jit::Node *node) {

--- a/torch_glow/src/ShapeInferenceEngine.h
+++ b/torch_glow/src/ShapeInferenceEngine.h
@@ -44,7 +44,12 @@ public:
                        const at::ArrayRef<torch::jit::IValue> &inputs);
 
   /// Get all VariableMeta for outputs of the given graph.
-  std::vector<std::vector<int64_t>> &getGraphOutputShape();
+  const std::vector<std::vector<int64_t>> &getGraphOutputShape();
+
+  /// Get the Variable Map which uses const torch::jit::Value * as a key,
+  /// VariableMeta as a value.
+  const std::unordered_map<const torch::jit::Value *, VariableMeta> &
+  getVariableMap();
 
   /// This run the shape inference engine for the given \p graph and \p inputs.
   /// \returns error of failure.


### PR DESCRIPTION
Summary: Check the correctness of AOT Model with Shape Inference. Add a map which using generated hash value as a key, output shape pointer as a value. If we already have a shape info for the graph output with the given inputs then use that; Else infer shape.

Reviewed By: qizzzh

Differential Revision: D22822054

