### PR TITLE
[ONNXImporter] Add Pow operator support

### DIFF
--- a/include/glow/Importer/CommonOperatorLoader.h
+++ b/include/glow/Importer/CommonOperatorLoader.h
@@ -790,6 +790,8 @@ protected:
         node = G_->createNodeWithBroadcast<SubNode>(opName, axis, in0, in1);
       } else if (typeName == "Div") {
         node = G_->createNodeWithBroadcast<DivNode>(opName, axis, in0, in1);
+      } else if (typeName == "Pow") {
+        node = G_->createNodeWithBroadcast<PowNode>(opName, axis, in0, in1);
       } else {
         return MAKE_ERR("Unsupported arithmetic typeName");
       }
@@ -802,6 +804,8 @@ protected:
         node = G_->createSub(opName, in0, in1);
       } else if (typeName == "Div") {
         node = G_->createDiv(opName, in0, in1);
+      } else if (typeName == "Pow") {
+        node = G_->createPow(opName, in0, in1);
       } else {
         return MAKE_ERR("Unsupported arithmetic typeName");
       }
@@ -1569,7 +1573,7 @@ protected:
       return true;
     }
     if (typeName == "Mul" || typeName == "Add" || typeName == "Sub" ||
-        typeName == "Div") {
+        typeName == "Div" || typeName == "Pow") {
       RETURN_IF_ERR(loadArithmetic(typeName, op, dict));
       return true;
     }

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -879,6 +879,7 @@ bool SinkCode::run(Function *F, const CompilationContext &cctx) {
         ARITHMETIC_CASE(Div);
         ARITHMETIC_CASE(Max);
         ARITHMETIC_CASE(Min);
+        ARITHMETIC_CASE(Pow);
         BOOLEAN_OP_CASE(CmpLTE);
         BOOLEAN_OP_CASE(CmpEQ);
       default:

--- a/tests/models/onnxModels/powMultiBroadcastOp7.onnxtxt
+++ b/tests/models/onnxModels/powMultiBroadcastOp7.onnxtxt
@@ -1,0 +1,51 @@
+ir_version: 3
+producer_name: "onnx-arith-broadcast"
+opset_import {
+  version: 7
+}
+
+graph {
+  node {
+    input: "data"
+    input: "const"
+    output: "out"
+    name: "op"
+    op_type: "Pow"
+  }
+  name: "test-model"
+  initializer {
+    dims: 4
+    dims: 1
+    data_type: 1
+    float_data: 2.0
+    float_data: 2.0
+    float_data: 2.0
+    float_data: 2.0
+   name: "const"
+  }
+  input {
+    name: "data"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 3
+          }
+          dim {
+            dim_value: 1
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "out"
+   }
+}

--- a/tests/unittests/OnnxExporterTest.cpp
+++ b/tests/unittests/OnnxExporterTest.cpp
@@ -361,6 +361,7 @@ TEST(exporter, onnxModels) {
     if (name.find("getInputsOnnxDefineSample.onnxtxt") != std::string::npos ||
         name.find("preluInvalidBroadcastSlope.onnxtxt") != std::string::npos ||
         name.find("padReflect.onnxtxt") != std::string::npos ||
+        name.find("powMultiBroadcastOp7.onnxtxt") != std::string::npos ||
         name.find("gatherConstantFolding.onnxtxt") != std::string::npos ||
         name.find("averagePool3D.onnxtxt") != std::string::npos ||
         name.find("sparseLengthsSum.onnxtxt") != std::string::npos ||

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -659,6 +659,13 @@ TEST_F(OnnxImporterTest, importDivUniBroadcastOp6Axis) {
       [](float a, float b) { return a / b; });
 }
 
+TEST_F(OnnxImporterTest, importPowMultiBroadcastOp7) {
+  importArithMultiBroadcastTest<PowNode>(
+      "powMultiBroadcastOp7.onnxtxt", {1, 3, 1, 2}, /* multi */ true,
+      /* leftBroadcast */ true, /* rightBroadcast */ true,
+      [](float a, float b) { return std::pow(a, b); });
+}
+
 /// This tests reproduces issue #2135.
 TEST_F(OnnxImporterTest, importUniBroadcastMultiOutput) {
   ExecutionEngine EE{};


### PR DESCRIPTION
Summary:
Add Pow operator support in ONNX importer. Extend Transpose sinking for Pow.

Documentation:
N/A

Test Plan:
Added ONNX importer test, extended GraphOptz test.
