### PR TITLE
Disable the flaky MLTest.testFindPixelRegression test on CPU

### DIFF
--- a/lib/Backends/CPU/tests/CPUMLTest.cpp
+++ b/lib/Backends/CPU/tests/CPUMLTest.cpp
@@ -19,4 +19,5 @@ using namespace glow;
 
 std::set<std::string> glow::backendTestBlacklist = {
     "learnSparseLengthsSumEmbeddings/0",
+    "testFindPixelRegression/0",
 };


### PR DESCRIPTION
This test is flaky is CI is often failing because of this. Once the test is fixed, we should enable it again.
