### PR TITLE
add a flag to guard input santiziation

### DIFF
--- a/include/glow/Flags/Flags.h
+++ b/include/glow/Flags/Flags.h
@@ -134,6 +134,7 @@ extern unsigned InterpreterMemory;
 extern bool EnableP2P;
 extern bool EnableDRT;
 extern unsigned DeviceInitTimeoutMs;
+extern bool EnableSanitizeInputs;
 } // namespace flags
 } // namespace runtime
 } // namespace glow

--- a/lib/Backends/CPU/tests/CPUOperatorTest.cpp
+++ b/lib/Backends/CPU/tests/CPUOperatorTest.cpp
@@ -322,6 +322,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "TanHSweep_BFloat16/0",
     "TanHSweep_Float16/0",
     "RepeatedSLSWithPartialTensors/0",
+    "RepeatedSLWSWithPartialTensors/0",
     "GatherWithInt32PartialTensors/0",
     "GatherWithInt64PartialTensors/0",
     "ParallelBatchMatMul_BFloat16/0",

--- a/lib/Backends/Interpreter/tests/InterpreterOperatorTest.cpp
+++ b/lib/Backends/Interpreter/tests/InterpreterOperatorTest.cpp
@@ -22,6 +22,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "GatherWithInt64PartialTensors/0",
     "LayerNorm_Int8/0",
     "RepeatedSLSWithPartialTensors/0",
+    "RepeatedSLWSWithPartialTensors/0",
     "SigmoidSweep_Float16/0",
     "TanHSweep_Float16/0",
     "ConvertFrom_BoolTy_To_FloatTy/0",

--- a/lib/Backends/NNPI/InferenceContext.h
+++ b/lib/Backends/NNPI/InferenceContext.h
@@ -49,6 +49,9 @@ private:
   /// Set of inputs that can be partial tensors.
   const std::unordered_set<const Placeholder *> *partialInputs_;
 
+  /// Mapping of inputs that belong to an SLS or EmbeddingBag operator
+  const std::vector<ValidateSLSInfo> *validateSLSInputs_;
+
   /// Set of inputs that requires non-zero paddings.
   const std::unordered_set<const Placeholder *> *paddedInputs_;
 
@@ -82,6 +85,10 @@ private:
   /// Dump the runtime resource graph.
   void dumpRuntime() const;
 
+  /// Sanitize inputs before sending inferences to the device
+  /// Currently doing SLS and EmbeddingBag OOB checks
+  bool sanitize(PlaceholderBindings &bindings);
+
 public:
   InferenceContext();
   ~InferenceContext();
@@ -94,6 +101,7 @@ public:
             NNPIDeviceNetwork deviceNetwork, NNPIAdapterContainer *adapter,
             NNPIDeviceContext device,
             const std::unordered_set<const Placeholder *> &partialInputs,
+            const std::vector<ValidateSLSInfo> &validateSLSInputs,
             const std::unordered_set<const Placeholder *> &paddedInputs,
             const std::unordered_set<const Placeholder *> &staticInputs,
             StaticPlaceholderMap *staticPlaceholderMap,

--- a/lib/Backends/NNPI/InferencePool.cpp
+++ b/lib/Backends/NNPI/InferencePool.cpp
@@ -262,6 +262,7 @@ Error InferencePoolEnv::init(NNPIAdapterContainer *adapter,
         nnpiCompiledFunction_->getCompiledNetworkHandle(),
         nnpiCompiledFunction_->getCompilationConfig(), deviceNetwork_, adapter,
         device, nnpiCompiledFunction_->getPartialInputs(),
+        nnpiCompiledFunction_->getValidateSLSInputs(),
         nnpiCompiledFunction_->getPaddedInputs(),
         nnpiCompiledFunction_->getStaticInputs(), staticPlaceholderMap_,
         deviceOptions_, functionName_, deviceId_);
