### PR TITLE
Move backend-specific opts processing to helper, use in Repro

### DIFF
--- a/include/glow/Flags/Flags.h
+++ b/include/glow/Flags/Flags.h
@@ -16,7 +16,9 @@
 #ifndef GLOW_FLAGS_FLAGS_H
 #define GLOW_FLAGS_FLAGS_H
 
+#include "llvm/ADT/StringRef.h"
 #include <gflags/gflags.h>
+#include <map>
 
 namespace glow {
 namespace flags {
@@ -75,6 +77,10 @@ extern int32_t DAGOptimizerNumParallelChunks;
 extern std::string DAGOptimizerPlacementTaggingAlgorithm;
 extern std::string DAGOptimizerParallelizationTaggingAlgorithm;
 
+/// Helper for processing opts in \p optsStr into \p opts. \returns if there is
+/// any error encountered when processing \p optsStr.
+bool processBackendSpecificOpts(std::map<std::string, std::string> &optsMap,
+                                llvm::StringRef optsStr);
 } // namespace flags
 } // namespace glow
 

--- a/lib/Flags/CMakeLists.txt
+++ b/lib/Flags/CMakeLists.txt
@@ -2,4 +2,6 @@ add_library(Flags
               Flags.cpp)
 target_link_libraries(Flags
                       PUBLIC
-                        gflags)
+                        gflags
+                        glog::glog
+                        LLVMSupport)

--- a/lib/Onnxifi/HostManagerOnnxifi.cpp
+++ b/lib/Onnxifi/HostManagerOnnxifi.cpp
@@ -254,21 +254,10 @@ onnxStatus HostManagerBackend::addNetwork(
   }
   cctx.saturateHost = glow::flags::SaturateHost;
 
-  if (!glow::flags::BackendSpecificOpts.empty()) {
-    llvm::StringRef opts(glow::flags::BackendSpecificOpts);
-    llvm::SmallVector<llvm::StringRef, 4> splitOpts;
-    opts.split(splitOpts, ',');
-
-    for (const llvm::StringRef &opt : splitOpts) {
-      LOG(INFO) << "Adding backend specific option: " << opt.str();
-      auto keyValPair = opt.split('=');
-      if (keyValPair.second.empty()) {
-        LOG(ERROR) << "No '=' found in backend-specific opt " << opt.str();
-        return ONNXIFI_STATUS_INTERNAL_ERROR;
-      }
-      cctx.backendOpts.backendSpecificOpts.emplace(keyValPair.first,
-                                                   keyValPair.second);
-    }
+  if (!glow::flags::processBackendSpecificOpts(
+          cctx.backendOpts.backendSpecificOpts,
+          glow::flags::BackendSpecificOpts)) {
+    return ONNXIFI_STATUS_INTERNAL_ERROR;
   }
 
   auto err = hostManager_->addNetwork(std::move(module), cctx);

--- a/tests/unittests/Repro.cpp
+++ b/tests/unittests/Repro.cpp
@@ -523,6 +523,12 @@ int run() {
         glow::flags::SparseNNPartitioningSchemeNumCoresOther;
   }
 
+  if (!glow::flags::processBackendSpecificOpts(
+          cctx.backendOpts.backendSpecificOpts,
+          glow::flags::BackendSpecificOpts)) {
+    return -1;
+  }
+
 #ifdef GLOW_WITH_NNPI
   if (glow::nnpi::flags::NumParallelChunks > 1) {
     cctx.backendOpts.backendSpecificOpts["NNPINumParallelChunks"] =

--- a/torch_glow/src/PyTorchCommon.cpp
+++ b/torch_glow/src/PyTorchCommon.cpp
@@ -24,6 +24,8 @@
 #include "Registration.h"
 #include "ShapeInferenceEngine.h"
 
+#include "glow/Flags/Flags.h"
+
 #include "torch/csrc/jit/passes/canonicalize_graph_fuser_ops.h"
 #include <torch/csrc/jit/passes/pass_manager.h>
 #include <torch/csrc/jit/passes/subgraph_rewrite.h>
@@ -279,20 +281,8 @@ void PyTorchLoaderSettings::initSettings() {
     }
   }
 
-  if (!FLAGS_backendSpecificOpts.empty()) {
-    llvm::StringRef opts(FLAGS_backendSpecificOpts);
-    llvm::SmallVector<llvm::StringRef, 4> splitOpts;
-    opts.split(splitOpts, ',');
-
-    for (const llvm::StringRef &opt : splitOpts) {
-      LOG(INFO) << "Adding backend specific option: " << opt.str();
-      auto keyValPair = opt.split('=');
-      if (keyValPair.second.empty()) {
-        LOG(ERROR) << "No '=' found in backend-specific opt " << opt.str();
-      }
-      backendSpecificOpts.emplace(keyValPair.first, keyValPair.second);
-    }
-  }
+  glow::flags::processBackendSpecificOpts(backendSpecificOpts,
+                                          FLAGS_backendSpecificOpts);
 }
 
 PyTorchLoaderSettings::PyTorchLoaderSettings() { initSettings(); }


### PR DESCRIPTION
Summary: Move logic for parsing backend-specific opts into helper in Flags

Differential Revision: D25404996

