### PR TITLE
Allow set interpreter memory through torch_glow

### DIFF
--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -1004,13 +1004,4 @@ Expected<bool> Interpreter::transformPostLowering(
 }
 
 void Interpreter::parseBackendSpecificOptions(
-    const BackendOptions &opts) const {
-  auto interpreterMaxMemOpt =
-      opts.backendSpecificOpts.find("interpreter-memory");
-  if (interpreterMaxMemOpt != opts.backendSpecificOpts.end()) {
-    glow::runtime::flags::InterpreterMemory =
-        std::stoi(interpreterMaxMemOpt->second);
-    llvm::outs() << "Interpreter memory set to "
-                 << glow::runtime::flags::InterpreterMemory << "\n";
-  }
-}
+    const BackendOptions &opts) const {}

--- a/torch_glow/src/binding.cpp
+++ b/torch_glow/src/binding.cpp
@@ -22,6 +22,7 @@
 #include "PyTorchCommon.h"
 #include "Registration.h"
 #include "TorchGlowBackend.h"
+#include "glow/Flags/Flags.h"
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <torch/csrc/jit/python/pybind_utils.h>
@@ -233,6 +234,11 @@ PYBIND11_MODULE(_torch_glow, m) {
   /// Disable shape inference engine.
   m.def("disable_shape_inference_engine", []() {
     getGlobalPyTorchLoaderSettingsMutable().runShapeInference = false;
+  });
+
+  /// Set interpreter device memory (in KiB).
+  m.def("set_interpreter_memory", [](const unsigned &memorySize) {
+    glow::runtime::flags::InterpreterMemory = memorySize;
   });
 
   /// Add all of the symbols in \p blacklist to the fusion blacklist so that

--- a/torch_glow/tests/functionality/to_glow_selective_test.py
+++ b/torch_glow/tests/functionality/to_glow_selective_test.py
@@ -86,14 +86,8 @@ class TestSelectiveToGlow(unittest.TestCase):
         inputs = (torch.zeros(4) + 8, torch.zeros(4) + 7)
         torch_res = model(*inputs)
 
-        bar_inputs = [
-            torch.randn(shape)
-            for shape in torch_glow.get_submod_input_shapes(model, "foo.bar", inputs)
-        ]
-        qux_inputs = [
-            torch.randn(shape)
-            for shape in torch_glow.get_submod_input_shapes(model, "qux", inputs)
-        ]
+        bar_inputs = torch_glow.get_submod_inputs(model, "foo.bar", inputs)
+        qux_inputs = torch_glow.get_submod_inputs(model, "qux", inputs)
 
         glow_mod = torch_glow.to_glow_selective(
             model,
@@ -113,14 +107,8 @@ class TestSelectiveToGlow(unittest.TestCase):
         inputs = (torch.zeros(4) + 8, torch.zeros(4) + 7)
         torch_res = model(*inputs)
 
-        bar_inputs = [
-            torch.randn(shape)
-            for shape in torch_glow.get_submod_input_shapes(model, "foo.bar", inputs)
-        ]
-        qux_inputs = [
-            torch.randn(shape)
-            for shape in torch_glow.get_submod_input_shapes(model, "qux", inputs)
-        ]
+        bar_inputs = torch_glow.get_submod_inputs(model, "foo.bar", inputs)
+        qux_inputs = torch_glow.get_submod_inputs(model, "qux", inputs)
 
         with torch.no_grad():
             traced_model = torch.jit.trace(model, inputs)


### PR DESCRIPTION
Summary:
Currently we set interpreter memory as a backend option and it gets parsed when compiling functions https://fburl.com/diffusion/9azfz1p1. However, we need it when creating the device https://fburl.com/diffusion/em64ihat.

Enable setting interpreter memory via `torch_glow.set_interpreter_memory(unsigned)`

Reviewed By: jackm321

Differential Revision: D25963849

