### PR TITLE
More accurate memory usage estimation in sls partitioning

### DIFF
--- a/lib/Runtime/Provisioner/Provisioner.cpp
+++ b/lib/Runtime/Provisioner/Provisioner.cpp
@@ -127,7 +127,7 @@ static std::vector<std::pair<DeviceIDTy, uint64_t>> calculateLogicalDeviceSize(
   std::vector<std::pair<DeviceIDTy, uint64_t>> logicalDeviceSize;
   for (auto &device : devices) {
     uint64_t sum{0};
-    for (auto &node : device.second) {
+    for (const auto *node : device.second) {
       sum += node->size;
     }
     logicalDeviceSize.push_back(std::make_pair(device.first, sum));
@@ -215,7 +215,10 @@ Provisioner::generateDeviceAssignments(
         // any available device.
         return MAKE_ERR(
             ErrorValue::ErrorCode::RUNTIME_OUT_OF_DEVICE_MEMORY,
-            "Logical Device is too large to fit in available device memory.");
+            strFormat(
+                "Logical Device is too large to fit in available device "
+                "memory. Largest device memory: %lu, logic device size:  %lu",
+                deviceMemoryMap[backendName][0].second, logicalDevice.second));
       }
     }
   }


### PR DESCRIPTION
Summary:
When we try estimate the cost of merging in a set of nodes into existing set of nodes, we cannot compute their memory simple by doing meminfo(set1).getTotalMemSize() + meminfo(set2).getTotalMemSize(), because its impact is a bit more profound (https://github.com/pytorch/glow/blob/0eb881da54fbadfa3e236c748d639dca0233a50f/lib/Partitioner/PartitionerUtils.cpp#L380-L382). Instead we should estimate the cost with meminfo(set1.merge(set2)).getTotalMemSize().

This will make the cost estimation consistent with the final partition info (https://github.com/pytorch/glow/blob/0eb881da54fbadfa3e236c748d639dca0233a50f/lib/Partitioner/PartitionerValidation.cpp#L101).

Differential Revision: D25516888

