### PR TITLE
Enable more FP16 precision settings in CachingGraphRunner

### DIFF
--- a/torch_glow/src/CachingGraphRunner.h
+++ b/torch_glow/src/CachingGraphRunner.h
@@ -167,6 +167,10 @@ class CachingGraphRunner {
   /// file no matter what.
   void aggregateAndDumpTraces(TraceContext *traceContext, bool flush = false);
 
+  /// Initialize the Glow compilation context \p cctx with \p settings
+  void initializeCompiliationContextFromSettings(
+      glow::CompilationContext &cctx, const PyTorchLoaderSettings &settings);
+
 public:
   CachingGraphRunner(std::shared_ptr<torch::jit::Graph> graph,
                      std::shared_ptr<runtime::HostManager> hostManager,

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -98,6 +98,21 @@ public:
   bool get_convert_fused_to_fp16() { return convertFusedToFP16; }
   void set_convert_fused_to_fp16(bool val) { convertFusedToFP16 = val; }
 
+  /// Add clip operators after each fp16 ops during Glow compilation.
+  bool clipFP16 = false;
+
+  /// Force glow to skip clipping fp16 Node inputs to min/max
+  bool clipFP16SkipInputs = true;
+
+  /// Enable fp16 conversion for Placeholders
+  bool convertPlaceholdersToFP16 = true;
+
+  /// Enable fp16 conversion for Constants
+  bool convertConstantsToFP16 = true;
+
+  /// Force all SLS/SLWS ops to use FP16 accumulation.
+  bool forceFP16AccumSLS = true;
+
   /// Dump Glow dot graph to file after Glow compilation is finished.
   bool dumpFinalGlowGraph = false;
 


### PR DESCRIPTION
Summary: Expose precision settings in glow::CompilationContext to gflags, and pass them in CachingGraphRunner.

Differential Revision: D22961497

