### PR TITLE
Loading aten::to with Device and Dtype Arguments

### DIFF
--- a/torch_glow/src/GlowFuser.cpp
+++ b/torch_glow/src/GlowFuser.cpp
@@ -423,6 +423,8 @@ void glowCustomFuseImpl(std::shared_ptr<torch::jit::Graph> graph,
   if (settings.dumpOperatorInventory) {
     dumpOperatorStats(graph, fn, kind);
   }
+
+  std::cout << "final graph\n" << *graph << std::endl;
 }
 
 } // namespace

--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -792,6 +792,18 @@ struct ToInputs {
   };
 };
 
+/// Indexes of aten::to inputs.
+struct ToWithDeviceInputs {
+  enum {
+    input = 0,
+    device, // Not used
+    dtype,
+    non_block,     // Not used
+    copy,          // Not used
+    memory_format, // Not used
+  };
+};
+
 /// Indexes of aten::embedding_bag inputs.
 struct EmbeddingBagInputs {
   enum {
@@ -5259,7 +5271,14 @@ Error PyTorchModelLoader::loadPermute(const torch::jit::Node *ptNode) {
 Error PyTorchModelLoader::loadTo(const torch::jit::Node *ptNode) {
   auto inputs = ptNode->inputs();
   auto outputs = ptNode->outputs();
-  // aten::to could take either 4 or 5 arguments
+
+  // Currently we only support the following two kinds of aten::to
+  //
+  // 1. aten::to(Tensor input, Device device, ScalarType dtype, bool
+  // non_blocking, bool copy, c10::optional<MemoryFormat> memory_format)
+  //
+  // 2. aten::to(Tensor input, ScalarType dtype, bool non_blocking, bool copy,
+  // c10::optional<MemoryFormat> memory_format)
   RETURN_IF_ERR(checkInputAndOutputSizes(inputs, -4, outputs, 1));
 
   glow::NodeValue input;
@@ -5267,8 +5286,14 @@ Error PyTorchModelLoader::loadTo(const torch::jit::Node *ptNode) {
                              getGlowNodeValueForValue(inputs[ToInputs::input]));
 
   int32_t dtype;
-  ASSIGN_VALUE_OR_RETURN_ERR(
-      dtype, iValToInt(getGlowIValueForValue(inputs[ToInputs::dtype])));
+  // case 1
+  if (inputs.size() == 6) {
+    ASSIGN_VALUE_OR_RETURN_ERR(dtype, iValToInt(getGlowIValueForValue(
+                                          inputs[ToWithDeviceInputs::dtype])));
+  } else { // case 2
+    ASSIGN_VALUE_OR_RETURN_ERR(
+        dtype, iValToInt(getGlowIValueForValue(inputs[ToInputs::dtype])));
+  }
 
   auto inputType = input.getType();
   auto glowElemKind = scalarTypeToElemKind(static_cast<c10::ScalarType>(dtype));

--- a/torch_glow/tests/nodes/to_test.py
+++ b/torch_glow/tests/nodes/to_test.py
@@ -18,6 +18,17 @@ class SimpleToModel(torch.nn.Module):
         return tensor
 
 
+class ToWithDeviceModel(torch.nn.Module):
+    def __init__(self, *conversions):
+        super(ToWithDeviceModel, self).__init__()
+        self.conversions = conversions
+
+    def forward(self, tensor):
+        for conversion_type in self.conversions:
+            tensor = tensor.to(device="cpu", dtype=conversion_type)
+        return tensor
+
+
 class TestTo(unittest.TestCase):
     @parameterized.expand(
         [
@@ -26,6 +37,11 @@ class TestTo(unittest.TestCase):
             (
                 "to_int_to_float",
                 SimpleToModel(torch.int, torch.float),
+                torch.randn(1, 2, 3, 4),
+            ),
+            (
+                "to_int_with_device",
+                ToWithDeviceModel(torch.int),
                 torch.randn(1, 2, 3, 4),
             ),
         ]


### PR DESCRIPTION
Summary:
Allow loading `aten::to` with device arg.

Without device arg the arguments are (input, dtype, ...)
with device arg the arguments are (input, device, dtype, ...)

Reviewed By: zrphercule

Differential Revision: D25696402

