### PR TITLE
[ONNXImporter] Allow ONNX initializer to use int32_data for bool.

### DIFF
--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -664,6 +664,14 @@ Error glow::loadTensor(const ONNX_NAMESPACE::TensorProto &in, Tensor *T,
     if (in.has_raw_data()) {
       std::istringstream inStream(in.raw_data(), std::stringstream::binary);
       inStream.read(T->getUnsafePtr(), T->size() * sizeof(bool));
+    } else if (in.int32_data_size() > 0) {
+      // Some ONNX models use int32_data to initialize bool type (e.g., when
+      // converted from Keras).
+      auto TH = T->getHandle<bool>();
+      size_t i = 0;
+      for (auto f : in.int32_data()) {
+        TH.raw(i++) = (bool)f;
+      }
     } else {
       RETURN_ERR("Unsupported Tensor format for BOOL, name: " + in.name(),
                  ErrorValue::ErrorCode::MODEL_LOADER_UNSUPPORTED_DATATYPE);

--- a/tests/models/onnxModels/bool_from_int.onnxtxt
+++ b/tests/models/onnxModels/bool_from_int.onnxtxt
@@ -1,0 +1,35 @@
+ir_version: 6
+producer_name: "onnx-example"
+
+graph {
+  node {
+    input: "input0"
+    output: "output0"
+    op_type: "Identity"
+  }
+  initializer {
+    dims: 3
+    data_type: 9
+    int32_data: 1
+    int32_data: 0
+    int32_data: 1
+    name: "input0"
+  }
+  output {
+    name: "output0"
+    type {
+      tensor_type {
+        elem_type: 9
+        shape {
+          dim {
+            dim_value: 3
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 11
+}
+

--- a/tests/unittests/OnnxExporterTest.cpp
+++ b/tests/unittests/OnnxExporterTest.cpp
@@ -420,6 +420,7 @@ TEST(exporter, onnxModels) {
     }
     if (name.find("constant.onnxtxt") != std::string::npos ||
         name.find("shape.onnxtxt") != std::string::npos ||
+        name.find("bool_from_int.onnxtxt") != std::string::npos ||
         name.find("sum1.onnxtxt") != std::string::npos) {
       // Ignore invalid ONNX files and graphs without nodes.
       llvm::outs() << "Ignore empty graph file: " << name << "\n";

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -4249,6 +4249,30 @@ static void importResizeBilinear(std::string filename) {
                                           {bindings.get(output)}));
 }
 
+TEST_F(OnnxImporterTest, importBoolFromInt) {
+  ExecutionEngine EE;
+  auto &mod = EE.getModule();
+  std::string netFilename(GLOW_DATA_PATH
+                          "tests/models/onnxModels/bool_from_int.onnxtxt");
+  auto *F = mod.createFunction("main");
+  PlaceholderBindings bindings;
+  Placeholder *output;
+  {
+    ONNXModelLoader onnxLD(netFilename, {}, {}, *F);
+    output = EXIT_ON_ERR(onnxLD.getSingleOutput());
+    ASSERT_TRUE(output);
+  }
+
+  EE.compile(CompilationMode::Infer);
+  bindings.allocate(mod.getPlaceholders());
+  EE.run(bindings);
+
+  std::vector<bool> expectedOut = {true, false, true};
+  auto result = bindings.get(output)->getHandle<bool>();
+  for (size_t i = 0; i < result.getType().size(); i++)
+    EXPECT_EQ(result.raw(i), expectedOut[i]);
+}
+
 /// ResizeNearest Test Helper.
 TEST(onnx, importResizeBilinear) {
   std::string netFilename(GLOW_DATA_PATH


### PR DESCRIPTION
Author: Jun Bum Lim <junlim@cadence.com>

Summary:
Allow ONNX initializer to use int32_data for bool. Some ONNX models converted from Keras use int32_data to initialize bool type.

Documentation:
N/A

Test Plan:
Added ONNXImporter unit test.
