### PR TITLE
[torch_glow] Add support for zeros_like, ones_like and ones

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -479,9 +479,20 @@ private:
   /// \returns error on failure.
   Error loadArange(const torch::jit::Node *ptNode);
 
-  /// Load a PyTorch zeros node.
+  Error loadZerosOrOnesHelper(const torch::jit::Node *ptNode,
+                              c10::ArrayRef<const torch::jit::Value *> outputs,
+                              llvm::ArrayRef<glow::dim_t> inputDims,
+                              float splatValue);
+
+  /// Load a PyTorch zeros or ones node.
   /// \returns error on failure.
-  Error loadZeros(const torch::jit::Node *ptNode);
+  template <int SplatValue>
+  Error loadZerosOrOnes(const torch::jit::Node *ptNode);
+
+  /// Load a PyTorch zeros_like or ones_like node.
+  /// \returns error on failure.
+  template <int SplatValue>
+  Error loadZerosOrOnesLike(const torch::jit::Node *ptNode);
 
   /// Load a PyTorch sub node.
   /// \returns error on failure.

--- a/torch_glow/tests/nodes/zeros_and_ones_like_test.py
+++ b/torch_glow/tests/nodes/zeros_and_ones_like_test.py
@@ -1,0 +1,40 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+
+import torch
+from tests import utils
+
+
+class SimpleLikeModule(torch.nn.Module):
+    def __init__(self, splat_val):
+        super(SimpleLikeModule, self).__init__()
+        self.splat_val = splat_val
+
+    def forward(self, tensor):
+        if self.splat_val == 0:
+            return torch.zeros_like(tensor + tensor)
+        else:
+            return torch.ones_like(tensor + tensor)
+
+
+class TestZerosLike(unittest.TestCase):
+    def test_zeros_like_basic(self):
+        """Test of the PyTorch zeros_like Node on Glow."""
+
+        utils.compare_tracing_methods(
+            SimpleLikeModule(splat_val=0),
+            torch.rand(4, 2, 3),
+            fusible_ops={"aten::zeros_like"},
+        )
+
+
+class TestOnesLike(unittest.TestCase):
+    def test_ones_like_basic(self):
+        """Test of the PyTorch ones_like Node on Glow."""
+
+        utils.compare_tracing_methods(
+            SimpleLikeModule(splat_val=1),
+            torch.rand(4, 2, 3),
+            fusible_ops={"aten::ones_like"},
+        )

--- a/torch_glow/tests/nodes/zeros_and_ones_test.py
+++ b/torch_glow/tests/nodes/zeros_and_ones_test.py
@@ -18,3 +18,17 @@ class TestZero(unittest.TestCase):
         x = torch.randn(2, 3, 4)
 
         utils.compare_tracing_methods(TestModule(), x, fusible_ops={"aten::zeros"})
+
+
+class TestOnes(unittest.TestCase):
+    def test_ones_basic(self):
+        """Basic test of the PyTorch ones Node on Glow."""
+
+        class TestModule(torch.nn.Module):
+            def forward(self, a):
+                b = torch.ones(a.size(), dtype=torch.float)
+                return a + b
+
+        x = torch.randn(2, 3, 4)
+
+        utils.compare_tracing_methods(TestModule(), x, fusible_ops={"aten::ones"})


### PR DESCRIPTION
Summary:
This PR adds support for loading the ops aten::zeros_like, aten::ones_like and aten::ones with PyTorchModelLoader.

Test Plan:
Relevant unit tests have been added.
