### PR TITLE
Back out "persist host manager for specific backend across the process lifetime"

### DIFF
--- a/lib/Onnxifi/GlowOnnxifiManager.cpp
+++ b/lib/Onnxifi/GlowOnnxifiManager.cpp
@@ -86,7 +86,7 @@ GlowOnnxifiManager::getOrCreateHostManager(llvm::StringRef backendName) {
   auto it = hostManagers_.find(backendName);
 
   if (it != hostManagers_.end()) {
-    hostManager = it->second;
+    hostManager = it->second.lock();
   }
 
   if (!hostManager) {
@@ -121,6 +121,10 @@ void GlowOnnxifiManager::release(BackendPtr backend) {
 
   if (erased) {
     delete backend;
+  }
+
+  if (backends_.empty()) {
+    hostManagers_.clear();
   }
 }
 

--- a/lib/Onnxifi/GlowOnnxifiManager.h
+++ b/lib/Onnxifi/GlowOnnxifiManager.h
@@ -104,9 +104,9 @@ private:
 
   /// Map from backend name to HostManager managing devices of that backend that
   /// is shared by all Backends using that HostManager. HostManager is stored
-  /// as shared_ptr here because we want to persist through the life time of the
-  /// process.
-  std::map<std::string, std::shared_ptr<runtime::HostManager>> hostManagers_;
+  /// as weak_ptr here so that it will be destructed when the last Backend
+  /// using it is destroyed not when this singleton is destroyed.
+  std::map<std::string, std::weak_ptr<runtime::HostManager>> hostManagers_;
 
   /// Mutex that protects all members of GlowOnnxifiManager.
   /// TODO: can use one mutex per set if performance becomes an issue.


### PR DESCRIPTION
Summary:
Original commit changeset: 89a48dd84cdd

It breaks the T17 NE eval flow. And it seems that we will create NNPI handles and don't release it. It doesn't seem to work well for all network.

Differential Revision: D23422995

