### PR TITLE
Add tril_indices op to Glow

### DIFF
--- a/include/glow/Backends/Interpreter/InterpreterFunction.h
+++ b/include/glow/Backends/Interpreter/InterpreterFunction.h
@@ -250,6 +250,9 @@ private:
   template <typename ElemTy>
   void fwdResizeBilinearInstImpl(const ResizeBilinearInst *I);
 
+  template <typename ElemTy>
+  void fwdTrilIndicesInstImpl(const TrilIndicesInst *I);
+
   template <typename ElemTy> void fwdSigmoidInstFloatImpl(const SigmoidInst *I);
 
   template <typename ElemTy> void fwdTanhInstFloatImpl(const TanhInst *I);

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -1513,6 +1513,13 @@ public:
   ResizeBilinearNode *createResizeBilinear(llvm::StringRef name,
                                            NodeValue input, TypeRef outTy);
 
+  // Return the indices of the elements in the lower triangular part of a row by
+  // column matrix. Offset specifies how many diagonals below or above
+  // the main diagonal to exclude or include, depending on whether its value is
+  // negative or positive respectively.
+  TrilIndicesNode *createTrilIndices(llvm::StringRef name, glow::unsigned_t row,
+                                     glow::unsigned_t column, int64_t offset);
+
   /// Create quantization node which transforms floating point tensor to a
   /// quantized one with given Scale and Offset. Scale and Offset params are
   /// part of the \p outTy.

--- a/lib/Backends/CPU/tests/CPUOperatorTest.cpp
+++ b/lib/Backends/CPU/tests/CPUOperatorTest.cpp
@@ -375,4 +375,6 @@ std::set<std::string> glow::backendTestBlacklist = {
     "BBoxTransform_Float16/0",
     "BBoxTransform_Rotated_Float/0",
     "BBoxTransform_Rotated_Float16/0",
-};
+    "trilIndicesBasic/0",
+    "trilIndicesNegativeOffset/0",
+    "trilIndicesPositiveOffset/0"};

--- a/lib/Backends/Habana/tests/HabanaOperatorTest.cpp
+++ b/lib/Backends/Habana/tests/HabanaOperatorTest.cpp
@@ -428,4 +428,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "Atan_Int8QTy/0",
     "BBoxTransform/0",
     "NonSquareDilationConvTranspose/0",
-    "NonSquareDilationConv2D/0"};
+    "NonSquareDilationConv2D/0",
+    "trilIndicesBasic/0",
+    "trilIndicesNegativeOffset/0",
+    "trilIndicesPositiveOffset/0"};

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -109,6 +109,9 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
          ElemKind::Int8QTy, ElemKind::Int16QTy, ElemKind::Int32QTy,
          ElemKind::Int32ITy, ElemKind::Int64ITy});
 
+  case Kinded::Kind::TrilIndicesNodeKind:
+    return true;
+
   case Kinded::Kind::AvgPoolNodeKind:
   case Kinded::Kind::AdaptiveAvgPoolNodeKind:
   case Kinded::Kind::BatchedReduceAddNodeKind:

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -2428,6 +2428,33 @@ void BoundInterpreterFunction::fwdResizeBilinearInst(
   dispatchImpl(fwdResizeBilinearInstImpl, I->getSrc()->getElementType(), I);
 }
 
+template <typename ElemTy>
+void BoundInterpreterFunction::fwdTrilIndicesInstImpl(
+    const glow::TrilIndicesInst *I) {
+  Tensor *outT = getTensor(I->getDest());
+  const auto numElems = outT->getRealNumElements();
+  const auto rows = I->getRow();
+  const auto cols = I->getColumn();
+  const auto offset = I->getOffset();
+
+  ElemTy idx = 0;
+  for (ElemTy i = 0; i < rows; ++i) {
+    for (ElemTy j = 0; j < cols; ++j) {
+      if (i + offset >= j) {
+        reinterpret_cast<ElemTy *>(outT->getUnsafePtr())[idx] = i;
+        reinterpret_cast<ElemTy *>(outT->getUnsafePtr())[(numElems / 2) + idx] =
+            j;
+        idx++;
+      }
+    }
+  }
+}
+
+void BoundInterpreterFunction::fwdTrilIndicesInst(
+    const glow::TrilIndicesInst *I) {
+  fwdTrilIndicesInstImpl<int64_t>(I);
+}
+
 //===----------------------------------------------------------------------===//
 //                      Local Response Normalization
 //===----------------------------------------------------------------------===//

