### PR TITLE
[torch_glow] Add support for torch.max(input, axis, keepdim)

### DIFF
--- a/torch_glow/tests/nodes/max_test.py
+++ b/torch_glow/tests/nodes/max_test.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
+from parameterized import parameterized
 from tests import utils
 
 
@@ -14,7 +15,17 @@ class SimpleMaxModule(torch.nn.Module):
         return torch.max(a + a, b + b)
 
 
-class TestMax(unittest.TestCase):
+class MaxModule(torch.nn.Module):
+    def __init__(self, axis, keepdim=False):
+        super(MaxModule, self).__init__()
+        self.axis = axis
+        self.keepdim = False
+
+    def forward(self, a):
+        return torch.max(a + a, self.axis, keepdim=self.keepdim)
+
+
+class TestMaxElementwise(unittest.TestCase):
     def test_elementwise_max(self):
         """Test of the PyTorch max Node on Glow."""
 
@@ -22,12 +33,19 @@ class TestMax(unittest.TestCase):
             SimpleMaxModule(), torch.randn(4), torch.randn(4), fusible_ops={"aten::max"}
         )
 
-    def test_elementwise_max_broadcast(self):
-        """Test of the PyTorch max Node with broadcast on Glow."""
 
+class TestMax(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("basic", MaxModule(0), torch.randn(2, 3)),
+            ("keepdim", MaxModule(0, True), torch.randn(5, 3)),
+            ("axis_1", MaxModule(1, True), torch.randn(4, 2)),
+        ]
+    )
+    def test_max(self, _, module, tensor, skip_to_glow=False):
         utils.compare_tracing_methods(
-            SimpleMaxModule(),
-            torch.randn(2, 4),
-            torch.randn(4),
+            module,
+            tensor,
             fusible_ops={"aten::max"},
+            skip_to_glow=skip_to_glow,
         )


### PR DESCRIPTION
Summary:
This PR adds support for loading `torch.max(input, axis, keepdim)` in Pytorch model loader. Currently only the elementwise version is supported.

Test Plan:
Additional tests have been added to max_test.py.