### PR TITLE
Retain C2 loader names and positions for ONNX model serialization

### DIFF
--- a/include/glow/Base/Traits.h
+++ b/include/glow/Base/Traits.h
@@ -114,7 +114,7 @@ public:
   const char *getKindName() const { return getKindName(kind_); }
 };
 
-using KindSet = llvm::SmallSet<Kinded::Kind, 4>;
+using KindSet = llvm::SmallSet<Kinded::Kind, 6>;
 
 /// Subclasses of this class represent an IR container, e.g. a function or a
 /// module.

--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -617,8 +617,9 @@ struct Type final {
       }
     }
 
-    // Compare the scale and offset of integers.
-    if (isQuantizedType()) {
+    // Compare the scale and offset of integers. Fused types use dummy
+    // scale/offset, so can ignore them.
+    if (isQuantizedType() && !isFusedQuantizedType()) {
       if (scale_ != other.scale_ || offset_ != other.offset_) {
         return false;
       }
@@ -708,6 +709,12 @@ struct Type final {
 
   /// \returns true if the type of this Tensor is one of the quantized types.
   bool isQuantizedType() const { return isQuantizedElemKind(elementType_); }
+
+  /// \returns true if the type of this Tensor is one of the fused quantized
+  /// types.
+  bool isFusedQuantizedType() const {
+    return isFusedQuantizedElemKind(elementType_);
+  }
 
   /// \returns true if the type of this Tensor is one of the floating point
   /// types.

--- a/include/glow/Exporter/ONNXModelWriter.h
+++ b/include/glow/Exporter/ONNXModelWriter.h
@@ -80,6 +80,9 @@ class ONNXModelWriter : public CommonOperatorWriter<ONNX_TRAITS> {
   const ConstantFoldingRecordMap &constFoldRecord_;
   /// Backend-specific node info to include in the exported model.
   const BackendSpecificNodeInfo &backendSpecificNodeInfo_;
+  /// Map from Placeholders in the Module to the symbolic name they were loaded
+  /// with from the input model. If not null, included in IO doc_string info.
+  const LoadedPlaceholderNameMap *loadedPHNames_;
   /// A dedicated list of initializers in case the tensors get too big and don't
   /// fit into the model.
   std::list<TensorType> initializers_;
@@ -87,9 +90,19 @@ class ONNXModelWriter : public CommonOperatorWriter<ONNX_TRAITS> {
   llvm::SmallSet<Function *, 6> functionsFromDAG_;
   /// Holds all constant folding Functions that have been processed.
   llvm::SmallSet<Function *, 6> processedConstFoldFunctions_;
-  /// Writes tensor shape from placeholder \p PH into protpbuf \p valueProto.
-  void tensorShapeFromPlaceholder(const Placeholder *PH,
-                                  ValueInfoType *valueProto);
+  /// Maps from all non-static input PHs to the generated proto. It's used to
+  /// buffer protos; later on written out in order based on \ref loadedPHNames_.
+  std::unordered_map<const Placeholder *, ValueInfoType> inputValueInfos_;
+  /// Maps from all output PHs to the generated proto. It's used to buffer
+  /// protos; later on written out in order based on \ref loadedPHNames_.
+  std::unordered_map<const Placeholder *, ValueInfoType> outputValueInfos_;
+
+  /// Creates and \returns a new ValueInfoType for \p PH based on \p isInput.
+  /// It's added either directy to \ref graphProto_, or to \ref inputValueInfos_
+  /// / \ref outputValueInfos_, depending on whether there's an order we need to
+  /// serialize the IO in (order comes from \ref loadedPHNames_ if non-null).
+  Expected<ValueInfoType *> createProtoForIO(const Placeholder *PH,
+                                             bool isInput);
   /// Writes all inputs and outputs with operator name \p opName from give Node
   /// \p node into protobuf \p proto.
   static Error writeAllWithNode(const std::string &opName, const Node *node,
@@ -211,7 +224,8 @@ public:
                       llvm::StringMap<std::string>(),
                   const ConstantFoldingRecordMap &constFoldRecord =
                       ConstantFoldingRecordMap(),
-                  const BackendSpecificNodeInfo &backendSpecificNodeInfo = {});
+                  const BackendSpecificNodeInfo &backendSpecificNodeInfo = {},
+                  const LoadedPlaceholderNameMap *loadedPHNames = nullptr);
 
 private:
   /// \returns error for the unexpected node kind.

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -1206,7 +1206,7 @@ public:
   /// use a specialized implementation.
   RowwiseQuantizedSparseLengthsWeightedSumNode *
   createRowwiseQuantizedSparseLengthsSum(
-      llvm::StringRef name, Storage *data, Constant *scales, Constant *offsets,
+      llvm::StringRef name, Storage *data, NodeValue scales, NodeValue offsets,
       NodeValue indices, NodeValue lengths,
       ElemKind precision = ElemKind::FloatTy, bool useFP16Accumulation = false,
       LengthsMode lengthsMode = LengthsMode::Variable, float avgLength = NAN);
@@ -1224,7 +1224,7 @@ public:
   /// multiplied by weights[i]. len(weights) must be equal to len(indices).
   RowwiseQuantizedSparseLengthsWeightedSumNode *
   createRowwiseQuantizedSparseLengthsWeightedSum(
-      llvm::StringRef name, Storage *data, Constant *scales, Constant *offsets,
+      llvm::StringRef name, Storage *data, NodeValue scales, NodeValue offsets,
       NodeValue weights, NodeValue indices, NodeValue lengths,
       ElemKind precision = ElemKind::FloatTy, bool useFP16Accumulation = false,
       LengthsMode lengthsMode = LengthsMode::Variable, float avgLength = NAN);

--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -363,6 +363,7 @@ constexpr char layoutSignifier[] = "layout";
 constexpr char staticSignifier[] = "offline";
 constexpr char trainableSignifier[] = "trainable";
 constexpr char elemKindSignifier[] = "elemKind";
+constexpr char loaderNameSignifier[] = "loaderName";
 constexpr char saveNameSignifier[] = "saveName";
 constexpr char qScaleSignifier[] = "qScale";
 constexpr char qOffsetSignifier[] = "qOffset";

--- a/include/glow/Importer/ONNXIFIModelLoader.h
+++ b/include/glow/Importer/ONNXIFIModelLoader.h
@@ -67,11 +67,13 @@ public:
   /// then \p PPC will be filled with relevant configuration for partitioning,
   /// and all Functions created will be named with prefix /p netName. Otherwise
   /// \p PPC is ignored, and \p netName is used as the name of the single
-  /// Function that is created inside \p mod.
+  /// Function that is created inside \p mod. \p BSNI is filled with any info
+  /// loaded from the proto, relevant for custom ONNX Glow models only.
   static Expected<std::unique_ptr<ONNXIFIModelLoader>>
   parse(const void *onnxModel, uint32_t onnxModelSize, uint32_t weightsCount,
         const onnxTensorDescriptorV1 *weightDescriptors, Module &mod,
         llvm::StringRef netName, runtime::PrePartitionedConfig *PPC,
+        BackendSpecificNodeInfo *BSNI,
         bool loadInputsAsPlaceholdersForOnnx = true, bool use_onnx = true,
         bool constFoldInLoader = true);
 };

--- a/include/glow/Importer/ONNXModelLoader.h
+++ b/include/glow/Importer/ONNXModelLoader.h
@@ -520,6 +520,10 @@ protected:
   /// Deletes the Functions in \ref constFoldFuns_ from \ref mod_.
   void deleteConstFoldFunctions();
 
+  /// Sets up positional IO into \ref positionalInputNames_ and
+  /// \ref positionalOutputNames_ from \p graph.
+  void setupPositionalIO(const ONNX_NAMESPACE::GraphProto &graph);
+
 public:
   /// \returns ONNX model ir_version;
   size_t getIrVersion() const { return irVersion_; };

--- a/include/glow/Importer/ONNXModelLoader.h
+++ b/include/glow/Importer/ONNXModelLoader.h
@@ -466,7 +466,27 @@ protected:
   ONNXModelLoader(const void *model, uint32_t modelSize, uint32_t weightsCount,
                   const onnxTensorDescriptorV1 *weightDescriptors, Function &F,
                   bool loadInputsAsPlaceholdersForOnnx, Error *errPtr = nullptr,
-                  bool constFoldInLoader = true);
+                  bool constFoldInLoader = true,
+                  BackendSpecificNodeInfo *perNodeOpts = nullptr);
+
+  /// Creates a ONNX model loader to build \p mod.
+  /// Loads the ONNIXFI \p model from memory of \p modelSize size,
+  /// and \p weightsCount, and \p onnxTensorDescriptorV1 correspondent
+  /// descriptors. Converts inputs into placeholder if requested \p
+  /// loadInputsAsPlaceholdersForOnnx. Reports success/failure through optional
+  /// parameter \p errPtr. This constructor always overrides the default
+  /// constant folding in loader flag with \p constFoldInLoader.
+  /// Supports loading a DAG which was serialized, loading in DAGNode meta info
+  /// into \p PPC which can be later used to recreated the DAG. \p funName is
+  /// used to setup the DAG root node's name, or if the input model is not
+  /// partitioned then is used as the name of the single Function loaded. Loads
+  /// backend-specific node info annotations into \p perNodeOpts.
+  ONNXModelLoader(const void *model, uint32_t modelSize, uint32_t weightsCount,
+                  const onnxTensorDescriptorV1 *weightDescriptors, Module &mod,
+                  llvm::StringRef funName, runtime::PrePartitionedConfig *PPC,
+                  bool loadInputsAsPlaceholdersForOnnx, Error *errPtr = nullptr,
+                  bool constFoldInLoader = true,
+                  BackendSpecificNodeInfo *perNodeOpts = nullptr);
 
   friend class ONNXIFIModelLoader;
 

--- a/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
+++ b/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
@@ -109,6 +109,11 @@ struct OptimizationOptions {
   /// If true, perform compile-time computation of constant operations.
   bool enableConstantFolding{true};
 
+  /// For all Splats in the Function being optimized, if they are used by any
+  /// Nodes listed in this set, then they will be materialized into Constants
+  /// during Constant Folding.
+  KindSet materializeSplatsUsedBySet;
+
   /// If true, before any Function optimization, all the Constants will be
   /// temporarily replaced by Placeholders, preventing the Constants from being
   /// modified during the normal optimization pipeline. The original Constants

--- a/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
+++ b/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
@@ -28,6 +28,12 @@ struct PrePartitionedConfig;
 class DeferredWeightLoader;
 } // namespace runtime
 
+/// Map from Placeholders to their original name and index in the proto that
+/// loaded them. Used to keep around info from when we import a proto to then
+/// exporting it later on.
+using LoadedPlaceholderNameMap =
+    std::unordered_map<const Placeholder *, std::pair<std::string, unsigned>>;
+
 /// Configuration for different precision modes.
 struct PrecisionConfiguration {
   /// Enum for what kind of transformation should be done for Quantization.
@@ -217,6 +223,10 @@ struct CompilationContext {
 
   /// Used during Quantization and Profiling.
   LoweredInfoMap *loweredInfoMap{nullptr};
+
+  /// Set up during model loading to map from Placeholders in the Module to the
+  /// symbolic name they were loaded with from the input model.
+  LoadedPlaceholderNameMap loadedPHNames;
 
   /// Select whether in Training or Inference mode.
   enum class CompilationMode {

--- a/include/glow/Optimizer/GraphOptimizer/GraphOptimizer.h
+++ b/include/glow/Optimizer/GraphOptimizer/GraphOptimizer.h
@@ -148,12 +148,18 @@ class ConstantModificationPreventer : protected ScopeGuard {
   /// Module which contains Constants we want to prevent modification of.
   Module &mod_;
 
+  /// CompilationContext under which we're compiling.
+  CompilationContext &cctx_;
+
+  /// Original setting in \ref cctx_ for if constant folding was enabled.
+  bool origEnableConstantFolding_;
+
   /// Map from temporary Placeholders to the Constants they replaced.
   std::unordered_map<Placeholder *, Constant *> tmpPHToConstMap_;
 
 public:
   /// Ctor.
-  ConstantModificationPreventer(Module &mod);
+  ConstantModificationPreventer(Module &mod, CompilationContext &cctx);
 
   /// Make not copyable.
   ConstantModificationPreventer(const ConstantModificationPreventer &) = delete;

--- a/lib/Backends/CPU/tests/CPUOperatorTest.cpp
+++ b/lib/Backends/CPU/tests/CPUOperatorTest.cpp
@@ -273,6 +273,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "ConvertFrom_Int64ITy_To_FloatTy_AndBack/0",
     "ConvertFrom_Int64ITy_To_Float16Ty_AndBack/0",
     "ConvertFrom_Int64ITy_To_Int32ITy_AndBack/0",
+    "ConvertFusedToFusedFP16/0",
     "BasicDivNetFloatVsInt8/0",
     "BasicAddNetFloatVsBFloat16/0",
     "BasicAddNetFloatVsFloat16/0",

--- a/lib/Backends/Habana/tests/HabanaOperatorTest.cpp
+++ b/lib/Backends/Habana/tests/HabanaOperatorTest.cpp
@@ -119,6 +119,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "ConvertFrom_Int64ITy_To_Int32ITy_AndBack/0",
     "ConvertFrom_BoolTy_To_FloatTy/0",
     "ConvertFrom_BoolTy_To_Float16Ty/0",
+    "ConvertFusedToFusedFP16/0",
     "convTest/0",
     "convTest_Float16/0",
     "CumSum_Float/0",

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -5000,7 +5000,8 @@ void BoundInterpreterFunction::fwdConvertToInst(const glow::ConvertToInst *I) {
 
   if (srcElType == ElemKind::UInt8FusedQTy &&
       destElType == ElemKind::UInt8FusedFP16QTy) {
-    dest->convertToType(ElemKind::UInt8FusedFP16QTy);
+    Tensor result = source->getCopyConvertedToType(ElemKind::UInt8FusedFP16QTy);
+    dest->assign(&result);
     return;
   }
   llvm_unreachable("Type not supported");

--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -1327,6 +1327,15 @@ Expected<bool> NNPIBackend::transformPostLowering(
     const glow::runtime::DeviceInfo *devInfo) const {
   LOG_SCOPE(F->getLogContext(), "NNPIBackend::transformPostLowering");
 
+  // Signal to ConstantFolding to materialize those Splats which we require to
+  // be Constants when importing later on.
+  auto &kindSet = cctx.optimizationOpts.materializeSplatsUsedBySet;
+  kindSet.insert(Kinded::Kind::ConvolutionNodeKind);
+  kindSet.insert(Kinded::Kind::Convolution3DNodeKind);
+  kindSet.insert(Kinded::Kind::FullyConnectedNodeKind);
+  kindSet.insert(Kinded::Kind::RowwiseQuantizedFullyConnectedNodeKind);
+  kindSet.insert(Kinded::Kind::ChannelwiseQuantizedConvolutionNodeKind);
+
   if (glow::onnxifi::GlowDisableNNPITransforms) {
     return false;
   }

--- a/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
@@ -52,6 +52,7 @@ struct BlacklistInitializer {
              TestBlacklist::AnyDeviceAnyEngine},
             {"ConvertFrom_Int64ITy_To_Float16Ty_AndBack/0",
              TestBlacklist::AnyDeviceAnyEngine},
+            {"ConvertFusedToFusedFP16/0", TestBlacklist::AnyDeviceAnyEngine},
             {"ConvolutionDepth10_Int16_BiasInt16/0",
              TestBlacklist::AnyDeviceAnyEngine},
             {"ConvolutionDepth10_Int16_BiasInt32/0",

--- a/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
@@ -539,6 +539,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "ConvertFrom_Float16Ty_To_BFloat16Ty_AndBack/0",
     "concatVectorsRepeated_BFloat16/0",
     "ConvertFrom_BFloat16Ty_To_Float16Ty/0",
+    "ConvertFusedToFusedFP16/0",
     "sliceVectors_BFloat16/0",
     "BFloat16Splat/0",
     "GatherDataBFloat16IdxInt32/0",

--- a/lib/Exporter/ONNXModelWriter.cpp
+++ b/lib/Exporter/ONNXModelWriter.cpp
@@ -704,8 +704,9 @@ Error ONNXModelWriter::writeFunction() {
         continue;
       }
       // Write global input, output only tensor shape.
-      auto *inputProto = graphProto_->add_input();
-      tensorShapeFromPlaceholder(PH, inputProto);
+      ONNX_NAMESPACE::ValueInfoProto *inputProto;
+      ASSIGN_VALUE_OR_RETURN_ERR(inputProto,
+                                 createProtoForIO(PH, /* isInput */ true));
     } else if (kind == Kinded::Kind::ConstantKind) {
       // Write global initializer, output tensor bytes.
       const auto *C = llvm::cast<Constant>(N);
@@ -781,8 +782,9 @@ Error ONNXModelWriter::writeFunction() {
         }
       }
 
-      auto *out = graphProto_->add_output();
-      tensorShapeFromPlaceholder(PH, out);
+      ONNX_NAMESPACE::ValueInfoProto *out;
+      ASSIGN_VALUE_OR_RETURN_ERR(out,
+                                 createProtoForIO(PH, /* isInput */ false));
 
       // Use the doc string to specify the name that should be used for the
       // SaveNode to ensure it's kept the same between export and import.
@@ -835,6 +837,46 @@ Error ONNXModelWriter::finalizeAndWriteProto(llvm::StringRef name) {
     }
   }
 
+  // If we have loadedPHNames_, then we buffered the non-static PH IO protobuf
+  // in inputValueInfos_ and outputValueInfos_. Now we write it all out in order
+  // according to indices provided in loadedPHNames_.
+  if (loadedPHNames_) {
+    RETURN_ERR_IF_NOT(
+        inputValueInfos_.size() + outputValueInfos_.size() ==
+            loadedPHNames_->size(),
+        strFormat("Number of buffered inputs and outputs %lu didn't match the "
+                  "number of loadedPHNames %lu",
+                  inputValueInfos_.size() + outputValueInfos_.size(),
+                  loadedPHNames_->size()));
+
+    // If we have the loaded PH names map, then we need to reorder the inputs
+    // and outputs to follow the same order as provided in the loadedPHNames_.
+    std::vector<const Placeholder *> orderedInputs(inputValueInfos_.size());
+    std::vector<const Placeholder *> orderedOutputs(outputValueInfos_.size());
+    for (const auto &pair : *loadedPHNames_) {
+      const Placeholder *PH = pair.first;
+      const unsigned orderIdx = pair.second.second;
+      if (inputValueInfos_.count(PH)) {
+        orderedInputs[orderIdx] = PH;
+      } else if (outputValueInfos_.count(PH)) {
+        orderedOutputs[orderIdx] = PH;
+      } else {
+        RETURN_ERR("PH must either be in inputs or outputs: " +
+                   PH->getName().str());
+      }
+    }
+
+    // Now have IO in order matching loadedPHNames_, so finally write them out.
+    for (const Placeholder *PH : orderedInputs) {
+      auto *inputProto = graphProto_->add_input();
+      inputProto->MergeFrom(inputValueInfos_[PH]);
+    }
+    for (const Placeholder *PH : orderedOutputs) {
+      auto *outputProto = graphProto_->add_output();
+      outputProto->MergeFrom(outputValueInfos_[PH]);
+    }
+  }
+
   if (zipMode_) {
     const bool compressed = false;
     ZipWriter zip(&ff_, name);
@@ -882,7 +924,8 @@ ONNXModelWriter::ONNXModelWriter(
       extraMetadataProps_(extraMetadataProps),
       useGlowCustomOps_(useGlowCustomOps), dagMode_(false),
       constFoldRecord_(constFoldRecord),
-      backendSpecificNodeInfo_(backendSpecificNodeInfo) {
+      backendSpecificNodeInfo_(backendSpecificNodeInfo),
+      loadedPHNames_(nullptr) {
   // If errPtr already contains an error then don't continue with constructor.
   if (errPtr && *errPtr) {
     return;
@@ -999,13 +1042,15 @@ ONNXModelWriter::ONNXModelWriter(
     bool includeConstantData,
     const llvm::StringMap<std::string> &extraMetadataProps,
     const ConstantFoldingRecordMap &constFoldRecord,
-    const BackendSpecificNodeInfo &backendSpecificNodeInfo)
+    const BackendSpecificNodeInfo &backendSpecificNodeInfo,
+    const LoadedPlaceholderNameMap *loadedPHNames)
     : CommonOperatorWriter(modelFilename, nullptr, errPtr),
       irVersion_(irVersion), opsetVersion_(opsetVersion), zipMode_(zipMode),
       textMode_(textMode), includeConstantData_(includeConstantData),
       extraMetadataProps_(extraMetadataProps), useGlowCustomOps_(true),
       dagMode_(true), constFoldRecord_(constFoldRecord),
-      backendSpecificNodeInfo_(backendSpecificNodeInfo) {
+      backendSpecificNodeInfo_(backendSpecificNodeInfo),
+      loadedPHNames_(loadedPHNames) {
   // If errPtr already contains an error then don't continue with constructor.
   if (errPtr && *errPtr) {
     return;
@@ -1122,8 +1167,19 @@ void ONNXModelWriter::writeTensor(const Tensor &T, TensorType *out,
   }
 }
 
-void ONNXModelWriter::tensorShapeFromPlaceholder(const Placeholder *PH,
-                                                 ValueInfoType *valueProto) {
+Expected<ONNX_NAMESPACE::ValueInfoProto *>
+ONNXModelWriter::createProtoForIO(const Placeholder *PH, bool isInput) {
+  // If loadedPHNames_ then we have a specific order we need to write out IO
+  // protos. If so, buffer non-static IO that is not part of a constant folding
+  // subgraph into inputValueInfos_/outputValueInfos_ to later be written out in
+  // order inside finalizeAndWriteProto() based on loadedPHNames_.
+  ONNX_NAMESPACE::ValueInfoProto *valueProto;
+  if (!loadedPHNames_ || isWritingConstFoldSubgraph() || PH->isStatic()) {
+    valueProto = isInput ? graphProto_->add_input() : graphProto_->add_output();
+  } else {
+    valueProto = isInput ? &inputValueInfos_[PH] : &outputValueInfos_[PH];
+  }
+
   tensorShapeFromInput(PH->getName(), PH->getType(), valueProto);
 
   if (useGlowCustomOps_) {
@@ -1136,11 +1192,29 @@ void ONNXModelWriter::tensorShapeFromPlaceholder(const Placeholder *PH,
     addAttrToDocString(valueProto, elemKindSignifier,
                        PH->getType()->getElementName());
 
+    // If we're writing out a Placeholder from the original input Function, then
+    // expect to find a corresponding input loaded PH name if they are
+    // provided. This is expected when the PH is not static (as otherwise it's
+    // input as a weight), when the Function being written isn't a constant
+    // folding subgraph (then we have PHs that are used just to save the const
+    // folding result), and when the PH isn't intermediate (then it's only
+    // visible/used by Glow when executing partitioned DAGs).
+    if (loadedPHNames_ && !PH->isStatic() && !isWritingConstFoldSubgraph() &&
+        !isIntermediatePHForDAG(PH)) {
+      auto it = loadedPHNames_->find(PH);
+      RETURN_ERR_IF_NOT(it != loadedPHNames_->end(),
+                        "Did not find associated loader name for " +
+                            PH->getName().str() + " while writing Function " +
+                            F_->getName().str());
+      addAttrToDocString(valueProto, loaderNameSignifier, it->second.first);
+    }
+
     // Also include quantization params if necessary.
     if (PH->getType()->isQuantizedType()) {
       addQuantParamsToDocString(valueProto, *PH->getType());
     }
   }
+  return valueProto;
 }
 
 Error ONNXModelWriter::writeAllWithNode(const std::string &opName,

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -2002,7 +2002,7 @@ SparseLengthsWeightedSumNode *Function::createSparseLengthsWeightedSum(
 
 RowwiseQuantizedSparseLengthsWeightedSumNode *
 Function::createRowwiseQuantizedSparseLengthsWeightedSum(
-    llvm::StringRef name, Storage *data, Constant *scales, Constant *offsets,
+    llvm::StringRef name, Storage *data, NodeValue scales, NodeValue offsets,
     NodeValue weights, NodeValue indices, NodeValue lengths, ElemKind precision,
     bool useFP16Accumulation, LengthsMode lengthsMode, float avgLength) {
   auto inDims = data->dims();
@@ -2016,7 +2016,7 @@ Function::createRowwiseQuantizedSparseLengthsWeightedSum(
 
 RowwiseQuantizedSparseLengthsWeightedSumNode *
 Function::createRowwiseQuantizedSparseLengthsSum(
-    llvm::StringRef name, Storage *data, Constant *scales, Constant *offsets,
+    llvm::StringRef name, Storage *data, NodeValue scales, NodeValue offsets,
     NodeValue indices, NodeValue lengths, ElemKind precision,
     bool useFP16Accumulation, LengthsMode lengthsMode, float avgLength) {
   auto ty = getParent()->uniqueType(precision, {indices.dims()[0]});
@@ -4904,8 +4904,13 @@ class FunctionDottyPrinter : public AbstractDottyPrinter {
 
 public:
   void visitGraph(Function *F) {
-    for (auto &N : F->getNodes()) {
-      visitNode(&N);
+    // Sort nodes before printing the dot so we can diff dot files.
+    std::set<Node *, SortNamed> sorted;
+    for (Node &N : F->getNodes()) {
+      sorted.insert(&N);
+    }
+    for (auto *N : sorted) {
+      visitNode(N);
     }
   }
 };
@@ -4919,15 +4924,21 @@ std::string Function::dumpDAG() {
 }
 
 void Function::dumpDAG(llvm::StringRef dotFilename) {
-  llvm::outs() << "Writing dotty graph for Function to: " << dotFilename
+  llvm::StringRef legalDotFilename = dotFilename.take_back(255);
+  llvm::outs() << "Writing dotty graph for Function to: " << legalDotFilename
                << '\n';
+  if (dotFilename.size() > 255) {
+    llvm::outs() << "WARNING: Filename " << dotFilename
+                 << " is longer than 255 characters, and so was truncated to "
+                 << legalDotFilename << '\n';
+  }
 
   FunctionDottyPrinter DP;
 
   DP.visitGraph(this);
 
   std::ofstream myfile;
-  myfile.open(dotFilename);
+  myfile.open(legalDotFilename);
   DP.dumpAll(myfile);
   myfile.close();
 }

--- a/lib/Importer/ONNXIFIModelLoader.cpp
+++ b/lib/Importer/ONNXIFIModelLoader.cpp
@@ -26,18 +26,17 @@ Expected<std::unique_ptr<ONNXIFIModelLoader>> ONNXIFIModelLoader::parse(
     const void *model, uint32_t modelSize, uint32_t weightsCount,
     const onnxTensorDescriptorV1 *weightDescriptors, Module &mod,
     llvm::StringRef netName, runtime::PrePartitionedConfig *PPC,
-    bool loadInputsAsPlaceholdersForOnnx, bool use_onnx,
-    bool constFoldInLoader) {
+    BackendSpecificNodeInfo *BSNI, bool loadInputsAsPlaceholdersForOnnx,
+    bool use_onnx, bool constFoldInLoader) {
 
   std::unique_ptr<ONNXIFIModelLoader> loader(new ONNXIFIModelLoader());
   Error loaderConstructionErr = Error::empty();
 
   if (use_onnx) {
-    Function *F = mod.createFunction(netName);
     std::unique_ptr<ONNXModelLoader> onnxLoader(
         new ONNXModelLoader(model, modelSize, weightsCount, weightDescriptors,
-                            *F, loadInputsAsPlaceholdersForOnnx,
-                            &loaderConstructionErr, constFoldInLoader));
+                            mod, netName, PPC, loadInputsAsPlaceholdersForOnnx,
+                            &loaderConstructionErr, constFoldInLoader, BSNI));
     if (loaderConstructionErr) {
       return std::move(loaderConstructionErr);
     }

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -769,12 +769,14 @@ Error ONNXModelLoader::loadInputs(ONNX_NAMESPACE::GraphProto &net,
       continue;
     }
 
+    const std::string &docString = in.doc_string();
+
     Type ty;
     ASSIGN_VALUE_OR_RETURN_ERR(ty, getTensorType(in));
     std::pair<bool, std::string> trainableLayoutPair;
-    ASSIGN_VALUE_OR_RETURN_ERR(trainableLayoutPair,
-                               getTrainableLayoutPairFromDocString(
-                                   in.doc_string(), useGlowCustomOps_));
+    ASSIGN_VALUE_OR_RETURN_ERR(
+        trainableLayoutPair,
+        getTrainableLayoutPairFromDocString(docString, useGlowCustomOps_));
 
     // If we already have the existing module then we may already have the input
     // Placeholder. If so, verify it has the correct type.
@@ -799,13 +801,20 @@ Error ONNXModelLoader::loadInputs(ONNX_NAMESPACE::GraphProto &net,
 
     // We must not have the input created yet, so do so.
     if (loadInputsAsPlaceholdersForOnnx) {
-      Placeholder *placeholder;
+      Placeholder *inPH;
       ASSIGN_VALUE_OR_RETURN_ERR(
-          placeholder,
-          createAndRegisterPlaceholder(
-              in.name(), mod_.uniqueType(ty), staticInputs_.count(in.name()),
-              trainableLayoutPair.first, trainableLayoutPair.second));
-      inputVarsByName_.try_emplace(in.name(), placeholder);
+          inPH, createAndRegisterPlaceholder(in.name(), mod_.uniqueType(ty),
+                                             staticInputs_.count(in.name()),
+                                             trainableLayoutPair.first,
+                                             trainableLayoutPair.second));
+      auto loaderNameOrErr =
+          getAttrFromDocString(loaderNameSignifier, docString);
+      const std::string &loaderName =
+          !ERR_TO_BOOL(loaderNameOrErr.takeError(), /* log */ false)
+              ? loaderNameOrErr.get()
+              : in.name();
+      RETURN_ERR_IF_NOT(inputVarsByName_.try_emplace(loaderName, inPH).second,
+                        "Already had input placeholder by name " + loaderName);
     } else {
       Tensor T(ty);
       RETURN_IF_ERR(createAndRegisterConstant(in.name(), std::move(T)));
@@ -4394,7 +4403,14 @@ Error ONNXModelLoader::setOutputNodes(ONNX_NAMESPACE::GraphProto &net) {
     }
     SaveNode *SN =
         G_->createSave(saveNodeName, r, savePH, hasSpecifiedSaveName);
-    outputVarsByName_[outputName] = SN->getPlaceholder();
+
+    auto loaderNameOrErr = getAttrFromDocString(loaderNameSignifier, docString);
+    const std::string &loaderName =
+        !ERR_TO_BOOL(loaderNameOrErr.takeError(), /* log */ false)
+            ? loaderNameOrErr.get()
+            : outputName;
+    RETURN_ERR_IF_NOT(outputVarsByName_.try_emplace(loaderName, savePH).second,
+                      "Already had output placeholder by name " + loaderName);
   }
 
   return Error::success();
@@ -4685,6 +4701,34 @@ Error ONNXModelLoader::setupPartitions(ONNX_NAMESPACE::ModelProto &modelDef,
   return Error::success();
 }
 
+void ONNXModelLoader::setupPositionalIO(
+    const ONNX_NAMESPACE::GraphProto &graph) {
+  for (const auto &in : graph.input()) {
+    if (staticInputs_.count(in.name())) {
+      continue;
+    }
+    auto loaderNameOrErr =
+        getAttrFromDocString(loaderNameSignifier, in.doc_string());
+    if (ERR_TO_BOOL(loaderNameOrErr.takeError(), /* log */ false)) {
+      positionalInputNames_.clear();
+      break;
+    }
+    const std::string &loaderName = loaderNameOrErr.get();
+    positionalInputNames_.emplace_back(loaderName);
+  }
+
+  for (const auto &out : graph.output()) {
+    auto loaderNameOrErr =
+        getAttrFromDocString(loaderNameSignifier, out.doc_string());
+    if (ERR_TO_BOOL(loaderNameOrErr.takeError(), /* log */ false)) {
+      positionalOutputNames_.clear();
+      break;
+    }
+    const std::string &loaderName = loaderNameOrErr.get();
+    positionalOutputNames_.emplace_back(loaderNameOrErr.get());
+  }
+}
+
 ONNXModelLoader::ONNXModelLoader(
     const std::string &modelDescFilename,
     llvm::ArrayRef<const char *> tensorNames, llvm::ArrayRef<TypeRef> types,
@@ -4804,11 +4848,8 @@ ONNXModelLoader::ONNXModelLoader(
     RETURN_IF_ERR(loadModel(modelDef, {}, {}, /* B */ nullptr,
                             loadInputsAsPlaceholdersForOnnx));
 
-    for (const auto &input : modelDef.graph().input()) {
-      positionalInputNames_.emplace_back(input.name());
-    }
-    for (const auto &output : modelDef.graph().output()) {
-      positionalOutputNames_.emplace_back(output.name());
+    if (loadInputsAsPlaceholdersForOnnx) {
+      setupPositionalIO(modelDef.graph());
     }
 
     return Error::success();

--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -91,8 +91,8 @@ onnxStatus Backend::checkGraphCompatibility(const void *onnxModel,
   auto loaderOrErr = ONNXIFIModelLoader::parse(
       onnxModel, onnxModelSize, 0 /*weightCount*/,
       nullptr /*weightDescriptors*/, module, compatibilityFunctionName,
-      /* PPC */ nullptr, false /*loadInputsAsPlaceholdersForOnnx*/,
-      getUseOnnx(),
+      /* PPC */ nullptr, /* BSNI */ nullptr,
+      false /*loadInputsAsPlaceholdersForOnnx*/, getUseOnnx(),
       /*constFoldInLoader*/ false);
   if (loaderOrErr) {
     loader = std::move(*loaderOrErr);

--- a/lib/Onnxifi/Base.h
+++ b/lib/Onnxifi/Base.h
@@ -190,7 +190,8 @@ protected:
   void setZeroLengthSequence(dim_t maxSeqLength);
 
   /// Bind input/output placeholders
-  void bindPlaceholders(const ONNXIFIModelLoader &loader);
+  bool bindPlaceholders(const ONNXIFIModelLoader &loader,
+                        LoadedPlaceholderNameMap *loadedPHNames = nullptr);
 
 private:
   /// inference dump counter

--- a/lib/Onnxifi/HostManagerOnnxifi.cpp
+++ b/lib/Onnxifi/HostManagerOnnxifi.cpp
@@ -313,7 +313,9 @@ HostManagerGraph::initGraph(const void *onnxModel, size_t onnxModelSize,
     return ONNXIFI_STATUS_INVALID_MODEL;
   }
 
-  bindPlaceholders(*loader);
+  if (!bindPlaceholders(*loader, &cctx.loadedPHNames)) {
+    return ONNXIFI_STATUS_INVALID_MODEL;
+  }
   setZeroLengthSequence(maxSeqLength);
   // Make sure the pool is ready to go.
   for (auto &obj : onnxInputToPlaceholder_) {

--- a/lib/Onnxifi/HostManagerOnnxifi.h
+++ b/lib/Onnxifi/HostManagerOnnxifi.h
@@ -36,8 +36,7 @@ public:
                   runtime::ResultCBTy callback, uint64_t priority = 0) override;
 
   onnxStatus addNetwork(std::unique_ptr<Module> module,
-                        void *deferredBlobReader,
-                        runtime::PrePartitionedConfig *PPC);
+                        void *deferredBlobReader, CompilationContext &cctx);
 
   onnxStatus removeNetwork(const Graph *graph) override;
 

--- a/lib/Onnxifi/InlineOnnxifi.cpp
+++ b/lib/Onnxifi/InlineOnnxifi.cpp
@@ -54,8 +54,8 @@ InlineGraph::initGraph(const void *onnxModel, size_t onnxModelSize,
   std::unique_ptr<ONNXIFIModelLoader> loader;
   auto loaderOrErr = ONNXIFIModelLoader::parse(
       onnxModel, onnxModelSize, weightCount, weightDescriptors, mod, "function",
-      /* PPC */ nullptr, true /*loadInputsAsPlaceholdersForOnnx*/,
-      backendPtr_->getUseOnnx());
+      /* PPC */ nullptr, /* BSNI */ nullptr,
+      true /*loadInputsAsPlaceholdersForOnnx*/, backendPtr_->getUseOnnx());
   if (loaderOrErr) {
     loader = std::move(*loaderOrErr);
   } else {

--- a/lib/Onnxifi/onnxifiGlow.cpp
+++ b/lib/Onnxifi/onnxifiGlow.cpp
@@ -94,7 +94,7 @@ GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxGetBackendIDs)(
                               /*useOnnx*/ false, /*forQuantization*/ true);
     backendIDs[0] = quantizationBackendC2;
   } else {
-    *numBackends = 1;
+    *numBackends = 2;
 
     auto backendName = GlowOnnxifiBackend;
 
@@ -117,10 +117,11 @@ GLOW_ONNXIFI_LIBRARY_FUNCTION_WRAPPER(onnxGetBackendIDs)(
     }
 
     LOG(INFO) << "ONNXIFI: Executing on " << backendName << " Glow backend";
-    auto *executionBackend = manager.createBackend(backendName,
-                                                   /*useOnnx*/ false);
 
-    backendIDs[0] = executionBackend;
+    backendIDs[0] = manager.createBackend(backendName,
+                                          /*useOnnx*/ false);
+    backendIDs[1] = manager.createBackend(backendName,
+                                          /*useOnnx*/ true);
   }
 
   return ONNXIFI_STATUS_SUCCESS;

--- a/lib/Optimizer/GraphOptimizer/ConstantFolding.cpp
+++ b/lib/Optimizer/GraphOptimizer/ConstantFolding.cpp
@@ -312,6 +312,7 @@ bool constantFoldNodeImpl(
   // Copy over the splats to materialize from the original cctx.
   cctx.optimizationOpts.materializeSplatsUsedBySet =
       origCctx.optimizationOpts.materializeSplatsUsedBySet;
+  assert(!ERR_TO_BOOL(cctx.verify()) && "cctx for const folding must be valid");
   return evaluateConstantOperation(backend, cctx, N, constResults, record);
 }
 
@@ -381,7 +382,7 @@ static bool constantFoldFun(Function *F, const CompilationContext &cctx,
     // Compute the constant value of the node.
     std::vector<Constant *> constResults;
     if (!constantFoldNodeImpl(*backend, N, constResults, record, cctx)) {
-      return false;
+      continue;
     }
     // Replace all results of the original operation by the computed
     // compile-time results of this operation.

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -93,10 +93,13 @@ void ConstantModificationPreventer::activate() {
   dismissed_ = false;
   // Prevent Constant modification by temporarily replacing them with PHs.
   for (Constant *C : mod_.getConstants()) {
+    // Note: These temp Placeholders are more like static Placeholders, but we
+    // don't want to set them as static here because optimizations may kick in
+    // to modify the type of the static Placeholder (see
+    // cctx.optimizationOpts.foldStaticPlaceholderConversions).
     Placeholder *tmpPH = mod_.createPlaceholder(
         C->getType(), C->getName().str() + "_SWAP_CONST_FOLD",
         /* isTrainable */ false, C->getLayout());
-    tmpPH->setStatic(true);
     tmpPHToConstMap_[tmpPH] = C;
     C->getOutput().replaceAllUsesOfWith(tmpPH->getOutput());
   }

--- a/lib/Quantization/Base/Base.cpp
+++ b/lib/Quantization/Base/Base.cpp
@@ -130,14 +130,14 @@ static void dequantizeTensorUtil(Tensor *dest, const Tensor &src) {
 }
 
 /// Helper for dequantizing UInt8FusedQTy \p src to \p dest.
-template <typename DeqElemTy>
+template <typename DeqElemTy, typename ScaleOffsetTy>
 static void dequantizeFusedRowwiseTensorUtil(Tensor &dest, const Tensor &src) {
   auto dims = dest.dims();
   auto srcH = src.getHandle<uint8_t>();
   auto destH = dest.getHandle<DeqElemTy>();
   for (dim_t i = 0, e = dims[0]; i < e; ++i) {
     float scale, offset;
-    std::tie(scale, offset) = srcH.getFusedScaleOffsetFromRow<float>(i);
+    std::tie(scale, offset) = srcH.getFusedScaleOffsetFromRow<ScaleOffsetTy>(i);
     for (dim_t j = 0, f = dims[1]; j < f; ++j) {
       destH.at({i, j}) =
           static_cast<DeqElemTy>(quantization::dequantizeWithFloatOffset(
@@ -151,18 +151,29 @@ Tensor dequantizeTensor(const Tensor &tensor, ElemKind floatKind) {
          "Non supported output floating point type");
   auto Ty = tensor.getType().getElementType();
 
-  if (Ty == ElemKind::UInt8FusedQTy) {
+  if (Ty == ElemKind::UInt8FusedQTy || Ty == ElemKind::UInt8FusedFP16QTy) {
+    const bool scaleOffsetFP16 = Ty == ElemKind::UInt8FusedFP16QTy;
+    const dim_t scaleOffsetSize =
+        scaleOffsetFP16 ? sizeof(float16_t) : sizeof(float);
     assert(tensor.dims().size() == 2 && "Fused tensors should be 2D");
-    assert(tensor.dims()[1] > 2 * sizeof(float) &&
+    assert(tensor.dims()[1] > 2 * scaleOffsetSize &&
            "Expected space for per-row scale/offset");
     Tensor tmp(floatKind, {tensor.dims()[0],
-                           tensor.dims()[1] - (dim_t)(2 * sizeof(float))});
+                           tensor.dims()[1] - (dim_t)(2 * scaleOffsetSize)});
     switch (floatKind) {
     case ElemKind::FloatTy:
-      dequantizeFusedRowwiseTensorUtil<float>(tmp, tensor);
+      if (scaleOffsetFP16) {
+        dequantizeFusedRowwiseTensorUtil<float, float16_t>(tmp, tensor);
+      } else {
+        dequantizeFusedRowwiseTensorUtil<float, float>(tmp, tensor);
+      }
       break;
     case ElemKind::Float16Ty:
-      dequantizeFusedRowwiseTensorUtil<float16_t>(tmp, tensor);
+      if (scaleOffsetFP16) {
+        dequantizeFusedRowwiseTensorUtil<float16_t, float16_t>(tmp, tensor);
+      } else {
+        dequantizeFusedRowwiseTensorUtil<float16_t, float>(tmp, tensor);
+      }
       break;
     default:
       llvm_unreachable("Cannot dequantize to the given type");

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -463,15 +463,16 @@ Error HostManager::addNetwork(std::unique_ptr<Module> module,
   // If requested, serialize the resulting DAG that was just optimized and
   // partitioned.
   if (cctx.serializeCompiledDAG) {
-    std::string loc = nodeList.begin()->root->name + ".onnx";
+    std::string loc = nodeList.begin()->root->name + ".onnxtxt";
     LOG(INFO) << "Serializing final compiled DAG to " << loc;
     {
       Error writeErr = Error::empty();
       ONNXModelWriter onnxWR(loc, nodeList, 7, 9, &writeErr,
-                             /* textMode */ false, /* zipMode */ false,
+                             /* textMode */ true, /* zipMode */ false,
                              /* includeConstantData */ false,
                              /* extraMetadataProps */ {}, record,
-                             cctx.backendOpts.backendSpecificNodeInfo);
+                             cctx.backendOpts.backendSpecificNodeInfo,
+                             &cctx.loadedPHNames);
       RETURN_IF_ERR(writeErr);
     }
   }

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -464,7 +464,7 @@ Error HostManager::addNetwork(std::unique_ptr<Module> module,
   // partitioned.
   if (cctx.serializeCompiledDAG) {
     std::string loc = nodeList.begin()->root->name + ".onnx";
-    LOG(INFO) << "Serializing DAG to " << loc;
+    LOG(INFO) << "Serializing final compiled DAG to " << loc;
     {
       Error writeErr = Error::empty();
       ONNXModelWriter onnxWR(loc, nodeList, 7, 9, &writeErr,
@@ -534,12 +534,14 @@ Error HostManager::addNetwork(std::unique_ptr<Module> module,
   {
     std::unique_lock<std::shared_timed_mutex> networkLock(networkLock_);
     for (auto &node : nodeList) {
+      LOG(INFO) << "Successfully compiled and provisioned " << node.root->name;
       auto &networkData = networks_[(node.root)->name];
       networkData.dag = std::move(node);
       networkData.module = sharedModule;
     }
     cleanupAddNetwork(names);
   }
+
   return Error::success();
 }
 

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -274,7 +274,7 @@ Error HostManager::addNetwork(std::unique_ptr<Module> module,
   /// If specified in the cctx, this will prevent Constants from being modified
   /// until the current scope ends or the preventer is dismissed. Does so by
   /// swapping in temporary Placeholders instead of Constants.
-  ConstantModificationPreventer constModPreventer(*module);
+  ConstantModificationPreventer constModPreventer(*module, cctx);
   if (cctx.optimizationOpts.delayAndRecordConstantModification) {
     constModPreventer.activate();
   }

--- a/lib/Runtime/Provisioner/Provisioner.cpp
+++ b/lib/Runtime/Provisioner/Provisioner.cpp
@@ -554,7 +554,8 @@ Error Provisioner::provision(DAGListTy &networks, Module &module,
   // If a deferredWeightLoader is provided, create a deferredWeightLoader and
   // load deferred weights.
   if (cctx.deferredWeightLoader) {
-    LOG(INFO) << "Loading deferred weights";
+    const size_t totalNumDeferredWeights = placeholderToDeviceManager.size();
+    LOG(INFO) << "Loading " << totalNumDeferredWeights << " deferred weights";
 
     auto startTime = std::chrono::steady_clock::now();
     auto loader = cctx.deferredWeightLoader;
@@ -566,8 +567,10 @@ Error Provisioner::provision(DAGListTy &networks, Module &module,
     }
     std::string weightName = loader->getName();
     // Load weights while there are weights to be loaded.
+    unsigned int weightCount = 0;
     while (weightName != "") {
-      LOG(INFO) << "Loading " << weightName;
+      LOG(INFO) << "Loading deferred weight (" << ++weightCount << " / "
+                << totalNumDeferredWeights << "): " << weightName;
       const auto PH = module.getPlaceholderByNameSlow(weightName);
       if (!PH) {
         cleanupProvision(localActiveNames, addedNetworks);

--- a/tests/unittests/Caffe2ImporterTest.cpp
+++ b/tests/unittests/Caffe2ImporterTest.cpp
@@ -143,8 +143,8 @@ TEST_F(Caffe2ImporterTest, importConvRelu) {
   }
 
   // High level check on the content of the graph. We should have
-  // transpose => conv => relu => transpose => save
-  EXPECT_EQ(F->getNodes().size(), 5);
+  // {transpose, transpose} => conv => relu => transpose => save
+  EXPECT_EQ(F->getNodes().size(), 6);
   auto *saveNode = getSaveNodeFromDest(output);
 
   auto *transNode1 =
@@ -158,6 +158,9 @@ TEST_F(Caffe2ImporterTest, importConvRelu) {
   auto *transNode2 =
       llvm::dyn_cast<TransposeNode>(convNode->getInput().getNode());
   ASSERT_TRUE(transNode2);
+  auto *transNode3 =
+      llvm::dyn_cast<TransposeNode>(convNode->getFilter().getNode());
+  ASSERT_TRUE(transNode3);
 
   auto res = bindings.get(output);
   EE.compile(CompilationMode::Infer);
@@ -198,12 +201,15 @@ TEST_F(Caffe2ImporterTest, convNHWC) {
     output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
   }
 
-  // High level check on the content of the graph. We have 1 conv and 1 save.
-  EXPECT_EQ(F->getNodes().size(), 2);
+  // High level check on the content of the graph. We have 1 conv, 1 transpose,
+  // and1 save.
+  EXPECT_EQ(F->getNodes().size(), 3);
   auto *saveNode = getSaveNodeFromDest(output);
   auto *convNode =
       llvm::dyn_cast<ConvolutionNode>(saveNode->getInput().getNode());
   ASSERT_TRUE(convNode);
+  auto *transposeNode = llvm::dyn_cast<TransposeNode>(convNode->getFilter());
+  ASSERT_TRUE(transposeNode);
 
   // We have 2 placeholders:  1 input and 1 output.
   EXPECT_EQ(mod.getPlaceholders().size(), 2);
@@ -420,12 +426,16 @@ TEST(caffe2, convTransposeNHWC) {
     output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
   }
 
-  // High level check on the content of the graph. We have 1 conv and 1 save.
-  EXPECT_EQ(F->getNodes().size(), 2);
+  // High level check on the content of the graph. We have 1 conv, 1 Transpose,
+  // and 1 save.
+  EXPECT_EQ(F->getNodes().size(), 3);
   auto *saveNode = getSaveNodeFromDest(output);
   auto *convTransposeNode =
       llvm::dyn_cast<ConvTransposeNode>(saveNode->getInput().getNode());
   ASSERT_TRUE(convTransposeNode);
+  auto *transposeNode =
+      llvm::dyn_cast<TransposeNode>(convTransposeNode->getFilter());
+  ASSERT_TRUE(transposeNode);
 
   // We have 2 placeholders:  1 input and 1 output.
   EXPECT_EQ(mod.getPlaceholders().size(), 2);
@@ -920,23 +930,26 @@ TEST_F(Caffe2ImporterTest, FC) {
     updateInputPlaceholdersByName(bindings, &mod, {"inputs"}, {&inputs});
   }
 
-  // High level check on the content of the graph. We have 1 FC node and 1 save.
-  EXPECT_EQ(F->getNodes().size(), 2);
+  // High level check on the content of the graph. We have 1 FC node,
+  // 1 transpose, and 1 save.
+  EXPECT_EQ(F->getNodes().size(), 3);
   auto *saveNode = getSaveNodeFromDest(output);
   auto *fcNode =
       llvm::dyn_cast<FullyConnectedNode>(saveNode->getInput().getNode());
-  EXPECT_TRUE(fcNode);
+  ASSERT_TRUE(fcNode);
+  auto *transposeNode = llvm::dyn_cast<TransposeNode>(fcNode->getWeights());
+  ASSERT_TRUE(transposeNode);
 
   // Check the numerical values of the weights and biases.
   {
-    // NOTE: this is weights1 because the weights constant was transposed
-    const Constant *constant = mod.getConstantByName("weights__1");
+    const Constant *constant =
+        llvm::dyn_cast<Constant>(transposeNode->getInput());
     ASSERT_TRUE(constant);
     const Tensor &weights = constant->getPayload();
-    const std::vector<dim_t> expectedDimensions = {3, 4};
-    const std::vector<float> expectedValues = {1.0f, 4.0f, 7.0f, 10.0f, //
-                                               2.0f, 5.0f, 8.0f, 11.0f, //
-                                               3.0f, 6.0f, 9.0f, 12.0f};
+    const std::vector<dim_t> expectedDimensions = {4, 3};
+    const std::vector<float> expectedValues = {1.0f, 2.0f,  3.0f,  4.0f,
+                                               5.0f, 6.0f,  7.0f,  8.0f,
+                                               9.0f, 10.0f, 11.0f, 12.0f};
     EXPECT_EQ(expectedDimensions, weights.dims().vec());
     ASSERT_EQ(expectedValues.size(), weights.size());
     const auto elements = weights.getHandle();
@@ -990,9 +1003,9 @@ TEST_F(Caffe2ImporterTest, FCWithFlatten) {
     updateInputPlaceholdersByName(bindings, &mod, {"inputs"}, {&inputs});
   }
 
-  // High level check on the content of the graph. We have a reshape, an FC,
-  // another reshape, and a save.
-  EXPECT_EQ(F->getNodes().size(), 4);
+  // High level check on the content of the graph. We have a reshape, Transpose
+  // for FC weights, an FC, another reshape, and a save.
+  EXPECT_EQ(F->getNodes().size(), 5);
 
   auto finalShape = output->getType()->dims();
   std::vector<dim_t> expectedOutput{1, 1, 1, 9190};
@@ -1007,6 +1020,8 @@ TEST_F(Caffe2ImporterTest, FCWithFlatten) {
   ASSERT_TRUE(fcNode);
   auto *reshape = llvm::dyn_cast<ReshapeNode>(fcNode->getInput());
   ASSERT_TRUE(reshape);
+  auto *transpose = llvm::dyn_cast<TransposeNode>(fcNode->getWeights());
+  ASSERT_TRUE(transpose);
 
   // We don't actually check that the output is correct, because this is
   // already covered in the Operator.FCWithFlatten/* tests.
@@ -2387,8 +2402,9 @@ TEST_F(Caffe2ImporterTest, SparseLengthsWeightedSum8BitsRowwise) {
   };
 
   // High level check on the content of the graph. We have 1 rowwise-quantized
-  // SLWS and 1 save.
-  EXPECT_EQ(F->getNodes().size(), 2);
+  // SLWS and 1 save, along with 2 Slices and 2 Reshapes to extract out
+  // scales/biases from the loaded Constant.
+  EXPECT_EQ(F->getNodes().size(), 6);
   SaveNode *saveNode = getSaveNodeFromDest(output);
   RowwiseQuantizedSparseLengthsWeightedSumNode *RWQSLWS =
       llvm::dyn_cast<RowwiseQuantizedSparseLengthsWeightedSumNode>(
@@ -2398,18 +2414,35 @@ TEST_F(Caffe2ImporterTest, SparseLengthsWeightedSum8BitsRowwise) {
   Constant *weights = llvm::dyn_cast<Constant>(RWQSLWS->getWeights().getNode());
   ASSERT_TRUE(weights);
 
+  // Check that we have a Reshape(Slice(Constant)) for Scales/Offsets.
+  ReshapeNode *reshapeScales =
+      llvm::dyn_cast<ReshapeNode>(RWQSLWS->getScales());
+  ASSERT_TRUE(reshapeScales);
+  SliceNode *sliceScales = llvm::dyn_cast<SliceNode>(reshapeScales->getInput());
+  ASSERT_TRUE(sliceScales);
+  ReshapeNode *reshapeOffsets =
+      llvm::dyn_cast<ReshapeNode>(RWQSLWS->getOffsets());
+  ASSERT_TRUE(reshapeOffsets);
+  SliceNode *sliceOffsets =
+      llvm::dyn_cast<SliceNode>(reshapeOffsets->getInput());
+  ASSERT_TRUE(sliceOffsets);
+  EXPECT_EQ(sliceScales->getInput(), sliceOffsets->getInput());
+  EXPECT_TRUE(llvm::isa<Constant>(sliceScales->getInput()));
+
   // We have 3 placeholders: 1 for save, and then indices and lengths.
   EXPECT_EQ(mod.getPlaceholders().size(), 3);
 
-  // We have 4 constants: data, scales, offsets, and weights. Originally fused
+  // We have 3 constants: data, scales+offsets, and weights. Originally fused
   // data is no longer used and is removed by loader.
-  EXPECT_EQ(mod.getConstants().size(), 4);
+  EXPECT_EQ(mod.getConstants().size(), 3);
 
   EE.compile(CompilationMode::Infer);
   bindings.allocate(mod.getPlaceholders());
 
-  // Post compile, DCE should have gotten rid of the originally fused data
-  // Constant, as it is no longer used.
+  // Post compile, should have folded the Slice and Reshape into the
+  // Scales/Biases. Also, DCE should have gotten rid of the originally fused
+  // data Constant, as it is no longer used.
+  EXPECT_EQ(F->getNodes().size(), 2);
   EXPECT_EQ(mod.getConstants().size(), 4);
 
   EE.run(bindings);
@@ -2489,8 +2522,10 @@ TEST_F(Caffe2ImporterTest, SparseLengthsSum8BitsRowwise) {
   };
 
   // High level check on the content of the graph. We have 1 rowwise-quantized
-  // SLWS (which implements SLS), 1 Splat for the weights, and 1 save.
-  EXPECT_EQ(F->getNodes().size(), 3);
+  // SLWS (which implements SLS), 1 Splat for the weights, and 1 save. For SLS
+  // scales/bias, we have 2 Slices and 2 Reshapes to extract out scales/biases
+  // from the loaded Constant.
+  EXPECT_EQ(F->getNodes().size(), 7);
   SaveNode *saveNode = getSaveNodeFromDest(output);
   RowwiseQuantizedSparseLengthsWeightedSumNode *RWQSLS =
       llvm::dyn_cast<RowwiseQuantizedSparseLengthsWeightedSumNode>(
@@ -2501,12 +2536,25 @@ TEST_F(Caffe2ImporterTest, SparseLengthsSum8BitsRowwise) {
   ASSERT_TRUE(splatNode);
   EXPECT_EQ(splatNode->getValue(), 1.0f);
 
+  // Check that we have a Reshape(Slice(Constant)) for Scales/Offsets.
+  ReshapeNode *reshapeScales = llvm::dyn_cast<ReshapeNode>(RWQSLS->getScales());
+  ASSERT_TRUE(reshapeScales);
+  SliceNode *sliceScales = llvm::dyn_cast<SliceNode>(reshapeScales->getInput());
+  ASSERT_TRUE(sliceScales);
+  ReshapeNode *reshapeOffsets =
+      llvm::dyn_cast<ReshapeNode>(RWQSLS->getOffsets());
+  ASSERT_TRUE(reshapeOffsets);
+  SliceNode *sliceOffsets =
+      llvm::dyn_cast<SliceNode>(reshapeOffsets->getInput());
+  ASSERT_TRUE(sliceOffsets);
+  EXPECT_EQ(sliceScales->getInput(), sliceOffsets->getInput());
+  EXPECT_TRUE(llvm::isa<Constant>(sliceScales->getInput()));
+
   // We have 3 placeholders: 1 for save, and then indices and lengths.
   EXPECT_EQ(mod.getPlaceholders().size(), 3);
 
-  // We have 5 constants: Data, scales, and offsets. Originally fused data is no
-  // longer used and is removed by loader.
-  EXPECT_EQ(mod.getConstants().size(), 3);
+  // We have 2 constants: Data and fused scales+offsets.
+  EXPECT_EQ(mod.getConstants().size(), 2);
 
   EE.compile(CompilationMode::Infer);
   bindings.allocate(mod.getPlaceholders());
@@ -2966,8 +3014,8 @@ TEST_F(Caffe2ImporterTest, importInt8ConvRelu) {
   }
 
   // High level check on the content of the graph. We should have
-  // transpose => conv => relu => transpose => save
-  EXPECT_EQ(F->getNodes().size(), 5);
+  // {transpose, transpose} => conv => relu => transpose => save
+  EXPECT_EQ(F->getNodes().size(), 6);
   auto *saveNode = getSaveNodeFromDest(output);
 
   auto *transNode1 =
@@ -2980,6 +3028,9 @@ TEST_F(Caffe2ImporterTest, importInt8ConvRelu) {
   ASSERT_TRUE(convNode);
   auto *transNode2 =
       llvm::dyn_cast<TransposeNode>(convNode->getInput().getNode());
+  ASSERT_TRUE(transNode2);
+  auto *transNode3 =
+      llvm::dyn_cast<TransposeNode>(convNode->getFilter().getNode());
   ASSERT_TRUE(transNode2);
 
   EE.compile(CompilationMode::Infer);

--- a/tests/unittests/GraphOptzTest.cpp
+++ b/tests/unittests/GraphOptzTest.cpp
@@ -5516,8 +5516,9 @@ TEST_F(GraphOptz, constantFoldPreventedNoop) {
   auto *add3 = F_->createAdd("add", const1, ph1);
   F_->createSave("save", add3);
 
-  ConstantModificationPreventer constModPreventer(mod_);
+  ConstantModificationPreventer constModPreventer(mod_, cctx_);
   constModPreventer.activate();
+  EXPECT_FALSE(cctx_.optimizationOpts.enableConstantFolding);
 
   // Check that both Constants are protected and no change is made to the
   // Function during optimization.
@@ -5530,6 +5531,7 @@ TEST_F(GraphOptz, constantFoldPreventedNoop) {
 
   // Now deactivate the constModPreventer and check we can const fold still.
   constModPreventer.deactivateAndCleanup();
+  EXPECT_TRUE(cctx_.optimizationOpts.enableConstantFolding);
   mod_.eraseFunction(optimizedF_);
   optimizedF_ = optimizeFunction(F_);
 

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -1009,7 +1009,7 @@ int main(int argc, char **argv) {
   BB.newInstr("ConvertTo")
       .addOperand("Result", OperandKind::Out)
       .addOperand("Input", OperandKind::In)
-      .autoVerify(VerifyKind::SameShape, {"Result", "Input"})
+      .autoVerify(VerifyKind::NoVerify)
       .autoIRGen();
 
   //===--------------------------------------------------------------------===//


### PR DESCRIPTION
Summary:
When loading through ONNXIFI, names of IO and the order of how they are provided is used for running the model. We need to retain these.

In order to do so, this diff adds `LoadedPlaceholderNameMap`, which is used during C2 proto loading to map from Placeholders to the name and position they were loaded in. This is then passed down into DAG serialization, where we use it (A) to store the names in the IO docstrings, and (B) to write out the IO in the same order as it was read through `onnxTensorDescriptorV1` during loading.

Reviewed By: yinghai

Differential Revision: D22890339

