### PR TITLE
Adding IR Nodes to Glow to support calling external functions

### DIFF
--- a/include/glow/Backends/Interpreter/InterpreterFunction.h
+++ b/include/glow/Backends/Interpreter/InterpreterFunction.h
@@ -100,10 +100,16 @@ public:
 
   Error execute(IRFunction *F, ExecutionContext *context);
 
-private:
   /// \returns a pointer to the tensor that is saved under \p v.
   Tensor *getTensor(const Value *v) const;
 
+  /// \returns a typed handle to the tensor that is stored at \p v.
+  template <class ElemTy = float>
+  Handle<ElemTy> getWeightHandle(Value *v) const {
+    return getTensor(v)->getHandle<ElemTy>();
+  }
+
+private:
   /// Allocate a tensor to back the value \p v. Do not allocate anything if a
   /// tensor is already allocated for \p v.
   /// \returns a tensor for \p v.
@@ -117,12 +123,6 @@ private:
 
   /// If a tensor is allocated for \p v then delete it.
   void deleteTensor(const Value *v);
-
-  /// \returns a typed handle to the tensor that is stored at \p v.
-  template <class ElemTy = float>
-  Handle<ElemTy> getWeightHandle(Value *v) const {
-    return getTensor(v)->getHandle<ElemTy>();
-  }
 
   /// @name BoundInterpreterFunction methods. This is a list of method
   /// declerations that are used by the interpreter to dispatch different

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -2146,6 +2146,17 @@ public:
                       int64_t angleBoundLo, int64_t angleBoundHi,
                       float clipAngleThresh, bool legacyPlusOne);
 
+  /// Create an ExternFunctionCall node. \p funcImpl will contain body
+  /// of or reference to the function which can be invoked.
+  /// \p funcKind contains the type of function. The type of function  could be
+  /// source code, like OpenCL, CUDA, or could be a binary or
+  /// a handle to an external function.
+  ExternalFunctionCallNode *
+  createExternalFunctionCall(llvm::StringRef name, TypeRef outTy,
+                             llvm::ArrayRef<glow::NodeValue> inputs,
+                             llvm::StringRef funcName, llvm::StringRef funcImpl,
+                             llvm::StringRef funcKind);
+
   /// Erase the node \p N from the Function.
   void eraseNode(Node *N);
 

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -6717,3 +6717,8 @@ void BoundInterpreterFunction::fwdBBoxTransformInst(
   dispatchFloatingPointImpl(fwdBBoxTransformInstFloatImpl,
                             I->getRois()->getElementType(), I);
 }
+
+void BoundInterpreterFunction::fwdExternalFunctionCallInst(
+    glow::ExternalFunctionCallInst const *) {
+  LOG(FATAL) << "ExternalFunctionCallInst is not supported yet";
+}

--- a/lib/Exporter/ONNXModelWriter.cpp
+++ b/lib/Exporter/ONNXModelWriter.cpp
@@ -2512,6 +2512,7 @@ DEF_UNSUPPORTED_NODE(Broadcast)
 DEF_UNSUPPORTED_NODE(SGD)
 // Artificial node.
 DEF_UNSUPPORTED_NODE(Save)
+DEF_UNSUPPORTED_NODE(ExternalFunctionCall)
 // TODO: Turn to ScatterNd when it is supported in ONNX.
 DEF_UNSUPPORTED_NODE(ScatterData)
 // Gradient nodes.

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -5078,6 +5078,14 @@ BBoxTransformNode *Function::createBBoxTransform(
       clipAngleThresh, legacyPlusOne));
 }
 
+ExternalFunctionCallNode *Function::createExternalFunctionCall(
+    llvm::StringRef name, TypeRef outTy, llvm::ArrayRef<glow::NodeValue> inputs,
+    llvm::StringRef funcName, llvm::StringRef funcImpl,
+    llvm::StringRef funcKind) {
+  return addNode(new ExternalFunctionCallNode(name, outTy, inputs, funcName,
+                                              funcImpl, funcKind));
+}
+
 //===----------------------------------------------------------------------===//
 //                   Graph dumping and printing
 //===----------------------------------------------------------------------===//

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -2556,6 +2556,8 @@ bool BroadcastNode::verify() const {
 
 bool ModuloNode::verify() const { return getDivisor() >= 1; }
 
+bool ExternalFunctionCallNode::verify() const { return true; }
+
 //===----------------------------------------------------------------------===//
 //                     Node hashing support
 //===----------------------------------------------------------------------===//

--- a/lib/IR/IRGen.cpp
+++ b/lib/IR/IRGen.cpp
@@ -520,6 +520,25 @@ void IRGenVisitor::post(Node *parent, Node *N) {
     }
     break;
   }
