### PR TITLE
BBoxTransform FP16 Support and Torch_Glow node tests

### DIFF
--- a/include/glow/Backends/Interpreter/InterpreterFunction.h
+++ b/include/glow/Backends/Interpreter/InterpreterFunction.h
@@ -382,6 +382,7 @@ private:
   template <typename T>
   void fwdROIAlignInstFloatImpl(glow::ROIAlignInst const *I);
 
+  template <typename T>
   void fwdBBoxTransformInstFloatImpl(glow::BBoxTransformInst const *I);
 
   template <typename T, typename AccumT>

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -668,10 +668,8 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
                /*ignoreIn*/ {ROIAlignNode::BatchIndicesIdx});
 
   case Kinded::Kind::BBoxTransformNodeKind:
-    return NI.getInElemTy(BBoxTransformNode::RoisIdx) == ElemKind::FloatTy &&
-           NI.getInElemTy(BBoxTransformNode::DeltasIdx) == ElemKind::FloatTy &&
-           NI.getInElemTy(BBoxTransformNode::ImInfoIdx) == ElemKind::FloatTy &&
-           NI.getOutElemTy(BBoxTransformNode::BoxOutIdx) == ElemKind::FloatTy;
+    return NI.allInputsAndOutputsHaveSameElemKind(
+        {ElemKind::FloatTy, ElemKind::Float16Ty});
 
   case Kinded::Kind::SoftMaxGradNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -6024,110 +6024,112 @@ void BoundInterpreterFunction::fwdROIAlignInst(glow::ROIAlignInst const *I) {
 // see "Rich feature hierarchies for accurate object detection and semantic
 //     segmentation" Appendix C for more details
 // reference: detectron/lib/utils/boxes.py bbox_transform()
-static void
-bbox_transform_upright(Handle<float> &boxesOut, const Handle<float> &boxes,
-                       const Handle<float> &deltas, dim_t startRowBoxesOut,
-                       dim_t startColBoxesOut, dim_t startRowBoxes,
-                       dim_t startColBoxes, dim_t startRowDeltas,
-                       dim_t startColDeltas, dim_t rows, dim_t cols,
-                       llvm::ArrayRef<float> weights, const float bboxXformClip,
-                       float scaleBeforeInv, const bool legacyPlusOne = false) {
+template <typename T>
+static void bbox_transform_upright(
+    Handle<T> &boxesOut, const Handle<T> &boxes, const Handle<T> &deltas,
+    dim_t startRowBoxesOut, dim_t startColBoxesOut, dim_t startRowBoxes,
+    dim_t startColBoxes, dim_t startRowDeltas, dim_t startColDeltas, dim_t rows,
+    llvm::ArrayRef<float> weights, const T &bboxXformClip, T scaleBeforeInv,
+    const bool legacyPlusOne = false) {
 
   if (boxes.dims()[0] == 0) {
     return;
   }
 
-  std::vector<float> widths(rows), heights(rows), ctrX(rows), ctrY(rows);
+  std::vector<T> widths(rows), heights(rows), ctrX(rows), ctrY(rows);
   for (dim_t i = 0; i < rows; i++) {
     widths[i] = boxes.at({startRowBoxes + i, startColBoxes + dim_t(2)}) *
                     scaleBeforeInv -
                 boxes.at({startRowBoxes + i, startColBoxes}) * scaleBeforeInv +
-                float(int(legacyPlusOne));
+                T(((legacyPlusOne) ? 1 : 0));
     heights[i] = boxes.at({startRowBoxes + i, startColBoxes + dim_t(3)}) *
                      scaleBeforeInv -
                  boxes.at({startRowBoxes + i, startColBoxes + dim_t(1)}) *
                      scaleBeforeInv +
-                 float(int(legacyPlusOne));
+                 T(((legacyPlusOne) ? 1 : 0));
 
     ctrX[i] = boxes.at({startRowBoxes + i, startColBoxes}) * scaleBeforeInv +
-              float(0.5) * widths[i];
+              T(0.5) * widths[i];
     ctrY[i] = boxes.at({startRowBoxes + i, startColBoxes + dim_t(1)}) *
                   scaleBeforeInv +
-              float(0.5) * heights[i];
+              T(0.5) * heights[i];
   }
 
-  std::vector<float> dx(rows), dy(rows), dw(rows), dh(rows);
+  std::vector<T> dx(rows), dy(rows), dw(rows), dh(rows);
   for (dim_t i = 0; i < rows; i++) {
-    dx[i] = deltas.at({startRowDeltas + i, startColDeltas}) / weights[0];
-    dy[i] =
-        deltas.at({startRowDeltas + i, startColDeltas + dim_t(1)}) / weights[1];
-    dw[i] = std::min(
-        deltas.at({startRowDeltas + i, startColDeltas + dim_t(2)}) / weights[2],
-        bboxXformClip);
-    dh[i] = std::min(
-        deltas.at({startRowDeltas + i, startColDeltas + dim_t(3)}) / weights[3],
-        bboxXformClip);
+    dx[i] = deltas.at({startRowDeltas + i, startColDeltas}) / T(weights[0]);
+    dy[i] = deltas.at({startRowDeltas + i, startColDeltas + dim_t(1)}) /
+            T(weights[1]);
+    dw[i] =
+        std::min(deltas.at({startRowDeltas + i, startColDeltas + dim_t(2)}) /
+                     T(weights[2]),
+                 bboxXformClip);
+    dh[i] =
+        std::min(deltas.at({startRowDeltas + i, startColDeltas + dim_t(3)}) /
+                     T(weights[3]),
+                 bboxXformClip);
   }
 
-  std::vector<float> predCtrX(rows), predCtrY(rows), predW(rows), predH(rows);
+  std::vector<T> predCtrX(rows), predCtrY(rows), predW(rows), predH(rows);
   for (dim_t i = 0; i < rows; i++) {
     predCtrX[i] = dx[i] * widths[i] + ctrX[i];
     predCtrY[i] = dy[i] * heights[i] + ctrY[i];
-    predW[i] = std::exp(dw[i]) * widths[i];
-    predH[i] = std::exp(dh[i]) * heights[i];
+    predW[i] = T(std::exp(float(dw[i]))) * widths[i];
+    predH[i] = T(std::exp(float(dh[i]))) * heights[i];
   }
 
   for (dim_t i = 0; i < rows; i++) {
     // x1
     boxesOut.at({startRowBoxesOut + i, startColBoxesOut}) =
-        predCtrX[i] - float(0.5) * predW[i];
+        predCtrX[i] - T(0.5) * predW[i];
     // x2
     boxesOut.at({startRowBoxesOut + i, startColBoxesOut + dim_t(1)}) =
-        predCtrY[i] - float(0.5) * predH[i];
+        predCtrY[i] - T(0.5) * predH[i];
     // y1
     boxesOut.at({startRowBoxesOut + i, startColBoxesOut + dim_t(2)}) =
-        predCtrX[i] + float(0.5) * predW[i] - float(int(legacyPlusOne));
+        predCtrX[i] + T(0.5) * predW[i] - T(((legacyPlusOne) ? 1 : 0));
     // y2
     boxesOut.at({startRowBoxesOut + i, startColBoxesOut + dim_t(3)}) =
-        predCtrY[i] + float(0.5) * predH[i] - float(int(legacyPlusOne));
+        predCtrY[i] + T(0.5) * predH[i] - T(((legacyPlusOne) ? 1 : 0));
   }
 }
 
 // Clip boxes to image boundaries
 // boxes: pixel coordinates of bounding box, size (M * 4)
-void clip_boxes_upright(Handle<float> &boxes, dim_t startRowBoxes,
-                        dim_t startColBoxes, dim_t rows, dim_t cols, int height,
-                        int width, float scaleAfter,
-                        bool legacyPlusOne = false) {
+template <typename T>
+void clip_boxes_upright(Handle<T> &boxes, dim_t startRowBoxes,
+                        dim_t startColBoxes, dim_t rows, int height, int width,
+                        T scaleAfter, bool legacyPlusOne = false) {
   for (dim_t i = 0; i < rows; i++) {
     // x1 >= 0 && x1 < width
     boxes.at({startRowBoxes + i, startColBoxes}) =
         scaleAfter *
         std::max(std::min(boxes.at({startRowBoxes + i, startColBoxes}),
-                          float(width - int(legacyPlusOne))),
-                 float(0));
+                          T(width - int(((legacyPlusOne) ? 1 : 0)))),
+                 T(0));
     // y1 >= 0 && y1 < height
     boxes.at({startRowBoxes + i, startColBoxes + dim_t(1)}) =
         scaleAfter * std::max(std::min(boxes.at({startRowBoxes + i,
                                                  startColBoxes + dim_t(1)}),
-                                       float(height - int(legacyPlusOne))),
-                              float(0));
+                                       T(height - ((legacyPlusOne) ? 1 : 0))),
+                              T(0));
 
     // x2 >= 0 && x2 < width
     boxes.at({startRowBoxes + i, startColBoxes + 2}) =
         scaleAfter * std::max(std::min(boxes.at({startRowBoxes + i,
                                                  startColBoxes + dim_t(2)}),
-                                       float(width - int(legacyPlusOne))),
-                              float(0));
+                                       T(width - ((legacyPlusOne) ? 1 : 0))),
+                              T(0));
     // y2 >= 0 && y2 < height
     boxes.at({startRowBoxes + i, startColBoxes + 3}) =
         scaleAfter * std::max(std::min(boxes.at({startRowBoxes + i,
                                                  startColBoxes + dim_t(3)}),
-                                       float(height - int(legacyPlusOne))),
-                              float(0));
+                                       T(height - ((legacyPlusOne) ? 1 : 0))),
+                              T(0));
   }
 }
 
