### PR TITLE
[LLVMIRCodeGen] Allow for easier customization of LLVMBackend-based backends

### DIFF
--- a/include/glow/LLVMIRCodeGen/AllocationsInfo.h
+++ b/include/glow/LLVMIRCodeGen/AllocationsInfo.h
@@ -61,24 +61,25 @@ public:
       : constantWeightVarsAllocator("ConstantWeights", 0),
         mutableWeightVarsAllocator("MutableWeights", 0),
         activationsAllocator("Activations", 0) {}
+  virtual ~AllocationsInfo() = default;
   /// Assign offsets to all of the variables in the module \p M and to the
   /// placeholders.
-  void allocateWeightVars(const IRFunction *F);
+  virtual void allocateWeightVars(const IRFunction *F);
   /// Assign offsets to all activations.
   /// No actual memory allocation is performed. All the allocations should be
   /// performed by the client based on the information provided by the
   /// AllocationsInfo or RuntimeBundle.
-  void allocateActivations(const IRFunction *F);
+  virtual void allocateActivations(const IRFunction *F);
   /// Assign offsets to all tensorviews.
   /// No memory allocation is performed. Sets up all offsets into already
   /// defined offsets for WeightVars and AllocActivations. Assumes the weight
   /// vars and alloc activations have already been added to allocatedAddress_.
-  void allocateTensorViews(const IRFunction *F);
+  virtual void allocateTensorViews(const IRFunction *F);
   /// Number all allocations and weight variables by assigning them unique
   /// numbers.
-  void numberValues(const IRFunction *F);
+  virtual void numberValues(const IRFunction *F);
 
-private:
+protected:
   /// Index to be used for a new value.
   size_t valueIdx_{0};
   /// Use two different allocators, because constant weights and mutable weights

