### PR TITLE
Lower unpacked per_channel quantized linear

### DIFF
--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -674,7 +674,7 @@ public:
   /// scales and \p offsets. The output is quantized in the regular way, and its
   /// type \p outTy is a quantized type.
   RowwiseQuantizedFullyConnectedNode *createRowwiseQuantizedFullyConnected(
-      llvm::StringRef name, NodeValue input, Constant *W, Constant *scales,
+      llvm::StringRef name, NodeValue input, NodeValue W, Constant *scales,
       Constant *offsets, NodeValue B, TypeRef outTy);
 
   /// Create a row-wise quantized fully connected node. This node is only used
@@ -684,7 +684,7 @@ public:
   /// \p outTy is a quantized type. if \p transposeWeight is true, \p W need to
   /// be transposed first.
   RowwiseQuantizedFullyConnectedNode *createRowwiseQuantizedFullyConnected(
-      llvm::StringRef name, NodeValue input, Constant *W, NodeValue B,
+      llvm::StringRef name, NodeValue input, NodeValue W, NodeValue B,
       TypeRef outTy, quantization::Schema schema, bool transposeWeight = false);
 
   /// Implement an operation that computes the row-wise dot product of its

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -883,13 +883,13 @@ static bool quantizeRQFCFloatBias(Function *F,
                   "Constant in order to quantize the bias");
 
   auto TQPs = getTensorQuantizationParams(
-      biasC->getPayload(), quantization::Schema::Asymmetric, ElemKind::Int8QTy,
+      biasC->getPayload(), quantization::Schema::Asymmetric, ElemKind::Int32QTy,
       0, biasC->dims()[0]);
 
   DCHECK_EQ(TQPs.size(), 1) << "Should only be one dimension to quantize on";
 
