### PR TITLE
[CPUBackend] Make backend options default to host when target not given

### DIFF
--- a/include/glow/LLVMIRCodeGen/LLVMBackend.h
+++ b/include/glow/LLVMIRCodeGen/LLVMBackend.h
@@ -128,10 +128,10 @@ public:
   virtual ~LLVMBackend() override = default;
 
   /// \returns the LLVM target triple for the host.
-  static llvm::StringRef getHostTarget();
+  static std::string getHostTarget();
 
   /// \returns the LLVM CPU name for the host.
-  static llvm::StringRef getHostCPU();
+  static std::string getHostCPU();
 
   /// \returns the LLVM CPU feature list for the host.
   static llvm::SmallVector<std::string, 0> getHostFeatures();

--- a/include/glow/LLVMIRCodeGen/LLVMBackend.h
+++ b/include/glow/LLVMIRCodeGen/LLVMBackend.h
@@ -35,7 +35,7 @@ class LLVMIRGen;
 /// LLVM backend options used to configure e.g. the LLVM TargetMachine, ORC JIT
 /// or BundleSaver.
 class LLVMBackendOptions {
-  /// Target used by this backend.
+  /// Target triple used by this backend.
   std::string target_;
   /// Arch used by this backend.
   std::string arch_;
@@ -58,9 +58,9 @@ class LLVMBackendOptions {
 
 public:
   LLVMBackendOptions();
-  /// \returns target used by this backend.
+  /// \returns target triple used by this backend.
   llvm::StringRef getTarget() const { return target_; }
-  /// Sets target used by this backend.
+  /// Sets target triple used by this backend.
   void setTarget(llvm::StringRef target) { target_ = target; }
   /// \returns arch used by this backend.
   llvm::StringRef getArch() const { return arch_; }
@@ -126,6 +126,15 @@ public:
   /// This is the implementation of the Backend interface.
   ///@{
   virtual ~LLVMBackend() override = default;
+
+  /// \returns the LLVM target triple for the host.
+  static llvm::StringRef getHostTarget();
+
+  /// \returns the LLVM CPU name for the host.
+  static llvm::StringRef getHostCPU();
+
+  /// \returns the LLVM CPU feature list for the host.
+  static llvm::SmallVector<std::string, 0> getHostFeatures();
 
   /// \returns LLVM backend options.
   const LLVMBackendOptions &getOptions() const { return options_; }

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -31,6 +31,16 @@
 
 using namespace glow;
 
+CPUBackend::CPUBackend() {
+  /// If target is not explicitly given we use the host attributes.
+  auto &opts = getOptions();
+  if (opts.getTarget().empty()) {
+    opts.setTarget(LLVMBackend::getHostTarget());
+    opts.setCPU(LLVMBackend::getHostCPU());
+    opts.setTargetFeatures(LLVMBackend::getHostFeatures());
+  }
+}
+
 /// We compile the standard library (libjit) to LLVM bitcode, and then convert
 /// that binary data to an include file using an external utility (include-bin).
 /// The resulting file is included here to compile the bitcode image into our

--- a/lib/Backends/CPU/CPUBackend.h
+++ b/lib/Backends/CPU/CPUBackend.h
@@ -31,7 +31,7 @@ class NodeInfo;
 
 class CPUBackend : public LLVMBackend {
 public:
-  CPUBackend() = default;
+  CPUBackend();
 
   /// @name Backend methods.
   /// This is the implementation of the Backend interface.

--- a/lib/LLVMIRCodeGen/CommandLine.cpp
+++ b/lib/LLVMIRCodeGen/CommandLine.cpp
@@ -21,8 +21,8 @@ llvm::cl::OptionCategory &getLLVMBackendCat() {
   return cpuBackendCat;
 }
 
-llvm::cl::opt<std::string> llvmTarget("target",
-                                      llvm::cl::desc("LLVM target to be used"));
+llvm::cl::opt<std::string>
+    llvmTarget("target", llvm::cl::desc("LLVM target triple to be used"));
 
 llvm::cl::opt<std::string>
     llvmArch("march", llvm::cl::desc("LLVM architecture to be used"));

--- a/lib/LLVMIRCodeGen/LLVMBackend.cpp
+++ b/lib/LLVMIRCodeGen/LLVMBackend.cpp
@@ -528,29 +528,18 @@ bool LLVMBackend::isOpSupported(const NodeInfo &NI) const {
   }
 }
 
-/// Initialize the LLVM options using command line options.
-/// If target is not explicitly given we use the host attributes.
 LLVMBackendOptions::LLVMBackendOptions() {
-  if (llvmTarget.empty()) {
-    // Default values.
-    target_ = LLVMBackend::getHostTarget();
-    arch_ = llvmArch;
-    cpu_ = LLVMBackend::getHostCPU();
-    targetFeatures_ = LLVMBackend::getHostFeatures();
-  } else {
-    // Explicit values.
-    target_ = llvmTarget;
-    arch_ = llvmArch;
-    cpu_ = llvmCPU;
-    targetFeatures_.append(llvmTargetFeatures.begin(),
-                           llvmTargetFeatures.end());
-  }
+  // Initialize using command-line options by default.
+  arch_ = llvmArch;
+  target_ = llvmTarget;
+  cpu_ = llvmCPU;
   abi_ = llvmABI;
   floatABI_ = floatABI;
   codeModel_ = llvmCodeModel;
   bundleCodeModel_ = llvmBundleCodeModel;
   relocModel_ = llvmRelocModel;
   bundleAPI_ = bundleAPI;
+  targetFeatures_.append(llvmTargetFeatures.begin(), llvmTargetFeatures.end());
 }
 
 LLVMBackend::LLVMBackend() {}

--- a/lib/LLVMIRCodeGen/LLVMBackend.cpp
+++ b/lib/LLVMIRCodeGen/LLVMBackend.cpp
@@ -555,15 +555,15 @@ LLVMBackendOptions::LLVMBackendOptions() {
 
 LLVMBackend::LLVMBackend() {}
 
-llvm::StringRef LLVMBackend::getHostTarget() {
+std::string LLVMBackend::getHostTarget() {
   return llvm::sys::getDefaultTargetTriple();
 }
 
-llvm::StringRef LLVMBackend::getHostCPU() {
+std::string LLVMBackend::getHostCPU() {
   auto cpu_name = llvm::sys::getHostCPUName();
   // Skip avx512 because LLVM does not support it well.
   cpu_name.consume_back("-avx512");
-  return cpu_name;
+  return cpu_name.str();
 }
 
 llvm::SmallVector<std::string, 0> LLVMBackend::getHostFeatures() {

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -58,33 +58,6 @@ llvm::cl::opt<bool>
 /// Limitation of number of arguments for `emitDataParallelKernel`.
 constexpr static size_t kArgLimit = 64;
 
-/// Generate the LLVM machine attribute list for the host.
-static llvm::SmallVector<std::string, 0> getHostMachineAttributes() {
-  llvm::SmallVector<std::string, 0> result;
-  llvm::StringMap<bool> hostFeatures;
-  if (llvm::sys::getHostCPUFeatures(hostFeatures)) {
-    for (auto &feature : hostFeatures) {
-      if (feature.second) {
-        llvm::StringRef fn = feature.first();
-        // Skip avx512 because LLVM does not support it well.
-        if (fn.startswith("avx512")) {
-          continue;
-        }
-        result.push_back(fn);
-      }
-    }
-  }
-  return result;
-}
-
-/// Returns the CPU hostname.
-static llvm::StringRef getHostCpuName() {
-  auto cpu_name = llvm::sys::getHostCPUName();
-  // Skip avx512 because LLVM does not support it well.
-  cpu_name.consume_back("-avx512");
-  return cpu_name;
-}
-
 /// Query the TargetMachine to get the pointer size in bits
 static unsigned getPointerNumBits(const llvm::TargetMachine &TM) {
   return TM.getPointerSize(0) * 8;
@@ -116,21 +89,16 @@ void LLVMIRGen::initTargetMachine(const LLVMBackendOptions &opts) {
   if (!opts.getABIName().empty()) {
     targetOpts.MCOptions.ABIName = opts.getABIName();
   }
-  if (opts.getTarget().empty()) {
-    TM_.reset(llvm::EngineBuilder()
-                  .setCodeModel(opts.getCodeModel())
-                  .setRelocationModel(opts.getRelocModel())
-                  .setTargetOptions(targetOpts)
-                  .selectTarget(llvm::Triple(), opts.getArch(),
-                                getHostCpuName(), getHostMachineAttributes()));
-  } else {
-    TM_.reset(llvm::EngineBuilder()
-                  .setCodeModel(opts.getCodeModel())
-                  .setRelocationModel(opts.getRelocModel())
-                  .setTargetOptions(targetOpts)
-                  .selectTarget(llvm::Triple(opts.getTarget()), opts.getArch(),
-                                opts.getCPU(), opts.getTargetFeatures()));
-  }
+
+  assert(!opts.getTarget().empty() && "LLVM target not provided!");
+
+  TM_.reset(llvm::EngineBuilder()
+                .setCodeModel(opts.getCodeModel())
+                .setRelocationModel(opts.getRelocModel())
+                .setTargetOptions(targetOpts)
+                .selectTarget(llvm::Triple(opts.getTarget()), opts.getArch(),
+                              opts.getCPU(), opts.getTargetFeatures()));
+
   assert(TM_ && "Could not initialize the target machine");
 }
 

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -89,16 +89,22 @@ void LLVMIRGen::initTargetMachine(const LLVMBackendOptions &opts) {
   if (!opts.getABIName().empty()) {
     targetOpts.MCOptions.ABIName = opts.getABIName();
   }
-
-  assert(!opts.getTarget().empty() && "LLVM target not provided!");
-
-  TM_.reset(llvm::EngineBuilder()
-                .setCodeModel(opts.getCodeModel())
-                .setRelocationModel(opts.getRelocModel())
-                .setTargetOptions(targetOpts)
-                .selectTarget(llvm::Triple(opts.getTarget()), opts.getArch(),
-                              opts.getCPU(), opts.getTargetFeatures()));
-
+  if (opts.getTarget().empty()) {
+    TM_.reset(llvm::EngineBuilder()
+                  .setCodeModel(opts.getCodeModel())
+                  .setRelocationModel(opts.getRelocModel())
+                  .setTargetOptions(targetOpts)
+                  .selectTarget(llvm::Triple(), opts.getArch(),
+                                LLVMBackend::getHostCPU(),
+                                LLVMBackend::getHostFeatures()));
+  } else {
+    TM_.reset(llvm::EngineBuilder()
+                  .setCodeModel(opts.getCodeModel())
+                  .setRelocationModel(opts.getRelocModel())
+                  .setTargetOptions(targetOpts)
+                  .selectTarget(llvm::Triple(opts.getTarget()), opts.getArch(),
+                                opts.getCPU(), opts.getTargetFeatures()));
+  }
   assert(TM_ && "Could not initialize the target machine");
 }
 


### PR DESCRIPTION
**Summary**
- I would like for the LLVM Backend options to be directly initialized with the default host attributes when no "-target" option is given
- I can now use the fields of the LLVMBackendOpts directly without verifying that the target field is empty for various purposes, for example specializing some kernels in LLVMIRGen depending on the target architecture (arm vs x86)

