### PR TITLE
Fix type mismatch caused by EmbeddingBag4BitRowwiseOffsets

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -4694,7 +4694,8 @@ Error PyTorchModelLoader::loadEmbeddingBagByteRowwiseOffsetsHelper(
     // offsets.dims[0] - 1, if offsets is not empty
     glow::Tensor t(ElemKind::FloatTy,
                    {offsets.dims()[0] > 0 ? offsets.dims()[0] - 1 : 0,
-                    weight.dims()[1] - 2 * sizeof(float)});
+                    (is4Bit ? weight.dims()[1] * 2 : weight.dims()[1]) -
+                        2 * sizeof(float)});
     t.zero();
     glow::Constant *glowConstant = F_.getParent()->createConstant(
         "EmptyEmbeddingBagByteRowwiseOffsets", std::move(t));

--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -4730,7 +4730,15 @@ Error PyTorchModelLoader::loadEmbeddingBagByteRowwiseOffsetsHelper(
       weightConstant->getOutput(), perSampleWeights, indices, offsets, false,
       includeLastOffset);
 
-  return addValueMapping(outputs[0], EB->getResult());
+  // Upcast EmbeddingBag4BitRowwiseOffsets to Float32 since its Glow output type
+  // is Float16.
+  if (is4Bit) {
+    auto *CT = F_.createConvertTo("ConvertEmbeddingBag4BitRowwiseOffsetsOutput",
+                                  EB, ElemKind::FloatTy);
+    return addValueMapping(outputs[0], CT->getResult());
+  } else {
+    return addValueMapping(outputs[0], EB->getResult());
+  }
 }
 
 Error PyTorchModelLoader::loadEmbeddingBagByteRowwiseOffsets(


### PR DESCRIPTION
Summary: PyTorch expects the output type for this operator to be fp32, however, the corresponding Glow operator produces a fp16 output. This can cause mismatch for other operators like concat. So we add a upcast operator to convert its output to fp32.

Reviewed By: hyuen, radkris-git

Differential Revision: D24029877

