### PR TITLE
Call optimizeFunctionBeforeLowering when emitting bundle

### DIFF
--- a/lib/Optimizer/GraphOptimizerPipeline/FunctionPassPipeline.cpp
+++ b/lib/Optimizer/GraphOptimizerPipeline/FunctionPassPipeline.cpp
@@ -167,6 +167,9 @@ createDefaultGraphOptimizationPassPipeline() {
       // Try to remove unnecessary Split-Concat operations
       {FunctionPassID::EliminateSliceConcat},
 
+      // Perform Common Subexpression Elimination.
+      {FunctionPassID::CSE},
+
       // Perform a round of Dead Code Elimination to cleanup the final pass.
       getDCEPassConfig(),
   };

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -320,17 +320,9 @@ Error HostManager::addNetwork(std::unique_ptr<Module> module,
   const bool skipOptimizations =
       cctx.loadingAOTModel || !cctx.backendOpts.backendSpecificNodeInfo.empty();
 
-  // Flag to check whether we are in profiling mode.
-  bool profilingMode =
-      (cctx.precisionConfig.quantMode == QuantizationMode::Profile);
-
   // Perform a round of target-independent graph optimizations. This helps the
   // partitioner to do its job more efficiently.
-  // When profiling we skip the optimization since in order for the quantization
-  // to be done properly same optimizations must be performed until the lowering
-  // stage for both the profiling and quantization path. Since the quantization
-  // for Ahead Of Time mode lacks this optimization we must disable it also.
-  if (!skipOptimizations && !profilingMode) {
+  if (!skipOptimizations) {
     for (Function *F : module->getFunctions()) {
       auto err = optimizeFunctionBeforeLowering(F, cctx);
       if (err) {

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -691,9 +691,10 @@ void Loader::compile(CompilationContext &cctx) {
     if (!llvm::sys::fs::is_directory(emitBundle)) {
       llvm::sys::fs::create_directory(emitBundle);
     }
-    // Emit IR for the graph, compile it and save as a bundle.
-    auto error = ::glow::optimizeFunction(F_, *backend_, cctx);
-    EXIT_ON_ERR(std::move(error));
+    // Emit IR for the graph, compile it and save as a bundle. Replicate the
+    // same optimizations seen during normal execution inside addNetwork().
+    EXIT_ON_ERR(::glow::optimizeFunctionBeforeLowering(F_, cctx));
+    EXIT_ON_ERR(::glow::optimizeFunction(F_, *backend_, cctx));
     backend_->save(F_, emitBundle, networkName,
                    mainEntryName.empty() ? networkName : mainEntryName);
   } else {


### PR DESCRIPTION
Summary: 

CI was breaking for bundles after https://github.com/pytorch/glow/pull/4831 due to a mismatch in optimizations between profiling mode (though `HostManager::addNetwork()`) and the optimizations in the Loader during bundle mode.

I removed the profiling mode from `HostManager::addNetwork()` and added `optimizeFunctionBeforeLowering()` to the bundle saving path. This way everything should be aligned.

I also added an extra CSE call at the end of the default opt pipeline, which was also something that would have fixed this issue (though would have covered the symptom without fixing the underlying problem).

Test Plan:

CI works again