### PR TITLE
Removing preprocessor guards for flags

### DIFF
--- a/include/glow/Flags/Flags.h
+++ b/include/glow/Flags/Flags.h
@@ -84,8 +84,6 @@ bool processBackendSpecificOpts(std::map<std::string, std::string> &optsMap,
 } // namespace flags
 } // namespace glow
 
-#ifdef GLOW_WITH_NNPI
-
 namespace glow {
 namespace nnpi {
 namespace flags {
@@ -101,8 +99,6 @@ extern bool UsePerPartitionIcetConfig;
 } // namespace flags
 } // namespace nnpi
 } // namespace glow
-
-#endif
 
 namespace glow {
 namespace torch_glow {
@@ -126,18 +122,12 @@ extern bool SaveDAG;
 namespace glow {
 namespace runtime {
 namespace flags {
-#ifdef GLOW_WITH_CPU
 extern unsigned CPUMemory;
-#endif
 
-#ifdef GLOW_WITH_HABANA
 extern unsigned HabanaMemory;
-#endif
 
-#ifdef GLOW_WITH_NNPI
 extern unsigned NNPIMemory;
 extern unsigned NNPITimeoutMs;
-#endif
 
 extern std::string AvailableDevices;
 extern unsigned InterpreterMemory;

--- a/lib/Flags/Flags.cpp
+++ b/lib/Flags/Flags.cpp
@@ -90,8 +90,6 @@ std::string DAGOptimizerParallelizationTaggingAlgorithm = "None";
 } // namespace flags
 } // namespace glow
 
-#ifdef GLOW_WITH_NNPI
-
 namespace glow {
 namespace nnpi {
 namespace flags {
@@ -108,8 +106,6 @@ bool UsePerPartitionIcetConfig = false;
 } // namespace flags
 } // namespace nnpi
 } // namespace glow
-
-#endif /* GLOW_WITH_NNPI */
 
 namespace glow {
 namespace torch_glow {
@@ -134,18 +130,10 @@ namespace glow {
 namespace runtime {
 namespace flags {
 
-#ifdef GLOW_WITH_CPU
 unsigned CPUMemory = 0;
-#endif
-
-#ifdef GLOW_WITH_HABANA
 unsigned HabanaMemory = 7 << 20;
-#endif
-
-#ifdef GLOW_WITH_NNPI
 unsigned NNPIMemory = 16 << 20;
 unsigned NNPITimeoutMs = 0;
-#endif
 
 std::string AvailableDevices = "";
 unsigned InterpreterMemory = 0;
@@ -483,7 +471,6 @@ DEFINE_validator(glow_dag_optimizer_parallelization_tagging_algorithm,
                        val;
                    return true;
                  });
-#ifdef GLOW_WITH_NNPI
 // Defined in glow/lib/Backends/NNPI/NNPI.cpp
 DEFINE_bool(glow_use_per_partition_icet_config,
             glow::nnpi::flags::UsePerPartitionIcetConfig,
@@ -562,7 +549,6 @@ DEFINE_validator(glow_nnpi_timeout_ms, [](const char *, int32_t val) {
   glow::runtime::flags::NNPITimeoutMs = val;
   return true;
 });
-#endif /* GLOW_WITH_NNPI */
 
 DEFINE_int32(glow_interpreter_memory, glow::runtime::flags::InterpreterMemory,
              "Amount of DRAM to allocate per Interpreter in KiB");
@@ -570,23 +556,19 @@ DEFINE_validator(glow_interpreter_memory, [](const char *, int32_t val) {
   glow::runtime::flags::InterpreterMemory = val;
   return true;
 });
-#ifdef GLOW_WITH_CPU
 DEFINE_int32(glow_cpu_memory, glow::runtime::flags::CPUMemory,
              "Amount of DRAM to allocate per CPU in KiB");
 DEFINE_validator(glow_cpu_memory, [](const char *, int32_t val) {
   glow::runtime::flags::CPUMemory = val;
   return true;
 });
-#endif
 
-#ifdef GLOW_WITH_HABANA
 DEFINE_int32(glow_habana_memory, glow::runtime::flags::HabanaMemory,
              "Amount of DRAM to allocate per Habana device in KiB");
 DEFINE_validator(glow_habana_memory, [](const char *, int32_t val) {
   glow::runtime::flags::HabanaMemory = val;
   return true;
 });
-#endif
 
 DEFINE_bool(glow_log_partition, glow::flags::LogPartition,
             "Enable logging partition info");

--- a/tests/unittests/HostManagerTest.cpp
+++ b/tests/unittests/HostManagerTest.cpp
@@ -911,7 +911,6 @@ TEST_P(HostManagerTest, testHostManagerRegistry) {
 TEST_P(HostManagerTest, testTimeout) {
   CHECK_IF_ENABLED();
 
-#ifdef GLOW_WITH_NNPI
   if (backendName_ == "NNPI") {
     // Skip this test if running on ICEREF, since we want to test the device
     // timeout.
@@ -922,7 +921,6 @@ TEST_P(HostManagerTest, testTimeout) {
     // Set the timeout to very short so we fail intentionally.
     glow::runtime::flags::NNPITimeoutMs = 1;
   }
-#endif
 
   std::unique_ptr<Module> module = glow::make_unique<Module>();
   std::unique_ptr<ExecutionContext> context =

--- a/tests/unittests/Repro.cpp
+++ b/tests/unittests/Repro.cpp
@@ -529,7 +529,6 @@ int run() {
     return -1;
   }
 
-#ifdef GLOW_WITH_NNPI
   if (glow::nnpi::flags::NumParallelChunks > 1) {
     cctx.backendOpts.backendSpecificOpts["NNPINumParallelChunks"] =
         std::to_string(glow::nnpi::flags::NumParallelChunks);
@@ -538,8 +537,6 @@ int run() {
     cctx.backendOpts.backendSpecificOpts["NNPIModelParallelSplitAlignment"] =
         std::to_string(glow::nnpi::flags::ModelParallelSplitAlignment);
   }
-#endif
-
   if (glow::flags::UseDAGOptimizer) {
     cctx.callDAGOptimizer = true;
     cctx.optimizationOpts.DAGOptimizerNumParallelChunks =
@@ -549,7 +546,6 @@ int run() {
     cctx.optimizationOpts.DAGOptimizerPlacementTaggingAlgorithm =
         glow::flags::DAGOptimizerPlacementTaggingAlgorithm;
   }
-
   if (glow::flags::DelayAndRecordConstantModification) {
     cctx.optimizationOpts.delayAndRecordConstantModification = true;
   }


### PR DESCRIPTION
Summary: In cleaning up the flags, I tried to unify use of the `#ifdef GLOW_WITH_xxx` preprocessor guards. As a result, it required other code which relied on Flags.h to utilize those macro definitions (which some of them weren't). That resulted in subtle bugs. This diff does away with those guards. The only downside is that flags will be available that don't actually apply to your environment. Given that the CLI is not particularly human-oriented, I'm asserting that that's not a problem.

Reviewed By: jfix71

Differential Revision: D25415089