-  auto biasQuantizedT =
-      quantization::quantizeTensor(biasC->getPayload(), TQPs[0]);
+  auto biasQuantizedT = quantization::quantizeTensor(
+      biasC->getPayload(), TQPs[0], ElemKind::Int32QTy);
 
   auto biasQuantizedC = F->getParent()->createConstant(
       biasC->getName(), std::move(biasQuantizedT));

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1128,7 +1128,7 @@ FullyConnectedNode *Function::createFullyConnected(llvm::StringRef name,
 
 RowwiseQuantizedFullyConnectedNode *
 Function::createRowwiseQuantizedFullyConnected(llvm::StringRef name,
-                                               NodeValue input, Constant *W,
+                                               NodeValue input, NodeValue W,
                                                Constant *scales,
                                                Constant *offsets, NodeValue B,
                                                TypeRef outTy) {
@@ -1138,7 +1138,7 @@ Function::createRowwiseQuantizedFullyConnected(llvm::StringRef name,
 
 RowwiseQuantizedFullyConnectedNode *
 Function::createRowwiseQuantizedFullyConnected(llvm::StringRef name,
-                                               NodeValue input, Constant *W,
+                                               NodeValue input, NodeValue W,
                                                NodeValue B, TypeRef outTy,
                                                quantization::Schema schema,
                                                bool transposeWeight) {
@@ -1146,10 +1146,13 @@ Function::createRowwiseQuantizedFullyConnected(llvm::StringRef name,
   // The quantized data is in qWeights, the scale of each row is in scales,
   // and the offset of each row is in offsets.
   Constant *weights = llvm::cast<Constant>(W);
-  dim_t numRows =
-      transposeWeight ? W->getType()->dims()[1] : W->getType()->dims()[0];
-  dim_t numCols =
-      transposeWeight ? W->getType()->dims()[0] : W->getType()->dims()[1];
+  CHECK(weights)
+      << "Expected RowwiseQuantizedFullyConnected weights to be a Constant";
+
+  dim_t numRows = transposeWeight ? weights->getType()->dims()[1]
+                                  : weights->getType()->dims()[0];
+  dim_t numCols = transposeWeight ? weights->getType()->dims()[0]
+                                  : weights->getType()->dims()[1];
 
   // So far, if we want to create a storage with Int8QTy/Int16QTy,
   // it is assumed to be quantized data and the scale and offset should be

--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -1990,6 +1990,58 @@ Error PyTorchModelLoader::loadQuantizedMul(const torch::jit::Node *ptNode) {
   }
 }
 
+// implementation for per_tensor and per_channel quantized linear from either
+// packed or unpacked linear
+Error PyTorchModelLoader::loadQuantizedLinearImpl(
+    NodeValue input, NodeValue weights, NodeValue bias, NodeValue wScales,
+    NodeValue wOffsets, float outScale, int64_t outZeroPoint,
+    const torch::jit::Value *outputValue, c10::ScalarType outputDtype) {
+  bool isRowwiseQuantized = false;
+  if (wScales) {
+    RETURN_ERR_IF_NOT(wOffsets, "Expected both weight scales and offsets for "
+                                "per_channel quantized linear");
+    isRowwiseQuantized = true;
+  } else {
+    RETURN_ERR_IF_NOT(!wOffsets, "Expected neight weight scales nor offsets "
+                                 "for per_tensor quantized linear");
+  }
+
+  // Flatten outer dims if necessary
+  auto inputDims = input.dims();
+  if (inputDims.size() > 2) {
+    input = F_.createFlatten("flatten", input, inputDims.size() - 1);
+  }
+
+  auto outTy = F_.getParent()->uniqueType(
+      ElemKind::Int8QTy, {input.dims()[0], weights.dims()[0]}, outScale,
+      outZeroPoint - UINT8_TO_INT8_SHIFT);
+
+  NodeValue output;
+  if (isRowwiseQuantized) {
+    auto rowwiseFC = F_.createRowwiseQuantizedFullyConnected(
+        "rowwise_quantized_fc", input, weights,
+        llvm::dyn_cast<glow::Constant>(wScales),
+        llvm::dyn_cast<glow::Constant>(wOffsets), bias, outTy);
+    output = rowwiseFC->getResult();
+  } else {
+    weights = rescaleUIntToInt(weights);
+
+    weights = F_.createTranspose("weight_transpose", weights, {1, 0});
+    auto fc =
+        F_.createFullyConnected("quantized_fc", input, weights, bias, outTy);
+    output = fc->getResult();
+  }
+
+  // Restore original outer dims
+  if (inputDims.size() > 2) {
+    std::vector<dim_t> finalDims = inputDims.vec();
+    finalDims.back() = output.dims().back();
+    output = F_.createReshape("expand", output, finalDims);
+  }
+
+  RETURN_ERR(addValueMapping(outputValue, output, outputDtype));
+}
+
 Error PyTorchModelLoader::loadQuantizedLinear(const torch::jit::Node *ptNode) {
   auto inputs = ptNode->inputs();
   auto outputs = ptNode->outputs();
@@ -1999,20 +2051,13 @@ Error PyTorchModelLoader::loadQuantizedLinear(const torch::jit::Node *ptNode) {
   ASSIGN_VALUE_OR_RETURN_ERR(
       input, getGlowNodeValueForValue(inputs[QuantizedLinearInputs::input]));
 
-  // Flatten outer dims if necessary
-  auto inputDims = input.dims();
-  if (inputDims.size() > 2) {
-    input = F_.createFlatten("flatten", input, inputDims.size() - 1);
-  }
-
   CHECK(qparamsMap_.count(inputs[QuantizedLinearInputs::packed_weights]));
-  auto packed_params =
-      qparamsMap_[inputs[QuantizedLinearInputs::packed_weights]]
-          .toCustomClass<LinearPackedParamsBase>();
+  auto packedParams = qparamsMap_[inputs[QuantizedLinearInputs::packed_weights]]
+                          .toCustomClass<LinearPackedParamsBase>();
 
   at::Tensor ptWeightTensor;
   c10::optional<at::Tensor> ptBiasTensorTmp;
-  std::tie(ptWeightTensor, ptBiasTensorTmp) = packed_params->unpack();
+  std::tie(ptWeightTensor, ptBiasTensorTmp) = packedParams->unpack();
 
   // unpacked weights
   auto weightTensor = ptTensorToGlowTensor(ptWeightTensor);
@@ -2021,7 +2066,7 @@ Error PyTorchModelLoader::loadQuantizedLinear(const torch::jit::Node *ptNode) {
   weightConstant->ensureIsOwned();
   RETURN_ERR_IF_NOT(weightConstant->dims().size() == 2,
                     "Expected 2d Linear weights");
-  auto weight = weightConstant->getOutput();
+  auto weights = weightConstant->getOutput();
 
   // unpacked bias
   glow::Tensor biasTensor;
@@ -2029,14 +2074,13 @@ Error PyTorchModelLoader::loadQuantizedLinear(const torch::jit::Node *ptNode) {
     auto ptBiasTensor = ptBiasTensorTmp.value().contiguous();
     biasTensor = ptTensorToGlowTensor(ptBiasTensor);
   } else {
-    biasTensor = glow::Tensor(glow::ElemKind::FloatTy, {weight.dims()[0]});
+    biasTensor = glow::Tensor(glow::ElemKind::FloatTy, {weights.dims()[0]});
     biasTensor.zero();
   }
 
   glow::Constant *biasConstant = F_.getParent()->createConstant(
       "quantized_linear_bias", std::move(biasTensor));
   biasConstant->ensureIsOwned();
-  RETURN_ERR_IF_NOT(biasConstant, "quantized::linear bias must be constant");
   auto bias = biasConstant->getOutput();
 
   float outScale;
@@ -2049,43 +2093,20 @@ Error PyTorchModelLoader::loadQuantizedLinear(const torch::jit::Node *ptNode) {
                              iValToInt(getGlowIValueForValue(
                                  inputs[QuantizedLinearInputs::zero_point])));
 
-  auto outTy = F_.getParent()->uniqueType(
-      ElemKind::Int8QTy, {input.dims()[0], weight.dims()[0]}, outScale,
-      outZeroPoint - UINT8_TO_INT8_SHIFT);
-
   bool isRowwiseQuantized = ptWeightTensor.is_quantized() &&
                             ptWeightTensor.qscheme() == at::kPerChannelAffine;
 
-  NodeValue output;
+  NodeValue wScales, wOffsets;
+  if (isRowwiseQuantized) {
+    std::tie(wScales, wOffsets) = extractChannelwiseQParams(F_, ptWeightTensor);
+  }
+
   c10::ScalarType dtype;
   RETURN_IF_ERR(
       getCorrectTypeMapping(dtype, inputs[QuantizedLinearInputs::input]));
 
-  if (isRowwiseQuantized) {
-    NodeValue wScales, wOffsets;
-    std::tie(wScales, wOffsets) = extractChannelwiseQParams(F_, ptWeightTensor);
-    auto rowwiseFC = F_.createRowwiseQuantizedFullyConnected(
-        "rowwise_quantized_fc", input, weightConstant,
-        llvm::dyn_cast<glow::Constant>(wScales),
-        llvm::dyn_cast<glow::Constant>(wOffsets), bias, outTy);
-    output = rowwiseFC->getResult();
-  } else {
-    weight = rescaleUIntToInt(weight);
-
-    weight = F_.createTranspose("weight_transpose", weight, {1, 0});
-    auto fc =
-        F_.createFullyConnected("quantized_fc", input, weight, bias, outTy);
-    output = fc->getResult();
-  }
-
-  // Restore original outer dims
-  if (inputDims.size() > 2) {
-    std::vector<dim_t> finalDims = inputDims.vec();
-    finalDims.back() = output.dims().back();
-    output = F_.createReshape("expand", output, finalDims);
-  }
-
-  RETURN_ERR(addValueMapping(outputs[0], output, dtype));
+  return loadQuantizedLinearImpl(input, weights, bias, wScales, wOffsets,
+                                 outScale, outZeroPoint, outputs[0], dtype);
 }
 
 Error PyTorchModelLoader::loadQuantizedLinearUnpacked(
@@ -2099,21 +2120,12 @@ Error PyTorchModelLoader::loadQuantizedLinearUnpacked(
       input,
       getGlowNodeValueForValue(inputs[QuantizedUnpackedLinearInputs::input]));
 
-  // Flatten outer dims if necessary
-  auto inputDims = input.dims();
-  if (inputDims.size() > 2) {
-    input = F_.createFlatten("flatten", input, inputDims.size() - 1);
-  }
-
-  glow::NodeValue weight;
+  glow::NodeValue weights;
   ASSIGN_VALUE_OR_RETURN_ERR(
-      weight,
+      weights,
       getGlowNodeValueForValue(inputs[QuantizedUnpackedLinearInputs::weight]));
-  weight = rescaleUIntToInt(weight);
-
-  RETURN_ERR_IF_NOT(weight.dims().size() == 2, "Expected 2d Linear weights");
-
-  weight = F_.createTranspose("weight_transpose", weight, {1, 0});
+  weights = rescaleUIntToInt(weights);
+  RETURN_ERR_IF_NOT(weights.dims().size() == 2, "Expected 2d Linear weights");
 
   float outScale;
   ASSIGN_VALUE_OR_RETURN_ERR(
@@ -2125,47 +2137,30 @@ Error PyTorchModelLoader::loadQuantizedLinearUnpacked(
       outZeroPoint, iValToInt(getGlowIValueForValue(
                         inputs[QuantizedUnpackedLinearInputs::zero_point])));
 
-  auto outTy = F_.getParent()->uniqueType(
-      ElemKind::Int8QTy, {input.dims()[0], weight.dims()[1]}, outScale,
-      outZeroPoint - UINT8_TO_INT8_SHIFT);
-
   // Get bias or create a zero bias if no bias is found.
   glow::NodeValue bias = loadNodeValueOrCreateBroadcastedConstant(
       inputs[QuantizedUnpackedLinearInputs::bias], "quantized_linear_bias",
-      glow::Type(ElemKind::FloatTy, {weight.dims()[1]}), 0.0);
+      glow::Type(ElemKind::FloatTy, {weights.dims()[0]}), 0.0);
 
   // Choose bias quantization params and quantize it.
   glow::Constant *biasConstant = llvm::dyn_cast<glow::Constant>(bias.getNode());
 
-  const auto biasHandle = biasConstant->getPayload().getHandle<float>();
-  const auto biasMinMaxIdx = biasHandle.minMaxArg();
-
-  const auto biasQParams = chooseQuantizationParams(
-      {biasHandle.raw(biasMinMaxIdx.first),
-       biasHandle.raw(biasMinMaxIdx.second)},
-      glow::quantization::Schema::Asymmetric, glow::ElemKind::Int32QTy);
-
-  const auto biasType =
-      F_.getParent()->uniqueType(glow::ElemKind::Int32QTy, bias.dims(),
-                                 biasQParams.scale, biasQParams.offset);
-
-  bias = F_.createQuantize("quantize_bias", bias, biasType);
-
-  auto output =
-      F_.createFullyConnected("quantized_fc", input, weight, bias, outTy)
-          ->getResult();
-
-  // Restore original outer dims
-  if (inputDims.size() > 2) {
-    std::vector<dim_t> finalDims = inputDims.vec();
-    finalDims.back() = output.dims().back();
-    output = F_.createReshape("expand", output, finalDims);
-  }
-
   c10::ScalarType dtype;
   RETURN_IF_ERR(getCorrectTypeMapping(
       dtype, inputs[QuantizedUnpackedLinearInputs::input]));
-  RETURN_ERR(addValueMapping(outputs[0], output, dtype));
+
+  auto ptWeightTensor =
+      qparamsMap_.at(inputs[QuantizedUnpackedLinearInputs::weight]).toTensor();
+
+  bool isPerChannelQuantized =
+      ptWeightTensor.is_quantized() &&
+      ptWeightTensor.qscheme() == at::kPerChannelAffine;
+
+  NodeValue wScales, wOffsets;
+  std::tie(wScales, wOffsets) = extractChannelwiseQParams(F_, ptWeightTensor);
+
+  return loadQuantizedLinearImpl(input, weights, bias, wScales, wOffsets,
+                                 outScale, outZeroPoint, outputs[0], dtype);
 }
 
 Error PyTorchModelLoader::loadGlowFusedLinear(const torch::jit::Node *ptNode) {
@@ -6454,6 +6449,7 @@ PyTorchModelLoader::PyTorchModelLoader(
     const at::ArrayRef<torch::jit::IValue> inputs,
     const InputMetaStack &metaStack)
     : F_(F), settings_(settings), inputs_(inputs) {
+  std::cerr << "loading PyTorch graph\n" << graph << std::endl;
   auto loadFn = [&]() -> Error {
     auto graphInputValues = graph.inputs();
 

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -646,6 +646,21 @@ private:
   // \return error on failure.
   Error loadQuantizedConvRelu(const torch::jit::Node *ptNode);
 
+  /// Implementation for loading a linear operator, either packed or unpacked.
+  /// \p input is the node's input, \p weights and \p bias are the linera
+  /// weights and bias. \p wScales and \p wOffsets are the weight tensor's
+  /// qparam tensors in the case of a per_channel quantized linear otherwise
+  /// these are empty. \p outScale and \p outZeroPoint are the node's output
+  /// qparams. \p outputValue is Value to map the output to. \p outputDtype is
+  /// the correct dtype of the output Value.
+  // \return error on failure.
+  Error loadQuantizedLinearImpl(NodeValue input, NodeValue weights,
+                                NodeValue bias, NodeValue wScales,
+                                NodeValue wOffsets, float outScale,
+                                int64_t outZeroPoint,
+                                const torch::jit::Value *outputValue,
+                                c10::ScalarType outputDtype);
+
   /// Load a glow::unpacked_quantized_linear node.
   /// \return error on failure.
   Error loadQuantizedLinearUnpacked(const torch::jit::Node *ptNode);


### PR DESCRIPTION
Summary:
Previously unpacked per_channel quantized Linear was lowered without the weights scales and biases accounted for

* consolidate the linear loading functions
* load per_channel and per_tensor unpacked linears
* don't quantize the bias in the loader, leave this decision to backends
* Interpreter backend was quantizing the bias to int8, change it to int32

Differential Revision: D25786919

