### PR TITLE
Add support for different opsetVersion implementation of Softmax in ONNXModelLoader

### DIFF
--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -356,6 +356,24 @@ inline std::pair<dim_t, dim_t> flattenCdr(llvm::ArrayRef<dim_t> dims,
   return {first, rest};
 }
 
+/// Collapse a tensor shape into two sizes: the first will be
+/// size of n without the axis dimension, and second will be
+/// size of the axis dimension. For example, ([7, 3, 4, 2], 1) -> [56, 3]
+inline std::pair<dim_t, dim_t> collapseShape(llvm::ArrayRef<dim_t> dims,
+                                             unsigned_t n = 1) {
+  assert(1 <= n && n <= dims.size());
+  size_t first = 1;
+  size_t second = 1;
+  for (unsigned_t i = 0; i < dims.size(); i++) {
+    if (i == n) {
+      second = dims[i];
+    } else {
+      first *= dims[i];
+    }
+  }
+  return {first, second};
+}
+
 inline bool operator==(const ShapeNHWC &LHS, const ShapeNHWC &RHS) {
   return LHS.equals(RHS);
 }

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -884,6 +884,12 @@ public:
   ReshapeNode *createFlatten(llvm::StringRef name, NodeValue input,
                              unsigned_t axis);
 
+  /// Flattens the input tensor into a 2D matrix. If input tensor has shape
+  /// (d_0, d_1, ... d_n) then the output will have shape:
+  /// ((d_0 X d_1 ... d_(axis-1) X d_(axis+1) ... X d_n), d_axis).
+  ReshapeNode *createFlattenV1(llvm::StringRef name, NodeValue input,
+                               unsigned_t axis);
+
   /// Create \p outputNum slice nodes of \p input. Slices happen along dimension
   /// number \p axis. Array \p split defines lengths of slices. If \p split is
   /// empty, \p input is split to equal sized parts.

--- a/include/glow/Importer/Caffe2ModelLoader.h
+++ b/include/glow/Importer/Caffe2ModelLoader.h
@@ -75,6 +75,9 @@ class Caffe2ModelLoader
   /// Load the Conv or ConvRelu operators.
   Error loadConv(const caffe2::OperatorDef &op, ArgumentDictionaryTy &dict);
 
+  /// Load the Softmax operator
+  Error loadSoftmax(const caffe2::OperatorDef &op, ArgumentDictionaryTy &dict);
+
   /// Load the ConvTranspose operator.
   Error loadConvTranspose(const caffe2::OperatorDef &op,
                           ArgumentDictionaryTy &dict);

--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -516,44 +516,6 @@ protected:
     return Error::success();
   }
 
