### PR TITLE
Updates for RoiAlignNode

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -93,7 +93,7 @@ else
 fi
 
 # Install ninja, (newest version of) autopep8 through pip
-sudo pip install ninja 
+sudo pip install ninja
 hash cmake ninja
 
 # Build glow
@@ -156,7 +156,7 @@ elif [[ "$CIRCLE_JOB" == "PYTORCH" ]]; then
     git clone https://github.com/pytorch/pytorch.git --recursive --depth 1
     cd pytorch
     pip install -r requirements.txt
-    BUILD_BINARY=OFF BUILD_TEST=0 BUILD_CAFFE2_OPS=0 USE_FBGEMM=ON python setup.py install
+    BUILD_BINARY=OFF BUILD_TEST=0 BUILD_CAFFE2_OPS=1 USE_FBGEMM=ON python setup.py install
     cd ${GLOW_DIR}
     cd build
 elif [[ "$CIRCLE_JOB" == "OPENCL" ]]; then

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -2023,9 +2023,10 @@ public:
   /// coordinates are aligned to the center of a pixel (VS top-left corner).
   ROIAlignNode *createROIAlign(llvm::StringRef name, NodeValue featureMap,
                                NodeValue boxes, NodeValue batchIndices,
-                               std::string mode, uint32_t outputHeight,
-                               uint32_t outputWidth, uint32_t samplingRatio,
-                               float spatialScale, bool aligned, bool rotated);
+                               uint32_t outputHeight, uint32_t outputWidth,
+                               uint32_t samplingRatio, float spatialScale,
+                               bool aligned, bool rotated = false,
+                               PoolingMode mode = PoolingMode::AVG);
 
   /// Transform proposal bounding boxes to target bounding box using bounding
   /// box regression deltas.

--- a/include/glow/Graph/Nodes.h
+++ b/include/glow/Graph/Nodes.h
@@ -264,6 +264,9 @@ inline bool is3DData(ConvolutionLayout layout) {
   return (layout == NTHWC || layout == NCTHW);
 }
 
