### PR TITLE
BBoxTransform add float16

### DIFF
--- a/lib/Backends/CPU/tests/CPUOperatorTest.cpp
+++ b/lib/Backends/CPU/tests/CPUOperatorTest.cpp
@@ -364,4 +364,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "ArithFloorDiv_float16_t/0",
     "VectorNorm_BFloat16/0",
     "VectorNorm_Float16/0",
-    "VectorNorm_Float16Ty/0"};
+    "VectorNorm_Float16Ty/0",
+    "BBoxTransform_Float/0",
+    "BBoxTransform_Float16/0",
+};

--- a/lib/Backends/Interpreter/tests/InterpreterOperatorTest.cpp
+++ b/lib/Backends/Interpreter/tests/InterpreterOperatorTest.cpp
@@ -31,4 +31,5 @@ std::set<std::string> glow::backendTestBlacklist = {
     "EmbeddingBagByteRowwiseOffsets_Float_End_Offset_Partial/0",
     "EmbeddingBagByteRowwiseOffsets_Float16_AccumFloat_End_Offset_Partial/0",
     "EmbeddingBagByteRowwiseOffsets_Float16_AccumFloat16_End_Offset_Partial/0",
+    "BBoxTransform_Float16/0",
 };

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -4814,8 +4814,9 @@ BBoxTransformNode *Function::createBBoxTransform(
 
   auto boxOutTy = getParent()->uniqueTypeWithNewShape(
       rois.getType(), {deltasDims[0], deltasDims[1]});
+  // Forcing roiBatchSplitsTy to always be Float.
   auto roiBatchSplitsTy =
-      getParent()->uniqueType(rois.getElementType(), {imInfoDims[0]});
+      getParent()->uniqueType(ElemKind::FloatTy, {imInfoDims[0]});
 
   return addNode(new BBoxTransformNode(
       name, boxOutTy, roiBatchSplitsTy, rois, deltas, imInfo, weights,

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -2182,7 +2182,8 @@ bool BBoxTransformNode::verify() const {
   bool isValid = checkTypeIgnoreShape(rois, boxOut, this);
   isValid &= checkSameType(deltas, boxOut, this);
   isValid &= checkTypeIgnoreShape(imInfo, boxOut, this);
-  isValid &= checkType(rois, ElemKind::FloatTy, this);
+  // ROIs can be float32 or float16.
+  isValid &= checkType(rois, {ElemKind::FloatTy, ElemKind::Float16Ty}, this);
   isValid &= expectCompareTrue("Rois must be a 2D tensor", roisDims.size(),
                                size_t(2), this);
   isValid &=

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -1532,20 +1532,22 @@ TEST_P(OperatorTest, FP16RoiAlignRotatedBatchIndexInBoxesTensor) {
       bindings_, mod_, *F_, EE_, ElemKind::Float16Ty, 1E-1);
 }
 
-TEST_P(OperatorTest, BBoxTransform) {
-  CHECK_IF_ENABLED();
-
-  auto *rois = mod_.createPlaceholder(ElemKind::FloatTy, {5, 5}, "rois", false);
-  bindings_.allocate(rois)->getHandle<float>() = {
+template <typename DataType>
+static void testBBoxTransform(PlaceholderBindings &bindings, Module &mod,
+                              Function &F, ExecutionEngine &EE, ElemKind ElemTy,
+                              bool applyScale, bool rotated, bool angleBoundOn,
+                              int64_t angleBoundLo, int64_t angleBoundHi,
+                              float clipAngleThresh, bool legacyPlusOne) {
+  llvm::SmallVector<dim_t, 2> roisDims = {5, 5};
+  llvm::SmallVector<DataType, 25> roisData = {
       0., 22.113754, 10.269318, 77.57481,   117.23254,
       0., 89.73806,  46.060974, 125.824005, 96.2649,
       1., 11.121593, 78.21209,  75.711426,  254.73167,
       3., 0.9983631, 352.86606, 248.86679,  367.66916,
       3., 221.1072,  136.93027, 413.82764,  211.13977};
 
-  auto *deltas =
-      mod_.createPlaceholder(ElemKind::FloatTy, {5, 8}, "deltas", false);
-  bindings_.allocate(deltas)->getHandle<float>() = {
+  llvm::SmallVector<dim_t, 2> deltasDims = {5, 8};
+  llvm::SmallVector<DataType, 40> deltasData = {
       -0.30892685, -0.44120562, 1.7046866,   -0.62745374, 1.1726723,
       -0.52569604, -0.14308402, 0.48242334,  -1.3132329,  -1.5958056,
       -0.81750935, 2.2151427,   -0.73521894, -0.00737088, 2.3750482,
@@ -1555,35 +1557,61 @@ TEST_P(OperatorTest, BBoxTransform) {
       1.3996177,   -1.3575566,  0.6860114,   -0.4028068,  0.15296046,
       -0.22815527, -2.4161322,  -1.8008438,  -0.92949533, 0.19269551};
 
-  auto *imInfo =
-      mod_.createPlaceholder(ElemKind::FloatTy, {4, 3}, "imInfo", false);
-  bindings_.allocate(imInfo)->getHandle<float>() = {
-      159., 159., 1., 328., 328., 1., 466., 466., 1., 414., 414., 1.};
+  llvm::SmallVector<dim_t, 2> imInfoDims = {4, 3};
+  llvm::SmallVector<DataType, 12> imInfoData = {159., 159., 1., 328., 328., 1.,
+                                                466., 466., 1., 414., 414., 1.};
 
   std::vector<float> weights = {1.0, 1.0, 1.0, 1.0};
-  auto *BBTN =
-      F_->createBBoxTransform("bboxTransform", rois, deltas, imInfo, weights,
-                              false, false, false, 0, 0, 0, true);
-  auto *save = F_->createSave("save", BBTN->getBoxOut());
-  auto *savePlaceholder = save->getPlaceholder();
-  bindings_.allocate(savePlaceholder);
 
-  EE_.compile(CompilationMode::Infer);
-
-  EE_.run(bindings_);
-
-  auto saveH = bindings_.get(savePlaceholder)->getHandle();
-
-  std::vector<float> expectedValues = {
+  std::vector<DataType> expectedValues = {
       0.0000,   0.0000,   158.0000, 44.4404,  92.0877,  0.0000,   140.0215,
       93.9451,  51.3913,  0.0000,   66.7658,  158.0000, 0.0000,   66.0093,
       158.0000, 75.5617,  0.0000,   327.0000, 71.3890,  327.0000, 0.7150,
       0.0000,   31.3340,  70.6096,  219.7409, 369.7931, 322.4225, 373.4951,
       0.0000,   344.4728, 413.0000, 347.5388, 337.9926, 114.3067, 413.0000,
       173.1735, 0.0000,   0.0000,   0.0000,   83.6907};
+
+  auto *rois = mod.createPlaceholder(ElemTy, roisDims, "rois", false);
+  bindings.allocate(rois)->getHandle<DataType>() = roisData;
+
+  auto *deltas = mod.createPlaceholder(ElemTy, deltasDims, "deltas", false);
+  bindings.allocate(deltas)->getHandle<DataType>() = deltasData;
+
+  auto *imInfo = mod.createPlaceholder(ElemTy, imInfoDims, "imInfo", false);
+  bindings.allocate(imInfo)->getHandle<DataType>() = imInfoData;
+
+  auto *bbTransform = F.createBBoxTransform(
+      "bboxTransform", rois, deltas, imInfo, weights, applyScale, rotated,
+      angleBoundOn, angleBoundLo, angleBoundHi, clipAngleThresh, legacyPlusOne);
+
+  auto *save = F.createSave("save", bbTransform->getBoxOut());
+  auto *savePlaceholder = save->getPlaceholder();
+  bindings.allocate(savePlaceholder);
+
+  EE.compile(CompilationMode::Infer);
+
+  EE.run(bindings);
+
+  auto saveH = bindings.get(savePlaceholder)->getHandle<DataType>();
+  float maxDiff = 0.0f;
   for (dim_t i = 0; i < expectedValues.size(); i++) {
-    EXPECT_NEAR(saveH.raw(i), expectedValues[i], 1E-4);
+    EXPECT_NEAR(saveH.raw(i), expectedValues[i], 1);
+    maxDiff =
+        std::max(maxDiff, std::abs((float)(saveH.raw(i) - expectedValues[i])));
   }
+  std::cout << "Max diff: " << maxDiff << std::endl;
+}
+
+TEST_P(OperatorTest, BBoxTransform_Float) {
+  CHECK_IF_ENABLED();
+  testBBoxTransform<float>(bindings_, mod_, *F_, EE_, ElemKind::FloatTy, false,
+                           false, false, 0, 0, 0, true);
+}
+
+TEST_P(OperatorTest, BBoxTransform_Float16) {
+  CHECK_IF_ENABLED();
+  testBBoxTransform<float16_t>(bindings_, mod_, *F_, EE_, ElemKind::Float16Ty,
+                               false, false, false, 0, 0, 0, true);
 }
 
 // Helper to test SpaceToDepth using \p DTy.


### PR DESCRIPTION
Summary: 
- Add support for float16 BBoxTransform and corresponding unittest.
- Change RoiBatchSplits to always be FP32

