### PR TITLE
[torch_glow] Add support for aten::argsort

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -764,6 +764,10 @@ private:
   /// \returns error on failure.
   Error loadTopK(const torch::jit::Node *ptNode);
 
+  /// Load a PyTorch argsort node.
+  /// \returns error on failure.
+  Error loadArgSort(const torch::jit::Node *ptNode);
+
   /// Load a PyTorch aten::size node.
   /// \returns error on failure.
   Error loadSize(const torch::jit::Node *ptNode);

--- a/torch_glow/tests/nodes/argsort_test.py
+++ b/torch_glow/tests/nodes/argsort_test.py
@@ -1,0 +1,51 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+
+import torch
+from parameterized import parameterized
+from tests import utils
+
+
+class SimpleArgSortModule(torch.nn.Module):
+    def __init__(self, descending=True):
+        super(SimpleArgSortModule, self).__init__()
+        self.descending = descending
+
+    def forward(self, inputs):
+        # Only last dim is currently supported
+        return torch.argsort(inputs, dim=-1, descending=self.descending)
+
+
+class TestArgSort(unittest.TestCase):
+    @parameterized.expand(
+        [
+            (
+                "desc",
+                SimpleArgSortModule(),
+                torch.randn(4),
+            ),
+            (
+                "asc",
+                SimpleArgSortModule(descending=False),
+                torch.randn(4),
+            ),
+            (
+                "2d_desc",
+                SimpleArgSortModule(),
+                torch.randn(4, 3),
+            ),
+            (
+                "3d_asc",
+                SimpleArgSortModule(descending=False),
+                torch.randn(6, 4, 5),
+            ),
+            (
+                "4d_desc",
+                SimpleArgSortModule(),
+                torch.randn(4, 7, 7, 3),
+            ),
+        ]
+    )
+    def test_argsort(self, _, module, a):
+        utils.compare_tracing_methods(module, a, fusible_ops={"aten::argsort"})


### PR DESCRIPTION
Summary:
This PR adds support for the aten::argsort op (currently only support along the last dimension).

Test Plan:
Tests have been added to argsort_test.py.
