### PR TITLE
default ice-ref to c-step

### DIFF
--- a/lib/Backends/NNPI/NNPICompiledFunction.cpp
+++ b/lib/Backends/NNPI/NNPICompiledFunction.cpp
@@ -84,6 +84,8 @@ Error NNPICompiledFunction::updateCompilationConfigFromOptions(
       LOG_IF_NOT_RETURN_LLVMERROR(
           false, "INVALID NNPI_DEVICE_VERSION, valid values are 1,2,3");
     }
+  } else {
+    config_.deviceType = NNPI_1000_C;
   }
 
   if (compilationOptions.iceCores > 0) {


### PR DESCRIPTION
Summary: if no compilation options are passed, default to c-step

Differential Revision: D23086534

