### PR TITLE
[torch_glow] Add support for maxpool2d _with_indices

### DIFF
--- a/include/glow/Backends/LayoutConverter.h
+++ b/include/glow/Backends/LayoutConverter.h
@@ -84,7 +84,8 @@ inline std::pair<Node *, Node *> convertMaxPoolToNCHWPool(MaxPoolNode *PN,
                                                     dimsNCHW);
 
   auto *MPN = new MaxPoolNode(PN->getName(), outTy, AMT, NI, PN->getKernels(),
-                              PN->getStrides(), PN->getPads(), NCHW);
+                              PN->getStrides(), PN->getPads(), NCHW,
+                              PN->getFlattenIndices());
   F->addNode(MPN);
   auto *NR = F->createTranspose("maxpool.result", MPN->getResult(), NCHW2NHWC);
   auto *NA = F->createTranspose("maxpool.argmax", MPN->getArgmax(), NCHW2NHWC);
@@ -109,7 +110,7 @@ inline Node *convertMaxPoolGradToNCHWPool(MaxPoolGradNode *PGN, Function *F) {
 
   auto *NPGN = F->addNode(new MaxPoolGradNode(
       PGN->getName(), NI, NOR, NGR, NOA, NGA, PGN->getKernels(),
-      PGN->getStrides(), PGN->getPads(), NCHW));
+      PGN->getStrides(), PGN->getPads(), NCHW, PGN->getFlattenIndices()));
   auto *NR = F->createTranspose("maxpoolgrad.result",
                                 NPGN->getGradOfInputNamedInput(), NCHW2NHWC);
 

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -590,13 +590,15 @@ public:
                              llvm::ArrayRef<unsigned_t> strides,
                              llvm::ArrayRef<unsigned_t> pads,
                              ElemKind elemTyAMT = ElemKind::Int64ITy,
