### PR TITLE
Extend ConvertBroadcastedBatchMatMul to handle BroadcastNode

### DIFF
--- a/lib/Optimizer/GraphOptimizerPipeline/FunctionPassPipeline.cpp
+++ b/lib/Optimizer/GraphOptimizerPipeline/FunctionPassPipeline.cpp
@@ -108,6 +108,9 @@ createDefaultGraphOptimizationPassPipeline() {
       // Convert BatchMatMuls with a broadcasted RHS to a single MatMul.
       {FunctionPassID::ConvertBroadcastedBatchMatMul},
 
+      // Eliminate nodes which do not do anything.
+      {FunctionPassID::EliminateNoop},
+
       // Perform Common Subexpression Elimination.
       {FunctionPassID::CSE},
 


### PR DESCRIPTION
Summary: Due to the recent addition of the BroadcastNode, this optimization no longer applied. Add support for Broadcast.

Differential Revision: D24943779

