### PR TITLE
[ONNXImporter] Fix default behavior when Transpose doesn't have shuffle

### DIFF
--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -765,7 +765,9 @@ protected:
     // one contains permutation under name "perm", the other contains it under
     // argument name "axes". That's why the name is passed as a parameter.
     std::vector<unsigned_t> perm;
-    ASSIGN_VALUE_OR_RETURN_ERR(perm, getShape<unsigned_t>(dict[permArgName]));
+    if (dict.count(permArgName))
+      ASSIGN_VALUE_OR_RETURN_ERR(perm, getShape<unsigned_t>(dict[permArgName]));
+
     if (perm.empty()) {
       // Empty permutation argument means reversing axes order.
       size_t N = in.dims().size();

--- a/tests/models/onnxModels/transpose_null_perm.onnxtxt
+++ b/tests/models/onnxModels/transpose_null_perm.onnxtxt
@@ -1,0 +1,57 @@
+ir_version: 6
+producer_name: "onnx-ex"
+graph {
+  node {
+    input: "X1"
+    output: "output0"
+    op_type: "Transpose"
+  }
+  name: "graph"
+  input {
+    name: "X1"
+    type {
+      tensor_type {
+        elem_type: 6
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 4
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "output0"
+    type {
+      tensor_type {
+        elem_type: 6
+        shape {
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 11
+}


### PR DESCRIPTION
Author: Jun Bum Lim <junlim@cadence.com>

Summary:
Fix default behavior when Transpose doesn't have shuffle (used to fail if shuffle is not provided).

Documentation:
N/A

Test Plan:
ONNX importer unit test.
