### PR TITLE
Add Support for aten::clamp_min and aten::expand_as

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -815,6 +815,22 @@ struct IndexSelectInputs {
   };
 };
 
+/// Indexes of aten::clamp_min inputs.
+struct ClampMinInputs {
+  enum {
+    input = 0,
+    min,
+  };
+};
+
+/// Indexes of aten::expand_as inputs.
+struct ExpandAsInputs {
+  enum {
+    input = 0,
+    other,
+  };
+};
+
 /// Indexes of fb::glow_embedding_bag inputs.
 struct GlowEmbeddingBagInputs {
   enum {
@@ -1075,6 +1091,8 @@ PyTorchModelLoader::buildSymbolsMapping() {
       {{"_caffe2::RoIAlignRotated"}, &PyTorchModelLoader::loadRoiAlignRotated},
       {{"_caffe2::BBoxTransform"}, &PyTorchModelLoader::loadBBoxTransform},
       {{"aten::index_select"}, &PyTorchModelLoader::loadIndexSelect},
+      {{"aten::clamp_min"}, &PyTorchModelLoader::loadClampMin},
+      {{"aten::expand_as"}, &PyTorchModelLoader::loadExpandAs},
   });
 
   // Add in custom operator loaders.
@@ -4589,6 +4607,44 @@ Error PyTorchModelLoader::loadClamp(const torch::jit::Node *ptNode) {
   ASSIGN_VALUE_OR_RETURN_ERR(max, to32Bit(maxDouble));
 
   auto output = F_.createClip("clip", input, min, max);
+  RETURN_ERR(addValueMapping(outputs[0], output));
+}
+
+Error PyTorchModelLoader::loadClampMin(const torch::jit::Node *ptNode) {
+  auto inputs = ptNode->inputs();
+  auto outputs = ptNode->outputs();
+  RETURN_IF_ERR(checkInputAndOutputSizes(inputs, 2, outputs, 1));
+
+  glow::NodeValue input;
+  ASSIGN_VALUE_OR_RETURN_ERR(
+      input, getGlowNodeValueForValue(inputs[ClampMinInputs::input]));
+
+  double minDouble;
+  ASSIGN_VALUE_OR_RETURN_ERR(minDouble, iValToDouble(getGlowIValueForValue(
+                                            inputs[ClampMinInputs::min])));
+  float min;
+  ASSIGN_VALUE_OR_RETURN_ERR(min, to32Bit(minDouble));
+  auto SN = F_.createSplat("minValue", input.getType(), min);
+
+  auto output = F_.createMax("clamp_min", input, SN);
+  RETURN_ERR(addValueMapping(outputs[0], output));
+}
+
+Error PyTorchModelLoader::loadExpandAs(const torch::jit::Node *ptNode) {
+  auto inputs = ptNode->inputs();
+  auto outputs = ptNode->outputs();
+  RETURN_IF_ERR(checkInputAndOutputSizes(inputs, 2, outputs, 1));
+
+  glow::NodeValue input;
+  ASSIGN_VALUE_OR_RETURN_ERR(
+      input, getGlowNodeValueForValue(inputs[ExpandAsInputs::input]));
+
+  glow::NodeValue other;
+  ASSIGN_VALUE_OR_RETURN_ERR(
+      other, getGlowNodeValueForValue(inputs[ExpandAsInputs::other]));
+
+  auto output = F_.createBroadcast("expand_as", input, other.dims(),
+                                   other.dims().size() - input.dims().size());
   RETURN_ERR(addValueMapping(outputs[0], output));
 }
 

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -825,6 +825,14 @@ private:
   /// Load a PyTorch aten::to node.
   /// \returns error on failure.
   Error loadTo(const torch::jit::Node *ptNode);
+
+  /// Load a PyTorch aten::clamp_min node.
+  /// \returns error on failure.
+  Error loadClampMin(const torch::jit::Node *ptNode);
+
+  /// Load a PyTorch aten::expand_as node.
+  /// \returns error on failure.
+  Error loadExpandAs(const torch::jit::Node *ptNode);
 };
 
 } // namespace glow

--- a/torch_glow/tests/nodes/clamp_min_test.py
+++ b/torch_glow/tests/nodes/clamp_min_test.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+
+import torch
+from tests import utils
+
+
+class SimpleClampMinModel(torch.nn.Module):
+    def __init__(self, min):
+        super(SimpleClampMinModel, self).__init__()
+        self.min = min
+
+    def forward(self, input):
+        return torch.clamp_min(input, self.min)
+
+
+class TestClamp(unittest.TestCase):
+    def test_clamp_min(self):
+        """Test of the PyTorch clamp_min Node on Glow."""
+
+        utils.compare_tracing_methods(
+            SimpleClampMinModel(0.1), torch.randn(7), fusible_ops={"aten::clamp_min"}
+        )

--- a/torch_glow/tests/nodes/expand_as_test.py
+++ b/torch_glow/tests/nodes/expand_as_test.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+
+import torch
+from tests import utils
+
+
+class ExpandAsModel(torch.nn.Module):
+    def __init__(self, shape):
+        super(ExpandAsModel, self).__init__()
+        self.other = torch.randn(shape)
+
+    def forward(self, a):
+        return a.expand_as(self.other)
+
+
+class TestClamp(unittest.TestCase):
+    def test_clamp_min(self):
+        """Test of the PyTorch expand_as Node on Glow."""
+
+        utils.compare_tracing_methods(
+            ExpandAsModel([2, 2, 4]), torch.randn(1, 4), fusible_ops={"aten::expand_as"}
+        )


### PR DESCRIPTION
Summary:
Loading `clamp_min` as MaxNode in Glow.
Loading `expand_as` as BroadcastNode in Glow.

Differential Revision: D25538344

