### PR TITLE
Improve partitioning algorithm with more heuristics

### DIFF
--- a/include/glow/Flags/Flags.h
+++ b/include/glow/Flags/Flags.h
@@ -134,6 +134,7 @@ extern unsigned InterpreterMemory;
 extern bool EnableP2P;
 extern bool EnableDRT;
 extern unsigned DeviceInitTimeoutMs;
+extern uint64_t BigTableThresholdBytes;
 extern unsigned SanitizeInputsPercent;
 } // namespace flags
 } // namespace runtime

--- a/include/glow/Partitioner/PartitionerTypes.h
+++ b/include/glow/Partitioner/PartitionerTypes.h
@@ -95,6 +95,22 @@ struct BackendInfo {
   std::set<Kinded::Kind> supportedNodesKinds;
 };
 
+struct SLSTableInfo {
+  Node *node;
+  std::unordered_set<Node *> neighbors;
+  std::unordered_set<NodeValue> frontier;
+  uint64_t numBytesInTable;
+  unsigned int deviceId;
+  NodeValue slsResult;
+  uint64_t cost;
+};
+
+struct SLSDeviceInfo {
+  unsigned int deviceId;
+  uint64_t memAvailableInBytes;
+  size_t currentCost;
+};
+
 /// A mapping of newly-created functions along with a set of nodes sets. The
 /// overloaded compare function to make sure the map is sorted by the key's
 /// name(i.e. the function's name) which makes the optimization sequence is

--- a/include/glow/Partitioner/PartitionerUtils.h
+++ b/include/glow/Partitioner/PartitionerUtils.h
@@ -63,5 +63,59 @@ std::set<Kinded::Kind> generateNodeKindsSet(llvm::StringRef names);
 
 /// Log the info of current partition \p partitions.
 void logPartitionInfo(const NodeToFunctionMap &partitions);
+
+/// Print numBytesInTable, deviceID, cost and cost/numBytesInTable.
+/// Print item from [start to end), with start inclusively and end
+/// exclusively.
+void printSlsTableInfo(std::vector<SLSTableInfo>::iterator start,
+                       std::vector<SLSTableInfo>::iterator end);
+void printSlsTableInfo(std::vector<SLSTableInfo> &slsTables);
+
+/// Print deviceId, used_memory, free_memory, cost, node_size, cost/used_memory.
+/// Used memeory is calculated using \p nodesets and \p contextCount.
+void printSlsDeviceInfo(const std::vector<SLSDeviceInfo> &slsDevices,
+                        const std::vector<NodesSet> &nodesets,
+                        const unsigned contextCount);
+
+/// Loop through slsDevices, assign \p table to first available \p slsDevices
+/// that can fit \p table.
+/// \returns Error if we could not find one.
+Error assignSlsTableToFirstAvailableDevice(
+    SLSTableInfo &table, std::vector<SLSDeviceInfo> &slsDevices,
+    std::vector<NodesSet> &nodesets,
+    std::vector<std::unordered_set<NodeValue>> &frontierValues,
+    const unsigned contextCount);
+
+/// Assign \p slsTables to \p slsDevices by:
+/// 1. Sort \p slsTables by size decreasing.
+/// 2. Split \p slsTables into two parts: large tables, and small tables where
+/// large tables have numBytesInTable >
+/// glow::runtime::flags::BigTableThresholdBytes.
+/// 3. For large tables, we sort tables by size, and then for each table we
+/// assign it to the device with lowest size.
+/// 4. For small tables, we sort tables by cost, and then for each table we
+/// assign it to the device with lowest cost.
+///
+/// \returns Error if we could not find a feasible partitioning plan to fit all
+/// slsTables into slsDevices.
+/// In case of error, all the inputs will be restored to original values.
+Error assignSlsTablesToDevices(
+    std::vector<SLSTableInfo> &slsTables,
+    std::vector<SLSDeviceInfo> &slsDevices,
+    std::vector<std::unordered_set<NodeValue>> &frontierValues,
+    const unsigned contextCount);
+
+/// Assign \p slsTables to \p slsDevices by:
+/// Sort \p slsTables by size, then for each sls table, assign to slsDevice with
+/// lowest cost.
+///
+/// \returns Error if we could not find a feasible allocation plan to fit all
+/// slsTables into slsDevices.
+/// In case of error, all the inputs will be restored to original values.
+Error assignSlsTablesToDevicesGreedy(
+    std::vector<SLSTableInfo> &slsTables,
+    std::vector<SLSDeviceInfo> &slsDevices,
+    std::vector<std::unordered_set<NodeValue>> &frontierValues,
+    const unsigned contextCount);
 } // namespace glow
 #endif // GLOW_PARTITIONER_PARTITIONUTILS_H

