### PR TITLE
Fix loading issue for ConstantFill

### DIFF
--- a/tests/models/caffe2Models/constant_fill_input_as_shape.pbtxt
+++ b/tests/models/caffe2Models/constant_fill_input_as_shape.pbtxt
@@ -1,0 +1,17 @@
+name: "constant_fill_input_as_shape"
+op {
+  input: "inputs_0"
+  output: "result"
+  name: ""
+  type: "ConstantFill"
+  arg {
+    name: "value"
+    f: 3.0
+  }
+  arg {
+    name: "input_as_shape"
+    i: 1
+  }
+}
+external_input: "inputs_0"
+external_output: "result"

--- a/tests/models/caffe2Models/constant_fill_input_as_shape_init.pbtxt
+++ b/tests/models/caffe2Models/constant_fill_input_as_shape_init.pbtxt
@@ -1,0 +1,16 @@
+name: "init"
+op {
+  output: "inputs_0"
+  type: "GivenTensorInt64Fill"
+  arg {
+    name: "shape"
+    ints: 4
+  }
+  arg {
+    name: "values"
+    ints: 17
+    ints: 23
+    ints: 29
+    ints: 31
+  }
+}

--- a/tests/models/caffe2Models/constant_fill_use_input_shape.pbtxt
+++ b/tests/models/caffe2Models/constant_fill_use_input_shape.pbtxt
@@ -1,0 +1,13 @@
+name: "constant_fill_use_input_shape"
+op {
+  input: "inputs_0"
+  output: "result"
+  name: ""
+  type: "ConstantFill"
+  arg {
+    name: "value"
+    f: 3.0
+  }
+}
+external_input: "inputs_0"
+external_output: "result"

--- a/tests/models/caffe2Models/constant_fill_use_provided_shape.pbtxt
+++ b/tests/models/caffe2Models/constant_fill_use_provided_shape.pbtxt
@@ -1,0 +1,18 @@
+name: "constant_fill_use_provided_shape"
+op {
+  output: "result"
+  name: ""
+  type: "ConstantFill"
+  arg {
+    name: "value"
+    f: 3.0
+  }
+  arg {
+    name: "shape"
+    ints: 7
+    ints: 11
+    ints: 13
+    ints: 17
+  }
+}
+external_output: "result"

--- a/tests/unittests/Caffe2ImporterTest.cpp
+++ b/tests/unittests/Caffe2ImporterTest.cpp
@@ -3937,3 +3937,145 @@ TEST_F(Caffe2ImporterTest, ClipLargeQRangeToFP16) {
 
   EE.compile(CompilationMode::Infer);
 }
