### PR TITLE
RoiAlign test against interpreter

### DIFF
--- a/lib/Backends/CPU/tests/CPUOperatorTest.cpp
+++ b/lib/Backends/CPU/tests/CPUOperatorTest.cpp
@@ -391,6 +391,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "RoiAlignC2Batched/0",
     "RoiAlignRotatedBatchIndexInBoxesTensor/0",
     "FP16RoiAlignBatchIndexInBoxesTensor/0",
+    "FP16RoiAlignBatchIndexInBoxesTensorCompareToInterpreter/0",
     "FP16RoiAlignC2Batched/0",
     "FP16RoiAlign/0",
     "FP16RoiAlignWithAlignedCoordinates/0",

--- a/lib/Backends/Habana/tests/HabanaOperatorTest.cpp
+++ b/lib/Backends/Habana/tests/HabanaOperatorTest.cpp
@@ -440,6 +440,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "FP16RoiAlignRotatedBatchIndexInBoxesTensor/0",
     "FP16RoiAlignC2Batched/0",
     "FP16RoiAlignBatchIndexInBoxesTensor/0",
+    "FP16RoiAlignBatchIndexInBoxesTensorCompareToInterpreter/0",
     "Asin_FloatTy/0",
     "Acos_FloatTy/0",
     "Atan_FloatTy/0",

--- a/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
+++ b/lib/Backends/NNPI/tests/NNPIOperatorTest.cpp
@@ -531,6 +531,8 @@ struct BlacklistInitializer {
       {"ConvertFrom_Int64ITy_To_FloatTy/0", TestBlacklist::AnyDeviceHWEngine},
       {"FP16RoiAlignBatchIndexInBoxesTensor/0",
        TestBlacklist::AnyDeviceAnyEngine},
+      {"FP16RoiAlignBatchIndexInBoxesTensorCompareToInterpreter/0",
+       TestBlacklist::AnyDeviceAnyEngine},
       {"FP16RoiAlignWithAlignedCoordinates/0",
        TestBlacklist::AnyDeviceAnyEngine},
       {"BBoxTransform_Float16/0", TestBlacklist::AnyDeviceAnyEngine},

--- a/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
@@ -605,6 +605,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "FP16RoiAlign/0",
     "FP16RoiAlignWithAlignedCoordinates/0",
     "FP16RoiAlignBatchIndexInBoxesTensor/0",
+    "FP16RoiAlignBatchIndexInBoxesTensorCompareToInterpreter/0",
     "FP16RoiAlignC2Batched/0",
     "FP16RoiAlignRotatedBatchIndexInBoxesTensor/0",
     "Asin_FloatTy/0",


### PR DESCRIPTION
Summary: Adding operator test for RoiAlign with compareAgainstInterpreter.

Reviewed By: 842974287

Differential Revision: D26117263

