### PR TITLE
Add option to continuously verify Glow function during model loading

### DIFF
--- a/tests/unittests/ErrorTest.cpp
+++ b/tests/unittests/ErrorTest.cpp
@@ -198,3 +198,12 @@ TEST(Error, WarningString) {
   EXPECT_NE(str.find("Warning"), std::string::npos)
       << "Expect warning to be present in message";
 }
+
+TEST(Error, StackMessages) {
+  const char *msg = "some message";
+  auto err = MAKE_ERR(msg);
+  ADD_MESSAGE_TO_ERR_STACK(err, "banana");
+  auto str = ERR_TO_STRING(std::move(err));
+  EXPECT_NE(str.find("banana"), std::string::npos)
+      << "Expect stack message to be present in message";
+}

--- a/torch_glow/src/PyTorchCommon.cpp
+++ b/torch_glow/src/PyTorchCommon.cpp
@@ -77,6 +77,8 @@ DEFINE_string(backendSpecificOpts, "",
               "Comma separated list of key=value for building the "
               "BackendSpecificOptions map in BackendOptions in "
               "CompilationContext.");
+DEFINE_bool(debugContinuouslyVerifyDuringModelLoading, false,
+            "See PyTorchLoaderSettings");
 
 namespace glow {
 namespace {
@@ -267,6 +269,8 @@ void PyTorchLoaderSettings::initSettings() {
   fusionEndIndex = FLAGS_fusionEndIndex;
   setIncludeLastOffsets = FLAGS_setIncludeLastOffsets;
   enableRemoveMutation = FLAGS_enableRemoveMutation;
+  debugContinuouslyVerifyDuringModelLoading =
+      FLAGS_debugContinuouslyVerifyDuringModelLoading;
 
   if (!FLAGS_opBlacklist.empty()) {
     auto kindStrings = splitString(FLAGS_opBlacklist);
@@ -339,6 +343,7 @@ std::string PyTorchLoaderSettings::toString() const {
   INSERT_BOOL_TO_STREAM(runShapeInference, s);
   INSERT_BOOL_TO_STREAM(setIncludeLastOffsets, s);
   INSERT_BOOL_TO_STREAM(enableDebugFuser, s);
+  INSERT_BOOL_TO_STREAM(debugContinuouslyVerifyDuringModelLoading, s);
 
   if (opBlacklist.size() > 0) {
     s << "opBlacklist: [";

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -157,6 +157,11 @@ public:
   /// embedding-bag-like operators. This is default to true since it is
   /// currently a requirement if we want to support partial inputs
   bool setIncludeLastOffsets = true;
+
+  /// Call Glow's Function verifier after loading each JIT node to catch any
+  /// Glow graph errors as soon as possible during loading. This is disabled by
+  /// default because it can slow down model loading.
+  bool debugContinuouslyVerifyDuringModelLoading = false;
 };
 
 /// Represents different possible output types from to_glow modules.

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -103,6 +103,9 @@ public:
   /// accessed by custom operator loaders.
   glow::Function &F_;
 
+  /// Settings used during model loading.
+  const PyTorchLoaderSettings &settings_;
+
 private:
   /// Map from input placeholders to their location on the input stack.
   std::unordered_map<glow::Placeholder *, size_t>

--- a/torch_glow/src/binding.cpp
+++ b/torch_glow/src/binding.cpp
@@ -339,4 +339,16 @@ PYBIND11_MODULE(_torch_glow, m) {
   m.def("disable_debug_fuser", []() {
     getGlobalPyTorchLoaderSettingsMutable().enableDebugFuser = false;
   });
+
+  /// Enable continuously verifying Glow graph during model loading
+  m.def("enable_debug_continuously_verify_during_model_loading", []() {
+    getGlobalPyTorchLoaderSettingsMutable()
+        .debugContinuouslyVerifyDuringModelLoading = true;
+  });
+
+  /// Disable continuously verifying Glow graph during model loading
+  m.def("disable_debug_continuously_verify_during_model_loading", []() {
+    getGlobalPyTorchLoaderSettingsMutable()
+        .debugContinuouslyVerifyDuringModelLoading = false;
+  });
 }


### PR DESCRIPTION
Summary:
* Add flag `debugContinuouslyVerifyDuringModelLoading`  to enable running Glow's Function verification after loading each JIT node to pinpoint bugs earlier.
* Add unconditional Function verification at the end of PyTorchModelLoader load with a hint to enable `debugContinuouslyVerifyDuringModelLoading` for better debugging granularity

Reviewed By: mjanderson09

Differential Revision: D24822046

