### PR TITLE
unbreaking openCL operatorTest

### DIFF
--- a/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
@@ -558,6 +558,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "TestFP32Accumulator/0",
     "ROIAlign/0",
     "ROIAlignWithAlignedCoordinates/0",
+    "ROIAlignBatchIndexInBoxesTensor/0",
     "Asin_FloatTy/0",
     "Acos_FloatTy/0",
     "Atan_FloatTy/0",


### PR DESCRIPTION
Summary: adding missing blacklist test to OpenCLOperatorTest.

Differential Revision: D23117429

