### PR TITLE
Fix destruction of pass caused fusion disabling problem

### DIFF
--- a/torch_glow/src/Registration.cpp
+++ b/torch_glow/src/Registration.cpp
@@ -194,8 +194,8 @@ void registerGlowOp(const c10::Symbol &symbol) {
 }
 
 void registerGlowFusionPass(std::function<bool()> enablePassFn) {
-  torch::jit::RegisterPass pass([enablePassFn = std::move(enablePassFn)](
-                                    std::shared_ptr<torch::jit::Graph> &g) {
+  torch::jit::registerPostPass([enablePassFn = std::move(enablePassFn)](
+                                   std::shared_ptr<torch::jit::Graph> &g) {
     if (enablePassFn()) {
       auto settings = getGlobalPyTorchLoaderSettingsSnapshot();
       glow::glowCustomFuse(g, settings, getGlowSymbol());


### PR DESCRIPTION
Summary:
Fusion pass registration was changed by D25850783, which destruct pass registration after its life cycle.
In this diff, we set the pass to be static to make sure its life cycle long enough.

Differential Revision: D26070119

