### PR TITLE
[JIT] Disable object file registration in debugger for LLVM 10.

### DIFF
--- a/lib/LLVMIRCodeGen/GlowJIT.cpp
+++ b/lib/LLVMIRCodeGen/GlowJIT.cpp
@@ -84,7 +84,8 @@ public:
     // Inform the debugger about the loaded object file. This should allow for
     // more complete stack traces under debugger. And even it should even enable
     // the stepping functionality on platforms supporting it.
-#if LLVM_VERSION_MAJOR == 7 || (LLVM_VERSION_MAJOR <= 8 && FACEBOOK_INTERNAL)
+#if LLVM_VERSION_MAJOR == 7 || LLVM_VERSION_MAJOR == 10 ||                     \
+    (LLVM_VERSION_MAJOR <= 8 && FACEBOOK_INTERNAL)
     // This fails sometimes with the following assertion:
     // lib/ExecutionEngine/GDBRegistrationListener.cpp:168: virtual void
     // {anonymous}::GDBJITRegistrationListener::NotifyObjectEmitted(const


### PR DESCRIPTION
Summary:
Prevent random assertions for LLVM 10 (see https://github.com/pytorch/glow/issues/2123).

Documentation:
N/A

Fixes #2123 (for LLVM 10) 

Test Plan:
N/A
