### PR TITLE
adding option to write onnx files to tmp dir

### DIFF
--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -125,6 +125,10 @@ public:
   /// Whether or not to use zip mode when writing graphs to ONNX files
   bool onnxZipMode = false;
 
+  /// Whether or not to write onnx files to /tmp/ directory.
+  /// Must be true in twshared hosts.
+  bool writeOnnxToTmp = false;
+
   /// Whether or not to do a numerical comparions of Glow and jit outputs
   bool jitVsGlowCompare = false;
 
@@ -246,6 +250,9 @@ void enableSignalHandlerOverrides(bool enable = true);
 
 /// \returns whether or not signal handler overriding is enabled.
 bool signalHandlerOverridesEnabled();
+
+Expected<std::string> getTempFileLoc(const std::string &name,
+                                     const std::string &suffix);
 
 } // namespace glow
 


### PR DESCRIPTION
Summary: In PyTorchModelLoader, adding support and a corresponding gflag to write onnx files to /tmp/ directory.

Reviewed By: jackm321

Differential Revision: D25813698

