### PR TITLE
[torch_glow] Add support for logical ops (and, or, xor, not)

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -899,6 +899,10 @@ PyTorchModelLoader::buildSymbolsMapping() {
       {{"aten::ceil"}, &PyTorchModelLoader::loadCeil},
       {{"aten::mean"}, &PyTorchModelLoader::loadMean},
       {{"aten::pow"}, &PyTorchModelLoader::loadPow},
+      {{"aten::logical_xor"}, &PyTorchModelLoader::loadLogicalXor},
+      {{"aten::logical_or"}, &PyTorchModelLoader::loadLogicalOr},
+      {{"aten::logical_and"}, &PyTorchModelLoader::loadLogicalAnd},
+      {{"aten::logical_not"}, &PyTorchModelLoader::loadLogicalNot},
       {{"aten::dropout", "aten::dropout_"}, &PyTorchModelLoader::loadDropout},
       {{"aten::sqrt", "aten::sqrt_"}, &PyTorchModelLoader::loadSqrt},
       {{"aten::clamp"}, &PyTorchModelLoader::loadClamp},
@@ -2858,6 +2862,53 @@ Error PyTorchModelLoader::loadPow(const torch::jit::Node *ptNode) {
 
   glow::PowNode *glowNode = F_.createPow("pow", input, exponent);
   RETURN_ERR(addValueMapping(outputs[0], glowNode->getResult()));
+}
+
+Error PyTorchModelLoader::loadLogicalXor(const torch::jit::Node *ptNode) {
+  auto inputs = ptNode->inputs();
+  auto outputs = ptNode->outputs();
+  RETURN_IF_ERR(checkInputAndOutputSizes(inputs, 2, outputs, 1));
+
+  glow::NodeValue res;
+  ASSIGN_VALUE_OR_RETURN_ERR(
+      res, loadArithmeticNode<XorNode>("logical_xor", inputs[0], inputs[1]));
+
+  RETURN_ERR(addValueMapping(outputs[0], res));
+}
+
+Error PyTorchModelLoader::loadLogicalOr(const torch::jit::Node *ptNode) {
+  auto inputs = ptNode->inputs();
+  auto outputs = ptNode->outputs();
+  RETURN_IF_ERR(checkInputAndOutputSizes(inputs, 2, outputs, 1));
+
+  glow::NodeValue res;
+  ASSIGN_VALUE_OR_RETURN_ERR(
+      res, loadArithmeticNode<OrNode>("logical_or", inputs[0], inputs[1]));
+
+  RETURN_ERR(addValueMapping(outputs[0], res));
+}
+
+Error PyTorchModelLoader::loadLogicalAnd(const torch::jit::Node *ptNode) {
+  auto inputs = ptNode->inputs();
+  auto outputs = ptNode->outputs();
+  RETURN_IF_ERR(checkInputAndOutputSizes(inputs, 2, outputs, 1));
+
+  glow::NodeValue res;
+  ASSIGN_VALUE_OR_RETURN_ERR(
+      res, loadArithmeticNode<AndNode>("logical_and", inputs[0], inputs[1]));
+
+  RETURN_ERR(addValueMapping(outputs[0], res));
+}
+
+Error PyTorchModelLoader::loadLogicalNot(const torch::jit::Node *ptNode) {
+  auto inputs = ptNode->inputs();
+  auto outputs = ptNode->outputs();
+  RETURN_IF_ERR(checkInputAndOutputSizes(inputs, 1, outputs, 1));
+
+  glow::NodeValue glowInput;
+  ASSIGN_VALUE_OR_RETURN_ERR(glowInput, getGlowNodeValueForValue(inputs[0]));
+
+  return addValueMapping(outputs[0], F_.createNot("logical_not", glowInput));
 }
 
 Error PyTorchModelLoader::loadSqrt(const torch::jit::Node *ptNode) {

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -485,6 +485,22 @@ private:
   /// \returns error on failure.
   Error loadPow(const torch::jit::Node *ptNode);
 
+  /// Load a PyTorch xor node.
+  /// \returns error on failure.
+  Error loadLogicalXor(const torch::jit::Node *ptNode);
+
+  /// Load a PyTorch or node.
+  /// \returns error on failure.
+  Error loadLogicalOr(const torch::jit::Node *ptNode);
+
+  /// Load a PyTorch and node.
+  /// \returns error on failure.
+  Error loadLogicalAnd(const torch::jit::Node *ptNode);
+
+  /// Load a PyTorch not node.
+  /// \returns error on failure.
+  Error loadLogicalNot(const torch::jit::Node *ptNode);
+
   /// Load a PyTorch sqrt node.
   /// \returns error on failure.
   Error loadSqrt(const torch::jit::Node *ptNode);

--- a/torch_glow/tests/nodes/logical_ops_test.py
+++ b/torch_glow/tests/nodes/logical_ops_test.py
@@ -1,0 +1,129 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+
+import torch
+from parameterized import parameterized
+from tests import utils
+
+
+class SimpleXorModule(torch.nn.Module):
+    def __init__(self):
+        super(SimpleXorModule, self).__init__()
+
+    def forward(self, a, b):
+        c = torch.logical_xor(a, b)
+        return torch.logical_xor(c, c)
+
+
+class SimpleOrModule(torch.nn.Module):
+    def __init__(self):
+        super(SimpleOrModule, self).__init__()
+
+    def forward(self, a, b):
+        c = torch.logical_or(a, b)
+        return torch.logical_or(c, c)
+
+
+class SimpleAndModule(torch.nn.Module):
+    def __init__(self):
+        super(SimpleAndModule, self).__init__()
+
+    def forward(self, a, b):
+        c = torch.logical_and(a, b)
+        return torch.logical_and(c, c)
+
+
+class SimpleNotModule(torch.nn.Module):
+    def __init__(self):
+        super(SimpleNotModule, self).__init__()
+
+    def forward(self, a):
+        b = torch.logical_not(a)
+        return torch.logical_not(b)
+
+
+class TestXor(unittest.TestCase):
+    @parameterized.expand(
+        [
+            (
+                "basic",
+                torch.zeros((3, 4, 5), dtype=torch.bool),
+                torch.ones((3, 4, 5), dtype=torch.bool),
+            ),
+            (
+                "broadcast",
+                torch.zeros((3, 4, 5), dtype=torch.bool),
+                torch.ones((4, 5), dtype=torch.bool),
+            ),
+        ]
+    )
+    def test_xor(self, _, a, b, skip_to_glow=False):
+        utils.compare_tracing_methods(
+            SimpleXorModule(),
+            a,
+            b,
+            fusible_ops={"aten::logical_xor"},
+            skip_to_glow=skip_to_glow,
+        )
+
+
+class TestOr(unittest.TestCase):
+    @parameterized.expand(
+        [
+            (
+                "basic",
+                torch.zeros((3, 4, 5), dtype=torch.bool),
+                torch.ones((3, 4, 5), dtype=torch.bool),
+            ),
+            (
+                "broadcast",
+                torch.zeros((3, 4, 5), dtype=torch.bool),
+                torch.ones((4, 5), dtype=torch.bool),
+            ),
+        ]
+    )
+    def test_or(self, _, a, b, skip_to_glow=False):
+        utils.compare_tracing_methods(
+            SimpleOrModule(),
+            a,
+            b,
+            fusible_ops={"aten::logical_or"},
+            skip_to_glow=skip_to_glow,
+        )
+
+
+class TestAnd(unittest.TestCase):
+    @parameterized.expand(
+        [
+            (
+                "basic",
+                torch.zeros((3, 4, 5), dtype=torch.bool),
+                torch.ones((3, 4, 5), dtype=torch.bool),
+            ),
+            (
+                "broadcast",
+                torch.zeros((3, 4, 5), dtype=torch.bool),
+                torch.ones((4, 5), dtype=torch.bool),
+            ),
+        ]
+    )
+    def test_and(self, _, a, b, skip_to_glow=False):
+        utils.compare_tracing_methods(
+            SimpleAndModule(),
+            a,
+            b,
+            fusible_ops={"aten::logical_and"},
+            skip_to_glow=skip_to_glow,
+        )
+
+
+class TestNot(unittest.TestCase):
+    @parameterized.expand([("basic", torch.zeros((3, 4, 5), dtype=torch.bool))])
+    def test_not(self, _, a, skip_to_glow=False):
+        utils.compare_tracing_methods(
+            SimpleNotModule(),
+            a,
+            fusible_ops={"aten::logical_not"},
+            skip_to_glow=skip_to_glow,
+        )

--- a/torch_glow/tests/utils.py
+++ b/torch_glow/tests/utils.py
@@ -92,15 +92,23 @@ def assert_equivalent(result, other_result, atol=5e-4, rtol=1e-3):
             assert_equivalent(a, b, atol=atol, rtol=rtol)
             for a, b in zip(result, other_result)
         )
-    elif torch.allclose(result, other_result, atol, rtol):
-        return True
+    elif other_result.dtype == torch.bool:
+        diff = torch.eq(result, other_result)
+        if torch.all(diff):
+            return True
+        else:
+            error = f"Diff:{diff}\n"
+            raise AssertionError(error)
     else:
-        diff = torch.abs(result - other_result)
-        error = f"First result:\n{result}\n"
-        error += f"Second result:\n{other_result}\n"
-        error += f"Diff:\n{diff}\n"
-        error += f"Max diff:\n{torch.max(diff)}"
-        raise AssertionError(error)
+        if torch.allclose(result, other_result, atol, rtol):
+            return True
+        else:
+            diff = torch.abs(result - other_result)
+            error = f"First result:\n{result}\n"
+            error += f"Second result:\n{other_result}\n"
+            error += f"Diff:\n{diff}\n"
+            error += f"Max diff:\n{torch.max(diff)}"
+            raise AssertionError(error)
 
 
 def compare_tracing_methods(


### PR DESCRIPTION
Summary:
Added support for logical ops (`and`, `or`, `xor`, `not`) in PyTorchModelLoader. Additionally, modified the python unit testing utils to support boolean tensors which is required to test the logical ops.

Test Plan:
Added multiple unit tests in logical_ops_test.py which cover basic cases and cases with broadcast.

