### PR TITLE
fix prototype for loading model into A*

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.cpp
+++ b/torch_glow/src/PyTorchModelLoader.cpp
@@ -6756,7 +6756,7 @@ PyTorchModelLoader::PyTorchModelLoader(
     const at::ArrayRef<torch::jit::IValue> inputs,
     const InputMetaStack &metaStack)
     : F_(F), settings_(settings), inputs_(inputs) {
-  std::cerr << "loading PyTorch graph\n" << graph << std::endl;
+  std::cerr << "loading PyTorch graph\n" << graph << std::endl << std::flush;
   auto loadFn = [&]() -> Error {
     auto graphInputValues = graph.inputs();
 


### PR DESCRIPTION
Summary:
fixed the prototype to correctly load the model into A* (only the remote_other)

this loads from the XL format

main bug was that the Glow Interpreter was being used, copied the same behavior as PtNetRunner

Differential Revision: D26379368

