### PR TITLE
BBoxTransform op Interpreter implementation

### DIFF
--- a/include/glow/Backends/Interpreter/InterpreterFunction.h
+++ b/include/glow/Backends/Interpreter/InterpreterFunction.h
@@ -381,6 +381,8 @@ private:
 
   void fwdROIAlignInstFloatImpl(glow::ROIAlignInst const *I);
 
+  void fwdBBoxTransformInstFloatImpl(glow::BBoxTransformInst const *I);
+
   template <typename T, typename AccumT>
   void fwdEmbeddingBagByteRowwiseOffsetsImpl(
       const EmbeddingBagByteRowwiseOffsetsInst *I);

--- a/lib/Backends/CPU/tests/CPUOperatorTest.cpp
+++ b/lib/Backends/CPU/tests/CPUOperatorTest.cpp
@@ -351,4 +351,5 @@ std::set<std::string> glow::backendTestBlacklist = {
     "Asin_Int8QTy/0",
     "Acos_Int8QTy/0",
     "Atan_Int8QTy/0",
+    "BBoxTransform/0",
 };

--- a/lib/Backends/Habana/tests/HabanaOperatorTest.cpp
+++ b/lib/Backends/Habana/tests/HabanaOperatorTest.cpp
@@ -415,4 +415,5 @@ std::set<std::string> glow::backendTestBlacklist = {
     "Asin_Int8QTy/0",
     "Acos_Int8QTy/0",
     "Atan_Int8QTy/0",
+    "BBoxTransform/0",
 };

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -665,6 +665,12 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
                ElemKind::Int64ITy &&
            NI.getOutElemTy(ROIAlignNode::ResultIdx) == ElemKind::FloatTy;
 
+  case Kinded::Kind::BBoxTransformNodeKind:
+    return NI.getInElemTy(BBoxTransformNode::RoisIdx) == ElemKind::FloatTy &&
+           NI.getInElemTy(BBoxTransformNode::DeltasIdx) == ElemKind::FloatTy &&
+           NI.getInElemTy(BBoxTransformNode::ImInfoIdx) == ElemKind::FloatTy &&
+           NI.getOutElemTy(BBoxTransformNode::BoxOutIdx) == ElemKind::FloatTy;
+
   case Kinded::Kind::SoftMaxGradNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
                {ElemKind::FloatTy}, {SoftMaxGradNode::SelectedIdx},

--- a/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
@@ -328,6 +328,7 @@ struct BlacklistInitializer {
             {"ChannelwiseQuantizedConv2D_Int8_BiasInt32/0",
              TestBlacklist::AnyDeviceAnyEngine},
             {"ROIAlign/0", TestBlacklist::AnyDeviceAnyEngine},
+            {"BBoxTransform/0", TestBlacklist::AnyDeviceAnyEngine},
             {"Abs_FloatTy/0", TestBlacklist::AnyDeviceAnyEngine},
             {"Abs_Int8QTy/0", TestBlacklist::AnyDeviceAnyEngine},
             {"And/0", TestBlacklist::AnyDeviceAnyEngine},

--- a/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
@@ -563,4 +563,5 @@ std::set<std::string> glow::backendTestBlacklist = {
     "Asin_Int8QTy/0",
     "Acos_Int8QTy/0",
     "Atan_Int8QTy/0",
+    "BBoxTransform/0",
 };

--- a/lib/Exporter/ONNXModelWriter.cpp
+++ b/lib/Exporter/ONNXModelWriter.cpp
@@ -1359,6 +1359,18 @@ Error ONNXModelWriter::writeROIAlign(const ROIAlignNode *node,
   return writeAllWithNode("ROIAlign", node, graph, proto);
 }
 
+Error ONNXModelWriter::writeBBoxTransform(const BBoxTransformNode *node,
+                                          GraphType &graph) {
+  auto *proto = graph.add_node();
+  addValueAttribute(proto, "ApplyScale", node->getApplyScale());
+  addValueAttribute(proto, "Rotated", node->getRotated());
+  addValueAttribute(proto, "AngleBoundOn", node->getAngleBoundOn());
+  addValueAttribute(proto, "AngleBoundLo", node->getAngleBoundLo());
+  addValueAttribute(proto, "AngleBoundHi", node->getAngleBoundHi());
+  addValueAttribute(proto, "ClipAngleThresh", node->getClipAngleThresh());
+  return writeAllWithNode("BBoxTransform", node, graph, proto);
+}
+
 Error ONNXModelWriter::writeConvolution(const ConvolutionNode *node,
                                         GraphType &graph) {
   // Loading convolution creates a sandwich with Transpose nodes for Input,

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -4821,6 +4821,25 @@ Function::createROIAlign(llvm::StringRef name, NodeValue featureMap,
       outputHeight, samplingRatio, spatialScale, offset, normalized));
 }
 
