### PR TITLE
Fix unwindBroadcast

### DIFF
--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -5018,22 +5018,27 @@ static NodeValue unwindBroadcast(NodeValue N, unsigned_t endDim) {
     }
 
     return BN->getInput();
-  } else {
-    while (TileNode *TN = dyn_cast<TileNode>(N)) {
-      // Check that the axis of the current Tile is inside of the expected
-      // provided endDim.
-      if (TN->getAxis() >= endDim) {
-        return N;
-      }
-      // Applicable only if original dim is 1 in the Broadcast's Tile.
-      if (TN->getInput().dims()[TN->getAxis()] != 1) {
-        return N;
-      }
-      N = TN->getInput();
+  }
+
+  // All non-Broadcast Tile Nodes must Tile at least once.
+  if (!isa<TileNode>(N)) {
+    return N;
+  }
+
+  while (TileNode *TN = dyn_cast<TileNode>(N)) {
+    // Check that the axis of the current Tile is inside of the expected
+    // provided endDim.
+    if (TN->getAxis() >= endDim) {
+      return N;
     }
-    if (ReshapeNode *RN = dyn_cast<ReshapeNode>(N)) {
-      return RN->getInput();
+    // Applicable only if original dim is 1 in the Broadcast's Tile.
+    if (TN->getInput().dims()[TN->getAxis()] != 1) {
+      return N;
     }
+    N = TN->getInput();
+  }
+  if (ReshapeNode *RN = dyn_cast<ReshapeNode>(N)) {
+    return RN->getInput();
   }
 
   return N;


### PR DESCRIPTION
Summary: There was a bug in the unwindBroadcast helper, where it would return some input of a Node if it was not a Tile. This was used meant I was broken behavior in opts that used it, such as MinMax  -> Clip folding, where a `Reshape -> Max -> Min` was being turned into `Broadcast -> Clip` and leading to an invalid graph.

Reviewed By: gcatron

Differential Revision: D25505465

