### PR TITLE
Enable setting available devices

### DIFF
--- a/torch_glow/src/PyTorchCommon.cpp
+++ b/torch_glow/src/PyTorchCommon.cpp
@@ -107,14 +107,14 @@ PyTorchLoaderSettings &getPyTorchLoaderSettingsInternalOnly() {
 } // namespace
 
 std::shared_ptr<runtime::HostManager>
-getHostManager(const std::string &backendName, int32_t numDevices) {
+getHostManager(const PyTorchLoaderSettings &settings) {
   static std::mutex m_;
   std::unique_lock<std::mutex> lock(m_);
   static std::unordered_map<std::string, std::weak_ptr<runtime::HostManager>>
       map_;
 
   std::shared_ptr<runtime::HostManager> hostManager;
-  auto it = map_.find(backendName);
+  auto it = map_.find(settings.backendName);
   if (it != map_.end()) {
     hostManager = it->second.lock();
   }
@@ -122,20 +122,20 @@ getHostManager(const std::string &backendName, int32_t numDevices) {
   // If HostManager was found, check that it's valid, otherwise create a new
   // HostManager
   if (hostManager) {
-    if (numDevices != -1) {
-      CHECK_EQ(hostManager->numDevices(), numDevices)
-          << "Tried to create a new HostManager for backend \"" << backendName
+    if (settings.numDevices != -1) {
+      CHECK_EQ(hostManager->numDevices(), settings.numDevices)
+          << "Tried to create a new HostManager for backend \""
+          << settings.backendName
           << "\" but there is already an existing HostManager in use for that "
              "Backend but with a different number of devices";
     }
   } else {
     // If number of devices isn't specified then just use 1 device.
-    if (numDevices < 0) {
-      numDevices = 1;
-    }
     std::vector<std::unique_ptr<runtime::DeviceConfig>> deviceConfigs;
-    for (int i = 0; i < numDevices; i++) {
-      auto config = std::make_unique<runtime::DeviceConfig>(backendName);
+    for (int32_t i = 0, e = settings.numDevices < 0 ? 1 : settings.numDevices;
+         i < e; i++) {
+      auto config =
+          std::make_unique<runtime::DeviceConfig>(settings.backendName);
       config->deviceID = i;
       deviceConfigs.push_back(std::move(config));
     }
@@ -146,8 +146,16 @@ getHostManager(const std::string &backendName, int32_t numDevices) {
     hostManager = std::make_shared<runtime::HostManager>(
         std::move(deviceConfigs), hostConfig);
 
-    map_[backendName] = hostManager;
+    map_[settings.backendName] = hostManager;
   }
+
+  // Update the available devices list if necessary
+  if (!settings.availableDevices.empty()) {
+    std::vector<size_t> availableDevices(settings.availableDevices.begin(),
+                                         settings.availableDevices.end());
+    hostManager->setAvailableDevices(availableDevices);
+  }
+
   return hostManager;
 }
 
@@ -572,9 +580,8 @@ void glowAOTFusionWithShapeInference(torch::jit::Module &model,
       auto runner = glow::setGraphRunnerForKey(
           kind + std::to_string(idx), [subgraph, settings] {
             return std::make_unique<glow::CachingGraphRunner>(
-                subgraph,
-                getHostManager(settings.backendName, settings.numDevices),
-                settings, /*useRunOnly*/ true);
+                subgraph, getHostManager(settings), settings,
+                /*useRunOnly*/ true);
           });
 
       InputMetaStack metaStackForCompilation;
@@ -646,8 +653,7 @@ void glowAOTFusion(torch::jit::Module &model, const std::string &inputMetaStr,
   auto runner =
       glow::setGraphRunnerForKey(symbol.toQualString(), [subgraph, settings] {
         return std::make_unique<glow::CachingGraphRunner>(
-            subgraph, getHostManager(settings.backendName, settings.numDevices),
-            settings, /*useRunOnly*/ true);
+            subgraph, getHostManager(settings), settings, /*useRunOnly*/ true);
       });
 
   auto e = runner->warmCache(metaStack, settings, loader,

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -146,9 +146,9 @@ public:
   /// PyTorchModelLoader.
   bool randomizeConstants = false;
 
-  // If true then writing to Onnx without randomizing the constants is allowed.
-  // Otherwise, program will be abort if trying to write to Onnx without
-  // randomizing the constants.
+  /// If true then writing to Onnx without randomizing the constants is allowed.
+  /// Otherwise, program will be abort if trying to write to Onnx without
+  /// randomizing the constants.
   bool writeWithoutRandomize = false;
 
   /// Name of the Glow backend to use.
@@ -176,6 +176,9 @@ public:
   /// Index of input to extract batch size
   /// NOTE: this should only be used for development testing.
   int32_t nominalBatchIdx = -1;
+
+  /// Indices of available backend devices on the machine.
+  std::vector<int32_t> availableDevices;
 };
 
 /// Represents different possible output types from to_glow modules.
@@ -209,7 +212,7 @@ PyTorchLoaderSettings &getGlobalPyTorchLoaderSettingsMutable();
 /// returned, if no active HostManager is found then a HostManager with 1 device
 /// will be returned.
 std::shared_ptr<runtime::HostManager>
-getHostManager(const std::string &backendName, int32_t numDevices = -1);
+getHostManager(const PyTorchLoaderSettings &settings);
 
 /// \returns the PyTorch symbol to be used for the PyTorch node which represents
 /// the subgraph that Glow will compile and run. \p g is the PyTorch graph to

--- a/torch_glow/src/Registration.cpp
+++ b/torch_glow/src/Registration.cpp
@@ -143,9 +143,7 @@ void registerGlowOp(const c10::Symbol &symbol) {
         if (!graphRunner) {
           auto settings = getGlobalPyTorchLoaderSettingsSnapshot();
           graphRunner = std::make_unique<CachingGraphRunner>(
-              node->g(at::attr::Subgraph),
-              getHostManager(settings.backendName, settings.numDevices),
-              settings);
+              node->g(at::attr::Subgraph), getHostManager(settings), settings);
         }
 
         return [graphRunner =

--- a/torch_glow/src/TorchGlowBackend.cpp
+++ b/torch_glow/src/TorchGlowBackend.cpp
@@ -689,11 +689,8 @@ compileImpl(const torch::jit::Module &origModule,
       // Create a corresponding runner and store {handle, runner} pair.
       std::unique_ptr<CachingGraphRunner> runner =
           std::make_unique<glow::CachingGraphRunner>(
-              graph,
-              glow::getHostManager(baseSettings.backendName,
-                                   baseSettings.numDevices),
-              baseSettings, /*useRunOnly*/ true, origGraph,
-              origModule._ivalue());
+              graph, glow::getHostManager(baseSettings), baseSettings,
+              /*useRunOnly*/ true, origGraph, origModule._ivalue());
 
       // Compile each compilation group
       for (const auto &compilationGroup : spec.compilation_groups) {

--- a/torch_glow/src/binding.cpp
+++ b/torch_glow/src/binding.cpp
@@ -375,4 +375,19 @@ PYBIND11_MODULE(_torch_glow, m) {
   m.def("to_glow_preview", [](const torch::jit::Module &orig_module) {
     TorchGlowBackend::preview(orig_module);
   });
+
+  /// Set avaialable devices to those listed in \p availableDevices.
+  m.def("set_available_devices", [](std::vector<int32_t> availableDevices) {
+    getGlobalPyTorchLoaderSettingsMutable().availableDevices = availableDevices;
+  });
+
+  /// Set avaialable devices to all devices on the host
+  m.def("clear_available_devices", []() {
+    getGlobalPyTorchLoaderSettingsMutable().availableDevices = {};
+  });
+
+  /// \returns the list of avaialble devices
+  m.def("get_available_devices", []() {
+    return getGlobalPyTorchLoaderSettingsMutable().availableDevices;
+  });
 }


### PR DESCRIPTION
Summary: Enable setting available devices from python torch_glow, useful for splitting devices between processes.

Differential Revision: D25948257

