### PR TITLE
BBoxTransform Rotated Boxes Support

### DIFF
--- a/include/glow/Support/Float16.h
+++ b/include/glow/Support/Float16.h
@@ -52,6 +52,14 @@ public:
     *this = *this - b;
     return *this;
   }
+  float16 operator*=(const float16 &b) {
+    *this = *this * b;
+    return *this;
+  }
+  float16 operator/=(const float16 &b) {
+    *this = *this / b;
+    return *this;
+  }
 
   /// Comparisons.
   bool operator<(const float16 &b) const { return operator float() < float(b); }

--- a/lib/Backends/CPU/tests/CPUOperatorTest.cpp
+++ b/lib/Backends/CPU/tests/CPUOperatorTest.cpp
@@ -373,4 +373,6 @@ std::set<std::string> glow::backendTestBlacklist = {
     "VectorNorm_Float16Ty/0",
     "BBoxTransform_Float/0",
     "BBoxTransform_Float16/0",
+    "BBoxTransform_Rotated_Float/0",
+    "BBoxTransform_Rotated_Float16/0",
 };

--- a/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
@@ -296,8 +296,10 @@ struct BlacklistInitializer {
       {"FP16RoiAlignRotatedBatchIndexInBoxesTensor/0",
        TestBlacklist::AnyDeviceAnyEngine},
       {"BBoxTransform_Float/0", TestBlacklist::AnyDeviceAnyEngine},
+      {"BBoxTransform_Rotated_Float/0", TestBlacklist::AnyDeviceAnyEngine},
 #if NNPI_MAJOR_VERSION == 1 && NNPI_MINOR_VERSION == 0
       {"BBoxTransform_Float16/0", TestBlacklist::AnyDeviceAnyEngine},
+      {"BBoxTransform_Rotated_Float16/0", TestBlacklist::AnyDeviceAnyEngine},
 #endif
       {"Abs_FloatTy/0", TestBlacklist::AnyDeviceAnyEngine},
       {"Abs_Int8QTy/0", TestBlacklist::AnyDeviceAnyEngine},

--- a/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
@@ -584,6 +584,8 @@ std::set<std::string> glow::backendTestBlacklist = {
     "Atan_Int8QTy/0",
     "BBoxTransform_Float/0",
     "BBoxTransform_Float16/0",
+    "BBoxTransform_Rotated_Float/0",
+    "BBoxTransform_Rotated_Float16/0",
     "BasicFloorDivNetFloatVsBFloat16/0",
     "BasicFloorDivNetFloatVsFloat16/0",
     "ArithFloorDiv_float/0",

--- a/tests/unittests/Float16Test.cpp
+++ b/tests/unittests/Float16Test.cpp
@@ -57,10 +57,26 @@ TEST(Float16, mul) {
   EXPECT_EQ(a * b, float16(float(a) * float(b)));
 }
 
+TEST(Float16, mulEqual) {
+  float16 a = 3.5;
+  float16 b = 3.0;
+  float16 aMulB = a * b;
+  a *= b;
+  EXPECT_EQ(a, aMulB);
+}
+
 TEST(Float16, div) {
   float16 a = 16.5;
   float16 b = -3.0;
   EXPECT_EQ(a / b, float16(float(a) / float(b)));
+}
+
+TEST(Float16, divEqual) {
+  float16 a = 16.5;
+  float16 b = -3.0;
+  float16 aDivB = a / b;
+  a /= b;
+  EXPECT_EQ(a, aDivB);
 }
 
 TEST(Float16, gt) {

--- a/torch_glow/tests/nodes/bbox_transform_test.py
+++ b/torch_glow/tests/nodes/bbox_transform_test.py
@@ -218,3 +218,186 @@ class TestBBoxTransform(unittest.TestCase):
             atol=1,
             rtol=1e-02,
         )
+
+    def test_bbox_transform_rotated_basic(self):
+        """Test of the _caffe2::BBoxTransform Node on Glow."""
+
+        def test_f(rois, deltas, im_info):
+            return torch.ops._caffe2.BBoxTransform(
+                rois,
+                deltas,
+                im_info,
+                weights=[1.0, 1.0, 1.0, 1.0],
+                apply_scale=False,
+                rotated=True,
+                angle_bound_on=False,
+                angle_bound_lo=-90,
+                angle_bound_hi=90,
+                clip_angle_thresh=1.0,
+                legacy_plus_one=False,
+            )
+
+        roi_counts, num_classes = ([1, 1], 1)
+        rois, deltas, im_info = create_bbox_transform_inputs(
+            roi_counts, num_classes, True
+        )
+        jitVsGlow(
+            test_f,
+            torch.tensor(rois),
+            torch.tensor(deltas),
+            torch.tensor(im_info),
+            expected_fused_ops={"_caffe2::BBoxTransform"},
+        )
+
+    def test_bbox_transform_rotated_angle_bound_on(self):
+        """Test of the _caffe2::BBoxTransform Node on Glow."""
+
+        def test_f(rois, deltas, im_info):
+            return torch.ops._caffe2.BBoxTransform(
+                rois,
+                deltas,
+                im_info,
+                weights=[1.0, 1.0, 1.0, 1.0],
+                apply_scale=False,
+                rotated=True,
+                angle_bound_on=True,
+                angle_bound_lo=-180,
+                angle_bound_hi=180,
+                clip_angle_thresh=1.0,
+                legacy_plus_one=False,
+            )
+
+        roi_counts, num_classes = ([5, 4, 3, 2, 1], 3)
+        rois, deltas, im_info = create_bbox_transform_inputs(
+            roi_counts, num_classes, True
+        )
+        jitVsGlow(
+            test_f,
+            torch.tensor(rois),
+            torch.tensor(deltas),
+            torch.tensor(im_info),
+            expected_fused_ops={"_caffe2::BBoxTransform"},
+        )
+
+    def test_bbox_transform_rotated_legacy_plus_one(self):
+        """Test of the _caffe2::BBoxTransform Node on Glow."""
+
+        def test_f(rois, deltas, im_info):
+            return torch.ops._caffe2.BBoxTransform(
+                rois,
+                deltas,
+                im_info,
+                weights=[1.0, 1.0, 1.0, 1.0],
+                apply_scale=False,
+                rotated=True,
+                angle_bound_on=False,
+                angle_bound_lo=-90,
+                angle_bound_hi=90,
+                clip_angle_thresh=1.0,
+                legacy_plus_one=True,
+            )
+
+        roi_counts, num_classes = ([5, 4, 3, 2, 1], 3)
+        rois, deltas, im_info = create_bbox_transform_inputs(
+            roi_counts, num_classes, True
+        )
+        jitVsGlow(
+            test_f,
+            torch.tensor(rois),
+            torch.tensor(deltas),
+            torch.tensor(im_info),
+            expected_fused_ops={"_caffe2::BBoxTransform"},
+        )
+
+    def test_bbox_transform_rotated_apply_scale(self):
+        """Test of the _caffe2::BBoxTransform Node on Glow."""
+
+        def test_f(rois, deltas, im_info):
+            return torch.ops._caffe2.BBoxTransform(
+                rois,
+                deltas,
+                im_info,
+                weights=[1.0, 1.0, 1.0, 1.0],
+                apply_scale=True,
+                rotated=True,
+                angle_bound_on=False,
+                angle_bound_lo=-90,
+                angle_bound_hi=90,
+                clip_angle_thresh=1.0,
+                legacy_plus_one=False,
+            )
+
+        roi_counts, num_classes = ([5, 4, 3, 2, 1], 3)
+        rois, deltas, im_info = create_bbox_transform_inputs(
+            roi_counts, num_classes, True
+        )
+        jitVsGlow(
+            test_f,
+            torch.tensor(rois),
+            torch.tensor(deltas),
+            torch.tensor(im_info),
+            expected_fused_ops={"_caffe2::BBoxTransform"},
+        )
+
+    def test_bbox_transform_rotated_weights(self):
+        """Test of the _caffe2::BBoxTransform Node on Glow."""
+
+        def test_f(rois, deltas, im_info):
+            return torch.ops._caffe2.BBoxTransform(
+                rois,
+                deltas,
+                im_info,
+                weights=[10.0, 10.0, 5.0, 5.0],
+                apply_scale=False,
+                rotated=True,
+                angle_bound_on=False,
+                angle_bound_lo=-90,
+                angle_bound_hi=90,
+                clip_angle_thresh=1.0,
+                legacy_plus_one=False,
+            )
+
+        roi_counts, num_classes = ([5, 4, 3, 2, 1], 3)
+        rois, deltas, im_info = create_bbox_transform_inputs(
+            roi_counts, num_classes, True
+        )
+        jitVsGlow(
+            test_f,
+            torch.tensor(rois),
+            torch.tensor(deltas),
+            torch.tensor(im_info),
+            expected_fused_ops={"_caffe2::BBoxTransform"},
+        )
+
+    def test_bbox_transform_rotated_fp16(self):
+        """Test of the _caffe2::BBoxTransform Node on Glow."""
+
+        def test_f(rois, deltas, im_info):
+            return torch.ops._caffe2.BBoxTransform(
+                rois,
+                deltas,
+                im_info,
+                weights=[1.0, 1.0, 1.0, 1.0],
+                apply_scale=False,
+                rotated=True,
+                angle_bound_on=False,
+                angle_bound_lo=-90,
+                angle_bound_hi=90,
+                clip_angle_thresh=1.0,
+                legacy_plus_one=False,
+            )
+
+        roi_counts, num_classes = ([5, 4, 3, 2, 1], 3)
+        rois, deltas, im_info = create_bbox_transform_inputs(
+            roi_counts, num_classes, True
+        )
+        jitVsGlow(
+            test_f,
+            torch.tensor(rois),
+            torch.tensor(deltas),
+            torch.tensor(im_info),
+            expected_fused_ops={"_caffe2::BBoxTransform"},
+            use_fp16=True,
+            atol=1,
+            rtol=1e-2,
+        )


### PR DESCRIPTION
Summary:
Add support to rotated boxes in BBoxTransform.
Unit tests for rotated boxes are added to OperatorTest for both fp16 and fp32 percision.
Unit tests for rotated boxes are added to torch_glow node to ensure the same results as Caffe2 ops.

Reviewed By: jackm321

Differential Revision: D24094666

