### PR TITLE
[torch_glow] Add support for keepdim to aten::mean

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -4965,7 +4965,12 @@ Error PyTorchModelLoader::loadMean(const torch::jit::Node *ptNode) {
     ASSIGN_VALUE_OR_RETURN_ERR(keepdims, iValToBool(getGlowIValueForValue(
                                              inputs[MeanInputs::keepdims])));
     if (keepdims == true) {
-      return MAKE_ERR("We don't currently support keeping dims");
+      std::vector<dim_t> shape = input.dims();
+      std::sort(axis->begin(), axis->end());
+      for (auto i : *axis) {
+        shape.insert(shape.begin() + i, static_cast<dim_t>(1));
+      }
+      input = F_.createReshape("reshape", input, shape)->getResult();
     }
   }
 

--- a/torch_glow/tests/nodes/mean_test.py
+++ b/torch_glow/tests/nodes/mean_test.py
@@ -7,13 +7,14 @@ from tests import utils
 
 
 class SimpleMeanModule(torch.nn.Module):
-    def __init__(self, dim=None):
+    def __init__(self, dim=None, keepdim=False):
         super(SimpleMeanModule, self).__init__()
         self.dim = dim
+        self.keepdim = keepdim
 
     def forward(self, a, b):
         if self.dim:
-            return torch.mean(a + b, self.dim)
+            return torch.mean(a + b, self.dim, keepdim=self.keepdim)
         else:
             return torch.mean(a + b)
 
@@ -34,6 +35,16 @@ class TestMean(unittest.TestCase):
 
         utils.compare_tracing_methods(
             SimpleMeanModule((1, 2)),
+            torch.randn([1, 2, 3, 4]),
+            torch.randn([1, 2, 3, 4]),
+            fusible_ops={"aten::mean"},
+        )
+
+    def test_with_keepdim(self):
+        """Test of the PyTorch mean node with dims and keepdim=True on Glow. """
+
+        utils.compare_tracing_methods(
+            SimpleMeanModule((2, 1), keepdim=True),
             torch.randn([1, 2, 3, 4]),
             torch.randn([1, 2, 3, 4]),
             fusible_ops={"aten::mean"},


### PR DESCRIPTION
Summary:
This PR adds support for the keepdim parameter to the PyTorchModelLoader implementation of aten::mean.