### PR TITLE
Add aten::div and aten::rsub in shape inference

### DIFF
--- a/torch_glow/src/ShapeInferenceEngine.cpp
+++ b/torch_glow/src/ShapeInferenceEngine.cpp
@@ -127,7 +127,9 @@ Error ShapeInferenceEngine::shapeOnNode(const torch::jit::Node *node) {
     case c10::aten::sub:
     case c10::aten::pow:
     case c10::aten::mul:
-    case c10::aten::add: {
+    case c10::aten::add:
+    case c10::aten::div:
+    case c10::aten::rsub: {
       ASSIGN_VALUE_OR_RETURN_ERR(tensorOutput, binaryOp(inputMetas));
       break;
     }


### PR DESCRIPTION
Summary:
## Context
In generated DPER PyTorch model, aten::div and aten::rsub is used. add these two operators shape inference support.

Since these two operators are binary op which has been supported in shape inference function. this diff is only to add them in the list and unit test.

Reviewed By: qizzzh

Differential Revision: D25146091

