### PR TITLE
Add aten::full_like, aten::zeros_like, aten::ones_like, aten::empty_like support

### DIFF
--- a/torch_glow/src/PyTorchModelLoader.h
+++ b/torch_glow/src/PyTorchModelLoader.h
@@ -481,6 +481,30 @@ private:
   /// \returns error on failure.
   Error loadZeros(const torch::jit::Node *ptNode);
 
+  /// Load a PyTorch empty_like node.
+  /// \returns error on failure.
+  Error loadEmptyLike(const torch::jit::Node *ptNode);
+
+  /// Load a PyTorch zeros_like node.
+  /// \returns error on failure.
+  Error loadZerosLike(const torch::jit::Node *ptNode);
+
+  /// Load a PyTorch ones_like node.
+  /// \returns error on failure.
+  Error loadOnesLike(const torch::jit::Node *ptNode);
+
+  /// Load a PyTorch full_like node.
+  /// \returns error on failure.
+  Error loadFullLike(const torch::jit::Node *ptNode);
+
+  /// Shared implementation for loadZerosLike, loadOnesLike, loadEmptyLike, and
+  /// loadFullLike. \returns error on failure.
+  Error loadFullLikeImpl(llvm::StringRef name,
+                         const torch::jit::Value *inputTensorValue,
+                         const torch::jit::Value *dtypeValue,
+                         at::optional<double> fillValue,
+                         const torch::jit::Value *outputValue);
+
   /// Load a PyTorch sub node.
   /// \returns error on failure.
   Error loadSub(const torch::jit::Node *ptNode);

--- a/torch_glow/tests/nodes/full_like_test.py
+++ b/torch_glow/tests/nodes/full_like_test.py
@@ -1,0 +1,57 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import unittest
+
+import torch
+from tests import utils
+
+
+class TestFullLike(unittest.TestCase):
+    def test_empty_like_basic(self):
+        """Basic test of the PyTorch empty_like Node on Glow."""
+
+        class TestModule(torch.nn.Module):
+            def forward(self, a):
+                b = torch.empty_like(a, dtype=torch.float)
+                c = torch.zeros_like(a, dtype=torch.float)
+                return a + (b * c)
+
+        x = torch.randn(2, 3, 4)
+
+        utils.compare_tracing_methods(TestModule(), x, fusible_ops={"aten::empty_like"})
+
+    def test_full_like_basic(self):
+        """Basic test of the PyTorch full_like Node on Glow."""
+
+        class TestModule(torch.nn.Module):
+            def forward(self, a):
+                b = torch.full_like(a, fill_value=3.1415, dtype=torch.float)
+                return a + b
+
+        x = torch.randn(2, 3, 4)
+
+        utils.compare_tracing_methods(TestModule(), x, fusible_ops={"aten::full_like"})
+
+    def test_zeros_like_basic(self):
+        """Basic test of the PyTorch zeros_like Node on Glow."""
+
+        class TestModule(torch.nn.Module):
+            def forward(self, a):
+                b = torch.zeros_like(a, dtype=torch.float)
+                return a + b
+
+        x = torch.randn(2, 3, 4)
+
+        utils.compare_tracing_methods(TestModule(), x, fusible_ops={"aten::zeros_like"})
+
+    def test_ones_like_basic(self):
+        """Basic test of the PyTorch ones_like Node on Glow."""
+
+        class TestModule(torch.nn.Module):
+            def forward(self, a):
+                b = torch.ones_like(a, dtype=torch.float)
+                return a + b
+
+        x = torch.randn(2, 3, 4)
+
+        utils.compare_tracing_methods(TestModule(), x, fusible_ops={"aten::ones_like"})


### PR DESCRIPTION
Summary: Adds implementations of `aten::full_like`, `aten::zeros_like`, `aten::ones_like`, and `aten::empty_like` to `glow::PyTorchModelLoader`. For `empty_like`, the tensor is created via `createTouch`, which does not initialize the elements of the tensor. For all of the others, the tensor is created via `createSplat`, which initializes each element to the desired fill value.

Differential Revision: D26355845

