### PR TITLE
remove logging that was causing initialization of Host Manager to fail

### DIFF
--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -117,13 +117,6 @@ HostManager::HostManager(
     : config_(hostConfig),
       statsExporterRegistry_(StatsExporterRegistry::Stats()) {
   // TODO: move all initialization out of constructor.
-#ifdef FACEBOOK_INTERNAL
-  LOG(INFO) << "Starting host manager with deviceConfigs: "
-            << deviceConfigs.size();
-  for (auto &config : deviceConfigs) {
-    LOG(INFO) << "Backend " << config->deviceID << ": " << config->backendName;
-  }
-#endif
   auto reporters = ErrorReporterRegistry::ErrorReporters();
 
   auto err = init(std::move(deviceConfigs));


### PR DESCRIPTION
Summary:
remove logging that was causing the test to fail
still not sure what happened here, but reverting this change will fix it
will reintroduce this logging after more investigation is done

Reviewed By: jfix71

Differential Revision: D26038621

