### PR TITLE
Add Support for Loading BatchNorm1d and BatchNorm0d

### DIFF
--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -1009,7 +1009,7 @@ void BoundInterpreterFunction::fwdBatchNormalizationFloatImpl(
   auto meanH = getWeightHandle<ElemTy>(I->getMean());
   auto varH = getWeightHandle<ElemTy>(I->getVar());
   unsigned_t channelIdx =
-      I->getChannelIdx(); // NOTE: We only support NTHWC, NHWC and NHC
+      I->getChannelIdx(); // NOTE: We only support NTHWC, NHWC, NWC and NCW
   float epsilon = I->getEpsilon();
 
   // output
@@ -1050,11 +1050,11 @@ void BoundInterpreterFunction::fwdBatchNormalizationFloatImpl(
       isCMinor = false;
     }
   } else {
-    // numDims == 1. This can happen due to UnitTests that test BatchNorm after
-    // Reshape
+    // numDims == 1. This can happen due to optimization pass that sinks reshape
+    // below batchnorm.
     N = I->getSrc()->dims()[0];
-    C = I->getSrc()->dims()[2];
-    sizeImg = I->getSrc()->dims()[1];
+    C = I->getSrc()->dims()[channelIdx];
+    sizeImg = I->getSrc()->dims()[channelIdx == 2 ? 1 : 2];
     sizeN = C * sizeImg;
     isCMinor = (channelIdx == 2);
   }
@@ -1103,7 +1103,7 @@ void BoundInterpreterFunction::fwdBatchNormalizationI8Impl(
   auto meanH = getWeightHandle<ParamTy>(I->getMean());
   auto varH = getWeightHandle<ParamTy>(I->getVar());
   unsigned_t channelIdx =
-      I->getChannelIdx(); // NOTE: We only support NTHWC, NHWC and NHC
+      I->getChannelIdx(); // NOTE: We only support NTHWC, NHWC, NWC and NCW
   float epsilon = I->getEpsilon();
   auto inScale = float(I->getSrc()->getType()->getScale());
   auto inZero = int8_t(I->getSrc()->getType()->getOffset());
@@ -1151,11 +1151,11 @@ void BoundInterpreterFunction::fwdBatchNormalizationI8Impl(
     }
 
   } else {
-    // numDims == 1. This can happen due to UnitTests that test BatchNorm after
-    // Reshape
+    // numDims == 1. This can happen due to optimization pass that sinks reshape
+    // below batchnorm.
     N = I->getSrc()->dims()[0];
-    C = I->getSrc()->dims()[2];
-    sizeImg = I->getSrc()->dims()[1];
+    C = I->getSrc()->dims()[channelIdx];
+    sizeImg = I->getSrc()->dims()[channelIdx == 2 ? 1 : 2];
     sizeN = C * sizeImg;
     isCMinor = (channelIdx == 2);
   }

