### PR TITLE
Express the logic in AllocationsInfo using the same logic as RuntimeBundle from BackendUtils

### DIFF
--- a/include/glow/Backend/BackendUtils.h
+++ b/include/glow/Backend/BackendUtils.h
@@ -231,6 +231,30 @@ template <typename FUN, typename ARR>
 ContiguousPlaceholders getContiguousPlaceHolder(const ARR &holders,
                                                 const FUN &F);
 
+/// Allocate \p placeholders using the provided \p allocator and store the
+/// allocation results into a \p symbolTable.
+void allocatePlaceholders(const ContiguousPlaceholders &placeholders,
+                          MemoryAllocator &allocator,
+                          glow::runtime::SymbolTableTy &symbolTable);
+
+/// Allocate \p constants using the provided \p allocator and store the
+/// allocation results into a \p symbolTable.
+void allocateConstants(const ConstList &constants, MemoryAllocator &allocator,
+                       glow::runtime::SymbolTableTy &symbolTable);
+
+/// Allocate \p constants using the provided \p allocator and store the
+/// allocation results into a \p symbolTable.
+void allocateConstants(const std::vector<const glow::Constant *> &constants,
+                       MemoryAllocator &allocator,
+                       glow::runtime::SymbolTableTy &symbolTable);
+
+/// Allocate activations from the instruction stream \p instrs using the
+/// provided \p allocator and store the allocation results into a \p
+/// symbolTable.
+void allocateActivations(const glow::IRFunction::InstListTy &instrs,
+                         MemoryAllocator &allocator,
+                         glow::runtime::SymbolTableTy &symbolTable);
+
 /// \returns true if \p V is capable of handling a partial tensor as input.
 bool allowsPartialInput(const Placeholder *V, const Function *F);
 

--- a/include/glow/LLVMIRCodeGen/AllocationsInfo.h
+++ b/include/glow/LLVMIRCodeGen/AllocationsInfo.h
@@ -16,6 +16,7 @@
 #ifndef GLOW_LLVMIRCODEGEN_ALLOCATIONSINFO_H
 #define GLOW_LLVMIRCODEGEN_ALLOCATIONSINFO_H
 
+#include "glow/Backend/BackendUtils.h"
 #include "glow/CodeGen/MemoryAllocator.h"
 #include "glow/Graph/Nodes.h"
 #include "llvm/IR/Module.h"
@@ -28,10 +29,6 @@ class IRFunction;
 class WeightVar;
 class Constant;
 class PlaceholderBindings;
-
-namespace runtime {
-class RuntimeBundle;
-}
 
 /// Information about allocations for activations, constant weight variables
 /// and mutable weight variables.
@@ -97,6 +94,8 @@ protected:
   /// Use a memory allocator with no upper bound on how much memory we can
   /// allocate.
   MemoryAllocator activationsAllocator_;
+  /// Symbol table for the allocated symbols.
+  glow::runtime::SymbolTableTy symbolTable_;
 };
 
 } // namespace glow

--- a/lib/Backend/BackendUtils.cpp
+++ b/lib/Backend/BackendUtils.cpp
@@ -37,117 +37,6 @@ static llvm::cl::opt<bool> reuseActivationsMemory(
     llvm::cl::desc("Should activation memory allocations be reused"),
     llvm::cl::init(true), llvm::cl::cat(BackendUtilsCat));
 
