### PR TITLE
Fix FbFCPacked for 3D

### DIFF
--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -1115,7 +1115,6 @@ FullyConnectedNode *Function::createFullyConnected(llvm::StringRef name,
                                                    NodeValue B, TypeRef outTy,
                                                    unsigned_t axis) {
   assert(outTy->dims().size() == 2 && "Invalid number of dimensions");
-  assert(outTy->dims()[0] == input.dims()[0] && "Invalid dimensions");
 
   // FC always uses 2D input; flatten if necessary.
   if (input.dims().size() != 2) {

--- a/tests/models/caffe2Models/fb_fc_packed_3d.pbtxt
+++ b/tests/models/caffe2Models/fb_fc_packed_3d.pbtxt
@@ -1,0 +1,17 @@
+name: "fb_fc_packed_3d"
+op {
+  input: "input"
+  input: "weights"
+  input: "bias"
+  output: "output"
+  name: ""
+  type: "FbFCPacked"
+  arg {
+    name: "axis"
+    i: 2
+  }
+}
+external_input: "input"
+external_input: "weights"
+external_input: "bias"
+external_output: "output"

--- a/tests/models/caffe2Models/fb_fc_packed_3d_init.pbtxt
+++ b/tests/models/caffe2Models/fb_fc_packed_3d_init.pbtxt
@@ -1,0 +1,49 @@
+name: "init"
+op {
+  output: "weights"
+  type: "GivenTensorFp16Fill"
+  arg {
+    name: "shape"
+    ints: 5
+    ints: 4
+  }
+  arg {
+    name: "values"
+    floats: 0
+    floats: 1
+    floats: 2
+    floats: 3
+    floats: 4
+    floats: 5
+    floats: 6
+    floats: 7
+    floats: 8
+    floats: 9
+    floats: 10
+    floats: 11
+    floats: 12
+    floats: 13
+    floats: 14
+    floats: 15
+    floats: 16
+    floats: 17
+    floats: 18
+    floats: 19
+  }
+}
+op {
+  output: "bias"
+  type: "GivenTensorFill"
+  arg {
+    name: "shape"
+    ints: 5
+  }
+  arg {
+    name: "values"
+    floats: 0
+    floats: 1
+    floats: 2
+    floats: 3
+    floats: 4
+  }
+}


### PR DESCRIPTION
Summary:
This diff fixes the flaw when for dimensions higher than 2D we would simply drop dimensions in the middle thus making results missing those dimensions.
E.g. if the input has shape `[64, 8, 40]`, weights have shape `[10, 40]` and bias has shape `[10]`, then we would expect the result to have shape `[64, 8, 10]`. Currently flawed logic makes the result to be `[64, 10]`.

Differential Revision: D25857493

