### PR TITLE
Type assertion for runtime input tensors

### DIFF
--- a/torch_glow/src/CachingGraphRunner.cpp
+++ b/torch_glow/src/CachingGraphRunner.cpp
@@ -445,6 +445,14 @@ Error CachingGraphRunner::runImpl(const PerGlowGraphInfo &info,
       glow::TypeRef ty = ph->getType();
 
       auto ptTensor = input.toTensor();
+
+      // Make sure the runtime pytorch tensor type matches the placeholder
+      CHECK(ty->getElementType() ==
+            scalarTypeToElemKind(ptTensor.scalar_type()))
+          << "Found type mismatch for input #" << placeholderI
+          << ": pytorch tensor is " << ptTensor.toString() << ", ph type is "
+          << ty->toString();
+
       bool needClone = false;
 
       if (ptTensor.is_quantized()) {


### PR DESCRIPTION
Summary: We use raw pointers during runtime input placeholder filling, it could be dangerous when we have a type mismatch when we use warmCache. So we add an assertion to guard the type mismatch.

Differential Revision: D24938390

