### PR TITLE
Fix bug where we change quantization parameters invalidly

### DIFF
--- a/lib/Onnxifi/Flags.cpp
+++ b/lib/Onnxifi/Flags.cpp
@@ -46,6 +46,7 @@ extern bool GlowSparseNNPartitioningAddSLSConcats;
 extern bool GlowSparseNNPartitioningBalancePerfModel;
 extern bool GlowSparseNNPartitioningPairLNWithSLS;
 extern bool GlowDumpGraph;
+extern bool GlowDumpInitialLoadedGraph;
 extern bool GlowUseDAGOptimizer;
 extern std::string GlowDAGOptimizerPlacementTaggingAlgorithm;
 extern std::string GlowDAGOptimizerParallelizationTaggingAlgorithm;
@@ -368,6 +369,14 @@ DEFINE_validator(glow_dump_graph, [](const char * /* unused */, bool value) {
   glow::onnxifi::GlowDumpGraph = value;
   return true;
 });
+
+DEFINE_bool(glow_dump_initial_loaded_graph, false,
+            "Dump the glow Graph right after onnxification");
+DEFINE_validator(glow_dump_initial_loaded_graph,
+                 [](const char * /* unused */, bool value) {
+                   glow::onnxifi::GlowDumpInitialLoadedGraph = value;
+                   return true;
+                 });
 
 DEFINE_bool(glow_use_dag_optimizer, false, "Whether to call the DAG optimizer");
 DEFINE_validator(glow_use_dag_optimizer,

--- a/lib/Onnxifi/HostManagerOnnxifi.cpp
+++ b/lib/Onnxifi/HostManagerOnnxifi.cpp
@@ -40,6 +40,7 @@ bool GlowFP16Placeholders = true;
 bool GlowFP16Constants = true;
 bool GlowEnableQuantParamChanges = true;
 bool GlowDumpGraph = false;
+bool GlowDumpInitialLoadedGraph = false;
 bool GlowUseDAGOptimizer = false;
 std::string GlowDAGOptimizerPlacementTaggingAlgorithm = "None";
 std::string GlowDAGOptimizerParallelizationTaggingAlgorithm = "None";
@@ -329,6 +330,14 @@ HostManagerGraph::initGraph(const void *onnxModel, size_t onnxModelSize,
   if (GlowSaveOnnxifiModel) {
     for (Function *F : module->getFunctions()) {
       saveOnnxifiModel(F);
+    }
+  }
+
+  if (GlowDumpInitialLoadedGraph) {
+    for (Function *F : module->getFunctions()) {
+      auto fname = strFormat("initial_graph__%s.dot", F->getName().data());
+      LOG(INFO) << "Dumping initially loaded graph to " << fname;
+      F->dumpDAG(fname);
     }
   }
 

--- a/tests/unittests/Repro.cpp
+++ b/tests/unittests/Repro.cpp
@@ -155,6 +155,11 @@ llvm::cl::opt<bool>
                          llvm::cl::Optional, llvm::cl::init(true),
                          llvm::cl::cat(reproTestCat));
 
+llvm::cl::opt<bool> enableQuantParamChangesOpt(
+    "glow_enable_quant_param_changes",
+    llvm::cl::desc("Enable quantization param changes during optimizations"),
+    llvm::cl::Optional, llvm::cl::init(true), llvm::cl::cat(reproTestCat));
+
 llvm::cl::opt<bool> enablePartialTensor("glow_enable_partial_tensor",
                                         llvm::cl::desc("Enable partial tensor"),
                                         llvm::cl::Optional,
@@ -561,6 +566,10 @@ int run() {
   if (forceFP16AccumSLSOpt) {
     precConfig.forceFP16AccumSLS = true;
     llvm::outs() << "Forcing fp16 accumulation for SLS ops enabled\n";
+  }
+  if (!enableQuantParamChangesOpt) {
+    cctx.optimizationOpts.enableQuantParamChanges = false;
+    LOG(INFO) << "Disabling quantization param changes during optimizations";
   }
   if (glowDumpGraphOpt) {
     cctx.dumpFinalGraph = true;


### PR DESCRIPTION
Summary:
Fix the situation where we have `Concat({X, Quantize(Clip)})`, which was incorrectly being optimized to `Concat({X, Quantize'})`, since Quantize' will have different quantization parameters and therefore won't have the same quantization parameters as X. This was causing verification issues.

Also added a flag for dumping the graph that is initially loaded via Onnxifi, `--glow_dump_initial_loaded_graph`. And also added `--glow_enable_quant_param_changes` to repro.

Differential Revision: D22996041

