### PR TITLE
[Interpreter Backend] Add support for BatchPermutation operator

### DIFF
--- a/include/glow/Backends/Interpreter/InterpreterFunction.h
+++ b/include/glow/Backends/Interpreter/InterpreterFunction.h
@@ -400,6 +400,9 @@ private:
   template <typename T>
   void fwdBBoxTransformInstFloatImpl(glow::BBoxTransformInst const *I);
 
+  template <typename T, typename InTy>
+  void fwdBatchPermutationInstImpl(glow::BatchPermutationInst const *I);
+
   template <typename T, typename AccumT>
   void fwdEmbeddingBagByteRowwiseOffsetsImpl(
       const EmbeddingBagByteRowwiseOffsetsInst *I);

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -2198,6 +2198,26 @@ public:
                       int64_t angleBoundLo, int64_t angleBoundHi,
                       float clipAngleThresh, bool legacyPlusOne);
 
+  /// Permute the batch elements of the input tensor X according to the
+  /// permutation specified in the input indices
+  /// Inputs:
+  /// - \p input - Tensor of at least 1D shape (N, D0, D1, ...)
+  /// - \p indices - 1D tensor with shape (M, ) where M <= N specifying a
+  ///    valid permutation of the indices.
+  /// Outputs:
+  /// - \p output - Tensor with the shape (M, D0, D1, ...) where the
+  ///    (D0, D1, ...) dimensional batch elements of input are permuted
+  ///    along the batch dimension according to input indices.
+  /// Note:
+  /// Caffe2 definition requires input and indices should have same value
+  /// at 0 dimension(i.e M == N). To fix the output shape while using
+  /// FasterRCNN network, mentioned changes have been made.
+  /// see definition:
+  /// https://github.com/pytorch/pytorch/blob/master/caffe2/operators/batch_permutation_op.cc#L48
+  BatchPermutationNode *createBatchPermutation(llvm::StringRef name,
+                                               NodeValue input,
+                                               NodeValue indices);
+
   /// Create an ExternFunctionCall node. \p funcImpl will contain body
   /// of or reference to the function which can be invoked.
   /// \p funcKind contains the type of function. The type of function  could be

--- a/lib/Backends/CPU/tests/CPUOperatorTest.cpp
+++ b/lib/Backends/CPU/tests/CPUOperatorTest.cpp
@@ -420,4 +420,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "batchedReduceAdd_Int32ITy/0",
     "Float16ArgMaxKeepDim/0",
     "Float16ArgMaxNoKeepDim/0",
+    "BatchPermutation/0",
+    "BatchPermutation_negative_index/0",
+    "BatchPermutation_Int32_indices/0",
 };

--- a/lib/Backends/Habana/tests/HabanaOperatorTest.cpp
+++ b/lib/Backends/Habana/tests/HabanaOperatorTest.cpp
@@ -459,4 +459,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "Upsample_Nearest1D_Float16/0",
     "Upsample_Nearest1D_Int8/0",
     "batchedReduceAdd_Int32ITy/0",
+    "BatchPermutation/0",
+    "BatchPermutation_negative_index/0",
+    "BatchPermutation_Int32_indices/0",
 };

--- a/lib/Backends/Interpreter/Interpreter.cpp
+++ b/lib/Backends/Interpreter/Interpreter.cpp
@@ -138,6 +138,15 @@ bool Interpreter::isOpSupported(const NodeInfo &NI) const {
         {ElemKind::Int32ITy, ElemKind::FloatTy, ElemKind::Float16Ty,
          ElemKind::BFloat16Ty, ElemKind::Int8QTy});
 
+  case Kinded::Kind::BatchPermutationNodeKind:
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::FloatTy, ElemKind::Float16Ty, ElemKind::Int8QTy},
+               /*ignoreIn*/ {BatchPermutationNode::IndicesIdx}) &&
+           ((NI.getInElemTy(BatchPermutationNode::IndicesIdx) ==
+             ElemKind::Int64ITy) ||
+            (NI.getInElemTy(BatchPermutationNode::IndicesIdx) ==
+             ElemKind::Int32ITy));
+
   case Kinded::Kind::MatMulNodeKind:
     return NI.allInputsAndOutputsHaveSameElemKind(
         {ElemKind::FloatTy, ElemKind::Float16Ty, ElemKind::BFloat16Ty,

--- a/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
@@ -119,6 +119,9 @@ struct BlacklistInitializer {
       {"ResizeNearest_BFloat16_outTy/0", TestBlacklist::AnyDeviceAnyEngine},
       {"ResizeNearest_Int16/0", TestBlacklist::AnyDeviceAnyEngine},
       {"ResizeNearest_Int16_outTy/0", TestBlacklist::AnyDeviceAnyEngine},
+      {"BatchPermutation/0", TestBlacklist::AnyDeviceAnyEngine},
+      {"BatchPermutation_negative_index/0", TestBlacklist::AnyDeviceAnyEngine},
+      {"BatchPermutation_Int32_indices/0", TestBlacklist::AnyDeviceAnyEngine},
 #if NNPI_MAJOR_VERSION == 1 && NNPI_MINOR_VERSION == 0
       {"Upsample_Nearest3D_Float/0", TestBlacklist::AnyDeviceAnyEngine},
       {"Upsample_Nearest3D_Float16/0", TestBlacklist::AnyDeviceAnyEngine},

--- a/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
@@ -651,4 +651,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "Upsample_Nearest1D_Float16/0",
     "Upsample_Nearest1D_Int8/0",
     "batchedReduceAdd_Int32ITy/0",
+    "BatchPermutation/0",
+    "BatchPermutation_negative_index/0",
+    "BatchPermutation_Int32_indices/0",
 };

--- a/lib/Exporter/ONNXModelWriter.cpp
+++ b/lib/Exporter/ONNXModelWriter.cpp
@@ -1808,6 +1808,13 @@ Error ONNXModelWriter::writeGatherND(const GatherNDNode *node,
   return writeAllWithNode("GatherND", node, graph, proto);
 }
 
+Error ONNXModelWriter::writeBatchPermutation(const BatchPermutationNode *node,
+                                             GraphType &graph) {
+  auto *proto = graph.add_node();
+  // Add dictionary entries.
+  return writeAllWithNode("BatchPermutation", node, graph, proto);
+}
+
 Error ONNXModelWriter::writeMatMul(const MatMulNode *node, GraphType &graph) {
   return writeMatMulKind(node, graph, "MatMul");
 }

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -5185,6 +5185,22 @@ BBoxTransformNode *Function::createBBoxTransform(
       clipAngleThresh, legacyPlusOne));
 }
 
