### PR TITLE
[torch_glow] Add support for int inputs to aten::clamp

### DIFF
--- a/torch_glow/tests/nodes/clamp_test.py
+++ b/torch_glow/tests/nodes/clamp_test.py
@@ -8,26 +8,53 @@ from tests import utils
 
 
 class SimpleClampModel(torch.nn.Module):
-    def __init__(self, min, max):
+    def __init__(self, min, max, inplace=False):
         super(SimpleClampModel, self).__init__()
         self.min = min
         self.max = max
+        self.inplace = inplace
 
     def forward(self, input):
-        return torch.clamp(input, self.min, self.max)
+        if self.inplace:
+            return input.clamp_(min=self.min, max=self.max)
+        else:
+            return torch.clamp(input, self.min, self.max)
 
 
 class TestClamp(unittest.TestCase):
     @parameterized.expand(
         [
-            ("basic", 0.0, 0.8),
-            ("no_min", None, 0.8),
-            ("no_max", 0.0, None),
+            ("basic", SimpleClampModel(0.0, 0.8), torch.randn(7), {"aten::clamp"}),
+            ("no_min", SimpleClampModel(None, 0.8), torch.randn(7), {"aten::clamp"}),
+            ("no_max", SimpleClampModel(0.0, None), torch.randn(7), {"aten::clamp"}),
+            (
+                "inplace",
+                SimpleClampModel(0.1, 0.6, inplace=True),
+                torch.randn(7),
+                {"aten::clamp_"},
+            ),
+            ("int", SimpleClampModel(0, 2), torch.arange(7), {"aten::clamp"}),
+            (
+                "int_inplace",
+                SimpleClampModel(0, 2, inplace=True),
+                torch.arange(7),
+                {"aten::clamp_"},
+            ),
+            (
+                "int_no_min",
+                SimpleClampModel(None, 1),
+                torch.arange(7),
+                {"aten::clamp"},
+            ),
+            (
+                "int_no_max",
+                SimpleClampModel(0, None),
+                torch.arange(7),
+                {"aten::clamp"},
+            ),
         ]
     )
-    def test_clamp(self, _, min, max):
+    def test_clamp(self, _, model, tensor, fusible):
         """Test of the PyTorch clamp Node on Glow."""
 
-        utils.compare_tracing_methods(
-            SimpleClampModel(min, max), torch.randn(7), fusible_ops={"aten::clamp"}
-        )
+        utils.compare_tracing_methods(model, tensor, fusible_ops=fusible)


### PR DESCRIPTION
Currently clamp assumes that inputs are always float and the min and max values are float too. This patch enables int inputs as per pytorch docs:

> If input is of type FloatTensor or DoubleTensor, args min and max must be real numbers, otherwise they should be integers.