### PR TITLE
Add function support for fb:glowEmbeddingBag

### DIFF
--- a/torch_glow/src/ShapeInferenceEngine.h
+++ b/torch_glow/src/ShapeInferenceEngine.h
@@ -176,6 +176,9 @@ private:
   glowUnpackedQuantizedLinear(const MetaStack &variableMetas);
   // Shape inference for aten::embedding_bag
   static Expected<TensorOutput> embeddingBag(const MetaStack &variableMetas);
+  // Shape inference for fb::glowEmbedding_bag
+  static Expected<TensorOutput>
+  glowEmbeddingBag(const MetaStack &variableMetas);
   // Shape inference for aten::chuck
   static Expected<TensorListOutput> chunk(const MetaStack &variableMetas);
   // Shape inference for aten::stack


### PR DESCRIPTION
Summary: As titled, to support glowEmbeddingBag for shape inference. It is mainly for enabling AOT fusion with shape inference on XL format models.

Differential Revision: D25391064

