### PR TITLE
load aten:div with two integer tensor inputs

### DIFF
--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -427,6 +427,11 @@ inline bool isFloatElemKind(ElemKind e) {
          e == ElemKind::BFloat16Ty;
 }
 
+/// \returns whether \p e is a non-quantized integer ElemKind.
+inline bool isNonQuantizedIntElemKind(ElemKind e) {
+  return e == ElemKind::Int32ITy || e == ElemKind::Int64ITy;
+}
+
 /// \returns whether \p e is a fused quantized ElemKind.
 inline bool isFusedQuantizedElemKind(ElemKind e) {
   return e == ElemKind::UInt8FusedQTy || e == ElemKind::UInt8FusedFP16QTy ||

--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -446,12 +446,15 @@ private:
   /// Helper function for loading arithmetic nodes. \p name is of the name of
   /// the node in the Glow graph, \p lhs and \p rhs are the inputs to the
   /// arithetic node and template parameter \p GlowNode is the type of the node
-  /// that should be created in the Glow graph. \returns the output of the
-  /// loaded arithmetic node or an Error if any occurred.
+  /// that should be created in the Glow graph. \p convertToDefaultType
+  /// indicates if we want to convert the input types to default pytorch dtypes
+  /// if both inputs are of integer types. \returns the output of the loaded
+  /// arithmetic node or an Error if any occurred.
   template <typename GlowNode>
   Expected<NodeValue> loadArithmeticNode(llvm::StringRef name,
                                          const torch::jit::Value *lhs,
-                                         const torch::jit::Value *rhs);
+                                         const torch::jit::Value *rhs,
+                                         bool convertToDefaultType = false);
 
   /// Load a PyTorch mul node.
   /// \returns error on failure.

--- a/torch_glow/tests/nodes/div_test.py
+++ b/torch_glow/tests/nodes/div_test.py
@@ -41,11 +41,11 @@ class TestDiv(unittest.TestCase):
                 torch.randn(4, 2),
                 torch.randn(8, 3, 4, 2),
             ),
-            ("float", SimpleDivModule(), torch.randn(4), torch.tensor(3.9)),
-            ("int", SimpleDivModule(), torch.randn(4), torch.tensor(20), True),
+            ("float_tensor", SimpleDivModule(), torch.randn(4), torch.tensor(3.9)),
+            ("int_tensor", SimpleDivModule(), torch.tensor([4]), torch.tensor([10])),
+            # This one will go through (a * a) / b.item() and b.item() is an integer.
+            ("int_number", SimpleDivModule(), torch.tensor([4]), torch.tensor(10)),
         ]
     )
-    def test_div_basic(self, _, module, a, b, skip_to_glow=False):
-        utils.compare_tracing_methods(
-            module, a, b, fusible_ops={"aten::div"}, skip_to_glow=skip_to_glow
-        )
+    def test_div(self, _, module, a, b):
+        utils.compare_tracing_methods(module, a, b, fusible_ops={"aten::div"})


### PR DESCRIPTION
Summary: Pytorch div would promote output type to default scalar type if both inputs are of integer type. However, in Glow we expect inputs and output have the same type for DivNode. So when loading aten::div with two integer tensor type inputs, we convert them to default scalar type before create Glow DivNode.

Reviewed By: jackm321

Differential Revision: D25875763

