### PR TITLE
[torch_glow] Improve topk

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -5060,7 +5060,9 @@ Error PyTorchModelLoader::loadTopK(const torch::jit::Node *ptNode) {
     int64_t dim;
     ASSIGN_VALUE_OR_RETURN_ERR(
         dim, iValToInt(getGlowIValueForValue(inputs[TopKInputs::dim])));
-    RETURN_ERR_IF_NOT(dim != input.dims().size() - 1,
+    if (dim < 0)
+      dim = input.dims().size() + dim;
+    RETURN_ERR_IF_NOT(dim == input.dims().size() - 1,
                       "topk is only supported along the last dimension");
   }
 


### PR DESCRIPTION
Summary:
Added support for negative `dim` in topk and fixed an incorrect assert for the value of `dim`.
