### PR TITLE
Lower BatchNorm to native 3D and int8 ops

### DIFF
--- a/lib/Converter/TypeAToTypeBFunctionConverter.cpp
+++ b/lib/Converter/TypeAToTypeBFunctionConverter.cpp
@@ -42,6 +42,17 @@ bool TypeAToTypeBFunctionConverter::canConvert(const Node &node) const {
     break;                                                                     \
   }
 
+#define QUANT_OR_FP16_INPUT_FLOAT_BIAS_CASE(NODE_NAME_)                        \
+  case glow::Kinded::Kind::NODE_NAME_##NodeKind: {                             \
+    auto *N = llvm::cast<NODE_NAME_##Node>(&node);                             \
+    if (N->getBias().getType()->getElementType() == ElemKind::FloatTy &&       \
+        (N->getInput().getType()->isQuantizedType() ||                         \
+         N->getInput().getType()->getElementType() == ElemKind::Float16Ty)) {  \
+      return false;                                                            \
+    }                                                                          \
+    break;                                                                     \
+  }
+
     switch (node.getKind()) {
       QUANT_INPUT_FLOAT_BIAS_CASE(FullyConnected);
       QUANT_INPUT_FLOAT_BIAS_CASE(RowwiseQuantizedFullyConnected);
@@ -49,6 +60,7 @@ bool TypeAToTypeBFunctionConverter::canConvert(const Node &node) const {
       QUANT_INPUT_FLOAT_BIAS_CASE(ConvTranspose);
       QUANT_INPUT_FLOAT_BIAS_CASE(Convolution3D);
       QUANT_INPUT_FLOAT_BIAS_CASE(ChannelwiseQuantizedConvolution);
+      QUANT_OR_FP16_INPUT_FLOAT_BIAS_CASE(BatchNormalization);
     default:
       break;
     }

--- a/torch_glow/tests/nodes/quantized_batchnorm3d_relu_test.py
+++ b/torch_glow/tests/nodes/quantized_batchnorm3d_relu_test.py
@@ -74,6 +74,5 @@ class TestQuantizedBatchNorm3DRelu(unittest.TestCase):
             fusible_ops={"quantized::batch_norm3d_relu"},
             atol=1e-1,
             rtol=1e-5,
-            fp16=True,
             skip_to_glow=True,
         )

--- a/torch_glow/tests/nodes/quantized_batchnorm3d_test.py
+++ b/torch_glow/tests/nodes/quantized_batchnorm3d_test.py
@@ -54,7 +54,6 @@ class TestQuantizedBatchNorm3D(unittest.TestCase):
             model,
             inputs,
             fusible_ops={"quantized::batch_norm3d"},
-            fp16=True,
             skip_to_glow=True,
         )
 
@@ -103,6 +102,5 @@ class TestQuantizedBatchNorm3D(unittest.TestCase):
             model,
             inputs,
             fusible_ops={"quantized::batch_norm3d"},
-            fp16=True,
             skip_to_glow=True,
         )


### PR DESCRIPTION
Summary:
- Lower BatchNorm to native 3D and int8 ops
- Disable quant/dequant decorators to BatchNorm in PyTorchModelLoader

Differential Revision: D25405755

