### PR TITLE
Support ReduceBackSum

### DIFF
--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -1654,6 +1654,16 @@ Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     return Error::success();
   }
 
+  if (typeName == "ReduceBackSum") {
+    NodeValue in;
+    ASSIGN_VALUE_OR_RETURN_ERR(in, getNodeValueByName(op.input(0)));
+    RETURN_ERR_IF_NOT(in.dims().size() >= 2,
+                      opErrMsg(op, "Input should be at least 2D."));
+    Node *node = G_->createBatchedReduceAdd(opName, in, in.dims().size() - 1);
+    RETURN_IF_ERR(addNodeAsOutput(op, node));
+    return Error::success();
+  }
+
   return MAKE_ERR(unexpectedNodeErrorMessage(op, "Unsupported operator."));
 }
 

--- a/tests/models/caffe2Models/reduce_back_sum.pbtxt
+++ b/tests/models/caffe2Models/reduce_back_sum.pbtxt
@@ -1,0 +1,9 @@
+name: "reduce_back_sum"
+op {
+  input: "inputs_0"
+  output: "result"
+  name: ""
+  type: "ReduceBackSum"
+}
+external_input: "inputs_0"
+external_output: "result"


### PR DESCRIPTION
Summary:
Implement `ReduceBackSum` operator as described in https://caffe2.ai/docs/operators-catalogue.html#reducebacksum using already existing `BatchedReduceAdd` from `Glow`.

The operator reduces the last dimension by applying `sum` to elements in that dimension.

Reviewed By: yinghai

Differential Revision: D25577695

