### PR TITLE
Fix reshaping issue for Int8FC for 3D input

### DIFF
--- a/lib/Importer/Caffe2ModelLoader.cpp
+++ b/lib/Importer/Caffe2ModelLoader.cpp
@@ -1136,11 +1136,12 @@ Error Caffe2ModelLoader::loadOperator(const caffe2::OperatorDef &op) {
     Node *node = nullptr;
     if (typeName == "Int8FC") {
       // Create the node with quantized type.
+      auto outputDims = flattenCdr(in.dims(), in.dims().size() - 1);
       TypeRef outTy;
       ASSIGN_VALUE_OR_RETURN_ERR(
-          outTy, loadQuantTy(opName, ElemKind::Int8QTy,
-                             {in.getType()->dims()[0], B->getType()->dims()[0]},
-                             dict));
+          outTy,
+          loadQuantTy(opName, ElemKind::Int8QTy,
+                      {outputDims.first, B->getType()->dims()[0]}, dict));
       node = G_->createFullyConnected(opName, in, W, B, outTy, axis);
     } else if (typeName == "FbFCPacked") {
       RETURN_ERR_IF_NOT(W.getElementType() == ElemKind::Float16Ty,

--- a/tests/models/caffe2Models/int8_fc_3d.pbtxt
+++ b/tests/models/caffe2Models/int8_fc_3d.pbtxt
@@ -1,0 +1,31 @@
+name: "int8_fc_3d"
+op {
+  input: "input"
+  input: "weights"
+  input: "bias"
+  output: "output_q"
+  name: ""
+  type: "Int8FC"
+  arg {
+    name: "axis"
+    i: 2
+  }
+  arg {
+    name: "Y_scale"
+    f: 1
+  }
+  arg {
+    name: "Y_zero_point"
+    i: 0
+  }
+}
+op {
+  input: "output_q"
+  output: "output"
+  name: ""
+  type: "Int8Dequantize"
+}
+external_input: "input"
+external_input: "weights"
+external_input: "bias"
+external_output: "output"

--- a/tests/models/caffe2Models/int8_fc_3d_init.pbtxt
+++ b/tests/models/caffe2Models/int8_fc_3d_init.pbtxt
@@ -1,0 +1,42 @@
+name: "init"
+op {
+  output: "weights"
+  type: "Int8GivenTensorFill"
+  arg {
+    name: "shape"
+    ints: 2
+    ints: 3
+  }
+  arg {
+    name: "values"
+    s: "\x0\x1\x2\x3\x4\x5"
+  }
+  arg {
+    name: "Y_scale"
+    f: 1
+  }
+  arg {
+    name: "Y_zero_point"
+    i: 0
+  }
+}
+op {
+  output: "bias"
+  type: "Int8GivenTensorFill"
+  arg {
+    name: "shape"
+    ints: 2
+  }
+  arg {
+    name: "values"
+    s: "\x0\x1"
+  }
+  arg {
+    name: "Y_scale"
+    f: 1
+  }
+  arg {
+    name: "Y_zero_point"
+    i: 0
+  }
+}


### PR DESCRIPTION
Summary:
This diff fixes the flaw when for dimensions higher than 2D we would simply drop dimensions in the middle thus making results missing those dimensions.
E.g. if the input has shape [64, 8, 40], weights have shape [10, 40] and bias has shape [10], then we would expect the result to have shape [64, 8, 10]. Currently flawed logic makes the result to be [64, 10].

Differential Revision: D25896412

