### PR TITLE
Fix multidimensional softmax

### DIFF
--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -57,6 +57,12 @@ ShapeVector expandDimsToMax(llvm::ArrayRef<dim_t> currDims);
 ShapeVector reduceDims(llvm::ArrayRef<dim_t> dims,
                        llvm::ArrayRef<unsigned_t> axes, bool keepDims);
 
+/// Helper function that \returns the transpose shuffle that would undo the
+/// given \p shuffle so that if two transposes were composed with the given
+/// shuffle and the result of this function, it would result in the identity
+/// shuffle.
+std::vector<unsigned_t> getInverseTranspose(llvm::ArrayRef<unsigned_t> shuffle);
+
 namespace runtime {
 class DeviceManager;
 }

--- a/lib/Base/Tensor.cpp
+++ b/lib/Base/Tensor.cpp
@@ -666,6 +666,21 @@ ShapeVector glow::reduceDims(llvm::ArrayRef<dim_t> dims,
   return newDims;
 }
 
+std::vector<unsigned_t>
+glow::getInverseTranspose(llvm::ArrayRef<unsigned_t> shuffle) {
+  std::vector<unsigned_t> unshuffle;
+  // For each index, go find where it ended up in the shuffle
+  for (auto i = 0; i < shuffle.size(); ++i) {
+    for (auto j = 0; j < shuffle.size(); ++j) {
+      if (shuffle[j] == i) {
+        unshuffle.push_back(j);
+        break;
+      }
+    }
+  }
+  return unshuffle;
+}
+
 void Tensor::init(InitKind init, float val, PseudoRNG &PRNG) {
   assert(!isDeviceResident() && "Tensor must reside on host to access data.");
   switch (init) {

--- a/torch_glow/tests/nodes/softmax_test.py
+++ b/torch_glow/tests/nodes/softmax_test.py
@@ -20,12 +20,22 @@ class SimpleSoftmaxModel(torch.nn.Module):
 class TestSoftmax(unittest.TestCase):
     @parameterized.expand(
         [
-            ("basic", SimpleSoftmaxModel(1), torch.randn(2, 3)),
-            ("neg_dim", SimpleSoftmaxModel(-1), torch.randn(2, 3)),
+            (-2, [2, 3]),
+            (-1, [2, 3]),
+            (0, [2, 3]),
+            (1, [2, 3]),
+            (-3, [2, 3, 4]),
+            (-2, [2, 3, 4]),
+            (-1, [2, 3, 4]),
+            (0, [2, 3, 4]),
+            (1, [2, 3, 4]),
+            (2, [2, 3, 4]),
         ]
     )
-    def test_softmax(self, _, module, tensor):
-        utils.compare_tracing_methods(module, tensor)
+    def test_softmax(self, dim, input_dims):
+        module = SimpleSoftmaxModel(dim)
+        input = torch.randn(input_dims)
+        utils.compare_tracing_methods(module, input)
 
     def test_softmax_oob_neg_dim(self):
         """Test out of bounds negative dimension index for the PyTorch SoftMax Node on Glow."""


### PR DESCRIPTION
Summary:
* Lowering PyTorch softmax with more than two dimensions or where dim != dims.size()-1 was not implemented correctly. This diff fixes both cases.
* Some small additional debugging things like dump dot graph when verification fails in PyTorchModelLoader and print the name of each tensor in `compare_tracing_methods` so we know what we're looking at

Reviewed By: 842974287

Differential Revision: D25750943

