### PR TITLE
Refactor SparseNN partitioning to account for NonSLS partition size

### DIFF
--- a/lib/Partitioner/Partitioner.cpp
+++ b/lib/Partitioner/Partitioner.cpp
@@ -857,7 +857,7 @@ Partitioner::partitionFromConfig(const PartitionConfig &partitionConfig,
   // If there is unused partition and unmapped nodes, map those nodes to the
   // unused partition.
   if (unMapped.size()) {
-    DCHECK(unused.size() == 1) << "There must be exactly 1 unused partition.";
+    DCHECK_EQ(unused.size(), 1) << "There must be exactly 1 unused partition.";
     auto partitionID = *(unused.begin());
     for (auto &node : unMapped) {
       partitionMap.add(node, funcList[partitionID]);
@@ -1018,8 +1018,11 @@ Partitioner::setupPrepartitionedModule(CompilationContext &cctx) {
   return std::move(partitions);
 }
 
+namespace {
 struct SLSTableInfo {
   Node *node;
+  std::unordered_set<Node *> neighbors;
+  std::unordered_set<NodeValue> frontier;
   uint64_t numBytesInTable;
   unsigned int deviceId;
   NodeValue slsResult;
@@ -1031,26 +1034,77 @@ struct SLSDeviceInfo {
   uint64_t memAvailableInBytes;
   size_t currentCost;
 };
+} // namespace
+
+// Do a search starting at an SLS output to capture any Clip or
+// LayerNormalization nodes which are there
+static void expandFrontier(Node *node, const NodeValue &value,
+                           std::unordered_set<NodeValue> &frontier,
+                           std::unordered_set<Node *> &traversedNodes,
+                           bool includeLN) {
+  traversedNodes.insert(node);
+  bool covered = true;
+  auto users = node->getUsers();
+  for (auto j = users.begin(), f = users.end(); j != f; ++j) {
+    Node *user = (*j).getUser();
+    if (ClipNode *CN = llvm::dyn_cast<ClipNode>(user)) {
+      expandFrontier(user, CN->getResult(), frontier, traversedNodes,
+                     includeLN);
+    } else if ((includeLN) &&
+               (user->getKind() ==
+                glow::Kinded::Kind::LayerNormalizationNodeKind)) {
+      expandFrontier(user,
+                     user->getNthResult(LayerNormalizationNode::ResultIdx),
+                     frontier, traversedNodes, includeLN);
+    } else {
+      covered = false;
+    }
+  }
+  if (!covered) {
+    frontier.insert(value);
+  }
+}
 
 /// Helper function for SparseNN Partitioning scheme. Checks for each
 /// kind of SLS table and appends their metadata to the vector.
 template <typename SLSType>
-Error appendSLSTable(Node &node, std::vector<SLSTableInfo> &slsTables,
-                     bool doPerfModelBalance, Backend *backend) {
-  auto *SLS0 = llvm::dyn_cast<SLSType>(&node);
-  if (SLS0) {
+static Error appendSLSTable(Node &node, std::vector<SLSTableInfo> &slsTables,
+                            bool doPerfModelBalance, Backend *backend,
+                            bool addLN) {
+  auto *SLS = llvm::dyn_cast<SLSType>(&node);
+  if (SLS) {
     uint64_t cost = 1;
     uint64_t numBytesInTable =
-        (uint64_t)SLS0->getData().getType()->getSizeInBytes();
+        (uint64_t)SLS->getData().getType()->getSizeInBytes();
 
     // If average length is available, then compute cost using perf model
     if (doPerfModelBalance) {
       double cost_d;
-      ASSIGN_VALUE_OR_RETURN_ERR(cost_d, backend->estimateNodeCost(SLS0));
+      ASSIGN_VALUE_OR_RETURN_ERR(cost_d, backend->estimateNodeCost(SLS));
       cost = (uint64_t)cost_d;
     }
-    auto slsResult = SLS0->getResult();
-    slsTables.push_back({SLS0, numBytesInTable, 0, slsResult, cost});
+    auto slsResult = SLS->getResult();
+
+    std::unordered_set<NodeValue> frontier;
+    std::unordered_set<Node *> neighbors;
+    expandFrontier(SLS, slsResult, frontier, neighbors, addLN);
+
+    // neighbors contains only successors; add all predecessors too.
+    std::queue<Node *> preds;
+    preds.push(SLS);
+    while (!preds.empty()) {
+      auto *cur = preds.front();
+      if (cur != SLS) {
+        neighbors.insert(cur);
+      }
+      preds.pop();
+      for (auto *node : getInputs(cur)) {
+        preds.push(node);
+      }
+    }
+
+    slsTables.push_back(
+        {SLS, neighbors, frontier, numBytesInTable, 0, slsResult, cost});
   }
   return Error::success();
 }
@@ -1070,21 +1124,21 @@ static void cloneSplatWeightsIfNecessary(T *SLWS, Function *F) {
 }
 
 // Insert Split->Concat at barrier between SLS and Non-SLS partitions
-Error sparseNNInsertSplitConcat(Function *F,
-                                std::vector<SLSDeviceInfo> slsDevices,
-                                std::vector<std::vector<NodeValue>> frontiers,
-                                PartitionConfig &partitionConfig) {
+static Error
+sparseNNInsertSplitConcat(Function *F, size_t numSLSDevices,
+                          std::vector<std::unordered_set<NodeValue>> &frontiers,
+                          PartitionConfig &partitionConfig) {
 
   // Walk through SLS tables and check that all the results are able to concat
-  std::vector<std::vector<NodeValue>> concatInputs(slsDevices.size());
+  std::vector<std::vector<NodeValue>> concatInputs(numSLSDevices);
   // Insert concat and slice nodes and assign them to partitions
-  for (size_t p = 0; p < slsDevices.size(); p++) {
-    auto frontier = frontiers[p];
+  for (size_t p = 0; p < numSLSDevices; p++) {
+    auto &frontier = frontiers[p];
 
     if (frontier.size() == 0) {
       continue;
     }
-    auto templateResult = frontier[0];
+    auto &templateResult = *frontier.begin();
     auto templateDims = templateResult.dims();
     auto templateConcatDim = templateDims.size() - 1;
 
@@ -1137,35 +1191,6 @@ Error sparseNNInsertSplitConcat(Function *F,
   return Error::success();
 };
 
-// Do a search starting at an SLS output to capture any Clip or
-// LayerNormalization nodes which are there
-void expandFrontier(const Node *node, const NodeValue &value,
-                    std::vector<NodeValue> &frontier,
-                    std::vector<const Node *> &traversedNodes, bool includeLN) {
-  traversedNodes.push_back(node);
-  bool covered = true;
-  auto users = node->getUsers();
-  for (auto j = users.begin(), f = users.end(); j != f; ++j) {
-    const Node *user = (*j).getUser();
-    if (const ClipNode *CN = llvm::dyn_cast<ClipNode>(user)) {
-      expandFrontier(user, CN->getResult(), frontier, traversedNodes,
-                     includeLN);
-    } else if ((includeLN) &&
-               (user->getKind() ==
-                glow::Kinded::Kind::LayerNormalizationNodeKind)) {
-      const LayerNormalizationNode *LN =
-          llvm::dyn_cast<LayerNormalizationNode>(user);
-      expandFrontier(user, LN->getResult(), frontier, traversedNodes,
-                     includeLN);
-    } else {
-      covered = false;
-    }
-  }
-  if (!covered) {
-    frontier.push_back(value);
-  }
-}
-
 Expected<DAGListTy> Partitioner::partitionSparseNN(CompilationContext &cctx) {
 
   VLOG(1) << "Doing SparseNN partitioning" << std::endl;
@@ -1173,10 +1198,9 @@ Expected<DAGListTy> Partitioner::partitionSparseNN(CompilationContext &cctx) {
   partitionConfig.numOfPartitions = 0;
 
   // Find the first partition with an SLS node
-  std::string funcName;
-  bool foundFunction = false;
-  for (Function *F : module_->getFunctions()) {
-    for (auto &node : F->getNodes()) {
+  Function *F = nullptr;
+  for (Function *currF : module_->getFunctions()) {
+    for (auto &node : currF->getNodes()) {
       if (node.getKind() ==
               glow::Kinded::Kind::
                   FusedRowwiseQuantizedSparseLengthsWeightedSumNodeKind ||
@@ -1191,18 +1215,17 @@ Expected<DAGListTy> Partitioner::partitionSparseNN(CompilationContext &cctx) {
           node.getKind() == glow::Kinded::Kind::EmbeddingBagNodeKind ||
           node.getKind() ==
               glow::Kinded::Kind::EmbeddingBagByteRowwiseOffsetsNodeKind) {
-        funcName = std::string(F->getName());
-        foundFunction = true;
+        F = currF;
         break;
       }
     }
-    if (foundFunction) {
+    if (F) {
       break;
     }
   }
 
   // If no matching functions then return empty config
-  if (!foundFunction) {
+  if (!F) {
     return MAKE_ERR(ErrorValue::ErrorCode::PARTITIONER_ERROR,
                     "Did not find a partition with an SLS node");
   }
@@ -1218,10 +1241,9 @@ Expected<DAGListTy> Partitioner::partitionSparseNN(CompilationContext &cctx) {
   }
 
   // Otherwise partition this function
-  partitionConfig.funcName = funcName;
+  partitionConfig.funcName = F->getName().str();
 
   // First optimize the function
-  Function *F = module_->getFunction(funcName);
   std::vector<Backend *> backends;
   genBackendMap(backendMap_, backendHolder_, backends);
   // First optimize it
@@ -1257,25 +1279,59 @@ Expected<DAGListTy> Partitioner::partitionSparseNN(CompilationContext &cctx) {
   std::vector<SLSTableInfo> slsTables;
   partitionConfig.funcName = std::string(F->getName());
   VLOG(1) << "Function: " << std::string(F->getName()) << std::endl;
+  const bool addLN = cctx.optimizationOpts.sparseNNPartitioningPairLNWithSLS;
   for (auto &node : F->getNodes()) {
     bool doPerfModelBalance =
         cctx.optimizationOpts.sparseNNPartitioningBalancePerfModel;
     RETURN_IF_ERR(
         appendSLSTable<FusedRowwiseQuantizedSparseLengthsWeightedSumNode>(
-            node, slsTables, doPerfModelBalance, backends[0]));
+            node, slsTables, doPerfModelBalance, backends[0], addLN));
     RETURN_IF_ERR(appendSLSTable<FusedRowwiseQuantizedSparseLengthsSumNode>(
-        node, slsTables, doPerfModelBalance, backends[0]));
+        node, slsTables, doPerfModelBalance, backends[0], addLN));
     RETURN_IF_ERR(appendSLSTable<RowwiseQuantizedSparseLengthsWeightedSumNode>(
-        node, slsTables, doPerfModelBalance, backends[0]));
+        node, slsTables, doPerfModelBalance, backends[0], addLN));
     RETURN_IF_ERR(appendSLSTable<SparseLengthsSumNode>(
-        node, slsTables, doPerfModelBalance, backends[0]));
+        node, slsTables, doPerfModelBalance, backends[0], addLN));
     RETURN_IF_ERR(appendSLSTable<SparseLengthsWeightedSumNode>(
-        node, slsTables, doPerfModelBalance, backends[0]));
+        node, slsTables, doPerfModelBalance, backends[0], addLN));
     RETURN_IF_ERR(appendSLSTable<EmbeddingBagNode>(
-        node, slsTables, doPerfModelBalance, backends[0]));
+        node, slsTables, doPerfModelBalance, backends[0], addLN));
     RETURN_IF_ERR(appendSLSTable<EmbeddingBagByteRowwiseOffsetsNode>(
-        node, slsTables, doPerfModelBalance, backends[0]));
+        node, slsTables, doPerfModelBalance, backends[0], addLN));
   }
+
+  // Now determine all nodes that fit in the NonSLS partition, so we know its
+  // total size and can better judge how much space is left for SLS partitions.
+  std::unordered_set<const Node *> slsPartitionNodes;
+  for (auto &slsTable : slsTables) {
+    slsPartitionNodes.insert(slsTable.node);
+    for (const Node *N : slsTable.neighbors) {
+      slsPartitionNodes.insert(N);
+    }
+  }
+
+  // Fill up the last partition with NonSLS nodes.
+  NodesSet nonSLSPartitionNodes;
+  for (auto &node : F->getNodes()) {
+    if (!slsPartitionNodes.count(&node)) {
+      partitionConfig.nodeToPartition[node.getName()] =
+          cctx.optimizationOpts.sparseNNPartitioningSchemeNumCards;
+      nonSLSPartitionNodes.insert(&node);
+    }
+  }
+
+  // Calculate how much space the NonSLS partition takes up, and compare that to
+  // how much memory the device has to determine the allows SLS partition size.
+  const uint64_t nonSLSPartitionSize =
+      getGraphMemInfo(nonSLSPartitionNodes, contextCount_).getTotalMemSize();
+  const uint64_t totalDeviceMemory = deviceInfo_[0].availableMemory;
+  RETURN_ERR_IF_NOT(
+      nonSLSPartitionSize < totalDeviceMemory,
+      strFormat(
+          "nonSLSPartitionSize %lu must be less than %s totalDeviceMemory %lu",
+          nonSLSPartitionSize, deviceInfo_[0].backendName.c_str(),
+          totalDeviceMemory));
+  const uint64_t allowedSLSMemBytes = totalDeviceMemory - nonSLSPartitionSize;
 
   // Now sort SLS tables by size decreasing
   VLOG(1) << "SLS tables sorted by size decreasing" << std::endl;
@@ -1296,16 +1352,11 @@ Expected<DAGListTy> Partitioner::partitionSparseNN(CompilationContext &cctx) {
   for (unsigned int device = 0;
        device < cctx.optimizationOpts.sparseNNPartitioningSchemeNumCards;
        device++) {
-    slsDevices.push_back(
-        {device,
-         (uint64_t)(
-             (uint64_t)1024 *
-             (uint64_t)(cctx.optimizationOpts
-                            .sparseNNPartitioningSchemeSLSTableKBytesPerCard)),
-         0});
+    slsDevices.push_back({device, allowedSLSMemBytes, 0});
   }
 
   // Now assign SLS Nodes to devices
+  std::vector<std::unordered_set<NodeValue>> frontierValues(slsDevices.size());
   for (auto &table : slsTables) {
 
     // Sort by cost increasing
@@ -1321,14 +1372,31 @@ Expected<DAGListTy> Partitioner::partitionSparseNN(CompilationContext &cctx) {
               << device.currentCost << std::endl;
     }
 
+    // Calculate the size of the SLS and all neighbors, i.e. the total
+    // additional memory needed to add to the device.
+    GraphMemInfo graphMem;
+    NodesSet currentPartition;
+    graphMem.contextCount = contextCount_;
+    // Insert SLS node, and then insert all neighbors.
+    graphMem =
+        updateGraphMemInfoByAddingNode(currentPartition, graphMem, table.node);
+    currentPartition.insert(table.node);
+    for (Node *N : table.neighbors) {
+      graphMem = updateGraphMemInfoByAddingNode(currentPartition, graphMem, N);
+      currentPartition.insert(N);
+    }
+    const uint64_t totalSize = graphMem.getTotalMemSize();
+
     // Pick the first that fits
     bool deviceFound = false;
     for (unsigned int d = 0; d < slsDevices.size(); d++) {
-      if (slsDevices[d].memAvailableInBytes >= table.numBytesInTable) {
+      if (slsDevices[d].memAvailableInBytes >= totalSize) {
         deviceFound = true;
-        slsDevices[d].memAvailableInBytes -= table.numBytesInTable;
+        slsDevices[d].memAvailableInBytes -= totalSize;
         slsDevices[d].currentCost += (size_t)table.cost;
         table.deviceId = slsDevices[d].deviceId;
+        frontierValues[table.deviceId].insert(table.frontier.begin(),
+                                              table.frontier.end());
         break;
       }
     }
@@ -1382,61 +1450,15 @@ Expected<DAGListTy> Partitioner::partitionSparseNN(CompilationContext &cctx) {
   // Map SLS nodes to their partitions
   for (auto &table : slsTables) {
     partitionConfig.nodeToPartition[table.node->getName()] = table.deviceId;
-  }
-
-  // For each partition, go through all SLS tables assigned and get all their
-  // predecessors into the same partition
-  for (size_t p = 0; p < slsDevices.size(); p++) {
-    std::queue<Node *> preds;
-    for (auto &table : slsTables) {
-      if (table.deviceId == p) {
-        preds.push(table.node);
-      }
-    }
-    while (!preds.empty()) {
-      auto cur = preds.front();
-      preds.pop();
-      for (auto &node : getInputs(cur)) {
-        if (partitionConfig.nodeToPartition.find(node->getName()) ==
-            partitionConfig.nodeToPartition.end()) {
-          partitionConfig.nodeToPartition[node->getName()] = p;
-          preds.push(node);
-        }
-      }
-    }
-  }
-
-  // Also, go through all SLS tables and assign any Clip or LN following
-  // them to same partition
-  std::vector<std::vector<NodeValue>> frontierValues(slsDevices.size());
-  for (dim_t deviceId = 0; deviceId < slsDevices.size(); deviceId++) {
-    std::vector<const Node *> traversedNodes;
-    for (auto &table : slsTables) {
-      if (table.deviceId == deviceId) {
-        bool includeLN =
-            cctx.optimizationOpts.sparseNNPartitioningPairLNWithSLS;
-        expandFrontier(table.node, table.slsResult, frontierValues[deviceId],
-                       traversedNodes, includeLN);
-      }
-    }
-    // Assign the nodes encountered to this partition
-    for (auto &node : traversedNodes) {
-      partitionConfig.nodeToPartition[node->getName()] = deviceId;
-    }
-  }
-
-  // All other nodes go in the last partition
-  for (auto &node : F->getNodes()) {
-    if (partitionConfig.nodeToPartition.find(node.getName()) ==
-        partitionConfig.nodeToPartition.end()) {
-      partitionConfig.nodeToPartition[node.getName()] = slsDevices.size();
+    for (Node *N : table.neighbors) {
+      partitionConfig.nodeToPartition[N->getName()] = table.deviceId;
     }
   }
 
   // Insert Split->Concat at barrier between SLS and Non-SLS partitions
   if (cctx.optimizationOpts.sparseNNPartitioningAddSLSConcats) {
-    RETURN_IF_ERR(sparseNNInsertSplitConcat(F, slsDevices, frontierValues,
-                                            partitionConfig));
+    RETURN_IF_ERR(sparseNNInsertSplitConcat(F, slsDevices.size(),
+                                            frontierValues, partitionConfig));
   }
 
   VLOG(1) << " Finished SparseNN partitioning" << std::endl;


### PR DESCRIPTION
Summary:
This diff removes the use of `sparseNNPartitioningSchemeSLSTableKBytesPerCard`. Instead, during SNN partitioning, we:

- Gather all Nodes for every SparseNN sub-graph (predecessors, and Clip/LN successors, called `neighbors`) inside each `SLSTableInfo`.
- Look for all nodes that are not in some set of `neighbors` and add them to the `NonSLSPartition`.
- Get the size of that `NonSLSPartition` and validate it fits inside the device's memory
- Subtract `NonSLSPartition` size from device's memory and use that memory size as the max size for SLS partitions.
- When adding an SLS node and its `neighbors` to an SLS partition, include its neighbors memory footprint

Also included small cleanups in the partitioner for data structures and pass-by-reference.

Reviewed By: mjanderson09

Differential Revision: D24472119

