### PR TITLE
Add support for constants to fx_glow

### DIFF
--- a/lib/Backends/NNPI/FXIRImporter.cpp
+++ b/lib/Backends/NNPI/FXIRImporter.cpp
@@ -421,6 +421,8 @@ FXNNPIImporter::importFunction(const folly::dynamic &FXIR,
   }
 
   // Add ops node.
+  // TODO, currently we assume that the target of get_attr nodes matches the
+  // name of the node, if they don't match we fail to load the graph.
   for (const auto &node : mod["nodes"]) {
     const auto &opCode = node["op_code"].getString();
     if (isOps(opCode)) {


### PR DESCRIPTION
Summary: Nested constants are created as placeholders by the graph_splitter used in the partitioner. So we change them back to get_attr nodes before serializing the graph.

Differential Revision: D26375577

