### PR TITLE
Zero out embedding table based on padIdx

### DIFF
--- a/lib/Backends/NNPI/Importer.cpp
+++ b/lib/Backends/NNPI/Importer.cpp
@@ -1408,42 +1408,10 @@ public:
 class EmbeddingNodeImporter : public INNPINodeImporter {
 public:
   NNPIErrorCode importNode(Node *n, NNPIImporter &importer) override {
-    auto *glowEmbedding = llvm::dyn_cast<EmbeddingNode>(n);
-    LOG_AND_RETURN_IF_NOT(ERROR, glowEmbedding, "Bad node type",
-                          NNPI_INVALID_PARAM);
+    LOG(ERROR) << "All EmbeddingNode should be lowered to GatherNode, please "
+                  "check if importing EmbeddingNode is desired behavior.";
 
-    auto wtDim = glowEmbedding->getWeights().getType()->dims().size();
-    LOG_AND_RETURN_IF_NOT(ERROR, wtDim == 2,
-                          "[Embedding] weight dimensions must be 2",
-                          NNPI_INVALID_PARAM);
-    int64_t padIdx = glowEmbedding->getPadIdx();
-
-    LOG_AND_RETURN_IF_NOT(ERROR, padIdx == -1,
-                          "[Embedding] real padIdx not supported",
-                          NNPI_INVALID_PARAM);
-
-    bool scale = glowEmbedding->getScale();
-    LOG_AND_RETURN_IF_NOT(ERROR, !scale, "[Embedding] scale must be false",
-                          NNPI_INVALID_PARAM);
-
-    bool sparse = glowEmbedding->getSparse();
-    LOG_AND_RETURN_IF_NOT(ERROR, !sparse, "[Embedding] sparse must be false",
-                          NNPI_INVALID_PARAM);
-
-    importer.setUsedTensors(
-        {
-            nodeValueName(glowEmbedding->getWeights()),
-            nodeValueName(glowEmbedding->getIndices()),
-        },
-        {nodeValueName(glowEmbedding->getResult())});
-
-    auto res = nnpiNetworkAddGatherOp(
-        importer.getNetwork(), glowEmbedding->getName().begin(),
-        nodeValueName(glowEmbedding->getWeights()).c_str(),
-        nodeValueName(glowEmbedding->getIndices()).c_str(),
-        nodeValueName(glowEmbedding->getResult()).c_str(), 0);
-
-    return res;
+    return NNPI_IMPORTER_ERROR;
   }
 };
 

--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -1446,6 +1446,84 @@ static_assert(ActivationIOIdx == SigmoidNode::ResultIdx, "Format incorrect");
 static_assert(ActivationIOIdx == TanhNode::InputIdx, "Format incorrect");
 static_assert(ActivationIOIdx == TanhNode::ResultIdx, "Format incorrect");
 
