### PR TITLE
Add getContextCount to backend

### DIFF
--- a/include/glow/Backend/Backend.h
+++ b/include/glow/Backend/Backend.h
@@ -249,6 +249,12 @@ public:
     return Error::success();
   }
 
+  /// Get the number of copies of inputs/outputs that will be reserved on a
+  /// device per network.
+  virtual unsigned getContextCount(CompilationContext & /* unused */) const {
+    return 1;
+  }
+
   /// \returns the supported options for compiled functions (name=>description).
   virtual llvm::StringMap<std::string>
   getSupportedCompiledFunctionOptions() const {

--- a/lib/Backends/NNPI/NNPI.cpp
+++ b/lib/Backends/NNPI/NNPI.cpp
@@ -1776,6 +1776,15 @@ traversePostOrder(const runtime::DAGNode *root,
   postOrder.push_back(root);
 }
 
+unsigned NNPIBackend::getContextCount(CompilationContext &cctx) const {
+  if (cctx.enableP2P || cctx.enableDRT) {
+    return cctx.maxActiveRequestsPerInstance;
+  } else {
+    auto opts = NNPICompilationOptions(cctx.backendOpts.backendSpecificOpts);
+    return opts.numWorkers;
+  }
+}
+
 Error NNPIBackend::bindContexts(
     llvm::ArrayRef<runtime::ContextBinding> bindings,
     const runtime::DAGNode *root, bool enableP2P, bool enableDRT) {

--- a/lib/Backends/NNPI/NNPI.h
+++ b/lib/Backends/NNPI/NNPI.h
@@ -88,6 +88,10 @@ public:
                              const runtime::DAGNode *root, bool enableP2P,
                              bool enableDRT) override;
 
+  /// Get the number of copies of inputs/outputs that will be reserved on a
+  /// device per network.
+  unsigned getContextCount(CompilationContext &cctx) const override;
+
   /// Estimate performance cost for a given Node \p N.
   /// \returns a unitless value to be used when comparing to other estimates.
   /// or -1 if no estimate could be generated.

--- a/lib/Runtime/HostManager/HostManager.cpp
+++ b/lib/Runtime/HostManager/HostManager.cpp
@@ -364,11 +364,10 @@ Error HostManager::addNetwork(std::unique_ptr<Module> module,
   }
   VLOG(1) << "Before partitioner";
   Partitioner partitioner(module.get(), deviceInfo, skipOptimizations);
-  if (cctx.enableP2P || cctx.enableDRT) {
-    partitioner.setContextCount(cctx.maxActiveRequestsPerInstance);
-  } else {
-    partitioner.setContextCount(2);
-  }
+  auto backendName = devices_[0]->getBackendName();
+  const auto &backend = provisioner_->getBackend(backendName);
+  auto contextCount = backend.getContextCount(cctx);
+  partitioner.setContextCount(contextCount);
   DAGListTy nodeList;
   auto result = partitioner.partition(cctx);
   VLOG(1) << "After partitioner";


### PR DESCRIPTION
Summary: This adds a new getContextCount method to Backend and an implementation to the NNPI backend. This allows the HostManager to query the backend for the appropriate number of contexts the Partitioner should assume when partitioning.

Differential Revision: D26419019

