### PR TITLE
Fixes in BatchMatMul implementation for higher dimensions

### DIFF
--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -602,9 +602,10 @@ protected:
     return Error::success();
   }
 
-  static Expected<NodeValue>
-  handleBatchMatMulTranspose(Function *F, ArgumentDictionaryTy &dict,
-                             llvm::StringRef key, NodeValue input) {
+  static Expected<NodeValue> handleMatMulTranspose(Function *F,
+                                                   ArgumentDictionaryTy &dict,
+                                                   llvm::StringRef key,
+                                                   NodeValue input) {
     if (!dict.count(key.str())) {
       return input;
     }
@@ -631,27 +632,128 @@ protected:
     return input;
   }
 
-  Error loadBatchMatMul(const OpType &op, ArgumentDictionaryTy &dict,
-                        bool isBatched) {
+  Error loadMatMul(const OpType &op, ArgumentDictionaryTy &dict) {
     const std::string &opName = loadOperatorName(op);
     NodeValue LHS;
     ASSIGN_VALUE_OR_RETURN_ERR(LHS, getNodeValueByName(op.input(0)));
     NodeValue RHS;
     ASSIGN_VALUE_OR_RETURN_ERR(RHS, getNodeValueByName(op.input(1)));
 
-    ASSIGN_VALUE_OR_RETURN_ERR(
-        LHS, handleBatchMatMulTranspose(G_, dict, "trans_a", LHS));
-    ASSIGN_VALUE_OR_RETURN_ERR(
-        RHS, handleBatchMatMulTranspose(G_, dict, "trans_b", RHS));
+    ASSIGN_VALUE_OR_RETURN_ERR(LHS,
+                               handleMatMulTranspose(G_, dict, "trans_a", LHS));
+    ASSIGN_VALUE_OR_RETURN_ERR(RHS,
+                               handleMatMulTranspose(G_, dict, "trans_b", RHS));
 
-    Node *node = nullptr;
+    Node *node = G_->createMatMul(opName, LHS, RHS);
 
-    // BatchMatMul sometimes is actually just a matmul, depending on dimensions
-    // of inputs. Thus, only do batch matmul if LHS is 3-dimensional.
-    if (isBatched && LHS.dims().size() == 3) {
-      node = G_->createBatchMatMul(opName, LHS, RHS);
-    } else {
-      node = G_->createMatMul(opName, LHS, RHS);
+    RETURN_IF_ERR(addNodeAsOutput(op, node));
+    return Error::success();
+  }
+
+  Error loadBatchMatMul(const OpType &op, ArgumentDictionaryTy &dict) {
+    const std::string &opName = loadOperatorName(op);
+    NodeValue LHS;
+    ASSIGN_VALUE_OR_RETURN_ERR(LHS, getNodeValueByName(op.input(0)));
+    NodeValue RHS;
+    ASSIGN_VALUE_OR_RETURN_ERR(RHS, getNodeValueByName(op.input(1)));
+
+    ASSIGN_VALUE_OR_RETURN_ERR(LHS,
+                               handleMatMulTranspose(G_, dict, "trans_a", LHS));
+    ASSIGN_VALUE_OR_RETURN_ERR(RHS,
+                               handleMatMulTranspose(G_, dict, "trans_b", RHS));
+
+    const size_t numDimsLHS = LHS.dims().size();
+    const size_t numDimsRHS = RHS.dims().size();
+    RETURN_ERR_IF_NOT(
+        numDimsLHS >= 2,
+        opErrMsg(op, "BatchMatMul 1D operands are not yet supported."));
+    RETURN_ERR_IF_NOT(
+        numDimsRHS >= 2,
+        opErrMsg(op, "BatchMatMul 1D operands are not yet supported."));
+
+    // This is a very simple case when we don't need any broadcasting
+    if (numDimsLHS == 2 && numDimsRHS == 2) {
+      Node *node = G_->createMatMul(opName, LHS, RHS);
+      RETURN_IF_ERR(addNodeAsOutput(op, node));
+      return Error::success();
+    }
+
+    // In the rest of the function body we:
+    // 1. normalize operands using broadcasting rules,
+    // 2. convert normalized operands to 3D matrices, so they look like these:
+    //    LHS = {numBatches, N, M}
+    //    RHS = {numBatches, M, P}
+    //    Result = {numBatches, N, P},
+    // 3. multiply 3D matrices using createBatchMatMul(), result will be 3D,
+    // 4. convert the result to the normalized broadcast shape.
+
+    const dim_t N = LHS.dims()[numDimsLHS - 2];
+    const dim_t M = LHS.dims()[numDimsLHS - 1];
+    const dim_t P = RHS.dims()[numDimsRHS - 1];
+
+    RETURN_ERR_IF_NOT(
+        RHS.dims()[numDimsRHS - 2] == M,
+        opErrMsg(op, "BatchMatMul operands dimensions are invalid."));
+
+    // Calculate broadcast shape and convert both operands to that shape
+    const std::vector<dim_t> originalDimsLHS{LHS.dims().begin(),
+                                             LHS.dims().end()};
+    const std::vector<dim_t> originalDimsRHS{RHS.dims().begin(),
+                                             RHS.dims().end()};
+    std::vector<dim_t> resultShape{P, N};
+    resultShape.reserve(std::max(numDimsLHS, numDimsRHS));
+    dim_t numBatches = 1;
+    int indLHS = numDimsLHS - 3; // skip last two dims
+    int indRHS = numDimsRHS - 3; // skip last two dims
+    for (; indLHS >= 0 && indRHS >= 0; --indLHS, --indRHS) {
+      const dim_t dimLHS = originalDimsLHS[indLHS];
+      const dim_t dimRHS = originalDimsRHS[indRHS];
+
+      RETURN_ERR_IF_NOT(
+          (dimLHS == dimRHS || (dimLHS == 1) || dimRHS == 1),
+          opErrMsg(op, "BatchMatMul dimensions cannot be broadcast."));
+      dim_t dim = 1;
+      if (dimLHS == dimRHS) {
+        dim = dimLHS;
+      } else if (dimLHS == 1) {
+        dim = dimRHS;
+        LHS = G_->createTile(opName + ".tileDim", LHS, dim, indLHS);
+      } else {
+        dim = dimLHS;
+        RHS = G_->createTile(opName + ".tileDim", RHS, dim, indRHS);
+      }
+      resultShape.push_back(dim);
+      numBatches *= dim;
+    }
+    for (; indLHS >= 0; --indLHS) {
+      const dim_t dim = originalDimsLHS[indLHS];
+      resultShape.push_back(dim);
+      numBatches *= dim;
+      RHS = G_->createExpandDims(opName + ".addDim", RHS, {0});
+      RHS = G_->createTile(opName + ".tileDim", RHS, dim, 0);
+    }
+    for (; indRHS >= 0; --indRHS) {
+      const dim_t dim = originalDimsRHS[indRHS];
+      resultShape.push_back(dim);
+      numBatches *= dim;
+      LHS = G_->createExpandDims(opName + ".addDim", LHS, {0});
+      LHS = G_->createTile(opName + ".tileDim", LHS, dim, 0);
+    }
+    std::reverse(resultShape.begin(), resultShape.end());
+
+    // Broadcast shape might have more than 3 dims,
+    // therefore, optionally, reshape the operands
+    if (resultShape.size() > 3) {
+      LHS =
+          G_->createReshape(opName + ".reshapeLHS3D", LHS, {numBatches, N, M});
+      RHS =
+          G_->createReshape(opName + ".reshapeRHS3D", RHS, {numBatches, M, P});
+    }
+    Node *node = G_->createBatchMatMul(opName, LHS, RHS);
+
+    // Optionally, reshape result to broadcast shape
+    if (resultShape.size() != 3) {
+      node = G_->createReshape(opName + ".reshapeResult", node, resultShape);
     }
 
     RETURN_IF_ERR(addNodeAsOutput(op, node));
@@ -1512,7 +1614,7 @@ protected:
       return true;
     }
     if (typeName == "BatchMatMul") {
-      RETURN_IF_ERR(loadBatchMatMul(op, dict, true));
+      RETURN_IF_ERR(loadBatchMatMul(op, dict));
       return true;
     }
     if (typeName == "BatchOneHot") {

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -937,8 +937,12 @@ bool MatMulNode::verify() const {
   auto LDims = lhs.dims();
   auto RDims = rhs.dims();
   auto DDims = dest.dims();
-  bool isValid = expectCompareTrue("Invalid MatMul dimensions", size_t(2),
-                                   DDims.size(), this);
+  bool isValid = expectCompareTrue("LHS input must be 2 dimensional.",
+                                   LDims.size(), size_t(2), this);
+  isValid &= expectCompareTrue("RHS input must be 2 dimensional.", RDims.size(),
+                               size_t(2), this);
+  isValid &= expectCompareTrue("Invalid MatMul dimensions", DDims.size(),
+                               size_t(2), this);
 
   auto elem = dest.getType()->getElementType();
   isValid &= checkType(lhs, elem, this);

--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -1377,7 +1377,7 @@ Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
   }
 
   if (typeName == "MatMul") {
-    RETURN_IF_ERR(loadBatchMatMul(op, dict, false));
+    RETURN_IF_ERR(loadMatMul(op, dict));
     return Error::success();
   }
 

--- a/tests/models/caffe2Models/batched_matmul.pbtxt
+++ b/tests/models/caffe2Models/batched_matmul.pbtxt
@@ -1,0 +1,11 @@
+name: "batched_matmul"
+op {
+  input: "lhs"
+  input: "rhs"
+  output: "result"
+  name: ""
+  type: "BatchMatMul"
+}
+external_input: "lhs"
+external_input: "rhs"
+external_output: "result"


### PR DESCRIPTION
Summary:
Turns out for Caffe2 models `BatchMatMul` operator didn't work properly for inputs with
more than 3 dimensions. This diff fixes the behavior and makes it on par with Caffe2 and NumPy.

Reviewed By: yinghai

Differential Revision: D25685833

