### PR TITLE
Get Input Shapes of a Submodule

### DIFF
--- a/torch_glow/src/CachingGraphRunner.cpp
+++ b/torch_glow/src/CachingGraphRunner.cpp
@@ -728,12 +728,12 @@ Error CachingGraphRunner::runOnly(torch::jit::Stack &stack) {
     auto it = perGlowGraphInfoMap_.find(hash);
     if (it == perGlowGraphInfoMap_.end()) {
       std::ostringstream ss;
-      ss << "No compiled graph found for input stack:" << std::endl
-         << metaStack.print() << std::endl;
+      ss << "No compiled graph found for input stack:\n"
+         << metaStack.print() << "\n";
       ss << "There are " << perGlowGraphInfoMap_.size()
-         << "input sets with compiled graphs, they are:" << std::endl;
+         << " input sets with compiled graphs, they are:\n";
       for (const auto &kv : perGlowGraphInfoMap_) {
-        ss << hash << std::endl;
+        ss << hash << "\n";
       }
       return MAKE_ERR(ss.str());
     }

--- a/torch_glow/tests/functionality/to_glow_selective_test.py
+++ b/torch_glow/tests/functionality/to_glow_selective_test.py
@@ -41,7 +41,7 @@ class Foo(torch.nn.Module):
         self.baz = baz
 
     def forward(self, a, b):
-        return self.baz(self.bar(a, b), b)
+        return self.baz(self.bar(a.reshape(1, -1), b.reshape(1, -1)), b)
 
 
 class Model(torch.nn.Module):
@@ -69,58 +69,69 @@ foo = Foo(bar, baz)
 model = Model(foo, qux)
 
 
+def get_compilation_spec(inputs):
+    """helper function to get the compilation spec of the submodule"""
+    spec = torch_glow.CompilationSpec()
+    spec.get_settings().set_glow_backend("Interpreter")
+
+    compilation_group = torch_glow.CompilationGroup()
+    spec.compilation_groups_append(compilation_group)
+
+    compilation_group.input_sets_append(torch_glow.input_specs_from_tensors(inputs))
+    return spec
+
+
 class TestSelectiveToGlow(unittest.TestCase):
     def test_to_glow_selective(self):
-        a = torch.zeros(4) + 8
-        b = torch.zeros(4) + 7
-        torch_res = model(a, b)
+        inputs = (torch.zeros(4) + 8, torch.zeros(4) + 7)
+        torch_res = model(*inputs)
 
-        spec = torch_glow.CompilationSpec()
-        spec.get_settings().set_glow_backend("Interpreter")
-
-        compilation_group = torch_glow.CompilationGroup()
-        spec.compilation_groups_append(compilation_group)
-
-        a_spec = torch_glow.InputSpec()
-        a_spec.set_same_as(a)
-        b_spec = torch_glow.InputSpec()
-        b_spec.set_same_as(b)
-
-        compilation_group.input_sets_append([a_spec, b_spec])
+        bar_inputs = [
+            torch.randn(shape)
+            for shape in torch_glow.get_submod_input_shapes(model, "foo.bar", inputs)
+        ]
+        qux_inputs = [
+            torch.randn(shape)
+            for shape in torch_glow.get_submod_input_shapes(model, "qux", inputs)
+        ]
 
         glow_mod = torch_glow.to_glow_selective(
-            model, {"foo.bar": (spec, (a, b)), "qux": (spec, (a, b))}
+            model,
+            {
+                "foo.bar": (get_compilation_spec(bar_inputs), bar_inputs),
+                "qux": (get_compilation_spec(qux_inputs), qux_inputs),
+            },
+            inplace=False,
         )
 
-        glow_mod = torch.jit.trace(glow_mod, (a, b))
-        glow_res = glow_mod(a, b)
+        glow_mod = torch.jit.trace(glow_mod, inputs)
+        glow_res = glow_mod(*inputs)
 
         assert torch.allclose(torch_res, glow_res)
 
     def test_to_glow_selective_already_scripted(self):
-        a = torch.zeros(4) + 8
-        b = torch.zeros(4) + 7
-        torch_res = model(a, b)
+        inputs = (torch.zeros(4) + 8, torch.zeros(4) + 7)
+        torch_res = model(*inputs)
 
-        spec = torch_glow.CompilationSpec()
-        spec.get_settings().set_glow_backend("Interpreter")
+        bar_inputs = [
+            torch.randn(shape)
+            for shape in torch_glow.get_submod_input_shapes(model, "foo.bar", inputs)
+        ]
+        qux_inputs = [
+            torch.randn(shape)
+            for shape in torch_glow.get_submod_input_shapes(model, "qux", inputs)
+        ]
 
-        compilation_group = torch_glow.CompilationGroup()
-        spec.compilation_groups_append(compilation_group)
-
-        a_spec = torch_glow.InputSpec()
-        a_spec.set_same_as(a)
-        b_spec = torch_glow.InputSpec()
-        b_spec.set_same_as(b)
-
-        compilation_group.input_sets_append([a_spec, b_spec])
         with torch.no_grad():
-            traced_model = torch.jit.trace(model, (a, b))
+            traced_model = torch.jit.trace(model, inputs)
 
         glow_mod = torch_glow.to_glow_selective(
             traced_model,
-            {"foo.bar": spec, "qux": spec},
+            {
+                "foo.bar": get_compilation_spec(bar_inputs),
+                "qux": get_compilation_spec(qux_inputs),
+            },
             inplace=False,
         )
-        glow_res = glow_mod(a, b)
+        glow_res = glow_mod(*inputs)
         assert torch.allclose(torch_res, glow_res)


### PR DESCRIPTION
Summary:
Add a function `get_submod_input_shapes` in torch_glow. Given the top-level model, the path to the submodule and the inputs of the top-level model, the function returns the input shapes of the submodule.

The reason why we don't return an input spec or even a compilation spec is that when `to_glow_selective` a Pytorch model (not traced yet) we also need the input to trace it. If a spec is returned we can't generate the input (maybe we can from the input spec?).

Reviewed By: jackm321

Differential Revision: D25622298