--- a/include/glow/LLVMIRCodeGen/LLVMBackend.h
+++ b/include/glow/LLVMIRCodeGen/LLVMBackend.h
@@ -28,6 +28,7 @@
 namespace glow {
 
 class AllocationsInfo;
+class BundleSaver;
 class PlaceholderBindings;
 class LLVMIRGen;
 
@@ -170,6 +171,17 @@ public:
   /// \returns backend-specific LLVMIRGen instance.
   virtual std::unique_ptr<LLVMIRGen>
   createIRGen(const IRFunction *IR, AllocationsInfo &allocationsInfo) const = 0;
+
+  /// Method that creates a BundleSaver. This gives the possibility to
+  /// create a backend that inherits from the LLVMBackend backend, while
+  /// providing a specific version of the BundleSaver derived from BundleSaver.
+  /// \param llvmBackend backend to be used to produce in a bundle.
+  /// \param outputDir output directory for the bundle.
+  /// \param bundleName the name of the bundle.
+  /// \returns backend-specific BundleSaver instance.
+  virtual std::unique_ptr<BundleSaver>
+  createBundleSaver(const LLVMBackend &llvmBackend, llvm::StringRef outputDir,
+                    llvm::StringRef bundleName) const;
 
 protected:
   /// Method that creates a CompiledFunction.

--- a/include/glow/LLVMIRCodeGen/LLVMIRGen.h
+++ b/include/glow/LLVMIRCodeGen/LLVMIRGen.h
@@ -167,8 +167,8 @@ protected:
 
   /// Generates LLVM IR that computes the address of \p val using \p builder.
   /// The address type is specified by \p ptrTy.
-  llvm::Value *emitValueAddress(llvm::IRBuilder<> &builder,
-                                const glow::Value *val);
+  virtual llvm::Value *emitValueAddress(llvm::IRBuilder<> &builder,
+                                        const glow::Value *val);
   /// Emit the address of the buffer \p v inside a data-parallel kernel \p
   /// kernel using the mapping provided by \p bufferToArgNum.
   llvm::Value *emitBufferAddress(llvm::IRBuilder<> &builder, Value *val,

--- a/lib/LLVMIRCodeGen/BundleSaver.h
+++ b/lib/LLVMIRCodeGen/BundleSaver.h
@@ -24,7 +24,7 @@
 namespace glow {
 class LLVMBackend;
 
-class BundleSaver final {
+class BundleSaver {
 public:
   /// Information about a saved IR function.
   struct SavedIRFunction {
@@ -52,34 +52,38 @@ public:
   /// Ctor.
   explicit BundleSaver(const LLVMBackend &llvmBackend,
                        llvm::StringRef outputDir, llvm::StringRef bundleName);
-  void save(llvm::StringRef mainEntryName, const IRFunction *F);
+  /// Dtor.
+  virtual ~BundleSaver() = default;
+  virtual void save(llvm::StringRef mainEntryName, const IRFunction *F);
   /// Produce a bundle.
-  void produceBundle();
+  virtual void produceBundle();
 
-private:
+protected:
   /// Perform memory allocation for a bundle.
-  void performBundleMemoryAllocation();
+  virtual void performBundleMemoryAllocation();
   /// Save weights for the bundle.
-  void saveWeights(llvm::StringRef weightsFileName);
+  virtual void saveWeights(llvm::StringRef weightsFileName);
   /// Save header file for the bundle.
-  void saveHeader(llvm::StringRef headerFileName);
+  virtual void saveHeader(llvm::StringRef headerFileName);
   /// Emit config for a bundle.
-  void emitBundleConfig();
+  virtual void emitBundleConfig();
   /// Emit the symbol table for a bundle.
-  void emitSymbolTable();
+  virtual void emitSymbolTable();
   /// Emit the entry function for the saved function \p savedF.
-  void emitBundleEntryFunction(SavedIRFunction &savedF);
+  virtual void emitBundleEntryFunction(SavedIRFunction &savedF);
   /// Set current IRFunction.
-  void setIRFunction(llvm::StringRef mainEntryName, const IRFunction *F);
+  virtual void setIRFunction(llvm::StringRef mainEntryName,
+                             const IRFunction *F);
   /// Returns a set of placeholders associated with IR functions inside this
   /// bundle.
-  std::set<const Placeholder *> findPlaceholders() const;
+  virtual std::set<const Placeholder *> findPlaceholders() const;
   /// Returns a set of constant weights associated with IR functions inside this
   /// bundle.
-  std::set<WeightInfo, WeightAddrComparator> findConstantWeights() const;
+  virtual std::set<WeightInfo, WeightAddrComparator>
+  findConstantWeights() const;
   /// \returns the weight that the variable \p v is lowered into in one of the
   /// IR functions inside this bundle, or null if the variable is unknown.
-  Value *getWeightForNode(const Storage *V) const;
+  virtual Value *getWeightForNode(const Storage *V) const;
   /// Information about allocations.
   AllocationsInfo allocationsInfo_;
   /// The LLVM IR code generator.

--- a/lib/LLVMIRCodeGen/LLVMBackend.cpp
+++ b/lib/LLVMIRCodeGen/LLVMBackend.cpp
@@ -652,20 +652,27 @@ void LLVMBackend::save(Function *F, llvm::StringRef outputDir,
   llvm::SmallVector<std::string, 8> targetFeatures(llvmTargetFeatures.begin(),
                                                    llvmTargetFeatures.end());
   auto IR = generateAndOptimizeIR(F, *this, shouldShareBuffers());
-  BundleSaver bundleSaver(*this, outputDir, bundleName);
-  bundleSaver.save(mainEntryName, IR.get());
-  bundleSaver.produceBundle();
+  auto bundleSaver = createBundleSaver(*this, outputDir, bundleName);
+  bundleSaver->save(mainEntryName, IR.get());
+  bundleSaver->produceBundle();
 }
 
 void LLVMBackend::saveFunctions(llvm::ArrayRef<BundleEntry> entries,
                                 llvm::StringRef outputDir,
                                 llvm::StringRef bundleName) const {
-  BundleSaver bundleSaver(*this, outputDir, bundleName);
+  auto bundleSaver = createBundleSaver(*this, outputDir, bundleName);
   std::vector<std::unique_ptr<glow::IRFunction>> irFunctions;
   for (auto &entry : entries) {
     auto IR = generateAndOptimizeIR(entry.func, *this, shouldShareBuffers());
-    bundleSaver.save(entry.name, IR.get());
+    bundleSaver->save(entry.name, IR.get());
     irFunctions.emplace_back(std::move(IR));
   }
-  bundleSaver.produceBundle();
+  bundleSaver->produceBundle();
+}
+
+std::unique_ptr<BundleSaver>
+LLVMBackend::createBundleSaver(const LLVMBackend &llvmBackend,
+                               llvm::StringRef outputDir,
+                               llvm::StringRef bundleName) const {
+  return glow::make_unique<BundleSaver>(llvmBackend, outputDir, bundleName);
 }


### PR DESCRIPTION
- Make LLVMIRGen a bit more flexible
   
   Allow for overriding of emitValueAddress in derived classes.

- Make it possible for LLVMBackend-based backends to customize BundleSavers they want to use

   - Backends can define their custom bundle savers by deriving from BundleSaver. BundleSaver is not final anymore and most of its methods are virtual now to enable easier customization by backends.

    - Backends can override LLVMBackend::createBundleSaver to create those custom bundle savers, similar to how it is done for IRGens.

This change does not change any functionality for the existing backends, it just enables better customization by LLVMBackend-based backends.