### PR TITLE
Update Glow to handle upsample overload

### DIFF
--- a/torch_glow/src/GlowIValue.cpp
+++ b/torch_glow/src/GlowIValue.cpp
@@ -493,6 +493,17 @@ iValToIntList(Expected<GlowIValue *> expectedIVal) {
   }
 }
 
+/// Unwrap a Expected<GlowIValue *> \p expectedIVal and call toDoubleList,
+/// propogate any Errors.
+Expected<std::vector<double> *>
+iValToDoubleList(Expected<GlowIValue *> expectedIVal) {
+  if (expectedIVal) {
+    return (*expectedIVal)->toDoubleList();
+  } else {
+    return expectedIVal.takeError();
+  }
+}
+
 /// Unwrap a Expected<GlowIValue *> \p expectedIVal and call toPTTensor,
 /// propogate any Errors.
 Expected<at::Tensor *> iValToPTTensor(Expected<GlowIValue *> expectedIVal) {

--- a/torch_glow/src/GlowIValue.h
+++ b/torch_glow/src/GlowIValue.h
@@ -253,6 +253,11 @@ Expected<bool> iValToBool(Expected<GlowIValue *> expectedIVal);
 Expected<std::vector<int64_t> *>
 iValToIntList(Expected<GlowIValue *> expectedIVal);
 
+/// Unwrap a Expected<GlowIValue *> \p expectedIVal and call toDoubleList,
+/// propogate any Errors.
+Expected<std::vector<double> *>
+iValToDoubleList(Expected<GlowIValue *> expectedIVal);
+
 /// Unwrap a Expected<GlowIValue *> \p expectedIVal and call toPTTensor,
 /// propogate any Errors.
 Expected<at::Tensor *> iValToPTTensor(Expected<GlowIValue *> expectedIVal);

--- a/torch_glow/tests/nodes/upsample_test.py
+++ b/torch_glow/tests/nodes/upsample_test.py
@@ -53,9 +53,6 @@ class TestUpsample(unittest.TestCase):
 
         jitVsGlow(test_f, x, expected_fused_ops={"aten::upsample_nearest3d"})
 
-    @unittest.skip(
-        reason="breaks because of constants not being differentiated in CachingGraphRunner"
-    )
     def test_upsample3d_not_2x_scale_factor(self):
         """Test of the PyTorch upsample Node on Glow."""
 


### PR DESCRIPTION
Summary:
An upcoming change will allow the PyTorch graph to explicitly represent
upsampling by a fixed scale.  Update Glow to handle this.

Reviewed By: jackm321

Differential Revision: D23108915

