### PR TITLE
Add ConvertTo node to UInt4FusedFPQTY to UInt4FusedQTY in FRWQSLWS

### DIFF
--- a/include/glow/Converter/FusedRowwiseConverter.h
+++ b/include/glow/Converter/FusedRowwiseConverter.h
@@ -22,8 +22,8 @@ class Function;
 struct PrecisionConfiguration;
 
 /// Converts all Fp16 scale/offset of a function \p F to Fp32. Now only support
-/// FusedSLWS's data param, from UInt8FusedFP16QTy/UInt4FusedFP16QTy to
-/// UInt8FusedQTy.
+/// FusedSLWS's data param, from UInt8FusedFP16QTy -> UInt8FusedQTy, and
+/// UInt4FusedFP16QTy -> UInt4FusedQTy
 void convertFunctionToFP32ScaleOffset(Function *F,
                                       const PrecisionConfiguration &precConfig);
 

--- a/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
+++ b/include/glow/Optimizer/GraphOptimizer/CompilationContext.h
@@ -74,6 +74,9 @@ struct PrecisionConfiguration {
   /// Whether to convert UInt8FusedFP16QTy to UInt8FusedQTy in the Function.
   bool convert8BitFusedToFP32{false};
 
+  /// Whether to convert UInt4FusedFP16QTy to UInt4FusedQTy in the Function.
+  bool convert4BitFusedToFP32{false};
+
   /// Whether to convert indices in FusedRowwiseSLWS to Int64ITy.
   bool convertIndicesToInt64{false};
 

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -5157,6 +5157,13 @@ void BoundInterpreterFunction::fwdConvertToInst(const glow::ConvertToInst *I) {
     return;
   }
 
+  if (srcElType == ElemKind::UInt4FusedFP16QTy &&
+      destElType == ElemKind::UInt4FusedQTy) {
+    Tensor result = source->getCopyConvertedToType(ElemKind::UInt4FusedQTy);
+    dest->assign(&result);
+    return;
+  }
+
   llvm_unreachable("Type not supported");
 }
 

--- a/lib/Base/Tensor.cpp
+++ b/lib/Base/Tensor.cpp
@@ -350,17 +350,21 @@ static bool isTiledImpl(const Tensor *tensor, unsigned_t axis, dim_t size,
   return true;
 }
 
