### PR TITLE
Dimensions for H,W set incorrectly for AdaptiveAvgPool2d loading

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -3240,8 +3240,8 @@ Error PyTorchModelLoader::loadAdaptiveAvgPool2d(
   ASSIGN_VALUE_OR_RETURN_ERR(
       input, getGlowNodeValueForValue(inputs[AdaptiveAvgPoolInputs::input]));
 
-  size_t inputH = input.dims()[1];
-  size_t inputW = input.dims()[2];
+  size_t inputH = input.dims()[2];
+  size_t inputW = input.dims()[3];
   input = F_.createTranspose("adaptive_avg_pool2d_input_transposed", input,
                              NCHW2NHWC);
 


### PR DESCRIPTION
Summary:
Since the input format is NCHW and not NHWC, the H,W dimensions are set
incorrectly. This bugfix fixes it. This bug would have manifested only
if the output sizes were not set.

Reviewed By: jackm321

Differential Revision: D23006258

