### PR TITLE
Fixing accidentally flipped flag default.

### DIFF
--- a/lib/Flags/Flags.cpp
+++ b/lib/Flags/Flags.cpp
@@ -46,7 +46,7 @@ bool ClipZeroScaleFP16 = false;
 // FP16 Constants
 bool ConvertToFP16 = false;
 bool ConvertPlaceholdersToFP16 = false;
-bool ConvertConstantsToFP16 = false;
+bool ConvertConstantsToFP16 = true;
 bool ConvertFusedScaleOffsetToFP16 = false;
 bool ClipToFP16 = false;
 bool SkipInputsOnClipToFP16 = true;


### PR DESCRIPTION
Summary: During flag renaming, I accidentally flipped the default of the fp16 constants flag from true to false. This is flipping it back.

Differential Revision: D25276078

