### PR TITLE
Adding to_glow based comparison util.

### DIFF
--- a/torch_glow/src/TorchGlowBackend.cpp
+++ b/torch_glow/src/TorchGlowBackend.cpp
@@ -1,5 +1,6 @@
 // Copyright 2004-present Facebook. All Rights Reserved.
 #include "TorchGlowBackend.h"
+#include "FuseKnownPatterns.h"
 #include "GlowCompileSpec.h"
 #include "GlowFuser.h"
 #include "Registration.h"
@@ -417,6 +418,7 @@ TorchGlowBackend::preprocess(c10::IValue mod,
     const auto &methodName = kv.key().toStringRef();
     auto method = m.get_method(methodName);
     auto graph = method.graph();
+    detail::fuseConcat(graph);
     torch::jit::Inline(*graph);
     RewriteQuantPackedParamOps(graph);
     glow::Error err = ProcessPackedParams(*graph, m._ivalue());

--- a/torch_glow/src/binding.cpp
+++ b/torch_glow/src/binding.cpp
@@ -63,6 +63,11 @@ PYBIND11_MODULE(_torch_glow, m) {
     getGlobalPyTorchLoaderSettingsMutable().fusionPassEnabled = false;
   });
 
+  /// Get status of converting PyTorch subgraphs to Glow Functions.
+  m.def("getFusionPassEnabled", []() {
+    return getGlobalPyTorchLoaderSettingsMutable().fusionPassEnabled;
+  });
+
   /// Enable dumping Glow DAG to file after model loading finishes.
   m.def("enableDumpGlowDag",
         []() { getGlobalPyTorchLoaderSettingsMutable().dumpGlowDag = true; });
@@ -89,13 +94,21 @@ PYBIND11_MODULE(_torch_glow, m) {
     getGlobalPyTorchLoaderSettingsMutable().convertToFP16 = false;
   });
 
-  /// Enable converting fp32 ops to fp16.
+  /// Get status of converting fp32 ops to fp16.
+  m.def("get_convert_to_fp16",
+        []() { return getGlobalPyTorchLoaderSettingsMutable().convertToFP16; });
+
+  /// Enable clipping of fp16.
   m.def("enable_clip_fp16",
         []() { getGlobalPyTorchLoaderSettingsMutable().clipFP16 = true; });
 
-  /// Disable converting fp32 ops to fp16.
+  /// Disable clipping of fp16.
   m.def("disable_clip_fp16",
         []() { getGlobalPyTorchLoaderSettingsMutable().clipFP16 = false; });
