### PR TITLE
Add API of exposing JIT node index for debuging

### DIFF
--- a/torch_glow/src/GlowFuser.cpp
+++ b/torch_glow/src/GlowFuser.cpp
@@ -324,6 +324,11 @@ void glowCustomFuseImpl(std::shared_ptr<torch::jit::Graph> graph,
     if (settings.fusionEndIndex >= 0 && i >= settings.fusionEndIndex) {
       indexBlacklistedNodes.insert(node);
     }
+    if (settings.printJITIndex) {
+      std::vector<const torch::jit::Node *> groups;
+      std::cout << "index: " << i;
+      node->print(std::cout, 1, &groups, false);
+    }
     i++;
   }
 

--- a/torch_glow/src/PyTorchCommon.cpp
+++ b/torch_glow/src/PyTorchCommon.cpp
@@ -42,6 +42,7 @@ DEFINE_bool(saturateHost, false, "See PyTorchLoaderSettings");
 
 DEFINE_int32(torch_glow_min_fusion_group_size, 1,
              "Minimum number of nodes in the glow fusion group");
+DEFINE_bool(printJITIndex, false, "Enable printing of jit node indexes");
 DEFINE_bool(dumpGlowDag, false, "See PyTorchLoaderSettings");
 DEFINE_bool(jitVsGlowCompare, false, "Enable per-group error check");
 DEFINE_bool(dumpFinalGlowGraph, false, "See PyTorchLoaderSettings");
@@ -238,6 +239,7 @@ void PyTorchLoaderSettings::initSettings() {
   minFusionGroupSize = FLAGS_torch_glow_min_fusion_group_size;
   dumpGlowDag = FLAGS_dumpGlowDag;
   jitVsGlowCompare = FLAGS_jitVsGlowCompare;
+  printJITIndex = FLAGS_printJITIndex;
   dumpFinalGlowGraph = FLAGS_dumpFinalGlowGraph;
   enableGlowTracing = FLAGS_enableGlowTracing;
   numTracesPerDump = FLAGS_numTracesPerDump;

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -89,6 +89,9 @@ public:
   bool get_convert_fused_to_fp16() { return convertFusedToFP16; }
   void set_convert_fused_to_fp16(bool val) { convertFusedToFP16 = val; }
 
+  /// Print all JIT node indexes for debugging use.
+  bool printJITIndex = false;
+
   /// Add clip operators after each fp16 ops during Glow compilation.
   bool clipFP16 = false;
 

--- a/torch_glow/src/binding.cpp
+++ b/torch_glow/src/binding.cpp
@@ -68,6 +68,14 @@ PYBIND11_MODULE(_torch_glow, m) {
   m.def("disableDumpGlowDag",
         []() { getPyTorchLoaderSettings().dumpGlowDag = false; });
 
+  /// Enable printing index of all jit node for debugging
+  m.def("enable_printing_jit_node_indices",
+        []() { getPyTorchLoaderSettings().printJITIndex = true; });
+
+  /// Disable printing index of all jit node for debugging
+  m.def("disable_printing_jit_node_indices",
+        []() { getPyTorchLoaderSettings().printJITIndex = false; });
+
   /// Enable converting fp32 ops to fp16.
   m.def("enable_convert_to_fp16",
         []() { getPyTorchLoaderSettings().convertToFP16 = true; });

--- a/torch_glow/tests/functionality/print_jit_index_test.py
+++ b/torch_glow/tests/functionality/print_jit_index_test.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+
+import torch
+import torch_glow
+
+
+class TestPrintJitNodeIndices(unittest.TestCase):
+    """Test printing PyTorch jit node indices."""
+
+    def test_print_jit_indices(self):
+        def test_f(a, b):
+            c = a.add(b)
+            return c.add(c)
+
+        x = torch.randn(4)
+        y = torch.randn(4)
+
+        torch_glow.enableFusionPass()
+        torch_glow.enable_printing_jit_node_indices()
+
+        graph = torch.jit.trace(test_f, (x, y), check_trace=False)
+        graph(x, y)


### PR DESCRIPTION
Summary:
In order to debug/blacklist by index, we would like to know the index of each JIT node.
This new added API
  torch_glow.enablePrintingJITIndex()
will enable this functionality.

The example output looks like:
  index: 0  %2 : int = prim::Constant[value=1]()
  index: 1  %c : Float(*, requires_grad=0, device=cpu) = aten::add(%a, %b, %2)
  index: 2  %4 : Float(*, requires_grad=0, device=cpu) = aten::add(%c, %c, %2)
  index: 3  %5 : bool = prim::Constant[value=1]()
And the original jit graph is:
  with glow::FusionGroup_0 = graph(%3 : Float(*, requires_grad=0, device=cpu),
      %4 : Float(*, requires_grad=0, device=cpu)):
  %5 : int = prim::Constant[value=1]()
  %c : Float(*, requires_grad=0, device=cpu) = aten::add(%3, %4, %5) # /data/users/zrphercule/fbsource/fbcode/buck-out/dev/gen/glow/glow/torch_glow/tests/print_jit_index_example#link-tree/glow/glow/torch_glow/tests/scripts/print_jit_index.py:6:0
  %1 : int = prim::Constant[value=1]()
  %2 : Float(*, requires_grad=0, device=cpu) = aten::add(%c, %c, %1) # /data/users/zrphercule/fbsource/fbcode/buck-out/dev/gen/glow/glow/torch_glow/tests/print_jit_index_example#link-tree/glow/glow/torch_glow/tests/scripts/print_jit_index.py:7:0
  return (%2)

Reviewed By: jackm321

Differential Revision: D23857944