+/// Modes of pooling for RoiAlign operation.
+enum PoolingMode { AVG = 0, MAX };
+
 /// Activations fused into ConvolutionNode (not supported on all backends).
 enum FusedActivation { NONE = 0, RELU, TANH, SIGMOID };
 

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -5702,7 +5702,7 @@ void BoundInterpreterFunction::fwdROIAlignInstFloatImpl(
   auto boxes = I->getBoxes();
   auto batchIndices = I->getBatchIndices();
   auto result = I->getResult();
-  std::string mode = I->getMode();
+  auto mode = I->getMode();
   dim_t outputHeight = I->getOutputHeight();
   dim_t outputWidth = I->getOutputHeight();
   dim_t samplingRatio = I->getSamplingRatio();
@@ -5789,7 +5789,7 @@ void BoundInterpreterFunction::fwdROIAlignInstFloatImpl(
           }   // end of h
           // {Average or Max} pooling
           resultH.at({b, oh, ow, d}) =
-              (mode == "avg")
+              (mode == PoolingMode::AVG)
                   ? std::accumulate(pixels.begin(), pixels.end(), 0.0) /
                         static_cast<float>(pixels.size())
                   : *std::max_element(pixels.begin(), pixels.end());

--- a/lib/Exporter/ONNXModelWriter.cpp
+++ b/lib/Exporter/ONNXModelWriter.cpp
@@ -1351,7 +1351,14 @@ Error ONNXModelWriter::writeMFCC(const MFCCNode *node, GraphType &graph) {
 Error ONNXModelWriter::writeROIAlign(const ROIAlignNode *node,
                                      GraphType &graph) {
   auto *proto = graph.add_node();
-  addValueAttribute(proto, "mode", node->getMode());
+  switch (node->getMode()) {
+  case PoolingMode::AVG:
+    addValueAttribute(proto, "mode", std::string("avg"));
+    break;
+  case PoolingMode::MAX:
+    addValueAttribute(proto, "mode", std::string("max"));
+    break;
+  }
   addValueAttribute(proto, "output_height", node->getOutputHeight());
   addValueAttribute(proto, "output_width", node->getOutputWidth());
   addValueAttribute(proto, "sampling_ratio", node->getSamplingRatio());

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -4776,9 +4776,9 @@ MFCCNode *Function::createMFCC(llvm::StringRef name, NodeValue spectrogram,
 ROIAlignNode *
 Function::createROIAlign(llvm::StringRef name, NodeValue featureMap,
                          NodeValue boxes, NodeValue batchIndices,
-                         std::string mode, uint32_t outputHeight,
-                         uint32_t outputWidth, uint32_t samplingRatio,
-                         float spatialScale, bool aligned, bool rotated) {
+                         uint32_t outputHeight, uint32_t outputWidth,
+                         uint32_t samplingRatio, float spatialScale,
+                         bool aligned, bool rotated, PoolingMode mode) {
   auto featureMapDims = featureMap.dims();
   auto boxesDims = boxes.dims();
   std::vector<dim_t> outDim = {boxesDims[0], outputHeight, outputWidth,

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -3811,12 +3811,27 @@ Error ONNXModelLoader::loadROIAlign(const ONNX_NAMESPACE::NodeProto &op,
   NodeValue batchIndices;
   ASSIGN_VALUE_OR_RETURN_ERR(batchIndices, getNodeValueByName(op.input(2)));
 
-  std::string mode = "avg";
+  PoolingMode mode = PoolingMode::AVG;
   if (dict.count("mode")) {
-    ASSIGN_VALUE_OR_RETURN_ERR(mode, loadStr(dict.at("mode")));
-    RETURN_ERR_IF_NOT(mode == "avg" || mode == "max",
-                      "Unsupported mode. Only average pooling and max pooling "
-                      "are supported.");
+    std::string modeStr;
+    ASSIGN_VALUE_OR_RETURN_ERR(modeStr, loadStr(dict.at("mode")));
+    if (modeStr == "avg") {
+      mode = PoolingMode::AVG;
+    } else if (modeStr == "max") {
+      mode = PoolingMode::MAX;
+    } else {
+      return MAKE_ERR(strFormat("Invalid PoolingMode: %s", modeStr.c_str()));
+    }
+  }
+
+  bool rotated = false;
+  if (dict.count("rotated")) {
+    ASSIGN_VALUE_OR_RETURN_ERR(rotated, loadInt(dict.at("rotated")));
+  }
+
+  bool aligned = false;
+  if (dict.count("aligned")) {
+    ASSIGN_VALUE_OR_RETURN_ERR(aligned, loadInt(dict.at("aligned")));
   }
 
   uint32_t outputHeight = 1;
@@ -3843,10 +3858,9 @@ Error ONNXModelLoader::loadROIAlign(const ONNX_NAMESPACE::NodeProto &op,
 
   const std::string &opName = loadOperatorName(op);
   featureMap = G_->createTranspose(opName, featureMap, NCHW2NHWC);
-  Node *N =
-      G_->createROIAlign(loadOperatorName(op), featureMap, boxes, batchIndices,
-                         mode, outputHeight, outputWidth, samplingRatio,
-                         spatialScale, /*aligned*/ false, /*rotated*/ false);
+  Node *N = G_->createROIAlign(
+      loadOperatorName(op), featureMap, boxes, batchIndices, outputHeight,
+      outputWidth, samplingRatio, spatialScale, aligned, rotated, mode);
   N = G_->createTranspose(opName, N, NHWC2NCHW);
   RETURN_IF_ERR(addNodeAsOutput(op, N));
   return Error::success();

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -1127,7 +1127,7 @@ int main(int argc, char **argv) {
       .addOperand("FeatureMap", OperandKind::In)
       .addOperand("Boxes", OperandKind::In)
       .addOperand("BatchIndices", OperandKind::In)
-      .addMember(MemberType::String, "Mode")
+      .addMember(MemberType::Enum, "Mode")
       .addMember(MemberType::Unsigned, "OutputHeight")
       .addMember(MemberType::Unsigned, "OutputWidth")
       .addMember(MemberType::Unsigned, "SamplingRatio")

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -1304,7 +1304,7 @@ int main(int argc, char **argv) {
       .addInput("FeatureMap")
       .addInput("Boxes")
       .addInput("BatchIndices")
-      .addMember(MemberType::String, "Mode")
+      .addMember(MemberType::Enum, "Mode")
       .addMember(MemberType::Unsigned, "OutputHeight")
       .addMember(MemberType::Unsigned, "OutputWidth")
       .addMember(MemberType::Unsigned, "SamplingRatio")
@@ -1313,7 +1313,7 @@ int main(int argc, char **argv) {
       .addMember(MemberType::Boolean, "Rotated")
       .addResultFromCtorArg()
       .setDocstring(
-          "Performs region of interest (ROI) align operator. "
+          "Performs region of interest align (ROI) operator. "
           "FeatureMap - a tensor of [N,H,W,C]. N is the batch, C is the "
           "channel, H is the height, W is the width. "
           "Boxes - a tensor of [K,4] or [K,5] with format "

--- a/torch_glow/src/CachingGraphRunner.cpp
+++ b/torch_glow/src/CachingGraphRunner.cpp
@@ -16,10 +16,11 @@
 
 #include "CachingGraphRunner.h"
 
+#include <mutex>
+
 #include "glow/Exporter/ONNXModelWriter.h"
 #include "glow/Support/Support.h"
 
-#include <mutex>
 #include <c10/util/hash.h>
 #include <torch/csrc/jit/runtime/argument_spec.h>
 

--- a/torch_glow/tests/nodes/roi_align_test.py
+++ b/torch_glow/tests/nodes/roi_align_test.py
@@ -1,0 +1,96 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+
+import torch
+from tests.utils import jitVsGlow
+
+
+def rand_rois(N, H, W, num_rois):
+    rois = torch.rand((num_rois, 5))
+
+    for i in range(num_rois):
+        rois[i][0] = (N * rois[i][0]) // 1  # batch index
+
+        rois[i][1] *= W - 1  # x1
+        rois[i][2] *= H - 1  # y1
+
+        rois[i][3] *= W - rois[i][1]  # x2
+        rois[i][3] += rois[i][1]
+        rois[i][4] *= H - rois[i][2]  # y2
+        rois[i][4] += rois[i][2]
+
+        assert rois[i][1] > 0 and rois[i][1] < W - 1
+        assert rois[i][2] > 0 and rois[i][2] < H - 1
+        assert rois[i][3] > rois[i][1] and rois[i][3] < W
+        assert rois[i][4] > rois[i][2] and rois[i][3] < W
+
+    return rois
+
+
+class TestRoiAlign(unittest.TestCase):
+    def test_roi_align_basic(self):
+        """Basic test of the _caffe2::RoiAlign Node on Glow."""
+
+        def test_f(features, rois):
+            return torch.ops._caffe2.RoIAlign(
+                features,
+                rois,
+                order="NCHW",
+                spatial_scale=0.0625,
+                pooled_h=6,
+                pooled_w=6,
+                sampling_ratio=2,
+                aligned=True,
+            )
+
+        N, C, H, W = 1, 3, 16, 20
+
+        features = torch.randn(N, C, H, W)
+        rois = rand_rois(N, H, W, 250)
+
+        jitVsGlow(test_f, features, rois, expected_fused_ops={"_caffe2::RoIAlign"})
+
+    def test_roi_align_nhwc(self):
+        """Test of the _caffe2::RoiAlign Node on Glow."""
+
+        def test_f(features, rois):
+            return torch.ops._caffe2.RoIAlign(
+                features,
+                rois,
+                order="NHWC",
+                spatial_scale=0.0625,
+                pooled_h=6,
+                pooled_w=6,
+                sampling_ratio=2,
+                aligned=True,
+            )
+
+        N, C, H, W = 1, 3, 16, 20
+
+        features = torch.randn(N, H, W, C)
+        rois = rand_rois(N, H, W, 250)
+
+        jitVsGlow(test_f, features, rois, expected_fused_ops={"_caffe2::RoIAlign"})
+
+    def test_roi_align_batched(self):
+        """Test of the _caffe2::RoiAlign Node on Glow."""
+
+        def test_f(features, rois):
+            return torch.ops._caffe2.RoIAlign(
+                features,
+                rois,
+                order="NCHW",
+                spatial_scale=0.0625,
+                pooled_h=6,
+                pooled_w=6,
+                sampling_ratio=2,
+                aligned=True,
+            )
+
+        N, C, H, W = 4, 3, 16, 20
+
+        features = torch.randn(N, C, H, W)
+        rois = rand_rois(N, H, W, 250)
+
+        jitVsGlow(test_f, features, rois, expected_fused_ops={"_caffe2::RoIAlign"})


### PR DESCRIPTION
Summary:
* Make a new dummy tensor for BatchIndices since it needs to be Int64ITy
* Only transpose features and pooled_features when layout is NCHW
* Remove rotated attribute, this and RoiAlignRotated actually are pretty different since coordinate system isn't shared
* Make mode an enum, previously layout string was being passed to mode triggering max pooling path
* Node tests to compare against PyTorch

Reviewed By: mortzur

Differential Revision: D23226443