--- a/lib/Flags/Flags.cpp
+++ b/lib/Flags/Flags.cpp
@@ -141,7 +141,7 @@ bool EnableP2P = false;
 bool EnableDRT = false;
 unsigned DeviceInitTimeoutMs = 5000;
 unsigned SanitizeInputsPercent = 0;
-
+uint64_t BigTableThresholdBytes = 104857600; // 100MB
 } // namespace flags
 } // namespace runtime
 } // namespace glow
@@ -598,6 +598,16 @@ DEFINE_validator(glow_device_init_timeout_ms, [](const char *, int32_t val) {
   glow::runtime::flags::DeviceInitTimeoutMs = val;
   return true;
 });
+DEFINE_uint64(
+    glow_partition_big_table_threshold_bytes,
+    glow::runtime::flags::BigTableThresholdBytes,
+    "Threshold to determin big tables, and used in partitioning algorithm. "
+    "Default 104857600(100MB)");
+DEFINE_validator(glow_partition_big_table_threshold_bytes,
+                 [](const char *, uint64_t val) {
+                   glow::runtime::flags::BigTableThresholdBytes = val;
+                   return true;
+                 });
 DEFINE_int32(glow_enable_sanitize_inputs,
              glow::runtime::flags::SanitizeInputsPercent,
              "Sanitize a percentage of inferences");

--- a/lib/Partitioner/Partitioner.cpp
+++ b/lib/Partitioner/Partitioner.cpp
@@ -1036,24 +1036,6 @@ Partitioner::setupPrepartitionedModule(CompilationContext &cctx) {
   return std::move(partitions);
 }
 
-namespace {
-struct SLSTableInfo {
-  Node *node;
-  std::unordered_set<Node *> neighbors;
-  std::unordered_set<NodeValue> frontier;
-  uint64_t numBytesInTable;
-  unsigned int deviceId;
-  NodeValue slsResult;
-  uint64_t cost;
-};
-
-struct SLSDeviceInfo {
-  unsigned int deviceId;
-  uint64_t memAvailableInBytes;
-  size_t currentCost;
-};
-} // namespace
-
 // Do a search starting at an SLS output to capture any Clip or
 // LayerNormalization nodes which are there
 static void expandFrontier(Node *node, const NodeValue &value,
@@ -1349,20 +1331,6 @@ Expected<DAGListTy> Partitioner::partitionSparseNN(CompilationContext &cctx) {
           totalDeviceMemory));
   const uint64_t allowedSLSMemBytes = totalDeviceMemory - nonSLSPartitionSize;
 
