### PR TITLE
Throw special exception when backend compilation is met with fatal error

### DIFF
--- a/lib/Onnxifi/HostManagerOnnxifi.cpp
+++ b/lib/Onnxifi/HostManagerOnnxifi.cpp
@@ -271,8 +271,12 @@ onnxStatus HostManagerBackend::addNetwork(
 
   auto err = hostManager_->addNetwork(std::move(module), cctx);
 
-  if (ERR_TO_BOOL(std::move(err))) {
-    return ONNXIFI_STATUS_INTERNAL_ERROR;
+  if (err) {
+    if (err.peekErrorValue() && err.peekErrorValue()->isFatalError()) {
+      return ONNXIFI_STATUS_FATAL_ERROR;
+    } else {
+      return ONNXIFI_STATUS_INTERNAL_ERROR;
+    }
   }
 
   return ONNXIFI_STATUS_SUCCESS;


### PR DESCRIPTION
Summary: When glow compilation meets with nonrecoverable fatal error (hardware is busted), we would like to throw a special exception other than the normal caffe2::EnforceNotMet so that we can signal the upper layer application to handle it differently.

Differential Revision: D24156792

