### PR TITLE
Let loadnorm accept float p without decimal digits

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -4808,16 +4808,22 @@ Error PyTorchModelLoader::loadNorm(const torch::jit::Node *ptNode) {
     // With p in torch.norm(input, p,  dim), inputs[1] is the int representing p
     GlowIValue *pVal;
     ASSIGN_VALUE_OR_RETURN_ERR(pVal, getGlowIValueForValue(inputs[1]));
-    // check if p is int
+
+    // Check if p is int or is float without decimal digit.
     if (!pVal->isInt()) {
-      return MAKE_ERR("We only support p as an integer input");
+      double pDouble;
+      ASSIGN_VALUE_OR_RETURN_ERR(pDouble, iValToDouble(pVal));
+      p = static_cast<int64_t>(pDouble);
+      RETURN_ERR_IF_NOT(p == pDouble, "We only support p as an integer input");
     } else {
       ASSIGN_VALUE_OR_RETURN_ERR(p, iValToInt(pVal));
-      // check if p is set to 2s
-      RETURN_ERR_IF_NOT(
-          p == 2, glow::strFormat(
-                      "we currently only support p = 2, but got p = %lu", p));
     }
+
+    // check if p is set to 2s
+    RETURN_ERR_IF_NOT(
+        p == 2,
+        glow::strFormat("we currently only support p = 2, but got p = %lu", p));
+
     // With p in torch.norm(input, p,  dim), inputs[2] is the list of int
     // representing axis/dim
     std::vector<int64_t> *axisList;

--- a/torch_glow/tests/nodes/norm_test.py
+++ b/torch_glow/tests/nodes/norm_test.py
@@ -26,6 +26,15 @@ class TestNorm(unittest.TestCase):
             fusible_ops={"aten::norm"},
         )
 
+    def test_norm_float_p(self):
+        """Test of the PyTorch norm Node that has p=2.0 on Glow."""
+
+        utils.compare_tracing_methods(
+            SimpleNormModule(dim=0, p=2.0),
+            torch.arange(8, dtype=torch.float).reshape(2, 4),
+            fusible_ops={"aten::norm"},
+        )
+
     def test_norm_3d_inner_axis(self):
         """Basic test of the PyTorch norm Node on Glow."""
 


### PR DESCRIPTION
Summary: Current Glow Norm only supports L2 norm, so we have constraint in `loadnorm` to check if p is int and if p is 2. However, p can be a float as long as it doesn't have any digits after decimal point. In this case we should treat it as an int.

Differential Revision: D25540182

