### PR TITLE
Add improved support for parallelization and related graph opts

### DIFF
--- a/include/glow/Graph/NodeValue.h
+++ b/include/glow/Graph/NodeValue.h
@@ -96,6 +96,8 @@ public:
   /// @{
   ElemKind getElementType() const;
   llvm::ArrayRef<dim_t> dims() const;
+  float getScale() const;
+  int32_t getOffset() const;
   /// @}
 
   bool operator==(const NodeValue &O) const {

--- a/lib/Graph/NodeValue.cpp
+++ b/lib/Graph/NodeValue.cpp
@@ -111,6 +111,10 @@ ElemKind NodeValue::getElementType() const {
   return getType()->getElementType();
 }
 
+float NodeValue::getScale() const { return getType()->getScale(); }
+
+int32_t NodeValue::getOffset() const { return getType()->getOffset(); }
+
 llvm::ArrayRef<dim_t> NodeValue::dims() const { return getType()->dims(); }
 
 std::string

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -895,20 +895,45 @@ bool SinkCode::run(Function *F, const CompilationContext &cctx) {
       node->getNthResult(ArithmeticNode::ResultIdx).replaceAllUsesOfWith(newTR);
     }
 
-    // Sink TransposeNode below QuantizedNode.
-    // If it doesn't work out it will be re-sinked later.
     if (auto *Q = dyn_cast<QuantizeNode>(node)) {
-      auto *TR = dyn_cast<TransposeNode>(Q->getInput());
-      if (!TR) {
+      // Sink TransposeNode below QuantizedNode.
+      // If it doesn't work out it will be re-sinked later.
+      if (auto *TR = dyn_cast<TransposeNode>(Q->getInput())) {
+        auto newQType = F->getParent()->uniqueTypeWithNewShape(
+            Q->getResult().getType(), TR->getInput().dims());
+        auto *newQ = F->createQuantize(Q->getName(), TR->getInput(), newQType);
+        auto *newTR = F->createTranspose(TR->getName(), newQ, TR->getShuffle());
+        Q->getResult().replaceAllUsesOfWith(newTR);
+        changed = true;
         continue;
       }
 
-      auto newQType = F->getParent()->uniqueTypeWithNewShape(
-          Q->getResult().getType(), TR->getInput().dims());
-      auto *newQ = F->createQuantize(Q->getName(), TR->getInput(), newQType);
-      auto *newTR = F->createTranspose(TR->getName(), newQ, TR->getShuffle());
-      Q->getResult().replaceAllUsesOfWith(newTR);
+      // Sink Reshape below Quantize.
+      if (auto *RN = dyn_cast<ReshapeNode>(Q->getInput())) {
+        auto newQType = F->getParent()->uniqueTypeWithNewShape(
+            Q->getResult().getType(), RN->getInput().dims());
+        auto *newQ = F->createQuantize(Q->getName(), RN->getInput(), newQType);
+        auto *newRN =
+            F->createReshape(RN->getName(), newQ, RN->getResult().dims());
+        Q->getResult().replaceAllUsesOfWith(newRN->getResult());
+        changed = true;
+        continue;
+      }
+    }
+
+    // Sink Reshape below ConvertTo.
+    if (auto *CN = dyn_cast<ConvertToNode>(node)) {
+      auto *RN = dyn_cast<ReshapeNode>(CN->getInput());
+      if (!RN) {
+        continue;
+      }
+      auto *newCN = F->createConvertTo(CN->getName(), RN->getInput(),
+                                       CN->getResult().getElementType());
+      auto *newRN =
+          F->createReshape(RN->getName(), newCN, RN->getResult().dims());
+      CN->getResult().replaceAllUsesOfWith(newRN->getResult());
       changed = true;
+      continue;
     }
 
     // Sink TransposeNode below DequantizedNode.
@@ -4000,28 +4025,47 @@ bool OptimizeConversions::run(Function *F, const CompilationContext &cctx) {
   return changed;
 }
 
-/// Optimize Quantize(ConvertTo(Node)) -> Quantize(Node), where Quantize is
-/// int8. This may have numerical differences but since Int8 has a small range
-/// it's likely fine. This is opt in by a backend.
+/// Optimize patterns of Int8 quantization/dequantization with ConvertTo. This
+/// may have numerical differences but since Int8 has a small range it's likely
+/// fine. This is opt in by a backend.
 bool OptimizeOutIntermediateConversions::run(Function *F,
                                              const CompilationContext &cctx) {
   LOG_SCOPE(F->getLogContext(), getName());
 
   bool changed = false;
   for (auto &node : F->getNodes()) {
-    QuantizeNode *QN = llvm::dyn_cast<QuantizeNode>(&node);
-    if (!QN ||
-        QN->getResult().getType()->getElementType() != ElemKind::Int8QTy) {
+    // Quantize(ConvertTo(Node)) -> Quantize(Node), where Quantize is int8
+    if (QuantizeNode *QN = llvm::dyn_cast<QuantizeNode>(&node)) {
+      if (QN->getResult().getType()->getElementType() != ElemKind::Int8QTy) {
+        continue;
+      }
+
+      ConvertToNode *CN = llvm::dyn_cast<ConvertToNode>(QN->getInput());
+      if (!CN) {
+        continue;
+      }
+
+      QN->setNthInput(QuantizeNode::InputIdx, CN->getInput());
+      changed = true;
       continue;
     }
 
-    ConvertToNode *CN = llvm::dyn_cast<ConvertToNode>(QN->getInput());
-    if (!CN) {
+    // ConvertTo(Dequantize(Node)) -> Dequantize(Node), where Dequantize is int8
+    if (ConvertToNode *CN = llvm::dyn_cast<ConvertToNode>(&node)) {
+      DequantizeNode *DN = llvm::dyn_cast<DequantizeNode>(CN->getInput());
+      if (!DN ||
+          DN->getInput().getType()->getElementType() != ElemKind::Int8QTy) {
+        continue;
+      }
+
+      // Create new Dequantize node, dequantizing directly to the kind of the
+      // ConverTo that originally consumed it.
+      DequantizeNode *newDN = F->createDequantize(
+          DN->getName(), DN->getInput(), CN->getResult().getElementType());
+      CN->getResult().replaceAllUsesOfWith(newDN->getResult());
+      changed = true;
       continue;
     }
-
-    QN->setNthInput(QuantizeNode::InputIdx, CN->getInput());
-    changed = true;
   }
 
   return changed;
@@ -6320,6 +6364,14 @@ Expected<std::unordered_map<Node *, ConcatNode *>> glow::parallelizeOps(
                     DequantizeNode::ResultIdx, splitDims, 0));
         break;
       }
+      case Kinded::Kind::RescaleQuantizedNodeKind: {
+        splitDims[RescaleQuantizedNode::InputIdx] = 0;
+        ASSIGN_VALUE_OR_RETURN_ERR(
+            CN, parallelizeAndReplaceNode(
+                    F, curNode, curNumOfChunks, RescaleQuantizedNode::InputIdx,
+                    RescaleQuantizedNode::ResultIdx, splitDims, 0));
+        break;
+      }
       case Kinded::Kind::ConvertToNodeKind: {
         splitDims[ConvertToNode::InputIdx] = 0;
         ASSIGN_VALUE_OR_RETURN_ERR(
@@ -6428,6 +6480,19 @@ Expected<std::unordered_map<Node *, ConcatNode *>> glow::parallelizeOps(
             CN, parallelizeAndReplaceNode(
                     F, curNode, curNumOfChunks, DequantizeNode::InputIdx,
                     DequantizeNode::ResultIdx, splitDims,
+                    /*resultDim*/ 1, modelParallelSplitAlignment));
+        break;
+      }
+      case Kinded::Kind::RescaleQuantizedNodeKind: {
+        if (curNode->getNthInput(RescaleQuantizedNode::InputIdx).dims().size() <
+            2) {
+          break;
+        }
+        splitDims[RescaleQuantizedNode::InputIdx] = 1;
+        ASSIGN_VALUE_OR_RETURN_ERR(
+            CN, parallelizeAndReplaceNode(
+                    F, curNode, curNumOfChunks, RescaleQuantizedNode::InputIdx,
+                    RescaleQuantizedNode::ResultIdx, splitDims,
                     /*resultDim*/ 1, modelParallelSplitAlignment));
         break;
       }


### PR DESCRIPTION
Summary:
- Add RescaleQuantized parallelization support to graph opts' parallelization code
- On NNPI, mirror Rescale parallelization for FC/Relus that come before it
- Sink Reshapes below Quantize and ConvertTo
- Remove unnecessary ConvertTo when following a Dequantize (i.e. just change the elem kind of the Dequantize instead)

Differential Revision: D25947824

