### PR TITLE
Reshape outer dims of quantized fc in torch_glow

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -1457,6 +1457,12 @@ Error PyTorchModelLoader::loadQuantizedLinear(const torch::jit::Node *ptNode) {
   ASSIGN_VALUE_OR_RETURN_ERR(
       input, getGlowNodeValueForValue(inputs[QuantizedLinearInputs::input]));
 
+  // Flatten outer dims if necessary
+  auto inputDims = input.dims();
+  if (inputDims.size() > 2) {
+    input = F_.createFlatten("flatten", input, inputDims.size() - 1);
+  }
+
   CHECK(qparamsMap_.count(inputs[QuantizedLinearInputs::packed_weights]));
   auto packed_params =
       qparamsMap_[inputs[QuantizedLinearInputs::packed_weights]]
@@ -1509,6 +1515,11 @@ Error PyTorchModelLoader::loadQuantizedLinear(const torch::jit::Node *ptNode) {
   bool isRowwiseQuantized = ptWeightTensor.is_quantized() &&
                             ptWeightTensor.qscheme() == at::kPerChannelAffine;
 
+  NodeValue output;
+  c10::ScalarType dtype;
+  RETURN_IF_ERR(
+      getCorrectTypeMapping(dtype, inputs[QuantizedLinearInputs::input]));
+
   if (isRowwiseQuantized) {
     // extract qparams from ptWeightTensor.
     // Notice since the memory of qparams may not be continous
@@ -1542,22 +1553,27 @@ Error PyTorchModelLoader::loadQuantizedLinear(const torch::jit::Node *ptNode) {
     auto wOffsets = F_.getParent()->createConstant(
         "channel_wised_offsets_of_qlinear", std::move(wOffsetsTensor));
     wOffsets->ensureIsOwned();
-    auto rowwise_fc = F_.createRowwiseQuantizedFullyConnected(
+    auto rowwiseFC = F_.createRowwiseQuantizedFullyConnected(
         "rowwise_quantized_fc", input, weightConstant, wScales, wOffsets, bias,
         outTy);
-    return addValueMapping(outputs[0], rowwise_fc->getResult());
+    output = rowwiseFC->getResult();
   } else {
     weight = rescaleUIntToInt(weight);
 
     weight = F_.createTranspose("weight_transpose", weight, {1, 0});
     auto fc =
         F_.createFullyConnected("quantized_fc", input, weight, bias, outTy);
-
-    c10::ScalarType dtype;
-    RETURN_IF_ERR(
-        getCorrectTypeMapping(dtype, inputs[QuantizedLinearInputs::input]));
-    return addValueMapping(outputs[0], fc->getResult(), dtype);
+    output = fc->getResult();
   }
+
+  // Restore original outer dims
+  if (inputDims.size() > 2) {
+    std::vector<dim_t> finalDims = inputDims.vec();
+    finalDims.back() = output.dims().back();
+    output = F_.createReshape("expand", output, finalDims);
+  }
+
+  return addValueMapping(outputs[0], output, dtype);
 }
 
 Error PyTorchModelLoader::loadQuantizedLinearUnpacked(
@@ -1570,6 +1586,12 @@ Error PyTorchModelLoader::loadQuantizedLinearUnpacked(
   ASSIGN_VALUE_OR_RETURN_ERR(
       input,
       getGlowNodeValueForValue(inputs[QuantizedUnpackedLinearInputs::input]));
+
+  // Flatten outer dims if necessary
+  auto inputDims = input.dims();
+  if (inputDims.size() > 2) {
+    input = F_.createFlatten("flatten", input, inputDims.size() - 1);
+  }
 
   glow::NodeValue weight;
   ASSIGN_VALUE_OR_RETURN_ERR(
@@ -1617,12 +1639,21 @@ Error PyTorchModelLoader::loadQuantizedLinearUnpacked(
 
   bias = F_.createQuantize("quantize_bias", bias, biasType);
 
-  auto fc = F_.createFullyConnected("quantized_fc", input, weight, bias, outTy);
+  auto output =
+      F_.createFullyConnected("quantized_fc", input, weight, bias, outTy)
+          ->getResult();
+
+  // Restore original outer dims
+  if (inputDims.size() > 2) {
+    std::vector<dim_t> finalDims = inputDims.vec();
+    finalDims.back() = output.dims().back();
+    output = F_.createReshape("expand", output, finalDims);
+  }
 
   c10::ScalarType dtype;
   RETURN_IF_ERR(getCorrectTypeMapping(
       dtype, inputs[QuantizedUnpackedLinearInputs::input]));
-  return addValueMapping(outputs[0], fc->getResult(), dtype);
+  return addValueMapping(outputs[0], output, dtype);
 }
 
 Error PyTorchModelLoader::loadGlowFusedLinear(const torch::jit::Node *ptNode) {

--- a/torch_glow/tests/nodes/quantized_linear_test.py
+++ b/torch_glow/tests/nodes/quantized_linear_test.py
@@ -24,8 +24,8 @@ class TestQuantizedLinear(unittest.TestCase):
         torch.quantization.convert(model, inplace=True)
 
         x = torch.tensor(range(5), dtype=torch.float)
-        x = torch.cat((x, x, x, x, x))
-        x = torch.reshape(x, [5, 5])
+        x = torch.cat((x, x, x, x, x, x))
+        x = torch.reshape(x, [3, 2, 5])
 
         jitVsGlow(
             model,
@@ -109,8 +109,8 @@ class TestQuantizedLinear(unittest.TestCase):
         linear.weight.data.random_(0, 100)
         linear.bias.data.random_(0, 10)
 
-        x = torch.tensor(range(30), dtype=torch.float)
-        x = torch.reshape(x, [5, 6])
+        x = torch.tensor(range(36), dtype=torch.float)
+        x = torch.reshape(x, [3, 2, 6])
 
         model = torch.quantization.QuantWrapper(linear)
         model.qconfig = torch.quantization.get_default_qconfig("fbgemm")


### PR DESCRIPTION
Summary: Outer dimensions of quantized.Linear need to be reshaped into a single dimension for Glow's FC op and then reshaped back to original size afterwards for compatibility with PyTorch

Differential Revision: D22963123

