### PR TITLE
Add aten::zeros support in torch_glow

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -1747,19 +1747,36 @@ public:
   LSTMUnitNode *createLSTMUnit(llvm::StringRef namePrefix, NodeValue Input,
                                NodeValue C);
 
+  /// Helper function create a PyTorch style LSTM for one direction, and returns
+  /// every output in a vector. \p T should be an iterator or reverse_iterator
+  /// of a NodeValue vector, and /p inputItr is an iterator pointer of the input
+  /// vector. \p Wx, \p Wh, \p Bx, \p Bh, \p H and \p C is i, f, g, o, hidden
+  /// state and cell state, whose shape should be the same to
+  /// createSingleDirectionLSTM.
+  template <class T>
+  std::vector<NodeValue> createSingleDirectionLSTM(
+      std::string nameBase, T inputItr, const int timeSteps, NodeValue Wx,
+      NodeValue Wh, NodeValue Bx, NodeValue Bh, NodeValue &H, NodeValue &C);
+
   /// Create PyTorch style LSTM with fixed weights and biases.
   /// The order of \p Wx \p Wh \p Bx and \p Bh is i, f, g, o,
   /// The \p inputs shape should be (numSteps, batchSize, hiddenSize),
   /// while \p Wx shape should be (inputSize, hiddenSize * 4),
   /// Wh shape should be (hiddenSize, hiddenSize * 4),
   /// \p Bx and \p Bh shape should be (hiddenSize * 4).
+  /// If \p isBidirectional == true, \p WxR, \p WhR, \p BxR and \p BhR
+  /// also need to be provided, indicates the reversed weights and biases.
   /// \p Ht and \p Ct are initial hidden state and cell.
   /// For more details, please read:
   /// https://pytorch.org/docs/stable/generated/torch.nn.LSTM.html
   void createPyTorchLSTM(llvm::StringRef namePrefix, NodeValue inputs,
                          NodeValue Wx, NodeValue Wh, NodeValue Bx, NodeValue Bh,
                          NodeValue &Ht, NodeValue &Ct, NodeValue &outputs,
-                         bool isBidirectional = false);
+                         bool isBidirectional = false,
+                         NodeValue WxR = NodeValue(),
+                         NodeValue WhR = NodeValue(),
+                         NodeValue BxR = NodeValue(),
+                         NodeValue BhR = NodeValue());
 
   /// Type definition for the direction of an RNN module (RNN, GRU, LSTM).
   enum class RnnDirection {

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -445,6 +445,10 @@ private:
   /// \returns error on failure.
   Error loadArange(const torch::jit::Node *ptNode);
 
+  /// Load a PyTorch zeros node.
+  /// \returns error on failure.
+  Error loadZeros(const torch::jit::Node *ptNode);
+
   /// Load a PyTorch sub node.
   /// \returns error on failure.
   Error loadSub(const torch::jit::Node *ptNode);

--- a/torch_glow/tests/nodes/lstm_test.py
+++ b/torch_glow/tests/nodes/lstm_test.py
@@ -56,3 +56,22 @@ class TestLSTM(unittest.TestCase):
         c = torch.randn(1, 3, 10)
         model = SimpleNoBiasLSTM()
         jitVsGlow(model, inputs, h, c, expected_fused_ops={"aten::lstm"})
+
+    def test_lstm_bidirectional(self):
+        """Bidirectional test of the PyTorch lstm Node on Glow."""
+
+        class BidirectionalLSTM(nn.Module):
+            def __init__(self):
+                super(BidirectionalLSTM, self).__init__()
+                self.rnn = torch.nn.LSTM(8, 10, 1, bidirectional=True)
+                self.rnn.training = False
+
+            def forward(self, inputs, h, c):
+                return self.rnn(inputs, (h, c))
+
+        inputs = torch.randn(5, 3, 8)
+        h = torch.randn(2, 3, 10)
+        c = torch.randn(2, 3, 10)
+        model = BidirectionalLSTM()
+
+        jitVsGlow(model, inputs, h, c, expected_fused_ops={"aten::lstm"})

--- a/torch_glow/tests/nodes/zero_test.py
+++ b/torch_glow/tests/nodes/zero_test.py
@@ -1,0 +1,19 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+
+import torch
+from tests.utils import jitVsGlow
+
+
+class TestZero(unittest.TestCase):
+    def test_zero_basic(self):
+        """Basic test of the PyTorch zero Node on Glow."""
+
+        def test_f(a):
+            b = torch.zeros(a.size(), dtype=torch.float)
+            return a + b
+
+        x = torch.randn(2, 3, 4)
+
+        jitVsGlow(test_f, x, expected_fused_ops={"aten::zeros"})


### PR DESCRIPTION
Summary:
Add support of creating empty zero tensor(constant) op in torch_glow: aten::zeros.
Ignored layout, device and pin_memory params for this op.

Reviewed By: jackm321

Differential Revision: D24208213

