### PR TITLE
Fixes a bug where LLVMIRGen::updateInlineAttributes() is clearing noalias parameter attributes

### DIFF
--- a/lib/LLVMIRCodeGen/Pipeline.cpp
+++ b/lib/LLVMIRCodeGen/Pipeline.cpp
@@ -69,9 +69,6 @@ LLVMIRGen::getInlinineAttr(const llvm::Function *F) const {
 }
 
 void LLVMIRGen::updateInlineAttributes(llvm::Module *M) {
-  // An empty attribute set to replace the target-specific machine code
-  // attributes that were attached by the frontend.
-  llvm::AttributeList AL;
   for (auto &FF : *M) {
     if (FF.isDeclaration()) {
       continue;
@@ -87,8 +84,12 @@ void LLVMIRGen::updateInlineAttributes(llvm::Module *M) {
           << "Unknown inlining attribute returned by getInlinineAttr";
       dontInline = (inlineAttr == llvm::Attribute::AttrKind::NoInline);
     }
-    // Clear all attributes.
-    FF.setAttributes(AL);
+    // Replace the target-specific machine code function attributes that were 
+    // attached by the frontend. Keep return and parameter attributes, e.g.,
+    // noalias.
+    FF.setAttributes(
+      FF.getAttributes().removeAttributes(M->getContext(),
+                                          llvm::AttributeList::FunctionIndex));
     // Force inline all non-no-inline functions.
     if (!dontInline || alwaysInline) {
       FF.addFnAttr(llvm::Attribute::AttrKind::AlwaysInline);


### PR DESCRIPTION
LLVMIRGen::updateInlineAttributes() currently clears all function attribute lists including the valuable noalias parameter attributes that were previously added. This leads to suboptimal optimization, e..g, loop vectorization inserts explicit memory region overlap checks in the final binary code.

I suggest making this change to only clear the function attributes and leave the return and parameter attributes alone.

A better fix would be to only remove the unwanted target-specific machine code function attributes, but that would require more work, esp. to identify what is wanted (inline/noinline) what is not .