### PR TITLE
Add aten::chunk into Shape Inference

### DIFF
--- a/torch_glow/src/CachingGraphRunner.cpp
+++ b/torch_glow/src/CachingGraphRunner.cpp
@@ -543,7 +543,7 @@ Error CachingGraphRunner::runImpl(const PerGlowGraphInfo &info,
     if (settings.runShapeInference) {
       if (i < (*ptrOutputShape).size()) {
         const std::vector<int64_t> &expectedShape =
-            std::get<std::vector<int64_t>>((*ptrOutputShape)[i].shape());
+            boost::get<std::vector<int64_t>>((*ptrOutputShape)[i].shape());
         ptTensor = sliceTensor(ptTensor, expectedShape);
       }
     }

--- a/torch_glow/src/CachingGraphRunner.h
+++ b/torch_glow/src/CachingGraphRunner.h
@@ -24,6 +24,7 @@
 #include <torch/csrc/jit/ir/ir.h>
 #include <torch/csrc/jit/serialization/import.h>
 
+#include "glow/glow/torch_glow/src/ShapeInferenceEngine.h"
 #include <shared_mutex>
 
 namespace glow {
@@ -78,8 +79,7 @@ class CachingGraphRunner {
   /// Here we assume this is only one corresponding Glow function.
   /// Mapping from hash of PyTorch inputs to PerGlowGraphShape for the Glow
   /// function that will run inputs matching that hash.
-  std::unordered_map<size_t, std::vector<std::vector<int64_t>>>
-      perGlowGraphShapeMap_;
+  std::unordered_map<size_t, MetaStack> perGlowGraphShapeMap_;
 
   /// In AOT flow, compile a single Glow function and use it for all input
   /// sizes. The PyTorch tensor inputs in this case should be smaller that the
@@ -136,9 +136,8 @@ class CachingGraphRunner {
   /// info is returned immediately. Otherwise this will run the shape inference
   /// engine, push the generated the output shape into \p perGlowGraphShapeMap_,
   /// and then \returns the output shape pointer.
-  Expected<std::vector<std::vector<int64_t>> *>
-  loadShape(const c10::ArrayRef<c10::IValue> &inputs,
-            TraceContext *traceContext);
+  Expected<MetaStack *> loadShape(const c10::ArrayRef<c10::IValue> &inputs,
+                                  TraceContext *traceContext);
 
   /// Given a PerGlowGraphInfo \p info for a subgraph that was previously
   /// loaded, this runs the Glow function that corresponds to that

--- a/torch_glow/src/ShapeInferenceEngine.h
+++ b/torch_glow/src/ShapeInferenceEngine.h
@@ -17,9 +17,10 @@
 #ifndef GLOW_TORCH_GLOW_SRC_SHAPEINFERENCEENGINE_H
 #define GLOW_TORCH_GLOW_SRC_SHAPEINFERENCEENGINE_H
 
+#include "boost/variant.hpp"
 #include <string>
 #include <unordered_set>
-#include <variant>
+
 #include <vector>
 
 #include "glow/Support/Error.h"
@@ -33,7 +34,7 @@ namespace glow {
 /// case1: Tensor shape: std::vector<int64_t>
 /// case2: Tensor[] shape: std::vector<std::vector<int64_t>>
 using ElemShape =
-    std::variant<std::vector<int64_t>, std::vector<std::vector<int64_t>>>;
+    boost::variant<std::vector<int64_t>, std::vector<std::vector<int64_t>>>;
 
 struct VariableMeta {
   /// For Tensor, Tensor[], store the shape in \p listOfShape[0]
@@ -46,7 +47,6 @@ struct VariableMeta {
 
   const ElemShape &shape() const { return listOfShape[0]; }
   const ElemShape &getShape(int i) const { return listOfShape[i]; }
-  void addShape(ElemShape s) { listOfShape.emplace_back(s); }
 };
 
 using MetaStack = std::vector<VariableMeta>;


### PR DESCRIPTION
Summary: Add aten::chuck(Tensor self, int chunks, int dim) -> Tensor[] into shape inference. Handle Tensor[] shape.

Differential Revision: D22940247