+
+// Here we use a shape that is provided as an argument
+TEST_F(Caffe2ImporterTest, constantFillUseProvidedShape) {
+  ExecutionEngine EE{};
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+
+  std::string NetDescFilename(
+      GLOW_DATA_PATH
+      "tests/models/caffe2Models/constant_fill_use_provided_shape.pbtxt");
+  std::string NetWeightFilename(
+      GLOW_DATA_PATH "tests/models/caffe2Models/empty_init_net.pbtxt");
+
+  PlaceholderBindings bindings;
+
+  Placeholder *output;
+  // Destroy the loader after the graph is loaded since the following execution
+  // will not depend on anything from the loader.
+  {
+    Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {}, {}, *F);
+    output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
+
+    bindings.allocate(mod.getPlaceholders());
+    updateInputPlaceholdersByName(bindings, &mod, {}, {});
+  }
+
+  // Shape is defined in .pbtxt file
+  const std::vector<dim_t> expectedShape{7, 11, 13, 17};
+  EXPECT_EQ(expectedShape, output->dims().vec());
+
+  auto res = bindings.get(output);
+  EE.compile(CompilationMode::Infer);
+  EE.run(bindings);
+
+  auto result = res->getHandle();
+  for (dim_t dim1 = 0; dim1 < expectedShape[0]; ++dim1) {
+    for (dim_t dim2 = 0; dim2 < expectedShape[1]; ++dim2) {
+      for (dim_t dim3 = 0; dim3 < expectedShape[2]; ++dim3) {
+        for (dim_t dim4 = 0; dim4 < expectedShape[3]; ++dim4) {
+          // As defined in the .pbtxt file
+          EXPECT_FLOAT_EQ(3.0f, result.at({dim1, dim2, dim3, dim4}));
+        }
+      }
+    }
+  }
+}
+
+// Here we use expect input to be 1D tensor and act like shape
+TEST_F(Caffe2ImporterTest, constantFillInputAsShape) {
+  ExecutionEngine EE{};
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+
+  std::string NetDescFilename(
+      GLOW_DATA_PATH
+      "tests/models/caffe2Models/constant_fill_input_as_shape.pbtxt");
+  std::string NetWeightFilename(
+      GLOW_DATA_PATH
+      "tests/models/caffe2Models/constant_fill_input_as_shape_init.pbtxt");
+
+  PlaceholderBindings bindings;
+
+  Placeholder *output;
+  // Destroy the loader after the graph is loaded since the following execution
+  // will not depend on anything from the loader.
+  {
+    Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {}, {}, *F);
+    output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
+
+    bindings.allocate(mod.getPlaceholders());
+    updateInputPlaceholdersByName(bindings, &mod, {}, {});
+  }
+
+  // Shape is defined in .pbtxt file
+  const std::vector<dim_t> expectedShape{17, 23, 29, 31};
+  EXPECT_EQ(expectedShape, output->dims().vec());
+
+  auto res = bindings.get(output);
+  EE.compile(CompilationMode::Infer);
+  EE.run(bindings);
+
+  auto result = res->getHandle();
+  for (dim_t dim1 = 0; dim1 < expectedShape[0]; ++dim1) {
+    for (dim_t dim2 = 0; dim2 < expectedShape[1]; ++dim2) {
+      for (dim_t dim3 = 0; dim3 < expectedShape[2]; ++dim3) {
+        for (dim_t dim4 = 0; dim4 < expectedShape[3]; ++dim4) {
+          // As defined in the .pbtxt file
+          EXPECT_FLOAT_EQ(3.0f, result.at({dim1, dim2, dim3, dim4}));
+        }
+      }
+    }
+  }
+}
+
+// Here we use input's shape for the result
+TEST_F(Caffe2ImporterTest, constantFillUseInputShape) {
+  ExecutionEngine EE{};
+  auto &mod = EE.getModule();
+  Function *F = mod.createFunction("main");
+
+  std::string NetDescFilename(
+      GLOW_DATA_PATH
+      "tests/models/caffe2Models/constant_fill_use_input_shape.pbtxt");
+  std::string NetWeightFilename(
+      GLOW_DATA_PATH "tests/models/caffe2Models/empty_init_net.pbtxt");
+
+  PlaceholderBindings bindings;
+
+  Placeholder *output;
+  const std::vector<dim_t> inputShape{7, 11, 13, 17};
+  Tensor inputs_0(ElemKind::FloatTy, inputShape);
+  inputs_0.getHandle().randomize(-3.0, 3.0, mod.getPRNG());
+  // Destroy the loader after the graph is loaded since the following execution
+  // will not depend on anything from the loader.
+  {
+    Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename, {"inputs_0"},
+                               {&inputs_0.getType()}, *F);
+    output = EXIT_ON_ERR(caffe2LD.getSingleOutput());
+
+    bindings.allocate(mod.getPlaceholders());
+    updateInputPlaceholdersByName(bindings, &mod, {"inputs_0"}, {&inputs_0});
+  }
+
+  // Check that the shape of the output matches what Caffe2 expects.
+  EXPECT_EQ(inputShape, output->dims().vec());
+
+  auto res = bindings.get(output);
+  EE.compile(CompilationMode::Infer);
+  EE.run(bindings);
+
+  auto result = res->getHandle();
+  for (dim_t dim1 = 0; dim1 < inputShape[0]; ++dim1) {
+    for (dim_t dim2 = 0; dim2 < inputShape[1]; ++dim2) {
+      for (dim_t dim3 = 0; dim3 < inputShape[2]; ++dim3) {
+        for (dim_t dim4 = 0; dim4 < inputShape[3]; ++dim4) {
+          // As defined in the .pbtxt file
+          EXPECT_FLOAT_EQ(3.0f, result.at({dim1, dim2, dim3, dim4}));
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Summary:
Making sure that for `ConstantFill` operator we determine output shape properly as described in https://caffe2.ai/docs/operators-catalogue.html, i.e.:
1. if `shape` argument is provided, then we rely on it,
2. if `input_as_shape` is `true`, then we use the first input data as a shape (therefore the input must be a 1D tensor of int type),
3. otherwise, we use shape of the first input.

Differential Revision: D25669044

