### PR TITLE
Fix Flaky BBoxTransform Float16 Tests

### DIFF
--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -6350,7 +6350,7 @@ void BoundInterpreterFunction::fwdBBoxTransformInstFloatImpl(
     // Apply for the rectangle starting at (startRowRoi, startColRoi)
     // with height (Rows) of num_rois, and width (Cols) of boxDim.
     dim_t startRowRoi = offset;
-    dim_t startColRoi = batchSize > 1 ? 1 : 0;
+    dim_t startColRoi = roiIn->dims()[1] != boxDim ? 1 : 0;
     dim_t rows = numRois;
     T scaleBeforeInv = T(1) / scaleBefore;
 

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -2239,6 +2239,11 @@ bool BBoxTransformNode::verify() const {
                                deltasDims[1] % expectedBoxDim, dim_t(0), this);
   isValid &= expectCompareTrue("Weights must be a 1D vector of length 4",
                                weights.size(), size_t(4), this);
+  if (roisDims[1] == expectedBoxDim) {
+    isValid &= expectCompareTrue(
+        "The batch size should be 1 if there's no batch index in rois",
+        imInfoDims[0], dim_t(1), this);
+  }
   if (rotated && angleBoundOn) {
     isValid &= expectCompareTrue(
         "The difference between angleBoundHi and angleBoundLo "

--- a/torch_glow/tests/nodes/bbox_transform_test.py
+++ b/torch_glow/tests/nodes/bbox_transform_test.py
@@ -50,7 +50,7 @@ def generate_rois_rotated(roi_counts, im_dims):
 def create_bbox_transform_inputs(roi_counts, num_classes, rotated):
     batch_size = len(roi_counts)
     total_rois = sum(roi_counts)
-    im_dims = np.random.randint(100, 600, batch_size)
+    im_dims = np.random.randint(100, 200, batch_size)
     rois = (
         generate_rois_rotated(roi_counts, im_dims)
         if rotated
@@ -61,7 +61,7 @@ def create_bbox_transform_inputs(roi_counts, num_classes, rotated):
     im_info = np.zeros((batch_size, 3)).astype(np.float32)
     im_info[:, 0] = im_dims
     im_info[:, 1] = im_dims
-    im_info[:, 2] = np.random.random()
+    im_info[:, 2] = max(np.random.random(), 0.1)
     return rois, deltas, im_info
 
 
@@ -96,7 +96,7 @@ class TestBBoxTransform(unittest.TestCase):
             expected_fused_ops={"_caffe2::BBoxTransform"},
         )
 
-    def test_bbox_transform_basic_legacy_plus_one(self):
+    def test_bbox_transform_legacy_plus_one(self):
         """Test of the _caffe2::BBoxTransform Node on Glow."""
 
         def test_f(rois, deltas, im_info):
@@ -216,7 +216,7 @@ class TestBBoxTransform(unittest.TestCase):
             expected_fused_ops={"_caffe2::BBoxTransform"},
             use_fp16=True,
             atol=1,
-            rtol=1e-02,
+            rtol=1e-01,
         )
 
     def test_bbox_transform_rotated_basic(self):
@@ -399,5 +399,5 @@ class TestBBoxTransform(unittest.TestCase):
             expected_fused_ops={"_caffe2::BBoxTransform"},
             use_fp16=True,
             atol=1,
-            rtol=1e-2,
+            rtol=1e-01,
         )


### PR DESCRIPTION
Summary:
- Relax rtol, decrease image dim range to avoid flaky test results when running fp16 tests.
- Set a min limit to image scale to avoid overflow when running fp16 tests.
- Fix a small bug in BBoxTransform function that `startColRoi` should be 1 when batch size is 1 but the roi still has batch index.
- Add a verify rule for BBoxTransform node that when roi doesn't have batch index, batch size should be 1.

Reviewed By: jackm321

Differential Revision: D24264981

