### PR TITLE
[torch_glow] Add support for index op

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -1026,6 +1026,7 @@ PyTorchModelLoader::buildSymbolsMapping() {
        &PyTorchModelLoader::loadMaskedFill},
       {{"aten::prelu"}, &PyTorchModelLoader::loadPRelu},
       {{"aten::slice"}, &PyTorchModelLoader::loadSlice},
+      {{"aten::index"}, &PyTorchModelLoader::loadIndex},
       {{"aten::softmax"}, &PyTorchModelLoader::loadSoftMax},
       {{"aten::topk"}, &PyTorchModelLoader::loadTopK},
       {{"aten::to"}, &PyTorchModelLoader::loadTo},
@@ -2465,9 +2466,25 @@ Error PyTorchModelLoader::loadListConstruct(const torch::jit::Node *ptNode) {
   auto outputs = ptNode->outputs();
   // Requires -1 because this requires at least one input.
   RETURN_IF_ERR(checkInputAndOutputSizes(inputs, -1, outputs, 1));
+
+  bool hasNodeValue = false, hasIValue = false;
+  for (size_t i = 0; i < inputs.size(); ++i) {
+    if (hasGlowIValueForValue(inputs[i])) {
+      GlowIValue *ival;
+      ASSIGN_VALUE_OR_RETURN_ERR(ival, getGlowIValueForValue(inputs[i]));
+      if (ival->getTag() == GlowIValue::Tag::None)
+        hasIValue = true;
+    } else if (hasGlowNodeValueForValue(inputs[i])) {
+      hasNodeValue = true;
+    } else {
+      assert(false && "Unreachable");
+    }
+  }
+  bool containsNone = hasIValue && hasNodeValue;
+
   GlowIValue glowIVal;
   // Get the Tag of the first input to use for the whole list.
-  if (hasGlowIValueForValue(inputs[0])) {
+  if (hasGlowIValueForValue(inputs[0]) && !containsNone) {
     // If it is IValue
     GlowIValue *firstInputIVal;
     ASSIGN_VALUE_OR_RETURN_ERR(firstInputIVal,
@@ -2505,14 +2522,30 @@ Error PyTorchModelLoader::loadListConstruct(const torch::jit::Node *ptNode) {
       return MAKE_ERR(
           "Encountered an unsupported GlowIValue type for ListConstruct");
     }
-  } else if (hasGlowNodeValueForValue(inputs[0])) {
-    // If it is a NodeValue, which we will store as a NodeValueList IValue.
+  } else if (hasGlowNodeValueForValue(inputs[0]) || containsNone) {
     std::vector<glow::NodeValue> nodeValues;
-    for (size_t i = 0; i < inputs.size(); i++) {
-      glow::NodeValue x;
-      ASSIGN_VALUE_OR_RETURN_ERR(x, getGlowNodeValueForValue(inputs[i]));
-      nodeValues.push_back(x);
+    std::vector<int64_t> noneIndices;
+    for (size_t i = 0; i < inputs.size(); ++i) {
+      if (hasGlowIValueForValue(inputs[i])) {
+        GlowIValue *ival;
+        ASSIGN_VALUE_OR_RETURN_ERR(ival, getGlowIValueForValue(inputs[i]));
+        if (ival->getTag() == GlowIValue::Tag::None) {
+          auto t = glow::Tensor();
+          auto constant =
+              F_.getParent()
+                  ->createConstant("dummy_" + std::to_string(i), std::move(t))
+                  ->getOutput();
+          nodeValues.push_back(constant);
+        } else {
+          assert(false && "Expected IValue with tag None");
+        }
+      } else {
+        glow::NodeValue x;
+        ASSIGN_VALUE_OR_RETURN_ERR(x, getGlowNodeValueForValue(inputs[i]));
+        nodeValues.push_back(x);
+      }
     }
+
     glowIVal.fromNodeValueList(std::move(nodeValues));
   } else {
     // Should never reach here
@@ -4866,6 +4899,164 @@ Error PyTorchModelLoader::loadSlice(const torch::jit::Node *ptNode) {
   RETURN_ERR(addValueMapping(outputs[0], glowNode, dtype));
 }
 
+Error PyTorchModelLoader::loadIndex(const torch::jit::Node *ptNode) {
+  auto inputs = ptNode->inputs();
+  auto outputs = ptNode->outputs();
+
+  RETURN_IF_ERR(checkInputAndOutputSizes(inputs, 2, outputs, 1));
+
+  glow::NodeValue input;
+  std::vector<glow::NodeValue> *inputIndices;
+  ASSIGN_VALUE_OR_RETURN_ERR(input, getGlowNodeValueForValue(inputs[0]));
+  ASSIGN_VALUE_OR_RETURN_ERR(
+      inputIndices, iValToNodeValueList(getGlowIValueForValue(inputs[1])));
+
+  const auto dims = input.getType()->dims();
+
+  std::vector<glow::unsigned_t> sliceAxes;
+  std::vector<glow::unsigned_t> indexAxes;
+  std::vector<glow::NodeValue> indices;
+  size_t actualIdx = 0;
+  for (auto it = inputIndices->begin(); it != inputIndices->end(); ++it) {
+    // Check if dummy tensor
+    if (it->getType()->numSizes_ == 0) {
+      sliceAxes.push_back(actualIdx);
+    } else {
+      indexAxes.push_back(actualIdx);
+      indices.push_back(std::move(*it));
+    }
+    actualIdx++;
+  }
+  auto advIdxIndices = indexAxes;
+  const auto advIdxCount = advIdxIndices.size();
+
+  bool needsTranspose = sliceAxes.size() != 0;
+  // Uses result of actualIdx from previous loop
+  for (auto i = actualIdx; i < dims.size(); ++i) {
+    sliceAxes.push_back(i);
+  }
+
+  bool indicesTogether = true;
+  for (size_t i = 0; i < indexAxes.size() - 1; ++i) {
+    indicesTogether = indexAxes[i + 1] - indexAxes[i] == 1;
+    if (!indicesTogether) {
+      break;
+    }
+  }
+
+  const auto numIndices = indices.size();
+  indexAxes.insert(indexAxes.end(), sliceAxes.begin(), sliceAxes.end());
+
+  glow::TransposeNode *transNode = nullptr;
+  if (needsTranspose) {
+    transNode = F_.createTranspose("transpose", input, indexAxes);
+  }
+
+  auto flattenNode = F_.createFlatten(
+      "flatten", needsTranspose ? static_cast<NodeValue>(transNode) : input,
+      numIndices);
+
+  std::vector<int64_t> inputDimsI64(dims.begin(), dims.end());
+  std::vector<glow::NodeValue> dimConstantList;
+  for (size_t i = 0; i < inputDimsI64.size(); ++i) {
+    glow::Tensor t(F_.getParent()->uniqueType(ElemKind::Int64ITy, {1}));
+    t.getHandle<int64_t>() = inputDimsI64[i];
+    auto *shapeConstant = F_.getParent()->createConstant(
+        "shapeConstant" + std::to_string(i), std::move(t));
+    dimConstantList.push_back(std::move(shapeConstant));
+  }
+
+  auto cumAdvIndex = (*inputIndices)[advIdxIndices[advIdxIndices.size() - 1]];
+  auto multiplier = dimConstantList[advIdxIndices[advIdxIndices.size() - 1]];
+  for (int64_t i = advIdxCount - 2; i > -1; --i) {
+    auto adv_index =
+        F_.createNodeWithBroadcast<MulNode>(
+              "mul", -1, (*inputIndices)[advIdxIndices[i]], multiplier)
+            ->getResult();
+
+    cumAdvIndex =
+        F_.createNodeWithBroadcast<AddNode>("add", -1, cumAdvIndex, adv_index)
+            ->getResult();
+
+    multiplier = F_.createNodeWithBroadcast<MulNode>(
+                       "mul", -1, multiplier, dimConstantList[advIdxIndices[i]])
+                     ->getResult();
+  }
+
+  auto *gatherNode =
+      F_.createGather("gather", flattenNode->getResult(), cumAdvIndex);
+
+  std::vector<unsigned_t> check;
+  for (int i = advIdxIndices[0];
+       i < advIdxIndices[advIdxIndices.size() - 1] + 1; ++i) {
+    check.push_back(i);
+  }
+
+  const bool consecutiveIndices = advIdxIndices == check;
+  glow::NodeValue output;
+  if (consecutiveIndices) {
+    const auto nElems =
+        std::accumulate(gatherNode->getResult().getType()->dims().begin(),
+                        gatherNode->getResult().getType()->dims().end(), 1,
+                        std::multiplies<dim_t>());
+    std::vector<dim_t> foldedAdvIdxShape;
+    dim_t product = 1;
+    for (int i = 0; i < sliceAxes.size(); ++i) {
+      const auto value = input.dims()[sliceAxes[i]];
+      foldedAdvIdxShape.push_back(value);
+      product *= value;
+    }
+    const auto firstDim = nElems / product;
+    foldedAdvIdxShape.insert(foldedAdvIdxShape.begin(), firstDim);
+
+    auto *reshapeNode =
+        F_.createReshape("reshape", gatherNode->getResult(), foldedAdvIdxShape);
+
+    std::vector<unsigned_t> advIdxPermute;
+    for (unsigned_t i = 1; i < advIdxIndices[0] + 1; ++i) {
+      advIdxPermute.push_back(i);
+    }
+    advIdxPermute.push_back(0);
+    for (unsigned_t i = advIdxIndices[0] + 1;
+         i < input.dims().size() - advIdxCount + 1; ++i) {
+      advIdxPermute.push_back(i);
+    }
+
+    auto *transposeNode = F_.createTranspose(
+        "transpose", reshapeNode->getResult(), advIdxPermute);
+
+    std::vector<dim_t> finalShape;
+    for (int i = 0; i < advIdxIndices[0]; ++i) {
+      finalShape.push_back(input.dims()[i]);
+    }
+    for (dim_t i = 0; i < cumAdvIndex.dims().size(); ++i) {
+      finalShape.push_back(cumAdvIndex.dims()[i]);
+    }
+    for (int i = advIdxIndices[0]; i < input.dims().size(); ++i) {
+      if (std::find(advIdxIndices.begin(), advIdxIndices.end(), i) ==
+          advIdxIndices.end()) {
+        finalShape.push_back(input.dims()[i]);
+      }
+    }
+
+    output = F_.createReshape("reshape", transposeNode->getResult(), finalShape)
+                 ->getResult();
+  } else {
+    std::vector<dim_t> finalShape;
+    for (dim_t i = 0; i < cumAdvIndex.dims().size(); ++i) {
+      finalShape.push_back(cumAdvIndex.dims()[i]);
+    }
+    for (int i = 0; i < sliceAxes.size(); ++i) {
+      finalShape.push_back(input.dims()[sliceAxes[i]]);
+    }
+
+    output = F_.createReshape("reshape", gatherNode->getResult(), finalShape)
+                 ->getResult();
+  }
+
+  return addValueMapping(outputs[0], output);
+}
+
 /// TODO: check Dtype is float (optional value).
 Error PyTorchModelLoader::loadSoftMax(const torch::jit::Node *ptNode) {
   auto inputs = ptNode->inputs();
@@ -5224,17 +5415,25 @@ Error PyTorchModelLoader::loadConstantChunk(const torch::jit::Node *ptNode) {
 
 Expected<GlowIValue>
 PyTorchModelLoader::getGenerictList(const torch::jit::IValue &iVal) {
+  std::cout << ">>>>>>>>>>> ENTERING getGenerictList >>>>>>>>>>>>>>\n ";
+
   auto iValList = iVal.toListRef();
   GlowIValue glowIVal;
-  if (iValList[0].isTensor()) {
+  if (iValList[0].isTensor() || iValList[0].isNone()) {
     std::vector<NodeValue> constantNodeValueList;
     for (const auto &v : iValList) {
-      RETURN_ERR_IF_NOT(v.isTensor(),
+      RETURN_ERR_IF_NOT(v.isTensor() || v.isNone(),
                         strFormat("Expect all ival in a PyTorch GenericList to "
                                   "be Tensor, but got %s.",
                                   v.tagKind().c_str()));
-      glow::Tensor glowTensor =
-          ptTensorToGlowTensor(v.toTensor().contiguous()).clone();
+
+      glow::Tensor glowTensor;
+      // If None is found in the list, insert a dummy tensor
+      if (v.isNone()) {
+        glowTensor = glow::Tensor();
+      } else {
+        glowTensor = ptTensorToGlowTensor(v.toTensor().contiguous()).clone();
+      }
       auto glowConstantNodeValue =
           F_.getParent()
               ->createConstant("GenericList_created_constant",

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -694,6 +694,10 @@ private:
   /// \returns error on failure.
   Error loadSlice(const torch::jit::Node *ptNode);
 
+  /// Load a PyTorch slice node.
+  /// \returns error on failure.
+  Error loadIndex(const torch::jit::Node *ptNode);
+
   /// Load a PyTorch SoftMax node.
   /// \returns error on failure.
   Error loadSoftMax(const torch::jit::Node *ptNode);

--- a/torch_glow/tests/nodes/index_test.py
+++ b/torch_glow/tests/nodes/index_test.py
@@ -1,0 +1,105 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+
+import torch
+from parameterized import parameterized
+from tests import utils
+
+
+class SimpleIndexModule(torch.nn.Module):
+    def __init__(self, indices, type, rank):
+        super(SimpleIndexModule, self).__init__()
+        self.indices = indices
+        self.type = type
+        self.rank = rank
+
+    def forward(self, a):
+        if self.rank == 3:
+            if self.type == 0:
+                if len(self.indices) == 1:
+                    return (a + a)[self.indices[0], :, :]
+                else:
+                    return (a + a)[self.indices[0], self.indices[1], :]
+            elif self.type == 1:
+                if len(self.indices) == 1:
+                    return (a + a)[:, :, self.indices[0]]
+                else:
+                    return (a + a)[:, self.indices[0], self.indices[1]]
+            else:
+                if len(self.indices) == 2:
+                    return (a + a)[self.indices[0], :, self.indices[1]]
+                else:
+                    return (a + a)[self.indices[0], self.indices[1], self.indices[2]]
+        elif self.rank == 4:
+            if len(self.indices) == 1:
+                return (a + a)[:, self.indices[0], :, :]
+            elif len(self.indices) == 2:
+                return (a + a)[:, self.indices[0], :, self.indices[1]]
+            elif len(self.indices) == 3:
+                return (a + a)[self.indices[0], self.indices[1], :, self.indices[2]]
+            else:
+                return (a + a)[
+                    self.indices[0], self.indices[1], self.indices[2], self.indices[3]
+                ]
+
+
+class TestIndex(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("3d_0", SimpleIndexModule([[1, 0]], 0, 3), torch.rand(2, 3, 4)),
+            ("3d_1", SimpleIndexModule([[1, 0], [2, 1]], 1, 3), torch.rand(2, 3, 4)),
+            ("3d_2", SimpleIndexModule([[1, 0], [2, 1]], 2, 3), torch.rand(2, 3, 4)),
+            ("3d_3", SimpleIndexModule([[1, 0]], 0, 3), torch.rand(4, 5, 3)),
+            ("3d_4", SimpleIndexModule([[1, 0], [1, 2]], 1, 3), torch.rand(4, 5, 3)),
+            ("3d_5", SimpleIndexModule([[1, 0], [1, 2]], 2, 3), torch.rand(4, 5, 3)),
+            (
+                "3d_6",
+                SimpleIndexModule([[1, 0], [2, 1], [1, 1]], 0, 3),
+                torch.rand(2, 3, 4),
+            ),
+            ("3d_7", SimpleIndexModule([[1, 0], [2, 1]], 1, 3), torch.rand(6, 5, 8)),
+            ("3d_8", SimpleIndexModule([[1, 0], [2, 1]], 2, 3), torch.rand(6, 5, 8)),
+            ("4d_1", SimpleIndexModule([[1, 0]], 0, 4), torch.rand(5, 3, 4, 6)),
+            ("4d_2", SimpleIndexModule([[1, 0], [2, 1]], 0, 4), torch.rand(5, 3, 4, 6)),
+            (
+                "4d_3",
+                SimpleIndexModule([[1, 0], [2, 1], [1, 1]], 0, 4),
+                torch.rand(5, 3, 4, 6),
+            ),
+            (
+                "4d_4",
+                SimpleIndexModule([[1, 0], [2, 1], [0, 1], [2, 3]], 0, 4),
+                torch.rand(5, 3, 4, 6),
+            ),
+            (
+                "2d_indices",
+                SimpleIndexModule(
+                    [torch.tensor([[1, 0], [1, 2]]), torch.tensor([[1, 0], [1, 2]])],
+                    1,
+                    3,
+                ),
+                torch.rand(6, 5, 8),
+            ),
+            (
+                "2d_indices",
+                SimpleIndexModule(
+                    [torch.tensor([[4, 0], [3, 2]]), torch.tensor([[2, 1], [1, 3]])],
+                    2,
+                    4,
+                ),
+                torch.rand(6, 5, 8, 7),
+            ),
+            (
+                "2d_indices",
+                SimpleIndexModule(
+                    [torch.tensor([[1, 0], [1, 2]]), torch.tensor([[1, 0], [1, 2]])],
+                    3,
+                    4,
+                ),
+                torch.rand(6, 5, 3, 7),
+            ),
+        ]
+    )
+    def test_f(self, _, module, tensor):
+        utils.compare_tracing_methods(module, tensor, fusible_ops={"aten::index"})


### PR DESCRIPTION
Summary:
Add support for the aten::index op. 

Note: When indexing if slices are used, e.g.:
```
tensor[indices0, indices1, :, indices2]
```
The resulting ListConstruct will contain None values which is not supported by loadListConstruct (or getGenericList):
```
%11 : None = prim::Constant()
%20 : Tensor?[] = prim::ListConstruct(%indices0, %indices1, %11, %indices2)
%21 : Tensor = aten::index(%13, %20)
```

We have added a workaround for this - the None values are converted to empty tensors. This allows us to check where the slices are in the list, however if there is a better solution to this please let us know.

Test Plan:
Relevant tests have been added in index_test.py