### PR TITLE
Check backend partial tensor support if enablePartialTensor=true

### DIFF
--- a/lib/Backends/Interpreter/InterpreterFunction.cpp
+++ b/lib/Backends/Interpreter/InterpreterFunction.cpp
@@ -214,8 +214,12 @@ Error BoundInterpreterFunction::execute(IRFunction *F,
     for (auto &ph : virtualPadded) {
       auto oldTensor = context->getPlaceholderBindings()->get(ph);
       Tensor paddedTensor(oldTensor->getType());
-      memcpy(paddedTensor.getUnsafePtr(), oldTensor->getUnsafePtr(),
-             oldTensor->getUnpaddedSizeInBytes());
+      if (oldTensor->getUnsafePtr()) {
+        memcpy(paddedTensor.getUnsafePtr(), oldTensor->getUnsafePtr(),
+               oldTensor->getUnpaddedSizeInBytes());
+      } else {
+        CHECK_EQ(oldTensor->getUnpaddedSizeInBytes(), 0);
+      }
       context->getPlaceholderBindings()->erase(ph);
       context->getPlaceholderBindings()->insert(ph, std::move(paddedTensor));
     }

--- a/tests/unittests/Repro.cpp
+++ b/tests/unittests/Repro.cpp
@@ -687,6 +687,12 @@ int run() {
 
   auto hostManager =
       glow::make_unique<runtime::HostManager>(std::move(configs), hostConfig);
+  if (enablePartialTensor) {
+    CHECK(hostManager->getBackend().get()->supportsPartialTensors())
+        << "Backend " << ExecutionBackend
+        << " doesn't support partial tensor but enablePartialTensor is set to "
+           "true.";
+  }
   cctx.saturateHost = glowSaturateHost;
   EXIT_ON_ERR(hostManager->addNetwork(std::move(mod), cctx));
 


### PR DESCRIPTION
Summary:
If a backend doesn't support partial tensor and we set `enablePartialTensor` to true in repro tool, the unpadded part will contain uninitialized memory content instead of zeros, hence causing surprising errors. This diff adds the check to avoid such surprise and remind user explicitly.

It also fixes a UB.

Differential Revision: D23801621

