### PR TITLE
Fix LSTMUnitNode lowering support on 1.0

### DIFF
--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -154,7 +154,11 @@ static NodeSupportLevels isNodeSupported(const NodeInfo &NI) {
             {ElemKind::Float16Ty}, {ROIAlignNode::BatchIndicesIdx}) &&
         (NI.getInElemTy(ROIAlignNode::BatchIndicesIdx) == ElemKind::Int64ITy);
     break;
-#endif // NNPI > 1.1
+  case Kinded::Kind::LSTMUnitNodeKind:
+    isNodePrecisionSupported =
+        NI.allInputsAndOutputsHaveSameElemKind({ElemKind::Float16Ty});
+    break;
+#endif // NNPI >= 1.1
   case Kinded::Kind::MulNodeKind:
     isNodePrecisionSupported = NI.allInputsAndOutputsHaveSameElemKind(
         {ElemKind::FloatTy, ElemKind::Float16Ty, ElemKind::Int8QTy});
@@ -602,10 +606,6 @@ static NodeSupportLevels isNodeSupported(const NodeInfo &NI) {
         (NI.getOutElemTy(ArgMaxNode::ResultIdx) == ElemKind::Int64ITy);
     break;
   case Kinded::Kind::LogitNodeKind:
-    isNodePrecisionSupported =
-        NI.allInputsAndOutputsHaveSameElemKind({ElemKind::Float16Ty});
-    break;
-  case Kinded::Kind::LSTMUnitNodeKind:
     isNodePrecisionSupported =
         NI.allInputsAndOutputsHaveSameElemKind({ElemKind::Float16Ty});
     break;


### PR DESCRIPTION
Summary: Fix LSTMUnitNode to not lower only on NNP-I v1.1.x and above.