-  // Now sort SLS tables by size decreasing
-  VLOG(1) << "SLS tables sorted by size decreasing" << std::endl;
-  std::sort(slsTables.begin(), slsTables.end(),
-            [](const SLSTableInfo &l, const SLSTableInfo &r) {
-              return l.numBytesInTable > r.numBytesInTable;
-            });
-
-  // Print SLS tables
-  for (auto &table : slsTables) {
-    VLOG(1) << "(numBytesInTable, deviceID, cost)"
-            << "\t" << table.numBytesInTable << "\t" << table.deviceId << "\t"
-            << table.cost << std::endl;
-  }
-
   // Create table of devices
   std::vector<SLSDeviceInfo> slsDevices;
   for (unsigned int device = 0;
@@ -1370,73 +1338,19 @@ Expected<DAGListTy> Partitioner::partitionSparseNN(CompilationContext &cctx) {
        device++) {
     slsDevices.push_back({device, allowedSLSMemBytes, 0});
   }
+  std::vector<std::unordered_set<NodeValue>> frontierValues(slsDevices.size());
 
   // Now assign SLS Nodes to devices
-  std::vector<std::unordered_set<NodeValue>> frontierValues(slsDevices.size());
-  std::vector<NodesSet> nodesets(slsDevices.size());
-  for (auto &table : slsTables) {
-
-    // Sort by cost increasing
-    std::sort(slsDevices.begin(), slsDevices.end(),
-              [](const SLSDeviceInfo &l, const SLSDeviceInfo &r) {
-                return l.currentCost < r.currentCost;
-              });
-
-    VLOG(1) << "Devices sorted by cost increasing" << std::endl;
-    for (const auto &device : slsDevices) {
-      const auto deviceId = device.deviceId;
-      auto meminfo = getGraphMemInfo(nodesets[deviceId], contextCount_);
-      const auto totalSize = meminfo.getTotalMemSize();
-      VLOG(1) << "(deviceId, memAvailableInBytes, totalSize, currentCost): "
-              << device.deviceId << "\t" << device.memAvailableInBytes << "\t"
-              << totalSize << "\t" << device.currentCost << std::endl;
-    }
-
-    // Pick the first that fits
-    bool deviceFound = false;
-    for (auto &d : slsDevices) {
-      const auto deviceId = d.deviceId;
-      // Calculate the memory needed if we merge SLS and its neighboring nodes
-      // into existing partition
-      auto nodesSetd = nodesets[deviceId];
-      nodesSetd.insert(table.node);
-      nodesSetd.insert(table.neighbors.begin(), table.neighbors.end());
-      auto meminfo = getGraphMemInfo(nodesSetd, contextCount_);
-      const auto totalSize = meminfo.getTotalMemSize();
-      if (d.memAvailableInBytes >= totalSize) {
-        deviceFound = true;
-        d.currentCost += (size_t)table.cost;
-        table.deviceId = d.deviceId;
-        frontierValues[table.deviceId].insert(table.frontier.begin(),
-                                              table.frontier.end());
-        nodesets[deviceId].swap(nodesSetd);
-        break;
-      }
-    }
-    if (!deviceFound) {
-      return MAKE_ERR(ErrorValue::ErrorCode::PARTITIONER_ERROR,
-                      "SLS Balancing Partitioning Error: Not enough memory");
-    }
+  if (ERR_TO_BOOL(assignSlsTablesToDevices(slsTables, slsDevices,
+                                           frontierValues, contextCount_))) {
+    LOG(INFO)
+        << "Failed to partition SLS tables, fall back to greedy algorithm.";
+    RETURN_IF_ERR(assignSlsTablesToDevicesGreedy(
+        slsTables, slsDevices, frontierValues, contextCount_));
   }
-
-  // Print final device info
-  VLOG(1) << "Devices sorted by cost increasing: ";
-  for (const auto &d : slsDevices) {
-    const auto deviceId = d.deviceId;
-    auto meminfo = getGraphMemInfo(nodesets[deviceId], contextCount_);
-    const auto totalSize = meminfo.getTotalMemSize();
-    VLOG(1) << "deviceId: " << deviceId << ", used memory: " << totalSize
-            << ", available memory: " << (d.memAvailableInBytes - totalSize)
-            << ", cost: " << d.currentCost
-            << ", node size: " << nodesets[deviceId].size();
-  }
-
-  // Print assignments
-  for (auto &table : slsTables) {
-    VLOG(1) << "(numBytesInTable, deviceId, cost)"
-            << "\t" << table.numBytesInTable << "\t" << table.deviceId << "\t"
-            << table.cost << std::endl;
-  }
+  // Print final table assignments
+  LOG(INFO) << "Final table assignments: ";
+  printSlsTableInfo(slsTables);
 
   // Create manual partition
   partitionConfig.numOfPartitions = slsDevices.size() + 1;

--- a/lib/Partitioner/PartitionerUtils.cpp
+++ b/lib/Partitioner/PartitionerUtils.cpp
@@ -13,9 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 #include "glow/Partitioner/PartitionerUtils.h"
+#include "glow/Flags/Flags.h"
 #include "glow/Partitioner/PartitionerTypes.h"
+#include "glow/Support/Support.h"
+
 #include <unordered_set>
 
 using llvm::isa;
@@ -27,6 +29,7 @@ namespace {
 auto compFunc = [](const Node *n1, Node *n2) -> bool {
   return n1->compareByName(*n2);
 };
+constexpr uint32_t MB = 1024 * 1024;
 } // namespace
 
 /// The nodes in function \p F which be grouped into levels based on how far
@@ -555,4 +558,256 @@ void logPartitionInfo(const NodeToFunctionMap &partitions) {
     }
   }
 }
