### PR TITLE
Support user defined classes as constants (#45556)

### DIFF
--- a/torch_glow/src/TorchGlowBackend.cpp
+++ b/torch_glow/src/TorchGlowBackend.cpp
@@ -15,6 +15,7 @@
 #include <torch/csrc/jit/ir/node_hashing.h>
 #include <torch/csrc/jit/passes/common_subexpression_elimination.h>
 #include <torch/csrc/jit/passes/constant_pooling.h>
+#include <torch/csrc/jit/passes/constant_propagation.h>
 #include <torch/csrc/jit/passes/dead_code_elimination.h>
 #include <torch/csrc/jit/passes/freeze_module.h>
 #include <torch/csrc/jit/passes/inliner.h>
@@ -595,6 +596,7 @@ compileImpl(const torch::jit::Module &origModule,
     auto graph = method.graph();
     EliminateDeadCode(graph);
     EliminateCommonSubexpression(graph);
+    ConstantPropagation(graph);
     ConstantPooling(graph);
   }
 


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/pytorch/pytorch/pull/45556

User defined classes can be used as constants.  This is useful when freezing and removing the module from the graph.

Differential Revision: D23994974