+  case glow::Kinded::Kind::ExternalFunctionCallNodeKind: {
+    auto *EFCN = llvm::cast<ExternalFunctionCallNode>(N);
+    std::string externalCallType = std::string(EFCN->getName());
+    std::string allocName = std::string(EFCN->getName()) + ".res";
+    auto *dest = builder_.createAllocActivationInst(
+        allocName, EFCN->getResult().getType());
+
+    auto *inst = builder_.createExternalFunctionCallInst(
+        EFCN->getName(), dest, EFCN->getFunctionName(), EFCN->getFunctionImpl(),
+        EFCN->getFunctionKind());
+
+    // First instruction operand is the buffer for the result, the
+    // rest are all inputs.
+    for (auto &in : EFCN->getInputs()) {
+      inst->pushOperand({valueForNode(in), OperandKind::In});
+    }
+    registerIR(EFCN->getResult(), dest);
+    break;
+  }
   }
 }
 

--- a/tests/unittests/BackendTest.cpp
+++ b/tests/unittests/BackendTest.cpp
@@ -117,6 +117,16 @@ TEST(Interpreter, profileQuantizationForANetwork) {
   EXPECT_NEAR(1.6, max, 0.00001);
 }
 
+/// Creates an interpreter with a given \p name and custom instruction handler
+/// \p hook. \retruns a newly created custom interpreter.
+static Backend *createCustomInterpreter(llvm::StringRef name,
+                                        IRInstructionProcessingFn hook) {
+  auto interpreter = new Interpreter();
+  interpreter->setIRInstructionProcessingHandler(hook);
+  interpreter->setName(name);
+  return interpreter;
+}
+
 #ifdef GLOW_WITH_CPU
 
 /// A couple of counters to check that custom processing has happened.
@@ -155,16 +165,6 @@ static IRInstructionProcessingFn customInterpreterHook =
   }
   return false;
 };
-
-/// Creates an interpreter with a given \p name and custom instruction handler
-/// \p hook. \retruns a newly created custom interpreter.
-static Backend *createCustomInterpreter(llvm::StringRef name,
-                                        IRInstructionProcessingFn hook) {
-  auto interpreter = new Interpreter();
-  interpreter->setIRInstructionProcessingHandler(hook);
-  interpreter->setName(name);
-  return interpreter;
-}
 
 /// Check support for intercepting and customizing the processing of
 /// instructions suppored by Interpreter.
@@ -252,6 +252,152 @@ TEST(Interpreter, customHandleUnsupportedInstruction) {
 }
 
 #endif
