### PR TITLE
Fix a small function attribute issue reported by LLVM verifier

### DIFF
--- a/lib/LLVMIRCodeGen/DebugInfo.cpp
+++ b/lib/LLVMIRCodeGen/DebugInfo.cpp
@@ -491,6 +491,14 @@ void LLVMIRGen::generateModuleDebugInfo() {
   // Finalize the debug info.
   DIBuilder_->finalize();
 
+  // Fix function attributes related issues.
+  for (auto &FF : getModule()) {
+    // Optnone requires NoInline.
+    if (FF.hasFnAttribute(llvm::Attribute::AttrKind::OptimizeNone)) {
+      FF.addFnAttr(llvm::Attribute::AttrKind::NoInline);
+    }
+  }
+
   // Verify the module to see if there are any errors due to the debug
   // information.
   bool brokenDebugInfo = false;

--- a/lib/LLVMIRCodeGen/Pipeline.cpp
+++ b/lib/LLVMIRCodeGen/Pipeline.cpp
@@ -129,6 +129,7 @@ void LLVMIRGen::optimizeLLVMModule(llvm::Module *M, llvm::TargetMachine &TM) {
       FF.setDLLStorageClass(llvm::GlobalValue::DefaultStorageClass);
     }
 
+    // Remove NoInline attribute.
     FF.removeFnAttr(llvm::Attribute::AttrKind::NoInline);
 
     // LinkOnce linkage seems to cause problems to OrcJIT on some OS platforms.


### PR DESCRIPTION
Summary: Remove nonline attribute, unless this function is optnone. Optnone requires noinline attribute to be present.

Reviewed By: beicy

Differential Revision: D25139365

