### PR TITLE
[torch-glow] Added keepdim support in torch.norm op

### DIFF
--- a/torch_glow/tests/nodes/norm_test.py
+++ b/torch_glow/tests/nodes/norm_test.py
@@ -26,6 +26,15 @@ class TestNorm(unittest.TestCase):
             fusible_ops={"aten::norm"},
         )
 
+    def test_norm_keep_dims(self):
+        """Basic test of the PyTorch norm Node on Glow."""
+
+        utils.compare_tracing_methods(
+            SimpleNormModule(dim=0, p=2, keepdim=True),
+            torch.arange(8, dtype=torch.float).reshape(2, 4),
+            fusible_ops={"aten::norm"},
+        )
+
     def test_norm_3d_inner_axis(self):
         """Basic test of the PyTorch norm Node on Glow."""
 


### PR DESCRIPTION
Summary:
Added support for keepdim parameter for norm op in PyTorchModelLoader.

Test Plan:
Added unit test to test funcitonality in norm_test.py.