### PR TITLE
Per-layer weights instead of one constant

### DIFF
--- a/tests/benchmark/GemmParallelBench.cpp
+++ b/tests/benchmark/GemmParallelBench.cpp
@@ -102,8 +102,12 @@ public:
             dtype, {k, n}, "weights" + std::to_string(core), false);
         bias[core] = mod->createPlaceholder(
             dtype, {n}, "bias" + std::to_string(core), false);
-        bindings_.allocate(weights[core])->getHandle<float16_t>().clear(0);
-        bindings_.allocate(bias[core])->getHandle<float16_t>().clear(32);
+        bindings_.allocate(weights[core])
+            ->getHandle<float16_t>()
+            .randomize(-128.f, 128.f, mod->getPRNG());
+        bindings_.allocate(bias[core])
+            ->getHandle<float16_t>()
+            .randomize(-128.f, 128.f, mod->getPRNG());
         fc[core] = fn->createFullyConnected(
             "fc" + std::to_string(core) + "_" + std::to_string(layer),
             cur[core], weights[core], bias[core]);

--- a/tests/benchmark/Int8GemmBench.cpp
+++ b/tests/benchmark/Int8GemmBench.cpp
@@ -94,7 +94,8 @@ public:
 
       bindings_.allocate(weights)->getHandle<int8_t>().randomize(
           -128, 127, mod->getPRNG());
-      bindings_.allocate(bias)->getHandle<int32_t>().clear(2);
+      bindings_.allocate(bias)->getHandle<int32_t>().randomize(-128, 127,
+                                                               mod->getPRNG());
 
       Node *fc;
       fc = fn->createFullyConnected("fc_" + std::to_string(layer), cur, weights,

--- a/tests/benchmark/Int8GemmParallelBench.cpp
+++ b/tests/benchmark/Int8GemmParallelBench.cpp
@@ -107,8 +107,12 @@ public:
         bias[core] =
             mod->createPlaceholder(ElemKind::Int32QTy, {n}, 1.0, 0,
                                    "bias_" + std::to_string(core), false);
-        bindings_.allocate(weights[core])->getHandle<int8_t>().clear(0);
-        bindings_.allocate(bias[core])->getHandle<int32_t>().clear(0);
+        bindings_.allocate(weights[core])
+            ->getHandle<int8_t>()
+            .randomize(0, 128, mod->getPRNG());
+        bindings_.allocate(bias[core])
+            ->getHandle<int32_t>()
+            .randomize(0, 128, mod->getPRNG());
         fc[core] = fn->createFullyConnected(
             "fc" + std::to_string(core) + "_" + std::to_string(layer),
             cur[core], weights[core], bias[core]);


### PR DESCRIPTION
Summary: Use random weights per layer so they are not opimized out

Differential Revision: D26204552

