### PR TITLE
[torch_glow] Add support for repeat op

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -732,6 +732,10 @@ private:
   /// \returns error on failure.
   Error loadReshape(const torch::jit::Node *ptNode);
 
+  /// Load a PyTorch aten::repeat node.
+  /// \returns error on failure.
+  Error loadRepeat(const torch::jit::Node *ptNode);
+
   /// Load a PyTorch aten::cos node.
   /// \returns error on failure.
   Error loadCos(const torch::jit::Node *ptNode);

--- a/torch_glow/tests/nodes/repeat_test.py
+++ b/torch_glow/tests/nodes/repeat_test.py
@@ -1,0 +1,35 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+
+import torch
+from parameterized import parameterized
+from tests import utils
+
+
+class RepeatModule(torch.nn.Module):
+    def __init__(self, repeats):
+        super(RepeatModule, self).__init__()
+        self.repeats = repeats
+
+    def forward(self, tensor):
+        tensor = tensor + tensor
+        return tensor.repeat(self.repeats)
+
+
+class TestRepeat(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("basic", RepeatModule([4]), torch.randn(3)),
+            ("basic", RepeatModule([3, 5]), torch.randn(3)),
+            ("basic", RepeatModule([4, 3, 5]), torch.tensor(3)),
+            ("2d", RepeatModule([4, 2]), torch.randn(5, 1)),
+            ("2d", RepeatModule([4, 2, 6]), torch.randn(4, 3)),
+            ("3d", RepeatModule([4, 4, 2]), torch.randn(6, 3, 4)),
+            ("3d", RepeatModule([3, 1, 1]), torch.randn(3, 3, 4)),
+            ("3d", RepeatModule([1, 5, 1]), torch.randn(5, 3, 4)),
+            ("3d", RepeatModule([4, 2, 1, 5, 2, 10]), torch.randn(6, 3, 4)),
+        ]
+    )
+    def test_repeat(self, _, module, tensor):
+        utils.compare_tracing_methods(module, tensor, fusible_ops={"aten::repeat"})


### PR DESCRIPTION
Summary:
This PR adds support for the aten::repeat op in PyTorchModelLoader.