### PR TITLE
Add ability to specify what Splats should be materialized into Constants

### DIFF
--- a/include/glow/Base/Traits.h
+++ b/include/glow/Base/Traits.h
@@ -114,7 +114,7 @@ public:
   const char *getKindName() const { return getKindName(kind_); }
 };
 
-using KindSet = llvm::SmallSet<Kinded::Kind, 4>;
+using KindSet = llvm::SmallSet<Kinded::Kind, 6>;
 
 /// Subclasses of this class represent an IR container, e.g. a function or a
 /// module.

--- a/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
+++ b/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
@@ -109,6 +109,11 @@ struct OptimizationOptions {
   /// If true, perform compile-time computation of constant operations.
   bool enableConstantFolding{true};
 
+  /// For all Splats in the Function being optimized, if they are used by any
+  /// Nodes listed in this set, then they will be materialized into Constants
+  /// during Constant Folding.
+  KindSet materializeSplatsUsedBySet;
+
   /// If true, before any Function optimization, all the Constants will be
   /// temporarily replaced by Placeholders, preventing the Constants from being
   /// modified during the normal optimization pipeline. The original Constants

--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -1327,6 +1327,15 @@ Expected<bool> NNPIBackend::transformPostLowering(
     const glow::runtime::DeviceInfo *devInfo) const {
   LOG_SCOPE(F->getLogContext(), "NNPIBackend::transformPostLowering");
 
+  // Signal to ConstantFolding to materialize those Splats which we require to
+  // be Constants when importing later on.
+  auto &kindSet = cctx.optimizationOpts.materializeSplatsUsedBySet;
+  kindSet.insert(Kinded::Kind::ConvolutionNodeKind);
+  kindSet.insert(Kinded::Kind::Convolution3DNodeKind);
+  kindSet.insert(Kinded::Kind::FullyConnectedNodeKind);
+  kindSet.insert(Kinded::Kind::RowwiseQuantizedFullyConnectedNodeKind);
+  kindSet.insert(Kinded::Kind::ChannelwiseQuantizedConvolutionNodeKind);
+
   if (glow::onnxifi::GlowDisableNNPITransforms) {
     return false;
   }


### PR DESCRIPTION
Summary: Some backend APIs e.g. NNPI require there to be Constants as inputs for specific ops instead of Splats. Add an ability to specify to ConstantFolding what Splats should be lowered based on what ops they're used by, via `materializeSplatsUsedBySet`. For NNPI, add to this set in `transformPostLowering()`, so that the constant folding pass after backend-specific optimizations lowers these Splats.

Reviewed By: yinghai

Differential Revision: D22796160

