### PR TITLE
re-introducing to_glow_preview

### DIFF
--- a/torch_glow/src/TorchGlowBackend.cpp
+++ b/torch_glow/src/TorchGlowBackend.cpp
@@ -538,23 +538,13 @@ Error applyFuserSettingsToPyTorchLoaderSettings(
   return Error::success();
 }
 
-/// Implementation of to_backend compile method for Glow. \returns a map from
-/// function name in the preprocessed module to the CachingGraphRunner or
-/// JITGraphRunner depending on settings for each method or if an
-/// error occurs then returns and Error which is converted to an exception for
-/// handling within PyTorch.
-static Expected<std::unordered_map<
-    std::string, std::pair<std::unique_ptr<CachingGraphRunner>,
-                           std::unique_ptr<JITGraphRunner>>>>
-compileImpl(const torch::jit::Module &origModule,
-            const c10::impl::GenericDict &method_compile_spec) {
-
-  std::unordered_map<std::string, std::pair<std::unique_ptr<CachingGraphRunner>,
-                                            std::unique_ptr<JITGraphRunner>>>
-      methodToRunnerMap;
-  std::unordered_map<std::string, std::shared_ptr<torch::jit::Graph>>
-      nameToOrigGraph;
-
+// Runs preprocessing flow on the JIT graph.
+// Returns the processed and frozen module or Error.
+static Expected<torch::jit::Module> preprocessImpl(
+    const torch::jit::Module &origModule,
+    const c10::impl::GenericDict &method_compile_spec,
+    std::unordered_map<std::string, std::shared_ptr<torch::jit::Graph>>
+        &nameToOrigGraph) {
   // Check input and outputs types of each method and inline and remove profiled
   // shapes (this must happen before other optimizations)
   for (const auto &kv : method_compile_spec) {
@@ -612,8 +602,35 @@ compileImpl(const torch::jit::Module &origModule,
     // EliminateDeadCode should be last
     EliminateDeadCode(graph);
   }
+  return frozenModule;
+}
 
-  auto compileModule = frozenModule.clone();
+/// Implementation of to_backend compile method for Glow. \returns a map from
+/// function name in the preprocessed module to the CachingGraphRunner or
+/// JITGraphRunner depending on settings for each method or if an
+/// error occurs then returns and Error which is converted to an exception for
+/// handling within PyTorch.
+static Expected<std::unordered_map<
+    std::string, std::pair<std::unique_ptr<CachingGraphRunner>,
+                           std::unique_ptr<JITGraphRunner>>>>
+compileImpl(const torch::jit::Module &origModule,
+            const c10::impl::GenericDict &method_compile_spec) {
+
+  std::unordered_map<std::string, std::pair<std::unique_ptr<CachingGraphRunner>,
+                                            std::unique_ptr<JITGraphRunner>>>
+      methodToRunnerMap;
+  std::unordered_map<std::string, std::shared_ptr<torch::jit::Graph>>
+      nameToOrigGraph;
+
+  auto frozenModuleOrErr =
+      preprocessImpl(origModule, method_compile_spec, nameToOrigGraph);
+  if (!frozenModuleOrErr) {
+    auto err = frozenModuleOrErr.takeError();
+    err = checkForFatalError(std::move(err));
+    throw std::runtime_error(ERR_TO_STRING(std::move(err)));
+  }
+
+  auto compileModule = frozenModuleOrErr.get().clone();
   // Compile each method
   for (const auto &kv : method_compile_spec) {
     const auto methodName = kv.key().toString()->string();
@@ -823,4 +840,51 @@ int JITGraphRunner::countFusionNodes() {
   }
   return count;
 }
+
+/*static*/
+void TorchGlowBackend::preview(torch::jit::Module mod,
+                               c10::impl::GenericDict method_compile_spec,
+                               c10::optional<torch::jit::Stack> inputStack) {
+  std::unordered_map<std::string, std::shared_ptr<torch::jit::Graph>>
+      nameToOrigGraph;
+
+  auto frozenModuleOrErr =
+      preprocessImpl(mod, method_compile_spec, nameToOrigGraph);
+  if (!frozenModuleOrErr) {
+    auto err = frozenModuleOrErr.takeError();
+    err = checkForFatalError(std::move(err));
+    throw std::runtime_error(ERR_TO_STRING(std::move(err)));
+  }
+  for (const auto &method : mod.get_methods()) {
+    auto graph = method.graph();
+    std::unordered_set<torch::jit::NodeKind> supportedKinds;
+    std::unordered_set<torch::jit::NodeKind> unsupportedKinds;
+    for (auto node : graph->nodes()) {
+      auto nk = node->kind();
+      if (supportedKinds.count(nk) == 0) {
+        if (PyTorchModelLoader::isNodeSupported(node)) {
+          supportedKinds.emplace(nk);
+        } else if (unsupportedKinds.count(nk) == 0) {
+          unsupportedKinds.emplace(nk);
+        }
+      }
+    }
+    // Print findings
+    std::cout << "=== Glow lowering preview ===" << std::endl;
+
+    if (unsupportedKinds.size() == 0) {
+      std::cout << "No unsupported nodes detected." << std::endl;
+    } else {
+      std::cout << "Unsupported Nodes:" << std::endl;
+      for (auto nk : unsupportedKinds) {
+        std::cout << nk.toQualString() << std::endl;
+      }
+    }
+    std::cout << "Supported Nodes:" << std::endl;
+    for (auto nk : supportedKinds) {
+      std::cout << nk.toQualString() << std::endl;
+    }
+  }
+}
+
 } // namespace glow

--- a/torch_glow/src/TorchGlowBackend.h
+++ b/torch_glow/src/TorchGlowBackend.h
@@ -47,6 +47,10 @@ public:
   c10::impl::GenericList execute(c10::IValue handle,
                                  c10::impl::GenericList inputs) override;
 
+  static void
+  preview(torch::jit::Module mod, c10::impl::GenericDict method_compile_spec,
+          c10::optional<torch::jit::Stack> inputStack = c10::nullopt);
+
 private:
   std::unordered_map<int64_t, std::pair<std::unique_ptr<CachingGraphRunner>,
                                         std::unique_ptr<JITGraphRunner>>>


### PR DESCRIPTION
Summary:
re-introducing to_glow_preview:
runs preprocessing flow on the given module and prints stats about supported nodes.
Preprocessing parted was refactored from compile() method.

Differential Revision: D25284396

