### PR TITLE
Fix type checks for EmbeddingBagByte|4BitRowwiseOffsets

### DIFF
--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -401,8 +401,10 @@ static NodeSupportLevels isNodeSupported(const NodeInfo &NI) {
         NI.allInputsAndOutputsHaveSameElemKind(
             {ElemKind::FloatTy, ElemKind::Float16Ty, ElemKind::Int8QTy},
             {EmbeddingBagNode::IndicesIdx, EmbeddingBagNode::OffsetsIdx}) &&
-        (NI.getInElemTy(EmbeddingBagNode::IndicesIdx) == ElemKind::Int64ITy) &&
-        (NI.getInElemTy(EmbeddingBagNode::OffsetsIdx) == ElemKind::Int64ITy);
+        (NI.getInElemTy(EmbeddingBagNode::IndicesIdx) == ElemKind::Int64ITy ||
+         NI.getInElemTy(EmbeddingBagNode::IndicesIdx) == ElemKind::Int32ITy) &&
+        (NI.getInElemTy(EmbeddingBagNode::OffsetsIdx) == ElemKind::Int64ITy ||
+         NI.getInElemTy(EmbeddingBagNode::OffsetsIdx) == ElemKind::Int32ITy);
     break;
   case Kinded::Kind::EmbeddingBagByteRowwiseOffsetsNodeKind: {
     auto dataK = NI.getInElemTy(EmbeddingBagByteRowwiseOffsetsNode::DataIdx);
@@ -419,7 +421,9 @@ static NodeSupportLevels isNodeSupported(const NodeInfo &NI) {
          dataK == ElemKind::UInt8FusedFP16QTy ||
          dataK == ElemKind::UInt4FusedFP16QTy) &&
         (resultK == ElemKind::FloatTy || resultK == ElemKind::Float16Ty) &&
-        (indicesK == ElemKind::Int64ITy) && (offsetsK == ElemKind::Int64ITy);
+        (offsetsK == ElemKind::Int64ITy || offsetsK == ElemKind::Int32ITy) &&
+        (indicesK == ElemKind::Int64ITy || indicesK == ElemKind::Int32ITy);
+
     break;
   }
   case Kinded::Kind::FusedRowwiseQuantizedSparseLengthsSumNodeKind: {

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -564,8 +564,14 @@ static bool verifyEmbeddingBag(NodeValue dest, NodeValue data,
                                NodeValue offsets) {
   bool isValid = checkType(dest, data.getElementType(), dest.getNode());
   isValid &= checkType(weights, data.getElementType(), dest.getNode());
-  isValid &= checkType(indices, ElemKind::Int64ITy, dest.getNode());
-  isValid &= checkType(offsets, ElemKind::Int64ITy, dest.getNode());
+  isValid &= checkType(
+      indices,
+      llvm::ArrayRef<ElemKind>({ElemKind::Int64ITy, ElemKind::Int32ITy}),
+      dest.getNode());
+  isValid &= checkType(
+      offsets,
+      llvm::ArrayRef<ElemKind>({ElemKind::Int64ITy, ElemKind::Int32ITy}),
+      dest.getNode());
   isValid &=
       expectCompareTrue("Indices must be a 1D vector", indices.dims().size(),
                         size_t(1), dest.getNode());
@@ -1603,10 +1609,13 @@ static bool verifyFusedRowwiseQuantizedSparseLengthsSum(
       indices,
       llvm::ArrayRef<ElemKind>({ElemKind::Int64ITy, ElemKind::Int32ITy}),
       parent);
-  // For EmbeddingBagByteRowwiseOffsets lengths are really offsets and should be
-  // Int64ITy.
+  // For EmbeddingBagByteRowwiseOffsets lengths are really offsets and
+  // can be either Int64ITy or Int64ITy.
   if (isEmbeddingBagByteRowwiseOffsets) {
-    isValid &= checkType(lengths, ElemKind::Int64ITy, parent);
+    isValid &= checkType(
+        lengths,
+        llvm::ArrayRef<ElemKind>({ElemKind::Int64ITy, ElemKind::Int32ITy}),
+        parent);
   } else {
     isValid &= checkType(lengths, ElemKind::Int32ITy, parent);
   }


### PR DESCRIPTION
Summary: Support 32 or 64 bit offsets and indexes

Reviewed By: allwu

Differential Revision: D24262983

