### PR TITLE
enable --glow_global_fused_scale_offset_fp32 for RecommendationSystemTest

### DIFF
--- a/tests/unittests/RecommendationSystemTest.cpp
+++ b/tests/unittests/RecommendationSystemTest.cpp
@@ -138,6 +138,12 @@ llvm::cl::opt<bool> dumpBinaryResults(
     "dump-binary-results",
     llvm::cl::desc("Dump raw binary Tensor results after execution."),
     llvm::cl::init(false), llvm::cl::cat(recSysTestCat));
+
+llvm::cl::opt<bool> fuseScaleOffsetFp32Opt(
+    "glow_global_fused_scale_offset_fp32",
+    llvm::cl::desc(
+        "Enable converting scale/offset in sls's input data from fp16 to fp32"),
+    llvm::cl::Optional, llvm::cl::init(false), llvm::cl::cat(recSysTestCat));
 } // namespace
 
 class TestDeferredWeightLoader : public DeferredWeightLoader {
@@ -856,6 +862,9 @@ protected:
           Kinded::Kind::FusedRowwiseQuantizedSparseLengthsWeightedSumNodeKind);
       precConfig_.precisionModeKindSet.insert(
           Kinded::Kind::RowwiseQuantizedFullyConnectedNodeKind);
+    } else if (fuseScaleOffsetFp32Opt) {
+      precConfig_.convert4BitFusedToFP32 = fuseScaleOffsetFp32Opt;
+      precConfig_.convert8BitFusedToFP32 = fuseScaleOffsetFp32Opt;
     }
   }
 


### PR DESCRIPTION
Summary: enable --glow_global_fused_scale_offset_fp32 for RecommendationSystemTest

Reviewed By: opti-mix

Differential Revision: D25017621

