### PR TITLE
Add use_glow_aot, and include ONNX again as a backend for onnxifiGlow

### DIFF
--- a/include/glow/Base/Traits.h
+++ b/include/glow/Base/Traits.h
@@ -114,7 +114,7 @@ public:
   const char *getKindName() const { return getKindName(kind_); }
 };
 
-using KindSet = llvm::SmallSet<Kinded::Kind, 4>;
+using KindSet = llvm::SmallSet<Kinded::Kind, 6>;
 
 /// Subclasses of this class represent an IR container, e.g. a function or a
 /// module.

--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -617,8 +617,9 @@ struct Type final {
       }
     }
 
-    // Compare the scale and offset of integers.
-    if (isQuantizedType()) {
+    // Compare the scale and offset of integers. Fused types use dummy
+    // scale/offset, so can ignore them.
+    if (isQuantizedType() && !isFusedQuantizedType()) {
       if (scale_ != other.scale_ || offset_ != other.offset_) {
         return false;
       }
@@ -708,6 +709,12 @@ struct Type final {
 
   /// \returns true if the type of this Tensor is one of the quantized types.
   bool isQuantizedType() const { return isQuantizedElemKind(elementType_); }
+
+  /// \returns true if the type of this Tensor is one of the fused quantized
+  /// types.
+  bool isFusedQuantizedType() const {
+    return isFusedQuantizedElemKind(elementType_);
+  }
 
   /// \returns true if the type of this Tensor is one of the floating point
   /// types.

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -1206,7 +1206,7 @@ public:
   /// use a specialized implementation.
   RowwiseQuantizedSparseLengthsWeightedSumNode *
   createRowwiseQuantizedSparseLengthsSum(
-      llvm::StringRef name, Storage *data, Constant *scales, Constant *offsets,
+      llvm::StringRef name, Storage *data, NodeValue scales, NodeValue offsets,
       NodeValue indices, NodeValue lengths,
       ElemKind precision = ElemKind::FloatTy, bool useFP16Accumulation = false,
       LengthsMode lengthsMode = LengthsMode::Variable, float avgLength = NAN);
@@ -1224,7 +1224,7 @@ public:
   /// multiplied by weights[i]. len(weights) must be equal to len(indices).
   RowwiseQuantizedSparseLengthsWeightedSumNode *
   createRowwiseQuantizedSparseLengthsWeightedSum(
-      llvm::StringRef name, Storage *data, Constant *scales, Constant *offsets,
+      llvm::StringRef name, Storage *data, NodeValue scales, NodeValue offsets,
       NodeValue weights, NodeValue indices, NodeValue lengths,
       ElemKind precision = ElemKind::FloatTy, bool useFP16Accumulation = false,
       LengthsMode lengthsMode = LengthsMode::Variable, float avgLength = NAN);

--- a/include/glow/Importer/ONNXIFIModelLoader.h
+++ b/include/glow/Importer/ONNXIFIModelLoader.h
@@ -67,11 +67,13 @@ public:
   /// then \p PPC will be filled with relevant configuration for partitioning,
   /// and all Functions created will be named with prefix /p netName. Otherwise
   /// \p PPC is ignored, and \p netName is used as the name of the single
-  /// Function that is created inside \p mod.
+  /// Function that is created inside \p mod. \p BSNI is filled with any info
+  /// loaded from the proto, relevant for custom ONNX Glow models only.
   static Expected<std::unique_ptr<ONNXIFIModelLoader>>
   parse(const void *onnxModel, uint32_t onnxModelSize, uint32_t weightsCount,
         const onnxTensorDescriptorV1 *weightDescriptors, Module &mod,
         llvm::StringRef netName, runtime::PrePartitionedConfig *PPC,
+        BackendSpecificNodeInfo *BSNI,
         bool loadInputsAsPlaceholdersForOnnx = true, bool use_onnx = true,
         bool constFoldInLoader = true);
 };

--- a/include/glow/Importer/ONNXModelLoader.h
+++ b/include/glow/Importer/ONNXModelLoader.h
@@ -466,7 +466,27 @@ protected:
   ONNXModelLoader(const void *model, uint32_t modelSize, uint32_t weightsCount,
                   const onnxTensorDescriptorV1 *weightDescriptors, Function &F,
                   bool loadInputsAsPlaceholdersForOnnx, Error *errPtr = nullptr,
-                  bool constFoldInLoader = true);
+                  bool constFoldInLoader = true,
+                  BackendSpecificNodeInfo *perNodeOpts = nullptr);
+
+  /// Creates a ONNX model loader to build \p mod.
+  /// Loads the ONNIXFI \p model from memory of \p modelSize size,
+  /// and \p weightsCount, and \p onnxTensorDescriptorV1 correspondent
+  /// descriptors. Converts inputs into placeholder if requested \p
+  /// loadInputsAsPlaceholdersForOnnx. Reports success/failure through optional
+  /// parameter \p errPtr. This constructor always overrides the default
+  /// constant folding in loader flag with \p constFoldInLoader.
+  /// Supports loading a DAG which was serialized, loading in DAGNode meta info
+  /// into \p PPC which can be later used to recreated the DAG. \p funName is
+  /// used to setup the DAG root node's name, or if the input model is not
+  /// partitioned then is used as the name of the single Function loaded. Loads
+  /// backend-specific node info annotations into \p perNodeOpts.
+  ONNXModelLoader(const void *model, uint32_t modelSize, uint32_t weightsCount,
+                  const onnxTensorDescriptorV1 *weightDescriptors, Module &mod,
+                  llvm::StringRef funName, runtime::PrePartitionedConfig *PPC,
+                  bool loadInputsAsPlaceholdersForOnnx, Error *errPtr = nullptr,
+                  bool constFoldInLoader = true,
+                  BackendSpecificNodeInfo *perNodeOpts = nullptr);
 
   friend class ONNXIFIModelLoader;
 

--- a/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
+++ b/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
@@ -109,6 +109,11 @@ struct OptimizationOptions {
   /// If true, perform compile-time computation of constant operations.
   bool enableConstantFolding{true};
 
+  /// For all Splats in the Function being optimized, if they are used by any
+  /// Nodes listed in this set, then they will be materialized into Constants
+  /// during Constant Folding.
+  KindSet materializeSplatsUsedBySet;
+
   /// If true, before any Function optimization, all the Constants will be
   /// temporarily replaced by Placeholders, preventing the Constants from being
   /// modified during the normal optimization pipeline. The original Constants

--- a/include/glow/Optimizer/GraphOptimizer/GraphOptimizer.h
+++ b/include/glow/Optimizer/GraphOptimizer/GraphOptimizer.h
@@ -148,12 +148,18 @@ class ConstantModificationPreventer : protected ScopeGuard {
   /// Module which contains Constants we want to prevent modification of.
   Module &mod_;
 
+  /// CompilationContext under which we're compiling.
+  CompilationContext &cctx_;
+
+  /// Original setting in \ref cctx_ for if constant folding was enabled.
+  bool origEnableConstantFolding_;
+
   /// Map from temporary Placeholders to the Constants they replaced.
   std::unordered_map<Placeholder *, Constant *> tmpPHToConstMap_;
 
 public:
   /// Ctor.
-  ConstantModificationPreventer(Module &mod);
+  ConstantModificationPreventer(Module &mod, CompilationContext &cctx);
 
   /// Make not copyable.
   ConstantModificationPreventer(const ConstantModificationPreventer &) = delete;

--- a/lib/Backends/CPU/tests/CPUOperatorTest.cpp
+++ b/lib/Backends/CPU/tests/CPUOperatorTest.cpp
@@ -273,6 +273,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "ConvertFrom_Int64ITy_To_FloatTy_AndBack/0",
     "ConvertFrom_Int64ITy_To_Float16Ty_AndBack/0",
     "ConvertFrom_Int64ITy_To_Int32ITy_AndBack/0",
+    "ConvertFusedToFusedFP16/0",
     "BasicDivNetFloatVsInt8/0",
     "BasicAddNetFloatVsBFloat16/0",
     "BasicAddNetFloatVsFloat16/0",

--- a/lib/Backends/Habana/tests/HabanaOperatorTest.cpp
+++ b/lib/Backends/Habana/tests/HabanaOperatorTest.cpp
@@ -119,6 +119,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "ConvertFrom_Int64ITy_To_Int32ITy_AndBack/0",
     "ConvertFrom_BoolTy_To_FloatTy/0",
     "ConvertFrom_BoolTy_To_Float16Ty/0",
+    "ConvertFusedToFusedFP16/0",
     "convTest/0",
     "convTest_Float16/0",
     "CumSum_Float/0",

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -5000,7 +5000,8 @@ void BoundInterpreterFunction::fwdConvertToInst(const glow::ConvertToInst *I) {
 
   if (srcElType == ElemKind::UInt8FusedQTy &&
       destElType == ElemKind::UInt8FusedFP16QTy) {
-    dest->convertToType(ElemKind::UInt8FusedFP16QTy);
+    Tensor result = source->getCopyConvertedToType(ElemKind::UInt8FusedFP16QTy);
+    dest->assign(&result);
     return;
   }
   llvm_unreachable("Type not supported");

--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -1327,6 +1327,15 @@ Expected<bool> NNPIBackend::transformPostLowering(
     const glow::runtime::DeviceInfo *devInfo) const {
   LOG_SCOPE(F->getLogContext(), "NNPIBackend::transformPostLowering");
 
+  // Signal to ConstantFolding to materialize those Splats which we require to
+  // be Constants when importing later on.
+  auto &kindSet = cctx.optimizationOpts.materializeSplatsUsedBySet;
+  kindSet.insert(Kinded::Kind::ConvolutionNodeKind);
+  kindSet.insert(Kinded::Kind::Convolution3DNodeKind);
+  kindSet.insert(Kinded::Kind::FullyConnectedNodeKind);
+  kindSet.insert(Kinded::Kind::RowwiseQuantizedFullyConnectedNodeKind);
+  kindSet.insert(Kinded::Kind::ChannelwiseQuantizedConvolutionNodeKind);
+
   if (glow::onnxifi::GlowDisableNNPITransforms) {
     return false;
   }

--- a/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
@@ -52,6 +52,7 @@ struct BlacklistInitializer {
              TestBlacklist::AnyDeviceAnyEngine},
             {"ConvertFrom_Int64ITy_To_Float16Ty_AndBack/0",
              TestBlacklist::AnyDeviceAnyEngine},
+            {"ConvertFusedToFusedFP16/0", TestBlacklist::AnyDeviceAnyEngine},
             {"ConvolutionDepth10_Int16_BiasInt16/0",
              TestBlacklist::AnyDeviceAnyEngine},
             {"ConvolutionDepth10_Int16_BiasInt32/0",

--- a/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
@@ -539,6 +539,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "ConvertFrom_Float16Ty_To_BFloat16Ty_AndBack/0",
     "concatVectorsRepeated_BFloat16/0",
     "ConvertFrom_BFloat16Ty_To_Float16Ty/0",
+    "ConvertFusedToFusedFP16/0",
     "sliceVectors_BFloat16/0",
     "BFloat16Splat/0",
     "GatherDataBFloat16IdxInt32/0",

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -2002,7 +2002,7 @@ SparseLengthsWeightedSumNode *Function::createSparseLengthsWeightedSum(
 
 RowwiseQuantizedSparseLengthsWeightedSumNode *
 Function::createRowwiseQuantizedSparseLengthsWeightedSum(
-    llvm::StringRef name, Storage *data, Constant *scales, Constant *offsets,
+    llvm::StringRef name, Storage *data, NodeValue scales, NodeValue offsets,
     NodeValue weights, NodeValue indices, NodeValue lengths, ElemKind precision,
     bool useFP16Accumulation, LengthsMode lengthsMode, float avgLength) {
   auto inDims = data->dims();
@@ -2016,7 +2016,7 @@ Function::createRowwiseQuantizedSparseLengthsWeightedSum(
 
 RowwiseQuantizedSparseLengthsWeightedSumNode *
 Function::createRowwiseQuantizedSparseLengthsSum(
-    llvm::StringRef name, Storage *data, Constant *scales, Constant *offsets,
+    llvm::StringRef name, Storage *data, NodeValue scales, NodeValue offsets,
     NodeValue indices, NodeValue lengths, ElemKind precision,
     bool useFP16Accumulation, LengthsMode lengthsMode, float avgLength) {
   auto ty = getParent()->uniqueType(precision, {indices.dims()[0]});
@@ -4904,8 +4904,13 @@ class FunctionDottyPrinter : public AbstractDottyPrinter {
 
 public:
   void visitGraph(Function *F) {
-    for (auto &N : F->getNodes()) {
-      visitNode(&N);
+    // Sort nodes before printing the dot so we can diff dot files.
+    std::set<Node *, SortNamed> sorted;
+    for (Node &N : F->getNodes()) {
+      sorted.insert(&N);
+    }
+    for (auto *N : sorted) {
+      visitNode(N);
     }
   }
 };
@@ -4919,15 +4924,21 @@ std::string Function::dumpDAG() {
 }
 
 void Function::dumpDAG(llvm::StringRef dotFilename) {
-  llvm::outs() << "Writing dotty graph for Function to: " << dotFilename
+  llvm::StringRef legalDotFilename = dotFilename.take_back(255);
+  llvm::outs() << "Writing dotty graph for Function to: " << legalDotFilename
                << '\n';
+  if (dotFilename.size() > 255) {
+    llvm::outs() << "WARNING: Filename " << dotFilename
+                 << " is longer than 255 characters, and so was truncated to "
+                 << legalDotFilename << '\n';
+  }
 
   FunctionDottyPrinter DP;
 
   DP.visitGraph(this);
 
   std::ofstream myfile;
-  myfile.open(dotFilename);
+  myfile.open(legalDotFilename);
   DP.dumpAll(myfile);
   myfile.close();
 }

--- a/lib/Importer/ONNXIFIModelLoader.cpp
+++ b/lib/Importer/ONNXIFIModelLoader.cpp
@@ -26,18 +26,17 @@ Expected<std::unique_ptr<ONNXIFIModelLoader>> ONNXIFIModelLoader::parse(
     const void *model, uint32_t modelSize, uint32_t weightsCount,
     const onnxTensorDescriptorV1 *weightDescriptors, Module &mod,
     llvm::StringRef netName, runtime::PrePartitionedConfig *PPC,
-    bool loadInputsAsPlaceholdersForOnnx, bool use_onnx,
-    bool constFoldInLoader) {
+    BackendSpecificNodeInfo *BSNI, bool loadInputsAsPlaceholdersForOnnx,
+    bool use_onnx, bool constFoldInLoader) {
 
   std::unique_ptr<ONNXIFIModelLoader> loader(new ONNXIFIModelLoader());
   Error loaderConstructionErr = Error::empty();
 
   if (use_onnx) {
-    Function *F = mod.createFunction(netName);
     std::unique_ptr<ONNXModelLoader> onnxLoader(
         new ONNXModelLoader(model, modelSize, weightsCount, weightDescriptors,
-                            *F, loadInputsAsPlaceholdersForOnnx,
-                            &loaderConstructionErr, constFoldInLoader));
+                            mod, netName, PPC, loadInputsAsPlaceholdersForOnnx,
+                            &loaderConstructionErr, constFoldInLoader, BSNI));
     if (loaderConstructionErr) {
       return std::move(loaderConstructionErr);
     }

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -91,8 +91,8 @@ onnxStatus Backend::checkGraphCompatibility(const void *onnxModel,
   auto loaderOrErr = ONNXIFIModelLoader::parse(
       onnxModel, onnxModelSize, 0 /*weightCount*/,
       nullptr /*weightDescriptors*/, module, compatibilityFunctionName,
-      /* PPC */ nullptr, false /*loadInputsAsPlaceholdersForOnnx*/,
-      getUseOnnx(),
+      /* PPC */ nullptr, /* BSNI */ nullptr,
+      false /*loadInputsAsPlaceholdersForOnnx*/, getUseOnnx(),
       /*constFoldInLoader*/ false);
   if (loaderOrErr) {
     loader = std::move(*loaderOrErr);

--- a/lib/Onnxifi/HostManagerOnnxifi.h
+++ b/lib/Onnxifi/HostManagerOnnxifi.h
@@ -36,8 +36,7 @@ public:
                   runtime::ResultCBTy callback, uint64_t priority = 0) override;
 
   onnxStatus addNetwork(std::unique_ptr<Module> module,
-                        void *deferredBlobReader,
-                        runtime::PrePartitionedConfig *PPC);
+                        void *deferredBlobReader, CompilationContext &cctx);
 
   onnxStatus removeNetwork(const Graph *graph) override;
 

--- a/lib/Onnxifi/InlineOnnxifi.cpp
+++ b/lib/Onnxifi/InlineOnnxifi.cpp
@@ -54,8 +54,8 @@ InlineGraph::initGraph(const void *onnxModel, size_t onnxModelSize,
   std::unique_ptr<ONNXIFIModelLoader> loader;
   auto loaderOrErr = ONNXIFIModelLoader::parse(
       onnxModel, onnxModelSize, weightCount, weightDescriptors, mod, "function",
-      /* PPC */ nullptr, true /*loadInputsAsPlaceholdersForOnnx*/,
-      backendPtr_->getUseOnnx());
+      /* PPC */ nullptr, /* BSNI */ nullptr,
+      true /*loadInputsAsPlaceholdersForOnnx*/, backendPtr_->getUseOnnx());
   if (loaderOrErr) {
     loader = std::move(*loaderOrErr);
   } else {

--- a/lib/Onnxifi/onnxifiGlow.cpp
+++ b/lib/Onnxifi/onnxifiGlow.cpp
@@ -94,7 +94,7 @@ GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxGetBackendIDs)(
                               /*useOnnx*/ false, /*forQuantization*/ true);
     backendIDs[0] = quantizationBackendC2;
   } else {
-    *numBackends = 1;
+    *numBackends = 2;
 
     auto backendName = GlowOnnxifiBackend;
 
@@ -117,10 +117,11 @@ GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxGetBackendIDs)(
     }
 
     LOG(INFO) << "ONNXIFI: Executing on " << backendName << " Glow backend";
-    auto *executionBackend = manager.createBackend(backendName,
-                                                   /*useOnnx*/ false);
 
-    backendIDs[0] = executionBackend;
+    backendIDs[0] = manager.createBackend(backendName,
+                                          /*useOnnx*/ false);
+    backendIDs[1] = manager.createBackend(backendName,
+                                          /*useOnnx*/ true);
   }
 
   return ONNXIFI_STATUS_SUCCESS;

--- a/lib/Optimizer/GraphOptimizer/ConstantFolding.cpp
+++ b/lib/Optimizer/GraphOptimizer/ConstantFolding.cpp
@@ -312,6 +312,7 @@ bool constantFoldNodeImpl(
   // Copy over the splats to materialize from the original cctx.
   cctx.optimizationOpts.materializeSplatsUsedBySet =
       origCctx.optimizationOpts.materializeSplatsUsedBySet;
+  assert(!ERR_TO_BOOL(cctx.verify()) && "cctx for const folding must be valid");
   return evaluateConstantOperation(backend, cctx, N, constResults, record);
 }
 
@@ -381,7 +382,7 @@ static bool constantFoldFun(Function *F, const CompilationContext &cctx,
     // Compute the constant value of the node.
     std::vector<Constant *> constResults;
     if (!constantFoldNodeImpl(*backend, N, constResults, record, cctx)) {
-      return false;
+      continue;
     }
     // Replace all results of the original operation by the computed
     // compile-time results of this operation.

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -93,10 +93,13 @@ void ConstantModificationPreventer::activate() {
   dismissed_ = false;
   // Prevent Constant modification by temporarily replacing them with PHs.
   for (Constant *C : mod_.getConstants()) {
+    // Note: These temp Placeholders are more like static Placeholders, but we
+    // don't want to set them as static here because optimizations may kick in
+    // to modify the type of the static Placeholder (see
+    // cctx.optimizationOpts.foldStaticPlaceholderConversions).
     Placeholder *tmpPH = mod_.createPlaceholder(
         C->getType(), C->getName().str() + "_SWAP_CONST_FOLD",
         /* isTrainable */ false, C->getLayout());
-    tmpPH->setStatic(true);
     tmpPHToConstMap_[tmpPH] = C;
     C->getOutput().replaceAllUsesOfWith(tmpPH->getOutput());
   }

--- a/lib/Quantization/Base/Base.cpp
+++ b/lib/Quantization/Base/Base.cpp
@@ -130,14 +130,14 @@ static void dequantizeTensorUtil(Tensor *dest, const Tensor &src) {
 }
 
 /// Helper for dequantizing UInt8FusedQTy \p src to \p dest.
-template <typename DeqElemTy>
+template <typename DeqElemTy, typename ScaleOffsetTy>
 static void dequantizeFusedRowwiseTensorUtil(Tensor &dest, const Tensor &src) {
   auto dims = dest.dims();
   auto srcH = src.getHandle<uint8_t>();
   auto destH = dest.getHandle<DeqElemTy>();
   for (dim_t i = 0, e = dims[0]; i < e; ++i) {
     float scale, offset;
-    std::tie(scale, offset) = srcH.getFusedScaleOffsetFromRow<float>(i);
+    std::tie(scale, offset) = srcH.getFusedScaleOffsetFromRow<ScaleOffsetTy>(i);
     for (dim_t j = 0, f = dims[1]; j < f; ++j) {
       destH.at({i, j}) =
           static_cast<DeqElemTy>(quantization::dequantizeWithFloatOffset(
@@ -151,18 +151,29 @@ Tensor dequantizeTensor(const Tensor &tensor, ElemKind floatKind) {
          "Non supported output floating point type");
   auto Ty = tensor.getType().getElementType();
 
-  if (Ty == ElemKind::UInt8FusedQTy) {
+  if (Ty == ElemKind::UInt8FusedQTy || Ty == ElemKind::UInt8FusedFP16QTy) {
+    const bool scaleOffsetFP16 = Ty == ElemKind::UInt8FusedFP16QTy;
+    const dim_t scaleOffsetSize =
+        scaleOffsetFP16 ? sizeof(float16_t) : sizeof(float);
     assert(tensor.dims().size() == 2 && "Fused tensors should be 2D");
-    assert(tensor.dims()[1] > 2 * sizeof(float) &&
+    assert(tensor.dims()[1] > 2 * scaleOffsetSize &&
            "Expected space for per-row scale/offset");
     Tensor tmp(floatKind, {tensor.dims()[0],
-                           tensor.dims()[1] - (dim_t)(2 * sizeof(float))});
+                           tensor.dims()[1] - (dim_t)(2 * scaleOffsetSize)});
     switch (floatKind) {
     case ElemKind::FloatTy:
-      dequantizeFusedRowwiseTensorUtil<float>(tmp, tensor);
+      if (scaleOffsetFP16) {
+        dequantizeFusedRowwiseTensorUtil<float, float16_t>(tmp, tensor);
+      } else {
+        dequantizeFusedRowwiseTensorUtil<float, float>(tmp, tensor);
+      }
       break;
     case ElemKind::Float16Ty:
-      dequantizeFusedRowwiseTensorUtil<float16_t>(tmp, tensor);
+      if (scaleOffsetFP16) {
+        dequantizeFusedRowwiseTensorUtil<float16_t, float16_t>(tmp, tensor);
+      } else {
+        dequantizeFusedRowwiseTensorUtil<float16_t, float>(tmp, tensor);
+      }
       break;
     default:
       llvm_unreachable("Cannot dequantize to the given type");

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -464,7 +464,7 @@ Error HostManager::addNetwork(std::unique_ptr<Module> module,
   // partitioned.
   if (cctx.serializeCompiledDAG) {
     std::string loc = nodeList.begin()->root->name + ".onnx";
-    LOG(INFO) << "Serializing DAG to " << loc;
+    LOG(INFO) << "Serializing final compiled DAG to " << loc;
     {
       Error writeErr = Error::empty();
       ONNXModelWriter onnxWR(loc, nodeList, 7, 9, &writeErr,
@@ -534,12 +534,14 @@ Error HostManager::addNetwork(std::unique_ptr<Module> module,
   {
     std::unique_lock<std::shared_timed_mutex> networkLock(networkLock_);
     for (auto &node : nodeList) {
+      LOG(INFO) << "Successfully compiled and provisioned " << node.root->name;
       auto &networkData = networks_[(node.root)->name];
       networkData.dag = std::move(node);
       networkData.module = sharedModule;
     }
     cleanupAddNetwork(names);
   }
+
   return Error::success();
 }
 

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -274,7 +274,7 @@ Error HostManager::addNetwork(std::unique_ptr<Module> module,
   /// If specified in the cctx, this will prevent Constants from being modified
   /// until the current scope ends or the preventer is dismissed. Does so by
   /// swapping in temporary Placeholders instead of Constants.
-  ConstantModificationPreventer constModPreventer(*module);
+  ConstantModificationPreventer constModPreventer(*module, cctx);
   if (cctx.optimizationOpts.delayAndRecordConstantModification) {
     constModPreventer.activate();
   }

--- a/lib/Runtime/Provisioner/Provisioner.cpp
+++ b/lib/Runtime/Provisioner/Provisioner.cpp
@@ -554,7 +554,8 @@ Error Provisioner::provision(DAGListTy &networks, Module &module,
   // If a deferredWeightLoader is provided, create a deferredWeightLoader and
   // load deferred weights.
   if (cctx.deferredWeightLoader) {
-    LOG(INFO) << "Loading deferred weights";
+    const size_t totalNumDeferredWeights = placeholderToDeviceManager.size();
+    LOG(INFO) << "Loading " << totalNumDeferredWeights << " deferred weights";
 
     auto startTime = std::chrono::steady_clock::now();
     auto loader = cctx.deferredWeightLoader;
@@ -566,8 +567,10 @@ Error Provisioner::provision(DAGListTy &networks, Module &module,
     }
     std::string weightName = loader->getName();
     // Load weights while there are weights to be loaded.
+    unsigned int weightCount = 0;
     while (weightName != "") {
-      LOG(INFO) << "Loading " << weightName;
+      LOG(INFO) << "Loading deferred weight (" << ++weightCount << " / "
+                << totalNumDeferredWeights << "): " << weightName;
       const auto PH = module.getPlaceholderByNameSlow(weightName);
       if (!PH) {
         cleanupProvision(localActiveNames, addedNetworks);

--- a/tests/unittests/GraphOptzTest.cpp
+++ b/tests/unittests/GraphOptzTest.cpp
@@ -5516,8 +5516,9 @@ TEST_F(GraphOptz, constantFoldPreventedNoop) {
   auto *add3 = F_->createAdd("add", const1, ph1);
   F_->createSave("save", add3);
 
-  ConstantModificationPreventer constModPreventer(mod_);
+  ConstantModificationPreventer constModPreventer(mod_, cctx_);
   constModPreventer.activate();
+  EXPECT_FALSE(cctx_.optimizationOpts.enableConstantFolding);
 
   // Check that both Constants are protected and no change is made to the
   // Function during optimization.
@@ -5530,6 +5531,7 @@ TEST_F(GraphOptz, constantFoldPreventedNoop) {
 
   // Now deactivate the constModPreventer and check we can const fold still.
   constModPreventer.deactivateAndCleanup();
+  EXPECT_TRUE(cctx_.optimizationOpts.enableConstantFolding);
   mod_.eraseFunction(optimizedF_);
   optimizedF_ = optimizeFunction(F_);
 

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -1009,7 +1009,7 @@ int main(int argc, char **argv) {
   BB.newInstr("ConvertTo")
       .addOperand("Result", OperandKind::Out)
       .addOperand("Input", OperandKind::In)
-      .autoVerify(VerifyKind::SameShape, {"Result", "Input"})
+      .autoVerify(VerifyKind::NoVerify)
       .autoIRGen();
 
   //===--------------------------------------------------------------------===//


### PR DESCRIPTION
Summary: Resurrect ONNX as a backend through onnxifiGlow (was killed as part of D16215878 (https://github.com/pytorch/glow/commit/abc6b8258610ad322a150f886dbcfdda4c0333a8)). Then look for the `use_glow_aot` argument in the Onnxifi op. If it's there and true, then we override whatever `backend_id` is set and use the ONNX backend.

Reviewed By: yinghai

Differential Revision: D22762123