+BBoxTransformNode *Function::createBBoxTransform(
+    llvm::StringRef name, NodeValue rois, NodeValue deltas, NodeValue imInfo,
+    llvm::ArrayRef<float> weights, bool applyScale, bool rotated,
+    bool angleBoundOn, int64_t angleBoundLo, int64_t angleBoundHi,
+    float clipAngleThresh, bool legacyPlusOne) {
+  auto deltasDims = deltas.dims();
+  auto imInfoDims = imInfo.dims();
+
+  auto boxOutTy = getParent()->uniqueTypeWithNewShape(
+      rois.getType(), {deltasDims[0], deltasDims[1]});
+  auto roiBatchSplitsTy =
+      getParent()->uniqueType(rois.getElementType(), {imInfoDims[0]});
+
+  return addNode(new BBoxTransformNode(
+      name, boxOutTy, roiBatchSplitsTy, rois, deltas, imInfo, weights,
+      applyScale, rotated, angleBoundOn, angleBoundLo, angleBoundHi,
+      clipAngleThresh, legacyPlusOne));
+}
+
 //===----------------------------------------------------------------------===//
 //                   Graph dumping and printing
 //===----------------------------------------------------------------------===//

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -1297,6 +1297,60 @@ TEST_P(OperatorTest, ROIAlign) {
   }
 }
 