-namespace {
-/// Allocate space for the activations of \p instrs using \p allocator and store
-/// the resultant symbols in \p symbolTable.
-void allocateActivations(const glow::IRFunction::InstListTy &instrs,
-                         MemoryAllocator &allocator,
-                         glow::runtime::SymbolTableTy &symbolTable) {
-  for (const auto &I : instrs) {
-    if (auto *A = dyn_cast<AllocActivationInst>(&I)) {
-      auto numBytes = I.getSizeInBytes();
-      size_t addr = allocator.allocate(numBytes, A);
-      assert(!symbolTable.count(std::string(A->getName())) &&
-             "Allocation already made!");
-      runtime::RuntimeSymbolInfo symbol;
-      symbol.offset = addr;
-      symbol.size = numBytes;
-      symbol.type = *A->getType();
-      symbol.input = false;
-      symbol.output = false;
-      symbol.symbolCategory = glow::runtime::SymbolCategory::Activation;
-      symbolTable.emplace(std::string(A->getName()), symbol);
-      DEBUG_GLOW(LOG(INFO) << strFormat(
-                     "Assigned address to activation %s: %zx (%zd bytes)\n",
-                     A->getName().data(), symbol.offset, symbol.size));
-      continue;
-    }
-
-    if (auto *TV = dyn_cast<TensorViewInst>(&I)) {
-      // Calculate and store the length of the offset into the base, using the
-      // source of the tensorview.
-      assert(!symbolTable.count(std::string(TV->getName())) &&
-             "Allocation already made!");
-      auto *tvSource = getOrigin(TV);
-      assert(symbolTable.count(std::string(tvSource->getName())) &&
-             "Source allocation not found!");
-      runtime::RuntimeSymbolInfo symbol;
-      size_t originAddr = symbolTable[std::string(tvSource->getName())].offset;
-      size_t offset = calculateTensorViewOffset(TV);
-
-      symbol.offset = originAddr + offset;
-      symbol.size = TV->getSizeInBytes();
-      symbol.type = *TV->getType();
-      symbol.input = false;
-      symbol.output = false;
-      auto parentCategory =
-          symbolTable.find(tvSource->getName().str())->second.symbolCategory;
-      if (parentCategory == glow::runtime::SymbolCategory::Placeholder) {
-        symbol.symbolCategory =
-            glow::runtime::SymbolCategory::PlaceholderTensorView;
-      } else {
-        symbol.symbolCategory =
-            glow::runtime::SymbolCategory::ConstantTensorView;
-      }
-      symbolTable.emplace(std::string(TV->getName()), symbol);
-      DEBUG_GLOW(LOG(INFO) << strFormat(
-                     "Assigned address to activation %s: %zx (%zd bytes)\n",
-                     TV->getName().data(), symbol.offset, symbol.size));
-      continue;
-    }
-
-    if (auto *D = dyn_cast<DeallocActivationInst>(&I)) {
-      auto *A = D->getAlloc();
-      assert(symbolTable.count(std::string(A->getName())) &&
-             "Invalid deallocation!");
-      if (reuseActivationsMemory) {
-        allocator.deallocate(A);
-      }
-      continue;
-    }
-  }
-}
-
-/// Allocate space for the Constants in \p constants using \p allocator and
-/// store the resultant symbols in \p symbolTable.
-void allocateConstants(const glow::ConstList &constants,
-                       MemoryAllocator &allocator,
-                       glow::runtime::SymbolTableTy &symbolTable) {
-  for (auto const *V : constants) {
-    auto size = V->getType()->getSizeInBytes();
-    auto offset = allocator.allocate(size, V);
-    runtime::RuntimeSymbolInfo symbol;
-    symbol.offset = offset;
-    symbol.size = size;
-    symbol.type = *V->getType();
-    symbol.input = false;
-    symbol.output = false;
-    symbol.symbolCategory = glow::runtime::SymbolCategory::Constant;
-    symbolTable.emplace(V->getName(), symbol);
-  }
-}
-
-/// Allocate space for the Placeholders in \p placeholders using \p allocator
-/// and store the resultant symbols in \p symbolTable.
-void allocatePlaceholders(const ContiguousPlaceholders &placeholders,
-                          MemoryAllocator &allocator,
-                          glow::runtime::SymbolTableTy &symbolTable) {
-  for (const auto &p : placeholders) {
-    auto &V = p.addr;
-    auto size = V->getType()->getSizeInBytes();
-    auto offset = allocator.allocate(size, V);
-    runtime::RuntimeSymbolInfo symbol;
-    symbol.offset = offset;
-    symbol.size = size;
-    symbol.type = *V->getType();
-    symbol.output = p.isOutput;
-    symbol.input = p.isInput;
-    symbol.symbolCategory = glow::runtime::SymbolCategory::Placeholder;
-    symbolTable.emplace(V->getName(), symbol);
-  }
-}
-} // namespace
-
 glow::runtime::RuntimeBundle::RuntimeBundle(
     glow::runtime::RuntimeBundle &&rhs) {
   *this = std::move(rhs);
@@ -475,6 +364,140 @@ bool usedInFunction(const Placeholder *V, const Function *F) {
   return false;
 }
 
+/// Allocate space for the Constants in \p constants using \p allocator and
+/// store the resultant symbols in \p symbolTable.
+template <typename ConstantsTy>
+static void allocateConstantsImpl(const ConstantsTy &constants,
+                                  MemoryAllocator &allocator,
+                                  glow::runtime::SymbolTableTy &symbolTable) {
+  for (auto const *C : constants) {
+    // Same constant may be used multiple times by different functions. But it
+    // should be assigned an address only once.
+    if (symbolTable.count(std::string(C->getName()))) {
+      continue;
+    }
+    auto size = C->getType()->getSizeInBytes();
+    auto offset = allocator.allocate(size, C);
+    runtime::RuntimeSymbolInfo symbol;
+    symbol.offset = offset;
+    symbol.size = size;
+    symbol.type = *C->getType();
+    symbol.input = false;
+    symbol.output = false;
+    symbol.symbolCategory = glow::runtime::SymbolCategory::Constant;
+    symbolTable.emplace(C->getName(), symbol);
+    DEBUG_GLOW(LOG(INFO) << strFormat(
+                   "Assigned address to constant %s: %zx (%zd bytes)\n",
+                   C->getName().data(), symbol.offset, symbol.size));
+  }
+}
+
+void allocateConstants(const ConstList &constants, MemoryAllocator &allocator,
+                       glow::runtime::SymbolTableTy &symbolTable) {
+  allocateConstantsImpl(constants, allocator, symbolTable);
+}
+
+void allocateConstants(const std::vector<const glow::Constant *> &constants,
+                       MemoryAllocator &allocator,
+                       glow::runtime::SymbolTableTy &symbolTable) {
+  allocateConstantsImpl(constants, allocator, symbolTable);
+}
+
+/// Allocate space for the Placeholders in \p placeholders using \p allocator
+/// and store the resultant symbols in \p symbolTable.
+void allocatePlaceholders(const ContiguousPlaceholders &placeholders,
+                          MemoryAllocator &allocator,
+                          glow::runtime::SymbolTableTy &symbolTable) {
+  for (const auto &p : placeholders) {
+    auto &V = p.addr;
+    assert(!symbolTable.count(std::string(V->getName())) &&
+           "Allocation already made!");
+    auto size = V->getType()->getSizeInBytes();
+    auto offset = allocator.allocate(size, V);
+    runtime::RuntimeSymbolInfo symbol;
+    symbol.offset = offset;
+    symbol.size = size;
+    symbol.type = *V->getType();
+    symbol.output = p.isOutput;
+    symbol.input = p.isInput;
+    symbol.symbolCategory = glow::runtime::SymbolCategory::Placeholder;
+    symbolTable.emplace(std::string(V->getName()), symbol);
+    DEBUG_GLOW(LOG(INFO) << strFormat(
+                   "Assigned address to mutable weight %s: %zx (%zd bytes)\n",
+                   V->getName().data(), symbol.offset, symbol.size));
+  }
+}
+
+/// Allocate space for the activations of \p instrs using \p allocator and store
+/// the resultant symbols in \p symbolTable.
+void allocateActivations(const glow::IRFunction::InstListTy &instrs,
+                         MemoryAllocator &allocator,
+                         glow::runtime::SymbolTableTy &symbolTable) {
+  for (const auto &I : instrs) {
+    if (auto *A = dyn_cast<AllocActivationInst>(&I)) {
+      auto numBytes = I.getSizeInBytes();
+      size_t addr = allocator.allocate(numBytes, A);
+      assert(!symbolTable.count(std::string(A->getName())) &&
+             "Allocation already made!");
+      runtime::RuntimeSymbolInfo symbol;
+      symbol.offset = addr;
+      symbol.size = numBytes;
+      symbol.type = *A->getType();
+      symbol.input = false;
+      symbol.output = false;
+      symbol.symbolCategory = glow::runtime::SymbolCategory::Activation;
+      symbolTable.emplace(std::string(A->getName()), symbol);
+      DEBUG_GLOW(LOG(INFO) << strFormat(
+                     "Assigned address to activation %s: %zx (%zd bytes)\n",
+                     A->getName().data(), symbol.offset, symbol.size));
+      continue;
+    }
+
+    if (auto *TV = dyn_cast<TensorViewInst>(&I)) {
+      // Calculate and store the length of the offset into the base, using the
+      // source of the tensorview.
+      assert(!symbolTable.count(std::string(TV->getName())) &&
+             "Allocation already made!");
+      auto *tvSource = getOrigin(TV);
+      assert(symbolTable.count(std::string(tvSource->getName())) &&
+             "Source allocation not found!");
+      runtime::RuntimeSymbolInfo symbol;
+      size_t originAddr = symbolTable[std::string(tvSource->getName())].offset;
+      size_t offset = calculateTensorViewOffset(TV);
+
+      symbol.offset = originAddr + offset;
+      symbol.size = TV->getSizeInBytes();
+      symbol.type = *TV->getType();
+      symbol.input = false;
+      symbol.output = false;
+      auto parentCategory = symbolTable.find(std::string(tvSource->getName()))
+                                ->second.symbolCategory;
+      if (parentCategory == glow::runtime::SymbolCategory::Placeholder) {
+        symbol.symbolCategory =
+            glow::runtime::SymbolCategory::PlaceholderTensorView;
+      } else {
+        symbol.symbolCategory =
+            glow::runtime::SymbolCategory::ConstantTensorView;
+      }
+      symbolTable.emplace(std::string(TV->getName()), symbol);
+      DEBUG_GLOW(LOG(INFO) << strFormat(
+                     "Assigned address to activation %s: %zx (%zd bytes)\n",
+                     TV->getName().data(), symbol.offset, symbol.size));
+      continue;
+    }
+
+    if (auto *D = dyn_cast<DeallocActivationInst>(&I)) {
+      auto *A = D->getAlloc();
+      assert(symbolTable.count(std::string(A->getName())) &&
+             "Invalid deallocation!");
+      if (reuseActivationsMemory) {
+        allocator.deallocate(A);
+      }
+      continue;
+    }
+  }
+}
+
 } // namespace glow
 
 runtime::RuntimeBundle
