### PR TITLE
[AvgPool]Add Flag to Not Include Pads When Normalizing Average Pooling

### DIFF
--- a/include/glow/Backends/LayoutConverter.h
+++ b/include/glow/Backends/LayoutConverter.h
@@ -125,9 +125,9 @@ inline Node *convertAvgPoolToNCHWPool(AvgPoolNode *PN, Function *F) {
   auto outTy = F->getParent()->uniqueTypeWithNewShape(PN->getResult().getType(),
                                                       dimsNCHW);
 
-  auto *NPN =
-      F->addNode(new AvgPoolNode(PN->getName(), outTy, NI, PN->getKernels(),
-                                 PN->getStrides(), PN->getPads(), NCHW));
+  auto *NPN = F->addNode(new AvgPoolNode(
+      PN->getName(), outTy, NI, PN->getKernels(), PN->getStrides(),
+      PN->getPads(), NCHW, PN->getCountIncludePads()));
   auto *NR = F->createTranspose("avgpool.result", NPN->getResult(), NCHW2NHWC);
 
   return NR;
@@ -143,9 +143,9 @@ inline Node *convertAvgPoolGradToNCHWPool(AvgPoolGradNode *PGN, Function *F) {
       F->createTranspose("avgpoolgrad.outputgrad",
                          PGN->getGradOfOriginalOutputNamedResult(), NHWC2NCHW);
 
-  auto *NPGN = F->addNode(
-      new AvgPoolGradNode(PGN->getName(), NI, NO, NG, PGN->getKernels(),
-                          PGN->getStrides(), PGN->getPads(), NCHW));
+  auto *NPGN = F->addNode(new AvgPoolGradNode(
+      PGN->getName(), NI, NO, NG, PGN->getKernels(), PGN->getStrides(),
+      PGN->getPads(), NCHW, PGN->getCountIncludePads()));
   auto *NR = F->createTranspose("avgpoolgrad.result",
                                 NPGN->getGradOfInputNamedInput(), NCHW2NHWC);
 

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -603,17 +603,20 @@ public:
                              llvm::ArrayRef<unsigned_t> kernels,
                              llvm::ArrayRef<unsigned_t> strides,
                              llvm::ArrayRef<unsigned_t> pads,
-                             ConvolutionLayout layout = NHWC);
+                             ConvolutionLayout layout = NHWC,
+                             bool countIncludePads = true);
 
   AvgPoolNode *createAvgPool(llvm::StringRef name, NodeValue input,
                              TypeRef outTy, llvm::ArrayRef<unsigned_t> kernels,
                              llvm::ArrayRef<unsigned_t> strides,
                              llvm::ArrayRef<unsigned_t> pads,
-                             ConvolutionLayout layout = NHWC);
+                             ConvolutionLayout layout = NHWC,
+                             bool countIncludePads = true);
 
   AvgPoolNode *createAvgPool(llvm::StringRef name, NodeValue input,
                              unsigned_t kernel, unsigned_t stride,
-                             unsigned_t pad, ConvolutionLayout layout = NHWC);
+                             unsigned_t pad, ConvolutionLayout layout = NHWC,
+                             bool countIncludePads = true);
 
   /// Creates and \returns an AdaptiveAvgPool node with \p name, \p input, and
   /// \p outTy. The AdaptiveAvgPoolNode will perform average pooling over the

--- a/include/glow/IR/IRBuilder.h
+++ b/include/glow/IR/IRBuilder.h
@@ -64,7 +64,7 @@ public:
   AvgPoolInst *createAvgPoolOp(Value *input, llvm::ArrayRef<unsigned_t> kernels,
                                llvm::ArrayRef<unsigned_t> strides,
                                llvm::ArrayRef<unsigned_t> pads,
-                               unsigned_t layout);
+                               unsigned_t layout, bool countIncludePads);
 
   CrossEntropyLossInst *createCrossEntropyLossOp(llvm::StringRef name, Value *P,
                                                  Value *labels);

--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -1597,6 +1597,18 @@ protected:
 
     return Error::success();
   }
+
+  static Expected<bool> getCountIncludePads(ArgumentDictionaryTy &dict,
+                                            bool defaultValue) {
+    if (dict.count("count_include_pad")) {
+      int countIncludePads;
+      ASSIGN_VALUE_OR_RETURN_ERR(countIncludePads,
+                                 loadInt(dict.at("count_include_pad")));
+      return (bool)countIncludePads;
+    }
+    // Return default value if can't find in the dict
+    return defaultValue;
+  }
 };
 
 } // namespace glow

