### PR TITLE
Explicitly fail if Glow is importing FC with more than 3 inputs

### DIFF
--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -754,6 +754,8 @@ Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
   }
 
   if (typeName == "Int8Quantize") {
+    RETURN_ERR_IF_NOT(op.input_size() == 1,
+                      "Glow only suports Int8Quantize with 1 input");
     RETURN_ERR_IF_NOT(dict.count("Y_zero_point"),
                       "missing zero point for quantized output type");
     RETURN_ERR_IF_NOT(dict.count("Y_scale"),
@@ -1006,6 +1008,8 @@ Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
 
   if (typeName == "FC" || typeName == "FCTransposed" || typeName == "Int8FC" ||
       typeName == "FbFCPacked") {
+    RETURN_ERR_IF_NOT(op.input_size() == 3,
+                      "Glow only suports FC with 3 inputs");
     // Load the inputs:
     NodeValue in;
     ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));


### PR DESCRIPTION
Summary: Recently, we introduced 2-input Int8Quantize and 4-input Int8FC where the last input contains data to represent the quantization parameters. And then, the scale and zero_point argument itself in the op becomes dummy (1.0 and 0). Glow doesn't support such ops yet. However, it doesn't really error out, instead it will lower it with dummy quantiztion params, resulting in silent numerical error. This is not desirable. Let's explicitly error out now.

Differential Revision: D23416668