+
+void printSlsTableInfo(std::vector<SLSTableInfo>::iterator start,
+                       std::vector<SLSTableInfo>::iterator end) {
+  if (start >= end) {
+    return;
+  }
+  LOG(INFO) << "(numBytesInTable(MB), deviceID, cost, cost/numBytesInTable) "
+            << strFormat(" - %zu tables -", end - start);
+  while (start < end) {
+    const auto tableSizeInMB = (float)start->numBytesInTable / MB;
+    const auto costPerByte = tableSizeInMB == 0
+                                 ? "nan"
+                                 : std::to_string(start->cost / tableSizeInMB);
+    LOG(INFO) << "        " << tableSizeInMB << "        " << start->deviceId
+              << "      " << start->cost << "      " << costPerByte
+              << std::endl;
+    start++;
+  }
+}
+
+void printSlsTableInfo(std::vector<SLSTableInfo> &slsTables) {
+  printSlsTableInfo(slsTables.begin(), slsTables.end());
+}
+
+void printSlsDeviceInfo(const std::vector<SLSDeviceInfo> &slsDevices,
+                        const std::vector<NodesSet> &nodesets,
+                        const unsigned contextCount) {
+  LOG(INFO) << "(deviceId, used_memory(MB), free_memory(MB), cost, "
+               "node_size, cost/used_memory)"
+            << strFormat(" - %zu devices -", slsDevices.size());
+  for (const auto &d : slsDevices) {
+    const auto deviceId = d.deviceId;
+    const auto meminfo = getGraphMemInfo(nodesets[deviceId], contextCount);
+    const auto usedMem = (float)meminfo.getTotalMemSize() / MB;
+    const auto availMem = (float)d.memAvailableInBytes / MB;
+    const auto freeMem = availMem - usedMem;
+    const auto costPerUsedMemory =
+        usedMem == 0 ? "nan" : std::to_string(d.currentCost / usedMem);
+    LOG(INFO) << "    " << deviceId << "         " << usedMem << "         "
+              << freeMem << "      " << d.currentCost << "      "
+              << nodesets[deviceId].size() << "      " << costPerUsedMemory;
+  }
+}
+
+Error assignSlsTableToFirstAvailableDevice(
+    SLSTableInfo &table, std::vector<SLSDeviceInfo> &slsDevices,
+    std::vector<NodesSet> &nodesets,
+    std::vector<std::unordered_set<NodeValue>> &frontierValues,
+    const unsigned contextCount) {
+  DCHECK(slsDevices.size() == nodesets.size() &&
+         slsDevices.size() == frontierValues.size());
+  bool deviceFound = false;
+  for (auto &d : slsDevices) {
+    const auto deviceId = d.deviceId;
+    // Calculate the memory needed if we merge SLS and its neighboring nodes
+    // into existing partition
+    auto nodesSetd = nodesets[deviceId];
+    nodesSetd.insert(table.node);
+    nodesSetd.insert(table.neighbors.begin(), table.neighbors.end());
+    auto meminfo = getGraphMemInfo(nodesSetd, contextCount);
+    const auto totalSize = meminfo.getTotalMemSize();
+    if (d.memAvailableInBytes >= totalSize) {
+      d.currentCost += (size_t)table.cost;
+      table.deviceId = deviceId;
+      frontierValues[deviceId].insert(table.frontier.begin(),
+                                      table.frontier.end());
+      nodesets[deviceId].swap(nodesSetd);
+      deviceFound = true;
+      break;
+    }
+  }
+  if (!deviceFound) {
+    return MAKE_ERR(ErrorValue::ErrorCode::PARTITIONER_ERROR,
+                    "SLS Balancing Partitioning Error: Not enough memory");
+  }
+  return Error::success();
+}
+
+Error assignSlsTablesToDevices(
+    std::vector<SLSTableInfo> &slsTables,
+    std::vector<SLSDeviceInfo> &slsDevices,
+    std::vector<std::unordered_set<NodeValue>> &frontierValues,
+    const unsigned contextCount) {
+  if (slsTables.empty()) {
+    LOG(INFO) << "SLS tables empty!";
+    return Error::success();
+  }
+  // Keep a copy of input parameters, so that ScopeGuard could restore
+  // inputs in case of error.
+  std::vector<SLSTableInfo> slsTablesCopy = slsTables;
+  std::vector<SLSDeviceInfo> slsDevicesCopy = slsDevices;
+  std::vector<std::unordered_set<NodeValue>> frontierValuesCopy =
+      frontierValues;
+  ScopeGuard restoreInputsOnError([&]() {
+    slsTables.swap(slsTablesCopy);
+    slsDevices.swap(slsDevicesCopy);
+    frontierValues.swap(frontierValuesCopy);
+  });
+
+  // Now sort SLS tables by size decreasing
+  LOG(INFO) << "SLS tables sorted by size decreasing" << std::endl;
+  std::sort(slsTables.begin(), slsTables.end(),
+            [](const SLSTableInfo &l, const SLSTableInfo &r) {
+              return l.numBytesInTable > r.numBytesInTable;
+            });
+
+  // slsTables is in sorted order decreasingly by numBytesInTable.
+  // The tables between [slsTablesLeft, slsTableRight) are large tables that
+  // have numBytesInTable > BigTableThresholdBytes.
+  // slsTablesLeft and slsTablesRight will be both pointed to slsTables.begin()
+  // if we could not find any large tables.
+  auto slsTablesLeft = slsTables.begin();
+  auto slsTableRight = slsTables.end();
+  if (slsTablesLeft->numBytesInTable >
+      glow::runtime::flags::BigTableThresholdBytes) {
+    for (auto it = slsTables.begin(); it < slsTables.end(); it++) {
+      if (it->numBytesInTable <= glow::runtime::flags::BigTableThresholdBytes) {
+        slsTableRight = it;
+        break;
+      }
+    }
+  } else {
+    // No large table found.
+    slsTablesLeft = slsTables.begin();
+    slsTableRight = slsTables.begin();
+  }
+
+  // We first assign large tables to devices. After allocation, each device
+  // should has roughly the same size.
+  LOG(INFO) << strFormat("Now assign %zu large tables to %zu devices.",
+                         (slsTableRight - slsTablesLeft), slsDevices.size());
+  // Print Large SLS tables
+  LOG(INFO) << "Large tables by size decreasing: ";
+  printSlsTableInfo(slsTablesLeft, slsTableRight);
+  std::vector<NodesSet> nodesets(slsDevices.size());
+  while (slsTablesLeft < slsTableRight) {
+    // Sort devices by size increasingly.
+    std::sort(slsDevices.begin(), slsDevices.end(),
+              [&nodesets, contextCount](const SLSDeviceInfo &l,
+                                        const SLSDeviceInfo &r) {
+                auto lTotalSize =
+                    getGraphMemInfo(nodesets[l.deviceId], contextCount)
+                        .getTotalMemSize();
+                auto rTotalSize =
+                    getGraphMemInfo(nodesets[r.deviceId], contextCount)
+                        .getTotalMemSize();
+                return lTotalSize < rTotalSize;
+              });
+    LOG(INFO) << "Devices sorted by used memory increasing: ";
+    printSlsDeviceInfo(slsDevices, nodesets, contextCount);
+
+    // Pick the first that fits
+    auto &table = *slsTablesLeft;
+    RETURN_IF_ERR(assignSlsTableToFirstAvailableDevice(
+        table, slsDevices, nodesets, frontierValues, contextCount));
+    slsTablesLeft++;
+  }
+  LOG(INFO) << "Done assigning large tables, devices info: ";
+  printSlsDeviceInfo(slsDevices, nodesets, contextCount);
+
+  // Now let us assign small size tables.
+  // First sort tables by cost decreasingly. For each table, we would like to
+  // assign it to the device with lowest cost.
+  LOG(INFO) << strFormat("Now assign %zu small tables to %zu devices.",
+                         (slsTables.end() - slsTablesLeft), slsDevices.size());
+  if (slsTablesLeft < slsTables.end()) {
+    std::sort(slsTablesLeft, slsTables.end(),
+              [](const SLSTableInfo &l, const SLSTableInfo &r) {
+                return l.cost > r.cost;
+              });
+  }
+  LOG(INFO) << "Small tables by cost decreasingly: ";
+  printSlsTableInfo(slsTablesLeft, slsTables.end());
+
+  while (slsTablesLeft < slsTables.end()) {
+    // Sort devices by cost increasingly.
+    std::sort(slsDevices.begin(), slsDevices.end(),
+              [](const SLSDeviceInfo &l, const SLSDeviceInfo &r) {
+                return l.currentCost < r.currentCost;
+              });
+
+    LOG(INFO) << "Devices sorted by cost increasing: ";
+    printSlsDeviceInfo(slsDevices, nodesets, contextCount);
+
+    // Pick the first that fits
+    auto &table = *slsTablesLeft;
+    RETURN_IF_ERR(assignSlsTableToFirstAvailableDevice(
+        table, slsDevices, nodesets, frontierValues, contextCount));
+    slsTablesLeft++;
+  }
+  // Print final device info
+  LOG(INFO) << "Done assigning small tables, final devices info: ";
+  printSlsDeviceInfo(slsDevices, nodesets, contextCount);
+  restoreInputsOnError.dismiss();
+  return Error::success();
+}
+
+Error assignSlsTablesToDevicesGreedy(
+    std::vector<SLSTableInfo> &slsTables,
+    std::vector<SLSDeviceInfo> &slsDevices,
+    std::vector<std::unordered_set<NodeValue>> &frontierValues,
+    const unsigned contextCount) {
+  if (slsTables.empty()) {
+    LOG(INFO) << "SLS tables empty!";
+    return Error::success();
+  }
+  // Keep a copy of input parameters, so that ScopeGuard could restore
+  // inputs in case of error.
+  std::vector<SLSTableInfo> slsTablesCopy = slsTables;
+  std::vector<SLSDeviceInfo> slsDevicesCopy = slsDevices;
+  std::vector<std::unordered_set<NodeValue>> frontierValuesCopy =
+      frontierValues;
+  ScopeGuard restoreInputsOnError([&]() {
+    slsTables.swap(slsTablesCopy);
+    slsDevices.swap(slsDevicesCopy);
+    frontierValues.swap(frontierValuesCopy);
+  });
+
+  // Now sort SLS tables by size decreasing
+  LOG(INFO) << "SLS tables sorted by size decreasing" << std::endl;
+  std::sort(slsTables.begin(), slsTables.end(),
+            [](const SLSTableInfo &l, const SLSTableInfo &r) {
+              return l.numBytesInTable > r.numBytesInTable;
+            });
+
+  // Print SLS tables
+  printSlsTableInfo(slsTables);
+
+  // Now assign SLS Nodes to devices
+  std::vector<NodesSet> nodesets(slsDevices.size());
+  for (auto &table : slsTables) {
+
+    // Sort by cost increasing
+    std::sort(slsDevices.begin(), slsDevices.end(),
+              [](const SLSDeviceInfo &l, const SLSDeviceInfo &r) {
+                return l.currentCost < r.currentCost;
+              });
+
+    LOG(INFO) << "Devices sorted by cost increasing" << std::endl;
+    printSlsDeviceInfo(slsDevices, nodesets, contextCount);
+
+    // Pick the first that fits
+    RETURN_IF_ERR(assignSlsTableToFirstAvailableDevice(
+        table, slsDevices, nodesets, frontierValues, contextCount));
+  }
+  // Print final device info
+  LOG(INFO) << "Devices sorted by cost increasing: ";
+  printSlsDeviceInfo(slsDevices, nodesets, contextCount);
+  restoreInputsOnError.dismiss();
+  return Error::success();
+}
+
 } // namespace glow


### PR DESCRIPTION
Summary:
# The original partitioning algorithm is greedy algorithm:
1. Sort \p slsTables by size, then for each sls table, assign to slsDevice with lowest cost.

# This diff improve the algorithm by:
Assign \p slsTables to \p slsDevices by:
1. Sort \p slsTables by size decreasing.
2. Split \p slsTables into two parts: large tables, and small tables where large tables have numBytesInTable > glow::runtime::flags::BigTableThresholdBytes.
3. For large tables, we sort tables by size, and then for each table we assign it to device with lowest size.
4. For small tables, we sort tables by cost, and then for each table we assign it to device with lowest cost.

The new algorithm has benefits:

> Improvements are there! Max SLS latency reduced by 12% for net10.

# What else:
* This diff keep both algorithms, and run improved algorithm first, if it fails to assign slsTables to slsDevices, then it will falls back to original algorithm.
* We can set BigTableThresholdBytes from command line flag: glow_partition_big_table_threshold_bytes. The default value is 100 * 1024*1024, i.e., 100 MB

Differential Revision: D26031473

