### PR TITLE
[torch_glow] Add support for repeat op

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -1024,6 +1024,14 @@ struct CompareInputs {
   };
 };
 
+/// Indexes used for aten::repeat inputs
+struct RepeatInputs {
+  enum {
+    input = 0,
+    repeats,
+  };
+};
+
 } // namespace
 
 // static
@@ -1118,6 +1126,7 @@ PyTorchModelLoader::buildSymbolsMapping() {
       {{"aten::adaptive_avg_pool2d"},
        &PyTorchModelLoader::loadAdaptiveAvgPool2d},
       {{"aten::reshape"}, &PyTorchModelLoader::loadReshape},
+      {{"aten::repeat"}, &PyTorchModelLoader::loadRepeat},
       {{"aten::abs"}, &PyTorchModelLoader::loadAbs},
       {{"aten::upsample_nearest3d"}, &PyTorchModelLoader::loadUpsampleNearest},
       {{"aten::upsample_nearest2d"}, &PyTorchModelLoader::loadUpsampleNearest},
@@ -3314,6 +3323,46 @@ Error PyTorchModelLoader::loadReshape(const torch::jit::Node *ptNode) {
   RETURN_ERR(addValueMapping(
       outputs[0], F_.createReshape("reshape", input, castVector<dim_t>(shape)),
       dtype));
+}
+
+Error PyTorchModelLoader::loadRepeat(const torch::jit::Node *ptNode) {
+  auto inputs = ptNode->inputs();
+  auto outputs = ptNode->outputs();
+  RETURN_IF_ERR(checkInputAndOutputSizes(inputs, 2, outputs, 1));
+
+  glow::NodeValue input;
+  ASSIGN_VALUE_OR_RETURN_ERR(
+      input, getGlowNodeValueForValue(inputs[RepeatInputs::input]));
+
+  std::vector<int64_t> *repeats;
+  ASSIGN_VALUE_OR_RETURN_ERR(repeats, iValToIntList(getGlowIValueForValue(
+                                          inputs[RepeatInputs::repeats])));
+  RETURN_ERR_IF_NOT(repeats->size() >= input.dims().size(),
+                    "The rank of the input tensor must be greater than or "
+                    "equal to the size of repeats vector for aten::repeat");
+
+  const bool needsExpand = input.dims().size() < repeats->size();
+  glow::ReshapeNode *reshapeNode = nullptr;
+  if (needsExpand) {
+    const auto diff = repeats->size() - input.dims().size();
+    std::vector<dim_t> newDims;
+    for (size_t i = 0; i < diff; ++i) {
+      newDims.push_back(1);
+    }
+    newDims.insert(newDims.end(), input.dims().begin(), input.dims().end());
+    reshapeNode = F_.createReshape("reshape", input, newDims);
+  }
+
+  Node *node = needsExpand ? reshapeNode : input;
+  for (size_t i = 0; i < repeats->size(); ++i) {
+    const auto repeat = (*repeats)[i];
+    RETURN_ERR_IF_NOT(
+        repeat > 0,
+        "The value of repeat must be greater than 0 for aten::repeat");
+    node = F_.createTile("tile." + std::to_string(i), node, repeat, i);
+  }
+
+  RETURN_ERR(addValueMapping(outputs[0], node));
 }
 
 Error PyTorchModelLoader::loadUpsampleNearest(const torch::jit::Node *ptNode) {

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -777,6 +777,10 @@ private:
   /// \returns error on failure.
   Error loadReshape(const torch::jit::Node *ptNode);
 
+  /// Load a PyTorch aten::repeat node.
+  /// \returns error on failure.
+  Error loadRepeat(const torch::jit::Node *ptNode);
+
   /// Load a PyTorch aten::cos node.
   /// \returns error on failure.
   Error loadCos(const torch::jit::Node *ptNode);

--- a/torch_glow/tests/nodes/repeat_test.py
+++ b/torch_glow/tests/nodes/repeat_test.py
@@ -1,0 +1,35 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+
+import torch
+from parameterized import parameterized
+from tests import utils
+
+
+class RepeatModule(torch.nn.Module):
+    def __init__(self, repeats):
+        super(RepeatModule, self).__init__()
+        self.repeats = repeats
+
+    def forward(self, tensor):
+        tensor = tensor + tensor
+        return tensor.repeat(self.repeats)
+
+
+class TestRepeat(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("basic", RepeatModule([4]), torch.randn(3)),
+            ("basic", RepeatModule([3, 5]), torch.randn(3)),
+            ("basic", RepeatModule([4, 3, 5]), torch.tensor(3)),
+            ("2d", RepeatModule([4, 2]), torch.randn(5, 1)),
+            ("2d", RepeatModule([4, 2, 6]), torch.randn(4, 3)),
+            ("3d", RepeatModule([4, 4, 2]), torch.randn(6, 3, 4)),
+            ("3d", RepeatModule([3, 1, 1]), torch.randn(3, 3, 4)),
+            ("3d", RepeatModule([1, 5, 1]), torch.randn(5, 3, 4)),
+            ("3d", RepeatModule([4, 2, 1, 5, 2, 10]), torch.randn(6, 3, 4)),
+        ]
+    )
+    def test_repeat(self, _, module, tensor):
+        utils.compare_tracing_methods(module, tensor, fusible_ops={"aten::repeat"})


### PR DESCRIPTION
This PR adds support for the aten::repeat op in PyTorchModelLoader.