### PR TITLE
Prelu operator lowering bug for output datatype

### DIFF
--- a/lib/Backends/Habana/tests/HabanaOperatorTest.cpp
+++ b/lib/Backends/Habana/tests/HabanaOperatorTest.cpp
@@ -318,6 +318,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "pow/0",
     "PReluSimple_Float/0",
     "PReluSimple_Float16/0",
+    "PRelu_Int8/0",
     "QuantizedArgMaxKeepDim/0",
     "QuantizedArgMaxNoKeepDim/0",
     "QuantizedArithmeticRescaled/0",

--- a/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
+++ b/lib/Backends/OpenCL/tests/OpenCLOperatorTest.cpp
@@ -620,6 +620,7 @@ std::set<std::string> glow::backendTestBlacklist = {
     "Asin_Int8QTy/0",
     "Acos_Int8QTy/0",
     "Atan_Int8QTy/0",
+    "PRelu_Int8/0",
     "BBoxTransform_Float/0",
     "BBoxTransform_Float16/0",
     "BBoxTransform_Rotated_Float/0",

--- a/lib/Optimizer/Lower/Lower.cpp
+++ b/lib/Optimizer/Lower/Lower.cpp
@@ -479,8 +479,9 @@ static void lowerPReluNode(Function *F, CompilationContext &cctx,
       F->createCmpLTE(DECORATE_NODE_NAME(R, "cmplte"), zeroSplat, R.getInput());
   auto *mul =
       F->createMul(DECORATE_NODE_NAME(R, "mul"), R.getSlope(), R.getInput());
-  auto *prelu = F->createSelect(DECORATE_NODE_NAME(R, "select"), cmplgt,
-                                R.getInput(), mul);
+  auto *prelu =
+      F->createSelect(DECORATE_NODE_NAME(R, "select"), R.getResult().getType(),
+                      cmplgt, R.getInput(), mul);
 
   replaceAllUsesOfWith(cctx.loweredInfoMap, R.getResult(), prelu);
 }

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -4566,6 +4566,37 @@ TEST_P(OperatorTest, PReluSimple_BFloat16) {
                               1E-16);
 }
 
+/// Verify that the PRELU operator works correctly for int8 with different
+/// input and output quantization parameters.
+TEST_P(OperatorTest, PRelu_Int8) {
+  CHECK_IF_ENABLED();
+  auto *in = mod_.createPlaceholder(ElemKind::Int8QTy, {7}, 1, 0, "in", false);
+  auto *slope =
+      mod_.createPlaceholder(ElemKind::Int8QTy, {7}, 1, 0, "slope", false);
+
+  auto outTy = mod_.uniqueType(ElemKind::Int8QTy, {7}, 2, 0);
+  auto *prelu = F_->createPRELU("prelu", in, slope, outTy);
+  auto *save = F_->createSave("prelu", prelu);
+  bindings_.allocate(save->getPlaceholder());
+
+  bindings_.allocate(in)->getHandle<int8_t>() = {0, -1, -2, -3, 4, 5, 6};
+  bindings_.allocate(slope)->getHandle<int8_t>().randomize(1, 10,
+                                                           mod_.getPRNG());
+
+  EE_.compile(CompilationMode::Infer);
+  EE_.run(bindings_);
+
+  auto resultH = bindings_.get(save->getPlaceholder())->getHandle<int8_t>();
+  auto inH = bindings_.get(in)->getHandle<int8_t>();
+  auto slopeH = bindings_.get(slope)->getHandle<int8_t>();
+
+  for (size_t i = 0; i < 7; i++) {
+    int8_t expectedResult = slopeH.raw(i) * std::min<int8_t>(0, inH.raw(i)) +
+                            std::max<int8_t>(0, inH.raw(i));
+    EXPECT_NEAR(resultH.at(i), expectedResult / 2, 1);
+  }
+}
+
 /// Helper to test Gelu using \p DTy.
 template <typename DataType>
 static void testGelu(glow::PlaceholderBindings &bindings, glow::Module &mod,


### PR DESCRIPTION
Summary: While lowering Prelu operator, the original node's output scale and offset are not considered. Added changes to keep same output type of lowered node as that of the original node.

Test Plan: Test case added in operator test 