### PR TITLE
[Type] Add support for unsigned 8-bit index type (UInt8ITy)

### DIFF
--- a/include/glow/Base/Tensor.h
+++ b/include/glow/Base/Tensor.h
@@ -678,6 +678,8 @@ public:
       return isEqualImpl<int16_t>(other, allowedError, verbose);
     case ElemKind::Int32QTy:
       return isEqualImpl<int32_t>(other, allowedError, verbose);
+    case ElemKind::UInt8ITy:
+      return isEqualImpl<uint8_t>(other, allowedError, verbose);
     case ElemKind::Int32ITy:
       return isEqualImpl<int32_t>(other, allowedError, verbose);
     case ElemKind::Int64ITy:

--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -413,6 +413,8 @@ enum class ElemKind : unsigned char {
   Int16QTy,
   // 32-bit quantized type (int32_t)
   Int32QTy,
+  // 8-bit index type (uint8_t)
+  UInt8ITy,
   // 32-bit index type (int32_t)
   Int32ITy,
   // 64-bit index type (int64_t)
@@ -696,6 +698,8 @@ struct Type final {
       return std::is_same<ElemTy, int16_t>::value;
     case ElemKind::Int32QTy:
       return std::is_same<ElemTy, int32_t>::value;
+    case ElemKind::UInt8ITy:
+      return std::is_same<ElemTy, uint8_t>::value;
     case ElemKind::Int32ITy:
       return std::is_same<ElemTy, int32_t>::value;
     case ElemKind::Int64ITy:
@@ -767,6 +771,8 @@ struct Type final {
       return sizeof(int16_t);
     case ElemKind::Int32QTy:
       return sizeof(int32_t);
+    case ElemKind::UInt8ITy:
+      return sizeof(uint8_t);
     case ElemKind::Int32ITy:
       return sizeof(int32_t);
     case ElemKind::Int64ITy:
@@ -793,9 +799,9 @@ struct Type final {
   /// \return the textual name of the element \p Ty.
   static llvm::StringRef getElementName(ElemKind Ty) {
     static const char *names[] = {
-        "float",        "float16",      "bfloat16", "i8",      "ui8",
-        "i16",          "i32",          "index32",  "index64", "ui8fused",
-        "ui8fusedfp16", "ui4fusedfp16", "ui4fused", "bool",
+        "float",    "float16",      "bfloat16",     "i8",       "ui8",
+        "i16",      "i32",          "uindex8",      "index32",  "index64",
+        "ui8fused", "ui8fusedfp16", "ui4fusedfp16", "ui4fused", "bool",
     };
     return names[(int)Ty];
   }
@@ -818,6 +824,8 @@ struct Type final {
       return ElemKind::Int16QTy;
     } else if (str == Type::getElementName(ElemKind::Int32QTy)) {
       return ElemKind::Int32QTy;
+    } else if (str == Type::getElementName(ElemKind::UInt8ITy)) {
+      return ElemKind::UInt8ITy;
     } else if (str == Type::getElementName(ElemKind::Int32ITy)) {
       return ElemKind::Int32ITy;
     } else if (str == Type::getElementName(ElemKind::Int64ITy)) {

--- a/lib/Base/Tensor.cpp
+++ b/lib/Base/Tensor.cpp
@@ -435,6 +435,8 @@ void glow::dumpAsciiImpl(const Tensor *T, llvm::raw_ostream &os) {
     return dumpAsciiGenericImpl(T->getHandle<int16_t>(), os);
   case ElemKind::Int32QTy:
     return dumpAsciiGenericImpl(T->getHandle<int32_t>(), os);
+  case ElemKind::UInt8ITy:
+    return dumpAsciiGenericImpl(T->getHandle<uint8_t>(), os);
   case ElemKind::Int32ITy:
     return dumpAsciiGenericImpl(T->getHandle<int32_t>(), os);
   case ElemKind::Int64ITy:
@@ -471,6 +473,8 @@ void glow::dumpImpl(const Tensor *T, llvm::raw_ostream &os,
     return dumpGenericImpl(T->getHandle<int16_t>(), os, maxNumElem);
   case ElemKind::Int32QTy:
     return dumpGenericImpl(T->getHandle<int32_t>(), os, maxNumElem);
+  case ElemKind::UInt8ITy:
+    return dumpGenericImpl(T->getHandle<uint8_t>(), os, maxNumElem);
   case ElemKind::Int32ITy:
     return dumpGenericImpl(T->getHandle<int32_t>(), os, maxNumElem);
   case ElemKind::Int64ITy:
@@ -606,6 +610,12 @@ void glow::genericTranspose(const Tensor *src, Tensor *dest,
     transposeSelectImpl(srcH, destH, shuffle);
     return;
   }
+  case ElemKind::UInt8ITy: {
+    auto srcH = src->getHandle<uint8_t>();
+    auto destH = dest->getHandle<uint8_t>();
+    transposeSelectImpl(srcH, destH, shuffle);
+    return;
+  }
   case ElemKind::Int32ITy: {
     auto srcH = src->getHandle<int32_t>();
     auto destH = dest->getHandle<int32_t>();
@@ -716,6 +726,10 @@ void Tensor::init(InitKind init, float val, PseudoRNG &PRNG) {
     }
     case ElemKind::Int32QTy: {
       getHandle<int32_t>().clear(val);
+      break;
+    }
+    case ElemKind::UInt8ITy: {
+      getHandle<uint8_t>().clear(val);
       break;
     }
     case ElemKind::Int32ITy: {

--- a/lib/Exporter/ONNXModelWriter.cpp
+++ b/lib/Exporter/ONNXModelWriter.cpp
@@ -1124,6 +1124,7 @@ ONNXModelWriter::convertType(const Type &glowType) {
   case ElemKind::UInt4FusedFP16QTy:
   case ElemKind::UInt4FusedQTy:
   case ElemKind::UInt8QTy:
+  case ElemKind::UInt8ITy:
     return TensorType::UINT8;
   case ElemKind::Int16QTy:
     return TensorType::INT16;

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -213,6 +213,8 @@ llvm::Type *LLVMIRGen::getElementType(llvm::IRBuilder<> &builder,
     return builder.getInt16Ty();
   case ElemKind::Int32QTy:
     return builder.getInt32Ty();
+  case ElemKind::UInt8ITy:
+    return builder.getInt8Ty();
   case ElemKind::Int32ITy:
     return builder.getInt32Ty();
   case ElemKind::UInt8FusedQTy:
@@ -346,6 +348,9 @@ llvm::Value *LLVMIRGen::emitValueAddress(llvm::IRBuilder<> &builder,
     break;
   case ElemKind::Int32ITy:
     T = llvm::Type::getInt32PtrTy(getLLVMContext());
+    break;
+  case ElemKind::UInt8ITy:
+    T = llvm::Type::getInt8PtrTy(ctx_);
     break;
   case ElemKind::UInt8FusedQTy:
     T = llvm::Type::getInt8PtrTy(getLLVMContext());
@@ -604,6 +609,8 @@ llvm::Value *LLVMIRGen::emitConst(llvm::IRBuilder<> &builder, float val,
     return builder.getInt16(static_cast<int16_t>(val));
   case ElemKind::Int32QTy:
     return builder.getInt32(static_cast<int32_t>(val));
+  case ElemKind::UInt8ITy:
+    return builder.getInt8(static_cast<uint8_t>(val));
   case ElemKind::Int32ITy:
     return builder.getInt32(static_cast<int32_t>(val));
   case ElemKind::UInt8FusedQTy:

--- a/tests/unittests/BasicIRTest.cpp
+++ b/tests/unittests/BasicIRTest.cpp
@@ -90,6 +90,8 @@ TEST(IR, basicQuantizedTypes) {
   EXPECT_FALSE(TF.isQuantizedType());
   Type T64I(ElemKind::Int64ITy, {2, 3});
   EXPECT_FALSE(T64I.isQuantizedType());
+  Type TU8I(ElemKind::UInt8ITy, {2, 3});
+  EXPECT_FALSE(TU8I.isQuantizedType());
 }
 
 TEST(IR, basicUseList) {

--- a/tests/unittests/TensorsTest.cpp
+++ b/tests/unittests/TensorsTest.cpp
@@ -358,6 +358,7 @@ TEST(Tensor, assignment) {
   testAssignment<uint8_t>(Type{ElemKind::UInt8QTy, dim, 1., 0});
   testAssignment<int16_t>(Type{ElemKind::Int16QTy, dim, 1., 0});
   testAssignment<int32_t>(Type{ElemKind::Int32QTy, dim, 1., 0});
+  testAssignment<uint8_t>(Type{ElemKind::UInt8ITy, dim});
   testAssignment<int32_t>(Type{ElemKind::Int32ITy, dim});
   testAssignment<int64_t>(Type{ElemKind::Int64ITy, dim});
 }
@@ -1341,6 +1342,7 @@ TEST(Tensor, typeSerialization) {
   testType(Type(ElemKind::UInt8QTy, {1, 2, 3}, 1.2, 2));
   testType(Type(ElemKind::Int16QTy, {1, 2, 3}, 1.3, 3));
   testType(Type(ElemKind::Int32QTy, {1, 2, 3}, 1.4, 4));
+  testType(Type(ElemKind::UInt8ITy, {1, 2, 3}));
   testType(Type(ElemKind::Int32ITy, {1, 2, 3}));
   testType(Type(ElemKind::Int64ITy, {1, 2, 3}));
   testType(Type(ElemKind::UInt8FusedQTy, {1, 2, 3}, 1.5, 5));


### PR DESCRIPTION
Summary:
Add support for unsigned 8-bit index type (UInt8ITy)

Documentation:
N/A

Test Plan:
A few BasicIR and Tensor unit tests are extended.

Co-authored-by: Max Kazantsev <maximkaz@cadence.com>