### PR TITLE
Add unittests for quantized embeddingbag for PyTorchModelLoader

### DIFF
--- a/.circleci/build.sh
+++ b/.circleci/build.sh
@@ -156,6 +156,7 @@ elif [[ "$CIRCLE_JOB" == "PYTORCH" ]]; then
     git clone https://github.com/pytorch/pytorch.git --recursive --depth 1
     cd pytorch
     pip install -r requirements.txt
+    pip install parameterized
     BUILD_BINARY=OFF BUILD_TEST=0 BUILD_CAFFE2_OPS=1 USE_FBGEMM=ON python setup.py install
     cd ${GLOW_DIR}
     cd build

--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -4718,13 +4718,36 @@ Error PyTorchModelLoader::loadEmbeddingBagByteRowwiseOffsetsHelper(
     return addValueMapping(outputs[0], glowConstant->getOutput());
   }
 
-  glow::NodeValue perSampleWeights = loadNodeValueOrCreateBroadcastedConstant(
-      inputs[EmbeddingBagByteRowwiseOffsetsInputs::per_sample_weights],
-      (is4Bit ? "EmbeddingBag4BitRowwiseOffsets.ones"
-              : "EmbeddingBagByteRowwiseOffsets.ones"),
-      glow::Type((is4Bit ? ElemKind::Float16Ty : ElemKind::FloatTy),
-                 {indices.dims()[0]}),
-      1.0);
+  glow::NodeValue perSampleWeights;
+  if (is4Bit) {
+    // Glow supported perSampleWeights is fp16 but PyTorch uses fp32,
+    // therefore the input needs to be cast.
+    auto node =
+        inputs[EmbeddingBagByteRowwiseOffsetsInputs::per_sample_weights];
+    if (hasGlowNodeValueForValue(node)) {
+      glow::NodeValue gnode;
+      ASSIGN_VALUE_OR_RETURN_ERR(gnode, getGlowNodeValueForValue(node));
+
+      perSampleWeights =
+          F_.createConvertTo(
+                "ConvertEmbeddingBag4BitRowwiseOffsetsPerSampleWeights", gnode,
+                ElemKind::Float16Ty)
+              ->getResult();
+    } else {
+      glow::Tensor t(ElemKind::Float16Ty, {indices.dims()[0]});
+      t.init(glow::Tensor::InitKind::Broadcast, 1.0, F_.getParent()->getPRNG());
+      perSampleWeights =
+          F_.getParent()
+              ->createConstant("EmbeddingBag4BitRowwiseOffsets.ones",
+                               std::move(t))
+              ->getOutput();
+    }
+  } else {
+    perSampleWeights = loadNodeValueOrCreateBroadcastedConstant(
+        inputs[EmbeddingBagByteRowwiseOffsetsInputs::per_sample_weights],
+        "EmbeddingBagByteRowwiseOffsets.ones",
+        glow::Type((ElemKind::FloatTy), {indices.dims()[0]}), 1.0);
+  }
 
   glow::Constant *weightConstant =
       llvm::dyn_cast<glow::Constant>(weight.getNode());

--- a/torch_glow/tests/functionality/quantized_cut_in_the_middle_test.py
+++ b/torch_glow/tests/functionality/quantized_cut_in_the_middle_test.py
@@ -42,6 +42,7 @@ class TestQuantizedCut(unittest.TestCase):
             # Cut using blacklist functionality
             blacklist = ["quantized::add_relu"]
             torch_glow.setFusionBlacklist(blacklist)
+            torch_glow.setGlowBackend("Interpreter")
             traced_model = torch.jit.trace(fun, (a, b, c, d))
             for node in traced_model.graph_for(a, b, c, d).nodes():
                 kind = node.kind()

--- a/torch_glow/tests/nodes/embedding_bag_test.py
+++ b/torch_glow/tests/nodes/embedding_bag_test.py
@@ -2,13 +2,19 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import unittest
 
+import numpy as np
 import torch
-from tests.utils import jitVsGlow
+from parameterized import parameterized
+from tests.utils import check_skip, get_backend_name, jitVsGlow
 
 
 class TestEmbeddingBag(unittest.TestCase):
+    supported_backends = {"Interpreter", "NNPI"}
+
     def test_embedding_bag_basic(self):
         """Test of aten::embedding_bag node on glow"""
+
+        check_skip(self)
 
         def embedding_bag_basic(input, offsets, per_sample_weights):
             weight = torch.FloatTensor([[1, 2.3, 3], [4, 5.1, 6.3]])
