### PR TITLE
[GraphOptz] Fold Exp+ReduceSum+Div into Softmax

### DIFF
--- a/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
+++ b/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
@@ -60,6 +60,7 @@ FUN_PASS(OptimizeConcatQuantization)
 FUN_PASS(SinkConcatBelowQuantize)
 FUN_PASS(FoldLayerNormArithmetic)
 FUN_PASS(QuantizeSwish)
+FUN_PASS(OptimizeExpSumDiv)
 
 
 // NOTE: This pass must be last; it's used to count the total number of passes.

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -5112,16 +5112,17 @@ bool OptimizeExpSumDiv::run(Function *F, const CompilationContext &cctx) {
     BatchedReduceAddNode *RSN;
     bool optimizationPossible = true;
 
-    for (auto &node : EN->getUsers()) {
-      auto *user = node.getUser();
-      if (isa<DivNode>(user)) {
-        DN = cast<DivNode>(user);
-      } else if (isa<BatchedReduceAddNode>(user)) {
-        RSN = cast<BatchedReduceAddNode>(user);
-      } else {
-        optimizationPossible = false;
-        break;
-      }
+    auto *user1 = EN->getUsers().front().getUser();
+    auto *user2 = EN->getUsers().back().getUser();
+
+    if (isa<DivNode>(user1) && isa<BatchedReduceAddNode>(user2)) {
+      DN = cast<DivNode>(user1);
+      RSN = cast<BatchedReduceAddNode>(user2);
+    } else if (isa<DivNode>(user2) && isa<BatchedReduceAddNode>(user1)) {
+      DN = cast<DivNode>(user2);
+      RSN = cast<BatchedReduceAddNode>(user1);
+    } else {
+      optimizationPossible = false;
     }
 
     if (!optimizationPossible || RSN->getNumUsers() != 1) {

--- a/lib/Optimizer/GraphOptimizerPipeline/FunctionPassPipeline.cpp
+++ b/lib/Optimizer/GraphOptimizerPipeline/FunctionPassPipeline.cpp
@@ -141,6 +141,9 @@ createDefaultGraphOptimizationPassPipeline() {
       // Optimize reshapes introduced during above optimizations.
       {FunctionPassID::OptimizeReshape},
 
+      // Optimize exp + reduce sum + div into softmax
+      {FunctionPassID::OptimizeExpSumDiv},
+
       // Run a round of constant folding.
       {FunctionPassID::ConstantFold},
 


### PR DESCRIPTION
Summary: Optimize exp + reduce sum + div into a single softmax node. This provides extra numerical stability as well.

Fixes #4654 

Test Plan: A test has been added to `GraphOptzTest` checking the optimization for a graph with the above three nodes, and the optimized graph only has a single softmax.