### PR TITLE
fix dequantize output type

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -4011,9 +4011,7 @@ Error PyTorchModelLoader::loadDequantize(const torch::jit::Node *ptNode) {
   glow::DequantizeNode *dn =
       F_.createDequantize("dequantize", input, ElemKind::FloatTy);
 
-  c10::ScalarType dtype;
-  RETURN_IF_ERR(getCorrectTypeMapping(dtype, inputs[0]));
-  RETURN_ERR(addValueMapping(outputs[0], dn->getResult(), dtype));
+  RETURN_ERR(addValueMapping(outputs[0], dn->getResult()));
 }
 
 Error PyTorchModelLoader::loadQuantizedConvRelu(


### PR DESCRIPTION
Summary: Avoid setting output correctType to input type in dequantize op: input type is quantized, output type is not quantized.

Reviewed By: zrphercule

Differential Revision: D25229040

