### PR TITLE
[torch_glow] Removal of batch_norm constraint of input rank, to suppo…

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -3535,11 +3535,6 @@ Error PyTorchModelLoader::loadBatchNorm(const torch::jit::Node *ptNode) {
                                            inputs[BatchNormInputs::training])));
   RETURN_ERR_IF_NOT(training == false, "Don't support BatchNorm training yet.");
 
-  RETURN_ERR_IF_NOT(
-      input.dims().size() == numDims + 2,
-      glow::strFormat("Number input dimensions must be equal to %d, got %lu",
-                      numDims + 2, input.dims().size()));
-
   size_t numChannels = input.dims()[1];
   glow::NodeValue weights = loadNodeValueOrCreateBroadcastedConstant(
       inputs[BatchNormInputs::weights], "weight",


### PR DESCRIPTION
Removal of constraint of input rank, to support Sparse input. Even if the input is sparse tensor, BatchNorm can work directly by applying normalization on the values. The checks for shape validation are already added to verify().