### PR TITLE
Fix NNPIDeviceManagerTest CanHandleDeviceResidentTensors

### DIFF
--- a/tests/unittests/DeviceManagerTest.cpp
+++ b/tests/unittests/DeviceManagerTest.cpp
@@ -907,6 +907,8 @@ public:
 };
 
 TEST_P(DeviceManagerTest, CanHandleDeviceResidentTensors) {
+  CHECK_IF_ENABLED();
+
   MockDM mockDM;
 
   auto module = makeBasicModule();


### PR DESCRIPTION
Summary: The test is actually in the blacklist but we didn't check blacklist when running the test. Add CHECK_IF_ENABLED() into the test

Differential Revision: D26001944

