### PR TITLE
Support for Arithmetic ReduceOps with multiple reduce axes.

### DIFF
--- a/include/glow/Graph/Utils.h
+++ b/include/glow/Graph/Utils.h
@@ -26,6 +26,19 @@
 
 namespace glow {
 
+/// \returns a ShapeVector of rank axes.size() less than the input \p dims,
+/// where the provided \p axes are removed from the shape.
+ShapeVector getNewShapeWithoutAxes(llvm::ArrayRef<dim_t> dims,
+                                   llvm::ArrayRef<unsigned_t> axes);
+
+/// Reshape by combining consecutive \p size axes starting from \p axis.
+ShapeVector getNewShapeCombineAxes(llvm::ArrayRef<dim_t> dims, unsigned_t axis,
+                                   size_t size);
+
+/// Get total size of the selected axes \p axes from dimensions \p dim.
+size_t getDimSizeOfAxes(llvm::ArrayRef<dim_t> dims,
+                        llvm::ArrayRef<unsigned_t> axes);
+
 /// A helper class for ordering the nodes in a post-order order.
 struct PostOrderVisitor : NodeWalker {
   /// A post-order list of nodes.

--- a/lib/Backends/Interpreter/InterpreterNodes.cpp
+++ b/lib/Backends/Interpreter/InterpreterNodes.cpp
@@ -4761,11 +4761,14 @@ DEFINE_REDUCEADDPROD_INST_IMPL(ReduceProd, 1, *, InstFloatImpl)
 void BoundInterpreterFunction::fwdBatchedReduceAddInst(
     const glow::BatchedReduceAddInst *I) {
   static_assert(max_tensor_dimensions == 6,
-                "Loops below assume max_tensor_dimensions = 6.");
+                "ReduceAdd: supporting up to 6D tensors only.");
 
   auto *batch = I->getBatch();
   auto *dest = I->getDest();
-  const auto axis = I->getAxis();
+  const auto axis = I->getAxes()[0];
+
+  assert(I->getAxes().size() == 1 &&
+         "ReduceAdd: supporting reduction of a single axis only.");
 
   // Initialize both expanded batch and dest dims to the expanded batch
   // dims. This allows us below to iterate over the tensor regardless of its
@@ -4839,11 +4842,14 @@ void BoundInterpreterFunction::fwdBatchedReduceAddInst(
 void BoundInterpreterFunction::fwdBatchedReduceProdInst(
     const glow::BatchedReduceProdInst *I) {
   static_assert(max_tensor_dimensions == 6,
-                "Loops below assume max_tensor_dimensions = 6.");
+                "ReduceProd: supporting up to 6D tensors only.");
 
   auto *batch = I->getBatch();
   auto *dest = I->getDest();
-  const auto axis = I->getAxis();
+  const auto axis = I->getAxes()[0];
+
+  assert(I->getAxes().size() == 1 &&
+         "ReduceAdd: supporting reduction of a single axis only.");
 
   // Initialize both expanded batch and dest dims to the expanded batch
   // dims. This allows us below to iterate over the tensor regardless of its

--- a/lib/Backends/OpenCL/Transforms.cpp
+++ b/lib/Backends/OpenCL/Transforms.cpp
@@ -108,7 +108,10 @@ Expected<bool> OCLBackend::transformPostLowering(
     // not need to be copied separately or at runtime (which would increase
     // execution latency).
     if (auto *BRA = dyn_cast<BatchedReduceAddNode>(&node)) {
-      auto axis = BRA->getAxis();
+
+      assert(BRA->getAxes().size() == 1 &&
+             "ReduceAdd: supporting reduction of a single axis only.");
+      auto axis = BRA->getAxes()[0];
 
       // Determine and store the slice sizes of each input dimension excluding
       // the reduce axis into batchSliceSizes. Determine also the slice size on

--- a/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
@@ -109,6 +109,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "BatchSparseToDense_Float/0",
     "BatchSparseToDense_Float16/0",
     "BatchSparseToDense_Float_Int32_Int32/0",
+    "batchedReduceProdDims01/0",
     "Gelu_Float16/0",
     "ReluSimple_Float16/0",
     "PReluSimple_Float16/0",

--- a/lib/Exporter/ONNXModelWriter.cpp
+++ b/lib/Exporter/ONNXModelWriter.cpp
@@ -1589,8 +1589,7 @@ Error ONNXModelWriter::writeBatchedReduceAdd(const BatchedReduceAddNode *node,
                                              GraphType &graph) {
   auto *proto = graph.add_node();
   // Add dictionary entries.
-  unsigned_t axis = node->getAxis();
-  llvm::ArrayRef<unsigned_t> axes(axis);
+  llvm::ArrayRef<unsigned_t> axes(node->getAxes());
   addValueAttribute(proto, "axes", axes);
 
   proto->set_name(node->getName().str());
@@ -1607,8 +1606,7 @@ Error ONNXModelWriter::writeBatchedReduceSumSquare(
     const BatchedReduceSumSquareNode *node, GraphType &graph) {
   auto *proto = graph.add_node();
   // Add dictionary entries.
-  unsigned_t axis = node->getAxis();
-  llvm::ArrayRef<unsigned_t> axes(axis);
+  llvm::ArrayRef<unsigned_t> axes(node->getAxes());
   addValueAttribute(proto, "axes", axes);
 
   proto->set_name(node->getName().str());
@@ -1643,8 +1641,7 @@ Error ONNXModelWriter::writeBatchedReduceProd(const BatchedReduceProdNode *node,
                                               GraphType &graph) {
   auto *proto = graph.add_node();
   // Add dictionary entries.
-  unsigned_t axis = node->getAxis();
-  llvm::ArrayRef<unsigned_t> axes(axis);
+  llvm::ArrayRef<unsigned_t> axes(node->getAxes());
   addValueAttribute(proto, "axes", axes);
 
   proto->set_name(node->getName().str());

--- a/lib/Graph/CMakeLists.txt
+++ b/lib/Graph/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(Graph
             PlaceholderBindings.cpp
             TensorLayout.cpp
             Graph.cpp
+            GraphUtils.cpp
             Grad.cpp
             VerifierHelper.cpp)
 

--- a/lib/Graph/Grad.cpp
+++ b/lib/Graph/Grad.cpp
@@ -193,9 +193,9 @@ Function *glow::differentiate(Function *F, const TrainingConfig &conf,
       auto *RN =
           new ReshapeNode(DECORATE_NODE_NAME(TN, "grad", "reshape"),
                           BRAInputType, outputG, BRAInputType->dims(), "*");
-      auto *BRA =
-          new BatchedReduceAddNode(DECORATE_NODE_NAME(TN, "grad", "bra"),
-                                   TN->getInput().getType(), RN, TN->getAxis());
+      auto *BRA = new BatchedReduceAddNode(
+          DECORATE_NODE_NAME(TN, "grad", "bra"), TN->getInput().getType(), RN,
+          {TN->getAxis()});
 
       toAppend.push_back(RN);
       toAppend.push_back(BRA);
@@ -386,7 +386,7 @@ Function *glow::differentiate(Function *F, const TrainingConfig &conf,
 
       // Gradient for BatchedReduceAddNode is TileNode,
       // repeating OutputG batch times.
-      auto Axis = BRA->getAxis();
+      auto Axis = BRA->getAxes()[0];
       // Copy input dimensions first.
       std::vector<dim_t> Dims{Input.dims()};
       // Then set to 1 dimension size on axis.

--- a/lib/Graph/GraphUtils.cpp
+++ b/lib/Graph/GraphUtils.cpp
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) Glow Contributors. See CONTRIBUTORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "glow/Graph/Graph.h"
+#include "glow/Graph/Node.h"
+#include "glow/Graph/Nodes.h"
+#include "glow/Graph/Utils.h"
+#include "glow/Support/Debug.h"
+#include <list>
+#include <set>
+
+#define DEBUG_TYPE "graph-utils"
+
+using namespace glow;
+
+/// get total size of the selected axes \p axes from dimensions \p dim.
+size_t glow::getDimSizeOfAxes(llvm::ArrayRef<dim_t> dim,
+                              llvm::ArrayRef<unsigned_t> axes) {
+  size_t axesSize = 1;
+  for (const auto axis : axes) {
+    axesSize *= dim[axis];
+  }
+  return axesSize;
+}
+
+/// Reshape by combining consecutive \p size axes starting from \p axis.
+ShapeVector glow::getNewShapeCombineAxes(llvm::ArrayRef<dim_t> dims,
+                                         unsigned_t axis, size_t size) {
+  assert(axis + size <= dims.size() &&
+         "Cannot remove more dimensions than exist.");
+  ShapeVector newDims(dims.begin(), dims.end());
+
+  for (size_t i = size - 1; i > 0; i--) {
+    assert(axis + i <= dims.size() &&
+           "Axis to remove must fit inside dimensions of the provided dims.");
+    newDims[axis] *= newDims[axis + i];
+    newDims.erase(newDims.begin() + axis + i);
+  }
+  return newDims;
+}
+
+/// \returns a ShapeVector of rank axes.size() less than the input \p dims,
+/// where the provided \p axes dimensions are removed from the shape.
+ShapeVector glow::getNewShapeWithoutAxes(llvm::ArrayRef<dim_t> dims,
+                                         llvm::ArrayRef<unsigned_t> axes) {
+  assert(axes.size() <= dims.size() &&
+         "Cannot remove more dimensions than exist.");
+  ShapeVector newDims(dims.begin(), dims.end());
+  ShapeVector shapeAxes(axes.begin(), axes.end());
+
+  // Sort so that looping erase below doesn't fail.
+  std::sort(shapeAxes.rbegin(), shapeAxes.rend());
+
+  for (const auto &axis : shapeAxes) {
+    assert(axis <= dims.size() &&
+           "Axis to remove must fit inside dimensions of the provided dims.");
+    newDims.erase(newDims.begin() + axis);
+  }
+  return newDims;
+}

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -2204,11 +2204,14 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     auto *batch = BR->getBatch();
     auto *destPtr = emitValueAddress(builder, dest);
     auto *batchPtr = emitValueAddress(builder, batch);
-    auto *axis = emitConstDimT(builder, BR->getAxis());
+    auto *axis = emitConstDimT(builder, BR->getAxes()[0]);
+
+    assert(BR->getAxes().size() == 1 &&
+           "ReduceAdd: supporting reduction of a single axis only.");
 
     ShapeVector eBatchDims = expandDimsToMax(batch->dims());
     ShapeVector eDestDims = eBatchDims;
-    eDestDims[BR->getAxis()] = 1;
+    eDestDims[BR->getAxes()[0]] = 1;
 
     auto *batchDims =
         emitConstDimTArray(builder, llvm::makeArrayRef(eBatchDims));
@@ -2252,11 +2255,14 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     auto *batch = BR->getBatch();
     auto *destPtr = emitValueAddress(builder, dest);
     auto *batchPtr = emitValueAddress(builder, batch);
-    auto *axis = emitConstDimT(builder, BR->getAxis());
+    auto *axis = emitConstDimT(builder, BR->getAxes()[0]);
+
+    assert(BR->getAxes().size() == 1 &&
+           "ReduceProd: supporting reduction of a single axis only.");
 
     ShapeVector eBatchDims = expandDimsToMax(batch->dims());
     ShapeVector eDestDims = eBatchDims;
-    eDestDims[BR->getAxis()] = 1;
+    eDestDims[BR->getAxes()[0]] = 1;
 
     auto *batchDims =
         emitConstDimTArray(builder, llvm::makeArrayRef(eBatchDims));

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -7078,8 +7078,11 @@ Expected<std::unordered_map<Node *, ConcatNode *>> glow::parallelizeOps(
       }
       case Kinded::Kind::BatchedReduceAddNodeKind: {
         BatchedReduceAddNode *BR = llvm::cast<BatchedReduceAddNode>(curNode);
+        RETURN_ERR_IF_NOT(BR->getAxes().size() == 1,
+                          "Parallelization for BatchedReduceAdd only supported "
+                          "for single axis.");
         splitDims[BatchedReduceAddNode::BatchIdx] =
-            (BR->getAxis() == 0) ? 1 : 0;
+            (BR->getAxes()[0] == 0) ? 1 : 0;
         ASSIGN_VALUE_OR_RETURN_ERR(
             CN, parallelizeAndReplaceNode(
                     F, curNode, curNumOfChunks, BatchedReduceAddNode::BatchIdx,

--- a/tests/models/onnxModels/reduceSum4DMulti.onnxtxt
+++ b/tests/models/onnxModels/reduceSum4DMulti.onnxtxt
@@ -1,0 +1,68 @@
+ir_version: 3
+producer_name: "glow-test"
+graph {
+  node {
+    input: "x"
+    output: "y"
+    op_type: "ReduceSum"
+    attribute {
+      name: "axes"
+      ints: 3
+      ints: 1
+      type: INTS
+    }
+    attribute {
+      name: "keepdims"
+      i: 1
+      type: INT
+    }
+  }
+  name: "test_reduce_sum_4d"
+  input {
+    name: "x"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+        }
+      }
+    }
+  }
+  output {
+    name: "y"
+    type {
+      tensor_type {
+        elem_type: 1
+        shape {
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 2
+          }
+          dim {
+            dim_value: 1
+          }
+        }
+      }
+    }
+  }
+}
+opset_import {
+  version: 9
+}

--- a/tests/unittests/OnnxImporterTest.cpp
+++ b/tests/unittests/OnnxImporterTest.cpp
@@ -1655,6 +1655,12 @@ TEST_F(OnnxImporterTest, reduceMean2AvgPoolKeepDims) {
                    {2.5, 6.5, 10.5, 14.5});
 }
 
+/// Test loading ReduceSum op from a ONNX model.
+/// Input shape is 4D, two dimensions are reduced, and output shape is 4D.
+TEST_F(OnnxImporterTest, reduceSum4DMulti) {
+  testReductionOps("reduceSum4DMulti.onnxtxt", {2, 1, 2, 1}, {14, 22, 46, 54});
+}
+
 /// Test loading ReduceSumSquare op from a ONNX model.
 /// Input shape is 4D, one dimension is reduced, and output shape is 4D.
 TEST_F(OnnxImporterTest, reduceSumSquare4D) {

--- a/tools/ClassGen/InstrGen.cpp
+++ b/tools/ClassGen/InstrGen.cpp
@@ -359,7 +359,7 @@ int main(int argc, char **argv) {
   BB.newInstr("BatchedReduceAdd")
       .addOperand("Dest", OperandKind::Out)
       .addOperand("Batch", OperandKind::In)
-      .addMember(MemberType::Unsigned, "Axis")
+      .addMember(MemberType::VectorUnsigned, "Axes")
       .autoVerify(VerifyKind::SameElementType, {"Dest", "Batch"})
       .autoIRGen();
 
@@ -389,7 +389,7 @@ int main(int argc, char **argv) {
   BB.newInstr("BatchedReduceProd")
       .addOperand("Dest", OperandKind::Out)
       .addOperand("Batch", OperandKind::In)
-      .addMember(MemberType::Unsigned, "Axis")
+      .addMember(MemberType::VectorUnsigned, "Axes")
       .autoVerify(VerifyKind::SameElementType, {"Dest", "Batch"})
       .autoIRGen();
 

--- a/tools/ClassGen/NodeGen.cpp
+++ b/tools/ClassGen/NodeGen.cpp
@@ -740,7 +740,7 @@ int main(int argc, char **argv) {
 
   BB.newNode("BatchedReduceAdd")
       .addInput("Batch")
-      .addMember(MemberType::Unsigned, "Axis")
+      .addMember(MemberType::VectorUnsigned, "Axes")
       .addResultFromCtorArg()
       .setDocstring("Accumulates all of the layers in the batch and produce a "
                     "tensor that has the same dimensions as the input tensor "
@@ -748,7 +748,7 @@ int main(int argc, char **argv) {
 
   BB.newNode("BatchedReduceSumSquare")
       .addInput("Batch")
-      .addMember(MemberType::Unsigned, "Axis")
+      .addMember(MemberType::VectorUnsigned, "Axes")
       .addResultFromCtorArg()
       .setDocstring(
           "Accumulates squares of all of the layers in the batch and produce a "
@@ -778,7 +778,7 @@ int main(int argc, char **argv) {
 
   BB.newNode("BatchedReduceProd")
       .addInput("Batch")
-      .addMember(MemberType::Unsigned, "Axis")
+      .addMember(MemberType::VectorUnsigned, "Axes")
       .addResultFromCtorArg()
       .setDocstring("Accumulates the product all of the layers in the batch "
                     " and produce a tensor that has the same dimensions as "


### PR DESCRIPTION
Arithmetic ReduceOps with multiple reduce axes are supported by combining the axes to be reduced using input reshape. If axes are not consecutive, transpose is inserted to make them consecutive.