+TEST_P(OperatorTest, BBoxTransform) {
+  CHECK_IF_ENABLED();
+
+  auto *rois = mod_.createPlaceholder(ElemKind::FloatTy, {5, 5}, "rois", false);
+  bindings_.allocate(rois)->getHandle<float>() = {
+      0., 22.113754, 10.269318, 77.57481,   117.23254,
+      0., 89.73806,  46.060974, 125.824005, 96.2649,
+      1., 11.121593, 78.21209,  75.711426,  254.73167,
+      3., 0.9983631, 352.86606, 248.86679,  367.66916,
+      3., 221.1072,  136.93027, 413.82764,  211.13977};
+
+  auto *deltas =
+      mod_.createPlaceholder(ElemKind::FloatTy, {5, 8}, "deltas", false);
+  bindings_.allocate(deltas)->getHandle<float>() = {
+      -0.30892685, -0.44120562, 1.7046866,   -0.62745374, 1.1726723,
+      -0.52569604, -0.14308402, 0.48242334,  -1.3132329,  -1.5958056,
+      -0.81750935, 2.2151427,   -0.73521894, -0.00737088, 2.3750482,
+      -1.5794574,  -0.48789233, 1.7873235,   0.6119284,   -0.7701755,
+      -0.41762614, -0.9074146,  -0.7296619,  -0.30050594, 0.58725464,
+      0.71989095,  -0.8755994,  -1.2122285,  -0.5378105,  -0.90247065,
+      1.3996177,   -1.3575566,  0.6860114,   -0.4028068,  0.15296046,
+      -0.22815527, -2.4161322,  -1.8008438,  -0.92949533, 0.19269551};
+
+  auto *imInfo =
+      mod_.createPlaceholder(ElemKind::FloatTy, {4, 3}, "imInfo", false);
+  bindings_.allocate(imInfo)->getHandle<float>() = {
+      159., 159., 1., 328., 328., 1., 466., 466., 1., 414., 414., 1.};
+
+  std::vector<float> weights = {1.0, 1.0, 1.0, 1.0};
+  auto *BBTN =
+      F_->createBBoxTransform("bboxTransform", rois, deltas, imInfo, weights,
+                              false, false, false, 0, 0, 0, true);
+  auto *save = F_->createSave("save", BBTN->getBoxOut());
+  auto *savePlaceholder = save->getPlaceholder();
+  bindings_.allocate(savePlaceholder);
+
+  EE_.compile(CompilationMode::Infer);
+
+  EE_.run(bindings_);
+
+  auto saveH = bindings_.get(savePlaceholder)->getHandle();
+
+  std::vector<float> expectedValues = {
+      0.0000,   0.0000,   158.0000, 44.4404,  92.0877,  0.0000,   140.0215,
+      93.9451,  51.3913,  0.0000,   66.7658,  158.0000, 0.0000,   66.0093,
+      158.0000, 75.5617,  0.0000,   327.0000, 71.3890,  327.0000, 0.7150,
+      0.0000,   31.3340,  70.6096,  219.7409, 369.7931, 322.4225, 373.4951,
+      0.0000,   344.4728, 413.0000, 347.5388, 337.9926, 114.3067, 413.0000,
+      173.1735, 0.0000,   0.0000,   0.0000,   83.6907};
+  for (dim_t i = 0; i < expectedValues.size(); i++) {
+    EXPECT_NEAR(saveH.raw(i), expectedValues[i], 1E-4);
+  }
+}
+
 // Helper to test SpaceToDepth using \p DTy.
 template <typename DataType>
 static void testSpaceToDepthBlock3(glow::PlaceholderBindings &bindings,

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -1137,6 +1137,24 @@ int main(int argc, char **argv) {
       .autoVerify(VerifyKind::SameElementType, {"FeatureMap", "Boxes"})
       .autoIRGen();
 
+  BB.newInstr("BBoxTransform")
+      .addOperand("BoxOut", OperandKind::Out)
+      .addOperand("RoiBatchSplits", OperandKind::Out)
+      .addOperand("Rois", OperandKind::In)
+      .addOperand("Deltas", OperandKind::In)
+      .addOperand("ImInfo", OperandKind::In)
+      .addMember(MemberType::VectorFloat, "Weights")
+      .addMember(MemberType::Boolean, "ApplyScale")
+      .addMember(MemberType::Boolean, "Rotated")
+      .addMember(MemberType::Boolean, "AngleBoundOn")
+      .addMember(MemberType::Int64, "AngleBoundLo")
+      .addMember(MemberType::Int64, "AngleBoundHi")
+      .addMember(MemberType::Float, "ClipAngleThresh")
+      .addMember(MemberType::Boolean, "LegacyPlusOne")
+      .autoVerify(VerifyKind::SameElementType, {"Rois", "Deltas"})
+      .autoVerify(VerifyKind::SameElementType, {"Rois", "ImInfo"})
+      .autoIRGen();
+
   //===--------------------------------------------------------------------===//
   //                Backend-Specific Instructions
   //===--------------------------------------------------------------------===//

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -1314,6 +1314,36 @@ int main(int argc, char **argv) {
           "Performs region of interest (ROI) align operator and generates"
           "an Output tensor with shape [K, OutputHeight, OutputWidth, C]");
 
+  BB.newNode("BBoxTransform")
+      .addInput("Rois")
+      .addInput("Deltas")
+      .addInput("ImInfo")
+      .addMember(MemberType::VectorFloat, "Weights")
+      .addMember(MemberType::Boolean, "ApplyScale")
+      .addMember(MemberType::Boolean, "Rotated")
+      .addMember(MemberType::Boolean, "AngleBoundOn")
+      .addMember(MemberType::Int64, "AngleBoundLo")
+      .addMember(MemberType::Int64, "AngleBoundHi")
+      .addMember(MemberType::Float, "ClipAngleThresh")
+      .addMember(MemberType::Boolean, "LegacyPlusOne")
+      .addResultFromCtorArg("BoxOut")
+      .addResultFromCtorArg("RoiBatchSplits")
+      .setDocstring(
+          "Transform proposal bounding boxes to target bounding box using "
+          "bounding box regression deltas. "
+          "Rois tensor's format is: "
+          "<[optional_batch_index], x1, y1, x2, y2>, shape (M, 4) or (M, 5) "
+          "where M is the number of Rois. "
+          "For rotated boxes, this would have an additional angle (in degrees) "
+          "in the format <[optional_batch_id], ctr_x, ctr_y, w, h, angle> "
+          "Deltas are of shape (M, K*4) with format <dx, dy, dw, dh>, "
+          "where K is the number of classes. "
+          "For rotated Rois: shape (M, K*5), format <dx, dy, dw, dh, da>. "
+          "ImInfo is of shape <batch_size, 3> with format <img_height, "
+          "img_width, img_scale>."
+          "If proposals from multiple images in a batch are present, they "
+          "should be grouped sequentially and in incremental order.");
+
   //===--------------------------------------------------------------------===//
   //                Backend-Specific Nodes
   //===--------------------------------------------------------------------===//


### PR DESCRIPTION
Summary:
Adding Caffe2 BBoxTransform op used in CV detection networks.
In this diff adding only transform for non-rotated boxes.

Reviewed By: jackm321

Differential Revision: D22989353

