### PR TITLE
Extend implementation of comparison operators in AI Compiler (Glow)

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -1090,8 +1090,10 @@ PyTorchModelLoader::buildSymbolsMapping() {
       {{"aten::lt", "aten::lt_"}, &PyTorchModelLoader::loadCmp<CmpLTNode>},
       {{"aten::ne", "aten::ne_"}, &PyTorchModelLoader::loadCmp<CmpNEQNode>},
       {{"aten::eq", "aten::eq_"}, &PyTorchModelLoader::loadCmp<CmpEQNode>},
-      {{"aten::ge", "aten::ge_"}, &PyTorchModelLoader::loadCmpGt<CmpLTENode>},
-      {{"aten::gt", "aten::gt_"}, &PyTorchModelLoader::loadCmpGt<CmpLTNode>},
+      {{"aten::ge", "aten::ge_"},
+       &PyTorchModelLoader::loadCmp<CmpLTENode, true>},
+      {{"aten::gt", "aten::gt_"},
+       &PyTorchModelLoader::loadCmp<CmpLTNode, true>},
       {{"aten::clamp"}, &PyTorchModelLoader::loadClamp},
       {{"aten::cos"}, &PyTorchModelLoader::loadCos},
       {{"aten::sin"}, &PyTorchModelLoader::loadSin},
@@ -3581,8 +3583,8 @@ Error PyTorchModelLoader::loadSqrt(const torch::jit::Node *ptNode) {
   RETURN_ERR(addValueMapping(outputs[0], glowNode->getResult()));
 }
 
-template <typename CmpType>
-Error PyTorchModelLoader::loadCmpGt(const torch::jit::Node *ptNode) {
+template <typename CmpType, bool invert>
+Error PyTorchModelLoader::loadCmp(const torch::jit::Node *ptNode) {
   auto inputs = ptNode->inputs();
   auto outputs = ptNode->outputs();
   auto kind = ptNode->kind();
@@ -3593,42 +3595,27 @@ Error PyTorchModelLoader::loadCmpGt(const torch::jit::Node *ptNode) {
   ASSIGN_VALUE_OR_RETURN_ERR(
       lhs, getGlowNodeValueForValue(inputs[CompareInputs::lhs]));
 
+  glow::NodeValue rhs;
   if (hasGlowIValueForValue(inputs[CompareInputs::rhs])) {
-    glow::NodeValue rhs;
     ASSIGN_VALUE_OR_RETURN_ERR(
         rhs, loadNodeValueOrBroadcastedIValue(inputs[CompareInputs::rhs],
                                               lhs.dims()));
+  } else {
+    ASSIGN_VALUE_OR_RETURN_ERR(
+        rhs, getGlowNodeValueForValue(inputs[CompareInputs::rhs]));
+  }
+
+  // Greater than and Greater or equal are mapped to inverted
+  // (swap between LHS and RHS) Less or equal and Less than
+  if constexpr (invert) {
     auto *glowNode = F_.createNodeWithBroadcast<CmpType>(kind.toUnqualString(),
                                                          axis, rhs, lhs);
     return addValueMapping(outputs[0], glowNode->getResult());
   } else {
-    glow::NodeValue rhs;
-    ASSIGN_VALUE_OR_RETURN_ERR(
-        rhs, getGlowNodeValueForValue(inputs[CompareInputs::rhs]));
     auto *glowNode = F_.createNodeWithBroadcast<CmpType>(kind.toUnqualString(),
-                                                         axis, rhs, lhs);
+                                                         axis, lhs, rhs);
     return addValueMapping(outputs[0], glowNode->getResult());
   }
-}
-template <typename CmpType>
-Error PyTorchModelLoader::loadCmp(const torch::jit::Node *ptNode) {
-  auto inputs = ptNode->inputs();
-  auto outputs = ptNode->outputs();
-  RETURN_IF_ERR(checkInputAndOutputSizes(inputs, 2, outputs, 1));
-
-  const auto kind = ptNode->kind();
-
-  glow::NodeValue lhs, rhs;
-  ASSIGN_VALUE_OR_RETURN_ERR(
-      lhs, getGlowNodeValueForValue(inputs[CompareInputs::lhs]));
-  ASSIGN_VALUE_OR_RETURN_ERR(
-      rhs, getGlowNodeValueForValue(inputs[CompareInputs::rhs]));
-
-  constexpr int axis = -1;
-  auto *glowNode = F_.createNodeWithBroadcast<CmpType>(kind.toUnqualString(),
-                                                       axis, lhs, rhs);
-
-  RETURN_ERR(addValueMapping(outputs[0], glowNode->getResult()));
 }
 
 Error PyTorchModelLoader::loadSigmoid(const torch::jit::Node *ptNode) {

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -545,13 +545,10 @@ private:
   /// \returns error on failure.
   Error loadSqrt(const torch::jit::Node *ptNode);
 
-  /// Load PyTorch eq, ne, lt, lte nodes.
+  /// Load PyTorch eq, ne, lt, lte, gt, gte nodes.
   /// \returns error on failure.
-  template <typename CmpType> Error loadCmp(const torch::jit::Node *ptNode);
-
-  /// Load PyTorch ge, gte nodes.
-  /// \returns error on failure.
-  template <typename CmpType> Error loadCmpGt(const torch::jit::Node *ptNode);
+  template <typename CmpType, bool invert = false>
+  Error loadCmp(const torch::jit::Node *ptNode);
 
   /// Load a PyTorch reciprocal node.
   /// \returns error on failure.


### PR DESCRIPTION
Summary:
This change enables the right-hand side of comparisons with a tensor to be a scalar.

Previously scalar RHS were supported only for greater than and greater or equal operators.

Differential Revision: D25856045