@@ -28,4 +34,106 @@ class TestEmbeddingBag(unittest.TestCase):
             offsets,
             per_sample_weights,
             expected_fused_ops={"aten::embedding_bag"},
+        )
+
+
+class TestQuantizedEmbeddingBag(unittest.TestCase):
+    supported_backends = {"Interpreter", "NNPI"}
+
+    @parameterized.expand(
+        [
+            [
+                "{len}{bits}{weighted}{fp16}{backend}".format(
+                    len=num_lengths,
+                    bits="_4bit" if is4bit else "_byte",
+                    weighted="_weighted" if is_weighted else "",
+                    fp16="_fp16" if use_fp16 else "",
+                    backend="_" + get_backend_name(),
+                ),
+                num_lengths,
+                is4bit,
+                is_weighted,
+                use_fp16,
+            ]
+            for num_lengths in [0, 8]
+            for is4bit in [False, True]
+            for is_weighted in [False, True]
+            for use_fp16 in [False, True]
+        ]
+    )
+    def test_embedding_bag_rowwise_offsets(
+        self, name, num_lengths, is4bit, is_weighted, use_fp16
+    ):
+        """Test of quantized::embedding_bag_byte_rowwise_offsets and
+        quantized::embedding_bag_4bit_rowwise_offsets node on glow"""
+        check_skip(self)
+
+        class TestModule(torch.nn.Module):
+            def __init__(self, q_weights, is4bit=False, per_sample_weights=None):
+                super().__init__()
+                self.q_weights = q_weights
+                self.per_sample_weights = per_sample_weights
+                if is4bit:
+                    self.op = torch.ops.quantized.embedding_bag_4bit_rowwise_offsets
+                else:
+                    self.op = torch.ops.quantized.embedding_bag_byte_rowwise_offsets
+
+            def forward(self, indices, offsets):
+                return self.op(
+                    self.q_weights,
+                    indices,
+                    offsets,
+                    mode=0,
+                    per_sample_weights=self.per_sample_weights,
+                    include_last_offset=True,
+                )
+
+        # generate random weights and indices
+        num_embeddings = 16
+        embedding_dim = 4
+        weights = torch.from_numpy(
+            (np.random.random_sample((num_embeddings, embedding_dim)) + 1).astype(
+                np.float32
+            )
+        )
+        q_weights = (
+            torch.ops.quantized.embedding_bag_4bit_prepack(weights)
+            if is4bit
+            else torch.ops.quantized.embedding_bag_byte_prepack(weights)
+        )
+        np_lengths = (
+            np.zeros(shape=[10]).astype(np.int32)
+            if num_lengths == 0
+            else np.random.randint(0, num_lengths, size=10).astype(np.int32)
+        )
+        num_lengths = np.sum(np_lengths)
+        lengths = torch.from_numpy(np_lengths)
+        indices = torch.from_numpy(
+            np.random.randint(
+                low=0, high=num_embeddings, size=num_lengths, dtype=np.int64
+            )
+        ).long()
+        offsets = torch.cat([torch.zeros([1]), torch.cumsum(lengths, 0)]).long()
+
+        per_sample_weights = torch.from_numpy(
+            np.random.uniform(low=0.01, high=0.5, size=[len(indices)]).astype(
+                np.float32
+            )
+        )
+
+        m = TestModule(q_weights, is4bit, per_sample_weights if is_weighted else None)
+
+        jitVsGlow(
+            m.forward,
+            indices,
+            offsets,
+            expected_fused_ops={
+                "quantized::embedding_bag_4bit_rowwise_offsets"
+                if is4bit
+                else "quantized::embedding_bag_byte_rowwise_offsets"
+            },
+            use_fp16=use_fp16,
+            # Known issue: 4bit version has bigger error
+            atol=0.005 if is4bit else 5e-4,
+            backend_name=get_backend_name(),
         )


### PR DESCRIPTION
Summary:
Adding unit tests for quantized embedding bag operators (quantized::embedding_bag_4bit_rowwise_offsets, and quantized::embedding_bag_byte_rowwise_offsets) mainly for PyTorchModelLoader. The test cases covers different input combinations for both CPU and NNPI backends.

During the test, one issue with the perSampleWeight input for embedding_bag_4bit_rowwise_offsets is identified and fixed in PyTorchModelLoader.

Differential Revision: D24057759

