### PR TITLE
Fix `loadQuantizedLinear` Without bias

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -2012,7 +2012,7 @@ Error PyTorchModelLoader::loadQuantizedLinear(const torch::jit::Node *ptNode) {
     auto ptBiasTensor = ptBiasTensorTmp.value().contiguous();
     biasTensor = ptTensorToGlowTensor(ptBiasTensor);
   } else {
-    biasTensor = glow::Tensor(glow::ElemKind::FloatTy, {weight.dims()[1]});
+    biasTensor = glow::Tensor(glow::ElemKind::FloatTy, {weight.dims()[0]});
     biasTensor.zero();
   }
 
@@ -2020,7 +2020,6 @@ Error PyTorchModelLoader::loadQuantizedLinear(const torch::jit::Node *ptNode) {
       "quantized_linear_bias", std::move(biasTensor));
   biasConstant->ensureIsOwned();
   RETURN_ERR_IF_NOT(biasConstant, "quantized::linear bias must be constant");
-
   auto bias = biasConstant->getOutput();
 
   float outScale;

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -833,6 +833,14 @@ private:
   /// Load a PyTorch aten::to node.
   /// \returns error on failure.
   Error loadTo(const torch::jit::Node *ptNode);
+
+  /// Load a PyTorch aten::clamp_min node.
+  /// \returns error on failure.
+  Error loadClampMin(const torch::jit::Node *ptNode);
+
+  /// Load a PyTorch aten::expand_as node.
+  /// \returns error on failure.
+  Error loadExpandAs(const torch::jit::Node *ptNode);
 };
 
 } // namespace glow

--- a/torch_glow/src/TorchGlowBackend.cpp
+++ b/torch_glow/src/TorchGlowBackend.cpp
@@ -410,8 +410,11 @@ static Error processLinearPackedQParams(torch::jit::Graph &graph,
       overrideTensorGradient(t);
       paramConst = torch::jit::insertConstant(graph, t);
       node->outputs().at(1)->replaceAllUsesWith(paramConst);
-    } else { // TODO Handle bias-not-exists case
-      return MAKE_ERR("Preprocess for empty bias is not yet supported.");
+    } else {
+      at::Tensor t = at::zeros(ptWeightTensor.size(0));
+      overrideTensorGradient(t);
+      paramConst = torch::jit::insertConstant(graph, t);
+      node->outputs().at(1)->replaceAllUsesWith(paramConst);
     }
   }
   return Error::success();

--- a/torch_glow/tests/nodes/clamp_min_test.py
+++ b/torch_glow/tests/nodes/clamp_min_test.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+
+import torch
+from tests import utils
+
+
+class SimpleClampMinModel(torch.nn.Module):
+    def __init__(self, min):
+        super(SimpleClampMinModel, self).__init__()
+        self.min = min
+
+    def forward(self, input):
+        return torch.clamp_min(input, self.min)
+
+
+class TestClamp(unittest.TestCase):
+    def test_clamp_min(self):
+        """Test of the PyTorch clamp_min Node on Glow."""
+
+        utils.compare_tracing_methods(
+            SimpleClampMinModel(0.1), torch.randn(7), fusible_ops={"aten::clamp_min"}
+        )

--- a/torch_glow/tests/nodes/clamp_test.py
+++ b/torch_glow/tests/nodes/clamp_test.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
+from parameterized import parameterized
 from tests import utils
 
 
@@ -17,9 +18,16 @@ class SimpleClampModel(torch.nn.Module):
 
 
 class TestClamp(unittest.TestCase):
-    def test_clamp(self):
+    @parameterized.expand(
+        [
+            ("basic", 0.0, 0.8),
+            ("no_min", None, 0.8),
+            ("no_max", 0.0, None),
+        ]
+    )
+    def test_clamp(self, _, min, max):
         """Test of the PyTorch clamp Node on Glow."""
 
         utils.compare_tracing_methods(
-            SimpleClampModel(0.0, 6.0), torch.randn(7), fusible_ops={"aten::clamp"}
+            SimpleClampModel(min, max), torch.randn(7), fusible_ops={"aten::clamp"}
         )

--- a/torch_glow/tests/nodes/expand_as_test.py
+++ b/torch_glow/tests/nodes/expand_as_test.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+
+import torch
+from tests import utils
+
+
+class ExpandAsModel(torch.nn.Module):
+    def __init__(self, shape):
+        super(ExpandAsModel, self).__init__()
+        self.other = torch.randn(shape)
+
+    def forward(self, a):
+        return a.expand_as(self.other)
+
+
+class TestClamp(unittest.TestCase):
+    def test_clamp_min(self):
+        """Test of the PyTorch expand_as Node on Glow."""
+
+        utils.compare_tracing_methods(
+            ExpandAsModel([2, 2, 4]), torch.randn(1, 4), fusible_ops={"aten::expand_as"}
+        )

--- a/torch_glow/tests/nodes/quantized_linear_test.py
+++ b/torch_glow/tests/nodes/quantized_linear_test.py
@@ -7,15 +7,14 @@ from tests import utils
 
 class SimpleQuantizedLinearModel(torch.nn.Sequential):
     def __init__(self, in_features, out_features, quantization, weight=None, bias=None):
-        linear = torch.nn.Linear(in_features, out_features)
+        linear = torch.nn.Linear(in_features, out_features, bias=(bias is not None))
         if weight:
             linear.weight.data.fill_(weight)
         else:
             linear.weight.data.random_(0, 100)
         if bias:
             linear.bias.data.fill_(bias)
-        else:
-            linear.bias.data.random_(0, 10)
+
         super(SimpleQuantizedLinearModel, self).__init__(
             quantization, linear, torch.nn.quantized.DeQuantize()
         )
@@ -44,6 +43,18 @@ class TestQuantizedLinear(unittest.TestCase):
                     ),
                     1.2,
                     3.0,
+                ),
+                _make_input(5, 6, [3, 2, 5]),
+            ),
+            (
+                "no_bias",
+                SimpleQuantizedLinearModel(
+                    5,
+                    3,
+                    torch.nn.quantized.Quantize(
+                        scale=1 / 15, zero_point=17, dtype=torch.quint8
+                    ),
+                    1.2,
                 ),
                 _make_input(5, 6, [3, 2, 5]),
             ),


### PR DESCRIPTION
Summary: For quantized linear, the shape of the weight is `(out_features, in_features)`. Thus, when generate zero bias we should set the shape to `weight.dims()[0]`.

Differential Revision: D25541713