+template <typename T>
 void BoundInterpreterFunction::fwdBBoxTransformInstFloatImpl(
     glow::BBoxTransformInst const *I) {
   auto roiIn = I->getRois();
@@ -6145,9 +6147,9 @@ void BoundInterpreterFunction::fwdBBoxTransformInstFloatImpl(
   const dim_t numClasses = deltaIn->dims()[1] / boxDim;
   const dim_t batchSize = imInfoIn->dims()[0];
 
-  auto roisH = getTensor(roiIn)->getHandle<float>();
-  auto deltasH = getTensor(deltaIn)->getHandle<float>();
-  auto roiBatchSplitsH = getTensor(roiBatchSplits)->getHandle<float>();
+  auto roisH = getTensor(roiIn)->getHandle<T>();
+  auto deltasH = getTensor(deltaIn)->getHandle<T>();
+  auto roiBatchSplitsH = getTensor(roiBatchSplits)->getHandle<T>();
 
   // Count the number of RoIs per batch
   std::vector<int> numRoisPerBatch(batchSize, 0);
@@ -6160,44 +6162,43 @@ void BoundInterpreterFunction::fwdBBoxTransformInstFloatImpl(
     }
   }
 
-  auto imInfoH = getTensor(imInfoIn)->getHandle<float>();
-  auto boxOutH = getTensor(boxOut)->getHandle<float>();
+  auto imInfoH = getTensor(imInfoIn)->getHandle<T>();
+  auto boxOutH = getTensor(boxOut)->getHandle<T>();
   getTensor(boxOut)->zero();
 
   // Default value for minimum bounding box width and height after bounding
   // box transformation (bbox_transform()) in log-space
-  const float bboxXformClip = std::log(1000.0 / 16.0);
+  const T bboxXformClip = std::log(1000.0 / 16.0);
 
   // We assume roiIn and deltaIn over multiple batches are grouped
   // together in increasing order as generated by GenerateProposalsOp
   dim_t offset = 0;
   for (dim_t i = 0; i < batchSize; ++i) {
     const dim_t numRois = numRoisPerBatch[i];
-    const float scaleBefore = imInfoH.at({i, 2});
-    const float scaleAfter = applyScale ? scaleBefore : 1.0;
-    dim_t imgH = dim_t(imInfoH.at({i, 0}) / scaleBefore + 0.5);
-    dim_t imgW = dim_t(imInfoH.at({i, 1}) / scaleBefore + 0.5);
+    const T scaleBefore = imInfoH.at({i, 2});
+    const T scaleAfter = applyScale ? scaleBefore : T(1.0);
+    dim_t imgH = dim_t(float(imInfoH.at({i, 0}) / scaleBefore) + 0.5);
+    dim_t imgW = dim_t(float(imInfoH.at({i, 1}) / scaleBefore) + 0.5);
 
     // Apply for the rectangle starting at (startRowRoi, startColRoi)
-    // with height (Rows) of unm_rois, and width (Cols) of boxDim.
+    // with height (Rows) of num_rois, and width (Cols) of boxDim.
     dim_t startRowRoi = offset;
     dim_t startColRoi = batchSize > 1 ? 1 : 0;
     dim_t rows = numRois;
-    dim_t cols = boxDim;
-    float scaleBeforeInv = 1 / scaleBefore;
+    T scaleBeforeInv = T(1) / scaleBefore;
 
     // scale before and after on the fly.
     // Do not apply scale for angle in rotated boxes
     for (dim_t k = 0; k < numClasses; k++) {
       dim_t startRowDelta = offset;
       dim_t startColDelta = k * boxDim;
-      bbox_transform_upright(boxOutH, roisH, deltasH, startRowDelta,
-                             startColDelta, startRowRoi, startColRoi,
-                             startRowDelta, startColDelta, rows, cols, weights,
-                             bboxXformClip, scaleBeforeInv, legacyPlusOne);
+      bbox_transform_upright<T>(boxOutH, roisH, deltasH, startRowDelta,
+                                startColDelta, startRowRoi, startColRoi,
+                                startRowDelta, startColDelta, rows, weights,
+                                bboxXformClip, scaleBeforeInv, legacyPlusOne);
 
-      clip_boxes_upright(boxOutH, startRowDelta, startColDelta, rows, cols,
-                         imgH, imgW, scaleAfter, legacyPlusOne);
+      clip_boxes_upright<T>(boxOutH, startRowDelta, startColDelta, rows, imgH,
+                            imgW, scaleAfter, legacyPlusOne);
     }
 
     offset += rows;
@@ -6210,5 +6211,6 @@ void BoundInterpreterFunction::fwdBBoxTransformInstFloatImpl(
 
 void BoundInterpreterFunction::fwdBBoxTransformInst(
     glow::BBoxTransformInst const *I) {
-  fwdBBoxTransformInstFloatImpl(I);
+  dispatchFloatingPointImpl(fwdBBoxTransformInstFloatImpl,
+                            I->getRois()->getElementType(), I);
 }

--- a/lib/Backends/Interpreter/tests/InterpreterOperatorTest.cpp
+++ b/lib/Backends/Interpreter/tests/InterpreterOperatorTest.cpp
@@ -31,5 +31,4 @@ std::set<std::string> glow::backendTestBlacklist = {
     "EmbeddingBagByteRowwiseOffsets_Float_End_Offset_Partial/0",
     "EmbeddingBagByteRowwiseOffsets_Float16_AccumFloat_End_Offset_Partial/0",
     "EmbeddingBagByteRowwiseOffsets_Float16_AccumFloat16_End_Offset_Partial/0",
-    "BBoxTransform_Float16/0",
 };

--- a/torch_glow/tests/nodes/bbox_transform_test.py
+++ b/torch_glow/tests/nodes/bbox_transform_test.py
@@ -1,0 +1,220 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+
+import numpy as np
+import torch
+from tests.utils import jitVsGlow
+
+
+def generate_rois(roi_counts, im_dims):
+    assert len(roi_counts) == len(im_dims)
+    all_rois = []
+    for i, num_rois in enumerate(roi_counts):
+        if num_rois == 0:
+            continue
+        # [batch_idx, x1, y1, x2, y2]
+        rois = np.random.uniform(0, im_dims[i], size=(roi_counts[i], 5)).astype(
+            np.float32
+        )
+        rois[:, 0] = i  # batch_idx
+        # Swap (x1, x2) if x1 > x2
+        rois[:, 1], rois[:, 3] = (
+            np.minimum(rois[:, 1], rois[:, 3]),
+            np.maximum(rois[:, 1], rois[:, 3]),
+        )
+        # Swap (y1, y2) if y1 > y2
+        rois[:, 2], rois[:, 4] = (
+            np.minimum(rois[:, 2], rois[:, 4]),
+            np.maximum(rois[:, 2], rois[:, 4]),
+        )
+        all_rois.append(rois)
+    if len(all_rois) > 0:
+        return np.vstack(all_rois)
+    return np.empty((0, 5)).astype(np.float32)
+
+
+def generate_rois_rotated(roi_counts, im_dims):
+    rois = generate_rois(roi_counts, im_dims)
+    # [batch_id, ctr_x, ctr_y, w, h, angle]
+    rotated_rois = np.empty((rois.shape[0], 6)).astype(np.float32)
+    rotated_rois[:, 0] = rois[:, 0]  # batch_id
+    rotated_rois[:, 1] = (rois[:, 1] + rois[:, 3]) / 2.0  # ctr_x = (x1 + x2) / 2
+    rotated_rois[:, 2] = (rois[:, 2] + rois[:, 4]) / 2.0  # ctr_y = (y1 + y2) / 2
+    rotated_rois[:, 3] = rois[:, 3] - rois[:, 1] + 1.0  # w = x2 - x1 + 1
+    rotated_rois[:, 4] = rois[:, 4] - rois[:, 2] + 1.0  # h = y2 - y1 + 1
+    rotated_rois[:, 5] = np.random.uniform(-90.0, 90.0)  # angle in degrees
+    return rotated_rois
+
+
+def create_bbox_transform_inputs(roi_counts, num_classes, rotated):
+    batch_size = len(roi_counts)
+    total_rois = sum(roi_counts)
+    im_dims = np.random.randint(100, 600, batch_size)
+    rois = (
+        generate_rois_rotated(roi_counts, im_dims)
+        if rotated
+        else generate_rois(roi_counts, im_dims)
+    )
+    box_dim = 5 if rotated else 4
+    deltas = np.random.randn(total_rois, box_dim * num_classes).astype(np.float32)
+    im_info = np.zeros((batch_size, 3)).astype(np.float32)
+    im_info[:, 0] = im_dims
+    im_info[:, 1] = im_dims
+    im_info[:, 2] = np.random.random()
+    return rois, deltas, im_info
+
+
+class TestBBoxTransform(unittest.TestCase):
+    def test_bbox_transform_basic(self):
+        """Test of the _caffe2::BBoxTransform Node on Glow."""
+
+        def test_f(rois, deltas, im_info):
+            return torch.ops._caffe2.BBoxTransform(
+                rois,
+                deltas,
+                im_info,
+                weights=[1.0, 1.0, 1.0, 1.0],
+                apply_scale=False,
+                rotated=False,
+                angle_bound_on=False,
+                angle_bound_lo=-90,
+                angle_bound_hi=90,
+                clip_angle_thresh=1.0,
+                legacy_plus_one=False,
+            )
+
+        roi_counts, num_classes = ([5, 4, 3, 2, 1], 3)
+        rois, deltas, im_info = create_bbox_transform_inputs(
+            roi_counts, num_classes, False
+        )
+        jitVsGlow(
+            test_f,
+            torch.tensor(rois),
+            torch.tensor(deltas),
+            torch.tensor(im_info),
+            expected_fused_ops={"_caffe2::BBoxTransform"},
+        )
+
+    def test_bbox_transform_basic_legacy_plus_one(self):
+        """Test of the _caffe2::BBoxTransform Node on Glow."""
+
+        def test_f(rois, deltas, im_info):
+            return torch.ops._caffe2.BBoxTransform(
+                rois,
+                deltas,
+                im_info,
+                weights=[1.0, 1.0, 1.0, 1.0],
+                apply_scale=False,
+                rotated=False,
+                angle_bound_on=False,
+                angle_bound_lo=-90,
+                angle_bound_hi=90,
+                clip_angle_thresh=1.0,
+                legacy_plus_one=True,
+            )
+
+        roi_counts, num_classes = ([5, 4, 3, 2, 1], 3)
+        rois, deltas, im_info = create_bbox_transform_inputs(
+            roi_counts, num_classes, False
+        )
+        jitVsGlow(
+            test_f,
+            torch.tensor(rois),
+            torch.tensor(deltas),
+            torch.tensor(im_info),
+            expected_fused_ops={"_caffe2::BBoxTransform"},
+        )
+
+    def test_bbox_transform_apply_scale(self):
+        """Test of the _caffe2::BBoxTransform Node on Glow."""
+
+        def test_f(rois, deltas, im_info):
+            return torch.ops._caffe2.BBoxTransform(
+                rois,
+                deltas,
+                im_info,
+                weights=[1.0, 1.0, 1.0, 1.0],
+                apply_scale=True,
+                rotated=False,
+                angle_bound_on=False,
+                angle_bound_lo=-90,
+                angle_bound_hi=90,
+                clip_angle_thresh=1.0,
+                legacy_plus_one=False,
+            )
+
+        roi_counts, num_classes = ([5, 4, 3, 2, 1], 3)
+        rois, deltas, im_info = create_bbox_transform_inputs(
+            roi_counts, num_classes, False
+        )
+        jitVsGlow(
+            test_f,
+            torch.tensor(rois),
+            torch.tensor(deltas),
+            torch.tensor(im_info),
+            expected_fused_ops={"_caffe2::BBoxTransform"},
+        )
+
+    def test_bbox_transform_weights(self):
+        """Test of the _caffe2::BBoxTransform Node on Glow."""
+
+        def test_f(rois, deltas, im_info):
+            return torch.ops._caffe2.BBoxTransform(
+                rois,
+                deltas,
+                im_info,
+                weights=[10.0, 10.0, 5.0, 5.0],
+                apply_scale=False,
+                rotated=False,
+                angle_bound_on=False,
+                angle_bound_lo=-90,
+                angle_bound_hi=90,
+                clip_angle_thresh=1.0,
+                legacy_plus_one=False,
+            )
+
+        roi_counts, num_classes = ([5, 4, 3, 2, 1], 3)
+        rois, deltas, im_info = create_bbox_transform_inputs(
+            roi_counts, num_classes, False
+        )
+        jitVsGlow(
+            test_f,
+            torch.tensor(rois),
+            torch.tensor(deltas),
+            torch.tensor(im_info),
+            expected_fused_ops={"_caffe2::BBoxTransform"},
+        )
+
+    def test_bbox_transform_fp16(self):
+        """Test of the _caffe2::BBoxTransform Node on Glow."""
+
+        def test_f(rois, deltas, im_info):
+            return torch.ops._caffe2.BBoxTransform(
+                rois,
+                deltas,
+                im_info,
+                weights=[1.0, 1.0, 1.0, 1.0],
+                apply_scale=False,
+                rotated=False,
+                angle_bound_on=False,
+                angle_bound_lo=-90,
+                angle_bound_hi=90,
+                clip_angle_thresh=1.0,
+                legacy_plus_one=False,
+            )
+
+        roi_counts, num_classes = ([5, 4, 3, 2, 1], 3)
+        rois, deltas, im_info = create_bbox_transform_inputs(
+            roi_counts, num_classes, False
+        )
+        jitVsGlow(
+            test_f,
+            torch.tensor(rois),
+            torch.tensor(deltas),
+            torch.tensor(im_info),
+            expected_fused_ops={"_caffe2::BBoxTransform"},
+            use_fp16=True,
+            atol=1,
+            rtol=1e-02,
+        )


### PR DESCRIPTION
Summary:
Make BBoxTransform support both fp16 and fp32 percision by templating the original function. Unblacklist the unit test for BBoxTransform fp16.
Add torch_glow node unit tests to ensure it has the same output as the Caffe2 version.
`BatchRoiSplit` is forced to be fp32 even when global fp16 conversion is required because it's how Intel implemented it.

Differential Revision: D24065348

