### PR TITLE
fuse detection model with roiAlign and bboxTransform ops

### DIFF
--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -661,8 +661,6 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
   case Kinded::Kind::ROIAlignNodeKind:
     return NI.getInElemTy(ROIAlignNode::FeatureMapIdx) == ElemKind::FloatTy &&
            NI.getInElemTy(ROIAlignNode::BoxesIdx) == ElemKind::FloatTy &&
-           NI.getInElemTy(ROIAlignNode::BatchIndicesIdx) ==
-               ElemKind::Int64ITy &&
            NI.getOutElemTy(ROIAlignNode::ResultIdx) == ElemKind::FloatTy;
 
   case Kinded::Kind::BBoxTransformNodeKind:

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -6001,10 +6001,9 @@ void BoundInterpreterFunction::fwdBBoxTransformInstFloatImpl(
 
     offset += rows;
   }
-  if (batchSize > 1) {
-    for (dim_t i = 0; i < batchSize; i++) {
-      roiBatchSplitsH.at({i}) = numRoisPerBatch[i];
-    }
+
+  for (dim_t i = 0; i < batchSize; i++) {
+    roiBatchSplitsH.at({i}) = numRoisPerBatch[i];
   }
 }
 

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -2118,7 +2118,6 @@ bool ROIAlignNode::verify() const {
 
   bool isValid = checkTypeIgnoreShape(featureMap, result, this);
   isValid &= checkTypeIgnoreShape(boxes, result, this);
-  isValid &= checkType(batchIndices, ElemKind::Int64ITy, this);
   isValid &= checkType(featureMap, ElemKind::FloatTy, this);
   isValid &= expectCompareTrue("FeatureMap must be a 4D tensor",
                                featureMapDims.size(), size_t(4), this);
@@ -2133,6 +2132,7 @@ bool ROIAlignNode::verify() const {
     // Onnx requires batchIndices to be valid
     if (!indicesInBoxesTensor) {
       auto batchIndicesDims = batchIndices.dims();
+      isValid &= checkType(batchIndices, ElemKind::Int64ITy, this);
       isValid &= expectCompareTrue("BatchIndices must be a 1D tensor",
                                    batchIndicesDims.size(), size_t(1), this);
       isValid &=

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -383,6 +383,14 @@ private:
   Error loadEmbeddingBagByteRowwiseOffsetsHelper(const torch::jit::Node *ptNode,
                                                  bool is4Bit = false);
 
+  // Load a PyTorch _caffe2::RoIAlign op.
+  // \returns error on failure.
+  Error loadRoiAlign(const torch::jit::Node *ptNode);
+
+  // Load a PyTorch _caffe2::BBoxTransform op.
+  // \returns error on failure.
+  Error loadBBoxTransform(const torch::jit::Node *ptNode);
+
   /// Load all PyTorch prim::GetAttr nodes in \p graph. This method uses the
   /// PyTorch Module hierarchy to map Values for all outputs of prim::GetAttr
   /// nodes. If the output type of a prim::GetAttr is a tensor, this will load


### PR DESCRIPTION
Summary:
Adding RoiAlign and BBoxTransform to PyTorchModelLoader. These ops are supported by Interpreter backend and this is used to fuse them into Glow function and create a repro.

More bug fixes to RoiAlign:
* fix roiBatchSplit output
* verify batchedIndices only when needed (this is an input in Onnx but not in caffe2)

Reviewed By: jackm321

Differential Revision: D23107145

