### PR TITLE
Fix SNN partitioning flag

### DIFF
--- a/tests/unittests/Repro.cpp
+++ b/tests/unittests/Repro.cpp
@@ -499,7 +499,7 @@ int run() {
     cctx.dumpGraphPath = glow::onnxifi::GlowDumpGraphPath;
   }
 
-  if (glow::onnxifi::GlowSparseNNPartitioningSchemeNumCards) {
+  if (glow::onnxifi::GlowUseSparseNNPartitioningScheme) {
     cctx.optimizationOpts.useSparseNNPartitioningScheme = true;
     cctx.optimizationOpts.sparseNNPartitioningAddSLSConcats =
         glow::onnxifi::GlowSparseNNPartitioningAddSLSConcats;


### PR DESCRIPTION
Summary: Typo made in D23776578 (https://github.com/pytorch/glow/commit/8ffcca7d9789cd8ee5e4ed16700b749a3a6d62d7)

Differential Revision: D23918707

