### PR TITLE
fix layernorm op data paralellism heuristics

### DIFF
--- a/include/glow/Graph/Utils.h
+++ b/include/glow/Graph/Utils.h
@@ -149,6 +149,12 @@ static bool isUniformConstant(const Constant &CN, ElemTy &val) {
   return true;
 }
 
+static int __attribute__((unused))
+getMaxDimOtherThanBatch(const llvm::ArrayRef<dim_t> &dims) {
+  return std::distance(dims.begin(),
+                       std::max_element(dims.begin() + 1, dims.end()));
+}
+
 } // namespace glow
 
 #endif // GLOW_GRAPH_UTILS_H

--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -744,7 +744,8 @@ static void setupBasicParallelizationConfigs(
       if (LN->getInput().dims().size() < 2) {
         continue;
       }
-      size_t N = LN->getInput().dims()[1];
+      size_t NIdx = getMaxDimOtherThanBatch(LN->getInput().dims());
+      size_t N = LN->getInput().dims()[NIdx];
       if (N < 1024) {
         continue;
       }

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -5625,6 +5625,15 @@ Expected<std::unordered_map<Node *, ConcatNode *>> glow::parallelizeOps(
                     modelParallelSplitAlignment));
         break;
       }
+      case Kinded::Kind::MatMulNodeKind: {
+        splitDims[MatMulNode::RHSIdx] = 1;
+        ASSIGN_VALUE_OR_RETURN_ERR(
+            CN, parallelizeAndReplaceNode(
+                    F, curNode, curNumOfChunks, MatMulNode::RHSIdx,
+                    MatMulNode::ResultIdx, splitDims, /*resultDim*/ 1,
+                    modelParallelSplitAlignment));
+        break;
+      }
       case Kinded::Kind::ReluNodeKind: {
         if (curNode->getNthInput(ReluNode::InputIdx).dims().size() < 2) {
           break;

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -5495,6 +5495,14 @@ Expected<std::unordered_map<Node *, ConcatNode *>> glow::parallelizeOps(
                     SigmoidNode::ResultIdx, splitDims, 0));
         break;
       }
+      case Kinded::Kind::SoftMaxNodeKind: {
+        splitDims[SoftMaxNode::InputIdx] = 0;
+        ASSIGN_VALUE_OR_RETURN_ERR(
+            CN, parallelizeAndReplaceNode(
+                    F, curNode, curNumOfChunks, SoftMaxNode::InputIdx,
+                    SoftMaxNode::ResultIdx, splitDims, 0));
+        break;
+      }
       case Kinded::Kind::TanhNodeKind: {
         splitDims[TanhNode::InputIdx] = 0;
         ASSIGN_VALUE_OR_RETURN_ERR(

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -5513,7 +5513,10 @@ Expected<std::unordered_map<Node *, ConcatNode *>> glow::parallelizeOps(
       }
       case Kinded::Kind::TransposeNodeKind: {
         splitDims[TransposeNode::InputIdx] = 0;
-        unsigned_t resultDim = cast<TransposeNode>(curNode)->getShuffle()[0];
+        auto shuffleVec = cast<TransposeNode>(curNode)->getShuffle();
+        unsigned_t resultDim =
+            std::find(shuffleVec.begin(), shuffleVec.end(), 0) -
+            shuffleVec.begin();
         ASSIGN_VALUE_OR_RETURN_ERR(
             CN, parallelizeAndReplaceNode(
                     F, curNode, curNumOfChunks, TransposeNode::InputIdx,


### PR DESCRIPTION
Summary: layernorm has some assumption on the 2nd dim of the tensor, which is not applicable for 3d+ tensors. thus change the heuristics to check the largest dim other than batch dim.

Reviewed By: mjanderson09

Differential Revision: D23386721