-                             ConvolutionLayout layout = NHWC);
+                             ConvolutionLayout layout = NHWC,
+                             bool flattenIndices = true);
 
   MaxPoolNode *createMaxPool(llvm::StringRef name, NodeValue input,
                              unsigned_t kernel, unsigned_t stride,
                              unsigned_t pad,
                              ElemKind elemTyAMT = ElemKind::Int64ITy,
-                             ConvolutionLayout layout = NHWC);
+                             ConvolutionLayout layout = NHWC,
+                             bool flattenIndices = true);
 
   AvgPoolNode *createAvgPool(llvm::StringRef name, NodeValue input,
                              llvm::ArrayRef<unsigned_t> kernels,

--- a/include/glow/IR/IRBuilder.h
+++ b/include/glow/IR/IRBuilder.h
@@ -55,7 +55,7 @@ public:
   MaxPoolWithArgmaxInst *createMaxPoolWithArgmaxOp(
       llvm::StringRef name, Value *input, llvm::ArrayRef<unsigned_t> kernels,
       llvm::ArrayRef<unsigned_t> strides, llvm::ArrayRef<unsigned_t> pads,
-      unsigned_t layout, ElemKind argMaxIndicesTy);
+      unsigned_t layout, ElemKind argMaxIndicesTy, bool flattenIndices = true);
 
   ArgMaxInst *createArgMaxOp(llvm::StringRef name, Value *input,
                              unsigned_t axis, bool keepDims,

--- a/lib/Backends/CPU/tests/CPUOperatorTest.cpp
+++ b/lib/Backends/CPU/tests/CPUOperatorTest.cpp
@@ -426,4 +426,6 @@ std::set<std::string> glow::backendTestBlacklist = {
     "batchedReduceAdd_Int32ITy/0",
     "Float16ArgMaxKeepDim/0",
     "Float16ArgMaxNoKeepDim/0",
+    "NonFlattenedIndicesMaxPoolWithArgmaxTransposed/0",
+    "NonFlattenedIndicesQuantizedMaxPoolWithArgmaxTransposed/0",
 };

--- a/lib/Backends/Habana/tests/HabanaOperatorTest.cpp
+++ b/lib/Backends/Habana/tests/HabanaOperatorTest.cpp
@@ -466,4 +466,6 @@ std::set<std::string> glow::backendTestBlacklist = {
     "Upsample_Nearest1D_Float16/0",
     "Upsample_Nearest1D_Int8/0",
     "batchedReduceAdd_Int32ITy/0",
+    "NonFlattenedIndicesMaxPoolWithArgmaxTransposed/0",
+    "NonFlattenedIndicesQuantizedMaxPoolWithArgmaxTransposed/0",
 };

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -1246,7 +1246,7 @@ template <class T>
 static void fwdMaxPool(Tensor *inW, Tensor *outW, Tensor *argmaxW,
                        llvm::ArrayRef<unsigned_t> kernelSizes,
                        llvm::ArrayRef<unsigned_t> strides,
-                       llvm::ArrayRef<unsigned_t> pads) {
+                       llvm::ArrayRef<unsigned_t> pads, bool flattenIndices) {
   ShapeNHWC odim(outW->dims());
   ShapeNHWC idim(inW->dims());
   Handle<T> inHandle = inW->getHandle<T>();
@@ -1294,8 +1294,14 @@ static void fwdMaxPool(Tensor *inW, Tensor *outW, Tensor *argmaxW,
                 first = false;
                 max_value = val;
                 if (argmaxW) {
-                  argmaxNHWC = &inHandle.at({n, (dim_t)ox, (dim_t)oy, z}) -
-                               &inHandle.raw(0);
+                  if (flattenIndices) {
+                    argmaxNHWC = &inHandle.at({n, (dim_t)ox, (dim_t)oy, z}) -
+                                 &inHandle.raw(0);
+                  } else {
+                    argmaxNHWC = &inHandle.at({n, (dim_t)ox, (dim_t)oy, z}) -
+                                 &inHandle.at({n, 0, 0, z});
+                    argmaxNHWC /= idim.c;
+                  }
                 }
               }
             }
@@ -1319,13 +1325,13 @@ void BoundInterpreterFunction::fwdMaxPoolInst(const MaxPoolInst *I) {
   if (inW->getType().isQuantizedType()) {
     dispatchQuantizedImpl(fwdMaxPool, inW->getType().getElementType(), inW,
                           outW, nullptr, I->getKernels(), I->getStrides(),
-                          I->getPads());
+                          I->getPads(), true);
     return;
   }
 
   dispatchFloatingPointImpl(fwdMaxPool, inW->getType().getElementType(), inW,
                             outW, nullptr, I->getKernels(), I->getStrides(),
-                            I->getPads());
+                            I->getPads(), true);
 }
 
 void BoundInterpreterFunction::fwdMaxPoolWithArgmaxInst(
@@ -1337,12 +1343,12 @@ void BoundInterpreterFunction::fwdMaxPoolWithArgmaxInst(
   if (inW->getType().isQuantizedType()) {
     dispatchQuantizedImpl(fwdMaxPool, inW->getType().getElementType(), inW,
                           outW, argmaxW, I->getKernels(), I->getStrides(),
-                          I->getPads());
+                          I->getPads(), I->getFlattenIndices());
     return;
   }
   dispatchFloatingPointImpl(fwdMaxPool, inW->getType().getElementType(), inW,
                             outW, argmaxW, I->getKernels(), I->getStrides(),
-                            I->getPads());
+                            I->getPads(), I->getFlattenIndices());
 }
 
 template <typename ElemTy>

--- a/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
@@ -559,6 +559,10 @@ struct BlacklistInitializer {
       {"Erf_FloatTy/0", TestBlacklist::AnyDeviceAnyEngine},
       {"Erf_Int8QTy/0", TestBlacklist::AnyDeviceAnyEngine},
       {"batchedReduceAdd_Int32ITy/0", TestBlacklist::AnyDeviceAnyEngine},
+      {"NonFlattenedIndicesMaxPoolWithArgmaxTransposed/0",
+       TestBlacklist::AnyDeviceAnyEngine},
+      {"NonFlattenedIndicesQuantizedMaxPoolWithArgmaxTransposed/0",
+       TestBlacklist::AnyDeviceAnyEngine},
     };
     TestBlacklist::prepareBlacklist(testBlacklistedSetups,
                                     backendTestBlacklist);

