### PR TITLE
Support Fast Gather shape inference

### DIFF
--- a/torch_glow/src/ShapeInferenceEngine.h
+++ b/torch_glow/src/ShapeInferenceEngine.h
@@ -185,6 +185,8 @@ private:
   lengthsToOffsets(const MetaStack &variableMetas);
   // Shape inference for prim::dtype
   static Expected<TensorOutput> primDtype(const MetaStack &variableMetas);
+  // Shape inference for fb::fast_gather
+  static Expected<TensorOutput> fastGather(const MetaStack &variableMetas);
 };
 
 } // namespace glow


### PR DESCRIPTION
Summary:
## Context
In DPER PyTorch model, fb::fast_gather operator is used. we need to support its shape inference.

fast_gather is defined in: https://fburl.com/diffusion/db41cav8.
```
Tensor fast_gather(const Tensor& input, const Tensor& indices) {
  if (input.dim() == 1 && indices.dim() == 1) {
    return torch::gather(input, 0, indices.to(at::kLong));
  }
  return input.index(indices.to(at::kLong));
}
```
suppose input has dimension `[d1, d2, ..., dm]`
indices has dimension `[D1 (https://github.com/pytorch/glow/commit/c9b49cfe0ac34c3ffec32cd1116521c9a00ffd9f), D2 (https://github.com/pytorch/glow/commit/385eb0f36a63b9f8e32c96f4b742c6f7d53af547), ..., Dn]`.

the result tensor dimension will be `[D1 (https://github.com/pytorch/glow/commit/c9b49cfe0ac34c3ffec32cd1116521c9a00ffd9f), D2 (https://github.com/pytorch/glow/commit/385eb0f36a63b9f8e32c96f4b742c6f7d53af547), ..., Dn, d2,, ..., dm]`

Reviewed By: qizzzh

Differential Revision: D25146484

