### PR TITLE
Dump onnx input tensors on failures in TorchGlowBackend execute

### DIFF
--- a/torch_glow/src/CachingGraphRunner.cpp
+++ b/torch_glow/src/CachingGraphRunner.cpp
@@ -95,18 +95,27 @@ void initializeCompiliationContextFromSettings(
   }
 }
 
-} // namespace
+/// This function slice the input Tensor according to the expected shape in the
+/// zero dimension.
+/// TODO: Multi-dimension slicing will be supported later.
+at::Tensor sliceTensor(at::Tensor &t, const TensorShape &shape) {
+  CHECK_GT(shape.size(), 0);
+  return at::native::slice(t, 0, 0, shape[0]);
+}
 
-static glow::Expected<std::string> getOnnxFilePath(const std::string &filename,
-                                                   bool writeOnnxToTmp) {
+glow::Expected<std::string> getOnnxFilePath(const std::string &filePrefix,
+                                            bool writeOnnxToTmp,
+                                            const char *extension = ".onnx") {
   if (writeOnnxToTmp) {
     std::string filepath;
-    ASSIGN_VALUE_OR_RETURN_ERR(filepath, getTempFileLoc(filename, ".onnx"));
+    ASSIGN_VALUE_OR_RETURN_ERR(filepath, getTempFileLoc(filePrefix, extension));
     return filepath;
   } else {
-    return filename + ".onnx";
+    return filePrefix + extension;
   }
 }
+
+} // namespace
 
 void CachingGraphRunner::aggregateAndDumpTraces(TraceContext *traceContext,
                                                 bool flush) {
@@ -324,12 +333,267 @@ TensorCompareResult compareTensors(glow::Tensor &RefT, glow::Tensor &CmpT) {
   return result;
 }
 
-/// This function slice the input Tensor according to the expected shape in the
-/// zero dimension.
-/// TODO: Multi-dimension slicing will be supported later.
-at::Tensor sliceTensor(at::Tensor &t, const TensorShape &shape) {
-  CHECK_GT(shape.size(), 0);
-  return at::native::slice(t, 0, 0, shape[0]);
+/// Create an onnx graph for the tensors in \p glowTensors with names from \p
+/// placeholders and write the graph to \p filePrefix
+static Error
+writeGlowTensorsToOnnx(const std::string &filePrefix,
+                       const PyTorchLoaderSettings &settings,
+                       const std::vector<glow::Placeholder *> &placeholders,
+                       const std::vector<glow::Tensor> &glowTensors) {
+  DCHECK_EQ(placeholders.size(), glowTensors.size());
+
+  ONNX_NAMESPACE::GraphProto onnxGraph;
+  for (size_t i = 0; i < placeholders.size(); ++i) {
+    auto *onnxT = onnxGraph.add_initializer();
+    const auto *ph = placeholders[i];
+    const auto &t = glowTensors[i];
+    onnxT->set_name(ph->getName());
+    size_t unpaddedSize = t.getUnpaddedSizeInBytes();
+    size_t tensorSize = t.getSizeInBytes();
+    if (unpaddedSize == tensorSize) {
+      ONNXModelWriter::writeTensor(t, onnxT,
+                                   /*useGlowCustomOps*/ true);
+    } else {
+      // If the tensor is a partial tensor, then save only the part
+      // that has data.
+      auto ty = t.getType();
+      auto dims = ty.dims().vec();
+      DCHECK_GT(dims.size(), 0);
+      dims[0] = dims[0] * unpaddedSize / tensorSize;
+      const auto &resized = t.getUnowned(dims);
+      ONNXModelWriter::writeTensor(resized, onnxT,
+                                   /*useGlowCustomOps*/ true);
+    }
+  }
+
+  std::string filename;
+  ASSIGN_VALUE_OR_RETURN_ERR(
+      filename, getOnnxFilePath(filePrefix, settings.writeOnnxToTmp));
+  std::ofstream of(filename, std::ios::binary);
+  if (!of) {
+    return MAKE_ERR(
+        strFormat("Cannot create onnx tensor file %s", filename.c_str()));
+  }
+
+  std::string buffer;
+  onnxGraph.SerializeToString(&buffer);
+  of << buffer;
+
+  return Error::success();
+}
+
+/// Get outputs from \p stack which contains PyTorch tensors from running on JIT
+/// GraphExector and create a onnx file for those outputs at \p filePrefix.
+static Error
+writeJITOutputsToOnnxFile(const std::string &filePrefix,
+                          const torch::jit::Stack &stack,
+                          const CachingGraphRunner::PerGlowGraphInfo &info) {
+  // pull outputs off the stack, create corresponding vector of Glow tensors
+  std::vector<glow::Tensor> glowTensorOutputs;
+  std::vector<torch::Tensor> ptTensorOutputs;
+  size_t numOutputs = info.outputPlaceholders.size();
+  for (size_t i = 0; i < numOutputs; ++i) {
+    auto &jitOutput = torch::jit::peek(stack, i, numOutputs);
+    auto jitPtTensor = jitOutput.toTensor().contiguous();
+    glow::Tensor jitGlowT = ptTensorToGlowTensor(jitPtTensor);
+    glowTensorOutputs.push_back(std::move(jitGlowT));
+    ptTensorOutputs.push_back(std::move(jitPtTensor));
+  }
+
+  // write outputs to file
+  RETURN_IF_ERR(writeGlowTensorsToOnnx(
+      filePrefix, info.settings, info.outputPlaceholders, glowTensorOutputs));
+
+  return Error::success();
+}
+
+Error CachingGraphRunner::writeJitIOToOnnxFile(
+    const std::string &inputFilePrefix, const std::string &outputFilePrefix,
+    const torch::jit::Stack &stack) {
+
+  if (!defaultSettings_.dumpFailedInputsToOnnxFiles) {
+    return Error::success();
+  }
+
+  std::shared_ptr<PerGlowGraphInfo> info;
+  ASSIGN_VALUE_OR_RETURN_ERR(info, findGraphInfoForStack(stack));
+
+  // Write inputs
+  size_t numInputs = graph_->inputs().size();
+  const auto inputs = torch::jit::last(stack, numInputs);
+
+  std::vector<glow::Tensor> glowTensorInputs;
+  std::vector<torch::Tensor> ptTensorInputs;
+
+  if (auto tensorsOrErr =
+          processPyTorchInputs(inputs, info->inputPlaceholders)) {
+    glowTensorInputs = std::move(tensorsOrErr->first);
+    ptTensorInputs = std::move(tensorsOrErr->second);
+  } else {
+    RETURN_ERR(tensorsOrErr.takeError());
+  }
+
+  RETURN_IF_ERR(writeGlowTensorsToOnnx(inputFilePrefix, info->settings,
+                                       info->inputPlaceholders,
+                                       glowTensorInputs));
+
+  // Write InputMetaStack to file so we know the type of the inputs
+  InputMetaStack metaStack;
+  ASSIGN_VALUE_OR_RETURN_ERR(metaStack, inputMetaStackFromStack(inputs));
+
+  std::string metaStackFilename;
+  ASSIGN_VALUE_OR_RETURN_ERR(
+      metaStackFilename,
+      getOnnxFilePath(inputFilePrefix, info->settings.writeOnnxToTmp, ".txt"));
+  std::ofstream metaStackOF(metaStackFilename, std::ios::binary);
+  if (!metaStackOF) {
+    return MAKE_ERR(strFormat("Cannot create metastack text file %s",
+                              metaStackFilename.c_str()));
+  }
+
+  metaStackOF << metaStack.print();
+
+  // Run the stack on JIT to get outputs then write them to file
+  torch::jit::Stack copyStack;
+  // We will use original graph for runOnJit, which means the first input
+  // should be module.
+  if (origGraph_ != nullptr) {
+    copyStack.push_back(module_);
+  }
+  for (auto &ival : stack) {
+    if (ival.isTensor()) {
+      copyStack.push_back(ival.deepcopy());
+    } else {
+      copyStack.push_back(ival);
+    }
+  }
+  runOnJit(copyStack);
+
+  // Write outputs
+  RETURN_IF_ERR(writeJITOutputsToOnnxFile(outputFilePrefix, copyStack, *info));
+
+  return Error::success();
+}
+
+Expected<std::pair<glow::Tensor, torch::Tensor>>
+CachingGraphRunner::convertPyTorchInputToGlowInput(
+    torch::Tensor ptTensor, const glow::Placeholder *ph) {
+  glow::Tensor glowTensor;
+
+  glow::TypeRef ty = ph->getType();
+
+  if (ptTensor.is_quantized()) {
+    ptTensor = convertQuantizedToDtype(ptTensor, at::kQInt8);
+  }
+
+  // Make sure the runtime pytorch tensor type matches the placeholder.
+  // Note this needs to be placed after convertQuantizedToDtype to
+  // correctly handle quantized types.
+  if (ty->getElementType() != scalarTypeToElemKind(ptTensor.scalar_type())) {
+    std::stringstream ss;
+    ss << "Found type mismatch for input \"" << ph->getName().str() << "\""
+       << ": pytorch tensor is " << ptTensor.toString() << ", ph type is "
+       << ty->toString();
+    return MAKE_ERR(ss.str());
+  }
+
+  if (!ptTensor.is_contiguous()) {
+    ptTensor = ptTensor.contiguous();
+  }
+
+  // Check Tensor size, making sure enough memory is allocated
+  if (ptTensor.numel() > ty->size()) {
+    std::stringstream ss;
+    ss << "Input tensor is too large: " << ptTensor.numel() << " vs "
+       << ty->size() << ": " << ph->getName().str();
+    return MAKE_ERR(ss.str());
+  }
+
+  if (ty->dims().size() == ptTensor.ndimension() &&
+      std::equal(ty->dims().begin(), ty->dims().end(),
+                 ptTensor.sizes().begin())) {
+    glowTensor = glow::Tensor(ptTensor.data_ptr(), ty);
+  } else if (ptTensor.data_ptr() && ptTensor.numel() > 0 &&
+             backend_.supportsPartialTensors()) {
+    // This is a partial tensor, to create padded unown tensor
+    glowTensor = glow::Tensor(ptTensor.data_ptr(), ty, ptTensor.nbytes());
+  } else if (ptTensor.numel() == 0) {
+    // Handles zero-size input tensor
+    // Here zeroLengthSequence_ is pre-allocated if warmCache is called
+    assert(zeroLengthSequence_.getUnsafePtr());
+    glowTensor = glow::Tensor((void *)zeroLengthSequence_.getUnsafePtr(), ty);
+  } else {
+    // For backends that does not support partial tensor, manually pad
+    // zeros
+    auto inputTensorOpt = tensorPool_.get(ty);
+    if (!inputTensorOpt.hasValue()) {
+      std::stringstream ss;
+      ss << "Tensorpool tensor not found for input " << ptTensor.name();
+      return MAKE_ERR(ss.str());
+    }
+    // We want fresh DeviceResidencyInfo for this fresh Tensor.
+    glow::Tensor inputTensor(std::move(inputTensorOpt.getValue()));
+    inputTensor.resetDeviceInfo();
+    if (ptTensor.data_ptr()) {
+      memcpy(inputTensor.getUnsafePtr(), ptTensor.data_ptr(),
+             ptTensor.nbytes());
+      // Pad remaining space with zeroes.
+      memset(inputTensor.getUnsafePtr() + ptTensor.nbytes(), 0,
+             inputTensor.getSizeInBytes() - ptTensor.nbytes());
+    } else {
+      inputTensor.zero();
+    }
+    glowTensor = std::move(inputTensor);
+  }
+
+  std::pair<glow::Tensor, torch::Tensor> tensors = {std::move(glowTensor),
+                                                    std::move(ptTensor)};
+  return tensors;
+}
+
+Expected<std::pair<std::vector<glow::Tensor>, std::vector<torch::Tensor>>>
+CachingGraphRunner::processPyTorchInputs(
+    at::ArrayRef<at::IValue> inputs,
+    const std::vector<Placeholder *> &inputPlaceholders) {
+  size_t numInputs = inputs.size();
+
+  std::vector<glow::Tensor> glowTensorInputs;
+  std::vector<torch::Tensor> ptTensorInputs;
+  glowTensorInputs.reserve(numInputs);
+  ptTensorInputs.reserve(numInputs);
+
+  // We only hold placeholders for tensor inputs so indexing them is
+  // different than indexing all inputs.
+  size_t placeholderI = 0;
+
+  for (const auto &input : inputs) {
+    if (!input.isTensor()) {
+      continue;
+    }
+
+    glow::Placeholder *ph = inputPlaceholders[placeholderI++];
+
+    auto ptTensorOrig = input.toTensor();
+
+    std::pair<glow::Tensor, torch::Tensor> tensors;
+    ASSIGN_VALUE_OR_RETURN_ERR(
+        tensors, convertPyTorchInputToGlowInput(ptTensorOrig, ph));
+
+    glowTensorInputs.push_back(std::move(tensors.first));
+
+    // Save the PyTorch tensor in case it owns memory we need for inference
+    ptTensorInputs.push_back(std::move(tensors.second));
+  }
+
+  RETURN_ERR_IF_NOT(inputPlaceholders.size() == glowTensorInputs.size(),
+                    strFormat("Expected %d Tensor inputs but found %d",
+                              int(inputPlaceholders.size()),
+                              int(glowTensorInputs.size())));
+
+  std::pair<std::vector<glow::Tensor>, std::vector<torch::Tensor>> tensors = {
+      std::move(glowTensorInputs), std::move(ptTensorInputs)};
+
+  return tensors;
 }
 
 Error CachingGraphRunner::runImpl(const PerGlowGraphInfo &info,
@@ -339,6 +603,10 @@ Error CachingGraphRunner::runImpl(const PerGlowGraphInfo &info,
 
   int64_t jitRunningTime = 0;
   const PyTorchLoaderSettings &settings = info.settings;
+
+  // Save all of the PyTorch input tensors in case they were allocated here for
+  // things like making an input contiguous.
+  std::vector<torch::Tensor> ptTensorInputs;
 
   // Run the subgraph using JIT for comparison with Glow.
   torch::jit::Stack copyStack;
@@ -377,155 +645,33 @@ Error CachingGraphRunner::runImpl(const PerGlowGraphInfo &info,
 
     size_t numInputs = graph_->inputs().size();
     const auto inputs = torch::jit::last(stack, numInputs);
+
     {
       RECORD_USER_SCOPE("adjustInputs");
-      // We only hold placeholders for tensor inputs so indexing them is
-      // different than indexing all inputs.
-      size_t placeholderI = 0;
 
-      for (const auto &input : inputs) {
-        if (input.isTensor()) {
-
-          glow::Placeholder *ph = info.inputPlaceholders[placeholderI++];
-          glow::TypeRef ty = ph->getType();
-
-          auto ptTensor = input.toTensor();
-
-          bool needClone = false;
-
-          if (ptTensor.is_quantized()) {
-            ptTensor = convertQuantizedToDtype(ptTensor, at::kQInt8);
-            // We need to clone a new tensor here since
-            // convertQuantizedToDtype might create a temporary tensor
-            needClone = true;
-          }
-
-          // Make sure the runtime pytorch tensor type matches the placeholder.
-          // Note this needs to be placed after convertQuantizedToDtype to
-          // correctly handle quantized types.
-          if (ty->getElementType() !=
-              scalarTypeToElemKind(ptTensor.scalar_type())) {
-            std::stringstream ss;
-            ss << "Found type mismatch for input #" << placeholderI
-               << ": pytorch tensor is " << ptTensor.toString()
-               << ", ph type is " << ty->toString();
-            return MAKE_ERR(ss.str());
-          }
-
-          if (!ptTensor.is_contiguous()) {
-            ptTensor = ptTensor.contiguous();
-            needClone = true;
-          }
-
-          // Check Tensor size, making sure enough memory is allocated
-          if (ptTensor.numel() > ty->size()) {
-            std::stringstream ss;
-            ss << "Input tensor is too large: " << ptTensor.numel() << " vs "
-               << ty->size() << ": " << ph->getName().str();
-            return MAKE_ERR(ss.str());
-          }
-
-          if (ty->dims().size() == ptTensor.ndimension() &&
-              std::equal(ty->dims().begin(), ty->dims().end(),
-                         ptTensor.sizes().begin())) {
-            glow::Tensor t;
-            if (needClone) {
-              t = glow::Tensor(ptTensor.data_ptr(), ty).clone();
-            } else {
-              t = glow::Tensor(ptTensor.data_ptr(), ty);
-            }
-            bindings->insert(ph, std::move(t));
-          } else if (ptTensor.data_ptr() && ptTensor.numel() > 0 &&
-                     backend_.supportsPartialTensors()) {
-            // This is a partial tensor, to create padded unown tensor
-            glow::Tensor t;
-            if (needClone) {
-              t = glow::Tensor(ptTensor.data_ptr(), ty, ptTensor.nbytes())
-                      .clone();
-            } else {
-              t = glow::Tensor(ptTensor.data_ptr(), ty, ptTensor.nbytes());
-            }
-            bindings->insert(ph, std::move(t));
-          } else if (ptTensor.numel() == 0) {
-            // Handles zero-size input tensor
-            // Here zeroLengthSequence_ is pre-allocated if warmCache is called
-            assert(zeroLengthSequence_.getUnsafePtr());
-            bindings->insert(
-                ph,
-                glow::Tensor((void *)zeroLengthSequence_.getUnsafePtr(), ty));
-          } else {
-            // For backends that does not support partial tensor, manually pad
-            // zeros
-            auto inputTensorOpt = tensorPool_.get(ty);
-            if (!inputTensorOpt.hasValue()) {
-              std::stringstream ss;
-              ss << "Tensorpool tensor not found for input " << ptTensor.name();
-              return MAKE_ERR(ss.str());
-            }
-            // We want fresh DeviceResidencyInfo for this fresh Tensor.
-            Tensor inputTensor(std::move(inputTensorOpt.getValue()));
-            inputTensor.resetDeviceInfo();
-            if (ptTensor.data_ptr()) {
-              memcpy(inputTensor.getUnsafePtr(), ptTensor.data_ptr(),
-                     ptTensor.nbytes());
-              // Pad remaining space with zeroes.
-              memset(inputTensor.getUnsafePtr() + ptTensor.nbytes(), 0,
-                     inputTensor.getSizeInBytes() - ptTensor.nbytes());
-            } else {
-              inputTensor.zero();
-            }
-            bindings->insert(ph, std::move(inputTensor));
-          }
-        } else if (input.isObject()) {
-          // Objects are only used for loading attributes at compile time.
-          continue;
-        } else if (!(input.isBool() || input.isInt() || input.isIntList())) {
-          return MAKE_ERR(
-              "Only Int/IntList, Tensor and Object IValue inputs are accepted");
-        }
+      std::vector<glow::Tensor> glowTensorInputs;
+      if (auto tensorsOrErr =
+              processPyTorchInputs(inputs, info.inputPlaceholders)) {
+        glowTensorInputs = std::move(tensorsOrErr->first);
+        ptTensorInputs = std::move(tensorsOrErr->second);
+      } else {
+        RETURN_ERR(tensorsOrErr.takeError());
       }
 
+      // Write input tensors to file
       if (settings.writeToOnnx) {
-        std::string filename;
-        LOG(ERROR) << onnxFileNamePrefix.c_str();
-        ASSIGN_VALUE_OR_RETURN_ERR(
-            filename,
-            getOnnxFilePath(
-                strFormat("%s_input_%zu", onnxFileNamePrefix.c_str(), runId),
-                settings.writeOnnxToTmp));
-        std::ofstream of(filename, std::ios::binary);
-        if (!of) {
-          LOG(ERROR) << "Cannot create input file " << filename;
-        } else {
-          ONNX_NAMESPACE::GraphProto inputG;
-          for (const auto &p : bindings->pairs()) {
-            auto *onnxT = inputG.add_initializer();
-            const auto ph = p.first;
-            const auto &t = p.second;
-            onnxT->set_name(ph->getName());
-            size_t unpaddedSize = t.getUnpaddedSizeInBytes();
-            size_t tensorSize = t.getSizeInBytes();
-            if (unpaddedSize == tensorSize) {
-              ONNXModelWriter::writeTensor(t, onnxT,
-                                           /*useGlowCustomOps*/ true);
-            } else {
-              // If the input is a partial tensor, then save only the part
-              // that has data.
-              auto ty = t.getType();
-              auto dims = ty.dims().vec();
-              assert(dims.size() > 0);
-              dims[0] = dims[0] * unpaddedSize / tensorSize;
-              const auto &resized = t.getUnowned(dims);
-              ONNXModelWriter::writeTensor(resized, onnxT,
-                                           /*useGlowCustomOps*/ true);
-            }
-          }
-          std::string buffer;
-          inputG.SerializeToString(&buffer);
-          of << buffer;
-        }
+        writeGlowTensorsToOnnx(
+            strFormat("%s_input_%zu", onnxFileNamePrefix.c_str(), runId),
+            settings, info.inputPlaceholders, glowTensorInputs);
       }
-    }
+
+      // Populate PlaceholderBindings
+      for (size_t i = 0; i < glowTensorInputs.size(); ++i) {
+        bindings->insert(info.inputPlaceholders[i],
+                         std::move(glowTensorInputs[i]));
+      }
+    } // end adjustInputs
+
     TRACE_EVENT_END(traceContext, TraceLevel::RUNTIME, "adjustInputs");
 
     TRACE_EVENT_BEGIN(traceContext, TraceLevel::RUNTIME, "setupOutput");
@@ -578,9 +724,7 @@ Error CachingGraphRunner::runImpl(const PerGlowGraphInfo &info,
       }
 
       torch::jit::drop(stack, numInputs);
-
-      ONNX_NAMESPACE::GraphProto outputG;
-      ONNX_NAMESPACE::GraphProto jitOutputG;
+      std::vector<glow::Tensor> convertedGlowTensors;
       for (int i = 0; i < outputs.size(); i++) {
         auto &output = outputs[i];
         auto ptTensor = output.toTensor();
@@ -599,22 +743,7 @@ Error CachingGraphRunner::runImpl(const PerGlowGraphInfo &info,
         // Write the output from Glow to ONNX if necessary.
         if (settings.writeToOnnx) {
           glow::Tensor glowT = ptTensorToGlowTensor(ptTensor);
-          auto *onnxT = outputG.add_initializer();
-          onnxT->set_name(info.outputPlaceholders[i]->getName());
-          ONNXModelWriter::writeTensor(glowT, onnxT,
-                                       /*useGlowCustomOps*/ true);
-        }
-
-        // Write the output from the JIT output (not from Glow) to ONNX if
-        // necessary.
-        if (settings.writeToOnnx) {
-          auto &jitOutput = torch::jit::peek(copyStack, i, outputs.size());
-          auto jitPtTensor = jitOutput.toTensor().contiguous();
-          glow::Tensor jitGlowT = ptTensorToGlowTensor(jitPtTensor);
-          auto *jitOnnxT = jitOutputG.add_initializer();
-          jitOnnxT->set_name(info.outputPlaceholders[i]->getName());
-          ONNXModelWriter::writeTensor(jitGlowT, jitOnnxT,
-                                       /*useGlowCustomOps*/ true);
+          convertedGlowTensors.push_back(std::move(glowT));
         }
 
         // Run shape inference and slice out the correct size of the Glow
@@ -664,37 +793,15 @@ Error CachingGraphRunner::runImpl(const PerGlowGraphInfo &info,
       }
 
       if (settings.writeToOnnx) {
-        std::string filename;
-        ASSIGN_VALUE_OR_RETURN_ERR(
-            filename,
-            getOnnxFilePath(strFormat("%s_glow_output_%zu",
-                                      onnxFileNamePrefix.c_str(), runId),
-                            settings.writeOnnxToTmp));
-        std::ofstream of(filename, std::ios::binary);
-        if (!of) {
-          LOG(ERROR) << "Cannot create output file " << filename;
-        } else {
-          std::string buffer;
-          outputG.SerializeToString(&buffer);
-          of << buffer;
-        }
-      }
+        // Write Glow outputs to file
+        writeGlowTensorsToOnnx(
+            strFormat("%s_glow_output_%zu", onnxFileNamePrefix.c_str(), runId),
+            info.settings, info.outputPlaceholders, convertedGlowTensors);
 
-      if (settings.writeToOnnx) {
-        std::string filename;
-        ASSIGN_VALUE_OR_RETURN_ERR(
-            filename,
-            getOnnxFilePath(strFormat("%s_pytorch_output_%zu",
-                                      onnxFileNamePrefix.c_str(), runId),
-                            settings.writeOnnxToTmp));
-        std::ofstream of(filename, std::ios::binary);
-        if (!of) {
-          LOG(ERROR) << "Cannot create output file " << filename;
-        } else {
-          std::string buffer;
-          jitOutputG.SerializeToString(&buffer);
-          of << buffer;
-        }
+        // Convert JIT outputs to Glow outputs and write to file
+        writeJITOutputsToOnnxFile(strFormat("%s_pytorch_output_%zu",
+                                            onnxFileNamePrefix.c_str(), runId),
+                                  copyStack, info);
       }
     }
     TRACE_EVENT_END(traceContext, TraceLevel::RUNTIME, "setOutputs");
@@ -737,8 +844,8 @@ Error CachingGraphRunner::run(torch::jit::Stack &stack) {
   return err;
 }
 
-Error CachingGraphRunner::runOnly(torch::jit::Stack &stack) {
-  std::shared_ptr<PerGlowGraphInfo> info;
+Expected<std::shared_ptr<CachingGraphRunner::PerGlowGraphInfo>>
+CachingGraphRunner::findGraphInfoForStack(const torch::jit::Stack &stack) {
   if (useMaxSizeCompilation_) {
     std::unique_lock<std::shared_timed_mutex> wlock(graphInfoMapMutex);
     if (perGlowGraphInfoMap_.size() != 1) {
@@ -746,7 +853,7 @@ Error CachingGraphRunner::runOnly(torch::jit::Stack &stack) {
           "There should be one and only one compiled graph, but got %lu",
           perGlowGraphInfoMap_.size()));
     }
-    info = perGlowGraphInfoMap_.begin()->second;
+    return perGlowGraphInfoMap_.begin()->second;
   } else {
     const auto relevantInputs =
         torch::jit::last(stack, graph_->inputs().size());
@@ -767,10 +874,13 @@ Error CachingGraphRunner::runOnly(torch::jit::Stack &stack) {
       }
       return MAKE_ERR(ss.str());
     }
-    info = it->second;
+    return it->second;
   }
+}
 
-  CHECK(info);
+Error CachingGraphRunner::runOnly(torch::jit::Stack &stack) {
+  std::shared_ptr<PerGlowGraphInfo> info;
+  ASSIGN_VALUE_OR_RETURN_ERR(info, findGraphInfoForStack(stack));
 
   const PyTorchLoaderSettings &settings = info->settings;
 

--- a/torch_glow/src/CachingGraphRunner.h
+++ b/torch_glow/src/CachingGraphRunner.h
@@ -28,11 +28,11 @@
 #include <shared_mutex>
 
 namespace glow {
-
 /// For a given PyTorch JIT graph, this class is responsible for maintaining a
 /// mapping from PyTorch input information to Glow Function used to run that
 /// graph in Glow.
 class CachingGraphRunner {
+public:
   /// Information that is stored per-Glow graph for running it using
   /// HostManager.
   struct PerGlowGraphInfo {
@@ -56,6 +56,7 @@ class CachingGraphRunner {
     PyTorchLoaderSettings settings;
   };
 
+private:
   /// The PyTorch JIT Graph that this CachingGraphRunner caches Glow functions
   /// for.
   std::shared_ptr<torch::jit::Graph> graph_;
@@ -173,11 +174,31 @@ class CachingGraphRunner {
   /// file no matter what.
   void aggregateAndDumpTraces(TraceContext *traceContext, bool flush = false);
 
+  /// Converts PyTorch input tensor \p ptTensor to a Glow input tensor for the
+  /// Placeholder \p ph. \returns the pair of the created Glow tensor and
+  /// PyTorch tensor which may have been created in order to make it the
+  /// original PyTorch tensor more suitable for Glow for example by making it
+  /// contiguous. The new PyTorch tensor owns the memory used by the Glow tensor
+  /// so much live at least as long as it.
+  Expected<std::pair<glow::Tensor, torch::Tensor>>
+  convertPyTorchInputToGlowInput(torch::Tensor ptTensor,
+                                 const glow::Placeholder *ph);
+
+  /// Calls convertPyTorchInputToGlowInput for several \p inputs and \p
+  /// inputPlaceholders.
+  Expected<std::pair<std::vector<glow::Tensor>, std::vector<torch::Tensor>>>
+  processPyTorchInputs(at::ArrayRef<at::IValue> inputs,
+                       const std::vector<Placeholder *> &inputPlaceholders);
+
   /// The Glow Function should've already been created. Returns an error if not.
   Error runOnly(torch::jit::Stack &stack);
 
   /// Get key of caching graph map from inputMetaStack.
   size_t getGraphMapKeyFromInputStack(const InputMetaStack &metaStack);
+
+  /// Find the PerGlowGraphInfo corresponding to a given \p stack.
+  Expected<std::shared_ptr<PerGlowGraphInfo>>
+  findGraphInfoForStack(const torch::jit::Stack &stack);
 
 public:
   CachingGraphRunner(std::shared_ptr<torch::jit::Graph> graph,
@@ -204,6 +225,13 @@ public:
                   const PyTorchLoaderSettings &settings,
                   runtime::DeferredWeightLoader *loader,
                   bool useMaxSizeCompilation = true);
+
+  /// Writes PyTorch tensor inputs on the \p stack to file \p inputFilePrefix,
+  /// then runs the JIT GraphExecutor to get the outputs and writes those to \p
+  /// outputFilePrefix.
+  Error writeJitIOToOnnxFile(const std::string &inputFilePrefix,
+                             const std::string &outputFilePrefix,
+                             const torch::jit::Stack &stack);
 };
 
 } // namespace glow

--- a/torch_glow/src/PyTorchCommon.cpp
+++ b/torch_glow/src/PyTorchCommon.cpp
@@ -86,6 +86,7 @@ DEFINE_string(backendSpecificOpts, "",
 DEFINE_bool(debugContinuouslyVerifyDuringModelLoading, false,
             "See PyTorchLoaderSettings");
 DEFINE_int32(nominalBatchIdx, -1, "See PyTorchLoaderSettings");
+DEFINE_bool(dumpFailedInputsToOnnxFiles, false, "See PyTorchLoaderSettings");
 
 namespace glow {
 namespace {
@@ -275,6 +276,7 @@ void PyTorchLoaderSettings::initSettings() {
   replicationCount = FLAGS_replicationCount;
   writeToOnnx = FLAGS_writeToOnnx;
   onnxZipMode = FLAGS_onnxZipMode;
+  dumpFailedInputsToOnnxFiles = FLAGS_dumpFailedInputsToOnnxFiles;
   writeOnnxToTmp = FLAGS_writeOnnxToTmp;
   randomizeConstants = FLAGS_randomizeConstants;
   writeWithoutRandomize = FLAGS_writeWithoutRandomize;
@@ -350,6 +352,7 @@ std::string PyTorchLoaderSettings::toString() const {
   INSERT_BOOL_TO_STREAM(setIncludeLastOffsets, s);
   INSERT_BOOL_TO_STREAM(enableDebugFuser, s);
   INSERT_BOOL_TO_STREAM(debugContinuouslyVerifyDuringModelLoading, s);
+  INSERT_BOOL_TO_STREAM(dumpFailedInputsToOnnxFiles, s);
 
   if (opBlacklist.size() > 0) {
     s << "opBlacklist: [";

--- a/torch_glow/src/PyTorchCommon.h
+++ b/torch_glow/src/PyTorchCommon.h
@@ -179,6 +179,9 @@ public:
 
   /// Indices of available backend devices on the machine.
   std::vector<int32_t> availableDevices;
+
+  /// Whether to dump out failed inputs and reference outputs to onnx files.
+  bool dumpFailedInputsToOnnxFiles = false;
 };
 
 /// Represents different possible output types from to_glow modules.

--- a/torch_glow/src/TorchGlowBackend.h
+++ b/torch_glow/src/TorchGlowBackend.h
@@ -53,6 +53,9 @@ private:
   std::unordered_map<int64_t, std::pair<std::unique_ptr<CachingGraphRunner>,
                                         std::unique_ptr<JITGraphRunner>>>
       handleToRunnerMap_;
+
+  // Number of runs that have failed, used for dumping io files on failures.
+  std::atomic<size_t> failedRunNum_{0};
 };
 
 /// Registers TorchGlowBackend, related custom classes and helper JIT IR ops.


### PR DESCRIPTION
Summary:
* When an inference fails on Glow, dump the inputs, reference outputs, and a description of the inputs types and shapes to file as onnx files.
* Factor all logic that's used to convert PyTorch input tensors to Glow into a separate function so it can be repeated exactly so we dump the right thing to file
* Also updates Repro.cpp so that if it's not going to use reference outputs for accuracy comparison, then don't try to load them so we can run Repro without any reference outputs

Reviewed By: mortzur

Differential Revision: D26120920