--- a/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
@@ -658,4 +658,6 @@ std::set<std::string> glow::backendTestBlacklist = {
     "Upsample_Nearest1D_Float16/0",
     "Upsample_Nearest1D_Int8/0",
     "batchedReduceAdd_Int32ITy/0",
+    "NonFlattenedIndicesMaxPoolWithArgmaxTransposed/0",
+    "NonFlattenedIndicesQuantizedMaxPoolWithArgmaxTransposed/0",
 };

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -937,12 +937,10 @@ ConvTransposeNode *Function::createConvTranspose(
                              pads, group, dilation);
 }
 
-MaxPoolNode *Function::createMaxPool(llvm::StringRef name, NodeValue input,
-                                     llvm::ArrayRef<unsigned_t> kernels,
-                                     llvm::ArrayRef<unsigned_t> strides,
-                                     llvm::ArrayRef<unsigned_t> pads,
-                                     ElemKind elemTyAMT,
-                                     ConvolutionLayout layout) {
+MaxPoolNode *Function::createMaxPool(
+    llvm::StringRef name, NodeValue input, llvm::ArrayRef<unsigned_t> kernels,
+    llvm::ArrayRef<unsigned_t> strides, llvm::ArrayRef<unsigned_t> pads,
+    ElemKind elemTyAMT, ConvolutionLayout layout, bool flattenIndices) {
   ShapeNHWC idim = ShapeNHWC(input.dims());
   checkKernelSize(idim, kernels, pads);
 
@@ -953,18 +951,20 @@ MaxPoolNode *Function::createMaxPool(llvm::StringRef name, NodeValue input,
   auto AMT = getParent()->uniqueType(
       elemTyAMT, {idim.n, outSz.first, outSz.second, idim.c});
 
-  return addNode(
-      new MaxPoolNode(name, OT, AMT, input, kernels, strides, pads, layout));
+  return addNode(new MaxPoolNode(name, OT, AMT, input, kernels, strides, pads,
+                                 layout, flattenIndices));
 }
 
 MaxPoolNode *Function::createMaxPool(llvm::StringRef name, NodeValue input,
                                      unsigned_t kernel, unsigned_t stride,
                                      unsigned_t pad, ElemKind elemTyAMT,
-                                     ConvolutionLayout layout) {
+                                     ConvolutionLayout layout,
+                                     bool flattenIndices) {
   llvm::SmallVector<unsigned_t, 4> pads = {pad, pad, pad, pad};
   llvm::SmallVector<unsigned_t, 2> strides = {stride, stride};
   llvm::SmallVector<unsigned_t, 2> kernels = {kernel, kernel};
-  return createMaxPool(name, input, kernels, strides, pads, elemTyAMT, layout);
+  return createMaxPool(name, input, kernels, strides, pads, elemTyAMT, layout,
+                       flattenIndices);
 }
 
 AvgPoolNode *Function::createAvgPool(llvm::StringRef name, NodeValue input,

--- a/lib/IR/IRBuilder.cpp
+++ b/lib/IR/IRBuilder.cpp
@@ -58,7 +58,7 @@ void IRBuilder::deallocateActiveInstrs() {
 MaxPoolWithArgmaxInst *IRBuilder::createMaxPoolWithArgmaxOp(
     llvm::StringRef name, Value *input, llvm::ArrayRef<unsigned_t> kernels,
     llvm::ArrayRef<unsigned_t> strides, llvm::ArrayRef<unsigned_t> pads,
-    unsigned_t layout, ElemKind argMaxIndicesTy) {
+    unsigned_t layout, ElemKind argMaxIndicesTy, bool flattenIndices) {
   TypeRef outTy{nullptr};
   Value *argmax{nullptr};
 
@@ -93,7 +93,7 @@ MaxPoolWithArgmaxInst *IRBuilder::createMaxPoolWithArgmaxOp(
   Value *dest = createAllocActivationInst(name.str() + ".res", outTy);
 
   return createMaxPoolWithArgmaxInst(name, dest, input, argmax, kernels,
-                                     strides, pads, layout);
+                                     strides, pads, layout, flattenIndices);
 }
 
 ArgMaxInst *IRBuilder::createArgMaxOp(llvm::StringRef name, Value *input,

--- a/lib/IR/IRGen.cpp
+++ b/lib/IR/IRGen.cpp
@@ -157,7 +157,7 @@ void IRGenVisitor::post(Node *parent, Node *N) {
     auto argMax = P->getArgmax();
     auto *V = builder_.createMaxPoolWithArgmaxOp(
         N->getName(), in, P->getKernels(), P->getStrides(), P->getPads(),
-        P->getLayout(), argMax.getElementType());
+        P->getLayout(), argMax.getElementType(), P->getFlattenIndices());
     Value *dest = V->getDest();
     Value *argmax = V->getArgmax();
     nodeToInstr_[N] = V;
@@ -183,7 +183,8 @@ void IRGenVisitor::post(Node *parent, Node *N) {
 
     builder_.createMaxPoolWithArgmaxGradInst(
         N->getName(), outW, inW, PI->getArgmax(), outG, inG, PG->getKernels(),
-        PG->getStrides(), PG->getPads(), PG->getLayout());
+        PG->getStrides(), PG->getPads(), PG->getLayout(),
+        PG->getFlattenIndices());
     registerIR(PG->getGradOfInputNamedInput(), inG);
     break;
   }

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -166,6 +166,7 @@ int main(int argc, char **argv) {
       .addMember(MemberType::VectorUnsigned, "Strides")
       .addMember(MemberType::VectorUnsigned, "Pads")
       .addMember(MemberType::Unsigned, "Layout")
+      .addMember(MemberType::Boolean, "FlattenIndices")
       .autoVerify(VerifyKind::SameElementType, {"Dest", "Src"})
       .addGradientInstr({"Dest", "Src", "Argmax"}, {"Dest", "Src"});
 

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -158,6 +158,7 @@ int main(int argc, char **argv) {
       .addMember(MemberType::VectorUnsigned, "Strides")
       .addMember(MemberType::VectorUnsigned, "Pads", /* addSetter */ true)
       .addMember(MemberType::Enum, "Layout")
+      .addMember(MemberType::Boolean, "FlattenIndices")
       .addResultFromCtorArg("Result")
       .addResultFromCtorArg("Argmax")
       .addGradient()
@@ -165,7 +166,11 @@ int main(int argc, char **argv) {
           "Performs a Max Pool with Argmax operation on the Input "
           "given provided Kernels, Strides, and Pads. Argmax is a flattened "
           "index corresponding to respective max element. Supported layouts "
-          "are defined in the ConvolutionLayout enum: NHWC and NCHW.");
+          "are defined in the ConvolutionLayout enum: NHWC and NCHW. If "
+          "FlattenIndices is set to true, the returned indices are flattened "
+          "and are relative to the whole tensor (similar to ONNX). If it is "
+          "set to false, the returned indices are relative to the H and W "
+          "dimensions (similar ot pytorch).");
 
   BB.newNode("ArgMax")
       .addInput("Input")

--- a/torch_glow/tests/nodes/max_pool2d_with_indices_test.py
+++ b/torch_glow/tests/nodes/max_pool2d_with_indices_test.py
@@ -1,0 +1,35 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+
+import torch
+import torch.nn.functional as F
+from tests import utils
+
+
+class SimpleMaxPool2dTest(torch.nn.Module):
+    def __init__(self, kernel_size, padding=0):
+        super(SimpleMaxPool2dTest, self).__init__()
+        self.kernel_size = kernel_size
+        self.padding = padding
+
+    def forward(self, inputs):
+        return F.max_pool2d_with_indices(
+            inputs, kernel_size=self.kernel_size, padding=self.padding
+        )
+
+
+class TestMaxPool2dWithIndices(unittest.TestCase):
+    def test_max_pool2d_with_indices_basic(self):
+        utils.compare_tracing_methods(
+            SimpleMaxPool2dTest(3),
+            torch.randn(20, 16, 50, 32),
+            fusible_ops={"aten::max_pool2d_with_indices"},
+        )
+
+    def test_max_pool2d_with_with_indices_pad(self):
+        utils.compare_tracing_methods(
+            SimpleMaxPool2dTest(7, 3),
+            torch.randn(1, 4, 10, 10),
+            fusible_ops={"aten::max_pool2d_with_indices"},
+        )


### PR DESCRIPTION
This PR adds support for the aten::max_pool2d_with_indices op in PyTorchModelLoader.

Note: This PR is on top of https://github.com/pytorch/glow/pull/5127