### PR TITLE
Add glow_device_init_timeout_ms to hostmanager so that we can config glow_device_init_timeout_ms from commandline

### DIFF
--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -90,6 +90,15 @@ llvm::cl::opt<bool, /* ExternalStorage */ true>
               llvm::cl::location(glow::runtime::flags::EnableP2P),
               llvm::cl::cat(hostManagerCat));
 
+/// The value that should be used for device initialization timeout, default:
+/// 5000 milliseconds.
+llvm::cl::opt<unsigned, /* ExternalStorage */ true> deviceInitTimeout(
+    "device_init_timeout_ms",
+    llvm::cl::desc("Set device init timout in milliseconds"),
+    llvm::cl::Optional,
+    llvm::cl::location(glow::runtime::flags::DeviceInitTimeoutMs),
+    llvm::cl::cat(hostManagerCat));
+
 HostManager::HostManager() : HostManager(HostConfig{}) {}
 
 HostManager::HostManager(const HostConfig &hostConfig)


### PR DESCRIPTION
Reviewed By: openrichardfb

Differential Revision: D25878205

