### PR TITLE
optimize tensor comparison

### DIFF
--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -977,18 +977,21 @@ private:
     auto const *myData = getUnsafePtr();
     auto const *otherData = other.getUnsafePtr();
     dim_t mismatchCount = 0;
-    for (size_t i = 0, e = getSizeInBytes(); i < e; i++) {
-      if (myData[i] != otherData[i]) {
-        if (!verbose) {
-          return false;
+
+    if (verbose) {
+      for (size_t i = 0, e = getSizeInBytes(); i < e; i++) {
+        if (myData[i] != otherData[i]) {
+          ++mismatchCount;
         }
-        ++mismatchCount;
       }
+      if (mismatchCount != 0) {
+        LOG(INFO) << "Tensors not bitwise equal: " << mismatchCount
+                  << " bytes out of " << getSizeInBytes() << " mismatched.";
+      }
+    } else {
+      mismatchCount = memcmp(myData, otherData, getSizeInBytes());
     }
-    if (mismatchCount != 0) {
-      LOG(INFO) << "Tensors not bitwise equal: " << mismatchCount
-                << " bytes out of " << getSizeInBytes() << " mismatched.";
-    }
+
     return mismatchCount == 0;
   }
 };

--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -1082,6 +1082,7 @@ Error PyTorchModelLoader::runAndRemapSingleNode(
   cctx.optimizationOpts.enableConstantFolding = false;
   cctx.backendOpts.collectConstants = true;
   cctx.verboseCompile = false;
+  cctx.optimizationOpts.enableConstantDeduplication = false;
   RETURN_IF_ERR(executeConstantFunction(*backend, *tmpF, bindings, cctx, true));
 
   // Remap result back to original jit graph


### PR DESCRIPTION
Summary:
this codepath is used a lot during deduplication, for the non-verbose
version we should rely on memcmp which is performant even in the dev builds

Reviewed By: jfix71

Differential Revision: D24167467

