### PR TITLE
[GraphOptimizer] Disable const deduplication during const folding

### DIFF
--- a/include/glow/Importer/ProtobufLoader.h
+++ b/include/glow/Importer/ProtobufLoader.h
@@ -431,6 +431,7 @@ Error constantFoldInLoader(Function *F, LoaderType &tmpLoader,
   CompilationContext cctx;
   cctx.compMode = CompilationMode::Infer;
   cctx.optimizationOpts.enableConstantFolding = false;
+  cctx.optimizationOpts.enableConstantDeduplication = false;
   cctx.backendOpts.collectConstants = true;
   // Do not print out compilation errors encountered, as constant folding is a
   // best effort; simply silently give up and continue with compilation.

--- a/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
+++ b/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
@@ -141,6 +141,9 @@ struct OptimizationOptions {
   /// If true, perform compile-time computation of constant operations.
   bool enableConstantFolding{true};
 
+  /// If true, perform compile-time deduplication of Constants.
+  bool enableConstantDeduplication{true};
+
   /// For all Splats in the Function being optimized, if they are used by any
   /// Nodes listed in this set, then they will be materialized into Constants
   /// during Constant Folding.

--- a/lib/Optimizer/GraphOptimizer/ConstantFolding.cpp
+++ b/lib/Optimizer/GraphOptimizer/ConstantFolding.cpp
@@ -320,6 +320,7 @@ bool constantFoldNodeImpl(
   CompilationContext cctx;
   // Do not recursively call constant folding.
   cctx.optimizationOpts.enableConstantFolding = false;
+  cctx.optimizationOpts.enableConstantDeduplication = false;
   cctx.backendOpts.collectConstants = true;
   // Do not print out compilation errors encountered, as constant folding is a
   // best effort; simply silently give up and continue with compilation.

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -2965,7 +2965,10 @@ bool CSE::run(Function *F, const CompilationContext &cctx) {
   LOG_SCOPE(F->getLogContext(), getName());
   CSEVisitor visitor;
 
-  bool changed = deduplicateConstants(F->getParent());
+  bool changed = false;
+  if (cctx.optimizationOpts.enableConstantDeduplication) {
+    changed |= deduplicateConstants(F->getParent());
+  }
 
   // Perform CSE on all nodes.
   for (auto &N : F->getNodes()) {


### PR DESCRIPTION
We do not need to deduplicate constants every time we optimize a constant folding subgraph. This adds to compile time, so just disable it. We will run deduplication after the constant folding pass itself.