### PR TITLE
Use glow_snn_partitioning_num_cards as a hint and try harder during snn partitioning

### DIFF
--- a/lib/Partitioner/PartitionerUtils.cpp
+++ b/lib/Partitioner/PartitionerUtils.cpp
@@ -671,7 +671,7 @@ Error assignSlsTablesToDevices(
   });
 
   // Now sort SLS tables by size decreasing
-  LOG(INFO) << "SLS tables sorted by size decreasing" << std::endl;
+  VLOG(1) << "SLS tables sorted by size decreasing";
   std::sort(slsTables.begin(), slsTables.end(),
             [](const SLSTableInfo &l, const SLSTableInfo &r) {
               return l.numBytesInTable > r.numBytesInTable;

--- a/lib/Runtime/Provisioner/Provisioner.cpp
+++ b/lib/Runtime/Provisioner/Provisioner.cpp
@@ -220,7 +220,7 @@ Provisioner::generateDeviceAssignments(
             ErrorValue::ErrorCode::RUNTIME_OUT_OF_DEVICE_MEMORY,
             strFormat(
                 "Logical Device is too large to fit in available device "
-                "memory. Largest device memory: %lu, logic device size:  %lu",
+                "memory. Largest device memory: %lu, logic device size: %lu",
                 deviceMemoryMap[backendName][0].second, logicalDevice.second));
       }
     }


### PR DESCRIPTION
Summary: Previous behavior is that we use `glow_snn_partitioning_num_cards` as a hard constraint when doing snn partitioning, which makes things a bit difficult. The diff here makes it that we use `glow_snn_partitioning_num_cards` only as a hint, and when snn partitioning fails due to not enough memory, we will increase the number of snn partitioning, using `glow_snn_partitioning_num_cards` as a step size, capped at maximum devices numbers. This will help in the case when user doesn't have a very good idea of how much memory embedding part of the model is going to take.

Differential Revision: D26299174