--- a/lib/Backends/NNPI/Importer.cpp
+++ b/lib/Backends/NNPI/Importer.cpp
@@ -682,6 +682,10 @@ public:
     std::vector<uint32_t> paddingStart(numDims);
     std::vector<uint32_t> paddingEnd(numDims);
     std::vector<uint32_t> stride(numDims);
+    bool countIncludePads = 1;
+    if (auto *APN = llvm::dyn_cast<AvgPoolNode>(glowPool)) {
+      countIncludePads = APN->getCountIncludePads();
+    }
 
     for (size_t i = 0; i < numDims; i++) {
       kernel[i] = glowPool->getKernels()[i];
@@ -715,7 +719,7 @@ public:
         nodeValueName(glowPool->getInput()).c_str(),
         nodeValueName(glowPool->getResult()).c_str(), NULL, kernel.data(),
         paddingStart.data(), paddingEnd.data(), stride.data(), numDims,
-        poolType, 0, 0);
+        poolType, !countIncludePads, 0);
   }
 };
 

--- a/lib/Backends/NNPI/tests/NNPIGradCheckTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIGradCheckTest.cpp
@@ -30,6 +30,8 @@ struct BlacklistInitializer {
             {"gradientCheckGroupConv/0", TestBlacklist::AnyDeviceAnyEngine},
             {"gradientCheckDilatedConv/0", TestBlacklist::AnyDeviceAnyEngine},
             {"gradientCheckAvgPool/0", TestBlacklist::AnyDeviceAnyEngine},
+            {"gradientCheckAvgPoolCountExcludePads/0",
+             TestBlacklist::AnyDeviceAnyEngine},
             {"gradientCheckMaxPool/0", TestBlacklist::AnyDeviceAnyEngine},
             {"gradientCheckAdaptiveAvgPool/0",
              TestBlacklist::AnyDeviceAnyEngine},

--- a/lib/Backends/OpenCL/tests/OpenCLGradCheckTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLGradCheckTest.cpp
@@ -19,6 +19,7 @@ using namespace glow;
 
 std::set<std::string> glow::backendTestBlacklist = {
     "gradientCheckAvgPool/0",
+    "gradientCheckAvgPoolCountExcludePads/0",
     "gradientCheckAdaptiveAvgPool/0",
     "gradientCheckCrossEntropyLoss/0",
     "gradientCheckTile/0",

--- a/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
@@ -176,6 +176,8 @@ std::set<std::string> glow::backendTestBlacklist = {
     "AdaptiveAvgPool/0",
     "FP16AdaptiveAvgPool/0",
     "Int8AdaptiveAvgPool/0",
+    "AvgPoolCountExcludePads/0",
+    "Int8AvgPoolCountExcludePads/0",
     "AdaptiveAvgPoolNonSquare/0",
     "FP16MaxPool/0",
     "QuantizedMaxPoolWithArgmax/0",

--- a/lib/Exporter/ONNXModelWriter.cpp
+++ b/lib/Exporter/ONNXModelWriter.cpp
@@ -1994,6 +1994,10 @@ void writeTensorwiseQuantizedPool(const T *node, const std::string &op,
   addValueAttribute(proto, "strides", node->getStrides());
   addValueAttribute(proto, "pads", node->getPads());
 
+  if (auto *APN = llvm::dyn_cast<AvgPoolNode>(node)) {
+    addValueAttribute(proto, "count_include_pad", APN->getCountIncludePads());
+  }
+
   proto->add_input(node->getInput().getNode()->getName());
   outputsToProto(node, graph, proto);
 
@@ -2035,6 +2039,10 @@ void writePool(const T *node, const std::string &op,
   addValueAttribute(proto, "kernel_shape", node->getKernels());
   addValueAttribute(proto, "strides", node->getStrides());
   addValueAttribute(proto, "pads", node->getPads());
+
+  if (auto *APN = llvm::dyn_cast<AvgPoolNode>(node)) {
+    addValueAttribute(proto, "count_include_pad", APN->getCountIncludePads());
+  }
 
   const Node *input = node->getInput().getNode();
   if (const TransposeNode *TN = llvm::dyn_cast<TransposeNode>(input)) {

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -969,7 +969,8 @@ AvgPoolNode *Function::createAvgPool(llvm::StringRef name, NodeValue input,
                                      llvm::ArrayRef<unsigned_t> kernels,
                                      llvm::ArrayRef<unsigned_t> strides,
                                      llvm::ArrayRef<unsigned_t> pads,
-                                     ConvolutionLayout layout) {
+                                     ConvolutionLayout layout,
+                                     bool countIncludePads) {
   if (!is3DData(layout)) {
 
     ShapeNHWC idim = ShapeNHWC(input.dims());
@@ -979,8 +980,8 @@ AvgPoolNode *Function::createAvgPool(llvm::StringRef name, NodeValue input,
         calculateConvPoolOutputDims(idim.h, idim.w, kernels, strides, pads);
     auto OT = getParent()->uniqueTypeWithNewShape(
         input.getType(), {idim.n, outSz.first, outSz.second, idim.c});
-    return addNode(
-        new AvgPoolNode(name, OT, input, kernels, strides, pads, layout));
+    return addNode(new AvgPoolNode(name, OT, input, kernels, strides, pads,
+                                   layout, countIncludePads));
 
   } else {
     ShapeNTHWC idim = ShapeNTHWC(input.dims());
@@ -991,8 +992,8 @@ AvgPoolNode *Function::createAvgPool(llvm::StringRef name, NodeValue input,
     auto OT = getParent()->uniqueTypeWithNewShape(
         input.getType(),
         {idim.n, outSz.temporal_frames, outSz.height, outSz.width, idim.c});
-    return addNode(
-        new AvgPoolNode(name, OT, input, kernels, strides, pads, layout));
+    return addNode(new AvgPoolNode(name, OT, input, kernels, strides, pads,
+                                   layout, countIncludePads));
   }
 }
 
@@ -1001,15 +1002,16 @@ AvgPoolNode *Function::createAvgPool(llvm::StringRef name, NodeValue input,
                                      llvm::ArrayRef<unsigned_t> kernels,
                                      llvm::ArrayRef<unsigned_t> strides,
                                      llvm::ArrayRef<unsigned_t> pads,
-                                     ConvolutionLayout layout) {
+                                     ConvolutionLayout layout,
+                                     bool countIncludePads) {
   if (!is3DData(layout)) {
 
     ShapeNHWC idim = ShapeNHWC(input.dims());
     ShapeHW kdim(kernels);
     (void)kdim;
     checkKernelSize(idim, kernels, pads);
-    return addNode(
-        new AvgPoolNode(name, outTy, input, kernels, strides, pads, layout));
+    return addNode(new AvgPoolNode(name, outTy, input, kernels, strides, pads,
+                                   layout, countIncludePads));
 
   } else {
 
@@ -1017,27 +1019,30 @@ AvgPoolNode *Function::createAvgPool(llvm::StringRef name, NodeValue input,
     ShapeTHW kdim(kernels);
     (void)kdim;
     check3DKernelSize(idim, kernels, pads);
-    return addNode(
-        new AvgPoolNode(name, outTy, input, kernels, strides, pads, layout));
+    return addNode(new AvgPoolNode(name, outTy, input, kernels, strides, pads,
+                                   layout, countIncludePads));
   }
 }
 
 AvgPoolNode *Function::createAvgPool(llvm::StringRef name, NodeValue input,
                                      unsigned_t kernel, unsigned_t stride,
-                                     unsigned_t pad, ConvolutionLayout layout) {
+                                     unsigned_t pad, ConvolutionLayout layout,
+                                     bool countIncludePads) {
   if (!is3DData(layout)) {
 
     llvm::SmallVector<unsigned_t, 4> pads = {pad, pad, pad, pad};
     llvm::SmallVector<unsigned_t, 2> strides = {stride, stride};
     llvm::SmallVector<unsigned_t, 2> kernels = {kernel, kernel};
-    return createAvgPool(name, input, kernels, strides, pads, layout);
+    return createAvgPool(name, input, kernels, strides, pads, layout,
+                         countIncludePads);
 
   } else {
 
     llvm::SmallVector<unsigned_t, 6> pads = {pad, pad, pad, pad, pad, pad};
     llvm::SmallVector<unsigned_t, 3> strides = {stride, stride, stride};
     llvm::SmallVector<unsigned_t, 3> kernels = {kernel, kernel, kernel};
-    return createAvgPool(name, input, kernels, strides, pads, layout);
+    return createAvgPool(name, input, kernels, strides, pads, layout,
+                         countIncludePads);
   }
 }
 

--- a/lib/IR/IRBuilder.cpp
+++ b/lib/IR/IRBuilder.cpp
@@ -109,7 +109,8 @@ AvgPoolInst *IRBuilder::createAvgPoolOp(Value *input,
                                         llvm::ArrayRef<unsigned_t> kernels,
                                         llvm::ArrayRef<unsigned_t> strides,
                                         llvm::ArrayRef<unsigned_t> pads,
-                                        unsigned_t layout) {
+                                        unsigned_t layout,
+                                        bool countIncludePads) {
 
   TypeRef outTy;
 
@@ -128,7 +129,8 @@ AvgPoolInst *IRBuilder::createAvgPoolOp(Value *input,
   }
 
   Value *dest = createAllocActivationInst("pool.res", outTy);
-  return createAvgPoolInst("pool", dest, input, kernels, strides, pads, layout);
+  return createAvgPoolInst("pool", dest, input, kernels, strides, pads, layout,
+                           countIncludePads);
 }
 
 CrossEntropyLossInst *IRBuilder::createCrossEntropyLossOp(llvm::StringRef name,

--- a/lib/IR/IRGen.cpp
+++ b/lib/IR/IRGen.cpp
@@ -198,9 +198,9 @@ void IRGenVisitor::post(Node *parent, Node *N) {
     auto *inG = builder_.createAllocActivationInst(
         DECORATE_NODE_NAME(N, "outG"), PG->getInput().getType());
 
-    builder_.createAvgPoolGradInst(N->getName(), outW, inW, outG, inG,
-                                   PG->getKernels(), PG->getStrides(),
-                                   PG->getPads(), PG->getLayout());
+    builder_.createAvgPoolGradInst(
+        N->getName(), outW, inW, outG, inG, PG->getKernels(), PG->getStrides(),
+        PG->getPads(), PG->getLayout(), PG->getCountIncludePads());
     registerIR(PG->getGradOfInputNamedInput(), inG);
     break;
   }

--- a/lib/LLVMIRCodeGen/libjit/libjit.cpp
+++ b/lib/LLVMIRCodeGen/libjit/libjit.cpp
@@ -2526,7 +2526,6 @@ void libjit_avg_pool_i8(const int8_t *inW, int8_t *outW, const dim_t *inWdims,
                      inOffset;
             }
           }
-
           outW[libjit_getXYZW(outWdims, n, ax, ay, z)] = libjit_clip(
               libjit_scale_i32i8(sum, outPre, outPost, outScale, outOffset));
         } // C
@@ -2535,16 +2534,64 @@ void libjit_avg_pool_i8(const int8_t *inW, int8_t *outW, const dim_t *inWdims,
   }       // N
 }
 
-void libjit_avg_pool_f(const float *inW, float *outW, const dim_t *inWdims,
-                       const dim_t *outWdims, dim_t *kernelSizes,
-                       dim_t *strides, dim_t *pads) {
+void libjit_avg_pool_count_exclude_pad_i8(
+    const int8_t *inW, int8_t *outW, const dim_t *inWdims,
+    const dim_t *outWdims, dim_t *kernelSizes, dim_t *strides, dim_t *pads,
+    int32_t inOffset, int32_t outOffset, float inScale, float outScale) {
   dim_t pad_t = pads[0];
   dim_t pad_l = pads[1];
   dim_t stride_h = strides[0];
   dim_t stride_w = strides[1];
   dim_t kernel_h = kernelSizes[0];
   dim_t kernel_w = kernelSizes[1];
-  float filterArea = kernel_h * kernel_w;
+
+  float rawFilterArea = kernel_h * kernel_w;
+  // For each input in the batch:
+  for (dim_t n = 0; n < outWdims[0]; n++) {
+    // For each (x,y) step in the input/output tensor:
+    sdim_t x = -sdim_t(pad_t);
+    for (dim_t ax = 0; ax < outWdims[1]; x += stride_h, ax++) {
+      sdim_t y = -sdim_t(pad_l);
+      for (dim_t ay = 0; ay < outWdims[2]; y += stride_w, ay++) {
+        // For each layer in the output tensor:
+        for (dim_t z = 0; z < inWdims[3]; z++) {
+          int32_t sum = 0;
+          float filterArea = rawFilterArea;
+
+          for (dim_t fx = 0; fx < kernel_h; fx++) {
+            for (dim_t fy = 0; fy < kernel_w; fy++) {
+              sdim_t ox = x + fx;
+              sdim_t oy = y + fy;
+
+              // Ignore index access below zero (this is due to padding).
+              if (ox < 0 || oy < 0 || ox >= (sdim_t)inWdims[1] ||
+                  oy >= (sdim_t)inWdims[2]) {
+                filterArea--;
+                continue;
+              }
+              sum += inW[libjit_getXYZW(inWdims, n, (dim_t)ox, (dim_t)oy, z)] -
+                     inOffset;
+            }
+          }
+          assert(filterArea != 0 && "FilterArea can't be 0");
+          outW[libjit_getXYZW(outWdims, n, ax, ay, z)] = libjit_clip(round(
+              float(sum) * (inScale / outScale / filterArea) + outOffset));
+        } // C
+      }   // W
+    }     // H
+  }       // N
+}
+
+void libjit_avg_pool_f(const float *inW, float *outW, const dim_t *inWdims,
+                       const dim_t *outWdims, dim_t *kernelSizes,
+                       dim_t *strides, dim_t *pads, bool countIncludePads) {
+  dim_t pad_t = pads[0];
+  dim_t pad_l = pads[1];
+  dim_t stride_h = strides[0];
+  dim_t stride_w = strides[1];
+  dim_t kernel_h = kernelSizes[0];
+  dim_t kernel_w = kernelSizes[1];
+  float rawFilterArea = kernel_h * kernel_w;
   // For each input in the batch:
   for (dim_t n = 0; n < outWdims[0]; n++) {
     // For each (x,y) step in the input/output tensor:
@@ -2556,6 +2603,7 @@ void libjit_avg_pool_f(const float *inW, float *outW, const dim_t *inWdims,
         for (dim_t z = 0; z < inWdims[3]; z++) {
 
           float sum = 0;
+          float filterArea = rawFilterArea;
 
           for (dim_t fx = 0; fx < kernel_h; fx++) {
             for (dim_t fy = 0; fy < kernel_w; fy++) {
@@ -2565,6 +2613,10 @@ void libjit_avg_pool_f(const float *inW, float *outW, const dim_t *inWdims,
               // Ignore index access below zero (this is due to padding).
               if (ox < 0 || oy < 0 || ox >= (sdim_t)inWdims[1] ||
                   oy >= (sdim_t)inWdims[2]) {
+                if (!countIncludePads) {
+                  filterArea--;
+                }
+
                 continue;
               }
 
@@ -2572,6 +2624,7 @@ void libjit_avg_pool_f(const float *inW, float *outW, const dim_t *inWdims,
             }
           }
 
+          assert(filterArea != 0 && "FilterArea shouldn't be 0");
           outW[libjit_getXYZW(outWdims, n, ax, ay, z)] = sum / filterArea;
         } // C
       }   // W
@@ -2620,14 +2673,15 @@ void libjit_adaptive_avg_pool_f(const float *inW, float *outW,
 
 void libjit_avg_pool_grad_f(float *inG, const float *outG, const dim_t *inGdims,
                             const dim_t *outWdims, dim_t *kernels,
-                            dim_t *strides, dim_t *pads) {
+                            dim_t *strides, dim_t *pads,
+                            bool countIncludePads) {
   dim_t pad_t = pads[0];
   dim_t pad_l = pads[1];
   dim_t stride_h = strides[0];
   dim_t stride_w = strides[1];
   dim_t kernel_h = kernels[0];
   dim_t kernel_w = kernels[1];
-  float kernelArea = kernel_h * kernel_w;
+  float rawKernelArea = kernel_h * kernel_w;
 
   // NHWC format is assumed
   for (dim_t n = 0; n < outWdims[0]; n++) {
@@ -2643,6 +2697,22 @@ void libjit_avg_pool_grad_f(float *inG, const float *outG, const dim_t *inGdims,
       for (dim_t ax = 0; ax < outWdims[1]; x += stride_h, ax++) {
         sdim_t y = -(sdim_t)pad_l;
         for (dim_t ay = 0; ay < outWdims[2]; y += stride_w, ay++) {
+          float kernelArea = rawKernelArea;
+
+          if (!countIncludePads) {
+            sdim_t pad_x = (-x > 0 ? -x : 0) +
+                           ((x + sdim_t(kernel_h) - sdim_t(inGdims[1])) > 0
+                                ? (x + sdim_t(kernel_h) - sdim_t(inGdims[1]))
+                                : 0);
+            sdim_t pad_y = (-y > 0 ? -y : 0) +
+                           ((y + sdim_t(kernel_w) - sdim_t(inGdims[2])) > 0
+                                ? (y + sdim_t(kernel_w) - sdim_t(inGdims[2]))
+                                : 0);
+            kernelArea = rawKernelArea - pad_x * kernel_w - pad_y * kernel_h +
+                         pad_x * pad_y;
+          }
+
+          assert(kernelArea != 0 && "KernelArea shouldn't be 0");
           float df = outG[libjit_getXYZW(outWdims, n, ax, ay, z)] / kernelArea;
           for (dim_t kx = 0; kx < kernel_h; kx++) {
             for (dim_t ky = 0; ky < kernel_w; ky++) {

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -3880,7 +3880,8 @@ FUNCTION_ENABLE_IF_TEMPLATE(MatMul)
 FUNCTION_ENABLE_IF_TEMPLATE(AvgPool) *
     createNewPool(Function &F, T *PN, RescaleQuantizedNode *rescale) {
   return createNode<T>(F, PN->getName(), rescale->getInput(), PN->getKernels(),
-                       PN->getStrides(), PN->getPads());
+                       PN->getStrides(), PN->getPads(), NCHW,
+                       PN->getCountIncludePads());
 }
 FUNCTION_ENABLE_IF_TEMPLATE(MaxPool) *
     createNewPool(Function &F, T *PN, RescaleQuantizedNode *rescale) {

--- a/tests/models/caffe2Models/avgpool_nhwc_predict_net.pbtxt
+++ b/tests/models/caffe2Models/avgpool_nhwc_predict_net.pbtxt
@@ -19,5 +19,9 @@ op {
     name: "pad"
     i: 1
   }
+  arg {
+    name: "count_include_pad"
+    i: 0
+  }
 }
 external_output: "output"

--- a/tests/models/onnxModels/averagePool2DAutoPadSameLower.onnxtxt
+++ b/tests/models/onnxModels/averagePool2DAutoPadSameLower.onnxtxt
@@ -22,6 +22,11 @@ graph {
       ints: 1
       type: INTS
     }
+    attribute {
+      name: "count_include_pad"
+      i: 1
+      type: INT
+    }
   }
   name: "test_averagepool"
   input {

--- a/tests/models/onnxModels/averagePool2DAutoPadValid.onnxtxt
+++ b/tests/models/onnxModels/averagePool2DAutoPadValid.onnxtxt
@@ -22,6 +22,11 @@ graph {
       ints: 1
       type: INTS
     }
+    attribute {
+      name: "count_include_pad"
+      i: 1
+      type: INT
+    }
   }
   name: "test_averagepool"
   input {

--- a/tests/models/onnxModels/averagePool2DCountExcludePads.onnxtxt
+++ b/tests/models/onnxModels/averagePool2DCountExcludePads.onnxtxt
@@ -7,25 +7,28 @@ graph {
     op_type: "AveragePool"
     attribute {
       name: "kernel_shape"
-      ints: 2
-      ints: 2
+      ints: 3
+      ints: 3
       type: INTS
     }
     attribute {
-      name: "auto_pad"
-      s: "SAME_UPPER"
-      type: STRING
+      name: "pads"
+      ints: 1
+      ints: 1
+      ints: 1
+      ints: 1
+      type: INTS
     }
     attribute {
       name: "strides"
-      ints: 1
-      ints: 1
+      ints: 2
+      ints: 2
       type: INTS
     }
     attribute {
-      name: "count_include_pad"
-      i: 1
-      type: INT
+        name: "count_include_pad"
+        i: 0
+        type: INT
     }
   }
   name: "test_averagepool"
@@ -64,10 +67,10 @@ graph {
             dim_value: 1
           }
           dim {
-            dim_value: 3
+            dim_value: 2
           }
           dim {
-            dim_value: 3
+            dim_value: 2
           }
         }
       }

--- a/tests/models/onnxModels/averagePool3D.onnxtxt
+++ b/tests/models/onnxModels/averagePool3D.onnxtxt
@@ -12,6 +12,11 @@ graph {
       ints: 2
       type: INTS
     }
+    attribute {
+      name: "count_include_pad"
+      i: 1
+      type: INT
+    }
   }
   name: "test_averagepool_3d_default"
   input {

--- a/tests/unittests/BasicIRTest.cpp
+++ b/tests/unittests/BasicIRTest.cpp
@@ -202,7 +202,8 @@ TEST(IR, casting) {
     auto *res = bb.createAllocActivationInst("sigmoid.res", input->getType());
     auto *sig = bb.createSigmoidInst("sigmoid", res, input);
     auto *pool =
-        bb.createAvgPoolOp(sig->getDest(), {7, 7}, {2, 2}, {3, 3, 3, 3}, NHWC);
+        bb.createAvgPoolOp(sig->getDest(), {7, 7}, {2, 2}, {3, 3, 3, 3}, NHWC,
+                           /* countIncludePads */ true);
 
     EXPECT_EQ(isa<AvgPoolInst>(pool), true);
     EXPECT_EQ(isa<AvgPoolInst>(input), false);
@@ -362,7 +363,8 @@ TEST(IR, getOperandName) {
     auto *res = bb.createAllocActivationInst("sigmoid.res", input->getType());
     auto *sig = bb.createSigmoidInst("sigmoid", res, input);
     auto *pool =
-        bb.createAvgPoolOp(sig->getDest(), {7, 7}, {2, 2}, {3, 3, 3, 3}, NHWC);
+        bb.createAvgPoolOp(sig->getDest(), {7, 7}, {2, 2}, {3, 3, 3, 3}, NHWC,
+                           /* countIncludePads */ true);
 
     EXPECT_EQ(pool->getNumOperands(), 2);
     EXPECT_EQ(pool->getOperandName(0), "Dest");

--- a/tests/unittests/Caffe2ImporterTest.cpp
+++ b/tests/unittests/Caffe2ImporterTest.cpp
@@ -581,6 +581,7 @@ TEST_F(Caffe2ImporterTest, avgPoolNHWC) {
   auto *avgPoolNode =
       llvm::dyn_cast<AvgPoolNode>(saveNode->getInput().getNode());
   ASSERT_TRUE(avgPoolNode);
+  ASSERT_FALSE(avgPoolNode->getCountIncludePads());
 
   // We have 2 placeholders:  1 input and 1 output.
   EXPECT_EQ(mod.getPlaceholders().size(), 2);
@@ -622,6 +623,7 @@ TEST_F(Caffe2ImporterTest, avgPool) {
   auto *avgPoolNode =
       llvm::dyn_cast<AvgPoolNode>(transNode1->getInput().getNode());
   ASSERT_TRUE(avgPoolNode);
+  ASSERT_TRUE(avgPoolNode->getCountIncludePads());
   auto *transNode2 =
       llvm::dyn_cast<TransposeNode>(avgPoolNode->getInput().getNode());
   ASSERT_TRUE(transNode2);

--- a/tests/unittests/GradCheckTest.cpp
+++ b/tests/unittests/GradCheckTest.cpp
@@ -605,6 +605,43 @@ TEST_P(GradCheck, gradientCheckAvgPool) {
                    &inputs, &outputs, 0.001, 0.004);
 }
 
+TEST_P(GradCheck, gradientCheckAvgPoolCountExcludePads) {
+  CHECK_IF_ENABLED();
+  PlaceholderBindings bindings;
+  dim_t numDim = 10;
+  dim_t numOutputElem = 10;
+  Placeholder *A, *Exp;
+  SaveNode *result;
+  for (auto *EE : engines_) {
+    auto &mod = EE->getModule();
+    bindings.clear();
+    Function *F = mod.createFunction("main");
+    A = mod.createPlaceholder(ElemKind::FloatTy, {1, numDim, numDim, 2}, "A",
+                              false);
+    Exp = mod.createPlaceholder(ElemKind::FloatTy, {1, numOutputElem}, "Exp",
+                                false);
+
+    Node *O = F->createAvgPool("pool", A, 3, 3, 1, NHWC,
+                               /* countIncludePads */ false);
+    O = F->createTanh("tanh", O);
+    O = F->createFullyConnected(bindings, "fc", O, numOutputElem);
+    O = F->createRegression("reg", O, Exp);
+    result = F->createSave("ret", O);
+  }
+
+  Tensor inputs(ElemKind::FloatTy, {1, numDim, numDim, 2});
+  Tensor outputs(ElemKind::FloatTy, {1, numOutputElem});
+
+  auto inputsH = inputs.getHandle<>();
+  auto outputsH = outputs.getHandle<>();
+  auto &mod = EET_.getModule();
+  inputsH.initXavier(1, mod.getPRNG());
+  outputsH.initXavier(1, mod.getPRNG());
+
+  performGradCheck(EET_, EEI_, bindings, result->getPlaceholder(), A, Exp,
+                   &inputs, &outputs, 0.001, 0.004);
+}
+
 TEST_P(GradCheck, gradientCheckMaxPool) {
   CHECK_IF_ENABLED();
   PlaceholderBindings bindings;

--- a/tests/unittests/OnnxExporterTest.cpp
+++ b/tests/unittests/OnnxExporterTest.cpp
@@ -747,6 +747,8 @@ TEST(exporter, QuantizedAvgPool) {
   EXPECT_EQ(avgPoolReloaded->getKernels(), avgPool->getKernels());
   EXPECT_EQ(avgPoolReloaded->getStrides(), avgPool->getStrides());
   EXPECT_EQ(avgPoolReloaded->getPads(), avgPool->getPads());
+  EXPECT_EQ(avgPoolReloaded->getCountIncludePads(),
+            avgPool->getCountIncludePads());
 }
 
 TEST(exporter, QuantizedAdaptiveAvgPool) {

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -1397,6 +1397,17 @@ TEST_F(OnnxImporterTest, importAveragePool2DAutoPadSameLower) {
   averagePoolTestHelper(filename, expectedDims, expectedValues);
 }
 
+/// Test loading AveragePool op from a ONNX model.
+/// The input is N*C*H*W (1*1*3*3), the kernels is {3, 3},
+/// strides is {2, 2}, pads is {1, 1, 1, 1},
+/// countIncludePads is false.
+TEST_F(OnnxImporterTest, importAveragePool2DCountExcludePads) {
+  std::string filename("averagePool2DCountExcludePads.onnxtxt");
+  std::vector<dim_t> expectedDims = {1, 1, 2, 2};
+  std::vector<float> expectedValues = {2, 3, 5, 6};
+  averagePoolTestHelper(filename, expectedDims, expectedValues);
+}
+
 TEST_F(OnnxImporterTest, importAveragePool3D) {
   ExecutionEngine EE{};
   auto &mod = EE.getModule();

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -169,6 +169,7 @@ int main(int argc, char **argv) {
       .addMember(MemberType::VectorUnsigned, "Strides")
       .addMember(MemberType::VectorUnsigned, "Pads")
       .addMember(MemberType::Unsigned, "Layout")
+      .addMember(MemberType::Boolean, "CountIncludePads")
       .autoIRGen()
       .autoVerify(VerifyKind::SameElementType, {"Dest", "Src"})
       .addGradientInstr({"Dest", "Src"}, {"Dest", "Src"});

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -188,6 +188,7 @@ int main(int argc, char **argv) {
       .addMember(MemberType::VectorUnsigned, "Strides")
       .addMember(MemberType::VectorUnsigned, "Pads", /* addSetter */ true)
       .addMember(MemberType::Enum, "Layout")
+      .addMember(MemberType::Boolean, "CountIncludePads")
       .addResultFromCtorArg()
       .addGradient()
       .setDocstring(

--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -3548,15 +3548,17 @@ PyTorchModelLoader::loadAvgPoolImpl(const torch::jit::Node *ptNode,
   RETURN_ERR_IF_NOT(ceilMode == false,
                     "ceilMode must be scalar with false value.");
 
-  // Glow always includes zero-padding in the averaging calculation.
-  bool countIncludePad;
-  ASSIGN_VALUE_OR_RETURN_ERR(countIncludePad,
-                             iValToBool(getGlowIValueForValue(
-                                 inputs[AvgPoolInputs::count_include_pad])));
-  RETURN_ERR_IF_NOT(countIncludePad, "countIncludePad must be true.");
+  // CountIncludePad defaults to true.
+  bool countIncludePads = true;
+  if (hasGlowIValueForValue(inputs[AvgPoolInputs::count_include_pad])) {
+    ASSIGN_VALUE_OR_RETURN_ERR(countIncludePads,
+                               iValToBool(getGlowIValueForValue(
+                                   inputs[AvgPoolInputs::count_include_pad])));
+  }
 
-  glow::AvgPoolNode *ap = F_.createAvgPool(opName, input, kernels, strides,
-                                           pads, (isConv3d ? NTHWC : NHWC));
+  glow::AvgPoolNode *ap =
+      F_.createAvgPool(opName, input, kernels, strides, pads,
+                       (isConv3d ? NTHWC : NHWC), countIncludePads);
   glow::NodeValue ap_output = ap->getResult();
   const glow::TransposeNode *output;
 


### PR DESCRIPTION
Summary:
https://github.com/pytorch/glow/issues/4565

Added a flag `CountIncludePads` to AvgPoolNode. The default value of the flag is set to true since the correspond flag in Caffe2 and Pytorch model has a default value of true. However, the default value in ONNX is false.

If the flag is false then pads won't be include during normalizing. This is implemented by decreasing the filterArea by 1 if a padding entry is encountered and flag is set to false in InterpreterNodes.cpp.

Differential Revision: D23843075

