### PR TITLE
Add _shape_as_tensor operator support

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -780,6 +780,10 @@ private:
   /// \returns error on failure.
   Error loadNumToTensor(const torch::jit::Node *ptNode);
 
+  /// Load a PyTorch aten::shape_as_tensor node.
+  /// \returns error on failure.
+  Error loadShapeAsTensor(const torch::jit::Node *ptNode);
+
   /// Load a PyTorch aten::reshape node.
   /// \returns error on failure.
   Error loadReshape(const torch::jit::Node *ptNode);

--- a/torch_glow/tests/nodes/shape_as_tensor_test.py
+++ b/torch_glow/tests/nodes/shape_as_tensor_test.py
@@ -1,0 +1,33 @@
+# isort:skip_file
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+
+import torch
+from parameterized import parameterized
+from tests import utils
+
+
+class SimpleShapeAsTensorModel(torch.nn.Module):
+    def __init__(self):
+        super(SimpleShapeAsTensorModel, self).__init__()
+
+    def forward(self, tensor):
+        result = torch._shape_as_tensor(tensor)
+        return result + result
+
+
+class TestShapeAsTensor(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("single dimension", SimpleShapeAsTensorModel(), torch.randn(6)),
+            ("multiple dimensions", SimpleShapeAsTensorModel(), torch.randn(3, 2, 4)),
+        ]
+    )
+    def test_shape_as_tensor(self, _, module, tensor):
+        """Test of the PyTorch ShapeAsTensor Node on Glow."""
+        utils.compare_tracing_methods(
+            module,
+            tensor,
+            fusible_ops={"aten::_shape_as_tensor"},
+        )


### PR DESCRIPTION
Summary: This commit adds supports for ATen's `_shape_as_tensor` operator function.

Differential Revision: D26217258

