### PR TITLE
Remove invalid qparams DCHECK

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -362,8 +362,6 @@ bool isQParamWeightNode(const torch::jit::Node *node) {
   const auto userKind = uses[0].user->kind();
 
   if (packedQuantNodeKinds.count(userKind)) {
-    DCHECK_EQ(uses.size(), 1) << "Expected packed quantization parameters to "
-                                 "only be used by one node";
     return true;
   }
 


### PR DESCRIPTION
Summary: Valid graphs can share qparam tensors and we have hit this assertion before

Reviewed By: yinghai

Differential Revision: D24821283

