### PR TITLE
Fixed BatchNormalization layout

### DIFF
--- a/lib/Backends/NNPI/Importer.cpp
+++ b/lib/Backends/NNPI/Importer.cpp
@@ -408,6 +408,7 @@ bool glow::NNPIImporter::isVariableUsingAlternativeLayout(Storage *v) {
     case Kinded::Kind::Convolution3DNodeKind:
     case Kinded::Kind::AvgPoolNodeKind:
     case Kinded::Kind::MaxPoolNodeKind:
+    case Kinded::Kind::BatchNormalizationNodeKind:
       return true;
     case Kinded::Kind::FullyConnectedNodeKind:
 #if NNPI_MAJOR_VERSION >= 1 && NNPI_MINOR_VERSION >= 1

--- a/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
@@ -184,14 +184,6 @@ struct BlacklistInitializer {
       {"ArithSub_int32_t/0", TestBlacklist::AnyDeviceAnyEngine},
       {"ArithSub_int64_t/0", TestBlacklist::AnyDeviceAnyEngine},
       {"BatchNorm_Float/0", TestBlacklist::AnyDeviceAnyEngine},
-      {"FP16BatchNorm2D/0",
-       TestBlacklist::AnyDeviceAnyEngine}, // Broken in NNPI 1.0 backend
-      {"Int8BatchNorm2D/0",
-       TestBlacklist::AnyDeviceAnyEngine}, // Not supported in NNPI 1.0
-      {"FP16BatchNorm3D/0",
-       TestBlacklist::AnyDeviceAnyEngine}, // Not supported in NNPI 1.0
-      {"Int8BatchNorm3D/0",
-       TestBlacklist::AnyDeviceAnyEngine}, // Not supported in NNPI 1.0
       {"batchedReduceMin_Int32/0", TestBlacklist::AnyDeviceAnyEngine},
       {"batchedReduceMin_Int64/0", TestBlacklist::AnyDeviceAnyEngine},
       {"batchedReduceMax_Int32/0", TestBlacklist::AnyDeviceAnyEngine},
@@ -520,6 +512,9 @@ struct BlacklistInitializer {
       {"LSTMUnitFP16/0", TestBlacklist::AnyDeviceAnyEngine},
       {"PyTorchLSTMFP16/0", TestBlacklist::AnyDeviceAnyEngine},
       {"ConvertFrom_FloatTy_To_BoolTy/0", TestBlacklist::AnyDeviceAnyEngine},
+      {"Int8BatchNorm2D/0", TestBlacklist::AnyDeviceAnyEngine},
+      {"FP16BatchNorm3D/0", TestBlacklist::AnyDeviceAnyEngine},
+      {"Int8BatchNorm3D/0", TestBlacklist::AnyDeviceAnyEngine},
 #endif
 #if NNPI_MAJOR_VERSION == 1 && NNPI_MINOR_VERSION == 1
       {"LSTMUnitFP16/0", TestBlacklist::AnyDeviceAnyEngine},


### PR DESCRIPTION
Summary:
- Fix the layout passed NNP-I compiler to for BatchNormalization to NDHWC.
- Updated the related OpratorTests black list.