### PR TITLE
Cleanup alternate AOT settings usages to not use global settings

### DIFF
--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -43,12 +43,6 @@ public:
 
   std::string toString() const;
 
-  /// This should be used with CachingGraphRunner::warmCache. When this flag is
-  /// enabled, it assumes the glow graph is compiled ahead of time instead of
-  /// at PyTorch JIT runtime. And the registered glow operator will run
-  /// the precompiled results directly.
-  bool preCompilePyTorchModule = false;
-
   /// Whether or not run the custom pass that fuses jit nodes into a glow node.
   bool fusionPassEnabled = false;
 
@@ -158,9 +152,6 @@ public:
   /// embedding-bag-like operators. This is default to true since it is
   /// currently a requirement if we want to support partial inputs
   bool setIncludeLastOffsets = true;
-
-  /// infer shape for entire model and run AOT compilation
-  bool inferShapeForCompilation = false;
 };
 
 /// Given a PyTorch ScalarType \p ty, \returns a matching Glow ElemKind.
@@ -216,7 +207,8 @@ std::vector<glow::InputMeta> loadInputMeta(const std::string &raw_data);
 
 /// Lower a pytorch \p module to glow before execution. \p inputMetaStr is the
 /// raw string containing the meta data of the glow fuser node input.
-void glowAOTFusion(torch::jit::Module &module, const std::string &inputMetaStr);
+void glowAOTFusion(torch::jit::Module &module, const std::string &inputMetaStr,
+                   PyTorchLoaderSettings settings);
 
 /// Lower a pytorch \p module to glow before execution. \p inputMeta is a
 /// vector containing the meta data of the model inputs.

--- a/torch_glow/src/TorchGlowBackend.cpp
+++ b/torch_glow/src/TorchGlowBackend.cpp
@@ -523,9 +523,6 @@ TorchGlowBackend::compile(c10::IValue processed,
     applyCompilationGroupSettingsToPyTorchLoaderSettings(
         baseSettings, *spec.default_compilation_group_settings);
 
-    // TODO: can we delete this?
-    baseSettings.preCompilePyTorchModule = true;
-
     // Override settings from gflags
     applySettingsOverrideFlagsToPyTorchLoaderSettings(baseSettings);
 
@@ -551,7 +548,7 @@ TorchGlowBackend::compile(c10::IValue processed,
               g,
               glow::getHostManager(baseSettings.backendName,
                                    baseSettings.numDevices),
-              baseSettings);
+              baseSettings, /*useRunOnly*/ true);
 
       // Compile each compilation group
       for (const auto &compilationGroup : spec.compilation_groups) {
@@ -596,7 +593,7 @@ TorchGlowBackend::execute(c10::IValue handle, c10::impl::GenericList inputs) {
     for (const auto &i : inputs) {
       torch::jit::push(stack, i);
     }
-    err = it->second.first->runOnly(stack);
+    err = it->second.first->run(stack);
   } else if (runnerPair.second) {
     stack = it->second.second->onExecute(inputs);
   } else {


### PR DESCRIPTION
Summary:
* make runOnly internal only to CachingGraphRunner (todo: merge it with run)
* explicitly pass settings into glowAOTFusion
* remove preCompilePyTorchModule from settings, instead use `useRunOnly` attribute of CachingGraphRunner
* remove inferShapeForCompilation from settings, just a regular gflag

Reviewed By: qizzzh

Differential Revision: D24319656

