### PR TITLE
Allow Quantized Input Meta

### DIFF
--- a/torch_glow/src/GlowCompileSpec.cpp
+++ b/torch_glow/src/GlowCompileSpec.cpp
@@ -108,7 +108,8 @@ void registerPyTorchGlowCustomClasses() {
           .def(torch::init())
           .def("get_elem_type", &InputSpec::get_elem_type)
           .def("get_dims", &InputSpec::get_dims)
-          .def("set", &InputSpec::set)
+          .def("set_non_quantized_tensor", &InputSpec::set_non_quantized_tensor)
+          .def("set_quantized_tensor", &InputSpec::set_quantized_tensor)
           .def("set_same_as", &InputSpec::set_same_as);
   addSerializationDefs<InputSpec>(InputSpec_registry);
 

--- a/torch_glow/src/InputMeta.h
+++ b/torch_glow/src/InputMeta.h
@@ -30,19 +30,26 @@ namespace glow {
 struct InputMeta {
   c10::ScalarType type;
   std::vector<glow::sdim_t> dims;
+  double scale;
+  int64_t offset;
 
-  InputMeta(c10::ScalarType type_, std::vector<glow::sdim_t> &&dims_)
-      : type(type_), dims(std::move(dims_)) {}
+  InputMeta(c10::ScalarType type_, std::vector<glow::sdim_t> &&dims_,
+            double scale_ = 1.0, int64_t offset_ = 0)
+      : type(type_), dims(std::move(dims_)), scale(scale_), offset(offset_) {}
 
-  InputMeta(c10::ScalarType type_, const std::vector<glow::sdim_t> &dims_)
-      : type(type_), dims(dims_) {}
+  InputMeta(c10::ScalarType type_, const std::vector<glow::sdim_t> &dims_,
+            double scale_ = 1.0, int64_t offset_ = 0)
+      : type(type_), dims(dims_), scale(scale_), offset(offset_) {}
 
-  InputMeta(c10::ScalarType type_, c10::IntArrayRef dims_)
+  InputMeta(c10::ScalarType type_, c10::IntArrayRef dims_, double scale_ = 1.0,
+            int64_t offset_ = 0)
       : type(type_),
-        dims(std::vector<glow::sdim_t>(dims_.begin(), dims_.end())) {}
+        dims(std::vector<glow::sdim_t>(dims_.begin(), dims_.end())),
+        scale(scale_), offset(offset_) {}
 
   bool operator==(const InputMeta &other) const {
-    return type == other.type && dims == other.dims;
+    return type == other.type && dims == other.dims && scale == other.scale &&
+           offset == other.offset;
   }
 
   /// Produce a printable string for the InputMeta

--- a/torch_glow/tests/functionality/input_spec_test.py
+++ b/torch_glow/tests/functionality/input_spec_test.py
@@ -1,0 +1,62 @@
+# isort:skip_file
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+
+import torch
+import torch_glow
+
+
+def get_compilation_spec(inputs):
+    """helper function to get the compilation spec of the submodule"""
+    spec = torch_glow.CompilationSpec()
+    spec.get_settings().set_glow_backend("Interpreter")
+
+    compilation_group = torch_glow.CompilationGroup()
+    spec.compilation_groups_append(compilation_group)
+
+    compilation_group.input_sets_append(torch_glow.input_specs_from_tensors(inputs))
+    return spec
+
+
+class QuantizedModule(torch.nn.Module):
+    def forward(self, a, b):
+        return torch.ops.quantized.add(a, b, scale=1.0 / 21, zero_point=10)
+
+
+class TestModule(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.quant = torch.nn.quantized.Quantize(
+            scale=1.0 / 21, zero_point=0, dtype=torch.qint8
+        )
+        self.dequant = torch.nn.quantized.DeQuantize()
+        self.add = QuantizedModule()
+
+    def forward(self, a, b):
+        return self.dequant(self.add(self.quant(a), self.quant(b)))
+
+
+class TestInputSpec(unittest.TestCase):
+    def test_input_spec(self):
+        """Test setting quantized and non-quantized input specs."""
+        with torch.no_grad():
+            a = torch.tensor([[0.1]])
+            b = torch.tensor([[0.1]])
+
+            mod = TestModule()
+            traced_model = torch.jit.trace(mod, (a, b))
+            ref_result = traced_model(a, b)
+
+            # test non-quantized input
+            glow_mod = torch_glow.to_glow(traced_model, get_compilation_spec((a, b)))
+            glow_result = glow_mod(a, b)
+            self.assertTrue(torch.allclose(ref_result, glow_result))
+
+            # test quantized input
+            add_inputs = torch_glow.get_submod_inputs(mod, "add", (a, b))
+            glow_mod = torch_glow.to_glow_selective(
+                traced_model, {"add": get_compilation_spec(add_inputs)}
+            )
+            glow_result = glow_mod(a, b)
+            self.assertTrue(torch.allclose(ref_result, glow_result))


### PR DESCRIPTION
Summary:
In FX net minimizer and splitter, we want to be able to split the net arbitrarily, which means we would have quantized input to acc subgraph.

1. Add fields to InputSpec and InputMeta so they can store scale and offset
2. When loading InputMetas in PytorchModelLoader take care of qint8 and quint8 cases.

Differential Revision: D26051771