--- a/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
@@ -482,7 +482,7 @@ struct BlacklistInitializer {
       {"Transpose6Dims/0", TestBlacklist::AnyDeviceHWEngine},
       {"NonSquareDilationConvTranspose/0", TestBlacklist::AnyDeviceAnyEngine},
       {"NonSquareDilationConv2D/0", TestBlacklist::AnyDeviceAnyEngine},
-    };
+      {"TrilIndices/0", TestBlacklist::AnyDeviceAnyEngine} };
     TestBlacklist::prepareBlacklist(testBlacklistedSetups,
                                     backendTestBlacklist);
   }

--- a/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
@@ -595,4 +595,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "VectorNorm_Float16/0",
     "VectorNorm_Float16Ty/0",
     "NonSquareDilationConvTranspose/0",
-    "NonSquareDilationConv2D/0"};
+    "NonSquareDilationConv2D/0",
+    "trilIndicesBasic/0",
+    "trilIndicesNegativeOffset/0",
+    "trilIndicesPositiveOffset/0"};

--- a/lib/Exporter/ONNXModelWriter.cpp
+++ b/lib/Exporter/ONNXModelWriter.cpp
@@ -1919,6 +1919,11 @@ Error ONNXModelWriter::writeResizeBilinear(const ResizeBilinearNode *node,
   return Error::success();
 }
 
