### PR TITLE
[torch_glow] Add support for remainder op

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -461,6 +461,10 @@ private:
   /// \returns error on failure.
   Error loadFloorDiv(const torch::jit::Node *ptNode);
 
+  /// Load a PyTorch remainder node.
+  /// \returns error on failure.
+  Error loadRemainder(const torch::jit::Node *ptNode);
+
   /// Load a PyTorch add node.
   /// \returns error on failure.
   Error loadAdd(const torch::jit::Node *ptNode);

--- a/torch_glow/tests/nodes/remainder_test.py
+++ b/torch_glow/tests/nodes/remainder_test.py
@@ -1,0 +1,32 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+
+import torch
+from parameterized import parameterized
+from tests import utils
+
+
+class SimpleRemainderModel(torch.nn.Module):
+    def __init__(self, other):
+        super(SimpleRemainderModel, self).__init__()
+        self.other = other
+
+    def forward(self, tensor):
+        return torch.remainder(tensor + tensor, self.other)
+
+
+class TestRemainder(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("basic", SimpleRemainderModel(torch.randn(2, 3, 4)), torch.randn(2, 3, 4)),
+            (
+                "broadcast",
+                SimpleRemainderModel(torch.randn(3, 4)),
+                torch.randn(2, 3, 4),
+            ),
+            ("scalar", SimpleRemainderModel(2), torch.randn(2, 3, 4)),
+        ]
+    )
+    def test_remainder(self, _, module, tensor):
+        utils.compare_tracing_methods(module, tensor, fusible_ops={"aten::remainder"})


### PR DESCRIPTION
Summary:
This PR adds support for the aten::remainder op in PyTorchModelLoader. 

Test plan:
Tests have been added to remainder_test.py.
