### PR TITLE
Make the glow trace theading name more clear

### DIFF
--- a/lib/Onnxifi/Base.cpp
+++ b/lib/Onnxifi/Base.cpp
@@ -507,7 +507,7 @@ onnxStatus Graph::setIOAndRun(uint32_t inputsCount,
   TRACE_EVENT_SCOPE_END_NAMED(soEvent);
 
   if (ctx->getTraceContext()) {
-    ctx->getTraceContext()->setThreadName("Caller");
+    ctx->getTraceContext()->setThreadName("Request Thread");
   }
 
   // End trace scope before calling into run. run() can trigger the completion

--- a/tests/unittests/Repro.cpp
+++ b/tests/unittests/Repro.cpp
@@ -709,7 +709,7 @@ int run() {
           ctx->setTraceContext(
               glow::make_unique<TraceContext>(TraceLevel::STANDARD));
           traceContext = ctx->getTraceContext();
-          traceContext->setThreadName("Caller");
+          traceContext->setThreadName("Request Thread");
         }
         TRACE_EVENT_SCOPE(traceContext, TraceLevel::RUNTIME,
                           "Dispatch to prep input and dispatch");


### PR DESCRIPTION
Summary: Caller is a bit generic name. In reality, the caller are usually request thread from the service.

Differential Revision: D25602110

