### PR TITLE
[torch_glow] Add support for aten::index op

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -729,6 +729,10 @@ private:
   /// \returns error on failure.
   Error loadSlice(const torch::jit::Node *ptNode);
 
+  /// Load a PyTorch slice node.
+  /// \returns error on failure.
+  Error loadIndex(const torch::jit::Node *ptNode);
+
   /// Load a PyTorch SoftMax node.
   /// \returns error on failure.
   Error loadSoftMax(const torch::jit::Node *ptNode);

--- a/torch_glow/tests/nodes/index_test.py
+++ b/torch_glow/tests/nodes/index_test.py
@@ -1,0 +1,105 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+
+import torch
+from parameterized import parameterized
+from tests import utils
+
+
+class SimpleIndexModule(torch.nn.Module):
+    def __init__(self, indices, type, rank):
+        super(SimpleIndexModule, self).__init__()
+        self.indices = indices
+        self.type = type
+        self.rank = rank
+
+    def forward(self, a):
+        if self.rank == 3:
+            if self.type == 0:
+                if len(self.indices) == 1:
+                    return (a + a)[self.indices[0], :, :]
+                else:
+                    return (a + a)[self.indices[0], self.indices[1], :]
+            elif self.type == 1:
+                if len(self.indices) == 1:
+                    return (a + a)[:, :, self.indices[0]]
+                else:
+                    return (a + a)[:, self.indices[0], self.indices[1]]
+            else:
+                if len(self.indices) == 2:
+                    return (a + a)[self.indices[0], :, self.indices[1]]
+                else:
+                    return (a + a)[self.indices[0], self.indices[1], self.indices[2]]
+        elif self.rank == 4:
+            if len(self.indices) == 1:
+                return (a + a)[:, self.indices[0], :, :]
+            elif len(self.indices) == 2:
+                return (a + a)[:, self.indices[0], :, self.indices[1]]
+            elif len(self.indices) == 3:
+                return (a + a)[self.indices[0], self.indices[1], :, self.indices[2]]
+            else:
+                return (a + a)[
+                    self.indices[0], self.indices[1], self.indices[2], self.indices[3]
+                ]
+
+
+class TestIndex(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("3d_0", SimpleIndexModule([[1, 0]], 0, 3), torch.rand(2, 3, 4)),
+            ("3d_1", SimpleIndexModule([[1, 0], [2, 1]], 1, 3), torch.rand(2, 3, 4)),
+            ("3d_2", SimpleIndexModule([[1, 0], [2, 1]], 2, 3), torch.rand(2, 3, 4)),
+            ("3d_3", SimpleIndexModule([[1, 0]], 0, 3), torch.rand(4, 5, 3)),
+            ("3d_4", SimpleIndexModule([[1, 0], [1, 2]], 1, 3), torch.rand(4, 5, 3)),
+            ("3d_5", SimpleIndexModule([[1, 0], [1, 2]], 2, 3), torch.rand(4, 5, 3)),
+            (
+                "3d_6",
+                SimpleIndexModule([[1, 0], [2, 1], [1, 1]], 0, 3),
+                torch.rand(2, 3, 4),
+            ),
+            ("3d_7", SimpleIndexModule([[1, 0], [2, 1]], 1, 3), torch.rand(6, 5, 8)),
+            ("3d_8", SimpleIndexModule([[1, 0], [2, 1]], 2, 3), torch.rand(6, 5, 8)),
+            ("4d_1", SimpleIndexModule([[1, 0]], 0, 4), torch.rand(5, 3, 4, 6)),
+            ("4d_2", SimpleIndexModule([[1, 0], [2, 1]], 0, 4), torch.rand(5, 3, 4, 6)),
+            (
+                "4d_3",
+                SimpleIndexModule([[1, 0], [2, 1], [1, 1]], 0, 4),
+                torch.rand(5, 3, 4, 6),
+            ),
+            (
+                "4d_4",
+                SimpleIndexModule([[1, 0], [2, 1], [0, 1], [2, 3]], 0, 4),
+                torch.rand(5, 3, 4, 6),
+            ),
+            (
+                "2d_indices",
+                SimpleIndexModule(
+                    [torch.tensor([[1, 0], [1, 2]]), torch.tensor([[1, 0], [1, 2]])],
+                    1,
+                    3,
+                ),
+                torch.rand(6, 5, 8),
+            ),
+            (
+                "2d_indices",
+                SimpleIndexModule(
+                    [torch.tensor([[4, 0], [3, 2]]), torch.tensor([[2, 1], [1, 3]])],
+                    2,
+                    4,
+                ),
+                torch.rand(6, 5, 8, 7),
+            ),
+            (
+                "2d_indices",
+                SimpleIndexModule(
+                    [torch.tensor([[1, 0], [1, 2]]), torch.tensor([[1, 0], [1, 2]])],
+                    3,
+                    4,
+                ),
+                torch.rand(6, 5, 3, 7),
+            ),
+        ]
+    )
+    def test_f(self, _, module, tensor):
+        utils.compare_tracing_methods(module, tensor, fusible_ops={"aten::index"})


### PR DESCRIPTION
This PR adds support for the aten::index op in PyTorchModelLoader.

Note: When indexing if slices are used, e.g.:

```
tensor[indices0, indices1, :, indices2]
``` 
The resulting ListConstruct will contain None values which is not supported by loadListConstruct (or getGenericList):

```
%11 : None = prim::Constant()
%20 : Tensor?[] = prim::ListConstruct(%indices0, %indices1, %11, %indices2)
%21 : Tensor = aten::index(%13, %20)
```

We have added a workaround for this -- the None values are converted to empty tensors. This allows us to check where the slices are in the list, however if there is a better solution to this please let us know.
