### PR TITLE
change the option to run input verification to be a percentage

### DIFF
--- a/include/glow/Flags/Flags.h
+++ b/include/glow/Flags/Flags.h
@@ -134,7 +134,7 @@ extern unsigned InterpreterMemory;
 extern bool EnableP2P;
 extern bool EnableDRT;
 extern unsigned DeviceInitTimeoutMs;
-extern bool EnableSanitizeInputs;
+extern unsigned SanitizeInputsPercent;
 } // namespace flags
 } // namespace runtime
 } // namespace glow

--- a/lib/Flags/Flags.cpp
+++ b/lib/Flags/Flags.cpp
@@ -140,7 +140,7 @@ unsigned InterpreterMemory = 0;
 bool EnableP2P = false;
 bool EnableDRT = false;
 unsigned DeviceInitTimeoutMs = 5000;
-bool EnableSanitizeInputs = false;
+unsigned SanitizeInputsPercent = 0;
 
 } // namespace flags
 } // namespace runtime
@@ -598,11 +598,15 @@ DEFINE_validator(glow_device_init_timeout_ms, [](const char *, int32_t val) {
   glow::runtime::flags::DeviceInitTimeoutMs = val;
   return true;
 });
-DEFINE_bool(glow_enable_sanitize_inputs,
-            glow::runtime::flags::EnableSanitizeInputs,
-            "Enable sanitize inputs passed from the Host to the device");
-DEFINE_validator(glow_enable_sanitize_inputs, [](const char *, bool val) {
-  glow::runtime::flags::EnableSanitizeInputs = val;
+DEFINE_int32(glow_enable_sanitize_inputs,
+             glow::runtime::flags::SanitizeInputsPercent,
+             "Sanitize a percentage of inferences");
+DEFINE_validator(glow_enable_sanitize_inputs, [](const char *, int32_t val) {
+  if (val < 0 || val > 100) {
+    return false;
+  }
+
+  glow::runtime::flags::SanitizeInputsPercent = val;
   return true;
 });
 


### PR DESCRIPTION
Summary:
instead of enabling/disabling, we are going to enable a percentage
[0,100] to run verification, this way we can adjust to whatever e2e performance
hit we will get from enabling this check

Reviewed By: jfix71

Differential Revision: D25722719

