### PR TITLE
[CPU] Add implementation for FullyConnected

### DIFF
--- a/.ci/bundle_instrument_expected_output.txt
+++ b/.ci/bundle_instrument_expected_output.txt
@@ -1,4 +1,4 @@
-Number of instructions: 10
-Number of data dumps: 28
+Number of instructions: 8
+Number of data dumps: 24
 Result: 0
 Confidence: 0.991618

--- a/lib/Backends/CPU/CPUBackend.cpp
+++ b/lib/Backends/CPU/CPUBackend.cpp
@@ -71,6 +71,7 @@ bool CPUBackend::shouldLower(const Node *N) const {
   case Kinded::Kind::ReluNodeKind:
   case Kinded::Kind::ClipNodeKind:
   case Kinded::Kind::LeakyReluNodeKind:
+  case Kinded::Kind::FullyConnectedNodeKind:
   case Kinded::Kind::ConvolutionNodeKind:
   case Kinded::Kind::SparseLengthsSumNodeKind:
     return false;

--- a/lib/LLVMIRCodeGen/LLVMBackend.cpp
+++ b/lib/LLVMIRCodeGen/LLVMBackend.cpp
@@ -439,6 +439,15 @@ bool LLVMBackend::isOpSupported(const NodeInfo &NI) const {
                 FusedRowwiseQuantizedSparseLengthsWeightedSumNode::ResultIdx) ==
             ElemKind::FloatTy);
 
+  case Kinded::Kind::FullyConnectedNodeKind:
+    if (!NI.getInTy(FullyConnectedNode::InputIdx)->isQuantizedType()) {
+      return NI.allInputsAndOutputsHaveSameElemKind({ElemKind::FloatTy});
+    }
+    return NI.allInputsAndOutputsHaveSameElemKind(
+               {ElemKind::Int8QTy}, {FullyConnectedNode::BiasIdx}) &&
+           (NI.getInElemTy(FullyConnectedNode::BiasIdx) == ElemKind::Int8QTy ||
+            NI.getInElemTy(FullyConnectedNode::BiasIdx) == ElemKind::Int32QTy);
+
   case Kinded::Kind::RowwiseQuantizedFullyConnectedNodeKind:
     return (NI.getInElemTy(RowwiseQuantizedFullyConnectedNode::InputIdx) ==
             ElemKind::Int8QTy) &&

--- a/lib/LLVMIRCodeGen/LLVMIRGen.cpp
+++ b/lib/LLVMIRCodeGen/LLVMIRGen.cpp
@@ -1878,6 +1878,67 @@ void LLVMIRGen::generateLLVMIRForInstr(llvm::IRBuilder<> &builder,
     break;
   }
 
+  case Kinded::Kind::FullyConnectedInstKind: {
+    auto *FCI = cast<FullyConnectedInst>(I);
+    auto *dest = FCI->getDest();
+    auto *src = FCI->getSrc();
+    auto *weights = FCI->getWeights();
+    auto *bias = FCI->getBias();
+    auto *destPtr = emitValueAddress(builder, dest);
+    auto *srcPtr = emitValueAddress(builder, src);
+    auto *weightsPtr = emitValueAddress(builder, weights);
+    auto *biasPtr = emitValueAddress(builder, bias);
+    auto *destDims = emitValueDims(builder, dest);
+    auto *srcDims = emitValueDims(builder, src);
+    auto *weightsDims = emitValueDims(builder, weights);
+    auto *biasDims = emitValueDims(builder, bias);
+
+    if (src->getType()->isQuantizedType()) {
+      auto *destTy = dest->getType();
+      auto *srcTy = src->getType();
+      auto *weightsTy = weights->getType();
+      auto *biasTy = bias->getType();
+
+      auto *destOffset = emitConstI32(builder, destTy->getOffset());
+      auto *srcOffset = emitConstI32(builder, srcTy->getOffset());
+      auto *weightsOffset = emitConstI32(builder, weightsTy->getOffset());
+      auto *biasOffset = emitConstI32(builder, biasTy->getOffset());
+
+      // Calculate the scale of the values that come out of the matrix
+      // multiplication part of the calculation.
+      float matMulScale = srcTy->getScale() * weightsTy->getScale();
+
+      // Calculate the scaling parameters for the bias and output.
+      auto biasScaleParam = quantization::quantizeScaleOffset32To8(
+          biasTy->getScale() / matMulScale, 0);
+      auto outScaleParam = quantization::quantizeScaleOffset32To8(
+          matMulScale / destTy->getScale(), 0);
+
+      // Pass the pre-shift, post-shift and integer scale parameters for the
+      // bias and output calculation.
+      auto *biasPre = emitConstI32(builder, biasScaleParam.pre);
+      auto *biasPost = emitConstI32(builder, biasScaleParam.post);
+      auto *biasScale = emitConstI32(builder, biasScaleParam.scale);
+      auto *outPre = emitConstI32(builder, outScaleParam.pre);
+      auto *outPost = emitConstI32(builder, outScaleParam.post);
+      auto *outScale = emitConstI32(builder, outScaleParam.scale);
+
+      auto *F =
+          getFunction("fc", {dest->getElementType(), bias->getElementType()});
+      createCall(builder, F,
+                 {destPtr, srcPtr, weightsPtr, biasPtr, destDims, srcDims,
+                  weightsDims, biasDims, destOffset, srcOffset, weightsOffset,
+                  biasOffset, biasPre, biasPost, biasScale, outPre, outPost,
+                  outScale});
+    } else {
+      auto *F = getFunction("fc", dest->getElementType());
+      createCall(builder, F,
+                 {destPtr, srcPtr, weightsPtr, biasPtr, destDims, srcDims,
+                  weightsDims, biasDims});
+    }
+    break;
+  }
+
   case Kinded::Kind::RowwiseQuantizedFullyConnectedInstKind: {
     auto *RWQFC = cast<RowwiseQuantizedFullyConnectedInst>(I);
 


### PR DESCRIPTION
**Summary**
- Added atomic implementation of FullyConnected layer for CPU backend.
- Disabled lowering of FullyConnected for CPU backend.
- Modified unit test from GraphOptz which was using FullyConnected but was using the CPU backend so FC was lowered to MatMul + BatchedAdd. The logic of the unit test was not supposed to work with an atomic implementation of FC because the comment suggests that the unit test does not work also for the Interpreter backend (which also has atomic implementation for FullyConnected). I modified the test to use MatMul instead.

**Fixes**
#2145

**Test Plan**
Current unit tests are working (there are already unit tests for CPU for both floating-point and quantized).