### PR TITLE
[ONNXImporter] Add support for ONNX Loop operator by unrolling in loader.

### DIFF
--- a/include/glow/Importer/ONNXModelLoader.h
+++ b/include/glow/Importer/ONNXModelLoader.h
@@ -428,6 +428,10 @@ class ONNXModelLoader
   Error loadAudioSpectrogram(const ONNX_NAMESPACE::NodeProto &op,
                              ArgumentDictionaryTy &dict);
 
+  /// Load Loop operator.
+  Error loadLoop(const ONNX_NAMESPACE::NodeProto &op,
+                 const ArgumentDictionaryTy &dict);
+
   /// Load MFCC Glow operator.
   Error loadMFCC(const ONNX_NAMESPACE::NodeProto &op,
                  ArgumentDictionaryTy &dict);
@@ -515,6 +519,12 @@ protected:
   /// they're added to \ref staticPlaceholderTypes_. If \ref
   /// staticPlaceholderTypes_ is a nullptr then this method is a no-op.
   Error setupOrigStaticTypeMap(ONNX_NAMESPACE::GraphProto &net);
+
+  /// Associate all inputs of \p net with nodes in \p NVs. Number of inputs of
+  /// \p net should match the number of elements of \p NVs.
+  /// \returns error code in case of error.
+  Error assignGraphInputs(const ONNX_NAMESPACE::GraphProto &net,
+                          llvm::ArrayRef<NodeValue> NVs);
 
   /// Creates a ONNX model loader to build \p F.
   /// Loads the ONNIXFI \p model from memory of \p modelSize size,

--- a/lib/Importer/ProtobufLoader.cpp
+++ b/lib/Importer/ProtobufLoader.cpp
@@ -46,7 +46,7 @@ bool ProtobufLoader::isConstantFoldable(llvm::ArrayRef<NodeValue> inputs,
     return false;
   }
   // foldUnsupportedTypes: List of typenames unsupported for folding.
-  std::string foldUnsupportedTypes[] = {"Constant"};
+  std::string foldUnsupportedTypes[] = {"Constant", "Loop"};
   std::string *findType = std::find(std::begin(foldUnsupportedTypes),
                                     std::end(foldUnsupportedTypes), typeName);
   // Early exit if folding is not supported for current operator.

