### PR TITLE
Add prim versions of aten::to operator in AI Compiler (Glow)

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -818,6 +818,36 @@ struct ToOtherInputs {
   };
 };
 
+/// Indexes of aten::to.prim_other inputs.
+struct ToPrimOtherInputs {
+  enum {
+    input = 0,
+    non_blocking,
+    copy,
+  };
+};
+
+/// Indexes of aten::to.prim_other inputs.
+struct ToPrimDtypeInputs {
+  enum {
+    input = 0,
+    dtype,
+    non_blocking,
+    copy,
+  };
+};
+
+/// Indexes of aten::to.prim_other inputs.
+struct ToPrimDeviceInputs {
+  enum {
+    input = 0,
+    device,
+    dtype,
+    non_blocking,
+    copy,
+  };
+};
+
 /// Indexes of aten::to.dtype inputs.
 struct ToDtypeInputs {
   enum {
@@ -826,18 +856,6 @@ struct ToDtypeInputs {
     non_blocking,
     copy,
     memory_format,
-  };
-};
-
-/// Indexes of aten::to inputs.
-struct ToWithDeviceInputs {
-  enum {
-    input = 0,
-    device, // Not used
-    dtype,
-    non_block,     // Not used
-    copy,          // Not used
-    memory_format, // Not used
   };
 };
 
@@ -5341,7 +5359,7 @@ Error PyTorchModelLoader::loadTo(const torch::jit::Node *ptNode) {
   else if (inputs.size() == 6 && outputs.size() == 1) {
     dtype_arg = ToDeviceInputs::dtype;
   }
-  // There are two alternatives with 5 inputs:
+  // There are three alternatives with 5 inputs:
   else if (inputs.size() == 5 && outputs.size() == 1) {
     auto glowVal = getGlowIValueForValue(inputs[ToOtherInputs::other]);
     if (glowVal) {
@@ -5349,6 +5367,22 @@ Error PyTorchModelLoader::loadTo(const torch::jit::Node *ptNode) {
       //            bool copy=False, MemoryFormat? memory_format=None)
       if ((*glowVal)->isTensor()) {
         return MAKE_ERR("aten::to.other is not supported.");
+      }
+      // - to.prim_device(Tensor self, Device device, ScalarType? dtype=None,
+      //                  bool non_blocking=False, bool copy=False)
+      else if ((*glowVal)->isString()) {
+        auto glowDtypeVal =
+            getGlowIValueForValue(inputs[ToPrimDeviceInputs::dtype]);
+        // Check if the dtype is set, otherwise nop (device is "cpu")
+        if (glowDtypeVal) {
+          if ((*glowDtypeVal)->isNone()) {
+            RETURN_ERR(addValueMapping(outputs[0], input));
+          }
+        } else {
+          RETURN_ERR(glowVal.takeError());
+        }
+        dtype_arg = ToPrimDeviceInputs::dtype;
+        return MAKE_ERR("aten::to.prim_device is not supported.");
       }
       // - to.dtype(Tensor self, ScalarType dtype, bool non_blocking=False,
       //            bool copy=False, MemoryFormat? memory_format=None)
@@ -5358,6 +5392,17 @@ Error PyTorchModelLoader::loadTo(const torch::jit::Node *ptNode) {
     } else {
       RETURN_ERR(glowVal.takeError());
     }
+  }
+  // The 4 arguments version is similary to to.dtype, without a memory format
+  // - to.prim_dtype(Tensor self, ScalarType dtype,
+  //                 bool non_blocking=False, bool copy=False)
+  else if (inputs.size() == 4 && outputs.size() == 1) {
+    dtype_arg = ToPrimDtypeInputs::dtype;
+  }
+  // The 3 arguments version only uses unsupported non_blocking/copy flags
+  // - to.prim_other(Tensor self, bool non_blocking=False, bool copy=False)
+  else if (inputs.size() == 3 && outputs.size() == 1) {
+    return MAKE_ERR("aten::to.prim_other is not supported.");
   }
   // Unsupported number of input/output arguments
   else {

--- a/torch_glow/tests/nodes/to_test.py
+++ b/torch_glow/tests/nodes/to_test.py
@@ -29,6 +29,25 @@ class ToWithDeviceModel(torch.nn.Module):
         return tensor
 
 
+class SimplePrimToModel(torch.nn.Module):
+    def __init__(self, conversion, device=None):
+        super().__init__()
+        self.device = None
+        self.conversion = conversion
+        if self.device is None:
+            self.forward = self._forward_dtype
+        else:
+            self.forward = self._forward_device_dtype
+
+    def _forward_device_dtype(self, dummy):
+        return torch.ops.prim.NumToTensor(dummy.size(0)).to(
+            device=self.device, dtype=self.conversion
+        )
+
+    def _forward_dtype(self, dummy):
+        return torch.ops.prim.NumToTensor(dummy.size(0)).to(self.conversion)
+
+
 class TestTo(unittest.TestCase):
     @parameterized.expand(
         [
@@ -54,3 +73,24 @@ class TestTo(unittest.TestCase):
     )
     def test_to(self, _, module, tensor):
         utils.compare_tracing_methods(module, tensor, fusible_ops={"aten::to"})
+
+    @parameterized.expand(
+        [
+            ("to_prim_dtype", SimplePrimToModel(torch.float), torch.randn(5, 6, 7)),
+            # The following test is not yet supported:
+            # ("to_prim_device", SimplePrimToModel("cpu"), torch.randn(5, 6, 7)),
+            (
+                "to_prim_device_with_dtype",
+                SimplePrimToModel(torch.float, "cpu"),
+                torch.randn(5, 6, 7),
+            ),
+        ]
+    )
+    def test_to_prim(self, _, module, tensor):
+        utils.compare_tracing_methods(
+            module,
+            tensor,
+            fusible_ops={"prim::NumToTensor"},
+            scripted=True,
+            skip_to_glow=True,
+        )


### PR DESCRIPTION
Summary:
Support for the prim versions of the aten::to operator were missing in Glow:

  - `to.prim_device(Tensor self, Device device, ScalarType dtype, bool non_blocking=False, bool copy=False)`
  - `to.prim_dtype(Tensor self, ScalarType dtype? = None, bool non_blocking=False, bool copy=False)`
  - `to.prim_other(Tensor self, bool non_blocking=False, bool copy=False)`

Due to a current limitation, the `dtype` argument of `to.prime_dtype` cannot be None.

Differential Revision: D25815077

