### PR TITLE
Add support for Convert from Bool to Int32 in Interpreter and CPU backends.

### DIFF
--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -5139,6 +5139,7 @@ void BoundInterpreterFunction::fwdConvertToInst(const glow::ConvertToInst *I) {
   CONVERT(int64_t, float16_t, ElemKind::Int64ITy, ElemKind::Float16Ty)
   CONVERT(int64_t, bfloat16_t, ElemKind::Int64ITy, ElemKind::BFloat16Ty)
   CONVERT(int64_t, int32_t, ElemKind::Int64ITy, ElemKind::Int32ITy)
+  CONVERT(bool, int32_t, ElemKind::BoolTy, ElemKind::Int32ITy)
 #undef CONVERT
 
   if (srcElType == ElemKind::UInt8FusedQTy &&

--- a/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
@@ -348,6 +348,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "ConvertFrom_Int64ITy_To_Int32ITy_AndBack/0",
     "ConvertFrom_BoolTy_To_FloatTy/0",
     "ConvertFrom_BoolTy_To_Float16Ty/0",
+    "ConvertFrom_BoolTy_To_Int32ITy/0",
     "BasicDivNetFloatVsInt8/0",
     "BasicAddNetFloatVsFloat16/0",
     "BasicSubNetFloatVsFloat16/0",

--- a/lib/LLVMIRCodeGen/LLVMBackend.cpp
+++ b/lib/LLVMIRCodeGen/LLVMBackend.cpp
@@ -519,7 +519,9 @@ bool LLVMBackend::isOpSupported(const NodeInfo &NI) const {
             (NI.getOutElemTy(ConvertToNode::ResultIdx) ==
              ElemKind::Int64ITy)) ||
            ((NI.getInElemTy(ConvertToNode::InputIdx) == ElemKind::FloatTy) &&
-            (NI.getOutElemTy(ConvertToNode::ResultIdx) == ElemKind::BoolTy));
+            (NI.getOutElemTy(ConvertToNode::ResultIdx) == ElemKind::BoolTy)) ||
+           ((NI.getInElemTy(ConvertToNode::InputIdx) == ElemKind::BoolTy) &&
+            (NI.getOutElemTy(ConvertToNode::ResultIdx) == ElemKind::Int32ITy));
 
   default:
     return false;

--- a/lib/LLVMIRCodeGen/libjit/libjit.cpp
+++ b/lib/LLVMIRCodeGen/libjit/libjit.cpp
@@ -3081,6 +3081,12 @@ void libjit_convertTo_u_i32(int64_t *dstPtr, const int32_t *srcPtr,
                                                        numDims);
 }
 
+void libjit_convertTo_i32_b(int32_t *dstPtr, const bool *srcPtr,
+                            const dim_t *dims, dim_t numDims) {
+  libjit_copy_kernel_with_conversion<int32_t, bool>(dstPtr, srcPtr, dims,
+                                                    numDims);
+}
+
 /// Update min/max values \p compInfo and histogram \p existingHistogram with
 /// data collected from tensor \p inputTensor.
 /// Note: code ported from Profile.cpp: generateTensorHistogram

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -16098,6 +16098,7 @@ TEST_CONVERT_TO(int64_t, int64_t, Int64ITy, Int64ITy)
 TEST_CONVERT_TO(bool, float, BoolTy, FloatTy)
 TEST_CONVERT_TO(bool, float16_t, BoolTy, Float16Ty)
 TEST_CONVERT_TO(bool, bfloat16_t, BoolTy, BFloat16Ty)
+TEST_CONVERT_TO(bool, int32_t, BoolTy, Int32ITy)
 
 #undef TEST_CONVERT_TO
 


### PR DESCRIPTION
Author: Jun Bum Lim <junlim@cadence.com>

Summary:
Add support for Convert from Bool to Int32 in Interpreter and CPU backends.

Documentation:
N/A

Test Plan:
Extended operator unit test.