### PR TITLE
Lower AdaptiveAvgPool to AvgPool for 1x1 outputs

### DIFF
--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -547,7 +547,6 @@ bool NNPIBackend::shouldLower(const Node *N) const {
   case Kinded::Kind::BatchMatMulNodeKind:
   case Kinded::Kind::BatchNormalizationNodeKind:
   case Kinded::Kind::ChannelwiseQuantizedConvolutionNodeKind:
-  case Kinded::Kind::AdaptiveAvgPoolNodeKind:
   case Kinded::Kind::EmbeddingBagNodeKind:
   case Kinded::Kind::EmbeddingBagByteRowwiseOffsetsNodeKind:
   case Kinded::Kind::LayerNormalizationNodeKind:


### PR DESCRIPTION
Summary:
* Replace AdaptiveAvgPool with AvgPool when output is 1x1 since this may be a more simple op to use in this case.
* Add AdaptiveAvgPool to ResNetBench to test
* Add GraphOptz test

Differential Revision: D23005037