+template <typename T>
+void zeroOutEmbeddingTable(Tensor &tensor, const int64_t &padIdx) {
+  auto handle = tensor.getHandle<T>();
+  size_t base = handle.getElementPtr({static_cast<unsigned long>(padIdx)});
+  for (unsigned i = 0; i < tensor.dims()[1]; i++) {
+    handle.raw(base + i) = 0;
+  }
+}
+
+/// Helper which looks for EmbeddingNode that has padIdx specified and lower it
+/// to GatherNode. Since Gather doesn't support padIdx so we'll need to zero out
+/// those index before creating GatherNode.
+bool lowerEmbeddingToGather(Function *F) {
+  bool changed = false;
+
+  for (auto &N : F->getNodes()) {
+    auto *EN = llvm::dyn_cast<EmbeddingNode>(&N);
+    if (!EN) {
+      continue;
+    }
+
+    auto weightsNV = EN->getWeights();
+    auto padIdx = EN->getPadIdx();
+
+    DCHECK(weightsNV.dims().size() == 2)
+        << "Expect [Embedding] weight dimensions be 2, but got "
+        << weightsNV.dims().size();
+    DCHECK(!EN->getScale()) << "[Embedding] scale must be false";
+    DCHECK(!EN->getSparse()) << "[Embedding] sparse must be false";
+
+    auto *weightsConstant = llvm::dyn_cast<glow::Constant>(weightsNV.getNode());
+
+    // If weightsConstant is not available, probably means we are doing AOT
+    if (!weightsConstant) {
+      continue;
+    }
+
+    // Zero out embedding table if padIdx is not -1
+    if (padIdx != -1) {
+      // If embedding table only has one user, we don't make additional copies
+      if (weightsConstant->hasOneUse()) {
+        auto &weightsTensorNew = weightsConstant->getPayloadMutable();
+
+        if (weightsTensorNew.getElementType() == ElemKind::FloatTy) {
+          zeroOutEmbeddingTable<float>(weightsTensorNew, padIdx);
+        } else if (weightsTensorNew.getElementType() == ElemKind::Float16Ty) {
+          zeroOutEmbeddingTable<float16_t>(weightsTensorNew, padIdx);
+        } else {
+          LOG(ERROR)
+              << "Unsupported Embedding weight Elemtype for transformation: "
+              << Type::getElementName(weightsTensorNew.getElementType()).str();
+        }
+      } else { // Embedding table has more than one user
+        auto weightsTensorNew = weightsConstant->getPayload().clone();
+
+        if (weightsTensorNew.getElementType() == ElemKind::FloatTy) {
+          zeroOutEmbeddingTable<float>(weightsTensorNew, padIdx);
+        } else if (weightsTensorNew.getElementType() == ElemKind::Float16Ty) {
+          zeroOutEmbeddingTable<float16_t>(weightsTensorNew, padIdx);
+        } else {
+          LOG(ERROR)
+              << "Unsupported Embedding weight Elemtype for transformation: "
+              << Type::getElementName(weightsTensorNew.getElementType()).str();
+        }
+
+        weightsConstant = F->getParent()->createConstant(
+            "PaddedEmbeddingWeights", std::move(weightsTensorNew));
+      }
+    }
+
+    auto *GN = F->createGather("embedding", weightsConstant, EN->getIndices());
+    EN->getResult().replaceAllUsesOfWith(GN);
+    changed = true;
+  }
+
+  return changed;
+}
+
 /// Helper which looks for Quantized Conv whose kernel is smaller than stride in
 /// one or more dimension. These kernels will be padded to at least stride size.
 static bool padKernelToStride(Function *F) {
@@ -1653,6 +1731,7 @@ Expected<bool> NNPIBackend::transformPostLowering(
 
   bool changed = removeClipsBlockingFusion(F);
   changed |= padKernelToStride(F);
+  changed |= lowerEmbeddingToGather(F);
   auto it =
       cctx.backendOpts.backendSpecificOpts.find("NNPI_ZeroScaleFP16Replace");
   if (it != cctx.backendOpts.backendSpecificOpts.end() && it->second == "1") {

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -14190,18 +14190,15 @@ static void testEmbedding(glow::PlaceholderBindings &bindings,
   // If hasEndOffset then add some additional junk to the end of indices and
   // weights and an extra offset to offsets.
 
-  auto *weights = mod.createPlaceholder(DTy, {3, 2}, "weights", false);
-  auto *indices =
-      mod.createPlaceholder(ElemKind::Int64ITy, {3}, "indices", false);
+  auto *weights = mod.createConstant(DTy, {3, 2}, "weights");
+  auto *indices = mod.createConstant(ElemKind::Int64ITy, {3}, "indices");
   bool scale = false;
   bool sparse = false;
-
   int64_t indexValues[] = {1, 0, 2};
 
-  bindings.allocate(weights)->getHandle<DataType>() = {2.0, -0.5, 4,
-                                                       5.1, 1,    2.3};
-
-  bindings.allocate(indices)->getHandle<int64_t>() = indexValues;
+  weights->getPayloadMutable().getHandle<DataType>() = {2.0, -0.5, 4,
+                                                        5.1, 1,    2.3};
+  indices->getPayloadMutable().getHandle<int64_t>() = indexValues;
 
   auto *R =
       F->createEmbedding("Embedding", weights, indices, padIdx, scale, sparse);

--- a/torch_glow/src/CachingGraphRunner.cpp
+++ b/torch_glow/src/CachingGraphRunner.cpp
@@ -596,7 +596,6 @@ Error CachingGraphRunner::runImpl(const PerGlowGraphInfo &info,
                 strFormat("Fail to propagate quantized dtype to output"));
           }
         }
-
         // Write the output from Glow to ONNX if necessary.
         if (settings.writeToOnnx) {
           glow::Tensor glowT = ptTensorToGlowTensor(ptTensor);


### PR DESCRIPTION
Summary:
1. Zero out the padIdx in embedding table if padIdx != -1
2. Lower EmbeddingNode to GatherNode

Reviewed By: jackm321

Differential Revision: D26077300

