### PR TITLE
Support LpNorm in Caffe2 loader

### DIFF
--- a/lib/Backends/NNPI/Importer.cpp
+++ b/lib/Backends/NNPI/Importer.cpp
@@ -2408,6 +2408,8 @@ std::unordered_map<
     {"Relu", glow::make_unique<ReluNodeImporter>()},
     {"PRelu", glow::make_unique<PReluNodeImporter>()},
     {"Gelu", glow::make_unique<GeluNodeImporter>()},
+    {"Abs", glow::make_unique<
+                UnaryEltwiseNodeImporter<glow::AbsNode, NNPI_ELTWISE_ABS>>()},
     {"Exp", glow::make_unique<
                 UnaryEltwiseNodeImporter<glow::ExpNode, NNPI_ELTWISE_EXP>>()},
     {"Neg", glow::make_unique<

--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -121,6 +121,7 @@ static NodeSupportLevels isNodeSupported(const NodeInfo &NI) {
   case Kinded::Kind::LogNodeKind:
   case Kinded::Kind::SigmoidNodeKind:
   case Kinded::Kind::NegNodeKind:
+  case Kinded::Kind::AbsNodeKind:
     isNodePrecisionSupported = NI.allInputsAndOutputsHaveSameElemKind(
         {ElemKind::FloatTy, ElemKind::Float16Ty, ElemKind::Int8QTy});
     break;

--- a/tests/models/caffe2Models/lpnorm_p1.pbtxt
+++ b/tests/models/caffe2Models/lpnorm_p1.pbtxt
@@ -1,0 +1,17 @@
+name: "lpnorm"
+op {
+  input: "input"
+  output: "output"
+  name: ""
+  type: "LpNorm"
+  arg {
+    name: "p"
+    i: 1
+  }
+  arg {
+    name: "average"
+    i: 0
+  }
+}
+external_input: "input"
+external_output: "output"

--- a/tests/models/caffe2Models/lpnorm_p2.pbtxt
+++ b/tests/models/caffe2Models/lpnorm_p2.pbtxt
@@ -1,0 +1,17 @@
+name: "lpnorm"
+op {
+  input: "input"
+  output: "output"
+  name: ""
+  type: "LpNorm"
+  arg {
+    name: "p"
+    i: 2
+  }
+  arg {
+    name: "average"
+    i: 0
+  }
+}
+external_input: "input"
+external_output: "output"

--- a/tests/unittests/Caffe2ImporterTest.cpp
+++ b/tests/unittests/Caffe2ImporterTest.cpp
@@ -4678,3 +4678,75 @@ TEST_F(Caffe2ImporterTest, negative) {
     }
   }
 }
+
+TEST_F(Caffe2ImporterTest, lpNorm) {
+  const std::vector<dim_t> inputShape{5, 6};
+
+  const auto runTest =
+      [&inputShape](const std::string &NetDescFilename,
+                    const std::string &NetWeightFilename,
+                    std::function<float(const Tensor &input)> refImpl) {
+        ExecutionEngine EE{};
+        auto &mod = EE.getModule();
+        Function *F = mod.createFunction("main");
+
+        PlaceholderBindings bindings;
+        Placeholder *outputPH;
+
+        Tensor input{ElemKind::FloatTy, inputShape};
+        input.getHandle().randomize(-3.0, 3.0, mod.getPRNG());
+
+        // Destroy the loader after the graph is loaded since the following
+        // execution will not depend on anything from the loader.
+        {
+          Caffe2ModelLoader caffe2LD(NetDescFilename, NetWeightFilename,
+                                     {"input"}, {&input.getType()}, *F);
+          outputPH = EXIT_ON_ERR(caffe2LD.getOutputByName("output"));
+
+          bindings.allocate(mod.getPlaceholders());
+          updateInputPlaceholdersByName(bindings, &mod, {"input"}, {&input});
+        }
+
+        auto output = bindings.get(outputPH);
+
+        const std::vector<dim_t> expectedOutputShape{1};
+        EXPECT_EQ(expectedOutputShape, output->dims().vec());
+
+        EE.compile(CompilationMode::Infer);
+        EE.run(bindings);
+
+        auto outputH = output->getHandle();
+
+        EXPECT_NEAR(refImpl(input), outputH.at({0}), 1e-5);
+      };
+
+  const auto refImplP1 = [&inputShape](const Tensor &input) {
+    float sum = 0;
+    for (dim_t d1 = 0; d1 < inputShape[0]; ++d1) {
+      for (dim_t d2 = 0; d2 < inputShape[1]; ++d2) {
+        auto val = input.getHandle().at({d1, d2});
+        sum += ((val >= 0) ? val : -val);
+      }
+    }
+    return sum;
+  };
+
+  const auto refImplP2 = [&inputShape](const Tensor &input) {
+    float sum = 0;
+    for (dim_t d1 = 0; d1 < inputShape[0]; ++d1) {
+      for (dim_t d2 = 0; d2 < inputShape[1]; ++d2) {
+        auto val = input.getHandle().at({d1, d2});
+        sum += val * val;
+      }
+    }
+    return sum;
+  };
+
+  runTest(GLOW_DATA_PATH "tests/models/caffe2Models/lpnorm_p1.pbtxt",
+          GLOW_DATA_PATH "tests/models/caffe2Models/empty_init_net.pbtxt",
+          refImplP1);
+
+  runTest(GLOW_DATA_PATH "tests/models/caffe2Models/lpnorm_p2.pbtxt",
+          GLOW_DATA_PATH "tests/models/caffe2Models/empty_init_net.pbtxt",
+          refImplP2);
+}


### PR DESCRIPTION
Summary: Implement LpNorm https://caffe2.ai/docs/operators-catalogue.html#lpnorm for p=1 and p=2.

Differential Revision: D26325784