+BatchPermutationNode *Function::createBatchPermutation(llvm::StringRef name,
+                                                       NodeValue input,
+                                                       NodeValue indices) {
+  auto inputDims = input.dims();
+  auto indicesDims = indices.dims();
+  std::vector<dim_t> outDims;
+  // Calculate output tensor shape from input and indices dimensions
+  for (auto dim : inputDims) {
+    outDims.push_back(dim);
+  }
+  outDims[0] = indicesDims[0];
+  auto outTy = getParent()->uniqueTypeWithNewShape(input.getType(), outDims);
+
+  return addNode(new BatchPermutationNode(name, outTy, input, indices));
+}
+
 ExternalFunctionCallNode *Function::createExternalFunctionCall(
     llvm::StringRef name, TypeRef outTy, llvm::ArrayRef<glow::NodeValue> inputs,
     llvm::StringRef funcName, llvm::StringRef funcImpl,

--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -2580,6 +2580,32 @@ bool ModuloNode::verify() const { return getDivisor() >= 1; }
 
 bool ExternalFunctionCallNode::verify() const { return true; }
 
+bool BatchPermutationNode::verify() const {
+  auto input = getInput();
+  auto indices = getIndices();
+  auto output = getOutput();
+
+  auto inputDims = input.dims();
+  auto outputDims = output.dims();
+  auto indicesDims = indices.dims();
+  bool isValid = checkTypeIgnoreShape(input, output, this);
+  isValid &= expectCompareTrue("Output and Indices must have same 0 dimension",
+                               outputDims[0], indicesDims[0], this);
+  isValid &= expectCompareTrue("Indices must be a 1D tensor",
+                               indicesDims.size(), size_t(1), this);
+  isValid &= expectCompareTrue("Input and Ouput must have same dimension size",
+                               inputDims.size(), outputDims.size(), this);
+  isValid &= expectCompareTrue(
+      "Input should be greater than or equal to output at 0 dimension",
+      inputDims[0] >= outputDims[0], true, this);
+  for (auto i = 1; i < inputDims.size(); ++i) {
+    isValid &=
+        expectCompareTrue("Dimension value mismatch between input and output",
+                          inputDims[i], outputDims[i], this);
+  }
+  return isValid;
+}
+
 //===----------------------------------------------------------------------===//
 //                     Node hashing support
 //===----------------------------------------------------------------------===//

--- a/lib/Graph/TensorLayout.cpp
+++ b/lib/Graph/TensorLayout.cpp
@@ -708,6 +708,7 @@ static bool acceptsAnyInputLayout(const glow::Node *node) {
   case Kinded::Kind::InsertTensorNodeKind:
   case Kinded::Kind::SGDNodeKind:
   case Kinded::Kind::BroadcastNodeKind:
+  case Kinded::Kind::BatchPermutationNodeKind:
     return true;
   default:
     return false;

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -1029,6 +1029,13 @@ int main(int argc, char **argv) {
       .autoVerify(VerifyKind::SameElementType, {"Dest", "Src"})
       .autoIRGen();
 
+  BB.newInstr("BatchPermutation")
+      .addOperand("Output", OperandKind::Out)
+      .addOperand("Input", OperandKind::In)
+      .addOperand("Indices", OperandKind::In)
+      .autoVerify(VerifyKind::SameElementType, {"Input", "Output"})
+      .autoIRGen();
+
   //===--------------------------------------------------------------------===//
   //                Reorder transformations
   //===--------------------------------------------------------------------===//

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -1154,6 +1154,20 @@ int main(int argc, char **argv) {
           "Broadcast the Input tensor to TargetDim using Axis to indicate the "
           "offset between Input dimension and TargetDim");
 
+  BB.newNode("BatchPermutation")
+      .addInput("Input")
+      .addInput("Indices")
+      .addResultFromCtorArg("Output")
+      .setDocstring(
+          "Given Input tensor of [N, D0, D1, ..], 1D Indices tensor of [M,], "
+          "where M <= N performs permutation along the batch elements of "
+          "Input and generates an Output tensor with shape [M, D0, D1, ..] "
+          "where (D0, D1, ..) dimensional batch elements are re-ordered "
+          "according to Indices. Caffe2 definition requires input and indices "
+          "should have same value at 0 dimension(i.e M == N). To fix the "
+          "shape while using FasterRCNN/MaskRCNN network, mentioned changes "
+          "have been made.");
+
   //===--------------------------------------------------------------------===//
   //                Reorder transformations
   //===--------------------------------------------------------------------===//


### PR DESCRIPTION
Summary:
Adding support for BatchPermutation operator Interpreter backend implementation

Documentation: None

Test Plan: Ninja test is run, added  InterpreterOperatorTest cases