### PR TITLE
TorchGlow AOT compilation multi-graph mode

### DIFF
--- a/torch_glow/src/PyTorchCommon.cpp
+++ b/torch_glow/src/PyTorchCommon.cpp
@@ -22,12 +22,17 @@
 #include "GlowFuser.h"
 #include "PyTorchModelLoader.h"
 #include "Registration.h"
+#include "ShapeInferenceEngine.h"
 
 #include "torch/csrc/jit/passes/canonicalize_graph_fuser_ops.h"
 #include <torch/csrc/jit/passes/pass_manager.h>
 #include <torch/csrc/jit/passes/subgraph_rewrite.h>
 #include <torch/csrc/jit/runtime/graph_executor.h>
 #include <torch/csrc/jit/runtime/operator_options.h>
+
+#include "torch/csrc/jit/ir/irparser.h"
+
+#include <torch/script.h>
 
 DEFINE_string(torch_glow_backend, "Interpreter",
               "Glow backend used for torchifi");
@@ -63,6 +68,8 @@ DEFINE_bool(runShapeInference, false, "See PyTorchLoaderSettings");
 DEFINE_int32(fusionStartIndex, -1, "See PyTorchLoaderSettings");
 DEFINE_int32(fusionEndIndex, -1, "See PyTorchLoaderSettings");
 DEFINE_bool(setIncludeLastOffsets, true, "See PyTorchLoaderSettings");
