### PR TITLE
Return Fatal error if NNPIDeviceManager fails to acquire deviceContext or deviceInfo

### DIFF
--- a/lib/Backends/NNPI/NNPIDeviceManager.cpp
+++ b/lib/Backends/NNPI/NNPIDeviceManager.cpp
@@ -114,11 +114,11 @@ Error NNPIDeviceManager::init() {
 
   if (deviceOptions_->inferOnDevice) {
     // Create NNPI device.
-    LOG_NNPI_INF_IF_ERROR_RETURN_LLVMERROR(
+    LOG_NNPI_INF_IF_ERROR_RETURN_FATAL_LLVMERROR(
         nnpiDeviceContextCreate(pAdapter_->getHandle(), deviceId_, &device_),
         "Failed to create NNPI Device");
     NNPIDeviceInfo deviceInfo;
-    LOG_NNPI_INF_IF_ERROR_RETURN_LLVMERROR(
+    LOG_NNPI_INF_IF_ERROR_RETURN_FATAL_LLVMERROR(
         nnpiDeviceGetInfo(deviceId_, &deviceInfo),
         "Failed to get NNPI Device Info");
     maxMemoryBytes_ =


### PR DESCRIPTION
Summary: Since failing to acquire a deviceContext or deviceInfo is a fatal error for NNPIDeviceManager we treat it as such.

Differential Revision: D25234391