+
+  /// Get status of clipping fp16.
+  m.def("get_clip_fp16",
+        []() { return getGlobalPyTorchLoaderSettingsMutable().clipFP16; });
 
   /// Enable converting fp32 fused ops to fp16.
   m.def("enable_convert_fused_to_fp16", []() {
@@ -105,6 +118,11 @@ PYBIND11_MODULE(_torch_glow, m) {
   /// Disable converting fp32 fused ops to fp16.
   m.def("disable_convert_fused_to_fp16", []() {
     getGlobalPyTorchLoaderSettingsMutable().convertFusedToFP16 = false;
+  });
+
+  /// Get status of converting fp32 fused ops to fp16.
+  m.def("get_convert_fused_to_fp16", []() {
+    return getGlobalPyTorchLoaderSettingsMutable().convertFusedToFP16;
   });
 
   /// Enable dumping the final Glow dag after compilation.
@@ -209,6 +227,15 @@ PYBIND11_MODULE(_torch_glow, m) {
     for (const auto &kind : blacklist) {
       bl.insert(torch::jit::Symbol::fromQualString(kind));
     }
+  });
+
+  /// Get the fusion blacklist.
+  m.def("getFusionBlacklist", []() {
+    auto &symbols = getGlobalPyTorchLoaderSettingsMutable().opBlacklist;
+    std::vector<std::string> strings;
+    std::transform(symbols.begin(), symbols.end(), std::back_inserter(strings),
+                   [](torch::jit::Symbol s) { return s.toQualString(); });
+    return strings;
   });
 
   /// Clear the fusion blacklist.

--- a/torch_glow/tests/functionality/blacklist_test.py
+++ b/torch_glow/tests/functionality/blacklist_test.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import torch_glow
 import torch
 
-from tests.utils import GLOW_NODE_NAME, SUBGRAPH_ATTR
+from tests.utils import GLOW_FUSION_GROUP, SUBGRAPH_ATTR
 import unittest
 
 
@@ -28,7 +28,7 @@ class TestBlackList(unittest.TestCase):
         fused_add = False
         fused_sub = False
         for node in jit_f_graph.nodes():
-            if node.kind() == GLOW_NODE_NAME:
+            if node.kind() == GLOW_FUSION_GROUP:
                 glow_subgraph = node.g(SUBGRAPH_ATTR)
                 for node in glow_subgraph.nodes():
                     if node.kind() == "aten::add":
@@ -71,7 +71,7 @@ class TestBlackList(unittest.TestCase):
         fused_muls = 0
         fused_divs = 0
         for node in jit_f_graph.nodes():
-            if node.kind() == GLOW_NODE_NAME:
+            if node.kind() == GLOW_FUSION_GROUP:
                 glow_subgraph = node.g(SUBGRAPH_ATTR)
                 for node in glow_subgraph.nodes():
                     if node.kind() == "aten::mul":

--- a/torch_glow/tests/functionality/fuse_necessary_getattrs_only.py
+++ b/torch_glow/tests/functionality/fuse_necessary_getattrs_only.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import torch_glow
 import torch
-from tests.utils import GLOW_NODE_NAME
 
 
 class LinearModel(torch.nn.Module):
@@ -46,14 +45,10 @@ def test_fuse_necessary_getattrs_only():
     jit_m = torch.jit.trace(m, x)
     jit_m_graph = jit_m.graph_for(x)
 
-    print(jit_m_graph)
-
     # don't fuse aten::_convolutions
     torch_glow.glowCustomFuseDebug_(
         jit_m_graph,
         ["prim::Constant", "prim::GetAttr", "aten::t", "aten::matmul", "aten::add_"],
     )
-
-    print(jit_m_graph)
 
     return m(x)

--- a/torch_glow/tests/functionality/jit_vs_glow_path_test.py
+++ b/torch_glow/tests/functionality/jit_vs_glow_path_test.py
@@ -6,7 +6,7 @@ import unittest
 import torch_glow
 import torch
 import torch.nn.functional as F
-from tests.utils import jitVsGlow
+from tests import utils
 
 
 class TestJITVsGlowPath(unittest.TestCase):
@@ -15,8 +15,9 @@ class TestJITVsGlowPath(unittest.TestCase):
 
         torch_glow.enable_jit_vs_glow_compare()
 
-        def test_f(input, weight, bias=None):
-            return F.linear((input + input), weight, bias)
+        class TestModule(torch.nn.Module):
+            def forward(self, input, weight):
+                return F.linear((input + input), weight)
 
         n = 5
         in_features = 4
@@ -25,11 +26,11 @@ class TestJITVsGlowPath(unittest.TestCase):
         input = torch.randn(n, in_features)
         weight = torch.randn(out_features, in_features)
 
-        jitVsGlow(
-            test_f,
+        utils.compare_tracing_methods(
+            TestModule(),
             input,
             weight,
-            expected_fused_ops={"aten::add", "aten::t", "aten::matmul"},
+            fusible_ops={"aten::add", "aten::t", "aten::matmul"},
         )
 
     def test_jit_vs_glow_int_path(self):
@@ -37,25 +38,27 @@ class TestJITVsGlowPath(unittest.TestCase):
 
         torch_glow.enable_jit_vs_glow_compare()
 
-        def test_f(a, b):
-            c = a + b
-            return c
+        class TestModule(torch.nn.Module):
+            def forward(self, a, b):
+                c = a + b
+                return c
 
         a = torch.randn(5, 6).to(dtype=torch.int32)
         b = torch.randn(5, 6).to(dtype=torch.int32)
 
-        jitVsGlow(test_f, a, b, expected_fused_ops={"aten::add"})
+        utils.compare_tracing_methods(TestModule(), a, b, fusible_ops={"aten::add"})
 
     def test_jit_vs_glow_inplace(self):
         """Test JIT vs. Glow logging with in-place op"""
 
         torch_glow.enable_jit_vs_glow_compare()
 
-        def test_f(a, b):
-            a += b
-            return a
+        class TestModule(torch.nn.Module):
+            def forward(self, a, b):
+                a += b
+                return a
 
         a = torch.randn(5, 6)
         b = torch.randn(5, 6)
 
-        jitVsGlow(test_f, a, b, expected_fused_ops={"aten::add_"})
+        utils.compare_tracing_methods(TestModule(), a, b, fusible_ops={"aten::add_"})

--- a/torch_glow/tests/functionality/max_fusion_merge_size_test.py
+++ b/torch_glow/tests/functionality/max_fusion_merge_size_test.py
@@ -5,7 +5,7 @@ import unittest
 
 import torch_glow
 import torch
-from tests.utils import GLOW_NODE_NAME, SUBGRAPH_ATTR
+from tests.utils import GLOW_FUSION_GROUP
 
 
 class TestMaxFusionMergeSize(unittest.TestCase):
@@ -34,7 +34,7 @@ class TestMaxFusionMergeSize(unittest.TestCase):
 
         fusion_nodes = 0
         for node in jit_f_graph.nodes():
-            if node.kind() == GLOW_NODE_NAME:
+            if node.kind() == GLOW_FUSION_GROUP:
                 fusion_nodes += 1
 
         assert fusion_nodes > 1, "Expected more than one fusion group to be created"
@@ -66,7 +66,7 @@ class TestMaxFusionMergeSize(unittest.TestCase):
 
         fusion_nodes = 0
         for node in jit_f_graph.nodes():
-            if node.kind() == GLOW_NODE_NAME:
+            if node.kind() == GLOW_FUSION_GROUP:
                 fusion_nodes += 1
 
         assert fusion_nodes == 1, "Expected just one fusion group to be created"

--- a/torch_glow/tests/functionality/min_graph_size_test.py
+++ b/torch_glow/tests/functionality/min_graph_size_test.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import torch_glow
 import torch
 
-from tests.utils import GLOW_NODE_NAME, SUBGRAPH_ATTR
+from tests.utils import GLOW_FUSION_GROUP
 import unittest
 
 
@@ -40,7 +40,7 @@ class TestMinGraphSize(unittest.TestCase):
 
         fusion_nodes = 0
         for node in jit_f_graph.nodes():
-            if node.kind() == GLOW_NODE_NAME:
+            if node.kind() == GLOW_FUSION_GROUP:
                 fusion_nodes += 1
 
         assert fusion_nodes == 2, "Expected smallest fusion group to not be created"

--- a/torch_glow/tests/functionality/only_tensor_outputs_test.py
+++ b/torch_glow/tests/functionality/only_tensor_outputs_test.py
@@ -5,7 +5,7 @@ import unittest
 
 import torch_glow
 import torch
-from tests.utils import GLOW_NODE_NAME
+from tests.utils import GLOW_FUSION_GROUP
 
 
 class TestOnlyTensorOutputs(unittest.TestCase):
@@ -36,7 +36,7 @@ class TestOnlyTensorOutputs(unittest.TestCase):
         fusion_nodes = 0
         aten_sizes = 0
         for node in jit_f_graph.nodes():
-            if node.kind() == GLOW_NODE_NAME:
+            if node.kind() == GLOW_FUSION_GROUP:
                 fusion_nodes += 1
             if node.kind() == "aten::size":
                 aten_sizes += 1

--- a/torch_glow/tests/functionality/quantized_cut_in_the_middle_test.py
+++ b/torch_glow/tests/functionality/quantized_cut_in_the_middle_test.py
@@ -5,7 +5,7 @@ import unittest
 
 import torch_glow
 import torch
-from tests.utils import GLOW_NODE_NAME
+from tests.utils import GLOW_FUSION_GROUP
 
 
 class TestQuantizedCut(unittest.TestCase):
@@ -48,7 +48,7 @@ class TestQuantizedCut(unittest.TestCase):
                 kind = node.kind()
                 # Make sure the blacklist is working
                 assert (
-                    kind == GLOW_NODE_NAME
+                    kind == GLOW_FUSION_GROUP
                     or kind in blacklist
                     or kind == "prim::Constant"
                 )

--- a/torch_glow/tests/nodes/Int_test.py
+++ b/torch_glow/tests/nodes/Int_test.py
@@ -3,7 +3,39 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimpleIntModule(torch.nn.Module):
+    def __init__(self, dtype):
+        super(SimpleIntModule, self).__init__()
+        # This has to be done in the init block, because control flow statements in the
+        # forward method won't be fused during scripting.
+        if dtype == torch.int32:
+            self.forward = self._int32_forward
+        else:
+            self.forward = self._int64_forward
+
+    def _int32_forward(self, a):
+        b = a.size(0)
+        c = a.size(1)
+        bt = torch.ops.prim.NumToTensor(b)
+        ct = torch.ops.prim.NumToTensor(c)
+        d = bt + ct
+        d = d.to(torch.int32)
+        i = torch.ops.aten.Int(d)
+        res = torch.ops.prim.NumToTensor(i)
+        return res
+
+    def _int64_forward(self, a):
+        b = a.size(0)
+        c = a.size(1)
+        bt = torch.ops.prim.NumToTensor(b)
+        ct = torch.ops.prim.NumToTensor(c)
+        d = bt * ct
+        i = torch.ops.aten.Int(d)
+        res = torch.ops.prim.NumToTensor(i)
+        return res
 
 
 class TestInt(unittest.TestCase):
@@ -11,33 +43,16 @@ class TestInt(unittest.TestCase):
         """Basic test of the PyTorch Int Node on Glow, along with constant
         propagation. Using int32 dtype, and aten::add."""
 
-        def test_f(a):
-            b = a.size(0)
-            c = a.size(1)
-            bt = torch.ops.prim.NumToTensor(b)
-            ct = torch.ops.prim.NumToTensor(c)
-            d = bt + ct
-            d = d.to(torch.int32)
-            i = torch.ops.aten.Int(d)
-            res = torch.ops.prim.NumToTensor(i)
-            return res
-
         x = torch.randn(2, 3, 4, dtype=torch.float32)
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::Int"}, use_script=True)
+        utils.compare_tracing_methods(
+            SimpleIntModule(torch.int32), x, fusible_ops={"aten::Int"}, scripted=True
+        )
 
     def test_Int_mul_long(self):
         """Basic test of the PyTorch Int Node on Glow, along with constant
         propagation. Using int64 dtype, and aten::mul"""
 
-        def test_f(a):
-            b = a.size(0)
-            c = a.size(1)
-            bt = torch.ops.prim.NumToTensor(b)
-            ct = torch.ops.prim.NumToTensor(c)
-            d = bt * ct
-            i = torch.ops.aten.Int(d)
-            res = torch.ops.prim.NumToTensor(i)
-            return res
-
         x = torch.randn(2, 3, 4, dtype=torch.float32)
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::Int"}, use_script=True)
+        utils.compare_tracing_methods(
+            SimpleIntModule(torch.int64), x, fusible_ops={"aten::Int"}, scripted=True
+        )

--- a/torch_glow/tests/nodes/adaptive_avg_pool2d_test.py
+++ b/torch_glow/tests/nodes/adaptive_avg_pool2d_test.py
@@ -4,36 +4,47 @@ import unittest
 
 import torch
 import torch.nn.functional as F
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimpleAdapativeAvgPool2dModule(torch.nn.Module):
+    def __init__(self, output_size):
+        super(SimpleAdapativeAvgPool2dModule, self).__init__()
+        self.output_size = output_size
+
+    def forward(self, inputs):
+        return F.adaptive_avg_pool2d(inputs, self.output_size)
 
 
 class TestAdaptiveAvgPool2d(unittest.TestCase):
     def test_adaptive_avg_pool2d_basic(self):
         """Basic test of PyTorch adaptive_avg_pool2d Node."""
-
-        def test_f(inputs):
-            return F.adaptive_avg_pool2d(inputs, (5, 5))
-
         inputs = torch.randn(3, 6, 14, 14)
 
-        jitVsGlow(test_f, inputs, expected_fused_ops={"aten::adaptive_avg_pool2d"})
+        utils.compare_tracing_methods(
+            SimpleAdapativeAvgPool2dModule((5, 5)),
+            inputs,
+            fusible_ops={"aten::adaptive_avg_pool2d"},
+        )
 
     def test_adaptive_avg_pool2d_nonsquare_inputs(self):
         """Test of PyTorch adaptive_avg_pool2d Node with non-square inputs."""
 
-        def test_f(inputs):
-            return F.adaptive_avg_pool2d(inputs, (3, 3))
-
         inputs = torch.randn(3, 6, 13, 14)
 
-        jitVsGlow(test_f, inputs, expected_fused_ops={"aten::adaptive_avg_pool2d"})
+        utils.compare_tracing_methods(
+            SimpleAdapativeAvgPool2dModule((3, 3)),
+            inputs,
+            fusible_ops={"aten::adaptive_avg_pool2d"},
+        )
 
     def test_adaptive_avg_pool2d_nonsquare_outputs(self):
         """Test of PyTorch adaptive_avg_pool2d Node with non-square outputs."""
 
-        def test_f(inputs):
-            return F.adaptive_avg_pool2d(inputs, (5, 3))
-
         inputs = torch.randn(3, 6, 14, 14)
 
-        jitVsGlow(test_f, inputs, expected_fused_ops={"aten::adaptive_avg_pool2d"})
+        utils.compare_tracing_methods(
+            SimpleAdapativeAvgPool2dModule((5, 3)),
+            inputs,
+            fusible_ops={"aten::adaptive_avg_pool2d"},
+        )

--- a/torch_glow/tests/nodes/add_test.py
+++ b/torch_glow/tests/nodes/add_test.py
@@ -3,86 +3,58 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from parameterized import parameterized
+from tests import utils
+
+
+class SimpleAddModule(torch.nn.Module):
+    def __init__(self, inplace=False):
+        super(SimpleAddModule, self).__init__()
+        self.inplace = inplace
+
+    def forward(self, a, b):
+        if b.size() == torch.Size([]):
+            return (a * a).add(b.item())
+        if self.inplace:
+            c = a.add_(b)
+            return c.add_(c)
+        else:
+            c = a.add(b)
+            return c.add(c)
 
 
 class TestAdd(unittest.TestCase):
-    def test_add_basic(self):
-        """Basic test of the PyTorch add Node on Glow."""
-
-        def test_f(a, b):
-            c = a.add(b)
-            return c.add(c)
-
-        x = torch.randn(4)
-        y = torch.randn(4)
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::add"})
-
-    def test_add_inplace(self):
-        """Test of the PyTorch add_ Node on Glow."""
-
-        def test_f(a, b):
-            c = a.add_(b)
-            return c.add_(c)
-
-        x = torch.randn(4)
-        y = torch.randn(4)
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::add_"})
-
-    def test_add_broadcast_1(self):
-        """Test of the PyTorch add Node on Glow with broadcasting."""
-
-        def test_f(a, b):
-            c = a.add(b)
-            return c.add(c)
-
-        x = torch.randn(8, 3, 4, 2)
-        y = torch.randn(4, 2)
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::add"})
-
-    def test_add_broadcast_2(self):
-        """Test of the PyTorch add Node on Glow with broadcasting."""
-
-        def test_f(a, b):
-            c = a.add(b)
-            return c.add(c)
-
-        x = torch.randn(8, 3, 4, 2)
-        y = torch.randn(1, 2)
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::add"})
-
-    def test_add_broadcast_3(self):
-        """Test of the PyTorch add Node on Glow with broadcasting."""
-
-        def test_f(a, b):
-            c = a.add(b)
-            return c.add(c)
-
-        x = torch.randn(4, 2)
-        y = torch.randn(8, 3, 4, 2)
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::add"})
-
-    def test_add_float(self):
-        """Test of the PyTorch aten::add Node with a float argument"""
-
-        def test_f(a):
-            return (a * a).add(3.9)
-
-        x = torch.randn(4)
-
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::add"})
-
-    def test_add_int(self):
-        """Test of the PyTorch aten::add Node with an int argument"""
-
-        def test_f(a):
-            return (a * a).add(20)
-
-        x = torch.randn(4)
-
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::add"})
+    @parameterized.expand(
+        [
+            ("basic", SimpleAddModule(), torch.randn(4), torch.randn(4)),
+            ("inplace", SimpleAddModule(True), torch.randn(4), torch.randn(4)),
+            (
+                "broadcast",
+                SimpleAddModule(),
+                torch.randn(8, 3, 4, 2),
+                torch.randn(4, 2),
+            ),
+            (
+                "broadcast",
+                SimpleAddModule(),
+                torch.randn(8, 3, 4, 2),
+                torch.randn(1, 2),
+            ),
+            (
+                "broadcast",
+                SimpleAddModule(),
+                torch.randn(4, 2),
+                torch.randn(8, 3, 4, 2),
+            ),
+            ("float", SimpleAddModule(), torch.randn(4), torch.tensor(1.2345)),
+            ("int", SimpleAddModule(), torch.randn(4), torch.tensor(42), True),
+        ]
+    )
+    def test_add(self, _, module, a, b, skip_to_glow=False):
+        utils.compare_tracing_methods(
+            module,
+            a,
+            b,
+            skip_to_glow=skip_to_glow,
+            fusible_ops={"aten::add_"} if module.inplace else {"aten::add"},
+        )

--- a/torch_glow/tests/nodes/addmm_test.py
+++ b/torch_glow/tests/nodes/addmm_test.py
@@ -3,42 +3,40 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimpleAddMmModule(torch.nn.Module):
+    def __init__(self, alpha=1, beta=1):
+        super(SimpleAddMmModule, self).__init__()
+        self.alpha = alpha
+        self.beta = beta
+
+    def forward(self, a, b, c):
+        return (a + a).addmm(b, c)
 
 
 class TestAddMM(unittest.TestCase):
     def test_addmm_basic(self):
         """Basic test of the PyTorch addmm Node on Glow."""
-
-        def test_f(a, b, c):
-            return (a + a).addmm(b, c)
-
-        x = torch.randn(6, 4)
-        y = torch.randn(6, 10)
-        z = torch.randn(10, 4)
-
-        jitVsGlow(test_f, x, y, z, expected_fused_ops={"aten::add", "aten::mm"})
+        utils.compare_tracing_methods(
+            SimpleAddMmModule(),
+            torch.randn(6, 4),
+            torch.randn(6, 10),
+            torch.randn(10, 4),
+        )
 
     def test_addmm_broadcast(self):
         """Test of the PyTorch addmm with broadcasting add on Glow."""
-
-        def test_f(a, b, c):
-            return (a + a).addmm(b, c)
-
-        x = torch.randn(4)
-        y = torch.randn(6, 10)
-        z = torch.randn(10, 4)
-
-        jitVsGlow(test_f, x, y, z, expected_fused_ops={"aten::add", "aten::mm"})
+        utils.compare_tracing_methods(
+            SimpleAddMmModule(), torch.randn(4), torch.randn(6, 10), torch.randn(10, 4)
+        )
 
     def test_addmm_broadcast_with_alpha_and_beta(self):
         """Test of the PyTorch addmm with broadcasting add on Glow."""
-
-        def test_f(a, b, c):
-            return (a + a).addmm(b, c, alpha=2.0, beta=3.0)
-
-        x = torch.randn(4)
-        y = torch.randn(6, 10)
-        z = torch.randn(10, 4)
-
-        jitVsGlow(test_f, x, y, z, expected_fused_ops={"aten::addmm"})
+        utils.compare_tracing_methods(
+            SimpleAddMmModule(2.0, 3.0),
+            torch.randn(4),
+            torch.randn(6, 10),
+            torch.randn(10, 4),
+        )

--- a/torch_glow/tests/nodes/avgpool2d_test.py
+++ b/torch_glow/tests/nodes/avgpool2d_test.py
@@ -4,26 +4,36 @@ import unittest
 
 import torch
 import torch.nn.functional as F
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimpleAvgPool2dModule(torch.nn.Module):
+    def __init__(self, kernel_size, stride=None, padding=0):
+        super(SimpleAvgPool2dModule, self).__init__()
+        self.kernel_size = kernel_size
+        self.padding = padding
+        self.stride = stride
+
+    def forward(self, inputs):
+        return F.avg_pool2d(
+            inputs, self.kernel_size, padding=self.padding, stride=self.stride
+        )
 
 
 class TestAvgPool2d(unittest.TestCase):
     def test_avg_pool2d_basic(self):
         """Basic test of the PyTorch avg_pool2d Node on Glow."""
-
-        def test_f(inputs):
-            return F.avg_pool2d(inputs, 3)
-
         inputs = torch.randn(1, 4, 5, 5)
 
-        jitVsGlow(test_f, inputs, expected_fused_ops={"aten::avg_pool2d"})
+        utils.compare_tracing_methods(
+            SimpleAvgPool2dModule(3), inputs, fusible_ops={"aten::avg_pool2d"}
+        )
 
     def test_avg_pool2d_with_args(self):
         """Test of the PyTorch avg_pool2d Node with arguments on Glow."""
 
-        def test_f(inputs):
-            return F.avg_pool2d(inputs, padding=3, kernel_size=7)
-
         inputs = torch.randn(1, 4, 10, 10)
 
-        jitVsGlow(test_f, inputs, expected_fused_ops={"aten::avg_pool2d"})
+        utils.compare_tracing_methods(
+            SimpleAvgPool2dModule(3, stride=7), inputs, fusible_ops={"aten::avg_pool2d"}
+        )

--- a/torch_glow/tests/nodes/avgpool3d_test.py
+++ b/torch_glow/tests/nodes/avgpool3d_test.py
@@ -4,26 +4,35 @@ import unittest
 
 import torch
 import torch.nn.functional as F
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimpleAvgPool3dModule(torch.nn.Module):
+    def __init__(self, kernel_size, stride=None, padding=0):
+        super(SimpleAvgPool3dModule, self).__init__()
+        self.kernel_size = kernel_size
+        self.padding = padding
+
+    def forward(self, inputs):
+        return F.avg_pool3d(inputs, self.kernel_size, padding=self.padding)
 
 
 class TestAvgPool3d(unittest.TestCase):
     def test_avg_pool3d_basic(self):
         """Basic test of the PyTorch avg_pool3d Node on Glow."""
 
-        def test_f(inputs):
-            return F.avg_pool3d(inputs, 3)
-
         inputs = torch.randn(1, 4, 5, 5, 5)
 
-        jitVsGlow(test_f, inputs, expected_fused_ops={"aten::avg_pool3d"})
+        utils.compare_tracing_methods(
+            SimpleAvgPool3dModule(3), inputs, fusible_ops={"aten::avg_pool3d"}
+        )
 
     def test_avg_pool3d_with_args(self):
         """Test of the PyTorch avg_pool3d Node with arguments on Glow."""
-
-        def test_f(inputs):
-            return F.avg_pool3d(inputs, padding=2, kernel_size=(4, 7, 7))
-
         inputs = torch.randn(1, 4, 10, 10, 10)
 
-        jitVsGlow(test_f, inputs, expected_fused_ops={"aten::avg_pool3d"})
+        utils.compare_tracing_methods(
+            SimpleAvgPool3dModule(3, (4, 7, 7)),
+            inputs,
+            fusible_ops={"aten::avg_pool3d"},
+        )

--- a/torch_glow/tests/nodes/batch_permutation_test.py
+++ b/torch_glow/tests/nodes/batch_permutation_test.py
@@ -3,17 +3,24 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimpleBatchPermutationModule(torch.nn.Module):
+    def forward(self, input, indices):
+        return torch.ops._caffe2.BatchPermutation(input + input, indices)
 
 
 class TestBatchPermutation(unittest.TestCase):
     def test_batch_permutation_basic(self):
         """Basic test of the _caffe2::BatchPermutation Node on Glow."""
 
-        def test_f(a, indices):
-            return torch.ops._caffe2.BatchPermutation(a + a, indices)
-
         x = torch.randn(4, 2, 3)
         indices = torch.tensor([1, 3, 0, 2], dtype=torch.int32)
 
-        jitVsGlow(test_f, x, indices, expected_fused_ops={"_caffe2::BatchPermutation"})
+        utils.compare_tracing_methods(
+            SimpleBatchPermutationModule(),
+            x,
+            indices,
+            fusible_ops={"_caffe2::BatchPermutation"},
+        )

--- a/torch_glow/tests/nodes/batchnorm2d_test.py
+++ b/torch_glow/tests/nodes/batchnorm2d_test.py
@@ -4,7 +4,7 @@ import unittest
 
 import torch
 import torch.nn as nn
-from tests.utils import jitVsGlow
+from tests import utils
 
 
 class TestBatchNorm2D(unittest.TestCase):
@@ -30,7 +30,7 @@ class TestBatchNorm2D(unittest.TestCase):
         model.eval()
 
         inputs = torch.randn(1, num_channels, 5, 5)
-        jitVsGlow(model, inputs, expected_fused_ops={"aten::batch_norm"})
+        utils.compare_tracing_methods(model, inputs, fusible_ops={"aten::batch_norm"})
 
     def test_batchnorm_with_weights(self):
         """
@@ -59,4 +59,4 @@ class TestBatchNorm2D(unittest.TestCase):
         model = SimpleBatchNorm(num_channels, weight, bias, running_mean, running_var)
         model.eval()
 
-        jitVsGlow(model, inputs, expected_fused_ops={"aten::batch_norm"})
+        utils.compare_tracing_methods(model, inputs, fusible_ops={"aten::batch_norm"})

--- a/torch_glow/tests/nodes/batchnorm3d_test.py
+++ b/torch_glow/tests/nodes/batchnorm3d_test.py
@@ -4,7 +4,7 @@ import unittest
 
 import torch
 import torch.nn as nn
-from tests.utils import jitVsGlow
+from tests import utils
 
 
 class TestBatchNorm3D(unittest.TestCase):
@@ -30,7 +30,7 @@ class TestBatchNorm3D(unittest.TestCase):
         model.eval()
 
         inputs = torch.randn(1, num_channels, 4, 5, 5)
-        jitVsGlow(model, inputs, expected_fused_ops={"aten::batch_norm"})
+        utils.compare_tracing_methods(model, inputs, fusible_ops={"aten::batch_norm"})
 
     def test_batchnorm_with_weights(self):
         """
@@ -59,4 +59,4 @@ class TestBatchNorm3D(unittest.TestCase):
         model = SimpleBatchNorm(num_channels, weight, bias, running_mean, running_var)
         model.eval()
 
-        jitVsGlow(model, inputs, expected_fused_ops={"aten::batch_norm"})
+        utils.compare_tracing_methods(model, inputs, fusible_ops={"aten::batch_norm"})

--- a/torch_glow/tests/nodes/bbox_transform_test.py
+++ b/torch_glow/tests/nodes/bbox_transform_test.py
@@ -4,7 +4,7 @@ import unittest
 
 import numpy as np
 import torch
-from tests.utils import jitVsGlow
+from tests import utils
 
 
 def generate_rois(roi_counts, im_dims):
@@ -69,152 +69,157 @@ class TestBBoxTransform(unittest.TestCase):
     def test_bbox_transform_basic(self):
         """Test of the _caffe2::BBoxTransform Node on Glow."""
 
-        def test_f(rois, deltas, im_info):
-            return torch.ops._caffe2.BBoxTransform(
-                rois,
-                deltas,
-                im_info,
-                weights=[1.0, 1.0, 1.0, 1.0],
-                apply_scale=False,
-                rotated=False,
-                angle_bound_on=False,
-                angle_bound_lo=-90,
-                angle_bound_hi=90,
-                clip_angle_thresh=1.0,
-                legacy_plus_one=False,
-            )
+        class TestModule(torch.nn.Module):
+            def forward(self, rois, deltas, im_info):
+                return torch.ops._caffe2.BBoxTransform(
+                    rois,
+                    deltas,
+                    im_info,
+                    weights=[1.0, 1.0, 1.0, 1.0],
+                    apply_scale=False,
+                    rotated=False,
+                    angle_bound_on=False,
+                    angle_bound_lo=-90,
+                    angle_bound_hi=90,
+                    clip_angle_thresh=1.0,
+                    legacy_plus_one=False,
+                )
 
         roi_counts, num_classes = ([5, 4, 3, 2, 1], 3)
         rois, deltas, im_info = create_bbox_transform_inputs(
             roi_counts, num_classes, False
         )
-        jitVsGlow(
-            test_f,
+        utils.compare_tracing_methods(
+            TestModule(),
             torch.tensor(rois),
             torch.tensor(deltas),
             torch.tensor(im_info),
-            expected_fused_ops={"_caffe2::BBoxTransform"},
+            fusible_ops={"_caffe2::BBoxTransform"},
         )
 
     def test_bbox_transform_legacy_plus_one(self):
         """Test of the _caffe2::BBoxTransform Node on Glow."""
 
-        def test_f(rois, deltas, im_info):
-            return torch.ops._caffe2.BBoxTransform(
-                rois,
-                deltas,
-                im_info,
-                weights=[1.0, 1.0, 1.0, 1.0],
-                apply_scale=False,
-                rotated=False,
-                angle_bound_on=False,
-                angle_bound_lo=-90,
-                angle_bound_hi=90,
-                clip_angle_thresh=1.0,
-                legacy_plus_one=True,
-            )
+        class TestModule(torch.nn.Module):
+            def forward(self, rois, deltas, im_info):
+                return torch.ops._caffe2.BBoxTransform(
+                    rois,
+                    deltas,
+                    im_info,
+                    weights=[1.0, 1.0, 1.0, 1.0],
+                    apply_scale=False,
+                    rotated=False,
+                    angle_bound_on=False,
+                    angle_bound_lo=-90,
+                    angle_bound_hi=90,
+                    clip_angle_thresh=1.0,
+                    legacy_plus_one=True,
+                )
 
         roi_counts, num_classes = ([5, 4, 3, 2, 1], 3)
         rois, deltas, im_info = create_bbox_transform_inputs(
             roi_counts, num_classes, False
         )
-        jitVsGlow(
-            test_f,
+        utils.compare_tracing_methods(
+            TestModule(),
             torch.tensor(rois),
             torch.tensor(deltas),
             torch.tensor(im_info),
-            expected_fused_ops={"_caffe2::BBoxTransform"},
+            fusible_ops={"_caffe2::BBoxTransform"},
         )
 
     def test_bbox_transform_apply_scale(self):
         """Test of the _caffe2::BBoxTransform Node on Glow."""
 
-        def test_f(rois, deltas, im_info):
-            return torch.ops._caffe2.BBoxTransform(
-                rois,
-                deltas,
-                im_info,
-                weights=[1.0, 1.0, 1.0, 1.0],
-                apply_scale=True,
-                rotated=False,
-                angle_bound_on=False,
-                angle_bound_lo=-90,
-                angle_bound_hi=90,
-                clip_angle_thresh=1.0,
-                legacy_plus_one=False,
-            )
+        class TestModule(torch.nn.Module):
+            def forward(self, rois, deltas, im_info):
+                return torch.ops._caffe2.BBoxTransform(
+                    rois,
+                    deltas,
+                    im_info,
+                    weights=[1.0, 1.0, 1.0, 1.0],
+                    apply_scale=True,
+                    rotated=False,
+                    angle_bound_on=False,
+                    angle_bound_lo=-90,
+                    angle_bound_hi=90,
+                    clip_angle_thresh=1.0,
+                    legacy_plus_one=False,
+                )
 
         roi_counts, num_classes = ([5, 4, 3, 2, 1], 3)
         rois, deltas, im_info = create_bbox_transform_inputs(
             roi_counts, num_classes, False
         )
-        jitVsGlow(
-            test_f,
+        utils.compare_tracing_methods(
+            TestModule(),
             torch.tensor(rois),
             torch.tensor(deltas),
             torch.tensor(im_info),
-            expected_fused_ops={"_caffe2::BBoxTransform"},
+            fusible_ops={"_caffe2::BBoxTransform"},
         )
 
     def test_bbox_transform_weights(self):
         """Test of the _caffe2::BBoxTransform Node on Glow."""
 
-        def test_f(rois, deltas, im_info):
-            return torch.ops._caffe2.BBoxTransform(
-                rois,
-                deltas,
-                im_info,
-                weights=[10.0, 10.0, 5.0, 5.0],
-                apply_scale=False,
-                rotated=False,
-                angle_bound_on=False,
-                angle_bound_lo=-90,
-                angle_bound_hi=90,
-                clip_angle_thresh=1.0,
-                legacy_plus_one=False,
-            )
+        class TestModule(torch.nn.Module):
+            def forward(self, rois, deltas, im_info):
+                return torch.ops._caffe2.BBoxTransform(
+                    rois,
+                    deltas,
+                    im_info,
+                    weights=[10.0, 10.0, 5.0, 5.0],
+                    apply_scale=False,
+                    rotated=False,
+                    angle_bound_on=False,
+                    angle_bound_lo=-90,
+                    angle_bound_hi=90,
+                    clip_angle_thresh=1.0,
+                    legacy_plus_one=False,
+                )
 
         roi_counts, num_classes = ([5, 4, 3, 2, 1], 3)
         rois, deltas, im_info = create_bbox_transform_inputs(
             roi_counts, num_classes, False
         )
-        jitVsGlow(
-            test_f,
+        utils.compare_tracing_methods(
+            TestModule(),
             torch.tensor(rois),
             torch.tensor(deltas),
             torch.tensor(im_info),
-            expected_fused_ops={"_caffe2::BBoxTransform"},
+            fusible_ops={"_caffe2::BBoxTransform"},
         )
 
     def test_bbox_transform_fp16(self):
         """Test of the _caffe2::BBoxTransform Node on Glow."""
 
-        def test_f(rois, deltas, im_info):
-            return torch.ops._caffe2.BBoxTransform(
-                rois,
-                deltas,
-                im_info,
-                weights=[1.0, 1.0, 1.0, 1.0],
-                apply_scale=False,
-                rotated=False,
-                angle_bound_on=False,
-                angle_bound_lo=-90,
-                angle_bound_hi=90,
-                clip_angle_thresh=1.0,
-                legacy_plus_one=False,
-            )
+        class TestModule(torch.nn.Module):
+            def forward(self, rois, deltas, im_info):
+                return torch.ops._caffe2.BBoxTransform(
+                    rois,
+                    deltas,
+                    im_info,
+                    weights=[1.0, 1.0, 1.0, 1.0],
+                    apply_scale=False,
+                    rotated=False,
+                    angle_bound_on=False,
+                    angle_bound_lo=-90,
+                    angle_bound_hi=90,
+                    clip_angle_thresh=1.0,
+                    legacy_plus_one=False,
+                )
 
         roi_counts, num_classes = ([5, 4, 3, 2, 1], 3)
         rois, deltas, im_info = create_bbox_transform_inputs(
             roi_counts, num_classes, False
         )
-        jitVsGlow(
-            test_f,
+        utils.compare_tracing_methods(
+            TestModule(),
             torch.tensor(rois),
             torch.tensor(deltas),
             torch.tensor(im_info),
-            expected_fused_ops={"_caffe2::BBoxTransform"},
-            use_fp16=True,
+            fusible_ops={"_caffe2::BBoxTransform"},
+            fp16=True,
             atol=1,
             rtol=1e-01,
         )
@@ -222,182 +227,188 @@ class TestBBoxTransform(unittest.TestCase):
     def test_bbox_transform_rotated_basic(self):
         """Test of the _caffe2::BBoxTransform Node on Glow."""
 
-        def test_f(rois, deltas, im_info):
-            return torch.ops._caffe2.BBoxTransform(
-                rois,
-                deltas,
-                im_info,
-                weights=[1.0, 1.0, 1.0, 1.0],
-                apply_scale=False,
-                rotated=True,
-                angle_bound_on=False,
-                angle_bound_lo=-90,
-                angle_bound_hi=90,
-                clip_angle_thresh=1.0,
-                legacy_plus_one=False,
-            )
+        class TestModule(torch.nn.Module):
+            def forward(self, rois, deltas, im_info):
+                return torch.ops._caffe2.BBoxTransform(
+                    rois,
+                    deltas,
+                    im_info,
+                    weights=[1.0, 1.0, 1.0, 1.0],
+                    apply_scale=False,
+                    rotated=True,
+                    angle_bound_on=False,
+                    angle_bound_lo=-90,
+                    angle_bound_hi=90,
+                    clip_angle_thresh=1.0,
+                    legacy_plus_one=False,
+                )
 
         roi_counts, num_classes = ([1, 1], 1)
         rois, deltas, im_info = create_bbox_transform_inputs(
             roi_counts, num_classes, True
         )
-        jitVsGlow(
-            test_f,
+        utils.compare_tracing_methods(
+            TestModule(),
             torch.tensor(rois),
             torch.tensor(deltas),
             torch.tensor(im_info),
-            expected_fused_ops={"_caffe2::BBoxTransform"},
+            fusible_ops={"_caffe2::BBoxTransform"},
         )
 
     def test_bbox_transform_rotated_angle_bound_on(self):
         """Test of the _caffe2::BBoxTransform Node on Glow."""
 
-        def test_f(rois, deltas, im_info):
-            return torch.ops._caffe2.BBoxTransform(
-                rois,
-                deltas,
-                im_info,
-                weights=[1.0, 1.0, 1.0, 1.0],
-                apply_scale=False,
-                rotated=True,
-                angle_bound_on=True,
-                angle_bound_lo=-180,
-                angle_bound_hi=180,
-                clip_angle_thresh=1.0,
-                legacy_plus_one=False,
-            )
+        class TestModule(torch.nn.Module):
+            def forward(self, rois, deltas, im_info):
+                return torch.ops._caffe2.BBoxTransform(
+                    rois,
+                    deltas,
+                    im_info,
+                    weights=[1.0, 1.0, 1.0, 1.0],
+                    apply_scale=False,
+                    rotated=True,
+                    angle_bound_on=True,
+                    angle_bound_lo=-180,
+                    angle_bound_hi=180,
+                    clip_angle_thresh=1.0,
+                    legacy_plus_one=False,
+                )
 
         roi_counts, num_classes = ([5, 4, 3, 2, 1], 3)
         rois, deltas, im_info = create_bbox_transform_inputs(
             roi_counts, num_classes, True
         )
-        jitVsGlow(
-            test_f,
+        utils.compare_tracing_methods(
+            TestModule(),
             torch.tensor(rois),
             torch.tensor(deltas),
             torch.tensor(im_info),
-            expected_fused_ops={"_caffe2::BBoxTransform"},
+            fusible_ops={"_caffe2::BBoxTransform"},
         )
 
     def test_bbox_transform_rotated_legacy_plus_one(self):
         """Test of the _caffe2::BBoxTransform Node on Glow."""
 
-        def test_f(rois, deltas, im_info):
-            return torch.ops._caffe2.BBoxTransform(
-                rois,
-                deltas,
-                im_info,
-                weights=[1.0, 1.0, 1.0, 1.0],
-                apply_scale=False,
-                rotated=True,
-                angle_bound_on=False,
-                angle_bound_lo=-90,
-                angle_bound_hi=90,
-                clip_angle_thresh=1.0,
-                legacy_plus_one=True,
-            )
+        class TestModule(torch.nn.Module):
+            def forward(self, rois, deltas, im_info):
+                return torch.ops._caffe2.BBoxTransform(
+                    rois,
+                    deltas,
+                    im_info,
+                    weights=[1.0, 1.0, 1.0, 1.0],
+                    apply_scale=False,
+                    rotated=True,
+                    angle_bound_on=False,
+                    angle_bound_lo=-90,
+                    angle_bound_hi=90,
+                    clip_angle_thresh=1.0,
+                    legacy_plus_one=True,
+                )
 
         roi_counts, num_classes = ([5, 4, 3, 2, 1], 3)
         rois, deltas, im_info = create_bbox_transform_inputs(
             roi_counts, num_classes, True
         )
-        jitVsGlow(
-            test_f,
+        utils.compare_tracing_methods(
+            TestModule(),
             torch.tensor(rois),
             torch.tensor(deltas),
             torch.tensor(im_info),
-            expected_fused_ops={"_caffe2::BBoxTransform"},
+            fusible_ops={"_caffe2::BBoxTransform"},
         )
 
     def test_bbox_transform_rotated_apply_scale(self):
         """Test of the _caffe2::BBoxTransform Node on Glow."""
 
-        def test_f(rois, deltas, im_info):
-            return torch.ops._caffe2.BBoxTransform(
-                rois,
-                deltas,
-                im_info,
-                weights=[1.0, 1.0, 1.0, 1.0],
-                apply_scale=True,
-                rotated=True,
-                angle_bound_on=False,
-                angle_bound_lo=-90,
-                angle_bound_hi=90,
-                clip_angle_thresh=1.0,
-                legacy_plus_one=False,
-            )
+        class TestModule(torch.nn.Module):
+            def forward(self, rois, deltas, im_info):
+                return torch.ops._caffe2.BBoxTransform(
+                    rois,
+                    deltas,
+                    im_info,
+                    weights=[1.0, 1.0, 1.0, 1.0],
+                    apply_scale=True,
+                    rotated=True,
+                    angle_bound_on=False,
+                    angle_bound_lo=-90,
+                    angle_bound_hi=90,
+                    clip_angle_thresh=1.0,
+                    legacy_plus_one=False,
+                )
 
         roi_counts, num_classes = ([5, 4, 3, 2, 1], 3)
         rois, deltas, im_info = create_bbox_transform_inputs(
             roi_counts, num_classes, True
         )
-        jitVsGlow(
-            test_f,
+        utils.compare_tracing_methods(
+            TestModule(),
             torch.tensor(rois),
             torch.tensor(deltas),
             torch.tensor(im_info),
-            expected_fused_ops={"_caffe2::BBoxTransform"},
+            fusible_ops={"_caffe2::BBoxTransform"},
         )
 
     def test_bbox_transform_rotated_weights(self):
         """Test of the _caffe2::BBoxTransform Node on Glow."""
 
-        def test_f(rois, deltas, im_info):
-            return torch.ops._caffe2.BBoxTransform(
-                rois,
-                deltas,
-                im_info,
-                weights=[10.0, 10.0, 5.0, 5.0],
-                apply_scale=False,
-                rotated=True,
-                angle_bound_on=False,
-                angle_bound_lo=-90,
-                angle_bound_hi=90,
-                clip_angle_thresh=1.0,
-                legacy_plus_one=False,
-            )
+        class TestModule(torch.nn.Module):
+            def forward(self, rois, deltas, im_info):
+                return torch.ops._caffe2.BBoxTransform(
+                    rois,
+                    deltas,
+                    im_info,
+                    weights=[10.0, 10.0, 5.0, 5.0],
+                    apply_scale=False,
+                    rotated=True,
+                    angle_bound_on=False,
+                    angle_bound_lo=-90,
+                    angle_bound_hi=90,
+                    clip_angle_thresh=1.0,
+                    legacy_plus_one=False,
+                )
 
         roi_counts, num_classes = ([5, 4, 3, 2, 1], 3)
         rois, deltas, im_info = create_bbox_transform_inputs(
             roi_counts, num_classes, True
         )
-        jitVsGlow(
-            test_f,
+        utils.compare_tracing_methods(
+            TestModule(),
             torch.tensor(rois),
             torch.tensor(deltas),
             torch.tensor(im_info),
-            expected_fused_ops={"_caffe2::BBoxTransform"},
+            fusible_ops={"_caffe2::BBoxTransform"},
         )
 
     def test_bbox_transform_rotated_fp16(self):
         """Test of the _caffe2::BBoxTransform Node on Glow."""
 
-        def test_f(rois, deltas, im_info):
-            return torch.ops._caffe2.BBoxTransform(
-                rois,
-                deltas,
-                im_info,
-                weights=[1.0, 1.0, 1.0, 1.0],
-                apply_scale=False,
-                rotated=True,
-                angle_bound_on=False,
-                angle_bound_lo=-90,
-                angle_bound_hi=90,
-                clip_angle_thresh=1.0,
-                legacy_plus_one=False,
-            )
+        class TestModule(torch.nn.Module):
+            def forward(self, rois, deltas, im_info):
+                return torch.ops._caffe2.BBoxTransform(
+                    rois,
+                    deltas,
+                    im_info,
+                    weights=[1.0, 1.0, 1.0, 1.0],
+                    apply_scale=False,
+                    rotated=True,
+                    angle_bound_on=False,
+                    angle_bound_lo=-90,
+                    angle_bound_hi=90,
+                    clip_angle_thresh=1.0,
+                    legacy_plus_one=False,
+                )
 
         roi_counts, num_classes = ([5, 4, 3, 2, 1], 3)
         rois, deltas, im_info = create_bbox_transform_inputs(
             roi_counts, num_classes, True
         )
-        jitVsGlow(
-            test_f,
+        utils.compare_tracing_methods(
+            TestModule(),
             torch.tensor(rois),
             torch.tensor(deltas),
             torch.tensor(im_info),
-            expected_fused_ops={"_caffe2::BBoxTransform"},
-            use_fp16=True,
+            fusible_ops={"_caffe2::BBoxTransform"},
+            fp16=True,
             atol=1,
             rtol=1e-01,
         )

--- a/torch_glow/tests/nodes/bmm_test.py
+++ b/torch_glow/tests/nodes/bmm_test.py
@@ -3,17 +3,21 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimpleBmmModule(torch.nn.Module):
+    def forward(self, a, b):
+        return (a + a).bmm(b)
 
 
 class TestBmm(unittest.TestCase):
     def test_bmm(self):
         """Basic test of the PyTorch bmm Node on Glow."""
 
-        def test_f(a, b):
-            return (a + a).bmm(b)
-
         x = torch.randn(6, 4, 10)
         y = torch.randn(6, 10, 2)
 
-        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::bmm"})
+        utils.compare_tracing_methods(
+            SimpleBmmModule(), x, y, fusible_ops={"aten::bmm"}
+        )

--- a/torch_glow/tests/nodes/cat_test.py
+++ b/torch_glow/tests/nodes/cat_test.py
@@ -3,46 +3,58 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimpleCatModule(torch.nn.Module):
+    def __init__(self, *dimensions):
+        super(SimpleCatModule, self).__init__()
+        self.dimensions = dimensions
+
+    def forward(self, a, b):
+        other = torch.cat((a, b), self.dimensions[0])
+        for dimension in self.dimensions[1:]:
+            other = torch.cat((other, other), dimension)
+        return other
 
 
 class TestCat(unittest.TestCase):
     def test_cat_basic(self):
         """Basic test of the PyTorch cat Node on Glow."""
 
-        def test_f(a, b):
-            c = torch.cat((a, b), 0)
-            d = torch.cat((c, c), 1)
-            return torch.cat((d, d), 2)
-
         x = torch.randn(2, 3, 4)
         y = torch.randn(2, 3, 4)
 
-        jitVsGlow(test_f, x, y, expected_fused_ops={"prim::FusedConcat"})
+        utils.compare_tracing_methods(
+            SimpleCatModule(0, 1, 2),
+            x,
+            y,
+            fusible_ops={"prim::FusedConcat"},
+        )
 
     def test_cat_neg_dim(self):
         """Test negative dimension index for the PyTorch cat Node on Glow."""
 
-        def test_f(a, b):
-            c = torch.cat((a, b), -3)
-            d = torch.cat((c, c), -2)
-            return torch.cat((d, d), -1)
-
         x = torch.randn(2, 3, 4)
         y = torch.randn(2, 3, 4)
 
-        jitVsGlow(test_f, x, y, expected_fused_ops={"prim::FusedConcat"})
+        utils.compare_tracing_methods(
+            SimpleCatModule(-3, -2, -1),
+            x,
+            y,
+            fusible_ops={"prim::FusedConcat"},
+        )
 
     def test_cat_oob_neg_dim(self):
         """Test out of bounds negative dimension index for the PyTorch cat Node on Glow."""
-
-        def test_f(a, b):
-            c = torch.cat((a, b), -4)
-            d = torch.cat((c, c), -2)
-            return torch.cat((d, d), -1)
 
         x = torch.randn(2, 3, 4)
         y = torch.randn(2, 3, 4)
 
         with self.assertRaises(IndexError):
-            jitVsGlow(test_f, x, y, expected_fused_ops={"prim::FusedConcat"})
+            utils.compare_tracing_methods(
+                SimpleCatModule(-4, -2, -1),
+                x,
+                y,
+                fusible_ops={"prim::FusedConcat"},
+            )

--- a/torch_glow/tests/nodes/ceil_test.py
+++ b/torch_glow/tests/nodes/ceil_test.py
@@ -3,18 +3,21 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimpleCeilModule(torch.nn.Module):
+    def forward(self, a, b):
+        c = a + b
+        return torch.ceil(c)
 
 
 class TestCeil(unittest.TestCase):
     def test_ceil(self):
         """Basic test of the PyTorch Ceil Node on Glow."""
 
-        def test_f(a, b):
-            c = a + b
-            d = torch.ceil(c)
-            return d
-
         x = torch.randn(3, 4, 5)
         y = torch.randn(3, 4, 5)
-        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::ceil"})
+        utils.compare_tracing_methods(
+            SimpleCeilModule(), x, y, fusible_ops={"aten::ceil"}
+        )

--- a/torch_glow/tests/nodes/clamp_test.py
+++ b/torch_glow/tests/nodes/clamp_test.py
@@ -3,14 +3,23 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimpleClampModel(torch.nn.Module):
+    def __init__(self, min, max):
+        super(SimpleClampModel, self).__init__()
+        self.min = min
+        self.max = max
+
+    def forward(self, input):
+        return torch.clamp(input, self.min, self.max)
 
 
 class TestClamp(unittest.TestCase):
     def test_clamp(self):
         """Test of the PyTorch clamp Node on Glow."""
 
-        def test_f(x):
-            return torch.clamp(x, 0.0, 6.0)
-
-        jitVsGlow(test_f, torch.randn(7), expected_fused_ops={"aten::clamp"})
+        utils.compare_tracing_methods(
+            SimpleClampModel(0.0, 6.0), torch.randn(7), fusible_ops={"aten::clamp"}
+        )

--- a/torch_glow/tests/nodes/constant_chunk_test.py
+++ b/torch_glow/tests/nodes/constant_chunk_test.py
@@ -3,27 +3,40 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimpleChunkModel(torch.nn.Module):
+    def __init__(self, chunks, dimension):
+        super(SimpleChunkModel, self).__init__()
+        self.chunks = chunks
+        self.dimension = dimension
+
+    def forward(self, input):
+        return torch.chunk(input + input, self.chunks, self.dimension)
 
 
 class TestConstantChunk(unittest.TestCase):
     def test_constant_chunk_basic(self):
         """Test of prim::ConstantChunk node on glow"""
 
-        def test_f(x):
-            return torch.chunk(x + x, 3, 1)  # shapes: [(10,4), (10,4), (10,3)]
-
         x = torch.rand((10, 11))
-
-        jitVsGlow(test_f, x, expected_fused_ops={"prim::ConstantChunk"})
+        # shapes: [(10,4), (10,4), (10,3)]
+        utils.compare_tracing_methods(
+            SimpleChunkModel(3, 1),
+            x,
+            fusible_ops={"prim::ConstantChunk"},
+            skip_to_glow=True,
+        )
 
     def test_constant_chunk_negative_indices(self):
         """Test of prim::ConstantChunk node on glow"""
 
-        def test_f(x):
-            # shapes: [(4,11), (4,11), (2,11)]
-            return torch.chunk(x + x, 3, -2)
-
         x = torch.rand((10, 11))
-
-        jitVsGlow(test_f, x, expected_fused_ops={"prim::ConstantChunk"})
+        # shapes: [(4,11), (4,11), (2,11)]
+        utils.compare_tracing_methods(
+            SimpleChunkModel(3, -2),
+            x,
+            fusible_ops={"prim::ConstantChunk"},
+            skip_to_glow=True,
+        )

--- a/torch_glow/tests/nodes/contiguous_test.py
+++ b/torch_glow/tests/nodes/contiguous_test.py
@@ -3,16 +3,20 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimpleContiguousModel(torch.nn.Module):
+    def forward(self, input):
+        return input.contiguous()
 
 
 class TestContiguous(unittest.TestCase):
     def test_contiguous_basic(self):
         """Test of the PyTorch contiguous Node on Glow."""
 
-        def contiguous_basic(a):
-            return a.contiguous()
-
         x = torch.randn(2, 2, 2)
 
-        jitVsGlow(contiguous_basic, x, expected_fused_ops={"aten::contiguous"})
+        utils.compare_tracing_methods(
+            SimpleContiguousModel(), x, fusible_ops={"aten::contiguous"}
+        )

--- a/torch_glow/tests/nodes/conv2d_test.py
+++ b/torch_glow/tests/nodes/conv2d_test.py
@@ -5,48 +5,61 @@ from collections import namedtuple
 
 import torch
 import torch.nn.functional as F
-from tests.utils import jitVsGlow
+from parameterized import parameterized
+from tests import utils
+
+
+class SimpleConv2dModule(torch.nn.Module):
+    def __init__(self, stride=1, padding=0, dilation=1, groups=1):
+        super(SimpleConv2dModule, self).__init__()
+        self.stride = stride
+        self.padding = padding
+        self.dilation = dilation
+        self.groups = groups
+
+    def forward(self, inputs, filters, bias=None):
+        conv = F.conv2d(
+            inputs,
+            filters,
+            bias=bias,
+            stride=self.stride,
+            padding=self.padding,
+            dilation=self.dilation,
+            groups=self.groups,
+        )
+        return F.relu(conv)
 
 
 class TestConv2d(unittest.TestCase):
-    def test_conv2d_basic(self):
-        """Basic test of the PyTorch conv2d Node on Glow."""
+    @parameterized.expand(
+        [
+            (
+                "basic",
+                SimpleConv2dModule(padding=1),
+                torch.randn(1, 4, 5, 5),
+                torch.randn(8, 4, 3, 3),
+            ),
+            (
+                "with_bias",
+                SimpleConv2dModule(padding=1),
+                torch.randn(1, 4, 5, 5),
+                torch.randn(8, 4, 3, 3),
+                torch.randn(8),
+            ),
+            (
+                "nonsquare_dilation",
+                SimpleConv2dModule(padding=1, dilation=[1, 2]),
+                torch.randn(1, 4, 5, 5),
+                torch.randn(8, 4, 3, 3),
+            ),
+        ]
+    )
+    def test_conv2d(self, _, module, inputs, filters, bias=None):
+        """Basic test of the PyTorch conv3d Node on Glow."""
 
-        def test_f(inputs, filters):
-            conv = F.conv2d(inputs, filters, padding=1)
-            return F.relu(conv)
-
-        inputs = torch.randn(1, 4, 5, 5)
-        filters = torch.randn(8, 4, 3, 3)
-
-        jitVsGlow(test_f, inputs, filters, expected_fused_ops={"aten::_convolution"})
-
-    def test_conv2d_with_bias(self):
-        """Test of the PyTorch conv2d Node with a provided bias tensor."""
-
-        def test_f(inputs, filters, bias):
-            conv = F.conv2d(inputs, filters, bias)
-            return F.relu(conv)
-
-        inputs = torch.randn(1, 4, 5, 5)
-        filters = torch.randn(8, 4, 3, 3)
-        bias = torch.randn(8)
-
-        jitVsGlow(
-            test_f, inputs, filters, bias, expected_fused_ops={"aten::_convolution"}
+        utils.compare_tracing_methods(
+            module, inputs, filters, fusible_ops={"aten::_convolution"}
         )
-
-    def test_conv2d_non_square_dilation(self):
-        """Test of the PyTorch conv2d Node on Glow with non-square dilation."""
-
-        def test_f(inputs, filters):
-            conv = F.conv2d(inputs, filters, dilation=[1, 2])
-            return F.relu(conv)
-
-        inputs = torch.randn(1, 4, 5, 5)
-        filters = torch.randn(8, 4, 3, 3)
-
-        jitVsGlow(test_f, inputs, filters, expected_fused_ops={"aten::_convolution"})
 
     @unittest.skip(reason="not ready")
     def test_conv2d_param_sweep(self):
@@ -82,6 +95,6 @@ class TestConv2d(unittest.TestCase):
             inputs = torch.randn(2, 4, setting.h, setting.w)
             filters = torch.randn(8, 4 / setting.g, 3, 3)
 
-            jitVsGlow(
-                test_f, inputs, filters, expected_fused_ops={"aten::_convolution"}
+            utils.compare_tracing_methods(
+                test_f, inputs, filters, fusible_ops={"aten::_convolution"}
             )

--- a/torch_glow/tests/nodes/div_test.py
+++ b/torch_glow/tests/nodes/div_test.py
@@ -3,74 +3,49 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from parameterized import parameterized
+from tests import utils
+
+
+class SimpleDivModule(torch.nn.Module):
+    def __init__(self):
+        super(SimpleDivModule, self).__init__()
+
+    def forward(self, a, b):
+        if b.size() == torch.Size([]):
+            return (a * a).div(b.item())
+        else:
+            c = a.div(b)
+            return c.div(c)
 
 
 class TestDiv(unittest.TestCase):
-    def test_div_basic(self):
-        """Basic test of the PyTorch div Node on Glow."""
-
-        def test_f(a, b):
-            c = a.div(b)
-            return c.div(c)
-
-        x = torch.randn(4)
-        y = torch.randn(4)
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::div"})
-
-    def test_div_broadcast_1(self):
-        """Test of the PyTorch div Node on Glow with broadcasting."""
-
-        def test_f(a, b):
-            c = a.div(b)
-            return c.div(c)
-
-        x = torch.randn(8, 3, 4, 2)
-        y = torch.randn(4, 2)
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::div"})
-
-    def test_div_broadcast_2(self):
-        """Test of the PyTorch div Node on Glow with broadcasting."""
-
-        def test_f(a, b):
-            c = a.div(b)
-            return c.div(c)
-
-        x = torch.randn(8, 3, 4, 2)
-        y = torch.randn(1, 2)
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::div"})
-
-    def test_div_broadcast_3(self):
-        """Test of the PyTorch div Node on Glow with broadcasting."""
-
-        def test_f(a, b):
-            c = a.div(b)
-            return c.div(c)
-
-        x = torch.randn(4, 2)
-        y = torch.randn(8, 3, 4, 2)
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::div"})
-
-    def test_div_float(self):
-        """Test of the PyTorch aten::div Node with a float argument"""
-
-        def test_f(a):
-            return (a * a).div(3.9)
-
-        x = torch.randn(4)
-
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::div"})
-
-    def test_div_int(self):
-        """Test of the PyTorch aten::div Node with an int argument"""
-
-        def test_f(a):
-            return (a * a).div(20)
-
-        x = torch.randn(4)
-
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::div"})
+    @parameterized.expand(
+        [
+            ("basic", SimpleDivModule(), torch.randn(4), torch.randn(4)),
+            (
+                "broadcast",
+                SimpleDivModule(),
+                torch.randn(8, 3, 4, 2),
+                torch.randn(4, 2),
+            ),
+            (
+                "broadcast",
+                SimpleDivModule(),
+                torch.randn(8, 3, 4, 2),
+                torch.randn(1, 2),
+            ),
+            (
+                "broadcast",
+                SimpleDivModule(),
+                torch.randn(4, 2),
+                torch.randn(8, 3, 4, 2),
+            ),
+            ("float", SimpleDivModule(), torch.randn(4), torch.tensor(3.9)),
+            ("int", SimpleDivModule(), torch.randn(4), torch.tensor(20), True),
+        ]
+    )
+    def test_div_basic(self, _, module, a, b, skip_to_glow=False):
+        utils.compare_tracing_methods(
+            module, a, b, fusible_ops={"aten::div"}, skip_to_glow=skip_to_glow
+        )

--- a/torch_glow/tests/nodes/dropout_test.py
+++ b/torch_glow/tests/nodes/dropout_test.py
@@ -4,27 +4,37 @@ import unittest
 
 import torch
 import torch.nn.functional as F
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimpleDropoutModule(torch.nn.Module):
+    def __init__(self, p=0.5, training=True, inplace=False):
+        super(SimpleDropoutModule, self).__init__()
+        self.p = p
+        self.training = training
+        self.inplace = inplace
+
+    def forward(self, input):
+        return F.dropout(
+            input + input, p=self.p, training=self.training, inplace=self.inplace
+        )
 
 
 class TestDropout(unittest.TestCase):
     def test_dropout(self):
         """Basic test of the PyTorch aten::dropout Node on Glow."""
 
-        def test_f(a):
-            return F.dropout(a + a, p=0.5, training=False)
-
-        x = torch.randn(6, 4, 10)
-
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::dropout"})
+        utils.compare_tracing_methods(
+            SimpleDropoutModule(training=False),
+            torch.randn(6, 4, 10),
+            fusible_ops={"aten::dropout"},
+        )
 
     def test_dropout_inplace(self):
         """Basic test of the PyTorch aten::dropout_ Node on Glow."""
-
-        def test_f(a):
-            return F.dropout(a + a, p=0.5, training=False, inplace=True)
-
-        x = torch.randn(6, 4, 10)
-
         # Expect fuser to out-of-place the operator
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::dropout"})
+        utils.compare_tracing_methods(
+            SimpleDropoutModule(training=False, inplace=True),
+            torch.randn(6, 4, 10),
+            fusible_ops={"aten::dropout"},
+        )

--- a/torch_glow/tests/nodes/exp_test.py
+++ b/torch_glow/tests/nodes/exp_test.py
@@ -3,17 +3,19 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimpleExpModule(torch.nn.Module):
+    def forward(self, input):
+        other = torch.exp(input)
+        return torch.exp(other)
 
 
 class TestExp(unittest.TestCase):
     def test_exp_basic(self):
         """Test of the PyTorch exp Node on Glow."""
 
-        def test_f(a):
-            b = torch.exp(a)
-            return torch.exp(b)
-
-        x = torch.randn(4)
-
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::exp"})
+        utils.compare_tracing_methods(
+            SimpleExpModule(), torch.randn(4), fusible_ops={"aten::exp"}
+        )

--- a/torch_glow/tests/nodes/flatten_test.py
+++ b/torch_glow/tests/nodes/flatten_test.py
@@ -3,66 +3,34 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from parameterized import parameterized
+from tests import utils
+
+
+class SimpleFlattenModule(torch.nn.Module):
+    def __init__(self, start_dim=0, end_dim=-1):
+        super(SimpleFlattenModule, self).__init__()
+        self.start_dim = start_dim
+        self.end_dim = end_dim
+
+    def forward(self, input):
+        return torch.flatten(input, start_dim=self.start_dim, end_dim=self.end_dim)
 
 
 class TestFlatten(unittest.TestCase):
-    def test_flatten_basic(self):
-        """Test of the PyTorch flatten Node on Glow."""
-
-        def test_f(a):
-            return torch.flatten(a)
-
-        x = torch.randn(2, 3, 2, 5)
-
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::flatten"})
-
-    def test_flatten_start_at_0(self):
-        """Test of the PyTorch flatten Node on Glow."""
-
-        def test_f(a):
-            return torch.flatten(a, start_dim=0, end_dim=2)
-
-        x = torch.randn(2, 3, 2, 5)
-
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::flatten"})
-
-    def test_flatten_start_in_middle(self):
-        """Test of the PyTorch flatten Node on Glow."""
-
-        def test_f(a):
-            return torch.flatten(a, start_dim=1, end_dim=2)
-
-        x = torch.randn(2, 3, 2, 5)
-
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::flatten"})
-
-    def test_flatten_negative_end_dim(self):
-        """Test of the PyTorch flatten Node on Glow."""
-
-        def test_f(a):
-            return torch.flatten(a, start_dim=0, end_dim=-2)
-
-        x = torch.randn(2, 3, 2, 5)
-
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::flatten"})
-
-    def test_flatten_same_dim(self):
-        """Test of the PyTorch flatten Node on Glow."""
-
-        def test_f(a):
-            return torch.flatten(a, start_dim=2, end_dim=2)
-
-        x = torch.randn(2, 3, 2, 5)
-
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::flatten"})
-
-    def test_flatten_negative_start_dim(self):
-        """Test of the PyTorch flatten Node on Glow."""
-
-        def test_f(a):
-            return torch.flatten(a, start_dim=-3, end_dim=-1)
-
-        x = torch.randn(2, 3, 2, 5)
-
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::flatten"})
+    @parameterized.expand(
+        [
+            ("basic", SimpleFlattenModule(), torch.randn(2, 3, 2, 5)),
+            ("start_at_0", SimpleFlattenModule(0, 2), torch.randn(2, 3, 2, 5)),
+            ("start_in_middle", SimpleFlattenModule(1, 2), torch.randn(2, 3, 2, 5)),
+            ("negative_end_dim", SimpleFlattenModule(0, -2), torch.randn(2, 3, 2, 5)),
+            ("same_dim", SimpleFlattenModule(2, 2), torch.randn(2, 3, 2, 5)),
+            (
+                "negative_start_dim",
+                SimpleFlattenModule(-3, -1),
+                torch.randn(2, 3, 2, 5),
+            ),
+        ]
+    )
+    def test_flatten(self, _, module, input):
+        utils.compare_tracing_methods(module, input, fusible_ops={"aten::flatten"})

--- a/torch_glow/tests/nodes/floor_div_test.py
+++ b/torch_glow/tests/nodes/floor_div_test.py
@@ -3,7 +3,22 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from parameterized import parameterized
+from tests import utils
+
+
+class SimpleFloorDivideModule(torch.nn.Module):
+    def __init__(self, inplace=False):
+        super(SimpleFloorDivideModule, self).__init__()
+        self.inplace = inplace
+
+    def forward(self, a, b):
+        if b.size() == torch.Size([]):
+            b = b.item()
+        if self.inplace:
+            return (a + a).floor_divide_(b)
+        else:
+            return (a + a).floor_divide(b)
 
 
 class TestFloorDiv(unittest.TestCase):
@@ -18,60 +33,49 @@ class TestFloorDiv(unittest.TestCase):
 
         x = torch.randn(4)
         y = torch.randn(4)
-        print(x)
-        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::floor_divide"})
+        utils.compare_tracing_methods(test_f, x, y, fusible_ops={"aten::floor_divide"})
 
-    def test_floor_div_positive_basic(self):
-        """Basic test of the PyTorch Floor div Node on Glow."""
-
-        def test_f(a, b):
-            return (a + a).floor_divide(b)
-
-        x = torch.Tensor(4).random_(0, 5)
-        y = torch.Tensor(4).random_(1, 5)
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::floor_divide"})
-
-    def test_floor_div_positive_float(self):
-        """Test of the PyTorch aten::floor_divide Node with a float argument"""
-
-        def test_f(a):
-            return (a + a).floor_divide_(3.9)
-
-        x = torch.Tensor(4).random_(0, 5)
-
-        # Expect fuser to out-of-place the operator
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::floor_divide"})
-
-    def test_floor_div_positive_broadcast_1(self):
-        """Test of the PyTorch floor div Node on Glow with broadcasting."""
-
-        def test_f(a, b):
-            return (a + a).floor_divide(b)
-
-        x = torch.Tensor(8, 3, 4, 2).random_(0, 5)
-        y = torch.Tensor(4, 2).random_(1, 5)
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::floor_divide"})
-
-    def test_floor_div_positive_broadcast_2(self):
-        """Test of the PyTorch floor div Node on Glow with broadcasting."""
-
-        def test_f(a, b):
-            return (a + a).floor_divide(b)
-
-        x = torch.Tensor(8, 3, 4, 2).random_(0, 5)
-        y = torch.Tensor(1, 2).random_(1, 5)
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::floor_divide"})
-
-    def test_floor_div_positive_broadcast_3(self):
-        """Test of the PyTorch floor div Node on Glow with broadcasting."""
-
-        def test_f(a, b):
-            return (a + a).floor_divide(b)
-
-        x = torch.Tensor(4, 2).random_(0, 5)
-        y = torch.Tensor(8, 3, 4, 2).random_(1, 5)
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::floor_divide"})
+    @parameterized.expand(
+        [
+            (
+                "basic",
+                SimpleFloorDivideModule(),
+                torch.Tensor(4).random_(0, 5),
+                torch.Tensor(4).random_(1, 5),
+            ),
+            (
+                "inplace",
+                SimpleFloorDivideModule(True),
+                torch.Tensor(4).random_(0, 5),
+                torch.Tensor(4).random_(1, 5),
+            ),
+            (
+                "positive_float",
+                SimpleFloorDivideModule(),
+                torch.Tensor(4).random_(0, 5),
+                torch.tensor(3.9),
+            ),
+            (
+                "positive_broadcast",
+                SimpleFloorDivideModule(),
+                torch.Tensor(8, 3, 4, 2).random_(0, 5),
+                torch.Tensor(4, 2).random_(1, 5),
+            ),
+            (
+                "positive_broadcast",
+                SimpleFloorDivideModule(),
+                torch.Tensor(8, 3, 4, 2).random_(0, 5),
+                torch.Tensor(1, 2).random_(1, 5),
+            ),
+            (
+                "positive_broadcast",
+                SimpleFloorDivideModule(),
+                torch.Tensor(4, 2).random_(0, 5),
+                torch.Tensor(8, 3, 4, 2).random_(1, 5),
+            ),
+        ]
+    )
+    def test_floor_div(self, _, module, left, right):
+        utils.compare_tracing_methods(
+            module, left, right, fusible_ops={"aten::floor_divide"}
+        )

--- a/torch_glow/tests/nodes/floor_test.py
+++ b/torch_glow/tests/nodes/floor_test.py
@@ -3,18 +3,21 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimpleFloorModule(torch.nn.Module):
+    def forward(self, a, b):
+        c = a + b
+        return torch.floor(c)
 
 
 class TestFloor(unittest.TestCase):
     def test_floor(self):
         """Basic test of the PyTorch floor Node on Glow."""
 
-        def test_f(a, b):
-            c = a + b
-            d = torch.floor(c)
-            return d
-
         x = torch.randn(3, 4, 5)
         y = torch.randn(3, 4, 5)
-        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::floor"})
+        utils.compare_tracing_methods(
+            SimpleFloorModule(), x, y, fusible_ops={"aten::floor"}
+        )

--- a/torch_glow/tests/nodes/gelu_test.py
+++ b/torch_glow/tests/nodes/gelu_test.py
@@ -4,7 +4,12 @@ import unittest
 
 import torch
 import torch.nn.functional as F
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimpleGeluModule(torch.nn.Module):
+    def forward(self, tensor):
+        return F.gelu(tensor + tensor)
 
 
 class TestGelu(unittest.TestCase):
@@ -14,12 +19,12 @@ class TestGelu(unittest.TestCase):
         def test_f(a):
             return F.gelu(a + a)
 
-        for i in range(100):
+        for _ in range(100):
             x = torch.randn(10)
-            jitVsGlow(
-                test_f,
+            utils.compare_tracing_methods(
+                SimpleGeluModule(),
                 x,
                 check_trace=False,
                 atol=1e-3,
-                expected_fused_ops={"aten::gelu"},
+                fusible_ops={"aten::gelu"},
             )

--- a/torch_glow/tests/nodes/getattr_test.py
+++ b/torch_glow/tests/nodes/getattr_test.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import torch_glow
 import torch
-from tests.utils import GLOW_NODE_NAME, SUBGRAPH_ATTR
+from tests.utils import GLOW_FUSION_GROUP, SUBGRAPH_ATTR
 import unittest
 
 
@@ -35,7 +35,7 @@ class TestGetAttr(unittest.TestCase):
                 assert (
                     kind != "prim::GetAttr"
                 ), "Expected all prim::GetAttrsGlow to be in Glow subgraph"
-                if kind == GLOW_NODE_NAME:
+                if kind == GLOW_FUSION_GROUP:
                     glow_subgraph = node.g(SUBGRAPH_ATTR)
                     for node in glow_subgraph.nodes():
                         if node.kind() == "prim::GetAttr":

--- a/torch_glow/tests/nodes/layernorm_test.py
+++ b/torch_glow/tests/nodes/layernorm_test.py
@@ -4,28 +4,39 @@ import unittest
 
 import torch
 import torch.nn.functional as F
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimpleLayerNormModule(torch.nn.Module):
+    def __init__(self, normalized_shape):
+        super(SimpleLayerNormModule, self).__init__()
+        self.normalized_shape = normalized_shape
+
+    def forward(self, input, weight=None, bias=None):
+        return F.layer_norm(input, self.normalized_shape, weight, bias)
 
 
 class TestLayerNorm(unittest.TestCase):
     def test_layernorm_basic(self):
         """Basic test of the PyTorch layernorm Node on Glow."""
 
-        def test_f(inputs, weight, bias):
-            return F.layer_norm(inputs, [5], weight, bias)
-
         inputs = torch.randn(1, 4, 5, 5)
         weight = torch.randn(5)
         bias = torch.randn(5)
 
-        jitVsGlow(test_f, inputs, weight, bias, expected_fused_ops={"aten::layer_norm"})
+        utils.compare_tracing_methods(
+            SimpleLayerNormModule([5]),
+            inputs,
+            weight,
+            bias,
+            fusible_ops={"aten::layer_norm"},
+        )
 
     def test_layernorm_no_bias(self):
         """Test of the PyTorch aten::layer_norm without weights and bias."""
 
-        def test_f(inputs):
-            return F.layer_norm(inputs, [5, 5])
-
         inputs = torch.randn(1, 4, 5, 5)
 
-        jitVsGlow(test_f, inputs, expected_fused_ops={"aten::layer_norm"})
+        utils.compare_tracing_methods(
+            SimpleLayerNormModule([5, 5]), inputs, fusible_ops={"aten::layer_norm"}
+        )

--- a/torch_glow/tests/nodes/linear_test.py
+++ b/torch_glow/tests/nodes/linear_test.py
@@ -4,7 +4,15 @@ import unittest
 
 import torch
 import torch.nn.functional as F
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimpleLinearModule(torch.nn.Module):
+    def __init__(self):
+        super(SimpleLinearModule, self).__init__()
+
+    def forward(self, input, weight, bias=None):
+        return F.linear((input + input), weight, bias)
 
 
 class TestLinear(unittest.TestCase):
@@ -21,8 +29,10 @@ class TestLinear(unittest.TestCase):
         input = torch.randn(n, in_features)
         weight = torch.randn(out_features, in_features)
 
-        # expected_fused_ops has is empty because linear gets lowered to other ops
-        jitVsGlow(test_f, input, weight, expected_fused_ops={})
+        # fusible_ops has is empty because linear gets lowered to other ops
+        utils.compare_tracing_methods(
+            SimpleLinearModule(), input, weight, fusible_ops={}
+        )
 
     def test_linear_bias(self):
         """Test of the PyTorch aten::linear op on Glow."""
@@ -38,8 +48,10 @@ class TestLinear(unittest.TestCase):
         weight = torch.randn(out_features, in_features)
         bias = torch.randn(out_features)
 
-        # expected_fused_ops has is empty because linear gets lowered to other ops
-        jitVsGlow(test_f, input, weight, bias, expected_fused_ops={})
+        # fusible_ops has is empty because linear gets lowered to other ops
+        utils.compare_tracing_methods(
+            SimpleLinearModule(), input, weight, bias, fusible_ops={}
+        )
 
     def test_linear_broadcast(self):
         """Test of the PyTorch aten::linear op with broadcasting on Glow."""
@@ -54,5 +66,7 @@ class TestLinear(unittest.TestCase):
         input = torch.randn(n, 9, 7, in_features)
         weight = torch.randn(out_features, in_features)
 
-        # expected_fused_ops has is empty because linear gets lowered to other ops
-        jitVsGlow(test_f, input, weight, expected_fused_ops={})
+        # fusible_ops has is empty because linear gets lowered to other ops
+        utils.compare_tracing_methods(
+            SimpleLinearModule(), input, weight, fusible_ops={}
+        )

--- a/torch_glow/tests/nodes/lstm_test.py
+++ b/torch_glow/tests/nodes/lstm_test.py
@@ -4,7 +4,7 @@ import unittest
 
 import torch
 import torch.nn as nn
-from tests.utils import jitVsGlow
+from tests import utils
 
 
 class TestLSTM(unittest.TestCase):
@@ -33,7 +33,9 @@ class TestLSTM(unittest.TestCase):
         c = torch.randn(1, 3, 10)
         model = SimpleLSTM()
 
-        jitVsGlow(model, inputs, h, c, expected_fused_ops={"aten::lstm"})
+        utils.compare_tracing_methods(
+            model, inputs, h, c, fusible_ops={"aten::lstm"}, skip_to_glow=True
+        )
 
     def test_lstm_no_bias(self):
         """Basic test of the PyTorch lstm Node with no bias on Glow."""
@@ -55,7 +57,9 @@ class TestLSTM(unittest.TestCase):
         h = torch.randn(1, 3, 10)
         c = torch.randn(1, 3, 10)
         model = SimpleNoBiasLSTM()
-        jitVsGlow(model, inputs, h, c, expected_fused_ops={"aten::lstm"})
+        utils.compare_tracing_methods(
+            model, inputs, h, c, fusible_ops={"aten::lstm"}, skip_to_glow=True
+        )
 
     def test_lstm_bidirectional(self):
         """Bidirectional test of the PyTorch lstm Node on Glow."""
@@ -74,4 +78,6 @@ class TestLSTM(unittest.TestCase):
         c = torch.randn(2, 3, 10)
         model = BidirectionalLSTM()
 
-        jitVsGlow(model, inputs, h, c, expected_fused_ops={"aten::lstm"})
+        utils.compare_tracing_methods(
+            model, inputs, h, c, fusible_ops={"aten::lstm"}, skip_to_glow=True
+        )

--- a/torch_glow/tests/nodes/matmul_test.py
+++ b/torch_glow/tests/nodes/matmul_test.py
@@ -4,102 +4,51 @@ import random
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from parameterized import parameterized
+from tests import utils
+
+
+class SimpleMatmulModule(torch.nn.Module):
+    def __init__(self):
+        super(SimpleMatmulModule, self).__init__()
+
+    def forward(self, a, b):
+        return a.matmul(b + b)
 
 
 class TestMatMul(unittest.TestCase):
-    def test_matmul_1d_1d(self):
+    @parameterized.expand(
+        [
+            ("1d_1d", torch.randn(4), torch.randn(4)),
+            ("1d_2d", torch.randn(4), torch.randn(4, 9)),
+            ("1d_3d", torch.randn(4), torch.randn(3, 4, 9)),
+            ("1d_4d", torch.randn(4), torch.randn(5, 3, 4, 9)),
+            ("2d_1d", torch.randn(9, 4), torch.randn(4)),
+            ("3d_1d", torch.randn(6, 9, 4), torch.randn(4)),
+            ("4d_1d", torch.randn(2, 6, 9, 4), torch.randn(4)),
+        ]
+    )
+    def test_matmul(self, _, left, right):
         """Test of aten::matmul with two 1d inputs Glow."""
 
-        def test_f(a, b):
-            return a.matmul(b + b)
-
-        x = torch.randn(4)
-        y = torch.randn(4)
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::matmul"})
-
-    def test_matmul_2d_1d(self):
-        """Test of aten::matmul with 2d and 1d inputs Glow."""
-
-        def test_f(a, b):
-            return a.matmul(b + b)
-
-        x = torch.randn(9, 4)
-        y = torch.randn(4)
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::matmul"})
-
-    def test_matmul_3d_1d(self):
-        """Test of aten::matmul with 2d and 1d inputs Glow."""
-
-        def test_f(a, b):
-            return a.matmul(b + b)
-
-        x = torch.randn(6, 9, 4)
-        y = torch.randn(4)
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::matmul"})
-
-    def test_matmul_4d_1d(self):
-        """Test of aten::matmul with 2d and 1d inputs Glow."""
-
-        def test_f(a, b):
-            return a.matmul(b + b)
-
-        x = torch.randn(2, 6, 9, 4)
-        y = torch.randn(4)
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::matmul"})
-
-    def test_matmul_1d_2d(self):
-        """Test of aten::matmul with 1d and 2d inputs Glow."""
-
-        def test_f(a, b):
-            return a.matmul(b + b)
-
-        x = torch.randn(4)
-        y = torch.randn(4, 9)
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::matmul"})
-
-    def test_matmul_1d_3d(self):
-        """Test of aten::matmul with 1d and 2d inputs Glow."""
-
-        def test_f(a, b):
-            return a.matmul(b + b)
-
-        x = torch.randn(4)
-        y = torch.randn(3, 4, 9)
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::matmul"})
-
-    def test_matmul_1d_4d(self):
-        """Test of aten::matmul with 1d and 2d inputs Glow."""
-
-        def test_f(a, b):
-            return a.matmul(b + b)
-
-        x = torch.randn(4)
-        y = torch.randn(5, 3, 4, 9)
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::matmul"})
+        utils.compare_tracing_methods(
+            SimpleMatmulModule(), left, right, fusible_ops={"aten::matmul"}
+        )
 
     def test_matmul_nd_nd(self):
         """Test of aten::matmul with >2d and >2d inputs Glow."""
-
-        def test_f(a, b):
-            return a.matmul(b + b)
 
         def do_test(lhsDims, rhsDims):
             lhs = torch.randn(lhsDims)
             rhs = torch.randn(rhsDims)
 
-            jitVsGlow(test_f, lhs, rhs, expected_fused_ops={"aten::matmul"})
+            utils.compare_tracing_methods(
+                SimpleMatmulModule(), lhs, rhs, fusible_ops={"aten::matmul"}
+            )
 
         def randomDimsOfRank(rank):
             dims = []
-            for i in range(rank):
+            for _ in range(rank):
                 dim = random.randint(2, 9)
                 dims.append(dim)
             return dims

--- a/torch_glow/tests/nodes/max_test.py
+++ b/torch_glow/tests/nodes/max_test.py
@@ -3,18 +3,21 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimpleMaxModule(torch.nn.Module):
+    def __init__(self):
+        super(SimpleMaxModule, self).__init__()
+
+    def forward(self, a, b):
+        return torch.max(a + a, b + b)
 
 
 class TestMax(unittest.TestCase):
     def test_elementwise_max(self):
         """Test of the PyTorch max Node on Glow."""
 
-        def test_f(a, b):
-            c = torch.max(a, b)
-            return torch.max(c, c)
-
-        x = torch.randn(4)
-        y = torch.randn(4)
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::max"})
+        utils.compare_tracing_methods(
+            SimpleMaxModule(), torch.randn(4), torch.randn(4), fusible_ops={"aten::max"}
+        )

--- a/torch_glow/tests/nodes/maxpool2d_test.py
+++ b/torch_glow/tests/nodes/maxpool2d_test.py
@@ -4,26 +4,34 @@ import unittest
 
 import torch
 import torch.nn.functional as F
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimpleMaxPool2dTest(torch.nn.Module):
+    def __init__(self, kernel_size, padding=0):
+        super(SimpleMaxPool2dTest, self).__init__()
+        self.kernel_size = kernel_size
+        self.padding = padding
+
+    def forward(self, inputs):
+        return F.max_pool2d(inputs, kernel_size=self.kernel_size, padding=self.padding)
 
 
 class TestMaxPool2d(unittest.TestCase):
     def test_max_pool2d_basic(self):
         """Basic test of the PyTorch max_pool2d Node on Glow."""
 
-        def test_f(inputs):
-            return F.max_pool2d(inputs, 3)
-
-        inputs = torch.randn(1, 4, 5, 5)
-
-        jitVsGlow(test_f, inputs, expected_fused_ops={"aten::max_pool2d"})
+        utils.compare_tracing_methods(
+            SimpleMaxPool2dTest(3),
+            torch.randn(1, 4, 5, 5),
+            fusible_ops={"aten::max_pool2d"},
+        )
 
     def test_max_pool2d_with_args(self):
         """Test of the PyTorch max_pool2d Node with arguments on Glow."""
 
-        def test_f(inputs):
-            return F.max_pool2d(inputs, padding=3, kernel_size=7)
-
-        inputs = torch.randn(1, 4, 10, 10)
-
-        jitVsGlow(test_f, inputs, expected_fused_ops={"aten::max_pool2d"})
+        utils.compare_tracing_methods(
+            SimpleMaxPool2dTest(7, 3),
+            torch.randn(1, 4, 10, 10),
+            fusible_ops={"aten::max_pool2d"},
+        )

--- a/torch_glow/tests/nodes/mean_test.py
+++ b/torch_glow/tests/nodes/mean_test.py
@@ -3,26 +3,38 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimpleMeanModule(torch.nn.Module):
+    def __init__(self, dim=None):
+        super(SimpleMeanModule, self).__init__()
+        self.dim = dim
+
+    def forward(self, a, b):
+        if self.dim:
+            return torch.mean(a + b, self.dim)
+        else:
+            return torch.mean(a + b)
 
 
 class TestMean(unittest.TestCase):
     def test_basic(self):
         """Test of the PyTorch mean Node on Glow."""
 
-        def test_f(a, b):
-            return torch.mean(a + b)
-
-        jitVsGlow(
-            test_f, torch.randn(7), torch.randn(7), expected_fused_ops={"aten::mean"}
+        utils.compare_tracing_methods(
+            SimpleMeanModule(),
+            torch.randn(7),
+            torch.randn(7),
+            fusible_ops={"aten::mean"},
         )
 
     def test_with_dims(self):
         """Test of the PyTorch mean node with dims on Glow. """
 
-        def test_f(a, b):
-            return torch.mean(a + b, (1, 2))
-
-        x = torch.randn([1, 2, 3, 4])
-        y = torch.randn([1, 2, 3, 4])
-        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::mean"})
+        utils.compare_tracing_methods(
+            SimpleMeanModule((1, 2)),
+            torch.randn([1, 2, 3, 4]),
+            torch.randn([1, 2, 3, 4]),
+            fusible_ops={"aten::mean"},
+        )

--- a/torch_glow/tests/nodes/min_test.py
+++ b/torch_glow/tests/nodes/min_test.py
@@ -3,16 +3,21 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimpleMinModule(torch.nn.Module):
+    def __init__(self):
+        super(SimpleMinModule, self).__init__()
+
+    def forward(self, a, b):
+        return torch.min(a + a, b + b)
 
 
 class TestMin(unittest.TestCase):
     def test_elementwise_min(self):
         """Test of the PyTorch min Node on Glow."""
 
-        def test_f(a, b):
-            return torch.min(a + a, b + b)
-
-        jitVsGlow(
-            test_f, torch.randn(7), torch.randn(7), expected_fused_ops={"aten::min"}
+        utils.compare_tracing_methods(
+            SimpleMinModule(), torch.randn(7), torch.randn(7), fusible_ops={"aten::min"}
         )

--- a/torch_glow/tests/nodes/mm_test.py
+++ b/torch_glow/tests/nodes/mm_test.py
@@ -3,19 +3,26 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimpleMmModule(torch.nn.Module):
+    def __init__(self):
+        super(SimpleMmModule, self).__init__()
+
+    def forward(self, a, b, t):
+        r = torch.mm(a, b)
+        return r.mm(t)
 
 
 class TestMm(unittest.TestCase):
     def test_mm_basic(self):
         """Test of the PyTorch mm Node on Glow."""
 
-        def test_f(a, b, t):
-            r = torch.mm(a, b)
-            return r.mm(t)
-
         x = torch.randn(2, 3)
         y = torch.randn(4, 3).t()
         t = torch.randn(4, 2)
 
-        jitVsGlow(test_f, x, y, t, expected_fused_ops={"aten::mm"})
+        utils.compare_tracing_methods(
+            SimpleMmModule(), x, y, t, fusible_ops={"aten::mm"}, skip_to_glow=True
+        )

--- a/torch_glow/tests/nodes/mul_test.py
+++ b/torch_glow/tests/nodes/mul_test.py
@@ -3,74 +3,37 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from parameterized import parameterized
+from tests import utils
+
+
+class SimpleMulModule(torch.nn.Module):
+    def __init__(self):
+        super(SimpleMulModule, self).__init__()
+
+    def forward(self, left, right):
+        other = left.mul(right.item() if right.size() == torch.Size([]) else right)
+        return other.mul(other)
 
 
 class TestMul(unittest.TestCase):
-    def test_mul_basic(self):
+    @parameterized.expand(
+        [
+            ("basic", torch.randn(4), torch.randn(4)),
+            ("broadcast", torch.randn(8, 3, 4, 2), torch.randn(4, 2)),
+            ("broadcast", torch.randn(8, 3, 4, 2), torch.randn(1, 2)),
+            ("broadcast", torch.randn(4, 2), torch.randn(8, 3, 4, 2)),
+            ("float", torch.randn(4, 2), torch.tensor(3.2)),
+            ("int", torch.randn(4, 2), torch.tensor(22), True),
+        ]
+    )
+    def test_mul(self, _, left, right, skip_to_glow=False):
         """Basic test of the PyTorch mul Node on Glow."""
 
-        def test_f(a, b):
-            c = a.mul(b)
-            return c.mul(c)
-
-        x = torch.randn(4)
-        y = torch.randn(4)
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::mul"})
-
-    def test_mul_broadcast_1(self):
-        """Test of the PyTorch mul Node on Glow with broadcasting."""
-
-        def test_f(a, b):
-            c = a.mul(b)
-            return c.mul(c)
-
-        x = torch.randn(8, 3, 4, 2)
-        y = torch.randn(4, 2)
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::mul"})
-
-    def test_mul_broadcast_2(self):
-        """Test of the PyTorch mul Node on Glow with broadcasting."""
-
-        def test_f(a, b):
-            c = a.mul(b)
-            return c.mul(c)
-
-        x = torch.randn(8, 3, 4, 2)
-        y = torch.randn(1, 2)
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::mul"})
-
-    def test_mul_broadcast_3(self):
-        """Test of the PyTorch mul Node on Glow with broadcasting."""
-
-        def test_f(a, b):
-            c = a.mul(b)
-            return c.mul(c)
-
-        x = torch.randn(4, 2)
-        y = torch.randn(8, 3, 4, 2)
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::mul"})
-
-    def test_mul_float(self):
-        """Test of the PyTorch aten::mul Node with a float argument"""
-
-        def test_f(a):
-            return (a + a).mul(3.9)
-
-        x = torch.randn(4)
-
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::mul"})
-
-    def test_mul_int(self):
-        """Test of the PyTorch aten::mul Node with an int argument"""
-
-        def test_f(a):
-            return (a + a).mul(20)
-
-        x = torch.randn(4)
-
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::mul"})
+        utils.compare_tracing_methods(
+            SimpleMulModule(),
+            left,
+            right,
+            fusible_ops={"aten::mul"},
+            skip_to_glow=skip_to_glow,
+        )

--- a/torch_glow/tests/nodes/norm_test.py
+++ b/torch_glow/tests/nodes/norm_test.py
@@ -3,36 +3,43 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimpleNormModule(torch.nn.Module):
+    def __init__(self, *args, **kwargs):
+        super(SimpleNormModule, self).__init__()
+        self.args = args
+        self.kwargs = kwargs
+
+    def forward(self, tensor):
+        return torch.norm(tensor, *self.args, **self.kwargs)
 
 
 class TestNorm(unittest.TestCase):
     def test_norm_basic(self):
         """Basic test of the PyTorch norm Node on Glow."""
 
-        def test_f(a):
-            return torch.norm(a, dim=0, p=2)
-
-        a = torch.arange(8, dtype=torch.float).reshape(2, 4)
-
-        jitVsGlow(test_f, a, expected_fused_ops={"aten::norm"})
+        utils.compare_tracing_methods(
+            SimpleNormModule(dim=0, p=2),
+            torch.arange(8, dtype=torch.float).reshape(2, 4),
+            fusible_ops={"aten::norm"},
+        )
 
     def test_norm_3d_inner_axis(self):
         """Basic test of the PyTorch norm Node on Glow."""
 
-        def test_f(a):
-            return torch.norm(a, dim=1)
-
-        a = torch.arange(8, dtype=torch.float).reshape(2, 2, 2)
-
-        jitVsGlow(test_f, a, expected_fused_ops={"aten::frobenius_norm"})
+        utils.compare_tracing_methods(
+            SimpleNormModule(dim=1),
+            torch.arange(8, dtype=torch.float).reshape(2, 2, 2),
+            fusible_ops={"aten::frobenius_norm"},
+        )
 
     def test_norm_4d_outer_axis(self):
         """Basic test of the PyTorch norm Node on Glow."""
 
-        def test_f(a):
-            return torch.norm(a, dim=[3])
-
-        a = torch.arange(16, dtype=torch.float).reshape(2, 2, 2, 2)
-
-        jitVsGlow(test_f, a, expected_fused_ops={"aten::frobenius_norm"})
+        utils.compare_tracing_methods(
+            SimpleNormModule(dim=[3]),
+            torch.arange(16, dtype=torch.float).reshape(2, 2, 2, 2),
+            fusible_ops={"aten::frobenius_norm"},
+        )

--- a/torch_glow/tests/nodes/num_to_tensor_test.py
+++ b/torch_glow/tests/nodes/num_to_tensor_test.py
@@ -3,31 +3,47 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimpleNumToTensorModule(torch.nn.Module):
+    def __init__(self, make_float=False):
+        super(SimpleNumToTensorModule, self).__init__()
+        self.forward = self._float_forward if make_float else self._forward
+
+    def _float_forward(self, dummy):
+        at0 = torch.ops.prim.NumToTensor(dummy.size(0)).to(torch.float)
+        # Const floating number is torch.float64 by-default
+        # Therefore we need to convert it to float32 once NumToTensor is
+        # used
+        at1 = torch.ops.prim.NumToTensor(1.2).to(torch.float)
+        return torch.cat((at0.reshape(1), at1.reshape(1)))
+
+    def _forward(self, dummy):
+        at0 = torch.ops.prim.NumToTensor(dummy.size(0))
+        at1 = torch.ops.prim.NumToTensor(dummy.size(1))
+        return torch.cat((at0.reshape(1), at1.reshape(1)))
 
 
 class TestNumToTensor(unittest.TestCase):
     def test_NumToTensor_basic(self):
         """Basic test of the PyTorch NumToTensor Node on Glow."""
 
-        def test_f(a):
-            at0 = torch.ops.prim.NumToTensor(a.size(0))
-            at1 = torch.ops.prim.NumToTensor(a.size(1))
-            return torch.cat((at0.reshape(1), at1.reshape(1)))
-
-        x = torch.randn(5, 6, 7)
-        jitVsGlow(test_f, x, expected_fused_ops={"prim::NumToTensor"}, use_script=True)
+        utils.compare_tracing_methods(
+            SimpleNumToTensorModule(),
+            torch.randn(5, 6, 7),
+            fusible_ops={"prim::NumToTensor"},
+            scripted=True,
+            skip_to_glow=True,
+        )
 
     def test_NumToTensor_float(self):
         """Basic test of the PyTorch NumToTensor Node on Glow."""
 
-        def test_f(a):
-            at0 = torch.ops.prim.NumToTensor(a.size(0)).to(torch.float)
-            # Const floating number is torch.float64 by-default
-            # Therefore we need to convert it to float32 once NumToTensor is
-            # used
-            at1 = torch.ops.prim.NumToTensor(1.2).to(torch.float)
-            return torch.cat((at0.reshape(1), at1.reshape(1)))
-
-        x = torch.randn(5, 6, 7)
-        jitVsGlow(test_f, x, expected_fused_ops={"prim::NumToTensor"}, use_script=True)
+        utils.compare_tracing_methods(
+            SimpleNumToTensorModule(True),
+            torch.randn(5, 6, 7),
+            fusible_ops={"prim::NumToTensor"},
+            scripted=True,
+            skip_to_glow=True,
+        )

--- a/torch_glow/tests/nodes/permute_test.py
+++ b/torch_glow/tests/nodes/permute_test.py
@@ -3,17 +3,24 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimplePermuteModule(torch.nn.Module):
+    def __init__(self, *dimensions):
+        super(SimplePermuteModule, self).__init__()
+        self.dimensions = dimensions
+
+    def forward(self, tensor):
+        return tensor.permute(*self.dimensions)
 
 
 class TestPermute(unittest.TestCase):
     def test_permute(self):
         """Basic test of the PyTorch aten::permute node on Glow."""
 
-        def test_f(a):
-            b = a.permute(0, 2, 1)
-            return b
-
-        x = torch.randn(2, 3, 4)
-
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::permute"})
+        utils.compare_tracing_methods(
+            SimplePermuteModule(0, 2, 1),
+            torch.randn(2, 3, 4),
+            fusible_ops={"aten::permute"},
+        )

--- a/torch_glow/tests/nodes/pow_test.py
+++ b/torch_glow/tests/nodes/pow_test.py
@@ -3,17 +3,24 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimplePowModule(torch.nn.Module):
+    def __init__(self, *powers):
+        super(SimplePowModule, self).__init__()
+        self.powers = powers
+
+    def forward(self, tensor):
+        for power in self.powers:
+            tensor = torch.pow(tensor, power)
+        return tensor
 
 
 class TestPow(unittest.TestCase):
     def test_pow_basic(self):
         """Test of the PyTorch pow Node on Glow."""
 
-        def pow_basic(a):
-            b = torch.pow(a, 2.3)
-            return torch.pow(b, 3.4)
-
-        x = torch.rand(4) + 5
-
-        jitVsGlow(pow_basic, x, expected_fused_ops={"aten::pow"})
+        utils.compare_tracing_methods(
+            SimplePowModule(2.3, 3.4), torch.rand(4) + 5, fusible_ops={"aten::pow"}
+        )

--- a/torch_glow/tests/nodes/prelu_test.py
+++ b/torch_glow/tests/nodes/prelu_test.py
@@ -4,17 +4,24 @@ import unittest
 
 import torch
 import torch.nn.functional as F
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimplePreluModule(torch.nn.Module):
+    def __init__(self):
+        super(SimplePreluModule, self).__init__()
+
+    def forward(self, inputs, weights):
+        return F.prelu(inputs + inputs, weights)
 
 
 class TestPrelu(unittest.TestCase):
     def test_prelu_basic(self):
         """Basic test of the PyTorch prelu Node on Glow."""
 
-        def prelu_basic(inputs, weight):
-            return F.prelu(inputs + inputs, weight)
-
-        inputs = torch.randn(1, 4, 5, 5)
-        weight = torch.tensor([0.25])
-
-        jitVsGlow(prelu_basic, inputs, weight, expected_fused_ops={"aten::prelu"})
+        utils.compare_tracing_methods(
+            SimplePreluModule(),
+            torch.randn(1, 4, 5, 5),
+            torch.tensor([0.25]),
+            fusible_ops={"aten::prelu"},
+        )

--- a/torch_glow/tests/nodes/quantized_add_relu_test.py
+++ b/torch_glow/tests/nodes/quantized_add_relu_test.py
@@ -3,89 +3,84 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimpleQuantizedAddReluModule(torch.nn.Module):
+    def __init__(self, left_quantization, right_quantization, scale, zero_point):
+        super(SimpleQuantizedAddReluModule, self).__init__()
+        self.left_quantization = left_quantization
+        self.right_quantization = right_quantization
+        self.scale = scale
+        self.zero_point = zero_point
+
+    def forward(self, left, right):
+        return torch.nn.quantized.DeQuantize()(
+            torch.ops.quantized.add_relu(
+                self.left_quantization(left),
+                self.right_quantization(right),
+                scale=self.scale,
+                zero_point=self.zero_point,
+            )
+        )
 
 
 class TestQuantizedAddRelu(unittest.TestCase):
     def test_quantized_add_relu_zerooffset(self):
         """Basic test of the PyTorch quantized::add Node_relu on Glow with zero offset."""
 
-        def test_f(a, b):
-            q = torch.nn.quantized.Quantize(scale=0.3, zero_point=0, dtype=torch.quint8)
-            dq = torch.nn.quantized.DeQuantize()
-            return dq(
-                torch.ops.quantized.add_relu(q(a), q(b), scale=0.05, zero_point=0)
-            )
-
-        x = torch.tensor([1, 2, 3, 4], dtype=torch.float32)
-        y = torch.tensor([5, 6, 7, 8], dtype=torch.float32)
-
-        jitVsGlow(
-            test_f,
-            x,
-            y,
-            expected_fused_ops={
-                "quantized::add_relu",
-                "aten::quantize_per_tensor",
-                "aten::dequantize",
-            },
+        utils.compare_tracing_methods(
+            SimpleQuantizedAddReluModule(
+                torch.nn.quantized.Quantize(
+                    scale=0.3, zero_point=0, dtype=torch.quint8
+                ),
+                torch.nn.quantized.Quantize(
+                    scale=0.3, zero_point=0, dtype=torch.quint8
+                ),
+                0.05,
+                0,
+            ),
+            torch.tensor([1, 2, 3, 4], dtype=torch.float32),
+            torch.tensor([5, 6, 7, 8], dtype=torch.float32),
+            skip_to_glow=True,
         )
 
     def test_quantized_add_relu(self):
         """Basic test of the PyTorch quantized::add_relu Node on Glow."""
 
-        def test_f(a, b):
-            q1 = torch.nn.quantized.Quantize(
-                scale=1.0 / 128, zero_point=5, dtype=torch.quint8
-            )
-            q2 = torch.nn.quantized.Quantize(
-                scale=1.0 / 128, zero_point=10, dtype=torch.quint8
-            )
-            dq = torch.nn.quantized.DeQuantize()
-            return dq(
-                torch.ops.quantized.add_relu(
-                    q1(a), q2(b), scale=1.0 / 128, zero_point=3
-                )
-            )
-
-        x = torch.randn([5, 5])
-        y = torch.randn([5, 5])
-
-        jitVsGlow(
-            test_f,
-            x,
-            y,
-            expected_fused_ops={
-                "quantized::add_relu",
-                "aten::quantize_per_tensor",
-                "aten::dequantize",
-            },
+        utils.compare_tracing_methods(
+            SimpleQuantizedAddReluModule(
+                torch.nn.quantized.Quantize(
+                    scale=1.0 / 128, zero_point=5, dtype=torch.quint8
+                ),
+                torch.nn.quantized.Quantize(
+                    scale=1.0 / 128, zero_point=10, dtype=torch.quint8
+                ),
+                1.0 / 128,
+                3,
+            ),
+            torch.rand([5, 5]),
+            torch.rand([5, 5]),
+            skip_to_glow=True,
         )
 
     def test_quantized_add_relu_cut_q_dq(self):
         """Basic test of the PyTorch quantized::add_relu Node on Glow, with quantize and dequantize excluded. """
 
-        def test_f(a, b):
-            q1 = torch.nn.quantized.Quantize(
-                scale=1.0 / 128, zero_point=5, dtype=torch.quint8
-            )
-            q2 = torch.nn.quantized.Quantize(
-                scale=1.0 / 128, zero_point=10, dtype=torch.quint8
-            )
-            dq = torch.nn.quantized.DeQuantize()
-            return dq(
-                torch.ops.quantized.add_relu(
-                    q1(a), q2(b), scale=1.0 / 128, zero_point=3
-                )
-            )
-
-        x = torch.randn([5, 5])
-        y = torch.randn([5, 5])
-
-        jitVsGlow(
-            test_f,
-            x,
-            y,
-            expected_fused_ops={"quantized::add_relu"},
-            black_list=["aten::quantize_per_tensor", "aten::dequantize"],
+        utils.compare_tracing_methods(
+            SimpleQuantizedAddReluModule(
+                torch.nn.quantized.Quantize(
+                    scale=1.0 / 128, zero_point=5, dtype=torch.quint8
+                ),
+                torch.nn.quantized.Quantize(
+                    scale=1.0 / 128, zero_point=10, dtype=torch.quint8
+                ),
+                1.0 / 128,
+                3,
+            ),
+            torch.rand([5, 5]),
+            torch.rand([5, 5]),
+            fusible_ops={"quantized::add_relu"},
+            fusion_blocklist=["aten::quantize_per_tensor", "aten::dequantize"],
+            skip_to_glow=True,
         )

--- a/torch_glow/tests/nodes/quantized_add_test.py
+++ b/torch_glow/tests/nodes/quantized_add_test.py
@@ -3,83 +3,94 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimpleQuantizedAddModule(torch.nn.Module):
+    def __init__(self, left_quantization, right_quantization, scale, zero_point):
+        super(SimpleQuantizedAddModule, self).__init__()
+        self.left_quantization = left_quantization
+        self.right_quantization = right_quantization
+        self.scale = scale
+        self.zero_point = zero_point
+
+    def forward(self, left, right):
+        return torch.nn.quantized.DeQuantize()(
+            torch.ops.quantized.add(
+                self.left_quantization(left),
+                self.right_quantization(right),
+                scale=self.scale,
+                zero_point=self.zero_point,
+            )
+        )
 
 
 class TestQuantizedAdd(unittest.TestCase):
     def test_quantized_add_zerooffset(self):
         """Basic test of the PyTorch quantized::add Node on Glow with zero offset."""
 
-        def test_f(a, b):
-            q = torch.nn.quantized.Quantize(scale=0.3, zero_point=0, dtype=torch.quint8)
-            dq = torch.nn.quantized.DeQuantize()
-            return dq(torch.ops.quantized.add(q(a), q(b), scale=0.05, zero_point=0))
-
-        x = torch.tensor([1, 2, 3, 4], dtype=torch.float32)
-        y = torch.tensor([5, 6, 7, 8], dtype=torch.float32)
-
-        jitVsGlow(
-            test_f,
-            x,
-            y,
-            expected_fused_ops={
+        utils.compare_tracing_methods(
+            SimpleQuantizedAddModule(
+                torch.nn.quantized.Quantize(
+                    scale=0.3, zero_point=0, dtype=torch.quint8
+                ),
+                torch.nn.quantized.Quantize(
+                    scale=0.3, zero_point=0, dtype=torch.quint8
+                ),
+                0.05,
+                0,
+            ),
+            torch.tensor([1, 2, 3, 4], dtype=torch.float32),
+            torch.tensor([5, 6, 7, 8], dtype=torch.float32),
+            fusible_ops={
                 "quantized::add",
                 "aten::quantize_per_tensor",
                 "aten::dequantize",
             },
+            skip_to_glow=True,
         )
 
     def test_quantized_add(self):
         """Basic test of the PyTorch quantized::add Node on Glow."""
 
-        def test_f(a, b):
-            q1 = torch.nn.quantized.Quantize(
-                scale=1.0 / 128, zero_point=5, dtype=torch.quint8
-            )
-            q2 = torch.nn.quantized.Quantize(
-                scale=1.0 / 128, zero_point=10, dtype=torch.quint8
-            )
-            dq = torch.nn.quantized.DeQuantize()
-            return dq(
-                torch.ops.quantized.add(q1(a), q2(b), scale=1.0 / 128, zero_point=3)
-            )
-
-        x = torch.randn([5, 5])
-        y = torch.randn([5, 5])
-
-        jitVsGlow(
-            test_f,
-            x,
-            y,
-            expected_fused_ops={
+        utils.compare_tracing_methods(
+            SimpleQuantizedAddModule(
+                torch.nn.quantized.Quantize(
+                    scale=1.0 / 128, zero_point=5, dtype=torch.quint8
+                ),
+                torch.nn.quantized.Quantize(
+                    scale=1.0 / 128, zero_point=10, dtype=torch.quint8
+                ),
+                1.0 / 128,
+                3,
+            ),
+            torch.randn([5, 5]),
+            torch.randn([5, 5]),
+            fusible_ops={
                 "quantized::add",
                 "aten::quantize_per_tensor",
                 "aten::dequantize",
             },
+            skip_to_glow=True,
         )
 
     def test_quantized_add_cut_q_dq(self):
         """Basic test of the PyTorch quantized::add Node on Glow, with quantize and dequantize excluded. """
 
-        def test_f(a, b):
-            q1 = torch.nn.quantized.Quantize(
-                scale=1.0 / 128, zero_point=5, dtype=torch.quint8
-            )
-            q2 = torch.nn.quantized.Quantize(
-                scale=1.0 / 128, zero_point=10, dtype=torch.quint8
-            )
-            dq = torch.nn.quantized.DeQuantize()
-            return dq(
-                torch.ops.quantized.add(q1(a), q2(b), scale=1.0 / 128, zero_point=3)
-            )
-
-        x = torch.randn([5, 5])
-        y = torch.randn([5, 5])
-
-        jitVsGlow(
-            test_f,
-            x,
-            y,
-            expected_fused_ops={"quantized::add"},
-            black_list=["aten::quantize_per_tensor", "aten::dequantize"],
+        utils.compare_tracing_methods(
+            SimpleQuantizedAddModule(
+                torch.nn.quantized.Quantize(
+                    scale=1.0 / 128, zero_point=5, dtype=torch.quint8
+                ),
+                torch.nn.quantized.Quantize(
+                    scale=1.0 / 128, zero_point=10, dtype=torch.quint8
+                ),
+                1.0 / 128,
+                3,
+            ),
+            torch.randn([5, 5]),
+            torch.randn([5, 5]),
+            fusible_ops={"quantized::add"},
+            fusion_blocklist=["aten::quantize_per_tensor", "aten::dequantize"],
+            skip_to_glow=True,
         )

--- a/torch_glow/tests/nodes/quantized_avgpool3d_test.py
+++ b/torch_glow/tests/nodes/quantized_avgpool3d_test.py
@@ -3,27 +3,29 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimpleQuantizedAvgPool3DModule(torch.nn.Module):
+    def __init__(self, scale, zero_point, dtype, kernel_size):
+        super(SimpleQuantizedAvgPool3DModule, self).__init__()
+        self.quantize = torch.nn.quantized.Quantize(
+            scale=scale, zero_point=zero_point, dtype=dtype
+        )
+        self.average_pool = torch.nn.AvgPool3d(kernel_size)
+
+    def forward(self, inputs):
+        return torch.nn.quantized.DeQuantize()(self.average_pool(self.quantize(inputs)))
 
 
 class TestQuantizedAvgPool3D(unittest.TestCase):
     def test_quantized_avgpool3d(self):
         """Basic test of the PyTorch quantized::avg_pool2d Node on Glow."""
 
-        def test_f(a):
-            q = torch.nn.quantized.Quantize(
-                scale=1.0 / 128, zero_point=3, dtype=torch.quint8
-            )
-            dq = torch.nn.quantized.DeQuantize()
-            ap = torch.nn.AvgPool3d(3)
-            return dq(ap(q(a)))
-
-        inputs = torch.randn(1, 2, 4, 5, 5)
-
-        jitVsGlow(
-            test_f,
-            inputs,
-            expected_fused_ops={
+        utils.compare_tracing_methods(
+            SimpleQuantizedAvgPool3DModule(1.0 / 128, 3, torch.quint8, 3),
+            torch.randn(1, 2, 4, 5, 5),
+            fusible_ops={
                 "aten::avg_pool3d",
                 "aten::quantize_per_tensor",
                 "aten::dequantize",
@@ -33,19 +35,9 @@ class TestQuantizedAvgPool3D(unittest.TestCase):
     def test_quantized_avgpool_cut_q_dq(self):
         """Basic test of the PyTorch quantized::avg_pool2d Node on Glow, with quantize and dequantize excluded. """
 
-        def test_f(a):
-            q = torch.nn.quantized.Quantize(
-                scale=1.0 / 128, zero_point=3, dtype=torch.quint8
-            )
-            dq = torch.nn.quantized.DeQuantize()
-            ap = torch.nn.AvgPool3d(3)
-            return dq(ap(q(a)))
-
-        inputs = torch.randn(1, 2, 4, 5, 5)
-
-        jitVsGlow(
-            test_f,
-            inputs,
-            expected_fused_ops={"aten::avg_pool3d"},
-            black_list=["aten::quantize_per_tensor", "aten::dequantize"],
+        utils.compare_tracing_methods(
+            SimpleQuantizedAvgPool3DModule(1.0 / 128, 3, torch.quint8, 3),
+            torch.randn(1, 2, 4, 5, 5),
+            fusible_ops={"aten::avg_pool3d"},
+            fusion_blocklist=["aten::quantize_per_tensor", "aten::dequantize"],
         )

--- a/torch_glow/tests/nodes/quantized_batchnorm2d_test.py
+++ b/torch_glow/tests/nodes/quantized_batchnorm2d_test.py
@@ -4,7 +4,7 @@ import unittest
 
 import torch
 import torch.nn as nn
-from tests.utils import jitVsGlow
+from tests import utils
 from torch.quantization import QConfig, observer
 
 
@@ -50,8 +50,12 @@ class TestQuantizedBatchNorm2D(unittest.TestCase):
         )
         model.eval()
 
-        jitVsGlow(
-            model, inputs, expected_fused_ops={"quantized::batch_norm2d"}, use_fp16=True
+        utils.compare_tracing_methods(
+            model,
+            inputs,
+            fusible_ops={"quantized::batch_norm2d"},
+            fp16=True,
+            skip_to_glow=True,
         )
 
     def test_batchnorm_with_weights(self):
@@ -95,6 +99,10 @@ class TestQuantizedBatchNorm2D(unittest.TestCase):
         )
         model.eval()
 
-        jitVsGlow(
-            model, inputs, expected_fused_ops={"quantized::batch_norm2d"}, use_fp16=True
+        utils.compare_tracing_methods(
+            model,
+            inputs,
+            fusible_ops={"quantized::batch_norm2d"},
+            fp16=True,
+            skip_to_glow=True,
         )

--- a/torch_glow/tests/nodes/quantized_batchnorm3d_relu_test.py
+++ b/torch_glow/tests/nodes/quantized_batchnorm3d_relu_test.py
@@ -4,7 +4,7 @@ import unittest
 
 import torch
 import torch.nn as nn
-from tests.utils import jitVsGlow
+from tests import utils
 from torch.quantization import (
     DeQuantStub,
     QConfig,
@@ -68,10 +68,11 @@ class TestQuantizedBatchNorm3DRelu(unittest.TestCase):
         # Batchnorm introduced great accuracy issues, which could create up to
         # ~1e-2 difference in some rare cases. In order to prevent this test
         # to be flaky, atol is set to be 0.1.
-        jitVsGlow(
+        utils.compare_tracing_methods(
             model,
             inputs,
-            expected_fused_ops={"quantized::batch_norm3d_relu"},
+            fusible_ops={"quantized::batch_norm3d_relu"},
             atol=1e-1,
-            use_fp16=True,
+            fp16=True,
+            skip_to_glow=True,
         )

--- a/torch_glow/tests/nodes/quantized_batchnorm3d_test.py
+++ b/torch_glow/tests/nodes/quantized_batchnorm3d_test.py
@@ -4,7 +4,7 @@ import unittest
 
 import torch
 import torch.nn as nn
-from tests.utils import jitVsGlow
+from tests import utils
 from torch.quantization import QConfig, observer
 
 
@@ -50,8 +50,12 @@ class TestQuantizedBatchNorm3D(unittest.TestCase):
         )
         model.eval()
 
-        jitVsGlow(
-            model, inputs, expected_fused_ops={"quantized::batch_norm3d"}, use_fp16=True
+        utils.compare_tracing_methods(
+            model,
+            inputs,
+            fusible_ops={"quantized::batch_norm3d"},
+            fp16=True,
+            skip_to_glow=True,
         )
 
     def test_batchnorm_with_weights(self):
@@ -95,6 +99,10 @@ class TestQuantizedBatchNorm3D(unittest.TestCase):
         )
         model.eval()
 
-        jitVsGlow(
-            model, inputs, expected_fused_ops={"quantized::batch_norm3d"}, use_fp16=True
+        utils.compare_tracing_methods(
+            model,
+            inputs,
+            fusible_ops={"quantized::batch_norm3d"},
+            fp16=True,
+            skip_to_glow=True,
         )

--- a/torch_glow/tests/nodes/quantized_conv2d_relu_test.py
+++ b/torch_glow/tests/nodes/quantized_conv2d_relu_test.py
@@ -4,7 +4,7 @@ import unittest
 from collections import OrderedDict
 
 import torch
-from tests.utils import jitVsGlow
+from tests import utils
 
 
 class TestQuantizedConv2dRelu(unittest.TestCase):
@@ -49,14 +49,15 @@ class TestQuantizedConv2dRelu(unittest.TestCase):
             torch.quantization.prepare(model, inplace=True)
             torch.quantization.convert(model, inplace=True)
 
-            jitVsGlow(
+            utils.compare_tracing_methods(
                 model,
                 x,
-                expected_fused_ops={
+                fusible_ops={
                     "aten::quantize_per_tensor",
                     "quantized::conv2d_relu",
                     "aten::dequantize",
                 },
+                skip_to_glow=True,
             )
 
     def test_quantized_conv2d_relu_packed_groupwise(self):
@@ -105,9 +106,10 @@ class TestQuantizedConv2dRelu(unittest.TestCase):
             torch.quantization.prepare(model, inplace=True)
             torch.quantization.convert(model, inplace=True)
 
-            jitVsGlow(
+            utils.compare_tracing_methods(
                 model,
                 x,
-                expected_fused_ops={"quantized::conv2d_relu"},
-                black_list=["aten::quantize_per_tensor", "aten::dequantize"],
+                fusible_ops={"quantized::conv2d_relu"},
+                fusion_blocklist=["aten::quantize_per_tensor", "aten::dequantize"],
+                skip_to_glow=True,
             )

--- a/torch_glow/tests/nodes/quantized_conv2d_test.py
+++ b/torch_glow/tests/nodes/quantized_conv2d_test.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from tests import utils
 
 
 class TestQuantizedConv2d(unittest.TestCase):
@@ -11,12 +11,16 @@ class TestQuantizedConv2d(unittest.TestCase):
     def test_quantized_conv2d_unpacked(self):
         """Basic test of the PyTorch quantize::conv2d Node with unpacked weights on Glow."""
 
-        def test_f(a, w, b):
-            qu = torch.nn.quantized.Quantize(1 / 16, 0, torch.quint8)
-            qi = torch.nn.quantized.Quantize(1 / 16, 0, torch.qint8)
-            dq = torch.nn.quantized.DeQuantize()
-            conv = torch.nn.quantized.functional.conv2d
-            return dq(conv(qu(a), qi(w), b))
+        class SimpleQuantizedConvModel(torch.nn.Module):
+            def __init__(self):
+                super(SimpleQuantizedConvModel, self).__init__()
+
+            def forward(self, a, w, b):
+                qu = torch.nn.quantized.Quantize(1 / 16, 0, torch.quint8)
+                qi = torch.nn.quantized.Quantize(1 / 16, 0, torch.qint8)
+                dq = torch.nn.quantized.DeQuantize()
+                conv = torch.nn.quantized.functional.conv2d
+                return dq(conv(qu(a), qi(w), b))
 
         # TODO
         # Due to the quantization error between
@@ -31,28 +35,30 @@ class TestQuantizedConv2d(unittest.TestCase):
         b_zero = torch.zeros(1)
         b = torch.randn(1)
 
-        jitVsGlow(
-            test_f,
+        utils.compare_tracing_methods(
+            SimpleQuantizedConvModel(),
             x,
             w,
             b,
-            expected_fused_ops={
+            fusible_ops={
                 "aten::quantize_per_tensor",
                 "glow::unpacked_quantized_conv2d",
                 "aten::dequantize",
             },
+            skip_to_glow=True,
         )
 
-        jitVsGlow(
-            test_f,
+        utils.compare_tracing_methods(
+            SimpleQuantizedConvModel(),
             x,
             w,
             b_zero,
-            expected_fused_ops={
+            fusible_ops={
                 "aten::quantize_per_tensor",
                 "glow::unpacked_quantized_conv2d",
                 "aten::dequantize",
             },
+            skip_to_glow=True,
         )
 
     def test_quantized_conv2d_packed_groupwise(self):
@@ -78,10 +84,10 @@ class TestQuantizedConv2d(unittest.TestCase):
         torch.quantization.prepare(model, inplace=True)
         torch.quantization.convert(model, inplace=True)
 
-        jitVsGlow(
+        utils.compare_tracing_methods(
             model,
             x,
-            expected_fused_ops={
+            fusible_ops={
                 "aten::quantize_per_tensor",
                 "quantized::conv2d",
                 "aten::dequantize",
@@ -111,11 +117,12 @@ class TestQuantizedConv2d(unittest.TestCase):
         torch.quantization.prepare(model, inplace=True)
         torch.quantization.convert(model, inplace=True)
 
-        jitVsGlow(
+        utils.compare_tracing_methods(
             model,
             x,
-            expected_fused_ops={"quantized::conv2d"},
-            black_list=["aten::quantize_per_tensor", "aten::dequantize"],
+            fusible_ops={"quantized::conv2d"},
+            fusion_blocklist=["aten::quantize_per_tensor", "aten::dequantize"],
+            skip_to_glow=True,
         )
 
     def test_quantized_conv2d_packed_channelwise(self):
@@ -138,10 +145,10 @@ class TestQuantizedConv2d(unittest.TestCase):
 
             # TODO: acuracy needs to be investigated. Average acuracy is decent
             # but some elements have errors (possibly from rounding differences)
-            jitVsGlow(
+            utils.compare_tracing_methods(
                 model,
                 x,
-                expected_fused_ops={
+                fusible_ops={
                     "aten::quantize_per_tensor",
                     "quantized::conv2d",
                     "aten::dequantize",
@@ -184,10 +191,10 @@ class TestQuantizedConv2d(unittest.TestCase):
             model.forward(x)
             torch.quantization.convert(model, inplace=True)
 
-            jitVsGlow(
+            utils.compare_tracing_methods(
                 model,
                 x,
-                expected_fused_ops={
+                fusible_ops={
                     "aten::quantize_per_tensor",
                     "quantized::conv2d",
                     "aten::dequantize",
@@ -234,12 +241,13 @@ class TestQuantizedConv2d(unittest.TestCase):
             model.forward(x)
             torch.quantization.convert(model, inplace=True)
 
-            jitVsGlow(
+            utils.compare_tracing_methods(
                 model,
                 x,
-                expected_fused_ops={
+                fusible_ops={
                     "aten::quantize_per_tensor",
                     "quantized::conv2d",
                     "aten::dequantize",
                 },
+                skip_to_glow=True,
             )

--- a/torch_glow/tests/nodes/quantized_conv3d_relu_test.py
+++ b/torch_glow/tests/nodes/quantized_conv3d_relu_test.py
@@ -4,7 +4,7 @@ import unittest
 from collections import OrderedDict
 
 import torch
-from tests.utils import jitVsGlow
+from tests import utils
 
 
 class TestQuantizedConv3dRelu(unittest.TestCase):
@@ -50,14 +50,15 @@ class TestQuantizedConv3dRelu(unittest.TestCase):
             torch.quantization.prepare(model, inplace=True)
             torch.quantization.convert(model, inplace=True)
 
-            jitVsGlow(
+            utils.compare_tracing_methods(
                 model,
                 x,
-                expected_fused_ops={
+                fusible_ops={
                     "aten::quantize_per_tensor",
                     "quantized::conv3d_relu",
                     "aten::dequantize",
                 },
+                skip_to_glow=True,
             )
 
     def test_quantized_conv3d_relu_packed_groupwise(self):
@@ -107,9 +108,10 @@ class TestQuantizedConv3dRelu(unittest.TestCase):
             torch.quantization.prepare(model, inplace=True)
             torch.quantization.convert(model, inplace=True)
 
-            jitVsGlow(
+            utils.compare_tracing_methods(
                 model,
                 x,
-                expected_fused_ops={"quantized::conv3d_relu"},
-                black_list=["aten::quantize_per_tensor", "aten::dequantize"],
+                fusible_ops={"quantized::conv3d_relu"},
+                fusion_blocklist=["aten::quantize_per_tensor", "aten::dequantize"],
+                skip_to_glow=True,
             )

--- a/torch_glow/tests/nodes/quantized_conv3d_test.py
+++ b/torch_glow/tests/nodes/quantized_conv3d_test.py
@@ -4,11 +4,40 @@ import logging
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from tests import utils
 
 
 logger = logging.getLogger("quantized conv3d test")
 logger.setLevel(logging.INFO)
+
+
+class UnpackedConv3dModel(torch.nn.Module):
+    def __init__(self, input_quantization, weight_quantization):
+        super(UnpackedConv3dModel, self).__init__()
+        self.input_quantization = input_quantization
+        self.weight_quantization = weight_quantization
+
+    def forward(self, tensor, weight, bias):
+        return torch.nn.quantized.DeQuantize()(
+            torch.nn.quantized.functional.conv3d(
+                self.input_quantization(tensor), self.weight_quantization(weight), bias
+            )
+        )
+
+
+class PackedConv3dModel(torch.nn.Sequential):
+    def __init__(self, quantization, convolution, dequantization, weight, bias):
+        # Due to the off-by-one error, we cannot let the weights, bias & input
+        # to be totally random.
+        convolution.weight.data.fill_(weight)
+        convolution.bias.data.fill_(bias)
+        super(PackedConv3dModel, self).__init__(
+            quantization, convolution, dequantization
+        )
+        self.eval()
+        self.qconfig = torch.quantization.get_default_qconfig("fbgemm")
+        torch.quantization.prepare(self, inplace=True)
+        torch.quantization.convert(self, inplace=True)
 
 
 class TestQuantizedConv3d(unittest.TestCase):
@@ -36,28 +65,36 @@ class TestQuantizedConv3d(unittest.TestCase):
         b_zero = torch.zeros(1)
         b = torch.randn(1)
 
-        jitVsGlow(
-            test_f,
+        utils.compare_tracing_methods(
+            UnpackedConv3dModel(
+                torch.nn.quantized.Quantize(1 / 16, 0, torch.quint8),
+                torch.nn.quantized.Quantize(1 / 16, 0, torch.qint8),
+            ),
             x,
             w,
             b,
-            expected_fused_ops={
+            fusible_ops={
                 "aten::quantize_per_tensor",
                 "glow::unpacked_quantized_conv3d",
                 "aten::dequantize",
             },
+            skip_to_glow=True,
         )
 
-        jitVsGlow(
-            test_f,
+        utils.compare_tracing_methods(
+            UnpackedConv3dModel(
+                torch.nn.quantized.Quantize(1 / 16, 0, torch.quint8),
+                torch.nn.quantized.Quantize(1 / 16, 0, torch.qint8),
+            ),
             x,
             w,
             b_zero,
-            expected_fused_ops={
+            fusible_ops={
                 "aten::quantize_per_tensor",
                 "glow::unpacked_quantized_conv3d",
                 "aten::dequantize",
             },
+            skip_to_glow=True,
         )
 
     def test_quantized_conv3d_packed_groupwise(self):
@@ -68,26 +105,17 @@ class TestQuantizedConv3d(unittest.TestCase):
         x = torch.cat((x, x, x))
         x = torch.cat((x, x, x))
         x = torch.reshape(x, [1, 3, 3, 5, 5])
-        q = torch.nn.quantized.Quantize(0.1, 2, torch.quint8)
-        conv = torch.nn.Conv3d(3, 3, kernel_size=1, stride=(1, 1, 1), groups=3)
-        dq = torch.nn.quantized.DeQuantize()
 
-        # Due to the off-by-one error, we cannot let the weights, bias & input
-        # to be totally random.
-        conv.weight.data.fill_(2.0)
-        conv.bias.data.fill_(1.0)
-
-        model = torch.nn.Sequential(q, conv, dq)
-        model.eval()
-        model.qconfig = torch.quantization.get_default_qconfig("fbgemm")
-
-        torch.quantization.prepare(model, inplace=True)
-        torch.quantization.convert(model, inplace=True)
-
-        jitVsGlow(
-            model,
+        utils.compare_tracing_methods(
+            PackedConv3dModel(
+                torch.nn.quantized.Quantize(0.1, 2, torch.quint8),
+                torch.nn.Conv3d(3, 3, kernel_size=1, stride=(1, 1, 1), groups=3),
+                torch.nn.quantized.DeQuantize(),
+                2.0,
+                1.0,
+            ),
             x,
-            expected_fused_ops={
+            fusible_ops={
                 "aten::quantize_per_tensor",
                 "quantized::conv3d",
                 "aten::dequantize",
@@ -102,27 +130,18 @@ class TestQuantizedConv3d(unittest.TestCase):
         x = torch.cat((x, x, x))
         x = torch.cat((x, x, x))
         x = torch.reshape(x, [1, 3, 3, 5, 5])
-        q = torch.nn.quantized.Quantize(0.1, 2, torch.quint8)
-        conv = torch.nn.Conv3d(3, 3, kernel_size=1, stride=(1, 1, 1), groups=3)
-        dq = torch.nn.quantized.DeQuantize()
 
-        # Due to the off-by-one error, we cannot let the weights, bias & input
-        # to be totally random.
-        conv.weight.data.fill_(2.0)
-        conv.bias.data.fill_(1.0)
-
-        model = torch.nn.Sequential(q, conv, dq)
-        model.eval()
-        model.qconfig = torch.quantization.get_default_qconfig("fbgemm")
-
-        torch.quantization.prepare(model, inplace=True)
-        torch.quantization.convert(model, inplace=True)
-
-        jitVsGlow(
-            model,
+        utils.compare_tracing_methods(
+            PackedConv3dModel(
+                torch.nn.quantized.Quantize(0.1, 2, torch.quint8),
+                torch.nn.Conv3d(3, 3, kernel_size=1, stride=(1, 1, 1), groups=3),
+                torch.nn.quantized.DeQuantize(),
+                2.0,
+                1.0,
+            ),
             x,
-            expected_fused_ops={"quantized::conv3d"},
-            black_list=["aten::quantize_per_tensor", "aten::dequantize"],
+            fusible_ops={"quantized::conv3d"},
+            fusion_blocklist=["aten::quantize_per_tensor", "aten::dequantize"],
         )
 
     def test_quantized_conv3d_packed_channelwise(self):
@@ -145,10 +164,10 @@ class TestQuantizedConv3d(unittest.TestCase):
 
             # TODO: acuracy needs to be investigated. Average acuracy is decent
             # but some elements have errors (possibly from rounding differences)
-            jitVsGlow(
+            utils.compare_tracing_methods(
                 model,
                 x,
-                expected_fused_ops={
+                fusible_ops={
                     "aten::quantize_per_tensor",
                     "quantized::conv3d",
                     "aten::dequantize",

--- a/torch_glow/tests/nodes/quantized_linear_test.py
+++ b/torch_glow/tests/nodes/quantized_linear_test.py
@@ -1,126 +1,87 @@
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from parameterized import parameterized
+from tests import utils
+
+
+class SimpleQuantizedLinearModel(torch.nn.Sequential):
+    def __init__(self, in_features, out_features, quantization, weight=None, bias=None):
+        linear = torch.nn.Linear(in_features, out_features)
+        if weight:
+            linear.weight.data.fill_(weight)
+        else:
+            linear.weight.data.random_(0, 100)
+        if bias:
+            linear.bias.data.fill_(bias)
+        else:
+            linear.bias.data.random_(0, 10)
+        super(SimpleQuantizedLinearModel, self).__init__(
+            quantization, linear, torch.nn.quantized.DeQuantize()
+        )
+        self.qconfig = torch.quantization.get_default_qconfig("fbgemm")
+        torch.quantization.prepare(self, inplace=True)
+        torch.quantization.convert(self, inplace=True)
+
+
+def _make_input(size, duplications, shape, dtype=torch.float):
+    tensor = torch.tensor(range(size), dtype=dtype)
+    tensor = torch.cat(tuple(tensor for _ in range(duplications)))
+    tensor = torch.reshape(tensor, shape)
+    return tensor
 
 
 class TestQuantizedLinear(unittest.TestCase):
-    def test_quantized_linear_packed(self):
-        """Basic test of the PyTorch quantized::linear Node on Glow."""
-
-        q = torch.nn.quantized.Quantize(scale=1 / 25, zero_point=17, dtype=torch.quint8)
-        dq = torch.nn.quantized.DeQuantize()
-
-        linear = torch.nn.Linear(5, 5)
-
-        linear.weight.data.fill_(1.2)
-        linear.bias.data.fill_(3.0)
-
-        model = torch.nn.Sequential(q, linear, dq)
-        model.qconfig = torch.quantization.get_default_qconfig("fbgemm")
-        torch.quantization.prepare(model, inplace=True)
-        torch.quantization.convert(model, inplace=True)
-
-        x = torch.tensor(range(5), dtype=torch.float)
-        x = torch.cat((x, x, x, x, x, x))
-        x = torch.reshape(x, [3, 2, 5])
-
-        jitVsGlow(
-            model,
-            x,
-            expected_fused_ops={
-                "aten::quantize_per_tensor",
-                "quantized::linear",
-                "aten::dequantize",
-            },
-        )
-
-    def test_quantized_linear_packed_dq_cut(self):
-        """Basic test of the PyTorch quantized::linear Node on Glow, with dequantize excluded. """
-
-        q = torch.nn.quantized.Quantize(scale=1 / 25, zero_point=17, dtype=torch.quint8)
-        dq = torch.nn.quantized.DeQuantize()
-
-        linear = torch.nn.Linear(5, 5)
-
-        linear.weight.data.fill_(1.2)
-        linear.bias.data.fill_(3.0)
-
-        model = torch.nn.Sequential(q, linear, dq)
-        model.qconfig = torch.quantization.get_default_qconfig("fbgemm")
-        torch.quantization.prepare(model, inplace=True)
-        torch.quantization.convert(model, inplace=True)
-
-        x = torch.tensor(range(5), dtype=torch.float)
-        x = torch.cat((x, x, x, x, x))
-        x = torch.reshape(x, [5, 5])
-
-        jitVsGlow(
-            model,
-            x,
-            expected_fused_ops={"aten::quantize_per_tensor", "quantized::linear"},
-            black_list=["aten::dequantize"],
-        )
-
-    @unittest.skip(reason="random input could cause flaky")
-    def test_quantized_linear_random_input(self):
-        """Basic test of the PyTorch quantized::linear Node on Glow."""
-
-        def test_f(inputs, weights, bias=None):
-            q_int = torch.nn.quantized.Quantize(
-                scale=1 / 13, zero_point=0, dtype=torch.qint8
-            )
-            q_uint = torch.nn.quantized.Quantize(
-                scale=1 / 13, zero_point=10, dtype=torch.quint8
-            )
-
-            dq = torch.nn.quantized.DeQuantize()
-
-            q_inputs = q_uint(inputs)
-            q_weights = q_int(weights)
-
-            return dq(torch.nn.quantized.functional.linear(q_inputs, q_weights, bias))
-
-        for _ in range(100):
-            inputs = torch.randn(7, 7)
-            weights = torch.randn(7, 7)
-
-            bias = torch.tensor([1, 1, 1, 1, 1, 1, 1], dtype=torch.float) * 0.1
-
-            jitVsGlow(
-                test_f,
-                inputs,
-                weights,
-                bias,
-                expected_fused_ops={
-                    "glow::unpacked_quantized_linear",
-                    "aten::quantize_per_tensor",
-                    "aten::dequantize",
-                },
-            )
-
-    def test_quantized_linear_packed_rowwise(self):
-        """Basic test of the PyTorch quantized::linear Node with rowwise quantized
-        packed weights on Glow."""
-
-        linear = torch.nn.Linear(6, 5)
-        linear.weight.data.random_(0, 100)
-        linear.bias.data.random_(0, 10)
-
-        x = torch.tensor(range(36), dtype=torch.float)
-        x = torch.reshape(x, [3, 2, 6])
-
-        model = torch.quantization.QuantWrapper(linear)
-        model.qconfig = torch.quantization.get_default_qconfig("fbgemm")
-        torch.quantization.prepare(model, inplace=True)
-        torch.quantization.convert(model, inplace=True)
-
-        jitVsGlow(
-            model,
-            x,
-            expected_fused_ops={
-                "aten::quantize_per_tensor",
-                "quantized::linear",
-                "aten::dequantize",
-            },
+    @parameterized.expand(
+        [
+            (
+                "basic",
+                SimpleQuantizedLinearModel(
+                    5,
+                    5,
+                    torch.nn.quantized.Quantize(
+                        scale=1 / 25, zero_point=17, dtype=torch.quint8
+                    ),
+                    1.2,
+                    3.0,
+                ),
+                _make_input(5, 6, [3, 2, 5]),
+            ),
+            (
+                "exclude_dq",
+                SimpleQuantizedLinearModel(
+                    5,
+                    5,
+                    torch.nn.quantized.Quantize(
+                        scale=1 / 25, zero_point=17, dtype=torch.quint8
+                    ),
+                    1.2,
+                    3.0,
+                ),
+                _make_input(5, 6, [3, 2, 5]),
+                {"aten::dequantize"},
+            ),
+            (
+                "rowwise",
+                SimpleQuantizedLinearModel(
+                    6,
+                    5,
+                    torch.nn.quantized.Quantize(
+                        scale=1 / 25, zero_point=17, dtype=torch.quint8
+                    ),
+                ),
+                _make_input(36, 1, [3, 2, 6]),
+                {"aten::dequantize"},
+            ),
+        ]
+    )
+    def test_quantized_linear(self, _, model, tensor, fusion_blocklist=None):
+        fusible_ops = {
+            "aten::quantize_per_tensor",
+            "quantized::linear",
+            "aten::dequantize",
+        }
+        fusible_ops -= fusion_blocklist or set()
+        utils.compare_tracing_methods(
+            model, tensor, fusible_ops=fusible_ops, fusion_blocklist=fusion_blocklist
         )

--- a/torch_glow/tests/nodes/quantized_mul_test.py
+++ b/torch_glow/tests/nodes/quantized_mul_test.py
@@ -3,145 +3,149 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from parameterized import parameterized
+from tests import utils
+
+
+class SimpleQuantizedMulModel(torch.nn.Module):
+    def __init__(
+        self, left_quantization, right_quantization=None, scale=None, zero_point=None
+    ):
+        super(SimpleQuantizedMulModel, self).__init__()
+        self.scale = scale
+        self.zero_point = zero_point
+        self.left_quantization = left_quantization
+        self.right_quantization = right_quantization or left_quantization
+
+    def forward(self, tensor, other):
+        if other.size() == torch.Size([]):
+            return torch.nn.quantized.DeQuantize()(
+                torch.ops.quantized.mul(self.left_quantization(tensor), other.item())
+            )
+        else:
+            return torch.nn.quantized.DeQuantize()(
+                torch.ops.quantized.mul(
+                    self.left_quantization(tensor),
+                    self.right_quantization(other),
+                    scale=self.scale,
+                    zero_point=self.zero_point,
+                )
+            )
 
 
 class TestQuantizedMul(unittest.TestCase):
-    def test_quantized_mul_zerooffset(self):
-        """Basic test of the PyTorch quantized::mul Node on Glow with zero offset."""
-
-        def test_f(a, b):
-            q = torch.nn.quantized.Quantize(scale=0.3, zero_point=0, dtype=torch.quint8)
-            dq = torch.nn.quantized.DeQuantize()
-            return dq(torch.ops.quantized.mul(q(a), q(b), scale=0.05, zero_point=0))
-
-        x = torch.tensor([1, 2, 3, 4], dtype=torch.float32)
-        y = torch.tensor([5, 6, 7, 8], dtype=torch.float32)
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={"quantized::mul"})
-
-    def test_quantized_mul(self):
-        """Basic test of the PyTorch quantized::mul Node on Glow."""
-
-        def test_f(a, b):
-            q1 = torch.nn.quantized.Quantize(
-                scale=0.2, zero_point=1, dtype=torch.quint8
-            )
-            q2 = torch.nn.quantized.Quantize(
-                scale=0.2, zero_point=1, dtype=torch.quint8
-            )
-            dq = torch.nn.quantized.DeQuantize()
-            return dq(torch.ops.quantized.mul(q1(a), q2(b), scale=0.2, zero_point=3))
-
-        x = torch.randn([5, 5])
-        y = torch.randn([5, 5])
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={"quantized::mul"})
-
-    def test_quantized_mul_cut_q_dq(self):
-        """Basic test of the PyTorch quantized::mul Node on Glow, with quantize and dequantize excluded. """
-
-        def test_f(a, b):
-            q1 = torch.nn.quantized.Quantize(
-                scale=0.2, zero_point=5, dtype=torch.quint8
-            )
-            q2 = torch.nn.quantized.Quantize(
-                scale=0.2, zero_point=10, dtype=torch.quint8
-            )
-            dq = torch.nn.quantized.DeQuantize()
-            return dq(torch.ops.quantized.mul(q1(a), q2(b), scale=0.2, zero_point=3))
-
-        x = torch.randn([5, 5])
-        y = torch.randn([5, 5])
-
-        jitVsGlow(
-            test_f,
-            x,
-            y,
-            expected_fused_ops={"quantized::mul"},
-            black_list=["aten::quantize_per_tensor", "aten::dequantize"],
+    @parameterized.expand(
+        [
+            (
+                "zero_offset",
+                SimpleQuantizedMulModel(
+                    torch.nn.quantized.Quantize(
+                        scale=0.3, zero_point=0, dtype=torch.quint8
+                    ),
+                    torch.nn.quantized.Quantize(
+                        scale=0.3, zero_point=0, dtype=torch.quint8
+                    ),
+                    0.05,
+                    0,
+                ),
+                torch.tensor([1, 2, 3, 4], dtype=torch.float32),
+                torch.tensor([5, 6, 7, 8], dtype=torch.float32),
+            ),
+            (
+                "basic",
+                SimpleQuantizedMulModel(
+                    torch.nn.quantized.Quantize(
+                        scale=0.2, zero_point=1, dtype=torch.quint8
+                    ),
+                    torch.nn.quantized.Quantize(
+                        scale=0.2, zero_point=1, dtype=torch.quint8
+                    ),
+                    0.2,
+                    3,
+                ),
+                torch.randn([5, 5]),
+                torch.randn([5, 5]),
+            ),
+            (
+                "cut_q_dq",
+                SimpleQuantizedMulModel(
+                    torch.nn.quantized.Quantize(
+                        scale=0.2, zero_point=5, dtype=torch.quint8
+                    ),
+                    torch.nn.quantized.Quantize(
+                        scale=0.2, zero_point=10, dtype=torch.quint8
+                    ),
+                    0.2,
+                    3,
+                ),
+                torch.randn([5, 5]),
+                torch.randn([5, 5]),
+                ["aten::quantize_per_tensor", "aten::dequantize"],
+            ),
+            (
+                "broadcast",
+                SimpleQuantizedMulModel(
+                    torch.nn.quantized.Quantize(
+                        scale=0.2, zero_point=1, dtype=torch.quint8
+                    ),
+                    torch.nn.quantized.Quantize(
+                        scale=0.2, zero_point=1, dtype=torch.quint8
+                    ),
+                    0.2,
+                    3,
+                ),
+                torch.randn([1, 5, 6, 6]),
+                torch.randn([1, 5, 1, 1]),
+                ["aten::quantize_per_tensor", "aten::dequantize"],
+            ),
+            (
+                "positive_scalar",
+                SimpleQuantizedMulModel(
+                    torch.nn.quantized.Quantize(
+                        scale=0.05, zero_point=1, dtype=torch.quint8
+                    ),
+                ),
+                torch.randn(1, 2, 3, 4),
+                torch.tensor(3.14),
+            ),
+            (
+                "negative_scalar",
+                SimpleQuantizedMulModel(
+                    torch.nn.quantized.Quantize(
+                        scale=0.05, zero_point=2, dtype=torch.quint8
+                    ),
+                ),
+                torch.randn(1, 2, 3, 4),
+                torch.tensor(-3.14),
+            ),
+            (
+                "zero_scalar",
+                SimpleQuantizedMulModel(
+                    torch.nn.quantized.Quantize(
+                        scale=0.05, zero_point=2, dtype=torch.quint8
+                    ),
+                ),
+                torch.randn(1, 2, 3, 4),
+                torch.tensor(0.00),
+            ),
+            (
+                "negative_int8_scalar",
+                SimpleQuantizedMulModel(
+                    torch.nn.quantized.Quantize(
+                        scale=0.05, zero_point=4, dtype=torch.qint8
+                    ),
+                ),
+                torch.randn(1, 2, 3, 4),
+                torch.tensor(-1.43),
+            ),
+        ]
+    )
+    def test_quantized_mul(self, _, module, tensor, other, fusion_blocklist=None):
+        utils.compare_tracing_methods(
+            module,
+            tensor,
+            other,
+            fusible_ops={"quantized::mul"},
+            fusion_blocklist=fusion_blocklist,
+            skip_to_glow=True,
         )
-
-    def test_quantized_mul_with_broadcast(self):
-        """Test of the PyTorch quantized::mul Node with broadcast on Glow."""
-
-        def test_f(a, b):
-            q1 = torch.nn.quantized.Quantize(
-                scale=0.2, zero_point=1, dtype=torch.quint8
-            )
-            q2 = torch.nn.quantized.Quantize(
-                scale=0.2, zero_point=1, dtype=torch.quint8
-            )
-            dq = torch.nn.quantized.DeQuantize()
-            return dq(torch.ops.quantized.mul(q1(a), q2(b), scale=0.2, zero_point=3))
-
-        x = torch.randn([1, 5, 6, 6])
-        y = torch.randn([1, 5, 1, 1])
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={"quantized::mul"})
-
-    def test_quantized_mul_positive_scalar(self):
-        """Test of PyTorch quantized::mul with scalar rhs Node on Glow."""
-
-        def test_f(a):
-            q = torch.nn.quantized.Quantize(
-                scale=0.05, zero_point=1, dtype=torch.quint8
-            )
-            dq = torch.nn.quantized.DeQuantize()
-            return dq(torch.ops.quantized.mul(q(a), 3.14))
-
-        x = torch.randn(1, 2, 3, 4)
-
-        jitVsGlow(test_f, x, expected_fused_ops={"quantized::mul"})
-
-    def test_quantized_mul_negative_scalar(self):
-        """Test of PyTorch quantized::mul with scalar rhs Node on Glow."""
-
-        def test_f(a):
-            q = torch.nn.quantized.Quantize(
-                scale=0.05, zero_point=2, dtype=torch.quint8
-            )
-            dq = torch.nn.quantized.DeQuantize()
-            return dq(torch.ops.quantized.mul(q(a), -3.14))
-
-        x = torch.randn(1, 2, 3, 4)
-
-        jitVsGlow(test_f, x, expected_fused_ops={"quantized::mul"})
-
-    def test_quantized_mul_zero_scalar(self):
-        """Test of PyTorch quantized::mul with scalar rhs Node on Glow."""
-
-        def test_f(a):
-            q = torch.nn.quantized.Quantize(
-                scale=0.05, zero_point=3, dtype=torch.quint8
-            )
-            dq = torch.nn.quantized.DeQuantize()
-            return dq(torch.ops.quantized.mul(q(a), 0.0))
-
-        x = torch.randn(1, 2, 3, 4)
-
-        jitVsGlow(test_f, x, expected_fused_ops={"quantized::mul"})
-
-    def test_quantized_mul_negative_int8_scalar(self):
-        """Test of PyTorch quantized::mul with int8 quantized scalar rhs Node on Glow."""
-
-        def test_f(a):
-            q = torch.nn.quantized.Quantize(scale=0.05, zero_point=4, dtype=torch.qint8)
-            dq = torch.nn.quantized.DeQuantize()
-            return dq(torch.ops.quantized.mul(q(a), -1.43))
-
-        x = torch.randn(1, 2, 3, 4)
-
-        jitVsGlow(test_f, x, expected_fused_ops={"quantized::mul"})
-
-    def test_quantized_mul_scalar_negative(self):
-        """Test of PyTorch quantized::mul_scalar with scalar rhs Node on Glow."""
-
-        def test_f(a):
-            q = torch.nn.quantized.Quantize(scale=0.05, zero_point=4, dtype=torch.qint8)
-            dq = torch.nn.quantized.DeQuantize()
-            return dq(torch.ops.quantized.mul_scalar(q(a), -3.41))
-
-        x = torch.randn(1, 2, 3, 4)
-
-        jitVsGlow(test_f, x, expected_fused_ops={"quantized::mul_scalar"})

--- a/torch_glow/tests/nodes/quantized_relu_test.py
+++ b/torch_glow/tests/nodes/quantized_relu_test.py
@@ -3,49 +3,41 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimpleQuantizedReluModel(torch.nn.Module):
+    def __init__(self, scale, zero_point, dtype):
+        super(SimpleQuantizedReluModel, self).__init__()
+        self.scale = scale
+        self.zero_point = zero_point
+        self.dtype = dtype
+
+    def forward(self, tensor):
+        quantize = torch.nn.quantized.Quantize(
+            scale=self.scale, zero_point=self.zero_point, dtype=self.dtype
+        )
+        dequantize = torch.nn.quantized.DeQuantize()
+        relu = torch.nn.quantized.ReLU()
+        return dequantize(relu(quantize(tensor)))
 
 
 class TestQuantizedRelu(unittest.TestCase):
     def test_quantized_relu(self):
         """Basic test of the PyTorch quantized::relu Node on Glow."""
 
-        def test_f(a):
-            q = torch.nn.quantized.Quantize(
-                scale=1.0 / 128, zero_point=3, dtype=torch.quint8
-            )
-            dq = torch.nn.quantized.DeQuantize()
-            re = torch.nn.quantized.ReLU()
-            return dq(re(q(a)))
-
-        x = torch.randn([5, 5])
-
-        jitVsGlow(
-            test_f,
-            x,
-            expected_fused_ops={
-                "aten::relu",
-                "aten::quantize_per_tensor",
-                "aten::dequantize",
-            },
+        utils.compare_tracing_methods(
+            SimpleQuantizedReluModel(1.0 / 128, 3, torch.quint8),
+            torch.randn([5, 5]),
+            fusible_ops={"aten::relu", "aten::quantize_per_tensor", "aten::dequantize"},
         )
 
     def test_quantized_relu_cut_dq(self):
         """Basic test of the PyTorch quantized::relu Node on Glow, with quantize and dequantize excluded. """
 
-        def test_f(a):
-            q = torch.nn.quantized.Quantize(
-                scale=1.0 / 128, zero_point=3, dtype=torch.quint8
-            )
-            dq = torch.nn.quantized.DeQuantize()
-            re = torch.nn.quantized.ReLU()
-            return dq(re(q(a)))
-
-        x = torch.randn([5, 5])
-
-        jitVsGlow(
-            test_f,
-            x,
-            expected_fused_ops={"aten::quantize_per_tensor", "aten::relu"},
-            black_list=["aten::dequantize"],
+        utils.compare_tracing_methods(
+            SimpleQuantizedReluModel(1.0 / 128, 3, torch.quint8),
+            torch.randn([5, 5]),
+            fusible_ops={"aten::relu", "aten::quantize_per_tensor"},
+            fusion_blocklist=["aten::dequantize"],
         )

--- a/torch_glow/tests/nodes/reciprocal_test.py
+++ b/torch_glow/tests/nodes/reciprocal_test.py
@@ -3,28 +3,33 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimpleReciprocalModel(torch.nn.Module):
+    def __init__(self, inplace=False):
+        super(SimpleReciprocalModel, self).__init__()
+        self.inplace = inplace
+
+    def forward(self, tensor):
+        other = tensor + tensor
+        return other.reciprocal_() if self.inplace else torch.reciprocal(other)
 
 
 class TestReciprocal(unittest.TestCase):
     def test_reciprocal(self):
         """Test of the PyTorch reciprocal Node on Glow."""
 
-        def test_f(a):
-            return torch.reciprocal(a + a)
-
-        x = torch.randn(4)
-
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::reciprocal"})
+        utils.compare_tracing_methods(
+            SimpleReciprocalModel(), torch.randn(4), fusible_ops={"aten::reciprocal"}
+        )
 
     def test_inplace_reciprocal(self):
         """Test of the PyTorch inplace reciprocal Node on Glow."""
 
-        def test_f(a):
-            b = a + a
-            return b.reciprocal_()
-
-        x = torch.randn(4)
-
         # Expect fuser to out-of-place the operator
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::reciprocal"})
+        utils.compare_tracing_methods(
+            SimpleReciprocalModel(inplace=True),
+            torch.randn(4),
+            fusible_ops={"aten::reciprocal"},
+        )

--- a/torch_glow/tests/nodes/relu_test.py
+++ b/torch_glow/tests/nodes/relu_test.py
@@ -4,32 +4,36 @@ import unittest
 
 import torch
 import torch.nn.functional as F
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimpleReluModel(torch.nn.Module):
+    def __init__(self, inplace=False):
+        super(SimpleReluModel, self).__init__()
+        self.inplace = inplace
+
+    def forward(self, tensor):
+        other = F.relu(tensor, inplace=self.inplace)
+        return F.relu(other, inplace=self.inplace)
 
 
 class TestRelu(unittest.TestCase):
     def test_relu_basic(self):
         """Basic test of the PyTorch relu Node on Glow."""
 
-        def test_f(a):
-            b = F.relu(a)
-            return F.relu(b)
-
         x = torch.randn(4)
         # make sure we have at least one negative
         x[0] = -2.0
 
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::relu"})
+        utils.compare_tracing_methods(SimpleReluModel(), x, fusible_ops={"aten::relu"})
 
     def test_relu_inplace(self):
         """Test of the PyTorch relu_ Node on Glow."""
 
-        def test_f(a):
-            b = F.relu(a, inplace=True)
-            return F.relu(b, inplace=True)
-
         x = torch.randn(4)
         # make sure we have at least one negative
         x[0] = -2.0
 
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::relu_"})
+        utils.compare_tracing_methods(
+            SimpleReluModel(inplace=True), x, fusible_ops={"aten::relu_"}
+        )

--- a/torch_glow/tests/nodes/reshape_test.py
+++ b/torch_glow/tests/nodes/reshape_test.py
@@ -3,17 +3,25 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimpleReshapeModel(torch.nn.Module):
+    def __init__(self, shape):
+        super(SimpleReshapeModel, self).__init__()
+        self.shape = shape
+
+    def forward(self, tensor):
+        combined = tensor + tensor
+        return combined.reshape(self.shape)
 
 
 class TestReshape(unittest.TestCase):
     def test_reshape(self):
         """Test of the PyTorch reshape Node on Glow."""
 
-        def test_f(a):
-            b = a + a
-            return b.reshape([2, -1])
-
-        x = torch.rand(2, 3, 4)
-
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::reshape"})
+        utils.compare_tracing_methods(
+            SimpleReshapeModel([2, -1]),
+            torch.rand(2, 3, 4),
+            fusible_ops={"aten::reshape"},
+        )

--- a/torch_glow/tests/nodes/roi_align_rotated_test.py
+++ b/torch_glow/tests/nodes/roi_align_rotated_test.py
@@ -3,16 +3,17 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from parameterized import parameterized
+from tests import utils
 
 
-def rand_rotated_rois(N, H, W, num_rois, horizontal=False):
+def rand_rotated_rois(N, H, W, count, horizontal=False):
     W -= 1
     H -= 1
 
-    rois = torch.rand((num_rois, 6))
+    rois = torch.rand((count, 6))
 
-    for i in range(num_rois):
+    for i in range(count):
         rois[i][0] = (N * rois[i][0]) // 1  # batch index
 
         rois[i][1] *= W - 1  # center_x
@@ -35,203 +36,66 @@ def rand_rotated_rois(N, H, W, num_rois, horizontal=False):
     return rois
 
 
+class SimpleRoiAlignRotatedModel(torch.nn.Module):
+    def __init__(
+        self,
+        order,
+        spatial_scale=1.0,
+        pooled_h=6,
+        pooled_w=6,
+        sampling_ratio=2,
+        aligned=True,
+    ):
+        super(SimpleRoiAlignRotatedModel, self).__init__()
+        self.kwargs = {
+            "order": order,
+            "spatial_scale": spatial_scale,
+            "pooled_h": pooled_h,
+            "pooled_w": pooled_w,
+            "sampling_ratio": sampling_ratio,
+            "aligned": aligned,
+        }
+
+    def forward(self, features, rois):
+        return torch.ops._caffe2.RoIAlignRotated(features, rois, **self.kwargs)
+
+
 class TestRoiAlignRotated(unittest.TestCase):
-    def test_roi_align_rotated_basic(self):
-        """Test of the _caffe2::RoIAlignRotated Node on Glow."""
+    """TODO: Combine with TestRoiAlign"""
 
-        def test_f(features, rois):
-            return torch.ops._caffe2.RoIAlignRotated(
-                features,
-                rois,
-                order="NCHW",
-                spatial_scale=1.0,
-                pooled_h=6,
-                pooled_w=6,
-                sampling_ratio=2,
-                aligned=True,
-            )
-
-        N, C, H, W = 1, 3, 16, 20
-
-        features = torch.randn(N, C, H, W)
-        rois = rand_rotated_rois(N, H, W, 250)
-
-        jitVsGlow(
-            test_f, features, rois, expected_fused_ops={"_caffe2::RoIAlignRotated"}
-        )
-
-    def test_roi_align_rotated_nhwc(self):
-        """Test of the _caffe2::RoIAlignRotated Node on Glow."""
-
-        def test_f(features, rois):
-            return torch.ops._caffe2.RoIAlignRotated(
-                features,
-                rois,
-                order="NHWC",
-                spatial_scale=1.0,
-                pooled_h=6,
-                pooled_w=6,
-                sampling_ratio=2,
-                aligned=True,
-            )
-
-        N, C, H, W = 1, 3, 16, 20
-
-        features = torch.randn(N, H, W, C)
-        rois = rand_rotated_rois(N, H, W, 250)
-
-        jitVsGlow(
-            test_f, features, rois, expected_fused_ops={"_caffe2::RoIAlignRotated"}
-        )
-
-    def test_roi_align_rotated_horizontal(self):
-        """Test of the _caffe2::RoIAlignRotated Node on Glow."""
-
-        def test_f(features, rois):
-            return torch.ops._caffe2.RoIAlignRotated(
-                features,
-                rois,
-                order="NHWC",
-                spatial_scale=1.0,
-                pooled_h=6,
-                pooled_w=6,
-                sampling_ratio=2,
-                aligned=True,
-            )
-
-        N, C, H, W = 1, 3, 16, 20
-
-        features = torch.randn(N, H, W, C)
-        rois = rand_rotated_rois(N, H, W, 250, horizontal=True)
-
-        jitVsGlow(
-            test_f, features, rois, expected_fused_ops={"_caffe2::RoIAlignRotated"}
-        )
-
-    def test_roi_align_rotated_batched(self):
-        """Test of the _caffe2::RoIAlignRotated Node on Glow."""
-
-        def test_f(features, rois):
-            return torch.ops._caffe2.RoIAlignRotated(
-                features,
-                rois,
-                order="NCHW",
-                spatial_scale=1.0,
-                pooled_h=6,
-                pooled_w=6,
-                sampling_ratio=2,
-                aligned=True,
-            )
-
-        N, C, H, W = 4, 3, 16, 20
-
-        features = torch.randn(N, C, H, W)
-        rois = rand_rotated_rois(N, H, W, 250)
-
-        jitVsGlow(
-            test_f, features, rois, expected_fused_ops={"_caffe2::RoIAlignRotated"}
-        )
-
-    def test_roi_align_rotated_scaled(self):
-        """Test of the _caffe2::RoIAlignRotated Node on Glow."""
-
-        def test_f(features, rois):
-            return torch.ops._caffe2.RoIAlignRotated(
-                features,
-                rois,
-                order="NCHW",
-                spatial_scale=0.0625,
-                pooled_h=6,
-                pooled_w=6,
-                sampling_ratio=2,
-                aligned=True,
-            )
-
-        N, C, H, W = 1, 3, 224, 224
-
-        features = torch.randn(N, C, H, W)
-        rois = rand_rotated_rois(N, H, W, 10)
-
-        jitVsGlow(
-            test_f, features, rois, expected_fused_ops={"_caffe2::RoIAlignRotated"}
-        )
-
-    def test_roi_align_rotated_unaligned(self):
-        """Test of the _caffe2::RoIAlignRotated Node on Glow."""
-
-        def test_f(features, rois):
-            return torch.ops._caffe2.RoIAlignRotated(
-                features,
-                rois,
-                order="NCHW",
-                spatial_scale=1.0,
-                pooled_h=6,
-                pooled_w=6,
-                sampling_ratio=2,
-                aligned=False,
-            )
-
-        N, C, H, W = 1, 3, 16, 20
-
-        features = torch.randn(N, C, H, W)
-        rois = rand_rotated_rois(N, H, W, 250)
-
-        jitVsGlow(
-            test_f, features, rois, expected_fused_ops={"_caffe2::RoIAlignRotated"}
-        )
-
-    def test_roi_align_rotated_dynamic_sampling(self):
-        """Test of the _caffe2::RoIAlignRotated Node on Glow."""
-
-        def test_f(features, rois):
-            return torch.ops._caffe2.RoIAlignRotated(
-                features,
-                rois,
-                order="NCHW",
-                spatial_scale=1.0,
-                pooled_h=6,
-                pooled_w=6,
-                sampling_ratio=0,
-                aligned=True,
-            )
-
-        N, C, H, W = 1, 3, 224, 224
-
-        features = torch.randn(N, C, H, W)
-        rois = rand_rotated_rois(N, H, W, 10)
-
-        jitVsGlow(
-            test_f, features, rois, expected_fused_ops={"_caffe2::RoIAlignRotated"}
-        )
-
-    def test_roi_align_rotated_fp16(self):
-        """Test of the _caffe2::RoIAlignRotated Node on Glow."""
-
-        def test_f(features, rois):
-            return torch.ops._caffe2.RoIAlignRotated(
-                features,
-                rois,
-                order="NCHW",
-                spatial_scale=1.0,
-                pooled_h=6,
-                pooled_w=6,
-                sampling_ratio=2,
-                aligned=True,
-            )
-
-        N, C, H, W = 1, 3, 16, 20
-
-        features = torch.randn(N, C, H, W)
-        rois = rand_rotated_rois(N, H, W, 250)
-
-        # atol/rtol must be high because maximum delta can be high due to shifts
-        # in sampling points due to fp16 rounding of coordinates.
-        jitVsGlow(
-            test_f,
-            features,
-            rois,
-            expected_fused_ops={"_caffe2::RoIAlignRotated"},
-            use_fp16=True,
-            atol=0.5,
-            rtol=0.5,
+    @parameterized.expand(
+        [
+            ("basic", SimpleRoiAlignRotatedModel("NCHW"), torch.randn(1, 3, 16, 20)),
+            ("nhwc", SimpleRoiAlignRotatedModel("NHWC"), torch.randn(1, 16, 20, 3)),
+            ("batched", SimpleRoiAlignRotatedModel("NCHW"), torch.randn(4, 3, 16, 20)),
+            (
+                "horizontal",
+                SimpleRoiAlignRotatedModel("NCHW"),
+                torch.randn(4, 3, 16, 20),
+                True,
+            ),
+            (
+                "scaled",
+                SimpleRoiAlignRotatedModel("NCHW", spatial_scale=0.0625),
+                torch.randn(1, 3, 224, 224),
+            ),
+            (
+                "unaligned",
+                SimpleRoiAlignRotatedModel("NCHW", aligned=False),
+                torch.randn(1, 3, 16, 20),
+            ),
+            (
+                "dynamic_sampling",
+                SimpleRoiAlignRotatedModel("NCHW", sampling_ratio=0),
+                torch.randn(1, 3, 16, 20),
+            ),
+        ]
+    )
+    def test_roi_align_rotated(self, _, module, features, horizontal=False):
+        order = module.kwargs.get("order")
+        kwargs = {k: v for k, v in zip(order, features.size())}
+        kwargs.pop("C")
+        rois = rand_rotated_rois(count=250, horizontal=horizontal, **kwargs)
+        utils.compare_tracing_methods(
+            module, features, rois, fusible_ops={"_caffe2::RoIAlignRotated"}
         )

--- a/torch_glow/tests/nodes/sigmoid_test.py
+++ b/torch_glow/tests/nodes/sigmoid_test.py
@@ -1,33 +1,33 @@
 # isort:skip_file
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import torch_glow
 import torch
 
-from tests.utils import jitVsGlow
+from tests import utils
+from parameterized import parameterized
 import unittest
 
 
+class SimpleSigmoidModel(torch.nn.Module):
+    def __init__(self, inplace=False):
+        super(SimpleSigmoidModel, self).__init__()
+        self.inplace = inplace
+
+    def forward(self, tensor):
+        if self.inplace:
+            other = tensor + tensor
+            return other.sigmoid_()
+        else:
+            other = tensor + tensor
+            return other.sigmoid()
+
+
 class TestSigmoid(unittest.TestCase):
-    def test_sigmoid_basic(self):
-        """Basic test of the PyTorch sigmoid Node on Glow"""
-
-        def sigmoid_basic(a):
-            c = a + a
-            return c.sigmoid()
-
-        x = torch.randn(6)
-
-        jitVsGlow(sigmoid_basic, x, expected_fused_ops={"aten::sigmoid"})
-
-    def test_sigmoid_inplace(self):
-        """Test of the inplace PyTorch sigmoid Node on Glow"""
-
-        def sigmoid_inplace(a):
-            c = a + a
-            return c.sigmoid_()
-
-        x = torch.randn(6)
-
-        # Expect fuser to out-of-place the operator
-        jitVsGlow(sigmoid_inplace, x, expected_fused_ops={"aten::sigmoid"})
+    @parameterized.expand(
+        [
+            ("basic", SimpleSigmoidModel(), torch.randn(6)),
+            ("inplace", SimpleSigmoidModel(inplace=True), torch.randn(6)),
+        ]
+    )
+    def test_sigmoid(self, _, module, tensor):
+        utils.compare_tracing_methods(module, tensor, fusible_ops={"aten::sigmoid"})

--- a/torch_glow/tests/nodes/size_test.py
+++ b/torch_glow/tests/nodes/size_test.py
@@ -3,7 +3,17 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from parameterized import parameterized
+from tests import utils
+
+
+class SimpleSizeModel(torch.nn.Module):
+    def __init__(self, dimension):
+        super(SimpleSizeModel, self).__init__()
+        self.dimension = dimension
+
+    def forward(self, tensor):
+        return tensor.size(self.dimension)
 
 
 class TestSize(unittest.TestCase):
@@ -19,26 +29,17 @@ class TestSize(unittest.TestCase):
 
     #    x = torch.zeros([4], dtype=torch.int32)
 
-    #    jitVsGlow(test_f, x, expected_fused_ops={"aten::size"})
+    #    utils.compare_tracing_methods(test_f, x, fusible_ops={"aten::size"})
 
-    # @unittest.skip(reason="not ready")
-    # def test_size_neg_dim(self):
-    #    """Test negative dimension index for the PyTorch aten::size Node on Glow."""
+    @parameterized.expand(
+        [("basic", SimpleSizeModel(-1), torch.randn(2, 3, 4, dtype=torch.float32))]
+    )
+    def test_size(self, _, module, tensor):
+        utils.compare_tracing_methods(module, tensor, fusible_ops={"aten::size"})
 
-    #    def test_f(a):
-    #        return a.size(-1)
-
-    #    x = torch.randn(2, 3, 4, dtype=torch.float32)
-
-    #    jitVsGlow(test_f, x, expected_fused_ops={"aten::size"})
-
-    def test_size_oob_neg_dim(self):
-        """Test out of bounds negative dimension index for the PyTorch aten::size Node on Glow."""
-
-        def test_f(a):
-            return a.size(-4)
-
-        x = torch.randn(2, 3, 4, dtype=torch.float32)
-
+    @parameterized.expand(
+        [("oob", SimpleSizeModel(-4), torch.randn(2, 3, 4, dtype=torch.float32))]
+    )
+    def test_size_failure(self, _, module, tensor):
         with self.assertRaises(IndexError):
-            jitVsGlow(test_f, x, expected_fused_ops={"aten::size"})
+            utils.compare_tracing_methods(module, tensor, fusible_ops={"aten::size"})

--- a/torch_glow/tests/nodes/slice_test.py
+++ b/torch_glow/tests/nodes/slice_test.py
@@ -3,17 +3,22 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimpleSliceModel(torch.nn.Module):
+    def __init__(self):
+        super(SimpleSliceModel, self).__init__()
+
+    def forward(self, tensor):
+        other = (tensor + tensor)[1:]
+        return other[0][1:]
 
 
 class TestSlice(unittest.TestCase):
     def test_slice_basic(self):
         """Test of the PyTorch slice Node on Glow."""
 
-        def slice_basic(a):
-            b = (a + a)[1:]
-            return b[0][1:]
-
-        x = torch.rand((2, 3))
-
-        jitVsGlow(slice_basic, x, expected_fused_ops={"aten::slice"})
+        utils.compare_tracing_methods(
+            SimpleSliceModel(), torch.rand((2, 3)), skip_to_glow=True
+        )

--- a/torch_glow/tests/nodes/softmax_test.py
+++ b/torch_glow/tests/nodes/softmax_test.py
@@ -4,36 +4,31 @@ import unittest
 
 import torch
 import torch.nn.functional as F
-from tests.utils import jitVsGlow
+from parameterized import parameterized
+from tests import utils
+
+
+class SimpleSoftmaxModel(torch.nn.Module):
+    def __init__(self, dimension):
+        super(SimpleSoftmaxModel, self).__init__()
+        self.dimension = dimension
+
+    def forward(self, tensor):
+        return F.softmax(tensor, self.dimension)
 
 
 class TestSoftmax(unittest.TestCase):
-    def test_softmax_basic(self):
-        """Basic test of the PyTorch SoftMax Node on Glow."""
-
-        def softmax_basic(inputs):
-            return F.softmax(inputs, dim=1)
-
-        inputs = torch.randn(2, 3)
-        jitVsGlow(softmax_basic, inputs, expected_fused_ops={"aten::softmax"})
-
-    def test_softmax_neg_dim(self):
-        """Test negative dimension index for the PyTorch SoftMax Node on Glow."""
-
-        def softmax_neg_dim(inputs):
-            # Note: dims in the range [-size, -2] cause an assert from flattenCdr() as currently implemented
-            return F.softmax(inputs, dim=-1)
-
-        inputs = torch.randn(2, 3)
-        jitVsGlow(softmax_neg_dim, inputs, expected_fused_ops={"aten::softmax"})
+    @parameterized.expand(
+        [
+            ("basic", SimpleSoftmaxModel(1), torch.randn(2, 3)),
+            ("neg_dim", SimpleSoftmaxModel(-1), torch.randn(2, 3)),
+        ]
+    )
+    def test_softmax(self, _, module, tensor):
+        utils.compare_tracing_methods(module, tensor)
 
     def test_softmax_oob_neg_dim(self):
         """Test out of bounds negative dimension index for the PyTorch SoftMax Node on Glow."""
 
-        def test_f(inputs):
-            with self.assertRaises(IndexError):
-                return F.softmax(inputs, dim=-3)
-
-        inputs = torch.randn(2, 3)
-        with self.assertRaises(RuntimeError):
-            jitVsGlow(test_f, inputs, expected_fused_ops={"aten::softmax"})
+        with self.assertRaises(IndexError):
+            utils.compare_tracing_methods(SimpleSoftmaxModel(-3), torch.randn(2, 3))

--- a/torch_glow/tests/nodes/sqrt_test.py
+++ b/torch_glow/tests/nodes/sqrt_test.py
@@ -3,30 +3,32 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimpleSqrtModel(torch.nn.Module):
+    def __init__(self, inplace=False):
+        super(SimpleSqrtModel, self).__init__()
+        self.inplace = inplace
+
+    def forward(self, tensor):
+        if self.inplace:
+            other = tensor.sqrt_()
+            return other.sqrt_()
+        else:
+            tensor = torch.sqrt(tensor)
+            return torch.sqrt(tensor)
 
 
 class TestSqrt(unittest.TestCase):
     def test_sqrt_basic(self):
         """Test of the PyTorch sqrt Node on Glow."""
 
-        def test_f(a):
-            b = torch.sqrt(a)
-            return torch.sqrt(b)
-
         # Make sure the input is positive and not super close to zero.
-        x = torch.rand(4) + 5
-
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::sqrt"})
+        utils.compare_tracing_methods(SimpleSqrtModel(), torch.rand(4) + 5)
 
     def test_sqrt_inplace(self):
         """Test of the PyTorch inplace sqrt Node on Glow."""
 
-        def test_f(a):
-            b = a.sqrt_()
-            return b.sqrt_()
-
         # Make sure the input is positive and not super close to zero.
-        x = torch.rand(4) + 5
-
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::sqrt_"})
+        utils.compare_tracing_methods(SimpleSqrtModel(inplace=True), torch.rand(4) + 5)

--- a/torch_glow/tests/nodes/stack_test.py
+++ b/torch_glow/tests/nodes/stack_test.py
@@ -3,19 +3,26 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimpleStackModel(torch.nn.Module):
+    def __init__(self):
+        super(SimpleStackModel, self).__init__()
+
+    def forward(self, a, b):
+        c = torch.stack((a, b), 0)
+        d = torch.stack((c, c), 1)
+        return torch.stack((d, d), 2)
 
 
 class TestStack(unittest.TestCase):
     def test_stack_basic(self):
         """Basic test of the PyTorch aten::stack Node on Glow."""
 
-        def test_f(a, b):
-            c = torch.stack((a, b), 0)
-            d = torch.stack((c, c), 1)
-            return torch.stack((d, d), 2)
-
-        x = torch.randn(2, 3, 4)
-        y = torch.randn(2, 3, 4)
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={"glow::fused_stack"})
+        utils.compare_tracing_methods(
+            SimpleStackModel(),
+            torch.randn(2, 3, 4),
+            torch.randn(2, 3, 4),
+            skip_to_glow=True,
+        )

--- a/torch_glow/tests/nodes/sub_test.py
+++ b/torch_glow/tests/nodes/sub_test.py
@@ -3,74 +3,47 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from parameterized import parameterized
+from tests import utils
+
+
+class SimpleSubtractModel(torch.nn.Module):
+    def __init__(self):
+        super(SimpleSubtractModel, self).__init__()
+
+    def forward(self, a, b):
+        if b.size() == torch.Size([]):
+            return (a * a).sub(b.item())
+        else:
+            c = a.sub(b)
+            return c.sub(c)
 
 
 class TestSub(unittest.TestCase):
-    def test_sub_basic(self):
-        """Basic test of the PyTorch sub Node on Glow."""
-
-        def test_f(a, b):
-            c = a.sub(b)
-            return c.sub(c)
-
-        x = torch.randn(4)
-        y = torch.randn(4)
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::sub"})
-
-    def test_sub_broadcast_1(self):
-        """Test of the PyTorch sub Node on Glow with broadcasting."""
-
-        def test_f(a, b):
-            c = a.sub(b)
-            return c.sub(c)
-
-        x = torch.randn(8, 3, 4, 2)
-        y = torch.randn(4, 2)
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::sub"})
-
-    def test_sub_broadcast_2(self):
-        """Test of the PyTorch sub Node on Glow with broadcasting."""
-
-        def test_f(a, b):
-            c = a.sub(b)
-            return c.sub(c)
-
-        x = torch.randn(8, 3, 4, 2)
-        y = torch.randn(1, 2)
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::sub"})
-
-    def test_sub_broadcast_3(self):
-        """Test of the PyTorch sub Node on Glow with broadcasting."""
-
-        def test_f(a, b):
-            c = a.sub(b)
-            return c.sub(c)
-
-        x = torch.randn(4, 2)
-        y = torch.randn(8, 3, 4, 2)
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::sub"})
-
-    def test_sub_float(self):
-        """Test of the PyTorch aten::sub Node with a float argument"""
-
-        def test_f(a):
-            return (a * a).sub(3.9)
-
-        x = torch.randn(4)
-
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::sub"})
-
-    def test_sub_int(self):
-        """Test of the PyTorch aten::sub Node with an int argument"""
-
-        def test_f(a):
-            return (a * a).sub(20)
-
-        x = torch.randn(4)
-
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::sub"})
+    @parameterized.expand(
+        [
+            ("basic", SimpleSubtractModel(), torch.randn(4), torch.randn(4)),
+            (
+                "broadcast_1",
+                SimpleSubtractModel(),
+                torch.randn(8, 3, 4, 2),
+                torch.randn(4, 2),
+            ),
+            (
+                "broadcast_2",
+                SimpleSubtractModel(),
+                torch.randn(8, 3, 4, 2),
+                torch.randn(1, 2),
+            ),
+            (
+                "broadcast_3",
+                SimpleSubtractModel(),
+                torch.randn(4, 2),
+                torch.randn(8, 3, 4, 2),
+            ),
+            ("float", SimpleSubtractModel(), torch.randn(4), torch.tensor(3.9)),
+            ("int", SimpleSubtractModel(), torch.randn(4), torch.tensor(20), True),
+        ]
+    )
+    def test_subtract(self, _, module, tensor, other, skip_to_glow=False):
+        utils.compare_tracing_methods(module, tensor, other, skip_to_glow=skip_to_glow)

--- a/torch_glow/tests/nodes/tanh_test.py
+++ b/torch_glow/tests/nodes/tanh_test.py
@@ -3,27 +3,30 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimpleTanhModel(torch.nn.Module):
+    def __init__(self, inplace=False):
+        super(SimpleTanhModel, self).__init__()
+        self.inplace = inplace
+
+    def forward(self, tensor):
+        tensor = tensor + tensor
+        return tensor.tanh_() if self.inplace else tensor.tanh()
 
 
 class TestTanh(unittest.TestCase):
     def test_tanh(self):
         """Basic test of the PyTorch aten::tanh Node on Glow."""
 
-        def test_f(a):
-            return (a + a).tanh()
-
-        x = torch.randn(4)
-
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::tanh"})
+        utils.compare_tracing_methods(
+            SimpleTanhModel(), torch.randn(4), fusible_ops={"aten::tanh"}
+        )
 
     def test_tanh_inplace(self):
         """Basic test of the PyTorch aten::tanh_ Node on Glow."""
 
-        def test_f(a):
-            return (a + a).tanh_()
-
-        x = torch.randn(4)
-
-        # Expect fuser to out-of-place the operator
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::tanh"})
+        utils.compare_tracing_methods(
+            SimpleTanhModel(inplace=True), torch.randn(4), fusible_ops={"aten::tanh"}
+        )

--- a/torch_glow/tests/nodes/to_test.py
+++ b/torch_glow/tests/nodes/to_test.py
@@ -3,40 +3,32 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from parameterized import parameterized
+from tests import utils
+
+
+class SimpleToModel(torch.nn.Module):
+    def __init__(self, *conversions):
+        super(SimpleToModel, self).__init__()
+        self.conversions = conversions
+
+    def forward(self, tensor):
+        for conversion_type in self.conversions:
+            tensor = tensor.to(conversion_type)
+        return tensor
 
 
 class TestTo(unittest.TestCase):
-    def test_to_basic(self):
-        """Test of the PyTorch to Node on Glow."""
-
-        def test_f(a):
-            b = a.to(torch.int)
-            c = b.to(torch.float)
-            return c
-
-        x = torch.randn(1, 2, 3, 4)
-
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::to"})
-
-    def test_to_int(self):
-        """Test of the PyTorch to Node on Glow with int output."""
-
-        def test_f(a):
-            ai = a.to(torch.int)
-            return ai
-
-        x = torch.randn(1, 2, 3, 4)
-
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::to"})
-
-    def test_to_float(self):
-        """Test of the PyTorch to Node on Glow with float output."""
-
-        def test_f(a):
-            ai = a.to(torch.float)
-            return ai
-
-        x = torch.randint(100, (1, 2, 3, 4))
-
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::to"})
+    @parameterized.expand(
+        [
+            ("to_int", SimpleToModel(torch.int), torch.randn(1, 2, 3, 4)),
+            ("to_float", SimpleToModel(torch.float), torch.randn(1, 2, 3, 4)),
+            (
+                "to_int_to_float",
+                SimpleToModel(torch.int, torch.float),
+                torch.randn(1, 2, 3, 4),
+            ),
+        ]
+    )
+    def test_to(self, _, module, tensor):
+        utils.compare_tracing_methods(module, tensor, fusible_ops={"aten::to"})

--- a/torch_glow/tests/nodes/topk_test.py
+++ b/torch_glow/tests/nodes/topk_test.py
@@ -3,17 +3,22 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from tests import utils
+
+
+class SimpleTopkModel(torch.nn.Module):
+    def __init__(self, count):
+        super(SimpleTopkModel, self).__init__()
+        self.count = count
+
+    def forward(self, tensor):
+        tensor = tensor + tensor
+        return torch.topk(tensor, self.count)
 
 
 class TestTopk(unittest.TestCase):
     def test_topk_basic(self):
         """Test of the PyTorch TopK Node on Glow."""
-
-        def test_topk(x):
-            x + x
-            return torch.topk(x, 3)
-
-        x = torch.arange(1.0, 6.0)
-
-        jitVsGlow(test_topk, x, expected_fused_ops={"aten::topk"})
+        utils.compare_tracing_methods(
+            SimpleTopkModel(3), torch.arange(1.0, 6.0), fusible_ops={"aten::topk"}
+        )

--- a/torch_glow/tests/nodes/transpose_test.py
+++ b/torch_glow/tests/nodes/transpose_test.py
@@ -3,91 +3,50 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from parameterized import parameterized
+from tests import utils
+
+
+class SimpleTransposeModel(torch.nn.Module):
+    def __init__(self, dim0=None, dim1=None, inplace=False):
+        super(SimpleTransposeModel, self).__init__()
+        self.dims = (dim0, dim1) if dim0 and dim1 else None
+        self.inplace = inplace
+
+    def forward(self, tensor):
+        t = tensor + tensor
+        if self.dims:
+            return t.transpose_(*self.dims) if self.inplace else t.transpose(*self.dims)
+        else:
+            return t.t_() if self.inplace else t.t()
 
 
 class TestTranspose(unittest.TestCase):
-    def test_t_2d(self):
-        """Test of PyTorch aten::t on Glow with 2d inputs."""
+    @parameterized.expand(
+        [
+            ("2d", SimpleTransposeModel(), torch.randn(7, 4)),
+            ("1d", SimpleTransposeModel(), torch.randn(7)),
+            ("inplace", SimpleTransposeModel(inplace=True), torch.randn(7, 4)),
+        ]
+    )
+    def test_t(self, _, module, tensor):
+        utils.compare_tracing_methods(module, tensor, fusible_ops={"aten::t"})
 
-        def test_f(a):
-            b = a + a
-            return b.t()
+    @parameterized.expand(
+        [
+            ("simple", SimpleTransposeModel(1, 2), torch.randn(2, 3, 4)),
+            ("inplace", SimpleTransposeModel(1, 2, inplace=True), torch.randn(2, 3, 4)),
+            ("neg_dim", SimpleTransposeModel(-2, -1), torch.randn(2, 3, 4)),
+        ]
+    )
+    def test_transpose(self, _, module, tensor, reference=None):
+        utils.compare_tracing_methods(module, tensor, fusible_ops={"aten::transpose"})
 
-        x = torch.randn(7, 4)
-
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::t"})
-
-    def test_t_1d(self):
-        """Test of PyTorch aten::t on Glow with 1d inputs."""
-
-        def test_f(a):
-            b = a + a
-            return b.t()
-
-        x = torch.randn(7)
-
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::t"})
-
-    def test_t_inplace(self):
-        """Test of PyTorch aten::t_ (in place t) on Glow."""
-
-        def test_f(a):
-            b = a + a
-            return b.t_()
-
-        x = torch.randn(7, 4)
-
-        # Expect fuser to out-of-place the operator
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::t"})
-
-    def test_transpose(self):
-        """Test of PyTorch aten::transpose on Glow."""
-
-        def test_f(a):
-            b = a + a
-            return b.transpose(1, 2)
-
-        x = torch.randn(2, 3, 4)
-
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::transpose"})
-
-    def test_transpose_inplace(self):
-        """Test of PyTorch aten::transpose on Glow."""
-
-        def test_f(a):
-            b = a + a
-            return b.transpose_(1, 2)
-
-        x = torch.randn(2, 3, 4)
-
-        # Expect fuser to out-of-place the operator
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::transpose"})
-
-    def test_transpose_neg_dim(self):
-        """Test negative dimension index for PyTorch aten::transpose on Glow."""
-
-        def test_f(a):
-            b = a + a
-            return b.transpose(-2, -1)
-
-        def expected_f(a):
-            b = a + a
-            return b.transpose(1, 2)
-
-        x = torch.randn(2, 3, 4)
-
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::transpose"})
-        self.assertTrue(test_f(x).equal(expected_f(x)))
-
-    def test_transpose_oob_neg_dim(self):
-        """Test out of bounds negative dimension index for PyTorch aten::transpose on Glow."""
-
-        def test_f(a):
-            b = a + a
-            return b.transpose(-2, -4)
-
-        x = torch.randn(2, 3, 4)
-
+    @parameterized.expand(
+        [("oob_neg_dim", SimpleTransposeModel(-2, -4), torch.randn(2, 3, 4))]
+    )
+    def test_transpose_failure(self, _, module, tensor):
         with self.assertRaises(IndexError):
-            jitVsGlow(test_f, x, expected_fused_ops={"aten::transpose"})
+            utils.compare_tracing_methods(
+                module, tensor, fusible_ops={"aten::transpose"}
+            )

--- a/torch_glow/tests/nodes/typeas_test.py
+++ b/torch_glow/tests/nodes/typeas_test.py
@@ -3,81 +3,70 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from parameterized import parameterized
+from tests import utils
+
+
+class SimpleTypeasModel(torch.nn.Module):
+    def __init__(self):
+        super(SimpleTypeasModel, self).__init__()
+
+    def forward(self, tensor, other=None):
+        # TODO: Understand and document the utility of the self-conversion test
+        # as well as the additional tensor + tensor step
+        other = tensor if other is None else other
+        if tensor.dtype != torch.bool:
+            tensor = tensor + tensor
+        typed = tensor.type_as(other)
+        return typed + typed
 
 
 class TestTypeAs(unittest.TestCase):
-    def test_typeas_basic(self):
-        """Basic test of the PyTorch type_as Node on Glow (float to int32)."""
-
-        def test_f(a, b):
-            c = a.type_as(b)
-            return c + c
-
-        x = torch.randn(4)
-        y = torch.zeros(4, dtype=torch.int32)
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::type_as"})
-
-    def test_typeas_basic2(self):
-        """Basic test of the PyTorch type_as Node on Glow (int32 to float)."""
-
-        def test_f(a, b):
-            c = a.type_as(b)
-            return c + c
-
-        x = torch.randn(4).to(dtype=torch.int32)
-        y = torch.randn(4)
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::type_as"})
-
-    def test_typeas_bool(self):
-        """Test of the PyTorch type_as Node on Glow converting bool to float."""
-
-        def test_f(a, b):
-            c = a.type_as(b)
-            return c + c
-
-        x = torch.randn(4).to(dtype=torch.bool)
-        y = torch.randn(4)
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::type_as"})
-
-    def test_typeas_self(self):
-        """Test of the PyTorch mul Node on Glow doing empty convert (float to float)."""
-
-        def test_f(a, b):
-            a = a + a
-            c = a.type_as(b)
-            return c + c
-
-        x = torch.randn(4)
-        y = x
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={})
-
-    def test_typeas_self_f2f2(self):
-        """Test of the PyTorch type_as Node on Glow float to float."""
-
-        def test_f(a, b):
-            a = a + a
-            c = a.type_as(b)
-            return c + c
-
-        x = torch.randn(4, 2)
-        y = torch.randn(8, 3, 4, 2)
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={})
-
-    def test_typeas_self_f2i2(self):
-        """Test of the PyTorch type_as Node on Glow with float to int32"""
-
-        def test_f(a, b):
-            a = a + a
-            c = a.type_as(b)
-            return c + c
-
-        x = torch.randn(4, 2)
-        y = torch.randn(8, 3, 4, 2).to(dtype=torch.int32)
-
-        jitVsGlow(test_f, x, y, expected_fused_ops={"aten::type_as"})
+    @parameterized.expand(
+        [
+            (
+                "to_int32",
+                SimpleTypeasModel(),
+                torch.randn(4),
+                torch.zeros(4, dtype=torch.int32),
+            ),
+            (
+                "from_int32",
+                SimpleTypeasModel(),
+                torch.randn(4).to(dtype=torch.int32),
+                torch.zeros(4),
+            ),
+            (
+                "from_bool",
+                SimpleTypeasModel(),
+                torch.randn(4).to(dtype=torch.bool),
+                torch.zeros(4),
+            ),
+            ("self", SimpleTypeasModel(), torch.randn(4), None, False),
+            (
+                "f2f2",
+                SimpleTypeasModel(),
+                torch.randn(4, 2),
+                torch.randn(8, 3, 4, 2),
+                False,
+            ),
+            (
+                "f2i2",
+                SimpleTypeasModel(),
+                torch.randn(4, 2),
+                torch.randn(8, 3, 4, 2).to(dtype=torch.int32),
+            ),
+        ]
+    )
+    def test_typeas(self, _, module, tensor, other=None, should_fuse=True):
+        if other is not None:
+            utils.compare_tracing_methods(
+                module,
+                tensor,
+                other,
+                fusible_ops={"aten::type_as"} if should_fuse else {},
+            )
+        else:
+            utils.compare_tracing_methods(
+                module, tensor, fusible_ops={"aten::type_as"} if should_fuse else {}
+            )

--- a/torch_glow/tests/nodes/upsample_test.py
+++ b/torch_glow/tests/nodes/upsample_test.py
@@ -3,74 +3,58 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import unittest
 
-import torch_glow
 import torch
-from tests.utils import jitVsGlow
+from parameterized import parameterized
+
+from tests import utils
+
+
+class SimpleUpsampleModel(torch.nn.Module):
+    def __init__(self, *args, **kwargs):
+        super(SimpleUpsampleModel, self).__init__()
+        self.args = args
+        self.kwargs = kwargs
+
+    def forward(self, tensor):
+        return torch.nn.Upsample(*self.args, **self.kwargs)(tensor)
 
 
 class TestUpsample(unittest.TestCase):
-    def test_upsample3d_2x_size(self):
-        """Test of the PyTorch upsample Node on Glow."""
-
-        def test_f(a):
-            U = torch.nn.Upsample(size=(8, 10, 12))
-            return U(a)
-
-        x = torch.rand(2, 3, 4, 5, 6)
-
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::upsample_nearest3d"})
-
-    def test_upsample3d_2x_scale_factor(self):
-        """Test of the PyTorch upsample Node on Glow."""
-
-        def test_f(a):
-            U = torch.nn.Upsample(scale_factor=(2, 2, 2))
-            return U(a)
-
-        x = torch.rand(2, 3, 4, 5, 6)
-
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::upsample_nearest3d"})
-
-    def test_upsample3d_2x_single_scale_factor(self):
-        """Test of the PyTorch upsample Node on Glow."""
-
-        def test_f(a):
-            U = torch.nn.Upsample(scale_factor=2)
-            return U(a)
-
-        x = torch.rand(2, 3, 4, 5, 6)
-
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::upsample_nearest3d"})
-
-    def test_upsample3d_not_2x_single_scale_factor(self):
-        """Test of the PyTorch upsample Node on Glow."""
-
-        def test_f(a):
-            U = torch.nn.Upsample(scale_factor=5)
-            return U(a)
-
-        x = torch.rand(2, 3, 4, 5, 6)
-
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::upsample_nearest3d"})
-
-    def test_upsample3d_not_2x_scale_factor(self):
-        """Test of the PyTorch upsample Node on Glow."""
-
-        def test_f(a):
-            U = torch.nn.Upsample(scale_factor=(1, 2, 3))
-            return U(a)
-
-        x = torch.rand(2, 2, 2, 2, 2)
-
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::upsample_nearest3d"})
-
-    def test_upsample3d_not_2x_size(self):
-        """Test of the PyTorch upsample Node on Glow."""
-
-        def test_f(a):
-            U = torch.nn.Upsample(size=(10, 12, 13))
-            return U(a)
-
-        x = torch.rand(2, 3, 4, 5, 6)
-
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::upsample_nearest3d"})
+    @parameterized.expand(
+        [
+            (
+                "3d_2x_size",
+                SimpleUpsampleModel(size=(8, 10, 12)),
+                torch.rand(2, 3, 4, 5, 6),
+            ),
+            (
+                "3d_2x_scale_factor",
+                SimpleUpsampleModel(scale_factor=(2, 2, 2)),
+                torch.rand(2, 3, 4, 5, 6),
+            ),
+            (
+                "3d_2x_single_scale_factor",
+                SimpleUpsampleModel(scale_factor=2),
+                torch.rand(2, 3, 4, 5, 6),
+            ),
+            (
+                "3d_not_2x_single_scale_factor",
+                SimpleUpsampleModel(scale_factor=5),
+                torch.rand(2, 3, 4, 5, 6),
+            ),
+            (
+                "3d_not_2x_scale_factor",
+                SimpleUpsampleModel(scale_factor=(1, 2, 3)),
+                torch.rand(2, 3, 4, 5, 6),
+            ),
+            (
+                "3d_not_2x_size",
+                SimpleUpsampleModel(size=(10, 12, 13)),
+                torch.rand(2, 3, 4, 5, 6),
+            ),
+        ]
+    )
+    def test_upsample(self, name, module, tensor):
+        utils.compare_tracing_methods(
+            module, tensor, fusible_ops=["aten::upsample_nearest3d"]
+        )

--- a/torch_glow/tests/nodes/view_test.py
+++ b/torch_glow/tests/nodes/view_test.py
@@ -3,17 +3,25 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
-from tests.utils import jitVsGlow
+from parameterized import parameterized
+from tests import utils
+
+
+class SimpleViewModule(torch.nn.Module):
+    def __init__(self, *shape):
+        super(SimpleViewModule, self).__init__()
+        self.shape = shape
+
+    def forward(self, tensor):
+        return (tensor + tensor).view(self.shape)
 
 
 class TestView(unittest.TestCase):
-    def test_view(self):
-        """Test of the PyTorch reshape Node on Glow."""
-
-        def test_f(a):
-            b = a + a
-            return b.view([2, -1])
-
-        x = torch.rand(2, 3, 4)
-
-        jitVsGlow(test_f, x, expected_fused_ops={"aten::view"})
+    @parameterized.expand(
+        [
+            (SimpleViewModule(2, -1), torch.rand(2, 3, 4)),
+            (SimpleViewModule(-1, 2), torch.rand(2, 3, 4)),
+        ]
+    )
+    def test_simple(self, module, tensor):
+        utils.compare_tracing_methods(module, tensor, fusible_ops={"aten::view"})

--- a/torch_glow/tests/utils.py
+++ b/torch_glow/tests/utils.py
@@ -1,22 +1,64 @@
 # isort:skip_file
+from __future__ import absolute_import, division, print_function, unicode_literals
+from copy import deepcopy
 import os
-import sys
 
 import torch_glow
 import torch
 
-GLOW_NODE_NAME = "glow::FusionGroup"
+from contextlib import contextmanager
+
+GLOW_FUSION_GROUP = "glow::FusionGroup"
 SUBGRAPH_ATTR = "Subgraph"
 BACKEND_NAME_KEY = "BACKEND_NAME"
 INTERPRETER = "Interpreter"
+DEFAULT_BACKEND = os.environ.get(BACKEND_NAME_KEY, "Interpreter")
 
 
 def get_backend_name():
     return os.environ.get(BACKEND_NAME_KEY, INTERPRETER)
 
 
+@contextmanager
+def ephemeral_torchglow_settings(
+    fp16=False, backend=DEFAULT_BACKEND, fusion=False, blocklist=None
+):
+    old_fp16 = torch_glow.get_convert_to_fp16()
+    old_clip = torch_glow.get_clip_fp16()
+    old_convert_fused = torch_glow.get_convert_fused_to_fp16()
+    old_backend = torch_glow.getGlowBackendName()
+    old_blocklist = torch_glow.getFusionBlacklist()
+    old_fusion = torch_glow.getFusionPassEnabled()
+    try:
+        if fusion:
+            torch_glow.enableFusionPass()
+        else:
+            torch_glow.disableFusionPass()
+        if fp16:
+            torch_glow.enable_convert_to_fp16()
+            torch_glow.enable_convert_fused_to_fp16()
+            torch_glow.enable_clip_fp16()
+        else:
+            torch_glow.disable_convert_to_fp16()
+            torch_glow.disable_convert_fused_to_fp16()
+            torch_glow.disable_clip_fp16()
+        if blocklist is None:
+            torch_glow.clearFusionBlacklist()
+        else:
+            torch_glow.setFusionBlacklist(list(blocklist))
+        torch_glow.setGlowBackend(backend)
+        yield
+    finally:
+        torch_glow.enable_convert_to_fp16() if old_fp16 else torch_glow.disable_convert_to_fp16()
+        torch_glow.enable_clip_fp16() if old_clip else torch_glow.disable_clip_fp16()
+        torch_glow.enable_convert_fused_to_fp16() if old_convert_fused else torch_glow.disable_convert_fused_to_fp16()
+        torch_glow.enableFusionPass() if old_fusion else torch_glow.disableFusionPass()
+        torch_glow.setGlowBackend(old_backend)
+        torch_glow.setFusionBlacklist(old_blocklist)
+
+
 def check_skip(case):
-    backend = get_backend_name()
+    backend = DEFAULT_BACKEND
     supported = {INTERPRETER}
     try:
         supported = supported | case.supported_backends
@@ -27,229 +69,114 @@ def check_skip(case):
         case.skipTest("Skipping tests for backend: " + backend)
 
 
-def jitVsGlow(
-    f,
+def generate_glow_spec(module, backend, *inputs):
+    spec = torch_glow.CompilationSpec()
+    spec.get_settings().set_glow_backend(backend)
+    compilation_group = torch_glow.CompilationGroup()
+    spec.compilation_groups_append(compilation_group)
+
+    input_specs = []
+    for input in inputs:
+        input_spec = torch_glow.InputSpec()
+        input_spec.set_same_as(input)
+        input_specs.append(input_spec)
+    compilation_group.input_sets_append(input_specs)
+    return spec
+
+
+def assert_equivalent(result, other_result, atol=5e-4, rtol=1e-3):
+    if isinstance(result, tuple) or isinstance(other_result, tuple):
+        assert isinstance(result, tuple) and isinstance(other_result, tuple)
+        assert len(result) == len(other_result)
+        return all(
+            assert_equivalent(a, b, atol=atol, rtol=rtol)
+            for a, b in zip(result, other_result)
+        )
+    elif torch.allclose(result, other_result, atol, rtol):
+        return True
+    else:
+        diff = torch.abs(result - other_result)
+        error = f"First result:\n{result}\n"
+        error += f"Second result:\n{other_result}\n"
+        error += f"Diff:\n{diff}\n"
+        error += f"Max diff:\n{torch.max(diff)}"
+        raise AssertionError(error)
+
+
+def compare_tracing_methods(
+    module,
     *inputs,
-    expected_fused_ops,
-    accept_all_ops=False,
-    check_trace=True,
     atol=5e-4,
     rtol=1e-3,
-    black_list=None,
-    use_script=False,
-    use_fp16=False,
-    backend_name=None,
+    reference=None,
+    fusible_ops=None,
+    fusion_blocklist=None,
+    fp16=False,
+    scripted=False,
+    check_trace=True,
+    skip_to_glow=False,  # Ugly hack, TODO: Remove
 ):
-    """
-    Runs the given inputs *inputs on f both with and without lowering f to Glow,
-    compares the results, and checks that ops in expected_fused_ops were indeed
-    lowered to Glow.
-    """
-    if use_script:
-        scriptVsGlow(
-            f,
-            atol,
-            rtol,
-            *inputs,
-            expected_fused_ops=expected_fused_ops,
-            accept_all_ops=accept_all_ops,
-            black_list=black_list,
-            use_fp16=use_fp16,
-            backend_name=backend_name,
-        )
-    else:
-        traceVsGlow(
-            f,
-            f,
-            check_trace,
-            atol,
-            rtol,
-            *inputs,
-            expected_fused_ops=expected_fused_ops,
-            accept_all_ops=accept_all_ops,
-            black_list=black_list,
-            use_fp16=use_fp16,
-            backend_name=backend_name,
-        )
+    if not isinstance(module, torch.nn.Module):
+        raise AssertionError("to_glow only supports nn.Modules")
 
+    def trace(mod, ins):
+        if scripted:
+            return torch.jit.script(mod)
+        else:
+            return torch.jit.trace(mod, ins, check_trace=check_trace)
 
-def checkResult(torch_res, glow_res, atol, rtol):
-    if isinstance(torch_res, tuple) or isinstance(glow_res, tuple):
-        assert isinstance(torch_res, tuple) and isinstance(glow_res, tuple)
-        assert len(torch_res) == len(glow_res)
-        for i in range(len(torch_res)):
-            checkResult(torch_res[i], glow_res[i], atol, rtol)
-    else:
-        print("torch shape: {}".format(torch_res.shape), file=sys.stderr)
-        print("glow shape: {}".format(glow_res.shape), file=sys.stderr)
-        is_all_close = torch.allclose(torch_res, glow_res, atol=atol, rtol=rtol)
-        if not is_all_close:
-            print("torch_res\n", torch_res)
-            print("glow_res\n", glow_res)
-            diff = torch.abs(glow_res - torch_res)
-            print("diff\n", diff)
-            print(
-                "diff histogram (100 buckets from 0.0 to 1.0)\n",
-                torch.histc(diff, bins=100, min=0, max=1),
+    with torch.no_grad():
+        with ephemeral_torchglow_settings(
+            fusion=True, fp16=fp16, blocklist=fusion_blocklist
+        ):
+            fusion_inputs = deepcopy(inputs)
+            fusion_trace = trace(module, fusion_inputs)
+            assert_fused(
+                fusion_trace.graph_for(*fusion_inputs),
+                *(fusible_ops or []),
+                accept_any=fusible_ops is None,
             )
-            print("max diff\n", torch.max(diff))
-        assert is_all_close
-
-
-def checkExpectedOps(glow_graph, expected_fused_ops, accept_all_ops):
-    with torch.no_grad():
-        expected_fused_ops_seen = set()
-
-        # Whether or not at least one node was fused to Glow.
-        nodes_were_fused = False
-
-        # Check that ops that were *not* fused are *not* in expected_fused_ops
-        for node in glow_graph.nodes():
-            kind = node.kind()
-            if kind != GLOW_NODE_NAME:
-                # If the node is not a Glow fusion group, check that it is
-                # *not* in expected_fused_ops
-                assert (
-                    accept_all_ops or kind not in expected_fused_ops
-                ), "Expected {} to be fused".format(kind)
+            fusion_result = fusion_trace(*fusion_inputs)
+        with ephemeral_torchglow_settings(fusion=False, fp16=fp16):
+            if scripted:
+                torchscript_result = module(*deepcopy(inputs))
             else:
-                # If the node is a Glow fusion group, record which ops from
-                # expected_fused_ops were in it
-
-                # Get the definition of the fusion group
-                glow_group = node.g(SUBGRAPH_ATTR)
-
-                # Put all nodes that are in the group and in expected_fused_ops
-                # into expected_fused_ops_seen
-                for fused_node in glow_group.nodes():
-                    nodes_were_fused = True
-                    fused_node_kind = fused_node.kind()
-
-                    if accept_all_ops or fused_node_kind in expected_fused_ops:
-                        expected_fused_ops_seen.add(fused_node_kind)
-
-        assert nodes_were_fused, "Expected some nodes to be fused to Glow"
-
-        # If the sizes of expected_fused_ops and expected_fused_ops_seen are
-        # different, some ops in expected_fused_ops are not in the graph at all
-        assert accept_all_ops or len(expected_fused_ops) == len(
-            expected_fused_ops_seen
-        ), "Expected all of expected_fused_ops to be in the graph"
+                torchscript_inputs = deepcopy(inputs)
+                torchscript_trace = trace(module, torchscript_inputs)
+                torchscript_result = torchscript_trace(*torchscript_inputs)
+        with ephemeral_torchglow_settings(fusion=False, fp16=fp16):
+            if not skip_to_glow:
+                glow_inputs = deepcopy(inputs)
+                glow_spec = generate_glow_spec(module, DEFAULT_BACKEND, *glow_inputs)
+                glow_trace = torch_glow.to_glow(trace(module, glow_inputs), glow_spec)
+                glow_result = glow_trace(*glow_inputs)
+        if reference:
+            assert_equivalent(reference, fusion_trace, atol=atol, rtol=rtol)
+            assert_equivalent(reference, torchscript_result, atol=atol, rtol=rtol)
+            if not skip_to_glow:
+                assert_equivalent(reference, glow_result, atol=atol, rtol=rtol)
+        # This is written out manually instead of using combinations in order to aid
+        # debugging. TODO: Clean up.
+        assert_equivalent(fusion_result, torchscript_result, atol=atol, rtol=rtol)
+        if not skip_to_glow:
+            assert_equivalent(fusion_result, glow_result, atol=atol, rtol=rtol)
+            assert_equivalent(torchscript_result, glow_result, atol=atol, rtol=rtol)
 
 
-def traceVsGlow(
-    f_torch,
-    f_glow,
-    check_trace,
-    atol,
-    rtol,
-    *inputs,
-    expected_fused_ops=None,
-    accept_all_ops=False,
-    black_list=None,
-    use_fp16=False,
-    backend_name=None,
-):
-    if black_list is None:
-        black_list = []
+def assert_fused(fused_graph, *ops, accept_any=False, strict=False):
+    expected = set(ops)
+    fused = set()
     with torch.no_grad():
-        torch_glow.disableFusionPass()
-
-        torch_trace = torch.jit.trace(f_torch, inputs, check_trace=check_trace)
-        torch_res = torch_trace(*inputs)
-
-        torch_glow.enableFusionPass()
-        torch_glow.setFusionBlacklist(black_list)
-
-        if use_fp16:
-            torch_glow.enable_convert_to_fp16()
-            torch_glow.enable_convert_fused_to_fp16()
-            torch_glow.enable_clip_fp16()
-        else:
-            torch_glow.disable_convert_to_fp16()
-            torch_glow.disable_convert_fused_to_fp16()
-            torch_glow.disable_clip_fp16()
-
-        if backend_name:
-            torch_glow.setGlowBackend(backend_name)
-        else:
-            torch_glow.setGlowBackend(INTERPRETER)
-
-        glow_trace = torch.jit.trace(f_glow, inputs, check_trace=check_trace)
-        glow_res = glow_trace(*inputs)
-
-        # check that there are no Glow nodes in the torch graph
-        torch_graph = torch_trace.graph_for(*inputs)
-        print("torch_graph,", torch_graph)
-
-        num_glow_nodes = len(torch_graph.findAllNodes(GLOW_NODE_NAME))
-        assert num_glow_nodes == 0, "Expected no Glow nodes, found {}".format(
-            num_glow_nodes
-        )
-
-        glow_graph = glow_trace.graph_for(*inputs)
-        print("glow_graph,", glow_graph)
-
-        # need to explicitly clear settings to avoid carry-over static settings
-        torch_glow.disableFusionPass()
-        torch_glow.disable_convert_to_fp16()
-        torch_glow.disable_convert_fused_to_fp16()
-        torch_glow.disable_clip_fp16()
-        torch_glow.setGlowBackend(INTERPRETER)
-
-    checkExpectedOps(glow_graph, expected_fused_ops, accept_all_ops)
-    checkResult(torch_res, glow_res, atol, rtol)
-
-
-def scriptVsGlow(
-    f,
-    atol,
-    rtol,
-    *inputs,
-    expected_fused_ops=None,
-    accept_all_ops=False,
-    black_list=None,
-    use_fp16=False,
-    backend_name=None,
-):
-    if black_list is None:
-        black_list = []
-    with torch.no_grad():
-
-        torch_res = f(*inputs)
-
-        torch_glow.enableFusionPass()
-        torch_glow.setFusionBlacklist(black_list)
-
-        if use_fp16:
-            torch_glow.enable_convert_to_fp16()
-            torch_glow.enable_convert_fused_to_fp16()
-            torch_glow.enable_clip_fp16()
-        else:
-            torch_glow.disable_convert_to_fp16()
-            torch_glow.disable_convert_fused_to_fp16()
-            torch_glow.disable_clip_fp16()
-
-        if backend_name:
-            torch_glow.setGlowBackend(backend_name)
-        else:
-            torch_glow.setGlowBackend(INTERPRETER)
-
-        glow_trace = torch.jit.script(f)
-        glow_res = glow_trace(*inputs)
-
-        glow_graph = glow_trace.graph_for(*inputs)
-        print("glow_graph,", glow_graph)
-
-        # need to explicitly clear settings to avoid carry-over static settings
-        torch_glow.disableFusionPass()
-        torch_glow.disable_convert_to_fp16()
-        torch_glow.disable_convert_fused_to_fp16()
-        torch_glow.disable_clip_fp16()
-        torch_glow.setGlowBackend(INTERPRETER)
-
-    checkExpectedOps(glow_graph, expected_fused_ops, accept_all_ops)
-    checkResult(torch_res, glow_res, atol, rtol)
+        for node in fused_graph.nodes():
+            kind = node.kind()
+            if kind == GLOW_FUSION_GROUP:
+                fused.update(map(lambda n: n.kind(), node.g(SUBGRAPH_ATTR).nodes()))
+            else:
+                assert kind not in expected, f"Expected {kind} to be fused"
+    missing = set() if (accept_any and fused) else expected - fused
+    unexpected = set() if (accept_any or not strict) else fused - expected
+    assert not unexpected, f"Expected fusion of {expected}, but {fused} was fused."
+    assert not missing, f"Expected fusion of {expected}, but only {fused} was fused."
 
 
 def graph_contains_str(graph, substr):


### PR DESCRIPTION
Summary: With the broader introduction of to_glow, we want a mechanism for testing the relative accuracy of to_glow against our other execution modes. This diff introduces a new testing util which allow said comparison. Because to_glow only supports `nn.Module`s (not functions), all of the pure function tests had to include a class wrapper. In addition, the use of parameterized tests (using the parameterized module) was expanded, so that we can trend towards something that looks a bit more like property-based testing.

Differential Revision: D24199066

