### PR TITLE
add missing return for failed inference pool init

### DIFF
--- a/lib/Backends/NNPI/NNPIDeviceManager.cpp
+++ b/lib/Backends/NNPI/NNPIDeviceManager.cpp
@@ -188,6 +188,7 @@ void NNPIDeviceManager::addNetwork(const Module *module,
       functions_.erase(func.first);
       lock.unlock();
       readyCB(module, std::move(err));
+      return;
     }
   }
 


### PR DESCRIPTION
Summary: This was caught by an unchecked error in debug mode. Otherwise we were setting an actual error through the callback, and then falling through to the normal return and setting success through the callback.

Differential Revision: D24116103

