### PR TITLE
Support upcast for floating types in cat and stack

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -93,6 +93,12 @@ public:
   const PyTorchLoaderSettings &settings_;
 
 private:
+  /// Helper function to support upcasting in concat, we calculate the higher
+  /// type among a list of types. For example, the higher type of [half, float,
+  /// half, double] will be double. Similar to at::result_type().
+  Expected<c10::ScalarType> getHigherType(
+      const c10::ArrayRef<const torch::jit::Value *> &values) noexcept;
+
   /// Map from input placeholders to their location on the input stack.
   std::unordered_map<glow::Placeholder *, size_t>
       inputPlaceholdersReverseIndex_;

--- a/torch_glow/tests/nodes/cat_test.py
+++ b/torch_glow/tests/nodes/cat_test.py
@@ -58,3 +58,20 @@ class TestCat(unittest.TestCase):
                 y,
                 fusible_ops={"prim::FusedConcat"},
             )
+
+    def test_cat_with_different_types(self):
+        """Test cat between different types that can be cast, which is supported in pytorch."""
+
+        utils.compare_tracing_methods(
+            SimpleCatModule(0, 1, 2),
+            torch.randn(2, 3, 4),
+            torch.randn(2, 3, 4, dtype=torch.half),
+            fusible_ops={"prim::FusedConcat"},
+        )
+
+        utils.compare_tracing_methods(
+            SimpleCatModule(0, 1, 2),
+            torch.randn(2, 3, 4).to(torch.int),
+            torch.randn(2, 3, 4).to(torch.long),
+            fusible_ops={"prim::FusedConcat"},
+        )

--- a/torch_glow/tests/nodes/stack_test.py
+++ b/torch_glow/tests/nodes/stack_test.py
@@ -26,3 +26,16 @@ class TestStack(unittest.TestCase):
             torch.randn(2, 3, 4),
             skip_to_glow=True,
         )
+
+    def test_stack_different_types(self):
+        """Test stack between fp16 and fp32, which is supported in pytorch."""
+
+        x = torch.randn(2, 3, 4)
+        y = torch.randn(2, 3, 4, dtype=torch.half)
+
+        utils.compare_tracing_methods(
+            SimpleStackModel(),
+            x,
+            y,
+            skip_to_glow=True,
+        )


### PR DESCRIPTION
Summary: torch.cat() supports different types as long as they can all be cast to a 'higher type'. Here we support the similar behavior in torch_glow. Currently only floating types are supported.

Differential Revision: D25069231

