### PR TITLE
Fold Min + Max into Clip

### DIFF
--- a/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
+++ b/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
@@ -60,6 +60,7 @@ FUN_PASS(OptimizeConcatQuantization)
 FUN_PASS(SinkConcatBelowQuantize)
 FUN_PASS(FoldLayerNormArithmetic)
 FUN_PASS(QuantizeSwish)
+FUN_PASS(FoldMinMaxtoClip)
 
 
 // NOTE: This pass must be last; it's used to count the total number of passes.

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1659,7 +1659,9 @@ UNARY_ARITHMETIC_FUN_DEF(Cos)
   NODE_NAME_##Node *Function::create##NODE_NAME_(                              \
       llvm::StringRef name, TypeRef T, NodeValue LHS, NodeValue RHS) {         \
     DCHECK(LHS.dims() == RHS.dims())                                           \
-        << "Invalid operand shapes " << LHS.dims() << " vs " << RHS.dims();    \
+        << "Invalid operand shapes LHS:" << LHS.getNode()->getName().str()     \
+        << " RHS: " << RHS.getNode()->getName().str() << " " << LHS.dims()     \
+        << " vs " << RHS.dims();                                               \
     TypeRef OT = getParent()->uniqueType(*T);                                  \
     return addNode(new NODE_NAME_##Node(name, OT, LHS, RHS));                  \
   }

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -4824,7 +4824,7 @@ bool FoldElemKindConversionIntoOutputs::run(Function *F,
 /// Broadcasts are implemented via as BroadcastNode. This helper unwinds
 /// BroadcastNode -- it \returns the original Node before the broadcasting \p N
 /// if the broadcast takes place between the 0th dimension to \p endDim.
-/// Otherwise, \p return nullptr.
+/// Otherwise, \p return \p N.
 static NodeValue unwindBroadcast(NodeValue N, unsigned_t endDim) {
   if (auto *BN = dyn_cast<BroadcastNode>(N)) {
     const auto newShape = BN->getTargetDim();
@@ -4832,12 +4832,12 @@ static NodeValue unwindBroadcast(NodeValue N, unsigned_t endDim) {
     const auto &origDims = BN->getInput().dims();
 
     if (origDims.size() + axis != newShape.size()) {
-      return nullptr;
+      return N;
     }
 
     for (dim_t i = endDim; i < newShape.size(); i++) {
       if (!(i >= axis && origDims[i - axis] == newShape[i])) {
-        return nullptr;
+        return N;
       }
     }
 
@@ -4876,7 +4876,8 @@ bool FoldLayerNormArithmetic::run(Function *F, const CompilationContext &cctx) {
     NodeValue RHS = unwindBroadcast(N.getNthInput(ArithmeticNode::RHSIdx),
                                     LN->getResult().dims().size() -
                                         LN->getScale().dims().size());
-    if (!RHS.getNode()) {
+
+    if (!isa<SplatNode>(RHS) && !isa<Constant>(RHS)) {
       continue;
     }
 
@@ -5097,6 +5098,104 @@ bool QuantizeSwish::run(Function *F, const CompilationContext &cctx) {
     QN->getResult().replaceAllUsesOfWith(newSN);
     changed = true;
   }
+  return changed;
+}
+
+/// Fold Min -> Max or Max -> Min to Clip
+/// We need to place this function after `OptimizeArithmeticNodes` in which the
+/// constant operator in commutative nodes is moved to the RHS, so that we can
+/// assume SplatNode is on the RHS of MinNode (MaxNode).
+/// Only if it's the following structure we do this optimization
+///
+///   someOtherInput  SplatNode
+///              \     /
+///  SplatNode   MinNode (MaxNode)
+///         \     /
+///         MaxNode (MinNode)
+///            |
+///           Out
+///
+/// ClipNode's min will be the SplatNode (maxSN) connected to the MaxNode.
+/// ClipNode's max will be the SplatNode (minSN) connected to the MinNode.
+bool FoldMinMaxtoClip::run(Function *F, const CompilationContext &cctx) {
+  LOG_SCOPE(F->getLogContext(), getName());
+
+  bool changed = false;
+  for (auto &N : F->getNodes()) {
+    MaxNode *maxNode = dyn_cast<MaxNode>(&N);
+    MinNode *minNode = dyn_cast<MinNode>(&N);
+    NodeValue otherInput;
+    NodeValue resultNV;
+    SplatNode *minSN = nullptr;
+    SplatNode *maxSN = nullptr;
+
+    // We assume SplatNode is on the RHS.
+    // If currect node is MinNode
+    //  - try casting the input to MaxNode and SplatNode.
+    //  - If LHS of MinNode is MaxNode
+    //    - try casting RHS of maxNode to SplatNode.
+    if (minNode) {
+      resultNV = minNode->getResult();
+      maxNode = dyn_cast<MaxNode>(
+          unwindBroadcast(minNode->getLHS(), minNode->getLHS().dims().size()));
+      minSN = dyn_cast<SplatNode>(
+          unwindBroadcast(minNode->getRHS(), minNode->getRHS().dims().size()));
+
+      if (maxNode) {
+        maxSN = dyn_cast<SplatNode>(unwindBroadcast(
+            maxNode->getRHS(), maxNode->getRHS().dims().size()));
+        otherInput =
+            unwindBroadcast(maxNode->getLHS(), maxNode->getLHS().dims().size());
+      }
+    } else if (maxNode) { // vice versa for MaxNode
+      resultNV = maxNode->getResult();
+      minNode = dyn_cast<MinNode>(
+          unwindBroadcast(maxNode->getLHS(), maxNode->getLHS().dims().size()));
+      maxSN = dyn_cast<SplatNode>(
+          unwindBroadcast(maxNode->getRHS(), maxNode->getRHS().dims().size()));
+
+      if (minNode) {
+        minSN = dyn_cast<SplatNode>(unwindBroadcast(
+            minNode->getRHS(), minNode->getRHS().dims().size()));
+        otherInput =
+            unwindBroadcast(minNode->getLHS(), minNode->getLHS().dims().size());
+      }
+    }
+
+    // If any of these is nullptr, it means the structure is not the same as
+    // above example.
+    if (!(minNode && maxNode && minSN && maxSN)) {
+      continue;
+    }
+
+    // If minSN is smaller than maxSN, which is really weird because every entry
+    // of the result will be a same number. In this case, we don't fold them.
+    if (minSN->getValue() < maxSN->getValue()) {
+      DLOG(INFO) << "Catch a combination of MinNode and MaxNode while MinSplat "
+                    "is smaller than MaxSplat, which would make all entries of "
+                    "the result tensor to be the same!";
+      continue;
+    }
+
+    // The second node is broadcasted and we need to broadcast the otherInput.
+    if (otherInput.dims() != resultNV.dims()) {
+      otherInput = F->createBroadcast(
+          otherInput.getNode()->getName().str() + ".broadcast", otherInput,
+          resultNV.dims(), resultNV.dims().size() - otherInput.dims().size());
+    }
+
+    // MinSN is the SplatNode input of MinNode while MaxSN is the SplatNode
+    // input of MaxNode. MinSN should be greater than MaxSN so we put MaxSN as
+    // the min of ClipNode.
+    auto minValue = maxSN->getValue();
+    auto maxValue = minSN->getValue();
+    ClipNode *CN = F->createClip(resultNV.getNode()->getName(), otherInput,
+                                 resultNV.getType(),
+                                 /* min */ minValue, /* max */ maxValue);
+    resultNV.replaceAllUsesOfWith(CN->getResult());
+    changed = true;
+  }
+
   return changed;
 }
 

--- a/lib/Optimizer/GraphOptimizerPipeline/FunctionPassPipeline.cpp
+++ b/lib/Optimizer/GraphOptimizerPipeline/FunctionPassPipeline.cpp
@@ -190,6 +190,11 @@ createFP16GraphOptimizationPassPipeline() {
 
 std::unique_ptr<FunctionPassPipeline> createDefaultFoldPassPipeline() {
   std::initializer_list<FunctionPassConfig> configs{
+      // Optimize arithmetic nodes based on algebraic identities.
+      // In this function, constant operators in communative nodes are moved to
+      // the RHS. Some folding functions depend on this. (e.g. FoldMinMaxtoClip)
+      {FunctionPassID::OptimizeArithmeticNodes},
+
       // Get Reshape nodes merged into constants to simplify folding.
       {FunctionPassID::OptimizeReshape},
 
@@ -201,6 +206,9 @@ std::unique_ptr<FunctionPassPipeline> createDefaultFoldPassPipeline() {
 
       // Fold MatMul->Add into FullyConnected.
       {FunctionPassID::FoldMatMulAddIntoFullyConnected},
+
+      // Fold Min + Max to Clip
+      {FunctionPassID::FoldMinMaxtoClip},
 
       // Perform Dead Code Elimination.
       getDCEPassConfig(),


### PR DESCRIPTION
Summary:
Fixes https://github.com/pytorch/glow/issues/4769

Enable folding Min -> Max or Max -> Min to a ClipNode.

Backends can then opt to lower them again or not when it is desired to provide atomic implementations or to fuse Clip into Convolution etc.

Differential Revision: D24484841

