### PR TITLE
Extend the ReplaceZeroScaleFP16QuantNodes pass to Storage

### DIFF
--- a/include/glow/Support/Float16.h
+++ b/include/glow/Support/Float16.h
@@ -23,6 +23,9 @@
 
 namespace glow {
 
+/// Smallest allowed scale in FP16 (at least for NNPI)
+constexpr float minScaleFP16 = 1.f / 65504.f;
+
 /// Use a proxy type in case we need to change it in the future.
 using Float16Storage = uint16_t;
 class float16 {

--- a/lib/Base/Type.cpp
+++ b/lib/Base/Type.cpp
@@ -24,7 +24,7 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os, const Type &type) {
 
   if (type.isQuantizedType()) {
     os << "[S:";
-    llvm::write_double(os, type.getScale(), llvm::FloatStyle::Fixed, 4);
+    llvm::write_double(os, type.getScale(), llvm::FloatStyle::Fixed, 9);
     os << " O:";
     os << type.getOffset();
     os << ']';

--- a/tests/unittests/GraphOptzTest.cpp
+++ b/tests/unittests/GraphOptzTest.cpp
@@ -6164,7 +6164,7 @@ TEST_F(GraphOptz, foldMinMaxToClipTest) {
 }
 
 /// Check that we replace a Node with 0.f scale in fp16 with a splat correctly.
-TEST_F(GraphOptz, ZeroScaleFP16QuantOpt) {
+TEST_F(GraphOptz, ReplaceZeroScaleFP16QuantOpt) {
   auto *LHS = mod_.createPlaceholder(ElemKind::FloatTy, {20, 30}, "LHS", false);
   auto *RHSQ = mod_.createPlaceholder(ElemKind::Int8QTy, {20, 30}, 0.1f, 10,
                                       "LHS", false);
@@ -6208,5 +6208,64 @@ TEST_F(GraphOptz, ZeroScaleFP16QuantOpt) {
   bindings_.allocate(RHSQ)->getHandle<int8_t>().randomize(-128, 127,
                                                           mod_.getPRNG());
 
+  checkNumericalEquivalence(0.f);
+}
+
+/// Same as GraphOptz, but when running numerical equivalence use the CPU
+/// backend instead of Interpreter.
+class GraphOptzOnCPU : public GraphOptz {
+public:
+  GraphOptzOnCPU() : GraphOptz("CPU") {}
+};
+
+/// Check that we replace a Node with 0.f scale in fp16 with a splat
+/// correctly. Note that when running this on the Interpreter backend (i.e. with
+/// the GraphOptz fixure) there are numerical differences because the
+/// Interpreter backend does not handle tiny scales correctly. Hence, for now
+/// run on the CPU backend for comparison. TODO to fix the Interpreter Int8 FC
+/// impl to handle correctly.
+TEST_F(GraphOptzOnCPU, ReplaceZeroScaleFP16QuantConstOpt) {
+  auto *input =
+      mod_.createPlaceholder(ElemKind::Int8QTy, {1, 1}, 1.0, 0, "input", false);
+  // scale = 1e-9 underflows fp16 and so this opt applies.
+  auto *weights =
+      mod_.createConstant(ElemKind::Int8QTy, {1, 1}, 1e-9, 0, "weights");
+  weights->getPayloadMutable().getHandle<int8_t>().randomize(-128, 127,
+                                                             mod_.getPRNG());
+  auto *bias = mod_.createConstant(ElemKind::Int8QTy, {1}, 1.0, 0, "bias");
+  bias->getPayloadMutable().getHandle<int8_t>().randomize(-128, 127,
+                                                          mod_.getPRNG());
+  auto *FC = F_->createFullyConnected("fc", input, weights, bias);
+  auto *DQ = F_->createDequantize("dq", FC, ElemKind::FloatTy);
+  F_->createSave("save", DQ);
+
+  optimizedF_ = optimizeFunctionForTest(
+      F_, {FunctionPassID::ReplaceZeroScaleFP16QuantNodes, getDCEPassConfig()});
+
+  SaveNode *save = nullptr;
+  for (auto &N : optimizedF_->getNodes()) {
+    if (N.getKind() == Kinded::Kind::SaveNodeKind) {
+      save = llvm::dyn_cast<SaveNode>(&N);
+      break;
+    }
+  }
+  ASSERT_TRUE(save);
+
+  auto *optDQ = llvm::dyn_cast<DequantizeNode>(save->getInput());
+  ASSERT_TRUE(optDQ);
+  auto *optFC = llvm::dyn_cast<FullyConnectedNode>(optDQ->getInput());
+  ASSERT_TRUE(optFC);
+
+  SplatNode *splat = llvm::dyn_cast<SplatNode>(optFC->getWeights());
+  ASSERT_TRUE(splat);
+  EXPECT_EQ(splat->getValue(), 0.f);
+  const TypeRef splatQTy = splat->getResult().getType();
+  EXPECT_EQ(splatQTy->getScale(), 1.f);
+  EXPECT_EQ(splatQTy->getOffset(), 0);
+  EXPECT_EQ(splatQTy->getElementType(), weights->getOutput().getElementType());
+  EXPECT_EQ(splatQTy->dims(), weights->getOutput().dims());
+
+  bindings_.allocate(input)->getHandle<int8_t>().randomize(-128, 127,
+                                                           mod_.getPRNG());
   checkNumericalEquivalence(0.f);
 }


### PR DESCRIPTION
Summary: The pass before only handled Nodes. Add handling of any Storage as well (Placeholders / Constants). Also adjust the check here for if the value is below `1/65504`, the lowest allowed FP16 float for NNPI.

Differential Revision: D24816424