-/// \returns a tensor with UInt8FusedQTy from \p T, whose type should be either
-/// UInt4FusedFP16QTy or UInt8FusedFP16QTy..
+/// \returns a tensor with UInt8FusedQTy from \p T, whose type should be
+/// UInt4FusedFP16QTy, UInt4FusedQTy, or UInt8FusedFP16QTy.
+template <class scaleOffsetTy = float16_t>
 static Tensor convertToUInt8FusedQTy(const Tensor *T) {
   const ElemKind origKind = T->getElementType();
-  // Supports UInt4FusedFP16QTy/UInt8FusedFP16QTy -> UInt8FusedQTy
+  // Supports UInt4FusedFP16QTy/UInt8FusedFP16QTy/UInt4FusedQTy -> UInt8FusedQTy
   DCHECK((origKind == ElemKind::UInt4FusedFP16QTy ||
+          origKind == ElemKind::UInt4FusedQTy ||
           origKind == ElemKind::UInt8FusedFP16QTy) &&
          T->dims().size() == 2)
-      << "UInt4FusedFP16QTy or UInt8FusedFP16QTy must be 2 dimensional.";
-  bool is4Bit = origKind == ElemKind::UInt4FusedFP16QTy;
-  const dim_t dataCol = T->dims()[1] - 2 * sizeof(float16);
+      << "UInt4FusedFP16QTy, UInt4FusedQTy or UInt8FusedFP16QTy must be 2 "
+         "dimensional.";
+  bool is4Bit = (origKind == ElemKind::UInt4FusedFP16QTy ||
+                 origKind == ElemKind::UInt4FusedQTy);
+  const dim_t dataCol = T->dims()[1] - 2 * sizeof(scaleOffsetTy);
   const dim_t numTotalRows = T->dims()[0];
   const dim_t numTotalColumns = dataCol * (is4Bit ? 2 : 1) + 2 * sizeof(float);
   Tensor tmp(ElemKind::UInt8FusedQTy, {numTotalRows, numTotalColumns}, 1.0, 0);
@@ -368,8 +372,9 @@ static Tensor convertToUInt8FusedQTy(const Tensor *T) {
   auto dstH = tmp.getHandle<uint8_t>();
   for (dim_t row = 0; row < T->dims()[0]; row++) {
     // Copy scale and offset from src to dst.
-    float16 scale, offset;
-    std::tie(scale, offset) = srcH.getFusedScaleOffsetFromRow<float16_t>(row);
+    scaleOffsetTy scale, offset;
+    std::tie(scale, offset) =
+        srcH.getFusedScaleOffsetFromRow<scaleOffsetTy>(row);
     dstH.setFusedScaleOffsetInRow<float>(row, static_cast<float>(scale),
                                          static_cast<float>(offset));
     for (dim_t column = 0; column < dataCol; column++) {
@@ -382,6 +387,32 @@ static Tensor convertToUInt8FusedQTy(const Tensor *T) {
       } else {
         dstH.at({row, column}) = srcH.at({row, column});
       }
+    }
+  }
+  return tmp;
+}
+
+/// \returns a tensor with UInt4FusedQTy from \p T, whose type should be
+/// UInt4FusedFP16QTy.
+static Tensor convertToUInt4FusedQTy(const Tensor *T) {
+  const ElemKind origKind = T->getElementType();
+  // Supports UInt4FusedFP16QTy -> UInt4FusedQTy.
+  DCHECK(origKind == ElemKind::UInt4FusedFP16QTy && T->dims().size() == 2)
+      << "UInt4FusedFP16QTy must be 2 dimensional.";
+  const dim_t dataCol = T->dims()[1] - 2 * sizeof(float16_t);
+  const dim_t numTotalRows = T->dims()[0];
+  const dim_t numTotalColumns = dataCol + 2 * sizeof(float);
+  Tensor tmp(ElemKind::UInt4FusedQTy, {numTotalRows, numTotalColumns}, 1.0, 0);
+  auto srcH = T->getHandle<uint8_t>();
+  auto dstH = tmp.getHandle<uint8_t>();
+  for (dim_t row = 0; row < T->dims()[0]; row++) {
+    // Copy scale and offset from src to dst.
+    float16_t scale, offset;
+    std::tie(scale, offset) = srcH.getFusedScaleOffsetFromRow<float16_t>(row);
+    dstH.setFusedScaleOffsetInRow<float>(row, static_cast<float>(scale),
+                                         static_cast<float>(offset));
+    for (dim_t column = 0; column < dataCol; column++) {
+      dstH.at({row, column}) = srcH.at({row, column});
     }
   }
   return tmp;
@@ -757,6 +788,10 @@ Tensor Tensor::getCopyConvertedToType(ElemKind newKind) const {
          (origKind == ElemKind::UInt8FusedFP16QTy &&
           newKind == ElemKind::UInt8FusedQTy) ||
          (origKind == ElemKind::UInt4FusedFP16QTy &&
+          newKind == ElemKind::UInt8FusedQTy) ||
+         (origKind == ElemKind::UInt4FusedFP16QTy &&
+          newKind == ElemKind::UInt4FusedQTy) ||
+         (origKind == ElemKind::UInt4FusedQTy &&
           newKind == ElemKind::UInt8FusedQTy))
       << "Conversion from " << Type::getElementName(origKind).str() << " to "
       << Type::getElementName(newKind).str() << " is not yet implemented";
@@ -811,9 +846,18 @@ Tensor Tensor::getCopyConvertedToType(ElemKind newKind) const {
   }
 
   // Handle Fused conversion.
-  if (origKind == ElemKind::UInt8FusedFP16QTy ||
-      origKind == ElemKind::UInt4FusedFP16QTy) {
-    return convertToUInt8FusedQTy(this);
+  if ((origKind == ElemKind::UInt8FusedFP16QTy ||
+       origKind == ElemKind::UInt4FusedFP16QTy) &&
+      newKind == ElemKind::UInt8FusedQTy) {
+    return convertToUInt8FusedQTy<float16_t>(this);
+  }
+  if (origKind == ElemKind::UInt4FusedQTy &&
+      newKind == ElemKind::UInt8FusedQTy) {
+    return convertToUInt8FusedQTy<float>(this);
+  }
+  if (origKind == ElemKind::UInt4FusedFP16QTy &&
+      newKind == ElemKind::UInt4FusedQTy) {
+    return convertToUInt4FusedQTy(this);
   }
 
   // Supports UInt8FusedQTy -> UInt8FusedFP16QTy.

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -1578,7 +1578,8 @@ static bool verifyFusedRowwiseQuantizedSparseLengthsSum(
       "Input data must be Fused Quantized type",
       isFusedQuantizedElemKind(data.getType()->getElementType()), true, parent);
   dim_t extraCols;
-  if (data.getType()->getElementType() == ElemKind::UInt8FusedQTy) {
+  if (data.getType()->getElementType() == ElemKind::UInt8FusedQTy ||
+      data.getType()->getElementType() == ElemKind::UInt4FusedQTy) {
     extraCols = 2 * sizeof(float);
   } else {
     extraCols = 2 * sizeof(float16_t);
@@ -1625,7 +1626,8 @@ static bool verifyFusedRowwiseQuantizedSparseLengthsSum(
     // If using 4-bit quantization for embeddings then the input is packed into
     // two elements per byte.
     dim_t finalSize = result.dims()[1];
-    if (data.getType()->getElementType() == ElemKind::UInt4FusedFP16QTy) {
+    if (data.getType()->getElementType() == ElemKind::UInt4FusedFP16QTy ||
+        data.getType()->getElementType() == ElemKind::UInt4FusedQTy) {
       finalSize /= 2;
     }
     isValid &=

--- a/tests/unittests/Repro.cpp
+++ b/tests/unittests/Repro.cpp
@@ -469,7 +469,7 @@ int run() {
     llvm::outs() << "Conversion of fused scales/offsets to fp16 enabled\n";
   }
   if (fuseScaleOffsetFp32Opt) {
-    precConfig.convert4BitFusedTo8Bit = fuseScaleOffsetFp32Opt;
+    precConfig.convert4BitFusedToFP32 = fuseScaleOffsetFp32Opt;
     precConfig.convert8BitFusedToFP32 = fuseScaleOffsetFp32Opt;
     llvm::outs()
         << "Conversion of fused scales/offsets to fp32 in frwqslws enabled\n";


### PR DESCRIPTION
Summary: This diff adds the conversion UInt4FusedFP16QTy -> UInt4FusedQTy for the param data in frwqslws nodes. Basically, for frwqslws, if the option is enabled, all fp16 scale/offset in frwqslws will be converted to fp32 scale/offset. This conversion is handled by convert4BitFusedToFP32 in cctx

Reviewed By: kunmingho

Differential Revision: D24107165

