### PR TITLE
[ONNXImporter] Support If operator with constant condition

### DIFF
--- a/include/glow/Importer/ONNXModelLoader.h
+++ b/include/glow/Importer/ONNXModelLoader.h
@@ -418,6 +418,10 @@ class ONNXModelLoader
   Error loadInsertTensor(const ONNX_NAMESPACE::NodeProto &op,
                          ArgumentDictionaryTy &dict);
 
+  /// Load If ONNX operator.
+  Error loadIf(const ONNX_NAMESPACE::NodeProto &op,
+               const ArgumentDictionaryTy &dict);
+
   /// Load AdaptiveAvgPool Glow operator.
   /// NOTE: since this operator is not a standard onnx op, assume this is from
   /// OnnxModelWriter and is therefore in NHWC format.

--- a/lib/Importer/ProtobufLoader.cpp
+++ b/lib/Importer/ProtobufLoader.cpp
@@ -46,7 +46,7 @@ bool ProtobufLoader::isConstantFoldable(llvm::ArrayRef<NodeValue> inputs,
     return false;
   }
   // foldUnsupportedTypes: List of typenames unsupported for folding.
-  std::string foldUnsupportedTypes[] = {"Constant", "Loop"};
+  std::string foldUnsupportedTypes[] = {"Constant", "Loop", "If"};
   std::string *findType = std::find(std::begin(foldUnsupportedTypes),
                                     std::end(foldUnsupportedTypes), typeName);
   // Early exit if folding is not supported for current operator.

--- a/tests/models/onnxModels/if_false.onnxtxt
+++ b/tests/models/onnxModels/if_false.onnxtxt
@@ -1,0 +1,132 @@
+ir_version: 5
+producer_name: "onnx-example"
+graph {
+  node {
+    output: "cond"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 9
+        raw_data: "\000"
+        name: "cond_tensor"
+      }
+      type: TENSOR
+    }
+  }
+  node {
+    input: "cond"
+    output: "output"
+    op_type: "If"
+    attribute {
+      name: "else_branch"
+      g {
+        node {
+          input: "input"
+          input: "input"
+          output: "square"
+          op_type: "Mul"
+        }
+        name: "if_false"
+        input {
+          name: "input"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        output {
+          name: "square"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+      }
+      type: GRAPH
+    }
+    attribute {
+      name: "then_branch"
+      g {
+        node {
+          input: "input"
+          input: "input"
+          output: "sum"
+          op_type: "Add"
+        }
+        name: "if_true"
+        input {
+          name: "input"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        output {
+          name: "sum"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+      }
+      type: GRAPH
+    }
+  }
+  name: "test-model"
+  input {
+    name: "input"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "output"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 10
+}
+

--- a/tests/models/onnxModels/if_true.onnxtxt
+++ b/tests/models/onnxModels/if_true.onnxtxt
@@ -1,0 +1,132 @@
+ir_version: 5
+producer_name: "onnx-example"
+graph {
+  node {
+    output: "cond"
+    op_type: "Constant"
+    attribute {
+      name: "value"
+      t {
+        dims: 1
+        data_type: 9
+        raw_data: "\001"
+        name: "cond_tensor"
+      }
+      type: TENSOR
+    }
+  }
+  node {
+    input: "cond"
+    output: "output"
+    op_type: "If"
+    attribute {
+      name: "else_branch"
+      g {
+        node {
+          input: "input"
+          input: "input"
+          output: "square"
+          op_type: "Mul"
+        }
+        name: "if_false"
+        input {
+          name: "input"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        output {
+          name: "square"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+      }
+      type: GRAPH
+    }
+    attribute {
+      name: "then_branch"
+      g {
+        node {
+          input: "input"
+          input: "input"
+          output: "sum"
+          op_type: "Add"
+        }
+        name: "if_true"
+        input {
+          name: "input"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+        output {
+          name: "sum"
+          type {
+            tensor_type {
+              elem_type: 1
+              shape {
+                dim {
+                  dim_value: 1
+                }
+              }
+            }
+          }
+        }
+      }
+      type: GRAPH
+    }
+  }
+  name: "test-model"
+  input {
+    name: "input"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "output"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 10
+}
+


### PR DESCRIPTION
Author: Max Kazantsev <maximkaz@cadence.com>

Summary: Limited support for If ONNX operator, when the condition input is a constant. The node is substituted by "then" or "else" sub-graph based on the condition in loader.

Documentation: N/A

Test Plan: Added ONNXImporter unit tests. 