### PR TITLE
save origGraph to runOnJIT after lower tuples

### DIFF
--- a/torch_glow/src/CachingGraphRunner.cpp
+++ b/torch_glow/src/CachingGraphRunner.cpp
@@ -660,9 +660,9 @@ Error CachingGraphRunner::runImpl(const PerGlowGraphInfo &info,
 
       // Write input tensors to file
       if (settings.writeToOnnx) {
-        writeGlowTensorsToOnnx(
+        RETURN_IF_ERR(writeGlowTensorsToOnnx(
             strFormat("%s_input_%zu", onnxFileNamePrefix.c_str(), runId),
-            settings, info.inputPlaceholders, glowTensorInputs);
+            settings, info.inputPlaceholders, glowTensorInputs));
       }
 
       // Populate PlaceholderBindings
@@ -794,14 +794,15 @@ Error CachingGraphRunner::runImpl(const PerGlowGraphInfo &info,
 
       if (settings.writeToOnnx) {
         // Write Glow outputs to file
-        writeGlowTensorsToOnnx(
+        RETURN_IF_ERR(writeGlowTensorsToOnnx(
             strFormat("%s_glow_output_%zu", onnxFileNamePrefix.c_str(), runId),
-            info.settings, info.outputPlaceholders, convertedGlowTensors);
+            info.settings, info.outputPlaceholders, convertedGlowTensors));
 
         // Convert JIT outputs to Glow outputs and write to file
-        writeJITOutputsToOnnxFile(strFormat("%s_pytorch_output_%zu",
-                                            onnxFileNamePrefix.c_str(), runId),
-                                  copyStack, info);
+        RETURN_IF_ERR(writeJITOutputsToOnnxFile(
+            strFormat("%s_pytorch_output_%zu", onnxFileNamePrefix.c_str(),
+                      runId),
+            copyStack, info));
       }
     }
     TRACE_EVENT_END(traceContext, TraceLevel::RUNTIME, "setOutputs");

--- a/torch_glow/tests/functionality/to_glow_write_to_onnx_test.py
+++ b/torch_glow/tests/functionality/to_glow_write_to_onnx_test.py
@@ -1,0 +1,102 @@
+# isort:skip_file
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import glob
+import os
+import unittest
+
+import torch
+import torch_glow
+
+
+class Foo(torch.nn.Module):
+    def __init__(self):
+        super(Foo, self).__init__()
+        self.conv1 = torch.nn.Conv2d(3, 6, 3)
+        self.relu = torch.nn.ReLU()
+        self.conv2 = torch.nn.Conv2d(6, 16, 3)
+
+    def forward(self, x):
+        x = self.conv1(x)
+        x = self.relu(x)
+        y = self.conv2(x)
+        return y
+
+
+class Bar(torch.nn.Module):
+    def __init__(self, foo):
+        super(Bar, self).__init__()
+        self.foo = foo
+
+    def forward(self, x):
+        y = self.foo(x)
+        return y
+
+
+class Baz(torch.nn.Module):
+    def __init__(self, foo):
+        super(Baz, self).__init__()
+        self.foo = foo
+
+    def forward(self, x):
+        y = self.foo(x)
+        return (x, y)
+
+
+def create_model(x, ModType):
+    foo = Foo()
+    foo = torch.quantization.QuantWrapper(foo)
+    foo.qconfig = torch.quantization.get_default_qconfig("fbgemm")
+    torch.quantization.prepare(foo, inplace=True)
+    foo(x)
+    torch.quantization.convert(foo, inplace=True)
+    model = ModType(foo)
+    return model
+
+
+class TestToGlowWriteToOnnx(unittest.TestCase):
+    def lower_and_write_to_onnx_helper(self, ModType, onnx_prefix):
+        x = torch.randn(1, 3, 8, 8)
+        model = create_model(x, ModType)
+
+        spec = torch_glow.CompilationSpec()
+        spec.get_settings().set_glow_backend("Interpreter")
+
+        compilation_group = torch_glow.CompilationGroup()
+        spec.compilation_groups_append(compilation_group)
+
+        input_spec = torch_glow.InputSpec()
+        input_spec.set_same_as(x)
+
+        compilation_group.input_sets_append([input_spec])
+
+        scripted_mod = torch.jit.trace(model, x)
+        torch_glow.enable_write_to_onnx()
+        torch_glow.set_onnx_file_name_prefix(onnx_prefix)
+        torch_glow.enable_write_without_randomize()
+        lowered_model = torch_glow.to_glow(scripted_mod, {"forward": spec})
+
+        # Run Glow model
+        g = lowered_model(x)
+
+        # Run reference model
+        t = model(x)
+
+        self.assertEqual(type(g), type(t))
+        self.assertEqual(len(g), len(t))
+
+        for (gi, ti) in zip(g, t):
+            self.assertTrue(torch.allclose(gi, ti))
+
+        assert os.path.exists(onnx_prefix + ".onnxtxt")
+        onnx_files = glob.glob(onnx_prefix + "*.onnx*")
+        for f in onnx_files:
+            os.remove(f)
+
+    def test_lower_and_write_to_onnx_tensor_output(self):
+        onnx_prefix = "write_to_onnx_test1"
+        self.lower_and_write_to_onnx_helper(Bar, onnx_prefix)
+
+    def test_lower_and_write_to_onnx_tuple_output(self):
+        onnx_prefix = "write_to_onnx_test2"
+        self.lower_and_write_to_onnx_helper(Baz, onnx_prefix)


### PR DESCRIPTION
Summary: Move lowerAllTuples back to apply on origGraph to maintain tensors output.

Differential Revision: D26155176

