### PR TITLE
Add Support for Loading aten:clamp with min or max missing.

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -4576,19 +4576,35 @@ Error PyTorchModelLoader::loadClamp(const torch::jit::Node *ptNode) {
   ASSIGN_VALUE_OR_RETURN_ERR(
       input, getGlowNodeValueForValue(inputs[ClampInputs::input]));
 
-  double minDouble;
-  ASSIGN_VALUE_OR_RETURN_ERR(
-      minDouble, iValToDouble(getGlowIValueForValue(inputs[ClampInputs::min])));
-  float min;
-  ASSIGN_VALUE_OR_RETURN_ERR(min, to32Bit(minDouble));
+  double minDouble = 0;
+  float min = 0;
+  NodeValue minSN = nullptr;
 
-  double maxDouble;
-  ASSIGN_VALUE_OR_RETURN_ERR(
-      maxDouble, iValToDouble(getGlowIValueForValue(inputs[ClampInputs::max])));
-  float max;
-  ASSIGN_VALUE_OR_RETURN_ERR(max, to32Bit(maxDouble));
+  if (hasGlowIValueForValue(inputs[ClampInputs::min], true)) {
+    ASSIGN_VALUE_OR_RETURN_ERR(minDouble, iValToDouble(getGlowIValueForValue(
+                                              inputs[ClampInputs::min])));
+    ASSIGN_VALUE_OR_RETURN_ERR(min, to32Bit(minDouble));
+    minSN = F_.createSplat("minValue", input.getType(), min);
+  }
 
-  auto output = F_.createClip("clip", input, min, max);
+  double maxDouble = 0;
+  float max = 0;
+  NodeValue maxSN = nullptr;
+  if (hasGlowIValueForValue(inputs[ClampInputs::max], true)) {
+    ASSIGN_VALUE_OR_RETURN_ERR(maxDouble, iValToDouble(getGlowIValueForValue(
+                                              inputs[ClampInputs::max])));
+    ASSIGN_VALUE_OR_RETURN_ERR(max, to32Bit(maxDouble));
+    maxSN = F_.createSplat("maxValue", input.getType(), max);
+  }
+
+  NodeValue output = input;
+  if (minSN) {
+    output = F_.createMax("Clamp_min", output, minSN);
+  }
+  if (maxSN) {
+    output = F_.createMin("Clamp_max", output, maxSN);
+  }
+  RETURN_ERR_IF_NOT(output, "Failed to load aten::clamp");
   RETURN_ERR(addValueMapping(outputs[0], output));
 }
 

--- a/torch_glow/tests/nodes/clamp_test.py
+++ b/torch_glow/tests/nodes/clamp_test.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
+from parameterized import parameterized
 from tests import utils
 
 
@@ -17,9 +18,16 @@ class SimpleClampModel(torch.nn.Module):
 
 
 class TestClamp(unittest.TestCase):
-    def test_clamp(self):
+    @parameterized.expand(
+        [
+            ("basic", 0.0, 0.8),
+            ("no_min", None, 0.8),
+            ("no_max", 0.0, None),
+        ]
+    )
+    def test_clamp(self, _, min, max):
         """Test of the PyTorch clamp Node on Glow."""
 
         utils.compare_tracing_methods(
-            SimpleClampModel(0.0, 6.0), torch.randn(7), fusible_ops={"aten::clamp"}
+            SimpleClampModel(min, max), torch.randn(7), fusible_ops={"aten::clamp"}
         )


### PR DESCRIPTION
Summary: Support ```torch.clamp(tensor, min=1, max=None)``` and `torch.clamp(tensor, min=None, max=1)`

Differential Revision: D25539996

