### PR TITLE
[Interpreter] Allow int32 inputs for BatchedReduceAdd

### DIFF
--- a/include/glow/Backends/Interpreter/InterpreterFunction.h
+++ b/include/glow/Backends/Interpreter/InterpreterFunction.h
@@ -310,10 +310,9 @@ private:
   void fwdUnaryTrigonometricImpl(const InstKind *I,
                                  std::function<float(float)> func);
   template <typename ElemTy>
-  void fwdBatchedReduceAddInstFloatImpl(Value *batch, Value *dest,
-                                        unsigned_t axis,
-                                        const ShapeVector &eBatchDims,
-                                        const ShapeVector &eDestDims);
+  void fwdBatchedReduceAddInstImpl(Value *batch, Value *dest, unsigned_t axis,
+                                   const ShapeVector &eBatchDims,
+                                   const ShapeVector &eDestDims);
 
   template <typename ElemTy>
   void fwdBatchedReduceMinInstImpl(Value *batch, Value *dest,

--- a/lib/Backends/CPU/tests/CPUOperatorTest.cpp
+++ b/lib/Backends/CPU/tests/CPUOperatorTest.cpp
@@ -375,4 +375,5 @@ std::set<std::string> glow::backendTestBlacklist = {
     "BBoxTransform_Float16/0",
     "BBoxTransform_Rotated_Float/0",
     "BBoxTransform_Rotated_Float16/0",
+    "batchedReduceAdd_Int32ITy/0",
 };

--- a/lib/Backends/Habana/tests/HabanaOperatorTest.cpp
+++ b/lib/Backends/Habana/tests/HabanaOperatorTest.cpp
@@ -428,4 +428,5 @@ std::set<std::string> glow::backendTestBlacklist = {
     "Atan_Int8QTy/0",
     "BBoxTransform/0",
     "NonSquareDilationConvTranspose/0",
-    "NonSquareDilationConv2D/0"};
+    "NonSquareDilationConv2D/0",
+    "batchedReduceAdd_Int32ITy/0"};

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -109,8 +109,8 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
   case Kinded::Kind::AdaptiveAvgPoolNodeKind:
   case Kinded::Kind::BatchedReduceAddNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
-        {ElemKind::FloatTy, ElemKind::Float16Ty, ElemKind::BFloat16Ty,
-         ElemKind::Int8QTy});
+        {ElemKind::Int32ITy, ElemKind::FloatTy, ElemKind::Float16Ty,
+         ElemKind::BFloat16Ty, ElemKind::Int8QTy});
 
   case Kinded::Kind::MatMulNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(

--- a/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
@@ -481,6 +481,7 @@ struct BlacklistInitializer {
       {"LSTMUnitFP16/0", TestBlacklist::AnyDeviceAnyEngine},
       {"PyTorchLSTMFP16/0", TestBlacklist::AnyDeviceAnyEngine},
       {"ConvertFrom_FloatTy_To_BoolTy/0", TestBlacklist::AnyDeviceAnyEngine},
+      {"batchedReduceAdd_Int32ITy/0", TestBlacklist::AnyDeviceAnyEngine},
 #endif
 #if NNPI_MAJOR_VERSION == 1 && NNPI_MINOR_VERSION == 1
       {"LSTMUnitFP16/0", TestBlacklist::AnyDeviceAnyEngine},

--- a/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
@@ -595,4 +595,5 @@ std::set<std::string> glow::backendTestBlacklist = {
     "VectorNorm_Float16/0",
     "VectorNorm_Float16Ty/0",
     "NonSquareDilationConvTranspose/0",
-    "NonSquareDilationConv2D/0"};
+    "NonSquareDilationConv2D/0",
+    "batchedReduceAdd_Int32ITy/0"};

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -3161,6 +3161,12 @@ TEST_P(OperatorTest, batchedReduceAdd_BFloat16) {
                                    ElemKind::BFloat16Ty);
 }
 
+/// Test that BatchedReduceAdd is correctly supported in Int32ITy.
+TEST_P(OperatorTest, batchedReduceAdd_Int32ITy) {
+  CHECK_IF_ENABLED();
+  testBatchedReduceAdd<int>(bindings_, mod_, F_, EE_, ElemKind::Int32ITy);
+}
+
 /// Test that BatchedReduceAdd works correctly reducing the outermost axis.
 TEST_P(OperatorTest, batchedReduceAdd_outerAxis) {
   CHECK_IF_ENABLED();


### PR DESCRIPTION
Summary:
This PR adds support for int32 inputs to the BatchedReduceAdd node.

Test Plan:
Tests have been added to InterpreterOperatorTest