### PR TITLE
Add Support for Loading Pow with Tensor Exponent

### DIFF
--- a/torch_glow/tests/nodes/pow_test.py
+++ b/torch_glow/tests/nodes/pow_test.py
@@ -3,24 +3,31 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import unittest
 
 import torch
+from parameterized import parameterized
 from tests import utils
 
 
 class SimplePowModule(torch.nn.Module):
-    def __init__(self, *powers):
+    def __init__(self, power):
         super(SimplePowModule, self).__init__()
-        self.powers = powers
+        self.power = power
 
     def forward(self, tensor):
-        for power in self.powers:
-            tensor = torch.pow(tensor, power)
-        return tensor
+        return torch.pow(tensor, self.power)
 
 
 class TestPow(unittest.TestCase):
-    def test_pow_basic(self):
+    @parameterized.expand(
+        [
+            ("float", 2.2),
+            ("tensor_basic", torch.randn(4) + 2),
+            ("tensor_size[]", torch.tensor(2.2)),
+            ("tensor_broadcast", torch.randn(1) + 2),
+        ]
+    )
+    def test_pow_basic(self, _, power):
         """Test of the PyTorch pow Node on Glow."""
 
         utils.compare_tracing_methods(
-            SimplePowModule(2.3, 3.4), torch.rand(4) + 5, fusible_ops={"aten::pow"}
+            SimplePowModule(power), torch.rand(4) + 5, fusible_ops={"aten::pow"}
         )


### PR DESCRIPTION
Summary: Exponent for `aten:pow` can be a tensor and it'll need broadcast.

Differential Revision: D25545645

