### PR TITLE
Fix the issue with concat and add_axis

### DIFF
--- a/tests/models/caffe2Models/concat_add_axis_at_edge.pbtxt
+++ b/tests/models/caffe2Models/concat_add_axis_at_edge.pbtxt
@@ -1,0 +1,22 @@
+name: "concat_add_axis_at_edge"
+op {
+  input: "inputs_0"
+  input: "inputs_1"
+  input: "inputs_2"
+  output: "concat_result"
+  output: "split_info"
+  name: ""
+  type: "Concat"
+  arg {
+    name: "add_axis"
+    i: 1
+  }
+  arg {
+    name: "axis"
+    i: 4
+  }
+}
+external_input: "inputs_0"
+external_input: "inputs_1"
+external_input: "inputs_2"
+external_output: "concat_result"

--- a/tests/unittests/Caffe2ImporterTest.cpp
+++ b/tests/unittests/Caffe2ImporterTest.cpp
@@ -767,6 +767,76 @@ TEST_F(Caffe2ImporterTest, concatAddAxis) {
   }
 }
 
+TEST_F(Caffe2ImporterTest, concatAddAxisAtEdge) {
+  ExecutionEngine EE{};
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+
+  std::string NetDescFilename(
+      GLOW_DATA_PATH "tests/models/caffe2Models/concat_add_axis_at_edge.pbtxt");
+  std::string NetWeightFilename(
+      GLOW_DATA_PATH "tests/models/caffe2Models/empty_init_net.pbtxt");
+
+  PlaceholderBindings bindings;
+
+  Placeholder *output;
+  const std::array<dim_t, 4> inputShape{7, 11, 13, 5};
+  Tensor inputs_0(ElemKind::FloatTy, inputShape);
+  Tensor inputs_1(ElemKind::FloatTy, inputShape);
+  Tensor inputs_2(ElemKind::FloatTy, inputShape);
+  inputs_0.getHandle().randomize(-3.0, 3.0, mod.getPRNG());
+  inputs_1.getHandle().randomize(-3.0, 3.0, mod.getPRNG());
+  inputs_2.getHandle().randomize(-3.0, 3.0, mod.getPRNG());
+  // Destroy the loader after the graph is loaded since the following execution
+  // will not depend on anything from the loader.
+  {
+    Caffe2ModelLoader caffe2LD(
+        NetDescFilename, NetWeightFilename,
+        {"inputs_0", "inputs_1", "inputs_2"},
+        {&inputs_0.getType(), &inputs_1.getType(), &inputs_2.getType()}, *F);
+    output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
+
+    bindings.allocate(mod.getPlaceholders());
+    updateInputPlaceholdersByName(bindings, &mod,
+                                  {"inputs_0", "inputs_1", "inputs_2"},
+                                  {&inputs_0, &inputs_1, &inputs_2});
+  }
+
+  const std::vector<Tensor *> inputs{&inputs_0, &inputs_1, &inputs_2};
+
+  // Check that the shape of the output matches what Caffe2 expects.
+  std::vector<dim_t> expectedDims{inputShape.begin(), inputShape.end()};
+  expectedDims.push_back(inputs.size());
+  EXPECT_EQ(expectedDims, output->dims().vec());
+
+  auto res = bindings.get(output);
+  EE.compile(CompilationMode::Infer);
+  EE.run(bindings);
+
+  auto result = res->getHandle();
+
+  // Check that the output matches the concatenation of all inputs.
+  LOG(INFO) << "inputs_0=" << inputs_0.toString();
+  LOG(INFO) << "inputs_1=" << inputs_1.toString();
+  LOG(INFO) << "inputs_2=" << inputs_2.toString();
+  LOG(INFO) << "result=" << result.clone().toString();
+
+  for (dim_t i = 0; i < inputs.size(); ++i) {
+    const auto inputsHandle = inputs[i]->getHandle();
+
+    for (dim_t dim1 = 0; dim1 < inputShape[0]; ++dim1) {
+      for (dim_t dim2 = 0; dim2 < inputShape[1]; ++dim2) {
+        for (dim_t dim3 = 0; dim3 < inputShape[2]; ++dim3) {
+          for (dim_t dim4 = 0; dim4 < inputShape[3]; ++dim4) {
+            EXPECT_FLOAT_EQ(result.at({dim1, dim2, dim3, dim4, i}),
+                            inputsHandle.at({dim1, dim2, dim3, dim4}));
+          }
+        }
+      }
+    }
+  }
+}
+
 /// Test loading a regular concat node.
 TEST_F(Caffe2ImporterTest, concat) {
   ExecutionEngine EE{};


### PR DESCRIPTION
Summary:
This change improves feature parity between Glow and Caffe2.

Let's assume we have three 2D tensors of shape `[n, m]`: `t1`, `t2`, `t3`.
Let's assume we apply concat like this (some Python-like pseudocode):
```
result = concat(inputs=[t1, t2, t3], axis=2, add_axis=True)
```
Note that `axis` is set to 2 which is beyond 2D dimensions, and `add_axis` is set to True,
which means we want to introduce a new dimension.
So, in this scenario we expect the `result` to have shape `[n, m, 3]`.

Some example with real numbers:
```
[
    [1.88834, -2.18714],
    [2.43475, 2.01005],
]

[
    [-2.23808, 2.81321],
    [2.48026, -1.67380],
]

[
    [0.79416, -1.15100],
    [-2.41476, 0.28332],
]
```
We expect to see such output:
```
[
    [
        [1.88834, -2.23808, 0.79416],
        [-2.18714, 2.81321, -1.15100]
    ],
    [
        [2.43475, 2.48026, -2.41476],
        [2.01005, -1.67380, 0.28332]
    ],
]
```

Reviewed By: yinghai

Differential Revision: D25413493

