### PR TITLE
add sls verification per inference

### DIFF
--- a/lib/Backends/CPU/tests/CPUOperatorTest.cpp
+++ b/lib/Backends/CPU/tests/CPUOperatorTest.cpp
@@ -322,6 +322,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "TanHSweep_BFloat16/0",
     "TanHSweep_Float16/0",
     "RepeatedSLSWithPartialTensors/0",
+    "RepeatedSLWSWithPartialTensors/0",
     "GatherWithInt32PartialTensors/0",
     "GatherWithInt64PartialTensors/0",
     "ParallelBatchMatMul_BFloat16/0",

--- a/lib/Backends/Interpreter/tests/InterpreterOperatorTest.cpp
+++ b/lib/Backends/Interpreter/tests/InterpreterOperatorTest.cpp
@@ -22,6 +22,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "GatherWithInt64PartialTensors/0",
     "LayerNorm_Int8/0",
     "RepeatedSLSWithPartialTensors/0",
+    "RepeatedSLWSWithPartialTensors/0",
     "SigmoidSweep_Float16/0",
     "TanHSweep_Float16/0",
     "ConvertFrom_BoolTy_To_FloatTy/0",

--- a/lib/Backends/NNPI/InferenceContext.h
+++ b/lib/Backends/NNPI/InferenceContext.h
@@ -49,6 +49,9 @@ private:
   /// Set of inputs that can be partial tensors.
   const std::unordered_set<const Placeholder *> *partialInputs_;
 
+  /// Mapping of inputs that belong to an SLS or EmbeddingBag operator
+  const std::vector<ValidateSLSInfo> *validateSLSInputs_;
+
   /// Set of inputs that requires non-zero paddings.
   const std::unordered_set<const Placeholder *> *paddedInputs_;
 
@@ -82,6 +85,10 @@ private:
   /// Dump the runtime resource graph.
   void dumpRuntime() const;
 
+  /// Sanitize inputs before sending inferences to the device
+  /// Currently doing SLS and EmbeddingBag OOB checks
+  bool sanitize(PlaceholderBindings &bindings);
+
 public:
   InferenceContext();
   ~InferenceContext();
@@ -94,6 +101,7 @@ public:
             NNPIDeviceNetwork deviceNetwork, NNPIAdapterContainer *adapter,
             NNPIDeviceContext device,
             const std::unordered_set<const Placeholder *> &partialInputs,
+            const std::vector<ValidateSLSInfo> &validateSLSInputs,
             const std::unordered_set<const Placeholder *> &paddedInputs,
             const std::unordered_set<const Placeholder *> &staticInputs,
             StaticPlaceholderMap *staticPlaceholderMap,

--- a/lib/Backends/NNPI/InferencePool.cpp
+++ b/lib/Backends/NNPI/InferencePool.cpp
@@ -262,6 +262,7 @@ Error InferencePoolEnv::init(NNPIAdapterContainer *adapter,
         nnpiCompiledFunction_->getCompiledNetworkHandle(),
         nnpiCompiledFunction_->getCompilationConfig(), deviceNetwork_, adapter,
         device, nnpiCompiledFunction_->getPartialInputs(),
+        nnpiCompiledFunction_->getValidateSLSInputs(),
         nnpiCompiledFunction_->getPaddedInputs(),
         nnpiCompiledFunction_->getStaticInputs(), staticPlaceholderMap_,
         deviceOptions_, functionName_, deviceId_);
@@ -349,6 +350,7 @@ InferencePoolEnv::createDetachedInferenceContext(PlaceholderUsageMap &phUsage) {
           nnpiCompiledFunction_->getCompiledNetworkHandle(),
           nnpiCompiledFunction_->getCompilationConfig(), deviceNetwork_,
           pAdapter_, device_, nnpiCompiledFunction_->getPartialInputs(),
+          nnpiCompiledFunction_->getValidateSLSInputs(),
           nnpiCompiledFunction_->getPaddedInputs(),
           nnpiCompiledFunction_->getStaticInputs(), staticPlaceholderMap_,
           deviceOptions_, functionName_, deviceId_, &phUsage)) {


### PR DESCRIPTION
Summary:
during compilation time, if there are partial tensors, append them to a list of inputs to verify

at runtime, if the tensors are partial, verify that:
sum(lengths) == len(indices)
or sum(lengths) == last offset

Differential Revision: D25419412