@@ -551,50 +574,16 @@ runtime::RuntimeBundle::create(const IRFunction &F,
   // Handle Constants, Placeholders, and Activations, in that order.
   // Symbol table mapping symbol name to offset for runtime.
   std::map<std::string, runtime::RuntimeSymbolInfo> symbolTable;
-  // Compute the offsets for Constants.
-  for (auto &v : F.findConstants()) {
-    assert(isa<WeightVar>(F.getWeightForNode(v)) && "Expected WeightVar");
-    auto *w = cast<WeightVar>(F.getWeightForNode(v));
-    auto numBytes = w->getSizeInBytes();
-    size_t addr = constantAllocator.allocate(numBytes, v);
-    runtime::RuntimeSymbolInfo symbol;
-    symbol.size = numBytes;
-    symbol.offset = addr;
-    symbol.type = *w->getType();
-    symbol.input = false;
-    symbol.output = false;
-    symbol.symbolCategory = SymbolCategory::Constant;
-    symbolTable.emplace(std::string(v->getName()), symbol);
-    DEBUG_GLOW(LOG(INFO) << strFormat(
-                   "Assigned address to constant %s: %zx (%zd bytes)\n",
-                   v->getName().data(), symbol.offset, symbol.size));
-  }
+
+  allocateConstants(F.findConstants(), constantAllocator, symbolTable);
   auto constantMaxSize = constantAllocator.getMaxMemoryUsage();
 
   // Placeholders should be allocated in a order of Input|InputOutput|Output.
   auto contiguousPlaceholders =
       getContiguousPlaceHolder(F.findPlaceholders(), F);
-
   // Compute the offsets for Placeholders.
-  for (auto it = contiguousPlaceholders.begin();
-       it != contiguousPlaceholders.end(); it++) {
-    auto &v = it->addr;
-    assert(isa<WeightVar>(F.getWeightForNode(v)) && "Expected WeightVar");
-    auto *w = cast<WeightVar>(F.getWeightForNode(v));
-    auto numBytes = w->getSizeInBytes();
-    size_t addr = placeholderAllocator.allocate(numBytes, w);
-    runtime::RuntimeSymbolInfo symbol;
-    symbol.offset = addr;
-    symbol.size = numBytes;
-    symbol.type = *w->getType();
-    symbol.output = it->isOutput;
-    symbol.input = it->isInput;
-    symbol.symbolCategory = SymbolCategory::Placeholder;
-    symbolTable.emplace(std::string(v->getName()), symbol);
-    DEBUG_GLOW(LOG(INFO) << strFormat(
-                   "Assigned address to mutable weight %s: %zx (%zd bytes)\n",
-                   w->getName().data(), symbol.offset, symbol.size));
-  }
+  allocatePlaceholders(contiguousPlaceholders, placeholderAllocator,
+                       symbolTable);
   auto placeholderMaxSize = placeholderAllocator.getMaxMemoryUsage();
   if (contiguous) {
     placeholderMaxSize -= constantMaxSize;

--- a/lib/LLVMIRCodeGen/AllocationsInfo.cpp
+++ b/lib/LLVMIRCodeGen/AllocationsInfo.cpp
@@ -39,16 +39,17 @@ using llvm::isa;
 void AllocationsInfo::allocateWeightVars(const IRFunction *F) {
   // Compute the new offsets for all the weights, do not reuse their current
   // addresses. Process all constant WeightVars first.
-  for (auto &v : F->findConstants()) {
-    assert(isa<WeightVar>(F->getWeightForNode(v)) && "Expected WeightVar");
-    auto *w = cast<WeightVar>(F->getWeightForNode(v));
-    if (allocatedAddress_.count(v)) {
-      allocatedAddress_[w] = allocatedAddress_[v];
+  allocateConstants(F->findConstants(), constantWeightVarsAllocator_,
+                    symbolTable_);
+  for (auto &c : F->findConstants()) {
+    assert(symbolTable_.find(std::string(c->getName())) != symbolTable_.end());
+    auto *w = cast<WeightVar>(F->getWeightForNode(c));
+    if (allocatedAddress_.count(c)) {
+      allocatedAddress_[w] = allocatedAddress_[c];
       continue;
     }
-    auto numBytes = w->getSizeInBytes();
-    size_t addr = constantWeightVarsAllocator_.allocate(numBytes, v);
-    allocatedAddress_[v] = addr;
+    auto addr = symbolTable_[std::string(c->getName())].offset;
+    allocatedAddress_[c] = addr;
     allocatedAddress_[w] = addr;
   }
 
@@ -57,18 +58,18 @@ void AllocationsInfo::allocateWeightVars(const IRFunction *F) {
   auto contiguousPlaceholders =
       getContiguousPlaceHolder(F->findPlaceholders(), *F);
 
+  allocatePlaceholders(contiguousPlaceholders, mutableWeightVarsAllocator_,
+                       symbolTable_);
   // Compute the offsets and total memory requirements for Placeholders.
   for (auto it = contiguousPlaceholders.begin();
        it != contiguousPlaceholders.end(); it++) {
     auto &v = it->addr;
-    // Get the WeightVar for each Placeholder to calculate offsets.
-    assert(isa<WeightVar>(F->getWeightForNode(v)) && "Expected WeightVar");
+    assert(symbolTable_.find(std::string(v->getName())) != symbolTable_.end());
     auto *w = cast<WeightVar>(F->getWeightForNode(v));
     if (allocatedAddress_.count(w)) {
       continue;
     }
-    auto numBytes = w->getSizeInBytes();
-    size_t addr = mutableWeightVarsAllocator_.allocate(numBytes, w);
+    auto addr = symbolTable_[std::string(v->getName())].offset;
     allocatedAddress_[w] = addr;
   }
 
@@ -97,23 +98,20 @@ void AllocationsInfo::allocateWeightVars(const IRFunction *F) {
 }
 
 void AllocationsInfo::allocateActivations(const IRFunction *F) {
+  glow::allocateActivations(F->getInstrs(), activationsAllocator_,
+                            symbolTable_);
+
   // Maps activations and views to some offset within the heap.
   llvm::DenseMap<const Value *, uint64_t> activationAddr;
 
   // Assign device-space addresses to the activations.
   for (const auto &I : F->getInstrs()) {
     if (auto *A = dyn_cast<AllocActivationInst>(&I)) {
-      auto numBytes = I.getSizeInBytes();
-      size_t addr = activationsAllocator_.allocate(numBytes, A);
+      assert(symbolTable_.find(std::string(A->getName())) !=
+             symbolTable_.end());
       assert(!activationAddr.count(A) && "Allocation already made!");
+      auto addr = symbolTable_[std::string(A->getName())].offset;
       activationAddr[A] = addr;
-      continue;
-    }
-
-    if (auto *D = dyn_cast<DeallocActivationInst>(&I)) {
-      auto *A = D->getAlloc();
-      assert(activationAddr.count(A) && "Invalid deallocation!");
-      activationsAllocator_.deallocate(A);
       continue;
     }
   }

--- a/lib/LLVMIRCodeGen/BundleSaver.cpp
+++ b/lib/LLVMIRCodeGen/BundleSaver.cpp
@@ -632,10 +632,10 @@ void BundleSaver::performBundleMemoryAllocation() {
   // Perform memory allocation for the current function.
   auto *F = savedIRFunctions_.back().savedF;
   allocationsInfo_.numberValues(F);
-  allocationsInfo_.allocateActivations(F);
   // Tell the allocateWeightVars to not reuse any existing addresses for weights
   // and to assign new ones.
   allocationsInfo_.allocateWeightVars(F);
+  allocationsInfo_.allocateActivations(F);
   allocationsInfo_.allocateTensorViews(F);
 }
 

--- a/lib/LLVMIRCodeGen/LLVMBackend.cpp
+++ b/lib/LLVMIRCodeGen/LLVMBackend.cpp
@@ -42,8 +42,8 @@ namespace {
 /// Perform memory allocation for a JIT execution.
 void allocateJITMemory(const IRFunction *F, AllocationsInfo &allocationsInfo) {
   allocationsInfo.numberValues(F);
-  allocationsInfo.allocateActivations(F);
   allocationsInfo.allocateWeightVars(F);
+  allocationsInfo.allocateActivations(F);
   allocationsInfo.allocateTensorViews(F);
 }
 


### PR DESCRIPTION
Summary:
AllocationsInfo and RuntimeBundle were using essentially the same logic, but their equivalence was not guaranteed or verified, which could lead to very hard to find differences and bugs, especially for the AOT compilation using LLVMBackend-derived backends.

This commit expresses the logic in AllocationsInfo by literally re-using the same logic that is used by RuntimeBundle. This ensures that the addresses allocated by both methods to a given weight, placeholder or activation are always the same.

Reviewed By: jfix71

Differential Revision: D26193839

