### PR TITLE
[ONNXImporter] Support ONNX opset 11 Pad inputs.

### DIFF
--- a/lib/Exporter/ONNXModelWriter.cpp
+++ b/lib/Exporter/ONNXModelWriter.cpp
@@ -1295,13 +1295,43 @@ Error ONNXModelWriter::writePad(const PadNode *node, GraphType &graph) {
                ErrorValue::ErrorCode::MODEL_WRITER_SERIALIZATION_ERROR);
   }
 
-  addValueAttribute(proto, "pads", node->getPads());
-  float value = node->getValue();
-  if (value != .0f) {
-    addValueAttribute(proto, "value", value);
-  }
+  if (opsetVersion_ <= 10) {
+    addValueAttribute(proto, "pads", node->getPads());
+    float value = node->getValue();
+    if (value != .0f) {
+      addValueAttribute(proto, "value", value);
+    }
+    return writeAllWithNode("Pad", node, graph, proto);
+  } else {
+    proto->set_name(node->getName());
+    proto->set_op_type("Pad");
+    // Input for data.
+    inputsToProto(node, proto);
 
-  return writeAllWithNode("Pad", node, graph, proto);
+    // Input for pads.
+    auto pads = node->getPads();
+    Tensor oneDimTensorPads(ElemKind::Int64ITy, {(dim_t)pads.size()});
+    auto oneDimTensorPadsH = oneDimTensorPads.getHandle<int64_t>();
+    for (size_t b = 0, e = oneDimTensorPads.size(); b < e; ++b) {
+      oneDimTensorPadsH.raw(b) = pads[b];
+    }
+    auto *tensorProto = addInitializer(graph);
+    tensorProto->set_name(node->getName().str() + "_pads");
+    writeTensor(oneDimTensorPads, tensorProto);
+    proto->add_input(node->getName().str() + "_pads");
+
+    // Input for value.
+    Tensor value(ElemKind::FloatTy, {1});
+    auto valueH = value.getHandle();
+    valueH.raw(0) = node->getValue();
+    tensorProto = addInitializer(graph);
+    tensorProto->set_name(node->getName().str() + "_value");
+    writeTensor(value, tensorProto);
+    proto->add_input(node->getName().str() + "_value");
+    // Output
+    outputsToProto(node, graph, proto);
+    return Error::success();
+  }
 }
 
 Error ONNXModelWriter::writeConcat(const ConcatNode *node, GraphType &graph) {

--- a/tests/models/onnxModels/padConstantInput.onnxtxt
+++ b/tests/models/onnxModels/padConstantInput.onnxtxt
@@ -1,0 +1,64 @@
+ir_version: 6
+producer_name: "test4glow"
+
+graph {
+  name: "test-model"
+  node {
+    input: "data"
+    input: "pads"
+    input: "value"
+    output: "out"
+    name: "op"
+    op_type: "Pad"
+  }
+
+  initializer {
+    dims: 8
+    data_type: 7
+    int64_data: 1
+    int64_data: 2
+    int64_data: -2
+    int64_data: 0
+    int64_data: 0
+    int64_data: -2
+    int64_data: 1
+    int64_data: 2
+    name: "pads"
+  }
+
+  initializer {
+    dims: 1
+    data_type: 1
+    float_data: 2.55
+    name: "value"
+  }
+
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 6
+          }
+          dim {
+            dim_value: 5
+          }
+          dim {
+            dim_value: 7
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "out"
+  }
+}
+opset_import {
+  version: 11
+}

--- a/tests/models/onnxModels/padDefaultInputPad.onnxtxt
+++ b/tests/models/onnxModels/padDefaultInputPad.onnxtxt
@@ -1,0 +1,54 @@
+ir_version: 6
+producer_name: "onnx-ex"
+graph {
+  node {
+    input: "data"
+    input: "pads"
+    output: "out"
+    op_type: "Pad"
+  }
+
+  name: "graph"
+  initializer {
+    dims: 8
+    data_type: 7
+    int64_data: 1
+    int64_data: 2
+    int64_data: -2
+    int64_data: 0
+    int64_data: 0
+    int64_data: -2
+    int64_data: 1
+    int64_data: 2
+    name: "pads"
+  }
+
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 4
+          }
+          dim {
+            dim_value: 6
+          }
+          dim {
+            dim_value: 5
+          }
+          dim {
+            dim_value: 7
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "out"
+  }
+}
+opset_import {
+  version: 11
+}

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -2710,8 +2710,23 @@ TEST_F(OnnxImporterTest, importPadDefault) {
             PaddingMode::CONSTANT, 0.f, false);
 }
 
+TEST_F(OnnxImporterTest, importPadDefaultInputPads) {
+  // This test Pad in opset v11 where "pads" is passed through the 2nd input.
+  importPad("padDefaultInputPad.onnxtxt", "data", {4, 6, 5, 7} /* input */,
+            {1, 2, -2, 0} /* starts */, {0, -2, 1, 2} /* ends */,
+            PaddingMode::CONSTANT, 0.f, false);
+}
+
 TEST_F(OnnxImporterTest, importPadConstant) {
   importPad("padConstant.onnxtxt", "data", {4, 6, 5, 7} /* input */,
+            {1, 2, -2, 0} /* starts */, {0, -2, 1, 2} /* ends */,
+            PaddingMode::CONSTANT, 2.55f, false);
+}
+
+TEST_F(OnnxImporterTest, importPadConstantInput) {
+  // This tests Pad in opset v11 where "pads" is passed through the 2nd input
+  // and "value" through the 3rd input.
+  importPad("padConstantInput.onnxtxt", "data", {4, 6, 5, 7} /* input */,
             {1, 2, -2, 0} /* starts */, {0, -2, 1, 2} /* ends */,
             PaddingMode::CONSTANT, 2.55f, false);
 }


### PR DESCRIPTION
Author: Jun Bum Lim <junlim@cadence.com>

Summary:
Support opset 11 inputs for Pad operator.

Documentation:
N/A

Test Plan:
New ONNX importer unit test.