### PR TITLE
[ONNXImporter] Add support for ONNX opset 11 Clip operator.

### DIFF
--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -1067,24 +1067,6 @@ protected:
     return Error::success();
   }
 
-  Error loadClip(const OpType &op, ArgumentDictionaryTy &dict) {
-    NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
-    float cmin = std::numeric_limits<float>::lowest();
-    if (dict.count("min")) {
-      ASSIGN_VALUE_OR_RETURN_ERR(cmin, loadFloat(dict.find("min")->second));
-    }
-
-    float cmax = std::numeric_limits<float>::max();
-    if (dict.count("max")) {
-      ASSIGN_VALUE_OR_RETURN_ERR(cmax, loadFloat(dict.find("max")->second));
-    }
-
-    auto *node = G_->createClip(loadOperatorName(op), in, cmin, cmax);
-    RETURN_IF_ERR(addNodeAsOutput(op, node));
-    return Error::success();
-  }
-
   Error loadSparseToDense(const OpType &op, ArgumentDictionaryTy &dict) {
     if (op.input_size() != 3) {
       RETURN_ERR("SparseToDense operator must have three inputs.");
@@ -1412,10 +1394,6 @@ protected:
     }
     if (typeName == "ExpandDims") {
       RETURN_IF_ERR(loadExpandDims(op, dict));
-      return true;
-    }
-    if (typeName == "Clip") {
-      RETURN_IF_ERR(loadClip(op, dict));
       return true;
     }
     if (typeName == "SparseToDense") {

--- a/include/glow/Importer/ONNXModelLoader.h
+++ b/include/glow/Importer/ONNXModelLoader.h
@@ -295,6 +295,10 @@ class ONNXModelLoader
   Error loadLSTM(const ONNX_NAMESPACE::NodeProto &op,
                  ArgumentDictionaryTy &dict);
 
+  /// Load Clip ONNX operator.
+  Error loadClip(const ONNX_NAMESPACE::NodeProto &op,
+                 const ArgumentDictionaryTy &dict);
+
   /// Load Glow specific operators, not defined in ONNX format
   /// Load Glow CmpEQ operator.
   Error loadCmpEQ(const ONNX_NAMESPACE::NodeProto &op,

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -1234,6 +1234,24 @@ Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     return Error::success();
   }
 
+  if (typeName == "Clip") {
+    NodeValue in;
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
+    float cmin = std::numeric_limits<float>::lowest();
+    if (dict.count("min")) {
+      ASSIGN_VALUE_OR_RETURN_ERR(cmin, loadFloat(dict.find("min")->second));
+    }
+
+    float cmax = std::numeric_limits<float>::max();
+    if (dict.count("max")) {
+      ASSIGN_VALUE_OR_RETURN_ERR(cmax, loadFloat(dict.find("max")->second));
+    }
+
+    auto *node = G_->createClip(loadOperatorName(op), in, cmin, cmax);
+    RETURN_IF_ERR(addNodeAsOutput(op, node));
+    return Error::success();
+  }
+
   if (typeName == "MatMul") {
     RETURN_IF_ERR(loadBatchMatMul(op, dict, false));
     return Error::success();

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -3224,6 +3224,36 @@ Error ONNXModelLoader::loadLSTM(const ONNX_NAMESPACE::NodeProto &op,
   return Error::success();
 }
 
+Error ONNXModelLoader::loadClip(const ONNX_NAMESPACE::NodeProto &op,
+                                const ArgumentDictionaryTy &dict) {
+  NodeValue in;
+  ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
+
+  float cmin = std::numeric_limits<float>::lowest();
+  if (opsetVersion_ > 10 && op.input_size() > 1) {
+    Constant *minC = getConstantByNameOrNull(op.input(1));
+    RETURN_ERR_IF_NOT(minC, "Expect constant for min value in Clip operator.");
+    cmin = minC->getPayload().getHandle().raw(0);
+  } else if (dict.count("min")) {
+    ASSIGN_VALUE_OR_RETURN_ERR(cmin, loadFloat(dict.find("min")->second));
+  }
+
+  // Windows headers define `max` macro, so have to wrap the function name in
+  // parenthesis to avoid compilation error.
+  float cmax = (std::numeric_limits<float>::max)();
+  if (opsetVersion_ > 10 && op.input_size() > 2) {
+    Constant *maxC = getConstantByNameOrNull(op.input(2));
+    RETURN_ERR_IF_NOT(maxC, "Expect constant for max value in Clip operator.");
+    cmax = maxC->getPayload().getHandle().raw(0);
+  } else if (dict.count("max")) {
+    ASSIGN_VALUE_OR_RETURN_ERR(cmax, loadFloat(dict.find("max")->second));
+  }
+
+  auto *node = G_->createClip(loadOperatorName(op), in, cmin, cmax);
+  RETURN_IF_ERR(addNodeAsOutput(op, node));
+  return Error::success();
+}
+
 Error ONNXModelLoader::loadCmpEQ(const ONNX_NAMESPACE::NodeProto &op,
                                  ArgumentDictionaryTy &dict) {
   NodeValue LHS;
@@ -4222,6 +4252,9 @@ Error ONNXModelLoader::loadOperator(const ONNX_NAMESPACE::NodeProto &op) {
   }
   if (typeName == "LSTM") {
     return loadLSTM(op, dict);
+  }
+  if (typeName == "Clip") {
+    return loadClip(op, dict);
   }
   // Glow specific operators
   if (typeName == "CmpEQ") {

--- a/tests/models/onnxModels/clipv11.onnxtxt
+++ b/tests/models/onnxModels/clipv11.onnxtxt
@@ -1,0 +1,65 @@
+ir_version: 6
+producer_name: "onnx-ex"
+graph {
+  node {
+    input: "X"
+    input: "min"
+    input: "max"
+    output: "output0"
+    op_type: "Clip"
+  }
+  name: "graph"
+  initializer {
+    data_type: 1
+    float_data: -2.0
+    name: "min"
+  }
+  initializer {
+    data_type: 1
+    float_data: 2.0
+    name: "max"
+  }
+  input {
+    name: "X"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "output0"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+          }
+          dim {
+          }
+          dim {
+          }
+          dim {
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 11
+}

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -4671,3 +4671,37 @@ TEST(onnx, importNames) {
     currNode = prevNode;
   }
 }
+
+TEST(onnx, importClipV11) {
+  // Test loading Clip in opset v11 format where min(-2) and max(2) are passed
+  // as inputs.
+  ExecutionEngine EE;
+  auto &mod = EE.getModule();
+  std::string netFilename(GLOW_DATA_PATH
+                          "tests/models/onnxModels/clipv11.onnxtxt");
+  auto *F = mod.createFunction("main");
+  PlaceholderBindings bindings;
+  Placeholder *output_0;
+
+  Tensor X(ElemKind::FloatTy, {1, 2, 2, 2});
+  X.getHandle() = {-3, -2, -1, 0, 1, 2, 3, 4};
+
+  {
+    ONNXModelLoader onnxLD(netFilename, {"X"}, {&X.getType()}, *F);
+    output_0 = EXIT_ON_ERR(onnxLD.getOutputByName("output0"));
+    bindings.allocate(mod.getPlaceholders());
+    updateInputPlaceholdersByName(bindings, &mod, {"X"}, {&X});
+  }
+
+  EE.compile(CompilationMode::Infer);
+  EE.run(bindings);
+
+  std::vector<dim_t> expectedDims = {1, 2, 2, 2};
+  std::vector<float> expectedValues = {-2, -2, -1, 0, 1, 2, 2, 2};
+  auto result = bindings.get(output_0)->getHandle();
+  EXPECT_EQ(result.dims().vec(), expectedDims);
+
+  for (size_t i = 0; i < 8; i++) {
+    EXPECT_FLOAT_EQ(result.raw(i), expectedValues[i]);
+  }
+}


### PR DESCRIPTION
Author: Jun Bum Lim <junlim@cadence.com>

Summary:
Add support for ONNX opset 11 Clip operator.

Documentation:
N/A

Test Plan:
ONNXImporter unit test.
