### PR TITLE
Pass loader and protobuf loader to postmodel load.

### DIFF
--- a/tests/unittests/LoaderTest.cpp
+++ b/tests/unittests/LoaderTest.cpp
@@ -19,7 +19,7 @@
 #include "glow/ExecutionEngine/ExecutionEngine.h"
 #include "glow/Graph/Graph.h"
 #include "glow/Importer/Caffe2ModelLoader.h"
-
+#include "glow/Importer/ONNXModelLoader.h"
 #include "gtest/gtest.h"
 
 #include "llvm/ADT/StringMap.h"
@@ -40,7 +40,8 @@ protected:
 using namespace glow;
 
 namespace {
-const dim_t BATCH_SIZE = 8;
+const dim_t BATCH_SIZE = 3;
+const dim_t BATCH_SIZE_TFLITE = 1;
 const size_t MINI_BATCH_SIZE = 2;
 } // namespace
 
@@ -51,6 +52,8 @@ public:
   static size_t index_;
   static Loader *loader_;
   static PlaceholderBindings *bindings_;
+  static ProtobufLoader *protobufLoader_;
+  static TFLiteModelLoader *tfliteloader_;
   static bool destructed_;
 
   testLoaderExtension() {
@@ -58,11 +61,14 @@ public:
     index_ = 0;
     loader_ = nullptr;
     bindings_ = nullptr;
+    protobufLoader_ = nullptr;
     destructed_ = false;
   }
 
   /// Called once after ONNX or Caffe2 model loading.
   virtual void postModelLoad(Loader &loader, PlaceholderBindings &bindings,
+                             ProtobufLoader &protobufLoader,
+                             llvm::StringMap<Placeholder *> &outputMap,
                              llvm::ArrayRef<TypeRef> inputImageType) {
 
     size_t compilationBatchSize = inputImageType[0]->dims()[0];
@@ -72,6 +78,7 @@ public:
     // To check params are correctly set.
     loader_ = &loader;
     bindings_ = &bindings;
+    protobufLoader_ = &protobufLoader;
     EXPECT_EQ(BATCH_SIZE, compilationBatchSize);
   }
   /// Called once at the beginning of the mini-batch inference.
@@ -98,6 +105,22 @@ public:
     index_ = minibatchIndex;
     EXPECT_EQ(MINI_BATCH_SIZE, minibatchSize);
   }
+  /// Called once after TFLite.
+  virtual void postModelLoad(Loader &loader, PlaceholderBindings &bindings,
+                             TFLiteModelLoader &tfliteLoader,
+                             llvm::StringMap<Placeholder *> &outputMap,
+                             llvm::ArrayRef<TypeRef> inputImageType) {
+
+    size_t compilationBatchSize = inputImageType[0]->dims()[0];
+    // To check the method was executed.
+    stage_ = 4;
+
+    // To check params are correctly set.
+    loader_ = &loader;
+    bindings_ = &bindings;
+    tfliteloader_ = &tfliteLoader;
+    EXPECT_EQ(BATCH_SIZE_TFLITE, compilationBatchSize);
+  }
   virtual ~testLoaderExtension() { destructed_ = true; }
 };
 
@@ -113,7 +136,8 @@ public:
   }
 
   /// Called once after ONNX or Caffe2 model loading.
-  virtual void postModelLoad(Loader &, PlaceholderBindings &,
+  virtual void postModelLoad(Loader &, PlaceholderBindings &, ProtobufLoader &,
+                             llvm::StringMap<Placeholder *> &,
                              llvm::ArrayRef<TypeRef> inputImageType) {
     stage_ = 1;
   }
@@ -127,6 +151,12 @@ public:
                                  size_t) {
     stage_ = 3;
   }
+  virtual void postModelLoad(Loader &, PlaceholderBindings &,
+                             TFLiteModelLoader &,
+                             llvm::StringMap<Placeholder *> &,
+                             llvm::ArrayRef<TypeRef> inputImageType) {
+    stage_ = 4;
+  }
 
   virtual ~secondTestLoaderExtension() { destructed_ = true; }
 };
@@ -136,12 +166,14 @@ int testLoaderExtension::stage_;
 size_t testLoaderExtension::index_;
 Loader *testLoaderExtension::loader_;
 PlaceholderBindings *testLoaderExtension::bindings_;
+ProtobufLoader *testLoaderExtension::protobufLoader_;
+TFLiteModelLoader *testLoaderExtension::tfliteloader_;
 bool testLoaderExtension::destructed_;
 int secondTestLoaderExtension::stage_;
 bool secondTestLoaderExtension::destructed_;
 
