### PR TITLE
Add Flag to Secure Writing to Onnx with Randomizing Constants

### DIFF
--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -5217,6 +5217,7 @@ Constant *Module::getConstantByName(llvm::StringRef name) const {
 
 void Function::randomizeConstants(
     const std::map<Kinded::Kind, std::set<unsigned>> &ignoredConstants) {
+  LOG(INFO) << "Randomize Constants............";
   for (Constant *c : getParent()->getConstants()) {
     bool usedHere = false;
     bool usedElsewhere = false;

--- a/torch_glow/src/PyTorchCommon.cpp
+++ b/torch_glow/src/PyTorchCommon.cpp
@@ -65,6 +65,7 @@ DEFINE_bool(onnxZipMode, false, "See PyTorchLoaderSettings");
 DEFINE_int32(maxActiveRequests, 250,
              "Max number of active requests before HostManager starts queuing");
 DEFINE_bool(randomizeConstants, false, "See PyTorchLoaderSettings");
+DEFINE_bool(writeWithoutRandomize, false, "See PyTorchLoaderSettings");
 DEFINE_bool(runShapeInference, false, "See PyTorchLoaderSettings");
 DEFINE_int32(fusionStartIndex, -1, "See PyTorchLoaderSettings");
 DEFINE_int32(fusionEndIndex, -1, "See PyTorchLoaderSettings");
@@ -258,6 +259,7 @@ void PyTorchLoaderSettings::initSettings() {
   writeToOnnx = FLAGS_writeToOnnx;
   onnxZipMode = FLAGS_onnxZipMode;
   randomizeConstants = FLAGS_randomizeConstants;
+  writeWithoutRandomize = FLAGS_writeWithoutRandomize;
   backendName = FLAGS_torch_glow_backend;
   numDevices = FLAGS_torch_glow_num_devices;
   runShapeInference = FLAGS_runShapeInference;
@@ -315,7 +317,6 @@ std::string PyTorchLoaderSettings::toString() const {
   INSERT_BOOL_TO_STREAM(convertConstantsToFP16, s);
   INSERT_BOOL_TO_STREAM(forceFP16AccumSLS, s);
   INSERT_BOOL_TO_STREAM(saturateHost, s);
-  INSERT_BOOL_TO_STREAM(randomizeConstants, s);
   INSERT_VALUE_TO_STREAM(backendOptionsFile, s);
   INSERT_VALUE_TO_STREAM(replicationCount, s);
   INSERT_BOOL_TO_STREAM(fusionPassEnabled, s);
@@ -332,6 +333,7 @@ std::string PyTorchLoaderSettings::toString() const {
   INSERT_BOOL_TO_STREAM(onnxZipMode, s);
   INSERT_BOOL_TO_STREAM(jitVsGlowCompare, s);
   INSERT_BOOL_TO_STREAM(randomizeConstants, s);
+  INSERT_BOOL_TO_STREAM(writeWithoutRandomize, s);
   INSERT_VALUE_TO_STREAM(backendName, s);
   INSERT_VALUE_TO_STREAM(numDevices, s);
   INSERT_BOOL_TO_STREAM(runShapeInference, s);

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -136,6 +136,11 @@ public:
   /// PyTorchModelLoader.
   bool randomizeConstants = false;
 
+  // If true then writing to Onnx without randomizing the constants is allowed.
+  // Otherwise, program will be abort if trying to write to Onnx without
+  // randomizing the constants.
+  bool writeWithoutRandomize = false;
+
   /// Name of the Glow backend to use.
   std::string backendName = "Interpreter";
 

--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -6010,6 +6010,12 @@ PyTorchModelLoader::PyTorchModelLoader(
     }
 
     if (settings.writeToOnnx) {
+      RETURN_ERR_IF_NOT(
+          settings.randomizeConstants || settings.writeWithoutRandomize,
+          "Write to Onnx without randomizing constants is not allowed! To "
+          "allow this set flag `writeWithoutRandomize`.");
+      LOG_IF(WARNING, !settings.randomizeConstants)
+          << "Write to Onnx without randomize constants!!!";
       RETURN_IF_ERR(dumpOnnxModel(F, settings.onnxZipMode));
     }
 

--- a/torch_glow/src/binding.cpp
+++ b/torch_glow/src/binding.cpp
@@ -191,6 +191,16 @@ PYBIND11_MODULE(_torch_glow, m) {
     getGlobalPyTorchLoaderSettingsMutable().randomizeConstants = false;
   });
 
+  /// Enable writing to Onnx without randomizing constants.
+  m.def("enable_write_without_randomize", []() {
+    getGlobalPyTorchLoaderSettingsMutable().writeWithoutRandomize = true;
+  });
+
+  /// Disable writing to Onnx without randomizing constants.
+  m.def("disable_write_without_randomize", []() {
+    getGlobalPyTorchLoaderSettingsMutable().writeWithoutRandomize = false;
+  });
+
   /// Enable check Glow vs jit correctness.
   m.def("enable_jit_vs_glow_compare", []() {
     getGlobalPyTorchLoaderSettingsMutable().jitVsGlowCompare = true;


### PR DESCRIPTION
Summary:
Add a flag `writeWithoutRandomize` to `PyTorchLoaderSettings` so that we only allow writing to Onnx without randomizing constant when this flag is set to true.

Before writing to Onnx, we'll check randomizeConstants || writeWithoutRandomize. If false then abort the program.

Reviewed By: jackm321

Differential Revision: D24844474