--- a/torch_glow/tests/nodes/batchnorm0d_test.py
+++ b/torch_glow/tests/nodes/batchnorm0d_test.py
@@ -1,0 +1,62 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+
+import torch
+import torch.nn as nn
+from tests import utils
+
+
+class TestBatchNorm0D(unittest.TestCase):
+    def test_batchnorm_basic(self):
+        """
+        Basic test of the PyTorch 0D batchnorm Node on Glow.
+        """
+
+        class SimpleBatchNorm(nn.Module):
+            def __init__(self, num_channels, running_mean, running_var):
+                super(SimpleBatchNorm, self).__init__()
+                self.batchnorm = nn.BatchNorm1d(num_channels)
+                self.batchnorm.running_mean = running_mean
+                self.batchnorm.running_var = running_var
+
+            def forward(self, x):
+                return self.batchnorm(x)
+
+        num_channels = 4
+        running_mean = torch.rand(num_channels)
+        running_var = torch.rand(num_channels)
+        model = SimpleBatchNorm(num_channels, running_mean, running_var)
+        model.eval()
+
+        inputs = torch.randn(1, num_channels)
+        utils.compare_tracing_methods(model, inputs, fusible_ops={"aten::batch_norm"})
+
+    def test_batchnorm_with_weights(self):
+        """
+        Test of the PyTorch 0D batchnorm Node with weights and biases on Glow.
+        """
+
+        class SimpleBatchNorm(nn.Module):
+            def __init__(self, num_channels, weight, bias, running_mean, running_var):
+                super(SimpleBatchNorm, self).__init__()
+                self.batchnorm = nn.BatchNorm1d(num_channels)
+                self.batchnorm.weight = torch.nn.Parameter(weight)
+                self.batchnorm.bias = torch.nn.Parameter(bias)
+                self.batchnorm.running_mean = running_mean
+                self.batchnorm.running_var = running_var
+
+            def forward(self, x):
+                return self.batchnorm(x)
+
+        num_channels = 4
+        weight = torch.rand(num_channels)
+        bias = torch.rand(num_channels)
+        running_mean = torch.rand(num_channels)
+        running_var = torch.ones(num_channels)
+
+        inputs = torch.randn(1, num_channels)
+        model = SimpleBatchNorm(num_channels, weight, bias, running_mean, running_var)
+        model.eval()
+
+        utils.compare_tracing_methods(model, inputs, fusible_ops={"aten::batch_norm"})

--- a/torch_glow/tests/nodes/batchnorm1d_test.py
+++ b/torch_glow/tests/nodes/batchnorm1d_test.py
@@ -1,0 +1,62 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+
+import torch
+import torch.nn as nn
+from tests import utils
+
+
+class TestBatchNorm1D(unittest.TestCase):
+    def test_batchnorm_basic(self):
+        """
+        Basic test of the PyTorch 1D batchnorm Node on Glow.
+        """
+
+        class SimpleBatchNorm(nn.Module):
+            def __init__(self, num_channels, running_mean, running_var):
+                super(SimpleBatchNorm, self).__init__()
+                self.batchnorm = nn.BatchNorm1d(num_channels)
+                self.batchnorm.running_mean = running_mean
+                self.batchnorm.running_var = running_var
+
+            def forward(self, x):
+                return self.batchnorm(x)
+
+        num_channels = 4
+        running_mean = torch.rand(num_channels)
+        running_var = torch.rand(num_channels)
+        model = SimpleBatchNorm(num_channels, running_mean, running_var)
+        model.eval()
+
+        inputs = torch.randn(1, num_channels, 5)
+        utils.compare_tracing_methods(model, inputs, fusible_ops={"aten::batch_norm"})
+
+    def test_batchnorm_with_weights(self):
+        """
+        Test of the PyTorch 1D batchnorm Node with weights and biases on Glow.
+        """
+
+        class SimpleBatchNorm(nn.Module):
+            def __init__(self, num_channels, weight, bias, running_mean, running_var):
+                super(SimpleBatchNorm, self).__init__()
+                self.batchnorm = nn.BatchNorm1d(num_channels)
+                self.batchnorm.weight = torch.nn.Parameter(weight)
+                self.batchnorm.bias = torch.nn.Parameter(bias)
+                self.batchnorm.running_mean = running_mean
+                self.batchnorm.running_var = running_var
+
+            def forward(self, x):
+                return self.batchnorm(x)
+
+        num_channels = 4
+        weight = torch.rand(num_channels)
+        bias = torch.rand(num_channels)
+        running_mean = torch.rand(num_channels)
+        running_var = torch.ones(num_channels)
+
+        inputs = torch.randn(1, num_channels, 5)
+        model = SimpleBatchNorm(num_channels, weight, bias, running_mean, running_var)
+        model.eval()
+
+        utils.compare_tracing_methods(model, inputs, fusible_ops={"aten::batch_norm"})


### PR DESCRIPTION
Summary: Reshape 0D and 1D as 2D since NNPI BatchNorm only supports 2D. Note: for 1D case, it's a little bit different as  there's an optimization pass that sinks reshape below batchnorm which would make 2D BN becomes 1D.

Differential Revision: D25545484

