### PR TITLE
move LowerAllTuples to compile()

### DIFF
--- a/torch_glow/tests/functionality/to_glow_tuple_output_test.py
+++ b/torch_glow/tests/functionality/to_glow_tuple_output_test.py
@@ -1,9 +1,11 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import io
 import unittest
 
 import torch
 import torch_glow
+from tests.utils import assertModulesEqual
 
 
 class TwoTupleModule(torch.nn.Module):
@@ -55,6 +57,13 @@ class TestToGlowTupleOutput(unittest.TestCase):
 
         for (gi, ti) in zip(g, t):
             self.assertTrue(torch.allclose(gi, ti))
+
+        # test module ser/de with tuple output
+        buffer = io.BytesIO()
+        torch.jit.save(lowered_model, buffer)
+        buffer.seek(0)
+        loaded_model = torch.jit.load(buffer)
+        assertModulesEqual(self, lowered_model, loaded_model)
 
     def test_to_glow_one_tuple_output(self):
         self.tuple_test_helper(OneTupleModule)

--- a/torch_glow/tests/utils.py
+++ b/torch_glow/tests/utils.py
@@ -1,6 +1,7 @@
 # isort:skip_file
 from __future__ import absolute_import, division, print_function, unicode_literals
 from copy import deepcopy
+import itertools
 import os
 
 import torch_glow
@@ -181,3 +182,9 @@ def assert_fused(fused_graph, *ops, accept_any=False, strict=False):
 
 def graph_contains_str(graph, substr):
     return graph.str().find(substr) >= 0
+
+
+# Verifies equal modules for save-load tests.
+def assertModulesEqual(case, mod1, mod2, message=None):
+    for p1, p2 in itertools.zip_longest(mod1.parameters(), mod2.parameters()):
+        case.assertTrue(p1.equal(p2), message)


### PR DESCRIPTION
Summary: Moving tuples lowering to compile() to allow valid ser/de of Glow's preprocessed module, because multiple tensor output is not valid in PyTorch serialization.

Reviewed By: 842974287

Differential Revision: D24651831

