### PR TITLE
Add support of quantized batchnorm 3d relu support in torch_glow

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -865,6 +865,8 @@ PyTorchModelLoader::buildSymbolsMapping() {
        &PyTorchModelLoader::loadQuantizedBatchNorm2d},
       {{"quantized::batch_norm3d"},
        &PyTorchModelLoader::loadQuantizedBatchNorm3d},
+      {{"quantized::batch_norm3d_relu"},
+       &PyTorchModelLoader::loadQuantizedBatchNorm3dRelu},
       {{"aten::layer_norm"}, &PyTorchModelLoader::loadLayerNorm},
       {{"aten::max_pool2d"}, &PyTorchModelLoader::loadMaxPool2d},
       {{"aten::avg_pool2d"}, &PyTorchModelLoader::loadAvgPool2d},
@@ -2787,6 +2789,19 @@ Error PyTorchModelLoader::loadQuantizedBatchNorm3d(
 
   c10::ScalarType dtype;
   RETURN_IF_ERR(getCorrectTypeMapping(dtype, inputs[0]));
+  return addValueMapping(outputs[0], output, dtype);
+}
+
+Error PyTorchModelLoader::loadQuantizedBatchNorm3dRelu(
+    const torch::jit::Node *ptNode) {
+  auto inputs = ptNode->inputs();
+  auto outputs = ptNode->outputs();
+  glow::NodeValue output;
+  ASSIGN_VALUE_OR_RETURN_ERR(output, loadQuantizedBatchNormImpl(ptNode, 3));
+
+  c10::ScalarType dtype;
+  RETURN_IF_ERR(getCorrectTypeMapping(dtype, inputs[0]));
+  output = F_.createRELU("quantized_relu_after_bn", output);
   return addValueMapping(outputs[0], output, dtype);
 }
 

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -484,13 +484,17 @@ private:
   /// \returns error on failure.
   Error loadBatchNorm(const torch::jit::Node *ptNode);
 
-  /// Load a PyTorch batch_norm2d node.
+  /// Load a PyTorch quantized::batch_norm2d node.
   /// \returns error on failure.
   Error loadQuantizedBatchNorm2d(const torch::jit::Node *ptNode);
 
-  /// Load a PyTorch batch_norm3d node.
+  /// Load a PyTorch quantized::batch_norm3d node.
   /// \returns error on failure.
   Error loadQuantizedBatchNorm3d(const torch::jit::Node *ptNode);
+
+  /// Load a PyTorch quantized::batch_norm3d_relu node.
+  /// \returns error on failure.
+  Error loadQuantizedBatchNorm3dRelu(const torch::jit::Node *ptNode);
 
   /// Load a PyTorch aten::layer_norm node.
   /// \returns error on failure.

--- a/torch_glow/tests/nodes/quantized_batchnorm3d_relu_test.py
+++ b/torch_glow/tests/nodes/quantized_batchnorm3d_relu_test.py
@@ -1,0 +1,78 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+
+import torch
+import torch.nn as nn
+import torch_glow
+from tests.utils import jitVsGlow
+from torch.quantization import (
+    DeQuantStub,
+    QConfig,
+    QuantStub,
+    convert,
+    fuse_modules,
+    observer,
+    prepare,
+)
+
+
+my_qconfig = QConfig(
+    activation=observer.default_observer,
+    weight=observer.HistogramObserver.with_args(dtype=torch.qint8, reduce_range=False),
+)
+
+
+class TestQuantizedBatchNorm3DRelu(unittest.TestCase):
+    def test_batchnorm_relu_basic(self):
+        """
+        Basic test of the PyTorch 3D batchnorm RELU Node on Glow.
+        """
+
+        class SimpleQuantizedBatchNormRelu(nn.Module):
+            def __init__(self, w, b, m, v):
+                super(SimpleQuantizedBatchNormRelu, self).__init__()
+                self.bn = torch.nn.BatchNorm3d(4)
+                self.relu = torch.nn.ReLU()
+                self.bn.weight = torch.nn.Parameter(w)
+                self.bn.bias = torch.nn.Parameter(b)
+                self.bn.running_mean = m
+                self.bn.running_var = v
+                self.q = QuantStub()
+                self.dq = DeQuantStub()
+
+            def forward(self, x):
+                qx = self.q(x)
+                qy = self.bn(qx)
+                qy_relu = self.relu(qy)
+                y = self.dq(qy_relu)
+                return y
+
+        C = 4
+        weight = torch.ones(C) + torch.rand(C) * 0.001
+        bias = torch.rand(C) * 0.0001
+        running_mean = torch.zeros(C)
+        running_var = torch.ones(C)
+
+        inputs = torch.randn((10, C, 2, 3, 4), requires_grad=False)
+        model = SimpleQuantizedBatchNormRelu(weight, bias, running_mean, running_var)
+        model.eval()
+        model.qconfig = my_qconfig
+        modules_to_fuse = [["bn", "relu"]]
+        fuse_modules(model, modules_to_fuse, inplace=True)
+        prepare(model, inplace=True)
+        model.forward(inputs)
+        convert(model, inplace=True)
+
+        torch_glow.enable_convert_to_fp16()
+        # Because of the difference of quantization between PyTorch & Glow
+        # We set eps big enough.
+        # Batchnorm introduced great accuracy issues, which could create up to
+        # ~1e-2 difference in some rare cases. In order to prevent this test
+        # to be flaky, atol is set to be 0.1.
+        jitVsGlow(
+            model,
+            inputs,
+            expected_fused_ops={"quantized::batch_norm3d_relu"},
+            atol=1e-1,
+        )


### PR DESCRIPTION
Summary: Add support of quantized batchnorm 3d relu node

Differential Revision: D23011963

