### PR TITLE
[GLOW Node] Fix batchnormalization verify function

### DIFF
--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -426,8 +426,8 @@ static bool verifyBatchNormalization(NodeValue src, NodeValue dest,
   bool isValid = checkSameType(dest, src, parent);
 
   isValid &= expectCompareTrue(
-      "Require some spatial dimensions in addition to batch and channel",
-      src.dims().size(), (size_t)2, parent,
+      "Require atleast two i.e., batch and channel dimensions",
+      src.dims().size(), (size_t)1, parent,
       CompareOperatorGreaterThan<size_t>());
 
   // Figure out how many channels are in the tensor.


### PR DESCRIPTION
Summary: The BN verify function has a constraint on i/p to be atleast
3 dimensional. However, the batchnormalization implementation
supports 2D input as well.

Test Plan: Ninja test

