### PR TITLE
Re-enable glow_nnpi_timeout_ms

### DIFF
--- a/lib/Backends/NNPI/NNPIDeviceManager.cpp
+++ b/lib/Backends/NNPI/NNPIDeviceManager.cpp
@@ -44,9 +44,6 @@ DeviceManager *createNNPIDeviceManager(const DeviceConfig &config,
     LOG(ERROR) << "Adapter allocation failed";
     return nullptr;
   }
-  if (GlowNNPITimeout != 0) {
-    deviceOptions->inferTimeout = GlowNNPITimeout;
-  }
   return new NNPIDeviceManager(config, deviceOptions, adapter);
 }
 
@@ -67,6 +64,9 @@ NNPIDeviceManager::NNPIDeviceManager(
   }
   if (deviceOptions_->deviceId >= 0) {
     deviceId_ = static_cast<unsigned>(deviceOptions_->deviceId);
+  }
+  if (GlowNNPITimeout != 0) {
+    deviceOptions_->inferTimeout = GlowNNPITimeout;
   }
 }
 

--- a/lib/Flags/Flags.cpp
+++ b/lib/Flags/Flags.cpp
@@ -542,14 +542,6 @@ DEFINE_validator(glow_nnpi_timeout_ms,
                    return true;
                  });
 
-DEFINE_int32(glow_nnpi_timeout, 0,
-             "Timeout threshold for inferecnce in microseconds. Default 0 "
-             "means infinity");
-DEFINE_validator(glow_nnpi_timeout, [](const char * /*unused*/, int32_t value) {
-  glow::runtime::GlowNNPITimeout = value;
-  return true;
-});
-
 #endif
 
 DEFINE_bool(glow_log_partition, true, "Enable logging partition info");


### PR DESCRIPTION
Summary:
Two issues:
1. `glow_nnpi_timeout` creates a conflict in terms of accessing GlowNNPITimeout which invalidate the `glow_nnpi_timeout_ms` flag. Removing it in this diff.
2. We have other ways of creating a NNPIDeviceManager, so we set GlowNNPITimeout in NNPIDeviceManager ctor directly.

Reviewed By: hyuen

Differential Revision: D23947426

