### PR TITLE
Int8Conv2dParallelBench fix to create convolution dilation dimensions.

### DIFF
--- a/tests/benchmark/Int8Conv2dParallelBench.cpp
+++ b/tests/benchmark/Int8Conv2dParallelBench.cpp
@@ -174,8 +174,8 @@ public:
                (unsigned int)(conv_param.pad[2]),
                (unsigned int)(conv_param.pad[3])},
               (unsigned int)(conv_param.G),
-              (unsigned int)(conv_param.dilation[0]));
-
+              {(unsigned int)(conv_param.dilation[0]),
+               (unsigned int)(conv_param.dilation[1])});
           cur[core] = conv[core * input_shapes_.size() + conv_ops];
           conv_ops += 1;
         }


### PR DESCRIPTION
Summary: Fix to create convolution node dilation dimensions in Int8Conv2dParallelBench test.