@@ -349,6 +350,7 @@ InferencePoolEnv::createDetachedInferenceContext(PlaceholderUsageMap &phUsage) {
           nnpiCompiledFunction_->getCompiledNetworkHandle(),
           nnpiCompiledFunction_->getCompilationConfig(), deviceNetwork_,
           pAdapter_, device_, nnpiCompiledFunction_->getPartialInputs(),
+          nnpiCompiledFunction_->getValidateSLSInputs(),
           nnpiCompiledFunction_->getPaddedInputs(),
           nnpiCompiledFunction_->getStaticInputs(), staticPlaceholderMap_,
           deviceOptions_, functionName_, deviceId_, &phUsage)) {

--- a/lib/Flags/Flags.cpp
+++ b/lib/Flags/Flags.cpp
@@ -140,6 +140,8 @@ unsigned InterpreterMemory = 0;
 bool EnableP2P = false;
 bool EnableDRT = false;
 unsigned DeviceInitTimeoutMs = 5000;
+bool EnableSanitizeInputs = false;
+
 } // namespace flags
 } // namespace runtime
 } // namespace glow
@@ -596,6 +598,14 @@ DEFINE_validator(glow_device_init_timeout_ms, [](const char *, int32_t val) {
   glow::runtime::flags::DeviceInitTimeoutMs = val;
   return true;
 });
