### PR TITLE
[GraphOptimizer] Reduce Mean operator optimization issue with output type

### DIFF
--- a/include/glow/Base/Type.h
+++ b/include/glow/Base/Type.h
@@ -569,6 +569,13 @@ struct Type final {
     return ty;
   }
 
+  /// Reshape existing type. This method takes care of quantized types.
+  static Type newQuantparams(const Type &T, float scale, int32_t offset) {
+    assert(T.isQuantizedType() &&
+           "Can't modify scale and offset of non quantized types");
+    return Type(T.getElementType(), T.dims(), scale, offset);
+  }
+
   /// An empty type.
   Type() = default;
 

--- a/include/glow/Graph/Graph.h
+++ b/include/glow/Graph/Graph.h
@@ -159,6 +159,11 @@ public:
   /// the type \p shapeType.
   TypeRef uniqueTypeWithNewShape(TypeRef T, TypeRef shapeType);
 
+  /// Return a pointer to a uniqued type \p T.
+  /// The new type is identical to \p T, with new scale and offset taken from
+  /// the type \p quantParamType.
+  TypeRef uniqueTypeWithNewQuantParams(TypeRef T, TypeRef quantParamType);
+
   /// Return the void type.
   TypeRef getVoidTy();
 

--- a/lib/Graph/Graph.cpp
+++ b/lib/Graph/Graph.cpp
@@ -555,6 +555,12 @@ TypeRef Module::uniqueTypeWithNewShape(TypeRef T, TypeRef shapeType) {
   return uniqueType(Type::newShape(*T, shapeType));
 }
 
+TypeRef Module::uniqueTypeWithNewQuantParams(TypeRef T,
+                                             TypeRef quantParamType) {
+  return uniqueType(Type::newQuantparams(*T, quantParamType->getScale(),
+                                         quantParamType->getOffset()));
+}
+
 TypeRef Module::uniqueType(const Type &T) {
   for (auto &tp : types_) {
     if (T.isEqual(tp)) {

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -1967,6 +1967,11 @@ bool OptimizeReduceMean::run(Function *F, const CompilationContext &cctx) {
           RM->getName().str() + ".transposeNCHW2NHWC", in, NCHW2NHWC, "NHWC");
       auto *AP = F->createAvgPool(RM->getName().str() + ".avgPool", TR1,
                                   kernels, strides, pads);
+      if (AP->getResult().getType()->isQuantizedType()) {
+        auto TypeAP = F->getParent()->uniqueTypeWithNewQuantParams(
+            AP->getResult().getType(), RM->getResult().getType());
+        AP->getResult().setType(TypeAP);
+      }
       auto *TR2 = F->createTranspose(
           RM->getName().str() + ".transposeNHWC2NCHW", AP, NHWC2NCHW, "NCHW");
 

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -4258,7 +4258,7 @@ TEST_P(OperatorTest, batchedReduceMeanUsingAvgPoolQuantized) {
   std::vector<dim_t> dims = {2, 3, 3, 4};
 
   auto BT = mod_.uniqueType(ElemKind::Int8QTy, dims, 1, 0);
-  auto OT = mod_.uniqueType(ElemKind::Int8QTy, {dims[0], dims[1]}, 1, 0);
+  auto OT = mod_.uniqueType(ElemKind::Int8QTy, {dims[0], dims[1]}, 3, 0);
   auto *batch = mod_.createPlaceholder(ElemKind::Int8QTy, dims, BT->getScale(),
                                        BT->getOffset(), "batch", false);
 


### PR DESCRIPTION
Summary: In reduce mean operator optimization, conversion to avg pool doesn't take care of output scale and offset. 

Test Plan: Added failing test case and required modifications.

