### PR TITLE
[torch_glow] Add support for trig ops (cos, sin, acos, asin, atan)

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -920,6 +920,11 @@ PyTorchModelLoader::buildSymbolsMapping() {
       {{"aten::dropout", "aten::dropout_"}, &PyTorchModelLoader::loadDropout},
       {{"aten::sqrt", "aten::sqrt_"}, &PyTorchModelLoader::loadSqrt},
       {{"aten::clamp"}, &PyTorchModelLoader::loadClamp},
+      {{"aten::cos"}, &PyTorchModelLoader::loadCos},
+      {{"aten::sin"}, &PyTorchModelLoader::loadSin},
+      {{"aten::acos"}, &PyTorchModelLoader::loadAcos},
+      {{"aten::asin"}, &PyTorchModelLoader::loadAsin},
+      {{"aten::atan"}, &PyTorchModelLoader::loadAtan},
       {{"quantized::add"}, &PyTorchModelLoader::loadQuantizedAdd},
       {{"quantized::add_relu"}, &PyTorchModelLoader::loadQuantizedAddRelu},
       {{"quantized::mul"}, &PyTorchModelLoader::loadQuantizedMul},
@@ -2520,6 +2525,61 @@ Error PyTorchModelLoader::loadFusedStack(const torch::jit::Node *ptNode) {
       F_.createReshape("stack_reshape", concat, reshapeDims)->getResult();
 
   RETURN_ERR(addValueMapping(outputs[0], reshape));
+}
+
+Error PyTorchModelLoader::loadCos(const torch::jit::Node *ptNode) {
+  auto inputs = ptNode->inputs();
+  auto outputs = ptNode->outputs();
+  RETURN_IF_ERR(checkInputAndOutputSizes(inputs, 1, outputs, 1));
+
+  glow::NodeValue input;
+  ASSIGN_VALUE_OR_RETURN_ERR(input, getGlowNodeValueForValue(inputs[0]));
+
+  return addValueMapping(outputs[0], F_.createCos("Cos", input));
+}
+
+Error PyTorchModelLoader::loadSin(const torch::jit::Node *ptNode) {
+  auto inputs = ptNode->inputs();
+  auto outputs = ptNode->outputs();
+  RETURN_IF_ERR(checkInputAndOutputSizes(inputs, 1, outputs, 1));
+
+  glow::NodeValue input;
+  ASSIGN_VALUE_OR_RETURN_ERR(input, getGlowNodeValueForValue(inputs[0]));
+
+  return addValueMapping(outputs[0], F_.createSin("Sin", input));
+}
+
+Error PyTorchModelLoader::loadAcos(const torch::jit::Node *ptNode) {
+  auto inputs = ptNode->inputs();
+  auto outputs = ptNode->outputs();
+  RETURN_IF_ERR(checkInputAndOutputSizes(inputs, 1, outputs, 1));
+
+  glow::NodeValue input;
+  ASSIGN_VALUE_OR_RETURN_ERR(input, getGlowNodeValueForValue(inputs[0]));
+
+  return addValueMapping(outputs[0], F_.createAcos("Acos", input));
+}
+
+Error PyTorchModelLoader::loadAsin(const torch::jit::Node *ptNode) {
+  auto inputs = ptNode->inputs();
+  auto outputs = ptNode->outputs();
+  RETURN_IF_ERR(checkInputAndOutputSizes(inputs, 1, outputs, 1));
+
+  glow::NodeValue input;
+  ASSIGN_VALUE_OR_RETURN_ERR(input, getGlowNodeValueForValue(inputs[0]));
+
+  return addValueMapping(outputs[0], F_.createAsin("Asin", input));
+}
+
+Error PyTorchModelLoader::loadAtan(const torch::jit::Node *ptNode) {
+  auto inputs = ptNode->inputs();
+  auto outputs = ptNode->outputs();
+  RETURN_IF_ERR(checkInputAndOutputSizes(inputs, 1, outputs, 1));
+
+  glow::NodeValue input;
+  ASSIGN_VALUE_OR_RETURN_ERR(input, getGlowNodeValueForValue(inputs[0]));
+
+  return addValueMapping(outputs[0], F_.createAtan("Atan", input));
 }
 
 Error PyTorchModelLoader::loadNumToTensor(const torch::jit::Node *ptNode) {

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -731,6 +731,26 @@ private:
   /// \returns error on failure.
   Error loadReshape(const torch::jit::Node *ptNode);
 
+  /// Load a PyTorch aten::cos node.
+  /// \returns error on failure.
+  Error loadCos(const torch::jit::Node *ptNode);
+
+  /// Load a PyTorch aten::sin node.
+  /// \returns error on failure.
+  Error loadSin(const torch::jit::Node *ptNode);
+
+  /// Load a PyTorch aten::acos node.
+  /// \returns error on failure.
+  Error loadAcos(const torch::jit::Node *ptNode);
+
+  /// Load a PyTorch aten::asin node.
+  /// \returns error on failure.
+  Error loadAsin(const torch::jit::Node *ptNode);
+
+  /// Load a PyTorch aten::atan node.
+  /// \returns error on failure.
+  Error loadAtan(const torch::jit::Node *ptNode);
+
   /// Load a PyTorch aten::upsample_nearest3d or aten::upsample_nearest2d node.
   /// \returns error on failure.
   Error loadUpsampleNearest(const torch::jit::Node *ptNode);

--- a/torch_glow/tests/nodes/trig_ops_test.py
+++ b/torch_glow/tests/nodes/trig_ops_test.py
@@ -1,0 +1,89 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+
+import numpy as np
+import torch
+from tests import utils
+
+
+class SimpleCosModule(torch.nn.Module):
+    def __init__(self):
+        super(SimpleCosModule, self).__init__()
+
+    def forward(self, a):
+        return torch.cos(a + a)
+
+
+class SimpleSinModule(torch.nn.Module):
+    def __init__(self):
+        super(SimpleSinModule, self).__init__()
+
+    def forward(self, a):
+        return torch.sin(a + a)
+
+
+class SimpleACosModule(torch.nn.Module):
+    def __init__(self):
+        super(SimpleACosModule, self).__init__()
+
+    def forward(self, a):
+        return torch.acos(a + a)
+
+
+class SimpleASinModule(torch.nn.Module):
+    def __init__(self):
+        super(SimpleASinModule, self).__init__()
+
+    def forward(self, a):
+        return torch.asin(a + a)
+
+
+class SimpleATanModule(torch.nn.Module):
+    def __init__(self):
+        super(SimpleATanModule, self).__init__()
+
+    def forward(self, a):
+        return torch.atan(a + a)
+
+
+class TestCos(unittest.TestCase):
+    def test_cos(self, skip_to_glow=False):
+        # Ensures range is in [-2*pi, 2*pi]
+        x = 4 * np.pi * (torch.rand(2, 3, 4) - 0.5)
+        utils.compare_tracing_methods(
+            SimpleCosModule(), x, fusible_ops={"aten::cos"}, skip_to_glow=skip_to_glow
+        )
+
+
+class TestSin(unittest.TestCase):
+    def test_sin(self, skip_to_glow=False):
+        # Ensures range is in [-2*pi, 2*pi]
+        x = 4 * np.pi * (torch.rand(2, 3, 4) - 0.5)
+        utils.compare_tracing_methods(
+            SimpleSinModule(), x, fusible_ops={"aten::sin"}, skip_to_glow=skip_to_glow
+        )
+
+
+class TestACos(unittest.TestCase):
+    def test_acos(self, skip_to_glow=False):
+        x = torch.rand(2, 3, 4) - 0.5  # Ensures range is in [-1,1]
+        utils.compare_tracing_methods(
+            SimpleACosModule(), x, fusible_ops={"aten::acos"}, skip_to_glow=skip_to_glow
+        )
+
+
+class TestASin(unittest.TestCase):
+    def test_asin(self, skip_to_glow=False):
+        x = torch.rand(2, 3, 4) - 0.5  # Ensures range is in [-1,1]
+        utils.compare_tracing_methods(
+            SimpleASinModule(), x, fusible_ops={"aten::asin"}, skip_to_glow=skip_to_glow
+        )
+
+
+class TestATan(unittest.TestCase):
+    def test_atan(self, skip_to_glow=False):
+        x = torch.randn(2, 3, 4)
+        utils.compare_tracing_methods(
+            SimpleATanModule(), x, fusible_ops={"aten::atan"}, skip_to_glow=skip_to_glow
+        )


### PR DESCRIPTION
Summary:
Added support for trig ops (cos, sin, acos, asin, atan) in PyTorchModelLoader.

Test Plan:
Added multiple unit tests in trig_ops_test.py which cover basic cases.