### PR TITLE
Lower fb::broadcast_cat

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -28,6 +28,7 @@
 #include <ATen/native/quantized/cpu/conv_packed_params.h>
 #include <ATen/native/quantized/cpu/packed_params.h>
 #include <torch/csrc/jit/ir/ir.h>
+#include <unordered_map>
 
 namespace glow {
 
@@ -950,6 +951,8 @@ PyTorchModelLoader::buildSymbolsMapping() {
       {{"aten::exp"}, &PyTorchModelLoader::loadExp},
       {{"prim::FusedConcat"}, &PyTorchModelLoader::loadFusedConcat},
       {{"glow::fused_stack"}, &PyTorchModelLoader::loadFusedStack},
+      {{"glow::fused_broadcast_cat"},
+       &PyTorchModelLoader::loadFusedBroadcastConcat},
       {{"aten::floor"}, &PyTorchModelLoader::loadFloor},
       {{"aten::ceil"}, &PyTorchModelLoader::loadCeil},
       {{"aten::mean"}, &PyTorchModelLoader::loadMean},
@@ -2641,7 +2644,8 @@ Expected<c10::ScalarType> PyTorchModelLoader::getHigherType(
   return higherType;
 }
 
-Error PyTorchModelLoader::loadFusedConcat(const torch::jit::Node *ptNode) {
+Error PyTorchModelLoader::loadFusedConcatHelper(const torch::jit::Node *ptNode,
+                                                bool doBroadcast) {
   auto inputs = ptNode->inputs();
   auto outputs = ptNode->outputs();
   RETURN_IF_ERR(checkInputAndOutputSizes(inputs, -1, outputs, 1));
@@ -2655,7 +2659,6 @@ Error PyTorchModelLoader::loadFusedConcat(const torch::jit::Node *ptNode) {
 
   int64_t dim = ptNode->i(at::attr::dim);
 
-  std::vector<glow::NodeValue> glowInputs;
   c10::ScalarType higherType;
   glow::ElemKind higherKind;
   ASSIGN_VALUE_OR_RETURN_ERR(higherType, getHigherType(inputs));
@@ -2674,6 +2677,19 @@ Error PyTorchModelLoader::loadFusedConcat(const torch::jit::Node *ptNode) {
     dim += numInputDims;
   }
 
+  RETURN_ERR_IF_NOT(dim < numInputDims && dim >= 0,
+                    strFormat("Dim value of %ld is out of range. Valid "
+                              "values are in the range [-%ld, %ld]",
+                              origDim, numInputDims, numInputDims - 1));
+
+  // Final shape for all tensors after broadcast
+  std::vector<int64_t> bcastShape(numInputDims, -1);
+  std::vector<bool> needBroadcast(inputs.size(), false);
+  bool noBroadcastNeeded = true;
+
+  // Use mulitple vectors for hierarchical concats, the first vector is the
+  // final concat
+  std::vector<glow::NodeValue> glowInputs;
   for (size_t i = 0; i < inputs.size(); ++i) {
     glow::NodeValue glowInput;
     ASSIGN_VALUE_OR_RETURN_ERR(glowInput, getGlowNodeValueForValue(inputs[i]));
@@ -2681,24 +2697,109 @@ Error PyTorchModelLoader::loadFusedConcat(const torch::jit::Node *ptNode) {
     RETURN_ERR_IF_NOT(numInputDims == glowInput.dims().size(),
                       "All inputs must have the same number of dimensions.");
 
-    RETURN_ERR_IF_NOT(dim < numInputDims && dim >= 0,
-                      strFormat("Dim value of %ld is out of range. Valid "
-                                "values are in the range [-%ld, %ld]",
-                                origDim, numInputDims, numInputDims - 1));
+    // Record broadcast shapes to perform broadcasting
+    for (int d = 0; d < glowInput.dims().size(); ++d) {
+      if (d != dim) {
+        if (bcastShape[d] < 0 && glowInput.dims()[d] != 1) {
+          // record first non-singleton size for dim_i as broadcast shape
+          bcastShape[d] = glowInput.dims()[d];
+        } else if (glowInput.dims()[d] == 1) {
+          needBroadcast[i] = true;
+          noBroadcastNeeded = false;
+        }
+      }
+    }
 
     if (higherType != c10::ScalarType::Undefined &&
         !isQuantizedElemKind(higherKind) &&
         glowInput.getElementType() != higherKind) {
       glow::ConvertToNode *toNode =
           F_.createConvertTo("upcastForConcat", glowInput, higherKind);
-      glowInputs.push_back(toNode->getResult());
+      glowInputs.emplace_back(toNode->getResult());
     } else {
-      glowInputs.push_back(std::move(glowInput));
+      glowInputs.emplace_back(std::move(glowInput));
     }
   }
 
-  RETURN_ERR(
-      addValueMapping(outputs[0], F_.createConcat("cat", glowInputs, dim)));
+  if (doBroadcast && !noBroadcastNeeded) {
+    // For all nodes that require broadcast, we perform opportunistic concat if
+    // the adjacent nodes can be broadcast the same way
+    std::vector<glow::NodeValue> finalConcatInputs;
+    std::vector<glow::NodeValue> partialConcatInputs;
+    std::string prevConcatKey = "";
+
+    // Helper function for concat and using Tile ops to expand.
+    auto addConcatAndBroadcastNode =
+        [&](const std::vector<glow::NodeValue> &nodes, const std::string &key) {
+          glow::NodeValue output;
+          if (nodes.size() > 1) {
+            auto *concatNode = F_.createConcat("cat_" + key, nodes, dim);
+            output = concatNode->getResult();
+          } else if (nodes.size() == 1) {
+            output = nodes[0];
+          } else {
+            // Should not come to this branch, trust downstream to handle errors
+            return output;
+          }
+
+          for (int d = 0; d < numInputDims; ++d) {
+            if (d != dim && output.dims()[d] == 1 && bcastShape[d] > 0) {
+              output = F_.createTile("tile_" + key + "_" + std::to_string(d),
+                                     output, bcastShape[d], /* tile */
+                                     d /* axis */)
+                           ->getResult();
+            }
+          }
+          return output;
+        };
+
+    for (size_t i = 0; i < glowInputs.size(); ++i) {
+      // Use dimensions as key so we can concat those of the same dimensions
+      // For example, for [1, 32, 1] when we concat dim=1, the key is '1_1',
+      // and for [1, 32, 4] the key is '1_4'.
+      // We use '_' as delimiter to conveniently reuse the key for node name.
+      std::stringstream ss;
+      for (int d = 0; d < glowInputs[i].dims().size(); ++d) {
+        if (d != dim) {
+          ss << glowInputs[i].dims()[d] << "_";
+        }
+      }
+      auto key = ss.str();
+      if (!partialConcatInputs.empty() &&
+          (!needBroadcast[i] || key != prevConcatKey)) {
+        finalConcatInputs.emplace_back(
+            addConcatAndBroadcastNode(partialConcatInputs, key));
+        partialConcatInputs.clear();
+      }
+      if (needBroadcast[i]) {
+        prevConcatKey = key;
+        partialConcatInputs.emplace_back(glowInputs[i]);
+      } else {
+        prevConcatKey = "";
+        finalConcatInputs.emplace_back(glowInputs[i]);
+      }
+    }
+    // In cast the last nodes (1 or more) need concat and broadcast
+    if (!partialConcatInputs.empty()) {
+      finalConcatInputs.emplace_back(
+          addConcatAndBroadcastNode(partialConcatInputs, prevConcatKey));
+    }
+
+    RETURN_ERR(addValueMapping(outputs[0],
+                               F_.createConcat("cat", finalConcatInputs, dim)));
+  } else {
+    RETURN_ERR(
+        addValueMapping(outputs[0], F_.createConcat("cat", glowInputs, dim)));
+  }
+}
+
+Error PyTorchModelLoader::loadFusedConcat(const torch::jit::Node *ptNode) {
+  RETURN_ERR(loadFusedConcatHelper(ptNode, false /* doBroadcast */));
+}
+
+Error PyTorchModelLoader::loadFusedBroadcastConcat(
+    const torch::jit::Node *ptNode) {
+  RETURN_ERR(loadFusedConcatHelper(ptNode, true /* doBroadcast */));
 }
 
 Error PyTorchModelLoader::loadFusedStack(const torch::jit::Node *ptNode) {

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -556,6 +556,18 @@ private:
   /// \returns error on failure.
   Error loadFusedConcat(const torch::jit::Node *ptNode);
 
+  /// Load a PyTorch fb::broadcast_cat node fused with a prim::ListConstruct
+  /// into a glow::fused_broadcast_cat node.
+  /// \returns error on failure.
+  Error loadFusedBroadcastConcat(const torch::jit::Node *ptNode);
+
+  /// Helper function for both \p loadFusedConcat and \p
+  /// loadFusedBroadcastConcat with a flag \p doBroadcast to select whether
+  /// broadcast is enabled for concat.
+  /// \returns error on failure.
+  Error loadFusedConcatHelper(const torch::jit::Node *ptNode,
+                              bool doBroadcast = false);
+
   /// Load a PyTorch prim::stack node fused with a prim::ListConstruct into a
   /// glow:FusedStack node.
   /// \returns error on failure.


### PR DESCRIPTION
Summary:
Lower `fb::broadcast_cat` which enables broadcast when concating tensors.
The implementation adds a flag in `loadFusedConcat` function to enable broadcast. During broadcast, all the tensors with the same basic dims are concat together before broadcasted with Tile.

Differential Revision: D25284521

