### PR TITLE
[Windows] enable math defines in OperatorTest

### DIFF
--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+#if defined(_MSC_VER)
+// Enable non-standard math constants (e.g. M_2_SQRTPI, M_SQRT1_2)
+#define _USE_MATH_DEFINES
+#endif
+
 #include "BackendTestUtils.h"
 
 #include "glow/ExecutionEngine/ExecutionEngine.h"


### PR DESCRIPTION
Summary:
Fixes Windows build break due to undefined M_2_SQRTPI and M_SQRT1_2.

Documentation:

[Optional Fixes #issue]

Test Plan:

Please see a detailed explanation of how to fill out the fields in the relevant sections in PULL_REQUEST.md.
