### PR TITLE
Print less values for Node vector member

### DIFF
--- a/include/glow/Support/Support.h
+++ b/include/glow/Support/Support.h
@@ -45,11 +45,16 @@ template <typename Stream, typename E>
 Stream &operator<<(Stream &os, const llvm::ArrayRef<E> list) {
   os << '[';
   // Print the array without a trailing comma.
-  for (size_t i = 0, e = list.size(); i < e; i++) {
+  // Only up to `limit` elements will be printed.
+  for (size_t i = 0, e = list.size(), limit = 4; i < e && i <= limit; i++) {
     if (i) {
       os << ", ";
     }
-    os << list[i];
+    if (i == limit) {
+      os << "...";
+    } else {
+      os << list[i];
+    }
   }
   os << ']';
 

--- a/tests/unittests/SupportTest.cpp
+++ b/tests/unittests/SupportTest.cpp
@@ -144,3 +144,15 @@ TEST(Support, ScopeGuardDismissAndRunAndDismiss) {
   }
   EXPECT_EQ(val, 1);
 }
+
+TEST(Support, ArrayRefPrinting) {
+  // Check that when printing ArrayRef,
+  // the elements are omitted when reached limit and vice versa.
+  const std::vector<int> shortVec(4, 0);
+  const std::vector<int> longVec(5, 0);
+  const llvm::ArrayRef<int> shortArr(shortVec);
+  const llvm::ArrayRef<int> longArr(longVec);
+  std::ostringstream oss;
+  oss << shortArr << longArr;
+  EXPECT_TRUE(oss.str().compare("[0, 0, 0, 0][0, 0, 0, 0, ...]") == 0);
+}


### PR DESCRIPTION
Summary: When printing a vector member in the node, only print the first 4 elements and end with "..." if there're some elements left unprinted.

Reviewed By: jfix71

Differential Revision: D23794310

Fixes https://github.com/pytorch/glow/issues/4805
