### PR TITLE
Add a Caffe2 loader test for RMSNorm

### DIFF
--- a/tests/models/caffe2Models/rmsnorm.pbtxt
+++ b/tests/models/caffe2Models/rmsnorm.pbtxt
@@ -1,0 +1,19 @@
+name: "rmsnorm"
+op {
+  input: "x"
+  input: "gamma"
+  input: "beta"
+  output: "y"
+  output: "rrms"
+  name: ""
+  type: "RMSNorm"
+  arg {
+    name: "eps"
+    f: 1
+  }
+}
+external_input: "x"
+external_input: "gamma"
+external_input: "beta"
+external_output: "y"
+external_output: "rrms"


### PR DESCRIPTION
Summary: Add a Caffe2 loader test for RMSNorm to verify that we get expected outputs.

Reviewed By: yinghai

Differential Revision: D26209528