+Error ONNXModelWriter::writeTrilIndices(const TrilIndicesNode *node,
+                                        GraphType &graph) {
+  RETURN_ERR(MAKE_ERR("tril_indices op not supported."));
+}
+
 Error ONNXModelWriter::writeSoftMax(const SoftMaxNode *node, GraphType &graph) {
   auto *proto = graph.add_node();
   proto->set_name(node->getName());

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -2679,6 +2679,26 @@ ResizeBilinearNode *Function::createResizeBilinear(llvm::StringRef name,
   return addNode(new ResizeBilinearNode(name, outTy, input, scales));
 }
 
+TrilIndicesNode *Function::createTrilIndices(llvm::StringRef name,
+                                             glow::unsigned_t row,
+                                             glow::unsigned_t column,
+                                             int64_t offset) {
+  dim_t outDims1 = 0;
+  for (int64_t i = 0; i < column; ++i) {
+    auto value = row - i;
+    if (value + offset <= 0) {
+      break;
+    }
+    outDims1 += std::max(
+        std::min(static_cast<dim_t>(value + offset), static_cast<dim_t>(row)),
+        static_cast<dim_t>(0));
+  }
+
+  std::vector<dim_t> outDims = {2, outDims1};
+  auto outTy = getParent()->uniqueType(ElemKind::Int64ITy, outDims);
+  return addNode(new TrilIndicesNode(name, outTy, row, column, offset));
+}
+
 QuantizeNode *Function::createQuantize(llvm::StringRef name, NodeValue input,
                                        TypeRef outTy) {
   assert(input.getType()->isFPType() && "Input must be a floating type");

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -2054,6 +2054,15 @@ bool ResizeBilinearNode::verify() const {
   return isValid;
 }
 
+bool TrilIndicesNode::verify() const {
+  bool isValid = true;
+  const auto offset = getOffset();
+  if (offset < 0) {
+    isValid = std::abs(offset) < getRow();
+  }
+  return isValid;
+}
+
 bool NonMaxSuppressionNode::verify() const {
   NodeValue boxes = getBoxes();
   NodeValue scores = getScores();

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -976,6 +976,14 @@ int main(int argc, char **argv) {
       .autoVerify(VerifyKind::SameElementType, {"Dest", "Src"})
       .autoIRGen();
 
+  BB.newInstr("TrilIndices")
+      .addOperand("Dest", OperandKind::Out)
+      .addMember(MemberType::Unsigned, "Row")
+      .addMember(MemberType::Unsigned, "Column")
+      .addMember(MemberType::Int64, "Offset")
+      .autoVerify(VerifyKind::NoVerify)
+      .autoIRGen();
+
   //===--------------------------------------------------------------------===//
   //                Reorder transformations
   //===--------------------------------------------------------------------===//

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -1110,6 +1110,23 @@ int main(int argc, char **argv) {
           "neighbor interpolation. The Output tensor is of shape "
           "floor(input_dimension * scale)");
 
+  BB.newNode("TrilIndices")
+      .addMember(MemberType::Unsigned, "Row")
+      .addMember(MemberType::Unsigned, "Column")
+      .addMember(MemberType::Int64, "Offset")
+      .addResultFromCtorArg()
+      .setDocstring(
+          "Returns the indices of the lower triangular part of a "
+          "matrix with dimensions Row by Column. If Offset is 0 (default "
+          "value), the indices of the elements below the main diagonal are "
+          "returned (including the main diagonal). If Offset is positive, "
+          "Offset diagonals above the main "
+          "diagonal are also included. If Offset is negative, Offset diagonals "
+          "below the main diagonal are excluded. The first dimension "
+          "of the output tensor contains the row indices, while the "
+          "second dimension contains the column indices of the selected "
+          "elements.");
+
   //===--------------------------------------------------------------------===//
   //                Reorder transformations
   //===--------------------------------------------------------------------===//

--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -925,6 +925,7 @@ PyTorchModelLoader::buildSymbolsMapping() {
       {{"aten::quantize_per_tensor"}, &PyTorchModelLoader::loadQuantize},
       {{"aten::dequantize"}, &PyTorchModelLoader::loadDequantize},
       {{"aten::size"}, &PyTorchModelLoader::loadSize},
+      {{"aten::tril_indices"}, &PyTorchModelLoader::loadTrilIndices},
       {{"prim::ListConstruct"}, &PyTorchModelLoader::loadListConstruct},
       {{"aten::reciprocal", "aten::reciprocal_"},
        &PyTorchModelLoader::loadReciprocal},
@@ -2354,6 +2355,26 @@ Error PyTorchModelLoader::loadListConstruct(const torch::jit::Node *ptNode) {
     return MAKE_ERR("Encountered unknown JIT Value mapping");
   }
   RETURN_ERR(addValueMapping(outputs[0], std::move(glowIVal)));
+}
+
+Error PyTorchModelLoader::loadTrilIndices(const torch::jit::Node *ptNode) {
+  auto inputs = ptNode->inputs();
+  auto outputs = ptNode->outputs();
+
+  glow::unsigned_t row, col;
+  int64_t offset;
+  ASSIGN_VALUE_OR_RETURN_ERR(row, iValToInt(getGlowIValueForValue(inputs[0])));
+  ASSIGN_VALUE_OR_RETURN_ERR(col, iValToInt(getGlowIValueForValue(inputs[1])));
+  ASSIGN_VALUE_OR_RETURN_ERR(offset,
+                             iValToInt(getGlowIValueForValue(inputs[2])));
+
+  if (offset < 0) {
+    RETURN_ERR_IF_NOT(std::abs(offset) < row,
+                      "abs(Offset) must be <= Row if offset is negative");
+  }
+
+  return addValueMapping(
+      outputs[0], F_.createTrilIndices("tril_indices", row, col, offset));
 }
 
 Error PyTorchModelLoader::loadFusedConcat(const torch::jit::Node *ptNode) {

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -535,6 +535,10 @@ private:
   /// \returns error on failure.
   Error loadQuantizedBatchNorm3dRelu(const torch::jit::Node *ptNode);
 
+  /// Load a PyTorch aten::tril_indices node.
+  /// \returns error on failure.
+  Error loadTrilIndices(const torch::jit::Node *ptNode);
+
   /// Load a PyTorch aten::layer_norm node.
   /// \returns error on failure.
   Error loadLayerNorm(const torch::jit::Node *ptNode);

--- a/torch_glow/tests/nodes/tril_indices_test.py
+++ b/torch_glow/tests/nodes/tril_indices_test.py
@@ -1,0 +1,37 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import torch
+
+from tests import utils
+from parameterized import parameterized
+import unittest
+
+
+class SimpleTrilIndicesModule(torch.nn.Module):
+    def __init__(self, row, col, offset):
+        super(SimpleTrilIndicesModule, self).__init__()
+        self.row = row
+        self.col = col
+        self.offset = offset
+
+    def forward(
+        self,
+    ):
+        b = torch.tril_indices(self.row, self.col, self.offset)
+        return b + b
+
+
+class TestTrilIndices(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("basic", SimpleTrilIndicesModule(2, 4, 0)),
+            ("negative_offset", SimpleTrilIndicesModule(2, 4, -1)),
+            ("positive_offset", SimpleTrilIndicesModule(2, 4, 1)),
+            ("col_gt_row", SimpleTrilIndicesModule(4, 2, 1)),
+            ("large_offset", SimpleTrilIndicesModule(4, 6, 1324)),
+        ]
+    )
+    def test_tril_indices(self, _, module):
+        utils.compare_tracing_methods(
+            module, fusible_ops={"aten::tril_indices"}, scripted=True
+        )


### PR DESCRIPTION
Summary:
Add tril_indices op which returns the indices of the lower triangular part of a row by column matrix. Also add support for loading it with PyTorchModelLoader.

Test Plan:
Relevant unit tests have been added to OperatorTest and tril_indices_test.py.