+DEFINE_bool(inferShapeForCompilation, false,
+            "Infer shape for the entire model for compilation");
 
 namespace glow {
 
@@ -251,6 +258,7 @@ void PyTorchLoaderSettings::initSettings() {
   fusionStartIndex = FLAGS_fusionStartIndex;
   fusionEndIndex = FLAGS_fusionEndIndex;
   setIncludeLastOffsets = FLAGS_setIncludeLastOffsets;
+  inferShapeForCompilation = FLAGS_inferShapeForCompilation;
 
   if (!FLAGS_opBlacklist.empty()) {
     auto kindStrings = splitString(FLAGS_opBlacklist);
@@ -335,6 +343,7 @@ PyTorchLoaderSettings::PyTorchLoaderSettings(
   TRY_LOAD_INT_FROM_DICT(numDevices, dict);
   TRY_LOAD_BOOL_FROM_DICT(runShapeInference, dict);
   TRY_LOAD_BOOL_FROM_DICT(setIncludeLastOffsets, dict);
+  TRY_LOAD_BOOL_FROM_DICT(inferShapeForCompilation, dict);
   TRY_LOAD_BOOL_FROM_DICT(enableDebugFuser, dict);
   if (dict.contains("opBlacklist")) {
     std::string commaSepOpsList = dict.at("opBlacklist");
@@ -437,12 +446,11 @@ const c10::Symbol &getGlowSymbol() {
 }
 
 c10::Symbol getGlowSymbol(std::shared_ptr<torch::jit::Graph> g) {
+  std::string symbol = "glow::FusionGroup";
   if (g) {
-    return at::Symbol::fromQualString(strFormat(
-        "glow::FusionGroup_%lu", reinterpret_cast<uint64_t>(g.get())));
-  } else {
-    return at::Symbol::fromQualString("glow::FusionGroup");
+    symbol += strFormat("_%lu", reinterpret_cast<uint64_t>(g.get()));
   }
+  return at::Symbol::fromQualString(symbol);
 }
 
 glow::Type ptTypeToGlowType(const c10::TensorType &ptType) {
@@ -566,17 +574,16 @@ glow::Tensor ptTensorToGlowTensor(const at::Tensor &ptTensor) {
   }
 }
 
-std::shared_ptr<std::vector<glow::InputMeta>>
-loadInputMeta(const std::string &raw_data) {
+std::vector<glow::InputMeta> loadInputMeta(const std::string &raw_data) {
   if (raw_data.empty()) {
-    return nullptr;
+    return {};
   }
-  auto inputMeta = std::make_shared<std::vector<glow::InputMeta>>();
+  auto inputMeta = std::vector<glow::InputMeta>();
   std::stringstream ss_raw(raw_data);
 
   std::string line;
   while (std::getline(ss_raw, line)) {
-    std::vector<size_t> dims;
+    std::vector<glow::sdim_t> dims;
     std::stringstream ss(line);
     ss.ignore();
     for (int i; ss >> i;) {
@@ -587,12 +594,121 @@ loadInputMeta(const std::string &raw_data) {
     }
     std::getline(ss_raw, line);
     c10::ScalarType t = static_cast<c10::ScalarType>(std::stoi(line));
-    inputMeta->emplace_back(t, std::move(dims));
+    inputMeta.emplace_back(t, std::move(dims));
   }
   return inputMeta;
 }
 
+// Similar to glowAOTFusion() however supports multiple Glow subgraphs and
+// runners. We'd still need both since in some cases we may not be able to infer
+// the entire model and would leverage glowAOTFusion() to run the partially
+// lowered model.
+void glowAOTFusionWithShapeInference(
+    torch::jit::Module &model, const std::vector<glow::InputMeta> &inputMeta) {
+  glow::PyTorchLoaderSettings &glowLoaderSettings =
+      glow::getPyTorchLoaderSettings();
+  glowLoaderSettings.preCompilePyTorchModule = true;
+
+  auto graph = model.get_method("forward").function().graph();
+
+  // fuse ListUnpack and Chunk into ConstantChunk. Put it here to work around
+  // some JIT serialization/deserialization problem.
+  torch::jit::CanonicalizeOps(graph);
+
+  // create some fake inputs to run shape inference.
+  // Usually users provide one set of inputs for the entire
+  // model and expect the model can be lowered. However there
+  // are cases where we cannot lower the entire model.
+  // There could be multiple fused graphs and the inputs to
+  // each fused graph could be different from the inputMeta user
+  // provided. Therefore we leverage shape inference to populate
+  // shape and type information over the entire model so we
+  // could lower whatever we want.
+  std::vector<torch::jit::IValue> inputs;
+  for (const auto &i : inputMeta) {
+    inputs.push_back(
+        torch::empty(i.dims, torch::TensorOptions().dtype(i.type)));
+  }
+
+  const at::ArrayRef<torch::jit::IValue> inputRefs(inputs);
+
+  // The base symbol of all.
+  std::string baseSymbol = glow::getGlowSymbol(nullptr).toQualString();
+
+  // There could be multiple glow fusion nodes created.
+  glow::glowCustomFuse(graph);
+
+  ShapeInferenceEngine shapeInf(*graph, inputRefs, baseSymbol);
+  auto e = shapeInf.run();
+  if (e) {
+    LOG(ERROR) << ERR_TO_STRING(std::move(e));
+  }
+
+  const auto &shapeMap = shapeInf.getVariableMap();
+
+  // this is a fuser subgraph to lower
+  std::shared_ptr<torch::jit::Graph> subgraph;
+
+  // Create one cachingGraphRunner for each fused graph.
+  for (auto *node : graph->nodes()) {
+    std::string kind = node->kind().toQualString();
+
+    if (kind == baseSymbol) { // Found a match
+      assert(node->hasAttribute(torch::jit::attr::Subgraph));
+      subgraph = node->g(torch::jit::attr::Subgraph);
+      // Find the index of this fusion node
+      int idx = findIndex(node);
+
+      // create the graph runner and warm its cache, this graph runner will be
+      // picked up during operator registration
+      // All Glow fusion nodes would have the same kind and there isn't a good
+      // native way to differentiate them at runtime. Therefore we scan the
+      // graph containing Glow fusion nodes and index each of them. The index
+      // would be used as part of the key to find corresponding
+      // cachingGraphRunner.
+      auto runner =
+          glow::setGraphRunnerForKey(kind + std::to_string(idx), [subgraph] {
+            return std::make_unique<glow::CachingGraphRunner>(
+                subgraph, glow::getHostManager(),
+                glow::getPyTorchLoaderSettings());
+          });
+
+      std::vector<glow::InputMeta> perGraphInputMeta;
+      auto graphInputValues = subgraph->inputs();
+
+      for (size_t i = 0; i < graphInputValues.size(); ++i) {
+        const torch::jit::Value *inputValue = graphInputValues[i];
+        auto itr = shapeMap.find(inputValue);
+        if (itr == shapeMap.end()) {
+          LOG(ERROR) << "Node " << node->kind().toQualString() << " input " << i
+                     << " Not found in the shape map!";
+        }
+        perGraphInputMeta.emplace_back(itr->second.dtype, itr->second.shape);
+      }
+
+      e = runner->warmCache(perGraphInputMeta, runner->getSettings(),
+                            /*useMaxSizeCompilation*/ true);
+      if (e) {
+        // If the graph is already compiled previously, warmCache() will report
+        // an error but it is fine with our execution. So here we extract the
+        // error only.
+        LOG(ERROR) << ERR_TO_STRING(std::move(e));
+      }
+    }
+  }
+  if (!subgraph) {
+    // at least one
+    LOG(ERROR) << "Cannot create a Glow fusion subgraph";
+  }
+}
+
 void glowAOTFusion(torch::jit::Module &model, const std::string &inputMetaStr) {
+  auto inputMeta = glow::loadInputMeta(inputMetaStr);
+
+  if (FLAGS_inferShapeForCompilation) {
+    return glowAOTFusionWithShapeInference(model, inputMeta);
+  }
+
   glow::PyTorchLoaderSettings &glowLoaderSettings =
       glow::getPyTorchLoaderSettings();
   glowLoaderSettings.preCompilePyTorchModule = true;
@@ -629,9 +745,7 @@ void glowAOTFusion(torch::jit::Module &model, const std::string &inputMetaStr) {
         subgraph, glow::getHostManager(), glow::getPyTorchLoaderSettings());
   });
 
-  auto inputMeta = glow::loadInputMeta(inputMetaStr);
-
-  auto e = runner->warmCache(*inputMeta, runner->getSettings(),
+  auto e = runner->warmCache(inputMeta, runner->getSettings(),
                              /*useMaxSizeCompilation*/ true);
   if (e) {
     // If the graph is already compiled previously, warmCache() will report

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -171,6 +171,9 @@ public:
   /// embedding-bag-like operators. This is default to true since it is
   /// currently a requirement if we want to support partial inputs
   bool setIncludeLastOffsets = true;
+
+  /// infer shape for entire model and run AOT compilation
+  bool inferShapeForCompilation = false;
 };
 
 /// Given a PyTorch ScalarType \p ty, \returns a matching Glow ElemKind.
@@ -222,12 +225,16 @@ at::Tensor glowTypeToEmptyPTTensor(const glow::Type &glowType);
 
 /// Load the \p InputMeta data contains Glow fusion node's input size and type
 /// info from \p raw_data stored in string format.
-std::shared_ptr<std::vector<glow::InputMeta>>
-loadInputMeta(const std::string &raw_data);
+std::vector<glow::InputMeta> loadInputMeta(const std::string &raw_data);
 
 /// Lower a pytorch \p module to glow before execution. \p inputMetaStr is the
 /// raw string containing the meta data of the glow fuser node input.
 void glowAOTFusion(torch::jit::Module &module, const std::string &inputMetaStr);
+
+/// Lower a pytorch \p module to glow before execution. \p inputMeta is a
+/// vector containing the meta data of the model inputs.
+void glowAOTFusionWithShapeInference(torch::jit::Module &module,
+                                     const std::vector<glow::InputMeta> &);
 
 /// Enable overriding signal handlers while exeucting torch_glow code. This
 /// should only be used in Python to enable easier debugging and not in

--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -5017,7 +5017,14 @@ PyTorchModelLoader::PyTorchModelLoader(
           } else {
             elemKind = ElemKind::Int8QTy;
           }
-          glow::Type t(elemKind, inputMeta[i].dims);
+
+          // TODO: Change Glow Type to use sdim_t to be consistent
+          // with other places.
+          std::vector<glow::dim_t> dims;
+          for (auto d : inputMeta[i].dims) {
+            dims.push_back(static_cast<glow::dim_t>(d));
+          }
+          glow::Type t(elemKind, dims);
 
           ph = F_.getParent()->createPlaceholder(&t, "input",
                                                  /*isTrainable*/ false);

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -84,9 +84,13 @@ public:
 // Input's shape and type
 struct InputMeta {
   c10::ScalarType type;
-  std::vector<glow::dim_t> dims;
+  std::vector<glow::sdim_t> dims;
 
-  InputMeta(c10::ScalarType type_, std::vector<glow::dim_t> &&dims_) {
+  InputMeta(c10::ScalarType type_, std::vector<glow::sdim_t> &&dims_) {
+    type = type_;
+    dims = dims_;
+  }
+  InputMeta(c10::ScalarType type_, const std::vector<glow::sdim_t> &dims_) {
     type = type_;
     dims = dims_;
   }

--- a/torch_glow/src/Registration.cpp
+++ b/torch_glow/src/Registration.cpp
@@ -91,18 +91,44 @@ bool removeGraphRunnerForKey(const std::string &key) {
   return true;
 }
 
+int findIndex(const torch::jit::Node *node) {
+  auto g = node->owningGraph();
+  auto kind = node->kind();
+  int index = 0;
+  for (auto n : g->nodes()) {
+    if (n->kind() == kind) {
+      if (n == node) {
+        return index;
+      }
+      ++index;
+    }
+  }
+  CHECK(0); // should never reach this line
+  return index;
+}
+
 void registerGlowOp(const c10::Symbol &symbol) {
   torch::jit::RegisterOperators op({torch::jit::Operator(
       symbol,
       [](const torch::jit::Node *node) -> torch::jit::Operation {
+        std::string key = node->kind().toQualString();
+        if (getPyTorchLoaderSettings().inferShapeForCompilation) {
+          // All Glow fusion nodes would have the same kind and there isn't a
+          // good native way to differentiate them at runtime. Therefore we scan
+          // the graph containing Glow fusion nodes and index each of them. The
+          // index would be used as part of the key to find corresponding
+          // cachingGraphRunner.
+          int idx = findIndex(node);
+          key += std::to_string(idx);
+        }
+
         // How to find a graphRunner:
         // 1. See if a key based on fusion node symbol string has been
         // registered, which is usually done in AOT fashion
         // 2. If not, create a graphRunner with graph hash as a key
         std::shared_ptr<CachingGraphRunner> graphRunner;
-
         if (!graphRunner) {
-          graphRunner = getGraphRunnerForKey(node->kind().toQualString());
+          graphRunner = getGraphRunnerForKey(key);
         }
 
         // If no preloaded graph runner was created for this node, create a new

--- a/torch_glow/src/Registration.h
+++ b/torch_glow/src/Registration.h
@@ -52,6 +52,15 @@ getGraphRunnerForKey(const std::string &key);
 /// Remove an existing CachingGraphRunner for a given \p key. \returns false if
 /// no CachingGraphRunner was registered for the given key, true otherwise.
 bool removeGraphRunnerForKey(const std::string &key);
+
+/// Custom op registration needs to happen before Glow fusion since AliasDB
+/// needs to be able to recognize each registered op/node. If there are multiple
+/// graphs then it's hard to know how many node kinds we need. It's probably not
+/// a good idea to merge op registration into fuser logic. Therefore we scan
+/// though the graph and find the index of each Glow fusion node to
+/// differentiate between them. Here we assume all fusion nodes all in the
+/// top level graph.
+int findIndex(const torch::jit::Node *node);
 } // namespace glow
 
 #endif // GLOW_TORCH_GLOW_SRC_REGISTRATION_H

--- a/torch_glow/src/TorchGlowBackend.cpp
+++ b/torch_glow/src/TorchGlowBackend.cpp
@@ -86,7 +86,7 @@ static std::vector<glow::InputMeta>
 getInputMetas(const GlowCompileSpec &method_spec) {
   std::vector<glow::InputMeta> inputMeta;
   for (const auto &in : method_spec.inputs()) {
-    std::vector<glow::dim_t> dims;
+    std::vector<glow::sdim_t> dims;
     for (auto d : in.dims()) {
       dims.emplace_back(static_cast<size_t>(d));
     }


### PR DESCRIPTION
Summary:
During development and debugging it's common that some nodes are not
supported or some nodes could be blocked from lowering. As a result there could
be multiple Glow fusion nodes and subgraphs. Since AOT compilation needs
inputMeta, it's not easy to have it for every Glow subgraphs. Therefore we'd
like to leverage shape inference to generate inputMeta for the entire graph and
make it easier for such cases. This diff implements the APIs. More work would
be required to implement shape functions for complex models.

TODO: support correct data type in shape inference

Reviewed By: allwu

Differential Revision: D23506748

