### PR TITLE
Fix Casting from float16 to Integer Type

### DIFF
--- a/include/glow/Support/Float16.h
+++ b/include/glow/Support/Float16.h
@@ -65,8 +65,12 @@ public:
   /// Cast operators.
   operator double() const { return double(operator float()); }
   operator float() const { return fp16_ieee_to_fp32_value(data_); }
-  operator int64_t() const { return static_cast<int64_t>(data_); }
-  operator int32_t() const { return static_cast<int32_t>(data_); }
+  operator int64_t() const {
+    return static_cast<int64_t>(fp16_ieee_to_fp32_value(data_));
+  }
+  operator int32_t() const {
+    return static_cast<int32_t>(fp16_ieee_to_fp32_value(data_));
+  }
 }; // End class float16.
 
 /// Allow float16_t to be passed to an ostream.

--- a/tests/unittests/Float16Test.cpp
+++ b/tests/unittests/Float16Test.cpp
@@ -98,3 +98,18 @@ TEST(Float16, le) {
   EXPECT_EQ(a <= b, float(a) <= float(b));
   EXPECT_TRUE(a <= b);
 }
+
+template <typename T> static void testConvertTo() {
+  float16 a = 19.3;
+  T b = static_cast<T>(19.3);
+  EXPECT_NEAR(T(a), b, 1);
+}
+
+#define TEST_CONVERT_TO(DEST_TYPE)                                             \
+  TEST(Float16, CONVERT_TO_##DEST_TYPE) { testConvertTo<DEST_TYPE>(); }
+TEST_CONVERT_TO(float)
+TEST_CONVERT_TO(double)
+TEST_CONVERT_TO(int32_t)
+TEST_CONVERT_TO(int64_t)
+
+#undef TEST_CONVERT_TO


### PR DESCRIPTION
Summary:
Before the fix, when casting float16 to int32 or int64, we are calling static_cast on float16 directly. This gives a wrong result since float16 is defined using a proxy type uint16_t.

So when casting float16 to int type, we convert it to fp32 first then do static cast. Unittests are added to ensure the results are correct.

Reviewed By: jfix71

Differential Revision: D24067917

