### PR TITLE
[GraphOptz] Add optional pass to convert FC to 1x1 Conv2D.

### DIFF
--- a/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
+++ b/include/glow/Optimizer/GraphOptimizer/FunctionPasses.def
@@ -60,6 +60,7 @@ FUN_PASS(OptimizeConcatQuantization)
 FUN_PASS(SinkConcatBelowQuantize)
 FUN_PASS(FoldLayerNormArithmetic)
 FUN_PASS(QuantizeSwish)
+FUN_PASS(ConvertFullyConnectedToConvolution)
 
 
 // NOTE: This pass must be last; it's used to count the total number of passes.

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -5108,7 +5108,6 @@ bool ConvertFullyConnectedToConvolution::run(Function *F,
 
   bool changed = false;
   for (auto &N : F->getNodes()) {
-
     auto *FCN = dyn_cast<FullyConnectedNode>(&N);
     if (!FCN) {
       continue;
@@ -5173,7 +5172,6 @@ bool FoldMinMaxToClip::run(Function *F, const CompilationContext &cctx) {
 
   bool changed = false;
   for (auto &N : F->getNodes()) {
-
     MaxNode *maxNode = dyn_cast<MaxNode>(&N);
     MinNode *minNode = dyn_cast<MinNode>(&N);
     NodeValue otherInput;

--- a/tests/unittests/GraphOptzTest.cpp
+++ b/tests/unittests/GraphOptzTest.cpp
@@ -6069,6 +6069,9 @@ TEST_F(GraphOptz, ConvertFullyConnectedToConvolutionOpt) {
   ASSERT_TRUE(conv);
   ReshapeNode *reshapeFilter = llvm::dyn_cast<ReshapeNode>(conv->getFilter());
   ASSERT_TRUE(reshapeFilter);
+  TransposeNode *transpFilter =
+      llvm::dyn_cast<TransposeNode>(reshapeFilter->getInput());
+  ASSERT_TRUE(transpFilter);
   ReshapeNode *reshapeInput = llvm::dyn_cast<ReshapeNode>(conv->getInput());
   ASSERT_TRUE(reshapeInput);
 


### PR DESCRIPTION
**Summary**
Add optional graph optimizer path to convert FC to 1x1 Conv2D.
The pass is not added to any pipeline so that backends can optionally use it.

Test Plan:
New unit test.
