### PR TITLE
[ONNXModelLoader, Caffe2ModelLoader] Separate PRelu loaders for ONNX …

### DIFF
--- a/include/glow/Importer/Caffe2ModelLoader.h
+++ b/include/glow/Importer/Caffe2ModelLoader.h
@@ -68,6 +68,10 @@ class Caffe2ModelLoader
   /// Helper function to print better log information for operator failure cases
   const std::string opErrMsg(const caffe2::OperatorDef &op,
                              const std::string &errMsg);
+
+  /// Load the PRelu operator.
+  Error loadPRelu(const caffe2::OperatorDef &op, ArgumentDictionaryTy &dict);
+
   /// Load the Conv or ConvRelu operators.
   Error loadConv(const caffe2::OperatorDef &op, ArgumentDictionaryTy &dict);
 

--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -325,29 +325,6 @@ protected:
     return Error::success();
   }
 
-  /// Loads PRELU operator, given its protobuf representation and parsed args.
-  /// Follows undirectional broadcasting described here:
-  /// https://github.com/onnx/onnx/blob/fb1a80692c1ab0bd27b1072f2e7bffacba336777/docs/Broadcasting.md
-  Error loadPRelu(const OpType &op, ArgumentDictionaryTy &dict) {
-    const std::string &opName = loadOperatorName(op);
-
-    NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
-
-    NodeValue slope;
-    ASSIGN_VALUE_OR_RETURN_ERR(slope, getNodeValueByName(op.input(1)));
-
-    // Do broadcasting.
-    auto targetDim = in.dims();
-    // Sets the axis of each inputs so that the trailing-most dimensions of
-    // input tensors and the target shape are aligned.
-    int axis = targetDim.size() - slope.dims().size();
-    auto *finalSlope = G_->createBroadcast(opName, slope, targetDim, axis);
-    auto *R = G_->createPRELU(opName, in, finalSlope);
-    RETURN_IF_ERR(addNodeAsOutput(op, R));
-    return Error::success();
-  }
-
 #define LOAD_UNARY_OP(OPNAME)                                                  \
   Error load##OPNAME(const OpType &op, ArgumentDictionaryTy &dict) {           \
     const std::string &opName = loadOperatorName(op);                          \
@@ -1308,10 +1285,6 @@ protected:
                                        ArgumentDictionaryTy &dict) {
     if (typeName == "Relu") {
       RETURN_IF_ERR(loadRelu(op, dict));
-      return true;
-    }
-    if (typeName == "PRelu") {
-      RETURN_IF_ERR(loadPRelu(op, dict));
       return true;
     }
     if (typeName == "Sigmoid") {

--- a/include/glow/Importer/ONNXModelLoader.h
+++ b/include/glow/Importer/ONNXModelLoader.h
@@ -158,6 +158,10 @@ class ONNXModelLoader
   Error loadRange(const ONNX_NAMESPACE::NodeProto &op,
                   ArgumentDictionaryTy &dict);
 
+  /// Load PRelu ONNX operator.
+  Error loadPRelu(const ONNX_NAMESPACE::NodeProto &op,
+                  ArgumentDictionaryTy &dict);
+
   /// Load Slice ONNX operator.
   Error loadSlice(const ONNX_NAMESPACE::NodeProto &op,
                   ArgumentDictionaryTy &dict);

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -1239,6 +1239,27 @@ Error ONNXModelLoader::loadRange(const ONNX_NAMESPACE::NodeProto &op,
   }
 }
 
+Error ONNXModelLoader::loadPRelu(const ONNX_NAMESPACE::NodeProto &op,
+                                 ArgumentDictionaryTy &dict) {
+  const std::string &opName = loadOperatorName(op);
+
+  NodeValue in;
+  ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
+
+  NodeValue slope;
+  ASSIGN_VALUE_OR_RETURN_ERR(slope, getNodeValueByName(op.input(1)));
+
+  // Do broadcasting.
+  auto targetDim = in.dims();
+  // Sets the axis of each inputs so that the trailing-most dimensions of
+  // input tensors and the target shape are aligned.
+  int axis = targetDim.size() - slope.dims().size();
+  auto *finalSlope = G_->createBroadcast(opName, slope, targetDim, axis);
+  auto *R = G_->createPRELU(opName, in, finalSlope);
+  RETURN_IF_ERR(addNodeAsOutput(op, R));
+  return Error::success();
+}
+
 Error ONNXModelLoader::loadSlice(const ONNX_NAMESPACE::NodeProto &op,
                                  ArgumentDictionaryTy &dict) {
   const std::string &opName = loadOperatorName(op);
@@ -4475,6 +4496,9 @@ Error ONNXModelLoader::loadOperator(const ONNX_NAMESPACE::NodeProto &op) {
   }
   if (typeName == "Range") {
     return loadRange(op, dict);
+  }
+  if (typeName == "PRelu") {
+    return loadPRelu(op, dict);
   }
   if (typeName == "Slice") {
     return loadSlice(op, dict);

--- a/tests/models/caffe2Models/prelu.pbtxt
+++ b/tests/models/caffe2Models/prelu.pbtxt
@@ -1,0 +1,10 @@
+name: "prelu"
+op {
+  input: "prelu_test_input"
+  input: "slope"
+  output: "prelu_test_output"
+  type: "PRelu"
+}
+external_input: "prelu_test_input"
+external_input: "slope"
+external_output: "prelu_test_output"


### PR DESCRIPTION
Change-Id: I3f729bf2fb40ba67c580714869bfb0a66f200a35

Summary: The existing PReLU loader API in commonoperatorloader supports only onnx and it can't be used for caffe2. Hence, 
two separate loaders for ONNX and caff2 are added. 

Test Plan: Ninja test and added caffe2importer test