### PR TITLE
Gemm operator Int32QTy bias verification bug

### DIFF
--- a/lib/Graph/Nodes.cpp
+++ b/lib/Graph/Nodes.cpp
@@ -2439,11 +2439,24 @@ bool GemmNode::verify() const {
   NodeValue Y = getResult();
   bool transA = getTransposeA();
   bool transB = getTransposeB();
+  const Node *parent = Y.getNode();
 
   // Check types.
   bool isValid = checkType(B, A.getElementType(), this);
+  // Check for element kind of bias
   if (C.getNode()) {
-    isValid &= checkType(C, A.getElementType(), this);
+    // Non quantization type check.
+    if (A.getElementType() == ElemKind::FloatTy ||
+        A.getElementType() == ElemKind::Float16Ty) {
+      isValid &= checkType(C, A.getElementType(), parent);
+    }
+    // Quantization type check.
+    if (A.getElementType() == ElemKind::Int8QTy) {
+      isValid &= expectCompareTrue("Bias type should be Int8 or Int32 for Gemm",
+                                   C.getElementType() == ElemKind::Int8QTy ||
+                                       C.getElementType() == ElemKind::Int32QTy,
+                                   true, parent);
+    }
   }
   isValid &= checkType(Y, A.getElementType(), this);
 

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -1906,6 +1906,14 @@ bool OptimizeReduceMean::run(Function *F, const CompilationContext &cctx) {
           RM->getName().str() + ".transposeNCHW2NHWC", in, NCHW2NHWC, "NHWC");
       auto *AP = F->createAvgPool(RM->getName().str() + ".avgPool", TR1,
                                   kernels, strides, pads);
+      if (AP->getResult().getType()->isQuantizedType()) {
+        auto TypeAP = F->getParent()->uniqueType(
+            AP->getResult().getType()->getElementType(),
+            AP->getResult().getType()->dims(),
+            RM->getResult().getType()->getScale(),
+            RM->getResult().getType()->getOffset());
+        AP->getResult().setType(TypeAP);
+      }
       auto *TR2 = F->createTranspose(
           RM->getName().str() + ".transposeNHWC2NCHW", AP, NHWC2NCHW, "NCHW");
 

--- a/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
+++ b/lib/Optimizer/GraphOptimizer/GraphOptimizer.cpp
@@ -1906,14 +1906,6 @@ bool OptimizeReduceMean::run(Function *F, const CompilationContext &cctx) {
           RM->getName().str() + ".transposeNCHW2NHWC", in, NCHW2NHWC, "NHWC");
       auto *AP = F->createAvgPool(RM->getName().str() + ".avgPool", TR1,
                                   kernels, strides, pads);
-      if (AP->getResult().getType()->isQuantizedType()) {
-        auto TypeAP = F->getParent()->uniqueType(
-            AP->getResult().getType()->getElementType(),
-            AP->getResult().getType()->dims(),
-            RM->getResult().getType()->getScale(),
-            RM->getResult().getType()->getOffset());
-        AP->getResult().setType(TypeAP);
-      }
       auto *TR2 = F->createTranspose(
           RM->getName().str() + ".transposeNHWC2NCHW", AP, NHWC2NCHW, "NCHW");
 

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -4242,7 +4242,7 @@ TEST_P(OperatorTest, batchedReduceMeanUsingAvgPoolQuantized) {
   std::vector<dim_t> dims = {2, 3, 3, 4};
 
   auto BT = mod_.uniqueType(ElemKind::Int8QTy, dims, 1, 0);
-  auto OT = mod_.uniqueType(ElemKind::Int8QTy, {dims[0], dims[1]}, 2, 0);
+  auto OT = mod_.uniqueType(ElemKind::Int8QTy, {dims[0], dims[1]}, 1, 0);
   auto *batch = mod_.createPlaceholder(ElemKind::Int8QTy, dims, BT->getScale(),
                                        BT->getOffset(), "batch", false);
 
@@ -6909,6 +6909,44 @@ TEST_P(OperatorTest, IntMatMul) {
   EXPECT_NEAR(H.at({2, 0}), 26.6, 1.0);
   EXPECT_NEAR(H.at({2, 1}), 69.8, 1.0);
   EXPECT_NEAR(H.at({2, 2}), 58.8, 1.0);
+}
+
+/// Gemm test for quantized case with Int32QTy bias
+TEST_P(OperatorTest, IntGemm) {
+  CHECK_IF_ENABLED();
+
+  TypeRef resTy = mod_.uniqueType(ElemKind::Int8QTy, {1, 2}, 1, 0);
+
+  auto *inp =
+      mod_.createPlaceholder(ElemKind::Int8QTy, {1, 5}, 1, 0, "inp", false);
+  bindings_.allocate(inp);
+  auto *weight =
+      mod_.createPlaceholder(ElemKind::Int8QTy, {2, 5}, 1, 0, "weight", false);
+  bindings_.allocate(weight);
+  auto *bias =
+      mod_.createPlaceholder(ElemKind::Int32QTy, {2}, 1, 0, "bias", false);
+  bindings_.allocate(bias);
+
+  bindings_.get(inp)->getHandle<int8_t>() = {
+      1, 1, 1, 1, 1,
+  };
+
+  bindings_.get(weight)->getHandle<int8_t>() = {2, 2, 2, 2, 2, 3, 3, 3, 3, 3};
+
+  bindings_.get(bias)->getHandle<int32_t>() = {1, 2};
+
+  auto *gemmnode = F_->createGemm("gemm", resTy, inp, weight, bias, 1, 1, 0, 1);
+
+  auto *S = F_->createSave("save", gemmnode);
+  bindings_.allocate(S->getPlaceholder());
+  EE_.compile(CompilationMode::Infer);
+
+  EE_.run(bindings_);
+
+  auto result = bindings_.get(S->getPlaceholder());
+  Tensor expected(resTy);
+  expected.getHandle<int8_t>() = {11, 17};
+  EXPECT_TRUE(expected.isEqual(*result));
 }
 
 TEST_P(OperatorTest, IntBatchedArith) {

--- a/tests/unittests/OperatorTest.cpp
+++ b/tests/unittests/OperatorTest.cpp
@@ -4242,7 +4242,7 @@ TEST_P(OperatorTest, batchedReduceMeanUsingAvgPoolQuantized) {
   std::vector<dim_t> dims = {2, 3, 3, 4};
 
   auto BT = mod_.uniqueType(ElemKind::Int8QTy, dims, 1, 0);
-  auto OT = mod_.uniqueType(ElemKind::Int8QTy, {dims[0], dims[1]}, 1, 0);
+  auto OT = mod_.uniqueType(ElemKind::Int8QTy, {dims[0], dims[1]}, 2, 0);
   auto *batch = mod_.createPlaceholder(ElemKind::Int8QTy, dims, BT->getScale(),
                                        BT->getOffset(), "batch", false);
 


### PR DESCRIPTION
Summary: Gemm operator is not accepting Int32QTy as the bias. Made modifications in nodes.CPP to accept INT32 type.

Test Plan: Added a unit test case for the bug. 