-  Error loadSoftmax(const OpType &op, ArgumentDictionaryTy &dict) {
-    const std::string &opName = loadOperatorName(op);
-
-    NodeValue in;
-    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
-
-    RETURN_ERR_IF_NOT(
-        in.dims().size() >= 2,
-        opErrMsg(
-            op,
-            strFormat(
-                "SoftMax input dims must be >= 2, but found input dims %zu ",
-                in.dims().size())));
-
-    // Create a constant to store labels to be used in SoftMaxGradNode.
-    auto *selected = G_->createSplat(
-        opName + ".selected",
-        mod_.uniqueType(ElemKind::Int64ITy, {in.dims()[0], 1}), 0.f);
-
-    // ONNX allows shapes like <N x 10 x 1 x 1 >. Flatten the inputs to the
-    // softmax function. This is similar to a bitcast operation.
-    int axis = 1;
-    if (dict.count("axis")) {
-      ASSIGN_VALUE_OR_RETURN_ERR(axis,
-                                 loadAxis<int>(dict["axis"], in.dims().size()));
-    }
-
-    auto *FN = G_->createFlatten(opName + ".reshapeInput", in, axis);
-
-    auto *SM = G_->createSoftMax(opName, FN, selected);
-
-    // The output should have the same shape as the original input.
-    auto origInDims = in.getType()->dims();
-    auto *RN = G_->createReshape(opName + ".reshapeOutput", SM, origInDims);
-    RETURN_IF_ERR(addNodeAsOutput(op, RN));
-    return Error::success();
-  }
-
   Error loadLRN(const OpType &op, ArgumentDictionaryTy &dict) {
     const std::string &opName = loadOperatorName(op);
     NodeValue in;
@@ -1460,10 +1422,6 @@ protected:
     }
     if (typeName == "Sum") {
       RETURN_IF_ERR(loadSum(op, dict));
-      return true;
-    }
-    if (typeName == "Softmax") {
-      RETURN_IF_ERR(loadSoftmax(op, dict));
       return true;
     }
     if (typeName == "LRN") {

--- a/include/glow/Importer/ONNXModelLoader.h
+++ b/include/glow/Importer/ONNXModelLoader.h
@@ -179,6 +179,10 @@ class ONNXModelLoader
   Error loadSign(const ONNX_NAMESPACE::NodeProto &op,
                  const ArgumentDictionaryTy &dict);
 
+  /// Load Softmax ONNX operator
+  Error loadSoftmax(const ONNX_NAMESPACE::NodeProto &op,
+                    const ArgumentDictionaryTy &dict);
+
   /// Load Conv ONNX operator.
   Error loadConv(const ONNX_NAMESPACE::NodeProto &op,
                  ArgumentDictionaryTy &dict);

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1603,6 +1603,12 @@ ReshapeNode *Function::createFlatten(llvm::StringRef name, NodeValue input,
   return createReshape(name, input, {xDim.first, xDim.second});
 }
 
+ReshapeNode *Function::createFlattenV1(llvm::StringRef name, NodeValue input,
+                                       unsigned_t axis) {
+  auto xDim = collapseShape(input.getType()->dims(), axis);
+  return createReshape(name, input, {xDim.first, xDim.second});
+}
+
 void Function::createSplit(llvm::StringRef name, NodeValue input,
                            unsigned_t outputNum, unsigned_t axis,
                            llvm::ArrayRef<dim_t> split,

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -332,6 +332,41 @@ Error Caffe2ModelLoader::loadPRelu(const caffe2::OperatorDef &op,
   return Error::success();
 }
 
+Error Caffe2ModelLoader::loadSoftmax(const caffe2::OperatorDef &op,
+                                     ArgumentDictionaryTy &dict) {
+  const std::string &opName = loadOperatorName(op);
+
+  NodeValue in;
+  ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
+
+  RETURN_ERR_IF_NOT(
+      in.dims().size() >= 2,
+      opErrMsg(op,
+               strFormat(
+                   "SoftMax input dims must be >= 2, but found input dims %zu ",
+                   in.dims().size())));
+
+  // Create a constant to store labels to be used in SoftMaxGradNode.
+  auto *selected = G_->createSplat(
+      opName + ".selected",
+      mod_.uniqueType(ElemKind::Int64ITy, {in.dims()[0], 1}), 0.f);
+
+  int axis = 1;
+  if (dict.count("axis")) {
+    ASSIGN_VALUE_OR_RETURN_ERR(axis,
+                               loadAxis<int>(dict["axis"], in.dims().size()));
+  }
+
+  auto *FN = G_->createFlatten(opName + ".reshapeInput", in, axis);
+  auto *SM = G_->createSoftMax(opName, FN, selected);
+
+  // The output should have the same shape as the original input.
+  auto origInDims = in.getType()->dims();
+  auto *RN = G_->createReshape(opName + ".reshapeOutput", SM, origInDims);
+  RETURN_IF_ERR(addNodeAsOutput(op, RN));
+  return Error::success();
+}
+
 Error Caffe2ModelLoader::loadConv(const caffe2::OperatorDef &op,
                                   ArgumentDictionaryTy &dict) {
   const std::string &opName = loadOperatorName(op);
@@ -740,6 +775,10 @@ Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
 
   if (typeName == "Conv" || typeName == "ConvRelu") {
     return loadConv(op, dict);
+  }
+
+  if (typeName == "Softmax") {
+    return loadSoftmax(op, dict);
   }
 
   if (typeName == "PRelu") {

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -4484,6 +4484,80 @@ Error ONNXModelLoader::loadSign(const ONNX_NAMESPACE::NodeProto &op,
   return Error::success();
 }
 
+Error ONNXModelLoader::loadSoftmax(const ONNX_NAMESPACE::NodeProto &op,
+                                   const ArgumentDictionaryTy &dict) {
+
+  const std::string &opName = loadOperatorName(op);
+  NodeValue in;
+  ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
+
+  RETURN_ERR_IF_NOT(in.dims().size() >= 2, "SoftMax input dims must be >= 2");
+
+  // Create a constant to store labels to be used in SoftMaxGradNode.
+  auto selected =
+      mod_.createConstant(ElemKind::Int64ITy, {in.dims()[0], 1}, "selected");
+
+  if (opsetVersion_ == 13) {
+    int axis = -1;
+    if (dict.count("axis")) {
+      ASSIGN_VALUE_OR_RETURN_ERR(axis, loadInt(dict.at("axis")));
+    }
+    RETURN_ERR_IF_NOT(in.dims().size() == 4, "SoftMax 13 input dims must be 4");
+    // Compute the shuffle layout  based on axis input.
+    std::vector<unsigned_t> shuffle;
+    std::vector<unsigned_t> shuffleBack;
+    switch (axis) {
+    case 0:
+      shuffle = {1u, 2u, 3u, 0u};
+      shuffleBack = {3u, 0u, 1u, 2u};
+      break;
+
+    case 1:
+      shuffle = {0u, 2u, 3u, 1u};
+      shuffleBack = {0u, 3u, 1u, 2u};
+      break;
+
+    case 2:
+      shuffle = {0u, 1u, 3u, 2u};
+      shuffleBack = {0u, 1u, 3u, 2u};
+      break;
+
+    case 3:
+      shuffle = {0u, 1u, 2u, 3u};
+      shuffleBack = {0u, 1u, 2u, 3u};
+      break;
+
+    default:
+      return MAKE_ERR("SoftMax Axis must be <=3");
+      break;
+    }
+    auto *NH = G_->createTranspose(opName, in, shuffle);
+    auto *FN = G_->createFlattenV1("reshapeInput", NH, axis);
+    auto *SM = G_->createSoftMax(opName, FN, selected);
+
+    // The output should have the same shape as the original input.
+    auto origInDims = NH->getResult().dims();
+    auto *RN = G_->createReshape("reshapeOutput", SM, origInDims);
+    auto *NC = G_->createTranspose(opName, RN, shuffleBack);
+    RETURN_IF_ERR(addNodeAsOutput(op, NC));
+  } else {
+    // ONNX allows shapes like <N x 10 x 1 x 1 >. Flatten the inputs to the
+    // softmax function. This is basimilar to a bitcast operation.
+    int axis = 1;
+    if (dict.count("axis")) {
+      ASSIGN_VALUE_OR_RETURN_ERR(axis, loadInt(dict.at("axis")));
+    }
+    auto *FN = G_->createFlatten("reshapeInput", in, axis);
+    auto *SM = G_->createSoftMax(opName, FN, selected);
+
+    // The output should have the same shape as the original input.
+    auto origInDims = in.getType()->dims();
+    auto *RN = G_->createReshape("reshapeOutput", SM, origInDims);
+    RETURN_IF_ERR(addNodeAsOutput(op, RN));
+  }
+  return Error::success();
+}
+
 Error ONNXModelLoader::loadLoop(const ONNX_NAMESPACE::NodeProto &op,
                                 const ArgumentDictionaryTy &dict) {
   int64_t maxTripCount;
@@ -5072,6 +5146,9 @@ Error ONNXModelLoader::loadOperator(const ONNX_NAMESPACE::NodeProto &op) {
   }
   if (typeName == "Sign") {
     return loadSign(op, dict);
+  }
+  if (typeName == "Softmax") {
+    return loadSoftmax(op, dict);
   }
 
   return MAKE_ERR("Failed to load operator " + typeName + " .",

--- a/tests/models/onnxModels/softmax11.onnxtxt
+++ b/tests/models/onnxModels/softmax11.onnxtxt
@@ -1,0 +1,63 @@
+ir_version: 3
+producer_name: "softmax11-onnx-example"
+graph {
+  node {
+    input: "x"
+    output: "y"
+    op_type: "Softmax"
+    attribute {
+      name: "axis"
+      i: 1
+      type: INT
+    }
+  }
+  name: "softmax11-node"
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  domain: ""
+  version: 11
+}

--- a/tests/models/onnxModels/softmax13.onnxtxt
+++ b/tests/models/onnxModels/softmax13.onnxtxt
@@ -1,0 +1,42 @@
+ir_version : 3 producer_name : "softmax11-onnx-example" graph {
+  node {
+  input:
+    "x" output : "y" op_type : "Softmax" attribute {
+    name:
+      "axis" i : 2 type : INT
+    }
+  }
+name:
+  "softmax11-node" input {
+  name:
+    "x" type {
+      tensor_type {
+      elem_type:
+        1 shape {
+          dim{dim_value : 2} dim{dim_value : 2} dim{dim_value : 2} dim {
+          dim_value:
+            2
+          }
+        }
+      }
+    }
+  }
+  output {
+  name:
+    "y" type {
+      tensor_type {
+      elem_type:
+        1 shape {
+          dim{dim_value : 2} dim{dim_value : 2} dim{dim_value : 2} dim {
+          dim_value:
+            2
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+domain:
+  "" version : 13
+}

--- a/tests/unittests/OnnxExporterTest.cpp
+++ b/tests/unittests/OnnxExporterTest.cpp
@@ -413,6 +413,7 @@ TEST(exporter, onnxModels) {
         name.find("loop_withoutN.onnxtxt") != std::string::npos ||
         name.find("sign.onnxtxt") != std::string::npos ||
         name.find("gatherND.onnxtxt") != std::string::npos ||
+        name.find("softmax13.onnxtxt") != std::string::npos ||
         name.find("simpleConvTranspose.onnxtxt") != std::string::npos ||
         name.find("simpleConvTransposeOutShape.onnxtxt") != std::string::npos ||
         name.find("simpleConvTransposeOutShapeDilation.onnxtxt") !=

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -5312,3 +5312,55 @@ TEST(onnx, importClipV11) {
     EXPECT_FLOAT_EQ(result.raw(i), expectedValues[i]);
   }
 }
+
+// Utility function to test ONNX Softmax
+static void testSoftmax(const std::string modelName,
+                        const std::vector<dim_t> &expectedDims,
+                        const std::vector<float> &expectedValues) {
+  ExecutionEngine EE{};
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+
+  // Input.
+  Tensor x(ElemKind::FloatTy, {2, 2, 2, 2});
+  x.getHandle() = {0.0, 1.0, 2.0,  3.0,  4.0,  5.0,  6.0,  7.0,
+                   8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0};
+
+  // Load model.
+  std::string netFilename =
+      std::string(GLOW_DATA_PATH "tests/models/onnxModels/") + modelName;
+  ONNXModelLoader onnxLD(netFilename, {"x"}, {&x.getType()}, *F);
+  Placeholder *output = EXIT_ON_ERR(onnxLD.getSingleOutput());
+
+  // Allocate placeholders.
+  PlaceholderBindings bindings;
+  bindings.allocate(mod.getPlaceholders());
+  updateInputPlaceholdersByName(bindings, &mod, {"x"}, {&x});
+
+  auto *res = bindings.get(output);
+  EE.compile(CompilationMode::Infer);
+  EE.run(bindings);
+
+  // Compare results.
+  auto result = res->getHandle();
+  EXPECT_TRUE(result.dims().vec() == expectedDims);
+  for (dim_t i = 0; i < result.size(); i++) {
+    EXPECT_FLOAT_EQ(result.raw(i), expectedValues[i]);
+  }
+}
+
+/// Test loading Softmax from a ONNX model.
+TEST_F(OnnxImporterTest, softmax) {
+  testSoftmax("softmax11.onnxtxt", {2, 2, 2, 2},
+              {5.7661277e-04, 1.5673960e-03, 4.2606238e-03, 1.1581578e-02,
+               3.1481992e-02, 8.5576929e-02, 2.3262219e-01, 6.3233274e-01,
+               5.7661277e-04, 1.5673960e-03, 4.2606238e-03, 1.1581578e-02,
+               3.1481992e-02, 8.5576929e-02, 2.3262219e-01, 6.3233274e-01});
+}
+/// Test loading Softmax opset13 from a ONNX model.
+TEST_F(OnnxImporterTest, softmax13) {
+  testSoftmax("softmax13.onnxtxt", {2, 2, 2, 2},
+              {0.11920292, 0.11920292, 0.880797, 0.880797, 0.11920292,
+               0.11920292, 0.880797, 0.880797, 0.11920292, 0.11920292, 0.880797,
+               0.880797, 0.11920292, 0.11920292, 0.880797, 0.880797});
+}


### PR DESCRIPTION
Summary: 
Add support for different opsetVersion implementation of Softmax in ONNXModelLoader
Since ONNX Softmax have different implementation for different set of Opset versions.
https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Softmax-13
https://github.com/onnx/onnx/blob/master/docs/Changelog.md#Softmax-11

In order to handle such case, have added the support for softmax in ONNXModelLoader depending upon the opset version requirement, currently softmax-13 works only for 4D input data.

Test Plan: Added softmax tests in OnnxImporterTest, Ninja test is run