-/// This test simulates what can be a Glow applciation (like image_classifier).
-TEST_F(LoaderTest, LoaderExtension) {
+/// This test simulates what can be a Glow application (like image_classifier).
+TEST_F(LoaderTest, LoaderExtensionCaffe2) {
   {
     std::unique_ptr<ExecutionContext> exContext =
         glow::make_unique<ExecutionContext>();
@@ -182,10 +214,11 @@ TEST_F(LoaderTest, LoaderExtension) {
 
     // Get bindings and call post model load extensions.
     ASSERT_EQ(testLoaderExtension::stage_, 0);
-    loader.postModelLoad(bindings, &inputData.getType());
+    loader.postModelLoad(bindings, caffe2LD, outputMap, &inputData.getType());
     ASSERT_EQ(testLoaderExtension::stage_, 1);
     ASSERT_EQ(testLoaderExtension::loader_, &loader);
     ASSERT_EQ(testLoaderExtension::bindings_, &bindings);
+    ASSERT_EQ(testLoaderExtension::protobufLoader_, &caffe2LD);
     ASSERT_EQ(secondTestLoaderExtension::stage_, 1);
 
     // Allocate tensors to back all inputs and outputs.
@@ -209,6 +242,7 @@ TEST_F(LoaderTest, LoaderExtension) {
       ASSERT_EQ(testLoaderExtension::index_, miniBatchIndex);
       ASSERT_EQ(testLoaderExtension::loader_, &loader);
       ASSERT_EQ(testLoaderExtension::bindings_, &bindings);
+      ASSERT_EQ(testLoaderExtension::protobufLoader_, &caffe2LD);
       ASSERT_EQ(secondTestLoaderExtension::stage_, 2);
 
       // Perform the inference execution for a minibatch.
@@ -220,6 +254,171 @@ TEST_F(LoaderTest, LoaderExtension) {
       ASSERT_EQ(testLoaderExtension::index_, miniBatchIndex);
       ASSERT_EQ(testLoaderExtension::loader_, &loader);
       ASSERT_EQ(testLoaderExtension::bindings_, &bindings);
+      ASSERT_EQ(testLoaderExtension::protobufLoader_, &caffe2LD);
+      ASSERT_EQ(secondTestLoaderExtension::stage_, 3);
+    }
+
+    // Extension object not destructed yet.
+    ASSERT_EQ(testLoaderExtension::destructed_, false);
+    ASSERT_EQ(secondTestLoaderExtension::destructed_, false);
+  } // End of the loader scope.
+
+  // Check that extensions were properly destructed by the Loader destruction.
+  ASSERT_EQ(testLoaderExtension::destructed_, true);
+  ASSERT_EQ(secondTestLoaderExtension::destructed_, true);
+}
+
+TEST_F(LoaderTest, LoaderExtensionTFlite) {
+  {
+    std::unique_ptr<ExecutionContext> exContext =
+        glow::make_unique<ExecutionContext>();
+    PlaceholderBindings &bindings = *exContext->getPlaceholderBindings();
+    llvm::StringMap<Placeholder *> outputMap;
+
+    // Create a loader object.
+    Loader loader;
+
+    // Register Loader extensions.
+    loader.registerExtension(
+        std::unique_ptr<LoaderExtension>(new testLoaderExtension()));
+    loader.registerExtension(
+        std::unique_ptr<LoaderExtension>(new secondTestLoaderExtension()));
+
+    // Load a model
+    std::string NetFilename(GLOW_DATA_PATH
+                            "tests/models/tfliteModels/abs.tflite");
+
+    Tensor inputData(ElemKind::FloatTy, {BATCH_SIZE_TFLITE, 10});
+    TFLiteModelLoader LD(NetFilename, loader.getFunction());
+
+    // Check the model was loaded.
+    EXPECT_EQ(loader.getFunction()->getNodes().size(), 2);
+
+    // Get bindings and call post model load extensions.
+    ASSERT_EQ(testLoaderExtension::stage_, 0);
+    loader.postModelLoad(bindings, LD, outputMap, &inputData.getType());
+    ASSERT_EQ(testLoaderExtension::stage_, 4);
+    ASSERT_EQ(testLoaderExtension::loader_, &loader);
+    ASSERT_EQ(testLoaderExtension::bindings_, &bindings);
+    ASSERT_EQ(testLoaderExtension::tfliteloader_, &LD);
+    ASSERT_EQ(secondTestLoaderExtension::stage_, 4);
+
+    // Allocate tensors to back all inputs and outputs.
+    bindings.allocate(loader.getModule()->getPlaceholders());
+
+    // Compile the model.
+    CompilationContext cctx = loader.getCompilationContext();
+    cctx.bindings = &bindings;
+    loader.compile(cctx);
+
+    // Load data to input placeholders.
+    updateInputPlaceholdersByName(bindings, loader.getModule(), {"input"},
+                                  {&inputData});
+
+    // Run mini-batches.
+    for (size_t miniBatchIndex = 0; miniBatchIndex < BATCH_SIZE;
+         miniBatchIndex += MINI_BATCH_SIZE) {
+      // Minibatch inference initialization of loader extensions.
+      loader.inferInitMiniBatch(bindings, miniBatchIndex, MINI_BATCH_SIZE);
+      ASSERT_EQ(testLoaderExtension::stage_, 2);
+      ASSERT_EQ(testLoaderExtension::index_, miniBatchIndex);
+      ASSERT_EQ(testLoaderExtension::loader_, &loader);
+      ASSERT_EQ(testLoaderExtension::bindings_, &bindings);
+      ASSERT_EQ(testLoaderExtension::tfliteloader_, &LD);
+      ASSERT_EQ(secondTestLoaderExtension::stage_, 2);
+
+      // Perform the inference execution for a minibatch.
+      loader.runInference(exContext.get(), BATCH_SIZE);
+
+      // Minibatch inference initialization of loader extensions.
+      loader.inferEndMiniBatch(bindings, miniBatchIndex, MINI_BATCH_SIZE);
+      ASSERT_EQ(testLoaderExtension::stage_, 3);
+      ASSERT_EQ(testLoaderExtension::index_, miniBatchIndex);
+      ASSERT_EQ(testLoaderExtension::loader_, &loader);
+      ASSERT_EQ(testLoaderExtension::bindings_, &bindings);
+      ASSERT_EQ(testLoaderExtension::tfliteloader_, &LD);
+      ASSERT_EQ(secondTestLoaderExtension::stage_, 3);
+    }
+
+    // Extension object not destructed yet.
+    ASSERT_EQ(testLoaderExtension::destructed_, false);
+    ASSERT_EQ(secondTestLoaderExtension::destructed_, false);
+  } // End of the loader scope.
+
+  // Check that extensions were properly destructed by the Loader destruction.
+  ASSERT_EQ(testLoaderExtension::destructed_, true);
+}
+
+TEST_F(LoaderTest, LoaderExtensionONNX) {
+  {
+    std::unique_ptr<ExecutionContext> exContext =
+        glow::make_unique<ExecutionContext>();
+    PlaceholderBindings &bindings = *exContext->getPlaceholderBindings();
+    llvm::StringMap<Placeholder *> outputMap;
+
+    // Create a loader object.
+    Loader loader;
+
+    // Register Loader extensions.
+    loader.registerExtension(
+        std::unique_ptr<LoaderExtension>(new testLoaderExtension()));
+    loader.registerExtension(
+        std::unique_ptr<LoaderExtension>(new secondTestLoaderExtension()));
+
+    // Load a model
+    std::string NetFilename(GLOW_DATA_PATH
+                            "tests/models/onnxModels/clip.onnxtxt");
+
+    Tensor inputData(ElemKind::FloatTy, {BATCH_SIZE, 3});
+    ONNXModelLoader LD(NetFilename, {"x"}, {&inputData.getType()},
+                       *loader.getFunction());
+
+    // Check the model was loaded.
+    EXPECT_EQ(loader.getFunction()->getNodes().size(), 2);
+
+    // Get bindings and call post model load extensions.
+    ASSERT_EQ(testLoaderExtension::stage_, 0);
+    loader.postModelLoad(bindings, LD, outputMap, &inputData.getType());
+    ASSERT_EQ(testLoaderExtension::stage_, 1);
+    ASSERT_EQ(testLoaderExtension::loader_, &loader);
+    ASSERT_EQ(testLoaderExtension::bindings_, &bindings);
+    ASSERT_EQ(testLoaderExtension::protobufLoader_, &LD);
+    ASSERT_EQ(secondTestLoaderExtension::stage_, 1);
+
+    // Allocate tensors to back all inputs and outputs.
+    bindings.allocate(loader.getModule()->getPlaceholders());
+
+    // Compile the model.
+    CompilationContext cctx = loader.getCompilationContext();
+    cctx.bindings = &bindings;
+    loader.compile(cctx);
+
+    // Load data to input placeholders.
+    updateInputPlaceholdersByName(bindings, loader.getModule(), {"x"},
+                                  {&inputData});
+
+    // Run mini-batches.
+    for (size_t miniBatchIndex = 0; miniBatchIndex < BATCH_SIZE;
+         miniBatchIndex += MINI_BATCH_SIZE) {
+      // Minibatch inference initialization of loader extensions.
+      loader.inferInitMiniBatch(bindings, miniBatchIndex, MINI_BATCH_SIZE);
+      ASSERT_EQ(testLoaderExtension::stage_, 2);
+      ASSERT_EQ(testLoaderExtension::index_, miniBatchIndex);
+      ASSERT_EQ(testLoaderExtension::loader_, &loader);
+      ASSERT_EQ(testLoaderExtension::bindings_, &bindings);
+      ASSERT_EQ(testLoaderExtension::protobufLoader_, &LD);
+      ASSERT_EQ(secondTestLoaderExtension::stage_, 2);
+
+      // Perform the inference execution for a minibatch.
+      loader.runInference(exContext.get(), BATCH_SIZE);
+
+      // Minibatch inference initialization of loader extensions.
+      loader.inferEndMiniBatch(bindings, miniBatchIndex, MINI_BATCH_SIZE);
+      ASSERT_EQ(testLoaderExtension::stage_, 3);
+      ASSERT_EQ(testLoaderExtension::index_, miniBatchIndex);
+      ASSERT_EQ(testLoaderExtension::loader_, &loader);
+      ASSERT_EQ(testLoaderExtension::bindings_, &bindings);
+      ASSERT_EQ(testLoaderExtension::protobufLoader_, &LD);
       ASSERT_EQ(secondTestLoaderExtension::stage_, 3);
     }
 

--- a/tools/loader/ExecutorCoreHelperFunctions.cpp
+++ b/tools/loader/ExecutorCoreHelperFunctions.cpp
@@ -319,10 +319,7 @@ std::pair<llvm::StringMap<Placeholder *>, llvm::StringMap<Placeholder *>>
 buildAndCompileAndGetInAndOutPair(Loader &loader, PlaceholderBindings &bindings,
                                   llvm::ArrayRef<TypeRef> inputImageType) {
   // Load model.
-  loader.loadModel(inputImageType);
-
-  // Post model loader transformation.
-  loader.postModelLoad(bindings, inputImageType);
+  loader.loadModel(&bindings, inputImageType);
 
   // Allocate tensors to back all inputs and outputs.
   bindings.allocate(loader.getModule()->getPlaceholders());

--- a/tools/loader/Loader.cpp
+++ b/tools/loader/Loader.cpp
@@ -438,7 +438,8 @@ static void getModelInputs(std::vector<std::string> &inputNames,
   }
 }
 
-void Loader::loadModel(llvm::ArrayRef<TypeRef> inputType) {
+void Loader::loadModel(PlaceholderBindings *bindings,
+                       llvm::ArrayRef<TypeRef> inputType) {
 
   // Get model input names and types.
   std::vector<std::string> inputNames;
@@ -467,17 +468,25 @@ void Loader::loadModel(llvm::ArrayRef<TypeRef> inputType) {
     // Load the maps between original model names and the placeholders.
     inputPlaceholderByName_ = protoLoader->getInputVarsMapping();
     outputPlaceholderByName_ = protoLoader->getOutputVarsMapping();
+    if (bindings) {
+      postModelLoad(*bindings, *protoLoader.get(), outputPlaceholderByName_,
+                    inputType);
+    }
   } else if (!getTFLiteModelFilename().empty()) {
     // For TensorFlowLite format the input placeholder names/types are not
     // provided since are used directly from the model.
-    auto tfliteLoader =
-        TFLiteModelLoader(getTFLiteModelFilename(), getFunction());
+    auto tfliteLoader = glow::make_unique<TFLiteModelLoader>(
+        getTFLiteModelFilename(), getFunction());
     // Load the maps between original model names and the placeholders.
-    inputPlaceholderByName_ = tfliteLoader.getInputPlaceholderMap();
-    outputPlaceholderByName_ = tfliteLoader.getOutputPlaceholderMap();
+    inputPlaceholderByName_ = tfliteLoader->getInputPlaceholderMap();
+    outputPlaceholderByName_ = tfliteLoader->getOutputPlaceholderMap();
     // Since TensorFlowLite loader currently does not have the capability to
     // enforce the input type (for batching) we must validate that when the
     // input type is explicitly given it actually matches the model input type.
+    if (bindings) {
+      postModelLoad(*bindings, *tfliteLoader, outputPlaceholderByName_,
+                    inputType);
+    }
     if (inputType.size()) {
       CHECK(inputPlaceholderByName_.size() == 1)
           << "Model is expected to have only 1 input!";
@@ -503,6 +512,10 @@ void Loader::loadModel(llvm::ArrayRef<TypeRef> inputType) {
     // Load the maps between original model names and the placeholders.
     inputPlaceholderByName_ = protoLoader->getInputVarsMapping();
     outputPlaceholderByName_ = protoLoader->getOutputVarsMapping();
+    if (bindings) {
+      postModelLoad(*bindings, *protoLoader.get(), outputPlaceholderByName_,
+                    inputType);
+    }
   }
 }
 
@@ -820,9 +833,22 @@ Loader &Loader::registerExtension(std::unique_ptr<LoaderExtension> extension) {
 }
 
 void Loader::postModelLoad(PlaceholderBindings &bindings,
+                           ProtobufLoader &protoLoader,
+                           llvm::StringMap<Placeholder *> &placeholderMap,
                            llvm::ArrayRef<TypeRef> inputImageType) {
   for (auto &&ext : loaderExtensionList_) {
-    ext->postModelLoad(*this, bindings, inputImageType);
+    ext->postModelLoad(*this, bindings, protoLoader, placeholderMap,
+                       inputImageType);
+  }
+}
+
+void Loader::postModelLoad(PlaceholderBindings &bindings,
+                           TFLiteModelLoader &tfloader,
+                           llvm::StringMap<Placeholder *> &placeholderMap,
+                           llvm::ArrayRef<TypeRef> inputImageType) {
+  for (auto &&ext : loaderExtensionList_) {
+    ext->postModelLoad(*this, bindings, tfloader, placeholderMap,
+                       inputImageType);
   }
 }
 

--- a/tools/loader/Loader.h
+++ b/tools/loader/Loader.h
@@ -18,6 +18,7 @@
 
 #include "glow/ExecutionEngine/ExecutionEngine.h"
 #include "glow/Importer/ProtobufLoader.h"
+#include "glow/Importer/TFLiteModelLoader.h"
 #include "glow/Quantization/Quantization.h"
 #include "glow/Runtime/HostManager/HostManager.h"
 
@@ -62,7 +63,12 @@ class ProtobufLoader;
 class LoaderExtension {
 public:
   /// Called once after ONNX or Caffe2 model loading.
+  virtual void postModelLoad(Loader &, PlaceholderBindings &, ProtobufLoader &,
+                             llvm::StringMap<Placeholder *> &,
+                             llvm::ArrayRef<TypeRef> inputImageType) = 0;
   virtual void postModelLoad(Loader &, PlaceholderBindings &,
+                             TFLiteModelLoader &,
+                             llvm::StringMap<Placeholder *> &,
                              llvm::ArrayRef<TypeRef> inputImageType) = 0;
   /// Called once at the beginning of the mini-batch inference.
   virtual void inferInitMiniBatch(Loader &, PlaceholderBindings &,
@@ -157,7 +163,8 @@ public:
   /// then the model input is forced to have the given input type regardless of
   /// the actual command line options (this requires for the model to have only
   /// one input).
-  void loadModel(llvm::ArrayRef<TypeRef> inputType = {});
+  void loadModel(PlaceholderBindings *bindings = nullptr,
+                 llvm::ArrayRef<TypeRef> inputType = {});
 
   /// \returns a map between the model input names and the input placeholders.
   /// The placeholder map is available once \ref loadModel() is called.
@@ -202,7 +209,12 @@ public:
   /// Register a loader extension.
   Loader &registerExtension(std::unique_ptr<LoaderExtension> ext);
   /// Called once after model loading.
+  void postModelLoad(PlaceholderBindings &bindings, ProtobufLoader &protoLoader,
+                     llvm::StringMap<Placeholder *> &,
+                     llvm::ArrayRef<TypeRef> inputImageType);
   void postModelLoad(PlaceholderBindings &bindings,
+                     TFLiteModelLoader &protoLoader,
+                     llvm::StringMap<Placeholder *> &,
                      llvm::ArrayRef<TypeRef> inputImageType);
   /// Called at the beginning of each mini-batch inference.
   void inferInitMiniBatch(PlaceholderBindings &bindings, size_t minibatchIndex,


### PR DESCRIPTION
Enabling passing loader to the postModelLoader, for customer-specific processing.
With TFLite not being protobuf based, this required changes to postModelLoad call.

Tests added to ImageLoaderTest.