--- a/lib/Importer/ProtobufLoader.cpp
+++ b/lib/Importer/ProtobufLoader.cpp
@@ -197,22 +197,31 @@ Error ProtobufLoader::createAndRegisterConstant(llvm::StringRef name,
 
 void ProtobufLoader::deleteUnusedConstants() {
   std::vector<std::string> nodeValuesToRemove;
+  // Note that it's possible a constant is referred by more than one names
+  // (e.g., via Identity operator). Therefore, we maintain a set of constants to
+  // erase separately from the list for names.
+  std::unordered_set<Constant *> constantToRemove;
+
   for (auto &kv : nodeValueByName_) {
     auto *node = kv.second.getNode();
     if (auto *c = llvm::dyn_cast<Constant>(node)) {
       if (!c->hasUsers()) {
         nodeValuesToRemove.push_back(kv.getKey());
+        constantToRemove.insert(c);
       }
     }
   }
 
   for (auto &name : nodeValuesToRemove) {
     auto it = nodeValueByName_.find(name);
-    auto *c = llvm::dyn_cast<Constant>(it->second.getNode());
-    DCHECK(c) << "NodeValue with name " << name
-              << " was expected to have been a Constant";
-    mod_.eraseConstant(c);
+    DCHECK(llvm::isa<Constant>(it->second.getNode()))
+        << "NodeValue with name " << name
+        << " was expected to have been a Constant";
     nodeValueByName_.erase(it);
+  }
+
+  for (auto *c : constantToRemove) {
+    G_->getParent()->eraseConstant(c);
   }
 }
 

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -110,10 +110,8 @@ void ConstantModificationPreventer::activate() {
   cctx_.optimizationOpts.enableConstantFolding = false;
 }
 
-/// Helper that \returns whether all sibling Functions of \p F (other Functions
-/// inside its Module) are Loaded.
-static bool shouldDeleteConstants(Function *F) {
-  Module *mod = F->getParent();
+/// Helper that \returns true if all functions in \p mod are loaded.
+static bool areAllFunctionsLoaded(Module *mod) {
   for (auto *MF : mod->getFunctions()) {
     if (MF->getState() < FunctionState::FuncLoaded) {
       return false;
@@ -222,7 +220,7 @@ bool DCE::run(Function *F, const CompilationContext &cctx) {
     return changed;
   }
 
-  if (!shouldDeleteConstants(F)) {
+  if (!areAllFunctionsLoaded(F->getParent())) {
     return changed;
   }
 
@@ -1809,7 +1807,7 @@ static Constant *getUniquelyUsedConstant(Module *M, Node &node) {
     return nullptr;
   }
 
-  if (constant->hasOneUse()) {
+  if (constant->hasOneUse() && areAllFunctionsLoaded(M)) {
     return constant;
   }
 

--- a/tests/models/onnxModels/loop_cond.onnxtxt
+++ b/tests/models/onnxModels/loop_cond.onnxtxt
@@ -1,0 +1,230 @@
+ir_version: 6
+producer_name: "jun-onnx-loop-ex"
+graph {
+  node {
+    output: "cond_orig"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 9
+        raw_data: "\001"
+        name: "cond_tensor"
+      }
+      type: TENSOR
+    }
+  }
+
+  node {
+    output: "dec"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 1
+        float_data: 1
+        name: "count_tensor"
+      }
+      type: TENSOR
+    }
+  }
+
+  node {
+    output: "reduce_i"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 1
+        float_data: 20
+        name: "count_tensor"
+      }
+      type: TENSOR
+    }
+  }
+
+  node {
+    input: "max_trip_count"
+    input: "cond_orig"
+    input: "reduce_i"
+    output: "v_final"
+    output: "scan_output_final"
+    op_type: "Loop"
+    attribute {
+      name: "body"
+      g {
+        node {
+          input: "pre_i"
+          input: "dec"
+          output: "cur_i"
+          op_type: "Sub"
+        }
+        node {
+          input: "cur_i"
+          output: "cur_cond"
+          op_type: "Cast"
+          attribute {
+            name: "to"
+            i: 9
+            type: INT
+          }
+        }
+        node {
+          input: "pre_i"
+          output: "scan_output"
+          op_type: "Identity"
+        }
+        name: "subgraph"
+        input {
+          name: "iter_num_in"
+          type {
+            tensor_type {
+              elem_type: 7
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        input {
+          name: "pre_cond"
+          type {
+            tensor_type {
+              elem_type: 9
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        input {
+          name: "pre_i"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        output {
+          name: "cur_cond"
+          type {
+            tensor_type {
+              elem_type: 9
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        output {
+          name: "cur_i"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        output {
+          name: "scan_output"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+      }
+      type: GRAPH
+    }
+  }
+  name: "loop_graph"
+  initializer {
+    data_type: 7
+    name: "max_trip_count"
+    raw_data: "\377\377\377\377\377\377\377\177"
+  }
+
+  input {
+    name: "init_i"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+
+  input {
+    name: "inc"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim{
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "v_final"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "scan_output_final"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 10
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 11
+}
+

--- a/tests/models/onnxModels/loop_empty_tripcount.onnxtxt
+++ b/tests/models/onnxModels/loop_empty_tripcount.onnxtxt
@@ -1,0 +1,239 @@
+ir_version: 6
+producer_name: "jun-onnx-loop-ex"
+graph {
+  node {
+    output: "cond_orig"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 9
+        raw_data: "\001"
+        name: "cond_tensor"
+      }
+      type: TENSOR
+    }
+  }
+  node {
+    output: "max_trip_count"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 7
+        int64_data: 10
+        name: "count_tensor"
+      }
+      type: TENSOR
+    }
+  }
+
+  node {
+    output: "dec"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 1
+        float_data: 1
+        name: "count_tensor"
+      }
+      type: TENSOR
+    }
+  }
+
+  node {
+    output: "reduce_i"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 1
+        float_data: 10
+        name: "count_tensor"
+      }
+      type: TENSOR
+    }
+  }
+
+  node {
+    #Ignore max_trip_count
+    input: ""
+    input: "cond_orig"
+    input: "reduce_i"
+    output: "v_final"
+    output: "scan_output_final"
+    op_type: "Loop"
+    attribute {
+      name: "body"
+      g {
+        node {
+          input: "pre_i"
+          input: "dec"
+          output: "cur_i"
+          op_type: "Sub"
+        }
+        node {
+          input: "cur_i"
+          output: "cur_cond"
+          op_type: "Cast"
+          attribute {
+            name: "to"
+            i: 9
+            type: INT
+          }
+        }
+        node {
+          input: "pre_i"
+          output: "scan_output"
+          op_type: "Identity"
+        }
+        name: "subgraph"
+        input {
+          name: "iter_num_in"
+          type {
+            tensor_type {
+              elem_type: 7
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        input {
+          name: "pre_cond"
+          type {
+            tensor_type {
+              elem_type: 9
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        input {
+          name: "pre_i"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        output {
+          name: "cur_cond"
+          type {
+            tensor_type {
+              elem_type: 9
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        output {
+          name: "cur_i"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        output {
+          name: "scan_output"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+      }
+      type: GRAPH
+    }
+  }
+  name: "loop_graph"
+  input {
+    name: "init_i"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+
+  input {
+    name: "inc"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim{
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "v_final"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "scan_output_final"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 10
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 11
+}
+

--- a/tests/models/onnxModels/loop_emptycond.onnxtxt
+++ b/tests/models/onnxModels/loop_emptycond.onnxtxt
@@ -1,0 +1,239 @@
+ir_version: 6
+producer_name: "jun-onnx-loop-ex"
+graph {
+  node {
+    output: "cond_orig"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 9
+        raw_data: "\000"
+        name: "cond_tensor"
+      }
+      type: TENSOR
+    }
+  }
+  node {
+    output: "max_trip_count"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 7
+        int64_data: 7
+        name: "count_tensor"
+      }
+      type: TENSOR
+    }
+  }
+
+  node {
+    output: "dec"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 1
+        float_data: 1
+        name: "count_tensor"
+      }
+      type: TENSOR
+    }
+  }
+
+  node {
+    output: "reduce_i"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 1
+        float_data: 5
+        name: "count_tensor"
+      }
+      type: TENSOR
+    }
+  }
+
+  node {
+    input: "max_trip_count"
+    # Ignore condition
+    input: ""
+    input: "reduce_i"
+    output: "v_final"
+    output: "scan_output_final"
+    op_type: "Loop"
+    attribute {
+      name: "body"
+      g {
+        node {
+          input: "pre_i"
+          input: "dec"
+          output: "cur_i"
+          op_type: "Sub"
+        }
+        node {
+          input: "cur_i"
+          output: "cur_cond"
+          op_type: "Cast"
+          attribute {
+            name: "to"
+            i: 9
+            type: INT
+          }
+        }
+        node {
+          input: "pre_i"
+          output: "scan_output"
+          op_type: "Identity"
+        }
+        name: "subgraph"
+        input {
+          name: "iter_num_in"
+          type {
+            tensor_type {
+              elem_type: 7
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        input {
+          name: "pre_cond"
+          type {
+            tensor_type {
+              elem_type: 9
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        input {
+          name: "pre_i"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        output {
+          name: "cur_cond"
+          type {
+            tensor_type {
+              elem_type: 9
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        output {
+          name: "cur_i"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        output {
+          name: "scan_output"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+      }
+      type: GRAPH
+    }
+  }
+  name: "loop_graph"
+  input {
+    name: "init_i"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+
+  input {
+    name: "inc"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim{
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "v_final"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "scan_output_final"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 10
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 11
+}
+

--- a/tests/models/onnxModels/loop_no_iteration.onnxtxt
+++ b/tests/models/onnxModels/loop_no_iteration.onnxtxt
@@ -1,0 +1,202 @@
+
+ir_version: 6
+producer_name: "onnx-static-loop"
+graph {
+  node {
+    output: "cond_orig"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 9
+        raw_data: "\000"
+        name: "cond_tensor"
+      }
+      type: TENSOR
+    }
+  }
+  node {
+    output: "max_trip_count"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 7
+        int64_data: 10
+        name: "count_tensor"
+      }
+      type: TENSOR
+    }
+  }
+  node {
+    input: "max_trip_count"
+    input: "cond_orig"
+    input: "init_i"
+    output: "v_final"
+    output: "scan_output_final"
+    op_type: "Loop"
+    attribute {
+      name: "body"
+      g {
+        node {
+          input: "pre_cond"
+          output: "cur_cond"
+          op_type: "Identity"
+        }
+        node {
+          input: "pre_i"
+          input: "inc"
+          output: "cur_i"
+          op_type: "Add"
+        }
+        node {
+          input: "pre_i"
+          output: "scan_output"
+          op_type: "Identity"
+        }
+        name: "subgraph"
+        input {
+          name: "iter_num_in"
+          type {
+            tensor_type {
+              elem_type: 7
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        input {
+          name: "pre_cond"
+          type {
+            tensor_type {
+              elem_type: 9
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        input {
+          name: "pre_i"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        output {
+          name: "cur_cond"
+          type {
+            tensor_type {
+              elem_type: 9
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        output {
+          name: "cur_i"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        output {
+          name: "scan_output"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+      }
+      type: GRAPH
+    }
+  }
+  name: "loop_graph"
+  input {
+    name: "init_i"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "inc"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "v_final"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "scan_output_final"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 10
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 11
+}
+

--- a/tests/models/onnxModels/loop_static.onnxtxt
+++ b/tests/models/onnxModels/loop_static.onnxtxt
@@ -1,0 +1,202 @@
+
+ir_version: 6
+producer_name: "onnx-static-loop"
+graph {
+  node {
+    output: "cond_orig"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 9
+        raw_data: "\001"
+        name: "cond_tensor"
+      }
+      type: TENSOR
+    }
+  }
+  node {
+    output: "max_trip_count"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 7
+        int64_data: 10
+        name: "count_tensor"
+      }
+      type: TENSOR
+    }
+  }
+  node {
+    input: "max_trip_count"
+    input: "cond_orig"
+    input: "init_i"
+    output: "v_final"
+    output: "scan_output_final"
+    op_type: "Loop"
+    attribute {
+      name: "body"
+      g {
+        node {
+          input: "pre_cond"
+          output: "cur_cond"
+          op_type: "Identity"
+        }
+        node {
+          input: "pre_i"
+          input: "inc"
+          output: "cur_i"
+          op_type: "Add"
+        }
+        node {
+          input: "pre_i"
+          output: "scan_output"
+          op_type: "Identity"
+        }
+        name: "subgraph"
+        input {
+          name: "iter_num_in"
+          type {
+            tensor_type {
+              elem_type: 7
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        input {
+          name: "pre_cond"
+          type {
+            tensor_type {
+              elem_type: 9
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        input {
+          name: "pre_i"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        output {
+          name: "cur_cond"
+          type {
+            tensor_type {
+              elem_type: 9
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        output {
+          name: "cur_i"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        output {
+          name: "scan_output"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+      }
+      type: GRAPH
+    }
+  }
+  name: "loop_graph"
+  input {
+    name: "init_i"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  input {
+    name: "inc"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "v_final"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "scan_output_final"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 10
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 11
+}
+

--- a/tests/models/onnxModels/loop_tripcount.onnxtxt
+++ b/tests/models/onnxModels/loop_tripcount.onnxtxt
@@ -1,0 +1,239 @@
+ir_version: 6
+producer_name: "jun-onnx-loop-ex"
+graph {
+  node {
+    output: "cond_orig"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 9
+        raw_data: "\001"
+        name: "cond_tensor"
+      }
+      type: TENSOR
+    }
+  }
+  node {
+    output: "max_trip_count"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 7
+        int64_data: 20
+        name: "count_tensor"
+      }
+      type: TENSOR
+    }
+  }
+
+  node {
+    output: "dec"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 1
+        float_data: 1
+        name: "count_tensor"
+      }
+      type: TENSOR
+    }
+  }
+
+  node {
+    output: "reduce_i"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 1
+        float_data: 20
+        name: "count_tensor"
+      }
+      type: TENSOR
+    }
+  }
+
+  node {
+    input: "max_trip_count"
+    input: "cond_orig"
+    #input: "init_i"
+    input: "reduce_i"
+    output: "v_final"
+    output: "scan_output_final"
+    op_type: "Loop"
+    attribute {
+      name: "body"
+      g {
+        node {
+          input: "pre_i"
+          input: "dec"
+          output: "cur_i"
+          op_type: "Sub"
+        }
+        node {
+          input: "cur_i"
+          output: "cur_cond"
+          op_type: "Cast"
+          attribute {
+            name: "to"
+            i: 9
+            type: INT
+          }
+        }
+        node {
+          input: "pre_i"
+          output: "scan_output"
+          op_type: "Identity"
+        }
+        name: "subgraph"
+        input {
+          name: "iter_num_in"
+          type {
+            tensor_type {
+              elem_type: 7
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        input {
+          name: "pre_cond"
+          type {
+            tensor_type {
+              elem_type: 9
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        input {
+          name: "pre_i"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        output {
+          name: "cur_cond"
+          type {
+            tensor_type {
+              elem_type: 9
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        output {
+          name: "cur_i"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        output {
+          name: "scan_output"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+      }
+      type: GRAPH
+    }
+  }
+  name: "loop_graph"
+  input {
+    name: "init_i"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+
+  input {
+    name: "inc"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim{
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "v_final"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "scan_output_final"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 10
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 11
+}
+

--- a/tests/models/onnxModels/loop_withoutN.onnxtxt
+++ b/tests/models/onnxModels/loop_withoutN.onnxtxt
@@ -1,0 +1,187 @@
+ir_version: 6
+producer_name: "jun-onnx-loop-ex"
+graph {
+  node {
+    output: "cond_orig"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 9
+        raw_data: "\001"
+        name: "cond_tensor"
+      }
+      type: TENSOR
+    }
+  }
+  node {
+    output: "max_trip_count"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 7
+        int64_data: 10
+        name: "count_tensor"
+      }
+      type: TENSOR
+    }
+  }
+
+  node {
+    input: "init_i"
+    output: "v_final"
+    op_type: "Identity"
+  }
+
+  node {
+    input: "max_trip_count"
+    input: "cond_orig"
+    output: "scan_output_final"
+    op_type: "Loop"
+    attribute {
+      name: "body"
+      g {
+
+        node {
+          input: "iter_num_in"
+          output: "toFloat"
+          name: "toFloat"
+          op_type: "Cast"
+          attribute {
+            name: "to"
+            i: 1
+            type: INT
+          }
+        }
+        node {
+          input: "pre_cond"
+          output: "cur_cond"
+          op_type: "Identity"
+        }
+        node {
+          input: "toFloat"
+          output: "scan_output"
+          op_type: "Identity"
+        }
+        name: "subgraph"
+        input {
+          name: "iter_num_in"
+          type {
+            tensor_type {
+              elem_type: 7
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        input {
+          name: "pre_cond"
+          type {
+            tensor_type {
+              elem_type: 9
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        output {
+          name: "cur_cond"
+          type {
+            tensor_type {
+              elem_type: 9
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        output {
+          name: "scan_output"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+      }
+      type: GRAPH
+    }
+  }
+  name: "loop_graph"
+  input {
+    name: "init_i"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+
+  input {
+    name: "inc"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim{
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "v_final"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "scan_output_final"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 10
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 11
+}
+

--- a/tests/unittests/OnnxExporterTest.cpp
+++ b/tests/unittests/OnnxExporterTest.cpp
@@ -404,6 +404,12 @@ TEST(exporter, onnxModels) {
         name.find("RangeFloat.onnxtxt") != std::string::npos ||
         name.find("scatterND.onnxtxt") != std::string::npos ||
         name.find("mscatterND.onnxtxt") != std::string::npos ||
+        name.find("loop_cond.onnxtxt") != std::string::npos ||
+        name.find("loop_empty_tripcount.onnxtxt") != std::string::npos ||
+        name.find("loop_emptycond.onnxtxt") != std::string::npos ||
+        name.find("loop_no_iteration.onnxtxt") != std::string::npos ||
+        name.find("loop_tripcount.onnxtxt") != std::string::npos ||
+        name.find("loop_withoutN.onnxtxt") != std::string::npos ||
         name.find("sign.onnxtxt") != std::string::npos ||
         name.find("gatherND.onnxtxt") != std::string::npos ||
         name.find("simpleConvTranspose.onnxtxt") != std::string::npos ||

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -3880,6 +3880,214 @@ TEST(onnx, importSign) {
   importUnary(netFilename, input, inputShape, outputShape, expectedValues);
 }
 
+static void
+testLoop(std::string &filename, const std::vector<dim_t> &expected_v_finalDims,
+         const std::vector<dim_t> &expected_scan_output_finalDims,
+         const std::vector<float> &expected_v_finalValues,
+         const std::vector<float> &expectedscan_output_finalValues) {
+  ExecutionEngine EE;
+  auto &mod = EE.getModule();
+  auto *F = mod.createFunction("main");
+
+  std::string netFilename =
+      std::string(GLOW_DATA_PATH "tests/models/onnxModels/") + filename;
+
+  PlaceholderBindings bindings;
+  Placeholder *v_final;
+  Placeholder *scan_output_final;
+
+  Tensor init_i(ElemKind::FloatTy, {1});
+  init_i.getHandle() = {0};
+  Tensor inc(ElemKind::FloatTy, {1});
+  inc.getHandle() = {1};
+
+  {
+    ONNXModelLoader onnxLD(netFilename, {"init_i", "inc"},
+                           {&init_i.getType(), &inc.getType()}, *F);
+
+    v_final = EXIT_ON_ERR(onnxLD.getOutputByName("v_final"));
+    scan_output_final =
+        EXIT_ON_ERR(onnxLD.getOutputByName("scan_output_final"));
+
+    bindings.allocate(mod.getPlaceholders());
+    updateInputPlaceholdersByName(bindings, &mod, {"init_i", "inc"},
+                                  {&init_i, &inc});
+  }
+
+  auto *v_finalT = bindings.get(v_final);
+  auto *scan_output_finalT = bindings.get(scan_output_final);
+
+  EE.compile(CompilationMode::Infer);
+  EE.run(bindings);
+
+  auto v_finalH = v_finalT->getHandle();
+  auto scan_output_finalH = scan_output_finalT->getHandle();
+
+  EXPECT_EQ(v_finalH.dims().vec(), expected_v_finalDims);
+  EXPECT_EQ(scan_output_finalH.dims().vec(), expected_scan_output_finalDims);
+  for (size_t i = 0; i < expected_v_finalValues.size(); i++) {
+    EXPECT_FLOAT_EQ(v_finalH.raw(i), expected_v_finalValues[i]);
+  }
+  for (size_t i = 0; i < expectedscan_output_finalValues.size(); i++) {
+    EXPECT_FLOAT_EQ(scan_output_finalH.raw(i),
+                    expectedscan_output_finalValues[i]);
+  }
+}
+
+TEST_F(OnnxImporterTest, importLoopStatic) {
+  // In this loop, cond is not changed in the loop body.
+  //
+  // input (trip_count, cond)
+  //
+  // int max_trip_count = 10;
+  // cond = true;
+  // init_i = 0;
+  // for (i=0; i< max_trip_count && cond; ++i){
+  //   scan_output[i] = init_i;
+  //   inti_i = init_i + inc;
+  // }
+  std::string filename("loop_static.onnxtxt");
+  std::vector<dim_t> expected_v_finalDims = {1};
+  std::vector<dim_t> expected_scan_output_finalDims = {10, 1};
+  std::vector<float> expected_v_finalValues = {10.};
+  std::vector<float> expectedscan_output_finalValues = {0., 1., 2., 3., 4.,
+                                                        5., 6., 7., 8., 9.};
+  testLoop(filename, expected_v_finalDims, expected_scan_output_finalDims,
+           expected_v_finalValues, expectedscan_output_finalValues);
+}
+
+TEST_F(OnnxImporterTest, importLoopNoIteration) {
+  // The loop should be zero iteration.
+  //
+  // input (trip_count, 0)
+  //
+  // int max_trip_count = 10;
+  // cond = false;
+  // init_i = 0;
+  // for (i=0; i < max_trip_count && cond; ++i) {
+  //   scan_output[i] = init_i;
+  //   inti_i = init_i + inc;
+  // }
+  std::string filename("loop_no_iteration.onnxtxt");
+  std::vector<dim_t> expected_v_finalDims = {1};
+  std::vector<dim_t> expected_scan_output_finalDims = {1, 1};
+  std::vector<float> expected_v_finalValues = {0.};
+  std::vector<float> expectedscan_output_finalValues = {0.};
+  testLoop(filename, expected_v_finalDims, expected_scan_output_finalDims,
+           expected_v_finalValues, expectedscan_output_finalValues);
+}
+
+TEST(onnx, importLoopCond) {
+  // In this loop, cond is updated in the loop body, but it should be folded
+  // into a Constant during loading time.
+  // The loop should exit by cond.
+  //
+  // input(trip_count, cond) :
+  //
+  // int max_trip_count = 9223372036854775807;
+  // int reduce_i = 20;
+  // for (i=0; i < max_trip_count && cond; ++i) {
+  //   scan_output[i] = reduce_i;
+  //   reduce_i = reduce_i - 1;
+  //   cond = (bool)(reduce_i - 1);
+  // }
+  std::string filename("loop_cond.onnxtxt");
+  std::vector<dim_t> expected_v_finalDims = {1};
+  std::vector<dim_t> expected_scan_output_finalDims = {20, 1};
+  std::vector<float> expected_v_finalValues = {0.};
+  std::vector<float> expectedscan_output_finalValues = {
+      20., 19., 18., 17., 16., 15., 14., 13., 12., 11.,
+      10., 9.,  8.,  7.,  6.,  5.,  4.,  3.,  2.,  1.};
+  testLoop(filename, expected_v_finalDims, expected_scan_output_finalDims,
+           expected_v_finalValues, expectedscan_output_finalValues);
+}
+
+TEST(onnx, importLoopTripCount) {
+  // The loop should exit by trip_count.
+  //
+  // input(trip_count, cond) :
+  //
+  // int max_trip_count = 20;
+  // int reduce_i = 20;
+  // for (i=0; i < max_trip_count && cond; ++i) {
+  //   scan_output[i] = reduce_i;
+  //   reduce_i = reduce_i - 1;
+  //   cond = (bool)(reduce_i - 1);
+  //  }
+  std::string filename("loop_tripcount.onnxtxt");
+  std::vector<dim_t> expected_v_finalDims = {1};
+  std::vector<dim_t> expected_scan_output_finalDims = {20, 1};
+  std::vector<float> expected_v_finalValues = {0.0};
+  std::vector<float> expectedscan_output_finalValues = {
+      20., 19., 18., 17., 16., 15., 14., 13., 12., 11.,
+      10., 9.,  8.,  7.,  6.,  5.,  4.,  3.,  2.,  1.};
+  testLoop(filename, expected_v_finalDims, expected_scan_output_finalDims,
+           expected_v_finalValues, expectedscan_output_finalValues);
+}
+
+TEST(onnx, importLoopEmptyTripCount) {
+  // The loop should ignore trip-count, so exit by cond.
+  //
+  // input ("", 1)
+  //
+  // int reduce_i = 10;
+  // bool cond = true;
+  // for (int i = 0; cond; ++i) {
+  //   scan_output[i] = reduce_i;
+  //   reduce_i = reduce_i - 1;
+  //   cond = (bool)reduce_i;
+  // }
+  std::string filename("loop_empty_tripcount.onnxtxt");
+  std::vector<dim_t> expected_v_finalDims = {1};
+  std::vector<dim_t> expected_scan_output_finalDims = {10, 1};
+  std::vector<float> expected_v_finalValues = {0.};
+  std::vector<float> expectedscan_output_finalValues = {10., 9., 8., 7., 6.,
+                                                        5.,  4., 3., 2., 1.};
+  testLoop(filename, expected_v_finalDims, expected_scan_output_finalDims,
+           expected_v_finalValues, expectedscan_output_finalValues);
+}
+
+TEST(onnx, importLoopEmptyCond) {
+  // The loop should ignore cond, so exit by trip_count.
+  //
+  // input(trip_count, "") :
+  //
+  // int max_trip_count = 7;
+  // int reduce_i = 5;
+  // for (i=0; i < max_trip_count; ++i) {
+  //   scan_output[i] = reduce_i;
+  //   reduce_i = reduce_i - 1;
+  //   cond = (bool)(reduce_i - 1); // ignored
+  // }
+  std::string filename("loop_emptycond.onnxtxt");
+  std::vector<dim_t> expected_v_finalDims = {1};
+  std::vector<dim_t> expected_scan_output_finalDims = {7, 1};
+  std::vector<float> expected_v_finalValues = {-2.0};
+  std::vector<float> expectedscan_output_finalValues = {5., 4., 3., 2.,
+                                                        1., 0., -1.};
+  testLoop(filename, expected_v_finalDims, expected_scan_output_finalDims,
+           expected_v_finalValues, expectedscan_output_finalValues);
+}
+
+TEST(onnx, importLoopWithoutN) {
+  // The loop should exit by trip_count.
+  //
+  // input(trip_count, cond) :
+  // bool cond = true;
+  // int max_trip_count = 10;
+  // for (i=0; i < max_trip_count && cond; ++i) {
+  //   scan_output[i] = i;
+  //  }
+  std::string filename("loop_withoutN.onnxtxt");
+  std::vector<dim_t> expected_v_finalDims = {1};
+  std::vector<dim_t> expected_scan_output_finalDims = {10, 1};
+  std::vector<float> expected_v_finalValues = {0.0};
+  std::vector<float> expectedscan_output_finalValues = {0., 1., 2., 3., 4.,
+                                                        5., 6., 7., 8., 9.};
+  testLoop(filename, expected_v_finalDims, expected_scan_output_finalDims,
+           expected_v_finalValues, expectedscan_output_finalValues);
+}
+
 /// Test loading RNN from a ONNX model. The ONNX model already computes
 /// the error compared to a PyTorch reference implementation.
 static void importRNN(std::string fileName) {


### PR DESCRIPTION
Author: Jun Bum Lim <junlim@cadence.com>

Summary:
Add support for ONNX Loop operator by unrolling in loader. This approach supports only static loops where the max trip-count and condition is constant or foldable to constant during model loading time.
While this might not always be the best solution from performance perspective, it allows to run new types of networks in Glow.

Documentation:
N/A

Test Plan:
Added ONNX importer unit tests.
