### PR TITLE
update pybind

### DIFF
--- a/torch_glow/src/CMakeLists.txt
+++ b/torch_glow/src/CMakeLists.txt
@@ -63,7 +63,6 @@ target_link_libraries(_torch_glow
                       PRIVATE
                         PyTorchModelLoader
                         Backends
-                        pybind11
                         torch_python)
 
 include_directories(${PYTORCH_DIR}/include)


### PR DESCRIPTION
Summary:
Recent update of pybind version from PyTorch (https://github.com/pytorch/pytorch/pull/46415) created compatibility issue, resulting in mysterious errors like 
```
__________________ TestRemoveException.test_remove_exceptions __________________
self = <tests.functionality.remove_exceptions_test.TestRemoveException testMethod=test_remove_exceptions>

    def test_remove_exceptions(self):
        """Test Glow's removeExceptions JIT pass"""
    
        foo_jit = torch.jit.script(foo)
        graph = foo_jit.graph
        assert graph_contains_str(graph, "prim::RaiseException")
>       torch_glow.removeExceptions_(graph)
E       TypeError: removeExceptions_(): incompatible function arguments. The following argument types are supported:
E           1. (arg0: torch::jit::Graph) -> None
```
This PR aligns the pybind11 versions in glow and pytorch, hence fixing the issue. 

Documentation:

[Optional Fixes #issue]

Test Plan:

CI
