### PR TITLE
[GraphOptimizer] Relax constraint on sink transpose below arithmetic with different scale/offset

### DIFF
--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -589,9 +589,12 @@ struct Type final {
   }
 
   /// \returns true if \p other is the same type. If \p allowDifferentShape then
-  /// shapes will not be considered as part of the equal comparison.
+  /// shapes will not be considered as part of the equal comparison. If \p
+  /// allowDifferentScaleOffset is true, scale and offset will not be considered
+  /// as part of the equal comparison.
   bool isEqual(const Type &other, bool allowDifferentShape = false,
-               bool allowDifferentStrides = false) const {
+               bool allowDifferentStrides = false,
+               bool allowDifferentScaleOffset = false) const {
     // Element type must be the same.
     if (elementType_ != other.elementType_) {
       return false;
@@ -619,7 +622,8 @@ struct Type final {
 
     // Compare the scale and offset of integers. Fused types use dummy
     // scale/offset, so can ignore them.
-    if (isQuantizedType() && !isFusedQuantizedType()) {
+    if (isQuantizedType() && !isFusedQuantizedType() &&
+        !allowDifferentScaleOffset) {
       if (scale_ != other.scale_ || offset_ != other.offset_) {
         return false;
       }

--- a/tests/unittests/GraphOptzTest.cpp
+++ b/tests/unittests/GraphOptzTest.cpp
@@ -1456,6 +1456,55 @@ TEST_F(GraphOptz, sinkTransposeBelowArithmeticNodesWithConstantOperand) {
   checkNumericalEquivalence();
 }
 
+/// Test sink Transpose below Add of which operands has the same element type
+/// and shape, but different scale and offset.
+TEST_F(GraphOptz, sinkQuantTransposeBelowArithmeticNodesWithConstantOperand) {
+  const dim_t origDims[] = {1, 5, 10, 15};
+  const dim_t transposedDims[] = {1, 15, 5, 10};
+
+  // Create graph where a Add take a Constant in LHS and Transpose in RHS.
+  // LHS and RHS has different scale and offset.
+  Constant *lhsC =
+      mod_.createConstant(ElemKind::Int8QTy, transposedDims, 0.2, 0, "C1");
+  lhsC->getHandle<int8_t>().randomize(-128, 127, mod_.getPRNG());
+
+  auto *inputP =
+      mod_.createPlaceholder(ElemKind::FloatTy, origDims, "Input", false);
+  auto *qTy = mod_.uniqueType(ElemKind::Int8QTy, origDims, 0.3, 2);
+  auto *quant = F_->createQuantize("Quant", inputP, qTy);
+  auto *rhsT = F_->createTranspose("RHS", quant, NHWC2NCHW);
+  auto *addQ = F_->createAdd("Add", lhsC, rhsT);
+  SaveNode *save = F_->createSave("Save", addQ);
+
+  EXPECT_EQ(F_->getNodes().size(), 4);
+
+  optimizedF_ = optimizeFunction(F_);
+
+  // Expecting Transpose->Output rather than Add->Output.
+  const auto *saveOpt =
+      findFunctionNodeByName<SaveNode>(optimizedF_, save->getName());
+  auto *transpose = llvm::dyn_cast<TransposeNode>(saveOpt->getInput());
+  ASSERT_NE(transpose, nullptr);
+  auto *add = llvm::dyn_cast<AddNode>(transpose->getInput());
+  ASSERT_TRUE(add);
+  // Check that the dimensions of the input and output of the add have been
+  // updated to compensate the absence of transpose.
+  EXPECT_EQ(add->getResult().dims(), llvm::makeArrayRef(origDims));
+  EXPECT_EQ(add->getLHS().dims(), llvm::makeArrayRef(origDims));
+  EXPECT_EQ(add->getRHS().dims(), llvm::makeArrayRef(origDims));
+  quant = llvm::dyn_cast<QuantizeNode>(add->getRHS().getNode());
+  ASSERT_TRUE(quant);
+  EXPECT_EQ(quant->getInput().getNode(), inputP);
+  EXPECT_EQ(optimizedF_->getNodes().size(), 4);
+
+  // Check that the original and optimized functions are numerically equivalent.
+  // This indirectly checks that the Constant has been transposed properly.
+  bindings_.allocate(mod_.getPlaceholders());
+  bindings_.get(inputP)->getHandle().randomize(-128, 127, mod_.getPRNG());
+
+  checkNumericalEquivalence();
+}
+
 /// Check that the predicates are properly preserved while doing
 /// the add(transpose, transpose) => transpose(add).
 TEST_F(GraphOptz, sinkTransposeBelowArithmeticNodesWithPredicate) {


### PR DESCRIPTION
Author: Jun Bum Lim <junlim@cadence.com>

Summary:
This change will allow the SinkCode optimization to move a transpose below
an arithmetic node of which operands has the same element type and shape,
but different scale and offset.

Documentation:
N/A

Test Plan:
GraphOptimizer unit test.
