### PR TITLE
Fix unit for glow_nnpi_timeout_ms

### DIFF
--- a/include/glow/Flags/Flags.h
+++ b/include/glow/Flags/Flags.h
@@ -130,7 +130,7 @@ extern unsigned HabanaMemory;
 
 #ifdef GLOW_WITH_NNPI
 extern unsigned NNPIMemory;
-extern unsigned NNPITimeout;
+extern unsigned NNPITimeoutMs;
 #endif
 
 extern std::string AvailableDevices;

--- a/lib/Backends/NNPI/NNPIDeviceManager.cpp
+++ b/lib/Backends/NNPI/NNPIDeviceManager.cpp
@@ -65,8 +65,8 @@ NNPIDeviceManager::NNPIDeviceManager(
   if (deviceOptions_->deviceId >= 0) {
     deviceId_ = static_cast<unsigned>(deviceOptions_->deviceId);
   }
-  if (flags::NNPITimeout != 0) {
-    deviceOptions_->inferTimeout = flags::NNPITimeout;
+  if (flags::NNPITimeoutMs != 0) {
+    deviceOptions_->inferTimeout = flags::NNPITimeoutMs * 1000;
   }
 }
 

--- a/lib/Backends/NNPI/NNPIOptions.h
+++ b/lib/Backends/NNPI/NNPIOptions.h
@@ -457,7 +457,7 @@ public:
       "\n 3 = All commands and pre/post processing are disabled.",
       "NNPI_DISABLE_COMMANDS", "0");
 
-  /// Inference timeout threshold. Default UINT32_MAX means infinity.
+  /// Inference timeout threshold in us. Default UINT32_MAX means infinity.
   unsigned inferTimeout{UINT32_MAX};
 
   NNPIDeviceOptions(const llvm::StringMap<std::string> &parameters) {

--- a/lib/Flags/Flags.cpp
+++ b/lib/Flags/Flags.cpp
@@ -138,7 +138,7 @@ unsigned HabanaMemory = 7 << 20;
 
 #ifdef GLOW_WITH_NNPI
 unsigned NNPIMemory = 16 << 20;
-unsigned NNPITimeout = 0;
+unsigned NNPITimeoutMs = 0;
 #endif
 
 std::string AvailableDevices = "";
@@ -549,11 +549,11 @@ DEFINE_validator(glow_nnpi_memory, [](const char *, int32_t val) {
   glow::runtime::flags::NNPIMemory = val;
   return true;
 });
-DEFINE_int32(glow_nnpi_timeout_ms, glow::runtime::flags::NNPITimeout,
+DEFINE_int32(glow_nnpi_timeout_ms, glow::runtime::flags::NNPITimeoutMs,
              "Timeout threshold for inferecnce in milliseconds. Default 0 "
              "means infinity");
 DEFINE_validator(glow_nnpi_timeout_ms, [](const char *, int32_t val) {
-  glow::runtime::flags::NNPITimeout = val;
+  glow::runtime::flags::NNPITimeoutMs = val;
   return true;
 });
 #endif /* GLOW_WITH_NNPI */

--- a/tests/unittests/HostManagerTest.cpp
+++ b/tests/unittests/HostManagerTest.cpp
@@ -920,7 +920,7 @@ TEST_P(HostManagerTest, testTimeout) {
       GTEST_SKIP();
     }
     // Set the timeout to very short so we fail intentionally.
-    glow::runtime::flags::NNPITimeout = 1;
+    glow::runtime::flags::NNPITimeoutMs = 1;
   }
 #endif
 


### PR DESCRIPTION
Summary: During refactoring in D24664663 (https://github.com/pytorch/glow/commit/bdf85a60ae323f3c94233aea79c1270d60899a9e), we missed the unit conversion for glow_nnpi_timeout_ms. This diff adds it back.

Differential Revision: D25080329

