### PR TITLE
Add opt-in ReplaceZeroScaleFP16QuantNodes pass

### DIFF
--- a/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
+++ b/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
@@ -60,6 +60,7 @@ FUN_PASS(OptimizeConcatQuantization)
 FUN_PASS(SinkConcatBelowQuantize)
 FUN_PASS(FoldLayerNormArithmetic)
 FUN_PASS(QuantizeSwish)
+FUN_PASS(ReplaceZeroScaleFP16QuantNodes)
 
 
 // NOTE: This pass must be last; it's used to count the total number of passes.

--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -1417,6 +1417,15 @@ Expected<bool> NNPIBackend::transformPostLowering(
   }
 
   bool changed = removeClipsBlockingFusion(F);
+  auto it =
+      cctx.backendOpts.backendSpecificOpts.find("NNPI_ZeroScaleFP16Replace");
+  if (it != cctx.backendOpts.backendSpecificOpts.end() && it->second == "1") {
+    FunctionPassManager FPM(
+        "NNPI_ZeroScaleFP16Replace",
+        {FunctionPassID::ReplaceZeroScaleFP16QuantNodes, getDCEPassConfig()},
+        this);
+    changed |= FPM.run(F, cctx);
+  }
   changed |= lowerRequiredNodes(F, cctx);
 
 #if FACEBOOK_INTERNAL

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -5098,6 +5098,58 @@ bool QuantizeSwish::run(Function *F, const CompilationContext &cctx) {
   return changed;
 }
 
+/// Look for qparams with scale (when casted to fp16) == 0 and replace them with
+/// zero Splats.
+bool ReplaceZeroScaleFP16QuantNodes::run(Function *F,
+                                         const CompilationContext &cctx) {
+  LOG_SCOPE(F->getLogContext(), getName());
+
+  // Cannot run this opt if we're using dummy qparams.
+  if (cctx.precisionConfig.loadUniquedDummyQParams) {
+    return false;
+  }
+
+  bool changed = false;
+  // Since we will be adding in new SplatNodes, reverse iterate to be safe.
+  auto &nodes = F->getNodes();
+  for (auto it = nodes.rbegin(), e = nodes.rend(); it != e; it++) {
+    Node *N = &*it;
+    // For now only support nodes with single outputs.
+    if (N->getNumResults() != 1) {
+      continue;
+    }
+    NodeValue resNV = N->getNthResult(0);
+    const TypeRef resTy = resNV.getType();
+    if (resTy->isFusedQuantizedType() || !resTy->isQuantizedType()) {
+      continue;
+    }
+
+    // Check if we have a scale of 0.f when it's casted to FP16.
+    if (float(float16_t(resTy->getScale())) != 0.f) {
+      continue;
+    }
+
+    // Skip if used by node with side effects, since we cannot change the
+    // qparams in such cases.
+    if (isUsedByNodeWithSideEffects(N)) {
+      continue;
+    }
+
+    // This NodeValue has scale = 0.f, which means the equivalent float result
+    // will always be equal to 0.f. So create a splat with value 0.f, scale 1.f,
+    // offset 0 instead.
+    auto splatTy = F->getParent()->uniqueType(resTy->getElementType(),
+                                              resTy->dims(), 1.f, 0);
+    auto *SN = F->createSplat(N->getName().str() + ".splatted", splatTy, 0.f);
+
+    // Note: must use type unsafe replace because we've changed the qparams.
+    resNV.typeUnsafeReplaceAllUsesOfWith(SN->getResult());
+    changed = true;
+  }
+
+  return changed;
+}
+
 /// This funciton uses TypeAToTypeBFunctionConverter to do a whole graph
 /// demotion of Index type from INT64 to INT32.
 static void transformIndexTypeDemotion(const Backend &B, Function *F,


### PR DESCRIPTION
Summary: We need scales of quantized nodes to be non-zero when casted to fp16 for NNPI. Add an opt-in pass to replace such nodes with a zero splat.

Differential Revision: D24751348