+
+/// An interceptor to be invoked when executing the interpreter instructions.
+/// This is similar in spirit to customInterpreterHook.
+/// Please remember, the user can choose to do what she wants to with funcImpl
+/// -- they can compile and call it (like CUDA), or just invoke it, if it's a
+/// handle to an external function. In this case, based on funcImpl being "PLUS"
+/// or not, we add the inputs and return the value in the output.
+static IRInstructionProcessingFn externFnCallInterpreterHook =
+    [](const Instruction *I, IRInstructionProcessingStage executionStage,
+       void *ctx) -> bool {
+  // Only handle instructions in the processing stage.
+  if (executionStage != IRInstructionProcessingStage::PROCESSING) {
+    return false;
+  }
+
+  if (llvm::isa<ExternalFunctionCallInst>(I)) {
+    auto boundInterpFn = reinterpret_cast<BoundInterpreterFunction *>(ctx);
+    auto EFCI = llvm::dyn_cast<ExternalFunctionCallInst>(I);
+    auto funcImpl = EFCI->getFunctionImpl();
+
+    auto output = EFCI->getDest();
+    auto input1 = EFCI->getOperand(1).first;
+    auto input2 = EFCI->getOperand(2).first;
+    auto out = boundInterpFn->getWeightHandle<float>(output);
+    auto in1 = boundInterpFn->getWeightHandle<float>(input1);
+    auto in2 = boundInterpFn->getWeightHandle<float>(input2);
+
+    // In this simple test, we check the funcImpl of the instruction is PLUS
+    // or MINUS. If so, we return the sum or difference of the inputs. If it's
+    // anything else we zero the output. Note that this test shows a simple use
+    // of the ExternalFunctionCallInst. The user based on their needs can
+    // compile, compile and invoke, or invoke an external function. PLEASE NOTE
+    // HERE WE COULD HAVE INVOKED AN EXTERNAL FUNCTION OR COMPILED AND RAN CODE.
+    if (funcImpl == "PLUS") {
+      for (dim_t i = 0, e = out.size(); i < e; i++) {
+        out.raw(i) = in1.raw(i) + in2.raw(i);
+      }
+    } else if (funcImpl == "MINUS") {
+      for (dim_t i = 0, e = out.size(); i < e; i++) {
+        out.raw(i) = in1.raw(i) - in2.raw(i);
+      }
+    } else {
+      // Only PLUS and MINUS are supported.
+      for (dim_t i = 0, e = out.size(); i < e; i++) {
+        out.raw(i) = 0.0;
+      }
+    }
+    // Tell the backend to skip standard processing of this instruction.
+    return true;
+  }
+  return false;
+};
+
+TEST(Interpreter, ExternalFunctionCallTest) {
+  // Register a custom Interpreter-based backend with a hook for handling the
+  // ExternalFunctionCall instructions.
+  REGISTER_DYNAMIC_GLOW_BACKEND_FACTORY(
+      CustomInterpreterFactory, Interpreter, "CustomInterpreter",
+      createCustomInterpreter("CustomInterpreter", externFnCallInterpreterHook))
+  // Create a custom interpreter backend.
+  ExecutionEngine customInterpreterEE("CustomInterpreter");
+  auto *customInterpreterBackend =
+      &customInterpreterEE.getBackend("CustomInterpreter");
+  auto &mod = customInterpreterEE.getModule();
+  auto *F = mod.createFunction("test");
+
+  Tensor inputs(ElemKind::FloatTy, {10});
+  inputs.zero();
+
+  auto *input1 = mod.createPlaceholder(ElemKind::FloatTy, {10}, "in1", false);
+  auto *input2 = mod.createPlaceholder(ElemKind::FloatTy, {10}, "in2", false);
+
+  // For this test, we send in a toy external function. We call it plus_call.
+  // The functionImpl is just a string "PLUS". Based on this string being equal
+  // to "PLUS", we compute an add operation with the inputs and store it to the
+  // output. PLEASE NOTE: This test is just a toy example. The user can choose
+  // to do what she wants to with funcImpl -- they can compile and call it (like
+  // CUDA), or just invoke it, if it's a handle to an external function, and use
+  // the inputs and outputs as they see fit.
+
+  std::string fnName = "plus_call";
+  // This can be source code like OpenCL, CUDA, or a handle to a function.
+  std::string fnImplPlus = "PLUS";
+  std::string fnImplMinus = "MINUS";
+  std::string fnImplMul = "MUL";
+  std::string fnKind = "CUSTOM_OP";
+
+  auto *extFnCallPlus = F->createExternalFunctionCall(
+      "external_function_call", input1->getType(), {input1, input2}, fnName,
+      fnImplPlus, fnKind);
+  auto *extFnCallMinus = F->createExternalFunctionCall(
+      "external_function_call", input1->getType(), {input1, input2}, fnName,
+      fnImplMinus, fnKind);
+  auto *extFnCallMul = F->createExternalFunctionCall(
+      "external_function_call", input1->getType(), {input1, input2}, fnName,
+      fnImplMul, fnKind);
+  auto *savePlus = F->createSave("save", extFnCallPlus);
+  auto *saveMinus = F->createSave("save", extFnCallMinus);
+  auto *saveMul = F->createSave("save", extFnCallMul);
+
+  std::unique_ptr<PlaceholderBindings> customInterpreterBindings(
+      new PlaceholderBindings);
+  customInterpreterBindings->allocate(
+      {input1, input2, savePlus->getPlaceholder(), saveMinus->getPlaceholder(),
+       saveMul->getPlaceholder()});
+
+  // Now get the tensors and set their values.
+  auto inTensor1 = customInterpreterBindings->get(input1)->getHandle<float>();
+  auto inTensor2 = customInterpreterBindings->get(input2)->getHandle<float>();
+  for (dim_t i = 0, e = inTensor1.size(); i < e; i++) {
+    inTensor1.raw(i) = 5.0;
+    inTensor2.raw(i) = 4.0;
+  }
+
+  // Generate the IR for the custom backend.
+  std::unique_ptr<IRFunction> customInterpreterIR =
+      glow::generateAndOptimizeIR(F, *customInterpreterBackend, false);
+
+  auto customInterpreterCompiledF(
+      reinterpret_cast<BackendUsingGlowIR *>(customInterpreterBackend)
+          ->compileIR(std::move(customInterpreterIR)));
+
+  ExecutionContext customInterpreterExecCtx(
+      std::move(customInterpreterBindings));
+
+  FAIL_TEST_IF_ERR(
+      customInterpreterCompiledF->execute(&customInterpreterExecCtx));
+
+  // Get bindings, then get the input and output tensors.
+  auto *bindings = customInterpreterExecCtx.getPlaceholderBindings();
+  auto in1 = bindings->get(input1)->getHandle<float>();
+  auto in2 = bindings->get(input2)->getHandle<float>();
+  auto outputPlus =
+      bindings->get(savePlus->getPlaceholder())->getHandle<float>();
+  auto outputMinus =
+      bindings->get(saveMinus->getPlaceholder())->getHandle<float>();
+  auto outputMul = bindings->get(saveMul->getPlaceholder())->getHandle<float>();
+
+  // Verify the output tensors. Add and Minus should have been processed in the
+  // hook. Mul is not supported, and this ouptut should be zero'd.
+  for (dim_t i = 0, e = outputPlus.size(); i < e; i++) {
+    EXPECT_TRUE(outputPlus.raw(i) == in1.raw(i) + in2.raw(i));
+    EXPECT_TRUE(outputMinus.raw(i) == in1.raw(i) - in2.raw(i));
+    EXPECT_TRUE(outputMul.raw(i) == 0.0);
+  }
+}
 
 /// Check that new backends and backend factories can be registered dynamically.
 TEST(Interpreter, DynamicBackendFactory) {

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -1117,6 +1117,16 @@ int main(int argc, char **argv) {
       .autoIRGen();
 
   //===--------------------------------------------------------------------===//
+  //                Custom kernels invocations
+  //===--------------------------------------------------------------------===//
+  BB.newInstr("ExternalFunctionCall")
+      .addOperand("Dest", OperandKind::Out)
+      .addMember(MemberType::String, "FunctionName")
+      .addMember(MemberType::String, "FunctionImpl")
+      .addMember(MemberType::String, "FunctionKind")
+      .autoVerify(VerifyKind::NoVerify);
+
+  //===--------------------------------------------------------------------===//
   //                Pre Processing
   //===--------------------------------------------------------------------===//
 

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -1307,6 +1307,31 @@ int main(int argc, char **argv) {
           "and Rescale nodes.");
 
   //===--------------------------------------------------------------------===//
+  //                Custom kernels invocations
+  //===--------------------------------------------------------------------===//
+  BB.newNode("ExternalFunctionCall")
+      .addMember(MemberType::VectorNodeValue, "Inputs")
+      // For now use single output.
+      .addResultFromCtorArg()
+      .addMember(MemberType::String, "FunctionName")
+      // Examples are function source code, binary, or as needed.
+      // The use of the following two fields will vary depending
+      // on which kind of external function is used.
+      .addMember(MemberType::String, "FunctionImpl")
+      // Function kind, e.g. CUDA, function pointer, binary, backend-specific
+      // source code.
+      .addMember(MemberType::String, "FunctionKind")
+      .skipAutogenSerialization()
+      .setHasSideEffects(true)
+      .setDocstring("This is a node representing an external function call. "
+                    "One possible use of this capability is to pass a source "
+                    "code for a function/kernel. When processing this node, a "
+                    "backend can compile and execute the source code. This "
+                    "node can also be used to pass binary or pointers to "
+                    "executable code. The semantics and implementation of this "
+                    "node not standardized and is very backend-specific.");
+
+  //===--------------------------------------------------------------------===//
   //                Pre Processing
   //===--------------------------------------------------------------------===//
 


### PR DESCRIPTION
Summary: This diff adds Glow nodes/instructions to enable call external functions invocations. One possible use of this capability is to pass a source code for a function/kernel. When processing this node, the backend can compile and execute the source code. This facility can also be used to pass a binary code or pointers to executable code.

Reviewed By: jackm321, opti-mix

Differential Revision: D25013669

