### PR TITLE
Support export/import large deferred weights

### DIFF
--- a/include/glow/Importer/ONNXModelLoader.h
+++ b/include/glow/Importer/ONNXModelLoader.h
@@ -44,7 +44,7 @@ namespace glow {
 /// Loads tensor \p T from the input \p in. \p useGlowCustomOps changes the
 /// format for doc_string format for adding meta information.
 Error loadTensor(const ONNX_NAMESPACE::TensorProto &in, Tensor *T,
-                 bool useGlowCustomOps = false);
+                 bool useGlowCustomOps = false, const std::string &data = "");
 
 /// Parses as input file name \p fileName which is an ONNX file
 /// and \returns a parsed GraphProto.

--- a/include/glow/Support/ZipUtils.h
+++ b/include/glow/Support/ZipUtils.h
@@ -83,6 +83,7 @@ public:
   ~ZipReader();
   void init();
   std::string getRecord(const std::string &name);
+  bool hasRecord(const std::string &name);
 };
 
 /// Zip Writer

--- a/lib/Importer/ONNXModelLoader.cpp
+++ b/lib/Importer/ONNXModelLoader.cpp
@@ -540,7 +540,7 @@ void glow::fillPlaceholders(const std::string &fileName,
 
 /// Loads tensor \p T from the input \p in.
 Error glow::loadTensor(const ONNX_NAMESPACE::TensorProto &in, Tensor *T,
-                       bool useGlowCustomOps) {
+                       bool useGlowCustomOps, const std::string &data) {
   std::vector<dim_t> dim;
   for (auto d : in.dims()) {
     dim.push_back(d);
@@ -555,8 +555,9 @@ Error glow::loadTensor(const ONNX_NAMESPACE::TensorProto &in, Tensor *T,
       for (auto f : in.float_data()) {
         TH.raw(i++) = f;
       }
-    } else if (in.has_raw_data()) {
-      std::istringstream inStream(in.raw_data(), std::stringstream::binary);
+    } else if (in.has_raw_data() || !data.empty()) {
+      std::istringstream inStream(data.empty() ? in.raw_data() : data,
+                                  std::stringstream::binary);
       inStream.read(T->getUnsafePtr(), T->size() * sizeof(float));
     } else {
       return MAKE_ERR("Unsupported Tensor format for FLOAT, name: " + in.name(),
@@ -564,8 +565,9 @@ Error glow::loadTensor(const ONNX_NAMESPACE::TensorProto &in, Tensor *T,
     }
   } else if (in.data_type() == ONNX_NAMESPACE::TensorProto::FLOAT16) {
     T->reset(ElemKind::Float16Ty, dim);
-    if (in.has_raw_data()) {
-      std::istringstream inStream(in.raw_data(), std::stringstream::binary);
+    if (in.has_raw_data() || !data.empty()) {
+      std::istringstream inStream(data.empty() ? in.raw_data() : data,
+                                  std::stringstream::binary);
       inStream.read(T->getUnsafePtr(), T->size() * (sizeof(float) / 2));
     } else {
       return MAKE_ERR("Unsupported Tensor format for FLOAT16, name: " +
@@ -574,8 +576,9 @@ Error glow::loadTensor(const ONNX_NAMESPACE::TensorProto &in, Tensor *T,
     }
   } else if (in.data_type() == ONNX_NAMESPACE::TensorProto::BFLOAT16) {
     T->reset(ElemKind::BFloat16Ty, dim);
-    if (in.has_raw_data()) {
-      std::istringstream inStream(in.raw_data(), std::stringstream::binary);
+    if (in.has_raw_data() || !data.empty()) {
+      std::istringstream inStream(data.empty() ? in.raw_data() : data,
+                                  std::stringstream::binary);
       inStream.read(T->getUnsafePtr(), T->size() * (sizeof(float) / 2));
     } else {
       return MAKE_ERR("Unsupported Tensor format for BFLOAT16, name: " +
@@ -591,8 +594,9 @@ Error glow::loadTensor(const ONNX_NAMESPACE::TensorProto &in, Tensor *T,
       for (auto f : in.int64_data()) {
         TH.raw(i++) = f;
       }
-    } else if (in.has_raw_data()) {
-      std::istringstream inStream(in.raw_data(), std::stringstream::binary);
+    } else if (in.has_raw_data() || !data.empty()) {
+      std::istringstream inStream(data.empty() ? in.raw_data() : data,
+                                  std::stringstream::binary);
       inStream.read(T->getUnsafePtr(), T->size() * sizeof(int64_t));
     } else {
       return MAKE_ERR("Unsupported Tensor format for INT64, name: " + in.name(),
@@ -604,8 +608,9 @@ Error glow::loadTensor(const ONNX_NAMESPACE::TensorProto &in, Tensor *T,
         ty, parseTypeFromDocString(in.doc_string(), dim, useGlowCustomOps));
     T->reset(ty);
 
-    if (in.has_raw_data()) {
-      std::istringstream inStream(in.raw_data(), std::stringstream::binary);
+    if (in.has_raw_data() || !data.empty()) {
+      std::istringstream inStream(data.empty() ? in.raw_data() : data,
+                                  std::stringstream::binary);
       inStream.read(T->getUnsafePtr(), T->size() * sizeof(int8_t));
     } else {
       return MAKE_ERR("Unsupported Tensor format for INT8, name: " + in.name(),
@@ -617,8 +622,9 @@ Error glow::loadTensor(const ONNX_NAMESPACE::TensorProto &in, Tensor *T,
         ty, parseTypeFromDocString(in.doc_string(), dim, useGlowCustomOps));
     T->reset(ty);
 
-    if (in.has_raw_data()) {
-      std::istringstream inStream(in.raw_data(), std::stringstream::binary);
+    if (in.has_raw_data() || !data.empty()) {
+      std::istringstream inStream(data.empty() ? in.raw_data() : data,
+                                  std::stringstream::binary);
       inStream.read(T->getUnsafePtr(), T->size() * sizeof(int16_t));
     } else {
       return MAKE_ERR("Unsupported Tensor format for INT16, name: " + in.name(),
@@ -642,8 +648,9 @@ Error glow::loadTensor(const ONNX_NAMESPACE::TensorProto &in, Tensor *T,
       for (auto f : in.int32_data()) {
         TH.raw(i++) = f;
       }
-    } else if (in.has_raw_data()) {
-      std::istringstream inStream(in.raw_data(), std::stringstream::binary);
+    } else if (in.has_raw_data() || !data.empty()) {
+      std::istringstream inStream(data.empty() ? in.raw_data() : data,
+                                  std::stringstream::binary);
       inStream.read(T->getUnsafePtr(), T->size() * sizeof(int32_t));
     } else {
       return MAKE_ERR("Unsupported Tensor format for INT32, name: " + in.name(),
@@ -655,8 +662,9 @@ Error glow::loadTensor(const ONNX_NAMESPACE::TensorProto &in, Tensor *T,
         ty, parseTypeFromDocString(in.doc_string(), dim, useGlowCustomOps));
     T->reset(ty);
 
-    if (in.has_raw_data()) {
-      std::istringstream inStream(in.raw_data(), std::stringstream::binary);
+    if (in.has_raw_data() || !data.empty()) {
+      std::istringstream inStream(data.empty() ? in.raw_data() : data,
+                                  std::stringstream::binary);
       inStream.read(T->getUnsafePtr(), T->size() * sizeof(uint8_t));
     } else {
       return MAKE_ERR("Unsupported Tensor format for UINT8, name: " + in.name(),
@@ -664,8 +672,9 @@ Error glow::loadTensor(const ONNX_NAMESPACE::TensorProto &in, Tensor *T,
     }
   } else if (in.data_type() == ONNX_NAMESPACE::TensorProto::BOOL) {
     T->reset(ElemKind::BoolTy, dim);
-    if (in.has_raw_data()) {
-      std::istringstream inStream(in.raw_data(), std::stringstream::binary);
+    if (in.has_raw_data() || !data.empty()) {
+      std::istringstream inStream(data.empty() ? in.raw_data() : data,
+                                  std::stringstream::binary);
       inStream.read(T->getUnsafePtr(), T->size() * sizeof(bool));
     } else if (in.int32_data_size() > 0) {
       // Some ONNX models use int32_data to initialize bool type (e.g., when

--- a/lib/Support/ZipUtils.cpp
+++ b/lib/Support/ZipUtils.cpp
@@ -109,6 +109,18 @@ size_t ZipReader::getRecordID(const std::string &name) {
   return result;
 }
 
+bool ZipReader::hasRecord(const std::string &name) {
+  std::stringstream ss;
+  ss << archive_name_ << "/" << name;
+  mz_zip_reader_locate_file(ar_.get(), ss.str().c_str(), nullptr, 0);
+  bool result = ar_->m_last_error != MZ_ZIP_FILE_NOT_FOUND;
+  if (!result) {
+    ar_->m_last_error = MZ_ZIP_NO_ERROR;
+  }
+  valid("attempting to locate file ", name.c_str());
+  return result;
+}
+
 std::string ZipReader::getRecord(const std::string &name) {
   size_t key = getRecordID(name);
   mz_zip_archive_file_stat stat;

--- a/tests/unittests/Repro.cpp
+++ b/tests/unittests/Repro.cpp
@@ -316,7 +316,7 @@ public:
     }
 
     std::stringstream ss;
-    ss << "weight_" << i_++;
+    ss << "weight_" << i_;
     largeBuffer_ = zip_->getRecord(ss.str());
     ::ONNX_NAMESPACE::TensorProto t;
     t.ParseFromString(largeBuffer_);
@@ -332,8 +332,17 @@ public:
     }
     auto ty = typeInfo_[currentBlobName_];
 
+    ss.str("");
+    ss << "data_" << i_++;
+    largeBuffer_.clear();
+    if (zip_->hasRecord(ss.str())) {
+      largeBuffer_ = zip_->getRecord(ss.str());
+      LOG(INFO) << "Read weight data " << ss.str() << " of size "
+                << largeBuffer_.size();
+    }
     currentTensor_.reset(new ::glow::Tensor());
-    RETURN_IF_ERR(::glow::loadTensor(t, currentTensor_.get()));
+    RETURN_IF_ERR(::glow::loadTensor(t, currentTensor_.get(),
+                                     /*useGlowCustomOps*/ false, largeBuffer_));
     CHECK(currentTensor_->getType().isEqual(ty))
         << "Mismatched tensor type: " << currentTensor_->getType().toString()
         << " vs " << ty.toString();


### PR DESCRIPTION
Summary:
Protobuf cannot support size larger than 2GB. Now we have embedding tables larger than 2GB, hence we cannot use TensorProto to carry the data anymore. This diff uses TensorProto to carry meta data only and save the raw bytes in a different file in the zip. When loading the deferred weights, similar logic is added.

This change should be backward compatible, as repro can still load previously generated .zip models fine.

Reviewed By: jfix71

Differential Revision: D24508593

