### PR TITLE
load glow embedding bag

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -352,6 +352,10 @@ private:
   // \returns error on failure.
   Error loadEmbeddingBag(const torch::jit::Node *ptNode);
 
+  // Load a PyTorch fb::glow_embedding_bag node.
+  // \returns error on failure.
+  Error loadGlowEmbeddingBag(const torch::jit::Node *ptNode);
+
   /// Load a _caffe2::BatchPermutation node.
   Error loadBatchPermutation(const torch::jit::Node *ptNode);
 


### PR DESCRIPTION
Summary:
GlowEmbeddingBag is implemented at https://fburl.com/diffusion/nu5dqx86, and this diff add the support for loading GlowEmbeddingBag in Glow.

It essentially read from the JIT IR and convert it to the GlowIR, in loadGlowEmbeddingBag
* It creates placeholder node for the actual weight using the shape and qualName
* When creating the GlowNode, it matches the Glow node interface for the `EmbeddingBagNode` as GlowEmbeddingBag is supposed to match the interface for EmbeddingBag

Next steps:
* Later on, during the large model loading, we will use the `transferStaticPlaceholderToDevice` interface to fill the actual weight loaded from WeightLoader

Reviewed By: qizzzh

Differential Revision: D24558651

