### PR TITLE
[ONNXModelLoader] Extend onnx matmul support for 4D inputs

### DIFF
--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -2578,9 +2578,19 @@ Error ONNXModelLoader::loadMatMul(const ONNX_NAMESPACE::NodeProto &op,
   NodeValue RHS;
   ASSIGN_VALUE_OR_RETURN_ERR(RHS, getNodeValueByName(op.input(1)));
 
-  /// For dimension size equal to 3 use batchedMatMul
-  if (LHS.dims().size() == 3) {
+  /// For dimension greater than 2 use batchedMatMul
+  if (LHS.dims().size() > 2) {
     Node *node = G_->createBatchMatMul(opName, LHS, RHS);
+    const size_t numDimsLHS = LHS.dims().size();
+    if (numDimsLHS > 3) {
+      const size_t numDimsRHS = RHS.dims().size();
+      std::vector<dim_t> finalShape;
+      for (auto d : LHS.dims()) {
+        finalShape.push_back(d);
+      }
+      finalShape[numDimsLHS - 1] = RHS.dims()[numDimsRHS - 1];
+      node = G_->createReshape(opName, node, finalShape);
+    }
     RETURN_IF_ERR(addNodeAsOutput(op, node));
   } else {
     Node *node = G_->createMatMul(opName, LHS, RHS);

--- a/tests/models/onnxModels/MatMul4D.onnxtxt
+++ b/tests/models/onnxModels/MatMul4D.onnxtxt
@@ -1,0 +1,173 @@
+ir_version: 6
+producer_name: "MatMul-onnx-example"
+graph {
+  node {
+    output: "a"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        dims: 2
+        dims: 3
+        dims: 4
+        data_type: 1
+        float_data: 4.0
+        float_data: 4.0
+        float_data: 1.0
+        float_data: 1.0
+        float_data: 4.0
+        float_data: 4.0
+        float_data: 1.0
+        float_data: 1.0
+        float_data: 0.0
+        float_data: 4.0
+        float_data: 2.0
+        float_data: 1.0
+        float_data: 2.0
+        float_data: 3.0
+        float_data: 2.0
+        float_data: 3.0
+        float_data: 0.0
+        float_data: 0.0
+        float_data: 3.0
+        float_data: 3.0
+        float_data: 3.0
+        float_data: 1.0
+        float_data: 1.0
+        float_data: 0.0
+        name: "const_tensor_1"
+      }
+      type: TENSOR
+    }
+  }
+  node {
+    output: "b"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        dims: 2
+        dims: 4
+        dims: 3
+        data_type: 1
+        float_data: 4.0
+        float_data: 0.0
+        float_data: 2.0
+        float_data: 0.0
+        float_data: 1.0
+        float_data: 4.0
+        float_data: 4.0
+        float_data: 4.0
+        float_data: 4.0
+        float_data: 4.0
+        float_data: 4.0
+        float_data: 0.0
+        float_data: 1.0
+        float_data: 3.0
+        float_data: 1.0
+        float_data: 0.0
+        float_data: 3.0
+        float_data: 4.0
+        float_data: 0.0
+        float_data: 2.0
+        float_data: 4.0
+        float_data: 0.0
+        float_data: 4.0
+        float_data: 1.0
+        name: "const_tensor_2"
+      }
+      type: TENSOR
+    }
+  }
+  node {
+    output: "Yref"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        dims: 2
+        dims: 3
+        dims: 3
+        data_type: 1
+        float_data: 24.0
+        float_data: 12.0
+        float_data: 28.0
+        float_data: 24.0
+        float_data: 12.0
+        float_data: 28.0
+        float_data: 12.0
+        float_data: 16.0
+        float_data: 24.0
+        float_data: 2.0
+        float_data: 31.0
+        float_data: 25.0
+        float_data: 0.0
+        float_data: 18.0
+        float_data: 15.0
+        float_data: 3.0
+        float_data: 14.0
+        float_data: 11.0
+        name: "const_tensor_3"
+      }
+      type: TENSOR
+    }
+  }
+  node {
+    input: "a"
+    input: "b"
+    output: "Y"
+    op_type: "MatMul"
+  }
+  name: "MatMul-test"
+  output {
+    name: "Y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "Yref"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 13
+}

--- a/tests/unittests/OnnxExporterTest.cpp
+++ b/tests/unittests/OnnxExporterTest.cpp
@@ -391,6 +391,8 @@ TEST(exporter, onnxModels) {
         name.find("NonMaxSuppression.onnxtxt") != std::string::npos ||
         name.find("NonMaxSuppressionSSD.onnxtxt") != std::string::npos ||
         name.find("ROIAlign_onnx.onnxtxt") != std::string::npos ||
+        name.find("MatMul4D.onnxtxt") != std::string::npos ||
+        name.find("Less.onnxtxt") != std::string::npos ||
         name.find("Asin.onnxtxt") != std::string::npos ||
         name.find("Acos.onnxtxt") != std::string::npos ||
         name.find("Atan.onnxtxt") != std::string::npos ||

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -3656,6 +3656,35 @@ TEST(onnx, ROIAlign_onnx) {
   }
 }
 
+/// Test loading and inference of ONNX MatMul operator with
+/// 4D inputs.
+TEST(onnx, MatMul4D) {
+  ExecutionEngine EE{};
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+  std::string netFilename(GLOW_DATA_PATH
+                          "tests/models/onnxModels/MatMul4D.onnxtxt");
+  PlaceholderBindings bindings;
+  Placeholder *output;
+  Placeholder *refOutput;
+
+  ONNXModelLoader onnxLD(netFilename, {}, {}, *F);
+  output = EXIT_ON_ERR(onnxLD.getOutputByName("Y"));
+  refOutput = EXIT_ON_ERR(onnxLD.getOutputByName("Yref"));
+
+  EE.compile(CompilationMode::Infer);
+  bindings.allocate(mod.getPlaceholders());
+  EE.run(bindings);
+  auto resultH = bindings.get(output)->getHandle();
+  auto refYH = bindings.get(refOutput)->getHandle();
+  std::vector<dim_t> outputShape = {1, 2, 3, 3};
+  float delta = 1e-03;
+  ASSERT_TRUE(resultH.dims() == (llvm::ArrayRef<dim_t>)outputShape);
+  for (size_t i = 0; i < resultH.getType().size(); i++) {
+    EXPECT_NEAR(resultH.raw(i), refYH.raw(i), delta);
+  }
+}
+
 TEST_F(OnnxImporterTest, importDimParamExplicit) {
   ExecutionEngine EE;
   auto &mod = EE.getModule();


### PR DESCRIPTION
Change-Id: I2dba89b230e15fcb3c9eb87afe22c052f1eab149

Summary: Extend onnx matmul support for 4D inputs

Documentation: BERT models include matmul or batchmatmul with 4D inputs. Hence we need to support matmu with 4D inputs.

Test Plan: ninja test and OnnxImporter test
