### PR TITLE
Make sure we clean up provisioner state when provisioning is met with errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,7 +275,7 @@ if (GLOW_BUILD_TESTS)
   get_property(GLOW_TEST_DEPENDS GLOBAL PROPERTY GLOW_TEST_DEPENDS)
 
   # All tests except expensive tests and stress tests.
-  add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} -LE EXPENSIVE\\|STRESS
+  add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure -LE EXPENSIVE\\|STRESS
                       DEPENDS ${GLOW_TEST_DEPENDS} USES_TERMINAL)
 
   # All tests including expensive tests but not stress tests.

--- a/lib/Runtime/Provisioner/Provisioner.cpp
+++ b/lib/Runtime/Provisioner/Provisioner.cpp
@@ -273,6 +273,21 @@ Error Provisioner::provision(DAGListTy &networks, Module &module,
   std::vector<std::string> localActiveNames;
   RETURN_IF_ERR(checkActiveNetworks(networks, localActiveNames));
 
+  // Container for duplicated functions and map tracking remaining installs for
+  // a duplicated function. NB: duplicatedFunctions will hold compiled function
+  // which might be used in clean up process by cleanupGuard, hence this needs
+  // to be declared before cleanupGuard. We probably should clean up the
+  // duplicatedFunctions logic to make this more intuitive.
+  std::map<std::string, std::unique_ptr<CompiledFunction>> duplicatedFunctions;
+  std::map<DAGNode *, unsigned> remainingDuplications;
+
+  // If any error happens during the provison process, we will clean up the
+  // compiled networks.
+  std::map<DeviceIDTy, std::vector<std::string>> addedNetworks;
+  ScopeGuard cleanupGuard([&localActiveNames, &addedNetworks, this]() {
+    cleanupProvision(localActiveNames, addedNetworks);
+  });
+
   // Walk the networks and group by logicalDeviceId.
   auto logicalDevices = generateLogicalDevices(networks);
 
@@ -323,17 +338,9 @@ Error Provisioner::provision(DAGListTy &networks, Module &module,
   VLOG(1) << "Before device assignment";
   // Check for errors.
   if (!deviceAssignments) {
-    // If and error occured, clean up provisioning state and return
-    // the error.
-    cleanupProvision(localActiveNames, {});
     RETURN_ERR(deviceAssignments.takeError());
   }
   auto assignments = std::move(*deviceAssignments);
-
-  // Container for duplicated functions and map tracking remaining installs for
-  // a duplicated function.
-  std::map<std::string, std::unique_ptr<CompiledFunction>> duplicatedFunctions;
-  std::map<DAGNode *, unsigned> remainingDuplications;
 
   // Map from Placeholder* to DeviceManager, this is used for deferred weight
   // loading.
@@ -372,7 +379,6 @@ Error Provisioner::provision(DAGListTy &networks, Module &module,
   // device are compiled and then added to their assigned device. If a function
   // is in multiple logical devices it is stored so that it only needs to be
   // compiled once.
-  std::map<DeviceIDTy, std::vector<std::string>> addedNetworks;
   for (auto &assignment : assignments) {
     auto logicalDevice = assignment.first;
     auto physicalDevice = assignment.second;
@@ -427,7 +433,6 @@ Error Provisioner::provision(DAGListTy &networks, Module &module,
           auto compiledOrErr2 =
               backends_[deviceBackendName]->compile(clonedFunction, options);
           if (!compiledOrErr2) {
-            cleanupProvision(localActiveNames, {});
             RETURN_ERR(compiledOrErr2.takeError());
           }
           auto compiled2 = std::move(*compiledOrErr2);
@@ -467,9 +472,6 @@ Error Provisioner::provision(DAGListTy &networks, Module &module,
 
         // Check to see if an error was encountered while compiling.
         if (!compiledOrErr) {
-          // If and error occured, clean up provisioning state and return
-          // the error.
-          cleanupProvision(localActiveNames, {});
           RETURN_ERR(compiledOrErr.takeError());
         }
         auto compiled = std::move(*compiledOrErr);
@@ -524,7 +526,6 @@ Error Provisioner::provision(DAGListTy &networks, Module &module,
     ready.wait();
     DCHECK_NOTNULL(addErr.get());
     if (*addErr.get()) {
-      cleanupProvision(localActiveNames, addedNetworks);
       return std::move(*addErr.get());
     }
     // Add networks successfully loaded on device to addedNetworks, this way if
@@ -581,7 +582,6 @@ Error Provisioner::provision(DAGListTy &networks, Module &module,
     // Load the first weight.
     auto err = loader->loadNextWeight();
     if (err) {
-      cleanupProvision(localActiveNames, addedNetworks);
       RETURN_ERR(err);
     }
     std::string weightName = loader->getName();
@@ -592,7 +592,6 @@ Error Provisioner::provision(DAGListTy &networks, Module &module,
                 << totalNumDeferredWeights << "): " << weightName;
       const auto PH = module.getPlaceholderByNameSlow(weightName);
       if (!PH) {
-        cleanupProvision(localActiveNames, addedNetworks);
         return MAKE_ERR(ErrorValue::ErrorCode::RUNTIME_ERROR,
                         llvm::formatv("Error loading deferred weight. Name: "
                                       "{0} not found in module.",
@@ -641,7 +640,6 @@ Error Provisioner::provision(DAGListTy &networks, Module &module,
 
       err = loader->loadNextWeight();
       if (err) {
-        cleanupProvision(localActiveNames, addedNetworks);
         RETURN_ERR(err);
       }
       weightName = loader->getName();
@@ -665,6 +663,8 @@ Error Provisioner::provision(DAGListTy &networks, Module &module,
       node->initAlternateState();
     }
   }
+
+  cleanupGuard.dismiss();
   cleanupProvision(localActiveNames, {}, false);
   return Error::success();
 };
@@ -899,8 +899,6 @@ void Provisioner::cleanupProvision(
     bool failure) {
   std::lock_guard<std::mutex> functionLock(functionsLock_);
   for (auto &name : names) {
-    LOG(INFO) << "Removing partition name: " << name
-              << " from activeFunctions_\n";
     activeFunctions_.erase(name);
     if (failure) {
       // Remove any functions added before the failure.
@@ -911,6 +909,8 @@ void Provisioner::cleanupProvision(
     // Remove any partitions added to devices.
     for (auto &device : currentNetworkResidency) {
       for (auto &network : device.second) {
+        LOG(INFO) << "Removing network " << network << " from device "
+                  << device.first;
         Error evictErr = evictFunction(network, devices_[device.first]);
         if (evictErr) {
           LOG(ERROR) << "Unable to evict network: " << network << "\n";


### PR DESCRIPTION
Summary: We are hand coding quite a few places with `cleanupProvision` before returning error but it's still not enough (e.g. https://github.com/pytorch/glow/blob/da0991c83079e751f7e4ff6f11ee3c4492084098/lib/Runtime/Provisioner/Provisioner.cpp#L645). So we use a scope guard here to make sure this is done before exiting the provision function. Also change the logging a bit to make sure we are calling the function removal.

Differential Revision: D25721859

