### PR TITLE
Support loading aten::upsample_nearest2d

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -700,9 +700,9 @@ private:
   /// \returns error on failure.
   Error loadReshape(const torch::jit::Node *ptNode);
 
-  /// Load a PyTorch aten::upsample_nearest3d node.
+  /// Load a PyTorch aten::upsample_nearest3d or aten::upsample_nearest2d node.
   /// \returns error on failure.
-  Error loadUpsampleNearest3D(const torch::jit::Node *ptNode);
+  Error loadUpsampleNearest(const torch::jit::Node *ptNode);
 
   /// Load a PyTorch aten::view node.
   /// \returns error on failure.

--- a/torch_glow/tests/nodes/upsample_test.py
+++ b/torch_glow/tests/nodes/upsample_test.py
@@ -23,38 +23,81 @@ class TestUpsample(unittest.TestCase):
     @parameterized.expand(
         [
             (
-                "3d_2x_size",
+                "3d_2x_size_nearest",
                 SimpleUpsampleModel(size=(8, 10, 12)),
                 torch.rand(2, 3, 4, 5, 6),
             ),
             (
-                "3d_2x_scale_factor",
+                "3d_2x_scale_factor_nearest",
                 SimpleUpsampleModel(scale_factor=(2, 2, 2)),
                 torch.rand(2, 3, 4, 5, 6),
             ),
             (
-                "3d_2x_single_scale_factor",
+                "3d_2x_single_scale_factor_nearest",
                 SimpleUpsampleModel(scale_factor=2),
                 torch.rand(2, 3, 4, 5, 6),
             ),
             (
-                "3d_not_2x_single_scale_factor",
+                "3d_not_2x_single_scale_factor_nearest",
                 SimpleUpsampleModel(scale_factor=5),
                 torch.rand(2, 3, 4, 5, 6),
             ),
             (
-                "3d_not_2x_scale_factor",
+                "3d_not_2x_scale_factor_nearest",
                 SimpleUpsampleModel(scale_factor=(1, 2, 3)),
                 torch.rand(2, 3, 4, 5, 6),
             ),
             (
-                "3d_not_2x_size",
+                "3d_not_2x_size_nearest",
                 SimpleUpsampleModel(size=(10, 12, 13)),
                 torch.rand(2, 3, 4, 5, 6),
             ),
         ]
     )
-    def test_upsample(self, name, module, tensor):
+    def test_upsample_nearest3d(self, name, module, tensor):
         utils.compare_tracing_methods(
-            module, tensor, fusible_ops=["aten::upsample_nearest3d"]
+            module,
+            tensor,
+            fusible_ops=["aten::upsample_nearest3d"],
+        )
+
+    @parameterized.expand(
+        [
+            (
+                "2d_2x_scale_factor_nearest",
+                SimpleUpsampleModel(scale_factor=(2, 2)),
+                torch.rand(1, 1, 3, 3),
+            ),
+            (
+                "2d_not_2x_scale_factor_nearest",
+                SimpleUpsampleModel(scale_factor=(3, 4)),
+                torch.rand(1, 1, 3, 3),
+            ),
+            (
+                "2d_2x_single_scale_factor_nearest",
+                SimpleUpsampleModel(scale_factor=2),
+                torch.rand(1, 1, 3, 3),
+            ),
+            (
+                "2d_not_2x_single_scale_factor_nearest",
+                SimpleUpsampleModel(scale_factor=3),
+                torch.rand(1, 1, 3, 3),
+            ),
+            (
+                "2d_2x_size_nearest",
+                SimpleUpsampleModel(size=(6, 6)),
+                torch.rand(1, 1, 3, 3),
+            ),
+            (
+                "2d_not_2x_size_nearest",
+                SimpleUpsampleModel(size=(4, 8)),
+                torch.rand(1, 1, 3, 3),
+            ),
+        ]
+    )
+    def test_upsample_nearest2d(self, name, module, tensor):
+        utils.compare_tracing_methods(
+            module,
+            tensor,
+            fusible_ops=["aten::upsample_nearest2d"],
         )


### PR DESCRIPTION
Summary: Support loading aten::upsample_nearest2d and add some tests. In glow, upsample_2d is already supported by resizeNearest.

Reviewed By: jackm321

Differential Revision: D24569726

