### PR TITLE
Eliminating non-contiguous memory request error in glow

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -2243,12 +2243,6 @@ Error PyTorchModelLoader::loadContiguous(const torch::jit::Node *ptNode) {
   glow::NodeValue dataValue;
   ASSIGN_VALUE_OR_RETURN_ERR(dataValue, getGlowNodeValueForValue(inputs[0]));
 
-  int64_t scalar;
-  ASSIGN_VALUE_OR_RETURN_ERR(scalar,
-                             iValToInt(getGlowIValueForValue(inputs[1])));
-  RETURN_ERR_IF_NOT(scalar == (int64_t)at::MemoryFormat::Contiguous,
-                    glow::strFormat("Scalar must have value equal 0."));
-
   RETURN_ERR(addValueMapping(outputs[0], dataValue));
 }
 

--- a/torch_glow/tests/nodes/contiguous_test.py
+++ b/torch_glow/tests/nodes/contiguous_test.py
@@ -7,8 +7,13 @@ from tests import utils
 
 
 class SimpleContiguousModel(torch.nn.Module):
+    def __init__(self, memory_format=torch.contiguous_format):
+        super(SimpleContiguousModel, self).__init__()
+        self.memory_format = memory_format
+
     def forward(self, input):
-        return input.contiguous()
+        formatted = input.contiguous(memory_format=self.memory_format)
+        return formatted + formatted
 
 
 class TestContiguous(unittest.TestCase):
@@ -19,4 +24,14 @@ class TestContiguous(unittest.TestCase):
 
         utils.compare_tracing_methods(
             SimpleContiguousModel(), x, fusible_ops={"aten::contiguous"}
+        )
+
+    def test_with_alternate_memory_format(self):
+
+        x = torch.randn(3, 4, 5, 6)
+
+        utils.compare_tracing_methods(
+            SimpleContiguousModel(torch.channels_last),
+            x,
+            fusible_ops={"aten::contiguous"},
         )


### PR DESCRIPTION
Summary: Currently, any calls to `.contiguous` with memory formats other than `contiguous` (e.g. `channel_last`) will error out when lowering, because glow only support contiguous memory format. However, this prevents all models using the contiguous call from lowering (without changing the model). This diff asserts and implements the idea that, in glow, such a call can be considered a no-op, given the lack of memory format guarantees provided by glow.

Differential Revision: D25415779

