### PR TITLE
[OnnxModelLoader] Add option to export the RNN states as placeholders.

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -1746,8 +1746,9 @@ public:
   /// - [f] in case the RNN is unidirectional (1 function).
   /// - [f] for the forward cell followed by [f] for the reverse cell in
   ///    case the RNN is bidirectional (4 functions).
-  /// The input \p B is optional (assumed 0 if nullptr is provided).
-  /// The names of all the nodes created are prefixed with \p namePrefix.
+  /// The inputs \p B and \p initial_h are optional (assumed 0 if nullptr is
+  /// provided). The names of all the nodes created are prefixed with
+  /// \p namePrefix.
   void createOnnxRNN(llvm::StringRef namePrefix, NodeValue X, NodeValue W,
                      NodeValue R, NodeValue B, NodeValue initial_h,
                      NodeValue &Y, NodeValue &Y_h, unsigned hiddenSize,
@@ -1772,10 +1773,11 @@ public:
   /// - [f,g] in case the GRU is unidirectional (2 functions).
   /// - [f,g] for the forward cell followed by [f,g] for the reverse cell in
   ///    case the GRU is bidirectional (4 functions).
-  /// The input \p B is optional (assumed 0 if nullptr is provided).
-  /// The names of all the nodes created are prefixed with \p namePrefix.
-  /// The boolean parameter \p linearBeforeReset defines whether the reset
-  /// for the previous hidden state occurs before/after the linear expression.
+  /// The inputs \p B and \p initial_h are optional (assumed 0 if nullptr is
+  /// provided). The names of all the nodes created are prefixed with
+  /// \p namePrefix. The boolean parameter \p linearBeforeReset defines whether
+  /// the reset for the previous hidden state occurs before/after the linear
+  /// expression.
   void createOnnxGRU(llvm::StringRef namePrefix, NodeValue X, NodeValue W,
                      NodeValue R, NodeValue B, NodeValue initial_h,
                      NodeValue &Y, NodeValue &Y_h, unsigned hiddenSize,
@@ -1804,10 +1806,11 @@ public:
   /// - [f,g,h] in case the LSTM is unidirectional (3 functions).
   /// - [f,g,h] for the forward cell followed by [f,g,h] for the reverse cell in
   ///    case the LSTM is bidirectional (6 functions).
-  /// The inputs \p B and \p P are optional (assumed 0 if nullptr is provided).
-  /// The names of all the nodes created are prefixed with \p namePrefix.
-  /// The boolean parameter \p inputForget defines whether the input and forget
-  /// gates should be coupled (compute the input gate from the forget gate).
+  /// The inputs \p B, \p initial_h, \p initial_c and \p P are optional (assumed
+  /// 0 if nullptr is provided). The names of all the nodes created are prefixed
+  /// with \p namePrefix. The boolean parameter \p inputForget defines whether
+  /// the input and forget gates should be coupled (compute the input gate from
+  /// the forget gate).
   void createOnnxLSTM(llvm::StringRef namePrefix, NodeValue X, NodeValue W,
                       NodeValue R, NodeValue B, NodeValue initial_h,
                       NodeValue initial_c, NodeValue P, NodeValue &Y,

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -3641,15 +3641,19 @@ void Function::createOnnxRNN(llvm::StringRef namePrefix, NodeValue X,
            "ONNX RNN 'B' tensor size invalid!");
   }
 
-  // Validate initial_h size.
-  assert(initial_h.getNode() &&
-         "ONNX RNN input 'initial_h' is mandatory. Null provided!");
-  assert(initial_h.dims().size() == 3 &&
-         "ONNX RNN input 'initial_h' should have 2 dimensions!");
-  assert(initial_h.dims()[0] == numDirections &&
-         initial_h.dims()[1] == batchSize &&
-         initial_h.dims()[2] == hiddenSize &&
-         "ONNX RNN 'initial_h' tensor size invalid!");
+  // Validate initial_h size if given else create Splat with 0.
+  if (initial_h.getNode()) {
+    assert(initial_h.dims().size() == 3 &&
+           "ONNX RNN input 'initial_h' should have 2 dimensions!");
+    assert(initial_h.dims()[0] == numDirections &&
+           initial_h.dims()[1] == batchSize &&
+           initial_h.dims()[2] == hiddenSize &&
+           "ONNX RNN 'initial_h' tensor size invalid!");
+  } else {
+    auto splatTy = getParent()->uniqueType(
+        ElemKind::FloatTy, {numDirections, batchSize, hiddenSize});
+    initial_h = createSplat(opName + ".initial_h", splatTy, 0.0);
+  }
 
   // Validate number of activations.
   assert(activations.size() == numDirections * 1 &&
@@ -3845,15 +3849,19 @@ void Function::createOnnxGRU(llvm::StringRef namePrefix, NodeValue X,
            "ONNX GRU 'B' tensor size invalid!");
   }
 
-  // Validate initial_h size.
-  assert(initial_h.getNode() &&
-         "ONNX GRU input 'initial_h' is mandatory. Null provided!");
-  assert(initial_h.dims().size() == 3 &&
-         "ONNX GRU input 'initial_h' should have 2 dimensions!");
-  assert(initial_h.dims()[0] == numDirections &&
-         initial_h.dims()[1] == batchSize &&
-         initial_h.dims()[2] == hiddenSize &&
-         "ONNX GRU 'initial_h' tensor size invalid!");
+  // Validate initial_h size if given else create Splat with 0.
+  if (initial_h.getNode()) {
+    assert(initial_h.dims().size() == 3 &&
+           "ONNX GRU input 'initial_h' should have 2 dimensions!");
+    assert(initial_h.dims()[0] == numDirections &&
+           initial_h.dims()[1] == batchSize &&
+           initial_h.dims()[2] == hiddenSize &&
+           "ONNX GRU 'initial_h' tensor size invalid!");
+  } else {
+    auto splatTy = getParent()->uniqueType(
+        ElemKind::FloatTy, {numDirections, batchSize, hiddenSize});
+    initial_h = createSplat(opName + ".initial_h", splatTy, 0.0);
+  }
 
   // Validate number of activations.
   assert(activations.size() == numDirections * 2 &&
@@ -4122,25 +4130,33 @@ void Function::createOnnxLSTM(llvm::StringRef namePrefix, NodeValue X,
            "ONNX LSTM 'B' tensor size invalid!");
   }
 
-  // Validate initial_h size.
-  assert(initial_h.getNode() &&
-         "ONNX LSTM input 'initial_h' is mandatory. Null provided!");
-  assert(initial_h.dims().size() == 3 &&
-         "ONNX LSTM input 'initial_h' should have 2 dimensions!");
-  assert(initial_h.dims()[0] == numDirections &&
-         initial_h.dims()[1] == batchSize &&
-         initial_h.dims()[2] == hiddenSize &&
-         "ONNX LSTM 'initial_h' tensor size invalid!");
+  // Validate initial_h size if given else create Splat with 0.
+  if (initial_h.getNode()) {
+    assert(initial_h.dims().size() == 3 &&
+           "ONNX LSTM input 'initial_h' should have 2 dimensions!");
+    assert(initial_h.dims()[0] == numDirections &&
+           initial_h.dims()[1] == batchSize &&
+           initial_h.dims()[2] == hiddenSize &&
+           "ONNX LSTM 'initial_h' tensor size invalid!");
+  } else {
+    auto splatTy = getParent()->uniqueType(
+        ElemKind::FloatTy, {numDirections, batchSize, hiddenSize});
+    initial_h = createSplat(opName + ".initial_h", splatTy, 0.0);
+  }
 
-  // Validate initial_c size.
-  assert(initial_c.getNode() &&
-         "ONNX LSTM input 'initial_c' is mandatory. Null provided!");
-  assert(initial_c.dims().size() == 3 &&
-         "ONNX LSTM input 'initial_c' should have 2 dimensions!");
-  assert(initial_c.dims()[0] == numDirections &&
-         initial_c.dims()[1] == batchSize &&
-         initial_c.dims()[2] == hiddenSize &&
-         "ONNX LSTM 'initial_c' tensor size invalid!");
+  // Validate initial_c size if given else create Splat with 0.
+  if (initial_c.getNode()) {
+    assert(initial_c.dims().size() == 3 &&
+           "ONNX LSTM input 'initial_c' should have 2 dimensions!");
+    assert(initial_c.dims()[0] == numDirections &&
+           initial_c.dims()[1] == batchSize &&
+           initial_c.dims()[2] == hiddenSize &&
+           "ONNX LSTM 'initial_c' tensor size invalid!");
+  } else {
+    auto splatTy = getParent()->uniqueType(
+        ElemKind::FloatTy, {numDirections, batchSize, hiddenSize});
+    initial_c = createSplat(opName + ".initial_c", splatTy, 0.0);
+  }
 
   // Validate P size.
   if (P.getNode()) {

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -62,6 +62,17 @@ llvm::cl::list<std::string, std::vector<std::string>> onnxDefineSymbolOpt(
         "    ..................................................\n"),
     llvm::cl::value_desc("name,value"), llvm::cl::cat(onnxModelLoaderCat));
 
+llvm::cl::opt<bool> onnxExportRnnStatesOpt(
+    "onnx-export-rnn-states", llvm::cl::init(false), llvm::cl::Optional,
+    llvm::cl::desc(
+        "Option to export the states of the ONNX RNN operators (for example \n"
+        "RNN, GRU, LSTM) as graph placeholders regardless of whether the    \n"
+        "states are explicitly set or not in the graph. The placeholders are\n"
+        "also providing an automatic way for tracking the RNN states since  \n"
+        "the states are updated automatically with the new RNN states after \n"
+        "each inference. Default is false."),
+    llvm::cl::cat(onnxModelLoaderCat));
+
 /// Parse the command line option and get the user defined map of symbols.
 /// The command line option has the format <symbol_name>,<symbol_value>.
 Expected<std::unordered_map<std::string, dim_t>> getSymbolMap() {
@@ -2855,7 +2866,7 @@ Error ONNXModelLoader::loadRNN(const ONNX_NAMESPACE::NodeProto &op,
   }
 
   // -------------------------- Outputs ---------------------------------------
-  // We always create placeholders for the RNN state variable Y_h for the
+  // We allow creating placeholders for the RNN state variable Y_h for the
   // following reasons:
   // - expose the RNN state in the graph interface for accessibility (set
   //   desired state, reset state, watch the state being updated automatically).
@@ -2871,25 +2882,28 @@ Error ONNXModelLoader::loadRNN(const ONNX_NAMESPACE::NodeProto &op,
   dim_t batchSize = X.dims()[1];
 
   // Create Y_h (hidden state) output placeholder.
-  Placeholder *Y_h_ph;
-  TypeRef Htype = mod_.uniqueTypeWithNewShape(
-      X.getType(), {numDirections, batchSize, hiddenSize});
-  std::string Hname = opName + ".Y_h";
-  ASSIGN_VALUE_OR_RETURN_ERR(Y_h_ph,
-                             createAndRegisterPlaceholder(Hname, Htype));
-  inputVarsByName_.try_emplace(Hname, Y_h_ph);
+  Placeholder *Y_h_ph = nullptr;
+  if (onnxExportRnnStatesOpt) {
+    TypeRef Htype = mod_.uniqueTypeWithNewShape(
+        X.getType(), {numDirections, batchSize, hiddenSize});
+    std::string Hname = opName + ".Y_h";
+    ASSIGN_VALUE_OR_RETURN_ERR(Y_h_ph,
+                               createAndRegisterPlaceholder(Hname, Htype));
+    inputVarsByName_.try_emplace(Hname, Y_h_ph);
+  }
 
-  // If RNN input state is explicitly provided then used it. If not, then
-  // use the RNN state placeholder.
-  NodeValue Y_h_init = initial_h.getNode() ? initial_h : Y_h_ph;
+  // Set RNN input state.
+  NodeValue Y_h_init = onnxExportRnnStatesOpt ? Y_h_ph : initial_h;
 
   // Create ONNX RNN.
   NodeValue Y, Y_h;
   G_->createOnnxRNN(opName, X, W, R, B, Y_h_init, Y, Y_h, hiddenSize, direction,
                     activations);
 
-  // Save RNN state in the state placeholder.
-  G_->createSave(opName + ".Y_h.save", Y_h, Y_h_ph);
+  // Save RNN output state.
+  if (onnxExportRnnStatesOpt) {
+    G_->createSave(opName + ".Y_h.save", Y_h, Y_h_ph);
+  }
 
   // Add node.
   const int numOutputs = op.output_size();
@@ -2981,7 +2995,7 @@ Error ONNXModelLoader::loadGRU(const ONNX_NAMESPACE::NodeProto &op,
   }
 
   // -------------------------- Outputs ---------------------------------------
-  // We always create placeholders for the GRU state variable Y_h for the
+  // We allow creating placeholders for the GRU state variable Y_h for the
   // following reasons:
   // - expose the GRU state in the graph interface for accessibility (set
   //   desired state, reset state, watch the state being updated automatically).
@@ -2997,25 +3011,28 @@ Error ONNXModelLoader::loadGRU(const ONNX_NAMESPACE::NodeProto &op,
   dim_t batchSize = X.dims()[1];
 
   // Create Y_h (hidden state) output placeholder.
-  Placeholder *Y_h_ph;
-  TypeRef Htype = mod_.uniqueTypeWithNewShape(
-      X.getType(), {numDirections, batchSize, hiddenSize});
-  std::string Hname = opName + ".Y_h";
-  ASSIGN_VALUE_OR_RETURN_ERR(Y_h_ph,
-                             createAndRegisterPlaceholder(Hname, Htype));
-  inputVarsByName_.try_emplace(Hname, Y_h_ph);
+  Placeholder *Y_h_ph = nullptr;
+  if (onnxExportRnnStatesOpt) {
+    TypeRef Htype = mod_.uniqueTypeWithNewShape(
+        X.getType(), {numDirections, batchSize, hiddenSize});
+    std::string Hname = opName + ".Y_h";
+    ASSIGN_VALUE_OR_RETURN_ERR(Y_h_ph,
+                               createAndRegisterPlaceholder(Hname, Htype));
+    inputVarsByName_.try_emplace(Hname, Y_h_ph);
+  }
 
-  // If GRU input state is explicitly provided then used it. If not, then
-  // use the GRU state placeholder.
-  NodeValue Y_h_init = initial_h.getNode() ? initial_h : Y_h_ph;
+  // Set GRU input state.
+  NodeValue Y_h_init = onnxExportRnnStatesOpt ? Y_h_ph : initial_h;
 
   // Create ONNX GRU.
   NodeValue Y, Y_h;
   G_->createOnnxGRU(opName, X, W, R, B, Y_h_init, Y, Y_h, hiddenSize, direction,
                     activations, (bool)linearBeforeReset);
 
-  // Save GRU state in the state placeholder.
-  G_->createSave(opName + ".Y_h.save", Y_h, Y_h_ph);
+  // Save GRU output state.
+  if (onnxExportRnnStatesOpt) {
+    G_->createSave(opName + ".Y_h.save", Y_h, Y_h_ph);
+  }
 
   // Add node.
   const int numOutputs = op.output_size();
@@ -3120,7 +3137,7 @@ Error ONNXModelLoader::loadLSTM(const ONNX_NAMESPACE::NodeProto &op,
   }
 
   // -------------------------- Outputs ---------------------------------------
-  // We always create placeholders for the LSTM state variables (Y_h and Y_c)
+  // We allow creating placeholders for the LSTM state variables (Y_h and Y_c)
   // for the following reasons:
   // - expose the LSTM state in the graph interface for accessibility (set
   //   desired state, reset state, watch the state being updated automatically).
@@ -3136,36 +3153,41 @@ Error ONNXModelLoader::loadLSTM(const ONNX_NAMESPACE::NodeProto &op,
   dim_t batchSize = X.dims()[1];
 
   // Create Y_h (hidden state) output placeholder.
-  Placeholder *Y_h_ph;
-  TypeRef Htype = mod_.uniqueTypeWithNewShape(
-      X.getType(), {numDirections, batchSize, hiddenSize});
-  std::string Hname = opName + ".Y_h";
-  ASSIGN_VALUE_OR_RETURN_ERR(Y_h_ph,
-                             createAndRegisterPlaceholder(Hname, Htype));
-  inputVarsByName_.try_emplace(Hname, Y_h_ph);
+  Placeholder *Y_h_ph = nullptr;
+  if (onnxExportRnnStatesOpt) {
+    TypeRef Htype = mod_.uniqueTypeWithNewShape(
+        X.getType(), {numDirections, batchSize, hiddenSize});
+    std::string Hname = opName + ".Y_h";
+    ASSIGN_VALUE_OR_RETURN_ERR(Y_h_ph,
+                               createAndRegisterPlaceholder(Hname, Htype));
+    inputVarsByName_.try_emplace(Hname, Y_h_ph);
+  }
 
   // Create Y_c (cell state) output placeholder.
-  Placeholder *Y_c_ph;
-  TypeRef Ctype = mod_.uniqueTypeWithNewShape(
-      X.getType(), {numDirections, batchSize, hiddenSize});
-  std::string Cname = opName + ".Y_c";
-  ASSIGN_VALUE_OR_RETURN_ERR(Y_c_ph,
-                             createAndRegisterPlaceholder(Cname, Ctype));
-  inputVarsByName_.try_emplace(Cname, Y_c_ph);
+  Placeholder *Y_c_ph = nullptr;
+  if (onnxExportRnnStatesOpt) {
+    TypeRef Ctype = mod_.uniqueTypeWithNewShape(
+        X.getType(), {numDirections, batchSize, hiddenSize});
+    std::string Cname = opName + ".Y_c";
+    ASSIGN_VALUE_OR_RETURN_ERR(Y_c_ph,
+                               createAndRegisterPlaceholder(Cname, Ctype));
+    inputVarsByName_.try_emplace(Cname, Y_c_ph);
+  }
 
-  // If LSTM input states are explicitly provided then used them. If not, then
-  // use the LSTM state placeholders.
-  NodeValue Y_h_init = initial_h.getNode() ? initial_h : Y_h_ph;
-  NodeValue Y_c_init = initial_c.getNode() ? initial_c : Y_c_ph;
+  // Set LSTM input states.
+  NodeValue Y_h_init = onnxExportRnnStatesOpt ? Y_h_ph : initial_h;
+  NodeValue Y_c_init = onnxExportRnnStatesOpt ? Y_c_ph : initial_c;
 
   // Create ONNX LSTM.
   NodeValue Y, Y_h, Y_c;
   G_->createOnnxLSTM(opName, X, W, R, B, Y_h_init, Y_c_init, P, Y, Y_h, Y_c,
                      hiddenSize, direction, activations, (bool)inputForget);
 
-  // Save LSTM state in the state placeholders.
-  G_->createSave(opName + ".Y_h.save", Y_h, Y_h_ph);
-  G_->createSave(opName + ".Y_c.save", Y_c, Y_c_ph);
+  // Save LSTM output states.
+  if (onnxExportRnnStatesOpt) {
+    G_->createSave(opName + ".Y_h.save", Y_h, Y_h_ph);
+    G_->createSave(opName + ".Y_c.save", Y_c, Y_c_ph);
+  }
 
   // Add node.
   const int numOutputs = op.output_size();

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -3653,18 +3653,7 @@ static void importRNN(std::string fileName) {
   {
     ONNXModelLoader onnxLD(fileName, {}, {}, *F);
     bindings.allocate(mod.getPlaceholders());
-    auto Y_h_nv = EXIT_ON_ERR(onnxLD.getNodeValueByName("Y_h"));
-    EXPECT_TRUE(Y_h_nv.getNode());
   }
-
-  // Search RNN state placeholder and set to 0.
-  Placeholder *Y_h_ph = nullptr;
-  for (const auto &ph : mod.getPlaceholders()) {
-    if (llvm::StringRef(ph->getName()).endswith("Y_h"))
-      Y_h_ph = ph;
-  }
-  EXPECT_TRUE(Y_h_ph);
-  bindings.get(Y_h_ph)->zero();
 
   // Compile and run.
   EE.compile(CompilationMode::Infer);
@@ -3710,18 +3699,7 @@ static void importGRU(std::string fileName) {
   {
     ONNXModelLoader onnxLD(fileName, {}, {}, *F);
     bindings.allocate(mod.getPlaceholders());
-    auto Y_h_nv = EXIT_ON_ERR(onnxLD.getNodeValueByName("Y_h"));
-    EXPECT_TRUE(Y_h_nv.getNode());
   }
-
-  // Search GRU state placeholder and set to 0.
-  Placeholder *Y_h_ph = nullptr;
-  for (const auto &ph : mod.getPlaceholders()) {
-    if (llvm::StringRef(ph->getName()).endswith("Y_h"))
-      Y_h_ph = ph;
-  }
-  EXPECT_TRUE(Y_h_ph);
-  bindings.get(Y_h_ph)->zero();
 
   // Compile and run.
   EE.compile(CompilationMode::Infer);
@@ -3772,25 +3750,7 @@ static void importLSTM(std::string fileName) {
   {
     ONNXModelLoader onnxLD(fileName, {}, {}, *F);
     bindings.allocate(mod.getPlaceholders());
-    auto Y_h_nv = EXIT_ON_ERR(onnxLD.getNodeValueByName("Y_h"));
-    auto Y_c_nv = EXIT_ON_ERR(onnxLD.getNodeValueByName("Y_c"));
-    EXPECT_TRUE(Y_h_nv.getNode());
-    EXPECT_TRUE(Y_c_nv.getNode());
   }
-
-  // Search LSTM state placeholders and set to 0.
-  Placeholder *Y_h_ph = nullptr;
-  Placeholder *Y_c_ph = nullptr;
-  for (const auto &ph : mod.getPlaceholders()) {
-    if (llvm::StringRef(ph->getName()).endswith("Y_h"))
-      Y_h_ph = ph;
-    if (llvm::StringRef(ph->getName()).endswith("Y_c"))
-      Y_c_ph = ph;
-  }
-  EXPECT_TRUE(Y_h_ph);
-  EXPECT_TRUE(Y_c_ph);
-  bindings.get(Y_h_ph)->zero();
-  bindings.get(Y_c_ph)->zero();
 
   // Compile and run.
   EE.compile(CompilationMode::Infer);


### PR DESCRIPTION
**Summary**
Since exporting by default the RNN states (for operators like RNN, GRU, LSTM) is considered somewhat controversial I added an option in OnnxModelLoader to export the RNN states as placeholders but the option by default is set to **false** meaning that by default the RNN operators are loaded as defined originally in the model.
In Graph.cpp the RNN operators can also be instantiated with null states in which case Splat nodes with 0 are created.
The new option is called `-onnx-export-rnn-states`.

**Fixes**
#4782
#4747

**Test Plan**
Unit tests are passing.
