### PR TITLE
[torch_glow] Add support for zeros_like, ones_like and ones

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -1038,7 +1038,10 @@ PyTorchModelLoader::buildSymbolsMapping() {
       {{"prim::NumToTensor"}, &PyTorchModelLoader::loadNumToTensor},
       {{"aten::Int"}, &PyTorchModelLoader::loadInt},
       {{"aten::arange"}, &PyTorchModelLoader::loadArange},
-      {{"aten::zeros"}, &PyTorchModelLoader::loadZeros},
+      {{"aten::zeros"}, &PyTorchModelLoader::loadZerosOrOnes<0>},
+      {{"aten::ones"}, &PyTorchModelLoader::loadZerosOrOnes<1>},
+      {{"aten::zeros_like"}, &PyTorchModelLoader::loadZerosOrOnesLike<0>},
+      {{"aten::ones_like"}, &PyTorchModelLoader::loadZerosOrOnesLike<1>},
       {{"aten::mul", "aten::mul_"}, &PyTorchModelLoader::loadMul},
       {{"aten::div", "aten::div_"}, &PyTorchModelLoader::loadDiv},
       {{"aten::floor_divide", "aten::floor_divide_"},
@@ -3159,7 +3162,25 @@ Error PyTorchModelLoader::loadInt(const torch::jit::Node *ptNode) {
   RETURN_ERR(addValueMapping(outputs[0], std::move(glowIVal)));
 }
 
-Error PyTorchModelLoader::loadZeros(const torch::jit::Node *ptNode) {
+Error PyTorchModelLoader::loadZerosOrOnesHelper(
+    const torch::jit::Node *ptNode,
+    c10::ArrayRef<const torch::jit::Value *> outputs,
+    llvm::ArrayRef<glow::dim_t> inputDims, float splatValue) {
+  int32_t dtype;
+  ASSIGN_VALUE_OR_RETURN_ERR(
+      dtype, iValToInt(getGlowIValueForValue(ptNode->namedInput("dtype"))));
+  auto glowElemKind = scalarTypeToElemKind(static_cast<c10::ScalarType>(dtype));
+
+  auto output =
+      F_.createSplat(splatValue == 1 ? "ones" : "zeros",
+                     F_.getParent()->uniqueType(glowElemKind, inputDims),
+                     splatValue)
+          ->getResult();
+  RETURN_ERR(addValueMapping(outputs[0], output));
+}
+
+template <int SplatValue>
+Error PyTorchModelLoader::loadZerosOrOnes(const torch::jit::Node *ptNode) {
   auto inputs = ptNode->inputs();
   auto outputs = ptNode->outputs();
   RETURN_IF_ERR(checkInputAndOutputSizes(inputs, 5, outputs, 1));
@@ -3173,17 +3194,22 @@ Error PyTorchModelLoader::loadZeros(const torch::jit::Node *ptNode) {
   }
   llvm::ArrayRef<glow::dim_t> inputSizeArrayRef(inputSizeGlow);
 
-  int32_t dtype;
-  ASSIGN_VALUE_OR_RETURN_ERR(
-      dtype, iValToInt(getGlowIValueForValue(inputs[ZerosInputs::dtype])));
-  auto glowElemKind = scalarTypeToElemKind(static_cast<c10::ScalarType>(dtype));
+  RETURN_ERR(loadZerosOrOnesHelper(ptNode, outputs, inputSizeArrayRef,
+                                   static_cast<float>(SplatValue)));
+}
 
-  auto output =
-      F_.createSplat(
-            "zeros",
-            F_.getParent()->uniqueType(glowElemKind, inputSizeArrayRef), 0)
-          ->getResult();
-  return addValueMapping(outputs[0], output);
+template <int SplatValue>
+Error PyTorchModelLoader::loadZerosOrOnesLike(const torch::jit::Node *ptNode) {
+  auto inputs = ptNode->inputs();
+  auto outputs = ptNode->outputs();
+  RETURN_IF_ERR(checkInputAndOutputSizes(inputs, 6, outputs, 1));
+
+  glow::NodeValue input;
+  ASSIGN_VALUE_OR_RETURN_ERR(input, getGlowNodeValueForValue(inputs[0]));
+  const auto inputDims = input.dims();
+
+  RETURN_ERR(loadZerosOrOnesHelper(ptNode, outputs, inputDims,
+                                   static_cast<float>(SplatValue)));
 }
 
 Error PyTorchModelLoader::loadArange(const torch::jit::Node *ptNode) {

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -477,9 +477,20 @@ private:
   /// \returns error on failure.
   Error loadArange(const torch::jit::Node *ptNode);
 
-  /// Load a PyTorch zeros node.
+  Error loadZerosOrOnesHelper(const torch::jit::Node *ptNode,
+                              c10::ArrayRef<const torch::jit::Value *> outputs,
+                              llvm::ArrayRef<glow::dim_t> inputDims,
+                              float splatValue);
+
+  /// Load a PyTorch zeros or ones node.
   /// \returns error on failure.
-  Error loadZeros(const torch::jit::Node *ptNode);
+  template <int SplatValue>
+  Error loadZerosOrOnes(const torch::jit::Node *ptNode);
+
+  /// Load a PyTorch zeros_like or ones_like node.
+  /// \returns error on failure.
+  template <int SplatValue>
+  Error loadZerosOrOnesLike(const torch::jit::Node *ptNode);
 
   /// Load a PyTorch sub node.
   /// \returns error on failure.

--- a/torch_glow/tests/nodes/zeros_and_ones_like_test.py
+++ b/torch_glow/tests/nodes/zeros_and_ones_like_test.py
@@ -1,0 +1,40 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+
+import torch
+from tests import utils
+
+
+class SimpleLikeModule(torch.nn.Module):
+    def __init__(self, splat_val):
+        super(SimpleLikeModule, self).__init__()
+        self.splat_val = splat_val
+
+    def forward(self, tensor):
+        if self.splat_val == 0:
+            return torch.zeros_like(tensor + tensor)
+        else:
+            return torch.ones_like(tensor + tensor)
+
+
+class TestZerosLike(unittest.TestCase):
+    def test_zeros_like_basic(self):
+        """Test of the PyTorch zeros_like Node on Glow."""
+
+        utils.compare_tracing_methods(
+            SimpleLikeModule(splat_val=0),
+            torch.rand(4, 2, 3),
+            fusible_ops={"aten::zeros_like"},
+        )
+
+
+class TestOnesLike(unittest.TestCase):
+    def test_ones_like_basic(self):
+        """Test of the PyTorch ones_like Node on Glow."""
+
+        utils.compare_tracing_methods(
+            SimpleLikeModule(splat_val=1),
+            torch.rand(4, 2, 3),
+            fusible_ops={"aten::ones_like"},
+        )

--- a/torch_glow/tests/nodes/zeros_and_ones_test.py
+++ b/torch_glow/tests/nodes/zeros_and_ones_test.py
@@ -18,3 +18,17 @@ class TestZero(unittest.TestCase):
         x = torch.randn(2, 3, 4)
 
         utils.compare_tracing_methods(TestModule(), x, fusible_ops={"aten::zeros"})
+
+
+class TestOnes(unittest.TestCase):
+    def test_ones_basic(self):
+        """Basic test of the PyTorch ones Node on Glow."""
+
+        class TestModule(torch.nn.Module):
+            def forward(self, a):
+                b = torch.ones(a.size(), dtype=torch.float)
+                return a + b
+
+        x = torch.randn(2, 3, 4)
+
+        utils.compare_tracing_methods(TestModule(), x, fusible_ops={"aten::ones"})


### PR DESCRIPTION
This PR adds support for loading the ops aten::zeros_like, aten::ones_like and aten::ones with PyTorchModelLoader.