+DEFINE_bool(glow_enable_sanitize_inputs,
+            glow::runtime::flags::EnableSanitizeInputs,
+            "Enable sanitize inputs passed from the Host to the device");
+DEFINE_validator(glow_enable_sanitize_inputs, [](const char *, bool val) {
+  glow::runtime::flags::EnableSanitizeInputs = val;
+  return true;
+});
+
 DEFINE_bool(glow_dump_partition, glow::flags::DumpPartition,
             "Enable dumping the graph of each partition");
 DEFINE_validator(glow_dump_partition, [](const char *, bool val) {

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -13501,15 +13501,15 @@ static void addEmbeddingBagPartialInputs(
     bool hasEndOffset, bool partialInput = false) {
 
   if (hasEndOffset) {
-    Tensor weightsTensorReal(DTy, {10});
-    Tensor indicesTensorReal(ElemKind::Int64ITy, {10});
+    Tensor weightsTensorReal(DTy, {8});
+    Tensor indicesTensorReal(ElemKind::Int64ITy, {8});
     Tensor offsetsTensorReal(ElemKind::Int64ITy, {5});
 
     weightsTensorReal.getHandle<DataType>() = {
-        3, 1, 0, 0, 0, 0, 2, -0.5, 42.0, 42.0,
+        3, 1, 0, 0, 0, 0, 2, -0.5,
     };
     indicesTensorReal.getHandle<int64_t>() = {
-        1, 0, 2, 0, 1, 2, 2, 0, 13, 10,
+        1, 0, 2, 0, 1, 2, 2, 0,
     };
     offsetsTensorReal.getHandle<int64_t>() = {
         0, 3, 3, 6,
@@ -13545,9 +13545,9 @@ static void addEmbeddingBagPartialInputs(
       bindings.insert(indices, indicesTensorPartial.clone());
       bindings.insert(offsets, offsetsTensorPartial.clone());
     } else {
-      weights = mod.createPlaceholder(DTy, {10}, "weights", false);
+      weights = mod.createPlaceholder(DTy, {8}, "weights", false);
       indices =
-          mod.createPlaceholder(ElemKind::Int64ITy, {10}, "indices", false);
+          mod.createPlaceholder(ElemKind::Int64ITy, {8}, "indices", false);
       offsets =
           mod.createPlaceholder(ElemKind::Int64ITy, {5}, "offsets", false);
 
@@ -14374,6 +14374,88 @@ TEST_P(OperatorTest, RepeatedSLSWithPartialTensors) {
   // the data is still around.
   unownedTensors_.push_back(std::move(indicesReal));
   unownedTensors_.push_back(std::move(lengthsReal));
+}
+
+TEST_P(OperatorTest, RepeatedSLWSWithPartialTensors) {
+  CHECK_IF_ENABLED();
+
+  // This test is only meaningful if the backend supports partial tensors.
+  ASSERT_TRUE(EE_.getBackend(getBackendName()).supportsPartialTensors());
+
+  constexpr dim_t embeddingRows = 1275;
+  constexpr dim_t numLengths = 20;
+  constexpr dim_t maxIndices = 20000;
+  constexpr dim_t numIndices = 20; // Must be less than sum(lengths).
+  constexpr dim_t iterations = 33;
+
+  auto *data =
+      mod_.createConstant(ElemKind::FloatTy, {embeddingRows, 1}, "data");
+  data->getPayloadMutable().getHandle<float>().randomize(-1.0, 1.0,
+                                                         mod_.getPRNG());
+  auto *indices = mod_.createPlaceholder(ElemKind::Int64ITy, {maxIndices},
+                                         "indices", false);
+  auto *weights =
+      mod_.createPlaceholder(ElemKind::FloatTy, {maxIndices}, "weights", false);
+  auto *lengths = mod_.createPlaceholder(ElemKind::Int32ITy, {numLengths},
+                                         "lengths", false);
+  auto *SLWS = F_->createSparseLengthsWeightedSum("SWLS", data, weights,
+                                                  indices, lengths);
+  auto *save = F_->createSave("save", SLWS);
+  auto *outPH = save->getPlaceholder();
+  EE_.compile(CompilationMode::Infer);
+
+  Tensor indicesReal(ElemKind::Int64ITy, {numIndices});
+  indicesReal.getHandle<int64_t>().randomize(0, embeddingRows - 1,
+                                             mod_.getPRNG());
+  Tensor indicesPartial(indicesReal.getUnsafePtr(), indices->getType(),
+                        indicesReal.getSizeInBytes());
+  Tensor indicesPadded(indices->getType());
+  indicesPadded.zero();
+  memcpy(indicesPadded.getUnsafePtr(), indicesReal.getUnsafePtr(),
+         numIndices * sizeof(int64_t));
+
+  Tensor weightsReal(ElemKind::FloatTy, {numIndices});
+  weightsReal.getHandle<float>().randomize(0, embeddingRows - 1,
+                                           mod_.getPRNG());
+  Tensor weightsPartial(weightsReal.getUnsafePtr(), weights->getType(),
+                        weightsReal.getSizeInBytes());
+  Tensor weightsPadded(weights->getType());
+  weightsPadded.zero();
+  memcpy(weightsPadded.getUnsafePtr(), weightsReal.getUnsafePtr(),
+         numIndices * sizeof(float));
+
+  Tensor lengthsReal(ElemKind::Int32ITy, {numLengths});
+  lengthsReal.getHandle<int32_t>().clear(1);
+  Tensor lengthsPartial(lengthsReal.getUnsafePtr(), lengths->getType(),
+                        lengthsReal.getSizeInBytes());
+  Tensor lengthsPadded(ElemKind::Int32ITy, {numLengths});
+  lengthsPadded.assign(&lengthsReal);
+
+  bindings_.insert(indices, std::move(indicesPartial));
+  bindings_.insert(weights, std::move(weightsPartial));
+  bindings_.insert(lengths, std::move(lengthsPartial));
+
+  bindings_.allocate(outPH);
+
+  PlaceholderBindings paddedBindings;
+  paddedBindings.insert(indices, std::move(indicesPadded));
+  paddedBindings.insert(weights, std::move(weightsPadded));
+  paddedBindings.insert(lengths, std::move(lengthsPadded));
+
+  paddedBindings.allocate(outPH);
+
+  for (dim_t i = 0; i < iterations; i++) {
+    EE_.run(bindings_);
+    EE_.run(paddedBindings);
+    ASSERT_TRUE(bindings_.get(outPH)->isEqual(*paddedBindings.get(outPH)));
+  }
+
+  // Keep these around so their memory is not freed at the end of the
+  // test/scope. This is so that inside TearDown during import/export testing
+  // the data is still around.
+  unownedTensors_.push_back(std::move(indicesReal));
+  unownedTensors_.push_back(std::move(lengthsReal));
+  unownedTensors_.push_back(std::move(weightsReal));
 }
 
 /// Helper to test gathers using partial inputs using \p ITy.


### PR DESCRIPTION
Summary:
we need to sanitize inputs to the SLS kernel since there are
cases where we run out of bound, however this might have bugs/perf
implications, so guarding it with a flag that is disabled by default

Differential Revision: D25533044

