### PR TITLE
Support count_include_pad flag in Avgpool for OpenCL Backend

### DIFF
--- a/lib/Backends/OpenCL/OpenCL.cpp
+++ b/lib/Backends/OpenCL/OpenCL.cpp
@@ -1401,6 +1401,7 @@ Error OpenCLFunction::execute(ExecutionContext *context) {
       } else {
         ShapeNHWC odim(PA->getDest()->getType()->dims());
         ShapeNHWC idim(PA->getSrc()->getType()->dims());
+
         setKernelArg(kernel, numArgs + 4, odim);
         setKernelArg(kernel, numArgs + 5, idim);
         global = {{odim.h, odim.w, odim.c}};
@@ -1415,6 +1416,10 @@ Error OpenCLFunction::execute(ExecutionContext *context) {
             destTy->getOffset());
         setKernelArg(kernel, numArgs + 6, srcTy->getOffset());
         setKernelArg(kernel, numArgs + 7, destScaleParam);
+      } else if (!isQuantized) {
+        auto countIncludePads = PA->getCountIncludePads();
+
+        setKernelArg(kernel, numArgs + 6, countIncludePads);
       }
 
       enqueueKernel(I.getName(), commands, kernel, deviceId, global,

--- a/lib/Backends/OpenCL/kernels.cl
+++ b/lib/Backends/OpenCL/kernels.cl
@@ -1480,6 +1480,7 @@ __kernel void avgpoolK(__global float *dest, __global float *src,
   // For each input in the batch:
   for (dim_t n = 0; n < idim.n; n++) {
     float sumVal = 0;
+
     // For each element in the convolution-filter:
     for (dim_t fx = 0; fx < kernelSize; fx++) {
       for (dim_t fy = 0; fy < kernelSize; fy++) {
@@ -1500,7 +1501,8 @@ __kernel void avgpoolK(__global float *dest, __global float *src,
 
 __kernel void avgpoolW(__global void *mem, cl_uint32_t dest, cl_uint32_t src,
                        cl_uint32_t kernelSize, cl_uint32_t stride,
-                       PaddingTLBR pads, ShapeNHWC odim, ShapeNHWC idim) {
+                       PaddingTLBR pads, ShapeNHWC odim, ShapeNHWC idim,
+                       bool countIncludePads) {
   avgpoolK(&mem[dest], &mem[src], kernelSize, stride, pads, odim, idim);
 }
 
@@ -1520,6 +1522,7 @@ __kernel void oclavgpoolK(__global float *dest, __global float *src,
   // For each input in the batch:
   for (dim_t n = 0; n < idim.n; n++) {
     float sumVal = 0;
+
     // For each element in the convolution-filter:
     for (dim_t fx = 0; fx < kernelSize; fx++) {
       for (dim_t fy = 0; fy < kernelSize; fy++) {

--- a/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
@@ -176,7 +176,6 @@ std::set<std::string> glow::backendTestBlacklist = {
     "AdaptiveAvgPool/0",
     "FP16AdaptiveAvgPool/0",
     "Int8AdaptiveAvgPool/0",
-    "AvgPoolCountExcludePads/0",
     "Int8AvgPoolCountExcludePads/0",
     "AdaptiveAvgPoolNonSquare/0",
     "FP16MaxPool/0",


### PR DESCRIPTION
Summary: Support count_include_pad flag for OpenCL backend.

Differential Revision: D24020996

