### PR TITLE
Add UInt4FusedQTy into Glow type

### DIFF
--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -683,6 +683,8 @@ public:
       return isEqualImpl<uint8_t>(other, allowedError, verbose);
     case ElemKind::UInt4FusedFP16QTy:
       return isEqualImpl<uint8_t>(other, allowedError, verbose);
+    case ElemKind::UInt4FusedQTy:
+      return isEqualImpl<uint8_t>(other, allowedError, verbose);
     case ElemKind::BoolTy:
       return isEqualImpl<bool>(other, allowedError, verbose);
     }
@@ -1598,7 +1600,8 @@ private:
   /// \p T of a row \p rowIdx.
   template <typename T> ElemTy *getFusedRowScaleOffsetPtr(dim_t rowIdx) {
     switch (getElementType()) {
-    case ElemKind::UInt8FusedQTy: {
+    case ElemKind::UInt8FusedQTy:
+    case ElemKind::UInt4FusedQTy: {
       constexpr auto isFloat = std::is_same<float, T>::value;
       DCHECK(isFloat) << "Expected float scale/offset";
       break;

--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -406,6 +406,9 @@ enum class ElemKind : unsigned char {
   // 4-bit quantized type with fused FP16 scale/offset (uint8_t, each byte
   // represents 2 4-bit quantized data)
   UInt4FusedFP16QTy,
+  // 4-bit quantized type with fused FP32 scale/offset (uint8_t, each byte
+  // represents 2 4-bit quantized data)
+  UInt4FusedQTy,
   // Bool type (bool)
   BoolTy,
 };
@@ -415,7 +418,7 @@ inline bool isQuantizedElemKind(ElemKind e) {
   return e == ElemKind::Int8QTy || e == ElemKind::UInt8QTy ||
          e == ElemKind::Int16QTy || e == ElemKind::Int32QTy ||
          e == ElemKind::UInt8FusedQTy || e == ElemKind::UInt8FusedFP16QTy ||
-         e == ElemKind::UInt4FusedFP16QTy;
+         e == ElemKind::UInt4FusedFP16QTy || e == ElemKind::UInt4FusedQTy;
 }
 
 /// \returns whether \p e is a float ElemKind.
@@ -427,7 +430,7 @@ inline bool isFloatElemKind(ElemKind e) {
 /// \returns whether \p e is a fused quantized ElemKind.
 inline bool isFusedQuantizedElemKind(ElemKind e) {
   return e == ElemKind::UInt8FusedQTy || e == ElemKind::UInt8FusedFP16QTy ||
-         e == ElemKind::UInt4FusedFP16QTy;
+         e == ElemKind::UInt4FusedFP16QTy || e == ElemKind::UInt4FusedQTy;
 }
 
 /// \returns the scale and offset ElemKind used by the fused ElemKind \p e.
@@ -701,6 +704,8 @@ struct Type final {
       return std::is_same<ElemTy, uint8_t>::value;
     case ElemKind::UInt4FusedFP16QTy:
       return std::is_same<ElemTy, uint8_t>::value;
+    case ElemKind::UInt4FusedQTy:
+      return std::is_same<ElemTy, uint8_t>::value;
     case ElemKind::BoolTy:
       return std::is_same<ElemTy, bool>::value;
     }
@@ -769,6 +774,8 @@ struct Type final {
       return sizeof(uint8_t);
     case ElemKind::UInt4FusedFP16QTy:
       return sizeof(uint8_t);
+    case ElemKind::UInt4FusedQTy:
+      return sizeof(uint8_t);
     case ElemKind::BoolTy:
       return sizeof(bool);
     }
@@ -785,7 +792,7 @@ struct Type final {
     static const char *names[] = {
         "float",        "float16",      "bfloat16", "i8",      "ui8",
         "i16",          "i32",          "index32",  "index64", "ui8fused",
-        "ui8fusedfp16", "ui4fusedfp16", "bool",
+        "ui8fusedfp16", "ui4fusedfp16", "ui4fused", "bool",
     };
     return names[(int)Ty];
   }
@@ -818,6 +825,8 @@ struct Type final {
       return ElemKind::UInt8FusedFP16QTy;
     } else if (str == Type::getElementName(ElemKind::UInt4FusedFP16QTy)) {
       return ElemKind::UInt4FusedFP16QTy;
+    } else if (str == Type::getElementName(ElemKind::UInt4FusedQTy)) {
+      return ElemKind::UInt4FusedQTy;
     } else if (str == Type::getElementName(ElemKind::BoolTy)) {
       return ElemKind::BoolTy;
     } else {

--- a/lib/Base/Tensor.cpp
+++ b/lib/Base/Tensor.cpp
@@ -414,6 +414,8 @@ void glow::dumpAsciiImpl(const Tensor *T, llvm::raw_ostream &os) {
     return dumpAsciiGenericImpl(T->getHandle<uint8_t>(), os);
   case ElemKind::UInt4FusedFP16QTy:
     return dumpAsciiGenericImpl(T->getHandle<uint8_t>(), os);
+  case ElemKind::UInt4FusedQTy:
+    return dumpAsciiGenericImpl(T->getHandle<uint8_t>(), os);
   case ElemKind::BoolTy:
     return dumpAsciiGenericImpl(T->getHandle<bool>(), os);
   }
@@ -447,6 +449,8 @@ void glow::dumpImpl(const Tensor *T, llvm::raw_ostream &os,
   case ElemKind::UInt8FusedFP16QTy:
     return dumpGenericImpl(T->getHandle<uint8_t>(), os, maxNumElem);
   case ElemKind::UInt4FusedFP16QTy:
+    return dumpGenericImpl(T->getHandle<uint8_t>(), os, maxNumElem);
+  case ElemKind::UInt4FusedQTy:
     return dumpGenericImpl(T->getHandle<uint8_t>(), os, maxNumElem);
   case ElemKind::BoolTy:
     return dumpGenericImpl(T->getHandle<bool>(), os, maxNumElem);
@@ -592,6 +596,9 @@ void glow::genericTranspose(const Tensor *src, Tensor *dest,
   case ElemKind::UInt4FusedFP16QTy: {
     llvm_unreachable("Transposing UInt4FusedFP16QTy is unsupported.");
   }
+  case ElemKind::UInt4FusedQTy: {
+    llvm_unreachable("Transposing UInt4FusedQTy is unsupported.");
+  }
   case ElemKind::BoolTy: {
     auto srcH = src->getHandle<bool>();
     auto destH = dest->getHandle<bool>();
@@ -691,6 +698,7 @@ void Tensor::init(InitKind init, float val, PseudoRNG &PRNG) {
     break;                                                                     \
   }
       FUSED_CASE(UInt8FusedQTy, float);
+      FUSED_CASE(UInt4FusedQTy, float);
       FUSED_CASE(UInt8FusedFP16QTy, float16_t);
       FUSED_CASE(UInt4FusedFP16QTy, float16_t);
 #undef FUSED_CASE

--- a/lib/Base/TensorSerialization.cpp
+++ b/lib/Base/TensorSerialization.cpp
@@ -216,6 +216,8 @@ void glow::dumpTensorToTextFile(Tensor &tensor, llvm::StringRef filename,
     return dumpTensorToTextFileImpl<uint8_t>(tensor, filename, fs);
   case ElemKind::UInt4FusedFP16QTy:
     return dumpTensorToTextFileImpl<uint8_t>(tensor, filename, fs);
+  case ElemKind::UInt4FusedQTy:
+    return dumpTensorToTextFileImpl<uint8_t>(tensor, filename, fs);
   case ElemKind::BoolTy:
     return dumpTensorToTextFileImpl<bool>(tensor, filename, fs);
   default:
@@ -265,6 +267,8 @@ void glow::loadTensorFromTextFile(Tensor &tensor, llvm::StringRef filename,
   case ElemKind::UInt8FusedFP16QTy:
     return loadTensorFromTextFileImpl<uint8_t>(tensor, filename, fs);
   case ElemKind::UInt4FusedFP16QTy:
+    return loadTensorFromTextFileImpl<uint8_t>(tensor, filename, fs);
+  case ElemKind::UInt4FusedQTy:
     return loadTensorFromTextFileImpl<uint8_t>(tensor, filename, fs);
   case ElemKind::BoolTy:
     return loadTensorFromTextFileImpl<bool>(tensor, filename, fs);

--- a/lib/Exporter/ONNXModelWriter.cpp
+++ b/lib/Exporter/ONNXModelWriter.cpp
@@ -1134,6 +1134,7 @@ ONNXModelWriter::convertType(const Type &glowType) {
   case ElemKind::UInt8FusedQTy:
   case ElemKind::UInt8FusedFP16QTy:
   case ElemKind::UInt4FusedFP16QTy:
+  case ElemKind::UInt4FusedQTy:
   case ElemKind::UInt8QTy:
     return TensorType::UINT8;
   case ElemKind::Int16QTy:

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -730,6 +730,8 @@ static size_t getNumDataColumnsFromFused(TypeRef type) {
     return n - 2 * sizeof(float16_t);
   case ElemKind::UInt4FusedFP16QTy:
     return (n - 2 * sizeof(float16_t)) * 2;
+  case ElemKind::UInt4FusedQTy:
+    return (n - 2 * sizeof(float)) * 2;
   default:
     llvm_unreachable("Not supported Fused ElemKind");
   }

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -247,6 +247,8 @@ llvm::Type *LLVMIRGen::getElementType(llvm::IRBuilder<> &builder,
     return builder.getInt8Ty();
   case ElemKind::UInt4FusedFP16QTy:
     return builder.getInt8Ty();
+  case ElemKind::UInt4FusedQTy:
+    return builder.getInt8Ty();
   case ElemKind::BoolTy:
     static_assert(sizeof(bool) == sizeof(int8_t),
                   "Bool is expected to be the same size as int8.");
@@ -378,6 +380,9 @@ llvm::Value *LLVMIRGen::emitValueAddress(llvm::IRBuilder<> &builder,
     T = llvm::Type::getInt8PtrTy(getLLVMContext());
     break;
   case ElemKind::UInt4FusedFP16QTy:
+    T = llvm::Type::getInt8PtrTy(getLLVMContext());
+    break;
+  case ElemKind::UInt4FusedQTy:
     T = llvm::Type::getInt8PtrTy(getLLVMContext());
     break;
   case ElemKind::BoolTy:
@@ -558,6 +563,8 @@ llvm::Value *LLVMIRGen::emitConst(llvm::IRBuilder<> &builder, float val,
   case ElemKind::UInt8FusedFP16QTy:
     return builder.getInt8(static_cast<int8_t>(val));
   case ElemKind::UInt4FusedFP16QTy:
+    return builder.getInt8(static_cast<int8_t>(val));
+  case ElemKind::UInt4FusedQTy:
     return builder.getInt8(static_cast<int8_t>(val));
   case ElemKind::BoolTy:
     return builder.getInt8(static_cast<int8_t>(val));

--- a/tests/unittests/TensorsTest.cpp
+++ b/tests/unittests/TensorsTest.cpp
@@ -1339,6 +1339,7 @@ TEST(Tensor, typeSerialization) {
   testType(Type(ElemKind::UInt8FusedQTy, {1, 2, 3}, 1.5, 5));
   testType(Type(ElemKind::UInt8FusedFP16QTy, {1, 2, 3}, 1.6, 6));
   testType(Type(ElemKind::UInt4FusedFP16QTy, {1, 2, 3}, 1.7, 7));
+  testType(Type(ElemKind::UInt4FusedQTy, {1, 2, 3}, 1.7, 7));
   testType(Type(ElemKind::BoolTy, {1, 2, 3}));
 }
 

--- a/torch_glow/src/PyTorchCommon.cpp
+++ b/torch_glow/src/PyTorchCommon.cpp
@@ -157,6 +157,7 @@ c10::ScalarType elemKindToScalarType(glow::ElemKind ty) {
   case ElemKind::UInt8FusedQTy:
   case ElemKind::UInt8FusedFP16QTy:
   case ElemKind::UInt4FusedFP16QTy:
+  case ElemKind::UInt4FusedQTy:
   case ElemKind::UInt8QTy:
   case ElemKind::Int16QTy:
   case ElemKind::Int32QTy:


### PR DESCRIPTION
Summary:
Add UInt4FusedQTy into Glow type: It is 4-bit quantized type with fused FP32 scale/offset (uint8_t, each byte represents 2 4-bit quantized data).

This diff just add the type declaration and simple test. In the following diffs, the corresponding quantization implementation and type conversion will be added.

Reviewed By: jfix71

Differential Revision: D24021832

